### PR TITLE
fix(github): prevent REST hydration starvation

### DIFF
--- a/README.md
+++ b/README.md
@@ -734,6 +734,8 @@ scoped to the issue, run the project validation gate, and prepare the work for
 human review.
 ```
 
+Set `github_rest_fanout_max_requests` to `0` to disable the per-cycle fanout cap while retaining the REST remaining-reserve guard.
+
 Tag-based projects can opt into release cadence in the same workflow file:
 
 ```yaml

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1309,7 +1309,7 @@ func (c *Config) validateTracker(problems *[]string) {
 	validatePositive("tracker.github_graphql_warn_remaining", c.Tracker.GitHubGraphQLWarnRemaining, problems)
 	validatePositive("tracker.github_graphql_min_remaining_reserve", c.Tracker.GitHubGraphQLMinReserve, problems)
 	validatePositive("tracker.github_rest_min_remaining_reserve", c.Tracker.GitHubRESTMinReserve, problems)
-	validatePositive("tracker.github_rest_fanout_max_requests", c.Tracker.GitHubRESTFanoutMaxRequests, problems)
+	validateNonNegative("tracker.github_rest_fanout_max_requests", c.Tracker.GitHubRESTFanoutMaxRequests, problems)
 	*problems = append(*problems, c.Tracker.Claims.Validate("tracker.claims")...)
 	*problems = append(*problems, c.Tracker.Authorization.Validate("tracker.authorization")...)
 }
@@ -2355,6 +2355,12 @@ func validateRequired(field string, value string, suffix string, problems *[]str
 func validatePositive(field string, value int, problems *[]string) {
 	if value <= 0 {
 		*problems = append(*problems, field+" must be greater than 0")
+	}
+}
+
+func validateNonNegative(field string, value int, problems *[]string) {
+	if value < 0 {
+		*problems = append(*problems, field+" must be greater than or equal to 0")
 	}
 }
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -149,6 +150,42 @@ func TestNoProgressSpendLimitConfiguration(t *testing.T) {
 			}
 			if workflow.Config.Agent.NoProgressSpendLimitUSD != tt.want {
 				t.Fatalf("NoProgressSpendLimitUSD = %g, want %g", workflow.Config.Agent.NoProgressSpendLimitUSD, tt.want)
+			}
+		})
+	}
+}
+
+func TestRESTFanoutMaxRequestsConfiguration(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		value   int
+		wantErr string
+	}{
+		{name: "disabled", value: 0},
+		{name: "custom cap", value: 200},
+		{name: "negative rejected", value: -1, wantErr: "tracker.github_rest_fanout_max_requests must be greater than or equal to 0"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			raw := []byte("---\ntracker:\n  kind: memory\n  github_rest_fanout_max_requests: " + strconv.Itoa(tt.value) + "\n---\nPrompt\n")
+			workflow, err := ParseWorkflow(raw)
+			if err == nil {
+				err = workflow.Config.Validate()
+			}
+			if tt.wantErr != "" {
+				if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
+					t.Fatalf("configuration error = %v, want %q", err, tt.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("ParseWorkflow() error = %v", err)
+			}
+			if workflow.Config.Tracker.GitHubRESTFanoutMaxRequests != tt.value {
+				t.Fatalf("GitHubRESTFanoutMaxRequests = %d, want %d", workflow.Config.Tracker.GitHubRESTFanoutMaxRequests, tt.value)
 			}
 		})
 	}
@@ -2170,7 +2207,6 @@ Prompt
 				"tracker.github_graphql_warn_remaining must be greater than 0",
 				"tracker.github_graphql_min_remaining_reserve must be greater than 0",
 				"tracker.github_rest_min_remaining_reserve must be greater than 0",
-				"tracker.github_rest_fanout_max_requests must be greater than 0",
 				"polling.interval_ms must be greater than 0",
 				"worker.max_concurrent_agents_per_host must be greater than 0",
 				"workspace.cleanup_idle_ttl_ms must be greater than 0",

--- a/internal/connector/github/adapter_test.go
+++ b/internal/connector/github/adapter_test.go
@@ -1785,6 +1785,81 @@ func TestConnectorFetchCandidateIssuesMarksBranchPullRequestHydrationUnavailable
 	}
 }
 
+func TestConnectorAttachPullRequestsRotatesAfterRESTBudgetReservation(t *testing.T) {
+	t.Parallel()
+
+	var mu sync.Mutex
+	var pullRequests []string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		path := r.URL.Path
+		switch {
+		case strings.Contains(path, "/pulls/") && !strings.HasSuffix(path, "/reviews"):
+			number := path[strings.LastIndex(path, "/")+1:]
+			mu.Lock()
+			pullRequests = append(pullRequests, number)
+			mu.Unlock()
+			_, _ = fmt.Fprintf(w, `{"number":%s,"html_url":"https://github.com/digitaldrywood/detent/pull/%s","state":"open","head":{"ref":"detent/issue-%s","sha":"sha-%s"}}`, number, number, number, number)
+		case strings.HasSuffix(path, "/check-runs"):
+			_, _ = w.Write([]byte(`{"check_runs":[]}`))
+		case strings.HasSuffix(path, "/statuses"), strings.HasSuffix(path, "/reviews"):
+			_, _ = w.Write([]byte(`[]`))
+		default:
+			t.Fatalf("unexpected REST path %s", r.URL.RequestURI())
+		}
+	}))
+	t.Cleanup(server.Close)
+
+	c, err := NewConnector(Config{
+		Endpoint:                   server.URL,
+		APIKey:                     "token",
+		HTTPClient:                 server.Client(),
+		RESTFanoutMaxRequests:      4,
+		DisableConditionalRequests: true,
+	})
+	if err != nil {
+		t.Fatalf("NewConnector() error = %v", err)
+	}
+
+	newIssues := func() []connector.Issue {
+		first := 101
+		second := 102
+		return []connector.Issue{
+			{Identifier: "digitaldrywood/detent#1", PRNumber: &first},
+			{Identifier: "digitaldrywood/detent#2", PRNumber: &second},
+		}
+	}
+
+	first := newIssues()
+	if err := c.attachPullRequests(context.Background(), first); err != nil {
+		t.Fatalf("attachPullRequests() first error = %v", err)
+	}
+	if first[0].PullRequest == nil || first[0].PullRequest.HydrationUnavailableReason != "" {
+		t.Fatalf("first pass issue 1 PullRequest = %#v, want hydrated", first[0].PullRequest)
+	}
+	if first[1].PullRequest == nil || first[1].PullRequest.HydrationUnavailableReason != connector.PullRequestHydrationReasonRESTBudgetReserved {
+		t.Fatalf("first pass issue 2 PullRequest = %#v, want budget reservation", first[1].PullRequest)
+	}
+	c.FlushRESTRateLimitUsage()
+
+	second := newIssues()
+	if err := c.attachPullRequests(context.Background(), second); err != nil {
+		t.Fatalf("attachPullRequests() second error = %v", err)
+	}
+	if second[1].PullRequest == nil || second[1].PullRequest.HydrationUnavailableReason != "" {
+		t.Fatalf("second pass issue 2 PullRequest = %#v, want rotated hydration", second[1].PullRequest)
+	}
+	if second[0].PullRequest == nil || second[0].PullRequest.HydrationUnavailableReason != connector.PullRequestHydrationReasonRESTBudgetReserved {
+		t.Fatalf("second pass issue 1 PullRequest = %#v, want rotated budget reservation", second[0].PullRequest)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if got, want := pullRequests, []string{"101", "102"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("hydrated pull requests = %v, want %v", got, want)
+	}
+}
+
 func TestConnectorFetchCandidateIssuesStopsBranchPullRequestHydrationAfterSecondaryThrottle(t *testing.T) {
 	t.Parallel()
 

--- a/internal/connector/github/adapter_test.go
+++ b/internal/connector/github/adapter_test.go
@@ -1860,6 +1860,86 @@ func TestConnectorAttachPullRequestsRotatesAfterRESTBudgetReservation(t *testing
 	}
 }
 
+func TestConnectorAttachPullRequestsPrioritizesSkippedBranchCandidate(t *testing.T) {
+	t.Parallel()
+
+	var mu sync.Mutex
+	var detailedPullRequests []string
+	var pullRequestLists int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		path := r.URL.Path
+		switch {
+		case path == "/repos/digitaldrywood/detent/pulls":
+			mu.Lock()
+			pullRequestLists++
+			mu.Unlock()
+			_, _ = w.Write([]byte(`[{"number":202,"html_url":"https://github.com/digitaldrywood/detent/pull/202","state":"open","head":{"ref":"detent/digitaldrywood_detent_2","sha":"sha-202"}}]`))
+		case strings.Contains(path, "/pulls/") && !strings.HasSuffix(path, "/reviews"):
+			number := path[strings.LastIndex(path, "/")+1:]
+			mu.Lock()
+			detailedPullRequests = append(detailedPullRequests, number)
+			mu.Unlock()
+			_, _ = fmt.Fprintf(w, `{"number":%s,"html_url":"https://github.com/digitaldrywood/detent/pull/%s","state":"open","head":{"ref":"detent/digitaldrywood_detent_%s","sha":"sha-%s"}}`, number, number, number, number)
+		case strings.HasSuffix(path, "/check-runs"):
+			_, _ = w.Write([]byte(`{"check_runs":[]}`))
+		case strings.HasSuffix(path, "/statuses"), strings.HasSuffix(path, "/reviews"):
+			_, _ = w.Write([]byte(`[]`))
+		default:
+			t.Fatalf("unexpected REST path %s", r.URL.RequestURI())
+		}
+	}))
+	t.Cleanup(server.Close)
+
+	c, err := NewConnector(Config{
+		Endpoint:                   server.URL,
+		APIKey:                     "token",
+		HTTPClient:                 server.Client(),
+		RESTFanoutMaxRequests:      5,
+		DisableConditionalRequests: true,
+	})
+	if err != nil {
+		t.Fatalf("NewConnector() error = %v", err)
+	}
+
+	newIssues := func() []connector.Issue {
+		linked := 101
+		return []connector.Issue{
+			{Identifier: "digitaldrywood/detent#1", PRNumber: &linked},
+			{Identifier: "digitaldrywood/detent#2"},
+		}
+	}
+
+	first := newIssues()
+	if err := c.attachPullRequests(context.Background(), first); err != nil {
+		t.Fatalf("attachPullRequests() first error = %v", err)
+	}
+	if first[1].PullRequest == nil || first[1].PullRequest.HydrationUnavailableReason != connector.PullRequestHydrationReasonRESTBudgetReserved {
+		t.Fatalf("first pass branch issue PullRequest = %#v, want budget reservation", first[1].PullRequest)
+	}
+	c.FlushRESTRateLimitUsage()
+
+	second := newIssues()
+	if err := c.attachPullRequests(context.Background(), second); err != nil {
+		t.Fatalf("attachPullRequests() second error = %v", err)
+	}
+	if second[1].PullRequest == nil || second[1].PullRequest.HydrationUnavailableReason != "" || second[1].PullRequest.Number != 202 {
+		t.Fatalf("second pass branch issue PullRequest = %#v, want prioritized hydration", second[1].PullRequest)
+	}
+	if second[0].PullRequest == nil || second[0].PullRequest.HydrationUnavailableReason != connector.PullRequestHydrationReasonRESTBudgetReserved {
+		t.Fatalf("second pass linked issue PullRequest = %#v, want rotated budget reservation", second[0].PullRequest)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if got, want := detailedPullRequests, []string{"101", "202"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("detailed pull requests = %v, want %v", got, want)
+	}
+	if pullRequestLists != 2 {
+		t.Fatalf("pull request list calls = %d, want 2", pullRequestLists)
+	}
+}
+
 func TestConnectorFetchCandidateIssuesStopsBranchPullRequestHydrationAfterSecondaryThrottle(t *testing.T) {
 	t.Parallel()
 

--- a/internal/connector/github/client.go
+++ b/internal/connector/github/client.go
@@ -29,6 +29,8 @@ const (
 const (
 	restRateLimitKindPrimaryExhausted   = "primary_exhausted"
 	restRateLimitKindSecondaryThrottled = "secondary_throttled"
+	restFanoutCostUnitsPerRequest       = int64(4)
+	restConditionalFanoutCostUnits      = int64(1)
 )
 
 var defaultRESTBackoffs = newRESTBackoffRegistry()
@@ -69,6 +71,7 @@ type Client struct {
 	restRateLimit          connector.RESTRateLimit
 	restRateLimits         map[string]connector.RESTRateLimit
 	restRequests           map[string]connector.RESTEndpointUsage
+	restFanoutUnits        int64
 	restCache              map[string]restCacheEntry
 	conditionalRequests    bool
 	restBackoffUntil       time.Time
@@ -614,6 +617,7 @@ func (c *Client) FlushRESTRateLimitUsage() connector.RESTRateLimitUsage {
 		}
 	}
 	c.restRequests = nil
+	c.restFanoutUnits = 0
 	return usage
 }
 
@@ -649,7 +653,7 @@ func normalizeRESTBudgetPolicy(policy RESTBudgetPolicy) RESTBudgetPolicy {
 
 func (c *Client) restBudgetPolicyError(method string, path string, conditional bool) error {
 	family := restEndpointFamily(method, path)
-	if !restFanoutEndpointFamily(family) || conditional {
+	if !restFanoutEndpointFamily(family) {
 		return nil
 	}
 
@@ -657,7 +661,12 @@ func (c *Client) restBudgetPolicyError(method string, path string, conditional b
 	defer c.mu.Unlock()
 
 	rateLimit, hasRateLimit := c.restRateLimitForResourceLocked(restEndpointRateLimitResource(family))
-	if c.restPolicy.FanoutMaxRequests > 0 && c.restFanoutRequestCountLocked() >= c.restPolicy.FanoutMaxRequests {
+	requestCost := restFanoutCostUnitsPerRequest
+	if conditional {
+		requestCost = restConditionalFanoutCostUnits
+	}
+	if c.restPolicy.FanoutMaxRequests > 0 &&
+		c.restFanoutUnits+requestCost > c.restPolicy.FanoutMaxRequests*restFanoutCostUnitsPerRequest {
 		c.recordRESTBudgetThrottleLocked(method, path, family, rateLimit, hasRateLimit)
 		return &StatusError{
 			StatusCode: http.StatusTooManyRequests,
@@ -666,6 +675,7 @@ func (c *Client) restBudgetPolicyError(method string, path string, conditional b
 		}
 	}
 	if c.restPolicy.MinRemainingReserve > 0 &&
+		!conditional &&
 		hasRateLimit &&
 		rateLimit.Limit > 0 &&
 		rateLimit.Remaining <= c.restPolicy.MinRemainingReserve {
@@ -676,17 +686,8 @@ func (c *Client) restBudgetPolicyError(method string, path string, conditional b
 			Err:        ErrRESTBudgetReserved,
 		}
 	}
+	c.restFanoutUnits += requestCost
 	return nil
-}
-
-func (c *Client) restFanoutRequestCountLocked() int64 {
-	var count int64
-	for family, request := range c.restRequests {
-		if restFanoutEndpointFamily(family) {
-			count += request.Billable
-		}
-	}
-	return count
 }
 
 func (c *Client) restRateLimitForResourceLocked(resource string) (connector.RESTRateLimit, bool) {
@@ -825,6 +826,9 @@ func (c *Client) recordRESTRateLimitFromHeaders(backoffKey string, method string
 		request.NotModified++
 	} else {
 		request.Billable++
+		if conditional && restFanoutEndpointFamily(family) {
+			c.restFanoutUnits += restFanoutCostUnitsPerRequest - restConditionalFanoutCostUnits
+		}
 	}
 	request.LastStatus = status
 	request.RateLimited = request.RateLimited || rateLimited

--- a/internal/connector/github/conditional_test.go
+++ b/internal/connector/github/conditional_test.go
@@ -2,6 +2,7 @@ package github
 
 import (
 	"context"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"strconv"
@@ -68,6 +69,83 @@ func TestClientRESTConditionalRequestUsesCachedResponseBelowReserve(t *testing.T
 	}
 	if usage.RateLimit.Used != 4100 || usage.RateLimit.Remaining != 900 {
 		t.Fatalf("rate limit = %#v, want unchanged 4100 used and 900 remaining", usage.RateLimit)
+	}
+}
+
+func TestClientRESTConditionalRequestsReserveConservativeFanoutCost(t *testing.T) {
+	t.Parallel()
+
+	var calls atomic.Int64
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls.Add(1)
+		if got := r.Header.Get("If-None-Match"); got == "" {
+			t.Fatal("If-None-Match is empty, want cached validator")
+		}
+		w.WriteHeader(http.StatusNotModified)
+	}))
+	t.Cleanup(server.Close)
+
+	client, err := NewClient(ClientConfig{
+		Endpoint:    server.URL,
+		TokenSource: StaticTokenSource("test-token"),
+		HTTPClient:  server.Client(),
+		RESTPolicy:  RESTBudgetPolicy{FanoutMaxRequests: 1},
+	})
+	if err != nil {
+		t.Fatalf("NewClient() error = %v", err)
+	}
+
+	headers := http.Header{"Etag": []string{`"cached"`}}
+	for index := range 5 {
+		path := "/repos/digitaldrywood/detent/pulls/" + strconv.Itoa(index+1)
+		client.storeRESTConditionalEntry(http.MethodGet, path, headers, []byte(`{}`))
+		err := client.REST(context.Background(), http.MethodGet, path, nil, nil)
+		if index < 4 && err != nil {
+			t.Fatalf("conditional REST() request %d error = %v", index+1, err)
+		}
+		if index == 4 && !errors.Is(err, ErrRESTBudgetReserved) {
+			t.Fatalf("conditional REST() request 5 error = %v, want ErrRESTBudgetReserved", err)
+		}
+	}
+	if calls.Load() != 4 {
+		t.Fatalf("REST calls = %d, want four quarter-cost conditional requests", calls.Load())
+	}
+}
+
+func TestClientRESTCachedPullRequestFleetFitsDefaultFanoutCap(t *testing.T) {
+	t.Parallel()
+
+	var calls atomic.Int64
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls.Add(1)
+		w.WriteHeader(http.StatusNotModified)
+	}))
+	t.Cleanup(server.Close)
+
+	client, err := NewClient(ClientConfig{
+		Endpoint:    server.URL,
+		TokenSource: StaticTokenSource("test-token"),
+		HTTPClient:  server.Client(),
+		RESTPolicy:  RESTBudgetPolicy{FanoutMaxRequests: 80},
+	})
+	if err != nil {
+		t.Fatalf("NewClient() error = %v", err)
+	}
+
+	headers := http.Header{"Etag": []string{`"cached"`}}
+	for index := range 200 {
+		path := "/repos/digitaldrywood/detent/pulls/" + strconv.Itoa(index+1)
+		client.storeRESTConditionalEntry(http.MethodGet, path, headers, []byte(`{}`))
+		if err := client.REST(context.Background(), http.MethodGet, path, nil, nil); err != nil {
+			t.Fatalf("conditional REST() request %d error = %v", index+1, err)
+		}
+	}
+	if calls.Load() != 200 {
+		t.Fatalf("REST calls = %d, want 200 cached hydration requests", calls.Load())
+	}
+	usage := client.FlushRESTRateLimitUsage()
+	if usage.BillableRequests != 0 || usage.NotModifiedRequests != 200 {
+		t.Fatalf("REST usage = %#v, want 200 free not-modified requests", usage)
 	}
 }
 

--- a/internal/connector/github/connector.go
+++ b/internal/connector/github/connector.go
@@ -104,6 +104,7 @@ type Connector struct {
 	projectCache      *projectCache
 	pullRequests      *pullRequestStatusCache
 	prHydration       *pullRequestHydrationCircuitBreaker
+	prHydrationCursor map[string]string
 	logger            *slog.Logger
 	mu                sync.RWMutex
 	writeMu           sync.Mutex
@@ -183,6 +184,7 @@ func NewConnector(cfg Config) (*Connector, error) {
 		projectCache:      newProjectCache(githubCacheTTL, cfg.Now),
 		pullRequests:      newPullRequestStatusCache(githubCacheTTL, cfg.Now),
 		prHydration:       newPullRequestHydrationCircuitBreaker(cfg.Now),
+		prHydrationCursor: map[string]string{},
 		logger:            logger,
 	}, nil
 }

--- a/internal/connector/github/pull_requests.go
+++ b/internal/connector/github/pull_requests.go
@@ -89,41 +89,91 @@ func (c *Connector) attachPullRequestsWithCache(ctx context.Context, issues []co
 
 	for _, repo := range repos {
 		candidates := c.rotatePullRequestHydrationCandidates(repo, byRepo[repo])
-		nextCursor, err := c.attachLinkedPullRequests(ctx, repo, issues, candidates, useStatusCache)
-		if err != nil {
-			return err
-		}
-		if !hasUnattachedBranchPullRequestCandidates(issues, candidates) {
-			c.setPullRequestHydrationCursor(repo, nextCursor)
-			continue
-		}
-		if state, ok := c.currentPullRequestHydrationState(repo); ok {
-			c.logPullRequestHydrationSkip(ctx, repo, state, "shared_backoff")
-			markPullRequestHydrationUnavailableForCandidates(issues, candidates, repo, state)
-			continue
-		}
-		pullRequests, err := c.fetchRepositoryPullRequests(ctx, repo)
-		if err != nil {
-			if state := c.pullRequestHydrationStateForError(repo, err); state.Reason != "" {
-				markPullRequestHydrationUnavailableForCandidates(issues, candidates, repo, state)
-				if errors.Is(err, ErrRESTBudgetReserved) && nextCursor == "" && len(candidates) > 0 {
-					nextCursor = candidates[0].Identifier
-				}
-				c.setPullRequestHydrationCursor(repo, nextCursor)
-				continue
+		nextCursor := ""
+		branchFirst := firstPullRequestCandidateNeedsBranchHydration(issues, candidates)
+		if branchFirst {
+			var err error
+			nextCursor, err = c.attachBranchPullRequests(ctx, repo, issues, candidates, useStatusCache)
+			if err != nil {
+				return err
 			}
-			return err
 		}
-		matchingCursor, err := c.attachMatchingPullRequests(ctx, repo, issues, candidates, pullRequests, useStatusCache)
+
+		linkedCursor, err := c.attachLinkedPullRequests(ctx, repo, issues, candidates, useStatusCache)
 		if err != nil {
 			return err
 		}
 		if nextCursor == "" {
-			nextCursor = matchingCursor
+			nextCursor = linkedCursor
+		}
+		if !branchFirst {
+			branchCursor, err := c.attachBranchPullRequests(ctx, repo, issues, candidates, useStatusCache)
+			if err != nil {
+				return err
+			}
+			if nextCursor == "" {
+				nextCursor = branchCursor
+			}
 		}
 		c.setPullRequestHydrationCursor(repo, nextCursor)
 	}
 	return nil
+}
+
+func (c *Connector) attachBranchPullRequests(
+	ctx context.Context,
+	repo pullRequestRepo,
+	issues []connector.Issue,
+	candidates []issuePullRequestCandidate,
+	useStatusCache bool,
+) (string, error) {
+	if !hasUnattachedBranchPullRequestCandidates(issues, candidates) {
+		return "", nil
+	}
+	if state, ok := c.currentPullRequestHydrationState(repo); ok {
+		c.logPullRequestHydrationSkip(ctx, repo, state, "shared_backoff")
+		markPullRequestHydrationUnavailableForCandidates(issues, candidates, repo, state)
+		return firstUnattachedBranchPullRequestCandidate(issues, candidates), nil
+	}
+	pullRequests, err := c.fetchRepositoryPullRequests(ctx, repo)
+	if err != nil {
+		if state := c.pullRequestHydrationStateForError(repo, err); state.Reason != "" {
+			cursor := ""
+			if errors.Is(err, ErrRESTBudgetReserved) {
+				cursor = firstUnattachedBranchPullRequestCandidate(issues, candidates)
+			}
+			markPullRequestHydrationUnavailableForCandidates(issues, candidates, repo, state)
+			return cursor, nil
+		}
+		return "", err
+	}
+	return c.attachMatchingPullRequests(ctx, repo, issues, candidates, pullRequests, useStatusCache)
+}
+
+func firstPullRequestCandidateNeedsBranchHydration(issues []connector.Issue, candidates []issuePullRequestCandidate) bool {
+	if len(candidates) == 0 {
+		return false
+	}
+	candidate := candidates[0]
+	return issues[candidate.Index].PullRequest == nil &&
+		candidate.PullRequestNumber <= 0 &&
+		strings.TrimSpace(candidate.BranchPrefix) != ""
+}
+
+func firstUnattachedBranchPullRequestCandidate(issues []connector.Issue, candidates []issuePullRequestCandidate) string {
+	for _, candidate := range candidates {
+		if issues[candidate.Index].PullRequest == nil &&
+			candidate.PullRequestNumber <= 0 &&
+			strings.TrimSpace(candidate.BranchPrefix) != "" {
+			return candidate.Identifier
+		}
+	}
+	for _, candidate := range candidates {
+		if issues[candidate.Index].PullRequest == nil && strings.TrimSpace(candidate.BranchPrefix) != "" {
+			return candidate.Identifier
+		}
+	}
+	return ""
 }
 
 func (c *Connector) attachPullRequestMergeStates(ctx context.Context, issues []connector.Issue) error {

--- a/internal/connector/github/pull_requests.go
+++ b/internal/connector/github/pull_requests.go
@@ -15,6 +15,7 @@ import (
 
 type issuePullRequestCandidate struct {
 	Index             int
+	Identifier        string
 	BranchPrefix      string
 	PullRequestNumber int
 	PullRequestRepo   pullRequestRepo
@@ -60,8 +61,13 @@ func (c *Connector) attachPullRequestsWithCache(ctx context.Context, issues []co
 		if branchPrefix == "" && pullRequestNumber <= 0 {
 			continue
 		}
+		identifier := strings.TrimSpace(issue.Identifier)
+		if identifier == "" {
+			identifier = strings.TrimSpace(issue.ID)
+		}
 		byRepo[repo] = append(byRepo[repo], issuePullRequestCandidate{
 			Index:             index,
+			Identifier:        identifier,
 			BranchPrefix:      branchPrefix,
 			PullRequestNumber: pullRequestNumber,
 			PullRequestRepo:   linkedPullRequestRepo,
@@ -82,28 +88,40 @@ func (c *Connector) attachPullRequestsWithCache(ctx context.Context, issues []co
 	})
 
 	for _, repo := range repos {
-		if err := c.attachLinkedPullRequests(ctx, repo, issues, byRepo[repo], useStatusCache); err != nil {
+		candidates := c.rotatePullRequestHydrationCandidates(repo, byRepo[repo])
+		nextCursor, err := c.attachLinkedPullRequests(ctx, repo, issues, candidates, useStatusCache)
+		if err != nil {
 			return err
 		}
-		if !hasUnattachedBranchPullRequestCandidates(issues, byRepo[repo]) {
+		if !hasUnattachedBranchPullRequestCandidates(issues, candidates) {
+			c.setPullRequestHydrationCursor(repo, nextCursor)
 			continue
 		}
 		if state, ok := c.currentPullRequestHydrationState(repo); ok {
 			c.logPullRequestHydrationSkip(ctx, repo, state, "shared_backoff")
-			markPullRequestHydrationUnavailableForCandidates(issues, byRepo[repo], repo, state)
+			markPullRequestHydrationUnavailableForCandidates(issues, candidates, repo, state)
 			continue
 		}
 		pullRequests, err := c.fetchRepositoryPullRequests(ctx, repo)
 		if err != nil {
 			if state := c.pullRequestHydrationStateForError(repo, err); state.Reason != "" {
-				markPullRequestHydrationUnavailableForCandidates(issues, byRepo[repo], repo, state)
+				markPullRequestHydrationUnavailableForCandidates(issues, candidates, repo, state)
+				if errors.Is(err, ErrRESTBudgetReserved) && nextCursor == "" && len(candidates) > 0 {
+					nextCursor = candidates[0].Identifier
+				}
+				c.setPullRequestHydrationCursor(repo, nextCursor)
 				continue
 			}
 			return err
 		}
-		if err := c.attachMatchingPullRequests(ctx, repo, issues, byRepo[repo], pullRequests, useStatusCache); err != nil {
+		matchingCursor, err := c.attachMatchingPullRequests(ctx, repo, issues, candidates, pullRequests, useStatusCache)
+		if err != nil {
 			return err
 		}
+		if nextCursor == "" {
+			nextCursor = matchingCursor
+		}
+		c.setPullRequestHydrationCursor(repo, nextCursor)
 	}
 	return nil
 }
@@ -124,6 +142,7 @@ func (c *Connector) attachPullRequestMergeStates(ctx context.Context, issues []c
 		}
 		byRepo[repo] = append(byRepo[repo], issuePullRequestCandidate{
 			Index:        index,
+			Identifier:   strings.TrimSpace(issue.Identifier),
 			BranchPrefix: branchPrefix,
 		})
 	}
@@ -343,8 +362,9 @@ func (c *Connector) attachLinkedPullRequests(
 	issues []connector.Issue,
 	candidates []issuePullRequestCandidate,
 	useStatusCache bool,
-) error {
+) (string, error) {
 	pullRequests := map[pullRequestKey]pullRequestNode{}
+	nextCursor := ""
 	for _, candidate := range candidates {
 		if issues[candidate.Index].PullRequest != nil || candidate.PullRequestNumber <= 0 {
 			continue
@@ -365,23 +385,29 @@ func (c *Connector) attachLinkedPullRequests(
 			pullRequest, err = c.fetchRepositoryPullRequest(ctx, pullRequestRepo, candidate.PullRequestNumber)
 			if err != nil {
 				if state := c.pullRequestHydrationStateForError(pullRequestRepo, err); state.Reason != "" {
+					if errors.Is(err, ErrRESTBudgetReserved) && nextCursor == "" {
+						nextCursor = candidate.Identifier
+					}
 					attachPullRequestHydrationUnavailableToIssue(&issues[candidate.Index], pullRequestRepo, candidate.PullRequestNumber, state)
 					continue
 				}
-				return err
+				return "", err
 			}
 			if err := c.populatePullRequestStatus(ctx, pullRequestRepo, &pullRequest, useStatusCache); err != nil {
 				if state := c.pullRequestHydrationStateForError(pullRequestRepo, err); state.Reason != "" {
+					if errors.Is(err, ErrRESTBudgetReserved) && nextCursor == "" {
+						nextCursor = candidate.Identifier
+					}
 					applyPullRequestHydrationUnavailableState(&pullRequest, state)
 				} else {
-					return err
+					return "", err
 				}
 			}
 			pullRequests[key] = pullRequest
 		}
 		attachPullRequestToIssue(&issues[candidate.Index], pullRequestRepo, pullRequest)
 	}
-	return nil
+	return nextCursor, nil
 }
 
 func (c *Connector) attachMatchingPullRequests(
@@ -391,15 +417,15 @@ func (c *Connector) attachMatchingPullRequests(
 	candidates []issuePullRequestCandidate,
 	pullRequests []pullRequestNode,
 	useStatusCache bool,
-) error {
+) (string, error) {
 	hydrated := map[int]pullRequestNode{}
-	for _, pullRequest := range pullRequests {
-		branchName := strings.TrimSpace(pullRequest.HeadRefName)
-		if branchName == "" {
-			continue
-		}
-		for _, candidate := range candidates {
+	for _, candidate := range candidates {
+		for _, pullRequest := range pullRequests {
 			if issues[candidate.Index].PullRequest != nil {
+				break
+			}
+			branchName := strings.TrimSpace(pullRequest.HeadRefName)
+			if branchName == "" {
 				continue
 			}
 			if !branchMatchesIssuePrefix(branchName, candidate.BranchPrefix) {
@@ -416,9 +442,12 @@ func (c *Connector) attachMatchingPullRequests(
 						hydrated[pullRequest.Number] = pullRequest
 						attachPullRequestToIssue(&issues[candidate.Index], repo, pullRequest)
 						markPullRequestHydrationUnavailableForCandidates(issues, candidates, repo, state)
-						return nil
+						if errors.Is(err, ErrRESTBudgetReserved) {
+							return candidate.Identifier, nil
+						}
+						return "", nil
 					}
-					return err
+					return "", err
 				}
 				if err := c.populatePullRequestStatus(ctx, repo, &hydratedPullRequest, useStatusCache); err != nil {
 					if state := c.pullRequestHydrationStateForError(repo, err); state.Reason != "" {
@@ -426,17 +455,64 @@ func (c *Connector) attachMatchingPullRequests(
 						hydrated[pullRequest.Number] = hydratedPullRequest
 						attachPullRequestToIssue(&issues[candidate.Index], repo, hydratedPullRequest)
 						markPullRequestHydrationUnavailableForCandidates(issues, candidates, repo, state)
-						return nil
+						if errors.Is(err, ErrRESTBudgetReserved) {
+							return candidate.Identifier, nil
+						}
+						return "", nil
 					} else {
-						return err
+						return "", err
 					}
 				}
 				hydrated[pullRequest.Number] = hydratedPullRequest
 			}
 			attachPullRequestToIssue(&issues[candidate.Index], repo, hydratedPullRequest)
+			break
 		}
 	}
-	return nil
+	return "", nil
+}
+
+func (c *Connector) rotatePullRequestHydrationCandidates(repo pullRequestRepo, candidates []issuePullRequestCandidate) []issuePullRequestCandidate {
+	if c == nil || len(candidates) < 2 {
+		return candidates
+	}
+	key := pullRequestRepoName(repo)
+	c.mu.RLock()
+	cursor := c.prHydrationCursor[key]
+	c.mu.RUnlock()
+	if cursor == "" {
+		return candidates
+	}
+	for index, candidate := range candidates {
+		if candidate.Identifier != cursor || index == 0 {
+			continue
+		}
+		rotated := make([]issuePullRequestCandidate, 0, len(candidates))
+		rotated = append(rotated, candidates[index:]...)
+		rotated = append(rotated, candidates[:index]...)
+		return rotated
+	}
+	return candidates
+}
+
+func (c *Connector) setPullRequestHydrationCursor(repo pullRequestRepo, identifier string) {
+	if c == nil {
+		return
+	}
+	key := pullRequestRepoName(repo)
+	if key == "" {
+		return
+	}
+	c.mu.Lock()
+	if identifier == "" {
+		delete(c.prHydrationCursor, key)
+	} else {
+		if c.prHydrationCursor == nil {
+			c.prHydrationCursor = make(map[string]string)
+		}
+		c.prHydrationCursor[key] = identifier
+	}
+	c.mu.Unlock()
 }
 
 func hasUnattachedBranchPullRequestCandidates(issues []connector.Issue, candidates []issuePullRequestCandidate) bool {

--- a/internal/orchestrator/hydration_starvation.go
+++ b/internal/orchestrator/hydration_starvation.go
@@ -1,0 +1,65 @@
+package orchestrator
+
+import (
+	"strings"
+
+	"github.com/digitaldrywood/detent/internal/connector"
+)
+
+const (
+	hydrationStarvationIssueThreshold = 10
+	hydrationStarvationTickThreshold  = 3
+)
+
+func (o *Orchestrator) observePullRequestHydrationSkips(issues []connector.Issue) {
+	if o == nil {
+		return
+	}
+	current := make(map[string]struct{})
+	for _, issue := range issues {
+		if issue.PullRequest == nil || strings.TrimSpace(issue.PullRequest.HydrationUnavailableReason) == "" {
+			continue
+		}
+		identifier := strings.TrimSpace(issue.Identifier)
+		if identifier == "" {
+			identifier = strings.TrimSpace(issue.ID)
+		}
+		if identifier != "" {
+			current[identifier] = struct{}{}
+		}
+	}
+
+	if o.hydrationSkipStreaks == nil {
+		o.hydrationSkipStreaks = make(map[string]int)
+	}
+	for identifier := range o.hydrationSkipStreaks {
+		if _, ok := current[identifier]; !ok {
+			delete(o.hydrationSkipStreaks, identifier)
+		}
+	}
+	for identifier := range current {
+		o.hydrationSkipStreaks[identifier]++
+	}
+
+	sustained := 0
+	maxTicks := 0
+	for _, ticks := range o.hydrationSkipStreaks {
+		if ticks > maxTicks {
+			maxTicks = ticks
+		}
+		if ticks > hydrationStarvationTickThreshold {
+			sustained++
+		}
+	}
+	starved := sustained > hydrationStarvationIssueThreshold
+	if starved && !o.hydrationWarned && o.logger != nil {
+		o.logger.Warn(
+			"github pull request hydration starvation",
+			"skipped_issue_count", sustained,
+			"issue_count_threshold", hydrationStarvationIssueThreshold,
+			"consecutive_tick_threshold", hydrationStarvationTickThreshold,
+			"max_consecutive_ticks", maxTicks,
+		)
+	}
+	o.hydrationWarned = starved
+}

--- a/internal/orchestrator/hydration_starvation_test.go
+++ b/internal/orchestrator/hydration_starvation_test.go
@@ -1,0 +1,63 @@
+package orchestrator
+
+import (
+	"bytes"
+	"fmt"
+	"log/slog"
+	"strings"
+	"testing"
+
+	"github.com/digitaldrywood/detent/internal/connector"
+)
+
+func TestObservePullRequestHydrationSkipsWarnsAfterSustainedFleetStarvation(t *testing.T) {
+	t.Parallel()
+
+	var logs bytes.Buffer
+	orchestrator := &Orchestrator{
+		logger: slog.New(slog.NewTextHandler(&logs, nil)),
+	}
+	issues := make([]connector.Issue, 11)
+	for index := range issues {
+		issues[index] = connector.Issue{
+			Identifier: fmt.Sprintf("digitaldrywood/detent#%d", index+1),
+			PullRequest: &connector.PullRequest{
+				HydrationUnavailableReason: connector.PullRequestHydrationReasonRESTBudgetReserved,
+			},
+		}
+	}
+
+	for range 3 {
+		orchestrator.observePullRequestHydrationSkips(issues)
+	}
+	if logs.Len() != 0 {
+		t.Fatalf("logs before sustained threshold = %q, want empty", logs.String())
+	}
+
+	orchestrator.observePullRequestHydrationSkips(issues)
+	got := logs.String()
+	for _, want := range []string{
+		"level=WARN",
+		`msg="github pull request hydration starvation"`,
+		"skipped_issue_count=11",
+		"consecutive_tick_threshold=3",
+		"max_consecutive_ticks=4",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("logs = %q, want %q", got, want)
+		}
+	}
+
+	orchestrator.observePullRequestHydrationSkips(issues)
+	if strings.Count(logs.String(), "github pull request hydration starvation") != 1 {
+		t.Fatalf("logs = %q, want one warning until recovery", logs.String())
+	}
+
+	orchestrator.observePullRequestHydrationSkips(nil)
+	for range 4 {
+		orchestrator.observePullRequestHydrationSkips(issues)
+	}
+	if strings.Count(logs.String(), "github pull request hydration starvation") != 2 {
+		t.Fatalf("logs = %q, want warning after starvation recurs", logs.String())
+	}
+}

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -168,6 +168,8 @@ type Orchestrator struct {
 	issueBudgetStatus       runpkg.IssueBudgetStatusProvider
 	now                     func() time.Time
 	retrospector            Retrospector
+	hydrationSkipStreaks    map[string]int
+	hydrationWarned         bool
 	stateRequests           chan stateRequest
 	drainRequests           chan drainRequest
 	forceRequests           chan forceRequest

--- a/internal/orchestrator/tick.go
+++ b/internal/orchestrator/tick.go
@@ -101,6 +101,7 @@ func (o *Orchestrator) tickWithManual(ctx context.Context, state *State, now tim
 	o.refreshStatusDrift(ctx, state, now, reserve)
 	fetched = retainUnavailablePullRequestsFromPrevious(fetched, previous)
 	fetched = applyStatusPullRequestHydrationBlocksToCandidates(fetched)
+	o.observePullRequestHydrationSkips(mergeIssueSlices(fetched.candidates, fetched.status))
 	o.restoreDurableGateWaitCompletions(ctx, state, mergeIssueSlices(fetched.candidates, fetched.status))
 
 	transitions := o.refreshTransitionSets(ctx, state, fetched, previous)


### PR DESCRIPTION
## Summary

- reserve validator-backed REST fanout at a conservative quarter-request cost and charge billable conditional responses at full cost
- rotate PR hydration from the first budget-skipped issue so capped lanes drain fairly across polling cycles
- warn after more than 10 issues remain hydration-skipped for more than 3 consecutive ticks
- allow `github_rest_fanout_max_requests: 0` to disable the cap while retaining the remaining-quota reserve

Fixes #1236

## UI Surface Contract

- [x] N/A; this PR has no UI surface changes.
- [x] This PR does not add persistent top-of-screen messaging.
- [x] N/A; this PR has no visual changes.

## Test Plan

- [x] `make check`
- [x] Focused REST conditional-budget, hydration-rotation, starvation-warning, and config validation tests
