### PR TITLE
fix(budget): hard hold per-issue refusals

### DIFF
--- a/internal/budget/budget.go
+++ b/internal/budget/budget.go
@@ -68,6 +68,12 @@ type DailyStatus struct {
 	MaxUSD          float64
 }
 
+type IssueStatus struct {
+	Active          bool
+	CurrentSpendUSD float64
+	MaxUSD          float64
+}
+
 type Refusal struct {
 	Code              ReasonCode
 	Message           string
@@ -209,6 +215,28 @@ func (c *Checker) DailyStatus(ctx context.Context, now time.Time) (DailyStatus, 
 	}, nil
 }
 
+func (c *Checker) IssueStatus(ctx context.Context, identity store.IssueIdentity) (IssueStatus, error) {
+	if !c.cfg.Enabled || !capActive(c.cfg.PerIssueMaxUSD) {
+		return IssueStatus{}, nil
+	}
+	if !issueIdentityPresent(identity) {
+		return IssueStatus{Active: true, MaxUSD: c.cfg.PerIssueMaxUSD}, nil
+	}
+	if missingSpendStore(c.spend) {
+		return IssueStatus{}, ErrMissingSpendStore
+	}
+
+	issueSpend, err := c.spend.IssueTokenSpend(ctx, identity)
+	if err != nil {
+		return IssueStatus{}, fmt.Errorf("issue token spend: %w", err)
+	}
+	return IssueStatus{
+		Active:          true,
+		CurrentSpendUSD: SpendUSD(issueSpend, c.pricing),
+		MaxUSD:          c.cfg.PerIssueMaxUSD,
+	}, nil
+}
+
 func SpendUSD(spend store.TokenSpend, pricing PricingTable) float64 {
 	total := 0.0
 	for _, row := range spend.ByModel {
@@ -319,8 +347,8 @@ Projected dispatch cost: %s
 Projected issue spend: %s / %s
 Model: %s
 The per-issue budget has no automatic reset.
-This issue will be reconsidered after: %s
-`, currentSpend, projectedCost, projectedSpend, max, model, dueAt))
+This issue is on a hard budget hold and needs an operator decision. Raise or disable the per-issue cap, or explicitly retry the issue after resetting its budget hold.
+`, currentSpend, projectedCost, projectedSpend, max, model))
 	default:
 		return strings.TrimSpace(fmt.Sprintf(`
 Detent refused to dispatch this issue because the budget check failed.

--- a/internal/budget/budget_test.go
+++ b/internal/budget/budget_test.go
@@ -345,6 +345,80 @@ func TestCheckerReportsEnforcedConfig(t *testing.T) {
 	}
 }
 
+func TestCheckerIssueStatus(t *testing.T) {
+	t.Parallel()
+
+	pricing := PricingTable{"gpt-test": {USDPerInputToken: 0.01}}
+	identity := store.IssueIdentity{IssueID: "issue-held", Identifier: "DET-1251"}
+	tests := []struct {
+		name      string
+		cfg       Config
+		spend     *fakeSpendStore
+		want      IssueStatus
+		wantError string
+	}{
+		{
+			name: "active cap reports lifetime issue spend",
+			cfg:  Config{Enabled: true, PerIssueMaxUSD: 2},
+			spend: &fakeSpendStore{issues: map[string]store.TokenSpend{
+				issueKey(identity): {ByModel: []store.ModelTokenSpend{{Model: "gpt-test", InputTokens: 125}}},
+			}},
+			want: IssueStatus{Active: true, CurrentSpendUSD: 1.25, MaxUSD: 2},
+		},
+		{
+			name:  "disabled cap reports inactive",
+			cfg:   Config{Enabled: true},
+			spend: &fakeSpendStore{},
+		},
+		{
+			name:      "spend failure is returned",
+			cfg:       Config{Enabled: true, PerIssueMaxUSD: 2},
+			spend:     &fakeSpendStore{issueErr: errors.New("database unavailable")},
+			wantError: "issue token spend",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := NewChecker(tt.cfg, tt.spend, pricing).IssueStatus(context.Background(), identity)
+			if tt.wantError != "" {
+				if err == nil || !strings.Contains(err.Error(), tt.wantError) {
+					t.Fatalf("IssueStatus() error = %v, want containing %q", err, tt.wantError)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("IssueStatus() error = %v", err)
+			}
+			if got != tt.want {
+				t.Fatalf("IssueStatus() = %#v, want %#v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestPerIssueRefusalCommentDescribesHardHold(t *testing.T) {
+	t.Parallel()
+
+	maxUSD := 5.0
+	comment := (Refusal{
+		Code:              ReasonPerIssueMaxUSD,
+		CurrentSpendUSD:   4.75,
+		ProjectedCostUSD:  1,
+		ProjectedSpendUSD: 5.75,
+		MaxUSD:            &maxUSD,
+		RefusedAt:         time.Date(2026, 7, 12, 12, 0, 0, 0, time.UTC),
+	}).Comment()
+	if !strings.Contains(comment, "hard budget hold") || !strings.Contains(comment, "needs an operator decision") {
+		t.Fatalf("Refusal.Comment() = %q, want hard-hold guidance", comment)
+	}
+	if strings.Contains(comment, "will be reconsidered after") {
+		t.Fatalf("Refusal.Comment() = %q, must not promise automatic reconsideration", comment)
+	}
+}
+
 func TestRefusalCommentUsesEffectiveDueAt(t *testing.T) {
 	t.Parallel()
 

--- a/internal/orchestrator/dispatch.go
+++ b/internal/orchestrator/dispatch.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/digitaldrywood/detent/internal/activity"
+	"github.com/digitaldrywood/detent/internal/budget"
 	"github.com/digitaldrywood/detent/internal/connector"
 	"github.com/digitaldrywood/detent/internal/dispatchpriority"
 	"github.com/digitaldrywood/detent/internal/gate"
@@ -20,7 +21,36 @@ func (o *Orchestrator) dispatchPlanner() dispatchPlanner {
 }
 
 func (o *Orchestrator) pruneBudgetRefusals(ctx context.Context, state *State, now time.Time) {
-	o.dispatchPlanner().pruneBudgetRefusals(state, now, o.currentDailyBudgetStatus(ctx, state, now))
+	o.dispatchPlanner().pruneBudgetRefusals(
+		state,
+		now,
+		o.currentDailyBudgetStatus(ctx, state, now),
+		o.currentIssueBudgetStatuses(ctx, state),
+	)
+}
+
+func (o *Orchestrator) currentIssueBudgetStatuses(ctx context.Context, state *State) map[string]IssueBudgetStatus {
+	if o.issueBudgetStatus == nil {
+		return nil
+	}
+
+	statuses := make(map[string]IssueBudgetStatus)
+	for issueID, refusal := range state.BudgetRefusals {
+		if refusal.Code != string(budget.ReasonPerIssueMaxUSD) {
+			continue
+		}
+		status, known, err := o.issueBudgetStatus.IssueBudgetStatus(ctx, refusal.Issue)
+		if err != nil {
+			if o.logger != nil {
+				o.logger.Warn("per-issue budget hold re-evaluation failed", "issue_id", issueID, "error", err)
+			}
+			continue
+		}
+		if known {
+			statuses[issueID] = status
+		}
+	}
+	return statuses
 }
 
 func (o *Orchestrator) currentDailyBudgetStatus(ctx context.Context, state *State, now time.Time) *DailyBudgetStatus {

--- a/internal/orchestrator/dispatch_planner.go
+++ b/internal/orchestrator/dispatch_planner.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/digitaldrywood/detent/internal/budget"
 	"github.com/digitaldrywood/detent/internal/connector"
 	"github.com/digitaldrywood/detent/internal/gate"
 	"github.com/digitaldrywood/detent/internal/runtimeoutput"
@@ -319,9 +320,18 @@ func (a dispatchAction) decision() DispatchDecision {
 	}
 }
 
-func (p dispatchPlanner) pruneBudgetRefusals(state *State, now time.Time, dailyStatus *DailyBudgetStatus) {
+func (p dispatchPlanner) pruneBudgetRefusals(
+	state *State,
+	now time.Time,
+	dailyStatus *DailyBudgetStatus,
+	issueStatuses map[string]IssueBudgetStatus,
+) {
 	for issueID, refusal := range state.BudgetRefusals {
-		if !p.budgetRefusalActive(refusal, now, dailyStatus) {
+		var issueStatus *IssueBudgetStatus
+		if status, ok := issueStatuses[issueID]; ok {
+			issueStatus = &status
+		}
+		if !p.budgetRefusalActive(refusal, now, dailyStatus, issueStatus) {
 			delete(state.BudgetRefusals, issueID)
 		}
 	}
@@ -333,12 +343,23 @@ func (p dispatchPlanner) budgetCooldownActive(state *State, issueID string, now 
 		return false
 	}
 
-	return p.budgetRefusalActive(refusal, now, nil)
+	return p.budgetRefusalActive(refusal, now, nil, nil)
 }
 
-func (p dispatchPlanner) budgetRefusalActive(refusal BudgetRefusal, now time.Time, dailyStatus *DailyBudgetStatus) bool {
+func (p dispatchPlanner) budgetRefusalActive(
+	refusal BudgetRefusal,
+	now time.Time,
+	dailyStatus *DailyBudgetStatus,
+	issueStatus *IssueBudgetStatus,
+) bool {
+	if refusal.Code == string(budget.ReasonPerIssueMaxUSD) {
+		if issueStatus == nil {
+			return true
+		}
+		return issueStatus.Active && issueStatus.CurrentSpendUSD+refusal.ProjectedCostUSD > issueStatus.MaxUSD
+	}
 	if refusal.ResetAt != nil && now.Before(*refusal.ResetAt) {
-		if refusal.Code == "per_day_max_usd" && dailyStatus != nil {
+		if refusal.Code == string(budget.ReasonPerDayMaxUSD) && dailyStatus != nil {
 			if !dailyStatus.Active {
 				return false
 			}

--- a/internal/orchestrator/dispatch_planner.go
+++ b/internal/orchestrator/dispatch_planner.go
@@ -337,6 +337,21 @@ func (p dispatchPlanner) pruneBudgetRefusals(
 	}
 }
 
+func (p dispatchPlanner) pruneInactiveIssueBudgetRefusals(state *State, candidates []connector.Issue) {
+	active := make(map[string]struct{}, len(candidates))
+	for _, issue := range candidates {
+		active[issue.ID] = struct{}{}
+	}
+	for issueID, refusal := range state.BudgetRefusals {
+		if refusal.Code != string(budget.ReasonPerIssueMaxUSD) {
+			continue
+		}
+		if _, ok := active[issueID]; !ok {
+			delete(state.BudgetRefusals, issueID)
+		}
+	}
+}
+
 func (p dispatchPlanner) budgetCooldownActive(state *State, issueID string, now time.Time) bool {
 	refusal, ok := state.BudgetRefusals[issueID]
 	if !ok {

--- a/internal/orchestrator/dispatch_test.go
+++ b/internal/orchestrator/dispatch_test.go
@@ -444,6 +444,8 @@ func TestPruneBudgetRefusalsReevaluatesDailyCap(t *testing.T) {
 
 			cfg := normalizeConfig(Config{BudgetRefusalCooldown: time.Hour})
 			state := newState(cfg)
+			issue := dispatchTestIssue("issue", "Todo")
+			tt.refusal.Issue = issue
 			state.BudgetRefusals["issue"] = tt.refusal
 			orch := Orchestrator{
 				cfg: cfg,
@@ -458,18 +460,53 @@ func TestPruneBudgetRefusalsReevaluatesDailyCap(t *testing.T) {
 				},
 			}
 
-			orch.dispatchTickIssues(
-				context.Background(),
-				&state,
-				tickFetchedIssues{statusOK: true},
-				tickTransitionRefresh{blockedRefreshOK: true},
-				tickPreviousState{},
-				nil,
-				now,
-			)
+			orch.dispatchPlanner().pruneInactiveIssueBudgetRefusals(&state, []connector.Issue{issue})
+			orch.pruneBudgetRefusals(context.Background(), &state, now)
 			_, gotActive := state.BudgetRefusals["issue"]
 			if gotActive != tt.wantActive {
 				t.Fatalf("budget refusal active = %t, want %t", gotActive, tt.wantActive)
+			}
+		})
+	}
+}
+
+func TestPruneInactiveIssueBudgetRefusals(t *testing.T) {
+	t.Parallel()
+
+	issue := dispatchTestIssue("issue-held", "Todo")
+	tests := []struct {
+		name       string
+		code       string
+		candidates []connector.Issue
+		wantHeld   bool
+	}{
+		{
+			name:       "active candidate keeps per issue hold",
+			code:       string(budget.ReasonPerIssueMaxUSD),
+			candidates: []connector.Issue{issue},
+			wantHeld:   true,
+		},
+		{
+			name: "missing candidate clears per issue hold",
+			code: string(budget.ReasonPerIssueMaxUSD),
+		},
+		{
+			name:     "missing candidate keeps daily cooldown",
+			code:     string(budget.ReasonPerDayMaxUSD),
+			wantHeld: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			state := newState(normalizeConfig(Config{}))
+			state.BudgetRefusals[issue.ID] = BudgetRefusal{Issue: issue, Code: tt.code}
+			newDispatchPlanner(Config{}).pruneInactiveIssueBudgetRefusals(&state, tt.candidates)
+			_, gotHeld := state.BudgetRefusals[issue.ID]
+			if gotHeld != tt.wantHeld {
+				t.Fatalf("budget refusal held = %t, want %t", gotHeld, tt.wantHeld)
 			}
 		})
 	}

--- a/internal/orchestrator/dispatch_test.go
+++ b/internal/orchestrator/dispatch_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/digitaldrywood/detent/internal/agentidentity"
+	"github.com/digitaldrywood/detent/internal/budget"
 	workflowconfig "github.com/digitaldrywood/detent/internal/config"
 	"github.com/digitaldrywood/detent/internal/connector"
 	"github.com/digitaldrywood/detent/internal/connector/memory"
@@ -333,11 +334,14 @@ func TestPruneBudgetRefusalsReevaluatesDailyCap(t *testing.T) {
 	now := time.Date(2026, 7, 11, 15, 0, 0, 0, time.UTC)
 	resetAt := time.Date(2026, 7, 12, 0, 0, 0, 0, time.UTC)
 	tests := []struct {
-		name       string
-		refusal    BudgetRefusal
-		status     DailyBudgetStatus
-		statusErr  error
-		wantActive bool
+		name           string
+		refusal        BudgetRefusal
+		dailyStatus    DailyBudgetStatus
+		dailyStatusErr error
+		issueStatus    IssueBudgetStatus
+		issueKnown     bool
+		issueStatusErr error
+		wantActive     bool
 	}{
 		{
 			name: "cap raise clears resolved daily refusal",
@@ -347,7 +351,7 @@ func TestPruneBudgetRefusalsReevaluatesDailyCap(t *testing.T) {
 				ResetAt:          &resetAt,
 				RefusedAt:        now,
 			},
-			status: DailyBudgetStatus{Active: true, CurrentSpendUSD: 100, MaxUSD: 250},
+			dailyStatus: DailyBudgetStatus{Active: true, CurrentSpendUSD: 100, MaxUSD: 250},
 		},
 		{
 			name: "cap raise keeps daily refusal when projected spend remains over cap",
@@ -357,8 +361,8 @@ func TestPruneBudgetRefusalsReevaluatesDailyCap(t *testing.T) {
 				ResetAt:          &resetAt,
 				RefusedAt:        now,
 			},
-			status:     DailyBudgetStatus{Active: true, CurrentSpendUSD: 245, MaxUSD: 250},
-			wantActive: true,
+			dailyStatus: DailyBudgetStatus{Active: true, CurrentSpendUSD: 245, MaxUSD: 250},
+			wantActive:  true,
 		},
 		{
 			name: "unchanged cap keeps daily refusal until midnight",
@@ -368,8 +372,8 @@ func TestPruneBudgetRefusalsReevaluatesDailyCap(t *testing.T) {
 				ResetAt:          &resetAt,
 				RefusedAt:        now,
 			},
-			status:     DailyBudgetStatus{Active: true, CurrentSpendUSD: 100, MaxUSD: 100},
-			wantActive: true,
+			dailyStatus: DailyBudgetStatus{Active: true, CurrentSpendUSD: 100, MaxUSD: 100},
+			wantActive:  true,
 		},
 		{
 			name: "disabled daily cap clears daily refusal",
@@ -388,17 +392,49 @@ func TestPruneBudgetRefusalsReevaluatesDailyCap(t *testing.T) {
 				ResetAt:          &resetAt,
 				RefusedAt:        now,
 			},
-			statusErr:  errors.New("lookup failed"),
-			wantActive: true,
+			dailyStatusErr: errors.New("lookup failed"),
+			wantActive:     true,
 		},
 		{
-			name: "per issue refusal keeps cooldown behavior",
+			name: "per issue hold persists across cooldown boundaries",
 			refusal: BudgetRefusal{
-				Code:      "per_issue_max_usd",
-				RefusedAt: now.Add(-30 * time.Minute),
+				Code:             "per_issue_max_usd",
+				ProjectedCostUSD: 10,
+				RefusedAt:        now.Add(-48 * time.Hour),
 			},
-			status:     DailyBudgetStatus{Active: true, CurrentSpendUSD: 0, MaxUSD: 1000},
-			wantActive: true,
+			issueStatus: IssueBudgetStatus{Active: true, CurrentSpendUSD: 95, MaxUSD: 100},
+			issueKnown:  true,
+			wantActive:  true,
+		},
+		{
+			name: "per issue cap raise clears resolved hold",
+			refusal: BudgetRefusal{
+				Code:             "per_issue_max_usd",
+				ProjectedCostUSD: 10,
+				RefusedAt:        now.Add(-48 * time.Hour),
+			},
+			issueStatus: IssueBudgetStatus{Active: true, CurrentSpendUSD: 95, MaxUSD: 125},
+			issueKnown:  true,
+		},
+		{
+			name: "disabled per issue cap clears hold",
+			refusal: BudgetRefusal{
+				Code:             "per_issue_max_usd",
+				ProjectedCostUSD: 10,
+				RefusedAt:        now.Add(-48 * time.Hour),
+			},
+			issueKnown: true,
+		},
+		{
+			name: "per issue status failure preserves hold",
+			refusal: BudgetRefusal{
+				Code:             "per_issue_max_usd",
+				ProjectedCostUSD: 10,
+				RefusedAt:        now.Add(-48 * time.Hour),
+			},
+			issueKnown:     true,
+			issueStatusErr: errors.New("lookup failed"),
+			wantActive:     true,
 		},
 	}
 
@@ -412,8 +448,13 @@ func TestPruneBudgetRefusalsReevaluatesDailyCap(t *testing.T) {
 			orch := Orchestrator{
 				cfg: cfg,
 				dailyBudgetStatus: fakeDailyBudgetStatusProvider{
-					status: tt.status,
-					err:    tt.statusErr,
+					status: tt.dailyStatus,
+					err:    tt.dailyStatusErr,
+				},
+				issueBudgetStatus: fakeIssueBudgetStatusProvider{
+					status: tt.issueStatus,
+					known:  tt.issueKnown,
+					err:    tt.issueStatusErr,
 				},
 			}
 
@@ -437,6 +478,16 @@ func TestPruneBudgetRefusalsReevaluatesDailyCap(t *testing.T) {
 type fakeDailyBudgetStatusProvider struct {
 	status DailyBudgetStatus
 	err    error
+}
+
+type fakeIssueBudgetStatusProvider struct {
+	status IssueBudgetStatus
+	known  bool
+	err    error
+}
+
+func (p fakeIssueBudgetStatusProvider) IssueBudgetStatus(context.Context, connector.Issue) (IssueBudgetStatus, bool, error) {
+	return p.status, p.known, p.err
 }
 
 func (p fakeDailyBudgetStatusProvider) DailyBudgetStatus(context.Context, time.Time) (DailyBudgetStatus, bool, error) {
@@ -731,6 +782,57 @@ func TestHandleRunResultRecordsBudgetRefusalAndComment(t *testing.T) {
 	}
 	if commentConnector.comments[0].issueID != issue.ID || !strings.Contains(commentConnector.comments[0].body, "projected dispatch would exceed the daily budget") {
 		t.Fatalf("comment = %#v, want budget refusal comment", commentConnector.comments[0])
+	}
+}
+
+func TestHandleRunResultCreatesPerIssueHardHoldWithoutRetry(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 7, 12, 12, 0, 0, 0, time.UTC)
+	cfg := normalizeConfig(Config{
+		MaxConcurrentAgents:    1,
+		ActiveStates:           []string{"Todo"},
+		TerminalStates:         []string{"Done"},
+		BudgetRefusalCooldown:  time.Hour,
+		ContinuationRetryDelay: time.Second,
+	})
+	orch := Orchestrator{cfg: cfg, connector: &budgetRefusalCommentConnector{}}
+	state := newState(cfg)
+	issue := dispatchTestIssue("issue-hard-budget-hold", "Todo")
+	state.Running[issue.ID] = Running{Issue: issue, StartedAt: now.Add(-time.Minute), WorkerHost: "local"}
+	state.Claimed[issue.ID] = Claimed{Issue: issue, ClaimedAt: now.Add(-time.Minute)}
+	maxUSD := 5.0
+
+	orch.handleRunResult(context.Background(), &state, runpkg.Completion{
+		IssueID:     issue.ID,
+		CompletedAt: now,
+		Result: runpkg.RunResult{
+			FinalState: runpkg.FinalStateCompleted,
+			BudgetRefusal: &runpkg.BudgetRefusal{
+				Code:             string(budget.ReasonPerIssueMaxUSD),
+				Message:          "per-issue budget exceeded",
+				Comment:          "hard budget hold",
+				CurrentSpendUSD:  4.75,
+				ProjectedCostUSD: 1,
+				MaxUSD:           &maxUSD,
+				RefusedAt:        now,
+			},
+		},
+	})
+
+	if _, ok := state.BudgetRefusals[issue.ID]; !ok {
+		t.Fatal("BudgetRefusals missing per-issue hard hold")
+	}
+	if _, ok := state.Retry[issue.ID]; ok {
+		t.Fatal("Retry contains per-issue hard hold, want no scheduled retry")
+	}
+	if _, ok := state.Claimed[issue.ID]; ok {
+		t.Fatal("Claimed contains per-issue hard hold, want claim released")
+	}
+	for _, boundary := range []time.Duration{time.Hour, 2 * time.Hour, 24 * time.Hour} {
+		if orch.dispatchable(issue, &state, now.Add(boundary)) {
+			t.Fatalf("dispatchable after %s = true, want hard hold", boundary)
+		}
 	}
 }
 

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -165,6 +165,7 @@ type Orchestrator struct {
 	capacityController      runpkg.CapacityController
 	validatorCapacity       runpkg.ValidatorCapacityController
 	dailyBudgetStatus       runpkg.DailyBudgetStatusProvider
+	issueBudgetStatus       runpkg.IssueBudgetStatusProvider
 	now                     func() time.Time
 	retrospector            Retrospector
 	stateRequests           chan stateRequest
@@ -249,6 +250,10 @@ func New(cfg Config, deps Dependencies) (*Orchestrator, error) {
 	if candidate, ok := runner.(runpkg.DailyBudgetStatusProvider); ok {
 		dailyBudgetStatus = candidate
 	}
+	var issueBudgetStatus runpkg.IssueBudgetStatusProvider
+	if candidate, ok := runner.(runpkg.IssueBudgetStatusProvider); ok {
+		issueBudgetStatus = candidate
+	}
 
 	logger := deps.Logger
 	if logger == nil {
@@ -328,6 +333,7 @@ func New(cfg Config, deps Dependencies) (*Orchestrator, error) {
 		capacityController:      capacityController,
 		validatorCapacity:       validatorCapacity,
 		dailyBudgetStatus:       dailyBudgetStatus,
+		issueBudgetStatus:       issueBudgetStatus,
 		now:                     now,
 		stateRequests:           make(chan stateRequest),
 		drainRequests:           make(chan drainRequest),

--- a/internal/orchestrator/run_completion.go
+++ b/internal/orchestrator/run_completion.go
@@ -317,6 +317,15 @@ func (o *Orchestrator) handleRunResult(ctx context.Context, state *State, event 
 			return
 		}
 	}
+	if event.Result.BudgetRefusal != nil && event.Result.BudgetRefusal.Code == string(budget.ReasonPerIssueMaxUSD) {
+		if err := o.abandonClaim(ctx, event.IssueID); err != nil && o.logger != nil {
+			o.logger.Warn("per-issue budget hold claim release failed", "issue_id", event.IssueID, "error", err)
+		}
+		delete(state.Claimed, event.IssueID)
+		delete(state.Retry, event.IssueID)
+		delete(state.PriorAttempts, event.IssueID)
+		return
+	}
 	o.scheduleRetry(state, running.Issue, 1, event.CompletedAt, "", true, running.WorkerHost)
 }
 

--- a/internal/orchestrator/runner.go
+++ b/internal/orchestrator/runner.go
@@ -26,6 +26,10 @@ type DailyBudgetStatus = runner.DailyBudgetStatus
 
 type DailyBudgetStatusProvider = runner.DailyBudgetStatusProvider
 
+type IssueBudgetStatus = runner.IssueBudgetStatus
+
+type IssueBudgetStatusProvider = runner.IssueBudgetStatusProvider
+
 type DiffStats = runner.DiffStats
 
 type TokenTotals = runner.TokenTotals

--- a/internal/orchestrator/shadow.go
+++ b/internal/orchestrator/shadow.go
@@ -33,7 +33,7 @@ func PlanDispatch(cfg Config, state State, candidates []connector.Issue, now tim
 	plannedState := state.clone()
 	plannedState.ensureInitialized(planner.cfg)
 	plannedCandidates := cloneIssues(candidates)
-	planner.pruneBudgetRefusals(&plannedState, now, nil)
+	planner.pruneBudgetRefusals(&plannedState, now, nil, nil)
 	planner.trackBlockedCandidates(&plannedState, plannedCandidates, now)
 
 	return planner.plan(&plannedState, plannedCandidates, now, dispatchPlanHooks{})

--- a/internal/orchestrator/snapshot.go
+++ b/internal/orchestrator/snapshot.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/digitaldrywood/detent/internal/budget"
 	"github.com/digitaldrywood/detent/internal/connector"
 	releasepkg "github.com/digitaldrywood/detent/internal/release"
 	"github.com/digitaldrywood/detent/internal/runtimeoutput"
@@ -466,6 +467,7 @@ func budgetRefusalSnapshots(refusals map[string]BudgetRefusal) []telemetry.Budge
 			CurrentSpendUSD:  entry.CurrentSpendUSD,
 			ProjectedCostUSD: entry.ProjectedCostUSD,
 			RefusedAt:        entry.RefusedAt,
+			HardHold:         entry.Code == string(budget.ReasonPerIssueMaxUSD),
 		}
 		if entry.MaxUSD != nil {
 			maxUSD := *entry.MaxUSD

--- a/internal/orchestrator/snapshot_test.go
+++ b/internal/orchestrator/snapshot_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/digitaldrywood/detent/internal/agentidentity"
 	"github.com/digitaldrywood/detent/internal/backendcapacity"
+	"github.com/digitaldrywood/detent/internal/budget"
 	"github.com/digitaldrywood/detent/internal/connector"
 	"github.com/digitaldrywood/detent/internal/gate"
 	"github.com/digitaldrywood/detent/internal/selector"
@@ -1180,7 +1181,7 @@ func TestStateSnapshotBudgetRefusals(t *testing.T) {
 	state := newState(normalizeConfig(Config{}))
 	state.BudgetRefusals["i-9"] = BudgetRefusal{
 		Issue:            connector.Issue{ID: "i-9", Identifier: "ISS-9"},
-		Code:             "per_issue",
+		Code:             string(budget.ReasonPerIssueMaxUSD),
 		Message:          "too expensive",
 		CurrentSpendUSD:  3,
 		ProjectedCostUSD: 9,
@@ -1194,8 +1195,11 @@ func TestStateSnapshotBudgetRefusals(t *testing.T) {
 		t.Fatalf("Budget.Refusals len = %d, want 1", len(snapshot.Budget.Refusals))
 	}
 	refusal := snapshot.Budget.Refusals[0]
-	if refusal.IssueID != "i-9" || refusal.Identifier != "ISS-9" || refusal.Code != "per_issue" {
+	if refusal.IssueID != "i-9" || refusal.Identifier != "ISS-9" || refusal.Code != string(budget.ReasonPerIssueMaxUSD) {
 		t.Fatalf("Refusals[0] = %#v", refusal)
+	}
+	if !refusal.HardHold {
+		t.Fatal("Refusals[0].HardHold = false, want true")
 	}
 	if refusal.MaxUSD == nil || *refusal.MaxUSD != maxUSD {
 		t.Fatalf("Refusals[0].MaxUSD = %v, want %v", refusal.MaxUSD, maxUSD)

--- a/internal/orchestrator/tick.go
+++ b/internal/orchestrator/tick.go
@@ -773,6 +773,7 @@ func (o *Orchestrator) dispatchTickIssues(
 ) {
 	issues := filterCompletedEpicCandidates(fetched.candidates, completedEpics)
 	planner := o.dispatchPlanner()
+	planner.pruneInactiveIssueBudgetRefusals(state, fetched.candidates)
 	o.pruneBudgetRefusals(ctx, state, now)
 	planner.trackBlockedCandidates(state, issues, now)
 	candidateBlockedStatusIssues := issuesInStates(fetched.candidates, []string{blockedStatusState})

--- a/internal/orchestrator/work_attempt_recovery_test.go
+++ b/internal/orchestrator/work_attempt_recovery_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/digitaldrywood/detent/internal/budget"
 	"github.com/digitaldrywood/detent/internal/connector"
 	runpkg "github.com/digitaldrywood/detent/internal/runner"
 	"github.com/digitaldrywood/detent/internal/scheduler"
@@ -129,6 +130,7 @@ func TestHandleWorkAttemptRecoveryQueuesResumeRetryWhenEligible(t *testing.T) {
 	}
 	orch := newWorkAttemptRecoveryOrchestrator(t, runtimeStore, nil)
 	state := newState(orch.cfg)
+	state.BudgetRefusals[issue.ID] = BudgetRefusal{Issue: issue, Code: string(budget.ReasonPerIssueMaxUSD), RefusedAt: now.Add(-time.Hour)}
 
 	response, err := orch.handleWorkAttemptRecovery(ctx, &state, WorkAttemptRecoveryRequest{
 		ProjectID: "detent",
@@ -154,6 +156,9 @@ func TestHandleWorkAttemptRecoveryQueuesResumeRetryWhenEligible(t *testing.T) {
 	}
 	if retry.ResumeState.DetentSessionID != sessionID || retry.ResumeState.ProviderSessionID != "session-979" {
 		t.Fatalf("retry resume state = %#v, want selected session", retry.ResumeState)
+	}
+	if _, ok := state.BudgetRefusals[issue.ID]; ok {
+		t.Fatalf("state.BudgetRefusals still contains %q after explicit operator retry", issue.ID)
 	}
 	event := recoveryTimelineEvent(t, ctx, runtimeStore, issue.ID, WorkAttemptRecoveryRetryResume)
 	if event.Status != "succeeded" || !strings.Contains(event.MetadataJSON, `"resume_eligible":true`) {

--- a/internal/runner/agent.go
+++ b/internal/runner/agent.go
@@ -252,6 +252,34 @@ func (r *Runner) DailyBudgetStatus(ctx context.Context, now time.Time) (DailyBud
 	}, true, nil
 }
 
+func (r *Runner) IssueBudgetStatus(ctx context.Context, issue connector.Issue) (IssueBudgetStatus, bool, error) {
+	_, _, checker, _ := r.runtimeSnapshot()
+	provider, ok := checker.(interface {
+		IssueStatus(context.Context, store.IssueIdentity) (budget.IssueStatus, error)
+	})
+	if !ok {
+		enforced, known := r.EnforcedBudget()
+		if known && (!enforced.Enabled || enforced.PerIssueMaxUSD <= 0) {
+			return IssueBudgetStatus{}, true, nil
+		}
+		return IssueBudgetStatus{}, false, nil
+	}
+
+	status, err := provider.IssueStatus(ctx, store.IssueIdentity{
+		IssueID:    issue.ID,
+		Identifier: issue.Identifier,
+		IssueURL:   issue.URL,
+	})
+	if err != nil {
+		return IssueBudgetStatus{}, true, err
+	}
+	return IssueBudgetStatus{
+		Active:          status.Active,
+		CurrentSpendUSD: status.CurrentSpendUSD,
+		MaxUSD:          status.MaxUSD,
+	}, true, nil
+}
+
 func enforcedBudgetConfig(requested config.Budget, checker BudgetChecker) (config.Budget, bool) {
 	if checker == nil {
 		if requested.Enabled {

--- a/internal/runner/runner_test.go
+++ b/internal/runner/runner_test.go
@@ -2915,6 +2915,57 @@ func TestRunnerUpdateWorkflowAppliesReloadedDailyBudget(t *testing.T) {
 	}
 }
 
+func TestRunnerUpdateWorkflowReportsReloadedIssueBudget(t *testing.T) {
+	t.Parallel()
+
+	pricing := budget.PricingTable{"gpt-test": {USDPerInputToken: 0.01}}
+	issue := connector.Issue{ID: "issue-held", Identifier: "digitaldrywood/detent#1251"}
+	spend := &fakeRunnerBudgetSpendStore{issue: store.TokenSpend{
+		ByModel: []store.ModelTokenSpend{{Model: "gpt-test", InputTokens: 125}},
+	}}
+	workflowCfg := config.Config{}
+	workflowCfg.Budget = config.Budget{Enabled: true, PerIssueMaxUSD: 1}
+	runner, err := NewRunner(Dependencies{
+		Workflow:     config.Workflow{Config: workflowCfg},
+		Workspace:    &fakeWorkspaceBackend{info: workspace.Info{Path: t.TempDir(), Key: "budget-reload", Branch: "detent/budget-reload"}},
+		AgentBackend: &fakeCodexClient{},
+		BudgetGuardBuilder: func(cfg config.Budget) (BudgetChecker, DispatchEstimator, error) {
+			if !cfg.Enabled {
+				return nil, nil, nil
+			}
+			return budget.NewChecker(budget.Config{
+				Enabled:        cfg.Enabled,
+				PerIssueMaxUSD: cfg.PerIssueMaxUSD,
+			}, spend, pricing), nil, nil
+		},
+	})
+	if err != nil {
+		t.Fatalf("NewRunner() error = %v", err)
+	}
+
+	assertStatus := func(want IssueBudgetStatus) {
+		t.Helper()
+		got, known, err := runner.IssueBudgetStatus(context.Background(), issue)
+		if err != nil {
+			t.Fatalf("IssueBudgetStatus() error = %v", err)
+		}
+		if !known || got != want {
+			t.Fatalf("IssueBudgetStatus() = %#v, %t, want %#v, true", got, known, want)
+		}
+	}
+
+	assertStatus(IssueBudgetStatus{Active: true, CurrentSpendUSD: 1.25, MaxUSD: 1})
+	workflowCfg.Budget.PerIssueMaxUSD = 2
+	runner.UpdateWorkflow(config.Workflow{Config: workflowCfg})
+	assertStatus(IssueBudgetStatus{Active: true, CurrentSpendUSD: 1.25, MaxUSD: 2})
+	workflowCfg.Budget.PerIssueMaxUSD = 0
+	runner.UpdateWorkflow(config.Workflow{Config: workflowCfg})
+	assertStatus(IssueBudgetStatus{})
+	workflowCfg.Budget.Enabled = false
+	runner.UpdateWorkflow(config.Workflow{Config: workflowCfg})
+	assertStatus(IssueBudgetStatus{})
+}
+
 func TestRunnerRunUsesSingleConfiguredBackendDefaultRoute(t *testing.T) {
 	t.Parallel()
 

--- a/internal/runner/types.go
+++ b/internal/runner/types.go
@@ -51,7 +51,17 @@ type DailyBudgetStatusProvider interface {
 	DailyBudgetStatus(context.Context, time.Time) (DailyBudgetStatus, bool, error)
 }
 
+type IssueBudgetStatusProvider interface {
+	IssueBudgetStatus(context.Context, connector.Issue) (IssueBudgetStatus, bool, error)
+}
+
 type DailyBudgetStatus struct {
+	Active          bool
+	CurrentSpendUSD float64
+	MaxUSD          float64
+}
+
+type IssueBudgetStatus struct {
 	Active          bool
 	CurrentSpendUSD float64
 	MaxUSD          float64

--- a/internal/telemetry/snapshot.go
+++ b/internal/telemetry/snapshot.go
@@ -515,6 +515,7 @@ type BudgetRefusal struct {
 	MaxUSD           *float64   `json:"max_usd"`
 	ResetAt          *time.Time `json:"reset_at,omitempty"`
 	RefusedAt        time.Time  `json:"refused_at"`
+	HardHold         bool       `json:"hard_hold"`
 }
 
 type RateLimits struct {

--- a/internal/web/demofixtures/fixtures.go
+++ b/internal/web/demofixtures/fixtures.go
@@ -389,6 +389,7 @@ func demoBudgetRefusalsSnapshot() telemetry.Snapshot {
 	snapshot.Budget.PerDayMaxUSD = &capValue
 	snapshot.Budget.Refusals = []telemetry.BudgetRefusal{
 		{IssueID: "demo-refusal-1", Identifier: "digitaldrywood/billing-api#5310", Code: "daily_cap_exceeded", Message: "Projected spend would exceed the daily cap.", CurrentSpendUSD: 41.15, ProjectedCostUSD: 6.2, MaxUSD: &capValue, RefusedAt: now.Add(-18 * time.Minute), ResetAt: demoTimePtr(now.Truncate(24 * time.Hour).Add(24 * time.Hour))},
+		{IssueID: "demo-refusal-2", Identifier: "digitaldrywood/billing-api#5311", Code: "per_issue_max_usd", Message: "Projected spend would exceed the per-issue cap.", CurrentSpendUSD: 41.15, ProjectedCostUSD: 6.2, MaxUSD: &capValue, RefusedAt: now.Add(-35 * time.Minute), HardHold: true},
 	}
 	return snapshot
 }

--- a/internal/web/templates/dashboard.templ
+++ b/internal/web/templates/dashboard.templ
@@ -4075,6 +4075,23 @@ templ budgetCard(snapshot telemetry.Snapshot) {
 						<strong class="font-mono font-medium text-text">{ optionalUSD(snapshot.Budget.PerIssueMaxUSD) }</strong>
 					</div>
 				</div>
+				if len(snapshot.Budget.Refusals) > 0 {
+					<div class="grid gap-2 border-t border-line pt-3" aria-label="Budget holds">
+						<div class="flex items-center justify-between gap-4">
+							@plainInlineLabel("Budget holds", "font-medium text-sec")
+							<span class="font-mono text-xs text-sec">{ formatInt(int64(len(snapshot.Budget.Refusals))) }</span>
+						</div>
+						for _, refusal := range snapshot.Budget.Refusals {
+							<div class="grid gap-1 rounded-md border border-line bg-elev px-3 py-2">
+								<div class="flex items-center justify-between gap-3">
+									<strong class="min-w-0 truncate font-mono text-xs font-medium text-text">{ budgetRefusalLabel(refusal) }</strong>
+									<span class={ budgetRefusalBadgeClass(refusal) }>{ budgetRefusalDisposition(refusal) }</span>
+								</div>
+								<p class="text-xs text-sec">{ budgetRefusalDetail(refusal) }</p>
+							</div>
+						}
+					</div>
+				}
 			</div>
 		}
 	</section>

--- a/internal/web/templates/dashboard_data.go
+++ b/internal/web/templates/dashboard_data.go
@@ -5762,6 +5762,37 @@ func budgetCardClass(budget telemetry.Budget) string {
 	return "dashboard-panel min-w-0 rounded-md border border-line bg-surface p-4 shadow-sm sm:p-5"
 }
 
+func budgetRefusalLabel(refusal telemetry.BudgetRefusal) string {
+	if label := strings.TrimSpace(refusal.Identifier); label != "" {
+		return label
+	}
+	return strings.TrimSpace(refusal.IssueID)
+}
+
+func budgetRefusalDisposition(refusal telemetry.BudgetRefusal) string {
+	if refusal.HardHold {
+		return "Hard hold"
+	}
+	return "Temporary cooldown"
+}
+
+func budgetRefusalBadgeClass(refusal telemetry.BudgetRefusal) string {
+	if refusal.HardHold {
+		return "shrink-0 rounded-full bg-danger/15 px-2 py-1 text-xs font-medium text-danger"
+	}
+	return "shrink-0 rounded-full bg-warn/15 px-2 py-1 text-xs font-medium text-warn"
+}
+
+func budgetRefusalDetail(refusal telemetry.BudgetRefusal) string {
+	if refusal.HardHold {
+		return "Needs an operator decision; it will not retry automatically."
+	}
+	if refusal.ResetAt != nil {
+		return "Retries automatically after " + localTimeToken(*refusal.ResetAt, LocalDateTimeSeconds) + "."
+	}
+	return "Retries automatically after its cooldown."
+}
+
 func budgetSpendTodayLabel(budget telemetry.Budget) string {
 	if strings.TrimSpace(budget.DegradedReason) != "" && budget.CurrentSpendUSD <= 0 && len(budget.SpendPoints) == 0 {
 		return "unavailable / " + budgetDailyCapLabel(budget)

--- a/internal/web/templates/dashboard_templ.go
+++ b/internal/web/templates/dashboard_templ.go
@@ -14253,12 +14253,114 @@ func budgetCard(snapshot telemetry.Snapshot) templ.Component {
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1033, "</strong></div></div></div>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1033, "</strong></div></div>")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			if len(snapshot.Budget.Refusals) > 0 {
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1034, "<div class=\"grid gap-2 border-t border-line pt-3\" aria-label=\"Budget holds\"><div class=\"flex items-center justify-between gap-4\">")
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+				templ_7745c5c3_Err = plainInlineLabel("Budget holds", "font-medium text-sec").Render(ctx, templ_7745c5c3_Buffer)
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1035, "<span class=\"font-mono text-xs text-sec\">")
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+				var templ_7745c5c3_Var687 string
+				templ_7745c5c3_Var687, templ_7745c5c3_Err = templ.JoinStringErrs(formatInt(int64(len(snapshot.Budget.Refusals))))
+				if templ_7745c5c3_Err != nil {
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/dashboard.templ`, Line: 4082, Col: 97}
+				}
+				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var687))
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1036, "</span></div>")
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+				for _, refusal := range snapshot.Budget.Refusals {
+					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1037, "<div class=\"grid gap-1 rounded-md border border-line bg-elev px-3 py-2\"><div class=\"flex items-center justify-between gap-3\"><strong class=\"min-w-0 truncate font-mono text-xs font-medium text-text\">")
+					if templ_7745c5c3_Err != nil {
+						return templ_7745c5c3_Err
+					}
+					var templ_7745c5c3_Var688 string
+					templ_7745c5c3_Var688, templ_7745c5c3_Err = templ.JoinStringErrs(budgetRefusalLabel(refusal))
+					if templ_7745c5c3_Err != nil {
+						return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/dashboard.templ`, Line: 4087, Col: 111}
+					}
+					_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var688))
+					if templ_7745c5c3_Err != nil {
+						return templ_7745c5c3_Err
+					}
+					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1038, "</strong> ")
+					if templ_7745c5c3_Err != nil {
+						return templ_7745c5c3_Err
+					}
+					var templ_7745c5c3_Var689 = []any{budgetRefusalBadgeClass(refusal)}
+					templ_7745c5c3_Err = templ.RenderCSSItems(ctx, templ_7745c5c3_Buffer, templ_7745c5c3_Var689...)
+					if templ_7745c5c3_Err != nil {
+						return templ_7745c5c3_Err
+					}
+					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1039, "<span class=\"")
+					if templ_7745c5c3_Err != nil {
+						return templ_7745c5c3_Err
+					}
+					var templ_7745c5c3_Var690 string
+					templ_7745c5c3_Var690, templ_7745c5c3_Err = templ.JoinStringErrs(templ.CSSClasses(templ_7745c5c3_Var689).String())
+					if templ_7745c5c3_Err != nil {
+						return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/dashboard.templ`, Line: 1, Col: 0}
+					}
+					_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var690))
+					if templ_7745c5c3_Err != nil {
+						return templ_7745c5c3_Err
+					}
+					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1040, "\">")
+					if templ_7745c5c3_Err != nil {
+						return templ_7745c5c3_Err
+					}
+					var templ_7745c5c3_Var691 string
+					templ_7745c5c3_Var691, templ_7745c5c3_Err = templ.JoinStringErrs(budgetRefusalDisposition(refusal))
+					if templ_7745c5c3_Err != nil {
+						return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/dashboard.templ`, Line: 4088, Col: 93}
+					}
+					_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var691))
+					if templ_7745c5c3_Err != nil {
+						return templ_7745c5c3_Err
+					}
+					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1041, "</span></div><p class=\"text-xs text-sec\">")
+					if templ_7745c5c3_Err != nil {
+						return templ_7745c5c3_Err
+					}
+					var templ_7745c5c3_Var692 string
+					templ_7745c5c3_Var692, templ_7745c5c3_Err = templ.JoinStringErrs(budgetRefusalDetail(refusal))
+					if templ_7745c5c3_Err != nil {
+						return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/dashboard.templ`, Line: 4090, Col: 66}
+					}
+					_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var692))
+					if templ_7745c5c3_Err != nil {
+						return templ_7745c5c3_Err
+					}
+					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1042, "</p></div>")
+					if templ_7745c5c3_Err != nil {
+						return templ_7745c5c3_Err
+					}
+				}
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1043, "</div>")
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1044, "</div>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1034, "</section>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1045, "</section>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -14282,12 +14384,12 @@ func budgetDisabledNote() templ.Component {
 			}()
 		}
 		ctx = templ.InitializeContext(ctx)
-		templ_7745c5c3_Var687 := templ.GetChildren(ctx)
-		if templ_7745c5c3_Var687 == nil {
-			templ_7745c5c3_Var687 = templ.NopComponent
+		templ_7745c5c3_Var693 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var693 == nil {
+			templ_7745c5c3_Var693 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1035, "<p class=\"truncate text-sm text-sec\">Budget disabled - enable a daily cap in configuration.</p>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1046, "<p class=\"truncate text-sm text-sec\">Budget disabled - enable a daily cap in configuration.</p>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -14311,16 +14413,16 @@ func rateLimitsCard(limits *RateLimits) templ.Component {
 			}()
 		}
 		ctx = templ.InitializeContext(ctx)
-		templ_7745c5c3_Var688 := templ.GetChildren(ctx)
-		if templ_7745c5c3_Var688 == nil {
-			templ_7745c5c3_Var688 = templ.NopComponent
+		templ_7745c5c3_Var694 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var694 == nil {
+			templ_7745c5c3_Var694 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1036, "<section class=\"dashboard-panel min-w-0 rounded-md border border-line bg-surface p-4 shadow-sm sm:p-5\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1047, "<section class=\"dashboard-panel min-w-0 rounded-md border border-line bg-surface p-4 shadow-sm sm:p-5\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Var689 := templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
+		templ_7745c5c3_Var695 := templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
 			templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
 			templ_7745c5c3_Buffer, templ_7745c5c3_IsBuffer := templruntime.GetBuffer(templ_7745c5c3_W)
 			if !templ_7745c5c3_IsBuffer {
@@ -14332,31 +14434,31 @@ func rateLimitsCard(limits *RateLimits) templ.Component {
 				}()
 			}
 			ctx = templ.InitializeContext(ctx)
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1037, "<span class=\"shrink-0 rounded-full bg-accent/15 px-2 py-1 text-xs font-medium text-accent\">")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1048, "<span class=\"shrink-0 rounded-full bg-accent/15 px-2 py-1 text-xs font-medium text-accent\">")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			var templ_7745c5c3_Var690 string
-			templ_7745c5c3_Var690, templ_7745c5c3_Err = templ.JoinStringErrs(rateLimitName(limits))
+			var templ_7745c5c3_Var696 string
+			templ_7745c5c3_Var696, templ_7745c5c3_Err = templ.JoinStringErrs(rateLimitName(limits))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/dashboard.templ`, Line: 4090, Col: 117}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/dashboard.templ`, Line: 4107, Col: 117}
 			}
-			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var690))
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var696))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1038, "</span>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1049, "</span>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			return nil
 		})
-		templ_7745c5c3_Err = panelHeader(icon.Gauge(icon.Props{Class: "size-4 shrink-0"}), "Rate limits", helpRateLimits, "rate-limits-card").Render(templ.WithChildren(ctx, templ_7745c5c3_Var689), templ_7745c5c3_Buffer)
+		templ_7745c5c3_Err = panelHeader(icon.Gauge(icon.Props{Class: "size-4 shrink-0"}), "Rate limits", helpRateLimits, "rate-limits-card").Render(templ.WithChildren(ctx, templ_7745c5c3_Var695), templ_7745c5c3_Buffer)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		if len(rateLimitRows(limits)) == 0 {
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1039, "<div class=\"mt-4\">")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1050, "<div class=\"mt-4\">")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -14364,17 +14466,17 @@ func rateLimitsCard(limits *RateLimits) templ.Component {
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1040, "</div>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1051, "</div>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 		} else {
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1041, "<div class=\"mt-5 grid gap-4\">")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1052, "<div class=\"mt-5 grid gap-4\">")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			for _, row := range rateLimitRows(limits) {
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1042, "<div class=\"grid gap-2\"><div class=\"flex items-center justify-between gap-3\">")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1053, "<div class=\"grid gap-2\"><div class=\"flex items-center justify-between gap-3\">")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
@@ -14382,82 +14484,82 @@ func rateLimitsCard(limits *RateLimits) templ.Component {
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1043, "<span class=\"font-mono text-sm text-sec\">")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1054, "<span class=\"font-mono text-sm text-sec\">")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				var templ_7745c5c3_Var691 string
-				templ_7745c5c3_Var691, templ_7745c5c3_Err = templ.JoinStringErrs(row.Reset)
+				var templ_7745c5c3_Var697 string
+				templ_7745c5c3_Var697, templ_7745c5c3_Err = templ.JoinStringErrs(row.Reset)
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/dashboard.templ`, Line: 4102, Col: 59}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/dashboard.templ`, Line: 4119, Col: 59}
 				}
-				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var691))
-				if templ_7745c5c3_Err != nil {
-					return templ_7745c5c3_Err
-				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1044, "</span></div><div class=\"h-2 overflow-hidden rounded-full bg-elev\"><div class=\"h-full rounded-full bg-accent transition-all\" style=\"")
+				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var697))
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				var templ_7745c5c3_Var692 string
-				templ_7745c5c3_Var692, templ_7745c5c3_Err = templruntime.SanitizeStyleAttributeValues(percentStyle(row.UsedPercent))
-				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/dashboard.templ`, Line: 4105, Col: 102}
-				}
-				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var692))
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1055, "</span></div><div class=\"h-2 overflow-hidden rounded-full bg-elev\"><div class=\"h-full rounded-full bg-accent transition-all\" style=\"")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1045, "\"></div></div><div class=\"grid grid-cols-3 gap-2 font-mono text-xs text-sec\"><span>")
+				var templ_7745c5c3_Var698 string
+				templ_7745c5c3_Var698, templ_7745c5c3_Err = templruntime.SanitizeStyleAttributeValues(percentStyle(row.UsedPercent))
+				if templ_7745c5c3_Err != nil {
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/dashboard.templ`, Line: 4122, Col: 102}
+				}
+				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var698))
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				var templ_7745c5c3_Var693 string
-				templ_7745c5c3_Var693, templ_7745c5c3_Err = templ.JoinStringErrs(row.Remaining)
-				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/dashboard.templ`, Line: 4108, Col: 28}
-				}
-				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var693))
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1056, "\"></div></div><div class=\"grid grid-cols-3 gap-2 font-mono text-xs text-sec\"><span>")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1046, "</span> <span>")
+				var templ_7745c5c3_Var699 string
+				templ_7745c5c3_Var699, templ_7745c5c3_Err = templ.JoinStringErrs(row.Remaining)
+				if templ_7745c5c3_Err != nil {
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/dashboard.templ`, Line: 4125, Col: 28}
+				}
+				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var699))
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				var templ_7745c5c3_Var694 string
-				templ_7745c5c3_Var694, templ_7745c5c3_Err = templ.JoinStringErrs(row.Used)
-				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/dashboard.templ`, Line: 4109, Col: 23}
-				}
-				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var694))
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1057, "</span> <span>")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1047, "</span> <span>")
+				var templ_7745c5c3_Var700 string
+				templ_7745c5c3_Var700, templ_7745c5c3_Err = templ.JoinStringErrs(row.Used)
+				if templ_7745c5c3_Err != nil {
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/dashboard.templ`, Line: 4126, Col: 23}
+				}
+				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var700))
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				var templ_7745c5c3_Var695 string
-				templ_7745c5c3_Var695, templ_7745c5c3_Err = templ.JoinStringErrs(row.Limit)
-				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/dashboard.templ`, Line: 4110, Col: 24}
-				}
-				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var695))
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1058, "</span> <span>")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1048, "</span></div></div>")
+				var templ_7745c5c3_Var701 string
+				templ_7745c5c3_Var701, templ_7745c5c3_Err = templ.JoinStringErrs(row.Limit)
+				if templ_7745c5c3_Err != nil {
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/dashboard.templ`, Line: 4127, Col: 24}
+				}
+				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var701))
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1059, "</span></div></div>")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1049, "</div>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1060, "</div>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1050, "</section>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1061, "</section>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -14481,17 +14583,17 @@ func graphQLBudgetCard(data DashboardData) templ.Component {
 			}()
 		}
 		ctx = templ.InitializeContext(ctx)
-		templ_7745c5c3_Var696 := templ.GetChildren(ctx)
-		if templ_7745c5c3_Var696 == nil {
-			templ_7745c5c3_Var696 = templ.NopComponent
+		templ_7745c5c3_Var702 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var702 == nil {
+			templ_7745c5c3_Var702 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
 		if hasGraphQLBudget(data.Snapshot.RateLimits) {
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1051, "<section class=\"dashboard-panel min-w-0 rounded-md border border-line bg-surface p-4 shadow-sm sm:p-5\" aria-label=\"GraphQL budget\">")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1062, "<section class=\"dashboard-panel min-w-0 rounded-md border border-line bg-surface p-4 shadow-sm sm:p-5\" aria-label=\"GraphQL budget\">")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Var697 := templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
+			templ_7745c5c3_Var703 := templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
 				templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
 				templ_7745c5c3_Buffer, templ_7745c5c3_IsBuffer := templruntime.GetBuffer(templ_7745c5c3_W)
 				if !templ_7745c5c3_IsBuffer {
@@ -14503,82 +14605,82 @@ func graphQLBudgetCard(data DashboardData) templ.Component {
 					}()
 				}
 				ctx = templ.InitializeContext(ctx)
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1052, "<span class=\"shrink-0 rounded-full bg-warn/15 px-2 py-1 font-mono text-xs font-medium text-warn\">")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1063, "<span class=\"shrink-0 rounded-full bg-warn/15 px-2 py-1 font-mono text-xs font-medium text-warn\">")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				var templ_7745c5c3_Var698 string
-				templ_7745c5c3_Var698, templ_7745c5c3_Err = templ.JoinStringErrs(graphQLBudgetCycleCost(data.Snapshot.RateLimits))
+				var templ_7745c5c3_Var704 string
+				templ_7745c5c3_Var704, templ_7745c5c3_Err = templ.JoinStringErrs(graphQLBudgetCycleCost(data.Snapshot.RateLimits))
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/dashboard.templ`, Line: 4123, Col: 151}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/dashboard.templ`, Line: 4140, Col: 151}
 				}
-				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var698))
+				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var704))
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1053, "</span>")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1064, "</span>")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
 				return nil
 			})
-			templ_7745c5c3_Err = panelHeader(icon.Github(icon.Props{Class: "size-4 shrink-0"}), "GraphQL budget", helpRateLimits, "graphql-budget-card").Render(templ.WithChildren(ctx, templ_7745c5c3_Var697), templ_7745c5c3_Buffer)
+			templ_7745c5c3_Err = panelHeader(icon.Github(icon.Props{Class: "size-4 shrink-0"}), "GraphQL budget", helpRateLimits, "graphql-budget-card").Render(templ.WithChildren(ctx, templ_7745c5c3_Var703), templ_7745c5c3_Buffer)
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1054, "<div class=\"mt-5 grid gap-3\"><div class=\"grid grid-cols-2 gap-3 text-sm\"><div class=\"grid gap-1\"><span class=\"text-sec\">Remaining</span> <strong class=\"break-all font-mono text-base font-semibold text-text\">")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1065, "<div class=\"mt-5 grid gap-3\"><div class=\"grid grid-cols-2 gap-3 text-sm\"><div class=\"grid gap-1\"><span class=\"text-sec\">Remaining</span> <strong class=\"break-all font-mono text-base font-semibold text-text\">")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			var templ_7745c5c3_Var699 string
-			templ_7745c5c3_Var699, templ_7745c5c3_Err = templ.JoinStringErrs(graphQLBudgetRemaining(data.Snapshot.RateLimits))
+			var templ_7745c5c3_Var705 string
+			templ_7745c5c3_Var705, templ_7745c5c3_Err = templ.JoinStringErrs(graphQLBudgetRemaining(data.Snapshot.RateLimits))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/dashboard.templ`, Line: 4129, Col: 126}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/dashboard.templ`, Line: 4146, Col: 126}
 			}
-			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var699))
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1055, "</strong></div><div class=\"grid gap-1\"><span class=\"text-sec\">Reset</span> <strong class=\"font-mono text-base font-semibold text-text\">")
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var705))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			var templ_7745c5c3_Var700 string
-			templ_7745c5c3_Var700, templ_7745c5c3_Err = templ.JoinStringErrs(graphQLBudgetReset(data.Snapshot.RateLimits, data.Snapshot.GeneratedAt))
-			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/dashboard.templ`, Line: 4133, Col: 139}
-			}
-			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var700))
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1066, "</strong></div><div class=\"grid gap-1\"><span class=\"text-sec\">Reset</span> <strong class=\"font-mono text-base font-semibold text-text\">")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1056, "</strong> <span class=\"font-mono text-xs text-sec\">")
+			var templ_7745c5c3_Var706 string
+			templ_7745c5c3_Var706, templ_7745c5c3_Err = templ.JoinStringErrs(graphQLBudgetReset(data.Snapshot.RateLimits, data.Snapshot.GeneratedAt))
+			if templ_7745c5c3_Err != nil {
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/dashboard.templ`, Line: 4150, Col: 139}
+			}
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var706))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			var templ_7745c5c3_Var701 string
-			templ_7745c5c3_Var701, templ_7745c5c3_Err = templ.JoinStringErrs(graphQLBudgetResetAt(data.Snapshot.RateLimits))
-			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/dashboard.templ`, Line: 4134, Col: 95}
-			}
-			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var701))
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1067, "</strong> <span class=\"font-mono text-xs text-sec\">")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1057, "</span></div></div><div class=\"flex items-center justify-between gap-3 border-t border-line pt-3 text-sm\"><span class=\"text-sec\">Cycle queries</span> <strong class=\"font-mono font-medium text-text\">")
+			var templ_7745c5c3_Var707 string
+			templ_7745c5c3_Var707, templ_7745c5c3_Err = templ.JoinStringErrs(graphQLBudgetResetAt(data.Snapshot.RateLimits))
+			if templ_7745c5c3_Err != nil {
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/dashboard.templ`, Line: 4151, Col: 95}
+			}
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var707))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			var templ_7745c5c3_Var702 string
-			templ_7745c5c3_Var702, templ_7745c5c3_Err = templ.JoinStringErrs(graphQLBudgetQueryCount(data.Snapshot.RateLimits))
-			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/dashboard.templ`, Line: 4139, Col: 104}
-			}
-			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var702))
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1068, "</span></div></div><div class=\"flex items-center justify-between gap-3 border-t border-line pt-3 text-sm\"><span class=\"text-sec\">Cycle queries</span> <strong class=\"font-mono font-medium text-text\">")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1058, "</strong></div>")
+			var templ_7745c5c3_Var708 string
+			templ_7745c5c3_Var708, templ_7745c5c3_Err = templ.JoinStringErrs(graphQLBudgetQueryCount(data.Snapshot.RateLimits))
+			if templ_7745c5c3_Err != nil {
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/dashboard.templ`, Line: 4156, Col: 104}
+			}
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var708))
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1069, "</strong></div>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -14588,74 +14690,74 @@ func graphQLBudgetCard(data DashboardData) templ.Component {
 					return templ_7745c5c3_Err
 				}
 			} else {
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1059, "<div class=\"grid gap-2 border-t border-line pt-3\">")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1070, "<div class=\"grid gap-2 border-t border-line pt-3\">")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
 				for _, row := range graphQLBudgetContributorRows(data.Snapshot.RateLimits) {
-					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1060, "<div class=\"grid grid-cols-[minmax(0,1fr)_auto] items-center gap-x-3 gap-y-1 text-sm\"><span class=\"truncate font-mono font-medium text-text\">")
+					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1071, "<div class=\"grid grid-cols-[minmax(0,1fr)_auto] items-center gap-x-3 gap-y-1 text-sm\"><span class=\"truncate font-mono font-medium text-text\">")
 					if templ_7745c5c3_Err != nil {
 						return templ_7745c5c3_Err
 					}
-					var templ_7745c5c3_Var703 string
-					templ_7745c5c3_Var703, templ_7745c5c3_Err = templ.JoinStringErrs(row.QueryType)
+					var templ_7745c5c3_Var709 string
+					templ_7745c5c3_Var709, templ_7745c5c3_Err = templ.JoinStringErrs(row.QueryType)
 					if templ_7745c5c3_Err != nil {
-						return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/dashboard.templ`, Line: 4147, Col: 78}
+						return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/dashboard.templ`, Line: 4164, Col: 78}
 					}
-					_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var703))
-					if templ_7745c5c3_Err != nil {
-						return templ_7745c5c3_Err
-					}
-					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1061, "</span> <span class=\"font-mono text-sec\">")
+					_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var709))
 					if templ_7745c5c3_Err != nil {
 						return templ_7745c5c3_Err
 					}
-					var templ_7745c5c3_Var704 string
-					templ_7745c5c3_Var704, templ_7745c5c3_Err = templ.JoinStringErrs(row.Cost)
-					if templ_7745c5c3_Err != nil {
-						return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/dashboard.templ`, Line: 4148, Col: 51}
-					}
-					_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var704))
+					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1072, "</span> <span class=\"font-mono text-sec\">")
 					if templ_7745c5c3_Err != nil {
 						return templ_7745c5c3_Err
 					}
-					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1062, "</span> <span class=\"font-mono text-xs text-sec\">")
+					var templ_7745c5c3_Var710 string
+					templ_7745c5c3_Var710, templ_7745c5c3_Err = templ.JoinStringErrs(row.Cost)
+					if templ_7745c5c3_Err != nil {
+						return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/dashboard.templ`, Line: 4165, Col: 51}
+					}
+					_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var710))
 					if templ_7745c5c3_Err != nil {
 						return templ_7745c5c3_Err
 					}
-					var templ_7745c5c3_Var705 string
-					templ_7745c5c3_Var705, templ_7745c5c3_Err = templ.JoinStringErrs(row.Count)
-					if templ_7745c5c3_Err != nil {
-						return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/dashboard.templ`, Line: 4149, Col: 60}
-					}
-					_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var705))
+					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1073, "</span> <span class=\"font-mono text-xs text-sec\">")
 					if templ_7745c5c3_Err != nil {
 						return templ_7745c5c3_Err
 					}
-					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1063, "</span> <span class=\"text-right font-mono text-xs text-sec\">")
+					var templ_7745c5c3_Var711 string
+					templ_7745c5c3_Var711, templ_7745c5c3_Err = templ.JoinStringErrs(row.Count)
+					if templ_7745c5c3_Err != nil {
+						return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/dashboard.templ`, Line: 4166, Col: 60}
+					}
+					_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var711))
 					if templ_7745c5c3_Err != nil {
 						return templ_7745c5c3_Err
 					}
-					var templ_7745c5c3_Var706 string
-					templ_7745c5c3_Var706, templ_7745c5c3_Err = templ.JoinStringErrs(row.Percent)
-					if templ_7745c5c3_Err != nil {
-						return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/dashboard.templ`, Line: 4150, Col: 73}
-					}
-					_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var706))
+					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1074, "</span> <span class=\"text-right font-mono text-xs text-sec\">")
 					if templ_7745c5c3_Err != nil {
 						return templ_7745c5c3_Err
 					}
-					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1064, "</span></div>")
+					var templ_7745c5c3_Var712 string
+					templ_7745c5c3_Var712, templ_7745c5c3_Err = templ.JoinStringErrs(row.Percent)
+					if templ_7745c5c3_Err != nil {
+						return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/dashboard.templ`, Line: 4167, Col: 73}
+					}
+					_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var712))
+					if templ_7745c5c3_Err != nil {
+						return templ_7745c5c3_Err
+					}
+					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1075, "</span></div>")
 					if templ_7745c5c3_Err != nil {
 						return templ_7745c5c3_Err
 					}
 				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1065, "</div>")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1076, "</div>")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1066, "</div></section>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1077, "</div></section>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -14680,17 +14782,17 @@ func restBudgetCard(data DashboardData) templ.Component {
 			}()
 		}
 		ctx = templ.InitializeContext(ctx)
-		templ_7745c5c3_Var707 := templ.GetChildren(ctx)
-		if templ_7745c5c3_Var707 == nil {
-			templ_7745c5c3_Var707 = templ.NopComponent
+		templ_7745c5c3_Var713 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var713 == nil {
+			templ_7745c5c3_Var713 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
 		if hasRESTBudget(data.Snapshot.RateLimits) {
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1067, "<section class=\"dashboard-panel min-w-0 rounded-md border border-line bg-surface p-4 shadow-sm sm:p-5\" aria-label=\"REST budget\">")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1078, "<section class=\"dashboard-panel min-w-0 rounded-md border border-line bg-surface p-4 shadow-sm sm:p-5\" aria-label=\"REST budget\">")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Var708 := templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
+			templ_7745c5c3_Var714 := templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
 				templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
 				templ_7745c5c3_Buffer, templ_7745c5c3_IsBuffer := templruntime.GetBuffer(templ_7745c5c3_W)
 				if !templ_7745c5c3_IsBuffer {
@@ -14702,69 +14804,69 @@ func restBudgetCard(data DashboardData) templ.Component {
 					}()
 				}
 				ctx = templ.InitializeContext(ctx)
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1068, "<span class=\"shrink-0 rounded-full bg-warn/15 px-2 py-1 font-mono text-xs font-medium text-warn\">")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1079, "<span class=\"shrink-0 rounded-full bg-warn/15 px-2 py-1 font-mono text-xs font-medium text-warn\">")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				var templ_7745c5c3_Var709 string
-				templ_7745c5c3_Var709, templ_7745c5c3_Err = templ.JoinStringErrs(restBudgetRequestCount(data.Snapshot.RateLimits))
+				var templ_7745c5c3_Var715 string
+				templ_7745c5c3_Var715, templ_7745c5c3_Err = templ.JoinStringErrs(restBudgetRequestCount(data.Snapshot.RateLimits))
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/dashboard.templ`, Line: 4164, Col: 151}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/dashboard.templ`, Line: 4181, Col: 151}
 				}
-				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var709))
+				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var715))
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1069, "</span>")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1080, "</span>")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
 				return nil
 			})
-			templ_7745c5c3_Err = panelHeader(icon.Server(icon.Props{Class: "size-4 shrink-0"}), "REST budget", helpRateLimits, "rest-budget-card").Render(templ.WithChildren(ctx, templ_7745c5c3_Var708), templ_7745c5c3_Buffer)
+			templ_7745c5c3_Err = panelHeader(icon.Server(icon.Props{Class: "size-4 shrink-0"}), "REST budget", helpRateLimits, "rest-budget-card").Render(templ.WithChildren(ctx, templ_7745c5c3_Var714), templ_7745c5c3_Buffer)
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1070, "<div class=\"mt-5 grid gap-3\"><div class=\"grid grid-cols-2 gap-3 text-sm\"><div class=\"grid gap-1\"><span class=\"text-sec\">Remaining</span> <strong class=\"break-all font-mono text-base font-semibold text-text\">")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1081, "<div class=\"mt-5 grid gap-3\"><div class=\"grid grid-cols-2 gap-3 text-sm\"><div class=\"grid gap-1\"><span class=\"text-sec\">Remaining</span> <strong class=\"break-all font-mono text-base font-semibold text-text\">")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			var templ_7745c5c3_Var710 string
-			templ_7745c5c3_Var710, templ_7745c5c3_Err = templ.JoinStringErrs(restBudgetRemaining(data.Snapshot.RateLimits))
+			var templ_7745c5c3_Var716 string
+			templ_7745c5c3_Var716, templ_7745c5c3_Err = templ.JoinStringErrs(restBudgetRemaining(data.Snapshot.RateLimits))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/dashboard.templ`, Line: 4170, Col: 123}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/dashboard.templ`, Line: 4187, Col: 123}
 			}
-			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var710))
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1071, "</strong></div><div class=\"grid gap-1\"><span class=\"text-sec\">Reset</span> <strong class=\"font-mono text-base font-semibold text-text\">")
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var716))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			var templ_7745c5c3_Var711 string
-			templ_7745c5c3_Var711, templ_7745c5c3_Err = templ.JoinStringErrs(restBudgetReset(data.Snapshot.RateLimits, data.Snapshot.GeneratedAt))
-			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/dashboard.templ`, Line: 4174, Col: 136}
-			}
-			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var711))
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1082, "</strong></div><div class=\"grid gap-1\"><span class=\"text-sec\">Reset</span> <strong class=\"font-mono text-base font-semibold text-text\">")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1072, "</strong> <span class=\"font-mono text-xs text-sec\">")
+			var templ_7745c5c3_Var717 string
+			templ_7745c5c3_Var717, templ_7745c5c3_Err = templ.JoinStringErrs(restBudgetReset(data.Snapshot.RateLimits, data.Snapshot.GeneratedAt))
+			if templ_7745c5c3_Err != nil {
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/dashboard.templ`, Line: 4191, Col: 136}
+			}
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var717))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			var templ_7745c5c3_Var712 string
-			templ_7745c5c3_Var712, templ_7745c5c3_Err = templ.JoinStringErrs(restBudgetResetAt(data.Snapshot.RateLimits))
-			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/dashboard.templ`, Line: 4175, Col: 92}
-			}
-			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var712))
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1083, "</strong> <span class=\"font-mono text-xs text-sec\">")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1073, "</span></div></div>")
+			var templ_7745c5c3_Var718 string
+			templ_7745c5c3_Var718, templ_7745c5c3_Err = templ.JoinStringErrs(restBudgetResetAt(data.Snapshot.RateLimits))
+			if templ_7745c5c3_Err != nil {
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/dashboard.templ`, Line: 4192, Col: 92}
+			}
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var718))
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1084, "</span></div></div>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -14774,20 +14876,20 @@ func restBudgetCard(data DashboardData) templ.Component {
 					return templ_7745c5c3_Err
 				}
 			} else {
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1074, "<details class=\"group border-t border-line pt-3\" data-preserve-details=\"rest-budget-contributors\"><summary class=\"flex cursor-pointer list-none items-center justify-between gap-3 text-sm text-sec marker:hidden\"><span class=\"font-medium text-text\">Endpoint details</span> <span class=\"inline-flex shrink-0 items-center gap-2\"><span class=\"rounded-md bg-elev px-2 py-1 font-mono text-xs text-sec\">")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1085, "<details class=\"group border-t border-line pt-3\" data-preserve-details=\"rest-budget-contributors\"><summary class=\"flex cursor-pointer list-none items-center justify-between gap-3 text-sm text-sec marker:hidden\"><span class=\"font-medium text-text\">Endpoint details</span> <span class=\"inline-flex shrink-0 items-center gap-2\"><span class=\"rounded-md bg-elev px-2 py-1 font-mono text-xs text-sec\">")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				var templ_7745c5c3_Var713 string
-				templ_7745c5c3_Var713, templ_7745c5c3_Err = templ.JoinStringErrs(formatInt(int64(len(restBudgetContributorRows(data.Snapshot.RateLimits)))))
+				var templ_7745c5c3_Var719 string
+				templ_7745c5c3_Var719, templ_7745c5c3_Err = templ.JoinStringErrs(formatInt(int64(len(restBudgetContributorRows(data.Snapshot.RateLimits)))))
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/dashboard.templ`, Line: 4185, Col: 154}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/dashboard.templ`, Line: 4202, Col: 154}
 				}
-				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var713))
+				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var719))
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1075, "</span>")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1086, "</span>")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
@@ -14795,74 +14897,74 @@ func restBudgetCard(data DashboardData) templ.Component {
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1076, "</span></summary><div class=\"mt-3 grid gap-2\">")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1087, "</span></summary><div class=\"mt-3 grid gap-2\">")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
 				for _, row := range restBudgetContributorRows(data.Snapshot.RateLimits) {
-					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1077, "<div class=\"grid grid-cols-[minmax(0,1fr)_auto] items-center gap-x-3 gap-y-1 text-sm\"><span class=\"truncate font-mono font-medium text-text\">")
+					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1088, "<div class=\"grid grid-cols-[minmax(0,1fr)_auto] items-center gap-x-3 gap-y-1 text-sm\"><span class=\"truncate font-mono font-medium text-text\">")
 					if templ_7745c5c3_Err != nil {
 						return templ_7745c5c3_Err
 					}
-					var templ_7745c5c3_Var714 string
-					templ_7745c5c3_Var714, templ_7745c5c3_Err = templ.JoinStringErrs(row.EndpointFamily)
+					var templ_7745c5c3_Var720 string
+					templ_7745c5c3_Var720, templ_7745c5c3_Err = templ.JoinStringErrs(row.EndpointFamily)
 					if templ_7745c5c3_Err != nil {
-						return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/dashboard.templ`, Line: 4192, Col: 84}
+						return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/dashboard.templ`, Line: 4209, Col: 84}
 					}
-					_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var714))
-					if templ_7745c5c3_Err != nil {
-						return templ_7745c5c3_Err
-					}
-					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1078, "</span> <span class=\"font-mono text-sec\">")
+					_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var720))
 					if templ_7745c5c3_Err != nil {
 						return templ_7745c5c3_Err
 					}
-					var templ_7745c5c3_Var715 string
-					templ_7745c5c3_Var715, templ_7745c5c3_Err = templ.JoinStringErrs(row.Count)
-					if templ_7745c5c3_Err != nil {
-						return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/dashboard.templ`, Line: 4193, Col: 53}
-					}
-					_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var715))
+					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1089, "</span> <span class=\"font-mono text-sec\">")
 					if templ_7745c5c3_Err != nil {
 						return templ_7745c5c3_Err
 					}
-					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1079, "</span> <span class=\"font-mono text-xs text-sec\">")
+					var templ_7745c5c3_Var721 string
+					templ_7745c5c3_Var721, templ_7745c5c3_Err = templ.JoinStringErrs(row.Count)
+					if templ_7745c5c3_Err != nil {
+						return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/dashboard.templ`, Line: 4210, Col: 53}
+					}
+					_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var721))
 					if templ_7745c5c3_Err != nil {
 						return templ_7745c5c3_Err
 					}
-					var templ_7745c5c3_Var716 string
-					templ_7745c5c3_Var716, templ_7745c5c3_Err = templ.JoinStringErrs(row.Remaining)
-					if templ_7745c5c3_Err != nil {
-						return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/dashboard.templ`, Line: 4194, Col: 65}
-					}
-					_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var716))
+					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1090, "</span> <span class=\"font-mono text-xs text-sec\">")
 					if templ_7745c5c3_Err != nil {
 						return templ_7745c5c3_Err
 					}
-					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1080, "</span> <span class=\"text-right font-mono text-xs text-sec\">")
+					var templ_7745c5c3_Var722 string
+					templ_7745c5c3_Var722, templ_7745c5c3_Err = templ.JoinStringErrs(row.Remaining)
+					if templ_7745c5c3_Err != nil {
+						return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/dashboard.templ`, Line: 4211, Col: 65}
+					}
+					_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var722))
 					if templ_7745c5c3_Err != nil {
 						return templ_7745c5c3_Err
 					}
-					var templ_7745c5c3_Var717 string
-					templ_7745c5c3_Var717, templ_7745c5c3_Err = templ.JoinStringErrs(row.Status)
-					if templ_7745c5c3_Err != nil {
-						return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/dashboard.templ`, Line: 4195, Col: 73}
-					}
-					_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var717))
+					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1091, "</span> <span class=\"text-right font-mono text-xs text-sec\">")
 					if templ_7745c5c3_Err != nil {
 						return templ_7745c5c3_Err
 					}
-					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1081, "</span></div>")
+					var templ_7745c5c3_Var723 string
+					templ_7745c5c3_Var723, templ_7745c5c3_Err = templ.JoinStringErrs(row.Status)
+					if templ_7745c5c3_Err != nil {
+						return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/dashboard.templ`, Line: 4212, Col: 73}
+					}
+					_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var723))
+					if templ_7745c5c3_Err != nil {
+						return templ_7745c5c3_Err
+					}
+					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1092, "</span></div>")
 					if templ_7745c5c3_Err != nil {
 						return templ_7745c5c3_Err
 					}
 				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1082, "</div></details>")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1093, "</div></details>")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1083, "</div></section>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1094, "</div></section>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -14887,16 +14989,16 @@ func tokenCard(data DashboardData) templ.Component {
 			}()
 		}
 		ctx = templ.InitializeContext(ctx)
-		templ_7745c5c3_Var718 := templ.GetChildren(ctx)
-		if templ_7745c5c3_Var718 == nil {
-			templ_7745c5c3_Var718 = templ.NopComponent
+		templ_7745c5c3_Var724 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var724 == nil {
+			templ_7745c5c3_Var724 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1084, "<section class=\"dashboard-panel min-w-0 rounded-md border border-line bg-surface p-4 shadow-sm sm:p-5\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1095, "<section class=\"dashboard-panel min-w-0 rounded-md border border-line bg-surface p-4 shadow-sm sm:p-5\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Var719 := templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
+		templ_7745c5c3_Var725 := templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
 			templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
 			templ_7745c5c3_Buffer, templ_7745c5c3_IsBuffer := templruntime.GetBuffer(templ_7745c5c3_W)
 			if !templ_7745c5c3_IsBuffer {
@@ -14908,56 +15010,56 @@ func tokenCard(data DashboardData) templ.Component {
 				}()
 			}
 			ctx = templ.InitializeContext(ctx)
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1085, "<span class=\"shrink-0 rounded-full bg-elev px-2 py-1 font-mono text-xs font-medium text-sec\">")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1096, "<span class=\"shrink-0 rounded-full bg-elev px-2 py-1 font-mono text-xs font-medium text-sec\">")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			var templ_7745c5c3_Var720 string
-			templ_7745c5c3_Var720, templ_7745c5c3_Err = templ.JoinStringErrs(tokenRate(data.Snapshot))
+			var templ_7745c5c3_Var726 string
+			templ_7745c5c3_Var726, templ_7745c5c3_Err = templ.JoinStringErrs(tokenRate(data.Snapshot))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/dashboard.templ`, Line: 4209, Col: 122}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/dashboard.templ`, Line: 4226, Col: 122}
 			}
-			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var720))
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var726))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1086, "</span>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1097, "</span>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			return nil
 		})
-		templ_7745c5c3_Err = panelHeader(icon.Coins(icon.Props{Class: "size-4 shrink-0"}), "Tokens", helpTokens, "tokens-card").Render(templ.WithChildren(ctx, templ_7745c5c3_Var719), templ_7745c5c3_Buffer)
+		templ_7745c5c3_Err = panelHeader(icon.Coins(icon.Props{Class: "size-4 shrink-0"}), "Tokens", helpTokens, "tokens-card").Render(templ.WithChildren(ctx, templ_7745c5c3_Var725), templ_7745c5c3_Buffer)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1087, "<div class=\"mt-5 grid gap-2\"><div class=\"break-all font-mono text-2xl font-semibold text-text sm:text-3xl\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1098, "<div class=\"mt-5 grid gap-2\"><div class=\"break-all font-mono text-2xl font-semibold text-text sm:text-3xl\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		var templ_7745c5c3_Var721 string
-		templ_7745c5c3_Var721, templ_7745c5c3_Err = templ.JoinStringErrs(formatTokens(data.Snapshot.Tokens))
+		var templ_7745c5c3_Var727 string
+		templ_7745c5c3_Var727, templ_7745c5c3_Err = templ.JoinStringErrs(formatTokens(data.Snapshot.Tokens))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/dashboard.templ`, Line: 4212, Col: 117}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/dashboard.templ`, Line: 4229, Col: 117}
 		}
-		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var721))
-		if templ_7745c5c3_Err != nil {
-			return templ_7745c5c3_Err
-		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1088, "</div><div class=\"font-mono text-sm text-sec\">")
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var727))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		var templ_7745c5c3_Var722 string
-		templ_7745c5c3_Var722, templ_7745c5c3_Err = templ.JoinStringErrs(formatTokenBreakdown(data.Snapshot.Tokens))
-		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/dashboard.templ`, Line: 4213, Col: 87}
-		}
-		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var722))
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1099, "</div><div class=\"font-mono text-sm text-sec\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1089, "</div></div><div class=\"mt-5\"><div class=\"mb-2 flex items-center justify-between gap-3 text-sm\">")
+		var templ_7745c5c3_Var728 string
+		templ_7745c5c3_Var728, templ_7745c5c3_Err = templ.JoinStringErrs(formatTokenBreakdown(data.Snapshot.Tokens))
+		if templ_7745c5c3_Err != nil {
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/dashboard.templ`, Line: 4230, Col: 87}
+		}
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var728))
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1100, "</div></div><div class=\"mt-5\"><div class=\"mb-2 flex items-center justify-between gap-3 text-sm\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -14965,20 +15067,20 @@ func tokenCard(data DashboardData) templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1090, "<span class=\"font-mono text-xs text-sec\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1101, "<span class=\"font-mono text-xs text-sec\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		var templ_7745c5c3_Var723 string
-		templ_7745c5c3_Var723, templ_7745c5c3_Err = templ.JoinStringErrs(formatDuration(data.Snapshot.Tokens.RuntimeSeconds))
+		var templ_7745c5c3_Var729 string
+		templ_7745c5c3_Var729, templ_7745c5c3_Err = templ.JoinStringErrs(formatDuration(data.Snapshot.Tokens.RuntimeSeconds))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/dashboard.templ`, Line: 4218, Col: 98}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/dashboard.templ`, Line: 4235, Col: 98}
 		}
-		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var723))
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var729))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1091, "</span></div>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1102, "</span></div>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -14992,12 +15094,12 @@ func tokenCard(data DashboardData) templ.Component {
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1092, " <div class=\"mt-3 flex flex-wrap items-center gap-4 text-xs font-medium text-sec\"><span class=\"inline-flex items-center gap-2\"><span class=\"h-2 w-2 rounded-full bg-accent\"></span>Input</span> <span class=\"inline-flex items-center gap-2\"><span class=\"h-2 w-2 rounded-full bg-ok\"></span>Output</span></div>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1103, " <div class=\"mt-3 flex flex-wrap items-center gap-4 text-xs font-medium text-sec\"><span class=\"inline-flex items-center gap-2\"><span class=\"h-2 w-2 rounded-full bg-accent\"></span>Input</span> <span class=\"inline-flex items-center gap-2\"><span class=\"h-2 w-2 rounded-full bg-ok\"></span>Output</span></div>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1093, "</div></section>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1104, "</div></section>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}

--- a/internal/web/templates/dashboard_test.go
+++ b/internal/web/templates/dashboard_test.go
@@ -592,6 +592,41 @@ func TestDashboardRendersBudgetHistoryAndDailyCap(t *testing.T) {
 	}
 }
 
+func TestDashboardDistinguishesBudgetHoldLifecycle(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 7, 12, 15, 0, 0, 0, time.UTC)
+	resetAt := now.Add(9 * time.Hour)
+	html := renderAnalyticsPage(t, templates.DashboardData{
+		Title:         "Detent",
+		ConnectorName: "github",
+		Snapshot: telemetry.Snapshot{
+			GeneratedAt: now,
+			Budget: telemetry.Budget{
+				Enabled: true,
+				Refusals: []telemetry.BudgetRefusal{
+					{IssueID: "issue-hard", Identifier: "digitaldrywood/detent#1251", Code: "per_issue_max_usd", HardHold: true},
+					{IssueID: "issue-daily", Identifier: "digitaldrywood/detent#1247", Code: "per_day_max_usd", ResetAt: &resetAt},
+				},
+			},
+		},
+	})
+
+	for _, want := range []string{
+		`aria-label="Budget holds"`,
+		"digitaldrywood/detent#1251",
+		"Hard hold",
+		"Needs an operator decision; it will not retry automatically.",
+		"digitaldrywood/detent#1247",
+		"Temporary cooldown",
+		"Retries automatically after {{detent-time:date-time-seconds:2026-07-13T00:00:00Z}}.",
+	} {
+		if !strings.Contains(html, want) {
+			t.Fatalf("analytics page missing %q:\n%s", want, html)
+		}
+	}
+}
+
 func renderHealthPage(t *testing.T, data templates.DashboardData) string {
 	t.Helper()
 


### PR DESCRIPTION
## Summary

- keep `per_issue_max_usd` refusals as non-expiring hard holds instead of cooldown retries
- re-evaluate held issues against live lifetime spend and the enforced cap so reload raises or disables clear them
- release claims without scheduling retries, prune inactive issues, and expose hard-hold state distinctly in telemetry and the dashboard

Fixes #1251

## UI Surface Contract

- [x] The linked issue explicitly authorizes the budget dashboard hold treatment.
- [x] This PR does not add persistent top-of-screen messaging.
- [x] Deterministic rendered-HTML coverage and the current-head Browser Visual CI gate passed for the operator-facing change.

## Test Plan

- [x] `make generate`
- [x] focused tests for budget, runner, orchestrator, recovery, telemetry, inactive-issue pruning, and dashboard rendering
- [x] `make check` (race tests; 77.2% aggregate coverage)
- [x] current-head CI: 10/10 checks passed, including Browser Visual and cross-platform portability
