### PR TITLE
fix(kanban): preserve advanced cards during reconciliation

### DIFF
--- a/internal/kanban/mutations.go
+++ b/internal/kanban/mutations.go
@@ -15,11 +15,12 @@ const (
 )
 
 type MutationTracker struct {
-	mu       sync.Mutex
-	locks    map[string]*sync.Mutex
-	states   map[string]pendingState
-	removed  map[string]pendingRemoval
-	reverted map[string]RevertNotice
+	mu          sync.Mutex
+	locks       map[string]*sync.Mutex
+	states      map[string]pendingState
+	synthesized map[string]synthesizedCard
+	removed     map[string]pendingRemoval
+	reverted    map[string]RevertNotice
 }
 
 type pendingState struct {
@@ -38,6 +39,11 @@ type pendingRemoval struct {
 	dataSeqAtWrite uint64
 }
 
+type synthesizedCard struct {
+	project string
+	issue   telemetry.Issue
+}
+
 type RevertNotice struct {
 	Identifier string
 	From       string
@@ -47,10 +53,11 @@ type RevertNotice struct {
 
 func NewMutationTracker() *MutationTracker {
 	return &MutationTracker{
-		locks:    map[string]*sync.Mutex{},
-		states:   map[string]pendingState{},
-		removed:  map[string]pendingRemoval{},
-		reverted: map[string]RevertNotice{},
+		locks:       map[string]*sync.Mutex{},
+		states:      map[string]pendingState{},
+		synthesized: map[string]synthesizedCard{},
+		removed:     map[string]pendingRemoval{},
+		reverted:    map[string]RevertNotice{},
 	}
 }
 
@@ -117,7 +124,6 @@ func (t *MutationTracker) cardStateLocked(stateKey string, snapshotState string,
 		return snapshotState
 	default:
 		delete(t.states, stateKey)
-		t.noteRevertLocked(stateKey, pending, snapshotState)
 		return snapshotState
 	}
 }
@@ -141,6 +147,7 @@ func (t *MutationTracker) NoteCardState(key string, projectID string, issue tele
 	}
 	delete(t.removed, stateKey)
 	delete(t.reverted, stateKey)
+	delete(t.synthesized, stateKey)
 	t.states[stateKey] = pendingState{
 		snapshot:       strings.TrimSpace(snapshotState),
 		current:        strings.TrimSpace(currentState),
@@ -168,6 +175,7 @@ func (t *MutationTracker) PendingMovedCards(key string, projectID string, snapsh
 			continue
 		}
 		stateKey := MutationStateKey(key, issueID)
+		delete(t.synthesized, stateKey)
 		if _, ok := t.states[stateKey]; !ok {
 			continue
 		}
@@ -183,34 +191,51 @@ func (t *MutationTracker) PendingMovedCards(key string, projectID string, snapsh
 		if _, ok := present[stateKey]; ok {
 			continue
 		}
-		if _, ok := t.states[stateKey]; !ok {
+		pending, ok := t.states[stateKey]
+		if !ok {
 			continue
 		}
 		snapshotState := strings.TrimSpace(issue.State)
-		t.cardStateLocked(stateKey, snapshotState, dataSeq)
+		state := t.cardStateLocked(stateKey, snapshotState, dataSeq)
+		_, stillPending := t.states[stateKey]
+		if !stillPending && NormalizeState(snapshotState) != NormalizeState(pending.current) && NormalizeState(snapshotState) != NormalizeState(pending.snapshot) {
+			synthesizedIssue := CloneIssue(pending.issue)
+			synthesizedIssue.State = strings.TrimSpace(state)
+			t.synthesized[stateKey] = synthesizedCard{
+				project: pending.project,
+				issue:   synthesizedIssue,
+			}
+		}
 	}
 
 	out := []telemetry.Issue{}
-	for stateKey, pending := range t.states {
+	appendCard := func(stateKey string, project string, issue telemetry.Issue) {
 		if _, ok := present[stateKey]; ok {
-			continue
+			return
 		}
-		issueID := strings.TrimSpace(pending.issue.ID)
+		issueID := strings.TrimSpace(issue.ID)
 		if issueID == "" || MutationStateKey(key, issueID) != stateKey {
-			continue
+			return
 		}
-		if projectID != "" && pending.project != "" && pending.project != projectID {
-			continue
+		if projectID != "" && project != "" && project != projectID {
+			return
 		}
-		if !SameProject(pending.issue, projectID, snapshot.Project.ID) {
-			continue
+		if !SameProject(issue, projectID, snapshot.Project.ID) {
+			return
 		}
-		issue := CloneIssue(pending.issue)
+		issue = CloneIssue(issue)
 		if strings.TrimSpace(issue.ProjectID) == "" {
 			issue.ProjectID = projectID
 		}
-		issue.State = strings.TrimSpace(pending.current)
 		out = append(out, issue)
+	}
+	for stateKey, pending := range t.states {
+		issue := CloneIssue(pending.issue)
+		issue.State = strings.TrimSpace(pending.current)
+		appendCard(stateKey, pending.project, issue)
+	}
+	for stateKey, synthesized := range t.synthesized {
+		appendCard(stateKey, synthesized.project, synthesized.issue)
 	}
 	sort.SliceStable(out, func(i, j int) bool {
 		left := strings.TrimSpace(out[i].Identifier)
@@ -290,6 +315,7 @@ func (t *MutationTracker) NoteCardRemoved(key string, issueID string, snapshotSt
 
 	t.mu.Lock()
 	delete(t.states, stateKey)
+	delete(t.synthesized, stateKey)
 	delete(t.reverted, stateKey)
 	t.removed[stateKey] = pendingRemoval{
 		snapshot:       strings.TrimSpace(snapshotState),

--- a/internal/kanban/mutations.go
+++ b/internal/kanban/mutations.go
@@ -157,13 +157,19 @@ func (t *MutationTracker) NoteCardState(key string, projectID string, issue tele
 	}
 }
 
-func (t *MutationTracker) PendingMovedCards(key string, projectID string, snapshot telemetry.Snapshot) []telemetry.Issue {
+func (t *MutationTracker) PendingMovedCards(key string, projectID string, snapshot telemetry.Snapshot, terminalStates []string) []telemetry.Issue {
 	key = strings.TrimSpace(key)
 	if key == "" {
 		return nil
 	}
 	projectID = strings.TrimSpace(projectID)
 	dataSeq := SnapshotProjectDataSeq(snapshot, projectID)
+	terminal := make(map[string]struct{}, len(terminalStates))
+	for _, state := range terminalStates {
+		if state = NormalizeState(state); state != "" {
+			terminal[state] = struct{}{}
+		}
+	}
 
 	t.mu.Lock()
 	defer t.mu.Unlock()
@@ -198,7 +204,8 @@ func (t *MutationTracker) PendingMovedCards(key string, projectID string, snapsh
 		snapshotState := strings.TrimSpace(issue.State)
 		state := t.cardStateLocked(stateKey, snapshotState, dataSeq)
 		_, stillPending := t.states[stateKey]
-		if !stillPending && NormalizeState(snapshotState) != NormalizeState(pending.current) && NormalizeState(snapshotState) != NormalizeState(pending.snapshot) {
+		_, terminalState := terminal[NormalizeState(snapshotState)]
+		if !stillPending && !terminalState && NormalizeState(snapshotState) != NormalizeState(pending.current) && NormalizeState(snapshotState) != NormalizeState(pending.snapshot) {
 			synthesizedIssue := CloneIssue(pending.issue)
 			synthesizedIssue.State = strings.TrimSpace(state)
 			t.synthesized[stateKey] = synthesizedCard{

--- a/internal/kanban/mutations_test.go
+++ b/internal/kanban/mutations_test.go
@@ -223,7 +223,7 @@ func TestMutationTrackerPendingMovedCards(t *testing.T) {
 				State:      "Backlog",
 			}, "Backlog", "Todo", 1)
 
-			got := tracker.PendingMovedCards("project:detent", "detent", tt.snapshot)
+			got := tracker.PendingMovedCards("project:detent", "detent", tt.snapshot, nil)
 			if len(got) != len(tt.wantIssues) {
 				t.Fatalf("PendingMovedCards() len = %d, want %d: %#v", len(got), len(tt.wantIssues), got)
 			}
@@ -267,7 +267,7 @@ func TestMutationTrackerPendingMovedCardsKeepsAdvancedCardUntilVisible(t *testin
 	}
 
 	for range 2 {
-		got := tracker.PendingMovedCards("project:detent", "detent", advancedSnapshot)
+		got := tracker.PendingMovedCards("project:detent", "detent", advancedSnapshot, []string{"Done"})
 		if len(got) != 1 || got[0].Identifier != issue.Identifier || got[0].State != "Production" {
 			t.Fatalf("PendingMovedCards() = %#v, want one Production card", got)
 		}
@@ -282,8 +282,45 @@ func TestMutationTrackerPendingMovedCardsKeepsAdvancedCardUntilVisible(t *testin
 	visibleSnapshot := advancedSnapshot
 	visibleSnapshot.Refresh.DataSeq = 3
 	visibleSnapshot.BoardIssues = []telemetry.Issue{advancedSnapshot.Completed[0].Issue}
-	if got := tracker.PendingMovedCards("project:detent", "detent", visibleSnapshot); len(got) != 0 {
+	if got := tracker.PendingMovedCards("project:detent", "detent", visibleSnapshot, []string{"Done"}); len(got) != 0 {
 		t.Fatalf("PendingMovedCards() = %#v, want visible snapshot entry to take over", got)
+	}
+}
+
+func TestMutationTrackerPendingMovedCardsDoesNotKeepTerminalCompletion(t *testing.T) {
+	t.Parallel()
+
+	tracker := NewMutationTracker()
+	issue := telemetry.Issue{
+		ID:         "terminal-card",
+		Identifier: "DDW-439",
+		ProjectID:  "detent",
+		Title:      "Terminal pending card",
+		State:      "Backlog",
+	}
+	tracker.NoteCardState("project:detent", "detent", issue, "Backlog", "Todo", 1)
+	snapshot := telemetry.Snapshot{
+		Project: telemetry.Project{ID: "detent"},
+		Refresh: telemetry.Refresh{DataSeq: 2},
+		Completed: []telemetry.Completed{{
+			Issue: telemetry.Issue{
+				ID:         issue.ID,
+				Identifier: issue.Identifier,
+				ProjectID:  issue.ProjectID,
+				Title:      issue.Title,
+				State:      "Done",
+			},
+		}},
+	}
+
+	if got := tracker.PendingMovedCards("project:detent", "detent", snapshot, []string{"Done", "Cancelled"}); len(got) != 0 {
+		t.Fatalf("PendingMovedCards() = %#v, want terminal completion released", got)
+	}
+	if pendingStateExists(tracker, "project:detent", issue.ID) {
+		t.Fatal("pending state exists after terminal completion")
+	}
+	if got := tracker.ConsumeRevertNotices("project:detent", "detent"); len(got) != 0 {
+		t.Fatalf("ConsumeRevertNotices() = %#v, want none", got)
 	}
 }
 

--- a/internal/kanban/mutations_test.go
+++ b/internal/kanban/mutations_test.go
@@ -65,11 +65,10 @@ func TestMutationTrackerCardStateByDataSeq(t *testing.T) {
 			wantNotice: RevertNotice{Identifier: "DDW-433", From: "Todo", To: "Backlog"},
 		},
 		{
-			name: "third state reverts immediately with notice",
+			name: "newer third state confirms and drops entry",
 			observations: []observation{
 				{snapshotState: "Blocked", dataSeq: 8, want: "Blocked"},
 			},
-			wantNotice: RevertNotice{Identifier: "DDW-433", From: "Todo", To: "Blocked"},
 		},
 	}
 
@@ -238,6 +237,53 @@ func TestMutationTrackerPendingMovedCards(t *testing.T) {
 				t.Fatalf("pending state exists = %t, want %t", got, tt.wantPending)
 			}
 		})
+	}
+}
+
+func TestMutationTrackerPendingMovedCardsKeepsAdvancedCardUntilVisible(t *testing.T) {
+	t.Parallel()
+
+	tracker := NewMutationTracker()
+	issue := telemetry.Issue{
+		ID:         "advanced-card",
+		Identifier: "DDW-437",
+		ProjectID:  "detent",
+		Title:      "Advanced pending card",
+		State:      "Backlog",
+	}
+	tracker.NoteCardState("project:detent", "detent", issue, "Backlog", "Todo", 1)
+	advancedSnapshot := telemetry.Snapshot{
+		Project: telemetry.Project{ID: "detent"},
+		Refresh: telemetry.Refresh{DataSeq: 2},
+		Completed: []telemetry.Completed{{
+			Issue: telemetry.Issue{
+				ID:         issue.ID,
+				Identifier: issue.Identifier,
+				ProjectID:  issue.ProjectID,
+				Title:      issue.Title,
+				State:      "Production",
+			},
+		}},
+	}
+
+	for range 2 {
+		got := tracker.PendingMovedCards("project:detent", "detent", advancedSnapshot)
+		if len(got) != 1 || got[0].Identifier != issue.Identifier || got[0].State != "Production" {
+			t.Fatalf("PendingMovedCards() = %#v, want one Production card", got)
+		}
+	}
+	if pendingStateExists(tracker, "project:detent", issue.ID) {
+		t.Fatal("pending state exists after authoritative advancement")
+	}
+	if got := tracker.ConsumeRevertNotices("project:detent", "detent"); len(got) != 0 {
+		t.Fatalf("ConsumeRevertNotices() = %#v, want none", got)
+	}
+
+	visibleSnapshot := advancedSnapshot
+	visibleSnapshot.Refresh.DataSeq = 3
+	visibleSnapshot.BoardIssues = []telemetry.Issue{advancedSnapshot.Completed[0].Issue}
+	if got := tracker.PendingMovedCards("project:detent", "detent", visibleSnapshot); len(got) != 0 {
+		t.Fatalf("PendingMovedCards() = %#v, want visible snapshot entry to take over", got)
 	}
 }
 

--- a/internal/web/kanban.go
+++ b/internal/web/kanban.go
@@ -349,7 +349,11 @@ func (s *Server) kanbanSnapshotWithPendingStates(lockKey string, projectID strin
 		}
 		return !s.kanbanMutations.CardRemoved(lockKey, issue.ID, issue.State, dataSeq)
 	})
-	pendingMovedCards := s.kanbanMutations.PendingMovedCards(lockKey, projectID, snapshot)
+	terminalStates := s.kanbanWorkflow.Tracker.TerminalStates
+	if configured := s.kanbanTerminalStatesByProject(projectID)[projectID]; len(configured) > 0 {
+		terminalStates = configured
+	}
+	pendingMovedCards := s.kanbanMutations.PendingMovedCards(lockKey, projectID, snapshot, terminalStates)
 	pendingStates := s.kanbanMutations.SnapshotCardStates(lockKey, projectID, snapshot)
 	kanbanstate.ApplySnapshotIssues(&snapshot, func(issue *telemetry.Issue) {
 		if issue == nil || strings.TrimSpace(issue.ID) == "" || !kanbanstate.SameProject(*issue, projectID, snapshot.Project.ID) {

--- a/internal/web/kanban_test.go
+++ b/internal/web/kanban_test.go
@@ -282,6 +282,42 @@ func TestKanbanSnapshotWithPendingStatesKeepsAdvancedPendingMoveVisible(t *testi
 	}
 }
 
+func TestKanbanSnapshotWithPendingStatesReleasesTerminalCompletedMove(t *testing.T) {
+	t.Parallel()
+
+	server := &Server{
+		kanbanMutations: kanbanstate.NewMutationTracker(),
+		kanbanWorkflow: workflowconfig.Config{
+			Tracker: workflowconfig.Tracker{TerminalStates: []string{"Done", "Cancelled"}},
+		},
+	}
+	issue := telemetry.Issue{
+		ID:         "terminal-card",
+		Identifier: "DDW-439",
+		ProjectID:  "detent",
+		Title:      "Terminal pending card",
+		State:      "Backlog",
+	}
+	server.kanbanMutations.NoteCardState("project:detent", "detent", issue, "Backlog", "Todo", 1)
+
+	got := server.kanbanSnapshotWithPendingStates("project:detent", "detent", telemetry.Snapshot{
+		Project: telemetry.Project{ID: "detent"},
+		Refresh: telemetry.Refresh{DataSeq: 2},
+		Completed: []telemetry.Completed{{
+			Issue: telemetry.Issue{
+				ID:         issue.ID,
+				Identifier: issue.Identifier,
+				ProjectID:  issue.ProjectID,
+				Title:      issue.Title,
+				State:      "Done",
+			},
+		}},
+	})
+	if len(got.BoardIssues) != 0 {
+		t.Fatalf("BoardIssues = %#v, want terminal completion released", got.BoardIssues)
+	}
+}
+
 func TestKanbanSnapshotWithPendingStatesConcurrentAdvancedRender(t *testing.T) {
 	t.Parallel()
 

--- a/internal/web/kanban_test.go
+++ b/internal/web/kanban_test.go
@@ -239,7 +239,7 @@ func TestKanbanSnapshotWithPendingStatesIgnoresCompletedHistoryForMissingPending
 	}
 }
 
-func TestKanbanSnapshotWithPendingStatesClearsCompletedPendingMove(t *testing.T) {
+func TestKanbanSnapshotWithPendingStatesKeepsAdvancedPendingMoveVisible(t *testing.T) {
 	t.Parallel()
 
 	server := &Server{kanbanMutations: kanbanstate.NewMutationTracker()}
@@ -252,7 +252,7 @@ func TestKanbanSnapshotWithPendingStatesClearsCompletedPendingMove(t *testing.T)
 	}
 	server.kanbanMutations.NoteCardState("project:detent", "detent", pendingIssue, "Backlog", "Todo", 1)
 
-	got := server.kanbanSnapshotWithPendingStates("project:detent", "detent", telemetry.Snapshot{
+	advancedSnapshot := telemetry.Snapshot{
 		Project: telemetry.Project{ID: "detent"},
 		Refresh: telemetry.Refresh{DataSeq: 2},
 		Completed: []telemetry.Completed{{
@@ -261,20 +261,78 @@ func TestKanbanSnapshotWithPendingStatesClearsCompletedPendingMove(t *testing.T)
 				Identifier: "digitaldrywood/detent#431",
 				ProjectID:  "detent",
 				Title:      "Completed pending card",
-				State:      "Done",
+				State:      "Production",
 			},
 		}},
-	})
-	if len(got.BoardIssues) != 0 {
-		t.Fatalf("BoardIssues = %#v, want no reinserted pending card", got.BoardIssues)
+	}
+	for range 2 {
+		got := server.kanbanSnapshotWithPendingStates("project:detent", "detent", advancedSnapshot)
+		if len(got.BoardIssues) != 1 || got.BoardIssues[0].State != "Production" {
+			t.Fatalf("BoardIssues = %#v, want one Production card", got.BoardIssues)
+		}
 	}
 
-	got = server.kanbanSnapshotWithPendingStates("project:detent", "detent", telemetry.Snapshot{
-		Project:     telemetry.Project{ID: "detent"},
-		BoardIssues: []telemetry.Issue{pendingIssue},
-	})
-	if got.BoardIssues[0].State != "Backlog" {
-		t.Fatalf("pending state = %q, want cleared Backlog", got.BoardIssues[0].State)
+	visibleIssue := advancedSnapshot.Completed[0].Issue
+	visibleSnapshot := advancedSnapshot
+	visibleSnapshot.Refresh.DataSeq = 3
+	visibleSnapshot.Pipeline = []telemetry.Issue{visibleIssue}
+	got := server.kanbanSnapshotWithPendingStates("project:detent", "detent", visibleSnapshot)
+	if len(got.BoardIssues) != 0 || len(got.Pipeline) != 1 || got.Pipeline[0].State != "Production" {
+		t.Fatalf("snapshot issues = BoardIssues %#v, Pipeline %#v; want one visible Production entry", got.BoardIssues, got.Pipeline)
+	}
+}
+
+func TestKanbanSnapshotWithPendingStatesConcurrentAdvancedRender(t *testing.T) {
+	t.Parallel()
+
+	server := &Server{kanbanMutations: kanbanstate.NewMutationTracker()}
+	issue := telemetry.Issue{
+		ID:         "advanced-race-card",
+		Identifier: "DDW-438",
+		ProjectID:  "detent",
+		Title:      "Advanced race card",
+		State:      "Backlog",
+	}
+	server.kanbanMutations.NoteCardState("project:detent", "detent", issue, "Backlog", "Todo", 1)
+	snapshot := telemetry.Snapshot{
+		Project: telemetry.Project{ID: "detent"},
+		Refresh: telemetry.Refresh{DataSeq: 2},
+		Completed: []telemetry.Completed{{
+			Issue: telemetry.Issue{
+				ID:         issue.ID,
+				Identifier: issue.Identifier,
+				ProjectID:  issue.ProjectID,
+				Title:      issue.Title,
+				State:      "Production",
+			},
+		}},
+	}
+
+	start := make(chan struct{})
+	errs := make(chan string, 8)
+	var wg sync.WaitGroup
+	for range 8 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+			for range 100 {
+				got := server.kanbanSnapshotWithPendingStates("project:detent", "detent", snapshot)
+				if len(got.BoardIssues) != 1 || got.BoardIssues[0].State != "Production" {
+					select {
+					case errs <- "advanced card was not rendered exactly once":
+					default:
+					}
+					return
+				}
+			}
+		}()
+	}
+	close(start)
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		t.Fatal(err)
 	}
 }
 


### PR DESCRIPTION
## Summary

- treat newer authoritative third states as successful forward progression without revert feedback
- retain a synthesized authoritative card until a visible snapshot entry takes over
- release terminal completions instead of retaining phantom terminal cards
- cover confirmation, persistent visibility, terminal release, snapshot takeover, and concurrent renders

Fixes #1094

## UI Surface Contract

- [x] N/A; this fixes reconciliation behavior without changing board layout or density.
- [x] This PR does not add persistent top-of-screen messaging.
- [x] No visual layout changes require screenshot verification.

## Test Plan

- [x] `go test -race ./internal/kanban ./internal/web -count=1`
- [x] `make check`