### PR TITLE
fix(orchestrator): allow seeded gate waits

### DIFF
--- a/docs/examples/non-code-artifact/README.md
+++ b/docs/examples/non-code-artifact/README.md
@@ -76,6 +76,10 @@ status values:
 | `invalid` | Route from Review to Rework. |
 | `missing_assets` | Route from Review to Rework. |
 
+A wait value seeded when a work item is created does not park its first
+dispatch. Wait statuses take effect after `render_status` is updated later
+than the time the item entered its current state.
+
 To flip the waiting Review card to approved:
 
 ```sh

--- a/docs/templates/WORKFLOW.non_code_artifact.md
+++ b/docs/templates/WORKFLOW.non_code_artifact.md
@@ -109,6 +109,10 @@ gate:
       - invalid
       - missing_assets
 
+# A wait status parks an item only when the status field is updated after the
+# item enters its current state. A value seeded when the item is created has
+# the same timestamp as the initial state and does not block first dispatch.
+
 server:
   kanban:
     mode: integration

--- a/internal/orchestrator/dispatch_planner.go
+++ b/internal/orchestrator/dispatch_planner.go
@@ -580,7 +580,7 @@ func artifactGateWaitStatusIsCurrent(issue connector.Issue, statusField string) 
 	for field, updatedAt := range issue.FieldUpdatedAt {
 		if strings.EqualFold(strings.TrimSpace(field), strings.TrimSpace(statusField)) &&
 			issue.StageUpdatedAt != nil && !issue.StageUpdatedAt.IsZero() && !updatedAt.IsZero() {
-			return !issue.StageUpdatedAt.After(updatedAt)
+			return updatedAt.After(*issue.StageUpdatedAt)
 		}
 	}
 	if issue.StageUpdatedAt == nil || issue.StageUpdatedAt.IsZero() || issue.UpdatedAt == nil || issue.UpdatedAt.IsZero() {

--- a/internal/orchestrator/dispatch_test.go
+++ b/internal/orchestrator/dispatch_test.go
@@ -688,12 +688,16 @@ func TestDispatchableArtifactGateWaitStatus(t *testing.T) {
 		wantReason     string
 	}{
 		{
-			name:         "fresh item dispatches",
-			state:        "Todo",
-			wantDispatch: true,
+			name:           "fresh item with seeded wait status dispatches",
+			state:          "Todo",
+			status:         "queued",
+			stageUpdatedAt: timePointer(now),
+			updatedAt:      timePointer(now),
+			fieldUpdatedAt: timePointer(now),
+			wantDispatch:   true,
 		},
 		{
-			name:           "mid wait item stays skipped",
+			name:           "post run wait item stays skipped",
 			state:          "Production",
 			status:         "pending_review",
 			stageUpdatedAt: timePointer(now.Add(-2 * time.Minute)),

--- a/internal/orchestrator/local_sqlite_e2e_test.go
+++ b/internal/orchestrator/local_sqlite_e2e_test.go
@@ -141,6 +141,7 @@ func TestLocalSQLiteArtifactLifecycleEndToEnd(t *testing.T) {
 	seed.Identifier = "wi-artifact-1"
 	seed.Title = "Render launch video"
 	seed.State = "Todo"
+	seed.Fields = map[string]string{"render_status": "queued"}
 	seed.Deliverable = &connector.Deliverable{Kind: "artifact"}
 
 	tracker, err := local.New(local.Config{

--- a/internal/orchestrator/snapshot.go
+++ b/internal/orchestrator/snapshot.go
@@ -14,6 +14,7 @@ import (
 )
 
 const (
+	artifactGateStatusMetadataKey = "detent.artifact_gate_status"
 	autoPromoteActionMetadataKey  = "detent.auto_promote_action"
 	autoPromoteReasonMetadataKey  = "detent.auto_promote_reason"
 	dispatchSkipReasonMetadataKey = "detent.dispatch_skip_reason"
@@ -195,6 +196,7 @@ func (s State) applyArtifactGateWaitDispatchSnapshots(snapshots []telemetry.Issu
 			snapshots[i].Metadata = map[string]string{}
 		}
 		snapshots[i].Metadata[dispatchSkipReasonMetadataKey] = dispatchSkipArtifactGateWaitStatus
+		snapshots[i].Metadata[artifactGateStatusMetadataKey] = strings.TrimSpace(artifactStatusFromIssue(issue, s.AutoPromote.Gate.Artifact.StatusField))
 	}
 }
 

--- a/internal/orchestrator/snapshot_test.go
+++ b/internal/orchestrator/snapshot_test.go
@@ -322,12 +322,26 @@ func TestStateSnapshotIncludesArtifactGateWaitDispatchReason(t *testing.T) {
 		FieldUpdatedAt: map[string]time.Time{"render_status": updatedAt},
 		StageUpdatedAt: &stageUpdatedAt,
 		UpdatedAt:      &updatedAt,
+	}, {
+		ID:             "artifact-seeded-wait",
+		Identifier:     "wi-artifact-seeded-wait",
+		State:          "Todo",
+		Fields:         map[string]string{"render_status": "queued"},
+		FieldUpdatedAt: map[string]time.Time{"render_status": updatedAt},
+		StageUpdatedAt: &updatedAt,
+		UpdatedAt:      &updatedAt,
 	}}
 
 	snapshot := state.Snapshot(now)
 
 	if got := snapshot.BoardIssues[0].Metadata["detent.dispatch_skip_reason"]; got != dispatchSkipArtifactGateWaitStatus {
 		t.Fatalf("dispatch skip reason = %q, want %q", got, dispatchSkipArtifactGateWaitStatus)
+	}
+	if got := snapshot.BoardIssues[0].Metadata["detent.artifact_gate_status"]; got != "pending_review" {
+		t.Fatalf("artifact gate status = %q, want pending_review", got)
+	}
+	if got := snapshot.BoardIssues[1].Metadata["detent.dispatch_skip_reason"]; got != "" {
+		t.Fatalf("seeded wait dispatch skip reason = %q, want empty", got)
 	}
 }
 

--- a/internal/web/templates/board_data_test.go
+++ b/internal/web/templates/board_data_test.go
@@ -223,7 +223,7 @@ func TestBoardCardExtraShowsWaitReasonAheadOfCI(t *testing.T) {
 	t.Parallel()
 
 	card := projectKanbanCard{
-		WaitDetail: "dispatch skipped: artifact_gate_wait_status",
+		WaitDetail: "waiting on artifact gate status ('queued')",
 		CIStatus:   "pass",
 	}
 

--- a/internal/web/templates/dashboard_data.go
+++ b/internal/web/templates/dashboard_data.go
@@ -47,6 +47,7 @@ const (
 	projectKanbanAutoPromoteActionMetadataKey     = "detent.auto_promote_action"
 	projectKanbanAutoPromoteReasonMetadataKey     = "detent.auto_promote_reason"
 	projectKanbanDispatchSkipReasonMetadataKey    = "detent.dispatch_skip_reason"
+	projectKanbanArtifactGateStatusMetadataKey    = "detent.artifact_gate_status"
 )
 
 type DashboardData struct {
@@ -3811,6 +3812,11 @@ func prPipelineDispatchSkipWaitReason(issue telemetry.Issue) string {
 	reason := strings.TrimSpace(issue.Metadata[projectKanbanDispatchSkipReasonMetadataKey])
 	if reason == "" {
 		return ""
+	}
+	if reason == "artifact_gate_wait_status" {
+		if status := strings.TrimSpace(issue.Metadata[projectKanbanArtifactGateStatusMetadataKey]); status != "" {
+			return "waiting on artifact gate status ('" + status + "')"
+		}
 	}
 	return "dispatch skipped: " + reason
 }

--- a/internal/web/templates/dashboard_data_test.go
+++ b/internal/web/templates/dashboard_data_test.go
@@ -2818,11 +2818,12 @@ func TestPRPipelineWaitDetailIncludesDispatchSkipReason(t *testing.T) {
 		State: "Todo",
 		Metadata: map[string]string{
 			"detent.dispatch_skip_reason": "artifact_gate_wait_status",
+			"detent.artifact_gate_status": "queued",
 		},
 	}
 
-	if got := prPipelineWaitDetail(issue); got != "dispatch skipped: artifact_gate_wait_status" {
-		t.Fatalf("prPipelineWaitDetail() = %q, want dispatch skip reason", got)
+	if got := prPipelineWaitDetail(issue); got != "waiting on artifact gate status ('queued')" {
+		t.Fatalf("prPipelineWaitDetail() = %q, want artifact gate status", got)
 	}
 }
 


### PR DESCRIPTION
## Summary

- treat creation-time artifact wait statuses as inert for first dispatch
- preserve waits written after an item enters its current state
- show the current artifact gate status in the board wait hint
- document seeded wait-status semantics for artifact workflows

Fixes #1174

## Test Plan

- `go test ./internal/orchestrator -run '^(TestDispatchableArtifactGateWaitStatus|TestStateSnapshotIncludesArtifactGateWaitDispatchReason|TestTransitionActiveArtifactGateWaitIssuesReconcilesToReviewAfterRestart|TestLocalSQLiteArtifactLifecycleEndToEnd)$' -count=1 -v`
- `go test ./internal/web/templates -run '^(TestPRPipelineWaitDetailIncludesDispatchSkipReason|TestBoardCardExtraShowsWaitReasonAheadOfCI)$' -count=1 -v`
- `make check`