### PR TITLE
fix(autopromote): skip same-state routing

### DIFF
--- a/internal/orchestrator/autopromote_tick.go
+++ b/internal/orchestrator/autopromote_tick.go
@@ -2123,6 +2123,10 @@ func (o *Orchestrator) applyAutoPromoteDecision(
 	targetState string,
 	now time.Time,
 ) bool {
+	if normalizeState(issue.State) == normalizeState(targetState) {
+		return false
+	}
+
 	issueID := strings.TrimSpace(issue.ID)
 	transitionReason := string(decision.Reason)
 	body := autoPromoteComment(summary, decision, displayStateName(issue.State), targetState)

--- a/internal/orchestrator/autopromote_tick_test.go
+++ b/internal/orchestrator/autopromote_tick_test.go
@@ -320,6 +320,108 @@ func TestTickAutoPromoteHumanReviewIssues(t *testing.T) {
 	}
 }
 
+func TestApplyAutoPromoteDecisionArtifactReworkTicks(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name         string
+		initialState string
+		statuses     []string
+		wantWrites   int
+	}{
+		{
+			name:         "already in rework remains a no-op",
+			initialState: "Rework",
+			statuses:     []string{"recut", "recut", "changes_requested", "changes_requested", "recut"},
+			wantWrites:   0,
+		},
+		{
+			name:         "source routes once and changed rework status remains a no-op",
+			initialState: "Review",
+			statuses:     []string{"recut", "recut", "changes_requested", "changes_requested", "recut"},
+			wantWrites:   1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			cfg := normalizeConfig(Config{
+				AutoPromote: AutoPromoteConfig{
+					Enabled:     true,
+					SourceState: "Review",
+					PassState:   "Ready for Pickup",
+					ReworkState: "Rework",
+					Gate: gate.Config{
+						Kind: gate.KindArtifact,
+						Artifact: gate.ArtifactConfig{
+							StatusField:    "render_status",
+							PassStatuses:   []string{"approved"},
+							WaitStatuses:   []string{"queued"},
+							ReworkStatuses: []string{"recut", "changes_requested"},
+						},
+					},
+				},
+				ActiveStates:   []string{"Todo", "In Progress", "Rework"},
+				ObservedStates: []string{"Review"},
+				TerminalStates: []string{"Done", "Cancelled"},
+			})
+			issue := autoPromoteTickIssue("issue-artifact-rework", nil, nil)
+			issue.State = tt.initialState
+			tracker := &autoPromoteTickConnector{stateIssues: []connector.Issue{issue}}
+			orch := &Orchestrator{
+				cfg:       cfg,
+				connector: tracker,
+				logger:    slog.New(slog.NewTextHandler(io.Discard, nil)),
+			}
+			state := newState(cfg)
+			now := time.Date(2026, 7, 12, 12, 0, 0, 0, time.UTC)
+
+			for tick, status := range tt.statuses {
+				current := cloneIssue(tracker.stateIssues[0])
+				current.Fields = map[string]string{"render_status": status}
+				summary := AutoPromoteSummaryFromIssue(current)
+				summary.ArtifactStatus = status
+				decision := EvaluateAutoPromote(current, summary, cfg.AutoPromote, now.Add(time.Duration(tick)*time.Minute))
+				if decision.Action != AutoPromoteActionRework {
+					t.Fatalf("tick %d decision = %#v, want rework", tick, decision)
+				}
+				targetState := autoPromoteTargetState(decision.Action, cfg.AutoPromote)
+				orch.applyAutoPromoteDecision(
+					t.Context(),
+					&state,
+					current,
+					summary,
+					decision,
+					targetState,
+					now.Add(time.Duration(tick)*time.Minute),
+				)
+			}
+
+			if got := len(tracker.updates); got != tt.wantWrites {
+				t.Fatalf("state updates = %d, want %d: %#v", got, tt.wantWrites, tracker.updates)
+			}
+			if got := len(tracker.comments); got != tt.wantWrites {
+				t.Fatalf("comments = %d, want %d: %#v", got, tt.wantWrites, tracker.comments)
+			}
+			if got := len(state.RecentEvents); got != tt.wantWrites {
+				t.Fatalf("recent events = %d, want %d: %#v", got, tt.wantWrites, state.RecentEvents)
+			}
+			if tt.wantWrites == 1 {
+				for _, fragment := range []string{
+					"Auto-promote routed this issue from Review to Rework.",
+					"reason: artifact_status_rework",
+				} {
+					if !strings.Contains(tracker.comments[0].body, fragment) {
+						t.Fatalf("comment %q missing fragment %q", tracker.comments[0].body, fragment)
+					}
+				}
+			}
+		})
+	}
+}
+
 func TestTickAutoPromoteCompletedActiveIssues(t *testing.T) {
 	t.Parallel()
 

--- a/internal/orchestrator/completion_transition.go
+++ b/internal/orchestrator/completion_transition.go
@@ -188,10 +188,13 @@ func (o *Orchestrator) tryDirectCompletedActiveAutoPromote(
 		o.logAutoPromoteDecision(issue, decision, "")
 		return false, connector.Issue{}
 	}
+	promoted := promotedIssue(issue, targetState, now)
+	if normalizeState(issue.State) == normalizeState(targetState) {
+		return true, promoted
+	}
 	if !o.applyAutoPromoteDecision(ctx, state, issue, summary, decision, targetState, now) {
 		return false, connector.Issue{}
 	}
-	promoted := promotedIssue(issue, targetState, now)
 	return true, promoted
 }
 

--- a/internal/orchestrator/completion_transition_test.go
+++ b/internal/orchestrator/completion_transition_test.go
@@ -370,6 +370,50 @@ func TestTransitionCompletedActiveIssuesLeavesAutoPromoteIssueActive(t *testing.
 	}
 }
 
+func TestTransitionCompletedActiveIssuesHandlesArtifactReworkNoop(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 7, 12, 13, 0, 0, 0, time.UTC)
+	issue := artifactCompletionTransitionIssue("Rework", "recut")
+	tracker := &autoPromoteTickConnector{stateIssues: []connector.Issue{issue}}
+	cfg := normalizeConfig(Config{
+		AutoPromote: AutoPromoteConfig{
+			Enabled:     true,
+			SourceState: "Review",
+			PassState:   "Ready for Pickup",
+			ReworkState: "Rework",
+			Gate:        artifactCompletionTestGate(),
+		},
+		ActiveStates:   []string{"Todo", "Production", "Rework"},
+		ObservedStates: []string{"Review"},
+		TerminalStates: []string{"Ready for Pickup", "Done", "Cancelled"},
+	})
+	orch := &Orchestrator{cfg: cfg, connector: tracker}
+	state := newState(cfg)
+	state.Completed[issue.ID] = Completed{
+		Issue:      issue,
+		FinalState: FinalStateCompleted,
+	}
+
+	result := orch.transitionCompletedActiveIssuesToReview(t.Context(), &state, []connector.Issue{issue}, now)
+
+	if _, ok := result.transitioned[issue.ID]; !ok {
+		t.Fatalf("transitioned[%q] missing", issue.ID)
+	}
+	if len(tracker.updates) != 0 {
+		t.Fatalf("updates = %#v, want none", tracker.updates)
+	}
+	if len(tracker.comments) != 0 {
+		t.Fatalf("comments = %#v, want none", tracker.comments)
+	}
+	if got := state.Completed[issue.ID].Issue.State; got != "Rework" {
+		t.Fatalf("Completed issue state = %q, want Rework", got)
+	}
+	if len(state.RecentEvents) != 0 {
+		t.Fatalf("RecentEvents = %#v, want none", state.RecentEvents)
+	}
+}
+
 func TestTransitionCompletedActiveIssuesRoutesInvalidWorkpadStatusToRework(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

- Treat normalized same-state auto-promote routes as no-ops before connector, comment, or telemetry side effects.
- Preserve direct completed-artifact routing semantics so handled Rework no-ops cannot fall back to Review.
- Add artifact rework regression coverage for repeated ticks, changed rework statuses, and completed-active reconciliation.

Fixes #1176

## UI Surface Contract

- [x] N/A; this PR does not change UI surfaces.
- [x] This PR does not add persistent top-of-screen messaging.
- [x] N/A; this PR has no visual changes.

## Test Plan

- [x] `go test ./internal/orchestrator -run '^(TestTransitionCompletedActiveIssuesHandlesArtifactReworkNoop|TestApplyAutoPromoteDecisionArtifactReworkTicks)$' -count=1 -v`
- [x] `go test ./internal/orchestrator -count=1`
- [x] `make check`
