### PR TITLE
fix(lifecycle): reap orphan worker groups

### DIFF
--- a/.detent/skills/worker-process-lifecycle.md
+++ b/.detent/skills/worker-process-lifecycle.md
@@ -1,0 +1,14 @@
+---
+name: worker-process-lifecycle
+description: Preserve Detent ownership of paid worker process trees across forced shutdowns and restarts.
+when_to_use: Use when changing Codex or Claude process launch, cancellation, shutdown, startup recovery, or session persistence.
+---
+
+# Worker process lifecycle
+
+- Configure every paid worker command through `internal/procgroup` before `Start` so its descendants share a dedicated process group while remaining in Detent's service cgroup.
+- Inspect the launched process and persist PID, PGID, and OS start time on the Detent session before provider work begins.
+- Validate PID and start time before signaling a recovered process record so PID reuse cannot terminate an unrelated process.
+- On forced shutdown or startup recovery, send SIGTERM to the process group, wait for the bounded grace period, then send SIGKILL and verify the group exited.
+- Log one INFO lifecycle decision with the issue identifier for every persisted worker record and record the reap outcome.
+- Test launch journaling, stale-identity refusal, process-group escalation, startup recovery, and drain-timeout cleanup without signaling the live Detent instance.

--- a/README.md
+++ b/README.md
@@ -1967,6 +1967,13 @@ service PATH resolves every command used by project hooks and validation gates;
 `doctor` checks Detent's direct dependencies, not repo-specific bootstrap tools.
 The onboarding runbook includes the service-context check.
 
+Keep systemd's default `KillMode=control-group` for the Detent service. Detent
+starts each Codex and Claude worker in its own process group without leaving the
+service cgroup, so its persisted worker registry can terminate stale process
+groups on shutdown or startup while systemd remains the final cleanup backstop.
+Do not wrap worker commands in launchers that double-fork or explicitly move
+children into another cgroup.
+
 ### Merge Train
 
 `Merging` is intentionally serialized. Keep this in every production workflow:

--- a/db/queries/store.sql
+++ b/db/queries/store.sql
@@ -119,6 +119,36 @@ SET provider_thread_id = COALESCE(sqlc.narg(provider_thread_id), provider_thread
     provider_session_id = COALESCE(sqlc.narg(provider_session_id), provider_session_id)
 WHERE id = sqlc.arg(id);
 
+-- name: UpdateCodexSessionWorkerProcess :execrows
+UPDATE codex_sessions
+SET worker_pid = sqlc.arg(worker_pid),
+    worker_pgid = sqlc.arg(worker_pgid),
+    worker_started_at = sqlc.arg(worker_started_at),
+    worker_reaped_at = NULL,
+    worker_reap_outcome = NULL
+WHERE id = sqlc.arg(id);
+
+-- name: ListActiveWorkerProcesses :many
+SELECT
+  id AS session_id,
+  CAST(COALESCE(issue_id, '') AS TEXT) AS issue_id,
+  CAST(COALESCE(identifier, '') AS TEXT) AS identifier,
+  CAST(COALESCE(issue_url, '') AS TEXT) AS issue_url,
+  CAST(worker_pid AS INTEGER) AS worker_pid,
+  CAST(COALESCE(worker_pgid, 0) AS INTEGER) AS worker_pgid,
+  CAST(worker_started_at AS TEXT) AS worker_started_at
+FROM codex_sessions
+WHERE completed_at IS NULL
+  AND worker_reaped_at IS NULL
+  AND COALESCE(worker_pid, 0) > 0
+ORDER BY started_at, id;
+
+-- name: MarkCodexSessionWorkerProcessReaped :execrows
+UPDATE codex_sessions
+SET worker_reaped_at = sqlc.arg(worker_reaped_at),
+    worker_reap_outcome = sqlc.arg(worker_reap_outcome)
+WHERE id = sqlc.arg(id);
+
 -- name: UpdateCodexSessionResumeState :execrows
 UPDATE codex_sessions
 SET resumed_from_session_id = sqlc.narg(resumed_from_session_id),

--- a/docs/ONBOARDING.md
+++ b/docs/ONBOARDING.md
@@ -2523,6 +2523,12 @@ awk 'NF {last=$0} END {exit last == "MUTATION_CONFIRMED=true" ? 0 : 1}' "$ONBOAR
    Environment=PATH=/home/<user>/.local/bin:/home/<user>/.asdf/shims:/home/<user>/.cargo/bin:/usr/local/bin:/usr/bin:/bin
    ```
 
+   Keep the service's default `KillMode=control-group`. Detent gives each worker
+   a dedicated process group but leaves it inside the service cgroup; persisted
+   process identity lets Detent reap stale workers, and systemd then remains the
+   final backstop. Reject worker launch wrappers that double-fork or move the
+   worker into another cgroup.
+
    When the project defines `hooks.after_create` or other bootstrap hooks,
    dry-run that hook or the equivalent repo bootstrap script from an isolated
    throwaway worktree with the same service PATH before moving an issue to

--- a/internal/claudecode/process.go
+++ b/internal/claudecode/process.go
@@ -50,11 +50,20 @@ func (b *AgentBackend) RunTurn(
 		return runner.AgentTurnResult{}, fmt.Errorf("start claude command: %w", err)
 	}
 	processGroupID := procgroup.GroupID(cmd)
+	workerProcess, err := procgroup.Inspect(cmd)
+	if err != nil {
+		err = terminateWithCause(cmd, processGroupID, fmt.Errorf("inspect claude worker process: %w", err))
+		if waitErr := waitAndCleanup(cmd, processGroupID); waitErr != nil {
+			err = errors.Join(err, waitErr)
+		}
+		return runner.AgentTurnResult{}, err
+	}
 
 	processIdentity := "claude-" + strconv.Itoa(cmd.Process.Pid)
 	if err := emitUpdate(onUpdate, runner.AgentUpdate{
 		Type:            runner.AgentUpdateProcessStarted,
 		ProcessIdentity: processIdentity,
+		WorkerProcess:   workerProcess,
 	}); err != nil {
 		err = terminateWithCause(cmd, processGroupID, err)
 		if waitErr := waitAndCleanup(cmd, processGroupID); waitErr != nil {

--- a/internal/cli/boot.go
+++ b/internal/cli/boot.go
@@ -30,6 +30,7 @@ import (
 	"github.com/digitaldrywood/detent/internal/hub"
 	"github.com/digitaldrywood/detent/internal/instancelock"
 	"github.com/digitaldrywood/detent/internal/orchestrator"
+	"github.com/digitaldrywood/detent/internal/procgroup"
 	"github.com/digitaldrywood/detent/internal/project"
 	"github.com/digitaldrywood/detent/internal/scheduler"
 	"github.com/digitaldrywood/detent/internal/store"
@@ -209,11 +210,6 @@ func startRunning(ctx context.Context, cfg BootConfig) error {
 	if err != nil {
 		return err
 	}
-	if cfg.Isolated != nil && cfg.Isolated.Demo == "screenshots" {
-		if err := demofixtures.SeedUsageEvents(runCtx, runtimeStore); err != nil {
-			return err
-		}
-	}
 	defer func() {
 		stop()
 		closeStarted := logShutdownBoundaryBegin(logger, "runtime_store_close", "component", "runtime_store")
@@ -224,6 +220,14 @@ func startRunning(ctx context.Context, cfg BootConfig) error {
 			logShutdownBoundaryEnd(logger, "runtime_store_close", closeStarted, nil, "component", "runtime_store")
 		}
 	}()
+	if err := reapWorkerProcesses(runCtx, runtimeStore, logger, "startup", procgroup.DefaultTerminationGrace, time.Now, nil); err != nil {
+		return fmt.Errorf("reap worker processes from prior instance: %w", err)
+	}
+	if cfg.Isolated != nil && cfg.Isolated.Demo == "screenshots" {
+		if err := demofixtures.SeedUsageEvents(runCtx, runtimeStore); err != nil {
+			return err
+		}
+	}
 
 	events := hub.New[project.Event]()
 	activityBroker := activity.NewBroker()
@@ -368,6 +372,8 @@ func startRunning(ctx context.Context, cfg BootConfig) error {
 				},
 				ProgressInterval: defaultShutdownProgressInterval,
 				HardTimeout:      defaultShutdownHardTimeout,
+				WorkerProcesses:  runtimeStore,
+				WorkerReapGrace:  procgroup.DefaultTerminationGrace,
 			}, func(ctx context.Context) error {
 				return serveWithTerminalDashboard(ctx, server, listener, snapshotHub, cfg.Build, runtimeLogPath(cfg), func() time.Duration {
 					return shutdownDrainTimeout(manager.Registry())
@@ -402,6 +408,8 @@ func startRunning(ctx context.Context, cfg BootConfig) error {
 			},
 			ProgressInterval: defaultShutdownProgressInterval,
 			HardTimeout:      defaultShutdownHardTimeout,
+			WorkerProcesses:  runtimeStore,
+			WorkerReapGrace:  procgroup.DefaultTerminationGrace,
 		}, func(ctx context.Context) error {
 			return serve(ctx, server, listener)
 		})

--- a/internal/cli/shutdown.go
+++ b/internal/cli/shutdown.go
@@ -156,6 +156,9 @@ type runningShutdownConfig struct {
 	DrainTimeoutSource func() time.Duration
 	ProgressInterval   time.Duration
 	HardTimeout        time.Duration
+	WorkerProcesses    workerProcessStore
+	ReapWorkerProcess  workerProcessReapFunc
+	WorkerReapGrace    time.Duration
 	Now                func() time.Time
 }
 
@@ -336,9 +339,23 @@ func runForceShutdownWithDeadline(
 	}); err != nil {
 		shutdownLogger(cfg).Warn("force shutdown cleanup failed", "error", err)
 	}
+	reapCtx, cancelReap := context.WithTimeout(context.Background(), hardTimeout)
+	reapErr := reapWorkerProcesses(
+		reapCtx,
+		cfg.WorkerProcesses,
+		shutdownLogger(cfg),
+		result,
+		cfg.WorkerReapGrace,
+		cfg.Now,
+		cfg.ReapWorkerProcess,
+	)
+	cancelReap()
+	if reapErr != nil {
+		shutdownLogger(cfg).Warn("worker process cleanup failed", "error", reapErr)
+	}
 	publishShutdownSnapshot(forceCtx, cfg, startedAt)
 
-	return completeShutdown(forceCtx, cfg, cancelServe, serveErrs, startedAt, machine, returnErr)
+	return errors.Join(completeShutdown(forceCtx, cfg, cancelServe, serveErrs, startedAt, machine, returnErr), reapErr)
 }
 
 func completeShutdown(

--- a/internal/cli/shutdown_test.go
+++ b/internal/cli/shutdown_test.go
@@ -16,7 +16,9 @@ import (
 	"github.com/digitaldrywood/detent/internal/connector"
 	"github.com/digitaldrywood/detent/internal/hub"
 	"github.com/digitaldrywood/detent/internal/orchestrator"
+	"github.com/digitaldrywood/detent/internal/procgroup"
 	projectpkg "github.com/digitaldrywood/detent/internal/project"
+	"github.com/digitaldrywood/detent/internal/store"
 	"github.com/digitaldrywood/detent/internal/telemetry"
 )
 
@@ -490,6 +492,17 @@ func TestRunWithShutdownActiveChildProcessReportsDrainBlockersAndTimesOut(t *tes
 	var output bytes.Buffer
 	var logs bytes.Buffer
 	logger := slog.New(slog.NewTextHandler(&logs, &slog.HandlerOptions{Level: slog.LevelDebug}))
+	processStartedAt := time.Date(2026, 6, 23, 14, 59, 0, 0, time.UTC)
+	processStore := &shutdownWorkerProcessStore{processes: []store.WorkerProcess{{
+		SessionID:  1214,
+		IssueID:    "issue-641",
+		Identifier: "digitaldrywood/detent#641",
+		WorkerProcessIdentity: store.WorkerProcessIdentity{
+			PID:       4242,
+			GroupID:   4242,
+			StartedAt: processStartedAt,
+		},
+	}}}
 	errs := make(chan error, 1)
 
 	go func() {
@@ -502,6 +515,13 @@ func TestRunWithShutdownActiveChildProcessReportsDrainBlockersAndTimesOut(t *tes
 			DrainTimeout:     20 * time.Millisecond,
 			ProgressInterval: 5 * time.Millisecond,
 			HardTimeout:      time.Second,
+			WorkerProcesses:  processStore,
+			ReapWorkerProcess: func(_ context.Context, identity procgroup.Identity, _ time.Duration) (procgroup.TerminationOutcome, error) {
+				if identity.PID != 4242 || identity.GroupID != 4242 || !identity.StartedAt.Equal(processStartedAt) {
+					t.Errorf("worker identity = %#v", identity)
+				}
+				return procgroup.TerminationOutcomeTerminated, nil
+			},
 			Now: func() time.Time {
 				return time.Date(2026, 6, 23, 15, 0, 0, 0, time.UTC)
 			},
@@ -532,6 +552,9 @@ func TestRunWithShutdownActiveChildProcessReportsDrainBlockersAndTimesOut(t *tes
 	case <-time.After(time.Second):
 		t.Fatal("runner was not canceled by forced shutdown")
 	}
+	if len(processStore.reaped) != 1 || processStore.reaped[0].sessionID != 1214 || processStore.reaped[0].reap.Outcome != store.WorkerProcessOutcomeTerminated {
+		t.Fatalf("reaped worker processes = %#v", processStore.reaped)
+	}
 
 	gotOutput := output.String()
 	for _, want := range []string{
@@ -556,11 +579,33 @@ func TestRunWithShutdownActiveChildProcessReportsDrainBlockersAndTimesOut(t *tes
 		"process=4242",
 		"session=thread-641-turn-1",
 		"digitaldrywood/detent#641",
+		"worker process lifecycle decision",
+		"reason=\"drain timeout\"",
+		"decision=terminated",
 	} {
 		if !strings.Contains(gotLogs, want) {
 			t.Fatalf("logs missing %q:\n%s", want, gotLogs)
 		}
 	}
+}
+
+type shutdownWorkerProcessStore struct {
+	processes []store.WorkerProcess
+	reaped    []shutdownWorkerProcessReap
+}
+
+type shutdownWorkerProcessReap struct {
+	sessionID int64
+	reap      store.WorkerProcessReap
+}
+
+func (s *shutdownWorkerProcessStore) ListActiveWorkerProcesses(context.Context) ([]store.WorkerProcess, error) {
+	return append([]store.WorkerProcess(nil), s.processes...), nil
+}
+
+func (s *shutdownWorkerProcessStore) MarkSessionWorkerProcessReaped(_ context.Context, sessionID int64, reap store.WorkerProcessReap) error {
+	s.reaped = append(s.reaped, shutdownWorkerProcessReap{sessionID: sessionID, reap: reap})
+	return nil
 }
 
 func TestRunWithShutdownMarksControllerActive(t *testing.T) {

--- a/internal/cli/worker_processes.go
+++ b/internal/cli/worker_processes.go
@@ -1,0 +1,82 @@
+package cli
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"strings"
+	"time"
+
+	"github.com/digitaldrywood/detent/internal/procgroup"
+	"github.com/digitaldrywood/detent/internal/store"
+)
+
+type workerProcessStore interface {
+	ListActiveWorkerProcesses(context.Context) ([]store.WorkerProcess, error)
+	MarkSessionWorkerProcessReaped(context.Context, int64, store.WorkerProcessReap) error
+}
+
+type workerProcessReapFunc func(context.Context, procgroup.Identity, time.Duration) (procgroup.TerminationOutcome, error)
+
+func reapWorkerProcesses(
+	ctx context.Context,
+	processStore workerProcessStore,
+	logger *slog.Logger,
+	reason string,
+	grace time.Duration,
+	now func() time.Time,
+	reap workerProcessReapFunc,
+) error {
+	if processStore == nil {
+		return nil
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if logger == nil {
+		logger = slog.Default()
+	}
+	if now == nil {
+		now = time.Now
+	}
+	if reap == nil {
+		reap = procgroup.Terminate
+	}
+	processes, err := processStore.ListActiveWorkerProcesses(ctx)
+	if err != nil {
+		return err
+	}
+	var result error
+	for _, process := range processes {
+		identity := procgroup.Identity{
+			PID:       process.PID,
+			GroupID:   process.GroupID,
+			StartedAt: process.StartedAt,
+		}
+		outcome, reapErr := reap(ctx, identity, grace)
+		attrs := []any{
+			"operation", "worker_process_reap",
+			"reason", strings.TrimSpace(reason),
+			"decision", string(outcome),
+			"detent_session_id", process.SessionID,
+			"issue_id", strings.TrimSpace(process.IssueID),
+			"issue_identifier", strings.TrimSpace(process.Identifier),
+			"pid", process.PID,
+			"pgid", process.GroupID,
+		}
+		if reapErr != nil {
+			attrs = append(attrs, "error", reapErr)
+			logger.Info("worker process lifecycle decision", attrs...)
+			result = errors.Join(result, reapErr)
+			continue
+		}
+		logger.Info("worker process lifecycle decision", attrs...)
+		if err := processStore.MarkSessionWorkerProcessReaped(ctx, process.SessionID, store.WorkerProcessReap{
+			ReapedAt: now().UTC(),
+			Outcome:  string(outcome),
+		}); err != nil {
+			result = errors.Join(result, err)
+		}
+	}
+	return result
+}

--- a/internal/cli/worker_processes_test.go
+++ b/internal/cli/worker_processes_test.go
@@ -1,0 +1,82 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"log/slog"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/digitaldrywood/detent/internal/procgroup"
+	"github.com/digitaldrywood/detent/internal/store"
+)
+
+func TestReapWorkerProcessesAtStartup(t *testing.T) {
+	t.Parallel()
+
+	startedAt := time.Date(2026, 7, 12, 16, 0, 0, 0, time.UTC)
+	reapedAt := startedAt.Add(time.Minute)
+	processStore := &shutdownWorkerProcessStore{processes: []store.WorkerProcess{
+		{
+			SessionID:  1214,
+			Identifier: "digitaldrywood/detent#1214",
+			WorkerProcessIdentity: store.WorkerProcessIdentity{
+				PID:       4242,
+				GroupID:   4242,
+				StartedAt: startedAt,
+			},
+		},
+		{
+			SessionID:  1215,
+			Identifier: "digitaldrywood/detent#1215",
+			WorkerProcessIdentity: store.WorkerProcessIdentity{
+				PID:       4343,
+				GroupID:   4343,
+				StartedAt: startedAt,
+			},
+		},
+	}}
+	var logs bytes.Buffer
+	logger := slog.New(slog.NewTextHandler(&logs, nil))
+
+	err := reapWorkerProcesses(
+		context.Background(),
+		processStore,
+		logger,
+		"startup",
+		time.Millisecond,
+		func() time.Time { return reapedAt },
+		func(_ context.Context, identity procgroup.Identity, _ time.Duration) (procgroup.TerminationOutcome, error) {
+			if identity.PID == 4242 {
+				return procgroup.TerminationOutcomeTerminated, nil
+			}
+			return procgroup.TerminationOutcomeAlreadyExited, nil
+		},
+	)
+	if err != nil {
+		t.Fatalf("reapWorkerProcesses() error = %v", err)
+	}
+	if len(processStore.reaped) != 2 {
+		t.Fatalf("reaped processes = %#v", processStore.reaped)
+	}
+	if processStore.reaped[0].reap.Outcome != store.WorkerProcessOutcomeTerminated || processStore.reaped[1].reap.Outcome != store.WorkerProcessOutcomeAlreadyExited {
+		t.Fatalf("reap outcomes = %#v", processStore.reaped)
+	}
+	for _, reaped := range processStore.reaped {
+		if !reaped.reap.ReapedAt.Equal(reapedAt) {
+			t.Fatalf("reaped at = %s, want %s", reaped.reap.ReapedAt, reapedAt)
+		}
+	}
+	for _, want := range []string{
+		"reason=startup",
+		"decision=terminated",
+		"decision=already_exited",
+		"issue_identifier=digitaldrywood/detent#1214",
+		"issue_identifier=digitaldrywood/detent#1215",
+	} {
+		if !strings.Contains(logs.String(), want) {
+			t.Fatalf("logs missing %q:\n%s", want, logs.String())
+		}
+	}
+}

--- a/internal/codex/appserver.go
+++ b/internal/codex/appserver.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/digitaldrywood/detent/internal/agentidentity"
+	"github.com/digitaldrywood/detent/internal/procgroup"
 )
 
 const (
@@ -205,6 +206,7 @@ type Update struct {
 	Type                UpdateType
 	Method              string
 	ProcessIdentity     string
+	WorkerProcess       procgroup.Identity
 	ThreadID            string
 	TurnID              string
 	ItemID              string
@@ -322,6 +324,7 @@ func (s *AppServer) RunTurn(ctx context.Context, req RunTurnRequest, onUpdate Up
 			Type:            UpdateProcessStarted,
 			Method:          "process/start",
 			ProcessIdentity: identity,
+			WorkerProcess:   transportWorkerProcess(transport),
 		}, onUpdate); err != nil {
 			return RunTurnResult{}, err
 		}
@@ -1029,6 +1032,16 @@ func transportProcessIdentity(transport Transport) string {
 		return ""
 	}
 	return provider.ProcessIdentity()
+}
+
+func transportWorkerProcess(transport Transport) procgroup.Identity {
+	provider, ok := transport.(interface {
+		WorkerProcess() procgroup.Identity
+	})
+	if !ok {
+		return procgroup.Identity{}
+	}
+	return provider.WorkerProcess()
 }
 
 func updateFromMessage(msg Message) (Update, bool, error) {

--- a/internal/codex/backend.go
+++ b/internal/codex/backend.go
@@ -113,6 +113,7 @@ func agentUpdateFromCodex(update Update) runner.AgentUpdate {
 		Type:                runner.AgentUpdateType(update.Type),
 		Method:              update.Method,
 		ProcessIdentity:     update.ProcessIdentity,
+		WorkerProcess:       update.WorkerProcess,
 		ThreadID:            update.ThreadID,
 		TurnID:              update.TurnID,
 		ProviderSessionID:   providerSessionID,

--- a/internal/codex/transport.go
+++ b/internal/codex/transport.go
@@ -33,6 +33,7 @@ type LocalTransportFactory struct {
 type localTransport struct {
 	cmd            *exec.Cmd
 	processGroupID int
+	workerProcess  procgroup.Identity
 	stdin          io.WriteCloser
 	codec          *Codec
 	received       chan transportResult
@@ -96,10 +97,23 @@ func (f *LocalTransportFactory) NewTransport(ctx context.Context) (Transport, er
 		}
 		return nil, fmt.Errorf("start command: %w", err)
 	}
+	workerProcess, err := procgroup.Inspect(cmd)
+	if err != nil {
+		terminateErr := procgroup.TerminateTree(cmd, procgroup.GroupID(cmd))
+		waitErr := cmd.Wait()
+		closeErr := stdin.Close()
+		return nil, errors.Join(
+			fmt.Errorf("inspect worker process: %w", err),
+			terminateErr,
+			waitErr,
+			closeErr,
+		)
+	}
 
 	transport := &localTransport{
 		cmd:            cmd,
 		processGroupID: procgroup.GroupID(cmd),
+		workerProcess:  workerProcess,
 		stdin:          stdin,
 		codec:          NewCodec(stdout, stdin),
 		received:       make(chan transportResult, 64),
@@ -195,6 +209,10 @@ func (t *localTransport) ProcessIdentity() string {
 		return ""
 	}
 	return strconv.Itoa(t.cmd.Process.Pid)
+}
+
+func (t *localTransport) WorkerProcess() procgroup.Identity {
+	return t.workerProcess
 }
 
 func transportContextError(ctxErr error, operation string, err error) error {

--- a/internal/procgroup/identity.go
+++ b/internal/procgroup/identity.go
@@ -1,0 +1,32 @@
+package procgroup
+
+import (
+	"errors"
+	"os/exec"
+	"time"
+)
+
+const DefaultTerminationGrace = 250 * time.Millisecond
+
+var ErrProcessNotRunning = errors.New("process is not running")
+
+type Identity struct {
+	PID       int
+	GroupID   int
+	StartedAt time.Time
+}
+
+type TerminationOutcome string
+
+const (
+	TerminationOutcomeTerminated    TerminationOutcome = "terminated"
+	TerminationOutcomeAlreadyExited TerminationOutcome = "already_exited"
+	TerminationOutcomeStaleIdentity TerminationOutcome = "stale_identity"
+)
+
+func Inspect(cmd *exec.Cmd) (Identity, error) {
+	if cmd == nil || cmd.Process == nil || cmd.Process.Pid <= 0 {
+		return Identity{}, ErrProcessNotRunning
+	}
+	return inspectProcess(cmd.Process.Pid)
+}

--- a/internal/procgroup/identity.go
+++ b/internal/procgroup/identity.go
@@ -30,3 +30,9 @@ func Inspect(cmd *exec.Cmd) (Identity, error) {
 	}
 	return inspectProcess(cmd.Process.Pid)
 }
+
+func sameIdentity(current Identity, recorded Identity) bool {
+	return current.PID == recorded.PID &&
+		(recorded.GroupID <= 0 || current.GroupID == recorded.GroupID) &&
+		!recorded.StartedAt.IsZero() && current.StartedAt.Equal(recorded.StartedAt)
+}

--- a/internal/procgroup/process_group_other.go
+++ b/internal/procgroup/process_group_other.go
@@ -1,9 +1,10 @@
-//go:build !unix
+//go:build !unix && !windows
 
 package procgroup
 
 import (
 	"context"
+	"errors"
 	"os"
 	"os/exec"
 	"time"
@@ -41,12 +42,5 @@ func Terminate(_ context.Context, identity Identity, _ time.Duration) (Terminati
 	if identity.PID <= 0 {
 		return TerminationOutcomeAlreadyExited, nil
 	}
-	process, err := os.FindProcess(identity.PID)
-	if err != nil {
-		return TerminationOutcomeAlreadyExited, nil
-	}
-	if err := process.Kill(); err != nil {
-		return "", err
-	}
-	return TerminationOutcomeTerminated, nil
+	return "", errors.New("validated worker process termination is unsupported on this platform")
 }

--- a/internal/procgroup/process_group_other.go
+++ b/internal/procgroup/process_group_other.go
@@ -2,7 +2,12 @@
 
 package procgroup
 
-import "os/exec"
+import (
+	"context"
+	"os"
+	"os/exec"
+	"time"
+)
 
 func Configure(cmd *exec.Cmd) {
 	cmd.Cancel = func() error {
@@ -23,4 +28,25 @@ func TerminateTree(cmd *exec.Cmd, _ int) error {
 
 func Cleanup(int) error {
 	return nil
+}
+
+func inspectProcess(pid int) (Identity, error) {
+	if pid <= 0 {
+		return Identity{}, ErrProcessNotRunning
+	}
+	return Identity{PID: pid, StartedAt: time.Now().UTC()}, nil
+}
+
+func Terminate(_ context.Context, identity Identity, _ time.Duration) (TerminationOutcome, error) {
+	if identity.PID <= 0 {
+		return TerminationOutcomeAlreadyExited, nil
+	}
+	process, err := os.FindProcess(identity.PID)
+	if err != nil {
+		return TerminationOutcomeAlreadyExited, nil
+	}
+	if err := process.Kill(); err != nil {
+		return "", err
+	}
+	return TerminationOutcomeTerminated, nil
 }

--- a/internal/procgroup/process_group_unix.go
+++ b/internal/procgroup/process_group_unix.go
@@ -136,12 +136,6 @@ func inspectProcess(pid int) (Identity, error) {
 	return Identity{PID: pid, GroupID: groupID, StartedAt: startedAt.UTC()}, nil
 }
 
-func sameIdentity(current Identity, recorded Identity) bool {
-	return current.PID == recorded.PID &&
-		(recorded.GroupID <= 0 || current.GroupID == recorded.GroupID) &&
-		!recorded.StartedAt.IsZero() && current.StartedAt.Equal(recorded.StartedAt)
-}
-
 func signalProcessTarget(pid int, groupID int, signal syscall.Signal) error {
 	if groupID > 0 {
 		return syscall.Kill(-groupID, signal)

--- a/internal/procgroup/process_group_unix.go
+++ b/internal/procgroup/process_group_unix.go
@@ -3,9 +3,15 @@
 package procgroup
 
 import (
+	"context"
 	"errors"
+	"fmt"
+	"os"
 	"os/exec"
+	"strconv"
+	"strings"
 	"syscall"
+	"time"
 )
 
 func Configure(cmd *exec.Cmd) {
@@ -52,4 +58,120 @@ func Cleanup(processGroupID int) error {
 		return nil
 	}
 	return err
+}
+
+func Terminate(ctx context.Context, identity Identity, grace time.Duration) (TerminationOutcome, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if identity.PID <= 0 {
+		return TerminationOutcomeAlreadyExited, nil
+	}
+
+	current, err := inspectProcess(identity.PID)
+	if err != nil && !errors.Is(err, ErrProcessNotRunning) {
+		return "", err
+	}
+	if err == nil && !sameIdentity(current, identity) {
+		return TerminationOutcomeStaleIdentity, nil
+	}
+	groupID := identity.GroupID
+	if groupID <= 0 && err == nil {
+		groupID = current.GroupID
+	}
+	if !processTargetAlive(identity.PID, groupID) {
+		return TerminationOutcomeAlreadyExited, nil
+	}
+	if err := signalProcessTarget(identity.PID, groupID, syscall.SIGTERM); err != nil {
+		if errors.Is(err, syscall.ESRCH) {
+			return TerminationOutcomeAlreadyExited, nil
+		}
+		return "", err
+	}
+	if waitForProcessTargetExit(ctx, identity.PID, groupID, grace) {
+		return TerminationOutcomeTerminated, nil
+	}
+	if err := signalProcessTarget(identity.PID, groupID, syscall.SIGKILL); err != nil && !errors.Is(err, syscall.ESRCH) {
+		return "", err
+	}
+	if !waitForProcessTargetExit(context.Background(), identity.PID, groupID, grace) {
+		return "", fmt.Errorf("process group %d remained alive after SIGKILL", groupID)
+	}
+	return TerminationOutcomeTerminated, nil
+}
+
+func inspectProcess(pid int) (Identity, error) {
+	if pid <= 0 {
+		return Identity{}, ErrProcessNotRunning
+	}
+	path, err := exec.LookPath("ps")
+	if err != nil {
+		return Identity{}, fmt.Errorf("locate ps: %w", err)
+	}
+	cmd := &exec.Cmd{
+		Path: path,
+		Args: []string{"ps", "-p", strconv.Itoa(pid), "-o", "pgid=", "-o", "lstart="},
+		Env:  append(os.Environ(), "LC_ALL=C"),
+	}
+	output, err := cmd.Output()
+	if err != nil {
+		var exitErr *exec.ExitError
+		if errors.As(err, &exitErr) {
+			return Identity{}, ErrProcessNotRunning
+		}
+		return Identity{}, fmt.Errorf("inspect process %d: %w", pid, err)
+	}
+	fields := strings.Fields(string(output))
+	if len(fields) != 6 {
+		return Identity{}, fmt.Errorf("inspect process %d: unexpected ps output %q", pid, strings.TrimSpace(string(output)))
+	}
+	groupID, err := strconv.Atoi(fields[0])
+	if err != nil {
+		return Identity{}, fmt.Errorf("inspect process %d group: %w", pid, err)
+	}
+	startedAt, err := time.ParseInLocation("Mon Jan 2 15:04:05 2006", strings.Join(fields[1:], " "), time.Local)
+	if err != nil {
+		return Identity{}, fmt.Errorf("inspect process %d start time: %w", pid, err)
+	}
+	return Identity{PID: pid, GroupID: groupID, StartedAt: startedAt.UTC()}, nil
+}
+
+func sameIdentity(current Identity, recorded Identity) bool {
+	return current.PID == recorded.PID &&
+		(recorded.GroupID <= 0 || current.GroupID == recorded.GroupID) &&
+		!recorded.StartedAt.IsZero() && current.StartedAt.Equal(recorded.StartedAt)
+}
+
+func signalProcessTarget(pid int, groupID int, signal syscall.Signal) error {
+	if groupID > 0 {
+		return syscall.Kill(-groupID, signal)
+	}
+	return syscall.Kill(pid, signal)
+}
+
+func processTargetAlive(pid int, groupID int) bool {
+	err := signalProcessTarget(pid, groupID, 0)
+	return err == nil || errors.Is(err, syscall.EPERM)
+}
+
+func waitForProcessTargetExit(ctx context.Context, pid int, groupID int, grace time.Duration) bool {
+	if grace <= 0 {
+		grace = DefaultTerminationGrace
+	}
+	timer := time.NewTimer(grace)
+	defer timer.Stop()
+	ticker := time.NewTicker(10 * time.Millisecond)
+	defer ticker.Stop()
+	for {
+		if !processTargetAlive(pid, groupID) {
+			return true
+		}
+		select {
+		case <-ctx.Done():
+			return false
+		case <-timer.C:
+			return false
+		case <-ticker.C:
+		}
+	}
 }

--- a/internal/procgroup/process_group_unix_test.go
+++ b/internal/procgroup/process_group_unix_test.go
@@ -197,6 +197,63 @@ func TestCleanup(t *testing.T) {
 	}
 }
 
+func TestInspectAndTerminate(t *testing.T) {
+	tests := []struct {
+		name        string
+		identity    func(Identity) Identity
+		wantOutcome TerminationOutcome
+		wantAlive   bool
+	}{
+		{
+			name:        "matching process group",
+			identity:    func(identity Identity) Identity { return identity },
+			wantOutcome: TerminationOutcomeTerminated,
+		},
+		{
+			name: "stale process start time",
+			identity: func(identity Identity) Identity {
+				identity.StartedAt = identity.StartedAt.Add(time.Second)
+				return identity
+			},
+			wantOutcome: TerminationOutcomeStaleIdentity,
+			wantAlive:   true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			proc := startSleepGroup(t)
+			identity, err := Inspect(proc.cmd)
+			if err != nil {
+				t.Fatalf("Inspect() error = %v", err)
+			}
+			if identity.PID != proc.cmd.Process.Pid || identity.GroupID != GroupID(proc.cmd) || identity.StartedAt.IsZero() {
+				t.Fatalf("Inspect() = %#v", identity)
+			}
+			if !tt.wantAlive {
+				go func() { _ = proc.Wait() }()
+				go func() { _ = proc.WaitGroupMember() }()
+			}
+
+			outcome, err := Terminate(context.Background(), tt.identity(identity), 50*time.Millisecond)
+			if err != nil {
+				t.Fatalf("Terminate() error = %v", err)
+			}
+			if outcome != tt.wantOutcome {
+				t.Fatalf("Terminate() outcome = %q, want %q", outcome, tt.wantOutcome)
+			}
+			if tt.wantAlive {
+				if !processTargetAlive(identity.PID, identity.GroupID) {
+					t.Fatal("Terminate() killed a process with a stale identity")
+				}
+				return
+			}
+			_ = waitForExit(t, proc.Wait)
+			_ = waitForExit(t, proc.WaitGroupMember)
+		})
+	}
+}
+
 type startedProcess struct {
 	cmd           *exec.Cmd
 	wait          sync.Once

--- a/internal/procgroup/process_group_windows.go
+++ b/internal/procgroup/process_group_windows.go
@@ -1,0 +1,108 @@
+//go:build windows
+
+package procgroup
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os/exec"
+	"time"
+
+	"golang.org/x/sys/windows"
+)
+
+func Configure(cmd *exec.Cmd) {
+	cmd.Cancel = func() error {
+		return TerminateTree(cmd, 0)
+	}
+}
+
+func GroupID(*exec.Cmd) int {
+	return 0
+}
+
+func TerminateTree(cmd *exec.Cmd, _ int) error {
+	if cmd == nil || cmd.Process == nil {
+		return nil
+	}
+	return cmd.Process.Kill()
+}
+
+func Cleanup(int) error {
+	return nil
+}
+
+func inspectProcess(pid int) (Identity, error) {
+	handle, err := openProcess(pid, windows.PROCESS_QUERY_LIMITED_INFORMATION)
+	if err != nil {
+		return Identity{}, err
+	}
+	defer windows.CloseHandle(handle)
+	startedAt, err := processStartedAt(handle)
+	if err != nil {
+		return Identity{}, fmt.Errorf("inspect process %d start time: %w", pid, err)
+	}
+	return Identity{PID: pid, StartedAt: startedAt}, nil
+}
+
+func Terminate(_ context.Context, identity Identity, grace time.Duration) (TerminationOutcome, error) {
+	if identity.PID <= 0 {
+		return TerminationOutcomeAlreadyExited, nil
+	}
+	handle, err := openProcess(identity.PID, windows.PROCESS_QUERY_LIMITED_INFORMATION|windows.PROCESS_TERMINATE|windows.SYNCHRONIZE)
+	if errors.Is(err, ErrProcessNotRunning) {
+		return TerminationOutcomeAlreadyExited, nil
+	}
+	if err != nil {
+		return "", err
+	}
+	defer windows.CloseHandle(handle)
+	startedAt, err := processStartedAt(handle)
+	if err != nil {
+		return "", fmt.Errorf("inspect process %d start time: %w", identity.PID, err)
+	}
+	if !sameIdentity(Identity{PID: identity.PID, StartedAt: startedAt}, identity) {
+		return TerminationOutcomeStaleIdentity, nil
+	}
+	if err := windows.TerminateProcess(handle, 1); err != nil {
+		return "", fmt.Errorf("terminate process %d: %w", identity.PID, err)
+	}
+	if grace <= 0 {
+		grace = DefaultTerminationGrace
+	}
+	waitMillis := uint32(max(1, grace.Milliseconds()))
+	event, err := windows.WaitForSingleObject(handle, waitMillis)
+	if err != nil {
+		return "", fmt.Errorf("wait for process %d exit: %w", identity.PID, err)
+	}
+	if event != windows.WAIT_OBJECT_0 {
+		return "", fmt.Errorf("process %d remained alive after termination", identity.PID)
+	}
+	return TerminationOutcomeTerminated, nil
+}
+
+func openProcess(pid int, access uint32) (windows.Handle, error) {
+	if pid <= 0 {
+		return 0, ErrProcessNotRunning
+	}
+	handle, err := windows.OpenProcess(access, false, uint32(pid))
+	if errors.Is(err, windows.ERROR_INVALID_PARAMETER) {
+		return 0, ErrProcessNotRunning
+	}
+	if err != nil {
+		return 0, fmt.Errorf("open process %d: %w", pid, err)
+	}
+	return handle, nil
+}
+
+func processStartedAt(handle windows.Handle) (time.Time, error) {
+	var created windows.Filetime
+	var exited windows.Filetime
+	var kernel windows.Filetime
+	var user windows.Filetime
+	if err := windows.GetProcessTimes(handle, &created, &exited, &kernel, &user); err != nil {
+		return time.Time{}, err
+	}
+	return time.Unix(0, created.Nanoseconds()).UTC(), nil
+}

--- a/internal/procgroup/process_group_windows_test.go
+++ b/internal/procgroup/process_group_windows_test.go
@@ -1,0 +1,65 @@
+//go:build windows
+
+package procgroup
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"testing"
+	"time"
+)
+
+func TestWindowsInspectAndTerminate(t *testing.T) {
+	cmd := exec.Command(os.Args[0], "-test.run=^TestWindowsProcessHelper$")
+	cmd.Env = append(os.Environ(), "DETENT_WINDOWS_PROCESS_HELPER=1")
+	Configure(cmd)
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("Start() error = %v", err)
+	}
+	t.Cleanup(func() {
+		if cmd.ProcessState == nil {
+			_ = cmd.Process.Kill()
+			_ = cmd.Wait()
+		}
+	})
+
+	identity, err := Inspect(cmd)
+	if err != nil {
+		t.Fatalf("Inspect() error = %v", err)
+	}
+	if identity.PID != cmd.Process.Pid || identity.StartedAt.IsZero() {
+		t.Fatalf("Inspect() = %#v", identity)
+	}
+
+	stale := identity
+	stale.StartedAt = stale.StartedAt.Add(time.Second)
+	outcome, err := Terminate(context.Background(), stale, time.Second)
+	if err != nil {
+		t.Fatalf("Terminate(stale) error = %v", err)
+	}
+	if outcome != TerminationOutcomeStaleIdentity {
+		t.Fatalf("Terminate(stale) outcome = %q, want %q", outcome, TerminationOutcomeStaleIdentity)
+	}
+	if _, err := inspectProcess(identity.PID); err != nil {
+		t.Fatalf("process after stale termination error = %v", err)
+	}
+
+	outcome, err = Terminate(context.Background(), identity, time.Second)
+	if err != nil {
+		t.Fatalf("Terminate() error = %v", err)
+	}
+	if outcome != TerminationOutcomeTerminated {
+		t.Fatalf("Terminate() outcome = %q, want %q", outcome, TerminationOutcomeTerminated)
+	}
+	_ = cmd.Wait()
+}
+
+func TestWindowsProcessHelper(t *testing.T) {
+	if os.Getenv("DETENT_WINDOWS_PROCESS_HELPER") != "1" {
+		return
+	}
+	for {
+		time.Sleep(time.Hour)
+	}
+}

--- a/internal/procgroup/process_group_windows_test.go
+++ b/internal/procgroup/process_group_windows_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func TestWindowsInspectAndTerminate(t *testing.T) {
-	cmd := exec.Command(os.Args[0], "-test.run=^TestWindowsProcessHelper$")
+	cmd := exec.CommandContext(context.Background(), os.Args[0], "-test.run=^TestWindowsProcessHelper$")
 	cmd.Env = append(os.Environ(), "DETENT_WINDOWS_PROCESS_HELPER=1")
 	Configure(cmd)
 	if err := cmd.Start(); err != nil {

--- a/internal/runner/agent.go
+++ b/internal/runner/agent.go
@@ -56,6 +56,10 @@ type sessionProviderStore interface {
 	UpdateSessionProviderIdentity(context.Context, int64, store.SessionProviderIdentity) error
 }
 
+type sessionWorkerProcessStore interface {
+	UpdateSessionWorkerProcess(context.Context, int64, store.WorkerProcessIdentity) error
+}
+
 type sessionResumeStore interface {
 	UpdateSessionResumeState(context.Context, int64, store.SessionResumeState) error
 }
@@ -585,6 +589,9 @@ func (r *Runner) runAgentTurn(
 			turnStarted = true
 		}
 		r.logAgentUpdate(runRequest.Issue, update)
+		if err := r.persistSessionWorkerProcess(ctx, detentSessionID, update); err != nil {
+			return err
+		}
 		if err := r.persistSessionProviderIdentity(ctx, detentSessionID, update); err != nil {
 			return err
 		}
@@ -1178,6 +1185,9 @@ func (r *Runner) Validate(ctx context.Context, req ValidatorRequest) (gate.Valid
 			update.RuntimeIdentity = update.RuntimeIdentity.ObserveAt(eventAt)
 		}
 		r.logAgentUpdate(req.Issue, update)
+		if err := r.persistSessionWorkerProcess(ctx, sessionID, update); err != nil {
+			return err
+		}
 		if err := r.persistSessionProviderIdentity(ctx, sessionID, update); err != nil {
 			return err
 		}
@@ -1533,6 +1543,25 @@ func (r *Runner) persistSessionProviderIdentity(ctx context.Context, sessionID i
 		SessionID: providerSessionID,
 	}); err != nil {
 		return fmt.Errorf("update agent session provider identity: %w", err)
+	}
+	return nil
+}
+
+func (r *Runner) persistSessionWorkerProcess(ctx context.Context, sessionID int64, update AgentUpdate) error {
+	identity := update.WorkerProcess
+	if sessionID <= 0 || identity.PID <= 0 || identity.StartedAt.IsZero() {
+		return nil
+	}
+	processStore, ok := r.store.(sessionWorkerProcessStore)
+	if !ok {
+		return nil
+	}
+	if err := processStore.UpdateSessionWorkerProcess(ctx, sessionID, store.WorkerProcessIdentity{
+		PID:       identity.PID,
+		GroupID:   identity.GroupID,
+		StartedAt: identity.StartedAt,
+	}); err != nil {
+		return fmt.Errorf("update agent session worker process: %w", err)
 	}
 	return nil
 }

--- a/internal/runner/runner_test.go
+++ b/internal/runner/runner_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/digitaldrywood/detent/internal/connector"
 	"github.com/digitaldrywood/detent/internal/gate"
 	"github.com/digitaldrywood/detent/internal/notes"
+	"github.com/digitaldrywood/detent/internal/procgroup"
 	"github.com/digitaldrywood/detent/internal/runtimeoutput"
 	"github.com/digitaldrywood/detent/internal/selector"
 	"github.com/digitaldrywood/detent/internal/store"
@@ -37,6 +38,7 @@ func TestRunnerRunPreparesWorkspaceRunsCodexAndRecordsSession(t *testing.T) {
 
 	startedAt := time.Date(2026, 5, 31, 13, 0, 0, 0, time.UTC)
 	completedAt := startedAt.Add(4 * time.Second)
+	processStartedAt := startedAt.Add(500 * time.Millisecond)
 	modelContextWindow := int64(200000)
 	workspaceBackend := &fakeWorkspaceBackend{
 		info: workspace.Info{
@@ -61,10 +63,15 @@ func TestRunnerRunPreparesWorkspaceRunsCodexAndRecordsSession(t *testing.T) {
 			{
 				Type:            AgentUpdateMessageDelta,
 				ProcessIdentity: "4242",
-				ThreadID:        "thread-1",
-				TurnID:          "turn-1",
-				ItemID:          "item-1",
-				Delta:           "hello\nSkill draft: yes — `.detent/skills/debug.md` captures the workflow.",
+				WorkerProcess: procgroup.Identity{
+					PID:       4242,
+					GroupID:   4242,
+					StartedAt: processStartedAt,
+				},
+				ThreadID: "thread-1",
+				TurnID:   "turn-1",
+				ItemID:   "item-1",
+				Delta:    "hello\nSkill draft: yes — `.detent/skills/debug.md` captures the workflow.",
 			},
 			{
 				Type:     AgentUpdateTokenUsage,
@@ -164,6 +171,9 @@ func TestRunnerRunPreparesWorkspaceRunsCodexAndRecordsSession(t *testing.T) {
 
 	if result.FinalState != FinalStateCompleted {
 		t.Fatalf("FinalState = %q, want %q", result.FinalState, FinalStateCompleted)
+	}
+	if len(sessionStore.workerProcesses) != 1 || sessionStore.workerProcesses[0].PID != 4242 || !sessionStore.workerProcesses[0].StartedAt.Equal(processStartedAt) {
+		t.Fatalf("worker process updates = %#v", sessionStore.workerProcesses)
 	}
 	if result.Tokens.TotalTokens != 125 || result.Tokens.RuntimeSeconds != 4 {
 		t.Fatalf("Tokens = %#v, want total 125 and runtime 4s", result.Tokens)
@@ -3736,6 +3746,7 @@ type fakeSessionStore struct {
 	resumeLookups   int
 	resumeLookup    store.AgentResumeLookup
 	providerUpdates []store.SessionProviderIdentity
+	workerProcesses []store.WorkerProcessIdentity
 	resumeUpdates   []store.SessionResumeState
 }
 
@@ -3758,6 +3769,11 @@ func (s *fakeSessionStore) UpdateSessionIdentity(_ context.Context, _ int64, ide
 
 func (s *fakeSessionStore) UpdateSessionProviderIdentity(_ context.Context, _ int64, identity store.SessionProviderIdentity) error {
 	s.providerUpdates = append(s.providerUpdates, identity)
+	return nil
+}
+
+func (s *fakeSessionStore) UpdateSessionWorkerProcess(_ context.Context, _ int64, identity store.WorkerProcessIdentity) error {
+	s.workerProcesses = append(s.workerProcesses, identity)
 	return nil
 }
 

--- a/internal/runner/types.go
+++ b/internal/runner/types.go
@@ -9,6 +9,7 @@ import (
 	"github.com/digitaldrywood/detent/internal/agentidentity"
 	"github.com/digitaldrywood/detent/internal/connector"
 	"github.com/digitaldrywood/detent/internal/gate"
+	"github.com/digitaldrywood/detent/internal/procgroup"
 	"github.com/digitaldrywood/detent/internal/runtimeoutput"
 	"github.com/digitaldrywood/detent/internal/selector"
 	"github.com/digitaldrywood/detent/internal/store"
@@ -172,6 +173,7 @@ type AgentUpdate struct {
 	Type                AgentUpdateType
 	Method              string
 	ProcessIdentity     string
+	WorkerProcess       procgroup.Identity
 	ThreadID            string
 	TurnID              string
 	ProviderSessionID   string

--- a/internal/store/migrations/00017_add_worker_process_registry.sql
+++ b/internal/store/migrations/00017_add_worker_process_registry.sql
@@ -1,0 +1,18 @@
+-- +goose Up
+ALTER TABLE codex_sessions ADD COLUMN worker_pid INTEGER;
+ALTER TABLE codex_sessions ADD COLUMN worker_pgid INTEGER;
+ALTER TABLE codex_sessions ADD COLUMN worker_started_at TEXT;
+ALTER TABLE codex_sessions ADD COLUMN worker_reaped_at TEXT;
+ALTER TABLE codex_sessions ADD COLUMN worker_reap_outcome TEXT;
+
+CREATE INDEX codex_sessions_active_worker_idx
+ON codex_sessions(completed_at, worker_reaped_at, worker_pid);
+
+-- +goose Down
+DROP INDEX IF EXISTS codex_sessions_active_worker_idx;
+
+ALTER TABLE codex_sessions DROP COLUMN worker_reap_outcome;
+ALTER TABLE codex_sessions DROP COLUMN worker_reaped_at;
+ALTER TABLE codex_sessions DROP COLUMN worker_started_at;
+ALTER TABLE codex_sessions DROP COLUMN worker_pgid;
+ALTER TABLE codex_sessions DROP COLUMN worker_pid;

--- a/internal/store/sqlc/models.go
+++ b/internal/store/sqlc/models.go
@@ -72,6 +72,11 @@ type CodexSession struct {
 	OrphanRecoveryOutcome        sql.NullString `json:"orphan_recovery_outcome"`
 	SkillDraftProposed           int64          `json:"skill_draft_proposed"`
 	OrphanRecoveryFallbackReason sql.NullString `json:"orphan_recovery_fallback_reason"`
+	WorkerPid                    sql.NullInt64  `json:"worker_pid"`
+	WorkerPgid                   sql.NullInt64  `json:"worker_pgid"`
+	WorkerStartedAt              sql.NullString `json:"worker_started_at"`
+	WorkerReapedAt               sql.NullString `json:"worker_reaped_at"`
+	WorkerReapOutcome            sql.NullString `json:"worker_reap_outcome"`
 }
 
 type DetentRun struct {

--- a/internal/store/sqlc/store.sql.go
+++ b/internal/store/sqlc/store.sql.go
@@ -363,7 +363,7 @@ INSERT INTO codex_sessions (
   orphan_recovery_outcome,
   orphan_recovery_fallback_reason
 ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-RETURNING id, run_id, issue_id, identifier, issue_url, started_at, completed_at, turns, input_tokens, output_tokens, total_tokens, runtime_seconds, final_state, model, cached_input_tokens, reasoning_output_tokens, model_context_window, requested_model, agent_backend_id, agent_backend_kind, agent_role, provider_thread_id, provider_session_id, resumed_from_session_id, work_attempt_id, agent_route, provider, provider_provenance, requested_model_provenance, model_provenance, reasoning_effort, reasoning_effort_provenance, service_tier, service_tier_provenance, identity_observed_at, orphan_recovery_outcome, skill_draft_proposed, orphan_recovery_fallback_reason
+RETURNING id, run_id, issue_id, identifier, issue_url, started_at, completed_at, turns, input_tokens, output_tokens, total_tokens, runtime_seconds, final_state, model, cached_input_tokens, reasoning_output_tokens, model_context_window, requested_model, agent_backend_id, agent_backend_kind, agent_role, provider_thread_id, provider_session_id, resumed_from_session_id, work_attempt_id, agent_route, provider, provider_provenance, requested_model_provenance, model_provenance, reasoning_effort, reasoning_effort_provenance, service_tier, service_tier_provenance, identity_observed_at, orphan_recovery_outcome, skill_draft_proposed, orphan_recovery_fallback_reason, worker_pid, worker_pgid, worker_started_at, worker_reaped_at, worker_reap_outcome
 `
 
 type CreateCodexSessionParams struct {
@@ -484,6 +484,11 @@ func (q *Queries) CreateCodexSession(ctx context.Context, arg CreateCodexSession
 		&i.OrphanRecoveryOutcome,
 		&i.SkillDraftProposed,
 		&i.OrphanRecoveryFallbackReason,
+		&i.WorkerPid,
+		&i.WorkerPgid,
+		&i.WorkerStartedAt,
+		&i.WorkerReapedAt,
+		&i.WorkerReapOutcome,
 	)
 	return i, err
 }
@@ -1391,7 +1396,7 @@ func (q *Queries) GetAPIKeyByHash(ctx context.Context, keyHash string) (ApiKey, 
 }
 
 const getCodexSession = `-- name: GetCodexSession :one
-SELECT id, run_id, issue_id, identifier, issue_url, started_at, completed_at, turns, input_tokens, output_tokens, total_tokens, runtime_seconds, final_state, model, cached_input_tokens, reasoning_output_tokens, model_context_window, requested_model, agent_backend_id, agent_backend_kind, agent_role, provider_thread_id, provider_session_id, resumed_from_session_id, work_attempt_id, agent_route, provider, provider_provenance, requested_model_provenance, model_provenance, reasoning_effort, reasoning_effort_provenance, service_tier, service_tier_provenance, identity_observed_at, orphan_recovery_outcome, skill_draft_proposed, orphan_recovery_fallback_reason
+SELECT id, run_id, issue_id, identifier, issue_url, started_at, completed_at, turns, input_tokens, output_tokens, total_tokens, runtime_seconds, final_state, model, cached_input_tokens, reasoning_output_tokens, model_context_window, requested_model, agent_backend_id, agent_backend_kind, agent_role, provider_thread_id, provider_session_id, resumed_from_session_id, work_attempt_id, agent_route, provider, provider_provenance, requested_model_provenance, model_provenance, reasoning_effort, reasoning_effort_provenance, service_tier, service_tier_provenance, identity_observed_at, orphan_recovery_outcome, skill_draft_proposed, orphan_recovery_fallback_reason, worker_pid, worker_pgid, worker_started_at, worker_reaped_at, worker_reap_outcome
 FROM codex_sessions
 WHERE id = ?
 `
@@ -1438,6 +1443,11 @@ func (q *Queries) GetCodexSession(ctx context.Context, id int64) (CodexSession, 
 		&i.OrphanRecoveryOutcome,
 		&i.SkillDraftProposed,
 		&i.OrphanRecoveryFallbackReason,
+		&i.WorkerPid,
+		&i.WorkerPgid,
+		&i.WorkerStartedAt,
+		&i.WorkerReapedAt,
+		&i.WorkerReapOutcome,
 	)
 	return i, err
 }
@@ -2143,6 +2153,63 @@ func (q *Queries) ListActiveWorkAttempts(ctx context.Context, filterProjectID in
 	return items, nil
 }
 
+const listActiveWorkerProcesses = `-- name: ListActiveWorkerProcesses :many
+SELECT
+  id AS session_id,
+  CAST(COALESCE(issue_id, '') AS TEXT) AS issue_id,
+  CAST(COALESCE(identifier, '') AS TEXT) AS identifier,
+  CAST(COALESCE(issue_url, '') AS TEXT) AS issue_url,
+  CAST(worker_pid AS INTEGER) AS worker_pid,
+  CAST(COALESCE(worker_pgid, 0) AS INTEGER) AS worker_pgid,
+  CAST(worker_started_at AS TEXT) AS worker_started_at
+FROM codex_sessions
+WHERE completed_at IS NULL
+  AND worker_reaped_at IS NULL
+  AND COALESCE(worker_pid, 0) > 0
+ORDER BY started_at, id
+`
+
+type ListActiveWorkerProcessesRow struct {
+	SessionID       int64  `json:"session_id"`
+	IssueID         string `json:"issue_id"`
+	Identifier      string `json:"identifier"`
+	IssueURL        string `json:"issue_url"`
+	WorkerPid       int64  `json:"worker_pid"`
+	WorkerPgid      int64  `json:"worker_pgid"`
+	WorkerStartedAt string `json:"worker_started_at"`
+}
+
+func (q *Queries) ListActiveWorkerProcesses(ctx context.Context) ([]ListActiveWorkerProcessesRow, error) {
+	rows, err := q.db.QueryContext(ctx, listActiveWorkerProcesses)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []ListActiveWorkerProcessesRow{}
+	for rows.Next() {
+		var i ListActiveWorkerProcessesRow
+		if err := rows.Scan(
+			&i.SessionID,
+			&i.IssueID,
+			&i.Identifier,
+			&i.IssueURL,
+			&i.WorkerPid,
+			&i.WorkerPgid,
+			&i.WorkerStartedAt,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const listFairShareUsage = `-- name: ListFairShareUsage :many
 SELECT
   project_id,
@@ -2550,7 +2617,7 @@ func (q *Queries) ListOrphanedAgentSessions(ctx context.Context, projectID strin
 }
 
 const listRecentCodexSessions = `-- name: ListRecentCodexSessions :many
-SELECT id, run_id, issue_id, identifier, issue_url, started_at, completed_at, turns, input_tokens, output_tokens, total_tokens, runtime_seconds, final_state, model, cached_input_tokens, reasoning_output_tokens, model_context_window, requested_model, agent_backend_id, agent_backend_kind, agent_role, provider_thread_id, provider_session_id, resumed_from_session_id, work_attempt_id, agent_route, provider, provider_provenance, requested_model_provenance, model_provenance, reasoning_effort, reasoning_effort_provenance, service_tier, service_tier_provenance, identity_observed_at, orphan_recovery_outcome, skill_draft_proposed, orphan_recovery_fallback_reason
+SELECT id, run_id, issue_id, identifier, issue_url, started_at, completed_at, turns, input_tokens, output_tokens, total_tokens, runtime_seconds, final_state, model, cached_input_tokens, reasoning_output_tokens, model_context_window, requested_model, agent_backend_id, agent_backend_kind, agent_role, provider_thread_id, provider_session_id, resumed_from_session_id, work_attempt_id, agent_route, provider, provider_provenance, requested_model_provenance, model_provenance, reasoning_effort, reasoning_effort_provenance, service_tier, service_tier_provenance, identity_observed_at, orphan_recovery_outcome, skill_draft_proposed, orphan_recovery_fallback_reason, worker_pid, worker_pgid, worker_started_at, worker_reaped_at, worker_reap_outcome
 FROM codex_sessions
 ORDER BY completed_at DESC, id DESC
 LIMIT ?
@@ -2604,6 +2671,11 @@ func (q *Queries) ListRecentCodexSessions(ctx context.Context, limit int64) ([]C
 			&i.OrphanRecoveryOutcome,
 			&i.SkillDraftProposed,
 			&i.OrphanRecoveryFallbackReason,
+			&i.WorkerPid,
+			&i.WorkerPgid,
+			&i.WorkerStartedAt,
+			&i.WorkerReapedAt,
+			&i.WorkerReapOutcome,
 		); err != nil {
 			return nil, err
 		}
@@ -2838,6 +2910,27 @@ type MarkCodexSessionOrphanedParams struct {
 
 func (q *Queries) MarkCodexSessionOrphaned(ctx context.Context, arg MarkCodexSessionOrphanedParams) (int64, error) {
 	result, err := q.db.ExecContext(ctx, markCodexSessionOrphaned, arg.CompletedAt, arg.ID)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected()
+}
+
+const markCodexSessionWorkerProcessReaped = `-- name: MarkCodexSessionWorkerProcessReaped :execrows
+UPDATE codex_sessions
+SET worker_reaped_at = ?1,
+    worker_reap_outcome = ?2
+WHERE id = ?3
+`
+
+type MarkCodexSessionWorkerProcessReapedParams struct {
+	WorkerReapedAt    sql.NullString `json:"worker_reaped_at"`
+	WorkerReapOutcome sql.NullString `json:"worker_reap_outcome"`
+	ID                int64          `json:"id"`
+}
+
+func (q *Queries) MarkCodexSessionWorkerProcessReaped(ctx context.Context, arg MarkCodexSessionWorkerProcessReapedParams) (int64, error) {
+	result, err := q.db.ExecContext(ctx, markCodexSessionWorkerProcessReaped, arg.WorkerReapedAt, arg.WorkerReapOutcome, arg.ID)
 	if err != nil {
 		return 0, err
 	}
@@ -3323,6 +3416,36 @@ func (q *Queries) UpdateCodexSessionResumeState(ctx context.Context, arg UpdateC
 		arg.ResumedFromSessionID,
 		arg.OrphanRecoveryOutcome,
 		arg.OrphanRecoveryFallbackReason,
+		arg.ID,
+	)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected()
+}
+
+const updateCodexSessionWorkerProcess = `-- name: UpdateCodexSessionWorkerProcess :execrows
+UPDATE codex_sessions
+SET worker_pid = ?1,
+    worker_pgid = ?2,
+    worker_started_at = ?3,
+    worker_reaped_at = NULL,
+    worker_reap_outcome = NULL
+WHERE id = ?4
+`
+
+type UpdateCodexSessionWorkerProcessParams struct {
+	WorkerPid       sql.NullInt64  `json:"worker_pid"`
+	WorkerPgid      sql.NullInt64  `json:"worker_pgid"`
+	WorkerStartedAt sql.NullString `json:"worker_started_at"`
+	ID              int64          `json:"id"`
+}
+
+func (q *Queries) UpdateCodexSessionWorkerProcess(ctx context.Context, arg UpdateCodexSessionWorkerProcessParams) (int64, error) {
+	result, err := q.db.ExecContext(ctx, updateCodexSessionWorkerProcess,
+		arg.WorkerPid,
+		arg.WorkerPgid,
+		arg.WorkerStartedAt,
 		arg.ID,
 	)
 	if err != nil {

--- a/internal/store/sqlite.go
+++ b/internal/store/sqlite.go
@@ -255,6 +255,71 @@ func (s *sqliteStore) UpdateSessionProviderIdentity(ctx context.Context, session
 	return requireAffected(rows, "codex session", sessionID)
 }
 
+func (s *sqliteStore) UpdateSessionWorkerProcess(ctx context.Context, sessionID int64, identity WorkerProcessIdentity) error {
+	if sessionID <= 0 || identity.PID <= 0 || identity.StartedAt.IsZero() {
+		return ErrNotFound
+	}
+	startedAt, err := requiredTimestamp("worker_started_at", identity.StartedAt)
+	if err != nil {
+		return err
+	}
+	rows, err := s.queries.UpdateCodexSessionWorkerProcess(ctx, sqlc.UpdateCodexSessionWorkerProcessParams{
+		WorkerPid:       sql.NullInt64{Int64: int64(identity.PID), Valid: true},
+		WorkerPgid:      sql.NullInt64{Int64: int64(identity.GroupID), Valid: true},
+		WorkerStartedAt: sql.NullString{String: startedAt, Valid: true},
+		ID:              sessionID,
+	})
+	if err != nil {
+		return fmt.Errorf("updating codex session worker process: %w", err)
+	}
+	return requireAffected(rows, "codex session", sessionID)
+}
+
+func (s *sqliteStore) ListActiveWorkerProcesses(ctx context.Context) ([]WorkerProcess, error) {
+	rows, err := s.queries.ListActiveWorkerProcesses(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("listing active worker processes: %w", err)
+	}
+	processes := make([]WorkerProcess, 0, len(rows))
+	for _, row := range rows {
+		startedAt, err := parseTimestamp("worker_started_at", row.WorkerStartedAt)
+		if err != nil {
+			return nil, err
+		}
+		processes = append(processes, WorkerProcess{
+			SessionID:  row.SessionID,
+			IssueID:    strings.TrimSpace(row.IssueID),
+			Identifier: strings.TrimSpace(row.Identifier),
+			IssueURL:   strings.TrimSpace(row.IssueURL),
+			WorkerProcessIdentity: WorkerProcessIdentity{
+				PID:       int(row.WorkerPid),
+				GroupID:   int(row.WorkerPgid),
+				StartedAt: startedAt,
+			},
+		})
+	}
+	return processes, nil
+}
+
+func (s *sqliteStore) MarkSessionWorkerProcessReaped(ctx context.Context, sessionID int64, reap WorkerProcessReap) error {
+	if sessionID <= 0 {
+		return ErrNotFound
+	}
+	reapedAt, err := requiredTimestamp("worker_reaped_at", reap.ReapedAt)
+	if err != nil {
+		return err
+	}
+	rows, err := s.queries.MarkCodexSessionWorkerProcessReaped(ctx, sqlc.MarkCodexSessionWorkerProcessReapedParams{
+		WorkerReapedAt:    sql.NullString{String: reapedAt, Valid: true},
+		WorkerReapOutcome: nullString(reap.Outcome),
+		ID:                sessionID,
+	})
+	if err != nil {
+		return fmt.Errorf("marking codex session worker process reaped: %w", err)
+	}
+	return requireAffected(rows, "codex session", sessionID)
+}
+
 func (s *sqliteStore) UpdateSessionResumeState(ctx context.Context, sessionID int64, state SessionResumeState) error {
 	if sessionID <= 0 {
 		return ErrNotFound

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -17,10 +17,13 @@ type Backend string
 const BackendSQLite Backend = "sqlite"
 
 const (
-	SessionStateRunning   = "running"
-	SessionStateOrphaned  = "orphaned"
-	OrphanRecoveryResumed = "resumed"
-	OrphanRecoveryFresh   = "fresh"
+	SessionStateRunning               = "running"
+	SessionStateOrphaned              = "orphaned"
+	OrphanRecoveryResumed             = "resumed"
+	OrphanRecoveryFresh               = "fresh"
+	WorkerProcessOutcomeTerminated    = "terminated"
+	WorkerProcessOutcomeAlreadyExited = "already_exited"
+	WorkerProcessOutcomeStaleIdentity = "stale_identity"
 )
 
 const defaultBusyTimeout = 5 * time.Second
@@ -59,6 +62,9 @@ type StatsStore interface {
 	StartSession(context.Context, SessionStart) (int64, error)
 	UpdateSessionIdentity(context.Context, int64, agentidentity.Identity) error
 	UpdateSessionProviderIdentity(context.Context, int64, SessionProviderIdentity) error
+	UpdateSessionWorkerProcess(context.Context, int64, WorkerProcessIdentity) error
+	ListActiveWorkerProcesses(context.Context) ([]WorkerProcess, error)
+	MarkSessionWorkerProcessReaped(context.Context, int64, WorkerProcessReap) error
 	UpdateSessionResumeState(context.Context, int64, SessionResumeState) error
 	FinishSession(context.Context, int64, SessionFinish) error
 	RecordUsageEvent(context.Context, UsageEvent) (int64, error)
@@ -289,6 +295,25 @@ type SessionStart struct {
 type SessionProviderIdentity struct {
 	ThreadID  string
 	SessionID string
+}
+
+type WorkerProcessIdentity struct {
+	PID       int
+	GroupID   int
+	StartedAt time.Time
+}
+
+type WorkerProcess struct {
+	SessionID  int64
+	IssueID    string
+	Identifier string
+	IssueURL   string
+	WorkerProcessIdentity
+}
+
+type WorkerProcessReap struct {
+	ReapedAt time.Time
+	Outcome  string
 }
 
 type SessionResumeState struct {

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -1209,6 +1209,57 @@ func TestOrphanedAgentSessionsJournalProviderIdentityAndExcludeCleanExits(t *tes
 	}
 }
 
+func TestActiveWorkerProcessesAreJournaledAndReaped(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	backend := openTestStore(t, ctx)
+	startedAt := time.Date(2026, 7, 12, 15, 0, 0, 0, time.UTC)
+	sessionID, err := backend.StartSession(ctx, SessionStart{
+		IssueID:    "issue-1214",
+		Identifier: "digitaldrywood/detent#1214",
+		StartedAt:  startedAt,
+	})
+	if err != nil {
+		t.Fatalf("StartSession() error = %v", err)
+	}
+
+	processStartedAt := startedAt.Add(time.Second)
+	if err := backend.UpdateSessionWorkerProcess(ctx, sessionID, WorkerProcessIdentity{
+		PID:       4242,
+		GroupID:   4242,
+		StartedAt: processStartedAt,
+	}); err != nil {
+		t.Fatalf("UpdateSessionWorkerProcess() error = %v", err)
+	}
+
+	active, err := backend.ListActiveWorkerProcesses(ctx)
+	if err != nil {
+		t.Fatalf("ListActiveWorkerProcesses() error = %v", err)
+	}
+	if len(active) != 1 {
+		t.Fatalf("ListActiveWorkerProcesses() len = %d, want 1", len(active))
+	}
+	if got := active[0]; got.SessionID != sessionID || got.Identifier != "digitaldrywood/detent#1214" || got.PID != 4242 || got.GroupID != 4242 || !got.StartedAt.Equal(processStartedAt) {
+		t.Fatalf("active worker process = %#v", got)
+	}
+
+	reapedAt := startedAt.Add(2 * time.Second)
+	if err := backend.MarkSessionWorkerProcessReaped(ctx, sessionID, WorkerProcessReap{
+		ReapedAt: reapedAt,
+		Outcome:  WorkerProcessOutcomeTerminated,
+	}); err != nil {
+		t.Fatalf("MarkSessionWorkerProcessReaped() error = %v", err)
+	}
+	active, err = backend.ListActiveWorkerProcesses(ctx)
+	if err != nil {
+		t.Fatalf("ListActiveWorkerProcesses() after reap error = %v", err)
+	}
+	if len(active) != 0 {
+		t.Fatalf("ListActiveWorkerProcesses() after reap len = %d, want 0", len(active))
+	}
+}
+
 func TestLifetimeTotalsMeasureOrphanRecoveryAndResumedCacheShare(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

- Persist worker PID, process-group ID, and OS start time with each active Detent session.
- Reap prior-instance workers before startup dispatch and independently reap all active worker groups when the drain deadline expires.
- Validate process start identity before signaling on Unix and Windows, escalate Unix process groups from SIGTERM to SIGKILL, log every issue-scoped decision, and document the systemd cgroup backstop.

The root cause was that process-group ownership existed only in memory. A systemd SIGKILL after a missed shutdown deadline therefore removed the only supervisor record while leaving paid worker descendants alive.

Fixes #1214

## UI Surface Contract

- [x] N/A, or the linked issue explicitly authorizes any high-impact UI surface, layout, density, first-viewport, or responsive visibility tradeoff.
- [x] Persistent top-of-screen messaging is explicitly authorized by the issue, or this PR does not add it.
- [x] Visual changes to primary operator screens include screenshot or browser verification below.

No UI changes.

## Test Plan

- [x] `make generate`
- [x] Focused race tests for procgroup, store, Codex, Claude Code, runner, and CLI lifecycle paths
- [x] `GOOS=windows GOARCH=amd64 go vet ./internal/procgroup`
- [x] Windows procgroup test cross-compilation
- [x] `make check` (77.2% aggregate coverage)