### PR TITLE
fix(web): trace kanban move outcomes

### DIFF
--- a/internal/kanban/mutations.go
+++ b/internal/kanban/mutations.go
@@ -10,6 +10,8 @@ import (
 )
 
 const (
+	// Successful polls advance DataSeq, so this permits about two poll cycles
+	// of tracker read-after-write lag.
 	overlayContradictionLimit = 2
 	removalPendingTTL         = 5 * time.Minute
 )
@@ -45,10 +47,14 @@ type synthesizedCard struct {
 }
 
 type RevertNotice struct {
-	Identifier string
-	From       string
-	To         string
-	At         time.Time
+	ProjectID      string
+	IssueID        string
+	Identifier     string
+	From           string
+	To             string
+	DataSeq        uint64
+	Contradictions int
+	At             time.Time
 }
 
 func NewMutationTracker() *MutationTracker {
@@ -120,7 +126,7 @@ func (t *MutationTracker) cardStateLocked(stateKey string, snapshotState string,
 			return pending.current
 		}
 		delete(t.states, stateKey)
-		t.noteRevertLocked(stateKey, pending, snapshotState)
+		t.noteRevertLocked(stateKey, pending, snapshotState, dataSeq)
 		return snapshotState
 	default:
 		delete(t.states, stateKey)
@@ -332,7 +338,7 @@ func (t *MutationTracker) NoteCardRemoved(key string, issueID string, snapshotSt
 	t.mu.Unlock()
 }
 
-func (t *MutationTracker) noteRevertLocked(stateKey string, pending pendingState, snapshotState string) {
+func (t *MutationTracker) noteRevertLocked(stateKey string, pending pendingState, snapshotState string, dataSeq uint64) {
 	identifier := strings.TrimSpace(pending.issue.Identifier)
 	if identifier == "" {
 		identifier = strings.TrimSpace(pending.issue.ID)
@@ -342,10 +348,14 @@ func (t *MutationTracker) noteRevertLocked(stateKey string, pending pendingState
 		to = strings.TrimSpace(pending.snapshot)
 	}
 	t.reverted[stateKey] = RevertNotice{
-		Identifier: identifier,
-		From:       strings.TrimSpace(pending.current),
-		To:         to,
-		At:         time.Now(),
+		ProjectID:      strings.TrimSpace(pending.project),
+		IssueID:        strings.TrimSpace(pending.issue.ID),
+		Identifier:     identifier,
+		From:           strings.TrimSpace(pending.current),
+		To:             to,
+		DataSeq:        dataSeq,
+		Contradictions: pending.contradictions,
+		At:             time.Now(),
 	}
 }
 

--- a/internal/web/kanban.go
+++ b/internal/web/kanban.go
@@ -143,10 +143,27 @@ func (s *Server) apiKanbanMove(c echo.Context) error {
 	var feedback string
 	var feedbackStatus int
 	var moveIssueIdentifier string
+	var moveCurrentState string
+	var moveDataSeq uint64
 	err := s.kanbanMutations.WithLock(target.key, func() error {
 		currentState := req.currentState
 		ok, current, snapshotState, snapshotIssue, dataSeqAtWrite := s.kanbanCardFresh(target.key, req.projectID, req.issueID, req.currentState)
-		if !ok {
+		if strings.TrimSpace(current) != "" {
+			currentState = current
+		}
+		moveIssueIdentifier = kanbanBlockedMoveIssueIdentifier(snapshotIssue, req.issueID)
+		moveCurrentState = currentState
+		moveDataSeq = dataSeqAtWrite
+		if !ok && (strings.TrimSpace(current) == "" || !target.workflow.KanbanTransitionAllowed(currentState, req.targetState)) {
+			s.logger.WarnContext(c.Request().Context(), "kanban move rejected: stale card",
+				"project", req.projectID,
+				"issue_id", req.issueID,
+				"identifier", moveIssueIdentifier,
+				"current_state", req.currentState,
+				"live_state", currentState,
+				"target_state", req.targetState,
+				"data_seq", dataSeqAtWrite,
+			)
 			feedback = "Card is stale; refresh and retry."
 			if current != "" {
 				feedback = fmt.Sprintf("Card is stale; current state is %s.", current)
@@ -154,11 +171,15 @@ func (s *Server) apiKanbanMove(c echo.Context) error {
 			feedbackStatus = http.StatusConflict
 			return nil
 		}
-		if strings.TrimSpace(current) != "" {
-			currentState = current
-		}
-		moveIssueIdentifier = kanbanBlockedMoveIssueIdentifier(snapshotIssue, req.issueID)
 		if !target.workflow.KanbanTransitionAllowed(currentState, req.targetState) {
+			s.logger.WarnContext(c.Request().Context(), "kanban move blocked by transition policy",
+				"project", req.projectID,
+				"issue_id", req.issueID,
+				"identifier", moveIssueIdentifier,
+				"current_state", currentState,
+				"target_state", req.targetState,
+				"data_seq", dataSeqAtWrite,
+			)
 			feedback = fmt.Sprintf("Move from %s to %s is not allowed by the Kanban transition policy.", currentState, req.targetState)
 			feedbackStatus = http.StatusUnprocessableEntity
 			return nil
@@ -189,14 +210,39 @@ func (s *Server) apiKanbanMove(c echo.Context) error {
 	if err != nil {
 		var blocked *connector.StateUpdateBlockedError
 		if errors.As(err, &blocked) {
+			s.logger.WarnContext(c.Request().Context(), "kanban move blocked by connector",
+				"project", req.projectID,
+				"issue_id", req.issueID,
+				"identifier", moveIssueIdentifier,
+				"current_state", moveCurrentState,
+				"target_state", req.targetState,
+				"data_seq", moveDataSeq,
+				"error", blocked,
+			)
 			return s.kanbanMoveValidationResponse(c, http.StatusUnprocessableEntity, kanbanBlockedMoveMessage(blocked, req.targetState, moveIssueIdentifier))
 		}
 		if errors.Is(err, connector.ErrNotImplemented) {
 			return s.kanbanMoveValidationResponse(c, http.StatusNotImplemented, kanbanMoveUnsupportedMessage)
 		}
-		s.logger.WarnContext(c.Request().Context(), "kanban move failed", "project", req.projectID, "issue_id", req.issueID, "target_state", req.targetState, "error", err)
+		s.logger.WarnContext(c.Request().Context(), "kanban move failed",
+			"project", req.projectID,
+			"issue_id", req.issueID,
+			"identifier", moveIssueIdentifier,
+			"current_state", moveCurrentState,
+			"target_state", req.targetState,
+			"data_seq", moveDataSeq,
+			"error", err,
+		)
 		return kanbanFeedback(c, http.StatusBadGateway, "Move failed: "+err.Error())
 	}
+	s.logger.InfoContext(c.Request().Context(), "kanban move succeeded",
+		"project", req.projectID,
+		"issue_id", req.issueID,
+		"identifier", moveIssueIdentifier,
+		"current_state", moveCurrentState,
+		"target_state", req.targetState,
+		"data_seq", moveDataSeq,
+	)
 	return s.kanbanMoveSuccess(c, req, "Moved card to "+req.targetState+".")
 }
 

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -722,10 +722,27 @@ func (s *Server) kanbanRevertNotices(data templates.DashboardData) []kanbanstate
 		return nil
 	}
 	projectID := strings.TrimSpace(data.ProjectID)
+	var notices []kanbanstate.RevertNotice
 	if projectID != "" {
-		return s.kanbanMutations.ConsumeRevertNotices("project:"+projectID, projectID)
+		notices = s.kanbanMutations.ConsumeRevertNotices("project:"+projectID, projectID)
+	} else {
+		notices = s.kanbanMutations.ConsumeRevertNotices("", "")
 	}
-	return s.kanbanMutations.ConsumeRevertNotices("", "")
+	if s.logger == nil {
+		return notices
+	}
+	for _, notice := range notices {
+		s.logger.Warn("kanban move reverted",
+			"project", notice.ProjectID,
+			"issue_id", notice.IssueID,
+			"identifier", notice.Identifier,
+			"from_state", notice.From,
+			"to_state", notice.To,
+			"data_seq", notice.DataSeq,
+			"contradiction_count", notice.Contradictions,
+		)
+	}
+	return notices
 }
 
 func kanbanRevertFeedback(notices []kanbanstate.RevertNotice) string {

--- a/internal/web/server_test.go
+++ b/internal/web/server_test.go
@@ -4171,7 +4171,310 @@ func TestKanbanMoveRejectsConcurrentTransitionFromStaleSource(t *testing.T) {
 	}
 }
 
-func TestKanbanMoveRejectsStaleAndPROnlyCards(t *testing.T) {
+func TestKanbanMoveUsesLiveStateTransitionForStaleCard(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		transitions map[string][]string
+		wantStatus  int
+		wantUpdates []kanbanStateUpdate
+	}{
+		{
+			name: "live transition allowed",
+			transitions: map[string][]string{
+				"Todo": {"In Progress"},
+			},
+			wantStatus:  http.StatusOK,
+			wantUpdates: []kanbanStateUpdate{{issueID: "I_stale1096", state: "In Progress"}},
+		},
+		{
+			name: "live transition disallowed",
+			transitions: map[string][]string{
+				"Todo": {"Blocked"},
+			},
+			wantStatus: http.StatusConflict,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			deps := testDeps(t)
+			actionConnector := &kanbanActionConnector{name: "github"}
+			mustSetKanbanProject(t, deps.Registry, "detent", workflowconfig.Kanban{
+				Mode:               workflowconfig.KanbanModeIntegration,
+				AllowedTransitions: tt.transitions,
+			}, actionConnector)
+			if err := deps.Hub.Publish(telemetry.Snapshot{
+				GeneratedAt: time.Date(2026, 7, 9, 12, 0, 0, 0, time.UTC),
+				Project:     telemetry.Project{ID: "detent"},
+				Refresh:     telemetry.Refresh{DataSeq: 41},
+				Pipeline: []telemetry.Issue{{
+					ID:         "I_stale1096",
+					Identifier: "digitaldrywood/detent#1096",
+					ProjectID:  "detent",
+					Title:      "Advanced under cursor",
+					State:      "Todo",
+				}},
+			}); err != nil {
+				t.Fatalf("Publish() error = %v", err)
+			}
+			server, err := web.NewServer(web.Config{}, deps)
+			if err != nil {
+				t.Fatalf("NewServer() error = %v", err)
+			}
+
+			form := url.Values{
+				"project_id":    {"detent"},
+				"issue_id":      {"I_stale1096"},
+				"current_state": {"Backlog"},
+				"target_state":  {"In Progress"},
+			}
+			rec := performForm(t, server.Handler(), http.MethodPost, "/api/v1/kanban/move", form)
+			if rec.Code != tt.wantStatus {
+				t.Fatalf("status = %d, want %d; body = %s", rec.Code, tt.wantStatus, rec.Body.String())
+			}
+			if got := actionConnector.stateUpdates(); !equalStateUpdates(got, tt.wantUpdates) {
+				t.Fatalf("state updates = %#v, want %#v", got, tt.wantUpdates)
+			}
+		})
+	}
+}
+
+func TestKanbanMoveLogsOutcome(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name           string
+		currentState   string
+		transitions    map[string][]string
+		connectorError error
+		wantStatus     int
+		wantLevel      string
+		wantMessage    string
+		wantCurrent    string
+		wantLive       string
+	}{
+		{
+			name:         "success",
+			currentState: "Todo",
+			transitions: map[string][]string{
+				"Todo": {"In Progress"},
+			},
+			wantStatus:  http.StatusOK,
+			wantLevel:   "INFO",
+			wantMessage: "kanban move succeeded",
+			wantCurrent: "Todo",
+		},
+		{
+			name:         "stale allowed",
+			currentState: "Backlog",
+			transitions: map[string][]string{
+				"Todo": {"In Progress"},
+			},
+			wantStatus:  http.StatusOK,
+			wantLevel:   "INFO",
+			wantMessage: "kanban move succeeded",
+			wantCurrent: "Todo",
+		},
+		{
+			name:         "stale disallowed",
+			currentState: "Backlog",
+			transitions: map[string][]string{
+				"Todo": {"Blocked"},
+			},
+			wantStatus:  http.StatusConflict,
+			wantLevel:   "WARN",
+			wantMessage: "kanban move rejected: stale card",
+			wantCurrent: "Backlog",
+			wantLive:    "Todo",
+		},
+		{
+			name:         "transition blocked",
+			currentState: "Todo",
+			transitions: map[string][]string{
+				"Todo": {"Blocked"},
+			},
+			wantStatus:  http.StatusUnprocessableEntity,
+			wantLevel:   "WARN",
+			wantMessage: "kanban move blocked by transition policy",
+			wantCurrent: "Todo",
+		},
+		{
+			name:         "connector blocked",
+			currentState: "Todo",
+			transitions: map[string][]string{
+				"Todo": {"In Progress"},
+			},
+			connectorError: &connector.StateUpdateBlockedError{
+				IssueID:      "I_log1096",
+				CurrentState: "Todo",
+				TargetState:  "In Progress",
+			},
+			wantStatus:  http.StatusUnprocessableEntity,
+			wantLevel:   "WARN",
+			wantMessage: "kanban move blocked by connector",
+			wantCurrent: "Todo",
+		},
+		{
+			name:           "connector error",
+			currentState:   "Todo",
+			connectorError: errors.New("tracker unavailable"),
+			transitions: map[string][]string{
+				"Todo": {"In Progress"},
+			},
+			wantStatus:  http.StatusBadGateway,
+			wantLevel:   "WARN",
+			wantMessage: "kanban move failed",
+			wantCurrent: "Todo",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			var logs bytes.Buffer
+			deps := testDeps(t)
+			actionConnector := &kanbanActionConnector{name: "github", updateErr: tt.connectorError}
+			mustSetKanbanProject(t, deps.Registry, "detent", workflowconfig.Kanban{
+				Mode:               workflowconfig.KanbanModeIntegration,
+				AllowedTransitions: tt.transitions,
+			}, actionConnector)
+			if err := deps.Hub.Publish(telemetry.Snapshot{
+				GeneratedAt: time.Date(2026, 7, 9, 12, 0, 0, 0, time.UTC),
+				Project:     telemetry.Project{ID: "detent"},
+				Refresh:     telemetry.Refresh{DataSeq: 41},
+				Pipeline: []telemetry.Issue{{
+					ID:         "I_log1096",
+					Identifier: "digitaldrywood/detent#1096",
+					ProjectID:  "detent",
+					Title:      "Logged move",
+					State:      "Todo",
+				}},
+			}); err != nil {
+				t.Fatalf("Publish() error = %v", err)
+			}
+			server, err := web.NewServer(web.Config{
+				Logger: slog.New(slog.NewJSONHandler(&logs, nil)),
+			}, deps)
+			if err != nil {
+				t.Fatalf("NewServer() error = %v", err)
+			}
+
+			form := url.Values{
+				"project_id":    {"detent"},
+				"issue_id":      {"I_log1096"},
+				"current_state": {tt.currentState},
+				"target_state":  {"In Progress"},
+			}
+			rec := performForm(t, server.Handler(), http.MethodPost, "/api/v1/kanban/move", form)
+			if rec.Code != tt.wantStatus {
+				t.Fatalf("status = %d, want %d; body = %s", rec.Code, tt.wantStatus, rec.Body.String())
+			}
+
+			records := kanbanMoveLogRecords(t, logs.Bytes())
+			if len(records) != 1 {
+				t.Fatalf("kanban move log records = %#v, want exactly one", records)
+			}
+			record := records[0]
+			assertJSONLogField(t, record, "level", tt.wantLevel)
+			assertJSONLogField(t, record, "msg", tt.wantMessage)
+			assertJSONLogField(t, record, "project", "detent")
+			assertJSONLogField(t, record, "issue_id", "I_log1096")
+			assertJSONLogField(t, record, "identifier", "digitaldrywood/detent#1096")
+			assertJSONLogField(t, record, "current_state", tt.wantCurrent)
+			assertJSONLogField(t, record, "target_state", "In Progress")
+			assertJSONLogField(t, record, "data_seq", float64(41))
+			if tt.wantLive != "" {
+				assertJSONLogField(t, record, "live_state", tt.wantLive)
+			}
+		})
+	}
+}
+
+func TestKanbanMoveLogsOverlayRevert(t *testing.T) {
+	t.Parallel()
+
+	var logs bytes.Buffer
+	deps := testDeps(t)
+	actionConnector := &kanbanActionConnector{name: "github"}
+	mustSetKanbanProject(t, deps.Registry, "detent", workflowconfig.Kanban{
+		Mode: workflowconfig.KanbanModeIntegration,
+		AllowedTransitions: map[string][]string{
+			"Backlog": {"Todo"},
+		},
+	}, actionConnector)
+	publish := func(dataSeq uint64) {
+		t.Helper()
+		if err := deps.Hub.Publish(telemetry.Snapshot{
+			GeneratedAt: time.Date(2026, 7, 9, 12, int(dataSeq), 0, 0, time.UTC),
+			Project:     telemetry.Project{ID: "detent", DisplayName: "Detent"},
+			Projects: []telemetry.ProjectSnapshot{{
+				Project: telemetry.Project{ID: "detent", DisplayName: "Detent"},
+				Refresh: telemetry.Refresh{DataSeq: dataSeq},
+			}},
+			Refresh: telemetry.Refresh{DataSeq: dataSeq},
+			BoardIssues: []telemetry.Issue{{
+				ID:         "I_revert1096",
+				Identifier: "digitaldrywood/detent#1096",
+				ProjectID:  "detent",
+				Title:      "Reverted move",
+				State:      "Backlog",
+			}},
+		}); err != nil {
+			t.Fatalf("Publish() error = %v", err)
+		}
+	}
+	publish(7)
+	server, err := web.NewServer(web.Config{
+		Logger: slog.New(slog.NewJSONHandler(&logs, nil)),
+	}, deps)
+	if err != nil {
+		t.Fatalf("NewServer() error = %v", err)
+	}
+
+	form := url.Values{
+		"project_id":    {"detent"},
+		"issue_id":      {"I_revert1096"},
+		"current_state": {"Backlog"},
+		"target_state":  {"Todo"},
+	}
+	rec := performForm(t, server.Handler(), http.MethodPost, "/api/v1/kanban/move", form)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d; body = %s", rec.Code, http.StatusOK, rec.Body.String())
+	}
+
+	publish(8)
+	requestHTML(t, server.Handler(), http.MethodGet, "/projects/detent/kanban", http.StatusOK)
+	publish(9)
+	requestHTML(t, server.Handler(), http.MethodGet, "/projects/detent/kanban", http.StatusOK)
+	requestHTML(t, server.Handler(), http.MethodGet, "/projects/detent/kanban", http.StatusOK)
+
+	records := kanbanMoveLogRecords(t, logs.Bytes())
+	var reverts []map[string]any
+	for _, record := range records {
+		if record["msg"] == "kanban move reverted" {
+			reverts = append(reverts, record)
+		}
+	}
+	if len(reverts) != 1 {
+		t.Fatalf("kanban revert log records = %#v, want exactly one", reverts)
+	}
+	record := reverts[0]
+	assertJSONLogField(t, record, "level", "WARN")
+	assertJSONLogField(t, record, "project", "detent")
+	assertJSONLogField(t, record, "issue_id", "I_revert1096")
+	assertJSONLogField(t, record, "identifier", "digitaldrywood/detent#1096")
+	assertJSONLogField(t, record, "from_state", "Todo")
+	assertJSONLogField(t, record, "to_state", "Backlog")
+	assertJSONLogField(t, record, "data_seq", float64(9))
+	assertJSONLogField(t, record, "contradiction_count", float64(2))
+}
+
+func TestKanbanMoveAllowsStaleAndRejectsPROnlyCards(t *testing.T) {
 	t.Parallel()
 
 	deps := testDeps(t)
@@ -4215,11 +4518,11 @@ func TestKanbanMoveRejectsStaleAndPROnlyCards(t *testing.T) {
 		"target_state":  {"In Progress"},
 	}
 	rec := performForm(t, server.Handler(), http.MethodPost, "/api/v1/kanban/move", staleForm)
-	if rec.Code != http.StatusConflict {
-		t.Fatalf("stale status = %d, want %d; body = %s", rec.Code, http.StatusConflict, rec.Body.String())
+	if rec.Code != http.StatusOK {
+		t.Fatalf("stale status = %d, want %d; body = %s", rec.Code, http.StatusOK, rec.Body.String())
 	}
-	if !strings.Contains(rec.Body.String(), "stale") {
-		t.Fatalf("stale body missing useful error: %s", rec.Body.String())
+	if !strings.Contains(rec.Body.String(), "Moved") {
+		t.Fatalf("stale-allowed body missing success feedback: %s", rec.Body.String())
 	}
 
 	prOnlyForm := url.Values{
@@ -4232,8 +4535,8 @@ func TestKanbanMoveRejectsStaleAndPROnlyCards(t *testing.T) {
 	if rec.Code != http.StatusUnprocessableEntity {
 		t.Fatalf("pr-only status = %d, want %d; body = %s", rec.Code, http.StatusUnprocessableEntity, rec.Body.String())
 	}
-	if len(actionConnector.stateUpdates()) != 0 {
-		t.Fatalf("state updates = %#v, want none", actionConnector.stateUpdates())
+	if got, want := actionConnector.stateUpdates(), []kanbanStateUpdate{{issueID: "I_kw1", state: "In Progress"}}; !equalStateUpdates(got, want) {
+		t.Fatalf("state updates = %#v, want %#v", got, want)
 	}
 }
 
@@ -10779,6 +11082,34 @@ func performForm(t *testing.T, handler http.Handler, method string, path string,
 	req.Header.Set("HX-Request", "true")
 	handler.ServeHTTP(rec, req)
 	return rec
+}
+
+func kanbanMoveLogRecords(t *testing.T, data []byte) []map[string]any {
+	t.Helper()
+
+	decoder := json.NewDecoder(bytes.NewReader(data))
+	var records []map[string]any
+	for {
+		var record map[string]any
+		if err := decoder.Decode(&record); errors.Is(err, io.EOF) {
+			break
+		} else if err != nil {
+			t.Fatalf("decode log record: %v", err)
+		}
+		message, _ := record["msg"].(string)
+		if strings.HasPrefix(message, "kanban move") {
+			records = append(records, record)
+		}
+	}
+	return records
+}
+
+func assertJSONLogField(t *testing.T, record map[string]any, key string, want any) {
+	t.Helper()
+
+	if got := record[key]; !reflect.DeepEqual(got, want) {
+		t.Fatalf("log field %q = %#v, want %#v; record = %#v", key, got, want, record)
+	}
 }
 
 func kanbanPendingStateCount(t *testing.T, server *web.Server) int {


### PR DESCRIPTION
## Summary

- apply stale card moves when the requested target remains valid from the live state
- emit structured move outcome logs for success, stale and policy rejection, connector failure, and overlay reversion
- preserve overlay sequence and contradiction metadata for incident reconstruction

Fixes #1096

## UI Surface Contract

- [x] N/A; this change does not alter UI surface, layout, density, first-viewport, or responsive visibility.
- [x] This PR does not add persistent top-of-screen messaging.
- [x] N/A; this PR has no visual changes to primary operator screens.

## Test Plan

- [x] `make check`