### PR TITLE
fix(github): expire stale REST snapshots

### DIFF
--- a/internal/connector/github/client.go
+++ b/internal/connector/github/client.go
@@ -31,6 +31,9 @@ const (
 	restRateLimitKindSecondaryThrottled = "secondary_throttled"
 	restFanoutCostUnitsPerRequest       = int64(4)
 	restConditionalFanoutCostUnits      = int64(1)
+	restRateLimitResetSkew              = 5 * time.Second
+	restBudgetGateFanoutCap             = "fanout_cap"
+	restBudgetGateReserve               = "reserve"
 )
 
 var defaultRESTBackoffs = newRESTBackoffRegistry()
@@ -342,7 +345,8 @@ func (c *Client) restWithTokenRefresh(ctx context.Context, method string, path s
 	backoffKey := c.restSharedBackoffKey(token)
 	c.rememberRESTBackoffKey(backoffKey)
 	cached, conditional := c.restConditionalEntry(method, path)
-	if err := c.restBackoffError(backoffKey, time.Now()); err != nil {
+	now := time.Now()
+	if err := c.restBackoffError(backoffKey, now); err != nil {
 		c.logger.DebugContext(ctx, "github rest backoff active",
 			"method", strings.ToUpper(strings.TrimSpace(method)),
 			"path", path,
@@ -353,7 +357,7 @@ func (c *Client) restWithTokenRefresh(ctx context.Context, method string, path s
 		)
 		return nil, err
 	}
-	if err := c.restBudgetPolicyError(method, path, conditional); err != nil {
+	if err := c.restBudgetPolicyError(method, path, conditional, now); err != nil {
 		c.logger.DebugContext(ctx, "github rest budget reserved",
 			"method", strings.ToUpper(strings.TrimSpace(method)),
 			"path", path,
@@ -651,7 +655,7 @@ func normalizeRESTBudgetPolicy(policy RESTBudgetPolicy) RESTBudgetPolicy {
 	return policy
 }
 
-func (c *Client) restBudgetPolicyError(method string, path string, conditional bool) error {
+func (c *Client) restBudgetPolicyError(method string, path string, conditional bool, now time.Time) error {
 	family := restEndpointFamily(method, path)
 	if !restFanoutEndpointFamily(family) {
 		return nil
@@ -667,7 +671,7 @@ func (c *Client) restBudgetPolicyError(method string, path string, conditional b
 	}
 	if c.restPolicy.FanoutMaxRequests > 0 &&
 		c.restFanoutUnits+requestCost > c.restPolicy.FanoutMaxRequests*restFanoutCostUnitsPerRequest {
-		c.recordRESTBudgetThrottleLocked(method, path, family, rateLimit, hasRateLimit)
+		c.recordRESTBudgetThrottleLocked(method, path, family, restBudgetGateFanoutCap, rateLimit, hasRateLimit, now)
 		return &StatusError{
 			StatusCode: http.StatusTooManyRequests,
 			Body:       "REST fanout request cap reached for " + family,
@@ -678,8 +682,9 @@ func (c *Client) restBudgetPolicyError(method string, path string, conditional b
 		!conditional &&
 		hasRateLimit &&
 		rateLimit.Limit > 0 &&
+		!restRateLimitSnapshotExpired(rateLimit, now) &&
 		rateLimit.Remaining <= c.restPolicy.MinRemainingReserve {
-		c.recordRESTBudgetThrottleLocked(method, path, family, rateLimit, hasRateLimit)
+		c.recordRESTBudgetThrottleLocked(method, path, family, restBudgetGateReserve, rateLimit, hasRateLimit, now)
 		return &StatusError{
 			StatusCode: http.StatusTooManyRequests,
 			Body:       "REST remaining budget is reserved for shared GitHub work",
@@ -688,6 +693,10 @@ func (c *Client) restBudgetPolicyError(method string, path string, conditional b
 	}
 	c.restFanoutUnits += requestCost
 	return nil
+}
+
+func restRateLimitSnapshotExpired(rateLimit connector.RESTRateLimit, now time.Time) bool {
+	return !rateLimit.ResetAt.IsZero() && now.After(rateLimit.ResetAt.Add(restRateLimitResetSkew))
 }
 
 func (c *Client) restRateLimitForResourceLocked(resource string) (connector.RESTRateLimit, bool) {
@@ -703,7 +712,16 @@ func (c *Client) restRateLimitForResourceLocked(resource string) (connector.REST
 	return connector.RESTRateLimit{}, false
 }
 
-func (c *Client) recordRESTBudgetThrottleLocked(method string, path string, family string, rateLimit connector.RESTRateLimit, hasRateLimit bool) {
+func (c *Client) recordRESTBudgetThrottleLocked(method string, path string, family string, branch string, rateLimit connector.RESTRateLimit, hasRateLimit bool, now time.Time) {
+	fanoutCount := float64(c.restFanoutUnits) / float64(restFanoutCostUnitsPerRequest)
+	snapshotAge := "unknown"
+	if !rateLimit.UpdatedAt.IsZero() {
+		age := now.Sub(rateLimit.UpdatedAt)
+		if age < 0 {
+			age = 0
+		}
+		snapshotAge = age.String()
+	}
 	if c.restRequests == nil {
 		c.restRequests = make(map[string]connector.RESTEndpointUsage)
 	}
@@ -729,7 +747,10 @@ func (c *Client) recordRESTBudgetThrottleLocked(method string, path string, fami
 		"resource", rateLimit.Resource,
 		"remaining", rateLimit.Remaining,
 		"reserve", c.restPolicy.MinRemainingReserve,
+		"gate_branch", branch,
+		"fanout_count", fanoutCount,
 		"fanout_cap", c.restPolicy.FanoutMaxRequests,
+		"snapshot_age", snapshotAge,
 	)
 }
 

--- a/internal/connector/github/client_test.go
+++ b/internal/connector/github/client_test.go
@@ -646,6 +646,7 @@ func TestClientRESTStopsFanoutAtRequestCap(t *testing.T) {
 	t.Parallel()
 
 	var calls atomic.Int64
+	var logs bytes.Buffer
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if calls.Add(1) != 1 {
 			t.Fatalf("unexpected REST call to %s", r.URL.Path)
@@ -667,6 +668,7 @@ func TestClientRESTStopsFanoutAtRequestCap(t *testing.T) {
 		TokenSource: StaticTokenSource("test-token"),
 		HTTPClient:  server.Client(),
 		RESTPolicy:  RESTBudgetPolicy{FanoutMaxRequests: 1},
+		Logger:      slog.New(slog.NewTextHandler(&logs, nil)),
 	})
 	if err != nil {
 		t.Fatalf("NewClient() error = %v", err)
@@ -693,6 +695,11 @@ func TestClientRESTStopsFanoutAtRequestCap(t *testing.T) {
 	}
 	if got := restEndpointUsageCount(usage.Requests, "check runs"); got != 1 {
 		t.Fatalf("check runs usage count = %d, want throttled synthetic request; usage = %#v", got, usage.Requests)
+	}
+	for _, want := range []string{"gate_branch=fanout_cap", "fanout_count=1", "snapshot_age="} {
+		if !strings.Contains(logs.String(), want) {
+			t.Fatalf("throttle log missing %q:\n%s", want, logs.String())
+		}
 	}
 }
 
@@ -750,7 +757,9 @@ func TestClientRESTCountsRepositoryIssuesAsFanout(t *testing.T) {
 func TestClientRESTStopsFanoutBelowReserve(t *testing.T) {
 	t.Parallel()
 
+	resetAt := time.Now().UTC().Add(time.Hour)
 	var calls atomic.Int64
+	var logs bytes.Buffer
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if calls.Add(1) != 1 {
 			t.Fatalf("unexpected REST call to %s", r.URL.Path)
@@ -760,6 +769,7 @@ func TestClientRESTStopsFanoutBelowReserve(t *testing.T) {
 		w.Header().Set("X-RateLimit-Used", "4100")
 		w.Header().Set("X-RateLimit-Remaining", "900")
 		w.Header().Set("X-RateLimit-Resource", "core")
+		w.Header().Set("X-RateLimit-Reset", strconv.FormatInt(resetAt.Unix(), 10))
 		w.WriteHeader(http.StatusOK)
 		_, _ = w.Write([]byte(`[]`))
 	}))
@@ -770,6 +780,7 @@ func TestClientRESTStopsFanoutBelowReserve(t *testing.T) {
 		TokenSource: StaticTokenSource("test-token"),
 		HTTPClient:  server.Client(),
 		RESTPolicy:  RESTBudgetPolicy{MinRemainingReserve: 1000},
+		Logger:      slog.New(slog.NewTextHandler(&logs, nil)),
 	})
 	if err != nil {
 		t.Fatalf("NewClient() error = %v", err)
@@ -793,6 +804,62 @@ func TestClientRESTStopsFanoutBelowReserve(t *testing.T) {
 	}
 	if got := restEndpointUsageCount(usage.Requests, "commit statuses"); got != 1 {
 		t.Fatalf("commit statuses usage count = %d, want throttled synthetic request; usage = %#v", got, usage.Requests)
+	}
+	for _, want := range []string{"gate_branch=reserve", "fanout_count=1", "snapshot_age="} {
+		if !strings.Contains(logs.String(), want) {
+			t.Fatalf("throttle log missing %q:\n%s", want, logs.String())
+		}
+	}
+}
+
+func TestClientRESTAllowsFanoutAfterReserveSnapshotReset(t *testing.T) {
+	t.Parallel()
+
+	resetAt := time.Now().UTC().Add(-time.Minute)
+	var calls atomic.Int64
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		call := calls.Add(1)
+		w.Header().Set("Content-Type", "application/json")
+		w.Header().Set("X-RateLimit-Limit", "5000")
+		w.Header().Set("X-RateLimit-Resource", "core")
+		if call == 1 {
+			w.Header().Set("X-RateLimit-Used", "4100")
+			w.Header().Set("X-RateLimit-Remaining", "900")
+			w.Header().Set("X-RateLimit-Reset", strconv.FormatInt(resetAt.Unix(), 10))
+		} else {
+			w.Header().Set("X-RateLimit-Used", "100")
+			w.Header().Set("X-RateLimit-Remaining", "4900")
+			w.Header().Set("X-RateLimit-Reset", strconv.FormatInt(resetAt.Add(time.Hour).Unix(), 10))
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`[]`))
+	}))
+	t.Cleanup(server.Close)
+
+	client, err := NewClient(ClientConfig{
+		Endpoint:    server.URL,
+		TokenSource: StaticTokenSource("test-token"),
+		HTTPClient:  server.Client(),
+		RESTPolicy:  RESTBudgetPolicy{MinRemainingReserve: 1000},
+	})
+	if err != nil {
+		t.Fatalf("NewClient() error = %v", err)
+	}
+
+	var pulls []restPullRequest
+	if err := client.REST(context.Background(), http.MethodGet, "/repos/digitaldrywood/detent/pulls?state=all", nil, &pulls); err != nil {
+		t.Fatalf("REST() pull requests error = %v", err)
+	}
+	if err := client.REST(context.Background(), http.MethodGet, "/repos/digitaldrywood/detent/commits/abc/statuses", nil, nil); err != nil {
+		t.Fatalf("REST() after reset error = %v", err)
+	}
+	if calls.Load() != 2 {
+		t.Fatalf("REST calls = %d, want post-reset request sent", calls.Load())
+	}
+
+	usage := client.FlushRESTRateLimitUsage()
+	if usage.RateLimited || usage.RateLimit.Remaining != 4900 {
+		t.Fatalf("REST usage = %#v, want refreshed budget with 4900 remaining", usage)
 	}
 }
 

--- a/internal/connector/github/conditional_test.go
+++ b/internal/connector/github/conditional_test.go
@@ -186,6 +186,41 @@ func TestClientRESTConditionalRequestsCanBeDisabled(t *testing.T) {
 	}
 }
 
+func TestConnectorConditionalPollingEnabled(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		source     string
+		disabled   bool
+		wantActive bool
+	}{
+		{name: "project v2", source: GitHubStatusSourceProjectV2, wantActive: true},
+		{name: "issue field", source: GitHubStatusSourceIssueField, wantActive: true},
+		{name: "label", source: GitHubStatusSourceLabel, wantActive: true},
+		{name: "disabled", source: GitHubStatusSourceProjectV2, disabled: true},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			connector, err := NewConnector(Config{
+				Endpoint:                   "https://api.github.test/graphql",
+				APIKey:                     "test-token",
+				GitHubStatusSource:         test.source,
+				DisableConditionalRequests: test.disabled,
+			})
+			if err != nil {
+				t.Fatalf("NewConnector() error = %v", err)
+			}
+			if got := connector.ConditionalPollingEnabled(); got != test.wantActive {
+				t.Fatalf("ConditionalPollingEnabled() = %v, want %v", got, test.wantActive)
+			}
+		})
+	}
+}
+
 func TestClientRESTConditionalCacheIsBounded(t *testing.T) {
 	t.Parallel()
 

--- a/internal/connector/github/connector.go
+++ b/internal/connector/github/connector.go
@@ -190,7 +190,10 @@ func NewConnector(cfg Config) (*Connector, error) {
 }
 
 func (c *Connector) ConditionalPollingEnabled() bool {
-	return c != nil && c.client != nil && c.client.conditionalRequests && (c.usesLabelStatus() || c.usesIssueFieldStatus())
+	return c != nil &&
+		c.client != nil &&
+		c.client.conditionalRequests &&
+		(c.statusSource == GitHubStatusSourceProjectV2 || c.usesLabelStatus() || c.usesIssueFieldStatus())
 }
 
 func (c *Connector) Name() string {

--- a/internal/orchestrator/rate_limit_test.go
+++ b/internal/orchestrator/rate_limit_test.go
@@ -703,6 +703,64 @@ func TestTickSkipsNonessentialGitHubWorkBelowRESTReserve(t *testing.T) {
 	}
 }
 
+func TestGitHubBudgetReserveDecisionUsesCurrentRateLimitWindow(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 7, 12, 18, 0, 0, 0, time.UTC)
+	activeReset := now.Add(time.Hour)
+	expiredReset := now.Add(-time.Minute)
+	tests := []struct {
+		name         string
+		rateLimits   *telemetry.RateLimits
+		wantDegraded bool
+	}{
+		{
+			name: "active REST window",
+			rateLimits: &telemetry.RateLimits{GitHubREST: &telemetry.RateLimitBucket{
+				Limit: 5000, Remaining: 900, ResetAt: &activeReset,
+			}},
+			wantDegraded: true,
+		},
+		{
+			name: "expired REST window",
+			rateLimits: &telemetry.RateLimits{GitHubREST: &telemetry.RateLimitBucket{
+				Limit: 5000, Remaining: 900, ResetAt: &expiredReset,
+			}},
+		},
+		{
+			name: "active GraphQL window",
+			rateLimits: &telemetry.RateLimits{GitHubGraphQL: &telemetry.RateLimitBucket{
+				Limit: 5000, Remaining: 900, ResetAt: &activeReset,
+			}},
+			wantDegraded: true,
+		},
+		{
+			name: "expired GraphQL window",
+			rateLimits: &telemetry.RateLimits{GitHubGraphQL: &telemetry.RateLimitBucket{
+				Limit: 5000, Remaining: 900, ResetAt: &expiredReset,
+			}},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			cfg := normalizeConfig(Config{
+				GitHubRESTMinReserve:    1000,
+				GitHubGraphQLMinReserve: 1000,
+			})
+			state := newState(cfg)
+			state.RateLimits = test.rateLimits
+			orch := newRateLimitTestOrchestrator(cfg, &rateLimitConnector{})
+
+			if got := orch.githubBudgetReserveDecision(&state, now).degraded; got != test.wantDegraded {
+				t.Fatalf("githubBudgetReserveDecision().degraded = %v, want %v", got, test.wantDegraded)
+			}
+		})
+	}
+}
+
 func TestTickAllowsConditionalPollingBelowRESTReserve(t *testing.T) {
 	t.Parallel()
 

--- a/internal/orchestrator/tick.go
+++ b/internal/orchestrator/tick.go
@@ -11,6 +11,8 @@ import (
 	"github.com/digitaldrywood/detent/internal/telemetry"
 )
 
+const githubRateLimitResetSkew = 5 * time.Second
+
 type tickPreviousState struct {
 	lastRefreshAt            time.Time
 	pipeline                 []connector.Issue
@@ -79,7 +81,7 @@ func (o *Orchestrator) tickWithManual(ctx context.Context, state *State, now tim
 		return
 	}
 
-	reserve := o.githubBudgetReserveDecision(state)
+	reserve := o.githubBudgetReserveDecision(state, now)
 	if reserve.degraded {
 		o.logGitHubBudgetReserveDecision(reserve)
 		recordStateEvent(state, telemetry.ActivityEvent{
@@ -510,17 +512,17 @@ func (o *Orchestrator) observedWorkExists(ctx context.Context, observedStates []
 	return len(issues) > 0
 }
 
-func (o *Orchestrator) githubBudgetReserveDecision(state *State) githubBudgetReserveDecision {
+func (o *Orchestrator) githubBudgetReserveDecision(state *State, now time.Time) githubBudgetReserveDecision {
 	decision := githubBudgetReserveDecision{
 		restRemaining:  gitHubRESTRemaining(state),
 		restReserve:    o.cfg.GitHubRESTMinReserve,
 		graphRemaining: gitHubGraphQLRemaining(state),
 		graphReserve:   o.cfg.GitHubGraphQLMinReserve,
 	}
-	if bucket := gitHubRESTBucketFromState(state); budgetBelowReserve(bucket, o.cfg.GitHubRESTMinReserve) && !o.conditionalPollingEnabled() {
+	if bucket := gitHubRESTBucketFromState(state); budgetBelowReserve(bucket, o.cfg.GitHubRESTMinReserve, now) && !o.conditionalPollingEnabled() {
 		decision.degraded = true
 	}
-	if bucket := gitHubGraphQLBucketFromState(state); budgetBelowReserve(bucket, o.cfg.GitHubGraphQLMinReserve) {
+	if bucket := gitHubGraphQLBucketFromState(state); budgetBelowReserve(bucket, o.cfg.GitHubGraphQLMinReserve, now) {
 		decision.degraded = true
 	}
 	return decision
@@ -531,8 +533,12 @@ func (o *Orchestrator) conditionalPollingEnabled() bool {
 	return ok && poller.ConditionalPollingEnabled()
 }
 
-func budgetBelowReserve(bucket *telemetry.RateLimitBucket, reserve int64) bool {
-	return bucket != nil && reserve > 0 && bucket.Limit > 0 && bucket.Remaining <= reserve
+func budgetBelowReserve(bucket *telemetry.RateLimitBucket, reserve int64, now time.Time) bool {
+	return bucket != nil &&
+		reserve > 0 &&
+		bucket.Limit > 0 &&
+		bucket.Remaining <= reserve &&
+		(bucket.ResetAt == nil || !now.After(bucket.ResetAt.Add(githubRateLimitResetSkew)))
 }
 
 func (o *Orchestrator) logGitHubBudgetReserveDecision(decision githubBudgetReserveDecision) {


### PR DESCRIPTION
## Summary

- Expire low REST rate-limit snapshots after the reset skew so the next fanout request refreshes the stored budget.
- Keep active-window reserve throttling while logging the gate branch, current fanout count, and snapshot age.
- Apply reset awareness to orchestrator reserve degradation and expose ProjectV2 REST conditional polling capability.

Fixes #1263

## UI Surface Contract

- [x] N/A; this change has no UI surface impact.
- [x] This PR does not add persistent top-of-screen messaging.
- [x] N/A; this PR has no visual changes to operator screens.

## Test Plan

- [x] `go test ./internal/connector/github ./internal/orchestrator -count=1`
- [x] `make check`