### PR TITLE
fix(runner): park token ceiling failures

### DIFF
--- a/internal/orchestrator/blocked_recovery_test.go
+++ b/internal/orchestrator/blocked_recovery_test.go
@@ -10,48 +10,52 @@ import (
 	"github.com/digitaldrywood/detent/internal/store"
 )
 
-func TestRecoverBlockedIssuesSkipsPersistedReworkLimitBlockedIssue(t *testing.T) {
+func TestRecoverBlockedIssuesSkipsPersistedStickyBlockedIssue(t *testing.T) {
 	t.Parallel()
 
-	issue := dependencyAutoUnblockIssue("issue-recovery-rework-limit", "Blocked")
-	prNumber := 418
-	issue.PRNumber = &prNumber
-	issue.PullRequest = &connector.PullRequest{
-		Number:         prNumber,
-		State:          "OPEN",
-		URL:            "https://github.test/digitaldrywood/detent/pull/418",
-		MergeableState: "behind",
-		HeadSHA:        "abc123",
-	}
-	tracker := &dependencyAutoUnblockConnector{
-		stateIssues: []connector.Issue{issue},
-	}
-	orch := dependencyAutoUnblockOrchestrator(tracker, DependencyAutoUnblockConfig{})
-	metrics := &autoPromoteWorkflowMetricsRecorder{}
-	orch.workflowMetrics = metrics
-	if _, err := metrics.RecordWorkflowPhaseEvent(context.Background(), store.WorkflowPhaseEvent{
-		ProjectID:    defaultWorkflowMetricsProjectID,
-		IssueID:      issue.ID,
-		Identifier:   issue.Identifier,
-		IssueURL:     issue.URL,
-		PhaseType:    store.WorkflowPhaseTypeLane,
-		PhaseName:    "Blocked",
-		Reason:       "rework_limit",
-		Status:       "entered",
-		StartedAt:    time.Date(2026, 7, 8, 15, 0, 0, 0, time.UTC),
-		MetadataJSON: "{}",
-	}); err != nil {
-		t.Fatalf("RecordWorkflowPhaseEvent() error = %v", err)
-	}
-	state := newState(orch.cfg)
+	for _, reason := range []string{"rework_limit", "token_ceiling_circuit_breaker"} {
+		t.Run(reason, func(t *testing.T) {
+			t.Parallel()
 
-	orch.recoverBlockedIssues(context.Background(), &state, []connector.Issue{issue}, time.Date(2026, 7, 8, 15, 1, 0, 0, time.UTC))
+			issue := dependencyAutoUnblockIssue("issue-recovery-"+reason, "Blocked")
+			prNumber := 418
+			issue.PRNumber = &prNumber
+			issue.PullRequest = &connector.PullRequest{
+				Number:         prNumber,
+				State:          "OPEN",
+				URL:            "https://github.test/digitaldrywood/detent/pull/418",
+				MergeableState: "behind",
+				HeadSHA:        "abc123",
+			}
+			tracker := &dependencyAutoUnblockConnector{stateIssues: []connector.Issue{issue}}
+			orch := dependencyAutoUnblockOrchestrator(tracker, DependencyAutoUnblockConfig{})
+			metrics := &autoPromoteWorkflowMetricsRecorder{}
+			orch.workflowMetrics = metrics
+			if _, err := metrics.RecordWorkflowPhaseEvent(context.Background(), store.WorkflowPhaseEvent{
+				ProjectID:    defaultWorkflowMetricsProjectID,
+				IssueID:      issue.ID,
+				Identifier:   issue.Identifier,
+				IssueURL:     issue.URL,
+				PhaseType:    store.WorkflowPhaseTypeLane,
+				PhaseName:    "Blocked",
+				Reason:       reason,
+				Status:       "entered",
+				StartedAt:    time.Date(2026, 7, 8, 15, 0, 0, 0, time.UTC),
+				MetadataJSON: "{}",
+			}); err != nil {
+				t.Fatalf("RecordWorkflowPhaseEvent() error = %v", err)
+			}
+			state := newState(orch.cfg)
 
-	if len(tracker.updates) != 0 {
-		t.Fatalf("updates = %#v, want no blocked recovery transition", tracker.updates)
-	}
-	if len(tracker.comments) != 0 {
-		t.Fatalf("comments = %#v, want no blocked recovery comment", tracker.comments)
+			orch.recoverBlockedIssues(context.Background(), &state, []connector.Issue{issue}, time.Date(2026, 7, 8, 15, 1, 0, 0, time.UTC))
+
+			if len(tracker.updates) != 0 {
+				t.Fatalf("updates = %#v, want no blocked recovery transition", tracker.updates)
+			}
+			if len(tracker.comments) != 0 {
+				t.Fatalf("comments = %#v, want no blocked recovery comment", tracker.comments)
+			}
+		})
 	}
 }
 

--- a/internal/orchestrator/dependency_autounblock.go
+++ b/internal/orchestrator/dependency_autounblock.go
@@ -850,8 +850,12 @@ func (o *Orchestrator) issueHasStickyBlockReason(ctx context.Context, state *Sta
 }
 
 func stickyBlockReason(reason string) bool {
-	switch strings.ToLower(strings.TrimSpace(reason)) {
-	case "rework_limit", "no_progress_limit", "workpad_blocked_unactioned", "circuit_breaker":
+	reason = strings.ToLower(strings.TrimSpace(reason))
+	if strings.HasPrefix(reason, tokenCeilingBlockedReasonPrefix) {
+		return true
+	}
+	switch reason {
+	case "rework_limit", "no_progress_limit", "workpad_blocked_unactioned", "circuit_breaker", "token_ceiling_circuit_breaker":
 		return true
 	default:
 		return false

--- a/internal/orchestrator/implement_progress_test.go
+++ b/internal/orchestrator/implement_progress_test.go
@@ -474,10 +474,15 @@ func TestHandleRunResultStopsCompletedGateWaitContinuations(t *testing.T) {
 	}
 }
 
-func TestStickyBlockReasonIncludesImplementProgressBreakers(t *testing.T) {
+func TestStickyBlockReasonIncludesCircuitBreakers(t *testing.T) {
 	t.Parallel()
 
-	for _, reason := range []string{noProgressLimitReason, workpadBlockedUnactionedReason} {
+	for _, reason := range []string{
+		noProgressLimitReason,
+		workpadBlockedUnactionedReason,
+		"token_ceiling_circuit_breaker",
+		tokenCeilingBlockedReasonPrefix + "observed 16100000 tokens above the 16000000 max_session_tokens ceiling",
+	} {
 		if !stickyBlockReason(reason) {
 			t.Fatalf("stickyBlockReason(%q) = false, want true", reason)
 		}

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -41,6 +41,7 @@ const (
 	instantFailureBlockedReasonPrefix  = "instant fail circuit breaker: "
 	repeatedFailureThreshold           = 5
 	repeatedFailureBlockedReasonPrefix = "repeated failure circuit breaker: "
+	tokenCeilingBlockedReasonPrefix    = "token ceiling circuit breaker: "
 	continuationDispatchBackoff        = 100 * time.Millisecond
 	runUpdateBufferSize                = 128
 	maxRecentEvents                    = 50

--- a/internal/orchestrator/reconcile.go
+++ b/internal/orchestrator/reconcile.go
@@ -488,7 +488,8 @@ func (o *Orchestrator) setBlockedStatusIssue(state *State, issue connector.Issue
 	if existing, ok := state.Blocked[issue.ID]; ok &&
 		existing.Source == BlockedSourceProjectStatus &&
 		(strings.HasPrefix(existing.Reason, instantFailureBlockedReasonPrefix) ||
-			strings.HasPrefix(existing.Reason, repeatedFailureBlockedReasonPrefix)) &&
+			strings.HasPrefix(existing.Reason, repeatedFailureBlockedReasonPrefix) ||
+			strings.HasPrefix(existing.Reason, tokenCeilingBlockedReasonPrefix)) &&
 		strings.TrimSpace(issue.BlockerReason) == "" {
 		existing.Issue = cloneIssue(issue)
 		state.Blocked[issue.ID] = existing

--- a/internal/orchestrator/run_completion.go
+++ b/internal/orchestrator/run_completion.go
@@ -154,7 +154,7 @@ func (o *Orchestrator) handleRunResult(ctx context.Context, state *State, event 
 		errorMessage := event.Err.Error()
 		phase := "failed"
 		statusMessage := "worker failed"
-		if spendProgress.Block {
+		if spendProgress.Block && !errors.Is(event.Err, runpkg.ErrSessionTokenCeilingExceeded) {
 			terminalState = store.WorkAttemptTerminalNoProgress
 			errorClass = spendProgressReason
 			errorMessage = fmt.Sprintf("spent %s since the last accepted state change; configured limit %s", budget.FormatUSD(spendProgress.Spend.CostUSD), budget.FormatUSD(spendProgress.LimitUSD))
@@ -162,16 +162,19 @@ func (o *Orchestrator) handleRunResult(ctx context.Context, state *State, event 
 			statusMessage = "spend-since-progress circuit breaker tripped"
 		}
 		o.completeDurableWorkAttemptWithMetadata(ctx, state, running, event.CompletedAt, terminalState, errorClass, errorMessage, phase, statusMessage, spendProgressMetadata(spendProgress))
+		attempt := event.RetryAttempt
+		if attempt < 1 {
+			attempt = nextAttempt(running.Attempt)
+		}
+		if o.tripTokenCeilingCircuitBreaker(ctx, state, event, running, attempt) {
+			return
+		}
 		if spendProgress.Block && o.blockSpendProgress(ctx, state, running.Issue, spendProgress, event.CompletedAt) {
 			return
 		}
 		if mergeWorkerIssue(running.Issue) {
 			o.logMergeWorkerFailure(running.Issue, "runner_failed", event.Err)
 			o.recordMergeFailed(state, running.Issue, event.CompletedAt, "runner_failed", event.Err)
-		}
-		attempt := event.RetryAttempt
-		if attempt < 1 {
-			attempt = nextAttempt(running.Attempt)
 		}
 		if mergeWorkerIssue(running.Issue) && attempt > maxMergeWorkerRunnerFailures {
 			if o.reworkExhaustedMergeWorker(ctx, state, running, event.CompletedAt, attempt, event.Err) {
@@ -566,6 +569,130 @@ func (o *Orchestrator) instantFailureParkState() string {
 	return blockedStatusState
 }
 
+func (o *Orchestrator) tripTokenCeilingCircuitBreaker(
+	ctx context.Context,
+	state *State,
+	event runpkg.Completion,
+	running Running,
+	attempt int,
+) bool {
+	var ceilingErr *runpkg.SessionTokenCeilingError
+	if state == nil || !errors.As(event.Err, &ceilingErr) || ceilingErr == nil {
+		return false
+	}
+	failure := o.recordRepeatedFailure(state, event, running)
+	targetState := o.instantFailureParkState()
+	issue := cloneIssue(running.Issue)
+	if targetState != "" {
+		if err := o.updateIssueState(ctx, state, issue, targetState, event.CompletedAt, "token_ceiling_circuit_breaker"); err != nil {
+			if o.logger != nil {
+				o.logger.Error(
+					"token ceiling circuit breaker state transition failed",
+					"issue_id", issue.ID,
+					"identifier", issue.Identifier,
+					"target_state", targetState,
+					"error", err,
+				)
+			}
+		} else {
+			issue.State = targetState
+		}
+	}
+	if o.connector != nil {
+		comment := tokenCeilingFailureComment(issue, ceilingErr, running.Attempt, attempt, targetState)
+		if err := o.connector.CreateComment(ctx, issue.ID, comment); err != nil && o.logger != nil {
+			o.logger.Error("token ceiling circuit breaker comment failed", "issue_id", issue.ID, "identifier", issue.Identifier, "error", err)
+		}
+	}
+	if err := o.abandonClaim(ctx, issue.ID); err != nil && o.logger != nil {
+		o.logger.Error("token ceiling circuit breaker claim release failed", "issue_id", issue.ID, "identifier", issue.Identifier, "error", err)
+	}
+	delete(state.Claimed, issue.ID)
+	delete(state.Retry, issue.ID)
+	delete(state.BudgetRefusals, issue.ID)
+	delete(state.PriorAttempts, issue.ID)
+	delete(state.InstantFailures, issue.ID)
+	delete(state.RepeatedFailures, issue.ID)
+	if state.Blocked == nil {
+		state.Blocked = map[string]Blocked{}
+	}
+	reason := tokenCeilingFailureReason(ceilingErr)
+	state.Blocked[issue.ID] = Blocked{
+		Issue:          issue,
+		Reason:         reason,
+		RecoveryReason: string(BlockedRecoveryReasonHumanBlocker),
+		RecoveryTarget: "Rework",
+		BlockedAt:      event.CompletedAt,
+		Source:         BlockedSourceProjectStatus,
+	}
+	recordStateEvent(state, telemetry.ActivityEvent{
+		At:      event.CompletedAt,
+		Event:   "worker_token_ceiling_circuit_breaker_tripped",
+		Message: "parked " + issueLabel(issue) + " after a session token ceiling failure: " + reason,
+	})
+	if o.logger != nil {
+		o.logger.Error(
+			"worker token ceiling circuit breaker tripped",
+			"event", "worker_token_ceiling_circuit_breaker_tripped",
+			"issue_id", issue.ID,
+			"issue_identifier", issue.Identifier,
+			"failed_attempt", running.Attempt,
+			"prevented_retry_attempt", attempt,
+			"repeated_failures", failure.Count,
+			"target_state", targetState,
+			"observed_total_tokens", ceilingErr.TotalTokens,
+			"ceiling_tokens", ceilingErr.CeilingTokens,
+			"ceiling_source", ceilingErr.Source,
+			"error", event.Err,
+		)
+	}
+	return true
+}
+
+func tokenCeilingFailureReason(ceilingErr *runpkg.SessionTokenCeilingError) string {
+	source := strings.TrimSpace(ceilingErr.Source)
+	if source == "" {
+		source = "unknown"
+	}
+	return fmt.Sprintf(
+		"%sobserved %d tokens above the %d %s ceiling",
+		tokenCeilingBlockedReasonPrefix,
+		ceilingErr.TotalTokens,
+		ceilingErr.CeilingTokens,
+		source,
+	)
+}
+
+func tokenCeilingFailureComment(
+	issue connector.Issue,
+	ceilingErr *runpkg.SessionTokenCeilingError,
+	failedAttempt int,
+	preventedRetryAttempt int,
+	targetState string,
+) string {
+	var b strings.Builder
+	b.WriteString("Detent stopped retrying this worker because the session exceeded its configured token ceiling.")
+	if targetState = strings.TrimSpace(targetState); targetState != "" {
+		b.WriteString("\n\nIssue parked in `")
+		b.WriteString(targetState)
+		b.WriteString("` for a human decision.")
+	}
+	b.WriteString("\n\n- issue: ")
+	b.WriteString(issueLabel(issue))
+	b.WriteString("\n- failed_attempt: ")
+	b.WriteString(strconv.Itoa(failedAttempt))
+	b.WriteString("\n- prevented_retry_attempt: ")
+	b.WriteString(strconv.Itoa(preventedRetryAttempt))
+	b.WriteString("\n- observed_total_tokens: ")
+	b.WriteString(strconv.FormatInt(ceilingErr.TotalTokens, 10))
+	b.WriteString("\n- ceiling_tokens: ")
+	b.WriteString(strconv.FormatInt(ceilingErr.CeilingTokens, 10))
+	b.WriteString("\n- ceiling_source: ")
+	b.WriteString(strings.TrimSpace(ceilingErr.Source))
+	b.WriteString("\n\nChoose one recovery before moving the issue to Rework: split the issue into narrower work, apply the label configured by `agent.max_session_token_override_label` for a deliberate per-issue bypass, or raise `agent.max_session_tokens` (and `agent.max_session_context_multiplier` when it is the active guard).")
+	return b.String()
+}
+
 // tripRepeatedFailureCircuitBreaker parks an issue after too many consecutive
 // worker failures of any duration. The instant-failure breaker only counts
 // sub-instantFailureMaxDuration failures with identical error text, which lets
@@ -582,6 +709,16 @@ func (o *Orchestrator) tripRepeatedFailureCircuitBreaker(
 	if state == nil || event.Err == nil {
 		return false
 	}
+	failure := o.recordRepeatedFailure(state, event, running)
+	if failure.Count < repeatedFailureThreshold {
+		return false
+	}
+
+	o.parkRepeatedFailure(ctx, state, event, running, failure, attempt)
+	return true
+}
+
+func (o *Orchestrator) recordRepeatedFailure(state *State, event runpkg.Completion, running Running) RepeatedFailure {
 	if state.RepeatedFailures == nil {
 		state.RepeatedFailures = map[string]RepeatedFailure{}
 	}
@@ -594,12 +731,7 @@ func (o *Orchestrator) tripRepeatedFailureCircuitBreaker(
 	failure.Error = o.operatorText(event.Err.Error())
 	failure.LastFailureAt = event.CompletedAt
 	state.RepeatedFailures[event.IssueID] = failure
-	if failure.Count < repeatedFailureThreshold {
-		return false
-	}
-
-	o.parkRepeatedFailure(ctx, state, event, running, failure, attempt)
-	return true
+	return failure
 }
 
 func (o *Orchestrator) parkRepeatedFailure(

--- a/internal/orchestrator/run_completion_token_ceiling_test.go
+++ b/internal/orchestrator/run_completion_token_ceiling_test.go
@@ -73,6 +73,9 @@ func TestHandleRunResultParksSlowTokenCeilingFailureWithoutRetry(t *testing.T) {
 			t.Fatalf("Blocked[%q].Reason = %q, want %q", issue.ID, blocked.Reason, want)
 		}
 	}
+	if !stickyBlockReason(blocked.Reason) {
+		t.Fatalf("stickyBlockReason(%q) = false, want token ceiling park to require human recovery", blocked.Reason)
+	}
 	orch.setBlockedStatusIssue(&state, connector.Issue{
 		ID:         issue.ID,
 		Identifier: issue.Identifier,

--- a/internal/orchestrator/run_completion_token_ceiling_test.go
+++ b/internal/orchestrator/run_completion_token_ceiling_test.go
@@ -1,0 +1,102 @@
+package orchestrator
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/digitaldrywood/detent/internal/connector"
+	runpkg "github.com/digitaldrywood/detent/internal/runner"
+)
+
+func TestHandleRunResultParksSlowTokenCeilingFailureWithoutRetry(t *testing.T) {
+	t.Parallel()
+
+	tracker := &dependencyAutoUnblockConnector{}
+	cfg := normalizeConfig(Config{
+		ActiveStates:   []string{"Todo", "In Progress", "Rework"},
+		ObservedStates: []string{"Blocked"},
+		TerminalStates: []string{"Done", "Cancelled"},
+	})
+	orch := &Orchestrator{cfg: cfg, connector: tracker}
+	state := newState(cfg)
+	issue := connector.Issue{
+		ID:         "issue-token-ceiling",
+		Identifier: "digitaldrywood/detent#1221",
+		Title:      "Token ceiling retry loop",
+		State:      "In Progress",
+	}
+	completedAt := time.Date(2026, 7, 10, 23, 5, 0, 0, time.UTC)
+	state.Running[issue.ID] = Running{
+		Issue:     issue,
+		Attempt:   1,
+		StartedAt: completedAt.Add(-5 * time.Minute),
+	}
+	state.Claimed[issue.ID] = Claimed{Issue: issue, ClaimedAt: completedAt.Add(-5 * time.Minute)}
+
+	orch.handleRunResult(context.Background(), &state, runpkg.Completion{
+		IssueID: issue.ID,
+		Request: runpkg.RunRequest{Mode: runpkg.RunModeImplement},
+		Result: runpkg.RunResult{
+			FinalState: runpkg.FinalStateTokenCeilingExceeded,
+			Tokens:     TokenTotals{TotalTokens: 16_100_000, RuntimeSeconds: 300},
+		},
+		Err: &runpkg.SessionTokenCeilingError{
+			TotalTokens:   16_100_000,
+			CeilingTokens: 16_000_000,
+			Source:        runpkg.TokenCeilingSourceAbsolute,
+		},
+		CompletedAt:  completedAt,
+		RetryAttempt: 2,
+		RetryDelay:   time.Minute,
+	})
+
+	if _, ok := state.Retry[issue.ID]; ok {
+		t.Fatalf("Retry[%q] present after token ceiling failure", issue.ID)
+	}
+	if _, ok := state.Claimed[issue.ID]; ok {
+		t.Fatalf("Claimed[%q] present after token ceiling failure", issue.ID)
+	}
+	blocked, ok := state.Blocked[issue.ID]
+	if !ok {
+		t.Fatalf("Blocked[%q] missing after token ceiling failure", issue.ID)
+	}
+	if blocked.Issue.State != blockedStatusState {
+		t.Fatalf("Blocked[%q].Issue.State = %q, want %q", issue.ID, blocked.Issue.State, blockedStatusState)
+	}
+	if blocked.RecoveryReason != "human_blocker" || blocked.RecoveryTarget != "Rework" {
+		t.Fatalf("Blocked[%q] recovery = %q to %q, want human_blocker to Rework", issue.ID, blocked.RecoveryReason, blocked.RecoveryTarget)
+	}
+	for _, want := range []string{"token ceiling", "16100000", "16000000", "max_session_tokens"} {
+		if !strings.Contains(blocked.Reason, want) {
+			t.Fatalf("Blocked[%q].Reason = %q, want %q", issue.ID, blocked.Reason, want)
+		}
+	}
+	orch.setBlockedStatusIssue(&state, connector.Issue{
+		ID:         issue.ID,
+		Identifier: issue.Identifier,
+		Title:      issue.Title,
+		State:      blockedStatusState,
+	}, completedAt.Add(time.Minute))
+	if got := state.Blocked[issue.ID].Reason; got != blocked.Reason {
+		t.Fatalf("Blocked[%q].Reason after status refresh = %q, want preserved %q", issue.ID, got, blocked.Reason)
+	}
+	if got := tracker.updates; len(got) != 1 || got[0] != (dependencyAutoUnblockUpdate{issueID: issue.ID, state: blockedStatusState}) {
+		t.Fatalf("state updates = %#v, want one Blocked transition", got)
+	}
+	if len(tracker.comments) != 1 {
+		t.Fatalf("comments = %#v, want one token ceiling comment", tracker.comments)
+	}
+	for _, want := range []string{
+		"16100000",
+		"16000000",
+		"max_session_token_override_label",
+		"max_session_tokens",
+		"split the issue",
+	} {
+		if !strings.Contains(tracker.comments[0].body, want) {
+			t.Fatalf("comment = %q, want %q", tracker.comments[0].body, want)
+		}
+	}
+}

--- a/internal/web/templates/board_data_test.go
+++ b/internal/web/templates/board_data_test.go
@@ -233,6 +233,22 @@ func TestBoardCardExtraShowsWaitReasonAheadOfCI(t *testing.T) {
 	}
 }
 
+func TestBoardCardExtraShowsTokenCeilingFailure(t *testing.T) {
+	t.Parallel()
+
+	reason := "token ceiling circuit breaker: observed 16100000 tokens above the 16000000 max_session_tokens ceiling"
+	card := projectKanbanCard{
+		BlockedSource:         telemetry.BlockedSourceProjectStatus,
+		BlockedReason:         reason,
+		BlockedRecoveryReason: "human_blocker",
+	}
+
+	kind, text, chip := boardCardExtra(card, boardCardView{})
+	if kind != primitives.KindErr || text != "needs review - "+reason || !chip {
+		t.Fatalf("boardCardExtra() = %q, %q, %t, want error token ceiling chip", kind, text, chip)
+	}
+}
+
 func TestBoardCardPriority(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

- park typed session token-ceiling failures after the first attempt instead of scheduling another full-cost retry
- post observed/ceiling token guidance and retain a board-visible human-blocker reason
- count the failure through the repeated-failure breaker and cover slow attempts, override bypass, board visibility, and hydration-starvation warnings

Fixes #1221

## UI Surface Contract

- [x] The linked issue explicitly authorizes the card-level ceiling failure signal; this PR makes no layout, density, first-viewport, or responsive visibility tradeoff.
- [x] This PR adds no persistent top-of-screen messaging.
- [x] The board uses its existing exception-chip presentation, covered by `TestBoardCardExtraShowsTokenCeilingFailure`; no layout change requires a new screenshot baseline.

## Test Plan

- [x] `make check`
- [x] `go test ./internal/orchestrator ./internal/runner ./internal/web/templates -count=1`