### PR TITLE
feat(config): hot-apply global runtime tuning

### DIFF
--- a/README.md
+++ b/README.md
@@ -2111,8 +2111,9 @@ can include `--workflow-ref origin/main` during registration or add
 | `global.startup` | Live reload |
 | `instance_name` | Live reload |
 | `global.identity` | Live reload; project runtimes restart in-process and `/api/v1/state.instance.name` updates after the next telemetry snapshot |
-| `global.max_concurrent_agents`, `global.scheduling`, `global.fair_share` | Restart required |
-| `port`, `env`, `log_level` | Restart required |
+| `global.max_concurrent_agents`, `global.scheduling`, `global.fair_share` | Live reload at the next dispatch decision; lowering capacity drains to the new limit without interrupting active workers |
+| `log_level` | Live reload |
+| `port`, `env`, `log_max_size_bytes`, `log_max_backups` | Restart required |
 
 When a changed field requires restart, Detent logs
 `global config setting change requires restart` with the field name.

--- a/cmd/detent/slog.go
+++ b/cmd/detent/slog.go
@@ -21,8 +21,21 @@ func setupLoggerFromEnv(stdout io.Writer, stderr io.Writer) *slog.Logger {
 	return setupLoggerWithOutputsAndSource(env, envSet, envValue("LOG_LEVEL", "DETENT_LOG_LEVEL"), stdout, stderr, stdoutTTY, commandOutputJSONSelected(os.Args[1:], stdoutTTY), addSource)
 }
 
-func setupLoggerFromRuntime(settings cli.RuntimeSettings, stdout io.Writer, stderr io.Writer, stdoutTTY bool) {
-	setupLoggerWithOutputsAndSource(settings.Env.Value, strings.TrimSpace(settings.Env.Value) != "", settings.LogLevel.Value, stdout, stderr, stdoutTTY, commandOutputJSONSelected(os.Args[1:], stdoutTTY), logSourceSettingFromEnv())
+func setupLoggerFromRuntime(settings cli.RuntimeSettings, stdout io.Writer, stderr io.Writer, stdoutTTY bool) *slog.LevelVar {
+	return setupRuntimeLoggerWithOutputsAndSource(settings.Env.Value, strings.TrimSpace(settings.Env.Value) != "", settings.LogLevel.Value, stdout, stderr, stdoutTTY, commandOutputJSONSelected(os.Args[1:], stdoutTTY), logSourceSettingFromEnv())
+}
+
+func setupRuntimeLoggerWithOutputsAndSource(env string, envSet bool, level string, stdout io.Writer, stderr io.Writer, stdoutTTY bool, forceStderr bool, addSource logSourceSetting) *slog.LevelVar {
+	w := stderr
+	if !forceStderr && useTextLogs(env, envSet, stdoutTTY) {
+		w = stdout
+	}
+	parsedLevel := parseLogLevel(level)
+	levelVar := &slog.LevelVar{}
+	levelVar.Set(parsedLevel)
+	logger := slog.New(newLogHandlerForTerminalWithLevel(env, envSet, parsedLevel, levelVar, w, stdoutTTY, addSource))
+	slog.SetDefault(logger)
+	return levelVar
 }
 
 func setupLogger(env string, level string, w io.Writer) *slog.Logger {
@@ -63,10 +76,18 @@ func newLogHandlerForTerminalWithSource(env string, envSet bool, level string, w
 	}
 
 	logLevel := parseLogLevel(level)
-	source := addSource.enabled(logLevel)
+	return newLogHandlerForTerminalWithLevel(env, envSet, logLevel, logLevel, w, stdoutTTY, addSource)
+}
+
+func newLogHandlerForTerminalWithLevel(env string, envSet bool, parsedLevel slog.Level, level slog.Leveler, w io.Writer, stdoutTTY bool, addSource logSourceSetting) slog.Handler {
+	if w == nil {
+		w = io.Discard
+	}
+
+	source := addSource.enabled(parsedLevel)
 	if useTextLogs(env, envSet, stdoutTTY) {
 		return tint.NewHandler(w, &tint.Options{
-			Level:       logLevel,
+			Level:       level,
 			TimeFormat:  time.Kitchen,
 			AddSource:   source,
 			ReplaceAttr: textLogReplaceAttr,
@@ -74,7 +95,7 @@ func newLogHandlerForTerminalWithSource(env string, envSet bool, level string, w
 	}
 
 	return slog.NewJSONHandler(w, &slog.HandlerOptions{
-		Level:       logLevel,
+		Level:       level,
 		AddSource:   source,
 		ReplaceAttr: sourceLogReplaceAttr,
 	})

--- a/cmd/detent/slog_test.go
+++ b/cmd/detent/slog_test.go
@@ -9,6 +9,8 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/digitaldrywood/detent/internal/cli"
 )
 
 func TestParseLogLevel(t *testing.T) {
@@ -50,6 +52,27 @@ func TestSetupLoggerSetsDefault(t *testing.T) {
 	}
 	if !logger.Enabled(context.Background(), slog.LevelDebug) {
 		t.Fatal("debug logger does not enable debug records")
+	}
+}
+
+func TestSetupLoggerFromRuntimeReturnsLiveLevel(t *testing.T) {
+	previous := slog.Default()
+	t.Cleanup(func() {
+		slog.SetDefault(previous)
+	})
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	level := setupLoggerFromRuntime(cli.RuntimeSettings{
+		Env:      cli.RuntimeValue{Value: "production"},
+		LogLevel: cli.RuntimeValue{Value: "info"},
+	}, &stdout, &stderr, false)
+	slog.Debug("before reload")
+	level.Set(slog.LevelDebug)
+	slog.Debug("after reload")
+
+	if strings.Contains(stderr.String(), "before reload") || !strings.Contains(stderr.String(), "after reload") {
+		t.Fatalf("stderr = %q, want only post-reload debug record", stderr.String())
 	}
 }
 

--- a/docs/ONBOARDING.md
+++ b/docs/ONBOARDING.md
@@ -2925,8 +2925,9 @@ awk 'NF {last=$0} END {exit last == "MUTATION_CONFIRMED=true" ? 0 : 1}' "$ONBOAR
    | `global.startup` | Live reload |
    | `instance_name` | Live reload |
    | `global.identity` | Live reload; project runtimes restart in-process and `/api/v1/state.instance.name` updates after the next telemetry snapshot |
-   | `global.max_concurrent_agents`, `global.scheduling`, `global.fair_share` | Restart required |
-   | `port`, `env`, `log_level` | Restart required |
+   | `global.max_concurrent_agents`, `global.scheduling`, `global.fair_share` | Live reload at the next dispatch decision; lowering capacity drains to the new limit without interrupting active workers |
+   | `log_level` | Live reload |
+   | `port`, `env`, `log_max_size_bytes`, `log_max_backups` | Restart required |
 
    When a changed field requires restart, Detent logs
    `global config setting change requires restart` with the field name.

--- a/internal/cli/boot.go
+++ b/internal/cli/boot.go
@@ -161,7 +161,7 @@ func startRunning(ctx context.Context, cfg BootConfig) error {
 
 	useDashboard := shouldLaunchTerminalDashboard(cfg)
 	if useDashboard {
-		restoreLogger, err := redirectDefaultLoggerWithRotation(runtimeLogPath(cfg), cfg.Runtime.LogLevel.Value, runtimeLogRotation(cfg.Runtime))
+		restoreLogger, err := redirectDefaultLoggerWithRotation(runtimeLogPath(cfg), cfg.Runtime.LogLevel.Value, runtimeLogRotation(cfg.Runtime), cfg.LogLevel)
 		if err != nil {
 			return err
 		}
@@ -324,12 +324,16 @@ func startRunning(ctx context.Context, cfg BootConfig) error {
 		globalConfigState.set(reloaded)
 		republishLatestSnapshot(snapshotHub, logger)
 	}
+	reloadLogLevel := runtimeLogLevelForReload(cfg)
+	applyRuntimeConfig := func(reloaded globalconfig.Config) error {
+		return applyGlobalRuntimeConfig(globalDispatchGate, runtimeStore, reloadLogLevel, reloaded)
+	}
 	startProjects := func(ctx context.Context) error {
 		if err := manager.Start(ctx); err != nil {
 			return err
 		}
 		go updateScheduler.Run(ctx)
-		globalWatcherDone := startGlobalConfigWatcher(ctx, cfg.Global, manager, logger, runtimeGitHubToken, onGlobalReload)
+		globalWatcherDone := startGlobalConfigWatcher(ctx, cfg.Global, manager, logger, runtimeGitHubToken, applyRuntimeConfig, onGlobalReload)
 		select {
 		case globalWatcherStarted <- globalWatcherDone:
 		default:
@@ -721,7 +725,7 @@ func redirectDefaultLogger(path string, level string) (func(), error) {
 	return redirectDefaultLoggerWithRotation(path, level, defaultRuntimeLogRotation())
 }
 
-func redirectDefaultLoggerWithRotation(path string, level string, rotation logRotation) (func(), error) {
+func redirectDefaultLoggerWithRotation(path string, level string, rotation logRotation, levels ...*slog.LevelVar) (func(), error) {
 	if strings.TrimSpace(path) == "" {
 		return nil, errors.New("log path is required")
 	}
@@ -735,10 +739,11 @@ func redirectDefaultLoggerWithRotation(path string, level string, rotation logRo
 	}
 
 	previous := slog.Default()
-	logLevel := parseSlogLevel(level)
+	parsedLevel := parseSlogLevel(level)
+	logLevel := resolveRuntimeLogLevel(parsedLevel, levels)
 	slog.SetDefault(slog.New(slog.NewJSONHandler(file, &slog.HandlerOptions{
 		Level:     logLevel,
-		AddSource: runtimeLogAddSource(logLevel),
+		AddSource: runtimeLogAddSource(parsedLevel),
 	})))
 
 	return func() {
@@ -747,6 +752,16 @@ func redirectDefaultLoggerWithRotation(path string, level string, rotation logRo
 			previous.Warn("close log file failed", "path", path, "error", err)
 		}
 	}, nil
+}
+
+func resolveRuntimeLogLevel(initial slog.Level, levels []*slog.LevelVar) *slog.LevelVar {
+	if len(levels) > 0 && levels[0] != nil {
+		levels[0].Set(initial)
+		return levels[0]
+	}
+	level := &slog.LevelVar{}
+	level.Set(initial)
+	return level
 }
 
 type logRotation struct {
@@ -954,18 +969,9 @@ func bootWorkflow(ctx context.Context, cfg BootConfig) (workflowconfig.Workflow,
 }
 
 func buildGlobalScheduler(settings globalconfig.Settings, fairShareStore scheduler.FairShareStore) (scheduler.GlobalScheduler, error) {
-	halfLife, err := globalFairShareHalfLife(settings.FairShare)
+	schedulerConfig, err := globalSchedulerConfig(settings, fairShareStore)
 	if err != nil {
 		return nil, err
-	}
-
-	schedulerConfig := scheduler.Config{
-		Kind:          settings.Scheduling,
-		Capacity:      settings.MaxConcurrentAgents,
-		DecayHalfLife: halfLife,
-	}
-	if settings.Scheduling == globalconfig.SchedulingFairShare {
-		schedulerConfig.FairShareStore = fairShareStore
 	}
 
 	sched, err := scheduler.NewFromConfig(schedulerConfig)
@@ -977,6 +983,52 @@ func buildGlobalScheduler(settings globalconfig.Settings, fairShareStore schedul
 		return nil, fmt.Errorf("create global scheduler: %w", scheduler.ErrUnsupportedBackend)
 	}
 	return global, nil
+}
+
+func globalSchedulerConfig(settings globalconfig.Settings, fairShareStore scheduler.FairShareStore) (scheduler.Config, error) {
+	halfLife, err := globalFairShareHalfLife(settings.FairShare)
+	if err != nil {
+		return scheduler.Config{}, err
+	}
+
+	schedulerConfig := scheduler.Config{
+		Kind:          settings.Scheduling,
+		Capacity:      settings.MaxConcurrentAgents,
+		DecayHalfLife: halfLife,
+	}
+	if settings.Scheduling == globalconfig.SchedulingFairShare {
+		schedulerConfig.FairShareStore = fairShareStore
+	}
+
+	return schedulerConfig, nil
+}
+
+func applyGlobalRuntimeConfig(
+	gate *scheduler.GlobalDispatchGate,
+	fairShareStore scheduler.FairShareStore,
+	logLevel *slog.LevelVar,
+	cfg globalconfig.Config,
+) error {
+	schedulerConfig, err := globalSchedulerConfig(cfg.Global, fairShareStore)
+	if err != nil {
+		return err
+	}
+	if err := gate.Reconfigure(schedulerConfig); err != nil {
+		return fmt.Errorf("reconfigure global scheduler: %w", err)
+	}
+	if logLevel != nil {
+		logLevel.Set(parseSlogLevel(cfg.LogLevel))
+	}
+	return nil
+}
+
+func runtimeLogLevelForReload(cfg BootConfig) *slog.LevelVar {
+	switch cfg.Runtime.LogLevel.Source {
+	case runtimeSourceConfig, runtimeSourceDefault:
+		return cfg.LogLevel
+	default:
+		return nil
+	}
 }
 
 func globalFairShareHalfLife(settings map[string]any) (time.Duration, error) {

--- a/internal/cli/boot_test.go
+++ b/internal/cli/boot_test.go
@@ -102,6 +102,37 @@ func TestBuildGlobalSchedulerFromSettings(t *testing.T) {
 	}
 }
 
+func TestRuntimeLogLevelForReloadPreservesOverrides(t *testing.T) {
+	t.Parallel()
+
+	level := &slog.LevelVar{}
+	tests := []struct {
+		name   string
+		source string
+		want   *slog.LevelVar
+	}{
+		{name: "config", source: runtimeSourceConfig, want: level},
+		{name: "default", source: runtimeSourceDefault, want: level},
+		{name: "flag", source: runtimeSourceFlag},
+		{name: "primary environment", source: "LOG_LEVEL"},
+		{name: "deprecated environment", source: "DETENT_LOG_LEVEL"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			cfg := BootConfig{
+				Runtime:  RuntimeSettings{LogLevel: RuntimeValue{Source: tt.source}},
+				LogLevel: level,
+			}
+			if got := runtimeLogLevelForReload(cfg); got != tt.want {
+				t.Fatalf("runtimeLogLevelForReload() = %p, want %p", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestSyncGlobalDispatchProjectsMarksUnstartedProjectsIdle(t *testing.T) {
 	t.Parallel()
 

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -165,6 +165,7 @@ type BootConfig struct {
 	Global           globalconfig.Config
 	ConfigPathRule   globalconfig.PathRule
 	Runtime          RuntimeSettings
+	LogLevel         *slog.LevelVar
 	WorkflowPath     string
 	Host             string
 	Port             *int
@@ -201,7 +202,7 @@ type BootFunc func(context.Context, BootConfig) error
 
 type SignalFunc func(context.Context, Signal) error
 
-type LoggerFunc func(RuntimeSettings, io.Writer, io.Writer, bool)
+type LoggerFunc func(RuntimeSettings, io.Writer, io.Writer, bool) *slog.LevelVar
 
 type CommandRunner func(context.Context, string, ...string) (string, error)
 
@@ -383,7 +384,7 @@ detent --format json config path`),
 			}
 			stdoutTTY := opts.stdoutTTY()
 			if opts.configureLog != nil {
-				opts.configureLog(boot.Runtime, cmd.OutOrStdout(), cmd.ErrOrStderr(), stdoutTTY)
+				boot.LogLevel = opts.configureLog(boot.Runtime, cmd.OutOrStdout(), cmd.ErrOrStderr(), stdoutTTY)
 			}
 			boot.Headless = headless
 			boot.StdoutTTY = stdoutTTY

--- a/internal/cli/global_reload.go
+++ b/internal/cli/global_reload.go
@@ -25,12 +25,15 @@ type globalConfigReloader struct {
 	logger             *slog.Logger
 	githubToken        *runtimeGitHubTokenState
 	resolveGitHubToken func(context.Context, globalconfig.Config) (string, error)
+	applyRuntime       func(globalconfig.Config) error
 	onReload           func(globalconfig.Config)
 }
 
 type globalConfigChange struct {
 	Field           string
 	RequiresRestart bool
+	Old             any
+	New             any
 }
 
 func startGlobalConfigWatcher(
@@ -39,7 +42,8 @@ func startGlobalConfigWatcher(
 	manager globalConfigManager,
 	logger *slog.Logger,
 	githubToken *runtimeGitHubTokenState,
-	onReload ...func(globalconfig.Config),
+	applyRuntime func(globalconfig.Config) error,
+	onReload func(globalconfig.Config),
 ) <-chan struct{} {
 	if ctx == nil {
 		ctx = context.Background()
@@ -67,13 +71,12 @@ func startGlobalConfigWatcher(
 
 	done := make(chan struct{})
 	reloader := &globalConfigReloader{
-		current:     current,
-		manager:     manager,
-		logger:      logger,
-		githubToken: githubToken,
-	}
-	if len(onReload) > 0 {
-		reloader.onReload = onReload[0]
+		current:      current,
+		manager:      manager,
+		logger:       logger,
+		githubToken:  githubToken,
+		applyRuntime: applyRuntime,
+		onReload:     onReload,
 	}
 	syncLatestGlobalConfig(ctx, path, reloader)
 	go func() {
@@ -167,8 +170,19 @@ func (r *globalConfigReloader) apply(
 	}
 
 	managerConfig := managerConfigWithRuntimeGitHubToken(update.Value, nextGitHubToken)
+	if r.applyRuntime != nil {
+		if err := r.applyRuntime(update.Value); err != nil {
+			if r.githubToken != nil {
+				r.githubToken.set(previousGitHubToken)
+			}
+			return project.ReconcileResult{}, err
+		}
+	}
 	result, err := r.manager.Reconcile(ctx, managerConfig)
 	if err != nil {
+		if r.applyRuntime != nil {
+			err = errors.Join(err, r.applyRuntime(r.current))
+		}
 		if r.githubToken != nil {
 			r.githubToken.set(previousGitHubToken)
 		}
@@ -225,17 +239,17 @@ func logGlobalConfigChanges(logger *slog.Logger, previous globalconfig.Config, n
 			logger.Warn("global config setting change requires restart", "field", change.Field)
 			continue
 		}
-		logger.Info("global config setting reloaded", "field", change.Field)
+		logger.Info("global config setting reloaded", "field", change.Field, "old", change.Old, "new", change.New)
 	}
 }
 
 func changedGlobalConfigFields(previous globalconfig.Config, next globalconfig.Config) []globalConfigChange {
 	fields := []globalConfigChange{}
 	if previous.Env != next.Env {
-		fields = append(fields, globalConfigChange{Field: "env", RequiresRestart: true})
+		fields = append(fields, globalConfigChange{Field: "env", RequiresRestart: true, Old: previous.Env, New: next.Env})
 	}
 	if previous.LogLevel != next.LogLevel {
-		fields = append(fields, globalConfigChange{Field: "log_level", RequiresRestart: true})
+		fields = append(fields, globalConfigChange{Field: "log_level", Old: previous.LogLevel, New: next.LogLevel})
 	}
 	if !sameOptionalInt(previous.LogMaxSizeBytes, next.LogMaxSizeBytes) {
 		fields = append(fields, globalConfigChange{Field: "log_max_size_bytes", RequiresRestart: true})
@@ -244,16 +258,16 @@ func changedGlobalConfigFields(previous globalconfig.Config, next globalconfig.C
 		fields = append(fields, globalConfigChange{Field: "log_max_backups", RequiresRestart: true})
 	}
 	if previous.GitHubToken != next.GitHubToken {
-		fields = append(fields, globalConfigChange{Field: "github_token"})
+		fields = append(fields, globalConfigChange{Field: "github_token", Old: "<redacted>", New: "<redacted>"})
 	}
 	if !sameOptionalInt(previous.Port, next.Port) {
 		fields = append(fields, globalConfigChange{Field: "port", RequiresRestart: true})
 	}
 	if previous.InstanceName != next.InstanceName {
-		fields = append(fields, globalConfigChange{Field: "instance_name"})
+		fields = append(fields, globalConfigChange{Field: "instance_name", Old: previous.InstanceName, New: next.InstanceName})
 	}
 	if !reflect.DeepEqual(previous.Projects, next.Projects) {
-		fields = append(fields, globalConfigChange{Field: "projects"})
+		fields = append(fields, globalConfigChange{Field: "projects", Old: globalProjectIDs(previous.Projects), New: globalProjectIDs(next.Projects)})
 	}
 	fields = append(fields, changedGlobalSettings(previous.Global, next.Global)...)
 	return fields
@@ -262,21 +276,29 @@ func changedGlobalConfigFields(previous globalconfig.Config, next globalconfig.C
 func changedGlobalSettings(previous globalconfig.Settings, next globalconfig.Settings) []globalConfigChange {
 	fields := []globalConfigChange{}
 	if previous.MaxConcurrentAgents != next.MaxConcurrentAgents {
-		fields = append(fields, globalConfigChange{Field: "global.max_concurrent_agents", RequiresRestart: true})
+		fields = append(fields, globalConfigChange{Field: "global.max_concurrent_agents", Old: previous.MaxConcurrentAgents, New: next.MaxConcurrentAgents})
 	}
 	if previous.Scheduling != next.Scheduling {
-		fields = append(fields, globalConfigChange{Field: "global.scheduling", RequiresRestart: true})
+		fields = append(fields, globalConfigChange{Field: "global.scheduling", Old: previous.Scheduling, New: next.Scheduling})
 	}
 	if !reflect.DeepEqual(previous.Identity, next.Identity) {
-		fields = append(fields, globalConfigChange{Field: "global.identity"})
+		fields = append(fields, globalConfigChange{Field: "global.identity", Old: previous.Identity, New: next.Identity})
 	}
 	if !reflect.DeepEqual(previous.FairShare, next.FairShare) {
-		fields = append(fields, globalConfigChange{Field: "global.fair_share", RequiresRestart: true})
+		fields = append(fields, globalConfigChange{Field: "global.fair_share", Old: previous.FairShare, New: next.FairShare})
 	}
 	if !reflect.DeepEqual(previous.Startup, next.Startup) {
-		fields = append(fields, globalConfigChange{Field: "global.startup"})
+		fields = append(fields, globalConfigChange{Field: "global.startup", Old: previous.Startup, New: next.Startup})
 	}
 	return fields
+}
+
+func globalProjectIDs(projects []globalconfig.Project) []string {
+	ids := make([]string, 0, len(projects))
+	for _, cfg := range projects {
+		ids = append(ids, cfg.ID)
+	}
+	return ids
 }
 
 func sameOptionalInt(left *int, right *int) bool {

--- a/internal/cli/global_reload_test.go
+++ b/internal/cli/global_reload_test.go
@@ -1,14 +1,20 @@
 package cli
 
 import (
+	"bytes"
 	"context"
 	"errors"
+	"log/slog"
 	"reflect"
+	"strings"
 	"testing"
+	"time"
 
 	globalconfig "github.com/digitaldrywood/detent/internal/config/global"
 	configwatcher "github.com/digitaldrywood/detent/internal/config/watcher"
 	"github.com/digitaldrywood/detent/internal/project"
+	"github.com/digitaldrywood/detent/internal/scheduler"
+	"github.com/digitaldrywood/detent/internal/store"
 )
 
 func TestGlobalConfigReloaderApply(t *testing.T) {
@@ -158,6 +164,34 @@ func TestGlobalConfigReloaderRestoresRuntimeGitHubTokenOnError(t *testing.T) {
 	}
 }
 
+func TestGlobalConfigReloaderRestoresRuntimeConfigOnReconcileError(t *testing.T) {
+	t.Parallel()
+
+	reconcileErr := errors.New("reconcile failed")
+	current := reloadTestConfig("global.yaml", 2, nil)
+	next := reloadTestConfig("global.yaml", 4, nil)
+	applied := []int{}
+	reloader := &globalConfigReloader{
+		current: current,
+		manager: &globalReloadManager{err: reconcileErr},
+		applyRuntime: func(cfg globalconfig.Config) error {
+			applied = append(applied, cfg.Global.MaxConcurrentAgents)
+			return nil
+		},
+	}
+
+	_, err := reloader.apply(context.Background(), configwatcher.FileUpdate[globalconfig.Config]{
+		Path:  next.Path,
+		Value: next,
+	})
+	if !errors.Is(err, reconcileErr) {
+		t.Fatalf("apply() error = %v, want %v", err, reconcileErr)
+	}
+	if want := []int{4, 2}; !reflect.DeepEqual(applied, want) {
+		t.Fatalf("runtime capacities = %v, want %v", applied, want)
+	}
+}
+
 func TestGlobalConfigReloaderAppliesIdentityReload(t *testing.T) {
 	t.Parallel()
 
@@ -186,45 +220,195 @@ func TestGlobalConfigReloaderAppliesIdentityReload(t *testing.T) {
 	}
 }
 
-func TestChangedGlobalConfigFieldsReloadMatrix(t *testing.T) {
+func TestChangedGlobalConfigFieldsReloadClassification(t *testing.T) {
 	t.Parallel()
 
-	base := reloadTestConfig("global.yaml", 2, []globalconfig.Project{{ID: "alpha", Weight: 1}})
-	next := reloadTestConfig("global.yaml", 4, []globalconfig.Project{{ID: "bravo", Weight: 2, CredentialRef: "github-app"}})
-	next.Env = "dev"
-	next.LogLevel = "debug"
-	logMaxSizeBytes := 2048
-	logMaxBackups := 2
-	next.LogMaxSizeBytes = &logMaxSizeBytes
-	next.LogMaxBackups = &logMaxBackups
-	next.GitHubToken = "gh"
-	port := 4101
-	next.Port = &port
-	next.InstanceName = "buildbox"
-	next.Global.Scheduling = globalconfig.SchedulingFairShare
-	next.Global.Identity = globalconfig.Identity{Name: "new-worker", GitHubLogin: "new-bot"}
-	next.Global.FairShare = map[string]any{"half_life": "2h"}
-	next.Global.Startup = map[string]any{"jitter_seconds": 1, "max_spawn_per_second": 2}
-
-	want := []globalConfigChange{
-		{Field: "env", RequiresRestart: true},
-		{Field: "log_level", RequiresRestart: true},
-		{Field: "log_max_size_bytes", RequiresRestart: true},
-		{Field: "log_max_backups", RequiresRestart: true},
-		{Field: "github_token", RequiresRestart: false},
-		{Field: "port", RequiresRestart: true},
-		{Field: "instance_name", RequiresRestart: false},
-		{Field: "projects", RequiresRestart: false},
-		{Field: "global.max_concurrent_agents", RequiresRestart: true},
-		{Field: "global.scheduling", RequiresRestart: true},
-		{Field: "global.identity", RequiresRestart: false},
-		{Field: "global.fair_share", RequiresRestart: true},
-		{Field: "global.startup", RequiresRestart: false},
+	tests := []struct {
+		name            string
+		field           string
+		requiresRestart bool
+		mutate          func(*globalconfig.Config)
+	}{
+		{name: "environment", field: "env", requiresRestart: true, mutate: func(cfg *globalconfig.Config) { cfg.Env = "dev" }},
+		{name: "log level", field: "log_level", mutate: func(cfg *globalconfig.Config) { cfg.LogLevel = "debug" }},
+		{name: "log max size", field: "log_max_size_bytes", requiresRestart: true, mutate: func(cfg *globalconfig.Config) { value := 2048; cfg.LogMaxSizeBytes = &value }},
+		{name: "log backups", field: "log_max_backups", requiresRestart: true, mutate: func(cfg *globalconfig.Config) { value := 2; cfg.LogMaxBackups = &value }},
+		{name: "GitHub token", field: "github_token", mutate: func(cfg *globalconfig.Config) { cfg.GitHubToken = "gh" }},
+		{name: "port", field: "port", requiresRestart: true, mutate: func(cfg *globalconfig.Config) { value := 4101; cfg.Port = &value }},
+		{name: "instance name", field: "instance_name", mutate: func(cfg *globalconfig.Config) { cfg.InstanceName = "buildbox" }},
+		{name: "projects", field: "projects", mutate: func(cfg *globalconfig.Config) { cfg.Projects = []globalconfig.Project{{ID: "bravo", Weight: 2}} }},
+		{name: "maximum concurrent agents", field: "global.max_concurrent_agents", mutate: func(cfg *globalconfig.Config) { cfg.Global.MaxConcurrentAgents = 4 }},
+		{name: "scheduling", field: "global.scheduling", mutate: func(cfg *globalconfig.Config) { cfg.Global.Scheduling = globalconfig.SchedulingRoundRobin }},
+		{name: "identity", field: "global.identity", mutate: func(cfg *globalconfig.Config) {
+			cfg.Global.Identity = globalconfig.Identity{Name: "new-worker", GitHubLogin: "new-bot"}
+		}},
+		{name: "fair share", field: "global.fair_share", mutate: func(cfg *globalconfig.Config) { cfg.Global.FairShare = map[string]any{"half_life": "2h"} }},
+		{name: "startup", field: "global.startup", mutate: func(cfg *globalconfig.Config) { cfg.Global.Startup = map[string]any{"jitter_seconds": 1} }},
 	}
 
-	got := changedGlobalConfigFields(base, next)
-	if !reflect.DeepEqual(got, want) {
-		t.Fatalf("changedGlobalConfigFields() = %#v, want %#v", got, want)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			base := reloadTestConfig("global.yaml", 2, []globalconfig.Project{{ID: "alpha", Weight: 1}})
+			next := reloadTestConfig("global.yaml", 2, []globalconfig.Project{{ID: "alpha", Weight: 1}})
+			tt.mutate(&next)
+
+			got := changedGlobalConfigFields(base, next)
+			if len(got) != 1 {
+				t.Fatalf("changedGlobalConfigFields() = %#v, want one change", got)
+			}
+			if got[0].Field != tt.field || got[0].RequiresRestart != tt.requiresRestart {
+				t.Fatalf("changedGlobalConfigFields() = %#v, want field %q restart %t", got[0], tt.field, tt.requiresRestart)
+			}
+		})
+	}
+}
+
+func TestGlobalConfigReloaderHotAppliesSchedulerCapacityWithoutInterruptingWorkers(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	global := scheduler.NewStrictPriority(scheduler.Config{Capacity: 2})
+	gate := scheduler.NewGlobalDispatchGate(global)
+	alpha := scheduler.ProjectCandidate{ID: "alpha", Weight: 1, Priority: 3}
+	bravo := scheduler.ProjectCandidate{ID: "bravo", Weight: 1, Priority: 2}
+	charlie := scheduler.ProjectCandidate{ID: "charlie", Weight: 1, Priority: 0}
+	alphaSlot, ok, err := gate.TryAcquire(ctx, alpha, scheduler.SlotRequest{State: "Todo"}, time.Time{})
+	if err != nil || !ok {
+		t.Fatalf("alpha TryAcquire() = ok %t error %v, want granted", ok, err)
+	}
+	bravoSlot, ok, err := gate.TryAcquire(ctx, bravo, scheduler.SlotRequest{State: "Todo"}, time.Time{})
+	if err != nil || !ok {
+		t.Fatalf("bravo TryAcquire() = ok %t error %v, want granted", ok, err)
+	}
+	interrupts := 0
+	gate.SetPreempt(alphaSlot, func() { interrupts++ })
+	gate.SetPreempt(bravoSlot, func() { interrupts++ })
+
+	next := reloadTestConfig("global.yaml", 1, nil)
+	next.Global.Scheduling = globalconfig.SchedulingStrict
+	if err := applyGlobalRuntimeConfig(gate, nil, nil, next); err != nil {
+		t.Fatalf("applyGlobalRuntimeConfig() error = %v", err)
+	}
+	if _, ok, decision, err := gate.TryAcquireWithDecision(ctx, charlie, scheduler.SlotRequest{State: "Merging"}, time.Time{}); err != nil {
+		t.Fatalf("charlie TryAcquireWithDecision() error = %v", err)
+	} else if ok {
+		t.Fatal("charlie TryAcquireWithDecision() ok = true above lowered capacity")
+	} else if decision.GlobalCapacity != 1 || decision.GlobalUsed != 2 {
+		t.Fatalf("capacity decision = %#v, want capacity 1 used 2", decision)
+	}
+	if interrupts != 0 {
+		t.Fatalf("worker interrupts = %d, want 0", interrupts)
+	}
+	if err := gate.Release(alphaSlot); err != nil {
+		t.Fatalf("Release(alpha) error = %v", err)
+	}
+	if _, ok, _, err := gate.TryAcquireWithDecision(ctx, charlie, scheduler.SlotRequest{State: "Merging"}, time.Time{}); err != nil {
+		t.Fatalf("charlie second TryAcquireWithDecision() error = %v", err)
+	} else if ok {
+		t.Fatal("charlie second TryAcquireWithDecision() ok = true before usage fell below the lowered capacity")
+	}
+	if interrupts != 0 {
+		t.Fatalf("worker interrupts after attrition to capacity = %d, want 0", interrupts)
+	}
+	if err := gate.Release(bravoSlot); err != nil {
+		t.Fatalf("Release(bravo) error = %v", err)
+	}
+	charlieSlot, ok, err := gate.TryAcquire(ctx, charlie, scheduler.SlotRequest{State: "Merging"}, time.Time{})
+	if err != nil || !ok {
+		t.Fatalf("charlie TryAcquire() after attrition = ok %t error %v, want granted", ok, err)
+	}
+	next.Global.MaxConcurrentAgents = 2
+	if err := applyGlobalRuntimeConfig(gate, nil, nil, next); err != nil {
+		t.Fatalf("raise applyGlobalRuntimeConfig() error = %v", err)
+	}
+	delta := scheduler.ProjectCandidate{ID: "delta", Weight: 1, Priority: 0}
+	deltaSlot, ok, err := gate.TryAcquire(ctx, delta, scheduler.SlotRequest{State: "Todo"}, time.Time{})
+	if err != nil || !ok {
+		t.Fatalf("delta TryAcquire() after raise = ok %t error %v, want granted", ok, err)
+	}
+	if err := gate.Release(charlieSlot); err != nil {
+		t.Fatalf("Release(charlie) error = %v", err)
+	}
+	if err := gate.Release(deltaSlot); err != nil {
+		t.Fatalf("Release(delta) error = %v", err)
+	}
+}
+
+func TestGlobalConfigReloaderHotAppliesSchedulingAndFairShare(t *testing.T) {
+	t.Parallel()
+
+	store := &globalReloadFairShareStore{}
+	global := scheduler.NewWeightedFair(scheduler.Config{Capacity: 2})
+	gate := scheduler.NewGlobalDispatchGate(global)
+	next := reloadTestConfig("global.yaml", 2, nil)
+	next.Global.Scheduling = globalconfig.SchedulingFairShare
+	next.Global.FairShare = map[string]any{"half_life": "2h"}
+
+	if err := applyGlobalRuntimeConfig(gate, store, nil, next); err != nil {
+		t.Fatalf("applyGlobalRuntimeConfig() error = %v", err)
+	}
+	if global.Mode() != scheduler.ModeFairShare {
+		t.Fatalf("Mode() = %q, want %q", global.Mode(), scheduler.ModeFairShare)
+	}
+}
+
+func TestGlobalConfigReloaderHotAppliesLogLevel(t *testing.T) {
+	t.Parallel()
+
+	var logs bytes.Buffer
+	level := &slog.LevelVar{}
+	level.Set(slog.LevelInfo)
+	logger := slog.New(slog.NewTextHandler(&logs, &slog.HandlerOptions{Level: level}))
+	logger.Debug("before reload")
+
+	global := scheduler.NewWeightedFair(scheduler.Config{Capacity: 2})
+	gate := scheduler.NewGlobalDispatchGate(global)
+	next := reloadTestConfig("global.yaml", 2, nil)
+	next.LogLevel = "debug"
+	if err := applyGlobalRuntimeConfig(gate, nil, level, next); err != nil {
+		t.Fatalf("applyGlobalRuntimeConfig() error = %v", err)
+	}
+	logger.Debug("after reload")
+
+	if strings.Contains(logs.String(), "before reload") || !strings.Contains(logs.String(), "after reload") {
+		t.Fatalf("captured logs = %q, want only post-reload debug record", logs.String())
+	}
+}
+
+func TestLogGlobalConfigChangesIncludesOldAndNewValues(t *testing.T) {
+	t.Parallel()
+
+	previous := reloadTestConfig("global.yaml", 2, nil)
+	next := reloadTestConfig("global.yaml", 1, nil)
+	var logs bytes.Buffer
+	logger := slog.New(slog.NewTextHandler(&logs, nil))
+
+	logGlobalConfigChanges(logger, previous, next)
+
+	for _, want := range []string{"global config setting reloaded", "field=global.max_concurrent_agents", "old=2", "new=1"} {
+		if !strings.Contains(logs.String(), want) {
+			t.Fatalf("reload log missing %q: %s", want, logs.String())
+		}
+	}
+}
+
+func TestLogGlobalConfigChangesPreservesRestartWarning(t *testing.T) {
+	t.Parallel()
+
+	previous := reloadTestConfig("global.yaml", 2, nil)
+	next := reloadTestConfig("global.yaml", 2, nil)
+	next.Env = "production"
+	var logs bytes.Buffer
+	logger := slog.New(slog.NewTextHandler(&logs, nil))
+
+	logGlobalConfigChanges(logger, previous, next)
+
+	for _, want := range []string{"level=WARN", `msg="global config setting change requires restart"`, "field=env"} {
+		if !strings.Contains(logs.String(), want) {
+			t.Fatalf("restart warning missing %q: %s", want, logs.String())
+		}
 	}
 }
 
@@ -232,6 +416,16 @@ type globalReloadManager struct {
 	calls  int
 	config project.ManagerConfig
 	err    error
+}
+
+type globalReloadFairShareStore struct{}
+
+func (s *globalReloadFairShareStore) ListFairShareUsage(context.Context) ([]store.FairShareUsage, error) {
+	return nil, nil
+}
+
+func (s *globalReloadFairShareStore) RecordFairShareDispatch(context.Context, store.FairShareDispatch) error {
+	return nil
 }
 
 func (m *globalReloadManager) Reconcile(

--- a/internal/scheduler/global.go
+++ b/internal/scheduler/global.go
@@ -22,6 +22,7 @@ type FairShareStore interface {
 
 type GlobalScheduler interface {
 	Scheduler
+	Reconfigurable
 	SelectProject(context.Context, ProjectSelectionRequest) (ProjectSelection, error)
 	RecordProjectDispatch(context.Context, ProjectDispatch) error
 }
@@ -103,7 +104,30 @@ func newGlobalScheduler(mode Mode, cfg Config) *globalScheduler {
 }
 
 func (s *globalScheduler) Mode() Mode {
+	s.mu.Lock()
+	defer s.mu.Unlock()
 	return s.mode
+}
+
+func (s *globalScheduler) Reconfigure(cfg Config) error {
+	mode, err := globalModeFromConfig(cfg)
+	if err != nil {
+		return err
+	}
+
+	s.sem.reconfigure(cfg)
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if s.mode != mode {
+		clear(s.weightedCurrent)
+		s.weightedLastUpdate = time.Time{}
+		s.roundRobinLastID = ""
+	}
+	s.mode = mode
+	s.decayHalfLife = cfg.DecayHalfLife
+	s.fairShareStore = cfg.FairShareStore
+	return nil
 }
 
 func (s *globalScheduler) RequestSlot(ctx context.Context, req SlotRequest) (Slot, error) {
@@ -133,8 +157,15 @@ func (s *globalScheduler) SelectProject(ctx context.Context, req ProjectSelectio
 		return ProjectSelection{}, ErrNoCandidates
 	}
 
-	switch s.mode {
+	s.mu.Lock()
+	mode := s.mode
+	s.mu.Unlock()
+
+	switch mode {
 	case ModeStrictPriority:
+		if s.capacitySnapshot("").draining {
+			return ProjectSelection{}, ErrNoSlots
+		}
 		return s.selectStrictPriority(candidates, req.Running)
 	case ModeRoundRobin:
 		if !s.projectSlotAvailable(req.Running) {
@@ -155,10 +186,14 @@ func (s *globalScheduler) SelectProject(ctx context.Context, req ProjectSelectio
 }
 
 func (s *globalScheduler) RecordProjectDispatch(ctx context.Context, dispatch ProjectDispatch) error {
-	if s.mode != ModeFairShare {
+	s.mu.Lock()
+	mode := s.mode
+	fairShareStore := s.fairShareStore
+	s.mu.Unlock()
+	if mode != ModeFairShare {
 		return nil
 	}
-	if s.fairShareStore == nil {
+	if fairShareStore == nil {
 		return ErrFairShareStoreRequired
 	}
 	if ctx == nil {
@@ -175,7 +210,7 @@ func (s *globalScheduler) RecordProjectDispatch(ctx context.Context, dispatch Pr
 		dispatchedAt = time.Now()
 	}
 
-	return s.fairShareStore.RecordFairShareDispatch(ctx, store.FairShareDispatch{
+	return fairShareStore.RecordFairShareDispatch(ctx, store.FairShareDispatch{
 		ProjectID:      projectID,
 		Weight:         normalizeProjectWeight(dispatch.Weight),
 		RuntimeSeconds: nonNegative(dispatch.RuntimeSeconds),
@@ -184,7 +219,7 @@ func (s *globalScheduler) RecordProjectDispatch(ctx context.Context, dispatch Pr
 }
 
 func (s *globalScheduler) projectSlotAvailable(running []RunningProject) bool {
-	return len(running) < s.sem.capacity
+	return len(running) < s.capacitySnapshot("").globalCapacity
 }
 
 func (s *globalScheduler) selectWeightedFair(candidates []ProjectCandidate, now time.Time) ProjectSelection {
@@ -297,12 +332,15 @@ func (s *globalScheduler) selectRoundRobin(candidates []ProjectCandidate) Projec
 }
 
 func (s *globalScheduler) selectFairShare(ctx context.Context, candidates []ProjectCandidate) (ProjectSelection, error) {
-	if s.fairShareStore == nil {
+	s.mu.Lock()
+	fairShareStore := s.fairShareStore
+	s.mu.Unlock()
+	if fairShareStore == nil {
 		return ProjectSelection{}, ErrFairShareStoreRequired
 	}
 
 	usageByProject := map[string]store.FairShareUsage{}
-	usage, err := s.fairShareStore.ListFairShareUsage(ctx)
+	usage, err := fairShareStore.ListFairShareUsage(ctx)
 	if err != nil {
 		return ProjectSelection{}, fmt.Errorf("read fair-share usage: %w", err)
 	}
@@ -324,6 +362,24 @@ func (s *globalScheduler) selectFairShare(ctx context.Context, candidates []Proj
 	}
 
 	return ProjectSelection{Project: selected}, nil
+}
+
+func globalModeFromConfig(cfg Config) (Mode, error) {
+	switch normalizeKind(cfg.Kind) {
+	case "", "weighted", "weighted_fair", "weightedfair":
+		return ModeWeightedFair, nil
+	case "strict", "strict_priority", "strictpriority":
+		return ModeStrictPriority, nil
+	case "round_robin", "roundrobin":
+		return ModeRoundRobin, nil
+	case "fair_share", "fairshare":
+		if cfg.FairShareStore == nil {
+			return "", ErrFairShareStoreRequired
+		}
+		return ModeFairShare, nil
+	default:
+		return "", fmt.Errorf("%w: %s", ErrUnsupportedBackend, strings.TrimSpace(cfg.Kind))
+	}
 }
 
 func fairShareScore(candidate ProjectCandidate, usage store.FairShareUsage) float64 {

--- a/internal/scheduler/global_gate.go
+++ b/internal/scheduler/global_gate.go
@@ -113,6 +113,29 @@ func (g *GlobalDispatchGate) SetProjects(projects []ProjectCandidate) {
 	g.projects = next
 }
 
+func (g *GlobalDispatchGate) Reconfigure(cfg Config) error {
+	if g == nil || g.global == nil {
+		return nil
+	}
+
+	g.mu.Lock()
+	defer g.mu.Unlock()
+
+	previousMode := g.global.Mode()
+	if err := g.global.Reconfigure(cfg); err != nil {
+		return err
+	}
+	clear(g.selected)
+	if previousMode != g.global.Mode() {
+		clear(g.projectCycles)
+		g.epoch++
+		if g.epoch == 0 {
+			g.epoch = 1
+		}
+	}
+	return nil
+}
+
 func (g *GlobalDispatchGate) BeginProjectCycle(project ProjectCandidate) {
 	if g == nil || g.global == nil {
 		return

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -37,6 +37,10 @@ type Scheduler interface {
 	Mode() Mode
 }
 
+type Reconfigurable interface {
+	Reconfigure(Config) error
+}
+
 type Config struct {
 	Kind            string
 	Capacity        int
@@ -77,6 +81,7 @@ type CountingSemaphore struct {
 	usedByHost      map[string]int
 	active          map[uint64]Slot
 	nextToken       uint64
+	draining        bool
 }
 
 type capacitySnapshot struct {
@@ -84,6 +89,7 @@ type capacitySnapshot struct {
 	globalUsed     int
 	stateCapacity  int
 	stateUsed      int
+	draining       bool
 }
 
 var _ Scheduler = (*CountingSemaphore)(nil)
@@ -181,8 +187,30 @@ func (s *CountingSemaphore) ReleaseSlot(slot Slot) error {
 	s.used -= held.Weight
 	decrement(s.usedByState, held.State, held.Weight)
 	decrement(s.usedByHost, held.Host, held.Weight)
+	if s.draining && s.used < s.capacity {
+		s.draining = false
+	}
 
 	return nil
+}
+
+func (s *CountingSemaphore) reconfigure(cfg Config) {
+	capacity := cfg.Capacity
+	if capacity <= 0 {
+		capacity = defaultCapacity
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if capacity < s.capacity && s.used >= capacity {
+		s.draining = true
+	} else if capacity > s.capacity {
+		s.draining = false
+	}
+	s.capacity = capacity
+	s.capacityByState = normalizedCapacities(cfg.CapacityByState)
+	s.capacityPerHost = normalizedCapacity(cfg.CapacityPerHost)
 }
 
 func (s *CountingSemaphore) Counters() Counters {
@@ -215,6 +243,7 @@ func (s *CountingSemaphore) capacitySnapshot(state string) capacitySnapshot {
 		globalUsed:     s.used,
 		stateCapacity:  stateCapacity,
 		stateUsed:      stateUsed,
+		draining:       s.draining,
 	}
 }
 

--- a/internal/web/templates/settings.templ
+++ b/internal/web/templates/settings.templ
@@ -76,8 +76,8 @@ templ Settings(data SettingsData) {
 					@settingsRow("Server host:port", data.Runtime.ServerAddress, true, true)
 				}
 				@settingsSection("settings-reload", "Configuration reload") {
-					@settingsRow("Live reload", "project list and settings · credentials · startup · instance_name · identity", false, false)
-					@settingsRow("Restart required", "max_concurrent_agents · scheduling · fair_share · port · env · log settings", false, true)
+					@settingsRow("Live reload", "project list and settings · credentials · startup · instance_name · identity · max_concurrent_agents · scheduling · fair_share · log_level", false, false)
+					@settingsRow("Restart required", "port · env · log rotation", false, true)
 				}
 				<p class="flex-none font-mono text-2xs text-dim">{ settingsBuildFooter(data) }</p>
 			</div>

--- a/internal/web/templates/settings_templ.go
+++ b/internal/web/templates/settings_templ.go
@@ -438,7 +438,7 @@ func Settings(data SettingsData) templ.Component {
 					}()
 				}
 				ctx = templ.InitializeContext(ctx)
-				templ_7745c5c3_Err = settingsRow("Live reload", "project list and settings · credentials · startup · instance_name · identity", false, false).Render(ctx, templ_7745c5c3_Buffer)
+				templ_7745c5c3_Err = settingsRow("Live reload", "project list and settings · credentials · startup · instance_name · identity · max_concurrent_agents · scheduling · fair_share · log_level", false, false).Render(ctx, templ_7745c5c3_Buffer)
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
@@ -446,7 +446,7 @@ func Settings(data SettingsData) templ.Component {
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				templ_7745c5c3_Err = settingsRow("Restart required", "max_concurrent_agents · scheduling · fair_share · port · env · log settings", false, true).Render(ctx, templ_7745c5c3_Buffer)
+				templ_7745c5c3_Err = settingsRow("Restart required", "port · env · log rotation", false, true).Render(ctx, templ_7745c5c3_Buffer)
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}


### PR DESCRIPTION
## Summary

- Hot-apply global concurrency, scheduling, and fair-share tuning at the dispatch decision boundary while preserving held worker slots.
- Back runtime logging with a shared slog.LevelVar so global log-level changes affect active text, JSON, and dashboard file handlers.
- Preserve restart warnings for environment, port, and log rotation settings while adding auditable old/new values for live changes.

Fixes #1220

## UI Surface Contract

- [x] N/A: the Settings change updates explanatory copy only and does not alter layout, density, first-viewport content, or responsive visibility.
- [x] This PR adds no persistent top-of-screen messaging.
- [x] The current-head GitHub Browser Visual gate passed, including the full browser visual and smoke suites.

## Test Plan

- [x] `make check`