### PR TITLE
feat(config): add per-project merge method

### DIFF
--- a/docs/ONBOARDING.md
+++ b/docs/ONBOARDING.md
@@ -3044,6 +3044,7 @@ the card instead of auto-resolving it.
 | Human validation label | `gate.kind: human_review` and `gate.approval_label` in `WORKFLOW.md`. |
 | Per-project concurrency | `agent.max_concurrent_agents` in `WORKFLOW.md`. |
 | Per-role reasoning effort | Optional `agent.effort.code`, `agent.effort.rework`, and `agent.effort.merge` defaults in `WORKFLOW.md`. |
+| Pull request merge strategy | `deliverable.merge_method: squash`, `merge`, or `rebase`; defaults to `squash`. |
 | Merge serialization | `agent.max_concurrent_agents_by_state.Merging: 1` in `WORKFLOW.md`. |
 | Session runaway brake | `agent.max_session_tokens`; `agent.max_session_context_multiplier` remains absent unless explicitly requested as a coarse ceiling. |
 | Hard-stop review policy | `agent.auto_promote.enabled: false` in `WORKFLOW.md`. |

--- a/docs/templates/WORKFLOW.github_local.md
+++ b/docs/templates/WORKFLOW.github_local.md
@@ -57,6 +57,8 @@ workspace:
   auto_branch: true
   cleanup_idle_ttl_ms: 86400000
   cleanup_sweep_interval_ms: 600000
+deliverable:
+  merge_method: squash
 agent:
   max_concurrent_agents: 5
   # Optional per-role reasoning defaults. Unset roles retain backend behavior.

--- a/docs/templates/WORKFLOW.issue_field.md
+++ b/docs/templates/WORKFLOW.issue_field.md
@@ -58,6 +58,8 @@ workspace:
   auto_branch: true
   cleanup_idle_ttl_ms: 86400000
   cleanup_sweep_interval_ms: 600000
+deliverable:
+  merge_method: squash
 agent:
   max_concurrent_agents: 5
   # Optional per-role reasoning defaults. Unset roles retain backend behavior.

--- a/docs/templates/WORKFLOW.label.md
+++ b/docs/templates/WORKFLOW.label.md
@@ -58,6 +58,8 @@ workspace:
   auto_branch: true
   cleanup_idle_ttl_ms: 86400000
   cleanup_sweep_interval_ms: 600000
+deliverable:
+  merge_method: squash
 agent:
   max_concurrent_agents: 5
   # Optional per-role reasoning defaults. Unset roles retain backend behavior.

--- a/docs/templates/WORKFLOW.project_v2.md
+++ b/docs/templates/WORKFLOW.project_v2.md
@@ -57,6 +57,8 @@ workspace:
   auto_branch: true
   cleanup_idle_ttl_ms: 86400000
   cleanup_sweep_interval_ms: 600000
+deliverable:
+  merge_method: squash
 agent:
   max_concurrent_agents: 5
   # Optional per-role reasoning defaults. Unset roles retain backend behavior.

--- a/internal/cli/onboarding_workflow_builder.go
+++ b/internal/cli/onboarding_workflow_builder.go
@@ -493,6 +493,9 @@ func applyOnboardingWorkflowDecisions(
 	decisions.set(root, "tracker.repository", validation.TargetRepository, "answer", "TARGET_REPOSITORY")
 	decisions.set(root, "workspace.source_root", sourceRoot, "answer", "TARGET_SOURCE_ROOT")
 	decisions.set(root, "workspace.root", worktreeRoot, worktreeProvenance, worktreeWhy)
+	if preset != "non_code_artifact" {
+		decisions.set(root, "deliverable.merge_method", workflowconfig.MergeMethodSquash, "preset", "default pull request merge strategy")
+	}
 	decisions.set(root, "agent.max_concurrent_agents", maxConcurrentAgents, maxConcurrentProvenance, maxConcurrentWhy)
 	decisions.set(root, "agent.max_turns", maxTurns, maxTurnsProvenance, maxTurnsWhy)
 	decisions.set(root, "agent.max_retry_backoff_ms", 300000, "preset", "recommended retry backoff ceiling")

--- a/internal/cli/onboarding_workflow_builder_test.go
+++ b/internal/cli/onboarding_workflow_builder_test.go
@@ -567,6 +567,9 @@ func TestBuildOnboardingWorkflowGeneratesParseablePausedProject(t *testing.T) {
 	if workflow.Config.Gate.Validator.Model != "" {
 		t.Fatalf("Gate.Validator.Model = %q, want provider or route default", workflow.Config.Gate.Validator.Model)
 	}
+	if workflow.Config.Deliverable.MergeMethod != workflowconfig.MergeMethodSquash {
+		t.Fatalf("Deliverable.MergeMethod = %q, want squash", workflow.Config.Deliverable.MergeMethod)
+	}
 	if strings.Contains(string(raw), "max_session_context_multiplier:") {
 		t.Fatalf("WORKFLOW.md includes opt-in max_session_context_multiplier:\n%s", string(raw))
 	}
@@ -598,6 +601,7 @@ func TestBuildOnboardingWorkflowGeneratesParseablePausedProject(t *testing.T) {
 	assertOnboardingWorkflowDecision(t, result.Decisions, "gate.validator.model", "preset")
 	assertOnboardingWorkflowDecision(t, result.Decisions, "agent.max_session_tokens", "preset")
 	assertOnboardingWorkflowDecision(t, result.Decisions, "agent.max_session_context_multiplier", "preset")
+	assertOnboardingWorkflowDecision(t, result.Decisions, "deliverable.merge_method", "preset")
 	assertOnboardingWorkflowDecision(t, result.Decisions, "answers.worker_model_mode", "preset")
 	assertOnboardingWorkflowDecision(t, result.Decisions, "codex.command", "preset")
 	for _, decision := range result.Decisions {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -37,6 +37,9 @@ const (
 
 	DeliverablePullRequest = "pull_request"
 	DeliverableArtifact    = "artifact"
+	MergeMethodSquash      = "squash"
+	MergeMethodMerge       = "merge"
+	MergeMethodRebase      = "rebase"
 
 	DependencyReadinessTerminal         = "terminal"
 	DependencyReadinessTerminalOrMerged = "terminal_or_merged"
@@ -209,9 +212,10 @@ type Workpad struct {
 }
 
 type Deliverable struct {
-	Kind       string `yaml:"kind"`
-	OutputRoot string `yaml:"output_root,omitempty"`
-	ReviewURL  string `yaml:"review_url,omitempty"`
+	Kind        string `yaml:"kind"`
+	MergeMethod string `yaml:"merge_method,omitempty"`
+	OutputRoot  string `yaml:"output_root,omitempty"`
+	ReviewURL   string `yaml:"review_url,omitempty"`
 }
 
 type Worker struct {
@@ -962,7 +966,8 @@ func Default() Config {
 			CleanupSweepIntervalMS: 600000,
 		},
 		Deliverable: Deliverable{
-			Kind: DeliverablePullRequest,
+			Kind:        DeliverablePullRequest,
+			MergeMethod: MergeMethodSquash,
 		},
 		Dependencies: Dependencies{
 			Source: DependencySourceMerged,
@@ -1500,6 +1505,7 @@ func (d *Deliverable) Normalize() {
 		return
 	}
 	d.Kind = normalizeDeliverableKind(d.Kind)
+	d.MergeMethod = normalizeMergeMethod(d.MergeMethod)
 	d.OutputRoot = strings.TrimSpace(d.OutputRoot)
 	d.ReviewURL = strings.TrimSpace(d.ReviewURL)
 }
@@ -1510,6 +1516,23 @@ func (d *Deliverable) validate(problems *[]string) {
 	default:
 		*problems = append(*problems, "deliverable.kind must be one of pull_request, artifact")
 	}
+	switch d.MergeMethod {
+	case "", MergeMethodSquash, MergeMethodMerge, MergeMethodRebase:
+	default:
+		*problems = append(*problems, "deliverable.merge_method must be one of squash, merge, rebase")
+	}
+}
+
+func (d Deliverable) EffectiveMergeMethod() string {
+	method := normalizeMergeMethod(d.MergeMethod)
+	if method == "" {
+		return MergeMethodSquash
+	}
+	return method
+}
+
+func normalizeMergeMethod(method string) string {
+	return strings.ToLower(strings.TrimSpace(method))
 }
 
 func normalizeDeliverableKind(kind string) string {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -45,6 +45,9 @@ func TestShippedWorkflowTemplatesEnableBudgetCaps(t *testing.T) {
 			if !workflow.Config.Budget.Enabled {
 				t.Fatalf("%s budget.enabled = false, want true", path)
 			}
+			if workflow.Config.Deliverable.Kind == DeliverablePullRequest && !strings.Contains(string(raw), "\n  merge_method: squash\n") {
+				t.Fatalf("%s does not declare deliverable.merge_method: squash", path)
+			}
 		})
 	}
 	if checked == 0 {
@@ -85,6 +88,51 @@ func TestParseWorkflowBudgetCapPresence(t *testing.T) {
 			}
 			if got := workflow.Config.Budget.PerIssueMaxUSDConfigured(); got != tt.wantPerIssue {
 				t.Fatalf("PerIssueMaxUSDConfigured() = %t, want %t", got, tt.wantPerIssue)
+			}
+		})
+	}
+}
+
+func TestParseWorkflowMergeMethod(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		value   string
+		want    string
+		wantErr string
+	}{
+		{name: "omitted defaults to squash", want: MergeMethodSquash},
+		{name: "squash", value: "squash", want: MergeMethodSquash},
+		{name: "merge", value: "merge", want: MergeMethodMerge},
+		{name: "rebase", value: "rebase", want: MergeMethodRebase},
+		{name: "normalizes case and whitespace", value: " ReBaSe ", want: MergeMethodRebase},
+		{name: "rejects invalid value", value: "octopus", wantErr: "deliverable.merge_method must be one of squash, merge, rebase"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			raw := "---\ntracker:\n  kind: memory\n"
+			if tt.value != "" {
+				raw += "deliverable:\n  merge_method: " + tt.value + "\n"
+			}
+			workflow, err := ParseWorkflow([]byte(raw + "---\nPrompt\n"))
+			if err == nil {
+				err = workflow.Config.Validate()
+			}
+			if tt.wantErr != "" {
+				if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
+					t.Fatalf("configuration error = %v, want %q", err, tt.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("configuration error = %v", err)
+			}
+			if got := workflow.Config.Deliverable.MergeMethod; got != tt.want {
+				t.Fatalf("Deliverable.MergeMethod = %q, want %q", got, tt.want)
 			}
 		})
 	}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -45,7 +45,8 @@ func TestShippedWorkflowTemplatesEnableBudgetCaps(t *testing.T) {
 			if !workflow.Config.Budget.Enabled {
 				t.Fatalf("%s budget.enabled = false, want true", path)
 			}
-			if workflow.Config.Deliverable.Kind == DeliverablePullRequest && !strings.Contains(string(raw), "\n  merge_method: squash\n") {
+			normalizedRaw := strings.ReplaceAll(string(raw), "\r\n", "\n")
+			if workflow.Config.Deliverable.Kind == DeliverablePullRequest && !strings.Contains(normalizedRaw, "\n  merge_method: squash\n") {
 				t.Fatalf("%s does not declare deliverable.merge_method: squash", path)
 			}
 		})

--- a/internal/connector/connector.go
+++ b/internal/connector/connector.go
@@ -87,7 +87,7 @@ type PullRequestCommenter interface {
 }
 
 type PullRequestMerger interface {
-	MergePullRequest(context.Context, string, int, string) error
+	MergePullRequest(context.Context, string, int, string, string) error
 }
 
 type PullRequestHydrator interface {

--- a/internal/connector/github/adapter_test.go
+++ b/internal/connector/github/adapter_test.go
@@ -4074,30 +4074,47 @@ func TestConnectorCreatePullRequestCommentUsesIssueCommentsEndpoint(t *testing.T
 	}
 }
 
-func TestConnectorMergePullRequestUsesRESTMergeEndpoint(t *testing.T) {
+func TestConnectorMergePullRequestUsesConfiguredMethod(t *testing.T) {
 	t.Parallel()
 
-	server := newGraphQLTestServer(t, []graphqlTestResponse{{
-		method: http.MethodPut,
-		path:   "/repos/example/repo/pulls/42/merge",
-		body:   `{"sha":"merge-sha","merged":true,"message":"Pull Request successfully merged"}`,
-	}})
-	c := newGitHubTestConnector(t, server, Config{})
-
-	if err := c.MergePullRequest(context.Background(), "example/repo", 42, "head-sha"); err != nil {
-		t.Fatalf("MergePullRequest() error = %v", err)
+	tests := []struct {
+		name   string
+		method string
+		want   string
+	}{
+		{name: "default", want: "squash"},
+		{name: "squash", method: "squash", want: "squash"},
+		{name: "merge", method: "merge", want: "merge"},
+		{name: "rebase", method: "rebase", want: "rebase"},
 	}
 
-	requests := server.requests()
-	if len(requests) != 1 {
-		t.Fatalf("request count = %d, want 1", len(requests))
-	}
-	if requests[0]["method"] != http.MethodPut || requests[0]["path"] != "/repos/example/repo/pulls/42/merge" {
-		t.Fatalf("merge request = %#v, want REST pull request merge", requests[0])
-	}
-	body := requests[0]["body"].(map[string]any)
-	if body["merge_method"] != "squash" || body["sha"] != "head-sha" {
-		t.Fatalf("merge body = %#v, want squash merge with head sha", body)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			server := newGraphQLTestServer(t, []graphqlTestResponse{{
+				method: http.MethodPut,
+				path:   "/repos/example/repo/pulls/42/merge",
+				body:   `{"sha":"merge-sha","merged":true,"message":"Pull Request successfully merged"}`,
+			}})
+			c := newGitHubTestConnector(t, server, Config{})
+
+			if err := c.MergePullRequest(context.Background(), "example/repo", 42, "head-sha", tt.method); err != nil {
+				t.Fatalf("MergePullRequest() error = %v", err)
+			}
+
+			requests := server.requests()
+			if len(requests) != 1 {
+				t.Fatalf("request count = %d, want 1", len(requests))
+			}
+			if requests[0]["method"] != http.MethodPut || requests[0]["path"] != "/repos/example/repo/pulls/42/merge" {
+				t.Fatalf("merge request = %#v, want REST pull request merge", requests[0])
+			}
+			body := requests[0]["body"].(map[string]any)
+			if body["merge_method"] != tt.want || body["sha"] != "head-sha" {
+				t.Fatalf("merge body = %#v, want %s merge with head sha", body, tt.want)
+			}
+		})
 	}
 }
 

--- a/internal/connector/github/adapter_test.go
+++ b/internal/connector/github/adapter_test.go
@@ -4078,14 +4078,18 @@ func TestConnectorMergePullRequestUsesConfiguredMethod(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name   string
-		method string
-		want   string
+		name         string
+		method       string
+		want         string
+		wantErr      string
+		wantRequests int
 	}{
-		{name: "default", want: "squash"},
-		{name: "squash", method: "squash", want: "squash"},
-		{name: "merge", method: "merge", want: "merge"},
-		{name: "rebase", method: "rebase", want: "rebase"},
+		{name: "default", want: "squash", wantRequests: 1},
+		{name: "squash", method: "squash", want: "squash", wantRequests: 1},
+		{name: "merge", method: "merge", want: "merge", wantRequests: 1},
+		{name: "rebase", method: "rebase", want: "rebase", wantRequests: 1},
+		{name: "normalizes case and whitespace", method: " ReBaSe ", want: "rebase", wantRequests: 1},
+		{name: "rejects invalid method", method: "octopus", wantErr: "merge method must be one of squash, merge, rebase"},
 	}
 
 	for _, tt := range tests {
@@ -4099,13 +4103,21 @@ func TestConnectorMergePullRequestUsesConfiguredMethod(t *testing.T) {
 			}})
 			c := newGitHubTestConnector(t, server, Config{})
 
-			if err := c.MergePullRequest(context.Background(), "example/repo", 42, "head-sha", tt.method); err != nil {
+			err := c.MergePullRequest(context.Background(), "example/repo", 42, "head-sha", tt.method)
+			if tt.wantErr != "" {
+				if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
+					t.Fatalf("MergePullRequest() error = %v, want %q", err, tt.wantErr)
+				}
+			} else if err != nil {
 				t.Fatalf("MergePullRequest() error = %v", err)
 			}
 
 			requests := server.requests()
-			if len(requests) != 1 {
-				t.Fatalf("request count = %d, want 1", len(requests))
+			if got := len(requests); got != tt.wantRequests {
+				t.Fatalf("request count = %d, want %d", got, tt.wantRequests)
+			}
+			if tt.wantRequests == 0 {
+				return
 			}
 			if requests[0]["method"] != http.MethodPut || requests[0]["path"] != "/repos/example/repo/pulls/42/merge" {
 				t.Fatalf("merge request = %#v, want REST pull request merge", requests[0])

--- a/internal/connector/github/pull_requests.go
+++ b/internal/connector/github/pull_requests.go
@@ -309,13 +309,22 @@ func (c *Connector) HydratePullRequest(ctx context.Context, issue connector.Issu
 	return issue, nil
 }
 
-func (c *Connector) MergePullRequest(ctx context.Context, repository string, number int, headSHA string) error {
+func (c *Connector) MergePullRequest(ctx context.Context, repository string, number int, headSHA string, mergeMethod string) error {
 	repo, ok := pullRequestRepoFromName(repository)
 	if !ok || number <= 0 {
 		return fmt.Errorf("merge github pull request: invalid pull request %s#%d", strings.TrimSpace(repository), number)
 	}
+	mergeMethod = strings.ToLower(strings.TrimSpace(mergeMethod))
+	if mergeMethod == "" {
+		mergeMethod = "squash"
+	}
+	switch mergeMethod {
+	case "squash", "merge", "rebase":
+	default:
+		return errors.New("merge github pull request: merge method must be one of squash, merge, rebase")
+	}
 	body := map[string]string{
-		"merge_method": "squash",
+		"merge_method": mergeMethod,
 	}
 	if headSHA = strings.TrimSpace(headSHA); headSHA != "" {
 		body["sha"] = headSHA

--- a/internal/connector/githublocal/githublocal.go
+++ b/internal/connector/githublocal/githublocal.go
@@ -483,8 +483,8 @@ func (c *Connector) FetchPullRequestComments(ctx context.Context, repository str
 	return c.github.FetchPullRequestComments(ctx, repository, number)
 }
 
-func (c *Connector) MergePullRequest(ctx context.Context, repository string, number int, headSHA string) error {
-	return c.github.MergePullRequest(ctx, repository, number, headSHA)
+func (c *Connector) MergePullRequest(ctx context.Context, repository string, number int, headSHA string, mergeMethod string) error {
+	return c.github.MergePullRequest(ctx, repository, number, headSHA, mergeMethod)
 }
 
 func (c *Connector) HydratePullRequest(ctx context.Context, issue connector.Issue) (connector.Issue, error) {

--- a/internal/connector/githublocal/githublocal_test.go
+++ b/internal/connector/githublocal/githublocal_test.go
@@ -146,7 +146,7 @@ func TestConnectorLocalAnnotationsStayLocalAndPRLifecycleWritesPassThrough(t *te
 	if err := conn.CreatePullRequestComment(context.Background(), "digitaldrywood/detent", 12, "ship it"); err != nil {
 		t.Fatalf("CreatePullRequestComment() error = %v", err)
 	}
-	if err := conn.MergePullRequest(context.Background(), "digitaldrywood/detent", 12, "head-sha"); err != nil {
+	if err := conn.MergePullRequest(context.Background(), "digitaldrywood/detent", 12, "head-sha", "merge"); err != nil {
 		t.Fatalf("MergePullRequest() error = %v", err)
 	}
 	got := server.writeRequests()
@@ -646,7 +646,7 @@ func (b *recordingGitHubBackend) FetchPullRequestComments(context.Context, strin
 	panic("unexpected github FetchPullRequestComments")
 }
 
-func (b *recordingGitHubBackend) MergePullRequest(context.Context, string, int, string) error {
+func (b *recordingGitHubBackend) MergePullRequest(context.Context, string, int, string, string) error {
 	panic("unexpected github MergePullRequest")
 }
 

--- a/internal/connector/memory/memory.go
+++ b/internal/connector/memory/memory.go
@@ -340,7 +340,7 @@ func (c *Connector) HydratePullRequest(_ context.Context, issue connector.Issue)
 	return cloneIssue(issue), nil
 }
 
-func (c *Connector) MergePullRequest(_ context.Context, repository string, number int, headSHA string) error {
+func (c *Connector) MergePullRequest(_ context.Context, repository string, number int, headSHA string, _ string) error {
 	repository = strings.TrimSpace(repository)
 	c.applyPullRequest(repository, number, func(issue *connector.Issue, now time.Time) {
 		if issue.PullRequest == nil {

--- a/internal/connector/memory/memory_test.go
+++ b/internal/connector/memory/memory_test.go
@@ -290,7 +290,7 @@ func TestConnectorCapturesIssueAndPullRequestComments(t *testing.T) {
 	if err := c.CreatePullRequestComment(context.Background(), "digitaldrywood/detent", 42, "pr comment"); err != nil {
 		t.Fatalf("CreatePullRequestComment() error = %v", err)
 	}
-	if err := c.MergePullRequest(context.Background(), "digitaldrywood/detent", 42, "head-sha"); err != nil {
+	if err := c.MergePullRequest(context.Background(), "digitaldrywood/detent", 42, "head-sha", "squash"); err != nil {
 		t.Fatalf("MergePullRequest() error = %v", err)
 	}
 
@@ -360,7 +360,7 @@ func TestConnectorMergePullRequestUpdatesStatefulFixture(t *testing.T) {
 		},
 	})
 
-	if err := c.MergePullRequest(context.Background(), "digitaldrywood/detent", 76, "head-sha"); err != nil {
+	if err := c.MergePullRequest(context.Background(), "digitaldrywood/detent", 76, "head-sha", "squash"); err != nil {
 		t.Fatalf("MergePullRequest() error = %v", err)
 	}
 	issues, err := c.FetchCandidateIssues(context.Background())

--- a/internal/orchestrator/autopromote_tick_test.go
+++ b/internal/orchestrator/autopromote_tick_test.go
@@ -4118,6 +4118,7 @@ func TestHandleRunResultProgrammaticallyMergesCleanMergeWorkerWithoutTerminalSta
 		MaxConcurrentAgents:   1,
 		FailureRetryBaseDelay: time.Minute,
 		MaxRetryBackoff:       time.Hour,
+		MergeMethod:           "merge",
 		ActiveStates:          []string{"Todo", "In Progress", "Rework", "Merging"},
 		TerminalStates:        []string{"Done", "Cancelled"},
 	})
@@ -4164,8 +4165,8 @@ func TestHandleRunResultProgrammaticallyMergesCleanMergeWorkerWithoutTerminalSta
 	if len(tracker.merges) != 1 {
 		t.Fatalf("merges = %#v, want one programmatic merge", tracker.merges)
 	}
-	if got := tracker.merges[0]; got.repository != "digitaldrywood/creswoodcorners-phone" || got.number != 76 || got.headSHA != "head-clean" {
-		t.Fatalf("merge request = %#v, want repository digitaldrywood/creswoodcorners-phone PR 76 head-clean", got)
+	if got := tracker.merges[0]; got.repository != "digitaldrywood/creswoodcorners-phone" || got.number != 76 || got.headSHA != "head-clean" || got.method != "merge" {
+		t.Fatalf("merge request = %#v, want repository digitaldrywood/creswoodcorners-phone PR 76 head-clean using merge", got)
 	}
 	if got := tracker.hydrations; !reflect.DeepEqual(got, []autoPromoteTickHydration{{
 		issueID:    issue.ID,
@@ -4629,6 +4630,7 @@ type autoPromoteTickMerge struct {
 	repository string
 	number     int
 	headSHA    string
+	method     string
 }
 
 type autoPromoteTickRerun struct {
@@ -4839,8 +4841,8 @@ func (c *autoPromoteTickMergeConnector) HydratePullRequest(_ context.Context, is
 	return cloneIssue(issue), nil
 }
 
-func (c *autoPromoteTickMergeConnector) MergePullRequest(_ context.Context, repository string, number int, headSHA string) error {
-	c.merges = append(c.merges, autoPromoteTickMerge{repository: repository, number: number, headSHA: headSHA})
+func (c *autoPromoteTickMergeConnector) MergePullRequest(_ context.Context, repository string, number int, headSHA string, method string) error {
+	c.merges = append(c.merges, autoPromoteTickMerge{repository: repository, number: number, headSHA: headSHA, method: method})
 	if c.err != nil {
 		return c.err
 	}

--- a/internal/orchestrator/config.go
+++ b/internal/orchestrator/config.go
@@ -24,6 +24,7 @@ func ConfigFromWorkflow(cfg workflowconfig.Config) Config {
 		DispatchPriorityByLabel:    append([]string(nil), cfg.Agent.DispatchPriorityByLabel...),
 		PrioritizeUnblockers:       cfg.Agent.PrioritizeUnblockers,
 		MergeFastPathEnabled:       cfg.Agent.MergeFastPath.Enabled,
+		MergeMethod:                cfg.Deliverable.EffectiveMergeMethod(),
 		ResumeOrphanedSessions:     cfg.Agent.ResumeOrphanedSessions,
 		MaxConcurrentAgentsPerHost: positiveIntValue(cfg.Worker.MaxConcurrentAgentsPerHost),
 		MaxRetryBackoff:            durationFromMillis(cfg.Agent.MaxRetryBackoffMS),
@@ -140,6 +141,7 @@ func normalizeConfig(cfg Config) Config {
 	cfg.MaxConcurrentAgentsByState = cloneStateLimits(cfg.MaxConcurrentAgentsByState)
 	cfg.DispatchPriorityByState = normalizedStates(cfg.DispatchPriorityByState)
 	cfg.DispatchPriorityByLabel = normalizeLabels(cfg.DispatchPriorityByLabel)
+	cfg.MergeMethod = workflowconfig.Deliverable{MergeMethod: cfg.MergeMethod}.EffectiveMergeMethod()
 	cfg.Claiming = normalizeClaimingConfig(cfg.Claiming)
 	cfg.AutoPromote = normalizeAutoPromoteConfig(cfg.AutoPromote)
 	cfg.Plan = gate.EffectivePlan(cfg.Plan)

--- a/internal/orchestrator/dispatch_test.go
+++ b/internal/orchestrator/dispatch_test.go
@@ -104,6 +104,7 @@ func TestConfigFromWorkflowIncludesDispatchControls(t *testing.T) {
 	cfg.Agent.AutoPromote.GateWaitTimeoutSeconds = 900
 	cfg.Agent.AutoPromote.ReworkLimit = 2
 	cfg.Agent.MergeFastPath.Enabled = true
+	cfg.Deliverable.MergeMethod = workflowconfig.MergeMethodRebase
 	cfg.Agent.OutputTruncation.MaxBytes = 4096
 	cfg.Identity.Name = "release-captain"
 	cfg.Identity.GitHubLogin = "detent-bot"
@@ -158,6 +159,9 @@ func TestConfigFromWorkflowIncludesDispatchControls(t *testing.T) {
 	}
 	if !got.MergeFastPathEnabled {
 		t.Fatal("MergeFastPathEnabled = false, want true")
+	}
+	if got.MergeMethod != workflowconfig.MergeMethodRebase {
+		t.Fatalf("MergeMethod = %q, want rebase", got.MergeMethod)
 	}
 	if got.OutputTruncationMaxBytes != 4096 {
 		t.Fatalf("OutputTruncationMaxBytes = %d, want 4096", got.OutputTruncationMaxBytes)

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -64,6 +64,7 @@ type Config struct {
 	DispatchPriorityByLabel       []string
 	PrioritizeUnblockers          bool
 	MergeFastPathEnabled          bool
+	MergeMethod                   string
 	ResumeOrphanedSessions        bool
 	MaxConcurrentAgentsPerHost    int
 	MaxRetryBackoff               time.Duration

--- a/internal/orchestrator/run_completion.go
+++ b/internal/orchestrator/run_completion.go
@@ -945,7 +945,7 @@ func (o *Orchestrator) completeProgrammaticMergeWorkerResult(
 	repository := pullRequestRepository(issue)
 	number := pullRequestNumber(issue)
 	headSHA := strings.TrimSpace(issue.PullRequest.HeadSHA)
-	if err := merger.MergePullRequest(ctx, repository, number, headSHA); err != nil {
+	if err := merger.MergePullRequest(ctx, repository, number, headSHA, o.cfg.MergeMethod); err != nil {
 		running.Issue = issue
 		o.failProgrammaticMergeWorkerResult(ctx, state, event, running, "programmatic_merge_failed", err)
 		return true

--- a/internal/runner/prompt.go
+++ b/internal/runner/prompt.go
@@ -102,6 +102,7 @@ func BuildPrompt(workflow config.Workflow, issue connector.Issue, opts PromptOpt
 
 	rendered = appendPriorAttemptBlock(rendered, opts.PriorAttempt)
 	rendered = appendWorkflowInstructionsBlock(rendered, workflow.Config.Agent, issue, opts)
+	rendered = appendMergeMethodBlock(rendered, workflow.Config.Deliverable)
 	rendered = appendDeliverableBlock(rendered, workflow.Config, issue, opts.WorkspacePath)
 	rendered = appendBlockedHandoffBlock(rendered)
 	rendered = appendGateBlock(rendered, workflow.Config.Gate)
@@ -158,6 +159,7 @@ func BuildMergeFallbackPrompt(workflow config.Workflow, issue connector.Issue, o
 		return "", err
 	}
 	prompt = appendWorkflowInstructionsBlock(prompt, workflow.Config.Agent, issue, opts)
+	prompt = appendMergeMethodBlock(prompt, workflow.Config.Deliverable)
 	prompt = appendBlockedHandoffBlock(prompt)
 	prompt = appendGateBlock(prompt, workflow.Config.Gate)
 	prompt = appendAvailableSkills(prompt, AvailableSkillsBlock(opts.AvailableSkills))
@@ -448,6 +450,15 @@ func appendDeliverableBlock(prompt string, cfg config.Config, issue connector.Is
 		}
 	}
 	return strings.TrimRight(prompt, " \t\r\n") + "\n\n" + strings.TrimRight(b.String(), "\n")
+}
+
+func appendMergeMethodBlock(prompt string, deliverable config.Deliverable) string {
+	if promptDeliverableKind(deliverable) != config.DeliverablePullRequest {
+		return prompt
+	}
+	return strings.TrimRight(prompt, " \t\r\n") + "\n\n## Merge strategy\n\n" +
+		"This project merges pull requests with: `" + deliverable.EffectiveMergeMethod() + "`.\n" +
+		"Use this method for every agent-shipped merge."
 }
 
 func promptDeliverableKind(cfg config.Deliverable) string {

--- a/internal/runner/prompt_test.go
+++ b/internal/runner/prompt_test.go
@@ -156,6 +156,43 @@ func TestBuildPromptSkillCreationUsesDefaultConfigForPullRequestsOnly(t *testing
 	}
 }
 
+func TestBuildPromptIncludesMergeMethod(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		deliverable config.Deliverable
+		want        string
+		wantBlock   bool
+	}{
+		{name: "omitted defaults to squash", want: "This project merges pull requests with: `squash`.", wantBlock: true},
+		{name: "squash", deliverable: config.Deliverable{MergeMethod: config.MergeMethodSquash}, want: "This project merges pull requests with: `squash`.", wantBlock: true},
+		{name: "merge", deliverable: config.Deliverable{MergeMethod: config.MergeMethodMerge}, want: "This project merges pull requests with: `merge`.", wantBlock: true},
+		{name: "rebase", deliverable: config.Deliverable{MergeMethod: config.MergeMethodRebase}, want: "This project merges pull requests with: `rebase`.", wantBlock: true},
+		{name: "artifact omits merge strategy", deliverable: config.Deliverable{Kind: config.DeliverableArtifact}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			prompt, err := BuildPrompt(config.Workflow{
+				Config: config.Config{Deliverable: tt.deliverable},
+				Prompt: "Base prompt",
+			}, connector.Issue{Identifier: "digitaldrywood/detent#1270"}, PromptOptions{})
+			if err != nil {
+				t.Fatalf("BuildPrompt() error = %v", err)
+			}
+			if got := strings.Contains(prompt, "## Merge strategy"); got != tt.wantBlock {
+				t.Fatalf("merge strategy block present = %v, want %v:\n%s", got, tt.wantBlock, prompt)
+			}
+			if tt.want != "" && !strings.Contains(prompt, tt.want) {
+				t.Fatalf("prompt missing %q:\n%s", tt.want, prompt)
+			}
+		})
+	}
+}
+
 func TestSkillDraftProposed(t *testing.T) {
 	t.Parallel()
 

--- a/internal/runner/prompt_test.go
+++ b/internal/runner/prompt_test.go
@@ -160,15 +160,18 @@ func TestBuildPromptIncludesMergeMethod(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name        string
-		deliverable config.Deliverable
-		want        string
-		wantBlock   bool
+		name          string
+		deliverable   config.Deliverable
+		mergeFallback bool
+		want          string
+		wantBlock     bool
 	}{
 		{name: "omitted defaults to squash", want: "This project merges pull requests with: `squash`.", wantBlock: true},
 		{name: "squash", deliverable: config.Deliverable{MergeMethod: config.MergeMethodSquash}, want: "This project merges pull requests with: `squash`.", wantBlock: true},
 		{name: "merge", deliverable: config.Deliverable{MergeMethod: config.MergeMethodMerge}, want: "This project merges pull requests with: `merge`.", wantBlock: true},
 		{name: "rebase", deliverable: config.Deliverable{MergeMethod: config.MergeMethodRebase}, want: "This project merges pull requests with: `rebase`.", wantBlock: true},
+		{name: "merge fallback defaults to squash", mergeFallback: true, want: "This project merges pull requests with: `squash`.", wantBlock: true},
+		{name: "merge fallback uses configured method", deliverable: config.Deliverable{MergeMethod: config.MergeMethodMerge}, mergeFallback: true, want: "This project merges pull requests with: `merge`.", wantBlock: true},
 		{name: "artifact omits merge strategy", deliverable: config.Deliverable{Kind: config.DeliverableArtifact}},
 	}
 
@@ -179,7 +182,7 @@ func TestBuildPromptIncludesMergeMethod(t *testing.T) {
 			prompt, err := BuildPrompt(config.Workflow{
 				Config: config.Config{Deliverable: tt.deliverable},
 				Prompt: "Base prompt",
-			}, connector.Issue{Identifier: "digitaldrywood/detent#1270"}, PromptOptions{})
+			}, connector.Issue{Identifier: "digitaldrywood/detent#1270"}, PromptOptions{MergeFallback: tt.mergeFallback})
 			if err != nil {
 				t.Fatalf("BuildPrompt() error = %v", err)
 			}


### PR DESCRIPTION
## Summary

- add validated per-project `deliverable.merge_method` configuration with a `squash` default
- use the configured strategy for orchestrator merges and worker merge prompts
- declare the strategy in onboarding templates and generated workflows

Fixes #1270

## UI Surface Contract

- [x] N/A, or the linked issue explicitly authorizes any high-impact UI surface, layout, density, first-viewport, or responsive visibility tradeoff.
- [x] Persistent top-of-screen messaging is explicitly authorized by the issue, or this PR does not add it.
- [x] Visual changes to primary operator screens include screenshot or browser verification below. N/A — no UI-visible changes.

## Test Plan

- [x] `go test ./internal/config ./internal/connector/... ./internal/runner ./internal/orchestrator ./internal/cli`
- [x] `make check`
- [x] changed-file coverage: 79.1% (threshold: 70%)