### PR TITLE
fix(breaker): count PR-advancing evidence

### DIFF
--- a/README.md
+++ b/README.md
@@ -2431,15 +2431,26 @@ primary or secondary provider rate-window percentage. An omitted mode preserves
 legacy metered enforcement when `budget.enabled=true`, and `detent doctor` warns
 until the mode is declared.
 
-`agent.no_progress_spend_limit_usd` defaults to `3`, below the default
-per-issue budget backstop. Detent sums persisted session cost for each issue
-after its latest accepted lane, pull-request, or
-recognized PR-signature change. In metered mode, when spend exceeds the limit,
-Detent parks the issue in `Blocked`, recommends narrowing or splitting the task,
-and requires the next worker to explain the missing progress signal in its first
-Workpad update before using tools. Set the value to `0` to disable the breaker
-and its history/spend lookups. In subscription mode, the same calculation is
-advisory telemetry and never parks the issue.
+`agent.no_progress_spend_limit_usd` defaults to a base limit of `3`, below the
+default per-issue budget backstop. The effective limit scales with the session's
+reasoning effort: unknown/low `1x`, medium `1.5x`, high `3x`, xhigh `6x`, and
+max/ultracode `8x`. These multipliers assume one retry at the observed cost
+profile should fit before the breaker fires; `detent doctor` warns when an
+effort tier's effective limit is below its observed p50 per-session cost and
+recommends a base limit with `1.5x` retry-cost headroom.
+
+Detent sums persisted session cost for each issue after its latest accepted
+lane or PR advancement. PR creation, a new head commit, a dirty-to-clean
+mergeability transition, and a failing-to-passing CI transition each reset the
+spend window. Spend accumulates only while the PR fingerprint remains static.
+In metered mode, when spend exceeds the effective limit, Detent parks the issue
+in `Blocked` and identifies whether no PR evidence was produced or a linked PR
+remained static. The latter points operators toward merge-train capacity and
+serialization tuning; the former recommends narrowing or splitting the task.
+The next worker must explain the missing progress signal in its first Workpad
+update before using tools. Set the value to `0` to disable the breaker and its
+history/spend lookups. In subscription mode, the same calculation is advisory
+telemetry and never parks the issue.
 
 `agent.failure_breaker` pauses new project dispatches when the same failure
 class reaches `same_class_limit` attempts inside `window_seconds`. The default

--- a/internal/cli/doctor_workflow_optimization.go
+++ b/internal/cli/doctor_workflow_optimization.go
@@ -37,6 +37,7 @@ const (
 	doctorWorkflowRulePinnedRouteModelRejected       = "pinned_route_model_rejected"
 	doctorWorkflowRulePinnedWorkerModelStale         = "pinned_worker_model_stale"
 	doctorWorkflowRuleSessionMultiplierKills         = "session_multiplier_ceiling_kills"
+	doctorWorkflowRuleSpendProgressBelowMedian       = "spend_progress_below_median_session_cost"
 	doctorWorkflowRuleNoSessionTokenBrake            = "no_session_token_brake"
 	doctorWorkflowRuleBudgetEstimateDrift            = "budget_estimate_drift"
 	doctorWorkflowRuleSchedulerSkipRate              = "scheduler_skip_rate"
@@ -172,6 +173,7 @@ type doctorWorkflowOptimizationMetrics struct {
 	InvalidWorkpadStatusIssue        string                               `json:"invalid_workpad_status_issue,omitempty"`
 	InvalidWorkpadStatusIssueCount   int64                                `json:"invalid_workpad_status_issue_count"`
 	OrphanRecovery                   doctorOrphanRecoveryMetrics          `json:"orphan_recovery"`
+	MedianSessionCostUSDByEffort     map[string]float64                   `json:"median_session_cost_usd_by_effort,omitempty"`
 }
 
 type doctorWorkflowModelTelemetry struct {
@@ -217,6 +219,7 @@ type doctorWorkflowSessionMetrics struct {
 	recentModelCounts        map[string]int64
 	recentDefaultModelCounts map[string]int64
 	failureTokens            int64
+	costUSDByEffort          map[string][]float64
 }
 
 type doctorWorkflowAnalyzedProject struct {
@@ -587,6 +590,7 @@ func doctorWorkflowOptimizationMetricsForProject(
 		InvalidWorkpadStatusIssue:      reviewFlow.invalidWorkpadStatusIssue,
 		InvalidWorkpadStatusIssueCount: reviewFlow.invalidWorkpadStatusIssueCount,
 		OrphanRecovery:                 orphanRecovery,
+		MedianSessionCostUSDByEffort:   doctorWorkflowMedianSessionCostUSDByEffort(sessions.costUSDByEffort),
 	}
 	if usage.count > 0 {
 		metrics.InputTokens = usage.inputTokens
@@ -786,6 +790,7 @@ SELECT
   COALESCE(s.output_tokens, 0),
   COALESCE(s.model, ''),
   COALESCE(s.requested_model, ''),
+  COALESCE(s.reasoning_effort, ''),
   COALESCE(s.final_state, ''),
   COALESCE(NULLIF(s.identifier, ''), NULLIF(s.issue_id, ''), NULLIF(s.issue_url, ''), 'unassigned'),
   COALESCE(s.completed_at, '')
@@ -810,6 +815,7 @@ ORDER BY s.completed_at DESC, s.id DESC`, projectID, projectID)
 		issueSessionCounts:       map[string]int64{},
 		recentModelCounts:        map[string]int64{},
 		recentDefaultModelCounts: map[string]int64{},
+		costUSDByEffort:          map[string][]float64{},
 	}
 	var recentCutoff time.Time
 	for rows.Next() {
@@ -819,10 +825,11 @@ ORDER BY s.completed_at DESC, s.id DESC`, projectID, projectID)
 		var outputTokens int64
 		var model string
 		var requestedModel string
+		var reasoningEffort string
 		var finalState string
 		var issueKey string
 		var completedAtRaw string
-		if err := rows.Scan(&totalTokens, &inputTokens, &cachedInputTokens, &outputTokens, &model, &requestedModel, &finalState, &issueKey, &completedAtRaw); err != nil {
+		if err := rows.Scan(&totalTokens, &inputTokens, &cachedInputTokens, &outputTokens, &model, &requestedModel, &reasoningEffort, &finalState, &issueKey, &completedAtRaw); err != nil {
 			return doctorWorkflowSessionMetrics{}, err
 		}
 		completedAt, err := doctorWorkflowSessionTimestamp(completedAtRaw)
@@ -839,6 +846,13 @@ ORDER BY s.completed_at DESC, s.id DESC`, projectID, projectID)
 		}
 		if billableTokens := doctorWorkflowBillableTokens(inputTokens, cachedInputTokens, outputTokens, totalTokens, model, pricing); billableTokens > 0 {
 			metrics.billableTokensBySession = append(metrics.billableTokensBySession, billableTokens)
+		}
+		reasoningEffort = strings.ToLower(strings.TrimSpace(reasoningEffort))
+		costModel := doctorFirstNonEmptyString(model, requestedModel)
+		if reasoningEffort != "" {
+			if costUSD, ok := budget.UsageCostUSD(pricing, costModel, inputTokens, cachedInputTokens, outputTokens); ok && costUSD > 0 {
+				metrics.costUSDByEffort[reasoningEffort] = append(metrics.costUSDByEffort[reasoningEffort], costUSD)
+			}
 		}
 		metrics.issueSessionCounts[issueKey]++
 		if metrics.count == 1 {
@@ -878,6 +892,68 @@ func doctorWorkflowRecentModelTelemetry(counts map[string]int64) []doctorWorkflo
 		return models[i].Model < models[j].Model
 	})
 	return models
+}
+
+func doctorWorkflowMedianSessionCostUSDByEffort(costs map[string][]float64) map[string]float64 {
+	medians := make(map[string]float64, len(costs))
+	for effort, values := range costs {
+		if median := doctorPercentileFloat64(values, 0.50); median > 0 {
+			medians[effort] = doctorRoundedFloat(median, 4)
+		}
+	}
+	return medians
+}
+
+func doctorWorkflowSpendProgressLimitFinding(
+	projectID string,
+	workflowPath string,
+	cfg workflowconfig.Config,
+	medianCostByEffort map[string]float64,
+) (doctorWorkflowOptimizationFinding, bool) {
+	configuredLimit := cfg.Agent.NoProgressSpendLimitUSD
+	if configuredLimit <= 0 || len(medianCostByEffort) == 0 {
+		return doctorWorkflowOptimizationFinding{}, false
+	}
+	efforts := make([]string, 0, len(medianCostByEffort))
+	for effort := range medianCostByEffort {
+		efforts = append(efforts, effort)
+	}
+	slices.Sort(efforts)
+	offendingMedians := map[string]float64{}
+	effectiveLimits := map[string]float64{}
+	details := make([]string, 0, len(efforts))
+	recommendedBase := configuredLimit
+	for _, effort := range efforts {
+		median := medianCostByEffort[effort]
+		effective := workflowconfig.EffectiveNoProgressSpendLimitUSD(configuredLimit, effort)
+		if median <= 0 || effective >= median {
+			continue
+		}
+		offendingMedians[effort] = median
+		effectiveLimits[effort] = effective
+		details = append(details, fmt.Sprintf("%s (%s < %s)", effort, budget.FormatUSD(effective), budget.FormatUSD(median)))
+		candidate := median * 1.5 / workflowconfig.NoProgressSpendLimitMultiplier(effort)
+		recommendedBase = math.Max(recommendedBase, candidate)
+	}
+	if len(offendingMedians) == 0 {
+		return doctorWorkflowOptimizationFinding{}, false
+	}
+	recommendedBase = math.Ceil(recommendedBase*100) / 100
+	return doctorWorkflowFinding(
+		projectID,
+		workflowPath,
+		doctorWorkflowRuleSpendProgressBelowMedian,
+		"Spend-progress breaker is below observed session cost",
+		"effective breaker limit is below observed p50 per-session cost for effort tier(s): "+strings.Join(details, ", "),
+		0,
+		map[string]any{
+			"configured_base_limit_usd":             configuredLimit,
+			"effective_limit_usd_by_effort":         effectiveLimits,
+			"observed_p50_session_cost_by_effort":   offendingMedians,
+			"recommended_retry_cost_headroom_ratio": 1.5,
+		},
+		doctorWorkflowOptimizationPatch{Path: "agent.no_progress_spend_limit_usd", Value: recommendedBase},
+	), true
 }
 
 func doctorWorkflowSessionGuardTelemetry(ctx context.Context, db doctorTelemetryStore, projectID string) ([]doctorWorkflowSessionGuardIncident, error) {
@@ -1226,6 +1302,9 @@ func doctorWorkflowOptimizationFindings(
 			},
 			patches...,
 		))
+	}
+	if finding, ok := doctorWorkflowSpendProgressLimitFinding(projectID, workflowPath, cfg, metrics.MedianSessionCostUSDByEffort); ok {
+		findings = append(findings, finding)
 	}
 	if incidents := doctorWorkflowRepeatedSessionGuardIncidents(metrics.SessionMultiplierKills); len(incidents) > 0 {
 		attemptCounts := make(map[string]int64, len(incidents))
@@ -2171,6 +2250,22 @@ func doctorPercentileInt64(values []int64, percentile float64) int64 {
 	}
 	sorted := append([]int64(nil), values...)
 	sort.Slice(sorted, func(i, j int) bool { return sorted[i] < sorted[j] })
+	index := int(math.Ceil(percentile*float64(len(sorted)))) - 1
+	if index < 0 {
+		index = 0
+	}
+	if index >= len(sorted) {
+		index = len(sorted) - 1
+	}
+	return sorted[index]
+}
+
+func doctorPercentileFloat64(values []float64, percentile float64) float64 {
+	if len(values) == 0 {
+		return 0
+	}
+	sorted := append([]float64(nil), values...)
+	sort.Float64s(sorted)
 	index := int(math.Ceil(percentile*float64(len(sorted)))) - 1
 	if index < 0 {
 		index = 0

--- a/internal/cli/doctor_workflow_optimization_test.go
+++ b/internal/cli/doctor_workflow_optimization_test.go
@@ -809,6 +809,47 @@ func TestDoctorWorkflowOptimizationRunawaySessionTokensRespectsConfiguredCap(t *
 	}
 }
 
+func TestDoctorWorkflowOptimizationWarnsWhenSpendProgressLimitIsBelowMedianCost(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		baseLimit   float64
+		medians     map[string]float64
+		wantFinding bool
+		wantPatch   float64
+	}{
+		{name: "xhigh effective limit below median", baseLimit: 3, medians: map[string]float64{"xhigh": 20}, wantFinding: true, wantPatch: 5},
+		{name: "xhigh effective limit above median", baseLimit: 3, medians: map[string]float64{"xhigh": 17}},
+		{name: "custom base covers median", baseLimit: 4, medians: map[string]float64{"high": 11}},
+		{name: "disabled breaker does not warn", baseLimit: 0, medians: map[string]float64{"xhigh": 20}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			cfg := workflowconfig.Default()
+			cfg.Agent.NoProgressSpendLimitUSD = tt.baseLimit
+			findings := doctorWorkflowOptimizationFindings("detent", "WORKFLOW.md", cfg, doctorWorkflowOptimizationMetrics{
+				MedianSessionCostUSDByEffort: tt.medians,
+			})
+			gotFinding := doctorWorkflowFindingExists(findings, doctorWorkflowRuleSpendProgressBelowMedian)
+			if gotFinding != tt.wantFinding {
+				t.Fatalf("spend-progress finding exists = %t, want %t: %#v", gotFinding, tt.wantFinding, findings)
+			}
+			if !tt.wantFinding {
+				return
+			}
+			finding := doctorWorkflowFindingByRule(t, findings, doctorWorkflowRuleSpendProgressBelowMedian)
+			if len(finding.Patch) != 1 || finding.Patch[0].Value != tt.wantPatch {
+				t.Fatalf("patch = %#v, want base limit %g", finding.Patch, tt.wantPatch)
+			}
+			if !strings.Contains(finding.Detail, "xhigh ($18.00 < $20.00)") {
+				t.Fatalf("detail = %q", finding.Detail)
+			}
+		})
+	}
+}
+
 func TestDoctorWorkflowOptimizationFlagsMissingSessionBrake(t *testing.T) {
 	t.Parallel()
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -354,6 +354,34 @@ func TestOverloadRetryDelayConfiguration(t *testing.T) {
 	}
 }
 
+func TestEffectiveNoProgressSpendLimitUSD(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		limit  float64
+		effort string
+		want   float64
+	}{
+		{name: "disabled", limit: 0, effort: "xhigh", want: 0},
+		{name: "unknown uses base", limit: 3, want: 3},
+		{name: "low uses base", limit: 3, effort: "low", want: 3},
+		{name: "medium", limit: 3, effort: "medium", want: 4.5},
+		{name: "high", limit: 3, effort: "high", want: 9},
+		{name: "xhigh", limit: 3, effort: "xhigh", want: 18},
+		{name: "max", limit: 3, effort: "max", want: 24},
+		{name: "ultracode", limit: 3, effort: "ultracode", want: 24},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := EffectiveNoProgressSpendLimitUSD(tt.limit, tt.effort); got != tt.want {
+				t.Fatalf("EffectiveNoProgressSpendLimitUSD(%g, %q) = %g, want %g", tt.limit, tt.effort, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestRESTFanoutMaxRequestsConfiguration(t *testing.T) {
 	t.Parallel()
 

--- a/internal/config/spend_progress.go
+++ b/internal/config/spend_progress.go
@@ -1,0 +1,25 @@
+package config
+
+import "strings"
+
+func NoProgressSpendLimitMultiplier(effort string) float64 {
+	switch strings.ToLower(strings.TrimSpace(effort)) {
+	case "medium":
+		return 1.5
+	case "high":
+		return 3
+	case "xhigh":
+		return 6
+	case "max", "ultracode":
+		return 8
+	default:
+		return 1
+	}
+}
+
+func EffectiveNoProgressSpendLimitUSD(limitUSD float64, effort string) float64 {
+	if limitUSD <= 0 {
+		return limitUSD
+	}
+	return limitUSD * NoProgressSpendLimitMultiplier(effort)
+}

--- a/internal/orchestrator/implement_progress_test.go
+++ b/internal/orchestrator/implement_progress_test.go
@@ -751,6 +751,7 @@ type implementProgressConnector struct {
 	hydrated   connector.Issue
 	refreshed  connector.Issue
 	hydrateErr error
+	refreshErr error
 	hydrations int
 	updates    []implementProgressUpdate
 	comments   []implementProgressComment
@@ -779,6 +780,9 @@ func (c *implementProgressConnector) FetchIssuesByStates(context.Context, []stri
 }
 
 func (c *implementProgressConnector) FetchIssueStatesByIDs(context.Context, []string) ([]connector.Issue, error) {
+	if c.refreshErr != nil {
+		return nil, c.refreshErr
+	}
 	if strings.TrimSpace(c.refreshed.ID) == "" {
 		return nil, nil
 	}

--- a/internal/orchestrator/run_completion.go
+++ b/internal/orchestrator/run_completion.go
@@ -153,8 +153,16 @@ func (o *Orchestrator) handleRunResult(ctx context.Context, state *State, event 
 		)
 		spendProgress := spendProgressDecision{}
 		if !mergeWorkerIssue(running.Issue) {
+			evidenceWarning := ""
+			if implementProgressLinkedPullRequest(running.Issue) || event.Result.PullRequestUpdated {
+				running.Issue, evidenceWarning = o.refreshSpendProgressIssue(ctx, running.Issue)
+			}
 			accepted, acceptedReason := dispatchAcceptedStateChange(running)
 			spendProgress = o.evaluateSpendProgress(ctx, running, event.CompletedAt, accepted, acceptedReason)
+			if evidenceWarning != "" {
+				spendProgress.Warning = evidenceWarning
+				spendProgress.Block = false
+			}
 		}
 		terminalState := terminalStateForRun(event.Err, event.Result.FinalState)
 		errorClass := workAttemptErrorRunner
@@ -267,12 +275,16 @@ func (o *Orchestrator) handleRunResult(ctx context.Context, state *State, event 
 		running.DiffStats = event.Result.DiffStats
 	}
 	progress := o.evaluateImplementCompletionProgress(ctx, running, finalState, event.Result.PullRequestUpdated)
+	running.Issue = progress.Issue
 	accepted, acceptedReason := implementAcceptedStateChange(running, progress)
 	spendProgress := o.evaluateSpendProgress(ctx, running, event.CompletedAt, accepted, acceptedReason)
+	if progress.Warning != "" && strings.HasPrefix(progress.Reason, "pull_request_hydrat") {
+		spendProgress.Warning = progress.Warning
+		spendProgress.Block = false
+	}
 	if terminalState != store.WorkAttemptTerminalSuccess {
 		progress.Outcome = terminalState
 	}
-	running.Issue = progress.Issue
 	phase := "completed"
 	statusMessage := "worker completed"
 	if terminalState == store.WorkAttemptTerminalSuccess && progress.Outcome == store.WorkAttemptTerminalNoProgress {

--- a/internal/orchestrator/safety_fuzz_test.go
+++ b/internal/orchestrator/safety_fuzz_test.go
@@ -12,7 +12,7 @@ import (
 func FuzzSafetyCriticalOrchestratorBoundaries(f *testing.F) {
 	f.Add(0, 0, 0, "", "clean", int64(1), " head ", "lint,test", int64(1), "head", "test,lint", int64(60), int64(0), true, int64(0), int64(1), int64(2), true)
 	f.Add(1, 2, 3, "fingerprint", "dirty", int64(1), "head-a", "test", int64(2), "head-b", "lint", int64(-60), int64(0), true, int64(10), int64(-10), int64(0), false)
-	f.Add(0, 0, 0, "clean", "dirty", int64(1), "same-head", "failure", int64(1), "same-head", "success", int64(0), int64(0), false, int64(0), int64(0), int64(0), false)
+	f.Add(0, 0, 0, "clean", "dirty", int64(1), "same-head", "fail", int64(1), "same-head", "pass", int64(0), int64(0), false, int64(0), int64(0), int64(0), false)
 	f.Add(0, 0, 0, "", "", int64(0), "", "", int64(0), "", "", int64(0), int64(0), false, int64(0), int64(0), int64(0), false)
 
 	f.Fuzz(func(

--- a/internal/orchestrator/safety_fuzz_test.go
+++ b/internal/orchestrator/safety_fuzz_test.go
@@ -12,6 +12,7 @@ import (
 func FuzzSafetyCriticalOrchestratorBoundaries(f *testing.F) {
 	f.Add(0, 0, 0, "", "clean", int64(1), " head ", "lint,test", int64(1), "head", "test,lint", int64(60), int64(0), true, int64(0), int64(1), int64(2), true)
 	f.Add(1, 2, 3, "fingerprint", "dirty", int64(1), "head-a", "test", int64(2), "head-b", "lint", int64(-60), int64(0), true, int64(10), int64(-10), int64(0), false)
+	f.Add(0, 0, 0, "clean", "dirty", int64(1), "same-head", "failure", int64(1), "same-head", "success", int64(0), int64(0), false, int64(0), int64(0), int64(0), false)
 	f.Add(0, 0, 0, "", "", int64(0), "", "", int64(0), "", "", int64(0), int64(0), false, int64(0), int64(0), int64(0), false)
 
 	f.Fuzz(func(
@@ -55,6 +56,33 @@ func FuzzSafetyCriticalOrchestratorBoundaries(f *testing.F) {
 			slicesEqual(autoPromoteCanonicalChecks(leftSignature.FailedChecks), autoPromoteCanonicalChecks(rightSignature.FailedChecks))
 		if gotEqual != wantEqual || gotEqual != implementProgressSignatureEqual(rightSignature, leftSignature) {
 			t.Fatalf("implementProgressSignatureEqual(%#v, %#v) = %t, want %t", leftSignature, rightSignature, gotEqual, wantEqual)
+		}
+
+		leftFingerprint := &spendProgressPRFingerprint{
+			Number:         leftNumber,
+			HeadSHA:        strings.TrimSpace(leftHead),
+			MergeableState: strings.ToLower(strings.TrimSpace(status)),
+			CIStatus:       strings.ToLower(strings.TrimSpace(leftChecks)),
+		}
+		rightFingerprint := &spendProgressPRFingerprint{
+			Number:         rightNumber,
+			HeadSHA:        strings.TrimSpace(rightHead),
+			MergeableState: strings.ToLower(strings.TrimSpace(fingerprint)),
+			CIStatus:       strings.ToLower(strings.TrimSpace(rightChecks)),
+		}
+		wantAdvance := ""
+		switch {
+		case leftNumber != rightNumber:
+			wantAdvance = "pull_request_created"
+		case leftFingerprint.HeadSHA != "" && rightFingerprint.HeadSHA != "" && leftFingerprint.HeadSHA != rightFingerprint.HeadSHA:
+			wantAdvance = "pull_request_head_changed"
+		case leftFingerprint.MergeableState == "dirty" && rightFingerprint.MergeableState == "clean":
+			wantAdvance = "pull_request_mergeable"
+		case spendProgressCIFailing(leftFingerprint.CIStatus) && spendProgressCIPassing(rightFingerprint.CIStatus):
+			wantAdvance = "pull_request_ci_passing"
+		}
+		if got := spendProgressPRAdvance(leftFingerprint, rightFingerprint); got != wantAdvance {
+			t.Fatalf("spendProgressPRAdvance(%#v, %#v) = %q, want %q", leftFingerprint, rightFingerprint, got, wantAdvance)
 		}
 
 		resetSeconds %= 1_000_000_000

--- a/internal/orchestrator/spend_progress.go
+++ b/internal/orchestrator/spend_progress.go
@@ -187,7 +187,7 @@ func spendProgressPRAdvance(previous *spendProgressPRFingerprint, current *spend
 
 func spendProgressCIFailing(status string) bool {
 	switch strings.ToLower(strings.TrimSpace(status)) {
-	case "error", "failed", "failure", "failing":
+	case "error", "fail", "failed", "failure", "failing":
 		return true
 	default:
 		return false
@@ -196,7 +196,7 @@ func spendProgressCIFailing(status string) bool {
 
 func spendProgressCIPassing(status string) bool {
 	switch strings.ToLower(strings.TrimSpace(status)) {
-	case "passed", "passing", "success", "successful":
+	case "pass", "passed", "passing", "success", "successful":
 		return true
 	default:
 		return false

--- a/internal/orchestrator/spend_progress.go
+++ b/internal/orchestrator/spend_progress.go
@@ -4,10 +4,12 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"strconv"
 	"strings"
 	"time"
 
 	"github.com/digitaldrywood/detent/internal/budget"
+	workflowconfig "github.com/digitaldrywood/detent/internal/config"
 	"github.com/digitaldrywood/detent/internal/connector"
 	runpkg "github.com/digitaldrywood/detent/internal/runner"
 	"github.com/digitaldrywood/detent/internal/store"
@@ -18,6 +20,8 @@ const (
 	spendProgressMetadataKey = "spend_since_progress_breaker"
 	spendProgressReason      = "spend_since_progress_circuit_breaker"
 	spendProgressHistorySize = 200
+	spendProgressCaseNoPR    = "spend_without_pr_evidence"
+	spendProgressCaseStatic  = "spend_with_static_pr_evidence"
 )
 
 type spendProgressDecision struct {
@@ -26,22 +30,37 @@ type spendProgressDecision struct {
 	AcceptedReason      string
 	Since               time.Time
 	Spend               store.IssueSpendSince
+	ConfiguredLimitUSD  float64
 	LimitUSD            float64
+	Effort              string
+	PRFingerprint       *spendProgressPRFingerprint
+	Case                string
 	Block               bool
 	Warning             string
 }
 
 type spendProgressRecord struct {
-	AcceptedStateChange bool    `json:"accepted_state_change,omitempty"`
-	AcceptedReason      string  `json:"accepted_reason,omitempty"`
-	Since               string  `json:"since,omitempty"`
-	SpendUSD            float64 `json:"spend_usd,omitempty"`
-	Sessions            int64   `json:"sessions,omitempty"`
-	FirstSessionAt      string  `json:"first_session_at,omitempty"`
-	LastSessionAt       string  `json:"last_session_at,omitempty"`
-	LimitUSD            float64 `json:"limit_usd,omitempty"`
-	BlockReason         string  `json:"block_reason,omitempty"`
-	Warning             string  `json:"warning,omitempty"`
+	AcceptedStateChange bool                        `json:"accepted_state_change,omitempty"`
+	AcceptedReason      string                      `json:"accepted_reason,omitempty"`
+	Since               string                      `json:"since,omitempty"`
+	SpendUSD            float64                     `json:"spend_usd,omitempty"`
+	Sessions            int64                       `json:"sessions,omitempty"`
+	FirstSessionAt      string                      `json:"first_session_at,omitempty"`
+	LastSessionAt       string                      `json:"last_session_at,omitempty"`
+	ConfiguredLimitUSD  float64                     `json:"configured_limit_usd,omitempty"`
+	LimitUSD            float64                     `json:"limit_usd,omitempty"`
+	Effort              string                      `json:"effort,omitempty"`
+	PRFingerprint       *spendProgressPRFingerprint `json:"pr_fingerprint,omitempty"`
+	Case                string                      `json:"case,omitempty"`
+	BlockReason         string                      `json:"block_reason,omitempty"`
+	Warning             string                      `json:"warning,omitempty"`
+}
+
+type spendProgressPRFingerprint struct {
+	Number         int64  `json:"number,omitempty"`
+	HeadSHA        string `json:"head_sha,omitempty"`
+	MergeableState string `json:"mergeable_state,omitempty"`
+	CIStatus       string `json:"ci_status,omitempty"`
 }
 
 func (o *Orchestrator) evaluateSpendProgress(
@@ -59,7 +78,10 @@ func (o *Orchestrator) evaluateSpendProgress(
 	if !decision.Enabled {
 		return decision
 	}
-	decision.LimitUSD = o.cfg.NoProgressSpendLimitUSD
+	decision.ConfiguredLimitUSD = o.cfg.NoProgressSpendLimitUSD
+	decision.Effort = spendProgressEffort(running)
+	decision.LimitUSD = workflowconfig.EffectiveNoProgressSpendLimitUSD(decision.ConfiguredLimitUSD, decision.Effort)
+	decision.PRFingerprint = spendProgressPRFingerprintFromIssue(running.Issue)
 	if accepted {
 		decision.Since = completedAt
 		return decision
@@ -74,6 +96,19 @@ func (o *Orchestrator) evaluateSpendProgress(
 	if err != nil {
 		decision.Warning = err.Error()
 		o.warnSpendProgress(running.Issue, "work attempt history lookup failed", err)
+		return decision
+	}
+	if previous, ok := latestSpendProgressPRFingerprint(attempts); ok {
+		if reason := spendProgressPRAdvance(previous, decision.PRFingerprint); reason != "" {
+			decision.AcceptedStateChange = true
+			decision.AcceptedReason = reason
+			decision.Since = completedAt
+			return decision
+		}
+	} else if decision.PRFingerprint != nil {
+		decision.AcceptedStateChange = true
+		decision.AcceptedReason = "pull_request_created"
+		decision.Since = completedAt
 		return decision
 	}
 	decision.Since = spendProgressBaseline(running.Issue, attempts)
@@ -92,8 +127,80 @@ func (o *Orchestrator) evaluateSpendProgress(
 		return decision
 	}
 	decision.Spend = spend
+	decision.Case = spendProgressCaseNoPR
+	if decision.PRFingerprint != nil {
+		decision.Case = spendProgressCaseStatic
+	}
 	decision.Block = !o.cfg.subscriptionBilling() && spend.CostUSD > decision.LimitUSD
 	return decision
+}
+
+func spendProgressEffort(running Running) string {
+	return strings.ToLower(strings.TrimSpace(running.RuntimeIdentity.ReasoningEffort.Value))
+}
+
+func spendProgressPRFingerprintFromIssue(issue connector.Issue) *spendProgressPRFingerprint {
+	number := workAttemptPRNumber(issue)
+	if number == nil || *number <= 0 {
+		return nil
+	}
+	fingerprint := &spendProgressPRFingerprint{Number: *number}
+	if issue.PullRequest == nil {
+		return fingerprint
+	}
+	fingerprint.HeadSHA = strings.TrimSpace(issue.PullRequest.HeadSHA)
+	fingerprint.MergeableState = strings.ToLower(strings.TrimSpace(issue.PullRequest.MergeableState))
+	fingerprint.CIStatus = strings.ToLower(strings.TrimSpace(issue.PullRequest.CIStatus))
+	return fingerprint
+}
+
+func latestSpendProgressPRFingerprint(attempts []store.WorkAttempt) (*spendProgressPRFingerprint, bool) {
+	for _, attempt := range attempts {
+		record, ok := spendProgressRecordFromAttempt(attempt)
+		if !ok || record.PRFingerprint == nil || record.PRFingerprint.Number <= 0 {
+			continue
+		}
+		fingerprint := *record.PRFingerprint
+		return &fingerprint, true
+	}
+	return nil, false
+}
+
+func spendProgressPRAdvance(previous *spendProgressPRFingerprint, current *spendProgressPRFingerprint) string {
+	if previous == nil || current == nil {
+		return ""
+	}
+	if previous.Number != current.Number {
+		return "pull_request_created"
+	}
+	if previous.HeadSHA != "" && current.HeadSHA != "" && previous.HeadSHA != current.HeadSHA {
+		return "pull_request_head_changed"
+	}
+	if previous.MergeableState == "dirty" && current.MergeableState == "clean" {
+		return "pull_request_mergeable"
+	}
+	if spendProgressCIFailing(previous.CIStatus) && spendProgressCIPassing(current.CIStatus) {
+		return "pull_request_ci_passing"
+	}
+	return ""
+}
+
+func spendProgressCIFailing(status string) bool {
+	switch strings.ToLower(strings.TrimSpace(status)) {
+	case "error", "failed", "failure", "failing":
+		return true
+	default:
+		return false
+	}
+}
+
+func spendProgressCIPassing(status string) bool {
+	switch strings.ToLower(strings.TrimSpace(status)) {
+	case "passed", "passing", "success", "successful":
+		return true
+	default:
+		return false
+	}
 }
 
 func (o *Orchestrator) recentSpendProgressAttempts(ctx context.Context, issue connector.Issue) ([]store.WorkAttempt, error) {
@@ -107,6 +214,40 @@ func (o *Orchestrator) recentSpendProgressAttempts(ctx context.Context, issue co
 		IssueURL:   strings.TrimSpace(issue.URL),
 		Limit:      spendProgressHistorySize,
 	})
+}
+
+func (o *Orchestrator) refreshSpendProgressIssue(ctx context.Context, issue connector.Issue) (connector.Issue, string) {
+	refreshed := cloneIssue(issue)
+	if !implementProgressLinkedPullRequest(refreshed) {
+		if o == nil || o.connector == nil || strings.TrimSpace(refreshed.ID) == "" {
+			return refreshed, "pull request evidence refresh unavailable"
+		}
+		issues, err := o.connector.FetchIssueStatesByIDs(ctx, []string{refreshed.ID})
+		if err != nil {
+			return refreshed, "pull request evidence refresh failed: " + err.Error()
+		}
+		for _, candidate := range issues {
+			if strings.TrimSpace(candidate.ID) == strings.TrimSpace(refreshed.ID) {
+				refreshed = mergeIssueTrackerFields(refreshed, candidate)
+				break
+			}
+		}
+	}
+	if !implementProgressLinkedPullRequest(refreshed) {
+		return refreshed, ""
+	}
+	hydrator, ok := o.connector.(connector.PullRequestHydrator)
+	if !ok {
+		return refreshed, "pull request hydrator unavailable"
+	}
+	hydrated, err := hydrator.HydratePullRequest(ctx, refreshed)
+	if err != nil {
+		return refreshed, "pull request hydration failed: " + err.Error()
+	}
+	if reason := implementProgressHydrationUnavailableReason(hydrated.PullRequest); reason != "" {
+		return hydrated, reason
+	}
+	return hydrated, ""
 }
 
 func spendProgressBaseline(issue connector.Issue, attempts []store.WorkAttempt) time.Time {
@@ -164,7 +305,11 @@ func spendProgressMetadata(decision spendProgressDecision) map[string]any {
 		AcceptedReason:      decision.AcceptedReason,
 		SpendUSD:            decision.Spend.CostUSD,
 		Sessions:            decision.Spend.Sessions,
+		ConfiguredLimitUSD:  decision.ConfiguredLimitUSD,
 		LimitUSD:            decision.LimitUSD,
+		Effort:              decision.Effort,
+		PRFingerprint:       decision.PRFingerprint,
+		Case:                decision.Case,
 		Warning:             strings.TrimSpace(decision.Warning),
 	}
 	if !decision.Since.IsZero() {
@@ -262,7 +407,7 @@ func (o *Orchestrator) blockSpendProgress(
 	state.Blocked[issueID] = Blocked{
 		Issue:          issue,
 		Reason:         spendProgressReason,
-		RecoveryReason: "narrow or split the task, then identify the missing accepted progress signal before moving the issue back to Todo or Rework",
+		RecoveryReason: spendProgressRecoveryReason(decision),
 		RecoveryTarget: "Rework",
 		BlockedAt:      blockedAt,
 		Source:         BlockedSourceProjectStatus,
@@ -270,7 +415,7 @@ func (o *Orchestrator) blockSpendProgress(
 	recordStateEvent(state, telemetry.ActivityEvent{
 		At:      blockedAt,
 		Event:   "spend_since_progress_circuit_breaker_tripped",
-		Message: fmt.Sprintf("parked %s after %s without an accepted state change", issueLabel(issue), budget.FormatUSD(decision.Spend.CostUSD)),
+		Message: fmt.Sprintf("parked %s after %s: %s", issueLabel(issue), budget.FormatUSD(decision.Spend.CostUSD), spendProgressCaseSummary(decision.Case)),
 	})
 	if o.logger != nil {
 		o.logger.Error("spend since progress circuit breaker tripped",
@@ -281,6 +426,8 @@ func (o *Orchestrator) blockSpendProgress(
 			"limit_usd", decision.LimitUSD,
 			"sessions", decision.Spend.Sessions,
 			"since", decision.Since,
+			"case", decision.Case,
+			"effort", decision.Effort,
 		)
 	}
 	return true
@@ -288,35 +435,83 @@ func (o *Orchestrator) blockSpendProgress(
 
 func spendProgressComment(issue connector.Issue, decision spendProgressDecision) string {
 	var b strings.Builder
-	b.WriteString("Routed this issue to Blocked because agent spend continued without an accepted state change.")
+	b.WriteString("Routed this issue to Blocked because ")
+	b.WriteString(spendProgressCaseSummary(decision.Case))
+	b.WriteString(".")
 	b.WriteString("\n\n- reason: ")
 	b.WriteString(spendProgressReason)
+	b.WriteString("\n- case: ")
+	b.WriteString(decision.Case)
 	b.WriteString("\n- issue: ")
 	b.WriteString(issueLabel(issue))
-	b.WriteString("\n- spend_since_last_accepted_state_change: ")
+	b.WriteString("\n- spend_since_last_accepted_progress: ")
 	b.WriteString(budget.FormatUSD(decision.Spend.CostUSD))
 	b.WriteString("\n- no_progress_spend_limit_usd: ")
 	b.WriteString(budget.FormatUSD(decision.LimitUSD))
+	if decision.Effort != "" {
+		b.WriteString("\n- effective_effort: ")
+		b.WriteString(decision.Effort)
+		b.WriteString("\n- configured_base_limit_usd: ")
+		b.WriteString(budget.FormatUSD(decision.ConfiguredLimitUSD))
+	}
 	b.WriteString(fmt.Sprintf("\n- sessions: %d", decision.Spend.Sessions))
+	if decision.PRFingerprint != nil {
+		b.WriteString("\n- pr_number: ")
+		b.WriteString(strconv.FormatInt(decision.PRFingerprint.Number, 10))
+		if decision.PRFingerprint.HeadSHA != "" {
+			b.WriteString("\n- pr_head_sha: ")
+			b.WriteString(decision.PRFingerprint.HeadSHA)
+		}
+		if decision.PRFingerprint.MergeableState != "" {
+			b.WriteString("\n- pr_mergeable_state: ")
+			b.WriteString(decision.PRFingerprint.MergeableState)
+		}
+		if decision.PRFingerprint.CIStatus != "" {
+			b.WriteString("\n- pr_ci_status: ")
+			b.WriteString(decision.PRFingerprint.CIStatus)
+		}
+	}
 	if !decision.Since.IsZero() {
-		b.WriteString("\n- last_accepted_state_change_at: ")
+		b.WriteString("\n- last_accepted_progress_at: ")
 		b.WriteString(decision.Since.UTC().Format(time.RFC3339))
 	}
 	if !decision.Spend.FirstSessionAt.IsZero() && !decision.Spend.LastSessionAt.IsZero() {
 		b.WriteString("\n- observed_session_span: ")
 		b.WriteString(decision.Spend.LastSessionAt.Sub(decision.Spend.FirstSessionAt).Round(time.Second).String())
 	}
-	b.WriteString("\n\nShrink the task before retrying: split or narrow the scope so the next session can produce a concrete accepted change.")
+	if decision.Case == spendProgressCaseStatic {
+		b.WriteString("\n\nThe linked PR fingerprint stayed static during this spend window. Check merge-train capacity, Merging serialization, and dispatch priority before narrowing the task; this pattern can indicate throughput starvation rather than missing implementation work.")
+	} else {
+		b.WriteString("\n\nShrink the task before retrying: split or narrow the scope so the next session can produce a concrete accepted change or linked PR evidence.")
+	}
 	b.WriteString("\n\nOn the next dispatch, the agent's first tool action must update the Workpad to explain which accepted progress signal was missing and what is concretely different before any other tool use.")
 	return b.String()
 }
 
+func spendProgressCaseSummary(progressCase string) string {
+	if progressCase == spendProgressCaseStatic {
+		return "spend continued while a linked PR existed but could not merge"
+	}
+	return "spend continued without any PR evidence"
+}
+
+func spendProgressRecoveryReason(decision spendProgressDecision) string {
+	if decision.Case == spendProgressCaseStatic {
+		return "inspect merge-train capacity, Merging serialization, and dispatch priority before moving the issue back to Rework"
+	}
+	return "narrow or split the task, then identify why no linked PR evidence was produced before moving the issue back to Todo or Rework"
+}
+
 func spendProgressRetryHandoff(decision spendProgressDecision) runpkg.PriorAttempt {
+	missingSignal := "lane transition, pull request creation, or a recognized PR fingerprint advancement"
+	if decision.Case == spendProgressCaseStatic {
+		missingSignal = "new PR head commit, dirty-to-clean mergeability, failing-to-passing CI, or merge-train capacity that lets the linked PR advance"
+	}
 	return runpkg.PriorAttempt{
 		Source:                  spendProgressReason,
-		Reason:                  "spend exceeded the configured limit without an accepted state change",
+		Reason:                  spendProgressCaseSummary(decision.Case),
 		ExplainBeforeRetry:      true,
-		MissingSignal:           "lane transition, pull request creation or merge, or a recognized PR content-signature change",
+		MissingSignal:           missingSignal,
 		ObservedSpendUSD:        decision.Spend.CostUSD,
 		NoProgressSpendLimitUSD: decision.LimitUSD,
 	}
@@ -341,8 +536,12 @@ func (o *Orchestrator) spendProgressPriorAttempt(ctx context.Context, issue conn
 		return runpkg.PriorAttempt{}, false
 	}
 	return spendProgressRetryHandoff(spendProgressDecision{
-		Spend:    store.IssueSpendSince{CostUSD: record.SpendUSD, Sessions: record.Sessions},
-		LimitUSD: record.LimitUSD,
+		Spend:              store.IssueSpendSince{CostUSD: record.SpendUSD, Sessions: record.Sessions},
+		ConfiguredLimitUSD: record.ConfiguredLimitUSD,
+		LimitUSD:           record.LimitUSD,
+		Effort:             record.Effort,
+		PRFingerprint:      record.PRFingerprint,
+		Case:               record.Case,
 	}), true
 }
 

--- a/internal/orchestrator/spend_progress_test.go
+++ b/internal/orchestrator/spend_progress_test.go
@@ -39,22 +39,108 @@ func TestEvaluateSpendProgress(t *testing.T) {
 		limit            float64
 		spend            store.IssueSpendSince
 		history          []store.WorkAttempt
+		issue            connector.Issue
+		effort           string
 		accepted         bool
 		acceptedReason   string
 		wantBlock        bool
+		wantAccepted     bool
+		wantReason       string
+		wantLimit        float64
 		wantSpendCalls   int
 		wantHistoryCalls int
 		wantSince        time.Time
 	}{
-		{name: "disabled avoids tracking", limit: 0, spend: store.IssueSpendSince{CostUSD: 100}, wantSpendCalls: 0, wantHistoryCalls: 0},
-		{name: "normal three retry sessions stay below default", limit: 3, spend: store.IssueSpendSince{CostUSD: 2.7, Sessions: 3}, wantSpendCalls: 1, wantHistoryCalls: 1, wantSince: createdAt},
-		{name: "below threshold", limit: 5, spend: store.IssueSpendSince{CostUSD: 4.99, Sessions: 3}, wantSpendCalls: 1, wantHistoryCalls: 1, wantSince: createdAt},
-		{name: "at threshold", limit: 5, spend: store.IssueSpendSince{CostUSD: 5, Sessions: 4}, wantSpendCalls: 1, wantHistoryCalls: 1, wantSince: createdAt},
-		{name: "metered blocks above threshold", billingMode: "metered", limit: 5, spend: store.IssueSpendSince{CostUSD: 5.01, Sessions: 4}, wantBlock: true, wantSpendCalls: 1, wantHistoryCalls: 1, wantSince: createdAt},
-		{name: "subscription keeps above-threshold spend advisory", billingMode: "subscription", limit: 5, spend: store.IssueSpendSince{CostUSD: 5.01, Sessions: 4}, wantSpendCalls: 1, wantHistoryCalls: 1, wantSince: createdAt},
-		{name: "July telemetry replay", limit: 5, spend: store.IssueSpendSince{CostUSD: 6.75, Sessions: 5}, wantBlock: true, wantSpendCalls: 1, wantHistoryCalls: 1, wantSince: createdAt},
-		{name: "old sessions reset after accepted change", limit: 5, spend: store.IssueSpendSince{CostUSD: 1.25, Sessions: 1}, history: []store.WorkAttempt{acceptedAttempt}, wantSpendCalls: 1, wantHistoryCalls: 1, wantSince: acceptedAt},
-		{name: "current accepted change resets without spend lookup", limit: 5, spend: store.IssueSpendSince{CostUSD: 100}, accepted: true, acceptedReason: "signature_changed", wantSpendCalls: 0, wantHistoryCalls: 0, wantSince: base},
+		{name: "disabled avoids tracking", limit: 0, spend: store.IssueSpendSince{CostUSD: 100}, wantLimit: 0, wantSpendCalls: 0, wantHistoryCalls: 0},
+		{name: "normal three retry sessions stay below default", limit: 3, spend: store.IssueSpendSince{CostUSD: 2.7, Sessions: 3}, wantLimit: 3, wantSpendCalls: 1, wantHistoryCalls: 1, wantSince: createdAt},
+		{name: "below threshold", limit: 5, spend: store.IssueSpendSince{CostUSD: 4.99, Sessions: 3}, wantLimit: 5, wantSpendCalls: 1, wantHistoryCalls: 1, wantSince: createdAt},
+		{name: "at threshold", limit: 5, spend: store.IssueSpendSince{CostUSD: 5, Sessions: 4}, wantLimit: 5, wantSpendCalls: 1, wantHistoryCalls: 1, wantSince: createdAt},
+		{name: "metered blocks above threshold", billingMode: "metered", limit: 5, spend: store.IssueSpendSince{CostUSD: 5.01, Sessions: 4}, wantBlock: true, wantLimit: 5, wantSpendCalls: 1, wantHistoryCalls: 1, wantSince: createdAt},
+		{name: "subscription keeps above-threshold spend advisory", billingMode: "subscription", limit: 5, spend: store.IssueSpendSince{CostUSD: 5.01, Sessions: 4}, wantLimit: 5, wantSpendCalls: 1, wantHistoryCalls: 1, wantSince: createdAt},
+		{name: "July telemetry replay", limit: 5, spend: store.IssueSpendSince{CostUSD: 6.75, Sessions: 5}, wantBlock: true, wantLimit: 5, wantSpendCalls: 1, wantHistoryCalls: 1, wantSince: createdAt},
+		{name: "old sessions reset after accepted change", limit: 5, spend: store.IssueSpendSince{CostUSD: 1.25, Sessions: 1}, history: []store.WorkAttempt{acceptedAttempt}, wantLimit: 5, wantSpendCalls: 1, wantHistoryCalls: 1, wantSince: acceptedAt},
+		{name: "current accepted change resets without spend lookup", limit: 5, spend: store.IssueSpendSince{CostUSD: 100}, accepted: true, acceptedReason: "signature_changed", wantAccepted: true, wantReason: "signature_changed", wantLimit: 5, wantSpendCalls: 0, wantHistoryCalls: 0, wantSince: base},
+		{
+			name:  "dirty to clean pull request resets spend",
+			limit: 5,
+			spend: store.IssueSpendSince{CostUSD: 6.75, Sessions: 2},
+			issue: spendProgressIssueWithPR("same-head", "clean", "failure"),
+			history: []store.WorkAttempt{{
+				CompletedAt: base.Add(-10 * time.Minute),
+				WorkerMetadataJSON: marshalWorkAttemptJSON(map[string]any{
+					spendProgressMetadataKey: map[string]any{
+						"limit_usd":      5,
+						"pr_fingerprint": map[string]any{"number": 214, "head_sha": "same-head", "mergeable_state": "dirty", "ci_status": "failure"},
+					},
+				}),
+			}},
+			wantAccepted:     true,
+			wantReason:       "pull_request_mergeable",
+			wantLimit:        5,
+			wantHistoryCalls: 1,
+			wantSince:        base,
+		},
+		{
+			name:  "failing to passing pull request resets spend",
+			limit: 5,
+			spend: store.IssueSpendSince{CostUSD: 6.75, Sessions: 2},
+			issue: spendProgressIssueWithPR("same-head", "dirty", "success"),
+			history: []store.WorkAttempt{{
+				CompletedAt: base.Add(-10 * time.Minute),
+				WorkerMetadataJSON: marshalWorkAttemptJSON(map[string]any{
+					spendProgressMetadataKey: map[string]any{
+						"limit_usd":      5,
+						"pr_fingerprint": map[string]any{"number": 214, "head_sha": "same-head", "mergeable_state": "dirty", "ci_status": "failure"},
+					},
+				}),
+			}},
+			wantAccepted:     true,
+			wantReason:       "pull_request_ci_passing",
+			wantLimit:        5,
+			wantHistoryCalls: 1,
+			wantSince:        base,
+		},
+		{
+			name:  "new pull request head resets spend",
+			limit: 5,
+			spend: store.IssueSpendSince{CostUSD: 6.75, Sessions: 2},
+			issue: spendProgressIssueWithPR("new-head", "dirty", "failure"),
+			history: []store.WorkAttempt{{
+				CompletedAt: base.Add(-10 * time.Minute),
+				WorkerMetadataJSON: marshalWorkAttemptJSON(map[string]any{
+					spendProgressMetadataKey: map[string]any{
+						"limit_usd":      5,
+						"pr_fingerprint": map[string]any{"number": 214, "head_sha": "old-head", "mergeable_state": "dirty", "ci_status": "failure"},
+					},
+				}),
+			}},
+			wantAccepted:     true,
+			wantReason:       "pull_request_head_changed",
+			wantLimit:        5,
+			wantHistoryCalls: 1,
+			wantSince:        base,
+		},
+		{
+			name:  "byte identical pull request still parks",
+			limit: 5,
+			spend: store.IssueSpendSince{CostUSD: 6.75, Sessions: 2},
+			issue: spendProgressIssueWithPR("same-head", "dirty", "failure"),
+			history: []store.WorkAttempt{{
+				CompletedAt: base.Add(-10 * time.Minute),
+				WorkerMetadataJSON: marshalWorkAttemptJSON(map[string]any{
+					spendProgressMetadataKey: map[string]any{
+						"limit_usd":      5,
+						"pr_fingerprint": map[string]any{"number": 214, "head_sha": "same-head", "mergeable_state": "dirty", "ci_status": "failure"},
+					},
+				}),
+			}},
+			wantBlock:        true,
+			wantLimit:        5,
+			wantSpendCalls:   1,
+			wantHistoryCalls: 1,
+			wantSince:        createdAt,
+		},
+		{name: "xhigh threshold allows one expensive session", limit: 3, effort: "xhigh", spend: store.IssueSpendSince{CostUSD: 17.99, Sessions: 1}, wantLimit: 18, wantSpendCalls: 1, wantHistoryCalls: 1, wantSince: createdAt},
 	}
 
 	for _, tt := range tests {
@@ -72,11 +158,25 @@ func TestEvaluateSpendProgress(t *testing.T) {
 				progressSpend: spend,
 				workAttempts:  attempts,
 			}
-			issue := connector.Issue{ID: "issue-214", Identifier: "gopherguides/gopher-ai#214", CreatedAt: &createdAt}
-			decision := orch.evaluateSpendProgress(context.Background(), Running{Issue: issue}, base, tt.accepted, tt.acceptedReason)
+			issue := tt.issue
+			issue.ID = "issue-214"
+			issue.Identifier = "gopherguides/gopher-ai#214"
+			issue.CreatedAt = &createdAt
+			running := Running{Issue: issue}
+			running.RuntimeIdentity.ReasoningEffort.Value = tt.effort
+			decision := orch.evaluateSpendProgress(context.Background(), running, base, tt.accepted, tt.acceptedReason)
 
 			if decision.Block != tt.wantBlock {
 				t.Fatalf("Block = %t, want %t", decision.Block, tt.wantBlock)
+			}
+			if decision.AcceptedStateChange != tt.wantAccepted {
+				t.Fatalf("AcceptedStateChange = %t, want %t", decision.AcceptedStateChange, tt.wantAccepted)
+			}
+			if decision.AcceptedReason != tt.wantReason {
+				t.Fatalf("AcceptedReason = %q, want %q", decision.AcceptedReason, tt.wantReason)
+			}
+			if math.Abs(decision.LimitUSD-tt.wantLimit) > 0.000001 {
+				t.Fatalf("LimitUSD = %f, want %f", decision.LimitUSD, tt.wantLimit)
 			}
 			if spend.calls != tt.wantSpendCalls {
 				t.Fatalf("spend calls = %d, want %d", spend.calls, tt.wantSpendCalls)
@@ -92,6 +192,143 @@ func TestEvaluateSpendProgress(t *testing.T) {
 			}
 		})
 	}
+}
+
+func spendProgressIssueWithPR(headSHA string, mergeableState string, ciStatus string) connector.Issue {
+	number := 214
+	return connector.Issue{
+		PRNumber: &number,
+		PullRequest: &connector.PullRequest{
+			Number:         214,
+			HeadSHA:        headSHA,
+			MergeableState: mergeableState,
+			CIStatus:       ciStatus,
+		},
+	}
+}
+
+func TestSpendProgressCommentNamesEvidenceCase(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name         string
+		decision     spendProgressDecision
+		wantContains []string
+	}{
+		{
+			name: "without PR evidence",
+			decision: spendProgressDecision{
+				Spend:    store.IssueSpendSince{CostUSD: 6.75, Sessions: 2},
+				LimitUSD: 5,
+				Case:     spendProgressCaseNoPR,
+			},
+			wantContains: []string{"spend continued without any PR evidence", "case: spend_without_pr_evidence", "Shrink the task"},
+		},
+		{
+			name: "static PR evidence",
+			decision: spendProgressDecision{
+				Spend:         store.IssueSpendSince{CostUSD: 6.75, Sessions: 2},
+				LimitUSD:      5,
+				Case:          spendProgressCaseStatic,
+				PRFingerprint: &spendProgressPRFingerprint{Number: 214, HeadSHA: "same-head", MergeableState: "dirty", CIStatus: "failure"},
+			},
+			wantContains: []string{"spend continued while a linked PR existed but could not merge", "case: spend_with_static_pr_evidence", "merge-train capacity", "pr_head_sha: same-head"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			comment := spendProgressComment(connector.Issue{Identifier: "digitaldrywood/detent#1276"}, tt.decision)
+			for _, want := range tt.wantContains {
+				if !strings.Contains(comment, want) {
+					t.Fatalf("comment missing %q:\n%s", want, comment)
+				}
+			}
+			if recovery := spendProgressRecoveryReason(tt.decision); recovery == "" {
+				t.Fatal("recovery reason is empty")
+			}
+			if handoff := spendProgressRetryHandoff(tt.decision); handoff.MissingSignal == "" {
+				t.Fatal("retry handoff missing signal")
+			}
+		})
+	}
+}
+
+func TestRefreshSpendProgressIssue(t *testing.T) {
+	t.Parallel()
+
+	baseIssue := connector.Issue{ID: "issue-1276", Identifier: "digitaldrywood/detent#1276"}
+	linkedIssue := spendProgressIssueWithPR("head", "dirty", "failure")
+	linkedIssue.ID = baseIssue.ID
+	linkedIssue.Identifier = baseIssue.Identifier
+	degradedIssue := cloneIssue(linkedIssue)
+	degradedIssue.PullRequest.HydrationDegradedReason = connector.PullRequestHydrationReasonStaleCachedPullData
+
+	tests := []struct {
+		name        string
+		orch        *Orchestrator
+		issue       connector.Issue
+		wantWarning string
+		wantPR      bool
+		wantHead    string
+	}{
+		{name: "missing connector", orch: &Orchestrator{}, issue: baseIssue, wantWarning: "refresh unavailable"},
+		{name: "refresh failure", orch: &Orchestrator{connector: &implementProgressConnector{refreshErr: errors.New("github unavailable")}}, issue: baseIssue, wantWarning: "refresh failed"},
+		{name: "refresh confirms no PR", orch: &Orchestrator{connector: &implementProgressConnector{refreshed: baseIssue}}, issue: baseIssue},
+		{
+			name: "refresh discovers and hydrates PR",
+			orch: &Orchestrator{connector: &implementProgressConnector{
+				refreshed: linkedIssue,
+				hydrated:  linkedIssue,
+			}},
+			issue:    baseIssue,
+			wantPR:   true,
+			wantHead: "head",
+		},
+		{
+			name:        "linked PR without hydrator",
+			orch:        &Orchestrator{connector: connectorOnly{Connector: &implementProgressConnector{}}},
+			issue:       linkedIssue,
+			wantWarning: "hydrator unavailable",
+			wantPR:      true,
+			wantHead:    "head",
+		},
+		{
+			name:        "hydration failure",
+			orch:        &Orchestrator{connector: &implementProgressConnector{hydrateErr: errors.New("github unavailable")}},
+			issue:       linkedIssue,
+			wantWarning: "hydration failed",
+			wantPR:      true,
+			wantHead:    "head",
+		},
+		{
+			name:        "degraded hydration",
+			orch:        &Orchestrator{connector: &implementProgressConnector{hydrated: degradedIssue}},
+			issue:       linkedIssue,
+			wantWarning: connector.PullRequestHydrationReasonStaleCachedPullData,
+			wantPR:      true,
+			wantHead:    "head",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			issue, warning := tt.orch.refreshSpendProgressIssue(t.Context(), tt.issue)
+			if !strings.Contains(warning, tt.wantWarning) {
+				t.Fatalf("warning = %q, want containing %q", warning, tt.wantWarning)
+			}
+			if got := issue.PullRequest != nil; got != tt.wantPR {
+				t.Fatalf("PR present = %t, want %t", got, tt.wantPR)
+			}
+			if tt.wantHead != "" && issue.PullRequest.HeadSHA != tt.wantHead {
+				t.Fatalf("head = %q, want %q", issue.PullRequest.HeadSHA, tt.wantHead)
+			}
+		})
+	}
+}
+
+type connectorOnly struct {
+	connector.Connector
 }
 
 func TestDispatchAcceptedStateChange(t *testing.T) {
@@ -198,6 +435,74 @@ func TestHandleRunResultTripsSpendProgressIndependentlyOfContentDetector(t *test
 	}
 	if !state.PriorAttempts[issue.ID].ExplainBeforeRetry {
 		t.Fatalf("PriorAttempts[%q] = %#v, want explain-before-retry", issue.ID, state.PriorAttempts[issue.ID])
+	}
+}
+
+func TestHandleRunResultAcceptsPRAdvanceBeforeWorkerError(t *testing.T) {
+	t.Parallel()
+
+	base := time.Date(2026, 7, 11, 16, 0, 0, 0, time.UTC)
+	createdAt := base.Add(-time.Hour)
+	runningIssue := spendProgressIssueWithPR("old-head", "dirty", "failure")
+	runningIssue.ID = "issue-1276"
+	runningIssue.Identifier = "digitaldrywood/detent#1276"
+	runningIssue.State = "In Progress"
+	runningIssue.CreatedAt = &createdAt
+	hydratedIssue := cloneIssue(runningIssue)
+	hydratedIssue.PullRequest.HeadSHA = "new-head"
+	tracker := &implementProgressConnector{hydrated: hydratedIssue}
+	attempts := &implementProgressAttemptStore{history: []store.WorkAttempt{{
+		CompletedAt: base.Add(-20 * time.Minute),
+		WorkerMetadataJSON: marshalWorkAttemptJSON(map[string]any{
+			spendProgressMetadataKey: map[string]any{
+				"limit_usd":      5,
+				"pr_fingerprint": map[string]any{"number": 214, "head_sha": "old-head", "mergeable_state": "dirty", "ci_status": "failure"},
+			},
+		}),
+	}}}
+	cfg := normalizeConfig(Config{
+		Project:                 scheduler.ProjectCandidate{ID: "detent"},
+		NoProgressSpendLimitUSD: 5,
+		ActiveStates:            []string{"In Progress"},
+		ObservedStates:          []string{"Blocked"},
+		TerminalStates:          []string{"Done"},
+	})
+	orch := &Orchestrator{
+		cfg:           cfg,
+		connector:     tracker,
+		workAttempts:  attempts,
+		progressSpend: &spendProgressStore{result: store.IssueSpendSince{CostUSD: 6.75, Sessions: 2}},
+	}
+	state := newState(cfg)
+	running := Running{
+		Issue:         runningIssue,
+		Attempt:       2,
+		WorkAttemptID: 42,
+		Mode:          runpkg.RunModeImplement,
+		StartedAt:     base.Add(-5 * time.Minute),
+	}
+	state.Running[runningIssue.ID] = running
+	state.Claimed[runningIssue.ID] = Claimed{Issue: runningIssue, ClaimedAt: running.StartedAt}
+
+	orch.handleRunResult(context.Background(), &state, runpkg.Completion{
+		IssueID:     runningIssue.ID,
+		CompletedAt: base,
+		Request:     runpkg.RunRequest{Mode: runpkg.RunModeImplement},
+		Err:         errors.New("session token ceiling exceeded"),
+	})
+
+	if _, blocked := state.Blocked[runningIssue.ID]; blocked {
+		t.Fatalf("Blocked[%q] present after PR head advanced", runningIssue.ID)
+	}
+	if tracker.hydrations != 1 {
+		t.Fatalf("hydrations = %d, want 1", tracker.hydrations)
+	}
+	if len(attempts.completions) != 1 {
+		t.Fatalf("completions = %#v, want one", attempts.completions)
+	}
+	record, ok := spendProgressRecordFromAttempt(store.WorkAttempt{WorkerMetadataJSON: attempts.completions[0].WorkerMetadataJSON})
+	if !ok || !record.AcceptedStateChange || record.AcceptedReason != "pull_request_head_changed" {
+		t.Fatalf("spend metadata = %#v, ok=%t", record, ok)
 	}
 }
 

--- a/internal/orchestrator/spend_progress_test.go
+++ b/internal/orchestrator/spend_progress_test.go
@@ -84,13 +84,13 @@ func TestEvaluateSpendProgress(t *testing.T) {
 			name:  "failing to passing pull request resets spend",
 			limit: 5,
 			spend: store.IssueSpendSince{CostUSD: 6.75, Sessions: 2},
-			issue: spendProgressIssueWithPR("same-head", "dirty", "success"),
+			issue: spendProgressIssueWithPR("same-head", "dirty", "pass"),
 			history: []store.WorkAttempt{{
 				CompletedAt: base.Add(-10 * time.Minute),
 				WorkerMetadataJSON: marshalWorkAttemptJSON(map[string]any{
 					spendProgressMetadataKey: map[string]any{
 						"limit_usd":      5,
-						"pr_fingerprint": map[string]any{"number": 214, "head_sha": "same-head", "mergeable_state": "dirty", "ci_status": "failure"},
+						"pr_fingerprint": map[string]any{"number": 214, "head_sha": "same-head", "mergeable_state": "dirty", "ci_status": "fail"},
 					},
 				}),
 			}},


### PR DESCRIPTION
## Summary

- Persist linked PR fingerprints and reset spend progress for PR creation, head commits, dirty-to-clean mergeability, and failing-to-passing CI.
- Scale the breaker threshold by effective reasoning effort and distinguish no-PR waste from static-PR merge-train starvation in parking diagnostics.
- Add a doctor warning when an effort tier's effective threshold is below observed p50 session cost, with a 1.5x retry-cost recommendation.

Fixes #1276

## UI Surface Contract

- [x] N/A, or the linked issue explicitly authorizes any high-impact UI surface, layout, density, first-viewport, or responsive visibility tradeoff.
- [x] Persistent top-of-screen messaging is explicitly authorized by the issue, or this PR does not add it.
- [x] Visual changes to primary operator screens include screenshot or browser verification below. (N/A: no UI changes.)

## Test Plan

- [x] `go test ./internal/config ./internal/orchestrator ./internal/cli -count=1`
- [x] `go test ./internal/orchestrator -run '^$' -fuzz=FuzzSafetyCriticalOrchestratorBoundaries -fuzztime=30s`
- [x] `make check`