### PR TITLE
fix(budget): scope daily spend by project

### DIFF
--- a/README.md
+++ b/README.md
@@ -2439,6 +2439,13 @@ a success or different failure class closes the breaker, while the same class
 starts a fresh cooldown. The board banner shows the active class, count, and
 window.
 
+Daily budget caps are scoped to the configured project. Session rows persist
+the project ID; on upgrade, Detent backfills older rows first from work
+attempts and then by matching each identifier's repository prefix against the
+configured project registry. Any session that remains unattributed counts
+toward every project's daily cap as a conservative fallback. `detent doctor`
+warns while unattributed completed sessions exist for the current UTC day.
+
 `agent.resume_orphaned_sessions` defaults to `true`. After an unclean Detent
 restart, active sessions whose provider identity was journaled are preflighted
 and resumed with a short continuation prompt. Missing provider state,

--- a/db/queries/store.sql
+++ b/db/queries/store.sql
@@ -32,6 +32,7 @@ WHERE id = ?;
 -- name: CreateCodexSession :one
 INSERT INTO codex_sessions (
   run_id,
+  project_id,
   issue_id,
   identifier,
   issue_url,
@@ -67,8 +68,17 @@ INSERT INTO codex_sessions (
   resumed_from_session_id,
   orphan_recovery_outcome,
   orphan_recovery_fallback_reason
-) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 RETURNING *;
+
+-- name: BackfillSessionProjectID :execrows
+UPDATE codex_sessions
+SET project_id = sqlc.arg(project_id)
+WHERE trim(COALESCE(project_id, '')) = ''
+  AND (
+    lower(substr(identifier, 1, instr(identifier, '#') - 1)) = lower(sqlc.arg(repository))
+    OR lower(substr(issue_url, 1, length('https://github.com/' || sqlc.arg(repository) || '/issues/'))) = lower('https://github.com/' || sqlc.arg(repository) || '/issues/')
+  );
 
 -- name: GetCodexSession :one
 SELECT *
@@ -409,6 +419,24 @@ SELECT
   CAST(COUNT(*) AS INTEGER) AS sessions
 FROM codex_sessions
 WHERE substr(completed_at, 1, 10) = ?
+GROUP BY COALESCE(NULLIF(model, ''), NULLIF(requested_model, ''), '')
+ORDER BY COALESCE(NULLIF(model, ''), NULLIF(requested_model, ''), '');
+
+-- name: ProjectDailyTokenSpend :many
+SELECT
+  CAST(COALESCE(NULLIF(model, ''), NULLIF(requested_model, ''), '') AS TEXT) AS model,
+  CAST(COALESCE(SUM(input_tokens), 0) AS INTEGER) AS input_tokens,
+  CAST(COALESCE(SUM(cached_input_tokens), 0) AS INTEGER) AS cached_input_tokens,
+  CAST(COALESCE(SUM(output_tokens), 0) AS INTEGER) AS output_tokens,
+  CAST(COALESCE(SUM(reasoning_output_tokens), 0) AS INTEGER) AS reasoning_output_tokens,
+  CAST(COALESCE(SUM(total_tokens), 0) AS INTEGER) AS total_tokens,
+  CAST(COUNT(*) AS INTEGER) AS sessions
+FROM codex_sessions
+WHERE substr(completed_at, 1, 10) = sqlc.arg(completed_at)
+  AND (
+    project_id = sqlc.arg(project_id)
+    OR trim(COALESCE(project_id, '')) = ''
+  )
 GROUP BY COALESCE(NULLIF(model, ''), NULLIF(requested_model, ''), '')
 ORDER BY COALESCE(NULLIF(model, ''), NULLIF(requested_model, ''), '');
 

--- a/internal/budget/budget.go
+++ b/internal/budget/budget.go
@@ -22,6 +22,7 @@ const (
 var ErrMissingSpendStore = errors.New("budget spend store is required")
 
 type Config struct {
+	ProjectID       string
 	Enabled         bool
 	PerDayMaxUSD    float64
 	PerIssueMaxUSD  float64
@@ -30,7 +31,7 @@ type Config struct {
 }
 
 type SpendStore interface {
-	DailyTokenSpend(context.Context, time.Time) (store.TokenSpend, error)
+	ProjectDailyTokenSpend(context.Context, string, time.Time) (store.TokenSpend, error)
 	IssueTokenSpend(context.Context, store.IssueIdentity) (store.TokenSpend, error)
 }
 
@@ -152,7 +153,7 @@ func (c *Checker) CheckDispatch(ctx context.Context, req DispatchRequest) (Decis
 		if missingSpendStore(c.spend) {
 			return Decision{}, ErrMissingSpendStore
 		}
-		dailySpend, err := c.spend.DailyTokenSpend(ctx, now)
+		dailySpend, err := c.spend.ProjectDailyTokenSpend(ctx, c.cfg.ProjectID, now)
 		if err != nil {
 			return Decision{}, fmt.Errorf("daily token spend: %w", err)
 		}
@@ -203,7 +204,7 @@ func (c *Checker) DailyStatus(ctx context.Context, now time.Time) (DailyStatus, 
 	if now.IsZero() {
 		now = time.Now().UTC()
 	}
-	dailySpend, err := c.spend.DailyTokenSpend(ctx, now)
+	dailySpend, err := c.spend.ProjectDailyTokenSpend(ctx, c.cfg.ProjectID, now)
 	if err != nil {
 		return DailyStatus{}, fmt.Errorf("daily token spend: %w", err)
 	}

--- a/internal/budget/budget_test.go
+++ b/internal/budget/budget_test.go
@@ -552,7 +552,7 @@ type fakeSpendStore struct {
 	issueLookups []string
 }
 
-func (s *fakeSpendStore) DailyTokenSpend(_ context.Context, day time.Time) (store.TokenSpend, error) {
+func (s *fakeSpendStore) ProjectDailyTokenSpend(_ context.Context, _ string, day time.Time) (store.TokenSpend, error) {
 	s.dailyCalls++
 	if day.IsZero() {
 		return store.TokenSpend{}, errors.New("zero day")

--- a/internal/cli/boot.go
+++ b/internal/cli/boot.go
@@ -228,6 +228,9 @@ func startRunning(ctx context.Context, cfg BootConfig) error {
 			return err
 		}
 	}
+	if err := backfillRuntimeSessionProjects(runCtx, cfg.Global.Projects, runtimeStore, project.LoadWorkflow); err != nil {
+		return err
+	}
 
 	events := hub.New[project.Event]()
 	activityBroker := activity.NewBroker()
@@ -421,6 +424,54 @@ func startRunning(ctx context.Context, cfg BootConfig) error {
 			return serve(ctx, server, listener)
 		})
 	})
+}
+
+type sessionProjectBackfiller interface {
+	BackfillSessionProjectIDs(context.Context, []store.SessionProjectAttribution) (int64, error)
+}
+
+func backfillRuntimeSessionProjects(
+	ctx context.Context,
+	projects []globalconfig.Project,
+	backfiller sessionProjectBackfiller,
+	loadWorkflow func(globalconfig.Project) (workflowconfig.Workflow, error),
+) error {
+	attributions := make(map[string]store.SessionProjectAttribution, len(projects))
+	ambiguous := make(map[string]struct{})
+	for _, configuredProject := range projects {
+		workflow, err := loadWorkflow(configuredProject)
+		if err != nil {
+			return fmt.Errorf("load project workflow %s for session attribution: %w", configuredProject.ID, err)
+		}
+		repository := strings.TrimSpace(workflow.Config.Tracker.Repository)
+		projectID := strings.TrimSpace(configuredProject.ID)
+		if repository == "" || projectID == "" {
+			continue
+		}
+		key := strings.ToLower(repository)
+		if existing, ok := attributions[key]; ok && existing.ProjectID != projectID {
+			delete(attributions, key)
+			ambiguous[key] = struct{}{}
+			continue
+		}
+		if _, ok := ambiguous[key]; !ok {
+			attributions[key] = store.SessionProjectAttribution{ProjectID: projectID, Repository: repository}
+		}
+	}
+
+	keys := make([]string, 0, len(attributions))
+	for key := range attributions {
+		keys = append(keys, key)
+	}
+	slices.Sort(keys)
+	ordered := make([]store.SessionProjectAttribution, 0, len(keys))
+	for _, key := range keys {
+		ordered = append(ordered, attributions[key])
+	}
+	if _, err := backfiller.BackfillSessionProjectIDs(ctx, ordered); err != nil {
+		return fmt.Errorf("backfill session project attribution: %w", err)
+	}
+	return nil
 }
 
 func globalProjectCandidates(projects []globalconfig.Project) []scheduler.ProjectCandidate {

--- a/internal/cli/boot_test.go
+++ b/internal/cli/boot_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/digitaldrywood/detent/internal/hub"
 	projectpkg "github.com/digitaldrywood/detent/internal/project"
 	"github.com/digitaldrywood/detent/internal/scheduler"
+	"github.com/digitaldrywood/detent/internal/store"
 	"github.com/digitaldrywood/detent/internal/telemetry"
 	"github.com/digitaldrywood/detent/internal/tui"
 	"github.com/digitaldrywood/detent/internal/web"
@@ -67,6 +68,30 @@ func TestShouldLaunchTerminalDashboard(t *testing.T) {
 				t.Fatalf("shouldLaunchTerminalDashboard(%#v) = %v, want %v", tt.cfg, got, tt.want)
 			}
 		})
+	}
+}
+
+func TestBackfillRuntimeSessionProjects(t *testing.T) {
+	t.Parallel()
+
+	projects := []globalconfig.Project{{ID: "detent"}, {ID: "gopher-ai"}, {ID: "duplicate"}}
+	backfiller := &fakeSessionProjectBackfiller{}
+	err := backfillRuntimeSessionProjects(context.Background(), projects, backfiller, func(project globalconfig.Project) (workflowconfig.Workflow, error) {
+		cfg := workflowconfig.Default()
+		switch project.ID {
+		case "detent":
+			cfg.Tracker.Repository = "digitaldrywood/detent"
+		case "gopher-ai", "duplicate":
+			cfg.Tracker.Repository = "gopherguides/gopher-ai"
+		}
+		return workflowconfig.Workflow{Config: cfg}, nil
+	})
+	if err != nil {
+		t.Fatalf("backfillRuntimeSessionProjects() error = %v", err)
+	}
+	want := []store.SessionProjectAttribution{{ProjectID: "detent", Repository: "digitaldrywood/detent"}}
+	if len(backfiller.attributions) != len(want) || backfiller.attributions[0] != want[0] {
+		t.Fatalf("attributions = %#v, want %#v", backfiller.attributions, want)
 	}
 }
 
@@ -1401,6 +1426,15 @@ func assertRefresh(t *testing.T, response web.RefreshResponse) {
 
 type bootProvisioningConnector struct {
 	provision func(context.Context) error
+}
+
+type fakeSessionProjectBackfiller struct {
+	attributions []store.SessionProjectAttribution
+}
+
+func (f *fakeSessionProjectBackfiller) BackfillSessionProjectIDs(_ context.Context, attributions []store.SessionProjectAttribution) (int64, error) {
+	f.attributions = append([]store.SessionProjectAttribution(nil), attributions...)
+	return int64(len(attributions)), nil
 }
 
 func (bootProvisioningConnector) Name() string {

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -365,6 +365,12 @@ func runDoctor(ctx context.Context, cfg doctorConfig, opts options, deps doctorD
 			},
 		},
 		doctorCheckJob{
+			Name: "Daily budget attribution",
+			Run: func(jobCtx context.Context) []doctorCheck {
+				return []doctorCheck{checkDoctorDailyBudgetAccuracy(jobCtx, resolution, deps, time.Now())}
+			},
+		},
+		doctorCheckJob{
 			Name: "Backend capacity",
 			Run: func(jobCtx context.Context) []doctorCheck {
 				return []doctorCheck{checkDoctorBackendCapacity(jobCtx, resolution, cfg.ProjectID, deps, time.Now())}

--- a/internal/cli/doctor_environment.go
+++ b/internal/cli/doctor_environment.go
@@ -12,6 +12,7 @@ import (
 	"strconv"
 	"strings"
 	"syscall"
+	"time"
 
 	workflowconfig "github.com/digitaldrywood/detent/internal/config"
 	globalconfig "github.com/digitaldrywood/detent/internal/config/global"
@@ -281,6 +282,55 @@ func checkDoctorSQLite(ctx context.Context, resolution globalconfig.PathResoluti
 		Status: doctorOK,
 		Detail: dbPath + " is reachable",
 	}
+}
+
+func checkDoctorDailyBudgetAccuracy(ctx context.Context, resolution globalconfig.PathResolution, deps doctorDeps, now time.Time) doctorCheck {
+	const name = "Daily budget attribution"
+	if strings.TrimSpace(resolution.Path) == "" {
+		return doctorCheck{Name: name, Status: doctorWarn, Detail: "daily budget accuracy is unavailable because the global config path is unavailable"}
+	}
+
+	dbPath := filepath.Join(filepath.Dir(resolution.Path), "detent.db")
+	db, err := deps.openSQLiteReadOnly(ctx, dbPath)
+	if err != nil {
+		return doctorCheck{Name: name, Status: doctorWarn, Detail: fmt.Sprintf("daily budget accuracy is unavailable: %v", err)}
+	}
+	check := inspectDoctorDailyBudgetAccuracy(ctx, db, now)
+	if err := db.Close(); err != nil {
+		return doctorCheck{Name: name, Status: doctorWarn, Detail: fmt.Sprintf("daily budget attribution database close failed: %v", err)}
+	}
+	return check
+}
+
+func inspectDoctorDailyBudgetAccuracy(ctx context.Context, db doctorTelemetryStore, now time.Time) doctorCheck {
+	const name = "Daily budget attribution"
+	var projectIDColumns int64
+	if err := db.QueryRowContext(ctx, "SELECT COUNT(*) FROM pragma_table_info('codex_sessions') WHERE name = 'project_id'").Scan(&projectIDColumns); err != nil {
+		return doctorCheck{Name: name, Status: doctorWarn, Detail: fmt.Sprintf("daily budget attribution could not be inspected: %v", err)}
+	}
+	if projectIDColumns == 0 {
+		return doctorCheck{
+			Name:   name,
+			Status: doctorWarn,
+			Detail: "daily budget accuracy is degraded because the session project migration has not been applied",
+			Hint:   "Restart Detent to apply the runtime store migration and project-registry backfill.",
+		}
+	}
+
+	date := now.UTC().Format(time.DateOnly)
+	var sessions int64
+	if err := db.QueryRowContext(ctx, `SELECT COUNT(*) FROM codex_sessions WHERE substr(completed_at, 1, 10) = ? AND trim(COALESCE(project_id, '')) = ''`, date).Scan(&sessions); err != nil {
+		return doctorCheck{Name: name, Status: doctorWarn, Detail: fmt.Sprintf("daily budget attribution could not be inspected: %v", err)}
+	}
+	if sessions > 0 {
+		return doctorCheck{
+			Name:   name,
+			Status: doctorWarn,
+			Detail: fmt.Sprintf("daily budget accuracy is degraded: %d completed session(s) today are unattributed and count toward every project", sessions),
+			Hint:   "Ensure each project tracker repository matches session identifiers, then restart Detent to rerun the project-registry backfill.",
+		}
+	}
+	return doctorCheck{Name: name, Status: doctorOK, Detail: "all completed sessions today have project attribution"}
 }
 
 func checkDoctorCodex(ctx context.Context, deps doctorDeps) doctorCheck {

--- a/internal/cli/doctor_test.go
+++ b/internal/cli/doctor_test.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"bytes"
 	"context"
+	"database/sql"
 	"encoding/json"
 	"errors"
 	"io"
@@ -3562,6 +3563,70 @@ func TestCheckDoctorSQLite(t *testing.T) {
 			}
 			if !strings.Contains(got.Detail, tt.wantDetail) {
 				t.Fatalf("Detail = %q, want containing %q", got.Detail, tt.wantDetail)
+			}
+		})
+	}
+}
+
+func TestCheckDoctorDailyBudgetAccuracy(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 7, 12, 20, 0, 0, 0, time.UTC)
+	tests := []struct {
+		name       string
+		schema     string
+		seed       string
+		want       doctorStatus
+		wantDetail string
+	}{
+		{
+			name:       "migration missing",
+			schema:     "CREATE TABLE codex_sessions (completed_at TEXT)",
+			want:       doctorWarn,
+			wantDetail: "migration has not been applied",
+		},
+		{
+			name:       "unattributed session today",
+			schema:     "CREATE TABLE codex_sessions (completed_at TEXT, project_id TEXT)",
+			seed:       "INSERT INTO codex_sessions (completed_at) VALUES ('2026-07-12T19:00:00Z')",
+			want:       doctorWarn,
+			wantDetail: "count toward every project",
+		},
+		{
+			name:       "all sessions attributed",
+			schema:     "CREATE TABLE codex_sessions (completed_at TEXT, project_id TEXT)",
+			seed:       "INSERT INTO codex_sessions (completed_at, project_id) VALUES ('2026-07-12T19:00:00Z', 'detent')",
+			want:       doctorOK,
+			wantDetail: "all completed sessions today have project attribution",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			dir := t.TempDir()
+			dbPath := filepath.Join(dir, "detent.db")
+			db, err := sql.Open("sqlite", dbPath)
+			if err != nil {
+				t.Fatalf("sql.Open() error = %v", err)
+			}
+			if _, err := db.Exec(tt.schema); err != nil {
+				t.Fatalf("create schema error = %v", err)
+			}
+			if tt.seed != "" {
+				if _, err := db.Exec(tt.seed); err != nil {
+					t.Fatalf("seed session error = %v", err)
+				}
+			}
+			if err := db.Close(); err != nil {
+				t.Fatalf("db.Close() error = %v", err)
+			}
+
+			got := checkDoctorDailyBudgetAccuracy(context.Background(), globalconfig.PathResolution{Path: filepath.Join(dir, "global.yaml")}, doctorDeps{
+				openSQLiteReadOnly: openDoctorSQLiteReadOnly,
+			}, now)
+			if got.Status != tt.want || !strings.Contains(got.Detail, tt.wantDetail) {
+				t.Fatalf("check = %#v, want status %s detail containing %q", got, tt.want, tt.wantDetail)
 			}
 		})
 	}

--- a/internal/cli/runner.go
+++ b/internal/cli/runner.go
@@ -108,7 +108,7 @@ func buildRunner(
 		return nil, fmt.Errorf("load pricing: %w", err)
 	}
 	budgetGuardBuilder := func(cfg workflowconfig.Budget) (runnerpkg.BudgetChecker, runnerpkg.DispatchEstimator, error) {
-		return buildBudgetDispatchGuards(cfg, sessionStore, pricing)
+		return buildBudgetDispatchGuards(projectID, cfg, sessionStore, pricing)
 	}
 
 	run, err := runnerpkg.NewRunner(runnerpkg.Dependencies{
@@ -128,6 +128,7 @@ func buildRunner(
 }
 
 func buildBudgetDispatchGuards(
+	projectID string,
 	cfg workflowconfig.Budget,
 	sessionStore runnerpkg.SessionStore,
 	pricing budget.PricingTable,
@@ -142,6 +143,7 @@ func buildBudgetDispatchGuards(
 	}
 
 	checker := budget.NewChecker(budget.Config{
+		ProjectID:       projectID,
 		Enabled:         cfg.Enabled,
 		PerDayMaxUSD:    cfg.PerDayMaxUSD,
 		PerIssueMaxUSD:  cfg.PerIssueMaxUSD,

--- a/internal/cli/runner_test.go
+++ b/internal/cli/runner_test.go
@@ -232,7 +232,7 @@ func TestBuildBudgetDispatchGuards(t *testing.T) {
 	t.Parallel()
 
 	disabled := workflowconfig.Default().Budget
-	checker, estimator, err := buildBudgetDispatchGuards(disabled, nil, nil)
+	checker, estimator, err := buildBudgetDispatchGuards("alpha", disabled, nil, nil)
 	if err != nil {
 		t.Fatalf("buildBudgetDispatchGuards(disabled) error = %v", err)
 	}
@@ -242,7 +242,7 @@ func TestBuildBudgetDispatchGuards(t *testing.T) {
 
 	enabled := disabled
 	enabled.Enabled = true
-	_, _, err = buildBudgetDispatchGuards(enabled, &runnerSessionStore{}, nil)
+	_, _, err = buildBudgetDispatchGuards("alpha", enabled, &runnerSessionStore{}, nil)
 	if !errors.Is(err, budget.ErrMissingSpendStore) {
 		t.Fatalf("buildBudgetDispatchGuards(missing spend store) error = %v, want ErrMissingSpendStore", err)
 	}
@@ -261,12 +261,72 @@ func TestBuildBudgetDispatchGuards(t *testing.T) {
 		}
 	})
 
-	checker, estimator, err = buildBudgetDispatchGuards(enabled, storeBackend, nil)
+	checker, estimator, err = buildBudgetDispatchGuards("alpha", enabled, storeBackend, nil)
 	if err != nil {
 		t.Fatalf("buildBudgetDispatchGuards(enabled) error = %v", err)
 	}
 	if checker == nil || estimator == nil {
 		t.Fatalf("enabled guards = %T/%T, want checker and estimator", checker, estimator)
+	}
+}
+
+func TestBuildBudgetDispatchGuardsIsolatesProjectDailySpend(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	backend, err := store.Open(ctx, store.Config{Backend: store.BackendSQLite, Path: filepath.Join(t.TempDir(), "detent.db")})
+	if err != nil {
+		t.Fatalf("store.Open() error = %v", err)
+	}
+	t.Cleanup(func() {
+		if err := backend.Close(); err != nil {
+			t.Fatalf("Close() error = %v", err)
+		}
+	})
+	now := time.Date(2026, 7, 12, 20, 0, 0, 0, time.UTC)
+	for _, session := range []struct {
+		projectID string
+		tokens    int64
+	}{
+		{projectID: "quiet", tokens: 10},
+		{projectID: "busy", tokens: 200},
+	} {
+		sessionID, err := backend.StartSession(ctx, store.SessionStart{ProjectID: session.projectID, StartedAt: now.Add(-time.Minute), Model: "gpt-test"})
+		if err != nil {
+			t.Fatalf("StartSession(%s) error = %v", session.projectID, err)
+		}
+		if err := backend.FinishSession(ctx, sessionID, store.SessionFinish{CompletedAt: now, InputTokens: session.tokens, TotalTokens: session.tokens, FinalState: "complete", Model: "gpt-test"}); err != nil {
+			t.Fatalf("FinishSession(%s) error = %v", session.projectID, err)
+		}
+	}
+
+	cfg := workflowconfig.Default().Budget
+	cfg.Enabled = true
+	cfg.PerDayMaxUSD = 100
+	pricing := budget.PricingTable{"gpt-test": {USDPerInputToken: 1}}
+	for _, tt := range []struct {
+		projectID string
+		wantAllow bool
+	}{
+		{projectID: "quiet", wantAllow: true},
+		{projectID: "busy", wantAllow: false},
+	} {
+		t.Run(tt.projectID, func(t *testing.T) {
+			checker, _, err := buildBudgetDispatchGuards(tt.projectID, cfg, backend, pricing)
+			if err != nil {
+				t.Fatalf("buildBudgetDispatchGuards() error = %v", err)
+			}
+			decision, err := checker.CheckDispatch(ctx, budget.DispatchRequest{Model: "gpt-test", Now: now, Estimate: budget.TokenEstimate{InputTokens: 1}})
+			if err != nil {
+				t.Fatalf("CheckDispatch() error = %v", err)
+			}
+			if decision.Allowed != tt.wantAllow {
+				t.Fatalf("Allowed = %t, want %t; refusal = %#v", decision.Allowed, tt.wantAllow, decision.Refusal)
+			}
+			if !tt.wantAllow && (decision.Refusal == nil || decision.Refusal.CurrentSpendUSD != 200) {
+				t.Fatalf("Refusal = %#v, want project-scoped current spend 200", decision.Refusal)
+			}
+		})
 	}
 }
 

--- a/internal/runner/agent.go
+++ b/internal/runner/agent.go
@@ -1499,6 +1499,7 @@ func (r *Runner) startSession(
 	}
 
 	sessionID, err := r.store.StartSession(ctx, store.SessionStart{
+		ProjectID:                    r.projectID,
 		IssueID:                      req.Issue.ID,
 		Identifier:                   req.Issue.Identifier,
 		IssueURL:                     req.Issue.URL,

--- a/internal/runner/runner_test.go
+++ b/internal/runner/runner_test.go
@@ -277,7 +277,7 @@ func TestRunnerRunPreparesWorkspaceRunsCodexAndRecordsSession(t *testing.T) {
 			t.Fatalf("codex prompt missing %q:\n%s", want, codexClient.request.Prompt)
 		}
 	}
-	if sessionStore.started.Identifier != "digitaldrywood/detent#22" || sessionStore.started.Model != "" || sessionStore.started.RequestedModel != "gpt-5-codex-high" || sessionStore.started.AgentRole != RoleCode {
+	if sessionStore.started.ProjectID != "detent" || sessionStore.started.Identifier != "digitaldrywood/detent#22" || sessionStore.started.Model != "" || sessionStore.started.RequestedModel != "gpt-5-codex-high" || sessionStore.started.AgentRole != RoleCode {
 		t.Fatalf("SessionStart = %#v, want requested model distinct from unresolved model and code role", sessionStore.started)
 	}
 	if sessionStore.started.RuntimeIdentity.ReasoningEffort != (agentidentity.Value{Value: "high", Provenance: agentidentity.ProvenanceConfigured}) {
@@ -3827,7 +3827,7 @@ type fakeRunnerBudgetSpendStore struct {
 	issueCalls int
 }
 
-func (s *fakeRunnerBudgetSpendStore) DailyTokenSpend(context.Context, time.Time) (store.TokenSpend, error) {
+func (s *fakeRunnerBudgetSpendStore) ProjectDailyTokenSpend(context.Context, string, time.Time) (store.TokenSpend, error) {
 	s.dailyCalls++
 	return s.daily, nil
 }

--- a/internal/store/migrations/00018_add_session_project_id.sql
+++ b/internal/store/migrations/00018_add_session_project_id.sql
@@ -1,0 +1,26 @@
+-- +goose Up
+ALTER TABLE codex_sessions
+ADD COLUMN project_id TEXT;
+
+UPDATE codex_sessions
+SET project_id = (
+  SELECT work_attempts.project_id
+  FROM work_attempts
+  WHERE work_attempts.id = codex_sessions.work_attempt_id
+)
+WHERE work_attempt_id IS NOT NULL
+  AND EXISTS (
+    SELECT 1
+    FROM work_attempts
+    WHERE work_attempts.id = codex_sessions.work_attempt_id
+      AND trim(work_attempts.project_id) != ''
+  );
+
+CREATE INDEX codex_sessions_project_completed_idx
+ON codex_sessions(project_id, completed_at DESC, id DESC);
+
+-- +goose Down
+DROP INDEX IF EXISTS codex_sessions_project_completed_idx;
+
+ALTER TABLE codex_sessions
+DROP COLUMN project_id;

--- a/internal/store/sqlc/models.go
+++ b/internal/store/sqlc/models.go
@@ -77,6 +77,7 @@ type CodexSession struct {
 	WorkerStartedAt              sql.NullString `json:"worker_started_at"`
 	WorkerReapedAt               sql.NullString `json:"worker_reaped_at"`
 	WorkerReapOutcome            sql.NullString `json:"worker_reap_outcome"`
+	ProjectID                    sql.NullString `json:"project_id"`
 }
 
 type DetentRun struct {

--- a/internal/store/sqlc/store.sql.go
+++ b/internal/store/sqlc/store.sql.go
@@ -10,6 +10,29 @@ import (
 	"database/sql"
 )
 
+const backfillSessionProjectID = `-- name: BackfillSessionProjectID :execrows
+UPDATE codex_sessions
+SET project_id = ?1
+WHERE trim(COALESCE(project_id, '')) = ''
+  AND (
+    lower(substr(identifier, 1, instr(identifier, '#') - 1)) = lower(?2)
+    OR lower(substr(issue_url, 1, length('https://github.com/' || ?2 || '/issues/'))) = lower('https://github.com/' || ?2 || '/issues/')
+  )
+`
+
+type BackfillSessionProjectIDParams struct {
+	ProjectID  sql.NullString `json:"project_id"`
+	Repository string         `json:"repository"`
+}
+
+func (q *Queries) BackfillSessionProjectID(ctx context.Context, arg BackfillSessionProjectIDParams) (int64, error) {
+	result, err := q.db.ExecContext(ctx, backfillSessionProjectID, arg.ProjectID, arg.Repository)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected()
+}
+
 const budgetCostEvents = `-- name: BudgetCostEvents :many
 SELECT
   project_id,
@@ -327,6 +350,7 @@ func (q *Queries) CreateAPIUsageLog(ctx context.Context, arg CreateAPIUsageLogPa
 const createCodexSession = `-- name: CreateCodexSession :one
 INSERT INTO codex_sessions (
   run_id,
+  project_id,
   issue_id,
   identifier,
   issue_url,
@@ -362,12 +386,13 @@ INSERT INTO codex_sessions (
   resumed_from_session_id,
   orphan_recovery_outcome,
   orphan_recovery_fallback_reason
-) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-RETURNING id, run_id, issue_id, identifier, issue_url, started_at, completed_at, turns, input_tokens, output_tokens, total_tokens, runtime_seconds, final_state, model, cached_input_tokens, reasoning_output_tokens, model_context_window, requested_model, agent_backend_id, agent_backend_kind, agent_role, provider_thread_id, provider_session_id, resumed_from_session_id, work_attempt_id, agent_route, provider, provider_provenance, requested_model_provenance, model_provenance, reasoning_effort, reasoning_effort_provenance, service_tier, service_tier_provenance, identity_observed_at, orphan_recovery_outcome, skill_draft_proposed, orphan_recovery_fallback_reason, worker_pid, worker_pgid, worker_started_at, worker_reaped_at, worker_reap_outcome
+) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+RETURNING id, run_id, issue_id, identifier, issue_url, started_at, completed_at, turns, input_tokens, output_tokens, total_tokens, runtime_seconds, final_state, model, cached_input_tokens, reasoning_output_tokens, model_context_window, requested_model, agent_backend_id, agent_backend_kind, agent_role, provider_thread_id, provider_session_id, resumed_from_session_id, work_attempt_id, agent_route, provider, provider_provenance, requested_model_provenance, model_provenance, reasoning_effort, reasoning_effort_provenance, service_tier, service_tier_provenance, identity_observed_at, orphan_recovery_outcome, skill_draft_proposed, orphan_recovery_fallback_reason, worker_pid, worker_pgid, worker_started_at, worker_reaped_at, worker_reap_outcome, project_id
 `
 
 type CreateCodexSessionParams struct {
 	RunID                        sql.NullInt64  `json:"run_id"`
+	ProjectID                    sql.NullString `json:"project_id"`
 	IssueID                      sql.NullString `json:"issue_id"`
 	Identifier                   sql.NullString `json:"identifier"`
 	IssueURL                     sql.NullString `json:"issue_url"`
@@ -408,6 +433,7 @@ type CreateCodexSessionParams struct {
 func (q *Queries) CreateCodexSession(ctx context.Context, arg CreateCodexSessionParams) (CodexSession, error) {
 	row := q.db.QueryRowContext(ctx, createCodexSession,
 		arg.RunID,
+		arg.ProjectID,
 		arg.IssueID,
 		arg.Identifier,
 		arg.IssueURL,
@@ -489,6 +515,7 @@ func (q *Queries) CreateCodexSession(ctx context.Context, arg CreateCodexSession
 		&i.WorkerStartedAt,
 		&i.WorkerReapedAt,
 		&i.WorkerReapOutcome,
+		&i.ProjectID,
 	)
 	return i, err
 }
@@ -1396,7 +1423,7 @@ func (q *Queries) GetAPIKeyByHash(ctx context.Context, keyHash string) (ApiKey, 
 }
 
 const getCodexSession = `-- name: GetCodexSession :one
-SELECT id, run_id, issue_id, identifier, issue_url, started_at, completed_at, turns, input_tokens, output_tokens, total_tokens, runtime_seconds, final_state, model, cached_input_tokens, reasoning_output_tokens, model_context_window, requested_model, agent_backend_id, agent_backend_kind, agent_role, provider_thread_id, provider_session_id, resumed_from_session_id, work_attempt_id, agent_route, provider, provider_provenance, requested_model_provenance, model_provenance, reasoning_effort, reasoning_effort_provenance, service_tier, service_tier_provenance, identity_observed_at, orphan_recovery_outcome, skill_draft_proposed, orphan_recovery_fallback_reason, worker_pid, worker_pgid, worker_started_at, worker_reaped_at, worker_reap_outcome
+SELECT id, run_id, issue_id, identifier, issue_url, started_at, completed_at, turns, input_tokens, output_tokens, total_tokens, runtime_seconds, final_state, model, cached_input_tokens, reasoning_output_tokens, model_context_window, requested_model, agent_backend_id, agent_backend_kind, agent_role, provider_thread_id, provider_session_id, resumed_from_session_id, work_attempt_id, agent_route, provider, provider_provenance, requested_model_provenance, model_provenance, reasoning_effort, reasoning_effort_provenance, service_tier, service_tier_provenance, identity_observed_at, orphan_recovery_outcome, skill_draft_proposed, orphan_recovery_fallback_reason, worker_pid, worker_pgid, worker_started_at, worker_reaped_at, worker_reap_outcome, project_id
 FROM codex_sessions
 WHERE id = ?
 `
@@ -1448,6 +1475,7 @@ func (q *Queries) GetCodexSession(ctx context.Context, id int64) (CodexSession, 
 		&i.WorkerStartedAt,
 		&i.WorkerReapedAt,
 		&i.WorkerReapOutcome,
+		&i.ProjectID,
 	)
 	return i, err
 }
@@ -2617,7 +2645,7 @@ func (q *Queries) ListOrphanedAgentSessions(ctx context.Context, projectID strin
 }
 
 const listRecentCodexSessions = `-- name: ListRecentCodexSessions :many
-SELECT id, run_id, issue_id, identifier, issue_url, started_at, completed_at, turns, input_tokens, output_tokens, total_tokens, runtime_seconds, final_state, model, cached_input_tokens, reasoning_output_tokens, model_context_window, requested_model, agent_backend_id, agent_backend_kind, agent_role, provider_thread_id, provider_session_id, resumed_from_session_id, work_attempt_id, agent_route, provider, provider_provenance, requested_model_provenance, model_provenance, reasoning_effort, reasoning_effort_provenance, service_tier, service_tier_provenance, identity_observed_at, orphan_recovery_outcome, skill_draft_proposed, orphan_recovery_fallback_reason, worker_pid, worker_pgid, worker_started_at, worker_reaped_at, worker_reap_outcome
+SELECT id, run_id, issue_id, identifier, issue_url, started_at, completed_at, turns, input_tokens, output_tokens, total_tokens, runtime_seconds, final_state, model, cached_input_tokens, reasoning_output_tokens, model_context_window, requested_model, agent_backend_id, agent_backend_kind, agent_role, provider_thread_id, provider_session_id, resumed_from_session_id, work_attempt_id, agent_route, provider, provider_provenance, requested_model_provenance, model_provenance, reasoning_effort, reasoning_effort_provenance, service_tier, service_tier_provenance, identity_observed_at, orphan_recovery_outcome, skill_draft_proposed, orphan_recovery_fallback_reason, worker_pid, worker_pgid, worker_started_at, worker_reaped_at, worker_reap_outcome, project_id
 FROM codex_sessions
 ORDER BY completed_at DESC, id DESC
 LIMIT ?
@@ -2676,6 +2704,7 @@ func (q *Queries) ListRecentCodexSessions(ctx context.Context, limit int64) ([]C
 			&i.WorkerStartedAt,
 			&i.WorkerReapedAt,
 			&i.WorkerReapOutcome,
+			&i.ProjectID,
 		); err != nil {
 			return nil, err
 		}
@@ -2964,6 +2993,71 @@ func (q *Queries) MarkValidatorVerdictCommented(ctx context.Context, arg MarkVal
 		return 0, err
 	}
 	return result.RowsAffected()
+}
+
+const projectDailyTokenSpend = `-- name: ProjectDailyTokenSpend :many
+SELECT
+  CAST(COALESCE(NULLIF(model, ''), NULLIF(requested_model, ''), '') AS TEXT) AS model,
+  CAST(COALESCE(SUM(input_tokens), 0) AS INTEGER) AS input_tokens,
+  CAST(COALESCE(SUM(cached_input_tokens), 0) AS INTEGER) AS cached_input_tokens,
+  CAST(COALESCE(SUM(output_tokens), 0) AS INTEGER) AS output_tokens,
+  CAST(COALESCE(SUM(reasoning_output_tokens), 0) AS INTEGER) AS reasoning_output_tokens,
+  CAST(COALESCE(SUM(total_tokens), 0) AS INTEGER) AS total_tokens,
+  CAST(COUNT(*) AS INTEGER) AS sessions
+FROM codex_sessions
+WHERE substr(completed_at, 1, 10) = ?1
+  AND (
+    project_id = ?2
+    OR trim(COALESCE(project_id, '')) = ''
+  )
+GROUP BY COALESCE(NULLIF(model, ''), NULLIF(requested_model, ''), '')
+ORDER BY COALESCE(NULLIF(model, ''), NULLIF(requested_model, ''), '')
+`
+
+type ProjectDailyTokenSpendParams struct {
+	CompletedAt sql.NullString `json:"completed_at"`
+	ProjectID   sql.NullString `json:"project_id"`
+}
+
+type ProjectDailyTokenSpendRow struct {
+	Model                 string `json:"model"`
+	InputTokens           int64  `json:"input_tokens"`
+	CachedInputTokens     int64  `json:"cached_input_tokens"`
+	OutputTokens          int64  `json:"output_tokens"`
+	ReasoningOutputTokens int64  `json:"reasoning_output_tokens"`
+	TotalTokens           int64  `json:"total_tokens"`
+	Sessions              int64  `json:"sessions"`
+}
+
+func (q *Queries) ProjectDailyTokenSpend(ctx context.Context, arg ProjectDailyTokenSpendParams) ([]ProjectDailyTokenSpendRow, error) {
+	rows, err := q.db.QueryContext(ctx, projectDailyTokenSpend, arg.CompletedAt, arg.ProjectID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []ProjectDailyTokenSpendRow{}
+	for rows.Next() {
+		var i ProjectDailyTokenSpendRow
+		if err := rows.Scan(
+			&i.Model,
+			&i.InputTokens,
+			&i.CachedInputTokens,
+			&i.OutputTokens,
+			&i.ReasoningOutputTokens,
+			&i.TotalTokens,
+			&i.Sessions,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
 }
 
 const recentModelTokenQuantiles = `-- name: RecentModelTokenQuantiles :one

--- a/internal/store/sqlite.go
+++ b/internal/store/sqlite.go
@@ -205,6 +205,7 @@ func (s *sqliteStore) StartSession(ctx context.Context, attrs SessionStart) (int
 
 	session, err := s.queries.CreateCodexSession(ctx, sqlc.CreateCodexSessionParams{
 		RunID:                        nullPositiveInt64(attrs.RunID),
+		ProjectID:                    nullString(attrs.ProjectID),
 		WorkAttemptID:                nullPositiveInt64(attrs.WorkAttemptID),
 		IssueID:                      nullString(attrs.IssueID),
 		Identifier:                   nullString(attrs.Identifier),
@@ -913,6 +914,66 @@ func (s *sqliteStore) DailyTokenSpend(ctx context.Context, day time.Time) (Token
 		spend.ByModel = append(spend.ByModel, modelSpend)
 	}
 	return spend, nil
+}
+
+func (s *sqliteStore) ProjectDailyTokenSpend(ctx context.Context, projectID string, day time.Time) (TokenSpend, error) {
+	projectID = strings.TrimSpace(projectID)
+	if projectID == "" {
+		return TokenSpend{}, errors.New("project_id is required")
+	}
+	date, err := dateString(day)
+	if err != nil {
+		return TokenSpend{}, err
+	}
+
+	rows, err := s.queries.ProjectDailyTokenSpend(ctx, sqlc.ProjectDailyTokenSpendParams{
+		CompletedAt: sql.NullString{String: date, Valid: true},
+		ProjectID:   nullString(projectID),
+	})
+	if err != nil {
+		return TokenSpend{}, fmt.Errorf("reading project daily token spend: %w", err)
+	}
+
+	spend := TokenSpend{Date: date, ByModel: make([]ModelTokenSpend, 0, len(rows))}
+	for _, row := range rows {
+		modelSpend := ModelTokenSpend{
+			Model:                 row.Model,
+			InputTokens:           row.InputTokens,
+			CachedInputTokens:     row.CachedInputTokens,
+			OutputTokens:          row.OutputTokens,
+			ReasoningOutputTokens: row.ReasoningOutputTokens,
+			TotalTokens:           row.TotalTokens,
+			Sessions:              row.Sessions,
+		}
+		spend.InputTokens += modelSpend.InputTokens
+		spend.CachedInputTokens += modelSpend.CachedInputTokens
+		spend.OutputTokens += modelSpend.OutputTokens
+		spend.ReasoningOutputTokens += modelSpend.ReasoningOutputTokens
+		spend.TotalTokens += modelSpend.TotalTokens
+		spend.Sessions += modelSpend.Sessions
+		spend.ByModel = append(spend.ByModel, modelSpend)
+	}
+	return spend, nil
+}
+
+func (s *sqliteStore) BackfillSessionProjectIDs(ctx context.Context, attributions []SessionProjectAttribution) (int64, error) {
+	var updated int64
+	for _, attribution := range attributions {
+		projectID := strings.TrimSpace(attribution.ProjectID)
+		repository := strings.TrimSpace(attribution.Repository)
+		if projectID == "" || repository == "" {
+			continue
+		}
+		rows, err := s.queries.BackfillSessionProjectID(ctx, sqlc.BackfillSessionProjectIDParams{
+			ProjectID:  nullString(projectID),
+			Repository: repository,
+		})
+		if err != nil {
+			return updated, fmt.Errorf("backfilling session project %q: %w", projectID, err)
+		}
+		updated += rows
+	}
+	return updated, nil
 }
 
 func (s *sqliteStore) IssueTokenSpend(ctx context.Context, identity IssueIdentity) (TokenSpend, error) {

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -73,6 +73,8 @@ type StatsStore interface {
 	CycleTimeReport(context.Context) (CycleTimeReport, error)
 	LifetimeTotals(context.Context) (LifetimeTotals, error)
 	DailyTokenSpend(context.Context, time.Time) (TokenSpend, error)
+	ProjectDailyTokenSpend(context.Context, string, time.Time) (TokenSpend, error)
+	BackfillSessionProjectIDs(context.Context, []SessionProjectAttribution) (int64, error)
 	IssueTokenSpend(context.Context, IssueIdentity) (TokenSpend, error)
 	RecentModelTokenQuantiles(context.Context, ModelTokenQuantileQuery) (ModelTokenQuantiles, error)
 }
@@ -275,6 +277,7 @@ type RunStop struct {
 type SessionStart struct {
 	RunID                        int64
 	WorkAttemptID                int64
+	ProjectID                    string
 	IssueID                      string
 	Identifier                   string
 	IssueURL                     string
@@ -290,6 +293,11 @@ type SessionStart struct {
 	ResumedFromSessionID         int64
 	OrphanRecoveryOutcome        string
 	OrphanRecoveryFallbackReason string
+}
+
+type SessionProjectAttribution struct {
+	ProjectID  string
+	Repository string
 }
 
 type SessionProviderIdentity struct {

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -159,6 +159,56 @@ func TestSkillDraftTelemetryMigrationUpDown(t *testing.T) {
 	assertColumnAbsent(t, db, "codex_sessions", "skill_draft_proposed")
 }
 
+func TestSessionProjectAttributionMigrationUpDown(t *testing.T) {
+	ctx := context.Background()
+	db, err := sql.Open("sqlite", filepath.Join(t.TempDir(), "detent.db"))
+	if err != nil {
+		t.Fatalf("sql.Open() error = %v", err)
+	}
+	db.SetMaxOpenConns(1)
+	t.Cleanup(func() {
+		if err := db.Close(); err != nil {
+			t.Fatalf("db.Close() error = %v", err)
+		}
+	})
+	if err := configureSQLite(ctx, db, 0); err != nil {
+		t.Fatalf("configureSQLite() error = %v", err)
+	}
+
+	migrationMu.Lock()
+	defer migrationMu.Unlock()
+	goose.SetBaseFS(migrationsFS)
+	defer goose.SetBaseFS(nil)
+	if err := goose.SetDialect("sqlite3"); err != nil {
+		t.Fatalf("goose.SetDialect() error = %v", err)
+	}
+	if err := goose.UpToContext(ctx, db, "migrations", 16); err != nil {
+		t.Fatalf("goose.UpToContext(16) error = %v", err)
+	}
+	if _, err := db.ExecContext(ctx, `
+INSERT INTO work_attempts (id, project_id, worker_type, status, started_at)
+VALUES (1279, 'detent', 'implementation', 'complete', '2026-07-12T19:00:00Z');
+INSERT INTO codex_sessions (work_attempt_id, identifier, started_at, completed_at)
+VALUES (1279, 'digitaldrywood/detent#1279', '2026-07-12T19:00:00Z', '2026-07-12T20:00:00Z');
+`); err != nil {
+		t.Fatalf("seed pre-migration rows error = %v", err)
+	}
+	assertColumnAbsent(t, db, "codex_sessions", "project_id")
+
+	if err := goose.UpToContext(ctx, db, "migrations", 18); err != nil {
+		t.Fatalf("goose.UpToContext(18) error = %v", err)
+	}
+	assertColumnPresent(t, db, "codex_sessions", "project_id")
+	if got := queryString(t, db, "SELECT project_id FROM codex_sessions WHERE work_attempt_id = 1279"); got != "detent" {
+		t.Fatalf("backfilled project_id = %q, want detent", got)
+	}
+
+	if err := goose.DownToContext(ctx, db, "migrations", 17); err != nil {
+		t.Fatalf("goose.DownToContext(17) error = %v", err)
+	}
+	assertColumnAbsent(t, db, "codex_sessions", "project_id")
+}
+
 func TestAgentResumeStateMigrationUpDown(t *testing.T) {
 	ctx := context.Background()
 	dbPath := filepath.Join(t.TempDir(), "detent.db")
@@ -928,6 +978,115 @@ func TestSessionRuntimeIdentityPersistsRequestedAndResolvedSeparately(t *testing
 	}
 	if finished.IdentityObservedAt.String != runtimeAt.Format(time.RFC3339Nano) {
 		t.Fatalf("identity observed at = %q, want %q", finished.IdentityObservedAt.String, runtimeAt.Format(time.RFC3339Nano))
+	}
+}
+
+func TestDailyTokenSpendIsScopedToProject(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	backend := openTestStore(t, ctx)
+	day := time.Date(2026, 7, 12, 12, 0, 0, 0, time.UTC)
+	for _, session := range []struct {
+		projectID  string
+		identifier string
+		tokens     int64
+	}{
+		{projectID: "detent", identifier: "digitaldrywood/detent#1279", tokens: 100},
+		{projectID: "gopher-ai", identifier: "gopherguides/gopher-ai#42", tokens: 900},
+	} {
+		sessionID, err := backend.StartSession(ctx, SessionStart{
+			ProjectID:  session.projectID,
+			Identifier: session.identifier,
+			StartedAt:  day.Add(-time.Minute),
+			Model:      "gpt-5",
+		})
+		if err != nil {
+			t.Fatalf("StartSession(%s) error = %v", session.identifier, err)
+		}
+		if err := backend.FinishSession(ctx, sessionID, SessionFinish{
+			CompletedAt: day,
+			InputTokens: session.tokens,
+			TotalTokens: session.tokens,
+			FinalState:  "complete",
+			Model:       "gpt-5",
+		}); err != nil {
+			t.Fatalf("FinishSession(%s) error = %v", session.identifier, err)
+		}
+	}
+
+	spend, err := backend.ProjectDailyTokenSpend(ctx, "detent", day)
+	if err != nil {
+		t.Fatalf("ProjectDailyTokenSpend() error = %v", err)
+	}
+	if spend.TotalTokens != 100 || spend.Sessions != 1 {
+		t.Fatalf("ProjectDailyTokenSpend() = %#v, want detent session only", spend)
+	}
+
+	unknownID, err := backend.StartSession(ctx, SessionStart{
+		Identifier: "example/legacy#1",
+		StartedAt:  day.Add(-time.Minute),
+		Model:      "gpt-5",
+	})
+	if err != nil {
+		t.Fatalf("StartSession(unknown) error = %v", err)
+	}
+	if err := backend.FinishSession(ctx, unknownID, SessionFinish{
+		CompletedAt: day,
+		InputTokens: 50,
+		TotalTokens: 50,
+		FinalState:  "complete",
+		Model:       "gpt-5",
+	}); err != nil {
+		t.Fatalf("FinishSession(unknown) error = %v", err)
+	}
+	spend, err = backend.ProjectDailyTokenSpend(ctx, "detent", day)
+	if err != nil {
+		t.Fatalf("ProjectDailyTokenSpend(unknown) error = %v", err)
+	}
+	if spend.TotalTokens != 150 || spend.Sessions != 2 {
+		t.Fatalf("ProjectDailyTokenSpend(unknown) = %#v, want conservative unknown fallback", spend)
+	}
+
+	updated, err := backend.BackfillSessionProjectIDs(ctx, []SessionProjectAttribution{{ProjectID: "legacy", Repository: "example/legacy"}})
+	if err != nil {
+		t.Fatalf("BackfillSessionProjectIDs() error = %v", err)
+	}
+	if updated != 1 {
+		t.Fatalf("BackfillSessionProjectIDs() = %d, want 1", updated)
+	}
+	spend, err = backend.ProjectDailyTokenSpend(ctx, "detent", day)
+	if err != nil {
+		t.Fatalf("ProjectDailyTokenSpend(backfilled) error = %v", err)
+	}
+	if spend.TotalTokens != 100 || spend.Sessions != 1 {
+		t.Fatalf("ProjectDailyTokenSpend(backfilled) = %#v, want detent session only", spend)
+	}
+
+	wildcardID, err := backend.StartSession(ctx, SessionStart{
+		IssueURL:  "https://github.com/owner/axb/issues/1",
+		StartedAt: day.Add(-time.Minute),
+		Model:     "gpt-5",
+	})
+	if err != nil {
+		t.Fatalf("StartSession(wildcard) error = %v", err)
+	}
+	if err := backend.FinishSession(ctx, wildcardID, SessionFinish{CompletedAt: day, FinalState: "complete", Model: "gpt-5"}); err != nil {
+		t.Fatalf("FinishSession(wildcard) error = %v", err)
+	}
+	updated, err = backend.BackfillSessionProjectIDs(ctx, []SessionProjectAttribution{{ProjectID: "wrong", Repository: "owner/a_b"}})
+	if err != nil {
+		t.Fatalf("BackfillSessionProjectIDs(wildcard) error = %v", err)
+	}
+	if updated != 0 {
+		t.Fatalf("BackfillSessionProjectIDs(wildcard) = %d, want 0", updated)
+	}
+	updated, err = backend.BackfillSessionProjectIDs(ctx, []SessionProjectAttribution{{ProjectID: "right", Repository: "owner/axb"}})
+	if err != nil {
+		t.Fatalf("BackfillSessionProjectIDs(exact URL) error = %v", err)
+	}
+	if updated != 1 {
+		t.Fatalf("BackfillSessionProjectIDs(exact URL) = %d, want 1", updated)
 	}
 }
 


### PR DESCRIPTION
## Summary

- persist each agent session's configured project ID and scope daily spend queries to that project
- backfill existing rows from work attempts and unique project-registry repository matches, while conservatively charging unknown rows to every project
- warn from `detent doctor` when current-day session attribution is missing

Fixes #1279

## UI Surface Contract

- [x] N/A, or the linked issue explicitly authorizes any high-impact UI surface, layout, density, first-viewport, or responsive visibility tradeoff.
- [x] Persistent top-of-screen messaging is explicitly authorized by the issue, or this PR does not add it.
- [x] Visual changes to primary operator screens include screenshot or browser verification below.

No UI changes.

## Test Plan

- [x] `make generate`
- [x] focused migration, store scoping, multi-project dispatch, registry backfill, and Doctor tests
- [x] `make check`
