### PR TITLE
fix(config): recover stale workflow watchers

### DIFF
--- a/README.md
+++ b/README.md
@@ -2112,6 +2112,10 @@ active `global.yaml`, including symlinked config targets, and reconciles
 supported live-reload fields without a process restart. Invalid edits are
 logged and ignored while the last valid config stays live.
 
+Paused projects do not run workflow watchers or periodic workflow reconciliation.
+`detent unpause <id>` synchronously reloads the project's current `WORKFLOW.md`
+before dispatch resumes, so edits made while paused take effect on unpause.
+
 For projects whose workflow file is already present on the target branch, you
 can include `--workflow-ref origin/main` during registration or add
 `workflow_ref: origin/main` to the project entry later.

--- a/README.md
+++ b/README.md
@@ -2114,7 +2114,9 @@ logged and ignored while the last valid config stays live.
 
 Paused projects do not run workflow watchers or periodic workflow reconciliation.
 `detent unpause <id>` synchronously reloads the project's current `WORKFLOW.md`
-before dispatch resumes, so edits made while paused take effect on unpause.
+before dispatch resumes, so edits made while paused take effect on unpause. If
+the current workflow cannot be loaded or prepared, unpause returns the error and
+the project remains paused.
 
 For projects whose workflow file is already present on the target branch, you
 can include `--workflow-ref origin/main` during registration or add

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -337,6 +337,14 @@ func runDoctor(ctx context.Context, cfg doctorConfig, opts options, deps doctorD
 	jobs := []doctorCheckJob{}
 	if global != nil {
 		globalConfig := *global
+		workflowDriftBoot := boot
+		if doctorServerPort(workflowDriftBoot) == 0 {
+			livePort := defaultWebPort
+			if globalConfig.Port != nil {
+				livePort = *globalConfig.Port
+			}
+			workflowDriftBoot.Port = &livePort
+		}
 		githubToken := runtime.GitHubToken
 		jobs = append(jobs, doctorCheckJob{
 			Name: "Update checking",
@@ -346,6 +354,12 @@ func runDoctor(ctx context.Context, cfg doctorConfig, opts options, deps doctorD
 		})
 		if projectScopeCheck == nil {
 			jobs = append(jobs, doctorProjectCheckJobs(globalConfig, deps, githubToken, cfg.AllowWriteProbes)...)
+			jobs = append(jobs, doctorCheckJob{
+				Name: "Workflow runtime drift",
+				Run: func(jobCtx context.Context) []doctorCheck {
+					return checkDoctorWorkflowDrift(jobCtx, globalConfig, workflowDriftBoot, deps)
+				},
+			})
 		}
 		jobs = append(jobs, doctorCheckJob{
 			Name: "Workflow optimization",

--- a/internal/cli/doctor_environment.go
+++ b/internal/cli/doctor_environment.go
@@ -501,10 +501,19 @@ type doctorHealthProbe struct {
 }
 
 type doctorHealthResponse struct {
-	Status  string               `json:"status"`
-	Mode    string               `json:"mode"`
-	Checks  map[string]string    `json:"checks"`
-	Budgets []doctorHealthBudget `json:"budgets"`
+	Status    string                 `json:"status"`
+	Mode      string                 `json:"mode"`
+	Checks    map[string]string      `json:"checks"`
+	Budgets   []doctorHealthBudget   `json:"budgets"`
+	Workflows []doctorHealthWorkflow `json:"workflows"`
+}
+
+type doctorHealthWorkflow struct {
+	ProjectID  string    `json:"project_id"`
+	Path       string    `json:"path"`
+	SourceHash string    `json:"source_hash"`
+	ModifiedAt time.Time `json:"modified_at"`
+	LoadedAt   time.Time `json:"loaded_at"`
 }
 
 type doctorHealthBudget struct {

--- a/internal/cli/doctor_project.go
+++ b/internal/cli/doctor_project.go
@@ -59,6 +59,14 @@ func checkDoctorWorkflowDrift(ctx context.Context, cfg globalconfig.Config, boot
 	for _, configuredProject := range cfg.Projects {
 		id := doctorProjectID(configuredProject)
 		name := "Project " + id + " workflow runtime"
+		if configuredProject.Paused {
+			checks = append(checks, doctorCheck{
+				Name:   name,
+				Status: doctorOK,
+				Detail: "project " + id + " is paused; workflow drift comparison deferred until unpause",
+			})
+			continue
+		}
 		runtimeWorkflow, ok := runtimeByProject[id]
 		if !ok {
 			checks = append(checks, doctorCheck{

--- a/internal/cli/doctor_project.go
+++ b/internal/cli/doctor_project.go
@@ -40,6 +40,99 @@ func checkDoctorProjects(ctx context.Context, cfg globalconfig.Config, deps doct
 	return checks
 }
 
+func checkDoctorWorkflowDrift(ctx context.Context, cfg globalconfig.Config, boot BootConfig, deps doctorDeps) []doctorCheck {
+	probe, err := probeDoctorHealth(ctx, boot, deps)
+	if err != nil {
+		return []doctorCheck{{
+			Name:   "Workflow runtime drift",
+			Status: doctorOK,
+			Detail: "runtime comparison skipped because no healthy live Detent instance was reachable",
+		}}
+	}
+
+	runtimeByProject := make(map[string]doctorHealthWorkflow, len(probe.Health.Workflows))
+	for _, workflow := range probe.Health.Workflows {
+		runtimeByProject[strings.TrimSpace(workflow.ProjectID)] = workflow
+	}
+
+	checks := make([]doctorCheck, 0, len(cfg.Projects))
+	for _, configuredProject := range cfg.Projects {
+		id := doctorProjectID(configuredProject)
+		name := "Project " + id + " workflow runtime"
+		runtimeWorkflow, ok := runtimeByProject[id]
+		if !ok {
+			checks = append(checks, doctorCheck{
+				Name:   name,
+				Status: doctorWarn,
+				Detail: "project " + id + " is missing workflow source status from the live instance",
+				Hint:   "Restart Detent with a version that reports workflow source status, then rerun detent doctor.",
+			})
+			continue
+		}
+
+		diskWorkflow, loadErr := loadDoctorProjectWorkflow(ctx, configuredProject, deps)
+		if loadErr != nil {
+			continue
+		}
+		if runtimeWorkflow.SourceHash == "" {
+			checks = append(checks, doctorCheck{
+				Name:   name,
+				Status: doctorWarn,
+				Detail: "project " + id + " live workflow source hash is unavailable",
+				Hint:   "Restart Detent with a version that records loaded workflow source hashes.",
+			})
+			continue
+		}
+		if diskWorkflow.SourceHash != runtimeWorkflow.SourceHash {
+			modifiedAt := doctorWorkflowModifiedAt(configuredProject)
+			checks = append(checks, doctorCheck{
+				Name:   name,
+				Status: doctorFail,
+				Detail: fmt.Sprintf(
+					"project %s is running stale config (file changed at %s, loaded at %s)",
+					id,
+					doctorWorkflowTimestamp(modifiedAt),
+					doctorWorkflowTimestamp(runtimeWorkflow.LoadedAt),
+				),
+				Hint: "Check workflow watcher warnings; Detent will reconcile the file automatically, or restart the process if drift persists.",
+			})
+			continue
+		}
+		checks = append(checks, doctorCheck{
+			Name:   name,
+			Status: doctorOK,
+			Detail: "project " + id + " loaded workflow matches the configured source",
+		})
+	}
+	return checks
+}
+
+func doctorWorkflowModifiedAt(project globalconfig.Project) time.Time {
+	if strings.TrimSpace(project.WorkflowRef) != "" {
+		return time.Time{}
+	}
+	path := strings.TrimSpace(project.Workflow)
+	if path == "~" || strings.HasPrefix(path, "~/") {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return time.Time{}
+		}
+		path = filepath.Join(home, strings.TrimPrefix(path, "~/"))
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		return time.Time{}
+	}
+	return info.ModTime().UTC()
+}
+
+func doctorWorkflowTimestamp(value time.Time) string {
+	if value.IsZero() {
+		return "unknown"
+	}
+	return value.UTC().Format(time.RFC3339)
+}
+
 func doctorProjectCheckJobs(cfg globalconfig.Config, deps doctorDeps, githubToken RuntimeSecret, allowWriteProbes bool) []doctorCheckJob {
 	if len(cfg.Projects) == 0 {
 		return []doctorCheckJob{{

--- a/internal/cli/doctor_test.go
+++ b/internal/cli/doctor_test.go
@@ -3918,6 +3918,32 @@ func TestCheckDoctorWorkflowDriftReportsStaleLiveConfig(t *testing.T) {
 	}
 }
 
+func TestCheckDoctorWorkflowDriftDefersPausedProject(t *testing.T) {
+	t.Parallel()
+
+	port := 4001
+	checks := checkDoctorWorkflowDrift(context.Background(), globalconfig.Config{
+		Projects: []globalconfig.Project{{ID: "detent", Workflow: "WORKFLOW.md", Paused: true}},
+	}, BootConfig{Host: "127.0.0.1", Port: &port}, doctorDeps{
+		httpDo: func(*http.Request) (*http.Response, error) {
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Body:       io.NopCloser(strings.NewReader(`{"status":"ok","mode":"running","checks":{"hub":"configured","store":"configured","registry":"configured","connector":"configured"},"workflows":[{"project_id":"detent","source_hash":"stale-hash"}]}`)),
+			}, nil
+		},
+	})
+
+	if len(checks) != 1 {
+		t.Fatalf("checks = %#v, want one", checks)
+	}
+	if checks[0].Status != doctorOK {
+		t.Fatalf("Status = %s, want %s: %#v", checks[0].Status, doctorOK, checks[0])
+	}
+	if !strings.Contains(checks[0].Detail, "paused; workflow drift comparison deferred until unpause") {
+		t.Fatalf("Detail = %q, want paused drift deferral", checks[0].Detail)
+	}
+}
+
 func TestCheckDoctorServerPortProbesExistingInstance(t *testing.T) {
 	t.Parallel()
 

--- a/internal/cli/doctor_test.go
+++ b/internal/cli/doctor_test.go
@@ -3863,6 +3863,61 @@ func TestCheckDoctorServerPort(t *testing.T) {
 	}
 }
 
+func TestCheckDoctorWorkflowDriftReportsStaleLiveConfig(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	workflowPath := filepath.Join(dir, "WORKFLOW.md")
+	if err := os.WriteFile(workflowPath, []byte("---\ntracker:\n  kind: memory\n---\ncurrent\n"), 0o600); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+	loadedAt := time.Date(2026, 7, 12, 14, 0, 0, 0, time.UTC)
+	payload, err := json.Marshal(map[string]any{
+		"status": "ok",
+		"mode":   "running",
+		"checks": map[string]string{
+			"hub": "configured", "store": "configured", "registry": "configured", "connector": "configured",
+		},
+		"workflows": []map[string]any{{
+			"project_id":  "detent",
+			"path":        workflowPath,
+			"source_hash": "stale-hash",
+			"loaded_at":   loadedAt,
+		}},
+	})
+	if err != nil {
+		t.Fatalf("Marshal() error = %v", err)
+	}
+	port := 4001
+	checks := checkDoctorWorkflowDrift(context.Background(), globalconfig.Config{
+		Projects: []globalconfig.Project{{ID: "detent", Workflow: workflowPath}},
+	}, BootConfig{Host: "127.0.0.1", Port: &port}, doctorDeps{
+		loadWorkflow: workflowconfig.LoadWorkflow,
+		httpDo: func(*http.Request) (*http.Response, error) {
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Body:       io.NopCloser(bytes.NewReader(payload)),
+			}, nil
+		},
+	})
+
+	if len(checks) != 1 {
+		t.Fatalf("checks = %#v, want one", checks)
+	}
+	if checks[0].Status != doctorFail {
+		t.Fatalf("Status = %s, want %s: %#v", checks[0].Status, doctorFail, checks[0])
+	}
+	for _, want := range []string{
+		"project detent is running stale config",
+		"file changed at ",
+		"loaded at 2026-07-12T14:00:00Z",
+	} {
+		if !strings.Contains(checks[0].Detail, want) {
+			t.Fatalf("Detail = %q, want containing %q", checks[0].Detail, want)
+		}
+	}
+}
+
 func TestCheckDoctorServerPortProbesExistingInstance(t *testing.T) {
 	t.Parallel()
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -2,6 +2,8 @@ package config
 
 import (
 	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"net/url"
@@ -94,8 +96,9 @@ const (
 )
 
 type Workflow struct {
-	Config Config
-	Prompt string
+	Config     Config
+	Prompt     string
+	SourceHash string
 }
 
 type Config struct {
@@ -953,9 +956,11 @@ func ParseWorkflow(raw []byte) (Workflow, error) {
 
 	cfg.normalize()
 
+	sum := sha256.Sum256(raw)
 	return Workflow{
-		Config: cfg,
-		Prompt: string(prompt),
+		Config:     cfg,
+		Prompt:     string(prompt),
+		SourceHash: hex.EncodeToString(sum[:]),
 	}, nil
 }
 

--- a/internal/config/watcher/file.go
+++ b/internal/config/watcher/file.go
@@ -17,10 +17,11 @@ import (
 type FileLoader[T any] func(string) (T, error)
 
 type FileUpdate[T any] struct {
-	Path  string
-	Value T
-	Err   error
-	At    time.Time
+	Path       string
+	Value      T
+	Err        error
+	WatcherErr bool
+	At         time.Time
 }
 
 type FileOption func(*fileOptions)
@@ -166,7 +167,7 @@ func (w *FileWatcher[T]) run(ctx context.Context, fsWatcher *fsnotify.Watcher, u
 			if !ok {
 				return
 			}
-			w.send(ctx, updates, FileUpdate[T]{Path: w.path, Err: err, At: time.Now()})
+			w.send(ctx, updates, FileUpdate[T]{Path: w.path, Err: err, WatcherErr: true, At: time.Now()})
 		case <-timerC:
 			timerC = nil
 			update := w.reload(ctx)

--- a/internal/config/watcher/watcher.go
+++ b/internal/config/watcher/watcher.go
@@ -19,10 +19,11 @@ var ErrMissingPath = errors.New("workflow watch path is required")
 type Loader func(string) (workflowconfig.Workflow, error)
 
 type Update struct {
-	Path     string
-	Workflow workflowconfig.Workflow
-	Err      error
-	At       time.Time
+	Path       string
+	Workflow   workflowconfig.Workflow
+	Err        error
+	WatcherErr bool
+	At         time.Time
 }
 
 type Option func(*options)
@@ -103,10 +104,11 @@ func (w *Watcher) Watch(ctx context.Context) (<-chan Update, error) {
 		defer close(updates)
 		for update := range fileUpdates {
 			mapped := Update{
-				Path:     update.Path,
-				Workflow: update.Value,
-				Err:      update.Err,
-				At:       update.At,
+				Path:       update.Path,
+				Workflow:   update.Value,
+				Err:        update.Err,
+				WatcherErr: update.WatcherErr,
+				At:         update.At,
 			}
 			select {
 			case updates <- mapped:

--- a/internal/project/project.go
+++ b/internal/project/project.go
@@ -533,9 +533,14 @@ func (p *Project) Unpause(ctx context.Context) error {
 		p.mu.Unlock()
 		return nil
 	}
+	fileBackedWorkflow := p.workflowSource.Hash != ""
 	p.mu.Unlock()
 
-	p.reconcileWorkflow(ctx)
+	if fileBackedWorkflow {
+		if err := p.reconcileWorkflow(ctx); err != nil {
+			return fmt.Errorf("reload workflow before unpause: %w", err)
+		}
+	}
 
 	p.mu.Lock()
 	if !p.cfg.Paused {
@@ -928,7 +933,9 @@ func (p *Project) startWorkflowWatcher(ctx context.Context) <-chan struct{} {
 				p.setWorkflowWatcherArmed(false)
 				return
 			case <-reconcileTicker.C:
-				p.reconcileWorkflow(ctx)
+				if err := p.reconcileWorkflow(ctx); err != nil {
+					continue
+				}
 			case <-retryC:
 				retryC = nil
 				if err := arm(); err != nil {
@@ -963,7 +970,9 @@ func (p *Project) startWorkflowWatcher(ctx context.Context) <-chan struct{} {
 					scheduleRetry(update.Err)
 					continue
 				}
-				p.handleWorkflowUpdate(ctx, update)
+				if err := p.handleWorkflowUpdate(ctx, update); err != nil {
+					continue
+				}
 			}
 		}
 	}()
@@ -1009,7 +1018,7 @@ func (p *Project) recordWorkflowWatchEvent(at time.Time) {
 	p.mu.Unlock()
 }
 
-func (p *Project) reconcileWorkflow(ctx context.Context) {
+func (p *Project) reconcileWorkflow(ctx context.Context) error {
 	p.mu.Lock()
 	projectConfig := p.cfg
 	loadedHash := p.workflowSource.Hash
@@ -1024,25 +1033,20 @@ func (p *Project) reconcileWorkflow(ctx context.Context) {
 		if ctx.Err() == nil {
 			p.logger.Warn("workflow reconcile failed", "project_id", p.id, "path", workflowSourceDisplayPath(projectConfig), "error", err)
 		}
-		return
+		return fmt.Errorf("load workflow: %w", err)
 	}
 	if workflow.SourceHash == "" || workflow.SourceHash == loadedHash {
-		return
+		return nil
 	}
 
 	path := workflowSourceDisplayPath(projectConfig)
 	p.logger.Warn("workflow reconcile detected stale config", "project_id", p.id, "path", path)
-	p.handleWorkflowUpdate(ctx, configwatcher.Update{Path: path, Workflow: workflow, At: now})
+	return p.handleWorkflowUpdate(ctx, configwatcher.Update{Path: path, Workflow: workflow, At: now})
 }
 
-func (p *Project) handleWorkflowUpdate(ctx context.Context, update configwatcher.Update) bool {
+func (p *Project) handleWorkflowUpdate(ctx context.Context, update configwatcher.Update) error {
 	if update.Err != nil {
-		p.logger.Warn("workflow reload failed",
-			"project_id", p.id,
-			"path", update.Path,
-			"error", update.Err,
-		)
-		return false
+		return p.workflowReloadError("workflow reload failed", update.Path, update.Err)
 	}
 
 	p.mu.Lock()
@@ -1060,52 +1064,27 @@ func (p *Project) handleWorkflowUpdate(ctx context.Context, update configwatcher
 	workflow.Config = workflowConfigWithProjectIdentity(projectConfig, workflow.Config)
 	workflow.Config = workflowConfigWithGitHubToken(workflow.Config, githubToken)
 	if err := workflow.Config.Validate(); err != nil {
-		p.logger.Warn("workflow reload validation failed",
-			"project_id", p.id,
-			"path", update.Path,
-			"error", err,
-		)
-		return false
+		return p.workflowReloadError("workflow reload validation failed", update.Path, err)
 	}
 
 	projectConnector, err := buildConnector(workflow.Config, connectorFactory)
 	if err != nil {
-		p.logger.Warn("workflow reload connector failed",
-			"project_id", p.id,
-			"path", update.Path,
-			"error", err,
-		)
-		return false
+		return p.workflowReloadError("workflow reload connector failed", update.Path, err)
 	}
 
 	projectScheduler, err := buildScheduler(workflow.Config, schedulerFactory)
 	if err != nil {
-		p.logger.Warn("workflow reload scheduler failed",
-			"project_id", p.id,
-			"path", update.Path,
-			"error", err,
-		)
-		return false
+		return p.workflowReloadError("workflow reload scheduler failed", update.Path, err)
 	}
 	releaseBuild, err := buildReleaseCoordinator(workflow.Config, projectConnector)
 	if err != nil {
-		p.logger.Warn("workflow reload release coordinator failed",
-			"project_id", p.id,
-			"path", update.Path,
-			"error", err,
-		)
-		return false
+		return p.workflowReloadError("workflow reload release coordinator failed", update.Path, err)
 	}
 	releaseCoordinator := releaseBuild.coordinator
 
 	projectRetroStore, productRetroStore, retroProductConnector, err := buildRetroIssueStores(workflow.Config, projectConnector, connectorFactory)
 	if err != nil {
-		p.logger.Warn("workflow reload retro connector failed",
-			"project_id", p.id,
-			"path", update.Path,
-			"error", err,
-		)
-		return false
+		return p.workflowReloadError("workflow reload retro connector failed", update.Path, err)
 	}
 	retainRetroProduct := false
 	defer func() {
@@ -1125,12 +1104,7 @@ func (p *Project) handleWorkflowUpdate(ctx context.Context, update configwatcher
 			intakeRoot(projectConfig, workflow.Config),
 		)
 		if err != nil {
-			p.logger.Warn("prepare workflow intake reload failed",
-				"project_id", p.id,
-				"path", update.Path,
-				"error", err,
-			)
-			return false
+			return p.workflowReloadError("prepare workflow intake reload failed", update.Path, err)
 		}
 	}
 
@@ -1143,14 +1117,9 @@ func (p *Project) handleWorkflowUpdate(ctx context.Context, update configwatcher
 			ReplaceRelease: true,
 		}); err != nil {
 			if ctx.Err() != nil {
-				return false
+				return ctx.Err()
 			}
-			p.logger.Warn("apply workflow reload failed",
-				"project_id", p.id,
-				"path", update.Path,
-				"error", err,
-			)
-			return false
+			return p.workflowReloadError("apply workflow reload failed", update.Path, err)
 		}
 	}
 	if updater, ok := runner.(workflowUpdater); ok {
@@ -1166,8 +1135,7 @@ func (p *Project) handleWorkflowUpdate(ctx context.Context, update configwatcher
 			ProjectIssues: projectRetroStore,
 			ProductIssues: productRetroStore,
 		}); err != nil {
-			p.logger.Warn("apply workflow retro reload failed", "project_id", p.id, "path", update.Path, "error", err)
-			return false
+			return p.workflowReloadError("apply workflow retro reload failed", update.Path, err)
 		}
 	}
 
@@ -1205,7 +1173,12 @@ func (p *Project) handleWorkflowUpdate(ctx context.Context, update configwatcher
 			At:        time.Now(),
 		})
 	}
-	return true
+	return nil
+}
+
+func (p *Project) workflowReloadError(message, path string, err error) error {
+	p.logger.Warn(message, "project_id", p.id, "path", path, "error", err)
+	return fmt.Errorf("%s: %w", message, err)
 }
 
 type releaseCoordinatorBuild struct {

--- a/internal/project/project.go
+++ b/internal/project/project.go
@@ -46,6 +46,9 @@ const (
 	EventStopped          EventKind = "project_stopped"
 	EventUnpaused         EventKind = "project_unpaused"
 	EventWorkflowReloaded EventKind = "project_workflow_reloaded"
+
+	workflowWatcherInitialBackoff = 100 * time.Millisecond
+	workflowWatcherMaxBackoff     = 5 * time.Second
 )
 
 type ID string
@@ -62,6 +65,16 @@ type Event struct {
 type RuntimeError struct {
 	Message string
 	At      time.Time
+}
+
+type WorkflowSourceStatus struct {
+	Path             string
+	Hash             string
+	ModifiedAt       time.Time
+	LoadedAt         time.Time
+	LastWatchEventAt time.Time
+	LastReconcileAt  time.Time
+	WatcherArmed     bool
 }
 
 type Config struct {
@@ -85,49 +98,51 @@ type startOptions struct {
 }
 
 type Dependencies struct {
-	Connector              connector.Connector
-	ConnectorFactory       ConnectorFactory
-	OrchestratorFactory    OrchestratorFactory
-	WorkflowWatcherFactory WorkflowWatcherFactory
-	Runner                 orchestrator.Runner
-	Scheduler              scheduler.Scheduler
-	GlobalDispatchGate     scheduler.ProjectDispatchGate
-	WorkflowMetrics        orchestrator.WorkflowMetricsRecorder
-	Efficiency             efficiency.Recorder
-	LifecycleExporter      efficiency.LifecycleExporter
-	WorkAttempts           store.WorkAttemptStore
-	ProgressSpend          store.ProgressSpendStore
-	AgentResume            store.AgentResumeStore
-	ValidatorMemo          store.ValidatorMemoStore
-	Activity               *activity.Broker
-	Events                 *hub.Hub[Event]
-	Logger                 *slog.Logger
-	GitHubToken            string
-	RefreshGitHubToken     func(context.Context) (string, error)
-	IntakeDependencies     intake.Dependencies
-	RetroStore             store.RetroStore
+	Connector                 connector.Connector
+	ConnectorFactory          ConnectorFactory
+	OrchestratorFactory       OrchestratorFactory
+	WorkflowWatcherFactory    WorkflowWatcherFactory
+	WorkflowReconcileInterval time.Duration
+	Runner                    orchestrator.Runner
+	Scheduler                 scheduler.Scheduler
+	GlobalDispatchGate        scheduler.ProjectDispatchGate
+	WorkflowMetrics           orchestrator.WorkflowMetricsRecorder
+	Efficiency                efficiency.Recorder
+	LifecycleExporter         efficiency.LifecycleExporter
+	WorkAttempts              store.WorkAttemptStore
+	ProgressSpend             store.ProgressSpendStore
+	AgentResume               store.AgentResumeStore
+	ValidatorMemo             store.ValidatorMemoStore
+	Activity                  *activity.Broker
+	Events                    *hub.Hub[Event]
+	Logger                    *slog.Logger
+	GitHubToken               string
+	RefreshGitHubToken        func(context.Context) (string, error)
+	IntakeDependencies        intake.Dependencies
+	RetroStore                store.RetroStore
 }
 
 type Project struct {
-	id               ID
-	cfg              globalconfig.Project
-	workflow         workflowconfig.Workflow
-	githubToken      string
-	connector        connector.Connector
-	connectorFactory ConnectorFactory
-	orchestrator     *orchestrator.Orchestrator
-	orchFactory      OrchestratorFactory
-	orchConfig       orchestrator.Config
-	orchDeps         orchestrator.Dependencies
-	runner           orchestrator.Runner
-	scheduler        scheduler.Scheduler
-	schedulerFactory schedulerFactory
-	intake           *intake.Manager
-	retro            *retro.Manager
-	retroProduct     connector.Connector
-	events           *hub.Hub[Event]
-	logger           *slog.Logger
-	watcher          WorkflowWatcherFactory
+	id                        ID
+	cfg                       globalconfig.Project
+	workflow                  workflowconfig.Workflow
+	githubToken               string
+	connector                 connector.Connector
+	connectorFactory          ConnectorFactory
+	orchestrator              *orchestrator.Orchestrator
+	orchFactory               OrchestratorFactory
+	orchConfig                orchestrator.Config
+	orchDeps                  orchestrator.Dependencies
+	runner                    orchestrator.Runner
+	scheduler                 scheduler.Scheduler
+	schedulerFactory          schedulerFactory
+	intake                    *intake.Manager
+	retro                     *retro.Manager
+	retroProduct              connector.Connector
+	events                    *hub.Hub[Event]
+	logger                    *slog.Logger
+	watcher                   WorkflowWatcherFactory
+	workflowReconcileInterval time.Duration
 
 	mu              sync.Mutex
 	cancel          context.CancelFunc
@@ -137,6 +152,7 @@ type Project struct {
 	started         bool
 	closed          bool
 	lifecycleEvents bool
+	workflowSource  WorkflowSourceStatus
 }
 
 func Load(cfg globalconfig.Project, deps Dependencies) (*Project, error) {
@@ -255,28 +271,37 @@ func New(cfg Config, deps Dependencies) (*Project, error) {
 	watcherProject := cfg.Project
 	watcherProject.ID = string(id)
 	watcherFactory := resolveWorkflowWatcherFactory(deps, watcherProject, deps.GitHubToken, logger)
+	workflowPath := workflowSourceDisplayPath(cfg.Project)
+	workflowModifiedAt := workflowFileModifiedAt(cfg.Project)
 
 	cfg.Project.ID = string(id)
 	return &Project{
-		id:               id,
-		cfg:              cfg.Project,
-		workflow:         workflow,
-		githubToken:      strings.TrimSpace(deps.GitHubToken),
-		connector:        projectConnector,
-		connectorFactory: connectorFactory,
-		orchestrator:     orch,
-		orchFactory:      orchestratorFactory,
-		orchConfig:       orchConfig,
-		orchDeps:         orchDeps,
-		runner:           deps.Runner,
-		scheduler:        projectScheduler,
-		schedulerFactory: schedulerFactory,
-		intake:           projectIntake,
-		retro:            projectRetro,
-		retroProduct:     retroProductConnector,
-		events:           projectEvents,
-		logger:           logger,
-		watcher:          watcherFactory,
+		id:                        id,
+		cfg:                       cfg.Project,
+		workflow:                  workflow,
+		githubToken:               strings.TrimSpace(deps.GitHubToken),
+		connector:                 projectConnector,
+		connectorFactory:          connectorFactory,
+		orchestrator:              orch,
+		orchFactory:               orchestratorFactory,
+		orchConfig:                orchConfig,
+		orchDeps:                  orchDeps,
+		runner:                    deps.Runner,
+		scheduler:                 projectScheduler,
+		schedulerFactory:          schedulerFactory,
+		intake:                    projectIntake,
+		retro:                     projectRetro,
+		retroProduct:              retroProductConnector,
+		events:                    projectEvents,
+		logger:                    logger,
+		watcher:                   watcherFactory,
+		workflowReconcileInterval: deps.WorkflowReconcileInterval,
+		workflowSource: WorkflowSourceStatus{
+			Path:       workflowPath,
+			Hash:       workflow.SourceHash,
+			ModifiedAt: workflowModifiedAt,
+			LoadedAt:   time.Now().UTC(),
+		},
 	}, nil
 }
 
@@ -299,6 +324,13 @@ func (p *Project) Workflow() workflowconfig.Workflow {
 	defer p.mu.Unlock()
 
 	return p.workflow
+}
+
+func (p *Project) WorkflowSourceStatus() WorkflowSourceStatus {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	return p.workflowSource
 }
 
 func (p *Project) EnforcedBudget() (workflowconfig.Budget, bool) {
@@ -495,6 +527,15 @@ func (p *Project) Unpause(ctx context.Context) error {
 	if ctx == nil {
 		ctx = context.Background()
 	}
+
+	p.mu.Lock()
+	if !p.cfg.Paused {
+		p.mu.Unlock()
+		return nil
+	}
+	p.mu.Unlock()
+
+	p.reconcileWorkflow(ctx)
 
 	p.mu.Lock()
 	if !p.cfg.Paused {
@@ -833,25 +874,94 @@ func (p *Project) startWorkflowWatcher(ctx context.Context) <-chan struct{} {
 	go func() {
 		defer close(done)
 
-		watcher, err := p.watcher(path)
-		if err != nil {
-			p.logger.Warn("create workflow watcher failed", "project_id", p.id, "path", path, "error", err)
-			return
+		reconcileTicker := time.NewTicker(p.workflowReconcileCadence())
+		defer reconcileTicker.Stop()
+		retryTimer := time.NewTimer(workflowWatcherInitialBackoff)
+		if !retryTimer.Stop() {
+			<-retryTimer.C
+		}
+		defer retryTimer.Stop()
+
+		var updates <-chan configwatcher.Update
+		var stopWatch context.CancelFunc
+		var retryC <-chan time.Time
+		backoff := workflowWatcherInitialBackoff
+		arm := func() error {
+			watcher, err := p.watcher(path)
+			if err != nil {
+				return fmt.Errorf("create workflow watcher: %w", err)
+			}
+			watchCtx, cancel := context.WithCancel(ctx)
+			watchUpdates, err := watcher.Watch(watchCtx)
+			if err != nil {
+				cancel()
+				return fmt.Errorf("watch workflow: %w", err)
+			}
+			updates = watchUpdates
+			stopWatch = cancel
+			p.setWorkflowWatcherArmed(true)
+			return nil
+		}
+		scheduleRetry := func(err error) {
+			p.setWorkflowWatcherArmed(false)
+			p.logger.Warn("workflow watcher stopped; re-establishing",
+				"project_id", p.id,
+				"path", path,
+				"backoff", backoff,
+				"error", err,
+			)
+			resetProjectTimer(retryTimer, backoff)
+			retryC = retryTimer.C
+			backoff = min(backoff*2, workflowWatcherMaxBackoff)
 		}
 
-		updates, err := watcher.Watch(ctx)
-		if err != nil {
-			p.logger.Warn("watch workflow failed", "project_id", p.id, "path", path, "error", err)
-			return
+		if err := arm(); err != nil {
+			scheduleRetry(err)
 		}
 
 		for {
 			select {
 			case <-ctx.Done():
+				if stopWatch != nil {
+					stopWatch()
+				}
+				p.setWorkflowWatcherArmed(false)
 				return
+			case <-reconcileTicker.C:
+				p.reconcileWorkflow(ctx)
+			case <-retryC:
+				retryC = nil
+				if err := arm(); err != nil {
+					scheduleRetry(err)
+				}
 			case update, ok := <-updates:
 				if !ok {
-					return
+					if ctx.Err() != nil {
+						p.setWorkflowWatcherArmed(false)
+						return
+					}
+					updates = nil
+					if stopWatch != nil {
+						stopWatch()
+						stopWatch = nil
+					}
+					scheduleRetry(errors.New("workflow watcher update channel closed"))
+					continue
+				}
+				p.recordWorkflowWatchEvent(update.At)
+				backoff = workflowWatcherInitialBackoff
+				if update.WatcherErr {
+					if ctx.Err() != nil {
+						p.setWorkflowWatcherArmed(false)
+						return
+					}
+					updates = nil
+					if stopWatch != nil {
+						stopWatch()
+						stopWatch = nil
+					}
+					scheduleRetry(update.Err)
+					continue
 				}
 				p.handleWorkflowUpdate(ctx, update)
 			}
@@ -860,14 +970,79 @@ func (p *Project) startWorkflowWatcher(ctx context.Context) <-chan struct{} {
 	return done
 }
 
-func (p *Project) handleWorkflowUpdate(ctx context.Context, update configwatcher.Update) {
+func resetProjectTimer(timer *time.Timer, delay time.Duration) {
+	if !timer.Stop() {
+		select {
+		case <-timer.C:
+		default:
+		}
+	}
+	timer.Reset(delay)
+}
+
+func (p *Project) workflowReconcileCadence() time.Duration {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	if p.workflowReconcileInterval > 0 {
+		return p.workflowReconcileInterval
+	}
+	interval := time.Duration(p.workflow.Config.Polling.IntervalMS) * time.Millisecond
+	if interval <= 0 {
+		return time.Duration(workflowconfig.DefaultPollingIntervalMS) * time.Millisecond
+	}
+	return interval
+}
+
+func (p *Project) setWorkflowWatcherArmed(armed bool) {
+	p.mu.Lock()
+	p.workflowSource.WatcherArmed = armed
+	p.mu.Unlock()
+}
+
+func (p *Project) recordWorkflowWatchEvent(at time.Time) {
+	if at.IsZero() {
+		at = time.Now()
+	}
+	p.mu.Lock()
+	p.workflowSource.LastWatchEventAt = at.UTC()
+	p.mu.Unlock()
+}
+
+func (p *Project) reconcileWorkflow(ctx context.Context) {
+	p.mu.Lock()
+	projectConfig := p.cfg
+	loadedHash := p.workflowSource.Hash
+	p.mu.Unlock()
+
+	workflow, err := LoadWorkflowContext(ctx, projectConfig)
+	now := time.Now().UTC()
+	p.mu.Lock()
+	p.workflowSource.LastReconcileAt = now
+	p.mu.Unlock()
+	if err != nil {
+		if ctx.Err() == nil {
+			p.logger.Warn("workflow reconcile failed", "project_id", p.id, "path", workflowSourceDisplayPath(projectConfig), "error", err)
+		}
+		return
+	}
+	if workflow.SourceHash == "" || workflow.SourceHash == loadedHash {
+		return
+	}
+
+	path := workflowSourceDisplayPath(projectConfig)
+	p.logger.Warn("workflow reconcile detected stale config", "project_id", p.id, "path", path)
+	p.handleWorkflowUpdate(ctx, configwatcher.Update{Path: path, Workflow: workflow, At: now})
+}
+
+func (p *Project) handleWorkflowUpdate(ctx context.Context, update configwatcher.Update) bool {
 	if update.Err != nil {
 		p.logger.Warn("workflow reload failed",
 			"project_id", p.id,
 			"path", update.Path,
 			"error", update.Err,
 		)
-		return
+		return false
 	}
 
 	p.mu.Lock()
@@ -877,13 +1052,10 @@ func (p *Project) handleWorkflowUpdate(ctx context.Context, update configwatcher
 	schedulerFactory := p.schedulerFactory
 	runner := p.runner
 	projectOrchestrator := p.orchestrator
+	projectRunning := p.done != nil
 	projectIntake := p.intake
 	projectRetro := p.retro
 	p.mu.Unlock()
-	if projectOrchestrator == nil {
-		return
-	}
-
 	workflow := normalizeWorkflow(update.Workflow)
 	workflow.Config = workflowConfigWithProjectIdentity(projectConfig, workflow.Config)
 	workflow.Config = workflowConfigWithGitHubToken(workflow.Config, githubToken)
@@ -893,7 +1065,7 @@ func (p *Project) handleWorkflowUpdate(ctx context.Context, update configwatcher
 			"path", update.Path,
 			"error", err,
 		)
-		return
+		return false
 	}
 
 	projectConnector, err := buildConnector(workflow.Config, connectorFactory)
@@ -903,7 +1075,7 @@ func (p *Project) handleWorkflowUpdate(ctx context.Context, update configwatcher
 			"path", update.Path,
 			"error", err,
 		)
-		return
+		return false
 	}
 
 	projectScheduler, err := buildScheduler(workflow.Config, schedulerFactory)
@@ -913,7 +1085,7 @@ func (p *Project) handleWorkflowUpdate(ctx context.Context, update configwatcher
 			"path", update.Path,
 			"error", err,
 		)
-		return
+		return false
 	}
 	releaseBuild, err := buildReleaseCoordinator(workflow.Config, projectConnector)
 	if err != nil {
@@ -922,7 +1094,7 @@ func (p *Project) handleWorkflowUpdate(ctx context.Context, update configwatcher
 			"path", update.Path,
 			"error", err,
 		)
-		return
+		return false
 	}
 	releaseCoordinator := releaseBuild.coordinator
 
@@ -933,7 +1105,7 @@ func (p *Project) handleWorkflowUpdate(ctx context.Context, update configwatcher
 			"path", update.Path,
 			"error", err,
 		)
-		return
+		return false
 	}
 	retainRetroProduct := false
 	defer func() {
@@ -958,26 +1130,28 @@ func (p *Project) handleWorkflowUpdate(ctx context.Context, update configwatcher
 				"path", update.Path,
 				"error", err,
 			)
-			return
+			return false
 		}
 	}
 
 	runtimeConfig := projectOrchestratorConfig(projectConfig, workflow.Config)
-	if err := projectOrchestrator.UpdateRuntime(ctx, orchestrator.RuntimeUpdate{
-		Config:         runtimeConfig,
-		Connector:      projectConnector,
-		Release:        releaseCoordinator,
-		ReplaceRelease: true,
-	}); err != nil {
-		if ctx.Err() != nil {
-			return
+	if projectOrchestrator != nil && projectRunning {
+		if err := projectOrchestrator.UpdateRuntime(ctx, orchestrator.RuntimeUpdate{
+			Config:         runtimeConfig,
+			Connector:      projectConnector,
+			Release:        releaseCoordinator,
+			ReplaceRelease: true,
+		}); err != nil {
+			if ctx.Err() != nil {
+				return false
+			}
+			p.logger.Warn("apply workflow reload failed",
+				"project_id", p.id,
+				"path", update.Path,
+				"error", err,
+			)
+			return false
 		}
-		p.logger.Warn("apply workflow reload failed",
-			"project_id", p.id,
-			"path", update.Path,
-			"error", err,
-		)
-		return
 	}
 	if updater, ok := runner.(workflowUpdater); ok {
 		updater.UpdateWorkflow(workflow)
@@ -993,13 +1167,20 @@ func (p *Project) handleWorkflowUpdate(ctx context.Context, update configwatcher
 			ProductIssues: productRetroStore,
 		}); err != nil {
 			p.logger.Warn("apply workflow retro reload failed", "project_id", p.id, "path", update.Path, "error", err)
-			return
+			return false
 		}
 	}
 
 	p.mu.Lock()
 	previousRetroProduct := p.retroProduct
 	p.workflow = workflow
+	p.workflowSource.Hash = workflow.SourceHash
+	p.workflowSource.ModifiedAt = workflowFileModifiedAt(projectConfig)
+	if update.At.IsZero() {
+		p.workflowSource.LoadedAt = time.Now().UTC()
+	} else {
+		p.workflowSource.LoadedAt = update.At.UTC()
+	}
 	p.connector = projectConnector
 	p.retroProduct = retroProductConnector
 	retainRetroProduct = true
@@ -1024,6 +1205,7 @@ func (p *Project) handleWorkflowUpdate(ctx context.Context, update configwatcher
 			At:        time.Now(),
 		})
 	}
+	return true
 }
 
 type releaseCoordinatorBuild struct {

--- a/internal/project/project_test.go
+++ b/internal/project/project_test.go
@@ -421,9 +421,7 @@ func TestProjectReestablishesClosedWorkflowWatcher(t *testing.T) {
 	if !bytes.Contains(logs.Bytes(), []byte("workflow watcher stopped")) {
 		t.Fatalf("logs = %q, want watcher failure warning", logs.String())
 	}
-	if !got.WorkflowSourceStatus().WatcherArmed {
-		t.Fatal("WatcherArmed = false after re-establishment")
-	}
+	waitForWorkflowWatcherArmed(t, got)
 
 	reloaded := initial
 	reloaded.Polling.IntervalMS = 60000
@@ -518,6 +516,44 @@ func TestProjectUnpauseReloadsWorkflowEditedWhilePaused(t *testing.T) {
 
 	if got.Workflow().Prompt != "reloaded before unpause\n" {
 		t.Fatalf("Workflow().Prompt = %q, want reloaded workflow", got.Workflow().Prompt)
+	}
+}
+
+func TestProjectUnpauseKeepsProjectPausedWhenWorkflowReloadFails(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	workflowPath := filepath.Join(dir, "WORKFLOW.md")
+	writeProjectGateWorkflow(t, workflowPath, 60000, "", "initial")
+	workflow, err := workflowconfig.LoadWorkflow(workflowPath)
+	if err != nil {
+		t.Fatalf("LoadWorkflow() error = %v", err)
+	}
+
+	got, err := project.New(project.Config{
+		Project:  globalconfig.Project{ID: "detent", Workflow: workflowPath, Weight: 1, Paused: true},
+		Workflow: workflow,
+	}, project.Dependencies{Runner: blockingRunner{}})
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	t.Cleanup(func() {
+		if err := got.Stop(context.Background()); err != nil && !errors.Is(err, project.ErrNotRunning) {
+			t.Fatalf("Stop() error = %v", err)
+		}
+	})
+
+	if err := os.WriteFile(workflowPath, []byte("---\ntracker: [\n---\ninvalid\n"), 0o600); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+	if err := got.Unpause(context.Background()); err == nil {
+		t.Fatal("Unpause() error = nil, want workflow reload failure")
+	}
+	if !got.Paused() {
+		t.Fatal("Paused() = false after failed workflow reload, want true")
+	}
+	if got.Workflow().Prompt != "initial\n" {
+		t.Fatalf("Workflow().Prompt = %q, want original workflow", got.Workflow().Prompt)
 	}
 }
 
@@ -1402,6 +1438,25 @@ func waitForWorkflowWatcher(t *testing.T, ready <-chan struct{}) {
 	case <-ready:
 	case <-time.After(time.Second):
 		t.Fatal("timed out waiting for workflow watcher")
+	}
+}
+
+func waitForWorkflowWatcherArmed(t *testing.T, got *project.Project) {
+	t.Helper()
+
+	ticker := time.NewTicker(10 * time.Millisecond)
+	defer ticker.Stop()
+	deadline := time.After(time.Second)
+
+	for {
+		if got.WorkflowSourceStatus().WatcherArmed {
+			return
+		}
+		select {
+		case <-ticker.C:
+		case <-deadline:
+			t.Fatal("timed out waiting for workflow watcher to become armed")
+		}
 	}
 }
 

--- a/internal/project/project_test.go
+++ b/internal/project/project_test.go
@@ -1,9 +1,11 @@
 package project_test
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
+	"log/slog"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -367,6 +369,156 @@ func TestProjectAppliesWorkflowReloadsToRunningOrchestrator(t *testing.T) {
 	}
 
 	close(runner.release)
+}
+
+func TestProjectReestablishesClosedWorkflowWatcher(t *testing.T) {
+	t.Parallel()
+
+	firstUpdates := make(chan configwatcher.Update)
+	close(firstUpdates)
+	secondUpdates := make(chan configwatcher.Update, 1)
+	rearmed := make(chan struct{})
+	var watcherCreates atomic.Int32
+	var logs bytes.Buffer
+
+	initial := workflowConfig("memory")
+	initial.Polling.IntervalMS = int(time.Hour / time.Millisecond)
+	got, err := project.New(project.Config{
+		Project:  globalconfig.Project{ID: "detent", Workflow: "workflow.md", Weight: 1},
+		Workflow: workflowconfig.Workflow{Config: initial, Prompt: "initial"},
+	}, project.Dependencies{
+		Runner: blockingRunner{},
+		Logger: slog.New(slog.NewTextHandler(&logs, nil)),
+		WorkflowWatcherFactory: func(string) (project.WorkflowWatcher, error) {
+			if watcherCreates.Add(1) == 1 {
+				return fakeWorkflowWatcher{updates: firstUpdates}, nil
+			}
+			select {
+			case <-rearmed:
+			default:
+				close(rearmed)
+			}
+			return fakeWorkflowWatcher{updates: secondUpdates}, nil
+		},
+	})
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	if err := got.Start(context.Background()); err != nil {
+		t.Fatalf("Start() error = %v", err)
+	}
+	t.Cleanup(func() {
+		if err := got.Stop(context.Background()); err != nil && !errors.Is(err, project.ErrNotRunning) {
+			t.Fatalf("Stop() error = %v", err)
+		}
+	})
+
+	select {
+	case <-rearmed:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for workflow watcher re-establishment")
+	}
+	if !bytes.Contains(logs.Bytes(), []byte("workflow watcher stopped")) {
+		t.Fatalf("logs = %q, want watcher failure warning", logs.String())
+	}
+	if !got.WorkflowSourceStatus().WatcherArmed {
+		t.Fatal("WatcherArmed = false after re-establishment")
+	}
+
+	reloaded := initial
+	reloaded.Polling.IntervalMS = 60000
+	secondUpdates <- configwatcher.Update{
+		Workflow: workflowconfig.Workflow{Config: reloaded, Prompt: "reloaded"},
+	}
+	waitForWorkflowPrompt(t, got, "reloaded")
+	if got.WorkflowSourceStatus().LastWatchEventAt.IsZero() {
+		t.Fatal("LastWatchEventAt is zero after re-established watcher update")
+	}
+}
+
+func TestProjectReconcilesWorkflowWhenWatcherMissesEdit(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	workflowPath := filepath.Join(dir, "WORKFLOW.md")
+	writeProjectGateWorkflow(t, workflowPath, 60000, "", "initial")
+	workflow, err := workflowconfig.LoadWorkflow(workflowPath)
+	if err != nil {
+		t.Fatalf("LoadWorkflow() error = %v", err)
+	}
+
+	stalledUpdates := make(chan configwatcher.Update)
+	got, err := project.New(project.Config{
+		Project:  globalconfig.Project{ID: "detent", Workflow: workflowPath, Weight: 1},
+		Workflow: workflow,
+	}, project.Dependencies{
+		Runner:                    blockingRunner{},
+		WorkflowReconcileInterval: 20 * time.Millisecond,
+		WorkflowWatcherFactory: func(string) (project.WorkflowWatcher, error) {
+			return fakeWorkflowWatcher{updates: stalledUpdates}, nil
+		},
+	})
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	if err := got.Start(context.Background()); err != nil {
+		t.Fatalf("Start() error = %v", err)
+	}
+	t.Cleanup(func() {
+		if err := got.Stop(context.Background()); err != nil && !errors.Is(err, project.ErrNotRunning) {
+			t.Fatalf("Stop() error = %v", err)
+		}
+	})
+
+	writeProjectGateWorkflow(t, workflowPath, 60000, "", "reconciled")
+	waitForWorkflowPrompt(t, got, "reconciled\n")
+
+	status := got.WorkflowSourceStatus()
+	if status.LastReconcileAt.IsZero() {
+		t.Fatal("LastReconcileAt is zero, want periodic reconciliation timestamp")
+	}
+	if status.Hash == "" || status.Hash != got.Workflow().SourceHash {
+		t.Fatalf("workflow source hash = %q, workflow hash = %q", status.Hash, got.Workflow().SourceHash)
+	}
+}
+
+func TestProjectUnpauseReloadsWorkflowEditedWhilePaused(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	workflowPath := filepath.Join(dir, "WORKFLOW.md")
+	writeProjectGateWorkflow(t, workflowPath, 60000, "", "initial")
+	workflow, err := workflowconfig.LoadWorkflow(workflowPath)
+	if err != nil {
+		t.Fatalf("LoadWorkflow() error = %v", err)
+	}
+
+	got, err := project.New(project.Config{
+		Project:  globalconfig.Project{ID: "detent", Workflow: workflowPath, Weight: 1, Paused: true},
+		Workflow: workflow,
+	}, project.Dependencies{
+		Runner: blockingRunner{},
+		WorkflowWatcherFactory: func(string) (project.WorkflowWatcher, error) {
+			return fakeWorkflowWatcher{updates: make(chan configwatcher.Update)}, nil
+		},
+	})
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+
+	writeProjectGateWorkflow(t, workflowPath, 60000, "", "reloaded before unpause")
+	if err := got.Unpause(context.Background()); err != nil {
+		t.Fatalf("Unpause() error = %v", err)
+	}
+	t.Cleanup(func() {
+		if err := got.Stop(context.Background()); err != nil && !errors.Is(err, project.ErrNotRunning) {
+			t.Fatalf("Stop() error = %v", err)
+		}
+	})
+
+	if got.Workflow().Prompt != "reloaded before unpause\n" {
+		t.Fatalf("Workflow().Prompt = %q, want reloaded workflow", got.Workflow().Prompt)
+	}
 }
 
 func TestProjectWorkflowReloadRefreshesRestartDependencies(t *testing.T) {

--- a/internal/project/workflow_source.go
+++ b/internal/project/workflow_source.go
@@ -58,6 +58,36 @@ func LoadWorkflowContext(ctx context.Context, cfg globalconfig.Project) (workflo
 	return workflow, err
 }
 
+func workflowSourceDisplayPath(cfg globalconfig.Project) string {
+	if strings.TrimSpace(cfg.WorkflowRef) == "" {
+		path, err := plainWorkflowPath(cfg.Workflow)
+		if err != nil {
+			return strings.TrimSpace(cfg.Workflow)
+		}
+		return path
+	}
+	source, err := newWorkflowGitRefSource(cfg)
+	if err != nil {
+		return strings.TrimSpace(cfg.Workflow)
+	}
+	return source.displayPath()
+}
+
+func workflowFileModifiedAt(cfg globalconfig.Project) time.Time {
+	if strings.TrimSpace(cfg.WorkflowRef) != "" {
+		return time.Time{}
+	}
+	path, err := plainWorkflowPath(cfg.Workflow)
+	if err != nil {
+		return time.Time{}
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		return time.Time{}
+	}
+	return info.ModTime().UTC()
+}
+
 func newWorkflowGitRefSource(cfg globalconfig.Project) (workflowGitRefSource, error) {
 	sourceRoot := strings.TrimSpace(cfg.Workdir)
 	if sourceRoot == "" {

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -848,7 +848,31 @@ func (s *Server) health(c echo.Context) error {
 		Update:            updateStatus,
 		Checks:            checks,
 		Budgets:           s.enforcedBudgets(),
+		Workflows:         s.workflowSources(),
 	})
+}
+
+func (s *Server) workflowSources() []healthWorkflowSource {
+	if s.registry == nil {
+		return nil
+	}
+
+	projects := s.registry.List()
+	sources := make([]healthWorkflowSource, 0, len(projects))
+	for _, trackedProject := range projects {
+		status := trackedProject.WorkflowSourceStatus()
+		sources = append(sources, healthWorkflowSource{
+			ProjectID:        string(trackedProject.ID()),
+			Path:             status.Path,
+			SourceHash:       status.Hash,
+			ModifiedAt:       status.ModifiedAt,
+			LoadedAt:         status.LoadedAt,
+			LastWatchEventAt: status.LastWatchEventAt,
+			LastReconcileAt:  status.LastReconcileAt,
+			WatcherArmed:     status.WatcherArmed,
+		})
+	}
+	return sources
 }
 
 func (s *Server) enforcedBudgets() []healthBudget {
@@ -1029,13 +1053,25 @@ func (s *Server) connectorName() string {
 }
 
 type healthResponse struct {
-	Status            string            `json:"status"`
-	Mode              string            `json:"mode"`
-	Connector         string            `json:"connector"`
-	SessionsRemaining int               `json:"sessions_remaining,omitempty"`
-	Update            telemetry.Update  `json:"update,omitzero"`
-	Checks            map[string]string `json:"checks"`
-	Budgets           []healthBudget    `json:"budgets,omitempty"`
+	Status            string                 `json:"status"`
+	Mode              string                 `json:"mode"`
+	Connector         string                 `json:"connector"`
+	SessionsRemaining int                    `json:"sessions_remaining,omitempty"`
+	Update            telemetry.Update       `json:"update,omitzero"`
+	Checks            map[string]string      `json:"checks"`
+	Budgets           []healthBudget         `json:"budgets,omitempty"`
+	Workflows         []healthWorkflowSource `json:"workflows,omitempty"`
+}
+
+type healthWorkflowSource struct {
+	ProjectID        string    `json:"project_id"`
+	Path             string    `json:"path"`
+	SourceHash       string    `json:"source_hash"`
+	ModifiedAt       time.Time `json:"modified_at,omitzero"`
+	LoadedAt         time.Time `json:"loaded_at,omitzero"`
+	LastWatchEventAt time.Time `json:"last_watch_event_at,omitzero"`
+	LastReconcileAt  time.Time `json:"last_reconcile_at,omitzero"`
+	WatcherArmed     bool      `json:"watcher_armed"`
 }
 
 type healthBudget struct {

--- a/internal/web/server_test.go
+++ b/internal/web/server_test.go
@@ -6498,8 +6498,9 @@ func TestHealthReportsEnforcedProjectBudgets(t *testing.T) {
 	trackedProject, err := project.New(project.Config{
 		Project: globalconfig.Project{ID: "detent"},
 		Workflow: workflowconfig.Workflow{
-			Config: workflowCfg,
-			Prompt: "Work the issue.",
+			Config:     workflowCfg,
+			Prompt:     "Work the issue.",
+			SourceHash: "loaded-workflow-hash",
 		},
 	}, project.Dependencies{
 		Connector: connectorProbe{name: "memory"},
@@ -6533,6 +6534,8 @@ func TestHealthReportsEnforcedProjectBudgets(t *testing.T) {
 		`"enabled":true`,
 		`"per_day_max_usd":250`,
 		`"per_issue_max_usd":25`,
+		`"source_hash":"loaded-workflow-hash"`,
+		`"watcher_armed":false`,
 	} {
 		if !strings.Contains(rec.Body.String(), want) {
 			t.Fatalf("body missing %q:\n%s", want, rec.Body.String())


### PR DESCRIPTION
## Summary

- re-establish failed or closed WORKFLOW.md watchers with WARN logging and exponential backoff
- reconcile on-disk workflow hashes at the project polling cadence and before unpausing
- expose workflow source liveness through health and fail doctor checks on live stale-config drift
- document paused-project reload behavior

Fixes #1283

## UI Surface Contract

- [x] N/A, or the linked issue explicitly authorizes any high-impact UI surface, layout, density, first-viewport, or responsive visibility tradeoff.
- [x] Persistent top-of-screen messaging is explicitly authorized by the issue, or this PR does not add it.
- [x] Visual changes to primary operator screens include screenshot or browser verification below. N/A: no visual changes.

## Test Plan

- [x] `go test -race ./internal/config/... ./internal/project/... -count=1`
- [x] `go test -race ./internal/cli ./internal/web -count=1`
- [x] `make check`