### PR TITLE
feat(budget): add subscription billing mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -2423,14 +2423,23 @@ by input tokens. Use that value with context pressure to evaluate whether
 thread-resume behavior is preserving useful context without repeatedly filling
 the window.
 
+`budget.billing_mode` accepts `metered` or `subscription`. Metered mode
+enforces configured USD caps and the spend-progress breaker. Subscription mode
+keeps notional spend telemetry but never refuses dispatch or parks work based
+on USD; Detent instead scales dispatch concurrency with the lowest reported
+primary or secondary provider rate-window percentage. An omitted mode preserves
+legacy metered enforcement when `budget.enabled=true`, and `detent doctor` warns
+until the mode is declared.
+
 `agent.no_progress_spend_limit_usd` defaults to `3`, below the default
 per-issue budget backstop. Detent sums persisted session cost for each issue
 after its latest accepted lane, pull-request, or
-recognized PR-signature change. When spend exceeds the limit, Detent parks the
-issue in `Blocked`, recommends narrowing or splitting the task, and requires
-the next worker to explain the missing progress signal in its first Workpad
-update before using tools. Set the value to `0` to disable the breaker and its
-history/spend lookups.
+recognized PR-signature change. In metered mode, when spend exceeds the limit,
+Detent parks the issue in `Blocked`, recommends narrowing or splitting the task,
+and requires the next worker to explain the missing progress signal in its first
+Workpad update before using tools. Set the value to `0` to disable the breaker
+and its history/spend lookups. In subscription mode, the same calculation is
+advisory telemetry and never parks the issue.
 
 `agent.failure_breaker` pauses new project dispatches when the same failure
 class reaches `same_class_limit` attempts inside `window_seconds`. The default

--- a/docs/templates/WORKFLOW.github_local.md
+++ b/docs/templates/WORKFLOW.github_local.md
@@ -163,6 +163,7 @@ server:
     # as one compact top-of-board alert; dependency waits stay on cards.
     # show_blocked_alerts: true
 budget:
+  billing_mode: metered
   enabled: true
   per_day_max_usd: 50
   per_issue_max_usd: 5

--- a/docs/templates/WORKFLOW.issue_field.md
+++ b/docs/templates/WORKFLOW.issue_field.md
@@ -170,6 +170,7 @@ server:
     #   Rework: [Blocked, Cancelled]
     #   Merging: [Blocked, Cancelled]
 budget:
+  billing_mode: metered
   enabled: true
   per_day_max_usd: 50
   per_issue_max_usd: 5

--- a/docs/templates/WORKFLOW.label.md
+++ b/docs/templates/WORKFLOW.label.md
@@ -170,6 +170,7 @@ server:
     #   Rework: [Blocked, Cancelled]
     #   Merging: [Blocked, Cancelled]
 budget:
+  billing_mode: metered
   enabled: true
   per_day_max_usd: 50
   per_issue_max_usd: 5

--- a/docs/templates/WORKFLOW.non_code_artifact.md
+++ b/docs/templates/WORKFLOW.non_code_artifact.md
@@ -143,6 +143,7 @@ server:
       Done: []
       Cancelled: []
 budget:
+  billing_mode: metered
   enabled: true
   per_day_max_usd: 50
   per_issue_max_usd: 5

--- a/docs/templates/WORKFLOW.project_v2.md
+++ b/docs/templates/WORKFLOW.project_v2.md
@@ -169,6 +169,7 @@ server:
     #   Rework: [Blocked, Cancelled]
     #   Merging: [Blocked, Cancelled]
 budget:
+  billing_mode: metered
   enabled: true
   per_day_max_usd: 50
   per_issue_max_usd: 5

--- a/internal/budget/budget.go
+++ b/internal/budget/budget.go
@@ -23,6 +23,7 @@ var ErrMissingSpendStore = errors.New("budget spend store is required")
 
 type Config struct {
 	ProjectID       string
+	BillingMode     string
 	Enabled         bool
 	PerDayMaxUSD    float64
 	PerIssueMaxUSD  float64
@@ -133,7 +134,7 @@ func (c *Checker) EnforcedConfig() Config {
 }
 
 func (c *Checker) CheckDispatch(ctx context.Context, req DispatchRequest) (Decision, error) {
-	if !c.cfg.Enabled {
+	if !c.usdEnforcementEnabled() {
 		return Decision{Allowed: true}, nil
 	}
 
@@ -193,7 +194,7 @@ func (c *Checker) CheckDispatch(ctx context.Context, req DispatchRequest) (Decis
 }
 
 func (c *Checker) DailyStatus(ctx context.Context, now time.Time) (DailyStatus, error) {
-	if !c.cfg.Enabled || !capActive(c.cfg.PerDayMaxUSD) {
+	if !c.usdEnforcementEnabled() || !capActive(c.cfg.PerDayMaxUSD) {
 		return DailyStatus{}, nil
 	}
 	if missingSpendStore(c.spend) {
@@ -217,7 +218,7 @@ func (c *Checker) DailyStatus(ctx context.Context, now time.Time) (DailyStatus, 
 }
 
 func (c *Checker) IssueStatus(ctx context.Context, identity store.IssueIdentity) (IssueStatus, error) {
-	if !c.cfg.Enabled || !capActive(c.cfg.PerIssueMaxUSD) {
+	if !c.usdEnforcementEnabled() || !capActive(c.cfg.PerIssueMaxUSD) {
 		return IssueStatus{}, nil
 	}
 	if !issueIdentityPresent(identity) {
@@ -236,6 +237,10 @@ func (c *Checker) IssueStatus(ctx context.Context, identity store.IssueIdentity)
 		CurrentSpendUSD: SpendUSD(issueSpend, c.pricing),
 		MaxUSD:          c.cfg.PerIssueMaxUSD,
 	}, nil
+}
+
+func (c *Checker) usdEnforcementEnabled() bool {
+	return c.cfg.Enabled && strings.ToLower(strings.TrimSpace(c.cfg.BillingMode)) != "subscription"
 }
 
 func SpendUSD(spend store.TokenSpend, pricing PricingTable) float64 {

--- a/internal/budget/budget_test.go
+++ b/internal/budget/budget_test.go
@@ -42,6 +42,28 @@ func TestCheckerCheckDispatch(t *testing.T) {
 			wantAllow: true,
 		},
 		{
+			name: "subscription daily cap is advisory without spend lookup",
+			cfg: Config{
+				BillingMode:  "subscription",
+				Enabled:      true,
+				PerDayMaxUSD: 0.01,
+			},
+			spend:     &fakeSpendStore{},
+			req:       DispatchRequest{Model: "gpt-test", Now: now, Estimate: TokenEstimate{InputTokens: 10}},
+			wantAllow: true,
+		},
+		{
+			name: "subscription per issue cap is advisory without spend lookup",
+			cfg: Config{
+				BillingMode:    "subscription",
+				Enabled:        true,
+				PerIssueMaxUSD: 0.01,
+			},
+			spend:     &fakeSpendStore{},
+			req:       DispatchRequest{IssueID: "issue-subscription", Model: "gpt-test", Now: now, Estimate: TokenEstimate{InputTokens: 10}},
+			wantAllow: true,
+		},
+		{
 			name: "unknown model uses fallback pricing",
 			cfg: Config{
 				Enabled:      true,
@@ -55,6 +77,7 @@ func TestCheckerCheckDispatch(t *testing.T) {
 		{
 			name: "daily cap refuses when projection exceeds limit",
 			cfg: Config{
+				BillingMode:     "metered",
 				Enabled:         true,
 				PerDayMaxUSD:    1.0,
 				RefusalCooldown: time.Minute,
@@ -81,6 +104,7 @@ func TestCheckerCheckDispatch(t *testing.T) {
 		{
 			name: "per issue cap refuses only matching issue spend",
 			cfg: Config{
+				BillingMode:    "metered",
 				Enabled:        true,
 				PerIssueMaxUSD: 0.5,
 			},
@@ -262,6 +286,11 @@ func TestCheckerDailyStatus(t *testing.T) {
 			spend: &fakeSpendStore{},
 		},
 		{
+			name:  "subscription daily cap is inactive",
+			cfg:   Config{BillingMode: "subscription", Enabled: true, PerDayMaxUSD: 2.5},
+			spend: &fakeSpendStore{},
+		},
+		{
 			name: "active cap reports live spend",
 			cfg:  Config{Enabled: true, PerDayMaxUSD: 2.5},
 			spend: &fakeSpendStore{daily: store.TokenSpend{
@@ -368,6 +397,11 @@ func TestCheckerIssueStatus(t *testing.T) {
 		{
 			name:  "disabled cap reports inactive",
 			cfg:   Config{Enabled: true},
+			spend: &fakeSpendStore{},
+		},
+		{
+			name:  "subscription cap reports inactive",
+			cfg:   Config{BillingMode: "subscription", Enabled: true, PerIssueMaxUSD: 2},
 			spend: &fakeSpendStore{},
 		},
 		{

--- a/internal/cli/doctor_project.go
+++ b/internal/cli/doctor_project.go
@@ -149,6 +149,9 @@ func checkDoctorProjectWithProgress(
 		}
 	}
 	checks := []doctorCheck{workflowCheck}
+	if billingCheck, ok := checkDoctorBillingMode(id, workflow.Config); ok {
+		checks = append(checks, billingCheck)
+	}
 	if budgetCheck, ok := checkDoctorDisabledBudgetCaps(id, workflow.Config.Budget); ok {
 		checks = append(checks, budgetCheck)
 	}
@@ -236,6 +239,41 @@ func checkDoctorProjectWithProgress(
 		checks = append(checks, checkDoctorGitHubReadiness(ctx, id, project, workflow.Config, deps, githubToken, expandedSourceRoot, allowWriteProbes)...)
 	}
 	return checks
+}
+
+func checkDoctorBillingMode(id string, cfg workflowconfig.Config) (doctorCheck, bool) {
+	mode := cfg.Budget.EffectiveBillingMode()
+	if !cfg.Budget.BillingModeConfigured() {
+		if !cfg.Budget.Enabled {
+			return doctorCheck{}, false
+		}
+		return doctorCheck{
+			Name:   "Project " + id + " billing mode",
+			Status: doctorWarn,
+			Detail: "budget.billing_mode is undeclared; metered billing and USD enforcement are assumed for compatibility",
+			Hint:   "Declare budget.billing_mode: metered or budget.billing_mode: subscription in WORKFLOW.md.",
+		}, true
+	}
+	if mode != workflowconfig.BillingModeSubscription {
+		return doctorCheck{}, false
+	}
+
+	controls := make([]string, 0, 2)
+	if cfg.Budget.Enabled {
+		controls = append(controls, "budget.enabled=true")
+	}
+	if cfg.Agent.NoProgressSpendLimitUSD > 0 {
+		controls = append(controls, fmt.Sprintf("agent.no_progress_spend_limit_usd=%g", cfg.Agent.NoProgressSpendLimitUSD))
+	}
+	if len(controls) == 0 {
+		return doctorCheck{}, false
+	}
+	return doctorCheck{
+		Name:   "Project " + id + " billing mode",
+		Status: doctorWarn,
+		Detail: "billing_mode=subscription makes USD enforcement advisory; Detent will not refuse or park work from: " + strings.Join(controls, ", "),
+		Hint:   "Use provider rate-window pacing and token or outcome-based brakes for subscription auth; set billing_mode=metered only for marginal API billing.",
+	}, true
 }
 
 func checkDoctorDisabledBudgetCaps(id string, cfg workflowconfig.Budget) (doctorCheck, bool) {
@@ -832,11 +870,20 @@ func doctorWorkflowDetail(path string, project globalconfig.Project, cfg workflo
 	details = append(details, doctorReviewFlowConfigDetail(cfg))
 	details = append(details, doctorWorkflowModelChoiceDetail(cfg))
 	details = append(details, doctorWorkflowSessionGuardDetail(cfg))
+	details = append(details, doctorWorkflowBillingModeDetail(cfg.Budget))
 	details = append(details, doctorWorkflowSpendBreakerDetail(cfg))
 	details = append(details, fmt.Sprintf("orphan-recovery=resume_orphaned_sessions=%t, experimental_thread_resume=%t", cfg.Agent.ResumeOrphanedSessions, cfg.Agent.ExperimentalThreadResume))
 	details = append(details, fmt.Sprintf("prioritize-unblockers=%t", cfg.Agent.PrioritizeUnblockers))
 	details = append(details, doctorAuthorizationDetail(project, cfg))
 	return strings.Join(details, "; ")
+}
+
+func doctorWorkflowBillingModeDetail(cfg workflowconfig.Budget) string {
+	detail := "billing-mode=" + cfg.EffectiveBillingMode()
+	if !cfg.BillingModeConfigured() {
+		detail += " (assumed)"
+	}
+	return detail
 }
 
 func doctorWorkflowModelChoiceDetail(cfg workflowconfig.Config) string {

--- a/internal/cli/doctor_project.go
+++ b/internal/cli/doctor_project.go
@@ -244,7 +244,7 @@ func checkDoctorProjectWithProgress(
 func checkDoctorBillingMode(id string, cfg workflowconfig.Config) (doctorCheck, bool) {
 	mode := cfg.Budget.EffectiveBillingMode()
 	if !cfg.Budget.BillingModeConfigured() {
-		if !cfg.Budget.Enabled {
+		if !cfg.Budget.Enabled && cfg.Agent.NoProgressSpendLimitUSD <= 0 {
 			return doctorCheck{}, false
 		}
 		return doctorCheck{

--- a/internal/cli/doctor_test.go
+++ b/internal/cli/doctor_test.go
@@ -835,17 +835,17 @@ func TestCheckDoctorProjects(t *testing.T) {
 				{ID: "alpha", Workflow: "WORKFLOW.md"},
 			},
 			workflow:   workflowconfig.Workflow{Config: disabledBudgetWorkflow},
-			wantStatus: []doctorStatus{doctorOK, doctorWarn, doctorOK, doctorOK, doctorOK, doctorWarn, doctorOK},
-			wantDetail: []string{"is valid", "budget.enabled=false disables configured caps", "enabled=true provides prompt guidance", "validated 0 pinned Codex route model(s)", "is a git worktree", "contain no detent-agent guidance", "loaded=0; dropped=0"},
+			wantStatus: []doctorStatus{doctorOK, doctorWarn, doctorWarn, doctorOK, doctorOK, doctorOK, doctorWarn, doctorOK},
+			wantDetail: []string{"is valid", "metered billing and USD enforcement are assumed", "budget.enabled=false disables configured caps", "enabled=true provides prompt guidance", "validated 0 pinned Codex route model(s)", "is a git worktree", "contain no detent-agent guidance", "loaded=0; dropped=0"},
 		},
 		{
-			name: "inherited budget caps do not warn",
+			name: "inherited spend breaker warns about billing ambiguity",
 			projects: []globalconfig.Project{
 				{ID: "alpha", Workflow: "WORKFLOW.md"},
 			},
 			workflow:   workflowconfig.Workflow{Config: omittedBudgetWorkflow},
-			wantStatus: []doctorStatus{doctorOK, doctorOK, doctorOK, doctorOK, doctorWarn, doctorOK},
-			wantDetail: []string{"is valid", "enabled=true provides prompt guidance", "validated 0 pinned Codex route model(s)", "is a git worktree", "contain no detent-agent guidance", "loaded=0; dropped=0"},
+			wantStatus: []doctorStatus{doctorOK, doctorWarn, doctorOK, doctorOK, doctorOK, doctorWarn, doctorOK},
+			wantDetail: []string{"is valid", "metered billing and USD enforcement are assumed", "enabled=true provides prompt guidance", "validated 0 pinned Codex route model(s)", "is a git worktree", "contain no detent-agent guidance", "loaded=0; dropped=0"},
 		},
 		{
 			name: "source repo missing",
@@ -963,6 +963,15 @@ func TestCheckDoctorBillingMode(t *testing.T) {
 			budget:     workflowconfig.Budget{Enabled: true},
 			wantOK:     true,
 			wantDetail: "metered billing and USD enforcement are assumed",
+		},
+		{
+			name:       "legacy spend breaker warns about assumed metered mode",
+			spendLimit: 3,
+			wantOK:     true,
+			wantDetail: "metered billing and USD enforcement are assumed",
+		},
+		{
+			name: "undeclared mode without USD controls does not warn",
 		},
 		{
 			name:   "declared metered mode does not warn",

--- a/internal/cli/doctor_test.go
+++ b/internal/cli/doctor_test.go
@@ -948,6 +948,63 @@ func TestCheckDoctorDisabledBudgetCaps(t *testing.T) {
 	}
 }
 
+func TestCheckDoctorBillingMode(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		budget     workflowconfig.Budget
+		spendLimit float64
+		wantOK     bool
+		wantDetail string
+	}{
+		{
+			name:       "legacy enabled budget warns about assumed metered mode",
+			budget:     workflowconfig.Budget{Enabled: true},
+			wantOK:     true,
+			wantDetail: "metered billing and USD enforcement are assumed",
+		},
+		{
+			name:   "declared metered mode does not warn",
+			budget: workflowconfig.Budget{BillingMode: workflowconfig.BillingModeMetered, Enabled: true},
+		},
+		{
+			name:       "subscription budget cap warns that enforcement is advisory",
+			budget:     workflowconfig.Budget{BillingMode: workflowconfig.BillingModeSubscription, Enabled: true},
+			wantOK:     true,
+			wantDetail: "budget.enabled=true",
+		},
+		{
+			name:       "subscription spend breaker warns that enforcement is advisory",
+			budget:     workflowconfig.Budget{BillingMode: workflowconfig.BillingModeSubscription},
+			spendLimit: 3,
+			wantOK:     true,
+			wantDetail: "agent.no_progress_spend_limit_usd=3",
+		},
+		{
+			name:   "subscription without USD controls does not warn",
+			budget: workflowconfig.Budget{BillingMode: workflowconfig.BillingModeSubscription},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, ok := checkDoctorBillingMode("detent", workflowconfig.Config{
+				Budget: tt.budget,
+				Agent:  workflowconfig.Agent{NoProgressSpendLimitUSD: tt.spendLimit},
+			})
+			if ok != tt.wantOK {
+				t.Fatalf("checkDoctorBillingMode() ok = %t, want %t: %#v", ok, tt.wantOK, got)
+			}
+			if tt.wantOK && (got.Status != doctorWarn || !strings.Contains(got.Detail, tt.wantDetail)) {
+				t.Fatalf("checkDoctorBillingMode() = %#v, want warning containing %q", got, tt.wantDetail)
+			}
+		})
+	}
+}
+
 func TestCheckDoctorIssueEffortGuidance(t *testing.T) {
 	t.Parallel()
 
@@ -2268,6 +2325,7 @@ func TestDoctorWorkflowDetailSurfacesIdentityAndAuthorization(t *testing.T) {
 		"identity release-captain",
 		"worker-model=provider-default",
 		"session-guard=max_session_tokens=disabled, max_session_context_multiplier=disabled",
+		"billing-mode=metered",
 		"orphan-recovery=resume_orphaned_sessions=true, experimental_thread_resume=false",
 		"prioritize-unblockers=true",
 		"authorization selectors from global.yaml and WORKFLOW.md",
@@ -4366,6 +4424,7 @@ func validDoctorWorkflow(sourceRoot string) workflowconfig.Config {
 	cfg := workflowconfig.Default()
 	cfg.Tracker.Kind = workflowconfig.TrackerMemory
 	cfg.Workspace.Root = sourceRoot
+	cfg.Budget.BillingMode = workflowconfig.BillingModeMetered
 	cfg.Budget.Enabled = true
 	return cfg
 }

--- a/internal/cli/onboarding_workflow_builder.go
+++ b/internal/cli/onboarding_workflow_builder.go
@@ -542,6 +542,7 @@ func applyOnboardingWorkflowDecisions(
 	decisions.set(root, "plan.enabled", false, "preset", "direct implementation dispatch by default")
 	decisions.set(root, "plan.review", "human", "preset", "human plan approval if plan mode is enabled later")
 	decisions.set(root, "server.kanban.mode", kanbanMode, kanbanProvenance, kanbanWhy)
+	decisions.set(root, "budget.billing_mode", workflowconfig.BillingModeMetered, "preset", "enforce USD guardrails for metered API billing")
 	decisions.set(root, "budget.enabled", true, "preset", "enable spend guardrails at onboarding")
 	decisions.set(root, "budget.per_day_max_usd", dayBudget, dayBudgetProvenance, dayBudgetWhy)
 	decisions.set(root, "budget.per_issue_max_usd", issueBudget, issueBudgetProvenance, issueBudgetWhy)

--- a/internal/cli/onboarding_workflow_builder_test.go
+++ b/internal/cli/onboarding_workflow_builder_test.go
@@ -561,7 +561,7 @@ func TestBuildOnboardingWorkflowGeneratesParseablePausedProject(t *testing.T) {
 	if workflow.Config.Gate.Run != "make check" {
 		t.Fatalf("Gate.Run = %q, want make check", workflow.Config.Gate.Run)
 	}
-	if !workflow.Config.Budget.Enabled || workflow.Config.Budget.PerDayMaxUSD != 50 || workflow.Config.Budget.PerIssueMaxUSD != 5 {
+	if workflow.Config.Budget.BillingMode != workflowconfig.BillingModeMetered || !workflow.Config.Budget.Enabled || workflow.Config.Budget.PerDayMaxUSD != 50 || workflow.Config.Budget.PerIssueMaxUSD != 5 {
 		t.Fatalf("Budget = %#v, want enabled 50/day 5/issue", workflow.Config.Budget)
 	}
 	if workflow.Config.Gate.Validator.Model != "" {

--- a/internal/cli/runner.go
+++ b/internal/cli/runner.go
@@ -136,20 +136,24 @@ func buildBudgetDispatchGuards(
 	if !cfg.Enabled {
 		return nil, nil, nil
 	}
-
-	spendStore, ok := sessionStore.(budget.SpendStore)
-	if !ok {
-		return nil, nil, budget.ErrMissingSpendStore
-	}
-
-	checker := budget.NewChecker(budget.Config{
+	checkerConfig := budget.Config{
 		ProjectID:       projectID,
+		BillingMode:     cfg.EffectiveBillingMode(),
 		Enabled:         cfg.Enabled,
 		PerDayMaxUSD:    cfg.PerDayMaxUSD,
 		PerIssueMaxUSD:  cfg.PerIssueMaxUSD,
 		RefusalCooldown: time.Duration(cfg.RefusalCooldownSeconds) * time.Second,
 		PricingPath:     cfg.PricingPath,
-	}, spendStore, pricing)
+	}
+	if cfg.EffectiveBillingMode() == workflowconfig.BillingModeSubscription {
+		return budget.NewChecker(checkerConfig, nil, pricing), nil, nil
+	}
+
+	spendStore, ok := sessionStore.(budget.SpendStore)
+	if !ok {
+		return nil, nil, budget.ErrMissingSpendStore
+	}
+	checker := budget.NewChecker(checkerConfig, spendStore, pricing)
 
 	estimateStore, ok := sessionStore.(budget.DispatchEstimateStore)
 	if !ok {

--- a/internal/cli/runner_test.go
+++ b/internal/cli/runner_test.go
@@ -249,7 +249,7 @@ func TestBuildBudgetDispatchGuards(t *testing.T) {
 
 	subscription := enabled
 	subscription.BillingMode = workflowconfig.BillingModeSubscription
-	checker, estimator, err = buildBudgetDispatchGuards(subscription, &runnerSessionStore{}, nil)
+	checker, estimator, err = buildBudgetDispatchGuards("alpha", subscription, &runnerSessionStore{}, nil)
 	if err != nil {
 		t.Fatalf("buildBudgetDispatchGuards(subscription) error = %v", err)
 	}

--- a/internal/cli/runner_test.go
+++ b/internal/cli/runner_test.go
@@ -247,6 +247,20 @@ func TestBuildBudgetDispatchGuards(t *testing.T) {
 		t.Fatalf("buildBudgetDispatchGuards(missing spend store) error = %v, want ErrMissingSpendStore", err)
 	}
 
+	subscription := enabled
+	subscription.BillingMode = workflowconfig.BillingModeSubscription
+	checker, estimator, err = buildBudgetDispatchGuards(subscription, &runnerSessionStore{}, nil)
+	if err != nil {
+		t.Fatalf("buildBudgetDispatchGuards(subscription) error = %v", err)
+	}
+	if checker == nil || estimator != nil {
+		t.Fatalf("subscription guards = %T/%T, want advisory checker and nil estimator", checker, estimator)
+	}
+	decision, err := checker.CheckDispatch(t.Context(), budget.DispatchRequest{Model: "gpt-5", Estimate: budget.TokenEstimate{TotalTokens: 1_000_000}})
+	if err != nil || !decision.Allowed || decision.Refusal != nil {
+		t.Fatalf("subscription decision = %#v, error = %v, want allowed", decision, err)
+	}
+
 	ctx := context.Background()
 	storeBackend, err := store.Open(ctx, store.Config{
 		Backend: store.BackendSQLite,

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -35,11 +35,13 @@ const (
 	WorkspaceLocalGit   = "local_git"
 	WorkspaceFilesystem = "filesystem"
 
-	DeliverablePullRequest = "pull_request"
-	DeliverableArtifact    = "artifact"
-	MergeMethodSquash      = "squash"
-	MergeMethodMerge       = "merge"
-	MergeMethodRebase      = "rebase"
+	DeliverablePullRequest  = "pull_request"
+	DeliverableArtifact     = "artifact"
+	MergeMethodSquash       = "squash"
+	MergeMethodMerge        = "merge"
+	MergeMethodRebase       = "rebase"
+	BillingModeMetered      = "metered"
+	BillingModeSubscription = "subscription"
 
 	DependencyReadinessTerminal         = "terminal"
 	DependencyReadinessTerminalOrMerged = "terminal_or_merged"
@@ -407,6 +409,7 @@ type Followups struct {
 }
 
 type Budget struct {
+	BillingMode            string  `yaml:"billing_mode,omitempty"`
 	Enabled                bool    `yaml:"enabled"`
 	PerDayMaxUSD           float64 `yaml:"per_day_max_usd"`
 	PerIssueMaxUSD         float64 `yaml:"per_issue_max_usd"`
@@ -415,6 +418,28 @@ type Budget struct {
 
 	perDayMaxUSDConfigured   bool
 	perIssueMaxUSDConfigured bool
+}
+
+func (b Budget) EffectiveBillingMode() string {
+	if strings.EqualFold(strings.TrimSpace(b.BillingMode), BillingModeSubscription) {
+		return BillingModeSubscription
+	}
+	return BillingModeMetered
+}
+
+func (b Budget) BillingModeConfigured() bool {
+	return strings.TrimSpace(b.BillingMode) != ""
+}
+
+func (b Budget) USDEnforcementEnabled() bool {
+	return b.Enabled && b.EffectiveBillingMode() == BillingModeMetered
+}
+
+func (b *Budget) Normalize() {
+	if b == nil {
+		return
+	}
+	b.BillingMode = strings.ToLower(strings.TrimSpace(b.BillingMode))
 }
 
 func (b Budget) PerDayMaxUSDConfigured() bool {
@@ -1257,6 +1282,8 @@ func (c *Config) normalize() {
 	c.Workspace.Normalize()
 	c.Deliverable.Normalize()
 	c.Release.normalize()
+	c.Budget.Normalize()
+	c.Agent.Budget.Normalize()
 
 	c.Agent.MaxConcurrentAgentsByState = normalizeStateLimits(c.Agent.MaxConcurrentAgentsByState)
 	if c.Agent.FailureBreaker.SameClassLimit == 0 {
@@ -1960,6 +1987,11 @@ func (s *SkillCreation) validate(prefix string, problems *[]string) {
 }
 
 func (b *Budget) validate(prefix string, problems *[]string) {
+	switch b.BillingMode {
+	case "", BillingModeMetered, BillingModeSubscription:
+	default:
+		*problems = append(*problems, prefix+".billing_mode must be one of metered, subscription")
+	}
 	validatePositiveFloat(prefix+".per_day_max_usd", b.PerDayMaxUSD, problems)
 	validatePositiveFloat(prefix+".per_issue_max_usd", b.PerIssueMaxUSD, problems)
 	if b.RefusalCooldownSeconds < 0 {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -45,6 +45,9 @@ func TestShippedWorkflowTemplatesEnableBudgetCaps(t *testing.T) {
 			if !workflow.Config.Budget.Enabled {
 				t.Fatalf("%s budget.enabled = false, want true", path)
 			}
+			if workflow.Config.Budget.BillingMode != BillingModeMetered {
+				t.Fatalf("%s budget.billing_mode = %q, want metered", path, workflow.Config.Budget.BillingMode)
+			}
 			normalizedRaw := strings.ReplaceAll(string(raw), "\r\n", "\n")
 			if workflow.Config.Deliverable.Kind == DeliverablePullRequest && !strings.Contains(normalizedRaw, "\n  merge_method: squash\n") {
 				t.Fatalf("%s does not declare deliverable.merge_method: squash", path)
@@ -89,6 +92,54 @@ func TestParseWorkflowBudgetCapPresence(t *testing.T) {
 			}
 			if got := workflow.Config.Budget.PerIssueMaxUSDConfigured(); got != tt.wantPerIssue {
 				t.Fatalf("PerIssueMaxUSDConfigured() = %t, want %t", got, tt.wantPerIssue)
+			}
+		})
+	}
+}
+
+func TestParseWorkflowBillingMode(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		value      string
+		want       string
+		configured bool
+		wantErr    string
+	}{
+		{name: "omitted assumes metered", want: BillingModeMetered},
+		{name: "metered", value: "metered", want: BillingModeMetered, configured: true},
+		{name: "subscription", value: "subscription", want: BillingModeSubscription, configured: true},
+		{name: "normalizes case and whitespace", value: " Subscription ", want: BillingModeSubscription, configured: true},
+		{name: "rejects invalid mode", value: "credits", wantErr: "budget.billing_mode must be one of metered, subscription"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			frontmatter := "---\ntracker:\n  kind: memory\n"
+			if tt.value != "" {
+				frontmatter += "budget:\n  billing_mode: \"" + tt.value + "\"\n"
+			}
+			workflow, err := ParseWorkflow([]byte(frontmatter + "---\n"))
+			if err == nil {
+				err = workflow.Config.Validate()
+			}
+			if tt.wantErr != "" {
+				if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
+					t.Fatalf("ParseWorkflow() error = %v, want containing %q", err, tt.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("ParseWorkflow() error = %v", err)
+			}
+			if got := workflow.Config.Budget.EffectiveBillingMode(); got != tt.want {
+				t.Fatalf("EffectiveBillingMode() = %q, want %q", got, tt.want)
+			}
+			if got := workflow.Config.Budget.BillingModeConfigured(); got != tt.configured {
+				t.Fatalf("BillingModeConfigured() = %t, want %t", got, tt.configured)
 			}
 		})
 	}

--- a/internal/orchestrator/config.go
+++ b/internal/orchestrator/config.go
@@ -30,6 +30,7 @@ func ConfigFromWorkflow(cfg workflowconfig.Config) Config {
 		MaxRetryBackoff:            durationFromMillis(cfg.Agent.MaxRetryBackoffMS),
 		OverloadRetryDelay:         durationFromMillis(cfg.Agent.OverloadRetryDelayMS),
 		NoProgressSpendLimitUSD:    cfg.Agent.NoProgressSpendLimitUSD,
+		BillingMode:                cfg.Budget.EffectiveBillingMode(),
 		FailureBreaker: FailureBreakerConfig{
 			SameClassLimit: cfg.Agent.FailureBreaker.SameClassLimit,
 			Window:         durationFromSeconds(cfg.Agent.FailureBreaker.WindowSeconds),
@@ -98,6 +99,10 @@ func ConfigFromWorkflow(cfg workflowconfig.Config) Config {
 }
 
 func normalizeConfig(cfg Config) Config {
+	cfg.BillingMode = strings.ToLower(strings.TrimSpace(cfg.BillingMode))
+	if cfg.BillingMode == "" {
+		cfg.BillingMode = workflowconfig.BillingModeMetered
+	}
 	if cfg.PollInterval <= 0 {
 		cfg.PollInterval = defaultPollInterval
 	}
@@ -179,6 +184,10 @@ func normalizeConfig(cfg Config) Config {
 	}
 
 	return cfg
+}
+
+func (cfg Config) subscriptionBilling() bool {
+	return cfg.BillingMode == workflowconfig.BillingModeSubscription
 }
 
 func normalizeClaimingConfig(cfg ClaimingConfig) ClaimingConfig {

--- a/internal/orchestrator/dependency_autounblock.go
+++ b/internal/orchestrator/dependency_autounblock.go
@@ -197,7 +197,7 @@ func (o *Orchestrator) blockerAutoPromoteCapacity(state *State, targetState stri
 	if state == nil {
 		return 0
 	}
-	available := availableSlots(state)
+	available := o.dispatchPlanner().availableSlots(state)
 	stats := o.projectStateSlotStats(connector.Issue{State: targetState}, state)
 	if stats.available < available {
 		available = stats.available

--- a/internal/orchestrator/dispatch.go
+++ b/internal/orchestrator/dispatch.go
@@ -203,7 +203,7 @@ func (o *Orchestrator) dispatchCandidates(ctx context.Context, state *State, iss
 		return
 	}
 	for _, issue := range issues {
-		if availableSlots(state) == 0 {
+		if o.dispatchPlanner().availableSlots(state) == 0 {
 			return
 		}
 		issue, ok := o.hydrateDispatchIssue(ctx, issue)

--- a/internal/orchestrator/dispatch_planner.go
+++ b/internal/orchestrator/dispatch_planner.go
@@ -11,6 +11,7 @@ import (
 	"github.com/digitaldrywood/detent/internal/gate"
 	"github.com/digitaldrywood/detent/internal/runtimeoutput"
 	"github.com/digitaldrywood/detent/internal/selector"
+	"github.com/digitaldrywood/detent/internal/telemetry"
 )
 
 type dispatchPlanner struct {
@@ -106,12 +107,16 @@ func (p dispatchPlanner) plan(
 			}
 			continue
 		}
-		if availableSlots(state) == 0 {
+		if p.availableSlots(state) == 0 {
+			reason := dispatchSkipGlobalCapacityFull
+			if p.rateWindowBackpressureActive(state) {
+				reason = dispatchSkipRateWindowBackpressure
+			}
 			for skipIndex := index; skipIndex < len(plannedCandidates); skipIndex++ {
 				p.logDecision(hooks, dispatchPlanDecision{
 					Issue:         plannedCandidates[skipIndex],
 					QueuePosition: skipIndex + 1,
-					SkipReason:    dispatchSkipGlobalCapacityFull,
+					SkipReason:    reason,
 				})
 			}
 			break
@@ -333,6 +338,10 @@ func (p dispatchPlanner) pruneBudgetRefusals(
 	dailyStatus *DailyBudgetStatus,
 	issueStatuses map[string]IssueBudgetStatus,
 ) {
+	if p.cfg.subscriptionBilling() {
+		clear(state.BudgetRefusals)
+		return
+	}
 	for issueID, refusal := range state.BudgetRefusals {
 		var issueStatus *IssueBudgetStatus
 		if status, ok := issueStatuses[issueID]; ok {
@@ -360,6 +369,9 @@ func (p dispatchPlanner) pruneInactiveIssueBudgetRefusals(state *State, candidat
 }
 
 func (p dispatchPlanner) budgetCooldownActive(state *State, issueID string, now time.Time) bool {
+	if p.cfg.subscriptionBilling() {
+		return false
+	}
 	refusal, ok := state.BudgetRefusals[issueID]
 	if !ok {
 		return false
@@ -493,6 +505,7 @@ const (
 	dispatchSkipDispatchBackoffCancelled = "dispatch_backoff_cancelled"
 	dispatchSkipGitHubRESTCapacity       = "github_rest_capacity_paused"
 	dispatchSkipProjectFailureBreaker    = projectFailureBreakerDispatchPaused
+	dispatchSkipRateWindowBackpressure   = "provider_rate_window_backpressure"
 )
 
 func (p dispatchPlanner) dispatchableIssueDecision(
@@ -612,9 +625,42 @@ func (p dispatchPlanner) authorized(issue connector.Issue) bool {
 }
 
 func (p dispatchPlanner) slotsAvailable(issue connector.Issue, state *State, preferredWorkerHost string) bool {
-	return availableSlots(state) > 0 &&
+	return p.availableSlots(state) > 0 &&
 		p.stateSlotsAvailable(issue, state) &&
 		p.workerSlotsAvailable(state, preferredWorkerHost)
+}
+
+func (p dispatchPlanner) availableSlots(state *State) int {
+	limit := state.MaxConcurrentAgents
+	if p.cfg.subscriptionBilling() {
+		if remaining, ok := providerRateWindowRemainingPercent(state); ok {
+			limit = int(math.Ceil(float64(limit) * remaining / 100))
+			limit = max(1, limit)
+		}
+	}
+	available := limit - len(state.Running)
+	return max(0, available)
+}
+
+func (p dispatchPlanner) rateWindowBackpressureActive(state *State) bool {
+	return p.cfg.subscriptionBilling() && availableSlots(state) > 0 && p.availableSlots(state) == 0
+}
+
+func providerRateWindowRemainingPercent(state *State) (float64, bool) {
+	if state == nil || state.RateLimits == nil {
+		return 0, false
+	}
+	remaining := 100.0
+	seen := false
+	for _, bucket := range []*telemetry.RateLimitBucket{state.RateLimits.Primary, state.RateLimits.Secondary} {
+		if bucket == nil || bucket.Limit <= 0 {
+			continue
+		}
+		percent := float64(bucket.Remaining) / float64(bucket.Limit) * 100
+		remaining = min(remaining, max(0, min(100, percent)))
+		seen = true
+	}
+	return remaining, seen
 }
 
 func (p dispatchPlanner) stateSlotsAvailable(issue connector.Issue, state *State) bool {

--- a/internal/orchestrator/dispatch_test.go
+++ b/internal/orchestrator/dispatch_test.go
@@ -3,6 +3,7 @@ package orchestrator
 import (
 	"context"
 	"errors"
+	"fmt"
 	"log/slog"
 	"slices"
 	"strings"
@@ -96,6 +97,7 @@ func TestConfigFromWorkflowIncludesDispatchControls(t *testing.T) {
 	cfg.Workspace.CleanupIdleTTLMS = 7200000
 	cfg.Workspace.CleanupSweepIntervalMS = 120000
 	cfg.Budget.RefusalCooldownSeconds = 45
+	cfg.Budget.BillingMode = workflowconfig.BillingModeSubscription
 	cfg.Agent.AutoPromote.Enabled = true
 	cfg.Agent.AutoPromote.QuietSeconds = 30
 	cfg.Agent.AutoPromote.OptoutLabel = " Requires-Human-Review "
@@ -131,6 +133,9 @@ func TestConfigFromWorkflowIncludesDispatchControls(t *testing.T) {
 	}
 	if got.BudgetRefusalCooldown != 45*time.Second {
 		t.Fatalf("BudgetRefusalCooldown = %s, want 45s", got.BudgetRefusalCooldown)
+	}
+	if got.BillingMode != workflowconfig.BillingModeSubscription {
+		t.Fatalf("BillingMode = %q, want subscription", got.BillingMode)
 	}
 	if got.WorkspaceCleanupIdleTTL != 2*time.Hour {
 		t.Fatalf("WorkspaceCleanupIdleTTL = %s, want 2h0m0s", got.WorkspaceCleanupIdleTTL)
@@ -202,6 +207,67 @@ func TestConfigFromWorkflowIncludesDispatchControls(t *testing.T) {
 	}
 	if got.AutoPromote.Gate.Kind != gate.KindHumanReview || got.AutoPromote.Gate.ApprovalLabel != "approved-by-human" {
 		t.Fatalf("AutoPromote.Gate = %#v, want human_review approved-by-human", got.AutoPromote.Gate)
+	}
+}
+
+func TestPlanDispatchSubscriptionRateWindowBackpressure(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		billingMode string
+		limits      *telemetry.RateLimits
+		want        int
+	}{
+		{name: "metered ignores provider window", billingMode: workflowconfig.BillingModeMetered, limits: providerRateLimits(20, 100), want: 10},
+		{name: "subscription scales to primary remaining", billingMode: workflowconfig.BillingModeSubscription, limits: providerRateLimits(50, 100), want: 5},
+		{name: "subscription uses lower secondary remaining", billingMode: workflowconfig.BillingModeSubscription, limits: &telemetry.RateLimits{Primary: &telemetry.RateLimitBucket{Remaining: 80, Limit: 100}, Secondary: &telemetry.RateLimitBucket{Remaining: 30, Limit: 100}}, want: 3},
+		{name: "subscription preserves one soft slot at exhaustion", billingMode: workflowconfig.BillingModeSubscription, limits: providerRateLimits(0, 100), want: 1},
+		{name: "subscription without snapshot uses configured capacity", billingMode: workflowconfig.BillingModeSubscription, want: 10},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			cfg := normalizeConfig(Config{
+				BillingMode:         tt.billingMode,
+				MaxConcurrentAgents: 10,
+				ActiveStates:        []string{"Todo"},
+				TerminalStates:      []string{"Done"},
+			})
+			state := newState(cfg)
+			state.RateLimits = tt.limits
+			issues := make([]connector.Issue, 10)
+			for index := range issues {
+				issues[index] = dispatchTestIssue(fmt.Sprintf("issue-%02d", index), "Todo")
+			}
+
+			plan := PlanDispatch(cfg, state, issues, time.Date(2026, 7, 12, 12, 0, 0, 0, time.UTC))
+			if got := len(plan.Dispatches); got != tt.want {
+				t.Fatalf("dispatches = %d, want %d", got, tt.want)
+			}
+		})
+	}
+}
+
+func providerRateLimits(remaining, limit int64) *telemetry.RateLimits {
+	return &telemetry.RateLimits{Primary: &telemetry.RateLimitBucket{Remaining: remaining, Limit: limit}}
+}
+
+func TestSubscriptionPrunesLegacyUSDBudgetRefusals(t *testing.T) {
+	t.Parallel()
+
+	cfg := normalizeConfig(Config{BillingMode: workflowconfig.BillingModeSubscription})
+	planner := newDispatchPlanner(cfg)
+	state := newState(cfg)
+	state.BudgetRefusals["daily"] = BudgetRefusal{Code: string(budget.ReasonPerDayMaxUSD)}
+	state.BudgetRefusals["issue"] = BudgetRefusal{Code: string(budget.ReasonPerIssueMaxUSD)}
+
+	planner.pruneBudgetRefusals(&state, time.Now(), nil, nil)
+
+	if len(state.BudgetRefusals) != 0 {
+		t.Fatalf("BudgetRefusals = %#v, want cleared in subscription mode", state.BudgetRefusals)
 	}
 }
 

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -74,6 +74,7 @@ type Config struct {
 	MaxRetryBackoff               time.Duration
 	OverloadRetryDelay            time.Duration
 	NoProgressSpendLimitUSD       float64
+	BillingMode                   string
 	FailureBreaker                FailureBreakerConfig
 	Project                       scheduler.ProjectCandidate
 	Claiming                      ClaimingConfig

--- a/internal/orchestrator/run_completion.go
+++ b/internal/orchestrator/run_completion.go
@@ -307,7 +307,7 @@ func (o *Orchestrator) handleRunResult(ctx context.Context, state *State, event 
 	if diffStatsPresent(event.Result.DiffStats) {
 		state.DiffStats[event.IssueID] = event.Result.DiffStats
 	}
-	if event.Result.BudgetRefusal != nil {
+	if event.Result.BudgetRefusal != nil && !o.cfg.subscriptionBilling() {
 		refusal := *event.Result.BudgetRefusal
 		refusal.Issue = cloneIssue(running.Issue)
 		state.BudgetRefusals[event.IssueID] = refusal
@@ -331,7 +331,7 @@ func (o *Orchestrator) handleRunResult(ctx context.Context, state *State, event 
 			return
 		}
 	}
-	if event.Result.BudgetRefusal != nil && event.Result.BudgetRefusal.Code == string(budget.ReasonPerIssueMaxUSD) {
+	if event.Result.BudgetRefusal != nil && !o.cfg.subscriptionBilling() && event.Result.BudgetRefusal.Code == string(budget.ReasonPerIssueMaxUSD) {
 		if err := o.abandonClaim(ctx, event.IssueID); err != nil && o.logger != nil {
 			o.logger.Warn("per-issue budget hold claim release failed", "issue_id", event.IssueID, "error", err)
 		}

--- a/internal/orchestrator/spend_progress.go
+++ b/internal/orchestrator/spend_progress.go
@@ -92,7 +92,7 @@ func (o *Orchestrator) evaluateSpendProgress(
 		return decision
 	}
 	decision.Spend = spend
-	decision.Block = spend.CostUSD > decision.LimitUSD
+	decision.Block = !o.cfg.subscriptionBilling() && spend.CostUSD > decision.LimitUSD
 	return decision
 }
 
@@ -323,7 +323,7 @@ func spendProgressRetryHandoff(decision spendProgressDecision) runpkg.PriorAttem
 }
 
 func (o *Orchestrator) spendProgressPriorAttempt(ctx context.Context, issue connector.Issue) (runpkg.PriorAttempt, bool) {
-	if o == nil || o.cfg.NoProgressSpendLimitUSD <= 0 || o.workAttempts == nil {
+	if o == nil || o.cfg.subscriptionBilling() || o.cfg.NoProgressSpendLimitUSD <= 0 || o.workAttempts == nil {
 		return runpkg.PriorAttempt{}, false
 	}
 	attempts, err := o.workAttempts.ListRecentTerminalWorkAttempts(ctx, store.WorkAttemptHistoryQuery{

--- a/internal/orchestrator/spend_progress_test.go
+++ b/internal/orchestrator/spend_progress_test.go
@@ -35,6 +35,7 @@ func TestEvaluateSpendProgress(t *testing.T) {
 
 	tests := []struct {
 		name             string
+		billingMode      string
 		limit            float64
 		spend            store.IssueSpendSince
 		history          []store.WorkAttempt
@@ -49,7 +50,8 @@ func TestEvaluateSpendProgress(t *testing.T) {
 		{name: "normal three retry sessions stay below default", limit: 3, spend: store.IssueSpendSince{CostUSD: 2.7, Sessions: 3}, wantSpendCalls: 1, wantHistoryCalls: 1, wantSince: createdAt},
 		{name: "below threshold", limit: 5, spend: store.IssueSpendSince{CostUSD: 4.99, Sessions: 3}, wantSpendCalls: 1, wantHistoryCalls: 1, wantSince: createdAt},
 		{name: "at threshold", limit: 5, spend: store.IssueSpendSince{CostUSD: 5, Sessions: 4}, wantSpendCalls: 1, wantHistoryCalls: 1, wantSince: createdAt},
-		{name: "above threshold", limit: 5, spend: store.IssueSpendSince{CostUSD: 5.01, Sessions: 4}, wantBlock: true, wantSpendCalls: 1, wantHistoryCalls: 1, wantSince: createdAt},
+		{name: "metered blocks above threshold", billingMode: "metered", limit: 5, spend: store.IssueSpendSince{CostUSD: 5.01, Sessions: 4}, wantBlock: true, wantSpendCalls: 1, wantHistoryCalls: 1, wantSince: createdAt},
+		{name: "subscription keeps above-threshold spend advisory", billingMode: "subscription", limit: 5, spend: store.IssueSpendSince{CostUSD: 5.01, Sessions: 4}, wantSpendCalls: 1, wantHistoryCalls: 1, wantSince: createdAt},
 		{name: "July telemetry replay", limit: 5, spend: store.IssueSpendSince{CostUSD: 6.75, Sessions: 5}, wantBlock: true, wantSpendCalls: 1, wantHistoryCalls: 1, wantSince: createdAt},
 		{name: "old sessions reset after accepted change", limit: 5, spend: store.IssueSpendSince{CostUSD: 1.25, Sessions: 1}, history: []store.WorkAttempt{acceptedAttempt}, wantSpendCalls: 1, wantHistoryCalls: 1, wantSince: acceptedAt},
 		{name: "current accepted change resets without spend lookup", limit: 5, spend: store.IssueSpendSince{CostUSD: 100}, accepted: true, acceptedReason: "signature_changed", wantSpendCalls: 0, wantHistoryCalls: 0, wantSince: base},
@@ -64,6 +66,7 @@ func TestEvaluateSpendProgress(t *testing.T) {
 			orch := &Orchestrator{
 				cfg: Config{
 					Project:                 scheduler.ProjectCandidate{ID: "detent"},
+					BillingMode:             tt.billingMode,
 					NoProgressSpendLimitUSD: tt.limit,
 				},
 				progressSpend: spend,

--- a/internal/runner/agent.go
+++ b/internal/runner/agent.go
@@ -300,6 +300,7 @@ func enforcedBudgetConfig(requested config.Budget, checker BudgetChecker) (confi
 	}
 	enforced := reporter.EnforcedConfig()
 	return config.Budget{
+		BillingMode:            enforced.BillingMode,
 		Enabled:                enforced.Enabled,
 		PerDayMaxUSD:           enforced.PerDayMaxUSD,
 		PerIssueMaxUSD:         enforced.PerIssueMaxUSD,
@@ -850,18 +851,20 @@ func (r *Runner) Run(ctx context.Context, req RunRequest) (RunResult, error) {
 	if effort != "" {
 		runtimeIdentity.ReasoningEffort = agentidentity.NewValue(effort, agentidentity.ProvenanceConfigured)
 	}
-	if result, refused, err := r.checkDispatchBudget(ctx, budgetChecker, dispatchEstimator, req.Issue, sessionModel, startedAt); err != nil {
-		return RunResult{}, err
-	} else if refused {
-		r.logWorkerEvent(req.Issue, "worker_budget_refused",
-			"workspace_path", info.Path,
-			"backend_id", selection.BackendID,
-			"route", selection.RouteName,
-			"role", role,
-			"model", sessionModel,
-			"code", result.BudgetRefusal.Code,
-		)
-		return result, nil
+	if workflow.Config.Budget.EffectiveBillingMode() != config.BillingModeSubscription {
+		if result, refused, err := r.checkDispatchBudget(ctx, budgetChecker, dispatchEstimator, req.Issue, sessionModel, startedAt); err != nil {
+			return RunResult{}, err
+		} else if refused {
+			r.logWorkerEvent(req.Issue, "worker_budget_refused",
+				"workspace_path", info.Path,
+				"backend_id", selection.BackendID,
+				"route", selection.RouteName,
+				"role", role,
+				"model", sessionModel,
+				"code", result.BudgetRefusal.Code,
+			)
+			return result, nil
+		}
 	}
 	resumeState, err := r.runRequestResumeState(ctx, workflow.Config.Agent, req, sessionModel, selection.BackendID, backendConfig.Kind, role)
 	if err != nil {

--- a/internal/runner/runner_test.go
+++ b/internal/runner/runner_test.go
@@ -728,6 +728,44 @@ func TestRunnerRunLogsBudgetRefusalWithDerivedRole(t *testing.T) {
 	}
 }
 
+func TestRunnerSubscriptionSkipsUSDBudgetGuards(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 7, 12, 12, 0, 0, 0, time.UTC)
+	workflowCfg := config.Default()
+	workflowCfg.Budget.BillingMode = config.BillingModeSubscription
+	workflowCfg.Budget.Enabled = true
+	checker := &fakeBudgetChecker{refusal: budget.Refusal{Code: budget.ReasonPerDayMaxUSD}}
+	estimator := &fakeDispatchEstimator{err: errors.New("estimator must not run")}
+	backend := &fakeCodexClient{}
+	runner, err := NewRunner(Dependencies{
+		Workflow: config.Workflow{Config: workflowCfg, Prompt: "work {{ issue.identifier }}"},
+		Workspace: &fakeWorkspaceBackend{
+			info: workspace.Info{Path: t.TempDir(), Key: "issue-subscription", Branch: "detent/issue-subscription"},
+		},
+		AgentBackend:      backend,
+		BudgetChecker:     checker,
+		DispatchEstimator: estimator,
+		Now:               newFakeClock(now).Now,
+	})
+	if err != nil {
+		t.Fatalf("NewRunner() error = %v", err)
+	}
+
+	result, err := runner.Run(t.Context(), RunRequest{
+		Issue: connector.Issue{ID: "issue-subscription", Identifier: "digitaldrywood/detent#1282", State: "Todo"},
+	})
+	if err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+	if result.BudgetRefusal != nil || checker.calls != 0 || estimator.model != "" {
+		t.Fatalf("result = %#v, checker calls = %d, estimator model = %q; want no USD guard execution", result, checker.calls, estimator.model)
+	}
+	if backend.calls != 1 {
+		t.Fatalf("backend calls = %d, want dispatched agent turn", backend.calls)
+	}
+}
+
 func TestRunnerRunLeavesThreadResumeDisabledByDefault(t *testing.T) {
 	t.Parallel()
 

--- a/internal/web/server_test.go
+++ b/internal/web/server_test.go
@@ -7543,7 +7543,7 @@ func TestServerEventsEnrichesSnapshotOncePerPublish(t *testing.T) {
 	var budgetCalls atomic.Int64
 
 	registry := project.NewRegistry()
-	if err := registry.Set(newBudgetTestProject(t, "detent", 100, 10)); err != nil {
+	if err := registry.Set(newBudgetTestProject(t, "detent", 100, 10, workflowconfig.BillingModeSubscription)); err != nil {
 		t.Fatalf("Registry.Set() error = %v", err)
 	}
 
@@ -8563,7 +8563,7 @@ func TestServerEnrichesBudgetBurnDownFromStoreAndRegistry(t *testing.T) {
 	}
 
 	registry := project.NewRegistry()
-	if err := registry.Set(newBudgetTestProject(t, "detent", 100, 10)); err != nil {
+	if err := registry.Set(newBudgetTestProject(t, "detent", 100, 10, workflowconfig.BillingModeSubscription)); err != nil {
 		t.Fatalf("Registry.Set() error = %v", err)
 	}
 
@@ -10061,7 +10061,7 @@ func newSettingsTestProject(t *testing.T, cfg globalconfig.Project, worktreeRoot
 	return trackedProject
 }
 
-func newBudgetTestProject(t *testing.T, id string, perDayMaxUSD float64, perIssueMaxUSD float64) *project.Project {
+func newBudgetTestProject(t *testing.T, id string, perDayMaxUSD float64, perIssueMaxUSD float64, billingModes ...string) *project.Project {
 	t.Helper()
 
 	workflowCfg := workflowconfig.Default()
@@ -10070,6 +10070,9 @@ func newBudgetTestProject(t *testing.T, id string, perDayMaxUSD float64, perIssu
 	workflowCfg.Tracker.APIKey = "$GITHUB_TOKEN"
 	workflowCfg.Tracker.ProjectSlug = "https://github.com/orgs/digitaldrywood/projects/4"
 	workflowCfg.Budget.Enabled = true
+	if len(billingModes) > 0 {
+		workflowCfg.Budget.BillingMode = billingModes[0]
+	}
 	workflowCfg.Budget.PerDayMaxUSD = perDayMaxUSD
 	workflowCfg.Budget.PerIssueMaxUSD = perIssueMaxUSD
 

--- a/internal/web/templates/dashboard_data.go
+++ b/internal/web/templates/dashboard_data.go
@@ -6214,24 +6214,30 @@ func rateLimitRows(limits *telemetry.RateLimits) []rateLimitRow {
 	}
 
 	rows := make([]rateLimitRow, 0, 4)
-	appendBucket := func(name string, bucket *telemetry.RateLimitBucket) {
+	appendBucket := func(name string, bucket *telemetry.RateLimitBucket, providerWindow bool) {
 		if bucket == nil {
 			return
 		}
-		rows = append(rows, rateLimitRow{
+		row := rateLimitRow{
 			Name:        name,
 			Remaining:   rateLimitRemainingLabel(bucket),
 			Used:        rateLimitUsedLabel(bucket),
 			Limit:       rateLimitLimitLabel(bucket),
 			Reset:       resetLabel(bucket),
 			UsedPercent: usedPercent(bucket),
-		})
+		}
+		if providerWindow {
+			row.Remaining = formatInt(int64(100-row.UsedPercent)) + "% left"
+			row.Used = formatInt(int64(row.UsedPercent)) + "% used"
+			row.Limit = "rolling window"
+		}
+		rows = append(rows, row)
 	}
 
-	appendBucket("Primary", limits.Primary)
-	appendBucket("Secondary", limits.Secondary)
-	appendBucket("GitHub GraphQL", limits.GitHubGraphQL)
-	appendBucket("GitHub REST", limits.GitHubREST)
+	appendBucket("Primary", limits.Primary, true)
+	appendBucket("Secondary", limits.Secondary, true)
+	appendBucket("GitHub GraphQL", limits.GitHubGraphQL, false)
+	appendBucket("GitHub REST", limits.GitHubREST, false)
 	if limits.Credits != nil {
 		rows = append(rows, creditRateLimitRow(limits.Credits))
 	}

--- a/internal/web/templates/dashboard_data_test.go
+++ b/internal/web/templates/dashboard_data_test.go
@@ -515,6 +515,24 @@ func TestGraphQLUnknownStatusFormatsBudgetLabels(t *testing.T) {
 	}
 }
 
+func TestProviderRateLimitRowsShowRemainingPercentages(t *testing.T) {
+	t.Parallel()
+
+	rows := rateLimitRows(&telemetry.RateLimits{
+		Primary:   &telemetry.RateLimitBucket{Remaining: 72, Used: 28, Limit: 100},
+		Secondary: &telemetry.RateLimitBucket{Remaining: 41, Used: 59, Limit: 100},
+	})
+	if len(rows) != 2 {
+		t.Fatalf("rateLimitRows() len = %d, want 2: %#v", len(rows), rows)
+	}
+	if rows[0].Remaining != "72% left" || rows[0].Used != "28% used" || rows[0].Limit != "rolling window" {
+		t.Fatalf("primary row = %#v, want percentage labels", rows[0])
+	}
+	if rows[1].Remaining != "41% left" || rows[1].Used != "59% used" || rows[1].Limit != "rolling window" {
+		t.Fatalf("secondary row = %#v, want percentage labels", rows[1])
+	}
+}
+
 func TestThroughputTrendPoints(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

- add explicit `budget.billing_mode: metered | subscription` with legacy metered fallback and doctor diagnostics
- keep notional spend telemetry while bypassing daily, per-issue, and spend-progress USD enforcement for subscription auth
- pace subscription dispatch concurrency against the lowest primary/secondary provider window and show those windows as remaining percentages
- declare metered mode in shipped workflow templates and onboarding output

Fixes #1282

## UI Surface Contract

- [x] The linked issue explicitly authorizes surfacing primary/secondary rate-window percentages on the dashboard.
- [x] This PR adds no persistent top-of-screen messaging.
- [x] Deterministic browser captures completed for `project-active-overview`, `diagnostics-healthy`, and `fleet-healthy-parallel-work` at DPR 1; visual inspection found no layout regression. `TestProviderRateLimitRowsShowRemainingPercentages` asserts the exact rendered percentage labels.

## Test Plan

- [x] `make check`
- [x] `go test ./internal/orchestrator -run '^$' -fuzz=. -fuzztime=30s`
- [x] `tmp/detent dev-runtime capture --scenario diagnostics-healthy --device-scale-factor 1 --width 1440 --height 1100`
- [x] `tmp/detent dev-runtime capture --scenario fleet-healthy-parallel-work --device-scale-factor 1 --width 1440 --height 2000`