### PR TITLE
feat(doctor): reconcile repository merge policy

### DIFF
--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -150,6 +150,7 @@ type doctorDeps struct {
 	httpDo               func(*http.Request) (*http.Response, error)
 	githubScopes         func(context.Context, string) ([]string, error)
 	githubReadiness      doctorGitHubReadinessFunc
+	githubMergeSettings  func(context.Context, workflowconfig.Config, string) (ghconnector.RepositoryMergeSettings, error)
 	ghAuthToken          func(context.Context) (string, error)
 	listen               func(string, string) (net.Listener, error)
 	openSQLite           func(context.Context, string) (doctorStore, error)
@@ -892,6 +893,9 @@ func (d doctorDeps) withDefaults() doctorDeps {
 	if d.githubReadiness == nil {
 		d.githubReadiness = defaults.githubReadiness
 	}
+	if d.githubMergeSettings == nil {
+		d.githubMergeSettings = defaults.githubMergeSettings
+	}
 	if d.ghAuthToken == nil {
 		d.ghAuthToken = defaults.ghAuthToken
 	}
@@ -942,6 +946,7 @@ func defaultDoctorDeps() doctorDeps {
 		httpDo:               defaultDoctorHTTPDo,
 		githubScopes:         defaultGitHubScopes,
 		githubReadiness:      ghconnector.CheckReadiness,
+		githubMergeSettings:  defaultDoctorGitHubMergeSettings,
 		ghAuthToken:          defaultGHAuthToken,
 		listen:               net.Listen,
 		openSQLite:           openDoctorSQLite,

--- a/internal/cli/doctor_merge_policy.go
+++ b/internal/cli/doctor_merge_policy.go
@@ -69,11 +69,16 @@ func checkDoctorRepositoryMergePolicy(ctx context.Context, id string, project gl
 func doctorRepositoryMergePolicyWarning(repository string, deliverable workflowconfig.Deliverable, settings ghconnector.RepositoryMergeSettings) (string, string, *doctorWorkflowOptimizationPatch) {
 	settingsDetail := doctorRepositoryMergeSettingsDetail(settings)
 	if !deliverable.MergeMethodConfigured() {
-		if doctorRepositoryEnabledMergeMethodCount(settings) <= 1 {
+		enabledCount := doctorRepositoryEnabledMergeMethodCount(settings)
+		if enabledCount == 1 && settings.AllowSquashMerge {
 			return "", "", nil
 		}
-		patch := doctorWorkflowOptimizationPatch{Path: "deliverable.merge_method", Value: workflowconfig.MergeMethodSquash}
-		return fmt.Sprintf("%s ambiguous merge policy: repo settings %s allow multiple methods and WORKFLOW.md declares none; agent-side auto-detection can produce mixed history", repository, settingsDetail), "add `merge_method: squash` under `deliverable:` in WORKFLOW.md", &patch
+		if enabledCount <= 1 {
+			return fmt.Sprintf("%s effective default merge_method=squash is forbidden by repo settings %s and WORKFLOW.md declares none", repository, settingsDetail), doctorRepositoryMergeSettingsCommand(repository, workflowconfig.MergeMethodSquash), nil
+		}
+		method := doctorRepositoryPreferredDeclaredMergeMethod(settings)
+		patch := doctorWorkflowOptimizationPatch{Path: "deliverable.merge_method", Value: method}
+		return fmt.Sprintf("%s ambiguous merge policy: repo settings %s allow multiple methods and WORKFLOW.md declares none; agent-side auto-detection can produce mixed history", repository, settingsDetail), fmt.Sprintf("add `merge_method: %s` under `deliverable:` in WORKFLOW.md", method), &patch
 	}
 
 	declared := deliverable.EffectiveMergeMethod()
@@ -84,6 +89,16 @@ func doctorRepositoryMergePolicyWarning(repository string, deliverable workflowc
 		return fmt.Sprintf("%s declared merge_method=%s is loose because repo settings %s permit additional methods", repository, declared, settingsDetail), doctorRepositoryMergeSettingsCommand(repository, declared), nil
 	}
 	return "", "", nil
+}
+
+func doctorRepositoryPreferredDeclaredMergeMethod(settings ghconnector.RepositoryMergeSettings) string {
+	if settings.AllowSquashMerge {
+		return workflowconfig.MergeMethodSquash
+	}
+	if settings.AllowMergeCommit {
+		return workflowconfig.MergeMethodMerge
+	}
+	return workflowconfig.MergeMethodRebase
 }
 
 func doctorRepositoryMergeSettingsDetail(settings ghconnector.RepositoryMergeSettings) string {

--- a/internal/cli/doctor_merge_policy.go
+++ b/internal/cli/doctor_merge_policy.go
@@ -1,0 +1,118 @@
+package cli
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	workflowconfig "github.com/digitaldrywood/detent/internal/config"
+	globalconfig "github.com/digitaldrywood/detent/internal/config/global"
+	ghconnector "github.com/digitaldrywood/detent/internal/connector/github"
+)
+
+const doctorWorkflowRuleRepositoryMergePolicy = "repository_merge_policy"
+
+func defaultDoctorGitHubMergeSettings(ctx context.Context, cfg workflowconfig.Config, repository string) (ghconnector.RepositoryMergeSettings, error) {
+	connector, err := ghconnector.NewConnector(doctorGitHubConnectorConfig(cfg))
+	if err != nil {
+		return ghconnector.RepositoryMergeSettings{}, err
+	}
+	return connector.RepositoryMergeSettings(ctx, repository)
+}
+
+func checkDoctorRepositoryMergePolicy(ctx context.Context, id string, project globalconfig.Project, cfg workflowconfig.Config, deps doctorDeps) doctorCheck {
+	name := "Project " + id + " repository merge policy"
+	if deps.githubMergeSettings == nil {
+		return doctorCheck{Name: name, Status: doctorWarn, Detail: "repository merge policy skipped because the GitHub settings reader is unavailable"}
+	}
+	repositories := doctorGitHubRepositories(ctx, project, cfg, deps, projectSourceRoot(project, cfg))
+	if len(repositories) == 0 {
+		return doctorCheck{Name: name, Status: doctorWarn, Detail: "repository merge policy skipped because no GitHub repository could be resolved", Hint: "Set tracker.repository to owner/repo in WORKFLOW.md."}
+	}
+
+	warnings := []string{}
+	findings := []doctorWorkflowOptimizationFinding{}
+	for _, repository := range repositories {
+		settings, err := deps.githubMergeSettings(ctx, cfg, repository)
+		if err != nil {
+			return doctorCheck{Name: name, Status: doctorFail, Detail: fmt.Sprintf("read %s merge settings: %v", repository, err), Hint: "Fix GitHub repository access, then rerun detent doctor."}
+		}
+		detail, fix, patch := doctorRepositoryMergePolicyWarning(repository, cfg.Deliverable, settings)
+		if detail == "" {
+			continue
+		}
+		warnings = append(warnings, detail+"; fix: "+fix)
+		finding := doctorWorkflowOptimizationFinding{
+			RuleID:    doctorWorkflowRuleRepositoryMergePolicy,
+			ProjectID: id,
+			Severity:  "warning",
+			Title:     "repository merge policy drift",
+			Detail:    detail,
+			Evidence: map[string]any{
+				"repository": repository,
+				"settings":   doctorRepositoryMergeSettingsDetail(settings),
+				"fix":        fix,
+			},
+		}
+		if patch != nil {
+			finding.Patch = []doctorWorkflowOptimizationPatch{*patch}
+		}
+		findings = append(findings, finding)
+	}
+	if len(warnings) == 0 {
+		return doctorCheck{Name: name, Status: doctorOK, Detail: "repository merge settings exactly match the declared strategy"}
+	}
+	report := doctorWorkflowOptimizationReport{Findings: findings, Proposals: doctorWorkflowProposalsForFindings(id, findings, 1)}
+	return doctorCheck{Name: name, Status: doctorWarn, Detail: strings.Join(warnings, "; "), Hint: "Apply each copy-paste fix, then rerun detent doctor.", WorkflowOptimization: report}
+}
+
+func doctorRepositoryMergePolicyWarning(repository string, deliverable workflowconfig.Deliverable, settings ghconnector.RepositoryMergeSettings) (string, string, *doctorWorkflowOptimizationPatch) {
+	settingsDetail := doctorRepositoryMergeSettingsDetail(settings)
+	if !deliverable.MergeMethodConfigured() {
+		if doctorRepositoryEnabledMergeMethodCount(settings) <= 1 {
+			return "", "", nil
+		}
+		patch := doctorWorkflowOptimizationPatch{Path: "deliverable.merge_method", Value: workflowconfig.MergeMethodSquash}
+		return fmt.Sprintf("%s ambiguous merge policy: repo settings %s allow multiple methods and WORKFLOW.md declares none; agent-side auto-detection can produce mixed history", repository, settingsDetail), "add `merge_method: squash` under `deliverable:` in WORKFLOW.md", &patch
+	}
+
+	declared := deliverable.EffectiveMergeMethod()
+	if !doctorRepositoryMergeMethodEnabled(settings, declared) {
+		return fmt.Sprintf("%s declared merge_method=%s is forbidden by repo settings %s", repository, declared, settingsDetail), doctorRepositoryMergeSettingsCommand(repository, declared), nil
+	}
+	if doctorRepositoryEnabledMergeMethodCount(settings) > 1 {
+		return fmt.Sprintf("%s declared merge_method=%s is loose because repo settings %s permit additional methods", repository, declared, settingsDetail), doctorRepositoryMergeSettingsCommand(repository, declared), nil
+	}
+	return "", "", nil
+}
+
+func doctorRepositoryMergeSettingsDetail(settings ghconnector.RepositoryMergeSettings) string {
+	return fmt.Sprintf("merge_commit=%t,squash=%t,rebase=%t", settings.AllowMergeCommit, settings.AllowSquashMerge, settings.AllowRebaseMerge)
+}
+
+func doctorRepositoryEnabledMergeMethodCount(settings ghconnector.RepositoryMergeSettings) int {
+	count := 0
+	for _, enabled := range []bool{settings.AllowMergeCommit, settings.AllowSquashMerge, settings.AllowRebaseMerge} {
+		if enabled {
+			count++
+		}
+	}
+	return count
+}
+
+func doctorRepositoryMergeMethodEnabled(settings ghconnector.RepositoryMergeSettings, method string) bool {
+	switch method {
+	case workflowconfig.MergeMethodMerge:
+		return settings.AllowMergeCommit
+	case workflowconfig.MergeMethodSquash:
+		return settings.AllowSquashMerge
+	case workflowconfig.MergeMethodRebase:
+		return settings.AllowRebaseMerge
+	default:
+		return false
+	}
+}
+
+func doctorRepositoryMergeSettingsCommand(repository string, method string) string {
+	return fmt.Sprintf("gh api --method PATCH repos/%s -F allow_merge_commit=%t -F allow_squash_merge=%t -F allow_rebase_merge=%t", repository, method == workflowconfig.MergeMethodMerge, method == workflowconfig.MergeMethodSquash, method == workflowconfig.MergeMethodRebase)
+}

--- a/internal/cli/doctor_merge_policy_test.go
+++ b/internal/cli/doctor_merge_policy_test.go
@@ -43,6 +43,19 @@ func TestDoctorRepositoryMergePolicyWarning(t *testing.T) {
 			wantPatch:  true,
 		},
 		{
+			name:       "undeclared ambiguity chooses enabled method",
+			settings:   ghconnector.RepositoryMergeSettings{AllowMergeCommit: true, AllowRebaseMerge: true},
+			wantDetail: "digitaldrywood/detent ambiguous merge policy: repo settings merge_commit=true,squash=false,rebase=true allow multiple methods and WORKFLOW.md declares none; agent-side auto-detection can produce mixed history",
+			wantFix:    "add `merge_method: merge` under `deliverable:` in WORKFLOW.md",
+			wantPatch:  true,
+		},
+		{
+			name:       "undeclared effective default forbidden",
+			settings:   ghconnector.RepositoryMergeSettings{AllowMergeCommit: true},
+			wantDetail: "digitaldrywood/detent effective default merge_method=squash is forbidden by repo settings merge_commit=true,squash=false,rebase=false and WORKFLOW.md declares none",
+			wantFix:    "gh api --method PATCH repos/digitaldrywood/detent -F allow_merge_commit=false -F allow_squash_merge=true -F allow_rebase_merge=false",
+		},
+		{
 			name:            "exact declared method",
 			mergeMethodYAML: "squash",
 			settings:        ghconnector.RepositoryMergeSettings{AllowSquashMerge: true},
@@ -63,10 +76,41 @@ func TestDoctorRepositoryMergePolicyWarning(t *testing.T) {
 			if (gotPatch != nil) != tt.wantPatch {
 				t.Fatalf("patch present = %t, want %t", gotPatch != nil, tt.wantPatch)
 			}
-			if gotPatch != nil && (gotPatch.Path != "deliverable.merge_method" || gotPatch.Value != workflowconfig.MergeMethodSquash) {
-				t.Fatalf("patch = %#v, want deliverable.merge_method=squash", gotPatch)
+			if gotPatch != nil && gotPatch.Path != "deliverable.merge_method" {
+				t.Fatalf("patch = %#v, want deliverable.merge_method", gotPatch)
 			}
 		})
+	}
+}
+
+func TestCheckDoctorProjectSkipsRepositoryMergePolicyForArtifact(t *testing.T) {
+	t.Parallel()
+
+	cfg := validDoctorWorkflow("/repo")
+	cfg.Tracker.Kind = workflowconfig.TrackerGitHub
+	cfg.Deliverable.Kind = workflowconfig.DeliverableArtifact
+	settingsReads := 0
+	checks := checkDoctorProject(context.Background(), globalconfig.Project{ID: "artifact", Workflow: "WORKFLOW.md", Workdir: "/repo"}, doctorDeps{
+		loadWorkflow: func(string) (workflowconfig.Workflow, error) {
+			return workflowconfig.Workflow{Config: cfg}, nil
+		},
+		gitWorkTree: func(context.Context, string) error { return nil },
+		githubReadiness: func(context.Context, ghconnector.Config, ghconnector.ReadinessConfig) ([]ghconnector.ReadinessCheck, error) {
+			return nil, nil
+		},
+		githubMergeSettings: func(context.Context, workflowconfig.Config, string) (ghconnector.RepositoryMergeSettings, error) {
+			settingsReads++
+			return ghconnector.RepositoryMergeSettings{}, nil
+		},
+	}, RuntimeSecret{}, false)
+
+	if settingsReads != 0 {
+		t.Fatalf("settings reads = %d, want 0", settingsReads)
+	}
+	for _, check := range checks {
+		if strings.Contains(check.Name, "repository merge policy") {
+			t.Fatalf("artifact checks include merge policy: %#v", check)
+		}
 	}
 }
 

--- a/internal/cli/doctor_merge_policy_test.go
+++ b/internal/cli/doctor_merge_policy_test.go
@@ -1,0 +1,130 @@
+package cli
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	workflowconfig "github.com/digitaldrywood/detent/internal/config"
+	globalconfig "github.com/digitaldrywood/detent/internal/config/global"
+	ghconnector "github.com/digitaldrywood/detent/internal/connector/github"
+)
+
+func TestDoctorRepositoryMergePolicyWarning(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name            string
+		mergeMethodYAML string
+		settings        ghconnector.RepositoryMergeSettings
+		wantDetail      string
+		wantFix         string
+		wantPatch       bool
+	}{
+		{
+			name:            "declared method forbidden",
+			mergeMethodYAML: "squash",
+			settings:        ghconnector.RepositoryMergeSettings{AllowMergeCommit: true},
+			wantDetail:      "digitaldrywood/detent declared merge_method=squash is forbidden by repo settings merge_commit=true,squash=false,rebase=false",
+			wantFix:         "gh api --method PATCH repos/digitaldrywood/detent -F allow_merge_commit=false -F allow_squash_merge=true -F allow_rebase_merge=false",
+		},
+		{
+			name:            "declared method loose",
+			mergeMethodYAML: "squash",
+			settings:        ghconnector.RepositoryMergeSettings{AllowMergeCommit: true, AllowSquashMerge: true},
+			wantDetail:      "digitaldrywood/detent declared merge_method=squash is loose because repo settings merge_commit=true,squash=true,rebase=false permit additional methods",
+			wantFix:         "gh api --method PATCH repos/digitaldrywood/detent -F allow_merge_commit=false -F allow_squash_merge=true -F allow_rebase_merge=false",
+		},
+		{
+			name:       "undeclared method ambiguous",
+			settings:   ghconnector.RepositoryMergeSettings{AllowMergeCommit: true, AllowSquashMerge: true, AllowRebaseMerge: true},
+			wantDetail: "digitaldrywood/detent ambiguous merge policy: repo settings merge_commit=true,squash=true,rebase=true allow multiple methods and WORKFLOW.md declares none; agent-side auto-detection can produce mixed history",
+			wantFix:    "add `merge_method: squash` under `deliverable:` in WORKFLOW.md",
+			wantPatch:  true,
+		},
+		{
+			name:            "exact declared method",
+			mergeMethodYAML: "squash",
+			settings:        ghconnector.RepositoryMergeSettings{AllowSquashMerge: true},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			deliverable := parseDoctorMergePolicyDeliverable(t, tt.mergeMethodYAML)
+			gotDetail, gotFix, gotPatch := doctorRepositoryMergePolicyWarning("digitaldrywood/detent", deliverable, tt.settings)
+			if gotDetail != tt.wantDetail {
+				t.Fatalf("detail = %q, want %q", gotDetail, tt.wantDetail)
+			}
+			if gotFix != tt.wantFix {
+				t.Fatalf("fix = %q, want %q", gotFix, tt.wantFix)
+			}
+			if (gotPatch != nil) != tt.wantPatch {
+				t.Fatalf("patch present = %t, want %t", gotPatch != nil, tt.wantPatch)
+			}
+			if gotPatch != nil && (gotPatch.Path != "deliverable.merge_method" || gotPatch.Value != workflowconfig.MergeMethodSquash) {
+				t.Fatalf("patch = %#v, want deliverable.merge_method=squash", gotPatch)
+			}
+		})
+	}
+}
+
+func TestCheckDoctorRepositoryMergePolicyFeedsProposalPipeline(t *testing.T) {
+	t.Parallel()
+
+	cfg := workflowconfig.Default()
+	cfg.Tracker.Kind = workflowconfig.TrackerGitHub
+	cfg.Tracker.Repository = "digitaldrywood/detent"
+	check := checkDoctorRepositoryMergePolicy(context.Background(), "detent", globalconfig.Project{}, cfg, doctorDeps{
+		githubMergeSettings: func(context.Context, workflowconfig.Config, string) (ghconnector.RepositoryMergeSettings, error) {
+			return ghconnector.RepositoryMergeSettings{AllowMergeCommit: true, AllowSquashMerge: true}, nil
+		},
+	})
+
+	if check.Status != doctorWarn {
+		t.Fatalf("Status = %s, want WARN", check.Status)
+	}
+	if len(check.WorkflowOptimization.Findings) != 1 || len(check.WorkflowOptimization.Proposals) != 1 {
+		t.Fatalf("WorkflowOptimization = %#v, want one finding and one proposal", check.WorkflowOptimization)
+	}
+	proposal := check.WorkflowOptimization.Proposals[0]
+	if proposal.TargetPath != "deliverable.merge_method" || !strings.Contains(proposal.SuggestedChange, "squash") {
+		t.Fatalf("proposal = %#v, want WORKFLOW.md merge_method squash change", proposal)
+	}
+}
+
+func TestCheckDoctorRepositoryMergePolicyTargetsRepositoryForDeclaredDrift(t *testing.T) {
+	t.Parallel()
+
+	workflow, err := workflowconfig.ParseWorkflow([]byte("---\ntracker:\n  kind: github\n  repository: digitaldrywood/detent\ndeliverable:\n  merge_method: squash\n---\n"))
+	if err != nil {
+		t.Fatalf("ParseWorkflow() error = %v", err)
+	}
+	check := checkDoctorRepositoryMergePolicy(context.Background(), "detent", globalconfig.Project{}, workflow.Config, doctorDeps{
+		githubMergeSettings: func(context.Context, workflowconfig.Config, string) (ghconnector.RepositoryMergeSettings, error) {
+			return ghconnector.RepositoryMergeSettings{AllowMergeCommit: true, AllowSquashMerge: true}, nil
+		},
+	})
+
+	if len(check.WorkflowOptimization.Proposals) != 1 {
+		t.Fatalf("proposals = %#v, want one", check.WorkflowOptimization.Proposals)
+	}
+	proposal := check.WorkflowOptimization.Proposals[0]
+	if proposal.TargetKind != "repository" || proposal.TargetPath != "digitaldrywood/detent" || !strings.HasPrefix(proposal.SuggestedChange, "gh api --method PATCH") {
+		t.Fatalf("proposal = %#v, want repository settings command", proposal)
+	}
+}
+
+func parseDoctorMergePolicyDeliverable(t *testing.T, mergeMethod string) workflowconfig.Deliverable {
+	t.Helper()
+	raw := "---\ntracker:\n  kind: github\n"
+	if mergeMethod != "" {
+		raw += "deliverable:\n  merge_method: " + mergeMethod + "\n"
+	}
+	workflow, err := workflowconfig.ParseWorkflow([]byte(raw + "---\n"))
+	if err != nil {
+		t.Fatalf("ParseWorkflow() error = %v", err)
+	}
+	return workflow.Config.Deliverable
+}

--- a/internal/cli/doctor_project.go
+++ b/internal/cli/doctor_project.go
@@ -272,9 +272,11 @@ func checkDoctorProjectWithProgress(
 		setDoctorCurrentCheck("Project " + id + " auto-promote")
 		checks = append(checks, checkDoctorAutoPromote(ctx, id, workflow.Config, deps, time.Now()))
 	}
-	if doctorTrackerUsesGitHubReads(workflow.Config.Tracker.Kind) {
+	if doctorTrackerUsesGitHubReads(workflow.Config.Tracker.Kind) && workflow.Config.Deliverable.Kind == workflowconfig.DeliverablePullRequest {
 		setDoctorCurrentCheck("Project " + id + " repository merge policy")
 		checks = append(checks, checkDoctorRepositoryMergePolicy(ctx, id, project, workflow.Config, deps))
+	}
+	if doctorTrackerUsesGitHubReads(workflow.Config.Tracker.Kind) {
 		if workflow.Config.Tracker.GitHubStatusSource == workflowconfig.GitHubStatusSourceLabel {
 			setDoctorCurrentCheck("Project " + id + " label status drift")
 			checks = append(checks, checkDoctorLabelStatusDrift(ctx, id, workflow.Config, deps))

--- a/internal/cli/doctor_project.go
+++ b/internal/cli/doctor_project.go
@@ -273,6 +273,8 @@ func checkDoctorProjectWithProgress(
 		checks = append(checks, checkDoctorAutoPromote(ctx, id, workflow.Config, deps, time.Now()))
 	}
 	if doctorTrackerUsesGitHubReads(workflow.Config.Tracker.Kind) {
+		setDoctorCurrentCheck("Project " + id + " repository merge policy")
+		checks = append(checks, checkDoctorRepositoryMergePolicy(ctx, id, project, workflow.Config, deps))
 		if workflow.Config.Tracker.GitHubStatusSource == workflowconfig.GitHubStatusSourceLabel {
 			setDoctorCurrentCheck("Project " + id + " label status drift")
 			checks = append(checks, checkDoctorLabelStatusDrift(ctx, id, workflow.Config, deps))

--- a/internal/cli/doctor_self_improvement.go
+++ b/internal/cli/doctor_self_improvement.go
@@ -270,6 +270,8 @@ func doctorWorkflowFindingProposalTarget(finding doctorWorkflowOptimizationFindi
 		return target, path, fmt.Sprintf("Set `%s` to `%v` in WORKFLOW.md after human review.", path, patch.Value)
 	}
 	switch finding.RuleID {
+	case doctorWorkflowRuleRepositoryMergePolicy:
+		return "repository", strings.TrimSpace(fmt.Sprint(finding.Evidence["repository"])), strings.TrimSpace(fmt.Sprint(finding.Evidence["fix"]))
 	case doctorWorkflowRuleEmptyModelTelemetry:
 		return "telemetry", "codex_sessions.model", "Repair effective-model resolution for completed sessions while leaving the project's pin/default policy unchanged."
 	case doctorWorkflowRulePinnedRouteModelRejected:

--- a/internal/cli/doctor_test.go
+++ b/internal/cli/doctor_test.go
@@ -4469,6 +4469,9 @@ func TestDoctorProjectCheckJobTimeoutReportsCurrentInnerCheck(t *testing.T) {
 			<-releaseReadiness
 			return nil, nil
 		},
+		githubMergeSettings: func(context.Context, workflowconfig.Config, string) (ghconnector.RepositoryMergeSettings, error) {
+			return ghconnector.RepositoryMergeSettings{AllowSquashMerge: true}, nil
+		},
 	}, RuntimeSecret{Value: "token", Source: "github_token"}, false)
 	if len(jobs) != 1 {
 		t.Fatalf("jobs len = %d, want 1", len(jobs))
@@ -4793,6 +4796,9 @@ func successfulDoctorDeps() doctorDeps {
 			return []ghconnector.ReadinessCheck{
 				{Name: "GitHub readiness", Status: ghconnector.ReadinessOK, Detail: "ready"},
 			}, nil
+		},
+		githubMergeSettings: func(context.Context, workflowconfig.Config, string) (ghconnector.RepositoryMergeSettings, error) {
+			return ghconnector.RepositoryMergeSettings{AllowSquashMerge: true}, nil
 		},
 		listen: func(string, string) (net.Listener, error) {
 			return fakeDoctorListener{addr: fakeDoctorAddr("127.0.0.1:49152")}, nil

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -224,10 +224,11 @@ type Workpad struct {
 }
 
 type Deliverable struct {
-	Kind        string `yaml:"kind"`
-	MergeMethod string `yaml:"merge_method,omitempty"`
-	OutputRoot  string `yaml:"output_root,omitempty"`
-	ReviewURL   string `yaml:"review_url,omitempty"`
+	Kind                  string `yaml:"kind"`
+	MergeMethod           string `yaml:"merge_method,omitempty"`
+	OutputRoot            string `yaml:"output_root,omitempty"`
+	ReviewURL             string `yaml:"review_url,omitempty"`
+	mergeMethodConfigured bool
 }
 
 type Worker struct {
@@ -946,6 +947,7 @@ func ParseWorkflow(raw []byte) (Workflow, error) {
 		normalizeTrackerIDFields(root)
 		gitHubStatusSourceSet := trackerFieldSet(root, "github_status_source")
 		knowledgeConfigured := nestedFieldSet(root, "agent", "knowledge")
+		mergeMethodConfigured := nestedFieldSet(root, "deliverable", "merge_method")
 		perDayMaxUSDConfigured := nestedFieldSet(root, "budget", "per_day_max_usd")
 		perIssueMaxUSDConfigured := nestedFieldSet(root, "budget", "per_issue_max_usd")
 		if err := root.Decode(&cfg); err != nil {
@@ -953,6 +955,7 @@ func ParseWorkflow(raw []byte) (Workflow, error) {
 		}
 		cfg.Tracker.gitHubStatusSourceSet = gitHubStatusSourceSet
 		cfg.Agent.Knowledge.Configured = knowledgeConfigured
+		cfg.Deliverable.mergeMethodConfigured = mergeMethodConfigured
 		cfg.Budget.perDayMaxUSDConfigured = perDayMaxUSDConfigured
 		cfg.Budget.perIssueMaxUSDConfigured = perIssueMaxUSDConfigured
 		cfg.configuredFields = configuredFieldPaths(root)
@@ -1608,6 +1611,10 @@ func (d Deliverable) EffectiveMergeMethod() string {
 		return MergeMethodSquash
 	}
 	return method
+}
+
+func (d Deliverable) MergeMethodConfigured() bool {
+	return d.mergeMethodConfigured
 }
 
 func normalizeMergeMethod(method string) string {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -150,16 +150,17 @@ func TestParseWorkflowMergeMethod(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name    string
-		value   string
-		want    string
-		wantErr string
+		name           string
+		value          string
+		want           string
+		wantConfigured bool
+		wantErr        string
 	}{
 		{name: "omitted defaults to squash", want: MergeMethodSquash},
-		{name: "squash", value: "squash", want: MergeMethodSquash},
-		{name: "merge", value: "merge", want: MergeMethodMerge},
-		{name: "rebase", value: "rebase", want: MergeMethodRebase},
-		{name: "normalizes case and whitespace", value: " ReBaSe ", want: MergeMethodRebase},
+		{name: "squash", value: "squash", want: MergeMethodSquash, wantConfigured: true},
+		{name: "merge", value: "merge", want: MergeMethodMerge, wantConfigured: true},
+		{name: "rebase", value: "rebase", want: MergeMethodRebase, wantConfigured: true},
+		{name: "normalizes case and whitespace", value: " ReBaSe ", want: MergeMethodRebase, wantConfigured: true},
 		{name: "rejects invalid value", value: "octopus", wantErr: "deliverable.merge_method must be one of squash, merge, rebase"},
 	}
 
@@ -186,6 +187,9 @@ func TestParseWorkflowMergeMethod(t *testing.T) {
 			}
 			if got := workflow.Config.Deliverable.MergeMethod; got != tt.want {
 				t.Fatalf("Deliverable.MergeMethod = %q, want %q", got, tt.want)
+			}
+			if got := workflow.Config.Deliverable.MergeMethodConfigured(); got != tt.wantConfigured {
+				t.Fatalf("Deliverable.MergeMethodConfigured() = %t, want %t", got, tt.wantConfigured)
 			}
 		})
 	}

--- a/internal/connector/github/connector.go
+++ b/internal/connector/github/connector.go
@@ -111,6 +111,24 @@ type Connector struct {
 	instanceLogin     string
 }
 
+type RepositoryMergeSettings struct {
+	AllowMergeCommit bool `json:"allow_merge_commit"`
+	AllowSquashMerge bool `json:"allow_squash_merge"`
+	AllowRebaseMerge bool `json:"allow_rebase_merge"`
+}
+
+func (c *Connector) RepositoryMergeSettings(ctx context.Context, repository string) (RepositoryMergeSettings, error) {
+	repo, ok := pullRequestRepoFromName(repository)
+	if !ok {
+		return RepositoryMergeSettings{}, fmt.Errorf("invalid GitHub repository %q", repository)
+	}
+	var settings RepositoryMergeSettings
+	if err := c.client.REST(ctx, "GET", "/repos/"+repo.Owner+"/"+repo.Name, nil, &settings); err != nil {
+		return RepositoryMergeSettings{}, err
+	}
+	return settings, nil
+}
+
 func NewConnector(cfg Config) (*Connector, error) {
 	httpClient := cfg.HTTPClient
 	if httpClient == nil {

--- a/internal/connector/github/connector_merge_settings_test.go
+++ b/internal/connector/github/connector_merge_settings_test.go
@@ -1,0 +1,34 @@
+package github
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestConnectorRepositoryMergeSettings(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet || r.URL.Path != "/repos/digitaldrywood/detent" {
+			t.Fatalf("request = %s %s, want GET /repos/digitaldrywood/detent", r.Method, r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"allow_merge_commit":false,"allow_squash_merge":true,"allow_rebase_merge":false}`))
+	}))
+	t.Cleanup(server.Close)
+
+	connector, err := NewConnector(Config{Endpoint: server.URL + "/graphql", APIKey: "token"})
+	if err != nil {
+		t.Fatalf("NewConnector() error = %v", err)
+	}
+	got, err := connector.RepositoryMergeSettings(context.Background(), "digitaldrywood/detent")
+	if err != nil {
+		t.Fatalf("RepositoryMergeSettings() error = %v", err)
+	}
+	want := RepositoryMergeSettings{AllowSquashMerge: true}
+	if got != want {
+		t.Fatalf("RepositoryMergeSettings() = %#v, want %#v", got, want)
+	}
+}


### PR DESCRIPTION
## Summary

- read GitHub repository merge-method settings during each GitHub project doctor check
- warn on declared methods that are forbidden or loosely enforced, and on undeclared ambiguous policies
- route merge-policy findings through governed self-improvement proposals with copy-paste fixes
- preserve whether `deliverable.merge_method` was explicitly declared while retaining the squash default

Fixes #1271

## UI Surface Contract

- [x] N/A, or the linked issue explicitly authorizes any high-impact UI surface, layout, density, first-viewport, or responsive visibility tradeoff.
- [x] Persistent top-of-screen messaging is explicitly authorized by the issue, or this PR does not add it.
- [x] Visual changes to primary operator screens include screenshot or browser verification below.

## Test Plan

- [x] `go test ./internal/config ./internal/connector/github ./internal/cli`
- [x] `make check`
