### PR TITLE
test(cli): isolate doctor health probes

### DIFF
--- a/internal/cli/doctor_test.go
+++ b/internal/cli/doctor_test.go
@@ -4789,6 +4789,9 @@ func successfulDoctorDeps() doctorDeps {
 		runCommandInDir: func(context.Context, string, []string, string, ...string) error {
 			return nil
 		},
+		httpDo: func(*http.Request) (*http.Response, error) {
+			return nil, errors.New("health unavailable")
+		},
 		githubScopes: func(context.Context, string) ([]string, error) {
 			return []string{"repo", "read:org", "read:project", "project"}, nil
 		},


### PR DESCRIPTION
## Summary

- prevent shared successful doctor test dependencies from falling back to the production HTTP client
- keep workflow drift coverage isolated behind explicit fake health responses

Fixes #1292

## UI Surface Contract

- [x] N/A, or the linked issue explicitly authorizes any high-impact UI surface, layout, density, first-viewport, or responsive visibility tradeoff.
- [x] Persistent top-of-screen messaging is explicitly authorized by the issue, or this PR does not add it.
- [x] Visual changes to primary operator screens include screenshot or browser verification below.

## Test Plan

- [x] `go test -race ./internal/cli -run '^(TestDoctorWorkflowOptimizationStrictFailsOnAdvisoryFindings|TestDoctorWorkflowOptimizationWriteRoundTripsWorkflow)$' -count=10`
- [x] `make check`
