### PR TITLE
fix(orchestrator): honor source gate waits

### DIFF
--- a/internal/orchestrator/autopromote_tick.go
+++ b/internal/orchestrator/autopromote_tick.go
@@ -369,7 +369,9 @@ func autoPromoteActiveGateEligibleIssue(
 
 func autoPromoteSourceGateWaitEnabled(cfg AutoPromoteConfig) bool {
 	cfg = normalizeAutoPromoteConfig(cfg)
-	return cfg.Enabled && cfg.QuietDuration == 0 && cfg.GateWaitState == autoPromoteGateWaitSource
+	return cfg.Enabled &&
+		cfg.GateWaitState == autoPromoteGateWaitSource &&
+		gate.Effective(cfg.Gate).Kind == gate.KindCommand
 }
 
 func autoPromoteActiveGateTrackingEnabled(cfg AutoPromoteConfig) bool {

--- a/internal/orchestrator/autopromote_tick_test.go
+++ b/internal/orchestrator/autopromote_tick_test.go
@@ -508,7 +508,7 @@ func TestTickAutoPromoteCompletedActiveIssues(t *testing.T) {
 				MaxConcurrentAgents: 1,
 				AutoPromote: AutoPromoteConfig{
 					Enabled:       true,
-					QuietDuration: 0,
+					QuietDuration: 10 * time.Minute,
 					Gate:          gate.Config{Kind: gate.KindCommand},
 				},
 				ActiveStates:   []string{"Todo", "In Progress", "Rework", "Merging"},
@@ -545,6 +545,50 @@ func TestTickAutoPromoteCompletedActiveIssues(t *testing.T) {
 				t.Fatalf("Completed[%q] present after auto-promote transition", tt.issue.ID)
 			}
 		})
+	}
+}
+
+func TestTickRoutesCompletedActiveArtifactToReview(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 7, 13, 12, 0, 0, 0, time.UTC)
+	issue := artifactCompletionTransitionIssue("Production", "approved")
+	cfg := normalizeConfig(Config{
+		PollInterval:        time.Minute,
+		MaxConcurrentAgents: 1,
+		AutoPromote: AutoPromoteConfig{
+			Enabled:       true,
+			QuietDuration: 10 * time.Minute,
+			SourceState:   "Review",
+			PassState:     "Ready for Pickup",
+			ReworkState:   "Rework",
+			GateWaitState: autoPromoteGateWaitSource,
+			Gate:          artifactCompletionTestGate(),
+		},
+		ActiveStates:   []string{"Todo", "Production", "Rework"},
+		ObservedStates: []string{"Review"},
+		TerminalStates: []string{"Ready for Pickup", "Done", "Cancelled"},
+	})
+	state := newState(cfg)
+	state.Completed[issue.ID] = Completed{
+		Issue:      issue,
+		FinalState: FinalStateCompleted,
+	}
+	tracker := &autoPromoteTickConnector{stateIssues: []connector.Issue{issue}}
+	orch := &Orchestrator{
+		cfg:       cfg,
+		connector: tracker,
+		logger:    slog.New(slog.NewTextHandler(io.Discard, nil)),
+	}
+
+	orch.tick(context.Background(), &state, now)
+
+	wantUpdates := []autoPromoteTickUpdate{{issueID: issue.ID, state: "Review"}}
+	if !reflect.DeepEqual(tracker.updates, wantUpdates) {
+		t.Fatalf("updates = %#v, want %#v", tracker.updates, wantUpdates)
+	}
+	if got := state.Completed[issue.ID].Issue.State; got != "Review" {
+		t.Fatalf("Completed issue state = %q, want Review", got)
 	}
 }
 

--- a/internal/orchestrator/completion_transition.go
+++ b/internal/orchestrator/completion_transition.go
@@ -258,9 +258,6 @@ func completedActiveShouldEnterReview(issue connector.Issue, cfg AutoPromoteConf
 	if gate.Effective(cfg.Gate).Kind == gate.KindArtifact {
 		return true
 	}
-	if cfg.QuietDuration > 0 {
-		return true
-	}
 	return cfg.GateWaitState == autoPromoteGateWaitReview
 }
 

--- a/internal/orchestrator/completion_transition_test.go
+++ b/internal/orchestrator/completion_transition_test.go
@@ -103,7 +103,7 @@ func TestCompletedActiveReviewTargetState(t *testing.T) {
 			},
 		},
 		{
-			name:       "command gate with quiet window advances to human review",
+			name:       "command gate with quiet window and source wait skips human review target",
 			issue:      completionTransitionIssue("In Progress", "OPEN"),
 			finalState: FinalStateCompleted,
 			cfg: AutoPromoteConfig{
@@ -111,7 +111,6 @@ func TestCompletedActiveReviewTargetState(t *testing.T) {
 				QuietDuration: 10 * time.Minute,
 				Gate:          gate.Config{Kind: gate.KindCommand},
 			},
-			want: autoPromoteSourceState,
 		},
 		{
 			name:       "zero quiet command gate with review wait advances to human review",

--- a/internal/orchestrator/orchestrator_test.go
+++ b/internal/orchestrator/orchestrator_test.go
@@ -183,6 +183,86 @@ func TestRunCompletionTransitionsLabelModeIssueToHumanReview(t *testing.T) {
 	}
 }
 
+func TestRunCompletionPromotesLabelModeWorkpadDirectlyToMerging(t *testing.T) {
+	t.Parallel()
+
+	issue := testIssue("issue-label-autopilot", "digitaldrywood/detent#1288", "Todo")
+	issue.Labels = []string{"detent:todo", "bug"}
+	tracker := newFakeLabelConnector(issue)
+	activityAt := time.Now().Add(-time.Hour)
+	runner := &staticRunner{
+		result: orchestrator.RunResult{FinalState: orchestrator.FinalStateCompleted},
+		onRun: func(request orchestrator.RunRequest) {
+			tracker.setCandidatePullRequest(request.Issue.ID, &connector.PullRequest{
+				Number:         1288,
+				URL:            "https://github.com/digitaldrywood/detent/pull/1288",
+				State:          "OPEN",
+				MergeableState: "clean",
+				CIStatus:       "success",
+				ActivityAt:     &activityAt,
+			})
+			tracker.setIssueComments(request.Issue.ID, []connector.IssueComment{{
+				Body: "## Codex Workpad\n\n```detent-status\nschema: 1\nstatus: complete\nblockers: []\nhuman_action: null\n```",
+			}})
+		},
+	}
+
+	orch, err := orchestrator.New(orchestrator.Config{
+		PollInterval:          5 * time.Millisecond,
+		MaxConcurrentAgents:   1,
+		MaxRetryBackoff:       time.Hour,
+		FailureRetryBaseDelay: time.Hour,
+		AutoPromote: orchestrator.AutoPromoteConfig{
+			Enabled:       true,
+			QuietDuration: 10 * time.Minute,
+			GateWaitState: "source",
+			OptoutLabel:   "requires-human-review",
+			Gate: gate.Config{
+				Kind:                   gate.KindCommand,
+				RequireAutomatedReview: new(false),
+			},
+		},
+		ActiveStates:           []string{"Todo", "In Progress", "Rework"},
+		ObservedStates:         []string{"Human Review", "Merging"},
+		TerminalStates:         []string{"Done", "Cancelled", "Canceled", "Closed"},
+		ContinuationRetryDelay: time.Millisecond,
+	}, orchestrator.Dependencies{
+		Connector: tracker,
+		Runner:    runner,
+	})
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	stop := runOrchestrator(t, orch)
+	defer stop()
+
+	waitForStateUpdate(t, tracker, stateUpdateCall{issueID: issue.ID, state: "Merging"})
+	updates := tracker.stateUpdateCalls()
+	wantUpdates := []stateUpdateCall{
+		{issueID: issue.ID, state: "In Progress"},
+		{issueID: issue.ID, state: "Merging"},
+	}
+	if !stateUpdateCallsContainInOrder(updates, wantUpdates) {
+		t.Fatalf("state updates = %#v, want sequence %#v", updates, wantUpdates)
+	}
+	for _, update := range updates {
+		if update.issueID == issue.ID && update.state == "Human Review" {
+			t.Fatalf("state updates = %#v, want no Human Review transition", updates)
+		}
+	}
+
+	got := tracker.candidateIssue(issue.ID)
+	if got.State != "Merging" {
+		t.Fatalf("State = %q, want Merging", got.State)
+	}
+	if count := statusLabelCount(got.Labels, "detent:"); count != 1 {
+		t.Fatalf("detent status label count = %d in %#v, want 1", count, got.Labels)
+	}
+	if !labelListContains(got.Labels, "detent:merging") {
+		t.Fatalf("Labels = %#v, want detent:merging", got.Labels)
+	}
+}
+
 func TestRunStartsLabelModeTodoIssueInProgress(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

- Keep completed full-autopilot work in its active source lane while PR readiness and the quiet window are evaluated.
- Promote ready, green PRs directly from the active lane to Merging while preserving explicit human-review opt-outs and artifact gates.
- Add label-mode Workpad and direct-promotion regression coverage.

The root cause was that quiet duration was used both as readiness timing and as an implicit Human Review lane selector. Source-lane promotion also rejected every nonzero quiet window.

Fixes #1288

## UI Surface Contract

- [x] N/A; this PR does not change UI surfaces, layout, density, first-viewport behavior, or responsive visibility.
- [x] This PR does not add persistent top-of-screen messaging.
- [x] This PR has no visual changes requiring screenshot or browser verification.

## Test Plan

- [x] Focused completion and direct-promotion regression tests
- [x] `go test ./internal/orchestrator -count=1`
- [x] `make check` (77.4% overall coverage; configured package and file floors pass)