### PR TITLE
fix(claudecode): preserve cancellation on stream-close race

### DIFF
--- a/internal/claudecode/backend_test.go
+++ b/internal/claudecode/backend_test.go
@@ -216,6 +216,47 @@ func TestAgentBackendRunTurnErrorResult(t *testing.T) {
 	}
 }
 
+func TestFinalTurnErrorAfterStreamClose(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		canceled bool
+		state    turnState
+		waitErr  error
+		wantErr  error
+	}{
+		{name: "cancellation takes precedence", canceled: true, waitErr: errors.New("process exited"), wantErr: context.Canceled},
+		{name: "uncanceled missing result", waitErr: errors.New("process exited"), wantErr: ErrMissingResult},
+		{name: "late cancellation preserves success", canceled: true, state: turnState{sawResult: true, resultSubtype: "success"}},
+		{name: "late cancellation preserves result error", canceled: true, state: turnState{sawResult: true, resultIsError: true, resultSubtype: "error_during_execution"}, wantErr: ErrTurnFailed},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			ctx := context.Background()
+			if tt.canceled {
+				var cancel context.CancelFunc
+				ctx, cancel = context.WithCancel(ctx)
+				cancel()
+			}
+
+			err := finalTurnError(ctx, tt.state, tt.waitErr, "")
+			if tt.wantErr == nil {
+				if err != nil {
+					t.Fatalf("finalTurnError() error = %v, want nil", err)
+				}
+				return
+			}
+			if !errors.Is(err, tt.wantErr) {
+				t.Fatalf("finalTurnError() error = %v, want %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
 func TestAgentBackendRunTurnSkipsMalformedLines(t *testing.T) {
 	t.Parallel()
 

--- a/internal/claudecode/capacity_test.go
+++ b/internal/claudecode/capacity_test.go
@@ -1,6 +1,7 @@
 package claudecode
 
 import (
+	"context"
 	"errors"
 	"testing"
 	"time"
@@ -20,7 +21,7 @@ func TestAgentBackendClassifyCapacityError(t *testing.T) {
 		{name: "anthropic overload", err: errors.New("claude turn failed: overloaded_error"), want: true},
 		{name: "http overload", err: errors.New("claude turn failed: HTTP 529"), want: true},
 		{name: "max turns", err: errors.New("claude turn failed: error_max_turns")},
-		{name: "result message", err: finalTurnError(turnState{sawResult: true, resultIsError: true, resultSubtype: "error_during_execution", resultText: "You've hit your limit. Try again at 9:39 PM"}, nil, ""), want: true},
+		{name: "result message", err: finalTurnError(context.Background(), turnState{sawResult: true, resultIsError: true, resultSubtype: "error_during_execution", resultText: "You've hit your limit. Try again at 9:39 PM"}, nil, ""), want: true},
 	}
 
 	for _, tt := range tests {

--- a/internal/claudecode/process.go
+++ b/internal/claudecode/process.go
@@ -85,7 +85,7 @@ func (b *AgentBackend) RunTurn(
 		return result, streamErr
 	}
 
-	finalErr := finalTurnError(state, waitErr, stderr.String())
+	finalErr := finalTurnError(ctx, state, waitErr, stderr.String())
 	status := runner.FinalStateCompleted
 	if finalErr != nil {
 		status = runner.FinalStateFailed
@@ -271,10 +271,15 @@ func waitAndCleanup(cmd *exec.Cmd, processGroupID int) error {
 	return err
 }
 
-func finalTurnError(state turnState, waitErr error, stderr string) error {
-	switch {
-	case !state.sawResult:
+func finalTurnError(ctx context.Context, state turnState, waitErr error, stderr string) error {
+	if !state.sawResult {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
 		return withStderrTail(ErrMissingResult, stderr)
+	}
+
+	switch {
 	case state.resultIsError || !strings.EqualFold(strings.TrimSpace(state.resultSubtype), "success"):
 		subtype := strings.TrimSpace(state.resultSubtype)
 		if subtype == "" {


### PR DESCRIPTION
## Summary

- preserve context cancellation when Claude stream closure wins the finalization race
- cover canceled finalization and uncanceled missing-result behavior deterministically

Fixes #1274

## UI Surface Contract

- [x] N/A, or the linked issue explicitly authorizes any high-impact UI surface, layout, density, first-viewport, or responsive visibility tradeoff.
- [x] Persistent top-of-screen messaging is explicitly authorized by the issue, or this PR does not add it.
- [x] Visual changes to primary operator screens include screenshot or browser verification below.

## Test Plan

- [x] `go test -race ./internal/claudecode -run '^TestFinalTurnErrorAfterStreamClose$' -count=1`
- [x] `go test -race ./internal/claudecode -run '^TestRunTurnCancellationKillsChildProcessGroup$' -count=1`
- [x] `go test -race ./internal/claudecode -count=1`
- [x] `make check`