### PR TITLE
fix(gate): recover failed validator reviews

### DIFF
--- a/README.md
+++ b/README.md
@@ -723,6 +723,7 @@ gate:
     # Watch rework-rate per validator model once cache/model telemetry lands.
     model: ""
     min_score: 0.8
+    max_attempts: 3
     max_inline_diff_bytes: 65536
     block_on:
       - p1
@@ -1125,6 +1126,9 @@ criteria and returns a structured verdict, score, summary, and severity-tagged
 findings. `gate.validator.model` optionally overrides the selected validator
 route model, `min_score` below threshold routes to `Rework`, and any finding
 severity listed in `block_on` routes to `Rework` regardless of score.
+Validator production failures are retried with backoff up to `max_attempts`
+(default `3`). Each failure is logged and visible to `detent doctor`; an
+exhausted validator routes the item to `Rework` with the failure cause.
 For Codex-backed validators, start with the cheap-tier override
 `gate.validator.model: gpt-5.4-mini` and watch rework-rate per validator model
 once cache/model telemetry lands. `gate.validator.max_inline_diff_bytes`

--- a/db/queries/store.sql
+++ b/db/queries/store.sql
@@ -1082,9 +1082,11 @@ INSERT INTO validator_verdicts (
   summary,
   findings_json,
   commented,
+  failure_attempts,
+  next_retry_at,
   recorded_at,
   updated_at
-) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 ON CONFLICT(project_id, issue_id, head_sha) DO UPDATE SET
   identifier = excluded.identifier,
   issue_url = excluded.issue_url,
@@ -1095,6 +1097,8 @@ ON CONFLICT(project_id, issue_id, head_sha) DO UPDATE SET
   summary = excluded.summary,
   findings_json = excluded.findings_json,
   commented = excluded.commented,
+  failure_attempts = excluded.failure_attempts,
+  next_retry_at = excluded.next_retry_at,
   recorded_at = excluded.recorded_at,
   updated_at = excluded.updated_at
 RETURNING *;

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -53,6 +53,7 @@ type doctorCheck struct {
 	AutoPromoteCandidates     []doctorAutoPromoteCandidateDiagnostic     `json:"auto_promote_candidates,omitempty"`
 	BlockedRecoveryCandidates []doctorBlockedRecoveryCandidateDiagnostic `json:"blocked_recovery_candidates,omitempty"`
 	BackendCapacity           []doctorBackendCapacityDiagnostic          `json:"backend_capacity,omitempty"`
+	ValidatorFailures         []doctorValidatorFailureDiagnostic         `json:"validator_failures,omitempty"`
 	OverloadRetriesLastHour   int                                        `json:"overload_retries_last_hour,omitempty"`
 	DependencyCapabilities    []connector.DependencyCapability           `json:"dependency_capabilities,omitempty"`
 	UntrackedIssues           []doctorStatusDriftIssueDiagnostic         `json:"untracked_issues,omitempty"`

--- a/internal/cli/doctor_project.go
+++ b/internal/cli/doctor_project.go
@@ -271,6 +271,10 @@ func checkDoctorProjectWithProgress(
 	if workflow.Config.Agent.AutoPromote.Enabled {
 		setDoctorCurrentCheck("Project " + id + " auto-promote")
 		checks = append(checks, checkDoctorAutoPromote(ctx, id, workflow.Config, deps, time.Now()))
+		if workflow.Config.Gate.Validator.Enabled {
+			setDoctorCurrentCheck("Project " + id + " validator health")
+			checks = append(checks, checkDoctorValidatorHealth(ctx, id, storePath, deps, time.Now()))
+		}
 	}
 	if doctorTrackerUsesGitHubReads(workflow.Config.Tracker.Kind) && workflow.Config.Deliverable.Kind == workflowconfig.DeliverablePullRequest {
 		setDoctorCurrentCheck("Project " + id + " repository merge policy")

--- a/internal/cli/doctor_validator.go
+++ b/internal/cli/doctor_validator.go
@@ -1,0 +1,123 @@
+package cli
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/digitaldrywood/detent/internal/gate"
+)
+
+const doctorValidatorFailureWindow = 24 * time.Hour
+
+type doctorValidatorFailureDiagnostic struct {
+	IssueID        string `json:"issue_id,omitempty"`
+	Identifier     string `json:"identifier,omitempty"`
+	PRNumber       int64  `json:"pr_number,omitempty"`
+	HeadSHA        string `json:"head_sha,omitempty"`
+	Attempts       int64  `json:"attempts"`
+	Summary        string `json:"summary"`
+	NextRetryAt    string `json:"next_retry_at,omitempty"`
+	LastObservedAt string `json:"last_observed_at"`
+}
+
+func checkDoctorValidatorHealth(ctx context.Context, projectID string, storePath string, deps doctorDeps, now time.Time) doctorCheck {
+	name := "Project " + projectID + " validator health"
+	if strings.TrimSpace(storePath) == "" {
+		return doctorCheck{Name: name, Status: doctorOK, Detail: "validator failure telemetry is unavailable without a runtime store"}
+	}
+	deps = deps.withDefaults()
+	db, err := deps.openSQLiteReadOnly(ctx, storePath)
+	if err != nil {
+		if errors.Is(err, errDoctorTelemetryStoreUnavailable) {
+			return doctorCheck{Name: name, Status: doctorOK, Detail: "validator failure telemetry is not available yet"}
+		}
+		return doctorCheck{Name: name, Status: doctorWarn, Detail: fmt.Sprintf("validator failure telemetry could not be read: %v", err)}
+	}
+	failures, queryErr := doctorValidatorFailures(ctx, db, projectID, now)
+	closeErr := db.Close()
+	if queryErr != nil {
+		return doctorCheck{Name: name, Status: doctorWarn, Detail: fmt.Sprintf("validator failure telemetry query failed: %v", queryErr)}
+	}
+	if closeErr != nil {
+		return doctorCheck{Name: name, Status: doctorWarn, Detail: fmt.Sprintf("validator failure telemetry close failed: %v", closeErr)}
+	}
+	if len(failures) == 0 {
+		return doctorCheck{Name: name, Status: doctorOK, Detail: "no validator production failures recorded in the last 24h"}
+	}
+	return doctorCheck{
+		Name:              name,
+		Status:            doctorWarn,
+		Detail:            doctorValidatorFailureDetail(failures),
+		Hint:              "Inspect the validator backend/model and the affected PRs; Detent will retry bounded failures and route exhausted validators to Rework.",
+		ValidatorFailures: failures,
+	}
+}
+
+func doctorValidatorFailures(ctx context.Context, db doctorTelemetryStore, projectID string, now time.Time) ([]doctorValidatorFailureDiagnostic, error) {
+	rows, err := db.QueryContext(ctx, `
+SELECT issue_id,
+       COALESCE(identifier, ''),
+       COALESCE(pr_number, 0),
+       head_sha,
+       failure_attempts,
+       COALESCE(summary, ''),
+       next_retry_at,
+       updated_at
+FROM validator_verdicts
+WHERE project_id = ?
+  AND submitted = 0
+  AND verdict = ?
+  AND datetime(updated_at) >= datetime(?)
+  AND datetime(updated_at) <= datetime(?)
+ORDER BY datetime(updated_at) DESC, id DESC
+LIMIT 5`,
+		strings.TrimSpace(projectID),
+		gate.ValidatorVerdictError,
+		now.Add(-doctorValidatorFailureWindow).UTC().Format(time.RFC3339Nano),
+		now.UTC().Format(time.RFC3339Nano),
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	failures := []doctorValidatorFailureDiagnostic{}
+	for rows.Next() {
+		var failure doctorValidatorFailureDiagnostic
+		var nextRetryAt sql.NullString
+		if err := rows.Scan(
+			&failure.IssueID,
+			&failure.Identifier,
+			&failure.PRNumber,
+			&failure.HeadSHA,
+			&failure.Attempts,
+			&failure.Summary,
+			&nextRetryAt,
+			&failure.LastObservedAt,
+		); err != nil {
+			return nil, err
+		}
+		failure.NextRetryAt = nextRetryAt.String
+		failures = append(failures, failure)
+	}
+	return failures, rows.Err()
+}
+
+func doctorValidatorFailureDetail(failures []doctorValidatorFailureDiagnostic) string {
+	parts := make([]string, 0, len(failures))
+	for _, failure := range failures {
+		issue := strings.TrimSpace(failure.Identifier)
+		if issue == "" {
+			issue = strings.TrimSpace(failure.IssueID)
+		}
+		if failure.PRNumber > 0 {
+			issue += fmt.Sprintf(" PR #%d", failure.PRNumber)
+		}
+		parts = append(parts, fmt.Sprintf("%s attempt %d: %s", issue, failure.Attempts, strings.TrimSpace(failure.Summary)))
+	}
+	return fmt.Sprintf("%d validator production failure(s) in the last 24h: %s", len(failures), strings.Join(parts, "; "))
+}

--- a/internal/cli/doctor_validator_test.go
+++ b/internal/cli/doctor_validator_test.go
@@ -1,0 +1,57 @@
+package cli
+
+import (
+	"context"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/digitaldrywood/detent/internal/gate"
+	"github.com/digitaldrywood/detent/internal/store"
+)
+
+func TestCheckDoctorValidatorHealthReportsProductionFailure(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	now := time.Date(2026, 7, 13, 12, 0, 0, 0, time.UTC)
+	path := filepath.Join(t.TempDir(), "detent.db")
+	backend, err := store.Open(ctx, store.Config{Backend: store.BackendSQLite, Path: path})
+	if err != nil {
+		t.Fatalf("Open() error = %v", err)
+	}
+	prNumber := int64(1298)
+	retryAt := now.Add(time.Minute)
+	if err := backend.RecordValidatorVerdict(ctx, store.ValidatorVerdict{
+		ProjectID:       "detent",
+		IssueID:         "issue-1298",
+		HeadSHA:         "head-1298",
+		Identifier:      "digitaldrywood/detent#1298",
+		PRNumber:        &prNumber,
+		Verdict:         gate.ValidatorVerdictError,
+		Summary:         "validator review production attempt 1/3 failed: empty output",
+		FailureAttempts: 1,
+		NextRetryAt:     &retryAt,
+		RecordedAt:      now,
+		UpdatedAt:       now,
+	}); err != nil {
+		t.Fatalf("RecordValidatorVerdict() error = %v", err)
+	}
+	if err := backend.Close(); err != nil {
+		t.Fatalf("Close() error = %v", err)
+	}
+
+	check := checkDoctorValidatorHealth(ctx, "detent", path, doctorDeps{openSQLiteReadOnly: openDoctorSQLiteReadOnly}, now.Add(time.Second))
+	if check.Status != doctorWarn {
+		t.Fatalf("Status = %q, want %q", check.Status, doctorWarn)
+	}
+	for _, fragment := range []string{"digitaldrywood/detent#1298", "PR #1298", "attempt 1", "empty output"} {
+		if !strings.Contains(check.Detail, fragment) {
+			t.Fatalf("Detail = %q, want %q", check.Detail, fragment)
+		}
+	}
+	if len(check.ValidatorFailures) != 1 || check.ValidatorFailures[0].NextRetryAt == "" {
+		t.Fatalf("ValidatorFailures = %#v", check.ValidatorFailures)
+	}
+}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -2031,6 +2031,7 @@ gate:
     enabled: true
     model: gpt-5-validator
     min_score: 0.85
+    max_attempts: 4
     turn_timeout_ms: 120000
     max_inline_diff_bytes: 32768
     block_on:
@@ -2055,6 +2056,9 @@ Prompt
 	}
 	if validator.MinScore != 0.85 {
 		t.Fatalf("Gate.Validator.MinScore = %v, want 0.85", validator.MinScore)
+	}
+	if validator.MaxAttempts != 4 {
+		t.Fatalf("Gate.Validator.MaxAttempts = %d, want 4", validator.MaxAttempts)
 	}
 	if validator.TurnTimeoutMS != 120000 {
 		t.Fatalf("Gate.Validator.TurnTimeoutMS = %d, want 120000", validator.TurnTimeoutMS)

--- a/internal/gate/gate.go
+++ b/internal/gate/gate.go
@@ -15,6 +15,7 @@ const (
 	DefaultPlanApprovalLabel           = "plan-approved"
 	DefaultPlanStop                    = "Plan Review"
 	DefaultValidatorMinScore           = 0.8
+	DefaultValidatorMaxAttempts        = 3
 	DefaultValidatorMaxInlineDiffBytes = 64 * 1024
 	DefaultArtifactStatusField         = "validation_status"
 	DefaultTransientCIRetries          = 2
@@ -51,6 +52,7 @@ type ValidatorConfig struct {
 	Model              string   `yaml:"model"`
 	MinScore           float64  `yaml:"min_score"`
 	BlockOn            []string `yaml:"block_on"`
+	MaxAttempts        int      `yaml:"max_attempts"`
 	TurnTimeoutMS      int      `yaml:"turn_timeout_ms"`
 	MaxInlineDiffBytes *int     `yaml:"max_inline_diff_bytes"`
 }
@@ -106,6 +108,7 @@ const (
 	ValidatorVerdictPass   = "pass"
 	ValidatorVerdictWait   = "wait"
 	ValidatorVerdictRework = "rework"
+	ValidatorVerdictError  = "error"
 )
 
 type Reason string
@@ -119,6 +122,7 @@ const (
 	ReasonAutomatedReviewNotQuiet      Reason = "automated_review_not_quiet"
 	ReasonHumanApprovalMissing         Reason = "human_approval_missing"
 	ReasonValidatorMissing             Reason = "validator_missing"
+	ReasonValidatorError               Reason = "validator_error"
 	ReasonValidatorWait                Reason = "validator_wait"
 	ReasonValidatorRework              Reason = "validator_rework"
 	ReasonValidatorScoreBelowThreshold Reason = "validator_score_below_threshold"
@@ -406,15 +410,15 @@ func evaluateCommand(cfg Config, summary Summary, now time.Time, opts Evaluation
 		out.Findings = cloneFindings(summary.P1Findings)
 		return out
 	}
+	if out, ok := evaluateValidator(cfg.Validator, summary.Validator); ok {
+		return out
+	}
 	if automatedReviewRequired(cfg) && !automatedReviewSubmitted(summary.ReviewState) {
 		return decision(ActionWait, ReasonAutomatedReviewMissing)
 	}
 	if remaining := quietRemaining(summary, opts, now); remaining > 0 {
 		out := decision(ActionWait, ReasonAutomatedReviewNotQuiet)
 		out.QuietRemaining = remaining
-		return out
-	}
-	if out, ok := evaluateValidator(cfg.Validator, summary.Validator); ok {
 		return out
 	}
 	return decision(ActionPass, ReasonReady)
@@ -546,6 +550,9 @@ func effectiveValidatorConfig(cfg ValidatorConfig) ValidatorConfig {
 	if cfg.MinScore == 0 {
 		cfg.MinScore = DefaultValidatorMinScore
 	}
+	if cfg.MaxAttempts == 0 {
+		cfg.MaxAttempts = DefaultValidatorMaxAttempts
+	}
 	if cfg.MaxInlineDiffBytes == nil {
 		cfg.MaxInlineDiffBytes = newInt(DefaultValidatorMaxInlineDiffBytes)
 	}
@@ -591,6 +598,9 @@ func validateValidator(prefix string, cfg ValidatorConfig) []string {
 	}
 	if cfg.TurnTimeoutMS < 0 {
 		problems = append(problems, prefix+".turn_timeout_ms must be greater than or equal to 0")
+	}
+	if cfg.MaxAttempts < 0 {
+		problems = append(problems, prefix+".max_attempts must be greater than 0")
 	}
 	if cfg.MaxInlineDiffBytes != nil && *cfg.MaxInlineDiffBytes < 0 {
 		problems = append(problems, prefix+".max_inline_diff_bytes must be greater than or equal to 0")
@@ -678,6 +688,11 @@ func evaluateValidator(cfg ValidatorConfig, result ValidatorResult) (Decision, b
 	cfg = effectiveValidatorConfig(cfg)
 	if !cfg.Enabled {
 		return Decision{}, false
+	}
+	if normalizeValidatorVerdict(result.Verdict) == ValidatorVerdictError {
+		out := decision(ActionRework, ReasonValidatorError)
+		out.Findings = cloneFindings(result.Findings)
+		return out, true
 	}
 	if !result.Submitted {
 		return decision(ActionWait, ReasonValidatorMissing), true

--- a/internal/gate/gate_test.go
+++ b/internal/gate/gate_test.go
@@ -300,7 +300,7 @@ func TestEvaluate(t *testing.T) {
 			want:  Decision{Action: ActionWait, Reason: ReasonValidatorMissing},
 		},
 		{
-			name: "validator gate waits for quiet window before requesting validator",
+			name: "validator gate requests validator before quiet window",
 			cfg: Config{
 				Kind:      KindCommand,
 				Validator: ValidatorConfig{Enabled: true, MinScore: 0.8, BlockOn: []string{"p1"}},
@@ -312,7 +312,40 @@ func TestEvaluate(t *testing.T) {
 				LastActivityAt: &recentActivity,
 			},
 			opts: EvaluationOptions{QuietDuration: 10 * time.Minute},
-			want: Decision{Action: ActionWait, Reason: ReasonAutomatedReviewNotQuiet, QuietRemaining: 570 * time.Second},
+			want: Decision{Action: ActionWait, Reason: ReasonValidatorMissing},
+		},
+		{
+			name: "validator gate requests validator before automated review",
+			cfg: Config{
+				Kind:      KindCommand,
+				Validator: ValidatorConfig{Enabled: true},
+			},
+			input: Summary{
+				PullRequestURL: "https://github.test/pull/42",
+				CIStatus:       "green",
+			},
+			want: Decision{Action: ActionWait, Reason: ReasonValidatorMissing},
+		},
+		{
+			name: "validator gate reworks production errors",
+			cfg: Config{
+				Kind:      KindCommand,
+				Validator: ValidatorConfig{Enabled: true},
+			},
+			input: Summary{
+				PullRequestURL: "https://github.test/pull/42",
+				CIStatus:       "green",
+				Validator: ValidatorResult{
+					Verdict:  ValidatorVerdictError,
+					Summary:  "validator review production failed",
+					Findings: []Finding{{Severity: "p1", Body: "validator review production failed"}},
+				},
+			},
+			want: Decision{
+				Action:   ActionRework,
+				Reason:   ReasonValidatorError,
+				Findings: []Finding{{Severity: "p1", Body: "validator review production failed"}},
+			},
 		},
 		{
 			name: "validator gate passes above score threshold",

--- a/internal/orchestrator/autopromote.go
+++ b/internal/orchestrator/autopromote.go
@@ -75,6 +75,7 @@ const (
 	AutoPromoteReasonCodexReviewNotQuiet             AutoPromoteReason = "codex_review_not_quiet"
 	AutoPromoteReasonHumanApprovalMissing            AutoPromoteReason = "human_approval_missing"
 	AutoPromoteReasonValidatorMissing                AutoPromoteReason = "validator_missing"
+	AutoPromoteReasonValidatorError                  AutoPromoteReason = "validator_error"
 	AutoPromoteReasonValidatorWait                   AutoPromoteReason = "validator_wait"
 	AutoPromoteReasonValidatorRework                 AutoPromoteReason = "validator_rework"
 	AutoPromoteReasonValidatorScoreBelowThreshold    AutoPromoteReason = "validator_score_below_threshold"
@@ -843,6 +844,8 @@ func autoPromoteReasonFromGate(reason gate.Reason) AutoPromoteReason {
 		return AutoPromoteReasonHumanApprovalMissing
 	case gate.ReasonValidatorMissing:
 		return AutoPromoteReasonValidatorMissing
+	case gate.ReasonValidatorError:
+		return AutoPromoteReasonValidatorError
 	case gate.ReasonValidatorWait:
 		return AutoPromoteReasonValidatorWait
 	case gate.ReasonValidatorRework:

--- a/internal/orchestrator/autopromote_tick.go
+++ b/internal/orchestrator/autopromote_tick.go
@@ -1536,20 +1536,41 @@ func (o *Orchestrator) clearAutoPromotedIssueDispatchMemory(state *State, issueI
 }
 
 func (o *Orchestrator) startValidatorStage(ctx context.Context, state *State, issue connector.Issue, now time.Time) {
-	if o.validator == nil {
+	identity := validatorStageIdentityForIssue(issue)
+	if identity.Key == "" {
 		if o.logger != nil {
-			o.logger.Warn(
-				"validator stage skipped",
+			o.logger.Error(
+				"validator stage identity unavailable",
 				"issue_id", strings.TrimSpace(issue.ID),
 				"identifier", issue.Identifier,
-				"reason", "validator runner unavailable",
+				"pull_request", pullRequestNumber(issue),
 			)
 		}
 		return
 	}
-
-	identity := validatorStageIdentityForIssue(issue)
-	if identity.Key == "" {
+	validatorConfig := gate.Effective(o.cfg.AutoPromote.Gate).Validator
+	if o.validator == nil {
+		failureErr := errors.New("validator runner unavailable")
+		result := validatorFailureResult(failureErr, validatorConfig.MaxAttempts, validatorConfig.MaxAttempts)
+		result.Summary = "validator review production could not start: " + failureErr.Error()
+		result.Findings[0].Body = result.Summary
+		o.validatorMu.Lock()
+		if o.validatorResults == nil {
+			o.validatorResults = map[string]validatorStageResult{}
+		}
+		o.validatorResults[identity.Key] = validatorStageResult{Result: result}
+		o.validatorMu.Unlock()
+		o.recordValidatorStageOutcome(ctx, issue, identity, result, validatorConfig.MaxAttempts, nil, now.UTC())
+		if o.logger != nil {
+			o.logger.Error(
+				"validator stage unavailable",
+				"issue_id", identity.IssueID,
+				"identifier", issue.Identifier,
+				"pull_request", pullRequestNumber(issue),
+				"head_sha", identity.HeadSHA,
+				"error", failureErr,
+			)
+		}
 		return
 	}
 	if _, _, ok := o.validatorStageResult(ctx, issue); ok {
@@ -1652,23 +1673,38 @@ func (o *Orchestrator) startValidatorStage(ctx context.Context, state *State, is
 				return
 			}
 			attempt := o.validatorFailures[identity.Key].Attempt + 1
-			o.validatorFailures[identity.Key] = validatorStageFailure{
-				Attempt:     attempt,
-				NextRetryAt: completedAt.Add(validatorStageRetryDelay(retryConfig, attempt)),
-				Error:       err.Error(),
+			retryAt := completedAt.Add(validatorStageRetryDelay(retryConfig, attempt))
+			failure := validatorStageFailure{Attempt: attempt, NextRetryAt: retryAt, Error: err.Error()}
+			exhausted := attempt >= validatorConfig.MaxAttempts
+			failureResult := validatorFailureResult(err, attempt, validatorConfig.MaxAttempts)
+			if exhausted {
+				delete(o.validatorFailures, identity.Key)
+				o.validatorResults[identity.Key] = validatorStageResult{Result: failureResult}
+			} else {
+				o.validatorFailures[identity.Key] = failure
 			}
-			failure := o.validatorFailures[identity.Key]
 			o.validatorMu.Unlock()
+			var nextRetryAt *time.Time
+			if !exhausted {
+				nextRetryAt = &retryAt
+			}
+			o.recordValidatorStageOutcome(ctx, issue, identity, failureResult, attempt, nextRetryAt, completedAt)
 			if o.logger != nil {
-				o.logger.Warn(
-					"validator stage failed",
+				attrs := []any{
 					"issue_id", strings.TrimSpace(issue.ID),
 					"identifier", issue.Identifier,
+					"pull_request", pullRequestNumber(issue),
 					"head_sha", identity.HeadSHA,
-					"retry_at", failure.NextRetryAt,
 					"attempt", attempt,
+					"max_attempts", validatorConfig.MaxAttempts,
 					"error", err,
-				)
+				}
+				if exhausted {
+					o.logger.Error("validator stage retries exhausted", attrs...)
+				} else {
+					attrs = append(attrs, "retry_at", failure.NextRetryAt)
+					o.logger.Warn("validator stage failed; retry scheduled", attrs...)
+				}
 			}
 			if capacityProbeKey != "" {
 				o.publishValidatorCapacityEvent(ctx, validatorCapacityEvent{
@@ -1889,6 +1925,27 @@ func (o *Orchestrator) loadValidatorVerdict(ctx context.Context, issue connector
 		}
 		return validatorStageResult{}, false
 	}
+	validatorConfig := gate.Effective(o.cfg.AutoPromote.Gate).Validator
+	if !verdict.Submitted && strings.EqualFold(strings.TrimSpace(verdict.Verdict), gate.ValidatorVerdictError) && verdict.FailureAttempts < validatorConfig.MaxAttempts {
+		nextRetryAt := o.clockNow().UTC()
+		if verdict.NextRetryAt != nil {
+			nextRetryAt = verdict.NextRetryAt.UTC()
+		}
+		o.validatorMu.Lock()
+		if o.validatorFailures == nil {
+			o.validatorFailures = map[string]validatorStageFailure{}
+		}
+		failure := o.validatorFailures[identity.Key]
+		if verdict.FailureAttempts > failure.Attempt {
+			o.validatorFailures[identity.Key] = validatorStageFailure{
+				Attempt:     verdict.FailureAttempts,
+				NextRetryAt: nextRetryAt,
+				Error:       verdict.Summary,
+			}
+		}
+		o.validatorMu.Unlock()
+		return validatorStageResult{}, false
+	}
 	return validatorStageResult{
 		Result: gate.ValidatorResult{
 			Submitted: verdict.Submitted,
@@ -1908,6 +1965,18 @@ func (o *Orchestrator) recordValidatorVerdict(
 	result gate.ValidatorResult,
 	recordedAt time.Time,
 ) {
+	o.recordValidatorStageOutcome(ctx, issue, identity, result, 0, nil, recordedAt)
+}
+
+func (o *Orchestrator) recordValidatorStageOutcome(
+	ctx context.Context,
+	issue connector.Issue,
+	identity validatorStageIdentity,
+	result gate.ValidatorResult,
+	failureAttempts int,
+	nextRetryAt *time.Time,
+	recordedAt time.Time,
+) {
 	if o.validatorMemo == nil {
 		return
 	}
@@ -1915,19 +1984,21 @@ func (o *Orchestrator) recordValidatorVerdict(
 		recordedAt = o.clockNow().UTC()
 	}
 	if err := o.validatorMemo.RecordValidatorVerdict(ctx, store.ValidatorVerdict{
-		ProjectID:  o.workflowMetricsProjectID(),
-		IssueID:    identity.IssueID,
-		HeadSHA:    identity.HeadSHA,
-		Identifier: issue.Identifier,
-		IssueURL:   issue.URL,
-		PRNumber:   workflowMetricsPRNumber(issue),
-		Submitted:  result.Submitted,
-		Verdict:    result.Verdict,
-		Score:      result.Score,
-		Summary:    result.Summary,
-		Findings:   storeFindingsFromGate(result.Findings),
-		RecordedAt: recordedAt,
-		UpdatedAt:  recordedAt,
+		ProjectID:       o.workflowMetricsProjectID(),
+		IssueID:         identity.IssueID,
+		HeadSHA:         identity.HeadSHA,
+		Identifier:      issue.Identifier,
+		IssueURL:        issue.URL,
+		PRNumber:        workflowMetricsPRNumber(issue),
+		Submitted:       result.Submitted,
+		Verdict:         result.Verdict,
+		Score:           result.Score,
+		Summary:         result.Summary,
+		Findings:        storeFindingsFromGate(result.Findings),
+		FailureAttempts: failureAttempts,
+		NextRetryAt:     nextRetryAt,
+		RecordedAt:      recordedAt,
+		UpdatedAt:       recordedAt,
 	}); err != nil && o.logger != nil {
 		o.logger.Warn(
 			"validator verdict persistence failed",
@@ -1936,6 +2007,27 @@ func (o *Orchestrator) recordValidatorVerdict(
 			"head_sha", identity.HeadSHA,
 			"error", err,
 		)
+	}
+}
+
+func validatorFailureResult(err error, attempt int, maxAttempts int) gate.ValidatorResult {
+	if attempt < 1 {
+		attempt = 1
+	}
+	if maxAttempts < 1 {
+		maxAttempts = gate.DefaultValidatorMaxAttempts
+	}
+	summary := fmt.Sprintf("validator review production attempt %d/%d failed: %v", attempt, maxAttempts, err)
+	if attempt >= maxAttempts {
+		summary = fmt.Sprintf("validator review production failed after %d attempts: %v", attempt, err)
+	}
+	return gate.ValidatorResult{
+		Verdict: gate.ValidatorVerdictError,
+		Summary: summary,
+		Findings: []gate.Finding{{
+			Severity: "p1",
+			Body:     summary,
+		}},
 	}
 }
 

--- a/internal/orchestrator/autopromote_tick_test.go
+++ b/internal/orchestrator/autopromote_tick_test.go
@@ -2436,6 +2436,91 @@ func TestTickAutoPromoteRunsValidatorStage(t *testing.T) {
 	}
 }
 
+func TestTickAutoPromoteStartsValidatorBeforeAutomatedReview(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 7, 13, 10, 0, 0, 0, time.UTC)
+	cfg := autoPromoteValidatorTestConfig()
+	issue := autoPromoteTickIssue("issue-validator-no-review", []string{"bug"}, &connector.PullRequest{
+		Number:     1298,
+		URL:        "https://github.test/digitaldrywood/detent/pull/1298",
+		BranchName: "detent/digitaldrywood_detent_1298",
+		HeadSHA:    "head-validator-no-review",
+		State:      "OPEN",
+		CIStatus:   "success",
+	})
+	tracker := &autoPromoteTickConnector{stateIssues: []connector.Issue{issue}}
+	validator := &autoPromoteTickValidator{
+		result: gate.ValidatorResult{
+			Submitted: true,
+			Verdict:   gate.ValidatorVerdictPass,
+			Score:     0.95,
+		},
+	}
+	orch := &Orchestrator{
+		cfg:       cfg,
+		connector: tracker,
+		validator: validator,
+		logger:    slog.New(slog.NewTextHandler(io.Discard, nil)),
+	}
+	state := newState(cfg)
+
+	orch.tick(t.Context(), &state, now)
+
+	waitForValidatorRequests(t, validator, 1)
+	if got := state.AutoPromoteDecisions[issue.ID].Reason; got != AutoPromoteReasonValidatorMissing {
+		t.Fatalf("auto-promote reason = %q, want %q", got, AutoPromoteReasonValidatorMissing)
+	}
+}
+
+func TestTickAutoPromoteValidatorUnavailableRoutesRework(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	memo := openValidatorMemoStore(t)
+	now := time.Date(2026, 7, 13, 10, 30, 0, 0, time.UTC)
+	cfg := autoPromoteValidatorTestConfig()
+	issue := autoPromoteTickIssue("issue-validator-unavailable", []string{"bug"}, &connector.PullRequest{
+		Number:     1299,
+		URL:        "https://github.test/digitaldrywood/detent/pull/1299",
+		BranchName: "detent/digitaldrywood_detent_1299",
+		HeadSHA:    "head-validator-unavailable",
+		State:      "OPEN",
+		CIStatus:   "success",
+	})
+	tracker := &autoPromoteTickConnector{stateIssues: []connector.Issue{issue}}
+	var logs strings.Builder
+	orch := &Orchestrator{
+		cfg:           cfg,
+		connector:     tracker,
+		validatorMemo: memo,
+		logger:        slog.New(slog.NewTextHandler(&logs, nil)),
+		now:           func() time.Time { return now },
+	}
+	state := newState(cfg)
+
+	orch.tick(ctx, &state, now)
+	waitForValidatorResult(t, orch, issue)
+	verdict := waitForPersistedValidatorFailure(t, memo, store.ValidatorVerdictKey{
+		ProjectID: "detent",
+		IssueID:   issue.ID,
+		HeadSHA:   issue.PullRequest.HeadSHA,
+	}, gate.DefaultValidatorMaxAttempts)
+	if verdict.Summary != "validator review production could not start: validator runner unavailable" {
+		t.Fatalf("validator summary = %q", verdict.Summary)
+	}
+
+	orch.tick(ctx, &state, now.Add(time.Second))
+	if got, want := tracker.updates, []autoPromoteTickUpdate{{issueID: issue.ID, state: "Rework"}}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("updates = %#v, want %#v", got, want)
+	}
+	for _, fragment := range []string{"validator stage unavailable", "issue_id=issue-validator-unavailable", "pull_request=1299"} {
+		if !strings.Contains(logs.String(), fragment) {
+			t.Fatalf("logs missing %q:\n%s", fragment, logs.String())
+		}
+	}
+}
+
 func TestTickAutoPromoteUsesPersistedValidatorVerdictAfterRestart(t *testing.T) {
 	t.Parallel()
 
@@ -2630,6 +2715,83 @@ func TestTickAutoPromoteValidatorFailureBackoff(t *testing.T) {
 	clock.Set(resumeAt)
 	orch.tick(ctx, &state, resumeAt)
 	waitForValidatorRequests(t, validator, 2)
+}
+
+func TestTickAutoPromoteValidatorFailureExhaustionRoutesRework(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	memo := openValidatorMemoStore(t)
+	clock := newAutoPromoteTickClock(time.Date(2026, 7, 13, 11, 0, 0, 0, time.UTC))
+	cfg := autoPromoteValidatorTestConfig()
+	cfg.FailureRetryBaseDelay = time.Second
+	cfg.MaxRetryBackoff = time.Second
+	issue := autoPromoteTickIssue("issue-validator-exhausted", []string{"bug"}, &connector.PullRequest{
+		Number:     1298,
+		URL:        "https://github.test/digitaldrywood/detent/pull/1298",
+		BranchName: "detent/digitaldrywood_detent_1298",
+		HeadSHA:    "head-validator-exhausted",
+		State:      "OPEN",
+		CIStatus:   "success",
+	})
+	tracker := &autoPromoteTickConnector{stateIssues: []connector.Issue{issue}}
+	validator := &autoPromoteTickValidator{err: errors.New("validator returned no output")}
+	var logs strings.Builder
+	orch := &Orchestrator{
+		cfg:           cfg,
+		connector:     tracker,
+		validator:     validator,
+		validatorMemo: memo,
+		logger:        slog.New(slog.NewTextHandler(&logs, nil)),
+		now:           clock.Now,
+	}
+	state := newState(cfg)
+	key := store.ValidatorVerdictKey{
+		ProjectID: "detent",
+		IssueID:   issue.ID,
+		HeadSHA:   issue.PullRequest.HeadSHA,
+	}
+
+	orch.tick(ctx, &state, clock.Now())
+	failure := waitForValidatorFailure(t, orch, issue, 1)
+	first := waitForPersistedValidatorFailure(t, memo, key, 1)
+	if first.Verdict != gate.ValidatorVerdictError || first.Submitted || first.NextRetryAt == nil {
+		t.Fatalf("first persisted validator failure = %#v", first)
+	}
+
+	clock.Set(failure.NextRetryAt)
+	orch.tick(ctx, &state, clock.Now())
+	failure = waitForValidatorFailure(t, orch, issue, 2)
+	waitForPersistedValidatorFailure(t, memo, key, 2)
+
+	clock.Set(failure.NextRetryAt)
+	orch.tick(ctx, &state, clock.Now())
+	waitForValidatorRequests(t, validator, gate.DefaultValidatorMaxAttempts)
+	waitForValidatorResult(t, orch, issue)
+	exhausted := waitForPersistedValidatorFailure(t, memo, key, gate.DefaultValidatorMaxAttempts)
+	if exhausted.NextRetryAt != nil {
+		t.Fatalf("exhausted validator retry_at = %s, want nil", exhausted.NextRetryAt)
+	}
+
+	clock.Set(clock.Now().Add(time.Second))
+	orch.tick(ctx, &state, clock.Now())
+	if got, want := tracker.updates, []autoPromoteTickUpdate{{issueID: issue.ID, state: "Rework"}}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("updates = %#v, want %#v", got, want)
+	}
+	for _, fragment := range []string{
+		"validator stage failed; retry scheduled",
+		"validator stage retries exhausted",
+		"issue_id=issue-validator-exhausted",
+		"pull_request=1298",
+		"validator returned no output",
+	} {
+		if !strings.Contains(logs.String(), fragment) {
+			t.Fatalf("logs missing %q:\n%s", fragment, logs.String())
+		}
+	}
+	if len(tracker.prComments) != 1 || !strings.Contains(tracker.prComments[0].body, "Validator verdict: error") {
+		t.Fatalf("pull request comments = %#v, want validator error", tracker.prComments)
+	}
 }
 
 func TestTickAutoPromoteRecordsValidatorReworkHandoff(t *testing.T) {
@@ -5008,6 +5170,24 @@ func waitForPersistedValidatorVerdict(t *testing.T, memo store.ValidatorMemoStor
 		time.Sleep(time.Millisecond)
 	}
 	t.Fatalf("validator verdict was not persisted for %#v", key)
+}
+
+func waitForPersistedValidatorFailure(t *testing.T, memo store.ValidatorMemoStore, key store.ValidatorVerdictKey, attempt int) store.ValidatorVerdict {
+	t.Helper()
+
+	deadline := time.Now().Add(time.Second)
+	for time.Now().Before(deadline) {
+		verdict, err := memo.ValidatorVerdict(t.Context(), key)
+		if err == nil && verdict.FailureAttempts >= attempt {
+			return verdict
+		}
+		if err != nil && !errors.Is(err, store.ErrNotFound) {
+			t.Fatalf("ValidatorVerdict() error = %v", err)
+		}
+		time.Sleep(time.Millisecond)
+	}
+	t.Fatalf("persisted validator failure attempt %d was not recorded", attempt)
+	return store.ValidatorVerdict{}
 }
 
 func waitForValidatorFailure(t *testing.T, orch *Orchestrator, issue connector.Issue, attempt int) validatorStageFailure {

--- a/internal/runner/prompt.go
+++ b/internal/runner/prompt.go
@@ -744,7 +744,7 @@ func appendPriorAttemptBlock(prompt string, prior PriorAttempt) string {
 		b.WriteString("\n- failing gate reason: ")
 		b.WriteString(reason)
 	}
-	if prior.Validator.Submitted {
+	if prior.Validator.Submitted || strings.TrimSpace(prior.Validator.Verdict) != "" || strings.TrimSpace(prior.Validator.Summary) != "" || len(prior.Validator.Findings) > 0 {
 		b.WriteString("\n- validator verdict: ")
 		b.WriteString(strings.TrimSpace(prior.Validator.Verdict))
 		if prior.Validator.Score > 0 {
@@ -867,6 +867,7 @@ func gateAssigns(cfg gate.Config) map[string]any {
 			"model":                 effective.Validator.Model,
 			"min_score":             effective.Validator.MinScore,
 			"block_on":              effective.Validator.BlockOn,
+			"max_attempts":          effective.Validator.MaxAttempts,
 			"max_inline_diff_bytes": validatorMaxInlineDiffBytes(effective.Validator),
 		},
 	}

--- a/internal/runner/runner_test.go
+++ b/internal/runner/runner_test.go
@@ -2755,6 +2755,28 @@ func TestRunnerValidateUsesValidatorRouteModelOverrideAndParsesJSON(t *testing.T
 	}
 }
 
+func TestParseValidatorResultRejectsMissingOutput(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		output string
+	}{
+		{name: "empty", output: ""},
+		{name: "whitespace", output: " \n\t"},
+		{name: "prose without verdict", output: "The change looks good."},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			if _, err := parseValidatorResult(tt.output); err == nil {
+				t.Fatal("parseValidatorResult() error = nil, want missing JSON error")
+			}
+		})
+	}
+}
+
 func TestRunnerUpdateWorkflowAppliesToFutureRuns(t *testing.T) {
 	t.Parallel()
 

--- a/internal/store/migrations/00020_add_validator_failure_state.sql
+++ b/internal/store/migrations/00020_add_validator_failure_state.sql
@@ -1,0 +1,7 @@
+-- +goose Up
+ALTER TABLE validator_verdicts ADD COLUMN failure_attempts INTEGER NOT NULL DEFAULT 0;
+ALTER TABLE validator_verdicts ADD COLUMN next_retry_at TEXT;
+
+-- +goose Down
+ALTER TABLE validator_verdicts DROP COLUMN next_retry_at;
+ALTER TABLE validator_verdicts DROP COLUMN failure_attempts;

--- a/internal/store/sqlc/models.go
+++ b/internal/store/sqlc/models.go
@@ -203,21 +203,23 @@ type UsageEvent struct {
 }
 
 type ValidatorVerdict struct {
-	ID           int64          `json:"id"`
-	ProjectID    string         `json:"project_id"`
-	IssueID      string         `json:"issue_id"`
-	HeadSha      string         `json:"head_sha"`
-	Identifier   sql.NullString `json:"identifier"`
-	IssueURL     sql.NullString `json:"issue_url"`
-	PrNumber     sql.NullInt64  `json:"pr_number"`
-	Submitted    int64          `json:"submitted"`
-	Verdict      string         `json:"verdict"`
-	Score        float64        `json:"score"`
-	Summary      sql.NullString `json:"summary"`
-	FindingsJson string         `json:"findings_json"`
-	Commented    int64          `json:"commented"`
-	RecordedAt   string         `json:"recorded_at"`
-	UpdatedAt    string         `json:"updated_at"`
+	ID              int64          `json:"id"`
+	ProjectID       string         `json:"project_id"`
+	IssueID         string         `json:"issue_id"`
+	HeadSha         string         `json:"head_sha"`
+	Identifier      sql.NullString `json:"identifier"`
+	IssueURL        sql.NullString `json:"issue_url"`
+	PrNumber        sql.NullInt64  `json:"pr_number"`
+	Submitted       int64          `json:"submitted"`
+	Verdict         string         `json:"verdict"`
+	Score           float64        `json:"score"`
+	Summary         sql.NullString `json:"summary"`
+	FindingsJson    string         `json:"findings_json"`
+	Commented       int64          `json:"commented"`
+	RecordedAt      string         `json:"recorded_at"`
+	UpdatedAt       string         `json:"updated_at"`
+	FailureAttempts int64          `json:"failure_attempts"`
+	NextRetryAt     sql.NullString `json:"next_retry_at"`
 }
 
 type WorkAttempt struct {

--- a/internal/store/sqlc/store.sql.go
+++ b/internal/store/sqlc/store.sql.go
@@ -1758,7 +1758,7 @@ func (q *Queries) GetUsageEvent(ctx context.Context, id int64) (UsageEvent, erro
 }
 
 const getValidatorVerdict = `-- name: GetValidatorVerdict :one
-SELECT id, project_id, issue_id, head_sha, identifier, issue_url, pr_number, submitted, verdict, score, summary, findings_json, commented, recorded_at, updated_at
+SELECT id, project_id, issue_id, head_sha, identifier, issue_url, pr_number, submitted, verdict, score, summary, findings_json, commented, recorded_at, updated_at, failure_attempts, next_retry_at
 FROM validator_verdicts
 WHERE project_id = ?
   AND issue_id = ?
@@ -1790,6 +1790,8 @@ func (q *Queries) GetValidatorVerdict(ctx context.Context, arg GetValidatorVerdi
 		&i.Commented,
 		&i.RecordedAt,
 		&i.UpdatedAt,
+		&i.FailureAttempts,
+		&i.NextRetryAt,
 	)
 	return i, err
 }
@@ -2946,7 +2948,7 @@ func (q *Queries) ListRecentTerminalWorkAttempts(ctx context.Context, arg ListRe
 }
 
 const listValidatorVerdicts = `-- name: ListValidatorVerdicts :many
-SELECT id, project_id, issue_id, head_sha, identifier, issue_url, pr_number, submitted, verdict, score, summary, findings_json, commented, recorded_at, updated_at
+SELECT id, project_id, issue_id, head_sha, identifier, issue_url, pr_number, submitted, verdict, score, summary, findings_json, commented, recorded_at, updated_at, failure_attempts, next_retry_at
 FROM validator_verdicts
 WHERE (?1 = '' OR project_id = ?1)
   AND (?2 IS NULL OR updated_at >= ?2)
@@ -2985,6 +2987,8 @@ func (q *Queries) ListValidatorVerdicts(ctx context.Context, arg ListValidatorVe
 			&i.Commented,
 			&i.RecordedAt,
 			&i.UpdatedAt,
+			&i.FailureAttempts,
+			&i.NextRetryAt,
 		); err != nil {
 			return nil, err
 		}
@@ -3847,9 +3851,11 @@ INSERT INTO validator_verdicts (
   summary,
   findings_json,
   commented,
+  failure_attempts,
+  next_retry_at,
   recorded_at,
   updated_at
-) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 ON CONFLICT(project_id, issue_id, head_sha) DO UPDATE SET
   identifier = excluded.identifier,
   issue_url = excluded.issue_url,
@@ -3860,26 +3866,30 @@ ON CONFLICT(project_id, issue_id, head_sha) DO UPDATE SET
   summary = excluded.summary,
   findings_json = excluded.findings_json,
   commented = excluded.commented,
+  failure_attempts = excluded.failure_attempts,
+  next_retry_at = excluded.next_retry_at,
   recorded_at = excluded.recorded_at,
   updated_at = excluded.updated_at
-RETURNING id, project_id, issue_id, head_sha, identifier, issue_url, pr_number, submitted, verdict, score, summary, findings_json, commented, recorded_at, updated_at
+RETURNING id, project_id, issue_id, head_sha, identifier, issue_url, pr_number, submitted, verdict, score, summary, findings_json, commented, recorded_at, updated_at, failure_attempts, next_retry_at
 `
 
 type UpsertValidatorVerdictParams struct {
-	ProjectID    string         `json:"project_id"`
-	IssueID      string         `json:"issue_id"`
-	HeadSha      string         `json:"head_sha"`
-	Identifier   sql.NullString `json:"identifier"`
-	IssueURL     sql.NullString `json:"issue_url"`
-	PrNumber     sql.NullInt64  `json:"pr_number"`
-	Submitted    int64          `json:"submitted"`
-	Verdict      string         `json:"verdict"`
-	Score        float64        `json:"score"`
-	Summary      sql.NullString `json:"summary"`
-	FindingsJson string         `json:"findings_json"`
-	Commented    int64          `json:"commented"`
-	RecordedAt   string         `json:"recorded_at"`
-	UpdatedAt    string         `json:"updated_at"`
+	ProjectID       string         `json:"project_id"`
+	IssueID         string         `json:"issue_id"`
+	HeadSha         string         `json:"head_sha"`
+	Identifier      sql.NullString `json:"identifier"`
+	IssueURL        sql.NullString `json:"issue_url"`
+	PrNumber        sql.NullInt64  `json:"pr_number"`
+	Submitted       int64          `json:"submitted"`
+	Verdict         string         `json:"verdict"`
+	Score           float64        `json:"score"`
+	Summary         sql.NullString `json:"summary"`
+	FindingsJson    string         `json:"findings_json"`
+	Commented       int64          `json:"commented"`
+	FailureAttempts int64          `json:"failure_attempts"`
+	NextRetryAt     sql.NullString `json:"next_retry_at"`
+	RecordedAt      string         `json:"recorded_at"`
+	UpdatedAt       string         `json:"updated_at"`
 }
 
 func (q *Queries) UpsertValidatorVerdict(ctx context.Context, arg UpsertValidatorVerdictParams) (ValidatorVerdict, error) {
@@ -3896,6 +3906,8 @@ func (q *Queries) UpsertValidatorVerdict(ctx context.Context, arg UpsertValidato
 		arg.Summary,
 		arg.FindingsJson,
 		arg.Commented,
+		arg.FailureAttempts,
+		arg.NextRetryAt,
 		arg.RecordedAt,
 		arg.UpdatedAt,
 	)
@@ -3916,6 +3928,8 @@ func (q *Queries) UpsertValidatorVerdict(ctx context.Context, arg UpsertValidato
 		&i.Commented,
 		&i.RecordedAt,
 		&i.UpdatedAt,
+		&i.FailureAttempts,
+		&i.NextRetryAt,
 	)
 	return i, err
 }

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -493,20 +493,22 @@ type ValidatorFinding struct {
 }
 
 type ValidatorVerdict struct {
-	ProjectID  string
-	IssueID    string
-	HeadSHA    string
-	Identifier string
-	IssueURL   string
-	PRNumber   *int64
-	Submitted  bool
-	Verdict    string
-	Score      float64
-	Summary    string
-	Findings   []ValidatorFinding
-	Commented  bool
-	RecordedAt time.Time
-	UpdatedAt  time.Time
+	ProjectID       string
+	IssueID         string
+	HeadSHA         string
+	Identifier      string
+	IssueURL        string
+	PRNumber        *int64
+	Submitted       bool
+	Verdict         string
+	Score           float64
+	Summary         string
+	Findings        []ValidatorFinding
+	Commented       bool
+	FailureAttempts int
+	NextRetryAt     *time.Time
+	RecordedAt      time.Time
+	UpdatedAt       time.Time
 }
 
 type WorkAttempt struct {

--- a/internal/store/validator_memo.go
+++ b/internal/store/validator_memo.go
@@ -41,22 +41,28 @@ func (s *sqliteStore) RecordValidatorVerdict(ctx context.Context, attrs Validato
 	if err != nil {
 		return err
 	}
+	nextRetryAt, err := nullableTimestamp("next_retry_at", attrs.NextRetryAt)
+	if err != nil {
+		return err
+	}
 
 	if _, err := s.queries.UpsertValidatorVerdict(ctx, sqlc.UpsertValidatorVerdictParams{
-		ProjectID:    projectID,
-		IssueID:      issueID,
-		HeadSha:      headSHA,
-		Identifier:   nullString(attrs.Identifier),
-		IssueURL:     nullString(attrs.IssueURL),
-		PrNumber:     nullOptionalInt64(attrs.PRNumber),
-		Submitted:    boolInt64(attrs.Submitted),
-		Verdict:      strings.TrimSpace(attrs.Verdict),
-		Score:        nonNegativeFloat(attrs.Score),
-		Summary:      nullString(attrs.Summary),
-		FindingsJson: findingsJSON,
-		Commented:    boolInt64(attrs.Commented),
-		RecordedAt:   recordedAt,
-		UpdatedAt:    updatedAt,
+		ProjectID:       projectID,
+		IssueID:         issueID,
+		HeadSha:         headSHA,
+		Identifier:      nullString(attrs.Identifier),
+		IssueURL:        nullString(attrs.IssueURL),
+		PrNumber:        nullOptionalInt64(attrs.PRNumber),
+		Submitted:       boolInt64(attrs.Submitted),
+		Verdict:         strings.TrimSpace(attrs.Verdict),
+		Score:           nonNegativeFloat(attrs.Score),
+		Summary:         nullString(attrs.Summary),
+		FindingsJson:    findingsJSON,
+		Commented:       boolInt64(attrs.Commented),
+		FailureAttempts: int64(max(attrs.FailureAttempts, 0)),
+		NextRetryAt:     nextRetryAt,
+		RecordedAt:      recordedAt,
+		UpdatedAt:       updatedAt,
 	}); err != nil {
 		return fmt.Errorf("recording validator verdict: %w", err)
 	}
@@ -172,20 +178,22 @@ func validatorVerdictFromRow(row sqlc.ValidatorVerdict) (ValidatorVerdict, error
 	}
 
 	return ValidatorVerdict{
-		ProjectID:  row.ProjectID,
-		IssueID:    row.IssueID,
-		HeadSHA:    row.HeadSha,
-		Identifier: row.Identifier.String,
-		IssueURL:   row.IssueURL.String,
-		PRNumber:   optionalInt64Pointer(row.PrNumber),
-		Submitted:  row.Submitted != 0,
-		Verdict:    row.Verdict,
-		Score:      nonNegativeFloat(row.Score),
-		Summary:    row.Summary.String,
-		Findings:   findings,
-		Commented:  row.Commented != 0,
-		RecordedAt: recordedAt.UTC(),
-		UpdatedAt:  updatedAt.UTC(),
+		ProjectID:       row.ProjectID,
+		IssueID:         row.IssueID,
+		HeadSHA:         row.HeadSha,
+		Identifier:      row.Identifier.String,
+		IssueURL:        row.IssueURL.String,
+		PRNumber:        optionalInt64Pointer(row.PrNumber),
+		Submitted:       row.Submitted != 0,
+		Verdict:         row.Verdict,
+		Score:           nonNegativeFloat(row.Score),
+		Summary:         row.Summary.String,
+		Findings:        findings,
+		Commented:       row.Commented != 0,
+		FailureAttempts: int(row.FailureAttempts),
+		NextRetryAt:     nullableTime(row.NextRetryAt),
+		RecordedAt:      recordedAt.UTC(),
+		UpdatedAt:       updatedAt.UTC(),
 	}, nil
 }
 


### PR DESCRIPTION
## Summary

- run the built-in validator before independent automated-review and quiet-window waits so a missing formal GitHub review cannot mask validator production
- persist validator failures and retry deadlines, retry with bounded backoff, and route exhausted or unavailable validators to Rework with an actionable `validator_error`
- add a project-scoped doctor warning for recent validator production failures and document `gate.validator.max_attempts`

Root cause: command-gate evaluation returned `automated_review_missing` before evaluating the built-in validator, while the orchestrator only launched the validator for `validator_missing`. This latent ordering bug was introduced with the validator stage in #599; it was not a v0.34.0/v0.35.0 regression. When formal GitHub reviews stopped arriving, validator production became unreachable and silent.

Fixes #1298

## UI Surface Contract

- [x] N/A, or the linked issue explicitly authorizes any high-impact UI surface, layout, density, first-viewport, or responsive visibility tradeoff.
- [x] Persistent top-of-screen messaging is explicitly authorized by the issue, or this PR does not add it.
- [x] Visual changes to primary operator screens include screenshot or browser verification below.

## Test Plan

- [x] `make generate`
- [x] `make check`
- [x] regression coverage for masked, unavailable, retrying, exhausted, persisted, and empty-output validators
