### PR TITLE
feat(gate): add optional automated review

### DIFF
--- a/README.md
+++ b/README.md
@@ -695,6 +695,7 @@ agent:
     allowed_issue_labels: []
     gate_wait_state: review
     gate_wait_timeout_seconds: 3600
+    gate_wait_timeout_action: human_review
     rework_limit: 3
   skills:
     enabled: true
@@ -713,7 +714,7 @@ codex:
 gate:
   kind: command
   run: make check
-  require_automated_review: true
+  automated_review: required
   required_status_checks: []
   ci_failure_action: rework
   transient_ci_retry_limit: 2
@@ -1105,9 +1106,11 @@ counts for every enabled project. ProjectV2 trackers must set
 Omitting it preserves the code default: `kind: command` with `run: make check`,
 plus green CI, no P1 automated PR review findings, a quiet window, and a
 current-head automated PR review before auto-promotion. Set
-`require_automated_review: false` on a command gate when the workflow should
-auto-promote from `Human Review` after a linked open PR, green CI, no P1 bot
-review findings, and the quiet period. The quiet period resets on observed
+`automated_review: optional` to wait through
+`agent.auto_promote.gate_wait_timeout_seconds` and then continue to `Merging`
+when the remaining checks pass. Set `automated_review: off` to skip that wait.
+The legacy `require_automated_review` boolean remains accepted and maps `true`
+to `required` and `false` to `off`. The quiet period resets on observed
 issue updates, Project status updates, automated PR review submission, and
 linked PR activity such as a fresh push to the PR head. Failed or cancelled
 current-head CI moves a `Human Review` item back to
@@ -1770,9 +1773,10 @@ of that state is controlled by the workflow:
 - `gate.kind: command` requires a linked open PR, green CI, no P1 automated PR
   review findings, and the configured quiet period. By default it also requires
   a current-head automated GitHub PR review.
-- `gate.kind: command` with `require_automated_review: false` keeps the linked
-  PR, green CI, no-P1, and quiet-period checks but does not require a bot PR
-  review to exist.
+- `gate.automated_review: optional` waits for a current-head review until the
+  gate deadline, honors any review that arrives, and then promotes without one
+  when the remaining checks pass. `off` does not wait; `required` waits and
+  defaults to a Human Review timeout.
 - `gate.required_status_checks` names release-blocking check runs or commit
   status contexts that must be present, completed, and successful on the current
   PR head.
@@ -1796,7 +1800,9 @@ of that state is controlled by the workflow:
   active issues in their current lane while CI/check gates are still pending;
   `review` restores the legacy behavior of parking those pending issues in the
   configured review source state. `gate_wait_timeout_seconds` bounds that active
-  wait and moves overdue items to review with an audit comment.
+  wait. `gate_wait_timeout_action: merge | human_review` makes the terminal
+  action explicit; it defaults to `merge` for optional review and
+  `human_review` for required review.
 - `gate.kind: human_review` requires a linked open PR plus the configured
   `approval_label` on the issue.
 
@@ -1812,7 +1818,9 @@ accidental bypass.
 A Codex coding session that created the PR is not the same signal as a
 Codex/ChatGPT/Claude GitHub PR review. If automated PR review is required and
 the PR head changes after a review, request or wait for a fresh automated review
-before expecting auto-promotion.
+before expecting auto-promotion. `detent doctor` warns when required or optional
+review is configured but none of the sampled recent merged PRs has an automated
+review, which indicates the review producer may be inactive.
 
 ### Set up status
 

--- a/docs/ONBOARDING.md
+++ b/docs/ONBOARDING.md
@@ -1302,14 +1302,17 @@ probes.
 
    For criteria-based auto-promote, use `agent.auto_promote.enabled`,
    `quiet_seconds`, `optout_label`, `allowed_issue_labels`, `gate_wait_state`,
-   `gate_wait_timeout_seconds`, and the top-level command gate's
-   `require_automated_review` setting. `quiet_seconds` is the quiet period after
+   `gate_wait_timeout_seconds`, `gate_wait_timeout_action`, and the top-level
+   command gate's `automated_review` setting. `quiet_seconds` is the quiet period after
    observed issue/status/review activity and linked PR activity such as a fresh
    push to the PR head, `optout_label` is the per-issue escape hatch,
    `allowed_issue_labels` is an allowlist such as `documentation` for low-risk
    issue classes, and `gate_wait_state: source` keeps zero-quiet completed work
    in its active lane while checks are pending until
-   `gate_wait_timeout_seconds` expires. When automated review is required, a
+   `gate_wait_timeout_seconds` expires. `automated_review: optional` defaults
+   the timeout action to `merge`; `required` defaults it to `human_review`.
+   The legacy `require_automated_review` boolean maps to `required` or `off`.
+   When automated review is required, a
    Codex/ChatGPT/Claude review on an older commit does not clear this gate.
    Verify:
 
@@ -2196,15 +2199,16 @@ awk 'NF {last=$0} END {exit last == "MUTATION_CONFIRMED=true" ? 0 : 1}' "$ONBOAR
          - <allowed-label>
        gate_wait_state: <source-or-review>
        gate_wait_timeout_seconds: <positive-seconds>
+       gate_wait_timeout_action: <merge-or-human_review>
        rework_limit: <0-to-disable-or-max-rework-laps>
    ```
 
    For a command gate, auto-promote requires a linked open PR, green CI, no P1
-   automated PR review findings, and the configured quiet period. With
-   `require_automated_review: true`, it also requires a current-head automated
-   GitHub PR review. With `require_automated_review: false`, bot PR review is
-   not required to exist, but any observed P1 bot findings still route the item
-   to `Rework`. `gate.required_status_checks` should list every
+   automated PR review findings, and the configured quiet period.
+   `automated_review: required` requires a current-head automated GitHub PR
+   review. `optional` waits until the gate deadline and then promotes if every
+   other check passes; `off` does not wait. Any observed P1 bot findings still
+   route the item to `Rework`. `gate.required_status_checks` should list every
    release-blocking branch-protection or ruleset check name; Detent treats
    missing, skipped, failed, cancelled, neutral, or still-running required
    checks as non-green on the current PR head. Failed or cancelled current-head
@@ -2221,7 +2225,8 @@ awk 'NF {last=$0} END {exit last == "MUTATION_CONFIRMED=true" ? 0 : 1}' "$ONBOAR
    auto-promotion; scores below `min_score` or findings whose severity appears
    in `block_on` route the item to `Rework`. `detent doctor --port 0` reports sampled
    `Human Review` candidates and reasons such as `automated_review_missing`
-   when that gate is not met.
+   when that gate is not met, and warns when recent merged PRs show no automated
+   reviews for a project configured to expect them.
 
    Keep `agent.max_session_context_multiplier` absent unless the operator
    explicitly requested the coarse ceiling. Use `agent.max_session_tokens` as

--- a/internal/cli/doctor_autopromote.go
+++ b/internal/cli/doctor_autopromote.go
@@ -12,6 +12,7 @@ import (
 	"github.com/digitaldrywood/detent/internal/connector/factory"
 	"github.com/digitaldrywood/detent/internal/connector/local"
 	"github.com/digitaldrywood/detent/internal/connector/memory"
+	"github.com/digitaldrywood/detent/internal/gate"
 	"github.com/digitaldrywood/detent/internal/orchestrator"
 )
 
@@ -256,21 +257,68 @@ func checkDoctorAutoPromoteLive(
 			AutoPromoteCandidates: candidates,
 		}
 	}
-	if invalid := doctorAutoPromoteInvalidWorkpadStatusCandidates(candidates); len(invalid) > 0 {
-		return doctorCheck{
-			Name:                  name,
-			Status:                doctorWarn,
-			Detail:                detail + "; invalid workpad status candidate(s): " + doctorAutoPromoteCandidateSummaries(invalid),
-			Hint:                  "Update the Workpad detent-status block to one of in_progress, blocked, or complete; if this repeats, align WORKFLOW.md handoff prose with the configured review flow.",
-			AutoPromoteCandidates: candidates,
-		}
-	}
-	return doctorCheck{
+	check := doctorCheck{
 		Name:                  name,
 		Status:                doctorOK,
 		Detail:                detail,
 		AutoPromoteCandidates: candidates,
 	}
+	if invalid := doctorAutoPromoteInvalidWorkpadStatusCandidates(candidates); len(invalid) > 0 {
+		check.Status = doctorWarn
+		check.Detail += "; invalid workpad status candidate(s): " + doctorAutoPromoteCandidateSummaries(invalid)
+		check.Hint = "Update the Workpad detent-status block to one of in_progress, blocked, or complete; if this repeats, align WORKFLOW.md handoff prose with the configured review flow."
+	}
+	merged, reviewed, err := doctorAutomatedReviewProducerSample(ctx, cfg, projectConnector)
+	if err != nil {
+		check.Status = doctorWarn
+		check.Detail += "; automated-review producer health unavailable: " + err.Error()
+		check.Hint = "Check terminal issue and merged pull request read access, then rerun detent doctor."
+	} else if merged > 0 {
+		check.Detail += fmt.Sprintf("; recent merged PR automated reviews=%d/%d", reviewed, merged)
+		if reviewed == 0 {
+			check.Status = doctorWarn
+			check.Detail += "; automated-review producer appears inactive"
+			check.Hint = "Restore the automated review producer or use gate.automated_review: optional so a missing review cannot strand merging."
+		}
+	}
+	return check
+}
+
+func doctorAutomatedReviewProducerSample(
+	ctx context.Context,
+	cfg workflowconfig.Config,
+	projectConnector doctorAutoPromoteConnector,
+) (int, int, error) {
+	mode := gate.AutomatedReviewMode(cfg.Gate)
+	if mode == gate.AutomatedReviewOff {
+		return 0, 0, nil
+	}
+	states := append([]string(nil), cfg.Tracker.TerminalStates...)
+	if len(states) == 0 {
+		states = []string{"Done"}
+	}
+	scan, err := fetchDoctorAutoPromoteIssues(ctx, projectConnector, states)
+	if err != nil {
+		return 0, 0, err
+	}
+	merged := 0
+	reviewed := 0
+	for _, issue := range scan.Issues {
+		if hydrator, ok := projectConnector.(connector.PullRequestHydrator); ok && issue.PullRequest != nil {
+			issue, err = hydrator.HydratePullRequest(ctx, issue)
+			if err != nil {
+				return 0, 0, fmt.Errorf("hydrate recent merged pull request for %s: %w", doctorIssueLabel(issue), err)
+			}
+		}
+		if issue.PullRequest == nil || !strings.EqualFold(strings.TrimSpace(issue.PullRequest.State), "merged") {
+			continue
+		}
+		merged++
+		if doctorLatestCodexReviewState(issue.PullRequest) != "" || doctorLatestCodexReviewSubmittedAt(issue.PullRequest) != nil {
+			reviewed++
+		}
+	}
+	return merged, reviewed, nil
 }
 
 func doctorReviewFlowChoice(cfg workflowconfig.Config) string {
@@ -284,11 +332,13 @@ func doctorReviewFlowChoice(cfg workflowconfig.Config) string {
 
 func doctorReviewFlowConfigDetail(cfg workflowconfig.Config) string {
 	return fmt.Sprintf(
-		"review-flow=%s (auto_promote.enabled=%t, quiet_seconds=%d, gate_wait_state=%s)",
+		"review-flow=%s (auto_promote.enabled=%t, quiet_seconds=%d, gate_wait_state=%s, automated_review=%s, gate_wait_timeout_action=%s)",
 		doctorReviewFlowChoice(cfg),
 		cfg.Agent.AutoPromote.Enabled,
 		cfg.Agent.AutoPromote.QuietSeconds,
 		doctorReviewFlowGateWaitState(cfg),
+		gate.AutomatedReviewMode(cfg.Gate),
+		workflowconfig.EffectiveAutoPromoteGateWaitTimeoutAction(cfg.Agent.AutoPromote.GateWaitTimeoutAction, cfg.Gate),
 	)
 }
 
@@ -515,6 +565,7 @@ func doctorAutoPromoteConfig(cfg workflowconfig.Config) orchestrator.AutoPromote
 		QuietDuration:         time.Duration(cfg.Agent.AutoPromote.QuietSeconds) * time.Second,
 		OptoutLabel:           cfg.Agent.AutoPromote.OptoutLabel,
 		AllowedIssueLabels:    append([]string(nil), cfg.Agent.AutoPromote.AllowedIssueLabels...),
+		GateWaitTimeoutAction: cfg.Agent.AutoPromote.GateWaitTimeoutAction,
 		SourceState:           cfg.Agent.AutoPromote.SourceState,
 		PassState:             cfg.Agent.AutoPromote.PassState,
 		ReworkState:           cfg.Agent.AutoPromote.ReworkState,

--- a/internal/cli/doctor_test.go
+++ b/internal/cli/doctor_test.go
@@ -1568,6 +1568,17 @@ func TestCheckDoctorAutoPromote(t *testing.T) {
 		CodexReviewState:       "COMMENTED",
 		CodexReviewSubmittedAt: &oldActivity,
 	})
+	mergedWithoutReview := doctorAutoPromoteIssue("issue-merged-missing-review", &connector.PullRequest{
+		Number: 46,
+		URL:    "https://github.test/pull/46",
+		State:  "MERGED",
+	})
+	mergedWithReview := doctorAutoPromoteIssue("issue-merged-reviewed", &connector.PullRequest{
+		Number:           47,
+		URL:              "https://github.test/pull/47",
+		State:            "MERGED",
+		CodexReviewState: "COMMENTED",
+	})
 
 	tests := []struct {
 		name        string
@@ -1658,6 +1669,24 @@ func TestCheckDoctorAutoPromote(t *testing.T) {
 			},
 			want:        doctorOK,
 			wantDetails: []string{"ready=1"},
+		},
+		{
+			name: "dead automated review producer warns",
+			cfg:  validDoctorAutoPromoteWorkflow(),
+			connector: &fakeDoctorAutoPromoteConnector{
+				mergedIssues: []connector.Issue{mergedWithoutReview},
+			},
+			want:        doctorWarn,
+			wantDetails: []string{"recent merged PR automated reviews=0/1", "producer appears inactive"},
+		},
+		{
+			name: "working automated review producer passes",
+			cfg:  validDoctorAutoPromoteWorkflow(),
+			connector: &fakeDoctorAutoPromoteConnector{
+				mergedIssues: []connector.Issue{mergedWithReview},
+			},
+			want:        doctorOK,
+			wantDetails: []string{"recent merged PR automated reviews=1/1"},
 		},
 		{
 			name: "project state count discrepancy fails",
@@ -4632,6 +4661,7 @@ func doctorDependencyResolvedIssue(id string, identifier string, state string, c
 
 type fakeDoctorAutoPromoteConnector struct {
 	issues         []connector.Issue
+	mergedIssues   []connector.Issue
 	hydratedIssues []connector.Issue
 	resolvedIssues []connector.Issue
 	capabilities   []connector.DependencyCapability
@@ -4643,25 +4673,42 @@ type fakeDoctorAutoPromoteConnector struct {
 	scan           *connector.IssueStateScan
 }
 
-func (c *fakeDoctorAutoPromoteConnector) FetchIssuesByStates(context.Context, []string) ([]connector.Issue, error) {
-	return c.issues, nil
+func (c *fakeDoctorAutoPromoteConnector) FetchIssuesByStates(_ context.Context, states []string) ([]connector.Issue, error) {
+	return c.issuesForStates(states), nil
 }
 
-func (c *fakeDoctorAutoPromoteConnector) FetchIssuesByStatesLimit(_ context.Context, _ []string, limit int) ([]connector.Issue, error) {
+func (c *fakeDoctorAutoPromoteConnector) FetchIssuesByStatesLimit(_ context.Context, states []string, limit int) ([]connector.Issue, error) {
 	c.limit = limit
-	return c.issues, nil
+	return c.issuesForStates(states), nil
 }
 
-func (c *fakeDoctorAutoPromoteConnector) FetchIssuesByStatesScan(_ context.Context, _ []string, limit int) (connector.IssueStateScan, error) {
+func (c *fakeDoctorAutoPromoteConnector) FetchIssuesByStatesScan(_ context.Context, states []string, limit int) (connector.IssueStateScan, error) {
 	c.limit = limit
-	if c.scan != nil {
+	if c.scan != nil && !doctorFakeTerminalStates(states) {
 		return *c.scan, nil
 	}
-	scan := doctorIssueStateScan(c.issues)
+	scan := doctorIssueStateScan(c.issuesForStates(states))
 	if limit > 0 && len(scan.Issues) > limit {
 		scan.Issues = scan.Issues[:limit]
 	}
 	return scan, nil
+}
+
+func (c *fakeDoctorAutoPromoteConnector) issuesForStates(states []string) []connector.Issue {
+	if doctorFakeTerminalStates(states) {
+		return c.mergedIssues
+	}
+	return c.issues
+}
+
+func doctorFakeTerminalStates(states []string) bool {
+	for _, state := range states {
+		switch strings.ToLower(strings.TrimSpace(state)) {
+		case "done", "cancelled", "canceled":
+			return true
+		}
+	}
+	return false
 }
 
 func (c *fakeDoctorAutoPromoteConnector) FetchIssueStatesByIdentifiers(_ context.Context, identifiers []string) ([]connector.Issue, error) {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -94,6 +94,9 @@ const (
 
 	AutoPromoteGateWaitStateSource = "source"
 	AutoPromoteGateWaitStateReview = "review"
+
+	AutoPromoteGateWaitTimeoutActionMerge       = "merge"
+	AutoPromoteGateWaitTimeoutActionHumanReview = "human_review"
 )
 
 type Workflow struct {
@@ -368,6 +371,7 @@ type AutoPromote struct {
 	AllowedIssueLabels     []string `yaml:"allowed_issue_labels"`
 	GateWaitState          string   `yaml:"gate_wait_state,omitempty"`
 	GateWaitTimeoutSeconds int      `yaml:"gate_wait_timeout_seconds,omitempty"`
+	GateWaitTimeoutAction  string   `yaml:"gate_wait_timeout_action,omitempty"`
 	SourceState            string   `yaml:"source_state,omitempty"`
 	PassState              string   `yaml:"pass_state,omitempty"`
 	ReworkState            string   `yaml:"rework_state,omitempty"`
@@ -1333,6 +1337,7 @@ func (c *Config) normalize() {
 	c.Agent.AutoPromote.OptoutLabel = normalizeLabel(c.Agent.AutoPromote.OptoutLabel)
 	c.Agent.AutoPromote.AllowedIssueLabels = normalizeLabels(c.Agent.AutoPromote.AllowedIssueLabels)
 	c.Agent.AutoPromote.GateWaitState = normalizeAutoPromoteGateWaitState(c.Agent.AutoPromote.GateWaitState)
+	c.Agent.AutoPromote.GateWaitTimeoutAction = normalizeAutoPromoteGateWaitTimeoutAction(c.Agent.AutoPromote.GateWaitTimeoutAction)
 	if c.Agent.AutoPromote.GateWaitTimeoutSeconds == 0 {
 		c.Agent.AutoPromote.GateWaitTimeoutSeconds = DefaultAutoPromoteGateWaitTimeoutSeconds
 	}
@@ -1354,6 +1359,10 @@ func (c *Config) normalize() {
 	c.Codex.ModelProvider = strings.TrimSpace(c.Codex.ModelProvider)
 	c.Codex.ServiceTier = strings.TrimSpace(c.Codex.ServiceTier)
 	c.Gate = gate.Effective(c.Gate)
+	c.Agent.AutoPromote.GateWaitTimeoutAction = EffectiveAutoPromoteGateWaitTimeoutAction(
+		c.Agent.AutoPromote.GateWaitTimeoutAction,
+		c.Gate,
+	)
 	c.Plan = gate.EffectivePlan(c.Plan)
 	if c.Plan.Enabled {
 		c.Tracker.ObservedStates = appendStateUnique(c.Tracker.ObservedStates, c.Plan.Stop)
@@ -1919,6 +1928,11 @@ func (a *AutoPromote) validate(prefix string, problems *[]string) {
 	if a.GateWaitTimeoutSeconds <= 0 {
 		*problems = append(*problems, prefix+".gate_wait_timeout_seconds must be greater than 0")
 	}
+	switch normalizeAutoPromoteGateWaitTimeoutAction(a.GateWaitTimeoutAction) {
+	case "", AutoPromoteGateWaitTimeoutActionMerge, AutoPromoteGateWaitTimeoutActionHumanReview:
+	default:
+		*problems = append(*problems, prefix+".gate_wait_timeout_action must be one of merge, human_review")
+	}
 	if strings.TrimSpace(a.SourceState) == "" {
 		*problems = append(*problems, prefix+".source_state must not be blank")
 	}
@@ -1945,6 +1959,28 @@ func normalizeAutoPromoteGateWaitState(state string) string {
 	default:
 		return strings.ToLower(strings.TrimSpace(state))
 	}
+}
+
+func normalizeAutoPromoteGateWaitTimeoutAction(action string) string {
+	switch strings.ToLower(strings.TrimSpace(action)) {
+	case "", AutoPromoteGateWaitTimeoutActionMerge, AutoPromoteGateWaitTimeoutActionHumanReview:
+		return strings.ToLower(strings.TrimSpace(action))
+	case "human-review", "humanreview":
+		return AutoPromoteGateWaitTimeoutActionHumanReview
+	default:
+		return strings.ToLower(strings.TrimSpace(action))
+	}
+}
+
+func EffectiveAutoPromoteGateWaitTimeoutAction(action string, gateCfg gate.Config) string {
+	action = normalizeAutoPromoteGateWaitTimeoutAction(action)
+	if action != "" {
+		return action
+	}
+	if gate.AutomatedReviewMode(gateCfg) == gate.AutomatedReviewRequired {
+		return AutoPromoteGateWaitTimeoutActionHumanReview
+	}
+	return AutoPromoteGateWaitTimeoutActionMerge
 }
 
 func (o OutputTruncation) validate(prefix string, problems *[]string) {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -1954,6 +1955,53 @@ Prompt
 	}
 }
 
+func TestParseWorkflowAutomatedReviewModeAndTimeoutAction(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		mode       string
+		action     string
+		wantAction string
+	}{
+		{name: "optional defaults to merge", mode: gate.AutomatedReviewOptional, wantAction: AutoPromoteGateWaitTimeoutActionMerge},
+		{name: "required defaults to human review", mode: gate.AutomatedReviewRequired, wantAction: AutoPromoteGateWaitTimeoutActionHumanReview},
+		{name: "optional can hold for human", mode: gate.AutomatedReviewOptional, action: AutoPromoteGateWaitTimeoutActionHumanReview, wantAction: AutoPromoteGateWaitTimeoutActionHumanReview},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			raw := fmt.Sprintf(`---
+tracker:
+  kind: memory
+agent:
+  auto_promote:
+    gate_wait_timeout_action: %s
+gate:
+  kind: command
+  automated_review: %s
+---
+Prompt
+`, tt.action, tt.mode)
+			workflow, err := ParseWorkflow([]byte(raw))
+			if err != nil {
+				t.Fatalf("ParseWorkflow() error = %v", err)
+			}
+			if err := workflow.Config.Validate(); err != nil {
+				t.Fatalf("Validate() error = %v", err)
+			}
+			if got := workflow.Config.Gate.AutomatedReview; got != tt.mode {
+				t.Fatalf("Gate.AutomatedReview = %q, want %q", got, tt.mode)
+			}
+			if got := workflow.Config.Agent.AutoPromote.GateWaitTimeoutAction; got != tt.wantAction {
+				t.Fatalf("GateWaitTimeoutAction = %q, want %q", got, tt.wantAction)
+			}
+		})
+	}
+}
+
 func TestParseWorkflowCommandGateCIFailureAction(t *testing.T) {
 	t.Parallel()
 
@@ -2748,6 +2796,24 @@ Prompt
 			want: []string{
 				"agent.auto_promote.gate_wait_state must be one of source, review",
 				"agent.auto_promote.gate_wait_timeout_seconds must be greater than 0",
+			},
+		},
+		{
+			name: "invalid automated review settings",
+			raw: `---
+tracker:
+  kind: memory
+agent:
+  auto_promote:
+    gate_wait_timeout_action: abandon
+gate:
+  automated_review: sometimes
+---
+Prompt
+`,
+			want: []string{
+				"agent.auto_promote.gate_wait_timeout_action must be one of merge, human_review",
+				"gate.automated_review must be one of required, optional, off",
 			},
 		},
 		{

--- a/internal/gate/gate.go
+++ b/internal/gate/gate.go
@@ -26,12 +26,17 @@ const (
 	PlanReviewHuman     = "human"
 	PlanReviewAutomated = "automated"
 	PlanReviewBoth      = "both"
+
+	AutomatedReviewRequired = "required"
+	AutomatedReviewOptional = "optional"
+	AutomatedReviewOff      = "off"
 )
 
 type Config struct {
 	Kind                   string          `yaml:"kind"`
 	Run                    string          `yaml:"run"`
 	ApprovalLabel          string          `yaml:"approval_label"`
+	AutomatedReview        string          `yaml:"automated_review"`
 	RequireAutomatedReview *bool           `yaml:"require_automated_review"`
 	RequiredStatusChecks   []string        `yaml:"required_status_checks"`
 	CIFailureAction        string          `yaml:"ci_failure_action"`
@@ -92,7 +97,8 @@ type ValidatorResult struct {
 }
 
 type EvaluationOptions struct {
-	QuietDuration time.Duration
+	QuietDuration              time.Duration
+	AutomatedReviewWaitExpired bool
 }
 
 type Action string
@@ -171,6 +177,7 @@ func Effective(cfg Config) Config {
 	cfg.Kind = NormalizeKind(cfg.Kind)
 	cfg.Run = strings.TrimSpace(cfg.Run)
 	cfg.ApprovalLabel = normalizeLabel(cfg.ApprovalLabel)
+	cfg.AutomatedReview = NormalizeAutomatedReview(cfg.AutomatedReview)
 	cfg.RequiredStatusChecks = NormalizeRequiredStatusChecks(cfg.RequiredStatusChecks)
 	cfg.CIFailureAction = NormalizeCIFailureAction(cfg.CIFailureAction)
 	if cfg.TransientCIRetryLimit == nil {
@@ -185,17 +192,33 @@ func Effective(cfg Config) Config {
 	if cfg.Kind == KindCommand && cfg.Run == "" {
 		cfg.Run = DefaultCommand
 	}
-	if cfg.Kind == KindHumanReview {
+	switch cfg.Kind {
+	case KindHumanReview:
 		cfg.Run = ""
+		cfg.AutomatedReview = ""
 		cfg.RequireAutomatedReview = nil
 		if cfg.ApprovalLabel == "" {
 			cfg.ApprovalLabel = DefaultApprovalLabel
 		}
-	} else if cfg.Kind == KindArtifact {
+	case KindArtifact:
 		cfg.Run = ""
+		cfg.AutomatedReview = ""
 		cfg.RequireAutomatedReview = nil
-	} else if cfg.RequireAutomatedReview == nil {
-		cfg.RequireAutomatedReview = new(true)
+	default:
+		if cfg.AutomatedReview == "" {
+			cfg.AutomatedReview = AutomatedReviewRequired
+			if cfg.RequireAutomatedReview != nil && !*cfg.RequireAutomatedReview {
+				cfg.AutomatedReview = AutomatedReviewOff
+			}
+		}
+		switch cfg.AutomatedReview {
+		case AutomatedReviewRequired:
+			cfg.RequireAutomatedReview = new(true)
+		case AutomatedReviewOff:
+			cfg.RequireAutomatedReview = new(false)
+		case AutomatedReviewOptional:
+			cfg.RequireAutomatedReview = nil
+		}
 	}
 	if cfg.ApprovalLabel == "" {
 		cfg.ApprovalLabel = DefaultApprovalLabel
@@ -266,6 +289,25 @@ func NormalizeCIFailureAction(action string) string {
 	}
 }
 
+func NormalizeAutomatedReview(mode string) string {
+	switch strings.ToLower(strings.TrimSpace(mode)) {
+	case "":
+		return ""
+	case AutomatedReviewRequired:
+		return AutomatedReviewRequired
+	case AutomatedReviewOptional:
+		return AutomatedReviewOptional
+	case AutomatedReviewOff, "disabled", "false":
+		return AutomatedReviewOff
+	default:
+		return strings.ToLower(strings.TrimSpace(mode))
+	}
+}
+
+func AutomatedReviewMode(cfg Config) string {
+	return Effective(cfg).AutomatedReview
+}
+
 func NormalizeRequiredStatusChecks(checks []string) []string {
 	normalized := make([]string, 0, len(checks))
 	seen := make(map[string]struct{}, len(checks))
@@ -294,6 +336,11 @@ func Validate(prefix string, cfg Config) []string {
 	case CIFailureActionSkip, CIFailureActionRework:
 	default:
 		problems = append(problems, prefix+".ci_failure_action must be one of skip, rework")
+	}
+	switch NormalizeAutomatedReview(cfg.AutomatedReview) {
+	case "", AutomatedReviewRequired, AutomatedReviewOptional, AutomatedReviewOff:
+	default:
+		problems = append(problems, prefix+".automated_review must be one of required, optional, off")
 	}
 	if cfg.TransientCIRetryLimit != nil && *cfg.TransientCIRetryLimit < 0 {
 		problems = append(problems, prefix+".transient_ci_retry_limit must be greater than or equal to 0")
@@ -339,9 +386,12 @@ func Instructions(cfg Config) string {
 			"Run full `" + cfg.Run + "` in Merging when code changes, conflicts are resolved, or validation state is stale or unknown. " +
 			"Watch current-head CI with REST check-runs polling/backoff, report slow checks, and record merge wait telemetry in the Workpad prose: quiet-window wait, local merge-gate duration, PR CI duration, slow check names, and whether post-merge main CI is still running. " +
 			"Keep blocker and human-action declarations in the structured detent-status block; narrative Workpad sentences are telemetry only."
-		if automatedReviewRequired(cfg) {
+		switch AutomatedReviewMode(cfg) {
+		case AutomatedReviewRequired:
 			instructions += " Automated review is required on the current pull request head before promotion."
-		} else {
+		case AutomatedReviewOptional:
+			instructions += " Automated review is optional: wait for it until the configured gate deadline, then promote when the remaining checks pass. Any P1 automated review findings still block promotion."
+		default:
 			instructions += " Automated review is not required for promotion, but any P1 automated review findings still block promotion."
 		}
 		if cfg.Validator.Enabled {
@@ -413,7 +463,7 @@ func evaluateCommand(cfg Config, summary Summary, now time.Time, opts Evaluation
 	if out, ok := evaluateValidator(cfg.Validator, summary.Validator); ok {
 		return out
 	}
-	if automatedReviewRequired(cfg) && !automatedReviewSubmitted(summary.ReviewState) {
+	if automatedReviewWaits(cfg) && !automatedReviewSubmitted(summary.ReviewState) && !opts.AutomatedReviewWaitExpired {
 		return decision(ActionWait, ReasonAutomatedReviewMissing)
 	}
 	if remaining := quietRemaining(summary, opts, now); remaining > 0 {
@@ -770,7 +820,7 @@ func normalizeLabel(label string) string {
 	return strings.ToLower(strings.TrimSpace(label))
 }
 
-func automatedReviewRequired(cfg Config) bool {
+func automatedReviewWaits(cfg Config) bool {
 	cfg = Effective(cfg)
-	return cfg.Kind == KindCommand && cfg.RequireAutomatedReview != nil && *cfg.RequireAutomatedReview
+	return cfg.Kind == KindCommand && cfg.AutomatedReview != AutomatedReviewOff
 }

--- a/internal/gate/gate_test.go
+++ b/internal/gate/gate_test.go
@@ -622,10 +622,55 @@ func TestInstructionsDescribeRequiredStatusChecks(t *testing.T) {
 	}
 }
 
+func TestEvaluateAutomatedReviewModes(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 7, 13, 12, 0, 0, 0, time.UTC)
+	tests := []struct {
+		name       string
+		mode       string
+		review     string
+		expired    bool
+		p1Findings []Finding
+		want       Decision
+	}{
+		{name: "required absent", mode: AutomatedReviewRequired, want: Decision{Action: ActionWait, Reason: ReasonAutomatedReviewMissing}},
+		{name: "required absent after deadline", mode: AutomatedReviewRequired, expired: true, want: Decision{Action: ActionPass, Reason: ReasonReady}},
+		{name: "required present", mode: AutomatedReviewRequired, review: "COMMENTED", want: Decision{Action: ActionPass, Reason: ReasonReady}},
+		{name: "required late review", mode: AutomatedReviewRequired, review: "COMMENTED", expired: true, want: Decision{Action: ActionPass, Reason: ReasonReady}},
+		{name: "optional absent", mode: AutomatedReviewOptional, want: Decision{Action: ActionWait, Reason: ReasonAutomatedReviewMissing}},
+		{name: "optional absent after deadline", mode: AutomatedReviewOptional, expired: true, want: Decision{Action: ActionPass, Reason: ReasonReady}},
+		{name: "optional present", mode: AutomatedReviewOptional, review: "APPROVED", want: Decision{Action: ActionPass, Reason: ReasonReady}},
+		{name: "optional late review", mode: AutomatedReviewOptional, review: "APPROVED", expired: true, want: Decision{Action: ActionPass, Reason: ReasonReady}},
+		{name: "off absent", mode: AutomatedReviewOff, want: Decision{Action: ActionPass, Reason: ReasonReady}},
+		{name: "off present", mode: AutomatedReviewOff, review: "COMMENTED", want: Decision{Action: ActionPass, Reason: ReasonReady}},
+		{name: "required p1", mode: AutomatedReviewRequired, review: "P1", want: Decision{Action: ActionRework, Reason: ReasonP1Findings}},
+		{name: "optional late p1", mode: AutomatedReviewOptional, review: "COMMENTED", expired: true, p1Findings: []Finding{{Severity: "p1"}}, want: Decision{Action: ActionRework, Reason: ReasonP1Findings, Findings: []Finding{{Severity: "p1"}}}},
+		{name: "off p1", mode: AutomatedReviewOff, review: "P1", want: Decision{Action: ActionRework, Reason: ReasonP1Findings}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := Evaluate(Config{Kind: KindCommand, AutomatedReview: tt.mode}, nil, Summary{
+				PullRequestURL: "https://github.test/pull/1297",
+				CIStatus:       "green",
+				ReviewState:    tt.review,
+				P1Findings:     tt.p1Findings,
+			}, now, EvaluationOptions{AutomatedReviewWaitExpired: tt.expired})
+			if got.Action != tt.want.Action || got.Reason != tt.want.Reason || !slices.Equal(got.Findings, tt.want.Findings) {
+				t.Fatalf("Evaluate() = %#v, want %#v", got, tt.want)
+			}
+		})
+	}
+}
+
 func configsEqual(left Config, right Config) bool {
 	return left.Kind == right.Kind &&
 		left.Run == right.Run &&
 		left.ApprovalLabel == right.ApprovalLabel &&
+		AutomatedReviewMode(left) == AutomatedReviewMode(right) &&
 		left.CIFailureAction == right.CIFailureAction &&
 		slices.Equal(left.RequiredStatusChecks, right.RequiredStatusChecks) &&
 		intPointerEqual(left.TransientCIRetryLimit, right.TransientCIRetryLimit) &&

--- a/internal/orchestrator/autopromote.go
+++ b/internal/orchestrator/autopromote.go
@@ -16,6 +16,7 @@ type AutoPromoteConfig struct {
 	AllowedIssueLabels    []string
 	GateWaitState         string
 	GateWaitTimeout       time.Duration
+	GateWaitTimeoutAction string
 	SourceState           string
 	PassState             string
 	ReworkState           string
@@ -40,6 +41,7 @@ type AutoPromoteSummary struct {
 	ArtifactStatus                        string
 	LastActivityAt                        *time.Time
 	CompletedFinalState                   string
+	AutomatedReviewWaitExpired            bool
 }
 
 type AutoPromoteFinding struct {
@@ -154,7 +156,8 @@ func EvaluateAutoPromote(
 		summary.ArtifactStatus = artifactStatusFromIssue(issue, cfg.Gate.Artifact.StatusField)
 	}
 	gateDecision := gate.Evaluate(cfg.Gate, issue.Labels, gateSummary(summary), now, gate.EvaluationOptions{
-		QuietDuration: cfg.QuietDuration,
+		QuietDuration:              cfg.QuietDuration,
+		AutomatedReviewWaitExpired: summary.AutomatedReviewWaitExpired,
 	})
 	decision := autoPromoteDecision(autoPromoteActionFromGate(gateDecision.Action), autoPromoteReasonFromGate(gateDecision.Reason))
 	decision.CIStatus = gateDecision.CIStatus
@@ -220,6 +223,7 @@ func normalizeAutoPromoteConfig(cfg AutoPromoteConfig) AutoPromoteConfig {
 	if cfg.GateWaitTimeout <= 0 {
 		cfg.GateWaitTimeout = defaultAutoPromoteGateWaitTimeout
 	}
+	cfg.GateWaitTimeoutAction = normalizeAutoPromoteGateWaitTimeoutAction(cfg.GateWaitTimeoutAction, cfg.Gate)
 	cfg.SourceState = strings.TrimSpace(cfg.SourceState)
 	if cfg.SourceState == "" {
 		cfg.SourceState = autoPromoteSourceState
@@ -241,6 +245,19 @@ func normalizeAutoPromoteConfig(cfg AutoPromoteConfig) AutoPromoteConfig {
 	}
 	cfg.Gate = gate.Effective(cfg.Gate)
 	return cfg
+}
+
+func normalizeAutoPromoteGateWaitTimeoutAction(action string, gateCfg gate.Config) string {
+	switch normalizeState(action) {
+	case autoPromoteGateWaitTimeoutMerge:
+		return autoPromoteGateWaitTimeoutMerge
+	case autoPromoteGateWaitTimeoutHumanReview, "human-review", "humanreview":
+		return autoPromoteGateWaitTimeoutHumanReview
+	}
+	if gate.AutomatedReviewMode(gateCfg) == gate.AutomatedReviewRequired {
+		return autoPromoteGateWaitTimeoutHumanReview
+	}
+	return autoPromoteGateWaitTimeoutMerge
 }
 
 func normalizeAutoPromoteGateWaitState(state string) string {

--- a/internal/orchestrator/autopromote_tick.go
+++ b/internal/orchestrator/autopromote_tick.go
@@ -230,7 +230,7 @@ func (o *Orchestrator) restoreDurableGateWaitCompletions(
 		return
 	}
 	autoCfg := normalizeAutoPromoteConfig(o.cfg.AutoPromote)
-	if !autoPromoteActiveGateTrackingEnabled(autoCfg) {
+	if !autoPromoteDurableGateWaitTrackingEnabled(autoCfg) {
 		return
 	}
 	if state.Completed == nil {
@@ -244,7 +244,7 @@ func (o *Orchestrator) restoreDurableGateWaitCompletions(
 		if _, ok := state.Completed[issueID]; ok {
 			continue
 		}
-		if !autoPromoteActiveGateTrackedIssue(issue, o.cfg, autoCfg) {
+		if !autoPromoteDurableGateWaitTrackedIssue(issue, o.cfg, autoCfg) {
 			continue
 		}
 		attempt, ok, err := o.latestSuccessfulGateWaitAttempt(ctx, issue)
@@ -360,6 +360,22 @@ func autoPromoteActiveGateTrackedIssue(
 	return autoPromoteActiveGateEligibleIssue(issue, cfg, autoCfg) && issueHasOpenPullRequest(issue)
 }
 
+func autoPromoteDurableGateWaitTrackedIssue(
+	issue connector.Issue,
+	cfg Config,
+	autoCfg AutoPromoteConfig,
+) bool {
+	if autoPromoteActiveGateTrackedIssue(issue, cfg, autoCfg) {
+		return true
+	}
+	autoCfg = normalizeAutoPromoteConfig(autoCfg)
+	return autoPromoteReviewStateDeadlineTrackingEnabled(autoCfg) &&
+		normalizeState(issue.State) == normalizeState(autoCfg.SourceState) &&
+		!stateIn(issue.State, cfg.TerminalStates) &&
+		!autoPromoteHumanReviewRequired(issue, autoCfg, autoCfg.Gate) &&
+		issueHasOpenPullRequest(issue)
+}
+
 func autoPromoteActiveGateEligibleIssue(
 	issue connector.Issue,
 	cfg Config,
@@ -393,6 +409,19 @@ func autoPromoteSourceGateWaitEnabled(cfg AutoPromoteConfig) bool {
 func autoPromoteActiveGateTrackingEnabled(cfg AutoPromoteConfig) bool {
 	cfg = normalizeAutoPromoteConfig(cfg)
 	return cfg.Enabled && (cfg.QuietDuration > 0 || cfg.GateWaitState == autoPromoteGateWaitSource)
+}
+
+func autoPromoteDurableGateWaitTrackingEnabled(cfg AutoPromoteConfig) bool {
+	return autoPromoteActiveGateTrackingEnabled(cfg) || autoPromoteReviewStateDeadlineTrackingEnabled(cfg)
+}
+
+func autoPromoteReviewStateDeadlineTrackingEnabled(cfg AutoPromoteConfig) bool {
+	cfg = normalizeAutoPromoteConfig(cfg)
+	mode := gate.AutomatedReviewMode(cfg.Gate)
+	return cfg.Enabled &&
+		cfg.GateWaitState == autoPromoteGateWaitReview &&
+		cfg.GateWaitTimeoutAction == autoPromoteGateWaitTimeoutMerge &&
+		(mode == gate.AutomatedReviewRequired || mode == gate.AutomatedReviewOptional)
 }
 
 func issueHasOpenPullRequest(issue connector.Issue) bool {

--- a/internal/orchestrator/autopromote_tick.go
+++ b/internal/orchestrator/autopromote_tick.go
@@ -20,14 +20,16 @@ import (
 )
 
 const (
-	autoPromoteSourceState            = "Human Review"
-	autoPromoteMergingState           = "Merging"
-	autoPromoteReworkState            = "Rework"
-	autoPromoteGateWaitSource         = "source"
-	autoPromoteGateWaitReview         = "review"
-	defaultAutoPromoteGateWaitTimeout = time.Hour
-	defaultMergeWorkerStartupTimeout  = 2 * time.Minute
-	mergeWorkerProjectStateFull       = "project_state_capacity_full"
+	autoPromoteSourceState                = "Human Review"
+	autoPromoteMergingState               = "Merging"
+	autoPromoteReworkState                = "Rework"
+	autoPromoteGateWaitSource             = "source"
+	autoPromoteGateWaitReview             = "review"
+	autoPromoteGateWaitTimeoutMerge       = "merge"
+	autoPromoteGateWaitTimeoutHumanReview = "human_review"
+	defaultAutoPromoteGateWaitTimeout     = time.Hour
+	defaultMergeWorkerStartupTimeout      = 2 * time.Minute
+	mergeWorkerProjectStateFull           = "project_state_capacity_full"
 )
 
 type autoPromoteTickResult struct {
@@ -81,6 +83,7 @@ func (o *Orchestrator) autoPromoteHumanReviewIssues(
 
 		summary := AutoPromoteSummaryFromIssue(issue)
 		summary.CompletedFinalState = autoPromoteCompletedFinalState(state, issueID)
+		summary.AutomatedReviewWaitExpired = autoPromoteReviewWaitExpired(state, issueID, cfg, now)
 		decision := EvaluateAutoPromote(issue, summary, cfg, now)
 		if decision.Reason == AutoPromoteReasonValidatorMissing {
 			validation, shouldComment, ok := o.validatorStageResult(ctx, issue)
@@ -141,6 +144,19 @@ func autoPromoteCompletedFinalState(state *State, issueID string) string {
 		return ""
 	}
 	return completed.FinalState
+}
+
+func autoPromoteReviewWaitExpired(state *State, issueID string, cfg AutoPromoteConfig, now time.Time) bool {
+	if state == nil {
+		return false
+	}
+	completed, ok := state.Completed[strings.TrimSpace(issueID)]
+	if !ok || completed.CompletedAt.IsZero() {
+		return false
+	}
+	cfg = normalizeAutoPromoteConfig(cfg)
+	return cfg.GateWaitTimeoutAction == autoPromoteGateWaitTimeoutMerge &&
+		!now.Before(completed.CompletedAt.Add(cfg.GateWaitTimeout))
 }
 
 func recordAutoPromoteSnapshotDecision(state *State, issueID string, decision AutoPromoteDecision) {

--- a/internal/orchestrator/autopromote_tick_test.go
+++ b/internal/orchestrator/autopromote_tick_test.go
@@ -681,6 +681,71 @@ func TestTickAutoPromoteRecoversActiveIssueAfterRestart(t *testing.T) {
 	}
 }
 
+func TestTickAutoPromoteRecoversOptionalReviewDeadlineAfterRestart(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 7, 13, 19, 0, 0, 0, time.UTC)
+	issue := autoPromoteTickIssue("issue-restart-optional-review", []string{"bug"}, &connector.PullRequest{
+		Number:         1297,
+		URL:            "https://github.test/digitaldrywood/detent/pull/1297",
+		State:          "OPEN",
+		MergeableState: "clean",
+		CIStatus:       "success",
+	})
+	cfg := normalizeConfig(Config{
+		Project:             scheduler.ProjectCandidate{ID: "detent"},
+		PollInterval:        time.Minute,
+		MaxConcurrentAgents: 1,
+		AutoPromote: AutoPromoteConfig{
+			Enabled:         true,
+			QuietDuration:   0,
+			GateWaitState:   autoPromoteGateWaitReview,
+			GateWaitTimeout: 15 * time.Minute,
+			Gate: gate.Config{
+				Kind:            gate.KindCommand,
+				AutomatedReview: gate.AutomatedReviewOptional,
+			},
+		},
+		ActiveStates:   []string{"Todo", "In Progress", "Rework", "Merging"},
+		TerminalStates: []string{"Done", "Cancelled"},
+	})
+	state := newState(cfg)
+	mergingSlot := dispatchTestIssue("issue-restart-optional-merging-slot", "Merging")
+	state.Running[mergingSlot.ID] = Running{Issue: mergingSlot}
+	tracker := &autoPromoteTickConnector{stateIssues: []connector.Issue{issue}}
+	prNumber := int64(issue.PullRequest.Number)
+	completedAt := now.Add(-20 * time.Minute)
+	attempts := &recordingWorkAttemptStore{history: []store.WorkAttempt{{
+		ProjectID:          cfg.Project.ID,
+		IssueID:            issue.ID,
+		Identifier:         issue.Identifier,
+		IssueURL:           issue.URL,
+		PRNumber:           &prNumber,
+		WorkerType:         "agent",
+		Status:             store.WorkAttemptStatusTerminal,
+		StartedAt:          completedAt.Add(-5 * time.Minute),
+		CompletedAt:        completedAt,
+		TerminalState:      store.WorkAttemptTerminalSuccess,
+		WorkerMetadataJSON: implementProgressMetadataJSON(autoPromoteReworkSignature{PRNumber: prNumber, HeadSHA: "optional-head"}, store.WorkAttemptTerminalSuccess),
+	}}}
+	orch := &Orchestrator{
+		cfg:          cfg,
+		connector:    tracker,
+		workAttempts: attempts,
+		logger:       slog.New(slog.NewTextHandler(io.Discard, nil)),
+	}
+
+	orch.tick(context.Background(), &state, now)
+
+	wantUpdates := []autoPromoteTickUpdate{{issueID: issue.ID, state: "Merging"}}
+	if !reflect.DeepEqual(tracker.updates, wantUpdates) {
+		t.Fatalf("updates = %#v, want %#v", tracker.updates, wantUpdates)
+	}
+	if len(attempts.historyQueries) == 0 {
+		t.Fatal("durable work attempt history was not queried")
+	}
+}
+
 func TestLatestSuccessfulGateWaitAttemptRequiresCurrentImplementationEvidence(t *testing.T) {
 	t.Parallel()
 

--- a/internal/orchestrator/completion_transition.go
+++ b/internal/orchestrator/completion_transition.go
@@ -39,8 +39,13 @@ func (o *Orchestrator) transitionCompletedActiveIssuesToReview(
 			cfg,
 		)
 		if targetState == "" {
-			if o.transitionTimedOutCompletedActiveGateWait(ctx, state, issue, completed, cfg, now) {
+			if transitioned, promoted := o.transitionTimedOutCompletedActiveGateWait(ctx, state, issue, completed, cfg, now); transitioned {
 				result.transitioned[issueID] = struct{}{}
+				if mergeWorkerIssue(promoted) {
+					o.recordMergeQueueEntered(state, promoted, now, "completed_active_gate_wait_timeout")
+					result.dispatchCandidates = append(result.dispatchCandidates, promoted)
+					o.logMergeWorkerPickup(promoted, "completed_active_gate_wait_timeout")
+				}
 			}
 			continue
 		}
@@ -310,16 +315,42 @@ func (o *Orchestrator) transitionTimedOutCompletedActiveGateWait(
 	completed Completed,
 	cfg AutoPromoteConfig,
 	now time.Time,
-) bool {
+) (bool, connector.Issue) {
 	issueID := strings.TrimSpace(issue.ID)
 	if issueID == "" || completed.CompletedAt.IsZero() {
-		return false
+		return false, connector.Issue{}
 	}
 	if now.Before(completed.CompletedAt.Add(cfg.GateWaitTimeout)) {
-		return false
+		return false, connector.Issue{}
 	}
 	if !autoPromoteActiveGatePendingIssue(issue, state, o.cfg, cfg) {
-		return false
+		return false, connector.Issue{}
+	}
+	if cfg.GateWaitTimeoutAction == autoPromoteGateWaitTimeoutMerge {
+		summary := AutoPromoteSummaryFromIssue(issue)
+		summary.CompletedFinalState = completed.FinalState
+		summary.AutomatedReviewWaitExpired = true
+		decision := EvaluateAutoPromote(issue, summary, cfg, now)
+		if autoPromoteDecisionNeedsWorkpadHydration(decision) {
+			issue, decision = o.hydrateAutoPromoteWorkpadDecision(ctx, issue, summary, cfg, now)
+		}
+		targetState := autoPromoteTargetState(decision.Action, cfg)
+		if targetState == "" {
+			recordAutoPromoteSnapshotDecision(state, issueID, decision)
+			o.logAutoPromoteDecision(issue, decision, "")
+			return false, connector.Issue{}
+		}
+		if !o.applyAutoPromoteDecision(ctx, state, issue, summary, decision, targetState, now) {
+			return false, connector.Issue{}
+		}
+		promoted := promotedIssue(issue, targetState, now)
+		o.finishCompletedActiveReviewTransition(ctx, state, issue, completed, targetState)
+		recordStateEvent(state, telemetry.ActivityEvent{
+			At:      now,
+			Event:   "completed_active_gate_wait_timeout",
+			Message: "moved " + issueLabel(issue) + " from " + strings.TrimSpace(issue.State) + " to " + targetState + " after auto-promote gate wait timeout",
+		})
+		return true, promoted
 	}
 	targetState := cfg.SourceState
 	if err := o.updateIssueStateByID(ctx, state, issueID, issue, targetState, now, "auto_promote_gate_wait_timeout"); err != nil {
@@ -333,7 +364,7 @@ func (o *Orchestrator) transitionTimedOutCompletedActiveGateWait(
 				"error", err,
 			)
 		}
-		return false
+		return false, connector.Issue{}
 	}
 	if err := o.connector.CreateComment(ctx, issueID, completedActiveGateWaitTimeoutComment(issue, completed, cfg, now)); err != nil && o.logger != nil {
 		o.logger.Warn(
@@ -349,7 +380,7 @@ func (o *Orchestrator) transitionTimedOutCompletedActiveGateWait(
 		Event:   "completed_active_gate_wait_timeout",
 		Message: "moved " + issueLabel(issue) + " from " + strings.TrimSpace(issue.State) + " to " + targetState + " after auto-promote gate wait timeout",
 	})
-	return true
+	return true, promotedIssue(issue, targetState, now)
 }
 
 func completedActiveGateWaitTimeoutComment(

--- a/internal/orchestrator/completion_transition_test.go
+++ b/internal/orchestrator/completion_transition_test.go
@@ -591,6 +591,77 @@ func TestTransitionCompletedActiveIssuesKeepsHumanReviewWhenRequired(t *testing.
 	}
 }
 
+func TestTransitionCompletedActiveIssuesAutomatedReviewTimeoutModes(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 7, 13, 18, 0, 0, 0, time.UTC)
+	tests := []struct {
+		name         string
+		mode         string
+		timeout      string
+		ciStatus     string
+		reviewState  string
+		wantState    string
+		wantDispatch bool
+	}{
+		{name: "required absent holds for human", mode: gate.AutomatedReviewRequired, ciStatus: "success", wantState: "Human Review"},
+		{name: "optional absent merges", mode: gate.AutomatedReviewOptional, ciStatus: "success", wantState: "Merging", wantDispatch: true},
+		{name: "optional present merges", mode: gate.AutomatedReviewOptional, ciStatus: "success", reviewState: "COMMENTED", wantState: "Merging", wantDispatch: true},
+		{name: "optional late p1 reworks", mode: gate.AutomatedReviewOptional, ciStatus: "success", reviewState: "P1", wantState: "Rework"},
+		{name: "optional pending ci keeps waiting", mode: gate.AutomatedReviewOptional, ciStatus: "pending"},
+		{name: "optional can hold for human", mode: gate.AutomatedReviewOptional, timeout: autoPromoteGateWaitTimeoutHumanReview, ciStatus: "success", wantState: "Human Review"},
+		{name: "off promotes without review", mode: gate.AutomatedReviewOff, ciStatus: "success", wantState: "Merging", wantDispatch: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			issue := completionTransitionIssue("In Progress", "OPEN")
+			issue.PullRequest.URL = "https://github.test/digitaldrywood/detent/pull/1297"
+			issue.PullRequest.MergeableState = "clean"
+			issue.PullRequest.CIStatus = tt.ciStatus
+			issue.PullRequest.CodexReviewState = tt.reviewState
+			tracker := &autoPromoteTickConnector{stateIssues: []connector.Issue{issue}}
+			cfg := normalizeConfig(Config{
+				AutoPromote: AutoPromoteConfig{
+					Enabled:               true,
+					GateWaitTimeout:       15 * time.Minute,
+					GateWaitTimeoutAction: tt.timeout,
+					Gate: gate.Config{
+						Kind:            gate.KindCommand,
+						AutomatedReview: tt.mode,
+					},
+				},
+				ActiveStates:   []string{"Todo", "In Progress", "Rework", "Merging"},
+				TerminalStates: []string{"Done", "Cancelled"},
+			})
+			orch := &Orchestrator{cfg: cfg, connector: tracker}
+			state := newState(cfg)
+			state.Completed[issue.ID] = Completed{
+				Issue:       issue,
+				CompletedAt: now.Add(-16 * time.Minute),
+				FinalState:  FinalStateCompleted,
+			}
+
+			result := orch.transitionCompletedActiveIssuesToReview(context.Background(), &state, []connector.Issue{issue}, now)
+
+			if tt.wantState == "" {
+				if len(result.transitioned) != 0 || len(tracker.updates) != 0 {
+					t.Fatalf("transitioned = %#v, updates = %#v, want continued wait", result.transitioned, tracker.updates)
+				}
+				return
+			}
+			if got := state.Completed[issue.ID].Issue.State; got != tt.wantState {
+				t.Fatalf("Completed issue state = %q, want %q", got, tt.wantState)
+			}
+			if got := len(result.dispatchCandidates) == 1; got != tt.wantDispatch {
+				t.Fatalf("dispatch candidate = %t, want %t: %#v", got, tt.wantDispatch, result.dispatchCandidates)
+			}
+		})
+	}
+}
+
 func TestTransitionCompletedActiveIssuesHandlesFailedReviewUpdate(t *testing.T) {
 	t.Parallel()
 

--- a/internal/orchestrator/config.go
+++ b/internal/orchestrator/config.go
@@ -53,6 +53,7 @@ func ConfigFromWorkflow(cfg workflowconfig.Config) Config {
 			AllowedIssueLabels:    append([]string(nil), cfg.Agent.AutoPromote.AllowedIssueLabels...),
 			GateWaitState:         cfg.Agent.AutoPromote.GateWaitState,
 			GateWaitTimeout:       durationFromSeconds(cfg.Agent.AutoPromote.GateWaitTimeoutSeconds),
+			GateWaitTimeoutAction: cfg.Agent.AutoPromote.GateWaitTimeoutAction,
 			SourceState:           cfg.Agent.AutoPromote.SourceState,
 			PassState:             cfg.Agent.AutoPromote.PassState,
 			ReworkState:           cfg.Agent.AutoPromote.ReworkState,

--- a/internal/orchestrator/snapshot.go
+++ b/internal/orchestrator/snapshot.go
@@ -8,6 +8,7 @@ import (
 	"github.com/digitaldrywood/detent/internal/backendcapacity"
 	"github.com/digitaldrywood/detent/internal/budget"
 	"github.com/digitaldrywood/detent/internal/connector"
+	"github.com/digitaldrywood/detent/internal/gate"
 	releasepkg "github.com/digitaldrywood/detent/internal/release"
 	"github.com/digitaldrywood/detent/internal/runtimeoutput"
 	"github.com/digitaldrywood/detent/internal/selector"
@@ -15,10 +16,13 @@ import (
 )
 
 const (
-	artifactGateStatusMetadataKey = "detent.artifact_gate_status"
-	autoPromoteActionMetadataKey  = "detent.auto_promote_action"
-	autoPromoteReasonMetadataKey  = "detent.auto_promote_reason"
-	dispatchSkipReasonMetadataKey = "detent.dispatch_skip_reason"
+	artifactGateStatusMetadataKey           = "detent.artifact_gate_status"
+	autoPromoteActionMetadataKey            = "detent.auto_promote_action"
+	autoPromoteReasonMetadataKey            = "detent.auto_promote_reason"
+	automatedReviewModeMetadataKey          = "detent.automated_review_mode"
+	automatedReviewDeadlineMetadataKey      = "detent.automated_review_deadline"
+	automatedReviewTimeoutActionMetadataKey = "detent.automated_review_timeout_action"
+	dispatchSkipReasonMetadataKey           = "detent.dispatch_skip_reason"
 )
 
 // Snapshot converts the orchestrator State into a telemetry.Snapshot suitable
@@ -187,6 +191,19 @@ func (s State) applyGatePendingSnapshots(snapshots []telemetry.Issue, issues []c
 		if i >= len(issues) {
 			return
 		}
+		issueID := strings.TrimSpace(issues[i].ID)
+		if completed, ok := s.Completed[issueID]; ok && !completed.CompletedAt.IsZero() {
+			autoCfg := normalizeAutoPromoteConfig(s.AutoPromote)
+			mode := gate.AutomatedReviewMode(autoCfg.Gate)
+			if autoCfg.Gate.Kind == gate.KindCommand && mode != gate.AutomatedReviewOff {
+				if snapshots[i].Metadata == nil {
+					snapshots[i].Metadata = map[string]string{}
+				}
+				snapshots[i].Metadata[automatedReviewModeMetadataKey] = mode
+				snapshots[i].Metadata[automatedReviewDeadlineMetadataKey] = completed.CompletedAt.Add(autoCfg.GateWaitTimeout).UTC().Format(time.RFC3339)
+				snapshots[i].Metadata[automatedReviewTimeoutActionMetadataKey] = autoCfg.GateWaitTimeoutAction
+			}
+		}
 		if autoPromoteActiveGatePendingIssue(issues[i], &s, cfg, s.AutoPromote) {
 			snapshots[i].GatePending = true
 		}
@@ -209,6 +226,7 @@ func (s State) applyAutoPromoteDecisionSnapshots(snapshots []telemetry.Issue, is
 			}
 			summary := AutoPromoteSummaryFromIssue(issues[i])
 			summary.CompletedFinalState = autoPromoteCompletedFinalState(&s, issueID)
+			summary.AutomatedReviewWaitExpired = autoPromoteReviewWaitExpired(&s, issueID, s.AutoPromote, now)
 			decision = EvaluateAutoPromote(issues[i], summary, s.AutoPromote, now)
 		}
 		if !autoPromoteDecisionVisibleOnCard(decision) {

--- a/internal/orchestrator/snapshot_test.go
+++ b/internal/orchestrator/snapshot_test.go
@@ -198,8 +198,12 @@ func TestStateSnapshotMarksGatePendingBoardIssues(t *testing.T) {
 	now := time.Date(2026, 7, 8, 12, 0, 0, 0, time.UTC)
 	cfg := normalizeConfig(Config{
 		AutoPromote: AutoPromoteConfig{
-			Enabled: true,
-			Gate:    gate.Config{Kind: gate.KindCommand},
+			Enabled:         true,
+			GateWaitTimeout: 15 * time.Minute,
+			Gate: gate.Config{
+				Kind:            gate.KindCommand,
+				AutomatedReview: gate.AutomatedReviewOptional,
+			},
 		},
 		ActiveStates:   []string{"Todo", "In Progress", "Rework", "Merging"},
 		TerminalStates: []string{"Done", "Cancelled"},
@@ -255,6 +259,17 @@ func TestStateSnapshotMarksGatePendingBoardIssues(t *testing.T) {
 	}
 	if snapshot.Queue[0].GatePending {
 		t.Fatal("queued issue GatePending = true, want false")
+	}
+	pendingMetadata := byID["gate-pending"].Metadata
+	if got := pendingMetadata[automatedReviewModeMetadataKey]; got != gate.AutomatedReviewOptional {
+		t.Fatalf("automated review mode metadata = %q, want optional", got)
+	}
+	if got := pendingMetadata[automatedReviewTimeoutActionMetadataKey]; got != autoPromoteGateWaitTimeoutMerge {
+		t.Fatalf("automated review timeout action metadata = %q, want merge", got)
+	}
+	wantDeadline := now.Add(14 * time.Minute).UTC().Format(time.RFC3339)
+	if got := pendingMetadata[automatedReviewDeadlineMetadataKey]; got != wantDeadline {
+		t.Fatalf("automated review deadline metadata = %q, want %q", got, wantDeadline)
 	}
 }
 

--- a/internal/runner/prompt.go
+++ b/internal/runner/prompt.go
@@ -859,6 +859,7 @@ func gateAssigns(cfg gate.Config) map[string]any {
 		"kind":                     effective.Kind,
 		"run":                      effective.Run,
 		"approval_label":           effective.ApprovalLabel,
+		"automated_review":         effective.AutomatedReview,
 		"require_automated_review": requireAutomatedReview(effective),
 		"ci_failure_action":        effective.CIFailureAction,
 		"transient_ci_retry_limit": transientCIRetryLimit,
@@ -884,8 +885,7 @@ func planAssigns(cfg gate.PlanConfig) map[string]any {
 }
 
 func requireAutomatedReview(cfg gate.Config) bool {
-	effective := gate.Effective(cfg)
-	return effective.RequireAutomatedReview != nil && *effective.RequireAutomatedReview
+	return gate.AutomatedReviewMode(cfg) == gate.AutomatedReviewRequired
 }
 
 func issueAssigns(issue connector.Issue) map[string]any {

--- a/internal/web/templates/dashboard_data.go
+++ b/internal/web/templates/dashboard_data.go
@@ -42,13 +42,16 @@ const (
 )
 
 const (
-	projectKanbanBlockedSourceMetadataKey         = "detent.blocked_source"
-	projectKanbanBlockedReasonMetadataKey         = "detent.blocked_reason"
-	projectKanbanBlockedRecoveryReasonMetadataKey = "detent.blocked_recovery_reason"
-	projectKanbanAutoPromoteActionMetadataKey     = "detent.auto_promote_action"
-	projectKanbanAutoPromoteReasonMetadataKey     = "detent.auto_promote_reason"
-	projectKanbanDispatchSkipReasonMetadataKey    = "detent.dispatch_skip_reason"
-	projectKanbanArtifactGateStatusMetadataKey    = "detent.artifact_gate_status"
+	projectKanbanBlockedSourceMetadataKey                = "detent.blocked_source"
+	projectKanbanBlockedReasonMetadataKey                = "detent.blocked_reason"
+	projectKanbanBlockedRecoveryReasonMetadataKey        = "detent.blocked_recovery_reason"
+	projectKanbanAutoPromoteActionMetadataKey            = "detent.auto_promote_action"
+	projectKanbanAutoPromoteReasonMetadataKey            = "detent.auto_promote_reason"
+	projectKanbanAutomatedReviewModeMetadataKey          = "detent.automated_review_mode"
+	projectKanbanAutomatedReviewDeadlineMetadataKey      = "detent.automated_review_deadline"
+	projectKanbanAutomatedReviewTimeoutActionMetadataKey = "detent.automated_review_timeout_action"
+	projectKanbanDispatchSkipReasonMetadataKey           = "detent.dispatch_skip_reason"
+	projectKanbanArtifactGateStatusMetadataKey           = "detent.artifact_gate_status"
 )
 
 type DashboardData struct {
@@ -3918,6 +3921,20 @@ func prPipelineAutoPromoteWaitReason(issue telemetry.Issue) string {
 	reason := strings.TrimSpace(issue.Metadata[projectKanbanAutoPromoteReasonMetadataKey])
 	if reason == "" {
 		return ""
+	}
+	if reason == "automated_review_missing" {
+		mode := strings.TrimSpace(issue.Metadata[projectKanbanAutomatedReviewModeMetadataKey])
+		timeoutAction := strings.TrimSpace(issue.Metadata[projectKanbanAutomatedReviewTimeoutActionMetadataKey])
+		if prPipelineLaneID(issue.State) == "human-review" && timeoutAction == "human_review" {
+			return "held for human review after " + mode + " automated review timed out"
+		}
+		if mode == "optional" && timeoutAction == "merge" {
+			deadline, err := time.Parse(time.RFC3339, strings.TrimSpace(issue.Metadata[projectKanbanAutomatedReviewDeadlineMetadataKey]))
+			if err == nil {
+				return "waiting for optional automated review; will merge at " + localTimeToken(deadline, LocalTimeOnly)
+			}
+			return "waiting for optional automated review; will merge when the wait expires"
+		}
 	}
 	return "auto-promote " + action + ": " + reason
 }

--- a/internal/web/templates/dashboard_data_test.go
+++ b/internal/web/templates/dashboard_data_test.go
@@ -2829,6 +2829,55 @@ func TestPRPipelineWaitDetailExplainsHumanReviewReasons(t *testing.T) {
 	}
 }
 
+func TestPRPipelineWaitDetailDistinguishesOptionalReviewFromHumanHold(t *testing.T) {
+	t.Parallel()
+
+	deadline := time.Date(2026, 7, 13, 19, 30, 0, 0, time.UTC)
+	tests := []struct {
+		name  string
+		issue telemetry.Issue
+		want  string
+	}{
+		{
+			name: "optional review shows merge deadline",
+			issue: telemetry.Issue{
+				State: "In Progress",
+				Metadata: map[string]string{
+					projectKanbanAutoPromoteActionMetadataKey:            "await_review",
+					projectKanbanAutoPromoteReasonMetadataKey:            "automated_review_missing",
+					projectKanbanAutomatedReviewModeMetadataKey:          "optional",
+					projectKanbanAutomatedReviewTimeoutActionMetadataKey: "merge",
+					projectKanbanAutomatedReviewDeadlineMetadataKey:      deadline.Format(time.RFC3339),
+				},
+			},
+			want: "waiting for optional automated review; will merge at " + localTimeToken(deadline, LocalTimeOnly),
+		},
+		{
+			name: "human review shows explicit hold",
+			issue: telemetry.Issue{
+				State: "Human Review",
+				Metadata: map[string]string{
+					projectKanbanAutoPromoteActionMetadataKey:            "await_review",
+					projectKanbanAutoPromoteReasonMetadataKey:            "automated_review_missing",
+					projectKanbanAutomatedReviewModeMetadataKey:          "required",
+					projectKanbanAutomatedReviewTimeoutActionMetadataKey: "human_review",
+				},
+			},
+			want: "held for human review after required automated review timed out",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			if got := prPipelineWaitDetail(tt.issue); got != tt.want {
+				t.Fatalf("prPipelineWaitDetail() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestPRPipelineWaitDetailIncludesDispatchSkipReason(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

- add backward-compatible required, optional, and off automated review modes
- make the gate wait timeout action explicit, with optional defaulting to merge
- expose review wait deadlines on the dashboard and warn when doctor detects an inactive review producer

Fixes #1297

## UI Surface Contract

- [x] N/A, or the linked issue explicitly authorizes any high-impact UI surface, layout, density, first-viewport, or responsive visibility tradeoff.
- [x] Persistent top-of-screen messaging is explicitly authorized by the issue, or this PR does not add it.
- [x] Visual changes to primary operator screens include screenshot or browser verification below.
  - N/A: this changes existing gate wait-detail copy only; it does not change layout or responsive behavior.

## Test Plan

- [x] make check
- [x] table-driven gate mode and timeout-action tests
- [x] doctor review-producer sampling tests