### PR TITLE
fix(merge): prevent merging worker livelock

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1048,6 +1048,7 @@ func Default() Config {
 			MaxRetryBackoffMS:       300000,
 			OverloadRetryDelayMS:    DefaultOverloadRetryDelayMS,
 			NoProgressSpendLimitUSD: DefaultNoProgressSpendLimitUSD,
+			MergeFastPath:           MergeFastPath{Enabled: true},
 			FailureBreaker: FailureBreaker{
 				SameClassLimit:  DefaultFailureBreakerSameClassLimit,
 				WindowSeconds:   DefaultFailureBreakerWindowSeconds,

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1100,8 +1100,8 @@ func TestParseWorkflowDefaults(t *testing.T) {
 	if cfg.Agent.MaxSessionContextMultiplier != 0 {
 		t.Fatalf("Agent.MaxSessionContextMultiplier = %v, want disabled default", cfg.Agent.MaxSessionContextMultiplier)
 	}
-	if cfg.Agent.MergeFastPath.Enabled {
-		t.Fatal("Agent.MergeFastPath.Enabled = true, want false default")
+	if !cfg.Agent.MergeFastPath.Enabled {
+		t.Fatal("Agent.MergeFastPath.Enabled = false, want true default")
 	}
 	if cfg.Agent.ExperimentalThreadResume {
 		t.Fatal("Agent.ExperimentalThreadResume = true, want disabled default")
@@ -1396,18 +1396,31 @@ func TestValidatePlanRejectsInvalidConfig(t *testing.T) {
 func TestParseWorkflowAgentMergeFastPath(t *testing.T) {
 	t.Parallel()
 
-	workflow, err := ParseWorkflow([]byte(`---
+	for _, tt := range []struct {
+		name    string
+		enabled string
+		want    bool
+	}{
+		{name: "enabled", enabled: "true", want: true},
+		{name: "disabled", enabled: "false", want: false},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			workflow, err := ParseWorkflow([]byte(`---
 agent:
   merge_fast_path:
-    enabled: true
+    enabled: ` + tt.enabled + `
 ---
 Body
 `))
-	if err != nil {
-		t.Fatalf("ParseWorkflow() error = %v", err)
-	}
-	if !workflow.Config.Agent.MergeFastPath.Enabled {
-		t.Fatal("Agent.MergeFastPath.Enabled = false, want true")
+			if err != nil {
+				t.Fatalf("ParseWorkflow() error = %v", err)
+			}
+			if workflow.Config.Agent.MergeFastPath.Enabled != tt.want {
+				t.Fatalf("Agent.MergeFastPath.Enabled = %t, want %t", workflow.Config.Agent.MergeFastPath.Enabled, tt.want)
+			}
+		})
 	}
 }
 

--- a/internal/orchestrator/autopromote_tick.go
+++ b/internal/orchestrator/autopromote_tick.go
@@ -963,7 +963,7 @@ func mergeWorkerSlotDecisionAttrs(
 	return attrs
 }
 
-func (o *Orchestrator) failStalledMergeWorkerStarts(state *State, now time.Time) {
+func (o *Orchestrator) failStalledMergeWorkerStarts(ctx context.Context, state *State, now time.Time) {
 	if state == nil || state.Draining {
 		return
 	}
@@ -982,12 +982,18 @@ func (o *Orchestrator) failStalledMergeWorkerStarts(state *State, now time.Time)
 		err := fmt.Errorf("merge worker did not report process or session startup within %s", timeout)
 		o.logMergeWorkerFailure(running.Issue, "runner_startup_timeout", err)
 		o.recordMergeFailed(state, running.Issue, now, "runner_startup_timeout", err)
+		o.recordProjectAttemptOutcome(state, issueID, now, store.WorkAttemptTerminalFailure, err, "runner_startup_timeout", err.Error())
+		o.completeDurableWorkAttempt(ctx, state, running, now, store.WorkAttemptTerminalFailure, "runner_startup_timeout", err.Error(), "starting", "merge worker startup timed out")
 		o.releaseGlobalDispatchSlot(running.globalSlot)
 		if running.cancel != nil {
 			running.cancel()
 		}
 		delete(state.Running, issueID)
-		o.scheduleRetry(state, running.Issue, nextAttempt(running.Attempt), now, err.Error(), false, running.WorkerHost)
+		attempt := nextAttempt(running.Attempt)
+		if attempt > maxMergeWorkerRunnerFailures && o.blockExhaustedMergeWorker(ctx, state, running, now, attempt, err) {
+			continue
+		}
+		o.scheduleRetry(state, running.Issue, attempt, now, err.Error(), false, running.WorkerHost)
 		recordStateEvent(state, telemetry.ActivityEvent{
 			At:      now,
 			Event:   "merge_worker_startup_timeout",

--- a/internal/orchestrator/autopromote_tick_test.go
+++ b/internal/orchestrator/autopromote_tick_test.go
@@ -3206,6 +3206,56 @@ func TestTickFailsAndRetriesStaleMergingWithoutStartupTelemetry(t *testing.T) {
 	}
 }
 
+func TestFailStalledMergeWorkerStartsBlocksAfterRetryCap(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 7, 13, 21, 30, 0, 0, time.UTC)
+	issue := autoPromoteTickIssue("issue-stalled-merge-exhausted", []string{"bug"}, &connector.PullRequest{
+		Number:         72,
+		URL:            "https://github.test/digitaldrywood/detent/pull/72",
+		State:          "OPEN",
+		MergeableState: "clean",
+		CIStatus:       "success",
+		HeadSHA:        "head-stalled",
+	})
+	issue.State = "Merging"
+	issue.Identifier = "digitaldrywood/detent#72"
+	cfg := normalizeConfig(Config{
+		PollInterval:        time.Minute,
+		MaxConcurrentAgents: 1,
+		ActiveStates:        []string{"Todo", "In Progress", "Rework", "Merging"},
+		TerminalStates:      []string{"Done", "Cancelled"},
+	})
+	tracker := &autoPromoteTickConnector{stateIssues: []connector.Issue{issue}}
+	orch := &Orchestrator{
+		cfg:       cfg,
+		connector: tracker,
+		logger:    slog.New(slog.NewTextHandler(io.Discard, nil)),
+	}
+	state := newState(cfg)
+	state.Running[issue.ID] = Running{
+		Issue:     cloneIssue(issue),
+		Attempt:   maxMergeWorkerRunnerFailures,
+		StartedAt: now.Add(-3 * time.Minute),
+	}
+
+	orch.failStalledMergeWorkerStarts(context.Background(), &state, now)
+
+	if _, ok := state.Retry[issue.ID]; ok {
+		t.Fatalf("Retry[%q] present after exhausted startup failures", issue.ID)
+	}
+	if _, ok := state.Running[issue.ID]; ok {
+		t.Fatalf("Running[%q] present after exhausted startup failures", issue.ID)
+	}
+	blocked, ok := state.Blocked[issue.ID]
+	if !ok || blocked.Issue.State != blockedStatusState {
+		t.Fatalf("Blocked[%q] = %#v, want Blocked issue", issue.ID, blocked)
+	}
+	if got := tracker.updates; !reflect.DeepEqual(got, []autoPromoteTickUpdate{{issueID: issue.ID, state: blockedStatusState}}) {
+		t.Fatalf("updates = %#v, want Blocked transition", got)
+	}
+}
+
 func TestTickDispatchesFreshAutoPromotedMergingIssue(t *testing.T) {
 	t.Parallel()
 
@@ -4186,7 +4236,7 @@ func TestTickPreservesDueMergingRetryWhenLaneFullAndMergingFetchOmitted(t *testi
 	}
 }
 
-func TestHandleRunResultReworksMergeWorkerAfterRepeatedRunnerFailures(t *testing.T) {
+func TestHandleRunResultBlocksMergeWorkerAfterRepeatedInterruptedSessions(t *testing.T) {
 	t.Parallel()
 
 	now := time.Date(2026, 6, 25, 21, 10, 0, 0, time.UTC)
@@ -4222,19 +4272,23 @@ func TestHandleRunResultReworksMergeWorkerAfterRepeatedRunnerFailures(t *testing
 	orch.handleRunResult(context.Background(), &state, runpkg.Completion{
 		IssueID:     issue.ID,
 		CompletedAt: now,
-		Err:         errors.New("run agent turn: stream turn: EOF"),
+		Err:         errors.New("codex turn failed: status interrupted: null"),
 	})
 
 	if _, ok := state.Retry[issue.ID]; ok {
 		t.Fatalf("Retry[%q] present after exhausted merge runner failures", issue.ID)
 	}
-	if got := tracker.updates; !reflect.DeepEqual(got, []autoPromoteTickUpdate{{issueID: issue.ID, state: autoPromoteReworkState}}) {
-		t.Fatalf("updates = %#v, want Rework transition", got)
+	if got := tracker.updates; !reflect.DeepEqual(got, []autoPromoteTickUpdate{{issueID: issue.ID, state: blockedStatusState}}) {
+		t.Fatalf("updates = %#v, want Blocked transition", got)
+	}
+	blocked, ok := state.Blocked[issue.ID]
+	if !ok || blocked.Issue.State != blockedStatusState {
+		t.Fatalf("Blocked[%q] = %#v, want Blocked issue", issue.ID, blocked)
 	}
 	if len(tracker.comments) != 1 {
 		t.Fatalf("comments = %#v, want one exhausted retry comment", tracker.comments)
 	}
-	for _, fragment := range []string{"runner_failed_retry_exhausted", "stream turn: EOF", "pull request"} {
+	for _, fragment := range []string{mergeWorkerRetryExhaustedReason, "status interrupted: null", "pull request"} {
 		if !strings.Contains(tracker.comments[0].body, fragment) {
 			t.Fatalf("comment %q missing fragment %q", tracker.comments[0].body, fragment)
 		}
@@ -4636,7 +4690,7 @@ func TestHandleRunResultCompletesMergeWorkerWhenLatestIssueIsTerminal(t *testing
 	}
 }
 
-func TestHandleRunResultReworksMergeWorkerAfterRepeatedIncompleteResults(t *testing.T) {
+func TestHandleRunResultBlocksMergeWorkerAfterRepeatedIncompleteResults(t *testing.T) {
 	t.Parallel()
 
 	now := time.Date(2026, 6, 26, 13, 20, 0, 0, time.UTC)
@@ -4678,13 +4732,13 @@ func TestHandleRunResultReworksMergeWorkerAfterRepeatedIncompleteResults(t *test
 	if _, ok := state.Retry[issue.ID]; ok {
 		t.Fatalf("Retry[%q] present after repeated incomplete merge results", issue.ID)
 	}
-	if got := tracker.updates; !reflect.DeepEqual(got, []autoPromoteTickUpdate{{issueID: issue.ID, state: autoPromoteReworkState}}) {
-		t.Fatalf("updates = %#v, want Rework transition", got)
+	if got := tracker.updates; !reflect.DeepEqual(got, []autoPromoteTickUpdate{{issueID: issue.ID, state: blockedStatusState}}) {
+		t.Fatalf("updates = %#v, want Blocked transition", got)
 	}
 	if len(tracker.comments) != 1 {
 		t.Fatalf("comments = %#v, want one exhausted retry comment", tracker.comments)
 	}
-	for _, fragment := range []string{"runner_failed_retry_exhausted", "terminal issue or pull request state", "pull request"} {
+	for _, fragment := range []string{mergeWorkerRetryExhaustedReason, "terminal issue or pull request state", "pull request"} {
 		if !strings.Contains(tracker.comments[0].body, fragment) {
 			t.Fatalf("comment %q missing fragment %q", tracker.comments[0].body, fragment)
 		}

--- a/internal/orchestrator/autopromote_tick_test.go
+++ b/internal/orchestrator/autopromote_tick_test.go
@@ -4285,6 +4285,15 @@ func TestHandleRunResultBlocksMergeWorkerAfterRepeatedInterruptedSessions(t *tes
 	if !ok || blocked.Issue.State != blockedStatusState {
 		t.Fatalf("Blocked[%q] = %#v, want Blocked issue", issue.ID, blocked)
 	}
+	orch.setBlockedStatusIssue(&state, connector.Issue{
+		ID:         issue.ID,
+		Identifier: issue.Identifier,
+		Title:      issue.Title,
+		State:      blockedStatusState,
+	}, now.Add(time.Minute))
+	if got := state.Blocked[issue.ID].Reason; got != blocked.Reason {
+		t.Fatalf("Blocked[%q].Reason after status refresh = %q, want preserved %q", issue.ID, got, blocked.Reason)
+	}
 	if len(tracker.comments) != 1 {
 		t.Fatalf("comments = %#v, want one exhausted retry comment", tracker.comments)
 	}

--- a/internal/orchestrator/dependency_autounblock.go
+++ b/internal/orchestrator/dependency_autounblock.go
@@ -851,7 +851,7 @@ func (o *Orchestrator) issueHasStickyBlockReason(ctx context.Context, state *Sta
 
 func stickyBlockReason(reason string) bool {
 	reason = strings.ToLower(strings.TrimSpace(reason))
-	if strings.HasPrefix(reason, tokenCeilingBlockedReasonPrefix) {
+	if strings.HasPrefix(reason, tokenCeilingBlockedReasonPrefix) || strings.HasPrefix(reason, mergeWorkerRetryExhaustedReason) {
 		return true
 	}
 	switch reason {

--- a/internal/orchestrator/dispatch_test.go
+++ b/internal/orchestrator/dispatch_test.go
@@ -105,7 +105,6 @@ func TestConfigFromWorkflowIncludesDispatchControls(t *testing.T) {
 	cfg.Agent.AutoPromote.GateWaitState = " Review "
 	cfg.Agent.AutoPromote.GateWaitTimeoutSeconds = 900
 	cfg.Agent.AutoPromote.ReworkLimit = 2
-	cfg.Agent.MergeFastPath.Enabled = true
 	cfg.Agent.OverloadRetryDelayMS = 60000
 	cfg.Deliverable.MergeMethod = workflowconfig.MergeMethodRebase
 	cfg.Agent.OutputTruncation.MaxBytes = 4096

--- a/internal/orchestrator/implement_progress_test.go
+++ b/internal/orchestrator/implement_progress_test.go
@@ -533,6 +533,7 @@ func TestStickyBlockReasonIncludesCircuitBreakers(t *testing.T) {
 		workpadBlockedUnactionedReason,
 		"token_ceiling_circuit_breaker",
 		tokenCeilingBlockedReasonPrefix + "observed 16100000 tokens above the 16000000 max_session_tokens ceiling",
+		mergeWorkerRetryExhaustedReason,
 	} {
 		if !stickyBlockReason(reason) {
 			t.Fatalf("stickyBlockReason(%q) = false, want true", reason)

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -53,6 +53,7 @@ const (
 	blockedReasonDependency             = "blocked by non-terminal dependency"
 	blockedReasonProjectStatus          = "blocked by project status"
 	mergeWorkerTerminalStateMissing     = "merge worker completed without reaching a terminal issue or pull request state"
+	mergeWorkerRetryExhaustedReason     = "merge_worker_retry_exhausted"
 )
 
 var (

--- a/internal/orchestrator/reconcile.go
+++ b/internal/orchestrator/reconcile.go
@@ -489,7 +489,8 @@ func (o *Orchestrator) setBlockedStatusIssue(state *State, issue connector.Issue
 		existing.Source == BlockedSourceProjectStatus &&
 		(strings.HasPrefix(existing.Reason, instantFailureBlockedReasonPrefix) ||
 			strings.HasPrefix(existing.Reason, repeatedFailureBlockedReasonPrefix) ||
-			strings.HasPrefix(existing.Reason, tokenCeilingBlockedReasonPrefix)) &&
+			strings.HasPrefix(existing.Reason, tokenCeilingBlockedReasonPrefix) ||
+			strings.HasPrefix(existing.Reason, mergeWorkerRetryExhaustedReason)) &&
 		strings.TrimSpace(issue.BlockerReason) == "" {
 		existing.Issue = cloneIssue(issue)
 		state.Blocked[issue.ID] = existing

--- a/internal/orchestrator/run_completion.go
+++ b/internal/orchestrator/run_completion.go
@@ -194,7 +194,7 @@ func (o *Orchestrator) handleRunResult(ctx context.Context, state *State, event 
 			o.recordMergeFailed(state, running.Issue, event.CompletedAt, "runner_failed", event.Err)
 		}
 		if mergeWorkerIssue(running.Issue) && attempt > maxMergeWorkerRunnerFailures {
-			if o.reworkExhaustedMergeWorker(ctx, state, running, event.CompletedAt, attempt, event.Err) {
+			if o.blockExhaustedMergeWorker(ctx, state, running, event.CompletedAt, attempt, event.Err) {
 				return
 			}
 		}
@@ -1063,7 +1063,7 @@ func (o *Orchestrator) failProgrammaticMergeWorkerResult(
 	o.recordMergeFailed(state, running.Issue, event.CompletedAt, reason, err)
 	attempt := nextAttempt(running.Attempt)
 	if attempt > maxMergeWorkerRunnerFailures {
-		if o.reworkExhaustedMergeWorker(ctx, state, running, event.CompletedAt, attempt, err) {
+		if o.blockExhaustedMergeWorker(ctx, state, running, event.CompletedAt, attempt, err) {
 			return
 		}
 	}
@@ -1158,9 +1158,10 @@ func (o *Orchestrator) handleIncompleteMergeWorkerResult(
 	o.recordProjectAttemptOutcome(state, event.IssueID, event.CompletedAt, store.WorkAttemptTerminalFailure, err, workAttemptErrorMergeIncomplete, err.Error())
 	o.completeDurableWorkAttempt(ctx, state, running, event.CompletedAt, store.WorkAttemptTerminalFailure, workAttemptErrorMergeIncomplete, err.Error(), "merging", "merge worker completed without terminal state")
 	o.logMergeWorkerFailure(running.Issue, "terminal_state_missing", err)
+	o.recordMergeFailed(state, running.Issue, event.CompletedAt, "terminal_state_missing", err)
 	attempt := nextAttempt(running.Attempt)
 	if attempt > maxMergeWorkerRunnerFailures {
-		if o.reworkExhaustedMergeWorker(ctx, state, running, event.CompletedAt, attempt, err) {
+		if o.blockExhaustedMergeWorker(ctx, state, running, event.CompletedAt, attempt, err) {
 			return
 		}
 	}
@@ -1180,7 +1181,7 @@ func (o *Orchestrator) handleIncompleteMergeWorkerResult(
 	})
 }
 
-func (o *Orchestrator) reworkExhaustedMergeWorker(
+func (o *Orchestrator) blockExhaustedMergeWorker(
 	ctx context.Context,
 	state *State,
 	running Running,
@@ -1192,14 +1193,14 @@ func (o *Orchestrator) reworkExhaustedMergeWorker(
 	if issueID == "" || o.connector == nil {
 		return false
 	}
-	if err := o.updateIssueStateByID(ctx, state, issueID, running.Issue, autoPromoteReworkState, completedAt, "merge_worker_retry_exhausted"); err != nil {
+	if err := o.updateIssueStateByID(ctx, state, issueID, running.Issue, blockedStatusState, completedAt, mergeWorkerRetryExhaustedReason); err != nil {
 		if o.logger != nil {
 			o.logger.Warn(
-				"merge_worker_rework_failed",
+				"merge_worker_block_failed",
 				"issue_id", issueID,
 				"identifier", running.Issue.Identifier,
-				"reason", "runner_failed_retry_exhausted",
-				"target_state", autoPromoteReworkState,
+				"reason", mergeWorkerRetryExhaustedReason,
+				"target_state", blockedStatusState,
 				"error", err,
 			)
 		}
@@ -1208,10 +1209,10 @@ func (o *Orchestrator) reworkExhaustedMergeWorker(
 	if comment := mergeWorkerRetryExhaustedComment(running.Issue, attempt, err); strings.TrimSpace(comment) != "" {
 		if err := o.connector.CreateComment(ctx, issueID, comment); err != nil && o.logger != nil {
 			o.logger.Warn(
-				"merge_worker_rework_comment_failed",
+				"merge_worker_block_comment_failed",
 				"issue_id", issueID,
 				"identifier", running.Issue.Identifier,
-				"reason", "runner_failed_retry_exhausted",
+				"reason", mergeWorkerRetryExhaustedReason,
 				"error", err,
 			)
 		}
@@ -1224,6 +1225,20 @@ func (o *Orchestrator) reworkExhaustedMergeWorker(
 	delete(state.BudgetRefusals, issueID)
 	delete(state.PriorAttempts, issueID)
 	delete(state.Completed, issueID)
+	issue := cloneIssue(running.Issue)
+	issue.State = blockedStatusState
+	issue.BlockerReason = mergeWorkerRetryExhaustedReason + ": " + errorString(err)
+	blockedAt := completedAt.UTC()
+	issue.StageUpdatedAt = &blockedAt
+	if state.Blocked == nil {
+		state.Blocked = map[string]Blocked{}
+	}
+	state.Blocked[issueID] = Blocked{
+		Issue:     issue,
+		Reason:    mergeWorkerRetryExhaustedReason,
+		BlockedAt: completedAt,
+		Source:    BlockedSourceProjectStatus,
+	}
 	recordStateEvent(state, telemetry.ActivityEvent{
 		At:      completedAt,
 		Event:   "merge_worker_retry_exhausted",
@@ -1234,8 +1249,9 @@ func (o *Orchestrator) reworkExhaustedMergeWorker(
 
 func mergeWorkerRetryExhaustedComment(issue connector.Issue, attempt int, err error) string {
 	var b strings.Builder
-	b.WriteString("Merge worker retries were exhausted; routed this issue from Merging to Rework.")
-	b.WriteString("\n\n- reason: runner_failed_retry_exhausted")
+	b.WriteString("Merge worker retries were exhausted; parked this issue in Blocked to stop automatic redispatch.")
+	b.WriteString("\n\n- reason: ")
+	b.WriteString(mergeWorkerRetryExhaustedReason)
 	if attempt > 0 {
 		b.WriteString("\n- attempt: ")
 		b.WriteString(strconv.Itoa(attempt))
@@ -1258,6 +1274,7 @@ func mergeWorkerRetryExhaustedComment(issue connector.Issue, attempt int, err er
 			b.WriteString(ciStatus)
 		}
 	}
+	b.WriteString("\n\nResolve the merge failure, then move the issue back to Merging to retry.")
 	return b.String()
 }
 

--- a/internal/orchestrator/tick.go
+++ b/internal/orchestrator/tick.go
@@ -296,7 +296,7 @@ func (o *Orchestrator) refreshActiveRuns(ctx context.Context, state *State, now 
 		o.reapWorkspacesIfDue(ctx, state, now)
 	}
 	o.reconcileRunningIssues(ctx, state, now)
-	o.failStalledMergeWorkerStarts(state, now)
+	o.failStalledMergeWorkerStarts(ctx, state, now)
 	o.heartbeatRunningClaims(ctx, state, now)
 	o.heartbeatRunningWorkAttempts(ctx, state, now)
 }


### PR DESCRIPTION
## Summary

- enable the direct merge fast path by default while preserving an explicit opt-out
- count interrupted, incomplete, programmatic, and startup merge failures against one retry cap
- park exhausted merge items in sticky Blocked state so they release the serialized lane

Fixes #1303

## UI Surface Contract

- [x] N/A; this change does not alter UI surfaces.
- [x] This PR does not add persistent top-of-screen messaging.
- [x] N/A; this PR has no visual changes.

## Test Plan

- [x] `go test ./internal/config ./internal/orchestrator`
- [x] `go test -race ./internal/cli -run '^TestRuntimeGitHubTokenRefresherResolvesConfiguredGHSentinelWithoutActionsToken$' -count=1 -v`
- [x] `make check`
