### PR TITLE
fix(merge): preserve checked heads

### DIFF
--- a/README.md
+++ b/README.md
@@ -2009,9 +2009,12 @@ When GitHub reports `HAS_MERGE_QUEUE`, Detent delegates every eligible green
 candidate to the repository's native merge queue instead of rebasing each PR
 through the serialized worker. GitHub owns merge-group validation and batching;
 Detent keeps the issues in `Merging`, observes their queue entries, and
-reconciles them to `Done` after GitHub reports the PR merged. Repositories
-without a native queue continue through the serialized rebase and current-head
-CI path.
+reconciles them to `Done` after GitHub reports the PR merged. Without a native
+queue, a BEHIND PR whose existing head is mergeable and already has green
+required checks is merged directly against the current base without rewriting
+the checked head. Rebase is reserved for fallback cases; if a refreshed head
+is missing required contexts, Detent routes the issue to `Rework` instead of
+retrying an incomplete merge worker.
 
 Inside the serialized `Merging` lane, avoid duplicating the full local release
 gate when it does not buy new signal. If the PR already passed the pre-review

--- a/internal/cli/doctor_workflow_lint.go
+++ b/internal/cli/doctor_workflow_lint.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/BurntSushi/toml"
+	"gopkg.in/yaml.v3"
 
 	workflowconfig "github.com/digitaldrywood/detent/internal/config"
 	globalconfig "github.com/digitaldrywood/detent/internal/config/global"
@@ -65,10 +66,226 @@ func checkDoctorWorkflowLint(ctx context.Context, projectID string, project glob
 		}
 	}
 	checks = append(checks, checkDoctorInertWorkflowBlocks(projectID, workflowPath, cfg)...)
+	checks = append(checks, checkDoctorRequiredCheckTriggers(projectID, project, cfg)...)
 	checks = append(checks, checkDoctorGateCommand(ctx, projectID, workflowPath, project, cfg, deps)...)
 	checks = append(checks, checkDoctorShipSkill(projectID, workflowPath, cfg, deps)...)
 	checks = append(checks, checkDoctorWorkflowRuntimeLint(ctx, projectID, workflowPath, storePath, cfg, deps)...)
 	return checks
+}
+
+type doctorRequiredCheckTrigger struct {
+	matched bool
+	safe    bool
+	risks   []string
+}
+
+func checkDoctorRequiredCheckTriggers(projectID string, project globalconfig.Project, cfg workflowconfig.Config) []doctorCheck {
+	required := uniqueDoctorStrings(cfg.Gate.RequiredStatusChecks)
+	if len(required) == 0 || cfg.Deliverable.Kind != workflowconfig.DeliverablePullRequest {
+		return nil
+	}
+	root, err := expandDoctorWorkspacePath(projectSourceRoot(project, cfg))
+	if err != nil {
+		return nil
+	}
+	dir := filepath.Join(root, ".github", "workflows")
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return nil
+	}
+	triggers := make(map[string]doctorRequiredCheckTrigger, len(required))
+	for _, name := range required {
+		triggers[name] = doctorRequiredCheckTrigger{}
+	}
+	for _, entry := range entries {
+		if entry.IsDir() || !doctorWorkflowYAMLFile(entry.Name()) {
+			continue
+		}
+		path := filepath.Join(dir, entry.Name())
+		raw, err := os.ReadFile(path)
+		if err != nil {
+			continue
+		}
+		var document yaml.Node
+		if err := yaml.Unmarshal(raw, &document); err != nil || len(document.Content) == 0 {
+			continue
+		}
+		rootNode := document.Content[0]
+		risks := doctorRequiredCheckTriggerRisks(doctorYAMLMapValue(rootNode, "on"))
+		jobs := doctorYAMLMapValue(rootNode, "jobs")
+		if jobs == nil || jobs.Kind != yaml.MappingNode {
+			continue
+		}
+		for index := 0; index+1 < len(jobs.Content); index += 2 {
+			jobID := strings.TrimSpace(jobs.Content[index].Value)
+			jobNode := jobs.Content[index+1]
+			jobName := doctorYAMLScalarValue(doctorYAMLMapValue(jobNode, "name"))
+			for _, requiredName := range required {
+				if !doctorRequiredCheckMatchesJob(requiredName, jobID, jobName) {
+					continue
+				}
+				trigger := triggers[requiredName]
+				trigger.matched = true
+				if len(risks) == 0 {
+					trigger.safe = true
+				} else {
+					relativePath, pathErr := filepath.Rel(root, path)
+					if pathErr != nil {
+						relativePath = path
+					}
+					for _, risk := range risks {
+						trigger.risks = append(trigger.risks, filepath.ToSlash(relativePath)+": "+risk)
+					}
+				}
+				triggers[requiredName] = trigger
+			}
+		}
+	}
+	warnings := make([]string, 0)
+	for _, name := range required {
+		trigger := triggers[name]
+		if !trigger.matched || trigger.safe {
+			continue
+		}
+		warnings = append(warnings, name+" ("+strings.Join(uniqueDoctorStrings(trigger.risks), "; ")+")")
+	}
+	if len(warnings) == 0 {
+		return nil
+	}
+	return []doctorCheck{{
+		Name:   "Project " + projectID + " workflow lint required check triggers",
+		Status: doctorWarn,
+		Detail: "required checks are not produced on every pull-request head: " + strings.Join(warnings, ", "),
+		Hint:   "Remove pull_request path filters and include the synchronize activity for required-check workflows; skip non-applicable work inside the job while still reporting the required check.",
+	}}
+}
+
+func doctorWorkflowYAMLFile(name string) bool {
+	switch strings.ToLower(filepath.Ext(name)) {
+	case ".yml", ".yaml":
+		return true
+	default:
+		return false
+	}
+}
+
+func doctorRequiredCheckMatchesJob(required string, jobID string, jobName string) bool {
+	required = strings.TrimSpace(required)
+	if index := strings.LastIndex(required, " / "); index >= 0 {
+		required = strings.TrimSpace(required[index+3:])
+	}
+	return strings.EqualFold(required, strings.TrimSpace(jobID)) || strings.EqualFold(required, strings.TrimSpace(jobName))
+}
+
+func doctorRequiredCheckTriggerRisks(on *yaml.Node) []string {
+	if on == nil {
+		return []string{"no pull_request or push trigger"}
+	}
+	switch on.Kind {
+	case yaml.ScalarNode:
+		if doctorRequiredCheckHeadEvent(on.Value) {
+			return nil
+		}
+		return []string{"no pull_request or push trigger"}
+	case yaml.SequenceNode:
+		for _, event := range on.Content {
+			if doctorRequiredCheckHeadEvent(event.Value) {
+				return nil
+			}
+		}
+		return []string{"no pull_request or push trigger"}
+	case yaml.MappingNode:
+		risks := make([]string, 0, 4)
+		pullRequest := doctorYAMLMapValue(on, "pull_request")
+		if pullRequest != nil {
+			pullRequestRisks := doctorPullRequestEventRisks(pullRequest)
+			if len(pullRequestRisks) == 0 {
+				return nil
+			}
+			risks = append(risks, pullRequestRisks...)
+		}
+		push := doctorYAMLMapValue(on, "push")
+		if push != nil {
+			pushRisks := doctorPushEventRisks(push)
+			if len(pushRisks) == 0 {
+				return nil
+			}
+			risks = append(risks, pushRisks...)
+		}
+		if pullRequest == nil && push == nil {
+			return []string{"no pull_request or push trigger"}
+		}
+		return risks
+	default:
+		return []string{"no pull_request or push trigger"}
+	}
+}
+
+func doctorRequiredCheckHeadEvent(event string) bool {
+	event = strings.ToLower(strings.TrimSpace(event))
+	return event == "pull_request" || event == "push"
+}
+
+func doctorPullRequestEventRisks(event *yaml.Node) []string {
+	if event.Kind != yaml.MappingNode {
+		return nil
+	}
+	risks := make([]string, 0, 2)
+	if doctorYAMLMapValue(event, "paths") != nil || doctorYAMLMapValue(event, "paths-ignore") != nil {
+		risks = append(risks, "pull_request paths filter")
+	}
+	if types := doctorYAMLMapValue(event, "types"); types != nil && !doctorYAMLContainsScalar(types, "synchronize") {
+		risks = append(risks, "pull_request types exclude synchronize")
+	}
+	return risks
+}
+
+func doctorPushEventRisks(event *yaml.Node) []string {
+	if event.Kind != yaml.MappingNode {
+		return nil
+	}
+	risks := make([]string, 0, 2)
+	if doctorYAMLMapValue(event, "paths") != nil || doctorYAMLMapValue(event, "paths-ignore") != nil {
+		risks = append(risks, "push paths filter")
+	}
+	if doctorYAMLMapValue(event, "branches") != nil || doctorYAMLMapValue(event, "branches-ignore") != nil {
+		risks = append(risks, "push branch filter")
+	}
+	return risks
+}
+
+func doctorYAMLMapValue(node *yaml.Node, key string) *yaml.Node {
+	if node == nil || node.Kind != yaml.MappingNode {
+		return nil
+	}
+	for index := 0; index+1 < len(node.Content); index += 2 {
+		if strings.EqualFold(strings.TrimSpace(node.Content[index].Value), key) {
+			return node.Content[index+1]
+		}
+	}
+	return nil
+}
+
+func doctorYAMLScalarValue(node *yaml.Node) string {
+	if node == nil || node.Kind != yaml.ScalarNode {
+		return ""
+	}
+	return strings.TrimSpace(node.Value)
+}
+
+func doctorYAMLContainsScalar(node *yaml.Node, value string) bool {
+	if node == nil {
+		return false
+	}
+	if node.Kind == yaml.ScalarNode {
+		return strings.EqualFold(strings.TrimSpace(node.Value), value)
+	}
+	for _, child := range node.Content {
+		if doctorYAMLContainsScalar(child, value) {
+			return true
+		}
+	}
+	return false
 }
 
 func doctorWorkflowLintPath(project globalconfig.Project) string {

--- a/internal/cli/doctor_workflow_lint_test.go
+++ b/internal/cli/doctor_workflow_lint_test.go
@@ -117,6 +117,67 @@ func TestCheckDoctorWorkflowLintStaticLandmines(t *testing.T) {
 	}
 }
 
+func TestCheckDoctorWorkflowLintWarnsForPathFilteredRequiredCheck(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		on          string
+		wantWarning bool
+		wantDetail  string
+	}{
+		{name: "pull request paths", on: "pull_request:\n    paths:\n      - '**/*.go'", wantWarning: true, wantDetail: "pull_request paths filter"},
+		{name: "pull request types exclude synchronize", on: "pull_request:\n    types: [opened, reopened]", wantWarning: true, wantDetail: "types exclude synchronize"},
+		{name: "pull request synchronize", on: "pull_request:\n    types: [opened, synchronize]"},
+		{name: "unfiltered pull request", on: "pull_request:"},
+		{name: "unfiltered push", on: "push:"},
+		{name: "filtered push", on: "push:\n    branches: [main]", wantWarning: true, wantDetail: "push branch filter"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			workdir := t.TempDir()
+			workflowDir := filepath.Join(workdir, ".github", "workflows")
+			if err := os.MkdirAll(workflowDir, 0o700); err != nil {
+				t.Fatalf("mkdir workflows: %v", err)
+			}
+			workflow := []byte("name: CI\non:\n  " + tt.on + "\njobs:\n  test:\n    name: Test\n    runs-on: ubuntu-latest\n    steps:\n      - run: go test ./...\n")
+			if err := os.WriteFile(filepath.Join(workflowDir, "ci.yml"), workflow, 0o600); err != nil {
+				t.Fatalf("write workflow: %v", err)
+			}
+			cfg := workflowconfig.Default()
+			cfg.Workspace.SourceRoot = workdir
+			cfg.Gate.RequiredStatusChecks = []string{"Test"}
+
+			checks := checkDoctorWorkflowLint(context.Background(), "alpha", globalconfig.Project{
+				ID:       "alpha",
+				Workflow: "WORKFLOW.md",
+				Workdir:  workdir,
+			}, cfg, "", doctorDeps{})
+
+			if !tt.wantWarning {
+				if len(checks) != 0 {
+					t.Fatalf("checks = %#v, want none", checks)
+				}
+				return
+			}
+			if len(checks) != 1 {
+				t.Fatalf("checks = %#v, want one warning", checks)
+			}
+			check := checks[0]
+			if check.Status != doctorWarn || !strings.Contains(check.Name, "required check triggers") {
+				t.Fatalf("check = %#v, want required check trigger warning", check)
+			}
+			for _, want := range []string{"Test", "ci.yml", tt.wantDetail, "every pull-request head"} {
+				if !strings.Contains(check.Detail, want) {
+					t.Fatalf("Detail = %q, want containing %q", check.Detail, want)
+				}
+			}
+		})
+	}
+}
+
 func TestDoctorWorkflowExecutableIndexSkipsEnvironmentAssignments(t *testing.T) {
 	t.Parallel()
 

--- a/internal/orchestrator/merge_fast_path_test.go
+++ b/internal/orchestrator/merge_fast_path_test.go
@@ -180,7 +180,7 @@ func TestMergingFastPathMissingRequiredChecksRoutesToRework(t *testing.T) {
 	state := newState(cfg)
 	state.Running[issue.ID] = Running{
 		Issue:      cloneIssue(issue),
-		Attempt:    1,
+		Attempt:    maxMergeWorkerRunnerFailures,
 		StartedAt:  now.Add(-time.Minute),
 		WorkerHost: "worker-a",
 		Mode:       runpkg.RunModeMerge,
@@ -212,6 +212,131 @@ func TestMergingFastPathMissingRequiredChecksRoutesToRework(t *testing.T) {
 	if _, ok := state.Claimed[issue.ID]; ok {
 		t.Fatalf("Claimed[%q] present after Rework handoff", issue.ID)
 	}
+}
+
+func TestMergingFastPathMissingRequiredChecksWaitsForPropagation(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 7, 14, 13, 25, 0, 0, time.UTC)
+	issue := autoPromoteTickIssue("issue-propagating-required-checks", []string{"bug"}, &connector.PullRequest{
+		Number:         864,
+		URL:            "https://github.test/digitaldrywood/detent/pull/864",
+		BranchName:     "detent/merge-fast-path-propagating-checks",
+		State:          "OPEN",
+		MergeableState: "blocked",
+		CIStatus:       "pending",
+		HeadSHA:        "head-propagating-required-checks",
+		RequiredCheckFailures: []connector.PullRequestCheck{
+			{Name: "Test", Status: "missing", Conclusion: "missing"},
+		},
+	})
+	issue.State = "Merging"
+	issue.Identifier = "digitaldrywood/detent#864"
+	issue.PRRepository = "digitaldrywood/detent"
+
+	tracker, state := completeMergeFastPathTestRun(t, issue, now, 1)
+
+	if len(tracker.merges) != 0 {
+		t.Fatalf("merges = %#v, want none while required checks propagate", tracker.merges)
+	}
+	if len(tracker.updates) != 0 {
+		t.Fatalf("updates = %#v, want no state transition while required checks propagate", tracker.updates)
+	}
+	retry, ok := state.Retry[issue.ID]
+	if !ok {
+		t.Fatalf("Retry[%q] missing while required checks propagate", issue.ID)
+	}
+	if retry.Attempt != 2 {
+		t.Fatalf("Retry[%q].Attempt = %d, want 2", issue.ID, retry.Attempt)
+	}
+	if !strings.Contains(retry.Error, "required checks") {
+		t.Fatalf("Retry[%q].Error = %q, want required-check propagation wait", issue.ID, retry.Error)
+	}
+}
+
+func TestMergingFastPathHydrationUnavailableDefers(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 7, 14, 13, 25, 0, 0, time.UTC)
+	issue := autoPromoteTickIssue("issue-fast-path-hydration-unavailable", []string{"bug"}, &connector.PullRequest{
+		Number:                     865,
+		URL:                        "https://github.test/digitaldrywood/detent/pull/865",
+		BranchName:                 "detent/merge-fast-path-hydration-unavailable",
+		State:                      "OPEN",
+		MergeableState:             "behind",
+		CIStatus:                   "success",
+		HeadSHA:                    "head-hydration-unavailable",
+		HydrationUnavailableReason: connector.PullRequestHydrationReasonRESTBudgetReserved,
+	})
+	issue.State = "Merging"
+	issue.Identifier = "digitaldrywood/detent#865"
+	issue.PRRepository = "digitaldrywood/detent"
+
+	tracker, state := completeMergeFastPathTestRun(t, issue, now, 2)
+
+	if len(tracker.merges) != 0 {
+		t.Fatalf("merges = %#v, want none without fresh pull request hydration", tracker.merges)
+	}
+	if len(tracker.updates) != 0 {
+		t.Fatalf("updates = %#v, want no state transition without fresh pull request hydration", tracker.updates)
+	}
+	retry, ok := state.Retry[issue.ID]
+	if !ok {
+		t.Fatalf("Retry[%q] missing without fresh pull request hydration", issue.ID)
+	}
+	if retry.Attempt != 2 {
+		t.Fatalf("Retry[%q].Attempt = %d, want unchanged attempt 2", issue.ID, retry.Attempt)
+	}
+	if !strings.Contains(retry.Error, "pull request hydration") {
+		t.Fatalf("Retry[%q].Error = %q, want pull request hydration wait", issue.ID, retry.Error)
+	}
+}
+
+func completeMergeFastPathTestRun(
+	t *testing.T,
+	issue connector.Issue,
+	now time.Time,
+	attempt int,
+) (*autoPromoteTickMergeConnector, State) {
+	t.Helper()
+
+	cfg := normalizeConfig(Config{
+		MaxConcurrentAgents:    1,
+		FailureRetryBaseDelay:  time.Minute,
+		MaxRetryBackoff:        time.Hour,
+		ContinuationRetryDelay: 5 * time.Second,
+		MergeFastPathEnabled:   true,
+		ActiveStates:           []string{"Todo", "In Progress", "Rework", "Merging"},
+		ObservedStates:         []string{"Merging"},
+		TerminalStates:         []string{"Done", "Cancelled"},
+	})
+	tracker := &autoPromoteTickMergeConnector{
+		autoPromoteTickConnector: &autoPromoteTickConnector{stateIssues: []connector.Issue{issue}},
+	}
+	orch := &Orchestrator{
+		cfg:       cfg,
+		connector: tracker,
+		logger:    slog.New(slog.NewTextHandler(io.Discard, nil)),
+	}
+	state := newState(cfg)
+	state.Running[issue.ID] = Running{
+		Issue:      cloneIssue(issue),
+		Attempt:    attempt,
+		StartedAt:  now.Add(-time.Minute),
+		WorkerHost: "worker-a",
+		Mode:       runpkg.RunModeMerge,
+	}
+	state.Claimed[issue.ID] = Claimed{Issue: cloneIssue(issue), ClaimedAt: now.Add(-time.Minute)}
+	orch.handleRunResult(context.Background(), &state, runpkg.Completion{
+		IssueID:     issue.ID,
+		CompletedAt: now,
+		Request:     runpkg.RunRequest{Mode: runpkg.RunModeMerge},
+		Result: runpkg.RunResult{
+			FinalState: runpkg.FinalStateCompleted,
+			Output:     runpkg.RunOutputMergeFastPathClean,
+		},
+	})
+	return tracker, state
 }
 
 func TestMergingFastPathCleanPrecheckWaitsForCurrentHeadCI(t *testing.T) {

--- a/internal/orchestrator/merge_fast_path_test.go
+++ b/internal/orchestrator/merge_fast_path_test.go
@@ -17,7 +17,7 @@ import (
 	"github.com/digitaldrywood/detent/internal/workspace"
 )
 
-func TestMergingFastPathCleanPrecheckMergesWithoutAgentDispatch(t *testing.T) {
+func TestMergingFastPathBehindCheckedHeadMergesWithoutRebaseOrAgentDispatch(t *testing.T) {
 	t.Parallel()
 
 	now := time.Date(2026, 6, 26, 13, 20, 0, 0, time.UTC)
@@ -38,7 +38,7 @@ func TestMergingFastPathCleanPrecheckMergesWithoutAgentDispatch(t *testing.T) {
 		URL:            "https://github.test/digitaldrywood/detent/pull/860",
 		BranchName:     "detent/detent-digitaldrywood_detent_860-030a2359de53",
 		State:          "OPEN",
-		MergeableState: "clean",
+		MergeableState: "behind",
 		CIStatus:       "success",
 		HeadSHA:        "head-fast-path",
 	})
@@ -94,8 +94,8 @@ func TestMergingFastPathCleanPrecheckMergesWithoutAgentDispatch(t *testing.T) {
 	}
 	orch.handleRunResult(context.Background(), &state, completion)
 
-	if got := workspaceBackend.prepareCalls.Load(); got != 1 {
-		t.Fatalf("PrepareMerge() calls = %d, want 1", got)
+	if got := workspaceBackend.prepareCalls.Load(); got != 0 {
+		t.Fatalf("PrepareMerge() calls = %d, want 0", got)
 	}
 	if got := workspaceBackend.afterRunCalls.Load(); got != 1 {
 		t.Fatalf("AfterRun() calls = %d, want 1", got)
@@ -134,6 +134,83 @@ func TestMergingFastPathCleanPrecheckMergesWithoutAgentDispatch(t *testing.T) {
 	}
 	if completed.Issue.PullRequest == nil || completed.Issue.PullRequest.State != "MERGED" {
 		t.Fatalf("Completed[%q].Issue.PullRequest = %#v, want merged PR", issue.ID, completed.Issue.PullRequest)
+	}
+}
+
+func TestMergingFastPathMissingRequiredChecksRoutesToRework(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 7, 14, 13, 25, 0, 0, time.UTC)
+	cfg := normalizeConfig(Config{
+		MaxConcurrentAgents:    1,
+		FailureRetryBaseDelay:  time.Minute,
+		MaxRetryBackoff:        time.Hour,
+		ContinuationRetryDelay: 5 * time.Second,
+		MergeFastPathEnabled:   true,
+		ActiveStates:           []string{"Todo", "In Progress", "Rework", "Merging"},
+		ObservedStates:         []string{"Merging"},
+		TerminalStates:         []string{"Done", "Cancelled"},
+	})
+	issue := autoPromoteTickIssue("issue-missing-required-checks", []string{"bug"}, &connector.PullRequest{
+		Number:         862,
+		URL:            "https://github.test/digitaldrywood/detent/pull/862",
+		BranchName:     "detent/merge-fast-path-missing-checks",
+		State:          "OPEN",
+		MergeableState: "blocked",
+		CIStatus:       "pending",
+		HeadSHA:        "head-missing-required-checks",
+		RequiredCheckFailures: []connector.PullRequestCheck{
+			{Name: "Test", Status: "missing", Conclusion: "missing"},
+			{Name: "Checks", Status: "missing", Conclusion: "missing"},
+		},
+	})
+	issue.State = "Merging"
+	issue.Identifier = "digitaldrywood/detent#862"
+	issue.PRRepository = "digitaldrywood/detent"
+	issue.BranchName = "detent/merge-fast-path-missing-checks"
+
+	tracker := &autoPromoteTickMergeConnector{
+		autoPromoteTickConnector: &autoPromoteTickConnector{stateIssues: []connector.Issue{issue}},
+	}
+	orch := &Orchestrator{
+		cfg:       cfg,
+		connector: tracker,
+		logger:    slog.New(slog.NewTextHandler(io.Discard, nil)),
+	}
+	state := newState(cfg)
+	state.Running[issue.ID] = Running{
+		Issue:      cloneIssue(issue),
+		Attempt:    1,
+		StartedAt:  now.Add(-time.Minute),
+		WorkerHost: "worker-a",
+		Mode:       runpkg.RunModeMerge,
+	}
+	state.Claimed[issue.ID] = Claimed{Issue: cloneIssue(issue), ClaimedAt: now.Add(-time.Minute)}
+
+	orch.handleRunResult(context.Background(), &state, runpkg.Completion{
+		IssueID:     issue.ID,
+		CompletedAt: now,
+		Request:     runpkg.RunRequest{Mode: runpkg.RunModeMerge},
+		Result: runpkg.RunResult{
+			FinalState: runpkg.FinalStateCompleted,
+			Output:     runpkg.RunOutputMergeFastPathClean,
+		},
+	})
+
+	if len(tracker.merges) != 0 {
+		t.Fatalf("merges = %#v, want none with missing required checks", tracker.merges)
+	}
+	if got, want := tracker.updates, []autoPromoteTickUpdate{{issueID: issue.ID, state: "Rework"}}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("updates = %#v, want %#v", got, want)
+	}
+	if len(tracker.comments) != 1 || !strings.Contains(tracker.comments[0].body, "Test, Checks") {
+		t.Fatalf("comments = %#v, want missing required check names", tracker.comments)
+	}
+	if _, ok := state.Retry[issue.ID]; ok {
+		t.Fatalf("Retry[%q] present after Rework handoff", issue.ID)
+	}
+	if _, ok := state.Claimed[issue.ID]; ok {
+		t.Fatalf("Claimed[%q] present after Rework handoff", issue.ID)
 	}
 }
 
@@ -220,6 +297,51 @@ func TestMergingFastPathCleanPrecheckWaitsForCurrentHeadCI(t *testing.T) {
 	}
 	if _, ok := state.Claimed[issue.ID]; !ok {
 		t.Fatalf("Claimed[%q] missing while waiting for CI", issue.ID)
+	}
+}
+
+func TestMergeWorkerProgrammaticMergeDisposition(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		state     string
+		ci        string
+		running   []string
+		wantReady bool
+		wantWait  bool
+	}{
+		{name: "clean green", state: "clean", ci: "success", wantReady: true},
+		{name: "behind green", state: "behind", ci: "success", wantReady: true},
+		{name: "behind pending", state: "behind", ci: "pending", wantWait: true},
+		{name: "blocked running", state: "blocked", ci: "pending", running: []string{"Test"}, wantWait: true},
+		{name: "blocked without running checks", state: "blocked", ci: "pending"},
+		{name: "dirty", state: "dirty", ci: "success"},
+		{name: "failed", state: "clean", ci: "failure"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			issue := connector.Issue{
+				ID:           "issue-disposition",
+				PRRepository: "digitaldrywood/detent",
+				PullRequest: &connector.PullRequest{
+					Number:         863,
+					State:          "open",
+					MergeableState: tt.state,
+					CIStatus:       tt.ci,
+					HeadSHA:        "head-disposition",
+					RunningChecks:  tt.running,
+				},
+			}
+			if got := mergeWorkerProgrammaticMergeReady(issue); got != tt.wantReady {
+				t.Fatalf("mergeWorkerProgrammaticMergeReady() = %t, want %t", got, tt.wantReady)
+			}
+			if got := mergeWorkerProgrammaticMergeWaiting(issue); got != tt.wantWait {
+				t.Fatalf("mergeWorkerProgrammaticMergeWaiting() = %t, want %t", got, tt.wantWait)
+			}
+		})
 	}
 }
 

--- a/internal/orchestrator/run_completion.go
+++ b/internal/orchestrator/run_completion.go
@@ -20,6 +20,11 @@ import (
 	"github.com/digitaldrywood/detent/internal/telemetry"
 )
 
+const (
+	mergeWorkerRequiredChecksMissingReason = "required_checks_missing_after_head_update"
+	mergeWorkerFastPathNotReadyReason      = "merge_fast_path_head_not_ready"
+)
+
 func (o *Orchestrator) handleRunUpdate(state *State, event runUpdate) {
 	running, ok := state.Running[event.issueID]
 	if !ok {
@@ -956,8 +961,16 @@ func (o *Orchestrator) completeProgrammaticMergeWorkerResult(
 	}
 	issue = refreshedIssue
 	if !mergeWorkerProgrammaticMergeReady(issue) {
-		if mergeFastPathCleanResult(event) && mergeWorkerProgrammaticMergeWaiting(issue) {
+		if missingChecks := mergeWorkerMissingRequiredChecks(issue); len(missingChecks) > 0 {
+			o.reworkMergeWorkerResult(ctx, state, event, running, issue, mergeWorkerRequiredChecksMissingReason, missingChecks)
+			return true
+		}
+		if mergeFastPathResult(event) && mergeWorkerProgrammaticMergeWaiting(issue) {
 			o.waitForMergeWorkerCurrentHeadCI(ctx, state, event, running, issue)
+			return true
+		}
+		if mergeFastPathResult(event) {
+			o.reworkMergeWorkerResult(ctx, state, event, running, issue, mergeWorkerFastPathNotReadyReason, nil)
 			return true
 		}
 		return false
@@ -1087,9 +1100,16 @@ func mergeWorkerTurnSucceeded(event runpkg.Completion) bool {
 	return event.Err == nil && !strings.EqualFold(strings.TrimSpace(event.Result.FinalState), runpkg.FinalStateFailed)
 }
 
-func mergeFastPathCleanResult(event runpkg.Completion) bool {
-	return event.Request.Mode == runpkg.RunModeMerge &&
-		strings.TrimSpace(event.Result.Output) == runpkg.RunOutputMergeFastPathClean
+func mergeFastPathResult(event runpkg.Completion) bool {
+	if event.Request.Mode != runpkg.RunModeMerge {
+		return false
+	}
+	switch strings.TrimSpace(event.Result.Output) {
+	case runpkg.RunOutputMergeFastPathClean, runpkg.RunOutputMergeFastPathCheckedHead:
+		return true
+	default:
+		return false
+	}
 }
 
 func mergeWorkerProgrammaticMergeReady(issue connector.Issue) bool {
@@ -1103,7 +1123,9 @@ func mergeWorkerProgrammaticMergeReady(issue connector.Issue) bool {
 	if normalizePullRequestState(pullRequest.State) != "open" || pullRequest.Draft {
 		return false
 	}
-	if strings.ToLower(strings.TrimSpace(pullRequest.MergeableState)) != "clean" {
+	switch strings.ToLower(strings.TrimSpace(pullRequest.MergeableState)) {
+	case "clean", "behind":
+	default:
 		return false
 	}
 	if !mergeWorkerCIGreen(pullRequest.CIStatus) {
@@ -1125,7 +1147,11 @@ func mergeWorkerProgrammaticMergeWaiting(issue connector.Issue) bool {
 	if normalizePullRequestState(pullRequest.State) != "open" || pullRequest.Draft {
 		return false
 	}
-	if mergeable := strings.ToLower(strings.TrimSpace(pullRequest.MergeableState)); mergeable != "" && mergeable != "clean" && mergeable != "unknown" {
+	mergeable := strings.ToLower(strings.TrimSpace(pullRequest.MergeableState))
+	if mergeable != "" && mergeable != "clean" && mergeable != "unknown" && mergeable != "behind" && mergeable != "blocked" {
+		return false
+	}
+	if mergeable == "blocked" && len(pullRequest.RunningChecks) == 0 {
 		return false
 	}
 	if pullRequestRepository(issue) == "" || pullRequestNumber(issue) <= 0 || strings.TrimSpace(pullRequest.HeadSHA) == "" {
@@ -1137,6 +1163,96 @@ func mergeWorkerProgrammaticMergeWaiting(issue connector.Issue) bool {
 	default:
 		return false
 	}
+}
+
+func mergeWorkerMissingRequiredChecks(issue connector.Issue) []string {
+	if issue.PullRequest == nil {
+		return nil
+	}
+	checks := make([]string, 0, len(issue.PullRequest.RequiredCheckFailures))
+	seen := map[string]struct{}{}
+	for _, check := range issue.PullRequest.RequiredCheckFailures {
+		if !strings.EqualFold(strings.TrimSpace(check.Status), "missing") &&
+			!strings.EqualFold(strings.TrimSpace(check.Conclusion), "missing") {
+			continue
+		}
+		name := strings.TrimSpace(check.Name)
+		if name == "" {
+			continue
+		}
+		if _, ok := seen[name]; ok {
+			continue
+		}
+		seen[name] = struct{}{}
+		checks = append(checks, name)
+	}
+	return checks
+}
+
+func (o *Orchestrator) reworkMergeWorkerResult(
+	ctx context.Context,
+	state *State,
+	event runpkg.Completion,
+	running Running,
+	issue connector.Issue,
+	reason string,
+	missingChecks []string,
+) {
+	issueID := strings.TrimSpace(event.IssueID)
+	running.Issue = issue
+	if err := o.updateIssueStateByID(ctx, state, issueID, issue, autoPromoteReworkState, event.CompletedAt, reason); err != nil {
+		o.failProgrammaticMergeWorkerResult(ctx, state, event, running, "merge_worker_rework_failed", err)
+		return
+	}
+	if comment := mergeWorkerReworkComment(issue, reason, missingChecks); comment != "" {
+		if err := o.connector.CreateComment(ctx, issueID, comment); err != nil && o.logger != nil {
+			o.logger.Warn("merge worker rework comment failed", "issue_id", issueID, "reason", reason, "error", err)
+		}
+	}
+	o.recordProjectAttemptOutcome(state, event.IssueID, event.CompletedAt, store.WorkAttemptTerminalSuccess, nil, "", "")
+	o.completeDurableWorkAttempt(ctx, state, running, event.CompletedAt, store.WorkAttemptTerminalSuccess, "", "", "rework", "merge worker routed current head to Rework")
+	o.logMergeWorkerFailure(issue, reason, nil)
+	o.recordMergeFailed(state, issue, event.CompletedAt, reason, nil)
+	if err := o.abandonClaim(ctx, issueID); err != nil && o.logger != nil {
+		o.logger.Warn("abandon merge worker rework claim failed", "issue_id", issueID, "error", err)
+	}
+	o.clearAutoPromotedIssueDispatchMemory(state, issueID)
+	if state.PriorAttempts == nil {
+		state.PriorAttempts = map[string]runpkg.PriorAttempt{}
+	}
+	state.PriorAttempts[issueID] = runpkg.PriorAttempt{Source: "merge_worker", Reason: reason}
+	recordStateEvent(state, telemetry.ActivityEvent{
+		At:      event.CompletedAt,
+		Event:   "merge_worker_routed_to_rework",
+		Message: "routed merge worker to Rework for " + issueLabel(issue) + ": " + reason,
+	})
+}
+
+func mergeWorkerReworkComment(issue connector.Issue, reason string, missingChecks []string) string {
+	var b strings.Builder
+	b.WriteString("Merge worker routed this issue from Merging to Rework.")
+	b.WriteString("\n\n- reason: ")
+	b.WriteString(reason)
+	if len(missingChecks) > 0 {
+		b.WriteString("\n- missing_required_checks: ")
+		b.WriteString(strings.Join(missingChecks, ", "))
+	}
+	if issue.PullRequest != nil {
+		if url := strings.TrimSpace(issue.PullRequest.URL); url != "" {
+			b.WriteString("\n- pull request: ")
+			b.WriteString(url)
+		}
+		if headSHA := strings.TrimSpace(issue.PullRequest.HeadSHA); headSHA != "" {
+			b.WriteString("\n- head_sha: ")
+			b.WriteString(headSHA)
+		}
+		if mergeableState := strings.TrimSpace(issue.PullRequest.MergeableState); mergeableState != "" {
+			b.WriteString("\n- mergeable_state: ")
+			b.WriteString(mergeableState)
+		}
+	}
+	b.WriteString("\n\nRefresh or re-push the current PR head so required checks run, then complete the normal Rework gate.")
+	return b.String()
 }
 
 func mergeWorkerCIGreen(status string) bool {

--- a/internal/orchestrator/run_completion.go
+++ b/internal/orchestrator/run_completion.go
@@ -961,7 +961,15 @@ func (o *Orchestrator) completeProgrammaticMergeWorkerResult(
 	}
 	issue = refreshedIssue
 	if !mergeWorkerProgrammaticMergeReady(issue) {
+		if pullRequestHydrationBlocksProgress(issue.PullRequest) {
+			o.waitForMergeWorkerPullRequestHydration(ctx, state, event, running, issue)
+			return true
+		}
 		if missingChecks := mergeWorkerMissingRequiredChecks(issue); len(missingChecks) > 0 {
+			if mergeWorkerMissingRequiredChecksPropagating(issue, running.Attempt) {
+				o.waitForMergeWorkerRequiredCheckPropagation(ctx, state, event, running, issue)
+				return true
+			}
 			o.reworkMergeWorkerResult(ctx, state, event, running, issue, mergeWorkerRequiredChecksMissingReason, missingChecks)
 			return true
 		}
@@ -1044,21 +1052,84 @@ func (o *Orchestrator) waitForMergeWorkerCurrentHeadCI(
 	running Running,
 	issue connector.Issue,
 ) {
+	o.waitForMergeWorkerRetry(
+		ctx,
+		state,
+		event,
+		running,
+		issue,
+		running.Attempt,
+		"waiting for current-head CI",
+		"merge_worker_waiting_current_head_ci",
+		"merge worker is waiting for current-head CI for ",
+	)
+}
+
+func (o *Orchestrator) waitForMergeWorkerRequiredCheckPropagation(
+	ctx context.Context,
+	state *State,
+	event runpkg.Completion,
+	running Running,
+	issue connector.Issue,
+) {
+	o.waitForMergeWorkerRetry(
+		ctx,
+		state,
+		event,
+		running,
+		issue,
+		nextAttempt(running.Attempt),
+		"waiting for required checks to appear on the current head",
+		"merge_worker_waiting_required_check_propagation",
+		"merge worker is waiting for required checks to appear for ",
+	)
+}
+
+func (o *Orchestrator) waitForMergeWorkerPullRequestHydration(
+	ctx context.Context,
+	state *State,
+	event runpkg.Completion,
+	running Running,
+	issue connector.Issue,
+) {
+	o.waitForMergeWorkerRetry(
+		ctx,
+		state,
+		event,
+		running,
+		issue,
+		running.Attempt,
+		"waiting for fresh pull request hydration",
+		"merge_worker_waiting_pull_request_hydration",
+		"merge worker is waiting for fresh pull request hydration for ",
+	)
+}
+
+func (o *Orchestrator) waitForMergeWorkerRetry(
+	ctx context.Context,
+	state *State,
+	event runpkg.Completion,
+	running Running,
+	issue connector.Issue,
+	attempt int,
+	retryError string,
+	eventName string,
+	eventMessage string,
+) {
 	running.Issue = issue
 	o.recordProjectAttemptOutcome(state, event.IssueID, event.CompletedAt, store.WorkAttemptTerminalSuccess, nil, "", "")
-	o.completeDurableWorkAttempt(ctx, state, running, event.CompletedAt, store.WorkAttemptTerminalSuccess, "", "", "waiting", "merge fast-path waiting for current-head CI")
-	attempt := running.Attempt
+	o.completeDurableWorkAttempt(ctx, state, running, event.CompletedAt, store.WorkAttemptTerminalSuccess, "", "", "waiting", retryError)
 	if attempt < 1 {
 		attempt = 1
 	}
-	o.scheduleRetry(state, issue, attempt, event.CompletedAt, "waiting for current-head CI", true, running.WorkerHost)
+	o.scheduleRetry(state, issue, attempt, event.CompletedAt, retryError, true, running.WorkerHost)
 	if o.logger != nil {
-		o.logger.Info("merge_worker_waiting_current_head_ci", mergeWorkerLogAttrs(issue, "attempt", attempt)...)
+		o.logger.Info(eventName, mergeWorkerLogAttrs(issue, "attempt", attempt)...)
 	}
 	recordStateEvent(state, telemetry.ActivityEvent{
 		At:      event.CompletedAt,
-		Event:   "merge_worker_waiting_current_head_ci",
-		Message: "merge worker is waiting for current-head CI for " + issueLabel(issue),
+		Event:   eventName,
+		Message: eventMessage + issueLabel(issue),
 	})
 }
 
@@ -1187,6 +1258,21 @@ func mergeWorkerMissingRequiredChecks(issue connector.Issue) []string {
 		checks = append(checks, name)
 	}
 	return checks
+}
+
+func mergeWorkerMissingRequiredChecksPropagating(issue connector.Issue, attempt int) bool {
+	if len(mergeWorkerMissingRequiredChecks(issue)) == 0 || attempt >= maxMergeWorkerRunnerFailures {
+		return false
+	}
+	if issue.PullRequest == nil {
+		return false
+	}
+	switch strings.ToLower(strings.TrimSpace(issue.PullRequest.CIStatus)) {
+	case "", "pending", "running", "queued", "in_progress", "waiting":
+		return true
+	default:
+		return false
+	}
 }
 
 func (o *Orchestrator) reworkMergeWorkerResult(

--- a/internal/runner/agent.go
+++ b/internal/runner/agent.go
@@ -517,6 +517,16 @@ func (r *Runner) prepareMergeFastPath(
 	info workspace.Info,
 	issue workspace.Issue,
 ) (RunResult, workspace.MergePrepareResult, bool, error) {
+	if mergeFastPathCheckedHead(req.Issue) {
+		r.logWorkerEvent(req.Issue, "worker_merge_fast_path_checked_head",
+			"workspace_path", info.Path,
+			"workspace_branch", info.Branch,
+		)
+		return RunResult{
+			FinalState: FinalStateCompleted,
+			Output:     RunOutputMergeFastPathCheckedHead,
+		}, workspace.MergePrepareResult{}, true, nil
+	}
 	preparer, ok := r.workspace.(workspace.MergePreparer)
 	if !ok {
 		return RunResult{}, workspace.MergePrepareResult{}, false, nil
@@ -545,6 +555,28 @@ func (r *Runner) prepareMergeFastPath(
 		return RunResult{}, precheck, false, nil
 	default:
 		return RunResult{}, precheck, false, fmt.Errorf("merge fast-path precheck returned unknown status %q", precheck.Status)
+	}
+}
+
+func mergeFastPathCheckedHead(issue connector.Issue) bool {
+	if issue.PullRequest == nil {
+		return false
+	}
+	pullRequest := issue.PullRequest
+	if !strings.EqualFold(strings.TrimSpace(pullRequest.State), "open") || pullRequest.Draft {
+		return false
+	}
+	if !strings.EqualFold(strings.TrimSpace(pullRequest.MergeableState), "behind") {
+		return false
+	}
+	if strings.TrimSpace(pullRequest.HeadSHA) == "" {
+		return false
+	}
+	switch strings.ToLower(strings.TrimSpace(pullRequest.CIStatus)) {
+	case "success", "green", "pass", "passed":
+		return true
+	default:
+		return false
 	}
 }
 

--- a/internal/runner/runner_test.go
+++ b/internal/runner/runner_test.go
@@ -1728,6 +1728,42 @@ func TestRunnerMergeModeCleanPrecheckSkipsAgent(t *testing.T) {
 	}
 }
 
+func TestMergeFastPathCheckedHead(t *testing.T) {
+	t.Parallel()
+
+	base := connector.PullRequest{
+		State:          "open",
+		MergeableState: "behind",
+		CIStatus:       "success",
+		HeadSHA:        "checked-head",
+	}
+	tests := []struct {
+		name   string
+		mutate func(*connector.PullRequest)
+		want   bool
+	}{
+		{name: "behind green head", want: true},
+		{name: "current head", mutate: func(pr *connector.PullRequest) { pr.MergeableState = "clean" }},
+		{name: "pending checks", mutate: func(pr *connector.PullRequest) { pr.CIStatus = "pending" }},
+		{name: "draft", mutate: func(pr *connector.PullRequest) { pr.Draft = true }},
+		{name: "closed", mutate: func(pr *connector.PullRequest) { pr.State = "closed" }},
+		{name: "missing head sha", mutate: func(pr *connector.PullRequest) { pr.HeadSHA = "" }},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			pullRequest := base
+			if tt.mutate != nil {
+				tt.mutate(&pullRequest)
+			}
+			if got := mergeFastPathCheckedHead(connector.Issue{PullRequest: &pullRequest}); got != tt.want {
+				t.Fatalf("mergeFastPathCheckedHead() = %t, want %t", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestRunnerMergeModeConflictUsesFocusedPrompt(t *testing.T) {
 	t.Parallel()
 

--- a/internal/runner/types.go
+++ b/internal/runner/types.go
@@ -27,7 +27,8 @@ const (
 	RunModePlan      = "plan"
 	RunModeMerge     = "merge"
 
-	RunOutputMergeFastPathClean = "merge_fast_path_clean"
+	RunOutputMergeFastPathClean       = "merge_fast_path_clean"
+	RunOutputMergeFastPathCheckedHead = "merge_fast_path_checked_head"
 )
 
 var (


### PR DESCRIPTION
## Summary

- merge green BEHIND heads directly after fresh hydration without rewriting the checked commit
- route refreshed heads with missing required contexts to Rework instead of retrying `terminal_state_missing`
- warn in Doctor when required-check workflows filter pull-request or push head updates

Fixes #1307

## UI Surface Contract

- [x] N/A, or the linked issue explicitly authorizes any high-impact UI surface, layout, density, first-viewport, or responsive visibility tradeoff.
- [x] Persistent top-of-screen messaging is explicitly authorized by the issue, or this PR does not add it.
- [x] Visual changes to primary operator screens include screenshot or browser verification below.

## Test Plan

- [x] `go test ./internal/runner ./internal/orchestrator ./internal/cli -count=1`
- [x] `make check` (77.3% total coverage; package/file floors pass)