### PR TITLE
test(web): drain API key writes on cleanup

### DIFF
--- a/internal/web/server_test.go
+++ b/internal/web/server_test.go
@@ -1437,6 +1437,13 @@ func TestAPIKeyRevokeExpireRotateAndRateLimit(t *testing.T) {
 	t.Parallel()
 
 	server, backend, _, _ := newAPIKeyWorkItemTestServer(t)
+	t.Cleanup(func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 12*time.Second)
+		defer cancel()
+		if err := server.Shutdown(ctx); err != nil {
+			t.Errorf("Shutdown() error = %v", err)
+		}
+	})
 	createdToken, createdID := createAPIKeyThroughHTTP(t, server, `{
 		"name": "Client",
 		"scopes": ["read"],


### PR DESCRIPTION
## Summary

- shut down the test server before API-key store and temp-directory cleanup
- drain queued usage-log and last-used writes deterministically
- preserve revoke, expiry, rotation, and rate-limit coverage

Fixes #1309

## UI Surface Contract

- [x] N/A; this test-only change has no UI impact.
- [x] This PR does not add persistent top-of-screen messaging.
- [x] This PR has no visual changes.

## Test Plan

- [x] `go test -race ./internal/web -run TestAPIKeyRevokeExpireRotateAndRateLimit -count=20 -v`
- [x] `make check`
