### PR TITLE
feat(gate): retrigger label-gated CI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1128,9 +1128,9 @@ implementation, rework, and merge workers to run the host-coordinated
 `detent ci-trigger-label` command after every head-changing push before they
 wait for current-head checks. Trigger events use a shared lock and persisted
 timestamp per repository and are spaced by
-`ci_trigger_label_stagger_seconds` (default `15`) to avoid a self-hosted CI
-stampede. `detent doctor` warns when it finds a label-gated required check
-without this setting.
+`ci_trigger_label_stagger_seconds` (a positive value, default `15`) to avoid a
+self-hosted CI stampede. `detent doctor` warns when it finds a label-gated
+required check without this setting.
 
 Set `gate.validator.enabled: true` to add a validator-agent review before
 auto-promotion. The validator inspects the PR diff against the issue acceptance

--- a/README.md
+++ b/README.md
@@ -1122,6 +1122,14 @@ Set `required_status_checks` to the exact branch-protection or ruleset check
 names that are release-blocking for the project. Detent treats a configured
 required check as non-green when it is missing, skipped, failed, cancelled,
 neutral, or still running on the current PR head.
+For required workflows that run only on a `pull_request` `labeled` event, set
+`ci_trigger_label` to that label, such as `ci:ready`. Detent then instructs
+implementation, rework, and merge workers to remove and re-add the label after
+every head-changing push before they wait for current-head checks. Trigger
+events are serialized on the host and spaced by
+`ci_trigger_label_stagger_seconds` (default `15`) to avoid a self-hosted CI
+stampede. `detent doctor` warns when it finds a label-gated required check
+without this setting.
 
 Set `gate.validator.enabled: true` to add a validator-agent review before
 auto-promotion. The validator inspects the PR diff against the issue acceptance
@@ -1780,6 +1788,9 @@ of that state is controlled by the workflow:
 - `gate.required_status_checks` names release-blocking check runs or commit
   status contexts that must be present, completed, and successful on the current
   PR head.
+- `gate.ci_trigger_label` re-fires label-gated required CI after each PR-head
+  push; `gate.ci_trigger_label_stagger_seconds` spaces host-local reapplications
+  by `15` seconds by default.
 - `gate.ci_failure_action: rework` routes failed or cancelled current-head CI
   from `Human Review` back to `Rework` by default; set
   `gate.ci_failure_action: skip` only when non-green CI should leave the item

--- a/README.md
+++ b/README.md
@@ -1126,7 +1126,8 @@ For required workflows that run only on a `pull_request` `labeled` event, set
 `ci_trigger_label` to that label, such as `ci:ready`. Detent then instructs
 implementation, rework, and merge workers to run the host-coordinated
 `detent ci-trigger-label` command after every head-changing push before they
-wait for current-head checks. Trigger events use a shared lock and persisted
+wait for current-head checks, passing the configured GitHub tracker host for
+Enterprise installations. Trigger events use a shared lock and persisted
 timestamp per repository and are spaced by
 `ci_trigger_label_stagger_seconds` (a positive value, default `15`) to avoid a
 self-hosted CI stampede. `detent doctor` warns when it finds a label-gated

--- a/README.md
+++ b/README.md
@@ -1127,7 +1127,8 @@ For required workflows that run only on a `pull_request` `labeled` event, set
 implementation, rework, and merge workers to run the host-coordinated
 `detent ci-trigger-label` command after every head-changing push before they
 wait for current-head checks, passing the configured GitHub tracker host for
-Enterprise installations. Trigger events use a shared lock and persisted
+Enterprise installations. Generated commands encode label and host arguments
+without shell-specific quoting. Trigger events use a shared lock and persisted
 timestamp per repository and are spaced by
 `ci_trigger_label_stagger_seconds` (a positive value, default `15`) to avoid a
 self-hosted CI stampede. `detent doctor` warns when it finds a label-gated

--- a/README.md
+++ b/README.md
@@ -1124,9 +1124,10 @@ required check as non-green when it is missing, skipped, failed, cancelled,
 neutral, or still running on the current PR head.
 For required workflows that run only on a `pull_request` `labeled` event, set
 `ci_trigger_label` to that label, such as `ci:ready`. Detent then instructs
-implementation, rework, and merge workers to remove and re-add the label after
-every head-changing push before they wait for current-head checks. Trigger
-events are serialized on the host and spaced by
+implementation, rework, and merge workers to run the host-coordinated
+`detent ci-trigger-label` command after every head-changing push before they
+wait for current-head checks. Trigger events use a shared lock and persisted
+timestamp per repository and are spaced by
 `ci_trigger_label_stagger_seconds` (default `15`) to avoid a self-hosted CI
 stampede. `detent doctor` warns when it finds a label-gated required check
 without this setting.

--- a/internal/cli/ci_trigger_label.go
+++ b/internal/cli/ci_trigger_label.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"context"
 	"crypto/sha256"
+	"encoding/base64"
 	"encoding/hex"
 	"errors"
 	"fmt"
@@ -37,7 +38,9 @@ type ciTriggerLabelInput struct {
 	Repository      string
 	PullRequest     int
 	Label           string
+	LabelBase64     string
 	Hostname        string
+	HostnameBase64  string
 	StaggerSeconds  int
 	CoordinationDir string
 }
@@ -69,7 +72,9 @@ func newCITriggerLabelCommand(opts options) *cobra.Command {
 	cmd.Flags().StringVar(&input.Repository, "repository", "", "GitHub repository in owner/name form")
 	cmd.Flags().IntVar(&input.PullRequest, "pull-request", 0, "pull request number")
 	cmd.Flags().StringVar(&input.Label, "label", "", "CI trigger label to remove and add")
+	cmd.Flags().StringVar(&input.LabelBase64, "label-base64", "", "URL-safe base64-encoded CI trigger label")
 	cmd.Flags().StringVar(&input.Hostname, "hostname", "", "GitHub host for API requests")
+	cmd.Flags().StringVar(&input.HostnameBase64, "hostname-base64", "", "URL-safe base64-encoded GitHub host")
 	cmd.Flags().IntVar(&input.StaggerSeconds, "stagger-seconds", gate.DefaultCITriggerLabelStaggerSeconds, "minimum seconds between trigger-label reapplications on this host")
 	cmd.Flags().StringVar(&input.CoordinationDir, "coordination-dir", "", "host-local coordination directory")
 	return cmd
@@ -88,6 +93,10 @@ func defaultCITriggerLabelDeps(opts options) ciTriggerLabelDeps {
 }
 
 func runCITriggerLabel(ctx context.Context, input ciTriggerLabelInput, deps ciTriggerLabelDeps) (result ciTriggerLabelResult, err error) {
+	input, err = decodeCITriggerLabelInput(input)
+	if err != nil {
+		return ciTriggerLabelResult{}, err
+	}
 	input.Repository = strings.TrimSpace(input.Repository)
 	input.Label = strings.TrimSpace(input.Label)
 	input.Hostname = strings.TrimSpace(input.Hostname)
@@ -127,6 +136,35 @@ func runCITriggerLabel(ctx context.Context, input ciTriggerLabelInput, deps ciTr
 		return ciTriggerLabelResult{}, fmt.Errorf("record CI trigger-label timestamp: %w", err)
 	}
 	return ciTriggerLabelResult{Repository: input.Repository, PullRequest: input.PullRequest, Label: input.Label, Reapplied: true}, nil
+}
+
+func decodeCITriggerLabelInput(input ciTriggerLabelInput) (ciTriggerLabelInput, error) {
+	var err error
+	input.Label, err = decodeCITriggerLabelValue("--label", input.Label, "--label-base64", input.LabelBase64)
+	if err != nil {
+		return ciTriggerLabelInput{}, err
+	}
+	input.Hostname, err = decodeCITriggerLabelValue("--hostname", input.Hostname, "--hostname-base64", input.HostnameBase64)
+	if err != nil {
+		return ciTriggerLabelInput{}, err
+	}
+	return input, nil
+}
+
+func decodeCITriggerLabelValue(plainFlag string, plainValue string, encodedFlag string, encodedValue string) (string, error) {
+	plainValue = strings.TrimSpace(plainValue)
+	encodedValue = strings.TrimSpace(encodedValue)
+	if plainValue != "" && encodedValue != "" {
+		return "", NewValidationError("ci-trigger-label "+plainFlag+" and "+encodedFlag+" are mutually exclusive", "Pass only one representation.", nil)
+	}
+	if encodedValue == "" {
+		return plainValue, nil
+	}
+	decoded, err := base64.RawURLEncoding.DecodeString(encodedValue)
+	if err != nil {
+		return "", NewValidationError("ci-trigger-label "+encodedFlag+" is invalid", "Pass unpadded URL-safe base64.", nil)
+	}
+	return string(decoded), nil
 }
 
 func (deps ciTriggerLabelDeps) withDefaults() ciTriggerLabelDeps {

--- a/internal/cli/ci_trigger_label.go
+++ b/internal/cli/ci_trigger_label.go
@@ -97,8 +97,8 @@ func runCITriggerLabel(ctx context.Context, input ciTriggerLabelInput, deps ciTr
 	if input.Label == "" {
 		return ciTriggerLabelResult{}, NewValidationError("ci-trigger-label --label is required", "Pass the configured gate.ci_trigger_label value.", nil)
 	}
-	if input.StaggerSeconds < 0 {
-		return ciTriggerLabelResult{}, NewValidationError("ci-trigger-label --stagger-seconds must be greater than or equal to 0", "Pass a non-negative stagger.", nil)
+	if input.StaggerSeconds <= 0 {
+		return ciTriggerLabelResult{}, NewValidationError("ci-trigger-label --stagger-seconds must be greater than 0", "Pass a positive stagger.", nil)
 	}
 	deps = deps.withDefaults()
 	coordinationDir, err := ciTriggerLabelCoordinationDir(input.CoordinationDir, deps.userCacheDir)

--- a/internal/cli/ci_trigger_label.go
+++ b/internal/cli/ci_trigger_label.go
@@ -1,0 +1,259 @@
+package cli
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/digitaldrywood/detent/internal/gate"
+	"github.com/digitaldrywood/detent/internal/instancelock"
+)
+
+const ciTriggerLabelLockRetry = 250 * time.Millisecond
+
+type ciTriggerLabelLock interface {
+	Close() error
+}
+
+type ciTriggerLabelDeps struct {
+	now          func() time.Time
+	wait         func(context.Context, time.Duration) error
+	acquire      func(string) (ciTriggerLabelLock, error)
+	userCacheDir func() (string, error)
+	runCommand   CommandRunner
+}
+
+type ciTriggerLabelInput struct {
+	Repository      string
+	PullRequest     int
+	Label           string
+	StaggerSeconds  int
+	CoordinationDir string
+}
+
+type ciTriggerLabelResult struct {
+	Repository  string `json:"repository"`
+	PullRequest int    `json:"pull_request"`
+	Label       string `json:"label"`
+	Reapplied   bool   `json:"reapplied"`
+}
+
+func newCITriggerLabelCommand(opts options) *cobra.Command {
+	deps := defaultCITriggerLabelDeps(opts)
+	var input ciTriggerLabelInput
+	cmd := &cobra.Command{
+		Use:          "ci-trigger-label",
+		Short:        "Reapply a pull request CI trigger label with host-wide staggering",
+		Example:      "detent ci-trigger-label --repository owner/repo --pull-request 42 --label ci:ready --stagger-seconds 15",
+		Args:         NoArgs,
+		SilenceUsage: true,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			result, err := runCITriggerLabel(cmd.Context(), input, deps)
+			if err != nil {
+				return err
+			}
+			return writeCITriggerLabelResult(cmd, result)
+		},
+	}
+	cmd.Flags().StringVar(&input.Repository, "repository", "", "GitHub repository in owner/name form")
+	cmd.Flags().IntVar(&input.PullRequest, "pull-request", 0, "pull request number")
+	cmd.Flags().StringVar(&input.Label, "label", "", "CI trigger label to remove and add")
+	cmd.Flags().IntVar(&input.StaggerSeconds, "stagger-seconds", gate.DefaultCITriggerLabelStaggerSeconds, "minimum seconds between trigger-label reapplications on this host")
+	cmd.Flags().StringVar(&input.CoordinationDir, "coordination-dir", "", "host-local coordination directory")
+	return cmd
+}
+
+func defaultCITriggerLabelDeps(opts options) ciTriggerLabelDeps {
+	return ciTriggerLabelDeps{
+		now:  time.Now,
+		wait: waitForCITriggerLabel,
+		acquire: func(path string) (ciTriggerLabelLock, error) {
+			return instancelock.Acquire(path)
+		},
+		userCacheDir: os.UserCacheDir,
+		runCommand:   opts.runCommand,
+	}
+}
+
+func runCITriggerLabel(ctx context.Context, input ciTriggerLabelInput, deps ciTriggerLabelDeps) (result ciTriggerLabelResult, err error) {
+	input.Repository = strings.TrimSpace(input.Repository)
+	input.Label = strings.TrimSpace(input.Label)
+	if !validCITriggerLabelRepository(input.Repository) {
+		return ciTriggerLabelResult{}, NewValidationError("ci-trigger-label --repository must be owner/name", "Pass --repository owner/name.", nil)
+	}
+	if input.PullRequest <= 0 {
+		return ciTriggerLabelResult{}, NewValidationError("ci-trigger-label --pull-request must be greater than 0", "Pass the pull request number.", nil)
+	}
+	if input.Label == "" {
+		return ciTriggerLabelResult{}, NewValidationError("ci-trigger-label --label is required", "Pass the configured gate.ci_trigger_label value.", nil)
+	}
+	if input.StaggerSeconds < 0 {
+		return ciTriggerLabelResult{}, NewValidationError("ci-trigger-label --stagger-seconds must be greater than or equal to 0", "Pass a non-negative stagger.", nil)
+	}
+	deps = deps.withDefaults()
+	coordinationDir, err := ciTriggerLabelCoordinationDir(input.CoordinationDir, deps.userCacheDir)
+	if err != nil {
+		return ciTriggerLabelResult{}, err
+	}
+	lockPath, timestampPath := ciTriggerLabelCoordinationPaths(coordinationDir, input.Repository)
+	lock, err := acquireCITriggerLabelLock(ctx, lockPath, deps)
+	if err != nil {
+		return ciTriggerLabelResult{}, err
+	}
+	defer func() {
+		err = errors.Join(err, lock.Close())
+	}()
+
+	if err := enforceCITriggerLabelStagger(ctx, timestampPath, time.Duration(input.StaggerSeconds)*time.Second, deps); err != nil {
+		return ciTriggerLabelResult{}, err
+	}
+	if err := reapplyGitHubPullRequestLabel(ctx, input, deps.runCommand); err != nil {
+		return ciTriggerLabelResult{}, err
+	}
+	if err := os.WriteFile(timestampPath, []byte(deps.now().UTC().Format(time.RFC3339Nano)+"\n"), 0o600); err != nil {
+		return ciTriggerLabelResult{}, fmt.Errorf("record CI trigger-label timestamp: %w", err)
+	}
+	return ciTriggerLabelResult{Repository: input.Repository, PullRequest: input.PullRequest, Label: input.Label, Reapplied: true}, nil
+}
+
+func (deps ciTriggerLabelDeps) withDefaults() ciTriggerLabelDeps {
+	if deps.now == nil {
+		deps.now = time.Now
+	}
+	if deps.wait == nil {
+		deps.wait = waitForCITriggerLabel
+	}
+	if deps.acquire == nil {
+		deps.acquire = func(path string) (ciTriggerLabelLock, error) { return instancelock.Acquire(path) }
+	}
+	if deps.userCacheDir == nil {
+		deps.userCacheDir = os.UserCacheDir
+	}
+	if deps.runCommand == nil {
+		deps.runCommand = defaultCommandRunner
+	}
+	return deps
+}
+
+func validCITriggerLabelRepository(repository string) bool {
+	owner, name, ok := strings.Cut(repository, "/")
+	return ok && strings.TrimSpace(owner) != "" && strings.TrimSpace(name) != "" && !strings.Contains(name, "/")
+}
+
+func ciTriggerLabelCoordinationDir(configured string, userCacheDir func() (string, error)) (string, error) {
+	if configured = strings.TrimSpace(configured); configured != "" {
+		return filepath.Abs(configured)
+	}
+	root, err := userCacheDir()
+	if err != nil {
+		return "", fmt.Errorf("resolve user cache directory: %w", err)
+	}
+	return filepath.Join(root, "detent", "ci-trigger-label"), nil
+}
+
+func ciTriggerLabelCoordinationPaths(dir string, repository string) (string, string) {
+	sum := sha256.Sum256([]byte(strings.ToLower(strings.TrimSpace(repository))))
+	key := hex.EncodeToString(sum[:8])
+	base := filepath.Join(dir, key)
+	return base + ".lock", base + ".last"
+}
+
+func acquireCITriggerLabelLock(ctx context.Context, path string, deps ciTriggerLabelDeps) (ciTriggerLabelLock, error) {
+	for {
+		lock, err := deps.acquire(path)
+		if err == nil {
+			return lock, nil
+		}
+		if !errors.Is(err, instancelock.ErrHeld) {
+			return nil, fmt.Errorf("acquire CI trigger-label coordination lock: %w", err)
+		}
+		if err := deps.wait(ctx, ciTriggerLabelLockRetry); err != nil {
+			return nil, err
+		}
+	}
+}
+
+func enforceCITriggerLabelStagger(ctx context.Context, timestampPath string, stagger time.Duration, deps ciTriggerLabelDeps) error {
+	if stagger <= 0 {
+		return nil
+	}
+	raw, err := os.ReadFile(timestampPath)
+	if errors.Is(err, os.ErrNotExist) {
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("read CI trigger-label timestamp: %w", err)
+	}
+	last, err := time.Parse(time.RFC3339Nano, strings.TrimSpace(string(raw)))
+	if err != nil {
+		return fmt.Errorf("parse CI trigger-label timestamp: %w", err)
+	}
+	remaining := last.Add(stagger).Sub(deps.now())
+	if remaining <= 0 {
+		return nil
+	}
+	return deps.wait(ctx, remaining)
+}
+
+func reapplyGitHubPullRequestLabel(ctx context.Context, input ciTriggerLabelInput, run CommandRunner) error {
+	basePath := "repos/" + input.Repository + "/issues/" + strconv.Itoa(input.PullRequest) + "/labels"
+	output, err := run(ctx, "gh", "api", "--paginate", basePath, "--jq", ".[].name")
+	if err != nil {
+		return fmt.Errorf("list pull request labels: %w", err)
+	}
+	if ciTriggerLabelPresent(output, input.Label) {
+		labelPath := basePath + "/" + url.PathEscape(input.Label)
+		if _, err := run(ctx, "gh", "api", "--method", "DELETE", labelPath, "--silent"); err != nil {
+			return fmt.Errorf("remove CI trigger label: %w", err)
+		}
+	}
+	if _, err := run(ctx, "gh", "api", "--method", "POST", basePath, "-f", "labels[]="+input.Label, "--silent"); err != nil {
+		return fmt.Errorf("add CI trigger label: %w", err)
+	}
+	return nil
+}
+
+func ciTriggerLabelPresent(output string, label string) bool {
+	for _, current := range strings.Split(output, "\n") {
+		if strings.EqualFold(strings.TrimSpace(current), strings.TrimSpace(label)) {
+			return true
+		}
+	}
+	return false
+}
+
+func waitForCITriggerLabel(ctx context.Context, duration time.Duration) error {
+	if duration <= 0 {
+		return nil
+	}
+	timer := time.NewTimer(duration)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-timer.C:
+		return nil
+	}
+}
+
+func writeCITriggerLabelResult(cmd *cobra.Command, result ciTriggerLabelResult) error {
+	output, err := OutputForCommand(cmd)
+	if err != nil {
+		return err
+	}
+	if output.Format == OutputFormatJSON {
+		return WriteJSON(output.Out, result)
+	}
+	_, err = fmt.Fprintf(output.Out, "Reapplied %s to %s#%d\n", result.Label, result.Repository, result.PullRequest)
+	return err
+}

--- a/internal/cli/ci_trigger_label.go
+++ b/internal/cli/ci_trigger_label.go
@@ -37,6 +37,7 @@ type ciTriggerLabelInput struct {
 	Repository      string
 	PullRequest     int
 	Label           string
+	Hostname        string
 	StaggerSeconds  int
 	CoordinationDir string
 }
@@ -54,7 +55,7 @@ func newCITriggerLabelCommand(opts options) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:          "ci-trigger-label",
 		Short:        "Reapply a pull request CI trigger label with host-wide staggering",
-		Example:      "detent ci-trigger-label --repository owner/repo --pull-request 42 --label ci:ready --stagger-seconds 15",
+		Example:      "detent ci-trigger-label --repository owner/repo --pull-request 42 --label ci:ready --hostname github.com --stagger-seconds 15",
 		Args:         NoArgs,
 		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, _ []string) error {
@@ -68,6 +69,7 @@ func newCITriggerLabelCommand(opts options) *cobra.Command {
 	cmd.Flags().StringVar(&input.Repository, "repository", "", "GitHub repository in owner/name form")
 	cmd.Flags().IntVar(&input.PullRequest, "pull-request", 0, "pull request number")
 	cmd.Flags().StringVar(&input.Label, "label", "", "CI trigger label to remove and add")
+	cmd.Flags().StringVar(&input.Hostname, "hostname", "", "GitHub host for API requests")
 	cmd.Flags().IntVar(&input.StaggerSeconds, "stagger-seconds", gate.DefaultCITriggerLabelStaggerSeconds, "minimum seconds between trigger-label reapplications on this host")
 	cmd.Flags().StringVar(&input.CoordinationDir, "coordination-dir", "", "host-local coordination directory")
 	return cmd
@@ -88,6 +90,7 @@ func defaultCITriggerLabelDeps(opts options) ciTriggerLabelDeps {
 func runCITriggerLabel(ctx context.Context, input ciTriggerLabelInput, deps ciTriggerLabelDeps) (result ciTriggerLabelResult, err error) {
 	input.Repository = strings.TrimSpace(input.Repository)
 	input.Label = strings.TrimSpace(input.Label)
+	input.Hostname = strings.TrimSpace(input.Hostname)
 	if !validCITriggerLabelRepository(input.Repository) {
 		return ciTriggerLabelResult{}, NewValidationError("ci-trigger-label --repository must be owner/name", "Pass --repository owner/name.", nil)
 	}
@@ -207,20 +210,28 @@ func enforceCITriggerLabelStagger(ctx context.Context, timestampPath string, sta
 
 func reapplyGitHubPullRequestLabel(ctx context.Context, input ciTriggerLabelInput, run CommandRunner) error {
 	basePath := "repos/" + input.Repository + "/issues/" + strconv.Itoa(input.PullRequest) + "/labels"
-	output, err := run(ctx, "gh", "api", "--paginate", basePath, "--jq", ".[].name")
+	output, err := run(ctx, "gh", ciTriggerLabelGHArgs(input.Hostname, "--paginate", basePath, "--jq", ".[].name")...)
 	if err != nil {
 		return fmt.Errorf("list pull request labels: %w", err)
 	}
 	if ciTriggerLabelPresent(output, input.Label) {
 		labelPath := basePath + "/" + url.PathEscape(input.Label)
-		if _, err := run(ctx, "gh", "api", "--method", "DELETE", labelPath, "--silent"); err != nil {
+		if _, err := run(ctx, "gh", ciTriggerLabelGHArgs(input.Hostname, "--method", "DELETE", labelPath, "--silent")...); err != nil {
 			return fmt.Errorf("remove CI trigger label: %w", err)
 		}
 	}
-	if _, err := run(ctx, "gh", "api", "--method", "POST", basePath, "-f", "labels[]="+input.Label, "--silent"); err != nil {
+	if _, err := run(ctx, "gh", ciTriggerLabelGHArgs(input.Hostname, "--method", "POST", basePath, "-f", "labels[]="+input.Label, "--silent")...); err != nil {
 		return fmt.Errorf("add CI trigger label: %w", err)
 	}
 	return nil
+}
+
+func ciTriggerLabelGHArgs(hostname string, args ...string) []string {
+	result := []string{"api"}
+	if hostname = strings.TrimSpace(hostname); hostname != "" {
+		result = append(result, "--hostname", hostname)
+	}
+	return append(result, args...)
 }
 
 func ciTriggerLabelPresent(output string, label string) bool {

--- a/internal/cli/ci_trigger_label_test.go
+++ b/internal/cli/ci_trigger_label_test.go
@@ -20,6 +20,7 @@ func TestRunCITriggerLabelRemovesAndAddsExistingLabel(t *testing.T) {
 		Repository:      "digitaldrywood/detent",
 		PullRequest:     1313,
 		Label:           "ci:ready",
+		Hostname:        "github.example.com",
 		StaggerSeconds:  15,
 		CoordinationDir: coordinationDir,
 	}, ciTriggerLabelDeps{
@@ -39,9 +40,9 @@ func TestRunCITriggerLabelRemovesAndAddsExistingLabel(t *testing.T) {
 		t.Fatalf("result = %#v", result)
 	}
 	want := [][]string{
-		{"gh", "api", "--paginate", "repos/digitaldrywood/detent/issues/1313/labels", "--jq", ".[].name"},
-		{"gh", "api", "--method", "DELETE", "repos/digitaldrywood/detent/issues/1313/labels/ci:ready", "--silent"},
-		{"gh", "api", "--method", "POST", "repos/digitaldrywood/detent/issues/1313/labels", "-f", "labels[]=ci:ready", "--silent"},
+		{"gh", "api", "--hostname", "github.example.com", "--paginate", "repos/digitaldrywood/detent/issues/1313/labels", "--jq", ".[].name"},
+		{"gh", "api", "--hostname", "github.example.com", "--method", "DELETE", "repos/digitaldrywood/detent/issues/1313/labels/ci:ready", "--silent"},
+		{"gh", "api", "--hostname", "github.example.com", "--method", "POST", "repos/digitaldrywood/detent/issues/1313/labels", "-f", "labels[]=ci:ready", "--silent"},
 	}
 	if !reflect.DeepEqual(calls, want) {
 		t.Fatalf("calls = %#v, want %#v", calls, want)

--- a/internal/cli/ci_trigger_label_test.go
+++ b/internal/cli/ci_trigger_label_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"strings"
 	"testing"
 	"time"
 )
@@ -95,5 +96,19 @@ func TestRunCITriggerLabelWaitsForRepositoryStagger(t *testing.T) {
 	}
 	if len(calls) != 2 || calls[1][3] != "POST" {
 		t.Fatalf("calls = %#v, want list then add without delete", calls)
+	}
+}
+
+func TestRunCITriggerLabelRejectsZeroStagger(t *testing.T) {
+	t.Parallel()
+
+	_, err := runCITriggerLabel(context.Background(), ciTriggerLabelInput{
+		Repository:     "digitaldrywood/detent",
+		PullRequest:    1314,
+		Label:          "ci:ready",
+		StaggerSeconds: 0,
+	}, ciTriggerLabelDeps{})
+	if err == nil || !strings.Contains(err.Error(), "--stagger-seconds must be greater than 0") {
+		t.Fatalf("runCITriggerLabel() error = %v, want positive stagger validation", err)
 	}
 }

--- a/internal/cli/ci_trigger_label_test.go
+++ b/internal/cli/ci_trigger_label_test.go
@@ -1,0 +1,99 @@
+package cli
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+	"time"
+)
+
+func TestRunCITriggerLabelRemovesAndAddsExistingLabel(t *testing.T) {
+	t.Parallel()
+
+	coordinationDir := t.TempDir()
+	now := time.Date(2026, 7, 14, 22, 0, 0, 0, time.UTC)
+	var calls [][]string
+	result, err := runCITriggerLabel(context.Background(), ciTriggerLabelInput{
+		Repository:      "digitaldrywood/detent",
+		PullRequest:     1313,
+		Label:           "ci:ready",
+		StaggerSeconds:  15,
+		CoordinationDir: coordinationDir,
+	}, ciTriggerLabelDeps{
+		now: func() time.Time { return now },
+		runCommand: func(_ context.Context, name string, args ...string) (string, error) {
+			calls = append(calls, append([]string{name}, args...))
+			if len(calls) == 1 {
+				return "bug\nci:ready\n", nil
+			}
+			return "", nil
+		},
+	})
+	if err != nil {
+		t.Fatalf("runCITriggerLabel() error = %v", err)
+	}
+	if !result.Reapplied || result.Repository != "digitaldrywood/detent" || result.PullRequest != 1313 || result.Label != "ci:ready" {
+		t.Fatalf("result = %#v", result)
+	}
+	want := [][]string{
+		{"gh", "api", "--paginate", "repos/digitaldrywood/detent/issues/1313/labels", "--jq", ".[].name"},
+		{"gh", "api", "--method", "DELETE", "repos/digitaldrywood/detent/issues/1313/labels/ci:ready", "--silent"},
+		{"gh", "api", "--method", "POST", "repos/digitaldrywood/detent/issues/1313/labels", "-f", "labels[]=ci:ready", "--silent"},
+	}
+	if !reflect.DeepEqual(calls, want) {
+		t.Fatalf("calls = %#v, want %#v", calls, want)
+	}
+	_, timestampPath := ciTriggerLabelCoordinationPaths(coordinationDir, "digitaldrywood/detent")
+	raw, err := os.ReadFile(timestampPath)
+	if err != nil {
+		t.Fatalf("ReadFile(%s) error = %v", timestampPath, err)
+	}
+	if string(raw) != now.Format(time.RFC3339Nano)+"\n" {
+		t.Fatalf("timestamp = %q, want %s", raw, now.Format(time.RFC3339Nano))
+	}
+}
+
+func TestRunCITriggerLabelWaitsForRepositoryStagger(t *testing.T) {
+	t.Parallel()
+
+	coordinationDir := t.TempDir()
+	now := time.Date(2026, 7, 14, 22, 0, 5, 0, time.UTC)
+	_, timestampPath := ciTriggerLabelCoordinationPaths(coordinationDir, "digitaldrywood/detent")
+	if err := os.MkdirAll(filepath.Dir(timestampPath), 0o755); err != nil {
+		t.Fatalf("MkdirAll() error = %v", err)
+	}
+	if err := os.WriteFile(timestampPath, []byte(now.Add(-5*time.Second).Format(time.RFC3339Nano)+"\n"), 0o600); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+	var waits []time.Duration
+	var calls [][]string
+	_, err := runCITriggerLabel(context.Background(), ciTriggerLabelInput{
+		Repository:      "digitaldrywood/detent",
+		PullRequest:     1314,
+		Label:           "ci:ready",
+		StaggerSeconds:  15,
+		CoordinationDir: coordinationDir,
+	}, ciTriggerLabelDeps{
+		now: func() time.Time { return now },
+		wait: func(_ context.Context, duration time.Duration) error {
+			waits = append(waits, duration)
+			now = now.Add(duration)
+			return nil
+		},
+		runCommand: func(_ context.Context, name string, args ...string) (string, error) {
+			calls = append(calls, append([]string{name}, args...))
+			return "bug\n", nil
+		},
+	})
+	if err != nil {
+		t.Fatalf("runCITriggerLabel() error = %v", err)
+	}
+	if !reflect.DeepEqual(waits, []time.Duration{10 * time.Second}) {
+		t.Fatalf("waits = %#v, want 10s stagger", waits)
+	}
+	if len(calls) != 2 || calls[1][3] != "POST" {
+		t.Fatalf("calls = %#v, want list then add without delete", calls)
+	}
+}

--- a/internal/cli/ci_trigger_label_test.go
+++ b/internal/cli/ci_trigger_label_test.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"context"
+	"encoding/base64"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -19,8 +20,8 @@ func TestRunCITriggerLabelRemovesAndAddsExistingLabel(t *testing.T) {
 	result, err := runCITriggerLabel(context.Background(), ciTriggerLabelInput{
 		Repository:      "digitaldrywood/detent",
 		PullRequest:     1313,
-		Label:           "ci:ready",
-		Hostname:        "github.example.com",
+		LabelBase64:     base64.RawURLEncoding.EncodeToString([]byte("ci:ready")),
+		HostnameBase64:  base64.RawURLEncoding.EncodeToString([]byte("github.example.com")),
 		StaggerSeconds:  15,
 		CoordinationDir: coordinationDir,
 	}, ciTriggerLabelDeps{
@@ -111,5 +112,20 @@ func TestRunCITriggerLabelRejectsZeroStagger(t *testing.T) {
 	}, ciTriggerLabelDeps{})
 	if err == nil || !strings.Contains(err.Error(), "--stagger-seconds must be greater than 0") {
 		t.Fatalf("runCITriggerLabel() error = %v, want positive stagger validation", err)
+	}
+}
+
+func TestRunCITriggerLabelRejectsConflictingLabelRepresentations(t *testing.T) {
+	t.Parallel()
+
+	_, err := runCITriggerLabel(context.Background(), ciTriggerLabelInput{
+		Repository:     "digitaldrywood/detent",
+		PullRequest:    1314,
+		Label:          "ci:ready",
+		LabelBase64:    base64.RawURLEncoding.EncodeToString([]byte("ci:ready")),
+		StaggerSeconds: 15,
+	}, ciTriggerLabelDeps{})
+	if err == nil || !strings.Contains(err.Error(), "--label and --label-base64 are mutually exclusive") {
+		t.Fatalf("runCITriggerLabel() error = %v, want mutually exclusive validation", err)
 	}
 }

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -415,6 +415,7 @@ detent --format json config path`),
 	AddFormatFlag(cmd, &format)
 	cmd.AddCommand(
 		newDoctorCommand(&configPath, &env, &logLevel, &host, &port, opts),
+		newCITriggerLabelCommand(opts),
 		newDevRuntimeCommand(&host, &port, opts),
 		newInitCommand(&configPath, opts),
 		newAddProjectCommand(&configPath, opts),

--- a/internal/cli/doctor_workflow_lint.go
+++ b/internal/cli/doctor_workflow_lint.go
@@ -34,6 +34,8 @@ var doctorJobLabelConditionPatterns = []*regexp.Regexp{
 	regexp.MustCompile(`(?i)github\.event\.label\.name\s*==\s*"([^"]*)"`),
 	regexp.MustCompile(`(?i)'([^']*)'\s*==\s*github\.event\.label\.name`),
 	regexp.MustCompile(`(?i)"([^"]*)"\s*==\s*github\.event\.label\.name`),
+	regexp.MustCompile(`(?i)contains\(\s*github\.event\.pull_request\.labels\.\*\.name\s*,\s*'([^']*)'\s*\)`),
+	regexp.MustCompile(`(?i)contains\(\s*github\.event\.pull_request\.labels\.\*\.name\s*,\s*"([^"]*)"\s*\)`),
 }
 
 type doctorShipSkill struct {
@@ -133,10 +135,15 @@ func checkDoctorRequiredCheckTriggers(projectID string, project globalconfig.Pro
 			jobName := doctorYAMLScalarValue(doctorYAMLMapValue(jobNode, "name"))
 			labelGated := doctorRequiredCheckLabelGated(on, jobNode)
 			risks := append([]string(nil), workflowRisks...)
-			jobRequiresLabel := doctorJobRequiresLabelEvent(jobNode)
-			jobMatchesTriggerLabel := !jobRequiresLabel || ciTriggerLabel == "" || doctorJobConditionMatchesLabel(jobNode, ciTriggerLabel)
-			if jobRequiresLabel {
-				risks = append(risks, "job condition requires labeled event")
+			jobRequiresLabelEvent := doctorJobRequiresLabelEvent(jobNode)
+			jobUsesTriggerLabel := doctorJobUsesTriggerLabel(jobNode)
+			jobMatchesTriggerLabel := !jobUsesTriggerLabel || ciTriggerLabel == "" || doctorJobConditionMatchesLabel(jobNode, ciTriggerLabel)
+			if jobUsesTriggerLabel {
+				if jobRequiresLabelEvent {
+					risks = append(risks, "job condition requires labeled event")
+				} else {
+					risks = append(risks, "job condition requires trigger label")
+				}
 				if !jobMatchesTriggerLabel {
 					risks = append(risks, "job condition does not match gate.ci_trigger_label")
 				}
@@ -207,7 +214,7 @@ func doctorRequiredCheckLabelGated(on *yaml.Node, job *yaml.Node) bool {
 	if !doctorYAMLContainsScalar(types, "labeled") {
 		return false
 	}
-	return !doctorYAMLContainsScalar(types, "synchronize") || doctorJobRequiresLabelEvent(job)
+	return !doctorYAMLContainsScalar(types, "synchronize") || doctorJobUsesTriggerLabel(job)
 }
 
 func doctorOnlyLabelGateRisk(risks []string) bool {
@@ -216,7 +223,7 @@ func doctorOnlyLabelGateRisk(risks []string) bool {
 	}
 	for _, risk := range risks {
 		switch risk {
-		case "pull_request types exclude synchronize", "job condition requires labeled event":
+		case "pull_request types exclude synchronize", "job condition requires labeled event", "job condition requires trigger label":
 		default:
 			return false
 		}
@@ -230,9 +237,15 @@ func doctorJobRequiresLabelEvent(job *yaml.Node) bool {
 		strings.Contains(condition, "github.event.action") && strings.Contains(condition, "labeled")
 }
 
+func doctorJobUsesTriggerLabel(job *yaml.Node) bool {
+	condition := strings.ToLower(doctorYAMLScalarValue(doctorYAMLMapValue(job, "if")))
+	return doctorJobRequiresLabelEvent(job) || strings.Contains(condition, "github.event.pull_request.labels")
+}
+
 func doctorJobConditionMatchesLabel(job *yaml.Node, label string) bool {
 	condition := doctorYAMLScalarValue(doctorYAMLMapValue(job, "if"))
-	if !strings.Contains(strings.ToLower(condition), "github.event.label") {
+	lowerCondition := strings.ToLower(condition)
+	if !strings.Contains(lowerCondition, "github.event.label") && !strings.Contains(lowerCondition, "github.event.pull_request.labels") {
 		return true
 	}
 	label = strings.TrimSpace(label)

--- a/internal/cli/doctor_workflow_lint.go
+++ b/internal/cli/doctor_workflow_lint.go
@@ -181,18 +181,30 @@ func checkDoctorRequiredCheckTriggers(projectID string, project globalconfig.Pro
 }
 
 func doctorRequiredCheckLabelGated(on *yaml.Node, job *yaml.Node) bool {
-	if on == nil || on.Kind != yaml.MappingNode {
+	jobRequiresLabel := doctorJobRequiresLabelEvent(job)
+	switch {
+	case on == nil:
+		return false
+	case on.Kind == yaml.ScalarNode:
+		return jobRequiresLabel && strings.EqualFold(strings.TrimSpace(on.Value), "pull_request")
+	case on.Kind == yaml.SequenceNode:
+		return jobRequiresLabel && doctorYAMLContainsScalar(on, "pull_request")
+	case on.Kind != yaml.MappingNode:
 		return false
 	}
 	pullRequest := doctorYAMLMapValue(on, "pull_request")
-	if pullRequest == nil || pullRequest.Kind != yaml.MappingNode {
+	if pullRequest == nil {
 		return false
+	}
+	if pullRequest.Kind != yaml.MappingNode {
+		return jobRequiresLabel
 	}
 	types := doctorYAMLMapValue(pullRequest, "types")
-	if !doctorYAMLContainsScalar(types, "labeled") {
-		return false
+	if types == nil {
+		return jobRequiresLabel
 	}
-	return !doctorYAMLContainsScalar(types, "synchronize") || doctorJobRequiresLabelEvent(job)
+	return doctorYAMLContainsScalar(types, "labeled") &&
+		(!doctorYAMLContainsScalar(types, "synchronize") || jobRequiresLabel)
 }
 
 func doctorOnlyLabelGateRisk(risks []string) bool {

--- a/internal/cli/doctor_workflow_lint.go
+++ b/internal/cli/doctor_workflow_lint.go
@@ -113,8 +113,8 @@ func checkDoctorRequiredCheckTriggers(projectID string, project globalconfig.Pro
 			continue
 		}
 		rootNode := document.Content[0]
-		risks := doctorRequiredCheckTriggerRisks(doctorYAMLMapValue(rootNode, "on"))
-		labelGated := doctorRequiredCheckLabelGated(doctorYAMLMapValue(rootNode, "on"))
+		on := doctorYAMLMapValue(rootNode, "on")
+		workflowRisks := doctorRequiredCheckTriggerRisks(on)
 		jobs := doctorYAMLMapValue(rootNode, "jobs")
 		if jobs == nil || jobs.Kind != yaml.MappingNode {
 			continue
@@ -123,6 +123,11 @@ func checkDoctorRequiredCheckTriggers(projectID string, project globalconfig.Pro
 			jobID := strings.TrimSpace(jobs.Content[index].Value)
 			jobNode := jobs.Content[index+1]
 			jobName := doctorYAMLScalarValue(doctorYAMLMapValue(jobNode, "name"))
+			labelGated := doctorRequiredCheckLabelGated(on, jobNode)
+			risks := append([]string(nil), workflowRisks...)
+			if doctorJobRequiresLabelEvent(jobNode) {
+				risks = append(risks, "job condition requires labeled event")
+			}
 			for _, requiredName := range required {
 				if !doctorRequiredCheckMatchesJob(requiredName, jobID, jobName) {
 					continue
@@ -175,7 +180,7 @@ func checkDoctorRequiredCheckTriggers(projectID string, project globalconfig.Pro
 	}}
 }
 
-func doctorRequiredCheckLabelGated(on *yaml.Node) bool {
+func doctorRequiredCheckLabelGated(on *yaml.Node, job *yaml.Node) bool {
 	if on == nil || on.Kind != yaml.MappingNode {
 		return false
 	}
@@ -183,11 +188,31 @@ func doctorRequiredCheckLabelGated(on *yaml.Node) bool {
 	if pullRequest == nil || pullRequest.Kind != yaml.MappingNode {
 		return false
 	}
-	return doctorYAMLContainsScalar(doctorYAMLMapValue(pullRequest, "types"), "labeled")
+	types := doctorYAMLMapValue(pullRequest, "types")
+	if !doctorYAMLContainsScalar(types, "labeled") {
+		return false
+	}
+	return !doctorYAMLContainsScalar(types, "synchronize") || doctorJobRequiresLabelEvent(job)
 }
 
 func doctorOnlyLabelGateRisk(risks []string) bool {
-	return len(risks) == 1 && risks[0] == "pull_request types exclude synchronize"
+	if len(risks) == 0 {
+		return false
+	}
+	for _, risk := range risks {
+		switch risk {
+		case "pull_request types exclude synchronize", "job condition requires labeled event":
+		default:
+			return false
+		}
+	}
+	return true
+}
+
+func doctorJobRequiresLabelEvent(job *yaml.Node) bool {
+	condition := strings.ToLower(doctorYAMLScalarValue(doctorYAMLMapValue(job, "if")))
+	return strings.Contains(condition, "github.event.label") ||
+		strings.Contains(condition, "github.event.action") && strings.Contains(condition, "labeled")
 }
 
 func doctorWorkflowYAMLFile(name string) bool {

--- a/internal/cli/doctor_workflow_lint.go
+++ b/internal/cli/doctor_workflow_lint.go
@@ -74,13 +74,15 @@ func checkDoctorWorkflowLint(ctx context.Context, projectID string, project glob
 }
 
 type doctorRequiredCheckTrigger struct {
-	matched bool
-	safe    bool
-	risks   []string
+	matched    bool
+	safe       bool
+	labelGated bool
+	risks      []string
 }
 
 func checkDoctorRequiredCheckTriggers(projectID string, project globalconfig.Project, cfg workflowconfig.Config) []doctorCheck {
 	required := uniqueDoctorStrings(cfg.Gate.RequiredStatusChecks)
+	ciTriggerLabel := gate.Effective(cfg.Gate).CITriggerLabel
 	if len(required) == 0 || cfg.Deliverable.Kind != workflowconfig.DeliverablePullRequest {
 		return nil
 	}
@@ -112,6 +114,7 @@ func checkDoctorRequiredCheckTriggers(projectID string, project globalconfig.Pro
 		}
 		rootNode := document.Content[0]
 		risks := doctorRequiredCheckTriggerRisks(doctorYAMLMapValue(rootNode, "on"))
+		labelGated := doctorRequiredCheckLabelGated(doctorYAMLMapValue(rootNode, "on"))
 		jobs := doctorYAMLMapValue(rootNode, "jobs")
 		if jobs == nil || jobs.Kind != yaml.MappingNode {
 			continue
@@ -126,7 +129,10 @@ func checkDoctorRequiredCheckTriggers(projectID string, project globalconfig.Pro
 				}
 				trigger := triggers[requiredName]
 				trigger.matched = true
+				trigger.labelGated = trigger.labelGated || labelGated
 				if len(risks) == 0 {
+					trigger.safe = true
+				} else if labelGated && ciTriggerLabel != "" && doctorOnlyLabelGateRisk(risks) {
 					trigger.safe = true
 				} else {
 					relativePath, pathErr := filepath.Rel(root, path)
@@ -147,17 +153,41 @@ func checkDoctorRequiredCheckTriggers(projectID string, project globalconfig.Pro
 		if !trigger.matched || trigger.safe {
 			continue
 		}
+		if trigger.labelGated && ciTriggerLabel == "" {
+			warnings = append(warnings, name+" (label-gated: "+strings.Join(uniqueDoctorStrings(trigger.risks), "; ")+")")
+			continue
+		}
 		warnings = append(warnings, name+" ("+strings.Join(uniqueDoctorStrings(trigger.risks), "; ")+")")
 	}
 	if len(warnings) == 0 {
 		return nil
 	}
+	detail := "required checks are not produced on every pull-request head: " + strings.Join(warnings, ", ")
+	hint := "Remove pull_request path filters and include the synchronize activity for required-check workflows; skip non-applicable work inside the job while still reporting the required check."
+	if ciTriggerLabel == "" && strings.Contains(detail, "label-gated:") {
+		hint = "Configure gate.ci_trigger_label with the workflow's label so Detent re-applies it after every PR-head push, or include the synchronize activity in the required-check workflow."
+	}
 	return []doctorCheck{{
 		Name:   "Project " + projectID + " workflow lint required check triggers",
 		Status: doctorWarn,
-		Detail: "required checks are not produced on every pull-request head: " + strings.Join(warnings, ", "),
-		Hint:   "Remove pull_request path filters and include the synchronize activity for required-check workflows; skip non-applicable work inside the job while still reporting the required check.",
+		Detail: detail,
+		Hint:   hint,
 	}}
+}
+
+func doctorRequiredCheckLabelGated(on *yaml.Node) bool {
+	if on == nil || on.Kind != yaml.MappingNode {
+		return false
+	}
+	pullRequest := doctorYAMLMapValue(on, "pull_request")
+	if pullRequest == nil || pullRequest.Kind != yaml.MappingNode {
+		return false
+	}
+	return doctorYAMLContainsScalar(doctorYAMLMapValue(pullRequest, "types"), "labeled")
+}
+
+func doctorOnlyLabelGateRisk(risks []string) bool {
+	return len(risks) == 1 && risks[0] == "pull_request types exclude synchronize"
 }
 
 func doctorWorkflowYAMLFile(name string) bool {

--- a/internal/cli/doctor_workflow_lint.go
+++ b/internal/cli/doctor_workflow_lint.go
@@ -181,30 +181,18 @@ func checkDoctorRequiredCheckTriggers(projectID string, project globalconfig.Pro
 }
 
 func doctorRequiredCheckLabelGated(on *yaml.Node, job *yaml.Node) bool {
-	jobRequiresLabel := doctorJobRequiresLabelEvent(job)
-	switch {
-	case on == nil:
-		return false
-	case on.Kind == yaml.ScalarNode:
-		return jobRequiresLabel && strings.EqualFold(strings.TrimSpace(on.Value), "pull_request")
-	case on.Kind == yaml.SequenceNode:
-		return jobRequiresLabel && doctorYAMLContainsScalar(on, "pull_request")
-	case on.Kind != yaml.MappingNode:
+	if on == nil || on.Kind != yaml.MappingNode {
 		return false
 	}
 	pullRequest := doctorYAMLMapValue(on, "pull_request")
-	if pullRequest == nil {
+	if pullRequest == nil || pullRequest.Kind != yaml.MappingNode {
 		return false
 	}
-	if pullRequest.Kind != yaml.MappingNode {
-		return jobRequiresLabel
-	}
 	types := doctorYAMLMapValue(pullRequest, "types")
-	if types == nil {
-		return jobRequiresLabel
+	if !doctorYAMLContainsScalar(types, "labeled") {
+		return false
 	}
-	return doctorYAMLContainsScalar(types, "labeled") &&
-		(!doctorYAMLContainsScalar(types, "synchronize") || jobRequiresLabel)
+	return !doctorYAMLContainsScalar(types, "synchronize") || doctorJobRequiresLabelEvent(job)
 }
 
 func doctorOnlyLabelGateRisk(risks []string) bool {

--- a/internal/cli/doctor_workflow_lint.go
+++ b/internal/cli/doctor_workflow_lint.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"regexp"
 	"slices"
 	"strings"
 	"time"
@@ -27,6 +28,13 @@ const (
 	doctorWorkflowCeilingMinAttempts = 5
 	doctorWorkflowCeilingShare       = 0.20
 )
+
+var doctorJobLabelConditionPatterns = []*regexp.Regexp{
+	regexp.MustCompile(`(?i)github\.event\.label\.name\s*==\s*'([^']*)'`),
+	regexp.MustCompile(`(?i)github\.event\.label\.name\s*==\s*"([^"]*)"`),
+	regexp.MustCompile(`(?i)'([^']*)'\s*==\s*github\.event\.label\.name`),
+	regexp.MustCompile(`(?i)"([^"]*)"\s*==\s*github\.event\.label\.name`),
+}
 
 type doctorShipSkill struct {
 	Version string
@@ -125,8 +133,13 @@ func checkDoctorRequiredCheckTriggers(projectID string, project globalconfig.Pro
 			jobName := doctorYAMLScalarValue(doctorYAMLMapValue(jobNode, "name"))
 			labelGated := doctorRequiredCheckLabelGated(on, jobNode)
 			risks := append([]string(nil), workflowRisks...)
-			if doctorJobRequiresLabelEvent(jobNode) {
+			jobRequiresLabel := doctorJobRequiresLabelEvent(jobNode)
+			jobMatchesTriggerLabel := !jobRequiresLabel || ciTriggerLabel == "" || doctorJobConditionMatchesLabel(jobNode, ciTriggerLabel)
+			if jobRequiresLabel {
 				risks = append(risks, "job condition requires labeled event")
+				if !jobMatchesTriggerLabel {
+					risks = append(risks, "job condition does not match gate.ci_trigger_label")
+				}
 			}
 			for _, requiredName := range required {
 				if !doctorRequiredCheckMatchesJob(requiredName, jobID, jobName) {
@@ -137,7 +150,7 @@ func checkDoctorRequiredCheckTriggers(projectID string, project globalconfig.Pro
 				trigger.labelGated = trigger.labelGated || labelGated
 				if len(risks) == 0 {
 					trigger.safe = true
-				} else if labelGated && ciTriggerLabel != "" && doctorOnlyLabelGateRisk(risks) {
+				} else if labelGated && ciTriggerLabel != "" && jobMatchesTriggerLabel && doctorOnlyLabelGateRisk(risks) {
 					trigger.safe = true
 				} else {
 					relativePath, pathErr := filepath.Rel(root, path)
@@ -169,7 +182,9 @@ func checkDoctorRequiredCheckTriggers(projectID string, project globalconfig.Pro
 	}
 	detail := "required checks are not produced on every pull-request head: " + strings.Join(warnings, ", ")
 	hint := "Remove pull_request path filters and include the synchronize activity for required-check workflows; skip non-applicable work inside the job while still reporting the required check."
-	if ciTriggerLabel == "" && strings.Contains(detail, "label-gated:") {
+	if strings.Contains(detail, "does not match gate.ci_trigger_label") {
+		hint = "Set gate.ci_trigger_label to a label explicitly accepted by the required job condition, or update the workflow condition to accept the configured label."
+	} else if ciTriggerLabel == "" && strings.Contains(detail, "label-gated:") {
 		hint = "Configure gate.ci_trigger_label with the workflow's label so Detent re-applies it after every PR-head push, or include the synchronize activity in the required-check workflow."
 	}
 	return []doctorCheck{{
@@ -213,6 +228,22 @@ func doctorJobRequiresLabelEvent(job *yaml.Node) bool {
 	condition := strings.ToLower(doctorYAMLScalarValue(doctorYAMLMapValue(job, "if")))
 	return strings.Contains(condition, "github.event.label") ||
 		strings.Contains(condition, "github.event.action") && strings.Contains(condition, "labeled")
+}
+
+func doctorJobConditionMatchesLabel(job *yaml.Node, label string) bool {
+	condition := doctorYAMLScalarValue(doctorYAMLMapValue(job, "if"))
+	if !strings.Contains(strings.ToLower(condition), "github.event.label") {
+		return true
+	}
+	label = strings.TrimSpace(label)
+	for _, pattern := range doctorJobLabelConditionPatterns {
+		for _, match := range pattern.FindAllStringSubmatch(condition, -1) {
+			if len(match) > 1 && strings.EqualFold(strings.TrimSpace(match[1]), label) {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 func doctorWorkflowYAMLFile(name string) bool {

--- a/internal/cli/doctor_workflow_lint_test.go
+++ b/internal/cli/doctor_workflow_lint_test.go
@@ -178,6 +178,67 @@ func TestCheckDoctorWorkflowLintWarnsForPathFilteredRequiredCheck(t *testing.T) 
 	}
 }
 
+func TestCheckDoctorWorkflowLintWarnsForUnconfiguredLabelGatedRequiredCheck(t *testing.T) {
+	t.Parallel()
+
+	workdir := t.TempDir()
+	workflowDir := filepath.Join(workdir, ".github", "workflows")
+	if err := os.MkdirAll(workflowDir, 0o700); err != nil {
+		t.Fatalf("mkdir workflows: %v", err)
+	}
+	workflow := []byte("name: CI\non:\n  pull_request:\n    types: [labeled]\njobs:\n  test:\n    name: Test\n    runs-on: self-hosted\n    if: github.event.label.name == 'ci:ready'\n    steps:\n      - run: go test ./...\n")
+	if err := os.WriteFile(filepath.Join(workflowDir, "ci.yml"), workflow, 0o600); err != nil {
+		t.Fatalf("write workflow: %v", err)
+	}
+	cfg := workflowconfig.Default()
+	cfg.Workspace.SourceRoot = workdir
+	cfg.Gate.RequiredStatusChecks = []string{"Test"}
+
+	checks := checkDoctorWorkflowLint(context.Background(), "alpha", globalconfig.Project{
+		ID:       "alpha",
+		Workflow: "WORKFLOW.md",
+		Workdir:  workdir,
+	}, cfg, "", doctorDeps{})
+
+	if len(checks) != 1 {
+		t.Fatalf("checks = %#v, want one warning", checks)
+	}
+	check := checks[0]
+	for _, want := range []string{"Test", "ci.yml", "label-gated", "gate.ci_trigger_label"} {
+		if !strings.Contains(check.Detail+" "+check.Hint, want) {
+			t.Fatalf("check = %#v, want containing %q", check, want)
+		}
+	}
+}
+
+func TestCheckDoctorWorkflowLintAcceptsConfiguredLabelGatedRequiredCheck(t *testing.T) {
+	t.Parallel()
+
+	workdir := t.TempDir()
+	workflowDir := filepath.Join(workdir, ".github", "workflows")
+	if err := os.MkdirAll(workflowDir, 0o700); err != nil {
+		t.Fatalf("mkdir workflows: %v", err)
+	}
+	workflow := []byte("name: CI\non:\n  pull_request:\n    types: [labeled]\njobs:\n  test:\n    name: Test\n    runs-on: self-hosted\n    if: github.event.label.name == 'ci:ready'\n    steps:\n      - run: go test ./...\n")
+	if err := os.WriteFile(filepath.Join(workflowDir, "ci.yml"), workflow, 0o600); err != nil {
+		t.Fatalf("write workflow: %v", err)
+	}
+	cfg := workflowconfig.Default()
+	cfg.Workspace.SourceRoot = workdir
+	cfg.Gate.RequiredStatusChecks = []string{"Test"}
+	cfg.Gate.CITriggerLabel = "ci:ready"
+
+	checks := checkDoctorWorkflowLint(context.Background(), "alpha", globalconfig.Project{
+		ID:       "alpha",
+		Workflow: "WORKFLOW.md",
+		Workdir:  workdir,
+	}, cfg, "", doctorDeps{})
+
+	if len(checks) != 0 {
+		t.Fatalf("checks = %#v, want configured label gate to be accepted", checks)
+	}
+}
+
 func TestDoctorWorkflowExecutableIndexSkipsEnvironmentAssignments(t *testing.T) {
 	t.Parallel()
 

--- a/internal/cli/doctor_workflow_lint_test.go
+++ b/internal/cli/doctor_workflow_lint_test.go
@@ -214,28 +214,41 @@ func TestCheckDoctorWorkflowLintWarnsForUnconfiguredLabelGatedRequiredCheck(t *t
 func TestCheckDoctorWorkflowLintAcceptsConfiguredLabelGatedRequiredCheck(t *testing.T) {
 	t.Parallel()
 
-	workdir := t.TempDir()
-	workflowDir := filepath.Join(workdir, ".github", "workflows")
-	if err := os.MkdirAll(workflowDir, 0o700); err != nil {
-		t.Fatalf("mkdir workflows: %v", err)
-	}
-	workflow := []byte("name: CI\non:\n  pull_request:\n    types: [labeled, synchronize]\njobs:\n  test:\n    name: Test\n    runs-on: self-hosted\n    if: github.event.label.name == 'ci:ready'\n    steps:\n      - run: go test ./...\n")
-	if err := os.WriteFile(filepath.Join(workflowDir, "ci.yml"), workflow, 0o600); err != nil {
-		t.Fatalf("write workflow: %v", err)
-	}
-	cfg := workflowconfig.Default()
-	cfg.Workspace.SourceRoot = workdir
-	cfg.Gate.RequiredStatusChecks = []string{"Test"}
-	cfg.Gate.CITriggerLabel = "ci:ready"
+	for _, tt := range []struct {
+		name string
+		on   string
+	}{
+		{name: "explicit labeled and synchronize types", on: "on:\n  pull_request:\n    types: [labeled, synchronize]"},
+		{name: "default pull request mapping", on: "on:\n  pull_request:"},
+		{name: "shorthand pull request", on: "on: pull_request"},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 
-	checks := checkDoctorWorkflowLint(context.Background(), "alpha", globalconfig.Project{
-		ID:       "alpha",
-		Workflow: "WORKFLOW.md",
-		Workdir:  workdir,
-	}, cfg, "", doctorDeps{})
+			workdir := t.TempDir()
+			workflowDir := filepath.Join(workdir, ".github", "workflows")
+			if err := os.MkdirAll(workflowDir, 0o700); err != nil {
+				t.Fatalf("mkdir workflows: %v", err)
+			}
+			workflow := []byte("name: CI\n" + tt.on + "\njobs:\n  test:\n    name: Test\n    runs-on: self-hosted\n    if: github.event.label.name == 'ci:ready'\n    steps:\n      - run: go test ./...\n")
+			if err := os.WriteFile(filepath.Join(workflowDir, "ci.yml"), workflow, 0o600); err != nil {
+				t.Fatalf("write workflow: %v", err)
+			}
+			cfg := workflowconfig.Default()
+			cfg.Workspace.SourceRoot = workdir
+			cfg.Gate.RequiredStatusChecks = []string{"Test"}
+			cfg.Gate.CITriggerLabel = "ci:ready"
 
-	if len(checks) != 0 {
-		t.Fatalf("checks = %#v, want configured label gate to be accepted", checks)
+			checks := checkDoctorWorkflowLint(context.Background(), "alpha", globalconfig.Project{
+				ID:       "alpha",
+				Workflow: "WORKFLOW.md",
+				Workdir:  workdir,
+			}, cfg, "", doctorDeps{})
+
+			if len(checks) != 0 {
+				t.Fatalf("checks = %#v, want configured label gate to be accepted", checks)
+			}
+		})
 	}
 }
 

--- a/internal/cli/doctor_workflow_lint_test.go
+++ b/internal/cli/doctor_workflow_lint_test.go
@@ -215,13 +215,19 @@ func TestCheckDoctorWorkflowLintAcceptsConfiguredLabelGatedRequiredCheck(t *test
 	t.Parallel()
 
 	for _, tt := range []struct {
-		name        string
-		on          string
-		wantWarning bool
+		name            string
+		on              string
+		condition       string
+		configuredLabel string
+		wantWarning     bool
+		wantDetail      string
+		wantHint        string
 	}{
 		{name: "explicit labeled and synchronize types", on: "on:\n  pull_request:\n    types: [labeled, synchronize]"},
-		{name: "default pull request mapping", on: "on:\n  pull_request:", wantWarning: true},
-		{name: "shorthand pull request", on: "on: pull_request", wantWarning: true},
+		{name: "one of multiple matching labels", on: "on:\n  pull_request:\n    types: [labeled, synchronize]", condition: "github.event.label.name == 'ci:ready' || github.event.label.name == 'ci:full'", configuredLabel: "ci:full"},
+		{name: "mismatched configured label", on: "on:\n  pull_request:\n    types: [labeled, synchronize]", configuredLabel: "ci:full", wantWarning: true, wantDetail: "does not match gate.ci_trigger_label", wantHint: "Set gate.ci_trigger_label to a label explicitly accepted"},
+		{name: "default pull request mapping", on: "on:\n  pull_request:", wantWarning: true, wantDetail: "job condition requires labeled event"},
+		{name: "shorthand pull request", on: "on: pull_request", wantWarning: true, wantDetail: "job condition requires labeled event"},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
@@ -231,14 +237,21 @@ func TestCheckDoctorWorkflowLintAcceptsConfiguredLabelGatedRequiredCheck(t *test
 			if err := os.MkdirAll(workflowDir, 0o700); err != nil {
 				t.Fatalf("mkdir workflows: %v", err)
 			}
-			workflow := []byte("name: CI\n" + tt.on + "\njobs:\n  test:\n    name: Test\n    runs-on: self-hosted\n    if: github.event.label.name == 'ci:ready'\n    steps:\n      - run: go test ./...\n")
+			condition := tt.condition
+			if condition == "" {
+				condition = "github.event.label.name == 'ci:ready'"
+			}
+			workflow := []byte("name: CI\n" + tt.on + "\njobs:\n  test:\n    name: Test\n    runs-on: self-hosted\n    if: " + condition + "\n    steps:\n      - run: go test ./...\n")
 			if err := os.WriteFile(filepath.Join(workflowDir, "ci.yml"), workflow, 0o600); err != nil {
 				t.Fatalf("write workflow: %v", err)
 			}
 			cfg := workflowconfig.Default()
 			cfg.Workspace.SourceRoot = workdir
 			cfg.Gate.RequiredStatusChecks = []string{"Test"}
-			cfg.Gate.CITriggerLabel = "ci:ready"
+			cfg.Gate.CITriggerLabel = tt.configuredLabel
+			if cfg.Gate.CITriggerLabel == "" {
+				cfg.Gate.CITriggerLabel = "ci:ready"
+			}
 
 			checks := checkDoctorWorkflowLint(context.Background(), "alpha", globalconfig.Project{
 				ID:       "alpha",
@@ -247,8 +260,11 @@ func TestCheckDoctorWorkflowLintAcceptsConfiguredLabelGatedRequiredCheck(t *test
 			}, cfg, "", doctorDeps{})
 
 			if tt.wantWarning {
-				if len(checks) != 1 || !strings.Contains(checks[0].Detail, "job condition requires labeled event") {
+				if len(checks) != 1 || !strings.Contains(checks[0].Detail, tt.wantDetail) {
 					t.Fatalf("checks = %#v, want unsafe default trigger warning", checks)
+				}
+				if tt.wantHint != "" && !strings.Contains(checks[0].Hint, tt.wantHint) {
+					t.Fatalf("Hint = %q, want containing %q", checks[0].Hint, tt.wantHint)
 				}
 				return
 			}

--- a/internal/cli/doctor_workflow_lint_test.go
+++ b/internal/cli/doctor_workflow_lint_test.go
@@ -186,7 +186,7 @@ func TestCheckDoctorWorkflowLintWarnsForUnconfiguredLabelGatedRequiredCheck(t *t
 	if err := os.MkdirAll(workflowDir, 0o700); err != nil {
 		t.Fatalf("mkdir workflows: %v", err)
 	}
-	workflow := []byte("name: CI\non:\n  pull_request:\n    types: [labeled]\njobs:\n  test:\n    name: Test\n    runs-on: self-hosted\n    if: github.event.label.name == 'ci:ready'\n    steps:\n      - run: go test ./...\n")
+	workflow := []byte("name: CI\non:\n  pull_request:\n    types: [labeled, synchronize]\njobs:\n  test:\n    name: Test\n    runs-on: self-hosted\n    if: github.event.label.name == 'ci:ready'\n    steps:\n      - run: go test ./...\n")
 	if err := os.WriteFile(filepath.Join(workflowDir, "ci.yml"), workflow, 0o600); err != nil {
 		t.Fatalf("write workflow: %v", err)
 	}
@@ -219,7 +219,7 @@ func TestCheckDoctorWorkflowLintAcceptsConfiguredLabelGatedRequiredCheck(t *test
 	if err := os.MkdirAll(workflowDir, 0o700); err != nil {
 		t.Fatalf("mkdir workflows: %v", err)
 	}
-	workflow := []byte("name: CI\non:\n  pull_request:\n    types: [labeled]\njobs:\n  test:\n    name: Test\n    runs-on: self-hosted\n    if: github.event.label.name == 'ci:ready'\n    steps:\n      - run: go test ./...\n")
+	workflow := []byte("name: CI\non:\n  pull_request:\n    types: [labeled, synchronize]\njobs:\n  test:\n    name: Test\n    runs-on: self-hosted\n    if: github.event.label.name == 'ci:ready'\n    steps:\n      - run: go test ./...\n")
 	if err := os.WriteFile(filepath.Join(workflowDir, "ci.yml"), workflow, 0o600); err != nil {
 		t.Fatalf("write workflow: %v", err)
 	}

--- a/internal/cli/doctor_workflow_lint_test.go
+++ b/internal/cli/doctor_workflow_lint_test.go
@@ -226,6 +226,8 @@ func TestCheckDoctorWorkflowLintAcceptsConfiguredLabelGatedRequiredCheck(t *test
 		{name: "explicit labeled and synchronize types", on: "on:\n  pull_request:\n    types: [labeled, synchronize]"},
 		{name: "one of multiple matching labels", on: "on:\n  pull_request:\n    types: [labeled, synchronize]", condition: "github.event.label.name == 'ci:ready' || github.event.label.name == 'ci:full'", configuredLabel: "ci:full"},
 		{name: "mismatched configured label", on: "on:\n  pull_request:\n    types: [labeled, synchronize]", configuredLabel: "ci:full", wantWarning: true, wantDetail: "does not match gate.ci_trigger_label", wantHint: "Set gate.ci_trigger_label to a label explicitly accepted"},
+		{name: "pull request label list matches", on: "on:\n  pull_request:\n    types: [labeled]", condition: "contains(github.event.pull_request.labels.*.name, 'ci:ready')"},
+		{name: "pull request label list mismatch", on: "on:\n  pull_request:\n    types: [labeled]", condition: "contains(github.event.pull_request.labels.*.name, 'ci:ready')", configuredLabel: "ci:full", wantWarning: true, wantDetail: "does not match gate.ci_trigger_label", wantHint: "Set gate.ci_trigger_label to a label explicitly accepted"},
 		{name: "default pull request mapping", on: "on:\n  pull_request:", wantWarning: true, wantDetail: "job condition requires labeled event"},
 		{name: "shorthand pull request", on: "on: pull_request", wantWarning: true, wantDetail: "job condition requires labeled event"},
 	} {

--- a/internal/cli/doctor_workflow_lint_test.go
+++ b/internal/cli/doctor_workflow_lint_test.go
@@ -215,12 +215,13 @@ func TestCheckDoctorWorkflowLintAcceptsConfiguredLabelGatedRequiredCheck(t *test
 	t.Parallel()
 
 	for _, tt := range []struct {
-		name string
-		on   string
+		name        string
+		on          string
+		wantWarning bool
 	}{
 		{name: "explicit labeled and synchronize types", on: "on:\n  pull_request:\n    types: [labeled, synchronize]"},
-		{name: "default pull request mapping", on: "on:\n  pull_request:"},
-		{name: "shorthand pull request", on: "on: pull_request"},
+		{name: "default pull request mapping", on: "on:\n  pull_request:", wantWarning: true},
+		{name: "shorthand pull request", on: "on: pull_request", wantWarning: true},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
@@ -245,8 +246,14 @@ func TestCheckDoctorWorkflowLintAcceptsConfiguredLabelGatedRequiredCheck(t *test
 				Workdir:  workdir,
 			}, cfg, "", doctorDeps{})
 
+			if tt.wantWarning {
+				if len(checks) != 1 || !strings.Contains(checks[0].Detail, "job condition requires labeled event") {
+					t.Fatalf("checks = %#v, want unsafe default trigger warning", checks)
+				}
+				return
+			}
 			if len(checks) != 0 {
-				t.Fatalf("checks = %#v, want configured label gate to be accepted", checks)
+				t.Fatalf("checks = %#v, want explicit label gate to be accepted", checks)
 			}
 		})
 	}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -2081,8 +2081,28 @@ Prompt
 	if got := workflow.Config.Gate.CITriggerLabel; got != "ci:ready" {
 		t.Fatalf("Gate.CITriggerLabel = %q, want ci:ready", got)
 	}
-	if got := workflow.Config.Gate.CITriggerLabelStaggerSeconds; got != 20 {
-		t.Fatalf("Gate.CITriggerLabelStaggerSeconds = %d, want 20", got)
+	if got := workflow.Config.Gate.CITriggerLabelStaggerSeconds; got == nil || *got != 20 {
+		t.Fatalf("Gate.CITriggerLabelStaggerSeconds = %v, want 20", got)
+	}
+}
+
+func TestParseWorkflowGateCITriggerLabelRejectsZeroStagger(t *testing.T) {
+	t.Parallel()
+
+	workflow, err := ParseWorkflow([]byte(`---
+tracker:
+  kind: memory
+gate:
+  ci_trigger_label: ci:ready
+  ci_trigger_label_stagger_seconds: 0
+---
+Prompt
+`))
+	if err != nil {
+		t.Fatalf("ParseWorkflow() error = %v", err)
+	}
+	if err := workflow.Config.Validate(); err == nil || !strings.Contains(err.Error(), "gate.ci_trigger_label_stagger_seconds must be greater than 0") {
+		t.Fatalf("Validate() error = %v, want positive stagger validation", err)
 	}
 }
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -2059,6 +2059,33 @@ Prompt
 	}
 }
 
+func TestParseWorkflowGateCITriggerLabel(t *testing.T) {
+	t.Parallel()
+
+	workflow, err := ParseWorkflow([]byte(`---
+tracker:
+  kind: memory
+gate:
+  ci_trigger_label: " CI:Ready "
+  ci_trigger_label_stagger_seconds: 20
+---
+Prompt
+`))
+	if err != nil {
+		t.Fatalf("ParseWorkflow() error = %v", err)
+	}
+	if err := workflow.Config.Validate(); err != nil {
+		t.Fatalf("Validate() error = %v", err)
+	}
+
+	if got := workflow.Config.Gate.CITriggerLabel; got != "ci:ready" {
+		t.Fatalf("Gate.CITriggerLabel = %q, want ci:ready", got)
+	}
+	if got := workflow.Config.Gate.CITriggerLabelStaggerSeconds; got != 20 {
+		t.Fatalf("Gate.CITriggerLabelStaggerSeconds = %d, want 20", got)
+	}
+}
+
 func TestParseWorkflowGateTransientCIRetryLimitCanDisable(t *testing.T) {
 	t.Parallel()
 

--- a/internal/gate/gate.go
+++ b/internal/gate/gate.go
@@ -421,7 +421,11 @@ func ciTriggerLabelInstructions(cfg Config) string {
 	if cfg.CITriggerLabelStaggerSeconds != nil {
 		staggerSeconds = *cfg.CITriggerLabelStaggerSeconds
 	}
-	return "This project uses CI trigger label `" + cfg.CITriggerLabel + "`. After every push that changes a pull request head in implementation, rework, or merging, run `detent ci-trigger-label --repository <owner/repo> --pull-request <number> --label " + cfg.CITriggerLabel + " --stagger-seconds " + strconv.Itoa(staggerSeconds) + "` before waiting for current-head checks. The command removes the label if present, adds it again through GitHub's REST issue-label endpoints, and uses a host-wide lock plus persisted timestamp to serialize reapplications at least " + strconv.Itoa(staggerSeconds) + " seconds apart so concurrent workers do not stampede self-hosted CI. "
+	return "This project uses CI trigger label `" + cfg.CITriggerLabel + "`. After every push that changes a pull request head in implementation, rework, or merging, run `detent ci-trigger-label --repository <owner/repo> --pull-request <number> --label " + quoteCITriggerLabel(cfg.CITriggerLabel) + " --stagger-seconds " + strconv.Itoa(staggerSeconds) + "` before waiting for current-head checks. The command removes the label if present, adds it again through GitHub's REST issue-label endpoints, and uses a host-wide lock plus persisted timestamp to serialize reapplications at least " + strconv.Itoa(staggerSeconds) + " seconds apart so concurrent workers do not stampede self-hosted CI. "
+}
+
+func quoteCITriggerLabel(label string) string {
+	return "'" + strings.ReplaceAll(label, "'", "'\\''") + "'"
 }
 
 func requiredStatusCheckInstructions(checks []string) string {

--- a/internal/gate/gate.go
+++ b/internal/gate/gate.go
@@ -1,6 +1,7 @@
 package gate
 
 import (
+	"strconv"
 	"strings"
 	"time"
 )
@@ -10,15 +11,16 @@ const (
 	KindHumanReview = "human_review"
 	KindArtifact    = "artifact"
 
-	DefaultCommand                     = "make check"
-	DefaultApprovalLabel               = "human-approved"
-	DefaultPlanApprovalLabel           = "plan-approved"
-	DefaultPlanStop                    = "Plan Review"
-	DefaultValidatorMinScore           = 0.8
-	DefaultValidatorMaxAttempts        = 3
-	DefaultValidatorMaxInlineDiffBytes = 64 * 1024
-	DefaultArtifactStatusField         = "validation_status"
-	DefaultTransientCIRetries          = 2
+	DefaultCommand                      = "make check"
+	DefaultApprovalLabel                = "human-approved"
+	DefaultPlanApprovalLabel            = "plan-approved"
+	DefaultPlanStop                     = "Plan Review"
+	DefaultValidatorMinScore            = 0.8
+	DefaultValidatorMaxAttempts         = 3
+	DefaultValidatorMaxInlineDiffBytes  = 64 * 1024
+	DefaultArtifactStatusField          = "validation_status"
+	DefaultTransientCIRetries           = 2
+	DefaultCITriggerLabelStaggerSeconds = 15
 
 	CIFailureActionSkip   = "skip"
 	CIFailureActionRework = "rework"
@@ -33,16 +35,18 @@ const (
 )
 
 type Config struct {
-	Kind                   string          `yaml:"kind"`
-	Run                    string          `yaml:"run"`
-	ApprovalLabel          string          `yaml:"approval_label"`
-	AutomatedReview        string          `yaml:"automated_review"`
-	RequireAutomatedReview *bool           `yaml:"require_automated_review"`
-	RequiredStatusChecks   []string        `yaml:"required_status_checks"`
-	CIFailureAction        string          `yaml:"ci_failure_action"`
-	TransientCIRetryLimit  *int            `yaml:"transient_ci_retry_limit"`
-	Validator              ValidatorConfig `yaml:"validator"`
-	Artifact               ArtifactConfig  `yaml:"artifact"`
+	Kind                         string          `yaml:"kind"`
+	Run                          string          `yaml:"run"`
+	ApprovalLabel                string          `yaml:"approval_label"`
+	AutomatedReview              string          `yaml:"automated_review"`
+	RequireAutomatedReview       *bool           `yaml:"require_automated_review"`
+	RequiredStatusChecks         []string        `yaml:"required_status_checks"`
+	CITriggerLabel               string          `yaml:"ci_trigger_label"`
+	CITriggerLabelStaggerSeconds int             `yaml:"ci_trigger_label_stagger_seconds"`
+	CIFailureAction              string          `yaml:"ci_failure_action"`
+	TransientCIRetryLimit        *int            `yaml:"transient_ci_retry_limit"`
+	Validator                    ValidatorConfig `yaml:"validator"`
+	Artifact                     ArtifactConfig  `yaml:"artifact"`
 }
 
 type ArtifactConfig struct {
@@ -179,6 +183,10 @@ func Effective(cfg Config) Config {
 	cfg.ApprovalLabel = normalizeLabel(cfg.ApprovalLabel)
 	cfg.AutomatedReview = NormalizeAutomatedReview(cfg.AutomatedReview)
 	cfg.RequiredStatusChecks = NormalizeRequiredStatusChecks(cfg.RequiredStatusChecks)
+	cfg.CITriggerLabel = normalizeLabel(cfg.CITriggerLabel)
+	if cfg.CITriggerLabel != "" && cfg.CITriggerLabelStaggerSeconds == 0 {
+		cfg.CITriggerLabelStaggerSeconds = DefaultCITriggerLabelStaggerSeconds
+	}
 	cfg.CIFailureAction = NormalizeCIFailureAction(cfg.CIFailureAction)
 	if cfg.TransientCIRetryLimit == nil {
 		cfg.TransientCIRetryLimit = newInt(DefaultTransientCIRetries)
@@ -345,6 +353,9 @@ func Validate(prefix string, cfg Config) []string {
 	if cfg.TransientCIRetryLimit != nil && *cfg.TransientCIRetryLimit < 0 {
 		problems = append(problems, prefix+".transient_ci_retry_limit must be greater than or equal to 0")
 	}
+	if cfg.CITriggerLabelStaggerSeconds < 0 {
+		problems = append(problems, prefix+".ci_trigger_label_stagger_seconds must be greater than or equal to 0")
+	}
 	for _, check := range cfg.RequiredStatusChecks {
 		if strings.TrimSpace(check) == "" {
 			problems = append(problems, prefix+".required_status_checks must not contain blank names")
@@ -382,6 +393,7 @@ func Instructions(cfg Config) string {
 		instructions := "The validation gate is a command. Run `" + cfg.Run +
 			"` from the workspace root before Human Review; the pull request still needs green CI before promotion. " +
 			requiredStatusCheckInstructions(cfg.RequiredStatusChecks) +
+			ciTriggerLabelInstructions(cfg) +
 			"In Merging, run a focused rebase/smoke gate after a clean rebase when the PR already passed current-head validation and no source files changed during rebase. " +
 			"Run full `" + cfg.Run + "` in Merging when code changes, conflicts are resolved, or validation state is stale or unknown. " +
 			"Watch current-head CI with REST check-runs polling/backoff, report slow checks, and record merge wait telemetry in the Workpad prose: quiet-window wait, local merge-gate duration, PR CI duration, slow check names, and whether post-merge main CI is still running. " +
@@ -399,6 +411,13 @@ func Instructions(cfg Config) string {
 		}
 		return instructions
 	}
+}
+
+func ciTriggerLabelInstructions(cfg Config) string {
+	if cfg.CITriggerLabel == "" {
+		return ""
+	}
+	return "This project uses CI trigger label `" + cfg.CITriggerLabel + "`. After every push that changes a pull request head in implementation, rework, or merging, re-apply that label by removing it if present and adding it again through GitHub's REST issue-label endpoints; fire the fresh labeled event before waiting for current-head checks. Serialize trigger-label reapplications on the host and start them at least " + strconv.Itoa(cfg.CITriggerLabelStaggerSeconds) + " seconds apart so concurrent workers do not stampede self-hosted CI. "
 }
 
 func requiredStatusCheckInstructions(checks []string) string {

--- a/internal/gate/gate.go
+++ b/internal/gate/gate.go
@@ -42,7 +42,7 @@ type Config struct {
 	RequireAutomatedReview       *bool           `yaml:"require_automated_review"`
 	RequiredStatusChecks         []string        `yaml:"required_status_checks"`
 	CITriggerLabel               string          `yaml:"ci_trigger_label"`
-	CITriggerLabelStaggerSeconds int             `yaml:"ci_trigger_label_stagger_seconds"`
+	CITriggerLabelStaggerSeconds *int            `yaml:"ci_trigger_label_stagger_seconds"`
 	CIFailureAction              string          `yaml:"ci_failure_action"`
 	TransientCIRetryLimit        *int            `yaml:"transient_ci_retry_limit"`
 	Validator                    ValidatorConfig `yaml:"validator"`
@@ -184,8 +184,8 @@ func Effective(cfg Config) Config {
 	cfg.AutomatedReview = NormalizeAutomatedReview(cfg.AutomatedReview)
 	cfg.RequiredStatusChecks = NormalizeRequiredStatusChecks(cfg.RequiredStatusChecks)
 	cfg.CITriggerLabel = normalizeLabel(cfg.CITriggerLabel)
-	if cfg.CITriggerLabel != "" && cfg.CITriggerLabelStaggerSeconds == 0 {
-		cfg.CITriggerLabelStaggerSeconds = DefaultCITriggerLabelStaggerSeconds
+	if cfg.CITriggerLabel != "" && cfg.CITriggerLabelStaggerSeconds == nil {
+		cfg.CITriggerLabelStaggerSeconds = newInt(DefaultCITriggerLabelStaggerSeconds)
 	}
 	cfg.CIFailureAction = NormalizeCIFailureAction(cfg.CIFailureAction)
 	if cfg.TransientCIRetryLimit == nil {
@@ -353,8 +353,8 @@ func Validate(prefix string, cfg Config) []string {
 	if cfg.TransientCIRetryLimit != nil && *cfg.TransientCIRetryLimit < 0 {
 		problems = append(problems, prefix+".transient_ci_retry_limit must be greater than or equal to 0")
 	}
-	if cfg.CITriggerLabelStaggerSeconds < 0 {
-		problems = append(problems, prefix+".ci_trigger_label_stagger_seconds must be greater than or equal to 0")
+	if cfg.CITriggerLabelStaggerSeconds != nil && *cfg.CITriggerLabelStaggerSeconds <= 0 {
+		problems = append(problems, prefix+".ci_trigger_label_stagger_seconds must be greater than 0")
 	}
 	for _, check := range cfg.RequiredStatusChecks {
 		if strings.TrimSpace(check) == "" {
@@ -417,7 +417,11 @@ func ciTriggerLabelInstructions(cfg Config) string {
 	if cfg.CITriggerLabel == "" {
 		return ""
 	}
-	return "This project uses CI trigger label `" + cfg.CITriggerLabel + "`. After every push that changes a pull request head in implementation, rework, or merging, run `detent ci-trigger-label --repository <owner/repo> --pull-request <number> --label " + cfg.CITriggerLabel + " --stagger-seconds " + strconv.Itoa(cfg.CITriggerLabelStaggerSeconds) + "` before waiting for current-head checks. The command removes the label if present, adds it again through GitHub's REST issue-label endpoints, and uses a host-wide lock plus persisted timestamp to serialize reapplications at least " + strconv.Itoa(cfg.CITriggerLabelStaggerSeconds) + " seconds apart so concurrent workers do not stampede self-hosted CI. "
+	staggerSeconds := 0
+	if cfg.CITriggerLabelStaggerSeconds != nil {
+		staggerSeconds = *cfg.CITriggerLabelStaggerSeconds
+	}
+	return "This project uses CI trigger label `" + cfg.CITriggerLabel + "`. After every push that changes a pull request head in implementation, rework, or merging, run `detent ci-trigger-label --repository <owner/repo> --pull-request <number> --label " + cfg.CITriggerLabel + " --stagger-seconds " + strconv.Itoa(staggerSeconds) + "` before waiting for current-head checks. The command removes the label if present, adds it again through GitHub's REST issue-label endpoints, and uses a host-wide lock plus persisted timestamp to serialize reapplications at least " + strconv.Itoa(staggerSeconds) + " seconds apart so concurrent workers do not stampede self-hosted CI. "
 }
 
 func requiredStatusCheckInstructions(checks []string) string {

--- a/internal/gate/gate.go
+++ b/internal/gate/gate.go
@@ -417,7 +417,7 @@ func ciTriggerLabelInstructions(cfg Config) string {
 	if cfg.CITriggerLabel == "" {
 		return ""
 	}
-	return "This project uses CI trigger label `" + cfg.CITriggerLabel + "`. After every push that changes a pull request head in implementation, rework, or merging, re-apply that label by removing it if present and adding it again through GitHub's REST issue-label endpoints; fire the fresh labeled event before waiting for current-head checks. Serialize trigger-label reapplications on the host and start them at least " + strconv.Itoa(cfg.CITriggerLabelStaggerSeconds) + " seconds apart so concurrent workers do not stampede self-hosted CI. "
+	return "This project uses CI trigger label `" + cfg.CITriggerLabel + "`. After every push that changes a pull request head in implementation, rework, or merging, run `detent ci-trigger-label --repository <owner/repo> --pull-request <number> --label " + cfg.CITriggerLabel + " --stagger-seconds " + strconv.Itoa(cfg.CITriggerLabelStaggerSeconds) + "` before waiting for current-head checks. The command removes the label if present, adds it again through GitHub's REST issue-label endpoints, and uses a host-wide lock plus persisted timestamp to serialize reapplications at least " + strconv.Itoa(cfg.CITriggerLabelStaggerSeconds) + " seconds apart so concurrent workers do not stampede self-hosted CI. "
 }
 
 func requiredStatusCheckInstructions(checks []string) string {

--- a/internal/gate/gate.go
+++ b/internal/gate/gate.go
@@ -381,6 +381,10 @@ func ValidatePlan(prefix string, cfg PlanConfig) []string {
 }
 
 func Instructions(cfg Config) string {
+	return InstructionsForGitHubHost(cfg, "")
+}
+
+func InstructionsForGitHubHost(cfg Config, hostname string) string {
 	cfg = Effective(cfg)
 	switch cfg.Kind {
 	case KindHumanReview:
@@ -393,7 +397,7 @@ func Instructions(cfg Config) string {
 		instructions := "The validation gate is a command. Run `" + cfg.Run +
 			"` from the workspace root before Human Review; the pull request still needs green CI before promotion. " +
 			requiredStatusCheckInstructions(cfg.RequiredStatusChecks) +
-			ciTriggerLabelInstructions(cfg) +
+			ciTriggerLabelInstructions(cfg, hostname) +
 			"In Merging, run a focused rebase/smoke gate after a clean rebase when the PR already passed current-head validation and no source files changed during rebase. " +
 			"Run full `" + cfg.Run + "` in Merging when code changes, conflicts are resolved, or validation state is stale or unknown. " +
 			"Watch current-head CI with REST check-runs polling/backoff, report slow checks, and record merge wait telemetry in the Workpad prose: quiet-window wait, local merge-gate duration, PR CI duration, slow check names, and whether post-merge main CI is still running. " +
@@ -413,7 +417,7 @@ func Instructions(cfg Config) string {
 	}
 }
 
-func ciTriggerLabelInstructions(cfg Config) string {
+func ciTriggerLabelInstructions(cfg Config, hostname string) string {
 	if cfg.CITriggerLabel == "" {
 		return ""
 	}
@@ -421,7 +425,11 @@ func ciTriggerLabelInstructions(cfg Config) string {
 	if cfg.CITriggerLabelStaggerSeconds != nil {
 		staggerSeconds = *cfg.CITriggerLabelStaggerSeconds
 	}
-	return "This project uses CI trigger label `" + cfg.CITriggerLabel + "`. After every push that changes a pull request head in implementation, rework, or merging, run `detent ci-trigger-label --repository <owner/repo> --pull-request <number> --label " + quoteCITriggerLabel(cfg.CITriggerLabel) + " --stagger-seconds " + strconv.Itoa(staggerSeconds) + "` before waiting for current-head checks. The command removes the label if present, adds it again through GitHub's REST issue-label endpoints, and uses a host-wide lock plus persisted timestamp to serialize reapplications at least " + strconv.Itoa(staggerSeconds) + " seconds apart so concurrent workers do not stampede self-hosted CI. "
+	hostnameArgument := ""
+	if hostname = strings.TrimSpace(hostname); hostname != "" {
+		hostnameArgument = " --hostname " + quoteCITriggerLabel(hostname)
+	}
+	return "This project uses CI trigger label `" + cfg.CITriggerLabel + "`. After every push that changes a pull request head in implementation, rework, or merging, run `detent ci-trigger-label --repository <owner/repo> --pull-request <number> --label " + quoteCITriggerLabel(cfg.CITriggerLabel) + hostnameArgument + " --stagger-seconds " + strconv.Itoa(staggerSeconds) + "` before waiting for current-head checks. The command removes the label if present, adds it again through GitHub's REST issue-label endpoints, and uses a host-wide lock plus persisted timestamp to serialize reapplications at least " + strconv.Itoa(staggerSeconds) + " seconds apart so concurrent workers do not stampede self-hosted CI. "
 }
 
 func quoteCITriggerLabel(label string) string {

--- a/internal/gate/gate.go
+++ b/internal/gate/gate.go
@@ -1,6 +1,7 @@
 package gate
 
 import (
+	"encoding/base64"
 	"strconv"
 	"strings"
 	"time"
@@ -427,13 +428,13 @@ func ciTriggerLabelInstructions(cfg Config, hostname string) string {
 	}
 	hostnameArgument := ""
 	if hostname = strings.TrimSpace(hostname); hostname != "" {
-		hostnameArgument = " --hostname " + quoteCITriggerLabel(hostname)
+		hostnameArgument = " --hostname-base64 " + encodeCITriggerLabelArgument(hostname)
 	}
-	return "This project uses CI trigger label `" + cfg.CITriggerLabel + "`. After every push that changes a pull request head in implementation, rework, or merging, run `detent ci-trigger-label --repository <owner/repo> --pull-request <number> --label " + quoteCITriggerLabel(cfg.CITriggerLabel) + hostnameArgument + " --stagger-seconds " + strconv.Itoa(staggerSeconds) + "` before waiting for current-head checks. The command removes the label if present, adds it again through GitHub's REST issue-label endpoints, and uses a host-wide lock plus persisted timestamp to serialize reapplications at least " + strconv.Itoa(staggerSeconds) + " seconds apart so concurrent workers do not stampede self-hosted CI. "
+	return "This project uses CI trigger label `" + cfg.CITriggerLabel + "`. After every push that changes a pull request head in implementation, rework, or merging, run `detent ci-trigger-label --repository <owner/repo> --pull-request <number> --label-base64 " + encodeCITriggerLabelArgument(cfg.CITriggerLabel) + hostnameArgument + " --stagger-seconds " + strconv.Itoa(staggerSeconds) + "` before waiting for current-head checks. The command removes the label if present, adds it again through GitHub's REST issue-label endpoints, and uses a host-wide lock plus persisted timestamp to serialize reapplications at least " + strconv.Itoa(staggerSeconds) + " seconds apart so concurrent workers do not stampede self-hosted CI. "
 }
 
-func quoteCITriggerLabel(label string) string {
-	return "'" + strings.ReplaceAll(label, "'", "'\\''") + "'"
+func encodeCITriggerLabelArgument(value string) string {
+	return base64.RawURLEncoding.EncodeToString([]byte(value))
 }
 
 func requiredStatusCheckInstructions(checks []string) string {

--- a/internal/gate/gate_test.go
+++ b/internal/gate/gate_test.go
@@ -662,7 +662,7 @@ func TestInstructionsDescribeCITriggerLabel(t *testing.T) {
 	}
 }
 
-func TestInstructionsQuoteCITriggerLabel(t *testing.T) {
+func TestInstructionsEncodeCITriggerLabel(t *testing.T) {
 	t.Parallel()
 
 	got := Instructions(Config{
@@ -670,7 +670,7 @@ func TestInstructionsQuoteCITriggerLabel(t *testing.T) {
 		CITriggerLabel:               "team's ci ready",
 		CITriggerLabelStaggerSeconds: newInt(15),
 	})
-	if want := "--label 'team'\\''s ci ready' --stagger-seconds 15"; !strings.Contains(got, want) {
+	if want := "--label-base64 " + encodeCITriggerLabelArgument("team's ci ready") + " --stagger-seconds 15"; !strings.Contains(got, want) {
 		t.Fatalf("Instructions() missing %q:\n%s", want, got)
 	}
 }
@@ -683,7 +683,7 @@ func TestInstructionsIncludeGitHubHostname(t *testing.T) {
 		CITriggerLabel:               "ci:ready",
 		CITriggerLabelStaggerSeconds: newInt(15),
 	}, "github.example.com")
-	if want := "--label 'ci:ready' --hostname 'github.example.com' --stagger-seconds 15"; !strings.Contains(got, want) {
+	if want := "--label-base64 " + encodeCITriggerLabelArgument("ci:ready") + " --hostname-base64 " + encodeCITriggerLabelArgument("github.example.com") + " --stagger-seconds 15"; !strings.Contains(got, want) {
 		t.Fatalf("InstructionsForGitHubHost() missing %q:\n%s", want, got)
 	}
 }

--- a/internal/gate/gate_test.go
+++ b/internal/gate/gate_test.go
@@ -72,7 +72,7 @@ func TestEffectiveSelectsGateDefaults(t *testing.T) {
 				ApprovalLabel:                DefaultApprovalLabel,
 				RequireAutomatedReview:       new(true),
 				CITriggerLabel:               "ci:ready",
-				CITriggerLabelStaggerSeconds: DefaultCITriggerLabelStaggerSeconds,
+				CITriggerLabelStaggerSeconds: newInt(DefaultCITriggerLabelStaggerSeconds),
 				CIFailureAction:              CIFailureActionRework,
 			},
 		},
@@ -644,7 +644,7 @@ func TestInstructionsDescribeCITriggerLabel(t *testing.T) {
 	got := Instructions(Config{
 		Kind:                         KindCommand,
 		CITriggerLabel:               "ci:ready",
-		CITriggerLabelStaggerSeconds: 20,
+		CITriggerLabelStaggerSeconds: newInt(20),
 	})
 	for _, want := range []string{
 		"CI trigger label `ci:ready`",
@@ -712,7 +712,9 @@ func configsEqual(left Config, right Config) bool {
 		left.ApprovalLabel == right.ApprovalLabel &&
 		AutomatedReviewMode(left) == AutomatedReviewMode(right) &&
 		left.CIFailureAction == right.CIFailureAction &&
+		left.CITriggerLabel == right.CITriggerLabel &&
 		slices.Equal(left.RequiredStatusChecks, right.RequiredStatusChecks) &&
+		intPointerEqual(left.CITriggerLabelStaggerSeconds, right.CITriggerLabelStaggerSeconds) &&
 		intPointerEqual(left.TransientCIRetryLimit, right.TransientCIRetryLimit) &&
 		boolPointerEqual(left.RequireAutomatedReview, right.RequireAutomatedReview) &&
 		validatorConfigsEqual(left.Validator, right.Validator) &&

--- a/internal/gate/gate_test.go
+++ b/internal/gate/gate_test.go
@@ -675,6 +675,19 @@ func TestInstructionsQuoteCITriggerLabel(t *testing.T) {
 	}
 }
 
+func TestInstructionsIncludeGitHubHostname(t *testing.T) {
+	t.Parallel()
+
+	got := InstructionsForGitHubHost(Config{
+		Kind:                         KindCommand,
+		CITriggerLabel:               "ci:ready",
+		CITriggerLabelStaggerSeconds: newInt(15),
+	}, "github.example.com")
+	if want := "--label 'ci:ready' --hostname 'github.example.com' --stagger-seconds 15"; !strings.Contains(got, want) {
+		t.Fatalf("InstructionsForGitHubHost() missing %q:\n%s", want, got)
+	}
+}
+
 func TestEvaluateAutomatedReviewModes(t *testing.T) {
 	t.Parallel()
 

--- a/internal/gate/gate_test.go
+++ b/internal/gate/gate_test.go
@@ -649,9 +649,11 @@ func TestInstructionsDescribeCITriggerLabel(t *testing.T) {
 	for _, want := range []string{
 		"CI trigger label `ci:ready`",
 		"After every push",
-		"removing it if present and adding it again",
+		"detent ci-trigger-label",
+		"removes the label if present, adds it again",
 		"REST issue-label endpoints",
 		"before waiting for current-head checks",
+		"host-wide lock plus persisted timestamp",
 		"at least 20 seconds apart",
 	} {
 		if !strings.Contains(got, want) {

--- a/internal/gate/gate_test.go
+++ b/internal/gate/gate_test.go
@@ -61,6 +61,22 @@ func TestEffectiveSelectsGateDefaults(t *testing.T) {
 			},
 		},
 		{
+			name: "command normalizes ci trigger label and defaults stagger",
+			cfg: Config{
+				Kind:           KindCommand,
+				CITriggerLabel: " CI:Ready ",
+			},
+			want: Config{
+				Kind:                         KindCommand,
+				Run:                          DefaultCommand,
+				ApprovalLabel:                DefaultApprovalLabel,
+				RequireAutomatedReview:       new(true),
+				CITriggerLabel:               "ci:ready",
+				CITriggerLabelStaggerSeconds: DefaultCITriggerLabelStaggerSeconds,
+				CIFailureAction:              CIFailureActionRework,
+			},
+		},
+		{
 			name: "human review normalizes alias and approval label",
 			cfg:  Config{Kind: "human-review", Run: "make check", ApprovalLabel: " Human-Approved "},
 			want: Config{Kind: KindHumanReview, Run: "", ApprovalLabel: "human-approved", CIFailureAction: CIFailureActionSkip},
@@ -615,6 +631,28 @@ func TestInstructionsDescribeRequiredStatusChecks(t *testing.T) {
 	for _, want := range []string{
 		"required status checks must be present on the current PR head",
 		"missing, skipped, failed, cancelled, or still-running required checks block promotion",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("Instructions() missing %q:\n%s", want, got)
+		}
+	}
+}
+
+func TestInstructionsDescribeCITriggerLabel(t *testing.T) {
+	t.Parallel()
+
+	got := Instructions(Config{
+		Kind:                         KindCommand,
+		CITriggerLabel:               "ci:ready",
+		CITriggerLabelStaggerSeconds: 20,
+	})
+	for _, want := range []string{
+		"CI trigger label `ci:ready`",
+		"After every push",
+		"removing it if present and adding it again",
+		"REST issue-label endpoints",
+		"before waiting for current-head checks",
+		"at least 20 seconds apart",
 	} {
 		if !strings.Contains(got, want) {
 			t.Fatalf("Instructions() missing %q:\n%s", want, got)

--- a/internal/gate/gate_test.go
+++ b/internal/gate/gate_test.go
@@ -662,6 +662,19 @@ func TestInstructionsDescribeCITriggerLabel(t *testing.T) {
 	}
 }
 
+func TestInstructionsQuoteCITriggerLabel(t *testing.T) {
+	t.Parallel()
+
+	got := Instructions(Config{
+		Kind:                         KindCommand,
+		CITriggerLabel:               "team's ci ready",
+		CITriggerLabelStaggerSeconds: newInt(15),
+	})
+	if want := "--label 'team'\\''s ci ready' --stagger-seconds 15"; !strings.Contains(got, want) {
+		t.Fatalf("Instructions() missing %q:\n%s", want, got)
+	}
+}
+
 func TestEvaluateAutomatedReviewModes(t *testing.T) {
 	t.Parallel()
 

--- a/internal/runner/prompt.go
+++ b/internal/runner/prompt.go
@@ -858,13 +858,15 @@ func gateAssigns(cfg gate.Config) map[string]any {
 		transientCIRetryLimit = *effective.TransientCIRetryLimit
 	}
 	return map[string]any{
-		"kind":                     effective.Kind,
-		"run":                      effective.Run,
-		"approval_label":           effective.ApprovalLabel,
-		"automated_review":         effective.AutomatedReview,
-		"require_automated_review": requireAutomatedReview(effective),
-		"ci_failure_action":        effective.CIFailureAction,
-		"transient_ci_retry_limit": transientCIRetryLimit,
+		"kind":                             effective.Kind,
+		"run":                              effective.Run,
+		"approval_label":                   effective.ApprovalLabel,
+		"ci_trigger_label":                 effective.CITriggerLabel,
+		"ci_trigger_label_stagger_seconds": effective.CITriggerLabelStaggerSeconds,
+		"automated_review":                 effective.AutomatedReview,
+		"require_automated_review":         requireAutomatedReview(effective),
+		"ci_failure_action":                effective.CIFailureAction,
+		"transient_ci_retry_limit":         transientCIRetryLimit,
 		"validator": map[string]any{
 			"enabled":               effective.Validator.Enabled,
 			"model":                 effective.Validator.Model,

--- a/internal/runner/prompt.go
+++ b/internal/runner/prompt.go
@@ -3,6 +3,7 @@ package runner
 import (
 	"errors"
 	"fmt"
+	"net/url"
 	"regexp"
 	"sort"
 	"strconv"
@@ -107,7 +108,7 @@ func BuildPrompt(workflow config.Workflow, issue connector.Issue, opts PromptOpt
 	rendered = appendMergeMethodBlock(rendered, workflow.Config.Deliverable)
 	rendered = appendDeliverableBlock(rendered, workflow.Config, issue, opts.WorkspacePath)
 	rendered = appendBlockedHandoffBlock(rendered)
-	rendered = appendGateBlock(rendered, workflow.Config.Gate)
+	rendered = appendGateBlock(rendered, workflow.Config)
 	rendered = appendAvailableSkills(rendered, AvailableSkillsBlock(opts.AvailableSkills))
 	if promptDeliverableKind(workflow.Config.Deliverable) != config.DeliverablePullRequest {
 		return rendered, nil
@@ -187,7 +188,7 @@ func BuildMergeFallbackPrompt(workflow config.Workflow, issue connector.Issue, o
 	prompt = appendWorkflowInstructionsBlock(prompt, workflow.Config.Agent, issue, opts)
 	prompt = appendMergeMethodBlock(prompt, workflow.Config.Deliverable)
 	prompt = appendBlockedHandoffBlock(prompt)
-	prompt = appendGateBlock(prompt, workflow.Config.Gate)
+	prompt = appendGateBlock(prompt, workflow.Config)
 	prompt = appendAvailableSkills(prompt, AvailableSkillsBlock(opts.AvailableSkills))
 	if promptDeliverableKind(workflow.Config.Deliverable) != config.DeliverablePullRequest {
 		return prompt, nil
@@ -580,12 +581,30 @@ func skillDraftProposed(output string) bool {
 	return skillDraftYesPattern.MatchString(output)
 }
 
-func appendGateBlock(prompt string, cfg gate.Config) string {
-	instructions := gate.Instructions(cfg)
+func appendGateBlock(prompt string, cfg config.Config) string {
+	instructions := gate.InstructionsForGitHubHost(cfg.Gate, githubTrackerHostname(cfg.Tracker))
 	if strings.TrimSpace(instructions) == "" {
 		return prompt
 	}
 	return strings.TrimRight(prompt, " \t\r\n") + "\n\n## Validation gate\n\n" + instructions
+}
+
+func githubTrackerHostname(tracker config.Tracker) string {
+	if tracker.Kind != config.TrackerGitHub && tracker.Kind != config.TrackerGitHubLocal {
+		return ""
+	}
+	endpoint := strings.TrimSpace(tracker.Endpoint)
+	if endpoint == "" {
+		return "github.com"
+	}
+	parsed, err := url.Parse(endpoint)
+	if err != nil || parsed.Host == "" {
+		return ""
+	}
+	if strings.EqualFold(parsed.Hostname(), "api.github.com") {
+		return "github.com"
+	}
+	return parsed.Host
 }
 
 func appendBlockedHandoffBlock(prompt string) string {

--- a/internal/runner/prompt.go
+++ b/internal/runner/prompt.go
@@ -853,6 +853,10 @@ func deliverableAssigns(cfg config.Deliverable) map[string]any {
 
 func gateAssigns(cfg gate.Config) map[string]any {
 	effective := gate.Effective(cfg)
+	ciTriggerLabelStaggerSeconds := 0
+	if effective.CITriggerLabelStaggerSeconds != nil {
+		ciTriggerLabelStaggerSeconds = *effective.CITriggerLabelStaggerSeconds
+	}
 	transientCIRetryLimit := 0
 	if effective.TransientCIRetryLimit != nil {
 		transientCIRetryLimit = *effective.TransientCIRetryLimit
@@ -862,7 +866,7 @@ func gateAssigns(cfg gate.Config) map[string]any {
 		"run":                              effective.Run,
 		"approval_label":                   effective.ApprovalLabel,
 		"ci_trigger_label":                 effective.CITriggerLabel,
-		"ci_trigger_label_stagger_seconds": effective.CITriggerLabelStaggerSeconds,
+		"ci_trigger_label_stagger_seconds": ciTriggerLabelStaggerSeconds,
 		"automated_review":                 effective.AutomatedReview,
 		"require_automated_review":         requireAutomatedReview(effective),
 		"ci_failure_action":                effective.CIFailureAction,

--- a/internal/runner/prompt_test.go
+++ b/internal/runner/prompt_test.go
@@ -639,7 +639,7 @@ func TestBuildPromptIncludesGitHubTrackerHostnameInCITriggerCommand(t *testing.T
 	if err != nil {
 		t.Fatalf("BuildPrompt() error = %v", err)
 	}
-	for _, want := range []string{"--label 'ci ready'", "--hostname 'github.example.com'", "--stagger-seconds 15"} {
+	for _, want := range []string{"--label-base64 Y2kgcmVhZHk", "--hostname-base64 Z2l0aHViLmV4YW1wbGUuY29t", "--stagger-seconds 15"} {
 		if !strings.Contains(prompt, want) {
 			t.Fatalf("prompt missing %q:\n%s", want, prompt)
 		}

--- a/internal/runner/prompt_test.go
+++ b/internal/runner/prompt_test.go
@@ -597,15 +597,16 @@ func TestBuildPromptRendersGateAssignsAndInstructions(t *testing.T) {
 	prompt, err := BuildPrompt(config.Workflow{
 		Config: config.Config{
 			Gate: gate.Config{
-				Kind:          gate.KindHumanReview,
-				ApprovalLabel: "Approved-By-Human",
+				Kind:           gate.KindHumanReview,
+				ApprovalLabel:  "Approved-By-Human",
+				CITriggerLabel: "CI:Ready",
 			},
 			Plan: gate.PlanConfig{
 				Enabled:       true,
 				ApprovalLabel: "Plan-Approved",
 			},
 		},
-		Prompt: "Gate {{ gate.kind }} label={{ gate.approval_label }} run={{ gate.run }} ci={{ gate.ci_failure_action }} max={{ gate.validator.max_inline_diff_bytes }} plan={{ plan.approval_label }}",
+		Prompt: "Gate {{ gate.kind }} label={{ gate.approval_label }} trigger={{ gate.ci_trigger_label }} stagger={{ gate.ci_trigger_label_stagger_seconds }} run={{ gate.run }} ci={{ gate.ci_failure_action }} max={{ gate.validator.max_inline_diff_bytes }} plan={{ plan.approval_label }}",
 	}, connector.Issue{
 		Identifier: "digitaldrywood/detent#266",
 		Title:      "Gate prompt",
@@ -615,7 +616,7 @@ func TestBuildPromptRendersGateAssignsAndInstructions(t *testing.T) {
 	}
 
 	for _, want := range []string{
-		"Gate human_review label=approved-by-human run= ci=skip max=65536 plan=plan-approved",
+		"Gate human_review label=approved-by-human trigger=ci:ready stagger=15 run= ci=skip max=65536 plan=plan-approved",
 		"## Validation gate",
 		"Keep the pull request in Human Review until a human applies label `approved-by-human`",
 	} {

--- a/internal/runner/prompt_test.go
+++ b/internal/runner/prompt_test.go
@@ -626,6 +626,26 @@ func TestBuildPromptRendersGateAssignsAndInstructions(t *testing.T) {
 	}
 }
 
+func TestBuildPromptIncludesGitHubTrackerHostnameInCITriggerCommand(t *testing.T) {
+	t.Parallel()
+
+	prompt, err := BuildPrompt(config.Workflow{Config: config.Config{
+		Tracker: config.Tracker{Kind: config.TrackerGitHub, Endpoint: "https://github.example.com/api/graphql"},
+		Gate: gate.Config{
+			Kind:           gate.KindCommand,
+			CITriggerLabel: "CI Ready",
+		},
+	}}, connector.Issue{Identifier: "owner/repo#42", Title: "Enterprise label gate"}, PromptOptions{})
+	if err != nil {
+		t.Fatalf("BuildPrompt() error = %v", err)
+	}
+	for _, want := range []string{"--label 'ci ready'", "--hostname 'github.example.com'", "--stagger-seconds 15"} {
+		if !strings.Contains(prompt, want) {
+			t.Fatalf("prompt missing %q:\n%s", want, prompt)
+		}
+	}
+}
+
 func TestBuildPromptAppendsWorkflowInstructionsByState(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

- add `gate.ci_trigger_label` and a positive, configurable 15-second default stagger for label-gated CI
- add `detent ci-trigger-label`, which serializes repository label retriggers with a host-wide lock and persisted timestamp
- direct implementation, rework, and merge workers to retrigger CI on the configured GitHub host after each head-changing push
- warn in Doctor when a required check is label-gated without trigger-label configuration, including job-level label conditions
- require explicit `pull_request.types: [labeled, ...]` before Doctor treats relabeling as a valid remediation

Fixes #1312

## UI Surface Contract

- [x] N/A, or the linked issue explicitly authorizes any high-impact UI surface, layout, density, first-viewport, or responsive visibility tradeoff.
- [x] Persistent top-of-screen messaging is explicitly authorized by the issue, or this PR does not add it.
- [x] Visual changes to primary operator screens include screenshot or browser verification below. No visual changes.

## Test Plan

- [x] `make check` (77.3% coverage; all configured package and file floors passed)
- [x] Current-head GitHub CI: 10/10 checks passed