### PR TITLE
fix(doctor): bound review-flow telemetry

### DIFF
--- a/internal/cli/doctor_workflow_optimization.go
+++ b/internal/cli/doctor_workflow_optimization.go
@@ -663,7 +663,7 @@ func doctorWorkflowReviewFlowTelemetry(ctx context.Context, db doctorTelemetrySt
 	metrics.reviewEntryIssue = doctorMaxMapKey(reviewEntryCounts)
 	metrics.reviewEntryIssueCount = doctorMaxMapValue(reviewEntryCounts)
 
-	invalidCounts, err := doctorWorkflowInvalidWorkpadStatusTelemetry(ctx, db, projectID)
+	invalidCounts, err := doctorWorkflowInvalidWorkpadStatusTelemetry(ctx, db, projectID, boundaryAt)
 	if err != nil {
 		return doctorWorkflowReviewFlowMetrics{}, err
 	}
@@ -785,7 +785,8 @@ func doctorWorkflowReviewEntryFollowsCompletedSession(entry doctorWorkflowReview
 	return false
 }
 
-func doctorWorkflowInvalidWorkpadStatusTelemetry(ctx context.Context, db doctorTelemetryStore, projectID string) (map[string]int64, error) {
+func doctorWorkflowInvalidWorkpadStatusTelemetry(ctx context.Context, db doctorTelemetryStore, projectID string, boundaryAt time.Time) (map[string]int64, error) {
+	boundary := doctorWorkflowTelemetryBoundaryValue(boundaryAt)
 	rows, err := db.QueryContext(ctx, `
 SELECT
   COALESCE(NULLIF(identifier, ''), NULLIF(issue_id, ''), NULLIF(issue_url, ''), 'unassigned'),
@@ -794,8 +795,9 @@ FROM workflow_phase_events
 WHERE phase_type = 'lane'
   AND lower(trim(COALESCE(status, ''))) = 'entered'
   AND lower(trim(COALESCE(reason, ''))) = 'workpad_status_invalid'
+  AND (? = '' OR started_at >= ?)
   AND (? = '' OR project_id = ?)
-GROUP BY COALESCE(NULLIF(identifier, ''), NULLIF(issue_id, ''), NULLIF(issue_url, ''), 'unassigned')`, projectID, projectID)
+GROUP BY COALESCE(NULLIF(identifier, ''), NULLIF(issue_id, ''), NULLIF(issue_url, ''), 'unassigned')`, boundary, boundary, projectID, projectID)
 	if err != nil {
 		return nil, fmt.Errorf("read invalid workpad status telemetry: %w", err)
 	}

--- a/internal/cli/doctor_workflow_optimization.go
+++ b/internal/cli/doctor_workflow_optimization.go
@@ -60,6 +60,7 @@ const (
 	doctorWorkflowSchedulerMinDecisions        = int64(5)
 	doctorWorkflowSchedulerHighSkipRate        = 0.50
 	doctorWorkflowReviewFlowMismatchMinEntries = int64(2)
+	doctorWorkflowReviewFlowRecentWindow       = 30 * 24 * time.Hour
 	doctorWorkflowInvalidWorkpadStatusMinCount = int64(2)
 	doctorWorkflowValidatorModel               = "gpt-5.4-mini"
 	doctorWorkflowRunawayCapTolerance          = 1.25
@@ -170,6 +171,8 @@ type doctorWorkflowOptimizationMetrics struct {
 	ReviewEntryCount                 int64                                `json:"review_entry_count"`
 	ReviewEntryIssue                 string                               `json:"review_entry_issue,omitempty"`
 	ReviewEntryIssueCount            int64                                `json:"review_entry_issue_count"`
+	ReviewFlowBoundaryAt             string                               `json:"review_flow_boundary_at,omitempty"`
+	ReviewFlowBoundaryType           string                               `json:"review_flow_boundary_type,omitempty"`
 	InvalidWorkpadStatusDecisions    int64                                `json:"invalid_workpad_status_decisions"`
 	InvalidWorkpadStatusIssue        string                               `json:"invalid_workpad_status_issue,omitempty"`
 	InvalidWorkpadStatusIssueCount   int64                                `json:"invalid_workpad_status_issue_count"`
@@ -262,6 +265,8 @@ type doctorWorkflowReviewFlowMetrics struct {
 	reviewEntryCount               int64
 	reviewEntryIssue               string
 	reviewEntryIssueCount          int64
+	boundaryAt                     time.Time
+	boundaryType                   string
 	invalidWorkpadStatusDecisions  int64
 	invalidWorkpadStatusIssue      string
 	invalidWorkpadStatusIssueCount int64
@@ -405,7 +410,8 @@ func doctorWorkflowOptimization(
 			workflowPath = ""
 		}
 
-		metrics, err := doctorWorkflowOptimizationMetricsForProject(ctx, db, projectID, workflow.Config)
+		reviewFlowBoundaryAt, reviewFlowBoundaryType := doctorWorkflowReviewFlowBoundary(project, deps.now())
+		metrics, err := doctorWorkflowOptimizationMetricsForProject(ctx, db, projectID, workflow.Config, reviewFlowBoundaryAt, reviewFlowBoundaryType)
 		if err != nil {
 			return doctorWorkflowOptimizationReport{}, err
 		}
@@ -518,11 +524,33 @@ LIMIT 1`, strings.TrimSpace(projectID)).Scan(
 	return status, nil
 }
 
+func doctorWorkflowReviewFlowBoundary(project globalconfig.Project, now time.Time) (time.Time, string) {
+	now = now.UTC()
+	recentBoundary := now.Add(-doctorWorkflowReviewFlowRecentWindow)
+	modifiedAt := doctorWorkflowModifiedAt(project)
+	if modifiedAt.After(now) {
+		modifiedAt = now
+	}
+	if modifiedAt.After(recentBoundary) {
+		return modifiedAt, "workflow_modified_at"
+	}
+	return recentBoundary, "recent_window"
+}
+
+func doctorWorkflowTelemetryBoundaryValue(value time.Time) string {
+	if value.IsZero() {
+		return ""
+	}
+	return value.UTC().Format(time.RFC3339Nano)
+}
+
 func doctorWorkflowOptimizationMetricsForProject(
 	ctx context.Context,
 	db doctorTelemetryStore,
 	projectID string,
 	cfg workflowconfig.Config,
+	reviewFlowBoundaryAt time.Time,
+	reviewFlowBoundaryType string,
 ) (doctorWorkflowOptimizationMetrics, error) {
 	pricing, err := budget.PricingForConfig(budget.Config{PricingPath: cfg.Budget.PricingPath})
 	if err != nil {
@@ -544,7 +572,7 @@ func doctorWorkflowOptimizationMetricsForProject(
 	if err != nil {
 		return doctorWorkflowOptimizationMetrics{}, err
 	}
-	reviewFlow, err := doctorWorkflowReviewFlowTelemetry(ctx, db, projectID, cfg.Agent.AutoPromote.SourceState)
+	reviewFlow, err := doctorWorkflowReviewFlowTelemetry(ctx, db, projectID, cfg.Agent.AutoPromote.SourceState, reviewFlowBoundaryAt, reviewFlowBoundaryType)
 	if err != nil {
 		return doctorWorkflowOptimizationMetrics{}, err
 	}
@@ -587,6 +615,8 @@ func doctorWorkflowOptimizationMetricsForProject(
 		ReviewEntryCount:               reviewFlow.reviewEntryCount,
 		ReviewEntryIssue:               reviewFlow.reviewEntryIssue,
 		ReviewEntryIssueCount:          reviewFlow.reviewEntryIssueCount,
+		ReviewFlowBoundaryAt:           doctorWorkflowTelemetryBoundaryValue(reviewFlow.boundaryAt),
+		ReviewFlowBoundaryType:         reviewFlow.boundaryType,
 		InvalidWorkpadStatusDecisions:  reviewFlow.invalidWorkpadStatusDecisions,
 		InvalidWorkpadStatusIssue:      reviewFlow.invalidWorkpadStatusIssue,
 		InvalidWorkpadStatusIssueCount: reviewFlow.invalidWorkpadStatusIssueCount,
@@ -612,16 +642,16 @@ func doctorWorkflowOptimizationMetricsForProject(
 	return metrics, nil
 }
 
-func doctorWorkflowReviewFlowTelemetry(ctx context.Context, db doctorTelemetryStore, projectID string, reviewState string) (doctorWorkflowReviewFlowMetrics, error) {
-	sessions, err := doctorWorkflowCompletedSessionTelemetry(ctx, db, projectID, reviewState)
+func doctorWorkflowReviewFlowTelemetry(ctx context.Context, db doctorTelemetryStore, projectID string, reviewState string, boundaryAt time.Time, boundaryType string) (doctorWorkflowReviewFlowMetrics, error) {
+	sessions, err := doctorWorkflowCompletedSessionTelemetry(ctx, db, projectID, reviewState, boundaryAt)
 	if err != nil {
 		return doctorWorkflowReviewFlowMetrics{}, err
 	}
-	entries, err := doctorWorkflowReviewEntryTelemetry(ctx, db, projectID, reviewState)
+	entries, err := doctorWorkflowReviewEntryTelemetry(ctx, db, projectID, reviewState, boundaryAt)
 	if err != nil {
 		return doctorWorkflowReviewFlowMetrics{}, err
 	}
-	metrics := doctorWorkflowReviewFlowMetrics{}
+	metrics := doctorWorkflowReviewFlowMetrics{boundaryAt: boundaryAt, boundaryType: boundaryType}
 	reviewEntryCounts := map[string]int64{}
 	for _, entry := range entries {
 		if !doctorWorkflowReviewEntryFollowsCompletedSession(entry, sessions[entry.issueKey]) {
@@ -645,8 +675,9 @@ func doctorWorkflowReviewFlowTelemetry(ctx context.Context, db doctorTelemetrySt
 	return metrics, nil
 }
 
-func doctorWorkflowCompletedSessionTelemetry(ctx context.Context, db doctorTelemetryStore, projectID string, reviewState string) (map[string][]doctorWorkflowCompletedSession, error) {
+func doctorWorkflowCompletedSessionTelemetry(ctx context.Context, db doctorTelemetryStore, projectID string, reviewState string, boundaryAt time.Time) (map[string][]doctorWorkflowCompletedSession, error) {
 	reviewState = strings.ToLower(strings.TrimSpace(reviewState))
+	boundary := doctorWorkflowTelemetryBoundaryValue(boundaryAt)
 	rows, err := db.QueryContext(ctx, `
 SELECT
   COALESCE(NULLIF(s.identifier, ''), NULLIF(s.issue_id, ''), NULLIF(s.issue_url, ''), 'unassigned'),
@@ -654,6 +685,7 @@ SELECT
 FROM codex_sessions s
 WHERE s.completed_at IS NOT NULL
   AND lower(trim(COALESCE(s.final_state, ''))) IN ('completed', ?)
+  AND (? = '' OR s.completed_at >= ?)
   AND (
     ? = ''
     OR s.id IN (
@@ -664,7 +696,7 @@ WHERE s.completed_at IS NOT NULL
     )
   )
 ORDER BY s.completed_at DESC, s.id DESC
-LIMIT 500`, reviewState, projectID, projectID)
+LIMIT 500`, reviewState, boundary, boundary, projectID, projectID)
 	if err != nil {
 		return nil, fmt.Errorf("read completed session review-flow telemetry: %w", err)
 	}
@@ -693,11 +725,12 @@ LIMIT 500`, reviewState, projectID, projectID)
 	return sessions, nil
 }
 
-func doctorWorkflowReviewEntryTelemetry(ctx context.Context, db doctorTelemetryStore, projectID string, reviewState string) ([]doctorWorkflowReviewEntryEvent, error) {
+func doctorWorkflowReviewEntryTelemetry(ctx context.Context, db doctorTelemetryStore, projectID string, reviewState string, boundaryAt time.Time) ([]doctorWorkflowReviewEntryEvent, error) {
 	reviewState = strings.ToLower(strings.TrimSpace(reviewState))
 	if reviewState == "" {
 		reviewState = "human review"
 	}
+	boundary := doctorWorkflowTelemetryBoundaryValue(boundaryAt)
 	rows, err := db.QueryContext(ctx, `
 SELECT
   COALESCE(NULLIF(identifier, ''), NULLIF(issue_id, ''), NULLIF(issue_url, ''), 'unassigned'),
@@ -706,9 +739,10 @@ FROM workflow_phase_events
 WHERE phase_type = 'lane'
   AND lower(trim(COALESCE(status, ''))) = 'entered'
   AND lower(trim(phase_name)) = ?
+  AND (? = '' OR started_at >= ?)
   AND (? = '' OR project_id = ?)
 ORDER BY started_at DESC, id DESC
-LIMIT 500`, reviewState, projectID, projectID)
+LIMIT 500`, reviewState, boundary, boundary, projectID, projectID)
 	if err != nil {
 		return nil, fmt.Errorf("read review-state entry telemetry: %w", err)
 	}
@@ -1442,6 +1476,8 @@ func doctorWorkflowOptimizationFindings(
 				"review_entry_count":       metrics.ReviewEntryCount,
 				"review_entry_issue":       metrics.ReviewEntryIssue,
 				"review_entry_issue_count": metrics.ReviewEntryIssueCount,
+				"telemetry_boundary_at":    metrics.ReviewFlowBoundaryAt,
+				"telemetry_boundary_type":  metrics.ReviewFlowBoundaryType,
 				"auto_promote_enabled":     cfg.Agent.AutoPromote.Enabled,
 				"quiet_seconds":            cfg.Agent.AutoPromote.QuietSeconds,
 				"gate_wait_state":          doctorReviewFlowGateWaitState(cfg),

--- a/internal/cli/doctor_workflow_optimization_test.go
+++ b/internal/cli/doctor_workflow_optimization_test.go
@@ -733,7 +733,7 @@ func TestDoctorWorkflowReviewFlowTelemetryCountsImmediateReviewEntries(t *testin
 	cfg.Agent.AutoPromote.Enabled = true
 	cfg.Agent.AutoPromote.QuietSeconds = 0
 	cfg.Agent.AutoPromote.GateWaitState = workflowconfig.AutoPromoteGateWaitStateSource
-	metrics, err := doctorWorkflowOptimizationMetricsForProject(ctx, db, "detent", cfg)
+	metrics, err := doctorWorkflowOptimizationMetricsForProject(ctx, db, "detent", cfg, time.Time{}, "")
 	if err != nil {
 		t.Fatalf("doctorWorkflowOptimizationMetricsForProject() error = %v", err)
 	}
@@ -746,6 +746,196 @@ func TestDoctorWorkflowReviewFlowTelemetryCountsImmediateReviewEntries(t *testin
 	findings := doctorWorkflowOptimizationFindings("detent", "WORKFLOW.md", cfg, metrics)
 	doctorWorkflowFindingByRule(t, findings, doctorWorkflowRuleReviewFlowBehaviorMismatch)
 	doctorWorkflowFindingByRule(t, findings, doctorWorkflowRuleInvalidWorkpadStatusRecurrence)
+}
+
+func TestDoctorWorkflowReviewFlowTelemetryRespectsCurrentWorkflowBoundary(t *testing.T) {
+	t.Parallel()
+
+	boundary := time.Date(2026, 7, 9, 16, 0, 0, 0, time.UTC)
+	tests := []struct {
+		name             string
+		entryOffsets     []time.Duration
+		wantEntries      int64
+		wantMismatch     bool
+		wantBoundaryType string
+	}{
+		{
+			name:         "historical entries before boundary",
+			entryOffsets: []time.Duration{-2 * time.Hour, -time.Hour},
+		},
+		{
+			name:             "new entries after boundary",
+			entryOffsets:     []time.Duration{time.Hour, 2 * time.Hour},
+			wantEntries:      2,
+			wantMismatch:     true,
+			wantBoundaryType: "workflow_modified_at",
+		},
+		{
+			name:         "mixed old and new entries",
+			entryOffsets: []time.Duration{-time.Hour, time.Hour},
+			wantEntries:  1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			ctx := context.Background()
+			dir := t.TempDir()
+			workflowPath := filepath.Join(dir, "WORKFLOW.md")
+			if err := os.WriteFile(workflowPath, []byte(`---
+tracker:
+  kind: memory
+agent:
+  auto_promote:
+    enabled: true
+    quiet_seconds: 0
+    gate_wait_state: source
+---
+Prompt
+`), 0o600); err != nil {
+				t.Fatalf("WriteFile(WORKFLOW.md) error = %v", err)
+			}
+			if err := os.Chtimes(workflowPath, boundary, boundary); err != nil {
+				t.Fatalf("Chtimes(WORKFLOW.md) error = %v", err)
+			}
+
+			dbPath := filepath.Join(dir, "detent.db")
+			backend, err := store.Open(ctx, store.Config{Backend: store.BackendSQLite, Path: dbPath})
+			if err != nil {
+				t.Fatalf("store.Open() error = %v", err)
+			}
+			issue := "digitaldrywood/detent#981"
+			for index, offset := range tt.entryOffsets {
+				entryAt := boundary.Add(offset)
+				completedAt := entryAt.Add(-2 * time.Minute)
+				sessionID, err := backend.StartSession(ctx, store.SessionStart{
+					Identifier: issue,
+					StartedAt:  completedAt.Add(-5 * time.Minute),
+				})
+				if err != nil {
+					t.Fatalf("StartSession(%d) error = %v", index, err)
+				}
+				if err := backend.FinishSession(ctx, sessionID, store.SessionFinish{
+					CompletedAt: completedAt,
+					FinalState:  "completed",
+				}); err != nil {
+					t.Fatalf("FinishSession(%d) error = %v", index, err)
+				}
+				if _, err := backend.RecordUsageEvent(ctx, store.UsageEvent{
+					ProjectID:  "detent",
+					SessionID:  sessionID,
+					Identifier: issue,
+					StartedAt:  completedAt.Add(-5 * time.Minute),
+					FinishedAt: completedAt,
+					Outcome:    "completed",
+				}); err != nil {
+					t.Fatalf("RecordUsageEvent(%d) error = %v", index, err)
+				}
+				if _, err := backend.RecordWorkflowPhaseEvent(ctx, store.WorkflowPhaseEvent{
+					ProjectID:         "detent",
+					Identifier:        issue,
+					PhaseType:         store.WorkflowPhaseTypeLane,
+					PhaseName:         "Human Review",
+					PreviousPhaseName: "In Progress",
+					Status:            "entered",
+					StartedAt:         entryAt,
+				}); err != nil {
+					t.Fatalf("RecordWorkflowPhaseEvent(%d) error = %v", index, err)
+				}
+			}
+			if err := backend.Close(); err != nil {
+				t.Fatalf("Close() error = %v", err)
+			}
+
+			db, err := openDoctorSQLiteReadOnly(ctx, dbPath)
+			if err != nil {
+				t.Fatalf("openDoctorSQLiteReadOnly() error = %v", err)
+			}
+			t.Cleanup(func() {
+				if err := db.Close(); err != nil {
+					t.Fatalf("Close() error = %v", err)
+				}
+			})
+			deps := successfulDoctorDeps()
+			deps.loadWorkflow = workflowconfig.LoadWorkflow
+			deps.now = func() time.Time { return boundary.Add(24 * time.Hour) }
+			report, err := doctorWorkflowOptimization(ctx, db, dbPath, globalconfig.Config{Projects: []globalconfig.Project{{
+				ID:       "detent",
+				Workflow: workflowPath,
+				Workdir:  dir,
+			}}}, deps, "", doctorWorkflowOptimizationOptions{})
+			if err != nil {
+				t.Fatalf("doctorWorkflowOptimization() error = %v", err)
+			}
+			if got := report.Projects[0].Metrics.ReviewEntryCount; got != tt.wantEntries {
+				t.Fatalf("ReviewEntryCount = %d, want %d", got, tt.wantEntries)
+			}
+			if got := doctorWorkflowFindingExists(report.Findings, doctorWorkflowRuleReviewFlowBehaviorMismatch); got != tt.wantMismatch {
+				t.Fatalf("review-flow mismatch finding = %t, want %t", got, tt.wantMismatch)
+			}
+			if tt.wantMismatch {
+				finding := doctorWorkflowFindingByRule(t, report.Findings, doctorWorkflowRuleReviewFlowBehaviorMismatch)
+				if got := finding.Evidence["telemetry_boundary_at"]; got != boundary.Format(time.RFC3339) {
+					t.Fatalf("telemetry_boundary_at = %#v, want %s", got, boundary.Format(time.RFC3339))
+				}
+				if got := finding.Evidence["telemetry_boundary_type"]; got != tt.wantBoundaryType {
+					t.Fatalf("telemetry_boundary_type = %#v, want %s", got, tt.wantBoundaryType)
+				}
+			}
+		})
+	}
+}
+
+func TestDoctorWorkflowReviewFlowBoundary(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 7, 15, 12, 0, 0, 0, time.UTC)
+	tests := []struct {
+		name     string
+		modified time.Time
+		wantAt   time.Time
+		wantType string
+	}{
+		{
+			name:     "current workflow modification",
+			modified: now.Add(-24 * time.Hour),
+			wantAt:   now.Add(-24 * time.Hour),
+			wantType: "workflow_modified_at",
+		},
+		{
+			name:     "old workflow uses recent window",
+			modified: now.Add(-60 * 24 * time.Hour),
+			wantAt:   now.Add(-doctorWorkflowReviewFlowRecentWindow),
+			wantType: "recent_window",
+		},
+		{
+			name:     "future modification clamps to now",
+			modified: now.Add(time.Hour),
+			wantAt:   now,
+			wantType: "workflow_modified_at",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			dir := t.TempDir()
+			workflowPath := filepath.Join(dir, "WORKFLOW.md")
+			if err := os.WriteFile(workflowPath, []byte("Prompt\n"), 0o600); err != nil {
+				t.Fatalf("WriteFile(WORKFLOW.md) error = %v", err)
+			}
+			if err := os.Chtimes(workflowPath, tt.modified, tt.modified); err != nil {
+				t.Fatalf("Chtimes(WORKFLOW.md) error = %v", err)
+			}
+			gotAt, gotType := doctorWorkflowReviewFlowBoundary(globalconfig.Project{Workflow: workflowPath}, now)
+			if !gotAt.Equal(tt.wantAt) || gotType != tt.wantType {
+				t.Fatalf("doctorWorkflowReviewFlowBoundary() = %s/%s, want %s/%s", gotAt, gotType, tt.wantAt, tt.wantType)
+			}
+		})
+	}
 }
 
 func TestDoctorWorkflowOptimizationRunawaySessionTokensRespectsConfiguredCap(t *testing.T) {

--- a/internal/cli/doctor_workflow_optimization_test.go
+++ b/internal/cli/doctor_workflow_optimization_test.go
@@ -756,6 +756,7 @@ func TestDoctorWorkflowReviewFlowTelemetryRespectsCurrentWorkflowBoundary(t *tes
 		name             string
 		entryOffsets     []time.Duration
 		wantEntries      int64
+		wantInvalid      int64
 		wantMismatch     bool
 		wantBoundaryType string
 	}{
@@ -767,6 +768,7 @@ func TestDoctorWorkflowReviewFlowTelemetryRespectsCurrentWorkflowBoundary(t *tes
 			name:             "new entries after boundary",
 			entryOffsets:     []time.Duration{time.Hour, 2 * time.Hour},
 			wantEntries:      2,
+			wantInvalid:      2,
 			wantMismatch:     true,
 			wantBoundaryType: "workflow_modified_at",
 		},
@@ -774,6 +776,7 @@ func TestDoctorWorkflowReviewFlowTelemetryRespectsCurrentWorkflowBoundary(t *tes
 			name:         "mixed old and new entries",
 			entryOffsets: []time.Duration{-time.Hour, time.Hour},
 			wantEntries:  1,
+			wantInvalid:  1,
 		},
 	}
 
@@ -844,6 +847,18 @@ Prompt
 				}); err != nil {
 					t.Fatalf("RecordWorkflowPhaseEvent(%d) error = %v", index, err)
 				}
+				if _, err := backend.RecordWorkflowPhaseEvent(ctx, store.WorkflowPhaseEvent{
+					ProjectID:         "detent",
+					Identifier:        issue,
+					PhaseType:         store.WorkflowPhaseTypeLane,
+					PhaseName:         "Rework",
+					PreviousPhaseName: "Human Review",
+					Status:            "entered",
+					StartedAt:         entryAt.Add(time.Minute),
+					Reason:            "workpad_status_invalid",
+				}); err != nil {
+					t.Fatalf("RecordWorkflowPhaseEvent(invalid %d) error = %v", index, err)
+				}
 			}
 			if err := backend.Close(); err != nil {
 				t.Fatalf("Close() error = %v", err)
@@ -871,6 +886,9 @@ Prompt
 			}
 			if got := report.Projects[0].Metrics.ReviewEntryCount; got != tt.wantEntries {
 				t.Fatalf("ReviewEntryCount = %d, want %d", got, tt.wantEntries)
+			}
+			if got := report.Projects[0].Metrics.InvalidWorkpadStatusDecisions; got != tt.wantInvalid {
+				t.Fatalf("InvalidWorkpadStatusDecisions = %d, want %d", got, tt.wantInvalid)
 			}
 			if got := doctorWorkflowFindingExists(report.Findings, doctorWorkflowRuleReviewFlowBehaviorMismatch); got != tt.wantMismatch {
 				t.Fatalf("review-flow mismatch finding = %t, want %t", got, tt.wantMismatch)


### PR DESCRIPTION
## Summary

- bound review-flow telemetry to the current workflow modification time or a 30-day recent window
- filter completed sessions and Human Review entries at the same effective boundary
- expose the boundary in metrics and finding evidence, with old/new/mixed regression coverage

Fixes #1316

## UI Surface Contract

- [x] N/A, or the linked issue explicitly authorizes any high-impact UI surface, layout, density, first-viewport, or responsive visibility tradeoff.
- [x] Persistent top-of-screen messaging is explicitly authorized by the issue, or this PR does not add it.
- [x] N/A — this PR has no visual changes to primary operator screens.

## Test Plan

- [x] `go test ./internal/cli -count=1`
- [x] `make check`
