### PR TITLE
fix(web): unblock cached board first paint

### DIFF
--- a/internal/web/budget.go
+++ b/internal/web/budget.go
@@ -43,6 +43,19 @@ func (s *Server) cachedEnrichedSnapshot(ctx context.Context, snapshot telemetry.
 	return s.snapshots.enrich(ctx, snapshot, s.enrichSnapshot)
 }
 
+func (c *snapshotEnrichmentCache) get(snapshot telemetry.Snapshot) (telemetry.Snapshot, bool) {
+	if c == nil {
+		return telemetry.Snapshot{}, false
+	}
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if !c.cached || !reflect.DeepEqual(c.raw, snapshot) {
+		return telemetry.Snapshot{}, false
+	}
+	return c.enriched, true
+}
+
 func (c *snapshotEnrichmentCache) enrich(ctx context.Context, snapshot telemetry.Snapshot, enrich func(context.Context, telemetry.Snapshot) telemetry.Snapshot) telemetry.Snapshot {
 	if c == nil {
 		return enrich(ctx, snapshot)

--- a/internal/web/projects.go
+++ b/internal/web/projects.go
@@ -53,6 +53,24 @@ func (s *Server) projectSmallMultiples(ctx context.Context, snapshot telemetry.S
 	return s.projects.record(now, projects)
 }
 
+func (s *Server) cachedProjectSmallMultiples(snapshot telemetry.Snapshot) []templates.ProjectSmallMultiple {
+	projects := projectSmallMultiplesFromSnapshot(snapshot)
+	projects = s.addConfiguredProjectMultiples(projects)
+	if len(projects) == 0 {
+		return nil
+	}
+
+	now := snapshot.GeneratedAt
+	if now.IsZero() {
+		now = time.Now().UTC().Truncate(time.Second)
+	}
+	now = now.UTC()
+	for i := range projects {
+		projects[i].BudgetResetAt = dailyBudgetReset(now)
+	}
+	return s.projects.record(now, projects)
+}
+
 func projectSmallMultiplesFromSnapshot(snapshot telemetry.Snapshot) []templates.ProjectSmallMultiple {
 	if len(snapshot.Projects) > 0 {
 		projects := make([]templates.ProjectSmallMultiple, 0, len(snapshot.Projects))

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -377,7 +377,8 @@ func (s *Server) board(c echo.Context) error {
 		return s.demoBoard(c, scenario)
 	}
 	ctx := c.Request().Context()
-	data := s.boardData(ctx, s.latestSnapshot(ctx))
+	snapshot, enriched := s.latestBoardSnapshot()
+	data := s.boardFirstPaintData(ctx, snapshot, !enriched)
 	data = s.withKanbanRefreshFeedback(data)
 	applyDashboardPreferences(c.Request(), &data)
 	return render(c, templates.BoardPage(data))
@@ -642,6 +643,26 @@ func (s *Server) boardData(ctx context.Context, snapshot telemetry.Snapshot) tem
 	return data
 }
 
+func (s *Server) boardFirstPaintData(ctx context.Context, snapshot telemetry.Snapshot, pendingEnrichment bool) templates.DashboardData {
+	instanceName := s.instanceName()
+	snapshot = s.fleetKanbanSnapshotWithPendingStates(snapshot)
+	return templates.DashboardData{
+		Title:             instancePageTitle(instanceName, "Detent"),
+		ApplicationName:   applicationName(instanceName),
+		InstanceName:      instanceName,
+		Version:           s.version,
+		Build:             s.build,
+		ConnectorName:     s.connector.Name(),
+		DashboardURL:      s.dashboardURL,
+		Snapshot:          snapshot,
+		Projects:          s.cachedProjectSmallMultiples(snapshot),
+		Kanban:            s.dashboardKanbanData(ctx, "", snapshot),
+		Assets:            s.assets.templatePaths(),
+		ActiveNav:         "board",
+		PendingEnrichment: pendingEnrichment,
+	}
+}
+
 func (s *Server) healthDashboardData(ctx context.Context, snapshot telemetry.Snapshot) templates.DashboardData {
 	data := s.dashboardData(ctx, snapshot)
 	data.ActiveNav = "health"
@@ -836,6 +857,17 @@ func (s *Server) latestSnapshot(ctx context.Context) telemetry.Snapshot {
 		return s.withManualRefresh(s.enrichSnapshot(ctx, telemetry.Snapshot{}))
 	}
 	return s.withManualRefresh(s.cachedEnrichedSnapshot(ctx, snapshot))
+}
+
+func (s *Server) latestBoardSnapshot() (telemetry.Snapshot, bool) {
+	snapshot, ok := s.hub.Latest()
+	if !ok {
+		return s.withManualRefresh(telemetry.Snapshot{}), false
+	}
+	if enriched, ok := s.snapshots.get(snapshot); ok {
+		return s.withManualRefresh(enriched), true
+	}
+	return s.withManualRefresh(snapshot), false
 }
 
 func (s *Server) health(c echo.Context) error {

--- a/internal/web/server_test.go
+++ b/internal/web/server_test.go
@@ -6665,6 +6665,145 @@ func TestDashboardReadsLatestSnapshotWithoutSubscribing(t *testing.T) {
 	}
 }
 
+func TestBoardFirstPaintDoesNotWaitForSnapshotEnrichment(t *testing.T) {
+	t.Parallel()
+
+	started := make(chan struct{})
+	release := make(chan struct{})
+	var startedOnce sync.Once
+	var fetchCalls atomic.Int64
+	deps := testDeps(t)
+	deps.Connector = connectorProbe{
+		name: "github",
+		fetchCandidateIssues: func(context.Context) ([]connector.Issue, error) {
+			fetchCalls.Add(1)
+			return nil, errors.New("github rest budget reserved")
+		},
+	}
+	deps.Store = storeProbe{
+		runtimeEvidence: func(ctx context.Context, _ store.RuntimeEvidenceQuery) (store.RuntimeEvidence, error) {
+			startedOnce.Do(func() { close(started) })
+			select {
+			case <-release:
+				return store.RuntimeEvidence{}, errors.New("github rest budget reserved")
+			case <-ctx.Done():
+				return store.RuntimeEvidence{}, ctx.Err()
+			}
+		},
+	}
+	generatedAt := time.Date(2026, 7, 15, 15, 4, 5, 0, time.UTC)
+	if err := deps.Hub.Publish(telemetry.Snapshot{
+		GeneratedAt: generatedAt,
+		BoardIssues: []telemetry.Issue{{
+			ID:         "issue-cached",
+			Identifier: "digitaldrywood/detent#1318",
+			Title:      "Cached board issue",
+			State:      "In Progress",
+		}},
+	}); err != nil {
+		t.Fatalf("Publish() error = %v", err)
+	}
+
+	server, err := web.NewServer(web.Config{SSETickInterval: time.Hour}, deps)
+	if err != nil {
+		t.Fatalf("NewServer() error = %v", err)
+	}
+
+	eventsCtx, cancelEvents := context.WithCancel(context.Background())
+	t.Cleanup(cancelEvents)
+	eventsDone := make(chan struct{})
+	go func() {
+		defer close(eventsDone)
+		rec := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodGet, "/events?view=board", nil).WithContext(eventsCtx)
+		server.Handler().ServeHTTP(rec, req)
+	}()
+
+	select {
+	case <-started:
+	case <-time.After(time.Second):
+		t.Fatal("snapshot enrichment did not start")
+	}
+
+	type response struct {
+		code int
+		body string
+	}
+	responseReady := make(chan response, 1)
+	go func() {
+		rec := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodGet, "/", nil)
+		server.Handler().ServeHTTP(rec, req)
+		responseReady <- response{code: rec.Code, body: rec.Body.String()}
+	}()
+
+	select {
+	case got := <-responseReady:
+		if got.code != http.StatusOK {
+			t.Fatalf("status = %d, want %d; body = %s", got.code, http.StatusOK, got.body)
+		}
+		for _, want := range []string{"Cached board issue", generatedAt.Format(time.RFC3339), `id="live-clock"`} {
+			if !strings.Contains(got.body, want) {
+				t.Fatalf("body missing %q:\n%s", want, got.body)
+			}
+		}
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("board first paint exceeded 500ms while snapshot enrichment was blocked")
+	}
+	if got := fetchCalls.Load(); got != 0 {
+		t.Fatalf("FetchCandidateIssues calls = %d, want 0", got)
+	}
+
+	close(release)
+	cancelEvents()
+	select {
+	case <-eventsDone:
+	case <-time.After(time.Second):
+		t.Fatal("event stream did not stop")
+	}
+}
+
+func TestBoardFirstPaintColdBootRendersPlaceholders(t *testing.T) {
+	t.Parallel()
+
+	var runtimeEvidenceCalls atomic.Int64
+	registry := project.NewRegistry()
+	if err := registry.Set(newBudgetTestProject(t, "detent", 100, 10)); err != nil {
+		t.Fatalf("Registry.Set() error = %v", err)
+	}
+	deps := testDeps(t)
+	deps.Registry = registry
+	deps.Store = storeProbe{
+		runtimeEvidence: func(context.Context, store.RuntimeEvidenceQuery) (store.RuntimeEvidence, error) {
+			runtimeEvidenceCalls.Add(1)
+			return store.RuntimeEvidence{}, nil
+		},
+	}
+	server, err := web.NewServer(web.Config{}, deps)
+	if err != nil {
+		t.Fatalf("NewServer() error = %v", err)
+	}
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	server.Handler().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d; body = %s", rec.Code, http.StatusOK, rec.Body.String())
+	}
+	for _, want := range []string{`class="dt-skeleton`, `id="live-clock"`, "--:--:--"} {
+		if !strings.Contains(rec.Body.String(), want) {
+			t.Fatalf("body missing %q:\n%s", want, rec.Body.String())
+		}
+	}
+	if strings.Contains(rec.Body.String(), "Connect a repository") {
+		t.Fatalf("configured cold boot rendered unconfigured first-run state:\n%s", rec.Body.String())
+	}
+	if got := runtimeEvidenceCalls.Load(); got != 0 {
+		t.Fatalf("RuntimeEvidence calls = %d, want 0", got)
+	}
+}
+
 func TestDashboardEnrichesCycleTimeFromStore(t *testing.T) {
 	t.Parallel()
 
@@ -10812,14 +10951,18 @@ func (storeProbe) Close() error {
 }
 
 type connectorProbe struct {
-	name string
+	name                 string
+	fetchCandidateIssues func(context.Context) ([]connector.Issue, error)
 }
 
 func (p connectorProbe) Name() string {
 	return p.name
 }
 
-func (p connectorProbe) FetchCandidateIssues(context.Context) ([]connector.Issue, error) {
+func (p connectorProbe) FetchCandidateIssues(ctx context.Context) ([]connector.Issue, error) {
+	if p.fetchCandidateIssues != nil {
+		return p.fetchCandidateIssues(ctx)
+	}
 	return nil, connector.ErrNotImplemented
 }
 

--- a/internal/web/templates/board_data.go
+++ b/internal/web/templates/board_data.go
@@ -108,12 +108,16 @@ type boardCardView struct {
 
 func boardViewFromDashboard(data DashboardData) boardView {
 	board := projectKanbanBoardView(data)
+	spend := "-- today"
+	if !data.PendingEnrichment {
+		spend = formatUSD(data.Snapshot.Budget.CurrentSpendUSD) + " today"
+	}
 	view := boardView{
 		Key:        boardVisibilityKey(data),
 		Exceptions: boardExceptions(data, true),
 		Figures:    boardFigures(data.Snapshot),
 		TPS:        throughputRate(data.Snapshot),
-		Spend:      formatUSD(data.Snapshot.Budget.CurrentSpendUSD) + " today",
+		Spend:      spend,
 	}
 	fallbackProjectID := boardFallbackProjectID(data)
 	globalTerminalStates := projectKanbanTerminalStateSet(data.Kanban.TerminalStates)

--- a/internal/web/templates/board_data_test.go
+++ b/internal/web/templates/board_data_test.go
@@ -1583,6 +1583,17 @@ func TestBoardSnapshotRenders(t *testing.T) {
 	}
 }
 
+func TestBoardSnapshotRendersPendingEnrichmentPlaceholder(t *testing.T) {
+	t.Parallel()
+
+	data := boardTestData()
+	data.PendingEnrichment = true
+	html := renderBoardComponent(t, BoardSnapshot(data))
+	if !strings.Contains(html, "-- today") {
+		t.Fatalf("pending enrichment missing spend placeholder:\n%s", html)
+	}
+}
+
 func TestBoardSnapshotRendersMorphSafePriorityBadge(t *testing.T) {
 	t.Parallel()
 

--- a/internal/web/templates/dashboard_data.go
+++ b/internal/web/templates/dashboard_data.go
@@ -75,6 +75,7 @@ type DashboardData struct {
 	Theme              string
 	Density            string
 	AnalyticsKind      string
+	PendingEnrichment  bool
 }
 
 type DashboardShellData struct {


### PR DESCRIPTION
## Summary

- Serve board first paint from the hub snapshot or an immediately available enrichment cache entry without joining in-flight enrichment.
- Build first-paint project and Kanban data from in-memory state, then let the existing SSE morph path deliver fully enriched data.
- Render placeholders for cold boot and enrichment-dependent spend while preserving the cached snapshot timestamp.

Fixes #1318

## UI Surface Contract

- [x] The linked issue explicitly authorizes the board first-paint and placeholder behavior.
- [x] This PR does not add persistent top-of-screen messaging.
- [x] Visual changes to primary operator screens include screenshot or browser verification below.

Local browser verification was attempted against an isolated dev runtime on an ephemeral port, but no browser binding was available in the session. The current-head `Browser Visual` CI check passed. Rendered HTML behavior is also covered by the focused tests below.

## Test Plan

- [x] `go test ./internal/web ./internal/web/templates -count=1`
- [x] `make check`

`make check` passed build, golangci-lint, vet, NilAway, race tests, and the coverage gate at 77.4%.