### PR TITLE
fix(merge): prioritize ready queue heads

### DIFF
--- a/internal/orchestrator/autopromote_tick.go
+++ b/internal/orchestrator/autopromote_tick.go
@@ -1129,6 +1129,7 @@ func staleMergingPullRequestDispatchActive(state *State, issueID string) bool {
 func staleMergingQueueIssues(issues []connector.Issue, cfg Config) []connector.Issue {
 	queue := issuesInStates(issues, []string{autoPromoteMergingState})
 	sortIssuesForDispatch(queue, cfg.DispatchPriorityByState, cfg.DispatchPriorityByLabel, cfg.PrioritizeUnblockers)
+	prioritizeReadyMergingIssues(queue)
 	return queue
 }
 
@@ -1184,6 +1185,7 @@ func mergeWorkerRepositoryKey(issue connector.Issue) string {
 }
 
 func (o *Orchestrator) mergeWorkerDispatchCandidates(state *State, issues []connector.Issue) []connector.Issue {
+	o.logMergeWorkerQueueCycle(issues)
 	candidates := o.staleMergingQueueDispatchCandidates(state, issues)
 	if len(candidates) == 0 {
 		return nil
@@ -1225,6 +1227,62 @@ func (o *Orchestrator) mergeWorkerDispatchCandidates(state *State, issues []conn
 		out = append(out, issue)
 	}
 	return out
+}
+
+func (o *Orchestrator) logMergeWorkerQueueCycle(issues []connector.Issue) {
+	if o.logger == nil {
+		return
+	}
+	queueDepth := 0
+	readyCount := 0
+	for _, issue := range issues {
+		if !mergeWorkerIssue(issue) {
+			continue
+		}
+		queueDepth++
+		if mergeWorkerHeadReady(issue) {
+			readyCount++
+		}
+	}
+	o.logger.Info(
+		"merge_worker_queue_cycle",
+		"queue_depth", queueDepth,
+		"ready_count", readyCount,
+	)
+}
+
+func prioritizeReadyMergingIssues(issues []connector.Issue) {
+	ordered := make([]connector.Issue, 0, len(issues))
+	for _, issue := range issues {
+		if mergeWorkerIssue(issue) && mergeWorkerHeadReady(issue) {
+			ordered = append(ordered, issue)
+		}
+	}
+	for _, issue := range issues {
+		if mergeWorkerIssue(issue) && !mergeWorkerHeadReady(issue) {
+			ordered = append(ordered, issue)
+		}
+	}
+	if len(ordered) == 0 {
+		return
+	}
+	next := 0
+	for index := range issues {
+		if !mergeWorkerIssue(issues[index]) {
+			continue
+		}
+		issues[index] = ordered[next]
+		next++
+	}
+}
+
+func mergeWorkerHeadReady(issue connector.Issue) bool {
+	if !mergeWorkerIssue(issue) || strings.TrimSpace(issue.ID) == "" || issue.PullRequest == nil {
+		return false
+	}
+	return mergeWorkerProgrammaticMergeReady(issue) &&
+		strings.EqualFold(strings.TrimSpace(issue.PullRequest.MergeableState), "clean") &&
+		len(issue.PullRequest.RequiredCheckFailures) == 0
 }
 
 func (o *Orchestrator) staleMergingQueueDispatchCandidates(state *State, issues []connector.Issue) []connector.Issue {

--- a/internal/orchestrator/autopromote_tick.go
+++ b/internal/orchestrator/autopromote_tick.go
@@ -1253,15 +1253,32 @@ func (o *Orchestrator) logMergeWorkerQueueCycle(issues []connector.Issue) {
 
 func prioritizeReadyMergingIssues(issues []connector.Issue) {
 	ordered := make([]connector.Issue, 0, len(issues))
+	readyHeads := make(map[string]struct{})
+	seenRepositories := make(map[string]struct{})
 	for _, issue := range issues {
-		if mergeWorkerIssue(issue) && mergeWorkerHeadReady(issue) {
+		if !mergeWorkerIssue(issue) {
+			continue
+		}
+		repository := mergeWorkerRepositoryKey(issue)
+		if repository != "" {
+			if _, seen := seenRepositories[repository]; seen {
+				continue
+			}
+			seenRepositories[repository] = struct{}{}
+		}
+		if mergeWorkerHeadReady(issue) {
+			readyHeads[issue.ID] = struct{}{}
 			ordered = append(ordered, issue)
 		}
 	}
 	for _, issue := range issues {
-		if mergeWorkerIssue(issue) && !mergeWorkerHeadReady(issue) {
-			ordered = append(ordered, issue)
+		if !mergeWorkerIssue(issue) {
+			continue
 		}
+		if _, ready := readyHeads[issue.ID]; ready {
+			continue
+		}
+		ordered = append(ordered, issue)
 	}
 	if len(ordered) == 0 {
 		return

--- a/internal/orchestrator/autopromote_tick_test.go
+++ b/internal/orchestrator/autopromote_tick_test.go
@@ -3989,6 +3989,9 @@ func TestMergeWorkerDispatchCandidatesPrefersReadyHead(t *testing.T) {
 	waiting.CreatedAt = &waitingCreatedAt
 	ready := nativeMergeQueueTestIssue(1322, "success")
 	ready.ID = "issue-ready-head"
+	ready.Identifier = "digitaldrywood/pyroapex#1322"
+	ready.PRRepository = "digitaldrywood/pyroapex"
+	ready.PullRequest.URL = "https://github.test/digitaldrywood/pyroapex/pull/1322"
 	ready.CreatedAt = &readyCreatedAt
 	state := newState(cfg)
 	var logs strings.Builder
@@ -4126,6 +4129,7 @@ func TestMergeWorkerDispatchCandidatesConsumesNotReadyQueueHeadRepository(t *tes
 		State:                      "OPEN",
 		MergeableState:             "clean",
 		CIStatus:                   "success",
+		HeadSHA:                    "head-phone-blocked",
 		HydrationUnavailableReason: connector.PullRequestHydrationReasonSecondaryThrottled,
 	})
 	phoneHead.State = "Merging"
@@ -4137,6 +4141,7 @@ func TestMergeWorkerDispatchCandidatesConsumesNotReadyQueueHeadRepository(t *tes
 		State:          "OPEN",
 		MergeableState: "clean",
 		CIStatus:       "success",
+		HeadSHA:        "head-phone-ready",
 	})
 	phoneSibling.State = "Merging"
 	phoneSibling.Identifier = "digitaldrywood/creswoodcorners-phone#68"
@@ -4147,6 +4152,7 @@ func TestMergeWorkerDispatchCandidatesConsumesNotReadyQueueHeadRepository(t *tes
 		State:          "OPEN",
 		MergeableState: "clean",
 		CIStatus:       "success",
+		HeadSHA:        "head-outlet-ready",
 	})
 	outlet.State = "Merging"
 	outlet.Identifier = "digitaldrywood/creswoodcornersoutlet#89"

--- a/internal/orchestrator/autopromote_tick_test.go
+++ b/internal/orchestrator/autopromote_tick_test.go
@@ -3970,6 +3970,82 @@ func TestMergeWorkerDispatchCandidatesPreservesScheduledRetry(t *testing.T) {
 	}
 }
 
+func TestMergeWorkerDispatchCandidatesPrefersReadyHead(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 7, 15, 8, 0, 0, 0, time.UTC)
+	cfg := normalizeConfig(Config{
+		MaxConcurrentAgents: 1,
+		MaxConcurrentAgentsByState: map[string]int{
+			"Merging": 1,
+		},
+		ActiveStates:   []string{"Merging"},
+		TerminalStates: []string{"Done"},
+	})
+	waitingCreatedAt := now.Add(-time.Hour)
+	readyCreatedAt := now.Add(-time.Minute)
+	waiting := nativeMergeQueueTestIssue(1321, "pending")
+	waiting.ID = "issue-waiting-head"
+	waiting.CreatedAt = &waitingCreatedAt
+	ready := nativeMergeQueueTestIssue(1322, "success")
+	ready.ID = "issue-ready-head"
+	ready.CreatedAt = &readyCreatedAt
+	state := newState(cfg)
+	var logs strings.Builder
+	orch := &Orchestrator{
+		cfg:    cfg,
+		logger: slog.New(slog.NewTextHandler(&logs, nil)),
+	}
+
+	got := orch.mergeWorkerDispatchCandidates(&state, []connector.Issue{waiting, ready})
+	if len(got) != 1 || got[0].ID != ready.ID {
+		t.Fatalf("mergeWorkerDispatchCandidates() = %#v, want ready issue %q", got, ready.ID)
+	}
+	for _, fragment := range []string{
+		"merge_worker_queue_cycle",
+		"queue_depth=2",
+		"ready_count=1",
+	} {
+		if !strings.Contains(logs.String(), fragment) {
+			t.Fatalf("logs %q missing fragment %q", logs.String(), fragment)
+		}
+	}
+}
+
+func TestMergeWorkerHeadReady(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		mutate func(*connector.Issue)
+		want   bool
+	}{
+		{name: "clean green current head", want: true},
+		{name: "pending checks", mutate: func(issue *connector.Issue) { issue.PullRequest.CIStatus = "pending" }},
+		{name: "behind green", mutate: func(issue *connector.Issue) { issue.PullRequest.MergeableState = "behind" }},
+		{name: "missing required check", mutate: func(issue *connector.Issue) {
+			issue.PullRequest.RequiredCheckFailures = []connector.PullRequestCheck{{Name: "Test", Status: "missing"}}
+		}},
+		{name: "missing head", mutate: func(issue *connector.Issue) { issue.PullRequest.HeadSHA = "" }},
+		{name: "draft", mutate: func(issue *connector.Issue) { issue.PullRequest.Draft = true }},
+		{name: "not merging", mutate: func(issue *connector.Issue) { issue.State = "In Progress" }},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			issue := nativeMergeQueueTestIssue(1325, "success")
+			if tt.mutate != nil {
+				tt.mutate(&issue)
+			}
+			if got := mergeWorkerHeadReady(issue); got != tt.want {
+				t.Fatalf("mergeWorkerHeadReady() = %t, want %t", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestMergeWorkerDispatchCandidatesSelectsOneQueueHeadPerRepository(t *testing.T) {
 	t.Parallel()
 

--- a/internal/orchestrator/dispatch_planner.go
+++ b/internal/orchestrator/dispatch_planner.go
@@ -72,6 +72,7 @@ func (p dispatchPlanner) plan(
 	)
 	clearBlockedUnblockerCounts(plannedCandidates, state.Blocked)
 	sortIssuesForDispatch(plannedCandidates, p.cfg.DispatchPriorityByState, p.cfg.DispatchPriorityByLabel, p.cfg.PrioritizeUnblockers)
+	prioritizeReadyMergingIssues(plannedCandidates)
 	dueRetries := dueRetriesByIssue(state, now)
 	p.releaseMissingDueRetries(state, plannedCandidates, dueRetries, hooks)
 

--- a/internal/orchestrator/retry_test.go
+++ b/internal/orchestrator/retry_test.go
@@ -138,6 +138,110 @@ func TestDispatchReadyIssuesRanksDueRetriesWithCandidates(t *testing.T) {
 	}
 }
 
+func TestDispatchReadyIssuesDefersNotReadyMergeRetryBehindReadyHead(t *testing.T) {
+	t.Parallel()
+
+	cfg := normalizeConfig(Config{
+		MaxConcurrentAgents: 1,
+		MaxConcurrentAgentsByState: map[string]int{
+			"Merging": 1,
+		},
+		DispatchPriorityByState: []string{"Merging"},
+		ActiveStates:            []string{"Merging"},
+		TerminalStates:          []string{"Done"},
+	})
+	orch := Orchestrator{
+		cfg:        cfg,
+		supervisor: newTestSupervisor(t, FakeRunner{}, cfg),
+		runResults: make(chan runpkg.Completion, 1),
+	}
+	state := newState(cfg)
+	now := time.Date(2026, 7, 15, 8, 15, 0, 0, time.UTC)
+	waiting := nativeMergeQueueTestIssue(1323, "pending")
+	waiting.ID = "issue-deferred-head"
+	waitingCreatedAt := now.Add(-time.Hour)
+	waiting.CreatedAt = &waitingCreatedAt
+	ready := nativeMergeQueueTestIssue(1324, "success")
+	ready.ID = "issue-ready-after-deferral"
+	readyCreatedAt := now.Add(-time.Minute)
+	ready.CreatedAt = &readyCreatedAt
+
+	state.Claimed[waiting.ID] = Claimed{Issue: waiting, ClaimedAt: now.Add(-time.Minute)}
+	state.Retry[waiting.ID] = Retry{
+		Issue:   waiting,
+		Attempt: 1,
+		DueAt:   now.Add(-time.Millisecond),
+		Error:   "waiting for current-head CI",
+	}
+
+	orch.dispatchReadyIssues(context.Background(), &state, []connector.Issue{waiting, ready}, now)
+
+	if _, ok := state.Running[ready.ID]; !ok {
+		t.Fatalf("Running[%q] missing", ready.ID)
+	}
+	if _, ok := state.Running[waiting.ID]; ok {
+		t.Fatalf("Running[%q] present while a ready head was queued", waiting.ID)
+	}
+	if _, ok := state.Retry[waiting.ID]; !ok {
+		t.Fatalf("Retry[%q] missing after ready head dispatch", waiting.ID)
+	}
+}
+
+func TestDispatchReadyIssuesRevisitsDeferredMergeWhenCurrentHeadBecomesReady(t *testing.T) {
+	t.Parallel()
+
+	cfg := normalizeConfig(Config{
+		MaxConcurrentAgents: 1,
+		MaxConcurrentAgentsByState: map[string]int{
+			"Merging": 1,
+		},
+		DispatchPriorityByState: []string{"Merging"},
+		ActiveStates:            []string{"Merging"},
+		TerminalStates:          []string{"Done"},
+	})
+	orch := Orchestrator{
+		cfg:        cfg,
+		supervisor: newTestSupervisor(t, FakeRunner{}, cfg),
+		runResults: make(chan runpkg.Completion, 1),
+	}
+	state := newState(cfg)
+	now := time.Date(2026, 7, 15, 8, 30, 0, 0, time.UTC)
+	queueHead := nativeMergeQueueTestIssue(1326, "pending")
+	queueHead.ID = "issue-older-waiting-head"
+	queueHeadCreatedAt := now.Add(-time.Hour)
+	queueHead.CreatedAt = &queueHeadCreatedAt
+	deferred := nativeMergeQueueTestIssue(1327, "pending")
+	deferred.ID = "issue-deferred-now-ready"
+	deferredCreatedAt := now.Add(-time.Minute)
+	deferred.CreatedAt = &deferredCreatedAt
+	refreshed := cloneIssue(deferred)
+	refreshed.PullRequest.CIStatus = "success"
+
+	state.Claimed[deferred.ID] = Claimed{Issue: deferred, ClaimedAt: now.Add(-time.Minute)}
+	state.Retry[deferred.ID] = Retry{
+		Issue:   deferred,
+		Attempt: 1,
+		DueAt:   now.Add(-time.Millisecond),
+		Error:   "waiting for current-head CI",
+	}
+
+	orch.dispatchReadyIssues(context.Background(), &state, []connector.Issue{queueHead, refreshed}, now)
+
+	running, ok := state.Running[deferred.ID]
+	if !ok {
+		t.Fatalf("Running[%q] missing", deferred.ID)
+	}
+	if running.Issue.PullRequest == nil || running.Issue.PullRequest.CIStatus != "success" {
+		t.Fatalf("Running[%q].Issue.PullRequest = %#v, want refreshed green head", deferred.ID, running.Issue.PullRequest)
+	}
+	if _, ok := state.Running[queueHead.ID]; ok {
+		t.Fatalf("Running[%q] present while refreshed deferred head was ready", queueHead.ID)
+	}
+	if _, ok := state.Retry[deferred.ID]; ok {
+		t.Fatalf("Retry[%q] present after refreshed head dispatch", deferred.ID)
+	}
+}
+
 func TestDispatchReadyIssuesPreservesBlockedStatusForMissingDueRetry(t *testing.T) {
 	t.Parallel()
 

--- a/internal/orchestrator/retry_test.go
+++ b/internal/orchestrator/retry_test.go
@@ -163,6 +163,9 @@ func TestDispatchReadyIssuesDefersNotReadyMergeRetryBehindReadyHead(t *testing.T
 	waiting.CreatedAt = &waitingCreatedAt
 	ready := nativeMergeQueueTestIssue(1324, "success")
 	ready.ID = "issue-ready-after-deferral"
+	ready.Identifier = "digitaldrywood/pyroapex#1324"
+	ready.PRRepository = "digitaldrywood/pyroapex"
+	ready.PullRequest.URL = "https://github.test/digitaldrywood/pyroapex/pull/1324"
 	readyCreatedAt := now.Add(-time.Minute)
 	ready.CreatedAt = &readyCreatedAt
 
@@ -212,6 +215,9 @@ func TestDispatchReadyIssuesRevisitsDeferredMergeWhenCurrentHeadBecomesReady(t *
 	queueHead.CreatedAt = &queueHeadCreatedAt
 	deferred := nativeMergeQueueTestIssue(1327, "pending")
 	deferred.ID = "issue-deferred-now-ready"
+	deferred.Identifier = "digitaldrywood/pyroapex#1327"
+	deferred.PRRepository = "digitaldrywood/pyroapex"
+	deferred.PullRequest.URL = "https://github.test/digitaldrywood/pyroapex/pull/1327"
 	deferredCreatedAt := now.Add(-time.Minute)
 	deferred.CreatedAt = &deferredCreatedAt
 	refreshed := cloneIssue(deferred)

--- a/internal/project/project_test.go
+++ b/internal/project/project_test.go
@@ -10,6 +10,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -379,7 +380,7 @@ func TestProjectReestablishesClosedWorkflowWatcher(t *testing.T) {
 	secondUpdates := make(chan configwatcher.Update, 1)
 	rearmed := make(chan struct{})
 	var watcherCreates atomic.Int32
-	var logs bytes.Buffer
+	var logs lockedBuffer
 
 	initial := workflowConfig("memory")
 	initial.Polling.IntervalMS = int(time.Hour / time.Millisecond)
@@ -418,7 +419,7 @@ func TestProjectReestablishesClosedWorkflowWatcher(t *testing.T) {
 	case <-time.After(time.Second):
 		t.Fatal("timed out waiting for workflow watcher re-establishment")
 	}
-	if !bytes.Contains(logs.Bytes(), []byte("workflow watcher stopped")) {
+	if !strings.Contains(logs.String(), "workflow watcher stopped") {
 		t.Fatalf("logs = %q, want watcher failure warning", logs.String())
 	}
 	waitForWorkflowWatcherArmed(t, got)
@@ -1608,6 +1609,25 @@ func (c provisioningConnector) Provision(ctx context.Context) error {
 type closeTrackingConnector struct {
 	closed chan struct{}
 	once   sync.Once
+}
+
+type lockedBuffer struct {
+	mu  sync.Mutex
+	buf bytes.Buffer
+}
+
+func (b *lockedBuffer) Write(p []byte) (int, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	return b.buf.Write(p)
+}
+
+func (b *lockedBuffer) String() string {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	return b.buf.String()
 }
 
 func newCloseTrackingConnector() *closeTrackingConnector {


### PR DESCRIPTION
## Summary

- rank CLEAN/green current-head merge candidates ahead of waiting heads
- keep deferred retries behind ready work and revisit them from refreshed PR state
- log merge queue depth and ready count on every selection cycle

Fixes #1320

## UI Surface Contract

- [x] N/A, or the linked issue explicitly authorizes any high-impact UI surface, layout, density, first-viewport, or responsive visibility tradeoff.
- [x] Persistent top-of-screen messaging is explicitly authorized by the issue, or this PR does not add it.
- [x] N/A — no visual changes to primary operator screens.

## Test Plan

- [x] `go test ./internal/orchestrator -count=1`
- [x] `go test -race ./internal/orchestrator -count=1`
- [x] `make check`