### PR TITLE
fix(gate): honor configured artifact status

### DIFF
--- a/internal/orchestrator/autopromote.go
+++ b/internal/orchestrator/autopromote.go
@@ -154,6 +154,8 @@ func EvaluateAutoPromote(
 	}
 	if status, ok := artifactStatusFieldFromIssue(issue, cfg.Gate.Artifact.StatusField); ok {
 		summary.ArtifactStatus = status
+	} else if !strings.EqualFold(cfg.Gate.Artifact.StatusField, gate.DefaultArtifactStatusField) {
+		summary.ArtifactStatus = ""
 	} else if strings.TrimSpace(summary.ArtifactStatus) == "" {
 		summary.ArtifactStatus = artifactStatusFromIssue(issue, cfg.Gate.Artifact.StatusField)
 	}
@@ -353,6 +355,10 @@ func gateRequiresPullRequest(cfg gate.Config) bool {
 func artifactStatusFromIssue(issue connector.Issue, statusField string) string {
 	if status, ok := artifactStatusFieldFromIssue(issue, statusField); ok {
 		return status
+	}
+	if statusField = strings.TrimSpace(statusField); statusField != "" &&
+		!strings.EqualFold(statusField, gate.DefaultArtifactStatusField) {
+		return ""
 	}
 	if issue.Deliverable != nil && strings.TrimSpace(issue.Deliverable.ValidationStatus) != "" {
 		return strings.TrimSpace(issue.Deliverable.ValidationStatus)

--- a/internal/orchestrator/autopromote.go
+++ b/internal/orchestrator/autopromote.go
@@ -152,7 +152,9 @@ func EvaluateAutoPromote(
 			return autoPromoteDecision(AutoPromoteActionSkip, AutoPromoteReasonPullRequestHydrationUnavailable)
 		}
 	}
-	if strings.TrimSpace(summary.ArtifactStatus) == "" {
+	if status, ok := artifactStatusFieldFromIssue(issue, cfg.Gate.Artifact.StatusField); ok {
+		summary.ArtifactStatus = status
+	} else if strings.TrimSpace(summary.ArtifactStatus) == "" {
 		summary.ArtifactStatus = artifactStatusFromIssue(issue, cfg.Gate.Artifact.StatusField)
 	}
 	gateDecision := gate.Evaluate(cfg.Gate, issue.Labels, gateSummary(summary), now, gate.EvaluationOptions{
@@ -349,19 +351,26 @@ func gateRequiresPullRequest(cfg gate.Config) bool {
 }
 
 func artifactStatusFromIssue(issue connector.Issue, statusField string) string {
+	if status, ok := artifactStatusFieldFromIssue(issue, statusField); ok {
+		return status
+	}
 	if issue.Deliverable != nil && strings.TrimSpace(issue.Deliverable.ValidationStatus) != "" {
 		return strings.TrimSpace(issue.Deliverable.ValidationStatus)
 	}
+	return ""
+}
+
+func artifactStatusFieldFromIssue(issue connector.Issue, statusField string) (string, bool) {
 	statusField = strings.TrimSpace(statusField)
 	if statusField == "" {
 		statusField = gate.DefaultArtifactStatusField
 	}
 	for key, value := range issue.Fields {
 		if strings.EqualFold(strings.TrimSpace(key), statusField) {
-			return strings.TrimSpace(value)
+			return strings.TrimSpace(value), true
 		}
 	}
-	return ""
+	return "", false
 }
 
 type autoPromoteWorkpadBlockerCheck struct {

--- a/internal/orchestrator/autopromote_test.go
+++ b/internal/orchestrator/autopromote_test.go
@@ -586,6 +586,31 @@ func TestEvaluateAutoPromote(t *testing.T) {
 			},
 		},
 		{
+			name: "artifact gate ignores stale summary when configured field is missing",
+			issue: func() connector.Issue {
+				issue := autoPromoteTestIssue("issue-artifact-configured-missing", nil)
+				issue.Deliverable = &connector.Deliverable{ValidationStatus: "invalid"}
+				return issue
+			}(),
+			cfg: AutoPromoteConfig{
+				Enabled: true,
+				Gate: gate.Config{
+					Kind: gate.KindArtifact,
+					Artifact: gate.ArtifactConfig{
+						StatusField:    "render_status",
+						PassStatuses:   []string{"approved"},
+						WaitStatuses:   []string{"pending_review"},
+						ReworkStatuses: []string{"invalid"},
+					},
+				},
+			},
+			input: AutoPromoteSummary{ArtifactStatus: "invalid"},
+			want: AutoPromoteDecision{
+				Action: AutoPromoteActionAwaitReview,
+				Reason: AutoPromoteReasonArtifactStatusMissing,
+			},
+		},
+		{
 			name: "artifact gate routes rework from deliverable validation status",
 			issue: func() connector.Issue {
 				issue := autoPromoteTestIssue("issue-artifact-deliverable", nil)
@@ -647,6 +672,33 @@ func TestEvaluateAutoPromote(t *testing.T) {
 				if got.Findings[i] != tt.want.Findings[i] {
 					t.Fatalf("Findings[%d] = %#v, want %#v", i, got.Findings[i], tt.want.Findings[i])
 				}
+			}
+		})
+	}
+}
+
+func TestArtifactStatusFromIssue(t *testing.T) {
+	t.Parallel()
+
+	issue := autoPromoteTestIssue("issue-artifact-status", nil)
+	issue.Fields = map[string]string{"render_status": "recut"}
+	issue.Deliverable = &connector.Deliverable{ValidationStatus: "invalid"}
+
+	tests := []struct {
+		name        string
+		statusField string
+		want        string
+	}{
+		{name: "configured field", statusField: "render_status", want: "recut"},
+		{name: "missing configured field", statusField: "publish_status"},
+		{name: "default field falls back to deliverable", statusField: gate.DefaultArtifactStatusField, want: "invalid"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			if got := artifactStatusFromIssue(issue, tt.statusField); got != tt.want {
+				t.Fatalf("artifactStatusFromIssue() = %q, want %q", got, tt.want)
 			}
 		})
 	}

--- a/internal/orchestrator/autopromote_test.go
+++ b/internal/orchestrator/autopromote_test.go
@@ -536,6 +536,56 @@ func TestEvaluateAutoPromote(t *testing.T) {
 			},
 		},
 		{
+			name: "artifact gate routes configured rework field over stale summary",
+			issue: func() connector.Issue {
+				issue := autoPromoteTestIssue("issue-artifact-configured-rework", nil)
+				issue.Fields = map[string]string{"render_status": "recut"}
+				return issue
+			}(),
+			cfg: AutoPromoteConfig{
+				Enabled: true,
+				Gate: gate.Config{
+					Kind: gate.KindArtifact,
+					Artifact: gate.ArtifactConfig{
+						StatusField:    "render_status",
+						PassStatuses:   []string{"approved"},
+						WaitStatuses:   []string{"pending_review"},
+						ReworkStatuses: []string{"recut"},
+					},
+				},
+			},
+			input: AutoPromoteSummary{ArtifactStatus: "pending_review"},
+			want: AutoPromoteDecision{
+				Action: AutoPromoteActionRework,
+				Reason: AutoPromoteReasonArtifactStatusRework,
+			},
+		},
+		{
+			name: "artifact gate promotes configured pass field over stale summary",
+			issue: func() connector.Issue {
+				issue := autoPromoteTestIssue("issue-artifact-configured-pass", nil)
+				issue.Fields = map[string]string{"render_status": "approved"}
+				return issue
+			}(),
+			cfg: AutoPromoteConfig{
+				Enabled: true,
+				Gate: gate.Config{
+					Kind: gate.KindArtifact,
+					Artifact: gate.ArtifactConfig{
+						StatusField:    "render_status",
+						PassStatuses:   []string{"approved"},
+						WaitStatuses:   []string{"pending_review"},
+						ReworkStatuses: []string{"recut"},
+					},
+				},
+			},
+			input: AutoPromoteSummary{ArtifactStatus: "pending_review"},
+			want: AutoPromoteDecision{
+				Action: AutoPromoteActionPromote,
+				Reason: AutoPromoteReasonReady,
+			},
+		},
+		{
 			name: "artifact gate routes rework from deliverable validation status",
 			issue: func() connector.Issue {
 				issue := autoPromoteTestIssue("issue-artifact-deliverable", nil)

--- a/internal/orchestrator/local_sqlite_e2e_test.go
+++ b/internal/orchestrator/local_sqlite_e2e_test.go
@@ -232,6 +232,95 @@ func TestLocalSQLiteArtifactLifecycleEndToEnd(t *testing.T) {
 	}
 }
 
+func TestLocalSQLiteArtifactReworkUsesConfiguredStatusField(t *testing.T) {
+	t.Parallel()
+
+	dbPath := filepath.Join(t.TempDir(), "artifact-rework.db")
+	seed := connector.NewIssue()
+	seed.ID = "wi-artifact-rework"
+	seed.Identifier = "wi-artifact-rework"
+	seed.Title = "Recut launch video"
+	seed.State = "Review"
+	seed.Fields = map[string]string{
+		"render_status": "recut",
+		"review_round":  "6",
+	}
+	seed.Deliverable = &connector.Deliverable{
+		Kind:             "artifact",
+		ValidationStatus: "pending_review",
+	}
+
+	tracker, err := local.New(local.Config{
+		Path:           dbPath,
+		ProjectID:      "digitaldrywood-video",
+		Issues:         []connector.Issue{seed},
+		ActiveStates:   []string{"Todo", "Production", "Rework"},
+		ObservedStates: []string{"Backlog", "Review", "Blocked"},
+		TerminalStates: []string{"Ready for Pickup", "Done", "Cancelled"},
+	})
+	if err != nil {
+		t.Fatalf("local.New() error = %v", err)
+	}
+	t.Cleanup(func() {
+		if err := tracker.Close(); err != nil {
+			t.Errorf("Close() error = %v", err)
+		}
+	})
+
+	runner := &staticRunner{
+		result: orchestrator.RunResult{FinalState: orchestrator.FinalStateCompleted},
+	}
+
+	orch, err := orchestrator.New(orchestrator.Config{
+		PollInterval:        time.Second,
+		MaxConcurrentAgents: 1,
+		ActiveStates:        []string{"Todo", "Production", "Rework"},
+		ObservedStates:      []string{"Backlog", "Review", "Blocked"},
+		TerminalStates:      []string{"Ready for Pickup", "Done", "Cancelled"},
+		AutoPromote: orchestrator.AutoPromoteConfig{
+			Enabled:       true,
+			QuietDuration: 0,
+			GateWaitState: "source",
+			SourceState:   "Review",
+			PassState:     "Ready for Pickup",
+			ReworkState:   "Rework",
+			ReworkLimit:   0,
+			Gate: gate.Config{
+				Kind: gate.KindArtifact,
+				Artifact: gate.ArtifactConfig{
+					StatusField:    "render_status",
+					PassStatuses:   []string{"approved", "valid"},
+					WaitStatuses:   []string{"pending_review"},
+					ReworkStatuses: []string{"recut", "invalid", "missing_assets"},
+				},
+			},
+		},
+		MaxRetryBackoff:        time.Millisecond,
+		FailureRetryBaseDelay:  time.Millisecond,
+		ContinuationRetryDelay: time.Millisecond,
+	}, orchestrator.Dependencies{
+		Connector: tracker,
+		Runner:    runner,
+	})
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	stop := runOrchestrator(t, orch)
+	t.Cleanup(stop)
+
+	db, err := sql.Open("sqlite", dbPath)
+	if err != nil {
+		t.Fatalf("open tracker db: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := db.Close(); err != nil {
+			t.Errorf("Close() error = %v", err)
+		}
+	})
+
+	waitForLocalStateUpdateEvents(t, db, seed.ID, []string{"Rework"})
+}
+
 func TestLocalSQLiteHumanRestartDispatchesArtifactRound(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

- Make the configured artifact `status_field` authoritative over stale summary or deliverable validation statuses.
- Restore pass and rework routing for artifact items fetched from the configured auto-promote source state.
- Add unit and local SQLite regression coverage for conflicting wait, pass, and rework statuses.

Fixes #1323

## UI Surface Contract

- [x] N/A, or the linked issue explicitly authorizes any high-impact UI surface, layout, density, first-viewport, or responsive visibility tradeoff.
- [x] Persistent top-of-screen messaging is explicitly authorized by the issue, or this PR does not add it.
- [x] Visual changes to primary operator screens include screenshot or browser verification below.

## Test Plan

- [x] `make check`