### PR TITLE
fix(boot): recover stale instance locks

### DIFF
--- a/internal/cli/boot.go
+++ b/internal/cli/boot.go
@@ -184,6 +184,22 @@ func startRunning(ctx context.Context, cfg BootConfig) error {
 			return err
 		}
 		instanceLock = acquiredLock
+		if recovery, recovered := instanceLock.Recovery(); recovered {
+			attrs := []any{"path", runtimeStoreLockPath(runtimeDBPath)}
+			if recovery.Owner.PID > 0 {
+				attrs = append(attrs, "pid", recovery.Owner.PID)
+			}
+			if recovery.Owner.Hostname != "" {
+				attrs = append(attrs, "hostname", recovery.Owner.Hostname)
+			}
+			if !recovery.Owner.StartedAt.IsZero() {
+				attrs = append(attrs, "started_at", recovery.Owner.StartedAt)
+			}
+			if recovery.MetadataError != nil {
+				attrs = append(attrs, "metadata_error", recovery.MetadataError)
+			}
+			logger.Info("self-healed stale runtime instance lock", attrs...)
+		}
 	}
 	if instanceLock != nil {
 		defer func() {
@@ -1158,7 +1174,11 @@ func openRuntimeStore(ctx context.Context, cfg BootConfig) (store.Store, error) 
 func acquireRuntimeInstanceLock(lockPath string) (*instancelock.Lock, error) {
 	lock, err := instancelock.Acquire(lockPath)
 	if errors.Is(err, instancelock.ErrHeld) {
-		return nil, fmt.Errorf("another Detent instance is using runtime database guarded by %q; wait for it to finish shutting down, then retry", lockPath)
+		var heldErr *instancelock.HeldError
+		if errors.As(err, &heldErr) && heldErr.Owner.PID > 0 && !heldErr.Owner.StartedAt.IsZero() {
+			return nil, fmt.Errorf("another detent (pid %d, started %s) holds %s", heldErr.Owner.PID, heldErr.Owner.StartedAt.Format(time.RFC3339), lockPath)
+		}
+		return nil, fmt.Errorf("another detent holds %s, but its owner metadata is unreadable; stop the other instance or remove the stale lock", lockPath)
 	}
 	if err != nil {
 		return nil, fmt.Errorf("protect runtime database with %q: %w", lockPath, err)

--- a/internal/cli/boot_test.go
+++ b/internal/cli/boot_test.go
@@ -22,6 +22,7 @@ import (
 	globalconfig "github.com/digitaldrywood/detent/internal/config/global"
 	"github.com/digitaldrywood/detent/internal/connector"
 	"github.com/digitaldrywood/detent/internal/hub"
+	"github.com/digitaldrywood/detent/internal/instancelock"
 	projectpkg "github.com/digitaldrywood/detent/internal/project"
 	"github.com/digitaldrywood/detent/internal/scheduler"
 	"github.com/digitaldrywood/detent/internal/store"
@@ -669,7 +670,7 @@ func TestStartRunningRefusesSharedRuntimeDatabase(t *testing.T) {
 
 	select {
 	case err := <-secondDone:
-		if err == nil || !strings.Contains(err.Error(), "another Detent instance is using runtime database") {
+		if err == nil || !strings.Contains(err.Error(), "another detent (pid ") {
 			t.Fatalf("second startRunning() error = %v, want shared runtime database error", err)
 		}
 	case <-time.After(2 * time.Second):
@@ -718,6 +719,34 @@ func TestRuntimeStoreLocation(t *testing.T) {
 				t.Fatalf("runtimeStoreLockPath(%q) = %q, want %q", tt.path, got, tt.lockPath)
 			}
 		})
+	}
+}
+
+func TestAcquireRuntimeInstanceLockReportsLiveHolder(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join(t.TempDir(), "detent.db.lock")
+	lock, err := instancelock.Acquire(path)
+	if err != nil {
+		t.Fatalf("Acquire() error = %v", err)
+	}
+	t.Cleanup(func() {
+		if err := lock.Close(); err != nil {
+			t.Fatalf("Close() error = %v", err)
+		}
+	})
+
+	_, err = acquireRuntimeInstanceLock(path)
+	if err == nil {
+		t.Fatal("acquireRuntimeInstanceLock() error = nil, want live holder error")
+	}
+	for _, want := range []string{"another detent (pid ", "started ", ") holds " + path} {
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("acquireRuntimeInstanceLock() error = %q, want %q", err, want)
+		}
+	}
+	if strings.Contains(err.Error(), "context deadline exceeded") {
+		t.Fatalf("acquireRuntimeInstanceLock() error = %q, want actionable contention error", err)
 	}
 }
 

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -381,6 +381,12 @@ func runDoctor(ctx context.Context, cfg doctorConfig, opts options, deps doctorD
 	}
 	jobs = append(jobs,
 		doctorCheckJob{
+			Name: "Instance lock",
+			Run: func(_ context.Context) []doctorCheck {
+				return []doctorCheck{checkDoctorInstanceLock(resolution)}
+			},
+		},
+		doctorCheckJob{
 			Name: "SQLite database",
 			Run: func(jobCtx context.Context) []doctorCheck {
 				return []doctorCheck{checkDoctorSQLite(jobCtx, resolution, deps)}

--- a/internal/cli/doctor_environment.go
+++ b/internal/cli/doctor_environment.go
@@ -16,6 +16,7 @@ import (
 
 	workflowconfig "github.com/digitaldrywood/detent/internal/config"
 	globalconfig "github.com/digitaldrywood/detent/internal/config/global"
+	"github.com/digitaldrywood/detent/internal/instancelock"
 )
 
 var doctorHealthCheckKeys = []string{"hub", "store", "registry", "connector"}
@@ -281,6 +282,34 @@ func checkDoctorSQLite(ctx context.Context, resolution globalconfig.PathResoluti
 		Name:   "SQLite database",
 		Status: doctorOK,
 		Detail: dbPath + " is reachable",
+	}
+}
+
+func checkDoctorInstanceLock(resolution globalconfig.PathResolution) doctorCheck {
+	const name = "Instance lock"
+	if strings.TrimSpace(resolution.Path) == "" {
+		return doctorCheck{Name: name, Status: doctorFail, Detail: "global config path is unavailable", Hint: "Fix config resolution, then rerun detent doctor."}
+	}
+
+	lockPath := filepath.Join(filepath.Dir(resolution.Path), "detent.db.lock")
+	inspection, err := instancelock.Inspect(lockPath)
+	if err != nil {
+		return doctorCheck{Name: name, Status: doctorFail, Detail: fmt.Sprintf("%s could not be inspected: %v", lockPath, err), Hint: "Check the lock file permissions, then rerun detent doctor."}
+	}
+	switch inspection.Status {
+	case instancelock.StatusStale:
+		detail := "stale lock: " + lockPath
+		if inspection.MetadataError == nil {
+			detail = fmt.Sprintf("stale lock: %s was left by pid %d on %s, started %s", lockPath, inspection.Owner.PID, inspection.Owner.Hostname, inspection.Owner.StartedAt.Format(time.RFC3339))
+		}
+		return doctorCheck{Name: name, Status: doctorWarn, Detail: detail, Hint: "Detent will self-heal this stale lock on the next start."}
+	case instancelock.StatusHeld:
+		if inspection.MetadataError == nil {
+			return doctorCheck{Name: name, Status: doctorOK, Detail: fmt.Sprintf("%s is held by pid %d on %s, started %s", lockPath, inspection.Owner.PID, inspection.Owner.Hostname, inspection.Owner.StartedAt.Format(time.RFC3339))}
+		}
+		return doctorCheck{Name: name, Status: doctorWarn, Detail: fmt.Sprintf("%s is held with unreadable owner metadata: %v", lockPath, inspection.MetadataError), Hint: "Stop the running Detent instance before repairing its lock metadata."}
+	default:
+		return doctorCheck{Name: name, Status: doctorOK, Detail: lockPath + " has no active or stale holder"}
 	}
 }
 

--- a/internal/cli/doctor_test.go
+++ b/internal/cli/doctor_test.go
@@ -25,6 +25,7 @@ import (
 	globalconfig "github.com/digitaldrywood/detent/internal/config/global"
 	"github.com/digitaldrywood/detent/internal/connector"
 	ghconnector "github.com/digitaldrywood/detent/internal/connector/github"
+	"github.com/digitaldrywood/detent/internal/instancelock"
 	runnerpkg "github.com/digitaldrywood/detent/internal/runner"
 	"github.com/digitaldrywood/detent/internal/selector"
 )
@@ -3661,6 +3662,41 @@ func TestCheckDoctorSQLite(t *testing.T) {
 				t.Fatalf("Detail = %q, want containing %q", got.Detail, tt.wantDetail)
 			}
 		})
+	}
+}
+
+func TestCheckDoctorInstanceLock(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	resolution := globalconfig.PathResolution{Path: filepath.Join(root, "global.yaml")}
+	lockPath := filepath.Join(root, "detent.db.lock")
+
+	check := checkDoctorInstanceLock(resolution)
+	if check.Status != doctorOK || !strings.Contains(check.Detail, "no active or stale holder") {
+		t.Fatalf("missing lock check = %+v, want OK", check)
+	}
+
+	if err := os.WriteFile(lockPath, []byte("pid=987654\n"), 0o600); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+	check = checkDoctorInstanceLock(resolution)
+	if check.Status != doctorWarn || !strings.Contains(check.Detail, "stale lock:") {
+		t.Fatalf("stale lock check = %+v, want explicit stale warning", check)
+	}
+
+	lock, err := instancelock.Acquire(lockPath)
+	if err != nil {
+		t.Fatalf("Acquire() error = %v", err)
+	}
+	t.Cleanup(func() {
+		if err := lock.Close(); err != nil {
+			t.Fatalf("Close() error = %v", err)
+		}
+	})
+	check = checkDoctorInstanceLock(resolution)
+	if check.Status != doctorOK || !strings.Contains(check.Detail, "is held by pid") {
+		t.Fatalf("held lock check = %+v, want holder detail", check)
 	}
 }
 

--- a/internal/instancelock/lock.go
+++ b/internal/instancelock/lock.go
@@ -1,11 +1,15 @@
 package instancelock
 
 import (
+	"bufio"
 	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
+	"strconv"
+	"strings"
 	"sync"
+	"time"
 )
 
 var ErrHeld = errors.New("instance lock is held")
@@ -18,8 +22,56 @@ var localLocks = struct {
 type Lock struct {
 	path      string
 	file      *os.File
+	recovered *Recovery
 	closeOnce sync.Once
 	closeErr  error
+}
+
+type Owner struct {
+	PID       int
+	Hostname  string
+	StartedAt time.Time
+}
+
+type HeldError struct {
+	Path          string
+	Owner         Owner
+	MetadataError error
+}
+
+func (e *HeldError) Error() string {
+	if e.Owner.PID > 0 && !e.Owner.StartedAt.IsZero() {
+		return fmt.Sprintf("%s: pid %d on %s, started %s", ErrHeld, e.Owner.PID, e.Owner.Hostname, e.Owner.StartedAt.Format(time.RFC3339))
+	}
+	if e.MetadataError != nil {
+		return fmt.Sprintf("%s: %s: unreadable owner metadata: %v", ErrHeld, e.Path, e.MetadataError)
+	}
+	return fmt.Sprintf("%s: %s", ErrHeld, e.Path)
+}
+
+func (e *HeldError) Unwrap() error {
+	return ErrHeld
+}
+
+type Status string
+
+const (
+	StatusMissing Status = "missing"
+	StatusClear   Status = "clear"
+	StatusStale   Status = "stale"
+	StatusHeld    Status = "held"
+)
+
+type Inspection struct {
+	Path          string
+	Status        Status
+	Owner         Owner
+	MetadataError error
+}
+
+type Recovery struct {
+	Owner         Owner
+	MetadataError error
 }
 
 func Acquire(path string) (*Lock, error) {
@@ -31,7 +83,8 @@ func Acquire(path string) (*Lock, error) {
 		return nil, fmt.Errorf("create instance lock directory: %w", err)
 	}
 	if !claimLocal(absolutePath) {
-		return nil, fmt.Errorf("%w: %s", ErrHeld, absolutePath)
+		owner, metadataErr := readLockedOwnerPath(absolutePath)
+		return nil, &HeldError{Path: absolutePath, Owner: owner, MetadataError: metadataErr}
 	}
 	releaseClaim := true
 	defer func() {
@@ -45,18 +98,28 @@ func Acquire(path string) (*Lock, error) {
 		return nil, fmt.Errorf("open instance lock: %w", err)
 	}
 	if err := tryLock(file); err != nil {
+		owner, metadataErr := readLockedOwner(file)
 		closeErr := file.Close()
 		if errors.Is(err, ErrHeld) {
-			return nil, errors.Join(fmt.Errorf("%w: %s", ErrHeld, absolutePath), closeErr)
+			return nil, errors.Join(&HeldError{Path: absolutePath, Owner: owner, MetadataError: metadataErr}, closeErr)
 		}
 		return nil, fmt.Errorf("acquire instance lock: %w", errors.Join(err, closeErr))
 	}
-	if err := writeOwner(file); err != nil {
+	previousOwner, metadataErr := readOwner(file)
+	owner, err := currentOwner()
+	if err != nil {
+		return nil, errors.Join(err, unlock(file), file.Close())
+	}
+	if err := writeOwner(file, owner); err != nil {
 		return nil, errors.Join(err, unlock(file), file.Close())
 	}
 
 	releaseClaim = false
-	return &Lock{path: absolutePath, file: file}, nil
+	lock := &Lock{path: absolutePath, file: file}
+	if !errors.Is(metadataErr, errEmptyOwner) {
+		lock.recovered = &Recovery{Owner: previousOwner, MetadataError: metadataErr}
+	}
+	return lock, nil
 }
 
 func (l *Lock) Close() error {
@@ -64,25 +127,151 @@ func (l *Lock) Close() error {
 		return nil
 	}
 	l.closeOnce.Do(func() {
+		clearErr := clearOwner(l.file)
 		unlockErr := unlock(l.file)
 		closeErr := l.file.Close()
 		releaseLocal(l.path)
-		l.closeErr = errors.Join(unlockErr, closeErr)
+		l.closeErr = errors.Join(clearErr, unlockErr, closeErr)
 	})
 	return l.closeErr
 }
 
-func writeOwner(file *os.File) error {
+func (l *Lock) Recovery() (Recovery, bool) {
+	if l == nil || l.recovered == nil {
+		return Recovery{}, false
+	}
+	return *l.recovered, true
+}
+
+func Inspect(path string) (Inspection, error) {
+	absolutePath, err := filepath.Abs(path)
+	if err != nil {
+		return Inspection{}, fmt.Errorf("resolve instance lock path: %w", err)
+	}
+	inspection := Inspection{Path: absolutePath, Status: StatusMissing}
+	if isLocallyClaimed(absolutePath) {
+		inspection.Status = StatusHeld
+		inspection.Owner, inspection.MetadataError = readLockedOwnerPath(absolutePath)
+		return inspection, nil
+	}
+	file, err := os.OpenFile(absolutePath, os.O_RDWR, 0o600)
+	if errors.Is(err, os.ErrNotExist) {
+		return inspection, nil
+	}
+	if err != nil {
+		return Inspection{}, fmt.Errorf("open instance lock: %w", err)
+	}
+
+	if err := tryLock(file); err != nil {
+		if !errors.Is(err, ErrHeld) {
+			return Inspection{}, fmt.Errorf("inspect instance lock: %w", errors.Join(err, file.Close()))
+		}
+		inspection.Status = StatusHeld
+		inspection.Owner, inspection.MetadataError = readLockedOwner(file)
+		return inspection, file.Close()
+	}
+
+	inspection.Owner, inspection.MetadataError = readOwner(file)
+	cleanupErr := errors.Join(unlock(file), file.Close())
+	if cleanupErr != nil {
+		return Inspection{}, fmt.Errorf("finish instance lock inspection: %w", cleanupErr)
+	}
+	if errors.Is(inspection.MetadataError, errEmptyOwner) {
+		inspection.Status = StatusClear
+		inspection.MetadataError = nil
+		return inspection, nil
+	}
+	inspection.Status = StatusStale
+	return inspection, nil
+}
+
+var errEmptyOwner = errors.New("instance lock owner is empty")
+
+func currentOwner() (Owner, error) {
+	hostname, err := os.Hostname()
+	if err != nil {
+		return Owner{}, fmt.Errorf("resolve instance lock hostname: %w", err)
+	}
+	return Owner{PID: os.Getpid(), Hostname: hostname, StartedAt: time.Now().UTC()}, nil
+}
+
+func writeOwner(file *os.File, owner Owner) error {
 	if err := file.Truncate(0); err != nil {
 		return fmt.Errorf("truncate instance lock: %w", err)
 	}
 	if _, err := file.Seek(0, 0); err != nil {
 		return fmt.Errorf("seek instance lock: %w", err)
 	}
-	if _, err := fmt.Fprintf(file, "pid=%d\n", os.Getpid()); err != nil {
+	if _, err := fmt.Fprintf(file, "\npid=%d\nhostname=%s\nstarted_at=%s\n", owner.PID, owner.Hostname, owner.StartedAt.Format(time.RFC3339Nano)); err != nil {
 		return fmt.Errorf("write instance lock owner: %w", err)
 	}
+	if err := file.Sync(); err != nil {
+		return fmt.Errorf("sync instance lock owner: %w", err)
+	}
 	return nil
+}
+
+func clearOwner(file *os.File) error {
+	if err := file.Truncate(0); err != nil {
+		return fmt.Errorf("clear instance lock owner: %w", err)
+	}
+	if err := file.Sync(); err != nil {
+		return fmt.Errorf("sync cleared instance lock owner: %w", err)
+	}
+	return nil
+}
+
+func readLockedOwnerPath(path string) (Owner, error) {
+	file, err := os.Open(path)
+	if err != nil {
+		return Owner{}, err
+	}
+	owner, readErr := readLockedOwner(file)
+	return owner, errors.Join(readErr, file.Close())
+}
+
+func readOwner(file *os.File) (Owner, error) {
+	if _, err := file.Seek(0, 0); err != nil {
+		return Owner{}, fmt.Errorf("seek instance lock owner: %w", err)
+	}
+	return scanOwner(file)
+}
+
+func readLockedOwner(file *os.File) (Owner, error) {
+	if err := seekLockedOwner(file); err != nil {
+		return Owner{}, fmt.Errorf("seek locked instance lock owner: %w", err)
+	}
+	return scanOwner(file)
+}
+
+func scanOwner(file *os.File) (Owner, error) {
+	values := make(map[string]string, 3)
+	scanner := bufio.NewScanner(file)
+	for scanner.Scan() {
+		key, value, ok := strings.Cut(scanner.Text(), "=")
+		if ok {
+			values[strings.TrimSpace(key)] = strings.TrimSpace(value)
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return Owner{}, fmt.Errorf("read instance lock owner: %w", err)
+	}
+	if len(values) == 0 {
+		return Owner{}, errEmptyOwner
+	}
+	pid, err := strconv.Atoi(values["pid"])
+	if err != nil || pid <= 0 {
+		return Owner{}, fmt.Errorf("invalid pid %q", values["pid"])
+	}
+	hostname := values["hostname"]
+	if hostname == "" {
+		return Owner{PID: pid}, errors.New("hostname is missing")
+	}
+	startedAt, err := time.Parse(time.RFC3339Nano, values["started_at"])
+	if err != nil {
+		return Owner{PID: pid, Hostname: hostname}, fmt.Errorf("invalid started_at %q: %w", values["started_at"], err)
+	}
+	return Owner{PID: pid, Hostname: hostname, StartedAt: startedAt}, nil
 }
 
 func claimLocal(path string) bool {
@@ -99,4 +288,11 @@ func releaseLocal(path string) {
 	localLocks.Lock()
 	defer localLocks.Unlock()
 	delete(localLocks.paths, path)
+}
+
+func isLocallyClaimed(path string) bool {
+	localLocks.Lock()
+	defer localLocks.Unlock()
+	_, exists := localLocks.paths[path]
+	return exists
 }

--- a/internal/instancelock/lock_test.go
+++ b/internal/instancelock/lock_test.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 )
 
 func TestAcquireExcludesAnotherProcessAndReleases(t *testing.T) {
@@ -37,6 +38,93 @@ func TestAcquireExcludesAnotherProcessAndReleases(t *testing.T) {
 	}
 	if err := reacquired.Close(); err != nil {
 		t.Fatalf("reacquired Close() error = %v", err)
+	}
+}
+
+func TestAcquireReportsLiveOwner(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join(t.TempDir(), "detent.db.lock")
+	lock, err := Acquire(path)
+	if err != nil {
+		t.Fatalf("Acquire() error = %v", err)
+	}
+	t.Cleanup(func() {
+		if err := lock.Close(); err != nil {
+			t.Fatalf("Close() error = %v", err)
+		}
+	})
+
+	_, err = Acquire(path)
+	var heldErr *HeldError
+	if !errors.As(err, &heldErr) {
+		t.Fatalf("Acquire() error = %v, want HeldError", err)
+	}
+	if heldErr.Owner.PID != os.Getpid() {
+		t.Fatalf("holder PID = %d, want %d", heldErr.Owner.PID, os.Getpid())
+	}
+	if heldErr.Owner.Hostname == "" || heldErr.Owner.StartedAt.IsZero() {
+		t.Fatalf("holder = %+v, want hostname and start time", heldErr.Owner)
+	}
+}
+
+func TestAcquireRecoversStaleOwnerAndClearsOnClose(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join(t.TempDir(), "detent.db.lock")
+	startedAt := time.Date(2026, 7, 15, 12, 30, 0, 0, time.UTC)
+	contents := "pid=987654\nhostname=old-host\nstarted_at=" + startedAt.Format(time.RFC3339Nano) + "\n"
+	if err := os.WriteFile(path, []byte(contents), 0o600); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+
+	inspection, err := Inspect(path)
+	if err != nil {
+		t.Fatalf("Inspect() error = %v", err)
+	}
+	if inspection.Status != StatusStale || inspection.Owner.PID != 987654 {
+		t.Fatalf("inspection = %+v, want stale owner", inspection)
+	}
+
+	lock, err := Acquire(path)
+	if err != nil {
+		t.Fatalf("Acquire() error = %v", err)
+	}
+	recovery, ok := lock.Recovery()
+	if !ok || recovery.Owner.PID != 987654 || !recovery.Owner.StartedAt.Equal(startedAt) {
+		t.Fatalf("Recovery() = %+v, %v, want stale owner", recovery, ok)
+	}
+	if err := lock.Close(); err != nil {
+		t.Fatalf("Close() error = %v", err)
+	}
+
+	inspection, err = Inspect(path)
+	if err != nil {
+		t.Fatalf("Inspect() after Close error = %v", err)
+	}
+	if inspection.Status != StatusClear {
+		t.Fatalf("inspection after Close = %+v, want clear", inspection)
+	}
+}
+
+func TestAcquireRecoversLegacyPIDOnlyLock(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join(t.TempDir(), "detent.db.lock")
+	if err := os.WriteFile(path, []byte("pid=987654\n"), 0o600); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+
+	lock, err := Acquire(path)
+	if err != nil {
+		t.Fatalf("Acquire() error = %v", err)
+	}
+	recovery, ok := lock.Recovery()
+	if !ok || recovery.Owner.PID != 987654 || recovery.MetadataError == nil {
+		t.Fatalf("Recovery() = %+v, %v, want legacy stale owner", recovery, ok)
+	}
+	if err := lock.Close(); err != nil {
+		t.Fatalf("Close() error = %v", err)
 	}
 }
 

--- a/internal/instancelock/lock_unix.go
+++ b/internal/instancelock/lock_unix.go
@@ -20,3 +20,8 @@ func tryLock(file *os.File) error {
 func unlock(file *os.File) error {
 	return unix.Flock(int(file.Fd()), unix.LOCK_UN)
 }
+
+func seekLockedOwner(file *os.File) error {
+	_, err := file.Seek(0, 0)
+	return err
+}

--- a/internal/instancelock/lock_windows.go
+++ b/internal/instancelock/lock_windows.go
@@ -28,3 +28,8 @@ func tryLock(file *os.File) error {
 func unlock(file *os.File) error {
 	return windows.UnlockFileEx(windows.Handle(file.Fd()), 0, 1, 0, new(windows.Overlapped))
 }
+
+func seekLockedOwner(file *os.File) error {
+	_, err := file.Seek(1, 0)
+	return err
+}


### PR DESCRIPTION
## Summary

- persist PID, hostname, and start time in the runtime database lock
- self-heal lock metadata left by dead holders and log the recovery
- fail immediately with live holder details and report stale locks in doctor

Fixes #1326

## Test Plan

- `go test ./internal/instancelock ./internal/cli`
- `GIT_CEILING_DIRECTORIES="$TMPDIR" make check`
- coverage: 77.3%