### PR TITLE
fix(local): tolerate mixed JSON work item fields

### DIFF
--- a/internal/connector/local/local.go
+++ b/internal/connector/local/local.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"log/slog"
 	"net/url"
 	"os"
 	"path/filepath"
@@ -49,6 +50,7 @@ type Config struct {
 	ObservedStates []string
 	TerminalStates []string
 	Now            func() time.Time
+	Logger         *slog.Logger
 }
 
 type Connector struct {
@@ -58,6 +60,7 @@ type Connector struct {
 	observedStates []string
 	terminalStates []string
 	now            func() time.Time
+	logger         *slog.Logger
 }
 
 var _ connector.Connector = (*Connector)(nil)
@@ -105,9 +108,13 @@ func New(cfg Config) (*Connector, error) {
 		observedStates: cloneStrings(cfg.ObservedStates),
 		terminalStates: cloneStrings(cfg.TerminalStates),
 		now:            cfg.Now,
+		logger:         cfg.Logger,
 	}
 	if conn.now == nil {
 		conn.now = time.Now
+	}
+	if conn.logger == nil {
+		conn.logger = slog.Default()
 	}
 	if err := conn.migrate(context.Background()); err != nil {
 		_ = db.Close()
@@ -989,7 +996,7 @@ where project_id = ?`
 
 	issues := []connector.Issue{}
 	for rows.Next() {
-		issue, err := scanIssue(rows)
+		issue, err := c.scanIssue(rows)
 		if err != nil {
 			closeErr := rows.Close()
 			return nil, errors.Join(err, closeErr)
@@ -1137,7 +1144,7 @@ type issueScanner interface {
 	Scan(dest ...any) error
 }
 
-func scanIssue(scanner issueScanner) (connector.Issue, error) {
+func (c *Connector) scanIssue(scanner issueScanner) (connector.Issue, error) {
 	var issue connector.Issue
 	var projectID string
 	var priority sql.NullInt64
@@ -1166,7 +1173,26 @@ func scanIssue(scanner issueScanner) (connector.Issue, error) {
 	}
 	issue.Assignees = unmarshalStringSlice(assigneesJSON)
 	issue.Labels = unmarshalStringSlice(labelsJSON)
-	issue.Fields = unmarshalStringMap(fieldsJSON)
+	issue.Fields = map[string]string{}
+	fields, warnings, fieldsErr := unmarshalIssueFields(fieldsJSON)
+	if fieldsErr != nil {
+		c.logger.Warn("decode local sqlite work item fields failed",
+			"project_id", projectID,
+			"issue_id", issue.ID,
+			"error", fieldsErr,
+		)
+	} else {
+		issue.Fields = fields
+		for _, warning := range warnings {
+			c.logger.Warn("local sqlite work item field has non-string JSON value",
+				"project_id", projectID,
+				"issue_id", issue.ID,
+				"field", warning.field,
+				"json_type", warning.jsonType,
+				"action", warning.action,
+			)
+		}
+	}
 	issue.Metadata = unmarshalStringMap(metadataJSON)
 	applyGitHubIdentityMetadata(&issue, githubIdentity{
 		NodeID:        githubNodeID,
@@ -1433,4 +1459,72 @@ func unmarshalStringMap(raw string) map[string]string {
 		return map[string]string{}
 	}
 	return values
+}
+
+type fieldHydrationWarning struct {
+	field    string
+	jsonType string
+	action   string
+}
+
+func unmarshalIssueFields(raw string) (map[string]string, []fieldHydrationWarning, error) {
+	var encoded map[string]json.RawMessage
+	if err := json.Unmarshal([]byte(strings.TrimSpace(raw)), &encoded); err != nil {
+		return map[string]string{}, nil, err
+	}
+
+	fields := make(map[string]string, len(encoded))
+	warnings := make([]fieldHydrationWarning, 0)
+	for field, encodedValue := range encoded {
+		value, jsonType, ok := issueFieldString(encodedValue)
+		if jsonType != "string" {
+			action := "skipped"
+			if ok {
+				action = "stringified"
+			}
+			warnings = append(warnings, fieldHydrationWarning{
+				field:    field,
+				jsonType: jsonType,
+				action:   action,
+			})
+		}
+		if ok {
+			fields[field] = value
+		}
+	}
+	return fields, warnings, nil
+}
+
+func issueFieldString(raw json.RawMessage) (string, string, bool) {
+	value := strings.TrimSpace(string(raw))
+	if value == "" {
+		return "", "invalid", false
+	}
+
+	switch value[0] {
+	case '"':
+		var decoded string
+		if err := json.Unmarshal(raw, &decoded); err != nil {
+			return "", "invalid", false
+		}
+		return decoded, "string", true
+	case 't', 'f':
+		var decoded bool
+		if err := json.Unmarshal(raw, &decoded); err != nil {
+			return "", "invalid", false
+		}
+		return strconv.FormatBool(decoded), "boolean", true
+	case 'n':
+		return "null", "null", true
+	case '[':
+		return "", "array", false
+	case '{':
+		return "", "object", false
+	default:
+		var decoded json.Number
+		if err := json.Unmarshal(raw, &decoded); err != nil {
+			return "", "invalid", false
+		}
+		return decoded.String(), "number", true
+	}
 }

--- a/internal/connector/local/local_test.go
+++ b/internal/connector/local/local_test.go
@@ -1,11 +1,14 @@
 package local
 
 import (
+	"bytes"
 	"context"
 	"database/sql"
 	"errors"
+	"log/slog"
 	"path/filepath"
 	"strconv"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -111,6 +114,84 @@ func TestConnectorPersistsWorkItemStateAndEvents(t *testing.T) {
 	}
 	if _, err := reopened.issueByID(ctx, "ad-1"); !errors.Is(err, sql.ErrNoRows) {
 		t.Fatalf("issueByID() error = %v, want sql.ErrNoRows", err)
+	}
+}
+
+func TestConnectorFetchesMixedTypeWorkItemFields(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	issue := connector.NewIssue()
+	issue.ID = "mock-1"
+	issue.Identifier = "video/mock-1"
+	issue.State = "Review"
+	var logs bytes.Buffer
+
+	store, err := New(Config{
+		Path:      filepath.Join(t.TempDir(), "mixed-fields.db"),
+		ProjectID: "video",
+		Issues:    []connector.Issue{issue},
+		Logger: slog.New(slog.NewTextHandler(&logs, &slog.HandlerOptions{
+			Level: slog.LevelWarn,
+		})),
+	})
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	t.Cleanup(func() {
+		if err := store.Close(); err != nil {
+			t.Errorf("Close() error = %v", err)
+		}
+	})
+
+	const fieldsJSON = `{"gate":"mock","slug":"demo","render_status":"recut","review_round":6,"approved":true,"quality":null,"nested":{"stage":1},"cuts":[1,2]}`
+	if _, err := store.db.ExecContext(ctx, `
+update detent_work_items set fields_json = ? where project_id = ? and id = ?`,
+		fieldsJSON, "video", issue.ID); err != nil {
+		t.Fatalf("update fields_json error = %v", err)
+	}
+
+	issues, err := store.FetchIssuesByStates(ctx, []string{"Review"})
+	if err != nil {
+		t.Fatalf("FetchIssuesByStates() error = %v", err)
+	}
+	if len(issues) != 1 {
+		t.Fatalf("FetchIssuesByStates() len = %d, want 1", len(issues))
+	}
+	want := map[string]string{
+		"gate":          "mock",
+		"slug":          "demo",
+		"render_status": "recut",
+		"review_round":  "6",
+		"approved":      "true",
+		"quality":       "null",
+	}
+	if len(issues[0].Fields) != len(want) {
+		t.Fatalf("Fields = %#v, want %#v", issues[0].Fields, want)
+	}
+	for field, value := range want {
+		if issues[0].Fields[field] != value {
+			t.Errorf("Fields[%q] = %q, want %q", field, issues[0].Fields[field], value)
+		}
+	}
+	for _, field := range []string{"nested", "cuts"} {
+		if value, ok := issues[0].Fields[field]; ok {
+			t.Errorf("Fields[%q] = %q, want field omitted", field, value)
+		}
+	}
+	if count := strings.Count(logs.String(), "local sqlite work item field has non-string JSON value"); count != 5 {
+		t.Fatalf("field warning count = %d, want 5:\n%s", count, logs.String())
+	}
+	for _, warning := range []string{
+		"field=review_round json_type=number action=stringified",
+		"field=approved json_type=boolean action=stringified",
+		"field=quality json_type=null action=stringified",
+		"field=nested json_type=object action=skipped",
+		"field=cuts json_type=array action=skipped",
+	} {
+		if !strings.Contains(logs.String(), warning) {
+			t.Errorf("logs missing %q:\n%s", warning, logs.String())
+		}
 	}
 }
 

--- a/internal/orchestrator/local_sqlite_e2e_test.go
+++ b/internal/orchestrator/local_sqlite_e2e_test.go
@@ -266,6 +266,21 @@ func TestLocalSQLiteArtifactReworkUsesConfiguredStatusField(t *testing.T) {
 			t.Errorf("Close() error = %v", err)
 		}
 	})
+	db, err := sql.Open("sqlite", dbPath)
+	if err != nil {
+		t.Fatalf("open tracker db: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := db.Close(); err != nil {
+			t.Errorf("Close() error = %v", err)
+		}
+	})
+	const fieldsJSON = `{"render_status":"recut","review_round":6}`
+	if _, err := db.ExecContext(t.Context(), `
+update detent_work_items set fields_json = ? where project_id = ? and id = ?`,
+		fieldsJSON, "digitaldrywood-video", seed.ID); err != nil {
+		t.Fatalf("update fields_json error = %v", err)
+	}
 
 	runner := &staticRunner{
 		result: orchestrator.RunResult{FinalState: orchestrator.FinalStateCompleted},
@@ -307,16 +322,6 @@ func TestLocalSQLiteArtifactReworkUsesConfiguredStatusField(t *testing.T) {
 	}
 	stop := runOrchestrator(t, orch)
 	t.Cleanup(stop)
-
-	db, err := sql.Open("sqlite", dbPath)
-	if err != nil {
-		t.Fatalf("open tracker db: %v", err)
-	}
-	t.Cleanup(func() {
-		if err := db.Close(); err != nil {
-			t.Errorf("Close() error = %v", err)
-		}
-	})
 
 	waitForLocalStateUpdateEvents(t, db, seed.ID, []string{"Rework"})
 }


### PR DESCRIPTION
## Summary

- hydrate local SQLite work-item fields independently so one non-string value cannot discard the entire map
- stringify JSON scalars, skip arrays and objects, and log field-specific normalization warnings
- cover the production numeric review-round shape through the artifact rework gate

Fixes #1332

## UI Surface Contract

- [x] N/A; this PR does not change any UI surface, layout, density, first-viewport, or responsive visibility.
- [x] This PR does not add persistent top-of-screen messaging.
- [x] N/A; this PR has no visual changes to operator screens.

## Test Plan

- [x] `go test ./internal/connector/local -count=1`
- [x] `go test ./internal/orchestrator -run '^TestLocalSQLiteArtifactReworkUsesConfiguredStatusField$' -count=1 -v`
- [x] `make check` with `GIT_CEILING_DIRECTORIES="$TMPDIR"` for the known nested-temp test isolation issue #1327; 77.4% overall coverage