### PR TITLE
fix(runner): detect dead claude parent

### DIFF
--- a/.detent/skills/worker-process-lifecycle.md
+++ b/.detent/skills/worker-process-lifecycle.md
@@ -8,8 +8,9 @@ when_to_use: Use when changing Codex or Claude process launch, cancellation, shu
 
 - Configure every paid worker command through `internal/procgroup` before `Start` so its descendants share a dedicated process group while remaining in Detent's service cgroup.
 - Inspect the launched process and persist PID, PGID, and OS start time on the Detent session before provider work begins.
+- Observe provider-parent exit concurrently with stdout and stderr consumption. Use Detent-owned pipes so `Wait` cannot be held open by descendants that inherited output descriptors, then reap the process group before finishing the drains.
 - Validate PID and start time before signaling a recovered process record so PID reuse cannot terminate an unrelated process.
 - On forced shutdown or startup recovery, send SIGTERM to the process group, wait for the bounded grace period, then send SIGKILL and verify the group exited.
 - Give each worker turn a Detent-owned temporary directory inside its workspace through `TMPDIR`, `TMP`, and `TEMP`. Remove it only after the provider process tree exits, remediate read-only generated-cache permissions before retrying deletion, and never infer ownership by scanning arbitrary host temp-directory prefixes.
 - Log one INFO lifecycle decision with the issue identifier for every persisted worker record and record the reap outcome.
-- Test launch journaling, stale-identity refusal, process-group escalation, startup recovery, drain-timeout cleanup, provider temp-environment propagation, and read-only scratch cleanup without signaling the live Detent instance.
+- Test launch journaling, dead-parent detection with inherited output descriptors, stale-identity refusal, process-group escalation, startup recovery, drain-timeout cleanup, provider temp-environment propagation, and read-only scratch cleanup without signaling the live Detent instance.

--- a/internal/claudecode/backend_test.go
+++ b/internal/claudecode/backend_test.go
@@ -225,9 +225,10 @@ func TestFinalTurnErrorAfterStreamClose(t *testing.T) {
 		state    turnState
 		waitErr  error
 		wantErr  error
+		wantText string
 	}{
 		{name: "cancellation takes precedence", canceled: true, waitErr: errors.New("process exited"), wantErr: context.Canceled},
-		{name: "uncanceled missing result", waitErr: errors.New("process exited"), wantErr: ErrMissingResult},
+		{name: "uncanceled missing result", waitErr: errors.New("exit status 9"), wantErr: ErrMissingResult, wantText: "process exited: exit status 9"},
 		{name: "late cancellation preserves success", canceled: true, state: turnState{sawResult: true, resultSubtype: "success"}},
 		{name: "late cancellation preserves result error", canceled: true, state: turnState{sawResult: true, resultIsError: true, resultSubtype: "error_during_execution"}, wantErr: ErrTurnFailed},
 	}
@@ -252,6 +253,9 @@ func TestFinalTurnErrorAfterStreamClose(t *testing.T) {
 			}
 			if !errors.Is(err, tt.wantErr) {
 				t.Fatalf("finalTurnError() error = %v, want %v", err, tt.wantErr)
+			}
+			if tt.wantText != "" && !strings.Contains(err.Error(), tt.wantText) {
+				t.Fatalf("finalTurnError() error = %q, want text %q", err, tt.wantText)
 			}
 		})
 	}

--- a/internal/claudecode/process.go
+++ b/internal/claudecode/process.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"os"
 	"os/exec"
 	"strconv"
 	"strings"
@@ -38,18 +39,43 @@ func (b *AgentBackend) RunTurn(
 	procgroup.SetTempDir(cmd, req.TempDir)
 
 	stderr := newTailBuffer(b.options.StderrTailBytes)
-	cmd.Stderr = stderr
 	cmd.Stdin = strings.NewReader(req.Prompt)
 
-	stdout, err := cmd.StdoutPipe()
+	stdout, stdoutWriter, err := os.Pipe()
 	if err != nil {
 		return runner.AgentTurnResult{}, fmt.Errorf("create stdout pipe: %w", err)
 	}
+	stderrReader, stderrWriter, err := os.Pipe()
+	if err != nil {
+		return runner.AgentTurnResult{}, errors.Join(
+			fmt.Errorf("create stderr pipe: %w", err),
+			stdout.Close(),
+			stdoutWriter.Close(),
+		)
+	}
+	cmd.Stdout = stdoutWriter
+	cmd.Stderr = stderrWriter
 
 	procgroup.Configure(cmd)
 	if err := cmd.Start(); err != nil {
-		return runner.AgentTurnResult{}, fmt.Errorf("start claude command: %w", err)
+		return runner.AgentTurnResult{}, errors.Join(
+			fmt.Errorf("start claude command: %w", err),
+			stdout.Close(),
+			stdoutWriter.Close(),
+			stderrReader.Close(),
+			stderrWriter.Close(),
+		)
 	}
+	if err := errors.Join(stdoutWriter.Close(), stderrWriter.Close()); err != nil {
+		processGroupID := procgroup.GroupID(cmd)
+		err = terminateWithCause(cmd, processGroupID, fmt.Errorf("close parent output writers: %w", err))
+		return runner.AgentTurnResult{}, errors.Join(err, waitAndCleanup(cmd, processGroupID), stdout.Close(), stderrReader.Close())
+	}
+	stderrDone := make(chan error)
+	go func() {
+		_, err := io.Copy(stderr, stderrReader)
+		stderrDone <- err
+	}()
 	processGroupID := procgroup.GroupID(cmd)
 	workerProcess, err := procgroup.Inspect(cmd)
 	if err != nil {
@@ -57,7 +83,10 @@ func (b *AgentBackend) RunTurn(
 		if waitErr := waitAndCleanup(cmd, processGroupID); waitErr != nil {
 			err = errors.Join(err, waitErr)
 		}
-		return runner.AgentTurnResult{}, err
+		if stderrErr := <-stderrDone; stderrErr != nil {
+			err = errors.Join(err, fmt.Errorf("read claude stderr: %w", stderrErr))
+		}
+		return runner.AgentTurnResult{}, errors.Join(err, stdout.Close(), stderrReader.Close())
 	}
 
 	processIdentity := "claude-" + strconv.Itoa(cmd.Process.Pid)
@@ -70,11 +99,22 @@ func (b *AgentBackend) RunTurn(
 		if waitErr := waitAndCleanup(cmd, processGroupID); waitErr != nil {
 			err = errors.Join(err, fmt.Errorf("wait after terminating claude command: %w", waitErr))
 		}
-		return runner.AgentTurnResult{}, err
+		if stderrErr := <-stderrDone; stderrErr != nil {
+			err = errors.Join(err, fmt.Errorf("read claude stderr: %w", stderrErr))
+		}
+		return runner.AgentTurnResult{}, errors.Join(err, stdout.Close(), stderrReader.Close())
 	}
 
+	waitDone := make(chan error)
+	go func() {
+		waitDone <- waitAndCleanup(cmd, processGroupID)
+	}()
 	state, streamErr := b.consumeStream(ctx, cmd, processGroupID, stdout, onUpdate)
-	waitErr := waitAndCleanup(cmd, processGroupID)
+	waitErr := <-waitDone
+	if stderrErr := <-stderrDone; stderrErr != nil {
+		waitErr = errors.Join(waitErr, fmt.Errorf("read claude stderr: %w", stderrErr))
+	}
+	closeErr := errors.Join(stdout.Close(), stderrReader.Close())
 
 	result := runner.AgentTurnResult{
 		ThreadID:  state.sessionID,
@@ -83,7 +123,7 @@ func (b *AgentBackend) RunTurn(
 	}
 
 	if streamErr != nil {
-		return result, streamErr
+		return result, errors.Join(streamErr, closeErr)
 	}
 
 	finalErr := finalTurnError(ctx, state, waitErr, stderr.String())
@@ -101,10 +141,10 @@ func (b *AgentBackend) RunTurn(
 		RuntimeIdentity:     agentidentity.RuntimeUpdate(state.model, "", "", "", time.Time{}),
 		BackendErrorMessage: state.resultText,
 	}); err != nil {
-		return result, err
+		return result, errors.Join(err, closeErr)
 	}
 
-	return result, finalErr
+	return result, errors.Join(finalErr, closeErr)
 }
 
 func (b *AgentBackend) command(ctx context.Context, req runner.AgentTurnRequest) (*exec.Cmd, error) {
@@ -277,7 +317,10 @@ func finalTurnError(ctx context.Context, state turnState, waitErr error, stderr 
 		if err := ctx.Err(); err != nil {
 			return err
 		}
-		return withStderrTail(ErrMissingResult, stderr)
+		if waitErr == nil {
+			return withStderrTail(ErrMissingResult, stderr)
+		}
+		return withStderrTail(fmt.Errorf("%w: process exited: %w", ErrMissingResult, waitErr), stderr)
 	}
 
 	switch {

--- a/internal/claudecode/process_unix_test.go
+++ b/internal/claudecode/process_unix_test.go
@@ -5,6 +5,7 @@ package claudecode
 import (
 	"context"
 	"errors"
+	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -52,6 +53,69 @@ func TestRunTurnCancellationKillsChildProcessGroup(t *testing.T) {
 		t.Fatal("RunTurn() did not return after context cancellation")
 	}
 	waitForProcessExit(t, pid)
+}
+
+func TestRunTurnDetectsExitedParentWithInheritedStdout(t *testing.T) {
+	t.Parallel()
+
+	pidPath := filepath.Join(t.TempDir(), "child.pid")
+	backend := newTestBackend(t, Options{
+		CommandFactory: func(ctx context.Context) *exec.Cmd {
+			cmd := exec.CommandContext(ctx, os.Args[0], "-test.run=TestClaudeCodeDeadParentHelper", "--")
+			cmd.Env = append(os.Environ(),
+				"CLAUDECODE_DEAD_PARENT_HELPER=1",
+				"CLAUDECODE_CHILD_PID_PATH="+pidPath,
+			)
+			return cmd
+		},
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	workspace := t.TempDir()
+	errCh := make(chan error, 1)
+	go func() {
+		_, err := backend.RunTurn(ctx, runner.AgentTurnRequest{
+			Workspace: workspace,
+			Prompt:    "detect dead parent",
+			Model:     "fable",
+		}, nil)
+		errCh <- err
+	}()
+
+	pid := waitForPIDFile(t, pidPath)
+	select {
+	case err := <-errCh:
+		if !errors.Is(err, ErrMissingResult) {
+			t.Fatalf("RunTurn() error = %v, want ErrMissingResult", err)
+		}
+		if !strings.Contains(err.Error(), "process exited: exit status 9") {
+			t.Fatalf("RunTurn() error = %q, want provider exit status", err)
+		}
+	case <-time.After(time.Second):
+		cancel()
+		<-errCh
+		t.Fatal("RunTurn() did not detect the exited provider parent")
+	}
+	waitForProcessExit(t, pid)
+}
+
+func TestClaudeCodeDeadParentHelper(t *testing.T) {
+	if os.Getenv("CLAUDECODE_DEAD_PARENT_HELPER") != "1" {
+		return
+	}
+
+	cmd := exec.Command("sleep", "3600")
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	if err := cmd.Start(); err != nil {
+		os.Exit(2)
+	}
+	if err := os.WriteFile(os.Getenv("CLAUDECODE_CHILD_PID_PATH"), []byte(strconv.Itoa(cmd.Process.Pid)), 0o600); err != nil {
+		os.Exit(3)
+	}
+	fmt.Fprintln(os.Stdout, `{"type":"system","subtype":"init","session_id":"session-dead-parent","model":"fable"}`)
+	os.Exit(9)
 }
 
 func waitForPIDFile(t *testing.T, path string) int {


### PR DESCRIPTION
## Summary

- observe Claude provider-parent exit independently of stdout and stderr EOF
- reap descendants that retain inherited output descriptors so the failed attempt becomes a bounded retry
- surface the provider exit status and document the lifecycle invariant in the worker-process skill

Fixes #1335

## UI Surface Contract

- [x] N/A; this PR changes worker lifecycle behavior without changing UI layout or density.
- [x] This PR does not add persistent top-of-screen messaging.
- [x] N/A; no visual changes are included.

## Test Plan

- [x] `make check` with Detent-local test isolation via `GIT_CEILING_DIRECTORIES="$TMPDIR"` (77.4% coverage; #1336 tracks the unrelated nested-worktree cleanup fallback)
- [x] `go test -race ./internal/claudecode -count=1`
- [x] focused supervisor/orchestrator retry and filesystem git-metadata tests