### PR TITLE
test(workspace): isolate nested temp git discovery

### DIFF
--- a/internal/workspace/workspace_test.go
+++ b/internal/workspace/workspace_test.go
@@ -1064,8 +1064,8 @@ func TestLocalGitCleanupRemovesOnlyTargetWorktree(t *testing.T) {
 }
 
 func TestLocalGitCleanupRemediatesGeneratedCachePermissions(t *testing.T) {
-	t.Parallel()
 	skipWindows(t)
+	t.Setenv("GIT_CEILING_DIRECTORIES", os.TempDir())
 
 	source := initSourceRepo(t)
 	root := filepath.Join(t.TempDir(), "workspaces")


### PR DESCRIPTION
## Summary

- stop Git discovery at the Go temporary-directory boundary in the generated-cache cleanup test
- keep production cleanup and its foreign-workspace refusal behavior unchanged

Fixes #1327

## UI Surface Contract

- [x] N/A, or the linked issue explicitly authorizes any high-impact UI surface, layout, density, first-viewport, or responsive visibility tradeoff.
- [x] Persistent top-of-screen messaging is explicitly authorized by the issue, or this PR does not add it.
- [x] Visual changes to primary operator screens include screenshot or browser verification below.

## Test Plan

- [x] Focused workspace cleanup tests (`-count=3`)
- [x] `make check`