### PR TITLE
test(orchestrator): synchronize validator exhaustion log

### DIFF
--- a/internal/orchestrator/autopromote_tick_test.go
+++ b/internal/orchestrator/autopromote_tick_test.go
@@ -2831,6 +2831,7 @@ func TestTickAutoPromoteValidatorFailureExhaustionRoutesRework(t *testing.T) {
 
 	clock.Set(failure.NextRetryAt)
 	orch.tick(ctx, &state, clock.Now())
+	orch.validatorWG.Wait()
 	waitForValidatorRequests(t, validator, gate.DefaultValidatorMaxAttempts)
 	waitForValidatorResult(t, orch, issue)
 	exhausted := waitForPersistedValidatorFailure(t, memo, key, gate.DefaultValidatorMaxAttempts)


### PR DESCRIPTION
## Summary

- wait for the final validator worker to finish before asserting its exhaustion log
- preserve the existing Rework routing, persistence, PR comment, and structured log assertions

The validator worker publishes its exhausted result and persists the failure before it emits the exhaustion log. The prior waits could therefore complete while the worker was still between persistence and logging.

Fixes #1334

## UI Surface Contract

- [x] N/A, or the linked issue explicitly authorizes any high-impact UI surface, layout, density, first-viewport, or responsive visibility tradeoff.
- [x] Persistent top-of-screen messaging is explicitly authorized by the issue, or this PR does not add it.
- [x] Visual changes to primary operator screens include screenshot or browser verification below.

## Test Plan

- [x] Focused test passed 500 repeated runs
- [x] Focused race test passed 100 repeated runs
- [x] `GIT_CEILING_DIRECTORIES="$TMPDIR" make check` (77.4% coverage; #1327/#1336 track the unrelated nested-temp cleanup failure without the Git ceiling)
