### PR TITLE
test(orchestrator): harden stop-run redispatch wait

### DIFF
--- a/internal/orchestrator/stop_run_integration_test.go
+++ b/internal/orchestrator/stop_run_integration_test.go
@@ -15,6 +15,8 @@ import (
 	"github.com/digitaldrywood/detent/internal/telemetry"
 )
 
+const operatorStopIntegrationWaitTimeout = 10 * time.Second
+
 func TestStopRunTargetsOneRunAndBlocksRedispatch(t *testing.T) {
 	issue := testIssue("issue-stop", "digitaldrywood/detent#1311", "In Progress")
 	other := testIssue("issue-other", "digitaldrywood/detent#1312", "In Progress")
@@ -260,14 +262,15 @@ func (c *operatorStopFailingConnector) setError(err error) {
 
 func waitForOperatorStopRunnerIssue(t *testing.T, started <-chan orchestrator.RunRequest, issueID string) {
 	t.Helper()
-	deadline := time.After(time.Second)
+	deadline := time.NewTimer(operatorStopIntegrationWaitTimeout)
+	defer deadline.Stop()
 	for {
 		select {
 		case request := <-started:
 			if request.Issue.ID == issueID {
 				return
 			}
-		case <-deadline:
+		case <-deadline.C:
 			t.Fatalf("timed out waiting for runner issue %q", issueID)
 		}
 	}


### PR DESCRIPTION
## Summary

- extend the deterministic runner-start wait to the bounded 10-second integration-test budget
- stop the wait timer when the expected redispatch arrives
- preserve targeted cancellation and non-redispatch assertions

Fixes #1330

## UI Surface Contract

- [x] N/A, or the linked issue explicitly authorizes any high-impact UI surface, layout, density, first-viewport, or responsive visibility tradeoff.
- [x] Persistent top-of-screen messaging is explicitly authorized by the issue, or this PR does not add it.
- [x] Visual changes to primary operator screens include screenshot or browser verification below.

## Test Plan

- [x] `go test ./internal/orchestrator -run "^TestStopRunTargetsOneRunAndBlocksRedispatch$" -count=250`
- [x] `go test -race ./internal/orchestrator -run "^TestStopRunTargetsOneRunAndBlocksRedispatch$" -count=25`
- [x] Windows/amd64 orchestrator test-binary cross-compile
- [x] `GIT_CEILING_DIRECTORIES="$TMPDIR" make check`