### PR TITLE
fix(workspace): bound nested git discovery

### DIFF
--- a/internal/workspace/workspace.go
+++ b/internal/workspace/workspace.go
@@ -701,12 +701,12 @@ func (l *LocalGit) deleteBranch(ctx context.Context, branch string) (bool, error
 }
 
 func (l *LocalGit) isGitWorkspace(ctx context.Context, path string) bool {
-	output, err := runGitAt(ctx, path, "rev-parse", "--is-inside-work-tree")
+	output, err := runGitAtWithEnv(ctx, path, gitDiscoveryBoundary(path), "rev-parse", "--is-inside-work-tree")
 	return err == nil && strings.TrimSpace(output) == "true"
 }
 
 func (l *LocalGit) isSourceWorktree(ctx context.Context, path string) bool {
-	workspaceCommon, err := gitCommonDir(ctx, path)
+	workspaceCommon, err := gitCommonDirWithinRoot(ctx, path)
 	if err != nil {
 		return false
 	}
@@ -1055,8 +1055,20 @@ func runGitAtWithEnv(ctx context.Context, dir string, env []string, args ...stri
 	}
 }
 
+func gitDiscoveryBoundary(dir string) []string {
+	return []string{"GIT_CEILING_DIRECTORIES=" + filepath.Dir(dir)}
+}
+
 func gitCommonDir(ctx context.Context, dir string) (string, error) {
-	output, err := runGitAt(ctx, dir, "rev-parse", "--git-common-dir")
+	return gitCommonDirWithEnv(ctx, dir, nil)
+}
+
+func gitCommonDirWithinRoot(ctx context.Context, dir string) (string, error) {
+	return gitCommonDirWithEnv(ctx, dir, gitDiscoveryBoundary(dir))
+}
+
+func gitCommonDirWithEnv(ctx context.Context, dir string, env []string) (string, error) {
+	output, err := runGitAtWithEnv(ctx, dir, env, "rev-parse", "--git-common-dir")
 	if err != nil {
 		return "", err
 	}

--- a/internal/workspace/workspace_test.go
+++ b/internal/workspace/workspace_test.go
@@ -1067,8 +1067,10 @@ func TestLocalGitCleanupRemediatesGeneratedCachePermissions(t *testing.T) {
 	t.Parallel()
 	skipWindows(t)
 
-	source := initSourceRepo(t)
-	root := filepath.Join(t.TempDir(), "workspaces")
+	enclosing := initSourceRepo(t)
+	source := filepath.Join(enclosing, "source")
+	initSourceRepoAt(t, source)
+	root := filepath.Join(enclosing, "workspaces")
 
 	backend, err := NewBackend(KindLocalGit, LocalGitOptions{
 		Root:       root,
@@ -1110,6 +1112,59 @@ func TestLocalGitCleanupRemediatesGeneratedCachePermissions(t *testing.T) {
 	}
 	if branchExists(t, source, "detent/dd-cache-perm") {
 		t.Fatal("detent/dd-cache-perm branch still exists after cleanup")
+	}
+}
+
+func TestLocalGitRepositoryDiscoveryStaysWithinCandidate(t *testing.T) {
+	t.Parallel()
+
+	enclosing := initSourceRepo(t)
+	source := filepath.Join(enclosing, "source")
+	initSourceRepoAt(t, source)
+	sourceSubdir := filepath.Join(source, "subdir")
+	if err := os.MkdirAll(sourceSubdir, 0o700); err != nil {
+		t.Fatalf("mkdir source subdirectory: %v", err)
+	}
+	root := filepath.Join(enclosing, "workspaces")
+
+	backend, err := NewLocalGit(LocalGitOptions{
+		Root:       root,
+		SourceRoot: sourceSubdir,
+		AutoBranch: true,
+	})
+	if err != nil {
+		t.Fatalf("NewLocalGit() error = %v", err)
+	}
+	managed, err := backend.Create(context.Background(), Issue{Identifier: "DD-MANAGED"})
+	if err != nil {
+		t.Fatalf("Create() error = %v", err)
+	}
+	foreign := filepath.Join(root, "DD-FOREIGN")
+	initSourceRepoAt(t, foreign)
+	unmanaged := filepath.Join(root, "DD-UNMANAGED")
+	if err := os.MkdirAll(unmanaged, 0o700); err != nil {
+		t.Fatalf("mkdir unmanaged workspace: %v", err)
+	}
+
+	tests := []struct {
+		name       string
+		path       string
+		wantGit    bool
+		wantSource bool
+	}{
+		{name: "managed worktree", path: managed.Path, wantGit: true, wantSource: true},
+		{name: "foreign repository", path: foreign, wantGit: true, wantSource: false},
+		{name: "unmanaged nested directory", path: unmanaged, wantGit: false, wantSource: false},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if got := backend.isGitWorkspace(context.Background(), test.path); got != test.wantGit {
+				t.Errorf("isGitWorkspace() = %t, want %t", got, test.wantGit)
+			}
+			if got := backend.isSourceWorktree(context.Background(), test.path); got != test.wantSource {
+				t.Errorf("isSourceWorktree() = %t, want %t", got, test.wantSource)
+			}
+		})
 	}
 }
 
@@ -1291,6 +1346,16 @@ func initSourceRepo(t *testing.T) string {
 	t.Helper()
 
 	dir := t.TempDir()
+	initSourceRepoAt(t, dir)
+	return dir
+}
+
+func initSourceRepoAt(t *testing.T, dir string) {
+	t.Helper()
+
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		t.Fatalf("mkdir source repo: %v", err)
+	}
 	runCommand(t, dir, "git", "init", "-b", "main")
 	runGit(t, dir, "config", "core.autocrlf", "false")
 	runGit(t, dir, "config", "user.name", "Test User")
@@ -1300,8 +1365,6 @@ func initSourceRepo(t *testing.T) string {
 	}
 	runGit(t, dir, "add", "README.md")
 	runGit(t, dir, "commit", "-m", "initial")
-
-	return dir
 }
 
 func initBareRemote(t *testing.T) string {


### PR DESCRIPTION
## Summary

- Bound cleanup safety probes to the inspected repository root so Git cannot discover an unrelated enclosing checkout after partial worktree removal.
- Made the permission-remediation regression self-contained beneath an explicit enclosing repository.
- Added table-driven coverage for managed worktrees, exact foreign repositories, and unmanaged nested directories.

The root cause was unconstrained `git rev-parse` fallback discovery after `git worktree remove --force` removed the managed administrative metadata but left a read-only generated cache behind.

Fixes #1336

## UI Surface Contract

- [x] N/A, or the linked issue explicitly authorizes any high-impact UI surface, layout, density, first-viewport, or responsive visibility tradeoff.
- [x] Persistent top-of-screen messaging is explicitly authorized by the issue, or this PR does not add it.
- [x] Visual changes to primary operator screens include screenshot or browser verification below.

## Test Plan

- [x] `go test -race ./internal/workspace -run "^(TestLocalGitCleanupRemediatesGeneratedCachePermissions|TestLocalGitRepositoryDiscoveryStaysWithinCandidate|TestLocalGitCleanupRejectsForeignGitRepoWithoutBeforeRemove|TestLocalGitCreateRejectsForeignGitRepo)$" -count=10`
- [x] `go test -race ./internal/workspace -count=1`
- [x] `make check`