### PR TITLE
fix(workspace): preserve cleanup ownership

### DIFF
--- a/.detent/skills/git-worktree-removal-recovery.md
+++ b/.detent/skills/git-worktree-removal-recovery.md
@@ -1,0 +1,14 @@
+---
+name: git-worktree-removal-recovery
+description: Diagnose and safely recover Git worktree removals that fail after partially deleting managed metadata.
+when_to_use: Use when worktree cleanup fails, a managed path is misclassified after removal starts, or read-only files leave a partially removed worktree.
+---
+
+# Git worktree removal recovery
+
+- Reproduce with an isolated source repository and place its managed worktree below a different ancestor repository. Add a read-only nonempty directory so Git removal fails after starting deletion.
+- Snapshot managed ownership before `git worktree remove`; a nonzero exit does not mean Git left the worktree's `.git` pointer or registration intact.
+- After failure, inspect the remaining `.git` pointer, `git -C <source> worktree list --porcelain`, and Git discovery from the remaining path. Treat ancestor discovery as environmental evidence, not ownership.
+- Remediate permissions within the validated workspace root. Retry Git removal only while the path is still registered to the source; otherwise remove only the path whose ownership was confirmed before removal, then prune stale worktree metadata.
+- Never use post-failure Git discovery alone to authorize raw deletion. Keep tests that prove foreign repositories are refused and unchanged.
+- Make the regression deterministic with a foreign ancestor repository rather than relying on the test runner's host repository layout.

--- a/internal/workspace/workspace.go
+++ b/internal/workspace/workspace.go
@@ -726,8 +726,9 @@ func (l *LocalGit) removePath(ctx context.Context, path string) error {
 		return nil
 	}
 
+	sourceWorktree := l.isSourceWorktree(ctx, path)
 	if _, err := l.runGit(ctx, "worktree", "remove", "--force", path); err != nil {
-		if l.isSourceWorktree(ctx, path) {
+		if sourceWorktree {
 			return l.retrySourceWorktreeRemoveAfterPermissionRemediation(ctx, path, err)
 		}
 		if l.isGitWorkspace(ctx, path) {
@@ -750,6 +751,16 @@ func (l *LocalGit) retrySourceWorktreeRemoveAfterPermissionRemediation(ctx conte
 			remediation: workspaceRemovalRemediation,
 			err:         errors.Join(removeErr, fmt.Errorf("remediate workspace permissions: %w", chmodErr)),
 		}
+	}
+	if !l.isSourceWorktree(ctx, path) {
+		if retryErr := removeWorkspacePath(l.root, path); retryErr != nil {
+			return &workspaceRemovalError{
+				path:        path,
+				remediation: workspaceRemovalRemediation,
+				err:         errors.Join(removeErr, retryErr),
+			}
+		}
+		return nil
 	}
 	if _, retryErr := l.runGit(ctx, "worktree", "remove", "--force", path); retryErr != nil {
 		return &workspaceRemovalError{


### PR DESCRIPTION
## Summary

- preserve managed worktree identity before a removal can discard Git metadata
- safely remove the validated managed path after permission remediation when Git has already dropped registration
- document the reusable partial-removal debugging and recovery method as a Detent skill draft

Fixes #1342

## UI Surface Contract

- [x] N/A; this change does not affect UI surfaces or layout.
- [x] This PR does not add persistent top-of-screen messaging.
- [x] This PR has no visual changes to primary operator screens.

## Test Plan

- [x] `go test ./internal/workspace -run '^(TestLocalGitCleanupRemediatesGeneratedCachePermissions|TestLocalGitCleanupRejectsForeignGitRepoWithoutBeforeRemove|TestLocalGitRepositoryDiscoveryStaysWithinCandidate)$' -count=1 -v`
- [x] `go test ./internal/workspace -count=1`
- [x] `make check`