### PR TITLE
fix(merge): honor pull request base

### DIFF
--- a/.detent/skills/git-fetch-arbitrary-pr-base.md
+++ b/.detent/skills/git-fetch-arbitrary-pr-base.md
@@ -1,0 +1,13 @@
+---
+name: git-fetch-arbitrary-pr-base
+description: Fetch and rebase arbitrary pull request base branches safely when the source repository may use a limited fetch refspec.
+when_to_use: Use when merge preparation must support per-PR base branches that a single-branch or refspec-limited clone may not already track.
+---
+
+# Fetch an arbitrary pull request base
+
+- Read the per-PR base ref from pull request metadata; do not replace it with a repository-wide configuration value.
+- Inspect `remote.<name>.fetch` before assuming `git fetch <remote> <branch>` creates `<remote>/<branch>`. A limited fetch refspec may update only `FETCH_HEAD`.
+- Fetch into the remote-tracking ref explicitly with `git fetch <remote> +refs/heads/<branch>:refs/remotes/<remote>/<branch>`, then rebase onto `<remote>/<branch>`.
+- Reproduce missing-ref failures by limiting the remote fetch refspec to another branch and deleting the target remote-tracking ref before the fetch.
+- Cover both an explicit pull request base and the remote symbolic HEAD fallback with real-Git tests. Assert the intended base content is present and unrelated trunk content is absent.

--- a/internal/runner/agent.go
+++ b/internal/runner/agent.go
@@ -531,7 +531,11 @@ func (r *Runner) prepareMergeFastPath(
 	if !ok {
 		return RunResult{}, workspace.MergePrepareResult{}, false, nil
 	}
-	precheck, err := preparer.PrepareMerge(ctx, info, issue, workspace.MergePrepareOptions{})
+	opts := workspace.MergePrepareOptions{}
+	if req.Issue.PullRequest != nil {
+		opts.TargetBranch = strings.TrimSpace(req.Issue.PullRequest.BaseRef)
+	}
+	precheck, err := preparer.PrepareMerge(ctx, info, issue, opts)
 	if err != nil {
 		return RunResult{}, precheck, false, fmt.Errorf("merge fast-path precheck: %w", err)
 	}
@@ -566,7 +570,8 @@ func mergeFastPathCheckedHead(issue connector.Issue) bool {
 	if !strings.EqualFold(strings.TrimSpace(pullRequest.State), "open") || pullRequest.Draft {
 		return false
 	}
-	if !strings.EqualFold(strings.TrimSpace(pullRequest.MergeableState), "behind") {
+	mergeableState := strings.ToLower(strings.TrimSpace(pullRequest.MergeableState))
+	if mergeableState != "behind" && mergeableState != "clean" {
 		return false
 	}
 	if strings.TrimSpace(pullRequest.HeadSHA) == "" {

--- a/internal/runner/runner_test.go
+++ b/internal/runner/runner_test.go
@@ -1708,6 +1708,9 @@ func TestRunnerMergeModeCleanPrecheckSkipsAgent(t *testing.T) {
 			ID:         "issue-860",
 			Identifier: "digitaldrywood/detent#860",
 			BranchName: "detent/digitaldrywood_detent_860",
+			PullRequest: &connector.PullRequest{
+				BaseRef: " dev ",
+			},
 		},
 		Mode: RunModeMerge,
 	})
@@ -1719,6 +1722,9 @@ func TestRunnerMergeModeCleanPrecheckSkipsAgent(t *testing.T) {
 	}
 	if !workspaceBackend.prepareCalled {
 		t.Fatal("PrepareMerge() was not called")
+	}
+	if workspaceBackend.prepareOptions.TargetBranch != "dev" {
+		t.Fatalf("PrepareMerge() TargetBranch = %q, want dev", workspaceBackend.prepareOptions.TargetBranch)
 	}
 	if !workspaceBackend.afterRun {
 		t.Fatal("AfterRun() was not called")
@@ -1743,7 +1749,7 @@ func TestMergeFastPathCheckedHead(t *testing.T) {
 		want   bool
 	}{
 		{name: "behind green head", want: true},
-		{name: "current head", mutate: func(pr *connector.PullRequest) { pr.MergeableState = "clean" }},
+		{name: "current head", mutate: func(pr *connector.PullRequest) { pr.MergeableState = " CLEAN " }, want: true},
 		{name: "pending checks", mutate: func(pr *connector.PullRequest) { pr.CIStatus = "pending" }},
 		{name: "draft", mutate: func(pr *connector.PullRequest) { pr.Draft = true }},
 		{name: "closed", mutate: func(pr *connector.PullRequest) { pr.State = "closed" }},
@@ -3758,18 +3764,20 @@ func (b *fakeWorkspaceBackend) DiffStat(context.Context, workspace.Info, workspa
 
 type fakeMergeWorkspaceBackend struct {
 	fakeWorkspaceBackend
-	prepareResult workspace.MergePrepareResult
-	prepareErr    error
-	prepareCalled bool
+	prepareResult  workspace.MergePrepareResult
+	prepareErr     error
+	prepareCalled  bool
+	prepareOptions workspace.MergePrepareOptions
 }
 
 func (b *fakeMergeWorkspaceBackend) PrepareMerge(
-	context.Context,
-	workspace.Info,
-	workspace.Issue,
-	workspace.MergePrepareOptions,
+	_ context.Context,
+	_ workspace.Info,
+	_ workspace.Issue,
+	opts workspace.MergePrepareOptions,
 ) (workspace.MergePrepareResult, error) {
 	b.prepareCalled = true
+	b.prepareOptions = opts
 	return b.prepareResult, b.prepareErr
 }
 

--- a/internal/workspace/merge.go
+++ b/internal/workspace/merge.go
@@ -9,10 +9,7 @@ import (
 	"strings"
 )
 
-const (
-	defaultMergeRemote       = "origin"
-	defaultMergeTargetBranch = "main"
-)
+const defaultMergeRemote = "origin"
 
 func (l *LocalGit) PrepareMerge(
 	ctx context.Context,
@@ -30,13 +27,17 @@ func (l *LocalGit) PrepareMerge(
 	}
 	targetBranch := strings.TrimSpace(opts.TargetBranch)
 	if targetBranch == "" {
-		targetBranch = defaultMergeTargetBranch
+		targetBranch, err = remoteDefaultBranch(ctx, normalized.Path, remote)
+		if err != nil {
+			return MergePrepareResult{}, fmt.Errorf("resolve remote default branch: %w", err)
+		}
 	}
 	targetRef := remote + "/" + targetBranch
+	fetchRefspec := "+refs/heads/" + targetBranch + ":refs/remotes/" + targetRef
 
-	if _, err := runGitAt(ctx, normalized.Path, "fetch", remote, targetBranch); err != nil {
+	if _, err := runGitAt(ctx, normalized.Path, "fetch", remote, fetchRefspec); err != nil {
 		return MergePrepareResult{}, errors.Join(
-			fmt.Errorf("git fetch %s %s: %w", remote, targetBranch, err),
+			fmt.Errorf("git fetch %s %s: %w", remote, fetchRefspec, err),
 			abortRebaseIfInProgress(ctx, normalized.Path),
 		)
 	}
@@ -88,6 +89,24 @@ func (l *LocalGit) PrepareMerge(
 		)
 	}
 	return MergePrepareResult{Status: MergePrepareStatusClean, DiffStat: diffStat}, nil
+}
+
+func remoteDefaultBranch(ctx context.Context, workspacePath string, remote string) (string, error) {
+	output, err := runGitAt(ctx, workspacePath, "ls-remote", "--symref", remote, "HEAD")
+	if err != nil {
+		return "", err
+	}
+	for _, line := range strings.Split(output, "\n") {
+		fields := strings.Fields(line)
+		if len(fields) != 3 || fields[0] != "ref:" || fields[2] != "HEAD" {
+			continue
+		}
+		branch := strings.TrimPrefix(fields[1], "refs/heads/")
+		if branch != fields[1] && strings.TrimSpace(branch) != "" {
+			return branch, nil
+		}
+	}
+	return "", fmt.Errorf("remote %s HEAD is not a branch", remote)
 }
 
 func remoteBranchHead(ctx context.Context, workspacePath string, remote string, branch string) (string, bool, error) {

--- a/internal/workspace/workspace_test.go
+++ b/internal/workspace/workspace_test.go
@@ -291,6 +291,98 @@ func TestLocalGitPrepareMergeRebasesAndPushesCleanBranch(t *testing.T) {
 	}
 }
 
+func TestLocalGitPrepareMergeUsesDevBranch(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name          string
+		remoteDefault string
+		opts          MergePrepareOptions
+	}{
+		{name: "remote default", remoteDefault: "dev"},
+		{name: "explicit target", remoteDefault: "main", opts: MergePrepareOptions{TargetBranch: "dev"}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			testLocalGitPrepareMergeUsesDevBranch(t, tt.remoteDefault, tt.opts)
+		})
+	}
+}
+
+func testLocalGitPrepareMergeUsesDevBranch(t *testing.T, remoteDefault string, opts MergePrepareOptions) {
+	t.Helper()
+
+	source := initSourceRepo(t)
+	remote := initBareRemote(t)
+	runGit(t, source, "remote", "add", "origin", remote)
+	runGit(t, source, "push", "-u", "origin", "main")
+	runGit(t, source, "switch", "-c", "dev")
+	if err := os.WriteFile(filepath.Join(source, "dev.txt"), []byte("dev\n"), 0o600); err != nil {
+		t.Fatalf("write dev file: %v", err)
+	}
+	runGit(t, source, "add", "dev.txt")
+	runGit(t, source, "commit", "-m", "dev branch")
+	runGit(t, source, "push", "-u", "origin", "dev")
+	runGit(t, source, "config", "--replace-all", "remote.origin.fetch", "+refs/heads/main:refs/remotes/origin/main")
+	runGit(t, source, "update-ref", "-d", "refs/remotes/origin/dev")
+	runGit(t, remote, "symbolic-ref", "HEAD", "refs/heads/"+remoteDefault)
+
+	root := filepath.Join(t.TempDir(), "workspaces")
+	backend, err := NewBackend(KindLocalGit, LocalGitOptions{
+		Root:       root,
+		SourceRoot: source,
+		AutoBranch: true,
+	})
+	if err != nil {
+		t.Fatalf("NewBackend() error = %v", err)
+	}
+	preparer, ok := backend.(MergePreparer)
+	if !ok {
+		t.Fatal("backend does not implement MergePreparer")
+	}
+	issue := Issue{Identifier: "DD-DEFAULT-BRANCH"}
+	info, err := backend.Create(context.Background(), issue)
+	if err != nil {
+		t.Fatalf("Create() error = %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(info.Path, "feature.txt"), []byte("feature\n"), 0o600); err != nil {
+		t.Fatalf("write feature: %v", err)
+	}
+	runGit(t, info.Path, "add", "feature.txt")
+	runGit(t, info.Path, "commit", "-m", "feature")
+	runGit(t, info.Path, "push", "origin", "HEAD:"+info.Branch)
+
+	runGit(t, source, "switch", "main")
+	if err := os.WriteFile(filepath.Join(source, "main-latest.txt"), []byte("main\n"), 0o600); err != nil {
+		t.Fatalf("write latest main file: %v", err)
+	}
+	runGit(t, source, "add", "main-latest.txt")
+	runGit(t, source, "commit", "-m", "main latest")
+	runGit(t, source, "push", "origin", "main")
+	runGit(t, source, "switch", "dev")
+	if err := os.WriteFile(filepath.Join(source, "dev-latest.txt"), []byte("dev latest\n"), 0o600); err != nil {
+		t.Fatalf("write latest dev file: %v", err)
+	}
+	runGit(t, source, "add", "dev-latest.txt")
+	runGit(t, source, "commit", "-m", "dev latest")
+	runGit(t, source, "push", "origin", "dev")
+
+	result, err := preparer.PrepareMerge(context.Background(), info, issue, opts)
+	if err != nil {
+		t.Fatalf("PrepareMerge() error = %v", err)
+	}
+	if result.Status != MergePrepareStatusClean {
+		t.Fatalf("PrepareMerge() status = %q, want clean", result.Status)
+	}
+	if got := readFile(t, filepath.Join(info.Path, "dev-latest.txt")); got != "dev latest\n" {
+		t.Fatalf("dev-latest.txt = %q, want rebased dev file", got)
+	}
+	if _, err := os.Stat(filepath.Join(info.Path, "main-latest.txt")); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("main-latest.txt stat error = %v, want file absent", err)
+	}
+}
+
 func TestLocalGitPrepareMergeAbortsConflictingRebase(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

- pass each pull request base ref into merge preparation
- resolve the remote default branch when the PR base is unavailable
- populate remote-tracking refs explicitly for single-branch clones
- preserve green CLEAN heads without rebasing and cover non-main trunks with real-Git regressions
- document the reusable arbitrary-base fetch workflow as a candidate Detent skill

Fixes #1331

## UI Surface Contract

- [x] N/A, or the linked issue explicitly authorizes any high-impact UI surface, layout, density, first-viewport, or responsive visibility tradeoff.
- [x] Persistent top-of-screen messaging is explicitly authorized by the issue, or this PR does not add it.
- [x] Visual changes to primary operator screens include screenshot or browser verification below.

## Test Plan

- [x] `go test ./internal/runner -run '^(TestRunnerMergeModeCleanPrecheckSkipsAgent|TestMergeFastPathCheckedHead)$' -count=1`
- [x] `go test ./internal/workspace -run '^(TestLocalGitPrepareMergeRebasesAndPushesCleanBranch|TestLocalGitPrepareMergeUsesDevBranch|TestLocalGitPrepareMergeAbortsConflictingRebase)$' -count=1`
- [x] `go test ./internal/skills -count=1`
- [x] `make check`