### PR TITLE
fix(board): hide scheduled recovery pacing

### DIFF
--- a/internal/web/demo_scenarios.go
+++ b/internal/web/demo_scenarios.go
@@ -140,6 +140,8 @@ func demoScenarioDefinitions() []demoScenario {
 		{ID: "fleet-kanban-multiproject", Route: "/", WaitSelector: "#board-lanes", Page: "fleet-kanban", Variant: "dense-kanban", KanbanMode: workflowconfig.KanbanModeReadOnly},
 		{ID: "fleet-kanban-blocked-alerts", Route: "/", WaitSelector: "#board-lanes", Page: "fleet-kanban", Variant: "healthy", KanbanMode: workflowconfig.KanbanModeReadOnly, ShowBlockedAlerts: true},
 		{ID: "board-ramp-active-recoveries", Route: "/", WaitSelector: "#board-lanes", Page: "fleet-kanban", Variant: "board-ramp-active-recoveries", KanbanMode: workflowconfig.KanbanModeReadOnly},
+		{ID: "board-scheduled-pacing", Route: "/", WaitSelector: "#board-lanes", Page: "fleet-kanban", Variant: "board-scheduled-pacing", KanbanMode: workflowconfig.KanbanModeReadOnly},
+		{ID: "health-scheduled-pacing", Route: "/health/ui", WaitSelector: "#dispatch-recovery-status", Page: "health", Variant: "board-scheduled-pacing"},
 		{ID: "board-degraded-health-banners", Route: "/", WaitSelector: "#board-lanes", Page: "fleet-kanban", Variant: "board-degraded-health-banners", KanbanMode: workflowconfig.KanbanModeReadOnly},
 		{ID: "health-dispatch-recoveries", Route: "/health/ui", WaitSelector: "#dispatch-recovery-status", Page: "health", Variant: "board-degraded-health-banners"},
 		{ID: "fleet-kanban-external-lane-timer", Route: "/", WaitSelector: "#board-lanes", Page: "fleet-kanban", Variant: "external-lane-timer", KanbanMode: workflowconfig.KanbanModeReadOnly, HideFromManifest: true},

--- a/internal/web/demofixtures/fixtures.go
+++ b/internal/web/demofixtures/fixtures.go
@@ -76,6 +76,8 @@ func SnapshotForScenario(id string, variant string) telemetry.Snapshot {
 		snapshot = demoBackendCapacityOutageSnapshot()
 	case "board-ramp-active-recoveries":
 		snapshot = demoBoardRampActiveRecoveriesSnapshot()
+	case "board-scheduled-pacing":
+		snapshot = demoBoardScheduledPacingSnapshot()
 	case "board-degraded-health-banners":
 		snapshot = demoBoardDegradedHealthBannersSnapshot()
 	}
@@ -376,6 +378,26 @@ func demoBoardRampActiveRecoveriesSnapshot() telemetry.Snapshot {
 	return snapshot
 }
 
+func demoBoardScheduledPacingSnapshot() telemetry.Snapshot {
+	snapshot := demoHealthySnapshot()
+	now := snapshot.GeneratedAt
+	snapshot.DispatchRecoveries = []telemetry.DispatchRecovery{
+		{ProjectID: demoPrimaryProjectID, Kind: "github_rest", Reason: "remaining 288 at or below dispatch floor", Status: "waiting", StartedAt: now.Add(-3 * time.Minute), ResumeAt: now.Add(14 * time.Minute), MaxConcurrent: 6},
+		{ProjectID: "docs-site", Kind: "github_rest", Reason: "remaining 296 at or below dispatch floor", Status: "waiting", StartedAt: now.Add(-2 * time.Minute), ResumeAt: now.Add(14 * time.Minute), MaxConcurrent: 6},
+		{ProjectID: "billing-api", Kind: "pull_request_hydration", Reason: "rest_budget_reserved", Status: "waiting", StartedAt: now.Add(-time.Minute), ResumeAt: now.Add(14 * time.Minute), MaxConcurrent: 6},
+	}
+	snapshot.BackendOutages = []telemetry.BackendOutage{{
+		BackendID:   "github-rest",
+		BackendKind: "tracker",
+		Provider:    "github",
+		Kind:        "github_rest_rate_limit",
+		Reason:      "GitHub REST remaining 288 is at or below dispatch floor 1000",
+		DetectedAt:  now.Add(-3 * time.Minute),
+		ResumeAt:    now.Add(14 * time.Minute),
+	}}
+	return snapshot
+}
+
 func demoBoardDegradedHealthBannersSnapshot() telemetry.Snapshot {
 	snapshot := demoHealthySnapshot()
 	now := snapshot.GeneratedAt
@@ -385,7 +407,7 @@ func demoBoardDegradedHealthBannersSnapshot() telemetry.Snapshot {
 	}
 	snapshot.DispatchRecoveries = []telemetry.DispatchRecovery{
 		{ProjectID: demoPrimaryProjectID, Kind: "github_rest", Reason: "primary quota exhausted", Status: "waiting", StartedAt: now.Add(-3 * time.Minute), ResumeAt: now.Add(20 * time.Minute), MaxConcurrent: 6},
-		{ProjectID: "docs-site", Kind: "github_rest", Reason: "primary quota exhausted", Status: "waiting", StartedAt: now.Add(-2 * time.Minute), ResumeAt: now.Add(20 * time.Minute), MaxConcurrent: 6},
+		{ProjectID: "docs-site", Kind: "github_rest", Reason: "automatic retry did not recover", Status: "waiting", StartedAt: now.Add(-12 * time.Minute), ResumeAt: now.Add(-2 * time.Minute), MaxConcurrent: 6},
 		{ProjectID: "billing-api", Kind: "backend_capacity", Status: "ramping", StartedAt: now.Add(-time.Minute), Limit: 1, MaxConcurrent: 6, Admitted: 1},
 	}
 	resumeAt := now.Add(30 * time.Minute)

--- a/internal/web/templates/board.templ
+++ b/internal/web/templates/board.templ
@@ -57,13 +57,13 @@ templ boardSnapshotBody(data DashboardData) {
 			@boardFailureBreakerBanner(failureSummary)
 		</div>
 	}
-	{{ recoverySummaries := boardDispatchRecoverySummaries(data.Snapshot.DispatchRecoveries) }}
+	{{ recoverySummaries := boardDispatchRecoverySummaries(data.Snapshot.DispatchRecoveries, data.Snapshot.GeneratedAt) }}
 	if len(recoverySummaries) > 0 {
 		<div class="flex-none px-5 pt-3.5">
 			@boardDispatchRecoveryBanner(recoverySummaries)
 		</div>
 	}
-	{{ capacitySummaries := boardBackendCapacitySummaries(data.Snapshot.BackendOutages) }}
+	{{ capacitySummaries := boardBackendCapacitySummaries(data.Snapshot.BackendOutages, data.Snapshot.GeneratedAt) }}
 	if len(capacitySummaries) > 0 {
 		<div class="flex-none px-5 pt-3.5">
 			@boardBackendCapacityBanner(capacitySummaries)

--- a/internal/web/templates/board_data_test.go
+++ b/internal/web/templates/board_data_test.go
@@ -1687,7 +1687,6 @@ func TestBoardSnapshotRendersBackendCapacityBanner(t *testing.T) {
 	t.Parallel()
 
 	data := boardTestData()
-	nextProbeAt := data.Snapshot.GeneratedAt.Add(5 * time.Minute)
 	lastProbeAt := data.Snapshot.GeneratedAt.Add(-time.Minute)
 	data.Snapshot.BackendOutages = []telemetry.BackendOutage{{
 		ProjectID:       "detent",
@@ -1695,8 +1694,6 @@ func TestBoardSnapshotRendersBackendCapacityBanner(t *testing.T) {
 		BackendKind:     "codex",
 		Provider:        "openai",
 		Reason:          "provider usage limit reached",
-		ResumeAt:        data.Snapshot.GeneratedAt.Add(44 * time.Minute),
-		NextProbeAt:     &nextProbeAt,
 		LastProbeAt:     &lastProbeAt,
 		LastProbeResult: "capacity_exhausted",
 		LastProbeDetail: "provider usage limit reached",
@@ -1714,6 +1711,100 @@ func TestBoardSnapshotRendersBackendCapacityBanner(t *testing.T) {
 		if strings.Contains(html, unwanted) {
 			t.Fatalf("capacity summary contains detail %q:\n%s", unwanted, html)
 		}
+	}
+}
+
+func TestBoardSnapshotHidesScheduledPacingStates(t *testing.T) {
+	t.Parallel()
+
+	data := boardTestData()
+	data.Snapshot.DispatchRecoveries = []telemetry.DispatchRecovery{
+		{ProjectID: "detent", Kind: "github_rest", Status: "waiting", ResumeAt: data.Snapshot.GeneratedAt.Add(14 * time.Minute)},
+		{ProjectID: "docs", Kind: "pull_request_hydration", Reason: "rest_budget_reserved", Status: "waiting", ResumeAt: data.Snapshot.GeneratedAt.Add(14 * time.Minute)},
+	}
+	data.Snapshot.BackendOutages = []telemetry.BackendOutage{{
+		Kind:     "github_rest_rate_limit",
+		Reason:   "GitHub REST remaining is at or below dispatch floor",
+		ResumeAt: data.Snapshot.GeneratedAt.Add(14 * time.Minute),
+	}}
+
+	html := renderBoardComponent(t, BoardSnapshot(data))
+	for _, unwanted := range []string{`id="dispatch-recovery-status"`, `id="backend-capacity-outage"`, "rest_budget_reserved"} {
+		if strings.Contains(html, unwanted) {
+			t.Fatalf("scheduled pacing state rendered Board banner %q:\n%s", unwanted, html)
+		}
+	}
+	if !strings.Contains(html, `id="board-figures"`) || !strings.Contains(html, `id="board-lanes"`) {
+		t.Fatalf("Board content missing after pacing banners were hidden:\n%s", html)
+	}
+}
+
+func TestBoardSnapshotEscalatesStuckAutomaticRecovery(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		prepare  func(*DashboardData)
+		wantID   string
+		wantText string
+	}{
+		{
+			name: "dispatch retry overdue",
+			prepare: func(data *DashboardData) {
+				data.Snapshot.DispatchRecoveries = []telemetry.DispatchRecovery{{
+					ProjectID: "detent",
+					Kind:      "github_rest",
+					Status:    "waiting",
+					ResumeAt:  data.Snapshot.GeneratedAt.Add(-2 * time.Minute),
+				}}
+			},
+			wantID:   `id="dispatch-recovery-status"`,
+			wantText: "Dispatch retry overdue for GitHub REST capacity",
+		},
+		{
+			name: "capacity probe overdue",
+			prepare: func(data *DashboardData) {
+				nextProbeAt := data.Snapshot.GeneratedAt.Add(-2 * time.Minute)
+				data.Snapshot.BackendOutages = []telemetry.BackendOutage{{
+					ProjectID:   "detent",
+					BackendID:   "codex",
+					ResumeAt:    data.Snapshot.GeneratedAt.Add(-10 * time.Minute),
+					NextProbeAt: &nextProbeAt,
+				}}
+			},
+			wantID:   `id="backend-capacity-outage"`,
+			wantText: "Backend codex recovery overdue",
+		},
+		{
+			name: "repeated capacity probes",
+			prepare: func(data *DashboardData) {
+				nextProbeAt := data.Snapshot.GeneratedAt.Add(10 * time.Minute)
+				data.Snapshot.BackendOutages = []telemetry.BackendOutage{{
+					ProjectID:       "detent",
+					BackendID:       "codex",
+					ResumeAt:        data.Snapshot.GeneratedAt.Add(10 * time.Minute),
+					NextProbeAt:     &nextProbeAt,
+					LastProbeResult: "capacity_exhausted",
+					ProbeAttempts:   3,
+				}}
+			},
+			wantID:   `id="backend-capacity-outage"`,
+			wantText: "Backend codex recovery failed repeatedly",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			data := boardTestData()
+			tt.prepare(&data)
+			html := renderBoardComponent(t, BoardSnapshot(data))
+			for _, want := range []string{tt.wantID, tt.wantText} {
+				if !strings.Contains(html, want) {
+					t.Fatalf("stuck recovery banner missing %q:\n%s", want, html)
+				}
+			}
+		})
 	}
 }
 
@@ -1853,7 +1944,6 @@ func TestBoardSnapshotRendersGitHubRESTCapacityBanner(t *testing.T) {
 		Provider:    "github",
 		Kind:        "github_rest_rate_limit",
 		Reason:      "GitHub REST remaining 0 is at or below dispatch floor 1000",
-		ResumeAt:    data.Snapshot.GeneratedAt.Add(44 * time.Minute),
 	}}
 	html := renderBoardComponent(t, BoardSnapshot(data))
 	for _, want := range []string{

--- a/internal/web/templates/board_templ.go
+++ b/internal/web/templates/board_templ.go
@@ -184,7 +184,7 @@ func boardSnapshotBody(data DashboardData) templ.Component {
 				return templ_7745c5c3_Err
 			}
 		}
-		recoverySummaries := boardDispatchRecoverySummaries(data.Snapshot.DispatchRecoveries)
+		recoverySummaries := boardDispatchRecoverySummaries(data.Snapshot.DispatchRecoveries, data.Snapshot.GeneratedAt)
 		if len(recoverySummaries) > 0 {
 			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 8, "<div class=\"flex-none px-5 pt-3.5\">")
 			if templ_7745c5c3_Err != nil {
@@ -199,7 +199,7 @@ func boardSnapshotBody(data DashboardData) templ.Component {
 				return templ_7745c5c3_Err
 			}
 		}
-		capacitySummaries := boardBackendCapacitySummaries(data.Snapshot.BackendOutages)
+		capacitySummaries := boardBackendCapacitySummaries(data.Snapshot.BackendOutages, data.Snapshot.GeneratedAt)
 		if len(capacitySummaries) > 0 {
 			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 10, "<div class=\"flex-none px-5 pt-3.5\">")
 			if templ_7745c5c3_Err != nil {

--- a/internal/web/templates/dashboard_data.go
+++ b/internal/web/templates/dashboard_data.go
@@ -27,6 +27,8 @@ import (
 const (
 	throughputTrendWindow        = 10 * time.Minute
 	defaultThroughputWindow      = time.Minute
+	boardRecoveryOverdueGrace    = time.Minute
+	boardRecoveryFailureAttempts = 3
 	prPipelineDoneTodayLimit     = 10
 	prPipelineMergeSummaryWindow = 24 * time.Hour
 	prPipelineActiveMergeTarget  = 5 * time.Minute
@@ -6509,7 +6511,37 @@ func boardFailureBreakerSummary(breakers []telemetry.FailureBreaker) (boardBanne
 	}, true
 }
 
-func boardDispatchRecoverySummaries(recoveries []telemetry.DispatchRecovery) []boardBannerSummary {
+func boardDispatchRecoverySummaries(recoveries []telemetry.DispatchRecovery, now time.Time) []boardBannerSummary {
+	return dispatchRecoverySummaries(recoveries, func(recovery telemetry.DispatchRecovery) (string, bool) {
+		status := strings.TrimSpace(recovery.Status)
+		switch status {
+		case "ramping":
+			return "", false
+		case "waiting":
+			if automaticRecoveryPending(recovery.ResumeAt, now) {
+				return "", false
+			}
+			kind := dispatchRecoveryKindLabel(recovery.Kind)
+			if automaticRecoveryOverdue(recovery.ResumeAt, now) {
+				return "Dispatch retry overdue for " + kind, true
+			}
+			return "Dispatch waiting on " + kind, true
+		default:
+			return "Dispatch recovery requires attention for " + dispatchRecoveryKindLabel(recovery.Kind), true
+		}
+	})
+}
+
+func healthDispatchRecoverySummaries(recoveries []telemetry.DispatchRecovery) []boardBannerSummary {
+	return dispatchRecoverySummaries(recoveries, func(recovery telemetry.DispatchRecovery) (string, bool) {
+		if strings.TrimSpace(recovery.Status) != "waiting" {
+			return "", false
+		}
+		return "Dispatch waiting on " + dispatchRecoveryKindLabel(recovery.Kind), true
+	})
+}
+
+func dispatchRecoverySummaries(recoveries []telemetry.DispatchRecovery, selectTitle func(telemetry.DispatchRecovery) (string, bool)) []boardBannerSummary {
 	type group struct {
 		title    string
 		projects map[string]struct{}
@@ -6518,13 +6550,14 @@ func boardDispatchRecoverySummaries(recoveries []telemetry.DispatchRecovery) []b
 	groups := make(map[string]*group)
 	order := make([]string, 0)
 	for _, recovery := range recoveries {
-		if strings.TrimSpace(recovery.Status) != "waiting" {
+		title, selected := selectTitle(recovery)
+		if !selected {
 			continue
 		}
-		key := strings.TrimSpace(recovery.Kind)
+		key := strings.TrimSpace(recovery.Kind) + "\x00" + title
 		if _, ok := groups[key]; !ok {
 			groups[key] = &group{
-				title:    "Dispatch waiting on " + dispatchRecoveryKindLabel(recovery.Kind),
+				title:    title,
 				projects: make(map[string]struct{}),
 			}
 			order = append(order, key)
@@ -6550,7 +6583,7 @@ func boardDispatchRecoverySummaries(recoveries []telemetry.DispatchRecovery) []b
 	return summaries
 }
 
-func boardBackendCapacitySummaries(outages []telemetry.BackendOutage) []boardBannerSummary {
+func boardBackendCapacitySummaries(outages []telemetry.BackendOutage, now time.Time) []boardBannerSummary {
 	type group struct {
 		title    string
 		projects map[string]struct{}
@@ -6559,7 +6592,10 @@ func boardBackendCapacitySummaries(outages []telemetry.BackendOutage) []boardBan
 	groups := make(map[string]*group)
 	order := make([]string, 0)
 	for _, outage := range backendCapacityOutageDetails(outages) {
-		title := backendCapacityOutageTitle(outage)
+		title, selected := boardBackendCapacityTitle(outage, now)
+		if !selected {
+			continue
+		}
 		if _, ok := groups[title]; !ok {
 			groups[title] = &group{title: title, projects: make(map[string]struct{})}
 			order = append(order, title)
@@ -6583,6 +6619,35 @@ func boardBackendCapacitySummaries(outages []telemetry.BackendOutage) []boardBan
 		})
 	}
 	return summaries
+}
+
+func boardBackendCapacityTitle(outage telemetry.BackendOutage, now time.Time) (string, bool) {
+	if strings.TrimSpace(outage.ProbeIssueID) != "" {
+		return "", false
+	}
+	backend := backendCapacityBackendID(outage)
+	if outage.ProbeAttempts >= boardRecoveryFailureAttempts {
+		return "Backend " + backend + " recovery failed repeatedly", true
+	}
+	resumeAt := outage.ResumeAt
+	if outage.NextProbeAt != nil && !outage.NextProbeAt.IsZero() {
+		resumeAt = *outage.NextProbeAt
+	}
+	if automaticRecoveryPending(resumeAt, now) {
+		return "", false
+	}
+	if automaticRecoveryOverdue(resumeAt, now) {
+		return "Backend " + backend + " recovery overdue", true
+	}
+	return backendCapacityOutageTitle(outage), true
+}
+
+func automaticRecoveryPending(resumeAt time.Time, now time.Time) bool {
+	return !resumeAt.IsZero() && !now.IsZero() && now.Before(resumeAt.Add(boardRecoveryOverdueGrace))
+}
+
+func automaticRecoveryOverdue(resumeAt time.Time, now time.Time) bool {
+	return !resumeAt.IsZero() && !now.IsZero() && !now.Before(resumeAt.Add(boardRecoveryOverdueGrace))
 }
 
 func boardAffectedProjectCount(entries int, projectIDs func(func(string))) int {

--- a/internal/web/templates/health_data.go
+++ b/internal/web/templates/health_data.go
@@ -68,7 +68,7 @@ func healthViewFromDashboard(data DashboardData) healthView {
 		view.Detail = "Dispatch remains paused until a canary succeeds."
 		return view
 	}
-	if summaries := boardDispatchRecoverySummaries(snapshot.DispatchRecoveries); len(summaries) > 0 {
+	if summaries := healthDispatchRecoverySummaries(snapshot.DispatchRecoveries); len(summaries) > 0 {
 		details := make([]string, 0, len(summaries))
 		for _, summary := range summaries {
 			details = append(details, summary.Title)

--- a/internal/web/templates/health_data_test.go
+++ b/internal/web/templates/health_data_test.go
@@ -104,7 +104,7 @@ func TestBackendCapacityProjectDetailDoesNotInflateVerdict(t *testing.T) {
 	if view.Verdict != "Backend codex at usage limit." {
 		t.Fatalf("verdict = %q, want one backend outage", view.Verdict)
 	}
-	summaries := boardBackendCapacitySummaries(snapshot.BackendOutages)
+	summaries := boardBackendCapacitySummaries(snapshot.BackendOutages, time.Time{})
 	if len(summaries) != 1 || summaries[0].Title != "Backend codex at usage limit — 2 projects" {
 		t.Fatalf("Board summaries = %#v", summaries)
 	}

--- a/internal/web/templates/shell_data.go
+++ b/internal/web/templates/shell_data.go
@@ -83,12 +83,17 @@ func appShellActiveNav(data DashboardShellData) string {
 
 func appShellHealthKind(data DashboardShellData) primitives.Kind {
 	switch gitHubAPIHealth(data.Snapshot).State {
-	case gitHubAPIHealthStateHealthy, gitHubAPIHealthStateAtRest:
-		return primitives.KindOK
-	case gitHubAPIHealthStateWarning:
-		return primitives.KindWarn
 	case gitHubAPIHealthStateBackoff, gitHubAPIHealthStateExhausted:
 		return primitives.KindErr
+	case gitHubAPIHealthStateWarning:
+		return primitives.KindWarn
+	}
+	if len(data.Snapshot.BackendOutages) > 0 || len(data.Snapshot.FailureBreakers) > 0 || len(data.Snapshot.DispatchRecoveries) > 0 {
+		return primitives.KindWarn
+	}
+	switch gitHubAPIHealth(data.Snapshot).State {
+	case gitHubAPIHealthStateHealthy, gitHubAPIHealthStateAtRest:
+		return primitives.KindOK
 	}
 	return primitives.KindNeutral
 }

--- a/internal/web/templates/shell_data_test.go
+++ b/internal/web/templates/shell_data_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/digitaldrywood/detent/internal/telemetry"
+	"github.com/digitaldrywood/detent/internal/web/ui/primitives"
 )
 
 func TestAppShellScriptRefreshesOpenDetailSheetAfterSnapshotSettle(t *testing.T) {
@@ -102,6 +103,44 @@ func TestAppShellNavGroupsOrderAndActiveState(t *testing.T) {
 	}
 	if !healthDot {
 		t.Fatalf("health nav item should carry the status dot")
+	}
+}
+
+func TestAppShellHealthKindReflectsScheduledPacing(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 7, 16, 15, 0, 0, 0, time.UTC)
+	tests := []struct {
+		name     string
+		snapshot telemetry.Snapshot
+	}{
+		{
+			name: "scheduled dispatch recovery",
+			snapshot: telemetry.Snapshot{
+				GeneratedAt: now,
+				DispatchRecoveries: []telemetry.DispatchRecovery{{
+					Kind: "github_rest", Status: "waiting", ResumeAt: now.Add(10 * time.Minute),
+				}},
+			},
+		},
+		{
+			name: "scheduled capacity resume",
+			snapshot: telemetry.Snapshot{
+				GeneratedAt: now,
+				BackendOutages: []telemetry.BackendOutage{{
+					BackendID: "github-rest", Kind: "github_rest_rate_limit", ResumeAt: now.Add(10 * time.Minute),
+				}},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := appShellHealthKind(DashboardShellData{Snapshot: tt.snapshot}); got != primitives.KindWarn {
+				t.Fatalf("appShellHealthKind() = %q, want %q", got, primitives.KindWarn)
+			}
+		})
 	}
 }
 

--- a/tests/visual/layout.spec.js
+++ b/tests/visual/layout.spec.js
@@ -338,7 +338,29 @@ test("board hides informational recovery and overload notices", async ({
   );
 });
 
-test("board collapses degraded health banners by kind", async ({ page }) => {
+test("board hides scheduled pacing while health retains its signal", async ({
+  page,
+}) => {
+  await openScenario(page, {
+    runtime: screenshotsRuntime,
+    scenario: "board-scheduled-pacing",
+    route: "/",
+    waitSelector: "#board-lanes",
+    viewport: desktopViewport,
+  });
+
+  await expect(page.locator("#dispatch-recovery-status")).toHaveCount(0);
+  await expect(page.locator("#backend-capacity-outage")).toHaveCount(0);
+  await expect(page.locator("#snapshot > :visible").first()).toHaveAttribute(
+    "id",
+    "board-figures",
+  );
+  await expect(
+    page.locator('[data-sidebar-nav-item="health"] .bg-warn'),
+  ).toBeVisible();
+});
+
+test("board shows only health states needing attention", async ({ page }) => {
   await openScenario(page, {
     runtime: screenshotsRuntime,
     scenario: "board-degraded-health-banners",
@@ -352,19 +374,14 @@ test("board collapses degraded health banners by kind", async ({ page }) => {
   const capacity = page.locator("#backend-capacity-outage");
   await expect(failure).toHaveCount(1);
   await expect(recovery).toHaveCount(1);
-  await expect(capacity).toHaveCount(1);
+  await expect(capacity).toHaveCount(0);
   await expect(failure).toHaveClass(/border-warn/);
   await expect(recovery).toHaveClass(/border-warn/);
-  await expect(capacity).toHaveClass(/border-warn/);
   await expect(failure.locator("p")).toHaveCount(1);
   await expect(recovery.locator("p")).toHaveCount(1);
-  await expect(capacity.locator("p")).toHaveCount(1);
   await expect(failure).toContainText("2 projects");
   await expect(recovery).toContainText(
-    "Dispatch waiting on GitHub REST capacity — 2 projects",
-  );
-  await expect(capacity).toContainText(
-    "Backend codex at usage limit — 2 projects",
+    "Dispatch retry overdue for GitHub REST capacity — 1 project",
   );
   await expect(page.locator("#backend-overload-retries")).toHaveCount(0);
   await expect(page.locator("#snapshot")).not.toContainText(
@@ -1022,6 +1039,35 @@ test("health keeps full waiting and ramp recovery detail", async ({ page }) => {
   await expect(page.locator("#backend-overload-retries")).toContainText(
     "3 overload retries last hour",
   );
+});
+
+test("health keeps full scheduled pacing detail hidden from the board", async ({
+  page,
+}) => {
+  await openScenario(page, {
+    runtime: screenshotsRuntime,
+    scenario: "health-scheduled-pacing",
+    route: "/health/ui",
+    waitSelector: "#dispatch-recovery-status",
+    viewport: desktopViewport,
+  });
+
+  const recoveries = page.locator("#dispatch-recovery-status");
+  await expect(
+    recoveries.getByText("Dispatch waiting on GitHub REST capacity", {
+      exact: true,
+    }),
+  ).toHaveCount(2);
+  await expect(recoveries).toContainText(
+    "remaining 288 at or below dispatch floor",
+  );
+  await expect(recoveries).toContainText("rest_budget_reserved");
+  await expect(page.locator("#backend-capacity-outage")).toContainText(
+    "GitHub REST dispatch paused",
+  );
+  await expect(
+    page.locator('[data-sidebar-nav-item="health"] .bg-warn'),
+  ).toBeVisible();
 });
 
 test("project overview renders tabs, hero, and recent runs", async ({


### PR DESCRIPTION
## Summary

- hide future-scheduled dispatch waits and capacity pauses from the Board while retaining complete Health detail
- escalate overdue retries, repeated capacity probe failures, unscheduled outages, breakers, and terminal recovery states through warning banners
- keep the Health navigation signal active for pacing states hidden from the Board

Fixes #1349

## UI Surface Contract

- [x] The linked issue explicitly authorizes removal of routine pacing banners from the Board first viewport.
- [x] This PR removes informational persistent messaging and adds no new persistent top-of-screen messaging.
- [x] Visual changes to primary operator screens were verified with focused and full Playwright coverage.

## Test Plan

- [x] `make check`
- [x] `make visual-e2e` (78 passed, 31 expected skips)
- [x] focused Board and Health Playwright acceptance scenarios