### PR TITLE
fix(workspace): reduce Git subprocess pressure

### DIFF
--- a/.detent/skills/subprocess-pressure-tracing.md
+++ b/.detent/skills/subprocess-pressure-tracing.md
@@ -1,0 +1,15 @@
+---
+name: subprocess-pressure-tracing
+description: Measure subprocess fan-out behind intermittent crashes, fork/exec hangs, and orphaned child processes.
+when_to_use: Use when focused tests pass but concurrent or race suites intermittently crash or hang an external command.
+---
+
+# Trace subprocess pressure
+
+- Put a temporary executable with the same name as the target command first on `PATH`. Keep it under the Detent-provided temporary directory and have it append PID, timestamp, and arguments to a trace file before `exec` replaces it with the absolute real executable.
+- Run the smallest concurrent package set that has exhibited the failure. Do not add retries or sleeps; preserve the original test scheduling and race settings.
+- Group trace entries by normalized arguments and caller scenario. Separate required integration commands from accidental discovery against fake workspaces or ancestor repositories.
+- Correlate the trace with the full failing log or stack. A failure in a later test-helper command after the production call succeeded indicates environmental process instability, not necessarily invalid fixture lifecycle.
+- Prefer eliminating launches: reject non-target paths before spawning, bound repository discovery, and combine read-only queries into one command when the tool supports it.
+- Repeat the same traced command after the change and record before/after launch counts. Then remove the tracing wrapper from `PATH` and run focused race repetitions plus the full validation gate.
+- Keep real integration coverage for the external tool's observable behavior; replace only redundant setup or expectation commands with direct fixture facts when those facts are independently known.

--- a/internal/workspace/workspace.go
+++ b/internal/workspace/workspace.go
@@ -1099,15 +1099,18 @@ func GitMetadataWritableRoots(ctx context.Context, workspacePath string) ([]stri
 	if err != nil {
 		return nil, fmt.Errorf("workspace path: %w", err)
 	}
-	commonDir, err := gitCommonDir(ctx, workspaceRoot)
+	if _, err := os.Lstat(filepath.Join(workspaceRoot, ".git")); err != nil {
+		return nil, fmt.Errorf("workspace git metadata: %w", err)
+	}
+	metadata, err := inspectGitMetadata(ctx, workspaceRoot)
 	if err != nil {
-		return nil, fmt.Errorf("git common dir: %w", err)
+		return nil, err
 	}
 
 	roots := []string{}
 	seen := map[string]struct{}{}
 	addRoot := func(path string) {
-		if path == "" || path == commonDir || pathWithin(workspaceRoot, path) || !pathWithin(commonDir, path) {
+		if path == "" || path == metadata.commonDir || pathWithin(workspaceRoot, path) || !pathWithin(metadata.commonDir, path) {
 			return
 		}
 		if _, ok := seen[path]; ok {
@@ -1117,45 +1120,19 @@ func GitMetadataWritableRoots(ctx context.Context, workspacePath string) ([]stri
 		roots = append(roots, path)
 	}
 
-	gitDir, err := gitDir(ctx, workspaceRoot)
-	if err != nil {
-		return nil, fmt.Errorf("git dir: %w", err)
-	}
-	addRoot(gitDir)
-
-	objectsDir, err := gitExistingPath(ctx, workspaceRoot, "objects")
-	if err != nil {
-		return nil, fmt.Errorf("git objects dir: %w", err)
-	}
-	addRoot(objectsDir)
-
-	ref, err := gitSymbolicHead(ctx, workspaceRoot)
-	if err != nil {
-		var cmdErr *CommandError
-		if errors.As(err, &cmdErr) && cmdErr.ExitCode == 1 {
-			return roots, nil
-		}
-		return nil, fmt.Errorf("git symbolic head: %w", err)
-	}
-	if !strings.HasPrefix(ref, "refs/heads/") {
+	addRoot(metadata.gitDir)
+	addRoot(metadata.objectsDir)
+	if !strings.HasPrefix(metadata.headRef, "refs/heads/") {
 		return roots, nil
 	}
 
-	refPath, err := gitPath(ctx, workspaceRoot, ref)
-	if err != nil {
-		return nil, fmt.Errorf("git branch ref path: %w", err)
-	}
-	refDir, err := canonicalExistingDir(filepath.Dir(refPath))
+	refDir, err := canonicalExistingDir(filepath.Dir(filepath.Join(metadata.commonDir, filepath.FromSlash(metadata.headRef))))
 	if err != nil {
 		return nil, fmt.Errorf("git branch ref dir: %w", err)
 	}
 	addRoot(refDir)
 
-	logPath, err := gitPath(ctx, workspaceRoot, "logs/"+ref)
-	if err != nil {
-		return nil, fmt.Errorf("git branch log path: %w", err)
-	}
-	logDir, err := canonicalExistingDir(filepath.Dir(logPath))
+	logDir, err := canonicalExistingDir(filepath.Dir(filepath.Join(metadata.commonDir, "logs", filepath.FromSlash(metadata.headRef))))
 	if err != nil {
 		return nil, fmt.Errorf("git branch log dir: %w", err)
 	}
@@ -1164,50 +1141,52 @@ func GitMetadataWritableRoots(ctx context.Context, workspacePath string) ([]stri
 	return roots, nil
 }
 
-func gitDir(ctx context.Context, dir string) (string, error) {
-	output, err := runGitAt(ctx, dir, "rev-parse", "--git-dir")
-	if err != nil {
-		return "", err
-	}
-	path := strings.TrimSpace(output)
-	if path == "" {
-		return "", errors.New("git dir is empty")
-	}
-	if !filepath.IsAbs(path) {
-		path = filepath.Join(dir, path)
-	}
-	return canonicalExistingPath(path)
+type gitMetadata struct {
+	commonDir  string
+	gitDir     string
+	objectsDir string
+	headRef    string
 }
 
-func gitExistingPath(ctx context.Context, dir string, name string) (string, error) {
-	path, err := gitPath(ctx, dir, name)
+func inspectGitMetadata(ctx context.Context, dir string) (gitMetadata, error) {
+	output, err := runGitAtWithEnv(
+		ctx,
+		dir,
+		gitDiscoveryBoundary(dir),
+		"rev-parse",
+		"--path-format=absolute",
+		"--git-common-dir",
+		"--git-dir",
+		"--git-path", "objects",
+		"--symbolic-full-name", "HEAD",
+	)
 	if err != nil {
-		return "", err
+		return gitMetadata{}, fmt.Errorf("inspect git metadata: %w", err)
 	}
-	return canonicalExistingPath(path)
-}
+	fields := strings.Split(strings.TrimSpace(output), "\n")
+	if len(fields) != 4 {
+		return gitMetadata{}, fmt.Errorf("inspect git metadata: expected 4 fields, got %d", len(fields))
+	}
 
-func gitPath(ctx context.Context, dir string, gitPath string) (string, error) {
-	output, err := runGitAt(ctx, dir, "rev-parse", "--git-path", gitPath)
-	if err != nil {
-		return "", err
+	paths := make([]string, 3)
+	for i, field := range fields[:3] {
+		path, err := canonicalExistingPath(strings.TrimSpace(field))
+		if err != nil {
+			return gitMetadata{}, fmt.Errorf("inspect git metadata field %d: %w", i+1, err)
+		}
+		paths[i] = path
 	}
-	path := strings.TrimSpace(output)
-	if path == "" {
-		return "", errors.New("git path is empty")
+	headRef := strings.TrimSpace(fields[3])
+	if headRef == "" {
+		return gitMetadata{}, errors.New("inspect git metadata: head ref is empty")
 	}
-	if !filepath.IsAbs(path) {
-		path = filepath.Join(dir, path)
-	}
-	return filepath.Clean(path), nil
-}
 
-func gitSymbolicHead(ctx context.Context, dir string) (string, error) {
-	output, err := runGitAt(ctx, dir, "symbolic-ref", "-q", "HEAD")
-	if err != nil {
-		return "", err
-	}
-	return strings.TrimSpace(output), nil
+	return gitMetadata{
+		commonDir:  paths[0],
+		gitDir:     paths[1],
+		objectsDir: paths[2],
+		headRef:    headRef,
+	}, nil
 }
 
 func canonicalExistingDir(path string) (string, error) {

--- a/internal/workspace/workspace_test.go
+++ b/internal/workspace/workspace_test.go
@@ -483,18 +483,19 @@ func TestGitMetadataWritableRootsForLinkedWorktree(t *testing.T) {
 		t.Fatalf("GitMetadataWritableRoots() error = %v", err)
 	}
 
+	commonDir := mustCanonicalExistingPath(t, filepath.Join(source, ".git"))
 	wantRoots := []string{
-		mustCanonicalExistingPath(t, strings.TrimSpace(runGit(t, info.Path, "rev-parse", "--git-dir"))),
-		mustCanonicalExistingPath(t, strings.TrimSpace(runGit(t, info.Path, "rev-parse", "--git-path", "objects"))),
-		mustCanonicalExistingPath(t, filepath.Dir(strings.TrimSpace(runGit(t, info.Path, "rev-parse", "--git-path", "refs/heads/detent/dd-git-roots")))),
-		mustCanonicalExistingPath(t, filepath.Dir(strings.TrimSpace(runGit(t, info.Path, "rev-parse", "--git-path", "logs/refs/heads/detent/dd-git-roots")))),
+		linkedWorktreeGitDir(t, info.Path),
+		mustCanonicalExistingPath(t, filepath.Join(commonDir, "objects")),
+		mustCanonicalExistingPath(t, filepath.Join(commonDir, "refs", "heads", "detent")),
+		mustCanonicalExistingPath(t, filepath.Join(commonDir, "logs", "refs", "heads", "detent")),
 	}
 	for _, want := range wantRoots {
 		if !containsString(roots, want) {
 			t.Fatalf("GitMetadataWritableRoots() = %#v, missing %q", roots, want)
 		}
 	}
-	if commonDir := mustCanonicalExistingPath(t, strings.TrimSpace(runGit(t, info.Path, "rev-parse", "--git-common-dir"))); containsString(roots, commonDir) {
+	if containsString(roots, commonDir) {
 		t.Fatalf("GitMetadataWritableRoots() = %#v, should not allow entire common git dir %q", roots, commonDir)
 	}
 
@@ -505,6 +506,21 @@ func TestGitMetadataWritableRootsForLinkedWorktree(t *testing.T) {
 	runGit(t, info.Path, "commit", "-m", "agent commit")
 	if got := strings.TrimSpace(runGit(t, info.Path, "log", "-1", "--pretty=%s")); got != "agent commit" {
 		t.Fatalf("latest commit subject = %q, want agent commit", got)
+	}
+}
+
+func TestGitMetadataWritableRootsRejectsEnclosingRepository(t *testing.T) {
+	t.Parallel()
+	skipWindows(t)
+
+	source := initSourceRepo(t)
+	workspacePath := filepath.Join(source, "nested")
+	if err := os.MkdirAll(workspacePath, 0o700); err != nil {
+		t.Fatalf("mkdir nested workspace: %v", err)
+	}
+
+	if _, err := GitMetadataWritableRoots(context.Background(), workspacePath); err == nil {
+		t.Fatal("GitMetadataWritableRoots() error = nil, want nested workspace rejection")
 	}
 }
 
@@ -1481,6 +1497,20 @@ func initBareRemote(t *testing.T) string {
 func runGit(t *testing.T, dir string, args ...string) string {
 	t.Helper()
 	return runCommand(t, dir, "git", args...)
+}
+
+func linkedWorktreeGitDir(t *testing.T, workspacePath string) string {
+	t.Helper()
+
+	data, err := os.ReadFile(filepath.Join(workspacePath, ".git"))
+	if err != nil {
+		t.Fatalf("read linked worktree .git file: %v", err)
+	}
+	gitDir, ok := strings.CutPrefix(strings.TrimSpace(string(data)), "gitdir: ")
+	if !ok || strings.TrimSpace(gitDir) == "" {
+		t.Fatalf("linked worktree .git file = %q, want gitdir path", data)
+	}
+	return mustCanonicalExistingPath(t, gitDir)
 }
 
 func branchExists(t *testing.T, dir string, branch string) bool {


### PR DESCRIPTION
## Summary

- require Git metadata discovery to start at an actual workspace root instead of climbing into an enclosing repository
- collapse six read-only metadata commands into one bounded `git rev-parse` invocation
- keep real linked-worktree commit coverage while removing redundant Git expectation commands
- add a reusable subprocess-pressure tracing skill draft

The intermittent failure was environmental Git instability under subprocess pressure: the failing CI command ran after production metadata discovery had already succeeded. Locally, fake runner workspaces inside Detent's `TMPDIR` were incorrectly discovering the enclosing repository and multiplying each inspection into six Git launches. The runner race-test trace fell from 309 Git launches to 29.

Fixes #1350

## UI Surface Contract

- [x] N/A; this PR does not change UI surfaces.
- [x] This PR does not add persistent messaging.
- [x] This PR has no visual changes.

## Test Plan

- [x] regression fails before the fix: `TestGitMetadataWritableRootsRejectsEnclosingRepository`
- [x] `go test -race ./internal/workspace -run '^TestGitMetadataWritableRoots(ForLinkedWorktree|RejectsEnclosingRepository)$' -count=20`
- [x] `go test -race ./internal/runner ./internal/workspace -count=5`
- [x] `make check` (twice; 77.4% coverage)