### PR TITLE
feat(config): add local workflow overlays

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 tmp/
 /detent
 node_modules/
+/WORKFLOW.local.md
 
 # Release signing secrets — NEVER commit the private key or the password
 .envrc

--- a/README.md
+++ b/README.md
@@ -165,9 +165,10 @@ agent-executable [Project Onboarding](docs/ONBOARDING.md) runbook.
 Configured GitHub status is the state machine; ProjectV2 board status, the
 boardless issue field, or repository status labels drive everything.
 
-1. **You write the contract.** Each project has a `WORKFLOW.md`: the tracker
-   binding, board states, the agent prompt, the validation gate, and the review
-   policy.
+1. **You write the contract.** Each project has a checked-in `WORKFLOW.md`: the
+   tracker binding, board states, the agent prompt, the validation gate, and
+   the review policy. An optional, gitignored `WORKFLOW.local.md` applies
+   machine-specific overrides without changing that shared contract.
 2. **You mark an issue `Todo`.** Detent claims it, creates an isolated Git
    worktree from your source checkout, and dispatches a Codex agent with the
    contract — moving the issue to `In Progress`.
@@ -2072,6 +2073,34 @@ Detent separates host-level orchestration from per-project workflow:
 - Each project has its own `WORKFLOW.md` with tracker credentials, states,
   workspace rules, Codex settings, budgets, hooks, and agent instructions.
 
+### Machine-local workflow overlays
+
+Keep `WORKFLOW.md` checked in as the shared project contract. For settings or
+agent direction that only apply on one machine, create `WORKFLOW.local.md`
+beside it and add that file to the repository's `.gitignore`. The local file
+uses the same YAML-frontmatter-plus-Markdown format. Local frontmatter wins per
+structured leaf key; mapping siblings that are not mentioned remain shared,
+while local lists and scalar values replace their shared values. Local Markdown
+is appended after the shared direction under a visible machine-local heading.
+
+Detent loads both files at startup. Its workflow watcher reloads edits,
+creation, and deletion of either file without a restart, and periodic
+reconciliation covers missed filesystem events. `detent doctor` reports an
+active overlay, lists its structured override keys, and warns if Git tracks the
+local file.
+
+For example:
+
+```markdown
+---
+tracker:
+  assignee: local-operator
+polling:
+  interval_ms: 90000
+---
+Use the tools installed on this build host.
+```
+
 A minimal global config looks like this:
 
 ```yaml
@@ -2131,9 +2160,11 @@ When set, the workflow file is read from a git ref in the configured source
 checkout instead of the checkout's working-tree copy. `workflow` may be an
 absolute path under `workdir` or a repository relative path such as
 `WORKFLOW.md`. When the ref advances, Detent reloads the workflow content from
-that ref; when `workflow_ref` is omitted, Detent keeps reading the working-tree
-file. If `workflow_ref` points at a ref that does not contain the workflow file,
-`detent doctor` reports a load failure for `<ref>:WORKFLOW.md`.
+that ref. `WORKFLOW.local.md` remains machine-local in the working tree and is
+applied over the ref-backed shared file. When `workflow_ref` is omitted, Detent
+keeps reading the working-tree shared file. If `workflow_ref` points at a ref
+that does not contain the workflow file, `detent doctor` reports a load failure
+for `<ref>:WORKFLOW.md`.
 
 Use the project administration commands to edit `global.yaml`:
 

--- a/docs/templates/WORKFLOW.github_local.md
+++ b/docs/templates/WORKFLOW.github_local.md
@@ -1,4 +1,5 @@
 ---
+# Keep machine-specific config and direction in gitignored WORKFLOW.local.md.
 tracker:
   kind: github_local
   repository: <repo-owner>/<repo-name>

--- a/docs/templates/WORKFLOW.issue_field.md
+++ b/docs/templates/WORKFLOW.issue_field.md
@@ -1,4 +1,5 @@
 ---
+# Keep machine-specific config and direction in gitignored WORKFLOW.local.md.
 tracker:
   kind: github
   github_status_source: issue_field

--- a/docs/templates/WORKFLOW.label.md
+++ b/docs/templates/WORKFLOW.label.md
@@ -1,4 +1,5 @@
 ---
+# Keep machine-specific config and direction in gitignored WORKFLOW.local.md.
 tracker:
   kind: github
   github_status_source: label

--- a/docs/templates/WORKFLOW.non_code_artifact.md
+++ b/docs/templates/WORKFLOW.non_code_artifact.md
@@ -1,4 +1,5 @@
 ---
+# Keep machine-specific config and direction in gitignored WORKFLOW.local.md.
 tracker:
   kind: local_sqlite
   local_sqlite:

--- a/docs/templates/WORKFLOW.project_v2.md
+++ b/docs/templates/WORKFLOW.project_v2.md
@@ -1,4 +1,5 @@
 ---
+# Keep machine-specific config and direction in gitignored WORKFLOW.local.md.
 tracker:
   kind: github
   github_status_source: project_v2

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -158,6 +158,7 @@ type doctorDeps struct {
 	openSQLiteReadOnly   func(context.Context, string) (doctorTelemetryStore, error)
 	gitWorkTree          func(context.Context, string) error
 	gitRemoteURL         func(context.Context, string) (string, error)
+	gitTracked           func(context.Context, string) (bool, error)
 	autoPromoteConnector func(workflowconfig.Config) (doctorAutoPromoteConnector, error)
 	proposalConnector    func(workflowconfig.Config) (doctorWorkflowProposalConnector, error)
 	modelProbe           func(context.Context, doctorRouteModelProbeRequest) error
@@ -927,6 +928,9 @@ func (d doctorDeps) withDefaults() doctorDeps {
 	if d.gitRemoteURL == nil {
 		d.gitRemoteURL = defaults.gitRemoteURL
 	}
+	if d.gitTracked == nil {
+		d.gitTracked = defaults.gitTracked
+	}
 	if d.autoPromoteConnector == nil {
 		d.autoPromoteConnector = defaults.autoPromoteConnector
 	}
@@ -966,6 +970,7 @@ func defaultDoctorDeps() doctorDeps {
 		openSQLiteReadOnly:   openDoctorSQLiteReadOnly,
 		gitWorkTree:          defaultGitWorkTree,
 		gitRemoteURL:         defaultGitRemoteURL,
+		gitTracked:           defaultGitTracked,
 		autoPromoteConnector: defaultDoctorAutoPromoteConnector,
 		proposalConnector:    defaultDoctorProposalConnector,
 		modelProbe:           defaultDoctorRouteModelProbe,
@@ -1238,6 +1243,28 @@ func defaultGitRemoteURL(ctx context.Context, path string) (string, error) {
 		return "", errors.New("origin remote URL is blank")
 	}
 	return remote, nil
+}
+
+func defaultGitTracked(ctx context.Context, path string) (bool, error) {
+	commandCtx, cancel := context.WithTimeout(ctx, doctorCommandTimeout)
+	defer cancel()
+
+	cmd := exec.CommandContext(commandCtx, "git", "-C", filepath.Dir(path), "ls-files", "--error-unmatch", "--", filepath.Base(path)) // #nosec G204 -- the local workflow path is passed as a git argument, not shell input.
+	output, err := cmd.CombinedOutput()
+	if commandCtx.Err() != nil {
+		return false, commandCtx.Err()
+	}
+	if err == nil {
+		return true, nil
+	}
+	var exitErr *exec.ExitError
+	if errors.As(err, &exitErr) && exitErr.ExitCode() == 1 {
+		return false, nil
+	}
+	if detail := strings.TrimSpace(string(output)); detail != "" {
+		return false, fmt.Errorf("check tracked file: %w: %s", err, detail)
+	}
+	return false, fmt.Errorf("check tracked file: %w", err)
 }
 
 func defaultGitHubScopes(ctx context.Context, token string) ([]string, error) {

--- a/internal/cli/doctor_project.go
+++ b/internal/cli/doctor_project.go
@@ -255,6 +255,9 @@ func checkDoctorProjectWithProgress(
 		}
 	}
 	checks := []doctorCheck{workflowCheck}
+	if overlayCheck, ok := checkDoctorLocalWorkflowOverlay(ctx, id, workflow, deps); ok {
+		checks = append(checks, overlayCheck)
+	}
 	if billingCheck, ok := checkDoctorBillingMode(id, workflow.Config); ok {
 		checks = append(checks, billingCheck)
 	}
@@ -352,6 +355,49 @@ func checkDoctorProjectWithProgress(
 		checks = append(checks, checkDoctorGitHubReadiness(ctx, id, project, workflow.Config, deps, githubToken, expandedSourceRoot, allowWriteProbes)...)
 	}
 	return checks
+}
+
+func checkDoctorLocalWorkflowOverlay(
+	ctx context.Context,
+	id string,
+	workflow workflowconfig.Workflow,
+	deps doctorDeps,
+) (doctorCheck, bool) {
+	path := strings.TrimSpace(workflow.Overlay.Path)
+	if path == "" {
+		return doctorCheck{}, false
+	}
+
+	detail := path + " is active"
+	if len(workflow.Overlay.OverriddenKeys) == 0 {
+		detail += "; overrides no structured config keys (prose only)"
+	} else {
+		detail += "; overrides structured config keys: " + strings.Join(workflow.Overlay.OverriddenKeys, ", ")
+	}
+	check := doctorCheck{
+		Name:   "Project " + id + " local workflow overlay",
+		Status: doctorOK,
+		Detail: detail,
+	}
+	if deps.gitTracked == nil {
+		deps.gitTracked = defaultGitTracked
+	}
+	tracked, err := deps.gitTracked(ctx, path)
+	if err != nil {
+		check.Status = doctorWarn
+		check.Detail += "; Git tracking status could not be determined: " + err.Error()
+		check.Hint = "Verify that " + filepath.Base(path) + " is listed in .gitignore and is not tracked by Git."
+		return check, true
+	}
+	if !tracked {
+		check.Detail += "; file is not tracked by Git"
+		return check, true
+	}
+
+	check.Status = doctorWarn
+	check.Detail += "; file is tracked by Git"
+	check.Hint = "Add " + filepath.Base(path) + " to .gitignore and remove it from Git tracking with git rm --cached -- " + filepath.Base(path) + "."
+	return check, true
 }
 
 func checkDoctorBillingMode(id string, cfg workflowconfig.Config) (doctorCheck, bool) {

--- a/internal/cli/doctor_test.go
+++ b/internal/cli/doctor_test.go
@@ -2399,6 +2399,124 @@ func TestDoctorWorkflowDetailReportsPinnedModelAndSessionGuard(t *testing.T) {
 	}
 }
 
+func TestCheckDoctorLocalWorkflowOverlay(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		overlay    workflowconfig.WorkflowOverlay
+		tracked    bool
+		trackedErr error
+		wantOK     bool
+		wantStatus doctorStatus
+		wantDetail []string
+		wantHint   string
+	}{
+		{
+			name: "active untracked overlay",
+			overlay: workflowconfig.WorkflowOverlay{
+				Path:           "/repo/WORKFLOW.local.md",
+				OverriddenKeys: []string{"polling.interval_ms", "tracker.assignee"},
+			},
+			wantOK:     true,
+			wantStatus: doctorOK,
+			wantDetail: []string{"is active", "polling.interval_ms, tracker.assignee", "not tracked by Git"},
+		},
+		{
+			name: "tracked overlay warns",
+			overlay: workflowconfig.WorkflowOverlay{
+				Path:           "/repo/WORKFLOW.local.md",
+				OverriddenKeys: []string{"tracker.assignee"},
+			},
+			tracked:    true,
+			wantOK:     true,
+			wantStatus: doctorWarn,
+			wantDetail: []string{"is active", "tracker.assignee", "tracked by Git"},
+			wantHint:   "Add WORKFLOW.local.md to .gitignore",
+		},
+		{
+			name: "prose-only overlay",
+			overlay: workflowconfig.WorkflowOverlay{
+				Path: "/repo/WORKFLOW.local.md",
+			},
+			wantOK:     true,
+			wantStatus: doctorOK,
+			wantDetail: []string{"is active", "prose only"},
+		},
+		{
+			name:       "tracking lookup failure warns",
+			overlay:    workflowconfig.WorkflowOverlay{Path: "/repo/WORKFLOW.local.md"},
+			trackedErr: errors.New("git unavailable"),
+			wantOK:     true,
+			wantStatus: doctorWarn,
+			wantDetail: []string{"could not be determined", "git unavailable"},
+			wantHint:   "listed in .gitignore",
+		},
+		{name: "inactive overlay"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			check, ok := checkDoctorLocalWorkflowOverlay(context.Background(), "detent", workflowconfig.Workflow{Overlay: tt.overlay}, doctorDeps{
+				gitTracked: func(context.Context, string) (bool, error) {
+					return tt.tracked, tt.trackedErr
+				},
+			})
+			if ok != tt.wantOK {
+				t.Fatalf("ok = %t, want %t", ok, tt.wantOK)
+			}
+			if !ok {
+				return
+			}
+			if check.Status != tt.wantStatus {
+				t.Fatalf("Status = %s, want %s", check.Status, tt.wantStatus)
+			}
+			for _, want := range tt.wantDetail {
+				if !strings.Contains(check.Detail, want) {
+					t.Fatalf("Detail = %q, want containing %q", check.Detail, want)
+				}
+			}
+			if tt.wantHint != "" && !strings.Contains(check.Hint, tt.wantHint) {
+				t.Fatalf("Hint = %q, want containing %q", check.Hint, tt.wantHint)
+			}
+		})
+	}
+}
+
+func TestDefaultGitTracked(t *testing.T) {
+	t.Parallel()
+
+	repo := t.TempDir()
+	if err := runDoctorCommand(context.Background(), "git", "-C", repo, "init"); err != nil {
+		t.Fatalf("git init error = %v", err)
+	}
+	path := filepath.Join(repo, "WORKFLOW.local.md")
+	if err := os.WriteFile(path, []byte("---\n---\nlocal\n"), 0o600); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+
+	tracked, err := defaultGitTracked(context.Background(), path)
+	if err != nil {
+		t.Fatalf("defaultGitTracked() untracked error = %v", err)
+	}
+	if tracked {
+		t.Fatal("defaultGitTracked() = true, want false before git add")
+	}
+
+	if err := runDoctorCommand(context.Background(), "git", "-C", repo, "add", "WORKFLOW.local.md"); err != nil {
+		t.Fatalf("git add error = %v", err)
+	}
+	tracked, err = defaultGitTracked(context.Background(), path)
+	if err != nil {
+		t.Fatalf("defaultGitTracked() tracked error = %v", err)
+	}
+	if !tracked {
+		t.Fatal("defaultGitTracked() = false, want true after git add")
+	}
+}
+
 func TestCheckDoctorInstanceIdentity(t *testing.T) {
 	t.Parallel()
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -103,6 +103,12 @@ type Workflow struct {
 	Config     Config
 	Prompt     string
 	SourceHash string
+	Overlay    WorkflowOverlay
+}
+
+type WorkflowOverlay struct {
+	Path           string
+	OverriddenKeys []string
 }
 
 type Config struct {
@@ -932,29 +938,107 @@ func LoadWorkflow(path string) (Workflow, error) {
 		return Workflow{}, fmt.Errorf("read workflow file: %w", err)
 	}
 
-	return ParseWorkflow(raw)
+	localPath := LocalWorkflowPath(path)
+	localRaw, err := os.ReadFile(localPath)
+	if errors.Is(err, os.ErrNotExist) {
+		return ParseWorkflow(raw)
+	}
+	if err != nil {
+		return Workflow{}, fmt.Errorf("read local workflow overlay: %w", err)
+	}
+	return ParseWorkflowOverlay(raw, localRaw, localPath)
 }
 
 func ParseWorkflow(raw []byte) (Workflow, error) {
-	frontmatter, prompt, err := splitFrontmatter(raw)
+	root, prompt, err := parseWorkflowDocument(raw)
+	if err != nil {
+		return Workflow{}, err
+	}
+	cfg, err := decodeWorkflowConfig(root)
 	if err != nil {
 		return Workflow{}, err
 	}
 
-	cfg := Default()
-	if len(bytes.TrimSpace(frontmatter)) > 0 {
-		var doc yaml.Node
-		if err := yaml.Unmarshal(frontmatter, &doc); err != nil {
-			return Workflow{}, fmt.Errorf("parse YAML frontmatter: %w", err)
-		}
+	sum := sha256.Sum256(raw)
+	return Workflow{
+		Config:     cfg,
+		Prompt:     string(prompt),
+		SourceHash: hex.EncodeToString(sum[:]),
+	}, nil
+}
 
-		root, err := documentRoot(&doc)
-		if err != nil {
-			return Workflow{}, err
-		}
-		if root.Kind != yaml.MappingNode {
-			return Workflow{}, errors.New("workflow frontmatter must be a mapping")
-		}
+func LocalWorkflowPath(path string) string {
+	extension := filepath.Ext(path)
+	if extension == "" {
+		return path + ".local"
+	}
+	return strings.TrimSuffix(path, extension) + ".local" + extension
+}
+
+func ParseWorkflowOverlay(sharedRaw []byte, localRaw []byte, localPath string) (Workflow, error) {
+	sharedRoot, sharedPrompt, err := parseWorkflowDocument(sharedRaw)
+	if err != nil {
+		return Workflow{}, err
+	}
+	localRoot, localPrompt, err := parseWorkflowDocument(localRaw)
+	if err != nil {
+		return Workflow{}, fmt.Errorf("parse local workflow overlay: %w", err)
+	}
+
+	if sharedRoot == nil {
+		sharedRoot = &yaml.Node{Kind: yaml.MappingNode}
+	}
+	if localRoot != nil {
+		mergeWorkflowMappings(sharedRoot, localRoot)
+	}
+	cfg, err := decodeWorkflowConfig(sharedRoot)
+	if err != nil {
+		return Workflow{}, err
+	}
+
+	overridden := sortedConfiguredFieldPaths(localRoot)
+	combined := make([]byte, 0, len(sharedRaw)+len(localRaw)+len("\x00workflow.local.md\x00"))
+	combined = append(combined, sharedRaw...)
+	combined = append(combined, "\x00workflow.local.md\x00"...)
+	combined = append(combined, localRaw...)
+	sum := sha256.Sum256(combined)
+	return Workflow{
+		Config:     cfg,
+		Prompt:     mergeWorkflowPrompts(sharedPrompt, localPrompt),
+		SourceHash: hex.EncodeToString(sum[:]),
+		Overlay: WorkflowOverlay{
+			Path:           strings.TrimSpace(localPath),
+			OverriddenKeys: overridden,
+		},
+	}, nil
+}
+
+func parseWorkflowDocument(raw []byte) (*yaml.Node, []byte, error) {
+	frontmatter, prompt, err := splitFrontmatter(raw)
+	if err != nil {
+		return nil, nil, err
+	}
+	if len(bytes.TrimSpace(frontmatter)) == 0 {
+		return nil, prompt, nil
+	}
+
+	var doc yaml.Node
+	if err := yaml.Unmarshal(frontmatter, &doc); err != nil {
+		return nil, nil, fmt.Errorf("parse YAML frontmatter: %w", err)
+	}
+	root, err := documentRoot(&doc)
+	if err != nil {
+		return nil, nil, err
+	}
+	if root.Kind != yaml.MappingNode {
+		return nil, nil, errors.New("workflow frontmatter must be a mapping")
+	}
+	return root, prompt, nil
+}
+
+func decodeWorkflowConfig(root *yaml.Node) (Config, error) {
+	cfg := Default()
+	if root != nil {
 		normalizeTrackerIDFields(root)
 		gitHubStatusSourceSet := trackerFieldSet(root, "github_status_source")
 		knowledgeConfigured := nestedFieldSet(root, "agent", "knowledge")
@@ -962,7 +1046,7 @@ func ParseWorkflow(raw []byte) (Workflow, error) {
 		perDayMaxUSDConfigured := nestedFieldSet(root, "budget", "per_day_max_usd")
 		perIssueMaxUSDConfigured := nestedFieldSet(root, "budget", "per_issue_max_usd")
 		if err := root.Decode(&cfg); err != nil {
-			return Workflow{}, fmt.Errorf("decode YAML frontmatter: %w", err)
+			return Config{}, fmt.Errorf("decode YAML frontmatter: %w", err)
 		}
 		cfg.Tracker.gitHubStatusSourceSet = gitHubStatusSourceSet
 		cfg.Agent.Knowledge.Configured = knowledgeConfigured
@@ -971,15 +1055,61 @@ func ParseWorkflow(raw []byte) (Workflow, error) {
 		cfg.Budget.perIssueMaxUSDConfigured = perIssueMaxUSDConfigured
 		cfg.configuredFields = configuredFieldPaths(root)
 	}
-
 	cfg.normalize()
+	return cfg, nil
+}
 
-	sum := sha256.Sum256(raw)
-	return Workflow{
-		Config:     cfg,
-		Prompt:     string(prompt),
-		SourceHash: hex.EncodeToString(sum[:]),
-	}, nil
+func mergeWorkflowMappings(shared *yaml.Node, local *yaml.Node) {
+	for index := 0; index+1 < len(local.Content); index += 2 {
+		localKey := local.Content[index]
+		localValue := local.Content[index+1]
+		sharedIndex := mappingKeyIndex(shared, localKey.Value)
+		if sharedIndex < 0 {
+			shared.Content = append(shared.Content, localKey, localValue)
+			continue
+		}
+		sharedValue := shared.Content[sharedIndex+1]
+		if sharedValue.Kind == yaml.MappingNode && localValue.Kind == yaml.MappingNode {
+			mergeWorkflowMappings(sharedValue, localValue)
+			continue
+		}
+		shared.Content[sharedIndex] = localKey
+		shared.Content[sharedIndex+1] = localValue
+	}
+}
+
+func mappingKeyIndex(node *yaml.Node, key string) int {
+	for index := 0; index+1 < len(node.Content); index += 2 {
+		if node.Content[index].Value == key {
+			return index
+		}
+	}
+	return -1
+}
+
+func sortedConfiguredFieldPaths(root *yaml.Node) []string {
+	if root == nil {
+		return nil
+	}
+	paths := configuredFieldPaths(root)
+	configured := make([]string, 0, len(paths))
+	for path := range paths {
+		configured = append(configured, path)
+	}
+	sort.Strings(configured)
+	return configured
+}
+
+func mergeWorkflowPrompts(shared []byte, local []byte) string {
+	if len(bytes.TrimSpace(local)) == 0 {
+		return string(shared)
+	}
+	sharedPrompt := strings.TrimRight(string(shared), "\n")
+	localPrompt := strings.TrimLeft(string(local), "\n")
+	if sharedPrompt == "" {
+		return "## Machine-local workflow overlay\n\n" + localPrompt
+	}
+	return sharedPrompt + "\n\n---\n\n## Machine-local workflow overlay\n\n" + localPrompt
 }
 
 func (c Config) ConfiguredSubsettings(prefix string) []string {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,6 +1,8 @@
 package config
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -16,6 +18,151 @@ import (
 	"github.com/digitaldrywood/detent/internal/gate"
 	"github.com/digitaldrywood/detent/internal/selector"
 )
+
+func TestParseWorkflowOverlayPrecedence(t *testing.T) {
+	t.Parallel()
+
+	shared := []byte("---\ntracker:\n  kind: memory\n  assignee: shared\n  active_states: [Todo, In Progress]\npolling:\n  interval_ms: 60000\n  conditional: true\nagent:\n  max_turns: 20\n---\nShared direction.\n")
+	tests := []struct {
+		name             string
+		local            string
+		wantAssignee     string
+		wantInterval     int
+		wantConditional  bool
+		wantActiveStates []string
+		wantMaxTurns     int
+		wantPrompt       string
+		wantKeys         []string
+	}{
+		{
+			name:             "nested scalar keys override independently",
+			local:            "---\ntracker:\n  assignee: local\npolling:\n  interval_ms: 90000\n---\n",
+			wantAssignee:     "local",
+			wantInterval:     90000,
+			wantConditional:  true,
+			wantActiveStates: []string{"Todo", "In Progress"},
+			wantMaxTurns:     20,
+			wantPrompt:       "Shared direction.\n",
+			wantKeys:         []string{"polling.interval_ms", "tracker.assignee"},
+		},
+		{
+			name:             "sequences replace shared values",
+			local:            "---\ntracker:\n  active_states: [Backlog]\n---\n",
+			wantAssignee:     "shared",
+			wantInterval:     60000,
+			wantConditional:  true,
+			wantActiveStates: []string{"Backlog"},
+			wantMaxTurns:     20,
+			wantPrompt:       "Shared direction.\n",
+			wantKeys:         []string{"tracker.active_states"},
+		},
+		{
+			name:             "local prose follows shared prose",
+			local:            "---\nagent:\n  max_turns: 30\n---\nLocal direction.\n",
+			wantAssignee:     "shared",
+			wantInterval:     60000,
+			wantConditional:  true,
+			wantActiveStates: []string{"Todo", "In Progress"},
+			wantMaxTurns:     30,
+			wantPrompt:       "Shared direction.\n\n---\n\n## Machine-local workflow overlay\n\nLocal direction.\n",
+			wantKeys:         []string{"agent.max_turns"},
+		},
+		{
+			name:             "prose-only overlay leaves structured config intact",
+			local:            "---\n---\nLocal direction.\n",
+			wantAssignee:     "shared",
+			wantInterval:     60000,
+			wantConditional:  true,
+			wantActiveStates: []string{"Todo", "In Progress"},
+			wantMaxTurns:     20,
+			wantPrompt:       "Shared direction.\n\n---\n\n## Machine-local workflow overlay\n\nLocal direction.\n",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			workflow, err := ParseWorkflowOverlay(shared, []byte(tt.local), "/repo/WORKFLOW.local.md")
+			if err != nil {
+				t.Fatalf("ParseWorkflowOverlay() error = %v", err)
+			}
+			if workflow.Config.Tracker.Kind != TrackerMemory {
+				t.Fatalf("Tracker.Kind = %q, want %q", workflow.Config.Tracker.Kind, TrackerMemory)
+			}
+			if workflow.Config.Tracker.Assignee != tt.wantAssignee {
+				t.Fatalf("Tracker.Assignee = %q, want %q", workflow.Config.Tracker.Assignee, tt.wantAssignee)
+			}
+			if workflow.Config.Polling.IntervalMS != tt.wantInterval {
+				t.Fatalf("Polling.IntervalMS = %d, want %d", workflow.Config.Polling.IntervalMS, tt.wantInterval)
+			}
+			if workflow.Config.Polling.Conditional != tt.wantConditional {
+				t.Fatalf("Polling.Conditional = %t, want %t", workflow.Config.Polling.Conditional, tt.wantConditional)
+			}
+			if !slices.Equal(workflow.Config.Tracker.ActiveStates, tt.wantActiveStates) {
+				t.Fatalf("Tracker.ActiveStates = %#v, want %#v", workflow.Config.Tracker.ActiveStates, tt.wantActiveStates)
+			}
+			if workflow.Config.Agent.MaxTurns != tt.wantMaxTurns {
+				t.Fatalf("Agent.MaxTurns = %d, want %d", workflow.Config.Agent.MaxTurns, tt.wantMaxTurns)
+			}
+			if workflow.Prompt != tt.wantPrompt {
+				t.Fatalf("Prompt = %q, want %q", workflow.Prompt, tt.wantPrompt)
+			}
+			if workflow.Overlay.Path != "/repo/WORKFLOW.local.md" {
+				t.Fatalf("Overlay.Path = %q, want local path", workflow.Overlay.Path)
+			}
+			if !slices.Equal(workflow.Overlay.OverriddenKeys, tt.wantKeys) {
+				t.Fatalf("Overlay.OverriddenKeys = %#v, want %#v", workflow.Overlay.OverriddenKeys, tt.wantKeys)
+			}
+		})
+	}
+}
+
+func TestLoadWorkflowWithoutOverlayPreservesExistingBehavior(t *testing.T) {
+	t.Parallel()
+
+	raw := []byte("---\ntracker:\n  kind: memory\n---\nShared direction.\n")
+	path := filepath.Join(t.TempDir(), "WORKFLOW.md")
+	if err := os.WriteFile(path, raw, 0o600); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+
+	workflow, err := LoadWorkflow(path)
+	if err != nil {
+		t.Fatalf("LoadWorkflow() error = %v", err)
+	}
+	sum := sha256.Sum256(raw)
+	if workflow.SourceHash != hex.EncodeToString(sum[:]) {
+		t.Fatalf("SourceHash = %q, want shared-only hash", workflow.SourceHash)
+	}
+	if workflow.Prompt != "Shared direction.\n" {
+		t.Fatalf("Prompt = %q, want shared prompt", workflow.Prompt)
+	}
+	if workflow.Overlay.Path != "" || len(workflow.Overlay.OverriddenKeys) != 0 {
+		t.Fatalf("Overlay = %#v, want inactive", workflow.Overlay)
+	}
+}
+
+func TestLocalWorkflowPath(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		path string
+		want string
+	}{
+		{path: "/repo/WORKFLOW.md", want: "/repo/WORKFLOW.local.md"},
+		{path: "/repo/workflow.md", want: "/repo/workflow.local.md"},
+		{path: "/repo/workflow", want: "/repo/workflow.local"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.path, func(t *testing.T) {
+			t.Parallel()
+			if got := LocalWorkflowPath(tt.path); got != tt.want {
+				t.Fatalf("LocalWorkflowPath(%q) = %q, want %q", tt.path, got, tt.want)
+			}
+		})
+	}
+}
 
 func TestShippedWorkflowTemplatesEnableBudgetCaps(t *testing.T) {
 	t.Parallel()

--- a/internal/config/watcher/file.go
+++ b/internal/config/watcher/file.go
@@ -27,17 +27,23 @@ type FileUpdate[T any] struct {
 type FileOption func(*fileOptions)
 
 type FileWatcher[T any] struct {
-	path      string
-	watchPath string
-	dirs      []string
-	debounce  time.Duration
-	loader    FileLoader[T]
-	logger    *slog.Logger
+	path     string
+	files    []watchedFile
+	dirs     []string
+	debounce time.Duration
+	loader   FileLoader[T]
+	logger   *slog.Logger
 }
 
 type fileOptions struct {
-	debounce time.Duration
-	logger   *slog.Logger
+	debounce   time.Duration
+	logger     *slog.Logger
+	watchPaths []string
+}
+
+type watchedFile struct {
+	path   string
+	target string
 }
 
 func NewFile[T any](path string, loader FileLoader[T], opts ...FileOption) (*FileWatcher[T], error) {
@@ -69,15 +75,36 @@ func NewFile[T any](path string, loader FileLoader[T], opts ...FileOption) (*Fil
 	}
 
 	path = filepath.Clean(absolute)
-	watchPath := resolveWatchPath(path)
+	files := []watchedFile{{path: path, target: resolveWatchPath(path)}}
+	seen := map[string]struct{}{path: {}}
+	for _, additionalPath := range cfg.watchPaths {
+		additionalPath = strings.TrimSpace(additionalPath)
+		if additionalPath == "" {
+			continue
+		}
+		additionalAbsolute, err := filepath.Abs(additionalPath)
+		if err != nil {
+			return nil, fmt.Errorf("resolve additional config watch path: %w", err)
+		}
+		additionalPath = filepath.Clean(additionalAbsolute)
+		if _, ok := seen[additionalPath]; ok {
+			continue
+		}
+		seen[additionalPath] = struct{}{}
+		files = append(files, watchedFile{path: additionalPath, target: resolveWatchPath(additionalPath)})
+	}
+	watchPaths := make([]string, 0, len(files)*2)
+	for _, file := range files {
+		watchPaths = append(watchPaths, file.path, file.target)
+	}
 
 	return &FileWatcher[T]{
-		path:      path,
-		watchPath: watchPath,
-		dirs:      watchDirs(path, watchPath),
-		debounce:  cfg.debounce,
-		loader:    loader,
-		logger:    cfg.logger,
+		path:     path,
+		files:    files,
+		dirs:     watchDirs(watchPaths...),
+		debounce: cfg.debounce,
+		loader:   loader,
+		logger:   cfg.logger,
 	}, nil
 }
 
@@ -111,6 +138,12 @@ func WithFileDebounce(debounce time.Duration) FileOption {
 func WithFileLogger(logger *slog.Logger) FileOption {
 	return func(opts *fileOptions) {
 		opts.logger = logger
+	}
+}
+
+func WithFileWatchPaths(paths ...string) FileOption {
+	return func(opts *fileOptions) {
+		opts.watchPaths = append(opts.watchPaths, paths...)
 	}
 }
 
@@ -186,32 +219,39 @@ func (w *FileWatcher[T]) matches(event fsnotify.Event) bool {
 		return false
 	}
 	name := filepath.Clean(event.Name)
-	return name == w.path || name == w.watchPath
+	for _, file := range w.files {
+		if name == file.path || name == file.target {
+			return true
+		}
+	}
+	return false
 }
 
 func (w *FileWatcher[T]) refreshWatchPath(addDir func(string) error) {
-	watchPath := resolveWatchPath(w.path)
-	if watchPath == w.watchPath {
-		return
-	}
-
-	w.watchPath = watchPath
-	for _, dir := range watchDirs(w.path, watchPath) {
-		if hasWatchDir(w.dirs, dir) {
+	for index := range w.files {
+		watchPath := resolveWatchPath(w.files[index].path)
+		if watchPath == w.files[index].target {
 			continue
 		}
-		if addDir != nil {
-			if err := addDir(dir); err != nil {
-				w.logger.Warn("watch config symlink target directory failed",
-					"path", w.path,
-					"target", watchPath,
-					"dir", dir,
-					"error", err,
-				)
+
+		w.files[index].target = watchPath
+		for _, dir := range watchDirs(w.files[index].path, watchPath) {
+			if hasWatchDir(w.dirs, dir) {
 				continue
 			}
+			if addDir != nil {
+				if err := addDir(dir); err != nil {
+					w.logger.Warn("watch config symlink target directory failed",
+						"path", w.files[index].path,
+						"target", watchPath,
+						"dir", dir,
+						"error", err,
+					)
+					continue
+				}
+			}
+			w.dirs = append(w.dirs, dir)
 		}
-		w.dirs = append(w.dirs, dir)
 	}
 }
 

--- a/internal/config/watcher/watcher.go
+++ b/internal/config/watcher/watcher.go
@@ -63,7 +63,7 @@ func New(path string, opts ...Option) (*Watcher, error) {
 			err = workflow.Config.Validate()
 		}
 		return workflow, err
-	}, WithFileDebounce(cfg.debounce), WithFileLogger(cfg.logger))
+	}, WithFileDebounce(cfg.debounce), WithFileLogger(cfg.logger), WithFileWatchPaths(workflowconfig.LocalWorkflowPath(path)))
 	if err != nil {
 		return nil, err
 	}

--- a/internal/config/watcher/watcher_test.go
+++ b/internal/config/watcher/watcher_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"strconv"
+	"strings"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -204,6 +205,94 @@ func TestWatchReportsInvalidReload(t *testing.T) {
 	}
 }
 
+func TestWatchReloadsLocalWorkflowOverlayLifecycle(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "WORKFLOW.md")
+	localPath := workflowconfig.LocalWorkflowPath(path)
+	writeWorkflow(t, path, 60000, "shared")
+
+	w, err := New(path, WithDebounce(10*time.Millisecond))
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	updates, err := w.Watch(ctx)
+	if err != nil {
+		t.Fatalf("Watch() error = %v", err)
+	}
+
+	writeWorkflow(t, localPath, 61000, "local first")
+	created := receiveUpdate(t, updates)
+	if created.Err != nil {
+		t.Fatalf("create update error = %v", created.Err)
+	}
+	if created.Workflow.Config.Polling.IntervalMS != 61000 || !strings.Contains(created.Workflow.Prompt, "local first") {
+		t.Fatalf("create workflow = %#v, want local overlay", created.Workflow)
+	}
+
+	writeWorkflow(t, localPath, 62000, "local second")
+	edited := receiveUpdate(t, updates)
+	if edited.Err != nil {
+		t.Fatalf("edit update error = %v", edited.Err)
+	}
+	if edited.Workflow.Config.Polling.IntervalMS != 62000 || !strings.Contains(edited.Workflow.Prompt, "local second") {
+		t.Fatalf("edit workflow = %#v, want updated local overlay", edited.Workflow)
+	}
+
+	if err := os.Remove(localPath); err != nil {
+		t.Fatalf("Remove() error = %v", err)
+	}
+	deleted := receiveUpdate(t, updates)
+	if deleted.Err != nil {
+		t.Fatalf("delete update error = %v", deleted.Err)
+	}
+	if deleted.Workflow.Config.Polling.IntervalMS != 60000 || deleted.Workflow.Prompt != "shared\n" {
+		t.Fatalf("delete workflow = %#v, want shared workflow", deleted.Workflow)
+	}
+	if deleted.Workflow.Overlay.Path != "" {
+		t.Fatalf("delete Overlay = %#v, want inactive", deleted.Workflow.Overlay)
+	}
+}
+
+func TestWatchSurvivesSharedWorkflowDeletionAndCreation(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "WORKFLOW.md")
+	writeWorkflow(t, path, 60000, "first")
+
+	w, err := New(path, WithDebounce(10*time.Millisecond))
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	updates, err := w.Watch(ctx)
+	if err != nil {
+		t.Fatalf("Watch() error = %v", err)
+	}
+
+	if err := os.Remove(path); err != nil {
+		t.Fatalf("Remove() error = %v", err)
+	}
+	deleted := receiveUpdate(t, updates)
+	if deleted.Err == nil {
+		t.Fatal("delete update error = nil, want missing shared workflow error")
+	}
+
+	writeWorkflow(t, path, 63000, "recreated")
+	recreated := receiveUpdate(t, updates)
+	if recreated.Err != nil {
+		t.Fatalf("recreate update error = %v", recreated.Err)
+	}
+	if recreated.Workflow.Config.Polling.IntervalMS != 63000 || recreated.Workflow.Prompt != "recreated\n" {
+		t.Fatalf("recreated workflow = %#v, want recreated shared workflow", recreated.Workflow)
+	}
+}
+
 func TestFileWatcherDebouncesGlobalConfigWrites(t *testing.T) {
 	t.Parallel()
 
@@ -369,8 +458,8 @@ func TestFileWatcherRefreshesRetargetedSymlinkTarget(t *testing.T) {
 	})
 
 	resolvedNext := resolveWatchPath(linkPath)
-	if w.watchPath != resolvedNext {
-		t.Fatalf("watchPath = %q, want %q", w.watchPath, resolvedNext)
+	if w.files[0].target != resolvedNext {
+		t.Fatalf("watchPath = %q, want %q", w.files[0].target, resolvedNext)
 	}
 	nextWatchDir := filepath.Dir(resolvedNext)
 	if !hasWatchDir(w.dirs, nextWatchDir) {

--- a/internal/project/workflow_source.go
+++ b/internal/project/workflow_source.go
@@ -176,11 +176,24 @@ func (s workflowGitRefSource) load(ctx context.Context) (workflowconfig.Workflow
 	if err != nil {
 		return workflowconfig.Workflow{}, revision, fmt.Errorf("load workflow from %s: %w", s.displayPath(), err)
 	}
-	workflow, err := workflowconfig.ParseWorkflow(raw)
+	localPath := s.localPath()
+	localRaw, localErr := os.ReadFile(localPath)
+	if errors.Is(localErr, os.ErrNotExist) {
+		workflow, err := workflowconfig.ParseWorkflow(raw)
+		return workflow, revision, err
+	}
+	if localErr != nil {
+		return workflowconfig.Workflow{}, revision, fmt.Errorf("read local workflow overlay: %w", localErr)
+	}
+	workflow, err := workflowconfig.ParseWorkflowOverlay(raw, localRaw, localPath)
 	if err != nil {
 		return workflowconfig.Workflow{}, revision, err
 	}
 	return workflow, revision, nil
+}
+
+func (s workflowGitRefSource) localPath() string {
+	return filepath.Join(s.sourceRoot, filepath.FromSlash(workflowconfig.LocalWorkflowPath(s.path)))
 }
 
 func (s workflowGitRefSource) revision(ctx context.Context) (string, error) {
@@ -231,12 +244,31 @@ func (w *gitRefWorkflowWatcher) Watch(ctx context.Context) (<-chan configwatcher
 		ctx = context.Background()
 	}
 
+	localWatcher, err := configwatcher.NewFile(w.source.localPath(), func(string) (workflowconfig.Workflow, error) {
+		workflow, _, err := w.source.load(ctx)
+		if err == nil {
+			err = workflow.Config.Validate()
+		}
+		return workflow, err
+	}, configwatcher.WithFileLogger(w.logger))
+	if err != nil {
+		return nil, fmt.Errorf("create local workflow overlay watcher: %w", err)
+	}
+	localUpdates, err := localWatcher.Watch(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("watch local workflow overlay: %w", err)
+	}
+
 	updates := make(chan configwatcher.Update, 1)
-	go w.run(ctx, updates)
+	go w.run(ctx, updates, localUpdates)
 	return updates, nil
 }
 
-func (w *gitRefWorkflowWatcher) run(ctx context.Context, updates chan<- configwatcher.Update) {
+func (w *gitRefWorkflowWatcher) run(
+	ctx context.Context,
+	updates chan<- configwatcher.Update,
+	localUpdates <-chan configwatcher.FileUpdate[workflowconfig.Workflow],
+) {
 	defer close(updates)
 
 	ticker := time.NewTicker(w.interval)
@@ -249,6 +281,26 @@ func (w *gitRefWorkflowWatcher) run(ctx context.Context, updates chan<- configwa
 			return
 		case <-ticker.C:
 			lastRevision, lastErr = w.reload(ctx, updates, lastRevision, lastErr)
+		case update, ok := <-localUpdates:
+			if !ok {
+				w.send(ctx, updates, configwatcher.Update{
+					Path:       w.source.localPath(),
+					Err:        errors.New("local workflow overlay watcher stopped"),
+					WatcherErr: true,
+					At:         time.Now(),
+				})
+				return
+			}
+			w.send(ctx, updates, configwatcher.Update{
+				Path:       update.Path,
+				Workflow:   update.Value,
+				Err:        update.Err,
+				WatcherErr: update.WatcherErr,
+				At:         update.At,
+			})
+			if update.WatcherErr {
+				return
+			}
 		}
 	}
 }

--- a/internal/project/workflow_source_test.go
+++ b/internal/project/workflow_source_test.go
@@ -79,6 +79,37 @@ func TestLoadWorkflowUsesConfiguredGitRef(t *testing.T) {
 	}
 }
 
+func TestLoadWorkflowUsesLocalOverlayWithConfiguredGitRef(t *testing.T) {
+	t.Parallel()
+
+	repo := initWorkflowSourceRepo(t)
+	workflowPath := filepath.Join(repo, "WORKFLOW.md")
+	writeWorkflowSourceFile(t, workflowPath, "from ref")
+	commitWorkflowSourceRepo(t, repo, "initial workflow")
+	updateWorkflowSourceRef(t, repo, "origin/main", "HEAD")
+	if err := os.WriteFile(filepath.Join(repo, "WORKFLOW.local.md"), []byte("---\npolling:\n  interval_ms: 90000\n---\nlocal direction\n"), 0o600); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+
+	workflow, err := LoadWorkflow(globalconfig.Project{
+		Workflow:    "WORKFLOW.md",
+		WorkflowRef: "origin/main",
+		Workdir:     repo,
+	})
+	if err != nil {
+		t.Fatalf("LoadWorkflow() error = %v", err)
+	}
+	if workflow.Config.Polling.IntervalMS != 90000 {
+		t.Fatalf("Polling.IntervalMS = %d, want 90000", workflow.Config.Polling.IntervalMS)
+	}
+	if got := workflow.Prompt; !strings.Contains(got, "from ref") || !strings.Contains(got, "local direction") {
+		t.Fatalf("Prompt = %q, want shared and local direction", got)
+	}
+	if workflow.Overlay.Path != filepath.Join(repo, "WORKFLOW.local.md") {
+		t.Fatalf("Overlay.Path = %q, want working-tree overlay", workflow.Overlay.Path)
+	}
+}
+
 func TestLoadWorkflowUsesAbsolutePathUnderWorkdirWithConfiguredGitRef(t *testing.T) {
 	t.Parallel()
 
@@ -163,6 +194,54 @@ func TestGitRefWorkflowWatcherReloadsWhenRefAdvances(t *testing.T) {
 	}
 	if got := strings.TrimSpace(update.Workflow.Prompt); got != "second" {
 		t.Fatalf("Prompt = %q, want second", got)
+	}
+}
+
+func TestGitRefWorkflowWatcherReloadsLocalOverlayLifecycle(t *testing.T) {
+	t.Parallel()
+
+	repo := initWorkflowSourceRepo(t)
+	writeWorkflowSourceFile(t, filepath.Join(repo, "WORKFLOW.md"), "shared")
+	commitWorkflowSourceRepo(t, repo, "initial workflow")
+	updateWorkflowSourceRef(t, repo, "origin/main", "HEAD")
+
+	watcher, err := newGitRefWorkflowWatcher(globalconfig.Project{
+		Workflow:    "WORKFLOW.md",
+		WorkflowRef: "origin/main",
+		Workdir:     repo,
+	}, time.Hour, slog.New(slog.NewTextHandler(bytes.NewBuffer(nil), nil)))
+	if err != nil {
+		t.Fatalf("newGitRefWorkflowWatcher() error = %v", err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	updates, err := watcher.Watch(ctx)
+	if err != nil {
+		t.Fatalf("Watch() error = %v", err)
+	}
+
+	localPath := filepath.Join(repo, "WORKFLOW.local.md")
+	writeWorkflowSourceFile(t, localPath, "local")
+	created := readWorkflowSourceUpdate(t, updates)
+	if created.Err != nil {
+		t.Fatalf("create update error = %v", created.Err)
+	}
+	if !strings.Contains(created.Workflow.Prompt, "shared") || !strings.Contains(created.Workflow.Prompt, "local") {
+		t.Fatalf("create Prompt = %q, want shared and local", created.Workflow.Prompt)
+	}
+
+	if err := os.Remove(localPath); err != nil {
+		t.Fatalf("Remove() error = %v", err)
+	}
+	deleted := readWorkflowSourceUpdate(t, updates)
+	if deleted.Err != nil {
+		t.Fatalf("delete update error = %v", deleted.Err)
+	}
+	if got := strings.TrimSpace(deleted.Workflow.Prompt); got != "shared" {
+		t.Fatalf("delete Prompt = %q, want shared", got)
+	}
+	if deleted.Workflow.Overlay.Path != "" {
+		t.Fatalf("delete Overlay = %#v, want inactive", deleted.Workflow.Overlay)
 	}
 }
 


### PR DESCRIPTION
## Summary

- load optional `WORKFLOW.local.md` overlays at startup with per-key structured precedence and local prose appended last
- hot-reload shared and local workflow edits, creation, and deletion for working-tree and `workflow_ref` projects
- report active overlay keys and tracked-file warnings in `detent doctor`, with docs, templates, and repository ignore defaults updated

Fixes #1353

## UI Surface Contract

- [x] N/A; this PR does not change a UI surface.
- [x] This PR does not add persistent top-of-screen messaging.
- [x] N/A; this PR does not change primary operator screens.

## Test Plan

- [x] `go test ./internal/config/... ./internal/project ./internal/cli`
- [x] `go test -race ./internal/workspace -run '^TestLocalGitDiffStat$' -count=1`
- [x] `make check`
