### PR TITLE
fix(refresh): accelerate board hydration

### DIFF
--- a/internal/connector/github/pull_requests.go
+++ b/internal/connector/github/pull_requests.go
@@ -9,6 +9,8 @@ import (
 	"strings"
 	"time"
 
+	"golang.org/x/sync/errgroup"
+
 	"github.com/digitaldrywood/detent/internal/citrigger"
 	"github.com/digitaldrywood/detent/internal/connector"
 	"github.com/digitaldrywood/detent/internal/reviewseverity"
@@ -30,6 +32,18 @@ type pullRequestKey struct {
 type pullRequestRepo struct {
 	Owner string
 	Name  string
+}
+
+const (
+	linkedPullRequestHydrationConcurrency     = 8
+	linkedPullRequestHydrationRequestEstimate = 5
+)
+
+type linkedPullRequestHydration struct {
+	repo        pullRequestRepo
+	number      int
+	pullRequest pullRequestNode
+	state       pullRequestHydrationState
 }
 
 func (c *Connector) attachPullRequests(ctx context.Context, issues []connector.Issue) error {
@@ -455,8 +469,9 @@ func (c *Connector) attachLinkedPullRequests(
 	candidates []issuePullRequestCandidate,
 	useStatusCache bool,
 ) (string, error) {
-	pullRequests := map[pullRequestKey]pullRequestNode{}
-	nextCursor := ""
+	hydrations := make([]linkedPullRequestHydration, 0, len(candidates))
+	hydrationByKey := make(map[pullRequestKey]int, len(candidates))
+	hydrationByCandidate := make(map[int]int, len(candidates))
 	for _, candidate := range candidates {
 		if issues[candidate.Index].PullRequest != nil || candidate.PullRequestNumber <= 0 {
 			continue
@@ -471,35 +486,87 @@ func (c *Connector) attachLinkedPullRequests(
 			continue
 		}
 		key := pullRequestKey{Repo: pullRequestRepo, Number: candidate.PullRequestNumber}
-		pullRequest, ok := pullRequests[key]
+		hydrationIndex, ok := hydrationByKey[key]
 		if !ok {
-			var err error
-			pullRequest, err = c.fetchRepositoryPullRequest(ctx, pullRequestRepo, candidate.PullRequestNumber)
-			if err != nil {
-				if state := c.pullRequestHydrationStateForError(pullRequestRepo, err); state.Reason != "" {
-					if errors.Is(err, ErrRESTBudgetReserved) && nextCursor == "" {
-						nextCursor = candidate.Identifier
-					}
-					attachPullRequestHydrationUnavailableToIssue(&issues[candidate.Index], pullRequestRepo, candidate.PullRequestNumber, state)
-					continue
-				}
-				return "", err
-			}
-			if err := c.populatePullRequestStatus(ctx, pullRequestRepo, &pullRequest, useStatusCache); err != nil {
-				if state := c.pullRequestHydrationStateForError(pullRequestRepo, err); state.Reason != "" {
-					if errors.Is(err, ErrRESTBudgetReserved) && nextCursor == "" {
-						nextCursor = candidate.Identifier
-					}
-					applyPullRequestHydrationUnavailableState(&pullRequest, state)
-				} else {
-					return "", err
-				}
-			}
-			pullRequests[key] = pullRequest
+			hydrationIndex = len(hydrations)
+			hydrationByKey[key] = hydrationIndex
+			hydrations = append(hydrations, linkedPullRequestHydration{
+				repo:   pullRequestRepo,
+				number: candidate.PullRequestNumber,
+			})
 		}
-		attachPullRequestToIssue(&issues[candidate.Index], pullRequestRepo, pullRequest)
+		hydrationByCandidate[candidate.Index] = hydrationIndex
+	}
+
+	group, groupCtx := errgroup.WithContext(ctx)
+	group.SetLimit(c.linkedPullRequestHydrationLimit())
+	for index := range hydrations {
+		group.Go(func() error {
+			return c.hydrateLinkedPullRequest(groupCtx, &hydrations[index], useStatusCache)
+		})
+	}
+	if err := group.Wait(); err != nil {
+		return "", err
+	}
+
+	nextCursor := ""
+	for _, candidate := range candidates {
+		hydrationIndex, ok := hydrationByCandidate[candidate.Index]
+		if !ok {
+			continue
+		}
+		hydration := hydrations[hydrationIndex]
+		if hydration.state.Reason != "" {
+			if hydration.state.Reason == connector.PullRequestHydrationReasonRESTBudgetReserved && nextCursor == "" {
+				nextCursor = candidate.Identifier
+			}
+			if hydration.pullRequest.Number <= 0 {
+				attachPullRequestHydrationUnavailableToIssue(&issues[candidate.Index], hydration.repo, candidate.PullRequestNumber, hydration.state)
+				continue
+			}
+		}
+		attachPullRequestToIssue(&issues[candidate.Index], hydration.repo, hydration.pullRequest)
 	}
 	return nextCursor, nil
+}
+
+func (c *Connector) hydrateLinkedPullRequest(ctx context.Context, hydration *linkedPullRequestHydration, useStatusCache bool) error {
+	pullRequest, err := c.fetchRepositoryPullRequest(ctx, hydration.repo, hydration.number)
+	if err != nil {
+		state := c.pullRequestHydrationStateForError(hydration.repo, err)
+		if state.Reason == "" {
+			return err
+		}
+		hydration.state = state
+		return nil
+	}
+	if err := c.populatePullRequestStatus(ctx, hydration.repo, &pullRequest, useStatusCache); err != nil {
+		state := c.pullRequestHydrationStateForError(hydration.repo, err)
+		if state.Reason == "" {
+			return err
+		}
+		hydration.state = state
+		applyPullRequestHydrationUnavailableState(&pullRequest, state)
+	}
+	hydration.pullRequest = pullRequest
+	return nil
+}
+
+func (c *Connector) linkedPullRequestHydrationLimit() int {
+	limit := linkedPullRequestHydrationConcurrency
+	if c == nil || c.client == nil {
+		return limit
+	}
+	if fanoutLimit := c.client.restPolicy.FanoutMaxRequests; fanoutLimit > 0 {
+		limit = int(fanoutLimit) / linkedPullRequestHydrationRequestEstimate
+		if limit < 1 {
+			return 1
+		}
+		if limit > linkedPullRequestHydrationConcurrency {
+			return linkedPullRequestHydrationConcurrency
+		}
+	}
+	return limit
 }
 
 func (c *Connector) attachMatchingPullRequests(

--- a/internal/connector/github/pull_requests.go
+++ b/internal/connector/github/pull_requests.go
@@ -498,9 +498,17 @@ func (c *Connector) attachLinkedPullRequests(
 		hydrationByCandidate[candidate.Index] = hydrationIndex
 	}
 
+	concurrentStart := 0
+	if c.linkedPullRequestHydrationUsesFiniteFanoutCap() && len(hydrations) > 0 {
+		if err := c.hydrateLinkedPullRequest(ctx, &hydrations[0], useStatusCache); err != nil {
+			return "", err
+		}
+		concurrentStart = 1
+	}
+
 	group, groupCtx := errgroup.WithContext(ctx)
 	group.SetLimit(c.linkedPullRequestHydrationLimit())
-	for index := range hydrations {
+	for index := concurrentStart; index < len(hydrations); index++ {
 		group.Go(func() error {
 			return c.hydrateLinkedPullRequest(groupCtx, &hydrations[index], useStatusCache)
 		})
@@ -550,6 +558,10 @@ func (c *Connector) hydrateLinkedPullRequest(ctx context.Context, hydration *lin
 	}
 	hydration.pullRequest = pullRequest
 	return nil
+}
+
+func (c *Connector) linkedPullRequestHydrationUsesFiniteFanoutCap() bool {
+	return c != nil && c.client != nil && c.client.restPolicy.FanoutMaxRequests > 0
 }
 
 func (c *Connector) linkedPullRequestHydrationLimit() int {

--- a/internal/connector/github/pull_requests_concurrency_test.go
+++ b/internal/connector/github/pull_requests_concurrency_test.go
@@ -1,0 +1,144 @@
+package github
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/digitaldrywood/detent/internal/connector"
+)
+
+func TestConnectorHydratesLinkedPullRequestsConcurrently(t *testing.T) {
+	t.Parallel()
+
+	const issueCount = 4
+	allDetailsStarted := make(chan struct{})
+	var detailRequests atomic.Int64
+	var startedOnce sync.Once
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if pullRequestNumber, ok := pullRequestDetailNumber(r.URL.Path); ok {
+			if detailRequests.Add(1) == issueCount {
+				startedOnce.Do(func() { close(allDetailsStarted) })
+			}
+			select {
+			case <-allDetailsStarted:
+			case <-r.Context().Done():
+				return
+			}
+			_, _ = fmt.Fprintf(w, `{"number":%d,"html_url":"https://github.com/digitaldrywood/detent/pull/%d","state":"open","head":{"ref":"detent/issue-%d","sha":"sha-%d"}}`, pullRequestNumber, pullRequestNumber, pullRequestNumber, pullRequestNumber)
+			return
+		}
+		writePullRequestStatusResponse(w, r.URL.Path)
+	}))
+	t.Cleanup(server.Close)
+
+	githubConnector, err := NewConnector(Config{
+		Endpoint:                   server.URL,
+		APIKey:                     "token",
+		HTTPClient:                 server.Client(),
+		DisableConditionalRequests: true,
+	})
+	if err != nil {
+		t.Fatalf("NewConnector() error = %v", err)
+	}
+
+	issues := linkedPullRequestIssues(1, issueCount)
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	t.Cleanup(cancel)
+	if err := githubConnector.attachPullRequests(ctx, issues); err != nil {
+		t.Fatalf("attachPullRequests() error = %v; detail requests started = %d, want %d concurrent requests", err, detailRequests.Load(), issueCount)
+	}
+	if got := detailRequests.Load(); got != issueCount {
+		t.Fatalf("detail requests started = %d, want %d", got, issueCount)
+	}
+	for index, issue := range issues {
+		if issue.PullRequest == nil || issue.PullRequest.Number != index+1 {
+			t.Fatalf("issues[%d].PullRequest = %#v, want PR %d", index, issue.PullRequest, index+1)
+		}
+	}
+}
+
+func BenchmarkConnectorHydratesLinkedPullRequests(b *testing.B) {
+	const (
+		issueCount   = 8
+		requestDelay = 5 * time.Millisecond
+	)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		timer := time.NewTimer(requestDelay)
+		defer timer.Stop()
+		select {
+		case <-timer.C:
+		case <-r.Context().Done():
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		if pullRequestNumber, ok := pullRequestDetailNumber(r.URL.Path); ok {
+			_, _ = fmt.Fprintf(w, `{"number":%d,"html_url":"https://github.com/digitaldrywood/detent/pull/%d","state":"open","head":{"ref":"detent/issue-%d","sha":"sha-%d"}}`, pullRequestNumber, pullRequestNumber, pullRequestNumber, pullRequestNumber)
+			return
+		}
+		writePullRequestStatusResponse(w, r.URL.Path)
+	}))
+	b.Cleanup(server.Close)
+
+	githubConnector, err := NewConnector(Config{
+		Endpoint:                   server.URL,
+		APIKey:                     "token",
+		HTTPClient:                 server.Client(),
+		DisableConditionalRequests: true,
+	})
+	if err != nil {
+		b.Fatalf("NewConnector() error = %v", err)
+	}
+
+	nextPullRequest := 1
+	b.ResetTimer()
+	for b.Loop() {
+		issues := linkedPullRequestIssues(nextPullRequest, issueCount)
+		if err := githubConnector.attachPullRequests(context.Background(), issues); err != nil {
+			b.Fatalf("attachPullRequests() error = %v", err)
+		}
+		nextPullRequest += issueCount
+	}
+}
+
+func linkedPullRequestIssues(first int, count int) []connector.Issue {
+	issues := make([]connector.Issue, count)
+	for index := range count {
+		number := first + index
+		issues[index] = connector.Issue{
+			Identifier: fmt.Sprintf("digitaldrywood/detent#%d", number),
+			PRNumber:   &number,
+		}
+	}
+	return issues
+}
+
+func pullRequestDetailNumber(path string) (int, bool) {
+	if !strings.Contains(path, "/pulls/") || strings.HasSuffix(path, "/reviews") {
+		return 0, false
+	}
+	number, err := strconv.Atoi(path[strings.LastIndex(path, "/")+1:])
+	return number, err == nil
+}
+
+func writePullRequestStatusResponse(w http.ResponseWriter, path string) {
+	switch {
+	case strings.HasSuffix(path, "/check-runs") || strings.Contains(path, "/check-runs?"):
+		_, _ = w.Write([]byte(`{"check_runs":[]}`))
+	case strings.HasSuffix(path, "/statuses") || strings.Contains(path, "/statuses?"):
+		_, _ = w.Write([]byte(`[]`))
+	case strings.HasSuffix(path, "/reviews") || strings.Contains(path, "/reviews?"):
+		_, _ = w.Write([]byte(`[]`))
+	default:
+		http.Error(w, "unexpected path "+path, http.StatusNotFound)
+	}
+}

--- a/internal/connector/github/pull_requests_concurrency_test.go
+++ b/internal/connector/github/pull_requests_concurrency_test.go
@@ -66,6 +66,128 @@ func TestConnectorHydratesLinkedPullRequestsConcurrently(t *testing.T) {
 	}
 }
 
+func TestConnectorFiniteFanoutCompletesPriorityHydrationBeforeConcurrentTail(t *testing.T) {
+	t.Parallel()
+
+	firstStarted := make(chan struct{})
+	releaseFirst := make(chan struct{})
+	secondStarted := make(chan struct{})
+	var firstOnce sync.Once
+	var secondOnce sync.Once
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if pullRequestNumber, ok := pullRequestDetailNumber(r.URL.Path); ok {
+			switch pullRequestNumber {
+			case 1:
+				firstOnce.Do(func() { close(firstStarted) })
+				select {
+				case <-releaseFirst:
+				case <-r.Context().Done():
+					return
+				}
+			case 2:
+				secondOnce.Do(func() { close(secondStarted) })
+			}
+			_, _ = fmt.Fprintf(w, `{"number":%d,"html_url":"https://github.com/digitaldrywood/detent/pull/%d","state":"open","head":{"ref":"detent/issue-%d","sha":"sha-%d"}}`, pullRequestNumber, pullRequestNumber, pullRequestNumber, pullRequestNumber)
+			return
+		}
+		writePullRequestStatusResponse(w, r.URL.Path)
+	}))
+	t.Cleanup(server.Close)
+
+	githubConnector, err := NewConnector(Config{
+		Endpoint:                   server.URL,
+		APIKey:                     "token",
+		HTTPClient:                 server.Client(),
+		RESTFanoutMaxRequests:      80,
+		DisableConditionalRequests: true,
+	})
+	if err != nil {
+		t.Fatalf("NewConnector() error = %v", err)
+	}
+
+	done := make(chan error, 1)
+	go func() {
+		done <- githubConnector.attachPullRequests(context.Background(), linkedPullRequestIssues(1, 2))
+	}()
+
+	select {
+	case <-firstStarted:
+	case <-time.After(time.Second):
+		t.Fatal("priority hydration did not start")
+	}
+	select {
+	case <-secondStarted:
+		t.Fatal("concurrent tail started before priority hydration completed")
+	case <-time.After(100 * time.Millisecond):
+	}
+	close(releaseFirst)
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("attachPullRequests() error = %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("attachPullRequests() did not complete")
+	}
+	select {
+	case <-secondStarted:
+	default:
+		t.Fatal("concurrent tail did not start after priority hydration completed")
+	}
+}
+
+func TestConnectorFiniteFanoutPreservesPriorityWithPaginatedHydration(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if pullRequestNumber, ok := pullRequestDetailNumber(r.URL.Path); ok {
+			_, _ = fmt.Fprintf(w, `{"number":%d,"html_url":"https://github.com/digitaldrywood/detent/pull/%d","state":"open","head":{"ref":"detent/issue-%d","sha":"sha-%d"}}`, pullRequestNumber, pullRequestNumber, pullRequestNumber, pullRequestNumber)
+			return
+		}
+		if strings.Contains(r.URL.Path, "/reviews") {
+			page, _ := strconv.Atoi(r.URL.Query().Get("page"))
+			if page == 0 {
+				page = 1
+			}
+			if page < 3 {
+				next := *r.URL
+				query := next.Query()
+				query.Set("page", strconv.Itoa(page+1))
+				next.RawQuery = query.Encode()
+				w.Header().Set("Link", "<"+next.String()+">; rel=\"next\"")
+			}
+			_, _ = w.Write([]byte(`[]`))
+			return
+		}
+		writePullRequestStatusResponse(w, r.URL.Path)
+	}))
+	t.Cleanup(server.Close)
+
+	githubConnector, err := NewConnector(Config{
+		Endpoint:                   server.URL,
+		APIKey:                     "token",
+		HTTPClient:                 server.Client(),
+		RESTFanoutMaxRequests:      10,
+		DisableConditionalRequests: true,
+	})
+	if err != nil {
+		t.Fatalf("NewConnector() error = %v", err)
+	}
+
+	issues := linkedPullRequestIssues(1, 2)
+	if err := githubConnector.attachPullRequests(context.Background(), issues); err != nil {
+		t.Fatalf("attachPullRequests() error = %v", err)
+	}
+	if issues[0].PullRequest == nil || issues[0].PullRequest.HydrationUnavailableReason != "" {
+		t.Fatalf("priority PullRequest = %#v, want complete hydration", issues[0].PullRequest)
+	}
+	if issues[1].PullRequest == nil || issues[1].PullRequest.HydrationUnavailableReason != connector.PullRequestHydrationReasonRESTBudgetReserved {
+		t.Fatalf("tail PullRequest = %#v, want deferred hydration", issues[1].PullRequest)
+	}
+}
+
 func BenchmarkConnectorHydratesLinkedPullRequests(b *testing.B) {
 	const (
 		issueCount   = 8
@@ -93,6 +215,7 @@ func BenchmarkConnectorHydratesLinkedPullRequests(b *testing.B) {
 		Endpoint:                   server.URL,
 		APIKey:                     "token",
 		HTTPClient:                 server.Client(),
+		RESTFanoutMaxRequests:      80,
 		DisableConditionalRequests: true,
 	})
 	if err != nil {

--- a/internal/orchestrator/refresh_timing.go
+++ b/internal/orchestrator/refresh_timing.go
@@ -1,0 +1,83 @@
+package orchestrator
+
+import (
+	"context"
+	"log/slog"
+	"strings"
+	"time"
+)
+
+type refreshTiming struct {
+	logger       *slog.Logger
+	projectID    string
+	manual       bool
+	startedAt    time.Time
+	phaseStarted time.Time
+	phase        string
+	phases       []any
+}
+
+func newRefreshTiming(logger *slog.Logger, projectID string, manual bool) *refreshTiming {
+	now := time.Now()
+	return &refreshTiming{
+		logger:       logger,
+		projectID:    strings.TrimSpace(projectID),
+		manual:       manual,
+		startedAt:    now,
+		phaseStarted: now,
+		phase:        "preflight",
+	}
+}
+
+func (t *refreshTiming) next(phase string) {
+	if t == nil {
+		return
+	}
+	now := time.Now()
+	t.finishPhase(now)
+	t.phase = strings.TrimSpace(phase)
+	t.phaseStarted = now
+}
+
+func (t *refreshTiming) log(ctx context.Context, completed bool, state *State) {
+	if t == nil || t.logger == nil {
+		return
+	}
+	now := time.Now()
+	t.finishPhase(now)
+	attrs := []any{
+		"project_id", t.projectID,
+		"manual", t.manual,
+		"completed", completed,
+		"total_duration", now.Sub(t.startedAt),
+	}
+	if state != nil {
+		attrs = append(attrs,
+			"refresh_status", refreshTimingStatus(state),
+			"last_error", strings.TrimSpace(state.LastRefreshError),
+		)
+	}
+	attrs = append(attrs, t.phases...)
+	t.logger.InfoContext(ctx, "project refresh timing", attrs...)
+}
+
+func refreshTimingStatus(state *State) string {
+	if state == nil {
+		return "unknown"
+	}
+	if strings.TrimSpace(state.LastRefreshError) != "" || !state.LastRefreshErrorAt.IsZero() {
+		return "degraded"
+	}
+	if state.LastRefreshAt.IsZero() {
+		return "initializing"
+	}
+	return "ready"
+}
+
+func (t *refreshTiming) finishPhase(now time.Time) {
+	if t.phase == "" {
+		return
+	}
+	t.phases = append(t.phases, t.phase+"_duration", now.Sub(t.phaseStarted))
+	t.phase = ""
+}

--- a/internal/orchestrator/refresh_timing_test.go
+++ b/internal/orchestrator/refresh_timing_test.go
@@ -1,0 +1,57 @@
+package orchestrator
+
+import (
+	"bytes"
+	"context"
+	"log/slog"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestRefreshTimingLogsEveryCompletedPhase(t *testing.T) {
+	t.Parallel()
+
+	var logs bytes.Buffer
+	timing := newRefreshTiming(
+		slog.New(slog.NewTextHandler(&logs, nil)),
+		"digitaldrywood/detent",
+		true,
+	)
+	for _, phase := range []string{
+		"release",
+		"active_runs",
+		"tracker_fetch",
+		"status_drift",
+		"reconciliation",
+		"rate_limits",
+		"dispatch",
+		"publish",
+	} {
+		timing.next(phase)
+	}
+	timing.log(context.Background(), true, &State{LastRefreshAt: time.Now()})
+
+	got := logs.String()
+	for _, want := range []string{
+		`msg="project refresh timing"`,
+		"project_id=digitaldrywood/detent",
+		"manual=true",
+		"completed=true",
+		"refresh_status=ready",
+		"total_duration=",
+		"preflight_duration=",
+		"release_duration=",
+		"active_runs_duration=",
+		"tracker_fetch_duration=",
+		"status_drift_duration=",
+		"reconciliation_duration=",
+		"rate_limits_duration=",
+		"dispatch_duration=",
+		"publish_duration=",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("logs = %q, want %q", got, want)
+		}
+	}
+}

--- a/internal/orchestrator/tick.go
+++ b/internal/orchestrator/tick.go
@@ -53,6 +53,11 @@ func (o *Orchestrator) tickManual(ctx context.Context, state *State, request man
 func (o *Orchestrator) tickWithManual(ctx context.Context, state *State, now time.Time, manual *manualRefreshRequest) {
 	o.beginGlobalProjectCycle()
 	defer o.endGlobalProjectCycle()
+	completed := false
+	timing := newRefreshTiming(o.logger, o.cfg.Project.ID, manual != nil)
+	defer func() {
+		timing.log(ctx, completed, state)
+	}()
 	state.tickTransitions = &issueStateSnapshotTransitions{}
 	defer func() {
 		state.tickTransitions = nil
@@ -60,7 +65,6 @@ func (o *Orchestrator) tickWithManual(ctx context.Context, state *State, now tim
 	if manual != nil {
 		startManualRefresh(state, *manual, now)
 	}
-	completed := false
 	restRateLimitsCaptured := false
 	previous := captureTickPreviousState(state)
 	o.markRefresh(state, now)
@@ -90,17 +94,22 @@ func (o *Orchestrator) tickWithManual(ctx context.Context, state *State, now tim
 			Message: githubBudgetReserveMessage(reserve),
 		})
 	}
+	timing.next("release")
 	o.evaluateRelease(ctx, state, now)
 
+	timing.next("active_runs")
 	o.refreshActiveRuns(ctx, state, now, reserve)
 	if state.Draining {
 		return
 	}
+	timing.next("tracker_fetch")
 	fetched, ok := o.fetchTickIssues(ctx, state, now, reserve)
 	if !ok {
 		return
 	}
+	timing.next("status_drift")
 	o.refreshStatusDrift(ctx, state, now, reserve)
+	timing.next("reconciliation")
 	fetched = retainUnavailablePullRequestsFromPrevious(fetched, previous)
 	fetched = applyStatusPullRequestHydrationBlocksToCandidates(fetched)
 	o.observePullRequestHydrationSkips(mergeIssueSlices(fetched.candidates, fetched.status))
@@ -190,11 +199,14 @@ func (o *Orchestrator) tickWithManual(ctx context.Context, state *State, now tim
 		fetched,
 		artifactWaitTransitions.transitioned,
 	)
+	timing.next("rate_limits")
 	restCycle := o.captureConnectorRESTRateLimits(state, now)
 	o.logRESTRateLimitCycle(restCycle)
 	o.syncGitHubRESTCapacityOutage(state, now)
 	restRateLimitsCaptured = true
+	timing.next("dispatch")
 	o.dispatchTickIssues(ctx, state, fetched, transitions, previous, completedEpics, now)
+	timing.next("publish")
 	if refreshSucceeded(state) {
 		state.BoardIssues = overlayIssueStateSnapshots(
 			boardIssuesFromFetched(fetched),

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -482,7 +482,14 @@ func (s *Server) projectDashboard(c echo.Context) error {
 		}
 		return s.demoProjectDashboard(c, scenario, view)
 	}
-	data, ok := s.projectDashboardData(ctx, projectID, s.latestSnapshot(ctx))
+	var data templates.DashboardData
+	var ok bool
+	if view == "kanban" {
+		snapshot, enriched := s.latestBoardSnapshot()
+		data, ok = s.projectBoardFirstPaintData(ctx, projectID, snapshot, !enriched)
+	} else {
+		data, ok = s.projectDashboardData(ctx, projectID, s.latestSnapshot(ctx))
+	}
 	if !ok {
 		return echo.NewHTTPError(http.StatusNotFound, "Project not found")
 	}
@@ -680,6 +687,28 @@ func (s *Server) analyticsDashboardData(ctx context.Context, snapshot telemetry.
 
 func (s *Server) projectDashboardData(ctx context.Context, projectID string, snapshot telemetry.Snapshot) (templates.DashboardData, bool) {
 	projects := s.projectSmallMultiples(ctx, snapshot)
+	return s.projectDashboardDataFromProjects(ctx, projectID, snapshot, projects, true)
+}
+
+func (s *Server) projectBoardFirstPaintData(
+	ctx context.Context,
+	projectID string,
+	snapshot telemetry.Snapshot,
+	pendingEnrichment bool,
+) (templates.DashboardData, bool) {
+	projects := s.cachedProjectSmallMultiples(snapshot)
+	data, ok := s.projectDashboardDataFromProjects(ctx, projectID, snapshot, projects, false)
+	data.PendingEnrichment = pendingEnrichment
+	return data, ok
+}
+
+func (s *Server) projectDashboardDataFromProjects(
+	ctx context.Context,
+	projectID string,
+	snapshot telemetry.Snapshot,
+	projects []templates.ProjectSmallMultiple,
+	loadDetails bool,
+) (templates.DashboardData, bool) {
 	project, ok := s.dashboardProject(projectID, projects, snapshot)
 	if !ok {
 		return templates.DashboardData{}, false
@@ -695,7 +724,9 @@ func (s *Server) projectDashboardData(ctx context.Context, projectID string, sna
 	if target, _, _ := s.kanbanActionTarget(project.ID); target.key != "" {
 		scopedSnapshot = s.kanbanSnapshotWithPendingStates(target.key, project.ID, scopedSnapshot)
 	}
-	scopedSnapshot.WorkflowMetrics = s.snapshotWorkflowMetrics(ctx, scopedSnapshot)
+	if loadDetails {
+		scopedSnapshot.WorkflowMetrics = s.snapshotWorkflowMetrics(ctx, scopedSnapshot)
+	}
 	name := strings.TrimSpace(project.Name)
 	if name == "" {
 		name = strings.TrimSpace(project.ID)
@@ -718,11 +749,13 @@ func (s *Server) projectDashboardData(ctx context.Context, projectID string, sna
 		ProjectName:     name,
 		ProjectPaused:   project.Paused,
 	}
-	receipts, err := s.store.ListEfficiencyReceipts(ctx, efficiency.Query{ProjectID: project.ID, Limit: 100})
-	if err != nil {
-		s.logger.Warn("efficiency receipts query failed", slog.Any("error", err))
-	} else {
-		data.EfficiencyReceipts = receipts
+	if loadDetails {
+		receipts, err := s.store.ListEfficiencyReceipts(ctx, efficiency.Query{ProjectID: project.ID, Limit: 100})
+		if err != nil {
+			s.logger.Warn("efficiency receipts query failed", slog.Any("error", err))
+		} else {
+			data.EfficiencyReceipts = receipts
+		}
 	}
 	return data, true
 }

--- a/internal/web/server_test.go
+++ b/internal/web/server_test.go
@@ -6794,6 +6794,87 @@ func TestBoardFirstPaintDoesNotWaitForSnapshotEnrichment(t *testing.T) {
 	}
 }
 
+func TestProjectBoardNavigationUsesCurrentInMemorySnapshot(t *testing.T) {
+	t.Parallel()
+
+	releaseStore := make(chan struct{})
+	t.Cleanup(func() { close(releaseStore) })
+	var fetchCalls atomic.Int64
+	var runtimeEvidenceCalls atomic.Int64
+	deps := testDeps(t)
+	deps.Connector = connectorProbe{
+		name: "github",
+		fetchCandidateIssues: func(context.Context) ([]connector.Issue, error) {
+			fetchCalls.Add(1)
+			return nil, errors.New("unexpected tracker hydration")
+		},
+	}
+	deps.Store = storeProbe{
+		runtimeEvidence: func(ctx context.Context, _ store.RuntimeEvidenceQuery) (store.RuntimeEvidence, error) {
+			runtimeEvidenceCalls.Add(1)
+			select {
+			case <-releaseStore:
+				return store.RuntimeEvidence{}, nil
+			case <-ctx.Done():
+				return store.RuntimeEvidence{}, ctx.Err()
+			}
+		},
+	}
+	mustSetWebProject(t, deps.Registry, "detent", false)
+	mustSetWebProject(t, deps.Registry, "pyroapex", false)
+	if err := deps.Hub.Publish(telemetry.Snapshot{
+		GeneratedAt: time.Date(2026, 7, 16, 15, 4, 5, 0, time.UTC),
+		Projects: []telemetry.ProjectSnapshot{
+			{Project: telemetry.Project{ID: "detent", DisplayName: "Detent"}},
+			{Project: telemetry.Project{ID: "pyroapex", DisplayName: "Pyro Apex"}},
+		},
+		BoardIssues: []telemetry.Issue{{
+			ID:         "issue-cached",
+			Identifier: "digitaldrywood/detent#1356",
+			Title:      "Cached project board issue",
+			State:      "In Progress",
+			ProjectID:  "detent",
+		}},
+	}); err != nil {
+		t.Fatalf("Publish() error = %v", err)
+	}
+
+	server, err := web.NewServer(web.Config{}, deps)
+	if err != nil {
+		t.Fatalf("NewServer() error = %v", err)
+	}
+
+	type response struct {
+		code int
+		body string
+	}
+	responseReady := make(chan response, 1)
+	go func() {
+		rec := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodGet, "/projects/detent/kanban", nil)
+		server.Handler().ServeHTTP(rec, req)
+		responseReady <- response{code: rec.Code, body: rec.Body.String()}
+	}()
+
+	select {
+	case got := <-responseReady:
+		if got.code != http.StatusOK {
+			t.Fatalf("status = %d, want %d; body = %s", got.code, http.StatusOK, got.body)
+		}
+		if !strings.Contains(got.body, "Cached project board issue") {
+			t.Fatalf("body missing cached project board issue:\n%s", got.body)
+		}
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("project board navigation exceeded 500ms while current in-memory state was available")
+	}
+	if got := fetchCalls.Load(); got != 0 {
+		t.Fatalf("FetchCandidateIssues calls = %d, want 0", got)
+	}
+	if got := runtimeEvidenceCalls.Load(); got != 0 {
+		t.Fatalf("RuntimeEvidence calls = %d, want 0", got)
+	}
+}
+
 func TestBoardFirstPaintColdBootRendersPlaceholders(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

- emit a structured `project refresh timing` log for every refresh with total, preflight, release, active-run, tracker-fetch, status-drift, reconciliation, rate-limit, dispatch, and publish durations
- hydrate linked pull requests with budget-aware bounded concurrency, deduplicating shared PRs while preserving REST fanout rotation and throttle markers
- render project Kanban navigation from the current hub snapshot so it never waits for tracker or runtime-store enrichment when in-memory board state is current

## Root cause and measurements

The multi-project manager already starts projects concurrently, and board handlers do not call `FetchCandidateIssues`. The dominant restart cost was one layer deeper: each linked PR was hydrated serially through PR detail, check-runs, commit statuses, workflow-run metadata, and reviews. Warm ETag and PR-status caches hide most of that cost, but both caches are empty after restart, making the entire cold REST fanout serial.

An 8-PR benchmark with 5 ms of simulated healthy API latency per request and the default 80-request fanout cap measured **188.8–197.1 ms/op before** and **48.5–51.4 ms/op after**, a roughly **3.8x reduction**. Concurrency is capped at eight and reduced automatically from `tracker.github_rest_fanout_max_requests`. Under finite caps, the priority PR completes before the concurrent tail is admitted, so pagination cannot fragment every hydration and the existing rotation guarantee keeps producing useful state.

The board-to-board stall had a separate web-path cause: `/projects/:id/kanban` called `latestSnapshot`, then waited for runtime-store enrichment and repeated project metrics queries even though the hub already contained current board state. The regression exceeded its 500 ms deadline before the change and now returns immediately with zero tracker fetches and zero runtime-evidence queries.

Fixes #1356

## UI Surface Contract

- [x] No high-impact layout, density, first-viewport, or responsive visibility change.
- [x] This PR adds no persistent top-of-screen messaging.
- [x] No visual output change; the project Kanban route changes only its data source and blocking behavior.

## Test Plan

- [x] `go test -race ./internal/connector/github ./internal/orchestrator ./internal/web`
- [x] cold hydration benchmark, six before/after samples with `-benchtime=1x`
- [x] finite-cap regressions cover priority-first admission and paginated review hydration at a cap of 10
- [x] `make check` (77.4% aggregate coverage; configured package/file floors pass)
