### PR TITLE
feat(cli): add service start and status

### DIFF
--- a/cmd/detent/main_test.go
+++ b/cmd/detent/main_test.go
@@ -72,6 +72,8 @@ func TestRootCommandHelpCatalogJSON(t *testing.T) {
 		"add-project": false,
 		"config path": false,
 		"doctor":      false,
+		"start":       false,
+		"status":      false,
 		"update":      false,
 		"version":     false,
 		"shadow-run":  false,

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -235,6 +235,7 @@ type options struct {
 	stdoutTTY     func() bool
 	shutdown      *ShutdownController
 	restart       *RestartRequest
+	service       ServiceFactory
 }
 
 func WithBootFunc(boot BootFunc) Option {
@@ -302,6 +303,14 @@ func WithRestartRequest(restart *RestartRequest) Option {
 func WithLoggerFunc(configure LoggerFunc) Option {
 	return func(opts *options) {
 		opts.configureLog = configure
+	}
+}
+
+func WithServiceFactory(factory ServiceFactory) Option {
+	return func(opts *options) {
+		if factory != nil {
+			opts.service = factory
+		}
 	}
 }
 
@@ -414,6 +423,8 @@ detent --format json config path`),
 	cmd.PersistentFlags().BoolVar(&headless, "headless", false, "stream logs instead of launching the terminal dashboard")
 	AddFormatFlag(cmd, &format)
 	cmd.AddCommand(
+		newStartCommand(&configPath, &host, &port, opts),
+		newStatusCommand(&configPath, &host, &port, opts),
 		newDoctorCommand(&configPath, &env, &logLevel, &host, &port, opts),
 		newCITriggerLabelCommand(opts),
 		newDevRuntimeCommand(&host, &port, opts),
@@ -468,6 +479,7 @@ func defaultOptions() options {
 		httpDo:      http.DefaultClient.Do,
 		captureDemo: runDemoCapture,
 		stdoutTTY:   stdoutIsTTY,
+		service:     defaultServiceFactory,
 	}
 }
 

--- a/internal/cli/service.go
+++ b/internal/cli/service.go
@@ -1,0 +1,281 @@
+package cli
+
+import (
+	"bufio"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	servicepkg "github.com/digitaldrywood/detent/internal/service"
+	"github.com/digitaldrywood/detent/internal/update"
+)
+
+type ServiceRunner interface {
+	Start(context.Context, servicepkg.StartOptions) (servicepkg.StartResult, error)
+	Status(context.Context) (servicepkg.Status, error)
+}
+
+type ServiceFactory func(servicepkg.Config) (ServiceRunner, error)
+
+func defaultServiceFactory(cfg servicepkg.Config) (ServiceRunner, error) {
+	return servicepkg.New(cfg)
+}
+
+func newStartCommand(configPath *string, host *string, port *int, opts options) *cobra.Command {
+	var assumeYes bool
+	var restart bool
+
+	cmd := &cobra.Command{
+		Use:          "start",
+		Short:        "Start Detent as a background service",
+		Example:      "detent start",
+		Args:         NoArgs,
+		SilenceUsage: true,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			out, err := OutputForCommand(cmd)
+			if err != nil {
+				return err
+			}
+			runner, err := serviceRunnerForCommand(cmd, configPath, host, port, opts)
+			if err != nil {
+				return err
+			}
+			result, err := runner.Start(cmd.Context(), servicepkg.StartOptions{Install: assumeYes, Restart: restart})
+			if err != nil {
+				return err
+			}
+			if result.Action == servicepkg.ActionNeedsInstall {
+				if out.IsJSON() {
+					if writeErr := out.WriteJSON(result); writeErr != nil {
+						return writeErr
+					}
+					return NewValidationError("service installation confirmation required", "Run detent start --yes to install and start the service.", nil)
+				}
+				confirmed, err := confirmServiceInstall(cmd, result)
+				if err != nil {
+					return err
+				}
+				if !confirmed {
+					_, err := fmt.Fprintln(cmd.OutOrStdout(), "Service installation canceled.")
+					return err
+				}
+				result, err = runner.Start(cmd.Context(), servicepkg.StartOptions{Install: true, Restart: restart})
+				if err != nil {
+					return err
+				}
+			}
+			return out.Write(func(out io.Writer) error {
+				return writeStartText(out, result)
+			}, result)
+		},
+	}
+	cmd.Flags().BoolVarP(&assumeYes, "yes", "y", false, "install a missing user service without prompting")
+	cmd.Flags().BoolVar(&restart, "restart", false, "restart Detent when the managed service is already running")
+	return cmd
+}
+
+func newStatusCommand(configPath *string, host *string, port *int, opts options) *cobra.Command {
+	return &cobra.Command{
+		Use:          "status",
+		Short:        "Show Detent installation and service status",
+		Example:      "detent status",
+		Args:         NoArgs,
+		SilenceUsage: true,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			out, err := OutputForCommand(cmd)
+			if err != nil {
+				return err
+			}
+			runner, err := serviceRunnerForCommand(cmd, configPath, host, port, opts)
+			if err != nil {
+				return err
+			}
+			status, err := runner.Status(cmd.Context())
+			if err != nil {
+				return err
+			}
+			if err := out.Write(func(out io.Writer) error {
+				return writeServiceStatusText(out, status)
+			}, status); err != nil {
+				return err
+			}
+			if status.Expected && !status.Running() {
+				return servicepkg.ErrNotRunning
+			}
+			return nil
+		},
+	}
+}
+
+func serviceRunnerForCommand(cmd *cobra.Command, configPath *string, host *string, port *int, opts options) (ServiceRunner, error) {
+	resolution, err := resolveConfigPathResolution(pointerString(configPath), opts)
+	if err != nil {
+		return nil, err
+	}
+	cfg, err := opts.readOrDefault(resolution.Path)
+	if err != nil {
+		return nil, err
+	}
+	portFlag := runtimeIntFlag{Value: pointerInt(port, -1), Set: flagChanged(cmd, "port")}
+	resolvedPort, err := resolveRuntimePort(cmd.Context(), runtimeInput{
+		Config:     &cfg,
+		ConfigPath: resolution,
+		Workflow:   firstGlobalWorkflowPath(cfg),
+		Flags:      runtimeFlags{Port: portFlag},
+	}, runtimeDepsFromOptions(opts))
+	if err != nil {
+		return nil, err
+	}
+
+	executable, err := os.Executable()
+	if err != nil {
+		return nil, fmt.Errorf("resolve current executable: %w", err)
+	}
+	arguments := []string{"--config", resolution.Path}
+	if flagChanged(cmd, "host") {
+		arguments = append(arguments, "--host", pointerString(host))
+	}
+	if portFlag.Set {
+		arguments = append(arguments, "--port", strconv.Itoa(portFlag.Value))
+	}
+	arguments = append(arguments, "--headless")
+	install := update.DetectInstallSource(update.DetectionOptions{
+		CurrentVersion: opts.version,
+		ExecutablePath: executable,
+		GOOS:           runtime.GOOS,
+	})
+	factory := opts.service
+	if factory == nil {
+		factory = defaultServiceFactory
+	}
+	return factory(servicepkg.Config{
+		GOOS:         runtime.GOOS,
+		BinaryPath:   executable,
+		ConfigPath:   resolution.Path,
+		Arguments:    arguments,
+		LockPath:     filepath.Join(filepath.Dir(resolution.Path), "detent.db.lock"),
+		Version:      opts.version,
+		AutoUpdate:   serviceAutoUpdate(cfg.Update.AutoCheckEnabled, cfg.Update.AutoApplyEnabled),
+		DashboardURL: "http://" + net.JoinHostPort(dashboardHost, strconv.Itoa(resolvedPort.Value)),
+		Install:      install,
+	})
+}
+
+func confirmServiceInstall(cmd *cobra.Command, result servicepkg.StartResult) (bool, error) {
+	path := "the platform default location"
+	if result.Definition != nil && strings.TrimSpace(result.Definition.Path) != "" {
+		path = result.Definition.Path
+	}
+	if _, err := fmt.Fprintf(cmd.OutOrStdout(), "Install the %s user service at %s? [y/N] ", result.Manager.Name, path); err != nil {
+		return false, err
+	}
+	line, err := bufio.NewReader(cmd.InOrStdin()).ReadString('\n')
+	if err != nil && !errors.Is(err, io.EOF) {
+		return false, fmt.Errorf("read service installation confirmation: %w", err)
+	}
+	answer := strings.ToLower(strings.TrimSpace(line))
+	return answer == "y" || answer == "yes", nil
+}
+
+func writeStartText(out io.Writer, result servicepkg.StartResult) error {
+	switch result.Action {
+	case servicepkg.ActionInstalled:
+		if result.Definition != nil {
+			if _, err := fmt.Fprintf(out, "Wrote %s:\n%s", result.Definition.Path, result.Definition.Content); err != nil {
+				return err
+			}
+		}
+		_, err := fmt.Fprintf(out, "Started %s via %s.\n", result.Manager.Unit, formatServiceManager(result.Manager))
+		return err
+	case servicepkg.ActionRestarted:
+		_, err := fmt.Fprintf(out, "Restarted %s via %s.\n", result.Manager.Unit, formatServiceManager(result.Manager))
+		return err
+	case servicepkg.ActionAlreadyActive:
+		if result.Manager.Name == servicepkg.ManagerManual {
+			_, err := fmt.Fprintf(out, "Detent is already running in foreground/manual mode%s. Stop it before installing a managed service.\n", formatPID(result.PID))
+			return err
+		}
+		_, err := fmt.Fprintf(out, "Detent is already %s via %s%s. Run detent start --restart to restart it.\n", result.State, formatServiceManager(result.Manager), formatPID(result.PID))
+		return err
+	default:
+		_, err := fmt.Fprintf(out, "Started %s via %s.\n", result.Manager.Unit, formatServiceManager(result.Manager))
+		return err
+	}
+}
+
+func writeServiceStatusText(out io.Writer, status servicepkg.Status) error {
+	lines := []string{
+		"Install method: " + string(status.InstallMethod),
+		"Service manager: " + formatServiceManager(servicepkg.ManagerInfo{Name: status.ServiceManager, Scope: status.ServiceScope}),
+		"Service: " + status.Service,
+		"State: " + string(status.State),
+	}
+	if status.PID > 0 {
+		lines = append(lines, "PID: "+strconv.Itoa(status.PID))
+	}
+	if status.UptimeSeconds > 0 {
+		lines = append(lines, "Uptime: "+(time.Duration(status.UptimeSeconds)*time.Second).String())
+	} else {
+		lines = append(lines, "Uptime: unavailable")
+	}
+	lines = append(lines,
+		"Version: "+status.Version,
+		"Auto-update: "+status.AutoUpdate,
+		"Dashboard: "+status.DashboardURL,
+		"Config: "+status.ConfigPath,
+	)
+	if status.DefinitionPath != "" {
+		lines = append(lines, "Definition: "+status.DefinitionPath)
+	}
+	_, err := fmt.Fprintln(out, strings.Join(lines, "\n"))
+	return err
+}
+
+func formatServiceManager(info servicepkg.ManagerInfo) string {
+	if info.Scope == "" || info.Name == servicepkg.ManagerManual {
+		return string(info.Name)
+	}
+	return fmt.Sprintf("%s (%s)", info.Name, info.Scope)
+}
+
+func formatPID(pid int) string {
+	if pid <= 0 {
+		return ""
+	}
+	return fmt.Sprintf(" (PID %d)", pid)
+}
+
+func serviceAutoUpdate(autoCheck bool, autoApply bool) string {
+	switch {
+	case autoApply:
+		return "apply enabled"
+	case autoCheck:
+		return "check enabled"
+	default:
+		return "disabled"
+	}
+}
+
+func pointerString(value *string) string {
+	if value == nil {
+		return ""
+	}
+	return *value
+}
+
+func pointerInt(value *int, fallback int) int {
+	if value == nil {
+		return fallback
+	}
+	return *value
+}

--- a/internal/cli/service.go
+++ b/internal/cli/service.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"net"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"runtime"
 	"strconv"
@@ -154,13 +155,17 @@ func serviceRunnerForCommand(cmd *cobra.Command, configPath *string, host *strin
 		ExecutablePath: executable,
 		GOOS:           runtime.GOOS,
 	})
+	binaryPath := serviceBinaryPath(executable, os.Args[0], exec.LookPath, filepath.EvalSymlinks)
+	if resolvedPort.Source == "PORT" && !portFlag.Set {
+		arguments = append(arguments[:len(arguments)-1], "--port", strconv.Itoa(resolvedPort.Value), "--headless")
+	}
 	factory := opts.service
 	if factory == nil {
 		factory = defaultServiceFactory
 	}
 	return factory(servicepkg.Config{
 		GOOS:         runtime.GOOS,
-		BinaryPath:   executable,
+		BinaryPath:   binaryPath,
 		ConfigPath:   resolution.Path,
 		Arguments:    arguments,
 		LockPath:     filepath.Join(filepath.Dir(resolution.Path), "detent.db.lock"),
@@ -169,6 +174,34 @@ func serviceRunnerForCommand(cmd *cobra.Command, configPath *string, host *strin
 		DashboardURL: "http://" + net.JoinHostPort(dashboardHost, strconv.Itoa(resolvedPort.Value)),
 		Install:      install,
 	})
+}
+
+func serviceBinaryPath(executable string, invocation string, lookPath func(string) (string, error), evalSymlinks func(string) (string, error)) string {
+	invocation = strings.TrimSpace(invocation)
+	if invocation == "" || lookPath == nil || evalSymlinks == nil {
+		return executable
+	}
+	candidate := invocation
+	if !filepath.IsAbs(candidate) && !strings.ContainsAny(candidate, `/\`) {
+		resolved, err := lookPath(candidate)
+		if err != nil {
+			return executable
+		}
+		candidate = resolved
+	}
+	candidate, err := filepath.Abs(candidate)
+	if err != nil {
+		return executable
+	}
+	realCandidate, err := evalSymlinks(candidate)
+	if err != nil {
+		return executable
+	}
+	realExecutable, err := evalSymlinks(executable)
+	if err != nil || filepath.Clean(realCandidate) != filepath.Clean(realExecutable) {
+		return executable
+	}
+	return candidate
 }
 
 func confirmServiceInstall(cmd *cobra.Command, result servicepkg.StartResult) (bool, error) {

--- a/internal/cli/service_test.go
+++ b/internal/cli/service_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"os/exec"
 	"path/filepath"
 	"reflect"
 	"strings"
@@ -260,6 +261,105 @@ func TestServiceCommandResolvesConfigAndRuntime(t *testing.T) {
 	}
 	if want := []string{"--config", path, "--headless"}; !reflect.DeepEqual(captured.Arguments, want) {
 		t.Fatalf("arguments = %#v, want %#v", captured.Arguments, want)
+	}
+}
+
+func TestServiceCommandPersistsEnvironmentPort(t *testing.T) {
+	t.Setenv("PORT", "4200")
+
+	path := filepath.Join(t.TempDir(), "global.yaml")
+	var captured servicepkg.Config
+	runner := &serviceRunnerStub{status: servicepkg.Status{ServiceManager: servicepkg.ManagerManual, Service: string(servicepkg.ManagerManual), State: servicepkg.StateStopped}}
+	cmd := NewRootCommand(t.Context(), WithServiceFactory(func(cfg servicepkg.Config) (ServiceRunner, error) {
+		captured = cfg
+		return runner, nil
+	}))
+	cmd.SetOut(&bytes.Buffer{})
+	cmd.SetErr(&bytes.Buffer{})
+	cmd.SetArgs([]string{"--format", "json", "--config", path, "status"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+	if captured.DashboardURL != "http://localhost:4200" {
+		t.Fatalf("DashboardURL = %q, want environment port", captured.DashboardURL)
+	}
+	want := []string{"--config", path, "--port", "4200", "--headless"}
+	if !reflect.DeepEqual(captured.Arguments, want) {
+		t.Fatalf("arguments = %#v, want %#v", captured.Arguments, want)
+	}
+}
+
+func TestServiceBinaryPathPreservesVerifiedInvocation(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	stable := filepath.Join(root, "bin", "detent")
+	cellar := filepath.Join(root, "Cellar", "detent", "1.2.3", "bin", "detent")
+	other := filepath.Join(root, "other", "detent")
+	tests := []struct {
+		name       string
+		invocation string
+		lookPath   func(string) (string, error)
+		eval       func(string) (string, error)
+		want       string
+	}{
+		{
+			name:       "absolute stable symlink",
+			invocation: stable,
+			lookPath:   exec.LookPath,
+			eval: func(path string) (string, error) {
+				if path == stable || path == cellar {
+					return cellar, nil
+				}
+				return path, nil
+			},
+			want: stable,
+		},
+		{
+			name:       "path lookup",
+			invocation: "detent",
+			lookPath: func(string) (string, error) {
+				return stable, nil
+			},
+			eval: func(string) (string, error) {
+				return cellar, nil
+			},
+			want: stable,
+		},
+		{
+			name:       "different executable",
+			invocation: other,
+			lookPath:   exec.LookPath,
+			eval: func(path string) (string, error) {
+				if path == other {
+					return other, nil
+				}
+				return cellar, nil
+			},
+			want: cellar,
+		},
+		{
+			name:       "lookup failure",
+			invocation: "detent",
+			lookPath: func(string) (string, error) {
+				return "", errors.New("not found")
+			},
+			eval: func(path string) (string, error) {
+				return path, nil
+			},
+			want: cellar,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			if got := serviceBinaryPath(cellar, tt.invocation, tt.lookPath, tt.eval); got != tt.want {
+				t.Fatalf("serviceBinaryPath() = %q, want %q", got, tt.want)
+			}
+		})
 	}
 }
 

--- a/internal/cli/service_test.go
+++ b/internal/cli/service_test.go
@@ -1,0 +1,296 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+
+	globalconfig "github.com/digitaldrywood/detent/internal/config/global"
+	servicepkg "github.com/digitaldrywood/detent/internal/service"
+	"github.com/digitaldrywood/detent/internal/update"
+)
+
+func TestStartCommandOffersAndInstallsService(t *testing.T) {
+	t.Parallel()
+
+	runner := &serviceRunnerStub{
+		startResults: []servicepkg.StartResult{
+			{
+				Action:  servicepkg.ActionNeedsInstall,
+				Manager: servicepkg.ManagerInfo{Name: servicepkg.ManagerSystemd, Scope: "user", Unit: "detent.service"},
+				State:   servicepkg.StateStopped,
+				Definition: &servicepkg.Definition{
+					Path:    "/home/user/.config/systemd/user/detent.service",
+					Content: "[Unit]\nDescription=Detent\n",
+				},
+			},
+			{
+				Action:  servicepkg.ActionInstalled,
+				Manager: servicepkg.ManagerInfo{Name: servicepkg.ManagerSystemd, Scope: "user", Unit: "detent.service"},
+				State:   servicepkg.StateRunning,
+				Definition: &servicepkg.Definition{
+					Path:    "/home/user/.config/systemd/user/detent.service",
+					Content: "[Unit]\nDescription=Detent\n",
+				},
+			},
+		},
+	}
+	cmd := NewRootCommand(t.Context(), WithVersion("v1.2.3"), WithServiceFactory(serviceFactoryFor(runner)))
+	var stdout bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&bytes.Buffer{})
+	cmd.SetIn(strings.NewReader("yes\n"))
+	cmd.SetArgs([]string{"--format", "pretty", "start"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+	if len(runner.startOptions) != 2 || runner.startOptions[0].Install || !runner.startOptions[1].Install {
+		t.Fatalf("start options = %#v", runner.startOptions)
+	}
+	for _, want := range []string{
+		"Install the systemd user service at /home/user/.config/systemd/user/detent.service? [y/N]",
+		"Wrote /home/user/.config/systemd/user/detent.service:\n[Unit]\nDescription=Detent\n",
+		"Started detent.service via systemd (user).",
+	} {
+		if !strings.Contains(stdout.String(), want) {
+			t.Fatalf("output missing %q:\n%s", want, stdout.String())
+		}
+	}
+}
+
+func TestStartCommandYesInstallsWithoutPrompt(t *testing.T) {
+	t.Parallel()
+
+	runner := &serviceRunnerStub{startResults: []servicepkg.StartResult{{
+		Action:  servicepkg.ActionInstalled,
+		Manager: servicepkg.ManagerInfo{Name: servicepkg.ManagerLaunchd, Scope: "user", Unit: "com.digitaldrywood.detent"},
+		State:   servicepkg.StateRunning,
+		Definition: &servicepkg.Definition{
+			Path:    "/Users/name/Library/LaunchAgents/com.digitaldrywood.detent.plist",
+			Content: "<plist/>\n",
+		},
+	}}}
+	cmd := NewRootCommand(t.Context(), WithServiceFactory(serviceFactoryFor(runner)))
+	var stdout bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&bytes.Buffer{})
+	cmd.SetArgs([]string{"--format", "pretty", "start", "--yes"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+	if len(runner.startOptions) != 1 || !runner.startOptions[0].Install {
+		t.Fatalf("start options = %#v", runner.startOptions)
+	}
+	if strings.Contains(stdout.String(), "[y/N]") {
+		t.Fatalf("output contains prompt:\n%s", stdout.String())
+	}
+}
+
+func TestStartCommandJSONRequiresExplicitInstallConfirmation(t *testing.T) {
+	t.Parallel()
+
+	runner := &serviceRunnerStub{startResults: []servicepkg.StartResult{{
+		Action:     servicepkg.ActionNeedsInstall,
+		Manager:    servicepkg.ManagerInfo{Name: servicepkg.ManagerSystemd, Scope: "user", Unit: "detent.service"},
+		State:      servicepkg.StateStopped,
+		Definition: &servicepkg.Definition{Path: "/tmp/detent.service", Content: "unit\n"},
+	}}}
+	cmd := NewRootCommand(t.Context(), WithServiceFactory(serviceFactoryFor(runner)))
+	var stdout bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&bytes.Buffer{})
+	cmd.SetArgs([]string{"--format", "json", "start"})
+
+	err := cmd.Execute()
+	if !errors.Is(err, ErrValidation) {
+		t.Fatalf("Execute() error = %v, want validation", err)
+	}
+	var result servicepkg.StartResult
+	if err := json.Unmarshal(stdout.Bytes(), &result); err != nil {
+		t.Fatalf("Unmarshal() error = %v\n%s", err, stdout.String())
+	}
+	if result.Action != servicepkg.ActionNeedsInstall || len(runner.startOptions) != 1 {
+		t.Fatalf("result/options = %#v %#v", result, runner.startOptions)
+	}
+}
+
+func TestStartCommandReportsAlreadyRunning(t *testing.T) {
+	t.Parallel()
+
+	runner := &serviceRunnerStub{startResults: []servicepkg.StartResult{{
+		Action:  servicepkg.ActionAlreadyActive,
+		Manager: servicepkg.ManagerInfo{Name: servicepkg.ManagerSystemd, Scope: "system", Unit: "detent.service"},
+		State:   servicepkg.StateRunning,
+		PID:     42,
+	}}}
+	cmd := NewRootCommand(t.Context(), WithServiceFactory(serviceFactoryFor(runner)))
+	var stdout bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&bytes.Buffer{})
+	cmd.SetArgs([]string{"--format", "pretty", "start"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+	for _, want := range []string{"already running", "systemd (system)", "PID 42", "detent start --restart"} {
+		if !strings.Contains(stdout.String(), want) {
+			t.Fatalf("output missing %q:\n%s", want, stdout.String())
+		}
+	}
+}
+
+func TestStatusCommandReportsFieldsAndFailsWhenExpectedServiceStopped(t *testing.T) {
+	t.Parallel()
+
+	runner := &serviceRunnerStub{status: servicepkg.Status{
+		InstallMethod:  update.InstallSourceRelease,
+		ServiceManager: servicepkg.ManagerSystemd,
+		ServiceScope:   "user",
+		Service:        "detent.service",
+		DefinitionPath: "/home/user/.config/systemd/user/detent.service",
+		Expected:       true,
+		State:          servicepkg.StateStopped,
+		Version:        "v1.2.3",
+		AutoUpdate:     "apply enabled",
+		DashboardURL:   "http://localhost:4000",
+		ConfigPath:     "/home/user/.config/detent/global.yaml",
+	}}
+	cmd := NewRootCommand(t.Context(), WithServiceFactory(serviceFactoryFor(runner)))
+	var stdout bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&bytes.Buffer{})
+	cmd.SetArgs([]string{"--format", "pretty", "status"})
+
+	err := cmd.Execute()
+	if !errors.Is(err, servicepkg.ErrNotRunning) {
+		t.Fatalf("Execute() error = %v, want %v", err, servicepkg.ErrNotRunning)
+	}
+	for _, want := range []string{
+		"Install method: release",
+		"Service manager: systemd (user)",
+		"Service: detent.service",
+		"State: stopped",
+		"Version: v1.2.3",
+		"Auto-update: apply enabled",
+		"Dashboard: http://localhost:4000",
+		"Definition: /home/user/.config/systemd/user/detent.service",
+	} {
+		if !strings.Contains(stdout.String(), want) {
+			t.Fatalf("output missing %q:\n%s", want, stdout.String())
+		}
+	}
+}
+
+func TestStatusCommandManualStoppedIsSuccessful(t *testing.T) {
+	t.Parallel()
+
+	runner := &serviceRunnerStub{status: servicepkg.Status{
+		InstallMethod:  update.InstallSourceDevelopment,
+		ServiceManager: servicepkg.ManagerManual,
+		Service:        string(servicepkg.ManagerManual),
+		State:          servicepkg.StateStopped,
+		Version:        "dev",
+		AutoUpdate:     "disabled",
+		DashboardURL:   "http://localhost:4000",
+		ConfigPath:     "/tmp/global.yaml",
+	}}
+	cmd := NewRootCommand(t.Context(), WithServiceFactory(serviceFactoryFor(runner)))
+	var stdout bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&bytes.Buffer{})
+	cmd.SetArgs([]string{"--format", "json", "status"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+	var status servicepkg.Status
+	if err := json.Unmarshal(stdout.Bytes(), &status); err != nil {
+		t.Fatalf("Unmarshal() error = %v\n%s", err, stdout.String())
+	}
+	if status.ServiceManager != servicepkg.ManagerManual || status.Expected {
+		t.Fatalf("status = %#v", status)
+	}
+}
+
+func TestStoppedManagedServiceUsesNonzeroExitCode(t *testing.T) {
+	t.Parallel()
+
+	if got := ExitCode(servicepkg.ErrNotRunning); got == ExitSuccess {
+		t.Fatalf("ExitCode() = %d, want nonzero", got)
+	}
+}
+
+func TestServiceCommandResolvesConfigAndRuntime(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join(t.TempDir(), "global.yaml")
+	cfg, err := globalconfig.DefaultAt(path)
+	if err != nil {
+		t.Fatalf("DefaultAt() error = %v", err)
+	}
+	port := 4100
+	cfg.Port = &port
+	cfg.Update.AutoApplyEnabled = true
+	if err := globalconfig.Write(path, cfg); err != nil {
+		t.Fatalf("Write() error = %v", err)
+	}
+
+	var captured servicepkg.Config
+	runner := &serviceRunnerStub{status: servicepkg.Status{ServiceManager: servicepkg.ManagerManual, Service: string(servicepkg.ManagerManual), State: servicepkg.StateStopped}}
+	cmd := NewRootCommand(t.Context(), WithVersion("dev"), WithServiceFactory(func(cfg servicepkg.Config) (ServiceRunner, error) {
+		captured = cfg
+		return runner, nil
+	}))
+	cmd.SetOut(&bytes.Buffer{})
+	cmd.SetErr(&bytes.Buffer{})
+	cmd.SetArgs([]string{"--format", "json", "--config", path, "status"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+	if captured.ConfigPath != path || captured.AutoUpdate != "apply enabled" || captured.DashboardURL != "http://localhost:4100" || captured.Install.Source != update.InstallSourceDevelopment {
+		t.Fatalf("captured config = %#v", captured)
+	}
+	if want := []string{"--config", path, "--headless"}; !reflect.DeepEqual(captured.Arguments, want) {
+		t.Fatalf("arguments = %#v, want %#v", captured.Arguments, want)
+	}
+}
+
+func serviceFactoryFor(runner ServiceRunner) ServiceFactory {
+	return func(servicepkg.Config) (ServiceRunner, error) {
+		return runner, nil
+	}
+}
+
+type serviceRunnerStub struct {
+	startResults []servicepkg.StartResult
+	startErrs    []error
+	startOptions []servicepkg.StartOptions
+	status       servicepkg.Status
+	statusErr    error
+}
+
+func (s *serviceRunnerStub) Start(_ context.Context, opts servicepkg.StartOptions) (servicepkg.StartResult, error) {
+	s.startOptions = append(s.startOptions, opts)
+	index := len(s.startOptions) - 1
+	var result servicepkg.StartResult
+	if index < len(s.startResults) {
+		result = s.startResults[index]
+	}
+	var err error
+	if index < len(s.startErrs) {
+		err = s.startErrs[index]
+	}
+	return result, err
+}
+
+func (s *serviceRunnerStub) Status(context.Context) (servicepkg.Status, error) {
+	return s.status, s.statusErr
+}

--- a/internal/service/files.go
+++ b/internal/service/files.go
@@ -1,0 +1,30 @@
+package service
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+func writeDefinition(definition Definition) error {
+	if err := os.MkdirAll(filepath.Dir(definition.Path), 0o755); err != nil {
+		return fmt.Errorf("create service definition directory: %w", err)
+	}
+	file, err := os.OpenFile(definition.Path, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o600)
+	if err != nil {
+		return fmt.Errorf("create service definition: %w", err)
+	}
+	if _, err := file.WriteString(definition.Content); err != nil {
+		return errors.Join(fmt.Errorf("write service definition: %w", err), file.Close(), os.Remove(definition.Path))
+	}
+	if err := file.Close(); err != nil {
+		return errors.Join(fmt.Errorf("close service definition: %w", err), os.Remove(definition.Path))
+	}
+	return nil
+}
+
+func regularFile(path string) bool {
+	info, err := os.Stat(path)
+	return err == nil && info != nil && info.Mode().IsRegular()
+}

--- a/internal/service/launchd.go
+++ b/internal/service/launchd.go
@@ -1,0 +1,193 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"html"
+	"path/filepath"
+	"strconv"
+	"strings"
+)
+
+const launchdLabel = "com.digitaldrywood.detent"
+
+type launchdManager struct {
+	cfg  Config
+	path string
+}
+
+func newLaunchdManager(cfg Config) *launchdManager {
+	path := cfg.LaunchdPlistPath
+	if strings.TrimSpace(path) == "" {
+		path = filepath.Join(cfg.HomeDir, "Library", "LaunchAgents", launchdLabel+".plist")
+	}
+	return &launchdManager{cfg: cfg, path: path}
+}
+
+func (m *launchdManager) Info() ManagerInfo {
+	return ManagerInfo{
+		Name:           ManagerLaunchd,
+		Scope:          "user",
+		Unit:           launchdLabel,
+		DefinitionPath: m.path,
+	}
+}
+
+func (m *launchdManager) Definition() Definition {
+	return Definition{Path: m.path, Content: launchdPlist(m.cfg)}
+}
+
+func (m *launchdManager) Inspect(ctx context.Context) (Inspection, error) {
+	present := regularFile(m.path)
+	output, err := m.cfg.RunCommand(ctx, "launchctl", "print", m.target())
+	if err != nil {
+		if launchdMissing(output, err) {
+			return Inspection{Present: present, State: StateStopped}, nil
+		}
+		if !present {
+			return Inspection{State: StateStopped}, nil
+		}
+		return Inspection{}, err
+	}
+	pid := launchdPID(output)
+	return Inspection{
+		Present:   true,
+		State:     launchdState(output),
+		PID:       pid,
+		StartedAt: processStartedAt(ctx, m.cfg.RunCommand, pid),
+	}, nil
+}
+
+func (m *launchdManager) Install(context.Context) (Definition, error) {
+	definition := m.Definition()
+	if err := writeDefinition(definition); err != nil {
+		return Definition{}, err
+	}
+	return definition, nil
+}
+
+func (m *launchdManager) Start(ctx context.Context) error {
+	inspection, err := m.Inspect(ctx)
+	if err != nil {
+		return err
+	}
+	if active(inspection.State) {
+		return nil
+	}
+	if _, err := m.cfg.RunCommand(ctx, "launchctl", "print", m.target()); err != nil {
+		if _, bootstrapErr := m.cfg.RunCommand(ctx, "launchctl", "bootstrap", m.domain(), m.path); bootstrapErr != nil {
+			return bootstrapErr
+		}
+		return nil
+	}
+	_, err = m.cfg.RunCommand(ctx, "launchctl", "kickstart", m.target())
+	return err
+}
+
+func (m *launchdManager) Restart(ctx context.Context) error {
+	_, err := m.cfg.RunCommand(ctx, "launchctl", "kickstart", "-k", m.target())
+	return err
+}
+
+func (m *launchdManager) WaitStopped(ctx context.Context) error {
+	return waitStopped(ctx, m.cfg.PollInterval, m.Inspect)
+}
+
+func (m *launchdManager) domain() string {
+	return "gui/" + m.cfg.UID
+}
+
+func (m *launchdManager) target() string {
+	return m.domain() + "/" + launchdLabel
+}
+
+func launchdPlist(cfg Config) string {
+	escape := func(value string) string {
+		return html.EscapeString(value)
+	}
+	lines := []string{
+		`<?xml version="1.0" encoding="UTF-8"?>`,
+		`<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">`,
+		`<plist version="1.0">`,
+		`<dict>`,
+		`  <key>Label</key>`,
+		`  <string>` + launchdLabel + `</string>`,
+		`  <key>ProgramArguments</key>`,
+		`  <array>`,
+		`    <string>` + escape(cfg.BinaryPath) + `</string>`,
+	}
+	for _, argument := range cfg.Arguments {
+		lines = append(lines, `    <string>`+escape(argument)+`</string>`)
+	}
+	lines = append(lines,
+		`  </array>`,
+		`  <key>EnvironmentVariables</key>`,
+		`  <dict>`,
+		`    <key>PATH</key>`,
+		`    <string>`+escape(cfg.Path)+`</string>`,
+		`  </dict>`,
+		`  <key>RunAtLoad</key>`,
+		`  <true/>`,
+		`  <key>KeepAlive</key>`,
+		`  <dict>`,
+		`    <key>SuccessfulExit</key>`,
+		`    <false/>`,
+		`  </dict>`,
+		`</dict>`,
+		`</plist>`,
+		``,
+	)
+	return strings.Join(lines, "\n")
+}
+
+func launchdMissing(output string, err error) bool {
+	text := strings.ToLower(strings.TrimSpace(output + " " + err.Error()))
+	return strings.Contains(text, "could not find service") ||
+		strings.Contains(text, "service not found") ||
+		strings.Contains(text, "no such process")
+}
+
+func launchdPID(output string) int {
+	for line := range strings.SplitSeq(output, "\n") {
+		key, value, ok := strings.Cut(strings.TrimSpace(line), "=")
+		if !ok || strings.TrimSpace(key) != "pid" {
+			continue
+		}
+		pid, err := strconv.Atoi(strings.TrimSpace(value))
+		if err != nil {
+			return 0
+		}
+		return pid
+	}
+	return 0
+}
+
+func launchdState(output string) State {
+	for line := range strings.SplitSeq(output, "\n") {
+		key, value, ok := strings.Cut(strings.TrimSpace(line), "=")
+		if !ok || strings.TrimSpace(key) != "state" {
+			continue
+		}
+		switch strings.ToLower(strings.TrimSpace(value)) {
+		case "running":
+			return StateRunning
+		case "waiting", "spawn scheduled":
+			return StateStarting
+		case "terminating":
+			return StateStopping
+		case "exited", "not running":
+			return StateStopped
+		}
+	}
+	if launchdPID(output) > 0 {
+		return StateRunning
+	}
+	return StateStopped
+}
+
+func validateLaunchdConfig(cfg Config) error {
+	if strings.TrimSpace(cfg.UID) == "" {
+		return errors.New("resolve launchd user domain: user id is unavailable")
+	}
+	return nil
+}

--- a/internal/service/launchd_test.go
+++ b/internal/service/launchd_test.go
@@ -1,0 +1,163 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func TestLaunchdPlistIncludesRuntimeSettings(t *testing.T) {
+	t.Parallel()
+
+	plist := launchdPlist(Config{
+		BinaryPath: "/Applications/Detent & Tools/detent",
+		Arguments:  []string{"--config", "/Users/name/Library/Application Support/Detent/global.yaml", "--headless"},
+		Path:       "/Users/name/bin:/usr/bin",
+	})
+	for _, want := range []string{
+		"<string>/Applications/Detent &amp; Tools/detent</string>",
+		"<string>--config</string>",
+		"<string>/Users/name/Library/Application Support/Detent/global.yaml</string>",
+		"<key>RunAtLoad</key>",
+		"<key>SuccessfulExit</key>",
+		"<string>/Users/name/bin:/usr/bin</string>",
+	} {
+		if !strings.Contains(plist, want) {
+			t.Fatalf("plist missing %q:\n%s", want, plist)
+		}
+	}
+}
+
+func TestLaunchdInspectStartAndRestart(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join(t.TempDir(), launchdLabel+".plist")
+	if err := os.WriteFile(path, []byte("plist"), 0o644); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+	var commands [][]string
+	loaded := false
+	cfg := normalizeConfig(Config{
+		UID:              "501",
+		LaunchdPlistPath: path,
+		RunCommand: func(_ context.Context, name string, args ...string) (string, error) {
+			commands = append(commands, append([]string{name}, args...))
+			if name == "ps" {
+				return "Thu Jul 16 10:30:00 2026\n", nil
+			}
+			if len(args) > 0 && args[0] == "bootstrap" {
+				loaded = true
+				return "", nil
+			}
+			if len(args) > 0 && args[0] == "print" {
+				if !loaded {
+					return "Could not find service", errors.New("exit status 113")
+				}
+				return "state = running\npid = 42\n", nil
+			}
+			return "", nil
+		},
+	})
+	manager := newLaunchdManager(cfg)
+	inspection, err := manager.Inspect(t.Context())
+	if err != nil {
+		t.Fatalf("Inspect() error = %v", err)
+	}
+	if !inspection.Present || inspection.State != StateStopped {
+		t.Fatalf("inspection = %#v, want present stopped", inspection)
+	}
+	if err := manager.Start(t.Context()); err != nil {
+		t.Fatalf("Start() error = %v", err)
+	}
+	if !loaded {
+		t.Fatal("bootstrap was not called")
+	}
+	inspection, err = manager.Inspect(t.Context())
+	if err != nil {
+		t.Fatalf("Inspect() running error = %v", err)
+	}
+	if inspection.State != StateRunning || inspection.PID != 42 || inspection.StartedAt.IsZero() {
+		t.Fatalf("running inspection = %#v", inspection)
+	}
+	if err := manager.Restart(t.Context()); err != nil {
+		t.Fatalf("Restart() error = %v", err)
+	}
+	wantRestart := []string{"launchctl", "kickstart", "-k", "gui/501/" + launchdLabel}
+	if len(commands) == 0 {
+		t.Fatal("commands are empty after restart")
+	}
+	if got := commands[len(commands)-1]; !reflect.DeepEqual(got, wantRestart) {
+		t.Fatalf("restart command = %#v, want %#v", got, wantRestart)
+	}
+}
+
+func TestLaunchdInstallWritesDefinition(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join(t.TempDir(), "LaunchAgents", launchdLabel+".plist")
+	cfg := normalizeConfig(Config{
+		UID:              "501",
+		LaunchdPlistPath: path,
+		BinaryPath:       "/usr/local/bin/detent",
+		ConfigPath:       "/Users/name/.config/detent/global.yaml",
+	})
+	manager := newLaunchdManager(cfg)
+	definition, err := manager.Install(t.Context())
+	if err != nil {
+		t.Fatalf("Install() error = %v", err)
+	}
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile() error = %v", err)
+	}
+	if definition.Path != path || string(raw) != definition.Content {
+		t.Fatalf("definition = %#v, contents = %q", definition, raw)
+	}
+}
+
+func TestLaunchdDetectsLoadedJobWithoutDefinitionFile(t *testing.T) {
+	t.Parallel()
+
+	cfg := normalizeConfig(Config{
+		UID:              "501",
+		LaunchdPlistPath: filepath.Join(t.TempDir(), "missing.plist"),
+		RunCommand: func(_ context.Context, name string, args ...string) (string, error) {
+			if name != "launchctl" || !reflect.DeepEqual(args, []string{"print", "gui/501/" + launchdLabel}) {
+				t.Fatalf("command = %s %#v", name, args)
+			}
+			return "state = running\npid = 0\n", nil
+		},
+	})
+	inspection, err := newLaunchdManager(cfg).Inspect(t.Context())
+	if err != nil {
+		t.Fatalf("Inspect() error = %v", err)
+	}
+	if !inspection.Present || inspection.State != StateRunning {
+		t.Fatalf("inspection = %#v", inspection)
+	}
+}
+
+func TestLaunchdState(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		output string
+		want   State
+	}{
+		{output: "state = running\npid = 42", want: StateRunning},
+		{output: "state = waiting", want: StateStarting},
+		{output: "state = terminating", want: StateStopping},
+		{output: "state = exited", want: StateStopped},
+		{output: "pid = 42", want: StateRunning},
+		{output: "", want: StateStopped},
+	}
+	for _, tt := range tests {
+		if got := launchdState(tt.output); got != tt.want {
+			t.Errorf("launchdState(%q) = %q, want %q", tt.output, got, tt.want)
+		}
+	}
+}

--- a/internal/service/service.go
+++ b/internal/service/service.go
@@ -1,0 +1,425 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"os/user"
+	"runtime"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/digitaldrywood/detent/internal/instancelock"
+	"github.com/digitaldrywood/detent/internal/update"
+)
+
+var (
+	ErrManualRestart = errors.New("manual Detent instance cannot be restarted by a service manager")
+	ErrNotRunning    = errors.New("detent service is expected to be running but is not")
+	ErrUnsupported   = errors.New("background service installation is unsupported on this platform")
+)
+
+type ManagerName string
+
+const (
+	ManagerManual  ManagerName = "foreground/manual"
+	ManagerSystemd ManagerName = "systemd"
+	ManagerLaunchd ManagerName = "launchd"
+)
+
+type State string
+
+const (
+	StateStopped  State = "stopped"
+	StateStarting State = "starting"
+	StateRunning  State = "running"
+	StateStopping State = "stopping"
+	StateUnknown  State = "unknown"
+)
+
+type Action string
+
+const (
+	ActionNeedsInstall  Action = "needs_install"
+	ActionInstalled     Action = "installed"
+	ActionStarted       Action = "started"
+	ActionRestarted     Action = "restarted"
+	ActionAlreadyActive Action = "already_active"
+)
+
+type ManagerInfo struct {
+	Name           ManagerName `json:"name"`
+	Scope          string      `json:"scope,omitempty"`
+	Unit           string      `json:"unit"`
+	DefinitionPath string      `json:"definition_path,omitempty"`
+}
+
+type Inspection struct {
+	Present   bool      `json:"present"`
+	State     State     `json:"state"`
+	PID       int       `json:"pid,omitempty"`
+	StartedAt time.Time `json:"started_at,omitempty"`
+}
+
+type Definition struct {
+	Path    string `json:"path"`
+	Content string `json:"content"`
+}
+
+type Manager interface {
+	Info() ManagerInfo
+	Definition() Definition
+	Inspect(context.Context) (Inspection, error)
+	Install(context.Context) (Definition, error)
+	Start(context.Context) error
+	Restart(context.Context) error
+	WaitStopped(context.Context) error
+}
+
+type ManualInspector func(string) (Inspection, error)
+
+type CommandRunner func(context.Context, string, ...string) (string, error)
+
+type Config struct {
+	GOOS             string
+	HomeDir          string
+	UID              string
+	Path             string
+	BinaryPath       string
+	ConfigPath       string
+	Arguments        []string
+	LockPath         string
+	Version          string
+	AutoUpdate       string
+	DashboardURL     string
+	Install          update.InstallInfo
+	Manager          Manager
+	InspectManual    ManualInspector
+	RunCommand       CommandRunner
+	Now              func() time.Time
+	PollInterval     time.Duration
+	SystemUnitPaths  []string
+	UserUnitPaths    []string
+	UserSystemdPath  string
+	LaunchdPlistPath string
+}
+
+type StartOptions struct {
+	Install bool
+	Restart bool
+}
+
+type StartResult struct {
+	Action     Action      `json:"action"`
+	Manager    ManagerInfo `json:"manager"`
+	State      State       `json:"state"`
+	PID        int         `json:"pid,omitempty"`
+	Definition *Definition `json:"definition,omitempty"`
+}
+
+type Status struct {
+	InstallMethod  update.InstallSource `json:"install_method"`
+	ServiceManager ManagerName          `json:"service_manager"`
+	ServiceScope   string               `json:"service_scope,omitempty"`
+	Service        string               `json:"service"`
+	DefinitionPath string               `json:"definition_path,omitempty"`
+	Expected       bool                 `json:"expected_running"`
+	State          State                `json:"state"`
+	PID            int                  `json:"pid,omitempty"`
+	StartedAt      time.Time            `json:"started_at,omitempty"`
+	UptimeSeconds  int64                `json:"uptime_seconds,omitempty"`
+	Version        string               `json:"version"`
+	AutoUpdate     string               `json:"auto_update"`
+	DashboardURL   string               `json:"dashboard_url"`
+	ConfigPath     string               `json:"config_path"`
+}
+
+func (s Status) Running() bool {
+	return s.State == StateRunning
+}
+
+type Controller struct {
+	cfg     Config
+	manager Manager
+}
+
+func New(cfg Config) (*Controller, error) {
+	cfg = normalizeConfig(cfg)
+	manager := cfg.Manager
+	if manager == nil {
+		if cfg.GOOS == "darwin" {
+			if err := validateLaunchdConfig(cfg); err != nil {
+				return nil, err
+			}
+		}
+		manager = newPlatformManager(cfg)
+	}
+	return &Controller{cfg: cfg, manager: manager}, nil
+}
+
+func (c *Controller) Start(ctx context.Context, opts StartOptions) (StartResult, error) {
+	inspection, err := c.manager.Inspect(ctx)
+	if err != nil {
+		return StartResult{}, fmt.Errorf("inspect %s service: %w", c.manager.Info().Name, err)
+	}
+	if inspection.Present {
+		return c.startManaged(ctx, inspection, opts)
+	}
+
+	manual, err := c.cfg.InspectManual(c.cfg.LockPath)
+	if err != nil {
+		return StartResult{}, fmt.Errorf("inspect manual Detent instance: %w", err)
+	}
+	if active(manual.State) {
+		result := StartResult{
+			Action:  ActionAlreadyActive,
+			Manager: manualManagerInfo(),
+			State:   manual.State,
+			PID:     manual.PID,
+		}
+		if opts.Restart {
+			return result, ErrManualRestart
+		}
+		return result, nil
+	}
+	if c.manager.Info().Name == ManagerManual {
+		return StartResult{}, ErrUnsupported
+	}
+	if !opts.Install {
+		definition := c.manager.Definition()
+		return StartResult{
+			Action:     ActionNeedsInstall,
+			Manager:    c.manager.Info(),
+			State:      StateStopped,
+			Definition: &definition,
+		}, nil
+	}
+
+	definition, err := c.manager.Install(ctx)
+	if err != nil {
+		return StartResult{}, fmt.Errorf("install %s service: %w", c.manager.Info().Name, err)
+	}
+	if err := c.manager.Start(ctx); err != nil {
+		return StartResult{}, fmt.Errorf("start %s service: %w", c.manager.Info().Name, err)
+	}
+	return StartResult{
+		Action:     ActionInstalled,
+		Manager:    c.manager.Info(),
+		State:      StateRunning,
+		Definition: &definition,
+	}, nil
+}
+
+func (c *Controller) Status(ctx context.Context) (Status, error) {
+	inspection, err := c.manager.Inspect(ctx)
+	if err != nil {
+		return Status{}, fmt.Errorf("inspect %s service: %w", c.manager.Info().Name, err)
+	}
+	info := c.manager.Info()
+	expected := inspection.Present
+	if !inspection.Present {
+		inspection, err = c.cfg.InspectManual(c.cfg.LockPath)
+		if err != nil {
+			return Status{}, fmt.Errorf("inspect manual Detent instance: %w", err)
+		}
+		info = manualManagerInfo()
+	}
+
+	status := Status{
+		InstallMethod:  c.cfg.Install.Source,
+		ServiceManager: info.Name,
+		ServiceScope:   info.Scope,
+		Service:        info.Unit,
+		DefinitionPath: info.DefinitionPath,
+		Expected:       expected,
+		State:          inspection.State,
+		PID:            inspection.PID,
+		StartedAt:      inspection.StartedAt,
+		Version:        c.cfg.Version,
+		AutoUpdate:     c.cfg.AutoUpdate,
+		DashboardURL:   c.cfg.DashboardURL,
+		ConfigPath:     c.cfg.ConfigPath,
+	}
+	if status.State == "" {
+		status.State = StateStopped
+	}
+	if !status.StartedAt.IsZero() {
+		uptime := c.cfg.Now().Sub(status.StartedAt)
+		if uptime > 0 {
+			status.UptimeSeconds = int64(uptime / time.Second)
+		}
+	}
+	return status, nil
+}
+
+func (c *Controller) startManaged(ctx context.Context, inspection Inspection, opts StartOptions) (StartResult, error) {
+	result := StartResult{
+		Manager: c.manager.Info(),
+		State:   inspection.State,
+		PID:     inspection.PID,
+	}
+	if active(inspection.State) {
+		if !opts.Restart {
+			result.Action = ActionAlreadyActive
+			return result, nil
+		}
+		if err := c.manager.Restart(ctx); err != nil {
+			return StartResult{}, fmt.Errorf("restart %s service: %w", c.manager.Info().Name, err)
+		}
+		result.Action = ActionRestarted
+		result.State = StateRunning
+		return result, nil
+	}
+	if inspection.State == StateStopping {
+		if err := c.manager.WaitStopped(ctx); err != nil {
+			return StartResult{}, fmt.Errorf("wait for %s service to stop: %w", c.manager.Info().Name, err)
+		}
+	}
+	if err := c.manager.Start(ctx); err != nil {
+		return StartResult{}, fmt.Errorf("start %s service: %w", c.manager.Info().Name, err)
+	}
+	result.Action = ActionStarted
+	result.State = StateRunning
+	return result, nil
+}
+
+func active(state State) bool {
+	return state == StateRunning || state == StateStarting
+}
+
+func normalizeConfig(cfg Config) Config {
+	if strings.TrimSpace(cfg.GOOS) == "" {
+		cfg.GOOS = runtime.GOOS
+	}
+	if strings.TrimSpace(cfg.HomeDir) == "" {
+		if homeDir, err := os.UserHomeDir(); err == nil {
+			cfg.HomeDir = homeDir
+		}
+	}
+	if strings.TrimSpace(cfg.UID) == "" {
+		if current, err := user.Current(); err == nil {
+			cfg.UID = current.Uid
+		}
+	}
+	if strings.TrimSpace(cfg.Path) == "" {
+		cfg.Path = os.Getenv("PATH")
+	}
+	if strings.TrimSpace(cfg.Version) == "" {
+		cfg.Version = "dev"
+	}
+	if len(cfg.Arguments) == 0 {
+		cfg.Arguments = []string{"--config", cfg.ConfigPath, "--headless"}
+	}
+	if strings.TrimSpace(cfg.AutoUpdate) == "" {
+		cfg.AutoUpdate = "disabled"
+	}
+	if cfg.InspectManual == nil {
+		cfg.InspectManual = inspectManual
+	}
+	if cfg.RunCommand == nil {
+		cfg.RunCommand = runCommand
+	}
+	if cfg.Now == nil {
+		cfg.Now = time.Now
+	}
+	if cfg.PollInterval <= 0 {
+		cfg.PollInterval = 100 * time.Millisecond
+	}
+	return cfg
+}
+
+func newPlatformManager(cfg Config) Manager {
+	switch cfg.GOOS {
+	case "linux":
+		return newSystemdManager(cfg)
+	case "darwin":
+		return newLaunchdManager(cfg)
+	default:
+		return manualManager{}
+	}
+}
+
+func manualManagerInfo() ManagerInfo {
+	return ManagerInfo{Name: ManagerManual, Unit: string(ManagerManual)}
+}
+
+func inspectManual(path string) (Inspection, error) {
+	if strings.TrimSpace(path) == "" {
+		return Inspection{State: StateStopped}, nil
+	}
+	status, err := instancelock.Inspect(path)
+	if err != nil {
+		return Inspection{}, err
+	}
+	if status.Status != instancelock.StatusHeld {
+		return Inspection{State: StateStopped}, nil
+	}
+	return Inspection{
+		State:     StateRunning,
+		PID:       status.Owner.PID,
+		StartedAt: status.Owner.StartedAt,
+	}, nil
+}
+
+func runCommand(ctx context.Context, name string, args ...string) (string, error) {
+	cmd := exec.CommandContext(ctx, name, args...)
+	output, err := cmd.CombinedOutput()
+	if ctx.Err() != nil {
+		return string(output), ctx.Err()
+	}
+	if err != nil {
+		if detail := strings.TrimSpace(string(output)); detail != "" {
+			return string(output), fmt.Errorf("%w: %s", err, detail)
+		}
+		return string(output), err
+	}
+	return string(output), nil
+}
+
+func processStartedAt(ctx context.Context, run CommandRunner, pid int) time.Time {
+	if pid <= 0 {
+		return time.Time{}
+	}
+	output, err := run(ctx, "ps", "-o", "lstart=", "-p", strconv.Itoa(pid))
+	if err != nil {
+		return time.Time{}
+	}
+	startedAt, err := time.ParseInLocation("Mon Jan _2 15:04:05 2006", strings.TrimSpace(output), time.Local)
+	if err != nil {
+		return time.Time{}
+	}
+	return startedAt
+}
+
+type manualManager struct{}
+
+func (manualManager) Info() ManagerInfo {
+	return manualManagerInfo()
+}
+
+func (manualManager) Definition() Definition {
+	return Definition{}
+}
+
+func (manualManager) Inspect(context.Context) (Inspection, error) {
+	return Inspection{State: StateStopped}, nil
+}
+
+func (manualManager) Install(context.Context) (Definition, error) {
+	return Definition{}, ErrUnsupported
+}
+
+func (manualManager) Start(context.Context) error {
+	return ErrUnsupported
+}
+
+func (manualManager) Restart(context.Context) error {
+	return ErrUnsupported
+}
+
+func (manualManager) WaitStopped(context.Context) error {
+	return nil
+}

--- a/internal/service/service_test.go
+++ b/internal/service/service_test.go
@@ -1,0 +1,370 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/digitaldrywood/detent/internal/instancelock"
+	"github.com/digitaldrywood/detent/internal/update"
+)
+
+func TestControllerStartDecisionMatrix(t *testing.T) {
+	t.Parallel()
+
+	installMethods := []update.InstallSource{
+		update.InstallSourceRelease,
+		update.InstallSourceHomebrew,
+		update.InstallSourceGoInstall,
+		update.InstallSourceDevelopment,
+	}
+	for _, installMethod := range installMethods {
+		for _, servicePresent := range []bool{false, true} {
+			for _, running := range []bool{false, true} {
+				name := string(installMethod) + "/present=" + boolName(servicePresent) + "/running=" + boolName(running)
+				t.Run(name, func(t *testing.T) {
+					t.Parallel()
+
+					state := StateStopped
+					if running {
+						state = StateRunning
+					}
+					manager := &serviceManagerStub{inspection: Inspection{Present: servicePresent, State: state, PID: 42}}
+					controller := controllerForTest(t, Config{
+						Install: update.InstallInfo{Source: installMethod},
+						Manager: manager,
+						InspectManual: func(string) (Inspection, error) {
+							if servicePresent {
+								return Inspection{State: StateStopped}, nil
+							}
+							return Inspection{State: state, PID: 84}, nil
+						},
+					})
+
+					result, err := controller.Start(t.Context(), StartOptions{})
+					if err != nil {
+						t.Fatalf("Start() error = %v", err)
+					}
+					switch {
+					case servicePresent && running:
+						assertStartResult(t, result, ActionAlreadyActive, ManagerSystemd, 42)
+					case servicePresent:
+						assertStartResult(t, result, ActionStarted, ManagerSystemd, 42)
+						if manager.startCalls != 1 {
+							t.Fatalf("start calls = %d, want 1", manager.startCalls)
+						}
+					case running:
+						assertStartResult(t, result, ActionAlreadyActive, ManagerManual, 84)
+					case !servicePresent:
+						assertStartResult(t, result, ActionNeedsInstall, ManagerSystemd, 0)
+					}
+				})
+			}
+		}
+	}
+}
+
+func TestControllerStartInstallsAndRestarts(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name          string
+		inspection    Inspection
+		opts          StartOptions
+		wantAction    Action
+		wantInstall   int
+		wantStart     int
+		wantRestart   int
+		wantWait      int
+		definitionSet bool
+	}{
+		{
+			name:          "installs missing service",
+			inspection:    Inspection{State: StateStopped},
+			opts:          StartOptions{Install: true},
+			wantAction:    ActionInstalled,
+			wantInstall:   1,
+			wantStart:     1,
+			definitionSet: true,
+		},
+		{
+			name:        "restarts running service",
+			inspection:  Inspection{Present: true, State: StateRunning, PID: 42},
+			opts:        StartOptions{Restart: true},
+			wantAction:  ActionRestarted,
+			wantRestart: 1,
+		},
+		{
+			name:       "waits for stopping service",
+			inspection: Inspection{Present: true, State: StateStopping, PID: 42},
+			wantAction: ActionStarted,
+			wantStart:  1,
+			wantWait:   1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			manager := &serviceManagerStub{inspection: tt.inspection}
+			controller := controllerForTest(t, Config{
+				Manager: manager,
+				InspectManual: func(string) (Inspection, error) {
+					return Inspection{State: StateStopped}, nil
+				},
+			})
+			result, err := controller.Start(t.Context(), tt.opts)
+			if err != nil {
+				t.Fatalf("Start() error = %v", err)
+			}
+			if result.Action != tt.wantAction {
+				t.Fatalf("Action = %q, want %q", result.Action, tt.wantAction)
+			}
+			if manager.installCalls != tt.wantInstall || manager.startCalls != tt.wantStart || manager.restartCalls != tt.wantRestart || manager.waitCalls != tt.wantWait {
+				t.Fatalf("calls = install:%d start:%d restart:%d wait:%d", manager.installCalls, manager.startCalls, manager.restartCalls, manager.waitCalls)
+			}
+			if got := result.Definition != nil; got != tt.definitionSet {
+				t.Fatalf("Definition set = %t, want %t", got, tt.definitionSet)
+			}
+		})
+	}
+}
+
+func TestControllerRefusesManualRestart(t *testing.T) {
+	t.Parallel()
+
+	controller := controllerForTest(t, Config{
+		Manager: &serviceManagerStub{inspection: Inspection{State: StateStopped}},
+		InspectManual: func(string) (Inspection, error) {
+			return Inspection{State: StateRunning, PID: 84}, nil
+		},
+	})
+	result, err := controller.Start(t.Context(), StartOptions{Restart: true})
+	if !errors.Is(err, ErrManualRestart) {
+		t.Fatalf("Start() error = %v, want %v", err, ErrManualRestart)
+	}
+	assertStartResult(t, result, ActionAlreadyActive, ManagerManual, 84)
+}
+
+func TestControllerStatusReportsManagedAndManualStates(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, time.July, 16, 12, 0, 0, 0, time.UTC)
+	tests := []struct {
+		name           string
+		managed        Inspection
+		manual         Inspection
+		wantManager    ManagerName
+		wantExpected   bool
+		wantRunning    bool
+		wantPID        int
+		wantUptimeSecs int64
+	}{
+		{
+			name:           "managed running",
+			managed:        Inspection{Present: true, State: StateRunning, PID: 42, StartedAt: now.Add(-time.Hour)},
+			wantManager:    ManagerSystemd,
+			wantExpected:   true,
+			wantRunning:    true,
+			wantPID:        42,
+			wantUptimeSecs: 3600,
+		},
+		{
+			name:         "managed stopped",
+			managed:      Inspection{Present: true, State: StateStopped},
+			wantManager:  ManagerSystemd,
+			wantExpected: true,
+		},
+		{
+			name:        "manual running",
+			manual:      Inspection{State: StateRunning, PID: 84},
+			wantManager: ManagerManual,
+			wantRunning: true,
+			wantPID:     84,
+		},
+		{
+			name:        "manual stopped",
+			manual:      Inspection{State: StateStopped},
+			wantManager: ManagerManual,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			controller := controllerForTest(t, Config{
+				Install:      update.InstallInfo{Source: update.InstallSourceRelease},
+				Version:      "v1.2.3",
+				AutoUpdate:   "apply enabled",
+				DashboardURL: "http://localhost:4000",
+				ConfigPath:   "/tmp/global.yaml",
+				Manager:      &serviceManagerStub{inspection: tt.managed},
+				InspectManual: func(string) (Inspection, error) {
+					return tt.manual, nil
+				},
+				Now: func() time.Time { return now },
+			})
+			status, err := controller.Status(t.Context())
+			if err != nil {
+				t.Fatalf("Status() error = %v", err)
+			}
+			if status.ServiceManager != tt.wantManager || status.Expected != tt.wantExpected || status.Running() != tt.wantRunning || status.PID != tt.wantPID || status.UptimeSeconds != tt.wantUptimeSecs {
+				t.Fatalf("Status() = %#v", status)
+			}
+			if status.InstallMethod != update.InstallSourceRelease || status.Version != "v1.2.3" || status.AutoUpdate != "apply enabled" || status.DashboardURL != "http://localhost:4000" {
+				t.Fatalf("metadata = %#v", status)
+			}
+		})
+	}
+}
+
+func TestStatusRunningRequiresRunningState(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		state State
+		want  bool
+	}{
+		{state: StateStopped, want: false},
+		{state: StateStarting, want: false},
+		{state: StateRunning, want: true},
+		{state: StateStopping, want: false},
+	}
+	for _, tt := range tests {
+		if got := (Status{State: tt.state}).Running(); got != tt.want {
+			t.Errorf("Running() for %q = %t, want %t", tt.state, got, tt.want)
+		}
+	}
+}
+
+func TestInspectManualUsesInstanceLock(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join(t.TempDir(), "detent.db.lock")
+	lock, err := instancelock.Acquire(path)
+	if err != nil {
+		t.Fatalf("Acquire() error = %v", err)
+	}
+	t.Cleanup(func() {
+		if err := lock.Close(); err != nil {
+			t.Errorf("Close() error = %v", err)
+		}
+	})
+
+	inspection, err := inspectManual(path)
+	if err != nil {
+		t.Fatalf("inspectManual() error = %v", err)
+	}
+	if inspection.State != StateRunning || inspection.PID != os.Getpid() || inspection.StartedAt.IsZero() {
+		t.Fatalf("inspection = %#v", inspection)
+	}
+}
+
+func TestProcessStartedAt(t *testing.T) {
+	t.Parallel()
+
+	startedAt := processStartedAt(t.Context(), func(_ context.Context, name string, args ...string) (string, error) {
+		if name != "ps" || !reflect.DeepEqual(args, []string{"-o", "lstart=", "-p", "42"}) {
+			t.Fatalf("command = %s %#v", name, args)
+		}
+		return "Thu Jul 16 10:30:00 2026\n", nil
+	}, 42)
+	if startedAt.IsZero() || startedAt.Hour() != 10 || startedAt.Minute() != 30 {
+		t.Fatalf("processStartedAt() = %v", startedAt)
+	}
+}
+
+func controllerForTest(t *testing.T, cfg Config) *Controller {
+	t.Helper()
+	controller, err := New(cfg)
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	return controller
+}
+
+func assertStartResult(t *testing.T, got StartResult, action Action, manager ManagerName, pid int) {
+	t.Helper()
+	if got.Action != action || got.Manager.Name != manager || got.PID != pid {
+		t.Fatalf("StartResult = %#v, want action=%q manager=%q pid=%d", got, action, manager, pid)
+	}
+}
+
+func boolName(value bool) string {
+	if value {
+		return "yes"
+	}
+	return "no"
+}
+
+type serviceManagerStub struct {
+	inspection   Inspection
+	inspectErr   error
+	installErr   error
+	startErr     error
+	restartErr   error
+	waitErr      error
+	installCalls int
+	startCalls   int
+	restartCalls int
+	waitCalls    int
+}
+
+func (s *serviceManagerStub) Info() ManagerInfo {
+	return ManagerInfo{Name: ManagerSystemd, Scope: "user", Unit: systemdUnitName, DefinitionPath: "/tmp/detent.service"}
+}
+
+func (s *serviceManagerStub) Definition() Definition {
+	return Definition{Path: "/tmp/detent.service", Content: "unit\n"}
+}
+
+func (s *serviceManagerStub) Inspect(context.Context) (Inspection, error) {
+	return s.inspection, s.inspectErr
+}
+
+func (s *serviceManagerStub) Install(context.Context) (Definition, error) {
+	s.installCalls++
+	return s.Definition(), s.installErr
+}
+
+func (s *serviceManagerStub) Start(context.Context) error {
+	s.startCalls++
+	return s.startErr
+}
+
+func (s *serviceManagerStub) Restart(context.Context) error {
+	s.restartCalls++
+	return s.restartErr
+}
+
+func (s *serviceManagerStub) WaitStopped(context.Context) error {
+	s.waitCalls++
+	return s.waitErr
+}
+
+func TestWriteDefinitionDoesNotOverwrite(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join(t.TempDir(), "service", "detent.service")
+	definition := Definition{Path: path, Content: "first\n"}
+	if err := writeDefinition(definition); err != nil {
+		t.Fatalf("writeDefinition() error = %v", err)
+	}
+	if err := writeDefinition(Definition{Path: path, Content: "second\n"}); err == nil {
+		t.Fatal("writeDefinition() error = nil, want existing-file error")
+	}
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile() error = %v", err)
+	}
+	if strings.TrimSpace(string(raw)) != "first" {
+		t.Fatalf("contents = %q, want first", raw)
+	}
+}

--- a/internal/service/systemd.go
+++ b/internal/service/systemd.go
@@ -1,0 +1,253 @@
+package service
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"time"
+)
+
+const systemdUnitName = "detent.service"
+
+type systemdManager struct {
+	cfg      Config
+	userPath string
+	scope    string
+	path     string
+}
+
+func newSystemdManager(cfg Config) *systemdManager {
+	userPath := cfg.UserSystemdPath
+	if strings.TrimSpace(userPath) == "" {
+		configHome := strings.TrimSpace(os.Getenv("XDG_CONFIG_HOME"))
+		if configHome == "" {
+			configHome = filepath.Join(cfg.HomeDir, ".config")
+		}
+		userPath = filepath.Join(configHome, "systemd", "user", systemdUnitName)
+	}
+	return &systemdManager{cfg: cfg, userPath: userPath, scope: "user", path: userPath}
+}
+
+func (m *systemdManager) Info() ManagerInfo {
+	return ManagerInfo{
+		Name:           ManagerSystemd,
+		Scope:          m.scope,
+		Unit:           systemdUnitName,
+		DefinitionPath: m.path,
+	}
+}
+
+func (m *systemdManager) Definition() Definition {
+	return Definition{Path: m.userPath, Content: systemdUnit(m.cfg)}
+}
+
+func (m *systemdManager) Inspect(ctx context.Context) (Inspection, error) {
+	scope, path, present := m.definitionLocation()
+	m.scope = scope
+	m.path = path
+	if !present {
+		for _, candidate := range []string{"user", "system"} {
+			m.scope = candidate
+			inspection, loaded, err := m.inspectLoaded(ctx)
+			if err == nil && loaded {
+				m.path = ""
+				return inspection, nil
+			}
+		}
+		m.scope = "user"
+		m.path = m.userPath
+		return Inspection{State: StateStopped}, nil
+	}
+	inspection, loaded, err := m.inspectLoaded(ctx)
+	if err != nil {
+		return Inspection{}, err
+	}
+	if !loaded {
+		inspection.Present = true
+	}
+	return inspection, nil
+}
+
+func (m *systemdManager) inspectLoaded(ctx context.Context) (Inspection, bool, error) {
+	args := m.systemctlArgs("show", systemdUnitName, "--property=LoadState", "--property=ActiveState", "--property=SubState", "--property=MainPID")
+	output, err := m.cfg.RunCommand(ctx, "systemctl", args...)
+	if err != nil {
+		return Inspection{}, false, err
+	}
+	properties := parseProperties(output)
+	if loadState := strings.ToLower(strings.TrimSpace(properties["LoadState"])); loadState == "" || loadState == "not-found" {
+		return Inspection{State: StateStopped}, false, nil
+	}
+	pid, err := strconv.Atoi(properties["MainPID"])
+	if err != nil {
+		pid = 0
+	}
+	return Inspection{
+		Present:   true,
+		State:     systemdState(properties["ActiveState"], properties["SubState"]),
+		PID:       pid,
+		StartedAt: processStartedAt(ctx, m.cfg.RunCommand, pid),
+	}, true, nil
+}
+
+func (m *systemdManager) Install(ctx context.Context) (Definition, error) {
+	definition := m.Definition()
+	if err := writeDefinition(definition); err != nil {
+		return Definition{}, err
+	}
+	m.scope = "user"
+	m.path = definition.Path
+	if _, err := m.cfg.RunCommand(ctx, "systemctl", "--user", "daemon-reload"); err != nil {
+		return Definition{}, err
+	}
+	if _, err := m.cfg.RunCommand(ctx, "systemctl", "--user", "enable", systemdUnitName); err != nil {
+		return Definition{}, err
+	}
+	return definition, nil
+}
+
+func (m *systemdManager) Start(ctx context.Context) error {
+	_, err := m.cfg.RunCommand(ctx, "systemctl", m.systemctlArgs("start", systemdUnitName)...)
+	return err
+}
+
+func (m *systemdManager) Restart(ctx context.Context) error {
+	_, err := m.cfg.RunCommand(ctx, "systemctl", m.systemctlArgs("restart", systemdUnitName)...)
+	return err
+}
+
+func (m *systemdManager) WaitStopped(ctx context.Context) error {
+	return waitStopped(ctx, m.cfg.PollInterval, m.Inspect)
+}
+
+func (m *systemdManager) definitionLocation() (string, string, bool) {
+	userPaths := append([]string{m.userPath}, m.cfg.UserUnitPaths...)
+	if strings.TrimSpace(m.cfg.HomeDir) != "" {
+		userPaths = append(userPaths, filepath.Join(m.cfg.HomeDir, ".local", "share", "systemd", "user", systemdUnitName))
+	}
+	userPaths = append(userPaths,
+		filepath.Join("/etc", "systemd", "user", systemdUnitName),
+		filepath.Join("/usr", "lib", "systemd", "user", systemdUnitName),
+	)
+	for _, path := range userPaths {
+		if regularFile(path) {
+			return "user", path, true
+		}
+	}
+	paths := m.cfg.SystemUnitPaths
+	if len(paths) == 0 {
+		paths = []string{
+			filepath.Join("/etc", "systemd", "system", systemdUnitName),
+			filepath.Join("/usr", "lib", "systemd", "system", systemdUnitName),
+			filepath.Join("/lib", "systemd", "system", systemdUnitName),
+		}
+	}
+	for _, path := range paths {
+		if regularFile(path) {
+			return "system", path, true
+		}
+	}
+	return "user", m.userPath, false
+}
+
+func (m *systemdManager) systemctlArgs(args ...string) []string {
+	if m.scope != "system" {
+		return append([]string{"--user"}, args...)
+	}
+	return args
+}
+
+func systemdUnit(cfg Config) string {
+	execStart := systemdQuote(cfg.BinaryPath)
+	for _, argument := range cfg.Arguments {
+		execStart += " " + systemdQuote(argument)
+	}
+	return strings.Join([]string{
+		"[Unit]",
+		"Description=Detent agent orchestrator",
+		"After=network-online.target",
+		"Wants=network-online.target",
+		"",
+		"[Service]",
+		"Type=simple",
+		"Environment=\"PATH=" + systemdEscape(cfg.Path) + "\"",
+		"ExecStart=" + execStart,
+		"Restart=on-failure",
+		"RestartSec=5",
+		"KillMode=control-group",
+		"",
+		"[Install]",
+		"WantedBy=default.target",
+		"",
+	}, "\n")
+}
+
+func systemdQuote(value string) string {
+	return strconv.Quote(strings.ReplaceAll(value, "%", "%%"))
+}
+
+func systemdEscape(value string) string {
+	value = strings.ReplaceAll(value, "%", "%%")
+	value = strings.ReplaceAll(value, "\\", "\\\\")
+	return strings.ReplaceAll(value, "\"", "\\\"")
+}
+
+func parseProperties(output string) map[string]string {
+	properties := make(map[string]string)
+	for line := range strings.SplitSeq(output, "\n") {
+		key, value, ok := strings.Cut(line, "=")
+		if ok {
+			properties[strings.TrimSpace(key)] = strings.TrimSpace(value)
+		}
+	}
+	return properties
+}
+
+func systemdState(activeState string, subState string) State {
+	switch strings.ToLower(strings.TrimSpace(activeState)) {
+	case "active":
+		return StateRunning
+	case "activating":
+		return StateStarting
+	case "deactivating":
+		return StateStopping
+	case "inactive", "failed":
+		return StateStopped
+	}
+	switch strings.ToLower(strings.TrimSpace(subState)) {
+	case "running", "listening":
+		return StateRunning
+	case "start", "start-pre", "start-post":
+		return StateStarting
+	case "stop", "stop-sigterm", "stop-sigkill", "final-sigterm", "final-sigkill":
+		return StateStopping
+	case "dead", "failed", "exited":
+		return StateStopped
+	default:
+		return StateUnknown
+	}
+}
+
+func waitStopped(ctx context.Context, interval time.Duration, inspect func(context.Context) (Inspection, error)) error {
+	for {
+		status, err := inspect(ctx)
+		if err != nil {
+			return err
+		}
+		if !active(status.State) && status.State != StateStopping {
+			return nil
+		}
+		timer := time.NewTimer(interval)
+		select {
+		case <-ctx.Done():
+			if !timer.Stop() {
+				<-timer.C
+			}
+			return fmt.Errorf("wait for service stop: %w", ctx.Err())
+		case <-timer.C:
+		}
+	}
+}

--- a/internal/service/systemd_test.go
+++ b/internal/service/systemd_test.go
@@ -1,0 +1,185 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func TestSystemdUnitIncludesRuntimeAndShutdownSettings(t *testing.T) {
+	t.Parallel()
+
+	unit := systemdUnit(Config{
+		BinaryPath: "/opt/Detent Release/detent",
+		Arguments:  []string{"--config", "/home/user/.config/detent/global.yaml", "--port", "4100", "--headless"},
+		Path:       `/home/user/bin:/usr/bin:%h/bin`,
+	})
+	for _, want := range []string{
+		`ExecStart="/opt/Detent Release/detent" "--config" "/home/user/.config/detent/global.yaml" "--port" "4100" "--headless"`,
+		`Environment="PATH=/home/user/bin:/usr/bin:%%h/bin"`,
+		"Restart=on-failure",
+		"KillMode=control-group",
+		"WantedBy=default.target",
+	} {
+		if !strings.Contains(unit, want) {
+			t.Fatalf("unit missing %q:\n%s", want, unit)
+		}
+	}
+}
+
+func TestSystemdInspectAndCommands(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	userPath := filepath.Join(root, "detent.service")
+	if err := os.WriteFile(userPath, []byte("unit"), 0o644); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+	var commands [][]string
+	cfg := normalizeConfig(Config{
+		UserSystemdPath: userPath,
+		RunCommand: func(_ context.Context, name string, args ...string) (string, error) {
+			commands = append(commands, append([]string{name}, args...))
+			switch name {
+			case "systemctl":
+				return "LoadState=loaded\nActiveState=active\nSubState=running\nMainPID=42\n", nil
+			case "ps":
+				return "Thu Jul 16 10:30:00 2026\n", nil
+			default:
+				return "", errors.New("unexpected command")
+			}
+		},
+	})
+	manager := newSystemdManager(cfg)
+	inspection, err := manager.Inspect(t.Context())
+	if err != nil {
+		t.Fatalf("Inspect() error = %v", err)
+	}
+	if !inspection.Present || inspection.State != StateRunning || inspection.PID != 42 || inspection.StartedAt.IsZero() {
+		t.Fatalf("inspection = %#v", inspection)
+	}
+	if len(commands) != 2 || !reflect.DeepEqual(commands[0][:3], []string{"systemctl", "--user", "show"}) {
+		t.Fatalf("commands = %#v", commands)
+	}
+	if err := manager.Restart(t.Context()); err != nil {
+		t.Fatalf("Restart() error = %v", err)
+	}
+	if got := commands[len(commands)-1]; !reflect.DeepEqual(got, []string{"systemctl", "--user", "restart", systemdUnitName}) {
+		t.Fatalf("restart command = %#v", got)
+	}
+}
+
+func TestSystemdUsesSystemScopeForSystemUnit(t *testing.T) {
+	t.Parallel()
+
+	systemPath := filepath.Join(t.TempDir(), "detent.service")
+	if err := os.WriteFile(systemPath, []byte("unit"), 0o644); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+	var command []string
+	cfg := normalizeConfig(Config{
+		UserSystemdPath: filepath.Join(t.TempDir(), "missing.service"),
+		SystemUnitPaths: []string{systemPath},
+		RunCommand: func(_ context.Context, name string, args ...string) (string, error) {
+			command = append([]string{name}, args...)
+			return "LoadState=loaded\nActiveState=inactive\nSubState=dead\nMainPID=0\n", nil
+		},
+	})
+	manager := newSystemdManager(cfg)
+	inspection, err := manager.Inspect(t.Context())
+	if err != nil {
+		t.Fatalf("Inspect() error = %v", err)
+	}
+	if !inspection.Present || inspection.State != StateStopped || manager.Info().Scope != "system" || manager.Info().DefinitionPath != systemPath {
+		t.Fatalf("inspection/info = %#v %#v", inspection, manager.Info())
+	}
+	if len(command) < 2 || command[1] != "show" {
+		t.Fatalf("command = %#v, want system scope without --user", command)
+	}
+}
+
+func TestSystemdDetectsLoadedUnitWithoutDefinitionFile(t *testing.T) {
+	t.Parallel()
+
+	var commands [][]string
+	cfg := normalizeConfig(Config{
+		HomeDir:         t.TempDir(),
+		UserSystemdPath: filepath.Join(t.TempDir(), "missing.service"),
+		SystemUnitPaths: []string{filepath.Join(t.TempDir(), "missing-system.service")},
+		RunCommand: func(_ context.Context, name string, args ...string) (string, error) {
+			commands = append(commands, append([]string{name}, args...))
+			return "LoadState=loaded\nActiveState=active\nSubState=running\nMainPID=0\n", nil
+		},
+	})
+	manager := newSystemdManager(cfg)
+	inspection, err := manager.Inspect(t.Context())
+	if err != nil {
+		t.Fatalf("Inspect() error = %v", err)
+	}
+	if !inspection.Present || inspection.State != StateRunning || manager.Info().Scope != "user" || manager.Info().DefinitionPath != "" {
+		t.Fatalf("inspection/info = %#v %#v", inspection, manager.Info())
+	}
+	if len(commands) != 1 || !reflect.DeepEqual(commands[0][:3], []string{"systemctl", "--user", "show"}) {
+		t.Fatalf("commands = %#v", commands)
+	}
+}
+
+func TestSystemdInstallWritesEnablesAndStarts(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join(t.TempDir(), "systemd", systemdUnitName)
+	var commands [][]string
+	cfg := normalizeConfig(Config{
+		UserSystemdPath: path,
+		BinaryPath:      "/usr/local/bin/detent",
+		ConfigPath:      "/home/user/.config/detent/global.yaml",
+		RunCommand: func(_ context.Context, name string, args ...string) (string, error) {
+			commands = append(commands, append([]string{name}, args...))
+			return "", nil
+		},
+	})
+	manager := newSystemdManager(cfg)
+	definition, err := manager.Install(t.Context())
+	if err != nil {
+		t.Fatalf("Install() error = %v", err)
+	}
+	if definition.Path != path {
+		t.Fatalf("definition path = %q, want %q", definition.Path, path)
+	}
+	if err := manager.Start(t.Context()); err != nil {
+		t.Fatalf("Start() error = %v", err)
+	}
+	wantCommands := [][]string{
+		{"systemctl", "--user", "daemon-reload"},
+		{"systemctl", "--user", "enable", systemdUnitName},
+		{"systemctl", "--user", "start", systemdUnitName},
+	}
+	if !reflect.DeepEqual(commands, wantCommands) {
+		t.Fatalf("commands = %#v, want %#v", commands, wantCommands)
+	}
+}
+
+func TestSystemdState(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		active string
+		sub    string
+		want   State
+	}{
+		{active: "active", sub: "running", want: StateRunning},
+		{active: "activating", sub: "start", want: StateStarting},
+		{active: "deactivating", sub: "stop-sigterm", want: StateStopping},
+		{active: "inactive", sub: "dead", want: StateStopped},
+		{active: "unexpected", sub: "unexpected", want: StateUnknown},
+	}
+	for _, tt := range tests {
+		if got := systemdState(tt.active, tt.sub); got != tt.want {
+			t.Errorf("systemdState(%q, %q) = %q, want %q", tt.active, tt.sub, got, tt.want)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

- Add install-aware `detent start` behavior for existing systemd and launchd services, including explicit restart handling and safe waits for stopping instances.
- Offer confirmed installation of platform user-service definitions for plain binaries and print the exact definition path and contents.
- Add scriptable `detent status` output for install source, manager, running state, PID/uptime, version, auto-update, config, and dashboard URL.

Fixes #1352

## UI Surface Contract

- [x] N/A; this is a CLI-only change with no high-impact UI surface or responsive visibility tradeoff.
- [x] This PR does not add persistent top-of-screen messaging.
- [x] This PR does not change primary operator screens.

## Test Plan

- [x] `make check`
- [x] Table-driven install-source × service-presence × running-state tests
- [x] Focused systemd, launchd, CLI prompt/output, stopped-exit, and race tests