### PR TITLE
feat(doctor): detect misplaced workflows

### DIFF
--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -217,25 +217,27 @@ type ProjectManager interface {
 type Option func(*options)
 
 type options struct {
-	resolvePath   func(string) (globalconfig.PathResolution, error)
-	read          func(string) (globalconfig.Config, error)
-	readProject   func(string, string) (globalconfig.Config, []string, error)
-	readOrDefault func(string) (globalconfig.Config, error)
-	write         func(string, globalconfig.Config) error
-	boot          BootFunc
-	signal        SignalFunc
-	lookupEnv     func(string) string
-	ghAuthToken   func(context.Context) (string, error)
-	runCommand    CommandRunner
-	httpDo        func(*http.Request) (*http.Response, error)
-	configureLog  LoggerFunc
-	captureDemo   demoCaptureFunc
-	version       string
-	build         buildinfo.Info
-	stdoutTTY     func() bool
-	shutdown      *ShutdownController
-	restart       *RestartRequest
-	service       ServiceFactory
+	resolvePath       func(string) (globalconfig.PathResolution, error)
+	read              func(string) (globalconfig.Config, error)
+	readProject       func(string, string) (globalconfig.Config, []string, error)
+	readDoctor        func(string) (globalconfig.Config, error)
+	readDoctorProject func(string, string) (globalconfig.Config, []string, error)
+	readOrDefault     func(string) (globalconfig.Config, error)
+	write             func(string, globalconfig.Config) error
+	boot              BootFunc
+	signal            SignalFunc
+	lookupEnv         func(string) string
+	ghAuthToken       func(context.Context) (string, error)
+	runCommand        CommandRunner
+	httpDo            func(*http.Request) (*http.Response, error)
+	configureLog      LoggerFunc
+	captureDemo       demoCaptureFunc
+	version           string
+	build             buildinfo.Info
+	stdoutTTY         func() bool
+	shutdown          *ShutdownController
+	restart           *RestartRequest
+	service           ServiceFactory
 }
 
 func WithBootFunc(boot BootFunc) Option {
@@ -465,6 +467,12 @@ func defaultOptions() options {
 		},
 		readProject: func(path string, projectID string) (globalconfig.Config, []string, error) {
 			return globalconfig.ReadProject(path, projectID)
+		},
+		readDoctor: func(path string) (globalconfig.Config, error) {
+			return globalconfig.Read(path, globalconfig.WithMissingWorkflowFiles())
+		},
+		readDoctorProject: func(path string, projectID string) (globalconfig.Config, []string, error) {
+			return globalconfig.ReadProject(path, projectID, globalconfig.WithMissingWorkflowFiles())
 		},
 		readOrDefault: func(path string) (globalconfig.Config, error) {
 			return globalconfig.ReadOrDefault(path, globalconfig.WithProjectPathLiterals())

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -784,10 +784,18 @@ func checkDoctorConfig(configPath string, projectID string, opts options) (globa
 
 	var cfg globalconfig.Config
 	if projectID == "" {
-		cfg, err = opts.read(resolution.Path)
+		read := opts.readDoctor
+		if read == nil {
+			read = opts.read
+		}
+		cfg, err = read(resolution.Path)
 	} else {
 		var skippedProjects []string
-		cfg, skippedProjects, err = opts.readProject(resolution.Path, projectID)
+		readProject := opts.readDoctorProject
+		if readProject == nil {
+			readProject = opts.readProject
+		}
+		cfg, skippedProjects, err = readProject(resolution.Path, projectID)
 		scope.SkippedProjects = skippedProjects
 	}
 	if err != nil {

--- a/internal/cli/doctor_project.go
+++ b/internal/cli/doctor_project.go
@@ -198,6 +198,20 @@ func checkDoctorProjectWithProgress(
 	}
 	workflowCheckName := "Project " + id + " workflow"
 	setDoctorCurrentCheck(workflowCheckName)
+	if workflowLocationCheck, ok := checkDoctorWorkflowLocation(project); ok {
+		workflowLocationCheck.Name = workflowCheckName
+		return []doctorCheck{
+			workflowLocationCheck,
+			{
+				Name:   "Project " + id + " source repo",
+				Status: doctorWarn,
+				Detail: "skipped because the repository-root workflow is missing",
+				Hint:   "Move the workflow file to the repository root, then rerun detent doctor.",
+			},
+			checkDoctorIssueEffortGuidanceUnavailable(id, "the repository-root workflow is missing"),
+			checkDoctorFollowupGuidanceUnavailable(id, "the repository-root workflow is missing"),
+		}
+	}
 	workflow, err := loadDoctorProjectWorkflow(ctx, project, deps)
 	if err != nil {
 		return []doctorCheck{
@@ -355,6 +369,84 @@ func checkDoctorProjectWithProgress(
 		checks = append(checks, checkDoctorGitHubReadiness(ctx, id, project, workflow.Config, deps, githubToken, expandedSourceRoot, allowWriteProbes)...)
 	}
 	return checks
+}
+
+func checkDoctorWorkflowLocation(project globalconfig.Project) (doctorCheck, bool) {
+	if strings.TrimSpace(project.WorkflowRef) != "" || strings.TrimSpace(project.Workdir) == "" {
+		return doctorCheck{}, false
+	}
+
+	repoRoot, err := expandDoctorWorkspacePath(project.Workdir)
+	if err != nil {
+		return doctorCheck{}, false
+	}
+	repoInfo, err := os.Stat(repoRoot)
+	if err != nil || !repoInfo.IsDir() {
+		return doctorCheck{}, false
+	}
+	workflowPath, err := expandDoctorWorkspacePath(project.Workflow)
+	if err != nil {
+		return doctorCheck{}, false
+	}
+	workflowName := filepath.Base(workflowPath)
+	expectedPath := filepath.Join(repoRoot, workflowName)
+	if doctorWorkflowFileExists(expectedPath) {
+		return doctorCheck{}, false
+	}
+
+	for _, candidate := range doctorNonstandardWorkflowCandidates(repoRoot, workflowPath, workflowName) {
+		if doctorWorkflowFileExists(candidate) {
+			return doctorCheck{
+				Status: doctorFail,
+				Detail: fmt.Sprintf("workflow found at %s; expected %s", candidate, expectedPath),
+				Hint:   doctorWorkflowRootConvention(expectedPath),
+			}, true
+		}
+	}
+
+	return doctorCheck{
+		Status: doctorFail,
+		Detail: "workflow not found; expected " + expectedPath,
+		Hint:   doctorWorkflowRootConvention(expectedPath),
+	}, true
+}
+
+func doctorNonstandardWorkflowCandidates(repoRoot string, configuredPath string, workflowName string) []string {
+	names := []string{workflowName, "workflow.md", "WORKFLOW.md"}
+	directories := []string{
+		filepath.Join(repoRoot, ".detent"),
+		filepath.Join(filepath.Dir(repoRoot), ".detent"),
+	}
+	candidates := []string{configuredPath}
+	seen := map[string]struct{}{filepath.Clean(filepath.Join(repoRoot, workflowName)): {}}
+	for _, directory := range directories {
+		for _, name := range names {
+			candidate := filepath.Clean(filepath.Join(directory, name))
+			if _, ok := seen[candidate]; ok {
+				continue
+			}
+			seen[candidate] = struct{}{}
+			candidates = append(candidates, candidate)
+		}
+	}
+	return candidates
+}
+
+func doctorWorkflowFileExists(path string) bool {
+	info, err := os.Stat(path)
+	if err != nil || info == nil {
+		return false
+	}
+	return info.Mode().IsRegular()
+}
+
+func doctorWorkflowRootConvention(expectedPath string) string {
+	return fmt.Sprintf(
+		"Move the workflow to %s. The convention is %s at the repository root, checked in; machine-local differences belong in %s.",
+		expectedPath,
+		filepath.Base(expectedPath),
+		filepath.Base(workflowconfig.LocalWorkflowPath(expectedPath)),
+	)
 }
 
 func checkDoctorLocalWorkflowOverlay(

--- a/internal/cli/doctor_project.go
+++ b/internal/cli/doctor_project.go
@@ -198,18 +198,23 @@ func checkDoctorProjectWithProgress(
 	}
 	workflowCheckName := "Project " + id + " workflow"
 	setDoctorCurrentCheck(workflowCheckName)
+	var workflowLocationFinding *doctorCheck
 	if workflowLocationCheck, ok := checkDoctorWorkflowLocation(project); ok {
 		workflowLocationCheck.Name = workflowCheckName
-		return []doctorCheck{
-			workflowLocationCheck,
-			{
-				Name:   "Project " + id + " source repo",
-				Status: doctorWarn,
-				Detail: "skipped because the repository-root workflow is missing",
-				Hint:   "Move the workflow file to the repository root, then rerun detent doctor.",
-			},
-			checkDoctorIssueEffortGuidanceUnavailable(id, "the repository-root workflow is missing"),
-			checkDoctorFollowupGuidanceUnavailable(id, "the repository-root workflow is missing"),
+		if workflowLocationCheck.Status == doctorWarn {
+			workflowLocationFinding = &workflowLocationCheck
+		} else {
+			return []doctorCheck{
+				workflowLocationCheck,
+				{
+					Name:   "Project " + id + " source repo",
+					Status: doctorWarn,
+					Detail: "skipped because the repository-root workflow is missing",
+					Hint:   "Move the workflow file to the repository root, then rerun detent doctor.",
+				},
+				checkDoctorIssueEffortGuidanceUnavailable(id, "the repository-root workflow is missing"),
+				checkDoctorFollowupGuidanceUnavailable(id, "the repository-root workflow is missing"),
+			}
 		}
 	}
 	workflow, err := loadDoctorProjectWorkflow(ctx, project, deps)
@@ -256,12 +261,20 @@ func checkDoctorProjectWithProgress(
 		Status: doctorOK,
 		Detail: doctorWorkflowDetail(project.Workflow, project, workflow.Config),
 	}
+	if workflowLocationFinding != nil {
+		workflowCheck.Status = workflowLocationFinding.Status
+		workflowCheck.Detail = workflowLocationFinding.Detail + "; " + workflowCheck.Detail
+		workflowCheck.Hint = workflowLocationFinding.Hint
+	}
 	if workflowPath, err := doctorWorkflowOptimizationWorkflowPath(project); err == nil {
 		findings := doctorReviewFlowWorkflowFindings(id, workflowPath, workflow.Config, workflow.Prompt)
 		if len(findings) > 0 {
 			workflowCheck.Status = doctorWarn
 			workflowCheck.Detail += "; review-flow prose mismatch: " + doctorWorkflowFindingDetails(findings)
-			workflowCheck.Hint = "Align WORKFLOW.md handoff prose with the configured review-flow choice, or adjust the frontmatter if the configured choice is not intended."
+			if workflowCheck.Hint != "" {
+				workflowCheck.Hint += " "
+			}
+			workflowCheck.Hint += "Align WORKFLOW.md handoff prose with the configured review-flow choice, or adjust the frontmatter if the configured choice is not intended."
 			workflowCheck.WorkflowOptimization = doctorWorkflowOptimizationReport{
 				Findings:  findings,
 				Proposals: doctorWorkflowProposalsForFindings(id, findings, 1),
@@ -396,8 +409,12 @@ func checkDoctorWorkflowLocation(project globalconfig.Project) (doctorCheck, boo
 
 	for _, candidate := range doctorNonstandardWorkflowCandidates(repoRoot, workflowPath, workflowName) {
 		if doctorWorkflowFileExists(candidate) {
+			status := doctorFail
+			if filepath.Clean(candidate) == filepath.Clean(workflowPath) {
+				status = doctorWarn
+			}
 			return doctorCheck{
-				Status: doctorFail,
+				Status: status,
 				Detail: fmt.Sprintf("workflow found at %s; expected %s", candidate, expectedPath),
 				Hint:   doctorWorkflowRootConvention(expectedPath),
 			}, true

--- a/internal/cli/doctor_workflow_location_test.go
+++ b/internal/cli/doctor_workflow_location_test.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"testing"
 
+	workflowconfig "github.com/digitaldrywood/detent/internal/config"
 	globalconfig "github.com/digitaldrywood/detent/internal/config/global"
 )
 
@@ -61,12 +62,13 @@ func TestCheckDoctorWorkflowLocation(t *testing.T) {
 		configuredOutside bool
 		wantFinding       bool
 		wantFoundPath     bool
+		wantStatus        doctorStatus
 	}{
 		{name: "root present", rootWorkflow: true},
-		{name: "nonstandard present", detentWorkflow: true, wantFinding: true, wantFoundPath: true},
+		{name: "nonstandard present", detentWorkflow: true, wantFinding: true, wantFoundPath: true, wantStatus: doctorFail},
 		{name: "both present", rootWorkflow: true, detentWorkflow: true},
-		{name: "neither present", wantFinding: true},
-		{name: "config points outside repo", configuredOutside: true, wantFinding: true, wantFoundPath: true},
+		{name: "neither present", wantFinding: true, wantStatus: doctorFail},
+		{name: "config points outside repo", configuredOutside: true, wantFinding: true, wantFoundPath: true, wantStatus: doctorWarn},
 	}
 
 	for _, tt := range tests {
@@ -102,8 +104,8 @@ func TestCheckDoctorWorkflowLocation(t *testing.T) {
 			if !tt.wantFinding {
 				return
 			}
-			if check.Status != doctorFail {
-				t.Fatalf("check.Status = %s, want %s", check.Status, doctorFail)
+			if check.Status != tt.wantStatus {
+				t.Fatalf("check.Status = %s, want %s", check.Status, tt.wantStatus)
 			}
 			if !strings.Contains(check.Detail, expectedPath) {
 				t.Fatalf("check.Detail = %q, want expected path %q", check.Detail, expectedPath)
@@ -117,6 +119,39 @@ func TestCheckDoctorWorkflowLocation(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+func TestCheckDoctorProjectContinuesWithConfiguredExternalWorkflow(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	repoRoot := filepath.Join(root, "repo")
+	externalPath := filepath.Join(root, "config", "WORKFLOW.md")
+	if err := os.MkdirAll(repoRoot, 0o755); err != nil {
+		t.Fatalf("create repo root: %v", err)
+	}
+	writeDoctorWorkflowLocationFile(t, externalPath)
+	deps := successfulDoctorDeps()
+	deps.loadWorkflow = func(string) (workflowconfig.Workflow, error) {
+		return workflowconfig.Workflow{Config: validDoctorWorkflow(repoRoot)}, nil
+	}
+
+	checks := checkDoctorProject(context.Background(), globalconfig.Project{
+		ID:       "alpha",
+		Workflow: externalPath,
+		Workdir:  repoRoot,
+	}, deps, RuntimeSecret{}, false)
+	if len(checks) < 2 {
+		t.Fatalf("len(checks) = %d, want continued project checks: %#v", len(checks), checks)
+	}
+	if checks[0].Status != doctorWarn {
+		t.Fatalf("workflow check status = %s, want %s", checks[0].Status, doctorWarn)
+	}
+	for _, want := range []string{externalPath, filepath.Join(repoRoot, "WORKFLOW.md"), "is valid"} {
+		if !strings.Contains(checks[0].Detail, want) {
+			t.Fatalf("workflow check detail = %q, want containing %q", checks[0].Detail, want)
+		}
 	}
 }
 

--- a/internal/cli/doctor_workflow_location_test.go
+++ b/internal/cli/doctor_workflow_location_test.go
@@ -1,0 +1,151 @@
+package cli
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	globalconfig "github.com/digitaldrywood/detent/internal/config/global"
+)
+
+func TestCheckDoctorConfigPreservesMissingWorkflowForDiagnosis(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	repoRoot := filepath.Join(root, "repo")
+	expectedPath := filepath.Join(repoRoot, "WORKFLOW.md")
+	foundPath := filepath.Join(repoRoot, ".detent", "WORKFLOW.md")
+	writeDoctorWorkflowLocationFile(t, foundPath)
+	configPath := filepath.Join(root, "global.yaml")
+	raw := fmt.Sprintf(`apiVersion: detent/v1
+kind: GlobalConfig
+global:
+  max_concurrent_agents: 1
+  scheduling: weighted
+projects:
+  - id: alpha
+    workflow: %q
+    workdir: %q
+    weight: 1
+    priority: 0
+`, expectedPath, repoRoot)
+	if err := os.WriteFile(configPath, []byte(raw), 0o600); err != nil {
+		t.Fatalf("write global config: %v", err)
+	}
+
+	_, cfg, _, _, configCheck := checkDoctorConfig(configPath, "", defaultOptions())
+	if configCheck.Status != doctorOK || cfg == nil {
+		t.Fatalf("checkDoctorConfig() = (%#v, %#v), want parsed config", cfg, configCheck)
+	}
+	checks := checkDoctorProjects(context.Background(), *cfg, successfulDoctorDeps(), RuntimeSecret{}, false)
+	if len(checks) == 0 {
+		t.Fatal("checkDoctorProjects() returned no checks")
+	}
+	for _, want := range []string{foundPath, expectedPath} {
+		if !strings.Contains(checks[0].Detail, want) {
+			t.Fatalf("workflow check detail = %q, want containing %q", checks[0].Detail, want)
+		}
+	}
+}
+
+func TestCheckDoctorWorkflowLocation(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name              string
+		rootWorkflow      bool
+		detentWorkflow    bool
+		configuredOutside bool
+		wantFinding       bool
+		wantFoundPath     bool
+	}{
+		{name: "root present", rootWorkflow: true},
+		{name: "nonstandard present", detentWorkflow: true, wantFinding: true, wantFoundPath: true},
+		{name: "both present", rootWorkflow: true, detentWorkflow: true},
+		{name: "neither present", wantFinding: true},
+		{name: "config points outside repo", configuredOutside: true, wantFinding: true, wantFoundPath: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			parent := t.TempDir()
+			repoRoot := filepath.Join(parent, "repo")
+			if err := os.MkdirAll(repoRoot, 0o755); err != nil {
+				t.Fatalf("create repo root: %v", err)
+			}
+			expectedPath := filepath.Join(repoRoot, "WORKFLOW.md")
+			configuredPath := expectedPath
+			foundPath := filepath.Join(repoRoot, ".detent", "WORKFLOW.md")
+			if tt.configuredOutside {
+				configuredPath = filepath.Join(parent, "detent-config", "WORKFLOW.md")
+				foundPath = configuredPath
+			}
+			if tt.rootWorkflow {
+				writeDoctorWorkflowLocationFile(t, expectedPath)
+			}
+			if tt.detentWorkflow || tt.configuredOutside {
+				writeDoctorWorkflowLocationFile(t, foundPath)
+			}
+
+			check, gotFinding := checkDoctorWorkflowLocation(globalconfig.Project{
+				Workflow: configuredPath,
+				Workdir:  repoRoot,
+			})
+			if gotFinding != tt.wantFinding {
+				t.Fatalf("checkDoctorWorkflowLocation() finding = %t, want %t: %#v", gotFinding, tt.wantFinding, check)
+			}
+			if !tt.wantFinding {
+				return
+			}
+			if check.Status != doctorFail {
+				t.Fatalf("check.Status = %s, want %s", check.Status, doctorFail)
+			}
+			if !strings.Contains(check.Detail, expectedPath) {
+				t.Fatalf("check.Detail = %q, want expected path %q", check.Detail, expectedPath)
+			}
+			if tt.wantFoundPath && !strings.Contains(check.Detail, foundPath) {
+				t.Fatalf("check.Detail = %q, want found path %q", check.Detail, foundPath)
+			}
+			for _, want := range []string{"repository root", "checked in", "WORKFLOW.local.md"} {
+				if !strings.Contains(check.Hint, want) {
+					t.Fatalf("check.Hint = %q, want containing %q", check.Hint, want)
+				}
+			}
+		})
+	}
+}
+
+func TestCheckDoctorWorkflowLocationClearsAfterMove(t *testing.T) {
+	t.Parallel()
+
+	repoRoot := t.TempDir()
+	configuredPath := filepath.Join(repoRoot, "WORKFLOW.md")
+	misplacedPath := filepath.Join(repoRoot, ".detent", "WORKFLOW.md")
+	writeDoctorWorkflowLocationFile(t, misplacedPath)
+	project := globalconfig.Project{Workflow: configuredPath, Workdir: repoRoot}
+
+	if _, ok := checkDoctorWorkflowLocation(project); !ok {
+		t.Fatal("checkDoctorWorkflowLocation() did not report misplaced workflow")
+	}
+	if err := os.Rename(misplacedPath, configuredPath); err != nil {
+		t.Fatalf("move workflow to repository root: %v", err)
+	}
+	if check, ok := checkDoctorWorkflowLocation(project); ok {
+		t.Fatalf("checkDoctorWorkflowLocation() = %#v, want finding cleared", check)
+	}
+}
+
+func writeDoctorWorkflowLocationFile(t *testing.T, path string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("create workflow directory: %v", err)
+	}
+	if err := os.WriteFile(path, []byte("---\n---\n"), 0o600); err != nil {
+		t.Fatalf("write workflow: %v", err)
+	}
+}

--- a/internal/config/global/config.go
+++ b/internal/config/global/config.go
@@ -153,9 +153,10 @@ type ValidationError struct {
 }
 
 type options struct {
-	home                string
-	relativeTo          string
-	projectPathLiterals bool
+	home                      string
+	relativeTo                string
+	projectPathLiterals       bool
+	allowMissingWorkflowFiles bool
 }
 
 type pathOptions struct {
@@ -180,6 +181,12 @@ func WithRelativeTo(path string) Option {
 func WithProjectPathLiterals() Option {
 	return func(opts *options) {
 		opts.projectPathLiterals = true
+	}
+}
+
+func WithMissingWorkflowFiles() Option {
+	return func(opts *options) {
+		opts.allowMissingWorkflowFiles = true
 	}
 }
 
@@ -1060,6 +1067,9 @@ func plainWorkflowPathErrors(path string, field string, opts options, expected p
 	}
 	if relativeWorkflowPathLiteral(path) {
 		return []string{field + ": " + plainWorkflowPathRequirement}
+	}
+	if opts.allowMissingWorkflowFiles {
+		return nil
 	}
 	return projectPathErrors(path, field, opts, expected)
 }


### PR DESCRIPTION
## Summary

- preserve configured projects with missing workflow files so doctor can diagnose them
- detect workflows in `.detent`, sibling config directories, and configured paths outside the repository
- report the checked-in repository-root convention and `WORKFLOW.local.md` guidance
- clear the placement finding immediately when the root workflow appears

Fixes #1363

## UI Surface Contract

- [x] N/A, or the linked issue explicitly authorizes any high-impact UI surface, layout, density, first-viewport, or responsive visibility tradeoff.
- [x] Persistent top-of-screen messaging is explicitly authorized by the issue, or this PR does not add it.
- [x] Visual changes to primary operator screens include screenshot or browser verification below.

No UI changes.

## Test Plan

- [x] `go test ./internal/config/global ./internal/cli -count=1`
- [x] `make check`
