### PR TITLE
test(check): serialize concurrent validation

### DIFF
--- a/.detent/skills/subprocess-pressure-tracing.md
+++ b/.detent/skills/subprocess-pressure-tracing.md
@@ -1,6 +1,6 @@
 ---
 name: subprocess-pressure-tracing
-description: Measure subprocess fan-out behind intermittent crashes, fork/exec hangs, and orphaned child processes.
+description: Measure and mitigate subprocess fan-out behind intermittent crashes, fork/exec hangs, and orphaned child processes.
 when_to_use: Use when focused tests pass but concurrent or race suites intermittently crash or hang an external command.
 ---
 
@@ -11,5 +11,6 @@ when_to_use: Use when focused tests pass but concurrent or race suites intermitt
 - Group trace entries by normalized arguments and caller scenario. Separate required integration commands from accidental discovery against fake workspaces or ancestor repositories.
 - Correlate the trace with the full failing log or stack. A failure in a later test-helper command after the production call succeeded indicates environmental process instability, not necessarily invalid fixture lifecycle.
 - Prefer eliminating launches: reject non-target paths before spawning, bound repository discovery, and combine read-only queries into one command when the tool supports it.
+- If required fan-out remains unsafe across concurrent worktrees, serialize only the top-level validation gate with a crash-safe OS lock scoped to the Git common directory. Bound the wait, share no outputs through the lock location, and keep temp files, generated assets, binaries, and coverage profiles worktree-local.
 - Repeat the same traced command after the change and record before/after launch counts. Then remove the tracing wrapper from `PATH` and run focused race repetitions plus the full validation gate.
 - Keep real integration coverage for the external tool's observable behavior; replace only redundant setup or expectation commands with direct fixture facts when those facts are independently known.

--- a/Makefile
+++ b/Makefile
@@ -24,8 +24,9 @@ DATABASE_URL ?= tmp/detent.db
 NILAWAY_VERSION ?= v0.0.0-20260612163715-2d8907f431ca
 NILAWAY ?= go run go.uber.org/nilaway/cmd/nilaway@$(NILAWAY_VERSION)
 NILAWAY_INCLUDE_PKGS ?= github.com/digitaldrywood/detent
+CHECK_LOCK_WAIT ?= 15m
 
-.PHONY: dev generate css css-watch build test test-race test-cover test-cover-packages soak visual-e2e visual-e2e-update lint vet check modernize-check nilaway-audit release-snapshot sqlc db-migrate setup clean help
+.PHONY: dev generate css css-watch build test test-race test-cover test-cover-packages soak visual-e2e visual-e2e-update lint vet check check-unlocked modernize-check nilaway-audit release-snapshot sqlc db-migrate setup clean help
 
 dev:
 	@mkdir -p tmp
@@ -109,7 +110,11 @@ vet:
 nilaway-audit:
 	$(NILAWAY) -include-pkgs=$(NILAWAY_INCLUDE_PKGS) ./...
 
-check: build lint vet nilaway-audit test-race test-cover test-cover-packages
+check:
+	@common_dir="$$(git rev-parse --path-format=absolute --git-common-dir)" && \
+	go run ./tools/checklock -lock "$$common_dir/detent-validation.lock" -wait-timeout "$(CHECK_LOCK_WAIT)" -- $(MAKE) check-unlocked
+
+check-unlocked: build lint vet nilaway-audit test-race test-cover test-cover-packages
 	@echo "All checks passed."
 
 modernize-check:

--- a/tools/checklock/main.go
+++ b/tools/checklock/main.go
@@ -1,0 +1,117 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"time"
+
+	"github.com/digitaldrywood/detent/internal/instancelock"
+)
+
+const validationLockPollInterval = 100 * time.Millisecond
+
+func main() {
+	os.Exit(run(context.Background(), os.Args[1:], os.Stdin, os.Stdout, os.Stderr))
+}
+
+func run(ctx context.Context, args []string, stdin io.Reader, stdout, stderr io.Writer) int {
+	flags := flag.NewFlagSet("checklock", flag.ContinueOnError)
+	flags.SetOutput(stderr)
+
+	lockPath := flags.String("lock", "", "validation lock path")
+	waitTimeout := flags.Duration("wait-timeout", 15*time.Minute, "maximum time to wait for another validation gate")
+
+	if err := flags.Parse(args); err != nil {
+		return 2
+	}
+	if *lockPath == "" {
+		fmt.Fprintln(stderr, "-lock is required")
+		return 2
+	}
+	if *waitTimeout <= 0 {
+		fmt.Fprintln(stderr, "-wait-timeout must be positive")
+		return 2
+	}
+	command := flags.Args()
+	if len(command) == 0 {
+		fmt.Fprintln(stderr, "command is required after --")
+		return 2
+	}
+
+	waitCtx, cancel := context.WithTimeout(ctx, *waitTimeout)
+	defer cancel()
+
+	lock, waited, err := acquireValidationLock(waitCtx, *lockPath, stderr)
+	if err != nil {
+		fmt.Fprintf(stderr, "acquire validation lock: %v\n", err)
+		return 1
+	}
+	if waited {
+		fmt.Fprintf(stderr, "validation gate acquired shared lock: %s\n", *lockPath)
+	}
+
+	commandPath, commandPathErr := exec.LookPath(command[0])
+	if commandPathErr != nil {
+		fmt.Fprintf(stderr, "resolve validation command: %v\n", commandPathErr)
+		if err := lock.Close(); err != nil {
+			fmt.Fprintf(stderr, "release validation lock: %v\n", err)
+		}
+		return 1
+	}
+	cmd := &exec.Cmd{
+		Path:   commandPath,
+		Args:   command,
+		Stdin:  stdin,
+		Stdout: stdout,
+		Stderr: stderr,
+	}
+	commandErr := cmd.Run()
+	closeErr := lock.Close()
+	if closeErr != nil {
+		fmt.Fprintf(stderr, "release validation lock: %v\n", closeErr)
+	}
+	if commandErr != nil {
+		var exitErr *exec.ExitError
+		if errors.As(commandErr, &exitErr) {
+			return exitErr.ExitCode()
+		}
+		fmt.Fprintf(stderr, "run validation command: %v\n", commandErr)
+		return 1
+	}
+	if closeErr != nil {
+		return 1
+	}
+	return 0
+}
+
+func acquireValidationLock(ctx context.Context, path string, stderr io.Writer) (*instancelock.Lock, bool, error) {
+	waited := false
+	for {
+		lock, err := instancelock.Acquire(path)
+		if err == nil {
+			return lock, waited, nil
+		}
+		if !errors.Is(err, instancelock.ErrHeld) {
+			return nil, waited, err
+		}
+		if !waited {
+			fmt.Fprintf(stderr, "validation gate waiting for another worktree: %s\n", path)
+			waited = true
+		}
+
+		timer := time.NewTimer(validationLockPollInterval)
+		select {
+		case <-ctx.Done():
+			if !timer.Stop() {
+				<-timer.C
+			}
+			return nil, waited, ctx.Err()
+		case <-timer.C:
+		}
+	}
+}

--- a/tools/checklock/main_test.go
+++ b/tools/checklock/main_test.go
@@ -1,0 +1,207 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/digitaldrywood/detent/internal/instancelock"
+)
+
+const validationSubprocessHelper = "DETENT_CHECKLOCK_HELPER"
+
+func TestRunValidatesArguments(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		args    []string
+		wantErr string
+	}{
+		{name: "missing lock", args: []string{"--", "go", "version"}, wantErr: "-lock is required"},
+		{name: "invalid wait timeout", args: []string{"-lock", "gate.lock", "-wait-timeout", "0s", "--", "go", "version"}, wantErr: "-wait-timeout must be positive"},
+		{name: "missing command", args: []string{"-lock", "gate.lock"}, wantErr: "command is required after --"},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			var stderr bytes.Buffer
+			if code := run(t.Context(), tt.args, strings.NewReader(""), io.Discard, &stderr); code != 2 {
+				t.Fatalf("run() = %d, want 2", code)
+			}
+			if !strings.Contains(stderr.String(), tt.wantErr) {
+				t.Fatalf("stderr = %q, want containing %q", stderr.String(), tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestRunSerializesConcurrentSubprocesses(t *testing.T) {
+	tempDir := t.TempDir()
+	validationLock := filepath.Join(tempDir, "validation.lock")
+	criticalLock := filepath.Join(tempDir, "critical.lock")
+	tracePath := filepath.Join(tempDir, "trace")
+	releasePath := filepath.Join(tempDir, "release")
+	t.Setenv(validationSubprocessHelper, "1")
+	t.Setenv("DETENT_CHECKLOCK_CRITICAL_LOCK", criticalLock)
+	t.Setenv("DETENT_CHECKLOCK_TRACE", tracePath)
+	t.Setenv("DETENT_CHECKLOCK_RELEASE", releasePath)
+	t.Cleanup(func() {
+		_ = os.WriteFile(releasePath, nil, 0o600)
+	})
+
+	ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
+	defer cancel()
+	args := []string{
+		"-lock", validationLock,
+		"-wait-timeout", "5s",
+		"--", os.Args[0], "-test.run=^TestValidationSubprocessHelper$",
+	}
+
+	firstDone := make(chan int, 1)
+	go func() {
+		firstDone <- run(ctx, args, strings.NewReader(""), io.Discard, io.Discard)
+	}()
+	waitForTraceLines(t, ctx, tracePath, 1)
+
+	secondWait := newNotifyingWriter()
+	secondDone := make(chan int, 1)
+	go func() {
+		secondDone <- run(ctx, args, strings.NewReader(""), io.Discard, secondWait)
+	}()
+	select {
+	case <-secondWait.notified:
+	case code := <-secondDone:
+		t.Fatalf("second run completed before first released lock with code %d", code)
+	case <-ctx.Done():
+		t.Fatalf("wait for second run contention: %v", ctx.Err())
+	}
+	if got := traceLineCount(t, tracePath); got != 1 {
+		t.Fatalf("trace lines while first subprocess holds critical section = %d, want 1", got)
+	}
+
+	if err := os.WriteFile(releasePath, nil, 0o600); err != nil {
+		t.Fatalf("write release signal: %v", err)
+	}
+	for name, done := range map[string]<-chan int{"first": firstDone, "second": secondDone} {
+		select {
+		case code := <-done:
+			if code != 0 {
+				t.Fatalf("%s run code = %d, want 0", name, code)
+			}
+		case <-ctx.Done():
+			t.Fatalf("wait for %s run: %v", name, ctx.Err())
+		}
+	}
+	if got := traceLineCount(t, tracePath); got != 2 {
+		t.Fatalf("serialized subprocess trace lines = %d, want 2", got)
+	}
+}
+
+func TestValidationSubprocessHelper(t *testing.T) {
+	if os.Getenv(validationSubprocessHelper) == "" {
+		t.Skip("helper process")
+	}
+
+	lock, err := instancelock.Acquire(os.Getenv("DETENT_CHECKLOCK_CRITICAL_LOCK"))
+	if err != nil {
+		t.Fatalf("acquire critical lock: %v", err)
+	}
+	defer func() {
+		if err := lock.Close(); err != nil {
+			t.Errorf("release critical lock: %v", err)
+		}
+	}()
+
+	trace, err := os.OpenFile(os.Getenv("DETENT_CHECKLOCK_TRACE"), os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0o600)
+	if err != nil {
+		t.Fatalf("open trace: %v", err)
+	}
+	if _, err := fmt.Fprintln(trace, os.Getpid()); err != nil {
+		t.Fatalf("write trace: %v", err)
+	}
+	if err := trace.Close(); err != nil {
+		t.Fatalf("close trace: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
+	defer cancel()
+	waitForPath(t, ctx, os.Getenv("DETENT_CHECKLOCK_RELEASE"))
+}
+
+type notifyingWriter struct {
+	mu       sync.Mutex
+	data     bytes.Buffer
+	notified chan struct{}
+	once     sync.Once
+}
+
+func newNotifyingWriter() *notifyingWriter {
+	return &notifyingWriter{notified: make(chan struct{})}
+}
+
+func (w *notifyingWriter) Write(data []byte) (int, error) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	w.once.Do(func() { close(w.notified) })
+	return w.data.Write(data)
+}
+
+func waitForTraceLines(t *testing.T, ctx context.Context, path string, want int) {
+	t.Helper()
+
+	ticker := time.NewTicker(10 * time.Millisecond)
+	defer ticker.Stop()
+	for {
+		if traceLineCount(t, path) >= want {
+			return
+		}
+		select {
+		case <-ctx.Done():
+			t.Fatalf("wait for %d trace lines: %v", want, ctx.Err())
+		case <-ticker.C:
+		}
+	}
+}
+
+func traceLineCount(t *testing.T, path string) int {
+	t.Helper()
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return 0
+		}
+		t.Fatalf("read trace: %v", err)
+	}
+	return len(strings.Fields(string(data)))
+}
+
+func waitForPath(t *testing.T, ctx context.Context, path string) {
+	t.Helper()
+
+	ticker := time.NewTicker(10 * time.Millisecond)
+	defer ticker.Stop()
+	for {
+		if _, err := os.Stat(path); err == nil {
+			return
+		} else if !os.IsNotExist(err) {
+			t.Fatalf("stat release signal: %v", err)
+		}
+		select {
+		case <-ctx.Done():
+			t.Fatalf("wait for release signal: %v", ctx.Err())
+		case <-ticker.C:
+		}
+	}
+}


### PR DESCRIPTION
## Summary

- serialize top-level `make check` runs across linked worktrees with a repository-scoped, bounded OS lock
- keep the nested validation gate outputs, generated files, coverage profiles, and temp paths worktree-local
- add a deterministic regression that runs real subprocesses concurrently and proves their critical sections cannot overlap
- extend the subprocess-pressure skill with the repository-scoped coordination fallback

Fixes #1369

## UI Surface Contract

- [x] N/A; this PR does not change UI surfaces.
- [x] This PR does not add persistent messaging.
- [x] This PR has no visual changes.

## Test Plan

- [x] `go test -race ./internal/instancelock ./tools/checklock -count=5`
- [x] `go vet ./tools/checklock`
- [x] `golangci-lint run --timeout=5m ./tools/checklock/...`
- [x] `make check`
- [x] concurrent `make check` in two linked worktrees at `f26a0c01` (both pass; queued gate logs wait/acquire events)
- [x] final `make check` after skill draft update (60.38s)