### PR TITLE
fix(orchestrator): settle current-head CI checks

### DIFF
--- a/internal/connector/github/adapter_test.go
+++ b/internal/connector/github/adapter_test.go
@@ -4476,6 +4476,64 @@ func TestConnectorHydratePullRequestNormalizesStaleSuccessfulWorkflowCheckRun(t 
 	}
 }
 
+func TestConnectorHydratePullRequestUsesEffectiveCheckRunsForWorkflowTelemetry(t *testing.T) {
+	t.Parallel()
+
+	server := newGraphQLTestServer(t, []graphqlTestResponse{
+		{
+			method: http.MethodGet,
+			path:   "/repos/example/repo/pulls/971",
+			body:   `{"number":971,"html_url":"https://github.com/example/repo/pull/971","state":"open","mergeable_state":"clean","draft":false,"head":{"ref":"detent/example_repo_971","sha":"head-sha"},"base":{"sha":"base-sha"},"updated_at":"2026-07-16T18:10:00Z"}`,
+		},
+		{
+			method: http.MethodGet,
+			path:   "/repos/example/repo/commits/head-sha/check-runs?per_page=100",
+			body:   `{"check_runs":[{"id":97101,"name":"Verify","status":"completed","conclusion":"cancelled","details_url":"https://github.com/example/repo/actions/runs/7001/job/97101","created_at":"2026-07-16T18:00:00Z","started_at":"2026-07-16T18:01:00Z","completed_at":"2026-07-16T18:02:00Z"},{"id":97102,"name":"Verify","status":"completed","conclusion":"success","details_url":"https://github.com/example/repo/actions/runs/7002/job/97102","created_at":"2026-07-16T18:05:00Z","started_at":"2026-07-16T18:06:00Z","completed_at":"2026-07-16T18:10:00Z"}]}`,
+		},
+		{
+			method: http.MethodGet,
+			path:   "/repos/example/repo/actions/runs/7002",
+			body:   `{"id":7002,"status":"completed","conclusion":"success","created_at":"2026-07-16T18:05:00Z","run_started_at":"2026-07-16T18:06:00Z","updated_at":"2026-07-16T18:10:00Z"}`,
+		},
+		{
+			method: http.MethodGet,
+			path:   "/repos/example/repo/commits/head-sha/statuses?per_page=100",
+			body:   `[]`,
+		},
+		{
+			method: http.MethodGet,
+			path:   "/repos/example/repo/pulls/971/reviews?per_page=100",
+			body:   `[]`,
+		},
+	})
+	c := newGitHubTestConnector(t, server, Config{})
+	prNumber := 971
+	issue := connector.Issue{
+		ID:         "I_kw971",
+		Identifier: "example/repo#971",
+		PRNumber:   &prNumber,
+	}
+
+	got, err := c.HydratePullRequest(context.Background(), issue)
+	if err != nil {
+		t.Fatalf("HydratePullRequest() error = %v", err)
+	}
+
+	pr := got.PullRequest
+	if pr == nil {
+		t.Fatal("PullRequest = nil, want hydrated pull request")
+		return
+	}
+	if pr.CIStatus != "pass" || pr.CIQueueSeconds != 60 || pr.CIDurationSeconds != 240 {
+		t.Fatalf("PullRequest CI = %#v, want pass with 60s queue and 240s duration", pr)
+	}
+	for _, request := range server.requests() {
+		if request["path"] == "/repos/example/repo/actions/runs/7001" {
+			t.Fatalf("request path = %q, want superseded workflow run excluded", request["path"])
+		}
+	}
+}
+
 func TestConnectorHydratePullRequestTreatsSkippedRequiredStatusCheckAsPending(t *testing.T) {
 	t.Parallel()
 

--- a/internal/connector/github/adapter_test.go
+++ b/internal/connector/github/adapter_test.go
@@ -2359,8 +2359,8 @@ func TestConnectorFetchIssuesByStatesAttachesPipelinePullRequest(t *testing.T) {
 		t.Fatalf("FetchIssuesByStates() len = %d, want 1", len(got))
 	}
 	pr := got[0].PullRequest
-	if pr == nil || pr.Number != 190 || pr.CIStatus != "fail" || pr.CodexReviewState != "P1" {
-		t.Fatalf("PullRequest = %#v, want PR 190 with failing CI and P1 review", pr)
+	if pr == nil || pr.Number != 190 || pr.CIStatus != "pending" || pr.CodexReviewState != "P1" {
+		t.Fatalf("PullRequest = %#v, want PR 190 with pending CI and P1 review", pr)
 	}
 	if pr.MergeableState != "dirty" {
 		t.Fatalf("MergeableState = %q, want dirty from hydrated PR", pr.MergeableState)
@@ -2445,6 +2445,159 @@ func TestCheckRunsStateTreatsStaleSuccessfulCheckRunAsSuccess(t *testing.T) {
 	}
 }
 
+func TestCheckRunsStateUsesSettledContextResults(t *testing.T) {
+	t.Parallel()
+
+	older := time.Date(2026, 7, 16, 18, 0, 0, 0, time.UTC)
+	newer := older.Add(time.Minute)
+	tests := []struct {
+		name      string
+		checkRuns []restCheckRun
+		want      string
+	}{
+		{
+			name: "pending current cycle supersedes settled failure",
+			checkRuns: []restCheckRun{
+				{ID: 1, Name: "Checks", Status: "completed", Conclusion: "failure", StartedAt: &older},
+				{ID: 2, Name: "Checks", Status: "in_progress", StartedAt: &newer},
+			},
+			want: "pending",
+		},
+		{
+			name: "pending context keeps a different failure unsettled",
+			checkRuns: []restCheckRun{
+				{Name: "Checks", Status: "completed", Conclusion: "failure"},
+				{Name: "Test", Status: "queued"},
+			},
+			want: "pending",
+		},
+		{
+			name: "cancelled artifact does not shadow success",
+			checkRuns: []restCheckRun{
+				{ID: 1, Name: "Changed-file coverage", Status: "completed", Conclusion: "success", StartedAt: &older},
+				{ID: 2, Name: "Changed-file coverage", Status: "completed", Conclusion: "cancelled", StartedAt: &newer},
+			},
+			want: "success",
+		},
+		{
+			name: "skipped artifact does not shadow success",
+			checkRuns: []restCheckRun{
+				{ID: 1, Name: "Test", Status: "completed", Conclusion: "success", StartedAt: &older},
+				{ID: 2, Name: "Test", Status: "completed", Conclusion: "skipped", StartedAt: &newer},
+			},
+			want: "success",
+		},
+		{
+			name: "newer settled success supersedes failure",
+			checkRuns: []restCheckRun{
+				{ID: 1, Name: "Checks", Status: "completed", Conclusion: "failure", StartedAt: &older},
+				{ID: 2, Name: "Checks", Status: "completed", Conclusion: "success", StartedAt: &newer},
+			},
+			want: "success",
+		},
+		{
+			name: "newer settled failure supersedes success",
+			checkRuns: []restCheckRun{
+				{ID: 1, Name: "Checks", Status: "completed", Conclusion: "success", StartedAt: &older},
+				{ID: 2, Name: "Checks", Status: "completed", Conclusion: "failure", StartedAt: &newer},
+			},
+			want: "failure",
+		},
+		{
+			name: "only ignored conclusions remain pending",
+			checkRuns: []restCheckRun{
+				{Name: "Checks", Status: "completed", Conclusion: "cancelled"},
+				{Name: "Test", Status: "completed", Conclusion: "skipped"},
+			},
+			want: "pending",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			if got := checkRunsState(tt.checkRuns); got != tt.want {
+				t.Fatalf("checkRunsState() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestCompletedFailedCheckRunIgnoresNonFailureArtifacts(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		conclusion string
+		want       bool
+	}{
+		{conclusion: "failure", want: true},
+		{conclusion: "timed_out", want: true},
+		{conclusion: "cancelled"},
+		{conclusion: "canceled"},
+		{conclusion: "skipped"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.conclusion, func(t *testing.T) {
+			t.Parallel()
+
+			checkRun := restCheckRun{Status: "completed", Conclusion: tt.conclusion}
+			if got := completedFailedCheckRun(checkRun); got != tt.want {
+				t.Fatalf("completedFailedCheckRun() = %t, want %t", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestCIStateWaitsForAllContextsToSettle(t *testing.T) {
+	t.Parallel()
+
+	statuses := []restCommitStatus{
+		{Context: "Checks", State: "failure"},
+		{Context: "Test", State: "pending"},
+	}
+	if got := commitStatusesState(statuses); got != "pending" {
+		t.Fatalf("commitStatusesState() = %q, want pending", got)
+	}
+	if got := combinedCIState("failure", "pending"); got != "pending" {
+		t.Fatalf("combinedCIState() = %q, want pending", got)
+	}
+}
+
+func TestCheckRunTelemetryExcludesSupersededFailures(t *testing.T) {
+	t.Parallel()
+
+	older := time.Date(2026, 7, 16, 18, 0, 0, 0, time.UTC)
+	olderDone := older.Add(10 * time.Minute)
+	newer := older.Add(time.Minute)
+	newerDone := newer.Add(time.Minute)
+	summary := checkRunTelemetry([]restCheckRun{
+		{ID: 1, Name: "Checks", Status: "completed", Conclusion: "failure", StartedAt: &older, CompletedAt: &olderDone},
+		{ID: 2, Name: "Checks", Status: "completed", Conclusion: "success", StartedAt: &newer, CompletedAt: &newerDone},
+	}, nil)
+
+	if len(summary.SlowChecks) != 1 || summary.SlowChecks[0].Conclusion != "success" {
+		t.Fatalf("SlowChecks = %#v, want only latest settled success", summary.SlowChecks)
+	}
+}
+
+func TestTransientCheckRunFailuresExcludeSupersededFailures(t *testing.T) {
+	t.Parallel()
+
+	older := time.Date(2026, 7, 16, 18, 0, 0, 0, time.UTC)
+	newer := older.Add(time.Minute)
+	checkRuns := []restCheckRun{
+		{ID: 1, Name: "Checks", Status: "completed", Conclusion: "failure", StartedAt: &older, Output: checkRunOutput{Text: "signal: killed"}},
+		{ID: 2, Name: "Checks", Status: "completed", Conclusion: "success", StartedAt: &newer},
+	}
+	c := &Connector{}
+
+	if got := c.transientCheckRunFailures(context.Background(), pullRequestRepo{}, checkRuns); len(got) != 0 {
+		t.Fatalf("transientCheckRunFailures() = %#v, want none", got)
+	}
+}
+
 func TestCheckRunTelemetryUsesWorkflowRunTimingForQueue(t *testing.T) {
 	t.Parallel()
 
@@ -2516,15 +2669,44 @@ func TestRequiredStatusCheckFailures(t *testing.T) {
 			}},
 		},
 		{
-			name:      "skipped required check fails",
+			name:      "skipped required check remains pending",
 			checkRuns: []restCheckRun{{Name: "Windows Core", Status: "completed", Conclusion: "skipped"}},
 			required:  []string{"Windows Core"},
-			wantState: "failure",
+			wantState: "pending",
 			wantChecks: []connector.PullRequestCheck{{
-				Name:       "Windows Core",
-				Status:     "completed",
-				Conclusion: "skipped",
+				Name:   "Windows Core",
+				Status: "pending",
 			}},
+		},
+		{
+			name: "pending required check wins over settled failure",
+			checkRuns: []restCheckRun{
+				{Name: "Checks", Status: "completed", Conclusion: "failure"},
+				{Name: "Test", Status: "in_progress"},
+			},
+			required:  []string{"Checks", "Test"},
+			wantState: "pending",
+			wantChecks: []connector.PullRequestCheck{
+				{Name: "Checks", Status: "completed", Conclusion: "failure"},
+				{Name: "Test", Status: "in_progress"},
+			},
+		},
+		{
+			name: "cancelled and skipped shadows do not replace settled success",
+			checkRuns: []restCheckRun{
+				{ID: 5, Name: "Checks", Status: "completed", Conclusion: "cancelled"},
+				{ID: 4, Name: "Checks", Status: "completed", Conclusion: "skipped"},
+				{ID: 3, Name: "Checks", Status: "completed", Conclusion: "success"},
+			},
+			required: []string{"Checks"},
+		},
+		{
+			name: "latest settled result wins regardless of response order",
+			checkRuns: []restCheckRun{
+				{ID: 1, Name: "Checks", Status: "completed", Conclusion: "failure", StartedAt: new(time.Date(2026, 7, 16, 18, 0, 0, 0, time.UTC))},
+				{ID: 2, Name: "Checks", Status: "completed", Conclusion: "success", StartedAt: new(time.Date(2026, 7, 16, 18, 1, 0, 0, time.UTC))},
+			},
+			required: []string{"Checks"},
 		},
 		{
 			name:      "neutral required check fails",
@@ -4294,7 +4476,7 @@ func TestConnectorHydratePullRequestNormalizesStaleSuccessfulWorkflowCheckRun(t 
 	}
 }
 
-func TestConnectorHydratePullRequestBlocksSkippedRequiredStatusCheck(t *testing.T) {
+func TestConnectorHydratePullRequestTreatsSkippedRequiredStatusCheckAsPending(t *testing.T) {
 	t.Parallel()
 
 	server := newGraphQLTestServer(t, []graphqlTestResponse{
@@ -4337,16 +4519,68 @@ func TestConnectorHydratePullRequestBlocksSkippedRequiredStatusCheck(t *testing.
 		t.Fatalf("PullRequest = nil, want hydrated pull request")
 		return
 	}
-	if pr.CIStatus != "fail" {
-		t.Fatalf("CIStatus = %q, want fail for skipped required check", pr.CIStatus)
+	if pr.CIStatus != "pending" {
+		t.Fatalf("CIStatus = %q, want pending for skipped required check", pr.CIStatus)
 	}
 	want := []connector.PullRequestCheck{{
-		Name:       "Windows Core",
-		Status:     "completed",
-		Conclusion: "skipped",
+		Name:   "Windows Core",
+		Status: "pending",
 	}}
 	if !reflect.DeepEqual(pr.RequiredCheckFailures, want) {
 		t.Fatalf("RequiredCheckFailures = %#v, want %#v", pr.RequiredCheckFailures, want)
+	}
+}
+
+func TestConnectorHydratePullRequestWaitsForRunningRequiredCheckDespiteCancelledShadow(t *testing.T) {
+	t.Parallel()
+
+	server := newGraphQLTestServer(t, []graphqlTestResponse{
+		{
+			method: http.MethodGet,
+			path:   "/repos/example/repo/pulls/42",
+			body:   `{"number":42,"html_url":"https://github.com/example/repo/pull/42","state":"open","mergeable_state":"clean","draft":false,"head":{"ref":"detent/example_repo_1","sha":"head-sha"},"base":{"sha":"base-sha"}}`,
+		},
+		{
+			method: http.MethodGet,
+			path:   "/repos/example/repo/commits/head-sha/check-runs?per_page=100",
+			body:   `{"check_runs":[{"name":"Changed-file coverage","status":"completed","conclusion":"success","started_at":"2026-07-16T18:21:41Z"},{"name":"Changed-file coverage","status":"completed","conclusion":"cancelled","started_at":"2026-07-16T18:20:00Z"},{"name":"Checks","status":"completed","conclusion":"failure","started_at":"2026-07-16T18:00:00Z"},{"id":5,"name":"Checks","status":"in_progress","started_at":"2026-07-16T18:21:40Z"}]}`,
+		},
+		{
+			method: http.MethodGet,
+			path:   "/repos/example/repo/commits/head-sha/statuses?per_page=100",
+			body:   `[]`,
+		},
+		{
+			method: http.MethodGet,
+			path:   "/repos/example/repo/pulls/42/reviews?per_page=100",
+			body:   `[]`,
+		},
+	})
+	c := newGitHubTestConnector(t, server, Config{RequiredStatusChecks: []string{"Changed-file coverage", "Checks"}})
+	prNumber := 42
+	issue := connector.Issue{
+		ID:         "I_kw42",
+		Identifier: "example/repo#1",
+		PRNumber:   &prNumber,
+	}
+
+	got, err := c.HydratePullRequest(context.Background(), issue)
+	if err != nil {
+		t.Fatalf("HydratePullRequest() error = %v", err)
+	}
+	if got.PullRequest == nil {
+		t.Fatal("PullRequest = nil, want hydrated pull request")
+	}
+	if got.PullRequest.CIStatus != "pending" {
+		t.Fatalf("CIStatus = %q, want pending", got.PullRequest.CIStatus)
+	}
+	want := []connector.PullRequestCheck{{
+		ID:     5,
+		Name:   "Checks",
+		Status: "in_progress",
+	}}
+	if !reflect.DeepEqual(got.PullRequest.RequiredCheckFailures, want) {
+		t.Fatalf("RequiredCheckFailures = %#v, want %#v", got.PullRequest.RequiredCheckFailures, want)
 	}
 }
 

--- a/internal/connector/github/pull_request_checks.go
+++ b/internal/connector/github/pull_request_checks.go
@@ -29,7 +29,8 @@ func (c *Connector) fetchPullRequestCI(ctx context.Context, repo pullRequestRepo
 	if err != nil {
 		return pullRequestCI{}, fmt.Errorf("fetch github check runs: %w", err)
 	}
-	workflowRuns, workflowRunErr := fetchRESTWorkflowRunsForCheckRuns(ctx, c.client, repo, checkRuns)
+	effectiveRuns := effectiveCheckRuns(checkRuns)
+	workflowRuns, workflowRunErr := fetchRESTWorkflowRunsForCheckRuns(ctx, c.client, repo, effectiveRuns)
 	if workflowRunErr != nil {
 		workflowRuns = nil
 	}
@@ -37,7 +38,7 @@ func (c *Connector) fetchPullRequestCI(ctx context.Context, repo pullRequestRepo
 	if err != nil {
 		return pullRequestCI{}, fmt.Errorf("fetch github commit statuses: %w", err)
 	}
-	telemetry := checkRunTelemetry(checkRuns, workflowRuns)
+	telemetry := checkRunTelemetry(effectiveRuns, workflowRuns)
 	staleSuccessfulChecks := staleSuccessfulCheckRuns(checkRuns)
 	c.logStaleSuccessfulCheckRuns(ctx, repo, sha, staleSuccessfulChecks)
 	requiredFailures := requiredStatusCheckFailures(checkRuns, statuses, c.requiredChecks)

--- a/internal/connector/github/pull_request_checks.go
+++ b/internal/connector/github/pull_request_checks.go
@@ -18,6 +18,12 @@ type checkRunTelemetrySummary struct {
 	RunningChecks   []string
 }
 
+type checkRunContextResult struct {
+	Run     restCheckRun
+	Pending bool
+	Settled bool
+}
+
 func (c *Connector) fetchPullRequestCI(ctx context.Context, repo pullRequestRepo, sha string) (pullRequestCI, error) {
 	checkRuns, err := fetchRESTCheckRuns(ctx, c.client, restCommitCheckRunsPath(repo, sha))
 	if err != nil {
@@ -36,7 +42,9 @@ func (c *Connector) fetchPullRequestCI(ctx context.Context, repo pullRequestRepo
 	c.logStaleSuccessfulCheckRuns(ctx, repo, sha, staleSuccessfulChecks)
 	requiredFailures := requiredStatusCheckFailures(checkRuns, statuses, c.requiredChecks)
 	state := combinedCIState(checkRunsState(checkRuns), commitStatusesState(statuses))
-	if requiredState := requiredStatusCheckState(requiredFailures); requiredState != "" {
+	if requiredState := requiredStatusCheckState(requiredFailures); requiredState == "pending" {
+		state = requiredState
+	} else if requiredState != "" {
 		state = combinedCIState(requiredState, state)
 	}
 	return pullRequestCI{
@@ -55,7 +63,7 @@ func (c *Connector) fetchPullRequestCI(ctx context.Context, repo pullRequestRepo
 
 func (c *Connector) transientCheckRunFailures(ctx context.Context, repo pullRequestRepo, checkRuns []restCheckRun) []connector.PullRequestCheck {
 	failures := make([]connector.PullRequestCheck, 0)
-	for _, checkRun := range checkRuns {
+	for _, checkRun := range effectiveCheckRuns(checkRuns) {
 		if !completedFailedCheckRun(checkRun) {
 			continue
 		}
@@ -103,7 +111,7 @@ func completedFailedCheckRun(checkRun restCheckRun) bool {
 		return false
 	}
 	switch strings.ToLower(strings.TrimSpace(checkRun.Conclusion)) {
-	case "", "success", "skipped", "neutral":
+	case "", "success", "skipped", "neutral", "cancelled", "canceled":
 		return false
 	default:
 		return true
@@ -212,23 +220,27 @@ func checkRunsState(checkRuns []restCheckRun) string {
 		return ""
 	}
 	pending := false
-	for _, checkRun := range checkRuns {
-		status := normalizedCheckRunStatus(checkRun)
-		conclusion := strings.ToLower(strings.TrimSpace(checkRun.Conclusion))
-		if status != "" && status != "completed" {
+	failed := false
+	for _, group := range groupedCheckRuns(checkRuns) {
+		result := selectCheckRunContext(group)
+		if result.Pending || !result.Settled {
 			pending = true
 			continue
 		}
+		conclusion := strings.ToLower(strings.TrimSpace(result.Run.Conclusion))
 		switch conclusion {
-		case "success", "skipped", "neutral":
+		case "success", "neutral":
 		case "":
 			pending = true
 		default:
-			return "failure"
+			failed = true
 		}
 	}
 	if pending {
 		return "pending"
+	}
+	if failed {
+		return "failure"
 	}
 	return "success"
 }
@@ -239,22 +251,20 @@ func requiredStatusCheckFailures(checkRuns []restCheckRun, statuses []restCommit
 		return nil
 	}
 
-	checkRunsByName := make(map[string]restCheckRun, len(checkRuns))
-	for _, checkRun := range checkRuns {
-		name := strings.TrimSpace(checkRun.Name)
+	checkRunsByName := make(map[string]checkRunContextResult, len(checkRuns))
+	for _, group := range groupedCheckRuns(checkRuns) {
+		name := strings.TrimSpace(group[0].Name)
 		if name == "" {
 			continue
 		}
-		if _, ok := checkRunsByName[name]; !ok {
-			checkRunsByName[name] = checkRun
-		}
+		checkRunsByName[name] = selectCheckRunContext(group)
 	}
 	statusesByContext := latestCommitStatusesByContext(statuses)
 
 	failures := make([]connector.PullRequestCheck, 0, len(required))
 	for _, name := range required {
-		if checkRun, ok := checkRunsByName[name]; ok {
-			if failure, failed := requiredCheckRunFailure(name, checkRun); failed {
+		if result, ok := checkRunsByName[name]; ok && (result.Pending || result.Settled) {
+			if failure, failed := requiredCheckRunFailure(name, result.Run); failed {
 				failures = append(failures, failure)
 			}
 			continue
@@ -263,6 +273,13 @@ func requiredStatusCheckFailures(checkRuns []restCheckRun, statuses []restCommit
 			if failure, failed := requiredCommitStatusFailure(name, status); failed {
 				failures = append(failures, failure)
 			}
+			continue
+		}
+		if _, ok := checkRunsByName[name]; ok {
+			failures = append(failures, connector.PullRequestCheck{
+				Name:   name,
+				Status: "pending",
+			})
 			continue
 		}
 		failures = append(failures, connector.PullRequestCheck{
@@ -280,6 +297,9 @@ func requiredStatusCheckFailures(checkRuns []restCheckRun, statuses []restCommit
 func requiredCheckRunFailure(name string, checkRun restCheckRun) (connector.PullRequestCheck, bool) {
 	status := normalizedCheckRunStatus(checkRun)
 	conclusion := strings.ToLower(strings.TrimSpace(checkRun.Conclusion))
+	if ignoredCheckRunConclusion(conclusion) {
+		return connector.PullRequestCheck{}, false
+	}
 	if status != "" && status != "completed" {
 		return connector.PullRequestCheck{
 			ID:            checkRun.ID,
@@ -326,6 +346,7 @@ func requiredStatusCheckState(failures []connector.PullRequestCheck) string {
 		return ""
 	}
 	pending := false
+	failed := false
 	for _, failure := range failures {
 		status := strings.ToLower(strings.TrimSpace(failure.Status))
 		conclusion := strings.ToLower(strings.TrimSpace(failure.Conclusion))
@@ -333,11 +354,14 @@ func requiredStatusCheckState(failures []connector.PullRequestCheck) string {
 		case requiredStatusCheckPending(status, conclusion):
 			pending = true
 		default:
-			return "failure"
+			failed = true
 		}
 	}
 	if pending {
 		return "pending"
+	}
+	if failed {
+		return "failure"
 	}
 	return ""
 }
@@ -369,7 +393,7 @@ func checkRunTelemetry(checkRuns []restCheckRun, workflowRuns []restWorkflowRun)
 		queueStartedAt = earliestGitHubTime(queueStartedAt, run.RunStartedAt)
 	}
 
-	for _, checkRun := range checkRuns {
+	for _, checkRun := range effectiveCheckRuns(checkRuns) {
 		queueCreatedAt = earliestGitHubTime(queueCreatedAt, checkRun.CreatedAt)
 		queueStartedAt = earliestGitHubTime(queueStartedAt, checkRun.StartedAt)
 		checkStartedAt = earliestGitHubTime(checkStartedAt, checkRun.StartedAt)
@@ -378,7 +402,7 @@ func checkRunTelemetry(checkRuns []restCheckRun, workflowRuns []restWorkflowRun)
 		name := strings.TrimSpace(checkRun.Name)
 		status := normalizedCheckRunStatus(checkRun)
 		conclusion := strings.ToLower(strings.TrimSpace(checkRun.Conclusion))
-		if status != "completed" || conclusion == "" {
+		if (status != "" && status != "completed") || conclusion == "" {
 			hasRunning = true
 			runningChecks = append(runningChecks, name)
 			continue
@@ -430,6 +454,102 @@ func checkRunTelemetry(checkRuns []restCheckRun, workflowRuns []restWorkflowRun)
 	}
 }
 
+func groupedCheckRuns(checkRuns []restCheckRun) [][]restCheckRun {
+	groups := make([][]restCheckRun, 0, len(checkRuns))
+	groupIndexes := make(map[string]int, len(checkRuns))
+	for _, checkRun := range checkRuns {
+		name := strings.TrimSpace(checkRun.Name)
+		if name == "" {
+			groups = append(groups, []restCheckRun{checkRun})
+			continue
+		}
+		index, ok := groupIndexes[name]
+		if !ok {
+			groupIndexes[name] = len(groups)
+			groups = append(groups, []restCheckRun{checkRun})
+			continue
+		}
+		groups[index] = append(groups[index], checkRun)
+	}
+	return groups
+}
+
+func effectiveCheckRuns(checkRuns []restCheckRun) []restCheckRun {
+	effective := make([]restCheckRun, 0, len(checkRuns))
+	for _, group := range groupedCheckRuns(checkRuns) {
+		result := selectCheckRunContext(group)
+		if result.Pending || result.Settled {
+			effective = append(effective, result.Run)
+		}
+	}
+	return effective
+}
+
+func selectCheckRunContext(checkRuns []restCheckRun) checkRunContextResult {
+	var latestPending restCheckRun
+	var latestSettled restCheckRun
+	hasPending := false
+	hasSettled := false
+	for _, checkRun := range checkRuns {
+		status := normalizedCheckRunStatus(checkRun)
+		conclusion := strings.ToLower(strings.TrimSpace(checkRun.Conclusion))
+		if (status != "" && status != "completed") || conclusion == "" {
+			if !hasPending || restCheckRunAfter(checkRun, latestPending) {
+				latestPending = checkRun
+				hasPending = true
+			}
+			continue
+		}
+		if ignoredCheckRunConclusion(conclusion) {
+			continue
+		}
+		if !hasSettled || restCheckRunAfter(checkRun, latestSettled) {
+			latestSettled = checkRun
+			hasSettled = true
+		}
+	}
+	if hasPending {
+		return checkRunContextResult{Run: latestPending, Pending: true}
+	}
+	if hasSettled {
+		return checkRunContextResult{Run: latestSettled, Settled: true}
+	}
+	return checkRunContextResult{}
+}
+
+func ignoredCheckRunConclusion(conclusion string) bool {
+	switch strings.ToLower(strings.TrimSpace(conclusion)) {
+	case "cancelled", "canceled", "skipped":
+		return true
+	default:
+		return false
+	}
+}
+
+func restCheckRunAfter(left restCheckRun, right restCheckRun) bool {
+	leftAt := checkRunOrderTime(left)
+	rightAt := checkRunOrderTime(right)
+	switch {
+	case leftAt != nil && rightAt != nil && !leftAt.Equal(*rightAt):
+		return leftAt.After(*rightAt)
+	case leftAt != nil && rightAt == nil:
+		return true
+	case leftAt == nil && rightAt != nil:
+		return false
+	default:
+		return left.ID > right.ID
+	}
+}
+
+func checkRunOrderTime(checkRun restCheckRun) *time.Time {
+	for _, at := range []*time.Time{checkRun.CreatedAt, checkRun.StartedAt, checkRun.CompletedAt} {
+		if at != nil {
+			return at
+		}
+	}
+	return nil
+}
+
 func earliestGitHubTime(current *time.Time, candidate *time.Time) *time.Time {
 	if candidate == nil {
 		return current
@@ -458,6 +578,7 @@ func commitStatusesState(statuses []restCommitStatus) string {
 	}
 	latestByContext := latestCommitStatusesByContext(statuses)
 	pending := false
+	failed := false
 	for _, status := range latestByContext {
 		switch strings.ToLower(strings.TrimSpace(status.State)) {
 		case "success":
@@ -466,11 +587,14 @@ func commitStatusesState(statuses []restCommitStatus) string {
 		case "":
 			pending = true
 		default:
-			return "failure"
+			failed = true
 		}
 	}
 	if pending {
 		return "pending"
+	}
+	if failed {
+		return "failure"
 	}
 	return "success"
 }
@@ -521,10 +645,11 @@ func combinedCIState(checkRuns string, statuses string) string {
 	states := []string{checkRuns, statuses}
 	hasSuccess := false
 	hasPending := false
+	hasFailure := false
 	for _, state := range states {
 		switch strings.ToLower(strings.TrimSpace(state)) {
 		case "failure", "failed", "error":
-			return "failure"
+			hasFailure = true
 		case "pending", "expected", "queued", "waiting", "in_progress", "in progress":
 			hasPending = true
 		case "success", "green", "pass", "passed":
@@ -533,6 +658,9 @@ func combinedCIState(checkRuns string, statuses string) string {
 	}
 	if hasPending {
 		return "pending"
+	}
+	if hasFailure {
+		return "failure"
 	}
 	if hasSuccess {
 		return "success"

--- a/internal/orchestrator/autopromote_tick.go
+++ b/internal/orchestrator/autopromote_tick.go
@@ -2336,7 +2336,7 @@ func autoPromoteStaleSuccessfulChecks(pullRequest *connector.PullRequest) []stri
 
 func autoPromoteCheckFailed(check connector.PullRequestCheck) bool {
 	switch strings.ToLower(strings.TrimSpace(check.Conclusion)) {
-	case "failure", "failed", "error", "timed_out", "startup_failure", "action_required", "cancelled", "canceled", "missing", "skipped", "neutral":
+	case "failure", "failed", "error", "timed_out", "startup_failure", "action_required", "missing", "neutral":
 		return true
 	default:
 		return false

--- a/internal/orchestrator/autopromote_tick_test.go
+++ b/internal/orchestrator/autopromote_tick_test.go
@@ -2281,6 +2281,27 @@ func TestTickReconcilesStaleTodoMergedPullRequestWithFailedChecksToRework(t *tes
 	}
 }
 
+func TestAutoPromoteFailedChecksIgnoreCancelledAndSkippedArtifacts(t *testing.T) {
+	t.Parallel()
+
+	pullRequest := &connector.PullRequest{
+		SlowChecks: []connector.PullRequestCheck{
+			{Name: "Cancelled coverage", Conclusion: "cancelled"},
+			{Name: "Skipped label gate", Conclusion: "skipped"},
+			{Name: "Neutral snapshot", Conclusion: "neutral"},
+		},
+		RequiredCheckFailures: []connector.PullRequestCheck{
+			{Name: "Checks", Conclusion: "failure"},
+			{Name: "Canceled spelling", Conclusion: "canceled"},
+		},
+	}
+
+	want := []string{"Neutral snapshot", "Checks"}
+	if got := autoPromoteFailedChecksFromPullRequest(pullRequest); !reflect.DeepEqual(got, want) {
+		t.Fatalf("autoPromoteFailedChecksFromPullRequest() = %#v, want %#v", got, want)
+	}
+}
+
 func TestTickReconcilesStaleTodoHydratesWorkpadBlockerBeforePromotion(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

- wait for queued or in-progress current-head contexts before treating CI as settled red
- evaluate each context from its latest completed non-skipped, non-cancelled check-run
- keep cancelled, skipped, and superseded runs out of required-check, transient-failure, telemetry, and rework evidence

Fixes #1379

## UI Surface Contract

- [x] N/A; this change has no UI surface impact.
- [x] This PR does not add persistent top-of-screen messaging.
- [x] N/A; no operator screen changed.

## Test Plan

- [x] `go test -race ./internal/connector/github ./internal/orchestrator -count=1`
- [x] `make check` (77.2% aggregate coverage; configured package and file floors passed)
