### PR TITLE
fix(orchestrator): auto-unpark cleared breaker parks

### DIFF
--- a/internal/orchestrator/autopromote_tick.go
+++ b/internal/orchestrator/autopromote_tick.go
@@ -2379,6 +2379,7 @@ func (o *Orchestrator) applyAutoPromoteDecision(
 	issueID := strings.TrimSpace(issue.ID)
 	transitionReason := string(decision.Reason)
 	body := autoPromoteComment(summary, decision, displayStateName(issue.State), targetState)
+	metadata := workflowLaneMetadata{}
 	if decision.Action == AutoPromoteActionRework {
 		limit, err := o.autoPromoteReworkLimit(ctx, issue, summary)
 		if err != nil {
@@ -2399,10 +2400,11 @@ func (o *Orchestrator) applyAutoPromoteDecision(
 			targetState = blockedStatusState
 			transitionReason = "rework_limit"
 			body = autoPromoteReworkLimitComment(summary, decision, displayStateName(issue.State), limit)
+			metadata.ReworkBreaker = &workflowLaneReworkBreakerMetadata{Reason: string(decision.Reason)}
 		}
 	}
 
-	if err := o.updateIssueStateByID(ctx, state, issueID, issue, targetState, now, transitionReason); err != nil {
+	if err := o.updateIssueStateByIDWithMetadata(ctx, state, issueID, issue, targetState, now, transitionReason, metadata); err != nil {
 		if o.logger != nil {
 			o.logger.Warn(
 				"auto promote transition failed",

--- a/internal/orchestrator/autopromote_tick_test.go
+++ b/internal/orchestrator/autopromote_tick_test.go
@@ -1517,6 +1517,10 @@ func TestTickAutoUnparksClearedReworkBreaker(t *testing.T) {
 		AutoPromote: AutoPromoteConfig{
 			Enabled:     true,
 			ReworkLimit: 3,
+			Gate: gate.Config{
+				Kind:            gate.KindCommand,
+				AutomatedReview: gate.AutomatedReviewOff,
+			},
 		},
 		ActiveStates:   []string{"Todo", "In Progress", "Rework", "Merging"},
 		TerminalStates: []string{"Done", "Cancelled"},

--- a/internal/orchestrator/autopromote_tick_test.go
+++ b/internal/orchestrator/autopromote_tick_test.go
@@ -1489,6 +1489,94 @@ func TestTickAutoPromoteBlocksRepeatedCINotGreenSignature(t *testing.T) {
 	if blocked.PhaseName != "Blocked" || blocked.Reason != "rework_limit" {
 		t.Fatalf("latest workflow event = %#v, want Blocked rework_limit entry", blocked)
 	}
+	metadata, ok := workflowLaneMetadataFromJSON(blocked.MetadataJSON)
+	if !ok || metadata.ReworkBreaker == nil || metadata.ReworkBreaker.Reason != string(AutoPromoteReasonCINotGreen) {
+		t.Fatalf("blocked metadata = %#v, want ci_not_green rework breaker reason", metadata)
+	}
+}
+
+func TestTickAutoUnparksClearedReworkBreaker(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 7, 16, 21, 0, 0, 0, time.UTC)
+	issue := autoPromoteTickIssue("issue-cleared-rework-breaker", []string{"bug"}, &connector.PullRequest{
+		Number:         1585,
+		URL:            "https://github.test/digitaldrywood/pyroapex/pull/1585",
+		State:          "OPEN",
+		HeadSHA:        "parked-head",
+		MergeableState: "clean",
+		CIStatus:       "success",
+		CheckRunCount:  4,
+	})
+	issue.Identifier = "digitaldrywood/pyroapex#1521"
+	issue.URL = "https://github.test/digitaldrywood/pyroapex/issues/1521"
+	issue.State = "Blocked"
+	cfg := normalizeConfig(Config{
+		PollInterval:        time.Minute,
+		MaxConcurrentAgents: 1,
+		AutoPromote: AutoPromoteConfig{
+			Enabled:     true,
+			ReworkLimit: 3,
+		},
+		ActiveStates:   []string{"Todo", "In Progress", "Rework", "Merging"},
+		TerminalStates: []string{"Done", "Cancelled"},
+	})
+	state := newState(cfg)
+	tracker := &autoPromoteTickConnector{stateIssues: []connector.Issue{issue}}
+	metrics := &autoPromoteWorkflowMetricsRecorder{}
+	prNumber := int64(1585)
+	for _, event := range []store.WorkflowPhaseEvent{
+		{
+			ProjectID:    defaultWorkflowMetricsProjectID,
+			IssueID:      issue.ID,
+			Identifier:   issue.Identifier,
+			IssueURL:     issue.URL,
+			PRNumber:     &prNumber,
+			PhaseType:    store.WorkflowPhaseTypeLane,
+			PhaseName:    autoPromoteReworkState,
+			Reason:       string(AutoPromoteReasonCINotGreen),
+			Status:       "entered",
+			StartedAt:    now.Add(-2 * time.Hour),
+			MetadataJSON: autoPromoteReworkEventMetadata(1585, "parked-head", "Test"),
+		},
+		{
+			ProjectID:    defaultWorkflowMetricsProjectID,
+			IssueID:      issue.ID,
+			Identifier:   issue.Identifier,
+			IssueURL:     issue.URL,
+			PRNumber:     &prNumber,
+			PhaseType:    store.WorkflowPhaseTypeLane,
+			PhaseName:    blockedStatusState,
+			Reason:       "rework_limit",
+			Status:       "entered",
+			StartedAt:    now.Add(-time.Hour),
+			MetadataJSON: autoPromoteReworkEventMetadata(1585, "parked-head", "Test"),
+		},
+	} {
+		if _, err := metrics.RecordWorkflowPhaseEvent(context.Background(), event); err != nil {
+			t.Fatalf("RecordWorkflowPhaseEvent() error = %v", err)
+		}
+	}
+	orch := &Orchestrator{
+		cfg:             cfg,
+		connector:       tracker,
+		workflowMetrics: metrics,
+		logger:          slog.New(slog.NewTextHandler(io.Discard, nil)),
+	}
+
+	orch.tick(context.Background(), &state, now)
+
+	if got, want := tracker.updates, []autoPromoteTickUpdate{{issueID: issue.ID, state: autoPromoteMergingState}}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("updates = %#v, want %#v", got, want)
+	}
+	if len(tracker.comments) != 1 {
+		t.Fatalf("comments = %#v, want one breaker recovery audit comment", tracker.comments)
+	}
+	for _, fragment := range []string{"Auto-unparked", "Blocked to Merging", "ci_not_green", "parked-head"} {
+		if !strings.Contains(tracker.comments[0].body, fragment) {
+			t.Fatalf("comment %q missing fragment %q", tracker.comments[0].body, fragment)
+		}
+	}
 }
 
 func TestTickAutoPromoteResetsReworkLimitAfterHeadSHAChange(t *testing.T) {

--- a/internal/orchestrator/blocked_recovery.go
+++ b/internal/orchestrator/blocked_recovery.go
@@ -11,6 +11,8 @@ import (
 	"github.com/digitaldrywood/detent/internal/telemetry"
 )
 
+const reworkBreakerStageUpdateSkew = time.Second
+
 type BlockedRecoveryAction string
 
 const (
@@ -48,6 +50,15 @@ type BlockedRecoveryDecision struct {
 	Kind        BlockedRecoveryKind
 	TargetState string
 	Detail      string
+}
+
+type reworkBreakerPark struct {
+	Event     store.WorkflowPhaseEvent
+	Reason    AutoPromoteReason
+	PRNumber  int64
+	HeadSHA   string
+	Signature string
+	Timeline  store.WorkflowTimeline
 }
 
 func EvaluateBlockedRecovery(issue connector.Issue) BlockedRecoveryDecision {
@@ -117,9 +128,20 @@ func (o *Orchestrator) recoverBlockedIssues(
 	now time.Time,
 ) map[string]struct{} {
 	transitioned := map[string]struct{}{}
+	autoPromoteCfg := normalizeAutoPromoteConfig(o.cfg.AutoPromote)
 	for _, issue := range issuesInStates(issues, []string{blockedStatusState}) {
 		issueID := strings.TrimSpace(issue.ID)
 		if issueID == "" {
+			continue
+		}
+		if park, ok := o.latestReworkBreakerPark(ctx, issue); autoPromoteCfg.Enabled && ok {
+			if !reworkBreakerAutoUnparkReady(issue, park) || reworkBreakerAutoUnparkConsumed(park.Timeline, park.Signature) {
+				continue
+			}
+			if !o.applyReworkBreakerAutoUnpark(ctx, state, issue, park, autoPromoteCfg.PassState, now) {
+				continue
+			}
+			transitioned[issueID] = struct{}{}
 			continue
 		}
 		if o.issueHasStickyBlockReason(ctx, state, issue) {
@@ -143,6 +165,211 @@ func (o *Orchestrator) recoverBlockedIssues(
 		return nil
 	}
 	return transitioned
+}
+
+func (o *Orchestrator) latestReworkBreakerPark(ctx context.Context, issue connector.Issue) (reworkBreakerPark, bool) {
+	timeline, ok := o.issueWorkflowTimeline(ctx, issue)
+	if !ok {
+		return reworkBreakerPark{}, false
+	}
+	for index := len(timeline.Events) - 1; index >= 0; index-- {
+		event := timeline.Events[index]
+		if event.PhaseType != store.WorkflowPhaseTypeLane || !strings.EqualFold(strings.TrimSpace(event.Status), "entered") {
+			continue
+		}
+		if normalizeState(event.PhaseName) != normalizeState(blockedStatusState) || !strings.EqualFold(strings.TrimSpace(event.Reason), "rework_limit") {
+			return reworkBreakerPark{}, false
+		}
+		metadata, ok := workflowLaneMetadataFromJSON(event.MetadataJSON)
+		if !ok || metadata.PullRequest == nil {
+			return reworkBreakerPark{}, false
+		}
+		reason, ok := reworkBreakerParkReason(timeline.Events, index, metadata)
+		if !ok {
+			return reworkBreakerPark{}, false
+		}
+		prNumber := metadata.PullRequest.Number
+		headSHA := strings.TrimSpace(metadata.PullRequest.HeadSHA)
+		if prNumber <= 0 || headSHA == "" {
+			return reworkBreakerPark{}, false
+		}
+		return reworkBreakerPark{
+			Event:     event,
+			Reason:    reason,
+			PRNumber:  prNumber,
+			HeadSHA:   headSHA,
+			Signature: fmt.Sprintf("pr=%d;head=%s", prNumber, headSHA),
+			Timeline:  timeline,
+		}, true
+	}
+	return reworkBreakerPark{}, false
+}
+
+func reworkBreakerParkReason(
+	events []store.WorkflowPhaseEvent,
+	parkIndex int,
+	parkMetadata workflowLaneMetadata,
+) (AutoPromoteReason, bool) {
+	if parkMetadata.ReworkBreaker != nil {
+		reason := AutoPromoteReason(strings.TrimSpace(parkMetadata.ReworkBreaker.Reason))
+		return reason, reworkBreakerReasonEligible(reason)
+	}
+	for index := parkIndex - 1; index >= 0; index-- {
+		event := events[index]
+		if event.PhaseType != store.WorkflowPhaseTypeLane || !strings.EqualFold(strings.TrimSpace(event.Status), "entered") {
+			continue
+		}
+		if normalizeState(event.PhaseName) == normalizeState(blockedStatusState) {
+			return "", false
+		}
+		if normalizeState(event.PhaseName) != normalizeState(autoPromoteReworkState) {
+			continue
+		}
+		reason := AutoPromoteReason(strings.TrimSpace(event.Reason))
+		if !reworkBreakerReasonEligible(reason) {
+			continue
+		}
+		metadata, ok := workflowLaneMetadataFromJSON(event.MetadataJSON)
+		if !ok || !reworkBreakerPullRequestMetadataEqual(metadata.PullRequest, parkMetadata.PullRequest) {
+			continue
+		}
+		return reason, true
+	}
+	return "", false
+}
+
+func reworkBreakerReasonEligible(reason AutoPromoteReason) bool {
+	switch reason {
+	case AutoPromoteReasonCINotGreen, AutoPromoteReasonMergeConflicts:
+		return true
+	default:
+		return false
+	}
+}
+
+func reworkBreakerPullRequestMetadataEqual(left, right *workflowLanePullRequestMetadata) bool {
+	return left != nil && right != nil &&
+		left.Number > 0 && left.Number == right.Number &&
+		strings.TrimSpace(left.HeadSHA) != "" && strings.TrimSpace(left.HeadSHA) == strings.TrimSpace(right.HeadSHA)
+}
+
+func reworkBreakerAutoUnparkReady(issue connector.Issue, park reworkBreakerPark) bool {
+	if normalizeState(issue.State) != normalizeState(blockedStatusState) || issue.Closed || reworkBreakerIssueHeld(issue) {
+		return false
+	}
+	if issue.StageUpdatedAt != nil && issue.StageUpdatedAt.After(park.Event.StartedAt.Add(reworkBreakerStageUpdateSkew)) {
+		return false
+	}
+	pr := issue.PullRequest
+	if pr == nil || pr.Draft || normalizePullRequestState(pr.State) != "open" {
+		return false
+	}
+	if pr.Number != int(park.PRNumber) || strings.TrimSpace(pr.HeadSHA) != park.HeadSHA {
+		return false
+	}
+	if pullRequestHydrationUnavailableReason(pr) != "" || pullRequestHydrationDegradedReason(pr) != "" {
+		return false
+	}
+	return reworkBreakerCIGreen(pr) &&
+		strings.EqualFold(strings.TrimSpace(pr.MergeableState), "clean") &&
+		len(autoPromoteFindingsFromPullRequest(pr)) == 0
+}
+
+func reworkBreakerIssueHeld(issue connector.Issue) bool {
+	issue = issueWithTextDependencyRefs(issue)
+	if len(issue.BlockedBy) > 0 || strings.TrimSpace(issue.BlockerReason) != "" || blockedRecoveryHumanOnly(issue) {
+		return true
+	}
+	signal := issue.WorkpadSignal
+	return signal != nil && (signal.Invalid != nil || strings.TrimSpace(signal.HumanAction) != "" || len(signal.Blockers) > 0 || strings.EqualFold(strings.TrimSpace(signal.Status), "blocked"))
+}
+
+func reworkBreakerCIGreen(pr *connector.PullRequest) bool {
+	if pr == nil || len(pr.RunningChecks) > 0 || len(pr.RequiredCheckFailures) > 0 {
+		return false
+	}
+	switch strings.ToLower(strings.TrimSpace(pr.CIStatus)) {
+	case "pass", "passed", "passing", "success", "successful":
+		return true
+	default:
+		return false
+	}
+}
+
+func reworkBreakerAutoUnparkConsumed(timeline store.WorkflowTimeline, signature string) bool {
+	for _, event := range timeline.Events {
+		metadata, ok := workflowLaneMetadataFromJSON(event.MetadataJSON)
+		if ok && workflowLaneMetadataHasActionSignature(metadata, workflowActionReworkBreakerAutoUnpark, signature) {
+			return true
+		}
+	}
+	return false
+}
+
+func (o *Orchestrator) applyReworkBreakerAutoUnpark(
+	ctx context.Context,
+	state *State,
+	issue connector.Issue,
+	park reworkBreakerPark,
+	targetState string,
+	now time.Time,
+) bool {
+	issueID := strings.TrimSpace(issue.ID)
+	targetState = strings.TrimSpace(targetState)
+	if targetState == "" {
+		targetState = autoPromoteMergingState
+	}
+	metadata := workflowLaneMetadataWithActionSignature(workflowLaneMetadata{}, workflowActionReworkBreakerAutoUnpark, park.Signature)
+	if err := o.updateIssueStateByIDWithMetadata(ctx, state, issueID, issue, targetState, now, "rework_breaker_auto_unpark", metadata); err != nil {
+		if o.logger != nil {
+			o.logger.Warn("rework breaker auto-unpark transition failed", "issue_id", issueID, "identifier", issue.Identifier, "reason", park.Reason, "signature", park.Signature, "error", err)
+		}
+		return false
+	}
+
+	body := reworkBreakerAutoUnparkComment(issue, park, targetState)
+	if err := o.connector.CreateComment(ctx, issueID, body); err != nil && o.logger != nil {
+		o.logger.Warn("rework breaker auto-unpark comment failed", "issue_id", issueID, "identifier", issue.Identifier, "reason", park.Reason, "signature", park.Signature, "error", err)
+	}
+
+	o.clearAutoPromotedIssueDispatchMemory(state, issueID)
+	promoted := promotedIssue(issue, targetState, now)
+	if mergeWorkerIssue(promoted) {
+		o.recordMergeQueueEntered(state, promoted, now, "rework_breaker_auto_unpark")
+	}
+	recordStateEvent(state, telemetry.ActivityEvent{
+		At:      now,
+		Event:   "rework_breaker_auto_unpark",
+		Message: "auto-unparked " + issueLabel(issue) + " from Blocked to " + targetState + ": " + string(park.Reason),
+	})
+	if o.logger != nil {
+		o.logger.Info("rework breaker auto-unpark", "issue_id", issueID, "identifier", issue.Identifier, "reason", park.Reason, "signature", park.Signature, "head_sha", park.HeadSHA)
+	}
+	return true
+}
+
+func reworkBreakerAutoUnparkComment(issue connector.Issue, park reworkBreakerPark, targetState string) string {
+	var b strings.Builder
+	b.WriteString("Auto-unparked this breaker-parked issue from Blocked to ")
+	b.WriteString(strings.TrimSpace(targetState))
+	b.WriteString(" after the original merge-path condition cleared.")
+	b.WriteString("\n\nPark reason: ")
+	b.WriteString(string(park.Reason))
+	b.WriteString(fmt.Sprintf("\nLinked PR: #%d", park.PRNumber))
+	if issue.PullRequest != nil && strings.TrimSpace(issue.PullRequest.URL) != "" {
+		b.WriteString(" ")
+		b.WriteString(strings.TrimSpace(issue.PullRequest.URL))
+	}
+	b.WriteString("\nParked head: ")
+	b.WriteString(park.HeadSHA)
+	if issue.PullRequest != nil {
+		b.WriteString("\nCurrent-head CI: ")
+		b.WriteString(strings.TrimSpace(issue.PullRequest.CIStatus))
+		b.WriteString("\nMergeable state: ")
+		b.WriteString(strings.TrimSpace(issue.PullRequest.MergeableState))
+	}
+	b.WriteString("\n\nThis is the only automatic unpark permitted for this PR head. If the breaker parks it again without a new head, a human must review it.")
+	return b.String()
 }
 
 func (o *Orchestrator) applyBlockedRecovery(

--- a/internal/orchestrator/blocked_recovery.go
+++ b/internal/orchestrator/blocked_recovery.go
@@ -135,7 +135,9 @@ func (o *Orchestrator) recoverBlockedIssues(
 			continue
 		}
 		if park, ok := o.latestReworkBreakerPark(ctx, issue); autoPromoteCfg.Enabled && ok {
-			if !reworkBreakerAutoUnparkReady(issue, park) || reworkBreakerAutoUnparkConsumed(park.Timeline, park.Signature) {
+			if reworkBreakerAutoUnparkConsumed(park.Timeline, park.Signature) ||
+				!reworkBreakerAutoUnparkReady(issue, park) ||
+				!o.reworkBreakerAutoPromoteGateReady(ctx, state, issue, autoPromoteCfg, now) {
 				continue
 			}
 			if !o.applyReworkBreakerAutoUnpark(ctx, state, issue, park, autoPromoteCfg.PassState, now) {
@@ -296,6 +298,29 @@ func reworkBreakerCIGreen(pr *connector.PullRequest) bool {
 	}
 }
 
+func (o *Orchestrator) reworkBreakerAutoPromoteGateReady(
+	ctx context.Context,
+	state *State,
+	issue connector.Issue,
+	cfg AutoPromoteConfig,
+	now time.Time,
+) bool {
+	issueID := strings.TrimSpace(issue.ID)
+	summary := AutoPromoteSummaryFromIssue(issue)
+	summary.CompletedFinalState = autoPromoteCompletedFinalState(state, issueID)
+	summary.AutomatedReviewWaitExpired = autoPromoteReviewWaitExpired(state, issueID, cfg, now)
+	decision := EvaluateAutoPromote(issue, summary, cfg, now)
+	if decision.Reason == AutoPromoteReasonValidatorMissing {
+		validation, _, ok := o.validatorStageResult(ctx, issue)
+		if !ok {
+			return false
+		}
+		summary.Validator = validation
+		decision = EvaluateAutoPromote(issue, summary, cfg, now)
+	}
+	return decision.Action == AutoPromoteActionPromote
+}
+
 func reworkBreakerAutoUnparkConsumed(timeline store.WorkflowTimeline, signature string) bool {
 	for _, event := range timeline.Events {
 		metadata, ok := workflowLaneMetadataFromJSON(event.MetadataJSON)
@@ -320,7 +345,7 @@ func (o *Orchestrator) applyReworkBreakerAutoUnpark(
 		targetState = autoPromoteMergingState
 	}
 	metadata := workflowLaneMetadataWithActionSignature(workflowLaneMetadata{}, workflowActionReworkBreakerAutoUnpark, park.Signature)
-	if err := o.updateIssueStateByIDWithMetadata(ctx, state, issueID, issue, targetState, now, "rework_breaker_auto_unpark", metadata); err != nil {
+	if err := o.updateIssueStateByIDStrictWithMetadata(ctx, state, issueID, issue, targetState, now, "rework_breaker_auto_unpark", metadata); err != nil {
 		if o.logger != nil {
 			o.logger.Warn("rework breaker auto-unpark transition failed", "issue_id", issueID, "identifier", issue.Identifier, "reason", park.Reason, "signature", park.Signature, "error", err)
 		}

--- a/internal/orchestrator/blocked_recovery_test.go
+++ b/internal/orchestrator/blocked_recovery_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/digitaldrywood/detent/internal/connector"
+	"github.com/digitaldrywood/detent/internal/gate"
 	"github.com/digitaldrywood/detent/internal/store"
 )
 
@@ -157,6 +158,8 @@ func TestRecoverBlockedIssuesReworkBreakerGuards(t *testing.T) {
 		manualReblock bool
 		consumed      bool
 		disabled      bool
+		mutateConfig  func(*AutoPromoteConfig)
+		prepare       func(*Orchestrator, connector.Issue)
 		wantUnpark    bool
 	}{
 		{
@@ -212,6 +215,88 @@ func TestRecoverBlockedIssuesReworkBreakerGuards(t *testing.T) {
 			},
 		},
 		{
+			name:   "auto promote optout label",
+			reason: AutoPromoteReasonCINotGreen,
+			mutate: func(issue *connector.Issue) {
+				issue.Labels = append(issue.Labels, "requires-human-review")
+			},
+			mutateConfig: func(cfg *AutoPromoteConfig) {
+				cfg.OptoutLabel = "requires-human-review"
+			},
+		},
+		{
+			name:   "required human approval missing",
+			reason: AutoPromoteReasonCINotGreen,
+			mutateConfig: func(cfg *AutoPromoteConfig) {
+				cfg.Gate = gate.Config{
+					Kind:          gate.KindHumanReview,
+					ApprovalLabel: "human-approved",
+				}
+			},
+		},
+		{
+			name:   "required automated review missing",
+			reason: AutoPromoteReasonCINotGreen,
+			mutateConfig: func(cfg *AutoPromoteConfig) {
+				cfg.Gate = gate.Config{
+					Kind:            gate.KindCommand,
+					AutomatedReview: gate.AutomatedReviewRequired,
+				}
+			},
+		},
+		{
+			name:   "validator result missing",
+			reason: AutoPromoteReasonCINotGreen,
+			mutateConfig: func(cfg *AutoPromoteConfig) {
+				cfg.Gate = gate.Config{
+					Kind:            gate.KindCommand,
+					AutomatedReview: gate.AutomatedReviewOff,
+					Validator:       gate.ValidatorConfig{Enabled: true},
+				}
+			},
+		},
+		{
+			name:   "passing validator result",
+			reason: AutoPromoteReasonCINotGreen,
+			mutateConfig: func(cfg *AutoPromoteConfig) {
+				cfg.Gate = gate.Config{
+					Kind:            gate.KindCommand,
+					AutomatedReview: gate.AutomatedReviewOff,
+					Validator:       gate.ValidatorConfig{Enabled: true},
+				}
+			},
+			prepare: func(orch *Orchestrator, issue connector.Issue) {
+				identity := validatorStageIdentityForIssue(issue)
+				orch.validatorResults = map[string]validatorStageResult{
+					identity.Key: {
+						Result: gate.ValidatorResult{
+							Submitted: true,
+							Verdict:   gate.ValidatorVerdictPass,
+							Score:     1,
+						},
+					},
+				}
+			},
+			wantUnpark: true,
+		},
+		{
+			name:   "artifact status waiting",
+			reason: AutoPromoteReasonCINotGreen,
+			mutate: func(issue *connector.Issue) {
+				issue.Fields[gate.DefaultArtifactStatusField] = "pending"
+			},
+			mutateConfig: func(cfg *AutoPromoteConfig) {
+				cfg.Gate = gate.Config{Kind: gate.KindArtifact}
+			},
+		},
+		{
+			name:   "allowed issue label missing",
+			reason: AutoPromoteReasonCINotGreen,
+			mutateConfig: func(cfg *AutoPromoteConfig) {
+				cfg.AllowedIssueLabels = []string{"approved-for-merge"}
+			},
+		},
+		{
 			name:          "manual reblock supersedes breaker park",
 			reason:        AutoPromoteReasonCINotGreen,
 			manualReblock: true,
@@ -246,6 +331,16 @@ func TestRecoverBlockedIssuesReworkBreakerGuards(t *testing.T) {
 			tracker := &dependencyAutoUnblockConnector{stateIssues: []connector.Issue{issue}}
 			orch := dependencyAutoUnblockOrchestrator(tracker, DependencyAutoUnblockConfig{})
 			orch.cfg.AutoPromote.Enabled = !tt.disabled
+			orch.cfg.AutoPromote.Gate = gate.Config{
+				Kind:            gate.KindCommand,
+				AutomatedReview: gate.AutomatedReviewOff,
+			}
+			if tt.mutateConfig != nil {
+				tt.mutateConfig(&orch.cfg.AutoPromote)
+			}
+			if tt.prepare != nil {
+				tt.prepare(orch, issue)
+			}
 			metrics := &autoPromoteWorkflowMetricsRecorder{}
 			orch.workflowMetrics = metrics
 			recordReworkBreakerPark(t, metrics, parkedIssue, base.Add(-time.Hour), tt.reason)
@@ -278,6 +373,67 @@ func TestRecoverBlockedIssuesReworkBreakerGuards(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestRecoverBlockedIssuesDoesNotRecordRejectedReworkBreakerUnpark(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 7, 16, 21, 0, 0, 0, time.UTC)
+	issue := reworkBreakerRecoveryIssue("issue-rejected-unpark")
+	tracker := &dependencyAutoUnblockConnector{stateIssues: []connector.Issue{issue}}
+	orch := dependencyAutoUnblockOrchestrator(tracker, DependencyAutoUnblockConfig{})
+	orch.connector = reworkBreakerRejectingConnector{dependencyAutoUnblockConnector: tracker}
+	orch.cfg.AutoPromote.Enabled = true
+	orch.cfg.AutoPromote.Gate = gate.Config{
+		Kind:            gate.KindCommand,
+		AutomatedReview: gate.AutomatedReviewOff,
+	}
+	metrics := &autoPromoteWorkflowMetricsRecorder{}
+	orch.workflowMetrics = metrics
+	recordReworkBreakerPark(t, metrics, issue, now.Add(-time.Hour), AutoPromoteReasonCINotGreen)
+	state := newState(orch.cfg)
+
+	transitioned := orch.recoverBlockedIssues(context.Background(), &state, []connector.Issue{issue}, now)
+
+	if got := len(tracker.updates); got != 1 {
+		t.Fatalf("updates = %#v, want one rejected transition attempt", tracker.updates)
+	}
+	if len(tracker.comments) != 0 {
+		t.Fatalf("comments = %#v, want no success audit after rejected transition", tracker.comments)
+	}
+	if _, ok := transitioned[issue.ID]; ok {
+		t.Fatalf("transitioned[%q] present after rejected transition", issue.ID)
+	}
+	if reworkBreakerAutoUnparkConsumed(metricsTimeline(t, metrics, issue), "pr=1585;head=parked-head") {
+		t.Fatal("rejected transition consumed the one-shot auto-unpark")
+	}
+}
+
+type reworkBreakerRejectingConnector struct {
+	*dependencyAutoUnblockConnector
+}
+
+func (c reworkBreakerRejectingConnector) UpdateIssueState(_ context.Context, issueID string, state string) error {
+	c.updates = append(c.updates, dependencyAutoUnblockUpdate{issueID: issueID, state: state})
+	return connector.ErrStateUpdateBlocked
+}
+
+func metricsTimeline(
+	t *testing.T,
+	metrics *autoPromoteWorkflowMetricsRecorder,
+	issue connector.Issue,
+) store.WorkflowTimeline {
+	t.Helper()
+
+	timeline, err := metrics.IssueWorkflowTimeline(context.Background(), store.IssueIdentity{
+		IssueID:    issue.ID,
+		Identifier: issue.Identifier,
+		IssueURL:   issue.URL,
+	})
+	if err != nil {
+		t.Fatalf("IssueWorkflowTimeline() error = %v", err)
+	}
+	return timeline
 }
 
 func reworkBreakerRecoveryIssue(id string) connector.Issue {

--- a/internal/orchestrator/blocked_recovery_test.go
+++ b/internal/orchestrator/blocked_recovery_test.go
@@ -146,6 +146,256 @@ func TestRecoverBlockedIssuesUsesPersistedSignatureGuard(t *testing.T) {
 	}
 }
 
+func TestRecoverBlockedIssuesReworkBreakerGuards(t *testing.T) {
+	t.Parallel()
+
+	base := time.Date(2026, 7, 16, 21, 0, 0, 0, time.UTC)
+	tests := []struct {
+		name          string
+		reason        AutoPromoteReason
+		mutate        func(*connector.Issue)
+		manualReblock bool
+		consumed      bool
+		disabled      bool
+		wantUnpark    bool
+	}{
+		{
+			name:       "same head green and clean",
+			reason:     AutoPromoteReasonCINotGreen,
+			wantUnpark: true,
+		},
+		{
+			name:       "merge conflicts cleared",
+			reason:     AutoPromoteReasonMergeConflicts,
+			wantUnpark: true,
+		},
+		{
+			name:   "changed head",
+			reason: AutoPromoteReasonCINotGreen,
+			mutate: func(issue *connector.Issue) {
+				issue.PullRequest.HeadSHA = "new-head"
+			},
+		},
+		{
+			name:   "ci still red",
+			reason: AutoPromoteReasonCINotGreen,
+			mutate: func(issue *connector.Issue) {
+				issue.PullRequest.CIStatus = "failure"
+			},
+		},
+		{
+			name:   "required check still running",
+			reason: AutoPromoteReasonCINotGreen,
+			mutate: func(issue *connector.Issue) {
+				issue.PullRequest.RunningChecks = []string{"Test"}
+			},
+		},
+		{
+			name:   "merge state is not clean",
+			reason: AutoPromoteReasonMergeConflicts,
+			mutate: func(issue *connector.Issue) {
+				issue.PullRequest.MergeableState = "behind"
+			},
+		},
+		{
+			name:   "explicit human hold",
+			reason: AutoPromoteReasonCINotGreen,
+			mutate: func(issue *connector.Issue) {
+				issue.BlockerReason = "hold until Friday"
+			},
+		},
+		{
+			name:   "new p1 finding",
+			reason: AutoPromoteReasonCINotGreen,
+			mutate: func(issue *connector.Issue) {
+				issue.PullRequest.CodexReviewState = "P1"
+			},
+		},
+		{
+			name:          "manual reblock supersedes breaker park",
+			reason:        AutoPromoteReasonCINotGreen,
+			manualReblock: true,
+		},
+		{
+			name:     "auto promotion disabled",
+			reason:   AutoPromoteReasonCINotGreen,
+			disabled: true,
+		},
+		{
+			name:       "automated review finding is human-gated",
+			reason:     AutoPromoteReasonP1Findings,
+			wantUnpark: false,
+		},
+		{
+			name:       "same head auto-unpark already consumed",
+			reason:     AutoPromoteReasonCINotGreen,
+			consumed:   true,
+			wantUnpark: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			issue := reworkBreakerRecoveryIssue("issue-" + strings.ReplaceAll(tt.name, " ", "-"))
+			parkedIssue := cloneIssue(issue)
+			if tt.mutate != nil {
+				tt.mutate(&issue)
+			}
+			tracker := &dependencyAutoUnblockConnector{stateIssues: []connector.Issue{issue}}
+			orch := dependencyAutoUnblockOrchestrator(tracker, DependencyAutoUnblockConfig{})
+			orch.cfg.AutoPromote.Enabled = !tt.disabled
+			metrics := &autoPromoteWorkflowMetricsRecorder{}
+			orch.workflowMetrics = metrics
+			recordReworkBreakerPark(t, metrics, parkedIssue, base.Add(-time.Hour), tt.reason)
+			if tt.consumed {
+				recordReworkBreakerAutoUnpark(t, metrics, parkedIssue, base.Add(-30*time.Minute))
+				recordReworkBreakerPark(t, metrics, parkedIssue, base.Add(-10*time.Minute), tt.reason)
+			}
+			if tt.manualReblock {
+				recordReworkBreakerManualBlock(t, metrics, parkedIssue, base.Add(-time.Minute))
+			}
+			state := newState(orch.cfg)
+
+			transitioned := orch.recoverBlockedIssues(context.Background(), &state, []connector.Issue{issue}, base)
+
+			if got := len(tracker.updates); got != boolInt(tt.wantUnpark) {
+				t.Fatalf("updates = %#v, want unpark %v", tracker.updates, tt.wantUnpark)
+			}
+			_, didTransition := transitioned[issue.ID]
+			if didTransition != tt.wantUnpark {
+				t.Fatalf("transitioned[%q] = %v, want %v", issue.ID, didTransition, tt.wantUnpark)
+			}
+			if tt.wantUnpark {
+				if tracker.updates[0].state != autoPromoteMergingState {
+					t.Fatalf("update state = %q, want %q", tracker.updates[0].state, autoPromoteMergingState)
+				}
+				if len(tracker.comments) != 1 || !strings.Contains(tracker.comments[0].body, "only automatic unpark permitted") {
+					t.Fatalf("comments = %#v, want one-shot auto-unpark audit", tracker.comments)
+				}
+				assertWorkflowActionSignature(t, metrics, issue, workflowActionReworkBreakerAutoUnpark, "pr=1585;head=parked-head")
+			}
+		})
+	}
+}
+
+func reworkBreakerRecoveryIssue(id string) connector.Issue {
+	issue := dependencyAutoUnblockIssue(id, blockedStatusState)
+	prNumber := 1585
+	issue.PRNumber = &prNumber
+	issue.PullRequest = &connector.PullRequest{
+		Number:         prNumber,
+		State:          "OPEN",
+		URL:            "https://github.test/digitaldrywood/pyroapex/pull/1585",
+		HeadSHA:        "parked-head",
+		MergeableState: "clean",
+		CIStatus:       "success",
+		CheckRunCount:  4,
+	}
+	return issue
+}
+
+func recordReworkBreakerPark(
+	t *testing.T,
+	metrics *autoPromoteWorkflowMetricsRecorder,
+	issue connector.Issue,
+	at time.Time,
+	reason AutoPromoteReason,
+) {
+	t.Helper()
+
+	metadata := workflowLaneMetadata{
+		ReworkBreaker: &workflowLaneReworkBreakerMetadata{Reason: string(reason)},
+	}
+	for _, event := range []store.WorkflowPhaseEvent{
+		{
+			ProjectID:    defaultWorkflowMetricsProjectID,
+			IssueID:      issue.ID,
+			Identifier:   issue.Identifier,
+			IssueURL:     issue.URL,
+			PhaseType:    store.WorkflowPhaseTypeLane,
+			PhaseName:    autoPromoteReworkState,
+			Reason:       string(reason),
+			Status:       "entered",
+			StartedAt:    at.Add(-time.Minute),
+			MetadataJSON: workflowLaneMetadataJSON(issue, workflowLaneMetadata{}),
+		},
+		{
+			ProjectID:    defaultWorkflowMetricsProjectID,
+			IssueID:      issue.ID,
+			Identifier:   issue.Identifier,
+			IssueURL:     issue.URL,
+			PhaseType:    store.WorkflowPhaseTypeLane,
+			PhaseName:    blockedStatusState,
+			Reason:       "rework_limit",
+			Status:       "entered",
+			StartedAt:    at,
+			MetadataJSON: workflowLaneMetadataJSON(issue, metadata),
+		},
+	} {
+		if _, err := metrics.RecordWorkflowPhaseEvent(context.Background(), event); err != nil {
+			t.Fatalf("RecordWorkflowPhaseEvent() error = %v", err)
+		}
+	}
+}
+
+func recordReworkBreakerAutoUnpark(
+	t *testing.T,
+	metrics *autoPromoteWorkflowMetricsRecorder,
+	issue connector.Issue,
+	at time.Time,
+) {
+	t.Helper()
+
+	metadata := workflowLaneMetadataWithActionSignature(workflowLaneMetadata{}, workflowActionReworkBreakerAutoUnpark, "pr=1585;head=parked-head")
+	if _, err := metrics.RecordWorkflowPhaseEvent(context.Background(), store.WorkflowPhaseEvent{
+		ProjectID:    defaultWorkflowMetricsProjectID,
+		IssueID:      issue.ID,
+		Identifier:   issue.Identifier,
+		IssueURL:     issue.URL,
+		PhaseType:    store.WorkflowPhaseTypeLane,
+		PhaseName:    autoPromoteMergingState,
+		Reason:       "rework_breaker_auto_unpark",
+		Status:       "entered",
+		StartedAt:    at,
+		MetadataJSON: workflowLaneMetadataJSON(issue, metadata),
+	}); err != nil {
+		t.Fatalf("RecordWorkflowPhaseEvent() error = %v", err)
+	}
+}
+
+func recordReworkBreakerManualBlock(
+	t *testing.T,
+	metrics *autoPromoteWorkflowMetricsRecorder,
+	issue connector.Issue,
+	at time.Time,
+) {
+	t.Helper()
+
+	if _, err := metrics.RecordWorkflowPhaseEvent(context.Background(), store.WorkflowPhaseEvent{
+		ProjectID:    defaultWorkflowMetricsProjectID,
+		IssueID:      issue.ID,
+		Identifier:   issue.Identifier,
+		IssueURL:     issue.URL,
+		PhaseType:    store.WorkflowPhaseTypeLane,
+		PhaseName:    blockedStatusState,
+		Reason:       "tracker_state_observed",
+		Status:       "entered",
+		StartedAt:    at,
+		MetadataJSON: workflowLaneMetadataJSON(issue, workflowLaneMetadata{}),
+	}); err != nil {
+		t.Fatalf("RecordWorkflowPhaseEvent() error = %v", err)
+	}
+}
+
+func boolInt(value bool) int {
+	if value {
+		return 1
+	}
+	return 0
+}
+
 func blockedRecoverySignatureIssue(id string, headSHA string) connector.Issue {
 	issue := dependencyAutoUnblockIssue(id, "Blocked")
 	prNumber := 418

--- a/internal/orchestrator/workflow_metrics.go
+++ b/internal/orchestrator/workflow_metrics.go
@@ -17,6 +17,7 @@ const (
 	workflowActionBlockedRecovery          = "blocked_recovery"
 	workflowActionBlockedRecoveryExhausted = "blocked_recovery_exhausted"
 	workflowActionPlanReviewRework         = "plan_review_rework"
+	workflowActionReworkBreakerAutoUnpark  = "rework_breaker_auto_unpark"
 )
 
 type WorkflowMetricsRecorder interface {
@@ -30,6 +31,7 @@ type WorkflowMetricsTimelineReader interface {
 type workflowLaneMetadata struct {
 	PullRequest           *workflowLanePullRequestMetadata           `json:"pull_request,omitempty"`
 	DependencyAutoUnblock *workflowLaneDependencyAutoUnblockMetadata `json:"dependency_auto_unblock,omitempty"`
+	ReworkBreaker         *workflowLaneReworkBreakerMetadata         `json:"rework_breaker,omitempty"`
 	ActionSignatures      []workflowLaneActionSignatureMetadata      `json:"action_signatures,omitempty"`
 }
 
@@ -42,6 +44,10 @@ type workflowLanePullRequestMetadata struct {
 type workflowLaneDependencyAutoUnblockMetadata struct {
 	BlockerSet string   `json:"blocker_set,omitempty"`
 	Blockers   []string `json:"blockers,omitempty"`
+}
+
+type workflowLaneReworkBreakerMetadata struct {
+	Reason string `json:"reason,omitempty"`
 }
 
 type workflowLaneActionSignatureMetadata struct {
@@ -584,7 +590,7 @@ func workflowLaneMetadataJSON(issue connector.Issue, metadata workflowLaneMetada
 	if metadata.PullRequest == nil {
 		metadata.PullRequest = workflowLanePullRequestMetadataFromIssue(issue)
 	}
-	if metadata.PullRequest == nil && metadata.DependencyAutoUnblock == nil && len(metadata.ActionSignatures) == 0 {
+	if metadata.PullRequest == nil && metadata.DependencyAutoUnblock == nil && metadata.ReworkBreaker == nil && len(metadata.ActionSignatures) == 0 {
 		return "{}"
 	}
 	data, err := json.Marshal(metadata)


### PR DESCRIPTION
## Summary

- persist the triggering reason when the rework breaker parks an issue
- re-evaluate eligible same-head CI and merge-conflict parks during Blocked polling
- require green/clean current PR state and a fresh configured promotion-gate decision
- persist a one-shot recovery signature only after a strict tracker transition succeeds

Fixes #1378

## UI Surface Contract

- [x] N/A; this PR changes orchestrator state reconciliation only.
- [x] This PR does not add persistent top-of-screen messaging.
- [x] N/A; this PR has no visual changes.

## Test Plan

- [x] `go test ./internal/orchestrator -run "TestRecoverBlockedIssues|TestTickAutoUnparksClearedReworkBreaker" -count=1`
- [x] `go test ./internal/orchestrator -count=1`
- [x] `make check` (77.3% repository coverage; 85.0% orchestrator coverage)
- [x] current-head GitHub CI: 10/10 checks passed