### PR TITLE
fix(github): settle latest check runs

### DIFF
--- a/internal/connector/github/adapter_test.go
+++ b/internal/connector/github/adapter_test.go
@@ -2704,6 +2704,17 @@ func TestRequiredStatusCheckFailures(t *testing.T) {
 			}},
 		},
 		{
+			name:      "skipped required check overrides successful legacy status",
+			checkRuns: []restCheckRun{{Name: "Windows Core", Status: "completed", Conclusion: "skipped"}},
+			statuses:  []restCommitStatus{{Context: "Windows Core", State: "success"}},
+			required:  []string{"Windows Core"},
+			wantState: "pending",
+			wantChecks: []connector.PullRequestCheck{{
+				Name:   "Windows Core",
+				Status: "pending",
+			}},
+		},
+		{
 			name: "pending required check wins over settled failure",
 			checkRuns: []restCheckRun{
 				{Name: "Checks", Status: "completed", Conclusion: "failure"},

--- a/internal/connector/github/adapter_test.go
+++ b/internal/connector/github/adapter_test.go
@@ -2464,6 +2464,22 @@ func TestCheckRunsStateUsesSettledContextResults(t *testing.T) {
 			want: "pending",
 		},
 		{
+			name: "newer settled success supersedes pending run",
+			checkRuns: []restCheckRun{
+				{ID: 1, Name: "Checks", Status: "in_progress", StartedAt: &older},
+				{ID: 2, Name: "Checks", Status: "completed", Conclusion: "success", StartedAt: &newer},
+			},
+			want: "success",
+		},
+		{
+			name: "newer settled failure supersedes pending run",
+			checkRuns: []restCheckRun{
+				{ID: 2, Name: "Checks", Status: "completed", Conclusion: "failure", StartedAt: &newer},
+				{ID: 1, Name: "Checks", Status: "queued", StartedAt: &older},
+			},
+			want: "failure",
+		},
+		{
 			name: "pending context keeps a different failure unsettled",
 			checkRuns: []restCheckRun{
 				{Name: "Checks", Status: "completed", Conclusion: "failure"},
@@ -2488,6 +2504,15 @@ func TestCheckRunsStateUsesSettledContextResults(t *testing.T) {
 			want: "success",
 		},
 		{
+			name: "newer success supersedes ignored workflow runs",
+			checkRuns: []restCheckRun{
+				{ID: 1, Name: "Checks", Status: "completed", Conclusion: "cancelled", StartedAt: &older},
+				{ID: 2, Name: "Checks", Status: "completed", Conclusion: "skipped", StartedAt: &older},
+				{ID: 3, Name: "Checks", Status: "completed", Conclusion: "success", StartedAt: &newer},
+			},
+			want: "success",
+		},
+		{
 			name: "newer settled success supersedes failure",
 			checkRuns: []restCheckRun{
 				{ID: 1, Name: "Checks", Status: "completed", Conclusion: "failure", StartedAt: &older},
@@ -2504,12 +2529,12 @@ func TestCheckRunsStateUsesSettledContextResults(t *testing.T) {
 			want: "failure",
 		},
 		{
-			name: "only ignored conclusions remain pending",
+			name: "only ignored conclusions are non-blocking",
 			checkRuns: []restCheckRun{
 				{Name: "Checks", Status: "completed", Conclusion: "cancelled"},
 				{Name: "Test", Status: "completed", Conclusion: "skipped"},
 			},
-			want: "pending",
+			want: "success",
 		},
 	}
 
@@ -2692,10 +2717,23 @@ func TestRequiredStatusCheckFailures(t *testing.T) {
 			},
 		},
 		{
-			name: "cancelled and skipped shadows do not replace settled success",
+			name: "latest skipped required run blocks despite older success",
 			checkRuns: []restCheckRun{
-				{ID: 5, Name: "Checks", Status: "completed", Conclusion: "cancelled"},
-				{ID: 4, Name: "Checks", Status: "completed", Conclusion: "skipped"},
+				{ID: 1, Name: "Checks", Status: "completed", Conclusion: "success"},
+				{ID: 2, Name: "Checks", Status: "completed", Conclusion: "skipped"},
+			},
+			required:  []string{"Checks"},
+			wantState: "pending",
+			wantChecks: []connector.PullRequestCheck{{
+				Name:   "Checks",
+				Status: "pending",
+			}},
+		},
+		{
+			name: "latest success replaces older ignored required runs",
+			checkRuns: []restCheckRun{
+				{ID: 1, Name: "Checks", Status: "completed", Conclusion: "cancelled"},
+				{ID: 2, Name: "Checks", Status: "completed", Conclusion: "skipped"},
 				{ID: 3, Name: "Checks", Status: "completed", Conclusion: "success"},
 			},
 			required: []string{"Checks"},
@@ -4531,6 +4569,58 @@ func TestConnectorHydratePullRequestUsesEffectiveCheckRunsForWorkflowTelemetry(t
 		if request["path"] == "/repos/example/repo/actions/runs/7001" {
 			t.Fatalf("request path = %q, want superseded workflow run excluded", request["path"])
 		}
+	}
+}
+
+func TestConnectorHydratePullRequestIgnoresOptionalSkippedCheckRun(t *testing.T) {
+	t.Parallel()
+
+	server := newGraphQLTestServer(t, []graphqlTestResponse{
+		{
+			method: http.MethodGet,
+			path:   "/repos/example/pyroapex/pulls/1648",
+			body:   `{"number":1648,"html_url":"https://github.com/example/pyroapex/pull/1648","state":"open","mergeable_state":"clean","draft":false,"head":{"ref":"detent/1647","sha":"head-sha"},"base":{"sha":"base-sha"}}`,
+		},
+		{
+			method: http.MethodGet,
+			path:   "/repos/example/pyroapex/commits/head-sha/check-runs?per_page=100",
+			body:   `{"check_runs":[{"id":1,"name":"Checks","status":"completed","conclusion":"success"},{"id":2,"name":"Changed-file coverage","status":"completed","conclusion":"success"},{"id":3,"name":"Race Tests","status":"completed","conclusion":"skipped"}]}`,
+		},
+		{
+			method: http.MethodGet,
+			path:   "/repos/example/pyroapex/commits/head-sha/statuses?per_page=100",
+			body:   `[]`,
+		},
+		{
+			method: http.MethodGet,
+			path:   "/repos/example/pyroapex/pulls/1648/reviews?per_page=100",
+			body:   `[]`,
+		},
+	})
+	c := newGitHubTestConnector(t, server, Config{})
+	prNumber := 1648
+	issue := connector.Issue{
+		ID:           "I_kw1647",
+		Identifier:   "example/pyroapex#1647",
+		PRNumber:     &prNumber,
+		PRRepository: "example/pyroapex",
+	}
+
+	got, err := c.HydratePullRequest(context.Background(), issue)
+	if err != nil {
+		t.Fatalf("HydratePullRequest() error = %v", err)
+	}
+
+	pr := got.PullRequest
+	if pr == nil {
+		t.Fatal("PullRequest = nil, want hydrated pull request")
+		return
+	}
+	if pr.MergeableState != "clean" || pr.CIStatus != "pass" {
+		t.Fatalf("PullRequest = %#v, want clean with passing CI", pr)
+	}
+	if len(pr.RunningChecks) != 0 {
+		t.Fatalf("RunningChecks = %#v, want none", pr.RunningChecks)
 	}
 }
 

--- a/internal/connector/github/pull_request_checks.go
+++ b/internal/connector/github/pull_request_checks.go
@@ -224,8 +224,11 @@ func checkRunsState(checkRuns []restCheckRun) string {
 	failed := false
 	for _, group := range groupedCheckRuns(checkRuns) {
 		result := selectCheckRunContext(group)
-		if result.Pending || !result.Settled {
+		if result.Pending {
 			pending = true
+			continue
+		}
+		if !result.Settled {
 			continue
 		}
 		conclusion := strings.ToLower(strings.TrimSpace(result.Run.Conclusion))
@@ -487,35 +490,24 @@ func effectiveCheckRuns(checkRuns []restCheckRun) []restCheckRun {
 }
 
 func selectCheckRunContext(checkRuns []restCheckRun) checkRunContextResult {
-	var latestPending restCheckRun
-	var latestSettled restCheckRun
-	hasPending := false
-	hasSettled := false
-	for _, checkRun := range checkRuns {
-		status := normalizedCheckRunStatus(checkRun)
-		conclusion := strings.ToLower(strings.TrimSpace(checkRun.Conclusion))
-		if (status != "" && status != "completed") || conclusion == "" {
-			if !hasPending || restCheckRunAfter(checkRun, latestPending) {
-				latestPending = checkRun
-				hasPending = true
-			}
-			continue
-		}
-		if ignoredCheckRunConclusion(conclusion) {
-			continue
-		}
-		if !hasSettled || restCheckRunAfter(checkRun, latestSettled) {
-			latestSettled = checkRun
-			hasSettled = true
+	if len(checkRuns) == 0 {
+		return checkRunContextResult{}
+	}
+	latest := checkRuns[0]
+	for _, checkRun := range checkRuns[1:] {
+		if restCheckRunAfter(checkRun, latest) {
+			latest = checkRun
 		}
 	}
-	if hasPending {
-		return checkRunContextResult{Run: latestPending, Pending: true}
+	status := normalizedCheckRunStatus(latest)
+	conclusion := strings.ToLower(strings.TrimSpace(latest.Conclusion))
+	if (status != "" && status != "completed") || conclusion == "" {
+		return checkRunContextResult{Run: latest, Pending: true}
 	}
-	if hasSettled {
-		return checkRunContextResult{Run: latestSettled, Settled: true}
+	if ignoredCheckRunConclusion(conclusion) {
+		return checkRunContextResult{}
 	}
-	return checkRunContextResult{}
+	return checkRunContextResult{Run: latest, Settled: true}
 }
 
 func ignoredCheckRunConclusion(conclusion string) bool {

--- a/internal/connector/github/pull_request_checks.go
+++ b/internal/connector/github/pull_request_checks.go
@@ -267,23 +267,23 @@ func requiredStatusCheckFailures(checkRuns []restCheckRun, statuses []restCommit
 
 	failures := make([]connector.PullRequestCheck, 0, len(required))
 	for _, name := range required {
-		if result, ok := checkRunsByName[name]; ok && (result.Pending || result.Settled) {
-			if failure, failed := requiredCheckRunFailure(name, result.Run); failed {
-				failures = append(failures, failure)
+		if result, ok := checkRunsByName[name]; ok {
+			if result.Pending || result.Settled {
+				if failure, failed := requiredCheckRunFailure(name, result.Run); failed {
+					failures = append(failures, failure)
+				}
+				continue
 			}
+			failures = append(failures, connector.PullRequestCheck{
+				Name:   name,
+				Status: "pending",
+			})
 			continue
 		}
 		if status, ok := statusesByContext[name]; ok {
 			if failure, failed := requiredCommitStatusFailure(name, status); failed {
 				failures = append(failures, failure)
 			}
-			continue
-		}
-		if _, ok := checkRunsByName[name]; ok {
-			failures = append(failures, connector.PullRequestCheck{
-				Name:   name,
-				Status: "pending",
-			})
 			continue
 		}
 		failures = append(failures, connector.PullRequestCheck{

--- a/internal/orchestrator/autopromote_tick.go
+++ b/internal/orchestrator/autopromote_tick.go
@@ -2321,6 +2321,34 @@ func autoPromoteFailedChecksFromPullRequest(pullRequest *connector.PullRequest) 
 	return uniqueStrings(checks)
 }
 
+func autoPromotePendingChecksFromPullRequest(pullRequest *connector.PullRequest) []string {
+	if pullRequest == nil {
+		return nil
+	}
+	checks := append([]string(nil), pullRequest.RunningChecks...)
+	for _, check := range pullRequest.RequiredCheckFailures {
+		if !autoPromoteCheckPending(check) {
+			continue
+		}
+		checks = append(checks, check.Name)
+	}
+	return uniqueStrings(checks)
+}
+
+func autoPromoteCheckPending(check connector.PullRequestCheck) bool {
+	status := strings.ToLower(strings.TrimSpace(check.Status))
+	conclusion := strings.ToLower(strings.TrimSpace(check.Conclusion))
+	if conclusion == "missing" {
+		return true
+	}
+	switch status {
+	case "missing", "pending", "queued", "waiting", "in_progress", "in progress", "requested", "expected":
+		return true
+	default:
+		return false
+	}
+}
+
 func autoPromoteStaleSuccessfulChecks(pullRequest *connector.PullRequest) []string {
 	if pullRequest == nil {
 		return nil
@@ -2667,6 +2695,9 @@ func (o *Orchestrator) logAutoPromoteDecision(issue connector.Issue, decision Au
 		}
 		if failedChecks := strings.Join(autoPromoteFailedChecksFromPullRequest(issue.PullRequest), ", "); failedChecks != "" {
 			attrs = append(attrs, "failed_checks", failedChecks)
+		}
+		if pendingChecks := strings.Join(autoPromotePendingChecksFromPullRequest(issue.PullRequest), ", "); pendingChecks != "" {
+			attrs = append(attrs, "pending_checks", pendingChecks)
 		}
 		if staleSuccessfulChecks := strings.Join(autoPromoteStaleSuccessfulChecks(issue.PullRequest), ", "); staleSuccessfulChecks != "" {
 			attrs = append(attrs,

--- a/internal/orchestrator/autopromote_tick_test.go
+++ b/internal/orchestrator/autopromote_tick_test.go
@@ -2096,6 +2096,33 @@ func TestLogAutoPromoteDecisionIncludesHydrationReasons(t *testing.T) {
 	}
 }
 
+func TestLogAutoPromoteDecisionNamesPendingChecks(t *testing.T) {
+	t.Parallel()
+
+	var logs strings.Builder
+	orch := &Orchestrator{
+		logger: slog.New(slog.NewTextHandler(&logs, &slog.HandlerOptions{Level: slog.LevelInfo})),
+	}
+	issue := autoPromoteTickIssue("issue-pending-ci-log", []string{"bug"}, &connector.PullRequest{
+		Number:        1648,
+		CIStatus:      "pending",
+		RunningChecks: []string{"Checks"},
+		RequiredCheckFailures: []connector.PullRequestCheck{{
+			Name:   "Race Tests",
+			Status: "pending",
+		}},
+	})
+	orch.logAutoPromoteDecision(issue, AutoPromoteDecision{
+		Action:   AutoPromoteActionSkip,
+		Reason:   AutoPromoteReasonCINotGreen,
+		CIStatus: "pending",
+	}, "")
+
+	if !strings.Contains(logs.String(), `pending_checks="Checks, Race Tests"`) {
+		t.Fatalf("logs %q missing pending check names", logs.String())
+	}
+}
+
 func TestTickReconcilesStaleTodoLinkedPullRequests(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

- Select the newest same-name check run across pending, settled, skipped, and cancelled outcomes.
- Keep optional skipped or cancelled jobs non-blocking while preserving pending policy for configured required checks.
- Name running and pending required checks in auto-promote diagnostics.

Fixes #1386

## UI Surface Contract

- [x] N/A, or the linked issue explicitly authorizes any high-impact UI surface, layout, density, first-viewport, or responsive visibility tradeoff.
- [x] Persistent top-of-screen messaging is explicitly authorized by the issue, or this PR does not add it.
- [x] Visual changes to primary operator screens include screenshot or browser verification below.

## Test Plan

- [x] `make check`
- [x] Connector regression coverage for mixed duplicate runs, optional skipped jobs, and required skipped jobs.
- [x] Auto-promote diagnostic coverage for pending check names.