### PR TITLE
ci(security): add baseline scanning

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
 
       - uses: actions/setup-go@v6
         with:
-          go-version: '1.26.4'
+          go-version: '1.26.5'
           cache: true
 
       - name: Download modules
@@ -37,7 +37,7 @@ jobs:
         uses: actions/cache@v5
         with:
           path: ~/go/bin/golangci-lint
-          key: golangci-lint-${{ runner.os }}-go1.26.4-v2.1.6
+          key: golangci-lint-${{ runner.os }}-go1.26.5-v2.1.6
 
       - name: Install golangci-lint
         if: steps.golangci-lint-cache.outputs.cache-hit != 'true'
@@ -62,7 +62,7 @@ jobs:
 
       - uses: actions/setup-go@v6
         with:
-          go-version: '1.26.4'
+          go-version: '1.26.5'
           cache: true
 
       - name: Download modules
@@ -88,11 +88,25 @@ jobs:
 
       - uses: actions/setup-go@v6
         with:
-          go-version: '1.26.4'
+          go-version: '1.26.5'
           cache: true
 
       - name: Check coverage
         run: make test-cover-packages
+
+  security:
+    name: Security
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: actions/setup-go@v6
+        with:
+          go-version: '1.26.5'
+          cache: true
+
+      - name: Run govulncheck and gosec
+        run: make security
 
   browser-visual:
     name: Browser Visual
@@ -104,7 +118,7 @@ jobs:
 
       - uses: actions/setup-go@v6
         with:
-          go-version: '1.26.4'
+          go-version: '1.26.5'
           cache: true
 
       - name: Detect visual-sensitive changes
@@ -195,7 +209,7 @@ jobs:
 
       - uses: actions/setup-go@v6
         with:
-          go-version: '1.26.4'
+          go-version: '1.26.5'
           cache: true
 
       - name: Download modules
@@ -225,7 +239,7 @@ jobs:
 
       - uses: actions/setup-go@v6
         with:
-          go-version: '1.26.4'
+          go-version: '1.26.5'
           cache: true
 
       - name: Run non-agent core tests
@@ -333,7 +347,7 @@ jobs:
 
       - uses: actions/setup-go@v6
         with:
-          go-version: '1.26.4'
+          go-version: '1.26.5'
           cache: true
 
       - name: Install minisign

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ jobs:
 
       - uses: actions/setup-go@v6
         with:
-          go-version: '1.26.4'
+          go-version: '1.26.5'
           cache: true
 
       - name: Verify tag points at main

--- a/Makefile
+++ b/Makefile
@@ -24,9 +24,18 @@ DATABASE_URL ?= tmp/detent.db
 NILAWAY_VERSION ?= v0.0.0-20260612163715-2d8907f431ca
 NILAWAY ?= go run go.uber.org/nilaway/cmd/nilaway@$(NILAWAY_VERSION)
 NILAWAY_INCLUDE_PKGS ?= github.com/digitaldrywood/detent
+GOVULNCHECK_VERSION ?= v1.6.0
+GOVULNCHECK ?= go run golang.org/x/vuln/cmd/govulncheck@$(GOVULNCHECK_VERSION)
+GOSEC_VERSION ?= v2.28.0
+GOSEC ?= go run github.com/securego/gosec/v2/cmd/gosec@$(GOSEC_VERSION)
+# G115: existing conversions are bounded or intentionally preserve platform/API widths.
+# G301: shared runtime, service, and artifact directories intentionally require traversal access.
+# G304: Detent intentionally reads operator-selected config, workflow, and workspace paths.
+# G306: flagged files are non-secret configs, manifests, screenshots, and generated artifacts.
+GOSEC_EXCLUDES ?= G115,G301,G304,G306
 CHECK_LOCK_WAIT ?= 15m
 
-.PHONY: dev generate css css-watch build test test-race test-cover test-cover-packages soak visual-e2e visual-e2e-update lint vet check check-unlocked modernize-check nilaway-audit release-snapshot sqlc db-migrate setup clean help
+.PHONY: dev generate css css-watch build test test-race test-cover test-cover-packages soak visual-e2e visual-e2e-update lint vet security check check-unlocked modernize-check nilaway-audit release-snapshot sqlc db-migrate setup clean help
 
 dev:
 	@mkdir -p tmp
@@ -107,6 +116,10 @@ lint:
 vet:
 	go vet ./...
 
+security:
+	$(GOVULNCHECK) ./...
+	$(GOSEC) -quiet -exclude-generated -severity=medium -confidence=medium -exclude=$(GOSEC_EXCLUDES) ./...
+
 nilaway-audit:
 	$(NILAWAY) -include-pkgs=$(NILAWAY_INCLUDE_PKGS) ./...
 
@@ -164,6 +177,7 @@ help:
 	@echo "  visual-e2e   Run Playwright visual layout tests"
 	@echo "  visual-e2e-update  Update Playwright visual baselines"
 	@echo "  lint         Run golangci-lint"
+	@echo "  security     Run govulncheck and gosec security scans"
 	@echo "  check        Run the local validation gate, including NilAway"
 	@echo "  modernize-check  Run the Go modernizer diff check"
 	@echo "  nilaway-audit  Run the local NilAway audit"

--- a/README.md
+++ b/README.md
@@ -2768,6 +2768,7 @@ Common development commands:
 make setup
 make dev
 make check
+make security
 make modernize-check
 ```
 
@@ -2780,6 +2781,9 @@ commit SHA and build date, rotates
 `make check` runs the local release gate: build, `golangci-lint`, `go vet`,
 NilAway, race tests, and the 70 percent coverage check. Run `make generate`
 before committing changes to Templ templates, sqlc queries, or Tailwind inputs.
+`make security` runs the pinned `govulncheck` and standalone `gosec` scans used
+by CI. The gosec baseline skips generated files and documents each legacy rule
+excluded in the Makefile; new findings must be fixed or narrowly annotated.
 `make modernize-check` runs the Go modernizer diff check with the repo's
 selected safe analyzer set.
 

--- a/cmd/detent/restart_posix.go
+++ b/cmd/detent/restart_posix.go
@@ -5,5 +5,5 @@ package main
 import "syscall"
 
 func restartProcess(binary string, args []string, env []string) error {
-	return syscall.Exec(binary, args, env)
+	return syscall.Exec(binary, args, env) // #nosec G204,G702 -- binary is the already-running Detent executable and arguments bypass a shell.
 }

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/digitaldrywood/detent
 
 go 1.26
 
-toolchain go1.26.4
+toolchain go1.26.5
 
 require (
 	charm.land/bubbles/v2 v2.1.1

--- a/internal/buildinfo/buildinfo.go
+++ b/internal/buildinfo/buildinfo.go
@@ -175,7 +175,7 @@ func runGit(dir string, args ...string) (string, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), gitTimeout)
 	defer cancel()
 
-	cmd := exec.CommandContext(ctx, "git", args...)
+	cmd := exec.CommandContext(ctx, "git", args...) // #nosec G204 -- arguments are assembled from fixed git subcommands and trusted repository paths.
 	if strings.TrimSpace(dir) != "" {
 		cmd.Dir = dir
 	}

--- a/internal/cli/boot.go
+++ b/internal/cli/boot.go
@@ -326,8 +326,8 @@ func startRunning(ctx context.Context, cfg BootConfig) error {
 	}
 	chatProvider := buildChatProvider(manager.Registry(), logger)
 	go publishSnapshots(runCtx, manager.Registry(), snapshotHub, snapshotSeq, runtimeStore, displayURL, defaultSnapshotInterval, time.Now, updateScheduler)
-	go republishSnapshotsOnProjectEvents(runCtx, events, snapshotHub, logger)
-	go persistBoardSnapshots(runCtx, snapshotHub, boardSnapshotStore, defaultBoardSnapshotInterval, logger)
+	go republishSnapshotsOnProjectEvents(runCtx, events, snapshotHub, logger)                               // #nosec G118 -- runCtx is the service-lifetime context canceled during shutdown.
+	go persistBoardSnapshots(runCtx, snapshotHub, boardSnapshotStore, defaultBoardSnapshotInterval, logger) // #nosec G118 -- runCtx is the service-lifetime context canceled during shutdown.
 	//nolint:contextcheck // Echo middleware receives request contexts at serve time.
 	server, err := web.NewServer(web.Config{
 		Mode:               web.ModeRunning,

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -493,7 +493,7 @@ func defaultOptions() options {
 }
 
 func defaultCommandRunner(ctx context.Context, name string, args ...string) (string, error) {
-	cmd := exec.CommandContext(ctx, name, args...)
+	cmd := exec.CommandContext(ctx, name, args...) // #nosec G204 -- command runners receive internally selected executables and bypass a shell.
 	output, err := cmd.CombinedOutput()
 	if ctx.Err() != nil {
 		return string(output), ctx.Err()

--- a/internal/cli/dev_runtime_capture_browser.go
+++ b/internal/cli/dev_runtime_capture_browser.go
@@ -170,7 +170,7 @@ func demoCaptureBrowserPaths() []string {
 }
 
 func executableDemoCaptureFile(path string) bool {
-	info, err := os.Stat(path)
+	info, err := os.Stat(path) // #nosec G703 -- candidates are assembled from fixed browser locations and environment-provided installation roots.
 	if err != nil {
 		return false
 	}

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -1214,7 +1214,7 @@ func defaultGitWorkTree(ctx context.Context, path string) error {
 	commandCtx, cancel := context.WithTimeout(ctx, doctorCommandTimeout)
 	defer cancel()
 
-	cmd := exec.CommandContext(commandCtx, "git", "-C", path, "rev-parse", "--is-inside-work-tree")
+	cmd := exec.CommandContext(commandCtx, "git", "-C", path, "rev-parse", "--is-inside-work-tree") // #nosec G204 -- the configured path is passed as a fixed git argument without a shell.
 	output, err := cmd.CombinedOutput()
 	if commandCtx.Err() != nil {
 		return commandCtx.Err()

--- a/internal/cli/doctor_workflow_optimization.go
+++ b/internal/cli/doctor_workflow_optimization.go
@@ -2502,7 +2502,7 @@ func writeDoctorWorkflowOptimizationPatches(report doctorWorkflowOptimizationRep
 		if bytes.Equal(raw, updated) {
 			continue
 		}
-		if err := os.WriteFile(path, updated, info.Mode().Perm()); err != nil {
+		if err := os.WriteFile(path, updated, info.Mode().Perm()); err != nil { // #nosec G703 -- path comes from the operator-selected workflow files already read and validated above.
 			return nil, fmt.Errorf("write workflow %s: %w", path, err)
 		}
 		written = append(written, path)

--- a/internal/cli/onboarding.go
+++ b/internal/cli/onboarding.go
@@ -1240,7 +1240,7 @@ func normalizeOnboardingAnswersFile(path string, write bool) (onboardingAnswersN
 		MutationConfirmed:      answers.Values["MUTATION_CONFIRMED"] == "true" && answers.LastNonblank == "MUTATION_CONFIRMED=true",
 	}
 	if write && result.Changed {
-		if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		if err := os.WriteFile(path, []byte(content), 0o600); err != nil { // #nosec G703 -- path is the explicit operator-selected answers file and is restricted to mode 0600.
 			return onboardingAnswersNormalizationResult{}, fmt.Errorf("write onboarding answers %s: %w", path, err)
 		}
 		if err := os.Chmod(path, 0o600); err != nil {

--- a/internal/config/global/config.go
+++ b/internal/config/global/config.go
@@ -285,7 +285,7 @@ func Write(path string, cfg Config, opts ...Option) error {
 		return err
 	}
 
-	raw, err := yaml.Marshal(cfg)
+	raw, err := yaml.Marshal(cfg) // #nosec G117 -- the operator-provided API token must be persisted in the permission-restricted config file.
 	if err != nil {
 		return fmt.Errorf("marshal global config %s: %w", expandedPath, err)
 	}
@@ -1084,7 +1084,7 @@ func projectPathErrors(path string, field string, opts options, expected pathExp
 		return []string{field + ": path does not exist"}
 	}
 
-	info, err := os.Stat(expanded)
+	info, err := os.Stat(expanded) // #nosec G703 -- validation intentionally inspects the operator-configured project path after expansion.
 	if err != nil {
 		return []string{field + ": path does not exist"}
 	}

--- a/internal/connector/github/projects_v2.go
+++ b/internal/connector/github/projects_v2.go
@@ -395,7 +395,7 @@ func (c *Connector) defaultBlankProjectItemStatuses(ctx context.Context, itemIDs
 		return
 	}
 
-	go c.defaultBlankProjectItemStatusesAsync(ctx, itemIDs, statusName)
+	go c.defaultBlankProjectItemStatusesAsync(ctx, itemIDs, statusName) // #nosec G118 -- the worker intentionally detaches cancellation while retaining context values for this must-finish write.
 }
 
 func (c *Connector) defaultBlankProjectItemStatusesAsync(parentCtx context.Context, itemIDs []string, statusName string) {

--- a/internal/connector/local/local.go
+++ b/internal/connector/local/local.go
@@ -981,7 +981,7 @@ where project_id = ?`
 		// Callers such as the orchestrator lowercase configured states while
 		// rows may hold the template's capitalized spellings; compare
 		// case-insensitively so items stay visible either way.
-		query += " and state collate nocase in (" + strings.Join(placeholders, ",") + ")"
+		query += " and state collate nocase in (" + strings.Join(placeholders, ",") + ")" // #nosec G202 -- only generated question-mark placeholders are concatenated; values remain bound parameters.
 	}
 	query += " order by updated_at desc, id asc"
 	if limit > 0 {

--- a/internal/service/service.go
+++ b/internal/service/service.go
@@ -365,7 +365,7 @@ func inspectManual(path string) (Inspection, error) {
 }
 
 func runCommand(ctx context.Context, name string, args ...string) (string, error) {
-	cmd := exec.CommandContext(ctx, name, args...)
+	cmd := exec.CommandContext(ctx, name, args...) // #nosec G204 -- service backends select the command and pass arguments without a shell.
 	output, err := cmd.CombinedOutput()
 	if ctx.Err() != nil {
 		return string(output), ctx.Err()

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -277,11 +277,11 @@ func launchDashboard(ctx context.Context, url string) error {
 func dashboardCommand(ctx context.Context, goos string, url string) (*exec.Cmd, error) {
 	switch goos {
 	case "darwin":
-		return exec.CommandContext(ctx, "open", url), nil
+		return exec.CommandContext(ctx, "open", url), nil // #nosec G204 -- the validated dashboard URL is passed to the platform opener without a shell.
 	case "linux":
-		return exec.CommandContext(ctx, "xdg-open", url), nil
+		return exec.CommandContext(ctx, "xdg-open", url), nil // #nosec G204 -- the validated dashboard URL is passed to the platform opener without a shell.
 	case "windows":
-		return exec.CommandContext(ctx, "rundll32", "url.dll,FileProtocolHandler", url), nil
+		return exec.CommandContext(ctx, "rundll32", "url.dll,FileProtocolHandler", url), nil // #nosec G204 -- the validated dashboard URL is passed to the platform opener without a shell.
 	default:
 		return nil, fmt.Errorf("open dashboard: unsupported operating system %s", goos)
 	}

--- a/internal/update/update.go
+++ b/internal/update/update.go
@@ -1064,7 +1064,7 @@ func runCommand(ctx context.Context, command string, args []string, stdout io.Wr
 }
 
 func verifyBinaryVersion(ctx context.Context, path string) (string, error) {
-	cmd := exec.CommandContext(ctx, path, "version")
+	cmd := exec.CommandContext(ctx, path, "version") // #nosec G204 -- the downloaded binary path is verified before installation and bypasses a shell.
 	output, err := cmd.CombinedOutput()
 	if err != nil {
 		return string(output), fmt.Errorf("verify %s version: %w: %s", path, err, strings.TrimSpace(string(output)))

--- a/internal/update/update.go
+++ b/internal/update/update.go
@@ -1050,11 +1050,11 @@ func escapeBatchValue(value string) string {
 }
 
 func startProcess(command string, args []string) error {
-	return exec.Command(command, args...).Start()
+	return exec.Command(command, args...).Start() // #nosec G204 -- updater commands and arguments are resolved internally and bypass a shell.
 }
 
 func runCommand(ctx context.Context, command string, args []string, stdout io.Writer, stderr io.Writer) error {
-	cmd := exec.CommandContext(ctx, command, args...)
+	cmd := exec.CommandContext(ctx, command, args...) // #nosec G204 -- updater commands and arguments are resolved internally and bypass a shell.
 	cmd.Stdout = outputWriter(stdout)
 	cmd.Stderr = outputWriter(stderr)
 	if err := cmd.Run(); err != nil {
@@ -1073,7 +1073,7 @@ func verifyBinaryVersion(ctx context.Context, path string) (string, error) {
 }
 
 func signBinary(ctx context.Context, path string) error {
-	cmd := exec.CommandContext(ctx, "codesign", "-s", "-", path)
+	cmd := exec.CommandContext(ctx, "codesign", "-s", "-", path) // #nosec G204 -- the downloaded binary path is passed directly to codesign without a shell.
 	output, err := cmd.CombinedOutput()
 	if err != nil {
 		return fmt.Errorf("codesign %s: %w: %s", path, err, strings.TrimSpace(string(output)))
@@ -1085,7 +1085,7 @@ func hasValidCodeSignature(ctx context.Context, path string, verifier CodeSignat
 	if verifier != nil {
 		return verifier(ctx, path)
 	}
-	cmd := exec.CommandContext(ctx, "codesign", "--verify", "--strict", path)
+	cmd := exec.CommandContext(ctx, "codesign", "--verify", "--strict", path) // #nosec G204 -- the downloaded binary path is passed directly to codesign without a shell.
 	output, err := cmd.CombinedOutput()
 	if err == nil {
 		return true, nil

--- a/internal/web/auth.go
+++ b/internal/web/auth.go
@@ -386,7 +386,7 @@ func (s *Server) setUIAPICookie(c echo.Context) {
 	if strings.HasPrefix(c.Request().URL.Path, "/api/") || s.uiAPIToken() == "" {
 		return
 	}
-	c.SetCookie(&http.Cookie{
+	c.SetCookie(&http.Cookie{ // #nosec G124 -- HttpOnly and SameSiteLax are fixed below; Secure follows the request transport.
 		Name:     uiAPICookieName,
 		Value:    s.uiAPIToken(),
 		Path:     "/api/v1/",
@@ -447,7 +447,7 @@ func (s *Server) setAPIKeyDashboardCookie(c echo.Context, token string) {
 	if c == nil || c.Request() == nil || strings.TrimSpace(token) == "" {
 		return
 	}
-	c.SetCookie(&http.Cookie{
+	c.SetCookie(&http.Cookie{ // #nosec G124 -- HttpOnly and SameSiteStrict are fixed below; Secure follows the request transport.
 		Name:     apiKeyDashboardCookieName,
 		Value:    token,
 		Path:     "/api/v1/keys",

--- a/internal/web/chat.go
+++ b/internal/web/chat.go
@@ -148,7 +148,7 @@ func chatSessionID(c echo.Context) (string, error) {
 		return "", err
 	}
 	id := hex.EncodeToString(data)
-	c.SetCookie(&http.Cookie{
+	c.SetCookie(&http.Cookie{ // #nosec G124 -- HttpOnly and SameSiteStrict are fixed below; Secure follows the request transport.
 		Name:     chatSessionCookieName,
 		Value:    id,
 		Path:     "/",

--- a/internal/web/session_auth.go
+++ b/internal/web/session_auth.go
@@ -177,7 +177,7 @@ func (s *Server) renderAuthPage(c echo.Context, status int, state templates.Auth
 }
 
 func (s *Server) setSessionCookie(c echo.Context, token string, expiresAt time.Time) {
-	c.SetCookie(&http.Cookie{
+	c.SetCookie(&http.Cookie{ // #nosec G124 -- all cookie security attributes are set below; Secure follows the configured HTTP/TLS mode.
 		Name:     webSessionCookieName,
 		Value:    token,
 		Path:     "/",
@@ -189,7 +189,7 @@ func (s *Server) setSessionCookie(c echo.Context, token string, expiresAt time.T
 }
 
 func (s *Server) clearSessionCookie(c echo.Context) {
-	c.SetCookie(&http.Cookie{
+	c.SetCookie(&http.Cookie{ // #nosec G124 -- the clearing cookie mirrors the protected session cookie attributes.
 		Name:     webSessionCookieName,
 		Path:     "/",
 		Expires:  time.Unix(1, 0),

--- a/internal/web/ui/utils/templui.go
+++ b/internal/web/ui/utils/templui.go
@@ -160,7 +160,7 @@ func SetupScriptRoutes(mux *http.ServeMux, isDevelopment bool) {
 			http.NotFound(w, r)
 			return
 		}
-		_, _ = w.Write(file)
+		_, _ = w.Write(file) // #nosec G705 -- bytes come from the compile-time embedded templUI JavaScript filesystem, not request input.
 	})
 
 	mux.Handle("GET /templui/js/", handler)

--- a/internal/workspace/process_unix.go
+++ b/internal/workspace/process_unix.go
@@ -83,7 +83,7 @@ func linuxWorkspaceProcessIDs(path string) ([]int, error) {
 }
 
 func lsofWorkspaceProcessIDs(ctx context.Context, path string) ([]int, error) {
-	cmd := exec.CommandContext(ctx, "lsof", "-t", "+D", path)
+	cmd := exec.CommandContext(ctx, "lsof", "-t", "+D", path) // #nosec G204 -- the workspace path is passed as an lsof argument without a shell.
 	output, err := cmd.Output()
 	if err != nil && len(output) == 0 {
 		var exitErr *exec.ExitError

--- a/internal/workspace/workspace.go
+++ b/internal/workspace/workspace.go
@@ -888,7 +888,7 @@ func makeWorkspaceTreeRemovable(path string) error {
 		default:
 			return nil
 		}
-		if err := os.Chmod(path, mode); err != nil {
+		if err := os.Chmod(path, mode); err != nil { // #nosec G122 -- the path is confined by validateWorkspacePath and symlinks are skipped before chmod.
 			return fmt.Errorf("chmod %s: %w", path, err)
 		}
 		return nil


### PR DESCRIPTION
## Summary

- add a blocking CI Security job backed by a matching `make security` target
- pin govulncheck v1.6.0 and gosec v2.28.0 with documented legacy exclusions and narrow initial finding annotations
- upgrade CI and release builds to Go 1.26.5 to resolve reachable standard-library vulnerabilities found by govulncheck

Fixes #1399

## UI Surface Contract

- [x] N/A, or the linked issue explicitly authorizes any high-impact UI surface, layout, density, first-viewport, or responsive visibility tradeoff.
- [x] Persistent top-of-screen messaging is explicitly authorized by the issue, or this PR does not add it.
- [x] Visual changes to primary operator screens include screenshot or browser verification below. (N/A: no visual changes.)

## Test Plan

- [x] `make security`
- [x] `actionlint`
- [x] `make check`