### PR TITLE
feat(lessons): capture rework and bounce signals

### DIFF
--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -370,6 +370,12 @@ func runDoctor(ctx context.Context, cfg doctorConfig, opts options, deps doctorD
 			})
 		}
 		jobs = append(jobs, doctorCheckJob{
+			Name: "Lessons",
+			Run: func(jobCtx context.Context) []doctorCheck {
+				return checkDoctorLessonCaptures(jobCtx, globalConfig, deps)
+			},
+		})
+		jobs = append(jobs, doctorCheckJob{
 			Name: "Workflow optimization",
 			Run: func(jobCtx context.Context) []doctorCheck {
 				return []doctorCheck{checkDoctorWorkflowOptimization(jobCtx, resolution, globalConfig, deps, githubToken, doctorWorkflowOptimizationOptions{

--- a/internal/cli/doctor_lessons.go
+++ b/internal/cli/doctor_lessons.go
@@ -1,0 +1,57 @@
+package cli
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	globalconfig "github.com/digitaldrywood/detent/internal/config/global"
+	"github.com/digitaldrywood/detent/internal/lessons"
+)
+
+func checkDoctorLessonCaptures(ctx context.Context, cfg globalconfig.Config, deps doctorDeps) []doctorCheck {
+	checks := make([]doctorCheck, 0, len(cfg.Projects))
+	for _, project := range cfg.Projects {
+		projectID := doctorProjectID(project)
+		name := "Lessons [" + projectID + "]"
+		workflow, err := loadDoctorProjectWorkflow(ctx, project, deps)
+		if err != nil {
+			checks = append(checks, doctorLessonCaptureWarning(name, err))
+			continue
+		}
+		path := strings.TrimSpace(workflow.Config.Agent.Lessons.Path)
+		if path == "" {
+			path = lessons.DefaultPath
+		}
+		path, err = resolveDoctorProjectPath(project, path)
+		if err != nil {
+			checks = append(checks, doctorLessonCaptureWarning(name, err))
+			continue
+		}
+		summary, err := lessons.CaptureSummary(path)
+		if err != nil {
+			checks = append(checks, doctorLessonCaptureWarning(name, fmt.Errorf("read %s: %w", path, err)))
+			continue
+		}
+		lastCapture := "never"
+		if summary.LastCapturedAt != nil {
+			lastCapture = summary.LastCapturedAt.UTC().Format(time.RFC3339Nano)
+		}
+		checks = append(checks, doctorCheck{
+			Name:   name,
+			Status: doctorOK,
+			Detail: fmt.Sprintf("%d captured lesson entries; last capture %s", summary.Count, lastCapture),
+		})
+	}
+	return checks
+}
+
+func doctorLessonCaptureWarning(name string, err error) doctorCheck {
+	return doctorCheck{
+		Name:   name,
+		Status: doctorWarn,
+		Detail: fmt.Sprintf("lesson captures could not be read: %v", err),
+		Hint:   "Confirm the project workdir and agent.lessons.path are readable, then rerun detent doctor.",
+	}
+}

--- a/internal/cli/doctor_lessons_test.go
+++ b/internal/cli/doctor_lessons_test.go
@@ -1,0 +1,79 @@
+package cli
+
+import (
+	"context"
+	"errors"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	workflowconfig "github.com/digitaldrywood/detent/internal/config"
+	globalconfig "github.com/digitaldrywood/detent/internal/config/global"
+	"github.com/digitaldrywood/detent/internal/lessons"
+)
+
+func TestCheckDoctorLessonCaptures(t *testing.T) {
+	t.Parallel()
+
+	capturedAt := time.Date(2026, 7, 17, 15, 45, 0, 0, time.UTC)
+	tests := []struct {
+		name       string
+		captures   int
+		loadErr    error
+		wantStatus doctorStatus
+		wantDetail string
+	}{
+		{
+			name:       "no captures",
+			wantStatus: doctorOK,
+			wantDetail: "0 captured lesson entries; last capture never",
+		},
+		{
+			name:       "reports count and latest capture",
+			captures:   2,
+			wantStatus: doctorOK,
+			wantDetail: "2 captured lesson entries; last capture " + capturedAt.Add(time.Minute).Format(time.RFC3339Nano),
+		},
+		{
+			name:       "workflow unavailable",
+			loadErr:    errors.New("workflow unavailable"),
+			wantStatus: doctorWarn,
+			wantDetail: "workflow unavailable",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			workdir := t.TempDir()
+			lessonPath := filepath.Join(workdir, lessons.DefaultPath)
+			for index := range tt.captures {
+				_, err := lessons.AppendUnique(lessonPath, lessons.Entry{
+					IssueRef:    "digitaldrywood/detent#1397",
+					FailureKind: "ci_failure",
+					CaptureKey:  "doctor-test-" + string(rune('a'+index)),
+				}, lessons.AppendOptions{Date: capturedAt.Add(time.Duration(index) * time.Minute)})
+				if err != nil {
+					t.Fatalf("lessons.AppendUnique() error = %v", err)
+				}
+			}
+
+			cfg := workflowconfig.Default()
+			checks := checkDoctorLessonCaptures(context.Background(), globalconfig.Config{
+				Projects: []globalconfig.Project{{ID: "detent", Workdir: workdir, Workflow: filepath.Join(workdir, "WORKFLOW.md")}},
+			}, doctorDeps{
+				loadWorkflow: func(string) (workflowconfig.Workflow, error) {
+					return workflowconfig.Workflow{Config: cfg}, tt.loadErr
+				},
+			})
+			if len(checks) != 1 {
+				t.Fatalf("checkDoctorLessonCaptures() len = %d, want 1", len(checks))
+			}
+			if checks[0].Name != "Lessons [detent]" || checks[0].Status != tt.wantStatus || !strings.Contains(checks[0].Detail, tt.wantDetail) {
+				t.Fatalf("checkDoctorLessonCaptures() = %#v, want status %s detail containing %q", checks[0], tt.wantStatus, tt.wantDetail)
+			}
+		})
+	}
+}

--- a/internal/cli/doctor_workflow_optimization_test.go
+++ b/internal/cli/doctor_workflow_optimization_test.go
@@ -318,6 +318,63 @@ func TestDoctorWorkflowOptimizationProposesGovernedSelfImprovement(t *testing.T)
 	}
 }
 
+func TestDoctorWorkflowImprovementProposalsUsesCapturedLessonThreshold(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name          string
+		captureCount  int
+		wantProposals int
+	}{
+		{name: "below threshold", captureCount: 1},
+		{name: "at threshold", captureCount: 2, wantProposals: 1},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			paths := seedDoctorWorkflowOptimizationFixture(t)
+			for index := range tt.captureCount {
+				appended, err := lessons.AppendUnique(filepath.Join(paths.dir, lessons.DefaultPath), lessons.Entry{
+					IssueRef:    "digitaldrywood/detent#" + strconv.Itoa(1397+index),
+					FailureKind: "ci_failure",
+					CaptureKey:  "automatic-ci-failure-" + strconv.Itoa(index),
+				}, lessons.AppendOptions{Date: time.Date(2026, 7, 17, 15, index, 0, 0, time.UTC)})
+				if err != nil || !appended {
+					t.Fatalf("lessons.AppendUnique() = (%t, %v), want (true, nil)", appended, err)
+				}
+			}
+
+			ctx := context.Background()
+			db, err := openDoctorSQLiteReadOnly(ctx, paths.db)
+			if err != nil {
+				t.Fatalf("openDoctorSQLiteReadOnly() error = %v", err)
+			}
+			t.Cleanup(func() {
+				if err := db.Close(); err != nil {
+					t.Fatalf("Close() error = %v", err)
+				}
+			})
+			workflow, err := workflowconfig.LoadWorkflow(paths.workflow)
+			if err != nil {
+				t.Fatalf("LoadWorkflow() error = %v", err)
+			}
+			project := doctorWorkflowOptimizationGlobal(paths).Projects[0]
+			proposals, err := doctorWorkflowImprovementProposals(ctx, db, project, workflow.Config, nil, 2)
+			if err != nil {
+				t.Fatalf("doctorWorkflowImprovementProposals() error = %v", err)
+			}
+			if len(proposals) != tt.wantProposals {
+				t.Fatalf("doctorWorkflowImprovementProposals() len = %d, want %d: %#v", len(proposals), tt.wantProposals, proposals)
+			}
+			if tt.wantProposals > 0 && (proposals[0].SignalKind != "lesson_failure_kind" || proposals[0].Pattern != "ci_failure" || proposals[0].Count != 2) {
+				t.Fatalf("doctorWorkflowImprovementProposals() = %#v, want repeated ci_failure lesson proposal", proposals)
+			}
+		})
+	}
+}
+
 func TestDoctorWorkflowOptimizationCreatesProposalIssuesWithMemoryTracker(t *testing.T) {
 	t.Parallel()
 

--- a/internal/lessons/lessons.go
+++ b/internal/lessons/lessons.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"sort"
 	"strings"
+	"sync"
 	"time"
 )
 
@@ -17,11 +18,13 @@ const (
 type Entry struct {
 	IssueNumber string
 	IssueRef    string
+	PullRequest string
 	Title       string
 	FailureKind string
 	Symptom     string
 	Hypothesis  string
 	Hint        string
+	CaptureKey  string
 }
 
 type AppendOptions struct {
@@ -35,7 +38,66 @@ type FailureKindPattern struct {
 	Examples    []string
 }
 
+type CaptureStats struct {
+	Count          int
+	LastCapturedAt *time.Time
+}
+
+var appendMu sync.Mutex
+
 func Append(path string, entry Entry, opts AppendOptions) error {
+	appendMu.Lock()
+	defer appendMu.Unlock()
+
+	return appendEntry(path, entry, opts)
+}
+
+func AppendUnique(path string, entry Entry, opts AppendOptions) (bool, error) {
+	appendMu.Lock()
+	defer appendMu.Unlock()
+
+	captureKey := strings.TrimSpace(entry.CaptureKey)
+	if captureKey == "" {
+		return false, errors.New("lesson capture key is required")
+	}
+	entries, err := ReadAll(path)
+	if err != nil {
+		return false, err
+	}
+	for _, existing := range entries {
+		if renderedEntryField(existing, "Capture key") == captureKey {
+			return false, nil
+		}
+	}
+	return true, appendEntryTo(path, entry, opts, entries)
+}
+
+func CaptureSummary(path string) (CaptureStats, error) {
+	entries, err := ReadAll(path)
+	if err != nil {
+		return CaptureStats{}, err
+	}
+	stats := CaptureStats{Count: len(entries)}
+	for _, entry := range entries {
+		capturedAt, ok := renderedEntryCapturedAt(entry)
+		if !ok || stats.LastCapturedAt != nil && !capturedAt.After(*stats.LastCapturedAt) {
+			continue
+		}
+		value := capturedAt
+		stats.LastCapturedAt = &value
+	}
+	return stats, nil
+}
+
+func appendEntry(path string, entry Entry, opts AppendOptions) error {
+	entries, err := ReadAll(path)
+	if err != nil {
+		return err
+	}
+	return appendEntryTo(path, entry, opts, entries)
+}
+
+func appendEntryTo(path string, entry Entry, opts AppendOptions, entries []string) error {
 	maxEntries := opts.MaxEntries
 	if maxEntries <= 0 {
 		maxEntries = DefaultMaxEntries
@@ -44,11 +106,6 @@ func Append(path string, entry Entry, opts AppendOptions) error {
 	date := opts.Date
 	if date.IsZero() {
 		date = time.Now().UTC()
-	}
-
-	entries, err := ReadAll(path)
-	if err != nil {
-		return err
 	}
 
 	rendered := renderEntry(entry, date)
@@ -144,10 +201,16 @@ func ReadAll(path string) ([]string, error) {
 func renderEntry(entry Entry, date time.Time) string {
 	lines := []string{
 		"## " + date.Format("2006-01-02") + " - " + issueRef(entry) + " - \"" + headingTitle(entry) + "\"",
+		"- **Captured at:** " + date.UTC().Format(time.RFC3339Nano),
 		"- **Failure kind:** " + field(entry.FailureKind, "<unknown>"),
+		"- **Issue:** " + field(entry.IssueRef, issueRef(entry)),
+		"- **Pull request:** " + field(entry.PullRequest, "<unavailable>"),
 		"- **Symptom:** " + field(entry.Symptom, "<unavailable>"),
 		"- **Hypothesis (Detent):** " + field(entry.Hypothesis, "<unavailable>"),
 		"- **Hint for next time:** " + field(entry.Hint, "<unavailable>"),
+	}
+	if captureKey := strings.TrimSpace(entry.CaptureKey); captureKey != "" {
+		lines = append(lines, "- **Capture key:** "+field(captureKey, ""))
 	}
 
 	return strings.Join(lines, "\n")
@@ -220,6 +283,24 @@ func renderedEntryHeading(entry string) string {
 		}
 	}
 	return ""
+}
+
+func renderedEntryCapturedAt(entry string) (time.Time, bool) {
+	if value := renderedEntryField(entry, "Captured at"); value != "" {
+		capturedAt, err := time.Parse(time.RFC3339Nano, value)
+		if err == nil {
+			return capturedAt.UTC(), true
+		}
+	}
+	heading := renderedEntryHeading(entry)
+	if len(heading) < len("2006-01-02") {
+		return time.Time{}, false
+	}
+	capturedAt, err := time.Parse("2006-01-02", heading[:len("2006-01-02")])
+	if err != nil {
+		return time.Time{}, false
+	}
+	return capturedAt.UTC(), true
 }
 
 func writeEntries(path string, entries []string) error {

--- a/internal/lessons/lessons_test.go
+++ b/internal/lessons/lessons_test.go
@@ -130,7 +130,10 @@ func TestAppendRendersFallbacksAndEscapesTitleQuotes(t *testing.T) {
 	entry := entries[0]
 	for _, want := range []string{
 		`## 2026-05-22 - issue MT-9 - "Needs \"quotes\" escaped"`,
+		"- **Captured at:** 2026-05-22T00:00:00Z",
 		"- **Failure kind:** <unknown>",
+		"- **Issue:** issue MT-9",
+		"- **Pull request:** <unavailable>",
 		"- **Symptom:** command failed before diff",
 		"- **Hypothesis (Detent):** <unavailable>",
 		"- **Hint for next time:** <unavailable>",
@@ -138,6 +141,104 @@ func TestAppendRendersFallbacksAndEscapesTitleQuotes(t *testing.T) {
 		if !strings.Contains(entry, want) {
 			t.Fatalf("entry missing %q:\n%s", want, entry)
 		}
+	}
+}
+
+func TestAppendRoundTripsStructuredFields(t *testing.T) {
+	t.Parallel()
+
+	capturedAt := time.Date(2026, 7, 17, 14, 15, 16, 123, time.UTC)
+	tests := []struct {
+		name  string
+		entry Entry
+		want  map[string]string
+	}{
+		{
+			name: "issue and pull request context",
+			entry: Entry{
+				IssueRef:    "digitaldrywood/detent#1397",
+				PullRequest: "https://github.com/digitaldrywood/detent/pull/1401",
+				Title:       "Capture rework",
+				FailureKind: "ci_failure",
+				Symptom:     "checks failed: test, lint",
+				Hypothesis:  "the change was not ready",
+				Hint:        "run the gate locally",
+				CaptureKey:  "rework|detent|1397|2026-07-17T14:15:16.000000123Z",
+			},
+			want: map[string]string{
+				"Captured at":         capturedAt.Format(time.RFC3339Nano),
+				"Failure kind":        "ci_failure",
+				"Issue":               "digitaldrywood/detent#1397",
+				"Pull request":        "https://github.com/digitaldrywood/detent/pull/1401",
+				"Symptom":             "checks failed: test, lint",
+				"Hypothesis (Detent)": "the change was not ready",
+				"Hint for next time":  "run the gate locally",
+				"Capture key":         "rework|detent|1397|2026-07-17T14:15:16.000000123Z",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			path := filepath.Join(t.TempDir(), "lessons.md")
+			if err := Append(path, tt.entry, AppendOptions{Date: capturedAt}); err != nil {
+				t.Fatalf("Append() error = %v", err)
+			}
+			entries, err := ReadAll(path)
+			if err != nil {
+				t.Fatalf("ReadAll() error = %v", err)
+			}
+			if len(entries) != 1 {
+				t.Fatalf("ReadAll() len = %d, want 1", len(entries))
+			}
+			for label, want := range tt.want {
+				if got := renderedEntryField(entries[0], label); got != want {
+					t.Errorf("renderedEntryField(%q) = %q, want %q", label, got, want)
+				}
+			}
+		})
+	}
+}
+
+func TestAppendUniqueAndCaptureSummary(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join(t.TempDir(), "lessons.md")
+	firstAt := time.Date(2026, 7, 16, 9, 30, 0, 0, time.FixedZone("CDT", -5*60*60))
+	secondAt := firstAt.Add(2 * time.Hour)
+	tests := []struct {
+		name       string
+		captureKey string
+		capturedAt time.Time
+		wantAppend bool
+	}{
+		{name: "first capture", captureKey: "rework|detent|1397|first", capturedAt: firstAt, wantAppend: true},
+		{name: "duplicate capture", captureKey: "rework|detent|1397|first", capturedAt: firstAt, wantAppend: false},
+		{name: "second capture", captureKey: "rework|detent|1397|second", capturedAt: secondAt, wantAppend: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			appended, err := AppendUnique(path, Entry{
+				IssueRef:    "digitaldrywood/detent#1397",
+				FailureKind: "ci_failure",
+				CaptureKey:  tt.captureKey,
+			}, AppendOptions{Date: tt.capturedAt})
+			if err != nil {
+				t.Fatalf("AppendUnique() error = %v", err)
+			}
+			if appended != tt.wantAppend {
+				t.Fatalf("AppendUnique() = %t, want %t", appended, tt.wantAppend)
+			}
+		})
+	}
+
+	summary, err := CaptureSummary(path)
+	if err != nil {
+		t.Fatalf("CaptureSummary() error = %v", err)
+	}
+	if summary.Count != 2 || summary.LastCapturedAt == nil || !summary.LastCapturedAt.Equal(secondAt.UTC()) {
+		t.Fatalf("CaptureSummary() = %#v, want count 2 last %v", summary, secondAt.UTC())
 	}
 }
 

--- a/internal/orchestrator/config.go
+++ b/internal/orchestrator/config.go
@@ -93,6 +93,10 @@ func ConfigFromWorkflow(cfg workflowconfig.Config) Config {
 		GitHubGraphQLMinReserve:       int64(cfg.Tracker.GitHubGraphQLMinReserve),
 		GitHubRESTMinReserve:          int64(cfg.Tracker.GitHubRESTMinReserve),
 		OutputTruncationMaxBytes:      cfg.Agent.OutputTruncation.MaxBytes,
+		Lessons: LessonCaptureConfig{
+			Path:       cfg.Agent.Lessons.Path,
+			MaxEntries: cfg.Agent.Lessons.MaxEntries,
+		},
 		EfficiencyThresholds: efficiency.Thresholds{
 			TokensMultiple:   cfg.Observability.Efficiency.AnomalyTokensMultiple,
 			SessionsMultiple: cfg.Observability.Efficiency.AnomalySessionsMultiple,

--- a/internal/orchestrator/lesson_capture.go
+++ b/internal/orchestrator/lesson_capture.go
@@ -1,0 +1,167 @@
+package orchestrator
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/digitaldrywood/detent/internal/connector"
+	"github.com/digitaldrywood/detent/internal/lessons"
+)
+
+const reworkTransitionFailureKind = "rework_transition"
+
+func (o *Orchestrator) captureReworkLesson(issue connector.Issue, at time.Time, reason string) {
+	if o == nil || !o.cfg.Lessons.Enabled || strings.TrimSpace(o.cfg.Lessons.Path) == "" {
+		return
+	}
+	if at.IsZero() {
+		if o.now != nil {
+			at = o.now()
+		} else {
+			at = time.Now()
+		}
+	}
+	entry := reworkLessonEntry(o.workflowMetricsProjectID(), issue, at.UTC(), reason)
+	appended, err := lessons.AppendUnique(o.cfg.Lessons.Path, entry, lessons.AppendOptions{
+		Date:       at.UTC(),
+		MaxEntries: o.cfg.Lessons.MaxEntries,
+	})
+	if err != nil {
+		if o.logger != nil {
+			o.logger.Warn("rework lesson capture failed", "project_id", o.workflowMetricsProjectID(), "issue_id", issue.ID, "identifier", issue.Identifier, "reason", reason, "error", err)
+		}
+		return
+	}
+	if appended && o.logger != nil {
+		o.logger.Info("rework lesson captured", "project_id", o.workflowMetricsProjectID(), "issue_id", issue.ID, "identifier", issue.Identifier, "failure_kind", entry.FailureKind)
+	}
+}
+
+func reworkLessonEntry(projectID string, issue connector.Issue, at time.Time, reason string) lessons.Entry {
+	failedChecks := autoPromoteFailedChecksFromPullRequest(issue.PullRequest)
+	reviewSummary := reworkReviewSummary(issue.PullRequest)
+	return lessons.Entry{
+		IssueNumber: reworkIssueNumber(issue),
+		IssueRef:    strings.TrimSpace(issue.Identifier),
+		PullRequest: reworkPullRequestRef(issue),
+		Title:       issue.Title,
+		FailureKind: reworkFailureKind(reason, issue.PullRequest, failedChecks),
+		Symptom:     reworkLessonSymptom(issue, reason, failedChecks, reviewSummary),
+		Hypothesis:  "the previous attempt did not satisfy the workflow gate or review expectations",
+		Hint:        "use the captured checks and review context to strengthen the next attempt and prevent the same bounce",
+		CaptureKey:  reworkLessonCaptureKey(projectID, issue, at),
+	}
+}
+
+func reworkIssueNumber(issue connector.Issue) string {
+	if issue.Number <= 0 {
+		return ""
+	}
+	return strconv.Itoa(issue.Number)
+}
+
+func reworkFailureKind(reason string, pullRequest *connector.PullRequest, failedChecks []string) string {
+	if len(failedChecks) > 0 {
+		return "ci_failure"
+	}
+	reason = strings.ToLower(strings.TrimSpace(reason))
+	switch reason {
+	case string(AutoPromoteReasonCINotGreen):
+		return "ci_failure"
+	case mergeWorkerRequiredChecksMissingReason, mergeWorkerFastPathNotReadyReason:
+		return "ci_signal_missing"
+	case string(AutoPromoteReasonP1Findings), "plan_review_decision":
+		return "changes_requested"
+	case string(AutoPromoteReasonValidatorRework), string(AutoPromoteReasonValidatorScoreBelowThreshold), string(AutoPromoteReasonValidatorBlockedSeverity):
+		return "validator_rework"
+	case string(AutoPromoteReasonArtifactStatusRework):
+		return "artifact_rework"
+	case string(AutoPromoteReasonMergeConflicts):
+		return "merge_conflict"
+	case string(AutoPromoteReasonWorkpadStatusInvalid):
+		return "invalid_workpad_status"
+	}
+	if pullRequest != nil {
+		reviewState := strings.ToUpper(strings.TrimSpace(pullRequest.CodexReviewState))
+		if reviewState == "CHANGES_REQUESTED" || reviewState == "REQUESTED_CHANGES" || reviewState == "P1" {
+			return "changes_requested"
+		}
+	}
+	if reason == "" || reason == "tracker_state_observed" {
+		return reworkTransitionFailureKind
+	}
+	return strings.ReplaceAll(reason, " ", "_")
+}
+
+func reworkLessonSymptom(issue connector.Issue, reason string, failedChecks []string, reviewSummary string) string {
+	transition := reworkIssueRef(issue) + " was observed entering Rework"
+	if sourceState := displayStateName(issue.State); sourceState != "" {
+		transition = fmt.Sprintf("%s entered Rework from %s", reworkIssueRef(issue), sourceState)
+	}
+	parts := []string{transition}
+	if reason = strings.TrimSpace(reason); reason != "" {
+		parts = append(parts, "reason: "+reason)
+	}
+	if len(failedChecks) > 0 {
+		parts = append(parts, "failed checks: "+strings.Join(failedChecks, ", "))
+	}
+	if reviewSummary != "" {
+		parts = append(parts, "review: "+reviewSummary)
+	}
+	return strings.Join(parts, "; ")
+}
+
+func reworkReviewSummary(pullRequest *connector.PullRequest) string {
+	if pullRequest == nil {
+		return ""
+	}
+	parts := make([]string, 0, len(pullRequest.CodexReviewFindings)+1)
+	if state := strings.TrimSpace(pullRequest.CodexReviewState); state != "" {
+		parts = append(parts, state)
+	}
+	for _, finding := range pullRequest.CodexReviewFindings {
+		if body := strings.Join(strings.Fields(finding.Body), " "); body != "" {
+			parts = append(parts, body)
+		}
+		if len(parts) == 4 {
+			break
+		}
+	}
+	return strings.Join(parts, ": ")
+}
+
+func reworkPullRequestRef(issue connector.Issue) string {
+	if issue.PullRequest != nil {
+		if url := strings.TrimSpace(issue.PullRequest.URL); url != "" {
+			return url
+		}
+		if issue.PullRequest.Number > 0 {
+			return fmt.Sprintf("PR #%d", issue.PullRequest.Number)
+		}
+	}
+	if issue.PRNumber != nil && *issue.PRNumber > 0 {
+		return fmt.Sprintf("PR #%d", *issue.PRNumber)
+	}
+	return ""
+}
+
+func reworkIssueRef(issue connector.Issue) string {
+	if identifier := strings.TrimSpace(issue.Identifier); identifier != "" {
+		return identifier
+	}
+	if issueID := strings.TrimSpace(issue.ID); issueID != "" {
+		return issueID
+	}
+	return "issue"
+}
+
+func reworkLessonCaptureKey(projectID string, issue connector.Issue, at time.Time) string {
+	return strings.Join([]string{
+		"rework",
+		strings.TrimSpace(projectID),
+		reworkIssueRef(issue),
+		at.UTC().Format(time.RFC3339Nano),
+	}, "|")
+}

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -103,6 +103,13 @@ type Config struct {
 	GitHubRESTMinReserve          int64
 	OutputTruncationMaxBytes      int
 	EfficiencyThresholds          efficiency.Thresholds
+	Lessons                       LessonCaptureConfig
+}
+
+type LessonCaptureConfig struct {
+	Enabled    bool
+	Path       string
+	MaxEntries int
 }
 
 type FailureBreakerConfig struct {

--- a/internal/orchestrator/workflow_metrics.go
+++ b/internal/orchestrator/workflow_metrics.go
@@ -134,6 +134,9 @@ func (o *Orchestrator) updateIssueStateByIDWithMetadataMode(
 		issue.ID = issueID
 	}
 	o.recordLaneTransition(ctx, issue, targetState, at, reason, metadata)
+	if normalizeState(targetState) == normalizeState(autoPromoteReworkState) && normalizeState(issue.State) != normalizeState(targetState) {
+		o.captureReworkLesson(issue, at, reason)
+	}
 	return nil
 }
 
@@ -390,6 +393,11 @@ func (o *Orchestrator) refreshCurrentLaneEntries(ctx context.Context, state *Sta
 		}
 		if !eventBacked {
 			o.recordObservedLaneEntry(ctx, issue, enteredAt)
+			if normalizeState(issue.State) == normalizeState(autoPromoteReworkState) {
+				observed := cloneIssue(issue)
+				observed.State = ""
+				o.captureReworkLesson(observed, enteredAt, "tracker_state_observed")
+			}
 		}
 	}
 	state.laneEntries = next

--- a/internal/orchestrator/workflow_metrics_test.go
+++ b/internal/orchestrator/workflow_metrics_test.go
@@ -5,10 +5,13 @@ import (
 	"io"
 	"log/slog"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/digitaldrywood/detent/internal/connector"
+	"github.com/digitaldrywood/detent/internal/lessons"
+	"github.com/digitaldrywood/detent/internal/scheduler"
 	"github.com/digitaldrywood/detent/internal/store"
 )
 
@@ -456,6 +459,139 @@ func TestUpdateIssueStateByIDSkipsWorkflowMetricsForBlockedUpdate(t *testing.T) 
 	}
 	if got := state.BoardIssues[0].State; got != "Done" {
 		t.Fatalf("snapshot BoardIssues state = %q, want Done", got)
+	}
+}
+
+func TestUpdateIssueStateByIDCapturesReworkLesson(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name            string
+		reason          string
+		pullRequest     *connector.PullRequest
+		wantFailureKind string
+		wantContext     []string
+	}{
+		{
+			name:   "CI failure includes failed checks",
+			reason: string(AutoPromoteReasonCINotGreen),
+			pullRequest: &connector.PullRequest{
+				Number: 1401,
+				URL:    "https://github.com/digitaldrywood/detent/pull/1401",
+				RequiredCheckFailures: []connector.PullRequestCheck{
+					{Name: "test", Conclusion: "failure"},
+					{Name: "lint", Conclusion: "failure"},
+				},
+			},
+			wantFailureKind: "ci_failure",
+			wantContext:     []string{"failed checks: test, lint", "https://github.com/digitaldrywood/detent/pull/1401"},
+		},
+		{
+			name:   "requested changes include review findings",
+			reason: string(AutoPromoteReasonP1Findings),
+			pullRequest: &connector.PullRequest{
+				Number:           1402,
+				CodexReviewState: "CHANGES_REQUESTED",
+				CodexReviewFindings: []connector.PullRequestFinding{
+					{Body: "Add rollback coverage."},
+				},
+			},
+			wantFailureKind: "changes_requested",
+			wantContext:     []string{"CHANGES_REQUESTED: Add rollback coverage.", "PR #1402"},
+		},
+		{
+			name:            "generic transition keeps a non-empty kind",
+			reason:          "operator_rework",
+			wantFailureKind: "operator_rework",
+			wantContext:     []string{"reason: operator_rework"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			path := filepath.Join(t.TempDir(), ".detent", "lessons.md")
+			transitionAt := time.Date(2026, 7, 17, 15, 30, 0, 0, time.UTC)
+			issue := connector.Issue{
+				ID:          "issue-1397",
+				Identifier:  "digitaldrywood/detent#1397",
+				Number:      1397,
+				Title:       "Capture rework lessons",
+				State:       "In Progress",
+				PullRequest: tt.pullRequest,
+			}
+			orch := &Orchestrator{
+				cfg: Config{
+					Project: scheduler.ProjectCandidate{ID: "detent"},
+					Lessons: LessonCaptureConfig{Enabled: true, Path: path, MaxEntries: 10},
+				},
+				connector: &workflowMetricsConnector{},
+			}
+			state := newState(Config{})
+			if err := orch.updateIssueStateByID(t.Context(), &state, issue.ID, issue, "Rework", transitionAt, tt.reason); err != nil {
+				t.Fatalf("updateIssueStateByID() error = %v", err)
+			}
+
+			patterns, err := lessons.FailureKindPatterns(path, 1)
+			if err != nil {
+				t.Fatalf("FailureKindPatterns() error = %v", err)
+			}
+			if len(patterns) != 1 || patterns[0].FailureKind != tt.wantFailureKind {
+				t.Fatalf("FailureKindPatterns() = %#v, want %q", patterns, tt.wantFailureKind)
+			}
+			entries, err := lessons.ReadAll(path)
+			if err != nil {
+				t.Fatalf("ReadAll() error = %v", err)
+			}
+			if len(entries) != 1 {
+				t.Fatalf("ReadAll() len = %d, want 1", len(entries))
+			}
+			for _, want := range tt.wantContext {
+				if !strings.Contains(entries[0], want) {
+					t.Errorf("lesson missing %q:\n%s", want, entries[0])
+				}
+			}
+		})
+	}
+}
+
+func TestRefreshCurrentLaneEntriesCapturesObservedReworkOnce(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join(t.TempDir(), ".detent", "lessons.md")
+	enteredAt := time.Date(2026, 7, 17, 16, 0, 0, 0, time.UTC)
+	issue := connector.Issue{
+		ID:             "issue-1397",
+		Identifier:     "digitaldrywood/detent#1397",
+		Number:         1397,
+		Title:          "Capture observed rework",
+		State:          "Rework",
+		StageUpdatedAt: &enteredAt,
+	}
+	cfg := Config{
+		Project: scheduler.ProjectCandidate{ID: "detent"},
+		Lessons: LessonCaptureConfig{Enabled: true, Path: path, MaxEntries: 10},
+	}
+	orch := &Orchestrator{cfg: cfg}
+	state := newState(cfg)
+	state.BoardIssues = []connector.Issue{issue}
+
+	orch.refreshCurrentLaneEntries(t.Context(), &state, enteredAt.Add(time.Minute))
+	orch.refreshCurrentLaneEntries(t.Context(), &state, enteredAt.Add(2*time.Minute))
+
+	entries, err := lessons.ReadAll(path)
+	if err != nil {
+		t.Fatalf("ReadAll() error = %v", err)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("ReadAll() len = %d, want one deduplicated capture", len(entries))
+	}
+	patterns, err := lessons.FailureKindPatterns(path, 1)
+	if err != nil {
+		t.Fatalf("FailureKindPatterns() error = %v", err)
+	}
+	if len(patterns) != 1 || patterns[0].FailureKind != reworkTransitionFailureKind {
+		t.Fatalf("FailureKindPatterns() = %#v, want %q", patterns, reworkTransitionFailureKind)
 	}
 }
 

--- a/internal/project/connector_config_test.go
+++ b/internal/project/connector_config_test.go
@@ -60,6 +60,54 @@ func TestWorkflowConfigWithProjectPathsResolvesArtifactWorkflowPaths(t *testing.
 	}
 }
 
+func TestProjectOrchestratorConfigEnablesLessonCapture(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		lessonPath string
+		maxEntries int
+		wantPath   string
+		wantMax    int
+	}{
+		{
+			name:     "defaults",
+			wantPath: filepath.Join(".detent", "lessons.md"),
+			wantMax:  50,
+		},
+		{
+			name:       "workflow override",
+			lessonPath: filepath.Join("ops", "lessons.md"),
+			maxEntries: 12,
+			wantPath:   filepath.Join("ops", "lessons.md"),
+			wantMax:    12,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			workdir := t.TempDir()
+			cfg := workflowconfig.Default()
+			cfg.Agent.Lessons.Enabled = false
+			cfg.Agent.Lessons.Path = tt.lessonPath
+			cfg.Agent.Lessons.MaxEntries = tt.maxEntries
+
+			got := projectOrchestratorConfig(globalconfig.Project{ID: "detent", Workdir: workdir}, cfg)
+			if !got.Lessons.Enabled {
+				t.Fatal("Lessons.Enabled = false, want automatic capture enabled")
+			}
+			if got.Lessons.Path != filepath.Join(workdir, tt.wantPath) {
+				t.Fatalf("Lessons.Path = %q, want %q", got.Lessons.Path, filepath.Join(workdir, tt.wantPath))
+			}
+			if got.Lessons.MaxEntries != tt.wantMax {
+				t.Fatalf("Lessons.MaxEntries = %d, want %d", got.Lessons.MaxEntries, tt.wantMax)
+			}
+		})
+	}
+}
+
 func TestWorkflowConfigWithProjectIntakeOverride(t *testing.T) {
 	t.Parallel()
 

--- a/internal/project/project.go
+++ b/internal/project/project.go
@@ -21,6 +21,7 @@ import (
 	"github.com/digitaldrywood/detent/internal/efficiency"
 	"github.com/digitaldrywood/detent/internal/hub"
 	"github.com/digitaldrywood/detent/internal/intake"
+	"github.com/digitaldrywood/detent/internal/lessons"
 	"github.com/digitaldrywood/detent/internal/orchestrator"
 	releasepkg "github.com/digitaldrywood/detent/internal/release"
 	"github.com/digitaldrywood/detent/internal/retro"
@@ -1212,6 +1213,15 @@ func projectOrchestratorConfig(project globalconfig.Project, workflow workflowco
 		Weight:   project.Weight,
 		Priority: project.Priority,
 		Paused:   project.Paused,
+	}
+	lessonPath := strings.TrimSpace(cfg.Lessons.Path)
+	if lessonPath == "" {
+		lessonPath = lessons.DefaultPath
+	}
+	cfg.Lessons.Path = projectRelativePath(project.Workdir, lessonPath)
+	cfg.Lessons.Enabled = true
+	if cfg.Lessons.MaxEntries <= 0 {
+		cfg.Lessons.MaxEntries = lessons.DefaultMaxEntries
 	}
 	cfg.Authorization = combineAuthorizationSelectors(cfg.Authorization, project.Authorization)
 	return cfg


### PR DESCRIPTION
## Summary

- capture structured, deduplicated lessons when issues enter Rework through orchestrator updates or observed tracker changes
- preserve failed check and review finding context for the existing failure-pattern proposal pipeline
- report per-project lesson capture count and latest capture time in `detent doctor`

Fixes #1397

## UI Surface Contract

- [x] N/A; this PR does not change UI surfaces.
- [x] This PR does not add persistent top-of-screen messaging.
- [x] N/A; this PR has no visual changes.

## Test Plan

- [x] `go test ./internal/project ./internal/lessons ./internal/orchestrator ./internal/cli`
- [x] `make check` (post-rebase, 77.3% coverage)