### PR TITLE
feat(doctor): flag oversized workflows for skill extraction

### DIFF
--- a/docs/ONBOARDING.md
+++ b/docs/ONBOARDING.md
@@ -1926,6 +1926,16 @@ awk 'NF {last=$0} END {exit last == "MUTATION_CONFIRMED=true" ? 0 : 1}' "$ONBOAR
    loss is unexplained instead of pushing. The commands named in the template
    rule are illustrative; equivalent comparisons are valid.
 
+   Treat the prompt body as a thin, always-loaded core. Keep universal safety,
+   state-transition, validation, and handoff contracts in `WORKFLOW.md`; move
+   domain-specific runbooks and conditionally relevant tool guidance into
+   reviewed lazy skills under `.detent/skills`. `detent doctor` estimates the
+   loaded prompt body at four characters per token and warns above 4,000 tokens
+   by default. Use `--workflow-token-threshold <tokens>` to choose a different
+   positive threshold. The warning names non-overlapping Markdown sections and
+   candidate skill files, but never rewrites `WORKFLOW.md`; use the existing
+   skill-creation review flow described below to perform any extraction.
+
 2. **Substitute the tracker and workspace answers.** In ProjectV2 mode, use the
    ProjectV2 node id as `tracker.project_slug`. In boardless issue-field mode,
    set the repository and issue field. In label mode, set the repository and

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -50,6 +50,7 @@ type doctorCheck struct {
 	Status                    doctorStatus                               `json:"status"`
 	Detail                    string                                     `json:"detail"`
 	Hint                      string                                     `json:"hint,omitempty"`
+	WorkflowSkillSuggestions  []doctorWorkflowSkillSuggestion            `json:"workflow_skill_suggestions,omitempty"`
 	AutoPromoteCandidates     []doctorAutoPromoteCandidateDiagnostic     `json:"auto_promote_candidates,omitempty"`
 	BlockedRecoveryCandidates []doctorBlockedRecoveryCandidateDiagnostic `json:"blocked_recovery_candidates,omitempty"`
 	BackendCapacity           []doctorBackendCapacityDiagnostic          `json:"backend_capacity,omitempty"`
@@ -127,6 +128,7 @@ type doctorConfig struct {
 	Build                     buildinfo.Info
 	AllowWriteProbes          bool
 	WorkflowDiff              bool
+	WorkflowTokenThreshold    int
 	WorkflowProposalThreshold int
 	WorkflowProposeIssues     bool
 }
@@ -177,6 +179,7 @@ func newDoctorCommandWithDeps(configPath *string, env *string, logLevel *string,
 	workflowDiff := false
 	workflowWrite := false
 	workflowProposeIssues := false
+	workflowTokenThreshold := doctorWorkflowDefaultTokenThreshold
 	workflowProposalThreshold := doctorWorkflowProposalDefaultThreshold
 	strict := false
 	projectID := ""
@@ -187,6 +190,9 @@ func newDoctorCommandWithDeps(configPath *string, env *string, logLevel *string,
 		Args:         NoArgs,
 		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, _ []string) error {
+			if workflowTokenThreshold <= 0 {
+				return errors.New("--workflow-token-threshold must be greater than zero")
+			}
 			out, err := OutputForCommand(cmd)
 			if err != nil {
 				return err
@@ -204,6 +210,7 @@ func newDoctorCommandWithDeps(configPath *string, env *string, logLevel *string,
 				Build:                     opts.build,
 				AllowWriteProbes:          allowWriteProbes,
 				WorkflowDiff:              workflowDiff || workflowWrite,
+				WorkflowTokenThreshold:    workflowTokenThreshold,
 				WorkflowProposalThreshold: workflowProposalThreshold,
 				WorkflowProposeIssues:     workflowProposeIssues,
 				Flags: runtimeFlags{
@@ -238,6 +245,7 @@ func newDoctorCommandWithDeps(configPath *string, env *string, logLevel *string,
 	cmd.Flags().BoolVar(&allowWriteProbes, "allow-write-probes", false, "run configured GitHub write probes")
 	cmd.Flags().BoolVar(&workflowDiff, "diff", false, "print proposed WORKFLOW.md frontmatter changes for workflow optimization findings")
 	cmd.Flags().BoolVar(&workflowWrite, "write", false, "apply proposed WORKFLOW.md frontmatter changes after confirmation")
+	cmd.Flags().IntVar(&workflowTokenThreshold, "workflow-token-threshold", doctorWorkflowDefaultTokenThreshold, "warn when a WORKFLOW.md prompt body exceeds this estimated token count")
 	cmd.Flags().IntVar(&workflowProposalThreshold, "proposal-threshold", doctorWorkflowProposalDefaultThreshold, "minimum repeated signal count before emitting a governed self-improvement proposal")
 	cmd.Flags().BoolVar(&workflowProposeIssues, "propose-issues", false, "create governed backlog issue proposals for repeated workflow optimization signals")
 	cmd.Flags().BoolVar(&strict, "strict", false, "fail when checks warn or workflow optimization findings exist")
@@ -361,7 +369,7 @@ func runDoctor(ctx context.Context, cfg doctorConfig, opts options, deps doctorD
 			},
 		})
 		if projectScopeCheck == nil {
-			jobs = append(jobs, doctorProjectCheckJobs(globalConfig, deps, githubToken, cfg.AllowWriteProbes)...)
+			jobs = append(jobs, doctorProjectCheckJobs(globalConfig, deps, githubToken, cfg.AllowWriteProbes, cfg.WorkflowTokenThreshold)...)
 			jobs = append(jobs, doctorCheckJob{
 				Name: "Workflow runtime drift",
 				Run: func(jobCtx context.Context) []doctorCheck {

--- a/internal/cli/doctor_project.go
+++ b/internal/cli/doctor_project.go
@@ -141,7 +141,7 @@ func doctorWorkflowTimestamp(value time.Time) string {
 	return value.UTC().Format(time.RFC3339)
 }
 
-func doctorProjectCheckJobs(cfg globalconfig.Config, deps doctorDeps, githubToken RuntimeSecret, allowWriteProbes bool) []doctorCheckJob {
+func doctorProjectCheckJobs(cfg globalconfig.Config, deps doctorDeps, githubToken RuntimeSecret, allowWriteProbes bool, workflowTokenThreshold int) []doctorCheckJob {
 	if len(cfg.Projects) == 0 {
 		return []doctorCheckJob{{
 			Name: "Project workflows",
@@ -166,7 +166,7 @@ func doctorProjectCheckJobs(cfg globalconfig.Config, deps doctorDeps, githubToke
 			Name:    "Project " + id + " checks",
 			Current: progress.Current,
 			Run: func(jobCtx context.Context) []doctorCheck {
-				return checkDoctorProjectWithProgress(jobCtx, project, doctorRuntimeStorePath(cfg.Path), deps, githubToken, allowWriteProbes, progress.Set)
+				return checkDoctorProjectWithProgress(jobCtx, project, doctorRuntimeStorePath(cfg.Path), deps, githubToken, allowWriteProbes, workflowTokenThreshold, progress.Set)
 			},
 		})
 	}
@@ -178,7 +178,7 @@ func checkDoctorProject(ctx context.Context, project globalconfig.Project, deps 
 }
 
 func checkDoctorProjectWithStore(ctx context.Context, project globalconfig.Project, storePath string, deps doctorDeps, githubToken RuntimeSecret, allowWriteProbes bool) []doctorCheck {
-	return checkDoctorProjectWithProgress(ctx, project, storePath, deps, githubToken, allowWriteProbes, nil)
+	return checkDoctorProjectWithProgress(ctx, project, storePath, deps, githubToken, allowWriteProbes, doctorWorkflowDefaultTokenThreshold, nil)
 }
 
 func checkDoctorProjectWithProgress(
@@ -188,6 +188,7 @@ func checkDoctorProjectWithProgress(
 	deps doctorDeps,
 	githubToken RuntimeSecret,
 	allowWriteProbes bool,
+	workflowTokenThreshold int,
 	setCurrent func(string),
 ) []doctorCheck {
 	id := doctorProjectID(project)
@@ -289,7 +290,7 @@ func checkDoctorProjectWithProgress(
 		checks = append(checks, billingCheck)
 	}
 	setDoctorCurrentCheck("Project " + id + " workflow lint")
-	checks = append(checks, checkDoctorWorkflowLint(ctx, id, project, workflow.Config, storePath, deps)...)
+	checks = append(checks, checkDoctorWorkflowLint(ctx, id, project, workflow.Config, workflow.Prompt, workflowTokenThreshold, storePath, deps)...)
 	setDoctorCurrentCheck("Project " + id + " out-of-scope follow-up guidance")
 	checks = append(checks, checkDoctorFollowupGuidance(id, workflow.Config.Agent.Followups, workflow.Prompt))
 	setDoctorCurrentCheck("Project " + id + " pinned route models")

--- a/internal/cli/doctor_test.go
+++ b/internal/cli/doctor_test.go
@@ -4655,7 +4655,7 @@ func TestDoctorProjectCheckJobTimeoutReportsCurrentInnerCheck(t *testing.T) {
 		githubMergeSettings: func(context.Context, workflowconfig.Config, string) (ghconnector.RepositoryMergeSettings, error) {
 			return ghconnector.RepositoryMergeSettings{AllowSquashMerge: true}, nil
 		},
-	}, RuntimeSecret{Value: "token", Source: "github_token"}, false)
+	}, RuntimeSecret{Value: "token", Source: "github_token"}, false, doctorWorkflowDefaultTokenThreshold)
 	if len(jobs) != 1 {
 		t.Fatalf("jobs len = %d, want 1", len(jobs))
 	}

--- a/internal/cli/doctor_workflow_lint.go
+++ b/internal/cli/doctor_workflow_lint.go
@@ -68,7 +68,7 @@ func doctorRuntimeStorePath(configPath string) string {
 func checkDoctorWorkflowLint(ctx context.Context, projectID string, project globalconfig.Project, cfg workflowconfig.Config, prompt string, workflowTokenThreshold int, storePath string, deps doctorDeps) []doctorCheck {
 	workflowPath := doctorWorkflowLintPath(project)
 	checks := make([]doctorCheck, 0)
-	if sizeCheck, ok := checkDoctorWorkflowPromptSize(projectID, workflowPath, prompt, workflowTokenThreshold); ok {
+	if sizeCheck, ok := checkDoctorWorkflowPromptSize(projectID, workflowPath, prompt, cfg.Agent.Skills.Path, workflowTokenThreshold); ok {
 		checks = append(checks, sizeCheck)
 	}
 	if len(cfg.ConfiguredSubsettings("budget")) == 0 {

--- a/internal/cli/doctor_workflow_lint.go
+++ b/internal/cli/doctor_workflow_lint.go
@@ -65,9 +65,12 @@ func doctorRuntimeStorePath(configPath string) string {
 	return filepath.Join(filepath.Dir(configPath), "detent.db")
 }
 
-func checkDoctorWorkflowLint(ctx context.Context, projectID string, project globalconfig.Project, cfg workflowconfig.Config, storePath string, deps doctorDeps) []doctorCheck {
+func checkDoctorWorkflowLint(ctx context.Context, projectID string, project globalconfig.Project, cfg workflowconfig.Config, prompt string, workflowTokenThreshold int, storePath string, deps doctorDeps) []doctorCheck {
 	workflowPath := doctorWorkflowLintPath(project)
 	checks := make([]doctorCheck, 0)
+	if sizeCheck, ok := checkDoctorWorkflowPromptSize(projectID, workflowPath, prompt, workflowTokenThreshold); ok {
+		checks = append(checks, sizeCheck)
+	}
 	if len(cfg.ConfiguredSubsettings("budget")) == 0 {
 		if budgetCheck, ok := checkDoctorDisabledBudgetCaps(projectID, cfg.Budget); ok {
 			budgetCheck.Detail = workflowPath + " " + budgetCheck.Detail

--- a/internal/cli/doctor_workflow_lint_test.go
+++ b/internal/cli/doctor_workflow_lint_test.go
@@ -95,7 +95,7 @@ func TestCheckDoctorWorkflowLintStaticLandmines(t *testing.T) {
 				ID:       "alpha",
 				Workflow: "WORKFLOW.md",
 				Workdir:  workdir,
-			}, tt.cfg, "", tt.deps)
+			}, tt.cfg, "", doctorWorkflowDefaultTokenThreshold, "", tt.deps)
 			if len(checks) != 1 {
 				t.Fatalf("checks = %#v, want one warning", checks)
 			}
@@ -154,7 +154,7 @@ func TestCheckDoctorWorkflowLintWarnsForPathFilteredRequiredCheck(t *testing.T) 
 				ID:       "alpha",
 				Workflow: "WORKFLOW.md",
 				Workdir:  workdir,
-			}, cfg, "", doctorDeps{})
+			}, cfg, "", doctorWorkflowDefaultTokenThreshold, "", doctorDeps{})
 
 			if !tt.wantWarning {
 				if len(checks) != 0 {
@@ -198,7 +198,7 @@ func TestCheckDoctorWorkflowLintWarnsForUnconfiguredLabelGatedRequiredCheck(t *t
 		ID:       "alpha",
 		Workflow: "WORKFLOW.md",
 		Workdir:  workdir,
-	}, cfg, "", doctorDeps{})
+	}, cfg, "", doctorWorkflowDefaultTokenThreshold, "", doctorDeps{})
 
 	if len(checks) != 1 {
 		t.Fatalf("checks = %#v, want one warning", checks)
@@ -259,7 +259,7 @@ func TestCheckDoctorWorkflowLintAcceptsConfiguredLabelGatedRequiredCheck(t *test
 				ID:       "alpha",
 				Workflow: "WORKFLOW.md",
 				Workdir:  workdir,
-			}, cfg, "", doctorDeps{})
+			}, cfg, "", doctorWorkflowDefaultTokenThreshold, "", doctorDeps{})
 
 			if tt.wantWarning {
 				if len(checks) != 1 || !strings.Contains(checks[0].Detail, tt.wantDetail) {
@@ -434,7 +434,7 @@ Prompt
 	checks := checkDoctorWorkflowLint(context.Background(), "alpha", globalconfig.Project{
 		ID:       "alpha",
 		Workflow: "WORKFLOW.md",
-	}, workflow.Config, "", doctorDeps{})
+	}, workflow.Config, "", doctorWorkflowDefaultTokenThreshold, "", doctorDeps{})
 	if len(checks) != 1 {
 		t.Fatalf("checks = %#v, want one inert agent budget warning", checks)
 	}
@@ -469,7 +469,7 @@ Prompt
 	checks := checkDoctorWorkflowLint(context.Background(), "alpha", globalconfig.Project{
 		ID:       "alpha",
 		Workflow: "WORKFLOW.md",
-	}, workflow.Config, "", doctorDeps{})
+	}, workflow.Config, "", doctorWorkflowDefaultTokenThreshold, "", doctorDeps{})
 	if len(checks) != 1 {
 		t.Fatalf("checks = %#v, want one inert top-level budget warning", checks)
 	}
@@ -494,7 +494,7 @@ func TestCheckDoctorWorkflowLintCleanWorkflowIsQuiet(t *testing.T) {
 		ID:       "alpha",
 		Workflow: "WORKFLOW.md",
 		Workdir:  workdir,
-	}, cfg, "", doctorDeps{
+	}, cfg, "", doctorWorkflowDefaultTokenThreshold, "", doctorDeps{
 		resolveCommandInDir: func(context.Context, string, []string, string) (string, error) {
 			return "/usr/bin/make", nil
 		},

--- a/internal/cli/doctor_workflow_size.go
+++ b/internal/cli/doctor_workflow_size.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"fmt"
+	"path/filepath"
 	"sort"
 	"strings"
 	"unicode"
@@ -18,6 +19,7 @@ const (
 type doctorWorkflowSkillSuggestion struct {
 	Heading         string `json:"heading"`
 	SkillName       string `json:"skill_name"`
+	Path            string `json:"path"`
 	EstimatedTokens int    `json:"estimated_tokens"`
 }
 
@@ -99,7 +101,7 @@ var doctorWorkflowCoreHeadings = []string{
 	"workpad status contract",
 }
 
-func checkDoctorWorkflowPromptSize(projectID string, workflowPath string, prompt string, threshold int) (doctorCheck, bool) {
+func checkDoctorWorkflowPromptSize(projectID string, workflowPath string, prompt string, skillsPath string, threshold int) (doctorCheck, bool) {
 	prompt = strings.TrimSpace(prompt)
 	if prompt == "" {
 		return doctorCheck{}, false
@@ -111,12 +113,13 @@ func checkDoctorWorkflowPromptSize(projectID string, workflowPath string, prompt
 		return doctorCheck{}, false
 	}
 
-	suggestions := doctorWorkflowPromptSkillSuggestions(prompt)
+	skillsPath = doctorWorkflowSkillsPath(skillsPath)
+	suggestions := doctorWorkflowPromptSkillSuggestions(prompt, skillsPath)
 	detail := fmt.Sprintf("%s prompt body is approximately %d tokens (%d characters at %d characters/token), above the %d-token threshold", workflowPath, estimatedTokens, characters, doctorWorkflowEstimatedCharsPerToken, threshold)
 	if len(suggestions) > 0 {
 		parts := make([]string, 0, len(suggestions))
 		for _, suggestion := range suggestions {
-			parts = append(parts, fmt.Sprintf("%q (~%d tokens) -> .detent/skills/%s.md", suggestion.Heading, suggestion.EstimatedTokens, suggestion.SkillName))
+			parts = append(parts, fmt.Sprintf("%q (~%d tokens) -> %s", suggestion.Heading, suggestion.EstimatedTokens, suggestion.Path))
 		}
 		detail += "; extraction candidates: " + strings.Join(parts, "; ")
 	}
@@ -125,7 +128,7 @@ func checkDoctorWorkflowPromptSize(projectID string, workflowPath string, prompt
 		Name:                     "Project " + projectID + " workflow lint prompt size",
 		Status:                   doctorWarn,
 		Detail:                   detail,
-		Hint:                     "Keep WORKFLOW.md as a thin core and move domain-specific or conditional guidance into reviewed lazy skills through the existing skill-creation flow. This check is guidance only and never rewrites WORKFLOW.md.",
+		Hint:                     fmt.Sprintf("Keep WORKFLOW.md as a thin core and move domain-specific or conditional guidance into reviewed lazy skills under %s through the existing skill-creation flow. This check is guidance only and never rewrites WORKFLOW.md.", skillsPath),
 		WorkflowSkillSuggestions: suggestions,
 	}, true
 }
@@ -142,7 +145,7 @@ func doctorWorkflowEstimatedTokens(content string) int {
 	return (characters + doctorWorkflowEstimatedCharsPerToken - 1) / doctorWorkflowEstimatedCharsPerToken
 }
 
-func doctorWorkflowPromptSkillSuggestions(prompt string) []doctorWorkflowSkillSuggestion {
+func doctorWorkflowPromptSkillSuggestions(prompt string, skillsPath string) []doctorWorkflowSkillSuggestion {
 	sections := doctorWorkflowPromptSections(prompt)
 	candidates := make([]doctorWorkflowPromptSection, 0, len(sections))
 	for _, section := range sections {
@@ -175,13 +178,27 @@ func doctorWorkflowPromptSkillSuggestions(prompt string) []doctorWorkflowSkillSu
 
 	suggestions := make([]doctorWorkflowSkillSuggestion, 0, len(candidates))
 	for _, section := range candidates {
+		skillName := doctorWorkflowSkillName(section.heading)
 		suggestions = append(suggestions, doctorWorkflowSkillSuggestion{
 			Heading:         section.heading,
-			SkillName:       doctorWorkflowSkillName(section.heading),
+			SkillName:       skillName,
+			Path:            doctorWorkflowSkillCandidatePath(skillsPath, skillName),
 			EstimatedTokens: doctorWorkflowEstimatedTokens(section.heading + "\n" + section.content),
 		})
 	}
 	return suggestions
+}
+
+func doctorWorkflowSkillsPath(skillsPath string) string {
+	skillsPath = strings.TrimRight(filepath.ToSlash(strings.TrimSpace(skillsPath)), "/")
+	if skillsPath == "" {
+		return ".detent/skills"
+	}
+	return skillsPath
+}
+
+func doctorWorkflowSkillCandidatePath(skillsPath string, skillName string) string {
+	return doctorWorkflowSkillsPath(skillsPath) + "/" + skillName + ".md"
 }
 
 func doctorWorkflowPromptSections(prompt string) []doctorWorkflowPromptSection {

--- a/internal/cli/doctor_workflow_size.go
+++ b/internal/cli/doctor_workflow_size.go
@@ -1,0 +1,305 @@
+package cli
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+	"unicode"
+	"unicode/utf8"
+)
+
+const (
+	doctorWorkflowDefaultTokenThreshold   = 4000
+	doctorWorkflowEstimatedCharsPerToken  = 4
+	doctorWorkflowMinimumSectionTokens    = 80
+	doctorWorkflowMaximumSkillSuggestions = 5
+)
+
+type doctorWorkflowSkillSuggestion struct {
+	Heading         string `json:"heading"`
+	SkillName       string `json:"skill_name"`
+	EstimatedTokens int    `json:"estimated_tokens"`
+}
+
+type doctorWorkflowPromptSection struct {
+	heading string
+	content string
+	index   int
+}
+
+var doctorWorkflowConditionalHeadingTerms = []string{
+	"api",
+	"browser",
+	"ci",
+	"cleanup",
+	"concurrency",
+	"database",
+	"deploy",
+	"docker",
+	"frontend",
+	"github",
+	"git",
+	"google",
+	"isolation",
+	"kubernetes",
+	"linux",
+	"macos",
+	"merge",
+	"migration",
+	"observability",
+	"performance",
+	"process lifecycle",
+	"profiling",
+	"recovery",
+	"release",
+	"rollout",
+	"security",
+	"slack",
+	"sql",
+	"subprocess",
+	"terraform",
+	"tracker",
+	"ui",
+	"windows",
+	"worktree",
+}
+
+var doctorWorkflowConditionalBodyTerms = []string{
+	".github/",
+	"api endpoint",
+	"database",
+	"docker",
+	"gh ",
+	"git ",
+	"go test",
+	"graphql",
+	"http://",
+	"https://",
+	"kubectl",
+	"kubernetes",
+	"make ",
+	"migration",
+	"npm ",
+	"pull request",
+	"sql",
+	"terraform",
+	"worktree",
+}
+
+var doctorWorkflowCoreHeadings = []string{
+	"acceptance criteria",
+	"general instructions",
+	"operating rules",
+	"overview",
+	"problem",
+	"required execution flow",
+	"scope",
+	"validation gate",
+	"workflow states",
+	"workpad status contract",
+}
+
+func checkDoctorWorkflowPromptSize(projectID string, workflowPath string, prompt string, threshold int) (doctorCheck, bool) {
+	prompt = strings.TrimSpace(prompt)
+	if prompt == "" {
+		return doctorCheck{}, false
+	}
+	threshold = doctorWorkflowTokenThreshold(threshold)
+	characters := utf8.RuneCountInString(prompt)
+	estimatedTokens := doctorWorkflowEstimatedTokens(prompt)
+	if estimatedTokens <= threshold {
+		return doctorCheck{}, false
+	}
+
+	suggestions := doctorWorkflowPromptSkillSuggestions(prompt)
+	detail := fmt.Sprintf("%s prompt body is approximately %d tokens (%d characters at %d characters/token), above the %d-token threshold", workflowPath, estimatedTokens, characters, doctorWorkflowEstimatedCharsPerToken, threshold)
+	if len(suggestions) > 0 {
+		parts := make([]string, 0, len(suggestions))
+		for _, suggestion := range suggestions {
+			parts = append(parts, fmt.Sprintf("%q (~%d tokens) -> .detent/skills/%s.md", suggestion.Heading, suggestion.EstimatedTokens, suggestion.SkillName))
+		}
+		detail += "; extraction candidates: " + strings.Join(parts, "; ")
+	}
+
+	return doctorCheck{
+		Name:                     "Project " + projectID + " workflow lint prompt size",
+		Status:                   doctorWarn,
+		Detail:                   detail,
+		Hint:                     "Keep WORKFLOW.md as a thin core and move domain-specific or conditional guidance into reviewed lazy skills through the existing skill-creation flow. This check is guidance only and never rewrites WORKFLOW.md.",
+		WorkflowSkillSuggestions: suggestions,
+	}, true
+}
+
+func doctorWorkflowTokenThreshold(threshold int) int {
+	if threshold <= 0 {
+		return doctorWorkflowDefaultTokenThreshold
+	}
+	return threshold
+}
+
+func doctorWorkflowEstimatedTokens(content string) int {
+	characters := utf8.RuneCountInString(strings.TrimSpace(content))
+	return (characters + doctorWorkflowEstimatedCharsPerToken - 1) / doctorWorkflowEstimatedCharsPerToken
+}
+
+func doctorWorkflowPromptSkillSuggestions(prompt string) []doctorWorkflowSkillSuggestion {
+	sections := doctorWorkflowPromptSections(prompt)
+	candidates := make([]doctorWorkflowPromptSection, 0, len(sections))
+	for _, section := range sections {
+		if doctorWorkflowCoreHeading(section.heading) || doctorWorkflowEstimatedTokens(section.heading+"\n"+section.content) < doctorWorkflowMinimumSectionTokens {
+			continue
+		}
+		if doctorWorkflowConditionalHeading(section.heading) || doctorWorkflowConditionalBody(section.content) {
+			candidates = append(candidates, section)
+		}
+	}
+	if len(candidates) == 0 {
+		for _, section := range sections {
+			if !doctorWorkflowCoreHeading(section.heading) && doctorWorkflowEstimatedTokens(section.heading+"\n"+section.content) >= doctorWorkflowMinimumSectionTokens {
+				candidates = append(candidates, section)
+			}
+		}
+	}
+
+	sort.SliceStable(candidates, func(i int, j int) bool {
+		left := doctorWorkflowEstimatedTokens(candidates[i].heading + "\n" + candidates[i].content)
+		right := doctorWorkflowEstimatedTokens(candidates[j].heading + "\n" + candidates[j].content)
+		if left != right {
+			return left > right
+		}
+		return candidates[i].index < candidates[j].index
+	})
+	if len(candidates) > doctorWorkflowMaximumSkillSuggestions {
+		candidates = candidates[:doctorWorkflowMaximumSkillSuggestions]
+	}
+
+	suggestions := make([]doctorWorkflowSkillSuggestion, 0, len(candidates))
+	for _, section := range candidates {
+		suggestions = append(suggestions, doctorWorkflowSkillSuggestion{
+			Heading:         section.heading,
+			SkillName:       doctorWorkflowSkillName(section.heading),
+			EstimatedTokens: doctorWorkflowEstimatedTokens(section.heading + "\n" + section.content),
+		})
+	}
+	return suggestions
+}
+
+func doctorWorkflowPromptSections(prompt string) []doctorWorkflowPromptSection {
+	lines := strings.Split(strings.ReplaceAll(prompt, "\r\n", "\n"), "\n")
+	sections := make([]doctorWorkflowPromptSection, 0)
+	var heading string
+	var content strings.Builder
+	inFence := false
+	sectionIndex := 0
+	flush := func() {
+		if heading == "" {
+			return
+		}
+		sections = append(sections, doctorWorkflowPromptSection{
+			heading: heading,
+			content: strings.TrimSpace(content.String()),
+			index:   sectionIndex,
+		})
+		sectionIndex++
+		content.Reset()
+	}
+
+	for _, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		if strings.HasPrefix(trimmed, "```") || strings.HasPrefix(trimmed, "~~~") {
+			inFence = !inFence
+		}
+		if !inFence {
+			if nextHeading, ok := doctorWorkflowMarkdownHeading(line); ok {
+				flush()
+				heading = nextHeading
+				continue
+			}
+		}
+		if heading != "" {
+			content.WriteString(line)
+			content.WriteByte('\n')
+		}
+	}
+	flush()
+	return sections
+}
+
+func doctorWorkflowMarkdownHeading(line string) (string, bool) {
+	line = strings.TrimSpace(line)
+	level := 0
+	for level < len(line) && line[level] == '#' {
+		level++
+	}
+	if level < 2 || level > 4 || len(line) <= level || line[level] != ' ' {
+		return "", false
+	}
+	heading := strings.TrimSpace(strings.TrimRight(strings.TrimSpace(line[level+1:]), "#"))
+	return heading, heading != ""
+}
+
+func doctorWorkflowCoreHeading(heading string) bool {
+	heading = strings.ToLower(strings.TrimSpace(heading))
+	for _, core := range doctorWorkflowCoreHeadings {
+		if heading == core {
+			return true
+		}
+	}
+	return false
+}
+
+func doctorWorkflowConditionalHeading(heading string) bool {
+	heading = strings.ToLower(strings.TrimSpace(heading))
+	words := strings.FieldsFunc(heading, func(r rune) bool {
+		return !unicode.IsLetter(r) && !unicode.IsDigit(r)
+	})
+	for _, term := range doctorWorkflowConditionalHeadingTerms {
+		if strings.ContainsRune(term, ' ') {
+			if strings.Contains(heading, term) {
+				return true
+			}
+			continue
+		}
+		for _, word := range words {
+			if word == term {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func doctorWorkflowConditionalBody(content string) bool {
+	content = strings.ToLower(content)
+	matches := 0
+	for _, term := range doctorWorkflowConditionalBodyTerms {
+		if strings.Contains(content, term) {
+			matches++
+			if matches >= 2 {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func doctorWorkflowSkillName(heading string) string {
+	var builder strings.Builder
+	separator := false
+	for _, r := range strings.ToLower(strings.TrimSpace(heading)) {
+		if unicode.IsLetter(r) || unicode.IsDigit(r) {
+			if separator && builder.Len() > 0 {
+				builder.WriteByte('-')
+			}
+			builder.WriteRune(r)
+			separator = false
+			continue
+		}
+		separator = true
+	}
+	name := strings.Trim(builder.String(), "-")
+	if name == "" {
+		return "workflow-guidance"
+	}
+	return name
+}

--- a/internal/cli/doctor_workflow_size_test.go
+++ b/internal/cli/doctor_workflow_size_test.go
@@ -8,12 +8,22 @@ import (
 func TestCheckDoctorWorkflowPromptSize(t *testing.T) {
 	t.Parallel()
 
+	oversizedPrompt := strings.Join([]string{
+		"## Operating Rules",
+		strings.Repeat("Keep the core contract concise. ", 40),
+		"## GitHub CI Recovery",
+		strings.Repeat("Use gh to inspect the pull request and GitHub check-runs before retrying CI. ", 20),
+		"## Database Migration Runbook",
+		strings.Repeat("Run the SQL migration against the database and verify rollback behavior. ", 20),
+	}, "\n\n")
 	tests := []struct {
 		name            string
 		workflowPath    string
 		prompt          string
+		skillsPath      string
 		threshold       int
 		wantWarning     bool
+		wantSkillsPath  string
 		wantSuggestions []string
 	}{
 		{
@@ -34,18 +44,22 @@ func TestCheckDoctorWorkflowPromptSize(t *testing.T) {
 			threshold:    1,
 		},
 		{
-			name:         "over threshold with section suggestions",
-			workflowPath: "/repo/WORKFLOW.md",
-			threshold:    100,
-			prompt: strings.Join([]string{
-				"## Operating Rules",
-				strings.Repeat("Keep the core contract concise. ", 40),
-				"## GitHub CI Recovery",
-				strings.Repeat("Use gh to inspect the pull request and GitHub check-runs before retrying CI. ", 20),
-				"## Database Migration Runbook",
-				strings.Repeat("Run the SQL migration against the database and verify rollback behavior. ", 20),
-			}, "\n\n"),
+			name:            "over threshold with section suggestions",
+			workflowPath:    "/repo/WORKFLOW.md",
+			threshold:       100,
+			prompt:          oversizedPrompt,
 			wantWarning:     true,
+			wantSkillsPath:  ".detent/skills",
+			wantSuggestions: []string{"github-ci-recovery", "database-migration-runbook"},
+		},
+		{
+			name:            "configured skills path",
+			workflowPath:    "/repo/WORKFLOW.md",
+			prompt:          oversizedPrompt,
+			skillsPath:      "ops/agent-skills",
+			threshold:       100,
+			wantWarning:     true,
+			wantSkillsPath:  "ops/agent-skills",
 			wantSuggestions: []string{"github-ci-recovery", "database-migration-runbook"},
 		},
 	}
@@ -53,7 +67,7 @@ func TestCheckDoctorWorkflowPromptSize(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			check, warned := checkDoctorWorkflowPromptSize("alpha", tt.workflowPath, tt.prompt, tt.threshold)
+			check, warned := checkDoctorWorkflowPromptSize("alpha", tt.workflowPath, tt.prompt, tt.skillsPath, tt.threshold)
 			if warned != tt.wantWarning {
 				t.Fatalf("warned = %t, want %t; check = %#v", warned, tt.wantWarning, check)
 			}
@@ -63,18 +77,18 @@ func TestCheckDoctorWorkflowPromptSize(t *testing.T) {
 			if check.Status != doctorWarn || !strings.Contains(check.Name, "workflow lint prompt size") {
 				t.Fatalf("check = %#v, want workflow lint warning", check)
 			}
-			if !strings.Contains(check.Detail, "above the 100-token threshold") || !strings.Contains(check.Hint, "existing skill-creation flow") {
+			if !strings.Contains(check.Detail, "above the 100-token threshold") || !strings.Contains(check.Hint, "existing skill-creation flow") || !strings.Contains(check.Hint, tt.wantSkillsPath) {
 				t.Fatalf("check = %#v, want threshold and skill-creation guidance", check)
 			}
 			got := make(map[string]bool, len(check.WorkflowSkillSuggestions))
 			for _, suggestion := range check.WorkflowSkillSuggestions {
 				got[suggestion.SkillName] = true
-				if suggestion.Heading == "" || suggestion.EstimatedTokens <= 0 {
+				if suggestion.Heading == "" || suggestion.EstimatedTokens <= 0 || !strings.HasPrefix(suggestion.Path, tt.wantSkillsPath+"/") {
 					t.Fatalf("suggestion = %#v, want heading and token estimate", suggestion)
 				}
 			}
 			for _, want := range tt.wantSuggestions {
-				if !got[want] || !strings.Contains(check.Detail, ".detent/skills/"+want+".md") {
+				if !got[want] || !strings.Contains(check.Detail, tt.wantSkillsPath+"/"+want+".md") {
 					t.Fatalf("suggestions = %#v, detail = %q, want %q", check.WorkflowSkillSuggestions, check.Detail, want)
 				}
 			}

--- a/internal/cli/doctor_workflow_size_test.go
+++ b/internal/cli/doctor_workflow_size_test.go
@@ -1,0 +1,101 @@
+package cli
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestCheckDoctorWorkflowPromptSize(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name            string
+		workflowPath    string
+		prompt          string
+		threshold       int
+		wantWarning     bool
+		wantSuggestions []string
+	}{
+		{
+			name:         "under threshold",
+			workflowPath: "/repo/WORKFLOW.md",
+			prompt:       "## Operating Rules\n\nKeep the issue scoped and run the validation gate.",
+			threshold:    100,
+		},
+		{
+			name:         "empty workflow",
+			workflowPath: "/repo/WORKFLOW.md",
+			threshold:    1,
+		},
+		{
+			name:         "missing workflow prompt",
+			workflowPath: "/repo/missing/WORKFLOW.md",
+			prompt:       " \n",
+			threshold:    1,
+		},
+		{
+			name:         "over threshold with section suggestions",
+			workflowPath: "/repo/WORKFLOW.md",
+			threshold:    100,
+			prompt: strings.Join([]string{
+				"## Operating Rules",
+				strings.Repeat("Keep the core contract concise. ", 40),
+				"## GitHub CI Recovery",
+				strings.Repeat("Use gh to inspect the pull request and GitHub check-runs before retrying CI. ", 20),
+				"## Database Migration Runbook",
+				strings.Repeat("Run the SQL migration against the database and verify rollback behavior. ", 20),
+			}, "\n\n"),
+			wantWarning:     true,
+			wantSuggestions: []string{"github-ci-recovery", "database-migration-runbook"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			check, warned := checkDoctorWorkflowPromptSize("alpha", tt.workflowPath, tt.prompt, tt.threshold)
+			if warned != tt.wantWarning {
+				t.Fatalf("warned = %t, want %t; check = %#v", warned, tt.wantWarning, check)
+			}
+			if !tt.wantWarning {
+				return
+			}
+			if check.Status != doctorWarn || !strings.Contains(check.Name, "workflow lint prompt size") {
+				t.Fatalf("check = %#v, want workflow lint warning", check)
+			}
+			if !strings.Contains(check.Detail, "above the 100-token threshold") || !strings.Contains(check.Hint, "existing skill-creation flow") {
+				t.Fatalf("check = %#v, want threshold and skill-creation guidance", check)
+			}
+			got := make(map[string]bool, len(check.WorkflowSkillSuggestions))
+			for _, suggestion := range check.WorkflowSkillSuggestions {
+				got[suggestion.SkillName] = true
+				if suggestion.Heading == "" || suggestion.EstimatedTokens <= 0 {
+					t.Fatalf("suggestion = %#v, want heading and token estimate", suggestion)
+				}
+			}
+			for _, want := range tt.wantSuggestions {
+				if !got[want] || !strings.Contains(check.Detail, ".detent/skills/"+want+".md") {
+					t.Fatalf("suggestions = %#v, detail = %q, want %q", check.WorkflowSkillSuggestions, check.Detail, want)
+				}
+			}
+		})
+	}
+}
+
+func TestDoctorWorkflowTokenThresholdFlag(t *testing.T) {
+	t.Parallel()
+
+	configPath := ""
+	env := ""
+	logLevel := ""
+	host := ""
+	port := -1
+	cmd := newDoctorCommand(&configPath, &env, &logLevel, &host, &port, options{})
+	flag := cmd.Flags().Lookup("workflow-token-threshold")
+	if flag == nil {
+		t.Fatal("workflow-token-threshold flag is missing")
+	}
+	if flag.DefValue != "4000" {
+		t.Fatalf("workflow-token-threshold default = %q, want 4000", flag.DefValue)
+	}
+}


### PR DESCRIPTION
## Summary

- warn when a loaded WORKFLOW.md prompt body exceeds a configurable estimated-token threshold
- suggest non-overlapping domain-specific sections as reviewed lazy skill candidates without rewriting the workflow
- document the 4,000-token default and thin-core/lazy-skills authoring convention

Fixes #1401

## UI Surface Contract

- [x] N/A, or the linked issue explicitly authorizes any high-impact UI surface, layout, density, first-viewport, or responsive visibility tradeoff.
- [x] Persistent top-of-screen messaging is explicitly authorized by the issue, or this PR does not add it.
- [x] Visual changes to primary operator screens include screenshot or browser verification below. N/A: no UI changes.

## Test Plan

- [x] `go test ./internal/cli`
- [x] `make check`