### PR TITLE
fix(orchestrator): release continuation claims

### DIFF
--- a/.detent/skills/worker-process-lifecycle.md
+++ b/.detent/skills/worker-process-lifecycle.md
@@ -1,7 +1,7 @@
 ---
 name: worker-process-lifecycle
-description: Preserve Detent ownership of paid worker process trees across forced shutdowns and restarts.
-when_to_use: Use when changing Codex or Claude process launch, cancellation, shutdown, startup recovery, or session persistence.
+description: Preserve Detent ownership of paid worker process trees and release it correctly across completion, shutdown, and restart.
+when_to_use: Use when changing Codex or Claude process launch, completion, cancellation, shutdown, startup recovery, retry scheduling, or session persistence.
 ---
 
 # Worker process lifecycle
@@ -12,5 +12,6 @@ when_to_use: Use when changing Codex or Claude process launch, cancellation, shu
 - Validate PID and start time before signaling a recovered process record so PID reuse cannot terminate an unrelated process.
 - On forced shutdown or startup recovery, send SIGTERM to the process group, wait for the bounded grace period, then send SIGKILL and verify the group exited.
 - Give each worker turn a Detent-owned temporary directory inside its workspace through `TMPDIR`, `TMP`, and `TEMP`. Remove it only after the provider process tree exits, remediate read-only generated-cache permissions before retrying deletion, and never infer ownership by scanning arbitrary host temp-directory prefixes.
+- Treat run completion as an ownership boundary: remove the running session and release its persisted and in-memory claim before scheduling a continuation. Represent retry pacing with retry state, and make ordinary dispatch honor a pending retry without relying on a live claim.
 - Log one INFO lifecycle decision with the issue identifier for every persisted worker record and record the reap outcome.
-- Test launch journaling, dead-parent detection with inherited output descriptors, stale-identity refusal, process-group escalation, startup recovery, drain-timeout cleanup, provider temp-environment propagation, and read-only scratch cleanup without signaling the live Detent instance.
+- Test launch journaling, dead-parent detection with inherited output descriptors, status-less active-state completion, claim release with a pending continuation, stale-identity refusal, process-group escalation, startup recovery, drain-timeout cleanup, provider temp-environment propagation, and read-only scratch cleanup without signaling the live Detent instance.

--- a/internal/orchestrator/claim_test.go
+++ b/internal/orchestrator/claim_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/digitaldrywood/detent/internal/connector"
+	runpkg "github.com/digitaldrywood/detent/internal/runner"
 	"github.com/digitaldrywood/detent/internal/selector"
 )
 
@@ -174,6 +175,44 @@ func TestClaimingHeartbeatKeepsActiveLeaseFromReclaim(t *testing.T) {
 	}
 	if _, ok := betaState.Running[issue.ID]; ok {
 		t.Fatalf("beta Running[%q] present", issue.ID)
+	}
+}
+
+func TestSuccessfulContinuationReleasesClaimLease(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 7, 17, 14, 0, 0, 0, time.UTC)
+	issue := claimTestIssue("issue-continuation")
+	issue.State = "Rework"
+	issue.Fields["Detent Lease"] = now.Add(-time.Minute).Format(time.RFC3339Nano)
+	claimStore := newClaimTestStore([]connector.Issue{issue})
+	cfg := normalizeConfig(claimTestConfig("alpha", "alpha"))
+	cfg.ActiveStates = normalizedStates([]string{"Rework"})
+	cfg.ContinuationRetryDelay = time.Minute
+	orch := Orchestrator{
+		cfg:       cfg,
+		connector: claimTestConnector{store: claimStore, login: "alpha"},
+	}
+	state := newState(cfg)
+	state.Running[issue.ID] = Running{Issue: issue, StartedAt: now.Add(-time.Minute)}
+	state.Claimed[issue.ID] = Claimed{Issue: issue, ClaimedAt: now.Add(-time.Minute), Owner: "alpha"}
+
+	orch.handleRunResult(t.Context(), &state, runpkg.Completion{
+		IssueID:     issue.ID,
+		CompletedAt: now,
+		Result:      runpkg.RunResult{FinalState: runpkg.FinalStateCompleted},
+	})
+
+	if got := claimStore.issue(issue.ID).Fields["Detent Lease"]; got != "" {
+		t.Fatalf("Detent Lease = %q, want released", got)
+	}
+	if _, ok := state.Claimed[issue.ID]; ok {
+		t.Fatalf("Claimed[%q] present after continuation completion", issue.ID)
+	}
+	if retry, ok := state.Retry[issue.ID]; !ok {
+		t.Fatalf("Retry[%q] missing after continuation completion", issue.ID)
+	} else if want := now.Add(time.Minute); !retry.DueAt.Equal(want) {
+		t.Fatalf("Retry[%q].DueAt = %s, want %s", issue.ID, retry.DueAt, want)
 	}
 }
 

--- a/internal/orchestrator/dispatch_planner.go
+++ b/internal/orchestrator/dispatch_planner.go
@@ -499,6 +499,7 @@ const (
 	dispatchSkipUnauthorized             = "unauthorized"
 	dispatchSkipBlockedByDependency      = "blocked_by_dependency"
 	dispatchSkipAlreadyRunning           = "already_running"
+	dispatchSkipRetryPending             = "retry_pending"
 	dispatchSkipAlreadyClaimed           = "already_claimed"
 	dispatchSkipBlocked                  = "blocked"
 	dispatchSkipBudgetCooldown           = "budget_cooldown"
@@ -560,6 +561,9 @@ func (p dispatchPlanner) dispatchableIssueDecision(
 	}
 	if _, ok := state.Running[issue.ID]; ok {
 		return dispatchableDecision{reason: dispatchSkipAlreadyRunning}
+	}
+	if _, ok := state.Retry[issue.ID]; ok {
+		return dispatchableDecision{reason: dispatchSkipRetryPending}
 	}
 	if _, ok := state.Claimed[issue.ID]; ok && !allowClaimed {
 		return dispatchableDecision{reason: dispatchSkipAlreadyClaimed}

--- a/internal/orchestrator/dispatch_test.go
+++ b/internal/orchestrator/dispatch_test.go
@@ -363,6 +363,15 @@ func TestDispatchableFiltersIneligibleCandidates(t *testing.T) {
 			want: false,
 		},
 		{
+			name:  "scheduled retry",
+			issue: dispatchTestIssue("issue-retry", "Todo"),
+			state: func(state State) {
+				issue := dispatchTestIssue("issue-retry", "Todo")
+				state.Retry[issue.ID] = Retry{Issue: issue, DueAt: now.Add(time.Minute)}
+			},
+			want: false,
+		},
+		{
 			name:  "already blocked",
 			issue: dispatchTestIssue("issue-blocked", "Todo"),
 			state: func(state State) {

--- a/internal/orchestrator/local_sqlite_e2e_test.go
+++ b/internal/orchestrator/local_sqlite_e2e_test.go
@@ -232,6 +232,68 @@ func TestLocalSQLiteArtifactLifecycleEndToEnd(t *testing.T) {
 	}
 }
 
+func TestLocalSQLiteStatuslessCompletionReleasesClaimAndSchedulesRetry(t *testing.T) {
+	t.Parallel()
+
+	seed := connector.NewIssue()
+	seed.ID = "wi-artifact-statusless"
+	seed.Identifier = "wi-artifact-statusless"
+	seed.Title = "Recut launch video"
+	seed.State = "Rework"
+	seed.Fields = map[string]string{"render_status": "recut"}
+	seed.Deliverable = &connector.Deliverable{Kind: "artifact"}
+
+	tracker, err := local.New(local.Config{
+		Path:           filepath.Join(t.TempDir(), "artifact-statusless.db"),
+		ProjectID:      "digitaldrywood-video",
+		Issues:         []connector.Issue{seed},
+		ActiveStates:   []string{"Todo", "Production", "Rework"},
+		ObservedStates: []string{"Backlog", "Review", "Blocked"},
+		TerminalStates: []string{"Ready for Pickup", "Done", "Cancelled"},
+	})
+	if err != nil {
+		t.Fatalf("local.New() error = %v", err)
+	}
+	t.Cleanup(func() {
+		if err := tracker.Close(); err != nil {
+			t.Errorf("Close() error = %v", err)
+		}
+	})
+
+	runner := &staticRunner{result: orchestrator.RunResult{FinalState: orchestrator.FinalStateCompleted}}
+	orch, err := orchestrator.New(orchestrator.Config{
+		PollInterval:           time.Millisecond,
+		MaxConcurrentAgents:    1,
+		ActiveStates:           []string{"Todo", "Production", "Rework"},
+		ObservedStates:         []string{"Backlog", "Review", "Blocked"},
+		TerminalStates:         []string{"Ready for Pickup", "Done", "Cancelled"},
+		ContinuationRetryDelay: time.Hour,
+	}, orchestrator.Dependencies{
+		Connector: tracker,
+		Runner:    runner,
+	})
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	stop := runOrchestrator(t, orch)
+	t.Cleanup(stop)
+
+	state := waitForState(t, orch, func(state orchestrator.State) bool {
+		_, completed := state.Completed[seed.ID]
+		_, retry := state.Retry[seed.ID]
+		return completed && retry
+	})
+	if _, ok := state.Running[seed.ID]; ok {
+		t.Fatalf("Running[%q] present after completed run", seed.ID)
+	}
+	if _, ok := state.Claimed[seed.ID]; ok {
+		t.Fatalf("Claimed[%q] present after completed run", seed.ID)
+	}
+	if got := runner.calls.Load(); got != 1 {
+		t.Fatalf("runner calls = %d, want 1 before retry is due", got)
+	}
+}
+
 func TestLocalSQLiteArtifactReworkUsesConfiguredStatusField(t *testing.T) {
 	t.Parallel()
 

--- a/internal/orchestrator/orchestrator_test.go
+++ b/internal/orchestrator/orchestrator_test.go
@@ -63,8 +63,8 @@ func TestRunDispatchesCandidateAndRecordsCompletion(t *testing.T) {
 	if got := runner.calls.Load(); got != 1 {
 		t.Fatalf("runner calls = %d, want 1", got)
 	}
-	if _, ok := state.Claimed[issue.ID]; !ok {
-		t.Fatalf("Claimed[%q] missing", issue.ID)
+	if _, ok := state.Claimed[issue.ID]; ok {
+		t.Fatalf("Claimed[%q] present after completed run", issue.ID)
 	}
 	if got := state.Completed[issue.ID].FinalState; got != "Human Review" {
 		t.Fatalf("Completed[%q].FinalState = %q, want Human Review", issue.ID, got)

--- a/internal/orchestrator/run_completion.go
+++ b/internal/orchestrator/run_completion.go
@@ -403,7 +403,7 @@ func (o *Orchestrator) handleRunResult(ctx context.Context, state *State, event 
 		delete(state.PriorAttempts, event.IssueID)
 		return
 	}
-	o.scheduleRetry(state, running.Issue, 1, event.CompletedAt, "", true, running.WorkerHost)
+	o.scheduleContinuationRetry(ctx, state, running.Issue, 1, event.CompletedAt, "", running.WorkerHost)
 }
 
 func (o *Orchestrator) completeRedundantGateWaitRun(
@@ -1789,6 +1789,26 @@ func (o *Orchestrator) scheduleRetry(
 	workerHost string,
 ) {
 	o.dispatchPlanner().scheduleRetry(state, issue, attempt, now, err, continuation, workerHost)
+}
+
+func (o *Orchestrator) scheduleContinuationRetry(
+	ctx context.Context,
+	state *State,
+	issue connector.Issue,
+	attempt int,
+	now time.Time,
+	err string,
+	workerHost string,
+) {
+	if releaseErr := o.abandonClaim(ctx, issue.ID); releaseErr != nil {
+		recordStateEvent(state, telemetry.ActivityEvent{
+			At:      cleanupEventAt(now),
+			Event:   "claim_release_failed",
+			Message: fmt.Sprintf("claim lease release failed for %s: %v", issueLabel(issue), releaseErr),
+		})
+	}
+	o.scheduleRetry(state, issue, attempt, now, err, true, workerHost)
+	delete(state.Claimed, issue.ID)
 }
 
 func (o *Orchestrator) scheduleRetryAfter(


### PR DESCRIPTION
## Summary

- Release persisted and in-memory claims when a successful run remains active and queues a continuation, preventing phantom worker ownership.
- Keep the continuation delay authoritative through retry state and block ordinary redispatch until the retry is due.
- Cover status-less local SQLite artifact completion and lease release, and preserve the lifecycle invariant in worker guidance.

Fixes #1407

## UI Surface Contract

- [x] N/A — this PR does not change UI surfaces, layout, density, or responsive visibility.
- [x] This PR does not add persistent top-of-screen messaging.
- [x] N/A — this PR has no visual changes to primary operator screens.

## Test Plan

- [x] `make check`
- [x] Focused orchestrator regression tests and focused race tests.
- [x] Confirmed the local SQLite regression test fails on unmodified `origin/main` because the completed item remains claimed.
