### PR TITLE
test(config): stabilize watcher debounce tests

### DIFF
--- a/.detent/skills/deterministic-debounce-testing.md
+++ b/.detent/skills/deterministic-debounce-testing.md
@@ -1,0 +1,14 @@
+---
+name: deterministic-debounce-testing
+description: Stabilize debounce coalescing tests by controlling event delivery and timer expiry without weakening assertions.
+when_to_use: Use when scheduler pressure lets a real debounce timer expire between back-to-back test actions, especially under race or concurrent suites.
+---
+
+# Test debounce coalescing deterministically
+
+- Confirm the intermediate value matches the observed failure before treating the problem as test timing rather than production behavior.
+- Inject private event-source and timer factories while keeping production defaults unchanged. Preserve real event-source integration coverage in separate tests.
+- Give the controlled timer observable reset acknowledgements and an explicit fire operation. Use bounded real-time deadlines only to detect a stuck test, never to arrange the debounce cycle.
+- Write the first value, deliver its matching event, and wait for the first timer reset. Write the second value, deliver its event, and wait for the second reset. Fire the timer exactly once.
+- Assert the first delivered update contains the second value and that no additional update follows. Never drain and ignore intermediate updates because that stops testing coalescing.
+- Run the focused test repeatedly with the race detector, then run the repository's full validation gate.

--- a/internal/config/watcher/file.go
+++ b/internal/config/watcher/file.go
@@ -27,24 +27,53 @@ type FileUpdate[T any] struct {
 type FileOption func(*fileOptions)
 
 type FileWatcher[T any] struct {
-	path     string
-	files    []watchedFile
-	dirs     []string
-	debounce time.Duration
-	loader   FileLoader[T]
-	logger   *slog.Logger
+	path       string
+	files      []watchedFile
+	dirs       []string
+	debounce   time.Duration
+	loader     FileLoader[T]
+	logger     *slog.Logger
+	newWatcher fileWatcherFactory
+	newTimer   fileTimerFactory
 }
 
 type fileOptions struct {
 	debounce   time.Duration
 	logger     *slog.Logger
 	watchPaths []string
+	newWatcher fileWatcherFactory
+	newTimer   fileTimerFactory
 }
 
 type watchedFile struct {
 	path   string
 	target string
 }
+
+type fileEventWatcher interface {
+	Add(string) error
+	Close() error
+	Events() <-chan fsnotify.Event
+	Errors() <-chan error
+}
+
+type fsnotifyEventWatcher struct {
+	watcher *fsnotify.Watcher
+}
+
+type fileWatcherFactory func() (fileEventWatcher, error)
+
+type fileTimer interface {
+	C() <-chan time.Time
+	Reset(time.Duration) bool
+	Stop() bool
+}
+
+type standardFileTimer struct {
+	timer *time.Timer
+}
+
+type fileTimerFactory func(time.Duration) fileTimer
 
 func NewFile[T any](path string, loader FileLoader[T], opts ...FileOption) (*FileWatcher[T], error) {
 	path = strings.TrimSpace(path)
@@ -61,8 +90,12 @@ func NewFile[T any](path string, loader FileLoader[T], opts ...FileOption) (*Fil
 	}
 
 	cfg := fileOptions{
-		debounce: defaultDebounce,
-		logger:   slog.Default(),
+		debounce:   defaultDebounce,
+		logger:     slog.Default(),
+		newWatcher: newFileEventWatcher,
+		newTimer: func(duration time.Duration) fileTimer {
+			return &standardFileTimer{timer: time.NewTimer(duration)}
+		},
 	}
 	for _, opt := range opts {
 		opt(&cfg)
@@ -72,6 +105,14 @@ func NewFile[T any](path string, loader FileLoader[T], opts ...FileOption) (*Fil
 	}
 	if cfg.logger == nil {
 		cfg.logger = slog.Default()
+	}
+	if cfg.newWatcher == nil {
+		cfg.newWatcher = newFileEventWatcher
+	}
+	if cfg.newTimer == nil {
+		cfg.newTimer = func(duration time.Duration) fileTimer {
+			return &standardFileTimer{timer: time.NewTimer(duration)}
+		}
 	}
 
 	path = filepath.Clean(absolute)
@@ -99,13 +140,58 @@ func NewFile[T any](path string, loader FileLoader[T], opts ...FileOption) (*Fil
 	}
 
 	return &FileWatcher[T]{
-		path:     path,
-		files:    files,
-		dirs:     watchDirs(watchPaths...),
-		debounce: cfg.debounce,
-		loader:   loader,
-		logger:   cfg.logger,
+		path:       path,
+		files:      files,
+		dirs:       watchDirs(watchPaths...),
+		debounce:   cfg.debounce,
+		loader:     loader,
+		logger:     cfg.logger,
+		newWatcher: cfg.newWatcher,
+		newTimer:   cfg.newTimer,
 	}, nil
+}
+
+func newFileEventWatcher() (fileEventWatcher, error) {
+	watcher, err := fsnotify.NewWatcher()
+	if err != nil {
+		return nil, err
+	}
+	return &fsnotifyEventWatcher{watcher: watcher}, nil
+}
+
+func (w *fsnotifyEventWatcher) Add(path string) error {
+	return w.watcher.Add(path)
+}
+
+func (w *fsnotifyEventWatcher) Close() error {
+	return w.watcher.Close()
+}
+
+func (w *fsnotifyEventWatcher) Events() <-chan fsnotify.Event {
+	return w.watcher.Events
+}
+
+func (w *fsnotifyEventWatcher) Errors() <-chan error {
+	return w.watcher.Errors
+}
+
+func (t *standardFileTimer) C() <-chan time.Time {
+	return t.timer.C
+}
+
+func (t *standardFileTimer) Reset(duration time.Duration) bool {
+	return t.timer.Reset(duration)
+}
+
+func (t *standardFileTimer) Stop() bool {
+	return t.timer.Stop()
+}
+
+func withFileRuntime(newWatcher fileWatcherFactory, newTimer fileTimerFactory) FileOption {
+	return func(opts *fileOptions) {
+		opts.newWatcher = newWatcher
+		opts.newTimer = newTimer
+	}
 }
 
 func watchDirs(paths ...string) []string {
@@ -152,7 +238,7 @@ func (w *FileWatcher[T]) Watch(ctx context.Context) (<-chan FileUpdate[T], error
 		ctx = context.Background()
 	}
 
-	fsWatcher, err := fsnotify.NewWatcher()
+	fsWatcher, err := w.newWatcher()
 	if err != nil {
 		return nil, fmt.Errorf("create config watcher: %w", err)
 	}
@@ -168,7 +254,7 @@ func (w *FileWatcher[T]) Watch(ctx context.Context) (<-chan FileUpdate[T], error
 	return updates, nil
 }
 
-func (w *FileWatcher[T]) run(ctx context.Context, fsWatcher *fsnotify.Watcher, updates chan<- FileUpdate[T]) {
+func (w *FileWatcher[T]) run(ctx context.Context, fsWatcher fileEventWatcher, updates chan<- FileUpdate[T]) {
 	defer close(updates)
 	defer func() {
 		if err := fsWatcher.Close(); err != nil {
@@ -176,9 +262,9 @@ func (w *FileWatcher[T]) run(ctx context.Context, fsWatcher *fsnotify.Watcher, u
 		}
 	}()
 
-	timer := time.NewTimer(w.debounce)
+	timer := w.newTimer(w.debounce)
 	if !timer.Stop() {
-		<-timer.C
+		<-timer.C()
 	}
 	var timerC <-chan time.Time
 	var lastUpdate *FileUpdate[T]
@@ -187,16 +273,16 @@ func (w *FileWatcher[T]) run(ctx context.Context, fsWatcher *fsnotify.Watcher, u
 		select {
 		case <-ctx.Done():
 			return
-		case event, ok := <-fsWatcher.Events:
+		case event, ok := <-fsWatcher.Events():
 			if !ok {
 				return
 			}
 			if w.matches(event) {
 				w.refreshWatchPath(fsWatcher.Add)
 				resetTimer(timer, w.debounce)
-				timerC = timer.C
+				timerC = timer.C()
 			}
-		case err, ok := <-fsWatcher.Errors:
+		case err, ok := <-fsWatcher.Errors():
 			if !ok {
 				return
 			}

--- a/internal/config/watcher/watcher.go
+++ b/internal/config/watcher/watcher.go
@@ -33,9 +33,10 @@ type Watcher struct {
 }
 
 type options struct {
-	debounce time.Duration
-	loader   Loader
-	logger   *slog.Logger
+	debounce    time.Duration
+	loader      Loader
+	logger      *slog.Logger
+	fileOptions []FileOption
 }
 
 func New(path string, opts ...Option) (*Watcher, error) {
@@ -63,7 +64,11 @@ func New(path string, opts ...Option) (*Watcher, error) {
 			err = workflow.Config.Validate()
 		}
 		return workflow, err
-	}, WithFileDebounce(cfg.debounce), WithFileLogger(cfg.logger), WithFileWatchPaths(workflowconfig.LocalWorkflowPath(path)))
+	}, append([]FileOption{
+		WithFileDebounce(cfg.debounce),
+		WithFileLogger(cfg.logger),
+		WithFileWatchPaths(workflowconfig.LocalWorkflowPath(path)),
+	}, cfg.fileOptions...)...)
 	if err != nil {
 		return nil, err
 	}
@@ -86,6 +91,12 @@ func WithLoader(loader Loader) Option {
 func WithLogger(logger *slog.Logger) Option {
 	return func(opts *options) {
 		opts.logger = logger
+	}
+}
+
+func withFileOptions(fileOptions ...FileOption) Option {
+	return func(opts *options) {
+		opts.fileOptions = append(opts.fileOptions, fileOptions...)
 	}
 }
 
@@ -127,10 +138,10 @@ func retryInterval(debounce time.Duration) time.Duration {
 	return reloadRetryInterval
 }
 
-func resetTimer(timer *time.Timer, debounce time.Duration) {
+func resetTimer(timer fileTimer, debounce time.Duration) {
 	if !timer.Stop() {
 		select {
-		case <-timer.C:
+		case <-timer.C():
 		default:
 		}
 	}

--- a/internal/config/watcher/watcher_test.go
+++ b/internal/config/watcher/watcher_test.go
@@ -11,6 +11,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/fsnotify/fsnotify"
+
 	workflowconfig "github.com/digitaldrywood/detent/internal/config"
 	globalconfig "github.com/digitaldrywood/detent/internal/config/global"
 )
@@ -18,12 +20,12 @@ import (
 func TestWatchDebouncesWorkflowWrites(t *testing.T) {
 	t.Parallel()
 
-	debounce := 150 * time.Millisecond
+	runtime := newControlledFileRuntime()
 	dir := t.TempDir()
 	path := filepath.Join(dir, "WORKFLOW.md")
 	writeWorkflow(t, path, 60000, "initial")
 
-	w, err := New(path, WithDebounce(debounce))
+	w, err := New(path, withFileOptions(runtime.option()))
 	if err != nil {
 		t.Fatalf("New() error = %v", err)
 	}
@@ -37,7 +39,12 @@ func TestWatchDebouncesWorkflowWrites(t *testing.T) {
 	}
 
 	writeWorkflow(t, path, 61000, "first")
+	runtime.sendEvent(t, path)
+	runtime.waitForReset(t)
 	writeWorkflow(t, path, 62000, "second")
+	runtime.sendEvent(t, path)
+	runtime.waitForReset(t)
+	runtime.fire(t)
 
 	update := receiveUpdate(t, updates)
 	if update.Err != nil {
@@ -50,11 +57,7 @@ func TestWatchDebouncesWorkflowWrites(t *testing.T) {
 		t.Fatalf("Prompt = %q, want second", update.Workflow.Prompt)
 	}
 
-	select {
-	case extra := <-updates:
-		t.Fatalf("extra update after debounce = %#v", extra)
-	case <-time.After(2 * debounce):
-	}
+	assertNoUpdate(t, updates)
 }
 
 func TestWatchSuppressesDuplicateWorkflowUpdates(t *testing.T) {
@@ -296,13 +299,14 @@ func TestWatchSurvivesSharedWorkflowDeletionAndCreation(t *testing.T) {
 func TestFileWatcherDebouncesGlobalConfigWrites(t *testing.T) {
 	t.Parallel()
 
+	runtime := newControlledFileRuntime()
 	dir := t.TempDir()
 	path := filepath.Join(dir, "global.yaml")
 	writeGlobalConfig(t, path, 2)
 
 	w, err := NewFile(path, func(path string) (globalconfig.Config, error) {
 		return globalconfig.Read(path)
-	}, WithFileDebounce(150*time.Millisecond))
+	}, runtime.option())
 	if err != nil {
 		t.Fatalf("NewFile() error = %v", err)
 	}
@@ -316,7 +320,12 @@ func TestFileWatcherDebouncesGlobalConfigWrites(t *testing.T) {
 	}
 
 	writeGlobalConfig(t, path, 3)
+	runtime.sendEvent(t, path)
+	runtime.waitForReset(t)
 	writeGlobalConfig(t, path, 4)
+	runtime.sendEvent(t, path)
+	runtime.waitForReset(t)
+	runtime.fire(t)
 
 	update := receiveFileUpdate(t, updates)
 	if update.Err != nil {
@@ -328,6 +337,8 @@ func TestFileWatcherDebouncesGlobalConfigWrites(t *testing.T) {
 	if update.Value.Path != path {
 		t.Fatalf("Path = %q, want %q", update.Value.Path, path)
 	}
+
+	assertNoFileUpdate(t, updates)
 }
 
 func TestFileWatcherWatchesSymlinkTargetWrites(t *testing.T) {
@@ -500,6 +511,114 @@ func receiveFileUpdate[T any](t *testing.T, updates <-chan FileUpdate[T]) FileUp
 	}
 
 	return FileUpdate[T]{}
+}
+
+func assertNoUpdate(t *testing.T, updates <-chan Update) {
+	t.Helper()
+
+	select {
+	case extra := <-updates:
+		t.Fatalf("extra update after debounce = %#v", extra)
+	case <-time.After(25 * time.Millisecond):
+	}
+}
+
+func assertNoFileUpdate[T any](t *testing.T, updates <-chan FileUpdate[T]) {
+	t.Helper()
+
+	select {
+	case extra := <-updates:
+		t.Fatalf("extra update after debounce = %#v", extra)
+	case <-time.After(25 * time.Millisecond):
+	}
+}
+
+type controlledFileRuntime struct {
+	events chan fsnotify.Event
+	errors chan error
+	timer  *controlledFileTimer
+}
+
+type controlledFileTimer struct {
+	ticks  chan time.Time
+	resets chan time.Duration
+}
+
+func newControlledFileRuntime() *controlledFileRuntime {
+	return &controlledFileRuntime{
+		events: make(chan fsnotify.Event, 2),
+		errors: make(chan error),
+		timer: &controlledFileTimer{
+			ticks:  make(chan time.Time, 1),
+			resets: make(chan time.Duration, 2),
+		},
+	}
+}
+
+func (r *controlledFileRuntime) option() FileOption {
+	return withFileRuntime(
+		func() (fileEventWatcher, error) { return r, nil },
+		func(time.Duration) fileTimer { return r.timer },
+	)
+}
+
+func (r *controlledFileRuntime) Add(string) error {
+	return nil
+}
+
+func (r *controlledFileRuntime) Close() error {
+	return nil
+}
+
+func (r *controlledFileRuntime) Events() <-chan fsnotify.Event {
+	return r.events
+}
+
+func (r *controlledFileRuntime) Errors() <-chan error {
+	return r.errors
+}
+
+func (r *controlledFileRuntime) sendEvent(t *testing.T, path string) {
+	t.Helper()
+
+	select {
+	case r.events <- fsnotify.Event{Name: path, Op: fsnotify.Write}:
+	case <-time.After(time.Second):
+		t.Fatal("timed out sending file event")
+	}
+}
+
+func (r *controlledFileRuntime) waitForReset(t *testing.T) {
+	t.Helper()
+
+	select {
+	case <-r.timer.resets:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for debounce reset")
+	}
+}
+
+func (r *controlledFileRuntime) fire(t *testing.T) {
+	t.Helper()
+
+	select {
+	case r.timer.ticks <- time.Now():
+	case <-time.After(time.Second):
+		t.Fatal("timed out firing debounce timer")
+	}
+}
+
+func (t *controlledFileTimer) C() <-chan time.Time {
+	return t.ticks
+}
+
+func (t *controlledFileTimer) Reset(duration time.Duration) bool {
+	t.resets <- duration
+	return true
+}
+
+func (t *controlledFileTimer) Stop() bool {
+	return true
 }
 
 func writeWorkflow(t *testing.T, path string, intervalMS int, prompt string) {


### PR DESCRIPTION
## Summary

- inject private file-event and debounce-timer factories while preserving production defaults
- drive both debounce tests with two synchronized events and one controlled expiry
- assert the first update contains the second write and no additional update follows
- add a reusable deterministic debounce testing skill draft

Fixes #1395

## UI Surface Contract

- [x] N/A, or the linked issue explicitly authorizes any high-impact UI surface, layout, density, first-viewport, or responsive visibility tradeoff.
- [x] Persistent top-of-screen messaging is explicitly authorized by the issue, or this PR does not add it.
- [x] Visual changes to primary operator screens include screenshot or browser verification below.

No UI changes.

## Test Plan

- [x] Focused watcher debounce race tests, 20 counts
- [x] Full watcher package race tests
- [x] `make check`