### PR TITLE
test(cli): stop kanban demo cleanup race

### DIFF
--- a/internal/cli/boot.go
+++ b/internal/cli/boot.go
@@ -154,7 +154,17 @@ func defaultBoot(ctx context.Context, cfg BootConfig) error {
 	}
 }
 
+type startRunningDependencies struct {
+	boardSnapshotStore    boardsnapshot.Store
+	boardSnapshotInterval time.Duration
+	backgroundWaitStarted func()
+}
+
 func startRunning(ctx context.Context, cfg BootConfig) error {
+	return startRunningWithDependencies(ctx, cfg, startRunningDependencies{})
+}
+
+func startRunningWithDependencies(ctx context.Context, cfg BootConfig, deps startRunningDependencies) error {
 	if ctx == nil {
 		ctx = context.Background()
 	}
@@ -284,6 +294,14 @@ func startRunning(ctx context.Context, cfg BootConfig) error {
 	if err != nil {
 		return err
 	}
+	defer func() {
+		stop()
+		for _, runtimeProject := range manager.Registry().List() {
+			if err := runtimeProject.Close(); err != nil {
+				logger.Warn("close runtime project failed", "project_id", runtimeProject.ID(), "error", err)
+			}
+		}
+	}()
 	globalWatcherStarted := make(chan (<-chan struct{}), 1)
 	defer func() {
 		stop()
@@ -306,12 +324,15 @@ func startRunning(ctx context.Context, cfg BootConfig) error {
 	if err != nil {
 		return err
 	}
-	boardSnapshotStore, err := boardsnapshot.New(boardsnapshot.Config{
-		Path:   runtimeBoardSnapshotPath(cfg),
-		MaxAge: time.Duration(kanbanWorkflow.Server.BoardSnapshotStaleAfterSeconds) * time.Second,
-	})
-	if err != nil {
-		return err
+	boardSnapshotStore := deps.boardSnapshotStore
+	if boardSnapshotStore == nil {
+		boardSnapshotStore, err = boardsnapshot.New(boardsnapshot.Config{
+			Path:   runtimeBoardSnapshotPath(cfg),
+			MaxAge: time.Duration(kanbanWorkflow.Server.BoardSnapshotStaleAfterSeconds) * time.Second,
+		})
+		if err != nil {
+			return err
+		}
 	}
 	cachedSnapshot, cached, loadErr := boardSnapshotStore.Load(runCtx)
 	if loadErr != nil {
@@ -325,9 +346,21 @@ func startRunning(ctx context.Context, cfg BootConfig) error {
 		return err
 	}
 	chatProvider := buildChatProvider(manager.Registry(), logger)
-	go publishSnapshots(runCtx, manager.Registry(), snapshotHub, snapshotSeq, runtimeStore, displayURL, defaultSnapshotInterval, time.Now, updateScheduler)
-	go republishSnapshotsOnProjectEvents(runCtx, events, snapshotHub, logger)                               // #nosec G118 -- runCtx is the service-lifetime context canceled during shutdown.
-	go persistBoardSnapshots(runCtx, snapshotHub, boardSnapshotStore, defaultBoardSnapshotInterval, logger) // #nosec G118 -- runCtx is the service-lifetime context canceled during shutdown.
+	var resourceWorkers sync.WaitGroup
+	defer func() {
+		stop()
+		if deps.backgroundWaitStarted != nil {
+			deps.backgroundWaitStarted()
+		}
+		resourceWorkers.Wait()
+	}()
+	resourceWorkers.Go(func() {
+		publishSnapshots(runCtx, manager.Registry(), snapshotHub, snapshotSeq, runtimeStore, displayURL, defaultSnapshotInterval, time.Now, updateScheduler)
+	})
+	go republishSnapshotsOnProjectEvents(runCtx, events, snapshotHub, logger) // #nosec G118 -- runCtx is the service-lifetime context canceled during shutdown.
+	resourceWorkers.Go(func() {
+		persistBoardSnapshots(runCtx, snapshotHub, boardSnapshotStore, deps.boardSnapshotInterval, logger)
+	})
 	//nolint:contextcheck // Echo middleware receives request contexts at serve time.
 	server, err := web.NewServer(web.Config{
 		Mode:               web.ModeRunning,

--- a/internal/cli/dev_runtime_e2e_test.go
+++ b/internal/cli/dev_runtime_e2e_test.go
@@ -15,6 +15,7 @@ import (
 	"time"
 
 	"github.com/digitaldrywood/detent/internal/devruntime"
+	"github.com/digitaldrywood/detent/internal/telemetry"
 )
 
 func TestStartIsolatedRuntimeAutoPromotesFixtureAndStopsOnCancel(t *testing.T) {
@@ -65,10 +66,19 @@ func TestStartKanbanDemoRendersAndAppliesSafeActions(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	output := &lockedBuffer{}
 	done := make(chan error, 1)
+	runtimeDone := make(chan struct{})
 	go func() {
 		done <- startRunning(ctx, devRuntimeBootConfig(runtime, "127.0.0.1", defaultOptions(), output))
+		close(runtimeDone)
 	}()
-	t.Cleanup(cancel)
+	t.Cleanup(func() {
+		cancel()
+		select {
+		case <-runtimeDone:
+		case <-time.After(10 * time.Second):
+			t.Error("timed out waiting for isolated runtime cleanup")
+		}
+	})
 
 	dashboardURL := waitForIsolatedRuntimeURL(t, output, done)
 	if banner := output.String(); !strings.Contains(banner, "Demo: kanban") {
@@ -182,6 +192,74 @@ func TestStartKanbanDemoRendersAndAppliesSafeActions(t *testing.T) {
 	}
 }
 
+func TestStartRunningWaitsForBoardSnapshotPersistence(t *testing.T) {
+	runtime, err := devruntime.Build(devruntime.Config{Home: t.TempDir(), Port: 0, Demo: devruntime.DemoKanban})
+	if err != nil {
+		t.Fatalf("devruntime.Build() error = %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	output := &lockedBuffer{}
+	store := newBlockingBoardSnapshotStore()
+	backgroundWaitStarted := make(chan struct{})
+	done := make(chan struct{})
+	var runErr error
+	go func() {
+		runErr = startRunningWithDependencies(
+			ctx,
+			devRuntimeBootConfig(runtime, "127.0.0.1", defaultOptions(), output),
+			startRunningDependencies{
+				boardSnapshotStore:    store,
+				boardSnapshotInterval: time.Millisecond,
+				backgroundWaitStarted: func() {
+					close(backgroundWaitStarted)
+				},
+			},
+		)
+		close(done)
+	}()
+	t.Cleanup(func() {
+		cancel()
+		store.release()
+		select {
+		case <-done:
+		case <-time.After(10 * time.Second):
+			t.Error("timed out waiting for isolated runtime cleanup")
+		}
+	})
+
+	dashboardURL := waitForIsolatedRuntimeURL(t, output, nil)
+	waitForDashboard(t, dashboardURL+"/health", nil)
+	postRuntimeRefresh(t, dashboardURL, nil)
+	select {
+	case <-store.started:
+	case <-time.After(10 * time.Second):
+		t.Fatal("timed out waiting for board snapshot persistence")
+	}
+
+	cancel()
+	select {
+	case <-backgroundWaitStarted:
+	case <-time.After(10 * time.Second):
+		t.Fatal("timed out waiting for background shutdown")
+	}
+	select {
+	case <-done:
+		t.Fatalf("startRunningWithDependencies() returned before persistence completed: %v", runErr)
+	default:
+	}
+
+	store.release()
+	select {
+	case <-done:
+		if !errors.Is(runErr, context.Canceled) {
+			t.Fatalf("startRunningWithDependencies() error = %v, want %v", runErr, context.Canceled)
+		}
+	case <-time.After(10 * time.Second):
+		t.Fatal("timed out waiting for isolated runtime to stop")
+	}
+}
+
 func TestStartScreenshotsDemoServesScenarioManifestAndUsage(t *testing.T) {
 	runtime, err := devruntime.Build(devruntime.Config{Home: t.TempDir(), Port: 0, Demo: devruntime.DemoScreenshots})
 	if err != nil {
@@ -236,6 +314,38 @@ func TestStartScreenshotsDemoServesScenarioManifestAndUsage(t *testing.T) {
 type lockedBuffer struct {
 	mu  sync.Mutex
 	buf bytes.Buffer
+}
+
+type blockingBoardSnapshotStore struct {
+	started     chan struct{}
+	releaseSave chan struct{}
+	startOnce   sync.Once
+	releaseOnce sync.Once
+}
+
+func newBlockingBoardSnapshotStore() *blockingBoardSnapshotStore {
+	return &blockingBoardSnapshotStore{
+		started:     make(chan struct{}),
+		releaseSave: make(chan struct{}),
+	}
+}
+
+func (s *blockingBoardSnapshotStore) Load(context.Context) (telemetry.Snapshot, bool, error) {
+	return telemetry.Snapshot{}, false, nil
+}
+
+func (s *blockingBoardSnapshotStore) Save(context.Context, telemetry.Snapshot) error {
+	s.startOnce.Do(func() {
+		close(s.started)
+	})
+	<-s.releaseSave
+	return nil
+}
+
+func (s *blockingBoardSnapshotStore) release() {
+	s.releaseOnce.Do(func() {
+		close(s.releaseSave)
+	})
 }
 
 func (b *lockedBuffer) Write(p []byte) (int, error) {


### PR DESCRIPTION
## Summary

- join board snapshot persistence and snapshot publishing before runtime resources close
- close runtime projects before the runtime store so late lesson and store writers cannot recreate demo directories
- make kanban test cleanup always cancel and await the runtime
- add a blocked-store lifecycle regression proving shutdown waits for an in-flight save

Fixes #1408

## UI Surface Contract

- [x] N/A; this PR has no UI changes.
- [x] This PR adds no persistent top-of-screen messaging.
- [x] N/A; this PR has no visual changes.

## Test Plan

- [x] `go test -race ./internal/cli -run '^(TestStartRunningWaitsForBoardSnapshotPersistence|TestStartKanbanDemoRendersAndAppliesSafeActions)$' -count=3`
- [x] `go test -race ./internal/cli -run '^TestStartKanbanDemoRendersAndAppliesSafeActions$' -count=20`
- [x] `go test -race ./internal/cli -count=1`
- [x] `make check`