### PR TITLE
test(web): shut down API key test servers

### DIFF
--- a/internal/web/chat_test.go
+++ b/internal/web/chat_test.go
@@ -194,6 +194,13 @@ func TestChatConfirmationEnforcesAPIKeyProjectScope(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewServer() error = %v", err)
 	}
+	t.Cleanup(func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 12*time.Second)
+		defer cancel()
+		if err := server.Shutdown(ctx); err != nil {
+			t.Errorf("Shutdown() error = %v", err)
+		}
+	})
 	restrictedAuth := map[string]string{"Authorization": "Bearer " + created.Token}
 	panel := performDashboardHTMXRequest(t, server.Handler(), dashboardHTMXRequest{path: "/api/v1/chat", headers: restrictedAuth})
 	cookie := panel.Result().Cookies()[0]

--- a/internal/web/server_test.go
+++ b/internal/web/server_test.go
@@ -1376,6 +1376,13 @@ func TestAPIKeyManagementAndScopedWorkItemAccess(t *testing.T) {
 	t.Parallel()
 
 	server, backend, _, _ := newAPIKeyWorkItemTestServer(t)
+	t.Cleanup(func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 12*time.Second)
+		defer cancel()
+		if err := server.Shutdown(ctx); err != nil {
+			t.Errorf("Shutdown() error = %v", err)
+		}
+	})
 	create := performJSON(t, server.Handler(), http.MethodPost, "/api/v1/keys", `{
 		"name": "Video Studio",
 		"scopes": ["write"],
@@ -1573,6 +1580,13 @@ func TestAPIUsageLogRecordsReturnedHTTPErrorStatus(t *testing.T) {
 	t.Parallel()
 
 	server, backend, _, _ := newAPIKeyWorkItemTestServer(t)
+	t.Cleanup(func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 12*time.Second)
+		defer cancel()
+		if err := server.Shutdown(ctx); err != nil {
+			t.Errorf("Shutdown() error = %v", err)
+		}
+	})
 	token, keyID := createAPIKeyThroughHTTP(t, server, `{
 		"name": "Read client",
 		"scopes": ["read"],


### PR DESCRIPTION
## Summary

- shut down the chat scope test server before its SQLite store cleanup
- apply the same bounded cleanup to sibling stored API-key route tests
- preserve the existing single backend close and drain queued usage writes through `Server.Shutdown`

Fixes #1410

## UI Surface Contract

- [x] N/A, or the linked issue explicitly authorizes any high-impact UI surface, layout, density, first-viewport, or responsive visibility tradeoff.
- [x] Persistent top-of-screen messaging is explicitly authorized by the issue, or this PR does not add it.
- [x] Visual changes to primary operator screens include screenshot or browser verification below. N/A: test-only lifecycle cleanup.

## Test Plan

- [x] `go test -race ./internal/web -run '^(TestChatConfirmationEnforcesAPIKeyProjectScope|TestAPIKeyManagementAndScopedWorkItemAccess|TestAPIUsageLogRecordsReturnedHTTPErrorStatus|TestAPIUsageWritesDrainOnShutdown)$' -count=20`
- [x] `make check`