### PR TITLE
test(ci): stabilize persisted auto-promote wait

### DIFF
--- a/internal/orchestrator/autopromote_integration_test.go
+++ b/internal/orchestrator/autopromote_integration_test.go
@@ -244,7 +244,7 @@ func TestRunAutoPromoteBlocksAfterPersistedReworkLimitSurvivesRestart(t *testing
 
 	var gotStateUpdate bool
 	var gotComment bool
-	deadline := time.After(time.Second)
+	deadline := time.After(slowCIIntegrationWaitTimeout)
 	for !gotStateUpdate || !gotComment {
 		select {
 		case event := <-events:
@@ -262,7 +262,15 @@ func TestRunAutoPromoteBlocksAfterPersistedReworkLimitSurvivesRestart(t *testing
 				}
 			}
 		case <-deadline:
-			t.Fatalf("timed out waiting for Blocked auto-promote events; state_update=%v comment=%v", gotStateUpdate, gotComment)
+			timeline, timelineErr := restartedStore.IssueWorkflowTimeline(ctx, store.IssueIdentity{IssueID: issue.ID})
+			t.Fatalf(
+				"timed out waiting for Blocked auto-promote events; state_update=%v comment=%v tracker_events=%#v workflow_timeline=%#v workflow_timeline_error=%v",
+				gotStateUpdate,
+				gotComment,
+				tracker.Events(),
+				timeline.Events,
+				timelineErr,
+			)
 		}
 	}
 }

--- a/internal/orchestrator/orchestrator_test.go
+++ b/internal/orchestrator/orchestrator_test.go
@@ -24,6 +24,8 @@ import (
 	"github.com/digitaldrywood/detent/internal/telemetry"
 )
 
+const slowCIIntegrationWaitTimeout = 10 * time.Second
+
 func TestRunDispatchesCandidateAndRecordsCompletion(t *testing.T) {
 	t.Parallel()
 
@@ -2393,8 +2395,16 @@ func runOrchestrator(t *testing.T, orch *orchestrator.Orchestrator) func() {
 			if err != nil && !errors.Is(err, context.Canceled) {
 				t.Fatalf("Run() error = %v", err)
 			}
-		case <-time.After(time.Second):
-			t.Fatal("timed out waiting for Run() to stop")
+		case <-time.After(slowCIIntegrationWaitTimeout):
+			stateCtx, stateCancel := context.WithTimeout(context.Background(), time.Second)
+			state, stateErr := orch.State(stateCtx)
+			stateCancel()
+			t.Fatalf(
+				"timed out waiting for Run() to stop; state=%#v event_history=%#v state_error=%v",
+				state,
+				state.RecentEvents,
+				stateErr,
+			)
 		}
 	}
 }


### PR DESCRIPTION
## Summary

- use a shared 10-second slow-CI deadline for the persisted rework-limit event wait and orchestrator shutdown helper
- report tracker events and the persisted workflow timeline when the Blocked state or exact rework-limit comment is missing
- report the latest obtainable orchestrator state and recent event history when shutdown stalls
- preserve production state/comment/metric ordering and the existing event channel capacity

Fixes #1419

## UI Surface Contract

- [x] N/A, or the linked issue explicitly authorizes any high-impact UI surface, layout, density, first-viewport, or responsive visibility tradeoff.
- [x] Persistent top-of-screen messaging is explicitly authorized by the issue, or this PR does not add it.
- [x] Visual changes to primary operator screens include screenshot or browser verification below.

## Test Plan

- [x] `go test ./internal/orchestrator -run '^TestRunAutoPromoteBlocksAfterPersistedReworkLimitSurvivesRestart$' -count=20`
- [x] `go test -race ./internal/orchestrator -run '^TestRunAutoPromoteBlocksAfterPersistedReworkLimitSurvivesRestart$' -count=10`
- [x] `make check`
