### PR TITLE
fix(cli): isolate status dashboard port

### DIFF
--- a/internal/cli/runtime.go
+++ b/internal/cli/runtime.go
@@ -259,18 +259,22 @@ func resolveRuntimePort(ctx context.Context, input runtimeInput, deps runtimeDep
 		}
 		return RuntimeIntValue{Value: port, Source: "PORT"}, nil
 	}
+	return resolveConfiguredRuntimePort(ctx, input, deps), nil
+}
+
+func resolveConfiguredRuntimePort(ctx context.Context, input runtimeInput, deps runtimeDeps) RuntimeIntValue {
 	if input.Config != nil && input.Config.Port != nil {
-		return RuntimeIntValue{Value: *input.Config.Port, Source: runtimeSourceConfig}, nil
+		return RuntimeIntValue{Value: *input.Config.Port, Source: runtimeSourceConfig}
 	}
 	if input.Config != nil {
 		if port, ok := globalWorkflowServerPort(ctx, *input.Config, deps); ok {
-			return RuntimeIntValue{Value: port, Source: runtimeSourceWorkflow}, nil
+			return RuntimeIntValue{Value: port, Source: runtimeSourceWorkflow}
 		}
 	}
 	if port, ok := workflowServerPort(ctx, input.Workflow, deps); ok {
-		return RuntimeIntValue{Value: port, Source: runtimeSourceWorkflow}, nil
+		return RuntimeIntValue{Value: port, Source: runtimeSourceWorkflow}
 	}
-	return RuntimeIntValue{Value: defaultWebPort, Source: runtimeSourceDefault}, nil
+	return RuntimeIntValue{Value: defaultWebPort, Source: runtimeSourceDefault}
 }
 
 func globalWorkflowServerPort(ctx context.Context, cfg globalconfig.Config, deps runtimeDeps) (int, bool) {

--- a/internal/cli/service.go
+++ b/internal/cli/service.go
@@ -2,7 +2,9 @@ package cli
 
 import (
 	"bufio"
+	"bytes"
 	"context"
+	"encoding/xml"
 	"errors"
 	"fmt"
 	"io"
@@ -27,6 +29,11 @@ type ServiceRunner interface {
 }
 
 type ServiceFactory func(servicepkg.Config) (ServiceRunner, error)
+
+type statusServiceRunner struct {
+	ServiceRunner
+	fallbackURL string
+}
 
 func defaultServiceFactory(cfg servicepkg.Config) (ServiceRunner, error) {
 	return servicepkg.New(cfg)
@@ -137,6 +144,14 @@ func serviceRunnerForCommand(cmd *cobra.Command, configPath *string, host *strin
 	if err != nil {
 		return nil, err
 	}
+	dashboardPort := resolvedPort
+	if cmd.Name() == "status" {
+		dashboardPort = resolveConfiguredRuntimePort(cmd.Context(), runtimeInput{
+			Config:     &cfg,
+			ConfigPath: resolution,
+			Workflow:   firstGlobalWorkflowPath(cfg),
+		}, runtimeDepsFromOptions(opts))
+	}
 
 	executable, err := os.Executable()
 	if err != nil {
@@ -163,7 +178,8 @@ func serviceRunnerForCommand(cmd *cobra.Command, configPath *string, host *strin
 	if factory == nil {
 		factory = defaultServiceFactory
 	}
-	return factory(servicepkg.Config{
+	dashboardURL := "http://" + net.JoinHostPort(dashboardHost, strconv.Itoa(dashboardPort.Value))
+	runner, err := factory(servicepkg.Config{
 		GOOS:         runtime.GOOS,
 		BinaryPath:   binaryPath,
 		ConfigPath:   resolution.Path,
@@ -171,9 +187,153 @@ func serviceRunnerForCommand(cmd *cobra.Command, configPath *string, host *strin
 		LockPath:     filepath.Join(filepath.Dir(resolution.Path), "detent.db.lock"),
 		Version:      opts.version,
 		AutoUpdate:   serviceAutoUpdate(cfg.Update.AutoCheckEnabled, cfg.Update.AutoApplyEnabled),
-		DashboardURL: "http://" + net.JoinHostPort(dashboardHost, strconv.Itoa(resolvedPort.Value)),
+		DashboardURL: dashboardURL,
 		Install:      install,
 	})
+	if err != nil {
+		return nil, err
+	}
+	if cmd.Name() == "status" {
+		return statusServiceRunner{ServiceRunner: runner, fallbackURL: dashboardURL}, nil
+	}
+	return runner, nil
+}
+
+func (r statusServiceRunner) Status(ctx context.Context) (servicepkg.Status, error) {
+	status, err := r.ServiceRunner.Status(ctx)
+	if err != nil {
+		return servicepkg.Status{}, err
+	}
+	status.DashboardURL = r.fallbackURL
+	if port, ok := installedServicePort(status.ServiceManager, status.DefinitionPath); ok {
+		status.DashboardURL = "http://" + net.JoinHostPort(dashboardHost, strconv.Itoa(port))
+	}
+	return status, nil
+}
+
+func installedServicePort(manager servicepkg.ManagerName, path string) (int, bool) {
+	if strings.TrimSpace(path) == "" {
+		return 0, false
+	}
+	content, err := os.ReadFile(path)
+	if err != nil {
+		return 0, false
+	}
+	var arguments []string
+	switch manager {
+	case servicepkg.ManagerSystemd:
+		arguments = systemdDefinitionArguments(content)
+	case servicepkg.ManagerLaunchd:
+		arguments = launchdDefinitionArguments(content)
+	default:
+		return 0, false
+	}
+	for index, argument := range arguments {
+		if argument == "--port" && index+1 < len(arguments) {
+			return validServicePort(arguments[index+1])
+		}
+		if raw, ok := strings.CutPrefix(argument, "--port="); ok {
+			return validServicePort(raw)
+		}
+	}
+	return 0, false
+}
+
+func validServicePort(raw string) (int, bool) {
+	port, err := strconv.Atoi(strings.TrimSpace(raw))
+	return port, err == nil && port >= 0
+}
+
+func systemdDefinitionArguments(content []byte) []string {
+	for line := range strings.SplitSeq(string(content), "\n") {
+		value, ok := strings.CutPrefix(strings.TrimSpace(line), "ExecStart=")
+		if ok {
+			return splitDefinitionArguments(value)
+		}
+	}
+	return nil
+}
+
+func splitDefinitionArguments(value string) []string {
+	var arguments []string
+	for value = strings.TrimSpace(value); value != ""; value = strings.TrimSpace(value) {
+		if value[0] == '"' {
+			end := quotedArgumentEnd(value)
+			if end < 0 {
+				return nil
+			}
+			argument, err := strconv.Unquote(value[:end+1])
+			if err != nil {
+				return nil
+			}
+			arguments = append(arguments, argument)
+			value = value[end+1:]
+		} else {
+			index := strings.IndexAny(value, " \t")
+			if index < 0 {
+				return append(arguments, value)
+			}
+			arguments = append(arguments, value[:index])
+			value = value[index:]
+		}
+	}
+	return arguments
+}
+
+func quotedArgumentEnd(value string) int {
+	escaped := false
+	for index := 1; index < len(value); index++ {
+		switch {
+		case escaped:
+			escaped = false
+		case value[index] == '\\':
+			escaped = true
+		case value[index] == '"':
+			return index
+		}
+	}
+	return -1
+}
+
+func launchdDefinitionArguments(content []byte) []string {
+	decoder := xml.NewDecoder(bytes.NewReader(content))
+	wantArguments := false
+	inArguments := false
+	var arguments []string
+	for {
+		token, err := decoder.Token()
+		if err != nil {
+			return nil
+		}
+		switch element := token.(type) {
+		case xml.StartElement:
+			switch element.Name.Local {
+			case "key":
+				var key string
+				if err := decoder.DecodeElement(&key, &element); err != nil {
+					return nil
+				}
+				wantArguments = strings.TrimSpace(key) == "ProgramArguments"
+			case "array":
+				if wantArguments {
+					inArguments = true
+					wantArguments = false
+				}
+			case "string":
+				if inArguments {
+					var argument string
+					if err := decoder.DecodeElement(&argument, &element); err != nil {
+						return nil
+					}
+					arguments = append(arguments, argument)
+				}
+			}
+		case xml.EndElement:
+			if inArguments && element.Name.Local == "array" {
+				return arguments
+			}
+		}
+	}
 }
 
 func serviceBinaryPath(executable string, invocation string, lookPath func(string) (string, error), evalSymlinks func(string) (string, error)) string {

--- a/internal/cli/service_test.go
+++ b/internal/cli/service_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"os"
 	"os/exec"
 	"path/filepath"
 	"reflect"
@@ -264,19 +265,140 @@ func TestServiceCommandResolvesConfigAndRuntime(t *testing.T) {
 	}
 }
 
-func TestServiceCommandPersistsEnvironmentPort(t *testing.T) {
+func TestStatusCommandResolvesDashboardPort(t *testing.T) {
+	t.Setenv("PORT", "4200")
+
+	tests := []struct {
+		name             string
+		configPort       int
+		writeConfig      bool
+		definition       string
+		manager          servicepkg.ManagerName
+		wantDashboardURL string
+		wantFactoryURL   string
+	}{
+		{
+			name:             "ambient port with config port",
+			configPort:       4100,
+			writeConfig:      true,
+			manager:          servicepkg.ManagerManual,
+			wantDashboardURL: "http://localhost:4100",
+			wantFactoryURL:   "http://localhost:4100",
+		},
+		{
+			name:             "installed unit port",
+			configPort:       4100,
+			writeConfig:      true,
+			definition:       "[Service]\nExecStart=\"/usr/bin/detent\" \"--config\" \"/tmp/global.yaml\" \"--port\" \"4300\" \"--headless\"\n",
+			manager:          servicepkg.ManagerSystemd,
+			wantDashboardURL: "http://localhost:4300",
+			wantFactoryURL:   "http://localhost:4100",
+		},
+		{
+			name:        "installed launchd port",
+			configPort:  4100,
+			writeConfig: true,
+			definition: `<?xml version="1.0" encoding="UTF-8"?>
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>com.digitaldrywood.detent</string>
+  <key>ProgramArguments</key>
+  <array>
+    <string>/usr/local/bin/detent</string>
+    <string>--config</string>
+    <string>/tmp/global.yaml</string>
+    <string>--port</string>
+    <string>4400</string>
+    <string>--headless</string>
+  </array>
+</dict>
+</plist>`,
+			manager:          servicepkg.ManagerLaunchd,
+			wantDashboardURL: "http://localhost:4400",
+			wantFactoryURL:   "http://localhost:4100",
+		},
+		{
+			name:             "default port without config port",
+			manager:          servicepkg.ManagerManual,
+			wantDashboardURL: "http://localhost:4000",
+			wantFactoryURL:   "http://localhost:4000",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			root := t.TempDir()
+			path := filepath.Join(root, "global.yaml")
+			if tt.writeConfig {
+				cfg, err := globalconfig.DefaultAt(path)
+				if err != nil {
+					t.Fatalf("DefaultAt() error = %v", err)
+				}
+				cfg.Port = &tt.configPort
+				if err := globalconfig.Write(path, cfg); err != nil {
+					t.Fatalf("Write() error = %v", err)
+				}
+			}
+
+			definitionPath := ""
+			if tt.definition != "" {
+				definitionPath = filepath.Join(root, "detent.service")
+				if err := os.WriteFile(definitionPath, []byte(tt.definition), 0o600); err != nil {
+					t.Fatalf("WriteFile() error = %v", err)
+				}
+			}
+
+			var captured servicepkg.Config
+			runner := &serviceRunnerStub{status: servicepkg.Status{
+				ServiceManager: tt.manager,
+				Service:        string(tt.manager),
+				DefinitionPath: definitionPath,
+				State:          servicepkg.StateRunning,
+			}}
+			cmd := NewRootCommand(t.Context(), WithServiceFactory(func(cfg servicepkg.Config) (ServiceRunner, error) {
+				captured = cfg
+				return runner, nil
+			}))
+			var stdout bytes.Buffer
+			cmd.SetOut(&stdout)
+			cmd.SetErr(&bytes.Buffer{})
+			cmd.SetArgs([]string{"--format", "json", "--config", path, "status"})
+
+			if err := cmd.Execute(); err != nil {
+				t.Fatalf("Execute() error = %v", err)
+			}
+			var status servicepkg.Status
+			if err := json.Unmarshal(stdout.Bytes(), &status); err != nil {
+				t.Fatalf("Unmarshal() error = %v", err)
+			}
+			if status.DashboardURL != tt.wantDashboardURL {
+				t.Fatalf("DashboardURL = %q, want %q", status.DashboardURL, tt.wantDashboardURL)
+			}
+			if captured.DashboardURL != tt.wantFactoryURL {
+				t.Fatalf("factory DashboardURL = %q, want %q", captured.DashboardURL, tt.wantFactoryURL)
+			}
+		})
+	}
+}
+
+func TestStartCommandPersistsEnvironmentPort(t *testing.T) {
 	t.Setenv("PORT", "4200")
 
 	path := filepath.Join(t.TempDir(), "global.yaml")
 	var captured servicepkg.Config
-	runner := &serviceRunnerStub{status: servicepkg.Status{ServiceManager: servicepkg.ManagerManual, Service: string(servicepkg.ManagerManual), State: servicepkg.StateStopped}}
+	runner := &serviceRunnerStub{startResults: []servicepkg.StartResult{{
+		Action:  servicepkg.ActionAlreadyActive,
+		Manager: servicepkg.ManagerInfo{Name: servicepkg.ManagerManual, Unit: string(servicepkg.ManagerManual)},
+		State:   servicepkg.StateRunning,
+	}}}
 	cmd := NewRootCommand(t.Context(), WithServiceFactory(func(cfg servicepkg.Config) (ServiceRunner, error) {
 		captured = cfg
 		return runner, nil
 	}))
 	cmd.SetOut(&bytes.Buffer{})
 	cmd.SetErr(&bytes.Buffer{})
-	cmd.SetArgs([]string{"--format", "json", "--config", path, "status"})
+	cmd.SetArgs([]string{"--format", "json", "--config", path, "start"})
 
 	if err := cmd.Execute(); err != nil {
 		t.Fatalf("Execute() error = %v", err)


### PR DESCRIPTION
## Summary

- Make status dashboard URLs independent of the invoking shell's ambient `PORT`.
- Prefer the installed systemd or launchd service definition's `--port`, with config, workflow, and default fallback resolution.
- Preserve start-time capture of `PORT` in installed service arguments.

Fixes #1421

## UI Surface Contract

- [x] N/A, or the linked issue explicitly authorizes any high-impact UI surface, layout, density, first-viewport, or responsive visibility tradeoff.
- [x] Persistent top-of-screen messaging is explicitly authorized by the issue, or this PR does not add it.
- [x] Visual changes to primary operator screens include screenshot or browser verification below.

No visual changes.

## Test Plan

- [x] `make check`