### PR TITLE
fix(web): join async writer on shutdown

### DIFF
--- a/internal/web/async_writer.go
+++ b/internal/web/async_writer.go
@@ -11,6 +11,7 @@ type asyncStoreWriter struct {
 	jobs   chan func(context.Context)
 	done   chan struct{}
 	logger *slog.Logger
+	cancel context.CancelFunc
 
 	mu     sync.Mutex
 	closed bool
@@ -23,12 +24,14 @@ func newAsyncStoreWriter(buffer int, logger *slog.Logger) *asyncStoreWriter {
 	if logger == nil {
 		logger = slog.Default()
 	}
+	ctx, cancel := context.WithCancel(context.Background())
 	writer := &asyncStoreWriter{
 		jobs:   make(chan func(context.Context), buffer),
 		done:   make(chan struct{}),
 		logger: logger,
+		cancel: cancel,
 	}
-	go writer.run()
+	go writer.run(ctx)
 	return writer
 }
 
@@ -67,19 +70,46 @@ func (w *asyncStoreWriter) Close(ctx context.Context) error {
 	}
 	w.mu.Unlock()
 
-	select {
-	case <-w.done:
-		return nil
-	case <-ctx.Done():
-		return ctx.Err()
+	drainCtx := ctx
+	cancelDrain := func() {}
+	if deadline, ok := ctx.Deadline(); ok {
+		remaining := time.Until(deadline)
+		if remaining > 0 {
+			joinGrace := min(time.Second, remaining/5)
+			drainCtx, cancelDrain = context.WithDeadline(ctx, deadline.Add(-joinGrace))
+		}
 	}
+	defer cancelDrain()
+	stopCancel := context.AfterFunc(drainCtx, w.cancel)
+	defer stopCancel()
+
+	<-w.done
+	return nil
 }
 
-func (w *asyncStoreWriter) run() {
+func (w *asyncStoreWriter) run(ctx context.Context) {
 	defer close(w.done)
-	for job := range w.jobs {
-		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-		job(ctx)
-		cancel()
+	defer w.cancel()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		default:
+		}
+
+		select {
+		case <-ctx.Done():
+			return
+		case job, ok := <-w.jobs:
+			if !ok {
+				return
+			}
+			if ctx.Err() != nil {
+				return
+			}
+			jobCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+			job(jobCtx)
+			cancel()
+		}
 	}
 }

--- a/internal/web/async_writer_test.go
+++ b/internal/web/async_writer_test.go
@@ -105,33 +105,76 @@ func TestAsyncStoreWriter(t *testing.T) {
 			},
 		},
 		{
-			name: "close returns canceled context error",
+			name: "close cancels active job and joins within deadline",
 			run: func(t *testing.T) {
 				t.Helper()
 
 				writer := newAsyncStoreWriter(1, discardAsyncStoreWriterLogger())
 				started := make(chan struct{})
-				release := make(chan struct{})
-				if !writer.Enqueue(func(context.Context) {
+				jobErr := make(chan error, 1)
+				if !writer.Enqueue(func(ctx context.Context) {
 					close(started)
-					<-release
+					<-ctx.Done()
+					jobErr <- ctx.Err()
 				}) {
 					t.Fatal("Enqueue() = false, want true")
 				}
 				waitForAsyncWriterSignal(t, started)
+				ctx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
+				defer cancel()
+
+				if err := writer.Close(ctx); err != nil {
+					t.Fatalf("Close() error = %v, want nil", err)
+				}
+				if err := ctx.Err(); err != nil {
+					t.Fatalf("context error after Close = %v, want nil", err)
+				}
+				if err := waitForAsyncWriterClose(t, jobErr); !errors.Is(err, context.Canceled) {
+					t.Fatalf("job context error = %v, want %v", err, context.Canceled)
+				}
+				select {
+				case <-writer.done:
+				default:
+					t.Fatal("worker still running after Close returned")
+				}
+			},
+		},
+		{
+			name: "close cancellation discards queued jobs",
+			run: func(t *testing.T) {
+				t.Helper()
+
+				writer := newAsyncStoreWriter(1, discardAsyncStoreWriterLogger())
+				started := make(chan struct{})
+				if !writer.Enqueue(func(ctx context.Context) {
+					close(started)
+					<-ctx.Done()
+				}) {
+					t.Fatal("Enqueue(active) = false, want true")
+				}
+				waitForAsyncWriterSignal(t, started)
+				queued := make(chan struct{})
+				if !writer.Enqueue(func(context.Context) {
+					close(queued)
+				}) {
+					t.Fatal("Enqueue(queued) = false, want true")
+				}
 				ctx, cancel := context.WithCancel(context.Background())
 				cancel()
 
-				closed := make(chan error, 1)
-				go func() {
-					closed <- writer.Close(ctx)
-				}()
-				err := waitForAsyncWriterClose(t, closed)
-				if !errors.Is(err, context.Canceled) {
-					t.Fatalf("Close() error = %v, want %v", err, context.Canceled)
+				if err := writer.Close(ctx); err != nil {
+					t.Fatalf("Close() error = %v, want nil", err)
 				}
-				close(release)
-				waitForAsyncWriterSignal(t, writer.done)
+				select {
+				case <-writer.done:
+				default:
+					t.Fatal("worker still running after Close returned")
+				}
+				select {
+				case <-queued:
+					t.Fatal("queued job ran after shutdown cancellation")
+				default:
+				}
 			},
 		},
 	}

--- a/internal/web/server_shutdown_test.go
+++ b/internal/web/server_shutdown_test.go
@@ -7,6 +7,7 @@ import (
 	"log/slog"
 	"net"
 	"net/http"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -98,6 +99,66 @@ func TestServerShutdownDrainsAsyncWritesAfterActiveHandlers(t *testing.T) {
 	waitForAsyncWriterSignal(t, ran)
 	if err := waitForAsyncWriterClose(t, serveErr); err != nil && !errors.Is(err, http.ErrServerClosed) {
 		t.Fatalf("StartListener() error = %v, want %v", err, http.ErrServerClosed)
+	}
+}
+
+func TestServerShutdownJoinsAsyncWriterBeforeStoreClose(t *testing.T) {
+	t.Parallel()
+
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	server := &Server{
+		echo:        echo.New(),
+		logger:      logger,
+		asyncWrites: newAsyncStoreWriter(1, logger),
+	}
+
+	var storeClosed atomic.Bool
+	var accessAfterClose atomic.Int64
+	accessStore := func() {
+		if storeClosed.Load() {
+			accessAfterClose.Add(1)
+		}
+	}
+	started := make(chan struct{})
+	release := make(chan struct{})
+	jobCanceled := make(chan struct{})
+	if !server.asyncWrites.Enqueue(func(ctx context.Context) {
+		close(started)
+		select {
+		case <-ctx.Done():
+			close(jobCanceled)
+		case <-release:
+		}
+		accessStore()
+	}) {
+		t.Fatal("Enqueue(active) = false, want true")
+	}
+	waitForAsyncWriterSignal(t, started)
+	if !server.asyncWrites.Enqueue(func(context.Context) {
+		accessStore()
+	}) {
+		t.Fatal("Enqueue(queued) = false, want true")
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	shutdownErr := make(chan error, 1)
+	go func() {
+		shutdownErr <- server.Shutdown(ctx)
+	}()
+	if err := waitForAsyncWriterClose(t, shutdownErr); err != nil {
+		t.Fatalf("Shutdown() error = %v, want nil", err)
+	}
+	storeClosed.Store(true)
+	close(release)
+	waitForAsyncWriterSignal(t, server.asyncWrites.done)
+	if got := accessAfterClose.Load(); got != 0 {
+		t.Fatalf("store accesses after Shutdown returned = %d, want 0", got)
+	}
+	select {
+	case <-jobCanceled:
+	default:
+		t.Fatal("active job did not observe shutdown cancellation")
 	}
 }
 

--- a/internal/web/server_test.go
+++ b/internal/web/server_test.go
@@ -1476,7 +1476,7 @@ func TestAPIKeyRevokeExpireRotateAndRateLimit(t *testing.T) {
 
 	server, backend, _, _ := newAPIKeyWorkItemTestServer(t)
 	t.Cleanup(func() {
-		ctx, cancel := context.WithTimeout(context.Background(), 12*time.Second)
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 		defer cancel()
 		if err := server.Shutdown(ctx); err != nil {
 			t.Errorf("Shutdown() error = %v", err)


### PR DESCRIPTION
## Summary

- Propagate shutdown cancellation into active async store writes and join the worker before returning.
- Drain normally while the budget remains, then discard queued writes cleanly when it expires so store ownership stays valid.
- Add deterministic timeout, queue cancellation, and store ownership coverage under the production five-second shutdown budget.

Fixes #1420

## UI Surface Contract

- [x] N/A, or the linked issue explicitly authorizes any high-impact UI surface, layout, density, first-viewport, or responsive visibility tradeoff.
- [x] Persistent top-of-screen messaging is explicitly authorized by the issue, or this PR does not add it.
- [x] Visual changes to primary operator screens include screenshot or browser verification below.

## Test Plan

- [x] `make check`
- [x] Repeated async writer and server shutdown tests (10 runs)
- [x] Repeated API-key lifecycle test (25 runs)
- [x] Race-instrumented shutdown and API-key lifecycle tests (5 runs)