### PR TITLE
fix(board): hide Done lane by default

### DIFF
--- a/internal/web/templates/board_data.go
+++ b/internal/web/templates/board_data.go
@@ -152,8 +152,7 @@ func boardViewFromDashboard(data DashboardData) boardView {
 			CardCount: len(lane.Cards),
 			Live:      strings.EqualFold(lane.Title, "In Progress") && len(lane.Cards) > 0,
 			// Populated lanes show by default, except terminal graveyards
-			// (Cancelled, Closed, …). Done stays visible so finished work
-			// reads at a glance; everything is reachable via the picker.
+			// (Done, Cancelled, Closed, …), which remain reachable via the picker.
 			DefaultVisible: boardLaneDefaultVisible(lane, laneTerminal, boardHasCards),
 			EmptyMessage:   "No issues in " + lane.Title,
 		}
@@ -276,7 +275,7 @@ func boardLaneDefaultVisible(lane projectKanbanLane, terminal bool, boardHasCard
 		// states are legible instead of a blank strip.
 		return !terminal
 	}
-	return len(lane.Cards) > 0 && (!terminal || strings.EqualFold(lane.Title, "Done"))
+	return len(lane.Cards) > 0 && !terminal
 }
 
 func boardVisibilityKey(data DashboardData) string {
@@ -392,7 +391,10 @@ func boardCardViewFromCard(data DashboardData, lane projectKanbanLane, card proj
 	}
 	identity := boardCardIdentityToken(card.Identifier, card.IssueID, card.IssueNumber)
 	moveDisabledText := projectKanbanCardMoveDisabledText(data, card)
-	canDrag := moveDisabledText == ""
+	if card.RecentCompletion {
+		moveDisabledText = ""
+	}
+	canDrag := moveDisabledText == "" && !card.RecentCompletion
 	view := boardCardView{
 		DomID:             "card-" + boardCardScopedSlug(projectID, identity),
 		Identity:          identity,

--- a/internal/web/templates/board_data_test.go
+++ b/internal/web/templates/board_data_test.go
@@ -244,6 +244,9 @@ func TestBoardViewLanes(t *testing.T) {
 	if len(done.Cards) != 1 || !done.Cards[0].Done {
 		t.Fatalf("Done lane should carry one done-styled card, got %+v", done.Cards)
 	}
+	if done.DefaultVisible {
+		t.Fatalf("populated Done lane should be hidden by default")
+	}
 
 	backlog := lanes["Backlog"]
 	if backlog.Cards[0].ExtraText != "" {
@@ -255,6 +258,31 @@ func TestBoardViewLanes(t *testing.T) {
 
 	if human, ok := lanes["Human Review"]; ok && human.DefaultVisible {
 		t.Fatalf("empty lane should be hidden by default")
+	}
+}
+
+func TestRecentCompletionCardSuppressesMoveDisabledBadge(t *testing.T) {
+	t.Parallel()
+
+	card := projectKanbanCard{
+		IssueNumber:      "#1385",
+		Identifier:       "digitaldrywood/detent#1385",
+		ProjectID:        "detent",
+		Title:            "Completed digitaldrywood/detent#1385",
+		Stage:            "Done",
+		RecentCompletion: true,
+	}
+	lane := projectKanbanLane{Title: "Done", Cards: []projectKanbanCard{card}}
+	view := boardCardViewFromCard(DashboardData{}, lane, card, true, "project", "detent")
+
+	if view.Number != "#1385" {
+		t.Fatalf("card number = %q, want #1385", view.Number)
+	}
+	if view.MoveDisabledText != "" || view.MoveDisabledLabel != "" {
+		t.Fatalf("recent completion move badge = %q / %q, want suppressed", view.MoveDisabledText, view.MoveDisabledLabel)
+	}
+	if view.DragDrop || view.CanDrag {
+		t.Fatalf("recent completion should remain non-draggable: %+v", view)
 	}
 }
 

--- a/internal/web/templates/dashboard_data.go
+++ b/internal/web/templates/dashboard_data.go
@@ -607,6 +607,7 @@ type projectKanbanCard struct {
 	PRRepository          string
 	PRURL                 string
 	Movable               bool
+	RecentCompletion      bool
 	DisabledText          string
 	RuntimeIdentity       agentidentity.Identity
 }
@@ -2958,6 +2959,7 @@ func projectKanbanCardForIssue(data DashboardData, issue telemetry.Issue, state 
 		ClearedBlockers:       clearedBlockers,
 		HasPullRequest:        issue.PullRequest != nil,
 		Movable:               strings.TrimSpace(issue.ID) != "" && issue.Metadata[projectKanbanRecentCompletionMetadataKey] != "true",
+		RecentCompletion:      issue.Metadata[projectKanbanRecentCompletionMetadataKey] == "true",
 		RuntimeIdentity:       issue.RuntimeIdentity,
 	}
 	if projectKanbanCardUsesInternalIssueView(data, card) {

--- a/internal/web/templates/dashboard_data_test.go
+++ b/internal/web/templates/dashboard_data_test.go
@@ -2310,6 +2310,9 @@ func TestProjectKanbanBoardShowsRecentTerminalCompletion(t *testing.T) {
 	if got := board.AllLanes[1].Cards[0].Title; got != "Completed session only" {
 		t.Fatalf("Done card title = %q, want completed issue title", got)
 	}
+	if board.AllLanes[1].DefaultVisible {
+		t.Fatalf("populated Done lane should be hidden by default")
+	}
 	if got := boardFiguresFromDashboard(data)[4].Value; got != "1" {
 		t.Fatalf("recent completion count = %q, want 1", got)
 	}
@@ -2347,6 +2350,12 @@ func TestProjectKanbanBoardRestoresRecentTerminalCompletionFromWorkAttempt(t *te
 	}
 	if got := board.AllLanes[1].Cards[0].Identifier; got != "digitaldrywood/detent#1385" {
 		t.Fatalf("Done card identifier = %q", got)
+	}
+	if got := board.AllLanes[1].Cards[0].IssueNumber; got != "#1385" {
+		t.Fatalf("Done card issue number = %q, want #1385", got)
+	}
+	if !board.AllLanes[1].Cards[0].RecentCompletion {
+		t.Fatalf("Done card should be marked as a recent completion")
 	}
 }
 

--- a/tests/visual/freshness.spec.js
+++ b/tests/visual/freshness.spec.js
@@ -48,7 +48,7 @@ test("faked tracker failures show stale data without hiding live SSE", async ({
   await expect(health).toContainText("status 503");
 });
 
-test("idle healthy board shows current freshness and recent Done cards", async ({
+test("idle healthy board keeps freshness while Done is opt-in", async ({
   page,
 }) => {
   await page.setExtraHTTPHeaders({
@@ -61,13 +61,33 @@ test("idle healthy board shows current freshness and recent Done cards", async (
   await expect(page.locator("#fig-completed")).toContainText("2 completed · 48h");
 
   const done = page.locator('[data-board-lane="done"]');
+
+  await expect(done).toHaveAttribute("data-board-lane-default", "false");
+  await expect(done).toBeHidden();
+  await expect(page.locator("[data-board-lane-count]")).toHaveText("0/9");
+
+  const picker = page.locator("#board-lane-picker");
+  await picker.locator("summary").click();
+  await picker
+    .locator('[data-board-lane-visibility="done"]')
+    .selectOption("show");
+
   await expect(done).toBeVisible();
+  await expect(page.locator("[data-board-lane-count]")).toHaveText("1/9");
   await expect(done).toContainText("Release v0.44.0");
   await expect(done).toContainText("Finish overnight release batch");
+  await expect(done.locator('[data-kanban-move-disabled-label]')).toHaveCount(0);
+
+  const persisted = await page.locator("#board-lanes").evaluate((root) => {
+    const key = `detent.ui.board.lanes.v2.${root.dataset.boardKey}`;
+    return JSON.parse(localStorage.getItem(key) || "{}").show?.includes("done");
+  });
+  expect(persisted).toBe(true);
 
   const originalDone = await done.elementHandle();
   await morphCurrentSnapshot(page);
   expect(await originalDone?.evaluate((element) => element.isConnected)).toBe(true);
+  await expect(done).toBeVisible();
 });
 
 async function morphCurrentSnapshot(page) {

--- a/tests/visual/layout.spec.js
+++ b/tests/visual/layout.spec.js
@@ -500,7 +500,7 @@ test("board applies persisted todo visibility before snapshot morphs", async ({
 
   await expect(lane).toBeVisible();
   await expect(visibility).toHaveValue("show");
-  await expect(count).toHaveText("8/9");
+  await expect(count).toHaveText("7/9");
 
   const incomingSnapshot = await page.evaluate((laneID) => {
     const template = document.createElement("template");
@@ -558,7 +558,7 @@ test("board applies persisted todo visibility before snapshot morphs", async ({
   expect(hiddenValues).not.toContain("true");
   await expect(lane).toBeVisible();
   await expect(visibility).toHaveValue("show");
-  await expect(count).toHaveText("8/9");
+  await expect(count).toHaveText("7/9");
 
   await startLaneHiddenRecorder(page, laneID);
   await page.evaluate(
@@ -588,7 +588,7 @@ test("board applies persisted todo visibility before snapshot morphs", async ({
   expect(sseHiddenValues).not.toContain("true");
   await expect(lane).toBeVisible();
   await expect(visibility).toHaveValue("show");
-  await expect(count).toHaveText("8/9");
+  await expect(count).toHaveText("7/9");
 });
 
 test("board card opens the detail sheet", async ({ page }, testInfo) => {


### PR DESCRIPTION
## Summary

- hide populated terminal Done lanes by default while preserving Lanes picker opt-in and localStorage persistence
- keep freshness and the 48-hour completion count visible
- suppress the contradictory move-disabled badge on synthesized recent-completion cards while retaining their issue reference

Fixes #1427

## UI Surface Contract

- [x] The linked issue explicitly authorizes hiding the Done lane by default while keeping it opt-in.
- [x] This PR does not add persistent top-of-screen messaging.
- [x] Browser verification covers default visibility, picker opt-in, localStorage persistence, freshness, and SSE morph persistence. Existing desktop screenshot scenarios do not contain recent-completion Done cards, so no unrelated baseline changed.

## Test Plan

- [x] `go test ./internal/web/templates -count=1`
- [x] Chromium `tests/visual/freshness.spec.js`
- [x] Chromium persisted-visibility layout spec
- [x] `make check`
- [x] All 11 current-head GitHub checks