### PR TITLE
fix(orchestrator): reconcile legacy release actions

### DIFF
--- a/db/queries/store.sql
+++ b/db/queries/store.sql
@@ -808,6 +808,23 @@ WHERE completed_at IS NOT NULL
 ORDER BY completed_at DESC, id DESC
 LIMIT sqlc.arg(result_limit);
 
+-- name: ListPendingWorkAttemptCapacityReleases :many
+SELECT *
+FROM work_attempts
+WHERE project_id = sqlc.arg(project_id)
+  AND status = 'terminal'
+  AND completed_at IS NOT NULL
+  AND lower(trim(COALESCE(next_action, ''))) = 'release capacity'
+ORDER BY completed_at, id;
+
+-- name: ClearWorkAttemptCapacityRelease :exec
+UPDATE work_attempts
+SET next_action = NULL
+WHERE id = sqlc.arg(work_attempt_id)
+  AND status = 'terminal'
+  AND completed_at IS NOT NULL
+  AND lower(trim(COALESCE(next_action, ''))) = 'release capacity';
+
 -- name: UpdateOperatorStop :execrows
 UPDATE work_attempts
 SET phase = sqlc.arg(phase),

--- a/internal/orchestrator/dispatch_test.go
+++ b/internal/orchestrator/dispatch_test.go
@@ -87,6 +87,92 @@ func TestRecoverDurableWorkAttemptsRestoresMostRecentRuntimeIdentity(t *testing.
 	}
 }
 
+func TestRecoverDurableWorkAttemptsReleasesLegacyTerminalCapacityActions(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 7, 17, 20, 0, 0, 0, time.UTC)
+	issue := claimTestIssue("issue-1430")
+	issue.Fields["Detent Lease"] = now.Add(-time.Hour).Format(time.RFC3339Nano)
+	claimStore := newClaimTestStore([]connector.Issue{issue})
+	attempts := &recordingWorkAttemptStore{pendingCapacityReleases: []store.WorkAttempt{{
+		ID:            1430,
+		ProjectID:     "detent",
+		IssueID:       issue.ID,
+		Identifier:    issue.Identifier,
+		Status:        store.WorkAttemptStatusTerminal,
+		CompletedAt:   now.Add(-30 * time.Minute),
+		TerminalState: store.WorkAttemptTerminalSuccess,
+		NextAction:    "release capacity",
+	}}}
+	cfg := normalizeConfig(claimTestConfig("alpha", "alpha"))
+	cfg.Project = scheduler.ProjectCandidate{ID: "detent"}
+	o := &Orchestrator{
+		cfg:          cfg,
+		connector:    claimTestConnector{store: claimStore, login: "alpha"},
+		workAttempts: attempts,
+	}
+	state := newState(cfg)
+
+	o.recoverDurableWorkAttempts(t.Context(), &state, now)
+
+	if got := claimStore.issue(issue.ID).Fields["Detent Lease"]; got != "" {
+		t.Fatalf("Detent Lease = %q, want released", got)
+	}
+	if len(attempts.clearedCapacityReleases) != 1 || attempts.clearedCapacityReleases[0] != 1430 {
+		t.Fatalf("cleared capacity releases = %v, want [1430]", attempts.clearedCapacityReleases)
+	}
+}
+
+func TestRecoverDurableWorkAttemptsRetainsCapacityActionWhenReleaseFails(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 7, 17, 20, 0, 0, 0, time.UTC)
+	issue := claimTestIssue("issue-1430-failure")
+	wantLease := now.Add(-time.Hour).Format(time.RFC3339Nano)
+	issue.Fields["Detent Lease"] = wantLease
+	claimStore := newClaimTestStore([]connector.Issue{issue})
+	attempts := &recordingWorkAttemptStore{pendingCapacityReleases: []store.WorkAttempt{{
+		ID:            1431,
+		ProjectID:     "detent",
+		IssueID:       issue.ID,
+		Identifier:    issue.Identifier,
+		Status:        store.WorkAttemptStatusTerminal,
+		CompletedAt:   now.Add(-30 * time.Minute),
+		TerminalState: store.WorkAttemptTerminalSuccess,
+		NextAction:    "release capacity",
+	}}}
+	cfg := normalizeConfig(claimTestConfig("alpha", "alpha"))
+	cfg.Project = scheduler.ProjectCandidate{ID: "detent"}
+	o := &Orchestrator{
+		cfg: cfg,
+		connector: failingCapacityReleaseConnector{
+			claimTestConnector: claimTestConnector{store: claimStore, login: "alpha"},
+			err:                errors.New("tracker unavailable"),
+		},
+		workAttempts: attempts,
+	}
+	state := newState(cfg)
+
+	o.recoverDurableWorkAttempts(t.Context(), &state, now)
+
+	if got := claimStore.issue(issue.ID).Fields["Detent Lease"]; got != wantLease {
+		t.Fatalf("Detent Lease = %q, want pending lease %q", got, wantLease)
+	}
+	if len(attempts.clearedCapacityReleases) != 0 {
+		t.Fatalf("cleared capacity releases = %v, want none", attempts.clearedCapacityReleases)
+	}
+	foundFailure := false
+	for _, event := range state.RecentEvents {
+		if event.Event == "work_attempt_capacity_release_failed" {
+			foundFailure = true
+			break
+		}
+	}
+	if !foundFailure {
+		t.Fatalf("RecentEvents = %#v, want capacity release failure", state.RecentEvents)
+	}
+}
+
 func TestConfigFromWorkflowIncludesDispatchControls(t *testing.T) {
 	t.Parallel()
 
@@ -2735,15 +2821,26 @@ func receiveWorkerHostRunRequest(t *testing.T, requests <-chan RunRequest) RunRe
 }
 
 type recordingWorkAttemptStore struct {
-	nextID         int64
-	starts         []store.WorkAttemptStart
-	heartbeats     []store.WorkAttemptHeartbeat
-	completions    []store.WorkAttemptCompletion
-	decisions      []store.SchedulerDecision
-	reclaimed      []store.WorkAttempt
-	recent         []store.WorkAttempt
-	history        []store.WorkAttempt
-	historyQueries []store.WorkAttemptHistoryQuery
+	nextID                  int64
+	starts                  []store.WorkAttemptStart
+	heartbeats              []store.WorkAttemptHeartbeat
+	completions             []store.WorkAttemptCompletion
+	decisions               []store.SchedulerDecision
+	reclaimed               []store.WorkAttempt
+	recent                  []store.WorkAttempt
+	history                 []store.WorkAttempt
+	historyQueries          []store.WorkAttemptHistoryQuery
+	pendingCapacityReleases []store.WorkAttempt
+	clearedCapacityReleases []int64
+}
+
+type failingCapacityReleaseConnector struct {
+	claimTestConnector
+	err error
+}
+
+func (c failingCapacityReleaseConnector) SetField(context.Context, string, string, string) error {
+	return c.err
 }
 
 type recordingRetrospector struct {
@@ -2788,6 +2885,15 @@ func (s *recordingWorkAttemptStore) ReclaimActiveWorkAttempts(context.Context, s
 
 func (s *recordingWorkAttemptStore) ListActiveWorkAttempts(context.Context, store.WorkAttemptQuery) ([]store.WorkAttempt, error) {
 	return nil, nil
+}
+
+func (s *recordingWorkAttemptStore) ListPendingWorkAttemptCapacityReleases(context.Context, string) ([]store.WorkAttempt, error) {
+	return append([]store.WorkAttempt(nil), s.pendingCapacityReleases...), nil
+}
+
+func (s *recordingWorkAttemptStore) ClearWorkAttemptCapacityRelease(_ context.Context, attemptID int64) error {
+	s.clearedCapacityReleases = append(s.clearedCapacityReleases, attemptID)
+	return nil
 }
 
 func (s *recordingWorkAttemptStore) ListRecentTerminalWorkAttempts(_ context.Context, query store.WorkAttemptHistoryQuery) ([]store.WorkAttempt, error) {

--- a/internal/orchestrator/dispatch_test.go
+++ b/internal/orchestrator/dispatch_test.go
@@ -173,6 +173,43 @@ func TestRecoverDurableWorkAttemptsRetainsCapacityActionWhenReleaseFails(t *test
 	}
 }
 
+func TestRecoverDurableWorkAttemptsPreservesNewerClaimLease(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 7, 17, 20, 0, 0, 0, time.UTC)
+	issue := claimTestIssue("issue-1430-newer-lease")
+	wantLease := now.Add(-10 * time.Minute).Format(time.RFC3339Nano)
+	issue.Fields["Detent Lease"] = wantLease
+	claimStore := newClaimTestStore([]connector.Issue{issue})
+	attempts := &recordingWorkAttemptStore{pendingCapacityReleases: []store.WorkAttempt{{
+		ID:            1432,
+		ProjectID:     "detent",
+		IssueID:       issue.ID,
+		Identifier:    issue.Identifier,
+		Status:        store.WorkAttemptStatusTerminal,
+		CompletedAt:   now.Add(-30 * time.Minute),
+		TerminalState: store.WorkAttemptTerminalSuccess,
+		NextAction:    "release capacity",
+	}}}
+	cfg := normalizeConfig(claimTestConfig("alpha", "alpha"))
+	cfg.Project = scheduler.ProjectCandidate{ID: "detent"}
+	o := &Orchestrator{
+		cfg:          cfg,
+		connector:    claimTestConnector{store: claimStore, login: "alpha"},
+		workAttempts: attempts,
+	}
+	state := newState(cfg)
+
+	o.recoverDurableWorkAttempts(t.Context(), &state, now)
+
+	if got := claimStore.issue(issue.ID).Fields["Detent Lease"]; got != wantLease {
+		t.Fatalf("Detent Lease = %q, want newer lease %q preserved", got, wantLease)
+	}
+	if len(attempts.clearedCapacityReleases) != 1 || attempts.clearedCapacityReleases[0] != 1432 {
+		t.Fatalf("cleared capacity releases = %v, want stale action [1432] acknowledged", attempts.clearedCapacityReleases)
+	}
+}
+
 func TestConfigFromWorkflowIncludesDispatchControls(t *testing.T) {
 	t.Parallel()
 

--- a/internal/orchestrator/work_attempts.go
+++ b/internal/orchestrator/work_attempts.go
@@ -98,14 +98,23 @@ func (o *Orchestrator) recoverPendingWorkAttemptCapacityReleases(ctx context.Con
 		}
 		return
 	}
+	issuesByID, err := o.workAttemptCapacityReleaseIssues(ctx, pending)
+	if err != nil {
+		if o.logger != nil {
+			o.logger.Warn("work attempt capacity release issue lookup failed", "project_id", projectID, "error", err)
+		}
+		return
+	}
 	for _, attempt := range pending {
-		if err := o.abandonClaim(ctx, attempt.IssueID); err != nil {
-			recordStateEvent(state, telemetry.ActivityEvent{
-				At:      now,
-				Event:   "work_attempt_capacity_release_failed",
-				Message: fmt.Sprintf("capacity release failed for %s: %v", workAttemptLabel(attempt), err),
-			})
-			continue
+		if o.workAttemptCapacityReleaseNeedsClaimClear(attempt, issuesByID) {
+			if err := o.abandonClaim(ctx, attempt.IssueID); err != nil {
+				recordStateEvent(state, telemetry.ActivityEvent{
+					At:      now,
+					Event:   "work_attempt_capacity_release_failed",
+					Message: fmt.Sprintf("capacity release failed for %s: %v", workAttemptLabel(attempt), err),
+				})
+				continue
+			}
 		}
 		if err := releases.ClearWorkAttemptCapacityRelease(ctx, attempt.ID); err != nil {
 			if o.logger != nil {
@@ -122,6 +131,40 @@ func (o *Orchestrator) recoverPendingWorkAttemptCapacityReleases(ctx context.Con
 			Message: "released legacy terminal capacity for " + workAttemptLabel(attempt),
 		})
 	}
+}
+
+func (o *Orchestrator) workAttemptCapacityReleaseIssues(ctx context.Context, attempts []store.WorkAttempt) (map[string]connector.Issue, error) {
+	issuesByID := make(map[string]connector.Issue)
+	if !o.cfg.Claiming.Enabled || strings.TrimSpace(o.cfg.Claiming.LeaseField) == "" {
+		return issuesByID, nil
+	}
+	issueIDs := make([]string, 0, len(attempts))
+	for _, attempt := range attempts {
+		if issueID := strings.TrimSpace(attempt.IssueID); issueID != "" {
+			issueIDs = append(issueIDs, issueID)
+		}
+	}
+	issueIDs = uniqueStrings(issueIDs)
+	if len(issueIDs) == 0 {
+		return issuesByID, nil
+	}
+	issues, err := o.connector.FetchIssueStatesByIDs(ctx, issueIDs)
+	if err != nil {
+		return nil, err
+	}
+	for _, issue := range issues {
+		issuesByID[issue.ID] = issue
+	}
+	return issuesByID, nil
+}
+
+func (o *Orchestrator) workAttemptCapacityReleaseNeedsClaimClear(attempt store.WorkAttempt, issuesByID map[string]connector.Issue) bool {
+	issue, ok := issuesByID[strings.TrimSpace(attempt.IssueID)]
+	if !ok || attempt.CompletedAt.IsZero() {
+		return false
+	}
+	lease, ok := o.issueLease(issue)
+	return ok && lease.Before(attempt.CompletedAt)
 }
 
 func workAttemptLabel(attempt store.WorkAttempt) string {

--- a/internal/orchestrator/work_attempts.go
+++ b/internal/orchestrator/work_attempts.go
@@ -68,6 +68,7 @@ func (o *Orchestrator) recoverDurableWorkAttempts(ctx context.Context, state *St
 	for _, attempt := range reclaimed {
 		o.recordRecoveredWorkAttempt(state, attempt, now)
 	}
+	o.recoverPendingWorkAttemptCapacityReleases(ctx, state, projectID, now)
 	recent, err := o.workAttempts.ListRecentTerminalWorkAttempts(ctx, store.WorkAttemptHistoryQuery{
 		ProjectID: projectID,
 		Limit:     maxRecentWorkAttemptSnapshots,
@@ -83,6 +84,54 @@ func (o *Orchestrator) recoverDurableWorkAttempts(ctx context.Context, state *St
 	}
 	o.recoverOrphanedAgentSessions(ctx, state, orphanedSessions, now)
 	o.recoverPendingOperatorStops(ctx, state, now)
+}
+
+func (o *Orchestrator) recoverPendingWorkAttemptCapacityReleases(ctx context.Context, state *State, projectID string, now time.Time) {
+	releases, ok := o.workAttempts.(store.WorkAttemptCapacityReleaseStore)
+	if !ok {
+		return
+	}
+	pending, err := releases.ListPendingWorkAttemptCapacityReleases(ctx, projectID)
+	if err != nil {
+		if o.logger != nil {
+			o.logger.Warn("work attempt capacity release recovery failed", "project_id", projectID, "error", err)
+		}
+		return
+	}
+	for _, attempt := range pending {
+		if err := o.abandonClaim(ctx, attempt.IssueID); err != nil {
+			recordStateEvent(state, telemetry.ActivityEvent{
+				At:      now,
+				Event:   "work_attempt_capacity_release_failed",
+				Message: fmt.Sprintf("capacity release failed for %s: %v", workAttemptLabel(attempt), err),
+			})
+			continue
+		}
+		if err := releases.ClearWorkAttemptCapacityRelease(ctx, attempt.ID); err != nil {
+			if o.logger != nil {
+				o.logger.Warn("work attempt capacity release clear failed", "project_id", projectID, "attempt_id", attempt.ID, "issue_id", attempt.IssueID, "identifier", attempt.Identifier, "error", err)
+			}
+			continue
+		}
+		if o.logger != nil {
+			o.logger.Info("reconciled terminal work attempt capacity release", "project_id", projectID, "attempt_id", attempt.ID, "issue_id", attempt.IssueID, "identifier", attempt.Identifier, "terminal_state", attempt.TerminalState)
+		}
+		recordStateEvent(state, telemetry.ActivityEvent{
+			At:      now,
+			Event:   "work_attempt_capacity_released",
+			Message: "released legacy terminal capacity for " + workAttemptLabel(attempt),
+		})
+	}
+}
+
+func workAttemptLabel(attempt store.WorkAttempt) string {
+	if identifier := strings.TrimSpace(attempt.Identifier); identifier != "" {
+		return identifier
+	}
+	if issueID := strings.TrimSpace(attempt.IssueID); issueID != "" {
+		return issueID
+	}
+	return fmt.Sprintf("work attempt %d", attempt.ID)
 }
 
 func (o *Orchestrator) recoverOrphanedAgentSessions(ctx context.Context, state *State, sessions []store.OrphanedAgentSession, now time.Time) {

--- a/internal/store/sqlc/store.sql.go
+++ b/internal/store/sqlc/store.sql.go
@@ -105,6 +105,20 @@ func (q *Queries) BudgetCostEvents(ctx context.Context, arg BudgetCostEventsPara
 	return items, nil
 }
 
+const clearWorkAttemptCapacityRelease = `-- name: ClearWorkAttemptCapacityRelease :exec
+UPDATE work_attempts
+SET next_action = NULL
+WHERE id = ?1
+  AND status = 'terminal'
+  AND completed_at IS NOT NULL
+  AND lower(trim(COALESCE(next_action, ''))) = 'release capacity'
+`
+
+func (q *Queries) ClearWorkAttemptCapacityRelease(ctx context.Context, workAttemptID int64) error {
+	_, err := q.db.ExecContext(ctx, clearWorkAttemptCapacityRelease, workAttemptID)
+	return err
+}
+
 const completeWorkAttempt = `-- name: CompleteWorkAttempt :execrows
 UPDATE work_attempts
 SET status = ?,
@@ -2841,6 +2855,75 @@ ORDER BY completed_at, id
 
 func (q *Queries) ListPendingOperatorStops(ctx context.Context, projectID string) ([]WorkAttempt, error) {
 	rows, err := q.db.QueryContext(ctx, listPendingOperatorStops, projectID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []WorkAttempt{}
+	for rows.Next() {
+		var i WorkAttempt
+		if err := rows.Scan(
+			&i.ID,
+			&i.ProjectID,
+			&i.IssueID,
+			&i.Identifier,
+			&i.IssueURL,
+			&i.PrNumber,
+			&i.Repo,
+			&i.WorkerType,
+			&i.WorkerHost,
+			&i.Lane,
+			&i.AttemptNumber,
+			&i.Status,
+			&i.StartedAt,
+			&i.LeaseExpiresAt,
+			&i.HeartbeatAt,
+			&i.CompletedAt,
+			&i.TerminalState,
+			&i.ErrorClass,
+			&i.ErrorMessage,
+			&i.Phase,
+			&i.StatusMessage,
+			&i.CurrentStep,
+			&i.TotalSteps,
+			&i.ProgressPercent,
+			&i.CurrentCommand,
+			&i.WaitReason,
+			&i.GithubRateSnapshotJson,
+			&i.CiState,
+			&i.CapacitySnapshotJson,
+			&i.WorkerMetadataJson,
+			&i.MetricsJson,
+			&i.NextAction,
+			&i.DetentSessionID,
+			&i.ProviderSessionID,
+			&i.RuntimeIdentityJson,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+const listPendingWorkAttemptCapacityReleases = `-- name: ListPendingWorkAttemptCapacityReleases :many
+SELECT id, project_id, issue_id, identifier, issue_url, pr_number, repo, worker_type, worker_host, lane, attempt_number, status, started_at, lease_expires_at, heartbeat_at, completed_at, terminal_state, error_class, error_message, phase, status_message, current_step, total_steps, progress_percent, current_command, wait_reason, github_rate_snapshot_json, ci_state, capacity_snapshot_json, worker_metadata_json, metrics_json, next_action, detent_session_id, provider_session_id, runtime_identity_json
+FROM work_attempts
+WHERE project_id = ?1
+  AND status = 'terminal'
+  AND completed_at IS NOT NULL
+  AND lower(trim(COALESCE(next_action, ''))) = 'release capacity'
+ORDER BY completed_at, id
+`
+
+func (q *Queries) ListPendingWorkAttemptCapacityReleases(ctx context.Context, projectID string) ([]WorkAttempt, error) {
+	rows, err := q.db.QueryContext(ctx, listPendingWorkAttemptCapacityReleases, projectID)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -46,6 +46,7 @@ type Store interface {
 	ProgressSpendStore
 	WorkflowMetricsStore
 	WorkAttemptStore
+	WorkAttemptCapacityReleaseStore
 	OperatorStopStore
 	ValidatorMemoStore
 	RuntimeEvidenceStore
@@ -138,6 +139,11 @@ type WorkAttemptStore interface {
 	ReclaimActiveWorkAttempts(context.Context, WorkAttemptReclaim) ([]WorkAttempt, error)
 	RecordSchedulerDecision(context.Context, SchedulerDecision) (int64, error)
 	ListRecentSchedulerDecisions(context.Context, SchedulerDecisionQuery) ([]SchedulerDecision, error)
+}
+
+type WorkAttemptCapacityReleaseStore interface {
+	ListPendingWorkAttemptCapacityReleases(context.Context, string) ([]WorkAttempt, error)
+	ClearWorkAttemptCapacityRelease(context.Context, int64) error
 }
 
 type OperatorStopStore interface {

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"errors"
+	"fmt"
 	"math"
 	"path/filepath"
 	"strings"
@@ -782,6 +783,84 @@ func TestWorkAttemptStoreRoundTripDecisionsAndRecovery(t *testing.T) {
 	}
 	if len(recovered) != 1 || recovered[0].ID != staleID || recovered[0].TerminalState != WorkAttemptTerminalTimedOut {
 		t.Fatalf("recovered stale attempts = %#v, want stale timeout id %d", recovered, staleID)
+	}
+}
+
+func TestWorkAttemptCapacityReleaseStore(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	backend := openTestStore(t, ctx)
+	base := time.Date(2026, 7, 17, 20, 0, 0, 0, time.UTC)
+	tests := []struct {
+		name        string
+		projectID   string
+		nextAction  string
+		terminal    bool
+		wantPending bool
+	}{
+		{name: "terminal release for project", projectID: "detent", nextAction: " release CAPACITY ", terminal: true, wantPending: true},
+		{name: "active release for project", projectID: "detent", nextAction: "release capacity"},
+		{name: "unrelated terminal action", projectID: "detent", nextAction: "retry tracker transition", terminal: true},
+		{name: "terminal release for another project", projectID: "video", nextAction: "release capacity", terminal: true},
+	}
+
+	var wantID int64
+	for index, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			startedAt := base.Add(time.Duration(index) * time.Minute)
+			attemptID, err := backend.StartWorkAttempt(ctx, WorkAttemptStart{
+				ProjectID:  tt.projectID,
+				IssueID:    fmt.Sprintf("issue-%d", index),
+				WorkerType: "agent",
+				StartedAt:  startedAt,
+				NextAction: tt.nextAction,
+			})
+			if err != nil {
+				t.Fatalf("StartWorkAttempt() error = %v", err)
+			}
+			if tt.terminal {
+				if err := backend.CompleteWorkAttempt(ctx, WorkAttemptCompletion{
+					AttemptID:     attemptID,
+					CompletedAt:   startedAt.Add(30 * time.Second),
+					TerminalState: WorkAttemptTerminalSuccess,
+					NextAction:    tt.nextAction,
+				}); err != nil {
+					t.Fatalf("CompleteWorkAttempt() error = %v", err)
+				}
+			}
+			if tt.wantPending {
+				wantID = attemptID
+			}
+		})
+	}
+
+	pending, err := backend.ListPendingWorkAttemptCapacityReleases(ctx, " detent ")
+	if err != nil {
+		t.Fatalf("ListPendingWorkAttemptCapacityReleases() error = %v", err)
+	}
+	if len(pending) != 1 || pending[0].ID != wantID {
+		t.Fatalf("pending capacity releases = %#v, want attempt %d", pending, wantID)
+	}
+	if err := backend.ClearWorkAttemptCapacityRelease(ctx, wantID); err != nil {
+		t.Fatalf("ClearWorkAttemptCapacityRelease() error = %v", err)
+	}
+	if err := backend.ClearWorkAttemptCapacityRelease(ctx, wantID); err != nil {
+		t.Fatalf("ClearWorkAttemptCapacityRelease() repeated error = %v", err)
+	}
+	pending, err = backend.ListPendingWorkAttemptCapacityReleases(ctx, "detent")
+	if err != nil {
+		t.Fatalf("ListPendingWorkAttemptCapacityReleases() after clear error = %v", err)
+	}
+	if len(pending) != 0 {
+		t.Fatalf("pending capacity releases after clear = %#v, want none", pending)
+	}
+	receipt, err := backend.WorkAttempt(ctx, wantID)
+	if err != nil {
+		t.Fatalf("WorkAttempt() error = %v", err)
+	}
+	if receipt.NextAction != "" {
+		t.Fatalf("NextAction = %q, want cleared", receipt.NextAction)
 	}
 }
 

--- a/internal/store/work_attempts.go
+++ b/internal/store/work_attempts.go
@@ -225,6 +225,28 @@ func (s *sqliteStore) ListRecentTerminalWorkAttempts(ctx context.Context, query 
 	return workAttemptsFromRows(rows)
 }
 
+func (s *sqliteStore) ListPendingWorkAttemptCapacityReleases(ctx context.Context, projectID string) ([]WorkAttempt, error) {
+	projectID = strings.TrimSpace(projectID)
+	if projectID == "" {
+		return nil, errors.New("project_id is required")
+	}
+	rows, err := s.queries.ListPendingWorkAttemptCapacityReleases(ctx, projectID)
+	if err != nil {
+		return nil, fmt.Errorf("listing pending work attempt capacity releases: %w", err)
+	}
+	return workAttemptsFromRows(rows)
+}
+
+func (s *sqliteStore) ClearWorkAttemptCapacityRelease(ctx context.Context, attemptID int64) error {
+	if attemptID <= 0 {
+		return errors.New("attempt_id is required")
+	}
+	if err := s.queries.ClearWorkAttemptCapacityRelease(ctx, attemptID); err != nil {
+		return fmt.Errorf("clearing work attempt capacity release: %w", err)
+	}
+	return nil
+}
+
 func (s *sqliteStore) UpdateOperatorStop(ctx context.Context, attrs OperatorStopUpdate) error {
 	if attrs.AttemptID <= 0 {
 		return ErrNotFound


### PR DESCRIPTION
## Summary

- Reconcile terminal work attempts with a pending `release capacity` action during orchestrator startup.
- Release only persisted claim leases older than their completed attempts, preserving newer claims held by another instance.
- Retain failed releases for retry and scope the SQLite sweep to matching terminal actions for the configured project.

Fixes #1430

## UI Surface Contract

- [x] N/A — this PR does not change UI surfaces, layout, density, or responsive visibility.
- [x] This PR does not add persistent top-of-screen messaging.
- [x] N/A — this PR has no visual changes to primary operator screens.

## Test Plan

- [x] `make generate`
- [x] `go test -race ./internal/store ./internal/orchestrator`
- [x] `make check` (77.3% total coverage; package/file floors passed)
- [x] Regression coverage preserves a newer multi-instance claim lease while acknowledging the stale action.
