### PR TITLE
fix(connector): budget CI detail REST fetches

### DIFF
--- a/internal/connector/github/adapter_test.go
+++ b/internal/connector/github/adapter_test.go
@@ -4841,6 +4841,75 @@ func TestConnectorHydratePullRequestDetectsTransientKilledCheck(t *testing.T) {
 	}
 }
 
+func TestConnectorHydratePullRequestIncludesWorkflowAndAnnotationsInRESTFanoutCap(t *testing.T) {
+	t.Parallel()
+
+	server := newGraphQLTestServer(t, []graphqlTestResponse{
+		{
+			method: http.MethodGet,
+			path:   "/repos/example/repo/pulls/42",
+			body:   `{"number":42,"html_url":"https://github.com/example/repo/pull/42","state":"open","mergeable_state":"clean","head":{"ref":"detent/example","sha":"head-sha"},"base":{"sha":"base-sha"}}`,
+		},
+		{
+			method: http.MethodGet,
+			path:   "/repos/example/repo/commits/head-sha/check-runs?per_page=100",
+			body:   `{"check_runs":[{"id":9001,"name":"Checks","status":"completed","conclusion":"failure","details_url":"https://github.com/example/repo/actions/runs/8001/job/9001"}]}`,
+		},
+		{
+			method: http.MethodGet,
+			path:   "/repos/example/repo/actions/runs/8001",
+			body:   `{"id":8001}`,
+		},
+		{
+			method: http.MethodGet,
+			path:   "/repos/example/repo/commits/head-sha/statuses?per_page=100",
+			body:   `[]`,
+		},
+		{
+			method: http.MethodGet,
+			path:   "/repos/example/repo/check-runs/9001/annotations?per_page=100",
+			body:   `[]`,
+		},
+		{
+			method: http.MethodGet,
+			path:   "/repos/example/repo/pulls/42/reviews?per_page=100",
+			body:   `[]`,
+		},
+	})
+	c := newGitHubTestConnector(t, server, Config{
+		RESTFanoutMaxRequests:      4,
+		DisableConditionalRequests: true,
+	})
+	prNumber := 42
+	issue := connector.Issue{
+		ID:         "I_kw42",
+		Identifier: "example/repo#1",
+		PRNumber:   &prNumber,
+	}
+
+	got, err := c.HydratePullRequest(context.Background(), issue)
+	if err != nil {
+		t.Fatalf("HydratePullRequest() error = %v", err)
+	}
+	if got.PullRequest == nil || got.PullRequest.HydrationUnavailableReason != connector.PullRequestHydrationReasonRESTBudgetReserved {
+		t.Fatalf("PullRequest = %#v, want REST budget reservation", got.PullRequest)
+	}
+	if requests := server.requests(); len(requests) != 4 {
+		t.Fatalf("outbound REST requests = %d, want fanout cap 4; requests = %#v", len(requests), requests)
+	}
+
+	usage := c.FlushRESTRateLimitUsage()
+	if got := restEndpointUsageCount(usage.Requests, "other"); got != 0 {
+		t.Fatalf("other usage count = %d, want no unclassified hydration requests; usage = %#v", got, usage.Requests)
+	}
+	if got := restEndpointUsageCount(usage.Requests, "workflow runs"); got != 1 {
+		t.Fatalf("workflow runs usage count = %d, want 1; usage = %#v", got, usage.Requests)
+	}
+	if got := restEndpointUsageCount(usage.Requests, "check run annotations"); got != 1 {
+		t.Fatalf("check run annotations usage count = %d, want throttled synthetic request; usage = %#v", got, usage.Requests)
+	}
+}
+
 func TestConnectorRerunPullRequestChecksUsesWorkflowRun(t *testing.T) {
 	t.Parallel()
 

--- a/internal/connector/github/adapter_test.go
+++ b/internal/connector/github/adapter_test.go
@@ -2601,7 +2601,11 @@ func TestTransientCheckRunFailuresExcludeSupersededFailures(t *testing.T) {
 	}
 	c := &Connector{}
 
-	if got := c.transientCheckRunFailures(context.Background(), pullRequestRepo{}, checkRuns); len(got) != 0 {
+	got, err := c.transientCheckRunFailures(context.Background(), pullRequestRepo{}, checkRuns)
+	if err != nil {
+		t.Fatalf("transientCheckRunFailures() error = %v", err)
+	}
+	if len(got) != 0 {
 		t.Fatalf("transientCheckRunFailures() = %#v, want none", got)
 	}
 }
@@ -4907,6 +4911,92 @@ func TestConnectorHydratePullRequestIncludesWorkflowAndAnnotationsInRESTFanoutCa
 	}
 	if got := restEndpointUsageCount(usage.Requests, "check run annotations"); got != 1 {
 		t.Fatalf("check run annotations usage count = %d, want throttled synthetic request; usage = %#v", got, usage.Requests)
+	}
+}
+
+func TestConnectorHydratePullRequestPropagatesCIDetailThrottles(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 7, 18, 13, 0, 0, 0, time.UTC)
+	throttleResponse := func(path string) graphqlTestResponse {
+		return graphqlTestResponse{
+			method: http.MethodGet,
+			path:   path,
+			status: http.StatusTooManyRequests,
+			headers: map[string]string{
+				"Retry-After":           "120",
+				"X-RateLimit-Limit":     "5000",
+				"X-RateLimit-Used":      "264",
+				"X-RateLimit-Remaining": "4736",
+				"X-RateLimit-Resource":  "core",
+			},
+			body: `{"message":"secondary rate limit"}`,
+		}
+	}
+	tests := []struct {
+		name         string
+		responses    []graphqlTestResponse
+		wantRequests int
+	}{
+		{
+			name: "workflow run",
+			responses: []graphqlTestResponse{
+				{method: http.MethodGet, path: "/repos/example/repo/pulls/42", body: `{"number":42,"html_url":"https://github.com/example/repo/pull/42","state":"open","head":{"ref":"detent/example","sha":"head-sha"}}`},
+				{method: http.MethodGet, path: "/repos/example/repo/commits/head-sha/check-runs?per_page=100", body: `{"check_runs":[{"id":9001,"name":"Checks","status":"completed","conclusion":"failure","details_url":"https://github.com/example/repo/actions/runs/8001/job/9001"}]}`},
+				throttleResponse("/repos/example/repo/actions/runs/8001"),
+				{method: http.MethodGet, path: "/repos/example/repo/commits/head-sha/statuses?per_page=100", body: `[]`},
+				{method: http.MethodGet, path: "/repos/example/repo/check-runs/9001/annotations?per_page=100", body: `[]`},
+				{method: http.MethodGet, path: "/repos/example/repo/pulls/42/reviews?per_page=100", body: `[]`},
+			},
+			wantRequests: 3,
+		},
+		{
+			name: "check run annotations",
+			responses: []graphqlTestResponse{
+				{method: http.MethodGet, path: "/repos/example/repo/pulls/42", body: `{"number":42,"html_url":"https://github.com/example/repo/pull/42","state":"open","head":{"ref":"detent/example","sha":"head-sha"}}`},
+				{method: http.MethodGet, path: "/repos/example/repo/commits/head-sha/check-runs?per_page=100", body: `{"check_runs":[{"id":9001,"name":"Checks","status":"completed","conclusion":"failure"}]}`},
+				{method: http.MethodGet, path: "/repos/example/repo/commits/head-sha/statuses?per_page=100", body: `[]`},
+				throttleResponse("/repos/example/repo/check-runs/9001/annotations?per_page=100"),
+				{method: http.MethodGet, path: "/repos/example/repo/pulls/42/reviews?per_page=100", body: `[]`},
+			},
+			wantRequests: 4,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			server := newGraphQLTestServer(t, test.responses)
+			c := newGitHubTestConnector(t, server, Config{
+				Now: func() time.Time {
+					return now
+				},
+			})
+			prNumber := 42
+			issue := connector.Issue{
+				ID:         "I_kw42",
+				Identifier: "example/repo#1",
+				PRNumber:   &prNumber,
+			}
+
+			got, err := c.HydratePullRequest(context.Background(), issue)
+			if err != nil {
+				t.Fatalf("HydratePullRequest() error = %v", err)
+			}
+			if got.PullRequest == nil {
+				t.Fatal("PullRequest = nil, want hydration throttle marker")
+			}
+			if got.PullRequest.HydrationUnavailableReason != connector.PullRequestHydrationReasonSecondaryThrottled {
+				t.Fatalf("HydrationUnavailableReason = %q, want secondary_throttled", got.PullRequest.HydrationUnavailableReason)
+			}
+			if got.PullRequest.HydrationNextRetryAt == nil || !got.PullRequest.HydrationNextRetryAt.After(now.Add(120*time.Second)) {
+				t.Fatalf("HydrationNextRetryAt = %v, want retry-after plus jitter", got.PullRequest.HydrationNextRetryAt)
+			}
+			if requests := server.requests(); len(requests) != test.wantRequests {
+				t.Fatalf("outbound REST requests = %d, want %d; requests = %#v", len(requests), test.wantRequests, requests)
+			}
+		})
 	}
 }
 

--- a/internal/connector/github/client.go
+++ b/internal/connector/github/client.go
@@ -1586,6 +1586,10 @@ func restEndpointFamily(method string, path string) string {
 		return "reviews"
 	case len(segments) == 6 && segments[3] == "pulls" && segments[5] == "merge":
 		return "mutations"
+	case len(segments) == 6 && segments[3] == "actions" && segments[4] == "runs":
+		return "workflow runs"
+	case len(segments) == 6 && segments[3] == "check-runs" && segments[5] == "annotations":
+		return "check run annotations"
 	case len(segments) == 6 && segments[3] == "commits" && segments[5] == "check-runs":
 		return "check runs"
 	case len(segments) == 6 && segments[3] == "commits" && segments[5] == "statuses":
@@ -1654,7 +1658,7 @@ func retryAfterSeconds(err error) int64 {
 
 func restFanoutEndpointFamily(family string) bool {
 	switch family {
-	case "pull requests", "check runs", "commit statuses", "reviews", "repository issues",
+	case "pull requests", "check runs", "check run annotations", "workflow runs", "commit statuses", "reviews", "repository issues",
 		"issue reads", "issue comments", "issue dependencies", "issue field values":
 		return true
 	default:

--- a/internal/connector/github/client_test.go
+++ b/internal/connector/github/client_test.go
@@ -766,6 +766,8 @@ func TestRESTFanoutEndpointFamilyIncludesBulkHydrationReads(t *testing.T) {
 		{name: "issue comments", path: "/repos/digitaldrywood/detent/issues/1384/comments?per_page=100", wantFamily: "issue comments"},
 		{name: "issue dependencies", path: "/repos/digitaldrywood/detent/issues/1384/dependencies/blocked_by?per_page=100", wantFamily: "issue dependencies"},
 		{name: "issue field values", path: "/repos/digitaldrywood/detent/issues/1384/issue-field-values?per_page=100", wantFamily: "issue field values"},
+		{name: "workflow run", path: "/repos/digitaldrywood/detent/actions/runs/8001", wantFamily: "workflow runs"},
+		{name: "check run annotations", path: "/repos/digitaldrywood/detent/check-runs/9001/annotations?per_page=100", wantFamily: "check run annotations"},
 	}
 
 	for _, test := range tests {

--- a/internal/connector/github/pull_request_checks.go
+++ b/internal/connector/github/pull_request_checks.go
@@ -2,6 +2,7 @@ package github
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sort"
 	"strconv"
@@ -32,6 +33,9 @@ func (c *Connector) fetchPullRequestCI(ctx context.Context, repo pullRequestRepo
 	effectiveRuns := effectiveCheckRuns(checkRuns)
 	workflowRuns, workflowRunErr := fetchRESTWorkflowRunsForCheckRuns(ctx, c.client, repo, effectiveRuns)
 	if workflowRunErr != nil {
+		if pullRequestHydrationThrottleError(workflowRunErr) {
+			return pullRequestCI{}, fmt.Errorf("fetch github workflow runs: %w", workflowRunErr)
+		}
 		workflowRuns = nil
 	}
 	statuses, err := fetchRESTList[restCommitStatus](ctx, c.client, restCommitStatusesPath(repo, sha))
@@ -48,6 +52,10 @@ func (c *Connector) fetchPullRequestCI(ctx context.Context, repo pullRequestRepo
 	} else if requiredState != "" {
 		state = combinedCIState(requiredState, state)
 	}
+	transientFailures, err := c.transientCheckRunFailures(ctx, repo, checkRuns)
+	if err != nil {
+		return pullRequestCI{}, err
+	}
 	return pullRequestCI{
 		State:                 state,
 		CheckRunCount:         len(checkRuns),
@@ -58,11 +66,11 @@ func (c *Connector) fetchPullRequestCI(ctx context.Context, repo pullRequestRepo
 		RunningChecks:         telemetry.RunningChecks,
 		StaleSuccessfulChecks: staleSuccessfulChecks,
 		RequiredFailures:      requiredFailures,
-		TransientFailures:     c.transientCheckRunFailures(ctx, repo, checkRuns),
+		TransientFailures:     transientFailures,
 	}, nil
 }
 
-func (c *Connector) transientCheckRunFailures(ctx context.Context, repo pullRequestRepo, checkRuns []restCheckRun) []connector.PullRequestCheck {
+func (c *Connector) transientCheckRunFailures(ctx context.Context, repo pullRequestRepo, checkRuns []restCheckRun) ([]connector.PullRequestCheck, error) {
 	failures := make([]connector.PullRequestCheck, 0)
 	for _, checkRun := range effectiveCheckRuns(checkRuns) {
 		if !completedFailedCheckRun(checkRun) {
@@ -72,6 +80,9 @@ func (c *Connector) transientCheckRunFailures(ctx context.Context, repo pullRequ
 		if checkRun.ID > 0 {
 			annotations, err := fetchRESTCheckRunAnnotations(ctx, c.client, restCheckRunAnnotationsPath(repo, checkRun.ID))
 			if err != nil {
+				if pullRequestHydrationThrottleError(err) {
+					return nil, fmt.Errorf("fetch github check run annotations: %w", err)
+				}
 				if c.logger != nil {
 					c.logger.DebugContext(ctx, "fetch github check run annotations failed", "check_run_id", checkRun.ID, "check_run_name", checkRun.Name, "error", err)
 				}
@@ -91,7 +102,11 @@ func (c *Connector) transientCheckRunFailures(ctx context.Context, repo pullRequ
 			DetailsURL:    firstNonBlank(checkRun.DetailsURL, checkRun.HTMLURL),
 		})
 	}
-	return failures
+	return failures, nil
+}
+
+func pullRequestHydrationThrottleError(err error) bool {
+	return errors.Is(err, ErrRateLimited) || errors.Is(err, ErrRESTBudgetReserved)
 }
 
 func (c *Connector) logStaleSuccessfulCheckRuns(ctx context.Context, repo pullRequestRepo, sha string, checks []connector.PullRequestCheck) {


### PR DESCRIPTION
## Summary

- classify workflow-run detail and check-run annotation reads as explicit REST endpoint families
- count both families against the configured hydration fan-out budget
- propagate budget and rate-limit interruptions from optional CI detail reads into the PR hydration circuit
- verify the cap with actual outbound request counts, per-family usage assertions, and secondary-throttle coverage

Fixes #1389

## UI Surface Contract

- [x] N/A, or the linked issue explicitly authorizes any high-impact UI surface, layout, density, first-viewport, or responsive visibility tradeoff.
- [x] Persistent top-of-screen messaging is explicitly authorized by the issue, or this PR does not add it.
- [x] Visual changes to primary operator screens include screenshot or browser verification below.

## Test Plan

- [x] `go test ./internal/connector/github -count=1`
- [x] `make check`