### PR TITLE
fix(orchestrator): isolate worker heartbeats

### DIFF
--- a/internal/claudecode/process.go
+++ b/internal/claudecode/process.go
@@ -66,6 +66,11 @@ func (b *AgentBackend) RunTurn(
 			stderrWriter.Close(),
 		)
 	}
+	if err := procgroup.Deprioritize(cmd); err != nil {
+		processGroupID := procgroup.GroupID(cmd)
+		err = terminateWithCause(cmd, processGroupID, fmt.Errorf("deprioritize claude worker process: %w", err))
+		return runner.AgentTurnResult{}, errors.Join(err, waitAndCleanup(cmd, processGroupID), stdout.Close(), stdoutWriter.Close(), stderrReader.Close(), stderrWriter.Close())
+	}
 	if err := errors.Join(stdoutWriter.Close(), stderrWriter.Close()); err != nil {
 		processGroupID := procgroup.GroupID(cmd)
 		err = terminateWithCause(cmd, processGroupID, fmt.Errorf("close parent output writers: %w", err))

--- a/internal/codex/transport.go
+++ b/internal/codex/transport.go
@@ -101,6 +101,17 @@ func (f *LocalTransportFactory) NewTransport(ctx context.Context) (Transport, er
 		}
 		return nil, fmt.Errorf("start command: %w", err)
 	}
+	if err := procgroup.Deprioritize(cmd); err != nil {
+		terminateErr := procgroup.TerminateTree(cmd, procgroup.GroupID(cmd))
+		waitErr := cmd.Wait()
+		closeErr := stdin.Close()
+		return nil, errors.Join(
+			fmt.Errorf("deprioritize worker process: %w", err),
+			terminateErr,
+			waitErr,
+			closeErr,
+		)
+	}
 	workerProcess, err := procgroup.Inspect(cmd)
 	if err != nil {
 		terminateErr := procgroup.TerminateTree(cmd, procgroup.GroupID(cmd))

--- a/internal/orchestrator/autopromote_tick.go
+++ b/internal/orchestrator/autopromote_tick.go
@@ -1033,6 +1033,7 @@ func (o *Orchestrator) failStalledMergeWorkerStarts(ctx context.Context, state *
 		if running.cancel != nil {
 			running.cancel()
 		}
+		o.heartbeats.remove(issueID)
 		delete(state.Running, issueID)
 		attempt := nextAttempt(running.Attempt)
 		if attempt > maxMergeWorkerRunnerFailures && o.blockExhaustedMergeWorker(ctx, state, running, now, attempt, err) {

--- a/internal/orchestrator/claim.go
+++ b/internal/orchestrator/claim.go
@@ -26,7 +26,7 @@ func (o *Orchestrator) claimIssue(ctx context.Context, issue connector.Issue, no
 	if owner == "" || o.cfg.Claiming.LeaseField == "" || o.fieldClaimMissingOwnerField() {
 		return connector.Issue{}, Claimed{}, false
 	}
-	if !o.claimable(issue, owner, now) {
+	if !o.claimable(ctx, issue, owner, now) {
 		return connector.Issue{}, Claimed{}, false
 	}
 	if err := o.writeClaim(ctx, issue.ID, owner, now); err != nil {
@@ -82,7 +82,7 @@ func (o *Orchestrator) refetchClaimedIssue(ctx context.Context, fallback connect
 	return connector.Issue{}, false
 }
 
-func (o *Orchestrator) claimable(issue connector.Issue, owner string, now time.Time) bool {
+func (o *Orchestrator) claimable(ctx context.Context, issue connector.Issue, owner string, now time.Time) bool {
 	winner := o.claimWinner(issue)
 	if winner == "" || sameClaimOwner(winner, owner) {
 		return true
@@ -91,7 +91,13 @@ func (o *Orchestrator) claimable(issue connector.Issue, owner string, now time.T
 	if !ok {
 		return true
 	}
-	return o.leaseStale(lease, now)
+	if !o.leaseStale(lease, now) {
+		return false
+	}
+	if o.heartbeats != nil && o.heartbeats.protects(issue.ID) {
+		return false
+	}
+	return !o.persistedWorkerLive(ctx, issue)
 }
 
 func (o *Orchestrator) verifiedClaim(issue connector.Issue, owner string) (Claimed, bool) {

--- a/internal/orchestrator/dispatch.go
+++ b/internal/orchestrator/dispatch.go
@@ -492,6 +492,7 @@ func (o *Orchestrator) dispatchIssueWithOutcome(
 	running := state.Running[issue.ID]
 	running.done = o.supervisor.Dispatch(runCtx, request, o.runResults)
 	state.Running[issue.ID] = running
+	o.trackRunningHeartbeat(state, running, claim, now)
 	return dispatchIssueOutcome{dispatched: true}
 }
 

--- a/internal/orchestrator/dispatch_test.go
+++ b/internal/orchestrator/dispatch_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/digitaldrywood/detent/internal/connector"
 	"github.com/digitaldrywood/detent/internal/connector/memory"
 	"github.com/digitaldrywood/detent/internal/gate"
+	"github.com/digitaldrywood/detent/internal/procgroup"
 	runpkg "github.com/digitaldrywood/detent/internal/runner"
 	"github.com/digitaldrywood/detent/internal/scheduler"
 	"github.com/digitaldrywood/detent/internal/selector"
@@ -35,12 +36,18 @@ func TestHandleRunUpdatePersistsRuntimeIdentityHeartbeat(t *testing.T) {
 	identity := agentidentity.Configured("codex-high", "codex", "high", "code", "gpt-5.5", "", "", "", time.Time{}).
 		Merge(agentidentity.RuntimeUpdate("gpt-5.6-sol", "openai", "xhigh", "priority", time.Time{}))
 	at := time.Date(2026, 7, 9, 20, 0, 0, 0, time.UTC)
+	processStartedAt := at.Add(-time.Second)
 
 	o.handleRunUpdate(&state, runUpdate{
 		issueID: issue.ID,
 		usage: runpkg.UsageUpdate{
 			DetentSessionID: 1118,
 			SessionID:       "thread-1118-turn-1",
+			WorkerProcess: procgroup.Identity{
+				PID:       4242,
+				GroupID:   4242,
+				StartedAt: processStartedAt,
+			},
 			LastEventAt:     at,
 			LastEvent:       "runtime_identity",
 			RuntimeIdentity: identity,
@@ -56,6 +63,9 @@ func TestHandleRunUpdatePersistsRuntimeIdentityHeartbeat(t *testing.T) {
 	}
 	if !state.WorkAttempts[0].RuntimeIdentity.MateriallyEqual(identity) {
 		t.Fatalf("snapshot work attempt identity = %#v, want runtime identity", state.WorkAttempts[0].RuntimeIdentity)
+	}
+	if running := state.Running[issue.ID]; running.WorkerProcess.PID != 4242 || !running.WorkerProcess.StartedAt.Equal(processStartedAt) {
+		t.Fatalf("running worker process = %#v, want persisted process identity", running.WorkerProcess)
 	}
 }
 

--- a/internal/orchestrator/heartbeat.go
+++ b/internal/orchestrator/heartbeat.go
@@ -1,0 +1,537 @@
+package orchestrator
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io/fs"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	workflowconfig "github.com/digitaldrywood/detent/internal/config"
+	"github.com/digitaldrywood/detent/internal/connector"
+	"github.com/digitaldrywood/detent/internal/procgroup"
+	"github.com/digitaldrywood/detent/internal/store"
+)
+
+const heartbeatOperationTimeout = 30 * time.Second
+
+type heartbeatManager struct {
+	mu           sync.Mutex
+	settings     heartbeatSettings
+	targets      map[string]heartbeatTarget
+	nextSequence uint64
+	wake         chan struct{}
+	results      chan heartbeatResult
+	running      atomic.Bool
+	now          func() time.Time
+	logger       *slog.Logger
+}
+
+type heartbeatSettings struct {
+	connector    connector.Connector
+	workAttempts store.WorkAttemptStore
+	claiming     ClaimingConfig
+	interval     time.Duration
+	leaseTTL     time.Duration
+}
+
+type heartbeatTarget struct {
+	issueID              string
+	claimOwner           string
+	workAttemptHeartbeat store.WorkAttemptHeartbeat
+	workerProcess        procgroup.Identity
+	workspacePath        string
+	workspaceModifiedAt  time.Time
+	workspaceAdvanced    bool
+	workerAlive          bool
+	workerChecked        bool
+	livenessError        error
+	sequence             uint64
+	nextDue              time.Time
+	inFlight             bool
+}
+
+type heartbeatResult struct {
+	issueID             string
+	sequence            uint64
+	heartbeat           store.WorkAttemptHeartbeat
+	workAttemptRenewed  bool
+	claimRenewed        bool
+	claimIssue          connector.Issue
+	claimOwnerLost      bool
+	currentClaimOwner   string
+	workerAlive         bool
+	workerChecked       bool
+	workspaceModifiedAt time.Time
+	workspaceAdvanced   bool
+	livenessError       error
+	workAttemptError    error
+	claimError          error
+}
+
+func newHeartbeatManager(cfg Config, connectorBackend connector.Connector, workAttempts store.WorkAttemptStore, now func() time.Time, logger *slog.Logger) *heartbeatManager {
+	if now == nil {
+		now = time.Now
+	}
+	if logger == nil {
+		logger = slog.Default()
+	}
+	manager := &heartbeatManager{
+		targets: make(map[string]heartbeatTarget),
+		wake:    make(chan struct{}, 1),
+		results: make(chan heartbeatResult, runUpdateBufferSize),
+		now:     now,
+		logger:  logger,
+	}
+	manager.configure(cfg, connectorBackend, workAttempts)
+	return manager
+}
+
+func (m *heartbeatManager) configure(cfg Config, connectorBackend connector.Connector, workAttempts store.WorkAttemptStore) {
+	if m == nil {
+		return
+	}
+	settings := heartbeatSettings{
+		connector:    connectorBackend,
+		workAttempts: workAttempts,
+		claiming:     cfg.Claiming,
+		interval:     workHeartbeatInterval(cfg),
+		leaseTTL:     cfg.Claiming.LeaseTTL,
+	}
+	if settings.leaseTTL <= 0 {
+		settings.leaseTTL = defaultWorkAttemptLeaseTTL
+	}
+	m.mu.Lock()
+	m.settings = settings
+	now := m.now()
+	for issueID, target := range m.targets {
+		if target.nextDue.IsZero() || target.nextDue.After(now.Add(settings.interval)) {
+			target.nextDue = now.Add(settings.interval)
+			m.targets[issueID] = target
+		}
+	}
+	m.mu.Unlock()
+	m.notify()
+}
+
+func workHeartbeatInterval(cfg Config) time.Duration {
+	interval := cfg.Claiming.HeartbeatInterval
+	if interval <= 0 && cfg.Claiming.LeaseTTL > 0 {
+		interval = cfg.Claiming.LeaseTTL / 2
+	}
+	leaseTTL := cfg.Claiming.LeaseTTL
+	if leaseTTL <= 0 {
+		leaseTTL = defaultWorkAttemptLeaseTTL
+	}
+	if maximum := leaseTTL / 3; maximum > 0 && (interval <= 0 || interval > maximum) {
+		interval = maximum
+	}
+	if interval <= 0 {
+		interval = defaultPollInterval
+	}
+	return interval
+}
+
+func (m *heartbeatManager) upsert(target heartbeatTarget) {
+	if m == nil || strings.TrimSpace(target.issueID) == "" {
+		return
+	}
+	m.mu.Lock()
+	current, ok := m.targets[target.issueID]
+	if ok && current.workAttemptHeartbeat.AttemptID == target.workAttemptHeartbeat.AttemptID {
+		target.sequence = current.sequence
+		target.nextDue = current.nextDue
+		target.inFlight = current.inFlight
+		target.workspaceModifiedAt = current.workspaceModifiedAt
+		target.workspaceAdvanced = current.workspaceAdvanced
+		target.workerAlive = current.workerAlive
+		target.workerChecked = current.workerChecked
+		target.livenessError = current.livenessError
+	} else {
+		m.nextSequence++
+		target.sequence = m.nextSequence
+		target.nextDue = m.now().Add(m.settings.interval)
+	}
+	m.targets[target.issueID] = target
+	m.mu.Unlock()
+	m.notify()
+}
+
+func (m *heartbeatManager) remove(issueID string) {
+	if m == nil {
+		return
+	}
+	m.mu.Lock()
+	delete(m.targets, strings.TrimSpace(issueID))
+	m.mu.Unlock()
+	m.notify()
+}
+
+func (m *heartbeatManager) protects(issueID string) bool {
+	if m == nil {
+		return false
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	target, ok := m.targets[strings.TrimSpace(issueID)]
+	if !ok {
+		return false
+	}
+	if !target.workerChecked || target.livenessError != nil {
+		return true
+	}
+	return target.workerAlive
+}
+
+func (m *heartbeatManager) current(issueID string, sequence uint64) bool {
+	if m == nil {
+		return false
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	target, ok := m.targets[strings.TrimSpace(issueID)]
+	return ok && target.sequence == sequence
+}
+
+func (m *heartbeatManager) Running() bool {
+	return m != nil && m.running.Load()
+}
+
+func (m *heartbeatManager) Run(ctx context.Context) {
+	if m == nil || !m.running.CompareAndSwap(false, true) {
+		return
+	}
+	defer m.running.Store(false)
+	var workers sync.WaitGroup
+	defer workers.Wait()
+	timer := time.NewTimer(time.Hour)
+	defer timer.Stop()
+	for {
+		resetHeartbeatTimer(timer, m.nextDelay(m.now()))
+		select {
+		case <-ctx.Done():
+			return
+		case <-m.wake:
+			continue
+		case <-timer.C:
+		}
+		for _, target := range m.due(m.now()) {
+			workers.Add(1)
+			go func() {
+				defer workers.Done()
+				m.execute(ctx, target)
+			}()
+		}
+	}
+}
+
+func (m *heartbeatManager) nextDelay(now time.Time) time.Duration {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	var next time.Time
+	for _, target := range m.targets {
+		if target.inFlight {
+			continue
+		}
+		if next.IsZero() || target.nextDue.Before(next) {
+			next = target.nextDue
+		}
+	}
+	if next.IsZero() {
+		return time.Hour
+	}
+	return max(time.Millisecond, next.Sub(now))
+}
+
+func (m *heartbeatManager) due(now time.Time) []heartbeatTarget {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	due := make([]heartbeatTarget, 0, len(m.targets))
+	for issueID, target := range m.targets {
+		if target.inFlight || now.Before(target.nextDue) {
+			continue
+		}
+		target.inFlight = true
+		target.nextDue = now.Add(m.settings.interval)
+		m.targets[issueID] = target
+		due = append(due, target)
+	}
+	return due
+}
+
+func (m *heartbeatManager) execute(ctx context.Context, target heartbeatTarget) {
+	operationCtx, cancel := context.WithTimeout(ctx, heartbeatOperationTimeout)
+	defer cancel()
+	settings := m.settingsSnapshot()
+	result := heartbeatResult{issueID: target.issueID, sequence: target.sequence}
+	result.workerAlive, result.workerChecked, result.livenessError = heartbeatWorkerLiveness(target.workerProcess)
+	result.workspaceModifiedAt, result.workspaceAdvanced = heartbeatWorkspaceActivity(target.workspacePath, target.workspaceModifiedAt)
+	if result.workerChecked && !result.workerAlive && result.livenessError == nil {
+		m.finish(target, result)
+		return
+	}
+	now := m.now().UTC()
+	heartbeat := target.workAttemptHeartbeat
+	heartbeat.HeartbeatAt = now
+	heartbeat.LeaseExpiresAt = now.Add(settings.leaseTTL)
+	result.heartbeat = heartbeat
+	if settings.workAttempts != nil && heartbeat.AttemptID > 0 {
+		result.workAttemptError = settings.workAttempts.RecordWorkAttemptHeartbeat(operationCtx, heartbeat)
+		result.workAttemptRenewed = result.workAttemptError == nil
+	}
+	if settings.claiming.Enabled && strings.TrimSpace(settings.claiming.LeaseField) != "" && strings.TrimSpace(target.claimOwner) != "" {
+		result.claimIssue, result.currentClaimOwner, result.claimOwnerLost, result.claimError = renewTrackerClaim(operationCtx, settings, target, now)
+		result.claimRenewed = result.claimError == nil && !result.claimOwnerLost
+	}
+	m.finish(target, result)
+}
+
+func (m *heartbeatManager) settingsSnapshot() heartbeatSettings {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.settings
+}
+
+func (m *heartbeatManager) finish(target heartbeatTarget, result heartbeatResult) {
+	m.mu.Lock()
+	current, ok := m.targets[target.issueID]
+	if !ok || current.sequence != target.sequence {
+		m.mu.Unlock()
+		return
+	}
+	current.inFlight = false
+	current.workerAlive = result.workerAlive
+	current.workerChecked = result.workerChecked
+	current.livenessError = result.livenessError
+	if !result.workspaceModifiedAt.IsZero() {
+		current.workspaceModifiedAt = result.workspaceModifiedAt
+	}
+	current.workspaceAdvanced = result.workspaceAdvanced
+	m.targets[target.issueID] = current
+	m.mu.Unlock()
+	if result.workAttemptError != nil && !errors.Is(result.workAttemptError, store.ErrNotFound) {
+		m.logger.Warn("dedicated work attempt heartbeat failed", "attempt_id", result.heartbeat.AttemptID, "issue_id", result.issueID, "error", result.workAttemptError)
+	}
+	if result.claimError != nil {
+		m.logger.Warn("dedicated claim heartbeat failed", "issue_id", result.issueID, "error", result.claimError)
+	}
+	if result.livenessError != nil {
+		m.logger.Warn("worker liveness inspection failed", "issue_id", result.issueID, "error", result.livenessError)
+	}
+	select {
+	case m.results <- result:
+	default:
+	}
+	m.notify()
+}
+
+func (m *heartbeatManager) notify() {
+	select {
+	case m.wake <- struct{}{}:
+	default:
+	}
+}
+
+func resetHeartbeatTimer(timer *time.Timer, delay time.Duration) {
+	if !timer.Stop() {
+		select {
+		case <-timer.C:
+		default:
+		}
+	}
+	timer.Reset(delay)
+}
+
+func heartbeatWorkerLiveness(identity procgroup.Identity) (bool, bool, error) {
+	if identity.PID <= 0 || identity.StartedAt.IsZero() {
+		return false, false, nil
+	}
+	alive, err := procgroup.Alive(identity)
+	return alive, true, err
+}
+
+func heartbeatWorkspaceActivity(path string, previous time.Time) (time.Time, bool) {
+	modifiedAt, err := latestHeartbeatWorkspaceModification(path)
+	if err != nil {
+		return time.Time{}, false
+	}
+	return modifiedAt, !previous.IsZero() && modifiedAt.After(previous)
+}
+
+func latestHeartbeatWorkspaceModification(path string) (time.Time, error) {
+	path = strings.TrimSpace(path)
+	if path == "" {
+		return time.Time{}, nil
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		return time.Time{}, err
+	}
+	latest := info.ModTime().UTC()
+	for _, candidate := range []string{filepath.Join(path, ".detent"), filepath.Join(path, ".detent", "tmp")} {
+		info, err := os.Stat(candidate)
+		if errors.Is(err, fs.ErrNotExist) {
+			continue
+		}
+		if err != nil {
+			return time.Time{}, err
+		}
+		if modifiedAt := info.ModTime().UTC(); modifiedAt.After(latest) {
+			latest = modifiedAt
+		}
+	}
+	return latest, nil
+}
+
+func renewTrackerClaim(ctx context.Context, settings heartbeatSettings, target heartbeatTarget, now time.Time) (connector.Issue, string, bool, error) {
+	if settings.connector == nil {
+		return connector.Issue{}, "", false, errors.New("connector is unavailable")
+	}
+	issues, err := settings.connector.FetchIssueStatesByIDs(ctx, []string{target.issueID})
+	if err != nil {
+		return connector.Issue{}, "", false, err
+	}
+	for _, issue := range issues {
+		if issue.ID != target.issueID {
+			continue
+		}
+		owner := heartbeatClaimOwner(issue, settings.claiming)
+		if !sameClaimOwner(owner, target.claimOwner) {
+			return cloneIssue(issue), owner, true, nil
+		}
+		if err := settings.connector.SetField(ctx, target.issueID, settings.claiming.LeaseField, formatClaimTime(now)); err != nil {
+			return connector.Issue{}, owner, false, err
+		}
+		return issueWithLeaseField(issue, settings.claiming.LeaseField, now), owner, false, nil
+	}
+	return connector.Issue{}, "", false, fmt.Errorf("issue %s was not returned during claim heartbeat", target.issueID)
+}
+
+func heartbeatClaimOwner(issue connector.Issue, claiming ClaimingConfig) string {
+	if claiming.OwnershipMode == workflowconfig.IdentityOwnershipField {
+		if issue.Fields == nil {
+			return ""
+		}
+		return strings.TrimSpace(issue.Fields[claiming.OwnerField])
+	}
+	owners := append([]string{issue.AssigneeID}, issue.Assignees...)
+	normalized := make([]string, 0, len(owners))
+	seen := make(map[string]struct{}, len(owners))
+	for _, owner := range owners {
+		owner = strings.TrimSpace(owner)
+		key := normalizeClaimOwner(owner)
+		if key == "" {
+			continue
+		}
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		seen[key] = struct{}{}
+		normalized = append(normalized, owner)
+	}
+	sortClaimOwners(normalized)
+	if len(normalized) == 0 {
+		return ""
+	}
+	return normalized[0]
+}
+
+func (o *Orchestrator) persistedWorkerLive(ctx context.Context, issue connector.Issue) bool {
+	processStore, ok := o.workAttempts.(interface {
+		ListActiveWorkerProcesses(context.Context) ([]store.WorkerProcess, error)
+	})
+	if !ok {
+		return false
+	}
+	processes, err := processStore.ListActiveWorkerProcesses(ctx)
+	if err != nil {
+		if o.logger != nil {
+			o.logger.Warn("worker liveness registry lookup failed", "issue_id", issue.ID, "identifier", issue.Identifier, "error", err)
+		}
+		return true
+	}
+	for _, process := range processes {
+		if !workerProcessMatchesIssue(process, issue) {
+			continue
+		}
+		alive, err := procgroup.Alive(procgroup.Identity{PID: process.PID, GroupID: process.GroupID, StartedAt: process.StartedAt})
+		if err != nil {
+			if o.logger != nil {
+				o.logger.Warn("persisted worker liveness inspection failed", "issue_id", issue.ID, "identifier", issue.Identifier, "pid", process.PID, "error", err)
+			}
+			return true
+		}
+		if alive {
+			return true
+		}
+	}
+	return false
+}
+
+func workerProcessMatchesIssue(process store.WorkerProcess, issue connector.Issue) bool {
+	if issue.ID != "" && process.IssueID == issue.ID {
+		return true
+	}
+	if issue.Identifier != "" && strings.EqualFold(process.Identifier, issue.Identifier) {
+		return true
+	}
+	return issue.URL != "" && strings.EqualFold(process.IssueURL, issue.URL)
+}
+
+func (o *Orchestrator) trackRunningHeartbeat(state *State, running Running, claimed Claimed, now time.Time) {
+	if o == nil || o.heartbeats == nil || strings.TrimSpace(running.Issue.ID) == "" {
+		return
+	}
+	owner := strings.TrimSpace(claimed.Owner)
+	if owner == "" {
+		owner = o.claimOwner()
+	}
+	o.heartbeats.upsert(heartbeatTarget{
+		issueID:              running.Issue.ID,
+		claimOwner:           owner,
+		workAttemptHeartbeat: o.runningWorkAttemptHeartbeat(state, running, now),
+		workerProcess:        running.WorkerProcess,
+		workspacePath:        running.WorkspacePath,
+	})
+}
+
+func (o *Orchestrator) handleHeartbeatResult(state *State, result heartbeatResult) {
+	if o == nil || state == nil || o.heartbeats == nil || !o.heartbeats.current(result.issueID, result.sequence) {
+		return
+	}
+	running, ok := state.Running[result.issueID]
+	if !ok {
+		o.heartbeats.remove(result.issueID)
+		return
+	}
+	if result.claimOwnerLost {
+		if o.logger != nil {
+			o.logger.Warn("claim heartbeat owner changed", "issue_id", result.issueID, "owner", o.claimOwner(), "current_owner", result.currentClaimOwner)
+		}
+		o.releaseClaim(state, result.issueID)
+		return
+	}
+	if result.workAttemptRenewed && result.heartbeat.AttemptID == running.WorkAttemptID {
+		o.applyWorkAttemptHeartbeatSnapshot(state, running.WorkAttemptID, result.heartbeat, running.LastMessageTruncation)
+	}
+	if !result.claimRenewed {
+		return
+	}
+	claimed, ok := state.Claimed[result.issueID]
+	if !ok {
+		return
+	}
+	claimed.Owner = result.currentClaimOwner
+	claimed.LeaseRenewedAt = result.heartbeat.HeartbeatAt
+	claimed.LeaseExpiresAt = o.leaseExpiresAt(result.heartbeat.HeartbeatAt)
+	claimed.Issue = mergeIssueTrackerFields(claimed.Issue, result.claimIssue)
+	state.Claimed[result.issueID] = claimed
+	running.Issue = mergeIssueTrackerFields(running.Issue, result.claimIssue)
+	state.Running[result.issueID] = running
+}

--- a/internal/orchestrator/heartbeat.go
+++ b/internal/orchestrator/heartbeat.go
@@ -55,6 +55,7 @@ type heartbeatTarget struct {
 	sequence             uint64
 	nextDue              time.Time
 	inFlight             bool
+	flightDone           chan struct{}
 }
 
 type heartbeatResult struct {
@@ -148,6 +149,7 @@ func (m *heartbeatManager) upsert(target heartbeatTarget) {
 		target.sequence = current.sequence
 		target.nextDue = current.nextDue
 		target.inFlight = current.inFlight
+		target.flightDone = current.flightDone
 		target.workspaceModifiedAt = current.workspaceModifiedAt
 		target.workspaceAdvanced = current.workspaceAdvanced
 		target.workerAlive = current.workerAlive
@@ -168,9 +170,13 @@ func (m *heartbeatManager) remove(issueID string) {
 		return
 	}
 	m.mu.Lock()
+	target := m.targets[strings.TrimSpace(issueID)]
 	delete(m.targets, strings.TrimSpace(issueID))
 	m.mu.Unlock()
 	m.notify()
+	if target.flightDone != nil {
+		<-target.flightDone
+	}
 }
 
 func (m *heartbeatManager) protects(issueID string) bool {
@@ -258,6 +264,7 @@ func (m *heartbeatManager) due(now time.Time) []heartbeatTarget {
 			continue
 		}
 		target.inFlight = true
+		target.flightDone = make(chan struct{})
 		target.nextDue = now.Add(m.settings.interval)
 		m.targets[issueID] = target
 		due = append(due, target)
@@ -266,6 +273,9 @@ func (m *heartbeatManager) due(now time.Time) []heartbeatTarget {
 }
 
 func (m *heartbeatManager) execute(ctx context.Context, target heartbeatTarget) {
+	if target.flightDone != nil {
+		defer close(target.flightDone)
+	}
 	operationCtx, cancel := context.WithTimeout(ctx, heartbeatOperationTimeout)
 	defer cancel()
 	settings := m.settingsSnapshot()

--- a/internal/orchestrator/heartbeat_test.go
+++ b/internal/orchestrator/heartbeat_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"sync"
 	"testing"
 	"time"
 
@@ -41,6 +42,77 @@ func TestHeartbeatManagerRenewsWithoutSchedulerLoop(t *testing.T) {
 	lease, ok := parseClaimTime(claimStore.issue(issue.ID).Fields["Detent Lease"])
 	if !ok || !lease.After(initial) {
 		t.Fatalf("tracker lease = %v, %v, want after %v", lease, ok, initial)
+	}
+}
+
+func TestCompleteTerminalRunningClearsInFlightHeartbeatLease(t *testing.T) {
+	now := time.Now().UTC()
+	issue := claimTestIssue("issue-terminal-heartbeat")
+	issue.State = "Done"
+	issue.AssigneeID = "alpha"
+	issue.Assignees = []string{"alpha"}
+	issue.Fields["Detent Lease"] = formatClaimTime(now.Add(-time.Minute))
+	claimStore := newClaimTestStore([]connector.Issue{issue})
+	connectorBackend := &terminalHeartbeatConnector{
+		claimTestConnector: claimTestConnector{store: claimStore, login: "alpha"},
+		renewalStarted:     make(chan struct{}),
+		allowRenewal:       make(chan struct{}),
+	}
+	cfg := normalizeConfig(claimTestConfig("alpha", "alpha"))
+	cfg.Claiming.HeartbeatInterval = 5 * time.Millisecond
+	manager := newHeartbeatManager(cfg, connectorBackend, nil, time.Now, nil)
+	orchestrator := &Orchestrator{cfg: cfg, connector: connectorBackend, heartbeats: manager}
+	state := newState(cfg)
+	running := Running{Issue: cloneIssue(issue), StartedAt: now.Add(-time.Minute)}
+	state.Running[issue.ID] = running
+	state.Claimed[issue.ID] = Claimed{Issue: cloneIssue(issue), Owner: "alpha"}
+	manager.upsert(heartbeatTarget{issueID: issue.ID, claimOwner: "alpha"})
+
+	ctx, cancel := context.WithCancel(t.Context())
+	managerDone := make(chan struct{})
+	go func() {
+		defer close(managerDone)
+		manager.Run(ctx)
+	}()
+	select {
+	case <-connectorBackend.renewalStarted:
+	case <-time.After(time.Second):
+		cancel()
+		<-managerDone
+		t.Fatal("timed out waiting for claim heartbeat renewal")
+	}
+
+	completionDone := make(chan struct{})
+	go func() {
+		defer close(completionDone)
+		orchestrator.completeTerminalRunning(t.Context(), &state, issue.ID, running, now, TokenTotals{})
+	}()
+	completedBeforeRenewal := false
+	select {
+	case <-completionDone:
+		completedBeforeRenewal = true
+	case <-time.After(20 * time.Millisecond):
+	}
+	close(connectorBackend.allowRenewal)
+	select {
+	case <-completionDone:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for terminal completion")
+	}
+	cancel()
+	<-managerDone
+
+	if completedBeforeRenewal {
+		t.Fatal("terminal completion returned before the in-flight heartbeat finished")
+	}
+	if got := claimStore.issue(issue.ID).Fields["Detent Lease"]; got != "" {
+		t.Fatalf("Detent Lease = %q, want cleared after terminal completion", got)
+	}
+	manager.mu.Lock()
+	_, tracked := manager.targets[issue.ID]
+	manager.mu.Unlock()
+	if tracked {
+		t.Fatalf("heartbeat target %q remains after terminal completion", issue.ID)
 	}
 }
 
@@ -265,6 +337,27 @@ func startHeartbeatWorkerProcess(t *testing.T) procgroup.Identity {
 		_ = cmd.Wait()
 	})
 	return identity
+}
+
+type terminalHeartbeatConnector struct {
+	claimTestConnector
+	renewalStarted chan struct{}
+	allowRenewal   chan struct{}
+	renewalOnce    sync.Once
+}
+
+func (c *terminalHeartbeatConnector) SetField(ctx context.Context, issueID string, fieldName string, value string) error {
+	if value != "" {
+		c.renewalOnce.Do(func() {
+			close(c.renewalStarted)
+		})
+		select {
+		case <-c.allowRenewal:
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+	}
+	return c.claimTestConnector.SetField(ctx, issueID, fieldName, value)
 }
 
 type heartbeatProcessStore struct {

--- a/internal/orchestrator/heartbeat_test.go
+++ b/internal/orchestrator/heartbeat_test.go
@@ -1,0 +1,277 @@
+package orchestrator
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/digitaldrywood/detent/internal/connector"
+	"github.com/digitaldrywood/detent/internal/procgroup"
+	"github.com/digitaldrywood/detent/internal/store"
+)
+
+func TestHeartbeatManagerRenewsWithoutSchedulerLoop(t *testing.T) {
+	initial := time.Now().UTC().Add(-time.Minute)
+	issue := claimTestIssue("issue-dedicated-heartbeat")
+	issue.AssigneeID = "alpha"
+	issue.Assignees = []string{"alpha"}
+	issue.Fields["Detent Lease"] = formatClaimTime(initial)
+	claimStore := newClaimTestStore([]connector.Issue{issue})
+	attempts := &recordingWorkAttemptStore{}
+	cfg := normalizeConfig(claimTestConfig("alpha", "alpha"))
+	cfg.Claiming.HeartbeatInterval = 5 * time.Millisecond
+	manager := newHeartbeatManager(cfg, claimTestConnector{store: claimStore, login: "alpha"}, attempts, time.Now, nil)
+
+	result := runHeartbeatManagerOnce(t, manager, heartbeatTarget{
+		issueID:              issue.ID,
+		claimOwner:           "alpha",
+		workAttemptHeartbeat: store.WorkAttemptHeartbeat{AttemptID: 1433},
+		workspacePath:        t.TempDir(),
+	})
+
+	if !result.workAttemptRenewed || !result.claimRenewed {
+		t.Fatalf("heartbeat result = %#v, want durable and tracker renewal", result)
+	}
+	if len(attempts.heartbeats) != 1 || attempts.heartbeats[0].AttemptID != 1433 {
+		t.Fatalf("durable heartbeats = %#v, want attempt 1433", attempts.heartbeats)
+	}
+	lease, ok := parseClaimTime(claimStore.issue(issue.ID).Fields["Detent Lease"])
+	if !ok || !lease.After(initial) {
+		t.Fatalf("tracker lease = %v, %v, want after %v", lease, ok, initial)
+	}
+}
+
+func TestHeartbeatManagerRequiresMatchingLiveProcessIdentity(t *testing.T) {
+	identity := startHeartbeatWorkerProcess(t)
+
+	tests := []struct {
+		name        string
+		identity    procgroup.Identity
+		wantRenewed bool
+		wantChecked bool
+		wantAlive   bool
+	}{
+		{name: "startup before process identity", wantRenewed: true},
+		{name: "matching live process", identity: identity, wantRenewed: true, wantChecked: true, wantAlive: true},
+		{name: "reused pid identity", identity: procgroup.Identity{PID: identity.PID, GroupID: identity.GroupID, StartedAt: identity.StartedAt.Add(time.Second)}, wantChecked: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			attempts := &recordingWorkAttemptStore{}
+			cfg := normalizeConfig(Config{Claiming: ClaimingConfig{LeaseTTL: time.Minute, HeartbeatInterval: 5 * time.Millisecond}})
+			manager := newHeartbeatManager(cfg, nil, attempts, time.Now, nil)
+			result := runHeartbeatManagerOnce(t, manager, heartbeatTarget{
+				issueID:              tt.name,
+				workAttemptHeartbeat: store.WorkAttemptHeartbeat{AttemptID: 1433},
+				workerProcess:        tt.identity,
+			})
+
+			if result.workAttemptRenewed != tt.wantRenewed || result.workerChecked != tt.wantChecked || result.workerAlive != tt.wantAlive {
+				t.Fatalf("heartbeat result = %#v, want renewed=%v checked=%v alive=%v", result, tt.wantRenewed, tt.wantChecked, tt.wantAlive)
+			}
+			if got := len(attempts.heartbeats); got != boolCount(tt.wantRenewed) {
+				t.Fatalf("durable heartbeat count = %d, want %d", got, boolCount(tt.wantRenewed))
+			}
+		})
+	}
+}
+
+func TestLatestHeartbeatWorkspaceModificationIncludesWorkerScratch(t *testing.T) {
+	workspacePath := t.TempDir()
+	scratchPath := filepath.Join(workspacePath, ".detent", "tmp")
+	if err := os.MkdirAll(scratchPath, 0o755); err != nil {
+		t.Fatalf("MkdirAll() error = %v", err)
+	}
+	base := time.Now().UTC().Add(-time.Minute).Truncate(time.Second)
+	latest := base.Add(30 * time.Second)
+	for _, item := range []struct {
+		path string
+		at   time.Time
+	}{
+		{path: workspacePath, at: base},
+		{path: filepath.Join(workspacePath, ".detent"), at: base.Add(10 * time.Second)},
+		{path: scratchPath, at: latest},
+	} {
+		if err := os.Chtimes(item.path, item.at, item.at); err != nil {
+			t.Fatalf("Chtimes(%s) error = %v", item.path, err)
+		}
+	}
+
+	got, err := latestHeartbeatWorkspaceModification(workspacePath)
+	if err != nil {
+		t.Fatalf("latestHeartbeatWorkspaceModification() error = %v", err)
+	}
+	if !got.Equal(latest) {
+		t.Fatalf("latest modification = %v, want %v", got, latest)
+	}
+}
+
+func TestHeartbeatWorkerProcessHelper(t *testing.T) {
+	if os.Getenv("DETENT_HEARTBEAT_PROCESS_HELPER") != "1" {
+		return
+	}
+	for {
+		time.Sleep(time.Hour)
+	}
+}
+
+func TestWorkHeartbeatInterval(t *testing.T) {
+	tests := []struct {
+		name string
+		cfg  Config
+		want time.Duration
+	}{
+		{name: "configured interval", cfg: Config{Claiming: ClaimingConfig{LeaseTTL: 10 * time.Minute, HeartbeatInterval: time.Minute}}, want: time.Minute},
+		{name: "lease midpoint clamped", cfg: Config{Claiming: ClaimingConfig{LeaseTTL: time.Minute}}, want: 20 * time.Second},
+		{name: "default lease", want: defaultWorkAttemptLeaseTTL / 3},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := workHeartbeatInterval(tt.cfg); got != tt.want {
+				t.Fatalf("workHeartbeatInterval() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestClaimableChecksLocalWorkerLivenessBeforeReclaim(t *testing.T) {
+	now := time.Now().UTC()
+	issue := claimTestIssue("issue-reclaim-guard")
+	issue.AssigneeID = "beta"
+	issue.Assignees = []string{"beta"}
+	issue.Fields["Detent Lease"] = formatClaimTime(now.Add(-2 * time.Minute))
+	cfg := normalizeConfig(claimTestConfig("alpha", "alpha"))
+
+	tests := []struct {
+		name        string
+		workerAlive bool
+		want        bool
+	}{
+		{name: "matching live worker blocks reclaim", workerAlive: true},
+		{name: "dead worker permits reclaim", want: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			manager := newHeartbeatManager(cfg, nil, nil, time.Now, nil)
+			manager.upsert(heartbeatTarget{issueID: issue.ID, workAttemptHeartbeat: store.WorkAttemptHeartbeat{AttemptID: 1433}})
+			manager.mu.Lock()
+			target := manager.targets[issue.ID]
+			target.workerChecked = true
+			target.workerAlive = tt.workerAlive
+			manager.targets[issue.ID] = target
+			manager.mu.Unlock()
+			orchestrator := &Orchestrator{cfg: cfg, heartbeats: manager}
+
+			if got := orchestrator.claimable(t.Context(), issue, "alpha", now); got != tt.want {
+				t.Fatalf("claimable() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestClaimableChecksPersistedProcessIdentityBeforeReclaim(t *testing.T) {
+	now := time.Now().UTC()
+	identity := startHeartbeatWorkerProcess(t)
+	issue := claimTestIssue("issue-persisted-reclaim-guard")
+	issue.AssigneeID = "beta"
+	issue.Assignees = []string{"beta"}
+	issue.Fields["Detent Lease"] = formatClaimTime(now.Add(-2 * time.Minute))
+	cfg := normalizeConfig(claimTestConfig("alpha", "alpha"))
+
+	tests := []struct {
+		name     string
+		identity procgroup.Identity
+		want     bool
+	}{
+		{name: "matching persisted identity blocks reclaim", identity: identity},
+		{name: "stale persisted identity permits reclaim", identity: procgroup.Identity{PID: identity.PID, GroupID: identity.GroupID, StartedAt: identity.StartedAt.Add(time.Second)}, want: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			attempts := &heartbeatProcessStore{
+				recordingWorkAttemptStore: &recordingWorkAttemptStore{},
+				processes: []store.WorkerProcess{{
+					SessionID:  1433,
+					IssueID:    issue.ID,
+					Identifier: issue.Identifier,
+					WorkerProcessIdentity: store.WorkerProcessIdentity{
+						PID:       tt.identity.PID,
+						GroupID:   tt.identity.GroupID,
+						StartedAt: tt.identity.StartedAt,
+					},
+				}},
+			}
+			orchestrator := &Orchestrator{cfg: cfg, workAttempts: attempts}
+			if got := orchestrator.claimable(t.Context(), issue, "alpha", now); got != tt.want {
+				t.Fatalf("claimable() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func runHeartbeatManagerOnce(t *testing.T, manager *heartbeatManager, target heartbeatTarget) heartbeatResult {
+	t.Helper()
+	ctx, cancel := context.WithCancel(t.Context())
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		manager.Run(ctx)
+	}()
+	manager.upsert(target)
+	select {
+	case result := <-manager.results:
+		manager.remove(target.issueID)
+		cancel()
+		<-done
+		return result
+	case <-time.After(time.Second):
+		cancel()
+		<-done
+		t.Fatal("timed out waiting for dedicated heartbeat")
+		return heartbeatResult{}
+	}
+}
+
+func boolCount(value bool) int {
+	if value {
+		return 1
+	}
+	return 0
+}
+
+func startHeartbeatWorkerProcess(t *testing.T) procgroup.Identity {
+	t.Helper()
+	cmd := exec.CommandContext(context.Background(), os.Args[0], "-test.run=^TestHeartbeatWorkerProcessHelper$")
+	cmd.Env = append(os.Environ(), "DETENT_HEARTBEAT_PROCESS_HELPER=1")
+	procgroup.Configure(cmd)
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("Start() error = %v", err)
+	}
+	identity, err := procgroup.Inspect(cmd)
+	if err != nil {
+		_ = procgroup.TerminateTree(cmd, procgroup.GroupID(cmd))
+		_ = cmd.Wait()
+		t.Fatalf("Inspect() error = %v", err)
+	}
+	t.Cleanup(func() {
+		_ = procgroup.TerminateTree(cmd, identity.GroupID)
+		_ = cmd.Wait()
+	})
+	return identity
+}
+
+type heartbeatProcessStore struct {
+	*recordingWorkAttemptStore
+	processes []store.WorkerProcess
+}
+
+func (s *heartbeatProcessStore) ListActiveWorkerProcesses(context.Context) ([]store.WorkerProcess, error) {
+	return append([]store.WorkerProcess(nil), s.processes...), nil
+}

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -195,6 +195,7 @@ type Orchestrator struct {
 	issueBudgetStatus       runpkg.IssueBudgetStatusProvider
 	now                     func() time.Time
 	retrospector            Retrospector
+	heartbeats              *heartbeatManager
 	hydrationSkipStreaks    map[string]int
 	hydrationWarned         bool
 	ciTriggerLabelMu        sync.Mutex
@@ -373,7 +374,7 @@ func New(cfg Config, deps Dependencies) (*Orchestrator, error) {
 		return nil, err
 	}
 
-	return &Orchestrator{
+	orchestrator := &Orchestrator{
 		cfg:                     cfg,
 		connector:               deps.Connector,
 		workflowMetrics:         deps.WorkflowMetrics,
@@ -419,7 +420,9 @@ func New(cfg Config, deps Dependencies) (*Orchestrator, error) {
 		done:                    make(chan struct{}),
 		pendingStops:            map[string]*pendingStopRun{},
 		completedStops:          map[string]StopRunResult{},
-	}, nil
+	}
+	orchestrator.heartbeats = newHeartbeatManager(cfg, deps.Connector, deps.WorkAttempts, now, logger)
+	return orchestrator, nil
 }
 
 type ciTriggerLabelHead struct {
@@ -433,6 +436,20 @@ func (o *Orchestrator) Run(ctx context.Context) error {
 	}
 	defer close(o.done)
 	defer o.markGlobalProjectIdle()
+	heartbeatCtx, stopHeartbeats := context.WithCancel(ctx)
+	heartbeatsDone := make(chan struct{})
+	var heartbeatResults <-chan heartbeatResult
+	if o.heartbeats != nil {
+		heartbeatResults = o.heartbeats.results
+	}
+	go func() {
+		defer close(heartbeatsDone)
+		o.heartbeats.Run(heartbeatCtx)
+	}()
+	defer func() {
+		stopHeartbeats()
+		<-heartbeatsDone
+	}()
 
 	ticker := time.NewTicker(o.cfg.PollInterval)
 	defer ticker.Stop()
@@ -472,6 +489,8 @@ func (o *Orchestrator) Run(ctx context.Context) error {
 			o.handleRunResult(ctx, &state, result)
 		case update := <-o.runUpdates:
 			o.handleRunUpdate(&state, update)
+		case result := <-heartbeatResults:
+			o.handleHeartbeatResult(&state, result)
 		case event := <-o.validatorCapacityEvents:
 			o.handleValidatorCapacityEvent(&state, event)
 		case request := <-o.drainRequests:
@@ -670,6 +689,7 @@ func (o *Orchestrator) applyRuntimeUpdate(state *State, update RuntimeUpdate, ti
 	if update.Connector != nil {
 		o.connector = update.Connector
 	}
+	o.heartbeats.configure(cfg, o.connector, o.workAttempts)
 	if update.ReplaceRelease {
 		o.release = update.Release
 		if update.Release == nil {
@@ -740,6 +760,7 @@ func (o *Orchestrator) forceQuit(ctx context.Context, state *State, now time.Tim
 	var err error
 	for _, issueID := range sortedKeys(state.Running) {
 		o.cancelRunning(state, issueID)
+		o.heartbeats.remove(issueID)
 		err = errors.Join(err, o.abandonClaim(ctx, issueID))
 		delete(state.Running, issueID)
 		delete(state.Claimed, issueID)

--- a/internal/orchestrator/run_completion.go
+++ b/internal/orchestrator/run_completion.go
@@ -60,6 +60,9 @@ func (o *Orchestrator) handleRunUpdate(state *State, event runUpdate) {
 	if event.usage.ProcessIdentity != "" {
 		running.ProcessIdentity = event.usage.ProcessIdentity
 	}
+	if event.usage.WorkerProcess.PID > 0 && !event.usage.WorkerProcess.StartedAt.IsZero() {
+		running.WorkerProcess = event.usage.WorkerProcess
+	}
 	if event.usage.WorkspacePath != "" {
 		running.WorkspacePath = event.usage.WorkspacePath
 	}
@@ -68,6 +71,7 @@ func (o *Orchestrator) handleRunUpdate(state *State, event runUpdate) {
 	}
 	running.Tokens = event.usage.Tokens
 	state.Running[event.issueID] = running
+	o.trackRunningHeartbeat(state, running, state.Claimed[event.issueID], o.clockNow())
 	if event.usage.RateLimits != nil {
 		state.RateLimits = mergeRateLimits(state.RateLimits, event.usage.RateLimits)
 		o.recoverBackendCapacityFromStatus(state, running, event.usage.RateLimits, event.usage.LastEventAt)
@@ -101,6 +105,7 @@ func (o *Orchestrator) handleRunResult(ctx context.Context, state *State, event 
 	if !ok {
 		return
 	}
+	o.heartbeats.remove(event.IssueID)
 	if o.retrospector != nil {
 		defer o.retrospector.Trigger("completion")
 	}
@@ -1829,6 +1834,7 @@ func (o *Orchestrator) retryDelay(attempt int, continuation bool) time.Duration 
 
 func (o *Orchestrator) releaseClaim(state *State, issueID string) {
 	o.cancelRunning(state, issueID)
+	o.heartbeats.remove(issueID)
 	delete(state.Running, issueID)
 	delete(state.Claimed, issueID)
 	delete(state.Retry, issueID)

--- a/internal/orchestrator/run_completion.go
+++ b/internal/orchestrator/run_completion.go
@@ -1850,6 +1850,7 @@ func (o *Orchestrator) completeTerminalRunning(
 	completedAt time.Time,
 	tokens TokenTotals,
 ) {
+	o.heartbeats.remove(issueID)
 	o.completeDurableWorkAttempt(ctx, state, running, completedAt, store.WorkAttemptTerminalSuccess, "", "", "completed", "worker reached terminal state")
 	o.releaseGlobalDispatchSlot(running.globalSlot)
 	if running.cancel != nil {

--- a/internal/orchestrator/state.go
+++ b/internal/orchestrator/state.go
@@ -9,6 +9,7 @@ import (
 	"github.com/digitaldrywood/detent/internal/backendcapacity"
 	"github.com/digitaldrywood/detent/internal/connector"
 	"github.com/digitaldrywood/detent/internal/gate"
+	"github.com/digitaldrywood/detent/internal/procgroup"
 	releasepkg "github.com/digitaldrywood/detent/internal/release"
 	runpkg "github.com/digitaldrywood/detent/internal/runner"
 	"github.com/digitaldrywood/detent/internal/runtimeoutput"
@@ -91,6 +92,7 @@ type Running struct {
 	StartedAt             time.Time
 	WorkerHost            string
 	ProcessIdentity       string
+	WorkerProcess         procgroup.Identity
 	WorkspacePath         string
 	SessionID             string
 	DetentSessionID       int64

--- a/internal/orchestrator/tick.go
+++ b/internal/orchestrator/tick.go
@@ -310,8 +310,10 @@ func (o *Orchestrator) refreshActiveRuns(ctx context.Context, state *State, now 
 	}
 	o.reconcileRunningIssues(ctx, state, now)
 	o.failStalledMergeWorkerStarts(ctx, state, now)
-	o.heartbeatRunningClaims(ctx, state, now)
-	o.heartbeatRunningWorkAttempts(ctx, state, now)
+	if o.heartbeats == nil || !o.heartbeats.Running() {
+		o.heartbeatRunningClaims(ctx, state, now)
+		o.heartbeatRunningWorkAttempts(ctx, state, now)
+	}
 }
 
 func (o *Orchestrator) fetchTickIssues(

--- a/internal/orchestrator/work_attempt_recovery.go
+++ b/internal/orchestrator/work_attempt_recovery.go
@@ -453,6 +453,7 @@ func (o *Orchestrator) clearLiveWorkAttemptState(state *State, attempt telemetry
 	if running, ok := state.Running[issueID]; ok && running.WorkAttemptID == attempt.AttemptID {
 		cancelRunning(state, issueID)
 		o.releaseGlobalDispatchSlot(running.globalSlot)
+		o.heartbeats.remove(issueID)
 		delete(state.Running, issueID)
 	}
 	delete(state.Claimed, issueID)

--- a/internal/procgroup/identity.go
+++ b/internal/procgroup/identity.go
@@ -31,6 +31,20 @@ func Inspect(cmd *exec.Cmd) (Identity, error) {
 	return inspectProcess(cmd.Process.Pid)
 }
 
+func Alive(identity Identity) (bool, error) {
+	if identity.PID <= 0 || identity.StartedAt.IsZero() {
+		return false, nil
+	}
+	current, err := inspectProcess(identity.PID)
+	if errors.Is(err, ErrProcessNotRunning) {
+		return false, nil
+	}
+	if err != nil {
+		return false, err
+	}
+	return sameIdentity(current, identity), nil
+}
+
 func sameIdentity(current Identity, recorded Identity) bool {
 	return current.PID == recorded.PID &&
 		(recorded.GroupID <= 0 || current.GroupID == recorded.GroupID) &&

--- a/internal/procgroup/priority_linux.go
+++ b/internal/procgroup/priority_linux.go
@@ -1,0 +1,13 @@
+//go:build linux
+
+package procgroup
+
+import "golang.org/x/sys/unix"
+
+func processNice(pid int) (int, error) {
+	priority, err := unix.Getpriority(unix.PRIO_PROCESS, pid)
+	if err != nil {
+		return 0, err
+	}
+	return 20 - priority, nil
+}

--- a/internal/procgroup/priority_other_unix.go
+++ b/internal/procgroup/priority_other_unix.go
@@ -1,0 +1,9 @@
+//go:build unix && !linux
+
+package procgroup
+
+import "golang.org/x/sys/unix"
+
+func processNice(pid int) (int, error) {
+	return unix.Getpriority(unix.PRIO_PROCESS, pid)
+}

--- a/internal/procgroup/process_group_other.go
+++ b/internal/procgroup/process_group_other.go
@@ -20,6 +20,10 @@ func GroupID(*exec.Cmd) int {
 	return 0
 }
 
+func Deprioritize(*exec.Cmd) error {
+	return nil
+}
+
 func TerminateTree(cmd *exec.Cmd, _ int) error {
 	if cmd == nil || cmd.Process == nil {
 		return nil

--- a/internal/procgroup/process_group_unix.go
+++ b/internal/procgroup/process_group_unix.go
@@ -12,7 +12,11 @@ import (
 	"strings"
 	"syscall"
 	"time"
+
+	"golang.org/x/sys/unix"
 )
+
+const workerNiceDelta = 5
 
 func Configure(cmd *exec.Cmd) {
 	if cmd.SysProcAttr == nil {
@@ -33,6 +37,21 @@ func GroupID(cmd *exec.Cmd) int {
 		return cmd.Process.Pid
 	}
 	return pgid
+}
+
+func Deprioritize(cmd *exec.Cmd) error {
+	if cmd == nil || cmd.Process == nil || cmd.Process.Pid <= 0 {
+		return ErrProcessNotRunning
+	}
+	current, err := processNice(os.Getpid())
+	if err != nil {
+		return fmt.Errorf("read Detent process priority: %w", err)
+	}
+	target := min(19, current+workerNiceDelta)
+	if err := unix.Setpriority(unix.PRIO_PROCESS, cmd.Process.Pid, target); err != nil {
+		return fmt.Errorf("set worker process %d priority: %w", cmd.Process.Pid, err)
+	}
+	return nil
 }
 
 func TerminateTree(cmd *exec.Cmd, processGroupID int) error {

--- a/internal/procgroup/process_group_unix.go
+++ b/internal/procgroup/process_group_unix.go
@@ -48,7 +48,9 @@ func Deprioritize(cmd *exec.Cmd) error {
 		return fmt.Errorf("read Detent process priority: %w", err)
 	}
 	target := min(19, current+workerNiceDelta)
-	if err := unix.Setpriority(unix.PRIO_PROCESS, cmd.Process.Pid, target); err != nil {
+	if err := unix.Setpriority(unix.PRIO_PROCESS, cmd.Process.Pid, target); errors.Is(err, syscall.ESRCH) {
+		return nil
+	} else if err != nil {
 		return fmt.Errorf("set worker process %d priority: %w", cmd.Process.Pid, err)
 	}
 	return nil

--- a/internal/procgroup/process_group_unix_test.go
+++ b/internal/procgroup/process_group_unix_test.go
@@ -125,6 +125,17 @@ func TestDeprioritize(t *testing.T) {
 	}
 }
 
+func TestDeprioritizeExitedProcess(t *testing.T) {
+	cmd := exec.CommandContext(context.Background(), "true")
+	Configure(cmd)
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+	if err := Deprioritize(cmd); err != nil {
+		t.Fatalf("Deprioritize() error = %v, want exited process ignored", err)
+	}
+}
+
 func TestAliveRejectsStaleProcessIdentity(t *testing.T) {
 	proc := startSleep(t)
 	identity, err := Inspect(proc.cmd)

--- a/internal/procgroup/process_group_unix_test.go
+++ b/internal/procgroup/process_group_unix_test.go
@@ -5,6 +5,7 @@ package procgroup
 import (
 	"context"
 	"errors"
+	"os"
 	"os/exec"
 	"sync"
 	"syscall"
@@ -102,6 +103,54 @@ func TestGroupID(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			cmd := tt.cmd(t)
 			tt.want(t, cmd, GroupID(cmd))
+		})
+	}
+}
+
+func TestDeprioritize(t *testing.T) {
+	proc := startSleep(t)
+	parentPriority, err := processNice(os.Getpid())
+	if err != nil {
+		t.Fatalf("Getpriority(parent) error = %v", err)
+	}
+	if err := Deprioritize(proc.cmd); err != nil {
+		t.Fatalf("Deprioritize() error = %v", err)
+	}
+	workerPriority, err := processNice(proc.cmd.Process.Pid)
+	if err != nil {
+		t.Fatalf("Getpriority(worker) error = %v", err)
+	}
+	if want := min(19, parentPriority+workerNiceDelta); workerPriority != want {
+		t.Fatalf("worker priority = %d, want %d", workerPriority, want)
+	}
+}
+
+func TestAliveRejectsStaleProcessIdentity(t *testing.T) {
+	proc := startSleep(t)
+	identity, err := Inspect(proc.cmd)
+	if err != nil {
+		t.Fatalf("Inspect() error = %v", err)
+	}
+
+	tests := []struct {
+		name     string
+		identity Identity
+		want     bool
+	}{
+		{name: "matching identity", identity: identity, want: true},
+		{name: "stale start time", identity: Identity{PID: identity.PID, GroupID: identity.GroupID, StartedAt: identity.StartedAt.Add(time.Second)}},
+		{name: "missing start time", identity: Identity{PID: identity.PID, GroupID: identity.GroupID}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := Alive(tt.identity)
+			if err != nil {
+				t.Fatalf("Alive() error = %v", err)
+			}
+			if got != tt.want {
+				t.Fatalf("Alive() = %v, want %v", got, tt.want)
+			}
 		})
 	}
 }

--- a/internal/procgroup/process_group_windows.go
+++ b/internal/procgroup/process_group_windows.go
@@ -22,6 +22,21 @@ func GroupID(*exec.Cmd) int {
 	return 0
 }
 
+func Deprioritize(cmd *exec.Cmd) error {
+	if cmd == nil || cmd.Process == nil || cmd.Process.Pid <= 0 {
+		return ErrProcessNotRunning
+	}
+	handle, err := openProcess(cmd.Process.Pid, windows.PROCESS_SET_INFORMATION)
+	if err != nil {
+		return err
+	}
+	defer windows.CloseHandle(handle)
+	if err := windows.SetPriorityClass(handle, windows.BELOW_NORMAL_PRIORITY_CLASS); err != nil {
+		return fmt.Errorf("set worker process %d priority: %w", cmd.Process.Pid, err)
+	}
+	return nil
+}
+
 func TerminateTree(cmd *exec.Cmd, _ int) error {
 	if cmd == nil || cmd.Process == nil {
 		return nil

--- a/internal/runner/agent.go
+++ b/internal/runner/agent.go
@@ -22,6 +22,7 @@ import (
 	"github.com/digitaldrywood/detent/internal/gate"
 	"github.com/digitaldrywood/detent/internal/lessons"
 	"github.com/digitaldrywood/detent/internal/notes"
+	"github.com/digitaldrywood/detent/internal/procgroup"
 	"github.com/digitaldrywood/detent/internal/runtimeoutput"
 	"github.com/digitaldrywood/detent/internal/selector"
 	"github.com/digitaldrywood/detent/internal/skills"
@@ -2079,6 +2080,7 @@ func applyAgentUpdate(result *RunResult, update AgentUpdate) {
 type agentRunProgress struct {
 	sessionID             string
 	processIdentity       string
+	workerProcess         procgroup.Identity
 	turnIDs               map[string]struct{}
 	messages              map[string]*runtimeoutput.Buffer
 	messageOrder          []string
@@ -2121,6 +2123,9 @@ func newAgentRunProgress(outputPolicy runtimeoutput.Policy, ciTriggerLabel strin
 func (p *agentRunProgress) apply(update AgentUpdate, eventAt time.Time) {
 	if update.ProcessIdentity != "" {
 		p.processIdentity = update.ProcessIdentity
+	}
+	if update.WorkerProcess.PID > 0 && !update.WorkerProcess.StartedAt.IsZero() {
+		p.workerProcess = update.WorkerProcess
 	}
 	if update.ThreadID != "" && update.TurnID != "" {
 		p.sessionID = update.ThreadID + "-" + update.TurnID
@@ -2602,6 +2607,7 @@ func (r *Runner) publishRunUpdate(
 		DetentSessionID:       detentSessionID,
 		SessionID:             progress.sessionID,
 		ProcessIdentity:       progress.processIdentity,
+		WorkerProcess:         progress.workerProcess,
 		WorkspacePath:         info.Path,
 		TurnCount:             progress.turnCount(),
 		LastEventAt:           progress.lastEventAt,

--- a/internal/runner/runner_test.go
+++ b/internal/runner/runner_test.go
@@ -203,6 +203,9 @@ func TestRunnerRunPreparesWorkspaceRunsCodexAndRecordsSession(t *testing.T) {
 	if usageUpdates[1].ProcessIdentity != "4242" {
 		t.Fatalf("second usage update ProcessIdentity = %q, want 4242", usageUpdates[1].ProcessIdentity)
 	}
+	if usageUpdates[1].WorkerProcess.PID != 4242 || usageUpdates[1].WorkerProcess.GroupID != 4242 || !usageUpdates[1].WorkerProcess.StartedAt.Equal(processStartedAt) {
+		t.Fatalf("second usage update WorkerProcess = %#v, want persisted process identity", usageUpdates[1].WorkerProcess)
+	}
 	if usageUpdates[1].WorkspacePath != workspacePath {
 		t.Fatalf("second usage update WorkspacePath = %q, want %q", usageUpdates[1].WorkspacePath, workspacePath)
 	}

--- a/internal/runner/types.go
+++ b/internal/runner/types.go
@@ -343,6 +343,7 @@ type UsageUpdate struct {
 	DetentSessionID       int64
 	SessionID             string
 	ProcessIdentity       string
+	WorkerProcess         procgroup.Identity
 	WorkspacePath         string
 	TurnCount             int
 	LastEventAt           time.Time


### PR DESCRIPTION
## Summary

- Renew tracker claims and durable attempt leases from a dedicated loop that stays independent of scheduler refresh work.
- Verify persisted PID, process-group, and start-time identity before protecting or reclaiming stale leases, with workspace activity as supporting liveness evidence.
- Lower owned provider process priority so the Detent service retains CPU access while worker builds saturate the host.

Fixes #1433

## UI Surface Contract

- [x] N/A; this change does not alter UI surfaces, layout, density, or responsive visibility.
- [x] This change does not add persistent top-of-screen messaging.
- [x] N/A; this change has no visual operator-screen changes.

## Test Plan

- [x] `make check`
- [x] Focused race tests for orchestrator heartbeat renewal and process identity checks.
- [x] Windows and Linux cross-compilation for process-priority and liveness support.