### PR TITLE
feat(workspace): support shared Go build caches

### DIFF
--- a/README.md
+++ b/README.md
@@ -667,6 +667,7 @@ polling:
 workspace:
   root: /absolute/path/to/detent-workspaces
   source_root: /absolute/path/to/project-checkout
+  cache_strategy: isolated
   auto_branch: true
   cleanup_idle_ttl_ms: 86400000
   cleanup_sweep_interval_ms: 600000
@@ -950,6 +951,14 @@ agent:
 If `workspace.source_root` is omitted, Detent falls back to the project
 `workdir` from global config, then to `workspace.root` for older single-root
 setups.
+
+`workspace.cache_strategy` controls the worker build environment. The default,
+`isolated`, sets `GOCACHE`, `GOMODCACHE`, `GOBIN`, and
+`GOLANGCI_LINT_CACHE` inside the per-turn scratch directory and removes them
+after the worker exits. Set it to `shared` to place those caches in a stable,
+per-project directory under `workspace.root/.detent/cache`, prepend the shared
+`GOBIN` to `PATH`, and reuse compiled dependencies and tools across worktrees
+and Detent restarts. `TMPDIR`, `TMP`, and `TEMP` remain per-turn in both modes.
 
 `workspace.cleanup_idle_ttl_ms` controls how long non-active observed
 workspaces can sit idle before cleanup. Terminal issues are cleaned on the next

--- a/docs/templates/WORKFLOW.github_local.md
+++ b/docs/templates/WORKFLOW.github_local.md
@@ -55,6 +55,7 @@ polling:
 workspace:
   root: <worktree-root>
   source_root: <source-root>
+  cache_strategy: isolated
   auto_branch: true
   cleanup_idle_ttl_ms: 86400000
   cleanup_sweep_interval_ms: 600000

--- a/docs/templates/WORKFLOW.issue_field.md
+++ b/docs/templates/WORKFLOW.issue_field.md
@@ -56,6 +56,7 @@ intake:
 workspace:
   root: <worktree-root>
   source_root: <source-root>
+  cache_strategy: isolated
   auto_branch: true
   cleanup_idle_ttl_ms: 86400000
   cleanup_sweep_interval_ms: 600000

--- a/docs/templates/WORKFLOW.label.md
+++ b/docs/templates/WORKFLOW.label.md
@@ -56,6 +56,7 @@ intake:
 workspace:
   root: <worktree-root>
   source_root: <source-root>
+  cache_strategy: isolated
   auto_branch: true
   cleanup_idle_ttl_ms: 86400000
   cleanup_sweep_interval_ms: 600000

--- a/docs/templates/WORKFLOW.project_v2.md
+++ b/docs/templates/WORKFLOW.project_v2.md
@@ -55,6 +55,7 @@ intake:
 workspace:
   root: <worktree-root>
   source_root: <source-root>
+  cache_strategy: isolated
   auto_branch: true
   cleanup_idle_ttl_ms: 86400000
   cleanup_sweep_interval_ms: 600000

--- a/internal/claudecode/backend_test.go
+++ b/internal/claudecode/backend_test.go
@@ -18,6 +18,7 @@ import (
 	"time"
 
 	"github.com/digitaldrywood/detent/internal/agentidentity"
+	"github.com/digitaldrywood/detent/internal/procgroup"
 	"github.com/digitaldrywood/detent/internal/runner"
 )
 
@@ -398,6 +399,10 @@ func TestAgentBackendBuildsCommandArgumentsAndWritesPromptToStdin(t *testing.T) 
 		Prompt:             "prompt from stdin",
 		Model:              "fable",
 		ExtraWritableRoots: []string{"/tmp/root-a", " ", "/tmp/root-b"},
+		Environment: procgroup.Environment{
+			Variables:    map[string]string{"GOCACHE": "/shared/go-build", "GOMODCACHE": "/shared/go-mod"},
+			PathPrefixes: []string{"/shared/go-bin"},
+		},
 	}, nil)
 	if err != nil {
 		t.Fatalf("RunTurn() error = %v", err)
@@ -441,6 +446,15 @@ func TestAgentBackendBuildsCommandArgumentsAndWritesPromptToStdin(t *testing.T) 
 		if want := filepath.Join(workspace, ".detent", "tmp"); got != want {
 			t.Fatalf("%s = %q, want %q", name, got, want)
 		}
+	}
+	if observed.GOCACHE != "/shared/go-build" {
+		t.Fatalf("GOCACHE = %q, want /shared/go-build", observed.GOCACHE)
+	}
+	if observed.GOMODCACHE != "/shared/go-mod" {
+		t.Fatalf("GOMODCACHE = %q, want /shared/go-mod", observed.GOMODCACHE)
+	}
+	if !strings.HasPrefix(observed.Path, "/shared/go-bin"+string(os.PathListSeparator)) {
+		t.Fatalf("PATH = %q, want shared tool prefix", observed.Path)
 	}
 }
 
@@ -599,12 +613,15 @@ func TestClaudeCodeHelperProcess(t *testing.T) {
 		os.Exit(3)
 	}
 	observed := helperObservation{
-		Args:    argsAfterDashDash(os.Args),
-		Stdin:   string(stdin),
-		Workdir: workdir,
-		TMPDIR:  os.Getenv("TMPDIR"),
-		TMP:     os.Getenv("TMP"),
-		TEMP:    os.Getenv("TEMP"),
+		Args:       argsAfterDashDash(os.Args),
+		Stdin:      string(stdin),
+		Workdir:    workdir,
+		TMPDIR:     os.Getenv("TMPDIR"),
+		TMP:        os.Getenv("TMP"),
+		TEMP:       os.Getenv("TEMP"),
+		GOCACHE:    os.Getenv("GOCACHE"),
+		GOMODCACHE: os.Getenv("GOMODCACHE"),
+		Path:       os.Getenv("PATH"),
 	}
 	raw, err := json.Marshal(observed)
 	if err != nil {
@@ -644,12 +661,15 @@ func TestPackageDoesNotImportConfigOrCLI(t *testing.T) {
 }
 
 type helperObservation struct {
-	Args    []string `json:"args"`
-	Stdin   string   `json:"stdin"`
-	Workdir string   `json:"workdir"`
-	TMPDIR  string   `json:"tmpdir"`
-	TMP     string   `json:"tmp"`
-	TEMP    string   `json:"temp"`
+	Args       []string `json:"args"`
+	Stdin      string   `json:"stdin"`
+	Workdir    string   `json:"workdir"`
+	TMPDIR     string   `json:"tmpdir"`
+	TMP        string   `json:"tmp"`
+	TEMP       string   `json:"temp"`
+	GOCACHE    string   `json:"gocache"`
+	GOMODCACHE string   `json:"gomodcache"`
+	Path       string   `json:"path"`
 }
 
 func newTestBackend(t *testing.T, options Options) *AgentBackend {

--- a/internal/claudecode/process.go
+++ b/internal/claudecode/process.go
@@ -36,6 +36,7 @@ func (b *AgentBackend) RunTurn(
 	if err != nil {
 		return runner.AgentTurnResult{}, err
 	}
+	procgroup.SetEnvironment(cmd, req.Environment)
 	procgroup.SetTempDir(cmd, req.TempDir)
 
 	stderr := newTailBuffer(b.options.StderrTailBytes)

--- a/internal/codex/backend.go
+++ b/internal/codex/backend.go
@@ -74,6 +74,7 @@ func (b *AgentBackend) runTurn(
 	onUpdate runner.AgentUpdateHandler,
 ) (runner.AgentTurnResult, error) {
 	ctx = withWorkerTempDir(ctx, req.TempDir)
+	ctx = withWorkerEnvironment(ctx, req.Environment)
 	restricted := req.ReadOnly || len(tools) > 0
 	result, err := b.client.RunTurn(ctx, RunTurnRequest{
 		Workspace:             req.Workspace,

--- a/internal/codex/transport.go
+++ b/internal/codex/transport.go
@@ -55,6 +55,7 @@ type transportResult struct {
 }
 
 type workerTempDirContextKey struct{}
+type workerEnvironmentContextKey struct{}
 
 func NewLocalTransportFactory(newCommand CommandFactory) (*LocalTransportFactory, error) {
 	if newCommand == nil {
@@ -71,6 +72,7 @@ func (f *LocalTransportFactory) NewTransport(ctx context.Context) (Transport, er
 	if cmd == nil {
 		return nil, errors.New("command factory returned nil command")
 	}
+	procgroup.SetEnvironment(cmd, workerEnvironment(ctx))
 	procgroup.SetTempDir(cmd, workerTempDir(ctx))
 
 	stdin, err := cmd.StdinPipe()
@@ -163,6 +165,25 @@ func workerTempDir(ctx context.Context) string {
 		return ""
 	}
 	return strings.TrimSpace(path)
+}
+
+func withWorkerEnvironment(ctx context.Context, environment procgroup.Environment) context.Context {
+	ctx = contextOrBackground(ctx)
+	if len(environment.Variables) == 0 && len(environment.PathPrefixes) == 0 {
+		return ctx
+	}
+	return context.WithValue(ctx, workerEnvironmentContextKey{}, environment)
+}
+
+func workerEnvironment(ctx context.Context) procgroup.Environment {
+	if ctx == nil {
+		return procgroup.Environment{}
+	}
+	environment, ok := ctx.Value(workerEnvironmentContextKey{}).(procgroup.Environment)
+	if !ok {
+		return procgroup.Environment{}
+	}
+	return environment
 }
 
 func (t *localTransport) Send(ctx context.Context, msg Message) error {

--- a/internal/codex/transport_test.go
+++ b/internal/codex/transport_test.go
@@ -12,6 +12,8 @@ import (
 	"sync"
 	"testing"
 	"time"
+
+	"github.com/digitaldrywood/detent/internal/procgroup"
 )
 
 func TestLocalTransportRoundTrip(t *testing.T) {
@@ -103,7 +105,13 @@ func TestLocalTransportFactoryAppliesWorkerTempDir(t *testing.T) {
 	}
 
 	tempDir := t.TempDir()
-	transport, err := factory.NewTransport(withWorkerTempDir(context.Background(), tempDir))
+	toolBin := t.TempDir()
+	ctx := withWorkerTempDir(context.Background(), tempDir)
+	ctx = withWorkerEnvironment(ctx, procgroup.Environment{
+		Variables:    map[string]string{"GOCACHE": "/shared/go-build", "GOMODCACHE": "/shared/go-mod"},
+		PathPrefixes: []string{toolBin},
+	})
+	transport, err := factory.NewTransport(ctx)
 	if err != nil {
 		t.Fatalf("NewTransport() error = %v", err)
 	}
@@ -123,6 +131,14 @@ func TestLocalTransportFactoryAppliesWorkerTempDir(t *testing.T) {
 		if got := environmentValue(local.cmd.Env, name); got != tempDir {
 			t.Fatalf("%s = %q, want %q", name, got, tempDir)
 		}
+	}
+	for name, want := range map[string]string{"GOCACHE": "/shared/go-build", "GOMODCACHE": "/shared/go-mod"} {
+		if got := environmentValue(local.cmd.Env, name); got != want {
+			t.Fatalf("%s = %q, want %q", name, got, want)
+		}
+	}
+	if got := environmentValue(local.cmd.Env, "PATH"); !strings.HasPrefix(got, toolBin+string(os.PathListSeparator)) {
+		t.Fatalf("PATH = %q, want prefix %q", got, toolBin)
 	}
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -35,8 +35,10 @@ const (
 	GitHubStatusSourceIssueField = "issue_field"
 	GitHubStatusSourceLabel      = "label"
 
-	WorkspaceLocalGit   = "local_git"
-	WorkspaceFilesystem = "filesystem"
+	WorkspaceLocalGit      = "local_git"
+	WorkspaceFilesystem    = "filesystem"
+	WorkspaceCacheIsolated = "isolated"
+	WorkspaceCacheShared   = "shared"
 
 	DeliverablePullRequest  = "pull_request"
 	DeliverableArtifact     = "artifact"
@@ -225,6 +227,7 @@ type Workspace struct {
 	Root                   string `yaml:"root"`
 	SourceRoot             string `yaml:"source_root"`
 	OutputRoot             string `yaml:"output_root"`
+	CacheStrategy          string `yaml:"cache_strategy"`
 	AutoBranch             bool   `yaml:"auto_branch"`
 	CleanupIdleTTLMS       int    `yaml:"cleanup_idle_ttl_ms"`
 	CleanupSweepIntervalMS int    `yaml:"cleanup_sweep_interval_ms"`
@@ -1170,6 +1173,7 @@ func Default() Config {
 		Workspace: Workspace{
 			Kind:                   WorkspaceLocalGit,
 			Root:                   filepath.Join(os.TempDir(), "detent_workspaces"),
+			CacheStrategy:          WorkspaceCacheIsolated,
 			AutoBranch:             true,
 			CleanupIdleTTLMS:       86400000,
 			CleanupSweepIntervalMS: 600000,
@@ -1739,6 +1743,11 @@ func (w *Workspace) validate(problems *[]string) {
 	default:
 		*problems = append(*problems, "workspace.kind must be one of local_git, filesystem")
 	}
+	switch w.CacheStrategy {
+	case "", WorkspaceCacheIsolated, WorkspaceCacheShared:
+	default:
+		*problems = append(*problems, "workspace.cache_strategy must be one of isolated, shared")
+	}
 	validatePositive("workspace.cleanup_idle_ttl_ms", w.CleanupIdleTTLMS, problems)
 	validatePositive("workspace.cleanup_sweep_interval_ms", w.CleanupSweepIntervalMS, problems)
 }
@@ -1751,6 +1760,7 @@ func (w *Workspace) Normalize() {
 	w.Root = strings.TrimSpace(w.Root)
 	w.SourceRoot = strings.TrimSpace(w.SourceRoot)
 	w.OutputRoot = strings.TrimSpace(w.OutputRoot)
+	w.CacheStrategy = normalizeWorkspaceCacheStrategy(w.CacheStrategy)
 }
 
 func normalizeWorkspaceKind(kind string) string {
@@ -1761,6 +1771,17 @@ func normalizeWorkspaceKind(kind string) string {
 		return WorkspaceFilesystem
 	default:
 		return strings.ToLower(strings.TrimSpace(kind))
+	}
+}
+
+func normalizeWorkspaceCacheStrategy(strategy string) string {
+	switch strings.ToLower(strings.TrimSpace(strategy)) {
+	case "", WorkspaceCacheIsolated:
+		return WorkspaceCacheIsolated
+	case WorkspaceCacheShared:
+		return WorkspaceCacheShared
+	default:
+		return strings.ToLower(strings.TrimSpace(strategy))
 	}
 }
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -637,6 +637,7 @@ polling:
   conditional: false
 workspace:
   root: ~/code/detent-workspaces
+  cache_strategy: shared
   auto_branch: false
   cleanup_idle_ttl_ms: 7200000
   cleanup_sweep_interval_ms: 120000
@@ -802,6 +803,9 @@ Ticket prompt {{ issue.title }}
 	}
 	if cfg.Workspace.CleanupIdleTTLMS != 7200000 {
 		t.Fatalf("Workspace.CleanupIdleTTLMS = %d, want 7200000", cfg.Workspace.CleanupIdleTTLMS)
+	}
+	if cfg.Workspace.CacheStrategy != WorkspaceCacheShared {
+		t.Fatalf("Workspace.CacheStrategy = %q, want %q", cfg.Workspace.CacheStrategy, WorkspaceCacheShared)
 	}
 	if cfg.Workspace.CleanupSweepIntervalMS != 120000 {
 		t.Fatalf("Workspace.CleanupSweepIntervalMS = %d, want 120000", cfg.Workspace.CleanupSweepIntervalMS)
@@ -1232,6 +1236,9 @@ func TestParseWorkflowDefaults(t *testing.T) {
 	}
 	if cfg.Workspace.AutoBranch != true {
 		t.Fatal("Workspace.AutoBranch = false, want true")
+	}
+	if cfg.Workspace.CacheStrategy != WorkspaceCacheIsolated {
+		t.Fatalf("Workspace.CacheStrategy = %q, want %q", cfg.Workspace.CacheStrategy, WorkspaceCacheIsolated)
 	}
 	if cfg.Workspace.CleanupIdleTTLMS != 86400000 {
 		t.Fatalf("Workspace.CleanupIdleTTLMS = %d, want 86400000", cfg.Workspace.CleanupIdleTTLMS)
@@ -2764,6 +2771,11 @@ func TestConfigValidateReportsInvalidSettings(t *testing.T) {
 			name: "dependency source",
 			raw:  "---\ntracker:\n  kind: memory\ndependencies:\n  source: prose\n---\nPrompt\n",
 			want: []string{"dependencies.source must be one of merged, native_only"},
+		},
+		{
+			name: "workspace cache strategy",
+			raw:  "---\ntracker:\n  kind: memory\nworkspace:\n  cache_strategy: ephemeral\n---\nPrompt\n",
+			want: []string{"workspace.cache_strategy must be one of isolated, shared"},
 		},
 		{
 			name: "partial github app credentials",

--- a/internal/procgroup/environment.go
+++ b/internal/procgroup/environment.go
@@ -3,8 +3,21 @@ package procgroup
 import (
 	"os/exec"
 	"runtime"
+	"sort"
 	"strings"
 )
+
+type Environment struct {
+	Variables    map[string]string
+	PathPrefixes []string
+}
+
+func SetEnvironment(cmd *exec.Cmd, environment Environment) {
+	if cmd == nil || (len(environment.Variables) == 0 && len(environment.PathPrefixes) == 0) {
+		return
+	}
+	cmd.Env = environmentWithOverrides(cmd.Environ(), environment, runtime.GOOS)
+}
 
 func SetTempDir(cmd *exec.Cmd, path string) {
 	path = strings.TrimSpace(path)
@@ -31,6 +44,59 @@ func environmentWithTempDir(environment []string, path string, goos string) []st
 		out = append(out, entry)
 	}
 	return append(out, "TMPDIR="+path, "TMP="+path, "TEMP="+path)
+}
+
+func environmentWithOverrides(current []string, configured Environment, goos string) []string {
+	overrides := make(map[string]struct{}, len(configured.Variables))
+	for key := range configured.Variables {
+		overrides[environmentKey(key, goos)] = struct{}{}
+	}
+	pathKey := environmentKey("PATH", goos)
+	pathValue := ""
+	out := make([]string, 0, len(current)+len(configured.Variables)+1)
+	for _, entry := range current {
+		key, value, ok := strings.Cut(entry, "=")
+		if !ok {
+			out = append(out, entry)
+			continue
+		}
+		normalized := environmentKey(key, goos)
+		if normalized == pathKey && len(configured.PathPrefixes) > 0 {
+			pathValue = value
+			continue
+		}
+		if _, remove := overrides[normalized]; remove {
+			continue
+		}
+		out = append(out, entry)
+	}
+
+	keys := make([]string, 0, len(configured.Variables))
+	for key := range configured.Variables {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	for _, key := range keys {
+		out = append(out, key+"="+configured.Variables[key])
+	}
+
+	pathParts := make([]string, 0, len(configured.PathPrefixes)+1)
+	for _, prefix := range configured.PathPrefixes {
+		if prefix = strings.TrimSpace(prefix); prefix != "" {
+			pathParts = append(pathParts, prefix)
+		}
+	}
+	if pathValue != "" {
+		pathParts = append(pathParts, pathValue)
+	}
+	if len(pathParts) > 0 {
+		separator := ":"
+		if goos == "windows" {
+			separator = ";"
+		}
+		out = append(out, "PATH="+strings.Join(pathParts, separator))
+	}
+	return out
 }
 
 func environmentKey(key string, goos string) string {

--- a/internal/procgroup/environment.go
+++ b/internal/procgroup/environment.go
@@ -10,10 +10,11 @@ import (
 type Environment struct {
 	Variables    map[string]string
 	PathPrefixes []string
+	PathSuffixes []string
 }
 
 func SetEnvironment(cmd *exec.Cmd, environment Environment) {
-	if cmd == nil || (len(environment.Variables) == 0 && len(environment.PathPrefixes) == 0) {
+	if cmd == nil || (len(environment.Variables) == 0 && len(environment.PathPrefixes) == 0 && len(environment.PathSuffixes) == 0) {
 		return
 	}
 	cmd.Env = environmentWithOverrides(cmd.Environ(), environment, runtime.GOOS)
@@ -61,7 +62,7 @@ func environmentWithOverrides(current []string, configured Environment, goos str
 			continue
 		}
 		normalized := environmentKey(key, goos)
-		if normalized == pathKey && len(configured.PathPrefixes) > 0 {
+		if normalized == pathKey && (len(configured.PathPrefixes) > 0 || len(configured.PathSuffixes) > 0) {
 			pathValue = value
 			continue
 		}
@@ -80,7 +81,7 @@ func environmentWithOverrides(current []string, configured Environment, goos str
 		out = append(out, key+"="+configured.Variables[key])
 	}
 
-	pathParts := make([]string, 0, len(configured.PathPrefixes)+1)
+	pathParts := make([]string, 0, len(configured.PathPrefixes)+len(configured.PathSuffixes)+1)
 	for _, prefix := range configured.PathPrefixes {
 		if prefix = strings.TrimSpace(prefix); prefix != "" {
 			pathParts = append(pathParts, prefix)
@@ -88,6 +89,11 @@ func environmentWithOverrides(current []string, configured Environment, goos str
 	}
 	if pathValue != "" {
 		pathParts = append(pathParts, pathValue)
+	}
+	for _, suffix := range configured.PathSuffixes {
+		if suffix = strings.TrimSpace(suffix); suffix != "" {
+			pathParts = append(pathParts, suffix)
+		}
 	}
 	if len(pathParts) > 0 {
 		separator := ":"

--- a/internal/procgroup/environment_test.go
+++ b/internal/procgroup/environment_test.go
@@ -70,6 +70,15 @@ func TestEnvironmentWithOverrides(t *testing.T) {
 			},
 			want: []string{"TEMP=C:\\temp", "GOCACHE=D:\\shared\\go-build", "PATH=D:\\shared\\go-bin;C:\\Windows"},
 		},
+		{
+			name:        "unix appends fallback tool paths",
+			goos:        "linux",
+			environment: []string{"PATH=/usr/bin", "HOME=/home/example"},
+			configured: Environment{
+				PathSuffixes: []string{"/shared/go-bin", " "},
+			},
+			want: []string{"HOME=/home/example", "PATH=/usr/bin:/shared/go-bin"},
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/procgroup/environment_test.go
+++ b/internal/procgroup/environment_test.go
@@ -39,3 +39,47 @@ func TestEnvironmentWithTempDir(t *testing.T) {
 		})
 	}
 }
+
+func TestEnvironmentWithOverrides(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		goos        string
+		environment []string
+		configured  Environment
+		want        []string
+	}{
+		{
+			name:        "unix replaces variables and prepends tool paths",
+			goos:        "linux",
+			environment: []string{"PATH=/usr/bin", "GOCACHE=/host/cache", "HOME=/home/example"},
+			configured: Environment{
+				Variables:    map[string]string{"GOMODCACHE": "/shared/go-mod", "GOCACHE": "/shared/go-build"},
+				PathPrefixes: []string{"/shared/go-bin", " "},
+			},
+			want: []string{"HOME=/home/example", "GOCACHE=/shared/go-build", "GOMODCACHE=/shared/go-mod", "PATH=/shared/go-bin:/usr/bin"},
+		},
+		{
+			name:        "windows replaces variables case insensitively",
+			goos:        "windows",
+			environment: []string{"Path=C:\\Windows", "gocache=C:\\host", "TEMP=C:\\temp"},
+			configured: Environment{
+				Variables:    map[string]string{"GOCACHE": "D:\\shared\\go-build"},
+				PathPrefixes: []string{"D:\\shared\\go-bin"},
+			},
+			want: []string{"TEMP=C:\\temp", "GOCACHE=D:\\shared\\go-build", "PATH=D:\\shared\\go-bin;C:\\Windows"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := environmentWithOverrides(tt.environment, tt.configured, tt.goos)
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Fatalf("environmentWithOverrides() = %#v, want %#v", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/runner/agent.go
+++ b/internal/runner/agent.go
@@ -641,6 +641,10 @@ func runAgentBackendTurnWithTools(
 		return AgentTurnResult{}, fmt.Errorf("prepare worker scratch: %w", err), nil
 	}
 	request.TempDir = tempDir
+	if err := configureWorkerCache(&request); err != nil {
+		cleanupErr := workspace.CleanupWorkerScratch(workspacePath)
+		return AgentTurnResult{}, fmt.Errorf("prepare worker cache: %w", err), cleanupErr
+	}
 	result, runErr := run(ctx, request)
 	cleanupErr := workspace.CleanupWorkerScratch(workspacePath)
 	if cleanupErr != nil {
@@ -1042,6 +1046,8 @@ func (r *Runner) Run(ctx context.Context, req RunRequest) (RunResult, error) {
 		ReasoningEffort:    effort,
 		Resume:             agentResumeFromState(resumeState),
 		ExtraWritableRoots: extraWritableRootsForWorkspace(ctx, info.Path, r.logger),
+		cacheStrategy:      workflow.Config.Workspace.CacheStrategy,
+		projectID:          r.projectID,
 	}
 	if mode == RunModeRoutine {
 		turnRequest.ToolInstructions = routineToolInstructions
@@ -1339,6 +1345,8 @@ func (r *Runner) Validate(ctx context.Context, req ValidatorRequest) (gate.Valid
 		ReasoningEffort:    effort,
 		TurnTimeout:        durationFromMillis(validator.TurnTimeoutMS),
 		ExtraWritableRoots: extraWritableRootsForWorkspace(ctx, info.Path, r.logger),
+		cacheStrategy:      workflow.Config.Workspace.CacheStrategy,
+		projectID:          r.projectID,
 	}, func(update AgentUpdate) error {
 		eventAt := r.now()
 		if !update.RuntimeIdentity.IsZero() {

--- a/internal/runner/runner_test.go
+++ b/internal/runner/runner_test.go
@@ -120,6 +120,7 @@ func TestRunnerRunPreparesWorkspaceRunsCodexAndRecordsSession(t *testing.T) {
 		ProjectID: "detent",
 		Workflow: config.Workflow{
 			Config: config.Config{
+				Workspace: config.Workspace{CacheStrategy: config.WorkspaceCacheShared},
 				Agent: config.Agent{
 					Skills: config.Skills{
 						Enabled:           true,
@@ -265,6 +266,20 @@ func TestRunnerRunPreparesWorkspaceRunsCodexAndRecordsSession(t *testing.T) {
 	}
 	if codexClient.request.Workspace != workspacePath {
 		t.Fatalf("codex workspace = %q, want %q", codexClient.request.Workspace, workspacePath)
+	}
+	cacheRoot := sharedWorkerCacheRoot(workspacePath, "detent")
+	for name, want := range map[string]string{
+		"GOCACHE":             filepath.Join(cacheRoot, "go-build"),
+		"GOMODCACHE":          filepath.Join(cacheRoot, "go-mod"),
+		"GOBIN":               filepath.Join(cacheRoot, "go-bin"),
+		"GOLANGCI_LINT_CACHE": filepath.Join(cacheRoot, "golangci-lint"),
+	} {
+		if got := codexClient.request.Environment.Variables[name]; got != want {
+			t.Fatalf("codex %s = %q, want %q", name, got, want)
+		}
+	}
+	if len(codexClient.request.ExtraWritableRoots) != 1 || codexClient.request.ExtraWritableRoots[0] != cacheRoot {
+		t.Fatalf("codex writable roots = %#v, want shared cache root %q", codexClient.request.ExtraWritableRoots, cacheRoot)
 	}
 	if codexClient.request.Model != "gpt-5-codex-high" {
 		t.Fatalf("codex model = %q, want issue override", codexClient.request.Model)

--- a/internal/runner/runner_test.go
+++ b/internal/runner/runner_test.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"testing"
 	"time"
@@ -280,6 +281,9 @@ func TestRunnerRunPreparesWorkspaceRunsCodexAndRecordsSession(t *testing.T) {
 	}
 	if len(codexClient.request.ExtraWritableRoots) != 1 || codexClient.request.ExtraWritableRoots[0] != cacheRoot {
 		t.Fatalf("codex writable roots = %#v, want shared cache root %q", codexClient.request.ExtraWritableRoots, cacheRoot)
+	}
+	if !reflect.DeepEqual(codexClient.request.Environment.PathSuffixes, []string{filepath.Join(cacheRoot, "go-bin")}) {
+		t.Fatalf("codex PATH suffixes = %#v, want shared tool fallback", codexClient.request.Environment.PathSuffixes)
 	}
 	if codexClient.request.Model != "gpt-5-codex-high" {
 		t.Fatalf("codex model = %q, want issue override", codexClient.request.Model)

--- a/internal/runner/types.go
+++ b/internal/runner/types.go
@@ -138,6 +138,9 @@ type AgentTurnRequest struct {
 	Resume             AgentResume
 	TurnTimeout        time.Duration
 	ExtraWritableRoots []string
+	Environment        procgroup.Environment
+	cacheStrategy      string
+	projectID          string
 }
 
 type AgentResume struct {

--- a/internal/runner/worker_cache.go
+++ b/internal/runner/worker_cache.go
@@ -1,0 +1,83 @@
+package runner
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/digitaldrywood/detent/internal/config"
+	"github.com/digitaldrywood/detent/internal/workspace"
+)
+
+const sharedCacheKeyDigestLength = 12
+
+func configureWorkerCache(request *AgentTurnRequest) error {
+	if request == nil {
+		return nil
+	}
+
+	strategy := strings.ToLower(strings.TrimSpace(request.cacheStrategy))
+	if strategy == "" {
+		strategy = config.WorkspaceCacheIsolated
+	}
+
+	root := request.TempDir
+	switch strategy {
+	case config.WorkspaceCacheIsolated:
+	case config.WorkspaceCacheShared:
+		root = sharedWorkerCacheRoot(request.Workspace, request.projectID)
+	default:
+		return fmt.Errorf("unsupported cache strategy %q", request.cacheStrategy)
+	}
+	if strings.TrimSpace(root) == "" {
+		return errors.New("worker cache root is empty")
+	}
+
+	goBuild := filepath.Join(root, "go-build")
+	goMod := filepath.Join(root, "go-mod")
+	goBin := filepath.Join(root, "go-bin")
+	golangCILint := filepath.Join(root, "golangci-lint")
+	for _, path := range []string{goBuild, goMod, goBin, golangCILint} {
+		if err := os.MkdirAll(path, 0o700); err != nil {
+			return fmt.Errorf("create %s cache: %w", filepath.Base(path), err)
+		}
+	}
+
+	variables := make(map[string]string, len(request.Environment.Variables)+4)
+	for key, value := range request.Environment.Variables {
+		variables[key] = value
+	}
+	variables["GOCACHE"] = goBuild
+	variables["GOMODCACHE"] = goMod
+	variables["GOBIN"] = goBin
+	variables["GOLANGCI_LINT_CACHE"] = golangCILint
+	request.Environment.Variables = variables
+	request.Environment.PathPrefixes = append([]string{goBin}, request.Environment.PathPrefixes...)
+	if strategy == config.WorkspaceCacheShared {
+		request.ExtraWritableRoots = appendUniquePath(request.ExtraWritableRoots, root)
+	}
+	return nil
+}
+
+func sharedWorkerCacheRoot(workspacePath string, projectID string) string {
+	projectID = strings.TrimSpace(projectID)
+	if projectID == "" {
+		projectID = defaultProjectID
+	}
+	sum := sha256.Sum256([]byte(projectID))
+	key := workspace.SafeKey(projectID) + "-" + hex.EncodeToString(sum[:])[:sharedCacheKeyDigestLength]
+	return filepath.Join(filepath.Dir(filepath.Clean(workspacePath)), ".detent", "cache", key)
+}
+
+func appendUniquePath(paths []string, candidate string) []string {
+	for _, path := range paths {
+		if filepath.Clean(path) == filepath.Clean(candidate) {
+			return paths
+		}
+	}
+	return append(paths, candidate)
+}

--- a/internal/runner/worker_cache.go
+++ b/internal/runner/worker_cache.go
@@ -56,7 +56,7 @@ func configureWorkerCache(request *AgentTurnRequest) error {
 	variables["GOBIN"] = goBin
 	variables["GOLANGCI_LINT_CACHE"] = golangCILint
 	request.Environment.Variables = variables
-	request.Environment.PathPrefixes = append([]string{goBin}, request.Environment.PathPrefixes...)
+	request.Environment.PathSuffixes = appendUniquePath(request.Environment.PathSuffixes, goBin)
 	if strategy == config.WorkspaceCacheShared {
 		request.ExtraWritableRoots = appendUniquePath(request.ExtraWritableRoots, root)
 	}

--- a/internal/runner/worker_cache_test.go
+++ b/internal/runner/worker_cache_test.go
@@ -1,0 +1,140 @@
+package runner
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+
+	"github.com/digitaldrywood/detent/internal/config"
+	"github.com/digitaldrywood/detent/internal/procgroup"
+)
+
+func TestConfigureWorkerCache(t *testing.T) {
+	t.Parallel()
+
+	workspaceRoot := t.TempDir()
+	tests := []struct {
+		name             string
+		strategy         string
+		workspace        string
+		tempDir          string
+		wantRoot         string
+		wantWritableRoot bool
+	}{
+		{
+			name:      "isolated uses turn scratch",
+			strategy:  config.WorkspaceCacheIsolated,
+			workspace: filepath.Join(workspaceRoot, "issue-1"),
+			tempDir:   filepath.Join(workspaceRoot, "issue-1", ".detent", "tmp"),
+			wantRoot:  filepath.Join(workspaceRoot, "issue-1", ".detent", "tmp"),
+		},
+		{
+			name:             "shared uses stable project root",
+			strategy:         config.WorkspaceCacheShared,
+			workspace:        filepath.Join(workspaceRoot, "issue-2"),
+			tempDir:          filepath.Join(workspaceRoot, "issue-2", ".detent", "tmp"),
+			wantRoot:         sharedWorkerCacheRoot(filepath.Join(workspaceRoot, "issue-1"), "parable"),
+			wantWritableRoot: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			request := AgentTurnRequest{
+				Workspace:     tt.workspace,
+				TempDir:       tt.tempDir,
+				cacheStrategy: tt.strategy,
+				projectID:     "parable",
+				Environment: procgroup.Environment{
+					Variables:    map[string]string{"EXISTING": "value", "GOCACHE": "/stale"},
+					PathPrefixes: []string{"/existing/bin"},
+				},
+			}
+			if err := configureWorkerCache(&request); err != nil {
+				t.Fatalf("configureWorkerCache() error = %v", err)
+			}
+
+			wantVariables := map[string]string{
+				"EXISTING":            "value",
+				"GOCACHE":             filepath.Join(tt.wantRoot, "go-build"),
+				"GOMODCACHE":          filepath.Join(tt.wantRoot, "go-mod"),
+				"GOBIN":               filepath.Join(tt.wantRoot, "go-bin"),
+				"GOLANGCI_LINT_CACHE": filepath.Join(tt.wantRoot, "golangci-lint"),
+			}
+			if !reflect.DeepEqual(request.Environment.Variables, wantVariables) {
+				t.Fatalf("Environment.Variables = %#v, want %#v", request.Environment.Variables, wantVariables)
+			}
+			wantPathPrefixes := []string{filepath.Join(tt.wantRoot, "go-bin"), "/existing/bin"}
+			if !reflect.DeepEqual(request.Environment.PathPrefixes, wantPathPrefixes) {
+				t.Fatalf("Environment.PathPrefixes = %#v, want %#v", request.Environment.PathPrefixes, wantPathPrefixes)
+			}
+			for _, name := range []string{"GOCACHE", "GOMODCACHE", "GOBIN", "GOLANGCI_LINT_CACHE"} {
+				path := wantVariables[name]
+				info, err := os.Stat(path)
+				if err != nil {
+					t.Fatalf("Stat(%s) error = %v", path, err)
+				}
+				if !info.IsDir() {
+					t.Fatalf("%s is not a directory", path)
+				}
+			}
+			gotWritableRoot := len(request.ExtraWritableRoots) == 1 && request.ExtraWritableRoots[0] == tt.wantRoot
+			if gotWritableRoot != tt.wantWritableRoot {
+				t.Fatalf("ExtraWritableRoots = %#v, want shared root = %t", request.ExtraWritableRoots, tt.wantWritableRoot)
+			}
+		})
+	}
+}
+
+func TestSharedWorkerCacheRootSeparatesProjects(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	firstWorkspace := filepath.Join(root, "project-issue-1")
+	secondWorkspace := filepath.Join(root, "project-issue-2")
+	first := sharedWorkerCacheRoot(firstWorkspace, "owner/project")
+	second := sharedWorkerCacheRoot(secondWorkspace, "owner/project")
+	other := sharedWorkerCacheRoot(secondWorkspace, "owner_project")
+	if first != second {
+		t.Fatalf("same project roots differ: %q != %q", first, second)
+	}
+	if first == other {
+		t.Fatalf("distinct project roots collide: %q", first)
+	}
+}
+
+func TestRunAgentBackendTurnCleansScratchAfterCacheFailure(t *testing.T) {
+	t.Parallel()
+
+	workspacePath := t.TempDir()
+	backend := &cacheTestAgentBackend{}
+	_, err, cleanupErr := runAgentBackendTurn(context.Background(), backend, AgentTurnRequest{
+		Workspace:     workspacePath,
+		cacheStrategy: "unsupported",
+	}, nil)
+	if err == nil {
+		t.Fatal("runAgentBackendTurn() error = nil, want cache preparation error")
+	}
+	if cleanupErr != nil {
+		t.Fatalf("runAgentBackendTurn() cleanup error = %v", cleanupErr)
+	}
+	if backend.called {
+		t.Fatal("backend called after cache preparation failure")
+	}
+	if _, statErr := os.Stat(filepath.Join(workspacePath, ".detent", "tmp")); !os.IsNotExist(statErr) {
+		t.Fatalf("worker scratch remains after cache preparation failure: %v", statErr)
+	}
+}
+
+type cacheTestAgentBackend struct {
+	called bool
+}
+
+func (b *cacheTestAgentBackend) RunTurn(context.Context, AgentTurnRequest, AgentUpdateHandler) (AgentTurnResult, error) {
+	b.called = true
+	return AgentTurnResult{}, nil
+}

--- a/internal/runner/worker_cache_test.go
+++ b/internal/runner/worker_cache_test.go
@@ -52,6 +52,7 @@ func TestConfigureWorkerCache(t *testing.T) {
 				Environment: procgroup.Environment{
 					Variables:    map[string]string{"EXISTING": "value", "GOCACHE": "/stale"},
 					PathPrefixes: []string{"/existing/bin"},
+					PathSuffixes: []string{"/fallback/bin"},
 				},
 			}
 			if err := configureWorkerCache(&request); err != nil {
@@ -68,9 +69,13 @@ func TestConfigureWorkerCache(t *testing.T) {
 			if !reflect.DeepEqual(request.Environment.Variables, wantVariables) {
 				t.Fatalf("Environment.Variables = %#v, want %#v", request.Environment.Variables, wantVariables)
 			}
-			wantPathPrefixes := []string{filepath.Join(tt.wantRoot, "go-bin"), "/existing/bin"}
+			wantPathPrefixes := []string{"/existing/bin"}
 			if !reflect.DeepEqual(request.Environment.PathPrefixes, wantPathPrefixes) {
 				t.Fatalf("Environment.PathPrefixes = %#v, want %#v", request.Environment.PathPrefixes, wantPathPrefixes)
+			}
+			wantPathSuffixes := []string{"/fallback/bin", filepath.Join(tt.wantRoot, "go-bin")}
+			if !reflect.DeepEqual(request.Environment.PathSuffixes, wantPathSuffixes) {
+				t.Fatalf("Environment.PathSuffixes = %#v, want %#v", request.Environment.PathSuffixes, wantPathSuffixes)
 			}
 			for _, name := range []string{"GOCACHE", "GOMODCACHE", "GOBIN", "GOLANGCI_LINT_CACHE"} {
 				path := wantVariables[name]


### PR DESCRIPTION
## Summary

- add an explicit `workspace.cache_strategy` with isolated and shared modes
- share per-project Go build, module, binary, and golangci-lint caches across worktrees while keeping turn scratch isolated
- propagate the cache contract through Codex and Claude worker environments and document the workflow setting

Fixes #1437

## UI Surface Contract

- [x] N/A; this change does not alter a UI surface.
- [x] This PR does not add persistent top-of-screen messaging.
- [x] N/A; there are no visual changes to primary operator screens.

## Test Plan

- [x] `make check`