### PR TITLE
fix(workspace): base branches on remote default

### DIFF
--- a/.detent/skills/serialize-git-worktree-creation.md
+++ b/.detent/skills/serialize-git-worktree-creation.md
@@ -1,0 +1,14 @@
+---
+name: serialize-git-worktree-creation
+description: Prevent concurrent Git fetch and worktree creation from observing partially written shared repository metadata.
+when_to_use: Use when adding remote fetches or other shared-repository mutations to concurrent workspace creation paths.
+---
+
+# Serialize Git worktree creation
+
+- Treat the source repository's object store, refs, and worktree metadata as shared state even when every worker has a separate filesystem path.
+- Reproduce concurrent creation with one backend, unique issue branches, and a real local remote. Use an upload-pack wrapper with an atomic directory lock and overlap marker to widen and detect concurrent remote operations.
+- Serialize remote-default discovery, explicit-refspec fetch, branch inspection, and `git worktree add` as one repository operation. Do not release the lock between fetch and add; that reintroduces the partially written worktree window.
+- Scope the mutex to the backend when one backend owns the source repository. If independent backends or processes can share the Git common directory, use a common-directory keyed or OS-backed lock instead.
+- Preserve existing managed branches without resetting them, and fail before branch or worktree creation when a configured remote cannot be resolved or fetched.
+- Run the concurrent regression repeatedly with `go test -race`, then run the repository's full validation gate.

--- a/README.md
+++ b/README.md
@@ -960,6 +960,12 @@ per-project directory under `workspace.root/.detent/cache`, prepend the shared
 `GOBIN` to `PATH`, and reuse compiled dependencies and tools across worktrees
 and Detent restarts. `TMPDIR`, `TMP`, and `TEMP` remain per-turn in both modes.
 
+When `workspace.auto_branch` is enabled and the source repository has an
+`origin` remote, Detent fetches that remote's default branch before creating a
+new managed branch. The source checkout's current branch and `HEAD` do not
+affect the new branch base. Existing managed branches are reused unchanged;
+local-only repositories without an `origin` continue to use `HEAD`.
+
 `workspace.cleanup_idle_ttl_ms` controls how long non-active observed
 workspaces can sit idle before cleanup. Terminal issues are cleaned on the next
 poll when observed. `workspace.cleanup_sweep_interval_ms` controls the startup

--- a/internal/workspace/merge.go
+++ b/internal/workspace/merge.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 )
 
-const defaultMergeRemote = "origin"
+const defaultGitRemote = "origin"
 
 func (l *LocalGit) PrepareMerge(
 	ctx context.Context,
@@ -23,7 +23,7 @@ func (l *LocalGit) PrepareMerge(
 	}
 	remote := strings.TrimSpace(opts.Remote)
 	if remote == "" {
-		remote = defaultMergeRemote
+		remote = defaultGitRemote
 	}
 	targetBranch := strings.TrimSpace(opts.TargetBranch)
 	if targetBranch == "" {

--- a/internal/workspace/workspace.go
+++ b/internal/workspace/workspace.go
@@ -550,7 +550,11 @@ func (l *LocalGit) addBranchedWorktree(ctx context.Context, path string, branch 
 			return err
 		}
 
-		_, err = l.runGit(ctx, "worktree", "add", "-b", branch, path, "HEAD")
+		baseRef, err := l.newBranchBaseRef(ctx)
+		if err != nil {
+			return err
+		}
+		_, err = l.runGit(ctx, "worktree", "add", "-b", branch, path, baseRef)
 		return err
 	})
 }
@@ -594,6 +598,36 @@ func withCommandOutput(err error) error {
 		return err
 	}
 	return fmt.Errorf("%w\n%s", err, output)
+}
+
+func (l *LocalGit) newBranchBaseRef(ctx context.Context) (string, error) {
+	remotes, err := l.runGit(ctx, "remote")
+	if err != nil {
+		return "", fmt.Errorf("list git remotes: %w", err)
+	}
+	if !stringListContains(remotes, defaultGitRemote) {
+		return "HEAD", nil
+	}
+
+	branch, err := remoteDefaultBranch(ctx, l.sourceRoot, defaultGitRemote)
+	if err != nil {
+		return "", fmt.Errorf("resolve %s default branch: %w", defaultGitRemote, err)
+	}
+	remoteRef := defaultGitRemote + "/" + branch
+	refspec := "+refs/heads/" + branch + ":refs/remotes/" + remoteRef
+	if _, err := l.runGit(ctx, "fetch", defaultGitRemote, refspec); err != nil {
+		return "", fmt.Errorf("fetch remote default branch %s: %w", remoteRef, err)
+	}
+	return remoteRef, nil
+}
+
+func stringListContains(list string, want string) bool {
+	for _, value := range strings.Fields(list) {
+		if value == want {
+			return true
+		}
+	}
+	return false
 }
 
 func (l *LocalGit) workspaceOnExpectedBranch(ctx context.Context, path string, branch string) (bool, string, error) {

--- a/internal/workspace/workspace.go
+++ b/internal/workspace/workspace.go
@@ -17,6 +17,7 @@ import (
 	"runtime"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	commandshell "github.com/digitaldrywood/detent/internal/shell"
@@ -131,6 +132,7 @@ type LocalGit struct {
 	autoBranch bool
 	hooks      Hooks
 	logger     *slog.Logger
+	createMu   sync.Mutex
 }
 
 type PathError struct {
@@ -332,7 +334,7 @@ func (l *LocalGit) Create(ctx context.Context, issue Issue) (Info, error) {
 		return Info{}, err
 	}
 
-	created, err := l.ensureWorktree(ctx, info.Path, info.Branch)
+	created, err := l.createWorktree(ctx, info.Path, info.Branch)
 	if err != nil {
 		return Info{}, err
 	}
@@ -351,6 +353,12 @@ func (l *LocalGit) Create(ctx context.Context, issue Issue) (Info, error) {
 	}
 
 	return info, nil
+}
+
+func (l *LocalGit) createWorktree(ctx context.Context, path string, branch string) (bool, error) {
+	l.createMu.Lock()
+	defer l.createMu.Unlock()
+	return l.ensureWorktree(ctx, path, branch)
 }
 
 func (l *LocalGit) Cleanup(ctx context.Context, identifier string) error {

--- a/internal/workspace/workspace_test.go
+++ b/internal/workspace/workspace_test.go
@@ -244,7 +244,6 @@ func TestLocalGitCreatePrunesMissingRegisteredWorktree(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewLocalGit() error = %v", err)
 	}
-
 	issue := Issue{Identifier: "DD-STALE-REGISTRATION"}
 	first, err := backend.Create(context.Background(), issue)
 	if err != nil {
@@ -286,7 +285,6 @@ func TestLocalGitCreateIncludesWorktreeAddStderr(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewLocalGit() error = %v", err)
 	}
-
 	occupiedPath := filepath.Join(t.TempDir(), "occupied-worktree")
 	runGit(t, source, "worktree", "add", "-b", "detent/dd-conflict", occupiedPath, "HEAD")
 
@@ -410,6 +408,99 @@ func TestRunWorktreeAddWithPrune(t *testing.T) {
 				t.Errorf("add calls = %d, want %d", addCalls, tt.wantAdds)
 			}
 		})
+	}
+}
+
+func TestLocalGitCreateBasesNewBranchOnFetchedRemoteDefault(t *testing.T) {
+	t.Parallel()
+
+	source := initSourceRepo(t)
+	remote := initBareRemote(t)
+	runGit(t, source, "remote", "add", "origin", remote)
+	runGit(t, source, "push", "-u", "origin", "main")
+	runGit(t, source, "switch", "-c", "dev")
+	if err := os.WriteFile(filepath.Join(source, "dev.txt"), []byte("dev\n"), 0o600); err != nil {
+		t.Fatalf("write dev file: %v", err)
+	}
+	runGit(t, source, "add", "dev.txt")
+	runGit(t, source, "commit", "-m", "add dev branch")
+	runGit(t, source, "push", "-u", "origin", "dev")
+	runGit(t, remote, "symbolic-ref", "HEAD", "refs/heads/dev")
+
+	runGit(t, source, "switch", "-c", "local-feature", "main")
+	if err := os.WriteFile(filepath.Join(source, "local-only.txt"), []byte("local only\n"), 0o600); err != nil {
+		t.Fatalf("write local-only file: %v", err)
+	}
+	runGit(t, source, "add", "local-only.txt")
+	runGit(t, source, "commit", "-m", "add local-only change")
+
+	publisher := filepath.Join(t.TempDir(), "publisher")
+	runCommand(t, t.TempDir(), "git", "clone", remote, publisher)
+	runGit(t, publisher, "config", "user.name", "Test Publisher")
+	runGit(t, publisher, "config", "user.email", "publisher@example.com")
+	if err := os.WriteFile(filepath.Join(publisher, "remote-latest.txt"), []byte("remote latest\n"), 0o600); err != nil {
+		t.Fatalf("write remote-latest file: %v", err)
+	}
+	runGit(t, publisher, "add", "remote-latest.txt")
+	runGit(t, publisher, "commit", "-m", "advance remote dev")
+	runGit(t, publisher, "push", "origin", "dev")
+	wantHead := strings.TrimSpace(runGit(t, publisher, "rev-parse", "HEAD"))
+
+	backend, err := NewLocalGit(LocalGitOptions{
+		Root:       filepath.Join(t.TempDir(), "workspaces"),
+		SourceRoot: source,
+		AutoBranch: true,
+	})
+	if err != nil {
+		t.Fatalf("NewLocalGit() error = %v", err)
+	}
+	info, err := backend.Create(context.Background(), Issue{Identifier: "DD-REMOTE-DEFAULT"})
+	if err != nil {
+		t.Fatalf("Create() error = %v", err)
+	}
+
+	if got := strings.TrimSpace(runGit(t, info.Path, "rev-parse", "HEAD")); got != wantHead {
+		t.Fatalf("worktree HEAD = %q, want remote default HEAD %q", got, wantHead)
+	}
+	if got := readFile(t, filepath.Join(info.Path, "remote-latest.txt")); got != "remote latest\n" {
+		t.Fatalf("remote-latest.txt = %q, want remote latest content", got)
+	}
+	if _, err := os.Stat(filepath.Join(info.Path, "local-only.txt")); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("local-only.txt stat error = %v, want file absent", err)
+	}
+}
+
+func TestLocalGitCreateDoesNotFallBackWhenOriginIsUnavailable(t *testing.T) {
+	t.Parallel()
+
+	source := initSourceRepo(t)
+	runGit(t, source, "remote", "add", "origin", filepath.Join(t.TempDir(), "missing.git"))
+	backend, err := NewLocalGit(LocalGitOptions{
+		Root:       filepath.Join(t.TempDir(), "workspaces"),
+		SourceRoot: source,
+		AutoBranch: true,
+	})
+	if err != nil {
+		t.Fatalf("NewLocalGit() error = %v", err)
+	}
+	issue := Issue{Identifier: "DD-UNAVAILABLE-ORIGIN"}
+
+	_, err = backend.Create(context.Background(), issue)
+	if err == nil {
+		t.Fatal("Create() error = nil, want unavailable origin error")
+	}
+	if !strings.Contains(err.Error(), "resolve origin default branch") {
+		t.Fatalf("Create() error = %v, want remote default branch context", err)
+	}
+	info, infoErr := backend.infoForIssue(issue)
+	if infoErr != nil {
+		t.Fatalf("infoForIssue() error = %v", infoErr)
+	}
+	if _, statErr := os.Stat(info.Path); !errors.Is(statErr, os.ErrNotExist) {
+		t.Fatalf("workspace stat error = %v, want workspace absent", statErr)
+	}
+	if branchExists(t, source, info.Branch) {
+		t.Fatalf("branch %q exists after failed Create()", info.Branch)
 	}
 }
 

--- a/internal/workspace/workspace_test.go
+++ b/internal/workspace/workspace_test.go
@@ -504,6 +504,68 @@ func TestLocalGitCreateDoesNotFallBackWhenOriginIsUnavailable(t *testing.T) {
 	}
 }
 
+func TestLocalGitCreateSerializesRemoteOperations(t *testing.T) {
+	t.Parallel()
+	skipWindows(t)
+
+	source := initSourceRepo(t)
+	remote := initBareRemote(t)
+	runGit(t, source, "remote", "add", "origin", remote)
+	runGit(t, source, "push", "-u", "origin", "main")
+
+	operationDir := t.TempDir()
+	lockDir := filepath.Join(operationDir, "active")
+	overlapPath := filepath.Join(operationDir, "overlap")
+	uploadPackPath := filepath.Join(operationDir, "upload-pack")
+	uploadPack := "#!/bin/sh\n" +
+		"lock_dir=" + shellQuote(lockDir) + "\n" +
+		"overlap_path=" + shellQuote(overlapPath) + "\n" +
+		"owns_lock=\n" +
+		"if mkdir \"$lock_dir\" 2>/dev/null; then\n" +
+		"  owns_lock=1\n" +
+		"else\n" +
+		"  : > \"$overlap_path\"\n" +
+		"fi\n" +
+		"sleep 0.1\n" +
+		"if [ -n \"$owns_lock\" ]; then\n" +
+		"  rmdir \"$lock_dir\"\n" +
+		"fi\n" +
+		"exec git-upload-pack \"$@\"\n"
+	if err := os.WriteFile(uploadPackPath, []byte(uploadPack), 0o700); err != nil {
+		t.Fatalf("write upload-pack wrapper: %v", err)
+	}
+	runGit(t, source, "config", "remote.origin.uploadpack", uploadPackPath)
+
+	backend, err := NewLocalGit(LocalGitOptions{
+		Root:       filepath.Join(t.TempDir(), "workspaces"),
+		SourceRoot: source,
+		AutoBranch: true,
+	})
+	if err != nil {
+		t.Fatalf("NewLocalGit() error = %v", err)
+	}
+
+	const creates = 6
+	start := make(chan struct{})
+	results := make(chan error, creates)
+	for i := range creates {
+		go func() {
+			<-start
+			_, err := backend.Create(context.Background(), Issue{Identifier: fmt.Sprintf("DD-CONCURRENT-%d", i)})
+			results <- err
+		}()
+	}
+	close(start)
+	for range creates {
+		if err := <-results; err != nil {
+			t.Errorf("Create() error = %v", err)
+		}
+	}
+	if _, err := os.Stat(overlapPath); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("remote operations overlapped, marker stat error = %v", err)
+	}
+}
+
 func TestLocalGitPrepareMergeRebasesAndPushesCleanBranch(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

- resolve and fetch `origin` default branch before creating a managed branch
- keep existing managed branches and local-only repositories behavior unchanged
- serialize create-time repository operations for concurrent dispatch safety
- cover stale tracking refs, unpushed source commits, unavailable remotes, and concurrent creation
- document `workspace.auto_branch` behavior and capture the reusable shared-git serialization skill

Fixes #1439

## UI Surface Contract

- [x] N/A, or the linked issue explicitly authorizes any high-impact UI surface, layout, density, first-viewport, or responsive visibility tradeoff.
- [x] Persistent top-of-screen messaging is explicitly authorized by the issue, or this PR does not add it.
- [x] Visual changes to primary operator screens include screenshot or browser verification below.

## Test Plan

- [x] `go test ./internal/workspace -count=1`
- [x] concurrent workspace creation under `go test -race`
- [x] managed-workspace integration tests in `internal/runner` and `internal/cli`
- [x] `go test ./internal/skills -count=1`
- [x] `make check`