### PR TITLE
fix(doctor): renew timeout on project progress

### DIFF
--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -92,9 +92,10 @@ type doctorOutputReport struct {
 }
 
 type doctorCheckJob struct {
-	Name    string
-	Current func() string
-	Run     func(context.Context) []doctorCheck
+	Name     string
+	Current  func() string
+	Progress <-chan struct{}
+	Run      func(context.Context) []doctorCheck
 }
 
 type doctorCheckResult struct {
@@ -105,18 +106,32 @@ type doctorCheckResult struct {
 type doctorCheckProgress struct {
 	mu      sync.Mutex
 	current string
+	updates chan struct{}
+}
+
+func newDoctorCheckProgress() *doctorCheckProgress {
+	return &doctorCheckProgress{updates: make(chan struct{}, 1)}
 }
 
 func (p *doctorCheckProgress) Set(current string) {
 	p.mu.Lock()
-	defer p.mu.Unlock()
 	p.current = strings.TrimSpace(current)
+	p.mu.Unlock()
+
+	select {
+	case p.updates <- struct{}{}:
+	default:
+	}
 }
 
 func (p *doctorCheckProgress) Current() string {
 	p.mu.Lock()
 	defer p.mu.Unlock()
 	return p.current
+}
+
+func (p *doctorCheckProgress) Updates() <-chan struct{} {
+	return p.updates
 }
 
 type doctorConfig struct {
@@ -569,25 +584,50 @@ func runDoctorCheck(ctx context.Context, job doctorCheckJob, timeout time.Durati
 		ctx = context.Background()
 	}
 	timeout = doctorNormalizedTimeout(timeout)
-	checkCtx, cancel := context.WithTimeout(ctx, timeout)
+	checkCtx, cancel := context.WithCancel(ctx)
 	defer cancel()
+	timer := time.NewTimer(timeout)
+	defer timer.Stop()
 
 	done := make(chan []doctorCheck, 1)
 	go func() {
 		done <- job.Run(checkCtx)
 	}()
 
-	select {
-	case checks := <-done:
-		return checks
-	case <-checkCtx.Done():
-		return []doctorCheck{{
-			Name:   job.Name,
-			Status: doctorFail,
-			Detail: doctorTimeoutDetail(job, timeout, checkCtx.Err()),
-			Hint:   doctorTimeoutHint(),
-		}}
+	for {
+		select {
+		case checks := <-done:
+			return checks
+		case <-job.Progress:
+			resetDoctorCheckTimer(timer, timeout)
+		case <-timer.C:
+			cancel()
+			return []doctorCheck{{
+				Name:   job.Name,
+				Status: doctorFail,
+				Detail: doctorTimeoutDetail(job, timeout, context.DeadlineExceeded),
+				Hint:   doctorTimeoutHint(),
+			}}
+		case <-ctx.Done():
+			cancel()
+			return []doctorCheck{{
+				Name:   job.Name,
+				Status: doctorFail,
+				Detail: doctorTimeoutDetail(job, timeout, ctx.Err()),
+				Hint:   doctorTimeoutHint(),
+			}}
+		}
 	}
+}
+
+func resetDoctorCheckTimer(timer *time.Timer, timeout time.Duration) {
+	if !timer.Stop() {
+		select {
+		case <-timer.C:
+		default:
+		}
+	}
+	timer.Reset(timeout)
 }
 
 func doctorTimeoutDetail(job doctorCheckJob, timeout time.Duration, err error) string {

--- a/internal/cli/doctor_project.go
+++ b/internal/cli/doctor_project.go
@@ -161,10 +161,11 @@ func doctorProjectCheckJobs(cfg globalconfig.Config, deps doctorDeps, githubToke
 	jobs := make([]doctorCheckJob, 0, len(cfg.Projects))
 	for _, project := range cfg.Projects {
 		id := doctorProjectID(project)
-		progress := &doctorCheckProgress{}
+		progress := newDoctorCheckProgress()
 		jobs = append(jobs, doctorCheckJob{
-			Name:    "Project " + id + " checks",
-			Current: progress.Current,
+			Name:     "Project " + id + " checks",
+			Current:  progress.Current,
+			Progress: progress.Updates(),
 			Run: func(jobCtx context.Context) []doctorCheck {
 				return checkDoctorProjectWithProgress(jobCtx, project, doctorRuntimeStorePath(cfg.Path), deps, githubToken, allowWriteProbes, workflowTokenThreshold, progress.Set)
 			},

--- a/internal/cli/doctor_test.go
+++ b/internal/cli/doctor_test.go
@@ -4625,6 +4625,33 @@ func TestRunDoctorCheckTimeoutReportsCurrentInnerCheck(t *testing.T) {
 	}
 }
 
+func TestRunDoctorCheckRenewsTimeoutForReportedProgress(t *testing.T) {
+	t.Parallel()
+
+	const timeout = 100 * time.Millisecond
+	progress := newDoctorCheckProgress()
+	checks := runDoctorCheck(context.Background(), doctorCheckJob{
+		Name:     "Project alpha checks",
+		Current:  progress.Current,
+		Progress: progress.Updates(),
+		Run: func(ctx context.Context) []doctorCheck {
+			for _, name := range []string{"first", "second", "third"} {
+				progress.Set("Project alpha " + name)
+				select {
+				case <-ctx.Done():
+					return nil
+				case <-time.After(60 * time.Millisecond):
+				}
+			}
+			return []doctorCheck{{Name: "Project alpha checks", Status: doctorOK, Detail: "done"}}
+		},
+	}, timeout)
+
+	if len(checks) != 1 || checks[0].Status != doctorOK {
+		t.Fatalf("checks = %#v, want completed project checks", checks)
+	}
+}
+
 func TestDoctorProjectCheckJobTimeoutReportsCurrentInnerCheck(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

- Renew the doctor timeout whenever an aggregate project job advances to its next named check.
- Preserve timeout failures and active-check diagnostics when an individual check stalls.
- Cover project checks whose healthy cumulative runtime exceeds the configured per-check timeout.

Fixes #1442

## UI Surface Contract

- [x] N/A; this change does not affect a UI surface.
- [x] This PR does not add persistent top-of-screen messaging.
- [x] This PR has no visual changes to primary operator screens.

## Test Plan

- [x] `go test ./internal/cli -count=1`
- [x] Focused doctor timeout tests under `go test -race`
- [x] `make check`