### PR TITLE
fix(workspace): serialize shared repo hooks

### DIFF
--- a/.detent/skills/git-worktree-shared-ref-coordination.md
+++ b/.detent/skills/git-worktree-shared-ref-coordination.md
@@ -1,0 +1,14 @@
+---
+name: git-worktree-shared-ref-coordination
+description: Diagnose and prevent concurrent Git ref updates across linked worktrees without serializing unrelated repositories.
+when_to_use: Use when parallel workspace hooks or merge preparation fail with cannot-lock-ref or expected-value mismatches under a shared Git common directory.
+---
+
+# Git worktree shared-ref coordination
+
+1. Confirm the affected paths are linked worktrees of the same repository with `git rev-parse --path-format=absolute --git-common-dir`.
+2. Trace whether the ref update comes from Detent-owned Git commands or a configured workspace hook. Preserve the full hook output because the final error often identifies the shared remote-tracking ref.
+3. Reproduce the overlap before editing. Have one hook hold an exclusive test resource while a second hook for the same source attempts to enter; also prove hooks for different sources can still overlap.
+4. Coordinate at the source-repository boundary with a context-aware keyed lock. Key by the canonical source path or common Git directory, cover hooks that may invoke arbitrary Git commands, and cover Detent-owned fetch/rebase/push sequences.
+5. Keep non-transient command and hook failures unchanged. Do not mark an entire failed hook successful merely because one ref-lock message looks transient.
+6. Run the focused test repeatedly with `-race`, then run the repository validation gate.

--- a/.detent/skills/git-worktree-shared-ref-coordination.md
+++ b/.detent/skills/git-worktree-shared-ref-coordination.md
@@ -9,6 +9,6 @@ when_to_use: Use when parallel workspace hooks or merge preparation fail with ca
 1. Confirm the affected paths are linked worktrees of the same repository with `git rev-parse --path-format=absolute --git-common-dir`.
 2. Trace whether the ref update comes from Detent-owned Git commands or a configured workspace hook. Preserve the full hook output because the final error often identifies the shared remote-tracking ref.
 3. Reproduce the overlap before editing. Have one hook hold an exclusive test resource while a second hook for the same source attempts to enter; also prove hooks for different sources can still overlap.
-4. Coordinate at the source-repository boundary with a context-aware keyed lock. Key by the canonical source path or common Git directory, cover hooks that may invoke arbitrary Git commands, and cover Detent-owned fetch/rebase/push sequences.
+4. Coordinate at the source-repository boundary with a context-aware keyed lock. Key by the canonical common Git directory, cover hooks that may invoke arbitrary Git commands, and cover Detent-owned fetch/rebase/push sequences. Different configured source paths can be linked worktrees of the same common directory.
 5. Keep non-transient command and hook failures unchanged. Do not mark an entire failed hook successful merely because one ref-lock message looks transient.
 6. Run the focused test repeatedly with `-race`, then run the repository validation gate.

--- a/internal/workspace/merge.go
+++ b/internal/workspace/merge.go
@@ -21,6 +21,11 @@ func (l *LocalGit) PrepareMerge(
 	if err != nil {
 		return MergePrepareResult{}, err
 	}
+	release, err := l.acquireSourceOperation(ctx)
+	if err != nil {
+		return MergePrepareResult{}, fmt.Errorf("wait for source repository operation: %w", err)
+	}
+	defer release()
 	remote := strings.TrimSpace(opts.Remote)
 	if remote == "" {
 		remote = defaultMergeRemote

--- a/internal/workspace/workspace.go
+++ b/internal/workspace/workspace.go
@@ -344,7 +344,15 @@ func (l *sourceOperationLock) acquire(ctx context.Context) (func(), error) {
 }
 
 func (l *LocalGit) acquireSourceOperation(ctx context.Context) (func(), error) {
-	return sourceOperationLockFor(l.sourceRoot).acquire(ctx)
+	key := l.sourceRoot
+	if key != "" {
+		commonDir, err := gitCommonDir(ctx, key)
+		if err != nil {
+			return nil, fmt.Errorf("source git common dir: %w", err)
+		}
+		key = commonDir
+	}
+	return sourceOperationLockFor(key).acquire(ctx)
 }
 
 func SafeKey(identifier string) string {

--- a/internal/workspace/workspace.go
+++ b/internal/workspace/workspace.go
@@ -17,6 +17,7 @@ import (
 	"runtime"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	commandshell "github.com/digitaldrywood/detent/internal/shell"
@@ -40,6 +41,15 @@ var (
 )
 
 var unsafeKeyPattern = regexp.MustCompile(`[^A-Za-z0-9._-]`)
+
+var sourceOperationLocks = struct {
+	sync.Mutex
+	bySource map[string]*sourceOperationLock
+}{bySource: make(map[string]*sourceOperationLock)}
+
+type sourceOperationLock struct {
+	permit chan struct{}
+}
 
 type Backend interface {
 	Create(context.Context, Issue) (Info, error)
@@ -302,6 +312,39 @@ func NewLocalGit(opts LocalGitOptions) (*LocalGit, error) {
 		hooks:      hooks,
 		logger:     logger,
 	}, nil
+}
+
+func newSourceOperationLock() *sourceOperationLock {
+	lock := &sourceOperationLock{permit: make(chan struct{}, 1)}
+	lock.permit <- struct{}{}
+	return lock
+}
+
+func sourceOperationLockFor(sourceRoot string) *sourceOperationLock {
+	key := filepath.Clean(sourceRoot)
+	sourceOperationLocks.Lock()
+	defer sourceOperationLocks.Unlock()
+	lock, ok := sourceOperationLocks.bySource[key]
+	if !ok {
+		lock = newSourceOperationLock()
+		sourceOperationLocks.bySource[key] = lock
+	}
+	return lock
+}
+
+func (l *sourceOperationLock) acquire(ctx context.Context) (func(), error) {
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	case <-l.permit:
+		return func() {
+			l.permit <- struct{}{}
+		}, nil
+	}
+}
+
+func (l *LocalGit) acquireSourceOperation(ctx context.Context) (func(), error) {
+	return sourceOperationLockFor(l.sourceRoot).acquire(ctx)
 }
 
 func SafeKey(identifier string) string {
@@ -945,6 +988,11 @@ func (l *LocalGit) runHook(ctx context.Context, name string, command string, inf
 	if strings.TrimSpace(command) == "" {
 		return nil
 	}
+	release, err := l.acquireSourceOperation(ctx)
+	if err != nil {
+		return err
+	}
+	defer release()
 
 	timeout := l.hooks.Timeout
 	if timeout == 0 {

--- a/internal/workspace/workspace_test.go
+++ b/internal/workspace/workspace_test.go
@@ -91,6 +91,130 @@ func TestLocalGitCreateCreatesWorktreeBranchAndRunsAfterCreateHook(t *testing.T)
 	}
 }
 
+func TestLocalGitCreateSerializesAfterCreateHooksForSharedSource(t *testing.T) {
+	skipWindows(t)
+
+	source := initSourceRepo(t)
+	hookState := t.TempDir()
+	lockPath := filepath.Join(hookState, "hook.lock")
+	startedPath := filepath.Join(hookState, "first.started")
+	releasePath := filepath.Join(hookState, "first.release")
+	hookCommand := "set -eu\n" +
+		"mkdir " + shellQuote(lockPath) + "\n" +
+		"if [ \"$ISSUE_IDENTIFIER\" = \"DD-FIRST\" ]; then\n" +
+		"  : > " + shellQuote(startedPath) + "\n" +
+		"  while [ ! -f " + shellQuote(releasePath) + " ]; do sleep 0.01; done\n" +
+		"fi\n" +
+		"rmdir " + shellQuote(lockPath)
+
+	newBackend := func() *LocalGit {
+		backend, err := NewLocalGit(LocalGitOptions{
+			Root:       filepath.Join(t.TempDir(), "workspaces"),
+			SourceRoot: source,
+			AutoBranch: true,
+			Hooks: Hooks{
+				AfterCreate: hookCommand,
+				Timeout:     5 * time.Second,
+			},
+		})
+		if err != nil {
+			t.Fatalf("NewLocalGit() error = %v", err)
+		}
+		return backend
+	}
+	firstBackend := newBackend()
+	secondBackend := newBackend()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	firstDone := make(chan error, 1)
+	go func() {
+		_, err := firstBackend.Create(ctx, Issue{Identifier: "DD-FIRST"})
+		firstDone <- err
+	}()
+	waitForFile(t, startedPath, 5*time.Second)
+
+	secondDone := make(chan error, 1)
+	go func() {
+		_, err := secondBackend.Create(ctx, Issue{Identifier: "DD-SECOND"})
+		secondDone <- err
+	}()
+
+	premature := false
+	var prematureErr error
+	select {
+	case prematureErr = <-secondDone:
+		premature = true
+	case <-time.After(500 * time.Millisecond):
+	}
+	if err := os.WriteFile(releasePath, nil, 0o600); err != nil {
+		t.Fatalf("release first hook: %v", err)
+	}
+	if err := waitForError(t, firstDone, 5*time.Second); err != nil {
+		t.Fatalf("first Create() error = %v", err)
+	}
+	if premature {
+		t.Fatalf("second Create() completed while first hook held the source lock: %v", prematureErr)
+	}
+	if err := waitForError(t, secondDone, 5*time.Second); err != nil {
+		t.Fatalf("second Create() error = %v", err)
+	}
+}
+
+func TestLocalGitCreateRunsAfterCreateHooksConcurrentlyForDifferentSources(t *testing.T) {
+	skipWindows(t)
+
+	hookState := t.TempDir()
+	startedPath := filepath.Join(hookState, "first.started")
+	releasePath := filepath.Join(hookState, "first.release")
+	hookCommand := "set -eu\n" +
+		"if [ \"$ISSUE_IDENTIFIER\" = \"DD-FIRST\" ]; then\n" +
+		"  : > " + shellQuote(startedPath) + "\n" +
+		"  while [ ! -f " + shellQuote(releasePath) + " ]; do sleep 0.01; done\n" +
+		"fi"
+	newBackend := func(source string) *LocalGit {
+		backend, err := NewLocalGit(LocalGitOptions{
+			Root:       filepath.Join(t.TempDir(), "workspaces"),
+			SourceRoot: source,
+			AutoBranch: true,
+			Hooks: Hooks{
+				AfterCreate: hookCommand,
+				Timeout:     5 * time.Second,
+			},
+		})
+		if err != nil {
+			t.Fatalf("NewLocalGit() error = %v", err)
+		}
+		return backend
+	}
+	firstBackend := newBackend(initSourceRepo(t))
+	secondBackend := newBackend(initSourceRepo(t))
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	firstDone := make(chan error, 1)
+	go func() {
+		_, err := firstBackend.Create(ctx, Issue{Identifier: "DD-FIRST"})
+		firstDone <- err
+	}()
+	waitForFile(t, startedPath, 5*time.Second)
+
+	secondDone := make(chan error, 1)
+	go func() {
+		_, err := secondBackend.Create(ctx, Issue{Identifier: "DD-SECOND"})
+		secondDone <- err
+	}()
+	if err := waitForError(t, secondDone, 5*time.Second); err != nil {
+		t.Fatalf("second Create() error = %v", err)
+	}
+	if err := os.WriteFile(releasePath, nil, 0o600); err != nil {
+		t.Fatalf("release first hook: %v", err)
+	}
+	if err := waitForError(t, firstDone, 5*time.Second); err != nil {
+		t.Fatalf("first Create() error = %v", err)
+	}
+}
+
 func TestLocalGitInfoForIssueNamespacesKeysByProjectID(t *testing.T) {
 	t.Parallel()
 
@@ -1640,6 +1764,39 @@ func TestLocalGitRejectsExistingGitRepoFromDifferentSource(t *testing.T) {
 	}
 	if _, err := os.Stat(filepath.Join(foreign, ".git")); err != nil {
 		t.Fatalf("foreign repo was removed, stat error = %v", err)
+	}
+}
+
+func waitForFile(t *testing.T, path string, timeout time.Duration) {
+	t.Helper()
+
+	ticker := time.NewTicker(10 * time.Millisecond)
+	defer ticker.Stop()
+	timer := time.NewTimer(timeout)
+	defer timer.Stop()
+	for {
+		if _, err := os.Stat(path); err == nil {
+			return
+		} else if !errors.Is(err, os.ErrNotExist) {
+			t.Fatalf("stat %s: %v", path, err)
+		}
+		select {
+		case <-ticker.C:
+		case <-timer.C:
+			t.Fatalf("timed out waiting for %s", path)
+		}
+	}
+}
+
+func waitForError(t *testing.T, result <-chan error, timeout time.Duration) error {
+	t.Helper()
+
+	select {
+	case err := <-result:
+		return err
+	case <-time.After(timeout):
+		t.Fatal("timed out waiting for result")
+		return nil
 	}
 }
 

--- a/internal/workspace/workspace_test.go
+++ b/internal/workspace/workspace_test.go
@@ -95,6 +95,8 @@ func TestLocalGitCreateSerializesAfterCreateHooksForSharedSource(t *testing.T) {
 	skipWindows(t)
 
 	source := initSourceRepo(t)
+	alternateSource := filepath.Join(t.TempDir(), "source-worktree")
+	runGit(t, source, "worktree", "add", "--detach", alternateSource, "HEAD")
 	hookState := t.TempDir()
 	lockPath := filepath.Join(hookState, "hook.lock")
 	startedPath := filepath.Join(hookState, "first.started")
@@ -107,10 +109,10 @@ func TestLocalGitCreateSerializesAfterCreateHooksForSharedSource(t *testing.T) {
 		"fi\n" +
 		"rmdir " + shellQuote(lockPath)
 
-	newBackend := func() *LocalGit {
+	newBackend := func(sourceRoot string) *LocalGit {
 		backend, err := NewLocalGit(LocalGitOptions{
 			Root:       filepath.Join(t.TempDir(), "workspaces"),
-			SourceRoot: source,
+			SourceRoot: sourceRoot,
 			AutoBranch: true,
 			Hooks: Hooks{
 				AfterCreate: hookCommand,
@@ -122,8 +124,8 @@ func TestLocalGitCreateSerializesAfterCreateHooksForSharedSource(t *testing.T) {
 		}
 		return backend
 	}
-	firstBackend := newBackend()
-	secondBackend := newBackend()
+	firstBackend := newBackend(source)
+	secondBackend := newBackend(alternateSource)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()


### PR DESCRIPTION
## Summary

- serialize workspace hooks by canonical common Git directory so linked worktrees cannot race shared remote-tracking refs
- coordinate merge preparation with the same context-aware lock while keeping unrelated repositories concurrent
- add linked-worktree regression coverage and a reusable worktree ref-coordination skill draft

Fixes #1440

## UI Surface Contract

- [x] N/A, or the linked issue explicitly authorizes any high-impact UI surface, layout, density, first-viewport, or responsive visibility tradeoff.
- [x] Persistent top-of-screen messaging is explicitly authorized by the issue, or this PR does not add it.
- [x] N/A — this PR has no visual changes to primary operator screens.

## Test Plan

- [x] `go test -race ./internal/workspace -count=5`
- [x] `make check` on rebased head `ba45dc0d`