### PR TITLE
fix(issue-intake): auto-label untracked new issues

### DIFF
--- a/.github/workflows/issue-intake.yml
+++ b/.github/workflows/issue-intake.yml
@@ -16,7 +16,7 @@ jobs:
         with:
           script: |
             const hasDetentStatus = context.payload.issue.labels.some(
-              (label) => label.name.startsWith('detent:'),
+              (label) => label.name.toLowerCase().startsWith('detent:'),
             )
             if (hasDetentStatus) {
               return

--- a/.github/workflows/issue-intake.yml
+++ b/.github/workflows/issue-intake.yml
@@ -1,0 +1,30 @@
+name: Issue Intake
+
+on:
+  issues:
+    types: [opened]
+
+permissions:
+  issues: write
+
+jobs:
+  add-backlog-label:
+    name: Add backlog label
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@v8
+        with:
+          script: |
+            const hasDetentStatus = context.payload.issue.labels.some(
+              (label) => label.name.startsWith('detent:'),
+            )
+            if (hasDetentStatus) {
+              return
+            }
+
+            await github.rest.issues.addLabels({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              labels: ['detent:backlog'],
+            })


### PR DESCRIPTION
## Summary

- add an `issues.opened` workflow that labels issues missing a Detent status as `detent:backlog`
- preserve any explicit `detent:*` status present when the issue is opened, using the connector-compatible case-insensitive match
- limit the workflow token to `issues: write`

Fixes #1444

## UI Surface Contract

- [x] N/A, or the linked issue explicitly authorizes any high-impact UI surface, layout, density, first-viewport, or responsive visibility tradeoff.
- [x] Persistent top-of-screen messaging is explicitly authorized by the issue, or this PR does not add it.
- [x] Visual changes to primary operator screens include screenshot or browser verification below.

## Test Plan

- [x] `actionlint .github/workflows/issue-intake.yml`
- [x] six Node label-selection cases, including uppercase status labels
- [x] `make check` (77.4% coverage)