### PR TITLE
fix(codex): diagnose backend startup failures

### DIFF
--- a/internal/backendcapacity/capacity.go
+++ b/internal/backendcapacity/capacity.go
@@ -14,7 +14,9 @@ import (
 const (
 	ErrorClass                  = "backend_capacity"
 	TransientOverloadErrorClass = "transient_overload"
+	StartupFailureErrorClass    = "backend_startup_failure"
 	StartupTimeoutErrorClass    = "backend_startup_timeout"
+	StartupFailureKind          = "startup_handshake_failure"
 	StartupTimeoutKind          = "startup_handshake_timeout"
 )
 
@@ -164,6 +166,11 @@ func ClassifyTransientOverload(text string, rules Rules) (Details, bool) {
 func IsTransientOverload(err error) bool {
 	capacityErr, ok := As(err)
 	return ok && capacityErr != nil && capacityErr.Details.Type == ErrorTypeTransientOverload
+}
+
+func IsStartupFailureKind(kind string) bool {
+	kind = strings.TrimSpace(kind)
+	return kind == StartupFailureKind || kind == StartupTimeoutKind
 }
 
 func cloneDetails(details Details) Details {

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -151,6 +151,7 @@ type doctorDeps struct {
 	runCommand           func(context.Context, string, ...string) error
 	resolveCommandInDir  func(context.Context, string, []string, string) (string, error)
 	runCommandInDir      func(context.Context, string, []string, string, ...string) error
+	codexInitialize      func(context.Context, string) error
 	httpDo               func(*http.Request) (*http.Response, error)
 	githubScopes         func(context.Context, string) ([]string, error)
 	githubReadiness      doctorGitHubReadinessFunc
@@ -921,6 +922,9 @@ func (d doctorDeps) withDefaults() doctorDeps {
 	if d.runCommandInDir == nil {
 		d.runCommandInDir = defaults.runCommandInDir
 	}
+	if d.codexInitialize == nil {
+		d.codexInitialize = defaults.codexInitialize
+	}
 	if d.httpDo == nil {
 		d.httpDo = defaults.httpDo
 	}
@@ -983,6 +987,7 @@ func defaultDoctorDeps() doctorDeps {
 		runCommand:           runDoctorCommand,
 		resolveCommandInDir:  resolveDoctorCommandInDir,
 		runCommandInDir:      runDoctorCommandInDir,
+		codexInitialize:      probeDoctorCodexInitialize,
 		httpDo:               defaultDoctorHTTPDo,
 		githubScopes:         defaultGitHubScopes,
 		githubReadiness:      ghconnector.CheckReadiness,

--- a/internal/cli/doctor_environment.go
+++ b/internal/cli/doctor_environment.go
@@ -8,12 +8,14 @@ import (
 	"net"
 	"net/http"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strconv"
 	"strings"
 	"syscall"
 	"time"
 
+	"github.com/digitaldrywood/detent/internal/codex"
 	workflowconfig "github.com/digitaldrywood/detent/internal/config"
 	globalconfig "github.com/digitaldrywood/detent/internal/config/global"
 	"github.com/digitaldrywood/detent/internal/instancelock"
@@ -363,7 +365,55 @@ func inspectDoctorDailyBudgetAccuracy(ctx context.Context, db doctorTelemetrySto
 }
 
 func checkDoctorCodex(ctx context.Context, deps doctorDeps) doctorCheck {
-	return checkDoctorBinary(ctx, deps, "codex", "codex binary", "--version", "Install Codex and ensure codex --version succeeds.")
+	const hint = "Install Codex and ensure codex --version and the app-server initialize handshake succeed."
+	path, err := deps.lookPath("codex")
+	if err != nil {
+		return doctorCheck{
+			Name:   "codex binary",
+			Status: doctorFail,
+			Detail: "codex was not found on PATH",
+			Hint:   hint,
+		}
+	}
+	if err := deps.runCommand(ctx, path, "--version"); err != nil {
+		return doctorCheck{
+			Name:   "codex binary",
+			Status: doctorFail,
+			Detail: fmt.Sprintf("%s --version failed: %v", path, err),
+			Hint:   hint,
+		}
+	}
+	initialize := deps.codexInitialize
+	if initialize == nil {
+		initialize = probeDoctorCodexInitialize
+	}
+	if err := initialize(ctx, path); err != nil {
+		return doctorCheck{
+			Name:   "codex binary",
+			Status: doctorFail,
+			Detail: fmt.Sprintf("%s app-server initialize failed: %v", path, err),
+			Hint:   hint,
+		}
+	}
+	return doctorCheck{
+		Name:   "codex binary",
+		Status: doctorOK,
+		Detail: path + " is runnable and completed an app-server initialize handshake",
+	}
+}
+
+func probeDoctorCodexInitialize(ctx context.Context, path string) error {
+	factory, err := codex.NewLocalTransportFactory(func(commandCtx context.Context) *exec.Cmd {
+		return exec.CommandContext(commandCtx, path, "app-server")
+	})
+	if err != nil {
+		return err
+	}
+	server, err := codex.NewAppServer(factory)
+	if err != nil {
+		return err
+	}
+	return server.CheckHealth(ctx)
 }
 
 func checkDoctorClaudeCode(ctx context.Context, deps doctorDeps) doctorCheck {

--- a/internal/cli/doctor_test.go
+++ b/internal/cli/doctor_test.go
@@ -186,6 +186,74 @@ func TestCheckDoctorClaudeCodeUsesVersionAndHint(t *testing.T) {
 	}
 }
 
+func TestCheckDoctorCodexRequiresInitializeHandshake(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name          string
+		versionErr    error
+		initializeErr error
+		wantStatus    doctorStatus
+		wantDetail    string
+		wantProbes    int
+	}{
+		{
+			name:       "version failure skips initialize",
+			versionErr: errors.New("version failed"),
+			wantStatus: doctorFail,
+			wantDetail: "version failed",
+		},
+		{
+			name:          "initialize failure includes diagnostics",
+			initializeErr: errors.New("exit status 23: stderr: broken launch environment"),
+			wantStatus:    doctorFail,
+			wantDetail:    "broken launch environment",
+			wantProbes:    1,
+		},
+		{
+			name:       "initialize success",
+			wantStatus: doctorOK,
+			wantDetail: "completed an app-server initialize handshake",
+			wantProbes: 1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			probes := 0
+			check := checkDoctorCodex(context.Background(), doctorDeps{
+				lookPath: func(binary string) (string, error) {
+					if binary != "codex" {
+						t.Fatalf("lookPath(%q), want codex", binary)
+					}
+					return "/usr/bin/codex", nil
+				},
+				runCommand: func(_ context.Context, path string, args ...string) error {
+					if path != "/usr/bin/codex" || !slices.Equal(args, []string{"--version"}) {
+						t.Fatalf("runCommand(%q, %#v), want codex --version", path, args)
+					}
+					return tt.versionErr
+				},
+				codexInitialize: func(_ context.Context, path string) error {
+					probes++
+					if path != "/usr/bin/codex" {
+						t.Fatalf("codexInitialize(%q), want /usr/bin/codex", path)
+					}
+					return tt.initializeErr
+				},
+			})
+			if check.Status != tt.wantStatus || !strings.Contains(check.Detail, tt.wantDetail) {
+				t.Fatalf("check = %#v, want %s containing %q", check, tt.wantStatus, tt.wantDetail)
+			}
+			if probes != tt.wantProbes {
+				t.Fatalf("initialize probes = %d, want %d", probes, tt.wantProbes)
+			}
+		})
+	}
+}
+
 func TestRunDoctorAgentBinaryChecksFollowWorkflowBackends(t *testing.T) {
 	t.Parallel()
 
@@ -4988,6 +5056,9 @@ func successfulDoctorDeps() doctorDeps {
 			return "/usr/bin/" + executable, nil
 		},
 		runCommandInDir: func(context.Context, string, []string, string, ...string) error {
+			return nil
+		},
+		codexInitialize: func(context.Context, string) error {
 			return nil
 		},
 		httpDo: func(*http.Request) (*http.Response, error) {

--- a/internal/codex/appserver.go
+++ b/internal/codex/appserver.go
@@ -336,8 +336,8 @@ func (s *AppServer) RunTurn(ctx context.Context, req RunTurnRequest, onUpdate Up
 	}
 	defer func() {
 		closeErr := closeTransport(ctx, transport, s.readTimeout)
-		if err == nil && closeErr != nil {
-			err = closeErr
+		if closeErr != nil {
+			err = errors.Join(err, closeErr)
 		}
 	}()
 
@@ -435,6 +435,21 @@ func (s *AppServer) RunTurn(ctx context.Context, req RunTurnRequest, onUpdate Up
 	return result, nil
 }
 
+func (s *AppServer) CheckHealth(ctx context.Context) (err error) {
+	ctx = contextOrBackground(ctx)
+	transport, err := s.transportFactory.NewTransport(ctx)
+	if err != nil {
+		return fmt.Errorf("start codex app-server transport: %w", err)
+	}
+	defer func() {
+		closeErr := closeTransport(ctx, transport, s.readTimeout)
+		if closeErr != nil {
+			err = errors.Join(err, closeErr)
+		}
+	}()
+	return s.initialize(ctx, transport, nil)
+}
+
 func (s *AppServer) ListModels(ctx context.Context) (models []Model, err error) {
 	ctx = contextOrBackground(ctx)
 	transport, err := s.transportFactory.NewTransport(ctx)
@@ -443,8 +458,8 @@ func (s *AppServer) ListModels(ctx context.Context) (models []Model, err error) 
 	}
 	defer func() {
 		closeErr := closeTransport(ctx, transport, s.readTimeout)
-		if err == nil && closeErr != nil {
-			err = closeErr
+		if closeErr != nil {
+			err = errors.Join(err, closeErr)
 		}
 	}()
 
@@ -512,8 +527,8 @@ func (s *AppServer) DefaultModel(ctx context.Context, workspace string) (model s
 	}
 	defer func() {
 		closeErr := closeTransport(ctx, transport, s.readTimeout)
-		if err == nil && closeErr != nil {
-			err = closeErr
+		if closeErr != nil {
+			err = errors.Join(err, closeErr)
 		}
 	}()
 
@@ -535,8 +550,8 @@ func (s *AppServer) VerifyThread(ctx context.Context, threadID string) (err erro
 	}
 	defer func() {
 		closeErr := closeTransport(ctx, transport, s.readTimeout)
-		if err == nil && closeErr != nil {
-			err = closeErr
+		if closeErr != nil {
+			err = errors.Join(err, closeErr)
 		}
 	}()
 

--- a/internal/codex/appserver_test.go
+++ b/internal/codex/appserver_test.go
@@ -171,6 +171,26 @@ func TestAppServerRunTurnStartsLifecycleAndStreamsUpdates(t *testing.T) {
 	}
 }
 
+func TestAppServerCheckHealthCompletesInitializeHandshake(t *testing.T) {
+	t.Parallel()
+
+	transport := newFakeAppServerTransport([]Message{
+		responseMessage(t, initializeRequestID, `{"userAgent":"codex-cli/test"}`),
+	})
+	server, err := NewAppServer(staticTransportFactory{transport: transport}, WithReadTimeout(time.Second))
+	if err != nil {
+		t.Fatalf("NewAppServer() error = %v", err)
+	}
+	if err := server.CheckHealth(context.Background()); err != nil {
+		t.Fatalf("CheckHealth() error = %v", err)
+	}
+
+	sent := transport.sentMessages()
+	if len(sent) != 2 || sent[0].Method != "initialize" || sent[1].Method != "initialized" {
+		t.Fatalf("sent messages = %#v, want initialize handshake", sent)
+	}
+}
+
 func TestAppServerRunTurnExecutesDynamicToolRequest(t *testing.T) {
 	t.Parallel()
 	transport := newFakeAppServerTransport([]Message{

--- a/internal/codex/capacity.go
+++ b/internal/codex/capacity.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"strings"
 	"time"
 
@@ -62,12 +63,21 @@ func ClassifyCapacityError(err error, limits *telemetry.RateLimits, now time.Tim
 		return backendcapacity.Details{}, false
 	}
 	text := codexCapacityErrorText(err)
-	if errors.Is(err, context.DeadlineExceeded) && codexStartupHandshakeTimeout(text) {
-		return backendcapacity.Details{
-			Type:   backendcapacity.ErrorTypeTransientOverload,
-			Kind:   backendcapacity.StartupTimeoutKind,
-			Reason: "backend startup handshake timed out",
-		}, true
+	if codexStartupOperation(text) {
+		switch {
+		case errors.Is(err, context.DeadlineExceeded):
+			return backendcapacity.Details{
+				Type:   backendcapacity.ErrorTypeTransientOverload,
+				Kind:   backendcapacity.StartupTimeoutKind,
+				Reason: "backend startup handshake timed out",
+			}, true
+		case errors.Is(err, io.EOF), strings.Contains(strings.ToLower(text), "process exited"), strings.Contains(strings.ToLower(text), "start codex app-server transport"):
+			return backendcapacity.Details{
+				Type:   backendcapacity.ErrorTypeTransientOverload,
+				Kind:   backendcapacity.StartupFailureKind,
+				Reason: "backend startup handshake failed",
+			}, true
+		}
 	}
 	if details, ok := backendcapacity.ClassifyTransientOverload(text, codexOverloadRules); ok {
 		return details, true
@@ -75,8 +85,11 @@ func ClassifyCapacityError(err error, limits *telemetry.RateLimits, now time.Tim
 	return backendcapacity.Classify(text, codexCapacityResetAt(limits), now, codexCapacityRules)
 }
 
-func codexStartupHandshakeTimeout(text string) bool {
+func codexStartupOperation(text string) bool {
 	text = strings.ToLower(strings.TrimSpace(text))
+	if strings.Contains(text, "start codex app-server transport") {
+		return true
+	}
 	for _, operation := range []string{"initialize", "thread/start", "thread/resume", "turn/start"} {
 		if strings.Contains(text, "wait for "+operation+" response") {
 			return true

--- a/internal/codex/capacity.go
+++ b/internal/codex/capacity.go
@@ -62,6 +62,9 @@ func ClassifyCapacityError(err error, limits *telemetry.RateLimits, now time.Tim
 	if err == nil {
 		return backendcapacity.Details{}, false
 	}
+	if errors.Is(err, context.Canceled) {
+		return backendcapacity.Details{}, false
+	}
 	text := codexCapacityErrorText(err)
 	if codexStartupOperation(text) {
 		switch {

--- a/internal/codex/capacity_test.go
+++ b/internal/codex/capacity_test.go
@@ -2,7 +2,9 @@ package codex
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"io"
 	"strings"
 	"testing"
 	"time"
@@ -61,6 +63,20 @@ func TestAgentBackendClassifyCapacityError(t *testing.T) {
 			want:     true,
 			wantType: backendcapacity.ErrorTypeTransientOverload,
 			wantKind: backendcapacity.StartupTimeoutKind,
+		},
+		{
+			name:     "initialize process exit",
+			err:      fmt.Errorf("run agent turn: wait for initialize response: %w: codex app-server process exited (exit status 23): stderr: broken environment", io.EOF),
+			want:     true,
+			wantType: backendcapacity.ErrorTypeTransientOverload,
+			wantKind: backendcapacity.StartupFailureKind,
+		},
+		{
+			name:     "transport spawn failure",
+			err:      errors.New("run agent turn: start codex app-server transport: start command: executable file not found"),
+			want:     true,
+			wantType: backendcapacity.ErrorTypeTransientOverload,
+			wantKind: backendcapacity.StartupFailureKind,
 		},
 		{
 			name: "unrelated deadline",

--- a/internal/codex/capacity_test.go
+++ b/internal/codex/capacity_test.go
@@ -79,6 +79,10 @@ func TestAgentBackendClassifyCapacityError(t *testing.T) {
 			wantKind: backendcapacity.StartupFailureKind,
 		},
 		{
+			name: "canceled transport spawn",
+			err:  fmt.Errorf("run agent turn: start codex app-server transport: start command: %w", context.Canceled),
+		},
+		{
 			name: "unrelated deadline",
 			err:  fmt.Errorf("run agent turn: wait for output: %w", context.DeadlineExceeded),
 		},

--- a/internal/codex/transport.go
+++ b/internal/codex/transport.go
@@ -15,6 +15,8 @@ import (
 	"github.com/digitaldrywood/detent/internal/procgroup"
 )
 
+const defaultStderrTailBytes = 64 * 1024
+
 type Transport interface {
 	Send(context.Context, Message) error
 	Receive(context.Context) (Message, error)
@@ -36,10 +38,14 @@ type localTransport struct {
 	processGroupID int
 	workerProcess  procgroup.Identity
 	stdin          io.WriteCloser
+	stdout         io.ReadCloser
+	stderr         io.ReadCloser
+	stderrTail     *tailBuffer
 	codec          *Codec
 	received       chan transportResult
 	readStop       chan struct{}
 	readDone       chan struct{}
+	stderrDone     chan error
 	done           chan struct{}
 	sendLock       chan struct{}
 	waitErr        error
@@ -52,6 +58,12 @@ type localTransport struct {
 type transportResult struct {
 	msg Message
 	err error
+}
+
+type tailBuffer struct {
+	mu    sync.Mutex
+	limit int
+	buf   []byte
 }
 
 type workerTempDirContextKey struct{}
@@ -80,7 +92,7 @@ func (f *LocalTransportFactory) NewTransport(ctx context.Context) (Transport, er
 		return nil, fmt.Errorf("create stdin pipe: %w", err)
 	}
 
-	stdout, err := cmd.StdoutPipe()
+	stdout, stdoutWriter, err := os.Pipe()
 	if err != nil {
 		closeErr := stdin.Close()
 		if closeErr != nil {
@@ -91,57 +103,71 @@ func (f *LocalTransportFactory) NewTransport(ctx context.Context) (Transport, er
 		}
 		return nil, fmt.Errorf("create stdout pipe: %w", err)
 	}
+	stderr, stderrWriter, err := os.Pipe()
+	if err != nil {
+		return nil, errors.Join(
+			fmt.Errorf("create stderr pipe: %w", err),
+			stdin.Close(),
+			stdout.Close(),
+			stdoutWriter.Close(),
+		)
+	}
+	cmd.Stdout = stdoutWriter
+	cmd.Stderr = stderrWriter
 
 	procgroup.Configure(cmd)
 	if err := cmd.Start(); err != nil {
-		closeErr := stdin.Close()
-		if closeErr != nil {
-			return nil, errors.Join(
-				fmt.Errorf("start command: %w", err),
-				fmt.Errorf("close stdin pipe: %w", closeErr),
-			)
-		}
-		return nil, fmt.Errorf("start command: %w", err)
-	}
-	if err := procgroup.Deprioritize(cmd); err != nil {
-		terminateErr := procgroup.TerminateTree(cmd, procgroup.GroupID(cmd))
-		waitErr := cmd.Wait()
-		closeErr := stdin.Close()
 		return nil, errors.Join(
-			fmt.Errorf("deprioritize worker process: %w", err),
-			terminateErr,
-			waitErr,
-			closeErr,
+			fmt.Errorf("start command: %w", err),
+			stdin.Close(),
+			stdout.Close(),
+			stdoutWriter.Close(),
+			stderr.Close(),
+			stderrWriter.Close(),
 		)
 	}
-	workerProcess, err := procgroup.Inspect(cmd)
-	if err != nil {
+	if err := errors.Join(stdoutWriter.Close(), stderrWriter.Close()); err != nil {
 		terminateErr := procgroup.TerminateTree(cmd, procgroup.GroupID(cmd))
 		waitErr := cmd.Wait()
-		closeErr := stdin.Close()
+		cleanupErr := procgroup.Cleanup(procgroup.GroupID(cmd))
 		return nil, errors.Join(
-			fmt.Errorf("inspect worker process: %w", err),
+			fmt.Errorf("close parent output writers: %w", err),
 			terminateErr,
 			waitErr,
-			closeErr,
+			cleanupErr,
+			stdin.Close(),
+			stdout.Close(),
+			stderr.Close(),
 		)
 	}
 
 	transport := &localTransport{
 		cmd:            cmd,
 		processGroupID: procgroup.GroupID(cmd),
-		workerProcess:  workerProcess,
 		stdin:          stdin,
+		stdout:         stdout,
+		stderr:         stderr,
+		stderrTail:     newTailBuffer(defaultStderrTailBytes),
 		codec:          NewCodec(stdout, stdin),
 		received:       make(chan transportResult, 64),
 		readStop:       make(chan struct{}),
 		readDone:       make(chan struct{}),
+		stderrDone:     make(chan error, 1),
 		done:           make(chan struct{}),
 		sendLock:       make(chan struct{}, 1),
 	}
 	transport.sendLock <- struct{}{}
-
 	go transport.readLoop()
+	go transport.readStderr()
+
+	if err := procgroup.Deprioritize(cmd); err != nil {
+		return nil, transport.abortStart(fmt.Errorf("deprioritize worker process: %w", err))
+	}
+	workerProcess, err := procgroup.Inspect(cmd)
+	if err != nil {
+		return nil, transport.abortStart(fmt.Errorf("inspect worker process: %w", err))
+	}
+	transport.workerProcess = workerProcess
 	go transport.wait()
 
 	return transport, nil
@@ -226,9 +252,12 @@ func (t *localTransport) Receive(ctx context.Context) (Message, error) {
 		return Message{}, ctx.Err()
 	case result, ok := <-t.received:
 		if !ok {
-			return Message{}, io.EOF
+			return Message{}, t.receiveError(ctx, io.EOF)
 		}
-		return result.msg, result.err
+		if result.err != nil {
+			return Message{}, t.receiveError(ctx, result.err)
+		}
+		return result.msg, nil
 	}
 }
 
@@ -240,10 +269,14 @@ func (t *localTransport) Close(ctx context.Context) error {
 
 	select {
 	case <-t.done:
-		if closeErr != nil {
-			return fmt.Errorf("close stdin: %w", closeErr)
+		waitErr := t.waitError()
+		if waitErr != nil {
+			waitErr = withStderrTail(waitErr, t.stderrText())
 		}
-		return t.waitError()
+		if closeErr != nil {
+			closeErr = fmt.Errorf("close stdin: %w", closeErr)
+		}
+		return errors.Join(closeErr, waitErr)
 	case <-ctx.Done():
 		var killErr error
 		killErr = procgroup.TerminateTree(t.cmd, t.processGroupID)
@@ -307,6 +340,11 @@ func (t *localTransport) closeStdin() error {
 }
 
 func (t *localTransport) closedError() error {
+	select {
+	case <-t.done:
+		return t.processExitError(errors.New("transport closed"))
+	default:
+	}
 	if err := t.waitError(); err != nil {
 		return fmt.Errorf("transport closed: %w", err)
 	}
@@ -333,17 +371,71 @@ func (t *localTransport) readLoop() {
 	}
 }
 
+func (t *localTransport) readStderr() {
+	_, err := io.Copy(t.stderrTail, t.stderr)
+	t.stderrDone <- err
+}
+
 func (t *localTransport) wait() {
-	<-t.readDone
-	t.stopReading()
 	err := t.cmd.Wait()
 	if cleanupErr := procgroup.Cleanup(t.processGroupID); cleanupErr != nil {
 		err = errors.Join(err, cleanupErr)
+	}
+	<-t.readDone
+	if stderrErr := <-t.stderrDone; stderrErr != nil {
+		err = errors.Join(err, fmt.Errorf("read codex stderr: %w", stderrErr))
+	}
+	if closeErr := errors.Join(t.stdout.Close(), t.stderr.Close()); closeErr != nil {
+		err = errors.Join(err, closeErr)
 	}
 	t.waitMu.Lock()
 	t.waitErr = err
 	t.waitMu.Unlock()
 	close(t.done)
+}
+
+func (t *localTransport) abortStart(cause error) error {
+	t.stopReading()
+	closeErr := t.closeStdin()
+	terminateErr := procgroup.TerminateTree(t.cmd, t.processGroupID)
+	waitErr := t.cmd.Wait()
+	cleanupErr := procgroup.Cleanup(t.processGroupID)
+	<-t.readDone
+	stderrErr := <-t.stderrDone
+	pipeCloseErr := errors.Join(t.stdout.Close(), t.stderr.Close())
+	err := errors.Join(cause, closeErr, terminateErr, waitErr, cleanupErr, stderrErr, pipeCloseErr)
+	return withStderrTail(err, t.stderrText())
+}
+
+func (t *localTransport) receiveError(ctx context.Context, cause error) error {
+	if !errors.Is(cause, io.EOF) {
+		return cause
+	}
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-t.done:
+		return t.processExitError(cause)
+	}
+}
+
+func (t *localTransport) processExitError(cause error) error {
+	status := "unknown status"
+	if t.cmd != nil && t.cmd.ProcessState != nil {
+		status = t.cmd.ProcessState.String()
+	}
+	err := fmt.Errorf("%w: codex app-server process exited (%s)", cause, status)
+	if waitErr := t.waitError(); waitErr != nil {
+		err = fmt.Errorf("%w: wait error: %w", err, waitErr)
+	}
+	return withStderrTail(err, t.stderrText())
+}
+
+func (t *localTransport) stderrText() string {
+	if t == nil || t.stderrTail == nil {
+		return ""
+	}
+	return t.stderrTail.String()
 }
 
 func (t *localTransport) publishReceived(result transportResult) bool {
@@ -392,6 +484,38 @@ func (t *localTransport) waitError() error {
 	t.waitMu.Lock()
 	defer t.waitMu.Unlock()
 	return t.waitErr
+}
+
+func newTailBuffer(limit int) *tailBuffer {
+	if limit <= 0 {
+		limit = defaultStderrTailBytes
+	}
+	return &tailBuffer{limit: limit}
+}
+
+func (b *tailBuffer) Write(p []byte) (int, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	b.buf = append(b.buf, p...)
+	if len(b.buf) > b.limit {
+		b.buf = append([]byte(nil), b.buf[len(b.buf)-b.limit:]...)
+	}
+	return len(p), nil
+}
+
+func (b *tailBuffer) String() string {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return string(b.buf)
+}
+
+func withStderrTail(err error, stderr string) error {
+	stderr = strings.TrimSpace(stderr)
+	if stderr == "" {
+		return err
+	}
+	return fmt.Errorf("%w: stderr: %s", err, stderr)
 }
 
 func contextOrBackground(ctx context.Context) context.Context {

--- a/internal/codex/transport_test.go
+++ b/internal/codex/transport_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
 	"os"
 	"os/exec"
@@ -91,6 +92,43 @@ func TestLocalTransportReceiveHonorsContext(t *testing.T) {
 	_, err = transport.Receive(receiveCtx)
 	if !errors.Is(err, context.DeadlineExceeded) {
 		t.Fatalf("Receive() error = %v, want context deadline exceeded", err)
+	}
+}
+
+func TestLocalTransportEarlyExitIncludesStatusAndStderr(t *testing.T) {
+	t.Parallel()
+
+	factory, err := NewLocalTransportFactory(func(ctx context.Context) *exec.Cmd {
+		return helperCommand(ctx, "exit-stderr")
+	})
+	if err != nil {
+		t.Fatalf("NewLocalTransportFactory() error = %v", err)
+	}
+	server, err := NewAppServer(factory, WithReadTimeout(time.Second))
+	if err != nil {
+		t.Fatalf("NewAppServer() error = %v", err)
+	}
+
+	err = server.CheckHealth(context.Background())
+	if err == nil {
+		t.Fatal("CheckHealth() error = nil, want early exit diagnostics")
+	}
+	for _, want := range []string{"exit status 23", "broken launch environment"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("CheckHealth() error = %v, want containing %q", err, want)
+		}
+	}
+}
+
+func TestTailBufferKeepsBoundedSuffix(t *testing.T) {
+	t.Parallel()
+
+	buffer := newTailBuffer(5)
+	if _, err := buffer.Write([]byte("abcdef")); err != nil {
+		t.Fatalf("Write() error = %v", err)
+	}
+	if got := buffer.String(); got != "bcdef" {
+		t.Fatalf("String() = %q, want %q", got, "bcdef")
 	}
 }
 
@@ -434,6 +472,9 @@ func TestLocalTransportHelperProcess(t *testing.T) {
 		time.Sleep(time.Hour)
 	case "exit":
 		return
+	case "exit-stderr":
+		fmt.Fprint(os.Stderr, "broken launch environment")
+		os.Exit(23)
 	case "turn-error-backpressure":
 		helperTurnBackpressure(json.RawMessage(`{"threadId":"thread-1","turn":{"id":"turn-1","status":"failed"}}`), true)
 	case "turn-complete-backpressure":

--- a/internal/orchestrator/backend_capacity_test.go
+++ b/internal/orchestrator/backend_capacity_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"fmt"
 	"log/slog"
 	"strings"
 	"testing"
@@ -162,7 +163,7 @@ func TestHandleRunResultTracksStartupTimeoutAsCapacityAndBreakerSignal(t *testin
 	if retry.Attempt != 3 || !retry.DueAt.Equal(now.Add(45*time.Second)) || retry.Error != backendcapacity.StartupTimeoutErrorClass {
 		t.Fatalf("Retry[%q] = %#v, want startup-capacity retry", issue.ID, retry)
 	}
-	if len(state.FailureBreaker.Failures[backendcapacity.StartupTimeoutErrorClass]) != 1 || state.FailureBreaker.Active() {
+	if len(state.FailureBreaker.Failures[backendcapacity.StartupFailureErrorClass]) != 1 || state.FailureBreaker.Active() {
 		t.Fatalf("FailureBreaker = %#v, want one preserved systemic signal", state.FailureBreaker)
 	}
 	if len(attempts.completions) != 1 {
@@ -171,6 +172,56 @@ func TestHandleRunResultTracksStartupTimeoutAsCapacityAndBreakerSignal(t *testin
 	completion := attempts.completions[0]
 	if completion.TerminalState != store.WorkAttemptTerminalTimedOut || completion.ErrorClass != backendcapacity.StartupTimeoutErrorClass || completion.StatusMessage != "retrying after backend startup timeout" {
 		t.Fatalf("completion = %#v, want startup timeout telemetry", completion)
+	}
+}
+
+func TestHandleRunResultTracksStartupExitAsStableBreakerSignal(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 7, 18, 18, 0, 0, 0, time.UTC)
+	scope := backendcapacity.Scope{BackendID: "codex", BackendKind: "codex", Provider: "openai"}
+	cfg := normalizeConfig(Config{
+		OverloadRetryDelay: 45 * time.Second,
+		TerminalStates:     []string{"Done"},
+		FailureBreaker: FailureBreakerConfig{
+			SameClassLimit: 2,
+			Window:         time.Hour,
+			Cooldown:       5 * time.Minute,
+		},
+	})
+	attempts := &recordingWorkAttemptStore{}
+	orch := &Orchestrator{cfg: cfg, workAttempts: attempts}
+	state := newState(cfg)
+
+	for index, stderr := range []string{"first issue stderr", "second issue stderr"} {
+		issue := connector.Issue{ID: fmt.Sprintf("issue-startup-exit-%d", index+1), State: "In Progress"}
+		state.Running[issue.ID] = Running{Issue: issue, Attempt: 1, WorkAttemptID: int64(42 + index), StartedAt: now.Add(-time.Minute)}
+		state.Claimed[issue.ID] = Claimed{Issue: issue, ClaimedAt: now.Add(-time.Minute)}
+		exitErr := backendcapacity.NewError(scope, backendcapacity.Details{
+			Type:   backendcapacity.ErrorTypeTransientOverload,
+			Kind:   backendcapacity.StartupFailureKind,
+			Reason: "backend startup handshake failed",
+		}, fmt.Errorf("wait for initialize response: EOF: stderr: %s", stderr))
+
+		orch.handleRunResult(t.Context(), &state, runpkg.Completion{
+			IssueID:      issue.ID,
+			Err:          exitErr,
+			CompletedAt:  now.Add(time.Duration(index) * time.Second),
+			RetryAttempt: 1,
+			RetryDelay:   45 * time.Second,
+		})
+	}
+
+	if !state.FailureBreaker.Active() || state.FailureBreaker.Class != backendcapacity.StartupFailureErrorClass || state.FailureBreaker.Count != 2 {
+		t.Fatalf("FailureBreaker = %#v, want two normalized startup failures", state.FailureBreaker)
+	}
+	if len(attempts.completions) != 2 {
+		t.Fatalf("work attempt completions = %#v, want two", attempts.completions)
+	}
+	for _, completion := range attempts.completions {
+		if completion.ErrorClass != backendcapacity.StartupFailureErrorClass || !strings.Contains(completion.ErrorMessage, "stderr") {
+			t.Fatalf("completion = %#v, want startup class with stderr diagnostics", completion)
+		}
 	}
 }
 

--- a/internal/orchestrator/failure_breaker.go
+++ b/internal/orchestrator/failure_breaker.go
@@ -9,6 +9,7 @@ import (
 	"time"
 	"unicode"
 
+	"github.com/digitaldrywood/detent/internal/backendcapacity"
 	runpkg "github.com/digitaldrywood/detent/internal/runner"
 	"github.com/digitaldrywood/detent/internal/store"
 	"github.com/digitaldrywood/detent/internal/telemetry"
@@ -364,7 +365,9 @@ func projectAttemptFailureClass(
 			return projectFailureClassBackendError + ":" + projectFailureHash(message)
 		}
 	}
-	if class := normalizeProjectFailureClass(errorClass); class != "" && class != workAttemptErrorRunner {
+	if class := normalizeProjectFailureClass(errorClass); class == backendcapacity.StartupFailureErrorClass || class == backendcapacity.StartupTimeoutErrorClass {
+		return backendcapacity.StartupFailureErrorClass
+	} else if class != "" && class != workAttemptErrorRunner {
 		return class
 	}
 	if terminalState == store.WorkAttemptTerminalNoProgress {

--- a/internal/orchestrator/failure_breaker_internal_test.go
+++ b/internal/orchestrator/failure_breaker_internal_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/digitaldrywood/detent/internal/backendcapacity"
 	"github.com/digitaldrywood/detent/internal/store"
 )
 
@@ -54,6 +55,18 @@ func TestProjectAttemptFailureClass(t *testing.T) {
 			terminalState: store.WorkAttemptTerminalNoProgress,
 			errorClass:    "spend_since_progress_circuit_breaker",
 			want:          "spend_since_progress_circuit_breaker",
+		},
+		{
+			name:          "startup timeout shares systemic startup class",
+			terminalState: store.WorkAttemptTerminalTimedOut,
+			errorClass:    backendcapacity.StartupTimeoutErrorClass,
+			want:          backendcapacity.StartupFailureErrorClass,
+		},
+		{
+			name:          "startup exit keeps systemic startup class",
+			terminalState: store.WorkAttemptTerminalFailure,
+			errorClass:    backendcapacity.StartupFailureErrorClass,
+			want:          backendcapacity.StartupFailureErrorClass,
 		},
 		{
 			name:          "no progress has stable class",

--- a/internal/orchestrator/transient_overload.go
+++ b/internal/orchestrator/transient_overload.go
@@ -31,12 +31,18 @@ func (o *Orchestrator) handleTransientOverload(
 	statusMessage := "retrying after transient provider overload"
 	retryEvent := "transient_overload_retry"
 	retryMessage := "transient provider overload"
-	if overloadErr.Details.Kind == backendcapacity.StartupTimeoutKind {
-		errorClass = backendcapacity.StartupTimeoutErrorClass
-		terminalState = store.WorkAttemptTerminalTimedOut
-		statusMessage = "retrying after backend startup timeout"
-		retryEvent = "backend_startup_timeout_retry"
-		retryMessage = "backend startup handshake timed out"
+	if backendcapacity.IsStartupFailureKind(overloadErr.Details.Kind) {
+		errorClass = backendcapacity.StartupFailureErrorClass
+		statusMessage = "retrying after backend startup failure"
+		retryEvent = "backend_startup_failure_retry"
+		retryMessage = "backend startup handshake failed"
+		if overloadErr.Details.Kind == backendcapacity.StartupTimeoutKind {
+			errorClass = backendcapacity.StartupTimeoutErrorClass
+			terminalState = store.WorkAttemptTerminalTimedOut
+			statusMessage = "retrying after backend startup timeout"
+			retryEvent = "backend_startup_timeout_retry"
+			retryMessage = "backend startup handshake timed out"
+		}
 		o.recordProjectAttemptOutcome(
 			state,
 			event.IssueID,


### PR DESCRIPTION
## Summary

- Capture bounded Codex app-server stderr and exit status across early process exits.
- Normalize spawn, initialize EOF, and handshake timeout failures into the existing project breaker without collapsing issue-specific backend errors.
- Extend doctor with a real app-server initialize handshake in the current environment.

Fixes #1443

## UI Surface Contract

- [x] N/A; this PR does not change UI surfaces or layout.
- [x] This PR does not add persistent top-of-screen messaging.
- [x] N/A; this PR has no visual changes.

## Test Plan

- [x] `go test ./internal/codex ./internal/backendcapacity ./internal/orchestrator ./internal/cli`
- [x] `go test -race ./internal/codex ./internal/orchestrator`
- [x] `make check`