### PR TITLE
fix(gate): apply workpad artifact status

### DIFF
--- a/internal/gate/gate.go
+++ b/internal/gate/gate.go
@@ -393,7 +393,17 @@ func InstructionsForGitHubHost(cfg Config, hostname string) string {
 			cfg.ApprovalLabel + "`; do not move it to Merging before that label is present."
 	case KindArtifact:
 		return "The validation gate is artifact status. Detent evaluates `" + cfg.Artifact.StatusField +
-			"` from the work item fields or deliverable validation status. Passing statuses advance the item, waiting statuses keep it in place, and rework statuses route it to rework without requiring a pull request or CI."
+			"` from the work item fields or deliverable validation status. Passing statuses advance the item, waiting statuses keep it in place, and rework statuses route it to rework without requiring a pull request or CI. " +
+			"At worker completion, update the configured field without shell or database commands by including it in the structured Workpad block:\n\n" +
+			"```detent-status\n" +
+			"schema: 1\n" +
+			"status: complete\n" +
+			"fields:\n" +
+			"  " + cfg.Artifact.StatusField + ": <configured status>\n" +
+			"blockers: []\n" +
+			"human_action: null\n" +
+			"```\n\n" +
+			"Allowed pass statuses: " + strings.Join(cfg.Artifact.PassStatuses, ", ") + ". Allowed wait statuses: " + strings.Join(cfg.Artifact.WaitStatuses, ", ") + ". Allowed rework statuses: " + strings.Join(cfg.Artifact.ReworkStatuses, ", ") + "."
 	default:
 		instructions := "The validation gate is a command. Run `" + cfg.Run +
 			"` from the workspace root before Human Review; the pull request still needs green CI before promotion. " +

--- a/internal/gate/gate_test.go
+++ b/internal/gate/gate_test.go
@@ -619,6 +619,38 @@ func TestInstructionsDescribeOptimizedMergingGate(t *testing.T) {
 	}
 }
 
+func TestInstructionsDescribeArtifactWorkpadCompletionField(t *testing.T) {
+	t.Parallel()
+
+	got := Instructions(Config{
+		Kind: KindArtifact,
+		Artifact: ArtifactConfig{
+			StatusField:    "render_status",
+			PassStatuses:   []string{"approved"},
+			WaitStatuses:   []string{"pending_review"},
+			ReworkStatuses: []string{"recut"},
+		},
+	})
+	for _, want := range []string{
+		"without shell or database commands",
+		"```detent-status\n" +
+			"schema: 1\n" +
+			"status: complete\n" +
+			"fields:\n" +
+			"  render_status: <configured status>\n" +
+			"blockers: []\n" +
+			"human_action: null\n" +
+			"```",
+		"Allowed pass statuses: approved.",
+		"Allowed wait statuses: pending_review.",
+		"Allowed rework statuses: recut.",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("Instructions() missing %q:\n%s", want, got)
+		}
+	}
+}
+
 func TestInstructionsDescribeRequiredStatusChecks(t *testing.T) {
 	t.Parallel()
 

--- a/internal/orchestrator/artifact_completion.go
+++ b/internal/orchestrator/artifact_completion.go
@@ -4,14 +4,18 @@ import (
 	"context"
 	"fmt"
 	"strings"
-	"time"
 
 	"github.com/digitaldrywood/detent/internal/connector"
 	"github.com/digitaldrywood/detent/internal/gate"
 	"github.com/digitaldrywood/detent/internal/workpad"
 )
 
-func (o *Orchestrator) applyArtifactGateCompletionFields(ctx context.Context, issue connector.Issue, startedAt time.Time) connector.Issue {
+func (o *Orchestrator) applyArtifactGateCompletionFields(
+	ctx context.Context,
+	issue connector.Issue,
+	dispatchWorkpadHash string,
+	dispatchWorkpadRead bool,
+) connector.Issue {
 	issue = cloneIssue(issue)
 	if o == nil || o.connector == nil {
 		return issue
@@ -27,12 +31,13 @@ func (o *Orchestrator) applyArtifactGateCompletionFields(ctx context.Context, is
 	if !ok || signal == nil || signal.Invalid != nil || signal.Source != workpad.SourceStructured || len(signal.Fields) == 0 {
 		return issue
 	}
-	if !workpadCurrent || !artifactGateCompletionWorkpadUpdatedSince(issue.Comments, startedAt) {
+	completionWorkpadHash := artifactGateWorkpadStatusHash(issue.Comments)
+	if !workpadCurrent || !dispatchWorkpadRead || completionWorkpadHash == "" || completionWorkpadHash == dispatchWorkpadHash {
 		if o.logger != nil {
 			o.logger.WarnContext(ctx, "artifact gate Workpad field update skipped",
 				"issue_id", issue.ID,
 				"identifier", issue.Identifier,
-				"reason", "Workpad status block was not updated during the completed attempt",
+				"reason", "Workpad status block content was not updated during the completed attempt",
 			)
 		}
 		return issue
@@ -116,22 +121,48 @@ func artifactGateCompletionStatusAllowed(status string, cfg gate.ArtifactConfig)
 	return false
 }
 
-func artifactGateCompletionWorkpadUpdatedSince(comments []connector.IssueComment, startedAt time.Time) bool {
-	if startedAt.IsZero() {
-		return false
-	}
+func artifactGateWorkpadStatusHash(comments []connector.IssueComment) string {
 	for index := len(comments) - 1; index >= 0; index-- {
 		comment := comments[index]
 		if !autoPromoteIsWorkpadComment(comment.Body) {
 			continue
 		}
-		updatedAt := comment.UpdatedAt
-		if updatedAt == nil {
-			updatedAt = comment.CreatedAt
+		content, ok := workpad.LastStatusBlock(comment.Body)
+		if !ok {
+			return ""
 		}
-		return updatedAt != nil && !updatedAt.Before(startedAt)
+		return workpad.ContentHash(content)
 	}
-	return false
+	return ""
+}
+
+func (o *Orchestrator) artifactGateDispatchWorkpadSnapshot(ctx context.Context, issue connector.Issue) (string, bool) {
+	if o == nil || o.connector == nil || gate.Effective(o.cfg.AutoPromote.Gate).Kind != gate.KindArtifact {
+		return "", false
+	}
+	reader, ok := o.connector.(connector.IssueCommentReader)
+	if !ok {
+		if o.logger != nil {
+			o.logger.WarnContext(ctx, "artifact gate dispatch Workpad snapshot failed",
+				"issue_id", issue.ID,
+				"identifier", issue.Identifier,
+				"reason", "issue comment reader unavailable",
+			)
+		}
+		return "", false
+	}
+	comments, err := reader.FetchIssueComments(ctx, issue)
+	if err != nil {
+		if o.logger != nil {
+			o.logger.WarnContext(ctx, "artifact gate dispatch Workpad snapshot failed",
+				"issue_id", issue.ID,
+				"identifier", issue.Identifier,
+				"error", err,
+			)
+		}
+		return "", false
+	}
+	return artifactGateWorkpadStatusHash(comments), true
 }
 
 func (o *Orchestrator) warnUnchangedArtifactGateCompletion(ctx context.Context, dispatched connector.Issue, completed connector.Issue) {

--- a/internal/orchestrator/artifact_completion.go
+++ b/internal/orchestrator/artifact_completion.go
@@ -1,0 +1,158 @@
+package orchestrator
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/digitaldrywood/detent/internal/connector"
+	"github.com/digitaldrywood/detent/internal/gate"
+	"github.com/digitaldrywood/detent/internal/workpad"
+)
+
+func (o *Orchestrator) applyArtifactGateCompletionFields(ctx context.Context, issue connector.Issue, startedAt time.Time) connector.Issue {
+	issue = cloneIssue(issue)
+	if o == nil || o.connector == nil {
+		return issue
+	}
+	gateConfig := gate.Effective(o.cfg.AutoPromote.Gate)
+	if gateConfig.Kind != gate.KindArtifact {
+		return issue
+	}
+
+	var workpadCurrent bool
+	issue, workpadCurrent = o.refreshImplementCompletionIssue(ctx, issue)
+	signal, ok := autoPromoteIssueWorkpadSignal(issue)
+	if !ok || signal == nil || signal.Invalid != nil || signal.Source != workpad.SourceStructured || len(signal.Fields) == 0 {
+		return issue
+	}
+	if !workpadCurrent || !artifactGateCompletionWorkpadUpdatedSince(issue.Comments, startedAt) {
+		if o.logger != nil {
+			o.logger.WarnContext(ctx, "artifact gate Workpad field update skipped",
+				"issue_id", issue.ID,
+				"identifier", issue.Identifier,
+				"reason", "Workpad status block was not updated during the completed attempt",
+			)
+		}
+		return issue
+	}
+	if strings.TrimSpace(signal.Status) != workpad.StatusComplete {
+		if o.logger != nil {
+			o.logger.WarnContext(ctx, "artifact gate Workpad field update rejected",
+				"issue_id", issue.ID,
+				"identifier", issue.Identifier,
+				"error", fmt.Errorf("status %q must be complete when setting artifact gate fields", signal.Status),
+			)
+		}
+		return issue
+	}
+	fieldName, value, err := artifactGateCompletionFieldUpdate(signal.Fields, gateConfig.Artifact)
+	if err != nil {
+		if o.logger != nil {
+			o.logger.WarnContext(ctx, "artifact gate Workpad field update rejected",
+				"issue_id", issue.ID,
+				"identifier", issue.Identifier,
+				"error", err,
+			)
+		}
+		return issue
+	}
+	if err := o.connector.SetField(ctx, issue.ID, fieldName, value); err != nil {
+		if o.logger != nil {
+			o.logger.WarnContext(ctx, "artifact gate Workpad field update failed",
+				"issue_id", issue.ID,
+				"identifier", issue.Identifier,
+				"status_field", fieldName,
+				"status", value,
+				"error", err,
+			)
+		}
+		return issue
+	}
+	if issue.Fields == nil {
+		issue.Fields = map[string]string{}
+	}
+	for existing := range issue.Fields {
+		if strings.EqualFold(strings.TrimSpace(existing), fieldName) {
+			delete(issue.Fields, existing)
+		}
+	}
+	issue.Fields[fieldName] = value
+	return issue
+}
+
+func artifactGateCompletionFieldUpdate(fields map[string]string, cfg gate.ArtifactConfig) (string, string, error) {
+	cfg = gate.Effective(gate.Config{Kind: gate.KindArtifact, Artifact: cfg}).Artifact
+	fieldName := strings.TrimSpace(cfg.StatusField)
+	if len(fields) != 1 {
+		return "", "", fmt.Errorf("fields must contain only the configured artifact status field %q", fieldName)
+	}
+	for name, rawValue := range fields {
+		if !strings.EqualFold(strings.TrimSpace(name), fieldName) {
+			return "", "", fmt.Errorf("field %q is not the configured artifact status field %q", name, fieldName)
+		}
+		value := strings.TrimSpace(rawValue)
+		if value == "" {
+			return "", "", fmt.Errorf("configured artifact status field %q is blank", fieldName)
+		}
+		if !artifactGateCompletionStatusAllowed(value, cfg) {
+			return "", "", fmt.Errorf("status %q is not configured in pass_statuses, wait_statuses, or rework_statuses", value)
+		}
+		return fieldName, value, nil
+	}
+	return "", "", fmt.Errorf("configured artifact status field %q is missing", fieldName)
+}
+
+func artifactGateCompletionStatusAllowed(status string, cfg gate.ArtifactConfig) bool {
+	status = strings.ToLower(strings.TrimSpace(status))
+	for _, values := range [][]string{cfg.PassStatuses, cfg.WaitStatuses, cfg.ReworkStatuses} {
+		for _, value := range values {
+			if status == strings.ToLower(strings.TrimSpace(value)) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func artifactGateCompletionWorkpadUpdatedSince(comments []connector.IssueComment, startedAt time.Time) bool {
+	if startedAt.IsZero() {
+		return false
+	}
+	for index := len(comments) - 1; index >= 0; index-- {
+		comment := comments[index]
+		if !autoPromoteIsWorkpadComment(comment.Body) {
+			continue
+		}
+		updatedAt := comment.UpdatedAt
+		if updatedAt == nil {
+			updatedAt = comment.CreatedAt
+		}
+		return updatedAt != nil && !updatedAt.Before(startedAt)
+	}
+	return false
+}
+
+func (o *Orchestrator) warnUnchangedArtifactGateCompletion(ctx context.Context, dispatched connector.Issue, completed connector.Issue) {
+	if o == nil || o.logger == nil {
+		return
+	}
+	gateConfig := gate.Effective(o.cfg.AutoPromote.Gate)
+	if gateConfig.Kind != gate.KindArtifact {
+		return
+	}
+	statusField := gateConfig.Artifact.StatusField
+	dispatchStatus, _ := artifactStatusFieldFromIssue(dispatched, statusField)
+	completionStatus, _ := artifactStatusFieldFromIssue(completed, statusField)
+	if !strings.EqualFold(strings.TrimSpace(dispatchStatus), strings.TrimSpace(completionStatus)) {
+		return
+	}
+	o.logger.WarnContext(ctx, "artifact gate completion left status field unchanged",
+		"issue_id", completed.ID,
+		"identifier", completed.Identifier,
+		"status_field", statusField,
+		"dispatch_status", dispatchStatus,
+		"completion_status", completionStatus,
+	)
+}

--- a/internal/orchestrator/artifact_completion_test.go
+++ b/internal/orchestrator/artifact_completion_test.go
@@ -1,0 +1,193 @@
+package orchestrator
+
+import (
+	"context"
+	"log/slog"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/digitaldrywood/detent/internal/connector"
+	"github.com/digitaldrywood/detent/internal/gate"
+	runpkg "github.com/digitaldrywood/detent/internal/runner"
+)
+
+func TestHandleRunResultAppliesArtifactGateWorkpadField(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name             string
+		workpadStatus    string
+		workpadFields    string
+		workpadBeforeRun bool
+		wantSetFields    []autoPromoteTickSetField
+		wantStatus       string
+		wantLogFragments []string
+	}{
+		{
+			name:          "applies configured wait status",
+			workpadStatus: "complete",
+			workpadFields: "fields:\n  render_status: pending_review\n",
+			wantSetFields: []autoPromoteTickSetField{{
+				issueID: "issue-artifact-completion",
+				field:   "render_status",
+				value:   "pending_review",
+			}},
+			wantStatus: "pending_review",
+		},
+		{
+			name:             "rejects unconfigured status",
+			workpadStatus:    "complete",
+			workpadFields:    "fields:\n  render_status: surprise\n",
+			wantStatus:       "recut",
+			wantLogFragments: []string{"artifact gate Workpad field update rejected", "artifact gate completion left status field unchanged"},
+		},
+		{
+			name:             "warns when successful completion omits field update",
+			workpadStatus:    "complete",
+			wantStatus:       "recut",
+			wantLogFragments: []string{"artifact gate completion left status field unchanged"},
+		},
+		{
+			name:             "rejects field without completion declaration",
+			workpadStatus:    "in_progress",
+			workpadFields:    "fields:\n  render_status: pending_review\n",
+			wantStatus:       "recut",
+			wantLogFragments: []string{"artifact gate Workpad field update rejected", "artifact gate completion left status field unchanged"},
+		},
+		{
+			name:             "skips field from stale completion declaration",
+			workpadStatus:    "complete",
+			workpadFields:    "fields:\n  render_status: pending_review\n",
+			workpadBeforeRun: true,
+			wantStatus:       "recut",
+			wantLogFragments: []string{"artifact gate Workpad field update skipped", "artifact gate completion left status field unchanged"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			now := time.Date(2026, 7, 18, 18, 0, 0, 0, time.UTC)
+			workpadAt := now.Add(-10 * time.Second)
+			if tt.workpadBeforeRun {
+				workpadAt = now.Add(-2 * time.Minute)
+			}
+			issue := connector.NewIssue()
+			issue.ID = "issue-artifact-completion"
+			issue.Identifier = "digitaldrywood/video#42"
+			issue.Title = "Render artifact"
+			issue.State = "Production"
+			issue.Fields = map[string]string{"render_status": "recut"}
+			issue.Deliverable = &connector.Deliverable{Kind: "artifact"}
+			tracker := &autoPromoteTickConnector{
+				stateIssues: []connector.Issue{issue},
+				issueComments: map[string][]connector.IssueComment{
+					issue.ID: {{
+						Body:      "## Codex Workpad\n\n```detent-status\nschema: 1\nstatus: " + tt.workpadStatus + "\n" + tt.workpadFields + "blockers: []\nhuman_action: null\n```",
+						URL:       "https://github.test/comment/42",
+						CreatedAt: &workpadAt,
+					}},
+				},
+			}
+			cfg := normalizeConfig(Config{
+				ActiveStates:   []string{"Todo", "Production", "Rework"},
+				ObservedStates: []string{"Backlog", "Review", "Blocked"},
+				TerminalStates: []string{"Ready for Pickup", "Done", "Cancelled"},
+				AutoPromote: AutoPromoteConfig{
+					Enabled:       true,
+					SourceState:   "Review",
+					PassState:     "Ready for Pickup",
+					ReworkState:   "Rework",
+					GateWaitState: autoPromoteGateWaitSource,
+					Gate: gate.Config{
+						Kind: gate.KindArtifact,
+						Artifact: gate.ArtifactConfig{
+							StatusField:    "render_status",
+							PassStatuses:   []string{"approved"},
+							WaitStatuses:   []string{"pending_review"},
+							ReworkStatuses: []string{"recut"},
+						},
+					},
+				},
+			})
+			var logs strings.Builder
+			orch := &Orchestrator{
+				cfg:       cfg,
+				connector: tracker,
+				logger:    slog.New(slog.NewTextHandler(&logs, nil)),
+			}
+			state := newState(cfg)
+			state.Running[issue.ID] = Running{
+				Issue:     cloneIssue(issue),
+				Attempt:   1,
+				StartedAt: now.Add(-time.Minute),
+			}
+
+			orch.handleRunResult(context.Background(), &state, runpkg.Completion{
+				IssueID:     issue.ID,
+				CompletedAt: now,
+				Result:      runpkg.RunResult{FinalState: runpkg.FinalStateCompleted},
+			})
+
+			if !reflect.DeepEqual(tracker.setFields, tt.wantSetFields) {
+				t.Fatalf("set fields = %#v, want %#v", tracker.setFields, tt.wantSetFields)
+			}
+			completed, ok := state.Completed[issue.ID]
+			if !ok {
+				t.Fatalf("Completed[%q] missing", issue.ID)
+			}
+			if got := artifactStatusFromIssue(completed.Issue, "render_status"); got != tt.wantStatus {
+				t.Fatalf("completed render_status = %q, want %q", got, tt.wantStatus)
+			}
+			for _, fragment := range tt.wantLogFragments {
+				if !strings.Contains(logs.String(), fragment) {
+					t.Fatalf("logs %q missing %q", logs.String(), fragment)
+				}
+			}
+		})
+	}
+}
+
+func TestArtifactGateCompletionFieldUpdate(t *testing.T) {
+	t.Parallel()
+
+	cfg := gate.ArtifactConfig{
+		StatusField:    "render_status",
+		PassStatuses:   []string{"approved"},
+		WaitStatuses:   []string{"pending_review"},
+		ReworkStatuses: []string{"recut"},
+	}
+	tests := []struct {
+		name      string
+		fields    map[string]string
+		wantField string
+		wantValue string
+		wantErr   bool
+	}{
+		{name: "pass status", fields: map[string]string{"render_status": "approved"}, wantField: "render_status", wantValue: "approved"},
+		{name: "wait status", fields: map[string]string{"render_status": "pending_review"}, wantField: "render_status", wantValue: "pending_review"},
+		{name: "rework status", fields: map[string]string{"render_status": "recut"}, wantField: "render_status", wantValue: "recut"},
+		{name: "case insensitive field and status", fields: map[string]string{"Render_Status": " APPROVED "}, wantField: "render_status", wantValue: "APPROVED"},
+		{name: "unknown status", fields: map[string]string{"render_status": "surprise"}, wantErr: true},
+		{name: "wrong field", fields: map[string]string{"validation_status": "approved"}, wantErr: true},
+		{name: "multiple fields", fields: map[string]string{"render_status": "approved", "owner": "worker"}, wantErr: true},
+		{name: "missing field", fields: nil, wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			field, value, err := artifactGateCompletionFieldUpdate(tt.fields, cfg)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("artifactGateCompletionFieldUpdate() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if field != tt.wantField || value != tt.wantValue {
+				t.Fatalf("artifactGateCompletionFieldUpdate() = (%q, %q), want (%q, %q)", field, value, tt.wantField, tt.wantValue)
+			}
+		})
+	}
+}

--- a/internal/orchestrator/artifact_completion_test.go
+++ b/internal/orchestrator/artifact_completion_test.go
@@ -20,7 +20,7 @@ func TestHandleRunResultAppliesArtifactGateWorkpadField(t *testing.T) {
 		name             string
 		workpadStatus    string
 		workpadFields    string
-		workpadBeforeRun bool
+		workpadUnchanged bool
 		wantSetFields    []autoPromoteTickSetField
 		wantStatus       string
 		wantLogFragments []string
@@ -60,7 +60,7 @@ func TestHandleRunResultAppliesArtifactGateWorkpadField(t *testing.T) {
 			name:             "skips field from stale completion declaration",
 			workpadStatus:    "complete",
 			workpadFields:    "fields:\n  render_status: pending_review\n",
-			workpadBeforeRun: true,
+			workpadUnchanged: true,
 			wantStatus:       "recut",
 			wantLogFragments: []string{"artifact gate Workpad field update skipped", "artifact gate completion left status field unchanged"},
 		},
@@ -71,10 +71,6 @@ func TestHandleRunResultAppliesArtifactGateWorkpadField(t *testing.T) {
 			t.Parallel()
 
 			now := time.Date(2026, 7, 18, 18, 0, 0, 0, time.UTC)
-			workpadAt := now.Add(-10 * time.Second)
-			if tt.workpadBeforeRun {
-				workpadAt = now.Add(-2 * time.Minute)
-			}
 			issue := connector.NewIssue()
 			issue.ID = "issue-artifact-completion"
 			issue.Identifier = "digitaldrywood/video#42"
@@ -82,13 +78,17 @@ func TestHandleRunResultAppliesArtifactGateWorkpadField(t *testing.T) {
 			issue.State = "Production"
 			issue.Fields = map[string]string{"render_status": "recut"}
 			issue.Deliverable = &connector.Deliverable{Kind: "artifact"}
+			workpadBody := "## Codex Workpad\n\n### Validation\n\nCurrent attempt.\n\n```detent-status\nschema: 1\nstatus: " + tt.workpadStatus + "\n" + tt.workpadFields + "blockers: []\nhuman_action: null\n```"
+			dispatchWorkpadBody := "## Codex Workpad\n\n### Validation\n\nPrior attempt.\n\n```detent-status\nschema: 1\nstatus: in_progress\nblockers: []\nhuman_action: null\n```"
+			if tt.workpadUnchanged {
+				dispatchWorkpadBody = "## Codex Workpad\n\n### Validation\n\nPrior attempt.\n\n```detent-status\nschema: 1\nstatus: " + tt.workpadStatus + "\n" + tt.workpadFields + "blockers: []\nhuman_action: null\n```"
+			}
 			tracker := &autoPromoteTickConnector{
 				stateIssues: []connector.Issue{issue},
 				issueComments: map[string][]connector.IssueComment{
 					issue.ID: {{
-						Body:      "## Codex Workpad\n\n```detent-status\nschema: 1\nstatus: " + tt.workpadStatus + "\n" + tt.workpadFields + "blockers: []\nhuman_action: null\n```",
-						URL:       "https://github.test/comment/42",
-						CreatedAt: &workpadAt,
+						Body: workpadBody,
+						URL:  "https://github.test/comment/42",
 					}},
 				},
 			}
@@ -121,9 +121,11 @@ func TestHandleRunResultAppliesArtifactGateWorkpadField(t *testing.T) {
 			}
 			state := newState(cfg)
 			state.Running[issue.ID] = Running{
-				Issue:     cloneIssue(issue),
-				Attempt:   1,
-				StartedAt: now.Add(-time.Minute),
+				Issue:               cloneIssue(issue),
+				Attempt:             1,
+				DispatchWorkpadHash: artifactGateWorkpadStatusHash([]connector.IssueComment{{Body: dispatchWorkpadBody}}),
+				DispatchWorkpadRead: true,
+				StartedAt:           now.Add(-time.Minute),
 			}
 
 			orch.handleRunResult(context.Background(), &state, runpkg.Completion{
@@ -189,5 +191,50 @@ func TestArtifactGateCompletionFieldUpdate(t *testing.T) {
 				t.Fatalf("artifactGateCompletionFieldUpdate() = (%q, %q), want (%q, %q)", field, value, tt.wantField, tt.wantValue)
 			}
 		})
+	}
+}
+
+func TestArtifactGateWorkpadStatusHashUsesOnlyStructuredBlock(t *testing.T) {
+	t.Parallel()
+
+	block := "```detent-status\nschema: 1\nstatus: complete\nfields:\n  render_status: pending_review\nblockers: []\nhuman_action: null\n```"
+	prior := artifactGateWorkpadStatusHash([]connector.IssueComment{{Body: "## Codex Workpad\n\nPrior prose.\n\n" + block}})
+	updatedProse := artifactGateWorkpadStatusHash([]connector.IssueComment{{Body: "## Codex Workpad\n\nUpdated prose only.\n\n" + block}})
+	updatedBlock := artifactGateWorkpadStatusHash([]connector.IssueComment{{Body: "## Codex Workpad\n\nUpdated prose.\n\n```detent-status\nschema: 1\nstatus: complete\nfields:\n  render_status: approved\nblockers: []\nhuman_action: null\n```"}})
+
+	if prior == "" {
+		t.Fatal("artifactGateWorkpadStatusHash() is empty")
+	}
+	if updatedProse != prior {
+		t.Fatalf("prose-only update hash = %q, want %q", updatedProse, prior)
+	}
+	if updatedBlock == prior {
+		t.Fatalf("structured block update hash = %q, want different from %q", updatedBlock, prior)
+	}
+}
+
+func TestArtifactGateDispatchWorkpadSnapshot(t *testing.T) {
+	t.Parallel()
+
+	issue := connector.NewIssue()
+	issue.ID = "issue-artifact-snapshot"
+	issue.Identifier = "digitaldrywood/video#43"
+	comment := connector.IssueComment{Body: "## Codex Workpad\n\n```detent-status\nschema: 1\nstatus: in_progress\nblockers: []\nhuman_action: null\n```"}
+	tracker := &autoPromoteTickConnector{issueComments: map[string][]connector.IssueComment{issue.ID: {comment}}}
+	orch := &Orchestrator{
+		cfg:       normalizeConfig(Config{AutoPromote: AutoPromoteConfig{Gate: gate.Config{Kind: gate.KindArtifact}}}),
+		connector: tracker,
+	}
+
+	hash, ok := orch.artifactGateDispatchWorkpadSnapshot(context.Background(), issue)
+
+	if !ok {
+		t.Fatal("artifactGateDispatchWorkpadSnapshot() ok = false")
+	}
+	if want := artifactGateWorkpadStatusHash([]connector.IssueComment{comment}); hash != want {
+		t.Fatalf("artifactGateDispatchWorkpadSnapshot() hash = %q, want %q", hash, want)
+	}
+	if !reflect.DeepEqual(tracker.fetchComments, []string{issue.ID}) {
+		t.Fatalf("FetchIssueComments() issues = %#v, want %#v", tracker.fetchComments, []string{issue.ID})
 	}
 }

--- a/internal/orchestrator/autopromote_tick_test.go
+++ b/internal/orchestrator/autopromote_tick_test.go
@@ -5727,5 +5727,14 @@ func (c *autoPromoteTickConnector) SetAssignee(context.Context, string, string) 
 
 func (c *autoPromoteTickConnector) SetField(_ context.Context, issueID string, field string, value string) error {
 	c.setFields = append(c.setFields, autoPromoteTickSetField{issueID: issueID, field: field, value: value})
+	for index := range c.stateIssues {
+		if c.stateIssues[index].ID != issueID {
+			continue
+		}
+		if c.stateIssues[index].Fields == nil {
+			c.stateIssues[index].Fields = map[string]string{}
+		}
+		c.stateIssues[index].Fields[field] = value
+	}
 	return nil
 }

--- a/internal/orchestrator/dispatch.go
+++ b/internal/orchestrator/dispatch.go
@@ -436,6 +436,7 @@ func (o *Orchestrator) dispatchIssueWithOutcome(
 	runCtx, stop := context.WithCancelCause(ctx)
 	cancel := func() { stop(nil) }
 	o.markBackendCapacityProbe(state, capacityProbeKey, issue.ID, now)
+	dispatchWorkpadHash, dispatchWorkpadRead := o.artifactGateDispatchWorkpadSnapshot(ctx, issue)
 	state.Running[issue.ID] = Running{
 		Issue:               issue,
 		Attempt:             attempt,
@@ -443,6 +444,8 @@ func (o *Orchestrator) dispatchIssueWithOutcome(
 		Mode:                runMode,
 		DispatchSourceState: dispatchStartSourceState,
 		DispatchTargetState: dispatchStartTargetState,
+		DispatchWorkpadHash: dispatchWorkpadHash,
+		DispatchWorkpadRead: dispatchWorkpadRead,
 		StartedAt:           now,
 		WorkerHost:          workerHost,
 		CapacityScope:       capacityScope,

--- a/internal/orchestrator/run_completion.go
+++ b/internal/orchestrator/run_completion.go
@@ -329,6 +329,9 @@ func (o *Orchestrator) handleRunResult(ctx context.Context, state *State, event 
 		running.DiffStats = event.Result.DiffStats
 	}
 	dispatchedIssue := cloneIssue(running.Issue)
+	if terminalState == store.WorkAttemptTerminalSuccess {
+		running.Issue = o.applyArtifactGateCompletionFields(ctx, running.Issue, running.StartedAt)
+	}
 	progress := o.evaluateImplementCompletionProgress(ctx, running, finalState, event.Result.PullRequestUpdated)
 	running.Issue = progress.Issue
 	if event.Result.PullRequestHeadPushed && !event.Result.CITriggerLabelReapplied {
@@ -368,6 +371,9 @@ func (o *Orchestrator) handleRunResult(ctx context.Context, state *State, event 
 		errorMessage = fmt.Sprintf("spent %s since the last accepted state change; configured limit %s", budget.FormatUSD(spendProgress.Spend.CostUSD), budget.FormatUSD(spendProgress.LimitUSD))
 		phase = "no_progress"
 		statusMessage = "spend-since-progress circuit breaker tripped"
+	}
+	if terminalState == store.WorkAttemptTerminalSuccess {
+		o.warnUnchangedArtifactGateCompletion(ctx, dispatchedIssue, running.Issue)
 	}
 	o.recordProjectAttemptOutcome(state, event.IssueID, event.CompletedAt, terminalState, nil, errorClass, errorMessage)
 	o.completeDurableWorkAttemptWithMetadata(ctx, state, running, event.CompletedAt, terminalState, errorClass, errorMessage, phase, statusMessage, mergeWorkAttemptMetadata(implementCompletionProgressMetadata(progress), spendProgressMetadata(spendProgress)))

--- a/internal/orchestrator/run_completion.go
+++ b/internal/orchestrator/run_completion.go
@@ -330,7 +330,7 @@ func (o *Orchestrator) handleRunResult(ctx context.Context, state *State, event 
 	}
 	dispatchedIssue := cloneIssue(running.Issue)
 	if terminalState == store.WorkAttemptTerminalSuccess {
-		running.Issue = o.applyArtifactGateCompletionFields(ctx, running.Issue, running.StartedAt)
+		running.Issue = o.applyArtifactGateCompletionFields(ctx, running.Issue, running.DispatchWorkpadHash, running.DispatchWorkpadRead)
 	}
 	progress := o.evaluateImplementCompletionProgress(ctx, running, finalState, event.Result.PullRequestUpdated)
 	running.Issue = progress.Issue

--- a/internal/orchestrator/state.go
+++ b/internal/orchestrator/state.go
@@ -89,6 +89,8 @@ type Running struct {
 	Mode                  string
 	DispatchSourceState   string
 	DispatchTargetState   string
+	DispatchWorkpadHash   string
+	DispatchWorkpadRead   bool
 	StartedAt             time.Time
 	WorkerHost            string
 	ProcessIdentity       string

--- a/internal/workpad/workpad.go
+++ b/internal/workpad/workpad.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"regexp"
+	"sort"
 	"strings"
 
 	"gopkg.in/yaml.v3"
@@ -26,12 +27,13 @@ const (
 var refPattern = regexp.MustCompile(`^(?:([A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+))?#([1-9][0-9]*)$`)
 
 type Signal struct {
-	Source      string    `json:"source,omitempty" yaml:"source,omitempty"`
-	CommentURL  string    `json:"comment_url,omitempty" yaml:"comment_url,omitempty"`
-	Status      string    `json:"status,omitempty" yaml:"status,omitempty"`
-	Blockers    []Blocker `json:"blockers,omitempty" yaml:"blockers,omitempty"`
-	HumanAction string    `json:"human_action,omitempty" yaml:"human_action,omitempty"`
-	Invalid     *Invalid  `json:"invalid,omitempty" yaml:"invalid,omitempty"`
+	Source      string            `json:"source,omitempty" yaml:"source,omitempty"`
+	CommentURL  string            `json:"comment_url,omitempty" yaml:"comment_url,omitempty"`
+	Status      string            `json:"status,omitempty" yaml:"status,omitempty"`
+	Blockers    []Blocker         `json:"blockers,omitempty" yaml:"blockers,omitempty"`
+	HumanAction string            `json:"human_action,omitempty" yaml:"human_action,omitempty"`
+	Fields      map[string]string `json:"fields,omitempty" yaml:"fields,omitempty"`
+	Invalid     *Invalid          `json:"invalid,omitempty" yaml:"invalid,omitempty"`
 }
 
 type Blocker struct {
@@ -47,10 +49,11 @@ type Invalid struct {
 }
 
 type statusBlockYAML struct {
-	Schema      int           `yaml:"schema"`
-	Status      string        `yaml:"status"`
-	Blockers    []blockerYAML `yaml:"blockers"`
-	HumanAction *string       `yaml:"human_action"`
+	Schema      int               `yaml:"schema"`
+	Status      string            `yaml:"status"`
+	Blockers    []blockerYAML     `yaml:"blockers"`
+	HumanAction *string           `yaml:"human_action"`
+	Fields      map[string]string `yaml:"fields"`
 }
 
 type blockerYAML struct {
@@ -163,6 +166,28 @@ func ParseStatusBlock(content string, repo string) (*Signal, error) {
 	if raw.Status == StatusBlocked && len(blockers) == 0 && humanAction == "" {
 		problems = append(problems, "status blocked requires at least one blocker ref or human_action")
 	}
+	fields := make(map[string]string, len(raw.Fields))
+	fieldNames := make([]string, 0, len(raw.Fields))
+	for name := range raw.Fields {
+		fieldNames = append(fieldNames, name)
+	}
+	sort.Strings(fieldNames)
+	for _, name := range fieldNames {
+		value := strings.TrimSpace(raw.Fields[name])
+		name = strings.TrimSpace(name)
+		if name == "" {
+			problems = append(problems, "fields must not contain a blank field name")
+			continue
+		}
+		if value == "" {
+			problems = append(problems, fmt.Sprintf("fields[%q] must not be blank", name))
+			continue
+		}
+		fields[name] = value
+	}
+	if len(fields) == 0 {
+		fields = nil
+	}
 	if len(problems) > 0 {
 		return nil, errors.New(strings.Join(problems, "; "))
 	}
@@ -172,6 +197,7 @@ func ParseStatusBlock(content string, repo string) (*Signal, error) {
 		Status:      raw.Status,
 		Blockers:    blockers,
 		HumanAction: humanAction,
+		Fields:      fields,
 	}, nil
 }
 
@@ -222,6 +248,12 @@ func CloneSignal(signal *Signal) *Signal {
 	}
 	cloned := *signal
 	cloned.Blockers = append([]Blocker(nil), signal.Blockers...)
+	if signal.Fields != nil {
+		cloned.Fields = make(map[string]string, len(signal.Fields))
+		for name, value := range signal.Fields {
+			cloned.Fields[name] = value
+		}
+	}
 	if signal.Invalid != nil {
 		invalid := *signal.Invalid
 		cloned.Invalid = &invalid

--- a/internal/workpad/workpad_test.go
+++ b/internal/workpad/workpad_test.go
@@ -1,6 +1,7 @@
 package workpad
 
 import (
+	"reflect"
 	"strings"
 	"testing"
 )
@@ -18,6 +19,7 @@ func TestSignalFromComment(t *testing.T) {
 		wantBlockers  []string
 		wantHuman     string
 		wantComment   string
+		wantFields    map[string]string
 		wantLastBlock bool
 	}{
 		{
@@ -28,6 +30,14 @@ func TestSignalFromComment(t *testing.T) {
 			wantReason:   "digitaldrywood/detent#1462: needs migration",
 			wantBlockers: []string{"digitaldrywood/detent#1462"},
 			wantComment:  "https://github.test/comment/1",
+		},
+		{
+			name:        "valid gate field",
+			body:        "## Codex Workpad\n\n```detent-status\nschema: 1\nstatus: complete\nfields:\n  render_status: pending_review\nblockers: []\nhuman_action: null\n```",
+			wantOK:      true,
+			wantStatus:  StatusComplete,
+			wantFields:  map[string]string{"render_status": "pending_review"},
+			wantComment: "https://github.test/comment/1",
 		},
 		{
 			name:        "malformed yaml",
@@ -114,6 +124,9 @@ func TestSignalFromComment(t *testing.T) {
 			}
 			if got.HumanAction != tt.wantHuman {
 				t.Fatalf("HumanAction = %q, want %q", got.HumanAction, tt.wantHuman)
+			}
+			if !reflect.DeepEqual(got.Fields, tt.wantFields) {
+				t.Fatalf("Fields = %#v, want %#v", got.Fields, tt.wantFields)
 			}
 			if Reason(got) != tt.wantReason {
 				t.Fatalf("Reason() = %q, want %q", Reason(got), tt.wantReason)


### PR DESCRIPTION
## Summary

- parse structured Workpad `fields` mappings and apply the configured artifact gate status on successful worker completion
- reject stale, non-complete, unrelated, or unconfigured field updates and warn when terminal success leaves the gate status unchanged
- teach artifact workers the structured completion contract and configured pass/wait/rework values

The root cause was that strict Workpad YAML decoding rejected `fields`, while run completion only consumed status/blocker metadata and never wrote the configured tracker gate field. Headless workers could therefore report completion without changing the only value artifact autopromotion evaluates.

Fixes #1451

## UI Surface Contract

- [x] N/A, or the linked issue explicitly authorizes any high-impact UI surface, layout, density, first-viewport, or responsive visibility tradeoff.
- [x] Persistent top-of-screen messaging is explicitly authorized by the issue, or this PR does not add it.
- [x] Visual changes to primary operator screens include screenshot or browser verification below.

## Test Plan

- [x] `go test ./internal/workpad ./internal/gate ./internal/runner ./internal/orchestrator -count=1`
- [x] `make check`