### PR TITLE
fix(orchestrator): resume same-state rework

### DIFF
--- a/internal/orchestrator/autopromote_tick_test.go
+++ b/internal/orchestrator/autopromote_tick_test.go
@@ -592,6 +592,85 @@ func TestTickRoutesCompletedActiveArtifactToReview(t *testing.T) {
 	}
 }
 
+func TestTickReleasesCompletedArtifactReworkNoopForNextDispatch(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 7, 18, 17, 28, 32, 0, time.UTC)
+	issue := artifactCompletionTransitionIssue("Rework", "recut")
+	cfg := normalizeConfig(Config{
+		PollInterval:        time.Minute,
+		MaxConcurrentAgents: 1,
+		AutoPromote: AutoPromoteConfig{
+			Enabled:     true,
+			SourceState: "Review",
+			PassState:   "Ready for Pickup",
+			ReworkState: "Rework",
+			Gate:        artifactCompletionTestGate(),
+		},
+		ActiveStates:   []string{"Todo", "Production", "Rework"},
+		ObservedStates: []string{"Review"},
+		TerminalStates: []string{"Ready for Pickup", "Done", "Cancelled"},
+	})
+	state := newState(cfg)
+	state.Completed[issue.ID] = Completed{
+		Issue:       issue,
+		CompletedAt: now,
+		FinalState:  FinalStateCompleted,
+	}
+	state.Retry[issue.ID] = Retry{Issue: issue, Attempt: 1, DueAt: now}
+	mergingSlot := dispatchTestIssue("issue-merging-slot", "Merging")
+	state.Running[mergingSlot.ID] = Running{Issue: mergingSlot}
+	tracker := &autoPromoteTickConnector{stateIssues: []connector.Issue{issue}}
+	attempts := &recordingWorkAttemptStore{}
+	var logs strings.Builder
+	orch := &Orchestrator{
+		cfg:          cfg,
+		connector:    tracker,
+		workAttempts: attempts,
+		logger:       slog.New(slog.NewTextHandler(&logs, nil)),
+	}
+
+	orch.tick(t.Context(), &state, now)
+
+	if _, ok := state.Completed[issue.ID]; ok {
+		t.Fatalf("Completed[%q] present after same-state auto-promote", issue.ID)
+	}
+	if retry, ok := state.Retry[issue.ID]; !ok || retry.Attempt != 1 {
+		t.Fatalf("Retry[%q] = %#v, want preserved continuation attempt 1", issue.ID, retry)
+	}
+	if len(attempts.decisions) != 1 {
+		t.Fatalf("scheduler decisions after completion tick = %#v, want one", attempts.decisions)
+	}
+	if got := attempts.decisions[0]; got.IssueID != issue.ID || got.Reason != dispatchSkipLocalSlotUnavailable {
+		t.Fatalf("scheduler decision = %#v, want issue %q skipped for %q", got, issue.ID, dispatchSkipLocalSlotUnavailable)
+	}
+	for _, fragment := range []string{
+		`level=INFO msg="auto promote decision"`,
+		"action=rework",
+		"target_state=Rework",
+		`level=WARN msg="completed artifact gate status unchanged after successful rework"`,
+		"gate_status_field=render_status",
+		"gate_status=recut",
+	} {
+		if !strings.Contains(logs.String(), fragment) {
+			t.Fatalf("logs %q missing fragment %q", logs.String(), fragment)
+		}
+	}
+
+	nextRetry := state.Retry[issue.ID]
+	orch.tick(t.Context(), &state, nextRetry.DueAt)
+
+	if len(attempts.decisions) != 2 {
+		t.Fatalf("scheduler decisions after next tick = %#v, want two", attempts.decisions)
+	}
+	if got := attempts.decisions[1]; got.IssueID != issue.ID || got.Reason != dispatchSkipLocalSlotUnavailable {
+		t.Fatalf("scheduler decision = %#v, want issue %q skipped for %q", got, issue.ID, dispatchSkipLocalSlotUnavailable)
+	}
+	if retry, ok := state.Retry[issue.ID]; !ok || retry.Attempt != 1 {
+		t.Fatalf("Retry[%q] after capacity skip = %#v, want rescheduled attempt 1", issue.ID, retry)
+	}
+}
+
 func TestTickAutoPromoteRecoversActiveIssueAfterRestart(t *testing.T) {
 	t.Parallel()
 

--- a/internal/orchestrator/completion_transition.go
+++ b/internal/orchestrator/completion_transition.go
@@ -230,8 +230,8 @@ func (o *Orchestrator) finishCompletedActiveReviewTransition(
 	delete(state.Claimed, issueID)
 	if !sameState {
 		delete(state.Retry, issueID)
+		delete(state.BudgetRefusals, issueID)
 	}
-	delete(state.BudgetRefusals, issueID)
 	delete(state.PriorAttempts, issueID)
 }
 

--- a/internal/orchestrator/completion_transition.go
+++ b/internal/orchestrator/completion_transition.go
@@ -52,7 +52,9 @@ func (o *Orchestrator) transitionCompletedActiveIssuesToReview(
 
 		result.transitioned[issueID] = struct{}{}
 		if direct, promoted := o.tryDirectCompletedActiveAutoPromote(ctx, state, issue, targetState, completed.FinalState, cfg, now); direct {
-			if mergeWorkerIssue(promoted) {
+			if normalizeState(issue.State) == normalizeState(promoted.State) {
+				result.dispatchCandidates = append(result.dispatchCandidates, promoted)
+			} else if mergeWorkerIssue(promoted) {
 				o.recordMergeQueueEntered(state, promoted, now, "completed_active_auto_promote")
 				result.dispatchCandidates = append(result.dispatchCandidates, promoted)
 				o.logMergeWorkerPickup(promoted, "completed_active_auto_promote")
@@ -195,6 +197,8 @@ func (o *Orchestrator) tryDirectCompletedActiveAutoPromote(
 	}
 	promoted := promotedIssue(issue, targetState, now)
 	if normalizeState(issue.State) == normalizeState(targetState) {
+		o.logAutoPromoteDecision(issue, decision, targetState)
+		o.logCompletedActiveAutoPromoteSameState(issue, decision, cfg)
 		return true, promoted
 	}
 	if !o.applyAutoPromoteDecision(ctx, state, issue, summary, decision, targetState, now) {
@@ -214,14 +218,46 @@ func (o *Orchestrator) finishCompletedActiveReviewTransition(
 	if err := o.abandonClaim(ctx, issueID); err != nil && o.logger != nil {
 		o.logger.Warn("abandon completed review claim failed", "issue_id", issueID, "error", err)
 	}
-	updated := mergeIssueTrackerFields(completed.Issue, issue)
-	updated.State = targetState
-	completed.Issue = updated
-	state.Completed[issueID] = completed
+	sameState := normalizeState(issue.State) == normalizeState(targetState)
+	if sameState {
+		delete(state.Completed, issueID)
+	} else {
+		updated := mergeIssueTrackerFields(completed.Issue, issue)
+		updated.State = targetState
+		completed.Issue = updated
+		state.Completed[issueID] = completed
+	}
 	delete(state.Claimed, issueID)
-	delete(state.Retry, issueID)
+	if !sameState {
+		delete(state.Retry, issueID)
+	}
 	delete(state.BudgetRefusals, issueID)
 	delete(state.PriorAttempts, issueID)
+}
+
+func (o *Orchestrator) logCompletedActiveAutoPromoteSameState(
+	issue connector.Issue,
+	decision AutoPromoteDecision,
+	cfg AutoPromoteConfig,
+) {
+	if o.logger == nil {
+		return
+	}
+	gateCfg := gate.Effective(cfg.Gate)
+	if gateCfg.Kind != gate.KindArtifact || decision.Action != AutoPromoteActionRework {
+		return
+	}
+	statusField := strings.TrimSpace(gateCfg.Artifact.StatusField)
+	o.logger.Warn(
+		"completed artifact gate status unchanged after successful rework",
+		"issue_id", strings.TrimSpace(issue.ID),
+		"identifier", issue.Identifier,
+		"state", issue.State,
+		"action", decision.Action,
+		"reason", decision.Reason,
+		"gate_status_field", statusField,
+		"gate_status", artifactStatusFromIssue(issue, statusField),
+	)
 }
 
 func completedActiveReviewTargetState(

--- a/internal/orchestrator/completion_transition_test.go
+++ b/internal/orchestrator/completion_transition_test.go
@@ -394,6 +394,7 @@ func TestTransitionCompletedActiveIssuesHandlesArtifactReworkNoop(t *testing.T) 
 		FinalState: FinalStateCompleted,
 	}
 	state.Retry[issue.ID] = Retry{Issue: issue}
+	state.BudgetRefusals[issue.ID] = BudgetRefusal{Issue: issue, Code: "per_issue_max_usd"}
 
 	result := orch.transitionCompletedActiveIssuesToReview(t.Context(), &state, []connector.Issue{issue}, now)
 
@@ -414,6 +415,9 @@ func TestTransitionCompletedActiveIssuesHandlesArtifactReworkNoop(t *testing.T) 
 	}
 	if _, ok := state.Retry[issue.ID]; !ok {
 		t.Fatalf("Retry[%q] missing after same-state auto-promote", issue.ID)
+	}
+	if _, ok := state.BudgetRefusals[issue.ID]; !ok {
+		t.Fatalf("BudgetRefusals[%q] missing after same-state auto-promote", issue.ID)
 	}
 	if len(state.RecentEvents) != 0 {
 		t.Fatalf("RecentEvents = %#v, want none", state.RecentEvents)

--- a/internal/orchestrator/completion_transition_test.go
+++ b/internal/orchestrator/completion_transition_test.go
@@ -393,6 +393,7 @@ func TestTransitionCompletedActiveIssuesHandlesArtifactReworkNoop(t *testing.T) 
 		Issue:      issue,
 		FinalState: FinalStateCompleted,
 	}
+	state.Retry[issue.ID] = Retry{Issue: issue}
 
 	result := orch.transitionCompletedActiveIssuesToReview(t.Context(), &state, []connector.Issue{issue}, now)
 
@@ -405,8 +406,14 @@ func TestTransitionCompletedActiveIssuesHandlesArtifactReworkNoop(t *testing.T) 
 	if len(tracker.comments) != 0 {
 		t.Fatalf("comments = %#v, want none", tracker.comments)
 	}
-	if got := state.Completed[issue.ID].Issue.State; got != "Rework" {
-		t.Fatalf("Completed issue state = %q, want Rework", got)
+	if len(result.dispatchCandidates) != 1 || result.dispatchCandidates[0].ID != issue.ID || result.dispatchCandidates[0].State != "Rework" {
+		t.Fatalf("dispatchCandidates = %#v, want same-state Rework issue", result.dispatchCandidates)
+	}
+	if _, ok := state.Completed[issue.ID]; ok {
+		t.Fatalf("Completed[%q] present after same-state auto-promote", issue.ID)
+	}
+	if _, ok := state.Retry[issue.ID]; !ok {
+		t.Fatalf("Retry[%q] missing after same-state auto-promote", issue.ID)
 	}
 	if len(state.RecentEvents) != 0 {
 		t.Fatalf("RecentEvents = %#v, want none", state.RecentEvents)


### PR DESCRIPTION
## Summary

- release completed same-state artifact rework items back into dispatch without rewriting tracker state
- preserve continuation retry pacing and emit the auto-promote decision plus an actionable unchanged-gate-status warning
- cover completion cleanup and scheduler liveness across consecutive ticks

Fixes #1459

## UI Surface Contract

- [x] N/A, or the linked issue explicitly authorizes any high-impact UI surface, layout, density, first-viewport, or responsive visibility tradeoff.
- [x] Persistent top-of-screen messaging is explicitly authorized by the issue, or this PR does not add it.
- [x] Visual changes to primary operator screens include screenshot or browser verification below. N/A: no UI changes.

## Test Plan

- [x] `go test ./internal/orchestrator -run '^(TestTransitionCompletedActiveIssuesHandlesArtifactReworkNoop|TestTickReleasesCompletedArtifactReworkNoopForNextDispatch)$' -count=10 -v`
- [x] `go test ./internal/orchestrator -count=1`
- [x] `make check`