### PR TITLE
Stabilize initial project readiness in hot-reload boot test

### DIFF
--- a/internal/cli/boot_test.go
+++ b/internal/cli/boot_test.go
@@ -973,16 +973,15 @@ func TestStartRunningHotReloadsGlobalConfigProjects(t *testing.T) {
 
 	baseURL := waitForBootDashboardURL(t, output, done)
 	settingsURL := baseURL + "/settings"
-	body := waitForDashboard(t, settingsURL, done)
-	if !strings.Contains(body, "alpha") {
-		t.Fatalf("settings body missing alpha:\n%s", body)
-	}
+	waitForDashboardCondition(t, settingsURL, done, "initial alpha project", func(body string) bool {
+		return strings.Contains(body, "alpha")
+	})
 
 	writeBootGlobalConfig(t, configPath, []globalconfig.Project{
 		{ID: "alpha", Workflow: alpha.workflowPath, Workdir: alpha.workdirPath, Weight: 1},
 		{ID: "bravo", Workflow: bravo.workflowPath, Workdir: bravo.workdirPath, Weight: 1},
 	})
-	body = waitForDashboardCondition(t, settingsURL, done, "bravo added", func(body string) bool {
+	body := waitForDashboardCondition(t, settingsURL, done, "bravo added", func(body string) bool {
 		return strings.Contains(body, "bravo")
 	})
 	if !strings.Contains(body, "alpha") {


### PR DESCRIPTION
## Summary

- Wait for the initial `alpha` project to appear in `/settings` before asserting startup readiness.
- Preserve the existing file-watch assertions for adding `bravo` and removing `alpha`.

Fixes #1463

## UI Surface Contract

- [x] N/A, or the linked issue explicitly authorizes any high-impact UI surface, layout, density, first-viewport, or responsive visibility tradeoff.
- [x] Persistent top-of-screen messaging is explicitly authorized by the issue, or this PR does not add it.
- [x] Visual changes to primary operator screens include screenshot or browser verification below. (N/A: test-only change.)

## Test Plan

- [x] `go test ./internal/cli -run ^'TestStartRunningHotReloadsGlobalConfigProjects$' -count=20`
- [x] `go test -cover ./internal/cli -run ^'TestStartRunningHotReloadsGlobalConfigProjects$' -count=20`
- [x] `go test -race ./internal/cli -run ^'TestStartRunningHotReloadsGlobalConfigProjects$' -count=20`
- [x] `make check`