### PR TITLE
fix(orchestrator): reap stopped worker groups

### DIFF
--- a/internal/orchestrator/backend_capacity_test.go
+++ b/internal/orchestrator/backend_capacity_test.go
@@ -362,14 +362,17 @@ func TestHandleOperatorStopCompletionDefersCapacityProbe(t *testing.T) {
 	state.FailureBreaker.ResumeAt = now
 	running := Running{Issue: issue, Attempt: 1, CapacityScope: scope, CapacityProbe: true}
 	state.Running[issue.ID] = running
-	orch.pendingStops[issue.ID] = &pendingStopRun{result: StopRunResult{
-		IssueID:     issue.ID,
-		Identifier:  issue.Identifier,
-		Attempt:     running.Attempt,
-		Destination: "Blocked",
-		Outcome:     "pending",
-		RequestedAt: now.Add(-time.Second),
-	}}
+	orch.pendingStops[issue.ID] = &pendingStopRun{
+		result: StopRunResult{
+			IssueID:     issue.ID,
+			Identifier:  issue.Identifier,
+			Attempt:     running.Attempt,
+			Destination: "Blocked",
+			Outcome:     "pending",
+			RequestedAt: now.Add(-time.Second),
+		},
+		reapDone: true,
+	}
 
 	if handled := orch.handleOperatorStopCompletion(t.Context(), &state, runpkg.Completion{IssueID: issue.ID, CompletedAt: now}, running); !handled {
 		t.Fatal("handleOperatorStopCompletion() handled = false")

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -13,6 +13,7 @@ import (
 	"github.com/digitaldrywood/detent/internal/connector"
 	"github.com/digitaldrywood/detent/internal/efficiency"
 	"github.com/digitaldrywood/detent/internal/gate"
+	"github.com/digitaldrywood/detent/internal/procgroup"
 	releasepkg "github.com/digitaldrywood/detent/internal/release"
 	runpkg "github.com/digitaldrywood/detent/internal/runner"
 	"github.com/digitaldrywood/detent/internal/scheduler"
@@ -147,7 +148,17 @@ type Dependencies struct {
 	Now                func() time.Time
 	Logger             *slog.Logger
 	Retrospector       Retrospector
+	WorkerProcesses    WorkerProcessStore
+	ReapWorkerProcess  WorkerProcessReapFunc
+	WorkerReapGrace    time.Duration
 }
+
+type WorkerProcessStore interface {
+	ListActiveWorkerProcesses(context.Context) ([]store.WorkerProcess, error)
+	MarkSessionWorkerProcessReaped(context.Context, int64, store.WorkerProcessReap) error
+}
+
+type WorkerProcessReapFunc func(context.Context, procgroup.Identity, time.Duration) (procgroup.TerminationOutcome, error)
 
 type Retrospector interface {
 	Trigger(string)
@@ -195,6 +206,9 @@ type Orchestrator struct {
 	issueBudgetStatus       runpkg.IssueBudgetStatusProvider
 	now                     func() time.Time
 	retrospector            Retrospector
+	workerProcesses         WorkerProcessStore
+	reapWorkerProcess       WorkerProcessReapFunc
+	workerReapGrace         time.Duration
 	heartbeats              *heartbeatManager
 	hydrationSkipStreaks    map[string]int
 	hydrationWarned         bool
@@ -363,6 +377,25 @@ func New(cfg Config, deps Dependencies) (*Orchestrator, error) {
 			operatorStops = candidate
 		}
 	}
+	workerProcesses := deps.WorkerProcesses
+	if workerProcesses == nil {
+		if candidate, ok := deps.WorkAttempts.(WorkerProcessStore); ok {
+			workerProcesses = candidate
+		}
+	}
+	if workerProcesses == nil {
+		if candidate, ok := deps.WorkflowMetrics.(WorkerProcessStore); ok {
+			workerProcesses = candidate
+		}
+	}
+	reapWorkerProcess := deps.ReapWorkerProcess
+	if reapWorkerProcess == nil {
+		reapWorkerProcess = procgroup.Terminate
+	}
+	workerReapGrace := deps.WorkerReapGrace
+	if workerReapGrace <= 0 {
+		workerReapGrace = procgroup.DefaultTerminationGrace
+	}
 
 	supervisor, err := runpkg.NewSupervisor(runner, runpkg.SupervisorConfig{
 		MaxRetryBackoff:       cfg.MaxRetryBackoff,
@@ -398,6 +431,9 @@ func New(cfg Config, deps Dependencies) (*Orchestrator, error) {
 		activity:                deps.Activity,
 		release:                 deps.Release,
 		retrospector:            deps.Retrospector,
+		workerProcesses:         workerProcesses,
+		reapWorkerProcess:       reapWorkerProcess,
+		workerReapGrace:         workerReapGrace,
 		capacityController:      capacityController,
 		capacityStatus:          capacityStatus,
 		validatorCapacity:       validatorCapacity,

--- a/internal/orchestrator/stop_run.go
+++ b/internal/orchestrator/stop_run.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/digitaldrywood/detent/internal/activity"
 	"github.com/digitaldrywood/detent/internal/connector"
+	"github.com/digitaldrywood/detent/internal/procgroup"
 	runpkg "github.com/digitaldrywood/detent/internal/runner"
 	"github.com/digitaldrywood/detent/internal/store"
 	"github.com/digitaldrywood/detent/internal/telemetry"
@@ -22,6 +23,7 @@ var (
 	ErrStopRunInvalidRoute    = errors.New("stop run destination or priority is invalid")
 	ErrStopRunStale           = errors.New("active run has completed or changed")
 	ErrStopRunTransition      = errors.New("run stopped but work item transition failed")
+	ErrStopRunWorkerProcess   = errors.New("worker process group exit was not verified")
 )
 
 const (
@@ -74,7 +76,11 @@ type stopRunReply struct {
 }
 
 type pendingStopRun struct {
-	result StopRunResult
+	result     StopRunResult
+	completion *runpkg.Completion
+	running    Running
+	reapDone   bool
+	reapErr    error
 }
 
 type operatorStopMetadata struct {
@@ -129,6 +135,12 @@ func (o *Orchestrator) handleStopRunRequest(ctx context.Context, state *State, e
 	}
 	if pending, ok := o.pendingStops[request.IssueID]; ok {
 		if stopRunResultMatchesRequest(pending.result, request) {
+			if pending.completion != nil && pending.reapErr != nil {
+				result, err := o.finishOperatorStopCompletion(ctx, state, pending)
+				result.AlreadyStopped = true
+				event.reply <- stopRunReply{result: result, err: err}
+				return
+			}
 			result := pending.result
 			result.AlreadyStopped = true
 			event.reply <- stopRunReply{result: result}
@@ -197,13 +209,15 @@ func (o *Orchestrator) handleStopRunRequest(ctx context.Context, state *State, e
 	delete(state.Retry, request.IssueID)
 	delete(state.BudgetRefusals, request.IssueID)
 	state.Running[request.IssueID] = running
+	recordStateEvent(state, telemetry.ActivityEvent{At: event.at, Event: "operator_stop_requested", Message: "operator requested stop for " + issueLabel(running.Issue)})
+	event.reply <- stopRunReply{result: result}
 	if running.stop != nil {
 		running.stop(runpkg.ErrOperatorStopped)
 	} else if running.cancel != nil {
 		running.cancel()
 	}
-	recordStateEvent(state, telemetry.ActivityEvent{At: event.at, Event: "operator_stop_requested", Message: "operator requested stop for " + issueLabel(running.Issue)})
-	event.reply <- stopRunReply{result: result}
+	pending := o.pendingStops[request.IssueID]
+	o.reapPendingOperatorStop(ctx, state, pending, running)
 }
 
 func (o *Orchestrator) handleOperatorStopCompletion(ctx context.Context, state *State, event runpkg.Completion, running Running) bool {
@@ -211,7 +225,65 @@ func (o *Orchestrator) handleOperatorStopCompletion(ctx context.Context, state *
 	if !ok {
 		return false
 	}
+	pending.completion = &event
+	pending.running = running
+	if pending.reapErr != nil || !pending.reapDone {
+		return true
+	}
+	if _, err := o.finishOperatorStopCompletion(ctx, state, pending); errors.Is(err, ErrStopRunWorkerProcess) && o.logger != nil {
+		o.logger.Warn("operator stop worker process reap failed", "issue_id", event.IssueID, "identifier", running.Issue.Identifier, "error", err)
+	}
+	return true
+}
+
+func (o *Orchestrator) finishOperatorStopCompletion(ctx context.Context, state *State, pending *pendingStopRun) (StopRunResult, error) {
+	if pending == nil || pending.completion == nil {
+		return StopRunResult{}, ErrStopRunStale
+	}
+	event := *pending.completion
+	running := pending.running
+	if pending.reapErr != nil || !pending.reapDone {
+		o.reapPendingOperatorStop(ctx, state, pending, running)
+	}
+	if pending.reapErr != nil {
+		return pending.result, pending.reapErr
+	}
 	delete(o.pendingStops, event.IssueID)
+	result, transitionErr := o.completeOperatorStopCompletion(ctx, state, event, running, pending.result)
+	return result, transitionErr
+}
+
+func (o *Orchestrator) reapPendingOperatorStop(ctx context.Context, state *State, pending *pendingStopRun, running Running) {
+	if pending == nil {
+		return
+	}
+	outcome, identity, err := o.reapOperatorStopWorker(ctx, running)
+	pending.reapDone = err == nil
+	pending.reapErr = err
+	if o.logger != nil {
+		attrs := []any{
+			"operation", "worker_process_reap",
+			"reason", "operator_stop",
+			"decision", string(outcome),
+			"detent_session_id", running.DetentSessionID,
+			"issue_id", running.Issue.ID,
+			"issue_identifier", running.Issue.Identifier,
+			"pid", identity.PID,
+			"pgid", identity.GroupID,
+		}
+		if err != nil {
+			attrs = append(attrs, "error", err)
+		}
+		o.logger.Info("worker process lifecycle decision", attrs...)
+	}
+	if err != nil {
+		state.Blocked[running.Issue.ID] = operatorStopBlocked(running.Issue, pending.result, "operator stop is waiting for the worker process group to exit: "+err.Error())
+		return
+	}
+	state.Blocked[running.Issue.ID] = operatorStopBlocked(running.Issue, pending.result, "operator stop is waiting for the worker to exit")
+}
+
+func (o *Orchestrator) completeOperatorStopCompletion(ctx context.Context, state *State, event runpkg.Completion, running Running, result StopRunResult) (StopRunResult, error) {
 	o.releaseGlobalDispatchSlot(running.globalSlot)
 	tokens := event.Result.Tokens
 	if tokens == (TokenTotals{}) {
@@ -234,12 +306,60 @@ func (o *Orchestrator) handleOperatorStopCompletion(ctx context.Context, state *
 		completedAt = o.clockNow().UTC()
 	}
 	o.deferBackendCapacityProbe(state, running, completedAt, runpkg.ErrOperatorStopped)
-	result := pending.result
 	result.CompletedAt = completedAt
-	if err := o.finishOperatorStopTransition(ctx, state, running.Issue, &result); err != nil && o.logger != nil {
-		o.logger.Warn("operator stop tracker transition failed", "issue_id", event.IssueID, "destination", result.Destination, "error", err)
+	if err := o.finishOperatorStopTransition(ctx, state, running.Issue, &result); err != nil {
+		if o.logger != nil {
+			o.logger.Warn("operator stop tracker transition failed", "issue_id", event.IssueID, "destination", result.Destination, "error", err)
+		}
+		return result, err
 	}
-	return true
+	return result, nil
+}
+
+func (o *Orchestrator) reapOperatorStopWorker(ctx context.Context, running Running) (procgroup.TerminationOutcome, procgroup.Identity, error) {
+	identity, found, err := o.persistedWorkerProcess(ctx, running)
+	if err != nil {
+		return "", procgroup.Identity{}, fmt.Errorf("%w: load persisted identity: %w", ErrStopRunWorkerProcess, err)
+	}
+	if !found {
+		return procgroup.TerminationOutcomeAlreadyExited, procgroup.Identity{}, nil
+	}
+	outcome, err := o.reapWorkerProcess(context.WithoutCancel(ctx), identity, o.workerReapGrace)
+	if err != nil {
+		return "", identity, fmt.Errorf("%w: %w", ErrStopRunWorkerProcess, err)
+	}
+	if outcome == procgroup.TerminationOutcomeStaleIdentity {
+		return outcome, identity, fmt.Errorf("%w: persisted PID, PGID, or start time is stale", ErrStopRunWorkerProcess)
+	}
+	if o.workerProcesses != nil && running.DetentSessionID > 0 {
+		if err := o.workerProcesses.MarkSessionWorkerProcessReaped(context.WithoutCancel(ctx), running.DetentSessionID, store.WorkerProcessReap{
+			ReapedAt: o.clockNow().UTC(),
+			Outcome:  string(outcome),
+		}); err != nil {
+			return outcome, identity, fmt.Errorf("%w: persist reap outcome: %w", ErrStopRunWorkerProcess, err)
+		}
+	}
+	return outcome, identity, nil
+}
+
+func (o *Orchestrator) persistedWorkerProcess(ctx context.Context, running Running) (procgroup.Identity, bool, error) {
+	if o.workerProcesses != nil && running.DetentSessionID > 0 {
+		processes, err := o.workerProcesses.ListActiveWorkerProcesses(context.WithoutCancel(ctx))
+		if err != nil {
+			return procgroup.Identity{}, false, err
+		}
+		for _, process := range processes {
+			if process.SessionID == running.DetentSessionID {
+				return procgroup.Identity{PID: process.PID, GroupID: process.GroupID, StartedAt: process.StartedAt}, true, nil
+			}
+		}
+		if running.WorkerProcess.PID > 0 {
+			return procgroup.Identity{}, false, fmt.Errorf("active worker identity for session %d was not persisted", running.DetentSessionID)
+		}
+		return procgroup.Identity{}, false, nil
+	}
+	identity := running.WorkerProcess
+	return identity, identity.PID > 0, nil
 }
 
 func (o *Orchestrator) finishOperatorStopTransition(ctx context.Context, state *State, issue connector.Issue, result *StopRunResult) error {

--- a/internal/orchestrator/stop_run.go
+++ b/internal/orchestrator/stop_run.go
@@ -76,11 +76,12 @@ type stopRunReply struct {
 }
 
 type pendingStopRun struct {
-	result     StopRunResult
-	completion *runpkg.Completion
-	running    Running
-	reapDone   bool
-	reapErr    error
+	result        StopRunResult
+	completion    *runpkg.Completion
+	running       Running
+	workerProcess procgroup.Identity
+	reapDone      bool
+	reapErr       error
 }
 
 type operatorStopMetadata struct {
@@ -257,7 +258,10 @@ func (o *Orchestrator) reapPendingOperatorStop(ctx context.Context, state *State
 	if pending == nil {
 		return
 	}
-	outcome, identity, err := o.reapOperatorStopWorker(ctx, running)
+	outcome, identity, err := o.reapOperatorStopWorker(ctx, running, pending.workerProcess)
+	if identity.PID > 0 {
+		pending.workerProcess = identity
+	}
 	pending.reapDone = err == nil
 	pending.reapErr = err
 	if o.logger != nil {
@@ -316,10 +320,14 @@ func (o *Orchestrator) completeOperatorStopCompletion(ctx context.Context, state
 	return result, nil
 }
 
-func (o *Orchestrator) reapOperatorStopWorker(ctx context.Context, running Running) (procgroup.TerminationOutcome, procgroup.Identity, error) {
-	identity, found, err := o.persistedWorkerProcess(ctx, running)
-	if err != nil {
-		return "", procgroup.Identity{}, fmt.Errorf("%w: load persisted identity: %w", ErrStopRunWorkerProcess, err)
+func (o *Orchestrator) reapOperatorStopWorker(ctx context.Context, running Running, identity procgroup.Identity) (procgroup.TerminationOutcome, procgroup.Identity, error) {
+	found := identity.PID > 0
+	if !found {
+		var err error
+		identity, found, err = o.persistedWorkerProcess(ctx, running)
+		if err != nil {
+			return "", procgroup.Identity{}, fmt.Errorf("%w: load persisted identity: %w", ErrStopRunWorkerProcess, err)
+		}
 	}
 	if !found {
 		return procgroup.TerminationOutcomeAlreadyExited, procgroup.Identity{}, nil

--- a/internal/orchestrator/stop_run_process_unix_test.go
+++ b/internal/orchestrator/stop_run_process_unix_test.go
@@ -180,6 +180,100 @@ func TestStopRunRefusesStalePersistedProcessIdentity(t *testing.T) {
 	}
 }
 
+func TestStopRunRetriesWorkerReapAfterSessionCompletion(t *testing.T) {
+	identity := procgroup.Identity{PID: 41453, GroupID: 41453, StartedAt: time.Unix(1453, 0).UTC()}
+	issue := testIssue("issue-stop-reap-retry", "digitaldrywood/detent#1453", "In Progress")
+	tracker := newFakeConnector(issue)
+	processStore := &operatorStopProcessStore{
+		processes: []store.WorkerProcess{{
+			SessionID:  3453,
+			IssueID:    issue.ID,
+			Identifier: issue.Identifier,
+			WorkerProcessIdentity: store.WorkerProcessIdentity{
+				PID: identity.PID, GroupID: identity.GroupID, StartedAt: identity.StartedAt,
+			},
+		}},
+		markFailures: 1,
+	}
+	runner := &operatorStopIdentityRunner{
+		identity:  identity,
+		sessionID: 3453,
+		started:   make(chan struct{}),
+		returned:  make(chan struct{}),
+	}
+	var reapMu sync.Mutex
+	var reapedIdentities []procgroup.Identity
+	orch, err := orchestrator.New(
+		orchestrator.Config{
+			PollInterval:        time.Hour,
+			MaxConcurrentAgents: 1,
+			Project:             scheduler.ProjectCandidate{ID: "detent"},
+			ActiveStates:        []string{"In Progress"},
+			ObservedStates:      []string{"Blocked"},
+			TerminalStates:      []string{"Done"},
+			StopRunTargetState:  "Blocked",
+		},
+		orchestrator.Dependencies{
+			Connector:       tracker,
+			Runner:          runner,
+			WorkerProcesses: processStore,
+			ReapWorkerProcess: func(_ context.Context, identity procgroup.Identity, _ time.Duration) (procgroup.TerminationOutcome, error) {
+				reapMu.Lock()
+				defer reapMu.Unlock()
+				reapedIdentities = append(reapedIdentities, identity)
+				if len(reapedIdentities) == 1 {
+					return procgroup.TerminationOutcomeTerminated, nil
+				}
+				return procgroup.TerminationOutcomeAlreadyExited, nil
+			},
+		},
+	)
+	if err != nil {
+		t.Fatalf("orchestrator.New() error = %v", err)
+	}
+	stop := runOrchestrator(t, orch)
+	t.Cleanup(stop)
+	<-runner.started
+	state := waitForOperatorStopState(t, orch, func(state orchestrator.State) bool {
+		return state.Running[issue.ID].WorkerProcess.PID == identity.PID
+	})
+	running := state.Running[issue.ID]
+	request := orchestrator.StopRunRequest{ProjectID: "detent", IssueID: issue.ID, Attempt: running.Attempt}
+	result, err := orch.StopRun(t.Context(), request)
+	if err != nil || result.Outcome != "pending" {
+		t.Fatalf("StopRun() = %#v, %v", result, err)
+	}
+	<-runner.returned
+	waitForOperatorStopState(t, orch, func(state orchestrator.State) bool {
+		blocked := state.Blocked[issue.ID]
+		_, stillRunning := state.Running[issue.ID]
+		return stillRunning && strings.Contains(blocked.Reason, "persist reap outcome")
+	})
+	processStore.clearProcesses()
+
+	deadline := time.Now().Add(time.Second)
+	for time.Now().Before(deadline) {
+		result, err = orch.StopRun(t.Context(), request)
+		if err == nil && result.Outcome == "succeeded" {
+			break
+		}
+		time.Sleep(time.Millisecond)
+	}
+	if err != nil || result.Outcome != "succeeded" || !result.AlreadyStopped {
+		t.Fatalf("retry StopRun() = %#v, %v", result, err)
+	}
+	reapMu.Lock()
+	gotReapedIdentities := append([]procgroup.Identity(nil), reapedIdentities...)
+	reapMu.Unlock()
+	if len(gotReapedIdentities) != 2 || gotReapedIdentities[0] != identity || gotReapedIdentities[1] != identity {
+		t.Fatalf("reaped identities = %#v, want persisted identity twice", gotReapedIdentities)
+	}
+	reaped := processStore.reapedSnapshot()
+	if len(reaped) != 1 || reaped[0].sessionID != runner.sessionID || reaped[0].reap.Outcome != store.WorkerProcessOutcomeAlreadyExited {
+		t.Fatalf("reaped worker processes = %#v", reaped)
+	}
+}
+
 type operatorStopDescendantRunner struct {
 	processStore       *operatorStopProcessStore
 	sessionID          int64
@@ -254,9 +348,10 @@ func (r *operatorStopIdentityRunner) Run(ctx context.Context, request orchestrat
 }
 
 type operatorStopProcessStore struct {
-	mu        sync.Mutex
-	processes []store.WorkerProcess
-	reaped    []operatorStopProcessReap
+	mu           sync.Mutex
+	processes    []store.WorkerProcess
+	reaped       []operatorStopProcessReap
+	markFailures int
 }
 
 type operatorStopProcessReap struct {
@@ -273,6 +368,10 @@ func (s *operatorStopProcessStore) ListActiveWorkerProcesses(context.Context) ([
 func (s *operatorStopProcessStore) MarkSessionWorkerProcessReaped(_ context.Context, sessionID int64, reap store.WorkerProcessReap) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
+	if s.markFailures > 0 {
+		s.markFailures--
+		return errors.New("worker reap outcome persistence failed")
+	}
 	s.reaped = append(s.reaped, operatorStopProcessReap{sessionID: sessionID, reap: reap})
 	return nil
 }
@@ -281,6 +380,12 @@ func (s *operatorStopProcessStore) setProcess(process store.WorkerProcess) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.processes = []store.WorkerProcess{process}
+}
+
+func (s *operatorStopProcessStore) clearProcesses() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.processes = nil
 }
 
 func (s *operatorStopProcessStore) reapedSnapshot() []operatorStopProcessReap {

--- a/internal/orchestrator/stop_run_process_unix_test.go
+++ b/internal/orchestrator/stop_run_process_unix_test.go
@@ -1,0 +1,329 @@
+//go:build unix
+
+package orchestrator_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"sync"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/digitaldrywood/detent/internal/orchestrator"
+	"github.com/digitaldrywood/detent/internal/procgroup"
+	"github.com/digitaldrywood/detent/internal/scheduler"
+	"github.com/digitaldrywood/detent/internal/store"
+)
+
+func TestStopRunReapsDescendantThatSurvivesParentCancellation(t *testing.T) {
+	issue := testIssue("issue-stop-process-group", "digitaldrywood/detent#1453", "In Progress")
+	tracker := newFakeConnector(issue)
+	processStore := &operatorStopProcessStore{}
+	runner := &operatorStopDescendantRunner{
+		processStore:       processStore,
+		sessionID:          1453,
+		pidPath:            filepath.Join(t.TempDir(), "descendant.pid"),
+		started:            make(chan procgroup.Identity, 1),
+		descendantSurvived: make(chan int, 1),
+	}
+	observedDescendant := make(chan int, 1)
+	orch, err := orchestrator.New(
+		orchestrator.Config{
+			PollInterval:        time.Hour,
+			MaxConcurrentAgents: 1,
+			Project:             scheduler.ProjectCandidate{ID: "detent"},
+			ActiveStates:        []string{"In Progress"},
+			ObservedStates:      []string{"Blocked"},
+			TerminalStates:      []string{"Done"},
+			StopRunTargetState:  "Blocked",
+		},
+		orchestrator.Dependencies{
+			Connector:       tracker,
+			Runner:          runner,
+			WorkerProcesses: processStore,
+			WorkerReapGrace: 20 * time.Millisecond,
+			ReapWorkerProcess: func(ctx context.Context, identity procgroup.Identity, grace time.Duration) (procgroup.TerminationOutcome, error) {
+				select {
+				case descendantPID := <-runner.descendantSurvived:
+					observedDescendant <- descendantPID
+				case <-time.After(time.Second):
+					return "", errors.New("parent cancellation did not leave a surviving descendant")
+				}
+				return procgroup.Terminate(ctx, identity, grace)
+			},
+		},
+	)
+	if err != nil {
+		t.Fatalf("orchestrator.New() error = %v", err)
+	}
+	stop := runOrchestrator(t, orch)
+	t.Cleanup(stop)
+
+	identity := <-runner.started
+	t.Cleanup(func() {
+		_ = procgroup.Cleanup(identity.GroupID)
+	})
+	state := waitForOperatorStopState(t, orch, func(state orchestrator.State) bool {
+		running := state.Running[issue.ID]
+		return running.DetentSessionID == runner.sessionID && running.WorkerProcess.PID == identity.PID
+	})
+	running := state.Running[issue.ID]
+	result, err := orch.StopRun(t.Context(), orchestrator.StopRunRequest{
+		ProjectID:       "detent",
+		IssueID:         issue.ID,
+		Attempt:         running.Attempt,
+		DetentSessionID: running.DetentSessionID,
+	})
+	if err != nil || result.Outcome != "pending" {
+		t.Fatalf("StopRun() = %#v, %v", result, err)
+	}
+
+	descendantPID := <-observedDescendant
+	if !operatorStopProcessAlive(descendantPID) {
+		t.Fatalf("descendant %d exited before process-group termination", descendantPID)
+	}
+	waitForOperatorStopState(t, orch, func(state orchestrator.State) bool {
+		_, stillRunning := state.Running[issue.ID]
+		return !stillRunning
+	})
+	waitForOperatorStopProcessExit(t, descendantPID)
+	reaped := processStore.reapedSnapshot()
+	if len(reaped) != 1 || reaped[0].sessionID != runner.sessionID || reaped[0].reap.Outcome != store.WorkerProcessOutcomeTerminated {
+		t.Fatalf("reaped worker processes = %#v", reaped)
+	}
+}
+
+func TestStopRunRefusesStalePersistedProcessIdentity(t *testing.T) {
+	cmd := exec.CommandContext(context.Background(), "sleep", "30")
+	procgroup.Configure(cmd)
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("Start() error = %v", err)
+	}
+	identity, err := procgroup.Inspect(cmd)
+	if err != nil {
+		_ = cmd.Process.Kill()
+		_ = cmd.Wait()
+		t.Fatalf("Inspect() error = %v", err)
+	}
+	t.Cleanup(func() {
+		_ = procgroup.Cleanup(identity.GroupID)
+		_ = cmd.Wait()
+	})
+	staleIdentity := identity
+	staleIdentity.StartedAt = staleIdentity.StartedAt.Add(time.Second)
+
+	issue := testIssue("issue-stop-stale-process", "digitaldrywood/detent#1453", "In Progress")
+	tracker := newFakeConnector(issue)
+	processStore := &operatorStopProcessStore{processes: []store.WorkerProcess{{
+		SessionID:  2453,
+		IssueID:    issue.ID,
+		Identifier: issue.Identifier,
+		WorkerProcessIdentity: store.WorkerProcessIdentity{
+			PID:       staleIdentity.PID,
+			GroupID:   staleIdentity.GroupID,
+			StartedAt: staleIdentity.StartedAt,
+		},
+	}}}
+	runner := &operatorStopIdentityRunner{
+		identity:  identity,
+		sessionID: 2453,
+		started:   make(chan struct{}),
+		returned:  make(chan struct{}),
+	}
+	orch, err := orchestrator.New(
+		orchestrator.Config{
+			PollInterval:        time.Hour,
+			MaxConcurrentAgents: 1,
+			Project:             scheduler.ProjectCandidate{ID: "detent"},
+			ActiveStates:        []string{"In Progress"},
+			ObservedStates:      []string{"Blocked"},
+			TerminalStates:      []string{"Done"},
+			StopRunTargetState:  "Blocked",
+		},
+		orchestrator.Dependencies{Connector: tracker, Runner: runner, WorkerProcesses: processStore, WorkerReapGrace: 20 * time.Millisecond},
+	)
+	if err != nil {
+		t.Fatalf("orchestrator.New() error = %v", err)
+	}
+	stop := runOrchestrator(t, orch)
+	t.Cleanup(stop)
+	<-runner.started
+	state := waitForOperatorStopState(t, orch, func(state orchestrator.State) bool {
+		return state.Running[issue.ID].WorkerProcess.PID == identity.PID
+	})
+	running := state.Running[issue.ID]
+	result, err := orch.StopRun(t.Context(), orchestrator.StopRunRequest{ProjectID: "detent", IssueID: issue.ID, Attempt: running.Attempt})
+	if err != nil || result.Outcome != "pending" {
+		t.Fatalf("StopRun() = %#v, %v", result, err)
+	}
+	<-runner.returned
+	waitForOperatorStopState(t, orch, func(state orchestrator.State) bool {
+		blocked := state.Blocked[issue.ID]
+		_, stillRunning := state.Running[issue.ID]
+		return stillRunning && strings.Contains(blocked.Reason, "persisted PID, PGID, or start time is stale")
+	})
+	if !operatorStopProcessAlive(identity.PID) {
+		t.Fatal("stale identity refusal terminated the unrelated test process")
+	}
+	if len(processStore.reapedSnapshot()) != 0 {
+		t.Fatalf("stale worker process was marked reaped: %#v", processStore.reapedSnapshot())
+	}
+	if len(tracker.stateUpdateCalls()) != 0 {
+		t.Fatalf("tracker state updates = %#v, want none before process-group exit", tracker.stateUpdateCalls())
+	}
+}
+
+type operatorStopDescendantRunner struct {
+	processStore       *operatorStopProcessStore
+	sessionID          int64
+	pidPath            string
+	started            chan procgroup.Identity
+	descendantSurvived chan int
+}
+
+func (r *operatorStopDescendantRunner) Run(ctx context.Context, request orchestrator.RunRequest) (orchestrator.RunResult, error) {
+	script := "sleep 30 >/dev/null 2>&1 & printf '%s\\n' \"$!\" > " + operatorStopShellQuote(r.pidPath) + "; wait"
+	cmd := exec.CommandContext(context.Background(), "sh", "-c", script)
+	procgroup.Configure(cmd)
+	if err := cmd.Start(); err != nil {
+		return orchestrator.RunResult{}, err
+	}
+	identity, err := procgroup.Inspect(cmd)
+	if err != nil {
+		_ = procgroup.Cleanup(procgroup.GroupID(cmd))
+		_ = cmd.Wait()
+		return orchestrator.RunResult{}, err
+	}
+	descendantPID, err := readOperatorStopPID(r.pidPath, time.Second)
+	if err != nil {
+		_ = procgroup.Cleanup(identity.GroupID)
+		_ = cmd.Wait()
+		return orchestrator.RunResult{}, err
+	}
+	r.processStore.setProcess(store.WorkerProcess{
+		SessionID:  r.sessionID,
+		IssueID:    request.Issue.ID,
+		Identifier: request.Issue.Identifier,
+		WorkerProcessIdentity: store.WorkerProcessIdentity{
+			PID: identity.PID, GroupID: identity.GroupID, StartedAt: identity.StartedAt,
+		},
+	})
+	if request.OnUsageUpdate != nil {
+		if err := request.OnUsageUpdate(orchestrator.UsageUpdate{DetentSessionID: r.sessionID, WorkerProcess: identity}); err != nil {
+			_ = procgroup.Cleanup(identity.GroupID)
+			_ = cmd.Wait()
+			return orchestrator.RunResult{}, err
+		}
+	}
+	r.started <- identity
+	<-ctx.Done()
+	_ = cmd.Process.Kill()
+	_ = cmd.Wait()
+	if operatorStopProcessAlive(descendantPID) {
+		r.descendantSurvived <- descendantPID
+	} else {
+		r.descendantSurvived <- -descendantPID
+	}
+	return orchestrator.RunResult{}, ctx.Err()
+}
+
+type operatorStopIdentityRunner struct {
+	identity  procgroup.Identity
+	sessionID int64
+	started   chan struct{}
+	returned  chan struct{}
+}
+
+func (r *operatorStopIdentityRunner) Run(ctx context.Context, request orchestrator.RunRequest) (orchestrator.RunResult, error) {
+	if request.OnUsageUpdate != nil {
+		if err := request.OnUsageUpdate(orchestrator.UsageUpdate{DetentSessionID: r.sessionID, WorkerProcess: r.identity}); err != nil {
+			return orchestrator.RunResult{}, err
+		}
+	}
+	close(r.started)
+	<-ctx.Done()
+	close(r.returned)
+	return orchestrator.RunResult{}, ctx.Err()
+}
+
+type operatorStopProcessStore struct {
+	mu        sync.Mutex
+	processes []store.WorkerProcess
+	reaped    []operatorStopProcessReap
+}
+
+type operatorStopProcessReap struct {
+	sessionID int64
+	reap      store.WorkerProcessReap
+}
+
+func (s *operatorStopProcessStore) ListActiveWorkerProcesses(context.Context) ([]store.WorkerProcess, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return append([]store.WorkerProcess(nil), s.processes...), nil
+}
+
+func (s *operatorStopProcessStore) MarkSessionWorkerProcessReaped(_ context.Context, sessionID int64, reap store.WorkerProcessReap) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.reaped = append(s.reaped, operatorStopProcessReap{sessionID: sessionID, reap: reap})
+	return nil
+}
+
+func (s *operatorStopProcessStore) setProcess(process store.WorkerProcess) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.processes = []store.WorkerProcess{process}
+}
+
+func (s *operatorStopProcessStore) reapedSnapshot() []operatorStopProcessReap {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return append([]operatorStopProcessReap(nil), s.reaped...)
+}
+
+func readOperatorStopPID(path string, timeout time.Duration) (int, error) {
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		raw, err := os.ReadFile(path)
+		if err == nil {
+			pid, parseErr := strconv.Atoi(strings.TrimSpace(string(raw)))
+			if parseErr == nil && pid > 0 {
+				return pid, nil
+			}
+		}
+		time.Sleep(time.Millisecond)
+	}
+	return 0, fmt.Errorf("timed out waiting for descendant PID at %s", path)
+}
+
+func waitForOperatorStopProcessExit(t *testing.T, pid int) {
+	t.Helper()
+	deadline := time.Now().Add(time.Second)
+	for time.Now().Before(deadline) {
+		if !operatorStopProcessAlive(pid) {
+			return
+		}
+		time.Sleep(time.Millisecond)
+	}
+	t.Fatalf("process %d is still alive", pid)
+}
+
+func operatorStopProcessAlive(pid int) bool {
+	if pid <= 0 {
+		return false
+	}
+	err := syscall.Kill(pid, 0)
+	return err == nil || errors.Is(err, syscall.EPERM)
+}
+
+func operatorStopShellQuote(value string) string {
+	return "'" + strings.ReplaceAll(value, "'", "'\"'\"'") + "'"
+}

--- a/internal/procgroup/process_group_unix.go
+++ b/internal/procgroup/process_group_unix.go
@@ -88,6 +88,9 @@ func Terminate(ctx context.Context, identity Identity, grace time.Duration) (Ter
 	if identity.PID <= 0 {
 		return TerminationOutcomeAlreadyExited, nil
 	}
+	if identity.GroupID <= 0 || identity.StartedAt.IsZero() {
+		return TerminationOutcomeStaleIdentity, nil
+	}
 
 	current, err := inspectProcess(identity.PID)
 	if err != nil && !errors.Is(err, ErrProcessNotRunning) {
@@ -97,9 +100,6 @@ func Terminate(ctx context.Context, identity Identity, grace time.Duration) (Ter
 		return TerminationOutcomeStaleIdentity, nil
 	}
 	groupID := identity.GroupID
-	if groupID <= 0 && err == nil {
-		groupID = current.GroupID
-	}
 	if !processTargetAlive(identity.PID, groupID) {
 		return TerminationOutcomeAlreadyExited, nil
 	}

--- a/internal/procgroup/process_group_unix_test.go
+++ b/internal/procgroup/process_group_unix_test.go
@@ -278,6 +278,33 @@ func TestInspectAndTerminate(t *testing.T) {
 			wantOutcome: TerminationOutcomeStaleIdentity,
 			wantAlive:   true,
 		},
+		{
+			name: "stale process group",
+			identity: func(identity Identity) Identity {
+				identity.GroupID++
+				return identity
+			},
+			wantOutcome: TerminationOutcomeStaleIdentity,
+			wantAlive:   true,
+		},
+		{
+			name: "missing process group",
+			identity: func(identity Identity) Identity {
+				identity.GroupID = 0
+				return identity
+			},
+			wantOutcome: TerminationOutcomeStaleIdentity,
+			wantAlive:   true,
+		},
+		{
+			name: "missing process start time",
+			identity: func(identity Identity) Identity {
+				identity.StartedAt = time.Time{}
+				return identity
+			},
+			wantOutcome: TerminationOutcomeStaleIdentity,
+			wantAlive:   true,
+		},
 	}
 
 	for _, tt := range tests {
@@ -312,6 +339,26 @@ func TestInspectAndTerminate(t *testing.T) {
 			_ = waitForExit(t, proc.WaitGroupMember)
 		})
 	}
+}
+
+func TestTerminateEscalatesSurvivingProcessGroup(t *testing.T) {
+	proc := startIgnoringTerminationGroup(t)
+	identity, err := Inspect(proc.cmd)
+	if err != nil {
+		t.Fatalf("Inspect() error = %v", err)
+	}
+	go func() { _ = proc.Wait() }()
+	go func() { _ = proc.WaitGroupMember() }()
+
+	outcome, err := Terminate(context.Background(), identity, 20*time.Millisecond)
+	if err != nil {
+		t.Fatalf("Terminate() error = %v", err)
+	}
+	if outcome != TerminationOutcomeTerminated {
+		t.Fatalf("Terminate() outcome = %q, want %q", outcome, TerminationOutcomeTerminated)
+	}
+	assertKilled(t, waitForExit(t, proc.Wait))
+	assertKilled(t, waitForExit(t, proc.WaitGroupMember))
 }
 
 type startedProcess struct {
@@ -381,6 +428,51 @@ func startSleepGroup(t *testing.T) *startedProcess {
 	}
 
 	return proc
+}
+
+func startIgnoringTerminationGroup(t *testing.T) *startedProcess {
+	t.Helper()
+
+	readyDir := t.TempDir()
+	leaderReady := readyDir + "/leader.ready"
+	memberReady := readyDir + "/member.ready"
+	cmd := exec.CommandContext(context.Background(), "sh", "-c", "trap '' TERM; : > \"$READY_PATH\"; exec sleep 30")
+	cmd.Env = append(os.Environ(), "READY_PATH="+leaderReady)
+	Configure(cmd)
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("Start() error = %v", err)
+	}
+	proc := &startedProcess{cmd: cmd}
+	pgid := GroupID(cmd)
+	member := exec.CommandContext(context.Background(), "sh", "-c", "trap '' TERM; : > \"$READY_PATH\"; exec sleep 30")
+	member.Env = append(os.Environ(), "READY_PATH="+memberReady)
+	member.SysProcAttr = &syscall.SysProcAttr{Setpgid: true, Pgid: pgid}
+	if err := member.Start(); err != nil {
+		_ = TerminateTree(cmd, pgid)
+		_ = proc.Wait()
+		t.Fatalf("Start() group member error = %v", err)
+	}
+	proc.groupMember = member
+	waitForProcessReadyFile(t, leaderReady)
+	waitForProcessReadyFile(t, memberReady)
+	t.Cleanup(func() {
+		_ = TerminateTree(cmd, pgid)
+		_ = proc.Wait()
+		_ = proc.WaitGroupMember()
+	})
+	return proc
+}
+
+func waitForProcessReadyFile(t *testing.T, path string) {
+	t.Helper()
+	deadline := time.Now().Add(time.Second)
+	for time.Now().Before(deadline) {
+		if _, err := os.Stat(path); err == nil {
+			return
+		}
+		time.Sleep(time.Millisecond)
+	}
+	t.Fatalf("timed out waiting for process readiness at %s", path)
 }
 
 func (p *startedProcess) Wait() error {


### PR DESCRIPTION
## Summary

- Reap the targeted persisted worker process group when an operator stops a run, with bounded SIGTERM-to-SIGKILL escalation.
- Keep the run claim and concurrency ownership until process-group exit is verified and the reap outcome is recorded.
- Refuse stale or incomplete PID, PGID, and OS start-time identities without signaling an unrelated process.

Fixes #1453

## UI Surface Contract

- [x] N/A, or the linked issue explicitly authorizes any high-impact UI surface, layout, density, first-viewport, or responsive visibility tradeoff. No UI surface changes are included.
- [x] Persistent top-of-screen messaging is explicitly authorized by the issue, or this PR does not add it.
- [x] Visual changes to primary operator screens include screenshot or browser verification below. No visual changes are included.

## Test Plan

- [x] `make check`
- [x] `go test -race ./internal/procgroup ./internal/orchestrator -count=1`
- [x] Repeat process lifecycle tests ten times.
- [x] Cross-compile targeted Linux and Windows test binaries.