### PR TITLE
fix(project): join startup rollback workers

### DIFF
--- a/.detent/skills/join-canceled-startup-rollback.md
+++ b/.detent/skills/join-canceled-startup-rollback.md
@@ -8,6 +8,6 @@ when_to_use: Use when shutdown returns while startup work still writes files, us
 
 1. Reproduce under the pressure mode that exposes the leak, such as coverage repetitions or the race suite. Record the resource touched after shutdown returns.
 2. Trace the writer to its owning worker and follow startup failure rollback. Check whether rollback passes an already-canceled context to stop, wait, or close operations.
-3. Preserve cancellation as the startup result, but derive cleanup with `context.WithoutCancel(ctx)`. Stop and join every started worker, close owned resources, and only then remove them from registries.
-4. Add a channel-driven regression test: block one started worker, cancel another startup, verify startup cannot finish before the worker is released, then verify the worker resource is closed before startup returns.
+3. Preserve cancellation as the startup result, but derive cleanup with a bounded timeout over `context.WithoutCancel(ctx)`. Stop and join every started worker, close owned resources, and only remove them from registries after cleanup completes; retain incomplete resources so their owner can retry closure.
+4. Add channel-driven regressions: verify normal rollback cannot finish before a blocked worker is released, then verify stalled rollback respects its cleanup bound without losing ownership of incomplete resources.
 5. Rerun the focused regression under `-race`, then repeat the original pressure reproduction with coverage before the full validation gate.

--- a/.detent/skills/join-canceled-startup-rollback.md
+++ b/.detent/skills/join-canceled-startup-rollback.md
@@ -1,0 +1,13 @@
+---
+name: join-canceled-startup-rollback
+description: Diagnose and fix service startup rollback that abandons already-started background workers when the startup context is canceled.
+when_to_use: Use when shutdown returns while startup work still writes files, uses a closed store, or recreates temporary directories after cancellation.
+---
+
+# Join canceled startup rollback
+
+1. Reproduce under the pressure mode that exposes the leak, such as coverage repetitions or the race suite. Record the resource touched after shutdown returns.
+2. Trace the writer to its owning worker and follow startup failure rollback. Check whether rollback passes an already-canceled context to stop, wait, or close operations.
+3. Preserve cancellation as the startup result, but derive cleanup with `context.WithoutCancel(ctx)`. Stop and join every started worker, close owned resources, and only then remove them from registries.
+4. Add a channel-driven regression test: block one started worker, cancel another startup, verify startup cannot finish before the worker is released, then verify the worker resource is closed before startup returns.
+5. Rerun the focused regression under `-race`, then repeat the original pressure reproduction with coverage before the full validation gate.

--- a/internal/project/manager.go
+++ b/internal/project/manager.go
@@ -23,7 +23,10 @@ var (
 	ErrProjectNotFound = errors.New("project not found")
 )
 
-const defaultMaxConcurrentStarts = 4
+const (
+	defaultMaxConcurrentStarts    = 4
+	defaultStartupRollbackTimeout = 5 * time.Second
+)
 
 type Factory func(globalconfig.Project) (*Project, error)
 
@@ -57,23 +60,25 @@ type rollbackProject struct {
 }
 
 type ManagerDependencies struct {
-	Registry            *Registry
-	ProjectFactory      Factory
-	ProjectDependencies Dependencies
-	Events              *hub.Hub[Event]
-	Logger              *slog.Logger
-	Sleep               func(context.Context, time.Duration) error
-	Jitter              func(time.Duration) time.Duration
+	Registry               *Registry
+	ProjectFactory         Factory
+	ProjectDependencies    Dependencies
+	Events                 *hub.Hub[Event]
+	Logger                 *slog.Logger
+	Sleep                  func(context.Context, time.Duration) error
+	Jitter                 func(time.Duration) time.Duration
+	StartupRollbackTimeout time.Duration
 }
 
 type Manager struct {
-	mu       sync.Mutex
-	cfg      ManagerConfig
-	registry *Registry
-	factory  Factory
-	sleep    func(context.Context, time.Duration) error
-	jitter   func(time.Duration) time.Duration
-	logger   *slog.Logger
+	mu                     sync.Mutex
+	cfg                    ManagerConfig
+	registry               *Registry
+	factory                Factory
+	sleep                  func(context.Context, time.Duration) error
+	jitter                 func(time.Duration) time.Duration
+	logger                 *slog.Logger
+	startupRollbackTimeout time.Duration
 
 	running bool
 	spawned bool
@@ -130,15 +135,20 @@ func NewManager(cfg ManagerConfig, deps ManagerDependencies) (*Manager, error) {
 	if logger == nil {
 		logger = slog.Default()
 	}
+	startupRollbackTimeout := deps.StartupRollbackTimeout
+	if startupRollbackTimeout <= 0 {
+		startupRollbackTimeout = defaultStartupRollbackTimeout
+	}
 
 	cfg = normalizeManagerConfig(cfg)
 	return &Manager{
-		cfg:      cfg,
-		registry: registry,
-		factory:  factory,
-		sleep:    sleep,
-		jitter:   jitter,
-		logger:   logger,
+		cfg:                    cfg,
+		registry:               registry,
+		factory:                factory,
+		sleep:                  sleep,
+		jitter:                 jitter,
+		logger:                 logger,
+		startupRollbackTimeout: startupRollbackTimeout,
 	}, nil
 }
 
@@ -609,15 +619,18 @@ func (m *Manager) rollbackInitialStart(
 	projects []*Project,
 	started []startedProject,
 ) error {
-	cleanupCtx := context.WithoutCancel(ctx)
+	cleanupCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), m.startupRollbackTimeout)
+	defer cancel()
 	cleanupErr := m.stopUncommittedStartedProjects(cleanupCtx, started)
 	cleanupErr = errors.Join(cleanupErr, closeProjectSlice(cleanupCtx, projects))
 
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	for _, id := range registered {
-		m.registry.Delete(id)
+	if cleanupCtx.Err() == nil {
+		for _, id := range registered {
+			m.registry.Delete(id)
+		}
 	}
 	m.running = false
 	m.spawned = false

--- a/internal/project/manager.go
+++ b/internal/project/manager.go
@@ -609,8 +609,9 @@ func (m *Manager) rollbackInitialStart(
 	projects []*Project,
 	started []startedProject,
 ) error {
-	cleanupErr := m.stopUncommittedStartedProjects(ctx, started)
-	cleanupErr = errors.Join(cleanupErr, closeProjectSlice(ctx, projects))
+	cleanupCtx := context.WithoutCancel(ctx)
+	cleanupErr := m.stopUncommittedStartedProjects(cleanupCtx, started)
+	cleanupErr = errors.Join(cleanupErr, closeProjectSlice(cleanupCtx, projects))
 
 	m.mu.Lock()
 	defer m.mu.Unlock()

--- a/internal/project/manager_test.go
+++ b/internal/project/manager_test.go
@@ -205,6 +205,88 @@ func TestManagerStartsProjectsWithBoundedConcurrency(t *testing.T) {
 	}
 }
 
+func TestManagerStartCancellationWaitsForStartedProjectCleanup(t *testing.T) {
+	t.Parallel()
+
+	events := hub.New[project.Event](hub.WithBuffer(4))
+	refreshStarted := make(chan struct{})
+	releaseRefresh := make(chan struct{})
+	alphaConnector := &blockingStartupConnector{
+		provisioningConnector: provisioningConnector{},
+		closeTracker:          newCloseTrackingConnector(),
+		refreshStarted:        refreshStarted,
+		releaseRefresh:        releaseRefresh,
+	}
+	manager, err := project.NewManager(project.ManagerConfig{
+		Projects: []globalconfig.Project{
+			{ID: "alpha", Weight: 1},
+			{ID: "bravo", Weight: 1},
+		},
+		Startup: project.StartupConfig{MaxConcurrentStarts: 2},
+	}, project.ManagerDependencies{
+		Events: events,
+		ProjectFactory: func(cfg globalconfig.Project) (*project.Project, error) {
+			workflowCfg := workflowConfig("memory")
+			workflowCfg.Tracker.AutoProvision = true
+			var currentConnector connector.Connector = provisioningConnector{
+				provision: func(ctx context.Context) error {
+					<-ctx.Done()
+					return ctx.Err()
+				},
+			}
+			if cfg.ID == "alpha" {
+				currentConnector = alphaConnector
+			}
+			return project.New(project.Config{
+				Project:  cfg,
+				Workflow: workflowconfig.Workflow{Config: workflowCfg},
+			}, project.Dependencies{
+				Connector: currentConnector,
+				Events:    events,
+				Runner:    blockingRunner{},
+			})
+		},
+		Sleep: func(context.Context, time.Duration) error {
+			return nil
+		},
+	})
+	if err != nil {
+		t.Fatalf("NewManager() error = %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() {
+		done <- manager.Start(ctx)
+	}()
+
+	select {
+	case <-refreshStarted:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for initial project refresh")
+	}
+	cancel()
+	select {
+	case err := <-done:
+		t.Fatalf("Manager.Start() returned before project refresh cleanup completed: %v", err)
+	default:
+	}
+
+	close(releaseRefresh)
+	select {
+	case err := <-done:
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("Manager.Start() error = %v, want %v", err, context.Canceled)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for manager startup rollback")
+	}
+	assertConnectorClosed(t, alphaConnector.closeTracker)
+	if manager.Registry().Len() != 0 {
+		t.Fatalf("Registry().Len() = %d, want 0", manager.Registry().Len())
+	}
+}
+
 func TestManagerLiveAddRemovePauseUnpause(t *testing.T) {
 	t.Parallel()
 
@@ -1459,6 +1541,30 @@ func TestManagerConfigFromGlobal(t *testing.T) {
 	if len(got.Projects[0].GlobalKnowledge.Sources) != 1 || got.Projects[0].GlobalKnowledge.Sources[0].Name != "Global" {
 		t.Fatalf("Projects[0].GlobalKnowledge = %#v, want global source", got.Projects[0].GlobalKnowledge)
 	}
+}
+
+type blockingStartupConnector struct {
+	provisioningConnector
+	closeTracker   *closeTrackingConnector
+	refreshStarted chan struct{}
+	releaseRefresh <-chan struct{}
+	startOnce      sync.Once
+}
+
+func (c *blockingStartupConnector) Name() string {
+	return "blocking-startup"
+}
+
+func (c *blockingStartupConnector) FetchCandidateIssues(context.Context) ([]connector.Issue, error) {
+	c.startOnce.Do(func() {
+		close(c.refreshStarted)
+	})
+	<-c.releaseRefresh
+	return nil, nil
+}
+
+func (c *blockingStartupConnector) Close() error {
+	return c.closeTracker.Close()
 }
 
 func newManagerTestProject(t *testing.T, cfg globalconfig.Project, events *hub.Hub[project.Event]) (*project.Project, error) {

--- a/internal/project/manager_test.go
+++ b/internal/project/manager_test.go
@@ -208,60 +208,16 @@ func TestManagerStartsProjectsWithBoundedConcurrency(t *testing.T) {
 func TestManagerStartCancellationWaitsForStartedProjectCleanup(t *testing.T) {
 	t.Parallel()
 
-	events := hub.New[project.Event](hub.WithBuffer(4))
-	refreshStarted := make(chan struct{})
-	releaseRefresh := make(chan struct{})
-	alphaConnector := &blockingStartupConnector{
-		provisioningConnector: provisioningConnector{},
-		closeTracker:          newCloseTrackingConnector(),
-		refreshStarted:        refreshStarted,
-		releaseRefresh:        releaseRefresh,
-	}
-	manager, err := project.NewManager(project.ManagerConfig{
-		Projects: []globalconfig.Project{
-			{ID: "alpha", Weight: 1},
-			{ID: "bravo", Weight: 1},
-		},
-		Startup: project.StartupConfig{MaxConcurrentStarts: 2},
-	}, project.ManagerDependencies{
-		Events: events,
-		ProjectFactory: func(cfg globalconfig.Project) (*project.Project, error) {
-			workflowCfg := workflowConfig("memory")
-			workflowCfg.Tracker.AutoProvision = true
-			var currentConnector connector.Connector = provisioningConnector{
-				provision: func(ctx context.Context) error {
-					<-ctx.Done()
-					return ctx.Err()
-				},
-			}
-			if cfg.ID == "alpha" {
-				currentConnector = alphaConnector
-			}
-			return project.New(project.Config{
-				Project:  cfg,
-				Workflow: workflowconfig.Workflow{Config: workflowCfg},
-			}, project.Dependencies{
-				Connector: currentConnector,
-				Events:    events,
-				Runner:    blockingRunner{},
-			})
-		},
-		Sleep: func(context.Context, time.Duration) error {
-			return nil
-		},
-	})
-	if err != nil {
-		t.Fatalf("NewManager() error = %v", err)
-	}
+	fixture := newBlockingStartupManager(t, time.Second)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	done := make(chan error, 1)
 	go func() {
-		done <- manager.Start(ctx)
+		done <- fixture.manager.Start(ctx)
 	}()
 
 	select {
-	case <-refreshStarted:
+	case <-fixture.refreshStarted:
 	case <-time.After(time.Second):
 		t.Fatal("timed out waiting for initial project refresh")
 	}
@@ -272,7 +228,7 @@ func TestManagerStartCancellationWaitsForStartedProjectCleanup(t *testing.T) {
 	default:
 	}
 
-	close(releaseRefresh)
+	close(fixture.releaseRefresh)
 	select {
 	case err := <-done:
 		if !errors.Is(err, context.Canceled) {
@@ -281,10 +237,50 @@ func TestManagerStartCancellationWaitsForStartedProjectCleanup(t *testing.T) {
 	case <-time.After(time.Second):
 		t.Fatal("timed out waiting for manager startup rollback")
 	}
-	assertConnectorClosed(t, alphaConnector.closeTracker)
-	if manager.Registry().Len() != 0 {
-		t.Fatalf("Registry().Len() = %d, want 0", manager.Registry().Len())
+	assertConnectorClosed(t, fixture.alphaConnector.closeTracker)
+	if fixture.manager.Registry().Len() != 0 {
+		t.Fatalf("Registry().Len() = %d, want 0", fixture.manager.Registry().Len())
 	}
+}
+
+func TestManagerStartCancellationBoundsStalledProjectCleanup(t *testing.T) {
+	t.Parallel()
+
+	fixture := newBlockingStartupManager(t, 20*time.Millisecond)
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() {
+		done <- fixture.manager.Start(ctx)
+	}()
+
+	select {
+	case <-fixture.refreshStarted:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for initial project refresh")
+	}
+	cancel()
+	select {
+	case err := <-done:
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("Manager.Start() error = %v, want %v", err, context.Canceled)
+		}
+		if !errors.Is(err, context.DeadlineExceeded) {
+			t.Fatalf("Manager.Start() error = %v, want %v", err, context.DeadlineExceeded)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for bounded manager startup rollback")
+	}
+	if fixture.manager.Registry().Len() != 2 {
+		t.Fatalf("Registry().Len() = %d, want 2 retained projects", fixture.manager.Registry().Len())
+	}
+
+	close(fixture.releaseRefresh)
+	for _, runtimeProject := range fixture.manager.Registry().List() {
+		if err := runtimeProject.Close(); err != nil {
+			t.Fatalf("Close() error = %v", err)
+		}
+	}
+	assertConnectorClosed(t, fixture.alphaConnector.closeTracker)
 }
 
 func TestManagerLiveAddRemovePauseUnpause(t *testing.T) {
@@ -1565,6 +1561,71 @@ func (c *blockingStartupConnector) FetchCandidateIssues(context.Context) ([]conn
 
 func (c *blockingStartupConnector) Close() error {
 	return c.closeTracker.Close()
+}
+
+type blockingStartupManager struct {
+	manager        *project.Manager
+	alphaConnector *blockingStartupConnector
+	refreshStarted <-chan struct{}
+	releaseRefresh chan struct{}
+}
+
+func newBlockingStartupManager(t *testing.T, rollbackTimeout time.Duration) blockingStartupManager {
+	t.Helper()
+
+	events := hub.New[project.Event](hub.WithBuffer(4))
+	refreshStarted := make(chan struct{})
+	releaseRefresh := make(chan struct{})
+	alphaConnector := &blockingStartupConnector{
+		provisioningConnector: provisioningConnector{},
+		closeTracker:          newCloseTrackingConnector(),
+		refreshStarted:        refreshStarted,
+		releaseRefresh:        releaseRefresh,
+	}
+	manager, err := project.NewManager(project.ManagerConfig{
+		Projects: []globalconfig.Project{
+			{ID: "alpha", Weight: 1},
+			{ID: "bravo", Weight: 1},
+		},
+		Startup: project.StartupConfig{MaxConcurrentStarts: 2},
+	}, project.ManagerDependencies{
+		Events:                 events,
+		StartupRollbackTimeout: rollbackTimeout,
+		ProjectFactory: func(cfg globalconfig.Project) (*project.Project, error) {
+			workflowCfg := workflowConfig("memory")
+			workflowCfg.Tracker.AutoProvision = true
+			var currentConnector connector.Connector = provisioningConnector{
+				provision: func(ctx context.Context) error {
+					<-ctx.Done()
+					return ctx.Err()
+				},
+			}
+			if cfg.ID == "alpha" {
+				currentConnector = alphaConnector
+			}
+			return project.New(project.Config{
+				Project:  cfg,
+				Workflow: workflowconfig.Workflow{Config: workflowCfg},
+			}, project.Dependencies{
+				Connector: currentConnector,
+				Events:    events,
+				Runner:    blockingRunner{},
+			})
+		},
+		Sleep: func(context.Context, time.Duration) error {
+			return nil
+		},
+	})
+	if err != nil {
+		t.Fatalf("NewManager() error = %v", err)
+	}
+
+	return blockingStartupManager{
+		manager:        manager,
+		alphaConnector: alphaConnector,
+		refreshStarted: refreshStarted,
+		releaseRefresh: releaseRefresh,
+	}
 }
 
 func newManagerTestProject(t *testing.T, cfg globalconfig.Project, events *hub.Hub[project.Event]) (*project.Project, error) {


### PR DESCRIPTION
## Summary
- join started projects during canceled manager startup rollback
- bound detached cleanup and retain incomplete projects for owner-driven closure
- add deterministic cleanup-ordering and stalled-cleanup regressions plus a reusable debugging skill draft

Fixes #1471

## Test Plan
- go test ./internal/project -run TestManagerStartCancellation -count=20
- go test ./internal/cli -run TestStartScreenshotsDemoServesScenarioManifestAndUsage -coverprofile=<temp>/cli-review-fixed.cover -count=100
- go test ./internal/project ./internal/cli -run focused-regressions -race -count=10
- make check (four total passes; latest two after review changes at 77.5% coverage)