### PR TITLE
test(cli): stabilize startup snapshot wait

### DIFF
--- a/internal/cli/boot_test.go
+++ b/internal/cli/boot_test.go
@@ -913,12 +913,8 @@ func TestStartRunningPublishesStartupSnapshotBeforeProjectStartCompletes(t *test
 		})
 	}()
 
-	select {
-	case <-provisionStarted:
-	case err := <-done:
-		t.Fatalf("startRunning returned before provisioning blocked: %v", err)
-	case <-time.After(10 * time.Second):
-		t.Fatal("timed out waiting for project provisioning to start")
+	if err := awaitProjectProvisioningStart(provisionStarted, done, output, bootProvisioningStartTimeout); err != nil {
+		t.Fatal(err)
 	}
 
 	baseURL := waitForBootDashboardURL(t, output, done)


### PR DESCRIPTION
## Summary

- reuse the slow-CI provisioning wait for the startup snapshot ordering test
- preserve blocked provisioning while adding distinct early-exit and delayed-start diagnostics

Fixes #1465

## UI Surface Contract

- [x] N/A, or the linked issue explicitly authorizes any high-impact UI surface, layout, density, first-viewport, or responsive visibility tradeoff.
- [x] Persistent top-of-screen messaging is explicitly authorized by the issue, or this PR does not add it.
- [x] Visual changes to primary operator screens include screenshot or browser verification below.

## Test Plan

- [x] `go test -race ./internal/cli -run '^(TestStartRunningPublishesStartupSnapshotBeforeProjectStartCompletes|TestAwaitProjectProvisioningStart)$' -count=20`
- [x] `make check`