### PR TITLE
fix(gate): break unchanged redispatch loop

### DIFF
--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -54,6 +54,7 @@ type doctorCheck struct {
 	AutoPromoteCandidates     []doctorAutoPromoteCandidateDiagnostic     `json:"auto_promote_candidates,omitempty"`
 	BlockedRecoveryCandidates []doctorBlockedRecoveryCandidateDiagnostic `json:"blocked_recovery_candidates,omitempty"`
 	BackendCapacity           []doctorBackendCapacityDiagnostic          `json:"backend_capacity,omitempty"`
+	ArtifactGateConvergence   []doctorArtifactGateConvergenceDiagnostic  `json:"artifact_gate_convergence,omitempty"`
 	ValidatorFailures         []doctorValidatorFailureDiagnostic         `json:"validator_failures,omitempty"`
 	Routines                  []doctorRoutineDiagnostic                  `json:"routines,omitempty"`
 	OverloadRetriesLastHour   int                                        `json:"overload_retries_last_hour,omitempty"`
@@ -457,6 +458,12 @@ func runDoctor(ctx context.Context, cfg doctorConfig, opts options, deps doctorD
 			Name: "Backend capacity",
 			Run: func(jobCtx context.Context) []doctorCheck {
 				return []doctorCheck{checkDoctorBackendCapacity(jobCtx, resolution, boot, cfg.ProjectID, deps, time.Now())}
+			},
+		},
+		doctorCheckJob{
+			Name: "Artifact gate convergence",
+			Run: func(jobCtx context.Context) []doctorCheck {
+				return []doctorCheck{checkDoctorArtifactGateConvergence(jobCtx, resolution, cfg.ProjectID, deps)}
 			},
 		},
 	)

--- a/internal/cli/doctor_artifact_gate_convergence.go
+++ b/internal/cli/doctor_artifact_gate_convergence.go
@@ -1,0 +1,160 @@
+package cli
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+
+	globalconfig "github.com/digitaldrywood/detent/internal/config/global"
+)
+
+const doctorArtifactGateConvergenceSampleLimit = 200
+
+type doctorArtifactGateConvergenceDiagnostic struct {
+	ProjectID          string `json:"project_id"`
+	IssueID            string `json:"issue_id,omitempty"`
+	Identifier         string `json:"identifier,omitempty"`
+	StatusField        string `json:"status_field"`
+	UnchangedStatus    string `json:"unchanged_status"`
+	ConsecutiveSuccess int    `json:"consecutive_successes"`
+	Limit              int    `json:"limit"`
+	CompletedAt        string `json:"completed_at"`
+}
+
+type doctorArtifactGateConvergenceRecord struct {
+	StatusField          string `json:"status_field"`
+	CompletionStatus     string `json:"completion_status"`
+	ConsecutiveUnchanged int    `json:"consecutive_unchanged"`
+	Limit                int    `json:"limit"`
+	Tripped              bool   `json:"tripped"`
+}
+
+func checkDoctorArtifactGateConvergence(
+	ctx context.Context,
+	resolution globalconfig.PathResolution,
+	projectID string,
+	deps doctorDeps,
+) doctorCheck {
+	const name = "Artifact gate convergence"
+	storePath := doctorRuntimeStorePath(resolution.Path)
+	if storePath == "" {
+		return doctorCheck{Name: name, Status: doctorOK, Detail: "artifact gate convergence telemetry is unavailable without a runtime store"}
+	}
+	deps = deps.withDefaults()
+	db, err := deps.openSQLiteReadOnly(ctx, storePath)
+	if err != nil {
+		if errors.Is(err, errDoctorTelemetryStoreUnavailable) {
+			return doctorCheck{Name: name, Status: doctorOK, Detail: "no artifact gate convergence telemetry recorded yet"}
+		}
+		return doctorCheck{Name: name, Status: doctorWarn, Detail: fmt.Sprintf("artifact gate convergence telemetry could not be read: %v", err)}
+	}
+	diagnostics, queryErr := doctorArtifactGateConvergenceDiagnostics(ctx, db, projectID)
+	closeErr := db.Close()
+	if queryErr != nil {
+		if strings.Contains(strings.ToLower(queryErr.Error()), "no such table") {
+			return doctorCheck{Name: name, Status: doctorOK, Detail: "no artifact gate convergence telemetry recorded yet"}
+		}
+		return doctorCheck{Name: name, Status: doctorWarn, Detail: fmt.Sprintf("artifact gate convergence telemetry query failed: %v", queryErr)}
+	}
+	if closeErr != nil {
+		return doctorCheck{Name: name, Status: doctorWarn, Detail: fmt.Sprintf("artifact gate convergence telemetry close failed: %v", closeErr)}
+	}
+	if len(diagnostics) == 0 {
+		return doctorCheck{Name: name, Status: doctorOK, Detail: "no latest artifact gate convergence outcomes are breaker trips"}
+	}
+	latest := diagnostics[0]
+	latestIssue := strings.TrimSpace(latest.Identifier)
+	if latestIssue == "" {
+		latestIssue = strings.TrimSpace(latest.IssueID)
+	}
+	return doctorCheck{
+		Name:   name,
+		Status: doctorWarn,
+		Detail: fmt.Sprintf(
+			"the latest artifact gate convergence outcome for %d item(s) is a breaker trip; latest %s at %s after %d unchanged successful attempts",
+			len(diagnostics),
+			latestIssue,
+			latest.CompletedAt,
+			latest.ConsecutiveSuccess,
+		),
+		Hint:                    "Verify each item state; when still Blocked, review the artifact and update its configured gate status before recovery.",
+		ArtifactGateConvergence: diagnostics,
+	}
+}
+
+func doctorArtifactGateConvergenceDiagnostics(
+	ctx context.Context,
+	db doctorTelemetryStore,
+	projectID string,
+) ([]doctorArtifactGateConvergenceDiagnostic, error) {
+	projectID = strings.TrimSpace(projectID)
+	rows, err := db.QueryContext(ctx, `
+WITH ranked AS (
+  SELECT project_id, issue_id, identifier, completed_at, worker_metadata_json,
+    ROW_NUMBER() OVER (
+      PARTITION BY project_id, COALESCE(NULLIF(TRIM(issue_id), ''), NULLIF(TRIM(identifier), ''), CAST(id AS TEXT))
+      ORDER BY completed_at DESC, id DESC
+    ) AS row_num
+  FROM work_attempts
+  WHERE terminal_state = 'success'
+    AND worker_metadata_json LIKE '%"artifact_gate_convergence"%'
+    AND (? = '' OR project_id = ?)
+)
+SELECT project_id, issue_id, identifier, completed_at, worker_metadata_json
+FROM ranked
+WHERE row_num = 1
+ORDER BY completed_at DESC
+LIMIT ?`, projectID, projectID, doctorArtifactGateConvergenceSampleLimit)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	diagnostics := []doctorArtifactGateConvergenceDiagnostic{}
+	seen := map[string]struct{}{}
+	for rows.Next() {
+		var rowProjectID string
+		var issueID sql.NullString
+		var identifier sql.NullString
+		var completedAt sql.NullString
+		var metadataJSON string
+		if err := rows.Scan(&rowProjectID, &issueID, &identifier, &completedAt, &metadataJSON); err != nil {
+			return nil, err
+		}
+		identity := strings.TrimSpace(issueID.String)
+		if identity == "" {
+			identity = strings.TrimSpace(identifier.String)
+		}
+		key := strings.TrimSpace(rowProjectID) + "\x00" + identity
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		seen[key] = struct{}{}
+		var root struct {
+			Record doctorArtifactGateConvergenceRecord `json:"artifact_gate_convergence"`
+		}
+		if err := json.Unmarshal([]byte(strings.TrimSpace(metadataJSON)), &root); err != nil || strings.TrimSpace(root.Record.StatusField) == "" {
+			continue
+		}
+		if !root.Record.Tripped {
+			continue
+		}
+		diagnostics = append(diagnostics, doctorArtifactGateConvergenceDiagnostic{
+			ProjectID:          strings.TrimSpace(rowProjectID),
+			IssueID:            strings.TrimSpace(issueID.String),
+			Identifier:         strings.TrimSpace(identifier.String),
+			StatusField:        strings.TrimSpace(root.Record.StatusField),
+			UnchangedStatus:    strings.TrimSpace(root.Record.CompletionStatus),
+			ConsecutiveSuccess: root.Record.ConsecutiveUnchanged,
+			Limit:              root.Record.Limit,
+			CompletedAt:        strings.TrimSpace(completedAt.String),
+		})
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return diagnostics, nil
+}

--- a/internal/cli/doctor_artifact_gate_convergence_test.go
+++ b/internal/cli/doctor_artifact_gate_convergence_test.go
@@ -1,0 +1,108 @@
+package cli
+
+import (
+	"database/sql"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	globalconfig "github.com/digitaldrywood/detent/internal/config/global"
+)
+
+func TestCheckDoctorArtifactGateConvergence(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "detent.db")
+	db, err := sql.Open("sqlite", dbPath)
+	if err != nil {
+		t.Fatalf("sql.Open() error = %v", err)
+	}
+	t.Cleanup(func() {
+		if db == nil {
+			return
+		}
+		if err := db.Close(); err != nil {
+			t.Errorf("db.Close() error = %v", err)
+		}
+	})
+	if _, err := db.Exec(`CREATE TABLE work_attempts (
+  id INTEGER PRIMARY KEY,
+  project_id TEXT NOT NULL,
+  issue_id TEXT,
+  identifier TEXT,
+  terminal_state TEXT,
+  completed_at TEXT,
+  worker_metadata_json TEXT NOT NULL DEFAULT '{}'
+)`); err != nil {
+		t.Fatalf("create work_attempts: %v", err)
+	}
+	insertDoctorArtifactGateAttempt(t, db, "video", "issue-active", "video#47", "2026-07-19T14:00:00Z", true, 3)
+	insertDoctorArtifactGateAttempt(t, db, "video", "issue-resolved", "video#48", "2026-07-19T13:00:00Z", false, 0)
+	insertDoctorArtifactGateAttempt(t, db, "video", "issue-resolved", "video#48", "2026-07-19T12:00:00Z", true, 3)
+	insertDoctorArtifactGateAttempt(t, db, "other", "issue-other", "other#49", "2026-07-19T15:00:00Z", true, 4)
+	noisyBase := time.Date(2026, 7, 20, 0, 0, 0, 0, time.UTC)
+	for index := range doctorArtifactGateConvergenceSampleLimit + 1 {
+		insertDoctorArtifactGateAttempt(t, db, "video", "issue-noisy", "video#50", noisyBase.Add(time.Duration(index)*time.Second).Format(time.RFC3339), false, 1)
+	}
+	if err := db.Close(); err != nil {
+		t.Fatalf("db.Close() before read-only check error = %v", err)
+	}
+	db = nil
+
+	check := checkDoctorArtifactGateConvergence(t.Context(), globalconfig.PathResolution{
+		Path: filepath.Join(dir, "global.yaml"),
+	}, "video", doctorDeps{openSQLiteReadOnly: openDoctorSQLiteReadOnly})
+
+	if check.Status != doctorWarn {
+		t.Fatalf("Status = %s, want %s; detail = %q", check.Status, doctorWarn, check.Detail)
+	}
+	if len(check.ArtifactGateConvergence) != 1 {
+		t.Fatalf("ArtifactGateConvergence = %#v, want one active finding", check.ArtifactGateConvergence)
+	}
+	diagnostic := check.ArtifactGateConvergence[0]
+	if diagnostic.ProjectID != "video" || diagnostic.IssueID != "issue-active" || diagnostic.Identifier != "video#47" {
+		t.Fatalf("diagnostic identity = %#v, want video issue-active", diagnostic)
+	}
+	if diagnostic.StatusField != "render_status" || diagnostic.UnchangedStatus != "recut" || diagnostic.ConsecutiveSuccess != 3 || diagnostic.Limit != 3 {
+		t.Fatalf("diagnostic convergence = %#v, want render_status recut 3/3", diagnostic)
+	}
+	if !strings.Contains(check.Detail, "video#47") || !strings.Contains(check.Hint, "Blocked") {
+		t.Fatalf("check = %#v, want actionable issue detail", check)
+	}
+}
+
+func TestCheckDoctorArtifactGateConvergenceWithoutTrips(t *testing.T) {
+	t.Parallel()
+
+	check := checkDoctorArtifactGateConvergence(t.Context(), globalconfig.PathResolution{}, "", doctorDeps{})
+	if check.Status != doctorOK || len(check.ArtifactGateConvergence) != 0 {
+		t.Fatalf("check = %#v, want unavailable telemetry to be OK", check)
+	}
+}
+
+func insertDoctorArtifactGateAttempt(
+	t *testing.T,
+	db *sql.DB,
+	projectID string,
+	issueID string,
+	identifier string,
+	completedAt string,
+	tripped bool,
+	consecutive int,
+) {
+	t.Helper()
+	metadata := `{"artifact_gate_convergence":{"status_field":"render_status","dispatch_status":"recut","completion_status":"recut","unchanged":true,"consecutive_unchanged":` + strconv.Itoa(consecutive) + `,"limit":3,"tripped":` + strconv.FormatBool(tripped) + `}}`
+	if _, err := db.Exec(
+		`INSERT INTO work_attempts (project_id, issue_id, identifier, terminal_state, completed_at, worker_metadata_json) VALUES (?, ?, ?, 'success', ?, ?)`,
+		projectID,
+		issueID,
+		identifier,
+		completedAt,
+		metadata,
+	); err != nil {
+		t.Fatalf("insert work attempt: %v", err)
+	}
+}

--- a/internal/orchestrator/artifact_completion.go
+++ b/internal/orchestrator/artifact_completion.go
@@ -2,13 +2,36 @@ package orchestrator
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
+	"strconv"
 	"strings"
+	"time"
 
 	"github.com/digitaldrywood/detent/internal/connector"
 	"github.com/digitaldrywood/detent/internal/gate"
+	"github.com/digitaldrywood/detent/internal/store"
+	"github.com/digitaldrywood/detent/internal/telemetry"
 	"github.com/digitaldrywood/detent/internal/workpad"
 )
+
+const (
+	artifactGateConvergenceLimit               = 3
+	artifactGateConvergenceMetadataKey         = "artifact_gate_convergence"
+	artifactGateConvergenceReason              = "artifact_gate_convergence_breaker"
+	artifactGateConvergenceBlockedReasonPrefix = "artifact gate convergence breaker: "
+)
+
+type artifactGateConvergenceRecord struct {
+	StatusField          string `json:"status_field"`
+	DispatchStatus       string `json:"dispatch_status"`
+	CompletionStatus     string `json:"completion_status"`
+	Unchanged            bool   `json:"unchanged"`
+	ConsecutiveUnchanged int    `json:"consecutive_unchanged"`
+	Limit                int    `json:"limit"`
+	Tripped              bool   `json:"tripped,omitempty"`
+	Warning              string `json:"warning,omitempty"`
+}
 
 func (o *Orchestrator) applyArtifactGateCompletionFields(
 	ctx context.Context,
@@ -165,25 +188,216 @@ func (o *Orchestrator) artifactGateDispatchWorkpadSnapshot(ctx context.Context, 
 	return artifactGateWorkpadStatusHash(comments), true
 }
 
-func (o *Orchestrator) warnUnchangedArtifactGateCompletion(ctx context.Context, dispatched connector.Issue, completed connector.Issue) {
-	if o == nil || o.logger == nil {
-		return
+func (o *Orchestrator) evaluateArtifactGateConvergence(
+	ctx context.Context,
+	dispatched connector.Issue,
+	completed connector.Issue,
+	running Running,
+) artifactGateConvergenceRecord {
+	if o == nil {
+		return artifactGateConvergenceRecord{}
 	}
 	gateConfig := gate.Effective(o.cfg.AutoPromote.Gate)
 	if gateConfig.Kind != gate.KindArtifact {
-		return
+		return artifactGateConvergenceRecord{}
 	}
-	statusField := gateConfig.Artifact.StatusField
+	statusField := strings.TrimSpace(gateConfig.Artifact.StatusField)
 	dispatchStatus, _ := artifactStatusFieldFromIssue(dispatched, statusField)
 	completionStatus, _ := artifactStatusFieldFromIssue(completed, statusField)
-	if !strings.EqualFold(strings.TrimSpace(dispatchStatus), strings.TrimSpace(completionStatus)) {
+	record := artifactGateConvergenceRecord{
+		StatusField:      statusField,
+		DispatchStatus:   strings.TrimSpace(dispatchStatus),
+		CompletionStatus: strings.TrimSpace(completionStatus),
+		Limit:            artifactGateConvergenceLimit,
+	}
+	record.Unchanged = strings.EqualFold(record.DispatchStatus, record.CompletionStatus)
+	if !record.Unchanged {
+		return record
+	}
+
+	record.ConsecutiveUnchanged = 1
+	attempts, err := o.recentArtifactGateConvergenceAttempts(ctx, completed, running)
+	if err != nil {
+		record.Warning = err.Error()
+		if o.logger != nil {
+			o.logger.WarnContext(ctx, "artifact gate convergence history lookup failed",
+				"issue_id", completed.ID,
+				"identifier", completed.Identifier,
+				"status_field", statusField,
+				"error", err,
+			)
+		}
+	} else {
+		record.ConsecutiveUnchanged += consecutiveArtifactGateConvergenceAttempts(attempts, record)
+	}
+	record.Tripped = record.ConsecutiveUnchanged >= record.Limit
+	if o.logger != nil {
+		o.logger.WarnContext(ctx, "artifact gate completion left status field unchanged",
+			"issue_id", completed.ID,
+			"identifier", completed.Identifier,
+			"status_field", statusField,
+			"dispatch_status", dispatchStatus,
+			"completion_status", completionStatus,
+			"consecutive_unchanged", record.ConsecutiveUnchanged,
+			"limit", record.Limit,
+			"tripped", record.Tripped,
+		)
+	}
+	return record
+}
+
+func (o *Orchestrator) recentArtifactGateConvergenceAttempts(
+	ctx context.Context,
+	issue connector.Issue,
+	running Running,
+) ([]store.WorkAttempt, error) {
+	if o == nil || o.workAttempts == nil {
+		return nil, nil
+	}
+	return o.workAttempts.ListRecentTerminalWorkAttempts(ctx, store.WorkAttemptHistoryQuery{
+		ProjectID:  strings.TrimSpace(o.cfg.Project.ID),
+		IssueID:    strings.TrimSpace(issue.ID),
+		Identifier: strings.TrimSpace(issue.Identifier),
+		IssueURL:   strings.TrimSpace(issue.URL),
+		WorkerType: workAttemptWorkerType(issue, running.Mode),
+		Limit:      artifactGateConvergenceLimit + 1,
+	})
+}
+
+func consecutiveArtifactGateConvergenceAttempts(attempts []store.WorkAttempt, current artifactGateConvergenceRecord) int {
+	count := 0
+	for _, attempt := range attempts {
+		if attempt.TerminalState != store.WorkAttemptTerminalSuccess {
+			return count
+		}
+		record, ok := artifactGateConvergenceRecordFromAttempt(attempt)
+		if !ok || !record.Unchanged ||
+			!strings.EqualFold(strings.TrimSpace(record.StatusField), strings.TrimSpace(current.StatusField)) ||
+			!strings.EqualFold(strings.TrimSpace(record.DispatchStatus), strings.TrimSpace(current.DispatchStatus)) ||
+			!strings.EqualFold(strings.TrimSpace(record.CompletionStatus), strings.TrimSpace(current.CompletionStatus)) {
+			return count
+		}
+		count++
+	}
+	return count
+}
+
+func artifactGateConvergenceRecordFromAttempt(attempt store.WorkAttempt) (artifactGateConvergenceRecord, bool) {
+	var root struct {
+		Record artifactGateConvergenceRecord `json:"artifact_gate_convergence"`
+	}
+	if err := json.Unmarshal([]byte(strings.TrimSpace(attempt.WorkerMetadataJSON)), &root); err != nil {
+		return artifactGateConvergenceRecord{}, false
+	}
+	if strings.TrimSpace(root.Record.StatusField) == "" || root.Record.Limit <= 0 {
+		return artifactGateConvergenceRecord{}, false
+	}
+	return root.Record, true
+}
+
+func artifactGateConvergenceMetadata(record artifactGateConvergenceRecord) map[string]any {
+	if strings.TrimSpace(record.StatusField) == "" {
+		return nil
+	}
+	return map[string]any{artifactGateConvergenceMetadataKey: record}
+}
+
+func (o *Orchestrator) parkArtifactGateConvergence(
+	ctx context.Context,
+	state *State,
+	issue connector.Issue,
+	attempt int,
+	completedAt time.Time,
+	record artifactGateConvergenceRecord,
+) {
+	if state == nil {
 		return
 	}
-	o.logger.WarnContext(ctx, "artifact gate completion left status field unchanged",
-		"issue_id", completed.ID,
-		"identifier", completed.Identifier,
-		"status_field", statusField,
-		"dispatch_status", dispatchStatus,
-		"completion_status", completionStatus,
+	issue = cloneIssue(issue)
+	if err := o.updateIssueState(ctx, state, issue, blockedStatusState, completedAt, artifactGateConvergenceReason); err != nil {
+		if o.logger != nil {
+			o.logger.WarnContext(ctx, "artifact gate convergence breaker state transition failed",
+				"issue_id", issue.ID,
+				"identifier", issue.Identifier,
+				"target_state", blockedStatusState,
+				"error", err,
+			)
+		}
+	} else {
+		issue.State = blockedStatusState
+	}
+	if o.connector != nil {
+		body := artifactGateConvergenceComment(issue, attempt, record)
+		if err := o.connector.CreateComment(ctx, issue.ID, body); err != nil && o.logger != nil {
+			o.logger.WarnContext(ctx, "artifact gate convergence breaker comment failed", "issue_id", issue.ID, "identifier", issue.Identifier, "error", err)
+		}
+	}
+	if err := o.abandonClaim(ctx, issue.ID); err != nil && o.logger != nil {
+		o.logger.WarnContext(ctx, "artifact gate convergence breaker claim release failed", "issue_id", issue.ID, "identifier", issue.Identifier, "error", err)
+	}
+	delete(state.Claimed, issue.ID)
+	delete(state.Completed, issue.ID)
+	delete(state.Retry, issue.ID)
+	delete(state.BudgetRefusals, issue.ID)
+	delete(state.PriorAttempts, issue.ID)
+	if state.Blocked == nil {
+		state.Blocked = map[string]Blocked{}
+	}
+	state.Blocked[issue.ID] = Blocked{
+		Issue:          issue,
+		Reason:         artifactGateConvergenceBlockedReason(record),
+		RecoveryReason: "review the artifact and update the configured gate status before moving the item out of Blocked",
+		RecoveryTarget: autoPromoteReworkState,
+		BlockedAt:      completedAt,
+		Source:         BlockedSourceProjectStatus,
+	}
+	recordStateEvent(state, telemetry.ActivityEvent{
+		At:      completedAt,
+		Event:   artifactGateConvergenceReason,
+		Message: "parked " + issueLabel(issue) + " after repeated successful attempts left the artifact gate status unchanged",
+	})
+	if o.logger != nil {
+		o.logger.WarnContext(ctx, "artifact gate convergence breaker tripped",
+			"event", artifactGateConvergenceReason,
+			"issue_id", issue.ID,
+			"identifier", issue.Identifier,
+			"attempt", attempt,
+			"status_field", record.StatusField,
+			"status", record.CompletionStatus,
+			"consecutive_unchanged", record.ConsecutiveUnchanged,
+			"limit", record.Limit,
+			"target_state", blockedStatusState,
+		)
+	}
+}
+
+func artifactGateConvergenceBlockedReason(record artifactGateConvergenceRecord) string {
+	return artifactGateConvergenceBlockedReasonPrefix + fmt.Sprintf(
+		"%s remained %s after %d consecutive successful attempts",
+		strings.TrimSpace(record.StatusField),
+		strconv.Quote(strings.TrimSpace(record.CompletionStatus)),
+		record.ConsecutiveUnchanged,
 	)
+}
+
+func artifactGateConvergenceComment(issue connector.Issue, attempt int, record artifactGateConvergenceRecord) string {
+	var b strings.Builder
+	b.WriteString("Detent stopped redispatching this item after ")
+	b.WriteString(strconv.Itoa(record.ConsecutiveUnchanged))
+	b.WriteString(" consecutive successful attempts left the configured artifact gate status unchanged.")
+	b.WriteString("\n\nIssue parked in `")
+	b.WriteString(strings.TrimSpace(issue.State))
+	b.WriteString("`.")
+	b.WriteString("\n\n- issue: ")
+	b.WriteString(issueLabel(issue))
+	b.WriteString("\n- latest_attempt: ")
+	b.WriteString(strconv.Itoa(attempt))
+	b.WriteString("\n- status_field: `")
+	b.WriteString(strings.TrimSpace(record.StatusField))
+	b.WriteString("`")
+	b.WriteString("\n- unchanged_status: `")
+	b.WriteString(strings.TrimSpace(record.CompletionStatus))
+	b.WriteString("`")
+	b.WriteString("\n\nReview the artifact and set the configured field to the appropriate pass or wait status before moving the item out of Blocked. If further rework is required, correct the worker instructions before moving it back to Rework; another unchanged success will remain breaker-protected.")
+	return b.String()
 }

--- a/internal/orchestrator/artifact_completion.go
+++ b/internal/orchestrator/artifact_completion.go
@@ -267,11 +267,10 @@ func (o *Orchestrator) recentArtifactGateConvergenceAttempts(
 func consecutiveArtifactGateConvergenceAttempts(attempts []store.WorkAttempt, current artifactGateConvergenceRecord) int {
 	count := 0
 	for _, attempt := range attempts {
-		if attempt.TerminalState != store.WorkAttemptTerminalSuccess {
-			return count
-		}
 		record, ok := artifactGateConvergenceRecordFromAttempt(attempt)
-		if !ok || !record.Unchanged ||
+		if !ok ||
+			(attempt.TerminalState != store.WorkAttemptTerminalSuccess && attempt.TerminalState != store.WorkAttemptTerminalNoProgress) ||
+			!record.Unchanged ||
 			!strings.EqualFold(strings.TrimSpace(record.StatusField), strings.TrimSpace(current.StatusField)) ||
 			!strings.EqualFold(strings.TrimSpace(record.DispatchStatus), strings.TrimSpace(current.DispatchStatus)) ||
 			!strings.EqualFold(strings.TrimSpace(record.CompletionStatus), strings.TrimSpace(current.CompletionStatus)) {

--- a/internal/orchestrator/artifact_completion_test.go
+++ b/internal/orchestrator/artifact_completion_test.go
@@ -186,7 +186,7 @@ func TestHandleRunResultParksThirdUnchangedArtifactGateSuccess(t *testing.T) {
 			IssueID:            issue.ID,
 			Identifier:         issue.Identifier,
 			WorkerType:         "agent",
-			TerminalState:      store.WorkAttemptTerminalSuccess,
+			TerminalState:      store.WorkAttemptTerminalNoProgress,
 			CompletedAt:        now.Add(-time.Minute),
 			WorkerMetadataJSON: `{"artifact_gate_convergence":{"status_field":"render_status","dispatch_status":"recut","completion_status":"recut","unchanged":true,"consecutive_unchanged":2,"limit":3}}`,
 		},
@@ -195,7 +195,7 @@ func TestHandleRunResultParksThirdUnchangedArtifactGateSuccess(t *testing.T) {
 			IssueID:            issue.ID,
 			Identifier:         issue.Identifier,
 			WorkerType:         "agent",
-			TerminalState:      store.WorkAttemptTerminalSuccess,
+			TerminalState:      store.WorkAttemptTerminalNoProgress,
 			CompletedAt:        now.Add(-2 * time.Minute),
 			WorkerMetadataJSON: `{"artifact_gate_convergence":{"status_field":"render_status","dispatch_status":"recut","completion_status":"recut","unchanged":true,"consecutive_unchanged":1,"limit":3}}`,
 		},
@@ -213,6 +213,7 @@ func TestHandleRunResultParksThirdUnchangedArtifactGateSuccess(t *testing.T) {
 		Attempt:       3,
 		WorkAttemptID: 47,
 		StartedAt:     now.Add(-40 * time.Second),
+		DiffStats:     DiffStats{Status: "clean"},
 	}
 	state.Claimed[issue.ID] = Claimed{Issue: cloneIssue(issue), ClaimedAt: now.Add(-time.Minute)}
 
@@ -235,8 +236,8 @@ func TestHandleRunResultParksThirdUnchangedArtifactGateSuccess(t *testing.T) {
 	if _, ok := state.Retry[issue.ID]; ok {
 		t.Fatalf("Retry[%q] present after convergence breaker", issue.ID)
 	}
-	if len(attempts.completions) != 1 || attempts.completions[0].TerminalState != store.WorkAttemptTerminalSuccess {
-		t.Fatalf("completions = %#v, want one durable success", attempts.completions)
+	if len(attempts.completions) != 1 || attempts.completions[0].TerminalState != store.WorkAttemptTerminalNoProgress {
+		t.Fatalf("completions = %#v, want one durable no-progress worker success", attempts.completions)
 	}
 	if !strings.Contains(attempts.completions[0].WorkerMetadataJSON, `"tripped":true`) {
 		t.Fatalf("worker metadata = %q, want durable convergence trip", attempts.completions[0].WorkerMetadataJSON)
@@ -271,6 +272,14 @@ func TestConsecutiveArtifactGateConvergenceAttempts(t *testing.T) {
 			attempts: []store.WorkAttempt{
 				artifactGateConvergenceAttempt(t, store.WorkAttemptTerminalSuccess, current),
 				artifactGateConvergenceAttempt(t, store.WorkAttemptTerminalSuccess, current),
+			},
+			want: 2,
+		},
+		{
+			name: "counts worker successes reclassified as no progress",
+			attempts: []store.WorkAttempt{
+				artifactGateConvergenceAttempt(t, store.WorkAttemptTerminalNoProgress, current),
+				artifactGateConvergenceAttempt(t, store.WorkAttemptTerminalNoProgress, current),
 			},
 			want: 2,
 		},

--- a/internal/orchestrator/artifact_completion_test.go
+++ b/internal/orchestrator/artifact_completion_test.go
@@ -2,6 +2,7 @@ package orchestrator
 
 import (
 	"context"
+	"encoding/json"
 	"log/slog"
 	"reflect"
 	"strings"
@@ -11,6 +12,7 @@ import (
 	"github.com/digitaldrywood/detent/internal/connector"
 	"github.com/digitaldrywood/detent/internal/gate"
 	runpkg "github.com/digitaldrywood/detent/internal/runner"
+	"github.com/digitaldrywood/detent/internal/store"
 )
 
 func TestHandleRunResultAppliesArtifactGateWorkpadField(t *testing.T) {
@@ -151,6 +153,190 @@ func TestHandleRunResultAppliesArtifactGateWorkpadField(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestHandleRunResultParksThirdUnchangedArtifactGateSuccess(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 7, 19, 14, 0, 0, 0, time.UTC)
+	issue := connector.NewIssue()
+	issue.ID = "issue-artifact-convergence"
+	issue.Identifier = "digitaldrywood/video#47"
+	issue.Title = "Render storyboard"
+	issue.State = "Rework"
+	issue.Fields = map[string]string{"render_status": "recut"}
+	issue.Deliverable = &connector.Deliverable{Kind: "artifact"}
+	cfg := normalizeConfig(Config{
+		ActiveStates:   []string{"Todo", "Production", "Rework"},
+		ObservedStates: []string{"Backlog", "Review", "Blocked"},
+		TerminalStates: []string{"Ready for Pickup", "Done", "Cancelled"},
+		AutoPromote: AutoPromoteConfig{
+			Enabled:       true,
+			SourceState:   "Review",
+			PassState:     "Ready for Pickup",
+			ReworkState:   "Rework",
+			GateWaitState: autoPromoteGateWaitSource,
+			Gate:          artifactCompletionTestGate(),
+		},
+	})
+	tracker := &autoPromoteTickConnector{stateIssues: []connector.Issue{issue}}
+	attempts := &recordingWorkAttemptStore{history: []store.WorkAttempt{
+		{
+			ProjectID:          cfg.Project.ID,
+			IssueID:            issue.ID,
+			Identifier:         issue.Identifier,
+			WorkerType:         "agent",
+			TerminalState:      store.WorkAttemptTerminalSuccess,
+			CompletedAt:        now.Add(-time.Minute),
+			WorkerMetadataJSON: `{"artifact_gate_convergence":{"status_field":"render_status","dispatch_status":"recut","completion_status":"recut","unchanged":true,"consecutive_unchanged":2,"limit":3}}`,
+		},
+		{
+			ProjectID:          cfg.Project.ID,
+			IssueID:            issue.ID,
+			Identifier:         issue.Identifier,
+			WorkerType:         "agent",
+			TerminalState:      store.WorkAttemptTerminalSuccess,
+			CompletedAt:        now.Add(-2 * time.Minute),
+			WorkerMetadataJSON: `{"artifact_gate_convergence":{"status_field":"render_status","dispatch_status":"recut","completion_status":"recut","unchanged":true,"consecutive_unchanged":1,"limit":3}}`,
+		},
+	}}
+	var logs strings.Builder
+	orch := &Orchestrator{
+		cfg:          cfg,
+		connector:    tracker,
+		workAttempts: attempts,
+		logger:       slog.New(slog.NewTextHandler(&logs, nil)),
+	}
+	state := newState(cfg)
+	state.Running[issue.ID] = Running{
+		Issue:         cloneIssue(issue),
+		Attempt:       3,
+		WorkAttemptID: 47,
+		StartedAt:     now.Add(-40 * time.Second),
+	}
+	state.Claimed[issue.ID] = Claimed{Issue: cloneIssue(issue), ClaimedAt: now.Add(-time.Minute)}
+
+	orch.handleRunResult(t.Context(), &state, runpkg.Completion{
+		IssueID:     issue.ID,
+		CompletedAt: now,
+		Result:      runpkg.RunResult{FinalState: runpkg.FinalStateCompleted},
+	})
+
+	wantUpdates := []autoPromoteTickUpdate{{issueID: issue.ID, state: "Blocked"}}
+	if !reflect.DeepEqual(tracker.updates, wantUpdates) {
+		t.Fatalf("updates = %#v, want %#v", tracker.updates, wantUpdates)
+	}
+	if blocked, ok := state.Blocked[issue.ID]; !ok || blocked.Issue.State != "Blocked" {
+		t.Fatalf("Blocked[%q] = %#v, want parked Blocked issue", issue.ID, blocked)
+	}
+	if _, ok := state.Completed[issue.ID]; ok {
+		t.Fatalf("Completed[%q] present after convergence breaker", issue.ID)
+	}
+	if _, ok := state.Retry[issue.ID]; ok {
+		t.Fatalf("Retry[%q] present after convergence breaker", issue.ID)
+	}
+	if len(attempts.completions) != 1 || attempts.completions[0].TerminalState != store.WorkAttemptTerminalSuccess {
+		t.Fatalf("completions = %#v, want one durable success", attempts.completions)
+	}
+	if !strings.Contains(attempts.completions[0].WorkerMetadataJSON, `"tripped":true`) {
+		t.Fatalf("worker metadata = %q, want durable convergence trip", attempts.completions[0].WorkerMetadataJSON)
+	}
+	if len(tracker.comments) != 1 || !strings.Contains(tracker.comments[0].body, "stopped redispatching") {
+		t.Fatalf("comments = %#v, want convergence breaker handoff", tracker.comments)
+	}
+	for _, fragment := range []string{"artifact gate convergence breaker tripped", "consecutive_unchanged=3"} {
+		if !strings.Contains(logs.String(), fragment) {
+			t.Fatalf("logs %q missing %q", logs.String(), fragment)
+		}
+	}
+}
+
+func TestConsecutiveArtifactGateConvergenceAttempts(t *testing.T) {
+	t.Parallel()
+
+	current := artifactGateConvergenceRecord{
+		StatusField:      "render_status",
+		DispatchStatus:   "recut",
+		CompletionStatus: "recut",
+		Unchanged:        true,
+		Limit:            artifactGateConvergenceLimit,
+	}
+	tests := []struct {
+		name     string
+		attempts []store.WorkAttempt
+		want     int
+	}{
+		{
+			name: "counts matching successes",
+			attempts: []store.WorkAttempt{
+				artifactGateConvergenceAttempt(t, store.WorkAttemptTerminalSuccess, current),
+				artifactGateConvergenceAttempt(t, store.WorkAttemptTerminalSuccess, current),
+			},
+			want: 2,
+		},
+		{
+			name: "field progress resets count",
+			attempts: []store.WorkAttempt{
+				artifactGateConvergenceAttempt(t, store.WorkAttemptTerminalSuccess, artifactGateConvergenceRecord{
+					StatusField:      "render_status",
+					DispatchStatus:   "recut",
+					CompletionStatus: "pending_review",
+					Limit:            artifactGateConvergenceLimit,
+				}),
+				artifactGateConvergenceAttempt(t, store.WorkAttemptTerminalSuccess, current),
+			},
+		},
+		{
+			name: "different unchanged value resets count",
+			attempts: []store.WorkAttempt{
+				artifactGateConvergenceAttempt(t, store.WorkAttemptTerminalSuccess, artifactGateConvergenceRecord{
+					StatusField:          "render_status",
+					DispatchStatus:       "pending_review",
+					CompletionStatus:     "pending_review",
+					Unchanged:            true,
+					ConsecutiveUnchanged: 1,
+					Limit:                artifactGateConvergenceLimit,
+				}),
+			},
+		},
+		{
+			name: "failure breaks successful sequence",
+			attempts: []store.WorkAttempt{
+				artifactGateConvergenceAttempt(t, store.WorkAttemptTerminalFailure, current),
+				artifactGateConvergenceAttempt(t, store.WorkAttemptTerminalSuccess, current),
+			},
+		},
+		{
+			name: "legacy success breaks recorded sequence",
+			attempts: []store.WorkAttempt{{
+				TerminalState:      store.WorkAttemptTerminalSuccess,
+				WorkerMetadataJSON: `{}`,
+			}},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			if got := consecutiveArtifactGateConvergenceAttempts(tt.attempts, current); got != tt.want {
+				t.Fatalf("consecutiveArtifactGateConvergenceAttempts() = %d, want %d", got, tt.want)
+			}
+		})
+	}
+}
+
+func artifactGateConvergenceAttempt(
+	t *testing.T,
+	terminalState store.WorkAttemptTerminalState,
+	record artifactGateConvergenceRecord,
+) store.WorkAttempt {
+	t.Helper()
+	metadata, err := json.Marshal(artifactGateConvergenceMetadata(record))
+	if err != nil {
+		t.Fatalf("json.Marshal() error = %v", err)
+	}
+	return store.WorkAttempt{TerminalState: terminalState, WorkerMetadataJSON: string(metadata)}
 }
 
 func TestArtifactGateCompletionFieldUpdate(t *testing.T) {

--- a/internal/orchestrator/blocked_recovery_test.go
+++ b/internal/orchestrator/blocked_recovery_test.go
@@ -14,7 +14,7 @@ import (
 func TestRecoverBlockedIssuesSkipsPersistedStickyBlockedIssue(t *testing.T) {
 	t.Parallel()
 
-	for _, reason := range []string{"rework_limit", "token_ceiling_circuit_breaker"} {
+	for _, reason := range []string{"rework_limit", "token_ceiling_circuit_breaker", artifactGateConvergenceReason} {
 		t.Run(reason, func(t *testing.T) {
 			t.Parallel()
 

--- a/internal/orchestrator/dependency_autounblock.go
+++ b/internal/orchestrator/dependency_autounblock.go
@@ -851,11 +851,13 @@ func (o *Orchestrator) issueHasStickyBlockReason(ctx context.Context, state *Sta
 
 func stickyBlockReason(reason string) bool {
 	reason = strings.ToLower(strings.TrimSpace(reason))
-	if strings.HasPrefix(reason, tokenCeilingBlockedReasonPrefix) || strings.HasPrefix(reason, mergeWorkerRetryExhaustedReason) {
+	if strings.HasPrefix(reason, tokenCeilingBlockedReasonPrefix) ||
+		strings.HasPrefix(reason, artifactGateConvergenceBlockedReasonPrefix) ||
+		strings.HasPrefix(reason, mergeWorkerRetryExhaustedReason) {
 		return true
 	}
 	switch reason {
-	case "rework_limit", "no_progress_limit", "workpad_blocked_unactioned", "circuit_breaker", "token_ceiling_circuit_breaker":
+	case "rework_limit", "no_progress_limit", "workpad_blocked_unactioned", "circuit_breaker", "token_ceiling_circuit_breaker", artifactGateConvergenceReason:
 		return true
 	default:
 		return false

--- a/internal/orchestrator/reconcile.go
+++ b/internal/orchestrator/reconcile.go
@@ -505,6 +505,7 @@ func (o *Orchestrator) setBlockedStatusIssue(state *State, issue connector.Issue
 		(strings.HasPrefix(existing.Reason, instantFailureBlockedReasonPrefix) ||
 			strings.HasPrefix(existing.Reason, repeatedFailureBlockedReasonPrefix) ||
 			strings.HasPrefix(existing.Reason, tokenCeilingBlockedReasonPrefix) ||
+			strings.HasPrefix(existing.Reason, artifactGateConvergenceBlockedReasonPrefix) ||
 			strings.HasPrefix(existing.Reason, mergeWorkerRetryExhaustedReason)) &&
 		strings.TrimSpace(issue.BlockerReason) == "" {
 		existing.Issue = cloneIssue(issue)

--- a/internal/orchestrator/run_completion.go
+++ b/internal/orchestrator/run_completion.go
@@ -372,11 +372,20 @@ func (o *Orchestrator) handleRunResult(ctx context.Context, state *State, event 
 		phase = "no_progress"
 		statusMessage = "spend-since-progress circuit breaker tripped"
 	}
+	artifactConvergence := artifactGateConvergenceRecord{}
 	if terminalState == store.WorkAttemptTerminalSuccess {
-		o.warnUnchangedArtifactGateCompletion(ctx, dispatchedIssue, running.Issue)
+		artifactConvergence = o.evaluateArtifactGateConvergence(ctx, dispatchedIssue, running.Issue, running)
+		if artifactConvergence.Tripped {
+			phase = "blocked"
+			statusMessage = "artifact gate convergence breaker tripped"
+		}
 	}
 	o.recordProjectAttemptOutcome(state, event.IssueID, event.CompletedAt, terminalState, nil, errorClass, errorMessage)
-	o.completeDurableWorkAttemptWithMetadata(ctx, state, running, event.CompletedAt, terminalState, errorClass, errorMessage, phase, statusMessage, mergeWorkAttemptMetadata(implementCompletionProgressMetadata(progress), spendProgressMetadata(spendProgress)))
+	o.completeDurableWorkAttemptWithMetadata(ctx, state, running, event.CompletedAt, terminalState, errorClass, errorMessage, phase, statusMessage, mergeWorkAttemptMetadata(
+		implementCompletionProgressMetadata(progress),
+		spendProgressMetadata(spendProgress),
+		artifactGateConvergenceMetadata(artifactConvergence),
+	))
 
 	state.Completed[event.IssueID] = Completed{
 		Issue:           cloneIssue(running.Issue),
@@ -399,6 +408,10 @@ func (o *Orchestrator) handleRunResult(ctx context.Context, state *State, event 
 		refusal.Issue = cloneIssue(running.Issue)
 		state.BudgetRefusals[event.IssueID] = refusal
 		o.commentBudgetRefusal(ctx, event.IssueID, refusal)
+	}
+	if artifactConvergence.Tripped {
+		o.parkArtifactGateConvergence(ctx, state, running.Issue, running.Attempt, event.CompletedAt, artifactConvergence)
+		return
 	}
 
 	if state.Draining {

--- a/internal/orchestrator/run_completion.go
+++ b/internal/orchestrator/run_completion.go
@@ -359,6 +359,10 @@ func (o *Orchestrator) handleRunResult(ctx context.Context, state *State, event 
 	}
 	phase := "completed"
 	statusMessage := "worker completed"
+	artifactConvergence := artifactGateConvergenceRecord{}
+	if terminalState == store.WorkAttemptTerminalSuccess {
+		artifactConvergence = o.evaluateArtifactGateConvergence(ctx, dispatchedIssue, running.Issue, running)
+	}
 	if terminalState == store.WorkAttemptTerminalSuccess && progress.Outcome == store.WorkAttemptTerminalNoProgress {
 		terminalState = store.WorkAttemptTerminalNoProgress
 		phase = "no_progress"
@@ -372,13 +376,9 @@ func (o *Orchestrator) handleRunResult(ctx context.Context, state *State, event 
 		phase = "no_progress"
 		statusMessage = "spend-since-progress circuit breaker tripped"
 	}
-	artifactConvergence := artifactGateConvergenceRecord{}
-	if terminalState == store.WorkAttemptTerminalSuccess {
-		artifactConvergence = o.evaluateArtifactGateConvergence(ctx, dispatchedIssue, running.Issue, running)
-		if artifactConvergence.Tripped {
-			phase = "blocked"
-			statusMessage = "artifact gate convergence breaker tripped"
-		}
+	if artifactConvergence.Tripped {
+		phase = "blocked"
+		statusMessage = "artifact gate convergence breaker tripped"
 	}
 	o.recordProjectAttemptOutcome(state, event.IssueID, event.CompletedAt, terminalState, nil, errorClass, errorMessage)
 	o.completeDurableWorkAttemptWithMetadata(ctx, state, running, event.CompletedAt, terminalState, errorClass, errorMessage, phase, statusMessage, mergeWorkAttemptMetadata(


### PR DESCRIPTION
## Summary

- Stop artifact-gate redispatch after three consecutive worker-success completions leave the configured status unchanged.
- Record convergence before generic no-progress classification, then park the item in Blocked with sticky recovery guidance and structured warnings.
- Report latest convergence-breaker outcomes through a project-scoped `detent doctor` diagnostic.

Fixes #1477

## UI Surface Contract

- [x] N/A; this change does not alter a UI surface, layout, density, first viewport, or responsive visibility.
- [x] This PR does not add persistent top-of-screen messaging.
- [x] N/A; this PR has no visual changes to primary operator screens.

## Test Plan

- [x] `make check`
- [x] Focused artifact convergence threshold, reset, sticky recovery, no-progress reclassification, and doctor scoping regressions.
- [x] Full touched-package suites for the orchestrator and CLI.
- [x] Current-head GitHub CI: 11/11 checks passed.