### PR TITLE
test(ci): harden local SQLite lifecycle wait

### DIFF
--- a/internal/orchestrator/local_sqlite_e2e_test.go
+++ b/internal/orchestrator/local_sqlite_e2e_test.go
@@ -77,7 +77,7 @@ func TestLocalSQLiteLifecycleEndToEnd(t *testing.T) {
 	defer stop()
 
 	// Scheduling: the capitalized Todo row must be fetched and dispatched.
-	state := waitForState(t, orch, func(state orchestrator.State) bool {
+	state := waitForStateWithin(t, orch, localSQLiteE2EWaitTimeout, func(state orchestrator.State) bool {
 		_, ok := state.Running[seed.ID]
 		return ok
 	})
@@ -111,7 +111,7 @@ func TestLocalSQLiteLifecycleEndToEnd(t *testing.T) {
 
 	// Completion: release the fake agent and wait for the run to finish.
 	close(release)
-	state = waitForState(t, orch, func(state orchestrator.State) bool {
+	state = waitForStateWithin(t, orch, localSQLiteE2EWaitTimeout, func(state orchestrator.State) bool {
 		_, ok := state.Completed[seed.ID]
 		return ok
 	})

--- a/internal/orchestrator/orchestrator_test.go
+++ b/internal/orchestrator/orchestrator_test.go
@@ -2412,20 +2412,37 @@ func runOrchestrator(t *testing.T, orch *orchestrator.Orchestrator) func() {
 func waitForState(t *testing.T, orch *orchestrator.Orchestrator, ready func(orchestrator.State) bool) orchestrator.State {
 	t.Helper()
 
-	deadline := time.After(time.Second)
+	return waitForStateWithin(t, orch, time.Second, ready)
+}
+
+func waitForStateWithin(t *testing.T, orch *orchestrator.Orchestrator, timeout time.Duration, ready func(orchestrator.State) bool) orchestrator.State {
+	t.Helper()
+
+	deadline := time.NewTimer(timeout)
+	defer deadline.Stop()
+	ticker := time.NewTicker(time.Millisecond)
+	defer ticker.Stop()
+	var lastState orchestrator.State
+	var lastErr error
 	for {
 		ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
 		state, err := orch.State(ctx)
 		cancel()
+		lastState = state
+		lastErr = err
 		if err == nil && ready(state) {
 			return state
 		}
 
 		select {
-		case <-deadline:
-			t.Fatal("timed out waiting for orchestrator state")
-		default:
-			time.Sleep(time.Millisecond)
+		case <-deadline.C:
+			t.Fatalf(
+				"timed out waiting for orchestrator state; last_state=%#v event_history=%#v last_error=%v",
+				lastState,
+				lastState.RecentEvents,
+				lastErr,
+			)
+		case <-ticker.C:
 		}
 	}
 }


### PR DESCRIPTION
## Summary

- give local SQLite lifecycle scheduling and completion waits the existing 10-second slow-CI deadline
- report the last orchestrator state, recent event history, and last state-read error on timeout
- preserve the original state predicates and the shared one-second default for other tests

Fixes #1479

## UI Surface Contract

- [x] N/A, or the linked issue explicitly authorizes any high-impact UI surface, layout, density, first-viewport, or responsive visibility tradeoff.
- [x] Persistent top-of-screen messaging is explicitly authorized by the issue, or this PR does not add it.
- [x] Visual changes to primary operator screens include screenshot or browser verification below. N/A: test-only change.

## Test Plan

- [x] `go test -race ./internal/orchestrator -run ^'TestLocalSQLiteLifecycleEndToEnd$' -count=100`
- [x] `make check`