### PR TITLE
Align Codex terminal wait horizons

### DIFF
--- a/README.md
+++ b/README.md
@@ -994,6 +994,9 @@ not consume GitHub's primary REST quota. This makes a `60000` interval practical
 for an idle REST-backed board while preserving the default cadence for existing
 workflows. Set `conditional: false` to restore unconditional requests; trackers
 without conditional-request support continue using their existing polling path.
+`polling.interval_ms` only controls tracker and project-board refreshes; it does
+not control Codex terminal-command waits or the enclosing tool-call yield
+horizon, which are governed by developer instructions on Codex turns.
 See GitHub's [conditional request guidance](https://docs.github.com/en/enterprise-cloud@latest/rest/using-the-rest-api/best-practices-for-using-the-rest-api#use-conditional-requests-if-appropriate).
 
 REST telemetry distinguishes `total_requests`, `conditional_requests`,

--- a/internal/codex/backend.go
+++ b/internal/codex/backend.go
@@ -14,6 +14,10 @@ import (
 
 var ErrMissingAppServer = errors.New("codex app-server is required")
 
+const terminalWaitInstructions = "For known long-running terminal commands, set the command wait to about 55 seconds and the enclosing functions.exec yield horizon to at least 60 seconds, with headroom beyond the command wait. Do not use 1-second yields for builds, test suites, CI checks, or an already-running managed session. Reuse the existing command session and wait on it instead of repeatedly running ps, pgrep, or tail probes unless there is evidence the session is stuck."
+
+const dynamicToolTurnInstructions = "You are Detent's board operator assistant. Use only the provided Detent tools for board, fleet, telemetry, activity, and operator actions. Never use shell, filesystem, network, MCP, browser, delegation, or configuration tools. Mutating tools only create proposals; tell the operator that confirmation is required and never claim a proposal already executed."
+
 type AgentBackend struct {
 	client  *AppServer
 	options Options
@@ -137,12 +141,12 @@ func turnSandboxPolicy(threadSandbox string, configured any, roots []string, res
 
 func toolTurnInstructions(tools []DynamicTool, override string) string {
 	if len(tools) == 0 {
-		return ""
+		return terminalWaitInstructions
 	}
 	if override = strings.TrimSpace(override); override != "" {
 		return override
 	}
-	return "You are Detent's board operator assistant. Use only the provided Detent tools for board, fleet, telemetry, activity, and operator actions. Never use shell, filesystem, network, MCP, browser, delegation, or configuration tools. Mutating tools only create proposals; tell the operator that confirmation is required and never claim a proposal already executed."
+	return dynamicToolTurnInstructions
 }
 
 func (b *AgentBackend) VerifyResume(ctx context.Context, resume runner.AgentResume) error {

--- a/internal/codex/backend_test.go
+++ b/internal/codex/backend_test.go
@@ -68,6 +68,7 @@ func TestAgentBackendAppliesOptionsAndExtraWritableRoots(t *testing.T) {
 	assertJSONContains(t, sent[2].Params, "sandbox", "workspace-write")
 	assertJSONContains(t, sent[2].Params, "model", "gpt-5-codex")
 	assertJSONOmits(t, sent[2].Params, "effort")
+	assertJSONContains(t, sent[2].Params, "developerInstructions", terminalWaitInstructions)
 
 	assertRequest(t, sent[3], 3, "turn/start")
 	assertJSONContains(t, sent[3].Params, "approvalPolicy", "never")
@@ -79,6 +80,49 @@ func TestAgentBackendAppliesOptionsAndExtraWritableRoots(t *testing.T) {
 
 	if len(updates) < 2 || updates[0].Type != runner.AgentUpdateRuntimeIdentity || updates[1].Type != runner.AgentUpdateTurnStarted || updates[1].Model != "gpt-5-codex-resolved" {
 		t.Fatalf("updates = %#v, want resolved model on turn started", updates)
+	}
+}
+
+func TestToolTurnInstructions(t *testing.T) {
+	t.Parallel()
+
+	tool := DynamicTool{Name: "board_state"}
+	tests := []struct {
+		name     string
+		tools    []DynamicTool
+		override string
+		want     string
+	}{
+		{
+			name: "normal turn",
+			want: terminalWaitInstructions,
+		},
+		{
+			name:     "normal turn ignores tool override",
+			override: "Use a custom tool policy.",
+			want:     terminalWaitInstructions,
+		},
+		{
+			name:  "dynamic tool turn",
+			tools: []DynamicTool{tool},
+			want:  dynamicToolTurnInstructions,
+		},
+		{
+			name:     "dynamic tool turn with override",
+			tools:    []DynamicTool{tool},
+			override: "  Inspect only and submit proposals.  ",
+			want:     "Inspect only and submit proposals.",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			if got := toolTurnInstructions(tt.tools, tt.override); got != tt.want {
+				t.Fatalf("toolTurnInstructions() = %q, want %q", got, tt.want)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## Summary

- send long-running terminal wait guidance on ordinary Codex coding turns
- preserve dynamic-tool instruction overrides and restricted sandbox behavior
- document that `polling.interval_ms` controls tracker refreshes, not terminal waits

Fixes #1481

## UI Surface Contract

- [x] N/A; this PR does not change a UI surface.
- [x] This PR does not add persistent top-of-screen messaging.
- [x] This PR has no visual changes to operator screens.

## Test Plan

- [x] `go test ./internal/codex`
- [x] controlled 12-second command with 55-second inner and 60-second outer horizons
- [x] `make check`