### PR TITLE
fix(orchestrator): reconcile operator moves

### DIFF
--- a/.detent/skills/operator-mutation-runtime-reconciliation.md
+++ b/.detent/skills/operator-mutation-runtime-reconciliation.md
@@ -1,0 +1,15 @@
+---
+name: operator-mutation-runtime-reconciliation
+description: Reconcile confirmed tracker mutations with event-loop-owned scheduler memory before degraded refresh fallback can restore stale state.
+when_to_use: Use when an operator mutation succeeds in the tracker or UI but scheduling, API counts, or runtime telemetry continue using stale item state.
+---
+
+# Reconcile operator mutations with runtime state
+
+1. Reproduce the split view: confirm the mutation response and tracker state changed while the runtime snapshot or scheduler still reports the prior state.
+2. Trace the mutation boundary separately from the refresh path. Identify every item-scoped runtime map that can veto dispatch and every degraded-refresh fallback that can restore prior observations.
+3. Send a synchronous request through the scheduler owner's event loop after the tracker mutation succeeds. Treat the reply as the serialization barrier that guarantees the next scheduler decision sees the mutation.
+4. Update cached issue state and clear only matching item memory. Preserve unrelated blocked entries, retries, claims, failure signals, and project-wide breaker evidence.
+5. Record structured runtime telemetry with the operator mutation as the reason and whether each veto was cleared.
+6. Build the regression with one moved item and one unrelated stale-status item. Fail the unrelated transition refresh, prove the moved item dispatches, and assert board, API snapshot, and scheduler-decision counts converge.
+7. Run focused package tests, the race suite, and the full repository validation gate.

--- a/internal/cli/boot.go
+++ b/internal/cli/boot.go
@@ -389,6 +389,7 @@ func startRunningWithDependencies(ctx context.Context, cfg BootConfig, deps star
 		Registry:      manager.Registry(),
 		Connector:     firstConnector(manager),
 		Refresher:     refresherForRegistry(manager.Registry()),
+		OperatorMoves: registryRefresher{registry: manager.Registry()},
 		Recovery:      recoveryForRegistry(manager.Registry()),
 		RunStopper:    registryRefresher{registry: manager.Registry()},
 		UpdateApplier: updateScheduler,
@@ -1505,6 +1506,14 @@ func (r registryRefresher) WorkAttemptReceipt(ctx context.Context, projectID str
 		return orchestrator.WorkAttemptRecoveryResponse{}, err
 	}
 	return orch.WorkAttemptReceipt(ctx, projectID, attemptID)
+}
+
+func (r registryRefresher) ReconcileOperatorMove(ctx context.Context, request orchestrator.OperatorMoveRequest) (orchestrator.OperatorMoveResult, error) {
+	orch, err := r.projectOrchestrator(request.ProjectID)
+	if err != nil {
+		return orchestrator.OperatorMoveResult{}, err
+	}
+	return orch.ReconcileOperatorMove(ctx, request)
 }
 
 func (r registryRefresher) RecoverWorkAttempt(ctx context.Context, request orchestrator.WorkAttemptRecoveryRequest) (orchestrator.WorkAttemptRecoveryResponse, error) {

--- a/internal/orchestrator/operator_move.go
+++ b/internal/orchestrator/operator_move.go
@@ -1,0 +1,186 @@
+package orchestrator
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"time"
+
+	"github.com/digitaldrywood/detent/internal/connector"
+	"github.com/digitaldrywood/detent/internal/telemetry"
+)
+
+var ErrMissingOperatorMoveIssueID = errors.New("operator move issue id is required")
+
+type OperatorMoveRequest struct {
+	ProjectID  string
+	IssueID    string
+	Identifier string
+	FromState  string
+	ToState    string
+}
+
+type OperatorMoveResult struct {
+	Reconciled           bool
+	BlockedCleared       bool
+	ClaimCleared         bool
+	RetryCleared         bool
+	FailureMemoryCleared bool
+}
+
+type operatorMoveRequest struct {
+	request OperatorMoveRequest
+	at      time.Time
+	reply   chan OperatorMoveResult
+}
+
+func (o *Orchestrator) ReconcileOperatorMove(ctx context.Context, request OperatorMoveRequest) (OperatorMoveResult, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	request.IssueID = strings.TrimSpace(request.IssueID)
+	if request.IssueID == "" {
+		return OperatorMoveResult{}, ErrMissingOperatorMoveIssueID
+	}
+	move := operatorMoveRequest{
+		request: request,
+		at:      o.clockNow().UTC(),
+		reply:   make(chan OperatorMoveResult, 1),
+	}
+	select {
+	case <-ctx.Done():
+		return OperatorMoveResult{}, ctx.Err()
+	case <-o.done:
+		return OperatorMoveResult{}, ErrStopped
+	case o.operatorMoves <- move:
+	}
+	select {
+	case <-ctx.Done():
+		return OperatorMoveResult{}, ctx.Err()
+	case <-o.done:
+		return OperatorMoveResult{}, ErrStopped
+	case result := <-move.reply:
+		return result, nil
+	}
+}
+
+func (o *Orchestrator) handleOperatorMove(state *State, request OperatorMoveRequest, at time.Time) OperatorMoveResult {
+	issueID := strings.TrimSpace(request.IssueID)
+	fromState := strings.TrimSpace(request.FromState)
+	toState := strings.TrimSpace(request.ToState)
+	if state == nil || issueID == "" || normalizeState(fromState) != normalizeState(blockedStatusState) ||
+		normalizeState(toState) == normalizeState(blockedStatusState) || !stateIn(toState, o.cfg.ActiveStates) {
+		return OperatorMoveResult{}
+	}
+
+	issue := connector.Issue{ID: issueID, Identifier: strings.TrimSpace(request.Identifier), State: fromState}
+	if current, ok := findRecoveryIssue(state, issue); ok {
+		issue = current
+	}
+	updateIssueStateSnapshots(state, issueID, issue, toState, at)
+	delete(state.AutoPromoteDecisions, issueID)
+
+	result := OperatorMoveResult{Reconciled: true}
+	if blocked, ok := state.Blocked[issueID]; ok && blocked.Source == BlockedSourceProjectStatus {
+		delete(state.Blocked, issueID)
+		result.BlockedCleared = true
+	}
+	if result.BlockedCleared {
+		if _, ok := state.Claimed[issueID]; ok {
+			delete(state.Claimed, issueID)
+			result.ClaimCleared = true
+		}
+		if _, ok := state.Retry[issueID]; ok {
+			delete(state.Retry, issueID)
+			result.RetryCleared = true
+		}
+		if _, ok := state.InstantFailures[issueID]; ok {
+			delete(state.InstantFailures, issueID)
+			result.FailureMemoryCleared = true
+		}
+		if _, ok := state.RepeatedFailures[issueID]; ok {
+			delete(state.RepeatedFailures, issueID)
+			result.FailureMemoryCleared = true
+		}
+		if clearProjectFailureBreakerIssue(&state.FailureBreaker, issueID) {
+			result.FailureMemoryCleared = true
+		}
+	}
+
+	recordStateEvent(state, telemetry.ActivityEvent{
+		At:      at,
+		Event:   "operator_kanban_move_reconciled",
+		Message: operatorMoveEventMessage(issue, fromState, toState, result),
+	})
+	if o.logger != nil {
+		o.logger.Info(
+			"operator kanban move reconciled",
+			"project_id", strings.TrimSpace(request.ProjectID),
+			"issue_id", issueID,
+			"identifier", issue.Identifier,
+			"from_state", fromState,
+			"to_state", toState,
+			"reason", "operator_kanban_move",
+			"runtime_block_cleared", result.BlockedCleared,
+			"claim_cleared", result.ClaimCleared,
+			"retry_cleared", result.RetryCleared,
+			"failure_memory_cleared", result.FailureMemoryCleared,
+		)
+	}
+	return result
+}
+
+func clearProjectFailureBreakerIssue(breaker *ProjectFailureBreaker, issueID string) bool {
+	if breaker == nil || strings.TrimSpace(issueID) == "" {
+		return false
+	}
+	changed := false
+	for class, failures := range breaker.Failures {
+		kept := failures[:0]
+		for _, failure := range failures {
+			if strings.TrimSpace(failure.IssueID) == issueID {
+				changed = true
+				continue
+			}
+			kept = append(kept, failure)
+		}
+		if len(kept) == 0 {
+			delete(breaker.Failures, class)
+			continue
+		}
+		breaker.Failures[class] = kept
+	}
+	if strings.TrimSpace(breaker.CanaryIssueID) == issueID {
+		breaker.CanaryIssueID = ""
+		changed = true
+	}
+	if !changed {
+		return false
+	}
+	if !breaker.Active() {
+		return true
+	}
+	failures := breaker.Failures[breaker.Class]
+	if len(failures) < normalizeFailureBreakerConfig(breaker.Config).SameClassLimit {
+		breaker.Class = ""
+		breaker.Count = 0
+		breaker.FirstFailureAt = time.Time{}
+		breaker.TrippedAt = time.Time{}
+		breaker.ResumeAt = time.Time{}
+		breaker.CanaryIssueID = ""
+		return true
+	}
+	breaker.Count = len(failures)
+	breaker.FirstFailureAt = failures[0].At
+	breaker.TrippedAt = failures[len(failures)-1].At
+	breaker.ResumeAt = breaker.TrippedAt.Add(breaker.Config.Cooldown)
+	return true
+}
+
+func operatorMoveEventMessage(issue connector.Issue, fromState string, toState string, result OperatorMoveResult) string {
+	message := "reconciled " + issueLabel(issue) + " after operator Kanban move from " + fromState + " to " + toState
+	if result.BlockedCleared {
+		message += "; cleared stale project-status runtime block"
+	}
+	return message
+}

--- a/internal/orchestrator/operator_move.go
+++ b/internal/orchestrator/operator_move.go
@@ -69,7 +69,7 @@ func (o *Orchestrator) handleOperatorMove(state *State, request OperatorMoveRequ
 	fromState := strings.TrimSpace(request.FromState)
 	toState := strings.TrimSpace(request.ToState)
 	if state == nil || issueID == "" || normalizeState(fromState) != normalizeState(blockedStatusState) ||
-		normalizeState(toState) == normalizeState(blockedStatusState) || !stateIn(toState, o.cfg.ActiveStates) {
+		normalizeState(toState) == normalizeState(blockedStatusState) || !o.operatorMoveTargetConfigured(toState) {
 		return OperatorMoveResult{}
 	}
 
@@ -128,6 +128,10 @@ func (o *Orchestrator) handleOperatorMove(state *State, request OperatorMoveRequ
 		)
 	}
 	return result
+}
+
+func (o *Orchestrator) operatorMoveTargetConfigured(state string) bool {
+	return stateIn(state, o.cfg.ActiveStates) || stateIn(state, o.cfg.ObservedStates) || stateIn(state, o.cfg.TerminalStates)
 }
 
 func clearProjectFailureBreakerIssue(breaker *ProjectFailureBreaker, issueID string) bool {

--- a/internal/orchestrator/operator_move_test.go
+++ b/internal/orchestrator/operator_move_test.go
@@ -1,0 +1,138 @@
+package orchestrator
+
+import (
+	"testing"
+	"time"
+
+	"github.com/digitaldrywood/detent/internal/connector"
+)
+
+func TestHandleOperatorMoveClearsOnlyMovedIssueRuntimeMemory(t *testing.T) {
+	t.Parallel()
+
+	at := time.Date(2026, 7, 22, 12, 0, 0, 0, time.UTC)
+	moved := connector.Issue{ID: "moved", Identifier: "digitaldrywood/detent#1482", State: "Blocked"}
+	unrelated := connector.Issue{ID: "unrelated", Identifier: "digitaldrywood/detent#1483", State: "Blocked"}
+	class := projectFailureClassRunnerError
+	cfg := normalizeConfig(Config{
+		ActiveStates: []string{"Todo", "Rework"},
+		FailureBreaker: FailureBreakerConfig{
+			SameClassLimit: 2,
+			Window:         time.Hour,
+			Cooldown:       time.Minute,
+		},
+	})
+	state := newState(cfg)
+	state.BoardIssues = []connector.Issue{moved, unrelated}
+	state.Blocked[moved.ID] = Blocked{Issue: moved, Source: BlockedSourceProjectStatus}
+	state.Blocked[unrelated.ID] = Blocked{Issue: unrelated, Source: BlockedSourceProjectStatus}
+	state.Claimed[moved.ID] = Claimed{Issue: moved}
+	state.Claimed[unrelated.ID] = Claimed{Issue: unrelated}
+	state.Retry[moved.ID] = Retry{Issue: moved}
+	state.Retry[unrelated.ID] = Retry{Issue: unrelated}
+	state.InstantFailures[moved.ID] = InstantFailure{Issue: moved, Count: 2}
+	state.InstantFailures[unrelated.ID] = InstantFailure{Issue: unrelated, Count: 1}
+	state.RepeatedFailures[moved.ID] = RepeatedFailure{Issue: moved, Count: 2}
+	state.RepeatedFailures[unrelated.ID] = RepeatedFailure{Issue: unrelated, Count: 1}
+	state.FailureBreaker.Failures[class] = []ProjectFailure{
+		{IssueID: unrelated.ID, At: at.Add(-time.Minute)},
+		{IssueID: moved.ID, At: at},
+	}
+	state.FailureBreaker.Class = class
+	state.FailureBreaker.Count = 2
+	state.FailureBreaker.FirstFailureAt = at.Add(-time.Minute)
+	state.FailureBreaker.TrippedAt = at
+	state.FailureBreaker.ResumeAt = at.Add(time.Minute)
+
+	orch := &Orchestrator{cfg: cfg}
+	result := orch.handleOperatorMove(&state, OperatorMoveRequest{
+		ProjectID:  "detent",
+		IssueID:    moved.ID,
+		Identifier: moved.Identifier,
+		FromState:  "Blocked",
+		ToState:    "Rework",
+	}, at)
+
+	if result != (OperatorMoveResult{
+		Reconciled:           true,
+		BlockedCleared:       true,
+		ClaimCleared:         true,
+		RetryCleared:         true,
+		FailureMemoryCleared: true,
+	}) {
+		t.Fatalf("handleOperatorMove() = %#v", result)
+	}
+	if state.BoardIssues[0].State != "Rework" {
+		t.Fatalf("moved board state = %q, want Rework", state.BoardIssues[0].State)
+	}
+	if _, ok := state.Blocked[moved.ID]; ok {
+		t.Fatalf("Blocked[%q] remains", moved.ID)
+	}
+	if _, ok := state.Claimed[moved.ID]; ok {
+		t.Fatalf("Claimed[%q] remains", moved.ID)
+	}
+	if _, ok := state.Retry[moved.ID]; ok {
+		t.Fatalf("Retry[%q] remains", moved.ID)
+	}
+	if _, ok := state.InstantFailures[moved.ID]; ok {
+		t.Fatalf("InstantFailures[%q] remains", moved.ID)
+	}
+	if _, ok := state.RepeatedFailures[moved.ID]; ok {
+		t.Fatalf("RepeatedFailures[%q] remains", moved.ID)
+	}
+	if _, ok := state.Blocked[unrelated.ID]; !ok {
+		t.Fatalf("Blocked[%q] missing", unrelated.ID)
+	}
+	if _, ok := state.Claimed[unrelated.ID]; !ok {
+		t.Fatalf("Claimed[%q] missing", unrelated.ID)
+	}
+	if _, ok := state.Retry[unrelated.ID]; !ok {
+		t.Fatalf("Retry[%q] missing", unrelated.ID)
+	}
+	if _, ok := state.InstantFailures[unrelated.ID]; !ok {
+		t.Fatalf("InstantFailures[%q] missing", unrelated.ID)
+	}
+	if _, ok := state.RepeatedFailures[unrelated.ID]; !ok {
+		t.Fatalf("RepeatedFailures[%q] missing", unrelated.ID)
+	}
+	if state.FailureBreaker.Active() {
+		t.Fatalf("FailureBreaker = %#v, want inactive after moved issue signal cleared", state.FailureBreaker)
+	}
+	failures := state.FailureBreaker.Failures[class]
+	if len(failures) != 1 || failures[0].IssueID != unrelated.ID {
+		t.Fatalf("FailureBreaker.Failures[%q] = %#v, want unrelated signal preserved", class, failures)
+	}
+	snapshot := state.Snapshot(at)
+	if snapshot.Counts.Blocked != 1 || len(snapshot.Blocked) != 1 || snapshot.Blocked[0].ID != unrelated.ID {
+		t.Fatalf("blocked snapshot = count %d rows %#v, want unrelated issue only", snapshot.Counts.Blocked, snapshot.Blocked)
+	}
+	if len(state.RecentEvents) != 1 || state.RecentEvents[0].Event != "operator_kanban_move_reconciled" {
+		t.Fatalf("RecentEvents = %#v, want operator move audit event", state.RecentEvents)
+	}
+}
+
+func TestHandleOperatorMovePreservesNonProjectStatusBlock(t *testing.T) {
+	t.Parallel()
+
+	issue := connector.Issue{ID: "dependency", State: "Blocked"}
+	cfg := normalizeConfig(Config{ActiveStates: []string{"Rework"}})
+	state := newState(cfg)
+	state.Blocked[issue.ID] = Blocked{Issue: issue, Source: BlockedSourceDependency}
+	state.Claimed[issue.ID] = Claimed{Issue: issue}
+
+	result := (&Orchestrator{cfg: cfg}).handleOperatorMove(&state, OperatorMoveRequest{
+		IssueID:   issue.ID,
+		FromState: "Blocked",
+		ToState:   "Rework",
+	}, time.Now())
+
+	if !result.Reconciled || result.BlockedCleared || result.ClaimCleared {
+		t.Fatalf("handleOperatorMove() = %#v, want non-project block preserved", result)
+	}
+	if _, ok := state.Blocked[issue.ID]; !ok {
+		t.Fatalf("Blocked[%q] missing", issue.ID)
+	}
+	if _, ok := state.Claimed[issue.ID]; !ok {
+		t.Fatalf("Claimed[%q] missing", issue.ID)
+	}
+}

--- a/internal/orchestrator/operator_move_test.go
+++ b/internal/orchestrator/operator_move_test.go
@@ -136,3 +136,53 @@ func TestHandleOperatorMovePreservesNonProjectStatusBlock(t *testing.T) {
 		t.Fatalf("Claimed[%q] missing", issue.ID)
 	}
 }
+
+func TestHandleOperatorMoveReconcilesConfiguredNonBlockedTargets(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		target      string
+		wantCleared bool
+	}{
+		{name: "observed state", target: "Human Review", wantCleared: true},
+		{name: "terminal state", target: "Done", wantCleared: true},
+		{name: "unknown state", target: "Unconfigured", wantCleared: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			issue := connector.Issue{ID: "configured-target", State: "Blocked"}
+			cfg := normalizeConfig(Config{
+				ActiveStates:   []string{"Rework"},
+				ObservedStates: []string{"Blocked", "Human Review"},
+				TerminalStates: []string{"Done"},
+			})
+			state := newState(cfg)
+			state.BoardIssues = []connector.Issue{issue}
+			state.Blocked[issue.ID] = Blocked{Issue: issue, Source: BlockedSourceProjectStatus}
+
+			result := (&Orchestrator{cfg: cfg}).handleOperatorMove(&state, OperatorMoveRequest{
+				IssueID:   issue.ID,
+				FromState: "Blocked",
+				ToState:   tt.target,
+			}, time.Now())
+
+			if result.BlockedCleared != tt.wantCleared || result.Reconciled != tt.wantCleared {
+				t.Fatalf("handleOperatorMove() = %#v, want cleared %t", result, tt.wantCleared)
+			}
+			_, blocked := state.Blocked[issue.ID]
+			if blocked == tt.wantCleared {
+				t.Fatalf("Blocked[%q] presence = %t, want %t", issue.ID, blocked, !tt.wantCleared)
+			}
+			wantState := "Blocked"
+			if tt.wantCleared {
+				wantState = tt.target
+			}
+			if state.BoardIssues[0].State != wantState {
+				t.Fatalf("BoardIssues[0].State = %q, want %q", state.BoardIssues[0].State, wantState)
+			}
+		})
+	}
+}

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -218,6 +218,7 @@ type Orchestrator struct {
 	drainRequests           chan drainRequest
 	forceRequests           chan forceRequest
 	recoveryRequests        chan workAttemptRecoveryRequest
+	operatorMoves           chan operatorMoveRequest
 	configUpdates           chan configUpdateRequest
 	refreshes               chan manualRefreshRequest
 	reconciles              chan targetedRefreshRequest
@@ -445,6 +446,7 @@ func New(cfg Config, deps Dependencies) (*Orchestrator, error) {
 		drainRequests:           make(chan drainRequest),
 		forceRequests:           make(chan forceRequest),
 		recoveryRequests:        make(chan workAttemptRecoveryRequest),
+		operatorMoves:           make(chan operatorMoveRequest),
 		configUpdates:           make(chan configUpdateRequest),
 		refreshes:               make(chan manualRefreshRequest, 1),
 		reconciles:              make(chan targetedRefreshRequest, 128),
@@ -539,6 +541,8 @@ func (o *Orchestrator) Run(ctx context.Context) error {
 		case request := <-o.recoveryRequests:
 			response, err := o.handleWorkAttemptRecovery(ctx, &state, request.request, request.at)
 			request.reply <- workAttemptRecoveryReply{response: response, err: err}
+		case request := <-o.operatorMoves:
+			request.reply <- o.handleOperatorMove(&state, request.request, request.at)
 		case update := <-o.configUpdates:
 			o.applyRuntimeUpdate(&state, update.update, ticker)
 			update.reply <- struct{}{}

--- a/internal/orchestrator/orchestrator_test.go
+++ b/internal/orchestrator/orchestrator_test.go
@@ -1987,6 +1987,84 @@ func TestRunTracksStatusLabelConflictCandidateAsBlocked(t *testing.T) {
 	}
 }
 
+func TestRunDispatchesOperatorMovedBlockedIssueDuringDegradedTransitionRefresh(t *testing.T) {
+	t.Parallel()
+
+	issue := testIssue("issue-operator-move", "digitaldrywood/detent#1482", "Blocked")
+	unrelated := testIssue("issue-unrelated-blocked", "digitaldrywood/detent#1483", "Blocked")
+	tracker := &operatorMoveConnector{fakeConnector: newFakeConnector(issue, unrelated)}
+	tracker.setStateIssues(issue, unrelated)
+	runner := newBlockingRunner()
+	orch, err := orchestrator.New(orchestrator.Config{
+		PollInterval:        time.Hour,
+		MaxConcurrentAgents: 1,
+		ActiveStates:        []string{"Todo", "Rework"},
+		ObservedStates:      []string{"Blocked"},
+		TerminalStates:      []string{"Done", "Cancelled"},
+	}, orchestrator.Dependencies{
+		Connector: tracker,
+		Runner:    runner,
+	})
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	stop := runOrchestrator(t, orch)
+	defer stop()
+
+	waitForState(t, orch, func(state orchestrator.State) bool {
+		_, movedBlocked := state.Blocked[issue.ID]
+		_, unrelatedBlocked := state.Blocked[unrelated.ID]
+		return movedBlocked && unrelatedBlocked
+	})
+	tracker.issueStateRefreshFailures.Store(1)
+	if err := tracker.UpdateIssueState(t.Context(), issue.ID, "Rework"); err != nil {
+		t.Fatalf("UpdateIssueState() error = %v", err)
+	}
+	result, err := orch.ReconcileOperatorMove(t.Context(), orchestrator.OperatorMoveRequest{
+		IssueID:    issue.ID,
+		Identifier: issue.Identifier,
+		FromState:  "Blocked",
+		ToState:    "Rework",
+	})
+	if err != nil {
+		t.Fatalf("ReconcileOperatorMove() error = %v", err)
+	}
+	if !result.Reconciled || !result.BlockedCleared {
+		t.Fatalf("ReconcileOperatorMove() = %#v, want reconciled runtime block", result)
+	}
+	state, err := orch.State(t.Context())
+	if err != nil {
+		t.Fatalf("State() error = %v", err)
+	}
+	if _, ok := state.Blocked[unrelated.ID]; !ok {
+		t.Fatalf("Blocked[%q] missing after item-scoped reconcile", unrelated.ID)
+	}
+	if _, err := orch.RequestRefresh(t.Context()); err != nil {
+		t.Fatalf("RequestRefresh() error = %v", err)
+	}
+
+	request := receiveRunRequest(t, runner.started)
+	if request.Issue.ID != issue.ID || request.Issue.State != "Rework" {
+		t.Fatalf("RunRequest.Issue = %#v, want moved Rework issue", request.Issue)
+	}
+	state = waitForState(t, orch, func(state orchestrator.State) bool {
+		for _, decision := range state.SchedulerDecisions {
+			if decision.IssueID == issue.ID && decision.Selected {
+				return true
+			}
+		}
+		return false
+	})
+	if _, ok := state.Blocked[issue.ID]; ok {
+		t.Fatalf("Blocked[%q] restored by degraded refresh", issue.ID)
+	}
+	snapshot := state.Snapshot(time.Now())
+	if snapshot.Counts.Blocked != 1 || len(snapshot.Blocked) != 1 || snapshot.Blocked[0].ID != unrelated.ID {
+		t.Fatalf("blocked snapshot = count %d rows %#v, want unrelated issue only", snapshot.Counts.Blocked, snapshot.Blocked)
+	}
+	close(runner.release)
+}
+
 func TestRunFetchesCandidatesBeforeObservedStates(t *testing.T) {
 	t.Parallel()
 
@@ -2548,6 +2626,24 @@ type fakeConnector struct {
 	fetchCandidateErrAt int
 	fetchByStatesErr    error
 	statusLabelPrefix   string
+}
+
+type operatorMoveConnector struct {
+	*fakeConnector
+	issueStateRefreshFailures atomic.Int64
+}
+
+func (c *operatorMoveConnector) FetchIssueStatesByIDs(ctx context.Context, ids []string) ([]connector.Issue, error) {
+	for {
+		remaining := c.issueStateRefreshFailures.Load()
+		if remaining <= 0 {
+			break
+		}
+		if c.issueStateRefreshFailures.CompareAndSwap(remaining, remaining-1) {
+			return nil, errors.New("blocked status transition refresh degraded")
+		}
+	}
+	return c.fakeConnector.FetchIssueStatesByIDs(ctx, ids)
 }
 
 type authHealthConnector struct {

--- a/internal/web/api.go
+++ b/internal/web/api.go
@@ -33,6 +33,10 @@ type Refresher interface {
 	RequestRefresh(context.Context) (RefreshResponse, error)
 }
 
+type OperatorMoveReconciler interface {
+	ReconcileOperatorMove(context.Context, orchestrator.OperatorMoveRequest) (orchestrator.OperatorMoveResult, error)
+}
+
 type TargetedRefresher interface {
 	RequestTargetedRefresh(context.Context, RefreshTarget) (RefreshResponse, error)
 }

--- a/internal/web/kanban.go
+++ b/internal/web/kanban.go
@@ -17,6 +17,7 @@ import (
 	workflowconfig "github.com/digitaldrywood/detent/internal/config"
 	"github.com/digitaldrywood/detent/internal/connector"
 	kanbanstate "github.com/digitaldrywood/detent/internal/kanban"
+	"github.com/digitaldrywood/detent/internal/orchestrator"
 	"github.com/digitaldrywood/detent/internal/project"
 	"github.com/digitaldrywood/detent/internal/store"
 	"github.com/digitaldrywood/detent/internal/telemetry"
@@ -69,6 +70,7 @@ const (
 	kanbanProjectBoardTarget       = "#snapshot"
 	kanbanFleetBoardTarget         = "#snapshot"
 	kanbanDialogSucceeded          = "kanbanActionSucceeded"
+	kanbanBlockedState             = "Blocked"
 	kanbanRefreshRetryDelay        = 2 * time.Second
 	kanbanMoveUnsupportedMessage   = "This project's tracker does not support moving cards."
 	kanbanRemoveUnsupportedMessage = "This project's tracker does not support removing cards."
@@ -235,6 +237,29 @@ func (s *Server) apiKanbanMove(c echo.Context) error {
 		)
 		return kanbanFeedback(c, http.StatusBadGateway, "Move failed: "+err.Error())
 	}
+	var runtimeMove orchestrator.OperatorMoveResult
+	if s.operatorMoves != nil && strings.EqualFold(strings.TrimSpace(moveCurrentState), kanbanBlockedState) &&
+		!strings.EqualFold(strings.TrimSpace(req.targetState), kanbanBlockedState) {
+		var reconcileErr error
+		runtimeMove, reconcileErr = s.operatorMoves.ReconcileOperatorMove(c.Request().Context(), orchestrator.OperatorMoveRequest{
+			ProjectID:  req.projectID,
+			IssueID:    req.issueID,
+			Identifier: moveIssueIdentifier,
+			FromState:  moveCurrentState,
+			ToState:    req.targetState,
+		})
+		if reconcileErr != nil {
+			s.logger.WarnContext(c.Request().Context(), "kanban move runtime reconcile failed",
+				"project", req.projectID,
+				"issue_id", req.issueID,
+				"identifier", moveIssueIdentifier,
+				"current_state", moveCurrentState,
+				"target_state", req.targetState,
+				"data_seq", moveDataSeq,
+				"error", reconcileErr,
+			)
+		}
+	}
 	s.logger.InfoContext(c.Request().Context(), "kanban move succeeded",
 		"project", req.projectID,
 		"issue_id", req.issueID,
@@ -242,6 +267,7 @@ func (s *Server) apiKanbanMove(c echo.Context) error {
 		"current_state", moveCurrentState,
 		"target_state", req.targetState,
 		"data_seq", moveDataSeq,
+		"runtime_block_cleared", runtimeMove.BlockedCleared,
 	)
 	return s.kanbanMoveSuccess(c, req, "Moved card to "+req.targetState+".")
 }

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -47,6 +47,7 @@ type Dependencies struct {
 	Registry         *project.Registry
 	Connector        connector.Connector
 	Refresher        Refresher
+	OperatorMoves    OperatorMoveReconciler
 	Recovery         WorkAttemptRecovery
 	RunStopper       RunStopper
 	UpdateApplier    UpdateApplier
@@ -111,6 +112,7 @@ type Server struct {
 	registry            *project.Registry
 	connector           connector.Connector
 	refresher           Refresher
+	operatorMoves       OperatorMoveReconciler
 	recovery            WorkAttemptRecovery
 	runStopper          RunStopper
 	updateApplier       UpdateApplier
@@ -216,6 +218,7 @@ func NewServer(cfg Config, deps Dependencies) (*Server, error) {
 		registry:            deps.Registry,
 		connector:           deps.Connector,
 		refresher:           deps.Refresher,
+		operatorMoves:       deps.OperatorMoves,
 		recovery:            deps.Recovery,
 		runStopper:          deps.RunStopper,
 		updateApplier:       deps.UpdateApplier,

--- a/internal/web/server_test.go
+++ b/internal/web/server_test.go
@@ -2261,6 +2261,62 @@ func TestKanbanMoveRoutesProjectV2AndIssueFieldUpdates(t *testing.T) {
 	}
 }
 
+func TestKanbanMoveReconcilesOperatorMoveAfterTrackerSuccess(t *testing.T) {
+	t.Parallel()
+
+	deps := testDeps(t)
+	actionConnector := &kanbanActionConnector{name: "github"}
+	mustSetKanbanProject(t, deps.Registry, "detent", workflowconfig.Kanban{
+		Mode: workflowconfig.KanbanModeIntegration,
+		AllowedTransitions: map[string][]string{
+			"Blocked": {"Rework"},
+		},
+	}, actionConnector)
+	probe := &operatorMoveProbe{result: orchestrator.OperatorMoveResult{Reconciled: true, BlockedCleared: true}}
+	deps.OperatorMoves = probe
+	if err := deps.Hub.Publish(telemetry.Snapshot{
+		GeneratedAt: time.Date(2026, 7, 22, 12, 0, 0, 0, time.UTC),
+		Project:     telemetry.Project{ID: "detent"},
+		Refresh:     telemetry.Refresh{DataSeq: 42},
+		Blocked: []telemetry.Blocked{{
+			Issue: telemetry.Issue{
+				ID:         "I_operator_move",
+				Identifier: "digitaldrywood/detent#1482",
+				ProjectID:  "detent",
+				Title:      "Operator move",
+				State:      "Blocked",
+			},
+			Source: telemetry.BlockedSourceProjectStatus,
+		}},
+	}); err != nil {
+		t.Fatalf("Publish() error = %v", err)
+	}
+	server, err := web.NewServer(web.Config{}, deps)
+	if err != nil {
+		t.Fatalf("NewServer() error = %v", err)
+	}
+
+	rec := performForm(t, server.Handler(), http.MethodPost, "/api/v1/kanban/move", url.Values{
+		"project_id":    {"detent"},
+		"issue_id":      {"I_operator_move"},
+		"current_state": {"Blocked"},
+		"target_state":  {"Rework"},
+	})
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d; body = %s", rec.Code, http.StatusOK, rec.Body.String())
+	}
+	want := orchestrator.OperatorMoveRequest{
+		ProjectID:  "detent",
+		IssueID:    "I_operator_move",
+		Identifier: "digitaldrywood/detent#1482",
+		FromState:  "Blocked",
+		ToState:    "Rework",
+	}
+	if probe.calls != 1 || probe.request != want {
+		t.Fatalf("operator move reconciliation = calls %d request %#v, want one %#v", probe.calls, probe.request, want)
+	}
+}
+
 func TestKanbanMoveRejectsMissingConnectorCapability(t *testing.T) {
 	t.Parallel()
 
@@ -11978,6 +12034,19 @@ type refreshProbe struct {
 	response web.RefreshResponse
 	err      error
 	calls    int
+}
+
+type operatorMoveProbe struct {
+	request orchestrator.OperatorMoveRequest
+	result  orchestrator.OperatorMoveResult
+	err     error
+	calls   int
+}
+
+func (p *operatorMoveProbe) ReconcileOperatorMove(_ context.Context, request orchestrator.OperatorMoveRequest) (orchestrator.OperatorMoveResult, error) {
+	p.calls++
+	p.request = request
+	return p.result, p.err
 }
 
 func (p *refreshProbe) RequestRefresh(context.Context) (web.RefreshResponse, error) {


### PR DESCRIPTION
## Summary

- synchronize confirmed Blocked-to-non-Blocked Kanban moves with the orchestrator event loop before returning success
- clear only the moved item's project-status block, claim, retry, and failure-breaker memory while preserving unrelated blockers
- cover degraded blocked-status refresh dispatch, runtime/API count convergence, configured inactive targets, and operator-move audit telemetry

Fixes #1482

## UI Surface Contract

- [x] N/A; this PR does not change UI layout, density, first-viewport, or responsive visibility.
- [x] This PR does not add persistent top-of-screen messaging.
- [x] N/A; this PR does not make visual changes to primary operator screens.

## Test Plan

- [x] `go test ./internal/orchestrator ./internal/web ./internal/cli -count=1`
- [x] `make check`
