### PR TITLE
fix(shutdown): stabilize drain teardown

### DIFF
--- a/cmd/detent/main_test.go
+++ b/cmd/detent/main_test.go
@@ -428,7 +428,7 @@ func TestWriteSignalShutdownNotice(t *testing.T) {
 	}
 }
 
-func TestHandleShutdownSignalHardExitsOnForceInterrupt(t *testing.T) {
+func TestHandleShutdownSignalQueuesForceInterrupt(t *testing.T) {
 	t.Parallel()
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -441,15 +441,8 @@ func TestHandleShutdownSignalHardExitsOnForceInterrupt(t *testing.T) {
 		},
 	}
 	var output bytes.Buffer
-	var exits []int
-
-	if done := handleShutdownSignal(interrupts, cancel, &output, func(code int) {
-		exits = append(exits, code)
-	}); done {
+	if request, done := handleShutdownSignal(interrupts, cancel, &output); done || request != cli.ShutdownRequestDrain {
 		t.Fatal("first interrupt stopped signal loop")
-	}
-	if len(exits) != 0 {
-		t.Fatalf("first interrupt exit codes = %v, want none", exits)
 	}
 	select {
 	case <-ctx.Done():
@@ -457,13 +450,8 @@ func TestHandleShutdownSignalHardExitsOnForceInterrupt(t *testing.T) {
 	default:
 	}
 
-	if done := handleShutdownSignal(interrupts, cancel, &output, func(code int) {
-		exits = append(exits, code)
-	}); !done {
-		t.Fatal("force interrupt did not stop signal loop")
-	}
-	if len(exits) != 1 || exits[0] != cli.ExitGeneral {
-		t.Fatalf("force interrupt exit codes = %v, want [%d]", exits, cli.ExitGeneral)
+	if request, done := handleShutdownSignal(interrupts, cancel, &output); done || request != cli.ShutdownRequestForce {
+		t.Fatalf("force interrupt = %v, done %v, want force request without stopping signal loop", request, done)
 	}
 
 	notice := output.String()
@@ -491,11 +479,7 @@ func TestHandleShutdownSignalSuppressesHandledNotices(t *testing.T) {
 		suppressNotices: true,
 	}
 	var output bytes.Buffer
-	var exits []int
-
-	if done := handleShutdownSignal(interrupts, cancel, &output, func(code int) {
-		exits = append(exits, code)
-	}); done {
+	if request, done := handleShutdownSignal(interrupts, cancel, &output); done || request != cli.ShutdownRequestDrain {
 		t.Fatal("first interrupt stopped signal loop")
 	}
 	if got := output.String(); got != "" {
@@ -507,16 +491,11 @@ func TestHandleShutdownSignalSuppressesHandledNotices(t *testing.T) {
 	default:
 	}
 
-	if done := handleShutdownSignal(interrupts, cancel, &output, func(code int) {
-		exits = append(exits, code)
-	}); !done {
-		t.Fatal("force interrupt did not stop signal loop")
+	if request, done := handleShutdownSignal(interrupts, cancel, &output); done || request != cli.ShutdownRequestForce {
+		t.Fatalf("force interrupt = %v, done %v, want force request without stopping signal loop", request, done)
 	}
 	if got := output.String(); got != "" {
 		t.Fatalf("force interrupt wrote suppressed notice:\n%s", got)
-	}
-	if len(exits) != 1 || exits[0] != cli.ExitGeneral {
-		t.Fatalf("force interrupt exit codes = %v, want [%d]", exits, cli.ExitGeneral)
 	}
 }
 

--- a/cmd/detent/signal.go
+++ b/cmd/detent/signal.go
@@ -8,9 +8,12 @@ import (
 	"os"
 	"os/signal"
 	"sync"
+	"time"
 
 	"github.com/digitaldrywood/detent/internal/cli"
 )
+
+const signalForceExitDeadline = 5 * time.Second
 
 func newSignalContext(parent context.Context) (context.Context, context.CancelFunc) {
 	return signal.NotifyContext(parent, shutdownSignals()...)
@@ -37,12 +40,29 @@ func notifyShutdownRequests(controller *cli.ShutdownController, cancelRoot conte
 	go func() {
 		defer close(done)
 		defer signal.Stop(signals)
+		var forceExitTimer *time.Timer
+		defer func() {
+			if forceExitTimer != nil {
+				forceExitTimer.Stop()
+			}
+		}()
 		for {
 			select {
 			case <-stop:
 				return
 			case <-signals:
-				if handleShutdownSignal(controller, cancelRoot, noticeOut, hardExit) {
+				request, stopLoop := handleShutdownSignal(controller, cancelRoot, noticeOut)
+				if request == cli.ShutdownRequestForce {
+					if forceExitTimer == nil {
+						forceExitTimer = time.AfterFunc(signalForceExitDeadline, func() {
+							hardExitSignal(hardExit)
+						})
+					} else {
+						hardExitSignal(hardExit)
+						return
+					}
+				}
+				if stopLoop {
 					return
 				}
 			}
@@ -59,7 +79,7 @@ func notifyShutdownRequests(controller *cli.ShutdownController, cancelRoot conte
 	}
 }
 
-func handleShutdownSignal(controller shutdownInterruptRequester, cancelRoot context.CancelFunc, noticeOut io.Writer, hardExit func(int)) bool {
+func handleShutdownSignal(controller shutdownInterruptRequester, cancelRoot context.CancelFunc, noticeOut io.Writer) (cli.ShutdownRequest, bool) {
 	var request cli.ShutdownRequest
 	var handled bool
 	if controller != nil {
@@ -69,17 +89,13 @@ func handleShutdownSignal(controller shutdownInterruptRequester, cancelRoot cont
 	if !handled || !signalNoticesSuppressed(controller) {
 		writeSignalShutdownNotice(noticeOut, request)
 	}
-	if request == cli.ShutdownRequestForce {
-		hardExitSignal(hardExit)
-		return true
-	}
 	if handled {
-		return false
+		return request, false
 	}
 	if cancelRoot != nil {
 		cancelRoot()
 	}
-	return true
+	return request, true
 }
 
 func signalNoticesSuppressed(controller shutdownInterruptRequester) bool {

--- a/internal/cli/boot.go
+++ b/internal/cli/boot.go
@@ -363,7 +363,7 @@ func startRunningWithDependencies(ctx context.Context, cfg BootConfig, deps star
 		resourceWorkers.Wait()
 	}()
 	resourceWorkers.Go(func() {
-		publishSnapshots(runCtx, manager.Registry(), snapshotHub, snapshotSeq, runtimeStore, displayURL, defaultSnapshotInterval, time.Now, updateScheduler)
+		publishSnapshots(runCtx, manager.Registry(), snapshotHub, snapshotSeq, cfg.Shutdown, runtimeStore, displayURL, defaultSnapshotInterval, time.Now, updateScheduler)
 	})
 	go republishSnapshotsOnProjectEvents(runCtx, events, snapshotHub, logger) // #nosec G118 -- runCtx is the service-lifetime context canceled during shutdown.
 	resourceWorkers.Go(func() {
@@ -437,19 +437,15 @@ func startRunningWithDependencies(ctx context.Context, cfg BootConfig, deps star
 				return serveWithTerminalDashboard(ctx, server, listener, snapshotHub, cfg.Build, runtimeLogPath(cfg), cfg.Output, nil, nil, nil)
 			})
 		}
-		var forceExitRequested atomic.Bool
 		return runStartupAndServe(runCtx, startProjects, func(ctx context.Context) error {
 			return runWithShutdown(ctx, runningShutdownConfig{
-				Controller:         cfg.Shutdown,
-				Registry:           manager.Registry(),
-				SnapshotHub:        snapshotHub,
-				SnapshotSeq:        snapshotSeq,
-				LifetimeSource:     runtimeStore,
-				UpdateStatusSource: updateScheduler,
-				DashboardURL:       displayURL,
-				Output:             cfg.Output,
-				Logger:             logger,
-				TerminalDashboard:  true,
+				Controller:        cfg.Shutdown,
+				Registry:          manager.Registry(),
+				SnapshotHub:       snapshotHub,
+				SnapshotSeq:       snapshotSeq,
+				Output:            cfg.Output,
+				Logger:            logger,
+				TerminalDashboard: true,
 				DrainTimeoutSource: func() time.Duration {
 					return shutdownDrainTimeout(manager.Registry())
 				},
@@ -461,14 +457,8 @@ func startRunningWithDependencies(ctx context.Context, cfg BootConfig, deps star
 				return serveWithTerminalDashboard(ctx, server, listener, snapshotHub, cfg.Build, runtimeLogPath(cfg), cfg.Output, func() time.Duration {
 					return shutdownDrainTimeout(manager.Registry())
 				}, func() {
-					requestTerminalShutdownInterrupt(cfg.Shutdown, func(int) {
-						forceExitRequested.Store(true)
-					})
-				}, func() {
-					if forceExitRequested.Load() {
-						hardExitProcess(cfg.HardExit)
-					}
-				})
+					requestTerminalShutdownInterrupt(cfg.Shutdown)
+				}, nil)
 			})
 		})
 	}
@@ -483,15 +473,12 @@ func startRunningWithDependencies(ctx context.Context, cfg BootConfig, deps star
 	}
 	return runStartupAndServe(runCtx, startProjects, func(ctx context.Context) error {
 		return runWithShutdown(ctx, runningShutdownConfig{
-			Controller:         cfg.Shutdown,
-			Registry:           manager.Registry(),
-			SnapshotHub:        snapshotHub,
-			SnapshotSeq:        snapshotSeq,
-			LifetimeSource:     runtimeStore,
-			UpdateStatusSource: updateScheduler,
-			DashboardURL:       displayURL,
-			Output:             cfg.Output,
-			Logger:             logger,
+			Controller:  cfg.Shutdown,
+			Registry:    manager.Registry(),
+			SnapshotHub: snapshotHub,
+			SnapshotSeq: snapshotSeq,
+			Output:      cfg.Output,
+			Logger:      logger,
 			DrainTimeoutSource: func() time.Duration {
 				return shutdownDrainTimeout(manager.Registry())
 			},
@@ -697,6 +684,10 @@ func runStartupAndServe(
 			if result.err != nil {
 				cancel()
 				serveResult := <-results
+				if primaryShutdownError(serveResult.err) {
+					logSecondaryShutdownError("startup", serveResult.err, result.err)
+					return serveResult.err
+				}
 				if unexpected := unexpectedBootServeError(serveResult.err); unexpected != nil {
 					return errors.Join(result.err, unexpected)
 				}
@@ -707,6 +698,10 @@ func runStartupAndServe(
 			cancel()
 			if !startupDone {
 				startupResult := <-results
+				if primaryShutdownError(result.err) {
+					logSecondaryShutdownError("startup", result.err, startupResult.err)
+					return result.err
+				}
 				if startupResult.err != nil {
 					if unexpected := unexpectedBootServeError(result.err); unexpected != nil {
 						return errors.Join(unexpected, startupResult.err)
@@ -717,6 +712,17 @@ func runStartupAndServe(
 			return result.err
 		}
 	}
+}
+
+func primaryShutdownError(err error) bool {
+	return errors.Is(err, ErrShutdownForced) || errors.Is(err, ErrShutdownTimeout)
+}
+
+func logSecondaryShutdownError(component string, primary error, secondary error) {
+	if secondary == nil || errors.Is(secondary, context.Canceled) {
+		return
+	}
+	slog.Default().Warn("shutdown cleanup error ignored in favor of primary result", "component", component, "primary", primary, "error", secondary)
 }
 
 func unexpectedBootServeError(err error) error {
@@ -873,23 +879,10 @@ func shouldLaunchTerminalDashboard(cfg BootConfig) bool {
 	return cfg.Mode == BootModeRunning && cfg.StdoutTTY && !cfg.Headless
 }
 
-func requestTerminalShutdownInterrupt(controller *ShutdownController, hardExit func(int)) bool {
+func requestTerminalShutdownInterrupt(controller *ShutdownController) bool {
 	request, handled := controller.RequestInterruptKind()
 	slog.Default().Debug("shutdown interrupt request", "operation", "shutdown_interrupt_request", "source", "terminal_dashboard", "request", request.String(), "handled", handled)
-	if !handled {
-		return false
-	}
-	if request == ShutdownRequestForce {
-		hardExitProcess(hardExit)
-	}
-	return true
-}
-
-func hardExitProcess(hardExit func(int)) {
-	if hardExit == nil {
-		hardExit = os.Exit
-	}
-	hardExit(ExitGeneral)
+	return handled
 }
 
 func redirectDefaultLogger(path string, level string) (func(), error) {

--- a/internal/cli/runner.go
+++ b/internal/cli/runner.go
@@ -303,6 +303,7 @@ func publishSnapshots(
 	registry *project.Registry,
 	snapshotHub *hub.Hub[telemetry.Snapshot],
 	seq *atomic.Uint64,
+	shutdown *ShutdownController,
 	lifetimeSource lifetimeTotalsSource,
 	dashboardURL string,
 	interval time.Duration,
@@ -327,7 +328,7 @@ func publishSnapshots(
 	defer ticker.Stop()
 
 	for {
-		if err := publishSnapshotOnce(ctx, registry, snapshotHub, seq, now(), trend, lifetimeSource, dashboardURL, updateSources...); err != nil {
+		if err := publishSnapshotOnce(ctx, registry, snapshotHub, seq, shutdown, now(), trend, lifetimeSource, dashboardURL, updateSources...); err != nil {
 			slog.Default().Warn("publish telemetry snapshot failed", "error", err)
 		}
 		select {
@@ -525,6 +526,7 @@ func publishSnapshotOnce(
 	registry *project.Registry,
 	snapshotHub *hub.Hub[telemetry.Snapshot],
 	seq *atomic.Uint64,
+	shutdown *ShutdownController,
 	now time.Time,
 	trend *tokenTrendRecorder,
 	lifetimeSource lifetimeTotalsSource,
@@ -621,6 +623,9 @@ func publishSnapshotOnce(
 	}
 	merged.LifetimeTotals = lifetimeTotals(ctx, lifetimeSource)
 	merged.Update = telemetryUpdateStatus(updateSources)
+	if status, ok := shutdown.currentShutdownStatus(); ok {
+		merged.Shutdown = status
+	}
 	merged.Seq = seq.Add(1)
 	if current, ok := snapshotHub.Latest(); ok && current.LastKnown && now.Before(current.LastKnownUntil) && !boardsnapshot.Eligible(merged) {
 		return nil

--- a/internal/cli/runner_test.go
+++ b/internal/cli/runner_test.go
@@ -519,7 +519,7 @@ func TestPublishSnapshotsPublishesToHub(t *testing.T) {
 	var seq atomic.Uint64
 	go func() {
 		defer close(done)
-		publishSnapshots(ctx, registry, snapshotHub, &seq, nil, "http://localhost:4101", 5*time.Millisecond, func() time.Time { return now })
+		publishSnapshots(ctx, registry, snapshotHub, &seq, nil, nil, "http://localhost:4101", 5*time.Millisecond, func() time.Time { return now })
 	}()
 
 	var (
@@ -569,7 +569,7 @@ func TestPublishSnapshotOnceAssignsMonotonicSeq(t *testing.T) {
 	now := time.Date(2026, 7, 8, 12, 0, 0, 0, time.UTC)
 
 	for index := range 3 {
-		if err := publishSnapshotOnce(context.Background(), registry, snapshotHub, &seq, now.Add(time.Duration(index)*time.Second), nil, nil, "http://localhost:4101"); err != nil {
+		if err := publishSnapshotOnce(context.Background(), registry, snapshotHub, &seq, nil, now.Add(time.Duration(index)*time.Second), nil, nil, "http://localhost:4101"); err != nil {
 			t.Fatalf("publishSnapshotOnce(%d) error = %v", index, err)
 		}
 		snapshot, ok := snapshotHub.Latest()
@@ -610,7 +610,7 @@ func TestPublishSnapshotOncePreservesLastKnownSnapshotUntilHydration(t *testing.
 		t.Fatalf("Publish(cached) error = %v", err)
 	}
 	var seq atomic.Uint64
-	if err := publishSnapshotOnce(context.Background(), registry, snapshotHub, &seq, cached.GeneratedAt.Add(time.Minute), nil, nil, ""); err != nil {
+	if err := publishSnapshotOnce(context.Background(), registry, snapshotHub, &seq, nil, cached.GeneratedAt.Add(time.Minute), nil, nil, ""); err != nil {
 		t.Fatalf("publishSnapshotOnce() error = %v", err)
 	}
 
@@ -647,7 +647,7 @@ func TestPublishSnapshotOnceExpiresLastKnownSnapshotDuringHydration(t *testing.T
 		t.Fatalf("Publish(cached) error = %v", err)
 	}
 	var seq atomic.Uint64
-	if err := publishSnapshotOnce(context.Background(), registry, snapshotHub, &seq, expiresAt, nil, nil, ""); err != nil {
+	if err := publishSnapshotOnce(context.Background(), registry, snapshotHub, &seq, nil, expiresAt, nil, nil, ""); err != nil {
 		t.Fatalf("publishSnapshotOnce() error = %v", err)
 	}
 
@@ -733,7 +733,7 @@ func TestPublishSnapshotOncePreservesProjectDataSeq(t *testing.T) {
 	snapshotHub := hub.New[telemetry.Snapshot]()
 	var seq atomic.Uint64
 	now := time.Date(2026, 7, 8, 12, 15, 0, 0, time.UTC)
-	if err := publishSnapshotOnce(context.Background(), registry, snapshotHub, &seq, now, nil, nil, "http://localhost:4101"); err != nil {
+	if err := publishSnapshotOnce(context.Background(), registry, snapshotHub, &seq, nil, now, nil, nil, "http://localhost:4101"); err != nil {
 		t.Fatalf("publishSnapshotOnce() error = %v", err)
 	}
 
@@ -779,7 +779,7 @@ func TestPublishSnapshotOnceDoesNotLetPausedProjectsHoldFleetReadiness(t *testin
 	snapshotHub := hub.New[telemetry.Snapshot]()
 	now := time.Date(2026, 6, 22, 14, 0, 0, 0, time.UTC)
 	var seq atomic.Uint64
-	if err := publishSnapshotOnce(context.Background(), registry, snapshotHub, &seq, now, nil, nil, "http://localhost:4101"); err != nil {
+	if err := publishSnapshotOnce(context.Background(), registry, snapshotHub, &seq, nil, now, nil, nil, "http://localhost:4101"); err != nil {
 		t.Fatalf("publishSnapshotOnce() error = %v", err)
 	}
 
@@ -840,7 +840,7 @@ func TestPublishSnapshotOnceSurfacesProjectStartupError(t *testing.T) {
 	snapshotHub := hub.New[telemetry.Snapshot]()
 	now := time.Date(2026, 6, 23, 14, 0, 0, 0, time.UTC)
 	var seq atomic.Uint64
-	if err := publishSnapshotOnce(context.Background(), registry, snapshotHub, &seq, now, nil, nil, "http://localhost:4101"); err != nil {
+	if err := publishSnapshotOnce(context.Background(), registry, snapshotHub, &seq, nil, now, nil, nil, "http://localhost:4101"); err != nil {
 		t.Fatalf("publishSnapshotOnce() error = %v", err)
 	}
 
@@ -943,7 +943,7 @@ func TestPublishSnapshotOncePausedProjectSuppressesStartupError(t *testing.T) {
 	snapshotHub := hub.New[telemetry.Snapshot]()
 	now := time.Date(2026, 6, 23, 14, 30, 0, 0, time.UTC)
 	var seq atomic.Uint64
-	if err := publishSnapshotOnce(context.Background(), registry, snapshotHub, &seq, now, nil, nil, "http://localhost:4101"); err != nil {
+	if err := publishSnapshotOnce(context.Background(), registry, snapshotHub, &seq, nil, now, nil, nil, "http://localhost:4101"); err != nil {
 		t.Fatalf("publishSnapshotOnce() error = %v", err)
 	}
 
@@ -1056,7 +1056,7 @@ func TestPublishSnapshotOncePreservesPipeline(t *testing.T) {
 
 	snapshotHub := hub.New[telemetry.Snapshot]()
 	var seq atomic.Uint64
-	if err := publishSnapshotOnce(context.Background(), registry, snapshotHub, &seq, now, nil, nil, "http://localhost:4101"); err != nil {
+	if err := publishSnapshotOnce(context.Background(), registry, snapshotHub, &seq, nil, now, nil, nil, "http://localhost:4101"); err != nil {
 		t.Fatalf("publishSnapshotOnce() error = %v", err)
 	}
 

--- a/internal/cli/runner_test.go
+++ b/internal/cli/runner_test.go
@@ -884,6 +884,7 @@ func TestPublishSnapshotOnceSurfacesPendingConnectorRetry(t *testing.T) {
 		registry,
 		snapshotHub,
 		&seq,
+		nil,
 		lastErrorAt,
 		nil,
 		nil,

--- a/internal/cli/shutdown.go
+++ b/internal/cli/shutdown.go
@@ -615,9 +615,6 @@ func liveShutdownRunningSessions(ctx context.Context, registry *project.Registry
 }
 
 func initialShutdownRunningSessions(ctx context.Context, cfg runningShutdownConfig, now time.Time) ([]telemetry.Running, bool) {
-	if sessions, ok := cachedShutdownRunningSessions(cfg); ok {
-		return sessions, true
-	}
 	return boundedShutdownRunningSessions(ctx, cfg, now)
 }
 

--- a/internal/cli/shutdown.go
+++ b/internal/cli/shutdown.go
@@ -29,6 +29,7 @@ const (
 	defaultShutdownProgressInterval = 15 * time.Second
 	defaultShutdownHardTimeout      = 5 * time.Second
 	shutdownDrainPollInterval       = 500 * time.Millisecond
+	shutdownInventoryTimeout        = 100 * time.Millisecond
 )
 
 type ShutdownRequest int
@@ -42,6 +43,8 @@ type ShutdownController struct {
 	requests                chan ShutdownRequest
 	active                  atomic.Bool
 	shutdownRequested       atomic.Bool
+	forceRequested          atomic.Bool
+	shutdownStatus          atomic.Pointer[telemetry.Shutdown]
 	signalNoticesSuppressed atomic.Bool
 }
 
@@ -70,6 +73,7 @@ func (c *ShutdownController) RequestDrainIfIdle(accepted func()) bool {
 func (c *ShutdownController) RequestForce() {
 	if c != nil {
 		c.shutdownRequested.Store(true)
+		c.forceRequested.Store(true)
 	}
 	c.request(ShutdownRequestForce)
 }
@@ -89,6 +93,28 @@ func (c *ShutdownController) SignalNoticesSuppressed() bool {
 	return c != nil && c.signalNoticesSuppressed.Load()
 }
 
+func (c *ShutdownController) ForceRequested() bool {
+	return c != nil && c.forceRequested.Load()
+}
+
+func (c *ShutdownController) currentShutdownStatus() (telemetry.Shutdown, bool) {
+	if c == nil {
+		return telemetry.Shutdown{}, false
+	}
+	status := c.shutdownStatus.Load()
+	if status == nil {
+		return telemetry.Shutdown{}, false
+	}
+	return *status, true
+}
+
+func (c *ShutdownController) publishShutdownStatus(status telemetry.Shutdown) {
+	if c == nil {
+		return
+	}
+	c.shutdownStatus.Store(&status)
+}
+
 func (c *ShutdownController) RequestInterrupt() bool {
 	_, handled := c.RequestInterruptKind()
 	return handled
@@ -102,6 +128,7 @@ func (c *ShutdownController) RequestInterruptKind() (ShutdownRequest, bool) {
 		c.request(ShutdownRequestDrain)
 		return ShutdownRequestDrain, true
 	}
+	c.forceRequested.Store(true)
 	c.request(ShutdownRequestForce)
 	return ShutdownRequestForce, true
 }
@@ -111,10 +138,14 @@ func (c *ShutdownController) activate() func() {
 		return func() {}
 	}
 	c.shutdownRequested.Store(false)
+	c.forceRequested.Store(false)
+	c.shutdownStatus.Store(nil)
 	c.active.Store(true)
 	return func() {
 		c.active.Store(false)
 		c.shutdownRequested.Store(false)
+		c.forceRequested.Store(false)
+		c.shutdownStatus.Store(nil)
 	}
 }
 
@@ -146,9 +177,6 @@ type runningShutdownConfig struct {
 	Registry           *project.Registry
 	SnapshotHub        *hub.Hub[telemetry.Snapshot]
 	SnapshotSeq        *atomic.Uint64
-	LifetimeSource     lifetimeTotalsSource
-	UpdateStatusSource autoUpdateStatusSource
-	DashboardURL       string
 	Output             io.Writer
 	Logger             *slog.Logger
 	TerminalDashboard  bool
@@ -188,15 +216,23 @@ func runWithShutdown(ctx context.Context, cfg runningShutdownConfig, serve shutd
 	for {
 		select {
 		case err := <-serveErrs:
+			if cfg.Controller.ForceRequested() {
+				machine = machine.Apply(shutdownstate.EventForceRequested)
+				sessions, _ := cachedShutdownRunningSessions(cfg)
+				return runForceShutdown(ctx, cfg, cancelServe, serveErrs, machine, "forced", sessions)
+			}
 			if ctx.Err() != nil && unexpectedShutdownServeError(err) == nil {
 				return ctx.Err()
 			}
 			return unexpectedShutdownServeError(err)
 		case <-ctx.Done():
-			cancelServe()
-			if err := loggedWaitForServeExit(context.Background(), cfg, serveErrs); err != nil {
-				return err
+			if cfg.Controller.ForceRequested() {
+				machine = machine.Apply(shutdownstate.EventForceRequested)
+				sessions, _ := cachedShutdownRunningSessions(cfg)
+				return runForceShutdown(ctx, cfg, cancelServe, serveErrs, machine, "forced", sessions)
 			}
+			cancelServe()
+			waitForServeCleanup(ctx, cfg, serveErrs, ctx.Err())
 			return ctx.Err()
 		case request := <-cfg.Controller.Requests():
 			shutdownLogger(cfg).Debug("shutdown request received", "operation", "shutdown_request", "request", request.String())
@@ -206,7 +242,8 @@ func runWithShutdown(ctx context.Context, cfg runningShutdownConfig, serve shutd
 				return runDrainShutdown(ctx, cfg, cancelServe, serveErrs, machine)
 			case ShutdownRequestForce:
 				machine = machine.Apply(shutdownstate.EventForceRequested)
-				return runForceShutdown(ctx, cfg, cancelServe, serveErrs, machine, "forced")
+				sessions, _ := cachedShutdownRunningSessions(cfg)
+				return runForceShutdown(ctx, cfg, cancelServe, serveErrs, machine, "forced", sessions)
 			}
 		}
 	}
@@ -222,8 +259,9 @@ func runDrainShutdown(
 	startedAt := shutdownNow(cfg)
 	drainTimeout := shutdownDrainTimeoutForConfig(cfg)
 	inventoryStarted := logShutdownBoundaryBegin(shutdownLogger(cfg), "initial_running_session_inventory")
-	sessions := shutdownRunningSessions(ctx, cfg.Registry, startedAt)
-	logShutdownBoundaryEnd(shutdownLogger(cfg), "initial_running_session_inventory", inventoryStarted, nil, "sessions", len(sessions))
+	sessions, inventoryKnown := initialShutdownRunningSessions(ctx, cfg, startedAt)
+	logShutdownBoundaryEndResult(shutdownLogger(cfg), "initial_running_session_inventory", inventoryStarted, shutdownInventoryResult(inventoryKnown), nil, "sessions", len(sessions))
+	publishShutdownSnapshot(cfg, startedAt, startedAt, sessions)
 	logShutdownDrainBlockers(cfg, "initial", sessions, drainTimeout)
 	writeShutdownBanner(shutdownOutput(cfg), sessions, drainTimeout)
 	shutdownLogger(cfg).Info("shutdown requested", "sessions", len(sessions))
@@ -233,18 +271,14 @@ func runDrainShutdown(
 		hardTimeout = defaultShutdownHardTimeout
 	}
 	drainCtx, cancelDrain := context.WithTimeout(ctx, hardTimeout)
-	if err := runLoggedShutdownStep(drainCtx, cfg, "drain_projects", func(stepCtx context.Context) error {
-		return drainProjects(stepCtx, cfg.Registry, shutdownLogger(cfg))
-	}); err != nil {
-		shutdownLogger(cfg).Warn("drain projects during shutdown failed", "error", err)
-	}
-	cancelDrain()
-	publishShutdownSnapshot(ctx, cfg, startedAt)
-
-	if len(sessions) == 0 {
-		machine = machine.Apply(shutdownstate.EventDrained)
-		return completeShutdown(ctx, cfg, cancelServe, serveErrs, startedAt, machine, nil)
-	}
+	defer cancelDrain()
+	drainErrs := make(chan error, 1)
+	go func() {
+		drainErrs <- runLoggedShutdownStep(drainCtx, cfg, "drain_projects", func(stepCtx context.Context) error {
+			return drainProjects(stepCtx, cfg.Registry, shutdownLogger(cfg))
+		})
+	}()
+	drainComplete := false
 
 	progressInterval := cfg.ProgressInterval
 	if progressInterval <= 0 {
@@ -264,35 +298,55 @@ func runDrainShutdown(
 	}
 
 	for {
-		sessions = shutdownRunningSessions(ctx, cfg.Registry, shutdownNow(cfg))
-		if len(sessions) == 0 {
+		if drainComplete && inventoryKnown && len(sessions) == 0 {
 			machine = machine.Apply(shutdownstate.EventDrained)
 			return completeShutdown(ctx, cfg, cancelServe, serveErrs, startedAt, machine, nil)
 		}
 
 		select {
 		case err := <-serveErrs:
+			if cfg.Controller.ForceRequested() {
+				cancelDrain()
+				machine = machine.Apply(shutdownstate.EventForceRequested)
+				return runForceShutdown(ctx, cfg, cancelServe, serveErrs, machine, "forced", sessions)
+			}
 			return unexpectedShutdownServeError(err)
 		case <-ctx.Done():
-			cancelServe()
-			if err := loggedWaitForServeExit(context.Background(), cfg, serveErrs); err != nil {
-				return err
+			cancelDrain()
+			if cfg.Controller.ForceRequested() {
+				machine = machine.Apply(shutdownstate.EventForceRequested)
+				return runForceShutdown(ctx, cfg, cancelServe, serveErrs, machine, "forced", sessions)
 			}
+			cancelServe()
+			waitForServeCleanup(ctx, cfg, serveErrs, ctx.Err())
 			return ctx.Err()
 		case request := <-cfg.Controller.Requests():
 			shutdownLogger(cfg).Debug("shutdown request received", "operation", "shutdown_request", "request", request.String())
 			if request == ShutdownRequestForce {
+				cancelDrain()
 				machine = machine.Apply(shutdownstate.EventForceRequested)
-				return runForceShutdown(ctx, cfg, cancelServe, serveErrs, machine, "forced")
+				return runForceShutdown(ctx, cfg, cancelServe, serveErrs, machine, "forced", sessions)
+			}
+		case err := <-drainErrs:
+			drainComplete = true
+			drainErrs = nil
+			if err != nil {
+				shutdownLogger(cfg).Warn("drain projects during shutdown failed", "error", err)
 			}
 		case <-poll.C:
+			if current, ok := boundedShutdownRunningSessions(ctx, cfg, shutdownNow(cfg)); ok {
+				sessions = current
+				inventoryKnown = true
+			}
+			publishShutdownSnapshot(cfg, shutdownNow(cfg), startedAt, sessions)
 		case <-progress.C:
 			logShutdownDrainBlockers(cfg, "progress", sessions, drainTimeout)
 			writeShutdownProgress(shutdownOutput(cfg), sessions, shutdownDrainRemaining(startedAt, drainTimeout, shutdownNow(cfg)))
 		case <-timeout:
+			cancelDrain()
 			machine = machine.Apply(shutdownstate.EventDrainTimedOut)
 			logShutdownDrainTimeout(cfg, sessions, drainTimeout)
-			return runForceShutdownWithDeadline(ctx, cfg, cancelServe, serveErrs, machine, "drain timeout", ErrShutdownTimeout, hardTimeout)
+			return runForceShutdownWithDeadline(ctx, cfg, cancelServe, serveErrs, machine, "drain timeout", ErrShutdownTimeout, hardTimeout, sessions)
 		}
 	}
 }
@@ -304,12 +358,13 @@ func runForceShutdown(
 	serveErrs <-chan error,
 	machine shutdownstate.Machine,
 	result string,
+	sessions []telemetry.Running,
 ) error {
 	hardTimeout := cfg.HardTimeout
 	if hardTimeout <= 0 {
 		hardTimeout = defaultShutdownHardTimeout
 	}
-	return runForceShutdownWithDeadline(ctx, cfg, cancelServe, serveErrs, machine, result, ErrShutdownForced, hardTimeout)
+	return runForceShutdownWithDeadline(ctx, cfg, cancelServe, serveErrs, machine, result, ErrShutdownForced, hardTimeout, sessions)
 }
 
 func runForceShutdownWithDeadline(
@@ -321,27 +376,22 @@ func runForceShutdownWithDeadline(
 	result string,
 	returnErr error,
 	hardTimeout time.Duration,
+	sessions []telemetry.Running,
 ) error {
 	startedAt := shutdownNow(cfg)
-	inventoryStarted := logShutdownBoundaryBegin(shutdownLogger(cfg), "force_running_session_inventory")
-	sessions := shutdownRunningSessions(ctx, cfg.Registry, startedAt)
-	logShutdownBoundaryEnd(shutdownLogger(cfg), "force_running_session_inventory", inventoryStarted, nil, "sessions", len(sessions))
 	if result == "drain timeout" {
 		fmt.Fprintf(shutdownOutput(cfg), "drain timeout reached — interrupting %d %s\n", len(sessions), shutdownSessionNoun(len(sessions)))
 	} else {
 		fmt.Fprintf(shutdownOutput(cfg), "force quit requested — interrupting %d %s\n", len(sessions), shutdownSessionNoun(len(sessions)))
 	}
 
-	forceCtx, cancel := context.WithTimeout(context.Background(), hardTimeout)
-	defer cancel()
-	if err := runLoggedShutdownStep(forceCtx, cfg, "force_projects", func(stepCtx context.Context) error {
-		return forceProjects(stepCtx, cfg.Registry, shutdownLogger(cfg))
-	}); err != nil {
-		shutdownLogger(cfg).Warn("force shutdown cleanup failed", "error", err)
+	if ctx == nil {
+		ctx = context.Background()
 	}
-	reapCtx, cancelReap := context.WithTimeout(context.Background(), hardTimeout)
+	forceCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), hardTimeout)
+	defer cancel()
 	reapErr := reapWorkerProcesses(
-		reapCtx,
+		forceCtx,
 		cfg.WorkerProcesses,
 		shutdownLogger(cfg),
 		result,
@@ -349,13 +399,16 @@ func runForceShutdownWithDeadline(
 		cfg.Now,
 		cfg.ReapWorkerProcess,
 	)
-	cancelReap()
 	if reapErr != nil {
-		shutdownLogger(cfg).Warn("worker process cleanup failed", "error", reapErr)
+		shutdownLogger(cfg).Warn("shutdown cleanup error ignored in favor of primary result", "component", "worker_processes", "primary", returnErr, "error", reapErr)
 	}
-	publishShutdownSnapshot(forceCtx, cfg, startedAt)
+	if err := runLoggedShutdownStep(forceCtx, cfg, "force_projects", func(stepCtx context.Context) error {
+		return forceProjects(stepCtx, cfg.Registry, shutdownLogger(cfg))
+	}); err != nil {
+		shutdownLogger(cfg).Warn("shutdown cleanup error ignored in favor of primary result", "component", "projects", "primary", returnErr, "error", err)
+	}
 
-	return errors.Join(completeShutdown(forceCtx, cfg, cancelServe, serveErrs, startedAt, machine, returnErr), reapErr)
+	return completeShutdown(forceCtx, cfg, cancelServe, serveErrs, startedAt, machine, returnErr)
 }
 
 func completeShutdown(
@@ -381,21 +434,44 @@ func completeShutdown(
 	}); err != nil {
 		shutdownLogger(cfg).Warn("stop projects during shutdown failed", "error", err)
 	}
+	select {
+	case err := <-serveErrs:
+		if unexpected := unexpectedShutdownServeError(err); unexpected != nil {
+			if returnErr == nil {
+				return unexpected
+			}
+			shutdownLogger(cfg).Warn("shutdown cleanup error ignored in favor of primary result", "component", "serve", "primary", returnErr, "error", unexpected)
+		}
+		return returnErr
+	default:
+	}
 
 	cancelStarted := logShutdownBoundaryBegin(shutdownLogger(cfg), "serve_cancel", "component", "serve")
 	cancelServe()
 	logShutdownBoundaryEnd(shutdownLogger(cfg), "serve_cancel", cancelStarted, nil, "component", "serve")
 	if err := loggedWaitForServeExit(stopCtx, cfg, serveErrs); err != nil {
-		if errors.Is(err, context.DeadlineExceeded) || errors.Is(err, context.Canceled) {
-			shutdownLogger(cfg).Warn("serve did not exit before shutdown deadline", "error", err)
-			return returnErr
-		}
-		return err
+		shutdownLogger(cfg).Warn("shutdown cleanup error ignored in favor of primary result", "component", "serve", "primary", returnErr, "error", err)
+		return returnErr
 	}
 
 	result := shutdownResultLabel(machine)
 	shutdownLogger(cfg).Info("shutdown complete ("+result+")", "duration", shutdownNow(cfg).Sub(startedAt))
 	return returnErr
+}
+
+func waitForServeCleanup(ctx context.Context, cfg runningShutdownConfig, serveErrs <-chan error, primary error) {
+	hardTimeout := cfg.HardTimeout
+	if hardTimeout <= 0 {
+		hardTimeout = defaultShutdownHardTimeout
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	waitCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), hardTimeout)
+	defer cancel()
+	if err := loggedWaitForServeExit(waitCtx, cfg, serveErrs); err != nil {
+		shutdownLogger(cfg).Warn("shutdown cleanup error ignored in favor of primary result", "component", "serve", "primary", primary, "error", err)
+	}
 }
 
 func runLoggedShutdownStep(ctx context.Context, cfg runningShutdownConfig, operation string, step func(context.Context) error, attrs ...any) error {
@@ -508,8 +584,13 @@ func stopProjects(ctx context.Context, registry *project.Registry, logger *slog.
 }
 
 func shutdownRunningSessions(ctx context.Context, registry *project.Registry, now time.Time) []telemetry.Running {
+	sessions, _ := liveShutdownRunningSessions(ctx, registry, now)
+	return sessions
+}
+
+func liveShutdownRunningSessions(ctx context.Context, registry *project.Registry, now time.Time) ([]telemetry.Running, bool) {
 	if registry == nil {
-		return nil
+		return nil, true
 	}
 
 	var sessions []telemetry.Running
@@ -523,14 +604,57 @@ func shutdownRunningSessions(ctx context.Context, registry *project.Registry, no
 		}
 		state, err := orch.State(ctx)
 		if err != nil {
-			continue
+			return nil, false
 		}
 		sessions = append(sessions, state.Snapshot(now).Running...)
 	}
 	sort.Slice(sessions, func(i int, j int) bool {
 		return shutdownIssueLabel(sessions[i]) < shutdownIssueLabel(sessions[j])
 	})
-	return sessions
+	return sessions, true
+}
+
+func initialShutdownRunningSessions(ctx context.Context, cfg runningShutdownConfig, now time.Time) ([]telemetry.Running, bool) {
+	if sessions, ok := cachedShutdownRunningSessions(cfg); ok {
+		return sessions, true
+	}
+	return boundedShutdownRunningSessions(ctx, cfg, now)
+}
+
+func boundedShutdownRunningSessions(ctx context.Context, cfg runningShutdownConfig, now time.Time) ([]telemetry.Running, bool) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	inventoryCtx, cancel := context.WithTimeout(ctx, shutdownInventoryTimeout)
+	defer cancel()
+	sessions, ok := liveShutdownRunningSessions(inventoryCtx, cfg.Registry, now)
+	if ok {
+		return sessions, true
+	}
+	sessions, _ = cachedShutdownRunningSessions(cfg)
+	return sessions, false
+}
+
+func cachedShutdownRunningSessions(cfg runningShutdownConfig) ([]telemetry.Running, bool) {
+	if cfg.SnapshotHub == nil {
+		return nil, false
+	}
+	snapshot, ok := cfg.SnapshotHub.Latest()
+	if !ok {
+		return nil, false
+	}
+	sessions := append([]telemetry.Running(nil), snapshot.Running...)
+	sort.Slice(sessions, func(i int, j int) bool {
+		return shutdownIssueLabel(sessions[i]) < shutdownIssueLabel(sessions[j])
+	})
+	return sessions, true
+}
+
+func shutdownInventoryResult(known bool) string {
+	if known {
+		return "ok"
+	}
+	return "cached"
 }
 
 func shutdownDrainTimeoutForConfig(cfg runningShutdownConfig) time.Duration {
@@ -544,20 +668,33 @@ func shutdownDrainTimeoutForConfig(cfg runningShutdownConfig) time.Duration {
 	return timeout
 }
 
-func publishShutdownSnapshot(ctx context.Context, cfg runningShutdownConfig, now time.Time) {
+func publishShutdownSnapshot(cfg runningShutdownConfig, now time.Time, requestedAt time.Time, sessions []telemetry.Running) {
 	started := logShutdownBoundaryBegin(shutdownLogger(cfg), "shutdown_snapshot_publish")
-	if cfg.Registry == nil || cfg.SnapshotHub == nil {
+	if cfg.SnapshotHub == nil {
 		logShutdownBoundaryEndResult(shutdownLogger(cfg), "shutdown_snapshot_publish", started, "skipped", nil)
 		return
 	}
+	snapshot, _ := cfg.SnapshotHub.Latest()
 	seq := cfg.SnapshotSeq
 	if seq == nil {
 		seq = &atomic.Uint64{}
-		if latest, ok := cfg.SnapshotHub.Latest(); ok {
-			seq.Store(latest.Seq)
-		}
 	}
-	if err := publishSnapshotOnce(ctx, cfg.Registry, cfg.SnapshotHub, seq, now, nil, cfg.LifetimeSource, cfg.DashboardURL, cfg.UpdateStatusSource); err != nil {
+	for current := seq.Load(); current < snapshot.Seq && !seq.CompareAndSwap(current, snapshot.Seq); current = seq.Load() {
+	}
+	snapshot.Seq = seq.Add(1)
+	snapshot.GeneratedAt = now
+	snapshot.Running = append([]telemetry.Running(nil), sessions...)
+	snapshot.Counts.Running = len(sessions)
+	requested := requestedAt
+	shutdownStatus := telemetry.Shutdown{
+		Status:            "draining",
+		Draining:          true,
+		SessionsRemaining: len(sessions),
+		RequestedAt:       &requested,
+	}
+	cfg.Controller.publishShutdownStatus(shutdownStatus)
+	snapshot.Shutdown = shutdownStatus
+	if err := cfg.SnapshotHub.Publish(snapshot); err != nil {
 		logShutdownBoundaryEnd(shutdownLogger(cfg), "shutdown_snapshot_publish", started, err)
 		shutdownLogger(cfg).Warn("publish shutdown telemetry snapshot failed", "error", err)
 		return

--- a/internal/cli/shutdown_test.go
+++ b/internal/cli/shutdown_test.go
@@ -577,6 +577,126 @@ func TestRunWithShutdownActiveChildProcessReportsDrainBlockersAndTimesOut(t *tes
 	}
 }
 
+func TestRunWithShutdownDoesNotTrustStaleEmptySnapshotOverLiveSession(t *testing.T) {
+	t.Parallel()
+
+	controller := NewShutdownController()
+	registry := projectpkg.NewRegistry()
+	releaseRunner := make(chan struct{})
+	runner := &shutdownBlockingRunner{
+		started:  make(chan struct{}, 1),
+		canceled: make(chan struct{}, 1),
+		release:  releaseRunner,
+	}
+	project := newShutdownRuntimeProject(t, "detent", []connector.Issue{{
+		ID:               "issue-1484",
+		Identifier:       "digitaldrywood/detent#1484",
+		Title:            "stale empty shutdown inventory",
+		State:            "Todo",
+		AssignedToWorker: true,
+	}}, runner)
+	if err := registry.Set(project); err != nil {
+		t.Fatalf("Registry.Set() error = %v", err)
+	}
+	if err := project.Start(context.Background()); err != nil {
+		t.Fatalf("Project.Start() error = %v", err)
+	}
+	t.Cleanup(func() {
+		select {
+		case <-releaseRunner:
+		default:
+			close(releaseRunner)
+		}
+		if err := project.Close(); err != nil && !errors.Is(err, projectpkg.ErrNotRunning) {
+			t.Fatalf("Project.Close() error = %v", err)
+		}
+	})
+
+	select {
+	case <-runner.started:
+	case <-time.After(time.Second):
+		t.Fatal("runner did not start")
+	}
+	waitForShutdownSession(t, registry, func(session telemetry.Running) bool {
+		return session.ID == "issue-1484"
+	})
+
+	snapshotHub := hub.New[telemetry.Snapshot]()
+	if err := snapshotHub.Publish(telemetry.Snapshot{
+		Seq:         1,
+		GeneratedAt: time.Date(2026, 7, 22, 12, 0, 0, 0, time.UTC),
+		Running:     []telemetry.Running{},
+		Counts:      telemetry.Counts{Running: 0},
+	}); err != nil {
+		t.Fatalf("SnapshotHub.Publish() error = %v", err)
+	}
+	snapshotCtx, cancelSnapshots := context.WithTimeout(context.Background(), time.Second)
+	defer cancelSnapshots()
+	snapshots, err := snapshotHub.Subscribe(snapshotCtx)
+	if err != nil {
+		t.Fatalf("SnapshotHub.Subscribe() error = %v", err)
+	}
+	defer snapshots.Close()
+
+	serveStarted := make(chan struct{})
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- runWithShutdown(context.Background(), runningShutdownConfig{
+			Controller:       controller,
+			Registry:         registry,
+			SnapshotHub:      snapshotHub,
+			DrainTimeout:     time.Second,
+			ProgressInterval: time.Hour,
+			HardTimeout:      time.Second,
+		}, func(ctx context.Context) error {
+			close(serveStarted)
+			<-ctx.Done()
+			return ctx.Err()
+		})
+	}()
+
+	select {
+	case <-serveStarted:
+	case <-time.After(time.Second):
+		t.Fatal("server did not start")
+	}
+	controller.RequestDrain()
+
+	drainObserved := false
+	for !drainObserved {
+		select {
+		case err := <-errCh:
+			t.Fatalf("shutdown completed while live session was active: %v", err)
+		case snapshot := <-snapshots.C():
+			if !snapshot.Shutdown.Draining {
+				continue
+			}
+			if snapshot.Shutdown.SessionsRemaining != 1 {
+				t.Fatalf("SessionsRemaining = %d, want live inventory count 1", snapshot.Shutdown.SessionsRemaining)
+			}
+			drainObserved = true
+		case <-snapshotCtx.Done():
+			t.Fatal("timed out waiting for draining snapshot")
+		}
+	}
+
+	select {
+	case <-runner.canceled:
+		t.Fatal("live session was canceled from stale empty shutdown inventory")
+	default:
+	}
+
+	close(releaseRunner)
+	select {
+	case err := <-errCh:
+		if err != nil {
+			t.Fatalf("runWithShutdown() error = %v, want nil", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for shutdown after live session completed")
+	}
+}
+
 type shutdownWorkerProcessStore struct {
 	processes []store.WorkerProcess
 	reaped    []shutdownWorkerProcessReap
@@ -1125,6 +1245,7 @@ func newShutdownRuntimeProjectWithConfig(t *testing.T, id string, cfg workflowco
 type shutdownBlockingRunner struct {
 	started  chan struct{}
 	canceled chan struct{}
+	release  <-chan struct{}
 }
 
 type shutdownBlockingConnector struct {
@@ -1190,12 +1311,16 @@ func (r *shutdownBlockingRunner) Run(ctx context.Context, request orchestrator.R
 	default:
 	}
 
-	<-ctx.Done()
 	select {
-	case r.canceled <- struct{}{}:
-	default:
+	case <-ctx.Done():
+		select {
+		case r.canceled <- struct{}{}:
+		default:
+		}
+		return orchestrator.RunResult{}, ctx.Err()
+	case <-r.release:
+		return orchestrator.RunResult{FinalState: orchestrator.FinalStateCompleted}, nil
 	}
-	return orchestrator.RunResult{}, ctx.Err()
 }
 
 func waitForShutdownSession(t *testing.T, registry *projectpkg.Registry, ready func(telemetry.Running) bool) telemetry.Running {

--- a/internal/cli/shutdown_test.go
+++ b/internal/cli/shutdown_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"fmt"
 	"io"
 	"log/slog"
 	"strings"
@@ -94,36 +95,25 @@ func TestShutdownControllerDrainMakesNextInterruptForce(t *testing.T) {
 	}
 }
 
-func TestRequestTerminalShutdownInterruptHardExitsOnSecondInterrupt(t *testing.T) {
+func TestRequestTerminalShutdownInterruptQueuesForcedShutdown(t *testing.T) {
 	t.Parallel()
 
 	controller := NewShutdownController()
 	deactivate := controller.activate()
 	defer deactivate()
 
-	var exits []int
-	hardExit := func(code int) {
-		exits = append(exits, code)
-	}
-
-	if !requestTerminalShutdownInterrupt(controller, hardExit) {
+	if !requestTerminalShutdownInterrupt(controller) {
 		t.Fatal("first interrupt was not handled")
-	}
-	if len(exits) != 0 {
-		t.Fatalf("first interrupt exit codes = %v, want none", exits)
 	}
 	if got := <-controller.Requests(); got != ShutdownRequestDrain {
 		t.Fatalf("first interrupt request = %v, want drain", got)
 	}
 
-	if !requestTerminalShutdownInterrupt(controller, hardExit) {
+	if !requestTerminalShutdownInterrupt(controller) {
 		t.Fatal("second interrupt was not handled")
 	}
 	if got := <-controller.Requests(); got != ShutdownRequestForce {
 		t.Fatalf("second interrupt request = %v, want force", got)
-	}
-	if len(exits) != 1 || exits[0] != ExitGeneral {
-		t.Fatalf("second interrupt exit codes = %v, want [%d]", exits, ExitGeneral)
 	}
 }
 
@@ -695,6 +685,278 @@ func TestRunWithShutdownForceReturnsForcedError(t *testing.T) {
 	}
 }
 
+func TestRunWithShutdownForceReapsOwnedWorkerGroupWithinHardDeadline(t *testing.T) {
+	t.Parallel()
+
+	controller := NewShutdownController()
+	started := make(chan struct{})
+	processStartedAt := time.Date(2026, 7, 22, 11, 0, 0, 0, time.UTC)
+	processStore := &shutdownWorkerProcessStore{processes: []store.WorkerProcess{
+		{
+			SessionID:  1484,
+			IssueID:    "issue-1484",
+			Identifier: "digitaldrywood/detent#1484",
+			WorkerProcessIdentity: store.WorkerProcessIdentity{
+				PID:       41484,
+				GroupID:   41484,
+				StartedAt: processStartedAt,
+			},
+		},
+		{
+			SessionID:  1485,
+			IssueID:    "issue-1485",
+			Identifier: "digitaldrywood/detent#1485",
+			WorkerProcessIdentity: store.WorkerProcessIdentity{
+				PID:       41485,
+				GroupID:   41485,
+				StartedAt: processStartedAt,
+			},
+		},
+	}}
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- runWithShutdown(context.Background(), runningShutdownConfig{
+			Controller:      controller,
+			Registry:        projectpkg.NewRegistry(),
+			SnapshotHub:     hub.New[telemetry.Snapshot](),
+			HardTimeout:     50 * time.Millisecond,
+			WorkerProcesses: processStore,
+			ReapWorkerProcess: func(ctx context.Context, identity procgroup.Identity, _ time.Duration) (procgroup.TerminationOutcome, error) {
+				if identity.GroupID == 41484 {
+					return procgroup.TerminationOutcomeTerminated, nil
+				}
+				<-ctx.Done()
+				return procgroup.TerminationOutcome(""), ctx.Err()
+			},
+		}, func(ctx context.Context) error {
+			close(started)
+			<-ctx.Done()
+			return ctx.Err()
+		})
+	}()
+
+	select {
+	case <-started:
+	case <-time.After(time.Second):
+		t.Fatal("server did not start")
+	}
+	forceStarted := time.Now()
+	controller.RequestForce()
+
+	select {
+	case err := <-errCh:
+		if !errors.Is(err, ErrShutdownForced) {
+			t.Fatalf("runWithShutdown() error = %v, want ErrShutdownForced", err)
+		}
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("forced shutdown exceeded hard deadline")
+	}
+	if elapsed := time.Since(forceStarted); elapsed >= 500*time.Millisecond {
+		t.Fatalf("forced shutdown duration = %s, want under 500ms", elapsed)
+	}
+	if len(processStore.reaped) != 1 || processStore.reaped[0].sessionID != 1484 {
+		t.Fatalf("reaped worker processes = %#v, want owned group 41484", processStore.reaped)
+	}
+}
+
+func TestRunWithShutdownPublishesDrainStatusDuringBlockedConnectorRefresh(t *testing.T) {
+	t.Parallel()
+
+	refreshStarted := make(chan struct{}, 1)
+	releaseRefresh := make(chan struct{})
+	project := newRefreshProjectWithConnector(t, "detent", shutdownBlockingConnector{
+		started: refreshStarted,
+		release: releaseRefresh,
+	})
+	if err := project.Start(context.Background()); err != nil {
+		t.Fatalf("Project.Start() error = %v", err)
+	}
+	t.Cleanup(func() {
+		select {
+		case <-releaseRefresh:
+		default:
+			close(releaseRefresh)
+		}
+		ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+		defer cancel()
+		if err := project.Stop(ctx); err != nil && !errors.Is(err, projectpkg.ErrNotRunning) {
+			t.Fatalf("Project.Stop() error = %v", err)
+		}
+	})
+
+	select {
+	case <-refreshStarted:
+	case <-time.After(time.Second):
+		t.Fatal("connector refresh did not start")
+	}
+
+	registry := projectpkg.NewRegistry()
+	mustSetProject(t, registry, project)
+	requestedAt := time.Date(2026, 7, 22, 12, 0, 0, 0, time.UTC)
+	snapshotHub := hub.New[telemetry.Snapshot]()
+	if err := snapshotHub.Publish(telemetry.Snapshot{
+		GeneratedAt: requestedAt.Add(-time.Second),
+		Running: []telemetry.Running{{
+			Issue: telemetry.Issue{
+				ID:         "issue-1484",
+				Identifier: "digitaldrywood/detent#1484",
+			},
+		}},
+		Counts: telemetry.Counts{Running: 1},
+	}); err != nil {
+		t.Fatalf("SnapshotHub.Publish() error = %v", err)
+	}
+
+	controller := NewShutdownController()
+	serveStarted := make(chan struct{})
+	errs := make(chan error, 1)
+	go func() {
+		errs <- runWithShutdown(context.Background(), runningShutdownConfig{
+			Controller:  controller,
+			Registry:    registry,
+			SnapshotHub: snapshotHub,
+			HardTimeout: 100 * time.Millisecond,
+			Now:         func() time.Time { return requestedAt },
+		}, func(ctx context.Context) error {
+			close(serveStarted)
+			<-ctx.Done()
+			return ctx.Err()
+		})
+	}()
+
+	select {
+	case <-serveStarted:
+	case <-time.After(time.Second):
+		t.Fatal("server did not start")
+	}
+	controller.RequestDrain()
+
+	deadline := time.NewTimer(250 * time.Millisecond)
+	defer deadline.Stop()
+	for {
+		snapshot, ok := snapshotHub.Latest()
+		if ok && snapshot.Shutdown.Draining {
+			if snapshot.Shutdown.SessionsRemaining != 1 {
+				t.Fatalf("SessionsRemaining = %d, want 1", snapshot.Shutdown.SessionsRemaining)
+			}
+			break
+		}
+		select {
+		case <-deadline.C:
+			close(releaseRefresh)
+			<-errs
+			t.Fatal("drain status was not published while connector refresh was blocked")
+		case <-time.After(time.Millisecond):
+		}
+	}
+
+	close(releaseRefresh)
+	select {
+	case err := <-errs:
+		if err != nil {
+			t.Fatalf("runWithShutdown() error = %v, want nil", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for shutdown")
+	}
+}
+
+func TestRunWithShutdownForcedResultPrecedesServeCleanupError(t *testing.T) {
+	t.Parallel()
+
+	controller := NewShutdownController()
+	started := make(chan struct{})
+	errs := make(chan error, 1)
+	go func() {
+		errs <- runWithShutdown(context.Background(), runningShutdownConfig{
+			Controller:  controller,
+			Registry:    projectpkg.NewRegistry(),
+			SnapshotHub: hub.New[telemetry.Snapshot](),
+			HardTimeout: time.Second,
+		}, func(ctx context.Context) error {
+			close(started)
+			<-ctx.Done()
+			cause := fmt.Errorf("resolve github_token via gh auth token: %w", errors.New("context deadline exceeded"))
+			return GitHubAuthError(cause)
+		})
+	}()
+
+	select {
+	case <-started:
+	case <-time.After(time.Second):
+		t.Fatal("server did not start")
+	}
+	controller.RequestForce()
+
+	select {
+	case err := <-errs:
+		if !errors.Is(err, ErrShutdownForced) {
+			t.Fatalf("runWithShutdown() error = %v, want ErrShutdownForced", err)
+		}
+		if got := ClassifyError(err).Slug; got != errorCodeShutdownForced {
+			t.Fatalf("ClassifyError() = %q, want %q", got, errorCodeShutdownForced)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for force shutdown")
+	}
+}
+
+func TestRunWithShutdownGracefulResultPrecedesServeCleanupError(t *testing.T) {
+	t.Parallel()
+
+	controller := NewShutdownController()
+	started := make(chan struct{})
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- runWithShutdown(context.Background(), runningShutdownConfig{
+			Controller:  controller,
+			Registry:    projectpkg.NewRegistry(),
+			SnapshotHub: hub.New[telemetry.Snapshot](),
+			HardTimeout: time.Second,
+		}, func(ctx context.Context) error {
+			close(started)
+			<-ctx.Done()
+			cause := fmt.Errorf("resolve github_token via gh auth token: %w", errors.New("context deadline exceeded"))
+			return GitHubAuthError(cause)
+		})
+	}()
+
+	select {
+	case <-started:
+	case <-time.After(time.Second):
+		t.Fatal("server did not start")
+	}
+	controller.RequestDrain()
+
+	select {
+	case err := <-errCh:
+		if err != nil {
+			t.Fatalf("runWithShutdown() error = %v, want nil", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for graceful shutdown")
+	}
+}
+
+func TestRunStartupAndServeForcedResultPrecedesStartupAuthError(t *testing.T) {
+	t.Parallel()
+
+	err := runStartupAndServe(context.Background(), func(ctx context.Context) error {
+		<-ctx.Done()
+		cause := fmt.Errorf("resolve github_token via gh auth token: %w", errors.New("context deadline exceeded"))
+		return GitHubAuthError(cause)
+	}, func(context.Context) error {
+		return ErrShutdownForced
+	})
+
+	if !errors.Is(err, ErrShutdownForced) {
+		t.Fatalf("runStartupAndServe() error = %v, want ErrShutdownForced", err)
+	}
+	if got := ClassifyError(err).Slug; got != errorCodeShutdownForced {
+		t.Fatalf("ClassifyError() = %q, want %q", got, errorCodeShutdownForced)
+	}
+}
+
 func TestRunningShutdownConfigComputesDrainTimeoutFromCurrentRegistry(t *testing.T) {
 	t.Parallel()
 
@@ -730,14 +992,19 @@ func TestPublishShutdownSnapshotSharesSnapshotSeq(t *testing.T) {
 	mustSetProject(t, registry, project)
 
 	snapshotHub := hub.New[telemetry.Snapshot]()
+	controller := NewShutdownController()
 	var seq atomic.Uint64
 	seq.Store(4)
 	now := time.Date(2026, 7, 8, 12, 30, 0, 0, time.UTC)
-	publishShutdownSnapshot(context.Background(), runningShutdownConfig{
+	if err := snapshotHub.Publish(telemetry.Snapshot{Seq: 4, GeneratedAt: now.Add(-time.Second)}); err != nil {
+		t.Fatalf("SnapshotHub.Publish() error = %v", err)
+	}
+	publishShutdownSnapshot(runningShutdownConfig{
+		Controller:  controller,
 		Registry:    registry,
 		SnapshotHub: snapshotHub,
 		SnapshotSeq: &seq,
-	}, now)
+	}, now, now, nil)
 
 	shutdownSnapshot, ok := snapshotHub.Latest()
 	if !ok {
@@ -746,8 +1013,11 @@ func TestPublishShutdownSnapshotSharesSnapshotSeq(t *testing.T) {
 	if shutdownSnapshot.Seq != 5 {
 		t.Fatalf("shutdown snapshot Seq = %d, want 5", shutdownSnapshot.Seq)
 	}
+	if !shutdownSnapshot.Shutdown.Draining {
+		t.Fatal("shutdown snapshot Draining = false, want true")
+	}
 
-	if err := publishSnapshotOnce(context.Background(), registry, snapshotHub, &seq, now.Add(time.Second), nil, nil, ""); err != nil {
+	if err := publishSnapshotOnce(context.Background(), registry, snapshotHub, &seq, controller, now.Add(time.Second), nil, nil, ""); err != nil {
 		t.Fatalf("publishSnapshotOnce() error = %v", err)
 	}
 	nextSnapshot, ok := snapshotHub.Latest()
@@ -756,6 +1026,9 @@ func TestPublishShutdownSnapshotSharesSnapshotSeq(t *testing.T) {
 	}
 	if nextSnapshot.Seq != 6 {
 		t.Fatalf("next snapshot Seq = %d, want 6", nextSnapshot.Seq)
+	}
+	if !nextSnapshot.Shutdown.Draining {
+		t.Fatal("next snapshot Draining = false, want latched shutdown state")
 	}
 }
 
@@ -852,6 +1125,52 @@ func newShutdownRuntimeProjectWithConfig(t *testing.T, id string, cfg workflowco
 type shutdownBlockingRunner struct {
 	started  chan struct{}
 	canceled chan struct{}
+}
+
+type shutdownBlockingConnector struct {
+	started chan<- struct{}
+	release <-chan struct{}
+}
+
+func (c shutdownBlockingConnector) Name() string {
+	return "blocking"
+}
+
+func (c shutdownBlockingConnector) FetchCandidateIssues(ctx context.Context) ([]connector.Issue, error) {
+	select {
+	case c.started <- struct{}{}:
+	default:
+	}
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	case <-c.release:
+		return nil, nil
+	}
+}
+
+func (shutdownBlockingConnector) FetchIssuesByStates(context.Context, []string) ([]connector.Issue, error) {
+	return nil, nil
+}
+
+func (shutdownBlockingConnector) FetchIssueStatesByIDs(context.Context, []string) ([]connector.Issue, error) {
+	return nil, nil
+}
+
+func (shutdownBlockingConnector) CreateComment(context.Context, string, string) error {
+	return nil
+}
+
+func (shutdownBlockingConnector) UpdateIssueState(context.Context, string, string) error {
+	return nil
+}
+
+func (shutdownBlockingConnector) SetAssignee(context.Context, string, string) error {
+	return nil
+}
+
+func (shutdownBlockingConnector) SetField(context.Context, string, string, string) error {
+	return nil
 }
 
 func (r *shutdownBlockingRunner) Run(ctx context.Context, request orchestrator.RunRequest) (orchestrator.RunResult, error) {

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -80,9 +80,7 @@ type snapshotMsg struct {
 
 type subscriptionClosedMsg struct{}
 
-type shutdownInterruptMsg struct {
-	force bool
-}
+type shutdownInterruptMsg struct{}
 
 func NewModel(ctx context.Context, snapshots *hub.Hub[telemetry.Snapshot], opts ...Option) (Model, error) {
 	if snapshots == nil {
@@ -185,10 +183,6 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		if m.interrupt != nil {
 			m.interrupt()
 		}
-		if msg.force {
-			m.Close()
-			return m, tea.Quit
-		}
 		return m, nil
 	case tea.InterruptMsg:
 		return m.handleInterrupt()
@@ -243,9 +237,8 @@ func (m Model) handleInterrupt() (tea.Model, tea.Cmd) {
 		m.shutdownNote = shutdownDrainNotice
 	}
 
-	force := m.interrupts > 1
 	return m, func() tea.Msg {
-		return shutdownInterruptMsg{force: force}
+		return shutdownInterruptMsg{}
 	}
 }
 

--- a/internal/tui/model_test.go
+++ b/internal/tui/model_test.go
@@ -408,15 +408,14 @@ func TestModelSecondInterruptRequestsForceQuit(t *testing.T) {
 		t.Fatalf("interrupts = %d before force command runs, want 1", interrupts)
 	}
 	next, quitCmd := model.Update(cmd())
-	assertSubscriptionClosed(t, next.(Model))
 	if interrupts != 2 {
 		t.Fatalf("interrupts = %d, want 2", interrupts)
 	}
-	if quitCmd == nil {
-		t.Fatal("second interrupt did not return quit command")
+	if quitCmd != nil {
+		t.Fatal("second interrupt returned a quit command before forced cleanup completed")
 	}
-	if _, ok := quitCmd().(tea.QuitMsg); !ok {
-		t.Fatalf("second interrupt command message = %T, want tea.QuitMsg", quitCmd())
+	if next.(Model).shutdownNote != shutdownForceNotice {
+		t.Fatal("force shutdown notice did not persist while cleanup ran")
 	}
 }
 

--- a/internal/web/api.go
+++ b/internal/web/api.go
@@ -74,8 +74,10 @@ func (s *Server) apiState(c echo.Context) error {
 	if !ok {
 		return c.JSON(http.StatusOK, snapshotErrorResponse(now, "snapshot_unavailable", "Snapshot unavailable"))
 	}
-	snapshot = s.cachedEnrichedSnapshot(c.Request().Context(), snapshot)
-	snapshot = s.withManualRefresh(snapshot)
+	if !snapshot.Shutdown.Draining {
+		snapshot = s.cachedEnrichedSnapshot(c.Request().Context(), snapshot)
+		snapshot = s.withManualRefresh(snapshot)
+	}
 
 	return c.JSON(http.StatusOK, stateResponse(snapshot, generatedAt(snapshot, now), s.instanceName()))
 }

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -1050,6 +1050,12 @@ func (s *Server) health(c echo.Context) error {
 		checks["demo_clock"] = s.demo.clock
 	}
 	projectStatus, projectHealth := s.projectHealth()
+	var budgets []healthBudget
+	var workflows []healthWorkflowSource
+	if status != "draining" {
+		budgets = s.enforcedBudgets()
+		workflows = s.workflowSources()
+	}
 	return c.JSON(http.StatusOK, healthResponse{
 		Status:            status,
 		ProjectStatus:     projectStatus,
@@ -1058,8 +1064,8 @@ func (s *Server) health(c echo.Context) error {
 		SessionsRemaining: sessionsRemaining,
 		Update:            updateStatus,
 		Checks:            checks,
-		Budgets:           s.enforcedBudgets(),
-		Workflows:         s.workflowSources(),
+		Budgets:           budgets,
+		Workflows:         workflows,
 		BackendOutages:    backendOutages,
 		Projects:          projectHealth,
 	})

--- a/internal/web/server_test.go
+++ b/internal/web/server_test.go
@@ -6637,6 +6637,69 @@ func TestHealthDistinguishesProcessHealthFromProjectConnectorDegradation(t *test
 	}
 }
 
+func TestHealthRespondsDuringDrainWithoutSupplementalProjectReads(t *testing.T) {
+	t.Parallel()
+
+	deps := testDeps(t)
+	blocked := make(chan struct{}, 1)
+	release := make(chan struct{})
+	workflowCfg := workflowconfig.Default()
+	workflowCfg.Tracker.Kind = workflowconfig.TrackerMemory
+	trackedProject, err := project.New(project.Config{
+		Project:  globalconfig.Project{ID: "detent"},
+		Workflow: workflowconfig.Workflow{Config: workflowCfg, Prompt: "Work the issue."},
+	}, project.Dependencies{
+		Connector: connectorProbe{name: "memory"},
+		Runner: blockingHealthBudgetRunner{
+			blocked: blocked,
+			release: release,
+		},
+	})
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	if err := deps.Registry.Set(trackedProject); err != nil {
+		t.Fatalf("Registry.Set() error = %v", err)
+	}
+	if err := deps.Hub.Publish(telemetry.Snapshot{
+		GeneratedAt: time.Date(2026, 7, 22, 12, 0, 0, 0, time.UTC),
+		Shutdown: telemetry.Shutdown{
+			Status:            "draining",
+			Draining:          true,
+			SessionsRemaining: 2,
+		},
+	}); err != nil {
+		t.Fatalf("Publish() error = %v", err)
+	}
+
+	server, err := web.NewServer(web.Config{}, deps)
+	if err != nil {
+		t.Fatalf("NewServer() error = %v", err)
+	}
+	result := make(chan *httptest.ResponseRecorder, 1)
+	go func() {
+		rec := httptest.NewRecorder()
+		server.Handler().ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/health", nil))
+		result <- rec
+	}()
+
+	select {
+	case rec := <-result:
+		if rec.Code != http.StatusOK || !strings.Contains(rec.Body.String(), `"status":"draining"`) {
+			t.Fatalf("draining health response = %d %s", rec.Code, rec.Body.String())
+		}
+		select {
+		case <-blocked:
+			t.Fatal("draining health request read supplemental project budget")
+		default:
+		}
+	case <-time.After(250 * time.Millisecond):
+		close(release)
+		<-result
+		t.Fatal("draining health request blocked on supplemental project budget")
+	}
+}
+
 func TestHealthReportsUpdateCheckStatus(t *testing.T) {
 	t.Parallel()
 
@@ -6775,6 +6838,87 @@ func TestAPIStateReportsDraining(t *testing.T) {
 	}
 	if payload.Shutdown.RequestedAt != "2026-06-12T15:00:00Z" {
 		t.Fatalf("Shutdown.RequestedAt = %q, want RFC3339 timestamp", payload.Shutdown.RequestedAt)
+	}
+}
+
+func TestAPIStateRespondsDuringDrainWithoutStoreEnrichment(t *testing.T) {
+	t.Parallel()
+
+	deps := testDeps(t)
+	blocked := make(chan struct{}, 1)
+	release := make(chan struct{})
+	deps.Store = storeProbe{
+		budgetCostEvents: func(ctx context.Context, _ store.BudgetCostQuery) ([]store.BudgetCostEvent, error) {
+			select {
+			case blocked <- struct{}{}:
+			default:
+			}
+			select {
+			case <-ctx.Done():
+				return nil, ctx.Err()
+			case <-release:
+				return nil, nil
+			}
+		},
+	}
+	workflowCfg := workflowconfig.Default()
+	workflowCfg.Tracker.Kind = workflowconfig.TrackerMemory
+	workflowCfg.Budget.Enabled = true
+	workflowCfg.Budget.PerDayMaxUSD = 100
+	trackedProject, err := project.New(project.Config{
+		Project:  globalconfig.Project{ID: "detent"},
+		Workflow: workflowconfig.Workflow{Config: workflowCfg, Prompt: "Work the issue."},
+	}, project.Dependencies{
+		Connector: connectorProbe{name: "memory"},
+		Runner: healthBudgetRunner{budget: workflowconfig.Budget{
+			Enabled:      true,
+			PerDayMaxUSD: 100,
+		}},
+	})
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	if err := deps.Registry.Set(trackedProject); err != nil {
+		t.Fatalf("Registry.Set() error = %v", err)
+	}
+	requestedAt := time.Date(2026, 7, 22, 12, 0, 0, 0, time.UTC)
+	if err := deps.Hub.Publish(telemetry.Snapshot{
+		GeneratedAt: requestedAt,
+		Shutdown: telemetry.Shutdown{
+			Status:            "draining",
+			Draining:          true,
+			SessionsRemaining: 1,
+			RequestedAt:       &requestedAt,
+		},
+	}); err != nil {
+		t.Fatalf("Publish() error = %v", err)
+	}
+
+	server, err := web.NewServer(web.Config{}, deps)
+	if err != nil {
+		t.Fatalf("NewServer() error = %v", err)
+	}
+	result := make(chan *httptest.ResponseRecorder, 1)
+	go func() {
+		rec := httptest.NewRecorder()
+		server.Handler().ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/api/v1/state", nil))
+		result <- rec
+	}()
+
+	select {
+	case rec := <-result:
+		if rec.Code != http.StatusOK || !strings.Contains(rec.Body.String(), `"status":"draining"`) {
+			t.Fatalf("draining state response = %d %s", rec.Code, rec.Body.String())
+		}
+		select {
+		case <-blocked:
+			t.Fatal("draining state request enriched from the store")
+		default:
+		}
+	case <-time.After(250 * time.Millisecond):
+		close(release)
+		<-result
+		t.Fatal("draining state request blocked on store enrichment")
 	}
 }
 
@@ -10466,6 +10610,24 @@ func mustSetWebProject(t *testing.T, registry *project.Registry, id string, paus
 
 type healthBudgetRunner struct {
 	budget workflowconfig.Budget
+}
+
+type blockingHealthBudgetRunner struct {
+	blocked chan<- struct{}
+	release <-chan struct{}
+}
+
+func (blockingHealthBudgetRunner) Run(context.Context, orchestrator.RunRequest) (orchestrator.RunResult, error) {
+	return orchestrator.RunResult{FinalState: orchestrator.FinalStateCompleted}, nil
+}
+
+func (r blockingHealthBudgetRunner) EnforcedBudget() (workflowconfig.Budget, bool) {
+	select {
+	case r.blocked <- struct{}{}:
+	default:
+	}
+	<-r.release
+	return workflowconfig.Budget{}, false
 }
 
 func (r healthBudgetRunner) Run(context.Context, orchestrator.RunRequest) (orchestrator.RunResult, error) {


### PR DESCRIPTION
## Summary

- publish and latch draining telemetry before potentially blocked orchestrator work
- keep health and state endpoints responsive during drain without store or project enrichment
- preserve forced and timed-out shutdown results over cancellation cleanup noise while reaping owned worker groups under one deadline
- route second signal and TUI interrupts through the shutdown state machine with a bounded OS fallback

Fixes #1484

## UI Surface Contract

- [x] N/A; this change does not alter a high-impact UI surface, layout, density, first viewport, or responsive visibility.
- [x] This PR does not add persistent top-of-screen messaging.
- [x] No visual changes to primary operator screens.

## Test Plan

- [x] `go test -race ./cmd/detent ./internal/cli ./internal/tui ./internal/web -count=1`
- [x] `make check`