### PR TITLE
fix(boot): isolate connector startup failures

### DIFF
--- a/internal/cli/boot.go
+++ b/internal/cli/boot.go
@@ -158,6 +158,7 @@ type startRunningDependencies struct {
 	boardSnapshotStore    boardsnapshot.Store
 	boardSnapshotInterval time.Duration
 	backgroundWaitStarted func()
+	managerDependencies   project.ManagerDependencies
 }
 
 func startRunning(ctx context.Context, cfg BootConfig) error {
@@ -287,16 +288,20 @@ func startRunningWithDependencies(ctx context.Context, cfg BootConfig, deps star
 		ConnectorFactory:   cfg.ConnectorFactory,
 		Runner:             cfg.Runner,
 	}, runtimeStore, nil, runtimeGitHubToken.get)
-	manager, err := project.NewManager(managerConfigWithRuntimeGitHubToken(cfg.Global, runtimeGitHubToken.get()), project.ManagerDependencies{
-		ProjectFactory: projectFactory,
-		Events:         events,
-		Logger:         logger,
-	})
+	managerDependencies := deps.managerDependencies
+	managerDependencies.ProjectFactory = projectFactory
+	managerDependencies.Events = events
+	managerDependencies.Logger = logger
+	manager, err := project.NewManager(
+		managerConfigWithRuntimeGitHubToken(cfg.Global, runtimeGitHubToken.get()),
+		managerDependencies,
+	)
 	if err != nil {
 		return err
 	}
 	defer func() {
 		stop()
+		manager.Wait()
 		for _, runtimeProject := range manager.Registry().List() {
 			if err := runtimeProject.Close(); err != nil {
 				logger.Warn("close runtime project failed", "project_id", runtimeProject.ID(), "error", err)

--- a/internal/cli/boot_test.go
+++ b/internal/cli/boot_test.go
@@ -22,6 +22,7 @@ import (
 	workflowconfig "github.com/digitaldrywood/detent/internal/config"
 	globalconfig "github.com/digitaldrywood/detent/internal/config/global"
 	"github.com/digitaldrywood/detent/internal/connector"
+	githubconnector "github.com/digitaldrywood/detent/internal/connector/github"
 	"github.com/digitaldrywood/detent/internal/hub"
 	"github.com/digitaldrywood/detent/internal/instancelock"
 	projectpkg "github.com/digitaldrywood/detent/internal/project"
@@ -929,6 +930,107 @@ func TestStartRunningPublishesStartupSnapshotBeforeProjectStartCompletes(t *test
 	}
 
 	close(provisionRelease)
+	cancel()
+	select {
+	case err := <-done:
+		if err != nil && !errors.Is(err, context.Canceled) {
+			t.Fatalf("startRunning() error = %v, want %v", err, context.Canceled)
+		}
+	case <-time.After(10 * time.Second):
+		t.Fatal("timed out waiting for startRunning to stop")
+	}
+}
+
+func TestStartRunningSurvivesTransientConnectorProvisioningFailure(t *testing.T) {
+	port := 0
+	output := newBootOutput()
+	configPath := filepath.Join(t.TempDir(), "global.yaml")
+	alpha := createBootProjectFiles(t)
+	writeBootGlobalConfig(t, configPath, []globalconfig.Project{
+		{ID: "alpha", Workflow: alpha.workflowPath, Workdir: alpha.workdirPath, Weight: 1},
+	})
+	global, err := globalconfig.Read(configPath)
+	if err != nil {
+		t.Fatalf("Read() error = %v", err)
+	}
+
+	firstAttempt := make(chan struct{})
+	retryScheduled := make(chan struct{})
+	releaseRetry := make(chan struct{})
+	var firstAttemptOnce sync.Once
+	var retryScheduledOnce sync.Once
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	done := make(chan error, 1)
+	go func() {
+		done <- startRunningWithDependencies(ctx, BootConfig{
+			Mode:   BootModeRunning,
+			Global: global,
+			Host:   "127.0.0.1",
+			Port:   &port,
+			Output: output,
+			ConnectorFactory: func(workflowconfig.Config) (connector.Connector, error) {
+				return bootProvisioningConnector{
+					provision: func(ctx context.Context) error {
+						failed := false
+						firstAttemptOnce.Do(func() {
+							failed = true
+							close(firstAttempt)
+						})
+						if failed {
+							return githubconnector.ErrTransient
+						}
+						<-ctx.Done()
+						return ctx.Err()
+					},
+				}, nil
+			},
+		}, startRunningDependencies{
+			managerDependencies: projectpkg.ManagerDependencies{
+				RetrySleep: func(ctx context.Context, _ time.Duration) error {
+					retryScheduledOnce.Do(func() {
+						close(retryScheduled)
+					})
+					select {
+					case <-ctx.Done():
+						return ctx.Err()
+					case <-releaseRetry:
+						return nil
+					}
+				},
+			},
+		})
+	}()
+
+	select {
+	case <-firstAttempt:
+	case err := <-done:
+		t.Fatalf("startRunning() returned before first provisioning attempt: %v", err)
+	case <-time.After(bootProvisioningStartTimeout):
+		t.Fatal("timed out waiting for transient provisioning attempt")
+	}
+
+	select {
+	case err := <-done:
+		t.Fatalf("startRunning() returned after transient provisioning failure: %v", err)
+	case <-retryScheduled:
+	}
+
+	baseURL := waitForBootDashboardURL(t, output, done)
+	health := waitForDashboard(t, baseURL+"/health", done)
+	for _, want := range []string{
+		`"status":"ok"`,
+		`"project_status":"degraded"`,
+		`"project_id":"alpha"`,
+		`"status":"degraded"`,
+		`"next_retry_at"`,
+		"github transient error",
+	} {
+		if !strings.Contains(health, want) {
+			t.Fatalf("health response missing %q:\n%s", want, health)
+		}
+	}
+
 	cancel()
 	select {
 	case err := <-done:

--- a/internal/cli/runner.go
+++ b/internal/cli/runner.go
@@ -533,10 +533,13 @@ func publishSnapshotOnce(
 ) error {
 	merged := telemetry.Snapshot{GeneratedAt: now}
 	trackedProjects := registry.List()
-	if len(trackedProjects) == 0 {
+	projectHealth := registry.Health()
+	if len(projectHealth) == 0 {
 		return nil
 	}
+	tracked := make(map[project.ID]struct{}, len(trackedProjects))
 	for _, trackedProject := range trackedProjects {
+		tracked[trackedProject.ID()] = struct{}{}
 		projectMetadata := projectSnapshotMetadata(trackedProject)
 		if !trackedProject.Running() {
 			if trackedProject.Paused() {
@@ -548,16 +551,11 @@ func publishSnapshotOnce(
 				continue
 			}
 			if runtimeErr := trackedProject.RuntimeError(); runtimeErr.Message != "" {
-				lastErrorAt := runtimeErr.At
 				merged = mergeSnapshot(merged, telemetry.Snapshot{
 					Project:      projectMetadata,
 					DashboardURL: cleanDashboardURL(dashboardURL),
 					Shutdown:     telemetry.Shutdown{Status: "running"},
-					Refresh: telemetry.Refresh{
-						Status:      telemetry.RefreshStatusDegraded,
-						LastError:   runtimeErr.Message,
-						LastErrorAt: &lastErrorAt,
-					},
+					Refresh:      runtimeErrorRefresh(runtimeErr),
 				})
 				continue
 			}
@@ -600,6 +598,23 @@ func publishSnapshotOnce(
 		snapshot.DashboardURL = cleanDashboardURL(dashboardURL)
 		merged = mergeSnapshot(merged, snapshot)
 	}
+	for _, health := range projectHealth {
+		id := project.ID(health.Project.ID)
+		if _, ok := tracked[id]; ok {
+			continue
+		}
+		merged = mergeSnapshot(merged, telemetry.Snapshot{
+			Project:      projectSnapshotMetadataFromConfig(health.Project),
+			DashboardURL: cleanDashboardURL(dashboardURL),
+			Shutdown:     telemetry.Shutdown{Status: "running"},
+			Refresh: runtimeErrorRefresh(project.RuntimeError{
+				Message:     health.LastError,
+				At:          health.LastErrorAt,
+				NextRetryAt: health.NextRetryAt,
+				Terminal:    health.RetryStopped,
+			}),
+		})
+	}
 	merged = dedupeSnapshotIssues(merged)
 	if trend != nil {
 		merged = trend.apply(merged)
@@ -641,13 +656,32 @@ func projectSnapshotMetadata(trackedProject *project.Project) telemetry.Project 
 
 	cfg := trackedProject.Config()
 	workflow := trackedProject.Workflow()
+	metadata := projectSnapshotMetadataFromConfig(cfg)
+	metadata.URL = projectURLFromWorkflow(workflow.Config)
+	return metadata
+}
+
+func projectSnapshotMetadataFromConfig(cfg globalconfig.Project) telemetry.Project {
 	id := strings.TrimSpace(cfg.ID)
 	return telemetry.Project{
 		ID:          id,
 		DisplayName: id,
-		URL:         projectURLFromWorkflow(workflow.Config),
 		Color:       projectcolor.ColorFor(id, cfg.Color),
 	}
+}
+
+func runtimeErrorRefresh(runtimeErr project.RuntimeError) telemetry.Refresh {
+	lastErrorAt := runtimeErr.At
+	refresh := telemetry.Refresh{
+		Status:      telemetry.RefreshStatusDegraded,
+		LastError:   runtimeErr.Message,
+		LastErrorAt: &lastErrorAt,
+	}
+	if !runtimeErr.NextRetryAt.IsZero() {
+		nextRetryAt := runtimeErr.NextRetryAt
+		refresh.NextRefreshAt = &nextRetryAt
+	}
+	return refresh
 }
 
 func projectURLFromWorkflow(cfg workflowconfig.Config) string {

--- a/internal/cli/runner_test.go
+++ b/internal/cli/runner_test.go
@@ -863,6 +863,51 @@ func TestPublishSnapshotOnceSurfacesProjectStartupError(t *testing.T) {
 	}
 }
 
+func TestPublishSnapshotOnceSurfacesPendingConnectorRetry(t *testing.T) {
+	t.Parallel()
+
+	lastErrorAt := time.Date(2026, 7, 22, 15, 0, 0, 0, time.UTC)
+	nextRetryAt := lastErrorAt.Add(30 * time.Second)
+	registry := projectpkg.NewRegistry()
+	if err := registry.SetPending(globalconfig.Project{ID: "alpha"}, projectpkg.RuntimeError{
+		Message:     "create project connector: github transient error",
+		At:          lastErrorAt,
+		NextRetryAt: nextRetryAt,
+	}); err != nil {
+		t.Fatalf("Registry.SetPending() error = %v", err)
+	}
+
+	snapshotHub := hub.New[telemetry.Snapshot]()
+	var seq atomic.Uint64
+	if err := publishSnapshotOnce(
+		context.Background(),
+		registry,
+		snapshotHub,
+		&seq,
+		lastErrorAt,
+		nil,
+		nil,
+		"http://localhost:4101",
+	); err != nil {
+		t.Fatalf("publishSnapshotOnce() error = %v", err)
+	}
+
+	snapshot, ok := snapshotHub.Latest()
+	if !ok || len(snapshot.Projects) != 1 {
+		t.Fatalf("snapshot = %#v, want one pending project", snapshot)
+	}
+	refresh := snapshot.Projects[0].Refresh
+	if refresh.ReadinessStatus() != telemetry.RefreshStatusDegraded {
+		t.Fatalf("Refresh status = %q, want degraded", refresh.ReadinessStatus())
+	}
+	if refresh.LastError != "create project connector: github transient error" {
+		t.Fatalf("Refresh LastError = %q", refresh.LastError)
+	}
+	if refresh.NextRefreshAt == nil || !refresh.NextRefreshAt.Equal(nextRetryAt) {
+		t.Fatalf("Refresh NextRefreshAt = %v, want %v", refresh.NextRefreshAt, nextRetryAt)
+	}
+}
+
 func TestPublishSnapshotOncePausedProjectSuppressesStartupError(t *testing.T) {
 	t.Parallel()
 

--- a/internal/connector/connector.go
+++ b/internal/connector/connector.go
@@ -11,6 +11,27 @@ var (
 	ErrStateUpdateBlocked = errors.New("issue state update blocked")
 )
 
+type retryableError struct {
+	message string
+}
+
+func (e *retryableError) Error() string {
+	return e.message
+}
+
+func (e *retryableError) Retryable() bool {
+	return true
+}
+
+func NewRetryableError(message string) error {
+	return &retryableError{message: message}
+}
+
+func IsRetryable(err error) bool {
+	var retryable *retryableError
+	return errors.As(err, &retryable) && retryable != nil && retryable.Retryable()
+}
+
 type StateUpdateBlockedError struct {
 	IssueID      string
 	CurrentState string

--- a/internal/connector/connector_test.go
+++ b/internal/connector/connector_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"testing"
 	"time"
 )
@@ -66,6 +67,32 @@ func TestBackendString(t *testing.T) {
 
 	if got := BackendGitHub.String(); got != "github" {
 		t.Fatalf("BackendGitHub.String() = %q, want github", got)
+	}
+}
+
+func TestIsRetryable(t *testing.T) {
+	t.Parallel()
+
+	retryable := NewRetryableError("temporarily unavailable")
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{name: "direct", err: retryable, want: true},
+		{name: "wrapped", err: fmt.Errorf("provision: %w", retryable), want: true},
+		{name: "permanent", err: errors.New("authentication failed"), want: false},
+		{name: "nil", err: nil, want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			if got := IsRetryable(tt.err); got != tt.want {
+				t.Fatalf("IsRetryable(%v) = %t, want %t", tt.err, got, tt.want)
+			}
+		})
 	}
 }
 

--- a/internal/connector/github/errors.go
+++ b/internal/connector/github/errors.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"strings"
 	"time"
+
+	"github.com/digitaldrywood/detent/internal/connector"
 )
 
 var (
@@ -31,12 +33,12 @@ var (
 	ErrProjectFieldOptionNotFound  = errors.New("github project field option not found")
 	ErrProjectFieldUpdateFailed    = errors.New("github project field update failed")
 	ErrProjectNotFound             = errors.New("github project not found")
-	ErrRateLimited                 = errors.New("github rate limited")
-	ErrRESTBudgetReserved          = errors.New("github rest budget reserved")
+	ErrRateLimited                 = connector.NewRetryableError("github rate limited")
+	ErrRESTBudgetReserved          = connector.NewRetryableError("github rest budget reserved")
 	ErrStatusFieldNotFound         = errors.New("github status field not found")
 	ErrStatusOptionNotFound        = errors.New("github status option not found")
 	ErrStatusUpdateFailed          = errors.New("github status update failed")
-	ErrTransient                   = errors.New("github transient error")
+	ErrTransient                   = connector.NewRetryableError("github transient error")
 	ErrUnexpectedStatus            = errors.New("github unexpected status")
 )
 

--- a/internal/connector/linear/errors.go
+++ b/internal/connector/linear/errors.go
@@ -4,6 +4,8 @@ import (
 	"errors"
 	"fmt"
 	"strings"
+
+	"github.com/digitaldrywood/detent/internal/connector"
 )
 
 var (
@@ -17,7 +19,7 @@ var (
 	ErrMissingUser         = errors.New("linear user is required")
 	ErrMissingToken        = errors.New("linear token is required")
 	ErrStateNotFound       = errors.New("linear state not found")
-	ErrTransient           = errors.New("linear transient error")
+	ErrTransient           = connector.NewRetryableError("linear transient error")
 	ErrUnexpectedStatus    = errors.New("linear unexpected status")
 	ErrUserAmbiguous       = errors.New("linear user ambiguous")
 	ErrUserNotFound        = errors.New("linear user not found")

--- a/internal/project/manager.go
+++ b/internal/project/manager.go
@@ -90,6 +90,7 @@ type retryRun struct {
 }
 
 type Manager struct {
+	operationMu            sync.Mutex
 	mu                     sync.Mutex
 	cfg                    ManagerConfig
 	registry               *Registry
@@ -209,6 +210,8 @@ func (m *Manager) Start(ctx context.Context) error {
 	if ctx == nil {
 		ctx = context.Background()
 	}
+	m.operationMu.Lock()
+	defer m.operationMu.Unlock()
 
 	m.mu.Lock()
 	if m.running {
@@ -270,6 +273,8 @@ func (m *Manager) Add(ctx context.Context, cfg globalconfig.Project) error {
 	if ctx == nil {
 		ctx = context.Background()
 	}
+	m.operationMu.Lock()
+	defer m.operationMu.Unlock()
 
 	m.mu.Lock()
 	defer m.mu.Unlock()
@@ -281,6 +286,8 @@ func (m *Manager) Remove(ctx context.Context, id ID) error {
 	if ctx == nil {
 		ctx = context.Background()
 	}
+	m.operationMu.Lock()
+	defer m.operationMu.Unlock()
 
 	m.mu.Lock()
 	defer m.mu.Unlock()
@@ -292,6 +299,8 @@ func (m *Manager) Reconcile(ctx context.Context, cfg ManagerConfig) (ReconcileRe
 	if ctx == nil {
 		ctx = context.Background()
 	}
+	m.operationMu.Lock()
+	defer m.operationMu.Unlock()
 
 	cfg = normalizeManagerConfig(cfg)
 	desired := make(map[ID]globalconfig.Project, len(cfg.Projects))
@@ -552,6 +561,8 @@ func (m *Manager) Pause(ctx context.Context, id ID) error {
 	if ctx == nil {
 		ctx = context.Background()
 	}
+	m.operationMu.Lock()
+	defer m.operationMu.Unlock()
 
 	m.mu.Lock()
 	defer m.mu.Unlock()
@@ -570,6 +581,8 @@ func (m *Manager) Unpause(ctx context.Context, id ID) error {
 	if ctx == nil {
 		ctx = context.Background()
 	}
+	m.operationMu.Lock()
+	defer m.operationMu.Unlock()
 
 	m.mu.Lock()
 	defer m.mu.Unlock()
@@ -1137,12 +1150,15 @@ func (m *Manager) cancelAndWaitRetryLocked(ctx context.Context, id ID) error {
 	if run == nil {
 		return nil
 	}
+	m.mu.Unlock()
+	var err error
 	select {
 	case <-run.done:
-		return nil
 	case <-ctx.Done():
-		return ctx.Err()
+		err = ctx.Err()
 	}
+	m.mu.Lock()
+	return err
 }
 
 func (m *Manager) cancelAllRetries() {

--- a/internal/project/manager.go
+++ b/internal/project/manager.go
@@ -14,6 +14,7 @@ import (
 	"golang.org/x/sync/errgroup"
 
 	globalconfig "github.com/digitaldrywood/detent/internal/config/global"
+	"github.com/digitaldrywood/detent/internal/connector"
 	"github.com/digitaldrywood/detent/internal/hub"
 )
 
@@ -26,6 +27,9 @@ var (
 const (
 	defaultMaxConcurrentStarts    = 4
 	defaultStartupRollbackTimeout = 5 * time.Second
+	defaultRetryInitialBackoff    = time.Second
+	defaultRetryMaxBackoff        = time.Minute
+	defaultRetryJitter            = 250 * time.Millisecond
 )
 
 type Factory func(globalconfig.Project) (*Project, error)
@@ -41,6 +45,12 @@ type ManagerConfig struct {
 	Projects                 []globalconfig.Project
 	Startup                  StartupConfig
 	RuntimeCredentialVersion string
+}
+
+type ConnectorRetryConfig struct {
+	InitialBackoff time.Duration
+	MaxBackoff     time.Duration
+	Jitter         time.Duration
 }
 
 type ReconcileResult struct {
@@ -67,7 +77,16 @@ type ManagerDependencies struct {
 	Logger                 *slog.Logger
 	Sleep                  func(context.Context, time.Duration) error
 	Jitter                 func(time.Duration) time.Duration
+	ConnectorRetry         ConnectorRetryConfig
+	RetrySleep             func(context.Context, time.Duration) error
+	RetryJitter            func(time.Duration) time.Duration
+	Now                    func() time.Time
 	StartupRollbackTimeout time.Duration
+}
+
+type retryRun struct {
+	cancel context.CancelFunc
+	done   chan struct{}
 }
 
 type Manager struct {
@@ -78,6 +97,12 @@ type Manager struct {
 	sleep                  func(context.Context, time.Duration) error
 	jitter                 func(time.Duration) time.Duration
 	logger                 *slog.Logger
+	retry                  ConnectorRetryConfig
+	retrySleep             func(context.Context, time.Duration) error
+	retryJitter            func(time.Duration) time.Duration
+	now                    func() time.Time
+	retryRuns              map[ID]*retryRun
+	retryWG                sync.WaitGroup
 	startupRollbackTimeout time.Duration
 
 	running bool
@@ -135,6 +160,18 @@ func NewManager(cfg ManagerConfig, deps ManagerDependencies) (*Manager, error) {
 	if logger == nil {
 		logger = slog.Default()
 	}
+	retrySleep := deps.RetrySleep
+	if retrySleep == nil {
+		retrySleep = sleepContext
+	}
+	retryJitter := deps.RetryJitter
+	if retryJitter == nil {
+		retryJitter = randomJitter
+	}
+	now := deps.Now
+	if now == nil {
+		now = time.Now
+	}
 	startupRollbackTimeout := deps.StartupRollbackTimeout
 	if startupRollbackTimeout <= 0 {
 		startupRollbackTimeout = defaultStartupRollbackTimeout
@@ -148,12 +185,24 @@ func NewManager(cfg ManagerConfig, deps ManagerDependencies) (*Manager, error) {
 		sleep:                  sleep,
 		jitter:                 jitter,
 		logger:                 logger,
+		retry:                  normalizeConnectorRetryConfig(deps.ConnectorRetry),
+		retrySleep:             retrySleep,
+		retryJitter:            retryJitter,
+		now:                    now,
+		retryRuns:              map[ID]*retryRun{},
 		startupRollbackTimeout: startupRollbackTimeout,
 	}, nil
 }
 
 func (m *Manager) Registry() *Registry {
 	return m.registry
+}
+
+func (m *Manager) Wait() {
+	if m == nil {
+		return
+	}
+	m.retryWG.Wait()
 }
 
 func (m *Manager) Start(ctx context.Context) error {
@@ -173,6 +222,9 @@ func (m *Manager) Start(ctx context.Context) error {
 	for _, cfg := range m.cfg.Projects {
 		id, project, err := m.createProjectLocked(cfg)
 		if err != nil {
+			if m.handleInitialCreationFailureLocked(ctx, cfg, err) {
+				continue
+			}
 			for _, registeredID := range registered {
 				m.registry.Delete(registeredID)
 			}
@@ -261,8 +313,11 @@ func (m *Manager) Reconcile(ctx context.Context, cfg ManagerConfig) (ReconcileRe
 
 	runtimeCredentialChanged := m.cfg.RuntimeCredentialVersion != cfg.RuntimeCredentialVersion
 	result := ReconcileResult{}
+	seen := make(map[ID]struct{}, len(m.cfg.Projects))
+	pending := map[ID]struct{}{}
 	for _, current := range m.registry.List() {
 		id := current.ID()
+		seen[id] = struct{}{}
 		next, ok := desired[id]
 		if !ok {
 			result.Removed = append(result.Removed, id)
@@ -274,18 +329,41 @@ func (m *Manager) Reconcile(ctx context.Context, cfg ManagerConfig) (ReconcileRe
 		}
 		result.Changed = append(result.Changed, id)
 	}
+	for _, health := range m.registry.Health() {
+		id := normalizeProjectID(ID(health.Project.ID))
+		if _, ok := seen[id]; ok {
+			continue
+		}
+		seen[id] = struct{}{}
+		pending[id] = struct{}{}
+		next, ok := desired[id]
+		if !ok {
+			result.Removed = append(result.Removed, id)
+			continue
+		}
+		if !runtimeCredentialChanged && sameProjectConfig(health.Project, next) {
+			result.Unchanged = append(result.Unchanged, id)
+			continue
+		}
+		result.Changed = append(result.Changed, id)
+	}
 
 	for _, next := range cfg.Projects {
 		id := ID(next.ID)
-		if _, ok := m.registry.Get(id); !ok {
+		if _, ok := seen[id]; !ok {
 			result.Added = append(result.Added, id)
 		}
 	}
 
 	prepared := make(map[ID]*Project, len(result.Added)+len(result.Changed))
+	handled := map[ID]struct{}{}
 	for _, id := range result.Changed {
 		_, preparedProject, err := m.createProjectLocked(desired[id])
 		if err != nil {
+			if _, ok := pending[id]; ok && m.handleInitialCreationFailureLocked(ctx, desired[id], err) {
+				handled[id] = struct{}{}
+				continue
+			}
 			return result, errors.Join(err, closePreparedProjects(ctx, prepared))
 		}
 		prepared[id] = preparedProject
@@ -293,6 +371,10 @@ func (m *Manager) Reconcile(ctx context.Context, cfg ManagerConfig) (ReconcileRe
 	for _, id := range result.Added {
 		_, preparedProject, err := m.createProjectLocked(desired[id])
 		if err != nil {
+			if m.handleInitialCreationFailureLocked(ctx, desired[id], err) {
+				handled[id] = struct{}{}
+				continue
+			}
 			return result, errors.Join(err, closePreparedProjects(ctx, prepared))
 		}
 		prepared[id] = preparedProject
@@ -331,7 +413,15 @@ func (m *Manager) Reconcile(ctx context.Context, cfg ManagerConfig) (ReconcileRe
 	}
 
 	for _, id := range result.Removed {
+		if err := m.cancelAndWaitRetryLocked(ctx, id); err != nil {
+			return result, errors.Join(err, rollback())
+		}
 		current, ok := m.registry.Get(id)
+		if !ok {
+			if _, pending := m.registry.Pending(id); pending && m.registry.Delete(id) {
+				continue
+			}
+		}
 		if !ok || current == nil {
 			return result, errors.Join(ErrProjectNotFound, rollback())
 		}
@@ -347,6 +437,36 @@ func (m *Manager) Reconcile(ctx context.Context, cfg ManagerConfig) (ReconcileRe
 		}
 	}
 	for _, id := range result.Changed {
+		if _, ok := handled[id]; ok {
+			continue
+		}
+		preparedProject, err := preparedProjectByID(prepared, id)
+		if err != nil {
+			return result, errors.Join(err, rollback())
+		}
+		if _, wasPending := pending[id]; wasPending {
+			didStart, startErr := m.startPreparedProjectLocked(ctx, preparedProject)
+			if startErr != nil && ctx.Err() != nil {
+				return result, errors.Join(startErr, rollback())
+			}
+			if err := m.cancelAndWaitRetryLocked(ctx, id); err != nil {
+				return result, errors.Join(err, rollback())
+			}
+			m.registry.Delete(id)
+			if startErr != nil {
+				m.handleProjectStartupFailureLocked(ctx, preparedProject, startErr)
+			}
+			if err := m.registry.Set(preparedProject); err != nil {
+				return result, errors.Join(err, rollback())
+			}
+			if didStart {
+				started = append(started, startedProject{project: preparedProject})
+			}
+			continue
+		}
+		if err := m.cancelAndWaitRetryLocked(ctx, id); err != nil {
+			return result, errors.Join(err, rollback())
+		}
 		current, ok := m.registry.Get(id)
 		if !ok || current == nil {
 			return result, errors.Join(ErrProjectNotFound, rollback())
@@ -358,10 +478,6 @@ func (m *Manager) Reconcile(ctx context.Context, cfg ManagerConfig) (ReconcileRe
 			}
 		}
 		stopped = append(stopped, rollbackProject{project: current, wasRunning: wasRunning})
-		preparedProject, err := preparedProjectByID(prepared, id)
-		if err != nil {
-			return result, errors.Join(err, rollback())
-		}
 		didStart, err := m.startPreparedProjectLocked(ctx, preparedProject)
 		if err != nil {
 			return result, errors.Join(err, rollback())
@@ -374,6 +490,9 @@ func (m *Manager) Reconcile(ctx context.Context, cfg ManagerConfig) (ReconcileRe
 		}
 	}
 	for _, id := range result.Added {
+		if _, ok := handled[id]; ok {
+			continue
+		}
 		preparedProject, err := preparedProjectByID(prepared, id)
 		if err != nil {
 			return result, errors.Join(err, rollback())
@@ -383,7 +502,7 @@ func (m *Manager) Reconcile(ctx context.Context, cfg ManagerConfig) (ReconcileRe
 			if len(result.Removed) > 0 || len(result.Changed) > 0 || !retainAddedProjectStartFailure(preparedProject, err) {
 				return result, errors.Join(err, rollback())
 			}
-			m.logProjectStartupFailure(id, err)
+			m.handleProjectStartupFailureLocked(ctx, preparedProject, err)
 			if err := m.registry.Set(preparedProject); err != nil {
 				return result, errors.Join(err, rollback())
 			}
@@ -412,8 +531,14 @@ func (m *Manager) Reconcile(ctx context.Context, cfg ManagerConfig) (ReconcileRe
 }
 
 func (m *Manager) removeLocked(ctx context.Context, id ID) error {
+	if err := m.cancelAndWaitRetryLocked(ctx, id); err != nil {
+		return err
+	}
 	project, ok := m.registry.Get(id)
 	if !ok || project == nil {
+		if _, pending := m.registry.Pending(id); pending && m.registry.Delete(id) {
+			return nil
+		}
 		return ErrProjectNotFound
 	}
 	if err := project.close(ctx, true); err != nil {
@@ -430,6 +555,9 @@ func (m *Manager) Pause(ctx context.Context, id ID) error {
 
 	m.mu.Lock()
 	defer m.mu.Unlock()
+	if err := m.cancelAndWaitRetryLocked(ctx, id); err != nil {
+		return err
+	}
 
 	project, ok := m.registry.Get(id)
 	if !ok || project == nil {
@@ -593,13 +721,21 @@ func (m *Manager) startInitialProjects(
 				return err
 			}
 			if err := trackedProject.provision(groupCtx); err != nil {
-				return err
+				if groupCtx.Err() != nil {
+					return err
+				}
+				m.handleProjectStartupFailure(ctx, trackedProject, err)
+				return nil
 			}
 			if err := groupCtx.Err(); err != nil {
 				return err
 			}
 			if err := trackedProject.start(ctx, startOptions{provision: false, publishEvents: true}); err != nil {
-				return err
+				if ctx.Err() != nil {
+					return err
+				}
+				m.handleProjectStartupFailure(ctx, trackedProject, err)
+				return nil
 			}
 			startedMu.Lock()
 			started = append(started, startedProject{project: trackedProject})
@@ -619,6 +755,9 @@ func (m *Manager) rollbackInitialStart(
 	projects []*Project,
 	started []startedProject,
 ) error {
+	m.cancelAllRetries()
+	m.Wait()
+
 	cleanupCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), m.startupRollbackTimeout)
 	defer cancel()
 	cleanupErr := m.stopUncommittedStartedProjects(cleanupCtx, started)
@@ -720,12 +859,312 @@ func (m *Manager) waitBeforeSpawn(ctx context.Context) error {
 	return m.sleep(ctx, delay)
 }
 
-func (m *Manager) logProjectStartupFailure(id ID, err error) {
+func (m *Manager) handleInitialCreationFailureLocked(
+	ctx context.Context,
+	cfg globalconfig.Project,
+	err error,
+) bool {
+	if !errors.Is(err, ErrConnectorCreation) {
+		return false
+	}
+
+	id := normalizeProjectID(ID(cfg.ID))
+	if id == "" {
+		return false
+	}
+	cfg.ID = string(id)
+	if !connector.IsRetryable(err) {
+		runtimeErr := RuntimeError{Message: err.Error(), At: m.nowUTC(), Terminal: true}
+		if pendingErr := m.registry.SetPending(cfg, runtimeErr); pendingErr != nil {
+			return false
+		}
+		m.logProjectStartupFailure(id, err, time.Time{}, true)
+		return true
+	}
+
+	attempt := 1
+	delay := m.retryDelay(attempt)
+	runtimeErr := m.retryRuntimeError(err, delay)
+	if pendingErr := m.registry.SetPending(cfg, runtimeErr); pendingErr != nil {
+		return false
+	}
+	retryCtx, cancel := context.WithCancel(ctx)
+	run := &retryRun{cancel: cancel, done: make(chan struct{})}
+	m.cancelRetryLocked(id)
+	m.retryRuns[id] = run
+	m.retryWG.Add(1)
+	m.logProjectStartupFailure(id, err, runtimeErr.NextRetryAt, false)
+	go m.retryPendingProject(retryCtx, run, cfg, attempt, delay)
+	return true
+}
+
+func (m *Manager) handleProjectStartupFailure(ctx context.Context, trackedProject *Project, err error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.handleProjectStartupFailureLocked(ctx, trackedProject, err)
+}
+
+func (m *Manager) handleProjectStartupFailureLocked(ctx context.Context, trackedProject *Project, err error) {
+	if trackedProject == nil || err == nil {
+		return
+	}
+	id := trackedProject.ID()
+	if !connector.IsRetryable(err) {
+		trackedProject.recordRuntimeErrorState(err, m.nowUTC(), time.Time{}, true)
+		m.logProjectStartupFailure(id, err, time.Time{}, true)
+		return
+	}
+
+	attempt := 1
+	delay := m.retryDelay(attempt)
+	runtimeErr := m.retryRuntimeError(err, delay)
+	trackedProject.recordRuntimeErrorState(err, runtimeErr.At, runtimeErr.NextRetryAt, false)
+	retryCtx, cancel := context.WithCancel(ctx)
+	run := &retryRun{cancel: cancel, done: make(chan struct{})}
+	m.cancelRetryLocked(id)
+	m.retryRuns[id] = run
+	m.retryWG.Add(1)
+	m.logProjectStartupFailure(id, err, runtimeErr.NextRetryAt, false)
+	go m.retryProject(retryCtx, run, trackedProject, attempt, delay)
+}
+
+func (m *Manager) retryPendingProject(
+	ctx context.Context,
+	run *retryRun,
+	cfg globalconfig.Project,
+	attempt int,
+	delay time.Duration,
+) {
+	id := normalizeProjectID(ID(cfg.ID))
+	defer m.finishRetry(id, run)
+	var trackedProject *Project
+
+	for {
+		if err := m.retrySleep(ctx, delay); err != nil {
+			return
+		}
+		if ctx.Err() != nil {
+			return
+		}
+
+		if trackedProject == nil {
+			_, candidate, err := m.createProjectLocked(cfg)
+			if err != nil {
+				if !errors.Is(err, ErrConnectorCreation) || !connector.IsRetryable(err) {
+					m.recordPendingFailure(cfg, err, time.Time{}, true)
+					m.logProjectStartupFailure(id, err, time.Time{}, true)
+					return
+				}
+				attempt++
+				delay = m.retryDelay(attempt)
+				runtimeErr := m.retryRuntimeError(err, delay)
+				m.recordPendingFailure(cfg, err, runtimeErr.NextRetryAt, false)
+				m.logProjectStartupFailure(id, err, runtimeErr.NextRetryAt, false)
+				continue
+			}
+			if !m.activateRetriedProject(ctx, cfg, candidate) {
+				return
+			}
+			trackedProject = candidate
+			if trackedProject.Paused() {
+				return
+			}
+		}
+
+		err := trackedProject.start(ctx, startOptions{provision: true, publishEvents: true})
+		if err == nil {
+			m.markProjectRetryRecovered(id)
+			return
+		}
+		if ctx.Err() != nil {
+			return
+		}
+		if !connector.IsRetryable(err) {
+			trackedProject.recordRuntimeErrorState(err, m.nowUTC(), time.Time{}, true)
+			m.logProjectStartupFailure(id, err, time.Time{}, true)
+			return
+		}
+		attempt++
+		delay = m.retryDelay(attempt)
+		runtimeErr := m.retryRuntimeError(err, delay)
+		trackedProject.recordRuntimeErrorState(err, runtimeErr.At, runtimeErr.NextRetryAt, false)
+		m.logProjectStartupFailure(id, err, runtimeErr.NextRetryAt, false)
+	}
+}
+
+func (m *Manager) retryProject(
+	ctx context.Context,
+	run *retryRun,
+	trackedProject *Project,
+	attempt int,
+	delay time.Duration,
+) {
+	id := trackedProject.ID()
+	defer m.finishRetry(id, run)
+
+	for {
+		if err := m.retrySleep(ctx, delay); err != nil {
+			return
+		}
+		if ctx.Err() != nil {
+			return
+		}
+
+		err := trackedProject.start(ctx, startOptions{provision: true, publishEvents: true})
+		if err == nil {
+			m.markProjectRetryRecovered(id)
+			return
+		}
+		if ctx.Err() != nil {
+			return
+		}
+		if !connector.IsRetryable(err) {
+			trackedProject.recordRuntimeErrorState(err, m.nowUTC(), time.Time{}, true)
+			m.logProjectStartupFailure(id, err, time.Time{}, true)
+			return
+		}
+		attempt++
+		delay = m.retryDelay(attempt)
+		runtimeErr := m.retryRuntimeError(err, delay)
+		trackedProject.recordRuntimeErrorState(err, runtimeErr.At, runtimeErr.NextRetryAt, false)
+		m.logProjectStartupFailure(id, err, runtimeErr.NextRetryAt, false)
+	}
+}
+
+func (m *Manager) activateRetriedProject(ctx context.Context, cfg globalconfig.Project, trackedProject *Project) bool {
+	id := normalizeProjectID(ID(cfg.ID))
+	m.mu.Lock()
+	current := m.running && ctx.Err() == nil && m.projectConfigCurrentLocked(cfg)
+	if current {
+		_, current = m.registry.Get(id)
+		current = !current
+	}
+	if current {
+		current = m.registry.Set(trackedProject) == nil
+	}
+	m.mu.Unlock()
+	if current {
+		return true
+	}
+	if err := trackedProject.close(context.WithoutCancel(ctx), false); err != nil {
+		m.logger.Warn("close unused retried project failed", "project_id", id, "error", err)
+	}
+	return false
+}
+
+func (m *Manager) projectConfigCurrentLocked(cfg globalconfig.Project) bool {
+	id := normalizeProjectID(ID(cfg.ID))
+	for _, current := range m.cfg.Projects {
+		if normalizeProjectID(ID(current.ID)) == id {
+			return sameProjectConfig(current, cfg)
+		}
+	}
+	return false
+}
+
+func (m *Manager) recordPendingFailure(
+	cfg globalconfig.Project,
+	err error,
+	nextRetryAt time.Time,
+	terminal bool,
+) {
+	runtimeErr := RuntimeError{
+		Message:     err.Error(),
+		At:          m.nowUTC(),
+		NextRetryAt: nextRetryAt,
+		Terminal:    terminal,
+	}
+	if pendingErr := m.registry.SetPending(cfg, runtimeErr); pendingErr != nil {
+		m.logger.Warn("record pending project startup failed", "project_id", cfg.ID, "error", pendingErr)
+	}
+}
+
+func (m *Manager) retryRuntimeError(err error, delay time.Duration) RuntimeError {
+	at := m.nowUTC()
+	return RuntimeError{Message: err.Error(), At: at, NextRetryAt: at.Add(delay)}
+}
+
+func (m *Manager) retryDelay(attempt int) time.Duration {
+	delay := m.retry.InitialBackoff
+	for current := 1; current < attempt && delay < m.retry.MaxBackoff; current++ {
+		if delay > m.retry.MaxBackoff/2 {
+			delay = m.retry.MaxBackoff
+			break
+		}
+		delay *= 2
+	}
+	if delay >= m.retry.MaxBackoff || m.retry.Jitter <= 0 {
+		return min(delay, m.retry.MaxBackoff)
+	}
+	jitter := m.retryJitter(m.retry.Jitter)
+	if jitter < 0 {
+		jitter = 0
+	}
+	return min(delay+jitter, m.retry.MaxBackoff)
+}
+
+func (m *Manager) nowUTC() time.Time {
+	return m.now().UTC()
+}
+
+func (m *Manager) markProjectRetryRecovered(id ID) {
+	m.mu.Lock()
+	m.spawned = true
+	m.mu.Unlock()
+	m.logger.Info("project startup recovered", "project_id", id)
+}
+
+func (m *Manager) finishRetry(id ID, run *retryRun) {
+	close(run.done)
+	m.mu.Lock()
+	if m.retryRuns[id] == run {
+		delete(m.retryRuns, id)
+	}
+	m.mu.Unlock()
+	m.retryWG.Done()
+}
+
+func (m *Manager) cancelRetryLocked(id ID) *retryRun {
+	run := m.retryRuns[normalizeProjectID(id)]
+	if run != nil {
+		run.cancel()
+	}
+	return run
+}
+
+func (m *Manager) cancelAndWaitRetryLocked(ctx context.Context, id ID) error {
+	run := m.cancelRetryLocked(id)
+	if run == nil {
+		return nil
+	}
+	select {
+	case <-run.done:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+func (m *Manager) cancelAllRetries() {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	for _, run := range m.retryRuns {
+		run.cancel()
+	}
+}
+
+func (m *Manager) logProjectStartupFailure(id ID, err error, nextRetryAt time.Time, retryStopped bool) {
 	logger := m.logger
 	if logger == nil {
 		logger = slog.Default()
 	}
-	logger.Warn("project startup failed", "project_id", id, "error", err)
+	logger.Warn(
+		"project startup failed",
+		"project_id", id,
+		"error", err,
+		"next_retry_at", nextRetryAt,
+		"retry_stopped", retryStopped,
+	)
 }
 
 func retainAddedProjectStartFailure(project *Project, err error) bool {
@@ -790,6 +1229,22 @@ func normalizeManagerConfig(cfg ManagerConfig) ManagerConfig {
 	cfg.Projects = append([]globalconfig.Project(nil), cfg.Projects...)
 	for i := range cfg.Projects {
 		cfg.Projects[i] = normalizeManagerProjectConfigWithIdentity(cfg.Projects[i], cfg.Identity)
+	}
+	return cfg
+}
+
+func normalizeConnectorRetryConfig(cfg ConnectorRetryConfig) ConnectorRetryConfig {
+	if cfg.InitialBackoff <= 0 {
+		cfg.InitialBackoff = defaultRetryInitialBackoff
+	}
+	if cfg.MaxBackoff <= 0 {
+		cfg.MaxBackoff = defaultRetryMaxBackoff
+	}
+	if cfg.MaxBackoff < cfg.InitialBackoff {
+		cfg.MaxBackoff = cfg.InitialBackoff
+	}
+	if cfg.Jitter <= 0 {
+		cfg.Jitter = defaultRetryJitter
 	}
 	return cfg
 }

--- a/internal/project/manager_test.go
+++ b/internal/project/manager_test.go
@@ -15,6 +15,7 @@ import (
 	workflowconfig "github.com/digitaldrywood/detent/internal/config"
 	globalconfig "github.com/digitaldrywood/detent/internal/config/global"
 	"github.com/digitaldrywood/detent/internal/connector"
+	githubconnector "github.com/digitaldrywood/detent/internal/connector/github"
 	"github.com/digitaldrywood/detent/internal/hub"
 	"github.com/digitaldrywood/detent/internal/orchestrator"
 	"github.com/digitaldrywood/detent/internal/project"
@@ -77,6 +78,421 @@ func TestManagerStartsProjectsWithStartupLimits(t *testing.T) {
 	}
 	if manager.Registry().Len() != 3 {
 		t.Fatalf("Registry().Len() = %d, want 3", manager.Registry().Len())
+	}
+}
+
+func TestManagerStartKeepsHealthyProjectRunningWhenProvisioningIsTransientlyUnavailable(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	var mu sync.Mutex
+	attempts := 0
+	manager, err := project.NewManager(project.ManagerConfig{
+		Projects: []globalconfig.Project{
+			{ID: "alpha", Weight: 1},
+			{ID: "bravo", Weight: 1},
+		},
+	}, project.ManagerDependencies{
+		ProjectFactory: func(cfg globalconfig.Project) (*project.Project, error) {
+			workflowCfg := workflowConfig("memory")
+			workflowCfg.Tracker.AutoProvision = true
+			projectConnector := provisioningConnector{}
+			if cfg.ID == "alpha" {
+				projectConnector.provision = func(context.Context) error {
+					mu.Lock()
+					defer mu.Unlock()
+					attempts++
+					if attempts == 1 {
+						return githubconnector.ErrTransient
+					}
+					return nil
+				}
+			}
+			return project.New(project.Config{
+				Project:  cfg,
+				Workflow: workflowconfig.Workflow{Config: workflowCfg},
+			}, project.Dependencies{
+				Connector: projectConnector,
+				Runner:    blockingRunner{},
+			})
+		},
+	})
+	if err != nil {
+		t.Fatalf("NewManager() error = %v", err)
+	}
+
+	if err := manager.Start(ctx); err != nil {
+		t.Fatalf("Start() error = %v, want degraded project startup", err)
+	}
+
+	alpha, ok := manager.Registry().Get("alpha")
+	if !ok {
+		t.Fatal("Registry().Get(alpha) ok = false, want degraded project retained")
+	}
+	if alpha.Running() {
+		t.Fatal("alpha Running() = true before provisioning retry, want false")
+	}
+	if alpha.RuntimeError().Message == "" {
+		t.Fatal("alpha RuntimeError().Message = empty, want transient provisioning error")
+	}
+	if alpha.RuntimeError().NextRetryAt.IsZero() {
+		t.Fatal("alpha RuntimeError().NextRetryAt is zero, want scheduled retry")
+	}
+	bravo, ok := manager.Registry().Get("bravo")
+	if !ok {
+		t.Fatal("Registry().Get(bravo) ok = false, want healthy project")
+	}
+	if !bravo.Running() {
+		t.Fatal("bravo Running() = false, want healthy project running")
+	}
+}
+
+func TestManagerRetriesTransientProvisioningWithBoundedExponentialBackoff(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	baseTime := time.Date(2026, 7, 22, 15, 0, 0, 0, time.UTC)
+	attempted := make(chan int, 4)
+	delays := make(chan time.Duration)
+	release := make(chan struct{})
+	var mu sync.Mutex
+	attempts := 0
+
+	manager, err := project.NewManager(project.ManagerConfig{
+		Projects: []globalconfig.Project{{ID: "alpha", Weight: 1}},
+	}, project.ManagerDependencies{
+		ProjectFactory: func(cfg globalconfig.Project) (*project.Project, error) {
+			workflowCfg := workflowConfig("memory")
+			workflowCfg.Tracker.AutoProvision = true
+			return project.New(project.Config{
+				Project:  cfg,
+				Workflow: workflowconfig.Workflow{Config: workflowCfg},
+			}, project.Dependencies{
+				Connector: provisioningConnector{provision: func(context.Context) error {
+					mu.Lock()
+					attempts++
+					attempt := attempts
+					mu.Unlock()
+					attempted <- attempt
+					if attempt < 4 {
+						return githubconnector.ErrTransient
+					}
+					return nil
+				}},
+				Runner: blockingRunner{},
+			})
+		},
+		ConnectorRetry: project.ConnectorRetryConfig{
+			InitialBackoff: 2 * time.Second,
+			MaxBackoff:     5 * time.Second,
+			Jitter:         time.Second,
+		},
+		RetrySleep: func(ctx context.Context, delay time.Duration) error {
+			select {
+			case delays <- delay:
+			case <-ctx.Done():
+				return ctx.Err()
+			}
+			select {
+			case <-release:
+				return nil
+			case <-ctx.Done():
+				return ctx.Err()
+			}
+		},
+		RetryJitter: func(time.Duration) time.Duration {
+			return 500 * time.Millisecond
+		},
+		Now: func() time.Time {
+			return baseTime
+		},
+	})
+	if err != nil {
+		t.Fatalf("NewManager() error = %v", err)
+	}
+
+	if err := manager.Start(ctx); err != nil {
+		t.Fatalf("Start() error = %v", err)
+	}
+	if attempt := receiveProvisionAttempt(t, attempted); attempt != 1 {
+		t.Fatalf("initial attempt = %d, want 1", attempt)
+	}
+
+	alpha, ok := manager.Registry().Get("alpha")
+	if !ok {
+		t.Fatal("Registry().Get(alpha) ok = false, want degraded project")
+	}
+	initialError := alpha.RuntimeError()
+	if !initialError.NextRetryAt.Equal(baseTime.Add(2500 * time.Millisecond)) {
+		t.Fatalf("initial NextRetryAt = %v, want %v", initialError.NextRetryAt, baseTime.Add(2500*time.Millisecond))
+	}
+
+	wantDelays := []time.Duration{2500 * time.Millisecond, 4500 * time.Millisecond, 5 * time.Second}
+	for index, wantDelay := range wantDelays {
+		if delay := receiveRetryDelay(t, delays); delay != wantDelay {
+			t.Fatalf("retry %d delay = %v, want %v", index+1, delay, wantDelay)
+		}
+		release <- struct{}{}
+		if attempt := receiveProvisionAttempt(t, attempted); attempt != index+2 {
+			t.Fatalf("retry %d attempt = %d, want %d", index+1, attempt, index+2)
+		}
+	}
+
+	waitForProjectRunning(t, alpha)
+	manager.Wait()
+	if runtimeErr := alpha.RuntimeError(); runtimeErr.Message != "" || !runtimeErr.NextRetryAt.IsZero() {
+		t.Fatalf("RuntimeError() after recovery = %#v, want cleared", runtimeErr)
+	}
+	cancel()
+	if err := alpha.Close(); err != nil {
+		t.Fatalf("Close() error = %v", err)
+	}
+}
+
+func TestManagerRetriesTransientConnectorFactoryFailure(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	retryStarted := make(chan time.Duration)
+	releaseRetry := make(chan struct{})
+	var mu sync.Mutex
+	factoryCalls := 0
+
+	manager, err := project.NewManager(project.ManagerConfig{
+		Projects: []globalconfig.Project{{ID: "alpha", Weight: 1}},
+	}, project.ManagerDependencies{
+		ProjectFactory: func(cfg globalconfig.Project) (*project.Project, error) {
+			workflowCfg := workflowConfig("memory")
+			return project.New(project.Config{
+				Project:  cfg,
+				Workflow: workflowconfig.Workflow{Config: workflowCfg},
+			}, project.Dependencies{
+				ConnectorFactory: func(workflowconfig.Config) (connector.Connector, error) {
+					mu.Lock()
+					defer mu.Unlock()
+					factoryCalls++
+					if factoryCalls == 1 {
+						return nil, githubconnector.ErrTransient
+					}
+					return provisioningConnector{}, nil
+				},
+				Runner: blockingRunner{},
+			})
+		},
+		ConnectorRetry: project.ConnectorRetryConfig{
+			InitialBackoff: time.Second,
+			MaxBackoff:     2 * time.Second,
+			Jitter:         time.Millisecond,
+		},
+		RetrySleep: func(ctx context.Context, delay time.Duration) error {
+			select {
+			case retryStarted <- delay:
+			case <-ctx.Done():
+				return ctx.Err()
+			}
+			select {
+			case <-releaseRetry:
+				return nil
+			case <-ctx.Done():
+				return ctx.Err()
+			}
+		},
+		RetryJitter: func(time.Duration) time.Duration { return 0 },
+	})
+	if err != nil {
+		t.Fatalf("NewManager() error = %v", err)
+	}
+
+	if err := manager.Start(ctx); err != nil {
+		t.Fatalf("Start() error = %v", err)
+	}
+	if manager.Registry().Len() != 0 {
+		t.Fatalf("Registry().Len() = %d, want no initialized project", manager.Registry().Len())
+	}
+	pending, ok := manager.Registry().Pending("alpha")
+	if !ok {
+		t.Fatal("Registry().Pending(alpha) ok = false, want degraded factory state")
+	}
+	if pending.Status != project.HealthStatusDegraded || pending.NextRetryAt.IsZero() || pending.RetryStopped {
+		t.Fatalf("pending health = %#v, want retrying degraded state", pending)
+	}
+
+	if delay := receiveRetryDelay(t, retryStarted); delay != time.Second {
+		t.Fatalf("retry delay = %v, want %v", delay, time.Second)
+	}
+	releaseRetry <- struct{}{}
+	manager.Wait()
+	alpha, ok := manager.Registry().Get("alpha")
+	if !ok || !alpha.Running() {
+		t.Fatalf("Registry().Get(alpha) = %#v, %t, want running project", alpha, ok)
+	}
+	if _, ok := manager.Registry().Pending("alpha"); ok {
+		t.Fatal("Registry().Pending(alpha) ok = true after recovery, want false")
+	}
+	cancel()
+	if err := alpha.Close(); err != nil {
+		t.Fatalf("Close() error = %v", err)
+	}
+}
+
+func TestManagerKeepsPermanentConnectorFactoryFailureTerminal(t *testing.T) {
+	t.Parallel()
+
+	retryStarted := make(chan time.Duration, 1)
+	manager, err := project.NewManager(project.ManagerConfig{
+		Projects: []globalconfig.Project{{ID: "alpha", Weight: 1}},
+	}, project.ManagerDependencies{
+		ProjectFactory: func(cfg globalconfig.Project) (*project.Project, error) {
+			workflowCfg := workflowConfig("memory")
+			return project.New(project.Config{
+				Project:  cfg,
+				Workflow: workflowconfig.Workflow{Config: workflowCfg},
+			}, project.Dependencies{
+				ConnectorFactory: func(workflowconfig.Config) (connector.Connector, error) {
+					return nil, errors.New("connector credentials are invalid")
+				},
+				Runner: blockingRunner{},
+			})
+		},
+		RetrySleep: func(context.Context, time.Duration) error {
+			retryStarted <- time.Second
+			return nil
+		},
+	})
+	if err != nil {
+		t.Fatalf("NewManager() error = %v", err)
+	}
+
+	if err := manager.Start(context.Background()); err != nil {
+		t.Fatalf("Start() error = %v, want terminal project degradation", err)
+	}
+	health, ok := manager.Registry().Pending("alpha")
+	if !ok {
+		t.Fatal("Registry().Pending(alpha) ok = false, want terminal health")
+	}
+	if health.Status != project.HealthStatusDegraded || !health.RetryStopped || !health.NextRetryAt.IsZero() {
+		t.Fatalf("pending health = %#v, want terminal degraded state", health)
+	}
+	if !strings.Contains(health.LastError, "connector credentials are invalid") {
+		t.Fatalf("LastError = %q, want credential error", health.LastError)
+	}
+	select {
+	case delay := <-retryStarted:
+		t.Fatalf("retry scheduled for permanent failure with delay %v", delay)
+	default:
+	}
+}
+
+func TestManagerReconcileRemovesPendingConnectorRetry(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	retryStarted := make(chan struct{})
+	manager, err := project.NewManager(project.ManagerConfig{
+		Projects: []globalconfig.Project{{ID: "alpha", Weight: 1}},
+	}, project.ManagerDependencies{
+		ProjectFactory: func(cfg globalconfig.Project) (*project.Project, error) {
+			workflowCfg := workflowConfig("memory")
+			return project.New(project.Config{
+				Project:  cfg,
+				Workflow: workflowconfig.Workflow{Config: workflowCfg},
+			}, project.Dependencies{
+				ConnectorFactory: func(workflowconfig.Config) (connector.Connector, error) {
+					return nil, githubconnector.ErrTransient
+				},
+				Runner: blockingRunner{},
+			})
+		},
+		RetrySleep: func(ctx context.Context, _ time.Duration) error {
+			select {
+			case <-retryStarted:
+			default:
+				close(retryStarted)
+			}
+			<-ctx.Done()
+			return ctx.Err()
+		},
+	})
+	if err != nil {
+		t.Fatalf("NewManager() error = %v", err)
+	}
+	if err := manager.Start(ctx); err != nil {
+		t.Fatalf("Start() error = %v", err)
+	}
+
+	select {
+	case <-retryStarted:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for pending retry")
+	}
+	result, err := manager.Reconcile(ctx, project.ManagerConfig{})
+	if err != nil {
+		t.Fatalf("Reconcile() error = %v", err)
+	}
+	if !reflect.DeepEqual(result.Removed, []project.ID{"alpha"}) {
+		t.Fatalf("Reconcile().Removed = %v, want [alpha]", result.Removed)
+	}
+	if _, ok := manager.Registry().Pending("alpha"); ok {
+		t.Fatal("Registry().Pending(alpha) ok = true after removal, want false")
+	}
+	manager.Wait()
+}
+
+func TestManagerReconcileRecoversTerminalConnectorFactoryFailureAfterConfigChange(t *testing.T) {
+	t.Parallel()
+
+	manager, err := project.NewManager(project.ManagerConfig{
+		Projects: []globalconfig.Project{{ID: "alpha", Weight: 1}},
+	}, project.ManagerDependencies{
+		ProjectFactory: func(cfg globalconfig.Project) (*project.Project, error) {
+			workflowCfg := workflowConfig("memory")
+			return project.New(project.Config{
+				Project:  cfg,
+				Workflow: workflowconfig.Workflow{Config: workflowCfg},
+			}, project.Dependencies{
+				ConnectorFactory: func(workflowconfig.Config) (connector.Connector, error) {
+					if cfg.Weight == 1 {
+						return nil, errors.New("connector credentials are invalid")
+					}
+					return provisioningConnector{}, nil
+				},
+				Runner: blockingRunner{},
+			})
+		},
+	})
+	if err != nil {
+		t.Fatalf("NewManager() error = %v", err)
+	}
+	if err := manager.Start(context.Background()); err != nil {
+		t.Fatalf("Start() error = %v", err)
+	}
+	if health, ok := manager.Registry().Pending("alpha"); !ok || !health.RetryStopped {
+		t.Fatalf("Registry().Pending(alpha) = %#v, %t, want terminal state", health, ok)
+	}
+
+	result, err := manager.Reconcile(context.Background(), project.ManagerConfig{
+		Projects: []globalconfig.Project{{ID: "alpha", Weight: 2}},
+	})
+	if err != nil {
+		t.Fatalf("Reconcile() error = %v", err)
+	}
+	if !reflect.DeepEqual(result.Changed, []project.ID{"alpha"}) {
+		t.Fatalf("Reconcile().Changed = %v, want [alpha]", result.Changed)
+	}
+	alpha, ok := manager.Registry().Get("alpha")
+	if !ok || !alpha.Running() {
+		t.Fatalf("Registry().Get(alpha) = %#v, %t, want recovered running project", alpha, ok)
+	}
+	if _, ok := manager.Registry().Pending("alpha"); ok {
+		t.Fatal("Registry().Pending(alpha) ok = true after config recovery, want false")
+	}
+	if err := alpha.Close(); err != nil {
+		t.Fatalf("Close() error = %v", err)
 	}
 }
 
@@ -1536,6 +1952,49 @@ func TestManagerConfigFromGlobal(t *testing.T) {
 	}
 	if len(got.Projects[0].GlobalKnowledge.Sources) != 1 || got.Projects[0].GlobalKnowledge.Sources[0].Name != "Global" {
 		t.Fatalf("Projects[0].GlobalKnowledge = %#v, want global source", got.Projects[0].GlobalKnowledge)
+	}
+}
+
+func receiveProvisionAttempt(t *testing.T, attempts <-chan int) int {
+	t.Helper()
+
+	select {
+	case attempt := <-attempts:
+		return attempt
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for connector provisioning attempt")
+		return 0
+	}
+}
+
+func receiveRetryDelay(t *testing.T, delays <-chan time.Duration) time.Duration {
+	t.Helper()
+
+	select {
+	case delay := <-delays:
+		return delay
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for connector retry delay")
+		return 0
+	}
+}
+
+func waitForProjectRunning(t *testing.T, trackedProject *project.Project) {
+	t.Helper()
+
+	timer := time.NewTimer(time.Second)
+	defer timer.Stop()
+	ticker := time.NewTicker(5 * time.Millisecond)
+	defer ticker.Stop()
+	for {
+		if trackedProject.Running() {
+			return
+		}
+		select {
+		case <-ticker.C:
+		case <-timer.C:
+			t.Fatal("timed out waiting for retried project to run")
+		}
 	}
 }
 

--- a/internal/project/manager_test.go
+++ b/internal/project/manager_test.go
@@ -443,6 +443,82 @@ func TestManagerReconcileRemovesPendingConnectorRetry(t *testing.T) {
 	manager.Wait()
 }
 
+func TestManagerRemoveDoesNotDeadlockWithActivatingConnectorRetry(t *testing.T) {
+	t.Parallel()
+
+	retryContexts := make(chan context.Context)
+	factoryEntered := make(chan struct{})
+	releaseFactory := make(chan struct{})
+	var mu sync.Mutex
+	factoryCalls := 0
+
+	manager, err := project.NewManager(project.ManagerConfig{
+		Projects: []globalconfig.Project{{ID: "alpha", Weight: 1}},
+	}, project.ManagerDependencies{
+		ProjectFactory: func(cfg globalconfig.Project) (*project.Project, error) {
+			mu.Lock()
+			factoryCalls++
+			call := factoryCalls
+			mu.Unlock()
+			if call == 1 {
+				return nil, errors.Join(project.ErrConnectorCreation, githubconnector.ErrTransient)
+			}
+			close(factoryEntered)
+			<-releaseFactory
+			return project.New(project.Config{
+				Project:  cfg,
+				Workflow: workflowconfig.Workflow{Config: workflowConfig("memory")},
+			}, project.Dependencies{
+				Connector: provisioningConnector{},
+				Runner:    blockingRunner{},
+			})
+		},
+		RetrySleep: func(ctx context.Context, _ time.Duration) error {
+			retryContexts <- ctx
+			return nil
+		},
+	})
+	if err != nil {
+		t.Fatalf("NewManager() error = %v", err)
+	}
+	if err := manager.Start(context.Background()); err != nil {
+		t.Fatalf("Start() error = %v", err)
+	}
+
+	var retryCtx context.Context
+	select {
+	case retryCtx = <-retryContexts:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for retry delay")
+	}
+	select {
+	case <-factoryEntered:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for retry factory")
+	}
+
+	removeDone := make(chan error, 1)
+	go func() {
+		removeDone <- manager.Remove(context.Background(), "alpha")
+	}()
+	select {
+	case <-retryCtx.Done():
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for retry cancellation")
+	}
+	close(releaseFactory)
+
+	select {
+	case err := <-removeDone:
+		if err != nil {
+			t.Fatalf("Remove() error = %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("Remove() deadlocked with activating connector retry")
+	}
+	manager.Wait()
+}
+
 func TestManagerReconcileRecoversTerminalConnectorFactoryFailureAfterConfigChange(t *testing.T) {
 	t.Parallel()
 

--- a/internal/project/project.go
+++ b/internal/project/project.go
@@ -33,6 +33,7 @@ import (
 
 var (
 	ErrAlreadyRunning      = errors.New("project already running")
+	ErrConnectorCreation   = errors.New("project connector creation failed")
 	ErrMissingConnector    = errors.New("project connector is required")
 	ErrMissingOrchestrator = errors.New("project orchestrator is required")
 	ErrMissingProject      = errors.New("project is required")
@@ -65,8 +66,10 @@ type Event struct {
 }
 
 type RuntimeError struct {
-	Message string
-	At      time.Time
+	Message     string
+	At          time.Time
+	NextRetryAt time.Time
+	Terminal    bool
 }
 
 type WorkflowSourceStatus struct {
@@ -810,7 +813,7 @@ func (p *Project) run(ctx context.Context, done chan struct{}, orch *orchestrato
 		p.done = nil
 		p.runErr = err
 		if err != nil {
-			p.runtimeErr = RuntimeError{Message: err.Error(), At: time.Now().UTC()}
+			p.runtimeErr = RuntimeError{Message: err.Error(), At: time.Now().UTC(), Terminal: true}
 		}
 	}
 	p.mu.Unlock()
@@ -1477,10 +1480,23 @@ func (p *Project) recordRuntimeError(err error) {
 		return
 	}
 
+	p.recordRuntimeErrorState(err, time.Now().UTC(), time.Time{}, true)
+}
+
+func (p *Project) recordRuntimeErrorState(err error, at time.Time, nextRetryAt time.Time, terminal bool) {
+	if p == nil || err == nil {
+		return
+	}
+
 	p.mu.Lock()
 	defer p.mu.Unlock()
 
-	p.runtimeErr = RuntimeError{Message: err.Error(), At: time.Now().UTC()}
+	p.runtimeErr = RuntimeError{
+		Message:     err.Error(),
+		At:          at.UTC(),
+		NextRetryAt: nextRetryAt.UTC(),
+		Terminal:    terminal,
+	}
 }
 
 type workflowUpdater interface {
@@ -1506,7 +1522,7 @@ func resolveConnectorFactory(deps Dependencies) ConnectorFactory {
 func buildConnector(cfg workflowconfig.Config, connectorFactory ConnectorFactory) (connector.Connector, error) {
 	projectConnector, err := connectorFactory(cfg)
 	if err != nil {
-		return nil, fmt.Errorf("create project connector: %w", err)
+		return nil, fmt.Errorf("%w: create project connector: %w", ErrConnectorCreation, err)
 	}
 	if projectConnector == nil {
 		return nil, ErrMissingConnector

--- a/internal/project/registry.go
+++ b/internal/project/registry.go
@@ -3,16 +3,44 @@ package project
 import (
 	"slices"
 	"sync"
+	"time"
+
+	globalconfig "github.com/digitaldrywood/detent/internal/config/global"
 )
+
+type HealthStatus string
+
+const (
+	HealthStatusInitializing HealthStatus = "initializing"
+	HealthStatusReady        HealthStatus = "ready"
+	HealthStatusDegraded     HealthStatus = "degraded"
+	HealthStatusPaused       HealthStatus = "paused"
+)
+
+type Health struct {
+	Project      globalconfig.Project
+	Status       HealthStatus
+	LastError    string
+	LastErrorAt  time.Time
+	NextRetryAt  time.Time
+	RetryStopped bool
+}
+
+type pendingProject struct {
+	config       globalconfig.Project
+	runtimeError RuntimeError
+}
 
 type Registry struct {
 	mu       sync.RWMutex
 	projects map[ID]*Project
+	pending  map[ID]pendingProject
 }
 
 func NewRegistry() *Registry {
 	return &Registry{
 		projects: map[ID]*Project{},
+		pending:  map[ID]pendingProject{},
 	}
 }
 
@@ -30,7 +58,36 @@ func (r *Registry) Set(project *Project) error {
 	defer r.mu.Unlock()
 
 	r.projects[id] = project
+	delete(r.pending, id)
 	return nil
+}
+
+func (r *Registry) SetPending(cfg globalconfig.Project, runtimeErr RuntimeError) error {
+	id := normalizeProjectID(ID(cfg.ID))
+	if id == "" {
+		return ErrMissingProjectID
+	}
+	cfg.ID = string(id)
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	if _, ok := r.projects[id]; ok {
+		return ErrProjectExists
+	}
+	r.pending[id] = pendingProject{config: cfg, runtimeError: runtimeErr}
+	return nil
+}
+
+func (r *Registry) Pending(id ID) (Health, bool) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	pending, ok := r.pending[normalizeProjectID(id)]
+	if !ok {
+		return Health{}, false
+	}
+	return pendingHealth(pending), true
 }
 
 func (r *Registry) Get(id ID) (*Project, bool) {
@@ -49,11 +106,14 @@ func (r *Registry) Delete(id ID) bool {
 	defer r.mu.Unlock()
 
 	id = normalizeProjectID(id)
-	if _, ok := r.projects[id]; !ok {
+	_, projectExists := r.projects[id]
+	_, pendingExists := r.pending[id]
+	if !projectExists && !pendingExists {
 		return false
 	}
 
 	delete(r.projects, id)
+	delete(r.pending, id)
 	return true
 }
 
@@ -79,4 +139,68 @@ func (r *Registry) Len() int {
 	defer r.mu.RUnlock()
 
 	return len(r.projects)
+}
+
+func (r *Registry) Health() []Health {
+	r.mu.RLock()
+	projects := make(map[ID]*Project, len(r.projects))
+	for id, trackedProject := range r.projects {
+		projects[id] = trackedProject
+	}
+	pending := make(map[ID]pendingProject, len(r.pending))
+	for id, pendingProject := range r.pending {
+		pending[id] = pendingProject
+	}
+	r.mu.RUnlock()
+
+	ids := make([]ID, 0, len(projects)+len(pending))
+	for id := range projects {
+		ids = append(ids, id)
+	}
+	for id := range pending {
+		ids = append(ids, id)
+	}
+	slices.Sort(ids)
+
+	health := make([]Health, 0, len(ids))
+	for _, id := range ids {
+		if trackedProject := projects[id]; trackedProject != nil {
+			health = append(health, projectHealth(trackedProject))
+			continue
+		}
+		health = append(health, pendingHealth(pending[id]))
+	}
+	return health
+}
+
+func projectHealth(trackedProject *Project) Health {
+	status := HealthStatusInitializing
+	if trackedProject.Paused() {
+		status = HealthStatusPaused
+	} else if trackedProject.Running() {
+		status = HealthStatusReady
+	}
+	runtimeErr := trackedProject.RuntimeError()
+	if status == HealthStatusInitializing && runtimeErr.Message != "" {
+		status = HealthStatusDegraded
+	}
+	return Health{
+		Project:      trackedProject.Config(),
+		Status:       status,
+		LastError:    runtimeErr.Message,
+		LastErrorAt:  runtimeErr.At,
+		NextRetryAt:  runtimeErr.NextRetryAt,
+		RetryStopped: runtimeErr.Terminal,
+	}
+}
+
+func pendingHealth(pending pendingProject) Health {
+	return Health{
+		Project:      pending.config,
+		Status:       HealthStatusDegraded,
+		LastError:    pending.runtimeError.Message,
+		LastErrorAt:  pending.runtimeError.At,
+		NextRetryAt:  pending.runtimeError.NextRetryAt,
+		RetryStopped: pending.runtimeError.Terminal,
+	}
 }

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -1046,8 +1046,10 @@ func (s *Server) health(c echo.Context) error {
 		checks["demo"] = DemoModeScreenshots
 		checks["demo_clock"] = s.demo.clock
 	}
+	projectStatus, projectHealth := s.projectHealth()
 	return c.JSON(http.StatusOK, healthResponse{
 		Status:            status,
+		ProjectStatus:     projectStatus,
 		Mode:              string(s.mode),
 		Connector:         s.connectorName(),
 		SessionsRemaining: sessionsRemaining,
@@ -1056,7 +1058,37 @@ func (s *Server) health(c echo.Context) error {
 		Budgets:           s.enforcedBudgets(),
 		Workflows:         s.workflowSources(),
 		BackendOutages:    backendOutages,
+		Projects:          projectHealth,
 	})
+}
+
+func (s *Server) projectHealth() (string, []healthProject) {
+	if s.registry == nil {
+		return "unknown", nil
+	}
+
+	status := "ok"
+	projectHealth := s.registry.Health()
+	projects := make([]healthProject, 0, len(projectHealth))
+	for _, health := range projectHealth {
+		switch health.Status {
+		case project.HealthStatusDegraded:
+			status = "degraded"
+		case project.HealthStatusInitializing:
+			if status == "ok" {
+				status = "initializing"
+			}
+		}
+		projects = append(projects, healthProject{
+			ProjectID:    health.Project.ID,
+			Status:       string(health.Status),
+			LastError:    health.LastError,
+			LastErrorAt:  health.LastErrorAt,
+			NextRetryAt:  health.NextRetryAt,
+			RetryStopped: health.RetryStopped,
+		})
+	}
+	return status, projects
 }
 
 func (s *Server) workflowSources() []healthWorkflowSource {
@@ -1263,6 +1295,7 @@ func (s *Server) connectorName() string {
 
 type healthResponse struct {
 	Status            string                    `json:"status"`
+	ProjectStatus     string                    `json:"project_status"`
 	Mode              string                    `json:"mode"`
 	Connector         string                    `json:"connector"`
 	SessionsRemaining int                       `json:"sessions_remaining,omitempty"`
@@ -1271,6 +1304,16 @@ type healthResponse struct {
 	Budgets           []healthBudget            `json:"budgets,omitempty"`
 	Workflows         []healthWorkflowSource    `json:"workflows,omitempty"`
 	BackendOutages    []telemetry.BackendOutage `json:"backend_outages,omitempty"`
+	Projects          []healthProject           `json:"projects,omitempty"`
+}
+
+type healthProject struct {
+	ProjectID    string    `json:"project_id"`
+	Status       string    `json:"status"`
+	LastError    string    `json:"last_error,omitempty"`
+	LastErrorAt  time.Time `json:"last_error_at,omitzero"`
+	NextRetryAt  time.Time `json:"next_retry_at,omitzero"`
+	RetryStopped bool      `json:"retry_stopped"`
 }
 
 type healthWorkflowSource struct {

--- a/internal/web/server_test.go
+++ b/internal/web/server_test.go
@@ -6534,6 +6534,53 @@ func TestHealthReportsDraining(t *testing.T) {
 	}
 }
 
+func TestHealthDistinguishesProcessHealthFromProjectConnectorDegradation(t *testing.T) {
+	t.Parallel()
+
+	lastErrorAt := time.Date(2026, 7, 22, 15, 0, 0, 0, time.UTC)
+	nextRetryAt := lastErrorAt.Add(30 * time.Second)
+	deps := testDeps(t)
+	if err := deps.Registry.SetPending(globalconfig.Project{ID: "alpha"}, project.RuntimeError{
+		Message:     "provision project connector: github transient error",
+		At:          lastErrorAt,
+		NextRetryAt: nextRetryAt,
+	}); err != nil {
+		t.Fatalf("Registry.SetPending() error = %v", err)
+	}
+
+	server, err := web.NewServer(web.Config{}, deps)
+	if err != nil {
+		t.Fatalf("NewServer() error = %v", err)
+	}
+	payload := requestJSON(t, server, http.MethodGet, "/health", http.StatusOK)
+	if payload["status"] != "ok" {
+		t.Fatalf("status = %#v, want process health ok", payload["status"])
+	}
+	if payload["project_status"] != "degraded" {
+		t.Fatalf("project_status = %#v, want degraded", payload["project_status"])
+	}
+	projects, ok := payload["projects"].([]any)
+	if !ok || len(projects) != 1 {
+		t.Fatalf("projects = %#v, want one degraded project", payload["projects"])
+	}
+	projectHealth, ok := projects[0].(map[string]any)
+	if !ok {
+		t.Fatalf("projects[0] = %#v, want object", projects[0])
+	}
+	if projectHealth["project_id"] != "alpha" || projectHealth["status"] != "degraded" {
+		t.Fatalf("project health = %#v, want alpha degraded", projectHealth)
+	}
+	if projectHealth["last_error"] != "provision project connector: github transient error" {
+		t.Fatalf("last_error = %#v", projectHealth["last_error"])
+	}
+	if projectHealth["next_retry_at"] != nextRetryAt.Format(time.RFC3339) {
+		t.Fatalf("next_retry_at = %#v, want %q", projectHealth["next_retry_at"], nextRetryAt.Format(time.RFC3339))
+	}
+	if projectHealth["retry_stopped"] != false {
+		t.Fatalf("retry_stopped = %#v, want false", projectHealth["retry_stopped"])
+	}
+}
+
 func TestHealthReportsUpdateCheckStatus(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

- keep Detent serving while connector creation or provisioning failures degrade only the affected project
- retry transient connector startup failures in-process with bounded exponential backoff, jitter, cancellation, and shutdown joining
- expose per-project connector state, last error, retry deadline, and terminal policy through snapshots and `/health`

Fixes #1483

## UI Surface Contract

- [x] N/A; this PR adds project health data without changing dashboard layout, density, or responsive visibility.
- [x] This PR does not add persistent top-of-screen messaging.
- [x] N/A; there are no visual changes to primary operator screens.

## Test Plan

- [x] `make check`
- [x] focused race tests for project retry, reconciliation, supervised boot, snapshot, and health behavior
- [x] regression tests for transient provisioning/factory failures, bounded jittered backoff, unaffected projects, permanent failures, and runtime survival