### PR TITLE
fix(doctor): preserve partial timeout results

### DIFF
--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -112,9 +112,14 @@ type doctorOutputReport struct {
 type doctorCheckJob struct {
 	Name     string
 	Current  func() string
-	Partial  func() []doctorCheck
+	Freeze   func() doctorCheckSnapshot
 	Progress <-chan struct{}
 	Run      func(context.Context) []doctorCheck
+}
+
+type doctorCheckSnapshot struct {
+	Current string
+	Checks  []doctorCheck
 }
 
 type doctorCheckResult struct {
@@ -126,6 +131,7 @@ type doctorCheckProgress struct {
 	mu      sync.Mutex
 	current string
 	checks  []doctorCheck
+	frozen  bool
 	updates chan struct{}
 }
 
@@ -135,6 +141,10 @@ func newDoctorCheckProgress() *doctorCheckProgress {
 
 func (p *doctorCheckProgress) Set(current string, checks []doctorCheck) {
 	p.mu.Lock()
+	if p.frozen {
+		p.mu.Unlock()
+		return
+	}
 	p.current = strings.TrimSpace(current)
 	p.checks = append(p.checks[:0], checks...)
 	p.mu.Unlock()
@@ -151,10 +161,14 @@ func (p *doctorCheckProgress) Current() string {
 	return p.current
 }
 
-func (p *doctorCheckProgress) Partial() []doctorCheck {
+func (p *doctorCheckProgress) Freeze() doctorCheckSnapshot {
 	p.mu.Lock()
 	defer p.mu.Unlock()
-	return append([]doctorCheck(nil), p.checks...)
+	p.frozen = true
+	return doctorCheckSnapshot{
+		Current: p.current,
+		Checks:  append([]doctorCheck(nil), p.checks...),
+	}
 }
 
 func (p *doctorCheckProgress) Updates() <-chan struct{} {
@@ -635,24 +649,33 @@ func runDoctorCheck(ctx context.Context, job doctorCheckJob, timeout time.Durati
 		case <-job.Progress:
 			resetDoctorCheckTimer(timer, timeout)
 		case <-timer.C:
+			snapshot := freezeDoctorCheck(job)
 			cancel()
-			return doctorTimedOutChecks(job, timeout, context.DeadlineExceeded)
+			return doctorTimedOutChecks(job.Name, snapshot, timeout, context.DeadlineExceeded)
 		case <-ctx.Done():
+			snapshot := freezeDoctorCheck(job)
 			cancel()
-			return doctorTimedOutChecks(job, timeout, ctx.Err())
+			return doctorTimedOutChecks(job.Name, snapshot, timeout, ctx.Err())
 		}
 	}
 }
 
-func doctorTimedOutChecks(job doctorCheckJob, timeout time.Duration, err error) []doctorCheck {
-	var checks []doctorCheck
-	if job.Partial != nil {
-		checks = job.Partial()
+func freezeDoctorCheck(job doctorCheckJob) doctorCheckSnapshot {
+	if job.Freeze != nil {
+		return job.Freeze()
 	}
-	return append(checks, doctorCheck{
-		Name:   job.Name,
+	snapshot := doctorCheckSnapshot{}
+	if job.Current != nil {
+		snapshot.Current = strings.TrimSpace(job.Current())
+	}
+	return snapshot
+}
+
+func doctorTimedOutChecks(name string, snapshot doctorCheckSnapshot, timeout time.Duration, err error) []doctorCheck {
+	return append(snapshot.Checks, doctorCheck{
+		Name:   name,
 		Status: doctorFail,
-		Detail: doctorTimeoutDetail(job, timeout, err),
+		Detail: doctorTimeoutDetail(name, snapshot.Current, timeout, err),
 		Hint:   doctorTimeoutHint(),
 	})
 }
@@ -667,12 +690,9 @@ func resetDoctorCheckTimer(timer *time.Timer, timeout time.Duration) {
 	timer.Reset(timeout)
 }
 
-func doctorTimeoutDetail(job doctorCheckJob, timeout time.Duration, err error) string {
-	current := ""
-	if job.Current != nil {
-		current = strings.TrimSpace(job.Current())
-	}
-	if current != "" && current != strings.TrimSpace(job.Name) {
+func doctorTimeoutDetail(name string, current string, timeout time.Duration, err error) string {
+	current = strings.TrimSpace(current)
+	if current != "" && current != strings.TrimSpace(name) {
 		return fmt.Sprintf("timed out after %s while running %s: %v", timeout, current, err)
 	}
 	return fmt.Sprintf("timed out after %s: %v", timeout, err)

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -112,6 +112,7 @@ type doctorOutputReport struct {
 type doctorCheckJob struct {
 	Name     string
 	Current  func() string
+	Partial  func() []doctorCheck
 	Progress <-chan struct{}
 	Run      func(context.Context) []doctorCheck
 }
@@ -124,6 +125,7 @@ type doctorCheckResult struct {
 type doctorCheckProgress struct {
 	mu      sync.Mutex
 	current string
+	checks  []doctorCheck
 	updates chan struct{}
 }
 
@@ -131,9 +133,10 @@ func newDoctorCheckProgress() *doctorCheckProgress {
 	return &doctorCheckProgress{updates: make(chan struct{}, 1)}
 }
 
-func (p *doctorCheckProgress) Set(current string) {
+func (p *doctorCheckProgress) Set(current string, checks []doctorCheck) {
 	p.mu.Lock()
 	p.current = strings.TrimSpace(current)
+	p.checks = append(p.checks[:0], checks...)
 	p.mu.Unlock()
 
 	select {
@@ -146,6 +149,12 @@ func (p *doctorCheckProgress) Current() string {
 	p.mu.Lock()
 	defer p.mu.Unlock()
 	return p.current
+}
+
+func (p *doctorCheckProgress) Partial() []doctorCheck {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return append([]doctorCheck(nil), p.checks...)
 }
 
 func (p *doctorCheckProgress) Updates() <-chan struct{} {
@@ -627,22 +636,25 @@ func runDoctorCheck(ctx context.Context, job doctorCheckJob, timeout time.Durati
 			resetDoctorCheckTimer(timer, timeout)
 		case <-timer.C:
 			cancel()
-			return []doctorCheck{{
-				Name:   job.Name,
-				Status: doctorFail,
-				Detail: doctorTimeoutDetail(job, timeout, context.DeadlineExceeded),
-				Hint:   doctorTimeoutHint(),
-			}}
+			return doctorTimedOutChecks(job, timeout, context.DeadlineExceeded)
 		case <-ctx.Done():
 			cancel()
-			return []doctorCheck{{
-				Name:   job.Name,
-				Status: doctorFail,
-				Detail: doctorTimeoutDetail(job, timeout, ctx.Err()),
-				Hint:   doctorTimeoutHint(),
-			}}
+			return doctorTimedOutChecks(job, timeout, ctx.Err())
 		}
 	}
+}
+
+func doctorTimedOutChecks(job doctorCheckJob, timeout time.Duration, err error) []doctorCheck {
+	var checks []doctorCheck
+	if job.Partial != nil {
+		checks = job.Partial()
+	}
+	return append(checks, doctorCheck{
+		Name:   job.Name,
+		Status: doctorFail,
+		Detail: doctorTimeoutDetail(job, timeout, err),
+		Hint:   doctorTimeoutHint(),
+	})
 }
 
 func resetDoctorCheckTimer(timer *time.Timer, timeout time.Duration) {

--- a/internal/cli/doctor_project.go
+++ b/internal/cli/doctor_project.go
@@ -186,8 +186,7 @@ func doctorProjectCheckJobs(cfg globalconfig.Config, deps doctorDeps, githubToke
 		progress := newDoctorCheckProgress()
 		jobs = append(jobs, doctorCheckJob{
 			Name:     "Project " + id + " checks",
-			Current:  progress.Current,
-			Partial:  progress.Partial,
+			Freeze:   progress.Freeze,
 			Progress: progress.Updates(),
 			Run: func(jobCtx context.Context) []doctorCheck {
 				return checkDoctorProjectWithProgress(jobCtx, project, doctorRuntimeStorePath(cfg.Path), deps, githubToken, allowWriteProbes, workflowTokenThreshold, progress.Set)

--- a/internal/cli/doctor_project.go
+++ b/internal/cli/doctor_project.go
@@ -187,6 +187,7 @@ func doctorProjectCheckJobs(cfg globalconfig.Config, deps doctorDeps, githubToke
 		jobs = append(jobs, doctorCheckJob{
 			Name:     "Project " + id + " checks",
 			Current:  progress.Current,
+			Partial:  progress.Partial,
 			Progress: progress.Updates(),
 			Run: func(jobCtx context.Context) []doctorCheck {
 				return checkDoctorProjectWithProgress(jobCtx, project, doctorRuntimeStorePath(cfg.Path), deps, githubToken, allowWriteProbes, workflowTokenThreshold, progress.Set)
@@ -212,12 +213,13 @@ func checkDoctorProjectWithProgress(
 	githubToken RuntimeSecret,
 	allowWriteProbes bool,
 	workflowTokenThreshold int,
-	setCurrent func(string),
+	setProgress func(string, []doctorCheck),
 ) []doctorCheck {
 	id := doctorProjectID(project)
+	var checks []doctorCheck
 	setDoctorCurrentCheck := func(name string) {
-		if setCurrent != nil {
-			setCurrent(name)
+		if setProgress != nil {
+			setProgress(name, checks)
 		}
 	}
 	workflowCheckName := "Project " + id + " workflow"
@@ -295,7 +297,7 @@ func checkDoctorProjectWithProgress(
 			}
 		}
 	}
-	checks := []doctorCheck{workflowCheck}
+	checks = append(checks, workflowCheck)
 	if overlayCheck, ok := checkDoctorLocalWorkflowOverlay(ctx, id, workflow, deps); ok {
 		checks = append(checks, overlayCheck)
 	}

--- a/internal/cli/doctor_project.go
+++ b/internal/cli/doctor_project.go
@@ -298,9 +298,11 @@ func checkDoctorProjectWithProgress(
 		}
 	}
 	checks = append(checks, workflowCheck)
+	setDoctorCurrentCheck("Project " + id + " local workflow overlay")
 	if overlayCheck, ok := checkDoctorLocalWorkflowOverlay(ctx, id, workflow, deps); ok {
 		checks = append(checks, overlayCheck)
 	}
+	setDoctorCurrentCheck("Project " + id + " billing mode")
 	if billingCheck, ok := checkDoctorBillingMode(id, workflow.Config); ok {
 		checks = append(checks, billingCheck)
 	}

--- a/internal/cli/doctor_test.go
+++ b/internal/cli/doctor_test.go
@@ -4720,6 +4720,46 @@ func TestRunDoctorCheckRenewsTimeoutForReportedProgress(t *testing.T) {
 	}
 }
 
+func TestRunDoctorCheckFreezesProgressBeforeCancellation(t *testing.T) {
+	t.Parallel()
+
+	progress := newDoctorCheckProgress()
+	postCancelPublication := make(chan struct{})
+	completed := doctorCheck{Name: "Project alpha workflow", Status: doctorOK, Detail: "loaded"}
+	canceled := doctorCheck{Name: "Project alpha route models", Status: doctorFail, Detail: "context canceled"}
+	checks := runDoctorCheck(context.Background(), doctorCheckJob{
+		Name:   "Project alpha checks",
+		Freeze: progress.Freeze,
+		Current: func() string {
+			<-postCancelPublication
+			return progress.Current()
+		},
+		Progress: progress.Updates(),
+		Run: func(ctx context.Context) []doctorCheck {
+			progress.Set("Project alpha route models", []doctorCheck{completed})
+			<-ctx.Done()
+			progress.Set("Project alpha GitHub readiness", []doctorCheck{completed, canceled})
+			close(postCancelPublication)
+			return []doctorCheck{completed, canceled}
+		},
+	}, 20*time.Millisecond)
+
+	select {
+	case <-postCancelPublication:
+	case <-time.After(time.Second):
+		t.Fatal("job did not attempt to publish after cancellation")
+	}
+	if len(checks) != 2 {
+		t.Fatalf("checks = %#v, want frozen completed check followed by timeout", checks)
+	}
+	if checks[0].Name != completed.Name || checks[0].Status != completed.Status || checks[0].Detail != completed.Detail {
+		t.Fatalf("checks[0] = %#v, want %#v", checks[0], completed)
+	}
+	if checks[1].Name != "Project alpha checks" || !strings.Contains(checks[1].Detail, "while running Project alpha route models") {
+		t.Fatalf("timeout check = %#v, want frozen route-model stage", checks[1])
+	}
+}
+
 func TestDoctorProjectCheckJobTimeoutPreservesCompletedChecks(t *testing.T) {
 	t.Parallel()
 

--- a/internal/cli/doctor_test.go
+++ b/internal/cli/doctor_test.go
@@ -4720,61 +4720,88 @@ func TestRunDoctorCheckRenewsTimeoutForReportedProgress(t *testing.T) {
 	}
 }
 
-func TestDoctorProjectCheckJobTimeoutReportsCurrentInnerCheck(t *testing.T) {
+func TestDoctorProjectCheckJobTimeoutPreservesCompletedChecks(t *testing.T) {
 	t.Parallel()
 
-	workflow := validDoctorDependencyWorkflow(false)
-	releaseReadiness := make(chan struct{})
-	t.Cleanup(func() {
-		close(releaseReadiness)
-	})
-	jobs := doctorProjectCheckJobs(globalconfig.Config{
-		Projects: []globalconfig.Project{{ID: "alpha", Workflow: "WORKFLOW.md"}},
-	}, doctorDeps{
-		loadWorkflow: func(string) (workflowconfig.Workflow, error) {
-			return workflowconfig.Workflow{Config: workflow}, nil
-		},
-		gitWorkTree: func(context.Context, string) error {
-			return nil
-		},
-		gitRemoteURL: func(context.Context, string) (string, error) {
-			return "https://github.com/digitaldrywood/detent", nil
-		},
-		autoPromoteConnector: func(workflowconfig.Config) (doctorAutoPromoteConnector, error) {
-			return &fakeDoctorAutoPromoteConnector{}, nil
-		},
-		githubReadiness: func(context.Context, ghconnector.Config, ghconnector.ReadinessConfig) ([]ghconnector.ReadinessCheck, error) {
-			<-releaseReadiness
-			return nil, nil
-		},
-		githubMergeSettings: func(context.Context, workflowconfig.Config, string) (ghconnector.RepositoryMergeSettings, error) {
-			return ghconnector.RepositoryMergeSettings{AllowSquashMerge: true}, nil
-		},
-	}, RuntimeSecret{Value: "token", Source: "github_token"}, false, doctorWorkflowDefaultTokenThreshold)
-	if len(jobs) != 1 {
-		t.Fatalf("jobs len = %d, want 1", len(jobs))
+	tests := []struct {
+		name         string
+		current      string
+		blockOverlay bool
+	}{
+		{name: "GitHub readiness", current: "GitHub readiness"},
+		{name: "local workflow overlay", current: "local workflow overlay", blockOverlay: true},
 	}
 
-	checks := runDoctorCheck(context.Background(), jobs[0], 20*time.Millisecond)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 
-	if len(checks) < 2 {
-		t.Fatalf("checks = %#v, want completed checks followed by timeout", checks)
-	}
-	var foundWorkflow bool
-	for _, check := range checks[:len(checks)-1] {
-		if check.Name == "Project alpha workflow" {
-			foundWorkflow = true
-			break
-		}
-	}
-	if !foundWorkflow {
-		t.Fatalf("checks = %#v, want completed workflow check", checks)
-	}
-	timeoutCheck := checks[len(checks)-1]
-	for _, want := range []string{"Project alpha checks", "timed out after 20ms", "while running Project alpha "} {
-		if !strings.Contains(timeoutCheck.Name+" "+timeoutCheck.Detail, want) {
-			t.Fatalf("timeout check = %#v, want containing %q", timeoutCheck, want)
-		}
+			workflow := validDoctorDependencyWorkflow(false)
+			releaseBlockedCheck := make(chan struct{})
+			t.Cleanup(func() {
+				close(releaseBlockedCheck)
+			})
+			loadedWorkflow := workflowconfig.Workflow{Config: workflow}
+			if tt.blockOverlay {
+				loadedWorkflow.Overlay.Path = "/repo/WORKFLOW.local.md"
+			}
+			jobs := doctorProjectCheckJobs(globalconfig.Config{
+				Projects: []globalconfig.Project{{ID: "alpha", Workflow: "WORKFLOW.md"}},
+			}, doctorDeps{
+				loadWorkflow: func(string) (workflowconfig.Workflow, error) {
+					return loadedWorkflow, nil
+				},
+				gitTracked: func(context.Context, string) (bool, error) {
+					if tt.blockOverlay {
+						<-releaseBlockedCheck
+					}
+					return false, nil
+				},
+				gitWorkTree: func(context.Context, string) error {
+					return nil
+				},
+				gitRemoteURL: func(context.Context, string) (string, error) {
+					return "https://github.com/digitaldrywood/detent", nil
+				},
+				autoPromoteConnector: func(workflowconfig.Config) (doctorAutoPromoteConnector, error) {
+					return &fakeDoctorAutoPromoteConnector{}, nil
+				},
+				githubReadiness: func(context.Context, ghconnector.Config, ghconnector.ReadinessConfig) ([]ghconnector.ReadinessCheck, error) {
+					if !tt.blockOverlay {
+						<-releaseBlockedCheck
+					}
+					return nil, nil
+				},
+				githubMergeSettings: func(context.Context, workflowconfig.Config, string) (ghconnector.RepositoryMergeSettings, error) {
+					return ghconnector.RepositoryMergeSettings{AllowSquashMerge: true}, nil
+				},
+			}, RuntimeSecret{Value: "token", Source: "github_token"}, false, doctorWorkflowDefaultTokenThreshold)
+			if len(jobs) != 1 {
+				t.Fatalf("jobs len = %d, want 1", len(jobs))
+			}
+
+			checks := runDoctorCheck(context.Background(), jobs[0], 20*time.Millisecond)
+
+			if len(checks) < 2 {
+				t.Fatalf("checks = %#v, want completed checks followed by timeout", checks)
+			}
+			var foundWorkflow bool
+			for _, check := range checks[:len(checks)-1] {
+				if check.Name == "Project alpha workflow" {
+					foundWorkflow = true
+					break
+				}
+			}
+			if !foundWorkflow {
+				t.Fatalf("checks = %#v, want completed workflow check", checks)
+			}
+			timeoutCheck := checks[len(checks)-1]
+			for _, want := range []string{"Project alpha checks", "timed out after 20ms", "while running Project alpha " + tt.current} {
+				if !strings.Contains(timeoutCheck.Name+" "+timeoutCheck.Detail, want) {
+					t.Fatalf("timeout check = %#v, want containing %q", timeoutCheck, want)
+				}
+			}
+		})
 	}
 }
 

--- a/internal/cli/doctor_test.go
+++ b/internal/cli/doctor_test.go
@@ -4704,7 +4704,7 @@ func TestRunDoctorCheckRenewsTimeoutForReportedProgress(t *testing.T) {
 		Progress: progress.Updates(),
 		Run: func(ctx context.Context) []doctorCheck {
 			for _, name := range []string{"first", "second", "third"} {
-				progress.Set("Project alpha " + name)
+				progress.Set("Project alpha "+name, nil)
 				select {
 				case <-ctx.Done():
 					return nil
@@ -4757,12 +4757,23 @@ func TestDoctorProjectCheckJobTimeoutReportsCurrentInnerCheck(t *testing.T) {
 
 	checks := runDoctorCheck(context.Background(), jobs[0], 20*time.Millisecond)
 
-	if len(checks) != 1 {
-		t.Fatalf("checks len = %d, want 1", len(checks))
+	if len(checks) < 2 {
+		t.Fatalf("checks = %#v, want completed checks followed by timeout", checks)
 	}
+	var foundWorkflow bool
+	for _, check := range checks[:len(checks)-1] {
+		if check.Name == "Project alpha workflow" {
+			foundWorkflow = true
+			break
+		}
+	}
+	if !foundWorkflow {
+		t.Fatalf("checks = %#v, want completed workflow check", checks)
+	}
+	timeoutCheck := checks[len(checks)-1]
 	for _, want := range []string{"Project alpha checks", "timed out after 20ms", "while running Project alpha "} {
-		if !strings.Contains(checks[0].Name+" "+checks[0].Detail, want) {
-			t.Fatalf("timeout check = %#v, want containing %q", checks[0], want)
+		if !strings.Contains(timeoutCheck.Name+" "+timeoutCheck.Detail, want) {
+			t.Fatalf("timeout check = %#v, want containing %q", timeoutCheck, want)
 		}
 	}
 }


### PR DESCRIPTION
## Summary

- preserve completed per-project doctor checks when a later sub-check exceeds the liveness timeout
- atomically freeze the completed results and current stage before cancellation, rejecting post-timeout publications
- publish progress boundaries before local overlay and billing probes so early completed results survive those stalls
- cover GitHub-readiness, local-overlay, and cancellation-aware timeout races with regression tests

Root cause: completed checks were local to `checkDoctorProjectWithProgress`, while `runDoctorCheck` could only receive the final slice after the entire job returned. Its timeout path therefore had no access to earlier results. The initial handoff also canceled before reading partial results and the current stage separately, allowing cancellation-aware work to advance the report past the timeout boundary.

Fixes #1489

## UI Surface Contract

- [x] N/A, or the linked issue explicitly authorizes any high-impact UI surface, layout, density, first-viewport, or responsive visibility tradeoff.
- [x] Persistent top-of-screen messaging is explicitly authorized by the issue, or this PR does not add it.
- [x] Visual changes to primary operator screens include screenshot or browser verification below.

No UI changes.

## Test Plan

- [x] `go test -race ./internal/cli -run '^(TestRunDoctorCheck.*|TestDoctorProjectCheckJobTimeoutPreservesCompletedChecks)$' -count=10`
- [x] `go test -race ./internal/cli -count=1`
- [x] `make check`