### PR TITLE
fix(codex): enforce configured stall timeout

### DIFF
--- a/internal/codex/appserver.go
+++ b/internal/codex/appserver.go
@@ -35,6 +35,7 @@ const (
 var (
 	ErrResponseError   = errors.New("codex response error")
 	ErrInvalidResponse = errors.New("invalid codex response")
+	ErrStreamStalled   = errors.New("codex stream stalled")
 	ErrTurnFailed      = errors.New("codex turn failed")
 	ErrTransportClose  = errors.New("close codex app-server transport")
 )
@@ -168,6 +169,7 @@ type RunTurnRequest struct {
 	ServiceTier           string
 	ReasoningEffort       string
 	TurnTimeout           time.Duration
+	StallTimeout          time.Duration
 	DynamicTools          []DynamicTool
 	ToolHandler           DynamicToolHandler
 }
@@ -428,7 +430,7 @@ func (s *AppServer) RunTurn(ctx context.Context, req RunTurnRequest, onUpdate Up
 		}
 	}
 
-	if err := s.streamTurn(ctx, transport, req.turnTimeout(s.turnTimeout), req.ToolHandler, onUpdate); err != nil {
+	if err := s.streamTurn(ctx, transport, req.turnTimeout(s.turnTimeout), req.StallTimeout, req.ToolHandler, onUpdate); err != nil {
 		return RunTurnResult{}, err
 	}
 
@@ -949,9 +951,16 @@ func (r RunTurnRequest) turnTimeout(fallback time.Duration) time.Duration {
 	return fallback
 }
 
-func (s *AppServer) streamTurn(ctx context.Context, transport Transport, turnTimeout time.Duration, toolHandler DynamicToolHandler, onUpdate UpdateHandler) error {
+func (s *AppServer) streamTurn(
+	ctx context.Context,
+	transport Transport,
+	turnTimeout time.Duration,
+	stallTimeout time.Duration,
+	toolHandler DynamicToolHandler,
+	onUpdate UpdateHandler,
+) error {
 	for {
-		msg, err := receiveWithTimeout(ctx, transport, turnTimeout)
+		msg, err := receiveTurnMessage(ctx, transport, turnTimeout, stallTimeout)
 		if err != nil {
 			return fmt.Errorf("stream turn: %w", err)
 		}
@@ -986,6 +995,27 @@ func (s *AppServer) streamTurn(ctx context.Context, transport Transport, turnTim
 			Body:    update.BackendErrorBody,
 		}
 	}
+}
+
+func receiveTurnMessage(
+	ctx context.Context,
+	transport Transport,
+	turnTimeout time.Duration,
+	stallTimeout time.Duration,
+) (Message, error) {
+	if stallTimeout <= 0 || turnTimeout > 0 && turnTimeout < stallTimeout {
+		return receiveWithTimeout(ctx, transport, turnTimeout)
+	}
+
+	stallErr := fmt.Errorf("%w after %s", ErrStreamStalled, stallTimeout)
+	receiveCtx, cancel := context.WithTimeoutCause(contextOrBackground(ctx), stallTimeout, stallErr)
+	defer cancel()
+
+	msg, err := transport.Receive(receiveCtx)
+	if err != nil && errors.Is(context.Cause(receiveCtx), ErrStreamStalled) {
+		return Message{}, context.Cause(receiveCtx)
+	}
+	return msg, err
 }
 
 func sendRequest(ctx context.Context, transport Transport, id int, method string, params any) error {

--- a/internal/codex/appserver_test.go
+++ b/internal/codex/appserver_test.go
@@ -738,8 +738,134 @@ func TestAppServerRunTurnRequestTurnTimeoutOverridesDefault(t *testing.T) {
 	if !errors.Is(err, context.DeadlineExceeded) {
 		t.Fatalf("RunTurn() error = %v, want context deadline exceeded", err)
 	}
+	if errors.Is(err, ErrStreamStalled) {
+		t.Fatalf("RunTurn() error = %v, want disabled stall timeout", err)
+	}
 	if elapsed := time.Since(startedAt); elapsed > time.Second {
 		t.Fatalf("RunTurn() elapsed = %v, want request timeout instead of default", elapsed)
+	}
+}
+
+func TestAppServerRunTurnEnforcesStallTimeout(t *testing.T) {
+	t.Parallel()
+
+	transport := newBlockingAppServerTransport([]Message{
+		responseMessage(t, 1, `{"userAgent":"codex-cli/0.135.0"}`),
+		responseMessage(t, 2, `{"thread":{"id":"thread-stall"}}`),
+		responseMessage(t, 5, `{"config":{"model":"gpt-5.6"}}`),
+		responseMessage(t, 3, `{"turn":{"id":"turn-stall"}}`),
+	})
+	server, err := NewAppServer(staticTransportFactory{transport: transport},
+		WithReadTimeout(time.Second),
+		WithTurnTimeout(time.Hour),
+	)
+	if err != nil {
+		t.Fatalf("NewAppServer() error = %v", err)
+	}
+
+	startedAt := time.Now()
+	_, err = server.RunTurn(context.Background(), RunTurnRequest{
+		Workspace:    "/tmp/detent-workspace",
+		Prompt:       "stall",
+		StallTimeout: 10 * time.Millisecond,
+	}, nil)
+	if !errors.Is(err, ErrStreamStalled) {
+		t.Fatalf("RunTurn() error = %v, want ErrStreamStalled", err)
+	}
+	if !strings.Contains(err.Error(), "after 10ms") {
+		t.Fatalf("RunTurn() error = %v, want configured stall duration", err)
+	}
+	if elapsed := time.Since(startedAt); elapsed > time.Second {
+		t.Fatalf("RunTurn() elapsed = %v, want stall timeout instead of turn timeout", elapsed)
+	}
+}
+
+func TestAppServerStreamTurnResetsStallTimeoutAfterActivity(t *testing.T) {
+	t.Parallel()
+
+	transport := &deadlineRecordingAppServerTransport{
+		fakeAppServerTransport: newFakeAppServerTransport([]Message{
+			notificationMessage(t, "item/agentMessage/delta", `{
+				"threadId":"thread-1",
+				"turnId":"turn-1",
+				"itemId":"item-1",
+				"delta":"still working"
+			}`),
+			notificationMessage(t, "turn/completed", `{"threadId":"thread-1","turn":{"id":"turn-1","status":"completed"}}`),
+		}),
+	}
+	server, err := NewAppServer(staticTransportFactory{transport: transport})
+	if err != nil {
+		t.Fatalf("NewAppServer() error = %v", err)
+	}
+
+	if err := server.streamTurn(context.Background(), transport, time.Hour, time.Second, nil, nil); err != nil {
+		t.Fatalf("streamTurn() error = %v", err)
+	}
+	if len(transport.deadlines) != 2 {
+		t.Fatalf("Receive() deadlines = %v, want two stall deadlines", transport.deadlines)
+	}
+	if !transport.deadlines[1].After(transport.deadlines[0]) {
+		t.Fatalf("Receive() deadlines = %v, want activity to reset stall deadline", transport.deadlines)
+	}
+}
+
+func TestReceiveTurnMessageTimeoutSelection(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name         string
+		context      func() context.Context
+		turnTimeout  time.Duration
+		stallTimeout time.Duration
+		want         error
+		wantStall    bool
+	}{
+		{
+			name:        "stall disabled",
+			context:     context.Background,
+			turnTimeout: 10 * time.Millisecond,
+			want:        context.DeadlineExceeded,
+		},
+		{
+			name:         "turn timeout is shorter",
+			context:      context.Background,
+			turnTimeout:  10 * time.Millisecond,
+			stallTimeout: time.Hour,
+			want:         context.DeadlineExceeded,
+		},
+		{
+			name:         "stall timeout is shorter",
+			context:      context.Background,
+			turnTimeout:  time.Hour,
+			stallTimeout: 10 * time.Millisecond,
+			want:         ErrStreamStalled,
+			wantStall:    true,
+		},
+		{
+			name: "parent canceled",
+			context: func() context.Context {
+				ctx, cancel := context.WithCancel(context.Background())
+				cancel()
+				return ctx
+			},
+			turnTimeout:  time.Hour,
+			stallTimeout: time.Second,
+			want:         context.Canceled,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			transport := newBlockingAppServerTransport(nil)
+			_, err := receiveTurnMessage(tt.context(), transport, tt.turnTimeout, tt.stallTimeout)
+			if !errors.Is(err, tt.want) {
+				t.Fatalf("receiveTurnMessage() error = %v, want %v", err, tt.want)
+			}
+			if got := errors.Is(err, ErrStreamStalled); got != tt.wantStall {
+				t.Fatalf("receiveTurnMessage() ErrStreamStalled = %t, want %t", got, tt.wantStall)
+			}
+		})
 	}
 }
 
@@ -921,6 +1047,20 @@ func (t *blockingAppServerTransport) Receive(ctx context.Context) (Message, erro
 	}
 	<-ctx.Done()
 	return Message{}, ctx.Err()
+}
+
+type deadlineRecordingAppServerTransport struct {
+	*fakeAppServerTransport
+	deadlines []time.Time
+}
+
+func (t *deadlineRecordingAppServerTransport) Receive(ctx context.Context) (Message, error) {
+	deadline, ok := ctx.Deadline()
+	if ok {
+		t.deadlines = append(t.deadlines, deadline)
+	}
+	time.Sleep(time.Millisecond)
+	return t.fakeAppServerTransport.Receive(ctx)
 }
 
 func responseMessage(t *testing.T, id int, result string) Message {

--- a/internal/codex/backend.go
+++ b/internal/codex/backend.go
@@ -93,6 +93,7 @@ func (b *AgentBackend) runTurn(
 		ServiceTier:           req.ServiceTier,
 		ReasoningEffort:       req.ReasoningEffort,
 		TurnTimeout:           req.TurnTimeout,
+		StallTimeout:          b.options.StallTimeout,
 		DynamicTools:          tools,
 		ToolHandler:           toolHandler,
 	}, func(update Update) error {

--- a/internal/codex/backend_test.go
+++ b/internal/codex/backend_test.go
@@ -3,9 +3,11 @@ package codex
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"testing"
 	"time"
 
+	"github.com/digitaldrywood/detent/internal/config"
 	"github.com/digitaldrywood/detent/internal/runner"
 )
 
@@ -123,6 +125,38 @@ func TestToolTurnInstructions(t *testing.T) {
 				t.Fatalf("toolTurnInstructions() = %q, want %q", got, tt.want)
 			}
 		})
+	}
+}
+
+func TestAgentBackendEnforcesConfiguredStallTimeout(t *testing.T) {
+	t.Parallel()
+
+	transport := newBlockingAppServerTransport([]Message{
+		responseMessage(t, 1, `{"userAgent":"codex-cli/0.135.0"}`),
+		responseMessage(t, 2, `{"thread":{"id":"thread-stall"}}`),
+		responseMessage(t, 5, `{"config":{"model":"gpt-5.6"}}`),
+		responseMessage(t, 3, `{"turn":{"id":"turn-stall"}}`),
+	})
+	server, err := NewAppServer(staticTransportFactory{transport: transport},
+		WithReadTimeout(time.Second),
+		WithTurnTimeout(time.Hour),
+	)
+	if err != nil {
+		t.Fatalf("NewAppServer() error = %v", err)
+	}
+	backend, err := NewAgentBackend(server, OptionsFromConfig(config.CodexOptions{
+		StallTimeoutMS: 10,
+	}))
+	if err != nil {
+		t.Fatalf("NewAgentBackend() error = %v", err)
+	}
+
+	_, err = backend.RunTurn(context.Background(), runner.AgentTurnRequest{
+		Workspace: "/tmp/detent-workspace",
+		Prompt:    "stall",
+	}, nil)
+	if !errors.Is(err, ErrStreamStalled) {
+		t.Fatalf("RunTurn() error = %v, want configured ErrStreamStalled", err)
 	}
 }
 

--- a/internal/codex/sandbox.go
+++ b/internal/codex/sandbox.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"maps"
 	"strings"
+	"time"
 
 	"github.com/digitaldrywood/detent/internal/config"
 )
@@ -12,6 +13,7 @@ type Options struct {
 	ApprovalPolicy    any
 	ThreadSandbox     string
 	TurnSandboxPolicy any
+	StallTimeout      time.Duration
 }
 
 func OptionsFromConfig(cfg config.CodexOptions) Options {
@@ -19,6 +21,7 @@ func OptionsFromConfig(cfg config.CodexOptions) Options {
 		ApprovalPolicy:    stringOrMapValue(cfg.ApprovalPolicy),
 		ThreadSandbox:     cfg.ThreadSandbox,
 		TurnSandboxPolicy: cfg.TurnSandboxPolicy,
+		StallTimeout:      time.Duration(cfg.StallTimeoutMS) * time.Millisecond,
 	}
 }
 

--- a/internal/codex/sandbox_test.go
+++ b/internal/codex/sandbox_test.go
@@ -3,6 +3,7 @@ package codex
 import (
 	"reflect"
 	"testing"
+	"time"
 
 	"github.com/digitaldrywood/detent/internal/config"
 )
@@ -72,6 +73,7 @@ func TestOptionsFromConfigClonesApprovalPolicy(t *testing.T) {
 	options := OptionsFromConfig(config.CodexOptions{
 		ApprovalPolicy: config.MapValue(rawPolicy),
 		ThreadSandbox:  "workspace-write",
+		StallTimeoutMS: 1250,
 		TurnSandboxPolicy: map[string]any{
 			"type": "workspaceWrite",
 		},
@@ -91,5 +93,8 @@ func TestOptionsFromConfigClonesApprovalPolicy(t *testing.T) {
 	}
 	if options.ThreadSandbox != "workspace-write" {
 		t.Fatalf("ThreadSandbox = %q, want workspace-write", options.ThreadSandbox)
+	}
+	if options.StallTimeout != 1250*time.Millisecond {
+		t.Fatalf("StallTimeout = %v, want 1.25s", options.StallTimeout)
 	}
 }


### PR DESCRIPTION
## Summary

- consume the validated Codex `stall_timeout_ms` option in the backend
- reset the stall deadline on each app-server message and return a distinguishable error on expiry
- preserve shorter turn timeouts, disabled zero values, parent cancellation, and deferred process cleanup

Fixes #1495

## UI Surface Contract

- [x] N/A; this change has no UI surface.
- [x] This PR does not add persistent top-of-screen messaging.
- [x] This PR has no visual changes to operator screens.

## Test Plan

- [x] `go test ./internal/codex -count=1`
- [x] `go test -race ./internal/codex -count=1`
- [x] `make check`