### PR TITLE
fix(doctor): renew timeout on remote progress

### DIFF
--- a/.detent/skills/activity-based-remote-liveness.md
+++ b/.detent/skills/activity-based-remote-liveness.md
@@ -1,0 +1,15 @@
+---
+name: activity-based-remote-liveness
+description: Prevent healthy paginated remote checks from exceeding an aggregate inactivity timeout while preserving deterministic partial results.
+when_to_use: Use when a bounded logical sample still requires a full remote scan, individual requests are healthy, and the aggregate check falsely reaches its liveness deadline.
+---
+
+# Track remote activity without masking stalls
+
+- Confirm the timeout wraps a multi-request operation and identify whether its bounded result still requires exhausting remote pages.
+- Treat the timeout as an inactivity budget. Renew it only after concrete forward progress, such as fully reading a remote response; never use an unconditional heartbeat.
+- Carry the reporter through the request context so only the active operation can renew its deadline and connector factories remain free of mutable callback state.
+- Keep liveness pulses separate from result publication. Snapshot completed results and the current stage atomically at named boundaries, then freeze that snapshot before cancellation.
+- Reject result publications after freeze so cancellation-aware work cannot move the reported stage or append cancellation artifacts past the timeout boundary.
+- Test the two behaviors independently: a multi-response operation whose total runtime exceeds the timeout must complete, while a stalled operation must return completed prior results followed by the synthesized timeout failure.
+- Repeat focused tests under the race detector, then run the repository validation gate.

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -149,6 +149,17 @@ func (p *doctorCheckProgress) Set(current string, checks []doctorCheck) {
 	p.checks = append(p.checks[:0], checks...)
 	p.mu.Unlock()
 
+	p.Pulse()
+}
+
+func (p *doctorCheckProgress) Pulse() {
+	p.mu.Lock()
+	frozen := p.frozen
+	p.mu.Unlock()
+	if frozen {
+		return
+	}
+
 	select {
 	case p.updates <- struct{}{}:
 	default:

--- a/internal/cli/doctor_project.go
+++ b/internal/cli/doctor_project.go
@@ -189,6 +189,7 @@ func doctorProjectCheckJobs(cfg globalconfig.Config, deps doctorDeps, githubToke
 			Freeze:   progress.Freeze,
 			Progress: progress.Updates(),
 			Run: func(jobCtx context.Context) []doctorCheck {
+				jobCtx = connector.WithProgressReporter(jobCtx, progress.Pulse)
 				return checkDoctorProjectWithProgress(jobCtx, project, doctorRuntimeStorePath(cfg.Path), deps, githubToken, allowWriteProbes, workflowTokenThreshold, progress.Set)
 			},
 		})

--- a/internal/cli/doctor_test.go
+++ b/internal/cli/doctor_test.go
@@ -4819,16 +4819,86 @@ func TestRunDoctorCheckFreezesProgressBeforeCancellation(t *testing.T) {
 	}
 }
 
+func TestDoctorProjectCheckJobRenewsTimeoutForConnectorProgress(t *testing.T) {
+	t.Parallel()
+
+	const (
+		timeout      = 100 * time.Millisecond
+		responseTime = 60 * time.Millisecond
+		responses    = 3
+	)
+	projectConnector := &fakeDoctorAutoPromoteConnector{
+		fetchIssuesByStatesLimit: func(ctx context.Context, _ []string, _ int) ([]connector.Issue, error) {
+			for range responses {
+				select {
+				case <-ctx.Done():
+					return nil, ctx.Err()
+				case <-time.After(responseTime):
+					connector.ReportProgress(ctx)
+				}
+			}
+			return nil, nil
+		},
+	}
+	jobs := doctorProjectCheckJobs(globalconfig.Config{
+		Projects: []globalconfig.Project{{ID: "alpha", Workflow: "WORKFLOW.md"}},
+	}, doctorDeps{
+		loadWorkflow: func(string) (workflowconfig.Workflow, error) {
+			return workflowconfig.Workflow{Config: validDoctorDependencyWorkflow(false)}, nil
+		},
+		gitWorkTree: func(context.Context, string) error {
+			return nil
+		},
+		gitRemoteURL: func(context.Context, string) (string, error) {
+			return "https://github.com/digitaldrywood/detent", nil
+		},
+		autoPromoteConnector: func(workflowconfig.Config) (doctorAutoPromoteConnector, error) {
+			return projectConnector, nil
+		},
+		githubReadiness: func(context.Context, ghconnector.Config, ghconnector.ReadinessConfig) ([]ghconnector.ReadinessCheck, error) {
+			return nil, nil
+		},
+		githubMergeSettings: func(context.Context, workflowconfig.Config, string) (ghconnector.RepositoryMergeSettings, error) {
+			return ghconnector.RepositoryMergeSettings{AllowSquashMerge: true}, nil
+		},
+	}, RuntimeSecret{Value: "token", Source: "github_token"}, false, doctorWorkflowDefaultTokenThreshold)
+	if len(jobs) != 1 {
+		t.Fatalf("jobs len = %d, want 1", len(jobs))
+	}
+
+	checks := runDoctorCheck(context.Background(), jobs[0], timeout)
+
+	for _, name := range []string{"Project alpha dependency auto-unblock", "Project alpha blocked recovery"} {
+		var found bool
+		for _, check := range checks {
+			if check.Name == name {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Fatalf("checks = %#v, want completed %s check", checks, name)
+		}
+	}
+	for _, check := range checks {
+		if check.Status == doctorFail && strings.Contains(check.Detail, "timed out") {
+			t.Fatalf("checks = %#v, want connector progress to renew timeout", checks)
+		}
+	}
+}
+
 func TestDoctorProjectCheckJobTimeoutPreservesCompletedChecks(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name         string
-		current      string
-		blockOverlay bool
+		name            string
+		current         string
+		blockOverlay    bool
+		blockDependency bool
 	}{
 		{name: "GitHub readiness", current: "GitHub readiness"},
 		{name: "local workflow overlay", current: "local workflow overlay", blockOverlay: true},
+		{name: "dependency auto-unblock", current: "dependency auto-unblock", blockDependency: true},
 	}
 
 	for _, tt := range tests {
@@ -4863,7 +4933,14 @@ func TestDoctorProjectCheckJobTimeoutPreservesCompletedChecks(t *testing.T) {
 					return "https://github.com/digitaldrywood/detent", nil
 				},
 				autoPromoteConnector: func(workflowconfig.Config) (doctorAutoPromoteConnector, error) {
-					return &fakeDoctorAutoPromoteConnector{}, nil
+					projectConnector := &fakeDoctorAutoPromoteConnector{}
+					if tt.blockDependency {
+						projectConnector.fetchIssuesByStatesLimit = func(context.Context, []string, int) ([]connector.Issue, error) {
+							<-releaseBlockedCheck
+							return nil, nil
+						}
+					}
+					return projectConnector, nil
 				},
 				githubReadiness: func(context.Context, ghconnector.Config, ghconnector.ReadinessConfig) ([]ghconnector.ReadinessCheck, error) {
 					if !tt.blockOverlay {
@@ -5046,25 +5123,29 @@ func doctorDependencyResolvedIssue(id string, identifier string, state string, c
 }
 
 type fakeDoctorAutoPromoteConnector struct {
-	issues         []connector.Issue
-	mergedIssues   []connector.Issue
-	hydratedIssues []connector.Issue
-	resolvedIssues []connector.Issue
-	capabilities   []connector.DependencyCapability
-	drift          connector.StatusDrift
-	driftErr       error
-	verifyErr      error
-	verifyStates   []string
-	limit          int
-	scan           *connector.IssueStateScan
+	issues                   []connector.Issue
+	mergedIssues             []connector.Issue
+	hydratedIssues           []connector.Issue
+	resolvedIssues           []connector.Issue
+	capabilities             []connector.DependencyCapability
+	drift                    connector.StatusDrift
+	driftErr                 error
+	verifyErr                error
+	verifyStates             []string
+	limit                    int
+	scan                     *connector.IssueStateScan
+	fetchIssuesByStatesLimit func(context.Context, []string, int) ([]connector.Issue, error)
 }
 
 func (c *fakeDoctorAutoPromoteConnector) FetchIssuesByStates(_ context.Context, states []string) ([]connector.Issue, error) {
 	return c.issuesForStates(states), nil
 }
 
-func (c *fakeDoctorAutoPromoteConnector) FetchIssuesByStatesLimit(_ context.Context, states []string, limit int) ([]connector.Issue, error) {
+func (c *fakeDoctorAutoPromoteConnector) FetchIssuesByStatesLimit(ctx context.Context, states []string, limit int) ([]connector.Issue, error) {
 	c.limit = limit
+	if c.fetchIssuesByStatesLimit != nil {
+		return c.fetchIssuesByStatesLimit(ctx, states, limit)
+	}
 	return c.issuesForStates(states), nil
 }
 

--- a/internal/connector/connector.go
+++ b/internal/connector/connector.go
@@ -6,6 +6,29 @@ import (
 	"time"
 )
 
+type progressReporterContextKey struct{}
+
+func WithProgressReporter(ctx context.Context, reporter func()) context.Context {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if reporter == nil {
+		return ctx
+	}
+	return context.WithValue(ctx, progressReporterContextKey{}, reporter)
+}
+
+func ReportProgress(ctx context.Context) {
+	if ctx == nil {
+		return
+	}
+	reporter, ok := ctx.Value(progressReporterContextKey{}).(func())
+	if !ok || reporter == nil {
+		return
+	}
+	reporter()
+}
+
 var (
 	ErrNotImplemented     = errors.New("connector operation not implemented")
 	ErrStateUpdateBlocked = errors.New("issue state update blocked")

--- a/internal/connector/connector_test.go
+++ b/internal/connector/connector_test.go
@@ -62,6 +62,56 @@ func TestConnectorInterface(t *testing.T) {
 	}
 }
 
+func TestProgressReporter(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		ctx  func(*int) context.Context
+		want int
+	}{
+		{
+			name: "reports",
+			ctx: func(calls *int) context.Context {
+				return WithProgressReporter(context.Background(), func() {
+					*calls = *calls + 1
+				})
+			},
+			want: 1,
+		},
+		{
+			name: "missing reporter",
+			ctx: func(*int) context.Context {
+				return context.Background()
+			},
+		},
+		{
+			name: "nil context",
+			ctx: func(*int) context.Context {
+				return nil
+			},
+		},
+		{
+			name: "nil reporter",
+			ctx: func(*int) context.Context {
+				return WithProgressReporter(context.Background(), nil)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			calls := 0
+			ReportProgress(tt.ctx(&calls))
+			if calls != tt.want {
+				t.Fatalf("reporter calls = %d, want %d", calls, tt.want)
+			}
+		})
+	}
+}
+
 func TestBackendString(t *testing.T) {
 	t.Parallel()
 

--- a/internal/connector/github/client.go
+++ b/internal/connector/github/client.go
@@ -204,6 +204,7 @@ func (c *Client) graphQLWithType(ctx context.Context, queryType string, query st
 	if err != nil {
 		return fmt.Errorf("%w: read response: %w", ErrTransient, err)
 	}
+	connector.ReportProgress(ctx)
 	receivedAt := time.Now()
 	headerRateLimit := c.recordRateLimitFromHeaders(resp.Header, receivedAt)
 
@@ -311,6 +312,7 @@ func (c *Client) restProbeWithTokenRefresh(ctx context.Context, method string, p
 	if err != nil {
 		return restProbeResult{}, fmt.Errorf("%w: read response: %w", ErrTransient, err)
 	}
+	connector.ReportProgress(ctx)
 	receivedAt := time.Now()
 	c.recordRESTRateLimitFromHeaders(backoffKey, method, path, resp.StatusCode, resp.Header, receivedAt, false)
 	c.logRESTResponse(ctx, "github rest probe response", method, path, family, resp.StatusCode)
@@ -415,6 +417,7 @@ func (c *Client) restWithTokenRefresh(ctx context.Context, method string, path s
 	if err != nil {
 		return nil, fmt.Errorf("%w: read response: %w", ErrTransient, err)
 	}
+	connector.ReportProgress(ctx)
 	receivedAt := time.Now()
 	c.recordRESTRateLimitFromHeaders(backoffKey, method, path, resp.StatusCode, resp.Header, receivedAt, conditional)
 	if resp.StatusCode == http.StatusNotModified {

--- a/internal/connector/github/client_test.go
+++ b/internal/connector/github/client_test.go
@@ -85,6 +85,71 @@ func TestClientGraphQLSendsBearerRequest(t *testing.T) {
 	}
 }
 
+func TestClientReportsResponseProgress(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		run  func(context.Context, *Client) error
+	}{
+		{
+			name: "GraphQL",
+			run: func(ctx context.Context, client *Client) error {
+				return client.GraphQL(ctx, "query { viewer { login } }", nil, nil)
+			},
+		},
+		{
+			name: "REST",
+			run: func(ctx context.Context, client *Client) error {
+				return client.REST(ctx, http.MethodGet, "/user", nil, nil)
+			},
+		},
+		{
+			name: "REST probe",
+			run: func(ctx context.Context, client *Client) error {
+				_, err := client.restProbe(ctx, http.MethodGet, "/user", nil)
+				return err
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				if r.URL.Path == "/" {
+					_, _ = w.Write([]byte(`{"data":{"viewer":{"login":"octocat"}}}`))
+					return
+				}
+				_, _ = w.Write([]byte(`{}`))
+			}))
+			t.Cleanup(server.Close)
+
+			client, err := NewClient(ClientConfig{
+				Endpoint:    server.URL,
+				TokenSource: StaticTokenSource("test-token"),
+				HTTPClient:  server.Client(),
+			})
+			if err != nil {
+				t.Fatalf("NewClient() error = %v", err)
+			}
+
+			calls := 0
+			ctx := connector.WithProgressReporter(context.Background(), func() {
+				calls++
+			})
+			if err := tt.run(ctx, client); err != nil {
+				t.Fatalf("request error = %v", err)
+			}
+			if calls != 1 {
+				t.Fatalf("progress reports = %d, want 1", calls)
+			}
+		})
+	}
+}
+
 func TestClientGraphQLClassifiesFailures(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

- renew project doctor liveness on each completed GitHub GraphQL or REST response
- keep request liveness pulses independent from frozen partial-result snapshots
- cover long multi-response dependency checks and dependency-stage partial timeout output
- draft the reusable activity-based remote liveness skill

Fixes #1497

## UI Surface Contract

- [x] N/A; this change does not affect a UI surface.
- [x] This PR does not add persistent top-of-screen messaging.
- [x] N/A; this PR has no visual changes.

## Test Plan

- [x] focused doctor and connector regression tests at count 10
- [x] `go test -race ./internal/connector ./internal/connector/github ./internal/cli -count=1`
- [x] `make check`