### PR TITLE
test(orchestrator): stabilize fetch ordering

### DIFF
--- a/internal/orchestrator/orchestrator_test.go
+++ b/internal/orchestrator/orchestrator_test.go
@@ -2069,7 +2069,7 @@ func TestRunFetchesCandidatesBeforeObservedStates(t *testing.T) {
 	t.Parallel()
 
 	tracker := newParallelFetchConnector()
-	orch := newTestOrchestrator(t, tracker, &staticRunner{})
+	orch := newTestOrchestratorWithPollInterval(t, tracker, &staticRunner{}, time.Hour)
 	stop := runOrchestrator(t, orch)
 	defer stop()
 
@@ -2438,8 +2438,19 @@ func TestFakeRunnerCompletes(t *testing.T) {
 func newTestOrchestrator(t *testing.T, tracker connector.Connector, runner orchestrator.Runner) *orchestrator.Orchestrator {
 	t.Helper()
 
+	return newTestOrchestratorWithPollInterval(t, tracker, runner, 5*time.Millisecond)
+}
+
+func newTestOrchestratorWithPollInterval(
+	t *testing.T,
+	tracker connector.Connector,
+	runner orchestrator.Runner,
+	pollInterval time.Duration,
+) *orchestrator.Orchestrator {
+	t.Helper()
+
 	orch, err := orchestrator.New(orchestrator.Config{
-		PollInterval:           5 * time.Millisecond,
+		PollInterval:           pollInterval,
 		MaxConcurrentAgents:    1,
 		MaxRetryBackoff:        time.Hour,
 		FailureRetryBaseDelay:  time.Hour,


### PR DESCRIPTION
## Summary

- isolate the fetch-ordering test from the shared 5 ms periodic poll ticker
- preserve the candidate-before-observed synchronization and exact single-refresh assertions
- allow other orchestrator tests to keep using the existing fast poll interval

The race-suite scheduler can delay the assertion long enough for a second periodic refresh, incrementing the candidate call counter even though production ordering remains correct. This test now uses an inert one-hour poll interval and observes only the initial refresh it arranges.

Fixes #1506

## UI Surface Contract

- [x] N/A, or the linked issue explicitly authorizes any high-impact UI surface, layout, density, first-viewport, or responsive visibility tradeoff.
- [x] Persistent top-of-screen messaging is explicitly authorized by the issue, or this PR does not add it.
- [x] Visual changes to primary operator screens include screenshot or browser verification below.

## Test Plan

- [x] `go test -race ./internal/orchestrator -run ^'TestRunFetchesCandidatesBeforeObservedStates$' -count=1000`
- [x] `make check`