### PR TITLE
feat(runner): add agent duration limits

### DIFF
--- a/README.md
+++ b/README.md
@@ -688,6 +688,8 @@ workspace:
 agent:
   max_concurrent_agents: 5
   max_turns: 20
+  max_turn_duration_ms: 0
+  max_session_duration_ms: 0
   max_retry_backoff_ms: 300000
   overload_retry_delay_ms: 45000
   no_progress_spend_limit_usd: 3
@@ -731,6 +733,9 @@ codex:
   turn_sandbox_policy:
     type: workspaceWrite
     networkAccess: true
+  turn_timeout_ms: 3600000
+  read_timeout_ms: 5000
+  stall_timeout_ms: 300000
 gate:
   kind: command
   run: make check
@@ -2476,7 +2481,9 @@ ids. Supported backend kinds are `codex` with `protocol: app-server` and
 `claude_code` with `protocol: headless`. Codex backend `options` use the same
 runtime fields as the top-level `codex` block, including `shell`,
 `approval_policy`, `thread_sandbox`, `turn_sandbox_policy`, `turn_timeout_ms`,
-`read_timeout_ms`, and `stall_timeout_ms`. Claude Code backend `options`
+`read_timeout_ms`, and `stall_timeout_ms`. `agent.max_turn_duration_ms` and
+`agent.max_session_duration_ms` apply across backends rather than belonging to
+an individual backend profile. Claude Code backend `options`
 include `permission_mode`, `allowed_tools`, `disallowed_tools`,
 `include_partial_messages`, `turn_timeout_ms`, `stall_timeout_ms`, `shell`, and
 `extra_args`. When a Codex backend needs different configuration, launch
@@ -2591,6 +2598,22 @@ same value as a compact percent. Thresholds are `normal` below 70%, `watch` at
 derived fields instead of reporting a misleading zero.
 
 Context pressure is a model-window signal, not a Detent stop threshold.
+For Codex, `codex.turn_timeout_ms` is an inter-message liveness bound, despite
+its name. Each stream message starts a new timer. Omitting the key still uses
+the one-hour (`3600000` ms) default, and continuous messages can keep one turn
+alive indefinitely. Lowering this value therefore detects silence sooner but
+does not cap total turn duration. `codex.stall_timeout_ms` is also reset by
+stream activity; when both liveness bounds are enabled, the shorter deadline
+wins for each receive.
+
+`agent.max_turn_duration_ms` is the total wall-clock bound for each provider
+turn attempt. `agent.max_session_duration_ms` spans the full persisted Detent
+session, including a failed resume attempt and its fresh fallback. When both
+are configured, the shorter applicable deadline wins. Both values default to
+`0`, which disables that total-duration bound. These deadlines cancel the
+worker through Detent's normal owned process context, so process-tree reaping,
+scratch cleanup, and session completion still run.
+
 `agent.max_session_tokens` is an absolute configured ceiling for a session.
 `total_tokens` counts input, output, cache-created, and cache-read tokens,
 accumulated across every turn of the session — cached context is re-counted on
@@ -2621,6 +2644,12 @@ max/ultracode `8x`. These multipliers assume one retry at the observed cost
 profile should fit before the breaker fires; `detent doctor` warns when an
 effort tier's effective limit is below its observed p50 per-session cost and
 recommends a base limit with `1.5x` retry-cost headroom.
+
+Duration limits stop a single overlong turn or session regardless of message
+volume. The no-progress spend limit is a separate runaway control that can stop
+repeated or expensive work even when each individual session stays below its
+duration cap; it is enforced in metered billing mode and advisory in
+subscription mode.
 
 Detent sums persisted session cost for each issue after its latest accepted
 lane or PR advancement. PR creation, a new head commit, a dirty-to-clean

--- a/internal/cli/doctor_project.go
+++ b/internal/cli/doctor_project.go
@@ -1304,6 +1304,14 @@ func doctorWorkflowModelChoiceDetail(cfg workflowconfig.Config) string {
 }
 
 func doctorWorkflowSessionGuardDetail(cfg workflowconfig.Config) string {
+	turnDuration := "disabled"
+	if cfg.Agent.MaxTurnDurationMS > 0 {
+		turnDuration = strconv.Itoa(cfg.Agent.MaxTurnDurationMS)
+	}
+	sessionDuration := "disabled"
+	if cfg.Agent.MaxSessionDurationMS > 0 {
+		sessionDuration = strconv.Itoa(cfg.Agent.MaxSessionDurationMS)
+	}
 	tokens := "disabled"
 	if cfg.Agent.MaxSessionTokens > 0 {
 		tokens = strconv.FormatInt(cfg.Agent.MaxSessionTokens, 10)
@@ -1312,7 +1320,13 @@ func doctorWorkflowSessionGuardDetail(cfg workflowconfig.Config) string {
 	if cfg.Agent.MaxSessionContextMultiplier > 0 {
 		multiplier = strconv.FormatFloat(cfg.Agent.MaxSessionContextMultiplier, 'g', -1, 64)
 	}
-	return fmt.Sprintf("session-guard=max_session_tokens=%s, max_session_context_multiplier=%s", tokens, multiplier)
+	return fmt.Sprintf(
+		"session-guard=max_turn_duration_ms=%s, max_session_duration_ms=%s, max_session_tokens=%s, max_session_context_multiplier=%s",
+		turnDuration,
+		sessionDuration,
+		tokens,
+		multiplier,
+	)
 }
 
 func doctorWorkflowSpendBreakerDetail(cfg workflowconfig.Config) string {

--- a/internal/cli/doctor_test.go
+++ b/internal/cli/doctor_test.go
@@ -2431,7 +2431,7 @@ func TestDoctorWorkflowDetailSurfacesIdentityAndAuthorization(t *testing.T) {
 		"WORKFLOW.md is valid",
 		"identity release-captain",
 		"worker-model=provider-default",
-		"session-guard=max_session_tokens=disabled, max_session_context_multiplier=disabled",
+		"session-guard=max_turn_duration_ms=disabled, max_session_duration_ms=disabled, max_session_tokens=disabled, max_session_context_multiplier=disabled",
 		"billing-mode=metered",
 		"orphan-recovery=resume_orphaned_sessions=true, experimental_thread_resume=false",
 		"prioritize-unblockers=true",
@@ -2455,11 +2455,13 @@ func TestDoctorWorkflowDetailReportsPinnedModelAndSessionGuard(t *testing.T) {
 	}}
 	cfg.Agent.MaxSessionTokens = 2_000_000
 	cfg.Agent.MaxSessionContextMultiplier = 4
+	cfg.Agent.MaxTurnDurationMS = 900000
+	cfg.Agent.MaxSessionDurationMS = 3600000
 
 	got := doctorWorkflowDetail("WORKFLOW.md", globalconfig.Project{}, cfg)
 	for _, want := range []string{
 		"worker-model=pinned gpt-5.5 via agents.routes.model",
-		"session-guard=max_session_tokens=2000000, max_session_context_multiplier=4",
+		"session-guard=max_turn_duration_ms=900000, max_session_duration_ms=3600000, max_session_tokens=2000000, max_session_context_multiplier=4",
 	} {
 		if !strings.Contains(got, want) {
 			t.Fatalf("doctorWorkflowDetail() = %q, want substring %q", got, want)

--- a/internal/codex/appserver_test.go
+++ b/internal/codex/appserver_test.go
@@ -810,6 +810,36 @@ func TestAppServerStreamTurnResetsStallTimeoutAfterActivity(t *testing.T) {
 	}
 }
 
+func TestAppServerStreamTurnResetsTurnTimeoutAfterActivity(t *testing.T) {
+	t.Parallel()
+
+	transport := &deadlineRecordingAppServerTransport{
+		fakeAppServerTransport: newFakeAppServerTransport([]Message{
+			notificationMessage(t, "item/agentMessage/delta", `{
+				"threadId":"thread-1",
+				"turnId":"turn-1",
+				"itemId":"item-1",
+				"delta":"still working"
+			}`),
+			notificationMessage(t, "turn/completed", `{"threadId":"thread-1","turn":{"id":"turn-1","status":"completed"}}`),
+		}),
+	}
+	server, err := NewAppServer(staticTransportFactory{transport: transport})
+	if err != nil {
+		t.Fatalf("NewAppServer() error = %v", err)
+	}
+
+	if err := server.streamTurn(context.Background(), transport, time.Second, 0, nil, nil); err != nil {
+		t.Fatalf("streamTurn() error = %v", err)
+	}
+	if len(transport.deadlines) != 2 {
+		t.Fatalf("Receive() deadlines = %v, want two turn timeout deadlines", transport.deadlines)
+	}
+	if !transport.deadlines[1].After(transport.deadlines[0]) {
+		t.Fatalf("Receive() deadlines = %v, want activity to reset turn timeout deadline", transport.deadlines)
+	}
+}
+
 func TestReceiveTurnMessageTimeoutSelection(t *testing.T) {
 	t.Parallel()
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -254,6 +254,8 @@ type Worker struct {
 type Agent struct {
 	MaxConcurrentAgents          int                          `yaml:"max_concurrent_agents"`
 	MaxTurns                     int                          `yaml:"max_turns"`
+	MaxTurnDurationMS            int                          `yaml:"max_turn_duration_ms"`
+	MaxSessionDurationMS         int                          `yaml:"max_session_duration_ms"`
 	MaxRetryBackoffMS            int                          `yaml:"max_retry_backoff_ms"`
 	OverloadRetryDelayMS         int                          `yaml:"overload_retry_delay_ms"`
 	NoProgressSpendLimitUSD      float64                      `yaml:"no_progress_spend_limit_usd"`
@@ -1826,6 +1828,12 @@ func normalizeDeliverableKind(kind string) string {
 func (a *Agent) validate(prefix string, problems *[]string) {
 	validatePositive(prefix+".max_concurrent_agents", a.MaxConcurrentAgents, problems)
 	validatePositive(prefix+".max_turns", a.MaxTurns, problems)
+	if a.MaxTurnDurationMS < 0 {
+		*problems = append(*problems, prefix+".max_turn_duration_ms must be greater than or equal to 0")
+	}
+	if a.MaxSessionDurationMS < 0 {
+		*problems = append(*problems, prefix+".max_session_duration_ms must be greater than or equal to 0")
+	}
 	validatePositive(prefix+".max_retry_backoff_ms", a.MaxRetryBackoffMS, problems)
 	validatePositive(prefix+".overload_retry_delay_ms", a.OverloadRetryDelayMS, problems)
 	if a.MaxSessionTokens < 0 {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -663,6 +663,8 @@ worker:
   max_concurrent_agents_per_host: 2
 agent:
   max_concurrent_agents: 5
+  max_turn_duration_ms: 900000
+  max_session_duration_ms: 3600000
   max_session_tokens: 10000000
   max_session_context_multiplier: 3.5
   max_session_token_override_label: Allow-Large-Session
@@ -895,6 +897,12 @@ Ticket prompt {{ issue.title }}
 	}
 	if got := cfg.Agent.MaxConcurrentAgentsByState["merging"]; got != 1 {
 		t.Fatalf("Agent.MaxConcurrentAgentsByState[merging] = %d, want 1", got)
+	}
+	if cfg.Agent.MaxTurnDurationMS != 900000 {
+		t.Fatalf("Agent.MaxTurnDurationMS = %d, want 900000", cfg.Agent.MaxTurnDurationMS)
+	}
+	if cfg.Agent.MaxSessionDurationMS != 3600000 {
+		t.Fatalf("Agent.MaxSessionDurationMS = %d, want 3600000", cfg.Agent.MaxSessionDurationMS)
 	}
 	if cfg.Agent.MaxSessionTokens != 10000000 {
 		t.Fatalf("Agent.MaxSessionTokens = %d, want 10000000", cfg.Agent.MaxSessionTokens)
@@ -2826,6 +2834,8 @@ workspace:
   cleanup_sweep_interval_ms: 0
 agent:
   max_concurrent_agents: 0
+  max_turn_duration_ms: -1
+  max_session_duration_ms: -1
   max_session_tokens: -1
   max_session_context_multiplier: -0.5
   output_truncation:
@@ -2863,6 +2873,8 @@ Prompt
 				"workspace.cleanup_idle_ttl_ms must be greater than 0",
 				"workspace.cleanup_sweep_interval_ms must be greater than 0",
 				"agent.max_concurrent_agents must be greater than 0",
+				"agent.max_turn_duration_ms must be greater than or equal to 0",
+				"agent.max_session_duration_ms must be greater than or equal to 0",
 				"agent.max_session_tokens must be greater than or equal to 0",
 				"agent.max_session_context_multiplier must be greater than or equal to 0",
 				"agent.output_truncation.max_bytes must be greater than or equal to 0",

--- a/internal/runner/agent.go
+++ b/internal/runner/agent.go
@@ -619,12 +619,28 @@ func runAgentBackendTurnWithTools(
 	onUpdate AgentUpdateHandler,
 ) (AgentTurnResult, error, error) {
 	run := func(ctx context.Context, request AgentTurnRequest) (AgentTurnResult, error) {
+		turnCtx, cancel := withAgentDurationLimit(
+			ctx,
+			shortestPositiveDuration(request.TurnTimeout, request.MaxDuration),
+			ErrTurnDurationExceeded,
+		)
+		defer cancel()
+
+		var result AgentTurnResult
+		var err error
 		if len(tools) > 0 {
 			if toolBackend, ok := backend.(AgentToolBackend); ok {
-				return toolBackend.RunTurnWithTools(ctx, request, tools, toolHandler, onUpdate)
+				result, err = toolBackend.RunTurnWithTools(turnCtx, request, tools, toolHandler, onUpdate)
+			} else {
+				result, err = backend.RunTurn(turnCtx, request, onUpdate)
 			}
+		} else {
+			result, err = backend.RunTurn(turnCtx, request, onUpdate)
 		}
-		return backend.RunTurn(ctx, request, onUpdate)
+		if cause := context.Cause(turnCtx); errors.Is(cause, ErrTurnDurationExceeded) {
+			return result, errors.Join(cause, err)
+		}
+		return result, err
 	}
 	workspacePath := strings.TrimSpace(request.Workspace)
 	if workspacePath == "" {
@@ -651,6 +667,33 @@ func runAgentBackendTurnWithTools(
 		cleanupErr = fmt.Errorf("cleanup worker scratch: %w", cleanupErr)
 	}
 	return result, runErr, cleanupErr
+}
+
+func withAgentDurationLimit(ctx context.Context, duration time.Duration, limit error) (context.Context, context.CancelFunc) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if duration <= 0 {
+		return ctx, func() {}
+	}
+	return context.WithTimeoutCause(ctx, duration, &agentDurationLimitError{
+		limit:    limit,
+		duration: duration,
+	})
+}
+
+func shortestPositiveDuration(durations ...time.Duration) time.Duration {
+	var shortest time.Duration
+	for _, duration := range durations {
+		if duration > 0 && (shortest == 0 || duration < shortest) {
+			shortest = duration
+		}
+	}
+	return shortest
+}
+
+func durationLimitError(err error) bool {
+	return errors.Is(err, ErrTurnDurationExceeded) || errors.Is(err, ErrSessionDurationExceeded)
 }
 
 func (r *Runner) runAgentTurn(
@@ -721,7 +764,7 @@ func (r *Runner) runAgentTurn(
 		}
 		return nil
 	})
-	if cause := context.Cause(ctx); cooperativeStopError(cause) {
+	if cause := context.Cause(ctx); cooperativeStopError(cause) || errors.Is(cause, ErrSessionDurationExceeded) {
 		turnErr = cause
 	}
 	result.Output = progress.outputText()
@@ -1023,6 +1066,12 @@ func (r *Runner) Run(ctx context.Context, req RunRequest) (RunResult, error) {
 	if err != nil {
 		return RunResult{}, err
 	}
+	sessionCtx, cancelSession := withAgentDurationLimit(
+		ctx,
+		durationFromMillis(workflow.Config.Agent.MaxSessionDurationMS),
+		ErrSessionDurationExceeded,
+	)
+	defer cancelSession()
 
 	commandStartedAttrs := []any{
 		"workspace_path", info.Path,
@@ -1045,18 +1094,19 @@ func (r *Runner) Run(ctx context.Context, req RunRequest) (RunResult, error) {
 		ServiceTier:        serviceTier,
 		ReasoningEffort:    effort,
 		Resume:             agentResumeFromState(resumeState),
-		ExtraWritableRoots: extraWritableRootsForWorkspace(ctx, info.Path, r.logger),
+		MaxDuration:        durationFromMillis(workflow.Config.Agent.MaxTurnDurationMS),
+		ExtraWritableRoots: extraWritableRootsForWorkspace(sessionCtx, info.Path, r.logger),
 		cacheStrategy:      workflow.Config.Workspace.CacheStrategy,
 		projectID:          r.projectID,
 	}
 	if mode == RunModeRoutine {
 		turnRequest.ToolInstructions = routineToolInstructions
 	}
-	execution := r.runAgentTurn(ctx, backend, turnRequest, req, info, workspaceIssue, workflow.Config.Agent, workflow.Config.Gate.CITriggerLabel, runStartedAt, sessionID, runtimeIdentity)
+	execution := r.runAgentTurn(sessionCtx, backend, turnRequest, req, info, workspaceIssue, workflow.Config.Agent, workflow.Config.Gate.CITriggerLabel, runStartedAt, sessionID, runtimeIdentity)
 	if execution.err != nil {
 		execution.err = classifyAgentCapacityError(backend, selection, backendConfig, execution.result.RuntimeIdentity, execution.err, execution.result.RateLimits, runStartedAt)
 	}
-	if execution.err != nil && !IsCapacityError(execution.err) && !agentResumeEmpty(turnRequest.Resume) && !execution.turnStarted {
+	if execution.err != nil && !IsCapacityError(execution.err) && !durationLimitError(execution.err) && !agentResumeEmpty(turnRequest.Resume) && !execution.turnStarted {
 		r.logWorkerEvent(req.Issue, "worker_resume_failed_fallback",
 			"workspace_path", info.Path,
 			"backend_id", selection.BackendID,
@@ -1072,11 +1122,11 @@ func (r *Runner) Run(ctx context.Context, req RunRequest) (RunResult, error) {
 		if orphanRecovery {
 			fallbackOutcome = store.OrphanRecoveryFresh
 		}
-		if updateErr := r.updateSessionResumeState(ctx, sessionID, 0, fallbackOutcome, errorString(execution.err)); updateErr != nil {
+		if updateErr := r.updateSessionResumeState(sessionCtx, sessionID, 0, fallbackOutcome, errorString(execution.err)); updateErr != nil {
 			r.logger.Warn("clear agent session resume state failed", "detent_session_id", sessionID, "issue_id", req.Issue.ID, "error", updateErr)
 		}
 		resumeState = store.AgentResumeState{}
-		execution = r.runAgentTurn(ctx, backend, turnRequest, req, info, workspaceIssue, workflow.Config.Agent, workflow.Config.Gate.CITriggerLabel, runStartedAt, sessionID, runtimeIdentity)
+		execution = r.runAgentTurn(sessionCtx, backend, turnRequest, req, info, workspaceIssue, workflow.Config.Agent, workflow.Config.Gate.CITriggerLabel, runStartedAt, sessionID, runtimeIdentity)
 		if execution.err != nil {
 			execution.err = classifyAgentCapacityError(backend, selection, backendConfig, execution.result.RuntimeIdentity, execution.err, execution.result.RateLimits, runStartedAt)
 		}
@@ -1320,6 +1370,12 @@ func (r *Runner) Validate(ctx context.Context, req ValidatorRequest) (gate.Valid
 	if err != nil {
 		return gate.ValidatorResult{}, err
 	}
+	sessionCtx, cancelSession := withAgentDurationLimit(
+		ctx,
+		durationFromMillis(workflow.Config.Agent.MaxSessionDurationMS),
+		ErrSessionDurationExceeded,
+	)
+	defer cancelSession()
 
 	checkStartedAttrs := []any{
 		"workspace_path", info.Path,
@@ -1336,7 +1392,7 @@ func (r *Runner) Validate(ctx context.Context, req ValidatorRequest) (gate.Valid
 	}
 	var output strings.Builder
 	modelProvider, serviceTier, effort := agentTurnIdentityOptions(backendConfig)
-	turnResult, turnErr, scratchCleanupErr := runAgentBackendTurn(ctx, backend, AgentTurnRequest{
+	turnResult, turnErr, scratchCleanupErr := runAgentBackendTurn(sessionCtx, backend, AgentTurnRequest{
 		Workspace:          info.Path,
 		Prompt:             prompt,
 		Model:              selectedModel,
@@ -1344,7 +1400,8 @@ func (r *Runner) Validate(ctx context.Context, req ValidatorRequest) (gate.Valid
 		ServiceTier:        serviceTier,
 		ReasoningEffort:    effort,
 		TurnTimeout:        durationFromMillis(validator.TurnTimeoutMS),
-		ExtraWritableRoots: extraWritableRootsForWorkspace(ctx, info.Path, r.logger),
+		MaxDuration:        durationFromMillis(workflow.Config.Agent.MaxTurnDurationMS),
+		ExtraWritableRoots: extraWritableRootsForWorkspace(sessionCtx, info.Path, r.logger),
 		cacheStrategy:      workflow.Config.Workspace.CacheStrategy,
 		projectID:          r.projectID,
 	}, func(update AgentUpdate) error {
@@ -1384,6 +1441,9 @@ func (r *Runner) Validate(ctx context.Context, req ValidatorRequest) (gate.Valid
 		}
 		return nil
 	})
+	if cause := context.Cause(sessionCtx); errors.Is(cause, ErrSessionDurationExceeded) {
+		turnErr = cause
+	}
 	turnErr = errors.Join(turnErr, scratchCleanupErr)
 	if turnErr != nil {
 		turnErr = classifyAgentCapacityError(backend, selection, backendConfig, runResult.RuntimeIdentity, turnErr, runResult.RateLimits, runStartedAt)

--- a/internal/runner/agent.go
+++ b/internal/runner/agent.go
@@ -607,8 +607,16 @@ func runAgentBackendTurn(
 	request AgentTurnRequest,
 	onUpdate AgentUpdateHandler,
 ) (AgentTurnResult, error, error) {
-	return runAgentBackendTurnWithTools(ctx, backend, request, nil, nil, onUpdate)
+	var contextualUpdateHandler agentContextUpdateHandler
+	if onUpdate != nil {
+		contextualUpdateHandler = func(_ context.Context, update AgentUpdate) error {
+			return onUpdate(update)
+		}
+	}
+	return runAgentBackendTurnWithTools(ctx, backend, request, nil, nil, contextualUpdateHandler)
 }
+
+type agentContextUpdateHandler func(context.Context, AgentUpdate) error
 
 func runAgentBackendTurnWithTools(
 	ctx context.Context,
@@ -616,26 +624,32 @@ func runAgentBackendTurnWithTools(
 	request AgentTurnRequest,
 	tools []AgentTool,
 	toolHandler AgentToolHandler,
-	onUpdate AgentUpdateHandler,
+	onUpdate agentContextUpdateHandler,
 ) (AgentTurnResult, error, error) {
 	run := func(ctx context.Context, request AgentTurnRequest) (AgentTurnResult, error) {
 		turnCtx, cancel := withAgentDurationLimit(
 			ctx,
-			shortestPositiveDuration(request.TurnTimeout, request.MaxDuration),
+			request.MaxDuration,
 			ErrTurnDurationExceeded,
 		)
 		defer cancel()
 
+		var boundedUpdateHandler AgentUpdateHandler
+		if onUpdate != nil {
+			boundedUpdateHandler = func(update AgentUpdate) error {
+				return onUpdate(turnCtx, update)
+			}
+		}
 		var result AgentTurnResult
 		var err error
 		if len(tools) > 0 {
 			if toolBackend, ok := backend.(AgentToolBackend); ok {
-				result, err = toolBackend.RunTurnWithTools(turnCtx, request, tools, toolHandler, onUpdate)
+				result, err = toolBackend.RunTurnWithTools(turnCtx, request, tools, toolHandler, boundedUpdateHandler)
 			} else {
-				result, err = backend.RunTurn(turnCtx, request, onUpdate)
+				result, err = backend.RunTurn(turnCtx, request, boundedUpdateHandler)
 			}
 		} else {
-			result, err = backend.RunTurn(turnCtx, request, onUpdate)
+			result, err = backend.RunTurn(turnCtx, request, boundedUpdateHandler)
 		}
 		if cause := context.Cause(turnCtx); errors.Is(cause, ErrTurnDurationExceeded) {
 			return result, errors.Join(cause, err)
@@ -682,16 +696,6 @@ func withAgentDurationLimit(ctx context.Context, duration time.Duration, limit e
 	})
 }
 
-func shortestPositiveDuration(durations ...time.Duration) time.Duration {
-	var shortest time.Duration
-	for _, duration := range durations {
-		if duration > 0 && (shortest == 0 || duration < shortest) {
-			shortest = duration
-		}
-	}
-	return shortest
-}
-
 func durationLimitError(err error) bool {
 	return errors.Is(err, ErrTurnDurationExceeded) || errors.Is(err, ErrSessionDurationExceeded)
 }
@@ -727,7 +731,7 @@ func (r *Runner) runAgentTurn(
 		}
 	}
 	turnStarted := false
-	turnResult, turnErr, scratchCleanupErr := runAgentBackendTurnWithTools(ctx, backend, turnRequest, runRequest.AgentTools, runRequest.AgentToolHandler, func(update AgentUpdate) error {
+	turnResult, turnErr, scratchCleanupErr := runAgentBackendTurnWithTools(ctx, backend, turnRequest, runRequest.AgentTools, runRequest.AgentToolHandler, func(updateCtx context.Context, update AgentUpdate) error {
 		eventAt := r.now()
 		if !update.RuntimeIdentity.IsZero() {
 			update.RuntimeIdentity = update.RuntimeIdentity.ObserveAt(eventAt)
@@ -736,10 +740,10 @@ func (r *Runner) runAgentTurn(
 			turnStarted = true
 		}
 		r.logAgentUpdate(runRequest.Issue, update)
-		if err := r.persistSessionWorkerProcess(ctx, detentSessionID, update); err != nil {
+		if err := r.persistSessionWorkerProcess(updateCtx, detentSessionID, update); err != nil {
 			return err
 		}
-		if err := r.persistSessionProviderIdentity(ctx, detentSessionID, update); err != nil {
+		if err := r.persistSessionProviderIdentity(updateCtx, detentSessionID, update); err != nil {
 			return err
 		}
 		if err := publishAgentActivity(runRequest, detentSessionID, update, eventAt); err != nil {
@@ -748,7 +752,7 @@ func (r *Runner) runAgentTurn(
 		previousIdentity := result.RuntimeIdentity
 		applyAgentUpdate(&result, update)
 		if !previousIdentity.MateriallyEqual(result.RuntimeIdentity) {
-			if err := r.persistSessionIdentity(ctx, detentSessionID, result.RuntimeIdentity); err != nil {
+			if err := r.persistSessionIdentity(updateCtx, detentSessionID, result.RuntimeIdentity); err != nil {
 				return err
 			}
 			if result.RuntimeIdentity.HasRuntimeValues() {
@@ -756,7 +760,7 @@ func (r *Runner) runAgentTurn(
 			}
 		}
 		progress.apply(update, eventAt)
-		if err := r.publishRunUpdate(ctx, runRequest, info, workspaceIssue, progress, result, eventAt, runStartedAt, detentSessionID); err != nil {
+		if err := r.publishRunUpdate(updateCtx, runRequest, info, workspaceIssue, progress, result, eventAt, runStartedAt, detentSessionID); err != nil {
 			return err
 		}
 		if err := r.enforceSessionTokenCeiling(agentConfig, runRequest.Issue, info.Path, update, eventAt); err != nil {
@@ -1387,12 +1391,12 @@ func (r *Runner) Validate(ctx context.Context, req ValidatorRequest) (gate.Valid
 	progress := newAgentRunProgress(runtimeoutput.Policy{MaxBytes: workflow.Config.Agent.OutputTruncation.MaxBytes}, "", "", 0)
 	eventAt := r.now()
 	progress.apply(AgentUpdate{Type: AgentUpdateRuntimeIdentity, RuntimeIdentity: runtimeIdentity}, eventAt)
-	if err := r.publishRunUpdate(ctx, runReq, info, workspaceIssue, progress, runResult, eventAt, runStartedAt, sessionID); err != nil {
+	if err := r.publishRunUpdate(sessionCtx, runReq, info, workspaceIssue, progress, runResult, eventAt, runStartedAt, sessionID); err != nil {
 		return gate.ValidatorResult{}, err
 	}
 	var output strings.Builder
 	modelProvider, serviceTier, effort := agentTurnIdentityOptions(backendConfig)
-	turnResult, turnErr, scratchCleanupErr := runAgentBackendTurn(sessionCtx, backend, AgentTurnRequest{
+	turnResult, turnErr, scratchCleanupErr := runAgentBackendTurnWithTools(sessionCtx, backend, AgentTurnRequest{
 		Workspace:          info.Path,
 		Prompt:             prompt,
 		Model:              selectedModel,
@@ -1404,16 +1408,16 @@ func (r *Runner) Validate(ctx context.Context, req ValidatorRequest) (gate.Valid
 		ExtraWritableRoots: extraWritableRootsForWorkspace(sessionCtx, info.Path, r.logger),
 		cacheStrategy:      workflow.Config.Workspace.CacheStrategy,
 		projectID:          r.projectID,
-	}, func(update AgentUpdate) error {
+	}, nil, nil, func(updateCtx context.Context, update AgentUpdate) error {
 		eventAt := r.now()
 		if !update.RuntimeIdentity.IsZero() {
 			update.RuntimeIdentity = update.RuntimeIdentity.ObserveAt(eventAt)
 		}
 		r.logAgentUpdate(req.Issue, update)
-		if err := r.persistSessionWorkerProcess(ctx, sessionID, update); err != nil {
+		if err := r.persistSessionWorkerProcess(updateCtx, sessionID, update); err != nil {
 			return err
 		}
-		if err := r.persistSessionProviderIdentity(ctx, sessionID, update); err != nil {
+		if err := r.persistSessionProviderIdentity(updateCtx, sessionID, update); err != nil {
 			return err
 		}
 		if err := publishAgentActivity(runReq, sessionID, update, eventAt); err != nil {
@@ -1425,7 +1429,7 @@ func (r *Runner) Validate(ctx context.Context, req ValidatorRequest) (gate.Valid
 		previousIdentity := runResult.RuntimeIdentity
 		applyAgentUpdate(&runResult, update)
 		if !previousIdentity.MateriallyEqual(runResult.RuntimeIdentity) {
-			if err := r.persistSessionIdentity(ctx, sessionID, runResult.RuntimeIdentity); err != nil {
+			if err := r.persistSessionIdentity(updateCtx, sessionID, runResult.RuntimeIdentity); err != nil {
 				return err
 			}
 			if runResult.RuntimeIdentity.HasRuntimeValues() {
@@ -1433,7 +1437,7 @@ func (r *Runner) Validate(ctx context.Context, req ValidatorRequest) (gate.Valid
 			}
 		}
 		progress.apply(update, eventAt)
-		if err := r.publishRunUpdate(ctx, runReq, info, workspaceIssue, progress, runResult, eventAt, runStartedAt, sessionID); err != nil {
+		if err := r.publishRunUpdate(updateCtx, runReq, info, workspaceIssue, progress, runResult, eventAt, runStartedAt, sessionID); err != nil {
 			return err
 		}
 		if err := r.enforceSessionTokenCeiling(workflow.Config.Agent, req.Issue, info.Path, update, eventAt); err != nil {

--- a/internal/runner/duration_limit_test.go
+++ b/internal/runner/duration_limit_test.go
@@ -9,6 +9,8 @@ import (
 
 	"github.com/digitaldrywood/detent/internal/config"
 	"github.com/digitaldrywood/detent/internal/connector"
+	"github.com/digitaldrywood/detent/internal/gate"
+	"github.com/digitaldrywood/detent/internal/procgroup"
 	"github.com/digitaldrywood/detent/internal/store"
 	"github.com/digitaldrywood/detent/internal/workspace"
 )
@@ -180,7 +182,7 @@ func TestRunAgentBackendTurnPreservesParentCancellation(t *testing.T) {
 	}
 }
 
-func TestRunAgentBackendTurnUsesShorterTotalDuration(t *testing.T) {
+func TestRunAgentBackendTurnKeepsLivenessTimeoutSeparateFromMaxDuration(t *testing.T) {
 	t.Parallel()
 
 	backend := &durationBlockingAgentBackend{}
@@ -202,6 +204,27 @@ func TestRunAgentBackendTurnUsesShorterTotalDuration(t *testing.T) {
 	}
 }
 
+func TestRunAgentBackendTurnDoesNotTreatLivenessTimeoutAsTotalDuration(t *testing.T) {
+	t.Parallel()
+
+	backend := &deadlineObservingAgentBackend{}
+	_, err, cleanupErr := runAgentBackendTurn(context.Background(), backend, AgentTurnRequest{
+		TurnTimeout: 25 * time.Millisecond,
+	}, nil)
+	if err != nil {
+		t.Fatalf("runAgentBackendTurn() error = %v", err)
+	}
+	if cleanupErr != nil {
+		t.Fatalf("runAgentBackendTurn() cleanup error = %v", cleanupErr)
+	}
+	if backend.hasDeadline {
+		t.Fatal("backend context has a total deadline from the liveness timeout")
+	}
+	if backend.request.TurnTimeout != 25*time.Millisecond {
+		t.Fatalf("backend TurnTimeout = %v, want liveness timeout preserved", backend.request.TurnTimeout)
+	}
+}
+
 func TestRunAgentBackendTurnLeavesDurationDisabledWithoutDeadline(t *testing.T) {
 	t.Parallel()
 
@@ -215,6 +238,83 @@ func TestRunAgentBackendTurnLeavesDurationDisabledWithoutDeadline(t *testing.T) 
 	}
 	if backend.hasDeadline {
 		t.Fatal("backend context has a deadline with duration limit disabled")
+	}
+}
+
+func TestRunAgentBackendTurnPropagatesDurationContextToUpdates(t *testing.T) {
+	t.Parallel()
+
+	hasDeadline := false
+	_, err, cleanupErr := runAgentBackendTurnWithTools(
+		context.Background(),
+		&durationUpdateAgentBackend{},
+		AgentTurnRequest{MaxDuration: 25 * time.Millisecond},
+		nil,
+		nil,
+		func(ctx context.Context, _ AgentUpdate) error {
+			_, hasDeadline = ctx.Deadline()
+			<-ctx.Done()
+			return ctx.Err()
+		},
+	)
+	if !errors.Is(err, ErrTurnDurationExceeded) {
+		t.Fatalf("runAgentBackendTurnWithTools() error = %v, want ErrTurnDurationExceeded", err)
+	}
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("runAgentBackendTurnWithTools() error = %v, want context deadline exceeded", err)
+	}
+	if cleanupErr != nil {
+		t.Fatalf("runAgentBackendTurnWithTools() cleanup error = %v, want nil", cleanupErr)
+	}
+	if !hasDeadline {
+		t.Fatal("update context has no duration deadline")
+	}
+}
+
+func TestRunnerValidatorUpdatePersistenceUsesSessionDurationContext(t *testing.T) {
+	t.Parallel()
+
+	sessionStore := &durationBlockingSessionStore{
+		fakeSessionStore: &fakeSessionStore{sessionID: 1496},
+	}
+	runner, err := NewRunner(Dependencies{
+		Workflow: config.Workflow{
+			Config: config.Config{
+				Agent: config.Agent{MaxSessionDurationMS: 25},
+				Gate:  gate.Config{Validator: gate.ValidatorConfig{Enabled: true}},
+			},
+			Prompt: "Work",
+		},
+		Workspace: &fakeWorkspaceBackend{
+			info: workspace.Info{Path: t.TempDir(), Key: "issue-validator-duration"},
+		},
+		AgentBackend: &durationUpdateAgentBackend{},
+		Store:        sessionStore,
+	})
+	if err != nil {
+		t.Fatalf("NewRunner() error = %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	startedAt := time.Now()
+	_, err = runner.Validate(ctx, ValidatorRequest{
+		Issue: connector.Issue{
+			ID:         "issue-validator-duration",
+			Identifier: "digitaldrywood/detent#1496",
+		},
+	})
+	if !errors.Is(err, ErrSessionDurationExceeded) {
+		t.Fatalf("Validate() error = %v, want ErrSessionDurationExceeded", err)
+	}
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("Validate() error = %v, want context deadline exceeded", err)
+	}
+	if elapsed := time.Since(startedAt); elapsed > time.Second {
+		t.Fatalf("Validate() elapsed = %v, want configured session duration", elapsed)
+	}
+	if !sessionStore.hasDeadline {
+		t.Fatal("UpdateSessionWorkerProcess() context has no session deadline")
 	}
 }
 
@@ -248,6 +348,22 @@ func (b *durationBlockingAgentBackend) recordDeadline(ctx context.Context) {
 	}
 }
 
+type durationUpdateAgentBackend struct{}
+
+func (b *durationUpdateAgentBackend) RunTurn(_ context.Context, _ AgentTurnRequest, onUpdate AgentUpdateHandler) (AgentTurnResult, error) {
+	if onUpdate == nil {
+		return AgentTurnResult{}, nil
+	}
+	return AgentTurnResult{}, onUpdate(AgentUpdate{
+		Type: AgentUpdateProcessStarted,
+		WorkerProcess: procgroup.Identity{
+			PID:       1496,
+			GroupID:   1496,
+			StartedAt: time.Now(),
+		},
+	})
+}
+
 type durationResumeFallbackAgentBackend struct {
 	calls    int
 	requests []AgentTurnRequest
@@ -265,9 +381,22 @@ func (b *durationResumeFallbackAgentBackend) RunTurn(ctx context.Context, reques
 
 type deadlineObservingAgentBackend struct {
 	hasDeadline bool
+	request     AgentTurnRequest
 }
 
-func (b *deadlineObservingAgentBackend) RunTurn(ctx context.Context, _ AgentTurnRequest, _ AgentUpdateHandler) (AgentTurnResult, error) {
+func (b *deadlineObservingAgentBackend) RunTurn(ctx context.Context, request AgentTurnRequest, _ AgentUpdateHandler) (AgentTurnResult, error) {
 	_, b.hasDeadline = ctx.Deadline()
+	b.request = request
 	return AgentTurnResult{}, nil
+}
+
+type durationBlockingSessionStore struct {
+	*fakeSessionStore
+	hasDeadline bool
+}
+
+func (s *durationBlockingSessionStore) UpdateSessionWorkerProcess(ctx context.Context, _ int64, _ store.WorkerProcessIdentity) error {
+	_, s.hasDeadline = ctx.Deadline()
+	<-ctx.Done()
+	return ctx.Err()
 }

--- a/internal/runner/duration_limit_test.go
+++ b/internal/runner/duration_limit_test.go
@@ -1,0 +1,273 @@
+package runner
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/digitaldrywood/detent/internal/config"
+	"github.com/digitaldrywood/detent/internal/connector"
+	"github.com/digitaldrywood/detent/internal/store"
+	"github.com/digitaldrywood/detent/internal/workspace"
+)
+
+func TestRunnerEnforcesConfiguredDurationLimits(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name            string
+		agent           config.Agent
+		want            error
+		wantMaxDuration time.Duration
+	}{
+		{
+			name:            "turn duration",
+			agent:           config.Agent{MaxTurnDurationMS: 25},
+			want:            ErrTurnDurationExceeded,
+			wantMaxDuration: 25 * time.Millisecond,
+		},
+		{
+			name:  "session duration",
+			agent: config.Agent{MaxSessionDurationMS: 25},
+			want:  ErrSessionDurationExceeded,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			workspaceBackend := &fakeWorkspaceBackend{
+				info: workspace.Info{Path: t.TempDir(), Key: "issue-duration"},
+			}
+			agentBackend := &durationBlockingAgentBackend{}
+			sessionStore := &fakeSessionStore{sessionID: 1496}
+			runner, err := NewRunner(Dependencies{
+				Workflow: config.Workflow{
+					Config: config.Config{Agent: tt.agent},
+					Prompt: "Work",
+				},
+				Workspace:    workspaceBackend,
+				AgentBackend: agentBackend,
+				Store:        sessionStore,
+			})
+			if err != nil {
+				t.Fatalf("NewRunner() error = %v", err)
+			}
+
+			startedAt := time.Now()
+			_, err = runner.Run(context.Background(), RunRequest{
+				Issue: connector.Issue{
+					ID:         "issue-duration",
+					Identifier: "digitaldrywood/detent#1496",
+				},
+			})
+			if !errors.Is(err, tt.want) {
+				t.Fatalf("Run() error = %v, want %v", err, tt.want)
+			}
+			if !errors.Is(err, context.DeadlineExceeded) {
+				t.Fatalf("Run() error = %v, want context deadline exceeded", err)
+			}
+			if elapsed := time.Since(startedAt); elapsed > time.Second {
+				t.Fatalf("Run() elapsed = %v, want configured duration limit", elapsed)
+			}
+			if !strings.Contains(err.Error(), "after 25ms") {
+				t.Fatalf("Run() error = %v, want configured duration", err)
+			}
+			if agentBackend.request.TurnTimeout != 0 {
+				t.Fatalf("AgentTurnRequest.TurnTimeout = %v, want backend liveness timeout unchanged", agentBackend.request.TurnTimeout)
+			}
+			if agentBackend.request.MaxDuration != tt.wantMaxDuration {
+				t.Fatalf("AgentTurnRequest.MaxDuration = %v, want %v", agentBackend.request.MaxDuration, tt.wantMaxDuration)
+			}
+			if len(agentBackend.deadlines) != 4 {
+				t.Fatalf("backend deadlines = %v, want one deadline before and after each update", agentBackend.deadlines)
+			}
+			for _, deadline := range agentBackend.deadlines[1:] {
+				if !deadline.Equal(agentBackend.deadlines[0]) {
+					t.Fatalf("backend deadlines = %v, want activity not to extend total duration", agentBackend.deadlines)
+				}
+			}
+			if sessionStore.finishCalls != 1 {
+				t.Fatalf("FinishSession() calls = %d, want 1", sessionStore.finishCalls)
+			}
+			if !workspaceBackend.afterRun {
+				t.Fatal("AfterRun() was not called")
+			}
+			if workspaceBackend.afterRunErr != nil {
+				t.Fatalf("AfterRun() context error = %v, want fresh cleanup context", workspaceBackend.afterRunErr)
+			}
+		})
+	}
+}
+
+func TestRunnerSessionDurationSpansResumeFallback(t *testing.T) {
+	t.Parallel()
+
+	agentBackend := &durationResumeFallbackAgentBackend{}
+	sessionStore := &fakeSessionStore{
+		sessionID: 1496,
+		resumeState: store.AgentResumeState{
+			DetentSessionID:   1495,
+			ProviderThreadID:  "thread-1495",
+			ProviderSessionID: "session-1495",
+		},
+	}
+	runner, err := NewRunner(Dependencies{
+		Workflow: config.Workflow{
+			Config: config.Config{
+				Agent: config.Agent{
+					ExperimentalThreadResume: true,
+					MaxSessionDurationMS:     25,
+				},
+				Agents: config.Agents{Routes: []config.AgentRoute{{
+					Backend: config.DefaultAgentBackendID,
+					Model:   "gpt-5-codex",
+					Default: true,
+				}}},
+			},
+			Prompt: "Work",
+		},
+		Workspace: &fakeWorkspaceBackend{
+			info: workspace.Info{Path: t.TempDir(), Key: "issue-duration-resume"},
+		},
+		AgentBackend: agentBackend,
+		Store:        sessionStore,
+	})
+	if err != nil {
+		t.Fatalf("NewRunner() error = %v", err)
+	}
+
+	_, err = runner.Run(context.Background(), RunRequest{
+		Issue: connector.Issue{
+			ID:         "issue-duration-resume",
+			Identifier: "digitaldrywood/detent#1496",
+		},
+	})
+	if !errors.Is(err, ErrSessionDurationExceeded) {
+		t.Fatalf("Run() error = %v, want ErrSessionDurationExceeded", err)
+	}
+	if agentBackend.calls != 2 {
+		t.Fatalf("RunTurn() calls = %d, want resume attempt and fresh fallback", agentBackend.calls)
+	}
+	if agentResumeEmpty(agentBackend.requests[0].Resume) {
+		t.Fatal("first RunTurn() resume state is empty")
+	}
+	if !agentResumeEmpty(agentBackend.requests[1].Resume) {
+		t.Fatalf("second RunTurn() resume state = %#v, want fresh fallback", agentBackend.requests[1].Resume)
+	}
+}
+
+func TestRunAgentBackendTurnPreservesParentCancellation(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, err, cleanupErr := runAgentBackendTurn(ctx, &durationBlockingAgentBackend{}, AgentTurnRequest{
+		MaxDuration: time.Hour,
+	}, nil)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("runAgentBackendTurn() error = %v, want context canceled", err)
+	}
+	if errors.Is(err, ErrTurnDurationExceeded) {
+		t.Fatalf("runAgentBackendTurn() error = %v, want parent cancellation", err)
+	}
+	if cleanupErr != nil {
+		t.Fatalf("runAgentBackendTurn() cleanup error = %v, want nil", cleanupErr)
+	}
+}
+
+func TestRunAgentBackendTurnUsesShorterTotalDuration(t *testing.T) {
+	t.Parallel()
+
+	backend := &durationBlockingAgentBackend{}
+	_, err, cleanupErr := runAgentBackendTurn(context.Background(), backend, AgentTurnRequest{
+		TurnTimeout: time.Hour,
+		MaxDuration: 25 * time.Millisecond,
+	}, nil)
+	if !errors.Is(err, ErrTurnDurationExceeded) {
+		t.Fatalf("runAgentBackendTurn() error = %v, want ErrTurnDurationExceeded", err)
+	}
+	if cleanupErr != nil {
+		t.Fatalf("runAgentBackendTurn() cleanup error = %v, want nil", cleanupErr)
+	}
+	if backend.request.TurnTimeout != time.Hour {
+		t.Fatalf("backend TurnTimeout = %v, want liveness timeout preserved", backend.request.TurnTimeout)
+	}
+	if backend.request.MaxDuration != 25*time.Millisecond {
+		t.Fatalf("backend MaxDuration = %v, want total duration preserved", backend.request.MaxDuration)
+	}
+}
+
+func TestRunAgentBackendTurnLeavesDurationDisabledWithoutDeadline(t *testing.T) {
+	t.Parallel()
+
+	backend := &deadlineObservingAgentBackend{}
+	_, err, cleanupErr := runAgentBackendTurn(context.Background(), backend, AgentTurnRequest{}, nil)
+	if err != nil {
+		t.Fatalf("runAgentBackendTurn() error = %v", err)
+	}
+	if cleanupErr != nil {
+		t.Fatalf("runAgentBackendTurn() cleanup error = %v", cleanupErr)
+	}
+	if backend.hasDeadline {
+		t.Fatal("backend context has a deadline with duration limit disabled")
+	}
+}
+
+type durationBlockingAgentBackend struct {
+	request   AgentTurnRequest
+	deadlines []time.Time
+}
+
+func (b *durationBlockingAgentBackend) RunTurn(ctx context.Context, request AgentTurnRequest, onUpdate AgentUpdateHandler) (AgentTurnResult, error) {
+	b.request = request
+	b.recordDeadline(ctx)
+	for range 3 {
+		if onUpdate != nil {
+			if err := onUpdate(AgentUpdate{
+				Type:   AgentUpdateMessageDelta,
+				ItemID: "message",
+				Delta:  "working",
+			}); err != nil {
+				return AgentTurnResult{}, err
+			}
+		}
+		b.recordDeadline(ctx)
+	}
+	<-ctx.Done()
+	return AgentTurnResult{}, ctx.Err()
+}
+
+func (b *durationBlockingAgentBackend) recordDeadline(ctx context.Context) {
+	if deadline, ok := ctx.Deadline(); ok {
+		b.deadlines = append(b.deadlines, deadline)
+	}
+}
+
+type durationResumeFallbackAgentBackend struct {
+	calls    int
+	requests []AgentTurnRequest
+}
+
+func (b *durationResumeFallbackAgentBackend) RunTurn(ctx context.Context, request AgentTurnRequest, _ AgentUpdateHandler) (AgentTurnResult, error) {
+	b.calls++
+	b.requests = append(b.requests, request)
+	if !agentResumeEmpty(request.Resume) {
+		return AgentTurnResult{}, errors.New("resume failed")
+	}
+	<-ctx.Done()
+	return AgentTurnResult{}, ctx.Err()
+}
+
+type deadlineObservingAgentBackend struct {
+	hasDeadline bool
+}
+
+func (b *deadlineObservingAgentBackend) RunTurn(ctx context.Context, _ AgentTurnRequest, _ AgentUpdateHandler) (AgentTurnResult, error) {
+	_, b.hasDeadline = ctx.Deadline()
+	return AgentTurnResult{}, nil
+}

--- a/internal/runner/types.go
+++ b/internal/runner/types.go
@@ -37,6 +37,8 @@ const (
 
 var (
 	ErrSessionTokenCeilingExceeded = errors.New("session token ceiling exceeded")
+	ErrTurnDurationExceeded        = errors.New("agent turn duration exceeded")
+	ErrSessionDurationExceeded     = errors.New("agent session duration exceeded")
 	ErrOperatorStopped             = errors.New("operator stopped run")
 	ErrMergeRevoked                = errors.New("merge eligibility revoked")
 	ErrAgentTurnCleanup            = errors.New("agent turn cleanup failed")
@@ -139,6 +141,7 @@ type AgentTurnRequest struct {
 	ReasoningEffort    string
 	Resume             AgentResume
 	TurnTimeout        time.Duration
+	MaxDuration        time.Duration
 	ExtraWritableRoots []string
 	Environment        procgroup.Environment
 	cacheStrategy      string
@@ -258,6 +261,19 @@ func (e *SessionTokenCeilingError) Error() string {
 
 func (e *SessionTokenCeilingError) Unwrap() error {
 	return ErrSessionTokenCeilingExceeded
+}
+
+type agentDurationLimitError struct {
+	limit    error
+	duration time.Duration
+}
+
+func (e *agentDurationLimitError) Error() string {
+	return fmt.Sprintf("%s after %s", e.limit, e.duration)
+}
+
+func (e *agentDurationLimitError) Is(target error) bool {
+	return target == e.limit || target == context.DeadlineExceeded
 }
 
 type RunRequest struct {


### PR DESCRIPTION
## Summary

- document that Codex `turn_timeout_ms` is a reset-on-message liveness bound with a one-hour default
- add backend-independent `agent.max_turn_duration_ms` and `agent.max_session_duration_ms` wall-clock limits
- preserve shorter backend liveness deadlines, parent cancellation, process-tree cleanup, resume fallback accounting, and doctor visibility

Fixes #1496

## UI Surface Contract

- [x] N/A; this change has no UI surface.
- [x] This PR does not add persistent top-of-screen messaging.
- [x] This PR has no visual changes to primary operator screens.

## Test Plan

- [x] `go test -race ./internal/runner ./internal/codex ./internal/config ./internal/cli -count=1`
- [x] `make check`