### PR TITLE
test(runner): stabilize resume duration test

### DIFF
--- a/internal/runner/agent.go
+++ b/internal/runner/agent.go
@@ -90,6 +90,8 @@ func (f AgentBackendFactoryFunc) NewAgentBackend(cfg config.AgentBackend) (Agent
 	return f(cfg)
 }
 
+type durationLimitContextFactory func(context.Context, time.Duration, error) (context.Context, context.CancelFunc)
+
 type Dependencies struct {
 	ProjectID           string
 	Workflow            config.Workflow
@@ -105,6 +107,7 @@ type Dependencies struct {
 	Now                 func() time.Time
 	Logger              *slog.Logger
 	AfterRunTimeout     time.Duration
+	sessionLimit        durationLimitContextFactory
 }
 
 type Runner struct {
@@ -124,6 +127,7 @@ type Runner struct {
 	now                 func() time.Time
 	logger              *slog.Logger
 	afterRunTimeout     time.Duration
+	sessionLimit        durationLimitContextFactory
 }
 
 func NewRunner(deps Dependencies) (*Runner, error) {
@@ -138,6 +142,9 @@ func NewRunner(deps Dependencies) (*Runner, error) {
 	}
 	if deps.AfterRunTimeout <= 0 {
 		deps.AfterRunTimeout = defaultAfterRunTimeout
+	}
+	if deps.sessionLimit == nil {
+		deps.sessionLimit = withAgentDurationLimit
 	}
 	projectID := strings.TrimSpace(deps.ProjectID)
 	if projectID == "" {
@@ -181,6 +188,7 @@ func NewRunner(deps Dependencies) (*Runner, error) {
 		now:                 deps.Now,
 		logger:              deps.Logger,
 		afterRunTimeout:     deps.AfterRunTimeout,
+		sessionLimit:        deps.sessionLimit,
 	}, nil
 }
 
@@ -1070,7 +1078,7 @@ func (r *Runner) Run(ctx context.Context, req RunRequest) (RunResult, error) {
 	if err != nil {
 		return RunResult{}, err
 	}
-	sessionCtx, cancelSession := withAgentDurationLimit(
+	sessionCtx, cancelSession := r.sessionLimit(
 		ctx,
 		durationFromMillis(workflow.Config.Agent.MaxSessionDurationMS),
 		ErrSessionDurationExceeded,
@@ -1374,7 +1382,7 @@ func (r *Runner) Validate(ctx context.Context, req ValidatorRequest) (gate.Valid
 	if err != nil {
 		return gate.ValidatorResult{}, err
 	}
-	sessionCtx, cancelSession := withAgentDurationLimit(
+	sessionCtx, cancelSession := r.sessionLimit(
 		ctx,
 		durationFromMillis(workflow.Config.Agent.MaxSessionDurationMS),
 		ErrSessionDurationExceeded,

--- a/internal/runner/duration_limit_test.go
+++ b/internal/runner/duration_limit_test.go
@@ -108,7 +108,10 @@ func TestRunnerEnforcesConfiguredDurationLimits(t *testing.T) {
 func TestRunnerSessionDurationSpansResumeFallback(t *testing.T) {
 	t.Parallel()
 
-	agentBackend := &durationResumeFallbackAgentBackend{}
+	sessionDurationLimit := &controlledDurationLimit{}
+	agentBackend := &durationResumeFallbackAgentBackend{
+		expireSession: sessionDurationLimit.Expire,
+	}
 	sessionStore := &fakeSessionStore{
 		sessionID: 1496,
 		resumeState: store.AgentResumeState{
@@ -137,6 +140,7 @@ func TestRunnerSessionDurationSpansResumeFallback(t *testing.T) {
 		},
 		AgentBackend: agentBackend,
 		Store:        sessionStore,
+		sessionLimit: sessionDurationLimit.Context,
 	})
 	if err != nil {
 		t.Fatalf("NewRunner() error = %v", err)
@@ -159,6 +163,12 @@ func TestRunnerSessionDurationSpansResumeFallback(t *testing.T) {
 	}
 	if !agentResumeEmpty(agentBackend.requests[1].Resume) {
 		t.Fatalf("second RunTurn() resume state = %#v, want fresh fallback", agentBackend.requests[1].Resume)
+	}
+	if sessionDurationLimit.duration != 25*time.Millisecond {
+		t.Fatalf("session duration = %v, want 25ms", sessionDurationLimit.duration)
+	}
+	if !errors.Is(sessionDurationLimit.limit, ErrSessionDurationExceeded) {
+		t.Fatalf("session duration limit = %v, want ErrSessionDurationExceeded", sessionDurationLimit.limit)
 	}
 }
 
@@ -365,8 +375,9 @@ func (b *durationUpdateAgentBackend) RunTurn(_ context.Context, _ AgentTurnReque
 }
 
 type durationResumeFallbackAgentBackend struct {
-	calls    int
-	requests []AgentTurnRequest
+	calls         int
+	requests      []AgentTurnRequest
+	expireSession func()
 }
 
 func (b *durationResumeFallbackAgentBackend) RunTurn(ctx context.Context, request AgentTurnRequest, _ AgentUpdateHandler) (AgentTurnResult, error) {
@@ -375,8 +386,31 @@ func (b *durationResumeFallbackAgentBackend) RunTurn(ctx context.Context, reques
 	if !agentResumeEmpty(request.Resume) {
 		return AgentTurnResult{}, errors.New("resume failed")
 	}
+	b.expireSession()
 	<-ctx.Done()
 	return AgentTurnResult{}, ctx.Err()
+}
+
+type controlledDurationLimit struct {
+	cancel   context.CancelCauseFunc
+	duration time.Duration
+	limit    error
+}
+
+func (l *controlledDurationLimit) Context(ctx context.Context, duration time.Duration, limit error) (context.Context, context.CancelFunc) {
+	ctx, l.cancel = context.WithCancelCause(ctx)
+	l.duration = duration
+	l.limit = limit
+	return ctx, func() {
+		l.cancel(context.Canceled)
+	}
+}
+
+func (l *controlledDurationLimit) Expire() {
+	l.cancel(&agentDurationLimitError{
+		limit:    l.limit,
+		duration: l.duration,
+	})
 }
 
 type deadlineObservingAgentBackend struct {


### PR DESCRIPTION
## Summary

- inject a private session-duration context factory while preserving the production timeout default
- expire the controlled test context only after the fresh fallback call is observed
- keep assertions for resume ordering, fresh fallback, configured duration, and ErrSessionDurationExceeded

Fixes #1509

## UI Surface Contract

- [x] N/A, or the linked issue explicitly authorizes any high-impact UI surface, layout, density, first-viewport, or responsive visibility tradeoff.
- [x] Persistent top-of-screen messaging is explicitly authorized by the issue, or this PR does not add it.
- [x] Visual changes to primary operator screens include screenshot or browser verification below.

## Test Plan

- [x] `go test -race ./internal/runner -run "^TestRunnerSessionDurationSpansResumeFallback$" -count=100`
- [x] `go test -race ./internal/runner -run "Duration" -count=10`
- [x] `make check`