### PR TITLE
test(doctor): make renewal test deterministic

### DIFF
--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -127,6 +127,16 @@ type doctorCheckResult struct {
 	Checks []doctorCheck
 }
 
+type doctorCheckTimer interface {
+	C() <-chan time.Time
+	Reset(time.Duration) bool
+	Stop() bool
+}
+
+type systemDoctorCheckTimer struct {
+	timer *time.Timer
+}
+
 type doctorCheckProgress struct {
 	mu      sync.Mutex
 	current string
@@ -643,9 +653,12 @@ func runDoctorCheck(ctx context.Context, job doctorCheckJob, timeout time.Durati
 		ctx = context.Background()
 	}
 	timeout = doctorNormalizedTimeout(timeout)
+	return runDoctorCheckWithTimer(ctx, job, timeout, &systemDoctorCheckTimer{timer: time.NewTimer(timeout)})
+}
+
+func runDoctorCheckWithTimer(ctx context.Context, job doctorCheckJob, timeout time.Duration, timer doctorCheckTimer) []doctorCheck {
 	checkCtx, cancel := context.WithCancel(context.WithoutCancel(ctx))
 	defer cancel()
-	timer := time.NewTimer(timeout)
 	defer timer.Stop()
 
 	done := make(chan []doctorCheck, 1)
@@ -659,7 +672,7 @@ func runDoctorCheck(ctx context.Context, job doctorCheckJob, timeout time.Durati
 			return checks
 		case <-job.Progress:
 			resetDoctorCheckTimer(timer, timeout)
-		case <-timer.C:
+		case <-timer.C():
 			snapshot := freezeDoctorCheck(job)
 			cancel()
 			return doctorTimedOutChecks(job.Name, snapshot, timeout, context.DeadlineExceeded)
@@ -669,6 +682,18 @@ func runDoctorCheck(ctx context.Context, job doctorCheckJob, timeout time.Durati
 			return doctorTimedOutChecks(job.Name, snapshot, timeout, ctx.Err())
 		}
 	}
+}
+
+func (t *systemDoctorCheckTimer) C() <-chan time.Time {
+	return t.timer.C
+}
+
+func (t *systemDoctorCheckTimer) Reset(timeout time.Duration) bool {
+	return t.timer.Reset(timeout)
+}
+
+func (t *systemDoctorCheckTimer) Stop() bool {
+	return t.timer.Stop()
 }
 
 func freezeDoctorCheck(job doctorCheckJob) doctorCheckSnapshot {
@@ -691,10 +716,10 @@ func doctorTimedOutChecks(name string, snapshot doctorCheckSnapshot, timeout tim
 	})
 }
 
-func resetDoctorCheckTimer(timer *time.Timer, timeout time.Duration) {
+func resetDoctorCheckTimer(timer doctorCheckTimer, timeout time.Duration) {
 	if !timer.Stop() {
 		select {
-		case <-timer.C:
+		case <-timer.C():
 		default:
 		}
 	}

--- a/internal/cli/doctor_test.go
+++ b/internal/cli/doctor_test.go
@@ -4764,26 +4764,72 @@ func TestRunDoctorCheckRenewsTimeoutForReportedProgress(t *testing.T) {
 
 	const timeout = 100 * time.Millisecond
 	progress := newDoctorCheckProgress()
-	checks := runDoctorCheck(context.Background(), doctorCheckJob{
-		Name:     "Project alpha checks",
-		Current:  progress.Current,
-		Progress: progress.Updates(),
-		Run: func(ctx context.Context) []doctorCheck {
-			for _, name := range []string{"first", "second", "third"} {
-				progress.Set("Project alpha "+name, nil)
-				select {
-				case <-ctx.Done():
-					return nil
-				case <-time.After(60 * time.Millisecond):
+	timer := &controlledDoctorCheckTimer{
+		deadline: make(chan time.Time),
+		resets:   make(chan time.Duration),
+	}
+	advance := make(chan struct{})
+	checksDone := make(chan []doctorCheck, 1)
+	stuck := time.NewTimer(10 * time.Second)
+	defer stuck.Stop()
+	go func() {
+		checksDone <- runDoctorCheckWithTimer(context.Background(), doctorCheckJob{
+			Name:     "Project alpha checks",
+			Current:  progress.Current,
+			Progress: progress.Updates(),
+			Run: func(ctx context.Context) []doctorCheck {
+				for _, name := range []string{"first", "second", "third"} {
+					progress.Set("Project alpha "+name, nil)
+					select {
+					case <-ctx.Done():
+						return nil
+					case <-advance:
+					}
 				}
-			}
-			return []doctorCheck{{Name: "Project alpha checks", Status: doctorOK, Detail: "done"}}
-		},
-	}, timeout)
+				return []doctorCheck{{Name: "Project alpha checks", Status: doctorOK, Detail: "done"}}
+			},
+		}, timeout, timer)
+	}()
 
+	for range 3 {
+		select {
+		case got := <-timer.resets:
+			if got != timeout {
+				t.Fatalf("timer reset = %s, want %s", got, timeout)
+			}
+		case <-stuck.C:
+			t.Fatal("timed out waiting for timer reset")
+		}
+		advance <- struct{}{}
+	}
+
+	var checks []doctorCheck
+	select {
+	case checks = <-checksDone:
+	case <-stuck.C:
+		t.Fatal("timed out waiting for completed project checks")
+	}
 	if len(checks) != 1 || checks[0].Status != doctorOK {
 		t.Fatalf("checks = %#v, want completed project checks", checks)
 	}
+}
+
+type controlledDoctorCheckTimer struct {
+	deadline chan time.Time
+	resets   chan time.Duration
+}
+
+func (t *controlledDoctorCheckTimer) C() <-chan time.Time {
+	return t.deadline
+}
+
+func (t *controlledDoctorCheckTimer) Reset(timeout time.Duration) bool {
+	t.resets <- timeout
+	return true
+}
+
+func (t *controlledDoctorCheckTimer) Stop() bool {
+	return true
 }
 
 func TestRunDoctorCheckFreezesProgressBeforeCancellation(t *testing.T) {


### PR DESCRIPTION
## Summary

- Inject the doctor check deadline timer behind a private production-default seam.
- Coordinate each reported progress update with an observable timer reset so runner scheduling cannot produce a false timeout.

Fixes #1510

## UI Surface Contract

- [x] N/A, or the linked issue explicitly authorizes any high-impact UI surface, layout, density, first-viewport, or responsive visibility tradeoff.
- [x] Persistent top-of-screen messaging is explicitly authorized by the issue, or this PR does not add it.
- [x] Visual changes to primary operator screens include screenshot or browser verification below.

## Test Plan

- [x] `go test -race ./internal/cli -run ^TestRunDoctorCheckRenewsTimeoutForReportedProgress$ -count=100`
- [x] `go test -race ./internal/cli`
- [x] `make check`