### PR TITLE
feat(scheduler): add agent pools

### DIFF
--- a/README.md
+++ b/README.md
@@ -2242,6 +2242,12 @@ update:
 global:
   max_concurrent_agents: 8
   scheduling: weighted
+  agent_pools:
+    - name: code
+      max_concurrent_agents: 5
+    - name: video
+      max_concurrent_agents: 10
+      scheduling: round_robin
   fair_share:
     half_life: 1h
   startup:
@@ -2250,6 +2256,7 @@ global:
     max_concurrent_starts: 4
 projects:
   - id: detent
+    pool: code
     workflow: /absolute/path/to/detent/WORKFLOW.md
     workdir: /absolute/path/to/detent
     color: "#1192e8"
@@ -2269,6 +2276,20 @@ projects:
 Project weights are relative scheduling weights. Higher weights receive a
 larger dispatch share in weighted and fair-share scheduling modes. Project
 priority is a rank: `0` is highest and `4` is lowest.
+
+`global.agent_pools` defines independent agent-capacity partitions. Each
+project belongs to exactly one pool through `projects[].pool`. A project with
+no `pool` uses the implicit `default` pool, whose capacity is
+`global.max_concurrent_agents` and whose policy is `global.scheduling`.
+`default` is reserved and cannot be declared in `agent_pools`.
+
+Every named pool requires a unique non-empty `name` and a positive
+`max_concurrent_agents`. Its optional `scheduling` accepts `weighted`,
+`strict`, `round_robin`, or `fair_share`; when omitted it inherits
+`global.scheduling`. Pool capacities are independent, with no additional
+fleet-wide ceiling. For example, `code: 5` plus `video: 10` permits up to 15
+agents concurrently. A configuration without `agent_pools` or project `pool`
+fields retains the previous single-pool behavior.
 
 Set optional `projects[].color` to an opaque CSS hex color in `#RGB` or
 `#RRGGBB` form when a project needs a fixed visual marker. The sidebar,
@@ -2341,7 +2362,7 @@ can include `--workflow-ref origin/main` during registration or add
 | `global.startup` | Live reload |
 | `instance_name` | Live reload |
 | `global.identity` | Live reload; project runtimes restart in-process and `/api/v1/state.instance.name` updates after the next telemetry snapshot |
-| `global.max_concurrent_agents`, `global.scheduling`, `global.fair_share` | Live reload at the next dispatch decision; lowering capacity drains to the new limit without interrupting active workers |
+| `global.max_concurrent_agents`, `global.scheduling`, `global.agent_pools`, `global.fair_share`, and project pool assignments | Live reload at the next dispatch decision; lowering capacity drains to the new limit without interrupting active workers, and removed pools drain their active workers before retirement |
 | `log_level` | Live reload |
 | `port`, `env`, `log_max_size_bytes`, `log_max_backups` | Restart required |
 

--- a/internal/cli/boot.go
+++ b/internal/cli/boot.go
@@ -262,11 +262,10 @@ func startRunningWithDependencies(ctx context.Context, cfg BootConfig, deps star
 
 	events := hub.New[project.Event]()
 	activityBroker := activity.NewBroker()
-	globalScheduler, err := buildGlobalScheduler(cfg.Global.Global, runtimeStore)
+	globalDispatchGate, err := buildGlobalDispatchPools(cfg.Global, runtimeStore)
 	if err != nil {
 		return err
 	}
-	globalDispatchGate := scheduler.NewGlobalDispatchGate(globalScheduler, globalProjectCandidates(cfg.Global.Projects)...)
 	runtimeGitHubToken := newRuntimeGitHubTokenState(runtimeGlobalGitHubToken(cfg.Runtime.GitHubToken))
 	globalConfigState := newGlobalConfigState(cfg.Global)
 	refreshGitHubToken := runtimeGitHubTokenRefresher(globalConfigState, runtimeGitHubToken)
@@ -576,6 +575,7 @@ func globalProjectCandidates(projects []globalconfig.Project) []scheduler.Projec
 	for _, project := range projects {
 		candidates = append(candidates, scheduler.ProjectCandidate{
 			ID:       project.ID,
+			Pool:     project.Pool,
 			Weight:   project.Weight,
 			Priority: project.Priority,
 			Paused:   project.Paused,
@@ -585,7 +585,7 @@ func globalProjectCandidates(projects []globalconfig.Project) []scheduler.Projec
 }
 
 func syncGlobalDispatchProjects(
-	gate *scheduler.GlobalDispatchGate,
+	gate *scheduler.PoolRegistry,
 	projects []globalconfig.Project,
 	registry *project.Registry,
 ) {
@@ -1180,6 +1180,53 @@ func buildGlobalScheduler(settings globalconfig.Settings, fairShareStore schedul
 	return global, nil
 }
 
+func buildGlobalDispatchPools(
+	cfg globalconfig.Config,
+	fairShareStore scheduler.FairShareStore,
+) (*scheduler.PoolRegistry, error) {
+	pools, err := globalPoolConfigs(cfg.Global, fairShareStore)
+	if err != nil {
+		return nil, err
+	}
+	registry, err := scheduler.NewPoolRegistry(pools, globalProjectCandidates(cfg.Projects))
+	if err != nil {
+		return nil, fmt.Errorf("create agent pools: %w", err)
+	}
+	return registry, nil
+}
+
+func globalPoolConfigs(
+	settings globalconfig.Settings,
+	fairShareStore scheduler.FairShareStore,
+) ([]scheduler.PoolConfig, error) {
+	defaultConfig, err := globalSchedulerConfig(settings, fairShareStore)
+	if err != nil {
+		return nil, err
+	}
+	pools := make([]scheduler.PoolConfig, 0, len(settings.AgentPools)+1)
+	pools = append(pools, scheduler.PoolConfig{
+		Name:      scheduler.DefaultPoolName,
+		Scheduler: defaultConfig,
+	})
+	for _, pool := range settings.AgentPools {
+		poolSettings := settings
+		poolSettings.MaxConcurrentAgents = pool.MaxConcurrentAgents
+		poolSettings.Scheduling = pool.Scheduling
+		if strings.TrimSpace(poolSettings.Scheduling) == "" {
+			poolSettings.Scheduling = settings.Scheduling
+		}
+		poolConfig, err := globalSchedulerConfig(poolSettings, fairShareStore)
+		if err != nil {
+			return nil, err
+		}
+		pools = append(pools, scheduler.PoolConfig{
+			Name:      pool.Name,
+			Scheduler: poolConfig,
+		})
+	}
+	return pools, nil
+}
+
 func globalSchedulerConfig(settings globalconfig.Settings, fairShareStore scheduler.FairShareStore) (scheduler.Config, error) {
 	halfLife, err := globalFairShareHalfLife(settings.FairShare)
 	if err != nil {
@@ -1199,17 +1246,17 @@ func globalSchedulerConfig(settings globalconfig.Settings, fairShareStore schedu
 }
 
 func applyGlobalRuntimeConfig(
-	gate *scheduler.GlobalDispatchGate,
+	gate *scheduler.PoolRegistry,
 	fairShareStore scheduler.FairShareStore,
 	logLevel *slog.LevelVar,
 	cfg globalconfig.Config,
 ) error {
-	schedulerConfig, err := globalSchedulerConfig(cfg.Global, fairShareStore)
+	pools, err := globalPoolConfigs(cfg.Global, fairShareStore)
 	if err != nil {
 		return err
 	}
-	if err := gate.Reconfigure(schedulerConfig); err != nil {
-		return fmt.Errorf("reconfigure global scheduler: %w", err)
+	if err := gate.Reconfigure(pools, globalProjectCandidates(cfg.Projects)); err != nil {
+		return fmt.Errorf("reconfigure agent pools: %w", err)
 	}
 	if logLevel != nil {
 		logLevel.Set(parseSlogLevel(cfg.LogLevel))

--- a/internal/cli/boot_test.go
+++ b/internal/cli/boot_test.go
@@ -132,6 +132,42 @@ func TestBuildGlobalSchedulerFromSettings(t *testing.T) {
 	}
 }
 
+func TestGlobalPoolConfigsApplySchedulingInheritanceAndOverrides(t *testing.T) {
+	t.Parallel()
+
+	pools, err := globalPoolConfigs(globalconfig.Settings{
+		MaxConcurrentAgents: 1,
+		Scheduling:          globalconfig.SchedulingStrict,
+		AgentPools: []globalconfig.AgentPool{
+			{Name: "code", MaxConcurrentAgents: 5},
+			{Name: "video", MaxConcurrentAgents: 10, Scheduling: globalconfig.SchedulingRoundRobin},
+		},
+		FairShare: map[string]any{"half_life": "30m"},
+	}, nil)
+	if err != nil {
+		t.Fatalf("globalPoolConfigs() error = %v", err)
+	}
+	if len(pools) != 3 {
+		t.Fatalf("globalPoolConfigs() = %#v, want three pools", pools)
+	}
+	tests := []struct {
+		index    int
+		name     string
+		capacity int
+		kind     string
+	}{
+		{index: 0, name: scheduler.DefaultPoolName, capacity: 1, kind: globalconfig.SchedulingStrict},
+		{index: 1, name: "code", capacity: 5, kind: globalconfig.SchedulingStrict},
+		{index: 2, name: "video", capacity: 10, kind: globalconfig.SchedulingRoundRobin},
+	}
+	for _, tt := range tests {
+		pool := pools[tt.index]
+		if pool.Name != tt.name || pool.Scheduler.Capacity != tt.capacity || pool.Scheduler.Kind != tt.kind {
+			t.Fatalf("pools[%d] = %#v, want name/capacity/kind %s/%d/%s", tt.index, pool, tt.name, tt.capacity, tt.kind)
+		}
+	}
+}
+
 func TestRuntimeLogLevelForReloadPreservesOverrides(t *testing.T) {
 	t.Parallel()
 
@@ -170,7 +206,19 @@ func TestSyncGlobalDispatchProjectsMarksUnstartedProjectsIdle(t *testing.T) {
 		{ID: "higher", Weight: 1, Priority: 0},
 		{ID: "lower", Weight: 1, Priority: 3},
 	}
-	gate := scheduler.NewGlobalDispatchGate(scheduler.NewStrictPriority(scheduler.Config{Capacity: 1}))
+	gate, err := scheduler.NewPoolRegistry(
+		[]scheduler.PoolConfig{{
+			Name: scheduler.DefaultPoolName,
+			Scheduler: scheduler.Config{
+				Kind:     globalconfig.SchedulingStrict,
+				Capacity: 1,
+			},
+		}},
+		globalProjectCandidates(projects),
+	)
+	if err != nil {
+		t.Fatalf("NewPoolRegistry() error = %v", err)
+	}
 	syncGlobalDispatchProjects(gate, projects, projectpkg.NewRegistry())
 
 	lower := globalProjectCandidates(projects)[1]

--- a/internal/cli/global_reload.go
+++ b/internal/cli/global_reload.go
@@ -293,6 +293,9 @@ func changedGlobalSettings(previous globalconfig.Settings, next globalconfig.Set
 	if previous.Scheduling != next.Scheduling {
 		fields = append(fields, globalConfigChange{Field: "global.scheduling", Old: previous.Scheduling, New: next.Scheduling})
 	}
+	if !reflect.DeepEqual(previous.AgentPools, next.AgentPools) {
+		fields = append(fields, globalConfigChange{Field: "global.agent_pools", Old: previous.AgentPools, New: next.AgentPools})
+	}
 	if !reflect.DeepEqual(previous.Identity, next.Identity) {
 		fields = append(fields, globalConfigChange{Field: "global.identity", Old: previous.Identity, New: next.Identity})
 	}

--- a/internal/cli/global_reload_test.go
+++ b/internal/cli/global_reload_test.go
@@ -241,8 +241,12 @@ func TestChangedGlobalConfigFieldsReloadClassification(t *testing.T) {
 		{name: "port", field: "port", requiresRestart: true, mutate: func(cfg *globalconfig.Config) { value := 4101; cfg.Port = &value }},
 		{name: "instance name", field: "instance_name", mutate: func(cfg *globalconfig.Config) { cfg.InstanceName = "buildbox" }},
 		{name: "projects", field: "projects", mutate: func(cfg *globalconfig.Config) { cfg.Projects = []globalconfig.Project{{ID: "bravo", Weight: 2}} }},
+		{name: "project pool", field: "projects", mutate: func(cfg *globalconfig.Config) { cfg.Projects[0].Pool = "video" }},
 		{name: "maximum concurrent agents", field: "global.max_concurrent_agents", mutate: func(cfg *globalconfig.Config) { cfg.Global.MaxConcurrentAgents = 4 }},
 		{name: "scheduling", field: "global.scheduling", mutate: func(cfg *globalconfig.Config) { cfg.Global.Scheduling = globalconfig.SchedulingRoundRobin }},
+		{name: "agent pools", field: "global.agent_pools", mutate: func(cfg *globalconfig.Config) {
+			cfg.Global.AgentPools = []globalconfig.AgentPool{{Name: "video", MaxConcurrentAgents: 4}}
+		}},
 		{name: "identity", field: "global.identity", mutate: func(cfg *globalconfig.Config) {
 			cfg.Global.Identity = globalconfig.Identity{Name: "new-worker", GitHubLogin: "new-bot"}
 		}},
@@ -273,11 +277,21 @@ func TestGlobalConfigReloaderHotAppliesSchedulerCapacityWithoutInterruptingWorke
 	t.Parallel()
 
 	ctx := context.Background()
-	global := scheduler.NewStrictPriority(scheduler.Config{Capacity: 2})
-	gate := scheduler.NewGlobalDispatchGate(global)
 	alpha := scheduler.ProjectCandidate{ID: "alpha", Weight: 1, Priority: 3}
 	bravo := scheduler.ProjectCandidate{ID: "bravo", Weight: 1, Priority: 2}
 	charlie := scheduler.ProjectCandidate{ID: "charlie", Weight: 1, Priority: 0}
+	initial := reloadTestConfig("global.yaml", 2, []globalconfig.Project{
+		{ID: alpha.ID, Weight: alpha.Weight, Priority: alpha.Priority},
+		{ID: bravo.ID, Weight: bravo.Weight, Priority: bravo.Priority},
+		{ID: charlie.ID, Weight: charlie.Weight, Priority: charlie.Priority},
+	})
+	initial.Global.Scheduling = globalconfig.SchedulingStrict
+	gate, err := buildGlobalDispatchPools(initial, nil)
+	if err != nil {
+		t.Fatalf("buildGlobalDispatchPools() error = %v", err)
+	}
+	gate.MarkIdle(bravo.ID)
+	gate.MarkIdle(charlie.ID)
 	alphaSlot, ok, err := gate.TryAcquire(ctx, alpha, scheduler.SlotRequest{State: "Todo"}, time.Time{})
 	if err != nil || !ok {
 		t.Fatalf("alpha TryAcquire() = ok %t error %v, want granted", ok, err)
@@ -344,17 +358,69 @@ func TestGlobalConfigReloaderHotAppliesSchedulingAndFairShare(t *testing.T) {
 	t.Parallel()
 
 	store := &globalReloadFairShareStore{}
-	global := scheduler.NewWeightedFair(scheduler.Config{Capacity: 2})
-	gate := scheduler.NewGlobalDispatchGate(global)
 	next := reloadTestConfig("global.yaml", 2, nil)
+	gate, err := buildGlobalDispatchPools(next, store)
+	if err != nil {
+		t.Fatalf("buildGlobalDispatchPools() error = %v", err)
+	}
 	next.Global.Scheduling = globalconfig.SchedulingFairShare
 	next.Global.FairShare = map[string]any{"half_life": "2h"}
 
 	if err := applyGlobalRuntimeConfig(gate, store, nil, next); err != nil {
 		t.Fatalf("applyGlobalRuntimeConfig() error = %v", err)
 	}
-	if global.Mode() != scheduler.ModeFairShare {
-		t.Fatalf("Mode() = %q, want %q", global.Mode(), scheduler.ModeFairShare)
+	if mode := gate.PoolSnapshotFor("").Mode; mode != scheduler.ModeFairShare {
+		t.Fatalf("Mode() = %q, want %q", mode, scheduler.ModeFairShare)
+	}
+}
+
+func TestGlobalConfigReloaderHotReconfiguresAgentPools(t *testing.T) {
+	t.Parallel()
+
+	initial := reloadTestConfig("global.yaml", 1, []globalconfig.Project{{ID: "alpha", Weight: 1}})
+	initial.Global.Scheduling = globalconfig.SchedulingStrict
+	gate, err := buildGlobalDispatchPools(initial, nil)
+	if err != nil {
+		t.Fatalf("buildGlobalDispatchPools() error = %v", err)
+	}
+
+	added := initial
+	added.Global.AgentPools = []globalconfig.AgentPool{{
+		Name:                "video",
+		MaxConcurrentAgents: 2,
+		Scheduling:          globalconfig.SchedulingRoundRobin,
+	}}
+	added.Projects = []globalconfig.Project{{ID: "alpha", Pool: "video", Weight: 1}}
+	if err := applyGlobalRuntimeConfig(gate, nil, nil, added); err != nil {
+		t.Fatalf("add applyGlobalRuntimeConfig() error = %v", err)
+	}
+	if snapshot := gate.PoolSnapshotFor("alpha"); snapshot.Name != "video" ||
+		snapshot.Capacity != 2 || snapshot.Mode != scheduler.ModeRoundRobin {
+		t.Fatalf("PoolSnapshotFor(alpha) after add = %#v", snapshot)
+	}
+
+	changed := added
+	changed.Global.AgentPools = []globalconfig.AgentPool{{
+		Name:                "video",
+		MaxConcurrentAgents: 3,
+		Scheduling:          globalconfig.SchedulingStrict,
+	}}
+	if err := applyGlobalRuntimeConfig(gate, nil, nil, changed); err != nil {
+		t.Fatalf("change applyGlobalRuntimeConfig() error = %v", err)
+	}
+	if snapshot := gate.PoolSnapshotFor("alpha"); snapshot.Capacity != 3 || snapshot.Mode != scheduler.ModeStrictPriority {
+		t.Fatalf("PoolSnapshotFor(alpha) after change = %#v", snapshot)
+	}
+
+	removed := initial
+	if err := applyGlobalRuntimeConfig(gate, nil, nil, removed); err != nil {
+		t.Fatalf("remove applyGlobalRuntimeConfig() error = %v", err)
+	}
+	if snapshot := gate.PoolSnapshotFor("alpha"); snapshot.Name != scheduler.DefaultPoolName || snapshot.Capacity != 1 {
+		t.Fatalf("PoolSnapshotFor(alpha) after removal = %#v", snapshot)
+	}
+	if snapshots := gate.PoolSnapshots(); len(snapshots) != 1 {
+		t.Fatalf("PoolSnapshots() after removal = %#v, want default only", snapshots)
 	}
 }
 
@@ -367,9 +433,11 @@ func TestGlobalConfigReloaderHotAppliesLogLevel(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(&logs, &slog.HandlerOptions{Level: level}))
 	logger.Debug("before reload")
 
-	global := scheduler.NewWeightedFair(scheduler.Config{Capacity: 2})
-	gate := scheduler.NewGlobalDispatchGate(global)
 	next := reloadTestConfig("global.yaml", 2, nil)
+	gate, err := buildGlobalDispatchPools(next, nil)
+	if err != nil {
+		t.Fatalf("buildGlobalDispatchPools() error = %v", err)
+	}
 	next.LogLevel = "debug"
 	if err := applyGlobalRuntimeConfig(gate, nil, level, next); err != nil {
 		t.Fatalf("applyGlobalRuntimeConfig() error = %v", err)

--- a/internal/cli/update_runtime.go
+++ b/internal/cli/update_runtime.go
@@ -11,7 +11,6 @@ import (
 	"time"
 
 	"github.com/digitaldrywood/detent/internal/project"
-	"github.com/digitaldrywood/detent/internal/scheduler"
 	detentupdate "github.com/digitaldrywood/detent/internal/update"
 )
 
@@ -111,7 +110,11 @@ func runtimeUpdateIdle(ctx context.Context, registry *project.Registry) bool {
 	return true
 }
 
-func runtimeUpdateIdleReservation(ctx context.Context, registry *project.Registry, gate *scheduler.GlobalDispatchGate) (func(), bool) {
+type dispatchPauser interface {
+	PauseDispatch() func()
+}
+
+func runtimeUpdateIdleReservation(ctx context.Context, registry *project.Registry, gate dispatchPauser) (func(), bool) {
 	if gate == nil {
 		return nil, false
 	}

--- a/internal/cli/update_runtime_test.go
+++ b/internal/cli/update_runtime_test.go
@@ -24,7 +24,17 @@ func TestRuntimeUpdateIdleIsConservative(t *testing.T) {
 func TestRuntimeUpdateIdleReservationBlocksDispatch(t *testing.T) {
 	t.Parallel()
 
-	gate := scheduler.NewGlobalDispatchGate(scheduler.NewRoundRobin(scheduler.Config{Capacity: 1}))
+	candidates := []scheduler.ProjectCandidate{
+		{ID: "detent", Weight: 1},
+		{ID: "video", Pool: "video", Weight: 1},
+	}
+	gate, err := scheduler.NewPoolRegistry([]scheduler.PoolConfig{
+		{Name: scheduler.DefaultPoolName, Scheduler: scheduler.Config{Kind: "round_robin", Capacity: 1}},
+		{Name: "video", Scheduler: scheduler.Config{Kind: "round_robin", Capacity: 1}},
+	}, candidates)
+	if err != nil {
+		t.Fatalf("NewPoolRegistry() error = %v", err)
+	}
 	if release, ok := runtimeUpdateIdleReservation(context.Background(), nil, gate); ok || release != nil {
 		t.Fatalf("runtimeUpdateIdleReservation() with nil registry ok = %t release nil = %t, want false/true", ok, release == nil)
 	}
@@ -32,24 +42,27 @@ func TestRuntimeUpdateIdleReservationBlocksDispatch(t *testing.T) {
 	if !ok || release == nil {
 		t.Fatal("runtimeUpdateIdleReservation() did not reserve an idle runtime")
 	}
-	candidate := scheduler.ProjectCandidate{ID: "detent", Weight: 1}
 	request := scheduler.SlotRequest{State: "Todo"}
-	if _, acquired, decision, err := gate.TryAcquireWithDecision(context.Background(), candidate, request, time.Now()); err != nil {
-		t.Fatalf("TryAcquireWithDecision() while reserved error = %v", err)
-	} else if acquired || decision.Reason != scheduler.DispatchGateReasonPaused {
-		t.Fatalf("TryAcquireWithDecision() while reserved acquired = %t decision = %#v", acquired, decision)
+	for _, candidate := range candidates {
+		if _, acquired, decision, err := gate.TryAcquireWithDecision(context.Background(), candidate, request, time.Now()); err != nil {
+			t.Fatalf("TryAcquireWithDecision(%s) while reserved error = %v", candidate.ID, err)
+		} else if acquired || decision.Reason != scheduler.DispatchGateReasonPaused {
+			t.Fatalf("TryAcquireWithDecision(%s) while reserved acquired = %t decision = %#v", candidate.ID, acquired, decision)
+		}
 	}
 
 	release()
-	slot, acquired, err := gate.TryAcquire(context.Background(), candidate, request, time.Now())
-	if err != nil {
-		t.Fatalf("TryAcquire() after release error = %v", err)
-	}
-	if !acquired {
-		t.Fatal("TryAcquire() after release acquired = false, want true")
-	}
-	if err := gate.Release(slot); err != nil {
-		t.Fatalf("Release() error = %v", err)
+	for _, candidate := range candidates {
+		slot, acquired, err := gate.TryAcquire(context.Background(), candidate, request, time.Now())
+		if err != nil {
+			t.Fatalf("TryAcquire(%s) after release error = %v", candidate.ID, err)
+		}
+		if !acquired {
+			t.Fatalf("TryAcquire(%s) after release acquired = false, want true", candidate.ID)
+		}
+		if err := gate.Release(slot); err != nil {
+			t.Fatalf("Release(%s) error = %v", candidate.ID, err)
+		}
 	}
 }
 

--- a/internal/config/global/config.go
+++ b/internal/config/global/config.go
@@ -28,6 +28,7 @@ const (
 	SchedulingStrict                = "strict"
 	SchedulingRoundRobin            = "round_robin"
 	SchedulingFairShare             = "fair_share"
+	DefaultAgentPoolName            = "default"
 	DashboardAccessModePrivateToken = "private_token"
 
 	configFileMode = 0o600
@@ -108,14 +109,22 @@ func (u Update) NormalizedCheckIntervalHours() int {
 type Settings struct {
 	MaxConcurrentAgents int            `yaml:"max_concurrent_agents"`
 	Scheduling          string         `yaml:"scheduling"`
+	AgentPools          []AgentPool    `yaml:"agent_pools,omitempty"`
 	Identity            Identity       `yaml:"identity,omitempty"`
 	Knowledge           Knowledge      `yaml:"knowledge,omitempty"`
 	FairShare           map[string]any `yaml:"fair_share,omitempty"`
 	Startup             map[string]any `yaml:"startup,omitempty"`
 }
 
+type AgentPool struct {
+	Name                string `yaml:"name"`
+	MaxConcurrentAgents int    `yaml:"max_concurrent_agents"`
+	Scheduling          string `yaml:"scheduling,omitempty"`
+}
+
 type Project struct {
 	ID               string              `yaml:"id"`
+	Pool             string              `yaml:"pool,omitempty"`
 	Workflow         string              `yaml:"workflow"`
 	WorkflowRef      string              `yaml:"workflow_ref,omitempty"`
 	Workdir          string              `yaml:"workdir"`
@@ -396,16 +405,16 @@ func mergeYAMLMapping(existing *yaml.Node, desired *yaml.Node) {
 func mergeYAMLSequence(existing *yaml.Node, desired *yaml.Node) {
 	existingByID := make(map[string]*yaml.Node, len(existing.Content))
 	for _, item := range existing.Content {
-		if id := yamlMappingScalar(item, "id"); id != "" {
-			existingByID[id] = item
+		if key := yamlSequenceMappingKey(item); key != "" {
+			existingByID[key] = item
 		}
 	}
 
 	merged := make([]*yaml.Node, 0, len(desired.Content))
 	for index, desiredItem := range desired.Content {
 		var existingItem *yaml.Node
-		if id := yamlMappingScalar(desiredItem, "id"); id != "" {
-			existingItem = existingByID[id]
+		if key := yamlSequenceMappingKey(desiredItem); key != "" {
+			existingItem = existingByID[key]
 		} else if index < len(existing.Content) {
 			existingItem = existing.Content[index]
 		}
@@ -417,6 +426,15 @@ func mergeYAMLSequence(existing *yaml.Node, desired *yaml.Node) {
 		merged = append(merged, existingItem)
 	}
 	existing.Content = merged
+}
+
+func yamlSequenceMappingKey(node *yaml.Node) string {
+	for _, key := range []string{"id", "name"} {
+		if value := yamlMappingScalar(node, key); value != "" {
+			return key + ":" + value
+		}
+	}
+	return ""
 }
 
 func yamlMappingScalar(node *yaml.Node, key string) string {
@@ -618,6 +636,7 @@ func (c Config) Validate(opts ...Option) error {
 	if !validSchedulingMode(c.Global.Scheduling) {
 		problems = append(problems, "global.scheduling: must be one of "+strings.Join(schedulingModes, ", "))
 	}
+	problems = append(problems, agentPoolProblems(c.Global.AgentPools)...)
 	problems = append(problems, c.Global.Identity.Validate("global.identity")...)
 	problems = append(problems, startupErrors(c.Global.Startup, "global.startup")...)
 
@@ -653,6 +672,7 @@ func (c Config) Validate(opts ...Option) error {
 		problems = append(problems, project.Authorization.Validate(prefix+".authorization")...)
 	}
 	problems = append(problems, duplicateProjectIDErrorsFromProjects(c.Projects)...)
+	problems = append(problems, projectAgentPoolProblems(c.Global.AgentPools, c.Projects)...)
 
 	if len(problems) > 0 {
 		return ValidationError{Path: c.Path, Problems: problems}
@@ -975,7 +995,8 @@ func globalErrors(value any) []string {
 	var problems []string
 	problems = append(problems, prefixErrors(requiredErrors(global, []string{"max_concurrent_agents", "scheduling"}), "global")...)
 	problems = append(problems, positiveIntegerError(global["max_concurrent_agents"], "global.max_concurrent_agents")...)
-	problems = append(problems, schedulingErrors(global["scheduling"])...)
+	problems = append(problems, schedulingErrors(global["scheduling"], "global.scheduling")...)
+	problems = append(problems, agentPoolsErrors(global["agent_pools"])...)
 	problems = append(problems, optionalMapErrors(global, "identity")...)
 	problems = append(problems, identityErrors(global["identity"], "global.identity")...)
 	problems = append(problems, knowledgeErrors(global["knowledge"], "global.knowledge")...)
@@ -989,7 +1010,7 @@ func globalErrors(value any) []string {
 	return problems
 }
 
-func schedulingErrors(value any) []string {
+func schedulingErrors(value any, field string) []string {
 	if value == nil {
 		return nil
 	}
@@ -997,11 +1018,107 @@ func schedulingErrors(value any) []string {
 	if ok && validSchedulingMode(mode) {
 		return nil
 	}
-	return []string{"global.scheduling: must be one of " + strings.Join(schedulingModes, ", ")}
+	return []string{field + ": must be one of " + strings.Join(schedulingModes, ", ")}
 }
 
 func validSchedulingMode(mode string) bool {
 	return slices.Contains(schedulingModes, mode)
+}
+
+func agentPoolsErrors(value any) []string {
+	if value == nil {
+		return nil
+	}
+	pools, ok := value.([]any)
+	if !ok {
+		return []string{"global.agent_pools: must be a list"}
+	}
+
+	var problems []string
+	names := make(map[string]int, len(pools))
+	for index, value := range pools {
+		prefix := fmt.Sprintf("global.agent_pools[%d]", index)
+		pool, ok := value.(map[string]any)
+		if !ok {
+			problems = append(problems, prefix+": must be a mapping")
+			continue
+		}
+		problems = append(problems, prefixErrors(requiredErrors(pool, []string{"name", "max_concurrent_agents"}), prefix)...)
+		problems = append(problems, stringErrors(pool, "name", prefix)...)
+		problems = append(problems, positiveIntegerError(pool["max_concurrent_agents"], prefix+".max_concurrent_agents")...)
+		if scheduling, configured := pool["scheduling"]; configured {
+			problems = append(problems, schedulingErrors(scheduling, prefix+".scheduling")...)
+		}
+
+		name, ok := pool["name"].(string)
+		if !ok {
+			continue
+		}
+		name = strings.TrimSpace(name)
+		if name == "" {
+			continue
+		}
+		if name == DefaultAgentPoolName {
+			problems = append(problems, prefix+".name: "+DefaultAgentPoolName+" is reserved")
+		}
+		if previous, exists := names[name]; exists {
+			problems = append(problems, fmt.Sprintf("%s.name: duplicates global.agent_pools[%d].name %q", prefix, previous, name))
+			continue
+		}
+		names[name] = index
+	}
+	return problems
+}
+
+func agentPoolProblems(pools []AgentPool) []string {
+	var problems []string
+	names := make(map[string]int, len(pools))
+	for index, pool := range pools {
+		prefix := fmt.Sprintf("global.agent_pools[%d]", index)
+		name := strings.TrimSpace(pool.Name)
+		if name == "" {
+			problems = append(problems, prefix+".name: must not be blank")
+		} else if name == DefaultAgentPoolName {
+			problems = append(problems, prefix+".name: "+DefaultAgentPoolName+" is reserved")
+		} else if previous, exists := names[name]; exists {
+			problems = append(problems, fmt.Sprintf("%s.name: duplicates global.agent_pools[%d].name %q", prefix, previous, name))
+		} else {
+			names[name] = index
+		}
+		if pool.MaxConcurrentAgents <= 0 {
+			problems = append(problems, prefix+".max_concurrent_agents: must be a positive integer")
+		}
+		if pool.Scheduling != "" && !validSchedulingMode(pool.Scheduling) {
+			problems = append(problems, prefix+".scheduling: must be one of "+strings.Join(schedulingModes, ", "))
+		}
+	}
+	return problems
+}
+
+func projectAgentPoolProblems(pools []AgentPool, projects []Project) []string {
+	available := make(map[string]struct{}, len(pools)+1)
+	available[DefaultAgentPoolName] = struct{}{}
+	for _, pool := range pools {
+		available[strings.TrimSpace(pool.Name)] = struct{}{}
+	}
+
+	var problems []string
+	for index, project := range projects {
+		pool := strings.TrimSpace(project.Pool)
+		if pool == "" {
+			pool = DefaultAgentPoolName
+		}
+		if _, ok := available[pool]; ok {
+			continue
+		}
+		problems = append(problems, fmt.Sprintf(
+			"projects[%d].pool: project %q references undefined agent pool %q",
+			index,
+			strings.TrimSpace(project.ID),
+			pool,
+		))
+	}
+	return problems
 }
 
 func optionalMapErrors(attrs map[string]any, field string) []string {
@@ -1061,6 +1178,7 @@ func projectErrors(value any, index int, opts options) []string {
 	var problems []string
 	problems = append(problems, prefixErrors(requiredErrors(project, []string{"id", "workflow", "workdir", "weight", "priority"}), prefix)...)
 	problems = append(problems, stringErrors(project, "id", prefix)...)
+	problems = append(problems, stringErrors(project, "pool", prefix)...)
 	problems = append(problems, stringErrors(project, "workflow_ref", prefix)...)
 	problems = append(problems, singleLineStringErrors(project, "workflow_ref", prefix)...)
 	problems = append(problems, projectColorErrors(project, prefix)...)
@@ -1702,14 +1820,55 @@ func buildSettings(attrs map[string]any, opts options) (Settings, error) {
 	if err != nil {
 		return Settings{}, err
 	}
+	agentPools, err := buildAgentPools(attrs["agent_pools"])
+	if err != nil {
+		return Settings{}, err
+	}
 
 	settings.MaxConcurrentAgents = maxConcurrentAgents
 	settings.Scheduling = scheduling
+	settings.AgentPools = agentPools
 	settings.Identity = identity
 	settings.Knowledge = knowledge
 	settings.FairShare = fairShare
 	settings.Startup = startup
 	return settings, nil
+}
+
+func buildAgentPools(value any) ([]AgentPool, error) {
+	if value == nil {
+		return nil, nil
+	}
+	items, err := listValue(value, "global.agent_pools")
+	if err != nil {
+		return nil, err
+	}
+	pools := make([]AgentPool, 0, len(items))
+	for index, item := range items {
+		prefix := fmt.Sprintf("global.agent_pools[%d]", index)
+		pool, err := mapValue(item, prefix)
+		if err != nil {
+			return nil, err
+		}
+		name, err := stringValue(pool["name"], prefix+".name")
+		if err != nil {
+			return nil, err
+		}
+		capacity, err := intValue(pool["max_concurrent_agents"], prefix+".max_concurrent_agents")
+		if err != nil {
+			return nil, err
+		}
+		scheduling, err := optionalString(pool["scheduling"], prefix+".scheduling")
+		if err != nil {
+			return nil, err
+		}
+		pools = append(pools, AgentPool{
+			Name:                strings.TrimSpace(name),
+			MaxConcurrentAgents: capacity,
+			Scheduling:          scheduling,
+		})
+	}
+	return pools, nil
 }
 
 func buildProjects(projects []any, opts options) ([]Project, error) {
@@ -1764,6 +1923,10 @@ func buildProjects(projects []any, opts options) ([]Project, error) {
 		if err != nil {
 			return nil, err
 		}
+		pool, err := optionalString(project["pool"], prefix+".pool")
+		if err != nil {
+			return nil, err
+		}
 		weight, err := intValue(project["weight"], prefix+".weight")
 		if err != nil {
 			return nil, err
@@ -1805,6 +1968,7 @@ func buildProjects(projects []any, opts options) ([]Project, error) {
 
 		out = append(out, Project{
 			ID:               strings.TrimSpace(id),
+			Pool:             pool,
 			Workflow:         strings.TrimSpace(workflow),
 			WorkflowRef:      strings.TrimSpace(workflowRef),
 			Workdir:          workdir,

--- a/internal/config/global/config.go
+++ b/internal/config/global/config.go
@@ -403,18 +403,27 @@ func mergeYAMLMapping(existing *yaml.Node, desired *yaml.Node) {
 }
 
 func mergeYAMLSequence(existing *yaml.Node, desired *yaml.Node) {
-	existingByID := make(map[string]*yaml.Node, len(existing.Content))
+	existingByKey := make(map[string]*yaml.Node, len(existing.Content))
+	existingKeyCounts := make(map[string]int, len(existing.Content))
 	for _, item := range existing.Content {
 		if key := yamlSequenceMappingKey(item); key != "" {
-			existingByID[key] = item
+			existingByKey[key] = item
+			existingKeyCounts[key]++
+		}
+	}
+	desiredKeyCounts := make(map[string]int, len(desired.Content))
+	for _, item := range desired.Content {
+		if key := yamlSequenceMappingKey(item); key != "" {
+			desiredKeyCounts[key]++
 		}
 	}
 
 	merged := make([]*yaml.Node, 0, len(desired.Content))
 	for index, desiredItem := range desired.Content {
 		var existingItem *yaml.Node
-		if key := yamlSequenceMappingKey(desiredItem); key != "" {
-			existingItem = existingByID[key]
+		key := yamlSequenceMappingKey(desiredItem)
+		if key != "" && existingKeyCounts[key] == 1 && desiredKeyCounts[key] == 1 {
+			existingItem = existingByKey[key]
 		} else if index < len(existing.Content) {
 			existingItem = existing.Content[index]
 		}

--- a/internal/config/global/config_test.go
+++ b/internal/config/global/config_test.go
@@ -449,8 +449,12 @@ func TestWriteRoundTripsConfig(t *testing.T) {
 		Global: Settings{
 			MaxConcurrentAgents: 3,
 			Scheduling:          SchedulingStrict,
-			FairShare:           map[string]any{"half_life": "30m"},
-			Startup:             map[string]any{"jitter_seconds": 0, "max_spawn_per_second": 1},
+			AgentPools: []AgentPool{
+				{Name: "code", MaxConcurrentAgents: 5},
+				{Name: "video", MaxConcurrentAgents: 10, Scheduling: SchedulingRoundRobin},
+			},
+			FairShare: map[string]any{"half_life": "30m"},
+			Startup:   map[string]any{"jitter_seconds": 0, "max_spawn_per_second": 1},
 			Identity: Identity{
 				Name:          "release-captain",
 				GitHubLogin:   "detent-bot",
@@ -461,6 +465,7 @@ func TestWriteRoundTripsConfig(t *testing.T) {
 		Projects: []Project{
 			{
 				ID:               "detent",
+				Pool:             "code",
 				Workflow:         paths.workflowPath,
 				Workdir:          paths.workdirPath,
 				Color:            "#1192e8",
@@ -949,6 +954,149 @@ func TestReadAcceptsSchedulingModes(t *testing.T) {
 				t.Fatalf("Global.Scheduling = %q, want %q", cfg.Global.Scheduling, mode)
 			}
 		})
+	}
+}
+
+func TestReadParsesAgentPools(t *testing.T) {
+	paths := createProjectFiles(t)
+	configPath := filepath.Join(paths.root, "global.yaml")
+	raw := strings.Replace(
+		validYAML(paths, map[string]string{"scheduling": SchedulingStrict}),
+		"  scheduling: strict\n",
+		`  scheduling: strict
+  agent_pools:
+    - name: code
+      max_concurrent_agents: 5
+    - name: video
+      max_concurrent_agents: 10
+      scheduling: round_robin
+`,
+		1,
+	)
+	raw = strings.Replace(raw, `  - id: " detent "`+"\n", `  - id: " detent "
+    pool: video
+`, 1)
+	writeFile(t, configPath, raw)
+
+	cfg, err := Read(configPath, WithHome(paths.home))
+	if err != nil {
+		t.Fatalf("Read() error = %v", err)
+	}
+	wantPools := []AgentPool{
+		{Name: "code", MaxConcurrentAgents: 5},
+		{Name: "video", MaxConcurrentAgents: 10, Scheduling: SchedulingRoundRobin},
+	}
+	if !reflect.DeepEqual(cfg.Global.AgentPools, wantPools) {
+		t.Fatalf("Global.AgentPools = %#v, want %#v", cfg.Global.AgentPools, wantPools)
+	}
+	if cfg.Projects[0].Pool != "video" {
+		t.Fatalf("Projects[0].Pool = %q, want video", cfg.Projects[0].Pool)
+	}
+}
+
+func TestReadReportsAgentPoolValidationErrors(t *testing.T) {
+	paths := createProjectFiles(t)
+	base := validYAML(paths, nil)
+	withPools := func(pools string) string {
+		return strings.Replace(base, "  scheduling: weighted\n", "  scheduling: weighted\n"+pools, 1)
+	}
+	withProjectPool := func(raw string, pool string) string {
+		return strings.Replace(raw, `  - id: " detent "`+"\n", `  - id: " detent "
+    pool: `+pool+`
+`, 1)
+	}
+
+	tests := []struct {
+		name string
+		raw  string
+		want string
+	}{
+		{
+			name: "duplicate name",
+			raw: withPools(`  agent_pools:
+    - name: code
+      max_concurrent_agents: 1
+    - name: code
+      max_concurrent_agents: 2
+`),
+			want: `global.agent_pools[1].name: duplicates global.agent_pools[0].name "code"`,
+		},
+		{
+			name: "blank name",
+			raw: withPools(`  agent_pools:
+    - name: "  "
+      max_concurrent_agents: 1
+`),
+			want: "global.agent_pools[0].name: must not be blank",
+		},
+		{
+			name: "reserved default",
+			raw: withPools(`  agent_pools:
+    - name: default
+      max_concurrent_agents: 1
+`),
+			want: "global.agent_pools[0].name: default is reserved",
+		},
+		{
+			name: "missing capacity",
+			raw: withPools(`  agent_pools:
+    - name: code
+`),
+			want: "global.agent_pools[0].max_concurrent_agents: is required",
+		},
+		{
+			name: "nonpositive capacity",
+			raw: withPools(`  agent_pools:
+    - name: code
+      max_concurrent_agents: 0
+`),
+			want: "global.agent_pools[0].max_concurrent_agents: must be a positive integer",
+		},
+		{
+			name: "invalid scheduling",
+			raw: withPools(`  agent_pools:
+    - name: code
+      max_concurrent_agents: 1
+      scheduling: random
+`),
+			want: "global.agent_pools[0].scheduling: must be one of weighted, strict, round_robin, fair_share",
+		},
+		{
+			name: "undefined project pool",
+			raw: withProjectPool(withPools(`  agent_pools:
+    - name: code
+      max_concurrent_agents: 1
+`), "video"),
+			want: `projects[0].pool: project "detent" references undefined agent pool "video"`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			configPath := filepath.Join(paths.root, strings.ReplaceAll(tt.name, " ", "-")+".yaml")
+			writeFile(t, configPath, tt.raw)
+			_, err := Read(configPath, WithHome(paths.home))
+			if err == nil || !strings.Contains(err.Error(), tt.want) {
+				t.Fatalf("Read() error = %v, want containing %q", err, tt.want)
+			}
+		})
+	}
+}
+
+func TestReadWithoutAgentPoolsPreservesLegacyDefaults(t *testing.T) {
+	paths := createProjectFiles(t)
+	configPath := filepath.Join(paths.root, "global.yaml")
+	writeFile(t, configPath, validYAML(paths, nil))
+
+	cfg, err := Read(configPath, WithHome(paths.home))
+	if err != nil {
+		t.Fatalf("Read() error = %v", err)
+	}
+	if cfg.Global.AgentPools != nil {
+		t.Fatalf("Global.AgentPools = %#v, want nil", cfg.Global.AgentPools)
+	}
+	if cfg.Projects[0].Pool != "" {
+		t.Fatalf("Projects[0].Pool = %q, want empty legacy value", cfg.Projects[0].Pool)
 	}
 }
 

--- a/internal/config/global/config_test.go
+++ b/internal/config/global/config_test.go
@@ -577,6 +577,93 @@ update:
 	}
 }
 
+func TestWritePreservesDuplicateKnowledgeSourceNames(t *testing.T) {
+	paths := createProjectFiles(t)
+	path := filepath.Join(paths.root, "global.yaml")
+	writeFile(t, path, `apiVersion: detent/v1
+kind: GlobalConfig
+global:
+  max_concurrent_agents: 8
+  scheduling: weighted
+  knowledge:
+    sources:
+      - name: Standards
+        path: `+filepath.Join(paths.root, "first.md")+`
+      - name: Standards
+        path: `+filepath.Join(paths.root, "second.md")+`
+projects:
+  - id: detent
+    workflow: `+paths.workflow+`
+    workdir: `+paths.workdir+`
+    weight: 1
+    priority: 0
+`)
+
+	cfg, err := Read(path, WithHome(paths.home))
+	if err != nil {
+		t.Fatalf("Read() error = %v", err)
+	}
+	if err := Write(path, cfg, WithHome(paths.home)); err != nil {
+		t.Fatalf("Write() error = %v", err)
+	}
+	roundTripped, err := Read(path, WithHome(paths.home))
+	if err != nil {
+		t.Fatalf("second Read() error = %v", err)
+	}
+	sources := roundTripped.Global.Knowledge.Sources
+	if len(sources) != 2 || sources[0].Path != filepath.Join(paths.root, "first.md") ||
+		sources[1].Path != filepath.Join(paths.root, "second.md") {
+		t.Fatalf("knowledge sources = %#v, want distinct duplicate-name entries", sources)
+	}
+}
+
+func TestWriteMatchesAgentPoolsByName(t *testing.T) {
+	paths := createProjectFiles(t)
+	path := filepath.Join(paths.root, "global.yaml")
+	writeFile(t, path, `apiVersion: detent/v1
+kind: GlobalConfig
+global:
+  max_concurrent_agents: 8
+  scheduling: weighted
+  agent_pools:
+    - name: code
+      # Code pool.
+      max_concurrent_agents: 1
+    - name: video
+      # Video pool.
+      max_concurrent_agents: 2
+projects:
+  - id: detent
+    pool: code
+    workflow: `+paths.workflow+`
+    workdir: `+paths.workdir+`
+    weight: 1
+    priority: 0
+`)
+
+	cfg, err := Read(path, WithHome(paths.home))
+	if err != nil {
+		t.Fatalf("Read() error = %v", err)
+	}
+	cfg.Global.AgentPools[0], cfg.Global.AgentPools[1] = cfg.Global.AgentPools[1], cfg.Global.AgentPools[0]
+	if err := Write(path, cfg, WithHome(paths.home)); err != nil {
+		t.Fatalf("Write() error = %v", err)
+	}
+	written, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile() error = %v", err)
+	}
+	text := string(written)
+	videoIndex := strings.Index(text, "- name: video")
+	codeIndex := strings.Index(text, "- name: code")
+	videoComment := strings.Index(text, "# Video pool.")
+	codeComment := strings.Index(text, "# Code pool.")
+	if videoIndex < 0 || codeIndex < 0 || videoComment < videoIndex || videoComment > codeIndex ||
+		codeIndex < videoIndex || codeComment < codeIndex {
+		t.Fatalf("agent pool comments did not follow names:\n%s", text)
+	}
+}
+
 func TestParsePauseMetadataValidatesExitConditions(t *testing.T) {
 	paths := createProjectFiles(t)
 	base := minimalYAML(paths, "  max_concurrent_agents: 8\n  scheduling: weighted\n")

--- a/internal/orchestrator/autopromote_tick.go
+++ b/internal/orchestrator/autopromote_tick.go
@@ -1005,6 +1005,7 @@ func mergeWorkerSlotDecisionAttrs(
 	attrs := mergeWorkerLogAttrs(issue,
 		"state", strings.TrimSpace(issue.State),
 		"reason", reason,
+		"pool", strings.TrimSpace(decision.PoolName),
 		"global_capacity", decision.GlobalCapacity,
 		"global_used", decision.GlobalUsed,
 		"global_available", decision.GlobalAvailable,

--- a/internal/orchestrator/diagnostics.go
+++ b/internal/orchestrator/diagnostics.go
@@ -69,6 +69,7 @@ func (o *Orchestrator) logSchedulerSlotDecision(issue connector.Issue, outcome s
 		"outcome", strings.TrimSpace(outcome),
 		"reason", reason,
 		"project_id", strings.TrimSpace(o.cfg.Project.ID),
+		"pool", strings.TrimSpace(decision.PoolName),
 		"project_weight", o.cfg.Project.Weight,
 		"project_priority", o.cfg.Project.Priority,
 		"global_capacity", decision.GlobalCapacity,
@@ -97,26 +98,19 @@ func (o *Orchestrator) logWorkerLifecycle(issue connector.Issue, event string, a
 
 func (o *Orchestrator) schedulerDecisionAttrs(state *State, now time.Time, issue connector.Issue, attrs ...any) []any {
 	projectStats := o.projectStateSlotStats(issue, state)
-	globalCapacity := o.cfg.MaxConcurrentAgents
-	globalUsed := 0
-	if state != nil {
-		globalUsed = len(state.Running)
-	}
-	globalAvailable := globalCapacity - globalUsed
-	if globalAvailable < 0 {
-		globalAvailable = 0
-	}
+	pool := o.dispatchPoolSnapshot()
 	all := o.issueLogAttrs(issue,
 		"lane", normalizeState(issue.State),
 		"project_id", strings.TrimSpace(o.cfg.Project.ID),
+		"pool", pool.Name,
 		"project_weight", o.cfg.Project.Weight,
 		"project_priority", o.cfg.Project.Priority,
 		"project_state_capacity", projectStats.capacity,
 		"project_state_used", projectStats.used,
 		"project_state_available", projectStats.available,
-		"global_capacity", globalCapacity,
-		"global_used", globalUsed,
-		"global_available", globalAvailable,
+		"global_capacity", pool.Capacity,
+		"global_used", pool.Used,
+		"global_available", pool.Available,
 	)
 	all = append(all, snapshotAgeAttrs(issue, now)...)
 	all = append(all, pullRequestDiagnosticAttrs(issue, now)...)

--- a/internal/orchestrator/dispatch.go
+++ b/internal/orchestrator/dispatch.go
@@ -614,7 +614,10 @@ func (o *Orchestrator) acquireGlobalDispatchSlot(
 	now time.Time,
 ) (scheduler.Slot, bool, scheduler.DispatchGateDecision) {
 	if o.globalDispatchGate == nil {
-		return scheduler.Slot{}, true, scheduler.DispatchGateDecision{Reason: scheduler.DispatchGateReasonGranted}
+		return scheduler.Slot{}, true, scheduler.DispatchGateDecision{
+			PoolName: scheduler.DefaultPoolName,
+			Reason:   scheduler.DispatchGateReasonGranted,
+		}
 	}
 
 	req := scheduler.SlotRequest{
@@ -643,6 +646,33 @@ func (o *Orchestrator) acquireGlobalDispatchSlot(
 		return scheduler.Slot{}, false, decision
 	}
 	return slot, ok, decision
+}
+
+func (o *Orchestrator) dispatchPoolSnapshot() scheduler.PoolSnapshot {
+	if o == nil {
+		return scheduler.PoolSnapshot{Name: scheduler.DefaultPoolName}
+	}
+	fallback := scheduler.PoolSnapshot{
+		Name:      scheduler.DefaultPoolName,
+		Capacity:  o.cfg.MaxConcurrentAgents,
+		Available: o.cfg.MaxConcurrentAgents,
+	}
+	if o.globalDispatchGate == nil {
+		return fallback
+	}
+	if snapshotter, ok := o.globalDispatchGate.(scheduler.ProjectPoolSnapshotter); ok {
+		snapshot := snapshotter.PoolSnapshotFor(o.cfg.Project.ID)
+		if snapshot.Capacity > 0 {
+			return snapshot
+		}
+	}
+	if snapshotter, ok := o.globalDispatchGate.(scheduler.PoolSnapshotter); ok {
+		snapshot := snapshotter.PoolSnapshot()
+		if snapshot.Capacity > 0 {
+			return snapshot
+		}
+	}
+	return fallback
 }
 
 func (o *Orchestrator) dispatchStatePriority(state string) int {

--- a/internal/orchestrator/dispatch_recovery.go
+++ b/internal/orchestrator/dispatch_recovery.go
@@ -27,7 +27,11 @@ type DispatchRecovery struct {
 	Admissions map[string]bool
 }
 
-func dispatchRecoverySnapshots(recoveries map[string]DispatchRecovery, maxConcurrent int) []telemetry.DispatchRecovery {
+func dispatchRecoverySnapshots(
+	recoveries map[string]DispatchRecovery,
+	pool string,
+	maxConcurrent int,
+) []telemetry.DispatchRecovery {
 	rows := make([]telemetry.DispatchRecovery, 0, len(recoveries))
 	for _, key := range sortedKeys(recoveries) {
 		recovery := recoveries[key]
@@ -38,6 +42,7 @@ func dispatchRecoverySnapshots(recoveries map[string]DispatchRecovery, maxConcur
 			}
 		}
 		rows = append(rows, telemetry.DispatchRecovery{
+			Pool:          strings.TrimSpace(pool),
 			Kind:          recovery.Kind,
 			Reason:        recovery.Reason,
 			Status:        recovery.Status,
@@ -52,10 +57,15 @@ func dispatchRecoverySnapshots(recoveries map[string]DispatchRecovery, maxConcur
 	return rows
 }
 
-func dispatchRecoveriesCapacitySnapshot(recoveries map[string]DispatchRecovery, maxConcurrent int) []map[string]any {
+func dispatchRecoveriesCapacitySnapshot(
+	recoveries map[string]DispatchRecovery,
+	pool string,
+	maxConcurrent int,
+) []map[string]any {
 	rows := make([]map[string]any, 0, len(recoveries))
-	for _, recovery := range dispatchRecoverySnapshots(recoveries, maxConcurrent) {
+	for _, recovery := range dispatchRecoverySnapshots(recoveries, pool, maxConcurrent) {
 		rows = append(rows, map[string]any{
+			"pool":           recovery.Pool,
 			"kind":           recovery.Kind,
 			"reason":         recovery.Reason,
 			"status":         recovery.Status,

--- a/internal/orchestrator/dispatch_recovery_test.go
+++ b/internal/orchestrator/dispatch_recovery_test.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/digitaldrywood/detent/internal/connector"
+	"github.com/digitaldrywood/detent/internal/scheduler"
 )
 
 func TestDispatchRecoveryRampBoundsDispatchUntilProgress(t *testing.T) {
@@ -62,6 +63,43 @@ func TestDispatchRecoveryRampBoundsDispatchUntilProgress(t *testing.T) {
 	}
 	if recoveries, ok := capacity["dispatch_recoveries"].([]any); !ok || len(recoveries) != 1 {
 		t.Fatalf("dispatch_recoveries = %#v, want one durable recovery record", capacity["dispatch_recoveries"])
+	}
+}
+
+func TestDispatchRecoveryTelemetryUsesAgentPoolCapacity(t *testing.T) {
+	t.Parallel()
+
+	project := scheduler.ProjectCandidate{ID: "detent", Pool: "video"}
+	gate, err := scheduler.NewPoolRegistry([]scheduler.PoolConfig{
+		{Name: scheduler.DefaultPoolName, Scheduler: scheduler.Config{Kind: "weighted", Capacity: 1}},
+		{Name: "video", Scheduler: scheduler.Config{Kind: "weighted", Capacity: 5}},
+	}, []scheduler.ProjectCandidate{project})
+	if err != nil {
+		t.Fatalf("NewPoolRegistry() error = %v", err)
+	}
+	cfg := normalizeConfig(Config{MaxConcurrentAgents: 2, Project: project})
+	orch := &Orchestrator{cfg: cfg, globalDispatchGate: gate}
+	state := newState(cfg)
+	pool := orch.dispatchPoolSnapshot()
+	state.PoolName = pool.Name
+	state.PoolCapacity = pool.Capacity
+	orch.activateDispatchRecovery(&state, dispatchRecoveryGitHubREST, "REST quota recovered", time.Now(), "")
+
+	snapshot := state.Snapshot(time.Now())
+	if len(snapshot.DispatchRecoveries) != 1 {
+		t.Fatalf("DispatchRecoveries = %#v, want one", snapshot.DispatchRecoveries)
+	}
+	recovery := snapshot.DispatchRecoveries[0]
+	if recovery.Pool != "video" || recovery.MaxConcurrent != 5 {
+		t.Fatalf("DispatchRecoveries[0] = %#v, want video pool capacity 5", recovery)
+	}
+
+	var capacity map[string]any
+	if err := json.Unmarshal([]byte(orch.capacitySnapshotJSON(&state, connector.Issue{State: "Todo"})), &capacity); err != nil {
+		t.Fatalf("capacitySnapshotJSON() error = %v", err)
+	}
+	if capacity["pool"] != "video" || capacity["pool_capacity"] != float64(5) {
+		t.Fatalf("capacity snapshot = %#v, want video pool capacity 5", capacity)
 	}
 }
 

--- a/internal/orchestrator/dispatch_test.go
+++ b/internal/orchestrator/dispatch_test.go
@@ -2086,6 +2086,7 @@ func TestDispatchReadyIssuesLogsMergeSlotDecisionAndStopsAfterGlobalWait(t *test
 	}
 	for _, fragment := range []string{
 		"reason=global_capacity_full",
+		"pool=default",
 		"global_capacity=1",
 		"global_used=1",
 		"global_available=0",

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -662,6 +662,9 @@ func (o *Orchestrator) State(ctx context.Context) (State, error) {
 	case <-o.done:
 		return State{}, ErrStopped
 	case state := <-request.reply:
+		pool := o.dispatchPoolSnapshot()
+		state.PoolName = pool.Name
+		state.PoolCapacity = pool.Capacity
 		return state, nil
 	}
 }

--- a/internal/orchestrator/orchestrator_test.go
+++ b/internal/orchestrator/orchestrator_test.go
@@ -1023,6 +1023,55 @@ func TestUpdateConfigAppliesBeforeNextTick(t *testing.T) {
 	close(runner.release)
 }
 
+func TestStateReportsLiveAgentPoolCapacity(t *testing.T) {
+	t.Parallel()
+
+	project := scheduler.ProjectCandidate{ID: "detent", Pool: "video"}
+	pools := []scheduler.PoolConfig{
+		{Name: scheduler.DefaultPoolName, Scheduler: scheduler.Config{Kind: "weighted", Capacity: 1}},
+		{Name: "video", Scheduler: scheduler.Config{Kind: "weighted", Capacity: 5}},
+	}
+	dispatch, err := scheduler.NewPoolRegistry(pools, []scheduler.ProjectCandidate{project})
+	if err != nil {
+		t.Fatalf("NewPoolRegistry() error = %v", err)
+	}
+	orch, err := orchestrator.New(orchestrator.Config{
+		PollInterval:        time.Hour,
+		MaxConcurrentAgents: 2,
+		ActiveStates:        []string{"Todo"},
+		TerminalStates:      []string{"Done"},
+		Project:             project,
+	}, orchestrator.Dependencies{
+		Connector:          newFakeConnector(),
+		GlobalDispatchGate: dispatch,
+	})
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	stop := runOrchestrator(t, orch)
+	defer stop()
+
+	state, err := orch.State(context.Background())
+	if err != nil {
+		t.Fatalf("State() error = %v", err)
+	}
+	if state.PoolName != "video" || state.PoolCapacity != 5 {
+		t.Fatalf("State() pool = %q/%d, want video/5", state.PoolName, state.PoolCapacity)
+	}
+
+	pools[1].Scheduler.Capacity = 7
+	if err := dispatch.Reconfigure(pools, []scheduler.ProjectCandidate{project}); err != nil {
+		t.Fatalf("Reconfigure() error = %v", err)
+	}
+	state, err = orch.State(context.Background())
+	if err != nil {
+		t.Fatalf("State() after reconfigure error = %v", err)
+	}
+	if state.PoolCapacity != 7 {
+		t.Fatalf("State().PoolCapacity after reconfigure = %d, want 7", state.PoolCapacity)
+	}
+}
+
 func TestUpdateRuntimeSwapsConnectorBeforeNextTick(t *testing.T) {
 	t.Parallel()
 

--- a/internal/orchestrator/snapshot.go
+++ b/internal/orchestrator/snapshot.go
@@ -29,6 +29,10 @@ const (
 // for publishing to the web dashboard. Slices are sorted by issue id so the
 // output is deterministic.
 func (s State) Snapshot(now time.Time) telemetry.Snapshot {
+	poolCapacity := s.PoolCapacity
+	if poolCapacity <= 0 {
+		poolCapacity = s.MaxConcurrentAgents
+	}
 	staleAfter := refreshStaleAfter(s.PollInterval)
 	sources := refreshSourceSnapshots(s.RefreshSources)
 	refresh := telemetry.Refresh{
@@ -98,7 +102,7 @@ func (s State) Snapshot(now time.Time) telemetry.Snapshot {
 		RateLimits:              cloneRateLimits(s.RateLimits),
 		BackendOutages:          backendOutageSnapshots(s.BackendOutages),
 		FailureBreakers:         projectFailureBreakerSnapshots(s.FailureBreaker),
-		DispatchRecoveries:      dispatchRecoverySnapshots(s.DispatchRecoveries, s.MaxConcurrentAgents),
+		DispatchRecoveries:      dispatchRecoverySnapshots(s.DispatchRecoveries, s.PoolName, poolCapacity),
 		OverloadRetriesLastHour: overloadRetriesLastHour(s.WorkAttempts, now),
 		Tokens:                  tokensFromTokenTotals(s.liveTokenTotals()),
 		Budget: telemetry.Budget{

--- a/internal/orchestrator/state.go
+++ b/internal/orchestrator/state.go
@@ -23,6 +23,8 @@ import (
 type State struct {
 	PollInterval             time.Duration
 	MaxConcurrentAgents      int
+	PoolName                 string
+	PoolCapacity             int
 	AutoPromoteQuietDuration time.Duration
 	AutoPromote              AutoPromoteConfig
 	ActiveStates             []string
@@ -287,6 +289,8 @@ func (s State) clone() State {
 	cloned := State{
 		PollInterval:             s.PollInterval,
 		MaxConcurrentAgents:      s.MaxConcurrentAgents,
+		PoolName:                 s.PoolName,
+		PoolCapacity:             s.PoolCapacity,
 		AutoPromoteQuietDuration: s.AutoPromoteQuietDuration,
 		AutoPromote:              cloneAutoPromoteConfig(s.AutoPromote),
 		ActiveStates:             append([]string(nil), s.ActiveStates...),

--- a/internal/orchestrator/work_attempts.go
+++ b/internal/orchestrator/work_attempts.go
@@ -740,21 +740,15 @@ func telemetrySchedulerDecision(decision store.SchedulerDecision) telemetry.Sche
 
 func (o *Orchestrator) capacitySnapshotJSON(state *State, issue connector.Issue) string {
 	projectStats := o.projectStateSlotStats(issue, state)
-	globalCapacity := o.cfg.MaxConcurrentAgents
-	globalUsed := 0
-	if state != nil {
-		globalUsed = len(state.Running)
-	}
-	globalAvailable := globalCapacity - globalUsed
-	if globalAvailable < 0 {
-		globalAvailable = 0
-	}
+	pool := o.dispatchPoolSnapshot()
 	snapshot := map[string]any{
 		"project_id":              strings.TrimSpace(o.cfg.Project.ID),
+		"pool":                    pool.Name,
+		"pool_capacity":           pool.Capacity,
 		"lane":                    normalizeState(issue.State),
-		"global_capacity":         globalCapacity,
-		"global_used":             globalUsed,
-		"global_available":        globalAvailable,
+		"global_capacity":         pool.Capacity,
+		"global_used":             pool.Used,
+		"global_available":        pool.Available,
 		"project_state_capacity":  projectStats.capacity,
 		"project_state_used":      projectStats.used,
 		"project_state_available": projectStats.available,
@@ -763,7 +757,7 @@ func (o *Orchestrator) capacitySnapshotJSON(state *State, issue connector.Issue)
 		snapshot["backend_outages"] = backendOutagesCapacitySnapshot(state.BackendOutages)
 	}
 	if state != nil && len(state.DispatchRecoveries) > 0 {
-		snapshot["dispatch_recoveries"] = dispatchRecoveriesCapacitySnapshot(state.DispatchRecoveries, o.cfg.MaxConcurrentAgents)
+		snapshot["dispatch_recoveries"] = dispatchRecoveriesCapacitySnapshot(state.DispatchRecoveries, pool.Name, pool.Capacity)
 	}
 	if state != nil && state.FailureBreaker.Active() {
 		snapshot["project_failure_breaker"] = map[string]any{

--- a/internal/project/project.go
+++ b/internal/project/project.go
@@ -1279,6 +1279,7 @@ func projectOrchestratorConfig(project globalconfig.Project, workflow workflowco
 	cfg := orchestrator.ConfigFromWorkflow(workflow)
 	cfg.Project = scheduler.ProjectCandidate{
 		ID:       project.ID,
+		Pool:     project.Pool,
 		Weight:   project.Weight,
 		Priority: project.Priority,
 		Paused:   project.Paused,

--- a/internal/project/project_test.go
+++ b/internal/project/project_test.go
@@ -46,6 +46,7 @@ func TestNewBuildsProjectLifecycleDependencies(t *testing.T) {
 	got, err := project.New(project.Config{
 		Project: globalconfig.Project{
 			ID:       "detent",
+			Pool:     "code",
 			Workflow: "workflow.md",
 			Workdir:  "/workspace/detent",
 			Weight:   2,
@@ -110,8 +111,9 @@ func TestNewBuildsProjectLifecycleDependencies(t *testing.T) {
 		if len(cfg.Authorization.And) != 2 {
 			t.Fatalf("Authorization.And = %#v, want workflow and project selectors", cfg.Authorization.And)
 		}
-		if cfg.Project.ID != "detent" || cfg.Project.Weight != 2 || cfg.Project.Priority != 10 {
-			t.Fatalf("orchestrator Project = %#v, want detent weight 2 priority 10", cfg.Project)
+		if cfg.Project.ID != "detent" || cfg.Project.Pool != "code" ||
+			cfg.Project.Weight != 2 || cfg.Project.Priority != 10 {
+			t.Fatalf("orchestrator Project = %#v, want detent in code pool with weight 2 priority 10", cfg.Project)
 		}
 	case <-time.After(time.Second):
 		t.Fatal("timed out waiting for orchestrator factory")

--- a/internal/scheduler/global.go
+++ b/internal/scheduler/global.go
@@ -29,6 +29,7 @@ type GlobalScheduler interface {
 
 type ProjectCandidate struct {
 	ID       string
+	Pool     string
 	Weight   int
 	Priority int
 	Paused   bool
@@ -409,6 +410,7 @@ func normalizeProjectCandidates(projects []ProjectCandidate) []ProjectCandidate 
 			continue
 		}
 		seen[project.ID] = struct{}{}
+		project.Pool = normalizePoolName(project.Pool)
 		project.Weight = normalizeProjectWeight(project.Weight)
 		candidates = append(candidates, project)
 	}
@@ -417,6 +419,14 @@ func normalizeProjectCandidates(projects []ProjectCandidate) []ProjectCandidate 
 
 func normalizeProjectID(projectID string) string {
 	return strings.TrimSpace(projectID)
+}
+
+func normalizePoolName(pool string) string {
+	pool = strings.TrimSpace(pool)
+	if pool == "" {
+		return DefaultPoolName
+	}
+	return pool
 }
 
 func normalizeProjectWeight(weight int) int {

--- a/internal/scheduler/global_gate.go
+++ b/internal/scheduler/global_gate.go
@@ -27,6 +27,7 @@ type ProjectDispatchGate interface {
 
 type DispatchGateDecision struct {
 	ProjectID            string
+	PoolName             string
 	State                string
 	SelectedProjectID    string
 	SelectedState        string
@@ -65,7 +66,8 @@ type projectCycleState struct {
 }
 
 type GlobalDispatchGate struct {
-	global GlobalScheduler
+	poolName string
+	global   GlobalScheduler
 
 	mu             sync.Mutex
 	ready          map[string]readyProjectSlot
@@ -78,7 +80,12 @@ type GlobalDispatchGate struct {
 }
 
 func NewGlobalDispatchGate(global GlobalScheduler, projects ...ProjectCandidate) *GlobalDispatchGate {
+	return newGlobalDispatchGate(DefaultPoolName, global, projects...)
+}
+
+func newGlobalDispatchGate(poolName string, global GlobalScheduler, projects ...ProjectCandidate) *GlobalDispatchGate {
 	gate := &GlobalDispatchGate{
+		poolName:      normalizePoolName(poolName),
 		global:        global,
 		ready:         map[string]readyProjectSlot{},
 		running:       map[uint64]runningProjectSlot{},
@@ -89,6 +96,23 @@ func NewGlobalDispatchGate(global GlobalScheduler, projects ...ProjectCandidate)
 	}
 	gate.SetProjects(projects)
 	return gate
+}
+
+func (g *GlobalDispatchGate) PoolSnapshot() PoolSnapshot {
+	if g == nil || g.global == nil {
+		return PoolSnapshot{Name: DefaultPoolName}
+	}
+	g.mu.Lock()
+	defer g.mu.Unlock()
+
+	stats := g.capacitySnapshotLocked("")
+	return PoolSnapshot{
+		Name:      g.poolName,
+		Capacity:  stats.globalCapacity,
+		Used:      stats.globalUsed,
+		Available: nonNegativeInt(stats.globalCapacity - stats.globalUsed),
+		Mode:      g.global.Mode(),
+	}
 }
 
 func (g *GlobalDispatchGate) SetProjects(projects []ProjectCandidate) {
@@ -253,7 +277,10 @@ func (g *GlobalDispatchGate) TryAcquireWithDecision(
 	now time.Time,
 ) (Slot, bool, DispatchGateDecision, error) {
 	if g == nil || g.global == nil {
-		return Slot{}, true, DispatchGateDecision{Reason: DispatchGateReasonGranted}, nil
+		return Slot{}, true, DispatchGateDecision{
+			PoolName: DefaultPoolName,
+			Reason:   DispatchGateReasonGranted,
+		}, nil
 	}
 	if ctx == nil {
 		ctx = context.Background()
@@ -557,6 +584,7 @@ func (g *GlobalDispatchGate) decisionLocked(projectID string, req SlotRequest, r
 
 	return DispatchGateDecision{
 		ProjectID:            projectID,
+		PoolName:             g.poolName,
 		State:                req.State,
 		SelectedProjectID:    selectedProjectID,
 		SelectedState:        selectedState,

--- a/internal/scheduler/pool_registry.go
+++ b/internal/scheduler/pool_registry.go
@@ -1,0 +1,494 @@
+package scheduler
+
+import (
+	"context"
+	"fmt"
+	"slices"
+	"strings"
+	"sync"
+	"time"
+)
+
+const DefaultPoolName = "default"
+
+type PoolConfig struct {
+	Name      string
+	Scheduler Config
+}
+
+type PoolSnapshot struct {
+	Name       string
+	Capacity   int
+	Used       int
+	Available  int
+	Mode       Mode
+	Draining   bool
+	Generation uint64
+}
+
+type PoolSnapshotter interface {
+	PoolSnapshot() PoolSnapshot
+}
+
+type ProjectPoolSnapshotter interface {
+	PoolSnapshotFor(string) PoolSnapshot
+}
+
+type poolRuntime struct {
+	name       string
+	generation uint64
+	gate       *GlobalDispatchGate
+	retired    bool
+}
+
+type poolPause struct {
+	releases map[uint64]func()
+}
+
+type PoolRegistry struct {
+	reconfigureMu sync.Mutex
+
+	mu             sync.RWMutex
+	active         map[string]*poolRuntime
+	byGeneration   map[uint64]*poolRuntime
+	projectPools   map[string]string
+	pauses         map[uint64]poolPause
+	nextGeneration uint64
+	nextPause      uint64
+}
+
+var _ ProjectDispatchGate = (*PoolRegistry)(nil)
+
+func NewPoolRegistry(pools []PoolConfig, projects []ProjectCandidate) (*PoolRegistry, error) {
+	registry := &PoolRegistry{
+		active:       map[string]*poolRuntime{},
+		byGeneration: map[uint64]*poolRuntime{},
+		projectPools: map[string]string{},
+		pauses:       map[uint64]poolPause{},
+	}
+	if err := registry.Reconfigure(pools, projects); err != nil {
+		return nil, err
+	}
+	return registry, nil
+}
+
+func (r *PoolRegistry) GateFor(projectID string) ProjectDispatchGate {
+	return &projectPoolGate{
+		registry:  r,
+		projectID: normalizeProjectID(projectID),
+	}
+}
+
+func (r *PoolRegistry) SetProjects(projects []ProjectCandidate) {
+	if r == nil {
+		return
+	}
+	r.reconfigureMu.Lock()
+	defer r.reconfigureMu.Unlock()
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.setProjectsLocked(projects)
+}
+
+func (r *PoolRegistry) Reconfigure(pools []PoolConfig, projects []ProjectCandidate) error {
+	if r == nil {
+		return nil
+	}
+	configs, err := normalizePoolConfigs(pools)
+	if err != nil {
+		return err
+	}
+
+	r.reconfigureMu.Lock()
+	defer r.reconfigureMu.Unlock()
+
+	r.mu.RLock()
+	current := make(map[string]*poolRuntime, len(r.active))
+	for name, runtime := range r.active {
+		current[name] = runtime
+	}
+	r.mu.RUnlock()
+
+	next := make(map[string]*poolRuntime, len(configs))
+	for name, cfg := range configs {
+		if runtime, ok := current[name]; ok {
+			if err := runtime.gate.Reconfigure(cfg.Scheduler); err != nil {
+				return fmt.Errorf("reconfigure agent pool %q: %w", name, err)
+			}
+			next[name] = runtime
+			continue
+		}
+		runtime, err := newPoolRuntime(cfg)
+		if err != nil {
+			return err
+		}
+		next[name] = runtime
+	}
+
+	r.mu.Lock()
+	for name, runtime := range current {
+		if _, ok := next[name]; ok {
+			continue
+		}
+		runtime.retired = true
+		runtime.gate.SetProjects(nil)
+		_ = runtime.gate.PauseDispatch()
+	}
+	for _, runtime := range next {
+		if runtime.generation != 0 {
+			continue
+		}
+		r.nextGeneration++
+		if r.nextGeneration == 0 {
+			r.nextGeneration++
+		}
+		runtime.generation = r.nextGeneration
+		r.byGeneration[runtime.generation] = runtime
+		for pauseID, pause := range r.pauses {
+			pause.releases[runtime.generation] = runtime.gate.PauseDispatch()
+			r.pauses[pauseID] = pause
+		}
+	}
+	r.active = next
+	r.setProjectsLocked(projects)
+	r.cleanupRetiredLocked()
+	r.mu.Unlock()
+	return nil
+}
+
+func (r *PoolRegistry) PauseDispatch() func() {
+	if r == nil {
+		return func() {}
+	}
+
+	r.mu.Lock()
+	r.nextPause++
+	if r.nextPause == 0 {
+		r.nextPause++
+	}
+	pauseID := r.nextPause
+	pause := poolPause{releases: make(map[uint64]func(), len(r.byGeneration))}
+	for generation, runtime := range r.byGeneration {
+		pause.releases[generation] = runtime.gate.PauseDispatch()
+	}
+	r.pauses[pauseID] = pause
+	r.mu.Unlock()
+
+	var once sync.Once
+	return func() {
+		once.Do(func() {
+			r.mu.Lock()
+			pause, ok := r.pauses[pauseID]
+			if ok {
+				delete(r.pauses, pauseID)
+			}
+			r.mu.Unlock()
+			if !ok {
+				return
+			}
+			for _, release := range pause.releases {
+				release()
+			}
+			r.cleanupRetired()
+		})
+	}
+}
+
+func (r *PoolRegistry) PoolSnapshotFor(projectID string) PoolSnapshot {
+	runtime := r.runtimeForProject(projectID)
+	if runtime == nil {
+		return PoolSnapshot{Name: DefaultPoolName}
+	}
+	snapshot := runtime.gate.PoolSnapshot()
+	r.mu.RLock()
+	snapshot.Draining = runtime.retired
+	snapshot.Generation = runtime.generation
+	r.mu.RUnlock()
+	return snapshot
+}
+
+func (r *PoolRegistry) PoolSnapshots() []PoolSnapshot {
+	if r == nil {
+		return nil
+	}
+	r.mu.RLock()
+	snapshots := make([]PoolSnapshot, 0, len(r.byGeneration))
+	for _, runtime := range r.byGeneration {
+		snapshot := runtime.gate.PoolSnapshot()
+		snapshot.Draining = runtime.retired
+		snapshot.Generation = runtime.generation
+		snapshots = append(snapshots, snapshot)
+	}
+	r.mu.RUnlock()
+	slices.SortFunc(snapshots, func(left PoolSnapshot, right PoolSnapshot) int {
+		if compared := strings.Compare(left.Name, right.Name); compared != 0 {
+			return compared
+		}
+		switch {
+		case left.Generation < right.Generation:
+			return -1
+		case left.Generation > right.Generation:
+			return 1
+		default:
+			return 0
+		}
+	})
+	return snapshots
+}
+
+func (r *PoolRegistry) MarkReady(project ProjectCandidate) {
+	runtime := r.runtimeForCandidate(project)
+	if runtime != nil {
+		runtime.gate.MarkReady(project)
+	}
+}
+
+func (r *PoolRegistry) MarkIdle(projectID string) {
+	runtime := r.runtimeForProject(projectID)
+	if runtime != nil {
+		runtime.gate.MarkIdle(projectID)
+	}
+}
+
+func (r *PoolRegistry) BeginProjectCycle(project ProjectCandidate) {
+	runtime := r.runtimeForCandidate(project)
+	if runtime != nil {
+		runtime.gate.BeginProjectCycle(project)
+	}
+}
+
+func (r *PoolRegistry) EndProjectCycle(projectID string) {
+	runtime := r.runtimeForProject(projectID)
+	if runtime != nil {
+		runtime.gate.EndProjectCycle(projectID)
+	}
+}
+
+func (r *PoolRegistry) TryAcquire(
+	ctx context.Context,
+	project ProjectCandidate,
+	req SlotRequest,
+	now time.Time,
+) (Slot, bool, error) {
+	slot, ok, _, err := r.TryAcquireWithDecision(ctx, project, req, now)
+	return slot, ok, err
+}
+
+func (r *PoolRegistry) TryAcquireWithDecision(
+	ctx context.Context,
+	project ProjectCandidate,
+	req SlotRequest,
+	now time.Time,
+) (Slot, bool, DispatchGateDecision, error) {
+	runtime := r.runtimeForCandidate(project)
+	if runtime == nil {
+		return Slot{}, false, DispatchGateDecision{}, ErrNoCandidates
+	}
+	slot, ok, decision, err := runtime.gate.TryAcquireWithDecision(ctx, project, req, now)
+	if !ok || err != nil {
+		return slot, ok, decision, err
+	}
+	slot.poolName = runtime.name
+	slot.poolGeneration = runtime.generation
+	return slot, true, decision, nil
+}
+
+func (r *PoolRegistry) SetPreempt(slot Slot, preempt func()) {
+	runtime := r.runtimeForSlot(slot)
+	if runtime != nil {
+		runtime.gate.SetPreempt(slot, preempt)
+	}
+}
+
+func (r *PoolRegistry) Release(slot Slot) error {
+	runtime := r.runtimeForSlot(slot)
+	if runtime == nil {
+		return ErrSlotNotHeld
+	}
+	if err := runtime.gate.Release(slot); err != nil {
+		return err
+	}
+	r.cleanupRetired()
+	return nil
+}
+
+func (r *PoolRegistry) setProjectsLocked(projects []ProjectCandidate) {
+	normalized := normalizeProjectCandidates(projects)
+	projectPools := make(map[string]string, len(normalized))
+	grouped := make(map[string][]ProjectCandidate, len(r.active))
+	for _, project := range normalized {
+		pool := project.Pool
+		if _, ok := r.active[pool]; !ok {
+			pool = DefaultPoolName
+			project.Pool = pool
+		}
+		projectPools[project.ID] = pool
+		grouped[pool] = append(grouped[pool], project)
+	}
+	for name, runtime := range r.active {
+		runtime.gate.SetProjects(grouped[name])
+	}
+	r.projectPools = projectPools
+}
+
+func (r *PoolRegistry) runtimeForCandidate(project ProjectCandidate) *poolRuntime {
+	projectID := normalizeProjectID(project.ID)
+	r.mu.RLock()
+	pool := r.projectPools[projectID]
+	if pool == "" {
+		pool = normalizePoolName(project.Pool)
+	}
+	runtime := r.active[pool]
+	if runtime == nil {
+		runtime = r.active[DefaultPoolName]
+	}
+	r.mu.RUnlock()
+	return runtime
+}
+
+func (r *PoolRegistry) runtimeForProject(projectID string) *poolRuntime {
+	projectID = normalizeProjectID(projectID)
+	r.mu.RLock()
+	pool := r.projectPools[projectID]
+	if pool == "" {
+		pool = DefaultPoolName
+	}
+	runtime := r.active[pool]
+	if runtime == nil {
+		runtime = r.active[DefaultPoolName]
+	}
+	r.mu.RUnlock()
+	return runtime
+}
+
+func (r *PoolRegistry) runtimeForSlot(slot Slot) *poolRuntime {
+	if r == nil {
+		return nil
+	}
+	r.mu.RLock()
+	runtime := r.byGeneration[slot.poolGeneration]
+	if runtime == nil && slot.poolName != "" {
+		runtime = r.active[slot.poolName]
+	}
+	r.mu.RUnlock()
+	return runtime
+}
+
+func (r *PoolRegistry) cleanupRetired() {
+	if r == nil {
+		return
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.cleanupRetiredLocked()
+}
+
+func (r *PoolRegistry) cleanupRetiredLocked() {
+	for generation, runtime := range r.byGeneration {
+		if !runtime.retired || runtime.gate.PoolSnapshot().Used > 0 {
+			continue
+		}
+		delete(r.byGeneration, generation)
+	}
+}
+
+func normalizePoolConfigs(pools []PoolConfig) (map[string]PoolConfig, error) {
+	configs := make(map[string]PoolConfig, len(pools))
+	for index, pool := range pools {
+		name := strings.TrimSpace(pool.Name)
+		if name == "" {
+			return nil, fmt.Errorf("agent pool %d name is required", index)
+		}
+		if _, exists := configs[name]; exists {
+			return nil, fmt.Errorf("agent pool %q is duplicated", name)
+		}
+		if pool.Scheduler.Capacity <= 0 {
+			return nil, fmt.Errorf("agent pool %q capacity must be positive", name)
+		}
+		if _, err := globalModeFromConfig(pool.Scheduler); err != nil {
+			return nil, fmt.Errorf("configure agent pool %q: %w", name, err)
+		}
+		pool.Name = name
+		configs[name] = pool
+	}
+	if _, ok := configs[DefaultPoolName]; !ok {
+		return nil, fmt.Errorf("agent pool %q is required", DefaultPoolName)
+	}
+	return configs, nil
+}
+
+func newPoolRuntime(cfg PoolConfig) (*poolRuntime, error) {
+	sched, err := NewFromConfig(cfg.Scheduler)
+	if err != nil {
+		return nil, fmt.Errorf("create agent pool %q: %w", cfg.Name, err)
+	}
+	global, ok := sched.(GlobalScheduler)
+	if !ok {
+		return nil, fmt.Errorf("create agent pool %q: %w", cfg.Name, ErrUnsupportedBackend)
+	}
+	return &poolRuntime{
+		name: cfg.Name,
+		gate: newGlobalDispatchGate(cfg.Name, global),
+	}, nil
+}
+
+type projectPoolGate struct {
+	registry  *PoolRegistry
+	projectID string
+}
+
+var _ ProjectDispatchGate = (*projectPoolGate)(nil)
+
+func (g *projectPoolGate) PoolSnapshot() PoolSnapshot {
+	if g == nil || g.registry == nil {
+		return PoolSnapshot{Name: DefaultPoolName}
+	}
+	return g.registry.PoolSnapshotFor(g.projectID)
+}
+
+func (g *projectPoolGate) MarkReady(project ProjectCandidate) {
+	project.ID = g.projectID
+	g.registry.MarkReady(project)
+}
+
+func (g *projectPoolGate) MarkIdle(string) {
+	g.registry.MarkIdle(g.projectID)
+}
+
+func (g *projectPoolGate) BeginProjectCycle(project ProjectCandidate) {
+	project.ID = g.projectID
+	g.registry.BeginProjectCycle(project)
+}
+
+func (g *projectPoolGate) EndProjectCycle(string) {
+	g.registry.EndProjectCycle(g.projectID)
+}
+
+func (g *projectPoolGate) TryAcquire(
+	ctx context.Context,
+	project ProjectCandidate,
+	req SlotRequest,
+	now time.Time,
+) (Slot, bool, error) {
+	project.ID = g.projectID
+	return g.registry.TryAcquire(ctx, project, req, now)
+}
+
+func (g *projectPoolGate) TryAcquireWithDecision(
+	ctx context.Context,
+	project ProjectCandidate,
+	req SlotRequest,
+	now time.Time,
+) (Slot, bool, DispatchGateDecision, error) {
+	project.ID = g.projectID
+	return g.registry.TryAcquireWithDecision(ctx, project, req, now)
+}
+
+func (g *projectPoolGate) SetPreempt(slot Slot, preempt func()) {
+	g.registry.SetPreempt(slot, preempt)
+}
+
+func (g *projectPoolGate) Release(slot Slot) error {
+	return g.registry.Release(slot)
+}

--- a/internal/scheduler/pool_registry.go
+++ b/internal/scheduler/pool_registry.go
@@ -238,6 +238,9 @@ func (r *PoolRegistry) PoolSnapshots() []PoolSnapshot {
 }
 
 func (r *PoolRegistry) MarkReady(project ProjectCandidate) {
+	r.reconfigureMu.Lock()
+	defer r.reconfigureMu.Unlock()
+
 	runtime := r.runtimeForCandidate(project)
 	if runtime != nil {
 		runtime.gate.MarkReady(project)
@@ -245,6 +248,9 @@ func (r *PoolRegistry) MarkReady(project ProjectCandidate) {
 }
 
 func (r *PoolRegistry) MarkIdle(projectID string) {
+	r.reconfigureMu.Lock()
+	defer r.reconfigureMu.Unlock()
+
 	runtime := r.runtimeForProject(projectID)
 	if runtime != nil {
 		runtime.gate.MarkIdle(projectID)
@@ -252,6 +258,9 @@ func (r *PoolRegistry) MarkIdle(projectID string) {
 }
 
 func (r *PoolRegistry) BeginProjectCycle(project ProjectCandidate) {
+	r.reconfigureMu.Lock()
+	defer r.reconfigureMu.Unlock()
+
 	runtime := r.runtimeForCandidate(project)
 	if runtime != nil {
 		runtime.gate.BeginProjectCycle(project)
@@ -259,6 +268,9 @@ func (r *PoolRegistry) BeginProjectCycle(project ProjectCandidate) {
 }
 
 func (r *PoolRegistry) EndProjectCycle(projectID string) {
+	r.reconfigureMu.Lock()
+	defer r.reconfigureMu.Unlock()
+
 	runtime := r.runtimeForProject(projectID)
 	if runtime != nil {
 		runtime.gate.EndProjectCycle(projectID)
@@ -281,6 +293,9 @@ func (r *PoolRegistry) TryAcquireWithDecision(
 	req SlotRequest,
 	now time.Time,
 ) (Slot, bool, DispatchGateDecision, error) {
+	r.reconfigureMu.Lock()
+	defer r.reconfigureMu.Unlock()
+
 	runtime := r.runtimeForCandidate(project)
 	if runtime == nil {
 		return Slot{}, false, DispatchGateDecision{}, ErrNoCandidates

--- a/internal/scheduler/pool_registry_concurrency_test.go
+++ b/internal/scheduler/pool_registry_concurrency_test.go
@@ -1,0 +1,74 @@
+package scheduler
+
+import (
+	"runtime"
+	"testing"
+	"time"
+)
+
+func TestPoolRegistrySerializesReadyRouteWithReconfigure(t *testing.T) {
+	t.Parallel()
+
+	project := ProjectCandidate{ID: "worker", Pool: "code"}
+	registry, err := NewPoolRegistry([]PoolConfig{
+		{Name: DefaultPoolName, Scheduler: Config{Kind: "weighted", Capacity: 1}},
+		{Name: "code", Scheduler: Config{Kind: "weighted", Capacity: 1}},
+		{Name: "video", Scheduler: Config{Kind: "weighted", Capacity: 1}},
+	}, []ProjectCandidate{project})
+	if err != nil {
+		t.Fatalf("NewPoolRegistry() error = %v", err)
+	}
+	if registry == nil {
+		t.Fatal("NewPoolRegistry() = nil")
+		return
+	}
+	oldRuntime, ok := registry.active["code"]
+	if !ok || oldRuntime == nil || oldRuntime.gate == nil {
+		t.Fatalf("code pool runtime = %#v, want configured gate", oldRuntime)
+		return
+	}
+	oldRuntime.gate.mu.Lock()
+
+	readyDone := make(chan struct{})
+	go func() {
+		defer close(readyDone)
+		registry.MarkReady(project)
+	}()
+
+	deadline := time.Now().Add(time.Second)
+	for registry.reconfigureMu.TryLock() {
+		registry.reconfigureMu.Unlock()
+		if time.Now().After(deadline) {
+			oldRuntime.gate.mu.Unlock()
+			<-readyDone
+			t.Fatal("MarkReady() did not lock routing")
+		}
+		runtime.Gosched()
+	}
+
+	reconfigureDone := make(chan error, 1)
+	go func() {
+		reconfigureDone <- registry.Reconfigure([]PoolConfig{
+			{Name: DefaultPoolName, Scheduler: Config{Kind: "weighted", Capacity: 1}},
+			{Name: "code", Scheduler: Config{Kind: "weighted", Capacity: 1}},
+			{Name: "video", Scheduler: Config{Kind: "weighted", Capacity: 1}},
+		}, []ProjectCandidate{{ID: project.ID, Pool: "video"}})
+	}()
+
+	oldRuntime.gate.mu.Unlock()
+	<-readyDone
+	if err := <-reconfigureDone; err != nil {
+		t.Fatalf("Reconfigure() error = %v", err)
+	}
+
+	oldRuntime.gate.mu.Lock()
+	_, ready := oldRuntime.gate.ready[project.ID]
+	_, configured := oldRuntime.gate.projects[project.ID]
+	oldRuntime.gate.mu.Unlock()
+	if ready || configured {
+		t.Fatalf("old pool retained project after reassignment: ready=%t configured=%t", ready, configured)
+	}
+	if snapshot := registry.PoolSnapshotFor(project.ID); snapshot.Name != "video" {
+		t.Fatalf("PoolSnapshotFor() = %#v, want video", snapshot)
+	}
+}

--- a/internal/scheduler/pool_registry_test.go
+++ b/internal/scheduler/pool_registry_test.go
@@ -1,0 +1,486 @@
+package scheduler_test
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/digitaldrywood/detent/internal/scheduler"
+	"github.com/digitaldrywood/detent/internal/store"
+)
+
+func TestPoolRegistryGrantsIndependentCapacity(t *testing.T) {
+	t.Parallel()
+
+	registry := newPoolRegistry(t,
+		[]scheduler.PoolConfig{
+			poolConfig(scheduler.DefaultPoolName, "round_robin", 1, nil),
+			poolConfig("video", "round_robin", 2, nil),
+		},
+		[]scheduler.ProjectCandidate{
+			{ID: "code", Pool: scheduler.DefaultPoolName},
+			{ID: "video-a", Pool: "video"},
+			{ID: "video-b", Pool: "video"},
+		},
+	)
+	now := time.Date(2026, 7, 27, 12, 0, 0, 0, time.UTC)
+	slots := acquirePoolSlots(t, registry, now,
+		scheduler.ProjectCandidate{ID: "code"},
+		scheduler.ProjectCandidate{ID: "video-a"},
+		scheduler.ProjectCandidate{ID: "video-b"},
+	)
+	if snapshots := registry.PoolSnapshots(); len(snapshots) != 2 ||
+		snapshots[0].Used+snapshots[1].Used != 3 {
+		t.Fatalf("PoolSnapshots() = %#v, want three slots used across two pools", snapshots)
+	}
+	releasePoolSlots(t, registry, slots)
+}
+
+func TestPoolRegistryScopesSchedulingState(t *testing.T) {
+	t.Parallel()
+
+	for _, mode := range []string{"weighted", "round_robin"} {
+		t.Run(mode, func(t *testing.T) {
+			t.Parallel()
+			registry := newPoolRegistry(t,
+				[]scheduler.PoolConfig{
+					poolConfig(scheduler.DefaultPoolName, mode, 1, nil),
+					poolConfig("video", mode, 1, nil),
+				},
+				[]scheduler.ProjectCandidate{
+					{ID: "alpha", Pool: scheduler.DefaultPoolName},
+					{ID: "zulu", Pool: "video"},
+				},
+			)
+			registry.MarkReady(scheduler.ProjectCandidate{ID: "zulu", Pool: "video"})
+			slot, ok, decision, err := registry.TryAcquireWithDecision(
+				context.Background(),
+				scheduler.ProjectCandidate{ID: "alpha"},
+				scheduler.SlotRequest{State: "Todo"},
+				time.Time{},
+			)
+			if err != nil {
+				t.Fatalf("TryAcquireWithDecision() error = %v", err)
+			}
+			if !ok || decision.PoolName != scheduler.DefaultPoolName {
+				t.Fatalf("TryAcquireWithDecision() ok = %t decision = %#v, want default pool grant", ok, decision)
+			}
+			if err := registry.Release(slot); err != nil {
+				t.Fatalf("Release() error = %v", err)
+			}
+		})
+	}
+}
+
+func TestPoolRegistryStrictPreemptionDoesNotCrossPools(t *testing.T) {
+	t.Parallel()
+
+	registry := newPoolRegistry(t,
+		[]scheduler.PoolConfig{
+			poolConfig(scheduler.DefaultPoolName, "strict", 1, nil),
+			poolConfig("video", "strict", 1, nil),
+		},
+		[]scheduler.ProjectCandidate{
+			{ID: "code-low", Priority: 4},
+			{ID: "code-urgent", Priority: 0},
+			{ID: "video-low", Pool: "video", Priority: 4},
+		},
+	)
+	registry.MarkIdle("code-urgent")
+	codeSlot := acquirePoolSlots(t, registry, time.Time{}, scheduler.ProjectCandidate{ID: "code-low", Priority: 4})[0]
+	videoSlot := acquirePoolSlots(t, registry, time.Time{}, scheduler.ProjectCandidate{ID: "video-low", Priority: 4})[0]
+	codePreemptions := 0
+	videoPreemptions := 0
+	registry.SetPreempt(codeSlot, func() { codePreemptions++ })
+	registry.SetPreempt(videoSlot, func() { videoPreemptions++ })
+
+	urgentSlot := acquirePoolSlots(t, registry, time.Time{}, scheduler.ProjectCandidate{ID: "code-urgent", Priority: 0})[0]
+	if codePreemptions != 1 || videoPreemptions != 0 {
+		t.Fatalf("preemptions code/video = %d/%d, want 1/0", codePreemptions, videoPreemptions)
+	}
+	releasePoolSlots(t, registry, []scheduler.Slot{urgentSlot, videoSlot})
+}
+
+func TestPoolRegistryFairShareIgnoresOtherPoolHistory(t *testing.T) {
+	t.Parallel()
+
+	usage := &fairShareStore{usage: []store.FairShareUsage{
+		{ProjectID: "alpha", Dispatches: 5},
+		{ProjectID: "beta", Dispatches: 10},
+		{ProjectID: "video", Dispatches: 0},
+	}}
+	registry := newPoolRegistry(t,
+		[]scheduler.PoolConfig{
+			poolConfig(scheduler.DefaultPoolName, "fair_share", 1, usage),
+			poolConfig("video", "fair_share", 1, usage),
+		},
+		[]scheduler.ProjectCandidate{
+			{ID: "alpha"},
+			{ID: "beta"},
+			{ID: "video", Pool: "video"},
+		},
+	)
+	registry.MarkReady(scheduler.ProjectCandidate{ID: "alpha"})
+	registry.MarkReady(scheduler.ProjectCandidate{ID: "beta"})
+	registry.MarkReady(scheduler.ProjectCandidate{ID: "video", Pool: "video"})
+
+	slot, ok, decision, err := registry.TryAcquireWithDecision(
+		context.Background(),
+		scheduler.ProjectCandidate{ID: "alpha"},
+		scheduler.SlotRequest{State: "Todo"},
+		time.Time{},
+	)
+	if err != nil {
+		t.Fatalf("TryAcquireWithDecision() error = %v", err)
+	}
+	if !ok || decision.SelectedProjectID != "alpha" {
+		t.Fatalf("TryAcquireWithDecision() ok = %t decision = %#v, want alpha", ok, decision)
+	}
+	if err := registry.Release(slot); err != nil {
+		t.Fatalf("Release() error = %v", err)
+	}
+}
+
+func TestPoolRegistryReconfigureDrainsLoweredCapacity(t *testing.T) {
+	t.Parallel()
+
+	projects := []scheduler.ProjectCandidate{{ID: "video-a", Pool: "video"}, {ID: "video-b", Pool: "video"}}
+	registry := newPoolRegistry(t,
+		[]scheduler.PoolConfig{
+			poolConfig(scheduler.DefaultPoolName, "weighted", 1, nil),
+			poolConfig("video", "weighted", 2, nil),
+		},
+		projects,
+	)
+	slots := acquirePoolSlots(t, registry, time.Time{}, projects...)
+	if err := registry.Reconfigure([]scheduler.PoolConfig{
+		poolConfig(scheduler.DefaultPoolName, "weighted", 1, nil),
+		poolConfig("video", "weighted", 1, nil),
+	}, projects); err != nil {
+		t.Fatalf("Reconfigure() error = %v", err)
+	}
+	assertPoolUnavailable(t, registry, projects[0])
+	if snapshot := registry.PoolSnapshotFor("video-a"); snapshot.Capacity != 1 || snapshot.Used != 2 {
+		t.Fatalf("PoolSnapshotFor(video-a) = %#v, want capacity 1 used 2", snapshot)
+	}
+	if err := registry.Release(slots[0]); err != nil {
+		t.Fatalf("Release(first) error = %v", err)
+	}
+	assertPoolUnavailable(t, registry, projects[0])
+	if err := registry.Release(slots[1]); err != nil {
+		t.Fatalf("Release(second) error = %v", err)
+	}
+	slot := acquirePoolSlots(t, registry, time.Time{}, projects[0])[0]
+	releasePoolSlots(t, registry, []scheduler.Slot{slot})
+}
+
+func TestPoolRegistryRemovedPoolDrainsAcrossReplacementGeneration(t *testing.T) {
+	t.Parallel()
+
+	video := scheduler.ProjectCandidate{ID: "video", Pool: "video"}
+	registry := newPoolRegistry(t,
+		[]scheduler.PoolConfig{
+			poolConfig(scheduler.DefaultPoolName, "weighted", 1, nil),
+			poolConfig("video", "weighted", 1, nil),
+		},
+		[]scheduler.ProjectCandidate{video},
+	)
+	oldSlot := acquirePoolSlots(t, registry, time.Time{}, video)[0]
+
+	reassigned := scheduler.ProjectCandidate{ID: "video"}
+	if err := registry.Reconfigure(
+		[]scheduler.PoolConfig{poolConfig(scheduler.DefaultPoolName, "weighted", 1, nil)},
+		[]scheduler.ProjectCandidate{reassigned},
+	); err != nil {
+		t.Fatalf("remove Reconfigure() error = %v", err)
+	}
+	defaultSlot := acquirePoolSlots(t, registry, time.Time{}, reassigned)[0]
+	if snapshots := registry.PoolSnapshots(); len(snapshots) != 2 || !snapshots[1].Draining {
+		t.Fatalf("PoolSnapshots() after removal = %#v, want active default and draining video", snapshots)
+	}
+
+	if err := registry.Reconfigure(
+		[]scheduler.PoolConfig{
+			poolConfig(scheduler.DefaultPoolName, "weighted", 1, nil),
+			poolConfig("video", "weighted", 1, nil),
+		},
+		[]scheduler.ProjectCandidate{video},
+	); err != nil {
+		t.Fatalf("re-add Reconfigure() error = %v", err)
+	}
+	newSlot := acquirePoolSlots(t, registry, time.Time{}, video)[0]
+	if snapshots := registry.PoolSnapshots(); len(snapshots) != 3 {
+		t.Fatalf("PoolSnapshots() with replacement = %#v, want three pool generations", snapshots)
+	}
+	if err := registry.Release(oldSlot); err != nil {
+		t.Fatalf("Release(oldSlot) error = %v", err)
+	}
+	if snapshots := registry.PoolSnapshots(); len(snapshots) != 2 {
+		t.Fatalf("PoolSnapshots() after drain = %#v, want two active pools", snapshots)
+	}
+	releasePoolSlots(t, registry, []scheduler.Slot{defaultSlot, newSlot})
+}
+
+func TestPoolRegistryPauseIncludesPoolsAddedWhilePaused(t *testing.T) {
+	t.Parallel()
+
+	registry := newPoolRegistry(t,
+		[]scheduler.PoolConfig{poolConfig(scheduler.DefaultPoolName, "weighted", 1, nil)},
+		[]scheduler.ProjectCandidate{{ID: "code"}},
+	)
+	resume := registry.PauseDispatch()
+	if err := registry.Reconfigure(
+		[]scheduler.PoolConfig{
+			poolConfig(scheduler.DefaultPoolName, "weighted", 1, nil),
+			poolConfig("video", "weighted", 1, nil),
+		},
+		[]scheduler.ProjectCandidate{{ID: "code"}, {ID: "video", Pool: "video"}},
+	); err != nil {
+		t.Fatalf("Reconfigure() error = %v", err)
+	}
+	assertPoolPaused(t, registry, scheduler.ProjectCandidate{ID: "code"})
+	assertPoolPaused(t, registry, scheduler.ProjectCandidate{ID: "video"})
+	resume()
+	resume()
+	slots := acquirePoolSlots(t, registry, time.Time{},
+		scheduler.ProjectCandidate{ID: "code"},
+		scheduler.ProjectCandidate{ID: "video"},
+	)
+	releasePoolSlots(t, registry, slots)
+}
+
+func TestPoolRegistryUsesDefaultPoolForLegacyProjects(t *testing.T) {
+	t.Parallel()
+
+	registry := newPoolRegistry(t,
+		[]scheduler.PoolConfig{poolConfig(scheduler.DefaultPoolName, "strict", 1, nil)},
+		[]scheduler.ProjectCandidate{{ID: "legacy"}},
+	)
+	gate := registry.GateFor("legacy")
+	detailed, ok := gate.(interface {
+		TryAcquireWithDecision(context.Context, scheduler.ProjectCandidate, scheduler.SlotRequest, time.Time) (
+			scheduler.Slot,
+			bool,
+			scheduler.DispatchGateDecision,
+			error,
+		)
+	})
+	if !ok {
+		t.Fatalf("GateFor() type = %T, want detailed gate", gate)
+	}
+	slot, acquired, decision, err := detailed.TryAcquireWithDecision(
+		context.Background(),
+		scheduler.ProjectCandidate{},
+		scheduler.SlotRequest{State: "Todo"},
+		time.Time{},
+	)
+	if err != nil {
+		t.Fatalf("TryAcquireWithDecision() error = %v", err)
+	}
+	if !acquired || decision.PoolName != scheduler.DefaultPoolName ||
+		decision.GlobalCapacity != 1 || registry.PoolSnapshotFor("legacy").Mode != scheduler.ModeStrictPriority {
+		t.Fatalf("legacy decision = %#v snapshot = %#v", decision, registry.PoolSnapshotFor("legacy"))
+	}
+	if err := gate.Release(slot); err != nil {
+		t.Fatalf("Release() error = %v", err)
+	}
+}
+
+func TestProjectPoolGateRoutesLifecycleToCurrentPool(t *testing.T) {
+	t.Parallel()
+
+	project := scheduler.ProjectCandidate{ID: "video", Pool: "video"}
+	registry := newPoolRegistry(t,
+		[]scheduler.PoolConfig{
+			poolConfig(scheduler.DefaultPoolName, "weighted", 1, nil),
+			poolConfig("video", "weighted", 1, nil),
+		},
+		[]scheduler.ProjectCandidate{project},
+	)
+	gate := registry.GateFor(project.ID)
+	snapshotter, ok := gate.(scheduler.PoolSnapshotter)
+	if !ok {
+		t.Fatalf("GateFor() type = %T, want PoolSnapshotter", gate)
+	}
+	if snapshot := snapshotter.PoolSnapshot(); snapshot.Name != "video" || snapshot.Capacity != 1 {
+		t.Fatalf("PoolSnapshot() = %#v, want video capacity 1", snapshot)
+	}
+	cycleGate, ok := gate.(interface {
+		BeginProjectCycle(scheduler.ProjectCandidate)
+		EndProjectCycle(string)
+	})
+	if !ok {
+		t.Fatalf("GateFor() type = %T, want project cycle gate", gate)
+	}
+
+	cycleGate.BeginProjectCycle(scheduler.ProjectCandidate{Priority: 2})
+	gate.MarkReady(scheduler.ProjectCandidate{Priority: 2})
+	cycleGate.EndProjectCycle("")
+	slot, acquired, err := gate.TryAcquire(
+		context.Background(),
+		scheduler.ProjectCandidate{},
+		scheduler.SlotRequest{State: "Todo"},
+		time.Time{},
+	)
+	if err != nil {
+		t.Fatalf("TryAcquire() error = %v", err)
+	}
+	if !acquired {
+		t.Fatal("TryAcquire() acquired = false, want true")
+	}
+	gate.SetPreempt(slot, func() {})
+	if err := gate.Release(slot); err != nil {
+		t.Fatalf("Release() error = %v", err)
+	}
+	if err := gate.Release(slot); err != nil {
+		t.Fatalf("second Release() error = %v", err)
+	}
+	gate.MarkIdle("")
+
+	registry.SetProjects([]scheduler.ProjectCandidate{{ID: project.ID}})
+	if snapshot := snapshotter.PoolSnapshot(); snapshot.Name != scheduler.DefaultPoolName {
+		t.Fatalf("PoolSnapshot() after reassignment = %#v, want default", snapshot)
+	}
+}
+
+func TestPoolRegistryRejectsInvalidConfigurations(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		pools []scheduler.PoolConfig
+		want  string
+	}{
+		{name: "missing default", pools: []scheduler.PoolConfig{poolConfig("video", "weighted", 1, nil)}, want: `"default" is required`},
+		{name: "blank name", pools: []scheduler.PoolConfig{{Scheduler: scheduler.Config{Capacity: 1}}}, want: "name is required"},
+		{name: "duplicate", pools: []scheduler.PoolConfig{
+			poolConfig(scheduler.DefaultPoolName, "weighted", 1, nil),
+			poolConfig(scheduler.DefaultPoolName, "weighted", 1, nil),
+		}, want: `"default" is duplicated`},
+		{name: "nonpositive capacity", pools: []scheduler.PoolConfig{{Name: scheduler.DefaultPoolName}}, want: "capacity must be positive"},
+		{name: "unsupported scheduling", pools: []scheduler.PoolConfig{
+			poolConfig(scheduler.DefaultPoolName, "unknown", 1, nil),
+		}, want: "unsupported scheduler backend"},
+		{name: "non-global scheduler", pools: []scheduler.PoolConfig{
+			poolConfig(scheduler.DefaultPoolName, "counting_semaphore", 1, nil),
+		}, want: "unsupported scheduler backend"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			_, err := scheduler.NewPoolRegistry(tt.pools, nil)
+			if err == nil || !strings.Contains(err.Error(), tt.want) {
+				t.Fatalf("NewPoolRegistry() error = %v, want containing %q", err, tt.want)
+			}
+		})
+	}
+}
+
+func TestNilPoolRegistryConfigurationMethodsAreNoOps(t *testing.T) {
+	t.Parallel()
+
+	var registry *scheduler.PoolRegistry
+	registry.SetProjects(nil)
+	if err := registry.Reconfigure(nil, nil); err != nil {
+		t.Fatalf("Reconfigure() error = %v", err)
+	}
+	resume := registry.PauseDispatch()
+	resume()
+	if snapshots := registry.PoolSnapshots(); snapshots != nil {
+		t.Fatalf("PoolSnapshots() = %#v, want nil", snapshots)
+	}
+}
+
+func newPoolRegistry(
+	t *testing.T,
+	pools []scheduler.PoolConfig,
+	projects []scheduler.ProjectCandidate,
+) *scheduler.PoolRegistry {
+	t.Helper()
+	registry, err := scheduler.NewPoolRegistry(pools, projects)
+	if err != nil {
+		t.Fatalf("NewPoolRegistry() error = %v", err)
+	}
+	return registry
+}
+
+func poolConfig(name string, kind string, capacity int, fairShare scheduler.FairShareStore) scheduler.PoolConfig {
+	return scheduler.PoolConfig{
+		Name: name,
+		Scheduler: scheduler.Config{
+			Kind:           kind,
+			Capacity:       capacity,
+			FairShareStore: fairShare,
+		},
+	}
+}
+
+func acquirePoolSlots(
+	t *testing.T,
+	registry *scheduler.PoolRegistry,
+	now time.Time,
+	projects ...scheduler.ProjectCandidate,
+) []scheduler.Slot {
+	t.Helper()
+	slots := make([]scheduler.Slot, 0, len(projects))
+	for _, project := range projects {
+		slot, ok, decision, err := registry.TryAcquireWithDecision(
+			context.Background(),
+			project,
+			scheduler.SlotRequest{State: "Todo"},
+			now,
+		)
+		if err != nil {
+			t.Fatalf("TryAcquireWithDecision(%s) error = %v", project.ID, err)
+		}
+		if !ok {
+			t.Fatalf("TryAcquireWithDecision(%s) decision = %#v, want grant", project.ID, decision)
+		}
+		slots = append(slots, slot)
+	}
+	return slots
+}
+
+func releasePoolSlots(t *testing.T, registry *scheduler.PoolRegistry, slots []scheduler.Slot) {
+	t.Helper()
+	for _, slot := range slots {
+		if err := registry.Release(slot); err != nil && !errors.Is(err, scheduler.ErrSlotNotHeld) {
+			t.Fatalf("Release() error = %v", err)
+		}
+	}
+}
+
+func assertPoolUnavailable(t *testing.T, registry *scheduler.PoolRegistry, project scheduler.ProjectCandidate) {
+	t.Helper()
+	_, ok, decision, err := registry.TryAcquireWithDecision(
+		context.Background(),
+		project,
+		scheduler.SlotRequest{State: "Todo"},
+		time.Time{},
+	)
+	if err != nil {
+		t.Fatalf("TryAcquireWithDecision() error = %v", err)
+	}
+	if ok || decision.Reason != scheduler.DispatchGateReasonGlobalCapacityFull {
+		t.Fatalf("TryAcquireWithDecision() ok = %t decision = %#v, want capacity wait", ok, decision)
+	}
+}
+
+func assertPoolPaused(t *testing.T, registry *scheduler.PoolRegistry, project scheduler.ProjectCandidate) {
+	t.Helper()
+	_, ok, decision, err := registry.TryAcquireWithDecision(
+		context.Background(),
+		project,
+		scheduler.SlotRequest{State: "Todo"},
+		time.Time{},
+	)
+	if err != nil {
+		t.Fatalf("TryAcquireWithDecision() error = %v", err)
+	}
+	if ok || decision.Reason != scheduler.DispatchGateReasonPaused {
+		t.Fatalf("TryAcquireWithDecision() ok = %t decision = %#v, want paused", ok, decision)
+	}
+}

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -58,11 +58,13 @@ type SlotRequest struct {
 }
 
 type Slot struct {
-	State    string
-	Host     string
-	Weight   int
-	Priority int
-	token    uint64
+	State          string
+	Host           string
+	Weight         int
+	Priority       int
+	token          uint64
+	poolName       string
+	poolGeneration uint64
 }
 
 type Counters struct {

--- a/internal/telemetry/snapshot.go
+++ b/internal/telemetry/snapshot.go
@@ -63,6 +63,7 @@ type FailureBreaker struct {
 
 type DispatchRecovery struct {
 	ProjectID     string    `json:"project_id,omitempty"`
+	Pool          string    `json:"pool,omitempty"`
 	Kind          string    `json:"kind"`
 	Reason        string    `json:"reason,omitempty"`
 	Status        string    `json:"status"`

--- a/scripts/coverage-exceptions.txt
+++ b/scripts/coverage-exceptions.txt
@@ -3,6 +3,7 @@ github.com/digitaldrywood/detent/internal/orchestrator/backend_capacity.go 90 # 
 github.com/digitaldrywood/detent/internal/orchestrator/implement_progress.go 90 # Safety-critical no-progress brake.
 github.com/digitaldrywood/detent/internal/orchestrator/ranking.go 90 # Safety-critical dispatch ranking.
 github.com/digitaldrywood/detent/internal/orchestrator/spend_progress.go 90 # Safety-critical spend progress brake.
+github.com/digitaldrywood/detent/internal/scheduler/pool_registry.go 90 # Safety-critical agent-pool dispatch control.
 github.com/digitaldrywood/detent/internal/web/ui/components/icon 0 # TemplUI icon glue has no direct behavior tests yet; raise or remove after component tests cover it.
 github.com/digitaldrywood/detent/internal/web/ui/primitives 0 # UI primitive wrappers are currently untested glue; raise or remove after behavior-focused tests cover them.
 github.com/digitaldrywood/detent/internal/web/ui/utils 0 # UI class utility helpers are below the package floor; raise or remove after helper tests cover them.


### PR DESCRIPTION
## Summary

- add validated named agent pools with an implicit reserved default pool and per-project assignment
- route dispatch, preemption, scheduling state, reload, draining, and fleet pause through independent pool gates
- expose pool capacity in scheduler decisions, work-attempt snapshots, runtime telemetry, and documentation

Fixes #1513

## UI Surface Contract

- [x] N/A, or the linked issue explicitly authorizes any high-impact UI surface, layout, density, first-viewport, or responsive visibility tradeoff.
- [x] Persistent top-of-screen messaging is explicitly authorized by the issue, or this PR does not add it.
- [x] Visual changes to primary operator screens include screenshot or browser verification below.

## Test Plan

- [x] `make check`
- [x] `go test -race ./internal/scheduler ./internal/config/global ./internal/cli ./internal/orchestrator -count=1`
- [x] `go test ./internal/orchestrator -run ^$ -fuzz=. -fuzztime=30s`