### PR TITLE
feat(doctor): recommend agent pool splits

### DIFF
--- a/README.md
+++ b/README.md
@@ -2291,6 +2291,33 @@ fleet-wide ceiling. For example, `code: 5` plus `video: 10` permits up to 15
 agents concurrently. A configuration without `agent_pools` or project `pool`
 fields retains the previous single-pool behavior.
 
+`detent doctor` recommends an initial `code` / `cloud` split only when both
+signals are present: the resolved workflows contain both local-heavy projects
+(local command/validator gates or CI triggers) and cloud-only projects, and
+the last seven days of runtime telemetry contain capacity waits where the
+waiting project and a recorded slot holder have different workload classes.
+Fresh installs, single-class fleets, and same-class starvation stay quiet.
+The finding keeps the code pool at the current default-pool cap, proposes a
+starting cloud cap labeled for provider-limit tuning, and prints the affected
+projects as valid YAML.
+
+Preview or apply that exact recommendation with:
+
+```sh
+detent fix agent-pools --dry-run
+detent fix agent-pools
+# Explicit non-interactive confirmation:
+detent fix agent-pools --yes
+```
+
+The fixer prints an additions-only diff, requires confirmation unless `--yes`
+is supplied, preserves unrelated YAML keys, comments, and project ordering,
+and writes `global.yaml` with mode `0600`. It is a no-op when doctor lacks
+either signal. It also declines any config that already declares
+`global.agent_pools`; changing an existing partition is an operator decision.
+The accepted change is picked up by global-config hot reload without a
+process restart.
+
 Set optional `projects[].color` to an opaque CSS hex color in `#RGB` or
 `#RRGGBB` form when a project needs a fixed visual marker. The sidebar,
 project cards, and top-level multi-project Kanban board keep the project name

--- a/docs/ONBOARDING.md
+++ b/docs/ONBOARDING.md
@@ -690,6 +690,16 @@ recommendations before asking what to change.
      "$ONBOARDING_DIR/gate-diagnostic.json"
    ```
 
+   When one onboarding operation configures multiple projects, classify the
+   resolved workflows after this inspection. If the set contains both
+   local-heavy projects (local command/validator gates or CI triggers) and
+   cloud-only projects, present agent pools as an optional profile choice:
+   start with separate `code` and `cloud` pools, or keep one shared pool and
+   decide later. Do not phrase this as a warning because onboarding has no
+   contention telemetry. Say nothing for one project or when every project is
+   in the same class. Existing `agent_pools` are never repartitioned
+   automatically.
+
    If the diagnostic reports `status: env_polluted`, record the failing command,
    `relevant_environment_keys`, and `passing_sanitized_command`. Use
    `recommended_gate_command` as the gate recommendation because Detent proved it

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -246,6 +246,7 @@ type doctorDeps struct {
 	executable           func() (string, error)
 	shipSkillProbe       func(string) (doctorShipSkill, error)
 	now                  func() time.Time
+	workflowCache        *doctorWorkflowCache
 }
 
 func newDoctorCommand(configPath *string, env *string, logLevel *string, host *string, port *int, opts options) *cobra.Command {
@@ -470,6 +471,12 @@ func runDoctor(ctx context.Context, cfg doctorConfig, opts options, deps doctorD
 					ProposalThreshold: cfg.WorkflowProposalThreshold,
 					ProposeIssues:     cfg.WorkflowProposeIssues,
 				})}
+			},
+		})
+		jobs = append(jobs, doctorCheckJob{
+			Name: doctorAgentPoolsCheckName,
+			Run: func(jobCtx context.Context) []doctorCheck {
+				return []doctorCheck{checkDoctorAgentPools(jobCtx, resolution, globalConfig, deps)}
 			},
 		})
 	}
@@ -1107,6 +1114,9 @@ func (d doctorDeps) withDefaults() doctorDeps {
 	}
 	if d.now == nil {
 		d.now = defaults.now
+	}
+	if d.workflowCache == nil {
+		d.workflowCache = newDoctorWorkflowCache()
 	}
 	return d
 }

--- a/internal/cli/doctor_agent_pools.go
+++ b/internal/cli/doctor_agent_pools.go
@@ -1,0 +1,250 @@
+package cli
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+
+	globalconfig "github.com/digitaldrywood/detent/internal/config/global"
+	"github.com/digitaldrywood/detent/internal/store"
+	"github.com/digitaldrywood/detent/internal/workload"
+)
+
+const (
+	doctorAgentPoolsCheckName   = "Agent pools"
+	doctorAgentPoolsWindow      = 7 * 24 * time.Hour
+	doctorCloudPoolStartingSize = 10
+)
+
+type doctorWorkloadProject struct {
+	ID      string
+	Class   workload.Class
+	Signals workload.Signals
+}
+
+type doctorAgentPoolRecommendation struct {
+	Pool          string
+	CurrentCap    int
+	CloudCap      int
+	LocalProjects []doctorWorkloadProject
+	CloudProjects []doctorWorkloadProject
+	Contention    []store.CrossClassPoolContention
+}
+
+func checkDoctorAgentPools(
+	ctx context.Context,
+	resolution globalconfig.PathResolution,
+	cfg globalconfig.Config,
+	deps doctorDeps,
+) doctorCheck {
+	if len(cfg.Global.AgentPools) > 0 {
+		return doctorCheck{
+			Name:   doctorAgentPoolsCheckName,
+			Status: doctorOK,
+			Detail: "agent pools are already configured; automatic repartitioning is intentionally disabled",
+		}
+	}
+	deps = deps.withDefaults()
+	projects, classes, mixed, err := doctorClassifyWorkloadProjects(ctx, cfg, deps)
+	if err != nil {
+		return doctorCheck{
+			Name:   doctorAgentPoolsCheckName,
+			Status: doctorOK,
+			Detail: "skipped because not every project workflow could be classified: " + err.Error(),
+		}
+	}
+	if !mixed {
+		return doctorCheck{
+			Name:   doctorAgentPoolsCheckName,
+			Status: doctorOK,
+			Detail: "one workload class is configured; no pool split is recommended",
+		}
+	}
+	storePath := filepath.Join(filepath.Dir(resolution.Path), "detent.db")
+	db, err := deps.openSQLiteReadOnly(ctx, storePath)
+	if err != nil {
+		if errors.Is(err, errDoctorTelemetryStoreUnavailable) {
+			return doctorCheck{
+				Name:   doctorAgentPoolsCheckName,
+				Status: doctorOK,
+				Detail: "mixed workload classes are configured, but there is no contention telemetry yet",
+			}
+		}
+		return doctorCheck{
+			Name:   doctorAgentPoolsCheckName,
+			Status: doctorWarn,
+			Detail: fmt.Sprintf("%s contention telemetry could not be read: %v", storePath, err),
+			Hint:   "Confirm the runtime database is readable, then rerun detent doctor.",
+		}
+	}
+
+	contention, err := store.QueryCrossClassPoolContention(ctx, db, store.PoolContentionQuery{
+		Since:          deps.now().UTC().Add(-doctorAgentPoolsWindow),
+		ProjectClasses: classes,
+	})
+	closeErr := db.Close()
+	if err != nil {
+		return doctorCheck{
+			Name:   doctorAgentPoolsCheckName,
+			Status: doctorWarn,
+			Detail: "pool contention telemetry could not be analyzed: " + err.Error(),
+			Hint:   "Confirm the runtime database has current work-attempt telemetry.",
+		}
+	}
+	if closeErr != nil {
+		return doctorCheck{
+			Name:   doctorAgentPoolsCheckName,
+			Status: doctorWarn,
+			Detail: "pool contention telemetry could not be closed: " + closeErr.Error(),
+		}
+	}
+	recommendation, ok := newDoctorAgentPoolRecommendation(cfg, projects, contention)
+	if !ok {
+		return doctorCheck{
+			Name:   doctorAgentPoolsCheckName,
+			Status: doctorOK,
+			Detail: "mixed workload classes have no cross-class pool contention in 7d",
+		}
+	}
+	return doctorCheck{
+		Name:   doctorAgentPoolsCheckName,
+		Status: doctorWarn,
+		Detail: recommendation.Detail(),
+		Hint:   "Review the proposed split, tune the cloud cap to provider limits, then run detent fix agent-pools.",
+	}
+}
+
+func doctorClassifyWorkloadProjects(
+	ctx context.Context,
+	cfg globalconfig.Config,
+	deps doctorDeps,
+) ([]doctorWorkloadProject, map[string]string, bool, error) {
+	projects := make([]doctorWorkloadProject, 0, len(cfg.Projects))
+	classes := make(map[string]string, len(cfg.Projects))
+	classSet := map[workload.Class]struct{}{}
+	for _, project := range cfg.Projects {
+		workflowConfig, err := loadDoctorProjectWorkflow(ctx, project, deps)
+		if err != nil {
+			return nil, nil, false, fmt.Errorf("%s: %w", doctorProjectID(project), err)
+		}
+		class, signals := workload.Classify(workflowConfig.Config)
+		item := doctorWorkloadProject{
+			ID:      doctorProjectID(project),
+			Class:   class,
+			Signals: signals,
+		}
+		projects = append(projects, item)
+		classes[item.ID] = string(class)
+		classSet[class] = struct{}{}
+	}
+	sort.Slice(projects, func(i, j int) bool {
+		return projects[i].ID < projects[j].ID
+	})
+	return projects, classes, len(classSet) > 1, nil
+}
+
+func newDoctorAgentPoolRecommendation(
+	cfg globalconfig.Config,
+	projects []doctorWorkloadProject,
+	contention []store.CrossClassPoolContention,
+) (doctorAgentPoolRecommendation, bool) {
+	recommendation := doctorAgentPoolRecommendation{
+		Pool:       globalconfig.DefaultAgentPoolName,
+		CurrentCap: cfg.Global.MaxConcurrentAgents,
+		CloudCap:   max(cfg.Global.MaxConcurrentAgents, doctorCloudPoolStartingSize),
+	}
+	for _, project := range projects {
+		switch project.Class {
+		case workload.ClassLocalHeavy:
+			recommendation.LocalProjects = append(recommendation.LocalProjects, project)
+		case workload.ClassCloudOnly:
+			recommendation.CloudProjects = append(recommendation.CloudProjects, project)
+		}
+	}
+	for _, item := range contention {
+		if item.Pool == recommendation.Pool && item.WaitCount > 0 {
+			recommendation.Contention = append(recommendation.Contention, item)
+		}
+	}
+	return recommendation, len(recommendation.LocalProjects) > 0 &&
+		len(recommendation.CloudProjects) > 0 &&
+		recommendation.TotalWaits() > 0
+}
+
+func (r doctorAgentPoolRecommendation) TotalWaits() int {
+	total := 0
+	for _, contention := range r.Contention {
+		total += contention.WaitCount
+	}
+	return total
+}
+
+func (r doctorAgentPoolRecommendation) Detail() string {
+	var builder strings.Builder
+	fmt.Fprintf(&builder, "2 workload classes share pool %q (cap %d)\n\n", r.Pool, r.CurrentCap)
+	fmt.Fprintf(&builder, "  local-heavy: %s\n", strings.Join(doctorWorkloadProjectIDs(r.LocalProjects), ", "))
+	builder.WriteString("    (declare local validation/build gates or CI triggers)\n")
+	fmt.Fprintf(&builder, "  cloud-only:  %s\n", strings.Join(doctorWorkloadProjectIDs(r.CloudProjects), ", "))
+	builder.WriteString("    (no local validation/build gate, no CI trigger)\n\n")
+	fmt.Fprintf(&builder, "  cross-class work waited on pool capacity %d times in 7d.\n", r.TotalWaits())
+	for _, contention := range r.Contention {
+		fmt.Fprintf(
+			&builder,
+			"  %s waited %d time(s); %s held a slot.\n",
+			contention.WaitingClass,
+			contention.WaitCount,
+			contention.HoldingClass,
+		)
+	}
+	builder.WriteString("\n  suggested:\n")
+	for _, line := range strings.Split(strings.TrimRight(r.SuggestedYAML(), "\n"), "\n") {
+		builder.WriteString("    ")
+		builder.WriteString(line)
+		builder.WriteByte('\n')
+	}
+	return strings.TrimRight(builder.String(), "\n")
+}
+
+func (r doctorAgentPoolRecommendation) SuggestedYAML() string {
+	var builder strings.Builder
+	builder.WriteString("global:\n")
+	builder.WriteString("  agent_pools:\n")
+	builder.WriteString("    - name: code\n")
+	fmt.Fprintf(&builder, "      max_concurrent_agents: %d\n", r.CurrentCap)
+	builder.WriteString("    - name: cloud\n")
+	fmt.Fprintf(&builder, "      max_concurrent_agents: %d # tune to your provider limits\n", r.CloudCap)
+	builder.WriteString("projects:\n")
+	for _, project := range r.LocalProjects {
+		fmt.Fprintf(&builder, "  - id: %s\n    pool: code\n", project.ID)
+	}
+	for _, project := range r.CloudProjects {
+		fmt.Fprintf(&builder, "  - id: %s\n    pool: cloud\n", project.ID)
+	}
+	return builder.String()
+}
+
+func doctorWorkloadProjectIDs(projects []doctorWorkloadProject) []string {
+	ids := make([]string, 0, len(projects))
+	for _, project := range projects {
+		ids = append(ids, project.ID)
+	}
+	return ids
+}
+
+func (r doctorAgentPoolRecommendation) PoolForProject(projectID string) string {
+	for _, project := range r.LocalProjects {
+		if project.ID == projectID {
+			return "code"
+		}
+	}
+	for _, project := range r.CloudProjects {
+		if project.ID == projectID {
+			return "cloud"
+		}
+	}
+	return ""
+}

--- a/internal/cli/doctor_agent_pools.go
+++ b/internal/cli/doctor_agent_pools.go
@@ -6,8 +6,11 @@ import (
 	"fmt"
 	"path/filepath"
 	"sort"
+	"strconv"
 	"strings"
 	"time"
+
+	"gopkg.in/yaml.v3"
 
 	globalconfig "github.com/digitaldrywood/detent/internal/config/global"
 	"github.com/digitaldrywood/detent/internal/store"
@@ -219,12 +222,25 @@ func (r doctorAgentPoolRecommendation) SuggestedYAML() string {
 	fmt.Fprintf(&builder, "      max_concurrent_agents: %d # tune to your provider limits\n", r.CloudCap)
 	builder.WriteString("projects:\n")
 	for _, project := range r.LocalProjects {
-		fmt.Fprintf(&builder, "  - id: %s\n    pool: code\n", project.ID)
+		fmt.Fprintf(&builder, "  - id: %s\n    pool: code\n", doctorAgentPoolYAMLString(project.ID))
 	}
 	for _, project := range r.CloudProjects {
-		fmt.Fprintf(&builder, "  - id: %s\n    pool: cloud\n", project.ID)
+		fmt.Fprintf(&builder, "  - id: %s\n    pool: cloud\n", doctorAgentPoolYAMLString(project.ID))
 	}
 	return builder.String()
+}
+
+func doctorAgentPoolYAMLString(value string) string {
+	encoded, err := yaml.Marshal(&yaml.Node{
+		Kind:  yaml.ScalarNode,
+		Tag:   "!!str",
+		Value: value,
+		Style: yaml.DoubleQuotedStyle,
+	})
+	if err != nil {
+		return strconv.Quote(value)
+	}
+	return strings.TrimSpace(string(encoded))
 }
 
 func doctorWorkloadProjectIDs(projects []doctorWorkloadProject) []string {

--- a/internal/cli/doctor_agent_pools_test.go
+++ b/internal/cli/doctor_agent_pools_test.go
@@ -7,6 +7,8 @@ import (
 	"testing"
 	"time"
 
+	"gopkg.in/yaml.v3"
+
 	workflowconfig "github.com/digitaldrywood/detent/internal/config"
 	globalconfig "github.com/digitaldrywood/detent/internal/config/global"
 	"github.com/digitaldrywood/detent/internal/gate"
@@ -189,6 +191,47 @@ func TestDoctorWorkflowCacheReusesResolvedWorkflow(t *testing.T) {
 	}
 	if calls != 1 {
 		t.Fatalf("loadWorkflow calls = %d, want 1", calls)
+	}
+}
+
+func TestDoctorAgentPoolRecommendationSuggestedYAMLQuotesProjectIDs(t *testing.T) {
+	t.Parallel()
+
+	recommendation := doctorAgentPoolRecommendation{
+		CurrentCap: 5,
+		CloudCap:   10,
+		LocalProjects: []doctorWorkloadProject{
+			{ID: "123"},
+			{ID: "null"},
+		},
+		CloudProjects: []doctorWorkloadProject{
+			{ID: "team: api"},
+		},
+	}
+	var parsed struct {
+		Projects []struct {
+			ID   string `yaml:"id"`
+			Pool string `yaml:"pool"`
+		} `yaml:"projects"`
+	}
+	if err := yaml.Unmarshal([]byte(recommendation.SuggestedYAML()), &parsed); err != nil {
+		t.Fatalf("yaml.Unmarshal() error = %v\n%s", err, recommendation.SuggestedYAML())
+	}
+	want := []struct {
+		ID   string
+		Pool string
+	}{
+		{ID: "123", Pool: "code"},
+		{ID: "null", Pool: "code"},
+		{ID: "team: api", Pool: "cloud"},
+	}
+	if len(parsed.Projects) != len(want) {
+		t.Fatalf("projects = %#v, want %#v", parsed.Projects, want)
+	}
+	for index := range want {
+		if parsed.Projects[index].ID != want[index].ID || parsed.Projects[index].Pool != want[index].Pool {
+			t.Fatalf("projects[%d] = %#v, want %#v", index, parsed.Projects[index], want[index])
+		}
 	}
 }
 

--- a/internal/cli/doctor_agent_pools_test.go
+++ b/internal/cli/doctor_agent_pools_test.go
@@ -1,0 +1,203 @@
+package cli
+
+import (
+	"context"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	workflowconfig "github.com/digitaldrywood/detent/internal/config"
+	globalconfig "github.com/digitaldrywood/detent/internal/config/global"
+	"github.com/digitaldrywood/detent/internal/gate"
+	"github.com/digitaldrywood/detent/internal/store"
+)
+
+func TestCheckDoctorAgentPools(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 7, 27, 20, 0, 0, 0, time.UTC)
+	localWorkflow := workflowconfig.Workflow{Config: workflowconfig.Config{
+		Gate: gate.Config{Kind: gate.KindCommand, Run: "make check"},
+	}}
+	cloudWorkflow := workflowconfig.Workflow{Config: workflowconfig.Config{
+		Gate: gate.Config{Kind: gate.KindArtifact},
+	}}
+
+	tests := []struct {
+		name          string
+		cfg           globalconfig.Config
+		workflows     map[string]workflowconfig.Workflow
+		waiting       string
+		holders       string
+		wantStatus    doctorStatus
+		wantSubstring string
+	}{
+		{
+			name: "one workload class",
+			cfg: doctorAgentPoolsTestConfig([]globalconfig.Project{
+				{ID: "detent", Workflow: "detent", Weight: 1},
+				{ID: "gopher-ai", Workflow: "gopher-ai", Weight: 1},
+			}),
+			workflows: map[string]workflowconfig.Workflow{
+				"detent":    localWorkflow,
+				"gopher-ai": localWorkflow,
+			},
+			wantStatus:    doctorOK,
+			wantSubstring: "one workload class",
+		},
+		{
+			name: "mixed classes without contention",
+			cfg: doctorAgentPoolsTestConfig([]globalconfig.Project{
+				{ID: "detent", Workflow: "detent", Weight: 1},
+				{ID: "video", Workflow: "video", Weight: 1},
+			}),
+			workflows: map[string]workflowconfig.Workflow{
+				"detent": localWorkflow,
+				"video":  cloudWorkflow,
+			},
+			wantStatus:    doctorOK,
+			wantSubstring: "no cross-class pool contention",
+		},
+		{
+			name: "same class contention",
+			cfg: doctorAgentPoolsTestConfig([]globalconfig.Project{
+				{ID: "detent", Workflow: "detent", Weight: 1},
+				{ID: "video", Workflow: "video", Weight: 1},
+				{ID: "podcast", Workflow: "podcast", Weight: 1},
+			}),
+			workflows: map[string]workflowconfig.Workflow{
+				"detent":  localWorkflow,
+				"video":   cloudWorkflow,
+				"podcast": cloudWorkflow,
+			},
+			waiting:       "video",
+			holders:       `["podcast"]`,
+			wantStatus:    doctorOK,
+			wantSubstring: "no cross-class pool contention",
+		},
+		{
+			name: "cross class contention",
+			cfg: doctorAgentPoolsTestConfig([]globalconfig.Project{
+				{ID: "detent", Workflow: "detent", Weight: 1},
+				{ID: "video", Workflow: "video", Weight: 1},
+			}),
+			workflows: map[string]workflowconfig.Workflow{
+				"detent": localWorkflow,
+				"video":  cloudWorkflow,
+			},
+			waiting:       "video",
+			holders:       `["detent"]`,
+			wantStatus:    doctorWarn,
+			wantSubstring: "cloud-only waited 1 time(s); local-heavy held a slot",
+		},
+		{
+			name: "existing pools",
+			cfg: func() globalconfig.Config {
+				cfg := doctorAgentPoolsTestConfig([]globalconfig.Project{
+					{ID: "detent", Workflow: "detent", Pool: "code", Weight: 1},
+					{ID: "video", Workflow: "video", Pool: "cloud", Weight: 1},
+				})
+				cfg.Global.AgentPools = []globalconfig.AgentPool{
+					{Name: "code", MaxConcurrentAgents: 5},
+					{Name: "cloud", MaxConcurrentAgents: 10},
+				}
+				return cfg
+			}(),
+			wantStatus:    doctorOK,
+			wantSubstring: "already configured",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			dir := t.TempDir()
+			configPath := filepath.Join(dir, "global.yaml")
+			dbPath := filepath.Join(dir, "detent.db")
+			backend, err := store.Open(t.Context(), store.Config{Path: dbPath})
+			if err != nil {
+				t.Fatalf("store.Open() error = %v", err)
+			}
+			if tt.waiting != "" {
+				if _, err := backend.StartWorkAttempt(t.Context(), store.WorkAttemptStart{
+					ProjectID:              tt.waiting,
+					WorkerType:             "implement",
+					StartedAt:              now.Add(-time.Hour),
+					WaitReason:             "global_capacity_full",
+					CapacitySnapshotJSON:   `{"pool":"default","holders":` + tt.holders + `}`,
+					GitHubRateSnapshotJSON: "{}",
+					WorkerMetadataJSON:     "{}",
+					MetricsJSON:            "{}",
+				}); err != nil {
+					t.Fatalf("StartWorkAttempt() error = %v", err)
+				}
+			}
+			if err := backend.Close(); err != nil {
+				t.Fatalf("Close() error = %v", err)
+			}
+
+			deps := doctorDeps{
+				loadWorkflow: func(path string) (workflowconfig.Workflow, error) {
+					return tt.workflows[path], nil
+				},
+				openSQLiteReadOnly: openDoctorSQLiteReadOnly,
+				now:                func() time.Time { return now },
+			}.withDefaults()
+			check := checkDoctorAgentPools(
+				context.Background(),
+				globalconfig.PathResolution{Path: configPath},
+				tt.cfg,
+				deps,
+			)
+			if check.Status != tt.wantStatus || !strings.Contains(check.Detail, tt.wantSubstring) {
+				t.Fatalf("check = %#v, want status %s containing %q", check, tt.wantStatus, tt.wantSubstring)
+			}
+			if tt.wantStatus == doctorWarn {
+				for _, want := range []string{
+					"local-heavy: detent",
+					"cloud-only:  video",
+					"pool capacity 1 times in 7d",
+					"max_concurrent_agents: 5",
+					"max_concurrent_agents: 10 # tune to your provider limits",
+				} {
+					if !strings.Contains(check.Detail, want) {
+						t.Fatalf("detail missing %q:\n%s", want, check.Detail)
+					}
+				}
+			}
+		})
+	}
+}
+
+func TestDoctorWorkflowCacheReusesResolvedWorkflow(t *testing.T) {
+	t.Parallel()
+
+	calls := 0
+	deps := doctorDeps{
+		loadWorkflow: func(string) (workflowconfig.Workflow, error) {
+			calls++
+			return workflowconfig.Workflow{}, nil
+		},
+	}.withDefaults()
+	project := globalconfig.Project{ID: "detent", Workflow: "/repo/WORKFLOW.md"}
+	for range 2 {
+		if _, err := loadDoctorProjectWorkflow(t.Context(), project, deps); err != nil {
+			t.Fatalf("loadDoctorProjectWorkflow() error = %v", err)
+		}
+	}
+	if calls != 1 {
+		t.Fatalf("loadWorkflow calls = %d, want 1", calls)
+	}
+}
+
+func doctorAgentPoolsTestConfig(projects []globalconfig.Project) globalconfig.Config {
+	return globalconfig.Config{
+		Global: globalconfig.Settings{
+			MaxConcurrentAgents: 5,
+			Scheduling:          globalconfig.SchedulingWeighted,
+		},
+		Projects: projects,
+	}
+}

--- a/internal/cli/doctor_project.go
+++ b/internal/cli/doctor_project.go
@@ -1480,6 +1480,13 @@ func projectSourceRoot(project globalconfig.Project, cfg workflowconfig.Config) 
 }
 
 func loadDoctorProjectWorkflow(ctx context.Context, project globalconfig.Project, deps doctorDeps) (workflowconfig.Workflow, error) {
+	if deps.workflowCache != nil {
+		return deps.workflowCache.load(ctx, project, deps)
+	}
+	return loadDoctorProjectWorkflowUncached(ctx, project, deps)
+}
+
+func loadDoctorProjectWorkflowUncached(ctx context.Context, project globalconfig.Project, deps doctorDeps) (workflowconfig.Workflow, error) {
 	if strings.TrimSpace(project.WorkflowRef) == "" {
 		return deps.loadWorkflow(project.Workflow)
 	}

--- a/internal/cli/doctor_workflow_cache.go
+++ b/internal/cli/doctor_workflow_cache.go
@@ -1,0 +1,57 @@
+package cli
+
+import (
+	"context"
+	"strings"
+	"sync"
+
+	workflowconfig "github.com/digitaldrywood/detent/internal/config"
+	globalconfig "github.com/digitaldrywood/detent/internal/config/global"
+)
+
+type doctorWorkflowCache struct {
+	mu      sync.Mutex
+	entries map[string]*doctorWorkflowCacheEntry
+}
+
+type doctorWorkflowCacheEntry struct {
+	ready    chan struct{}
+	workflow workflowconfig.Workflow
+	err      error
+}
+
+func newDoctorWorkflowCache() *doctorWorkflowCache {
+	return &doctorWorkflowCache{entries: map[string]*doctorWorkflowCacheEntry{}}
+}
+
+func (c *doctorWorkflowCache) load(
+	ctx context.Context,
+	project globalconfig.Project,
+	deps doctorDeps,
+) (workflowconfig.Workflow, error) {
+	key := strings.Join([]string{
+		strings.TrimSpace(project.ID),
+		strings.TrimSpace(project.Workflow),
+		strings.TrimSpace(project.WorkflowRef),
+		strings.TrimSpace(project.Workdir),
+	}, "\x00")
+
+	c.mu.Lock()
+	entry, ok := c.entries[key]
+	if ok {
+		c.mu.Unlock()
+		select {
+		case <-entry.ready:
+			return entry.workflow, entry.err
+		case <-ctx.Done():
+			return workflowconfig.Workflow{}, ctx.Err()
+		}
+	}
+	entry = &doctorWorkflowCacheEntry{ready: make(chan struct{})}
+	c.entries[key] = entry
+	c.mu.Unlock()
+
+	entry.workflow, entry.err = loadDoctorProjectWorkflowUncached(ctx, project, deps)
+	close(entry.ready)
+	return entry.workflow, entry.err
+}

--- a/internal/cli/fix.go
+++ b/internal/cli/fix.go
@@ -33,9 +33,12 @@ func newFixCommand(configPath *string, opts options) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "fix",
 		Short:   "Repair Detent project configuration",
-		Example: "detent fix workflow-layout --workflow /repo/WORKFLOW.md --dry-run",
+		Example: "detent fix workflow-layout --workflow /repo/WORKFLOW.md --dry-run\n  detent fix agent-pools --dry-run",
 	}
-	cmd.AddCommand(newWorkflowLayoutFixCommand(configPath, opts))
+	cmd.AddCommand(
+		newWorkflowLayoutFixCommand(configPath, opts),
+		newAgentPoolsFixCommand(configPath, opts),
+	)
 	return cmd
 }
 
@@ -172,12 +175,16 @@ func newWorkflowLayoutFixResult(plan workflowconfig.ProjectDefinitionMigrationPl
 }
 
 func confirmWorkflowLayoutFix(cmd *cobra.Command) (bool, error) {
-	if _, err := fmt.Fprint(cmd.ErrOrStderr(), "Apply this workflow-layout migration? [y/N] "); err != nil {
+	return confirmFix(cmd, "Apply this workflow-layout migration?", "migration")
+}
+
+func confirmFix(cmd *cobra.Command, prompt string, action string) (bool, error) {
+	if _, err := fmt.Fprintf(cmd.ErrOrStderr(), "%s [y/N] ", prompt); err != nil {
 		return false, err
 	}
 	answer, err := bufio.NewReader(cmd.InOrStdin()).ReadString('\n')
 	if err != nil && !errors.Is(err, io.EOF) {
-		return false, fmt.Errorf("read migration confirmation: %w", err)
+		return false, fmt.Errorf("read %s confirmation: %w", action, err)
 	}
 	answer = strings.ToLower(strings.TrimSpace(answer))
 	return answer == "y" || answer == "yes", nil

--- a/internal/cli/fix_agent_pools.go
+++ b/internal/cli/fix_agent_pools.go
@@ -328,6 +328,13 @@ func applyAgentPoolsFix(plan agentPoolsFixPlan) error {
 	if plan.Noop || len(plan.After) == 0 {
 		return nil
 	}
+	current, err := os.ReadFile(plan.Path)
+	if err != nil {
+		return fmt.Errorf("read global config %s before applying agent-pool fix: %w", plan.Path, err)
+	}
+	if !bytes.Equal(current, plan.Before) {
+		return errors.New("global config changed since the agent-pool recommendation was prepared; rerun detent fix agent-pools")
+	}
 	if err := os.WriteFile(plan.Path, plan.After, configFileMode); err != nil {
 		return fmt.Errorf("write global config %s: %w", plan.Path, err)
 	}

--- a/internal/cli/fix_agent_pools.go
+++ b/internal/cli/fix_agent_pools.go
@@ -1,0 +1,365 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"strconv"
+	"strings"
+
+	"github.com/spf13/cobra"
+	"gopkg.in/yaml.v3"
+
+	globalconfig "github.com/digitaldrywood/detent/internal/config/global"
+	"github.com/digitaldrywood/detent/internal/store"
+)
+
+const configFileMode = 0o600
+
+type agentPoolsFixResult struct {
+	Path          string `json:"path"`
+	Diff          string `json:"diff,omitempty"`
+	SuggestedYAML string `json:"suggested_yaml,omitempty"`
+	Message       string `json:"message"`
+	DryRun        bool   `json:"dry_run"`
+	Applied       bool   `json:"applied"`
+	Cancelled     bool   `json:"cancelled"`
+	Noop          bool   `json:"noop"`
+}
+
+type agentPoolsFixPlan struct {
+	Path           string
+	Before         []byte
+	After          []byte
+	Diff           string
+	Recommendation doctorAgentPoolRecommendation
+	Noop           bool
+	Message        string
+}
+
+func newAgentPoolsFixCommand(configPath *string, opts options) *cobra.Command {
+	return newAgentPoolsFixCommandWithDeps(configPath, opts, doctorDeps{})
+}
+
+func newAgentPoolsFixCommandWithDeps(configPath *string, opts options, deps doctorDeps) *cobra.Command {
+	var dryRun bool
+	var confirmed bool
+	cmd := &cobra.Command{
+		Use:          "agent-pools",
+		Short:        "Apply the doctor-recommended agent pool split",
+		Example:      "detent fix agent-pools --dry-run\n  detent fix agent-pools --yes",
+		Args:         NoArgs,
+		SilenceUsage: true,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			if dryRun && confirmed {
+				return WrapValidation(errors.New("--dry-run and --yes cannot be used together"))
+			}
+			plan, err := planAgentPoolsFix(cmd.Context(), derefString(configPath), opts, deps)
+			if err != nil {
+				return err
+			}
+			result := agentPoolsFixResult{
+				Path:    plan.Path,
+				Diff:    plan.Diff,
+				Message: plan.Message,
+				DryRun:  dryRun,
+				Noop:    plan.Noop,
+			}
+			if !plan.Noop {
+				result.SuggestedYAML = plan.Recommendation.SuggestedYAML()
+			}
+			out, err := OutputForCommand(cmd)
+			if err != nil {
+				return err
+			}
+			if plan.Noop || dryRun {
+				return out.Write(func(writer io.Writer) error {
+					return writeAgentPoolsFixResult(writer, result)
+				}, result)
+			}
+			if !confirmed {
+				if !out.IsJSON() {
+					if err := writeAgentPoolsFixResult(cmd.OutOrStdout(), result); err != nil {
+						return err
+					}
+				}
+				ok, err := confirmFix(cmd, "Apply this agent-pool split?", "agent-pool")
+				if err != nil {
+					return err
+				}
+				if !ok {
+					result.Cancelled = true
+					result.Message = "Agent-pool fix cancelled; no files changed."
+					if out.IsJSON() {
+						return out.Write(nil, result)
+					}
+					_, err := fmt.Fprintln(cmd.OutOrStdout(), result.Message)
+					return err
+				}
+			}
+			if err := applyAgentPoolsFix(plan); err != nil {
+				return err
+			}
+			result.Applied = true
+			result.Message = "Agent-pool split applied; global config reload will take effect without a restart."
+			return out.Write(func(writer io.Writer) error {
+				return writeAgentPoolsFixResult(writer, result)
+			}, result)
+		},
+	}
+	cmd.Flags().BoolVar(&dryRun, "dry-run", false, "show the recommended global.yaml diff without writing")
+	cmd.Flags().BoolVar(&confirmed, "yes", false, "apply the split without an interactive confirmation")
+	return cmd
+}
+
+func planAgentPoolsFix(
+	ctx context.Context,
+	configPath string,
+	opts options,
+	deps doctorDeps,
+) (agentPoolsFixPlan, error) {
+	defaults := defaultOptions()
+	if opts.resolvePath == nil {
+		opts.resolvePath = defaults.resolvePath
+	}
+	if opts.read == nil {
+		opts.read = defaults.read
+	}
+	resolution, err := opts.resolvePath(configPath)
+	if err != nil {
+		return agentPoolsFixPlan{}, err
+	}
+	cfg, err := opts.read(resolution.Path)
+	if err != nil {
+		return agentPoolsFixPlan{}, err
+	}
+	plan := agentPoolsFixPlan{Path: resolution.Path}
+	if len(cfg.Global.AgentPools) > 0 {
+		plan.Noop = true
+		plan.Message = "No changes made: global.agent_pools is already configured; repartitioning requires an operator decision."
+		return plan, nil
+	}
+
+	deps = deps.withDefaults()
+	projects, classes, mixed, err := doctorClassifyWorkloadProjects(ctx, cfg, deps)
+	if err != nil {
+		return agentPoolsFixPlan{}, err
+	}
+	if !mixed {
+		plan.Noop = true
+		plan.Message = "No changes needed: doctor sees only one workload class."
+		return plan, nil
+	}
+
+	db, err := deps.openSQLiteReadOnly(ctx, doctorRuntimeStorePath(resolution.Path))
+	if err != nil {
+		if errors.Is(err, errDoctorTelemetryStoreUnavailable) {
+			plan.Noop = true
+			plan.Message = "No changes needed: doctor has no pool-contention telemetry yet."
+			return plan, nil
+		}
+		return agentPoolsFixPlan{}, err
+	}
+	contention, queryErr := store.QueryCrossClassPoolContention(ctx, db, store.PoolContentionQuery{
+		Since:          deps.now().UTC().Add(-doctorAgentPoolsWindow),
+		ProjectClasses: classes,
+	})
+	closeErr := db.Close()
+	if queryErr != nil {
+		return agentPoolsFixPlan{}, queryErr
+	}
+	if closeErr != nil {
+		return agentPoolsFixPlan{}, closeErr
+	}
+	recommendation, ok := newDoctorAgentPoolRecommendation(cfg, projects, contention)
+	if !ok {
+		plan.Noop = true
+		plan.Message = "No changes needed: doctor found no cross-class pool contention in 7d."
+		return plan, nil
+	}
+
+	raw, err := os.ReadFile(resolution.Path)
+	if err != nil {
+		return agentPoolsFixPlan{}, fmt.Errorf("read global config %s: %w", resolution.Path, err)
+	}
+	updated, err := applyAgentPoolRecommendationToYAML(raw, recommendation)
+	if err != nil {
+		return agentPoolsFixPlan{}, err
+	}
+	if _, err := globalconfig.Parse(updated, resolution.Path); err != nil {
+		return agentPoolsFixPlan{}, fmt.Errorf("validate recommended global config: %w", err)
+	}
+	plan.Before = raw
+	plan.After = updated
+	plan.Recommendation = recommendation
+	plan.Diff = agentPoolsFixDiff(resolution.Path, recommendation)
+	plan.Message = "Doctor found mixed workloads with cross-class pool contention."
+	return plan, nil
+}
+
+func applyAgentPoolRecommendationToYAML(
+	raw []byte,
+	recommendation doctorAgentPoolRecommendation,
+) ([]byte, error) {
+	var document yaml.Node
+	if err := yaml.Unmarshal(raw, &document); err != nil {
+		return nil, fmt.Errorf("parse global config YAML: %w", err)
+	}
+	if len(document.Content) == 0 || document.Content[0].Kind != yaml.MappingNode {
+		return nil, errors.New("global config root must be a mapping")
+	}
+	root := document.Content[0]
+	global := yamlMappingValue(root, "global")
+	if global == nil || global.Kind != yaml.MappingNode {
+		return nil, errors.New("global config global key must be a mapping")
+	}
+	if yamlMappingValue(global, "agent_pools") != nil {
+		return nil, errors.New("global.agent_pools is already configured")
+	}
+	global.Content = append(global.Content,
+		&yaml.Node{Kind: yaml.ScalarNode, Tag: "!!str", Value: "agent_pools"},
+		agentPoolsYAMLNode(recommendation),
+	)
+
+	projects := yamlMappingValue(root, "projects")
+	if projects == nil || projects.Kind != yaml.SequenceNode {
+		return nil, errors.New("global config projects key must be a sequence")
+	}
+	for _, project := range projects.Content {
+		if project.Kind != yaml.MappingNode {
+			return nil, errors.New("global config project must be a mapping")
+		}
+		idNode := yamlMappingValue(project, "id")
+		if idNode == nil {
+			return nil, errors.New("global config project id is required")
+		}
+		pool := recommendation.PoolForProject(strings.TrimSpace(idNode.Value))
+		if pool == "" {
+			continue
+		}
+		if yamlMappingValue(project, "pool") != nil {
+			return nil, fmt.Errorf("project %s already declares a pool", idNode.Value)
+		}
+		project.Content = append(project.Content,
+			&yaml.Node{Kind: yaml.ScalarNode, Tag: "!!str", Value: "pool"},
+			&yaml.Node{Kind: yaml.ScalarNode, Tag: "!!str", Value: pool},
+		)
+	}
+
+	var output bytes.Buffer
+	encoder := yaml.NewEncoder(&output)
+	encoder.SetIndent(2)
+	if err := encoder.Encode(&document); err != nil {
+		return nil, fmt.Errorf("encode global config YAML: %w", err)
+	}
+	if err := encoder.Close(); err != nil {
+		return nil, fmt.Errorf("close global config YAML encoder: %w", err)
+	}
+	return output.Bytes(), nil
+}
+
+func yamlMappingValue(mapping *yaml.Node, key string) *yaml.Node {
+	if mapping == nil || mapping.Kind != yaml.MappingNode {
+		return nil
+	}
+	for index := 0; index+1 < len(mapping.Content); index += 2 {
+		if mapping.Content[index].Value == key {
+			return mapping.Content[index+1]
+		}
+	}
+	return nil
+}
+
+func agentPoolsYAMLNode(recommendation doctorAgentPoolRecommendation) *yaml.Node {
+	return &yaml.Node{
+		Kind: yaml.SequenceNode,
+		Tag:  "!!seq",
+		Content: []*yaml.Node{
+			agentPoolYAMLNode("code", recommendation.CurrentCap, ""),
+			agentPoolYAMLNode("cloud", recommendation.CloudCap, "tune to your provider limits"),
+		},
+	}
+}
+
+func agentPoolYAMLNode(name string, capacity int, comment string) *yaml.Node {
+	capacityNode := &yaml.Node{Kind: yaml.ScalarNode, Tag: "!!int", Value: strconv.Itoa(capacity)}
+	capacityNode.LineComment = comment
+	return &yaml.Node{
+		Kind: yaml.MappingNode,
+		Tag:  "!!map",
+		Content: []*yaml.Node{
+			{Kind: yaml.ScalarNode, Tag: "!!str", Value: "name"},
+			{Kind: yaml.ScalarNode, Tag: "!!str", Value: name},
+			{Kind: yaml.ScalarNode, Tag: "!!str", Value: "max_concurrent_agents"},
+			capacityNode,
+		},
+	}
+}
+
+func agentPoolsFixDiff(path string, recommendation doctorAgentPoolRecommendation) string {
+	var builder strings.Builder
+	fmt.Fprintf(&builder, "--- %s\n+++ %s\n", path, path)
+	builder.WriteString("@@ global.agent_pools @@\n")
+	for _, line := range strings.Split(strings.TrimRight(recommendation.SuggestedYAML(), "\n"), "\n") {
+		if line == "projects:" {
+			break
+		}
+		if line == "global:" {
+			continue
+		}
+		builder.WriteByte('+')
+		builder.WriteString(line)
+		builder.WriteByte('\n')
+	}
+	builder.WriteString("@@ projects[].pool @@\n")
+	for _, project := range append(
+		append([]doctorWorkloadProject(nil), recommendation.LocalProjects...),
+		recommendation.CloudProjects...,
+	) {
+		fmt.Fprintf(&builder, "+%s: %s\n", project.ID, recommendation.PoolForProject(project.ID))
+	}
+	return strings.TrimRight(builder.String(), "\n")
+}
+
+func applyAgentPoolsFix(plan agentPoolsFixPlan) error {
+	if plan.Noop || len(plan.After) == 0 {
+		return nil
+	}
+	if err := os.WriteFile(plan.Path, plan.After, configFileMode); err != nil {
+		return fmt.Errorf("write global config %s: %w", plan.Path, err)
+	}
+	if err := os.Chmod(plan.Path, configFileMode); err != nil {
+		return fmt.Errorf("restrict global config %s: %w", plan.Path, err)
+	}
+	return nil
+}
+
+func writeAgentPoolsFixResult(out io.Writer, result agentPoolsFixResult) error {
+	if result.Diff != "" {
+		if _, err := fmt.Fprintln(out, "Agent pool recommendation:"); err != nil {
+			return err
+		}
+		if _, err := fmt.Fprintln(out, result.Diff); err != nil {
+			return err
+		}
+	}
+	if result.Message != "" {
+		if _, err := fmt.Fprintln(out, result.Message); err != nil {
+			return err
+		}
+	}
+	switch {
+	case result.Noop:
+		return nil
+	case result.DryRun:
+		_, err := fmt.Fprintln(out, "Dry run; no files changed.")
+		return err
+	case result.Applied:
+		return nil
+	default:
+		return nil
+	}
+}

--- a/internal/cli/fix_agent_pools_test.go
+++ b/internal/cli/fix_agent_pools_test.go
@@ -149,6 +149,30 @@ func TestAgentPoolsFixDeclinesExistingPools(t *testing.T) {
 	}
 }
 
+func TestApplyAgentPoolsFixDeclinesStalePlan(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join(t.TempDir(), "global.yaml")
+	before := []byte("global:\n  max_concurrent_agents: 5\n")
+	after := []byte("global:\n  max_concurrent_agents: 5\n  agent_pools: []\n")
+	changed := []byte("global:\n  max_concurrent_agents: 7\n")
+	if err := os.WriteFile(path, changed, configFileMode); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+
+	err := applyAgentPoolsFix(agentPoolsFixPlan{Path: path, Before: before, After: after})
+	if err == nil || !strings.Contains(err.Error(), "global config changed") {
+		t.Fatalf("applyAgentPoolsFix() error = %v, want stale-plan error", err)
+	}
+	got, readErr := os.ReadFile(path)
+	if readErr != nil {
+		t.Fatalf("ReadFile() error = %v", readErr)
+	}
+	if !bytes.Equal(got, changed) {
+		t.Fatalf("global config = %q, want concurrent change preserved", got)
+	}
+}
+
 func TestAgentPoolsFixHotReloadsScheduler(t *testing.T) {
 	fixture := newAgentPoolsFixFixture(t, true)
 	initial, err := globalconfig.Read(fixture.configPath)

--- a/internal/cli/fix_agent_pools_test.go
+++ b/internal/cli/fix_agent_pools_test.go
@@ -1,0 +1,300 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	workflowconfig "github.com/digitaldrywood/detent/internal/config"
+	globalconfig "github.com/digitaldrywood/detent/internal/config/global"
+	"github.com/digitaldrywood/detent/internal/gate"
+	"github.com/digitaldrywood/detent/internal/store"
+)
+
+func TestAgentPoolsFixModesAndPreservation(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		args        []string
+		input       string
+		contention  bool
+		wantApplied bool
+		wantOutput  string
+	}{
+		{
+			name:       "dry run",
+			args:       []string{"--dry-run"},
+			contention: true,
+			wantOutput: "Dry run; no files changed.",
+		},
+		{
+			name:       "interactive decline",
+			input:      "no\n",
+			contention: true,
+			wantOutput: "Agent-pool fix cancelled; no files changed.",
+		},
+		{
+			name:        "interactive confirmation",
+			input:       "yes\n",
+			contention:  true,
+			wantApplied: true,
+			wantOutput:  "global config reload will take effect without a restart",
+		},
+		{
+			name:        "non-interactive confirmation",
+			args:        []string{"--yes"},
+			contention:  true,
+			wantApplied: true,
+			wantOutput:  "global config reload will take effect without a restart",
+		},
+		{
+			name:       "no contention",
+			args:       []string{"--yes"},
+			wantOutput: "no cross-class pool contention in 7d",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			fixture := newAgentPoolsFixFixture(t, tt.contention)
+			before, err := os.ReadFile(fixture.configPath)
+			if err != nil {
+				t.Fatalf("ReadFile() error = %v", err)
+			}
+			var stdout bytes.Buffer
+			var stderr bytes.Buffer
+			cmd := newAgentPoolsFixCommandWithDeps(&fixture.configPath, defaultOptions(), fixture.deps)
+			cmd.SetOut(&stdout)
+			cmd.SetErr(&stderr)
+			cmd.SetIn(strings.NewReader(tt.input))
+			cmd.SetContext(withCommandOutputOptions(t.Context(), commandOutputOptions{
+				stdoutTTY: func() bool { return true },
+			}))
+			cmd.SetArgs(tt.args)
+			if err := cmd.ExecuteContext(cmd.Context()); err != nil {
+				t.Fatalf("ExecuteContext() error = %v", err)
+			}
+			if !strings.Contains(stdout.String(), tt.wantOutput) {
+				t.Fatalf("stdout = %q, want containing %q", stdout.String(), tt.wantOutput)
+			}
+			if strings.Contains(stdout.String(), "secret-token") {
+				t.Fatalf("stdout exposed unrelated config secret: %s", stdout.String())
+			}
+
+			after, err := os.ReadFile(fixture.configPath)
+			if err != nil {
+				t.Fatalf("ReadFile() error = %v", err)
+			}
+			if !tt.wantApplied {
+				if !bytes.Equal(after, before) {
+					t.Fatalf("global config changed without application:\n%s", after)
+				}
+				return
+			}
+			for _, preserved := range []string{
+				"# fleet comment",
+				"log_level: debug # keep this setting",
+				"max_concurrent_agents: 5 # sized for this box",
+			} {
+				if !strings.Contains(string(after), preserved) {
+					t.Fatalf("global config lost %q:\n%s", preserved, after)
+				}
+			}
+			cfg, err := globalconfig.Read(fixture.configPath)
+			if err != nil {
+				t.Fatalf("globalconfig.Read() error = %v\n%s", err, after)
+			}
+			if len(cfg.Global.AgentPools) != 2 ||
+				cfg.Global.AgentPools[0].Name != "code" ||
+				cfg.Global.AgentPools[0].MaxConcurrentAgents != 5 ||
+				cfg.Global.AgentPools[1].Name != "cloud" ||
+				cfg.Global.AgentPools[1].MaxConcurrentAgents != 10 {
+				t.Fatalf("agent pools = %#v", cfg.Global.AgentPools)
+			}
+			if len(cfg.Projects) != 2 || cfg.Projects[0].ID != "detent" ||
+				cfg.Projects[0].Pool != "code" || cfg.Projects[1].ID != "video" ||
+				cfg.Projects[1].Pool != "cloud" {
+				t.Fatalf("projects = %#v, want original order and class pools", cfg.Projects)
+			}
+			info, err := os.Stat(fixture.configPath)
+			if err != nil {
+				t.Fatalf("Stat() error = %v", err)
+			}
+			if info.Mode().Perm() != configFileMode {
+				t.Fatalf("mode = %04o, want %04o", info.Mode().Perm(), configFileMode)
+			}
+		})
+	}
+}
+
+func TestAgentPoolsFixDeclinesExistingPools(t *testing.T) {
+	t.Parallel()
+
+	fixture := newAgentPoolsFixFixture(t, true)
+	runAgentPoolsFixTestCommand(t, fixture, "--yes")
+
+	output := runAgentPoolsFixTestCommand(t, fixture, "--yes")
+	if !strings.Contains(output, "global.agent_pools is already configured") {
+		t.Fatalf("output = %q, want existing-pool decline", output)
+	}
+}
+
+func TestAgentPoolsFixHotReloadsScheduler(t *testing.T) {
+	fixture := newAgentPoolsFixFixture(t, true)
+	initial, err := globalconfig.Read(fixture.configPath)
+	if err != nil {
+		t.Fatalf("globalconfig.Read() error = %v", err)
+	}
+	registry, err := buildGlobalDispatchPools(initial, nil)
+	if err != nil {
+		t.Fatalf("buildGlobalDispatchPools() error = %v", err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	done := startGlobalConfigWatcher(
+		ctx,
+		initial,
+		&globalReloadManager{},
+		slog.New(slog.NewTextHandler(io.Discard, nil)),
+		nil,
+		func(next globalconfig.Config) error {
+			return applyGlobalRuntimeConfig(registry, nil, nil, next)
+		},
+		nil,
+	)
+	if done == nil {
+		t.Fatal("startGlobalConfigWatcher() returned nil")
+	}
+
+	runAgentPoolsFixTestCommand(t, fixture, "--yes")
+
+	ticker := time.NewTicker(10 * time.Millisecond)
+	defer ticker.Stop()
+	timeout := time.NewTimer(5 * time.Second)
+	defer timeout.Stop()
+	for {
+		snapshot := registry.PoolSnapshotFor("video")
+		if snapshot.Name == "cloud" && snapshot.Capacity == 10 {
+			break
+		}
+		select {
+		case <-ticker.C:
+		case <-timeout.C:
+			t.Fatalf("hot reload did not apply agent pools: %#v", snapshot)
+		}
+	}
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for global config watcher shutdown")
+	}
+}
+
+type agentPoolsFixFixture struct {
+	configPath string
+	deps       doctorDeps
+}
+
+func newAgentPoolsFixFixture(t *testing.T, contention bool) agentPoolsFixFixture {
+	t.Helper()
+
+	dir := t.TempDir()
+	localWorkflowPath := filepath.Join(dir, "detent-WORKFLOW.md")
+	cloudWorkflowPath := filepath.Join(dir, "video-WORKFLOW.md")
+	for _, path := range []string{localWorkflowPath, cloudWorkflowPath} {
+		if err := os.WriteFile(path, []byte("Workflow\n"), 0o644); err != nil {
+			t.Fatalf("WriteFile(%s) error = %v", path, err)
+		}
+	}
+	configPath := filepath.Join(dir, "global.yaml")
+	raw := strings.Join([]string{
+		"# fleet comment",
+		"apiVersion: detent/v1",
+		"kind: GlobalConfig",
+		"github_token: secret-token",
+		"log_level: debug # keep this setting",
+		"global:",
+		"  max_concurrent_agents: 5 # sized for this box",
+		"  scheduling: weighted",
+		"projects:",
+		"  - id: detent",
+		"    workflow: " + localWorkflowPath,
+		"    workdir: " + dir,
+		"    weight: 1",
+		"    priority: 0",
+		"  - id: video",
+		"    workflow: " + cloudWorkflowPath,
+		"    workdir: " + dir,
+		"    weight: 1",
+		"    priority: 0",
+		"",
+	}, "\n")
+	if err := os.WriteFile(configPath, []byte(raw), configFileMode); err != nil {
+		t.Fatalf("WriteFile(global.yaml) error = %v", err)
+	}
+	backend, err := store.Open(t.Context(), store.Config{Path: filepath.Join(dir, "detent.db")})
+	if err != nil {
+		t.Fatalf("store.Open() error = %v", err)
+	}
+	now := time.Date(2026, 7, 27, 20, 0, 0, 0, time.UTC)
+	if contention {
+		if _, err := backend.StartWorkAttempt(t.Context(), store.WorkAttemptStart{
+			ProjectID:              "video",
+			WorkerType:             "implement",
+			StartedAt:              now.Add(-time.Hour),
+			WaitReason:             "global_capacity_full",
+			CapacitySnapshotJSON:   `{"pool":"default","holders":["detent"]}`,
+			GitHubRateSnapshotJSON: "{}",
+			WorkerMetadataJSON:     "{}",
+			MetricsJSON:            "{}",
+		}); err != nil {
+			t.Fatalf("StartWorkAttempt() error = %v", err)
+		}
+	}
+	if err := backend.Close(); err != nil {
+		t.Fatalf("Close() error = %v", err)
+	}
+
+	workflows := map[string]workflowconfig.Workflow{
+		localWorkflowPath: {Config: workflowconfig.Config{
+			Gate: gate.Config{Kind: gate.KindCommand, Run: "make check"},
+		}},
+		cloudWorkflowPath: {Config: workflowconfig.Config{
+			Gate: gate.Config{Kind: gate.KindArtifact},
+		}},
+	}
+	deps := doctorDeps{
+		loadWorkflow: func(path string) (workflowconfig.Workflow, error) {
+			return workflows[path], nil
+		},
+		openSQLiteReadOnly: openDoctorSQLiteReadOnly,
+		now:                func() time.Time { return now },
+	}.withDefaults()
+	return agentPoolsFixFixture{configPath: configPath, deps: deps}
+}
+
+func runAgentPoolsFixTestCommand(t *testing.T, fixture agentPoolsFixFixture, args ...string) string {
+	t.Helper()
+
+	var stdout bytes.Buffer
+	cmd := newAgentPoolsFixCommandWithDeps(&fixture.configPath, defaultOptions(), fixture.deps)
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&bytes.Buffer{})
+	cmd.SetContext(withCommandOutputOptions(t.Context(), commandOutputOptions{
+		stdoutTTY: func() bool { return true },
+	}))
+	cmd.SetArgs(args)
+	if err := cmd.ExecuteContext(cmd.Context()); err != nil {
+		t.Fatalf("ExecuteContext() error = %v", err)
+	}
+	return stdout.String()
+}

--- a/internal/cli/fix_agent_pools_test.go
+++ b/internal/cli/fix_agent_pools_test.go
@@ -7,6 +7,7 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -129,7 +130,7 @@ func TestAgentPoolsFixModesAndPreservation(t *testing.T) {
 			if err != nil {
 				t.Fatalf("Stat() error = %v", err)
 			}
-			if info.Mode().Perm() != configFileMode {
+			if runtime.GOOS != "windows" && info.Mode().Perm() != configFileMode {
 				t.Fatalf("mode = %04o, want %04o", info.Mode().Perm(), configFileMode)
 			}
 		})

--- a/internal/onboarding/profile.go
+++ b/internal/onboarding/profile.go
@@ -5,6 +5,9 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+
+	workflowconfig "github.com/digitaldrywood/detent/internal/config"
+	"github.com/digitaldrywood/detent/internal/workload"
 )
 
 const (
@@ -28,22 +31,41 @@ type DeliveryProfileSettings struct {
 }
 
 type DeliveryProfileSummary struct {
-	EffectiveDeliveryProfile      string   `json:"effective_delivery_profile"`
-	EffectiveDeliveryProfileLabel string   `json:"effective_delivery_profile_label"`
-	KanbanMode                    string   `json:"kanban_mode"`
-	KanbanBehavior                string   `json:"kanban_behavior"`
-	GateRequiresAutomatedReview   bool     `json:"gate_requires_automated_review"`
-	GateBehavior                  string   `json:"gate_behavior"`
-	AutoPromoteEnabled            bool     `json:"auto_promote_enabled"`
-	AutoPromoteQuietSeconds       int      `json:"auto_promote_quiet_seconds"`
-	AutoPromotionBehavior         string   `json:"auto_promotion_behavior"`
-	QuietWindowBehavior           string   `json:"quiet_window_behavior"`
-	DependencyAutoUnblockEnabled  bool     `json:"dependency_auto_unblock_enabled"`
-	DependencyAutoUnblockBehavior string   `json:"dependency_auto_unblock_behavior"`
-	MergingConcurrency            int      `json:"merging_concurrency"`
-	MergeConcurrencyBehavior      string   `json:"merge_concurrency_behavior"`
-	StopBehavior                  string   `json:"stop_behavior"`
-	StopConditions                []string `json:"stop_conditions"`
+	EffectiveDeliveryProfile      string           `json:"effective_delivery_profile"`
+	EffectiveDeliveryProfileLabel string           `json:"effective_delivery_profile_label"`
+	KanbanMode                    string           `json:"kanban_mode"`
+	KanbanBehavior                string           `json:"kanban_behavior"`
+	GateRequiresAutomatedReview   bool             `json:"gate_requires_automated_review"`
+	GateBehavior                  string           `json:"gate_behavior"`
+	AutoPromoteEnabled            bool             `json:"auto_promote_enabled"`
+	AutoPromoteQuietSeconds       int              `json:"auto_promote_quiet_seconds"`
+	AutoPromotionBehavior         string           `json:"auto_promotion_behavior"`
+	QuietWindowBehavior           string           `json:"quiet_window_behavior"`
+	DependencyAutoUnblockEnabled  bool             `json:"dependency_auto_unblock_enabled"`
+	DependencyAutoUnblockBehavior string           `json:"dependency_auto_unblock_behavior"`
+	MergingConcurrency            int              `json:"merging_concurrency"`
+	MergeConcurrencyBehavior      string           `json:"merge_concurrency_behavior"`
+	StopBehavior                  string           `json:"stop_behavior"`
+	StopConditions                []string         `json:"stop_conditions"`
+	AgentPoolChoice               *AgentPoolChoice `json:"agent_pool_choice,omitempty"`
+}
+
+type ProjectWorkload struct {
+	ID       string
+	Workflow workflowconfig.Config
+}
+
+type AgentPoolChoice struct {
+	Question      string            `json:"question"`
+	Options       []AgentPoolOption `json:"options"`
+	LocalProjects []string          `json:"local_projects"`
+	CloudProjects []string          `json:"cloud_projects"`
+}
+
+type AgentPoolOption struct {
+	ID          string `json:"id"`
+	Label       string `json:"label"`
+	Description string `json:"description"`
 }
 
 func NormalizeDeliveryProfile(value string) string {
@@ -132,6 +154,59 @@ func SummarizeDeliveryProfile(value string) (DeliveryProfileSummary, bool) {
 			"gate failures",
 		},
 	}, true
+}
+
+func SummarizeDeliveryProfileForProjects(
+	value string,
+	projects []ProjectWorkload,
+) (DeliveryProfileSummary, bool) {
+	summary, ok := SummarizeDeliveryProfile(value)
+	if !ok {
+		return DeliveryProfileSummary{}, false
+	}
+	if choice, offered := AgentPoolChoiceForProjects(projects); offered {
+		summary.AgentPoolChoice = &choice
+	}
+	return summary, true
+}
+
+func AgentPoolChoiceForProjects(projects []ProjectWorkload) (AgentPoolChoice, bool) {
+	if len(projects) < 2 {
+		return AgentPoolChoice{}, false
+	}
+	var choice AgentPoolChoice
+	for _, project := range projects {
+		id := strings.TrimSpace(project.ID)
+		if id == "" {
+			continue
+		}
+		class, _ := workload.Classify(project.Workflow)
+		switch class {
+		case workload.ClassLocalHeavy:
+			choice.LocalProjects = append(choice.LocalProjects, id)
+		case workload.ClassCloudOnly:
+			choice.CloudProjects = append(choice.CloudProjects, id)
+		}
+	}
+	if len(choice.LocalProjects) == 0 || len(choice.CloudProjects) == 0 {
+		return AgentPoolChoice{}, false
+	}
+	sort.Strings(choice.LocalProjects)
+	sort.Strings(choice.CloudProjects)
+	choice.Question = "Optional: keep local validation/build work and cloud-only model work in separate agent pools?"
+	choice.Options = []AgentPoolOption{
+		{
+			ID:          "split",
+			Label:       "Use separate pools",
+			Description: "Start with code and cloud pools so each workload class can be tuned independently.",
+		},
+		{
+			ID:          "shared",
+			Label:       "Keep one pool",
+			Description: "Continue with one shared capacity setting and decide on partitioning later.",
+		},
+	}
+	return choice, true
 }
 
 func DeliveryProfileAnswerExpansion(value string) (map[string]string, bool) {

--- a/internal/onboarding/profile_test.go
+++ b/internal/onboarding/profile_test.go
@@ -1,6 +1,12 @@
 package onboarding
 
-import "testing"
+import (
+	"strings"
+	"testing"
+
+	workflowconfig "github.com/digitaldrywood/detent/internal/config"
+	"github.com/digitaldrywood/detent/internal/gate"
+)
 
 func TestDeliveryProfileAnswerExpansion(t *testing.T) {
 	t.Parallel()
@@ -202,5 +208,83 @@ func TestSummarizeDeliveryProfile(t *testing.T) {
 				t.Fatalf("stop summary = conditions %#v behavior %q, want populated stop behavior", got.StopConditions, got.StopBehavior)
 			}
 		})
+	}
+}
+
+func TestAgentPoolChoiceForProjects(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		projects    []ProjectWorkload
+		wantOffered bool
+	}{
+		{
+			name: "mixed classes",
+			projects: []ProjectWorkload{
+				{ID: "video", Workflow: workflowconfig.Config{Gate: gate.Config{Kind: gate.KindArtifact}}},
+				{ID: "detent", Workflow: workflowconfig.Config{Gate: gate.Config{Kind: gate.KindCommand, Run: "make check"}}},
+			},
+			wantOffered: true,
+		},
+		{
+			name: "single project",
+			projects: []ProjectWorkload{
+				{ID: "detent", Workflow: workflowconfig.Config{Gate: gate.Config{Kind: gate.KindCommand, Run: "make check"}}},
+			},
+		},
+		{
+			name: "all local heavy",
+			projects: []ProjectWorkload{
+				{ID: "detent", Workflow: workflowconfig.Config{Gate: gate.Config{Kind: gate.KindCommand, Run: "make check"}}},
+				{ID: "gopher-ai", Workflow: workflowconfig.Config{Gate: gate.Config{CITriggerLabel: "ci:ready"}}},
+			},
+		},
+		{
+			name: "all cloud only",
+			projects: []ProjectWorkload{
+				{ID: "video", Workflow: workflowconfig.Config{Gate: gate.Config{Kind: gate.KindArtifact}}},
+				{ID: "podcast", Workflow: workflowconfig.Config{Gate: gate.Config{Kind: gate.KindHumanReview}}},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, offered := AgentPoolChoiceForProjects(tt.projects)
+			if offered != tt.wantOffered {
+				t.Fatalf("AgentPoolChoiceForProjects() offered = %t, want %t: %#v", offered, tt.wantOffered, got)
+			}
+			if !offered {
+				return
+			}
+			if len(got.Options) != 2 || got.Options[0].ID != "split" || got.Options[1].ID != "shared" {
+				t.Fatalf("options = %#v, want split and shared choices", got.Options)
+			}
+			if got.Question == "" || strings.Contains(strings.ToLower(got.Question), "warn") {
+				t.Fatalf("question = %q, want optional non-warning wording", got.Question)
+			}
+			if len(got.LocalProjects) != 1 || got.LocalProjects[0] != "detent" ||
+				len(got.CloudProjects) != 1 || got.CloudProjects[0] != "video" {
+				t.Fatalf("project classes = local %#v cloud %#v", got.LocalProjects, got.CloudProjects)
+			}
+		})
+	}
+}
+
+func TestSummarizeDeliveryProfileForProjectsIncludesPoolChoice(t *testing.T) {
+	t.Parallel()
+
+	summary, ok := SummarizeDeliveryProfileForProjects("full_autopilot", []ProjectWorkload{
+		{ID: "detent", Workflow: workflowconfig.Config{Gate: gate.Config{Kind: gate.KindCommand, Run: "make check"}}},
+		{ID: "video", Workflow: workflowconfig.Config{Gate: gate.Config{Kind: gate.KindArtifact}}},
+	})
+	if !ok {
+		t.Fatal("SummarizeDeliveryProfileForProjects() ok = false, want true")
+	}
+	if summary.AgentPoolChoice == nil {
+		t.Fatal("AgentPoolChoice = nil, want mixed-workload choice")
 	}
 }

--- a/internal/orchestrator/dispatch_recovery_test.go
+++ b/internal/orchestrator/dispatch_recovery_test.go
@@ -1,6 +1,7 @@
 package orchestrator
 
 import (
+	"context"
 	"encoding/json"
 	"testing"
 	"time"
@@ -77,6 +78,24 @@ func TestDispatchRecoveryTelemetryUsesAgentPoolCapacity(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewPoolRegistry() error = %v", err)
 	}
+	projectGate := gate.GateFor(project.ID)
+	slot, acquired, err := projectGate.TryAcquire(
+		context.Background(),
+		project,
+		scheduler.SlotRequest{State: "Todo"},
+		time.Now(),
+	)
+	if err != nil {
+		t.Fatalf("TryAcquire() error = %v", err)
+	}
+	if !acquired {
+		t.Fatal("TryAcquire() acquired = false, want true")
+	}
+	t.Cleanup(func() {
+		if err := projectGate.Release(slot); err != nil {
+			t.Fatalf("Release() error = %v", err)
+		}
+	})
 	cfg := normalizeConfig(Config{MaxConcurrentAgents: 2, Project: project})
 	orch := &Orchestrator{cfg: cfg, globalDispatchGate: gate}
 	state := newState(cfg)
@@ -100,6 +119,10 @@ func TestDispatchRecoveryTelemetryUsesAgentPoolCapacity(t *testing.T) {
 	}
 	if capacity["pool"] != "video" || capacity["pool_capacity"] != float64(5) {
 		t.Fatalf("capacity snapshot = %#v, want video pool capacity 5", capacity)
+	}
+	holders, ok := capacity["holders"].([]any)
+	if !ok || len(holders) != 1 || holders[0] != "detent" {
+		t.Fatalf("capacity holders = %#v, want detent", capacity["holders"])
 	}
 }
 

--- a/internal/orchestrator/work_attempts.go
+++ b/internal/orchestrator/work_attempts.go
@@ -944,7 +944,7 @@ func runningWorkAttemptMetadataJSON(running Running, metadata map[string]any) st
 func schedulerDecisionWaitReason(reason string) string {
 	switch strings.TrimSpace(reason) {
 	case dispatchSkipGlobalCapacityFull:
-		return scheduler.DispatchGateReasonGlobalCapacityFull
+		return "project_capacity_full"
 	case dispatchSkipLocalSlotUnavailable:
 		return "lane_capacity_full"
 	case dispatchIssueFailureGlobalSlotUnavailable:

--- a/internal/orchestrator/work_attempts.go
+++ b/internal/orchestrator/work_attempts.go
@@ -12,6 +12,7 @@ import (
 	"github.com/digitaldrywood/detent/internal/connector"
 	runpkg "github.com/digitaldrywood/detent/internal/runner"
 	"github.com/digitaldrywood/detent/internal/runtimeoutput"
+	"github.com/digitaldrywood/detent/internal/scheduler"
 	"github.com/digitaldrywood/detent/internal/store"
 	"github.com/digitaldrywood/detent/internal/telemetry"
 )
@@ -745,6 +746,7 @@ func (o *Orchestrator) capacitySnapshotJSON(state *State, issue connector.Issue)
 		"project_id":              strings.TrimSpace(o.cfg.Project.ID),
 		"pool":                    pool.Name,
 		"pool_capacity":           pool.Capacity,
+		"holders":                 pool.Holders,
 		"lane":                    normalizeState(issue.State),
 		"global_capacity":         pool.Capacity,
 		"global_used":             pool.Used,
@@ -942,11 +944,11 @@ func runningWorkAttemptMetadataJSON(running Running, metadata map[string]any) st
 func schedulerDecisionWaitReason(reason string) string {
 	switch strings.TrimSpace(reason) {
 	case dispatchSkipGlobalCapacityFull:
-		return "project_capacity_full"
+		return scheduler.DispatchGateReasonGlobalCapacityFull
 	case dispatchSkipLocalSlotUnavailable:
 		return "lane_capacity_full"
 	case dispatchIssueFailureGlobalSlotUnavailable:
-		return "project_capacity_full"
+		return scheduler.DispatchGateReasonGlobalCapacityFull
 	default:
 		return strings.TrimSpace(reason)
 	}

--- a/internal/orchestrator/work_attempts_wait_reason_test.go
+++ b/internal/orchestrator/work_attempts_wait_reason_test.go
@@ -15,9 +15,9 @@ func TestSchedulerDecisionWaitReason(t *testing.T) {
 		want   string
 	}{
 		{
-			name:   "planner pool capacity wait",
+			name:   "planner project capacity wait",
 			reason: dispatchSkipGlobalCapacityFull,
-			want:   scheduler.DispatchGateReasonGlobalCapacityFull,
+			want:   "project_capacity_full",
 		},
 		{
 			name:   "slot acquisition pool capacity wait",

--- a/internal/orchestrator/work_attempts_wait_reason_test.go
+++ b/internal/orchestrator/work_attempts_wait_reason_test.go
@@ -1,0 +1,48 @@
+package orchestrator
+
+import (
+	"testing"
+
+	"github.com/digitaldrywood/detent/internal/scheduler"
+)
+
+func TestSchedulerDecisionWaitReason(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		reason string
+		want   string
+	}{
+		{
+			name:   "planner pool capacity wait",
+			reason: dispatchSkipGlobalCapacityFull,
+			want:   scheduler.DispatchGateReasonGlobalCapacityFull,
+		},
+		{
+			name:   "slot acquisition pool capacity wait",
+			reason: dispatchIssueFailureGlobalSlotUnavailable,
+			want:   scheduler.DispatchGateReasonGlobalCapacityFull,
+		},
+		{
+			name:   "lane capacity wait",
+			reason: dispatchSkipLocalSlotUnavailable,
+			want:   "lane_capacity_full",
+		},
+		{
+			name:   "other reason",
+			reason: "provider_backoff",
+			want:   "provider_backoff",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			if got := schedulerDecisionWaitReason(tt.reason); got != tt.want {
+				t.Fatalf("schedulerDecisionWaitReason(%q) = %q, want %q", tt.reason, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/scheduler/global_gate.go
+++ b/internal/scheduler/global_gate.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"sort"
+	"strings"
 	"sync"
 	"time"
 )
@@ -106,12 +107,27 @@ func (g *GlobalDispatchGate) PoolSnapshot() PoolSnapshot {
 	defer g.mu.Unlock()
 
 	stats := g.capacitySnapshotLocked("")
+	holders := make([]string, 0, len(g.running))
+	seen := make(map[string]struct{}, len(g.running))
+	for _, running := range g.running {
+		projectID := strings.TrimSpace(running.ProjectID)
+		if projectID == "" {
+			continue
+		}
+		if _, ok := seen[projectID]; ok {
+			continue
+		}
+		seen[projectID] = struct{}{}
+		holders = append(holders, projectID)
+	}
+	sort.Strings(holders)
 	return PoolSnapshot{
 		Name:      g.poolName,
 		Capacity:  stats.globalCapacity,
 		Used:      stats.globalUsed,
 		Available: nonNegativeInt(stats.globalCapacity - stats.globalUsed),
 		Mode:      g.global.Mode(),
+		Holders:   holders,
 	}
 }
 

--- a/internal/scheduler/pool_registry.go
+++ b/internal/scheduler/pool_registry.go
@@ -24,6 +24,7 @@ type PoolSnapshot struct {
 	Mode       Mode
 	Draining   bool
 	Generation uint64
+	Holders    []string
 }
 
 type PoolSnapshotter interface {

--- a/internal/scheduler/pool_registry_test.go
+++ b/internal/scheduler/pool_registry_test.go
@@ -3,6 +3,7 @@ package scheduler_test
 import (
 	"context"
 	"errors"
+	"slices"
 	"strings"
 	"testing"
 	"time"
@@ -329,6 +330,9 @@ func TestProjectPoolGateRoutesLifecycleToCurrentPool(t *testing.T) {
 	}
 	if !acquired {
 		t.Fatal("TryAcquire() acquired = false, want true")
+	}
+	if snapshot := snapshotter.PoolSnapshot(); !slices.Equal(snapshot.Holders, []string{"video"}) {
+		t.Fatalf("PoolSnapshot().Holders = %#v, want video", snapshot.Holders)
 	}
 	gate.SetPreempt(slot, func() {})
 	if err := gate.Release(slot); err != nil {

--- a/internal/store/pool_contention.go
+++ b/internal/store/pool_contention.go
@@ -1,0 +1,122 @@
+package store
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+)
+
+const poolCapacityWaitReason = "global_capacity_full"
+
+type PoolContentionQuery struct {
+	Since          time.Time
+	ProjectClasses map[string]string
+}
+
+type CrossClassPoolContention struct {
+	Pool         string
+	WaitingClass string
+	HoldingClass string
+	WaitCount    int
+}
+
+type poolContentionQueryer interface {
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+}
+
+type poolCapacitySnapshot struct {
+	Pool    string   `json:"pool"`
+	Holders []string `json:"holders"`
+}
+
+func QueryCrossClassPoolContention(
+	ctx context.Context,
+	db poolContentionQueryer,
+	query PoolContentionQuery,
+) ([]CrossClassPoolContention, error) {
+	if db == nil {
+		return nil, errors.New("pool contention database is required")
+	}
+	if query.Since.IsZero() {
+		return nil, errors.New("pool contention start time is required")
+	}
+
+	since := query.Since.UTC().Truncate(time.Second).Format(time.RFC3339)
+	rows, err := db.QueryContext(ctx, `
+SELECT project_id, capacity_snapshot_json
+FROM work_attempts
+WHERE wait_reason = ?
+  AND COALESCE(NULLIF(heartbeat_at, ''), NULLIF(completed_at, ''), started_at) >= ?
+UNION ALL
+SELECT project_id, capacity_snapshot_json
+FROM scheduler_decisions
+WHERE wait_reason = ?
+  AND decision_at >= ?`,
+		poolCapacityWaitReason, since, poolCapacityWaitReason, since,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("querying pool capacity waits: %w", err)
+	}
+	defer rows.Close()
+
+	counts := map[string]CrossClassPoolContention{}
+	for rows.Next() {
+		var projectID string
+		var snapshotJSON string
+		if err := rows.Scan(&projectID, &snapshotJSON); err != nil {
+			return nil, fmt.Errorf("scanning pool capacity wait: %w", err)
+		}
+		waitingClass := strings.TrimSpace(query.ProjectClasses[strings.TrimSpace(projectID)])
+		if waitingClass == "" {
+			continue
+		}
+		var snapshot poolCapacitySnapshot
+		if err := json.Unmarshal([]byte(snapshotJSON), &snapshot); err != nil {
+			return nil, fmt.Errorf("decode pool capacity snapshot for project %s: %w", projectID, err)
+		}
+		pool := strings.TrimSpace(snapshot.Pool)
+		if pool == "" {
+			pool = "default"
+		}
+		holderClasses := make(map[string]struct{}, len(snapshot.Holders))
+		for _, holderID := range snapshot.Holders {
+			holderClass := strings.TrimSpace(query.ProjectClasses[strings.TrimSpace(holderID)])
+			if holderClass == "" || holderClass == waitingClass {
+				continue
+			}
+			holderClasses[holderClass] = struct{}{}
+		}
+		for holdingClass := range holderClasses {
+			key := strings.Join([]string{pool, waitingClass, holdingClass}, "\x00")
+			contention := counts[key]
+			contention.Pool = pool
+			contention.WaitingClass = waitingClass
+			contention.HoldingClass = holdingClass
+			contention.WaitCount++
+			counts[key] = contention
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate pool capacity waits: %w", err)
+	}
+
+	contention := make([]CrossClassPoolContention, 0, len(counts))
+	for _, item := range counts {
+		contention = append(contention, item)
+	}
+	sort.Slice(contention, func(i, j int) bool {
+		if contention[i].Pool != contention[j].Pool {
+			return contention[i].Pool < contention[j].Pool
+		}
+		if contention[i].WaitingClass != contention[j].WaitingClass {
+			return contention[i].WaitingClass < contention[j].WaitingClass
+		}
+		return contention[i].HoldingClass < contention[j].HoldingClass
+	})
+	return contention, nil
+}

--- a/internal/store/pool_contention_test.go
+++ b/internal/store/pool_contention_test.go
@@ -1,0 +1,117 @@
+package store
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestQueryCrossClassPoolContention(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	backend, err := Open(ctx, Config{
+		Backend: BackendSQLite,
+		Path:    filepath.Join(t.TempDir(), "detent.db"),
+	})
+	if err != nil {
+		t.Fatalf("Open() error = %v", err)
+	}
+	t.Cleanup(func() {
+		if err := backend.Close(); err != nil {
+			t.Fatalf("Close() error = %v", err)
+		}
+	})
+	sqliteBackend := backend.(*sqliteStore)
+
+	now := time.Date(2026, 7, 27, 18, 0, 0, 0, time.UTC)
+	rows := []struct {
+		name       string
+		projectID  string
+		startedAt  time.Time
+		waitReason string
+		snapshot   string
+	}{
+		{
+			name:       "cross class cloud wait",
+			projectID:  "video",
+			startedAt:  now.Add(-24 * time.Hour),
+			waitReason: poolCapacityWaitReason,
+			snapshot:   `{"pool":"default","holders":["detent"]}`,
+		},
+		{
+			name:       "cross class wait counts once per holder class",
+			projectID:  "video",
+			startedAt:  now.Add(-48 * time.Hour),
+			waitReason: poolCapacityWaitReason,
+			snapshot:   `{"pool":"default","holders":["detent","gopher-ai"]}`,
+		},
+		{
+			name:       "same class wait",
+			projectID:  "video",
+			startedAt:  now.Add(-72 * time.Hour),
+			waitReason: poolCapacityWaitReason,
+			snapshot:   `{"pool":"default","holders":["podcast"]}`,
+		},
+		{
+			name:       "outside seven day window",
+			projectID:  "video",
+			startedAt:  now.Add(-8 * 24 * time.Hour),
+			waitReason: poolCapacityWaitReason,
+			snapshot:   `{"pool":"default","holders":["detent"]}`,
+		},
+		{
+			name:       "different wait reason",
+			projectID:  "video",
+			startedAt:  now.Add(-time.Hour),
+			waitReason: "provider_capacity",
+			snapshot:   `{"pool":"default","holders":["detent"]}`,
+		},
+	}
+	for _, row := range rows {
+		t.Run(row.name, func(t *testing.T) {
+			if _, err := backend.StartWorkAttempt(ctx, WorkAttemptStart{
+				ProjectID:              row.projectID,
+				WorkerType:             "implement",
+				StartedAt:              row.startedAt,
+				WaitReason:             row.waitReason,
+				CapacitySnapshotJSON:   row.snapshot,
+				WorkerMetadataJSON:     "{}",
+				GitHubRateSnapshotJSON: "{}",
+				MetricsJSON:            "{}",
+			}); err != nil {
+				t.Fatalf("StartWorkAttempt() error = %v", err)
+			}
+		})
+	}
+	if _, err := backend.RecordSchedulerDecision(ctx, SchedulerDecision{
+		ProjectID:            "video",
+		Result:               SchedulerDecisionResultSkipped,
+		DecisionAt:           now.Add(-30 * time.Minute),
+		WaitReason:           poolCapacityWaitReason,
+		CapacitySnapshotJSON: `{"pool":"default","holders":["detent"]}`,
+	}); err != nil {
+		t.Fatalf("RecordSchedulerDecision() error = %v", err)
+	}
+
+	got, err := QueryCrossClassPoolContention(ctx, sqliteBackend.db, PoolContentionQuery{
+		Since: now.Add(-7 * 24 * time.Hour),
+		ProjectClasses: map[string]string{
+			"detent":    "local-heavy",
+			"gopher-ai": "local-heavy",
+			"video":     "cloud-only",
+			"podcast":   "cloud-only",
+		},
+	})
+	if err != nil {
+		t.Fatalf("QueryCrossClassPoolContention() error = %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("contention = %#v, want one cross-class aggregate", got)
+	}
+	if got[0].Pool != "default" || got[0].WaitingClass != "cloud-only" ||
+		got[0].HoldingClass != "local-heavy" || got[0].WaitCount != 3 {
+		t.Fatalf("contention[0] = %#v, want three cloud-only waits held by local-heavy", got[0])
+	}
+}

--- a/internal/workload/class.go
+++ b/internal/workload/class.go
@@ -1,0 +1,33 @@
+package workload
+
+import (
+	"strings"
+
+	workflowconfig "github.com/digitaldrywood/detent/internal/config"
+	"github.com/digitaldrywood/detent/internal/gate"
+)
+
+type Class string
+
+const (
+	ClassLocalHeavy Class = "local-heavy"
+	ClassCloudOnly  Class = "cloud-only"
+)
+
+type Signals struct {
+	LocalGate bool
+	CITrigger bool
+}
+
+func Classify(cfg workflowconfig.Config) (Class, Signals) {
+	signals := Signals{
+		LocalGate: cfg.Gate.Kind == gate.KindCommand && strings.TrimSpace(cfg.Gate.Run) != "" ||
+			cfg.Gate.Validator.Enabled,
+		CITrigger: strings.TrimSpace(cfg.Gate.CITriggerLabel) != "" ||
+			len(cfg.Gate.RequiredStatusChecks) > 0,
+	}
+	if signals.LocalGate || signals.CITrigger {
+		return ClassLocalHeavy, signals
+	}
+	return ClassCloudOnly, signals
+}

--- a/internal/workload/class_test.go
+++ b/internal/workload/class_test.go
@@ -1,0 +1,68 @@
+package workload
+
+import (
+	"testing"
+
+	workflowconfig "github.com/digitaldrywood/detent/internal/config"
+	"github.com/digitaldrywood/detent/internal/gate"
+)
+
+func TestClassify(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		cfg         workflowconfig.Config
+		wantClass   Class
+		wantSignals Signals
+	}{
+		{
+			name:      "command validation gate",
+			cfg:       workflowconfig.Config{Gate: gate.Config{Kind: gate.KindCommand, Run: "make check"}},
+			wantClass: ClassLocalHeavy,
+			wantSignals: Signals{
+				LocalGate: true,
+			},
+		},
+		{
+			name:      "validator",
+			cfg:       workflowconfig.Config{Gate: gate.Config{Validator: gate.ValidatorConfig{Enabled: true}}},
+			wantClass: ClassLocalHeavy,
+			wantSignals: Signals{
+				LocalGate: true,
+			},
+		},
+		{
+			name:      "CI trigger label",
+			cfg:       workflowconfig.Config{Gate: gate.Config{CITriggerLabel: "ci:ready"}},
+			wantClass: ClassLocalHeavy,
+			wantSignals: Signals{
+				CITrigger: true,
+			},
+		},
+		{
+			name:      "required CI checks",
+			cfg:       workflowconfig.Config{Gate: gate.Config{RequiredStatusChecks: []string{"test"}}},
+			wantClass: ClassLocalHeavy,
+			wantSignals: Signals{
+				CITrigger: true,
+			},
+		},
+		{
+			name:      "no local gate or CI trigger",
+			cfg:       workflowconfig.Config{Gate: gate.Config{Kind: gate.KindArtifact}},
+			wantClass: ClassCloudOnly,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			gotClass, gotSignals := Classify(tt.cfg)
+			if gotClass != tt.wantClass || gotSignals != tt.wantSignals {
+				t.Fatalf("Classify() = %q, %#v, want %q, %#v", gotClass, gotSignals, tt.wantClass, tt.wantSignals)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- Classify resolved project workflows and recommend pool splits only when seven-day telemetry shows cross-class capacity waits.
- Add a confirmation-gated, YAML-preserving `detent fix agent-pools` command and optional onboarding guidance.
- Record pool holder projects in capacity telemetry while distinguishing project-local saturation from shared-pool exhaustion.

Fixes #1514

## UI Surface Contract

- [x] N/A — this change adds CLI doctor/fix output and onboarding profile guidance, not a persistent operator screen.
- [x] No persistent screen was added; the CLI output is the sole operator surface.
- [x] No existing primary operator screen was visually changed.

## Test Plan

- [x] `make check`
- [x] `go test -race ./internal/cli ./internal/onboarding ./internal/store ./internal/scheduler ./internal/orchestrator ./internal/workload -count=1`
- [x] `GOOS=windows GOARCH=amd64 go test -c ./internal/cli`
- [x] Current-head GitHub CI: 11/11 checks passed