### PR TITLE
fix(telemetry): persist fleet-gate slot refusals

### DIFF
--- a/internal/cli/doctor_agent_pools_test.go
+++ b/internal/cli/doctor_agent_pools_test.go
@@ -123,17 +123,15 @@ func TestCheckDoctorAgentPools(t *testing.T) {
 				t.Fatalf("store.Open() error = %v", err)
 			}
 			if tt.waiting != "" {
-				if _, err := backend.StartWorkAttempt(t.Context(), store.WorkAttemptStart{
-					ProjectID:              tt.waiting,
-					WorkerType:             "implement",
-					StartedAt:              now.Add(-time.Hour),
-					WaitReason:             "global_capacity_full",
-					CapacitySnapshotJSON:   `{"pool":"default","holders":` + tt.holders + `}`,
-					GitHubRateSnapshotJSON: "{}",
-					WorkerMetadataJSON:     "{}",
-					MetricsJSON:            "{}",
+				if _, err := backend.RecordSchedulerDecision(t.Context(), store.SchedulerDecision{
+					ProjectID:            tt.waiting,
+					Result:               store.SchedulerDecisionResultSkipped,
+					Reason:               "reserved_for_higher_priority_project",
+					DecisionAt:           now.Add(-time.Hour),
+					WaitReason:           "reserved_for_higher_priority_project",
+					CapacitySnapshotJSON: `{"pool":"default","global_available":0,"holders":` + tt.holders + `}`,
 				}); err != nil {
-					t.Fatalf("StartWorkAttempt() error = %v", err)
+					t.Fatalf("RecordSchedulerDecision() error = %v", err)
 				}
 			}
 			if err := backend.Close(); err != nil {

--- a/internal/cli/fix_agent_pools_test.go
+++ b/internal/cli/fix_agent_pools_test.go
@@ -272,17 +272,15 @@ func newAgentPoolsFixFixture(t *testing.T, contention bool) agentPoolsFixFixture
 	}
 	now := time.Date(2026, 7, 27, 20, 0, 0, 0, time.UTC)
 	if contention {
-		if _, err := backend.StartWorkAttempt(t.Context(), store.WorkAttemptStart{
-			ProjectID:              "video",
-			WorkerType:             "implement",
-			StartedAt:              now.Add(-time.Hour),
-			WaitReason:             "global_capacity_full",
-			CapacitySnapshotJSON:   `{"pool":"default","holders":["detent"]}`,
-			GitHubRateSnapshotJSON: "{}",
-			WorkerMetadataJSON:     "{}",
-			MetricsJSON:            "{}",
+		if _, err := backend.RecordSchedulerDecision(t.Context(), store.SchedulerDecision{
+			ProjectID:            "video",
+			Result:               store.SchedulerDecisionResultSkipped,
+			Reason:               "reserved_for_higher_priority_project",
+			DecisionAt:           now.Add(-time.Hour),
+			WaitReason:           "reserved_for_higher_priority_project",
+			CapacitySnapshotJSON: `{"pool":"default","global_available":0,"holders":["detent"]}`,
 		}); err != nil {
-			t.Fatalf("StartWorkAttempt() error = %v", err)
+			t.Fatalf("RecordSchedulerDecision() error = %v", err)
 		}
 	}
 	if err := backend.Close(); err != nil {

--- a/internal/orchestrator/diagnostics.go
+++ b/internal/orchestrator/diagnostics.go
@@ -11,6 +11,7 @@ import (
 	"github.com/digitaldrywood/detent/internal/connector"
 	runpkg "github.com/digitaldrywood/detent/internal/runner"
 	"github.com/digitaldrywood/detent/internal/scheduler"
+	"github.com/digitaldrywood/detent/internal/store"
 )
 
 const (
@@ -18,7 +19,16 @@ const (
 	workerOutcomeFailed    = "failed"
 	workerOutcomeCancelled = "cancelled"
 	workerOutcomeTimedOut  = "timed_out"
+
+	dispatchGateSampleInterval = 5 * time.Minute
 )
+
+type dispatchGateSampleKey struct {
+	pool              string
+	reason            string
+	globalCapacity    int
+	capacityExhausted bool
+}
 
 func (o *Orchestrator) logDispatchPlanDecision(ctx context.Context, state *State, now time.Time, decision dispatchPlanDecision) {
 	result := "skipped"
@@ -85,6 +95,134 @@ func (o *Orchestrator) logSchedulerSlotDecision(issue connector.Issue, outcome s
 		"running_projects", decision.RunningProjects,
 	)
 	o.logger.Debug("scheduler_dispatch_slot_decision", attrs...)
+}
+
+func (o *Orchestrator) recordDispatchGateRefusal(
+	ctx context.Context,
+	state *State,
+	issue connector.Issue,
+	attempt int,
+	workerHost string,
+	now time.Time,
+	decision scheduler.DispatchGateDecision,
+	projectStats projectStateSlotStats,
+) {
+	if o == nil {
+		return
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if now.IsZero() {
+		now = time.Now()
+	}
+	reason := strings.TrimSpace(decision.Reason)
+	if reason == "" {
+		reason = dispatchIssueFailureGlobalSlotUnavailable
+	}
+	pool := strings.TrimSpace(decision.PoolName)
+	if pool == "" {
+		pool = scheduler.DefaultPoolName
+	}
+	key := dispatchGateSampleKey{
+		pool:              pool,
+		reason:            reason,
+		globalCapacity:    decision.GlobalCapacity,
+		capacityExhausted: decision.GlobalAvailable == 0,
+	}
+	if !o.reserveDispatchGateSample(key, now) {
+		return
+	}
+
+	record := store.SchedulerDecision{
+		ProjectID:            strings.TrimSpace(o.cfg.Project.ID),
+		IssueID:              strings.TrimSpace(issue.ID),
+		Identifier:           strings.TrimSpace(issue.Identifier),
+		IssueURL:             strings.TrimSpace(issue.URL),
+		PRNumber:             workAttemptPRNumber(issue),
+		Repo:                 workAttemptRepository(issue),
+		Lane:                 strings.TrimSpace(issue.State),
+		Result:               store.SchedulerDecisionResultSkipped,
+		Reason:               reason,
+		AttemptNumber:        attempt,
+		WorkerHost:           strings.TrimSpace(workerHost),
+		DecisionAt:           now,
+		WaitReason:           reason,
+		CapacitySnapshotJSON: o.dispatchGateCapacitySnapshotJSON(issue, decision, projectStats),
+		MetadataJSON: marshalWorkAttemptJSON(map[string]any{
+			"decision_kind":           "dispatch_gate_refusal",
+			"sample_interval_seconds": int64(dispatchGateSampleInterval / time.Second),
+		}),
+	}
+	snapshot := telemetrySchedulerDecision(record)
+	if o.workAttempts != nil {
+		id, err := o.workAttempts.RecordSchedulerDecision(ctx, record)
+		if err != nil {
+			o.releaseDispatchGateSample(key, now)
+			if o.logger != nil {
+				o.logger.Warn("record dispatch gate refusal failed", "issue_id", issue.ID, "reason", reason, "error", err)
+			}
+		} else {
+			snapshot.ID = id
+		}
+	}
+	appendSchedulerDecisionSnapshot(state, snapshot)
+}
+
+func (o *Orchestrator) reserveDispatchGateSample(key dispatchGateSampleKey, now time.Time) bool {
+	o.dispatchGateSampleMu.Lock()
+	defer o.dispatchGateSampleMu.Unlock()
+
+	if o.dispatchGateSamples == nil {
+		o.dispatchGateSamples = map[dispatchGateSampleKey]time.Time{}
+	}
+	if last, ok := o.dispatchGateSamples[key]; ok && now.Before(last.Add(dispatchGateSampleInterval)) {
+		return false
+	}
+	o.dispatchGateSamples[key] = now
+	return true
+}
+
+func (o *Orchestrator) releaseDispatchGateSample(key dispatchGateSampleKey, sampledAt time.Time) {
+	o.dispatchGateSampleMu.Lock()
+	defer o.dispatchGateSampleMu.Unlock()
+
+	if current, ok := o.dispatchGateSamples[key]; ok && current.Equal(sampledAt) {
+		delete(o.dispatchGateSamples, key)
+	}
+}
+
+func (o *Orchestrator) dispatchGateCapacitySnapshotJSON(
+	issue connector.Issue,
+	decision scheduler.DispatchGateDecision,
+	projectStats projectStateSlotStats,
+) string {
+	pool := o.dispatchPoolSnapshot()
+	poolName := strings.TrimSpace(decision.PoolName)
+	if poolName == "" {
+		poolName = strings.TrimSpace(pool.Name)
+	}
+	if poolName == "" {
+		poolName = scheduler.DefaultPoolName
+	}
+	return marshalWorkAttemptJSON(map[string]any{
+		"project_id":              strings.TrimSpace(o.cfg.Project.ID),
+		"pool":                    poolName,
+		"pool_capacity":           decision.GlobalCapacity,
+		"holders":                 pool.Holders,
+		"lane":                    normalizeState(issue.State),
+		"global_capacity":         decision.GlobalCapacity,
+		"global_used":             decision.GlobalUsed,
+		"global_available":        decision.GlobalAvailable,
+		"project_state_capacity":  projectStats.capacity,
+		"project_state_used":      projectStats.used,
+		"project_state_available": projectStats.available,
+		"selected_project_id":     strings.TrimSpace(decision.SelectedProjectID),
+		"selected_state":          strings.TrimSpace(decision.SelectedState),
+		"lower_priority_running":  decision.LowerPriorityRunning,
+		"ready_projects":          decision.ReadyProjects,
+		"running_projects":        decision.RunningProjects,
+	})
 }
 
 func (o *Orchestrator) logWorkerLifecycle(issue connector.Issue, event string, attrs ...any) {

--- a/internal/orchestrator/diagnostics.go
+++ b/internal/orchestrator/diagnostics.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"net/url"
+	"sort"
 	"strings"
 	"time"
 
@@ -28,6 +29,7 @@ type dispatchGateSampleKey struct {
 	reason            string
 	globalCapacity    int
 	capacityExhausted bool
+	holders           string
 }
 
 func (o *Orchestrator) logDispatchPlanDecision(ctx context.Context, state *State, now time.Time, decision dispatchPlanDecision) {
@@ -124,11 +126,13 @@ func (o *Orchestrator) recordDispatchGateRefusal(
 	if pool == "" {
 		pool = scheduler.DefaultPoolName
 	}
+	decision.Holders = normalizeDispatchGateHolders(decision.Holders)
 	key := dispatchGateSampleKey{
 		pool:              pool,
 		reason:            reason,
 		globalCapacity:    decision.GlobalCapacity,
 		capacityExhausted: decision.GlobalAvailable == 0,
+		holders:           strings.Join(decision.Holders, "\x00"),
 	}
 	if !o.reserveDispatchGateSample(key, now) {
 		return
@@ -197,11 +201,7 @@ func (o *Orchestrator) dispatchGateCapacitySnapshotJSON(
 	decision scheduler.DispatchGateDecision,
 	projectStats projectStateSlotStats,
 ) string {
-	pool := o.dispatchPoolSnapshot()
 	poolName := strings.TrimSpace(decision.PoolName)
-	if poolName == "" {
-		poolName = strings.TrimSpace(pool.Name)
-	}
 	if poolName == "" {
 		poolName = scheduler.DefaultPoolName
 	}
@@ -209,7 +209,7 @@ func (o *Orchestrator) dispatchGateCapacitySnapshotJSON(
 		"project_id":              strings.TrimSpace(o.cfg.Project.ID),
 		"pool":                    poolName,
 		"pool_capacity":           decision.GlobalCapacity,
-		"holders":                 pool.Holders,
+		"holders":                 decision.Holders,
 		"lane":                    normalizeState(issue.State),
 		"global_capacity":         decision.GlobalCapacity,
 		"global_used":             decision.GlobalUsed,
@@ -223,6 +223,24 @@ func (o *Orchestrator) dispatchGateCapacitySnapshotJSON(
 		"ready_projects":          decision.ReadyProjects,
 		"running_projects":        decision.RunningProjects,
 	})
+}
+
+func normalizeDispatchGateHolders(holders []string) []string {
+	normalized := make([]string, 0, len(holders))
+	seen := make(map[string]struct{}, len(holders))
+	for _, holder := range holders {
+		holder = strings.TrimSpace(holder)
+		if holder == "" {
+			continue
+		}
+		if _, ok := seen[holder]; ok {
+			continue
+		}
+		seen[holder] = struct{}{}
+		normalized = append(normalized, holder)
+	}
+	sort.Strings(normalized)
+	return normalized
 }
 
 func (o *Orchestrator) logWorkerLifecycle(issue connector.Issue, event string, attrs ...any) {

--- a/internal/orchestrator/dispatch.go
+++ b/internal/orchestrator/dispatch.go
@@ -305,6 +305,7 @@ func (o *Orchestrator) dispatchIssueWithOutcome(
 
 	globalSlot, ok, decision := o.acquireGlobalDispatchSlot(ctx, slotIssue, workerHost, now)
 	if !ok {
+		o.recordDispatchGateRefusal(ctx, state, issue, attempt, workerHost, now, decision, projectStats)
 		o.logSchedulerSlotDecision(issue, "waiting", decision, projectStats)
 		if mergeWorkerIssue(issue) {
 			o.logMergeWorkerSlotWait(issue, decision, projectStats)

--- a/internal/orchestrator/dispatch_test.go
+++ b/internal/orchestrator/dispatch_test.go
@@ -2200,6 +2200,114 @@ func TestDispatchReadyIssuesRecordsNonMergeSlotWaitTelemetry(t *testing.T) {
 	}
 }
 
+func TestRecordDispatchGateRefusalPersistsPoolArbitrationReasons(t *testing.T) {
+	t.Parallel()
+
+	reasons := []string{
+		scheduler.DispatchGateReasonGlobalCapacityFull,
+		scheduler.DispatchGateReasonReservedForHigherPriorityProject,
+		scheduler.DispatchGateReasonReservedForHigherPriority,
+		scheduler.DispatchGateReasonSelectedProjectWaiting,
+	}
+	for _, reason := range reasons {
+		t.Run(reason, func(t *testing.T) {
+			t.Parallel()
+
+			cfg := normalizeConfig(Config{
+				MaxConcurrentAgents: 1,
+				ActiveStates:        []string{"Todo"},
+				TerminalStates:      []string{"Done"},
+				Project:             scheduler.ProjectCandidate{ID: "cloud"},
+			})
+			attempts := &recordingWorkAttemptStore{}
+			orch := Orchestrator{cfg: cfg, workAttempts: attempts}
+			state := newState(cfg)
+			issue := dispatchTestIssue("issue-cloud", "Todo")
+			now := time.Date(2026, 7, 28, 10, 0, 0, 0, time.UTC)
+
+			orch.recordDispatchGateRefusal(
+				t.Context(),
+				&state,
+				issue,
+				2,
+				"worker-a",
+				now,
+				scheduler.DispatchGateDecision{
+					PoolName:          "shared",
+					Reason:            reason,
+					GlobalCapacity:    5,
+					GlobalUsed:        5,
+					GlobalAvailable:   0,
+					SelectedProjectID: "local",
+					SelectedState:     "Merging",
+				},
+				projectStateSlotStats{capacity: 2, used: 1, available: 1},
+			)
+
+			if len(attempts.decisions) != 1 {
+				t.Fatalf("scheduler decisions = %#v, want one gate refusal", attempts.decisions)
+			}
+			got := attempts.decisions[0]
+			if got.Result != store.SchedulerDecisionResultSkipped ||
+				got.Reason != reason ||
+				got.WaitReason != reason ||
+				got.ProjectID != "cloud" ||
+				got.AttemptNumber != 2 ||
+				got.WorkerHost != "worker-a" {
+				t.Fatalf("scheduler decision = %#v, want durable %q refusal", got, reason)
+			}
+			for _, fragment := range []string{
+				`"pool":"shared"`,
+				`"global_capacity":5`,
+				`"global_used":5`,
+				`"global_available":0`,
+				`"selected_project_id":"local"`,
+			} {
+				if !strings.Contains(got.CapacitySnapshotJSON, fragment) {
+					t.Fatalf("capacity snapshot %q missing %q", got.CapacitySnapshotJSON, fragment)
+				}
+			}
+			if !strings.Contains(got.MetadataJSON, `"sample_interval_seconds":300`) {
+				t.Fatalf("metadata = %q, want documented sampling interval", got.MetadataJSON)
+			}
+		})
+	}
+}
+
+func TestRecordDispatchGateRefusalSamplesEquivalentCandidates(t *testing.T) {
+	t.Parallel()
+
+	cfg := normalizeConfig(Config{
+		MaxConcurrentAgents: 1,
+		ActiveStates:        []string{"Todo"},
+		TerminalStates:      []string{"Done"},
+		Project:             scheduler.ProjectCandidate{ID: "cloud"},
+	})
+	attempts := &recordingWorkAttemptStore{}
+	orch := Orchestrator{cfg: cfg, workAttempts: attempts}
+	state := newState(cfg)
+	now := time.Date(2026, 7, 28, 10, 0, 0, 0, time.UTC)
+	decision := scheduler.DispatchGateDecision{
+		PoolName:        "shared",
+		Reason:          scheduler.DispatchGateReasonGlobalCapacityFull,
+		GlobalCapacity:  5,
+		GlobalUsed:      5,
+		GlobalAvailable: 0,
+	}
+	projectStats := projectStateSlotStats{capacity: 2, used: 1, available: 1}
+
+	orch.recordDispatchGateRefusal(t.Context(), &state, dispatchTestIssue("issue-a", "Todo"), 0, "", now, decision, projectStats)
+	orch.recordDispatchGateRefusal(t.Context(), &state, dispatchTestIssue("issue-b", "Todo"), 0, "", now.Add(time.Minute), decision, projectStats)
+	orch.recordDispatchGateRefusal(t.Context(), &state, dispatchTestIssue("issue-b", "Todo"), 0, "", now.Add(dispatchGateSampleInterval), decision, projectStats)
+
+	if len(attempts.decisions) != 2 {
+		t.Fatalf("scheduler decisions = %#v, want one sample per five-minute condition window", attempts.decisions)
+	}
+	if attempts.decisions[0].IssueID != "issue-a" || attempts.decisions[1].IssueID != "issue-b" {
+		t.Fatalf("sampled issues = %q/%q, want representative candidates across windows", attempts.decisions[0].IssueID, attempts.decisions[1].IssueID)
+	}
+}
+
 func TestDispatchReadyIssuesHydratesLightweightCandidateBeforeDependencyGate(t *testing.T) {
 	t.Parallel()
 

--- a/internal/orchestrator/dispatch_test.go
+++ b/internal/orchestrator/dispatch_test.go
@@ -2234,6 +2234,7 @@ func TestRecordDispatchGateRefusalPersistsPoolArbitrationReasons(t *testing.T) {
 				now,
 				scheduler.DispatchGateDecision{
 					PoolName:          "shared",
+					Holders:           []string{"local"},
 					Reason:            reason,
 					GlobalCapacity:    5,
 					GlobalUsed:        5,
@@ -2258,6 +2259,7 @@ func TestRecordDispatchGateRefusalPersistsPoolArbitrationReasons(t *testing.T) {
 			}
 			for _, fragment := range []string{
 				`"pool":"shared"`,
+				`"holders":["local"]`,
 				`"global_capacity":5`,
 				`"global_used":5`,
 				`"global_available":0`,
@@ -2293,18 +2295,29 @@ func TestRecordDispatchGateRefusalSamplesEquivalentCandidates(t *testing.T) {
 		GlobalCapacity:  5,
 		GlobalUsed:      5,
 		GlobalAvailable: 0,
+		Holders:         []string{"detent"},
 	}
 	projectStats := projectStateSlotStats{capacity: 2, used: 1, available: 1}
 
 	orch.recordDispatchGateRefusal(t.Context(), &state, dispatchTestIssue("issue-a", "Todo"), 0, "", now, decision, projectStats)
 	orch.recordDispatchGateRefusal(t.Context(), &state, dispatchTestIssue("issue-b", "Todo"), 0, "", now.Add(time.Minute), decision, projectStats)
+	changedHolders := decision
+	changedHolders.Holders = []string{"podcast"}
+	orch.recordDispatchGateRefusal(t.Context(), &state, dispatchTestIssue("issue-c", "Todo"), 0, "", now.Add(2*time.Minute), changedHolders, projectStats)
 	orch.recordDispatchGateRefusal(t.Context(), &state, dispatchTestIssue("issue-b", "Todo"), 0, "", now.Add(dispatchGateSampleInterval), decision, projectStats)
 
-	if len(attempts.decisions) != 2 {
-		t.Fatalf("scheduler decisions = %#v, want one sample per five-minute condition window", attempts.decisions)
+	if len(attempts.decisions) != 3 {
+		t.Fatalf("scheduler decisions = %#v, want one sample per holder set and five-minute condition window", attempts.decisions)
 	}
-	if attempts.decisions[0].IssueID != "issue-a" || attempts.decisions[1].IssueID != "issue-b" {
-		t.Fatalf("sampled issues = %q/%q, want representative candidates across windows", attempts.decisions[0].IssueID, attempts.decisions[1].IssueID)
+	if attempts.decisions[0].IssueID != "issue-a" ||
+		attempts.decisions[1].IssueID != "issue-c" ||
+		attempts.decisions[2].IssueID != "issue-b" {
+		t.Fatalf(
+			"sampled issues = %q/%q/%q, want holder change and representative candidate across windows",
+			attempts.decisions[0].IssueID,
+			attempts.decisions[1].IssueID,
+			attempts.decisions[2].IssueID,
+		)
 	}
 }
 

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -213,6 +213,8 @@ type Orchestrator struct {
 	heartbeats              *heartbeatManager
 	hydrationSkipStreaks    map[string]int
 	hydrationWarned         bool
+	dispatchGateSampleMu    sync.Mutex
+	dispatchGateSamples     map[dispatchGateSampleKey]time.Time
 	ciTriggerLabelMu        sync.Mutex
 	ciTriggerLabelHeads     map[string]ciTriggerLabelHead
 	stateRequests           chan stateRequest
@@ -442,6 +444,7 @@ func New(cfg Config, deps Dependencies) (*Orchestrator, error) {
 		dailyBudgetStatus:       dailyBudgetStatus,
 		issueBudgetStatus:       issueBudgetStatus,
 		now:                     now,
+		dispatchGateSamples:     map[dispatchGateSampleKey]time.Time{},
 		ciTriggerLabelHeads:     map[string]ciTriggerLabelHead{},
 		stateRequests:           make(chan stateRequest),
 		drainRequests:           make(chan drainRequest),

--- a/internal/scheduler/global_gate.go
+++ b/internal/scheduler/global_gate.go
@@ -29,6 +29,7 @@ type ProjectDispatchGate interface {
 type DispatchGateDecision struct {
 	ProjectID            string
 	PoolName             string
+	Holders              []string
 	State                string
 	SelectedProjectID    string
 	SelectedState        string
@@ -107,6 +108,18 @@ func (g *GlobalDispatchGate) PoolSnapshot() PoolSnapshot {
 	defer g.mu.Unlock()
 
 	stats := g.capacitySnapshotLocked("")
+	holders := g.holderProjectIDsLocked()
+	return PoolSnapshot{
+		Name:      g.poolName,
+		Capacity:  stats.globalCapacity,
+		Used:      stats.globalUsed,
+		Available: nonNegativeInt(stats.globalCapacity - stats.globalUsed),
+		Mode:      g.global.Mode(),
+		Holders:   holders,
+	}
+}
+
+func (g *GlobalDispatchGate) holderProjectIDsLocked() []string {
 	holders := make([]string, 0, len(g.running))
 	seen := make(map[string]struct{}, len(g.running))
 	for _, running := range g.running {
@@ -121,14 +134,7 @@ func (g *GlobalDispatchGate) PoolSnapshot() PoolSnapshot {
 		holders = append(holders, projectID)
 	}
 	sort.Strings(holders)
-	return PoolSnapshot{
-		Name:      g.poolName,
-		Capacity:  stats.globalCapacity,
-		Used:      stats.globalUsed,
-		Available: nonNegativeInt(stats.globalCapacity - stats.globalUsed),
-		Mode:      g.global.Mode(),
-		Holders:   holders,
-	}
+	return holders
 }
 
 func (g *GlobalDispatchGate) SetProjects(projects []ProjectCandidate) {
@@ -601,6 +607,7 @@ func (g *GlobalDispatchGate) decisionLocked(projectID string, req SlotRequest, r
 	return DispatchGateDecision{
 		ProjectID:            projectID,
 		PoolName:             g.poolName,
+		Holders:              g.holderProjectIDsLocked(),
 		State:                req.State,
 		SelectedProjectID:    selectedProjectID,
 		SelectedState:        selectedState,

--- a/internal/scheduler/global_gate_test.go
+++ b/internal/scheduler/global_gate_test.go
@@ -3,6 +3,7 @@ package scheduler_test
 import (
 	"context"
 	"errors"
+	"slices"
 	"testing"
 	"time"
 
@@ -114,6 +115,8 @@ func TestGlobalDispatchGateReservesFreedSlotForPendingMergeLane(t *testing.T) {
 		t.Fatal("merge waiting TryAcquireWithDecision() ok = true while the global slot is held, want false")
 	} else if decision.SelectedProjectID != mergeProject.ID || decision.Reason != scheduler.DispatchGateReasonGlobalCapacityFull {
 		t.Fatalf("merge waiting decision = %#v, want selected merge with global capacity full", decision)
+	} else if !slices.Equal(decision.Holders, []string{todoProject.ID}) {
+		t.Fatalf("merge waiting holders = %#v, want refusal-time holder %q", decision.Holders, todoProject.ID)
 	}
 
 	if err := gate.Release(todoSlot); err != nil {

--- a/internal/store/pool_contention.go
+++ b/internal/store/pool_contention.go
@@ -11,7 +11,12 @@ import (
 	"time"
 )
 
-const poolCapacityWaitReason = "global_capacity_full"
+const (
+	poolCapacityWaitReason              = "global_capacity_full"
+	poolHigherPriorityProjectWaitReason = "reserved_for_higher_priority_project"
+	poolHigherPriorityStateWaitReason   = "reserved_for_higher_priority_state"
+	poolSelectedProjectWaitReason       = "selected_project_waiting"
+)
 
 type PoolContentionQuery struct {
 	Since          time.Time
@@ -49,15 +54,15 @@ func QueryCrossClassPoolContention(
 	since := query.Since.UTC().Truncate(time.Second).Format(time.RFC3339)
 	rows, err := db.QueryContext(ctx, `
 SELECT project_id, capacity_snapshot_json
-FROM work_attempts
-WHERE wait_reason = ?
-  AND COALESCE(NULLIF(heartbeat_at, ''), NULLIF(completed_at, ''), started_at) >= ?
-UNION ALL
-SELECT project_id, capacity_snapshot_json
 FROM scheduler_decisions
-WHERE wait_reason = ?
-  AND decision_at >= ?`,
-		poolCapacityWaitReason, since, poolCapacityWaitReason, since,
+WHERE wait_reason IN (?, ?, ?, ?)
+  AND decision_at >= ?
+  AND COALESCE(CAST(json_extract(capacity_snapshot_json, '$.global_available') AS INTEGER), -1) = 0`,
+		poolCapacityWaitReason,
+		poolHigherPriorityProjectWaitReason,
+		poolHigherPriorityStateWaitReason,
+		poolSelectedProjectWaitReason,
+		since,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("querying pool capacity waits: %w", err)

--- a/internal/store/pool_contention_e2e_test.go
+++ b/internal/store/pool_contention_e2e_test.go
@@ -1,0 +1,199 @@
+package store_test
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"io"
+	"log/slog"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/digitaldrywood/detent/internal/connector"
+	"github.com/digitaldrywood/detent/internal/connector/memory"
+	"github.com/digitaldrywood/detent/internal/orchestrator"
+	"github.com/digitaldrywood/detent/internal/scheduler"
+	"github.com/digitaldrywood/detent/internal/store"
+)
+
+func TestPoolContentionTelemetryEndToEnd(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	dbPath := filepath.Join(t.TempDir(), "detent.db")
+	runtimeStore, err := store.Open(ctx, store.Config{
+		Backend: store.BackendSQLite,
+		Path:    dbPath,
+	})
+	if err != nil {
+		t.Fatalf("store.Open() error = %v", err)
+	}
+	t.Cleanup(func() {
+		if err := runtimeStore.Close(); err != nil {
+			t.Fatalf("runtime store Close() error = %v", err)
+		}
+	})
+
+	localProject := scheduler.ProjectCandidate{ID: "local", Weight: 1, Priority: 0}
+	cloudProject := scheduler.ProjectCandidate{ID: "cloud", Weight: 1, Priority: 1}
+	dispatchGate := scheduler.NewGlobalDispatchGate(
+		scheduler.NewStrictPriority(scheduler.Config{Capacity: 1}),
+		localProject,
+		cloudProject,
+	)
+	localSlot, acquired, decision, err := dispatchGate.TryAcquireWithDecision(
+		ctx,
+		localProject,
+		scheduler.SlotRequest{State: "Todo"},
+		time.Now(),
+	)
+	if err != nil {
+		t.Fatalf("local TryAcquireWithDecision() error = %v", err)
+	}
+	if !acquired {
+		t.Fatalf("local TryAcquireWithDecision() acquired = false; decision = %#v", decision)
+	}
+	t.Cleanup(func() {
+		if err := dispatchGate.Release(localSlot); err != nil && !errors.Is(err, scheduler.ErrSlotNotHeld) {
+			t.Fatalf("dispatch gate Release() error = %v", err)
+		}
+	})
+
+	issue := connector.NewIssue()
+	issue.ID = "issue-cloud"
+	issue.Identifier = "digitaldrywood/video#42"
+	issue.Title = "render cloud video"
+	issue.State = "Todo"
+	issue.URL = "https://github.com/digitaldrywood/video/issues/42"
+
+	orch, err := orchestrator.New(orchestrator.Config{
+		PollInterval:        time.Hour,
+		MaxConcurrentAgents: 1,
+		ActiveStates:        []string{"Todo"},
+		TerminalStates:      []string{"Done"},
+		Project:             cloudProject,
+	}, orchestrator.Dependencies{
+		Connector:          memory.New(memory.Config{Issues: []connector.Issue{issue}}),
+		WorkAttempts:       runtimeStore,
+		GlobalDispatchGate: dispatchGate,
+		Logger:             slog.New(slog.NewTextHandler(io.Discard, nil)),
+	})
+	if err != nil {
+		t.Fatalf("orchestrator.New() error = %v", err)
+	}
+
+	runCtx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- orch.Run(runCtx)
+	}()
+
+	refusal := waitForSchedulerDecision(
+		t,
+		runtimeStore,
+		scheduler.DispatchGateReasonReservedForHigherPriorityProject,
+	)
+	cancel()
+	select {
+	case err := <-errCh:
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("orchestrator Run() error = %v, want context canceled", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for orchestrator to stop")
+	}
+
+	if refusal.ProjectID != cloudProject.ID || refusal.IssueID != issue.ID {
+		t.Fatalf("refusal identity = %q/%q, want %q/%q", refusal.ProjectID, refusal.IssueID, cloudProject.ID, issue.ID)
+	}
+	if refusal.Result != store.SchedulerDecisionResultSkipped || refusal.WaitReason != refusal.Reason {
+		t.Fatalf("refusal result/reason = %q/%q/%q, want skipped gate reason", refusal.Result, refusal.Reason, refusal.WaitReason)
+	}
+	var capacity map[string]any
+	if err := json.Unmarshal([]byte(refusal.CapacitySnapshotJSON), &capacity); err != nil {
+		t.Fatalf("capacity snapshot JSON error = %v", err)
+	}
+	for key, want := range map[string]any{
+		"pool":                scheduler.DefaultPoolName,
+		"global_capacity":     float64(1),
+		"global_used":         float64(1),
+		"global_available":    float64(0),
+		"selected_project_id": localProject.ID,
+	} {
+		if got := capacity[key]; got != want {
+			t.Fatalf("capacity[%q] = %#v, want %#v; snapshot = %s", key, got, want, refusal.CapacitySnapshotJSON)
+		}
+	}
+
+	attempts, err := runtimeStore.ListActiveWorkAttempts(ctx, store.WorkAttemptQuery{ProjectID: cloudProject.ID})
+	if err != nil {
+		t.Fatalf("ListActiveWorkAttempts() error = %v", err)
+	}
+	if len(attempts) != 0 {
+		t.Fatalf("active work attempts = %#v, want none for pre-acquisition wait", attempts)
+	}
+
+	db, err := sql.Open("sqlite", dbPath)
+	if err != nil {
+		t.Fatalf("sql.Open() error = %v", err)
+	}
+	t.Cleanup(func() {
+		if err := db.Close(); err != nil {
+			t.Fatalf("query database Close() error = %v", err)
+		}
+	})
+	contention, err := store.QueryCrossClassPoolContention(ctx, db, store.PoolContentionQuery{
+		Since: time.Now().Add(-time.Hour),
+		ProjectClasses: map[string]string{
+			localProject.ID: "local-heavy",
+			cloudProject.ID: "cloud-only",
+		},
+	})
+	if err != nil {
+		t.Fatalf("QueryCrossClassPoolContention() error = %v", err)
+	}
+	if len(contention) != 1 || contention[0].WaitCount != 1 ||
+		contention[0].WaitingClass != "cloud-only" ||
+		contention[0].HoldingClass != "local-heavy" {
+		t.Fatalf("contention = %#v, want one production-recorded cross-class wait", contention)
+	}
+}
+
+func waitForSchedulerDecision(
+	t *testing.T,
+	runtimeStore store.Store,
+	reason string,
+) store.SchedulerDecision {
+	t.Helper()
+
+	timeout := time.NewTimer(time.Second)
+	defer timeout.Stop()
+	ticker := time.NewTicker(10 * time.Millisecond)
+	defer ticker.Stop()
+
+	var last []store.SchedulerDecision
+	for {
+		decisions, err := runtimeStore.ListRecentSchedulerDecisions(
+			t.Context(),
+			store.SchedulerDecisionQuery{Limit: 100},
+		)
+		if err != nil {
+			t.Fatalf("ListRecentSchedulerDecisions() error = %v", err)
+		}
+		last = decisions
+		for _, decision := range decisions {
+			if decision.Reason == reason {
+				return decision
+			}
+		}
+
+		select {
+		case <-timeout.C:
+			t.Fatalf("timed out waiting for scheduler decision %q; decisions = %#v", reason, last)
+		case <-ticker.C:
+		}
+	}
+}

--- a/internal/store/pool_contention_e2e_test.go
+++ b/internal/store/pool_contention_e2e_test.go
@@ -127,6 +127,10 @@ func TestPoolContentionTelemetryEndToEnd(t *testing.T) {
 			t.Fatalf("capacity[%q] = %#v, want %#v; snapshot = %s", key, got, want, refusal.CapacitySnapshotJSON)
 		}
 	}
+	holders, ok := capacity["holders"].([]any)
+	if !ok || len(holders) != 1 || holders[0] != localProject.ID {
+		t.Fatalf("capacity holders = %#v, want refusal-time holder %q", capacity["holders"], localProject.ID)
+	}
 
 	attempts, err := runtimeStore.ListActiveWorkAttempts(ctx, store.WorkAttemptQuery{ProjectID: cloudProject.ID})
 	if err != nil {

--- a/internal/store/pool_contention_test.go
+++ b/internal/store/pool_contention_test.go
@@ -29,70 +29,80 @@ func TestQueryCrossClassPoolContention(t *testing.T) {
 	rows := []struct {
 		name       string
 		projectID  string
-		startedAt  time.Time
+		decisionAt time.Time
 		waitReason string
 		snapshot   string
 	}{
 		{
-			name:       "cross class cloud wait",
+			name:       "global capacity full",
 			projectID:  "video",
-			startedAt:  now.Add(-24 * time.Hour),
+			decisionAt: now.Add(-24 * time.Hour),
 			waitReason: poolCapacityWaitReason,
-			snapshot:   `{"pool":"default","holders":["detent"]}`,
+			snapshot:   `{"pool":"default","global_available":0,"holders":["detent"]}`,
 		},
 		{
-			name:       "cross class wait counts once per holder class",
+			name:       "higher priority project",
 			projectID:  "video",
-			startedAt:  now.Add(-48 * time.Hour),
-			waitReason: poolCapacityWaitReason,
-			snapshot:   `{"pool":"default","holders":["detent","gopher-ai"]}`,
+			decisionAt: now.Add(-48 * time.Hour),
+			waitReason: poolHigherPriorityProjectWaitReason,
+			snapshot:   `{"pool":"default","global_available":0,"holders":["detent","gopher-ai"]}`,
+		},
+		{
+			name:       "higher priority state",
+			projectID:  "video",
+			decisionAt: now.Add(-72 * time.Hour),
+			waitReason: poolHigherPriorityStateWaitReason,
+			snapshot:   `{"pool":"default","global_available":0,"holders":["detent"]}`,
+		},
+		{
+			name:       "selected project waiting",
+			projectID:  "video",
+			decisionAt: now.Add(-96 * time.Hour),
+			waitReason: poolSelectedProjectWaitReason,
+			snapshot:   `{"pool":"default","global_available":0,"holders":["detent"]}`,
+		},
+		{
+			name:       "pure arbitration with capacity",
+			projectID:  "video",
+			decisionAt: now.Add(-time.Hour),
+			waitReason: poolHigherPriorityProjectWaitReason,
+			snapshot:   `{"pool":"default","global_available":1,"holders":["detent"]}`,
 		},
 		{
 			name:       "same class wait",
 			projectID:  "video",
-			startedAt:  now.Add(-72 * time.Hour),
-			waitReason: poolCapacityWaitReason,
-			snapshot:   `{"pool":"default","holders":["podcast"]}`,
+			decisionAt: now.Add(-time.Hour),
+			waitReason: poolSelectedProjectWaitReason,
+			snapshot:   `{"pool":"default","global_available":0,"holders":["podcast"]}`,
 		},
 		{
 			name:       "outside seven day window",
 			projectID:  "video",
-			startedAt:  now.Add(-8 * 24 * time.Hour),
-			waitReason: poolCapacityWaitReason,
-			snapshot:   `{"pool":"default","holders":["detent"]}`,
+			decisionAt: now.Add(-8 * 24 * time.Hour),
+			waitReason: poolHigherPriorityProjectWaitReason,
+			snapshot:   `{"pool":"default","global_available":0,"holders":["detent"]}`,
 		},
 		{
 			name:       "different wait reason",
 			projectID:  "video",
-			startedAt:  now.Add(-time.Hour),
+			decisionAt: now.Add(-time.Hour),
 			waitReason: "provider_capacity",
-			snapshot:   `{"pool":"default","holders":["detent"]}`,
+			snapshot:   `{"pool":"default","global_available":0,"holders":["detent"]}`,
 		},
 	}
 	for _, row := range rows {
 		t.Run(row.name, func(t *testing.T) {
-			if _, err := backend.StartWorkAttempt(ctx, WorkAttemptStart{
-				ProjectID:              row.projectID,
-				WorkerType:             "implement",
-				StartedAt:              row.startedAt,
-				WaitReason:             row.waitReason,
-				CapacitySnapshotJSON:   row.snapshot,
-				WorkerMetadataJSON:     "{}",
-				GitHubRateSnapshotJSON: "{}",
-				MetricsJSON:            "{}",
+			if _, err := backend.RecordSchedulerDecision(ctx, SchedulerDecision{
+				ProjectID:            row.projectID,
+				Result:               SchedulerDecisionResultSkipped,
+				Reason:               row.waitReason,
+				DecisionAt:           row.decisionAt,
+				WaitReason:           row.waitReason,
+				CapacitySnapshotJSON: row.snapshot,
 			}); err != nil {
-				t.Fatalf("StartWorkAttempt() error = %v", err)
+				t.Fatalf("RecordSchedulerDecision() error = %v", err)
 			}
 		})
-	}
-	if _, err := backend.RecordSchedulerDecision(ctx, SchedulerDecision{
-		ProjectID:            "video",
-		Result:               SchedulerDecisionResultSkipped,
-		DecisionAt:           now.Add(-30 * time.Minute),
-		WaitReason:           poolCapacityWaitReason,
-		CapacitySnapshotJSON: `{"pool":"default","holders":["detent"]}`,
-	}); err != nil {
-		t.Fatalf("RecordSchedulerDecision() error = %v", err)
 	}
 
 	got, err := QueryCrossClassPoolContention(ctx, sqliteBackend.db, PoolContentionQuery{
@@ -111,7 +121,7 @@ func TestQueryCrossClassPoolContention(t *testing.T) {
 		t.Fatalf("contention = %#v, want one cross-class aggregate", got)
 	}
 	if got[0].Pool != "default" || got[0].WaitingClass != "cloud-only" ||
-		got[0].HoldingClass != "local-heavy" || got[0].WaitCount != 3 {
-		t.Fatalf("contention[0] = %#v, want three cloud-only waits held by local-heavy", got[0])
+		got[0].HoldingClass != "local-heavy" || got[0].WaitCount != 4 {
+		t.Fatalf("contention[0] = %#v, want four exhausted cloud-only waits held by local-heavy", got[0])
 	}
 }


### PR DESCRIPTION
## Summary

- persist pre-acquisition dispatch-gate refusals in `scheduler_decisions` with pool, requesting and selected projects, capacity, usage, availability, and holder snapshots
- sample equivalent pool/reason/capacity conditions once per five minutes and record the sampling interval in telemetry metadata
- query all four production pool-arbitration reasons while using `global_available == 0` to keep pure arbitration out of capacity advice
- replace synthetic work-attempt contention fixtures and add an orchestrator-to-SQLite end-to-end saturation test

## Root cause

The dispatch planner persisted its pre-selection decision, but the subsequent fleet gate decision was sent only to debug logging. Because work attempts begin after slot acquisition, a rejected candidate had no durable representation.

Fixes #1520

## Test Plan

- `go test -race ./internal/orchestrator ./internal/scheduler ./internal/store ./internal/cli -count=1`
- `go test ./internal/orchestrator -run '^$' -fuzz=. -fuzztime=30s`
- `make check`