### PR TITLE
fix(doctor): resolve binaries against orchestrator PATH

### DIFF
--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -225,10 +225,10 @@ type doctorTelemetryStore interface {
 type doctorDeps struct {
 	loadWorkflow         func(string) (workflowconfig.Workflow, error)
 	lookupEnv            func(string) string
-	runCommand           func(context.Context, string, ...string) error
+	resolveCommandOnPath func(string, string) (string, error)
 	resolveCommandInDir  func(context.Context, string, []string, string) (string, error)
 	runCommandInDir      func(context.Context, string, []string, string, ...string) error
-	codexInitialize      func(context.Context, string) error
+	codexInitialize      func(context.Context, string, []string) error
 	httpDo               func(*http.Request) (*http.Response, error)
 	githubScopes         func(context.Context, string) ([]string, error)
 	githubReadiness      doctorGitHubReadinessFunc
@@ -1056,8 +1056,8 @@ func (d doctorDeps) withDefaults() doctorDeps {
 	if d.lookupEnv == nil {
 		d.lookupEnv = defaults.lookupEnv
 	}
-	if d.runCommand == nil {
-		d.runCommand = defaults.runCommand
+	if d.resolveCommandOnPath == nil {
+		d.resolveCommandOnPath = defaults.resolveCommandOnPath
 	}
 	if d.resolveCommandInDir == nil {
 		d.resolveCommandInDir = defaults.resolveCommandInDir
@@ -1129,7 +1129,7 @@ func defaultDoctorDeps() doctorDeps {
 	return doctorDeps{
 		loadWorkflow:         workflowconfig.LoadWorkflow,
 		lookupEnv:            os.Getenv,
-		runCommand:           runDoctorCommand,
+		resolveCommandOnPath: resolveDoctorCommandOnPath,
 		resolveCommandInDir:  resolveDoctorCommandInDir,
 		runCommandInDir:      runDoctorCommandInDir,
 		codexInitialize:      probeDoctorCodexInitialize,
@@ -1185,22 +1185,38 @@ func doctorSQLitePingError(err, closeErr error) error {
 	return fmt.Errorf("ping sqlite database: %w", err)
 }
 
-func runDoctorCommand(ctx context.Context, path string, args ...string) error {
-	commandCtx, cancel := context.WithTimeout(ctx, doctorCommandTimeout)
-	defer cancel()
+func resolveDoctorCommandOnPath(pathValue string, executable string) (string, error) {
+	if runtime.GOOS == "windows" {
+		dir, err := os.Getwd()
+		if err != nil {
+			return "", err
+		}
+		return resolveDoctorWindowsCommand(dir, doctorCommandEnvironment(os.Environ(), []string{"PATH=" + pathValue}), executable)
+	}
+	if strings.ContainsRune(executable, os.PathSeparator) {
+		if doctorExecutablePath(executable) {
+			return executable, nil
+		}
+		return "", fmt.Errorf("executable %q not found", executable)
+	}
+	for _, dir := range filepath.SplitList(pathValue) {
+		if dir == "" {
+			dir = "."
+		}
+		candidate := filepath.Join(dir, executable)
+		if doctorExecutablePath(candidate) {
+			return candidate, nil
+		}
+	}
+	return "", fmt.Errorf("executable %q not found on configured PATH", executable)
+}
 
-	cmd := exec.CommandContext(commandCtx, path, args...) // #nosec G204 -- doctor runs fixed PATH-resolved preflight binaries.
-	output, err := cmd.CombinedOutput()
-	if commandCtx.Err() != nil {
-		return commandCtx.Err()
+func doctorExecutablePath(path string) bool {
+	info, err := os.Stat(path)
+	if err != nil {
+		return false
 	}
-	if err == nil {
-		return nil
-	}
-	if detail := strings.TrimSpace(string(output)); detail != "" {
-		return fmt.Errorf("%w: %s", err, detail)
-	}
-	return err
+	return info.Mode().IsRegular() && info.Mode().Perm()&0o111 != 0
 }
 
 func resolveDoctorCommandInDir(ctx context.Context, dir string, environment []string, executable string) (string, error) {

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -50,6 +50,7 @@ type doctorCheck struct {
 	Status                    doctorStatus                               `json:"status"`
 	Detail                    string                                     `json:"detail"`
 	Hint                      string                                     `json:"hint,omitempty"`
+	BinaryResolution          *doctorBinaryResolution                    `json:"binary_resolution,omitempty"`
 	WorkflowSkillSuggestions  []doctorWorkflowSkillSuggestion            `json:"workflow_skill_suggestions,omitempty"`
 	AutoPromoteCandidates     []doctorAutoPromoteCandidateDiagnostic     `json:"auto_promote_candidates,omitempty"`
 	BlockedRecoveryCandidates []doctorBlockedRecoveryCandidateDiagnostic `json:"blocked_recovery_candidates,omitempty"`
@@ -224,7 +225,6 @@ type doctorTelemetryStore interface {
 type doctorDeps struct {
 	loadWorkflow         func(string) (workflowconfig.Workflow, error)
 	lookupEnv            func(string) string
-	lookPath             func(string) (string, error)
 	runCommand           func(context.Context, string, ...string) error
 	resolveCommandInDir  func(context.Context, string, []string, string) (string, error)
 	runCommandInDir      func(context.Context, string, []string, string, ...string) error
@@ -430,17 +430,12 @@ func runDoctor(ctx context.Context, cfg doctorConfig, opts options, deps doctorD
 		report.Add(check)
 	}
 
+	liveBoot := doctorLiveBoot(boot, global)
+	binaryEnvironment := resolveDoctorBinaryEnvironment(ctx, resolution, liveBoot, deps)
 	jobs := []doctorCheckJob{}
 	if global != nil {
 		globalConfig := *global
-		workflowDriftBoot := boot
-		if doctorServerPort(workflowDriftBoot) == 0 {
-			livePort := defaultWebPort
-			if globalConfig.Port != nil {
-				livePort = *globalConfig.Port
-			}
-			workflowDriftBoot.Port = &livePort
-		}
+		workflowDriftBoot := liveBoot
 		githubToken := runtime.GitHubToken
 		jobs = append(jobs, doctorCheckJob{
 			Name: "Update checking",
@@ -518,7 +513,7 @@ func runDoctor(ctx context.Context, cfg doctorConfig, opts options, deps doctorD
 			},
 		},
 	)
-	jobs = append(jobs, doctorAgentBinaryCheckJobs(ctx, global, deps)...)
+	jobs = append(jobs, doctorAgentBinaryCheckJobs(ctx, global, deps, binaryEnvironment)...)
 	jobs = append(jobs,
 		doctorCheckJob{
 			Name: "GitHub token",
@@ -535,7 +530,7 @@ func runDoctor(ctx context.Context, cfg doctorConfig, opts options, deps doctorD
 		doctorCheckJob{
 			Name: "git binary",
 			Run: func(jobCtx context.Context) []doctorCheck {
-				return []doctorCheck{checkDoctorGit(jobCtx, deps)}
+				return []doctorCheck{checkDoctorGit(jobCtx, deps, binaryEnvironment)}
 			},
 		},
 	)
@@ -549,6 +544,18 @@ func runDoctor(ctx context.Context, cfg doctorConfig, opts options, deps doctorD
 	}
 
 	return report
+}
+
+func doctorLiveBoot(boot BootConfig, cfg *globalconfig.Config) BootConfig {
+	if doctorServerPort(boot) != 0 {
+		return boot
+	}
+	port := defaultWebPort
+	if cfg != nil && cfg.Port != nil {
+		port = *cfg.Port
+	}
+	boot.Port = &port
+	return boot
 }
 
 func checkDoctorUpdateRuntime(ctx context.Context, cfg globalconfig.Update, boot BootConfig, deps doctorDeps) doctorCheck {
@@ -1049,9 +1056,6 @@ func (d doctorDeps) withDefaults() doctorDeps {
 	if d.lookupEnv == nil {
 		d.lookupEnv = defaults.lookupEnv
 	}
-	if d.lookPath == nil {
-		d.lookPath = defaults.lookPath
-	}
 	if d.runCommand == nil {
 		d.runCommand = defaults.runCommand
 	}
@@ -1125,7 +1129,6 @@ func defaultDoctorDeps() doctorDeps {
 	return doctorDeps{
 		loadWorkflow:         workflowconfig.LoadWorkflow,
 		lookupEnv:            os.Getenv,
-		lookPath:             exec.LookPath,
 		runCommand:           runDoctorCommand,
 		resolveCommandInDir:  resolveDoctorCommandInDir,
 		runCommandInDir:      runDoctorCommandInDir,

--- a/internal/cli/doctor_environment.go
+++ b/internal/cli/doctor_environment.go
@@ -429,7 +429,8 @@ func checkDoctorCodex(ctx context.Context, deps doctorDeps, environment doctorBi
 			Hint:   hint,
 		})
 	}
-	if err := deps.runCommand(ctx, path, "--version"); err != nil {
+	commandEnvironment := doctorBinaryCommandEnvironment(environment)
+	if err := deps.runCommandInDir(ctx, ".", commandEnvironment, path, "--version"); err != nil {
 		return doctorBinaryCheck(environment, doctorCheck{
 			Name:   "codex binary",
 			Status: doctorFail,
@@ -441,7 +442,7 @@ func checkDoctorCodex(ctx context.Context, deps doctorDeps, environment doctorBi
 	if initialize == nil {
 		initialize = probeDoctorCodexInitialize
 	}
-	if err := initialize(ctx, path); err != nil {
+	if err := initialize(ctx, path, commandEnvironment); err != nil {
 		return doctorBinaryCheck(environment, doctorCheck{
 			Name:   "codex binary",
 			Status: doctorFail,
@@ -456,9 +457,11 @@ func checkDoctorCodex(ctx context.Context, deps doctorDeps, environment doctorBi
 	})
 }
 
-func probeDoctorCodexInitialize(ctx context.Context, path string) error {
+func probeDoctorCodexInitialize(ctx context.Context, path string, environment []string) error {
 	factory, err := codex.NewLocalTransportFactory(func(commandCtx context.Context) *exec.Cmd {
-		return exec.CommandContext(commandCtx, path, "app-server")
+		cmd := exec.CommandContext(commandCtx, path, "app-server")
+		cmd.Env = doctorCommandEnvironment(os.Environ(), environment)
+		return cmd
 	})
 	if err != nil {
 		return err
@@ -552,7 +555,7 @@ func checkDoctorBinary(ctx context.Context, deps doctorDeps, environment doctorB
 			Hint:   hint,
 		})
 	}
-	if err := deps.runCommand(ctx, path, arg); err != nil {
+	if err := deps.runCommandInDir(ctx, ".", doctorBinaryCommandEnvironment(environment), path, arg); err != nil {
 		return doctorBinaryCheck(environment, doctorCheck{
 			Name:   name,
 			Status: doctorFail,
@@ -569,7 +572,14 @@ func checkDoctorBinary(ctx context.Context, deps doctorDeps, environment doctorB
 }
 
 func resolveDoctorBinary(ctx context.Context, deps doctorDeps, environment doctorBinaryEnvironment, binary string) (string, error) {
-	return deps.resolveCommandInDir(ctx, ".", []string{"PATH=" + environment.CheckedPath}, binary)
+	if err := ctx.Err(); err != nil {
+		return "", err
+	}
+	return deps.resolveCommandOnPath(environment.CheckedPath, binary)
+}
+
+func doctorBinaryCommandEnvironment(environment doctorBinaryEnvironment) []string {
+	return []string{"PATH=" + environment.CheckedPath}
 }
 
 func doctorBinaryCheck(environment doctorBinaryEnvironment, check doctorCheck) doctorCheck {

--- a/internal/cli/doctor_environment.go
+++ b/internal/cli/doctor_environment.go
@@ -23,6 +23,60 @@ import (
 
 var doctorHealthCheckKeys = []string{"hub", "store", "registry", "connector"}
 
+const (
+	doctorBinaryPathSourceDoctor       = "doctor"
+	doctorBinaryPathSourceOrchestrator = "orchestrator"
+)
+
+type doctorBinaryEnvironment struct {
+	Source           string
+	CheckedPath      string
+	DoctorPath       string
+	OrchestratorPath string
+	FallbackReason   string
+}
+
+type doctorBinaryResolution struct {
+	Source             string `json:"source"`
+	CheckedPath        string `json:"checked_path"`
+	DoctorPath         string `json:"doctor_path"`
+	OrchestratorPath   string `json:"orchestrator_path,omitempty"`
+	EnvironmentsDiffer bool   `json:"environments_differ"`
+	FallbackReason     string `json:"fallback_reason,omitempty"`
+}
+
+func resolveDoctorBinaryEnvironment(ctx context.Context, resolution globalconfig.PathResolution, boot BootConfig, deps doctorDeps) doctorBinaryEnvironment {
+	doctorPath := deps.lookupEnv("PATH")
+	fallback := func(reason string) doctorBinaryEnvironment {
+		return doctorBinaryEnvironment{
+			Source:         doctorBinaryPathSourceDoctor,
+			CheckedPath:    doctorPath,
+			DoctorPath:     doctorPath,
+			FallbackReason: reason,
+		}
+	}
+	if strings.TrimSpace(resolution.Path) == "" {
+		return fallback("orchestrator PATH is unavailable because the global config path is unavailable")
+	}
+	probe, err := probeDoctorHealth(ctx, boot, deps)
+	orchestratorPath := probe.Health.Environment.Path
+	if probe.Health.Mode != "" && doctorHealthHasDetentChecks(probe.Health.Checks) {
+		if orchestratorPath != "" {
+			return doctorBinaryEnvironment{
+				Source:           doctorBinaryPathSourceOrchestrator,
+				CheckedPath:      orchestratorPath,
+				DoctorPath:       doctorPath,
+				OrchestratorPath: orchestratorPath,
+			}
+		}
+		return fallback("orchestrator PATH is unavailable because the running instance did not report it")
+	}
+	if err != nil {
+		return fallback(fmt.Sprintf("orchestrator PATH is unavailable because no running instance was reachable at %s: %v", probe.URL, err))
+	}
+	return fallback("orchestrator PATH is unavailable because the running instance did not report it")
+}
+
 func checkDoctorConfigReload(cfg globalconfig.Config) doctorCheck {
 	path := strings.TrimSpace(cfg.Path)
 	if path == "" {
@@ -364,42 +418,42 @@ func inspectDoctorDailyBudgetAccuracy(ctx context.Context, db doctorTelemetrySto
 	return doctorCheck{Name: name, Status: doctorOK, Detail: "all completed sessions today have project attribution"}
 }
 
-func checkDoctorCodex(ctx context.Context, deps doctorDeps) doctorCheck {
+func checkDoctorCodex(ctx context.Context, deps doctorDeps, environment doctorBinaryEnvironment) doctorCheck {
 	const hint = "Install Codex and ensure codex --version and the app-server initialize handshake succeed."
-	path, err := deps.lookPath("codex")
+	path, err := resolveDoctorBinary(ctx, deps, environment, "codex")
 	if err != nil {
-		return doctorCheck{
+		return doctorBinaryCheck(environment, doctorCheck{
 			Name:   "codex binary",
 			Status: doctorFail,
 			Detail: "codex was not found on PATH",
 			Hint:   hint,
-		}
+		})
 	}
 	if err := deps.runCommand(ctx, path, "--version"); err != nil {
-		return doctorCheck{
+		return doctorBinaryCheck(environment, doctorCheck{
 			Name:   "codex binary",
 			Status: doctorFail,
 			Detail: fmt.Sprintf("%s --version failed: %v", path, err),
 			Hint:   hint,
-		}
+		})
 	}
 	initialize := deps.codexInitialize
 	if initialize == nil {
 		initialize = probeDoctorCodexInitialize
 	}
 	if err := initialize(ctx, path); err != nil {
-		return doctorCheck{
+		return doctorBinaryCheck(environment, doctorCheck{
 			Name:   "codex binary",
 			Status: doctorFail,
 			Detail: fmt.Sprintf("%s app-server initialize failed: %v", path, err),
 			Hint:   hint,
-		}
+		})
 	}
-	return doctorCheck{
+	return doctorBinaryCheck(environment, doctorCheck{
 		Name:   "codex binary",
 		Status: doctorOK,
 		Detail: path + " is runnable and completed an app-server initialize handshake",
-	}
+	})
 }
 
 func probeDoctorCodexInitialize(ctx context.Context, path string) error {
@@ -416,23 +470,23 @@ func probeDoctorCodexInitialize(ctx context.Context, path string) error {
 	return server.CheckHealth(ctx)
 }
 
-func checkDoctorClaudeCode(ctx context.Context, deps doctorDeps) doctorCheck {
-	return checkDoctorBinary(ctx, deps, "claude", "claude binary", "--version", "Install Claude Code and run `claude` once to log in (or set ANTHROPIC_API_KEY).")
+func checkDoctorClaudeCode(ctx context.Context, deps doctorDeps, environment doctorBinaryEnvironment) doctorCheck {
+	return checkDoctorBinary(ctx, deps, environment, "claude", "claude binary", "--version", "Install Claude Code and run `claude` once to log in (or set ANTHROPIC_API_KEY).")
 }
 
-func doctorAgentBinaryCheckJobs(ctx context.Context, cfg *globalconfig.Config, deps doctorDeps) []doctorCheckJob {
+func doctorAgentBinaryCheckJobs(ctx context.Context, cfg *globalconfig.Config, deps doctorDeps, environment doctorBinaryEnvironment) []doctorCheckJob {
 	kinds := doctorAgentBackendKinds(ctx, cfg, deps)
 	jobs := make([]doctorCheckJob, 0, len(kinds))
 	for _, kind := range kinds {
 		switch kind {
 		case workflowconfig.AgentBackendCodex:
-			jobs = append(jobs, doctorCodexBinaryCheckJob(deps))
+			jobs = append(jobs, doctorCodexBinaryCheckJob(deps, environment))
 		case workflowconfig.AgentBackendClaudeCode:
-			jobs = append(jobs, doctorClaudeCodeBinaryCheckJob(deps))
+			jobs = append(jobs, doctorClaudeCodeBinaryCheckJob(deps, environment))
 		}
 	}
 	if len(jobs) == 0 {
-		return []doctorCheckJob{doctorCodexBinaryCheckJob(deps)}
+		return []doctorCheckJob{doctorCodexBinaryCheckJob(deps, environment)}
 	}
 	return jobs
 }
@@ -466,52 +520,93 @@ func doctorAgentBackendKinds(ctx context.Context, cfg *globalconfig.Config, deps
 	return kinds
 }
 
-func doctorCodexBinaryCheckJob(deps doctorDeps) doctorCheckJob {
+func doctorCodexBinaryCheckJob(deps doctorDeps, environment doctorBinaryEnvironment) doctorCheckJob {
 	return doctorCheckJob{
 		Name: "codex binary",
 		Run: func(jobCtx context.Context) []doctorCheck {
-			return []doctorCheck{checkDoctorCodex(jobCtx, deps)}
+			return []doctorCheck{checkDoctorCodex(jobCtx, deps, environment)}
 		},
 	}
 }
 
-func doctorClaudeCodeBinaryCheckJob(deps doctorDeps) doctorCheckJob {
+func doctorClaudeCodeBinaryCheckJob(deps doctorDeps, environment doctorBinaryEnvironment) doctorCheckJob {
 	return doctorCheckJob{
 		Name: "claude binary",
 		Run: func(jobCtx context.Context) []doctorCheck {
-			return []doctorCheck{checkDoctorClaudeCode(jobCtx, deps)}
+			return []doctorCheck{checkDoctorClaudeCode(jobCtx, deps, environment)}
 		},
 	}
 }
 
-func checkDoctorGit(ctx context.Context, deps doctorDeps) doctorCheck {
-	return checkDoctorBinary(ctx, deps, "git", "git binary", "--version", "Install git and ensure git --version succeeds.")
+func checkDoctorGit(ctx context.Context, deps doctorDeps, environment doctorBinaryEnvironment) doctorCheck {
+	return checkDoctorBinary(ctx, deps, environment, "git", "git binary", "--version", "Install git and ensure git --version succeeds.")
 }
 
-func checkDoctorBinary(ctx context.Context, deps doctorDeps, binary string, name string, arg string, hint string) doctorCheck {
-	path, err := deps.lookPath(binary)
+func checkDoctorBinary(ctx context.Context, deps doctorDeps, environment doctorBinaryEnvironment, binary string, name string, arg string, hint string) doctorCheck {
+	path, err := resolveDoctorBinary(ctx, deps, environment, binary)
 	if err != nil {
-		return doctorCheck{
+		return doctorBinaryCheck(environment, doctorCheck{
 			Name:   name,
 			Status: doctorFail,
 			Detail: binary + " was not found on PATH",
 			Hint:   hint,
-		}
+		})
 	}
 	if err := deps.runCommand(ctx, path, arg); err != nil {
-		return doctorCheck{
+		return doctorBinaryCheck(environment, doctorCheck{
 			Name:   name,
 			Status: doctorFail,
 			Detail: fmt.Sprintf("%s %s failed: %v", path, arg, err),
 			Hint:   hint,
-		}
+		})
 	}
 
-	return doctorCheck{
+	return doctorBinaryCheck(environment, doctorCheck{
 		Name:   name,
 		Status: doctorOK,
 		Detail: path + " is runnable",
+	})
+}
+
+func resolveDoctorBinary(ctx context.Context, deps doctorDeps, environment doctorBinaryEnvironment, binary string) (string, error) {
+	return deps.resolveCommandInDir(ctx, ".", []string{"PATH=" + environment.CheckedPath}, binary)
+}
+
+func doctorBinaryCheck(environment doctorBinaryEnvironment, check doctorCheck) doctorCheck {
+	resolution := doctorBinaryResolution{
+		Source:             environment.Source,
+		CheckedPath:        environment.CheckedPath,
+		DoctorPath:         environment.DoctorPath,
+		OrchestratorPath:   environment.OrchestratorPath,
+		EnvironmentsDiffer: environment.OrchestratorPath != "" && environment.DoctorPath != environment.OrchestratorPath,
+		FallbackReason:     environment.FallbackReason,
 	}
+	check.BinaryResolution = &resolution
+	check.Detail += "; " + doctorBinaryEnvironmentDetail(resolution)
+	return check
+}
+
+func doctorBinaryEnvironmentDetail(resolution doctorBinaryResolution) string {
+	checkedPath := resolution.CheckedPath
+	if checkedPath == "" {
+		checkedPath = "<empty>"
+	}
+	source := "doctor fallback"
+	if resolution.Source == doctorBinaryPathSourceOrchestrator {
+		source = "orchestrator"
+	}
+	detail := fmt.Sprintf("checked PATH: %s (%s)", checkedPath, source)
+	if resolution.FallbackReason != "" {
+		detail += "; " + resolution.FallbackReason
+	}
+	if resolution.EnvironmentsDiffer {
+		doctorPath := resolution.DoctorPath
+		if doctorPath == "" {
+			doctorPath = "<empty>"
+		}
+		detail += fmt.Sprintf("; doctor PATH: %s; doctor PATH differs from orchestrator PATH", doctorPath)
+	}
+	return detail
 }
 
 func checkDoctorServerPort(ctx context.Context, cfg BootConfig, deps doctorDeps) doctorCheck {
@@ -580,11 +675,16 @@ type doctorHealthProbe struct {
 }
 
 type doctorHealthResponse struct {
-	Status    string                 `json:"status"`
-	Mode      string                 `json:"mode"`
-	Checks    map[string]string      `json:"checks"`
-	Budgets   []doctorHealthBudget   `json:"budgets"`
-	Workflows []doctorHealthWorkflow `json:"workflows"`
+	Status      string                  `json:"status"`
+	Mode        string                  `json:"mode"`
+	Checks      map[string]string       `json:"checks"`
+	Environment doctorHealthEnvironment `json:"environment"`
+	Budgets     []doctorHealthBudget    `json:"budgets"`
+	Workflows   []doctorHealthWorkflow  `json:"workflows"`
+}
+
+type doctorHealthEnvironment struct {
+	Path string `json:"path"`
 }
 
 type doctorHealthWorkflow struct {

--- a/internal/cli/doctor_test.go
+++ b/internal/cli/doctor_test.go
@@ -13,6 +13,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"runtime"
 	"slices"
 	"strconv"
 	"strings"
@@ -98,17 +99,17 @@ func TestCheckDoctorBinary(t *testing.T) {
 
 	tests := []struct {
 		name       string
-		resolve    func(context.Context, string, []string, string) (string, error)
-		runCommand func(context.Context, string, ...string) error
+		resolve    func(string, string) (string, error)
+		runCommand func(context.Context, string, []string, string, ...string) error
 		want       doctorStatus
 		wantDetail string
 	}{
 		{
 			name: "missing from path",
-			resolve: func(context.Context, string, []string, string) (string, error) {
+			resolve: func(string, string) (string, error) {
 				return "", errors.New("missing")
 			},
-			runCommand: func(context.Context, string, ...string) error {
+			runCommand: func(context.Context, string, []string, string, ...string) error {
 				return nil
 			},
 			want:       doctorFail,
@@ -116,10 +117,10 @@ func TestCheckDoctorBinary(t *testing.T) {
 		},
 		{
 			name: "not runnable",
-			resolve: func(context.Context, string, []string, string) (string, error) {
+			resolve: func(string, string) (string, error) {
 				return "/usr/bin/codex", nil
 			},
-			runCommand: func(context.Context, string, ...string) error {
+			runCommand: func(context.Context, string, []string, string, ...string) error {
 				return errors.New("permission denied")
 			},
 			want:       doctorFail,
@@ -127,10 +128,10 @@ func TestCheckDoctorBinary(t *testing.T) {
 		},
 		{
 			name: "runnable",
-			resolve: func(context.Context, string, []string, string) (string, error) {
+			resolve: func(string, string) (string, error) {
 				return "/usr/bin/codex", nil
 			},
-			runCommand: func(context.Context, string, ...string) error {
+			runCommand: func(context.Context, string, []string, string, ...string) error {
 				return nil
 			},
 			want:       doctorOK,
@@ -143,8 +144,8 @@ func TestCheckDoctorBinary(t *testing.T) {
 			t.Parallel()
 
 			got := checkDoctorBinary(context.Background(), doctorDeps{
-				resolveCommandInDir: tt.resolve,
-				runCommand:          tt.runCommand,
+				resolveCommandOnPath: tt.resolve,
+				runCommandInDir:      tt.runCommand,
 			}, doctorBinaryEnvironment{
 				Source:         doctorBinaryPathSourceDoctor,
 				CheckedPath:    "/doctor/bin",
@@ -230,17 +231,20 @@ func TestDoctorBinaryResolutionUsesSelectedEnvironment(t *testing.T) {
 						)),
 					}, nil
 				},
-				resolveCommandInDir: func(_ context.Context, _ string, environment []string, binary string) (string, error) {
+				resolveCommandOnPath: func(pathValue string, binary string) (string, error) {
 					if binary != tt.binary {
 						t.Fatalf("binary = %q, want %q", binary, tt.binary)
 					}
+					if pathValue != tt.wantCheckedPath {
+						t.Fatalf("pathValue = %q, want %q", pathValue, tt.wantCheckedPath)
+					}
+					return filepath.Join(tt.wantCheckedPath, binary), nil
+				},
+				runCommandInDir: func(_ context.Context, _ string, environment []string, _ string, _ ...string) error {
 					wantEnvironment := []string{"PATH=" + tt.wantCheckedPath}
 					if !slices.Equal(environment, wantEnvironment) {
 						t.Fatalf("environment = %#v, want %#v", environment, wantEnvironment)
 					}
-					return filepath.Join(tt.wantCheckedPath, binary), nil
-				},
-				runCommand: func(context.Context, string, ...string) error {
 					return nil
 				},
 			}
@@ -314,20 +318,47 @@ func TestDoctorLiveBootUsesConfiguredPortForZero(t *testing.T) {
 	}
 }
 
+func TestResolveDoctorCommandOnPath(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	executable := "backend"
+	mode := os.FileMode(0o755)
+	if runtime.GOOS == "windows" {
+		executable += ".exe"
+		mode = 0o644
+	}
+	want := filepath.Join(root, executable)
+	if err := os.WriteFile(want, []byte("example"), mode); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+
+	got, err := resolveDoctorCommandOnPath(root, executable)
+	if err != nil {
+		t.Fatalf("resolveDoctorCommandOnPath() error = %v", err)
+	}
+	if got != want {
+		t.Fatalf("resolveDoctorCommandOnPath() = %q, want %q", got, want)
+	}
+}
+
 func TestCheckDoctorClaudeCodeUsesVersionAndHint(t *testing.T) {
 	t.Parallel()
 
 	var gotArgs []string
 	got := checkDoctorClaudeCode(context.Background(), doctorDeps{
-		resolveCommandInDir: func(_ context.Context, _ string, _ []string, binary string) (string, error) {
+		resolveCommandOnPath: func(_ string, binary string) (string, error) {
 			if binary != "claude" {
-				t.Fatalf("resolveCommandInDir(%q), want claude", binary)
+				t.Fatalf("resolveCommandOnPath(%q), want claude", binary)
 			}
 			return "/usr/bin/claude", nil
 		},
-		runCommand: func(_ context.Context, path string, args ...string) error {
+		runCommandInDir: func(_ context.Context, _ string, environment []string, path string, args ...string) error {
 			if path != "/usr/bin/claude" {
-				t.Fatalf("runCommand path = %q, want /usr/bin/claude", path)
+				t.Fatalf("runCommandInDir path = %q, want /usr/bin/claude", path)
+			}
+			if !slices.Equal(environment, []string{"PATH=/usr/bin"}) {
+				t.Fatalf("environment = %#v, want selected PATH", environment)
 			}
 			gotArgs = append([]string{}, args...)
 			return errors.New("not logged in")
@@ -383,22 +414,28 @@ func TestCheckDoctorCodexRequiresInitializeHandshake(t *testing.T) {
 
 			probes := 0
 			check := checkDoctorCodex(context.Background(), doctorDeps{
-				resolveCommandInDir: func(_ context.Context, _ string, _ []string, binary string) (string, error) {
+				resolveCommandOnPath: func(_ string, binary string) (string, error) {
 					if binary != "codex" {
-						t.Fatalf("resolveCommandInDir(%q), want codex", binary)
+						t.Fatalf("resolveCommandOnPath(%q), want codex", binary)
 					}
 					return "/usr/bin/codex", nil
 				},
-				runCommand: func(_ context.Context, path string, args ...string) error {
+				runCommandInDir: func(_ context.Context, _ string, environment []string, path string, args ...string) error {
 					if path != "/usr/bin/codex" || !slices.Equal(args, []string{"--version"}) {
-						t.Fatalf("runCommand(%q, %#v), want codex --version", path, args)
+						t.Fatalf("runCommandInDir(%q, %#v), want codex --version", path, args)
+					}
+					if !slices.Equal(environment, []string{"PATH=/usr/bin"}) {
+						t.Fatalf("environment = %#v, want selected PATH", environment)
 					}
 					return tt.versionErr
 				},
-				codexInitialize: func(_ context.Context, path string) error {
+				codexInitialize: func(_ context.Context, path string, environment []string) error {
 					probes++
 					if path != "/usr/bin/codex" {
 						t.Fatalf("codexInitialize(%q), want /usr/bin/codex", path)
+					}
+					if !slices.Equal(environment, []string{"PATH=/usr/bin"}) {
+						t.Fatalf("initialize environment = %#v, want selected PATH", environment)
 					}
 					return tt.initializeErr
 				},
@@ -487,7 +524,7 @@ func TestRunDoctorAgentBinaryChecksFollowWorkflowBackends(t *testing.T) {
 
 			var commandsMu sync.Mutex
 			commands := []string{}
-			deps.runCommand = func(_ context.Context, path string, args ...string) error {
+			deps.runCommandInDir = func(_ context.Context, _ string, _ []string, path string, args ...string) error {
 				binary := filepath.Base(path)
 				if binary == "codex" || binary == "claude" {
 					commandsMu.Lock()
@@ -2781,7 +2818,7 @@ func TestDefaultGitTracked(t *testing.T) {
 	t.Parallel()
 
 	repo := t.TempDir()
-	if err := runDoctorCommand(context.Background(), "git", "-C", repo, "init"); err != nil {
+	if err := runDoctorCommandInDir(context.Background(), ".", nil, "git", "-C", repo, "init"); err != nil {
 		t.Fatalf("git init error = %v", err)
 	}
 	path := filepath.Join(repo, "WORKFLOW.local.md")
@@ -2797,7 +2834,7 @@ func TestDefaultGitTracked(t *testing.T) {
 		t.Fatal("defaultGitTracked() = true, want false before git add")
 	}
 
-	if err := runDoctorCommand(context.Background(), "git", "-C", repo, "add", "WORKFLOW.local.md"); err != nil {
+	if err := runDoctorCommandInDir(context.Background(), ".", nil, "git", "-C", repo, "add", "WORKFLOW.local.md"); err != nil {
 		t.Fatalf("git add error = %v", err)
 	}
 	tracked, err = defaultGitTracked(context.Background(), path)
@@ -4595,7 +4632,7 @@ func TestDoctorCommandExitStatus(t *testing.T) {
 		{
 			name: "fails when any check fails",
 			deps: doctorDeps{
-				runCommand: func(_ context.Context, path string, _ ...string) error {
+				runCommandInDir: func(_ context.Context, _ string, _ []string, path string, _ ...string) error {
 					if strings.HasSuffix(path, "codex") {
 						return errors.New("not runnable")
 					}
@@ -4618,8 +4655,8 @@ func TestDoctorCommandExitStatus(t *testing.T) {
 			port := 0
 			opts := successfulDoctorOptions(configPath)
 			deps := successfulDoctorDeps()
-			if tt.deps.runCommand != nil {
-				deps.runCommand = tt.deps.runCommand
+			if tt.deps.runCommandInDir != nil {
+				deps.runCommandInDir = tt.deps.runCommandInDir
 			}
 			cmd := newDoctorCommandWithDeps(&configPath, &env, &logLevel, &host, &port, opts, deps)
 			cmd.SetArgs(tt.args)
@@ -4651,7 +4688,7 @@ func TestDoctorCommandStreamsProgressBeforeSlowCheckCompletes(t *testing.T) {
 	codexStarted := make(chan struct{})
 	releaseCodex := make(chan struct{})
 	var once sync.Once
-	deps.runCommand = func(ctx context.Context, path string, _ ...string) error {
+	deps.runCommandInDir = func(ctx context.Context, _ string, _ []string, path string, _ ...string) error {
 		if strings.HasSuffix(path, "codex") {
 			once.Do(func() {
 				close(codexStarted)
@@ -4708,7 +4745,7 @@ func TestDoctorCommandTimeoutFlagBoundsCheck(t *testing.T) {
 	deps := successfulDoctorDeps()
 	releaseCodex := make(chan struct{})
 	defer close(releaseCodex)
-	deps.runCommand = func(_ context.Context, path string, _ ...string) error {
+	deps.runCommandInDir = func(_ context.Context, _ string, _ []string, path string, _ ...string) error {
 		if strings.HasSuffix(path, "codex") {
 			<-releaseCodex
 		}
@@ -5560,8 +5597,8 @@ func successfulDoctorDeps() doctorDeps {
 			}
 			return ""
 		},
-		runCommand: func(context.Context, string, ...string) error {
-			return nil
+		resolveCommandOnPath: func(pathValue string, executable string) (string, error) {
+			return filepath.Join(pathValue, executable), nil
 		},
 		resolveCommandInDir: func(_ context.Context, _ string, _ []string, executable string) (string, error) {
 			return "/usr/bin/" + executable, nil
@@ -5569,7 +5606,7 @@ func successfulDoctorDeps() doctorDeps {
 		runCommandInDir: func(context.Context, string, []string, string, ...string) error {
 			return nil
 		},
-		codexInitialize: func(context.Context, string) error {
+		codexInitialize: func(context.Context, string, []string) error {
 			return nil
 		},
 		httpDo: func(*http.Request) (*http.Response, error) {

--- a/internal/cli/doctor_test.go
+++ b/internal/cli/doctor_test.go
@@ -194,7 +194,7 @@ func TestDoctorBinaryResolutionUsesSelectedEnvironment(t *testing.T) {
 			wantSource:           doctorBinaryPathSourceOrchestrator,
 			wantCheckedPath:      "/orchestrator/bin",
 			wantDiffer:           true,
-			wantDetail:           []string{"/orchestrator/bin/claude is runnable", "doctor PATH: /doctor/bin", "doctor PATH differs from orchestrator PATH"},
+			wantDetail:           []string{filepath.Join("/orchestrator/bin", "claude") + " is runnable", "doctor PATH: /doctor/bin", "doctor PATH differs from orchestrator PATH"},
 			wantOrchestratorPath: "/orchestrator/bin",
 		},
 		{

--- a/internal/cli/doctor_test.go
+++ b/internal/cli/doctor_test.go
@@ -98,25 +98,25 @@ func TestCheckDoctorBinary(t *testing.T) {
 
 	tests := []struct {
 		name       string
-		lookPath   func(string) (string, error)
+		resolve    func(context.Context, string, []string, string) (string, error)
 		runCommand func(context.Context, string, ...string) error
 		want       doctorStatus
 		wantDetail string
 	}{
 		{
 			name: "missing from path",
-			lookPath: func(string) (string, error) {
+			resolve: func(context.Context, string, []string, string) (string, error) {
 				return "", errors.New("missing")
 			},
 			runCommand: func(context.Context, string, ...string) error {
 				return nil
 			},
 			want:       doctorFail,
-			wantDetail: "not found on PATH",
+			wantDetail: "checked PATH:",
 		},
 		{
 			name: "not runnable",
-			lookPath: func(string) (string, error) {
+			resolve: func(context.Context, string, []string, string) (string, error) {
 				return "/usr/bin/codex", nil
 			},
 			runCommand: func(context.Context, string, ...string) error {
@@ -127,7 +127,7 @@ func TestCheckDoctorBinary(t *testing.T) {
 		},
 		{
 			name: "runnable",
-			lookPath: func(string) (string, error) {
+			resolve: func(context.Context, string, []string, string) (string, error) {
 				return "/usr/bin/codex", nil
 			},
 			runCommand: func(context.Context, string, ...string) error {
@@ -143,8 +143,13 @@ func TestCheckDoctorBinary(t *testing.T) {
 			t.Parallel()
 
 			got := checkDoctorBinary(context.Background(), doctorDeps{
-				lookPath:   tt.lookPath,
-				runCommand: tt.runCommand,
+				resolveCommandInDir: tt.resolve,
+				runCommand:          tt.runCommand,
+			}, doctorBinaryEnvironment{
+				Source:         doctorBinaryPathSourceDoctor,
+				CheckedPath:    "/doctor/bin",
+				DoctorPath:     "/doctor/bin",
+				FallbackReason: "orchestrator PATH is unavailable because no running instance was reachable",
 			}, "codex", "codex binary", "--version", "install codex")
 			if got.Status != tt.want {
 				t.Fatalf("Status = %s, want %s", got.Status, tt.want)
@@ -156,14 +161,167 @@ func TestCheckDoctorBinary(t *testing.T) {
 	}
 }
 
+func TestDoctorBinaryResolutionUsesSelectedEnvironment(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name                 string
+		binary               string
+		doctorPath           string
+		orchestratorPath     string
+		reachableErr         error
+		wantSource           string
+		wantCheckedPath      string
+		wantDiffer           bool
+		wantDetail           []string
+		wantOrchestratorPath string
+	}{
+		{
+			name:                 "agreeing environments use orchestrator",
+			binary:               "codex",
+			doctorPath:           "/shared/bin",
+			orchestratorPath:     "/shared/bin",
+			wantSource:           doctorBinaryPathSourceOrchestrator,
+			wantCheckedPath:      "/shared/bin",
+			wantDetail:           []string{"checked PATH: /shared/bin (orchestrator)"},
+			wantOrchestratorPath: "/shared/bin",
+		},
+		{
+			name:                 "binary present only in differing orchestrator environment",
+			binary:               "claude",
+			doctorPath:           "/doctor/bin",
+			orchestratorPath:     "/orchestrator/bin",
+			wantSource:           doctorBinaryPathSourceOrchestrator,
+			wantCheckedPath:      "/orchestrator/bin",
+			wantDiffer:           true,
+			wantDetail:           []string{"/orchestrator/bin/claude is runnable", "doctor PATH: /doctor/bin", "doctor PATH differs from orchestrator PATH"},
+			wantOrchestratorPath: "/orchestrator/bin",
+		},
+		{
+			name:            "no reachable instance falls back to doctor",
+			binary:          "git",
+			doctorPath:      "/doctor/bin",
+			reachableErr:    errors.New("connection refused"),
+			wantSource:      doctorBinaryPathSourceDoctor,
+			wantCheckedPath: "/doctor/bin",
+			wantDetail:      []string{"checked PATH: /doctor/bin (doctor fallback)", "no running instance was reachable"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			deps := doctorDeps{
+				lookupEnv: func(key string) string {
+					if key != "PATH" {
+						t.Fatalf("lookupEnv(%q), want PATH", key)
+					}
+					return tt.doctorPath
+				},
+				httpDo: func(*http.Request) (*http.Response, error) {
+					if tt.reachableErr != nil {
+						return nil, tt.reachableErr
+					}
+					return &http.Response{
+						StatusCode: http.StatusOK,
+						Body: io.NopCloser(strings.NewReader(
+							`{"status":"ok","mode":"running","checks":{"hub":"configured","store":"configured","registry":"configured","connector":"configured"},"environment":{"path":"` + tt.orchestratorPath + `"}}`,
+						)),
+					}, nil
+				},
+				resolveCommandInDir: func(_ context.Context, _ string, environment []string, binary string) (string, error) {
+					if binary != tt.binary {
+						t.Fatalf("binary = %q, want %q", binary, tt.binary)
+					}
+					wantEnvironment := []string{"PATH=" + tt.wantCheckedPath}
+					if !slices.Equal(environment, wantEnvironment) {
+						t.Fatalf("environment = %#v, want %#v", environment, wantEnvironment)
+					}
+					return filepath.Join(tt.wantCheckedPath, binary), nil
+				},
+				runCommand: func(context.Context, string, ...string) error {
+					return nil
+				},
+			}
+			port := 4100
+			environment := resolveDoctorBinaryEnvironment(context.Background(), globalconfig.PathResolution{Path: "/config/global.yaml"}, BootConfig{Host: "127.0.0.1", Port: &port}, deps)
+			check := checkDoctorBinary(context.Background(), deps, environment, tt.binary, tt.binary+" binary", "--version", "install "+tt.binary)
+
+			if check.Status != doctorOK {
+				t.Fatalf("Status = %s, want %s", check.Status, doctorOK)
+			}
+			for _, want := range tt.wantDetail {
+				if !strings.Contains(check.Detail, want) {
+					t.Fatalf("Detail = %q, want containing %q", check.Detail, want)
+				}
+			}
+			if check.BinaryResolution == nil {
+				t.Fatal("BinaryResolution = nil")
+			}
+			if check.BinaryResolution.Source != tt.wantSource ||
+				check.BinaryResolution.CheckedPath != tt.wantCheckedPath ||
+				check.BinaryResolution.OrchestratorPath != tt.wantOrchestratorPath ||
+				check.BinaryResolution.EnvironmentsDiffer != tt.wantDiffer {
+				t.Fatalf("BinaryResolution = %#v", check.BinaryResolution)
+			}
+
+			raw, err := json.Marshal(check)
+			if err != nil {
+				t.Fatalf("json.Marshal() error = %v", err)
+			}
+			var output struct {
+				BinaryResolution doctorBinaryResolution `json:"binary_resolution"`
+			}
+			if err := json.Unmarshal(raw, &output); err != nil {
+				t.Fatalf("json.Unmarshal() error = %v", err)
+			}
+			if output.BinaryResolution.Source != tt.wantSource ||
+				output.BinaryResolution.CheckedPath != tt.wantCheckedPath ||
+				output.BinaryResolution.EnvironmentsDiffer != tt.wantDiffer {
+				t.Fatalf("JSON binary_resolution = %#v", output.BinaryResolution)
+			}
+		})
+	}
+}
+
+func TestDoctorLiveBootUsesConfiguredPortForZero(t *testing.T) {
+	t.Parallel()
+
+	configuredPort := 4100
+	zero := 0
+	explicit := 4200
+	tests := []struct {
+		name string
+		boot BootConfig
+		cfg  *globalconfig.Config
+		want int
+	}{
+		{name: "explicit doctor port", boot: BootConfig{Port: &explicit}, cfg: &globalconfig.Config{Port: &configuredPort}, want: explicit},
+		{name: "zero doctor port uses configured live port", boot: BootConfig{Port: &zero}, cfg: &globalconfig.Config{Port: &configuredPort}, want: configuredPort},
+		{name: "zero doctor port uses default live port", boot: BootConfig{Port: &zero}, cfg: &globalconfig.Config{}, want: defaultWebPort},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := doctorLiveBoot(tt.boot, tt.cfg)
+			if doctorServerPort(got) != tt.want {
+				t.Fatalf("doctorServerPort() = %d, want %d", doctorServerPort(got), tt.want)
+			}
+		})
+	}
+}
+
 func TestCheckDoctorClaudeCodeUsesVersionAndHint(t *testing.T) {
 	t.Parallel()
 
 	var gotArgs []string
 	got := checkDoctorClaudeCode(context.Background(), doctorDeps{
-		lookPath: func(binary string) (string, error) {
+		resolveCommandInDir: func(_ context.Context, _ string, _ []string, binary string) (string, error) {
 			if binary != "claude" {
-				t.Fatalf("lookPath(%q), want claude", binary)
+				t.Fatalf("resolveCommandInDir(%q), want claude", binary)
 			}
 			return "/usr/bin/claude", nil
 		},
@@ -174,7 +332,7 @@ func TestCheckDoctorClaudeCodeUsesVersionAndHint(t *testing.T) {
 			gotArgs = append([]string{}, args...)
 			return errors.New("not logged in")
 		},
-	})
+	}, doctorBinaryEnvironment{Source: doctorBinaryPathSourceDoctor, CheckedPath: "/usr/bin", DoctorPath: "/usr/bin"})
 
 	if got.Status != doctorFail {
 		t.Fatalf("Status = %s, want %s", got.Status, doctorFail)
@@ -225,9 +383,9 @@ func TestCheckDoctorCodexRequiresInitializeHandshake(t *testing.T) {
 
 			probes := 0
 			check := checkDoctorCodex(context.Background(), doctorDeps{
-				lookPath: func(binary string) (string, error) {
+				resolveCommandInDir: func(_ context.Context, _ string, _ []string, binary string) (string, error) {
 					if binary != "codex" {
-						t.Fatalf("lookPath(%q), want codex", binary)
+						t.Fatalf("resolveCommandInDir(%q), want codex", binary)
 					}
 					return "/usr/bin/codex", nil
 				},
@@ -244,7 +402,7 @@ func TestCheckDoctorCodexRequiresInitializeHandshake(t *testing.T) {
 					}
 					return tt.initializeErr
 				},
-			})
+			}, doctorBinaryEnvironment{Source: doctorBinaryPathSourceDoctor, CheckedPath: "/usr/bin", DoctorPath: "/usr/bin"})
 			if check.Status != tt.wantStatus || !strings.Contains(check.Detail, tt.wantDetail) {
 				t.Fatalf("check = %#v, want %s containing %q", check, tt.wantStatus, tt.wantDetail)
 			}
@@ -4463,10 +4621,6 @@ func TestDoctorCommandExitStatus(t *testing.T) {
 			if tt.deps.runCommand != nil {
 				deps.runCommand = tt.deps.runCommand
 			}
-			if tt.deps.lookPath != nil {
-				deps.lookPath = tt.deps.lookPath
-			}
-
 			cmd := newDoctorCommandWithDeps(&configPath, &env, &logLevel, &host, &port, opts, deps)
 			cmd.SetArgs(tt.args)
 			var stdout bytes.Buffer
@@ -5401,10 +5555,10 @@ func successfulDoctorDeps() doctorDeps {
 			if key == "GITHUB_TOKEN" {
 				return "token"
 			}
+			if key == "PATH" {
+				return "/usr/bin"
+			}
 			return ""
-		},
-		lookPath: func(binary string) (string, error) {
-			return "/usr/bin/" + binary, nil
 		},
 		runCommand: func(context.Context, string, ...string) error {
 			return nil

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -9,6 +9,7 @@ import (
 	"net"
 	"net/http"
 	"net/url"
+	"os"
 	"strings"
 	"sync/atomic"
 	"time"
@@ -1068,6 +1069,7 @@ func (s *Server) health(c echo.Context) error {
 		SessionsRemaining: sessionsRemaining,
 		Update:            updateStatus,
 		Checks:            checks,
+		Environment:       healthEnvironment{Path: os.Getenv("PATH")},
 		Budgets:           budgets,
 		Workflows:         workflows,
 		BackendOutages:    backendOutages,
@@ -1314,10 +1316,15 @@ type healthResponse struct {
 	SessionsRemaining int                       `json:"sessions_remaining,omitempty"`
 	Update            telemetry.Update          `json:"update,omitzero"`
 	Checks            map[string]string         `json:"checks"`
+	Environment       healthEnvironment         `json:"environment"`
 	Budgets           []healthBudget            `json:"budgets,omitempty"`
 	Workflows         []healthWorkflowSource    `json:"workflows,omitempty"`
 	BackendOutages    []telemetry.BackendOutage `json:"backend_outages,omitempty"`
 	Projects          []healthProject           `json:"projects,omitempty"`
+}
+
+type healthEnvironment struct {
+	Path string `json:"path"`
 }
 
 type healthProject struct {

--- a/internal/web/server_test.go
+++ b/internal/web/server_test.go
@@ -6734,6 +6734,23 @@ func TestHealthReportsUpdateCheckStatus(t *testing.T) {
 	}
 }
 
+func TestHealthReportsEnvironmentPath(t *testing.T) {
+	t.Parallel()
+
+	server, err := web.NewServer(web.Config{}, testDeps(t))
+	if err != nil {
+		t.Fatalf("NewServer() error = %v", err)
+	}
+	payload := requestJSON(t, server, http.MethodGet, "/health", http.StatusOK)
+	environment, ok := payload["environment"].(map[string]any)
+	if !ok {
+		t.Fatalf("environment payload = %#v, want object", payload["environment"])
+	}
+	if environment["path"] != os.Getenv("PATH") {
+		t.Fatalf("environment path = %#v, want %q", environment["path"], os.Getenv("PATH"))
+	}
+}
+
 func TestHealthReportsEnforcedProjectBudgets(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

- expose the running orchestrator PATH through its health response
- resolve Codex, Claude, and Git checks against the reachable orchestrator PATH
- label doctor PATH fallback and environment differences in text and structured JSON
- probe the configured live port when doctor is invoked with `--port 0`

Root cause: doctor used `exec.LookPath`, so binary checks inherited the caller PATH even when a running orchestrator had a different environment.

Fixes #1522

## UI Surface Contract

- [x] N/A; this change does not affect UI surfaces or layout.
- [x] This PR does not add persistent top-of-screen messaging.
- [x] N/A; this PR has no visual changes.

## Test Plan

- [x] `go test -race ./internal/cli -count=1`
- [x] `make check`
