### PR TITLE
feat(doctor): report binding capacity constraint

### DIFF
--- a/README.md
+++ b/README.md
@@ -2316,11 +2316,13 @@ one observation per five-minute interval before doctor selects the binding
 constraint. Telemetry from a project's previous pool assignment is ignored.
 
 A pool-bound project in a single-class pool is told to raise that pool's
-capacity, never to split it. When mixed workload classes share the implicit
-default pool and pool waits bind, doctor preserves the initial `code` / `cloud`
-split recommendation: the code pool keeps the current cap, the cloud pool gets
-a provider-tuned starting cap, and the affected projects are printed as valid
-YAML. Configured pools are reported but are never repartitioned automatically.
+capacity, never to split it. For an elastic pool this names `burst_to`, the
+reachable ceiling; rigid pools name `max_concurrent_agents`. When mixed
+workload classes share the implicit default pool and pool waits bind, doctor
+preserves the initial `code` / `cloud` split recommendation: the code pool
+keeps the current cap, the cloud pool gets a provider-tuned starting cap, and
+the affected projects are printed as valid YAML. Configured pools are reported
+but are never repartitioned automatically.
 
 Doctor also checks capacity coherence without requiring telemetry. It warns
 when member project caps cannot add up to a pool's declared capacity, when a

--- a/README.md
+++ b/README.md
@@ -2311,6 +2311,9 @@ largest observed constraint across pool capacity, the project's
 provider rate-window backpressure. Each finding names the matching lever.
 Rate-window backpressure recommends no configuration change because raising a
 configured cap cannot increase the effective provider-paced limit.
+Because pool refusals are sampled, all constraint reasons are normalized to
+one observation per five-minute interval before doctor selects the binding
+constraint. Telemetry from a project's previous pool assignment is ignored.
 
 A pool-bound project in a single-class pool is told to raise that pool's
 capacity, never to split it. When mixed workload classes share the implicit

--- a/README.md
+++ b/README.md
@@ -2303,15 +2303,26 @@ admission at a time. Project selection, scheduling history, and strict-mode
 preemption remain local to each pool. A configuration without `agent_pools` or
 project `pool` fields retains the previous single-pool behavior.
 
-`detent doctor` recommends an initial `code` / `cloud` split only when both
-signals are present: the resolved workflows contain both local-heavy projects
-(local command/validator gates or CI triggers) and cloud-only projects, and
-the last seven days of runtime telemetry contain capacity waits where the
-waiting project and a recorded slot holder have different workload classes.
-Fresh installs, single-class fleets, and same-class starvation stay quiet.
-The finding keeps the code pool at the current default-pool cap, proposes a
-starting cloud cap labeled for provider-limit tuning, and prints the affected
-projects as valid YAML.
+`detent doctor` reports the last seven days of capacity waits for each project,
+annotated with its local-heavy or cloud-only workload class. It identifies the
+largest observed constraint across pool capacity, the project's
+`agent.max_concurrent_agents`, lane-specific
+`agent.max_concurrent_agents_by_state`, worker-host capacity, and subscription
+provider rate-window backpressure. Each finding names the matching lever.
+Rate-window backpressure recommends no configuration change because raising a
+configured cap cannot increase the effective provider-paced limit.
+
+A pool-bound project in a single-class pool is told to raise that pool's
+capacity, never to split it. When mixed workload classes share the implicit
+default pool and pool waits bind, doctor preserves the initial `code` / `cloud`
+split recommendation: the code pool keeps the current cap, the cloud pool gets
+a provider-tuned starting cap, and the affected projects are printed as valid
+YAML. Configured pools are reported but are never repartitioned automatically.
+
+Doctor also checks capacity coherence without requiring telemetry. It warns
+when member project caps cannot add up to a pool's declared capacity, when a
+project cap exceeds its pool, or when an active work lane other than the
+intentionally serialized `Merging` lane is capped below the project.
 
 Preview or apply that exact recommendation with:
 
@@ -2324,11 +2335,11 @@ detent fix agent-pools --yes
 
 The fixer prints an additions-only diff, requires confirmation unless `--yes`
 is supplied, preserves unrelated YAML keys, comments, and project ordering,
-and writes `global.yaml` with mode `0600`. It is a no-op when doctor lacks
-either signal. It also declines any config that already declares
-`global.agent_pools`; changing an existing partition is an operator decision.
-The accepted change is picked up by global-config hot reload without a
-process restart.
+and writes `global.yaml` with mode `0600`. It is a no-op unless mixed workload
+classes have binding default-pool waits. It also declines any config that
+already declares `global.agent_pools`; changing an existing partition is an
+operator decision. The accepted change is picked up by global-config hot
+reload without a process restart.
 
 Set optional `projects[].color` to an opaque CSS hex color in `#RGB` or
 `#RRGGBB` form when a project needs a fixed visual marker. The sidebar,

--- a/internal/cli/doctor_agent_pools.go
+++ b/internal/cli/doctor_agent_pools.go
@@ -263,7 +263,7 @@ func newDoctorCapacityFindings(
 			continue
 		}
 		project, ok := projectsByID[wait.ProjectID]
-		if !ok {
+		if !ok || wait.Pool != project.Pool {
 			continue
 		}
 		builder := builders[wait.ProjectID]

--- a/internal/cli/doctor_agent_pools.go
+++ b/internal/cli/doctor_agent_pools.go
@@ -12,30 +12,48 @@ import (
 
 	"gopkg.in/yaml.v3"
 
+	workflowconfig "github.com/digitaldrywood/detent/internal/config"
 	globalconfig "github.com/digitaldrywood/detent/internal/config/global"
 	"github.com/digitaldrywood/detent/internal/store"
 	"github.com/digitaldrywood/detent/internal/workload"
 )
 
 const (
-	doctorAgentPoolsCheckName   = "Agent pools"
+	doctorAgentPoolsCheckName   = "Capacity constraints"
 	doctorAgentPoolsWindow      = 7 * 24 * time.Hour
 	doctorCloudPoolStartingSize = 10
 )
 
 type doctorWorkloadProject struct {
-	ID      string
-	Class   workload.Class
-	Signals workload.Signals
+	ID       string
+	Pool     string
+	Class    workload.Class
+	Signals  workload.Signals
+	Workflow workflowconfig.Config
 }
 
 type doctorAgentPoolRecommendation struct {
 	Pool          string
 	CurrentCap    int
 	CloudCap      int
+	PoolWaits     int
 	LocalProjects []doctorWorkloadProject
 	CloudProjects []doctorWorkloadProject
 	Contention    []store.CrossClassPoolContention
+}
+
+type doctorCapacityRow struct {
+	Reason store.CapacityConstraintReason
+	Lane   string
+	Count  int
+}
+
+type doctorCapacityFinding struct {
+	Project doctorWorkloadProject
+	Pool    string
+	Rows    []doctorCapacityRow
+	Binding doctorCapacityRow
+	Total   int
 }
 
 func checkDoctorAgentPools(
@@ -44,15 +62,8 @@ func checkDoctorAgentPools(
 	cfg globalconfig.Config,
 	deps doctorDeps,
 ) doctorCheck {
-	if len(cfg.Global.AgentPools) > 0 {
-		return doctorCheck{
-			Name:   doctorAgentPoolsCheckName,
-			Status: doctorOK,
-			Detail: configuredAgentPoolsDetail(cfg.Global.AgentPools),
-		}
-	}
 	deps = deps.withDefaults()
-	projects, classes, mixed, err := doctorClassifyWorkloadProjects(ctx, cfg, deps)
+	projects, classes, _, err := doctorClassifyWorkloadProjects(ctx, cfg, deps)
 	if err != nil {
 		return doctorCheck{
 			Name:   doctorAgentPoolsCheckName,
@@ -60,22 +71,12 @@ func checkDoctorAgentPools(
 			Detail: "skipped because not every project workflow could be classified: " + err.Error(),
 		}
 	}
-	if !mixed {
-		return doctorCheck{
-			Name:   doctorAgentPoolsCheckName,
-			Status: doctorOK,
-			Detail: "one workload class is configured; no pool split is recommended",
-		}
-	}
+	coherence := doctorPoolCoherenceFindings(cfg, projects)
 	storePath := filepath.Join(filepath.Dir(resolution.Path), "detent.db")
 	db, err := deps.openSQLiteReadOnly(ctx, storePath)
 	if err != nil {
 		if errors.Is(err, errDoctorTelemetryStoreUnavailable) {
-			return doctorCheck{
-				Name:   doctorAgentPoolsCheckName,
-				Status: doctorOK,
-				Detail: "mixed workload classes are configured, but there is no contention telemetry yet",
-			}
+			return newDoctorCapacityCheck(cfg, projects, nil, nil, coherence)
 		}
 		return doctorCheck{
 			Name:   doctorAgentPoolsCheckName,
@@ -85,11 +86,23 @@ func checkDoctorAgentPools(
 		}
 	}
 
+	waits, waitErr := store.QueryCapacityConstraintWaits(ctx, db, store.CapacityConstraintQuery{
+		Since:          deps.now().UTC().Add(-doctorAgentPoolsWindow),
+		ProjectClasses: classes,
+	})
 	contention, err := store.QueryCrossClassPoolContention(ctx, db, store.PoolContentionQuery{
 		Since:          deps.now().UTC().Add(-doctorAgentPoolsWindow),
 		ProjectClasses: classes,
 	})
 	closeErr := db.Close()
+	if waitErr != nil {
+		return doctorCheck{
+			Name:   doctorAgentPoolsCheckName,
+			Status: doctorWarn,
+			Detail: "capacity constraint telemetry could not be analyzed: " + waitErr.Error(),
+			Hint:   "Confirm the runtime database has current scheduler-decision telemetry.",
+		}
+	}
 	if err != nil {
 		return doctorCheck{
 			Name:   doctorAgentPoolsCheckName,
@@ -105,20 +118,7 @@ func checkDoctorAgentPools(
 			Detail: "pool contention telemetry could not be closed: " + closeErr.Error(),
 		}
 	}
-	recommendation, ok := newDoctorAgentPoolRecommendation(cfg, projects, contention)
-	if !ok {
-		return doctorCheck{
-			Name:   doctorAgentPoolsCheckName,
-			Status: doctorOK,
-			Detail: "mixed workload classes have no cross-class pool contention in 7d",
-		}
-	}
-	return doctorCheck{
-		Name:   doctorAgentPoolsCheckName,
-		Status: doctorWarn,
-		Detail: recommendation.Detail(),
-		Hint:   "Review the proposed split, tune the cloud cap to provider limits, then run detent fix agent-pools.",
-	}
+	return newDoctorCapacityCheck(cfg, projects, waits, contention, coherence)
 }
 
 func configuredAgentPoolsDetail(pools []globalconfig.AgentPool) string {
@@ -155,9 +155,11 @@ func doctorClassifyWorkloadProjects(
 		}
 		class, signals := workload.Classify(workflowConfig.Config)
 		item := doctorWorkloadProject{
-			ID:      doctorProjectID(project),
-			Class:   class,
-			Signals: signals,
+			ID:       doctorProjectID(project),
+			Pool:     doctorProjectPool(project),
+			Class:    class,
+			Signals:  signals,
+			Workflow: workflowConfig.Config,
 		}
 		projects = append(projects, item)
 		classes[item.ID] = string(class)
@@ -169,15 +171,388 @@ func doctorClassifyWorkloadProjects(
 	return projects, classes, len(classSet) > 1, nil
 }
 
-func newDoctorAgentPoolRecommendation(
+func newDoctorCapacityCheck(
+	cfg globalconfig.Config,
+	projects []doctorWorkloadProject,
+	waits []store.CapacityConstraintWait,
+	contention []store.CrossClassPoolContention,
+	coherence []string,
+) doctorCheck {
+	findings := newDoctorCapacityFindings(projects, waits)
+	if len(findings) == 0 && len(coherence) == 0 {
+		return doctorCheck{
+			Name:   doctorAgentPoolsCheckName,
+			Status: doctorOK,
+			Detail: "no binding capacity constraint detected",
+		}
+	}
+
+	var builder strings.Builder
+	hint := "Review the binding constraint before changing capacity."
+	for index, finding := range findings {
+		if index > 0 {
+			builder.WriteString("\n\n")
+		}
+		fmt.Fprintf(
+			&builder,
+			"%s (%s) blocked %s in 7d\n",
+			finding.Project.ID,
+			finding.Project.Class,
+			doctorCountTimes(finding.Total),
+		)
+		for _, row := range finding.Rows {
+			marker := ""
+			if row.Reason == finding.Binding.Reason && row.Lane == finding.Binding.Lane {
+				marker = "  <- binding"
+			}
+			fmt.Fprintf(&builder, "  %-48s %6d%s\n", doctorCapacityRowLabel(row), row.Count, marker)
+		}
+		recommendation, recommendationHint := doctorCapacityRecommendation(cfg, projects, finding, contention)
+		if recommendation != "" {
+			builder.WriteByte('\n')
+			for _, line := range strings.Split(recommendation, "\n") {
+				builder.WriteString("  ")
+				builder.WriteString(line)
+				builder.WriteByte('\n')
+			}
+		}
+		if recommendationHint != "" {
+			hint = recommendationHint
+		}
+	}
+	if len(coherence) > 0 {
+		if builder.Len() > 0 {
+			builder.WriteString("\n")
+		}
+		builder.WriteString("static configuration cannot deliver its declared capacity:\n")
+		for _, finding := range coherence {
+			builder.WriteString("  - ")
+			builder.WriteString(finding)
+			builder.WriteByte('\n')
+		}
+		if len(findings) == 0 {
+			hint = "Align pool, project, and active-lane caps before raising capacity."
+		}
+	}
+
+	return doctorCheck{
+		Name:   doctorAgentPoolsCheckName,
+		Status: doctorWarn,
+		Detail: strings.TrimRight(builder.String(), "\n"),
+		Hint:   hint,
+	}
+}
+
+func newDoctorCapacityFindings(
+	projects []doctorWorkloadProject,
+	waits []store.CapacityConstraintWait,
+) []doctorCapacityFinding {
+	projectsByID := make(map[string]doctorWorkloadProject, len(projects))
+	for _, project := range projects {
+		projectsByID[project.ID] = project
+	}
+	type findingBuilder struct {
+		project doctorWorkloadProject
+		pool    string
+		counts  map[string]doctorCapacityRow
+		total   int
+	}
+	builders := map[string]*findingBuilder{}
+	for _, wait := range waits {
+		if wait.WaitCount <= 0 {
+			continue
+		}
+		project, ok := projectsByID[wait.ProjectID]
+		if !ok {
+			continue
+		}
+		builder := builders[wait.ProjectID]
+		if builder == nil {
+			builder = &findingBuilder{
+				project: project,
+				pool:    wait.Pool,
+				counts:  map[string]doctorCapacityRow{},
+			}
+			builders[wait.ProjectID] = builder
+		}
+		lane := ""
+		if wait.Reason == store.CapacityConstraintLane {
+			lane = strings.TrimSpace(wait.Lane)
+		}
+		key := string(wait.Reason) + "\x00" + strings.ToLower(lane)
+		row := builder.counts[key]
+		row.Reason = wait.Reason
+		row.Lane = lane
+		row.Count += wait.WaitCount
+		builder.counts[key] = row
+		builder.total += wait.WaitCount
+	}
+
+	findings := make([]doctorCapacityFinding, 0, len(builders))
+	for _, builder := range builders {
+		rows := doctorCapacityRows(builder.counts)
+		findings = append(findings, doctorCapacityFinding{
+			Project: builder.project,
+			Pool:    builder.pool,
+			Rows:    rows,
+			Binding: rows[0],
+			Total:   builder.total,
+		})
+	}
+	sort.Slice(findings, func(i, j int) bool {
+		return findings[i].Project.ID < findings[j].Project.ID
+	})
+	return findings
+}
+
+func doctorCapacityRows(counts map[string]doctorCapacityRow) []doctorCapacityRow {
+	for _, reason := range []store.CapacityConstraintReason{
+		store.CapacityConstraintPool,
+		store.CapacityConstraintProject,
+		store.CapacityConstraintLane,
+		store.CapacityConstraintWorkerHost,
+		store.CapacityConstraintRateWindow,
+	} {
+		found := false
+		for _, row := range counts {
+			if row.Reason == reason {
+				found = true
+				break
+			}
+		}
+		if !found {
+			counts[string(reason)+"\x00"] = doctorCapacityRow{Reason: reason}
+		}
+	}
+	rows := make([]doctorCapacityRow, 0, len(counts))
+	for _, row := range counts {
+		rows = append(rows, row)
+	}
+	sort.Slice(rows, func(i, j int) bool {
+		if rows[i].Count != rows[j].Count {
+			return rows[i].Count > rows[j].Count
+		}
+		if doctorCapacityReasonPriority(rows[i].Reason) != doctorCapacityReasonPriority(rows[j].Reason) {
+			return doctorCapacityReasonPriority(rows[i].Reason) < doctorCapacityReasonPriority(rows[j].Reason)
+		}
+		return strings.ToLower(rows[i].Lane) < strings.ToLower(rows[j].Lane)
+	})
+	return rows
+}
+
+func doctorCapacityReasonPriority(reason store.CapacityConstraintReason) int {
+	switch reason {
+	case store.CapacityConstraintRateWindow:
+		return 0
+	case store.CapacityConstraintPool:
+		return 1
+	case store.CapacityConstraintProject:
+		return 2
+	case store.CapacityConstraintLane:
+		return 3
+	case store.CapacityConstraintWorkerHost:
+		return 4
+	default:
+		return 5
+	}
+}
+
+func doctorCapacityRowLabel(row doctorCapacityRow) string {
+	if row.Reason == store.CapacityConstraintPool {
+		return "pool waits"
+	}
+	if row.Reason == store.CapacityConstraintLane && strings.TrimSpace(row.Lane) != "" {
+		return fmt.Sprintf("%s (%s)", row.Reason, row.Lane)
+	}
+	return string(row.Reason)
+}
+
+func doctorCapacityRecommendation(
+	cfg globalconfig.Config,
+	projects []doctorWorkloadProject,
+	finding doctorCapacityFinding,
+	contention []store.CrossClassPoolContention,
+) (string, string) {
+	projectID := finding.Project.ID
+	switch finding.Binding.Reason {
+	case store.CapacityConstraintPool:
+		if doctorPoolHasMixedClasses(projects, finding.Pool) {
+			if len(cfg.Global.AgentPools) == 0 && finding.Pool == globalconfig.DefaultAgentPoolName {
+				recommendation, ok := newDoctorAgentPoolRecommendationForWaits(
+					cfg,
+					projects,
+					contention,
+					finding.Binding.Count,
+				)
+				if ok {
+					return recommendation.Detail(),
+						"Review the proposed split, tune the cloud cap to provider limits, then run detent fix agent-pools."
+				}
+			}
+			return fmt.Sprintf(
+				"split pool %q by workload class; configured pools require an operator-reviewed repartition.",
+				finding.Pool,
+			), ""
+		}
+		return fmt.Sprintf("raise %s; this pool contains one workload class, so do not split it.", doctorPoolCapacityPath(cfg, finding.Pool)), ""
+	case store.CapacityConstraintProject:
+		return fmt.Sprintf(
+			"the pool cap is not throttling this workload.\nraise project %q agent.max_concurrent_agents.",
+			projectID,
+		), ""
+	case store.CapacityConstraintLane:
+		path := "agent.max_concurrent_agents_by_state"
+		if strings.TrimSpace(finding.Binding.Lane) != "" {
+			path += "." + finding.Binding.Lane
+		}
+		return fmt.Sprintf(
+			"the pool cap is not throttling this workload.\nraise project %q %s before reaching for a pool split.",
+			projectID,
+			path,
+		), ""
+	case store.CapacityConstraintWorkerHost:
+		return fmt.Sprintf(
+			"the pool cap is not throttling this workload.\nraise project %q worker.max_concurrent_agents_per_host.",
+			projectID,
+		), ""
+	case store.CapacityConstraintRateWindow:
+		return "provider rate-window backpressure is binding; no config change is recommended because raising a cap will not help.", ""
+	default:
+		return "", ""
+	}
+}
+
+func doctorPoolCoherenceFindings(
+	cfg globalconfig.Config,
+	projects []doctorWorkloadProject,
+) []string {
+	poolCaps := map[string]int{
+		globalconfig.DefaultAgentPoolName: cfg.Global.MaxConcurrentAgents,
+	}
+	for _, pool := range cfg.Global.AgentPools {
+		poolCaps[strings.TrimSpace(pool.Name)] = pool.MaxConcurrentAgents
+	}
+	memberCapSums := map[string]int{}
+	memberCounts := map[string]int{}
+	var findings []string
+	for _, project := range projects {
+		poolCap, ok := poolCaps[project.Pool]
+		if !ok {
+			continue
+		}
+		projectCap := project.Workflow.Agent.MaxConcurrentAgents
+		memberCapSums[project.Pool] += projectCap
+		memberCounts[project.Pool]++
+		if projectCap > poolCap {
+			findings = append(findings, fmt.Sprintf(
+				"project %q agent.max_concurrent_agents=%d exceeds pool %q capacity %d; the project cap is dead configuration",
+				project.ID,
+				projectCap,
+				project.Pool,
+				poolCap,
+			))
+		}
+		lanes := make([]string, 0, len(project.Workflow.Agent.MaxConcurrentAgentsByState))
+		for lane := range project.Workflow.Agent.MaxConcurrentAgentsByState {
+			lanes = append(lanes, lane)
+		}
+		sort.Strings(lanes)
+		for _, lane := range lanes {
+			laneCap := project.Workflow.Agent.MaxConcurrentAgentsByState[lane]
+			if laneCap >= projectCap || !doctorActiveWorkLane(project.Workflow, lane) {
+				continue
+			}
+			findings = append(findings, fmt.Sprintf(
+				"project %q active lane %q cap %d binds below agent.max_concurrent_agents=%d",
+				project.ID,
+				lane,
+				laneCap,
+				projectCap,
+			))
+		}
+	}
+	pools := make([]string, 0, len(memberCounts))
+	for pool := range memberCounts {
+		pools = append(pools, pool)
+	}
+	sort.Strings(pools)
+	for _, pool := range pools {
+		if memberCapSums[pool] >= poolCaps[pool] {
+			continue
+		}
+		findings = append(findings, fmt.Sprintf(
+			"pool %q capacity %d exceeds its %d member project cap total %d; the pool can never fill",
+			pool,
+			poolCaps[pool],
+			memberCounts[pool],
+			memberCapSums[pool],
+		))
+	}
+	sort.Strings(findings)
+	return findings
+}
+
+func doctorActiveWorkLane(cfg workflowconfig.Config, lane string) bool {
+	normalized := strings.ToLower(strings.TrimSpace(lane))
+	if normalized == "" || normalized == "merging" {
+		return false
+	}
+	for _, active := range cfg.Tracker.ActiveStates {
+		if strings.EqualFold(strings.TrimSpace(active), lane) {
+			return true
+		}
+	}
+	return false
+}
+
+func doctorPoolHasMixedClasses(projects []doctorWorkloadProject, pool string) bool {
+	classes := map[workload.Class]struct{}{}
+	for _, project := range projects {
+		if project.Pool == pool {
+			classes[project.Class] = struct{}{}
+		}
+	}
+	return len(classes) > 1
+}
+
+func doctorPoolCapacityPath(cfg globalconfig.Config, pool string) string {
+	if pool == globalconfig.DefaultAgentPoolName {
+		return "global.max_concurrent_agents"
+	}
+	for _, configured := range cfg.Global.AgentPools {
+		if strings.TrimSpace(configured.Name) == pool {
+			return fmt.Sprintf("global.agent_pools[%q].max_concurrent_agents", pool)
+		}
+	}
+	return fmt.Sprintf("pool %q capacity", pool)
+}
+
+func doctorProjectPool(project globalconfig.Project) string {
+	pool := strings.TrimSpace(project.Pool)
+	if pool == "" {
+		return globalconfig.DefaultAgentPoolName
+	}
+	return pool
+}
+
+func doctorCountTimes(count int) string {
+	if count == 1 {
+		return "1x"
+	}
+	return fmt.Sprintf("%dx", count)
+}
+
+func newDoctorAgentPoolRecommendationForWaits(
 	cfg globalconfig.Config,
 	projects []doctorWorkloadProject,
 	contention []store.CrossClassPoolContention,
+	poolWaits int,
 ) (doctorAgentPoolRecommendation, bool) {
 	recommendation := doctorAgentPoolRecommendation{
 		Pool:       globalconfig.DefaultAgentPoolName,
 		CurrentCap: cfg.Global.MaxConcurrentAgents,
 		CloudCap:   max(cfg.Global.MaxConcurrentAgents, doctorCloudPoolStartingSize),
+		PoolWaits:  poolWaits,
 	}
 	for _, project := range projects {
 		switch project.Class {
@@ -202,6 +577,9 @@ func (r doctorAgentPoolRecommendation) TotalWaits() int {
 	for _, contention := range r.Contention {
 		total += contention.WaitCount
 	}
+	if total == 0 {
+		total = r.PoolWaits
+	}
 	return total
 }
 
@@ -212,7 +590,11 @@ func (r doctorAgentPoolRecommendation) Detail() string {
 	builder.WriteString("    (declare local validation/build gates or CI triggers)\n")
 	fmt.Fprintf(&builder, "  cloud-only:  %s\n", strings.Join(doctorWorkloadProjectIDs(r.CloudProjects), ", "))
 	builder.WriteString("    (no local validation/build gate, no CI trigger)\n\n")
-	fmt.Fprintf(&builder, "  cross-class work waited on pool capacity %d times in 7d.\n", r.TotalWaits())
+	if len(r.Contention) > 0 {
+		fmt.Fprintf(&builder, "  cross-class work waited on pool capacity %d times in 7d.\n", r.TotalWaits())
+	} else {
+		fmt.Fprintf(&builder, "  mixed workload classes waited on pool capacity %d times in 7d.\n", r.TotalWaits())
+	}
 	for _, contention := range r.Contention {
 		fmt.Fprintf(
 			&builder,

--- a/internal/cli/doctor_agent_pools.go
+++ b/internal/cli/doctor_agent_pools.go
@@ -121,25 +121,6 @@ func checkDoctorAgentPools(
 	return newDoctorCapacityCheck(cfg, projects, waits, contention, coherence)
 }
 
-func configuredAgentPoolsDetail(pools []globalconfig.AgentPool) string {
-	elastic := make([]string, 0, len(pools))
-	for _, pool := range pools {
-		if pool.BurstTo <= pool.MaxConcurrentAgents {
-			continue
-		}
-		elastic = append(elastic, fmt.Sprintf(
-			"%s (guaranteed %d, burst ceiling %d)",
-			strings.TrimSpace(pool.Name),
-			pool.MaxConcurrentAgents,
-			pool.BurstTo,
-		))
-	}
-	if len(elastic) == 0 {
-		return "agent pools are already configured with rigid capacity; automatic repartitioning is intentionally disabled"
-	}
-	return "agent pools are already configured; elastic capacity: " + strings.Join(elastic, ", ")
-}
-
 func doctorClassifyWorkloadProjects(
 	ctx context.Context,
 	cfg globalconfig.Config,
@@ -430,7 +411,7 @@ func doctorPoolCoherenceFindings(
 		globalconfig.DefaultAgentPoolName: cfg.Global.MaxConcurrentAgents,
 	}
 	for _, pool := range cfg.Global.AgentPools {
-		poolCaps[strings.TrimSpace(pool.Name)] = pool.MaxConcurrentAgents
+		poolCaps[strings.TrimSpace(pool.Name)] = doctorConfiguredPoolCapacity(pool)
 	}
 	memberCapSums := map[string]int{}
 	memberCounts := map[string]int{}
@@ -521,10 +502,20 @@ func doctorPoolCapacityPath(cfg globalconfig.Config, pool string) string {
 	}
 	for _, configured := range cfg.Global.AgentPools {
 		if strings.TrimSpace(configured.Name) == pool {
+			if configured.BurstTo > configured.MaxConcurrentAgents {
+				return fmt.Sprintf("global.agent_pools[%q].burst_to", pool)
+			}
 			return fmt.Sprintf("global.agent_pools[%q].max_concurrent_agents", pool)
 		}
 	}
 	return fmt.Sprintf("pool %q capacity", pool)
+}
+
+func doctorConfiguredPoolCapacity(pool globalconfig.AgentPool) int {
+	if pool.BurstTo > pool.MaxConcurrentAgents {
+		return pool.BurstTo
+	}
+	return pool.MaxConcurrentAgents
 }
 
 func doctorProjectPool(project globalconfig.Project) string {

--- a/internal/cli/doctor_agent_pools_test.go
+++ b/internal/cli/doctor_agent_pools_test.go
@@ -129,18 +129,24 @@ func TestDoctorCapacityConstraintBindingRecommendations(t *testing.T) {
 			want:       []string{"no binding capacity constraint detected"},
 		},
 		{
-			name: "elastic pools",
+			name: "elastic pool contention raises burst ceiling",
 			cfg: func() globalconfig.Config {
 				cfg := doctorAgentPoolsTestConfig([]globalconfig.Project{
-					{ID: "detent", Workflow: "detent", Pool: "code", Weight: 1},
+					{ID: "video", Pool: "cloud"},
 				})
 				cfg.Global.AgentPools = []globalconfig.AgentPool{
-					{Name: "code", MaxConcurrentAgents: 5, BurstTo: 8},
+					{Name: "cloud", MaxConcurrentAgents: 5, BurstTo: 8},
 				}
 				return cfg
 			}(),
-			wantStatus:    doctorOK,
-			wantSubstring: "code (guaranteed 5, burst ceiling 8)",
+			projects: []doctorWorkloadProject{
+				doctorCapacityTestProject("video", "cloud", workload.ClassCloudOnly, 10),
+			},
+			waits: []store.CapacityConstraintWait{
+				{ProjectID: "video", WorkloadClass: "cloud-only", Pool: "cloud", Reason: store.CapacityConstraintPool, WaitCount: 9},
+			},
+			wantStatus: doctorWarn,
+			want:       []string{`raise global.agent_pools["cloud"].burst_to`},
 		},
 	}
 
@@ -204,6 +210,22 @@ func TestDoctorPoolCoherenceFindings(t *testing.T) {
 				doctorCapacityTestProject("video", "cloud", workload.ClassCloudOnly, 8),
 			},
 			want: `project "video" agent.max_concurrent_agents=8 exceeds pool "cloud" capacity 5`,
+		},
+		{
+			name: "elastic pool uses burst ceiling",
+			cfg: globalconfig.Config{
+				Global: globalconfig.Settings{
+					MaxConcurrentAgents: 5,
+					AgentPools: []globalconfig.AgentPool{{
+						Name:                "cloud",
+						MaxConcurrentAgents: 5,
+						BurstTo:             8,
+					}},
+				},
+			},
+			projects: []doctorWorkloadProject{
+				doctorCapacityTestProject("video", "cloud", workload.ClassCloudOnly, 8),
+			},
 		},
 		{
 			name: "active lane binds below project",

--- a/internal/cli/doctor_agent_pools_test.go
+++ b/internal/cli/doctor_agent_pools_test.go
@@ -2,10 +2,8 @@ package cli
 
 import (
 	"context"
-	"path/filepath"
 	"strings"
 	"testing"
-	"time"
 
 	"gopkg.in/yaml.v3"
 
@@ -13,101 +11,122 @@ import (
 	globalconfig "github.com/digitaldrywood/detent/internal/config/global"
 	"github.com/digitaldrywood/detent/internal/gate"
 	"github.com/digitaldrywood/detent/internal/store"
+	"github.com/digitaldrywood/detent/internal/workload"
 )
 
-func TestCheckDoctorAgentPools(t *testing.T) {
+func TestDoctorCapacityConstraintBindingRecommendations(t *testing.T) {
 	t.Parallel()
 
-	now := time.Date(2026, 7, 27, 20, 0, 0, 0, time.UTC)
-	localWorkflow := workflowconfig.Workflow{Config: workflowconfig.Config{
-		Gate: gate.Config{Kind: gate.KindCommand, Run: "make check"},
-	}}
-	cloudWorkflow := workflowconfig.Workflow{Config: workflowconfig.Config{
-		Gate: gate.Config{Kind: gate.KindArtifact},
-	}}
-
 	tests := []struct {
-		name          string
-		cfg           globalconfig.Config
-		workflows     map[string]workflowconfig.Workflow
-		waiting       string
-		holders       string
-		wantStatus    doctorStatus
-		wantSubstring string
+		name       string
+		cfg        globalconfig.Config
+		projects   []doctorWorkloadProject
+		waits      []store.CapacityConstraintWait
+		contention []store.CrossClassPoolContention
+		wantStatus doctorStatus
+		want       []string
+		notWant    []string
+		wantHint   string
 	}{
 		{
-			name: "one workload class",
+			name: "mixed class pool contention preserves split",
 			cfg: doctorAgentPoolsTestConfig([]globalconfig.Project{
-				{ID: "detent", Workflow: "detent", Weight: 1},
-				{ID: "gopher-ai", Workflow: "gopher-ai", Weight: 1},
+				{ID: "detent"},
+				{ID: "video"},
 			}),
-			workflows: map[string]workflowconfig.Workflow{
-				"detent":    localWorkflow,
-				"gopher-ai": localWorkflow,
+			projects: []doctorWorkloadProject{
+				doctorCapacityTestProject("detent", "default", workload.ClassLocalHeavy, 5),
+				doctorCapacityTestProject("video", "default", workload.ClassCloudOnly, 5),
 			},
-			wantStatus:    doctorOK,
-			wantSubstring: "one workload class",
+			waits: []store.CapacityConstraintWait{
+				{ProjectID: "video", WorkloadClass: "cloud-only", Pool: "default", Reason: store.CapacityConstraintPool, WaitCount: 12},
+				{ProjectID: "video", WorkloadClass: "cloud-only", Pool: "default", Reason: store.CapacityConstraintProject, WaitCount: 2},
+			},
+			contention: []store.CrossClassPoolContention{
+				{Pool: "default", WaitingClass: "cloud-only", HoldingClass: "local-heavy", WaitCount: 12},
+			},
+			wantStatus: doctorWarn,
+			want: []string{
+				"video (cloud-only) blocked 14x in 7d",
+				"pool waits",
+				"<- binding",
+				`2 workload classes share pool "default"`,
+				"suggested:",
+			},
+			wantHint: "detent fix agent-pools",
 		},
 		{
-			name: "mixed classes without contention",
-			cfg: doctorAgentPoolsTestConfig([]globalconfig.Project{
-				{ID: "detent", Workflow: "detent", Weight: 1},
-				{ID: "video", Workflow: "video", Weight: 1},
-			}),
-			workflows: map[string]workflowconfig.Workflow{
-				"detent": localWorkflow,
-				"video":  cloudWorkflow,
-			},
-			wantStatus:    doctorOK,
-			wantSubstring: "no cross-class pool contention",
-		},
-		{
-			name: "same class contention",
-			cfg: doctorAgentPoolsTestConfig([]globalconfig.Project{
-				{ID: "detent", Workflow: "detent", Weight: 1},
-				{ID: "video", Workflow: "video", Weight: 1},
-				{ID: "podcast", Workflow: "podcast", Weight: 1},
-			}),
-			workflows: map[string]workflowconfig.Workflow{
-				"detent":  localWorkflow,
-				"video":   cloudWorkflow,
-				"podcast": cloudWorkflow,
-			},
-			waiting:       "video",
-			holders:       `["podcast"]`,
-			wantStatus:    doctorOK,
-			wantSubstring: "no cross-class pool contention",
-		},
-		{
-			name: "cross class contention",
-			cfg: doctorAgentPoolsTestConfig([]globalconfig.Project{
-				{ID: "detent", Workflow: "detent", Weight: 1},
-				{ID: "video", Workflow: "video", Weight: 1},
-			}),
-			workflows: map[string]workflowconfig.Workflow{
-				"detent": localWorkflow,
-				"video":  cloudWorkflow,
-			},
-			waiting:       "video",
-			holders:       `["detent"]`,
-			wantStatus:    doctorWarn,
-			wantSubstring: "cloud-only waited 1 time(s); local-heavy held a slot",
-		},
-		{
-			name: "existing pools",
+			name: "single class pool contention raises capacity",
 			cfg: func() globalconfig.Config {
-				cfg := doctorAgentPoolsTestConfig([]globalconfig.Project{
-					{ID: "detent", Workflow: "detent", Pool: "code", Weight: 1},
-					{ID: "video", Workflow: "video", Pool: "cloud", Weight: 1},
-				})
-				cfg.Global.AgentPools = []globalconfig.AgentPool{
-					{Name: "code", MaxConcurrentAgents: 5},
-					{Name: "cloud", MaxConcurrentAgents: 10},
-				}
+				cfg := doctorAgentPoolsTestConfig([]globalconfig.Project{{ID: "video", Pool: "cloud"}})
+				cfg.Global.AgentPools = []globalconfig.AgentPool{{Name: "cloud", MaxConcurrentAgents: 5}}
 				return cfg
 			}(),
-			wantStatus:    doctorOK,
-			wantSubstring: "already configured",
+			projects: []doctorWorkloadProject{
+				doctorCapacityTestProject("video", "cloud", workload.ClassCloudOnly, 5),
+			},
+			waits: []store.CapacityConstraintWait{
+				{ProjectID: "video", WorkloadClass: "cloud-only", Pool: "cloud", Reason: store.CapacityConstraintPool, WaitCount: 9},
+			},
+			wantStatus: doctorWarn,
+			want: []string{
+				`raise global.agent_pools["cloud"].max_concurrent_agents`,
+				"one workload class",
+			},
+			notWant: []string{"split pool", "suggested:"},
+		},
+		{
+			name:     "project cap",
+			cfg:      doctorAgentPoolsTestConfig([]globalconfig.Project{{ID: "video"}}),
+			projects: []doctorWorkloadProject{doctorCapacityTestProject("video", "default", workload.ClassCloudOnly, 5)},
+			waits: []store.CapacityConstraintWait{
+				{ProjectID: "video", WorkloadClass: "cloud-only", Pool: "default", Reason: store.CapacityConstraintProject, WaitCount: 8},
+				{ProjectID: "video", WorkloadClass: "cloud-only", Pool: "default", Reason: store.CapacityConstraintPool, WaitCount: 1},
+			},
+			wantStatus: doctorWarn,
+			want:       []string{`raise project "video" agent.max_concurrent_agents`, "pool cap is not throttling"},
+		},
+		{
+			name:     "lane cap names lane",
+			cfg:      doctorAgentPoolsTestConfig([]globalconfig.Project{{ID: "video"}}),
+			projects: []doctorWorkloadProject{doctorCapacityTestProject("video", "default", workload.ClassCloudOnly, 5)},
+			waits: []store.CapacityConstraintWait{
+				{ProjectID: "video", WorkloadClass: "cloud-only", Pool: "default", Lane: "In Progress", Reason: store.CapacityConstraintLane, WaitCount: 11},
+				{ProjectID: "video", WorkloadClass: "cloud-only", Pool: "default", Reason: store.CapacityConstraintProject, WaitCount: 2},
+			},
+			wantStatus: doctorWarn,
+			want: []string{
+				"lane_capacity_full (In Progress)",
+				`raise project "video" agent.max_concurrent_agents_by_state.In Progress`,
+			},
+		},
+		{
+			name:     "worker host cap",
+			cfg:      doctorAgentPoolsTestConfig([]globalconfig.Project{{ID: "video"}}),
+			projects: []doctorWorkloadProject{doctorCapacityTestProject("video", "default", workload.ClassCloudOnly, 5)},
+			waits: []store.CapacityConstraintWait{
+				{ProjectID: "video", WorkloadClass: "cloud-only", Pool: "default", Reason: store.CapacityConstraintWorkerHost, WaitCount: 7},
+			},
+			wantStatus: doctorWarn,
+			want:       []string{`raise project "video" worker.max_concurrent_agents_per_host`},
+		},
+		{
+			name:     "rate window recommends no config change",
+			cfg:      doctorAgentPoolsTestConfig([]globalconfig.Project{{ID: "video"}}),
+			projects: []doctorWorkloadProject{doctorCapacityTestProject("video", "default", workload.ClassCloudOnly, 5)},
+			waits: []store.CapacityConstraintWait{
+				{ProjectID: "video", WorkloadClass: "cloud-only", Pool: "default", Reason: store.CapacityConstraintRateWindow, WaitCount: 6},
+			},
+			wantStatus: doctorWarn,
+			want:       []string{"provider rate-window backpressure is binding", "no config change is recommended"},
+			notWant:    []string{"raise ", "split "},
+		},
+		{
+			name:       "nothing binding stays silent",
+			cfg:        doctorAgentPoolsTestConfig([]globalconfig.Project{{ID: "video"}}),
+			projects:   []doctorWorkloadProject{doctorCapacityTestProject("video", "default", workload.ClassCloudOnly, 5)},
+			wantStatus: doctorOK,
+			want:       []string{"no binding capacity constraint detected"},
 		},
 		{
 			name: "elastic pools",
@@ -129,59 +148,139 @@ func TestCheckDoctorAgentPools(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			dir := t.TempDir()
-			configPath := filepath.Join(dir, "global.yaml")
-			dbPath := filepath.Join(dir, "detent.db")
-			backend, err := store.Open(t.Context(), store.Config{Path: dbPath})
-			if err != nil {
-				t.Fatalf("store.Open() error = %v", err)
+			check := newDoctorCapacityCheck(tt.cfg, tt.projects, tt.waits, tt.contention, nil)
+			if check.Status != tt.wantStatus {
+				t.Fatalf("check status = %s, want %s; detail:\n%s", check.Status, tt.wantStatus, check.Detail)
 			}
-			if tt.waiting != "" {
-				if _, err := backend.RecordSchedulerDecision(t.Context(), store.SchedulerDecision{
-					ProjectID:            tt.waiting,
-					Result:               store.SchedulerDecisionResultSkipped,
-					Reason:               "reserved_for_higher_priority_project",
-					DecisionAt:           now.Add(-time.Hour),
-					WaitReason:           "reserved_for_higher_priority_project",
-					CapacitySnapshotJSON: `{"pool":"default","global_available":0,"holders":` + tt.holders + `}`,
-				}); err != nil {
-					t.Fatalf("RecordSchedulerDecision() error = %v", err)
+			for _, want := range tt.want {
+				if !strings.Contains(check.Detail, want) {
+					t.Fatalf("detail missing %q:\n%s", want, check.Detail)
 				}
 			}
-			if err := backend.Close(); err != nil {
-				t.Fatalf("Close() error = %v", err)
-			}
-
-			deps := doctorDeps{
-				loadWorkflow: func(path string) (workflowconfig.Workflow, error) {
-					return tt.workflows[path], nil
-				},
-				openSQLiteReadOnly: openDoctorSQLiteReadOnly,
-				now:                func() time.Time { return now },
-			}.withDefaults()
-			check := checkDoctorAgentPools(
-				context.Background(),
-				globalconfig.PathResolution{Path: configPath},
-				tt.cfg,
-				deps,
-			)
-			if check.Status != tt.wantStatus || !strings.Contains(check.Detail, tt.wantSubstring) {
-				t.Fatalf("check = %#v, want status %s containing %q", check, tt.wantStatus, tt.wantSubstring)
-			}
-			if tt.wantStatus == doctorWarn {
-				for _, want := range []string{
-					"local-heavy: detent",
-					"cloud-only:  video",
-					"pool capacity 1 times in 7d",
-					"max_concurrent_agents: 5",
-					"max_concurrent_agents: 10 # tune to your provider limits",
-				} {
-					if !strings.Contains(check.Detail, want) {
-						t.Fatalf("detail missing %q:\n%s", want, check.Detail)
-					}
+			for _, notWant := range tt.notWant {
+				if strings.Contains(check.Detail, notWant) {
+					t.Fatalf("detail unexpectedly contains %q:\n%s", notWant, check.Detail)
 				}
+			}
+			if tt.wantHint != "" && !strings.Contains(check.Hint, tt.wantHint) {
+				t.Fatalf("hint = %q, want containing %q", check.Hint, tt.wantHint)
 			}
 		})
+	}
+}
+
+func TestDoctorPoolCoherenceFindings(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		cfg      globalconfig.Config
+		projects []doctorWorkloadProject
+		want     string
+	}{
+		{
+			name: "pool cannot fill",
+			cfg: globalconfig.Config{
+				Global: globalconfig.Settings{
+					MaxConcurrentAgents: 5,
+					AgentPools:          []globalconfig.AgentPool{{Name: "cloud", MaxConcurrentAgents: 10}},
+				},
+			},
+			projects: []doctorWorkloadProject{
+				doctorCapacityTestProject("video", "cloud", workload.ClassCloudOnly, 2),
+				doctorCapacityTestProject("podcast", "cloud", workload.ClassCloudOnly, 3),
+			},
+			want: `pool "cloud" capacity 10 exceeds its 2 member project cap total 5`,
+		},
+		{
+			name: "project cap is dead",
+			cfg: globalconfig.Config{
+				Global: globalconfig.Settings{
+					MaxConcurrentAgents: 5,
+					AgentPools:          []globalconfig.AgentPool{{Name: "cloud", MaxConcurrentAgents: 5}},
+				},
+			},
+			projects: []doctorWorkloadProject{
+				doctorCapacityTestProject("video", "cloud", workload.ClassCloudOnly, 8),
+			},
+			want: `project "video" agent.max_concurrent_agents=8 exceeds pool "cloud" capacity 5`,
+		},
+		{
+			name: "active lane binds below project",
+			cfg: globalconfig.Config{
+				Global: globalconfig.Settings{MaxConcurrentAgents: 5},
+			},
+			projects: []doctorWorkloadProject{
+				func() doctorWorkloadProject {
+					project := doctorCapacityTestProject("video", "default", workload.ClassCloudOnly, 5)
+					project.Workflow.Tracker.ActiveStates = []string{"In Progress", "Merging"}
+					project.Workflow.Agent.MaxConcurrentAgentsByState = map[string]int{
+						"In Progress": 2,
+						"Merging":     1,
+					}
+					return project
+				}(),
+			},
+			want: `project "video" active lane "In Progress" cap 2 binds below agent.max_concurrent_agents=5`,
+		},
+		{
+			name: "serialized merging lane is coherent",
+			cfg: globalconfig.Config{
+				Global: globalconfig.Settings{MaxConcurrentAgents: 5},
+			},
+			projects: []doctorWorkloadProject{
+				func() doctorWorkloadProject {
+					project := doctorCapacityTestProject("detent", "default", workload.ClassLocalHeavy, 5)
+					project.Workflow.Tracker.ActiveStates = []string{"Merging"}
+					project.Workflow.Agent.MaxConcurrentAgentsByState = map[string]int{"Merging": 1}
+					return project
+				}(),
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			findings := doctorPoolCoherenceFindings(tt.cfg, tt.projects)
+			detail := strings.Join(findings, "\n")
+			if tt.want == "" {
+				if len(findings) != 0 {
+					t.Fatalf("findings = %#v, want none", findings)
+				}
+				return
+			}
+			if !strings.Contains(detail, tt.want) {
+				t.Fatalf("findings missing %q:\n%s", tt.want, detail)
+			}
+		})
+	}
+}
+
+func TestCheckDoctorAgentPoolsReportsStaticFindingsWithoutTelemetry(t *testing.T) {
+	t.Parallel()
+
+	cfg := doctorAgentPoolsTestConfig([]globalconfig.Project{{ID: "video", Workflow: "video"}})
+	deps := doctorDeps{
+		loadWorkflow: func(string) (workflowconfig.Workflow, error) {
+			return workflowconfig.Workflow{Config: workflowconfig.Config{
+				Agent: workflowconfig.Agent{MaxConcurrentAgents: 2},
+				Gate:  gate.Config{Kind: gate.KindArtifact},
+			}}, nil
+		},
+		openSQLiteReadOnly: func(context.Context, string) (doctorTelemetryStore, error) {
+			return nil, errDoctorTelemetryStoreUnavailable
+		},
+	}
+	check := checkDoctorAgentPools(
+		t.Context(),
+		globalconfig.PathResolution{Path: "/config/global.yaml"},
+		cfg,
+		deps,
+	)
+	if check.Status != doctorWarn || !strings.Contains(check.Detail, "pool can never fill") {
+		t.Fatalf("check = %#v, want static warning without telemetry", check)
 	}
 }
 
@@ -254,5 +353,21 @@ func doctorAgentPoolsTestConfig(projects []globalconfig.Project) globalconfig.Co
 			Scheduling:          globalconfig.SchedulingWeighted,
 		},
 		Projects: projects,
+	}
+}
+
+func doctorCapacityTestProject(
+	id string,
+	pool string,
+	class workload.Class,
+	maxConcurrentAgents int,
+) doctorWorkloadProject {
+	return doctorWorkloadProject{
+		ID:    id,
+		Pool:  pool,
+		Class: class,
+		Workflow: workflowconfig.Config{
+			Agent: workflowconfig.Agent{MaxConcurrentAgents: maxConcurrentAgents},
+		},
 	}
 }

--- a/internal/cli/doctor_agent_pools_test.go
+++ b/internal/cli/doctor_agent_pools_test.go
@@ -258,6 +258,35 @@ func TestDoctorPoolCoherenceFindings(t *testing.T) {
 	}
 }
 
+func TestDoctorCapacityFindingsIgnorePreviousPoolAssignments(t *testing.T) {
+	t.Parallel()
+
+	project := doctorCapacityTestProject("video", "cloud", workload.ClassCloudOnly, 5)
+	findings := newDoctorCapacityFindings(
+		[]doctorWorkloadProject{project},
+		[]store.CapacityConstraintWait{
+			{
+				ProjectID: "video",
+				Pool:      "default",
+				Reason:    store.CapacityConstraintPool,
+				WaitCount: 100,
+			},
+			{
+				ProjectID: "video",
+				Pool:      "cloud",
+				Reason:    store.CapacityConstraintProject,
+				WaitCount: 2,
+			},
+		},
+	)
+	if len(findings) != 1 ||
+		findings[0].Pool != "cloud" ||
+		findings[0].Total != 2 ||
+		findings[0].Binding.Reason != store.CapacityConstraintProject {
+		t.Fatalf("findings = %#v, want only current cloud-pool telemetry", findings)
+	}
+}
+
 func TestCheckDoctorAgentPoolsReportsStaticFindingsWithoutTelemetry(t *testing.T) {
 	t.Parallel()
 

--- a/internal/cli/fix_agent_pools.go
+++ b/internal/cli/fix_agent_pools.go
@@ -163,18 +163,32 @@ func planAgentPoolsFix(
 		}
 		return agentPoolsFixPlan{}, err
 	}
+	waits, waitsErr := store.QueryCapacityConstraintWaits(ctx, db, store.CapacityConstraintQuery{
+		Since:          deps.now().UTC().Add(-doctorAgentPoolsWindow),
+		ProjectClasses: classes,
+	})
 	contention, queryErr := store.QueryCrossClassPoolContention(ctx, db, store.PoolContentionQuery{
 		Since:          deps.now().UTC().Add(-doctorAgentPoolsWindow),
 		ProjectClasses: classes,
 	})
 	closeErr := db.Close()
+	if waitsErr != nil {
+		return agentPoolsFixPlan{}, waitsErr
+	}
 	if queryErr != nil {
 		return agentPoolsFixPlan{}, queryErr
 	}
 	if closeErr != nil {
 		return agentPoolsFixPlan{}, closeErr
 	}
-	recommendation, ok := newDoctorAgentPoolRecommendation(cfg, projects, contention)
+	poolWaits := 0
+	for _, finding := range newDoctorCapacityFindings(projects, waits) {
+		if finding.Pool == globalconfig.DefaultAgentPoolName &&
+			finding.Binding.Reason == store.CapacityConstraintPool {
+			poolWaits += finding.Binding.Count
+		}
+	}
+	recommendation, ok := newDoctorAgentPoolRecommendationForWaits(cfg, projects, contention, poolWaits)
 	if !ok {
 		plan.Noop = true
 		plan.Message = "No changes needed: doctor found no cross-class pool contention in 7d."

--- a/internal/cli/fix_agent_pools_test.go
+++ b/internal/cli/fix_agent_pools_test.go
@@ -149,6 +149,18 @@ func TestAgentPoolsFixDeclinesExistingPools(t *testing.T) {
 	}
 }
 
+func TestAgentPoolsFixPreservesSplitPathForMixedClassPoolBinding(t *testing.T) {
+	t.Parallel()
+
+	fixture := newAgentPoolsFixFixtureWithHolder(t, "video")
+	output := runAgentPoolsFixTestCommand(t, fixture, "--dry-run")
+	if !strings.Contains(output, "agent_pools:") ||
+		!strings.Contains(output, "Dry run; no files changed.") ||
+		strings.Contains(output, "no cross-class pool contention") {
+		t.Fatalf("output = %q, want mixed-class binding split preview", output)
+	}
+}
+
 func TestApplyAgentPoolsFixDeclinesStalePlan(t *testing.T) {
 	t.Parallel()
 
@@ -232,6 +244,16 @@ type agentPoolsFixFixture struct {
 func newAgentPoolsFixFixture(t *testing.T, contention bool) agentPoolsFixFixture {
 	t.Helper()
 
+	holder := ""
+	if contention {
+		holder = "detent"
+	}
+	return newAgentPoolsFixFixtureWithHolder(t, holder)
+}
+
+func newAgentPoolsFixFixtureWithHolder(t *testing.T, holder string) agentPoolsFixFixture {
+	t.Helper()
+
 	dir := t.TempDir()
 	localWorkflowPath := filepath.Join(dir, "detent-WORKFLOW.md")
 	cloudWorkflowPath := filepath.Join(dir, "video-WORKFLOW.md")
@@ -271,14 +293,14 @@ func newAgentPoolsFixFixture(t *testing.T, contention bool) agentPoolsFixFixture
 		t.Fatalf("store.Open() error = %v", err)
 	}
 	now := time.Date(2026, 7, 27, 20, 0, 0, 0, time.UTC)
-	if contention {
+	if holder != "" {
 		if _, err := backend.RecordSchedulerDecision(t.Context(), store.SchedulerDecision{
 			ProjectID:            "video",
 			Result:               store.SchedulerDecisionResultSkipped,
 			Reason:               "reserved_for_higher_priority_project",
 			DecisionAt:           now.Add(-time.Hour),
 			WaitReason:           "reserved_for_higher_priority_project",
-			CapacitySnapshotJSON: `{"pool":"default","global_available":0,"holders":["detent"]}`,
+			CapacitySnapshotJSON: `{"pool":"default","global_available":0,"holders":["` + holder + `"]}`,
 		}); err != nil {
 			t.Fatalf("RecordSchedulerDecision() error = %v", err)
 		}

--- a/internal/orchestrator/autopromote_tick_test.go
+++ b/internal/orchestrator/autopromote_tick_test.go
@@ -641,8 +641,8 @@ func TestTickReleasesCompletedArtifactReworkNoopForNextDispatch(t *testing.T) {
 	if len(attempts.decisions) != 1 {
 		t.Fatalf("scheduler decisions after completion tick = %#v, want one", attempts.decisions)
 	}
-	if got := attempts.decisions[0]; got.IssueID != issue.ID || got.Reason != dispatchSkipLocalSlotUnavailable {
-		t.Fatalf("scheduler decision = %#v, want issue %q skipped for %q", got, issue.ID, dispatchSkipLocalSlotUnavailable)
+	if got := attempts.decisions[0]; got.IssueID != issue.ID || got.Reason != dispatchSkipGlobalCapacityFull {
+		t.Fatalf("scheduler decision = %#v, want issue %q skipped for %q", got, issue.ID, dispatchSkipGlobalCapacityFull)
 	}
 	for _, fragment := range []string{
 		`level=INFO msg="auto promote decision"`,
@@ -663,8 +663,8 @@ func TestTickReleasesCompletedArtifactReworkNoopForNextDispatch(t *testing.T) {
 	if len(attempts.decisions) != 2 {
 		t.Fatalf("scheduler decisions after next tick = %#v, want two", attempts.decisions)
 	}
-	if got := attempts.decisions[1]; got.IssueID != issue.ID || got.Reason != dispatchSkipLocalSlotUnavailable {
-		t.Fatalf("scheduler decision = %#v, want issue %q skipped for %q", got, issue.ID, dispatchSkipLocalSlotUnavailable)
+	if got := attempts.decisions[1]; got.IssueID != issue.ID || got.Reason != dispatchSkipGlobalCapacityFull {
+		t.Fatalf("scheduler decision = %#v, want issue %q skipped for %q", got, issue.ID, dispatchSkipGlobalCapacityFull)
 	}
 	if retry, ok := state.Retry[issue.ID]; !ok || retry.Attempt != 1 {
 		t.Fatalf("Retry[%q] after capacity skip = %#v, want rescheduled attempt 1", issue.ID, retry)

--- a/internal/orchestrator/dispatch_planner.go
+++ b/internal/orchestrator/dispatch_planner.go
@@ -574,8 +574,17 @@ func (p dispatchPlanner) dispatchableIssueDecision(
 	if p.budgetCooldownActive(state, issue.ID, now) {
 		return dispatchableDecision{reason: dispatchSkipBudgetCooldown}
 	}
-	if !p.slotsAvailable(issue, state, preferredWorkerHost) {
+	if p.availableSlots(state) == 0 {
+		if p.rateWindowBackpressureActive(state) {
+			return dispatchableDecision{reason: dispatchSkipRateWindowBackpressure}
+		}
+		return dispatchableDecision{reason: dispatchSkipGlobalCapacityFull}
+	}
+	if !p.stateSlotsAvailable(issue, state) {
 		return dispatchableDecision{reason: dispatchSkipLocalSlotUnavailable}
+	}
+	if !p.workerSlotsAvailable(state, preferredWorkerHost) {
+		return dispatchableDecision{reason: dispatchSkipWorkerHostUnavailable}
 	}
 	return dispatchableDecision{dispatchable: true}
 }

--- a/internal/orchestrator/dispatch_test.go
+++ b/internal/orchestrator/dispatch_test.go
@@ -1535,6 +1535,94 @@ func TestDispatchableChecksSlots(t *testing.T) {
 	}
 }
 
+func TestDispatchableIssueDecisionCapacityReason(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		cfg   Config
+		state func(*State)
+		want  string
+	}{
+		{
+			name: "project cap",
+			cfg: Config{
+				MaxConcurrentAgents: 1,
+				ActiveStates:        []string{"Todo"},
+				TerminalStates:      []string{"Done"},
+			},
+			state: func(state *State) {
+				running := dispatchTestIssue("running", "Todo")
+				state.Running[running.ID] = Running{Issue: running}
+			},
+			want: dispatchSkipGlobalCapacityFull,
+		},
+		{
+			name: "lane cap",
+			cfg: Config{
+				MaxConcurrentAgents:        2,
+				MaxConcurrentAgentsByState: map[string]int{"Todo": 1},
+				ActiveStates:               []string{"Todo"},
+				TerminalStates:             []string{"Done"},
+			},
+			state: func(state *State) {
+				running := dispatchTestIssue("running", "Todo")
+				state.Running[running.ID] = Running{Issue: running}
+			},
+			want: dispatchSkipLocalSlotUnavailable,
+		},
+		{
+			name: "worker host cap",
+			cfg: Config{
+				MaxConcurrentAgents:        2,
+				ActiveStates:               []string{"Todo"},
+				TerminalStates:             []string{"Done"},
+				WorkerHosts:                []string{"worker-a"},
+				MaxConcurrentAgentsPerHost: 1,
+			},
+			state: func(state *State) {
+				running := dispatchTestIssue("running", "Todo")
+				state.Running[running.ID] = Running{Issue: running, WorkerHost: "worker-a"}
+			},
+			want: dispatchSkipWorkerHostUnavailable,
+		},
+		{
+			name: "provider rate window",
+			cfg: Config{
+				MaxConcurrentAgents: 10,
+				ActiveStates:        []string{"Todo"},
+				TerminalStates:      []string{"Done"},
+				BillingMode:         workflowconfig.BillingModeSubscription,
+			},
+			state: func(state *State) {
+				state.RateLimits = &telemetry.RateLimits{
+					Primary: &telemetry.RateLimitBucket{Remaining: 50, Limit: 100},
+				}
+				for index := range 5 {
+					running := dispatchTestIssue(fmt.Sprintf("running-%d", index), "Todo")
+					state.Running[running.ID] = Running{Issue: running}
+				}
+			},
+			want: dispatchSkipRateWindowBackpressure,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			cfg := normalizeConfig(tt.cfg)
+			state := newState(cfg)
+			tt.state(&state)
+			issue := dispatchTestIssue("candidate", "Todo")
+			decision := newDispatchPlanner(cfg).dispatchableIssueDecision(issue, &state, false, time.Now(), "")
+			if decision.dispatchable || decision.reason != tt.want {
+				t.Fatalf("dispatchable decision = %#v, want skipped for %q", decision, tt.want)
+			}
+		})
+	}
+}
+
 func TestDispatchableSkipsDuplicatePullRequestWork(t *testing.T) {
 	t.Parallel()
 

--- a/internal/orchestrator/work_attempts.go
+++ b/internal/orchestrator/work_attempts.go
@@ -954,6 +954,8 @@ func schedulerDecisionWaitReason(reason string) string {
 		return "project_capacity_full"
 	case dispatchSkipLocalSlotUnavailable:
 		return "lane_capacity_full"
+	case dispatchSkipWorkerHostUnavailable:
+		return "worker_host_capacity_full"
 	case dispatchIssueFailureGlobalSlotUnavailable:
 		return scheduler.DispatchGateReasonGlobalCapacityFull
 	default:

--- a/internal/orchestrator/work_attempts_wait_reason_test.go
+++ b/internal/orchestrator/work_attempts_wait_reason_test.go
@@ -30,6 +30,11 @@ func TestSchedulerDecisionWaitReason(t *testing.T) {
 			want:   "lane_capacity_full",
 		},
 		{
+			name:   "worker host capacity wait",
+			reason: dispatchSkipWorkerHostUnavailable,
+			want:   "worker_host_capacity_full",
+		},
+		{
 			name:   "other reason",
 			reason: "provider_backoff",
 			want:   "provider_backoff",

--- a/internal/store/capacity_constraints.go
+++ b/internal/store/capacity_constraints.go
@@ -1,0 +1,156 @@
+package store
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+)
+
+type CapacityConstraintReason string
+
+const (
+	CapacityConstraintPool       CapacityConstraintReason = "pool_waits"
+	CapacityConstraintProject    CapacityConstraintReason = "project_capacity_full"
+	CapacityConstraintLane       CapacityConstraintReason = "lane_capacity_full"
+	CapacityConstraintWorkerHost CapacityConstraintReason = "worker_host_capacity_full"
+	CapacityConstraintRateWindow CapacityConstraintReason = "provider_rate_window_backpressure"
+)
+
+type CapacityConstraintQuery struct {
+	Since          time.Time
+	ProjectClasses map[string]string
+}
+
+type CapacityConstraintWait struct {
+	ProjectID     string
+	WorkloadClass string
+	Pool          string
+	Lane          string
+	Reason        CapacityConstraintReason
+	WaitCount     int
+}
+
+func QueryCapacityConstraintWaits(
+	ctx context.Context,
+	db poolContentionQueryer,
+	query CapacityConstraintQuery,
+) ([]CapacityConstraintWait, error) {
+	if db == nil {
+		return nil, errors.New("capacity constraint database is required")
+	}
+	if query.Since.IsZero() {
+		return nil, errors.New("capacity constraint start time is required")
+	}
+
+	since := query.Since.UTC().Truncate(time.Second).Format(time.RFC3339)
+	rows, err := db.QueryContext(ctx, `
+SELECT project_id, COALESCE(lane, ''), wait_reason, capacity_snapshot_json
+FROM scheduler_decisions
+WHERE result = ?
+  AND wait_reason IN (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+  AND decision_at >= ?`,
+		string(SchedulerDecisionResultSkipped),
+		poolCapacityWaitReason,
+		poolHigherPriorityProjectWaitReason,
+		poolHigherPriorityStateWaitReason,
+		poolSelectedProjectWaitReason,
+		string(CapacityConstraintProject),
+		string(CapacityConstraintLane),
+		string(CapacityConstraintWorkerHost),
+		"worker_host_unavailable",
+		string(CapacityConstraintRateWindow),
+		"local_slot_unavailable",
+		since,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("querying capacity constraint waits: %w", err)
+	}
+	defer rows.Close()
+
+	counts := map[string]CapacityConstraintWait{}
+	for rows.Next() {
+		var projectID string
+		var lane string
+		var waitReason string
+		var snapshotJSON string
+		if err := rows.Scan(&projectID, &lane, &waitReason, &snapshotJSON); err != nil {
+			return nil, fmt.Errorf("scanning capacity constraint wait: %w", err)
+		}
+		projectID = strings.TrimSpace(projectID)
+		class := strings.TrimSpace(query.ProjectClasses[projectID])
+		if class == "" {
+			continue
+		}
+
+		var snapshot poolCapacitySnapshot
+		if err := json.Unmarshal([]byte(snapshotJSON), &snapshot); err != nil {
+			return nil, fmt.Errorf("decode capacity snapshot for project %s: %w", projectID, err)
+		}
+		reason, ok := capacityConstraintReason(waitReason, snapshot.GlobalAvailable)
+		if !ok {
+			continue
+		}
+		pool := strings.TrimSpace(snapshot.Pool)
+		if pool == "" {
+			pool = "default"
+		}
+		lane = strings.TrimSpace(lane)
+		key := strings.Join([]string{projectID, class, pool, lane, string(reason)}, "\x00")
+		wait := counts[key]
+		wait.ProjectID = projectID
+		wait.WorkloadClass = class
+		wait.Pool = pool
+		wait.Lane = lane
+		wait.Reason = reason
+		wait.WaitCount++
+		counts[key] = wait
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate capacity constraint waits: %w", err)
+	}
+
+	waits := make([]CapacityConstraintWait, 0, len(counts))
+	for _, wait := range counts {
+		waits = append(waits, wait)
+	}
+	sort.Slice(waits, func(i, j int) bool {
+		if waits[i].ProjectID != waits[j].ProjectID {
+			return waits[i].ProjectID < waits[j].ProjectID
+		}
+		if waits[i].Reason != waits[j].Reason {
+			return waits[i].Reason < waits[j].Reason
+		}
+		if waits[i].Lane != waits[j].Lane {
+			return waits[i].Lane < waits[j].Lane
+		}
+		return waits[i].Pool < waits[j].Pool
+	})
+	return waits, nil
+}
+
+func capacityConstraintReason(waitReason string, globalAvailable *int) (CapacityConstraintReason, bool) {
+	switch strings.TrimSpace(waitReason) {
+	case poolCapacityWaitReason,
+		poolHigherPriorityProjectWaitReason,
+		poolHigherPriorityStateWaitReason,
+		poolSelectedProjectWaitReason:
+		if globalAvailable == nil || *globalAvailable != 0 {
+			return "", false
+		}
+		return CapacityConstraintPool, true
+	case string(CapacityConstraintProject):
+		return CapacityConstraintProject, true
+	case string(CapacityConstraintLane), "local_slot_unavailable":
+		return CapacityConstraintLane, true
+	case string(CapacityConstraintWorkerHost), "worker_host_unavailable":
+		return CapacityConstraintWorkerHost, true
+	case string(CapacityConstraintRateWindow):
+		return CapacityConstraintRateWindow, true
+	default:
+		return "", false
+	}
+}

--- a/internal/store/capacity_constraints.go
+++ b/internal/store/capacity_constraints.go
@@ -13,11 +13,12 @@ import (
 type CapacityConstraintReason string
 
 const (
-	CapacityConstraintPool       CapacityConstraintReason = "pool_waits"
-	CapacityConstraintProject    CapacityConstraintReason = "project_capacity_full"
-	CapacityConstraintLane       CapacityConstraintReason = "lane_capacity_full"
-	CapacityConstraintWorkerHost CapacityConstraintReason = "worker_host_capacity_full"
-	CapacityConstraintRateWindow CapacityConstraintReason = "provider_rate_window_backpressure"
+	CapacityConstraintSampleInterval                          = 5 * time.Minute
+	CapacityConstraintPool           CapacityConstraintReason = "pool_waits"
+	CapacityConstraintProject        CapacityConstraintReason = "project_capacity_full"
+	CapacityConstraintLane           CapacityConstraintReason = "lane_capacity_full"
+	CapacityConstraintWorkerHost     CapacityConstraintReason = "worker_host_capacity_full"
+	CapacityConstraintRateWindow     CapacityConstraintReason = "provider_rate_window_backpressure"
 )
 
 type CapacityConstraintQuery struct {
@@ -48,7 +49,7 @@ func QueryCapacityConstraintWaits(
 
 	since := query.Since.UTC().Truncate(time.Second).Format(time.RFC3339)
 	rows, err := db.QueryContext(ctx, `
-SELECT project_id, COALESCE(lane, ''), wait_reason, capacity_snapshot_json
+SELECT project_id, COALESCE(lane, ''), wait_reason, decision_at, capacity_snapshot_json
 FROM scheduler_decisions
 WHERE result = ?
   AND wait_reason IN (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
@@ -72,12 +73,14 @@ WHERE result = ?
 	defer rows.Close()
 
 	counts := map[string]CapacityConstraintWait{}
+	samples := map[string]struct{}{}
 	for rows.Next() {
 		var projectID string
 		var lane string
 		var waitReason string
+		var decisionAt string
 		var snapshotJSON string
-		if err := rows.Scan(&projectID, &lane, &waitReason, &snapshotJSON); err != nil {
+		if err := rows.Scan(&projectID, &lane, &waitReason, &decisionAt, &snapshotJSON); err != nil {
 			return nil, fmt.Errorf("scanning capacity constraint wait: %w", err)
 		}
 		projectID = strings.TrimSpace(projectID)
@@ -98,8 +101,17 @@ WHERE result = ?
 		if pool == "" {
 			pool = "default"
 		}
+		sampledAt, err := time.Parse(time.RFC3339, strings.TrimSpace(decisionAt))
+		if err != nil {
+			return nil, fmt.Errorf("parse capacity constraint decision time for project %s: %w", projectID, err)
+		}
 		lane = strings.TrimSpace(lane)
 		key := strings.Join([]string{projectID, class, pool, lane, string(reason)}, "\x00")
+		sampleKey := key + "\x00" + sampledAt.UTC().Truncate(CapacityConstraintSampleInterval).Format(time.RFC3339)
+		if _, ok := samples[sampleKey]; ok {
+			continue
+		}
+		samples[sampleKey] = struct{}{}
 		wait := counts[key]
 		wait.ProjectID = projectID
 		wait.WorkloadClass = class

--- a/internal/store/capacity_constraints_test.go
+++ b/internal/store/capacity_constraints_test.go
@@ -1,0 +1,88 @@
+package store
+
+import "testing"
+
+func TestCapacityConstraintReason(t *testing.T) {
+	t.Parallel()
+
+	zero := 0
+	one := 1
+	tests := []struct {
+		name            string
+		waitReason      string
+		globalAvailable *int
+		want            CapacityConstraintReason
+		wantOK          bool
+	}{
+		{
+			name:            "exhausted pool",
+			waitReason:      poolHigherPriorityProjectWaitReason,
+			globalAvailable: &zero,
+			want:            CapacityConstraintPool,
+			wantOK:          true,
+		},
+		{
+			name:            "pool arbitration with capacity",
+			waitReason:      poolSelectedProjectWaitReason,
+			globalAvailable: &one,
+		},
+		{
+			name:       "project",
+			waitReason: "project_capacity_full",
+			want:       CapacityConstraintProject,
+			wantOK:     true,
+		},
+		{
+			name:       "lane",
+			waitReason: "lane_capacity_full",
+			want:       CapacityConstraintLane,
+			wantOK:     true,
+		},
+		{
+			name:       "legacy lane",
+			waitReason: "local_slot_unavailable",
+			want:       CapacityConstraintLane,
+			wantOK:     true,
+		},
+		{
+			name:       "worker host",
+			waitReason: "worker_host_capacity_full",
+			want:       CapacityConstraintWorkerHost,
+			wantOK:     true,
+		},
+		{
+			name:       "legacy worker host",
+			waitReason: "worker_host_unavailable",
+			want:       CapacityConstraintWorkerHost,
+			wantOK:     true,
+		},
+		{
+			name:       "rate window",
+			waitReason: "provider_rate_window_backpressure",
+			want:       CapacityConstraintRateWindow,
+			wantOK:     true,
+		},
+		{
+			name:       "unrelated scheduler reason",
+			waitReason: "blocked_by_dependency",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, ok := capacityConstraintReason(tt.waitReason, tt.globalAvailable)
+			if got != tt.want || ok != tt.wantOK {
+				t.Fatalf(
+					"capacityConstraintReason(%q) = %q, %v, want %q, %v",
+					tt.waitReason,
+					got,
+					ok,
+					tt.want,
+					tt.wantOK,
+				)
+			}
+		})
+	}
+}

--- a/internal/store/capacity_constraints_test.go
+++ b/internal/store/capacity_constraints_test.go
@@ -1,6 +1,11 @@
 package store
 
-import "testing"
+import (
+	"context"
+	"path/filepath"
+	"testing"
+	"time"
+)
 
 func TestCapacityConstraintReason(t *testing.T) {
 	t.Parallel()
@@ -84,5 +89,92 @@ func TestCapacityConstraintReason(t *testing.T) {
 				)
 			}
 		})
+	}
+}
+
+func TestQueryCapacityConstraintWaitsNormalizesFiveMinuteSamples(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	backend, err := Open(ctx, Config{
+		Backend: BackendSQLite,
+		Path:    filepath.Join(t.TempDir(), "detent.db"),
+	})
+	if err != nil {
+		t.Fatalf("Open() error = %v", err)
+	}
+	t.Cleanup(func() {
+		if err := backend.Close(); err != nil {
+			t.Fatalf("Close() error = %v", err)
+		}
+	})
+	now := time.Date(2026, 7, 28, 12, 0, 0, 0, time.UTC)
+	rows := []struct {
+		reason     string
+		lane       string
+		decisionAt time.Time
+		snapshot   string
+	}{
+		{
+			reason:     poolCapacityWaitReason,
+			decisionAt: now,
+			snapshot:   `{"pool":"default","global_available":0}`,
+		},
+		{
+			reason:     poolHigherPriorityProjectWaitReason,
+			decisionAt: now.Add(4 * time.Minute),
+			snapshot:   `{"pool":"default","global_available":0}`,
+		},
+		{
+			reason:     poolCapacityWaitReason,
+			decisionAt: now.Add(5 * time.Minute),
+			snapshot:   `{"pool":"default","global_available":0}`,
+		},
+		{
+			reason:     string(CapacityConstraintLane),
+			lane:       "In Progress",
+			decisionAt: now.Add(time.Minute),
+			snapshot:   `{"pool":"default"}`,
+		},
+		{
+			reason:     string(CapacityConstraintLane),
+			lane:       "In Progress",
+			decisionAt: now.Add(3 * time.Minute),
+			snapshot:   `{"pool":"default"}`,
+		},
+		{
+			reason:     string(CapacityConstraintLane),
+			lane:       "In Progress",
+			decisionAt: now.Add(6 * time.Minute),
+			snapshot:   `{"pool":"default"}`,
+		},
+	}
+	for _, row := range rows {
+		if _, err := backend.RecordSchedulerDecision(ctx, SchedulerDecision{
+			ProjectID:            "video",
+			Lane:                 row.lane,
+			Result:               SchedulerDecisionResultSkipped,
+			Reason:               row.reason,
+			DecisionAt:           row.decisionAt,
+			WaitReason:           row.reason,
+			CapacitySnapshotJSON: row.snapshot,
+		}); err != nil {
+			t.Fatalf("RecordSchedulerDecision() error = %v", err)
+		}
+	}
+
+	waits, err := QueryCapacityConstraintWaits(ctx, backend.(*sqliteStore).db, CapacityConstraintQuery{
+		Since:          now.Add(-time.Hour),
+		ProjectClasses: map[string]string{"video": "cloud-only"},
+	})
+	if err != nil {
+		t.Fatalf("QueryCapacityConstraintWaits() error = %v", err)
+	}
+	counts := map[CapacityConstraintReason]int{}
+	for _, wait := range waits {
+		counts[wait.Reason] += wait.WaitCount
+	}
+	if counts[CapacityConstraintPool] != 2 || counts[CapacityConstraintLane] != 2 {
+		t.Fatalf("normalized counts = %#v, want two five-minute samples for pool and lane", counts)
 	}
 }

--- a/internal/store/pool_contention.go
+++ b/internal/store/pool_contention.go
@@ -35,8 +35,9 @@ type poolContentionQueryer interface {
 }
 
 type poolCapacitySnapshot struct {
-	Pool    string   `json:"pool"`
-	Holders []string `json:"holders"`
+	Pool            string   `json:"pool"`
+	Holders         []string `json:"holders"`
+	GlobalAvailable *int     `json:"global_available"`
 }
 
 func QueryCrossClassPoolContention(

--- a/internal/store/pool_contention_e2e_test.go
+++ b/internal/store/pool_contention_e2e_test.go
@@ -164,6 +164,24 @@ func TestPoolContentionTelemetryEndToEnd(t *testing.T) {
 		contention[0].HoldingClass != "local-heavy" {
 		t.Fatalf("contention = %#v, want one production-recorded cross-class wait", contention)
 	}
+
+	constraints, err := store.QueryCapacityConstraintWaits(ctx, db, store.CapacityConstraintQuery{
+		Since: time.Now().Add(-time.Hour),
+		ProjectClasses: map[string]string{
+			localProject.ID: "local-heavy",
+			cloudProject.ID: "cloud-only",
+		},
+	})
+	if err != nil {
+		t.Fatalf("QueryCapacityConstraintWaits() error = %v", err)
+	}
+	if len(constraints) != 1 ||
+		constraints[0].ProjectID != cloudProject.ID ||
+		constraints[0].WorkloadClass != "cloud-only" ||
+		constraints[0].Reason != store.CapacityConstraintPool ||
+		constraints[0].WaitCount != 1 {
+		t.Fatalf("constraints = %#v, want one production-recorded cloud-only pool wait", constraints)
+	}
 }
 
 func waitForSchedulerDecision(


### PR DESCRIPTION
## Summary

- report seven-day capacity blocking distributions per project and workload class
- identify pool, project, lane, worker-host, or provider rate-window binding constraints and recommend the matching lever
- add static pool/project/lane coherence diagnostics while preserving the mixed-class pool split and `detent fix agent-pools` path
- distinguish worker-host and retry project-cap waits in scheduler telemetry

Fixes #1521

## Test Plan

- `go test -race ./internal/cli ./internal/store ./internal/workload ./internal/orchestrator -count=1`
- `make check`
- end-to-end capacity query assertion against an orchestrator-written pool-refusal row