### PR TITLE
test(ci): control timing-sensitive tests

### DIFF
--- a/.detent/skills/deterministic-timeout-testing.md
+++ b/.detent/skills/deterministic-timeout-testing.md
@@ -1,0 +1,15 @@
+---
+name: deterministic-timeout-testing
+description: Test timeout renewal, expiration, and duration limits with explicit control instead of wall-clock margins.
+when_to_use: Use when a test sleeps for a timeout, expects a timer to fire within a margin, or asserts elapsed time under hosted-runner load.
+---
+
+# Test timeout behavior with controllable time
+
+- Confirm the failure is an elapsed-time assumption by reading the hosted-runner log and identifying the sleep, timer, deadline, or elapsed assertion.
+- Inject a private timer or context factory while preserving the real production default.
+- Give the test double explicit reset acknowledgements and an expiration operation. Synchronize the work under test with channels so expiration happens only after the intended stage is reached.
+- Test progress propagation separately when the timer loop consumes the same progress channel; do not make the assertion compete with production for one signal.
+- Preserve deadline metadata when callers inspect `Context.Deadline`, but trigger cancellation explicitly with the configured cause.
+- Keep real time only as a generous deadlock guard around explicit synchronization or OS integration, and document that it is not a behavioral margin.
+- Run focused cases repeatedly under `-race`, then run the affected packages with `-race -count=10` and the repository validation gate.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -228,6 +228,9 @@ jobs:
         if: runner.os == 'Windows'
         run: go test ./internal/orchestrator -run '^TestLocalSQLiteArtifactLifecycleEndToEnd$' -count=20
 
+      - name: Stress timing-sensitive packages
+        run: go test -race ./internal/cli ./internal/runner ./tools/checklock -count=10
+
       - name: Race test
         run: go test -race ./...
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -229,7 +229,7 @@ jobs:
         run: go test ./internal/orchestrator -run '^TestLocalSQLiteArtifactLifecycleEndToEnd$' -count=20
 
       - name: Stress timing-sensitive packages
-        run: go test -race ./internal/cli ./internal/runner ./tools/checklock -count=10
+        run: go test -race ./internal/cli ./internal/runner ./tools/checklock -count=10 -timeout=30m
 
       - name: Race test
         run: go test -race ./...

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -136,6 +136,23 @@ New or changed observable behavior needs tests.
 - Keep tests close to the package they cover.
 - Use ephemeral ports in tests that start servers.
 - Do not rely on process state from a running Detent orchestrator.
+- Assert timeout, renewal, debounce, and duration-limit behavior with injected
+  clocks, timers, or context factories instead of elapsed wall-clock margins.
+- Use real time only as a generous deadlock guard around explicit
+  synchronization or an OS integration boundary, and document why the bound is
+  necessary.
+
+The timing-sensitive test inventory is triaged by purpose:
+
+- `internal/cli/doctor_test.go` and `internal/runner/duration_limit_test.go`
+  drive behavioral deadlines through controlled timers and context factories.
+- `internal/cli/boot_test.go`, `internal/cli/dev_runtime_e2e_test.go`,
+  `internal/cli/fix_agent_pools_test.go`, `internal/cli/runner_test.go`,
+  `internal/cli/shutdown_test.go`, `internal/runner/supervisor_test.go`, and
+  `tools/checklock/main_test.go` retain real-time bounds only for liveness
+  around goroutines, HTTP servers, subprocesses, file locks, or production
+  ticker integration; their success conditions use channels, observable
+  state, or process completion rather than elapsed-time margins.
 
 ## Commits
 

--- a/internal/cli/doctor_test.go
+++ b/internal/cli/doctor_test.go
@@ -32,6 +32,10 @@ import (
 	"github.com/digitaldrywood/detent/internal/workpad"
 )
 
+// This deadline only detects broken test synchronization and is deliberately
+// generous enough for loaded hosted runners; timeout behavior uses controlled timers.
+const doctorTestSafetyTimeout = 30 * time.Second
+
 func TestCheckDoctorUpdate(t *testing.T) {
 	t.Parallel()
 
@@ -4715,7 +4719,7 @@ func TestDoctorCommandStreamsProgressBeforeSlowCheckCompletes(t *testing.T) {
 
 	select {
 	case <-codexStarted:
-	case <-time.After(time.Second):
+	case <-time.After(doctorTestSafetyTimeout):
 		t.Fatal("codex check did not start")
 	}
 	if got := stdout.String(); !strings.Contains(got, "RUN    codex binary") {
@@ -4728,7 +4732,7 @@ func TestDoctorCommandStreamsProgressBeforeSlowCheckCompletes(t *testing.T) {
 		if err != nil {
 			t.Fatalf("Execute() error = %v, want nil", err)
 		}
-	case <-time.After(time.Second):
+	case <-time.After(doctorTestSafetyTimeout):
 		t.Fatal("timed out waiting for doctor command")
 	}
 }
@@ -4908,12 +4912,18 @@ func TestDoctorReportKeepsStableOrderAfterParallelChecks(t *testing.T) {
 func TestRunDoctorCheckTimesOutUnresponsiveJob(t *testing.T) {
 	t.Parallel()
 
-	checks := runDoctorCheck(context.Background(), doctorCheckJob{
-		Name: "slow check",
-		Run: func(context.Context) []doctorCheck {
-			select {}
-		},
-	}, 20*time.Millisecond)
+	timer := &controlledDoctorCheckTimer{deadline: make(chan time.Time)}
+	checksDone := make(chan []doctorCheck, 1)
+	go func() {
+		checksDone <- runDoctorCheckWithTimer(context.Background(), doctorCheckJob{
+			Name: "slow check",
+			Run: func(context.Context) []doctorCheck {
+				select {}
+			},
+		}, 20*time.Millisecond, timer)
+	}()
+	timer.Expire()
+	checks := <-checksDone
 
 	if len(checks) != 1 {
 		t.Fatalf("checks len = %d, want 1", len(checks))
@@ -4932,13 +4942,19 @@ func TestRunDoctorCheckTimesOutUnresponsiveJob(t *testing.T) {
 func TestRunDoctorCheckTimeoutReportsCurrentInnerCheck(t *testing.T) {
 	t.Parallel()
 
-	checks := runDoctorCheck(context.Background(), doctorCheckJob{
-		Name:    "Project alpha checks",
-		Current: func() string { return "Project alpha GitHub readiness" },
-		Run: func(context.Context) []doctorCheck {
-			select {}
-		},
-	}, 20*time.Millisecond)
+	timer := &controlledDoctorCheckTimer{deadline: make(chan time.Time)}
+	checksDone := make(chan []doctorCheck, 1)
+	go func() {
+		checksDone <- runDoctorCheckWithTimer(context.Background(), doctorCheckJob{
+			Name:    "Project alpha checks",
+			Current: func() string { return "Project alpha GitHub readiness" },
+			Run: func(context.Context) []doctorCheck {
+				select {}
+			},
+		}, 20*time.Millisecond, timer)
+	}()
+	timer.Expire()
+	checks := <-checksDone
 
 	if len(checks) != 1 {
 		t.Fatalf("checks len = %d, want 1", len(checks))
@@ -4961,7 +4977,7 @@ func TestRunDoctorCheckRenewsTimeoutForReportedProgress(t *testing.T) {
 	}
 	advance := make(chan struct{})
 	checksDone := make(chan []doctorCheck, 1)
-	stuck := time.NewTimer(10 * time.Second)
+	stuck := time.NewTimer(doctorTestSafetyTimeout)
 	defer stuck.Stop()
 	go func() {
 		checksDone <- runDoctorCheckWithTimer(context.Background(), doctorCheckJob{
@@ -5015,12 +5031,18 @@ func (t *controlledDoctorCheckTimer) C() <-chan time.Time {
 }
 
 func (t *controlledDoctorCheckTimer) Reset(timeout time.Duration) bool {
-	t.resets <- timeout
+	if t.resets != nil {
+		t.resets <- timeout
+	}
 	return true
 }
 
 func (t *controlledDoctorCheckTimer) Stop() bool {
 	return true
+}
+
+func (t *controlledDoctorCheckTimer) Expire() {
+	t.deadline <- time.Time{}
 }
 
 func TestRunDoctorCheckFreezesProgressBeforeCancellation(t *testing.T) {
@@ -5055,17 +5077,23 @@ func TestRunDoctorCheckFreezesProgressBeforeCancellation(t *testing.T) {
 			workerStarted := make(chan struct{})
 			parentCtx, cancelParent := context.WithCancel(context.Background())
 			defer cancelParent()
+			timer := &controlledDoctorCheckTimer{deadline: make(chan time.Time)}
 			if tt.cancelParent {
 				go func() {
 					<-workerStarted
 					cancelParent()
+				}()
+			} else {
+				go func() {
+					<-workerStarted
+					timer.Expire()
 				}()
 			}
 
 			var freezeSawCanceledWorker bool
 			completed := doctorCheck{Name: "Project alpha workflow", Status: doctorOK, Detail: "loaded"}
 			canceled := doctorCheck{Name: "Project alpha route models", Status: doctorFail, Detail: "context canceled"}
-			checks := runDoctorCheck(parentCtx, doctorCheckJob{
+			checks := runDoctorCheckWithTimer(parentCtx, doctorCheckJob{
 				Name: "Project alpha checks",
 				Freeze: func() doctorCheckSnapshot {
 					ctx := <-workerContext
@@ -5086,14 +5114,14 @@ func TestRunDoctorCheckFreezesProgressBeforeCancellation(t *testing.T) {
 					close(postCancelPublication)
 					return []doctorCheck{completed, canceled}
 				},
-			}, tt.timeout)
+			}, tt.timeout, timer)
 
 			if freezeSawCanceledWorker {
 				t.Fatal("worker context was canceled before progress was frozen")
 			}
 			select {
 			case <-postCancelPublication:
-			case <-time.After(time.Second):
+			case <-time.After(doctorTestSafetyTimeout):
 				t.Fatal("job did not attempt to publish after cancellation")
 			}
 			postPublicationSnapshot := progress.Freeze()
@@ -5125,22 +5153,35 @@ func TestRunDoctorCheckFreezesProgressBeforeCancellation(t *testing.T) {
 func TestDoctorProjectCheckJobRenewsTimeoutForConnectorProgress(t *testing.T) {
 	t.Parallel()
 
-	const (
-		timeout      = 100 * time.Millisecond
-		responseTime = 60 * time.Millisecond
-		responses    = 3
-	)
+	const responses = 3
+	connectorStarted := make(chan struct{})
+	requestProgress := make(chan struct{})
+	progressReported := make(chan struct{})
+	advance := make(chan struct{})
+	var reportProgress sync.Once
 	projectConnector := &fakeDoctorAutoPromoteConnector{
 		fetchIssuesByStatesLimit: func(ctx context.Context, _ []string, _ int) ([]connector.Issue, error) {
-			for range responses {
-				select {
-				case <-ctx.Done():
-					return nil, ctx.Err()
-				case <-time.After(responseTime):
+			var progressErr error
+			reportProgress.Do(func() {
+				close(connectorStarted)
+				for range responses {
+					select {
+					case <-ctx.Done():
+						progressErr = ctx.Err()
+						return
+					case <-requestProgress:
+					}
 					connector.ReportProgress(ctx)
+					progressReported <- struct{}{}
+					select {
+					case <-ctx.Done():
+						progressErr = ctx.Err()
+						return
+					case <-advance:
+					}
 				}
-			}
-			return nil, nil
+			})
+			return nil, progressErr
 		},
 	}
 	jobs := doctorProjectCheckJobs(globalconfig.Config{
@@ -5169,7 +5210,47 @@ func TestDoctorProjectCheckJobRenewsTimeoutForConnectorProgress(t *testing.T) {
 		t.Fatalf("jobs len = %d, want 1", len(jobs))
 	}
 
-	checks := runDoctorCheck(context.Background(), jobs[0], timeout)
+	checksDone := make(chan []doctorCheck, 1)
+	go func() {
+		checksDone <- jobs[0].Run(context.Background())
+	}()
+	stuck := time.NewTimer(doctorTestSafetyTimeout)
+	defer stuck.Stop()
+	select {
+	case <-connectorStarted:
+	case <-stuck.C:
+		t.Fatal("timed out waiting for connector check")
+	}
+	for {
+		select {
+		case <-jobs[0].Progress:
+		default:
+			goto progressDrained
+		}
+	}
+
+progressDrained:
+	for range responses {
+		requestProgress <- struct{}{}
+		select {
+		case <-progressReported:
+		case <-stuck.C:
+			t.Fatal("timed out waiting for connector progress report")
+		}
+		select {
+		case <-jobs[0].Progress:
+		case <-stuck.C:
+			t.Fatal("timed out waiting for connector progress signal")
+		}
+		advance <- struct{}{}
+	}
+
+	var checks []doctorCheck
+	select {
+	case checks = <-checksDone:
+	case <-stuck.C:
+		t.Fatal("timed out waiting for completed project checks")
+	}
 
 	for _, name := range []string{"Project alpha dependency auto-unblock", "Project alpha blocked recovery"} {
 		var found bool
@@ -5210,6 +5291,13 @@ func TestDoctorProjectCheckJobTimeoutPreservesCompletedChecks(t *testing.T) {
 
 			workflow := validDoctorDependencyWorkflow(false)
 			releaseBlockedCheck := make(chan struct{})
+			blockedCheckStarted := make(chan struct{})
+			var blockedCheckOnce sync.Once
+			markBlockedCheckStarted := func() {
+				blockedCheckOnce.Do(func() {
+					close(blockedCheckStarted)
+				})
+			}
 			t.Cleanup(func() {
 				close(releaseBlockedCheck)
 			})
@@ -5225,6 +5313,7 @@ func TestDoctorProjectCheckJobTimeoutPreservesCompletedChecks(t *testing.T) {
 				},
 				gitTracked: func(context.Context, string) (bool, error) {
 					if tt.blockOverlay {
+						markBlockedCheckStarted()
 						<-releaseBlockedCheck
 					}
 					return false, nil
@@ -5239,6 +5328,7 @@ func TestDoctorProjectCheckJobTimeoutPreservesCompletedChecks(t *testing.T) {
 					projectConnector := &fakeDoctorAutoPromoteConnector{}
 					if tt.blockDependency {
 						projectConnector.fetchIssuesByStatesLimit = func(context.Context, []string, int) ([]connector.Issue, error) {
+							markBlockedCheckStarted()
 							<-releaseBlockedCheck
 							return nil, nil
 						}
@@ -5247,6 +5337,9 @@ func TestDoctorProjectCheckJobTimeoutPreservesCompletedChecks(t *testing.T) {
 				},
 				githubReadiness: func(context.Context, ghconnector.Config, ghconnector.ReadinessConfig) ([]ghconnector.ReadinessCheck, error) {
 					if !tt.blockOverlay {
+						if !tt.blockDependency {
+							markBlockedCheckStarted()
+						}
 						<-releaseBlockedCheck
 					}
 					return nil, nil
@@ -5259,7 +5352,26 @@ func TestDoctorProjectCheckJobTimeoutPreservesCompletedChecks(t *testing.T) {
 				t.Fatalf("jobs len = %d, want 1", len(jobs))
 			}
 
-			checks := runDoctorCheck(context.Background(), jobs[0], 20*time.Millisecond)
+			timer := &controlledDoctorCheckTimer{deadline: make(chan time.Time)}
+			checksDone := make(chan []doctorCheck, 1)
+			go func() {
+				checksDone <- runDoctorCheckWithTimer(context.Background(), jobs[0], 20*time.Millisecond, timer)
+			}()
+			stuck := time.NewTimer(doctorTestSafetyTimeout)
+			defer stuck.Stop()
+			select {
+			case <-blockedCheckStarted:
+			case <-stuck.C:
+				t.Fatalf("timed out waiting for blocked %s check", tt.current)
+			}
+			timer.Expire()
+
+			var checks []doctorCheck
+			select {
+			case checks = <-checksDone:
+			case <-stuck.C:
+				t.Fatal("timed out waiting for controlled doctor timeout")
+			}
 
 			if len(checks) < 2 {
 				t.Fatalf("checks = %#v, want completed checks followed by timeout", checks)

--- a/internal/runner/agent.go
+++ b/internal/runner/agent.go
@@ -108,6 +108,7 @@ type Dependencies struct {
 	Logger              *slog.Logger
 	AfterRunTimeout     time.Duration
 	sessionLimit        durationLimitContextFactory
+	turnLimit           durationLimitContextFactory
 }
 
 type Runner struct {
@@ -128,6 +129,7 @@ type Runner struct {
 	logger              *slog.Logger
 	afterRunTimeout     time.Duration
 	sessionLimit        durationLimitContextFactory
+	turnLimit           durationLimitContextFactory
 }
 
 func NewRunner(deps Dependencies) (*Runner, error) {
@@ -145,6 +147,9 @@ func NewRunner(deps Dependencies) (*Runner, error) {
 	}
 	if deps.sessionLimit == nil {
 		deps.sessionLimit = withAgentDurationLimit
+	}
+	if deps.turnLimit == nil {
+		deps.turnLimit = withAgentDurationLimit
 	}
 	projectID := strings.TrimSpace(deps.ProjectID)
 	if projectID == "" {
@@ -189,6 +194,7 @@ func NewRunner(deps Dependencies) (*Runner, error) {
 		logger:              deps.Logger,
 		afterRunTimeout:     deps.AfterRunTimeout,
 		sessionLimit:        deps.sessionLimit,
+		turnLimit:           deps.turnLimit,
 	}, nil
 }
 
@@ -634,8 +640,31 @@ func runAgentBackendTurnWithTools(
 	toolHandler AgentToolHandler,
 	onUpdate agentContextUpdateHandler,
 ) (AgentTurnResult, error, error) {
+	return runAgentBackendTurnWithToolsUsingLimit(
+		ctx,
+		backend,
+		request,
+		tools,
+		toolHandler,
+		onUpdate,
+		withAgentDurationLimit,
+	)
+}
+
+func runAgentBackendTurnWithToolsUsingLimit(
+	ctx context.Context,
+	backend AgentBackend,
+	request AgentTurnRequest,
+	tools []AgentTool,
+	toolHandler AgentToolHandler,
+	onUpdate agentContextUpdateHandler,
+	turnLimit durationLimitContextFactory,
+) (AgentTurnResult, error, error) {
+	if turnLimit == nil {
+		turnLimit = withAgentDurationLimit
+	}
 	run := func(ctx context.Context, request AgentTurnRequest) (AgentTurnResult, error) {
-		turnCtx, cancel := withAgentDurationLimit(
+		turnCtx, cancel := turnLimit(
 			ctx,
 			request.MaxDuration,
 			ErrTurnDurationExceeded,
@@ -739,7 +768,7 @@ func (r *Runner) runAgentTurn(
 		}
 	}
 	turnStarted := false
-	turnResult, turnErr, scratchCleanupErr := runAgentBackendTurnWithTools(ctx, backend, turnRequest, runRequest.AgentTools, runRequest.AgentToolHandler, func(updateCtx context.Context, update AgentUpdate) error {
+	turnResult, turnErr, scratchCleanupErr := runAgentBackendTurnWithToolsUsingLimit(ctx, backend, turnRequest, runRequest.AgentTools, runRequest.AgentToolHandler, func(updateCtx context.Context, update AgentUpdate) error {
 		eventAt := r.now()
 		if !update.RuntimeIdentity.IsZero() {
 			update.RuntimeIdentity = update.RuntimeIdentity.ObserveAt(eventAt)
@@ -775,7 +804,7 @@ func (r *Runner) runAgentTurn(
 			return err
 		}
 		return nil
-	})
+	}, r.turnLimit)
 	if cause := context.Cause(ctx); cooperativeStopError(cause) || errors.Is(cause, ErrSessionDurationExceeded) {
 		turnErr = cause
 	}
@@ -1404,7 +1433,7 @@ func (r *Runner) Validate(ctx context.Context, req ValidatorRequest) (gate.Valid
 	}
 	var output strings.Builder
 	modelProvider, serviceTier, effort := agentTurnIdentityOptions(backendConfig)
-	turnResult, turnErr, scratchCleanupErr := runAgentBackendTurnWithTools(sessionCtx, backend, AgentTurnRequest{
+	turnResult, turnErr, scratchCleanupErr := runAgentBackendTurnWithToolsUsingLimit(sessionCtx, backend, AgentTurnRequest{
 		Workspace:          info.Path,
 		Prompt:             prompt,
 		Model:              selectedModel,
@@ -1452,7 +1481,7 @@ func (r *Runner) Validate(ctx context.Context, req ValidatorRequest) (gate.Valid
 			return err
 		}
 		return nil
-	})
+	}, r.turnLimit)
 	if cause := context.Cause(sessionCtx); errors.Is(cause, ErrSessionDurationExceeded) {
 		turnErr = cause
 	}

--- a/internal/runner/duration_limit_test.go
+++ b/internal/runner/duration_limit_test.go
@@ -44,7 +44,8 @@ func TestRunnerEnforcesConfiguredDurationLimits(t *testing.T) {
 			workspaceBackend := &fakeWorkspaceBackend{
 				info: workspace.Info{Path: t.TempDir(), Key: "issue-duration"},
 			}
-			agentBackend := &durationBlockingAgentBackend{}
+			durationLimit := &controlledDurationLimit{}
+			agentBackend := &durationBlockingAgentBackend{expireDuration: durationLimit.Expire}
 			sessionStore := &fakeSessionStore{sessionID: 1496}
 			runner, err := NewRunner(Dependencies{
 				Workflow: config.Workflow{
@@ -54,12 +55,13 @@ func TestRunnerEnforcesConfiguredDurationLimits(t *testing.T) {
 				Workspace:    workspaceBackend,
 				AgentBackend: agentBackend,
 				Store:        sessionStore,
+				sessionLimit: durationLimit.Context,
+				turnLimit:    durationLimit.Context,
 			})
 			if err != nil {
 				t.Fatalf("NewRunner() error = %v", err)
 			}
 
-			startedAt := time.Now()
 			_, err = runner.Run(context.Background(), RunRequest{
 				Issue: connector.Issue{
 					ID:         "issue-duration",
@@ -72,11 +74,14 @@ func TestRunnerEnforcesConfiguredDurationLimits(t *testing.T) {
 			if !errors.Is(err, context.DeadlineExceeded) {
 				t.Fatalf("Run() error = %v, want context deadline exceeded", err)
 			}
-			if elapsed := time.Since(startedAt); elapsed > time.Second {
-				t.Fatalf("Run() elapsed = %v, want configured duration limit", elapsed)
-			}
 			if !strings.Contains(err.Error(), "after 25ms") {
 				t.Fatalf("Run() error = %v, want configured duration", err)
+			}
+			if durationLimit.duration != 25*time.Millisecond {
+				t.Fatalf("duration limit = %v, want 25ms", durationLimit.duration)
+			}
+			if !errors.Is(durationLimit.limit, tt.want) {
+				t.Fatalf("duration limit error = %v, want %v", durationLimit.limit, tt.want)
 			}
 			if agentBackend.request.TurnTimeout != 0 {
 				t.Fatalf("AgentTurnRequest.TurnTimeout = %v, want backend liveness timeout unchanged", agentBackend.request.TurnTimeout)
@@ -195,11 +200,20 @@ func TestRunAgentBackendTurnPreservesParentCancellation(t *testing.T) {
 func TestRunAgentBackendTurnKeepsLivenessTimeoutSeparateFromMaxDuration(t *testing.T) {
 	t.Parallel()
 
-	backend := &durationBlockingAgentBackend{}
-	_, err, cleanupErr := runAgentBackendTurn(context.Background(), backend, AgentTurnRequest{
-		TurnTimeout: time.Hour,
-		MaxDuration: 25 * time.Millisecond,
-	}, nil)
+	durationLimit := &controlledDurationLimit{}
+	backend := &durationBlockingAgentBackend{expireDuration: durationLimit.Expire}
+	_, err, cleanupErr := runAgentBackendTurnWithToolsUsingLimit(
+		context.Background(),
+		backend,
+		AgentTurnRequest{
+			TurnTimeout: time.Hour,
+			MaxDuration: 25 * time.Millisecond,
+		},
+		nil,
+		nil,
+		nil,
+		durationLimit.Context,
+	)
 	if !errors.Is(err, ErrTurnDurationExceeded) {
 		t.Fatalf("runAgentBackendTurn() error = %v, want ErrTurnDurationExceeded", err)
 	}
@@ -211,6 +225,9 @@ func TestRunAgentBackendTurnKeepsLivenessTimeoutSeparateFromMaxDuration(t *testi
 	}
 	if backend.request.MaxDuration != 25*time.Millisecond {
 		t.Fatalf("backend MaxDuration = %v, want total duration preserved", backend.request.MaxDuration)
+	}
+	if durationLimit.duration != 25*time.Millisecond {
+		t.Fatalf("duration limit = %v, want 25ms", durationLimit.duration)
 	}
 }
 
@@ -254,8 +271,9 @@ func TestRunAgentBackendTurnLeavesDurationDisabledWithoutDeadline(t *testing.T) 
 func TestRunAgentBackendTurnPropagatesDurationContextToUpdates(t *testing.T) {
 	t.Parallel()
 
+	durationLimit := &controlledDurationLimit{}
 	hasDeadline := false
-	_, err, cleanupErr := runAgentBackendTurnWithTools(
+	_, err, cleanupErr := runAgentBackendTurnWithToolsUsingLimit(
 		context.Background(),
 		&durationUpdateAgentBackend{},
 		AgentTurnRequest{MaxDuration: 25 * time.Millisecond},
@@ -263,9 +281,11 @@ func TestRunAgentBackendTurnPropagatesDurationContextToUpdates(t *testing.T) {
 		nil,
 		func(ctx context.Context, _ AgentUpdate) error {
 			_, hasDeadline = ctx.Deadline()
+			durationLimit.Expire()
 			<-ctx.Done()
 			return ctx.Err()
 		},
+		durationLimit.Context,
 	)
 	if !errors.Is(err, ErrTurnDurationExceeded) {
 		t.Fatalf("runAgentBackendTurnWithTools() error = %v, want ErrTurnDurationExceeded", err)
@@ -284,8 +304,10 @@ func TestRunAgentBackendTurnPropagatesDurationContextToUpdates(t *testing.T) {
 func TestRunnerValidatorUpdatePersistenceUsesSessionDurationContext(t *testing.T) {
 	t.Parallel()
 
+	sessionDurationLimit := &controlledDurationLimit{}
 	sessionStore := &durationBlockingSessionStore{
 		fakeSessionStore: &fakeSessionStore{sessionID: 1496},
+		expireSession:    sessionDurationLimit.Expire,
 	}
 	runner, err := NewRunner(Dependencies{
 		Workflow: config.Workflow{
@@ -300,15 +322,13 @@ func TestRunnerValidatorUpdatePersistenceUsesSessionDurationContext(t *testing.T
 		},
 		AgentBackend: &durationUpdateAgentBackend{},
 		Store:        sessionStore,
+		sessionLimit: sessionDurationLimit.Context,
 	})
 	if err != nil {
 		t.Fatalf("NewRunner() error = %v", err)
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
-	defer cancel()
-	startedAt := time.Now()
-	_, err = runner.Validate(ctx, ValidatorRequest{
+	_, err = runner.Validate(context.Background(), ValidatorRequest{
 		Issue: connector.Issue{
 			ID:         "issue-validator-duration",
 			Identifier: "digitaldrywood/detent#1496",
@@ -320,17 +340,18 @@ func TestRunnerValidatorUpdatePersistenceUsesSessionDurationContext(t *testing.T
 	if !errors.Is(err, context.DeadlineExceeded) {
 		t.Fatalf("Validate() error = %v, want context deadline exceeded", err)
 	}
-	if elapsed := time.Since(startedAt); elapsed > time.Second {
-		t.Fatalf("Validate() elapsed = %v, want configured session duration", elapsed)
-	}
 	if !sessionStore.hasDeadline {
 		t.Fatal("UpdateSessionWorkerProcess() context has no session deadline")
+	}
+	if sessionDurationLimit.duration != 25*time.Millisecond {
+		t.Fatalf("session duration = %v, want 25ms", sessionDurationLimit.duration)
 	}
 }
 
 type durationBlockingAgentBackend struct {
-	request   AgentTurnRequest
-	deadlines []time.Time
+	request        AgentTurnRequest
+	deadlines      []time.Time
+	expireDuration func()
 }
 
 func (b *durationBlockingAgentBackend) RunTurn(ctx context.Context, request AgentTurnRequest, onUpdate AgentUpdateHandler) (AgentTurnResult, error) {
@@ -347,6 +368,9 @@ func (b *durationBlockingAgentBackend) RunTurn(ctx context.Context, request Agen
 			}
 		}
 		b.recordDeadline(ctx)
+	}
+	if b.expireDuration != nil {
+		b.expireDuration()
 	}
 	<-ctx.Done()
 	return AgentTurnResult{}, ctx.Err()
@@ -398,10 +422,16 @@ type controlledDurationLimit struct {
 }
 
 func (l *controlledDurationLimit) Context(ctx context.Context, duration time.Duration, limit error) (context.Context, context.CancelFunc) {
-	ctx, l.cancel = context.WithCancelCause(ctx)
+	if duration <= 0 {
+		return ctx, func() {}
+	}
+	cancelCtx, cancel := context.WithCancelCause(ctx)
+	l.cancel = cancel
 	l.duration = duration
 	l.limit = limit
-	return ctx, func() {
+	deadlineCtx, cancelDeadline := context.WithDeadline(cancelCtx, time.Date(2100, time.January, 1, 0, 0, 0, 0, time.UTC).Add(duration))
+	return deadlineCtx, func() {
+		cancelDeadline()
 		l.cancel(context.Canceled)
 	}
 }
@@ -426,11 +456,13 @@ func (b *deadlineObservingAgentBackend) RunTurn(ctx context.Context, request Age
 
 type durationBlockingSessionStore struct {
 	*fakeSessionStore
-	hasDeadline bool
+	hasDeadline   bool
+	expireSession func()
 }
 
 func (s *durationBlockingSessionStore) UpdateSessionWorkerProcess(ctx context.Context, _ int64, _ store.WorkerProcessIdentity) error {
 	_, s.hasDeadline = ctx.Deadline()
+	s.expireSession()
 	<-ctx.Done()
 	return ctx.Err()
 }

--- a/tools/checklock/main_test.go
+++ b/tools/checklock/main_test.go
@@ -17,6 +17,13 @@ import (
 
 const validationSubprocessHelper = "DETENT_CHECKLOCK_HELPER"
 
+// These deadlines only detect deadlocked OS subprocess and file-lock handshakes.
+// They are deliberately generous enough for loaded Windows and macOS runners.
+const (
+	validationIntegrationTimeout = 60 * time.Second
+	validationLockWaitTimeout    = 45 * time.Second
+)
+
 func TestRunValidatesArguments(t *testing.T) {
 	t.Parallel()
 
@@ -60,11 +67,11 @@ func TestRunSerializesConcurrentSubprocesses(t *testing.T) {
 		_ = os.WriteFile(releasePath, nil, 0o600)
 	})
 
-	ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
+	ctx, cancel := context.WithTimeout(t.Context(), validationIntegrationTimeout)
 	defer cancel()
 	args := []string{
 		"-lock", validationLock,
-		"-wait-timeout", "5s",
+		"-wait-timeout", validationLockWaitTimeout.String(),
 		"--", os.Args[0], "-test.run=^TestValidationSubprocessHelper$",
 	}
 
@@ -134,7 +141,7 @@ func TestValidationSubprocessHelper(t *testing.T) {
 		t.Fatalf("close trace: %v", err)
 	}
 
-	ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
+	ctx, cancel := context.WithTimeout(t.Context(), validationLockWaitTimeout)
 	defer cancel()
 	waitForPath(t, ctx, os.Getenv("DETENT_CHECKLOCK_RELEASE"))
 }


### PR DESCRIPTION
## Summary

- drive doctor timeout, renewal, and completed-check preservation through controlled timers and channel synchronization
- inject controllable session and turn duration contexts into runner tests while preserving production defaults
- retain generous documented safety bounds for OS subprocess/file-lock integration and stress affected packages on both portability runners
- document the controllable-time convention, triage the nine-file inventory, and draft a reusable timeout-testing skill

Fixes #1529

## UI Surface Contract

- [x] N/A; this PR does not change UI surfaces.
- [x] This PR does not add persistent top-of-screen messaging.
- [x] This PR has no visual changes.

## Test Plan

- [x] `go test -race ./internal/cli ./internal/runner ./tools/checklock -count=10`
- [x] focused deterministic cases under `-race -count=20`
- [x] `make check` (78.0% coverage)