### PR TITLE
fix(github): refresh stale PR metadata

### DIFF
--- a/internal/connector/github/adapter_test.go
+++ b/internal/connector/github/adapter_test.go
@@ -13,6 +13,7 @@ import (
 	"reflect"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -4447,6 +4448,73 @@ func TestConnectorHydratePullRequestRefreshesCurrentStatus(t *testing.T) {
 	}
 	if got.PRRepository != "example/repo" {
 		t.Fatalf("PRRepository = %q, want example/repo", got.PRRepository)
+	}
+}
+
+func TestConnectorHydratePullRequestRefreshesDraftMetadataAfterNotModified(t *testing.T) {
+	t.Parallel()
+
+	var pullRequestCalls atomic.Int64
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.RequestURI() {
+		case "/repos/example/repo/pulls/42":
+			call := pullRequestCalls.Add(1)
+			if call == 1 {
+				w.Header().Set("ETag", `"draft"`)
+				_, _ = w.Write([]byte(`{"number":42,"state":"open","draft":true,"head":{"sha":"head-sha"},"base":{"sha":"base-sha"}}`))
+				return
+			}
+			if r.Header.Get("If-None-Match") != "" {
+				w.WriteHeader(http.StatusNotModified)
+				return
+			}
+			w.Header().Set("ETag", `"ready"`)
+			_, _ = w.Write([]byte(`{"number":42,"state":"open","draft":false,"head":{"sha":"head-sha"},"base":{"sha":"base-sha"}}`))
+		case "/repos/example/repo/commits/head-sha/check-runs?per_page=100":
+			_, _ = w.Write([]byte(`{"check_runs":[]}`))
+		case "/repos/example/repo/commits/head-sha/statuses?per_page=100",
+			"/repos/example/repo/pulls/42/reviews?per_page=100":
+			_, _ = w.Write([]byte(`[]`))
+		default:
+			t.Errorf("unexpected request path %q", r.URL.RequestURI())
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(server.Close)
+
+	c, err := NewConnector(Config{
+		Endpoint:   server.URL,
+		APIKey:     "test-token",
+		HTTPClient: server.Client(),
+	})
+	if err != nil {
+		t.Fatalf("NewConnector() error = %v", err)
+	}
+	prNumber := 42
+	issue := connector.Issue{
+		Identifier:   "example/repo#1",
+		PRNumber:     &prNumber,
+		PRRepository: "example/repo",
+	}
+
+	draft, err := c.HydratePullRequest(context.Background(), issue)
+	if err != nil {
+		t.Fatalf("HydratePullRequest() draft error = %v", err)
+	}
+	if draft.PullRequest == nil || !draft.PullRequest.Draft {
+		t.Fatalf("first PullRequest = %#v, want draft", draft.PullRequest)
+	}
+
+	ready, err := c.HydratePullRequest(context.Background(), draft)
+	if err != nil {
+		t.Fatalf("HydratePullRequest() ready error = %v", err)
+	}
+	if ready.PullRequest == nil || ready.PullRequest.Draft {
+		t.Fatalf("second PullRequest = %#v, want ready with unchanged head SHA", ready.PullRequest)
+	}
+	if ready.PullRequest.HeadSHA != "head-sha" {
+		t.Fatalf("HeadSHA = %q, want unchanged head-sha", ready.PullRequest.HeadSHA)
 	}
 }
 

--- a/internal/connector/github/client.go
+++ b/internal/connector/github/client.go
@@ -332,10 +332,22 @@ func (c *Client) restProbeWithTokenRefresh(ctx context.Context, method string, p
 }
 
 func (c *Client) rest(ctx context.Context, method string, path string, body any, out any) (http.Header, error) {
-	return c.restWithTokenRefresh(ctx, method, path, body, out, true)
+	return c.restWithTokenRefresh(ctx, method, path, body, out, true, true)
 }
 
-func (c *Client) restWithTokenRefresh(ctx context.Context, method string, path string, body any, out any, allowTokenRefresh bool) (http.Header, error) {
+func (c *Client) restFresh(ctx context.Context, method string, path string, body any, out any) (http.Header, error) {
+	return c.restWithTokenRefresh(ctx, method, path, body, out, true, false)
+}
+
+func (c *Client) restWithTokenRefresh(
+	ctx context.Context,
+	method string,
+	path string,
+	body any,
+	out any,
+	allowTokenRefresh bool,
+	allowConditional bool,
+) (http.Header, error) {
 	token, err := c.tokenSource.Token(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("resolve github token: %w", err)
@@ -346,7 +358,11 @@ func (c *Client) restWithTokenRefresh(ctx context.Context, method string, path s
 	}
 	backoffKey := c.restSharedBackoffKey(token)
 	c.rememberRESTBackoffKey(backoffKey)
-	cached, conditional := c.restConditionalEntry(method, path)
+	cached := restCacheEntry{}
+	conditional := false
+	if allowConditional {
+		cached, conditional = c.restConditionalEntry(method, path)
+	}
 	now := time.Now()
 	if err := c.restBackoffError(backoffKey, now); err != nil {
 		c.logger.DebugContext(ctx, "github rest backoff active",
@@ -441,7 +457,7 @@ func (c *Client) restWithTokenRefresh(ctx context.Context, method string, path s
 		err := classifyStatusAt(resp.StatusCode, resp.Header, raw, receivedAt)
 		c.logRESTStatusError(ctx, method, path, family, resp.StatusCode, err)
 		if c.refreshAfterAuthFailure(ctx, err, allowTokenRefresh) {
-			return c.restWithTokenRefresh(ctx, method, path, body, out, false)
+			return c.restWithTokenRefresh(ctx, method, path, body, out, false, allowConditional)
 		}
 		return nil, err
 	}

--- a/internal/connector/github/conditional.go
+++ b/internal/connector/github/conditional.go
@@ -6,7 +6,10 @@ import (
 	"time"
 )
 
-const restConditionalCacheMaxEntries = 1024
+const (
+	restConditionalCacheMaxAge     = time.Minute
+	restConditionalCacheMaxEntries = 1024
+)
 
 type restCacheEntry struct {
 	etag     string
@@ -20,10 +23,15 @@ func (c *Client) restConditionalEntry(method string, path string) (restCacheEntr
 		return restCacheEntry{}, false
 	}
 	key := restCacheKey(method, path)
-	c.mu.RLock()
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
 	entry, ok := c.restCache[key]
-	c.mu.RUnlock()
 	if !ok || strings.TrimSpace(entry.etag) == "" {
+		return restCacheEntry{}, false
+	}
+	if time.Since(entry.cachedAt) >= restConditionalCacheMaxAge {
+		delete(c.restCache, key)
 		return restCacheEntry{}, false
 	}
 	return cloneRESTCacheEntry(entry), true

--- a/internal/connector/github/conditional_test.go
+++ b/internal/connector/github/conditional_test.go
@@ -8,6 +8,7 @@ import (
 	"strconv"
 	"sync/atomic"
 	"testing"
+	"time"
 )
 
 func TestClientRESTConditionalRequestUsesCachedResponseBelowReserve(t *testing.T) {
@@ -237,5 +238,61 @@ func TestClientRESTConditionalCacheIsBounded(t *testing.T) {
 	}
 	if got := len(client.restCache); got != restConditionalCacheMaxEntries {
 		t.Fatalf("conditional cache size = %d, want %d", got, restConditionalCacheMaxEntries)
+	}
+}
+
+func TestClientRESTConditionalCacheExpiresStaleResponse(t *testing.T) {
+	t.Parallel()
+
+	var calls atomic.Int64
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch calls.Add(1) {
+		case 1:
+			w.Header().Set("ETag", `"draft"`)
+			_, _ = w.Write([]byte(`{"draft":true}`))
+		case 2:
+			if r.Header.Get("If-None-Match") != "" {
+				w.WriteHeader(http.StatusNotModified)
+				return
+			}
+			w.Header().Set("ETag", `"ready"`)
+			_, _ = w.Write([]byte(`{"draft":false}`))
+		default:
+			t.Fatalf("unexpected request %d", calls.Load())
+		}
+	}))
+	t.Cleanup(server.Close)
+
+	client, err := NewClient(ClientConfig{
+		Endpoint:    server.URL,
+		TokenSource: StaticTokenSource("test-token"),
+		HTTPClient:  server.Client(),
+	})
+	if err != nil {
+		t.Fatalf("NewClient() error = %v", err)
+	}
+
+	const path = "/repos/digitaldrywood/detent/pulls/1541"
+	var draft restPullRequest
+	if err := client.REST(context.Background(), http.MethodGet, path, nil, &draft); err != nil {
+		t.Fatalf("first REST() error = %v", err)
+	}
+	if !draft.Draft {
+		t.Fatalf("first REST() Draft = false, want true")
+	}
+
+	key := restCacheKey(http.MethodGet, path)
+	client.mu.Lock()
+	entry := client.restCache[key]
+	entry.cachedAt = time.Now().Add(-time.Hour)
+	client.restCache[key] = entry
+	client.mu.Unlock()
+
+	var ready restPullRequest
+	if err := client.REST(context.Background(), http.MethodGet, path, nil, &ready); err != nil {
+		t.Fatalf("second REST() error = %v", err)
+	}
+	if ready.Draft {
+		t.Fatal("second REST() Draft = true, want refreshed ready state")
 	}
 }

--- a/internal/connector/github/pull_requests.go
+++ b/internal/connector/github/pull_requests.go
@@ -301,9 +301,16 @@ func (c *Connector) fetchRepositoryPullRequests(ctx context.Context, repo pullRe
 	return pullRequests, nil
 }
 
-func (c *Connector) fetchRepositoryPullRequest(ctx context.Context, repo pullRequestRepo, number int) (pullRequestNode, error) {
+func (c *Connector) fetchRepositoryPullRequest(ctx context.Context, repo pullRequestRepo, number int, fresh bool) (pullRequestNode, error) {
 	var response restPullRequest
-	if err := c.client.REST(ctx, http.MethodGet, restPullRequestPath(repo, number), nil, &response); err != nil {
+	path := restPullRequestPath(repo, number)
+	var err error
+	if fresh {
+		_, err = c.client.restFresh(ctx, http.MethodGet, path, nil, &response)
+	} else {
+		err = c.client.REST(ctx, http.MethodGet, path, nil, &response)
+	}
+	if err != nil {
 		return pullRequestNode{}, fmt.Errorf("fetch github pull request: %w", err)
 	}
 	return pullRequestNodeFromREST(response), nil
@@ -314,7 +321,7 @@ func (c *Connector) HydratePullRequest(ctx context.Context, issue connector.Issu
 	if !ok {
 		return issue, nil
 	}
-	pullRequest, err := c.fetchRepositoryPullRequest(ctx, repo, number)
+	pullRequest, err := c.fetchRepositoryPullRequest(ctx, repo, number, true)
 	if err != nil {
 		if state := c.pullRequestHydrationStateForError(repo, err); state.Reason != "" {
 			attachPullRequestHydrationUnavailableToIssue(&issue, repo, number, state)
@@ -622,7 +629,7 @@ func (c *Connector) attachLinkedPullRequests(
 }
 
 func (c *Connector) hydrateLinkedPullRequest(ctx context.Context, hydration *linkedPullRequestHydration, useStatusCache bool) error {
-	pullRequest, err := c.fetchRepositoryPullRequest(ctx, hydration.repo, hydration.number)
+	pullRequest, err := c.fetchRepositoryPullRequest(ctx, hydration.repo, hydration.number, !useStatusCache)
 	if err != nil {
 		state := c.pullRequestHydrationStateForError(hydration.repo, err)
 		if state.Reason == "" {
@@ -689,7 +696,7 @@ func (c *Connector) attachMatchingPullRequests(
 			hydratedPullRequest, ok := hydrated[pullRequest.Number]
 			if !ok {
 				var err error
-				hydratedPullRequest, err = c.fetchRepositoryPullRequest(ctx, repo, pullRequest.Number)
+				hydratedPullRequest, err = c.fetchRepositoryPullRequest(ctx, repo, pullRequest.Number, !useStatusCache)
 				if err != nil {
 					if state := c.pullRequestHydrationStateForError(repo, err); state.Reason != "" {
 						applyPullRequestHydrationUnavailableState(&pullRequest, state)

--- a/internal/connector/github/reconcile.go
+++ b/internal/connector/github/reconcile.go
@@ -61,7 +61,7 @@ func (c *Connector) reconcilePullRequest(ctx context.Context, repo pullRequestRe
 	if target.ChangeNumber <= 0 {
 		return pullRequestNode{}, false, nil
 	}
-	pullRequest, err := c.fetchRepositoryPullRequest(ctx, repo, target.ChangeNumber)
+	pullRequest, err := c.fetchRepositoryPullRequest(ctx, repo, target.ChangeNumber, true)
 	if err != nil {
 		return pullRequestNode{}, false, err
 	}


### PR DESCRIPTION
## Summary

- expire cached conditional REST response bodies after one minute
- fetch pull-request metadata unconditionally for fresh hydration, promotion scans, and targeted reconciliation
- cover draft → ready transitions with an unchanged head SHA and stale 304 behavior

Fixes #1541

## UI Surface Contract

- [x] N/A, or the linked issue explicitly authorizes any high-impact UI surface, layout, density, first-viewport, or responsive visibility tradeoff.
- [x] Persistent top-of-screen messaging is explicitly authorized by the issue, or this PR does not add it.
- [x] N/A — no visual changes.

## Test Plan

- [x] `go test -race ./internal/connector/github -count=1`
- [x] `make check`