### PR TITLE
fix(merge): bound revocation comments

### DIFF
--- a/internal/connector/connector.go
+++ b/internal/connector/connector.go
@@ -31,6 +31,7 @@ func ReportProgress(ctx context.Context) {
 
 var (
 	ErrNotImplemented     = errors.New("connector operation not implemented")
+	ErrResourceExhausted  = errors.New("connector resource exhausted")
 	ErrStateUpdateBlocked = errors.New("issue state update blocked")
 )
 

--- a/internal/connector/github/client.go
+++ b/internal/connector/github/client.go
@@ -1286,6 +1286,8 @@ func classifyStatusAt(status int, headers http.Header, body []byte, now time.Tim
 	switch {
 	case status == http.StatusUnauthorized:
 		base = ErrAuthenticationFailed
+	case status == http.StatusForbidden && githubCommentingDisabled(body):
+		base = ErrResourceExhausted
 	case status == http.StatusForbidden:
 		if strings.TrimSpace(headers.Get("Retry-After")) != "" || headers.Get("X-RateLimit-Remaining") == "0" {
 			base = ErrRateLimited
@@ -1313,6 +1315,13 @@ func classifyStatusAt(status int, headers http.Header, body []byte, now time.Tim
 		}
 	}
 	return statusErr
+}
+
+func githubCommentingDisabled(body []byte) bool {
+	return strings.Contains(
+		strings.ToLower(string(body)),
+		"commenting is disabled on issues with more than 2500 comments",
+	)
 }
 
 func restStatusRateLimited(status int, headers http.Header) bool {

--- a/internal/connector/github/client_test.go
+++ b/internal/connector/github/client_test.go
@@ -181,6 +181,12 @@ func TestClientGraphQLClassifiesFailures(t *testing.T) {
 			want:       ErrRateLimited,
 		},
 		{
+			name:       "issue comment cap",
+			statusCode: http.StatusForbidden,
+			body:       `{"message":"Commenting is disabled on issues with more than 2500 comments"}`,
+			want:       ErrResourceExhausted,
+		},
+		{
 			name:       "not found",
 			statusCode: http.StatusNotFound,
 			body:       `{"message":"not found"}`,
@@ -233,6 +239,26 @@ func TestClientGraphQLClassifiesFailures(t *testing.T) {
 				t.Fatalf("GraphQL() error = %v, want %v", err, tt.want)
 			}
 		})
+	}
+}
+
+func TestClassifyStatusMapsCommentCapToResourceExhaustion(t *testing.T) {
+	t.Parallel()
+
+	err := classifyStatus(
+		http.StatusForbidden,
+		nil,
+		[]byte(`{"message":"Commenting is disabled on issues with more than 2500 comments"}`),
+	)
+
+	if !errors.Is(err, ErrResourceExhausted) {
+		t.Fatalf("classifyStatus() error = %v, want ErrResourceExhausted", err)
+	}
+	if errors.Is(err, ErrAuthenticationFailed) {
+		t.Fatalf("classifyStatus() error = %v, do not want ErrAuthenticationFailed", err)
+	}
+	if !strings.Contains(err.Error(), "github resource exhausted") {
+		t.Fatalf("classifyStatus() error = %v, want resource exhaustion message", err)
 	}
 }
 

--- a/internal/connector/github/errors.go
+++ b/internal/connector/github/errors.go
@@ -34,6 +34,7 @@ var (
 	ErrProjectFieldUpdateFailed    = errors.New("github project field update failed")
 	ErrProjectNotFound             = errors.New("github project not found")
 	ErrRateLimited                 = connector.NewRetryableError("github rate limited")
+	ErrResourceExhausted           = fmt.Errorf("github resource exhausted: %w", connector.ErrResourceExhausted)
 	ErrRESTBudgetReserved          = connector.NewRetryableError("github rest budget reserved")
 	ErrStatusFieldNotFound         = errors.New("github status field not found")
 	ErrStatusOptionNotFound        = errors.New("github status option not found")

--- a/internal/orchestrator/merge_revocation.go
+++ b/internal/orchestrator/merge_revocation.go
@@ -2,6 +2,7 @@ package orchestrator
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 	"time"
@@ -22,10 +23,28 @@ const (
 	mergeRevocationPullRequestNotOpen    = "pull_request_not_open"
 )
 
+const (
+	mergeRevocationCommentLimit  = 10
+	mergeRevocationCommentWindow = 24 * time.Hour
+	mergeRevocationCommentPrefix = "<!-- detent:merge-revocation "
+)
+
 type mergeRevocation struct {
 	issue       connector.Issue
 	reason      string
 	targetState string
+}
+
+type mergeRevocationCommentState struct {
+	localWrites       []mergeRevocationCommentWrite
+	lastSignature     string
+	warnedUntil       time.Time
+	resourceExhausted bool
+}
+
+type mergeRevocationCommentWrite struct {
+	signature string
+	at        time.Time
 }
 
 func (o *Orchestrator) revokeRunningMergeIfIneligible(
@@ -268,7 +287,7 @@ func (o *Orchestrator) finishMergeRevocation(
 	)
 	o.recordMergeFailed(state, running.Issue, completedAt, revocation.reason, nil)
 	o.routeMergeRevocation(ctx, state, &revocation, completedAt)
-	o.commentMergeRevocation(ctx, revocation)
+	o.commentMergeRevocation(ctx, state, revocation, completedAt)
 	o.logWorkerLifecycle(running.Issue, "worker_merge_revoked",
 		"attempt", running.Attempt,
 		"worker_host", strings.TrimSpace(running.WorkerHost),
@@ -335,14 +354,59 @@ func (o *Orchestrator) routeMergeRevocation(ctx context.Context, state *State, r
 	revocation.issue.State = revocation.targetState
 }
 
-func (o *Orchestrator) commentMergeRevocation(ctx context.Context, revocation mergeRevocation) {
+func (o *Orchestrator) commentMergeRevocation(
+	ctx context.Context,
+	state *State,
+	revocation mergeRevocation,
+	at time.Time,
+) {
 	if o.connector == nil {
+		return
+	}
+	issueID := strings.TrimSpace(revocation.issue.ID)
+	if issueID == "" {
+		return
+	}
+	at = at.UTC()
+	if at.IsZero() {
+		at = o.clockNow().UTC()
+	}
+	commentState := o.mergeRevocationCommentState(issueID)
+	if commentState.resourceExhausted {
+		return
+	}
+	signature := mergeRevocationCommentSignature(revocation)
+	comments := o.mergeRevocationIssueComments(ctx, revocation.issue)
+	if commentState.lastSignature == signature || latestMergeRevocationCommentSignature(comments) == signature {
+		return
+	}
+	if mergeRevocationCommentCount(comments, commentState.localWrites, at) >= mergeRevocationCommentLimit {
+		if !at.Before(commentState.warnedUntil) {
+			commentState.warnedUntil = at.Add(mergeRevocationCommentWindow)
+			if o.logger != nil {
+				o.logger.Warn(
+					"merge revocation comment budget exhausted; issue needs human attention",
+					"issue_id", issueID,
+					"limit", mergeRevocationCommentLimit,
+					"window", mergeRevocationCommentWindow,
+				)
+			}
+			o.escalateMergeRevocationCommentLoss(
+				ctx,
+				state,
+				revocation.issue,
+				at,
+				"merge_revocation_comment_budget_exhausted",
+			)
+		}
 		return
 	}
 	var body strings.Builder
 	body.WriteString("Detent stopped the active merge because merge eligibility was revoked.")
 	body.WriteString("\n\n- reason: ")
 	body.WriteString(revocation.reason)
+	body.WriteString("\n- head_sha: ")
+	body.WriteString(mergeRevocationHeadSHA(revocation))
 	if stateName := strings.TrimSpace(revocation.issue.State); stateName != "" {
 		body.WriteString("\n- observed_state: ")
 		body.WriteString(stateName)
@@ -357,8 +421,161 @@ func (o *Orchestrator) commentMergeRevocation(ctx context.Context, revocation me
 			body.WriteString(url)
 		}
 	}
-	if err := o.connector.CreateComment(ctx, revocation.issue.ID, body.String()); err != nil && o.logger != nil {
-		o.logger.Warn("merge revocation comment failed", "issue_id", revocation.issue.ID, "error", err)
+	body.WriteString("\n\n")
+	body.WriteString(signature)
+	if err := o.connector.CreateComment(ctx, issueID, body.String()); err != nil {
+		if errors.Is(err, connector.ErrResourceExhausted) {
+			commentState.resourceExhausted = true
+			if o.logger != nil {
+				o.logger.Warn(
+					"merge revocation comment resource exhausted; issue needs human attention",
+					"issue_id", issueID,
+					"error", err,
+				)
+			}
+			o.escalateMergeRevocationCommentLoss(
+				ctx,
+				state,
+				revocation.issue,
+				at,
+				"merge_revocation_comment_resource_exhausted",
+			)
+			return
+		}
+		if o.logger != nil {
+			o.logger.Warn("merge revocation comment failed", "issue_id", issueID, "error", err)
+		}
+		return
+	}
+	commentState.lastSignature = signature
+	commentState.localWrites = append(commentState.localWrites, mergeRevocationCommentWrite{
+		signature: signature,
+		at:        at,
+	})
+}
+
+func (o *Orchestrator) mergeRevocationCommentState(issueID string) *mergeRevocationCommentState {
+	if o.mergeRevocationComments == nil {
+		o.mergeRevocationComments = map[string]*mergeRevocationCommentState{}
+	}
+	state := o.mergeRevocationComments[issueID]
+	if state == nil {
+		state = &mergeRevocationCommentState{}
+		o.mergeRevocationComments[issueID] = state
+	}
+	return state
+}
+
+func (o *Orchestrator) mergeRevocationIssueComments(
+	ctx context.Context,
+	issue connector.Issue,
+) []connector.IssueComment {
+	reader, ok := o.connector.(connector.IssueCommentReader)
+	if !ok {
+		return issue.Comments
+	}
+	comments, err := reader.FetchIssueComments(ctx, issue)
+	if err != nil {
+		if o.logger != nil {
+			o.logger.Warn(
+				"merge revocation comment history failed",
+				"issue_id", issue.ID,
+				"error", err,
+			)
+		}
+		return issue.Comments
+	}
+	return comments
+}
+
+func mergeRevocationCommentSignature(revocation mergeRevocation) string {
+	return fmt.Sprintf(
+		"%sreason=%s head_sha=%s -->",
+		mergeRevocationCommentPrefix,
+		strings.TrimSpace(revocation.reason),
+		mergeRevocationHeadSHA(revocation),
+	)
+}
+
+func mergeRevocationHeadSHA(revocation mergeRevocation) string {
+	if revocation.issue.PullRequest == nil {
+		return ""
+	}
+	return strings.TrimSpace(revocation.issue.PullRequest.HeadSHA)
+}
+
+func latestMergeRevocationCommentSignature(comments []connector.IssueComment) string {
+	for index := len(comments) - 1; index >= 0; index-- {
+		if signature := mergeRevocationCommentMarker(comments[index].Body); signature != "" {
+			return signature
+		}
+	}
+	return ""
+}
+
+func mergeRevocationCommentCount(
+	comments []connector.IssueComment,
+	localWrites []mergeRevocationCommentWrite,
+	at time.Time,
+) int {
+	cutoff := at.Add(-mergeRevocationCommentWindow)
+	persisted := map[string]struct{}{}
+	count := 0
+	for _, comment := range comments {
+		signature := mergeRevocationCommentMarker(comment.Body)
+		if signature == "" {
+			continue
+		}
+		persisted[signature] = struct{}{}
+		if comment.CreatedAt == nil || !comment.CreatedAt.Before(cutoff) {
+			count++
+		}
+	}
+	for _, write := range localWrites {
+		if write.at.Before(cutoff) {
+			continue
+		}
+		if _, ok := persisted[write.signature]; ok {
+			continue
+		}
+		count++
+	}
+	return count
+}
+
+func mergeRevocationCommentMarker(body string) string {
+	for line := range strings.SplitSeq(body, "\n") {
+		line = strings.TrimSpace(line)
+		if strings.HasPrefix(line, mergeRevocationCommentPrefix) && strings.HasSuffix(line, " -->") {
+			return line
+		}
+	}
+	return ""
+}
+
+func (o *Orchestrator) escalateMergeRevocationCommentLoss(
+	ctx context.Context,
+	state *State,
+	issue connector.Issue,
+	at time.Time,
+	reason string,
+) {
+	if err := o.updateIssueStateByID(
+		ctx,
+		state,
+		issue.ID,
+		issue,
+		autoPromoteSourceState,
+		at,
+		reason,
+	); err != nil && o.logger != nil {
+		o.logger.Warn(
+			"merge revocation comment loss escalation failed",
+			"issue_id", issue.ID,
+			"target_state", autoPromoteSourceState,
+			"reason", reason,
+			"error", err,
+		)
 	}
 }
 

--- a/internal/orchestrator/merge_revocation.go
+++ b/internal/orchestrator/merge_revocation.go
@@ -36,10 +36,12 @@ type mergeRevocation struct {
 }
 
 type mergeRevocationCommentState struct {
-	localWrites       []mergeRevocationCommentWrite
-	lastSignature     string
-	warnedUntil       time.Time
-	resourceExhausted bool
+	localWrites                 []mergeRevocationCommentWrite
+	lastSignature               string
+	warnedUntil                 time.Time
+	budgetEscalated             bool
+	resourceExhausted           bool
+	resourceExhaustionEscalated bool
 }
 
 type mergeRevocationCommentWrite struct {
@@ -373,6 +375,15 @@ func (o *Orchestrator) commentMergeRevocation(
 	}
 	commentState := o.mergeRevocationCommentState(issueID)
 	if commentState.resourceExhausted {
+		if !commentState.resourceExhaustionEscalated {
+			commentState.resourceExhaustionEscalated = o.escalateMergeRevocationCommentLoss(
+				ctx,
+				state,
+				revocation.issue,
+				at,
+				"merge_revocation_comment_resource_exhausted",
+			)
+		}
 		return
 	}
 	signature := mergeRevocationCommentSignature(revocation)
@@ -391,7 +402,9 @@ func (o *Orchestrator) commentMergeRevocation(
 					"window", mergeRevocationCommentWindow,
 				)
 			}
-			o.escalateMergeRevocationCommentLoss(
+		}
+		if !commentState.budgetEscalated {
+			commentState.budgetEscalated = o.escalateMergeRevocationCommentLoss(
 				ctx,
 				state,
 				revocation.issue,
@@ -433,7 +446,7 @@ func (o *Orchestrator) commentMergeRevocation(
 					"error", err,
 				)
 			}
-			o.escalateMergeRevocationCommentLoss(
+			commentState.resourceExhaustionEscalated = o.escalateMergeRevocationCommentLoss(
 				ctx,
 				state,
 				revocation.issue,
@@ -559,24 +572,29 @@ func (o *Orchestrator) escalateMergeRevocationCommentLoss(
 	issue connector.Issue,
 	at time.Time,
 	reason string,
-) {
+) bool {
+	targetState := normalizeAutoPromoteConfig(o.cfg.AutoPromote).SourceState
 	if err := o.updateIssueStateByID(
 		ctx,
 		state,
 		issue.ID,
 		issue,
-		autoPromoteSourceState,
+		targetState,
 		at,
 		reason,
-	); err != nil && o.logger != nil {
-		o.logger.Warn(
-			"merge revocation comment loss escalation failed",
-			"issue_id", issue.ID,
-			"target_state", autoPromoteSourceState,
-			"reason", reason,
-			"error", err,
-		)
+	); err != nil {
+		if o.logger != nil {
+			o.logger.Warn(
+				"merge revocation comment loss escalation failed",
+				"issue_id", issue.ID,
+				"target_state", targetState,
+				"reason", reason,
+				"error", err,
+			)
+		}
+		return false
 	}
+	return true
 }
 
 func mergeRevocationError(revocation mergeRevocation) error {

--- a/internal/orchestrator/merge_revocation_test.go
+++ b/internal/orchestrator/merge_revocation_test.go
@@ -1,10 +1,13 @@
 package orchestrator
 
 import (
+	"bytes"
 	"context"
 	"errors"
+	"fmt"
 	"io"
 	"log/slog"
+	"strings"
 	"testing"
 	"time"
 
@@ -198,4 +201,196 @@ func TestDraftMergeRevocationUsesConfiguredSourceState(t *testing.T) {
 	if revocation.targetState != "Review" {
 		t.Fatalf("target state = %q, want configured source state Review", revocation.targetState)
 	}
+}
+
+func TestMergeRevocationCommentsDeduplicateReasonAndHeadSHA(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 7, 29, 12, 0, 0, 0, time.UTC)
+	tracker := &mergeRevocationCommentConnector{now: now}
+	orch := &Orchestrator{
+		connector: tracker,
+		logger:    slog.New(slog.NewTextHandler(io.Discard, nil)),
+		now:       func() time.Time { return now },
+	}
+	revocation := mergeRevocation{
+		issue: connector.Issue{
+			ID:    "issue-comment-dedup",
+			State: "Merging",
+			PullRequest: &connector.PullRequest{
+				HeadSHA: "same-head",
+			},
+		},
+		reason:      mergeRevocationDraftPullRequest,
+		targetState: "In Progress",
+	}
+
+	orch.commentMergeRevocation(t.Context(), &State{}, revocation, now)
+	orch = &Orchestrator{
+		connector: tracker,
+		logger:    slog.New(slog.NewTextHandler(io.Discard, nil)),
+		now:       func() time.Time { return now },
+	}
+	for range 19 {
+		orch.commentMergeRevocation(t.Context(), &State{}, revocation, now)
+	}
+
+	if got := len(tracker.comments); got != 1 {
+		t.Fatalf("comments = %d, want 1", got)
+	}
+	body := tracker.comments[0].Body
+	for _, want := range []string{
+		"- reason: " + mergeRevocationDraftPullRequest,
+		"- head_sha: same-head",
+		mergeRevocationCommentSignature(revocation),
+	} {
+		if !strings.Contains(body, want) {
+			t.Fatalf("comment body = %q, want %q", body, want)
+		}
+	}
+}
+
+func TestMergeRevocationCommentBudgetWarnsAndEscalatesOnce(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 7, 29, 12, 0, 0, 0, time.UTC)
+	tracker := &mergeRevocationCommentConnector{now: now}
+	for index := range mergeRevocationCommentLimit {
+		createdAt := now.Add(-time.Duration(index) * time.Minute)
+		revocation := mergeRevocation{
+			issue: connector.Issue{
+				ID: "issue-comment-budget",
+				PullRequest: &connector.PullRequest{
+					HeadSHA: fmt.Sprintf("prior-head-%d", index),
+				},
+			},
+			reason: mergeRevocationDraftPullRequest,
+		}
+		tracker.comments = append(tracker.comments, connector.IssueComment{
+			Body:      mergeRevocationCommentSignature(revocation),
+			CreatedAt: &createdAt,
+		})
+	}
+	var logs bytes.Buffer
+	orch := &Orchestrator{
+		connector: tracker,
+		logger:    slog.New(slog.NewTextHandler(&logs, nil)),
+		now:       func() time.Time { return now },
+	}
+	revocation := mergeRevocation{
+		issue: connector.Issue{
+			ID:    "issue-comment-budget",
+			State: "Merging",
+			PullRequest: &connector.PullRequest{
+				HeadSHA: "new-head",
+			},
+		},
+		reason: mergeRevocationDraftPullRequest,
+	}
+
+	orch.commentMergeRevocation(t.Context(), &State{}, revocation, now)
+	orch.commentMergeRevocation(t.Context(), &State{}, revocation, now.Add(time.Minute))
+
+	if got := len(tracker.comments); got != mergeRevocationCommentLimit {
+		t.Fatalf("comments = %d, want budget limit %d", got, mergeRevocationCommentLimit)
+	}
+	if got, want := tracker.updates, []string{autoPromoteSourceState}; fmt.Sprint(got) != fmt.Sprint(want) {
+		t.Fatalf("updates = %#v, want %#v", got, want)
+	}
+	if got := strings.Count(logs.String(), "merge revocation comment budget exhausted"); got != 1 {
+		t.Fatalf("budget warnings = %d, want 1: %s", got, logs.String())
+	}
+}
+
+func TestMergeRevocationCommentResourceExhaustionEscalates(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 7, 29, 12, 0, 0, 0, time.UTC)
+	tracker := &mergeRevocationCommentConnector{
+		now:        now,
+		commentErr: fmt.Errorf("create github comment: %w", connector.ErrResourceExhausted),
+	}
+	var logs bytes.Buffer
+	orch := &Orchestrator{
+		connector: tracker,
+		logger:    slog.New(slog.NewTextHandler(&logs, nil)),
+		now:       func() time.Time { return now },
+	}
+	revocation := mergeRevocation{
+		issue: connector.Issue{
+			ID:    "issue-comment-cap",
+			State: "Merging",
+			PullRequest: &connector.PullRequest{
+				HeadSHA: "capped-head",
+			},
+		},
+		reason: mergeRevocationDraftPullRequest,
+	}
+
+	orch.commentMergeRevocation(t.Context(), &State{}, revocation, now)
+	orch.commentMergeRevocation(t.Context(), &State{}, revocation, now.Add(time.Minute))
+
+	if tracker.commentAttempts != 1 {
+		t.Fatalf("comment attempts = %d, want 1", tracker.commentAttempts)
+	}
+	if got, want := tracker.updates, []string{autoPromoteSourceState}; fmt.Sprint(got) != fmt.Sprint(want) {
+		t.Fatalf("updates = %#v, want %#v", got, want)
+	}
+	if !strings.Contains(logs.String(), "comment resource exhausted") {
+		t.Fatalf("logs = %q, want resource exhaustion", logs.String())
+	}
+}
+
+type mergeRevocationCommentConnector struct {
+	now             time.Time
+	comments        []connector.IssueComment
+	updates         []string
+	commentErr      error
+	commentAttempts int
+}
+
+func (c *mergeRevocationCommentConnector) Name() string {
+	return "merge-revocation-comment"
+}
+
+func (c *mergeRevocationCommentConnector) FetchCandidateIssues(context.Context) ([]connector.Issue, error) {
+	return nil, nil
+}
+
+func (c *mergeRevocationCommentConnector) FetchIssuesByStates(context.Context, []string) ([]connector.Issue, error) {
+	return nil, nil
+}
+
+func (c *mergeRevocationCommentConnector) FetchIssueStatesByIDs(context.Context, []string) ([]connector.Issue, error) {
+	return nil, nil
+}
+
+func (c *mergeRevocationCommentConnector) FetchIssueComments(context.Context, connector.Issue) ([]connector.IssueComment, error) {
+	return append([]connector.IssueComment(nil), c.comments...), nil
+}
+
+func (c *mergeRevocationCommentConnector) CreateComment(_ context.Context, _ string, body string) error {
+	c.commentAttempts++
+	if c.commentErr != nil {
+		return c.commentErr
+	}
+	createdAt := c.now
+	c.comments = append(c.comments, connector.IssueComment{
+		Body:      body,
+		CreatedAt: &createdAt,
+	})
+	return nil
+}
+
+func (c *mergeRevocationCommentConnector) UpdateIssueState(_ context.Context, _ string, state string) error {
+	c.updates = append(c.updates, state)
+	return nil
+}
+
+func (c *mergeRevocationCommentConnector) SetAssignee(context.Context, string, string) error {
+	return nil
+}
+
+func (c *mergeRevocationCommentConnector) SetField(context.Context, string, string, string) error {
+	return nil
 }

--- a/internal/orchestrator/merge_revocation_test.go
+++ b/internal/orchestrator/merge_revocation_test.go
@@ -274,8 +274,11 @@ func TestMergeRevocationCommentBudgetWarnsAndEscalatesOnce(t *testing.T) {
 	var logs bytes.Buffer
 	orch := &Orchestrator{
 		connector: tracker,
-		logger:    slog.New(slog.NewTextHandler(&logs, nil)),
-		now:       func() time.Time { return now },
+		cfg: Config{
+			AutoPromote: AutoPromoteConfig{SourceState: "Review"},
+		},
+		logger: slog.New(slog.NewTextHandler(&logs, nil)),
+		now:    func() time.Time { return now },
 	}
 	revocation := mergeRevocation{
 		issue: connector.Issue{
@@ -294,7 +297,7 @@ func TestMergeRevocationCommentBudgetWarnsAndEscalatesOnce(t *testing.T) {
 	if got := len(tracker.comments); got != mergeRevocationCommentLimit {
 		t.Fatalf("comments = %d, want budget limit %d", got, mergeRevocationCommentLimit)
 	}
-	if got, want := tracker.updates, []string{autoPromoteSourceState}; fmt.Sprint(got) != fmt.Sprint(want) {
+	if got, want := tracker.updates, []string{"Review"}; fmt.Sprint(got) != fmt.Sprint(want) {
 		t.Fatalf("updates = %#v, want %#v", got, want)
 	}
 	if got := strings.Count(logs.String(), "merge revocation comment budget exhausted"); got != 1 {
@@ -307,8 +310,9 @@ func TestMergeRevocationCommentResourceExhaustionEscalates(t *testing.T) {
 
 	now := time.Date(2026, 7, 29, 12, 0, 0, 0, time.UTC)
 	tracker := &mergeRevocationCommentConnector{
-		now:        now,
-		commentErr: fmt.Errorf("create github comment: %w", connector.ErrResourceExhausted),
+		now:            now,
+		commentErr:     fmt.Errorf("create github comment: %w", connector.ErrResourceExhausted),
+		updateFailures: 1,
 	}
 	var logs bytes.Buffer
 	orch := &Orchestrator{
@@ -333,6 +337,9 @@ func TestMergeRevocationCommentResourceExhaustionEscalates(t *testing.T) {
 	if tracker.commentAttempts != 1 {
 		t.Fatalf("comment attempts = %d, want 1", tracker.commentAttempts)
 	}
+	if tracker.updateAttempts != 2 {
+		t.Fatalf("update attempts = %d, want 2", tracker.updateAttempts)
+	}
 	if got, want := tracker.updates, []string{autoPromoteSourceState}; fmt.Sprint(got) != fmt.Sprint(want) {
 		t.Fatalf("updates = %#v, want %#v", got, want)
 	}
@@ -347,6 +354,8 @@ type mergeRevocationCommentConnector struct {
 	updates         []string
 	commentErr      error
 	commentAttempts int
+	updateFailures  int
+	updateAttempts  int
 }
 
 func (c *mergeRevocationCommentConnector) Name() string {
@@ -383,6 +392,11 @@ func (c *mergeRevocationCommentConnector) CreateComment(_ context.Context, _ str
 }
 
 func (c *mergeRevocationCommentConnector) UpdateIssueState(_ context.Context, _ string, state string) error {
+	c.updateAttempts++
+	if c.updateFailures > 0 {
+		c.updateFailures--
+		return connector.NewRetryableError("transient state update")
+	}
 	c.updates = append(c.updates, state)
 	return nil
 }

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -234,6 +234,7 @@ type Orchestrator struct {
 	done                    chan struct{}
 	pendingStops            map[string]*pendingStopRun
 	pendingMergeRevocations map[string]mergeRevocation
+	mergeRevocationComments map[string]*mergeRevocationCommentState
 	completedStops          map[string]StopRunResult
 	refreshSeq              atomic.Uint64
 }
@@ -463,6 +464,7 @@ func New(cfg Config, deps Dependencies) (*Orchestrator, error) {
 		done:                    make(chan struct{}),
 		pendingStops:            map[string]*pendingStopRun{},
 		pendingMergeRevocations: map[string]mergeRevocation{},
+		mergeRevocationComments: map[string]*mergeRevocationCommentState{},
 		completedStops:          map[string]StopRunResult{},
 	}
 	orchestrator.heartbeats = newHeartbeatManager(cfg, deps.Connector, deps.WorkAttempts, now, logger)


### PR DESCRIPTION
## Summary

- deduplicate merge-revocation comments by persisted reason and pull-request head SHA
- enforce a 10-comment-per-24-hour issue budget and route exhausted issues to the configured review/source state
- classify the permanent GitHub 2,500-comment 403 as resource exhaustion instead of authentication failure

Fixes #1540

## UI Surface Contract

- [x] N/A; this change does not alter UI surfaces, layout, density, first-viewport content, or responsive visibility.
- [x] This PR does not add persistent top-of-screen messaging.
- [x] This PR has no visual changes to primary operator screens.

## Test Plan

- [x] `go test ./internal/connector/github ./internal/orchestrator -run 'TestClientGraphQLClassifiesFailures|TestClassifyStatusMapsCommentCapToResourceExhaustion|TestMergeRevocation'`
- [x] `make check`