### PR TITLE
fix(merge): prevent draft slot starvation

### DIFF
--- a/internal/orchestrator/autopromote.go
+++ b/internal/orchestrator/autopromote.go
@@ -69,6 +69,8 @@ const (
 	AutoPromoteReasonLabelNotAllowed                 AutoPromoteReason = "label_not_allowed"
 	AutoPromoteReasonMissingPullRequest              AutoPromoteReason = "missing_pull_request"
 	AutoPromoteReasonPullRequestMerged               AutoPromoteReason = "pull_request_merged"
+	AutoPromoteReasonDraftPullRequest                AutoPromoteReason = "draft_pull_request"
+	AutoPromoteReasonMergeRevocationLimit            AutoPromoteReason = "merge_revocation_limit"
 	AutoPromoteReasonPullRequestHydrationUnavailable AutoPromoteReason = "pull_request_hydration_unavailable"
 	AutoPromoteReasonMergeConflicts                  AutoPromoteReason = "merge_conflicts"
 	AutoPromoteReasonCINotGreen                      AutoPromoteReason = "ci_not_green"
@@ -144,6 +146,11 @@ func EvaluateAutoPromote(
 		return decision
 	}
 	if gateRequiresPullRequest(cfg.Gate) {
+		if issue.PullRequest != nil &&
+			normalizePullRequestState(issue.PullRequest.State) == "open" &&
+			issue.PullRequest.Draft {
+			return autoPromoteDecision(AutoPromoteActionSkip, AutoPromoteReasonDraftPullRequest)
+		}
 		if autoPromoteMergeConflicts(summary.MergeableState) {
 			return autoPromoteDecision(AutoPromoteActionRework, AutoPromoteReasonMergeConflicts)
 		}

--- a/internal/orchestrator/autopromote_test.go
+++ b/internal/orchestrator/autopromote_test.go
@@ -92,6 +92,23 @@ func TestEvaluateAutoPromote(t *testing.T) {
 			},
 		},
 		{
+			name: "draft pull request skips",
+			issue: func() connector.Issue {
+				issue := autoPromoteTestIssue("issue-draft-pr", nil)
+				issue.PullRequest = &connector.PullRequest{
+					State: "OPEN",
+					Draft: true,
+				}
+				return issue
+			}(),
+			cfg:   enabled,
+			input: ready,
+			want: AutoPromoteDecision{
+				Action: AutoPromoteActionSkip,
+				Reason: AutoPromoteReasonDraftPullRequest,
+			},
+		},
+		{
 			name:  "red ci reworks by default",
 			issue: autoPromoteTestIssue("issue-red-ci", nil),
 			cfg:   enabled,

--- a/internal/orchestrator/autopromote_tick.go
+++ b/internal/orchestrator/autopromote_tick.go
@@ -80,6 +80,13 @@ func (o *Orchestrator) autoPromoteHumanReviewIssues(
 		if issueID == "" {
 			continue
 		}
+		if handled, transitioned := o.parkRepeatedMergeRevocations(ctx, state, issue, now); handled {
+			if transitioned {
+				result.transitioned[issueID] = struct{}{}
+				o.clearAutoPromotedIssueDispatchMemory(state, issueID)
+			}
+			continue
+		}
 
 		summary := AutoPromoteSummaryFromIssue(issue)
 		summary.CompletedFinalState = autoPromoteCompletedFinalState(state, issueID)

--- a/internal/orchestrator/autopromote_tick_test.go
+++ b/internal/orchestrator/autopromote_tick_test.go
@@ -3608,6 +3608,113 @@ func TestTickDispatchesFreshAutoPromotedMergingIssue(t *testing.T) {
 	}
 }
 
+func TestTickDraftPullRequestDoesNotBlockReadyPeerMerge(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 7, 29, 16, 0, 0, 0, time.UTC)
+	draft := autoPromoteTickIssue("issue-draft-peer", []string{"bug"}, &connector.PullRequest{
+		Number:         45,
+		URL:            "https://github.test/digitaldrywood/video-studio/pull/45",
+		State:          "OPEN",
+		Draft:          true,
+		MergeableState: "clean",
+		CIStatus:       "success",
+		HeadSHA:        "draft-head",
+	})
+	draft.Identifier = "digitaldrywood/video-studio#41"
+	ready := autoPromoteTickIssue("issue-ready-peer", []string{"bug"}, &connector.PullRequest{
+		Number:         55,
+		URL:            "https://github.test/digitaldrywood/video-studio/pull/55",
+		State:          "OPEN",
+		MergeableState: "clean",
+		CIStatus:       "success",
+		HeadSHA:        "ready-head",
+	})
+	ready.Identifier = "digitaldrywood/video-studio#50"
+	cfg := normalizeConfig(Config{
+		PollInterval:        time.Minute,
+		MaxConcurrentAgents: 1,
+		MaxConcurrentAgentsByState: map[string]int{
+			"Merging": 1,
+		},
+		MergeMethod: "squash",
+		AutoPromote: AutoPromoteConfig{
+			Enabled: true,
+			Gate: gate.Config{
+				Kind:                   gate.KindCommand,
+				RequireAutomatedReview: new(false),
+			},
+		},
+		ActiveStates:   []string{"Todo", "In Progress", "Rework", "Merging"},
+		TerminalStates: []string{"Done", "Cancelled"},
+	})
+	baseConnector := &autoPromoteTickConnector{stateIssues: []connector.Issue{draft, ready}}
+	tracker := &autoPromoteTickMergeConnector{autoPromoteTickConnector: baseConnector}
+	runner := newWorkerHostRunner()
+	var logs strings.Builder
+	orch := &Orchestrator{
+		cfg:        cfg,
+		connector:  tracker,
+		supervisor: newTestSupervisor(t, runner, cfg),
+		runResults: make(chan runpkg.Completion, 1),
+		logger:     slog.New(slog.NewTextHandler(&logs, nil)),
+	}
+	state := newState(cfg)
+
+	orch.tick(t.Context(), &state, now)
+
+	request := receiveWorkerHostRunRequest(t, runner.started)
+	if request.Issue.ID != ready.ID {
+		t.Fatalf("RunRequest.Issue.ID = %q, want ready peer %q", request.Issue.ID, ready.ID)
+	}
+	if _, ok := state.Running[draft.ID]; ok {
+		t.Fatalf("Running[%q] present, want draft peer to acquire no slot", draft.ID)
+	}
+	if running := state.Running[ready.ID]; running.cancel != nil {
+		running.cancel()
+	}
+	orch.handleRunResult(t.Context(), &state, runpkg.Completion{
+		IssueID:     ready.ID,
+		CompletedAt: now.Add(time.Minute),
+		Result: runpkg.RunResult{
+			FinalState: runpkg.FinalStateCompleted,
+			Output:     "validated current-head CI and updated the Workpad",
+		},
+	})
+
+	if len(tracker.merges) != 1 || tracker.merges[0].number != 55 {
+		t.Fatalf("merges = %#v, want ready PR #55 merged", tracker.merges)
+	}
+	wantUpdates := []autoPromoteTickUpdate{
+		{issueID: ready.ID, state: "Merging"},
+		{issueID: ready.ID, state: "Done"},
+	}
+	if !reflect.DeepEqual(baseConnector.updates, wantUpdates) {
+		t.Fatalf("updates = %#v, want %#v", baseConnector.updates, wantUpdates)
+	}
+	logLines := strings.Split(logs.String(), "\n")
+	draftSlotAcquisition := false
+	for _, line := range logLines {
+		if strings.Contains(line, "merge_worker_slot_acquired") && strings.Contains(line, "identifier="+draft.Identifier) {
+			draftSlotAcquisition = true
+			break
+		}
+	}
+	if draftSlotAcquisition {
+		t.Fatalf("logs = %q, want draft peer to acquire zero merge slots", logs.String())
+	}
+	for _, fragment := range []string{
+		"identifier=" + draft.Identifier + " action=skip reason=draft_pull_request",
+		"merge_worker_slot_acquired",
+		"identifier=" + ready.Identifier,
+		"merge_worker_success",
+	} {
+		if !strings.Contains(logs.String(), fragment) {
+			t.Fatalf("logs = %q, missing %q", logs.String(), fragment)
+		}
+	}
+}
+
 func TestTickReconcilesStaleMergingPullRequestStates(t *testing.T) {
 	t.Parallel()
 

--- a/internal/orchestrator/dependency_autounblock.go
+++ b/internal/orchestrator/dependency_autounblock.go
@@ -857,7 +857,7 @@ func stickyBlockReason(reason string) bool {
 		return true
 	}
 	switch reason {
-	case "rework_limit", "no_progress_limit", "workpad_blocked_unactioned", "circuit_breaker", "token_ceiling_circuit_breaker", artifactGateConvergenceReason:
+	case "rework_limit", string(AutoPromoteReasonMergeRevocationLimit), "no_progress_limit", "workpad_blocked_unactioned", "circuit_breaker", "token_ceiling_circuit_breaker", artifactGateConvergenceReason:
 		return true
 	default:
 		return false

--- a/internal/orchestrator/merge_revocation.go
+++ b/internal/orchestrator/merge_revocation.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strconv"
 	"strings"
 	"time"
 
@@ -21,6 +22,7 @@ const (
 	mergeRevocationMissingPullRequest    = "missing_pull_request"
 	mergeRevocationDraftPullRequest      = "draft_pull_request"
 	mergeRevocationPullRequestNotOpen    = "pull_request_not_open"
+	maxIdenticalMergeRevocations         = 3
 )
 
 const (
@@ -47,6 +49,11 @@ type mergeRevocationCommentState struct {
 type mergeRevocationCommentWrite struct {
 	signature string
 	at        time.Time
+}
+
+type mergeRevocationStreak struct {
+	reason string
+	count  int
 }
 
 func (o *Orchestrator) revokeRunningMergeIfIneligible(
@@ -309,6 +316,174 @@ func (o *Orchestrator) finishMergeRevocation(
 		Event:   "merge_worker_revoked",
 		Message: "stopped merge worker for " + issueLabel(revocation.issue) + ": " + revocation.reason,
 	})
+}
+
+func (o *Orchestrator) parkRepeatedMergeRevocations(
+	ctx context.Context,
+	state *State,
+	issue connector.Issue,
+	now time.Time,
+) (bool, bool) {
+	streak, err := o.consecutiveMergeRevocations(ctx, state, issue)
+	if err != nil {
+		if o.logger != nil {
+			o.logger.Warn(
+				"merge revocation backoff check failed",
+				"issue_id", strings.TrimSpace(issue.ID),
+				"identifier", issue.Identifier,
+				"error", err,
+			)
+		}
+		return false, false
+	}
+	if streak.count < maxIdenticalMergeRevocations {
+		return false, false
+	}
+
+	decision := autoPromoteDecision(AutoPromoteActionSkip, AutoPromoteReasonMergeRevocationLimit)
+	if err := o.updateIssueStateByIDStrictWithMetadata(
+		ctx,
+		state,
+		issue.ID,
+		issue,
+		blockedStatusState,
+		now,
+		string(AutoPromoteReasonMergeRevocationLimit),
+		workflowLaneMetadata{},
+	); err != nil {
+		if o.logger != nil {
+			o.logger.Warn(
+				"merge revocation backoff park failed",
+				"issue_id", strings.TrimSpace(issue.ID),
+				"identifier", issue.Identifier,
+				"revocation_reason", streak.reason,
+				"consecutive_revocations", streak.count,
+				"limit", maxIdenticalMergeRevocations,
+				"error", err,
+			)
+		}
+		o.logAutoPromoteDecision(issue, decision, "")
+		return true, false
+	}
+
+	if err := o.connector.CreateComment(ctx, issue.ID, mergeRevocationLimitComment(issue, streak)); err != nil && o.logger != nil {
+		o.logger.Warn(
+			"merge revocation backoff comment failed",
+			"issue_id", strings.TrimSpace(issue.ID),
+			"identifier", issue.Identifier,
+			"error", err,
+		)
+	}
+	o.logAutoPromoteDecision(issue, decision, blockedStatusState)
+	if o.logger != nil {
+		o.logger.Warn(
+			"merge_worker_revocation_limit",
+			mergeWorkerLogAttrs(issue,
+				"revocation_reason", streak.reason,
+				"consecutive_revocations", streak.count,
+				"limit", maxIdenticalMergeRevocations,
+				"target_state", blockedStatusState,
+			)...,
+		)
+	}
+	recordStateEvent(state, telemetry.ActivityEvent{
+		At:      now,
+		Event:   "merge_worker_revocation_limit",
+		Message: fmt.Sprintf("parked %s after %d consecutive %s merge revocations", issueLabel(issue), streak.count, streak.reason),
+	})
+	return true, true
+}
+
+func (o *Orchestrator) consecutiveMergeRevocations(
+	ctx context.Context,
+	state *State,
+	issue connector.Issue,
+) (mergeRevocationStreak, error) {
+	if o != nil && o.workAttempts != nil {
+		attempts, err := o.workAttempts.ListRecentTerminalWorkAttempts(ctx, store.WorkAttemptHistoryQuery{
+			ProjectID:  strings.TrimSpace(o.cfg.Project.ID),
+			IssueID:    strings.TrimSpace(issue.ID),
+			Identifier: strings.TrimSpace(issue.Identifier),
+			IssueURL:   strings.TrimSpace(issue.URL),
+			WorkerType: "merge",
+			Limit:      maxIdenticalMergeRevocations + 1,
+		})
+		if err != nil {
+			return mergeRevocationStreak{}, err
+		}
+		return mergeRevocationStreakFromAttempts(attempts, pullRequestNumber(issue)), nil
+	}
+	return mergeRevocationStreakFromSnapshots(state, issue), nil
+}
+
+func mergeRevocationStreakFromAttempts(attempts []store.WorkAttempt, currentPRNumber int) mergeRevocationStreak {
+	streak := mergeRevocationStreak{}
+	for _, attempt := range attempts {
+		if attempt.TerminalState != store.WorkAttemptTerminalMergeRevoked {
+			break
+		}
+		reason := strings.TrimSpace(attempt.ErrorMessage)
+		if reason == "" || streak.reason != "" && reason != streak.reason {
+			break
+		}
+		if currentPRNumber > 0 && attempt.PRNumber != nil && *attempt.PRNumber > 0 && int(*attempt.PRNumber) != currentPRNumber {
+			break
+		}
+		if streak.reason == "" {
+			streak.reason = reason
+		}
+		streak.count++
+	}
+	return streak
+}
+
+func mergeRevocationStreakFromSnapshots(state *State, issue connector.Issue) mergeRevocationStreak {
+	if state == nil {
+		return mergeRevocationStreak{}
+	}
+	streak := mergeRevocationStreak{}
+	currentPRNumber := pullRequestNumber(issue)
+	for _, attempt := range state.WorkAttempts {
+		if strings.TrimSpace(attempt.IssueID) != strings.TrimSpace(issue.ID) {
+			continue
+		}
+		if attempt.TerminalState != string(store.WorkAttemptTerminalMergeRevoked) {
+			break
+		}
+		reason := strings.TrimSpace(attempt.ErrorMessage)
+		if reason == "" || streak.reason != "" && reason != streak.reason {
+			break
+		}
+		if currentPRNumber > 0 && attempt.PRNumber != nil && *attempt.PRNumber > 0 && int(*attempt.PRNumber) != currentPRNumber {
+			break
+		}
+		if streak.reason == "" {
+			streak.reason = reason
+		}
+		streak.count++
+	}
+	return streak
+}
+
+func mergeRevocationLimitComment(issue connector.Issue, streak mergeRevocationStreak) string {
+	var body strings.Builder
+	body.WriteString("Detent parked this issue in Blocked after repeated identical merge eligibility revocations.")
+	body.WriteString("\n\n- reason: ")
+	body.WriteString(string(AutoPromoteReasonMergeRevocationLimit))
+	body.WriteString("\n- revocation_reason: ")
+	body.WriteString(streak.reason)
+	body.WriteString("\n- consecutive_revocations: ")
+	body.WriteString(strconv.Itoa(streak.count))
+	body.WriteString("\n- limit: ")
+	body.WriteString(strconv.Itoa(maxIdenticalMergeRevocations))
+	if issue.PullRequest != nil {
+		if url := strings.TrimSpace(issue.PullRequest.URL); url != "" {
+			body.WriteString("\n- pull_request: ")
+			body.WriteString(url)
+		}
+	}
+	body.WriteString("\n- human_action: correct the repeated merge eligibility failure, then move the issue to Rework")
+	return body.String()
 }
 
 func (o *Orchestrator) routeMergeRevocation(ctx context.Context, state *State, revocation *mergeRevocation, at time.Time) {

--- a/internal/orchestrator/merge_revocation.go
+++ b/internal/orchestrator/merge_revocation.go
@@ -405,7 +405,6 @@ func (o *Orchestrator) consecutiveMergeRevocations(
 			IssueID:    strings.TrimSpace(issue.ID),
 			Identifier: strings.TrimSpace(issue.Identifier),
 			IssueURL:   strings.TrimSpace(issue.URL),
-			WorkerType: "merge",
 			Limit:      maxIdenticalMergeRevocations + 1,
 		})
 		if err != nil {

--- a/internal/orchestrator/merge_revocation_test.go
+++ b/internal/orchestrator/merge_revocation_test.go
@@ -490,9 +490,9 @@ func TestAutoPromoteParksIssueAfterRepeatedIdenticalMergeRevocations(t *testing.
 		}
 	}
 	if len(attempts.historyQueries) != 1 ||
-		attempts.historyQueries[0].WorkerType != "merge" ||
+		attempts.historyQueries[0].WorkerType != "" ||
 		attempts.historyQueries[0].Limit != maxIdenticalMergeRevocations+1 {
-		t.Fatalf("history queries = %#v, want bounded revocation lookup", attempts.historyQueries)
+		t.Fatalf("history queries = %#v, want bounded all-worker lookup", attempts.historyQueries)
 	}
 }
 

--- a/internal/orchestrator/merge_revocation_test.go
+++ b/internal/orchestrator/merge_revocation_test.go
@@ -408,3 +408,146 @@ func (c *mergeRevocationCommentConnector) SetAssignee(context.Context, string, s
 func (c *mergeRevocationCommentConnector) SetField(context.Context, string, string, string) error {
 	return nil
 }
+
+func TestAutoPromoteParksIssueAfterRepeatedIdenticalMergeRevocations(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 7, 29, 14, 0, 0, 0, time.UTC)
+	issue := autoPromoteTickIssue("issue-repeated-draft-revocation", []string{"bug"}, &connector.PullRequest{
+		Number:         45,
+		URL:            "https://github.test/digitaldrywood/video-studio/pull/45",
+		State:          "OPEN",
+		Draft:          true,
+		MergeableState: "clean",
+		CIStatus:       "success",
+	})
+	issue.Identifier = "digitaldrywood/video-studio#41"
+	prNumber := int64(45)
+	attempts := &recordingWorkAttemptStore{}
+	for index := range maxIdenticalMergeRevocations {
+		attempts.history = append(attempts.history, store.WorkAttempt{
+			ID:            int64(maxIdenticalMergeRevocations - index),
+			IssueID:       issue.ID,
+			Identifier:    issue.Identifier,
+			PRNumber:      &prNumber,
+			WorkerType:    "agent",
+			TerminalState: store.WorkAttemptTerminalMergeRevoked,
+			ErrorMessage:  mergeRevocationDraftPullRequest,
+			CompletedAt:   now.Add(-time.Duration(index+1) * time.Minute),
+		})
+	}
+	cfg := normalizeConfig(Config{
+		Project: scheduler.ProjectCandidate{ID: "video-studio"},
+		AutoPromote: AutoPromoteConfig{
+			Enabled: true,
+		},
+		ActiveStates:   []string{"Todo", "In Progress", "Rework", "Merging"},
+		TerminalStates: []string{"Done", "Cancelled"},
+	})
+	tracker := &autoPromoteTickConnector{stateIssues: []connector.Issue{issue}}
+	var logs strings.Builder
+	orch := &Orchestrator{
+		cfg:          cfg,
+		connector:    tracker,
+		workAttempts: attempts,
+		logger:       slog.New(slog.NewTextHandler(&logs, nil)),
+	}
+	state := newState(cfg)
+
+	result := orch.autoPromoteHumanReviewIssues(t.Context(), &state, []connector.Issue{issue}, now)
+
+	if _, ok := result.transitioned[issue.ID]; !ok {
+		t.Fatalf("transitioned = %#v, want %q parked", result.transitioned, issue.ID)
+	}
+	if len(result.dispatchCandidates) != 0 {
+		t.Fatalf("dispatch candidates = %#v, want none", result.dispatchCandidates)
+	}
+	if len(tracker.updates) != 1 || tracker.updates[0] != (autoPromoteTickUpdate{issueID: issue.ID, state: blockedStatusState}) {
+		t.Fatalf("updates = %#v, want Blocked transition", tracker.updates)
+	}
+	if len(tracker.comments) != 1 {
+		t.Fatalf("comments = %#v, want one parking comment", tracker.comments)
+	}
+	for _, fragment := range []string{
+		"reason: merge_revocation_limit",
+		"revocation_reason: draft_pull_request",
+		"consecutive_revocations: 3",
+		"human_action:",
+	} {
+		if !strings.Contains(tracker.comments[0].body, fragment) {
+			t.Fatalf("comment = %q, missing %q", tracker.comments[0].body, fragment)
+		}
+	}
+	for _, fragment := range []string{
+		"auto promote decision",
+		"action=skip",
+		"reason=merge_revocation_limit",
+		"merge_worker_revocation_limit",
+		"revocation_reason=draft_pull_request",
+	} {
+		if !strings.Contains(logs.String(), fragment) {
+			t.Fatalf("logs = %q, missing %q", logs.String(), fragment)
+		}
+	}
+	if len(attempts.historyQueries) != 1 ||
+		attempts.historyQueries[0].WorkerType != "merge" ||
+		attempts.historyQueries[0].Limit != maxIdenticalMergeRevocations+1 {
+		t.Fatalf("history queries = %#v, want bounded revocation lookup", attempts.historyQueries)
+	}
+}
+
+func TestMergeRevocationStreakStopsAtDifferentOutcomeOrReason(t *testing.T) {
+	t.Parallel()
+
+	prNumber := int64(45)
+	revoked := func(reason string) store.WorkAttempt {
+		return store.WorkAttempt{
+			PRNumber:      &prNumber,
+			TerminalState: store.WorkAttemptTerminalMergeRevoked,
+			ErrorMessage:  reason,
+		}
+	}
+	tests := []struct {
+		name     string
+		attempts []store.WorkAttempt
+		want     mergeRevocationStreak
+	}{
+		{
+			name: "identical revocations count consecutively",
+			attempts: []store.WorkAttempt{
+				revoked(mergeRevocationDraftPullRequest),
+				revoked(mergeRevocationDraftPullRequest),
+			},
+			want: mergeRevocationStreak{reason: mergeRevocationDraftPullRequest, count: 2},
+		},
+		{
+			name: "different reason ends streak",
+			attempts: []store.WorkAttempt{
+				revoked(mergeRevocationDraftPullRequest),
+				revoked(mergeRevocationCITriggerLabelRemoved),
+				revoked(mergeRevocationDraftPullRequest),
+			},
+			want: mergeRevocationStreak{reason: mergeRevocationDraftPullRequest, count: 1},
+		},
+		{
+			name: "successful attempt ends streak",
+			attempts: []store.WorkAttempt{
+				revoked(mergeRevocationDraftPullRequest),
+				{PRNumber: &prNumber, TerminalState: store.WorkAttemptTerminalSuccess},
+				revoked(mergeRevocationDraftPullRequest),
+			},
+			want: mergeRevocationStreak{reason: mergeRevocationDraftPullRequest, count: 1},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := mergeRevocationStreakFromAttempts(tt.attempts, int(prNumber))
+			if got != tt.want {
+				t.Fatalf("mergeRevocationStreakFromAttempts() = %#v, want %#v", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/orchestrator/merge_timing.go
+++ b/internal/orchestrator/merge_timing.go
@@ -6,7 +6,19 @@ import (
 	"time"
 
 	"github.com/digitaldrywood/detent/internal/connector"
+	"github.com/digitaldrywood/detent/internal/telemetry"
 )
+
+const (
+	mergeSlotConcentrationWindow       = 15 * time.Minute
+	mergeSlotConcentrationMinimumCount = 5
+	mergeSlotConcentrationPercent      = 80
+)
+
+type mergeSlotAcquisition struct {
+	issueID string
+	at      time.Time
+}
 
 func (o *Orchestrator) recordMergeQueueEntries(state *State, issues []connector.Issue, now time.Time, source string) {
 	for _, issue := range issuesInStates(issues, []string{autoPromoteMergingState}) {
@@ -44,13 +56,81 @@ func (o *Orchestrator) markMergeWorkerSlotAcquired(state *State, issue connector
 		return MergeTiming{}
 	}
 	timing := o.recordMergeQueueEntered(state, issue, now, "dispatch")
+	slotAlreadyAcquired := !timing.MergeWorkerSlotAcquiredAt.IsZero() &&
+		timing.MergedAt.IsZero() &&
+		timing.MergeFailedAt.IsZero()
 	timing.MergeWorkerSlotAcquiredAt = now.UTC()
 	timing.MergedAt = time.Time{}
 	timing.MergeFailedAt = time.Time{}
 	timing.MergeFailureReason = ""
 	timing = timing.withDurations(now)
 	state.MergeTimings[strings.TrimSpace(issue.ID)] = timing
+	if !slotAlreadyAcquired {
+		o.observeMergeSlotConcentration(state, issue, now)
+	}
 	return timing
+}
+
+func (o *Orchestrator) observeMergeSlotConcentration(state *State, issue connector.Issue, now time.Time) {
+	if state == nil {
+		return
+	}
+	issueID := strings.TrimSpace(issue.ID)
+	if issueID == "" {
+		return
+	}
+	cutoff := now.Add(-mergeSlotConcentrationWindow)
+	recent := state.mergeSlotAcquisitions[:0]
+	for _, acquisition := range state.mergeSlotAcquisitions {
+		if acquisition.at.Before(cutoff) {
+			continue
+		}
+		recent = append(recent, acquisition)
+	}
+	recent = append(recent, mergeSlotAcquisition{issueID: issueID, at: now.UTC()})
+	state.mergeSlotAcquisitions = recent
+	if len(recent) < mergeSlotConcentrationMinimumCount {
+		return
+	}
+
+	issueCount := 0
+	for _, acquisition := range recent {
+		if acquisition.issueID == issueID {
+			issueCount++
+		}
+	}
+	if issueCount*100 < len(recent)*mergeSlotConcentrationPercent {
+		return
+	}
+	if state.mergeSlotWarnings == nil {
+		state.mergeSlotWarnings = map[string]time.Time{}
+	}
+	for warnedIssueID, warnedAt := range state.mergeSlotWarnings {
+		if warnedAt.Before(cutoff) {
+			delete(state.mergeSlotWarnings, warnedIssueID)
+		}
+	}
+	if warnedAt := state.mergeSlotWarnings[issueID]; !warnedAt.IsZero() && now.Before(warnedAt.Add(mergeSlotConcentrationWindow)) {
+		return
+	}
+	state.mergeSlotWarnings[issueID] = now.UTC()
+	if o.logger != nil {
+		o.logger.Warn(
+			"merge_worker_slot_concentration",
+			mergeWorkerLogAttrs(issue,
+				"project_id", strings.TrimSpace(o.cfg.Project.ID),
+				"window", mergeSlotConcentrationWindow,
+				"issue_acquisitions", issueCount,
+				"total_acquisitions", len(recent),
+				"share_percent", issueCount*100/len(recent),
+			)...,
+		)
+	}
+	recordStateEvent(state, telemetry.ActivityEvent{
+		At:      now,
+		Event:   "merge_worker_slot_concentration",
+		Message: "one issue acquired a disproportionate share of merge slots: " + issueLabel(issue),
+	})
 }
 
 func (o *Orchestrator) markMergeStarted(state *State, issue connector.Issue, now time.Time) MergeTiming {

--- a/internal/orchestrator/merge_timing_test.go
+++ b/internal/orchestrator/merge_timing_test.go
@@ -1,6 +1,8 @@
 package orchestrator
 
 import (
+	"log/slog"
+	"strings"
 	"testing"
 	"time"
 
@@ -46,5 +48,49 @@ func TestRecordMergeQueueEnteredResetsTerminalAttempt(t *testing.T) {
 	}
 	if got.QueueWaitSeconds != int64((2*time.Minute)/time.Second) || got.ActiveMergeDurationSeconds != 0 || got.TotalMergingSeconds != int64((2*time.Minute)/time.Second) {
 		t.Fatalf("durations = queue %d active %d total %d, want 120/0/120", got.QueueWaitSeconds, got.ActiveMergeDurationSeconds, got.TotalMergingSeconds)
+	}
+}
+
+func TestObserveMergeSlotConcentrationWarnsOncePerWindow(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 7, 29, 15, 0, 0, 0, time.UTC)
+	issue := connector.Issue{
+		ID:         "issue-slot-monopoly",
+		Identifier: "digitaldrywood/video-studio#41",
+		State:      "Merging",
+		PullRequest: &connector.PullRequest{
+			Number: 45,
+			State:  "OPEN",
+		},
+	}
+	cfg := normalizeConfig(Config{})
+	var logs strings.Builder
+	orch := &Orchestrator{
+		cfg:    cfg,
+		logger: slog.New(slog.NewTextHandler(&logs, nil)),
+	}
+	state := newState(cfg)
+
+	for index := range mergeSlotConcentrationMinimumCount + 1 {
+		orch.observeMergeSlotConcentration(&state, issue, now.Add(time.Duration(index)*time.Minute))
+	}
+
+	logText := logs.String()
+	if count := strings.Count(logText, "merge_worker_slot_concentration"); count != 1 {
+		t.Fatalf("merge_worker_slot_concentration count = %d, want 1; logs = %q", count, logText)
+	}
+	for _, fragment := range []string{
+		"issue_acquisitions=5",
+		"total_acquisitions=5",
+		"share_percent=100",
+		"pull_request_number=45",
+	} {
+		if !strings.Contains(logText, fragment) {
+			t.Fatalf("logs = %q, missing %q", logText, fragment)
+		}
+	}
+	if len(state.RecentEvents) != 1 || state.RecentEvents[0].Event != "merge_worker_slot_concentration" {
+		t.Fatalf("recent events = %#v, want one concentration warning", state.RecentEvents)
 	}
 }

--- a/internal/orchestrator/state.go
+++ b/internal/orchestrator/state.go
@@ -60,6 +60,8 @@ type State struct {
 	Completed                map[string]Completed
 	Retry                    map[string]Retry
 	MergeTimings             map[string]MergeTiming
+	mergeSlotAcquisitions    []mergeSlotAcquisition
+	mergeSlotWarnings        map[string]time.Time
 	nativeMergeQueueEntries  map[string]nativeMergeQueueEntry
 	nativeMergeQueueRepos    map[string]nativeMergeQueueRepository
 	nativeMergeQueueDeferred map[string]struct{}
@@ -264,6 +266,7 @@ func newState(cfg Config) State {
 		Completed:                map[string]Completed{},
 		Retry:                    map[string]Retry{},
 		MergeTimings:             map[string]MergeTiming{},
+		mergeSlotWarnings:        map[string]time.Time{},
 		nativeMergeQueueEntries:  map[string]nativeMergeQueueEntry{},
 		nativeMergeQueueRepos:    map[string]nativeMergeQueueRepository{},
 		nativeMergeQueueDeferred: map[string]struct{}{},
@@ -326,6 +329,8 @@ func (s State) clone() State {
 		Completed:                make(map[string]Completed, len(s.Completed)),
 		Retry:                    make(map[string]Retry, len(s.Retry)),
 		MergeTimings:             maps.Clone(s.MergeTimings),
+		mergeSlotAcquisitions:    append([]mergeSlotAcquisition(nil), s.mergeSlotAcquisitions...),
+		mergeSlotWarnings:        maps.Clone(s.mergeSlotWarnings),
 		nativeMergeQueueEntries:  cloneNativeMergeQueueEntries(s.nativeMergeQueueEntries),
 		nativeMergeQueueRepos:    maps.Clone(s.nativeMergeQueueRepos),
 		nativeMergeQueueDeferred: maps.Clone(s.nativeMergeQueueDeferred),


### PR DESCRIPTION
## Summary

- reject draft pull requests before auto-promotion and merge-slot acquisition
- park issues after three persisted identical merge revocations
- warn when one issue dominates merge-slot acquisitions in a 15-minute window
- preserve and regression-test existing merge-slot wait telemetry

Fixes #1539

## UI Surface Contract

- [x] N/A; this change has no UI surface impact.
- [x] This PR does not add persistent top-of-screen messaging.
- [x] No visual changes are included.

## Test Plan

- [x] `go test ./internal/orchestrator -count=1`
- [x] `make check`