### PR TITLE
fix(shutdown): quiesce dispatch before drain

### DIFF
--- a/internal/cli/shutdown.go
+++ b/internal/cli/shutdown.go
@@ -258,6 +258,20 @@ func runDrainShutdown(
 ) error {
 	startedAt := shutdownNow(cfg)
 	drainTimeout := shutdownDrainTimeoutForConfig(cfg)
+	hardTimeout := cfg.HardTimeout
+	if hardTimeout <= 0 {
+		hardTimeout = defaultShutdownHardTimeout
+	}
+	quiesceCtx, cancelQuiesce := context.WithTimeout(ctx, hardTimeout)
+	err := quiesceProjects(quiesceCtx, cfg.Registry)
+	cancelQuiesce()
+	if err != nil {
+		sessions, _ := cachedShutdownRunningSessions(cfg)
+		machine = machine.Apply(shutdownstate.EventDrainTimedOut)
+		shutdownLogger(cfg).Warn("quiesce projects during shutdown failed", "error", err)
+		logShutdownDrainTimeout(cfg, sessions, drainTimeout)
+		return runForceShutdownWithDeadline(ctx, cfg, cancelServe, serveErrs, machine, "drain timeout", ErrShutdownTimeout, hardTimeout, sessions)
+	}
 	inventoryStarted := logShutdownBoundaryBegin(shutdownLogger(cfg), "initial_running_session_inventory")
 	sessions, inventoryKnown := initialShutdownRunningSessions(ctx, cfg, startedAt)
 	logShutdownBoundaryEndResult(shutdownLogger(cfg), "initial_running_session_inventory", inventoryStarted, shutdownInventoryResult(inventoryKnown), nil, "sessions", len(sessions))
@@ -266,10 +280,6 @@ func runDrainShutdown(
 	writeShutdownBanner(shutdownOutput(cfg), sessions, drainTimeout)
 	shutdownLogger(cfg).Info("shutdown requested", "sessions", len(sessions))
 
-	hardTimeout := cfg.HardTimeout
-	if hardTimeout <= 0 {
-		hardTimeout = defaultShutdownHardTimeout
-	}
 	drainCtx, cancelDrain := context.WithTimeout(ctx, hardTimeout)
 	defer cancelDrain()
 	drainErrs := make(chan error, 1)
@@ -529,6 +539,30 @@ func drainProjects(ctx context.Context, registry *project.Registry, logger *slog
 		}
 		logShutdownBoundaryEnd(logger, "orchestrator_drain", operationStarted, err, "component", "orchestrator", "project_id", trackedProject.ID())
 		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func quiesceProjects(ctx context.Context, registry *project.Registry) error {
+	if registry == nil {
+		return nil
+	}
+	orchestrators := make([]*orchestrator.Orchestrator, 0)
+	for _, trackedProject := range registry.List() {
+		if !trackedProject.Running() {
+			continue
+		}
+		orch := trackedProject.Orchestrator()
+		if orch == nil {
+			continue
+		}
+		orch.BeginDrain()
+		orchestrators = append(orchestrators, orch)
+	}
+	for _, orch := range orchestrators {
+		if err := orch.WaitForDispatchQuiesced(ctx); err != nil {
 			return err
 		}
 	}

--- a/internal/cli/shutdown_test.go
+++ b/internal/cli/shutdown_test.go
@@ -577,6 +577,66 @@ func TestRunWithShutdownActiveChildProcessReportsDrainBlockersAndTimesOut(t *tes
 	}
 }
 
+func TestShutdownRunningSessionsIncludesActiveMergeWorker(t *testing.T) {
+	t.Parallel()
+
+	release := make(chan struct{})
+	runner := &shutdownBlockingRunner{
+		started: make(chan struct{}, 1),
+		release: release,
+	}
+	cfg := workflowconfig.Default()
+	cfg.Tracker.Kind = workflowconfig.TrackerMemory
+	cfg.Tracker.ActiveStates = []string{"Merging"}
+	cfg.Tracker.Issues = []connector.Issue{{
+		ID:               "issue-1546-merge",
+		Identifier:       "digitaldrywood/detent#1546",
+		Title:            "quiesce merge dispatch during shutdown",
+		State:            "Merging",
+		AssignedToWorker: true,
+		PullRequest: &connector.PullRequest{
+			Number:         1546,
+			State:          "OPEN",
+			MergeableState: "clean",
+			CIStatus:       "success",
+		},
+	}}
+	cfg.Polling.IntervalMS = 60000
+	cfg.Agent.MaxConcurrentAgents = 1
+	cfg.Agent.MergeFastPath.Enabled = true
+	project := newShutdownRuntimeProjectWithConfig(t, "detent", cfg, runner)
+	registry := projectpkg.NewRegistry()
+	if err := registry.Set(project); err != nil {
+		t.Fatalf("Registry.Set() error = %v", err)
+	}
+	if err := project.Start(context.Background()); err != nil {
+		t.Fatalf("Project.Start() error = %v", err)
+	}
+	t.Cleanup(func() {
+		close(release)
+		if err := project.Close(); err != nil && !errors.Is(err, projectpkg.ErrNotRunning) {
+			t.Fatalf("Project.Close() error = %v", err)
+		}
+	})
+
+	select {
+	case <-runner.started:
+	case <-time.After(time.Second):
+		t.Fatal("merge worker did not start")
+	}
+
+	sessions := shutdownRunningSessions(context.Background(), registry, time.Now())
+	if len(sessions) != 1 {
+		t.Fatalf("shutdownRunningSessions() = %#v, want one active merge worker", sessions)
+	}
+	if sessions[0].ID != "issue-1546-merge" || sessions[0].State != "Merging" {
+		t.Fatalf("active merge blocker = %#v, want issue-1546-merge in Merging", sessions[0])
+	}
+	if summary := shutdownSessionSummary(sessions[0]); !strings.Contains(summary, "digitaldrywood/detent#1546") {
+		t.Fatalf("shutdownSessionSummary() = %q, want named merge blocker", summary)
+	}
+}
+
 func TestRunWithShutdownDoesNotTrustStaleEmptySnapshotOverLiveSession(t *testing.T) {
 	t.Parallel()
 

--- a/internal/orchestrator/autopromote_tick.go
+++ b/internal/orchestrator/autopromote_tick.go
@@ -881,6 +881,10 @@ func (o *Orchestrator) logStaleMergingPullRequestDeferred(issue connector.Issue,
 }
 
 func (o *Orchestrator) logMergeWorkerPickup(issue connector.Issue, source string) {
+	if !o.beginDispatchStart() {
+		return
+	}
+	defer o.finishDispatchStart()
 	if o.logger == nil || !mergeWorkerIssue(issue) {
 		return
 	}
@@ -1206,6 +1210,9 @@ func mergeWorkerRepositoryKey(issue connector.Issue) string {
 }
 
 func (o *Orchestrator) mergeWorkerDispatchCandidates(state *State, issues []connector.Issue) []connector.Issue {
+	if o.dispatchQuiesced() {
+		return nil
+	}
 	o.logMergeWorkerQueueCycle(issues)
 	candidates := o.staleMergingQueueDispatchCandidates(state, issues)
 	if len(candidates) == 0 {

--- a/internal/orchestrator/dispatch.go
+++ b/internal/orchestrator/dispatch.go
@@ -127,7 +127,7 @@ func normalizeWorkerHosts(hosts []string) []string {
 func (o *Orchestrator) dispatchReadyIssues(ctx context.Context, state *State, issues []connector.Issue, now time.Time) {
 	o.beginGlobalProjectCycle()
 	defer o.endGlobalProjectCycle()
-	if state.Draining {
+	if state.Draining || o.dispatchQuiesced() {
 		return
 	}
 	o.observePullRequestHydrationRecovery(state, issues, now)
@@ -200,7 +200,7 @@ func (o *Orchestrator) hydrateDispatchIssue(ctx context.Context, issue connector
 func (o *Orchestrator) dispatchCandidates(ctx context.Context, state *State, issues []connector.Issue, now time.Time) {
 	o.beginGlobalProjectCycle()
 	defer o.endGlobalProjectCycle()
-	if state.Draining {
+	if state.Draining || o.dispatchQuiesced() {
 		return
 	}
 	for _, issue := range issues {
@@ -234,6 +234,7 @@ func (o *Orchestrator) dispatchable(issue connector.Issue, state *State, now tim
 }
 
 const (
+	dispatchIssueFailureDraining              = "dispatch_draining"
 	dispatchIssueFailureLocalSlotUnavailable  = "local_slot_unavailable"
 	dispatchIssueFailureWorkerHostUnavailable = "worker_host_unavailable"
 	dispatchIssueFailureGlobalSlotUnavailable = "global_slot_unavailable"
@@ -269,6 +270,13 @@ func (o *Orchestrator) dispatchIssueWithOutcome(
 	now time.Time,
 	preferredWorkerHost string,
 ) dispatchIssueOutcome {
+	if !o.beginDispatchStart() {
+		return dispatchIssueOutcome{reason: dispatchIssueFailureDraining}
+	}
+	defer o.finishDispatchStart()
+	if state.Draining {
+		return dispatchIssueOutcome{reason: dispatchIssueFailureDraining}
+	}
 	if _, paused := activeGitHubRESTCapacityOutage(state, now); paused {
 		return dispatchIssueOutcome{reason: dispatchIssueFailureGitHubRESTPaused}
 	}

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -213,6 +213,11 @@ type Orchestrator struct {
 	heartbeats              *heartbeatManager
 	hydrationSkipStreaks    map[string]int
 	hydrationWarned         bool
+	dispatchStartMu         sync.Mutex
+	dispatchStarts          int
+	dispatchStartsDone      chan struct{}
+	dispatchClosed          atomic.Bool
+	projectID               string
 	dispatchGateSampleMu    sync.Mutex
 	dispatchGateSamples     map[dispatchGateSampleKey]time.Time
 	ciTriggerLabelMu        sync.Mutex
@@ -439,6 +444,7 @@ func New(cfg Config, deps Dependencies) (*Orchestrator, error) {
 		workerProcesses:         workerProcesses,
 		reapWorkerProcess:       reapWorkerProcess,
 		workerReapGrace:         workerReapGrace,
+		projectID:               cfg.Project.ID,
 		capacityController:      capacityController,
 		capacityStatus:          capacityStatus,
 		validatorCapacity:       validatorCapacity,
@@ -678,6 +684,10 @@ func (o *Orchestrator) Drain(ctx context.Context) error {
 	if ctx == nil {
 		ctx = context.Background()
 	}
+	o.BeginDrain()
+	if err := o.WaitForDispatchQuiesced(ctx); err != nil {
+		return err
+	}
 
 	request := drainRequest{
 		at:    time.Now().UTC(),
@@ -705,6 +715,10 @@ func (o *Orchestrator) ForceQuit(ctx context.Context) error {
 	if ctx == nil {
 		ctx = context.Background()
 	}
+	o.BeginDrain()
+	if err := o.WaitForDispatchQuiesced(ctx); err != nil {
+		return err
+	}
 
 	request := forceRequest{
 		ctx:   ctx,
@@ -727,6 +741,75 @@ func (o *Orchestrator) ForceQuit(ctx context.Context) error {
 	case err := <-request.reply:
 		return err
 	}
+}
+
+func (o *Orchestrator) BeginDrain() {
+	if o == nil {
+		return
+	}
+
+	o.dispatchStartMu.Lock()
+	if o.dispatchClosed.Swap(true) {
+		o.dispatchStartMu.Unlock()
+		return
+	}
+	o.dispatchStartMu.Unlock()
+	if gate, ok := o.globalDispatchGate.(interface{ PauseDispatch() func() }); ok {
+		gate.PauseDispatch()
+	}
+	if o.globalDispatchGate != nil {
+		o.globalDispatchGate.MarkIdle(o.projectID)
+	}
+}
+
+func (o *Orchestrator) WaitForDispatchQuiesced(ctx context.Context) error {
+	if o == nil {
+		return nil
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
+	o.dispatchStartMu.Lock()
+	done := o.dispatchStartsDone
+	o.dispatchStartMu.Unlock()
+	if done == nil {
+		return nil
+	}
+
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-done:
+		return nil
+	}
+}
+
+func (o *Orchestrator) beginDispatchStart() bool {
+	o.dispatchStartMu.Lock()
+	defer o.dispatchStartMu.Unlock()
+	if o.dispatchQuiesced() {
+		return false
+	}
+	if o.dispatchStarts == 0 {
+		o.dispatchStartsDone = make(chan struct{})
+	}
+	o.dispatchStarts++
+	return true
+}
+
+func (o *Orchestrator) finishDispatchStart() {
+	o.dispatchStartMu.Lock()
+	defer o.dispatchStartMu.Unlock()
+	o.dispatchStarts--
+	if o.dispatchStarts == 0 {
+		close(o.dispatchStartsDone)
+		o.dispatchStartsDone = nil
+	}
+}
+
+func (o *Orchestrator) dispatchQuiesced() bool {
+	return o == nil || o.dispatchClosed.Load()
 }
 
 func (o *Orchestrator) applyRuntimeUpdate(state *State, update RuntimeUpdate, ticker *time.Ticker) {

--- a/internal/orchestrator/orchestrator_test.go
+++ b/internal/orchestrator/orchestrator_test.go
@@ -740,6 +740,159 @@ func TestDrainStopsDispatchAndLetsRunningSessionFinish(t *testing.T) {
 	}
 }
 
+func TestBeginDrainStopsPendingDispatchTick(t *testing.T) {
+	t.Parallel()
+
+	issue := testIssue("issue-pending-shutdown", "digitaldrywood/detent#1546", "Merging")
+	issue.PullRequest = &connector.PullRequest{
+		Number:         1546,
+		URL:            "https://github.test/digitaldrywood/detent/pull/1546",
+		State:          "OPEN",
+		MergeableState: "clean",
+		CIStatus:       "success",
+	}
+	issue.PRRepository = "digitaldrywood/detent"
+	tracker := &pendingDispatchConnector{
+		fakeConnector: newFakeConnector(issue),
+		started:       make(chan struct{}),
+		release:       make(chan struct{}),
+	}
+	tracker.stateIssues = []connector.Issue{issue}
+	runner := newBlockingRunner()
+	var logs bytes.Buffer
+
+	orch, err := orchestrator.New(orchestrator.Config{
+		PollInterval:         time.Hour,
+		MergeFastPathEnabled: true,
+		MaxConcurrentAgents:  1,
+		MaxConcurrentAgentsByState: map[string]int{
+			"Merging": 1,
+		},
+		ActiveStates:           []string{"Merging"},
+		ObservedStates:         []string{"Merging"},
+		TerminalStates:         []string{"Done", "Cancelled"},
+		ContinuationRetryDelay: time.Second,
+	}, orchestrator.Dependencies{
+		Connector: tracker,
+		Runner:    runner,
+		Logger:    slog.New(slog.NewTextHandler(&logs, nil)),
+	})
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	stop := runOrchestrator(t, orch)
+	defer stop()
+
+	select {
+	case <-tracker.started:
+	case <-time.After(time.Second):
+		t.Fatal("dispatch tick did not reach pending tracker fetch")
+	}
+
+	orch.BeginDrain()
+	close(tracker.release)
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	if err := orch.Drain(ctx); err != nil {
+		t.Fatalf("Drain() error = %v", err)
+	}
+
+	state, err := orch.State(ctx)
+	if err != nil {
+		t.Fatalf("State() error = %v", err)
+	}
+	if !state.Draining {
+		t.Fatal("State().Draining = false, want true")
+	}
+	if len(state.Running) != 0 {
+		t.Fatalf("State().Running = %#v, want no work started", state.Running)
+	}
+	select {
+	case request := <-runner.started:
+		t.Fatalf("unexpected dispatch after drain began = %#v", request)
+	default:
+	}
+	for _, event := range []string{"merge_worker_pickup", "merge_worker_slot_acquired"} {
+		if strings.Contains(logs.String(), event) {
+			t.Fatalf("logs contain %q after drain began:\n%s", event, logs.String())
+		}
+	}
+}
+
+func TestWaitForDispatchQuiescedHonorsContext(t *testing.T) {
+	t.Parallel()
+
+	issue := testIssue("issue-starting-shutdown", "digitaldrywood/detent#1546", "Todo")
+	tracker := &dispatchStartBlockingConnector{
+		fakeConnector: newFakeConnector(issue),
+		started:       make(chan struct{}),
+		release:       make(chan struct{}),
+	}
+	runner := newBlockingRunner()
+	orch, err := orchestrator.New(orchestrator.Config{
+		PollInterval:        time.Hour,
+		MaxConcurrentAgents: 1,
+		Claiming: orchestrator.ClaimingConfig{
+			Enabled:           true,
+			OwnershipMode:     workflowconfig.IdentityOwnershipField,
+			Owner:             "detent-test",
+			OwnerField:        "Owner",
+			LeaseField:        "Lease",
+			LeaseTTL:          time.Minute,
+			HeartbeatInterval: time.Hour,
+		},
+		ActiveStates:   []string{"Todo"},
+		TerminalStates: []string{"Done", "Cancelled"},
+	}, orchestrator.Dependencies{
+		Connector: tracker,
+		Runner:    runner,
+	})
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	stop := runOrchestrator(t, orch)
+	defer stop()
+
+	select {
+	case <-tracker.started:
+	case <-time.After(time.Second):
+		t.Fatal("dispatch startup did not reach blocking connector")
+	}
+
+	beginDone := make(chan struct{})
+	go func() {
+		orch.BeginDrain()
+		close(beginDone)
+	}()
+	select {
+	case <-beginDone:
+	case <-time.After(time.Second):
+		close(tracker.release)
+		t.Fatal("BeginDrain blocked on active dispatch startup")
+	}
+
+	waitCtx, cancelWait := context.WithCancel(context.Background())
+	cancelWait()
+	if err := orch.WaitForDispatchQuiesced(waitCtx); !errors.Is(err, context.Canceled) {
+		t.Fatalf("WaitForDispatchQuiesced() error = %v, want context canceled", err)
+	}
+
+	close(tracker.release)
+	settleCtx, cancelSettle := context.WithTimeout(context.Background(), time.Second)
+	defer cancelSettle()
+	if err := orch.WaitForDispatchQuiesced(settleCtx); err != nil {
+		t.Fatalf("WaitForDispatchQuiesced() after release error = %v", err)
+	}
+
+	select {
+	case <-runner.started:
+	case <-time.After(time.Second):
+		t.Fatal("admitted dispatch did not become visible after startup resumed")
+	}
+	close(runner.release)
+}
+
 func TestForceQuitInterruptsRunningSessionAndAbandonsClaim(t *testing.T) {
 	t.Parallel()
 
@@ -2686,6 +2839,44 @@ type fakeConnector struct {
 	fetchCandidateErrAt int
 	fetchByStatesErr    error
 	statusLabelPrefix   string
+}
+
+type pendingDispatchConnector struct {
+	*fakeConnector
+	started chan struct{}
+	release chan struct{}
+	once    sync.Once
+}
+
+type dispatchStartBlockingConnector struct {
+	*fakeConnector
+	started chan struct{}
+	release chan struct{}
+	once    sync.Once
+}
+
+func (c *dispatchStartBlockingConnector) SetField(ctx context.Context, issueID string, field string, value string) error {
+	c.once.Do(func() {
+		close(c.started)
+	})
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-c.release:
+		return c.fakeConnector.SetField(ctx, issueID, field, value)
+	}
+}
+
+func (c *pendingDispatchConnector) FetchCandidateIssues(ctx context.Context) ([]connector.Issue, error) {
+	c.once.Do(func() {
+		close(c.started)
+	})
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	case <-c.release:
+		return c.fakeConnector.FetchCandidateIssues(ctx)
+	}
 }
 
 type operatorMoveConnector struct {

--- a/internal/orchestrator/tick.go
+++ b/internal/orchestrator/tick.go
@@ -101,7 +101,7 @@ func (o *Orchestrator) tickWithManual(ctx context.Context, state *State, now tim
 	o.evaluateRelease(ctx, state, now)
 	timing.next("active_runs")
 	o.refreshActiveRuns(ctx, state, now, reserve)
-	if state.Draining {
+	if state.Draining || o.dispatchQuiesced() {
 		return
 	}
 	timing.next("tracker_fetch")


### PR DESCRIPTION
## Summary

- close each orchestrator dispatch path before shutdown inventories running sessions
- track admitted dispatch startup so zero sessions means no work is active or still becoming visible
- bound startup quiescence by the shutdown context and keep the shared dispatch gate closed after drain failures
- report active merge workers as named blockers and avoid caller-side config races during teardown

Fixes #1546

## UI Surface Contract

- [x] N/A; this PR does not change UI surfaces, layout, density, first-viewport, or responsive visibility.
- [x] This PR does not add persistent top-of-screen messaging.
- [x] N/A; this PR has no visual changes to primary operator screens.

## Test Plan

- [x] `go test -race ./internal/orchestrator ./internal/cli -run 'Test(BeginDrainStopsPendingDispatchTick|WaitForDispatchQuiescedHonorsContext|ShutdownRunningSessionsIncludesActiveMergeWorker|DrainStopsDispatchAndLetsRunningSessionFinish)$'`
- [x] `make check`
