### PR TITLE
fix(merge): bound worker wall-clock lifetime

### DIFF
--- a/README.md
+++ b/README.md
@@ -699,6 +699,7 @@ agent:
   max_turns: 20
   max_turn_duration_ms: 0
   max_session_duration_ms: 0
+  merge_worker_max_duration_ms: 21600000
   max_retry_backoff_ms: 300000
   overload_retry_delay_ms: 45000
   no_progress_spend_limit_usd: 3
@@ -2794,6 +2795,13 @@ are configured, the shorter applicable deadline wins. Both values default to
 `0`, which disables that total-duration bound. These deadlines cancel the
 worker through Detent's normal owned process context, so process-tree reaping,
 scratch cleanup, and session completion still run.
+
+`agent.merge_worker_max_duration_ms` is a separate hard wall-clock ceiling for
+the full lifetime of a worker dispatched in `Merging`, starting when Detent
+acquires its slot. It defaults to six hours (`21600000` ms), is not renewed by
+progress, and overrides the disabled general duration defaults for merge work.
+On breach, Detent cancels the owned worker, releases its slot, logs the elapsed
+time and last progress marker at WARN, and parks the issue in `Blocked`.
 
 `agent.max_session_tokens` is an absolute configured ceiling for a session.
 `total_tokens` counts input, output, cache-created, and cache-read tokens,

--- a/docs/templates/detent.github_local.yaml
+++ b/docs/templates/detent.github_local.yaml
@@ -76,6 +76,7 @@ agent:
   # effort:
   #   merge: high
   max_turns: 20
+  merge_worker_max_duration_ms: 21600000
   max_retry_backoff_ms: 300000
   overload_retry_delay_ms: 45000
   no_progress_spend_limit_usd: 3

--- a/docs/templates/detent.issue_field.yaml
+++ b/docs/templates/detent.issue_field.yaml
@@ -77,6 +77,7 @@ agent:
   # effort:
   #   merge: high
   max_turns: 20
+  merge_worker_max_duration_ms: 21600000
   max_retry_backoff_ms: 300000
   overload_retry_delay_ms: 45000
   no_progress_spend_limit_usd: 3

--- a/docs/templates/detent.label.yaml
+++ b/docs/templates/detent.label.yaml
@@ -77,6 +77,7 @@ agent:
   # effort:
   #   merge: high
   max_turns: 20
+  merge_worker_max_duration_ms: 21600000
   max_retry_backoff_ms: 300000
   overload_retry_delay_ms: 45000
   no_progress_spend_limit_usd: 3

--- a/docs/templates/detent.project_v2.yaml
+++ b/docs/templates/detent.project_v2.yaml
@@ -76,6 +76,7 @@ agent:
   # effort:
   #   merge: high
   max_turns: 20
+  merge_worker_max_duration_ms: 21600000
   max_retry_backoff_ms: 300000
   overload_retry_delay_ms: 45000
   no_progress_spend_limit_usd: 3

--- a/internal/cli/doctor_project.go
+++ b/internal/cli/doctor_project.go
@@ -1401,6 +1401,10 @@ func doctorWorkflowSessionGuardDetail(cfg workflowconfig.Config) string {
 	if cfg.Agent.MaxSessionDurationMS > 0 {
 		sessionDuration = strconv.Itoa(cfg.Agent.MaxSessionDurationMS)
 	}
+	mergeDuration := "disabled"
+	if cfg.Agent.MergeWorkerMaxDurationMS > 0 {
+		mergeDuration = strconv.Itoa(cfg.Agent.MergeWorkerMaxDurationMS)
+	}
 	tokens := "disabled"
 	if cfg.Agent.MaxSessionTokens > 0 {
 		tokens = strconv.FormatInt(cfg.Agent.MaxSessionTokens, 10)
@@ -1410,9 +1414,10 @@ func doctorWorkflowSessionGuardDetail(cfg workflowconfig.Config) string {
 		multiplier = strconv.FormatFloat(cfg.Agent.MaxSessionContextMultiplier, 'g', -1, 64)
 	}
 	return fmt.Sprintf(
-		"session-guard=max_turn_duration_ms=%s, max_session_duration_ms=%s, max_session_tokens=%s, max_session_context_multiplier=%s",
+		"session-guard=max_turn_duration_ms=%s, max_session_duration_ms=%s, merge_worker_max_duration_ms=%s, max_session_tokens=%s, max_session_context_multiplier=%s",
 		turnDuration,
 		sessionDuration,
+		mergeDuration,
 		tokens,
 		multiplier,
 	)

--- a/internal/cli/doctor_test.go
+++ b/internal/cli/doctor_test.go
@@ -2694,7 +2694,7 @@ func TestDoctorWorkflowDetailSurfacesIdentityAndAuthorization(t *testing.T) {
 		"WORKFLOW.md is valid",
 		"identity release-captain",
 		"worker-model=provider-default",
-		"session-guard=max_turn_duration_ms=disabled, max_session_duration_ms=disabled, max_session_tokens=disabled, max_session_context_multiplier=disabled",
+		"session-guard=max_turn_duration_ms=disabled, max_session_duration_ms=disabled, merge_worker_max_duration_ms=21600000, max_session_tokens=disabled, max_session_context_multiplier=disabled",
 		"billing-mode=metered",
 		"orphan-recovery=resume_orphaned_sessions=true, experimental_thread_resume=false",
 		"prioritize-unblockers=true",
@@ -2720,11 +2720,12 @@ func TestDoctorWorkflowDetailReportsPinnedModelAndSessionGuard(t *testing.T) {
 	cfg.Agent.MaxSessionContextMultiplier = 4
 	cfg.Agent.MaxTurnDurationMS = 900000
 	cfg.Agent.MaxSessionDurationMS = 3600000
+	cfg.Agent.MergeWorkerMaxDurationMS = 7200000
 
 	got := doctorWorkflowDetail("WORKFLOW.md", globalconfig.Project{}, cfg)
 	for _, want := range []string{
 		"worker-model=pinned gpt-5.5 via agents.routes.model",
-		"session-guard=max_turn_duration_ms=900000, max_session_duration_ms=3600000, max_session_tokens=2000000, max_session_context_multiplier=4",
+		"session-guard=max_turn_duration_ms=900000, max_session_duration_ms=3600000, merge_worker_max_duration_ms=7200000, max_session_tokens=2000000, max_session_context_multiplier=4",
 	} {
 		if !strings.Contains(got, want) {
 			t.Fatalf("doctorWorkflowDetail() = %q, want substring %q", got, want)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -68,6 +68,7 @@ const (
 	DefaultFailureBreakerCooldownSeconds     = 3600
 	DefaultAutoPromoteGateWaitTimeoutSeconds = 3600
 	DefaultOverloadRetryDelayMS              = 45000
+	DefaultMergeWorkerMaxDurationMS          = 6 * 60 * 60 * 1000
 
 	DefaultPollingIntervalMS              = 120000
 	MinPollingIntervalMS                  = 60000
@@ -266,6 +267,7 @@ type Agent struct {
 	MaxTurns                     int                          `yaml:"max_turns"`
 	MaxTurnDurationMS            int                          `yaml:"max_turn_duration_ms"`
 	MaxSessionDurationMS         int                          `yaml:"max_session_duration_ms"`
+	MergeWorkerMaxDurationMS     int                          `yaml:"merge_worker_max_duration_ms"`
 	MaxRetryBackoffMS            int                          `yaml:"max_retry_backoff_ms"`
 	OverloadRetryDelayMS         int                          `yaml:"overload_retry_delay_ms"`
 	NoProgressSpendLimitUSD      float64                      `yaml:"no_progress_spend_limit_usd"`
@@ -1250,13 +1252,14 @@ func Default() Config {
 			SSHHosts: []string{},
 		},
 		Agent: Agent{
-			MaxConcurrentAgents:     10,
-			MaxTurns:                20,
-			MaxRetryBackoffMS:       300000,
-			OverloadRetryDelayMS:    DefaultOverloadRetryDelayMS,
-			NoProgressSpendLimitUSD: DefaultNoProgressSpendLimitUSD,
-			StopRun:                 StopRun{TargetState: "Blocked"},
-			MergeFastPath:           MergeFastPath{Enabled: true},
+			MaxConcurrentAgents:      10,
+			MaxTurns:                 20,
+			MergeWorkerMaxDurationMS: DefaultMergeWorkerMaxDurationMS,
+			MaxRetryBackoffMS:        300000,
+			OverloadRetryDelayMS:     DefaultOverloadRetryDelayMS,
+			NoProgressSpendLimitUSD:  DefaultNoProgressSpendLimitUSD,
+			StopRun:                  StopRun{TargetState: "Blocked"},
+			MergeFastPath:            MergeFastPath{Enabled: true},
 			FailureBreaker: FailureBreaker{
 				SameClassLimit:  DefaultFailureBreakerSameClassLimit,
 				WindowSeconds:   DefaultFailureBreakerWindowSeconds,
@@ -1548,6 +1551,9 @@ func (c *Config) normalize() {
 	}
 
 	c.Agent.MaxConcurrentAgentsByState = normalizeStateLimits(c.Agent.MaxConcurrentAgentsByState)
+	if c.Agent.MergeWorkerMaxDurationMS == 0 {
+		c.Agent.MergeWorkerMaxDurationMS = DefaultMergeWorkerMaxDurationMS
+	}
 	if c.Agent.FailureBreaker.SameClassLimit == 0 {
 		c.Agent.FailureBreaker.SameClassLimit = DefaultFailureBreakerSameClassLimit
 	}
@@ -1920,6 +1926,7 @@ func (a *Agent) validate(prefix string, problems *[]string) {
 	if a.MaxSessionDurationMS < 0 {
 		*problems = append(*problems, prefix+".max_session_duration_ms must be greater than or equal to 0")
 	}
+	validatePositive(prefix+".merge_worker_max_duration_ms", a.MergeWorkerMaxDurationMS, problems)
 	validatePositive(prefix+".max_retry_backoff_ms", a.MaxRetryBackoffMS, problems)
 	validatePositive(prefix+".overload_retry_delay_ms", a.OverloadRetryDelayMS, problems)
 	if a.MaxSessionTokens < 0 {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -674,6 +674,7 @@ agent:
   max_concurrent_agents: 5
   max_turn_duration_ms: 900000
   max_session_duration_ms: 3600000
+  merge_worker_max_duration_ms: 7200000
   max_session_tokens: 10000000
   max_session_context_multiplier: 3.5
   max_session_token_override_label: Allow-Large-Session
@@ -924,6 +925,9 @@ Ticket prompt {{ issue.title }}
 	}
 	if cfg.Agent.MaxSessionDurationMS != 3600000 {
 		t.Fatalf("Agent.MaxSessionDurationMS = %d, want 3600000", cfg.Agent.MaxSessionDurationMS)
+	}
+	if cfg.Agent.MergeWorkerMaxDurationMS != 7200000 {
+		t.Fatalf("Agent.MergeWorkerMaxDurationMS = %d, want 7200000", cfg.Agent.MergeWorkerMaxDurationMS)
 	}
 	if cfg.Agent.MaxSessionTokens != 10000000 {
 		t.Fatalf("Agent.MaxSessionTokens = %d, want 10000000", cfg.Agent.MaxSessionTokens)
@@ -1301,6 +1305,9 @@ func TestParseWorkflowDefaults(t *testing.T) {
 	}
 	if cfg.Agent.MaxConcurrentAgents != 10 {
 		t.Fatalf("Agent.MaxConcurrentAgents = %d, want 10", cfg.Agent.MaxConcurrentAgents)
+	}
+	if cfg.Agent.MergeWorkerMaxDurationMS != DefaultMergeWorkerMaxDurationMS {
+		t.Fatalf("Agent.MergeWorkerMaxDurationMS = %d, want %d", cfg.Agent.MergeWorkerMaxDurationMS, DefaultMergeWorkerMaxDurationMS)
 	}
 	if cfg.Agent.MaxSessionTokens != 0 {
 		t.Fatalf("Agent.MaxSessionTokens = %d, want disabled default", cfg.Agent.MaxSessionTokens)
@@ -2869,6 +2876,7 @@ agent:
   max_concurrent_agents: 0
   max_turn_duration_ms: -1
   max_session_duration_ms: -1
+  merge_worker_max_duration_ms: -1
   max_session_tokens: -1
   max_session_context_multiplier: -0.5
   output_truncation:
@@ -2908,6 +2916,7 @@ Prompt
 				"agent.max_concurrent_agents must be greater than 0",
 				"agent.max_turn_duration_ms must be greater than or equal to 0",
 				"agent.max_session_duration_ms must be greater than or equal to 0",
+				"agent.merge_worker_max_duration_ms must be greater than 0",
 				"agent.max_session_tokens must be greater than or equal to 0",
 				"agent.max_session_context_multiplier must be greater than or equal to 0",
 				"agent.output_truncation.max_bytes must be greater than or equal to 0",

--- a/internal/orchestrator/config.go
+++ b/internal/orchestrator/config.go
@@ -25,6 +25,7 @@ func ConfigFromWorkflow(cfg workflowconfig.Config) Config {
 		PrioritizeUnblockers:       cfg.Agent.PrioritizeUnblockers,
 		MergeFastPathEnabled:       cfg.Agent.MergeFastPath.Enabled,
 		MergeMethod:                cfg.Deliverable.EffectiveMergeMethod(),
+		MergeWorkerMaxDuration:     durationFromMillis(cfg.Agent.MergeWorkerMaxDurationMS),
 		ResumeOrphanedSessions:     cfg.Agent.ResumeOrphanedSessions,
 		StopRunTargetState:         cfg.Agent.StopRun.TargetState,
 		StopRunPriorityNames:       stopRunPriorityNames(cfg.Tracker.PriorityMap),
@@ -127,6 +128,9 @@ func normalizeConfig(cfg Config) Config {
 	}
 	if cfg.OverloadRetryDelay <= 0 {
 		cfg.OverloadRetryDelay = defaultOverloadRetryDelay
+	}
+	if cfg.MergeWorkerMaxDuration <= 0 {
+		cfg.MergeWorkerMaxDuration = durationFromMillis(workflowconfig.DefaultMergeWorkerMaxDurationMS)
 	}
 	if cfg.ContinuationRetryDelay < 0 {
 		cfg.ContinuationRetryDelay = 0

--- a/internal/orchestrator/dispatch.go
+++ b/internal/orchestrator/dispatch.go
@@ -323,6 +323,25 @@ func (o *Orchestrator) dispatchIssueWithOutcome(
 		}
 		return dispatchIssueOutcome{reason: dispatchIssueFailureGlobalSlotUnavailable}
 	}
+	runCtx := ctx
+	cancelDurationLimit := func() {}
+	if mergeWorkerIssue(slotIssue) {
+		limit := o.mergeWorkerLimit
+		if limit == nil {
+			limit = context.WithTimeoutCause
+		}
+		runCtx, cancelDurationLimit = limit(
+			ctx,
+			o.cfg.MergeWorkerMaxDuration,
+			runpkg.ErrMergeWorkerDurationExceeded,
+		)
+	}
+	durationLimitTransferred := false
+	defer func() {
+		if !durationLimitTransferred {
+			cancelDurationLimit()
+		}
+	}()
 	mergeTiming := o.markMergeWorkerSlotAcquired(state, issue, now)
 	o.logSchedulerSlotDecision(issue, "acquired", decision, projectStats)
 	o.logMergeWorkerSlotAcquired(issue, decision, projectStats, mergeTiming)
@@ -347,7 +366,7 @@ func (o *Orchestrator) dispatchIssueWithOutcome(
 		return dispatchIssueOutcome{reason: projectFailureBreakerDispatchPaused}
 	}
 
-	claimedIssue, claim, ok := o.claimIssue(ctx, issue, now)
+	claimedIssue, claim, ok := o.claimIssue(runCtx, issue, now)
 	if !ok {
 		if recovery {
 			releaseDispatchRecoveryAdmission(state, issue.ID)
@@ -369,11 +388,11 @@ func (o *Orchestrator) dispatchIssueWithOutcome(
 	issue = cloneIssue(claimedIssue)
 	priorAttempt := state.PriorAttempts[issue.ID]
 	if !priorAttemptPresent(priorAttempt) {
-		if breakerAttempt, ok := o.spendProgressPriorAttempt(ctx, issue); ok {
+		if breakerAttempt, ok := o.spendProgressPriorAttempt(runCtx, issue); ok {
 			priorAttempt = breakerAttempt
 		}
 	}
-	workAttemptID, ok := o.startDurableWorkAttempt(ctx, state, issue, attempt, now, workerHost, runMode)
+	workAttemptID, ok := o.startDurableWorkAttempt(runCtx, state, issue, attempt, now, workerHost, runMode)
 	if !ok {
 		if recovery {
 			releaseDispatchRecoveryAdmission(state, issue.ID)
@@ -400,7 +419,7 @@ func (o *Orchestrator) dispatchIssueWithOutcome(
 	dispatchStartTargetState := ""
 	if targetState != "" {
 		sourceState := issue.State
-		if err := o.updateIssueState(ctx, state, issue, targetState, now, "dispatch_start"); err != nil {
+		if err := o.updateIssueState(runCtx, state, issue, targetState, now, "dispatch_start"); err != nil {
 			if recovery {
 				releaseDispatchRecoveryAdmission(state, issue.ID)
 			}
@@ -438,30 +457,17 @@ func (o *Orchestrator) dispatchIssueWithOutcome(
 		dispatchStartTargetState = targetState
 	}
 	if dispatchSourceState == "" || dispatchTargetState == "" {
-		dispatchSourceState, dispatchTargetState = o.dispatchTimelineTransitionContext(ctx, issue)
+		dispatchSourceState, dispatchTargetState = o.dispatchTimelineTransitionContext(runCtx, issue)
 	}
 	o.markMergeStarted(state, issue, now)
 	claim.Issue = issue
-	runCtx := ctx
-	cancelDurationLimit := func() {}
-	if mergeWorkerIssue(issue) {
-		limit := o.mergeWorkerLimit
-		if limit == nil {
-			limit = context.WithTimeoutCause
-		}
-		runCtx, cancelDurationLimit = limit(
-			ctx,
-			o.cfg.MergeWorkerMaxDuration,
-			runpkg.ErrMergeWorkerDurationExceeded,
-		)
-	}
 	runCtx, stop := context.WithCancelCause(runCtx)
 	cancel := func() {
 		stop(nil)
 		cancelDurationLimit()
 	}
 	o.markBackendCapacityProbe(state, capacityProbeKey, issue.ID, now)
-	dispatchWorkpadHash, dispatchWorkpadRead := o.artifactGateDispatchWorkpadSnapshot(ctx, issue)
+	dispatchWorkpadHash, dispatchWorkpadRead := o.artifactGateDispatchWorkpadSnapshot(runCtx, issue)
 	state.Running[issue.ID] = Running{
 		Issue:               issue,
 		Attempt:             attempt,
@@ -520,6 +526,7 @@ func (o *Orchestrator) dispatchIssueWithOutcome(
 	running := state.Running[issue.ID]
 	running.done = o.supervisor.Dispatch(runCtx, request, o.runResults)
 	state.Running[issue.ID] = running
+	durationLimitTransferred = true
 	o.trackRunningHeartbeat(state, running, claim, now)
 	return dispatchIssueOutcome{dispatched: true}
 }

--- a/internal/orchestrator/dispatch.go
+++ b/internal/orchestrator/dispatch.go
@@ -442,8 +442,24 @@ func (o *Orchestrator) dispatchIssueWithOutcome(
 	}
 	o.markMergeStarted(state, issue, now)
 	claim.Issue = issue
-	runCtx, stop := context.WithCancelCause(ctx)
-	cancel := func() { stop(nil) }
+	runCtx := ctx
+	cancelDurationLimit := func() {}
+	if mergeWorkerIssue(issue) {
+		limit := o.mergeWorkerLimit
+		if limit == nil {
+			limit = context.WithTimeoutCause
+		}
+		runCtx, cancelDurationLimit = limit(
+			ctx,
+			o.cfg.MergeWorkerMaxDuration,
+			runpkg.ErrMergeWorkerDurationExceeded,
+		)
+	}
+	runCtx, stop := context.WithCancelCause(runCtx)
+	cancel := func() {
+		stop(nil)
+		cancelDurationLimit()
+	}
 	o.markBackendCapacityProbe(state, capacityProbeKey, issue.ID, now)
 	dispatchWorkpadHash, dispatchWorkpadRead := o.artifactGateDispatchWorkpadSnapshot(ctx, issue)
 	state.Running[issue.ID] = Running{

--- a/internal/orchestrator/dispatch_test.go
+++ b/internal/orchestrator/dispatch_test.go
@@ -243,6 +243,7 @@ func TestConfigFromWorkflowIncludesDispatchControls(t *testing.T) {
 	cfg.Agent.AutoPromote.GateWaitTimeoutSeconds = 900
 	cfg.Agent.AutoPromote.ReworkLimit = 2
 	cfg.Agent.OverloadRetryDelayMS = 60000
+	cfg.Agent.MergeWorkerMaxDurationMS = 7200000
 	cfg.Deliverable.MergeMethod = workflowconfig.MergeMethodRebase
 	cfg.Agent.OutputTruncation.MaxBytes = 4096
 	cfg.Identity.Name = "release-captain"
@@ -279,6 +280,9 @@ func TestConfigFromWorkflowIncludesDispatchControls(t *testing.T) {
 	}
 	if got.OverloadRetryDelay != time.Minute {
 		t.Fatalf("OverloadRetryDelay = %s, want 1m", got.OverloadRetryDelay)
+	}
+	if got.MergeWorkerMaxDuration != 2*time.Hour {
+		t.Fatalf("MergeWorkerMaxDuration = %s, want 2h", got.MergeWorkerMaxDuration)
 	}
 	if len(got.WorkerHosts) != 2 || got.WorkerHosts[0] != "worker-a" || got.WorkerHosts[1] != "worker-b" {
 		t.Fatalf("WorkerHosts = %#v, want worker-a and worker-b", got.WorkerHosts)

--- a/internal/orchestrator/merge_duration.go
+++ b/internal/orchestrator/merge_duration.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/digitaldrywood/detent/internal/connector"
 	runpkg "github.com/digitaldrywood/detent/internal/runner"
 	"github.com/digitaldrywood/detent/internal/store"
 	"github.com/digitaldrywood/detent/internal/telemetry"
@@ -21,6 +22,9 @@ func (o *Orchestrator) handleMergeWorkerDurationExceeded(
 ) bool {
 	if !errors.Is(event.Err, runpkg.ErrMergeWorkerDurationExceeded) {
 		return false
+	}
+	if o.completeLatestTerminalMergeWorkerResult(ctx, state, event, running) {
+		return true
 	}
 
 	completedAt := event.CompletedAt.UTC()
@@ -81,7 +85,7 @@ func (o *Orchestrator) parkMergeWorkerDurationExceeded(
 ) {
 	issueID := strings.TrimSpace(running.Issue.ID)
 	issue := cloneIssue(running.Issue)
-	if err := o.updateIssueStateByID(
+	transitionErr := o.updateIssueStateByIDStrictWithMetadata(
 		ctx,
 		state,
 		issueID,
@@ -89,20 +93,26 @@ func (o *Orchestrator) parkMergeWorkerDurationExceeded(
 		blockedStatusState,
 		completedAt,
 		mergeWorkerDurationExceededReason,
-	); err != nil && o.logger != nil {
+		workflowLaneMetadata{},
+	)
+	if transitionErr != nil && o.logger != nil {
 		o.logger.Error(
 			"merge worker duration state transition failed",
 			"issue_id", issueID,
 			"identifier", issue.Identifier,
 			"target_state", blockedStatusState,
-			"error", err,
+			"error", transitionErr,
 		)
 	}
 
-	issue.State = blockedStatusState
 	issue.BlockerReason = mergeWorkerDurationExceededReason
 	blockedAt := completedAt.UTC()
 	issue.StageUpdatedAt = &blockedAt
+	source := BlockedSourceMergeDuration
+	if transitionErr == nil {
+		issue.State = blockedStatusState
+		source = BlockedSourceProjectStatus
+	}
 	if o.connector != nil {
 		comment := mergeWorkerDurationExceededComment(
 			running,
@@ -135,13 +145,81 @@ func (o *Orchestrator) parkMergeWorkerDurationExceeded(
 		RecoveryReason: string(BlockedRecoveryReasonHumanBlocker),
 		RecoveryTarget: autoPromoteMergingState,
 		BlockedAt:      completedAt,
-		Source:         BlockedSourceProjectStatus,
+		Source:         source,
 	}
 	recordStateEvent(state, telemetry.ActivityEvent{
 		At:      completedAt,
 		Event:   mergeWorkerDurationExceededReason,
 		Message: "parked " + issueLabel(issue) + " after its merge worker exceeded the wall-clock ceiling",
 	})
+}
+
+func (o *Orchestrator) reconcileMergeDurationHolds(
+	ctx context.Context,
+	state *State,
+	issues []connector.Issue,
+	now time.Time,
+) map[string]struct{} {
+	byID := make(map[string]connector.Issue, len(issues))
+	for _, issue := range issues {
+		byID[strings.TrimSpace(issue.ID)] = issue
+	}
+	transitioned := map[string]struct{}{}
+	for issueID, blocked := range state.Blocked {
+		if blocked.Source != BlockedSourceMergeDuration {
+			continue
+		}
+		issue, ok := byID[issueID]
+		if !ok {
+			continue
+		}
+		if workspaceIssueTerminal(issue, o.cfg.TerminalStates) {
+			delete(state.Blocked, issueID)
+			continue
+		}
+		if normalizeState(issue.State) != normalizeState(autoPromoteMergingState) {
+			if normalizeState(issue.State) == normalizeState(blockedStatusState) {
+				blocked.Issue = cloneIssue(issue)
+				blocked.Issue.BlockerReason = mergeWorkerDurationExceededReason
+				blocked.Source = BlockedSourceProjectStatus
+				state.Blocked[issueID] = blocked
+				transitioned[issueID] = struct{}{}
+			} else {
+				delete(state.Blocked, issueID)
+			}
+			continue
+		}
+		blocked.Issue = mergeIssueTrackerFields(blocked.Issue, issue)
+		state.Blocked[issueID] = blocked
+		if err := o.updateIssueStateByIDStrictWithMetadata(
+			ctx,
+			state,
+			issueID,
+			issue,
+			blockedStatusState,
+			now,
+			mergeWorkerDurationExceededReason,
+			workflowLaneMetadata{},
+		); err != nil {
+			if o.logger != nil {
+				o.logger.Warn(
+					"merge worker duration state transition retry failed",
+					"issue_id", issueID,
+					"identifier", issue.Identifier,
+					"target_state", blockedStatusState,
+					"error", err,
+				)
+			}
+			continue
+		}
+		blocked.Issue = cloneIssue(issue)
+		blocked.Issue.State = blockedStatusState
+		blocked.Issue.BlockerReason = mergeWorkerDurationExceededReason
+		blocked.Source = BlockedSourceProjectStatus
+		state.Blocked[issueID] = blocked
+		transitioned[issueID] = struct{}{}
+	}
+	return transitioned
 }
 
 func mergeWorkerDurationExceededComment(

--- a/internal/orchestrator/merge_duration.go
+++ b/internal/orchestrator/merge_duration.go
@@ -1,0 +1,186 @@
+package orchestrator
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+
+	runpkg "github.com/digitaldrywood/detent/internal/runner"
+	"github.com/digitaldrywood/detent/internal/store"
+	"github.com/digitaldrywood/detent/internal/telemetry"
+)
+
+func (o *Orchestrator) handleMergeWorkerDurationExceeded(
+	ctx context.Context,
+	state *State,
+	event runpkg.Completion,
+	running Running,
+) bool {
+	if !errors.Is(event.Err, runpkg.ErrMergeWorkerDurationExceeded) {
+		return false
+	}
+
+	completedAt := event.CompletedAt.UTC()
+	if completedAt.IsZero() {
+		completedAt = o.clockNow().UTC()
+	}
+	elapsed := completedAt.Sub(running.StartedAt)
+	if elapsed < 0 {
+		elapsed = 0
+	}
+	progressMarker := mergeWorkerProgressMarker(running)
+	if o.logger != nil {
+		o.logger.Warn(
+			"merge_worker_duration_exceeded",
+			"issue_id", running.Issue.ID,
+			"identifier", running.Issue.Identifier,
+			"attempt", running.Attempt,
+			"elapsed", elapsed,
+			"configured_ceiling", o.cfg.MergeWorkerMaxDuration,
+			"last_progress_marker", progressMarker,
+			"last_progress_at", running.LastEventAt,
+		)
+	}
+
+	o.recordProjectAttemptOutcome(
+		state,
+		event.IssueID,
+		completedAt,
+		store.WorkAttemptTerminalTimedOut,
+		event.Err,
+		workAttemptErrorMergeDuration,
+		event.Err.Error(),
+	)
+	o.completeDurableWorkAttempt(
+		ctx,
+		state,
+		running,
+		completedAt,
+		store.WorkAttemptTerminalTimedOut,
+		workAttemptErrorMergeDuration,
+		event.Err.Error(),
+		"timed_out",
+		"merge worker exceeded its wall-clock ceiling",
+	)
+	o.logMergeWorkerFailure(running.Issue, mergeWorkerDurationExceededReason, event.Err)
+	o.recordMergeFailed(state, running.Issue, completedAt, mergeWorkerDurationExceededReason, event.Err)
+	o.parkMergeWorkerDurationExceeded(ctx, state, running, completedAt, elapsed, progressMarker)
+	return true
+}
+
+func (o *Orchestrator) parkMergeWorkerDurationExceeded(
+	ctx context.Context,
+	state *State,
+	running Running,
+	completedAt time.Time,
+	elapsed time.Duration,
+	progressMarker string,
+) {
+	issueID := strings.TrimSpace(running.Issue.ID)
+	issue := cloneIssue(running.Issue)
+	if err := o.updateIssueStateByID(
+		ctx,
+		state,
+		issueID,
+		issue,
+		blockedStatusState,
+		completedAt,
+		mergeWorkerDurationExceededReason,
+	); err != nil && o.logger != nil {
+		o.logger.Error(
+			"merge worker duration state transition failed",
+			"issue_id", issueID,
+			"identifier", issue.Identifier,
+			"target_state", blockedStatusState,
+			"error", err,
+		)
+	}
+
+	issue.State = blockedStatusState
+	issue.BlockerReason = mergeWorkerDurationExceededReason
+	blockedAt := completedAt.UTC()
+	issue.StageUpdatedAt = &blockedAt
+	if o.connector != nil {
+		comment := mergeWorkerDurationExceededComment(
+			running,
+			elapsed,
+			o.cfg.MergeWorkerMaxDuration,
+			progressMarker,
+		)
+		if err := o.connector.CreateComment(ctx, issueID, comment); err != nil && o.logger != nil {
+			o.logger.Warn(
+				"merge worker duration comment failed",
+				"issue_id", issueID,
+				"identifier", issue.Identifier,
+				"error", err,
+			)
+		}
+	}
+	delete(state.Claimed, issueID)
+	delete(state.Retry, issueID)
+	delete(state.BudgetRefusals, issueID)
+	delete(state.PriorAttempts, issueID)
+	delete(state.Completed, issueID)
+	delete(state.InstantFailures, issueID)
+	delete(state.RepeatedFailures, issueID)
+	if state.Blocked == nil {
+		state.Blocked = map[string]Blocked{}
+	}
+	state.Blocked[issueID] = Blocked{
+		Issue:          issue,
+		Reason:         mergeWorkerDurationExceededReason,
+		RecoveryReason: string(BlockedRecoveryReasonHumanBlocker),
+		RecoveryTarget: autoPromoteMergingState,
+		BlockedAt:      completedAt,
+		Source:         BlockedSourceProjectStatus,
+	}
+	recordStateEvent(state, telemetry.ActivityEvent{
+		At:      completedAt,
+		Event:   mergeWorkerDurationExceededReason,
+		Message: "parked " + issueLabel(issue) + " after its merge worker exceeded the wall-clock ceiling",
+	})
+}
+
+func mergeWorkerDurationExceededComment(
+	running Running,
+	elapsed time.Duration,
+	ceiling time.Duration,
+	progressMarker string,
+) string {
+	var body strings.Builder
+	body.WriteString("Detent cancelled this merge worker after it exceeded the configured hard wall-clock ceiling and parked the issue in Blocked for human attention.")
+	body.WriteString("\n\n- reason: ")
+	body.WriteString(mergeWorkerDurationExceededReason)
+	body.WriteString("\n- elapsed: ")
+	body.WriteString(elapsed.String())
+	body.WriteString("\n- configured_ceiling: ")
+	body.WriteString(ceiling.String())
+	body.WriteString("\n- last_progress_marker: ")
+	body.WriteString(progressMarker)
+	if !running.LastEventAt.IsZero() {
+		body.WriteString("\n- last_progress_at: ")
+		body.WriteString(running.LastEventAt.UTC().Format(time.RFC3339))
+	}
+	if running.Attempt > 0 {
+		body.WriteString("\n- attempt: ")
+		body.WriteString(strconv.Itoa(running.Attempt))
+	}
+	body.WriteString("\n\nInspect the worker and pull request state, then move the issue back to Merging when it is safe to retry.")
+	return body.String()
+}
+
+func mergeWorkerProgressMarker(running Running) string {
+	if marker := strings.TrimSpace(running.LastEvent); marker != "" {
+		return marker
+	}
+	if running.TurnCount > 0 {
+		return fmt.Sprintf("turn_%d", running.TurnCount)
+	}
+	if strings.TrimSpace(running.SessionID) != "" {
+		return "session_started"
+	}
+	return "none"
+}

--- a/internal/orchestrator/merge_duration_test.go
+++ b/internal/orchestrator/merge_duration_test.go
@@ -1,0 +1,309 @@
+package orchestrator
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"log/slog"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/digitaldrywood/detent/internal/connector"
+	"github.com/digitaldrywood/detent/internal/connector/memory"
+	runpkg "github.com/digitaldrywood/detent/internal/runner"
+	"github.com/digitaldrywood/detent/internal/scheduler"
+	"github.com/digitaldrywood/detent/internal/store"
+)
+
+func TestMergeWorkerDurationCeilingCancelsProgressingRunAndReleasesSlot(t *testing.T) {
+	t.Parallel()
+
+	startedAt := time.Date(2026, 7, 29, 12, 0, 0, 0, time.UTC)
+	ceiling := 6 * time.Hour
+	completedAt := startedAt.Add(ceiling)
+	issue := mergeDurationTestIssue("issue-1547-timeout")
+	var events []memory.Event
+	tracker := memory.New(memory.Config{
+		Issues:    []connector.Issue{issue},
+		Stateful:  true,
+		Now:       func() time.Time { return completedAt },
+		EventSink: func(event memory.Event) { events = append(events, event) },
+	})
+	project := scheduler.ProjectCandidate{ID: "detent", Weight: 1}
+	dispatchGate := scheduler.NewGlobalDispatchGate(scheduler.NewRoundRobin(scheduler.Config{Capacity: 1}))
+	cfg := normalizeConfig(Config{
+		MaxConcurrentAgents:        1,
+		MaxConcurrentAgentsByState: map[string]int{"Merging": 1},
+		MergeWorkerMaxDuration:     ceiling,
+		Project:                    project,
+		ActiveStates:               []string{"Merging"},
+		ObservedStates:             []string{"Blocked"},
+		TerminalStates:             []string{"Done", "Cancelled"},
+	})
+	durationLimit := &controlledMergeDurationLimit{}
+	runner := &progressingMergeRunner{progressed: make(chan struct{})}
+	attempts := &recordingWorkAttemptStore{}
+	var logs bytes.Buffer
+	supervisor, err := runpkg.NewSupervisor(runner, runpkg.SupervisorConfig{
+		MaxRetryBackoff:       cfg.MaxRetryBackoff,
+		FailureRetryBaseDelay: cfg.FailureRetryBaseDelay,
+		OverloadRetryDelay:    cfg.OverloadRetryDelay,
+		Now:                   func() time.Time { return completedAt },
+	})
+	if err != nil {
+		t.Fatalf("NewSupervisor() error = %v", err)
+	}
+	orch := &Orchestrator{
+		cfg:                cfg,
+		connector:          tracker,
+		supervisor:         supervisor,
+		workAttempts:       attempts,
+		globalDispatchGate: dispatchGate,
+		mergeWorkerLimit:   durationLimit.Context,
+		runResults:         make(chan runpkg.Completion, 1),
+		runUpdates:         make(chan runUpdate, 1),
+		logger:             slog.New(slog.NewTextHandler(&logs, nil)),
+	}
+	state := newState(cfg)
+
+	if !orch.dispatchIssue(t.Context(), &state, issue, 1, startedAt, "") {
+		t.Fatal("dispatchIssue() = false, want true")
+	}
+	select {
+	case <-runner.progressed:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for merge worker progress")
+	}
+	select {
+	case update := <-orch.runUpdates:
+		orch.handleRunUpdate(&state, update)
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for merge worker usage update")
+	}
+	if durationLimit.duration != ceiling {
+		t.Fatalf("duration limit = %s, want %s", durationLimit.duration, ceiling)
+	}
+	if !errors.Is(durationLimit.limit, runpkg.ErrMergeWorkerDurationExceeded) {
+		t.Fatalf("duration limit cause = %v, want ErrMergeWorkerDurationExceeded", durationLimit.limit)
+	}
+
+	durationLimit.Expire()
+	var completion runpkg.Completion
+	select {
+	case completion = <-orch.runResults:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for cancelled merge worker completion")
+	}
+	if !errors.Is(completion.Err, runpkg.ErrMergeWorkerDurationExceeded) {
+		t.Fatalf("completion error = %v, want ErrMergeWorkerDurationExceeded", completion.Err)
+	}
+	if completion.Retryable || completion.RetryAttempt != 0 || completion.RetryDelay != 0 {
+		t.Fatalf(
+			"retry state = retryable %v attempt %d delay %s, want no runner retry",
+			completion.Retryable,
+			completion.RetryAttempt,
+			completion.RetryDelay,
+		)
+	}
+	if completion.Result.FinalState != runpkg.FinalStateMergeDurationExceeded {
+		t.Fatalf(
+			"final state = %q, want %q",
+			completion.Result.FinalState,
+			runpkg.FinalStateMergeDurationExceeded,
+		)
+	}
+	orch.handleRunResult(t.Context(), &state, completion)
+
+	if _, ok := state.Running[issue.ID]; ok {
+		t.Fatalf("Running[%q] present after duration breach", issue.ID)
+	}
+	if _, ok := state.Retry[issue.ID]; ok {
+		t.Fatalf("Retry[%q] present after duration breach", issue.ID)
+	}
+	blocked, ok := state.Blocked[issue.ID]
+	if !ok || blocked.Issue.State != "Blocked" || blocked.Reason != mergeWorkerDurationExceededReason {
+		t.Fatalf("Blocked[%q] = %#v, want duration breach parked in Blocked", issue.ID, blocked)
+	}
+	if len(attempts.completions) != 1 {
+		t.Fatalf("work attempt completions = %#v, want one", attempts.completions)
+	}
+	attemptCompletion := attempts.completions[0]
+	if attemptCompletion.TerminalState != store.WorkAttemptTerminalTimedOut ||
+		attemptCompletion.ErrorClass != workAttemptErrorMergeDuration {
+		t.Fatalf("work attempt completion = %#v, want merge duration timeout", attemptCompletion)
+	}
+	if availableSlots(&state) != 1 {
+		t.Fatalf("availableSlots() = %d, want released local slot", availableSlots(&state))
+	}
+	if _, ok, err := dispatchGate.TryAcquire(
+		t.Context(),
+		project,
+		scheduler.SlotRequest{State: "Merging"},
+		completedAt,
+	); err != nil || !ok {
+		t.Fatalf("TryAcquire() after duration breach = %v, %v, want released global slot", ok, err)
+	}
+
+	var stateUpdated bool
+	var comment string
+	for _, event := range events {
+		switch event.Kind {
+		case memory.EventKindStateUpdate:
+			stateUpdated = event.State == "Blocked"
+		case memory.EventKindComment:
+			comment = event.Body
+		}
+	}
+	if !stateUpdated {
+		t.Fatalf("events = %#v, want Blocked state update", events)
+	}
+	for _, want := range []string{
+		"merge_worker_duration_exceeded",
+		"elapsed: 6h0m0s",
+		"configured_ceiling: 6h0m0s",
+		"last_progress_marker: tool_output",
+	} {
+		if !strings.Contains(comment, want) {
+			t.Fatalf("duration breach comment = %q, want %q", comment, want)
+		}
+	}
+	if got := logs.String(); !strings.Contains(got, "level=WARN") ||
+		!strings.Contains(got, "msg=merge_worker_duration_exceeded") ||
+		!strings.Contains(got, "last_progress_marker=tool_output") {
+		t.Fatalf("logs = %q, want WARN breach with progress marker", got)
+	}
+}
+
+func TestNormalDurationMergeIsUnaffected(t *testing.T) {
+	t.Parallel()
+
+	startedAt := time.Date(2026, 7, 29, 12, 0, 0, 0, time.UTC)
+	completedAt := startedAt.Add(5 * time.Minute)
+	issue := mergeDurationTestIssue("issue-1547-normal")
+	tracker := memory.New(memory.Config{
+		Issues:   []connector.Issue{issue},
+		Stateful: true,
+		Now:      func() time.Time { return completedAt },
+	})
+	cfg := normalizeConfig(Config{
+		MaxConcurrentAgents:    1,
+		MergeWorkerMaxDuration: 6 * time.Hour,
+		Project:                scheduler.ProjectCandidate{ID: "detent", Weight: 1},
+		ActiveStates:           []string{"Merging"},
+		ObservedStates:         []string{"Blocked"},
+		TerminalStates:         []string{"Done", "Cancelled"},
+	})
+	durationLimit := &controlledMergeDurationLimit{}
+	supervisor, err := runpkg.NewSupervisor(instantMergeRunner{}, runpkg.SupervisorConfig{
+		Now: func() time.Time { return completedAt },
+	})
+	if err != nil {
+		t.Fatalf("NewSupervisor() error = %v", err)
+	}
+	orch := &Orchestrator{
+		cfg:              cfg,
+		connector:        tracker,
+		supervisor:       supervisor,
+		mergeWorkerLimit: durationLimit.Context,
+		runResults:       make(chan runpkg.Completion, 1),
+	}
+	state := newState(cfg)
+
+	if !orch.dispatchIssue(t.Context(), &state, issue, 1, startedAt, "") {
+		t.Fatal("dispatchIssue() = false, want true")
+	}
+	var completion runpkg.Completion
+	select {
+	case completion = <-orch.runResults:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for normal merge completion")
+	}
+	if completion.Err != nil {
+		t.Fatalf("completion error = %v, want nil", completion.Err)
+	}
+	running := state.Running[issue.ID]
+	running.Issue.State = "Done"
+	state.Running[issue.ID] = running
+	orch.handleRunResult(t.Context(), &state, completion)
+
+	if _, ok := state.Blocked[issue.ID]; ok {
+		t.Fatalf("Blocked[%q] present after normal merge", issue.ID)
+	}
+	if _, ok := state.Retry[issue.ID]; ok {
+		t.Fatalf("Retry[%q] present after normal merge", issue.ID)
+	}
+	if completed, ok := state.Completed[issue.ID]; !ok || completed.FinalState != "Done" {
+		t.Fatalf("Completed[%q] = %#v, want normal Done completion", issue.ID, completed)
+	}
+	if durationLimit.duration != 6*time.Hour {
+		t.Fatalf("duration limit = %s, want 6h", durationLimit.duration)
+	}
+}
+
+type controlledMergeDurationLimit struct {
+	cancel   context.CancelCauseFunc
+	duration time.Duration
+	limit    error
+}
+
+func (l *controlledMergeDurationLimit) Context(
+	ctx context.Context,
+	duration time.Duration,
+	limit error,
+) (context.Context, context.CancelFunc) {
+	cancelCtx, cancel := context.WithCancelCause(ctx)
+	l.cancel = cancel
+	l.duration = duration
+	l.limit = limit
+	deadlineCtx, cancelDeadline := context.WithDeadline(
+		cancelCtx,
+		time.Date(2100, time.January, 1, 0, 0, 0, 0, time.UTC).Add(duration),
+	)
+	return deadlineCtx, func() {
+		cancelDeadline()
+		cancel(context.Canceled)
+	}
+}
+
+func (l *controlledMergeDurationLimit) Expire() {
+	l.cancel(l.limit)
+}
+
+type progressingMergeRunner struct {
+	progressed chan struct{}
+}
+
+func (r *progressingMergeRunner) Run(ctx context.Context, request RunRequest) (RunResult, error) {
+	if request.OnUsageUpdate == nil {
+		return RunResult{}, errors.New("missing usage update callback")
+	}
+	if err := request.OnUsageUpdate(runpkg.UsageUpdate{
+		SessionID:   "merge-session-1547",
+		TurnCount:   3,
+		LastEventAt: request.StartedAt.Add(5*time.Hour + 30*time.Minute),
+		LastEvent:   "tool_output",
+		LastMessage: "CI is still progressing",
+	}); err != nil {
+		return RunResult{}, err
+	}
+	close(r.progressed)
+	<-ctx.Done()
+	return RunResult{}, ctx.Err()
+}
+
+type instantMergeRunner struct{}
+
+func (instantMergeRunner) Run(context.Context, RunRequest) (RunResult, error) {
+	return RunResult{FinalState: FinalStateCompleted}, nil
+}
+
+func mergeDurationTestIssue(id string) connector.Issue {
+	return connector.Issue{
+		ID:               id,
+		Identifier:       "digitaldrywood/detent#1547",
+		Title:            "Merge duration test",
+		State:            "Merging",
+		AssignedToWorker: true,
+	}
+}

--- a/internal/orchestrator/merge_duration_test.go
+++ b/internal/orchestrator/merge_duration_test.go
@@ -173,6 +173,16 @@ func TestMergeWorkerDurationCeilingCancelsProgressingRunAndReleasesSlot(t *testi
 		!strings.Contains(got, "last_progress_marker=tool_output") {
 		t.Fatalf("logs = %q, want WARN breach with progress marker", got)
 	}
+
+	orch.setBlockedStatusIssue(&state, connector.Issue{
+		ID:    issue.ID,
+		State: blockedStatusState,
+	}, completedAt.Add(time.Minute))
+	blocked = state.Blocked[issue.ID]
+	if blocked.Reason != mergeWorkerDurationExceededReason ||
+		blocked.RecoveryTarget != autoPromoteMergingState {
+		t.Fatalf("Blocked[%q] after refresh = %#v, want preserved duration breach", issue.ID, blocked)
+	}
 }
 
 func TestNormalDurationMergeIsUnaffected(t *testing.T) {
@@ -241,6 +251,278 @@ func TestNormalDurationMergeIsUnaffected(t *testing.T) {
 	}
 }
 
+func TestMergeWorkerDurationCeilingStartsAtSlotAcquisition(t *testing.T) {
+	t.Parallel()
+
+	startedAt := time.Date(2026, 7, 29, 12, 0, 0, 0, time.UTC)
+	issue := mergeDurationTestIssue("issue-1547-startup-timeout")
+	store := newClaimTestStore([]connector.Issue{issue})
+	claimStarted := make(chan struct{}, 1)
+	claimCause := make(chan error, 1)
+	store.assigneeHook = func(ctx context.Context, _ string, _ string) error {
+		claimStarted <- struct{}{}
+		<-ctx.Done()
+		claimCause <- context.Cause(ctx)
+		return ctx.Err()
+	}
+	tracker := claimTestConnector{store: store, login: "worker"}
+	project := scheduler.ProjectCandidate{ID: "detent", Weight: 1}
+	dispatchGate := scheduler.NewGlobalDispatchGate(scheduler.NewRoundRobin(scheduler.Config{Capacity: 1}))
+	cfg := normalizeConfig(Config{
+		MaxConcurrentAgents:    1,
+		MergeWorkerMaxDuration: 6 * time.Hour,
+		Project:                project,
+		ActiveStates:           []string{"Merging"},
+		TerminalStates:         []string{"Done", "Cancelled"},
+		SelectorContext:        selectorContextForClaimTest("worker"),
+		Claiming: ClaimingConfig{
+			Enabled:           true,
+			OwnershipMode:     "assignee",
+			Owner:             "worker",
+			AssigneeLogin:     "worker",
+			LeaseField:        "Detent Lease",
+			LeaseTTL:          time.Minute,
+			HeartbeatInterval: 10 * time.Second,
+		},
+	})
+	durationLimit := &controlledMergeDurationLimit{}
+	orch := &Orchestrator{
+		cfg:                cfg,
+		connector:          tracker,
+		globalDispatchGate: dispatchGate,
+		mergeWorkerLimit:   durationLimit.Context,
+	}
+	state := newState(cfg)
+	outcome := make(chan dispatchIssueOutcome, 1)
+	go func() {
+		outcome <- orch.dispatchIssueWithOutcome(t.Context(), &state, issue, 1, startedAt, "")
+	}()
+
+	select {
+	case <-claimStarted:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for startup claim")
+	}
+	durationLimit.Expire()
+	select {
+	case cause := <-claimCause:
+		if !errors.Is(cause, runpkg.ErrMergeWorkerDurationExceeded) {
+			t.Fatalf("claim context cause = %v, want ErrMergeWorkerDurationExceeded", cause)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for claim cancellation")
+	}
+	select {
+	case got := <-outcome:
+		if got.dispatched || got.reason != dispatchIssueFailureClaimFailed {
+			t.Fatalf("dispatch outcome = %#v, want claim failure", got)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for dispatch outcome")
+	}
+	if _, ok, err := dispatchGate.TryAcquire(
+		t.Context(),
+		project,
+		scheduler.SlotRequest{State: "Merging"},
+		startedAt,
+	); err != nil || !ok {
+		t.Fatalf("TryAcquire() after startup timeout = %v, %v, want released global slot", ok, err)
+	}
+}
+
+func TestMergeWorkerDurationCeilingHonorsLatestTerminalState(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		terminate func(*testing.T, *memory.Connector, connector.Issue)
+	}{
+		{
+			name: "issue moved to terminal state",
+			terminate: func(t *testing.T, tracker *memory.Connector, issue connector.Issue) {
+				t.Helper()
+				if err := tracker.UpdateIssueState(t.Context(), issue.ID, "Done"); err != nil {
+					t.Fatalf("UpdateIssueState() error = %v", err)
+				}
+			},
+		},
+		{
+			name: "pull request merged",
+			terminate: func(t *testing.T, tracker *memory.Connector, issue connector.Issue) {
+				t.Helper()
+				if err := tracker.MergePullRequest(
+					t.Context(),
+					issue.PRRepository,
+					issue.PullRequest.Number,
+					issue.PullRequest.HeadSHA,
+					"squash",
+				); err != nil {
+					t.Fatalf("MergePullRequest() error = %v", err)
+				}
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			startedAt := time.Date(2026, 7, 29, 12, 0, 0, 0, time.UTC)
+			completedAt := startedAt.Add(6 * time.Hour)
+			issue := mergeDurationTestIssue("issue-1547-terminal-" + strings.ReplaceAll(tt.name, " ", "-"))
+			prNumber := 1547
+			issue.PRNumber = &prNumber
+			issue.PRRepository = "digitaldrywood/detent"
+			issue.PullRequest = &connector.PullRequest{
+				Number:  prNumber,
+				State:   "OPEN",
+				HeadSHA: "terminal-head",
+			}
+			tracker := memory.New(memory.Config{
+				Issues:   []connector.Issue{issue},
+				Stateful: true,
+				Now:      func() time.Time { return completedAt },
+			})
+			cfg := normalizeConfig(Config{
+				MaxConcurrentAgents:    1,
+				MergeWorkerMaxDuration: 6 * time.Hour,
+				Project:                scheduler.ProjectCandidate{ID: "detent", Weight: 1},
+				ActiveStates:           []string{"Merging"},
+				ObservedStates:         []string{"Blocked"},
+				TerminalStates:         []string{"Done", "Cancelled"},
+			})
+			durationLimit := &controlledMergeDurationLimit{}
+			runner := &progressingMergeRunner{progressed: make(chan struct{})}
+			supervisor, err := runpkg.NewSupervisor(runner, runpkg.SupervisorConfig{
+				Now: func() time.Time { return completedAt },
+			})
+			if err != nil {
+				t.Fatalf("NewSupervisor() error = %v", err)
+			}
+			orch := &Orchestrator{
+				cfg:              cfg,
+				connector:        tracker,
+				supervisor:       supervisor,
+				mergeWorkerLimit: durationLimit.Context,
+				runResults:       make(chan runpkg.Completion, 1),
+				runUpdates:       make(chan runUpdate, 1),
+			}
+			state := newState(cfg)
+
+			if !orch.dispatchIssue(t.Context(), &state, issue, 1, startedAt, "") {
+				t.Fatal("dispatchIssue() = false, want true")
+			}
+			select {
+			case <-runner.progressed:
+			case <-time.After(time.Second):
+				t.Fatal("timed out waiting for merge worker progress")
+			}
+			tt.terminate(t, tracker, issue)
+			durationLimit.Expire()
+			var completion runpkg.Completion
+			select {
+			case completion = <-orch.runResults:
+			case <-time.After(time.Second):
+				t.Fatal("timed out waiting for cancelled merge worker completion")
+			}
+			orch.handleRunResult(t.Context(), &state, completion)
+
+			if _, ok := state.Blocked[issue.ID]; ok {
+				t.Fatalf("Blocked[%q] present after latest state became terminal", issue.ID)
+			}
+			if _, ok := state.Completed[issue.ID]; !ok {
+				t.Fatalf("Completed[%q] missing after latest state became terminal", issue.ID)
+			}
+		})
+	}
+}
+
+func TestMergeWorkerDurationTransitionFailureKeepsDispatchBlocked(t *testing.T) {
+	t.Parallel()
+
+	startedAt := time.Date(2026, 7, 29, 12, 0, 0, 0, time.UTC)
+	completedAt := startedAt.Add(6 * time.Hour)
+	issue := mergeDurationTestIssue("issue-1547-transition-failure")
+	memoryTracker := memory.New(memory.Config{
+		Issues:   []connector.Issue{issue},
+		Stateful: true,
+		Now:      func() time.Time { return completedAt },
+	})
+	tracker := &mergeDurationTransitionConnector{
+		Connector:         memoryTracker,
+		stateUpdateErrors: 1,
+	}
+	cfg := normalizeConfig(Config{
+		MaxConcurrentAgents:    1,
+		MergeWorkerMaxDuration: 6 * time.Hour,
+		Project:                scheduler.ProjectCandidate{ID: "detent", Weight: 1},
+		ActiveStates:           []string{"Merging"},
+		ObservedStates:         []string{"Blocked"},
+		TerminalStates:         []string{"Done", "Cancelled"},
+	})
+	durationLimit := &controlledMergeDurationLimit{}
+	runner := &progressingMergeRunner{progressed: make(chan struct{})}
+	supervisor, err := runpkg.NewSupervisor(runner, runpkg.SupervisorConfig{
+		Now: func() time.Time { return completedAt },
+	})
+	if err != nil {
+		t.Fatalf("NewSupervisor() error = %v", err)
+	}
+	orch := &Orchestrator{
+		cfg:              cfg,
+		connector:        tracker,
+		supervisor:       supervisor,
+		mergeWorkerLimit: durationLimit.Context,
+		runResults:       make(chan runpkg.Completion, 1),
+		runUpdates:       make(chan runUpdate, 1),
+	}
+	state := newState(cfg)
+
+	if !orch.dispatchIssue(t.Context(), &state, issue, 1, startedAt, "") {
+		t.Fatal("dispatchIssue() = false, want true")
+	}
+	select {
+	case <-runner.progressed:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for merge worker progress")
+	}
+	durationLimit.Expire()
+	var completion runpkg.Completion
+	select {
+	case completion = <-orch.runResults:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for cancelled merge worker completion")
+	}
+	orch.handleRunResult(t.Context(), &state, completion)
+
+	blocked, ok := state.Blocked[issue.ID]
+	if !ok || blocked.Source != BlockedSourceMergeDuration ||
+		normalizeState(blocked.Issue.State) != normalizeState(autoPromoteMergingState) {
+		t.Fatalf("Blocked[%q] = %#v, want merge duration reconciliation hold", issue.ID, blocked)
+	}
+	orch.trackCandidateBlockedStatusIssues(&state, []connector.Issue{issue}, completedAt)
+	if _, ok := state.Blocked[issue.ID]; !ok {
+		t.Fatalf("Blocked[%q] cleared by tracker hydration", issue.ID)
+	}
+	if decision := orch.dispatchPlanner().dispatchableIssueDecision(issue, &state, false, completedAt, ""); decision.dispatchable {
+		t.Fatalf("dispatchableIssueDecision() = %#v, want blocked", decision)
+	}
+
+	transitioned := orch.reconcileMergeDurationHolds(
+		t.Context(),
+		&state,
+		[]connector.Issue{issue},
+		completedAt.Add(time.Minute),
+	)
+	if _, ok := transitioned[issue.ID]; !ok {
+		t.Fatalf("reconcileMergeDurationHolds() = %#v, want transitioned issue", transitioned)
+	}
+	blocked = state.Blocked[issue.ID]
+	if blocked.Source != BlockedSourceProjectStatus ||
+		normalizeState(blocked.Issue.State) != normalizeState(blockedStatusState) {
+		t.Fatalf("Blocked[%q] after retry = %#v, want project status block", issue.ID, blocked)
+	}
+}
+
 type controlledMergeDurationLimit struct {
 	cancel   context.CancelCauseFunc
 	duration time.Duration
@@ -296,6 +578,23 @@ type instantMergeRunner struct{}
 
 func (instantMergeRunner) Run(context.Context, RunRequest) (RunResult, error) {
 	return RunResult{FinalState: FinalStateCompleted}, nil
+}
+
+type mergeDurationTransitionConnector struct {
+	connector.Connector
+	stateUpdateErrors int
+}
+
+func (c *mergeDurationTransitionConnector) UpdateIssueState(
+	ctx context.Context,
+	issueID string,
+	state string,
+) error {
+	if c.stateUpdateErrors > 0 {
+		c.stateUpdateErrors--
+		return errors.New("transient state update failure")
+	}
+	return c.Connector.UpdateIssueState(ctx, issueID, state)
 }
 
 func mergeDurationTestIssue(id string) connector.Issue {

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -55,6 +55,7 @@ const (
 	blockedReasonProjectStatus          = "blocked by project status"
 	mergeWorkerTerminalStateMissing     = "merge worker completed without reaching a terminal issue or pull request state"
 	mergeWorkerRetryExhaustedReason     = "merge_worker_retry_exhausted"
+	mergeWorkerDurationExceededReason   = "merge_worker_duration_exceeded"
 )
 
 var (
@@ -71,6 +72,7 @@ type Config struct {
 	PrioritizeUnblockers          bool
 	MergeFastPathEnabled          bool
 	MergeMethod                   string
+	MergeWorkerMaxDuration        time.Duration
 	ResumeOrphanedSessions        bool
 	StopRunTargetState            string
 	StopRunPriorityNames          map[int]string
@@ -165,6 +167,8 @@ type Retrospector interface {
 	Trigger(string)
 }
 
+type runDurationLimitFactory func(context.Context, time.Duration, error) (context.Context, context.CancelFunc)
+
 type WorkspaceReapResult = runpkg.WorkspaceReapResult
 
 type WorkspaceReaper = runpkg.WorkspaceReaper
@@ -210,6 +214,7 @@ type Orchestrator struct {
 	workerProcesses         WorkerProcessStore
 	reapWorkerProcess       WorkerProcessReapFunc
 	workerReapGrace         time.Duration
+	mergeWorkerLimit        runDurationLimitFactory
 	heartbeats              *heartbeatManager
 	hydrationSkipStreaks    map[string]int
 	hydrationWarned         bool

--- a/internal/orchestrator/reconcile.go
+++ b/internal/orchestrator/reconcile.go
@@ -510,7 +510,8 @@ func (o *Orchestrator) setBlockedStatusIssue(state *State, issue connector.Issue
 			strings.HasPrefix(existing.Reason, repeatedFailureBlockedReasonPrefix) ||
 			strings.HasPrefix(existing.Reason, tokenCeilingBlockedReasonPrefix) ||
 			strings.HasPrefix(existing.Reason, artifactGateConvergenceBlockedReasonPrefix) ||
-			strings.HasPrefix(existing.Reason, mergeWorkerRetryExhaustedReason)) &&
+			strings.HasPrefix(existing.Reason, mergeWorkerRetryExhaustedReason) ||
+			strings.HasPrefix(existing.Reason, mergeWorkerDurationExceededReason)) &&
 		strings.TrimSpace(issue.BlockerReason) == "" {
 		existing.Issue = cloneIssue(issue)
 		state.Blocked[issue.ID] = existing

--- a/internal/orchestrator/run_completion.go
+++ b/internal/orchestrator/run_completion.go
@@ -150,6 +150,9 @@ func (o *Orchestrator) handleRunResult(ctx context.Context, state *State, event 
 	if o.handleMergeRevocationCompletion(ctx, state, event, running) {
 		return
 	}
+	if o.handleMergeWorkerDurationExceeded(ctx, state, event, running) {
+		return
+	}
 	if o.handleGitHubRESTCapacityCompletion(ctx, state, event, running) {
 		o.recordProjectAttemptOutcome(state, event.IssueID, event.CompletedAt, store.WorkAttemptTerminalFailure, event.Err, "github_rest_capacity", errorString(event.Err))
 		return

--- a/internal/orchestrator/state.go
+++ b/internal/orchestrator/state.go
@@ -134,6 +134,7 @@ type BlockedSource = telemetry.BlockedSource
 
 const (
 	BlockedSourceDependency    = telemetry.BlockedSourceDependency
+	BlockedSourceMergeDuration = telemetry.BlockedSourceMergeDuration
 	BlockedSourceProjectStatus = telemetry.BlockedSourceProjectStatus
 	BlockedSourceOperatorStop  = telemetry.BlockedSourceOperatorStop
 )

--- a/internal/orchestrator/tick.go
+++ b/internal/orchestrator/tick.go
@@ -118,6 +118,7 @@ func (o *Orchestrator) tickWithManual(ctx context.Context, state *State, now tim
 	o.observePullRequestHydrationSkips(mergeIssueSlices(fetched.candidates, fetched.status))
 	o.restoreDurableGateWaitCompletions(ctx, state, mergeIssueSlices(fetched.candidates, fetched.status))
 	fetched = filterReconciledTickIssues(state, fetched, o.reconcileOperatorStopHolds(ctx, state, mergeIssueSlices(fetched.candidates, fetched.status), now))
+	fetched = filterReconciledTickIssues(state, fetched, o.reconcileMergeDurationHolds(ctx, state, mergeIssueSlices(fetched.candidates, fetched.status), now))
 
 	transitions := o.refreshTransitionSets(ctx, state, fetched, previous)
 	completedEpics := o.resolveCompletedEpics(ctx, state, transitions, previous)

--- a/internal/orchestrator/work_attempts.go
+++ b/internal/orchestrator/work_attempts.go
@@ -24,6 +24,7 @@ const (
 	workAttemptErrorRunner          = "runner_error"
 	workAttemptErrorStartTransition = "start_state_transition_failed"
 	workAttemptErrorMergeIncomplete = "merge_worker_terminal_state_missing"
+	workAttemptErrorMergeDuration   = "merge_worker_duration_exceeded"
 )
 
 func (o *Orchestrator) recoverDurableWorkAttempts(ctx context.Context, state *State, now time.Time) {

--- a/internal/runner/agent.go
+++ b/internal/runner/agent.go
@@ -2136,6 +2136,9 @@ func finalStateForTurnError(err error) string {
 	if errors.Is(err, ErrMergeRevoked) {
 		return FinalStateMergeRevoked
 	}
+	if errors.Is(err, ErrMergeWorkerDurationExceeded) {
+		return FinalStateMergeDurationExceeded
+	}
 	if errors.Is(err, ErrSessionTokenCeilingExceeded) {
 		return FinalStateTokenCeilingExceeded
 	}

--- a/internal/runner/supervisor.go
+++ b/internal/runner/supervisor.go
@@ -187,6 +187,10 @@ func (s *Supervisor) Run(ctx context.Context, request RunRequest) (completion Co
 	}()
 
 	result, err := s.backend.Run(ctx, request)
+	if cause := context.Cause(ctx); errors.Is(cause, ErrMergeWorkerDurationExceeded) {
+		err = errors.Join(cause, err)
+		result.FinalState = FinalStateMergeDurationExceeded
+	}
 	completion.CompletedAt = s.now()
 	completion.Result = result
 	completion.Err = err
@@ -194,7 +198,9 @@ func (s *Supervisor) Run(ctx context.Context, request RunRequest) (completion Co
 }
 
 func cooperativeStopError(err error) bool {
-	return errors.Is(err, ErrOperatorStopped) || errors.Is(err, ErrMergeRevoked)
+	return errors.Is(err, ErrOperatorStopped) ||
+		errors.Is(err, ErrMergeRevoked) ||
+		errors.Is(err, ErrMergeWorkerDurationExceeded)
 }
 
 func (s *Supervisor) OverloadRetryDelay() time.Duration {

--- a/internal/runner/supervisor_test.go
+++ b/internal/runner/supervisor_test.go
@@ -138,6 +138,14 @@ func TestSupervisorDoesNotRetryMergeRevokedRun(t *testing.T) {
 	}
 }
 
+func TestMergeWorkerDurationExceededFinalState(t *testing.T) {
+	t.Parallel()
+
+	if got := finalStateForTurnError(ErrMergeWorkerDurationExceeded); got != FinalStateMergeDurationExceeded {
+		t.Fatalf("finalStateForTurnError() = %q, want %q", got, FinalStateMergeDurationExceeded)
+	}
+}
+
 func TestSupervisorUsesFlatSameAttemptRetryForTransientOverload(t *testing.T) {
 	t.Parallel()
 

--- a/internal/runner/types.go
+++ b/internal/runner/types.go
@@ -23,6 +23,7 @@ const (
 	FinalStateTokenCeilingExceeded  = "token_ceiling_exceeded"
 	FinalStateOperatorStopped       = "operator_stopped"
 	FinalStateMergeRevoked          = "merge_revoked"
+	FinalStateMergeDurationExceeded = "merge_duration_exceeded"
 	TokenCeilingSourceAbsolute      = "max_session_tokens"
 	TokenCeilingSourceContextWindow = "max_session_context_multiplier"
 
@@ -41,6 +42,7 @@ var (
 	ErrSessionDurationExceeded     = errors.New("agent session duration exceeded")
 	ErrOperatorStopped             = errors.New("operator stopped run")
 	ErrMergeRevoked                = errors.New("merge eligibility revoked")
+	ErrMergeWorkerDurationExceeded = errors.New("merge worker duration exceeded")
 	ErrAgentTurnCleanup            = errors.New("agent turn cleanup failed")
 	ErrAgentResumeUnsupported      = errors.New("agent backend does not support resume verification")
 )

--- a/internal/telemetry/snapshot.go
+++ b/internal/telemetry/snapshot.go
@@ -573,6 +573,7 @@ type BlockedSource string
 
 const (
 	BlockedSourceDependency    BlockedSource = "dependency"
+	BlockedSourceMergeDuration BlockedSource = "merge_duration_reconciliation"
 	BlockedSourceProjectStatus BlockedSource = "project_status"
 	BlockedSourceOperatorStop  BlockedSource = "operator_stop_reconciliation"
 )


### PR DESCRIPTION
## Summary

- add a configurable six-hour default hard wall-clock ceiling for workers in `Merging`
- cancel breached workers through the owned run context, release capacity, and park the issue in `Blocked` with WARN progress telemetry
- add deterministic regression coverage for a progressing stuck worker and an unaffected normal merge

Fixes #1547

## UI Surface Contract

- [x] N/A — no UI surface or layout changes.
- [x] This PR does not add persistent top-of-screen messaging.
- [x] N/A — no visual changes to primary operator screens.

## Test Plan

- [x] focused merge-duration tests under `-race -count=10`
- [x] `make check`