### PR TITLE
fix(observability): report saturated merge queue

### DIFF
--- a/internal/orchestrator/autopromote_tick.go
+++ b/internal/orchestrator/autopromote_tick.go
@@ -1216,11 +1216,11 @@ func mergeWorkerRepositoryKey(issue connector.Issue) string {
 	return strings.ToLower(strings.TrimSpace(pullRequestRepository(issue)))
 }
 
-func (o *Orchestrator) mergeWorkerDispatchCandidates(state *State, issues []connector.Issue) []connector.Issue {
+func (o *Orchestrator) mergeWorkerDispatchCandidates(state *State, issues []connector.Issue, now time.Time) []connector.Issue {
 	if o.dispatchQuiesced() {
 		return nil
 	}
-	o.logMergeWorkerQueueCycle(issues)
+	o.logMergeWorkerQueueCycle(state, issues, now)
 	candidates := o.staleMergingQueueDispatchCandidates(state, issues)
 	if len(candidates) == 0 {
 		return nil
@@ -1264,26 +1264,74 @@ func (o *Orchestrator) mergeWorkerDispatchCandidates(state *State, issues []conn
 	return out
 }
 
-func (o *Orchestrator) logMergeWorkerQueueCycle(issues []connector.Issue) {
+func (o *Orchestrator) logMergeWorkerQueueCycle(state *State, issues []connector.Issue, now time.Time) {
 	if o.logger == nil {
 		return
 	}
 	queueDepth := 0
 	readyCount := 0
+	queueIssueIDs := map[string]struct{}{}
 	for _, issue := range issues {
 		if !mergeWorkerIssue(issue) {
 			continue
 		}
 		queueDepth++
+		queueIssueIDs[strings.TrimSpace(issue.ID)] = struct{}{}
 		if mergeWorkerHeadReady(issue) {
 			readyCount++
 		}
 	}
-	o.logger.Info(
-		"merge_worker_queue_cycle",
+	projectStats := o.projectStateSlotStats(connector.Issue{State: autoPromoteMergingState}, state)
+	occupant, occupantCount := mergeWorkerLaneOccupant(state)
+	queuedBehind := queueDepth
+	for issueID := range queueIssueIDs {
+		if staleMergingPullRequestDispatchActive(state, issueID) {
+			queuedBehind--
+		}
+	}
+	if queuedBehind < 0 {
+		queuedBehind = 0
+	}
+	attrs := []any{
 		"queue_depth", queueDepth,
 		"ready_count", readyCount,
-	)
+		"lane_occupied", occupantCount > 0,
+		"lane_saturated", projectStats.available <= 0,
+		"lane_occupant_count", occupantCount,
+		"queued_behind", queuedBehind,
+	}
+	if occupantCount > 0 {
+		occupancySeconds := int64(0)
+		if !occupant.StartedAt.IsZero() && !now.Before(occupant.StartedAt) {
+			occupancySeconds = int64(now.Sub(occupant.StartedAt) / time.Second)
+		}
+		attrs = append(attrs,
+			"occupying_issue_id", strings.TrimSpace(occupant.Issue.ID),
+			"occupying_issue_identifier", strings.TrimSpace(occupant.Issue.Identifier),
+			"occupying_issue_number", issueNumberFromIdentifier(occupant.Issue.Identifier),
+			"occupancy_seconds", occupancySeconds,
+		)
+	}
+	o.logger.Info("merge_worker_queue_cycle", attrs...)
+}
+
+func mergeWorkerLaneOccupant(state *State) (Running, int) {
+	if state == nil {
+		return Running{}, 0
+	}
+	var occupant Running
+	count := 0
+	for _, running := range state.Running {
+		if !mergeWorkerIssue(running.Issue) {
+			continue
+		}
+		count++
+		if occupant.Issue.ID == "" ||
+			(!running.StartedAt.IsZero() && (occupant.StartedAt.IsZero() || running.StartedAt.Before(occupant.StartedAt))) {
+			occupant = running
+		}
+	}
+	return occupant, count
 }
 
 func prioritizeReadyMergingIssues(issues []connector.Issue) {

--- a/internal/orchestrator/autopromote_tick_test.go
+++ b/internal/orchestrator/autopromote_tick_test.go
@@ -3,6 +3,7 @@ package orchestrator
 import (
 	"context"
 	"errors"
+	"fmt"
 	"io"
 	"log/slog"
 	"path/filepath"
@@ -289,8 +290,8 @@ func TestTickAutoPromoteHumanReviewIssues(t *testing.T) {
 			if len(tracker.fetchByStatesRequests) != 1 {
 				t.Fatalf("FetchIssuesByStates() calls = %d, want 1", len(tracker.fetchByStatesRequests))
 			}
-			if !autoPromoteTickStatesEqual(tracker.fetchByStatesRequests[0], []string{"Blocked", "Human Review"}) {
-				t.Fatalf("FetchIssuesByStates() states = %#v, want Blocked/Human Review", tracker.fetchByStatesRequests[0])
+			if !autoPromoteTickStatesEqual(tracker.fetchByStatesRequests[0], []string{"Blocked", "Human Review", "Merging"}) {
+				t.Fatalf("FetchIssuesByStates() states = %#v, want Blocked/Human Review/Merging", tracker.fetchByStatesRequests[0])
 			}
 			if len(tt.wantCommentFragments) == 0 {
 				if len(tracker.comments) != 0 {
@@ -4311,7 +4312,7 @@ func TestMergeWorkerDispatchCandidatesPreservesScheduledRetry(t *testing.T) {
 	}
 	orch := &Orchestrator{cfg: cfg}
 
-	got := orch.mergeWorkerDispatchCandidates(&state, []connector.Issue{issue})
+	got := orch.mergeWorkerDispatchCandidates(&state, []connector.Issue{issue}, now)
 	if len(got) != 0 {
 		t.Fatalf("mergeWorkerDispatchCandidates() = %#v, want none while retry is scheduled", got)
 	}
@@ -4357,7 +4358,7 @@ func TestMergeWorkerDispatchCandidatesPrefersReadyHead(t *testing.T) {
 		logger: slog.New(slog.NewTextHandler(&logs, nil)),
 	}
 
-	got := orch.mergeWorkerDispatchCandidates(&state, []connector.Issue{waiting, ready})
+	got := orch.mergeWorkerDispatchCandidates(&state, []connector.Issue{waiting, ready}, now)
 	if len(got) != 1 || got[0].ID != ready.ID {
 		t.Fatalf("mergeWorkerDispatchCandidates() = %#v, want ready issue %q", got, ready.ID)
 	}
@@ -4369,6 +4370,108 @@ func TestMergeWorkerDispatchCandidatesPrefersReadyHead(t *testing.T) {
 		if !strings.Contains(logs.String(), fragment) {
 			t.Fatalf("logs %q missing fragment %q", logs.String(), fragment)
 		}
+	}
+}
+
+func TestLogMergeWorkerQueueCycle(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 7, 29, 12, 0, 0, 0, time.UTC)
+	cfg := normalizeConfig(Config{
+		MaxConcurrentAgents: 3,
+		MaxConcurrentAgentsByState: map[string]int{
+			"Merging": 1,
+		},
+		ActiveStates:   []string{"Merging"},
+		TerminalStates: []string{"Done"},
+	})
+	readyIssue := func(id, identifier string, number int) connector.Issue {
+		issue := autoPromoteTickIssue(id, []string{"bug"}, &connector.PullRequest{
+			Number:         number,
+			URL:            fmt.Sprintf("https://github.test/digitaldrywood/detent/pull/%d", number),
+			State:          "OPEN",
+			MergeableState: "clean",
+			CIStatus:       "success",
+			HeadSHA:        fmt.Sprintf("head-%d", number),
+		})
+		issue.State = autoPromoteMergingState
+		issue.Identifier = identifier
+		return issue
+	}
+	occupant := readyIssue("issue-occupant", "digitaldrywood/detent#1540", 1550)
+	firstWaiting := readyIssue("issue-first-waiting", "digitaldrywood/detent#1541", 1551)
+	secondWaiting := readyIssue("issue-second-waiting", "digitaldrywood/detent#1542", 1552)
+
+	tests := []struct {
+		name        string
+		state       State
+		issues      []connector.Issue
+		want        []string
+		doesNotWant []string
+	}{
+		{
+			name: "saturated lane with backlog",
+			state: func() State {
+				state := newState(cfg)
+				state.Running[occupant.ID] = Running{
+					Issue:     cloneIssue(occupant),
+					StartedAt: now.Add(-5 * time.Minute),
+				}
+				return state
+			}(),
+			issues: []connector.Issue{occupant, firstWaiting, secondWaiting},
+			want: []string{
+				"queue_depth=3",
+				"ready_count=3",
+				"lane_occupied=true",
+				"lane_saturated=true",
+				"lane_occupant_count=1",
+				"queued_behind=2",
+				"occupying_issue_id=issue-occupant",
+				"occupying_issue_identifier=digitaldrywood/detent#1540",
+				"occupying_issue_number=1540",
+				"occupancy_seconds=300",
+			},
+		},
+		{
+			name:   "free lane with empty queue",
+			state:  newState(cfg),
+			issues: nil,
+			want: []string{
+				"queue_depth=0",
+				"ready_count=0",
+				"lane_occupied=false",
+				"lane_saturated=false",
+				"lane_occupant_count=0",
+				"queued_behind=0",
+			},
+			doesNotWant: []string{"occupying_issue_id", "occupancy_seconds"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			var logs strings.Builder
+			orch := &Orchestrator{
+				cfg:    cfg,
+				logger: slog.New(slog.NewTextHandler(&logs, nil)),
+			}
+
+			orch.logMergeWorkerQueueCycle(&tt.state, tt.issues, now)
+
+			for _, fragment := range tt.want {
+				if !strings.Contains(logs.String(), fragment) {
+					t.Errorf("logs %q missing fragment %q", logs.String(), fragment)
+				}
+			}
+			for _, fragment := range tt.doesNotWant {
+				if strings.Contains(logs.String(), fragment) {
+					t.Errorf("logs %q contain fragment %q", logs.String(), fragment)
+				}
+			}
+		})
 	}
 }
 
@@ -4454,7 +4557,7 @@ func TestMergeWorkerDispatchCandidatesSelectsOneQueueHeadPerRepository(t *testin
 	state := newState(cfg)
 	orch := &Orchestrator{cfg: cfg}
 
-	got := orch.mergeWorkerDispatchCandidates(&state, []connector.Issue{phoneSibling, outlet, phoneHead})
+	got := orch.mergeWorkerDispatchCandidates(&state, []connector.Issue{phoneSibling, outlet, phoneHead}, now)
 	gotIDs := make([]string, 0, len(got))
 	for _, issue := range got {
 		gotIDs = append(gotIDs, issue.ID)
@@ -4517,7 +4620,7 @@ func TestMergeWorkerDispatchCandidatesConsumesNotReadyQueueHeadRepository(t *tes
 	state := newState(cfg)
 	orch := &Orchestrator{cfg: cfg}
 
-	got := orch.mergeWorkerDispatchCandidates(&state, []connector.Issue{phoneSibling, outlet, phoneHead})
+	got := orch.mergeWorkerDispatchCandidates(&state, []connector.Issue{phoneSibling, outlet, phoneHead}, now)
 	gotIDs := make([]string, 0, len(got))
 	for _, issue := range got {
 		gotIDs = append(gotIDs, issue.ID)
@@ -4569,7 +4672,7 @@ func TestMergeWorkerDispatchCandidatesWaitsWhenMergingLaneFull(t *testing.T) {
 		logger: slog.New(slog.NewTextHandler(&logs, nil)),
 	}
 
-	got := orch.mergeWorkerDispatchCandidates(&state, []connector.Issue{waiting})
+	got := orch.mergeWorkerDispatchCandidates(&state, []connector.Issue{waiting}, now)
 	if len(got) != 0 {
 		t.Fatalf("mergeWorkerDispatchCandidates() = %#v, want none while Merging lane is full", got)
 	}
@@ -4591,7 +4694,7 @@ func TestMergeWorkerDispatchCandidatesWaitsWhenMergingLaneFull(t *testing.T) {
 	}
 }
 
-func TestFetchTickIssuesSkipsMergingStatusHydrationWhenMergingLaneFull(t *testing.T) {
+func TestFetchTickIssuesIncludesMergingStatusHydrationWhenMergingLaneFull(t *testing.T) {
 	t.Parallel()
 
 	now := time.Date(2026, 6, 25, 21, 5, 0, 0, time.UTC)
@@ -4654,14 +4757,21 @@ func TestFetchTickIssuesSkipsMergingStatusHydrationWhenMergingLaneFull(t *testin
 	if len(tracker.fetchByStatesRequests) != 1 {
 		t.Fatalf("FetchIssuesByStates requests = %#v, want one observed status fetch", tracker.fetchByStatesRequests)
 	}
+	mergingFetched := false
 	for _, stateName := range tracker.fetchByStatesRequests[0] {
 		if normalizeState(stateName) == normalizeState(autoPromoteMergingState) {
-			t.Fatalf("FetchIssuesByStates states = %#v, want Merging omitted while lane is full", tracker.fetchByStatesRequests[0])
+			mergingFetched = true
 		}
+	}
+	if !mergingFetched {
+		t.Fatalf("FetchIssuesByStates states = %#v, want Merging included while lane is full", tracker.fetchByStatesRequests[0])
+	}
+	if got := len(issuesInStates(fetched.status, []string{autoPromoteMergingState})); got != 2 {
+		t.Fatalf("Merging status issue count = %d, want 2", got)
 	}
 }
 
-func TestTickPreservesDueMergingRetryWhenLaneFullAndMergingFetchOmitted(t *testing.T) {
+func TestTickPreservesDueMergingRetryWhenLaneFullAndCandidateFetchOmitted(t *testing.T) {
 	t.Parallel()
 
 	now := time.Date(2026, 6, 25, 21, 7, 0, 0, time.UTC)

--- a/internal/orchestrator/merge_queue_test.go
+++ b/internal/orchestrator/merge_queue_test.go
@@ -67,7 +67,7 @@ func TestDelegateNativeMergeQueueIssuesEnqueuesGreenTrainWithoutWorkerDispatch(t
 			t.Fatalf("issue %q merge queue entry missing", issue.ID)
 		}
 	}
-	if candidates := orch.mergeWorkerDispatchCandidates(&state, queued); len(candidates) != 0 {
+	if candidates := orch.mergeWorkerDispatchCandidates(&state, queued, now); len(candidates) != 0 {
 		t.Fatalf("merge worker candidates = %#v, want native queue entries excluded", candidates)
 	}
 }
@@ -225,7 +225,7 @@ func TestDelegateNativeMergeQueueIssuesFallsBackWhenCachedQueueDisappears(t *tes
 	if second[0].PullRequest == nil || second[0].PullRequest.MergeQueueEntry != nil {
 		t.Fatalf("pull request = %#v, want stale queue entry cleared", second[0].PullRequest)
 	}
-	candidates := orch.mergeWorkerDispatchCandidates(&state, second)
+	candidates := orch.mergeWorkerDispatchCandidates(&state, second, now.Add(nativeMergeQueueEntryRefresh))
 	if len(candidates) != 1 || candidates[0].ID != issue.ID {
 		t.Fatalf("merge worker candidates = %#v, want fallback issue %q", candidates, issue.ID)
 	}
@@ -260,7 +260,7 @@ func TestDelegateNativeMergeQueueIssuesRecoversExistingEntriesAfterRestart(t *te
 	if len(tracker.enqueued) != 0 {
 		t.Fatalf("enqueued = %#v, want existing entries observed without mutation", tracker.enqueued)
 	}
-	if candidates := orch.mergeWorkerDispatchCandidates(&state, queued); len(candidates) != 0 {
+	if candidates := orch.mergeWorkerDispatchCandidates(&state, queued, time.Now()); len(candidates) != 0 {
 		t.Fatalf("merge worker candidates = %#v, want recovered queue entries excluded", candidates)
 	}
 }
@@ -292,7 +292,7 @@ func TestDelegateNativeMergeQueueIssuesFallsBackWithoutNativeQueue(t *testing.T)
 	if len(tracker.enqueued) != 0 {
 		t.Fatalf("enqueued = %#v, want no native enqueue", tracker.enqueued)
 	}
-	candidates := orch.mergeWorkerDispatchCandidates(&state, queued)
+	candidates := orch.mergeWorkerDispatchCandidates(&state, queued, time.Now())
 	if len(candidates) != 1 || candidates[0].ID != issue.ID {
 		t.Fatalf("merge worker candidates = %#v, want fallback issue %q", candidates, issue.ID)
 	}

--- a/internal/orchestrator/reconcile.go
+++ b/internal/orchestrator/reconcile.go
@@ -33,12 +33,8 @@ func (o *Orchestrator) observedStatusFetchStates() []string {
 	return displayStateNames(states)
 }
 
-func (o *Orchestrator) observedStatusFetchStatesForTick(state *State) []string {
-	states := o.observedStatusFetchStates()
-	if !autoPromoteUsesMergePassState(o.cfg.AutoPromote) || o.mergeWorkerLocalSlotsAvailable(state) {
-		return states
-	}
-	return statesWithoutState(states, autoPromoteMergingState)
+func (o *Orchestrator) observedStatusFetchStatesForTick(_ *State) []string {
+	return o.observedStatusFetchStates()
 }
 
 func (o *Orchestrator) mergeWorkerLocalSlotsAvailable(state *State) bool {

--- a/internal/orchestrator/tick.go
+++ b/internal/orchestrator/tick.go
@@ -179,7 +179,7 @@ func (o *Orchestrator) tickWithManual(ctx context.Context, state *State, now tim
 		state.Pipeline = overlayNativeMergeQueueIssues(state.Pipeline, mergeQueueIssues)
 		fetched.candidates = mergeIssueSlices(
 			fetched.candidates,
-			o.mergeWorkerDispatchCandidates(state, mergeQueueIssues),
+			o.mergeWorkerDispatchCandidates(state, mergeQueueIssues, now),
 		)
 	}
 	fetched = filterReconciledTickIssues(


### PR DESCRIPTION
## Summary

- Keep Merging issues in the observed-status fetch even when the local merge lane is saturated.
- Report complete merge queue depth/readiness plus lane saturation, occupant identity, hold duration, and queued-behind telemetry.
- Add regression coverage for saturated backlogs and free empty lanes.

Fixes #1548

## UI Surface Contract

- [x] N/A, or the linked issue explicitly authorizes any high-impact UI surface, layout, density, first-viewport, or responsive visibility tradeoff.
- [x] Persistent top-of-screen messaging is explicitly authorized by the issue, or this PR does not add it.
- [x] Visual changes to primary operator screens include screenshot or browser verification below.

No UI changes.

## Test Plan

- [x] `go test ./internal/orchestrator`
- [x] `make check`
