### PR TITLE
feat(admission): track target provenance

### DIFF
--- a/README.md
+++ b/README.md
@@ -1177,7 +1177,10 @@ Backlog admission evaluates existing issues and proposes which ones should
 become eligible for dispatch. It does not create work like routines, classify
 incoming work like intake, rank eligible work like the scheduler, or change
 issue status. Every proposal is a durable record with an expiry and one audit
-comment; a human accepts it by moving the issue to the configured target state.
+comment. To accept a proposal, an operator posts the exact proposal-specific
+`/detent admission accept <proposal-id>` command and then moves the issue to the
+configured target state. To reject it, the operator posts
+`/detent admission reject <proposal-id>`.
 
 Admission is disabled unless a project opts in:
 
@@ -1232,6 +1235,13 @@ title/body fingerprint, so the proposal's own comment cannot create a
 duplicate. Unanswered proposals expire; an issue demoted after acceptance is
 not proposed again.
 
+Acceptance is attributed only when the command names an open proposal and a
+subsequent transition enters that proposal's target state. When both events
+include actors, they must identify the same actor. A target-state transition
+without that correlation remains an unattributed transition and does not accept
+the proposal. Rejection, expiry, and supersession are separate outcomes:
+silence can expire a proposal but never accepts or rejects one.
+
 GitHub, `github_local`, `local_sqlite`, and `memory` trackers support
 state-based admission. Linear configurations fail validation because their
 state readers are not implemented. `authors.allow` on `local_sqlite` or
@@ -1241,10 +1251,29 @@ first 20 issue labels are fetched. The memory tracker is evaluation-only across
 restarts: durable proposal records can survive while its process-local comments
 and mutations do not.
 
-The admission ledger records timing, candidate, proposal, skip, truncation,
-deferral, failure, and issue-reference details. `detent doctor` warns when
-criteria cannot be resolved, admission has never run, tracker limitations
-apply, or three consecutive runs fail, and shows the latest result otherwise.
+Every lane-entry event records how the issue reached the state:
+
+- `human` means the tracker explicitly identified a `User` actor for the
+  transition. It confirms a person moved the issue, but does not imply that the
+  person endorsed any admission proposal.
+- `routine` and `retro` are unattended Detent-created transitions and imply no
+  human vetting.
+- `dependency` is a deterministic dependency auto-unblock or blocker promotion
+  and implies no human vetting at transition time.
+- `admission` means an explicit accept command was correlated with an open
+  proposal and its later target-state transition. This is proposal-specific
+  operator approval.
+- `unknown` means the tracker did not provide enough actor or mechanism data.
+  Detent never guesses that an unknown transition was human.
+
+The board card and detail sheet show the current lane origin and actor when one
+is available. The admission ledger records accepted, rejected, expired, and
+superseded proposal counts with average decision time. Accepted proposals also
+accumulate completion, rework entries, review events, and metered spend after
+the decision. `detent doctor` reports that labeled history alongside the origin
+distribution; it does not reduce calibration to a single acceptance
+percentage. It also warns when criteria cannot be resolved, admission has never
+run, tracker limitations apply, or three consecutive runs fail.
 
 ### Efficiency retrospection
 

--- a/internal/admission/manager.go
+++ b/internal/admission/manager.go
@@ -47,7 +47,9 @@ type Store interface {
 	CountOpenAdmissionProposals(context.Context, string) (int, error)
 	ExpireAdmissionProposals(context.Context, string, time.Time) (int, error)
 	TransitionAdmissionProposal(context.Context, string, admissionmodel.ProposalStatus, admissionmodel.ProposalStatus, time.Time) error
+	ResolveAdmissionProposal(context.Context, admissionmodel.Decision) error
 	MarkAdmissionProposalCommented(context.Context, string, time.Time) error
+	RefreshAdmissionOutcomes(context.Context, admissionmodel.OutcomeRefresh) error
 	RecordAdmissionRun(context.Context, admissionmodel.RunRecord) error
 	LatestAdmissionRun(context.Context, string) (admissionmodel.RunRecord, bool, error)
 }
@@ -70,6 +72,8 @@ type Settings struct {
 	Scheduler          scheduler.Scheduler
 	GlobalDispatchGate scheduler.ProjectDispatchGate
 	ProjectCandidate   scheduler.ProjectCandidate
+	TerminalStates     []string
+	ReworkState        string
 }
 
 type Result struct {
@@ -287,6 +291,14 @@ func (m *Manager) runOnce(ctx context.Context, settings Settings, scheduledFor t
 	if err != nil {
 		return result, err
 	}
+	if err := m.store.RefreshAdmissionOutcomes(ctx, admissionmodel.OutcomeRefresh{
+		ProjectID:      settings.ProjectID,
+		TerminalStates: settings.TerminalStates,
+		ReworkState:    settings.ReworkState,
+		ObservedAt:     startedAt,
+	}); err != nil {
+		return result, err
+	}
 	if deferred, reason, err := admissionBudgetDeferred(ctx, settings.Runner, startedAt); err != nil {
 		return result, err
 	} else if deferred {
@@ -405,24 +417,49 @@ func (m *Manager) reconcileOpenProposals(
 		return commentsRemaining, fmt.Errorf("reconcile backlog admission proposals: %w", err)
 	}
 	byID := issueMap(issues)
+	commentReader, ok := settings.Issues.(connector.IssueCommentReader)
+	if !ok {
+		return commentsRemaining, errors.New("backlog admission issue comment reader is required")
+	}
+	commentsByIssue := map[string][]connector.IssueComment{}
 	for _, proposal := range proposals {
 		issue, ok := byID[proposal.IssueID]
-		switch {
-		case !ok:
-			if err := m.store.TransitionAdmissionProposal(ctx, proposal.ID, admissionmodel.ProposalOpen, admissionmodel.ProposalRejected, at); err != nil {
+		if !ok {
+			continue
+		}
+		comments, loaded := commentsByIssue[proposal.IssueID]
+		if !loaded {
+			comments, err = commentReader.FetchIssueComments(ctx, issue)
+			if err != nil {
+				return commentsRemaining, fmt.Errorf("read backlog admission decision comments: %w", err)
+			}
+			commentsByIssue[proposal.IssueID] = comments
+		}
+		decision, decided := proposalDecision(proposal, comments)
+		if decided && decision.Outcome == admissionmodel.ProposalRejected {
+			if err := m.store.ResolveAdmissionProposal(ctx, decision); err != nil {
 				return commentsRemaining, err
 			}
 			continue
-		case ok && strings.EqualFold(strings.TrimSpace(issue.State), proposal.TargetState):
-			if err := m.store.TransitionAdmissionProposal(ctx, proposal.ID, admissionmodel.ProposalOpen, admissionmodel.ProposalAccepted, at); err != nil {
+		}
+		if decided && decision.Outcome == admissionmodel.ProposalAccepted &&
+			strings.EqualFold(strings.TrimSpace(issue.State), proposal.TargetState) {
+			transition, found, err := admissionIssueTransition(ctx, settings.Issues, issue)
+			if err != nil {
 				return commentsRemaining, err
 			}
-			continue
-		case ok && (issue.Closed || !containsFold(settings.Config.Sources.States, issue.State)):
-			if err := m.store.TransitionAdmissionProposal(ctx, proposal.ID, admissionmodel.ProposalOpen, admissionmodel.ProposalRejected, at); err != nil {
-				return commentsRemaining, err
+			if found && !transition.EnteredAt.Before(decision.DecidedAt) &&
+				admissionActorsCorrelate(decision.ActorLogin, transition.Actor.Login) {
+				decision.TransitionAt = transition.EnteredAt
+				if strings.TrimSpace(transition.Actor.Login) != "" {
+					decision.ActorLogin = transition.Actor.Login
+					decision.ActorKind = transition.Actor.Kind
+				}
+				if err := m.store.ResolveAdmissionProposal(ctx, decision); err != nil {
+					return commentsRemaining, err
+				}
+				continue
 			}
-			continue
 		}
 		if proposal.CommentedAt.IsZero() && commentsRemaining > 0 {
 			if err := m.commentProposal(ctx, settings, proposal); err != nil {
@@ -567,6 +604,69 @@ func (m *Manager) commentProposal(ctx context.Context, settings Settings, propos
 		return fmt.Errorf("mark backlog admission audit comment: %w", err)
 	}
 	return nil
+}
+
+func proposalDecision(proposal admissionmodel.Proposal, comments []connector.IssueComment) (admissionmodel.Decision, bool) {
+	notBefore := proposal.CreatedAt
+	if proposal.CommentedAt.After(notBefore) {
+		notBefore = proposal.CommentedAt
+	}
+	accept := admissionAcceptCommand(proposal.ID)
+	reject := admissionRejectCommand(proposal.ID)
+	var decision admissionmodel.Decision
+	for _, comment := range comments {
+		if comment.CreatedAt == nil || comment.CreatedAt.IsZero() || comment.CreatedAt.Before(notBefore) {
+			continue
+		}
+		var outcome admissionmodel.ProposalStatus
+		switch strings.TrimSpace(comment.Body) {
+		case accept:
+			outcome = admissionmodel.ProposalAccepted
+		case reject:
+			outcome = admissionmodel.ProposalRejected
+		default:
+			continue
+		}
+		if !decision.DecidedAt.IsZero() && !comment.CreatedAt.After(decision.DecidedAt) {
+			continue
+		}
+		decision = admissionmodel.Decision{
+			ProposalID: proposal.ID,
+			Outcome:    outcome,
+			DecidedAt:  comment.CreatedAt.UTC(),
+			CommentID:  comment.ID,
+			ActorLogin: comment.AuthorLogin,
+			ActorKind:  comment.AuthorKind,
+		}
+	}
+	return decision, !decision.DecidedAt.IsZero()
+}
+
+func admissionIssueTransition(ctx context.Context, issues IssueStore, issue connector.Issue) (connector.IssueStateTransition, bool, error) {
+	if reader, ok := issues.(connector.IssueStateTransitionReader); ok {
+		transition, found, err := reader.IssueStateTransition(ctx, issue)
+		if err != nil || found {
+			return transition, found, err
+		}
+	}
+	if issue.StageUpdatedAt == nil || issue.StageUpdatedAt.IsZero() {
+		return connector.IssueStateTransition{}, false, nil
+	}
+	return connector.IssueStateTransition{EnteredAt: issue.StageUpdatedAt.UTC()}, true, nil
+}
+
+func admissionActorsCorrelate(decisionActor string, transitionActor string) bool {
+	decisionActor = strings.TrimSpace(decisionActor)
+	transitionActor = strings.TrimSpace(transitionActor)
+	return decisionActor == "" || transitionActor == "" || strings.EqualFold(decisionActor, transitionActor)
+}
+
+func admissionAcceptCommand(proposalID string) string {
+	return "/detent admission accept " + strings.TrimSpace(proposalID)
+}
+
+func admissionRejectCommand(proposalID string) string {
+	return "/detent admission reject " + strings.TrimSpace(proposalID)
 }
 
 func (m *Manager) nextScheduled(ctx context.Context) (time.Time, bool, error) {
@@ -772,7 +872,11 @@ func proposalComment(proposal admissionmodel.Proposal) string {
 	b.WriteString(proposal.ID)
 	b.WriteString("` recommends moving this issue to **")
 	b.WriteString(proposal.TargetState)
-	b.WriteString("**. Detent has not changed the issue status. Move it to that state to accept; leaving it unactioned will expire the proposal.\n\n")
+	b.WriteString("**. Detent has not changed the issue status. To accept, reply with `")
+	b.WriteString(admissionAcceptCommand(proposal.ID))
+	b.WriteString("` and then move the issue to that state. To reject, reply with `")
+	b.WriteString(admissionRejectCommand(proposal.ID))
+	b.WriteString("`. Leaving it unactioned will expire the proposal without counting as rejection.\n\n")
 	b.WriteString("Criteria section: **")
 	b.WriteString(proposal.CriteriaSection)
 	b.WriteString("**\n\n")
@@ -917,6 +1021,11 @@ func normalizeSettings(settings Settings) Settings {
 	settings.Config.Normalize()
 	settings.DispatchStates = normalizeStrings(settings.DispatchStates)
 	settings.DispatchLabels = normalizeStrings(settings.DispatchLabels)
+	settings.TerminalStates = normalizeStrings(settings.TerminalStates)
+	settings.ReworkState = strings.TrimSpace(settings.ReworkState)
+	if settings.ReworkState == "" {
+		settings.ReworkState = "Rework"
+	}
 	settings.ProjectCandidate.ID = strings.TrimSpace(settings.ProjectCandidate.ID)
 	if settings.ProjectCandidate.ID == "" {
 		settings.ProjectCandidate.ID = settings.ProjectID
@@ -931,6 +1040,7 @@ func cloneSettings(settings Settings) Settings {
 	settings.Criteria.Dimensions = append([]config.AdmissionDimension(nil), settings.Criteria.Dimensions...)
 	settings.DispatchStates = append([]string(nil), settings.DispatchStates...)
 	settings.DispatchLabels = append([]string(nil), settings.DispatchLabels...)
+	settings.TerminalStates = append([]string(nil), settings.TerminalStates...)
 	return settings
 }
 

--- a/internal/admission/manager.go
+++ b/internal/admission/manager.go
@@ -48,6 +48,7 @@ type Store interface {
 	ExpireAdmissionProposals(context.Context, string, time.Time) (int, error)
 	TransitionAdmissionProposal(context.Context, string, admissionmodel.ProposalStatus, admissionmodel.ProposalStatus, time.Time) error
 	ResolveAdmissionProposal(context.Context, admissionmodel.Decision) error
+	AdmissionTargetTransitions(context.Context, admissionmodel.TargetTransitionQuery) ([]admissionmodel.TargetTransition, error)
 	MarkAdmissionProposalCommented(context.Context, string, time.Time) error
 	RefreshAdmissionOutcomes(context.Context, admissionmodel.OutcomeRefresh) error
 	RecordAdmissionRun(context.Context, admissionmodel.RunRecord) error
@@ -441,6 +442,37 @@ func (m *Manager) reconcileOpenProposals(
 				return commentsRemaining, err
 			}
 			continue
+		}
+		if decided && decision.Outcome == admissionmodel.ProposalAccepted {
+			transitions, err := m.store.AdmissionTargetTransitions(ctx, admissionmodel.TargetTransitionQuery{
+				ProjectID:   proposal.ProjectID,
+				IssueID:     proposal.IssueID,
+				TargetState: proposal.TargetState,
+				NotBefore:   decision.DecidedAt,
+			})
+			if err != nil {
+				return commentsRemaining, err
+			}
+			resolved := false
+			for _, transition := range transitions {
+				if !admissionActorsCorrelate(decision.ActorLogin, transition.ActorLogin) {
+					continue
+				}
+				decision.TransitionAt = transition.EnteredAt
+				decision.TransitionEventID = transition.EventID
+				if strings.TrimSpace(transition.ActorLogin) != "" {
+					decision.ActorLogin = transition.ActorLogin
+					decision.ActorKind = transition.ActorKind
+				}
+				if err := m.store.ResolveAdmissionProposal(ctx, decision); err != nil {
+					return commentsRemaining, err
+				}
+				resolved = true
+				break
+			}
+			if resolved {
+				continue
+			}
 		}
 		if decided && decision.Outcome == admissionmodel.ProposalAccepted &&
 			strings.EqualFold(strings.TrimSpace(issue.State), proposal.TargetState) {

--- a/internal/admission/manager_test.go
+++ b/internal/admission/manager_test.go
@@ -131,6 +131,10 @@ func TestManagerExpiresProposalAndReproposesUnchangedIssue(t *testing.T) {
 	if len(history) != 2 || history[0].Status != admissionmodel.ProposalOpen || history[1].Status != admissionmodel.ProposalExpired {
 		t.Fatalf("history = %#v", history)
 	}
+	outcomes, err := backend.AdmissionDownstreamOutcomes(context.Background(), "detent")
+	if err != nil || len(outcomes) != 0 {
+		t.Fatalf("AdmissionDownstreamOutcomes() = %#v, %v, want expiry not counted as acceptance", outcomes, err)
+	}
 }
 
 func TestManagerAuditCommentDoesNotDuplicateProposal(t *testing.T) {
@@ -167,6 +171,16 @@ func TestManagerReconcilesAgainstStoredProposalTarget(t *testing.T) {
 	now := time.Date(2026, 7, 29, 12, 0, 0, 0, time.UTC)
 	issue := admissionIssueFixture("issue-1", "DD-1", 1, now)
 	issue.State = "Todo"
+	transitionAt := now.Add(2 * time.Minute)
+	decisionAt := now.Add(time.Minute)
+	issue.StageUpdatedAt = &transitionAt
+	issue.Comments = []connector.IssueComment{{
+		ID:          "decision-1",
+		Body:        admissionAcceptCommand("proposal-1"),
+		AuthorLogin: "ada",
+		AuthorKind:  "User",
+		CreatedAt:   &decisionAt,
+	}}
 	tracker := memory.New(memory.Config{Issues: []connector.Issue{issue}, Stateful: true})
 	backend := openManagerTestStore(t)
 	proposal := admissionTestProposalForIssue("proposal-1", issue, now)
@@ -176,7 +190,7 @@ func TestManagerReconcilesAgainstStoredProposalTarget(t *testing.T) {
 	agent := &scriptedAdmissionRunner{propose: proposeEveryCandidate}
 	settings := admissionTestSettings(tracker, agent)
 	settings.Config.TargetState = "Ready"
-	manager := newAdmissionTestManager(t, settings, backend, func() time.Time { return now })
+	manager := newAdmissionTestManager(t, settings, backend, func() time.Time { return transitionAt })
 
 	if _, err := manager.RunOnce(context.Background()); err != nil {
 		t.Fatalf("RunOnce() error = %v", err)
@@ -185,8 +199,45 @@ func TestManagerReconcilesAgainstStoredProposalTarget(t *testing.T) {
 	if err != nil || len(history) != 1 || history[0].Status != admissionmodel.ProposalAccepted {
 		t.Fatalf("history = %#v, %v", history, err)
 	}
+	if history[0].DecisionSeconds != 60 || !history[0].TransitionAt.Equal(transitionAt) ||
+		history[0].DecisionCommentID != "decision-1" {
+		t.Fatalf("decision evidence = %#v", history[0])
+	}
 	if agent.calls != 0 {
 		t.Fatalf("runner calls = %d, want 0", agent.calls)
+	}
+}
+
+func TestManagerTargetTransitionWithoutDecisionRemainsOpen(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 7, 29, 12, 0, 0, 0, time.UTC)
+	issue := admissionIssueFixture("issue-1", "DD-1", 1, now)
+	issue.State = "Todo"
+	transitionAt := now.Add(time.Minute)
+	issue.StageUpdatedAt = &transitionAt
+	tracker := memory.New(memory.Config{Issues: []connector.Issue{issue}, Stateful: true})
+	backend := openManagerTestStore(t)
+	proposal := admissionTestProposalForIssue("proposal-1", issue, now)
+	if created, err := backend.CreateAdmissionProposal(context.Background(), proposal); err != nil || !created {
+		t.Fatalf("CreateAdmissionProposal() = %t, %v", created, err)
+	}
+	manager := newAdmissionTestManager(
+		t,
+		admissionTestSettings(tracker, &scriptedAdmissionRunner{propose: proposeEveryCandidate}),
+		backend,
+		func() time.Time { return transitionAt },
+	)
+	if _, err := manager.RunOnce(context.Background()); err != nil {
+		t.Fatalf("RunOnce() error = %v", err)
+	}
+	open, err := backend.OpenAdmissionProposals(context.Background(), "detent", 0)
+	if err != nil || len(open) != 1 || open[0].ID != proposal.ID {
+		t.Fatalf("OpenAdmissionProposals() = %#v, %v, want proposal open", open, err)
+	}
+	outcomes, err := backend.AdmissionDownstreamOutcomes(context.Background(), "detent")
+	if err != nil || len(outcomes) != 0 {
+		t.Fatalf("AdmissionDownstreamOutcomes() = %#v, %v, want none", outcomes, err)
 	}
 }
 
@@ -236,15 +287,25 @@ func TestManagerAcceptedDemotionIsSticky(t *testing.T) {
 	t.Parallel()
 
 	now := time.Date(2026, 7, 29, 12, 0, 0, 0, time.UTC)
+	current := now
 	tracker := memory.New(memory.Config{
 		Issues:   []connector.Issue{admissionIssueFixture("issue-1", "DD-1", 1, now)},
 		Stateful: true,
+		Now:      func() time.Time { return current },
 	})
 	backend := openManagerTestStore(t)
 	agent := &scriptedAdmissionRunner{propose: proposeEveryCandidate}
-	manager := newAdmissionTestManager(t, admissionTestSettings(tracker, agent), backend, func() time.Time { return now })
+	manager := newAdmissionTestManager(t, admissionTestSettings(tracker, agent), backend, func() time.Time { return current })
 	if result, err := manager.RunOnce(context.Background()); err != nil || len(result.Proposals) != 1 {
 		t.Fatalf("initial RunOnce() = %#v, %v", result, err)
+	}
+	open, err := backend.OpenAdmissionProposals(context.Background(), "detent", 0)
+	if err != nil || len(open) != 1 {
+		t.Fatalf("OpenAdmissionProposals() = %#v, %v", open, err)
+	}
+	current = now.Add(time.Minute)
+	if err := tracker.CreateComment(context.Background(), "issue-1", admissionAcceptCommand(open[0].ID)); err != nil {
+		t.Fatalf("CreateComment() error = %v", err)
 	}
 	if err := tracker.UpdateIssueState(context.Background(), "issue-1", "Todo"); err != nil {
 		t.Fatalf("UpdateIssueState(Todo) error = %v", err)

--- a/internal/admission/manager_test.go
+++ b/internal/admission/manager_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/digitaldrywood/detent/internal/connector"
 	"github.com/digitaldrywood/detent/internal/connector/local"
 	"github.com/digitaldrywood/detent/internal/connector/memory"
+	"github.com/digitaldrywood/detent/internal/provenance"
 	"github.com/digitaldrywood/detent/internal/runner"
 	"github.com/digitaldrywood/detent/internal/scheduler"
 	"github.com/digitaldrywood/detent/internal/store"
@@ -205,6 +206,79 @@ func TestManagerReconcilesAgainstStoredProposalTarget(t *testing.T) {
 	}
 	if agent.calls != 0 {
 		t.Fatalf("runner calls = %d, want 0", agent.calls)
+	}
+}
+
+func TestManagerReconcilesAcceptanceAfterIssueLeavesTargetState(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	now := time.Date(2026, 7, 29, 12, 0, 0, 0, time.UTC)
+	current := now
+	issue := admissionIssueFixture("issue-1", "DD-1", 1, now)
+	tracker := memory.New(memory.Config{
+		Issues:   []connector.Issue{issue},
+		Stateful: true,
+		Now:      func() time.Time { return current },
+	})
+	backend := openManagerTestStore(t)
+	proposal := admissionTestProposalForIssue("proposal-1", issue, now)
+	if created, err := backend.CreateAdmissionProposal(ctx, proposal); err != nil || !created {
+		t.Fatalf("CreateAdmissionProposal() = %t, %v", created, err)
+	}
+	decisionAt := now.Add(time.Minute)
+	current = decisionAt
+	if err := tracker.CreateComment(ctx, issue.ID, admissionAcceptCommand(proposal.ID)); err != nil {
+		t.Fatalf("CreateComment() error = %v", err)
+	}
+	targetAt := now.Add(2 * time.Minute)
+	current = targetAt
+	if err := tracker.UpdateIssueState(ctx, issue.ID, proposal.TargetState); err != nil {
+		t.Fatalf("UpdateIssueState(%s) error = %v", proposal.TargetState, err)
+	}
+	if _, err := backend.RecordWorkflowPhaseEvent(ctx, store.WorkflowPhaseEvent{
+		ProjectID:  proposal.ProjectID,
+		IssueID:    proposal.IssueID,
+		Identifier: proposal.IssueIdentifier,
+		IssueURL:   proposal.IssueURL,
+		PhaseType:  store.WorkflowPhaseTypeLane,
+		PhaseName:  proposal.TargetState,
+		Reason:     "tracker_state_observed",
+		Status:     "entered",
+		StartedAt:  targetAt,
+		MetadataJSON: provenance.Apply(
+			"{}",
+			provenance.Attribution{Origin: provenance.OriginUnknown},
+			&provenance.Admission{Attributed: false},
+		),
+	}); err != nil {
+		t.Fatalf("RecordWorkflowPhaseEvent() error = %v", err)
+	}
+	current = now.Add(3 * time.Minute)
+	if err := tracker.UpdateIssueState(ctx, issue.ID, "In Progress"); err != nil {
+		t.Fatalf("UpdateIssueState(In Progress) error = %v", err)
+	}
+	manager := newAdmissionTestManager(
+		t,
+		admissionTestSettings(tracker, &scriptedAdmissionRunner{propose: proposeEveryCandidate}),
+		backend,
+		func() time.Time { return current },
+	)
+
+	if _, err := manager.RunOnce(ctx); err != nil {
+		t.Fatalf("RunOnce() error = %v", err)
+	}
+	history, err := backend.AdmissionProposalHistory(ctx, proposal.ProjectID, proposal.IssueID)
+	if err != nil || len(history) != 1 {
+		t.Fatalf("AdmissionProposalHistory() = %#v, %v", history, err)
+	}
+	if history[0].Status != admissionmodel.ProposalAccepted || !history[0].TransitionAt.Equal(targetAt) {
+		t.Fatalf("accepted proposal = %#v", history[0])
+	}
+	timeline, err := backend.IssueWorkflowTimeline(ctx, store.IssueIdentity{IssueID: proposal.IssueID})
+	if err != nil || len(timeline.Events) != 1 ||
+		timeline.Events[0].Reason != "admission_proposal_accepted" {
+		t.Fatalf("IssueWorkflowTimeline() = %#v, %v", timeline, err)
 	}
 }
 

--- a/internal/admission/model/model.go
+++ b/internal/admission/model/model.go
@@ -13,22 +13,27 @@ const (
 )
 
 type Proposal struct {
-	ID              string
-	ProjectID       string
-	IssueID         string
-	IssueIdentifier string
-	IssueURL        string
-	TargetState     string
-	Fingerprint     string
-	CriteriaSection string
-	CriteriaText    string
-	Findings        []Finding
-	Confidence      float64
-	Status          ProposalStatus
-	CreatedAt       time.Time
-	ExpiresAt       time.Time
-	ResolvedAt      time.Time
-	CommentedAt     time.Time
+	ID                 string
+	ProjectID          string
+	IssueID            string
+	IssueIdentifier    string
+	IssueURL           string
+	TargetState        string
+	Fingerprint        string
+	CriteriaSection    string
+	CriteriaText       string
+	Findings           []Finding
+	Confidence         float64
+	Status             ProposalStatus
+	CreatedAt          time.Time
+	ExpiresAt          time.Time
+	ResolvedAt         time.Time
+	CommentedAt        time.Time
+	DecisionCommentID  string
+	DecisionActorLogin string
+	DecisionActorKind  string
+	TransitionAt       time.Time
+	DecisionSeconds    int64
 }
 
 type Finding struct {
@@ -59,4 +64,32 @@ type IssueRecord struct {
 	Identifier string `json:"identifier,omitempty"`
 	URL        string `json:"url,omitempty"`
 	ProposalID string `json:"proposal_id,omitempty"`
+}
+
+type Decision struct {
+	ProposalID   string
+	Outcome      ProposalStatus
+	DecidedAt    time.Time
+	CommentID    string
+	ActorLogin   string
+	ActorKind    string
+	TransitionAt time.Time
+}
+
+type OutcomeRefresh struct {
+	ProjectID      string
+	TerminalStates []string
+	ReworkState    string
+	ObservedAt     time.Time
+}
+
+type DownstreamOutcome struct {
+	ProposalID       string
+	ProjectID        string
+	IssueID          string
+	CompletedAt      time.Time
+	ReworkCount      int
+	ReviewChurnCount int
+	SpendUSD         float64
+	UpdatedAt        time.Time
 }

--- a/internal/admission/model/model.go
+++ b/internal/admission/model/model.go
@@ -67,13 +67,28 @@ type IssueRecord struct {
 }
 
 type Decision struct {
-	ProposalID   string
-	Outcome      ProposalStatus
-	DecidedAt    time.Time
-	CommentID    string
-	ActorLogin   string
-	ActorKind    string
-	TransitionAt time.Time
+	ProposalID        string
+	Outcome           ProposalStatus
+	DecidedAt         time.Time
+	CommentID         string
+	ActorLogin        string
+	ActorKind         string
+	TransitionAt      time.Time
+	TransitionEventID int64
+}
+
+type TargetTransitionQuery struct {
+	ProjectID   string
+	IssueID     string
+	TargetState string
+	NotBefore   time.Time
+}
+
+type TargetTransition struct {
+	EventID    int64
+	EnteredAt  time.Time
+	ActorLogin string
+	ActorKind  string
 }
 
 type OutcomeRefresh struct {

--- a/internal/cli/doctor_admission.go
+++ b/internal/cli/doctor_admission.go
@@ -10,27 +10,35 @@ import (
 
 	admissionmodel "github.com/digitaldrywood/detent/internal/admission/model"
 	workflowconfig "github.com/digitaldrywood/detent/internal/config"
+	"github.com/digitaldrywood/detent/internal/provenance"
 )
 
 const doctorAdmissionFailureThreshold = 3
 
 type doctorAdmissionDiagnostic struct {
-	Schedule            string         `json:"schedule"`
-	CriteriaSection     string         `json:"criteria_section"`
-	Dimensions          []string       `json:"dimensions,omitempty"`
-	NeverRun            bool           `json:"never_run,omitempty"`
-	LastRun             string         `json:"last_run,omitempty"`
-	Outcome             string         `json:"outcome,omitempty"`
-	DeferredReason      string         `json:"deferred_reason,omitempty"`
-	CandidatesFound     int            `json:"candidates_found,omitempty"`
-	CandidatesEvaluated int            `json:"candidates_evaluated,omitempty"`
-	Proposed            int            `json:"proposed,omitempty"`
-	Skipped             map[string]int `json:"skipped,omitempty"`
-	Truncated           map[string]int `json:"truncated,omitempty"`
-	IssueReferences     []string       `json:"issue_references,omitempty"`
-	ConsecutiveFailures int            `json:"consecutive_failures,omitempty"`
-	LatestError         string         `json:"latest_error,omitempty"`
-	Warnings            []string       `json:"warnings,omitempty"`
+	Schedule            string           `json:"schedule"`
+	CriteriaSection     string           `json:"criteria_section"`
+	Dimensions          []string         `json:"dimensions,omitempty"`
+	NeverRun            bool             `json:"never_run,omitempty"`
+	LastRun             string           `json:"last_run,omitempty"`
+	Outcome             string           `json:"outcome,omitempty"`
+	DeferredReason      string           `json:"deferred_reason,omitempty"`
+	CandidatesFound     int              `json:"candidates_found,omitempty"`
+	CandidatesEvaluated int              `json:"candidates_evaluated,omitempty"`
+	Proposed            int              `json:"proposed,omitempty"`
+	Skipped             map[string]int   `json:"skipped,omitempty"`
+	Truncated           map[string]int   `json:"truncated,omitempty"`
+	IssueReferences     []string         `json:"issue_references,omitempty"`
+	ConsecutiveFailures int              `json:"consecutive_failures,omitempty"`
+	LatestError         string           `json:"latest_error,omitempty"`
+	Warnings            []string         `json:"warnings,omitempty"`
+	Origins             map[string]int   `json:"origins,omitempty"`
+	ProposalOutcomes    map[string]int   `json:"proposal_outcomes,omitempty"`
+	DecisionSeconds     map[string]int64 `json:"average_decision_seconds,omitempty"`
+	AcceptedCompleted   int              `json:"accepted_completed,omitempty"`
+	ReworkCount         int              `json:"rework_count,omitempty"`
+	ReviewChurnCount    int              `json:"review_churn_count,omitempty"`
+	SpendUSD            float64          `json:"spend_usd,omitempty"`
 }
 
 func checkDoctorAdmission(
@@ -182,7 +190,91 @@ LIMIT ?`, strings.TrimSpace(projectID), doctorAdmissionFailureThreshold)
 		diagnostic.ConsecutiveFailures++
 		index++
 	}
-	return diagnostic, rows.Err()
+	if err := rows.Err(); err != nil {
+		return diagnostic, err
+	}
+	if err := rows.Close(); err != nil {
+		return diagnostic, err
+	}
+	return readDoctorAdmissionEvidence(ctx, db, projectID, diagnostic)
+}
+
+func readDoctorAdmissionEvidence(
+	ctx context.Context,
+	db doctorTelemetryStore,
+	projectID string,
+	diagnostic doctorAdmissionDiagnostic,
+) (doctorAdmissionDiagnostic, error) {
+	diagnostic.ProposalOutcomes = map[string]int{}
+	diagnostic.DecisionSeconds = map[string]int64{}
+	rows, err := db.QueryContext(ctx, `
+SELECT status, COUNT(*), COALESCE(AVG(decision_seconds), 0)
+FROM backlog_admission_proposals
+WHERE project_id = ? AND status <> 'open'
+GROUP BY status
+ORDER BY status`, strings.TrimSpace(projectID))
+	if err != nil {
+		if strings.Contains(strings.ToLower(err.Error()), "no such table: backlog_admission_proposals") {
+			return diagnostic, nil
+		}
+		return diagnostic, err
+	}
+	if err := func() (resultErr error) {
+		defer func() {
+			resultErr = errors.Join(resultErr, rows.Close())
+		}()
+		for rows.Next() {
+			var status string
+			var count int
+			var average float64
+			if err := rows.Scan(&status, &count, &average); err != nil {
+				return err
+			}
+			diagnostic.ProposalOutcomes[status] = count
+			diagnostic.DecisionSeconds[status] = int64(average)
+		}
+		return rows.Err()
+	}(); err != nil {
+		return diagnostic, err
+	}
+	if err := db.QueryRowContext(ctx, `
+SELECT COUNT(completed_at), COALESCE(SUM(rework_count), 0),
+       COALESCE(SUM(review_churn_count), 0), COALESCE(SUM(spend_usd), 0.0)
+FROM backlog_admission_downstream_outcomes
+WHERE project_id = ?`, strings.TrimSpace(projectID)).Scan(
+		&diagnostic.AcceptedCompleted,
+		&diagnostic.ReworkCount,
+		&diagnostic.ReviewChurnCount,
+		&diagnostic.SpendUSD,
+	); err != nil && !strings.Contains(strings.ToLower(err.Error()), "no such table: backlog_admission_downstream_outcomes") {
+		return diagnostic, err
+	}
+	diagnostic.Origins = map[string]int{}
+	originRows, err := db.QueryContext(ctx, `
+SELECT metadata_json
+FROM workflow_phase_events
+WHERE project_id = ? AND phase_type = 'lane' AND status = 'entered'
+ORDER BY id`, strings.TrimSpace(projectID))
+	if err != nil {
+		if strings.Contains(strings.ToLower(err.Error()), "no such table: workflow_phase_events") {
+			return diagnostic, nil
+		}
+		return diagnostic, err
+	}
+	defer originRows.Close()
+	for originRows.Next() {
+		var metadataJSON string
+		if err := originRows.Scan(&metadataJSON); err != nil {
+			return diagnostic, err
+		}
+		metadata, ok := provenance.Parse(metadataJSON)
+		if !ok {
+			diagnostic.Origins[string(provenance.OriginUnknown)]++
+			continue
+		}
+		diagnostic.Origins[string(metadata.Provenance.Origin)]++
+	}
+	return diagnostic, originRows.Err()
 }
 
 func doctorAdmissionCheck(name string, diagnostic doctorAdmissionDiagnostic, unavailable string) doctorCheck {
@@ -227,12 +319,46 @@ func doctorAdmissionCheck(name string, diagnostic doctorAdmissionDiagnostic, una
 	if len(diagnostic.IssueReferences) > 0 {
 		details = append(details, "issues="+strings.Join(diagnostic.IssueReferences, ","))
 	}
+	if counts := doctorAdmissionCounts(diagnostic.Origins); counts != "" {
+		details = append(details, "origins="+counts)
+	}
+	if counts := doctorAdmissionCounts(diagnostic.ProposalOutcomes); counts != "" {
+		details = append(details, "proposal_outcomes="+counts)
+	}
+	if decisions := doctorAdmissionDurations(diagnostic.DecisionSeconds); decisions != "" {
+		details = append(details, "average_decision_seconds="+decisions)
+	}
+	if diagnostic.AcceptedCompleted > 0 || diagnostic.ReworkCount > 0 ||
+		diagnostic.ReviewChurnCount > 0 || diagnostic.SpendUSD > 0 {
+		details = append(details, fmt.Sprintf(
+			"accepted_downstream=completed:%d,rework:%d,review_churn:%d,spend:$%.2f",
+			diagnostic.AcceptedCompleted,
+			diagnostic.ReworkCount,
+			diagnostic.ReviewChurnCount,
+			diagnostic.SpendUSD,
+		))
+	}
 	if len(diagnostic.Warnings) > 0 {
 		check.Status = doctorWarn
 		details = append(details, diagnostic.Warnings...)
 	}
 	check.Detail = strings.Join(details, "; ")
 	return check
+}
+
+func doctorAdmissionDurations(durations map[string]int64) string {
+	keys := make([]string, 0, len(durations))
+	for key := range durations {
+		if strings.TrimSpace(key) != "" {
+			keys = append(keys, key)
+		}
+	}
+	sort.Strings(keys)
+	values := make([]string, 0, len(keys))
+	for _, key := range keys {
+		values = append(values, fmt.Sprintf("%s:%d", key, durations[key]))
+	}
+	return strings.Join(values, ",")
 }
 
 func doctorAdmissionCounts(counts map[string]int) string {

--- a/internal/cli/doctor_admission_test.go
+++ b/internal/cli/doctor_admission_test.go
@@ -43,6 +43,35 @@ INSERT INTO backlog_admission_runs (
   ('detent', '2026-07-29T10:03:00Z', 'failed', NULL, 12, 4, 1, '{"excluded_label":2}', '{"candidate_cap":8}', '[{"identifier":"digitaldrywood/detent#1535"}]', 'third failure'),
   ('detent', '2026-07-29T10:02:00Z', 'failed', NULL, 10, 4, 0, '{}', '{"candidate_cap":6}', '[]', 'second failure'),
   ('detent', '2026-07-29T10:01:00Z', 'failed', NULL, 8, 4, 0, '{}', '{"candidate_cap":4}', '[]', 'first failure');
+CREATE TABLE backlog_admission_proposals (
+  project_id TEXT NOT NULL,
+  status TEXT NOT NULL,
+  decision_seconds INTEGER
+);
+INSERT INTO backlog_admission_proposals (project_id, status, decision_seconds) VALUES
+  ('detent', 'accepted', 60),
+  ('detent', 'expired', 604800);
+CREATE TABLE backlog_admission_downstream_outcomes (
+  project_id TEXT NOT NULL,
+  completed_at TEXT,
+  rework_count INTEGER NOT NULL,
+  review_churn_count INTEGER NOT NULL,
+  spend_usd REAL NOT NULL
+);
+INSERT INTO backlog_admission_downstream_outcomes (
+  project_id, completed_at, rework_count, review_churn_count, spend_usd
+) VALUES ('detent', '2026-07-29T11:00:00Z', 2, 3, 4.5);
+CREATE TABLE workflow_phase_events (
+  id INTEGER PRIMARY KEY,
+  project_id TEXT NOT NULL,
+  phase_type TEXT NOT NULL,
+  status TEXT NOT NULL,
+  metadata_json TEXT NOT NULL
+);
+INSERT INTO workflow_phase_events (project_id, phase_type, status, metadata_json) VALUES
+  ('detent', 'lane', 'entered', '{"provenance":{"origin":"admission"}}'),
+  ('detent', 'lane', 'entered', '{"provenance":{"origin":"routine"}}'),
+  ('detent', 'lane', 'entered', '{}');
 `); err != nil {
 		t.Fatalf("seed backlog_admission_runs error = %v", err)
 	}
@@ -68,6 +97,10 @@ INSERT INTO backlog_admission_runs (
 		"skipped=excluded_label:2",
 		"truncated=candidate_cap:8",
 		"issues=digitaldrywood/detent#1535",
+		"origins=admission:1,routine:1,unknown:1",
+		"proposal_outcomes=accepted:1,expired:1",
+		"average_decision_seconds=accepted:60,expired:604800",
+		"accepted_downstream=completed:1,rework:2,review_churn:3,spend:$4.50",
 	} {
 		if !strings.Contains(check.Detail, want) {
 			t.Fatalf("Detail = %q, want %q", check.Detail, want)
@@ -78,6 +111,15 @@ INSERT INTO backlog_admission_runs (
 	}
 	if diagnostic.Skipped["excluded_label"] != 2 || diagnostic.Truncated["candidate_cap"] != 8 {
 		t.Fatalf("diagnostic counts = skipped %#v truncated %#v", diagnostic.Skipped, diagnostic.Truncated)
+	}
+	if diagnostic.Origins["admission"] != 1 || diagnostic.Origins["unknown"] != 1 ||
+		diagnostic.ProposalOutcomes["expired"] != 1 ||
+		diagnostic.DecisionSeconds["accepted"] != 60 ||
+		diagnostic.AcceptedCompleted != 1 ||
+		diagnostic.ReworkCount != 2 ||
+		diagnostic.ReviewChurnCount != 3 ||
+		diagnostic.SpendUSD != 4.5 {
+		t.Fatalf("evidence diagnostic = %#v", diagnostic)
 	}
 }
 

--- a/internal/connector/connector.go
+++ b/internal/connector/connector.go
@@ -247,7 +247,17 @@ type IssueReferenceResolver interface {
 }
 
 type IssueStateTransitionReader interface {
-	IssueStateEnteredAt(context.Context, Issue) (time.Time, bool, error)
+	IssueStateTransition(context.Context, Issue) (IssueStateTransition, bool, error)
+}
+
+type IssueStateTransition struct {
+	EnteredAt time.Time  `json:"entered_at" yaml:"entered_at"`
+	Actor     IssueActor `json:"actor,omitzero" yaml:"actor,omitempty"`
+}
+
+type IssueActor struct {
+	Login string `json:"login,omitempty" yaml:"login,omitempty"`
+	Kind  string `json:"kind,omitempty" yaml:"kind,omitempty"`
 }
 
 type IssueDependencyWriter interface {

--- a/internal/connector/github/issue_read.go
+++ b/internal/connector/github/issue_read.go
@@ -1411,6 +1411,7 @@ func connectorIssueComment(comment issueComment, targetType string) connector.Is
 		Body:        comment.Body,
 		URL:         comment.URL,
 		AuthorLogin: actorLogin(comment.Author),
+		AuthorKind:  actorType(comment.Author),
 		CreatedAt:   parseGitHubTime(comment.CreatedAt),
 		UpdatedAt:   parseGitHubTime(comment.UpdatedAt),
 		TargetType:  targetType,

--- a/internal/connector/github/statuslabel.go
+++ b/internal/connector/github/statuslabel.go
@@ -141,27 +141,28 @@ func (c *Connector) fetchLabelIssueByRef(ctx context.Context, ref issueRef) (con
 	return c.buildLabelIssue(issue, c.githubIssueStateToDetentState(issue.State)), true, nil
 }
 
-func (c *Connector) IssueStateEnteredAt(ctx context.Context, issue connector.Issue) (time.Time, bool, error) {
+func (c *Connector) IssueStateTransition(ctx context.Context, issue connector.Issue) (connector.IssueStateTransition, bool, error) {
 	if !c.usesLabelStatus() {
-		return time.Time{}, false, nil
+		return connector.IssueStateTransition{}, false, nil
 	}
 	ref, ok := issueRefFromIdentifier(issue.Identifier)
 	if !ok {
 		ref, ok = issueRefFromURL(issue.URL)
 	}
 	if !ok {
-		return time.Time{}, false, nil
+		return connector.IssueStateTransition{}, false, nil
 	}
 	targetLabel := normalizeLabelName(c.statusLabelForState(issue.State))
 	if targetLabel == "" {
-		return time.Time{}, false, nil
+		return connector.IssueStateTransition{}, false, nil
 	}
 
 	events, err := fetchRESTList[restIssueTimelineEvent](ctx, c.client, restIssueTimelinePath(ref))
 	if err != nil {
-		return time.Time{}, false, fmt.Errorf("fetch github issue timeline: %w", err)
+		return connector.IssueStateTransition{}, false, fmt.Errorf("fetch github issue timeline: %w", err)
 	}
 	var enteredAt time.Time
+	var transitionActor connector.IssueActor
 	present := false
 	for _, event := range events {
 		if event.Label == nil || normalizeLabelName(event.Label.Name) != targetLabel {
@@ -171,16 +172,31 @@ func (c *Connector) IssueStateEnteredAt(ctx context.Context, issue connector.Iss
 		case strings.EqualFold(strings.TrimSpace(event.Event), "labeled"):
 			if !present && event.CreatedAt != nil && !event.CreatedAt.IsZero() {
 				enteredAt = event.CreatedAt.UTC()
+				transitionActor = connector.IssueActor{
+					Login: actorLogin(event.Actor),
+					Kind:  actorType(event.Actor),
+				}
 			}
 			present = true
 		case strings.EqualFold(strings.TrimSpace(event.Event), "unlabeled"):
 			present = false
+			transitionActor = connector.IssueActor{}
 		}
 	}
 	if !present {
-		return time.Time{}, false, nil
+		return connector.IssueStateTransition{}, false, nil
 	}
-	return enteredAt, !enteredAt.IsZero(), nil
+	return connector.IssueStateTransition{
+		EnteredAt: enteredAt,
+		Actor:     transitionActor,
+	}, !enteredAt.IsZero(), nil
+}
+
+func actorType(value *actor) string {
+	if value == nil {
+		return ""
+	}
+	return strings.TrimSpace(value.Type)
 }
 
 func (c *Connector) updateIssueStatusLabel(ctx context.Context, ref issueRef, issue githubIssueNode, targetState string) error {

--- a/internal/connector/github/statuslabel_test.go
+++ b/internal/connector/github/statuslabel_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/digitaldrywood/detent/internal/connector"
 )
 
-func TestConnectorIssueStateEnteredAtUsesLatestMatchingLabelEvent(t *testing.T) {
+func TestConnectorIssueStateTransitionUsesLatestMatchingLabelEvent(t *testing.T) {
 	t.Parallel()
 
 	first := time.Date(2026, 7, 10, 14, 36, 55, 0, time.UTC)
@@ -19,13 +19,19 @@ func TestConnectorIssueStateEnteredAtUsesLatestMatchingLabelEvent(t *testing.T) 
 	tests := []struct {
 		name  string
 		body  string
-		want  time.Time
+		want  connector.IssueStateTransition
 		found bool
 	}{
 		{
-			name:  "latest matching event",
-			body:  `[{"event":"labeled","created_at":"2026-07-10T14:34:38Z","label":{"name":"detent:in-progress"}},{"event":"labeled","created_at":"2026-07-10T14:36:55Z","label":{"name":"DETENT:BLOCKED"}},{"event":"labeled","created_at":"2026-07-10T14:40:00Z","label":{"name":"detent:blocked"}},{"event":"unlabeled","created_at":"2026-07-10T15:30:00Z","label":{"name":"detent:blocked"}},{"event":"labeled","created_at":"2026-07-10T15:36:55Z","label":{"name":"detent:blocked"}}]`,
-			want:  latest,
+			name: "latest matching event",
+			body: `[{"event":"labeled","created_at":"2026-07-10T14:34:38Z","label":{"name":"detent:in-progress"}},{"event":"labeled","created_at":"2026-07-10T14:36:55Z","label":{"name":"DETENT:BLOCKED"},"actor":{"login":"first","type":"User"}},{"event":"labeled","created_at":"2026-07-10T14:40:00Z","label":{"name":"detent:blocked"}},{"event":"unlabeled","created_at":"2026-07-10T15:30:00Z","label":{"name":"detent:blocked"}},{"event":"labeled","created_at":"2026-07-10T15:36:55Z","label":{"name":"detent:blocked"},"actor":{"login":"dependabot[bot]","type":"Bot"}}]`,
+			want: connector.IssueStateTransition{
+				EnteredAt: latest,
+				Actor: connector.IssueActor{
+					Login: "dependabot[bot]",
+					Kind:  "Bot",
+				},
+			},
 			found: true,
 		},
 		{
@@ -49,15 +55,15 @@ func TestConnectorIssueStateEnteredAtUsesLatestMatchingLabelEvent(t *testing.T) 
 				ObservedStates:     []string{"Blocked"},
 			})
 
-			got, found, err := c.IssueStateEnteredAt(t.Context(), connector.Issue{
+			got, found, err := c.IssueStateTransition(t.Context(), connector.Issue{
 				Identifier: "digitaldrywood/detent#1162",
 				State:      "Blocked",
 			})
 			if err != nil {
-				t.Fatalf("IssueStateEnteredAt() error = %v", err)
+				t.Fatalf("IssueStateTransition() error = %v", err)
 			}
-			if found != tt.found || !got.Equal(tt.want) {
-				t.Fatalf("IssueStateEnteredAt() = (%v, %v), want (%v, %v)", got, found, tt.want, tt.found)
+			if found != tt.found || !reflect.DeepEqual(got, tt.want) {
+				t.Fatalf("IssueStateTransition() = (%#v, %v), want (%#v, %v)", got, found, tt.want, tt.found)
 			}
 		})
 	}

--- a/internal/connector/github/types.go
+++ b/internal/connector/github/types.go
@@ -184,6 +184,7 @@ type pullRequestCodexReviews struct {
 
 type actor struct {
 	Login string `json:"login"`
+	Type  string `json:"type"`
 }
 
 type restIssue struct {
@@ -347,6 +348,7 @@ type restIssueTimelineEvent struct {
 	Event     string     `json:"event"`
 	CreatedAt *time.Time `json:"created_at"`
 	Label     *label     `json:"label"`
+	Actor     *actor     `json:"actor"`
 }
 
 type repository struct {

--- a/internal/connector/githublocal/githublocal.go
+++ b/internal/connector/githublocal/githublocal.go
@@ -372,15 +372,18 @@ func (c *Connector) FetchIssueStatesByIdentifiers(ctx context.Context, identifie
 	return sortIssuesByIdentifiers(out, identifiers), nil
 }
 
-func (c *Connector) IssueStateEnteredAt(ctx context.Context, issue connector.Issue) (time.Time, bool, error) {
-	if issue.StageUpdatedAt != nil && !issue.StageUpdatedAt.IsZero() {
-		return issue.StageUpdatedAt.UTC(), true, nil
-	}
+func (c *Connector) IssueStateTransition(ctx context.Context, issue connector.Issue) (connector.IssueStateTransition, bool, error) {
 	reader, ok := c.github.(connector.IssueStateTransitionReader)
-	if !ok {
-		return time.Time{}, false, nil
+	if ok {
+		transition, found, err := reader.IssueStateTransition(ctx, issue)
+		if err != nil || found {
+			return transition, found, err
+		}
 	}
-	return reader.IssueStateEnteredAt(ctx, issue)
+	if issue.StageUpdatedAt != nil && !issue.StageUpdatedAt.IsZero() {
+		return connector.IssueStateTransition{EnteredAt: issue.StageUpdatedAt.UTC()}, true, nil
+	}
+	return connector.IssueStateTransition{}, false, nil
 }
 
 func (c *Connector) FetchIssueComments(ctx context.Context, issue connector.Issue) ([]connector.IssueComment, error) {

--- a/internal/connector/githublocal/githublocal_test.go
+++ b/internal/connector/githublocal/githublocal_test.go
@@ -97,6 +97,36 @@ func TestConnectorImportPersistsAndDetectsClosedUpstreamDivergence(t *testing.T)
 	}
 }
 
+func TestConnectorIssueStateTransitionPrefersGitHubActor(t *testing.T) {
+	t.Parallel()
+
+	localAt := time.Date(2026, 7, 29, 12, 0, 0, 0, time.UTC)
+	githubAt := localAt.Add(time.Minute)
+	backend := &transitionGitHubBackend{
+		recordingGitHubBackend: &recordingGitHubBackend{calls: &recordingCallLog{}},
+		transition: connector.IssueStateTransition{
+			EnteredAt: githubAt,
+			Actor: connector.IssueActor{
+				Login: "ada",
+				Kind:  "User",
+			},
+		},
+		found: true,
+	}
+	conn := &Connector{github: backend}
+	got, found, err := conn.IssueStateTransition(context.Background(), connector.Issue{
+		Identifier:     "digitaldrywood/detent#1537",
+		State:          "Todo",
+		StageUpdatedAt: &localAt,
+	})
+	if err != nil {
+		t.Fatalf("IssueStateTransition() error = %v", err)
+	}
+	if !found || !got.EnteredAt.Equal(githubAt) || got.Actor.Login != "ada" || got.Actor.Kind != "User" {
+		t.Fatalf("IssueStateTransition() = %#v, %t", got, found)
+	}
+}
+
 func TestConnectorLocalAnnotationsStayLocalAndPRLifecycleWritesPassThrough(t *testing.T) {
 	t.Parallel()
 
@@ -650,6 +680,17 @@ func (l *recordingCallLog) snapshot() []string {
 type recordingGitHubBackend struct {
 	calls *recordingCallLog
 	errs  map[string]error
+}
+
+type transitionGitHubBackend struct {
+	*recordingGitHubBackend
+	transition connector.IssueStateTransition
+	found      bool
+	err        error
+}
+
+func (b *transitionGitHubBackend) IssueStateTransition(context.Context, connector.Issue) (connector.IssueStateTransition, bool, error) {
+	return b.transition, b.found, b.err
 }
 
 func (b *recordingGitHubBackend) Close() error {

--- a/internal/connector/issue.go
+++ b/internal/connector/issue.go
@@ -143,6 +143,7 @@ type IssueComment struct {
 	Body              string     `json:"body,omitempty" yaml:"body,omitempty"`
 	URL               string     `json:"url,omitempty" yaml:"url,omitempty"`
 	AuthorLogin       string     `json:"author_login,omitempty" yaml:"author_login,omitempty"`
+	AuthorKind        string     `json:"author_kind,omitempty" yaml:"author_kind,omitempty"`
 	AuthorDisplayName string     `json:"author_display_name,omitempty" yaml:"author_display_name,omitempty"`
 	CreatedAt         *time.Time `json:"created_at,omitempty" yaml:"created_at,omitempty"`
 	UpdatedAt         *time.Time `json:"updated_at,omitempty" yaml:"updated_at,omitempty"`
@@ -157,6 +158,7 @@ type IssueEvent struct {
 	Kind      string            `json:"kind,omitempty" yaml:"kind,omitempty"`
 	State     string            `json:"state,omitempty" yaml:"state,omitempty"`
 	Body      string            `json:"body,omitempty" yaml:"body,omitempty"`
+	Actor     IssueActor        `json:"actor,omitzero" yaml:"actor,omitempty"`
 	Fields    map[string]string `json:"fields,omitempty" yaml:"fields,omitempty"`
 	CreatedAt *time.Time        `json:"created_at,omitempty" yaml:"created_at,omitempty"`
 }

--- a/internal/connector/linear/connector.go
+++ b/internal/connector/linear/connector.go
@@ -361,6 +361,7 @@ func connectorIssueComment(comment linearComment) connector.IssueComment {
 		Body:              comment.Body,
 		URL:               strings.TrimSpace(comment.URL),
 		AuthorLogin:       linearAuthorLogin(comment),
+		AuthorKind:        linearAuthorKind(comment),
 		AuthorDisplayName: linearAuthorDisplayName(comment),
 		CreatedAt:         linearTimePtr(comment.CreatedAt),
 		UpdatedAt:         linearTimePtr(comment.UpdatedAt),
@@ -377,6 +378,16 @@ func linearAuthorLogin(comment linearComment) string {
 	}
 	if comment.BotActor != nil {
 		return firstNonBlank(comment.BotActor.UserDisplayName, comment.BotActor.Name, comment.BotActor.ID)
+	}
+	return ""
+}
+
+func linearAuthorKind(comment linearComment) string {
+	if comment.BotActor != nil {
+		return "Bot"
+	}
+	if comment.User != nil || comment.ExternalUser != nil {
+		return "User"
 	}
 	return ""
 }

--- a/internal/connector/linear/connector_test.go
+++ b/internal/connector/linear/connector_test.go
@@ -67,6 +67,7 @@ func TestConnectorFetchIssueCommentsMapsLinearMetadata(t *testing.T) {
 		Body:              "Root cause found.",
 		URL:               "https://linear.app/acme/issue/LIN-123#comment-1",
 		AuthorLogin:       "ada",
+		AuthorKind:        "User",
 		AuthorDisplayName: "Ada Lovelace",
 		CreatedAt:         &createdAt,
 		UpdatedAt:         &updatedAt,

--- a/internal/connector/local/local.go
+++ b/internal/connector/local/local.go
@@ -290,6 +290,7 @@ order by id asc`, c.projectID, strings.TrimSpace(issue.ID), eventKindComment, ev
 				Backend:           connector.BackendLocalSQLite.String(),
 				Body:              body,
 				AuthorLogin:       "detent",
+				AuthorKind:        "Bot",
 				AuthorDisplayName: "Detent",
 				CreatedAt:         eventTime,
 				Local:             true,
@@ -348,6 +349,9 @@ order by id asc`, c.projectID, strings.TrimSpace(issue.ID))
 		}
 		event.ID = strconv.FormatInt(id, 10)
 		event.Fields = unmarshalStringMap(payloadJSON)
+		event.Actor = connector.IssueActor{
+			Login: strings.TrimSpace(event.Fields[commentPayloadActor]),
+		}
 		event.CreatedAt = parseTimePointer(createdAt)
 		events = append(events, event)
 	}

--- a/internal/orchestrator/config.go
+++ b/internal/orchestrator/config.go
@@ -15,6 +15,10 @@ import (
 func ConfigFromWorkflow(cfg workflowconfig.Config) Config {
 	identity := cfg.Identity
 	identity.Normalize()
+	admissionTargetState := ""
+	if cfg.BacklogAdmission.Enabled {
+		admissionTargetState = cfg.BacklogAdmission.TargetState
+	}
 
 	return Config{
 		PollInterval:               durationFromMillis(cfg.Polling.IntervalMS),
@@ -86,6 +90,7 @@ func ConfigFromWorkflow(cfg workflowconfig.Config) Config {
 			BlockerStates: append([]string(nil), cfg.Tracker.BlockerAutoPromote.BlockerStates...),
 			TargetState:   cfg.Tracker.BlockerAutoPromote.TargetState,
 		},
+		AdmissionTargetState:          admissionTargetState,
 		ActiveStates:                  append([]string(nil), cfg.Tracker.ActiveStates...),
 		ObservedStates:                append([]string(nil), cfg.Tracker.ObservedStates...),
 		TerminalStates:                append([]string(nil), cfg.Tracker.TerminalStates...),

--- a/internal/orchestrator/dependency_autounblock_test.go
+++ b/internal/orchestrator/dependency_autounblock_test.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/digitaldrywood/detent/internal/connector"
+	"github.com/digitaldrywood/detent/internal/provenance"
 	"github.com/digitaldrywood/detent/internal/store"
 )
 
@@ -107,7 +108,8 @@ func TestTickAutoUnblocksDependencyOnlyOnceForSameResolvedBlockerSet(t *testing.
 		}
 	}
 	metadata, ok := workflowLaneMetadataFromJSON(rework.MetadataJSON)
-	if !ok || metadata.DependencyAutoUnblock == nil || metadata.DependencyAutoUnblock.BlockerSet == "" {
+	if !ok || metadata.DependencyAutoUnblock == nil || metadata.DependencyAutoUnblock.BlockerSet == "" ||
+		metadata.Provenance.Origin != provenance.OriginDependency {
 		t.Fatalf("latest Rework metadata = %q, want dependency_auto_unblock blocker_set", rework.MetadataJSON)
 	}
 }

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -90,6 +90,7 @@ type Config struct {
 	DependencyAutoUnblock         DependencyAutoUnblockConfig
 	BlockedRecovery               BlockedRecoveryConfig
 	BlockerAutoPromote            BlockerAutoPromoteConfig
+	AdmissionTargetState          string
 	ActiveStates                  []string
 	ObservedStates                []string
 	TerminalStates                []string

--- a/internal/orchestrator/snapshot.go
+++ b/internal/orchestrator/snapshot.go
@@ -9,6 +9,7 @@ import (
 	"github.com/digitaldrywood/detent/internal/budget"
 	"github.com/digitaldrywood/detent/internal/connector"
 	"github.com/digitaldrywood/detent/internal/gate"
+	"github.com/digitaldrywood/detent/internal/provenance"
 	releasepkg "github.com/digitaldrywood/detent/internal/release"
 	"github.com/digitaldrywood/detent/internal/runtimeoutput"
 	"github.com/digitaldrywood/detent/internal/selector"
@@ -115,7 +116,69 @@ func (s State) Snapshot(now time.Time) telemetry.Snapshot {
 		Blocked:   len(snapshot.Blocked),
 		Completed: len(snapshot.Completed),
 	}
+	applySnapshotLaneProvenance(&snapshot, s.laneProvenance)
 	return snapshot
+}
+
+func applySnapshotLaneProvenance(snapshot *telemetry.Snapshot, laneProvenance map[string]provenance.Attribution) {
+	if snapshot == nil {
+		return
+	}
+	apply := func(issue *telemetry.Issue) {
+		if issue == nil {
+			return
+		}
+		attribution, ok := laneProvenance[telemetryIssueLaneKey(*issue)]
+		if !ok {
+			return
+		}
+		issue.Origin = string(provenance.NormalizeOrigin(attribution.Origin))
+		if attribution.Actor != nil {
+			issue.OriginActor = attribution.Actor.Login
+			issue.OriginActorKind = attribution.Actor.Kind
+		}
+	}
+	for index := range snapshot.BoardIssues {
+		apply(&snapshot.BoardIssues[index])
+	}
+	for index := range snapshot.Pipeline {
+		apply(&snapshot.Pipeline[index])
+	}
+	for index := range snapshot.TrackerDrift.UntrackedOpen {
+		apply(&snapshot.TrackerDrift.UntrackedOpen[index])
+	}
+	for index := range snapshot.TrackerDrift.OpenTerminal {
+		apply(&snapshot.TrackerDrift.OpenTerminal[index])
+	}
+	for index := range snapshot.Running {
+		apply(&snapshot.Running[index].Issue)
+	}
+	for index := range snapshot.Queue {
+		apply(&snapshot.Queue[index].Issue)
+	}
+	for index := range snapshot.Blocked {
+		apply(&snapshot.Blocked[index].Issue)
+	}
+	for index := range snapshot.Completed {
+		apply(&snapshot.Completed[index].Issue)
+	}
+}
+
+func telemetryIssueLaneKey(issue telemetry.Issue) string {
+	identity := ""
+	switch {
+	case strings.TrimSpace(issue.ID) != "":
+		identity = "id:" + strings.TrimSpace(issue.ID)
+	case strings.TrimSpace(issue.Identifier) != "":
+		identity = "identifier:" + strings.TrimSpace(issue.Identifier)
+	case strings.TrimSpace(issue.URL) != "":
+		identity = "url:" + strings.TrimSpace(issue.URL)
+	}
+	state := normalizeState(issue.State)
+	if identity == "" || state == "" {
+		return ""
+	}
+	return identity + "\x00" + state
 }
 
 func projectFailureBreakerSnapshots(breaker ProjectFailureBreaker) []telemetry.FailureBreaker {
@@ -701,6 +764,7 @@ func telemetryIssueComments(comments []connector.IssueComment) []telemetry.Issue
 			Body:              comment.Body,
 			URL:               comment.URL,
 			AuthorLogin:       comment.AuthorLogin,
+			AuthorKind:        comment.AuthorKind,
 			AuthorDisplayName: comment.AuthorDisplayName,
 			CreatedAt:         cloneTime(comment.CreatedAt),
 			UpdatedAt:         cloneTime(comment.UpdatedAt),

--- a/internal/orchestrator/state.go
+++ b/internal/orchestrator/state.go
@@ -10,6 +10,7 @@ import (
 	"github.com/digitaldrywood/detent/internal/connector"
 	"github.com/digitaldrywood/detent/internal/gate"
 	"github.com/digitaldrywood/detent/internal/procgroup"
+	"github.com/digitaldrywood/detent/internal/provenance"
 	releasepkg "github.com/digitaldrywood/detent/internal/release"
 	runpkg "github.com/digitaldrywood/detent/internal/runner"
 	"github.com/digitaldrywood/detent/internal/runtimeoutput"
@@ -80,6 +81,7 @@ type State struct {
 	TokenTotals              TokenTotals
 	RateLimits               *telemetry.RateLimits
 	laneEntries              map[string]time.Time
+	laneProvenance           map[string]provenance.Attribution
 	planRework               map[string]struct{}
 	epicTransitionWatch      []connector.Issue
 	pendingEpicParentLookups map[string]connector.Issue
@@ -284,6 +286,7 @@ func newState(cfg Config) State {
 		DiffStats:                map[string]DiffStats{},
 		ReapedWorkspaces:         map[string]time.Time{},
 		laneEntries:              map[string]time.Time{},
+		laneProvenance:           map[string]provenance.Attribution{},
 		planRework:               map[string]struct{}{},
 		pendingEpicParentLookups: map[string]connector.Issue{},
 	}
@@ -350,6 +353,7 @@ func (s State) clone() State {
 		TokenTotals:              s.TokenTotals,
 		RateLimits:               cloneRateLimits(s.RateLimits),
 		laneEntries:              maps.Clone(s.laneEntries),
+		laneProvenance:           maps.Clone(s.laneProvenance),
 		planRework:               make(map[string]struct{}, len(s.planRework)),
 		epicTransitionWatch:      cloneIssues(s.epicTransitionWatch),
 		pendingEpicParentLookups: cloneIssueMap(s.pendingEpicParentLookups),

--- a/internal/orchestrator/workflow_metrics.go
+++ b/internal/orchestrator/workflow_metrics.go
@@ -8,7 +8,9 @@ import (
 	"time"
 
 	"github.com/digitaldrywood/detent/internal/connector"
+	"github.com/digitaldrywood/detent/internal/provenance"
 	"github.com/digitaldrywood/detent/internal/store"
+	"github.com/digitaldrywood/detent/internal/workflowmetrics"
 )
 
 const defaultWorkflowMetricsProjectID = "default"
@@ -33,6 +35,8 @@ type workflowLaneMetadata struct {
 	DependencyAutoUnblock *workflowLaneDependencyAutoUnblockMetadata `json:"dependency_auto_unblock,omitempty"`
 	ReworkBreaker         *workflowLaneReworkBreakerMetadata         `json:"rework_breaker,omitempty"`
 	ActionSignatures      []workflowLaneActionSignatureMetadata      `json:"action_signatures,omitempty"`
+	Provenance            provenance.Attribution                     `json:"provenance"`
+	Admission             *provenance.Admission                      `json:"admission,omitempty"`
 }
 
 type workflowLanePullRequestMetadata struct {
@@ -242,8 +246,7 @@ func (o *Orchestrator) recordLaneTransition(
 	reason string,
 	metadata workflowLaneMetadata,
 ) {
-	recorder := o.workflowMetrics
-	if recorder == nil {
+	if o.workflowMetrics == nil {
 		return
 	}
 
@@ -259,38 +262,18 @@ func (o *Orchestrator) recordLaneTransition(
 	if reason == "" {
 		reason = "state_transition"
 	}
-
-	base := store.WorkflowPhaseEvent{
-		ProjectID:      o.workflowMetricsProjectID(),
-		IssueID:        issue.ID,
-		Identifier:     issue.Identifier,
-		IssueURL:       issue.URL,
-		PRNumber:       workflowMetricsPRNumber(issue),
-		PhaseType:      store.WorkflowPhaseTypeLane,
-		Reason:         reason,
-		StartedAt:      at,
-		MetadataJSON:   workflowLaneMetadataJSON(issue, metadata),
-		EndpointFamily: "tracker",
+	if metadata.Provenance.Origin == "" {
+		metadata.Provenance.Origin = workflowOriginForReason(reason)
 	}
-	if sourceState != "" {
-		startedAt := workflowLaneStartedAt(issue, at)
-		exitEvent := base
-		exitEvent.PhaseName = sourceState
-		exitEvent.Status = "exited"
-		exitEvent.StartedAt = startedAt
-		exitEvent.FinishedAt = at
-		exitEvent.DurationSeconds = workflowDurationSeconds(startedAt, at)
-		if _, err := recorder.RecordWorkflowPhaseEvent(ctx, exitEvent); err != nil && o.logger != nil {
-			o.logger.Warn("record lane exit metric failed", "issue_id", issue.ID, "identifier", issue.Identifier, "from_state", sourceState, "target_state", targetState, "error", err)
-		}
-	}
-
-	enterEvent := base
-	enterEvent.PhaseName = targetState
-	enterEvent.PreviousPhaseName = sourceState
-	enterEvent.Status = "entered"
-	if _, err := recorder.RecordWorkflowPhaseEvent(ctx, enterEvent); err != nil && o.logger != nil {
-		o.logger.Warn("record lane enter metric failed", "issue_id", issue.ID, "identifier", issue.Identifier, "from_state", sourceState, "target_state", targetState, "error", err)
+	if err := workflowmetrics.RecordLaneTransition(ctx, o.workflowMetrics, workflowmetrics.LaneTransition{
+		ProjectID:    o.workflowMetricsProjectID(),
+		Issue:        issue,
+		TargetState:  targetState,
+		At:           at,
+		Reason:       reason,
+		MetadataJSON: workflowLaneMetadataJSON(issue, metadata),
+	}); err != nil && o.logger != nil {
+		o.logger.Warn("record lane transition metric failed", "issue_id", issue.ID, "identifier", issue.Identifier, "from_state", sourceState, "target_state", targetState, "error", err)
 	}
 }
 
@@ -344,16 +327,6 @@ func (o *Orchestrator) workflowMetricsProjectID() string {
 	return projectID
 }
 
-func workflowLaneStartedAt(issue connector.Issue, fallback time.Time) time.Time {
-	for _, candidate := range []*time.Time{issue.StageUpdatedAt, issue.UpdatedAt, issue.CreatedAt} {
-		if candidate == nil || candidate.IsZero() || candidate.After(fallback) {
-			continue
-		}
-		return *candidate
-	}
-	return fallback
-}
-
 func (o *Orchestrator) refreshCurrentLaneEntries(ctx context.Context, state *State, observedAt time.Time) {
 	if state == nil {
 		return
@@ -365,6 +338,7 @@ func (o *Orchestrator) refreshCurrentLaneEntries(ctx context.Context, state *Sta
 
 	previous := state.laneEntries
 	next := make(map[string]time.Time)
+	nextProvenance := make(map[string]provenance.Attribution)
 	timelines := make(map[string]timelineResult)
 	for _, issue := range stateLaneEntryIssues(state) {
 		laneKey := workflowLaneEntryKey(issue)
@@ -382,51 +356,75 @@ func (o *Orchestrator) refreshCurrentLaneEntries(ctx context.Context, state *Sta
 			timelines[identityKey] = result
 		}
 
-		_, eventBacked := latestCurrentLaneEnteredAt(result.timeline.Events, issue.State)
-		trackerEnteredAt := time.Time{}
+		latestEvent, eventBacked := latestCurrentLaneEntry(result.timeline.Events, issue.State)
+		trackerTransition := connector.IssueStateTransition{}
 		if !eventBacked {
-			trackerEnteredAt = o.trackerIssueStateEnteredAt(ctx, issue)
+			trackerTransition = o.trackerIssueStateTransition(ctx, issue)
 		}
-		enteredAt := resolveCurrentLaneEnteredAt(issue, previous[laneKey], trackerEnteredAt, observedAt, result.timeline.Events)
+		enteredAt := resolveCurrentLaneEnteredAt(issue, previous[laneKey], trackerTransition.EnteredAt, observedAt, result.timeline.Events)
 		if !enteredAt.IsZero() {
 			next[laneKey] = enteredAt
 		}
 		if !eventBacked {
-			o.recordObservedLaneEntry(ctx, issue, enteredAt)
+			o.recordObservedLaneEntry(ctx, issue, enteredAt, trackerTransition.Actor)
 			if normalizeState(issue.State) == normalizeState(autoPromoteReworkState) {
 				observed := cloneIssue(issue)
 				observed.State = ""
 				o.captureReworkLesson(observed, enteredAt, "tracker_state_observed")
 			}
+			latestEvent, eventBacked = latestCurrentLaneEntryForAt(result.timeline.Events, issue.State, enteredAt)
+		}
+		if eventBacked {
+			if metadata, ok := provenance.Parse(latestEvent.MetadataJSON); ok {
+				nextProvenance[laneKey] = metadata.Provenance
+			} else {
+				nextProvenance[laneKey] = provenance.Attribution{Origin: provenance.OriginUnknown}
+			}
+		} else {
+			actor := provenance.Actor{Login: trackerTransition.Actor.Login, Kind: trackerTransition.Actor.Kind}
+			nextProvenance[laneKey] = provenance.Attribution{
+				Origin: provenance.OriginFromActor(actor),
+				Actor:  provenanceActorPointer(actor),
+			}
 		}
 	}
 	state.laneEntries = next
+	state.laneProvenance = nextProvenance
 }
 
-func (o *Orchestrator) trackerIssueStateEnteredAt(ctx context.Context, issue connector.Issue) time.Time {
-	if issue.StageUpdatedAt != nil && !issue.StageUpdatedAt.IsZero() {
-		return issue.StageUpdatedAt.UTC()
-	}
+func (o *Orchestrator) trackerIssueStateTransition(ctx context.Context, issue connector.Issue) connector.IssueStateTransition {
 	reader, ok := o.connector.(connector.IssueStateTransitionReader)
-	if !ok || reader == nil {
-		return time.Time{}
-	}
-	enteredAt, found, err := reader.IssueStateEnteredAt(ctx, issue)
-	if err != nil {
-		if o.logger != nil {
-			o.logger.Warn("tracker lane transition read failed", "issue_id", issue.ID, "identifier", issue.Identifier, "state", issue.State, "error", err)
+	if ok && reader != nil {
+		transition, found, err := reader.IssueStateTransition(ctx, issue)
+		if err != nil {
+			if o.logger != nil {
+				o.logger.Warn("tracker lane transition read failed", "issue_id", issue.ID, "identifier", issue.Identifier, "state", issue.State, "error", err)
+			}
+		} else if found {
+			transition.EnteredAt = transition.EnteredAt.UTC()
+			return transition
 		}
-		return time.Time{}
 	}
-	if !found {
-		return time.Time{}
+	if issue.StageUpdatedAt != nil && !issue.StageUpdatedAt.IsZero() {
+		return connector.IssueStateTransition{EnteredAt: issue.StageUpdatedAt.UTC()}
 	}
-	return enteredAt.UTC()
+	return connector.IssueStateTransition{}
 }
 
-func (o *Orchestrator) recordObservedLaneEntry(ctx context.Context, issue connector.Issue, enteredAt time.Time) {
+func (o *Orchestrator) recordObservedLaneEntry(ctx context.Context, issue connector.Issue, enteredAt time.Time, transitionActor connector.IssueActor) {
 	if o.workflowMetrics == nil || enteredAt.IsZero() || strings.TrimSpace(issue.State) == "" {
 		return
+	}
+	actor := provenance.Actor{Login: transitionActor.Login, Kind: transitionActor.Kind}
+	metadata := workflowLaneMetadata{
+		Provenance: provenance.Attribution{
+			Origin: provenance.OriginFromActor(actor),
+			Actor:  provenanceActorPointer(actor),
+		},
+	}
+	if strings.EqualFold(strings.TrimSpace(issue.State), strings.TrimSpace(o.cfg.AdmissionTargetState)) &&
+		strings.TrimSpace(o.cfg.AdmissionTargetState) != "" {
+		metadata.Admission = &provenance.Admission{Attributed: false}
 	}
 	if _, err := o.workflowMetrics.RecordWorkflowPhaseEvent(ctx, store.WorkflowPhaseEvent{
 		ProjectID:      o.workflowMetricsProjectID(),
@@ -439,7 +437,7 @@ func (o *Orchestrator) recordObservedLaneEntry(ctx context.Context, issue connec
 		Reason:         "tracker_state_observed",
 		Status:         "entered",
 		StartedAt:      enteredAt,
-		MetadataJSON:   workflowLaneMetadataJSON(issue, workflowLaneMetadata{}),
+		MetadataJSON:   workflowLaneMetadataJSON(issue, metadata),
 		EndpointFamily: "tracker",
 	}); err != nil && o.logger != nil {
 		o.logger.Warn("record observed lane enter metric failed", "issue_id", issue.ID, "identifier", issue.Identifier, "state", issue.State, "error", err)
@@ -510,9 +508,14 @@ func laneOccupancyChangedSince(events []store.WorkflowPhaseEvent, state string, 
 }
 
 func latestCurrentLaneEnteredAt(events []store.WorkflowPhaseEvent, state string) (time.Time, bool) {
+	event, ok := latestCurrentLaneEntry(events, state)
+	return event.StartedAt, ok
+}
+
+func latestCurrentLaneEntry(events []store.WorkflowPhaseEvent, state string) (store.WorkflowPhaseEvent, bool) {
 	state = normalizeState(state)
 	if state == "" {
-		return time.Time{}, false
+		return store.WorkflowPhaseEvent{}, false
 	}
 
 	var latest store.WorkflowPhaseEvent
@@ -529,9 +532,17 @@ func latestCurrentLaneEnteredAt(events []store.WorkflowPhaseEvent, state string)
 		}
 	}
 	if latest.StartedAt.IsZero() {
-		return time.Time{}, false
+		return store.WorkflowPhaseEvent{}, false
 	}
-	return latest.StartedAt, true
+	return latest, true
+}
+
+func latestCurrentLaneEntryForAt(events []store.WorkflowPhaseEvent, state string, enteredAt time.Time) (store.WorkflowPhaseEvent, bool) {
+	event, ok := latestCurrentLaneEntry(events, state)
+	if !ok || !event.StartedAt.Equal(enteredAt) {
+		return store.WorkflowPhaseEvent{}, false
+	}
+	return event, true
 }
 
 func workflowLaneFallbackAt(issue connector.Issue) time.Time {
@@ -574,13 +585,6 @@ func workflowIssueIdentityKey(issue connector.Issue) string {
 	return ""
 }
 
-func workflowDurationSeconds(startedAt time.Time, finishedAt time.Time) int64 {
-	if startedAt.IsZero() || finishedAt.IsZero() || finishedAt.Before(startedAt) {
-		return 0
-	}
-	return int64(finishedAt.Sub(startedAt) / time.Second)
-}
-
 func workflowMetricsPRNumber(issue connector.Issue) *int64 {
 	switch {
 	case issue.PRNumber != nil:
@@ -598,14 +602,32 @@ func workflowLaneMetadataJSON(issue connector.Issue, metadata workflowLaneMetada
 	if metadata.PullRequest == nil {
 		metadata.PullRequest = workflowLanePullRequestMetadataFromIssue(issue)
 	}
-	if metadata.PullRequest == nil && metadata.DependencyAutoUnblock == nil && metadata.ReworkBreaker == nil && len(metadata.ActionSignatures) == 0 {
-		return "{}"
+	if metadata.Provenance.Origin == "" {
+		metadata.Provenance.Origin = provenance.OriginUnknown
 	}
 	data, err := json.Marshal(metadata)
 	if err != nil {
 		return "{}"
 	}
 	return string(data)
+}
+
+func workflowOriginForReason(reason string) provenance.Origin {
+	switch strings.ToLower(strings.TrimSpace(reason)) {
+	case "dependency_auto_unblock", "blocker_auto_promote":
+		return provenance.OriginDependency
+	default:
+		return provenance.OriginUnknown
+	}
+}
+
+func provenanceActorPointer(actor provenance.Actor) *provenance.Actor {
+	actor.Login = strings.TrimSpace(actor.Login)
+	actor.Kind = strings.TrimSpace(actor.Kind)
+	if actor.Login == "" && actor.Kind == "" {
+		return nil
+	}
+	return &actor
 }
 
 func workflowLaneMetadataFromJSON(raw string) (workflowLaneMetadata, bool) {

--- a/internal/orchestrator/workflow_metrics_test.go
+++ b/internal/orchestrator/workflow_metrics_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/digitaldrywood/detent/internal/connector"
 	"github.com/digitaldrywood/detent/internal/lessons"
+	"github.com/digitaldrywood/detent/internal/provenance"
 	"github.com/digitaldrywood/detent/internal/scheduler"
 	"github.com/digitaldrywood/detent/internal/store"
 )
@@ -290,6 +291,10 @@ func TestRefreshCurrentLaneEntriesPersistsPollObservationAcrossRestart(t *testin
 	if event := timeline.Events[0]; event.PhaseType != store.WorkflowPhaseTypeLane || event.PhaseName != "Blocked" || event.Status != "entered" || !event.StartedAt.Equal(enteredAt) {
 		t.Fatalf("workflow event = %#v, want Blocked entered at %v", event, enteredAt)
 	}
+	metadata, ok := provenance.Parse(timeline.Events[0].MetadataJSON)
+	if !ok || metadata.Provenance.Origin != provenance.OriginUnknown || metadata.Provenance.Actor != nil {
+		t.Fatalf("workflow metadata = %#v, want unknown origin without actor", metadata)
+	}
 	if err := backend.Close(); err != nil {
 		t.Fatalf("backend.Close() error = %v", err)
 	}
@@ -335,11 +340,26 @@ func TestRefreshCurrentLaneEntriesUsesTrackerTransitionAcrossPollsAndRestart(t *
 		State:      "Blocked",
 		UpdatedAt:  &updatedAt,
 	}}
-	orch := &Orchestrator{cfg: normalizeConfig(Config{}), connector: tracker, workflowMetrics: backend}
+	orch := &Orchestrator{
+		cfg:             normalizeConfig(Config{AdmissionTargetState: "Blocked"}),
+		connector:       tracker,
+		workflowMetrics: backend,
+	}
 	orch.refreshCurrentLaneEntries(ctx, &state, firstPollAt)
 	first := state.Snapshot(firstPollAt)
 	if got := first.BoardIssues[0].CurrentLaneEnteredAt; got == nil || !got.Equal(enteredAt) {
 		t.Fatalf("first CurrentLaneEnteredAt = %v, want %v", got, enteredAt)
+	}
+	if got := first.BoardIssues[0].Origin; got != string(provenance.OriginHuman) {
+		t.Fatalf("first Origin = %q, want %q", got, provenance.OriginHuman)
+	}
+	timeline, err := backend.IssueWorkflowTimeline(ctx, store.IssueIdentity{IssueID: "issue-1162"})
+	if err != nil {
+		t.Fatalf("IssueWorkflowTimeline() error = %v", err)
+	}
+	metadata, ok := provenance.Parse(timeline.Events[0].MetadataJSON)
+	if !ok || metadata.Admission == nil || metadata.Admission.Attributed {
+		t.Fatalf("observed transition metadata = %#v, want unattributed admission", metadata)
 	}
 
 	updatedAt = secondPollAt
@@ -620,9 +640,15 @@ func (c *workflowMetricsConnector) Name() string {
 	return c.name
 }
 
-func (c *workflowMetricsConnector) IssueStateEnteredAt(context.Context, connector.Issue) (time.Time, bool, error) {
+func (c *workflowMetricsConnector) IssueStateTransition(context.Context, connector.Issue) (connector.IssueStateTransition, bool, error) {
 	c.stateEnteredAtCalls++
-	return c.stateEnteredAt, c.stateEnteredAtFound, c.stateEnteredAtErr
+	return connector.IssueStateTransition{
+		EnteredAt: c.stateEnteredAt,
+		Actor: connector.IssueActor{
+			Login: "ada",
+			Kind:  "User",
+		},
+	}, c.stateEnteredAtFound, c.stateEnteredAtErr
 }
 
 func (c *workflowMetricsConnector) FetchCandidateIssues(context.Context) ([]connector.Issue, error) {

--- a/internal/project/project.go
+++ b/internal/project/project.go
@@ -236,6 +236,7 @@ func New(cfg Config, deps Dependencies) (*Project, error) {
 		Config:        workflow.Config.Retro,
 		ProjectIssues: projectRetroStore,
 		ProductIssues: productRetroStore,
+		Metrics:       deps.WorkflowMetrics,
 	}, deps.RetroStore, logger, nil)
 	if err != nil {
 		return nil, errors.Join(fmt.Errorf("create project retro: %w", err), closeConnector(retroProductConnector))
@@ -246,6 +247,7 @@ func New(cfg Config, deps Dependencies) (*Project, error) {
 		SearchStates: workflow.Config.KanbanStateNames(),
 		Runner:       deps.Runner,
 		Issues:       routineIssueStore(projectConnector),
+		Metrics:      deps.WorkflowMetrics,
 	}, deps.RoutineStore, logger, nil)
 	if err != nil {
 		return nil, errors.Join(fmt.Errorf("create project routine: %w", err), closeConnector(retroProductConnector))
@@ -272,6 +274,8 @@ func New(cfg Config, deps Dependencies) (*Project, error) {
 		Scheduler:          projectScheduler,
 		GlobalDispatchGate: deps.GlobalDispatchGate,
 		ProjectCandidate:   projectSchedulerCandidate(cfg.Project),
+		TerminalStates:     workflow.Config.Tracker.TerminalStates,
+		ReworkState:        workflow.Config.Agent.AutoPromote.ReworkState,
 	}, deps.AdmissionStore, logger, nil)
 	if err != nil {
 		return nil, errors.Join(fmt.Errorf("create project backlog admission: %w", err), closeConnector(retroProductConnector))
@@ -1274,6 +1278,7 @@ func (p *Project) handleWorkflowUpdate(ctx context.Context, update configwatcher
 			Config:        workflow.Config.Retro,
 			ProjectIssues: projectRetroStore,
 			ProductIssues: productRetroStore,
+			Metrics:       p.orchDeps.WorkflowMetrics,
 		}); err != nil {
 			return p.workflowReloadError("apply workflow retro reload failed", update.Path, err)
 		}
@@ -1285,6 +1290,7 @@ func (p *Project) handleWorkflowUpdate(ctx context.Context, update configwatcher
 			SearchStates: workflow.Config.KanbanStateNames(),
 			Runner:       runner,
 			Issues:       routineIssueStore(projectConnector),
+			Metrics:      p.orchDeps.WorkflowMetrics,
 		}); err != nil {
 			return p.workflowReloadError("apply workflow routine reload failed", update.Path, err)
 		}
@@ -1302,6 +1308,8 @@ func (p *Project) handleWorkflowUpdate(ctx context.Context, update configwatcher
 			Scheduler:          projectScheduler,
 			GlobalDispatchGate: globalDispatchGate,
 			ProjectCandidate:   projectSchedulerCandidate(projectConfig),
+			TerminalStates:     workflow.Config.Tracker.TerminalStates,
+			ReworkState:        workflow.Config.Agent.AutoPromote.ReworkState,
 		}); err != nil {
 			return p.workflowReloadError("apply workflow backlog admission reload failed", update.Path, err)
 		}

--- a/internal/provenance/provenance.go
+++ b/internal/provenance/provenance.go
@@ -1,0 +1,106 @@
+package provenance
+
+import (
+	"encoding/json"
+	"strings"
+)
+
+type Origin string
+
+const (
+	OriginHuman      Origin = "human"
+	OriginRoutine    Origin = "routine"
+	OriginRetro      Origin = "retro"
+	OriginDependency Origin = "dependency"
+	OriginAdmission  Origin = "admission"
+	OriginUnknown    Origin = "unknown"
+)
+
+type Actor struct {
+	Login string `json:"login,omitempty"`
+	Kind  string `json:"kind,omitempty"`
+}
+
+type Attribution struct {
+	Origin Origin `json:"origin"`
+	Actor  *Actor `json:"actor,omitempty"`
+}
+
+type Admission struct {
+	ProposalID string `json:"proposal_id,omitempty"`
+	Attributed bool   `json:"attributed"`
+}
+
+type Metadata struct {
+	Provenance Attribution `json:"provenance"`
+	Admission  *Admission  `json:"admission,omitempty"`
+}
+
+func NormalizeOrigin(origin Origin) Origin {
+	switch origin {
+	case OriginHuman, OriginRoutine, OriginRetro, OriginDependency, OriginAdmission, OriginUnknown:
+		return origin
+	default:
+		return OriginUnknown
+	}
+}
+
+func OriginFromActor(actor Actor) Origin {
+	if strings.TrimSpace(actor.Login) != "" && strings.EqualFold(strings.TrimSpace(actor.Kind), "user") {
+		return OriginHuman
+	}
+	return OriginUnknown
+}
+
+func Apply(raw string, attribution Attribution, admission *Admission) string {
+	fields := map[string]json.RawMessage{}
+	if trimmed := strings.TrimSpace(raw); trimmed != "" && trimmed != "{}" {
+		if err := json.Unmarshal([]byte(trimmed), &fields); err != nil {
+			fields = map[string]json.RawMessage{}
+		}
+	}
+	attribution.Origin = NormalizeOrigin(attribution.Origin)
+	if attribution.Actor != nil {
+		actor := Actor{
+			Login: strings.TrimSpace(attribution.Actor.Login),
+			Kind:  strings.TrimSpace(attribution.Actor.Kind),
+		}
+		if actor.Login == "" && actor.Kind == "" {
+			attribution.Actor = nil
+		} else {
+			attribution.Actor = &actor
+		}
+	}
+	provenanceJSON, err := json.Marshal(attribution)
+	if err != nil {
+		return `{"provenance":{"origin":"unknown"}}`
+	}
+	fields["provenance"] = provenanceJSON
+	if admission != nil {
+		value := Admission{
+			ProposalID: strings.TrimSpace(admission.ProposalID),
+			Attributed: admission.Attributed,
+		}
+		admissionJSON, err := json.Marshal(value)
+		if err == nil {
+			fields["admission"] = admissionJSON
+		}
+	}
+	data, err := json.Marshal(fields)
+	if err != nil {
+		return `{"provenance":{"origin":"unknown"}}`
+	}
+	return string(data)
+}
+
+func Parse(raw string) (Metadata, bool) {
+	var metadata Metadata
+	if err := json.Unmarshal([]byte(strings.TrimSpace(raw)), &metadata); err != nil {
+		return Metadata{}, false
+	}
+	metadata.Provenance.Origin = NormalizeOrigin(metadata.Provenance.Origin)
+	if metadata.Provenance.Origin == OriginUnknown && !strings.Contains(raw, `"origin"`) {
+		return Metadata{}, false
+	}
+	return metadata, true
+}

--- a/internal/provenance/provenance_test.go
+++ b/internal/provenance/provenance_test.go
@@ -1,0 +1,61 @@
+package provenance
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestOriginFromActorRequiresExplicitUserType(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		actor Actor
+		want  Origin
+	}{
+		{name: "user", actor: Actor{Login: "ada", Kind: "User"}, want: OriginHuman},
+		{name: "bot", actor: Actor{Login: "dependabot[bot]", Kind: "Bot"}, want: OriginUnknown},
+		{name: "missing kind", actor: Actor{Login: "ada"}, want: OriginUnknown},
+		{name: "missing actor", want: OriginUnknown},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := OriginFromActor(tt.actor); got != tt.want {
+				t.Fatalf("OriginFromActor(%#v) = %q, want %q", tt.actor, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestApplyPreservesMetadataAndRecordsAdmission(t *testing.T) {
+	t.Parallel()
+
+	raw := Apply(
+		`{"pull_request":{"number":1537},"provenance":{"origin":"unknown"}}`,
+		Attribution{
+			Origin: OriginAdmission,
+			Actor:  &Actor{Login: "ada", Kind: "User"},
+		},
+		&Admission{ProposalID: "proposal-1", Attributed: true},
+	)
+	metadata, ok := Parse(raw)
+	if !ok {
+		t.Fatalf("Parse(%q) = false", raw)
+	}
+	if metadata.Provenance.Origin != OriginAdmission ||
+		metadata.Provenance.Actor == nil ||
+		metadata.Provenance.Actor.Login != "ada" ||
+		metadata.Admission == nil ||
+		metadata.Admission.ProposalID != "proposal-1" ||
+		!metadata.Admission.Attributed {
+		t.Fatalf("metadata = %#v", metadata)
+	}
+	var fields map[string]json.RawMessage
+	if err := json.Unmarshal([]byte(raw), &fields); err != nil {
+		t.Fatalf("json.Unmarshal() error = %v", err)
+	}
+	if _, ok := fields["pull_request"]; !ok {
+		t.Fatalf("Apply() removed existing metadata: %s", raw)
+	}
+}

--- a/internal/retro/manager.go
+++ b/internal/retro/manager.go
@@ -12,7 +12,10 @@ import (
 
 	"github.com/robfig/cron/v3"
 
+	"github.com/digitaldrywood/detent/internal/connector"
 	"github.com/digitaldrywood/detent/internal/intake"
+	"github.com/digitaldrywood/detent/internal/provenance"
+	"github.com/digitaldrywood/detent/internal/workflowmetrics"
 )
 
 const (
@@ -49,6 +52,7 @@ type Settings struct {
 	Config        Config
 	ProjectIssues intake.IssueStore
 	ProductIssues intake.IssueStore
+	Metrics       workflowmetrics.Recorder
 }
 
 type Result struct {
@@ -286,6 +290,9 @@ func (m *Manager) upsertFinding(ctx context.Context, issueStore intake.IssueStor
 			if err := issueStore.SetIntakeIssueState(ctx, issue.ID, settings.Config.TargetState); err != nil {
 				return upsertOutcome{}, err
 			}
+			if err := m.recordTransition(ctx, settings, issue, settings.Config.TargetState); err != nil {
+				return upsertOutcome{}, err
+			}
 		}
 		draft.Body = preserveFindingOutcome(draft.Body, issue.Body)
 		if strings.TrimSpace(issue.Body) == strings.TrimSpace(draft.Body) {
@@ -310,12 +317,30 @@ func (m *Manager) upsertFinding(ctx context.Context, issueStore intake.IssueStor
 	if err := issueStore.SetIntakeIssueState(ctx, issue.ID, settings.Config.TargetState); err != nil {
 		return upsertOutcome{created: true}, err
 	}
+	if err := m.recordTransition(ctx, settings, issue, settings.Config.TargetState); err != nil {
+		return upsertOutcome{created: true}, err
+	}
 	updated, err := issueStore.UpdateIntakeIssue(ctx, issue.ID, draft)
 	if err != nil {
 		return upsertOutcome{created: true}, err
 	}
 	m.issues[cacheKey] = updated
 	return upsertOutcome{created: true}, nil
+}
+
+func (m *Manager) recordTransition(ctx context.Context, settings Settings, issue intake.Issue, targetState string) error {
+	return workflowmetrics.RecordLaneTransition(ctx, settings.Metrics, workflowmetrics.LaneTransition{
+		ProjectID: settings.ProjectID,
+		Issue: connector.Issue{
+			ID:         issue.ID,
+			Identifier: issue.Identifier,
+			URL:        issue.URL,
+		},
+		TargetState:  targetState,
+		At:           m.now().UTC(),
+		Reason:       "retro",
+		MetadataJSON: provenance.Apply("{}", provenance.Attribution{Origin: provenance.OriginRetro}, nil),
+	})
 }
 
 func preserveFindingOutcome(draft string, existing string) string {

--- a/internal/retro/manager_test.go
+++ b/internal/retro/manager_test.go
@@ -8,6 +8,8 @@ import (
 
 	"github.com/digitaldrywood/detent/internal/connector/memory"
 	"github.com/digitaldrywood/detent/internal/intake"
+	"github.com/digitaldrywood/detent/internal/provenance"
+	"github.com/digitaldrywood/detent/internal/workflowmetrics"
 )
 
 func TestManagerRoutesAndDeduplicatesRecurringFindings(t *testing.T) {
@@ -17,6 +19,7 @@ func TestManagerRoutesAndDeduplicatesRecurringFindings(t *testing.T) {
 	telemetry := &recordingTelemetryStore{snapshot: routingSnapshot(now)}
 	projectIssues := memory.New(memory.Config{Stateful: true})
 	productIssues := memory.New(memory.Config{Stateful: true})
+	metrics := &retroMetricsRecorder{}
 	manager, err := New(Settings{
 		ProjectID: "example",
 		Config: Config{
@@ -24,6 +27,7 @@ func TestManagerRoutesAndDeduplicatesRecurringFindings(t *testing.T) {
 		},
 		ProjectIssues: projectIssues,
 		ProductIssues: productIssues,
+		Metrics:       metrics,
 	}, telemetry, nil, func() time.Time { return now })
 	if err != nil {
 		t.Fatalf("New() error = %v", err)
@@ -38,6 +42,15 @@ func TestManagerRoutesAndDeduplicatesRecurringFindings(t *testing.T) {
 	}
 	assertSingleRetroIssue(t, projectIssues, PatternInvalidWorkpadStatus, "Proposed WORKFLOW.md change")
 	assertSingleRetroIssue(t, productIssues, PatternCompletedRedispatch, "classification: product")
+	if len(metrics.events) != 2 {
+		t.Fatalf("workflow events = %#v, want two retro lane entries", metrics.events)
+	}
+	for _, event := range metrics.events {
+		metadata, ok := provenance.Parse(event.MetadataJSON)
+		if event.Status != "entered" || !ok || metadata.Provenance.Origin != provenance.OriginRetro {
+			t.Fatalf("workflow event = %#v, metadata = %#v", event, metadata)
+		}
+	}
 
 	telemetry.snapshot.PhaseEvents = append(telemetry.snapshot.PhaseEvents, PhaseEvent{Identifier: "issue-status-c", Reason: "workpad_status_invalid", StartedAt: now.Add(time.Minute)})
 	second, err := manager.RunOnce(context.Background(), TriggerCompletion)
@@ -176,6 +189,15 @@ type recordingTelemetryStore struct {
 	snapshot Snapshot
 	loads    int
 	records  []RunRecord
+}
+
+type retroMetricsRecorder struct {
+	events []workflowmetrics.PhaseEvent
+}
+
+func (r *retroMetricsRecorder) RecordWorkflowPhaseEvent(_ context.Context, event workflowmetrics.PhaseEvent) (int64, error) {
+	r.events = append(r.events, event)
+	return int64(len(r.events)), nil
 }
 
 func (s *recordingTelemetryStore) LoadRetroSnapshot(context.Context, string, time.Time) (Snapshot, error) {

--- a/internal/routine/manager.go
+++ b/internal/routine/manager.go
@@ -18,8 +18,10 @@ import (
 	"github.com/digitaldrywood/detent/internal/config"
 	"github.com/digitaldrywood/detent/internal/connector"
 	"github.com/digitaldrywood/detent/internal/intake"
+	"github.com/digitaldrywood/detent/internal/provenance"
 	routinemodel "github.com/digitaldrywood/detent/internal/routine/model"
 	"github.com/digitaldrywood/detent/internal/runner"
+	"github.com/digitaldrywood/detent/internal/workflowmetrics"
 )
 
 const (
@@ -73,6 +75,7 @@ type Settings struct {
 	SearchStates []string
 	Runner       runner.Backend
 	Issues       IssueStore
+	Metrics      workflowmetrics.Recorder
 }
 
 type Manager struct {
@@ -350,6 +353,21 @@ func (m *Manager) fileProposals(ctx context.Context, settings Settings, definiti
 		openMarkers[marker] = struct{}{}
 		if stateErr := settings.Issues.SetIntakeIssueState(ctx, issue.ID, IssueState); stateErr != nil {
 			runErr = errors.Join(runErr, fmt.Errorf("set routine issue %s state: %w", proposal.DedupKey, stateErr))
+			continue
+		}
+		if metricsErr := workflowmetrics.RecordLaneTransition(ctx, settings.Metrics, workflowmetrics.LaneTransition{
+			ProjectID: settings.ProjectID,
+			Issue: connector.Issue{
+				ID:         issue.ID,
+				Identifier: issue.Identifier,
+				URL:        issue.URL,
+			},
+			TargetState:  IssueState,
+			At:           m.now().UTC(),
+			Reason:       "routine",
+			MetadataJSON: provenance.Apply("{}", provenance.Attribution{Origin: provenance.OriginRoutine}, nil),
+		}); metricsErr != nil {
+			runErr = errors.Join(runErr, fmt.Errorf("record routine issue %s state provenance: %w", proposal.DedupKey, metricsErr))
 		}
 	}
 	return result, runErr

--- a/internal/routine/manager_test.go
+++ b/internal/routine/manager_test.go
@@ -11,7 +11,9 @@ import (
 	"github.com/digitaldrywood/detent/internal/config"
 	"github.com/digitaldrywood/detent/internal/connector"
 	"github.com/digitaldrywood/detent/internal/intake"
+	"github.com/digitaldrywood/detent/internal/provenance"
 	"github.com/digitaldrywood/detent/internal/runner"
+	"github.com/digitaldrywood/detent/internal/workflowmetrics"
 )
 
 func TestDue(t *testing.T) {
@@ -204,6 +206,35 @@ func TestManagerRunOnceFilesAndDeduplicatesOpenIssue(t *testing.T) {
 	}
 }
 
+func TestManagerRunOnceRecordsRoutineOrigin(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, time.July, 17, 10, 0, 0, 0, time.UTC)
+	metrics := &routineMetricsRecorder{}
+	manager, err := New(Settings{
+		ProjectID:    "detent",
+		Definitions:  []config.Routine{{Name: "maintenance", Schedule: "0 * * * *", Prompt: "Inspect."}},
+		SearchStates: []string{"Backlog", "Todo"},
+		Runner:       fakeRunner{proposals: []Proposal{{DedupKey: "lint/deadcode", Title: "Remove dead code", Body: "Reproducible."}}},
+		Issues:       &fakeIssueStore{},
+		Metrics:      metrics,
+	}, &fakeStore{}, nil, func() time.Time { return now })
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	if _, err := manager.RunOnce(context.Background(), "maintenance"); err != nil {
+		t.Fatalf("RunOnce() error = %v", err)
+	}
+	if len(metrics.events) != 1 {
+		t.Fatalf("events = %#v, want one lane entry", metrics.events)
+	}
+	metadata, ok := provenance.Parse(metrics.events[0].MetadataJSON)
+	if metrics.events[0].PhaseName != IssueState || metrics.events[0].Status != "entered" ||
+		!ok || metadata.Provenance.Origin != provenance.OriginRoutine {
+		t.Fatalf("event = %#v, metadata = %#v", metrics.events[0], metadata)
+	}
+}
+
 func TestManagerRunOnceRefilesClosedIssue(t *testing.T) {
 	t.Parallel()
 	now := time.Date(2026, time.July, 17, 10, 0, 0, 0, time.UTC)
@@ -350,6 +381,15 @@ type fakeIssueStore struct {
 	fetchErr  error
 	createErr error
 	stateErr  error
+}
+
+type routineMetricsRecorder struct {
+	events []workflowmetrics.PhaseEvent
+}
+
+func (r *routineMetricsRecorder) RecordWorkflowPhaseEvent(_ context.Context, event workflowmetrics.PhaseEvent) (int64, error) {
+	r.events = append(r.events, event)
+	return int64(len(r.events)), nil
 }
 
 func (s *fakeIssueStore) FetchIssuesByStates(context.Context, []string) ([]connector.Issue, error) {

--- a/internal/store/admission.go
+++ b/internal/store/admission.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	admissionmodel "github.com/digitaldrywood/detent/internal/admission/model"
+	"github.com/digitaldrywood/detent/internal/provenance"
 )
 
 func (s *sqliteStore) CreateAdmissionProposal(ctx context.Context, proposal admissionmodel.Proposal) (bool, error) {
@@ -57,8 +58,10 @@ LIMIT 1`,
 	}
 	if _, err = tx.ExecContext(ctx, `
 UPDATE backlog_admission_proposals
-SET status = 'superseded', resolved_at = ?
+SET status = 'superseded', resolved_at = ?,
+    decision_seconds = CAST(MAX(0, (julianday(?) - julianday(created_at)) * 86400) AS INTEGER)
 WHERE project_id = ? AND issue_id = ? AND target_state = ? AND status = 'open'`,
+		createdAt,
 		createdAt,
 		strings.TrimSpace(proposal.ProjectID),
 		strings.TrimSpace(proposal.IssueID),
@@ -98,7 +101,10 @@ func (s *sqliteStore) OpenAdmissionProposals(ctx context.Context, projectID stri
 	query := `
 SELECT id, project_id, issue_id, issue_identifier, issue_url, target_state, fingerprint,
        criteria_section, criteria_text, findings_json, confidence, status, created_at,
-       expires_at, COALESCE(resolved_at, ''), COALESCE(commented_at, '')
+       expires_at, COALESCE(resolved_at, ''), COALESCE(commented_at, ''),
+       COALESCE(decision_comment_id, ''), COALESCE(decision_actor_login, ''),
+       COALESCE(decision_actor_kind, ''), COALESCE(transition_at, ''),
+       COALESCE(decision_seconds, 0)
 FROM backlog_admission_proposals
 WHERE project_id = ? AND status = 'open'
 ORDER BY created_at, id`
@@ -119,7 +125,10 @@ func (s *sqliteStore) AdmissionProposalHistory(ctx context.Context, projectID st
 	rows, err := s.db.QueryContext(ctx, `
 SELECT id, project_id, issue_id, issue_identifier, issue_url, target_state, fingerprint,
        criteria_section, criteria_text, findings_json, confidence, status, created_at,
-       expires_at, COALESCE(resolved_at, ''), COALESCE(commented_at, '')
+       expires_at, COALESCE(resolved_at, ''), COALESCE(commented_at, ''),
+       COALESCE(decision_comment_id, ''), COALESCE(decision_actor_login, ''),
+       COALESCE(decision_actor_kind, ''), COALESCE(transition_at, ''),
+       COALESCE(decision_seconds, 0)
 FROM backlog_admission_proposals
 WHERE project_id = ? AND issue_id = ?
 ORDER BY created_at DESC, id DESC`,
@@ -151,8 +160,10 @@ func (s *sqliteStore) ExpireAdmissionProposals(ctx context.Context, projectID st
 	}
 	result, err := s.db.ExecContext(ctx, `
 UPDATE backlog_admission_proposals
-SET status = 'expired', resolved_at = ?
+SET status = 'expired', resolved_at = ?,
+    decision_seconds = CAST(MAX(0, (julianday(?) - julianday(created_at)) * 86400) AS INTEGER)
 WHERE project_id = ? AND status = 'open' AND expires_at <= ?`,
+		resolvedAt,
 		resolvedAt,
 		strings.TrimSpace(projectID),
 		resolvedAt,
@@ -201,6 +212,415 @@ WHERE id = ? AND status = ?`,
 		return ErrNotFound
 	}
 	return nil
+}
+
+func (s *sqliteStore) ResolveAdmissionProposal(ctx context.Context, decision admissionmodel.Decision) error {
+	if strings.TrimSpace(decision.ProposalID) == "" {
+		return errors.New("backlog admission proposal id is required")
+	}
+	if decision.Outcome != admissionmodel.ProposalAccepted && decision.Outcome != admissionmodel.ProposalRejected {
+		return errors.New("backlog admission decision outcome must be accepted or rejected")
+	}
+	if decision.DecidedAt.IsZero() {
+		return errors.New("backlog admission decision time is required")
+	}
+	if strings.TrimSpace(decision.CommentID) == "" {
+		return errors.New("backlog admission decision comment is required")
+	}
+	if decision.Outcome == admissionmodel.ProposalAccepted && decision.TransitionAt.IsZero() {
+		return errors.New("backlog admission acceptance transition is required")
+	}
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("begin backlog admission decision: %w", err)
+	}
+	committed := false
+	defer func() {
+		if !committed {
+			_ = tx.Rollback()
+		}
+	}()
+	var proposal admissionmodel.Proposal
+	var createdAt string
+	if err := tx.QueryRowContext(ctx, `
+SELECT project_id, issue_id, issue_identifier, issue_url, target_state, created_at
+FROM backlog_admission_proposals
+WHERE id = ? AND status = 'open'`,
+		strings.TrimSpace(decision.ProposalID),
+	).Scan(
+		&proposal.ProjectID,
+		&proposal.IssueID,
+		&proposal.IssueIdentifier,
+		&proposal.IssueURL,
+		&proposal.TargetState,
+		&createdAt,
+	); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return ErrNotFound
+		}
+		return fmt.Errorf("read backlog admission proposal for decision: %w", err)
+	}
+	proposal.CreatedAt, err = parseTimestamp("created_at", createdAt)
+	if err != nil {
+		return err
+	}
+	decidedAt, err := requiredTimestamp("resolved_at", decision.DecidedAt)
+	if err != nil {
+		return err
+	}
+	transitionAt, err := optionalTimestamp("transition_at", decision.TransitionAt)
+	if err != nil {
+		return err
+	}
+	decisionSeconds := int64(decision.DecidedAt.Sub(proposal.CreatedAt) / time.Second)
+	if decisionSeconds < 0 {
+		decisionSeconds = 0
+	}
+	result, err := tx.ExecContext(ctx, `
+UPDATE backlog_admission_proposals
+SET status = ?, resolved_at = ?, decision_comment_id = ?, decision_actor_login = ?,
+    decision_actor_kind = ?, transition_at = ?, decision_seconds = ?
+WHERE id = ? AND status = 'open'`,
+		string(decision.Outcome),
+		decidedAt,
+		strings.TrimSpace(decision.CommentID),
+		nullString(decision.ActorLogin),
+		nullString(decision.ActorKind),
+		transitionAt,
+		decisionSeconds,
+		strings.TrimSpace(decision.ProposalID),
+	)
+	if err != nil {
+		return fmt.Errorf("resolve backlog admission proposal: %w", err)
+	}
+	affected, err := result.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("read backlog admission decision count: %w", err)
+	}
+	if affected == 0 {
+		return ErrNotFound
+	}
+	if decision.Outcome == admissionmodel.ProposalAccepted {
+		if err := attributeAdmissionTransition(ctx, tx, proposal, decision); err != nil {
+			return err
+		}
+		if _, err := tx.ExecContext(ctx, `
+INSERT INTO backlog_admission_downstream_outcomes (
+  proposal_id, project_id, issue_id, updated_at
+) VALUES (?, ?, ?, ?)
+ON CONFLICT(proposal_id) DO UPDATE SET updated_at = excluded.updated_at`,
+			strings.TrimSpace(decision.ProposalID),
+			strings.TrimSpace(proposal.ProjectID),
+			strings.TrimSpace(proposal.IssueID),
+			decidedAt,
+		); err != nil {
+			return fmt.Errorf("initialize backlog admission downstream outcome: %w", err)
+		}
+	}
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("commit backlog admission decision: %w", err)
+	}
+	committed = true
+	return nil
+}
+
+func attributeAdmissionTransition(
+	ctx context.Context,
+	tx *sql.Tx,
+	proposal admissionmodel.Proposal,
+	decision admissionmodel.Decision,
+) error {
+	transitionAt, err := requiredTimestamp("transition_at", decision.TransitionAt)
+	if err != nil {
+		return err
+	}
+	var eventID int64
+	var metadataJSON string
+	err = tx.QueryRowContext(ctx, `
+SELECT id, metadata_json
+FROM workflow_phase_events
+WHERE project_id = ? AND issue_id = ? AND phase_type = 'lane' AND status = 'entered'
+  AND lower(phase_name) = lower(?) AND started_at = ?
+ORDER BY id DESC
+LIMIT 1`,
+		strings.TrimSpace(proposal.ProjectID),
+		strings.TrimSpace(proposal.IssueID),
+		strings.TrimSpace(proposal.TargetState),
+		transitionAt,
+	).Scan(&eventID, &metadataJSON)
+	actor := provenance.Actor{
+		Login: strings.TrimSpace(decision.ActorLogin),
+		Kind:  strings.TrimSpace(decision.ActorKind),
+	}
+	attribution := provenance.Attribution{
+		Origin: provenance.OriginAdmission,
+		Actor:  admissionActorPointer(actor),
+	}
+	metadataJSON = provenance.Apply(metadataJSON, attribution, &provenance.Admission{
+		ProposalID: strings.TrimSpace(decision.ProposalID),
+		Attributed: true,
+	})
+	if err == nil {
+		if _, err := tx.ExecContext(ctx, `
+UPDATE workflow_phase_events
+SET reason = 'admission_proposal_accepted', metadata_json = ?
+WHERE id = ?`, metadataJSON, eventID); err != nil {
+			return fmt.Errorf("attribute backlog admission transition: %w", err)
+		}
+		return nil
+	}
+	if !errors.Is(err, sql.ErrNoRows) {
+		return fmt.Errorf("find backlog admission transition: %w", err)
+	}
+	if _, err := tx.ExecContext(ctx, `
+INSERT INTO workflow_phase_events (
+  project_id, issue_id, identifier, issue_url, phase_type, phase_name, reason,
+  status, started_at, event_day, endpoint_family, metadata_json
+) VALUES (?, ?, ?, ?, 'lane', ?, 'admission_proposal_accepted', 'entered', ?, ?, 'tracker', ?)`,
+		strings.TrimSpace(proposal.ProjectID),
+		nullString(proposal.IssueID),
+		nullString(proposal.IssueIdentifier),
+		nullString(proposal.IssueURL),
+		strings.TrimSpace(proposal.TargetState),
+		transitionAt,
+		decision.TransitionAt.UTC().Format("2006-01-02"),
+		metadataJSON,
+	); err != nil {
+		return fmt.Errorf("record backlog admission transition: %w", err)
+	}
+	return nil
+}
+
+func admissionActorPointer(actor provenance.Actor) *provenance.Actor {
+	if actor.Login == "" && actor.Kind == "" {
+		return nil
+	}
+	return &actor
+}
+
+func (s *sqliteStore) RefreshAdmissionOutcomes(ctx context.Context, refresh admissionmodel.OutcomeRefresh) error {
+	projectID := strings.TrimSpace(refresh.ProjectID)
+	if projectID == "" {
+		return errors.New("backlog admission outcome project id is required")
+	}
+	if refresh.ObservedAt.IsZero() {
+		return errors.New("backlog admission outcome observation time is required")
+	}
+	proposals, err := s.acceptedAdmissionProposals(ctx, projectID)
+	if err != nil {
+		return err
+	}
+	for _, proposal := range proposals {
+		if err := s.refreshAdmissionOutcome(ctx, projectID, proposal.id, proposal.issueID, proposal.resolvedAt, refresh); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+type acceptedAdmissionProposal struct {
+	id         string
+	issueID    string
+	resolvedAt time.Time
+}
+
+func (s *sqliteStore) acceptedAdmissionProposals(ctx context.Context, projectID string) (_ []acceptedAdmissionProposal, resultErr error) {
+	rows, err := s.db.QueryContext(ctx, `
+SELECT id, issue_id, resolved_at
+FROM backlog_admission_proposals
+WHERE project_id = ? AND status = 'accepted'
+ORDER BY resolved_at, id`, projectID)
+	if err != nil {
+		return nil, fmt.Errorf("read accepted backlog admission proposals: %w", err)
+	}
+	defer func() {
+		resultErr = errors.Join(resultErr, rows.Close())
+	}()
+	proposals := []acceptedAdmissionProposal{}
+	for rows.Next() {
+		var proposal acceptedAdmissionProposal
+		var resolvedAt string
+		if err := rows.Scan(&proposal.id, &proposal.issueID, &resolvedAt); err != nil {
+			return nil, err
+		}
+		proposal.resolvedAt, err = parseTimestamp("resolved_at", resolvedAt)
+		if err != nil {
+			return nil, err
+		}
+		proposals = append(proposals, proposal)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return proposals, nil
+}
+
+func (s *sqliteStore) refreshAdmissionOutcome(
+	ctx context.Context,
+	projectID string,
+	proposalID string,
+	issueID string,
+	resolvedAt time.Time,
+	refresh admissionmodel.OutcomeRefresh,
+) error {
+	resolvedAtRaw, err := requiredTimestamp("resolved_at", resolvedAt)
+	if err != nil {
+		return err
+	}
+	workflowOutcome, err := s.admissionWorkflowOutcome(ctx, projectID, issueID, resolvedAtRaw, refresh)
+	if err != nil {
+		return err
+	}
+	var spendUSD float64
+	if err := s.db.QueryRowContext(ctx, `
+SELECT COALESCE(SUM(cost_usd), 0.0)
+FROM usage_events
+WHERE project_id = ? AND issue_id = ? AND finished_at >= ?`,
+		projectID,
+		strings.TrimSpace(issueID),
+		resolvedAtRaw,
+	).Scan(&spendUSD); err != nil {
+		return fmt.Errorf("read backlog admission downstream spend: %w", err)
+	}
+	observedAt, err := requiredTimestamp("updated_at", refresh.ObservedAt)
+	if err != nil {
+		return err
+	}
+	completedAtRaw, err := optionalTimestamp("completed_at", workflowOutcome.completedAt)
+	if err != nil {
+		return err
+	}
+	if _, err := s.db.ExecContext(ctx, `
+INSERT INTO backlog_admission_downstream_outcomes (
+  proposal_id, project_id, issue_id, completed_at, rework_count,
+  review_churn_count, spend_usd, updated_at
+) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+ON CONFLICT(proposal_id) DO UPDATE SET
+  completed_at = excluded.completed_at,
+  rework_count = excluded.rework_count,
+  review_churn_count = excluded.review_churn_count,
+  spend_usd = excluded.spend_usd,
+  updated_at = excluded.updated_at`,
+		strings.TrimSpace(proposalID),
+		projectID,
+		strings.TrimSpace(issueID),
+		completedAtRaw,
+		workflowOutcome.reworkCount,
+		workflowOutcome.reviewChurnCount,
+		spendUSD,
+		observedAt,
+	); err != nil {
+		return fmt.Errorf("record backlog admission downstream outcome: %w", err)
+	}
+	return nil
+}
+
+type admissionWorkflowOutcome struct {
+	completedAt      time.Time
+	reworkCount      int
+	reviewChurnCount int
+}
+
+func (s *sqliteStore) admissionWorkflowOutcome(
+	ctx context.Context,
+	projectID string,
+	issueID string,
+	resolvedAtRaw string,
+	refresh admissionmodel.OutcomeRefresh,
+) (_ admissionWorkflowOutcome, resultErr error) {
+	rows, err := s.db.QueryContext(ctx, `
+SELECT phase_type, phase_name, status, started_at
+FROM workflow_phase_events
+WHERE project_id = ? AND issue_id = ? AND started_at >= ?
+ORDER BY started_at, id`, projectID, strings.TrimSpace(issueID), resolvedAtRaw)
+	if err != nil {
+		return admissionWorkflowOutcome{}, fmt.Errorf("read backlog admission downstream workflow: %w", err)
+	}
+	defer func() {
+		resultErr = errors.Join(resultErr, rows.Close())
+	}()
+	outcome := admissionWorkflowOutcome{}
+	for rows.Next() {
+		var phaseType string
+		var phaseName string
+		var status string
+		var startedAtRaw string
+		if err := rows.Scan(&phaseType, &phaseName, &status, &startedAtRaw); err != nil {
+			return admissionWorkflowOutcome{}, err
+		}
+		startedAt, err := parseTimestamp("started_at", startedAtRaw)
+		if err != nil {
+			return admissionWorkflowOutcome{}, err
+		}
+		if strings.EqualFold(strings.TrimSpace(phaseType), "review") {
+			outcome.reviewChurnCount++
+		}
+		if !strings.EqualFold(strings.TrimSpace(phaseType), "lane") ||
+			!strings.EqualFold(strings.TrimSpace(status), "entered") {
+			continue
+		}
+		if strings.EqualFold(strings.TrimSpace(phaseName), strings.TrimSpace(refresh.ReworkState)) {
+			outcome.reworkCount++
+		}
+		if outcome.completedAt.IsZero() && containsAdmissionState(refresh.TerminalStates, phaseName) {
+			outcome.completedAt = startedAt
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return admissionWorkflowOutcome{}, err
+	}
+	return outcome, nil
+}
+
+func (s *sqliteStore) AdmissionDownstreamOutcomes(ctx context.Context, projectID string) ([]admissionmodel.DownstreamOutcome, error) {
+	rows, err := s.db.QueryContext(ctx, `
+SELECT proposal_id, project_id, issue_id, COALESCE(completed_at, ''), rework_count,
+       review_churn_count, spend_usd, updated_at
+FROM backlog_admission_downstream_outcomes
+WHERE project_id = ?
+ORDER BY updated_at DESC, proposal_id`, strings.TrimSpace(projectID))
+	if err != nil {
+		return nil, fmt.Errorf("read backlog admission downstream outcomes: %w", err)
+	}
+	defer rows.Close()
+	outcomes := []admissionmodel.DownstreamOutcome{}
+	for rows.Next() {
+		var outcome admissionmodel.DownstreamOutcome
+		var completedAt string
+		var updatedAt string
+		if err := rows.Scan(
+			&outcome.ProposalID,
+			&outcome.ProjectID,
+			&outcome.IssueID,
+			&completedAt,
+			&outcome.ReworkCount,
+			&outcome.ReviewChurnCount,
+			&outcome.SpendUSD,
+			&updatedAt,
+		); err != nil {
+			return nil, err
+		}
+		if outcome.CompletedAt, err = parseAdmissionOptionalTimestamp("completed_at", completedAt); err != nil {
+			return nil, err
+		}
+		if outcome.UpdatedAt, err = parseTimestamp("updated_at", updatedAt); err != nil {
+			return nil, err
+		}
+		outcomes = append(outcomes, outcome)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return outcomes, nil
+}
+
+func containsAdmissionState(states []string, state string) bool {
+	for _, candidate := range states {
+		if strings.EqualFold(strings.TrimSpace(candidate), strings.TrimSpace(state)) {
+			return true
+		}
+	}
+	return false
 }
 
 func (s *sqliteStore) MarkAdmissionProposalCommented(ctx context.Context, id string, at time.Time) error {
@@ -400,6 +820,7 @@ func scanAdmissionProposal(scan admissionScan) (admissionmodel.Proposal, error) 
 	var expiresAt string
 	var resolvedAt string
 	var commentedAt string
+	var transitionAt string
 	if err := scan(
 		&proposal.ID,
 		&proposal.ProjectID,
@@ -417,6 +838,11 @@ func scanAdmissionProposal(scan admissionScan) (admissionmodel.Proposal, error) 
 		&expiresAt,
 		&resolvedAt,
 		&commentedAt,
+		&proposal.DecisionCommentID,
+		&proposal.DecisionActorLogin,
+		&proposal.DecisionActorKind,
+		&transitionAt,
+		&proposal.DecisionSeconds,
 	); err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			return admissionmodel.Proposal{}, ErrNotFound
@@ -438,6 +864,9 @@ func scanAdmissionProposal(scan admissionScan) (admissionmodel.Proposal, error) 
 		return admissionmodel.Proposal{}, err
 	}
 	if proposal.CommentedAt, err = parseAdmissionOptionalTimestamp("commented_at", commentedAt); err != nil {
+		return admissionmodel.Proposal{}, err
+	}
+	if proposal.TransitionAt, err = parseAdmissionOptionalTimestamp("transition_at", transitionAt); err != nil {
 		return admissionmodel.Proposal{}, err
 	}
 	return proposal, nil

--- a/internal/store/admission.go
+++ b/internal/store/admission.go
@@ -142,6 +142,53 @@ ORDER BY created_at DESC, id DESC`,
 	return scanAdmissionProposals(rows)
 }
 
+func (s *sqliteStore) AdmissionTargetTransitions(
+	ctx context.Context,
+	query admissionmodel.TargetTransitionQuery,
+) ([]admissionmodel.TargetTransition, error) {
+	notBefore, err := requiredTimestamp("not_before", query.NotBefore)
+	if err != nil {
+		return nil, err
+	}
+	rows, err := s.db.QueryContext(ctx, `
+SELECT id, started_at, metadata_json
+FROM workflow_phase_events
+WHERE project_id = ? AND issue_id = ? AND phase_type = 'lane' AND status = 'entered'
+  AND lower(phase_name) = lower(?) AND started_at >= ?
+ORDER BY started_at, id`,
+		strings.TrimSpace(query.ProjectID),
+		strings.TrimSpace(query.IssueID),
+		strings.TrimSpace(query.TargetState),
+		notBefore,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("read backlog admission target transitions: %w", err)
+	}
+	defer rows.Close()
+	transitions := []admissionmodel.TargetTransition{}
+	for rows.Next() {
+		var transition admissionmodel.TargetTransition
+		var enteredAt string
+		var metadataJSON string
+		if err := rows.Scan(&transition.EventID, &enteredAt, &metadataJSON); err != nil {
+			return nil, err
+		}
+		transition.EnteredAt, err = parseTimestamp("started_at", enteredAt)
+		if err != nil {
+			return nil, err
+		}
+		if metadata, ok := provenance.Parse(metadataJSON); ok && metadata.Provenance.Actor != nil {
+			transition.ActorLogin = metadata.Provenance.Actor.Login
+			transition.ActorKind = metadata.Provenance.Actor.Kind
+		}
+		transitions = append(transitions, transition)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return transitions, nil
+}
+
 func (s *sqliteStore) CountOpenAdmissionProposals(ctx context.Context, projectID string) (int, error) {
 	var count int
 	if err := s.db.QueryRowContext(ctx, `
@@ -336,18 +383,35 @@ func attributeAdmissionTransition(
 	}
 	var eventID int64
 	var metadataJSON string
-	err = tx.QueryRowContext(ctx, `
+	if decision.TransitionEventID > 0 {
+		err = tx.QueryRowContext(ctx, `
+SELECT id, metadata_json
+FROM workflow_phase_events
+WHERE id = ? AND project_id = ? AND issue_id = ? AND phase_type = 'lane'
+  AND status = 'entered' AND lower(phase_name) = lower(?)
+LIMIT 1`,
+			decision.TransitionEventID,
+			strings.TrimSpace(proposal.ProjectID),
+			strings.TrimSpace(proposal.IssueID),
+			strings.TrimSpace(proposal.TargetState),
+		).Scan(&eventID, &metadataJSON)
+		if err != nil {
+			return fmt.Errorf("find correlated backlog admission transition: %w", err)
+		}
+	} else {
+		err = tx.QueryRowContext(ctx, `
 SELECT id, metadata_json
 FROM workflow_phase_events
 WHERE project_id = ? AND issue_id = ? AND phase_type = 'lane' AND status = 'entered'
   AND lower(phase_name) = lower(?) AND started_at = ?
 ORDER BY id DESC
 LIMIT 1`,
-		strings.TrimSpace(proposal.ProjectID),
-		strings.TrimSpace(proposal.IssueID),
-		strings.TrimSpace(proposal.TargetState),
-		transitionAt,
-	).Scan(&eventID, &metadataJSON)
+			strings.TrimSpace(proposal.ProjectID),
+			strings.TrimSpace(proposal.IssueID),
+			strings.TrimSpace(proposal.TargetState),
+			transitionAt,
+		).Scan(&eventID, &metadataJSON)
+	}
 	actor := provenance.Actor{
 		Login: strings.TrimSpace(decision.ActorLogin),
 		Kind:  strings.TrimSpace(decision.ActorKind),

--- a/internal/store/admission_test.go
+++ b/internal/store/admission_test.go
@@ -138,11 +138,12 @@ func TestAdmissionAcceptanceAttributionAndDownstreamOutcomes(t *testing.T) {
 	createdAt := time.Date(2026, 7, 29, 12, 0, 0, 0, time.UTC)
 	decisionAt := createdAt.Add(time.Minute)
 	transitionAt := createdAt.Add(2 * time.Minute)
+	recordedTransitionAt := transitionAt.Add(-30 * time.Second)
 	proposal := admissionTestProposal("proposal-accepted", "fingerprint-accepted", createdAt)
 	if created, err := backend.CreateAdmissionProposal(ctx, proposal); err != nil || !created {
 		t.Fatalf("CreateAdmissionProposal() = %t, %v", created, err)
 	}
-	if _, err := backend.RecordWorkflowPhaseEvent(ctx, WorkflowPhaseEvent{
+	transitionEventID, err := backend.RecordWorkflowPhaseEvent(ctx, WorkflowPhaseEvent{
 		ProjectID:    "detent",
 		IssueID:      proposal.IssueID,
 		Identifier:   proposal.IssueIdentifier,
@@ -151,19 +152,21 @@ func TestAdmissionAcceptanceAttributionAndDownstreamOutcomes(t *testing.T) {
 		PhaseName:    proposal.TargetState,
 		Reason:       "tracker_state_observed",
 		Status:       "entered",
-		StartedAt:    transitionAt,
+		StartedAt:    recordedTransitionAt,
 		MetadataJSON: provenance.Apply("{}", provenance.Attribution{Origin: provenance.OriginHuman}, &provenance.Admission{Attributed: false}),
-	}); err != nil {
+	})
+	if err != nil {
 		t.Fatalf("RecordWorkflowPhaseEvent(transition) error = %v", err)
 	}
 	if err := backend.ResolveAdmissionProposal(ctx, admissionmodel.Decision{
-		ProposalID:   proposal.ID,
-		Outcome:      admissionmodel.ProposalAccepted,
-		DecidedAt:    decisionAt,
-		CommentID:    "decision-1",
-		ActorLogin:   "ada",
-		ActorKind:    "User",
-		TransitionAt: transitionAt,
+		ProposalID:        proposal.ID,
+		Outcome:           admissionmodel.ProposalAccepted,
+		DecidedAt:         decisionAt,
+		CommentID:         "decision-1",
+		ActorLogin:        "ada",
+		ActorKind:         "User",
+		TransitionAt:      transitionAt,
+		TransitionEventID: transitionEventID,
 	}); err != nil {
 		t.Fatalf("ResolveAdmissionProposal() error = %v", err)
 	}
@@ -181,6 +184,9 @@ func TestAdmissionAcceptanceAttributionAndDownstreamOutcomes(t *testing.T) {
 	timeline, err := backend.IssueWorkflowTimeline(ctx, IssueIdentity{IssueID: proposal.IssueID})
 	if err != nil {
 		t.Fatalf("IssueWorkflowTimeline() error = %v", err)
+	}
+	if len(timeline.Events) != 1 || !timeline.Events[0].StartedAt.Equal(recordedTransitionAt) {
+		t.Fatalf("workflow events = %#v, want one recorded transition", timeline.Events)
 	}
 	metadata, ok := provenance.Parse(timeline.Events[0].MetadataJSON)
 	if !ok || timeline.Events[0].Reason != "admission_proposal_accepted" ||

--- a/internal/store/admission_test.go
+++ b/internal/store/admission_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	admissionmodel "github.com/digitaldrywood/detent/internal/admission/model"
+	"github.com/digitaldrywood/detent/internal/provenance"
 )
 
 func TestAdmissionProposalLifecycleAndIdempotency(t *testing.T) {
@@ -126,6 +127,153 @@ func TestAdmissionProposalExpiryAndRunLedger(t *testing.T) {
 	runs, err := backend.RecentAdmissionRuns(ctx, "detent", 3)
 	if err != nil || len(runs) != 1 {
 		t.Fatalf("RecentAdmissionRuns() = %#v, %v", runs, err)
+	}
+}
+
+func TestAdmissionAcceptanceAttributionAndDownstreamOutcomes(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	backend := openAdmissionTestStore(t, ctx)
+	createdAt := time.Date(2026, 7, 29, 12, 0, 0, 0, time.UTC)
+	decisionAt := createdAt.Add(time.Minute)
+	transitionAt := createdAt.Add(2 * time.Minute)
+	proposal := admissionTestProposal("proposal-accepted", "fingerprint-accepted", createdAt)
+	if created, err := backend.CreateAdmissionProposal(ctx, proposal); err != nil || !created {
+		t.Fatalf("CreateAdmissionProposal() = %t, %v", created, err)
+	}
+	if _, err := backend.RecordWorkflowPhaseEvent(ctx, WorkflowPhaseEvent{
+		ProjectID:    "detent",
+		IssueID:      proposal.IssueID,
+		Identifier:   proposal.IssueIdentifier,
+		IssueURL:     proposal.IssueURL,
+		PhaseType:    WorkflowPhaseTypeLane,
+		PhaseName:    proposal.TargetState,
+		Reason:       "tracker_state_observed",
+		Status:       "entered",
+		StartedAt:    transitionAt,
+		MetadataJSON: provenance.Apply("{}", provenance.Attribution{Origin: provenance.OriginHuman}, &provenance.Admission{Attributed: false}),
+	}); err != nil {
+		t.Fatalf("RecordWorkflowPhaseEvent(transition) error = %v", err)
+	}
+	if err := backend.ResolveAdmissionProposal(ctx, admissionmodel.Decision{
+		ProposalID:   proposal.ID,
+		Outcome:      admissionmodel.ProposalAccepted,
+		DecidedAt:    decisionAt,
+		CommentID:    "decision-1",
+		ActorLogin:   "ada",
+		ActorKind:    "User",
+		TransitionAt: transitionAt,
+	}); err != nil {
+		t.Fatalf("ResolveAdmissionProposal() error = %v", err)
+	}
+	history, err := backend.AdmissionProposalHistory(ctx, proposal.ProjectID, proposal.IssueID)
+	if err != nil || len(history) != 1 {
+		t.Fatalf("AdmissionProposalHistory() = %#v, %v", history, err)
+	}
+	if got := history[0]; got.Status != admissionmodel.ProposalAccepted ||
+		got.DecisionSeconds != 60 ||
+		got.DecisionCommentID != "decision-1" ||
+		got.DecisionActorLogin != "ada" ||
+		!got.TransitionAt.Equal(transitionAt) {
+		t.Fatalf("accepted proposal = %#v", got)
+	}
+	timeline, err := backend.IssueWorkflowTimeline(ctx, IssueIdentity{IssueID: proposal.IssueID})
+	if err != nil {
+		t.Fatalf("IssueWorkflowTimeline() error = %v", err)
+	}
+	metadata, ok := provenance.Parse(timeline.Events[0].MetadataJSON)
+	if !ok || timeline.Events[0].Reason != "admission_proposal_accepted" ||
+		metadata.Provenance.Origin != provenance.OriginAdmission ||
+		metadata.Admission == nil ||
+		!metadata.Admission.Attributed ||
+		metadata.Admission.ProposalID != proposal.ID {
+		t.Fatalf("attributed workflow event = %#v, metadata = %#v", timeline.Events[0], metadata)
+	}
+
+	reworkAt := transitionAt.Add(time.Minute)
+	reviewAt := reworkAt.Add(time.Minute)
+	completedAt := reviewAt.Add(time.Minute)
+	for _, event := range []WorkflowPhaseEvent{
+		{
+			ProjectID: "detent", IssueID: proposal.IssueID, PhaseType: WorkflowPhaseTypeLane,
+			PhaseName: "Rework", Reason: "review_feedback", Status: "entered", StartedAt: reworkAt,
+		},
+		{
+			ProjectID: "detent", IssueID: proposal.IssueID, PhaseType: WorkflowPhaseTypeReview,
+			PhaseName: "automated_review", Reason: "p1_findings", Status: "completed", StartedAt: reviewAt, FinishedAt: reviewAt,
+		},
+		{
+			ProjectID: "detent", IssueID: proposal.IssueID, PhaseType: WorkflowPhaseTypeLane,
+			PhaseName: "Done", Reason: "merged", Status: "entered", StartedAt: completedAt,
+		},
+	} {
+		if _, err := backend.RecordWorkflowPhaseEvent(ctx, event); err != nil {
+			t.Fatalf("RecordWorkflowPhaseEvent(%s) error = %v", event.PhaseName, err)
+		}
+	}
+	if _, err := backend.RecordUsageEvent(ctx, UsageEvent{
+		ProjectID:  "detent",
+		IssueID:    proposal.IssueID,
+		CostUSD:    1.25,
+		StartedAt:  reworkAt,
+		FinishedAt: reviewAt,
+		Outcome:    "completed",
+	}); err != nil {
+		t.Fatalf("RecordUsageEvent() error = %v", err)
+	}
+	observedAt := completedAt.Add(time.Minute)
+	if err := backend.RefreshAdmissionOutcomes(ctx, admissionmodel.OutcomeRefresh{
+		ProjectID:      "detent",
+		TerminalStates: []string{"Done"},
+		ReworkState:    "Rework",
+		ObservedAt:     observedAt,
+	}); err != nil {
+		t.Fatalf("RefreshAdmissionOutcomes() error = %v", err)
+	}
+	outcomes, err := backend.AdmissionDownstreamOutcomes(ctx, "detent")
+	if err != nil || len(outcomes) != 1 {
+		t.Fatalf("AdmissionDownstreamOutcomes() = %#v, %v", outcomes, err)
+	}
+	if got := outcomes[0]; !got.CompletedAt.Equal(completedAt) ||
+		got.ReworkCount != 1 ||
+		got.ReviewChurnCount != 1 ||
+		got.SpendUSD != 1.25 ||
+		!got.UpdatedAt.Equal(observedAt) {
+		t.Fatalf("downstream outcome = %#v", got)
+	}
+}
+
+func TestAdmissionRejectionIsDistinctFromAcceptance(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	backend := openAdmissionTestStore(t, ctx)
+	createdAt := time.Date(2026, 7, 29, 12, 0, 0, 0, time.UTC)
+	proposal := admissionTestProposal("proposal-rejected", "fingerprint-rejected", createdAt)
+	if created, err := backend.CreateAdmissionProposal(ctx, proposal); err != nil || !created {
+		t.Fatalf("CreateAdmissionProposal() = %t, %v", created, err)
+	}
+	if err := backend.ResolveAdmissionProposal(ctx, admissionmodel.Decision{
+		ProposalID: proposal.ID,
+		Outcome:    admissionmodel.ProposalRejected,
+		DecidedAt:  createdAt.Add(3 * time.Minute),
+		CommentID:  "decision-rejected",
+		ActorLogin: "grace",
+		ActorKind:  "User",
+	}); err != nil {
+		t.Fatalf("ResolveAdmissionProposal() error = %v", err)
+	}
+	history, err := backend.AdmissionProposalHistory(ctx, proposal.ProjectID, proposal.IssueID)
+	if err != nil || len(history) != 1 ||
+		history[0].Status != admissionmodel.ProposalRejected ||
+		history[0].DecisionSeconds != 180 ||
+		!history[0].TransitionAt.IsZero() {
+		t.Fatalf("AdmissionProposalHistory() = %#v, %v", history, err)
+	}
+	outcomes, err := backend.AdmissionDownstreamOutcomes(ctx, proposal.ProjectID)
+	if err != nil || len(outcomes) != 0 {
+		t.Fatalf("AdmissionDownstreamOutcomes() = %#v, %v, want none", outcomes, err)
 	}
 }
 

--- a/internal/store/migrations/00025_add_admission_outcomes.sql
+++ b/internal/store/migrations/00025_add_admission_outcomes.sql
@@ -1,0 +1,48 @@
+-- +goose Up
+ALTER TABLE backlog_admission_proposals
+ADD COLUMN decision_comment_id TEXT;
+
+ALTER TABLE backlog_admission_proposals
+ADD COLUMN decision_actor_login TEXT;
+
+ALTER TABLE backlog_admission_proposals
+ADD COLUMN decision_actor_kind TEXT;
+
+ALTER TABLE backlog_admission_proposals
+ADD COLUMN transition_at TEXT;
+
+ALTER TABLE backlog_admission_proposals
+ADD COLUMN decision_seconds INTEGER;
+
+CREATE TABLE backlog_admission_downstream_outcomes (
+  proposal_id TEXT PRIMARY KEY,
+  project_id TEXT NOT NULL,
+  issue_id TEXT NOT NULL,
+  completed_at TEXT,
+  rework_count INTEGER NOT NULL DEFAULT 0,
+  review_churn_count INTEGER NOT NULL DEFAULT 0,
+  spend_usd REAL NOT NULL DEFAULT 0.0,
+  updated_at TEXT NOT NULL,
+  FOREIGN KEY (proposal_id) REFERENCES backlog_admission_proposals(id) ON DELETE CASCADE
+);
+
+CREATE INDEX backlog_admission_downstream_project_idx
+ON backlog_admission_downstream_outcomes(project_id, updated_at DESC, proposal_id);
+
+-- +goose Down
+DROP TABLE IF EXISTS backlog_admission_downstream_outcomes;
+
+ALTER TABLE backlog_admission_proposals
+DROP COLUMN decision_seconds;
+
+ALTER TABLE backlog_admission_proposals
+DROP COLUMN transition_at;
+
+ALTER TABLE backlog_admission_proposals
+DROP COLUMN decision_actor_kind;
+
+ALTER TABLE backlog_admission_proposals
+DROP COLUMN decision_actor_login;
+
+ALTER TABLE backlog_admission_proposals
+DROP COLUMN decision_comment_id;

--- a/internal/store/sqlc/models.go
+++ b/internal/store/sqlc/models.go
@@ -51,23 +51,39 @@ type AuthSession struct {
 	CreatedAt time.Time `json:"created_at"`
 }
 
+type BacklogAdmissionDownstreamOutcome struct {
+	ProposalID       string         `json:"proposal_id"`
+	ProjectID        string         `json:"project_id"`
+	IssueID          string         `json:"issue_id"`
+	CompletedAt      sql.NullString `json:"completed_at"`
+	ReworkCount      int64          `json:"rework_count"`
+	ReviewChurnCount int64          `json:"review_churn_count"`
+	SpendUsd         float64        `json:"spend_usd"`
+	UpdatedAt        string         `json:"updated_at"`
+}
+
 type BacklogAdmissionProposal struct {
-	ID              string         `json:"id"`
-	ProjectID       string         `json:"project_id"`
-	IssueID         string         `json:"issue_id"`
-	IssueIdentifier string         `json:"issue_identifier"`
-	IssueURL        string         `json:"issue_url"`
-	TargetState     string         `json:"target_state"`
-	Fingerprint     string         `json:"fingerprint"`
-	CriteriaSection string         `json:"criteria_section"`
-	CriteriaText    string         `json:"criteria_text"`
-	FindingsJson    string         `json:"findings_json"`
-	Confidence      float64        `json:"confidence"`
-	Status          string         `json:"status"`
-	CreatedAt       string         `json:"created_at"`
-	ExpiresAt       string         `json:"expires_at"`
-	ResolvedAt      sql.NullString `json:"resolved_at"`
-	CommentedAt     sql.NullString `json:"commented_at"`
+	ID                 string         `json:"id"`
+	ProjectID          string         `json:"project_id"`
+	IssueID            string         `json:"issue_id"`
+	IssueIdentifier    string         `json:"issue_identifier"`
+	IssueURL           string         `json:"issue_url"`
+	TargetState        string         `json:"target_state"`
+	Fingerprint        string         `json:"fingerprint"`
+	CriteriaSection    string         `json:"criteria_section"`
+	CriteriaText       string         `json:"criteria_text"`
+	FindingsJson       string         `json:"findings_json"`
+	Confidence         float64        `json:"confidence"`
+	Status             string         `json:"status"`
+	CreatedAt          string         `json:"created_at"`
+	ExpiresAt          string         `json:"expires_at"`
+	ResolvedAt         sql.NullString `json:"resolved_at"`
+	CommentedAt        sql.NullString `json:"commented_at"`
+	DecisionCommentID  sql.NullString `json:"decision_comment_id"`
+	DecisionActorLogin sql.NullString `json:"decision_actor_login"`
+	DecisionActorKind  sql.NullString `json:"decision_actor_kind"`
+	TransitionAt       sql.NullString `json:"transition_at"`
+	DecisionSeconds    sql.NullInt64  `json:"decision_seconds"`
 }
 
 type BacklogAdmissionRun struct {

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -13,6 +13,7 @@ import (
 	"github.com/digitaldrywood/detent/internal/retro"
 	routinemodel "github.com/digitaldrywood/detent/internal/routine/model"
 	"github.com/digitaldrywood/detent/internal/store/sqlc"
+	"github.com/digitaldrywood/detent/internal/workflowmetrics"
 )
 
 type Backend string
@@ -195,7 +196,10 @@ type AdmissionStore interface {
 	CountOpenAdmissionProposals(context.Context, string) (int, error)
 	ExpireAdmissionProposals(context.Context, string, time.Time) (int, error)
 	TransitionAdmissionProposal(context.Context, string, admissionmodel.ProposalStatus, admissionmodel.ProposalStatus, time.Time) error
+	ResolveAdmissionProposal(context.Context, admissionmodel.Decision) error
 	MarkAdmissionProposalCommented(context.Context, string, time.Time) error
+	RefreshAdmissionOutcomes(context.Context, admissionmodel.OutcomeRefresh) error
+	AdmissionDownstreamOutcomes(context.Context, string) ([]admissionmodel.DownstreamOutcome, error)
 	RecordAdmissionRun(context.Context, admissionmodel.RunRecord) error
 	LatestAdmissionRun(context.Context, string) (admissionmodel.RunRecord, bool, error)
 	RecentAdmissionRuns(context.Context, string, int) ([]admissionmodel.RunRecord, error)
@@ -240,18 +244,18 @@ type RuntimeWorkflowPhaseEventEvidence struct {
 	NewestFinishedAt *time.Time
 }
 
-type WorkflowPhaseType string
+type WorkflowPhaseType = workflowmetrics.PhaseType
 
 const (
-	WorkflowPhaseTypeLane           WorkflowPhaseType = "lane"
-	WorkflowPhaseTypeAgentSession   WorkflowPhaseType = "agent_session"
-	WorkflowPhaseTypeLocalCheck     WorkflowPhaseType = "local_check"
-	WorkflowPhaseTypeCI             WorkflowPhaseType = "ci"
-	WorkflowPhaseTypeGitHubBackoff  WorkflowPhaseType = "github_backoff"
-	WorkflowPhaseTypeReview         WorkflowPhaseType = "review"
-	WorkflowPhaseTypeMergeQueue     WorkflowPhaseType = "merge_queue"
-	WorkflowPhaseTypeRecovery       WorkflowPhaseType = "recovery"
-	WorkflowPhaseTypeOperatorAction WorkflowPhaseType = "operator_action"
+	WorkflowPhaseTypeLane           = workflowmetrics.PhaseTypeLane
+	WorkflowPhaseTypeAgentSession   = workflowmetrics.PhaseTypeAgentSession
+	WorkflowPhaseTypeLocalCheck     = workflowmetrics.PhaseTypeLocalCheck
+	WorkflowPhaseTypeCI             = workflowmetrics.PhaseTypeCI
+	WorkflowPhaseTypeGitHubBackoff  = workflowmetrics.PhaseTypeGitHubBackoff
+	WorkflowPhaseTypeReview         = workflowmetrics.PhaseTypeReview
+	WorkflowPhaseTypeMergeQueue     = workflowmetrics.PhaseTypeMergeQueue
+	WorkflowPhaseTypeRecovery       = workflowmetrics.PhaseTypeRecovery
+	WorkflowPhaseTypeOperatorAction = workflowmetrics.PhaseTypeOperatorAction
 )
 
 type WorkAttemptStatus string
@@ -481,35 +485,7 @@ type UsageEvent struct {
 	Outcome               string
 }
 
-type WorkflowPhaseEvent struct {
-	ID                    int64
-	ProjectID             string
-	RunID                 int64
-	SessionID             int64
-	IssueID               string
-	Identifier            string
-	IssueURL              string
-	PRNumber              *int64
-	PhaseType             WorkflowPhaseType
-	PhaseName             string
-	PreviousPhaseName     string
-	Reason                string
-	Status                string
-	StartedAt             time.Time
-	FinishedAt            time.Time
-	DurationSeconds       int64
-	CommandName           string
-	ExitCode              *int64
-	Turns                 int64
-	InputTokens           int64
-	CachedInputTokens     int64
-	OutputTokens          int64
-	ReasoningOutputTokens int64
-	TotalTokens           int64
-	ModelContextWindow    *int64
-	EndpointFamily        string
-	MetadataJSON          string
-}
+type WorkflowPhaseEvent = workflowmetrics.PhaseEvent
 
 type ValidatorVerdictKey struct {
 	ProjectID string

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -197,6 +197,7 @@ type AdmissionStore interface {
 	ExpireAdmissionProposals(context.Context, string, time.Time) (int, error)
 	TransitionAdmissionProposal(context.Context, string, admissionmodel.ProposalStatus, admissionmodel.ProposalStatus, time.Time) error
 	ResolveAdmissionProposal(context.Context, admissionmodel.Decision) error
+	AdmissionTargetTransitions(context.Context, admissionmodel.TargetTransitionQuery) ([]admissionmodel.TargetTransition, error)
 	MarkAdmissionProposalCommented(context.Context, string, time.Time) error
 	RefreshAdmissionOutcomes(context.Context, admissionmodel.OutcomeRefresh) error
 	AdmissionDownstreamOutcomes(context.Context, string) ([]admissionmodel.DownstreamOutcome, error)

--- a/internal/telemetry/snapshot.go
+++ b/internal/telemetry/snapshot.go
@@ -346,6 +346,9 @@ type Issue struct {
 	PriorityName          string                 `json:"priority_name,omitempty"`
 	UnblockerCount        int                    `json:"unblocker_count,omitempty"`
 	State                 string                 `json:"state,omitempty"`
+	Origin                string                 `json:"origin,omitempty"`
+	OriginActor           string                 `json:"origin_actor,omitempty"`
+	OriginActorKind       string                 `json:"origin_actor_kind,omitempty"`
 	Labels                []string               `json:"labels,omitempty"`
 	Assignees             []string               `json:"assignees,omitempty"`
 	Comments              []IssueComment         `json:"comments,omitempty"`
@@ -373,6 +376,7 @@ type IssueComment struct {
 	Body              string     `json:"body,omitempty"`
 	URL               string     `json:"url,omitempty"`
 	AuthorLogin       string     `json:"author_login,omitempty"`
+	AuthorKind        string     `json:"author_kind,omitempty"`
 	AuthorDisplayName string     `json:"author_display_name,omitempty"`
 	CreatedAt         *time.Time `json:"created_at,omitempty"`
 	UpdatedAt         *time.Time `json:"updated_at,omitempty"`

--- a/internal/web/kanban.go
+++ b/internal/web/kanban.go
@@ -19,9 +19,10 @@ import (
 	kanbanstate "github.com/digitaldrywood/detent/internal/kanban"
 	"github.com/digitaldrywood/detent/internal/orchestrator"
 	"github.com/digitaldrywood/detent/internal/project"
-	"github.com/digitaldrywood/detent/internal/store"
+	"github.com/digitaldrywood/detent/internal/provenance"
 	"github.com/digitaldrywood/detent/internal/telemetry"
 	"github.com/digitaldrywood/detent/internal/web/templates"
+	"github.com/digitaldrywood/detent/internal/workflowmetrics"
 )
 
 type kanbanActionTarget struct {
@@ -195,14 +196,32 @@ func (s *Server) apiKanbanMove(c echo.Context) error {
 			if err := setter.SetIssueField(c.Request().Context(), req.issueID, target.kanban.IssueStateFieldID, kanbanstate.MappedState(target.workflow, req.targetState)); err != nil {
 				return err
 			}
-			s.recordKanbanLaneTransition(c.Request().Context(), req.projectID, snapshotIssue, currentState, req.targetState, "kanban_move_field")
+			s.recordKanbanLaneTransition(
+				c.Request().Context(),
+				req.projectID,
+				snapshotIssue,
+				currentState,
+				req.targetState,
+				"kanban_move_field",
+				target.connector,
+				kanbanAdmissionTargetState(target.workflow),
+			)
 			s.kanbanMutations.NoteCardState(target.key, req.projectID, snapshotIssue, snapshotState, req.targetState, dataSeqAtWrite)
 			return nil
 		}
 		if err := target.connector.UpdateIssueState(c.Request().Context(), req.issueID, req.targetState); err != nil {
 			return err
 		}
-		s.recordKanbanLaneTransition(c.Request().Context(), req.projectID, snapshotIssue, currentState, req.targetState, "kanban_move")
+		s.recordKanbanLaneTransition(
+			c.Request().Context(),
+			req.projectID,
+			snapshotIssue,
+			currentState,
+			req.targetState,
+			"kanban_move",
+			target.connector,
+			kanbanAdmissionTargetState(target.workflow),
+		)
 		s.kanbanMutations.NoteCardState(target.key, req.projectID, snapshotIssue, snapshotState, req.targetState, dataSeqAtWrite)
 		return nil
 	})
@@ -1008,6 +1027,7 @@ func telemetryCommentsFromConnector(comments []connector.IssueComment) []telemet
 			Body:              comment.Body,
 			URL:               comment.URL,
 			AuthorLogin:       comment.AuthorLogin,
+			AuthorKind:        comment.AuthorKind,
 			AuthorDisplayName: comment.AuthorDisplayName,
 			CreatedAt:         cloneCommentTime(comment.CreatedAt),
 			UpdatedAt:         cloneCommentTime(comment.UpdatedAt),
@@ -1386,6 +1406,8 @@ func (s *Server) recordKanbanLaneTransition(
 	currentState string,
 	targetState string,
 	reason string,
+	tracker connector.Connector,
+	admissionTargetState string,
 ) {
 	if s.store == nil {
 		return
@@ -1395,7 +1417,6 @@ func (s *Server) recordKanbanLaneTransition(
 	if targetState == "" || kanbanstate.NormalizeState(currentState) == kanbanstate.NormalizeState(targetState) {
 		return
 	}
-	now := time.Now()
 	projectID = strings.TrimSpace(projectID)
 	if projectID == "" {
 		projectID = strings.TrimSpace(issue.ProjectID)
@@ -1403,65 +1424,62 @@ func (s *Server) recordKanbanLaneTransition(
 	if projectID == "" {
 		projectID = "default"
 	}
-	base := store.WorkflowPhaseEvent{
-		ProjectID:      projectID,
-		IssueID:        issue.ID,
+	now := time.Now().UTC()
+	connectorIssue := connector.Issue{
+		ID:             issue.ID,
 		Identifier:     issue.Identifier,
-		IssueURL:       issue.URL,
-		PRNumber:       kanbanWorkflowPRNumber(issue),
-		PhaseType:      store.WorkflowPhaseTypeLane,
-		Reason:         strings.TrimSpace(reason),
-		StartedAt:      now,
-		EndpointFamily: "tracker",
-		MetadataJSON:   "{}",
+		URL:            issue.URL,
+		State:          currentState,
+		CreatedAt:      issue.CreatedAt,
+		UpdatedAt:      issue.UpdatedAt,
+		StageUpdatedAt: issue.StageUpdatedAt,
 	}
-	if base.Reason == "" {
-		base.Reason = "kanban_move"
+	if issue.PullRequest != nil && issue.PullRequest.Number > 0 {
+		number := issue.PullRequest.Number
+		connectorIssue.PRNumber = &number
 	}
-	if currentState != "" {
-		startedAt := kanbanLaneStartedAt(issue, now)
-		exitEvent := base
-		exitEvent.PhaseName = currentState
-		exitEvent.Status = "exited"
-		exitEvent.StartedAt = startedAt
-		exitEvent.FinishedAt = now
-		exitEvent.DurationSeconds = kanbanWorkflowDurationSeconds(startedAt, now)
-		if _, err := s.store.RecordWorkflowPhaseEvent(ctx, exitEvent); err != nil && s.logger != nil {
-			s.logger.WarnContext(ctx, "record kanban lane exit metric failed", "project", projectID, "issue_id", issue.ID, "identifier", issue.Identifier, "from_state", currentState, "target_state", targetState, "error", err)
+	actor := provenance.Actor{}
+	if reader, ok := tracker.(connector.IssueStateTransitionReader); ok {
+		observed := connectorIssue
+		observed.State = targetState
+		transition, found, err := reader.IssueStateTransition(ctx, observed)
+		if err != nil {
+			if s.logger != nil {
+				s.logger.WarnContext(ctx, "read kanban lane transition actor failed", "project", projectID, "issue_id", issue.ID, "identifier", issue.Identifier, "target_state", targetState, "error", err)
+			}
+		} else if found {
+			if !transition.EnteredAt.IsZero() {
+				now = transition.EnteredAt.UTC()
+			}
+			actor = provenance.Actor{Login: transition.Actor.Login, Kind: transition.Actor.Kind}
 		}
 	}
-	enterEvent := base
-	enterEvent.PhaseName = targetState
-	enterEvent.PreviousPhaseName = currentState
-	enterEvent.Status = "entered"
-	if _, err := s.store.RecordWorkflowPhaseEvent(ctx, enterEvent); err != nil && s.logger != nil {
-		s.logger.WarnContext(ctx, "record kanban lane enter metric failed", "project", projectID, "issue_id", issue.ID, "identifier", issue.Identifier, "from_state", currentState, "target_state", targetState, "error", err)
+	attribution := provenance.Attribution{Origin: provenance.OriginFromActor(actor)}
+	if actor.Login != "" || actor.Kind != "" {
+		attribution.Actor = &actor
+	}
+	var admission *provenance.Admission
+	if strings.EqualFold(strings.TrimSpace(targetState), strings.TrimSpace(admissionTargetState)) &&
+		strings.TrimSpace(admissionTargetState) != "" {
+		admission = &provenance.Admission{Attributed: false}
+	}
+	if err := workflowmetrics.RecordLaneTransition(ctx, s.store, workflowmetrics.LaneTransition{
+		ProjectID:    projectID,
+		Issue:        connectorIssue,
+		TargetState:  targetState,
+		At:           now,
+		Reason:       strings.TrimSpace(reason),
+		MetadataJSON: provenance.Apply("{}", attribution, admission),
+	}); err != nil && s.logger != nil {
+		s.logger.WarnContext(ctx, "record kanban lane transition metric failed", "project", projectID, "issue_id", issue.ID, "identifier", issue.Identifier, "from_state", currentState, "target_state", targetState, "error", err)
 	}
 }
 
-func kanbanLaneStartedAt(issue telemetry.Issue, fallback time.Time) time.Time {
-	for _, candidate := range []*time.Time{issue.StageUpdatedAt, issue.UpdatedAt, issue.CreatedAt} {
-		if candidate == nil || candidate.IsZero() || candidate.After(fallback) {
-			continue
-		}
-		return *candidate
+func kanbanAdmissionTargetState(cfg workflowconfig.Config) string {
+	if !cfg.BacklogAdmission.Enabled {
+		return ""
 	}
-	return fallback
-}
-
-func kanbanWorkflowDurationSeconds(startedAt time.Time, finishedAt time.Time) int64 {
-	if startedAt.IsZero() || finishedAt.IsZero() || finishedAt.Before(startedAt) {
-		return 0
-	}
-	return int64(finishedAt.Sub(startedAt) / time.Second)
-}
-
-func kanbanWorkflowPRNumber(issue telemetry.Issue) *int64 {
-	if issue.PullRequest == nil || issue.PullRequest.Number <= 0 {
-		return nil
-	}
-	value := int64(issue.PullRequest.Number)
-	return &value
+	return cfg.BacklogAdmission.TargetState
 }
 
 func (s *Server) kanbanCommentTargetKnown(req kanbanCommentRequest) bool {
@@ -1560,6 +1578,7 @@ func telemetryIssueComments(comments []connector.IssueComment) []telemetry.Issue
 			Body:              comment.Body,
 			URL:               comment.URL,
 			AuthorLogin:       comment.AuthorLogin,
+			AuthorKind:        comment.AuthorKind,
 			AuthorDisplayName: comment.AuthorDisplayName,
 			CreatedAt:         kanbanstate.CloneTimePointer(comment.CreatedAt),
 			UpdatedAt:         kanbanstate.CloneTimePointer(comment.UpdatedAt),

--- a/internal/web/server_test.go
+++ b/internal/web/server_test.go
@@ -39,6 +39,7 @@ import (
 	"github.com/digitaldrywood/detent/internal/hub"
 	"github.com/digitaldrywood/detent/internal/orchestrator"
 	"github.com/digitaldrywood/detent/internal/project"
+	"github.com/digitaldrywood/detent/internal/provenance"
 	"github.com/digitaldrywood/detent/internal/selector"
 	"github.com/digitaldrywood/detent/internal/store"
 	"github.com/digitaldrywood/detent/internal/store/sqlc"
@@ -2449,6 +2450,8 @@ func TestKanbanMoveSuccessResponseRefreshesProjectBoard(t *testing.T) {
 	t.Parallel()
 
 	deps := testDeps(t)
+	metrics := &workflowPhaseEventStoreProbe{}
+	deps.Store = metrics
 	actionConnector := &kanbanActionConnector{name: "github"}
 	mustSetKanbanProject(t, deps.Registry, "detent", workflowconfig.Kanban{
 		Mode: workflowconfig.KanbanModeIntegration,
@@ -2512,6 +2515,14 @@ func TestKanbanMoveSuccessResponseRefreshesProjectBoard(t *testing.T) {
 	}
 	if got, want := actionConnector.stateUpdates(), []kanbanStateUpdate{{issueID: "I_kw559", state: "Todo"}}; !equalStateUpdates(got, want) {
 		t.Fatalf("state updates = %#v, want %#v", got, want)
+	}
+	events := metrics.workflowPhaseEvents()
+	if len(events) != 2 || events[0].Status != "exited" || events[1].Status != "entered" {
+		t.Fatalf("workflow phase events = %#v, want lane exit and entry", events)
+	}
+	metadata, ok := provenance.Parse(events[1].MetadataJSON)
+	if !ok || metadata.Provenance.Origin != provenance.OriginUnknown {
+		t.Fatalf("lane entry metadata = %#v, want unknown origin without tracker actor", metadata)
 	}
 }
 
@@ -11407,6 +11418,13 @@ func (p *workflowPhaseEventStoreProbe) workflowPhaseEventCount() int {
 	defer p.mu.Unlock()
 
 	return len(p.events)
+}
+
+func (p *workflowPhaseEventStoreProbe) workflowPhaseEvents() []store.WorkflowPhaseEvent {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	return append([]store.WorkflowPhaseEvent(nil), p.events...)
 }
 
 func (storeProbe) WorkflowMetricsReport(context.Context, store.WorkflowMetricsQuery) (store.WorkflowMetricsReport, error) {

--- a/internal/web/templates/board.templ
+++ b/internal/web/templates/board.templ
@@ -486,6 +486,12 @@ templ boardCardView2(card boardCardView) {
 		if card.RuntimeBadge {
 			@boardRuntimeBadge(card)
 		}
+		if card.OriginDetail != "" {
+			<div class="flex items-center gap-1.5 text-2xs text-info" data-board-card-origin data-board-card-expanded>
+				@primitives.StatusDot(primitives.KindInfo, false)
+				<span class="min-w-0 truncate font-mono">{ card.OriginDetail }</span>
+			</div>
+		}
 		if card.ExtraText != "" && (!card.RuntimeBadge || card.ExtraText != "agent working") {
 			if card.ExtraChip {
 				<div class="flex" data-board-card-expanded>

--- a/internal/web/templates/board_data.go
+++ b/internal/web/templates/board_data.go
@@ -447,6 +447,8 @@ type boardCardView struct {
 	AgeFooterTitle    string
 	Title             string
 	State             string
+	Origin            string
+	OriginDetail      string
 	CompactSignal     string
 	ExtraKind         primitives.Kind
 	ExtraText         string
@@ -827,6 +829,7 @@ func boardCardViewFromCard(data DashboardData, lane projectKanbanLane, card proj
 		Terminal: terminal,
 		Title:    card.Title,
 		State:    card.Stage,
+		Origin:   card.Origin,
 		Labels:   append([]string(nil), card.Labels...),
 		Effort:   strings.TrimSpace(card.RuntimeIdentity.ReasoningEffort.Value),
 	}
@@ -848,6 +851,7 @@ func boardCardViewFromCard(data DashboardData, lane projectKanbanLane, card proj
 		view.AgeFooterTitle = strings.TrimSpace(card.TimeInStageTitle)
 	}
 	view.ExtraKind, view.ExtraText, view.ExtraChip = boardCardExtra(card, view)
+	view.OriginDetail = boardCardOriginDetail(card.Origin, card.OriginActor)
 	view.Activity = boardCardActivity(data.Snapshot, card)
 	view.PRStatus, view.PRStatusClass = boardCardPRStatus(card)
 	if view.Running {
@@ -867,6 +871,19 @@ func boardCardViewFromCard(data DashboardData, lane projectKanbanLane, card proj
 	view.PriorityBadge, view.PriorityTitle, view.PriorityDetail, view.PriorityTop = boardCardPriority(card)
 	view.CompactSignal = boardCardCompactSignal(view)
 	return view
+}
+
+func boardCardOriginDetail(origin string, actor string) string {
+	origin = strings.ToLower(strings.TrimSpace(origin))
+	actor = strings.TrimSpace(actor)
+	if origin == "" {
+		return ""
+	}
+	detail := "via " + origin
+	if actor != "" {
+		detail += " · @" + strings.TrimPrefix(actor, "@")
+	}
+	return detail
 }
 
 func boardCardCompactSignal(card boardCardView) string {

--- a/internal/web/templates/board_data_test.go
+++ b/internal/web/templates/board_data_test.go
@@ -52,6 +52,49 @@ func TestBoardDetailSheetRendersEfficiencyReceipt(t *testing.T) {
 	}
 }
 
+func TestBoardCardAndDetailSheetRenderOrigin(t *testing.T) {
+	t.Parallel()
+
+	card := projectKanbanCard{
+		IssueID:     "issue-1537",
+		IssueNumber: "#1537",
+		Identifier:  "digitaldrywood/detent#1537",
+		ProjectID:   "detent",
+		Title:       "Track admission provenance",
+		Stage:       "Todo",
+		Origin:      "admission",
+		OriginActor: "ada",
+	}
+	view := boardCardViewFromCard(
+		DashboardData{},
+		projectKanbanLane{Title: "Todo"},
+		card,
+		false,
+		"project",
+		"detent",
+	)
+	cardHTML := renderBoardComponent(t, boardCardView2(view))
+	for _, want := range []string{`data-board-card-origin`, "via admission", "@ada"} {
+		if !strings.Contains(cardHTML, want) {
+			t.Fatalf("board card missing %q:\n%s", want, cardHTML)
+		}
+	}
+	sheetHTML := renderBoardComponent(t, BoardCardSheet(
+		DashboardData{},
+		card,
+		false,
+		false,
+		KanbanConversationData{},
+		BoardActivityData{},
+		BoardSessionData{},
+	))
+	for _, want := range []string{"Origin", "via admission", "@ada"} {
+		if !strings.Contains(sheetHTML, want) {
+			t.Fatalf("detail sheet missing %q:\n%s", want, sheetHTML)
+		}
+	}
+}
+
 func TestBoardDetailSheetUsesTrackerSpecificIssueAction(t *testing.T) {
 	t.Parallel()
 

--- a/internal/web/templates/board_templ.go
+++ b/internal/web/templates/board_templ.go
@@ -1708,9 +1708,36 @@ func boardCardView2(card boardCardView) templ.Component {
 				return templ_7745c5c3_Err
 			}
 		}
+		if card.OriginDetail != "" {
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 142, "<div class=\"flex items-center gap-1.5 text-2xs text-info\" data-board-card-origin data-board-card-expanded>")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = primitives.StatusDot(primitives.KindInfo, false).Render(ctx, templ_7745c5c3_Buffer)
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 143, "<span class=\"min-w-0 truncate font-mono\">")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			var templ_7745c5c3_Var87 string
+			templ_7745c5c3_Var87, templ_7745c5c3_Err = templ.JoinStringErrs(card.OriginDetail)
+			if templ_7745c5c3_Err != nil {
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 492, Col: 64}
+			}
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var87))
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 144, "</span></div>")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+		}
 		if card.ExtraText != "" && (!card.RuntimeBadge || card.ExtraText != "agent working") {
 			if card.ExtraChip {
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 142, "<div class=\"flex\" data-board-card-expanded>")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 145, "<div class=\"flex\" data-board-card-expanded>")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
@@ -1718,30 +1745,30 @@ func boardCardView2(card boardCardView) templ.Component {
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 143, "</div>")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 146, "</div>")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
 			} else {
-				var templ_7745c5c3_Var87 = []any{"flex items-center gap-1.5 text-2xs " + boardExtraTextClass(card.ExtraKind)}
-				templ_7745c5c3_Err = templ.RenderCSSItems(ctx, templ_7745c5c3_Buffer, templ_7745c5c3_Var87...)
+				var templ_7745c5c3_Var88 = []any{"flex items-center gap-1.5 text-2xs " + boardExtraTextClass(card.ExtraKind)}
+				templ_7745c5c3_Err = templ.RenderCSSItems(ctx, templ_7745c5c3_Buffer, templ_7745c5c3_Var88...)
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 144, "<div class=\"")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 147, "<div class=\"")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				var templ_7745c5c3_Var88 string
-				templ_7745c5c3_Var88, templ_7745c5c3_Err = templ.JoinStringErrs(templ.CSSClasses(templ_7745c5c3_Var87).String())
+				var templ_7745c5c3_Var89 string
+				templ_7745c5c3_Var89, templ_7745c5c3_Err = templ.JoinStringErrs(templ.CSSClasses(templ_7745c5c3_Var88).String())
 				if templ_7745c5c3_Err != nil {
 					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 1, Col: 0}
 				}
-				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var88))
+				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var89))
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 145, "\" data-board-card-expanded>")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 148, "\" data-board-card-expanded>")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
@@ -1749,154 +1776,117 @@ func boardCardView2(card boardCardView) templ.Component {
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				var templ_7745c5c3_Var89 string
-				templ_7745c5c3_Var89, templ_7745c5c3_Err = templ.JoinStringErrs(card.ExtraText)
+				var templ_7745c5c3_Var90 string
+				templ_7745c5c3_Var90, templ_7745c5c3_Err = templ.JoinStringErrs(card.ExtraText)
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 497, Col: 21}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 503, Col: 21}
 				}
-				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var89))
+				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var90))
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 146, "</div>")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 149, "</div>")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
 			}
 		}
 		if card.AgeFooter != "" {
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 147, "<div class=\"mt-0.5 flex items-center justify-between gap-2 border-t border-line/70 pt-1.5 font-mono text-2xs text-sec\" title=\"")
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
-			var templ_7745c5c3_Var90 string
-			templ_7745c5c3_Var90, templ_7745c5c3_Err = templ.JoinStringErrs(card.AgeFooterTitle)
-			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 502, Col: 149}
-			}
-			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var90))
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 148, "\" data-board-card-age-footer data-board-card-expanded><span class=\"min-w-0 truncate\">In lane</span> <span class=\"flex-none whitespace-nowrap tabular-nums\">")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 150, "<div class=\"mt-0.5 flex items-center justify-between gap-2 border-t border-line/70 pt-1.5 font-mono text-2xs text-sec\" title=\"")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var91 string
-			templ_7745c5c3_Var91, templ_7745c5c3_Err = templ.JoinStringErrs(card.AgeFooter)
+			templ_7745c5c3_Var91, templ_7745c5c3_Err = templ.JoinStringErrs(card.AgeFooterTitle)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 504, Col: 75}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 508, Col: 149}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var91))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 149, "</span></div>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 151, "\" data-board-card-age-footer data-board-card-expanded><span class=\"min-w-0 truncate\">In lane</span> <span class=\"flex-none whitespace-nowrap tabular-nums\">")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			var templ_7745c5c3_Var92 string
+			templ_7745c5c3_Var92, templ_7745c5c3_Err = templ.JoinStringErrs(card.AgeFooter)
+			if templ_7745c5c3_Err != nil {
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 510, Col: 75}
+			}
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var92))
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 152, "</span></div>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 		}
 		if len(card.Labels) > 0 || card.Effort != "" || card.Activity != "" || card.PRStatus != "" {
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 150, "<div class=\"gap-1.5 border-t border-line/70 pt-1.5 text-2xs text-sec\" data-board-card-content=\"comfy\">")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 153, "<div class=\"gap-1.5 border-t border-line/70 pt-1.5 text-2xs text-sec\" data-board-card-content=\"comfy\">")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			if len(card.Labels) > 0 {
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 151, "<div class=\"flex min-w-0 flex-wrap gap-1\" data-board-card-labels>")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 154, "<div class=\"flex min-w-0 flex-wrap gap-1\" data-board-card-labels>")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
 				for _, label := range card.Labels {
-					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 152, "<span class=\"max-w-full truncate rounded-chip bg-surface px-1.5 py-0.5\">")
+					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 155, "<span class=\"max-w-full truncate rounded-chip bg-surface px-1.5 py-0.5\">")
 					if templ_7745c5c3_Err != nil {
 						return templ_7745c5c3_Err
 					}
-					var templ_7745c5c3_Var92 string
-					templ_7745c5c3_Var92, templ_7745c5c3_Err = templ.JoinStringErrs(label)
+					var templ_7745c5c3_Var93 string
+					templ_7745c5c3_Var93, templ_7745c5c3_Err = templ.JoinStringErrs(label)
 					if templ_7745c5c3_Err != nil {
-						return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 512, Col: 86}
+						return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 518, Col: 86}
 					}
-					_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var92))
+					_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var93))
 					if templ_7745c5c3_Err != nil {
 						return templ_7745c5c3_Err
 					}
-					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 153, "</span>")
+					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 156, "</span>")
 					if templ_7745c5c3_Err != nil {
 						return templ_7745c5c3_Err
 					}
 				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 154, "</div>")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 157, "</div>")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
 			}
 			if card.Effort != "" {
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 155, "<div class=\"flex min-w-0 items-center gap-1.5\" data-board-card-effort><span class=\"text-dim\">Effort</span> <span class=\"truncate font-mono text-text\">")
-				if templ_7745c5c3_Err != nil {
-					return templ_7745c5c3_Err
-				}
-				var templ_7745c5c3_Var93 string
-				templ_7745c5c3_Var93, templ_7745c5c3_Err = templ.JoinStringErrs(card.Effort)
-				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 519, Col: 62}
-				}
-				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var93))
-				if templ_7745c5c3_Err != nil {
-					return templ_7745c5c3_Err
-				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 156, "</span></div>")
-				if templ_7745c5c3_Err != nil {
-					return templ_7745c5c3_Err
-				}
-			}
-			if card.Activity != "" {
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 157, "<div class=\"line-clamp-2 min-w-0\" data-board-card-activity><span class=\"text-dim\">Activity</span> ")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 158, "<div class=\"flex min-w-0 items-center gap-1.5\" data-board-card-effort><span class=\"text-dim\">Effort</span> <span class=\"truncate font-mono text-text\">")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
 				var templ_7745c5c3_Var94 string
-				templ_7745c5c3_Var94, templ_7745c5c3_Err = templ.JoinStringErrs(card.Activity)
+				templ_7745c5c3_Var94, templ_7745c5c3_Err = templ.JoinStringErrs(card.Effort)
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 523, Col: 118}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 525, Col: 62}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var94))
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 158, "</div>")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 159, "</span></div>")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
 			}
-			if card.PRStatus != "" {
-				var templ_7745c5c3_Var95 = []any{"w-fit rounded-chip border px-1.5 py-0.5 font-mono " + card.PRStatusClass}
-				templ_7745c5c3_Err = templ.RenderCSSItems(ctx, templ_7745c5c3_Buffer, templ_7745c5c3_Var95...)
+			if card.Activity != "" {
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 160, "<div class=\"line-clamp-2 min-w-0\" data-board-card-activity><span class=\"text-dim\">Activity</span> ")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 159, "<div class=\"")
+				var templ_7745c5c3_Var95 string
+				templ_7745c5c3_Var95, templ_7745c5c3_Err = templ.JoinStringErrs(card.Activity)
 				if templ_7745c5c3_Err != nil {
-					return templ_7745c5c3_Err
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 529, Col: 118}
 				}
-				var templ_7745c5c3_Var96 string
-				templ_7745c5c3_Var96, templ_7745c5c3_Err = templ.JoinStringErrs(templ.CSSClasses(templ_7745c5c3_Var95).String())
-				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 1, Col: 0}
-				}
-				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var96))
-				if templ_7745c5c3_Err != nil {
-					return templ_7745c5c3_Err
-				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 160, "\" data-board-card-pr-status>")
-				if templ_7745c5c3_Err != nil {
-					return templ_7745c5c3_Err
-				}
-				var templ_7745c5c3_Var97 string
-				templ_7745c5c3_Var97, templ_7745c5c3_Err = templ.JoinStringErrs(card.PRStatus)
-				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 526, Col: 135}
-				}
-				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var97))
+				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var95))
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
@@ -1905,7 +1895,44 @@ func boardCardView2(card boardCardView) templ.Component {
 					return templ_7745c5c3_Err
 				}
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 162, "</div>")
+			if card.PRStatus != "" {
+				var templ_7745c5c3_Var96 = []any{"w-fit rounded-chip border px-1.5 py-0.5 font-mono " + card.PRStatusClass}
+				templ_7745c5c3_Err = templ.RenderCSSItems(ctx, templ_7745c5c3_Buffer, templ_7745c5c3_Var96...)
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 162, "<div class=\"")
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+				var templ_7745c5c3_Var97 string
+				templ_7745c5c3_Var97, templ_7745c5c3_Err = templ.JoinStringErrs(templ.CSSClasses(templ_7745c5c3_Var96).String())
+				if templ_7745c5c3_Err != nil {
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 1, Col: 0}
+				}
+				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var97))
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 163, "\" data-board-card-pr-status>")
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+				var templ_7745c5c3_Var98 string
+				templ_7745c5c3_Var98, templ_7745c5c3_Err = templ.JoinStringErrs(card.PRStatus)
+				if templ_7745c5c3_Err != nil {
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 532, Col: 135}
+				}
+				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var98))
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 164, "</div>")
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 165, "</div>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -1916,7 +1943,7 @@ func boardCardView2(card boardCardView) templ.Component {
 				return templ_7745c5c3_Err
 			}
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 163, "</article>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 166, "</article>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -1940,74 +1967,74 @@ func boardRuntimeBadge(card boardCardView) templ.Component {
 			}()
 		}
 		ctx = templ.InitializeContext(ctx)
-		templ_7745c5c3_Var98 := templ.GetChildren(ctx)
-		if templ_7745c5c3_Var98 == nil {
-			templ_7745c5c3_Var98 = templ.NopComponent
+		templ_7745c5c3_Var99 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var99 == nil {
+			templ_7745c5c3_Var99 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 164, "<div id=\"")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 167, "<div id=\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		var templ_7745c5c3_Var99 string
-		templ_7745c5c3_Var99, templ_7745c5c3_Err = templ.JoinStringErrs(card.DomID + "-runtime-badge")
+		var templ_7745c5c3_Var100 string
+		templ_7745c5c3_Var100, templ_7745c5c3_Err = templ.JoinStringErrs(card.DomID + "-runtime-badge")
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 538, Col: 36}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 544, Col: 36}
 		}
-		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var99))
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var100))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 165, "\" class=\"flex min-w-0 items-center gap-1.5 text-2xs text-ok\" data-board-runtime-badge data-board-card-expanded")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 168, "\" class=\"flex min-w-0 items-center gap-1.5 text-2xs text-ok\" data-board-runtime-badge data-board-card-expanded")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		if card.RuntimeSummary != "" {
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 166, " tabindex=\"0\" role=\"img\" aria-label=\"")
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
-			var templ_7745c5c3_Var100 string
-			templ_7745c5c3_Var100, templ_7745c5c3_Err = templ.JoinStringErrs("Agent runtime: " + card.RuntimeSummary)
-			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 545, Col: 55}
-			}
-			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var100))
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 167, "\" data-help-trigger data-help-scope=\"runtime-identity\" data-help-term=\"")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 169, " tabindex=\"0\" role=\"img\" aria-label=\"")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var101 string
-			templ_7745c5c3_Var101, templ_7745c5c3_Err = templ.JoinStringErrs(card.DomID + "-runtime-identity")
+			templ_7745c5c3_Var101, templ_7745c5c3_Err = templ.JoinStringErrs("Agent runtime: " + card.RuntimeSummary)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 548, Col: 52}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 551, Col: 55}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var101))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 168, "\" data-help-title=\"Agent runtime\" data-help-description=\"")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 170, "\" data-help-trigger data-help-scope=\"runtime-identity\" data-help-term=\"")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var102 string
-			templ_7745c5c3_Var102, templ_7745c5c3_Err = templ.JoinStringErrs(card.RuntimeDetail)
+			templ_7745c5c3_Var102, templ_7745c5c3_Err = templ.JoinStringErrs(card.DomID + "-runtime-identity")
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 550, Col: 45}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 554, Col: 52}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var102))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 169, "\" onclick=\"event.stopPropagation()\"")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 171, "\" data-help-title=\"Agent runtime\" data-help-description=\"")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			var templ_7745c5c3_Var103 string
+			templ_7745c5c3_Var103, templ_7745c5c3_Err = templ.JoinStringErrs(card.RuntimeDetail)
+			if templ_7745c5c3_Err != nil {
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 556, Col: 45}
+			}
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var103))
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 172, "\" onclick=\"event.stopPropagation()\"")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 170, ">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 173, ">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -2015,33 +2042,33 @@ func boardRuntimeBadge(card boardCardView) templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 171, "<span class=\"min-w-0 truncate font-mono\"><span class=\"runtime-badge-cozy\" data-runtime-density=\"cozy\">")
-		if templ_7745c5c3_Err != nil {
-			return templ_7745c5c3_Err
-		}
-		var templ_7745c5c3_Var103 string
-		templ_7745c5c3_Var103, templ_7745c5c3_Err = templ.JoinStringErrs(card.RuntimeCozyText)
-		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 556, Col: 86}
-		}
-		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var103))
-		if templ_7745c5c3_Err != nil {
-			return templ_7745c5c3_Err
-		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 172, "</span> <span class=\"runtime-badge-comfy\" data-runtime-density=\"comfy\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 174, "<span class=\"min-w-0 truncate font-mono\"><span class=\"runtime-badge-cozy\" data-runtime-density=\"cozy\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		var templ_7745c5c3_Var104 string
-		templ_7745c5c3_Var104, templ_7745c5c3_Err = templ.JoinStringErrs(card.RuntimeComfyText)
+		templ_7745c5c3_Var104, templ_7745c5c3_Err = templ.JoinStringErrs(card.RuntimeCozyText)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 557, Col: 89}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 562, Col: 86}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var104))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 173, "</span></span></div>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 175, "</span> <span class=\"runtime-badge-comfy\" data-runtime-density=\"comfy\">")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		var templ_7745c5c3_Var105 string
+		templ_7745c5c3_Var105, templ_7745c5c3_Err = templ.JoinStringErrs(card.RuntimeComfyText)
+		if templ_7745c5c3_Err != nil {
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 563, Col: 89}
+		}
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var105))
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 176, "</span></span></div>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -2065,87 +2092,87 @@ func boardKanbanDragMoveForm(card boardCardView) templ.Component {
 			}()
 		}
 		ctx = templ.InitializeContext(ctx)
-		templ_7745c5c3_Var105 := templ.GetChildren(ctx)
-		if templ_7745c5c3_Var105 == nil {
-			templ_7745c5c3_Var105 = templ.NopComponent
+		templ_7745c5c3_Var106 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var106 == nil {
+			templ_7745c5c3_Var106 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 174, "<form class=\"hidden\" hx-post=\"/api/v1/kanban/move\" hx-target=\"#snapshot\" hx-swap=\"morph:innerHTML\" data-kanban-drag-move-form><input type=\"hidden\" name=\"kanban_drag\" value=\"true\"> <input type=\"hidden\" name=\"kanban_board\" value=\"")
-		if templ_7745c5c3_Err != nil {
-			return templ_7745c5c3_Err
-		}
-		var templ_7745c5c3_Var106 string
-		templ_7745c5c3_Var106, templ_7745c5c3_Err = templ.JoinStringErrs(card.Scope)
-		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 565, Col: 61}
-		}
-		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var106))
-		if templ_7745c5c3_Err != nil {
-			return templ_7745c5c3_Err
-		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 175, "\"> <input type=\"hidden\" name=\"project_id\" value=\"")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 177, "<form class=\"hidden\" hx-post=\"/api/v1/kanban/move\" hx-target=\"#snapshot\" hx-swap=\"morph:innerHTML\" data-kanban-drag-move-form><input type=\"hidden\" name=\"kanban_drag\" value=\"true\"> <input type=\"hidden\" name=\"kanban_board\" value=\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		var templ_7745c5c3_Var107 string
-		templ_7745c5c3_Var107, templ_7745c5c3_Err = templ.JoinStringErrs(card.MoveProject)
+		templ_7745c5c3_Var107, templ_7745c5c3_Err = templ.JoinStringErrs(card.Scope)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 566, Col: 65}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 571, Col: 61}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var107))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 176, "\"> <input type=\"hidden\" name=\"issue_id\" value=\"")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 178, "\"> <input type=\"hidden\" name=\"project_id\" value=\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		var templ_7745c5c3_Var108 string
-		templ_7745c5c3_Var108, templ_7745c5c3_Err = templ.JoinStringErrs(card.IssueID)
+		templ_7745c5c3_Var108, templ_7745c5c3_Err = templ.JoinStringErrs(card.MoveProject)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 567, Col: 59}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 572, Col: 65}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var108))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 177, "\"> <input type=\"hidden\" name=\"current_state\" value=\"")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 179, "\"> <input type=\"hidden\" name=\"issue_id\" value=\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		var templ_7745c5c3_Var109 string
-		templ_7745c5c3_Var109, templ_7745c5c3_Err = templ.JoinStringErrs(card.CurrentState)
+		templ_7745c5c3_Var109, templ_7745c5c3_Err = templ.JoinStringErrs(card.IssueID)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 568, Col: 69}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 573, Col: 59}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var109))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 178, "\"> <input type=\"hidden\" name=\"target_state\" value=\"\" data-kanban-drag-target-state> ")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 180, "\"> <input type=\"hidden\" name=\"current_state\" value=\"")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		var templ_7745c5c3_Var110 string
+		templ_7745c5c3_Var110, templ_7745c5c3_Err = templ.JoinStringErrs(card.CurrentState)
+		if templ_7745c5c3_Err != nil {
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 574, Col: 69}
+		}
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var110))
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 181, "\"> <input type=\"hidden\" name=\"target_state\" value=\"\" data-kanban-drag-target-state> ")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		if card.PRNumber != "" {
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 179, "<input type=\"hidden\" name=\"pr_number\" value=\"")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 182, "<input type=\"hidden\" name=\"pr_number\" value=\"")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			var templ_7745c5c3_Var110 string
-			templ_7745c5c3_Var110, templ_7745c5c3_Err = templ.JoinStringErrs(card.PRNumber)
+			var templ_7745c5c3_Var111 string
+			templ_7745c5c3_Var111, templ_7745c5c3_Err = templ.JoinStringErrs(card.PRNumber)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 571, Col: 62}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 577, Col: 62}
 			}
-			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var110))
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var111))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 180, "\">")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 183, "\">")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 181, "</form>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 184, "</form>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -2172,74 +2199,74 @@ func boardLanePicker(view boardView) templ.Component {
 			}()
 		}
 		ctx = templ.InitializeContext(ctx)
-		templ_7745c5c3_Var111 := templ.GetChildren(ctx)
-		if templ_7745c5c3_Var111 == nil {
-			templ_7745c5c3_Var111 = templ.NopComponent
+		templ_7745c5c3_Var112 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var112 == nil {
+			templ_7745c5c3_Var112 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 182, "<details id=\"board-lane-picker\" class=\"relative col-span-3 justify-self-start md:col-span-1\" data-board-lane-picker data-preserve-details=\"board-lane-picker\"><summary class=\"flex min-h-11 cursor-pointer list-none items-center gap-1.5 rounded-chip border border-line px-2.5 py-1 text-2xs text-sec hover:text-text [&::-webkit-details-marker]:hidden md:min-h-0\">Lanes <span data-board-lane-count class=\"tabular-nums\">")
-		if templ_7745c5c3_Err != nil {
-			return templ_7745c5c3_Err
-		}
-		var templ_7745c5c3_Var112 string
-		templ_7745c5c3_Var112, templ_7745c5c3_Err = templ.JoinStringErrs(boardLaneCountLabel(view))
-		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 582, Col: 85}
-		}
-		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var112))
-		if templ_7745c5c3_Err != nil {
-			return templ_7745c5c3_Err
-		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 183, "</span> <span class=\"rounded-chip bg-warn/15 px-1.5 py-0.5 font-mono text-warn\" data-board-hidden-card-count title=\"")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 185, "<details id=\"board-lane-picker\" class=\"relative col-span-3 justify-self-start md:col-span-1\" data-board-lane-picker data-preserve-details=\"board-lane-picker\"><summary class=\"flex min-h-11 cursor-pointer list-none items-center gap-1.5 rounded-chip border border-line px-2.5 py-1 text-2xs text-sec hover:text-text [&::-webkit-details-marker]:hidden md:min-h-0\">Lanes <span data-board-lane-count class=\"tabular-nums\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		var templ_7745c5c3_Var113 string
-		templ_7745c5c3_Var113, templ_7745c5c3_Err = templ.JoinStringErrs(boardLaneHiddenCardSummary(view))
+		templ_7745c5c3_Var113, templ_7745c5c3_Err = templ.JoinStringErrs(boardLaneCountLabel(view))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 586, Col: 44}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 588, Col: 85}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var113))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 184, "\" aria-label=\"")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 186, "</span> <span class=\"rounded-chip bg-warn/15 px-1.5 py-0.5 font-mono text-warn\" data-board-hidden-card-count title=\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		var templ_7745c5c3_Var114 string
 		templ_7745c5c3_Var114, templ_7745c5c3_Err = templ.JoinStringErrs(boardLaneHiddenCardSummary(view))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 587, Col: 49}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 592, Col: 44}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var114))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 185, "\"")
-		if templ_7745c5c3_Err != nil {
-			return templ_7745c5c3_Err
-		}
-		if view.HiddenCards == 0 {
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 186, " hidden")
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
-		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 187, ">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 187, "\" aria-label=\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		var templ_7745c5c3_Var115 string
-		templ_7745c5c3_Var115, templ_7745c5c3_Err = templ.JoinStringErrs(boardLaneHiddenCardBadgeLabel(view))
+		templ_7745c5c3_Var115, templ_7745c5c3_Err = templ.JoinStringErrs(boardLaneHiddenCardSummary(view))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 589, Col: 41}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 593, Col: 49}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var115))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 188, "</span>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 188, "\"")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		if view.HiddenCards == 0 {
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 189, " hidden")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 190, ">")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		var templ_7745c5c3_Var116 string
+		templ_7745c5c3_Var116, templ_7745c5c3_Err = templ.JoinStringErrs(boardLaneHiddenCardBadgeLabel(view))
+		if templ_7745c5c3_Err != nil {
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 595, Col: 41}
+		}
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var116))
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 191, "</span>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -2247,7 +2274,7 @@ func boardLanePicker(view boardView) templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 189, "</summary><div class=\"absolute left-0 top-full z-40 mt-1 flex max-h-[calc(100vh-10rem)] w-[calc(100vw-2.5rem)] flex-col gap-1 overflow-y-auto rounded-card border border-line bg-elev p-1.5 md:left-auto md:right-0 md:max-h-none md:w-80 md:overflow-visible\"><div class=\"flex items-center justify-between gap-2 border-b border-line px-1 pb-1.5\"><span class=\"text-2xs font-medium uppercase text-sec\">Visibility</span> <button type=\"button\" class=\"inline-flex min-h-11 items-center gap-1.5 rounded-chip border border-line px-2 text-2xs font-medium text-sec hover:border-accent hover:text-accent disabled:pointer-events-none disabled:opacity-40 md:min-h-7\" data-board-lane-reset-all aria-label=\"Reset all lanes to Auto\" title=\"Reset all lanes to Auto\" disabled aria-disabled=\"true\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 192, "</summary><div class=\"absolute left-0 top-full z-40 mt-1 flex max-h-[calc(100vh-10rem)] w-[calc(100vw-2.5rem)] flex-col gap-1 overflow-y-auto rounded-card border border-line bg-elev p-1.5 md:left-auto md:right-0 md:max-h-none md:w-80 md:overflow-visible\"><div class=\"flex items-center justify-between gap-2 border-b border-line px-1 pb-1.5\"><span class=\"text-2xs font-medium uppercase text-sec\">Visibility</span> <button type=\"button\" class=\"inline-flex min-h-11 items-center gap-1.5 rounded-chip border border-line px-2 text-2xs font-medium text-sec hover:border-accent hover:text-accent disabled:pointer-events-none disabled:opacity-40 md:min-h-7\" data-board-lane-reset-all aria-label=\"Reset all lanes to Auto\" title=\"Reset all lanes to Auto\" disabled aria-disabled=\"true\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -2255,264 +2282,264 @@ func boardLanePicker(view boardView) templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 190, "<span>Reset all</span></button></div>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 193, "<span>Reset all</span></button></div>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		for _, lane := range view.Lanes {
-			var templ_7745c5c3_Var116 = []any{boardLaneVisibilityRowClass(lane)}
-			templ_7745c5c3_Err = templ.RenderCSSItems(ctx, templ_7745c5c3_Buffer, templ_7745c5c3_Var116...)
+			var templ_7745c5c3_Var117 = []any{boardLaneVisibilityRowClass(lane)}
+			templ_7745c5c3_Err = templ.RenderCSSItems(ctx, templ_7745c5c3_Buffer, templ_7745c5c3_Var117...)
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 191, "<div class=\"")
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
-			var templ_7745c5c3_Var117 string
-			templ_7745c5c3_Var117, templ_7745c5c3_Err = templ.JoinStringErrs(templ.CSSClasses(templ_7745c5c3_Var116).String())
-			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 1, Col: 0}
-			}
-			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var117))
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 192, "\" data-board-lane-row=\"")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 194, "<div class=\"")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var118 string
-			templ_7745c5c3_Var118, templ_7745c5c3_Err = templ.JoinStringErrs(lane.LaneID)
+			templ_7745c5c3_Var118, templ_7745c5c3_Err = templ.JoinStringErrs(templ.CSSClasses(templ_7745c5c3_Var117).String())
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 609, Col: 86}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 1, Col: 0}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var118))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 193, "\" data-board-lane-card-count=\"")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 195, "\" data-board-lane-row=\"")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var119 string
-			templ_7745c5c3_Var119, templ_7745c5c3_Err = templ.JoinStringErrs(strconv.Itoa(lane.CardCount))
+			templ_7745c5c3_Var119, templ_7745c5c3_Err = templ.JoinStringErrs(lane.LaneID)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 609, Col: 146}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 615, Col: 86}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var119))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 194, "\" data-board-lane-hidden-populated=\"")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 196, "\" data-board-lane-card-count=\"")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var120 string
-			templ_7745c5c3_Var120, templ_7745c5c3_Err = templ.JoinStringErrs(boardBoolAttr(boardLaneHiddenPopulated(lane)))
+			templ_7745c5c3_Var120, templ_7745c5c3_Err = templ.JoinStringErrs(strconv.Itoa(lane.CardCount))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 609, Col: 229}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 615, Col: 146}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var120))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 195, "\"><div class=\"flex min-w-0 items-center gap-2\"><span class=\"min-w-0 flex-1 truncate font-medium\">")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 197, "\" data-board-lane-hidden-populated=\"")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var121 string
-			templ_7745c5c3_Var121, templ_7745c5c3_Err = templ.JoinStringErrs(lane.Title)
+			templ_7745c5c3_Var121, templ_7745c5c3_Err = templ.JoinStringErrs(boardBoolAttr(boardLaneHiddenPopulated(lane)))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 611, Col: 68}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 615, Col: 229}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var121))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 196, "</span> <span class=\"rounded-chip bg-surface px-1.5 py-0.5 font-mono text-2xs text-sec tabular-nums\">")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 198, "\"><div class=\"flex min-w-0 items-center gap-2\"><span class=\"min-w-0 flex-1 truncate font-medium\">")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var122 string
-			templ_7745c5c3_Var122, templ_7745c5c3_Err = templ.JoinStringErrs(lane.Count)
+			templ_7745c5c3_Var122, templ_7745c5c3_Err = templ.JoinStringErrs(lane.Title)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 612, Col: 111}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 617, Col: 68}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var122))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 197, "</span></div><div class=\"grid grid-cols-[minmax(0,1fr)_auto_auto] items-center gap-1.5\"><span class=\"min-w-0 truncate text-2xs text-sec\" title=\"")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 199, "</span> <span class=\"rounded-chip bg-surface px-1.5 py-0.5 font-mono text-2xs text-sec tabular-nums\">")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var123 string
-			templ_7745c5c3_Var123, templ_7745c5c3_Err = templ.JoinStringErrs(boardLaneVisibilityStatusTitle(lane))
+			templ_7745c5c3_Var123, templ_7745c5c3_Err = templ.JoinStringErrs(lane.Count)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 615, Col: 99}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 618, Col: 111}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var123))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 198, "\" data-board-lane-visibility-status>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 200, "</span></div><div class=\"grid grid-cols-[minmax(0,1fr)_auto_auto] items-center gap-1.5\"><span class=\"min-w-0 truncate text-2xs text-sec\" title=\"")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var124 string
-			templ_7745c5c3_Var124, templ_7745c5c3_Err = templ.JoinStringErrs(boardLaneVisibilityStatusLabel(lane))
+			templ_7745c5c3_Var124, templ_7745c5c3_Err = templ.JoinStringErrs(boardLaneVisibilityStatusTitle(lane))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 615, Col: 174}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 621, Col: 99}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var124))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 199, "</span> <select class=\"h-11 rounded-chip border border-line bg-surface px-2 text-2xs text-text outline-none focus:border-accent md:h-7\" data-board-lane-visibility=\"")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 201, "\" data-board-lane-visibility-status>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var125 string
-			templ_7745c5c3_Var125, templ_7745c5c3_Err = templ.JoinStringErrs(lane.LaneID)
+			templ_7745c5c3_Var125, templ_7745c5c3_Err = templ.JoinStringErrs(boardLaneVisibilityStatusLabel(lane))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 618, Col: 47}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 621, Col: 174}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var125))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 200, "\" data-board-lane-visibility-state=\"")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 202, "</span> <select class=\"h-11 rounded-chip border border-line bg-surface px-2 text-2xs text-text outline-none focus:border-accent md:h-7\" data-board-lane-visibility=\"")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var126 string
-			templ_7745c5c3_Var126, templ_7745c5c3_Err = templ.JoinStringErrs(string(boardLaneVisibilityAuto))
+			templ_7745c5c3_Var126, templ_7745c5c3_Err = templ.JoinStringErrs(lane.LaneID)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 619, Col: 73}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 624, Col: 47}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var126))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 201, "\" data-board-lane-visibility-effective=\"")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 203, "\" data-board-lane-visibility-state=\"")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var127 string
-			templ_7745c5c3_Var127, templ_7745c5c3_Err = templ.JoinStringErrs(boardBoolAttr(lane.DefaultVisible))
+			templ_7745c5c3_Var127, templ_7745c5c3_Err = templ.JoinStringErrs(string(boardLaneVisibilityAuto))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 620, Col: 80}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 625, Col: 73}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var127))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 202, "\" aria-label=\"")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 204, "\" data-board-lane-visibility-effective=\"")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var128 string
-			templ_7745c5c3_Var128, templ_7745c5c3_Err = templ.JoinStringErrs("Visibility for " + lane.Title + " lane")
+			templ_7745c5c3_Var128, templ_7745c5c3_Err = templ.JoinStringErrs(boardBoolAttr(lane.DefaultVisible))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 621, Col: 60}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 626, Col: 80}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var128))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 203, "\" title=\"")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 205, "\" aria-label=\"")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var129 string
-			templ_7745c5c3_Var129, templ_7745c5c3_Err = templ.JoinStringErrs(boardLaneVisibilityStatusTitle(lane))
+			templ_7745c5c3_Var129, templ_7745c5c3_Err = templ.JoinStringErrs("Visibility for " + lane.Title + " lane")
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 622, Col: 51}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 627, Col: 60}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var129))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 204, "\"><option value=\"")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 206, "\" title=\"")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var130 string
-			templ_7745c5c3_Var130, templ_7745c5c3_Err = templ.JoinStringErrs(string(boardLaneVisibilityAuto))
+			templ_7745c5c3_Var130, templ_7745c5c3_Err = templ.JoinStringErrs(boardLaneVisibilityStatusTitle(lane))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 624, Col: 54}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 628, Col: 51}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var130))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 205, "\" selected>Auto</option> <option value=\"")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 207, "\"><option value=\"")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var131 string
-			templ_7745c5c3_Var131, templ_7745c5c3_Err = templ.JoinStringErrs(string(boardLaneVisibilityShow))
+			templ_7745c5c3_Var131, templ_7745c5c3_Err = templ.JoinStringErrs(string(boardLaneVisibilityAuto))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 625, Col: 54}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 630, Col: 54}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var131))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 206, "\">Show</option> <option value=\"")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 208, "\" selected>Auto</option> <option value=\"")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var132 string
-			templ_7745c5c3_Var132, templ_7745c5c3_Err = templ.JoinStringErrs(string(boardLaneVisibilityHide))
+			templ_7745c5c3_Var132, templ_7745c5c3_Err = templ.JoinStringErrs(string(boardLaneVisibilityShow))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 626, Col: 54}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 631, Col: 54}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var132))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 207, "\">Hide</option></select> <button type=\"button\" class=\"inline-flex size-11 items-center justify-center rounded-chip border border-line text-sec hover:border-accent hover:text-accent disabled:pointer-events-none disabled:opacity-40 md:size-7\" data-board-lane-reset=\"")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 209, "\">Show</option> <option value=\"")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var133 string
-			templ_7745c5c3_Var133, templ_7745c5c3_Err = templ.JoinStringErrs(lane.LaneID)
+			templ_7745c5c3_Var133, templ_7745c5c3_Err = templ.JoinStringErrs(string(boardLaneVisibilityHide))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 631, Col: 42}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 632, Col: 54}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var133))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 208, "\" value=\"")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 210, "\">Hide</option></select> <button type=\"button\" class=\"inline-flex size-11 items-center justify-center rounded-chip border border-line text-sec hover:border-accent hover:text-accent disabled:pointer-events-none disabled:opacity-40 md:size-7\" data-board-lane-reset=\"")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var134 string
 			templ_7745c5c3_Var134, templ_7745c5c3_Err = templ.JoinStringErrs(lane.LaneID)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 632, Col: 26}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 637, Col: 42}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var134))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 209, "\" aria-label=\"")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 211, "\" value=\"")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var135 string
-			templ_7745c5c3_Var135, templ_7745c5c3_Err = templ.JoinStringErrs("Reset " + lane.Title + " lane to Auto")
+			templ_7745c5c3_Var135, templ_7745c5c3_Err = templ.JoinStringErrs(lane.LaneID)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 633, Col: 59}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 638, Col: 26}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var135))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 210, "\" title=\"Reset lane to Auto\" disabled aria-disabled=\"true\">")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 212, "\" aria-label=\"")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			var templ_7745c5c3_Var136 string
+			templ_7745c5c3_Var136, templ_7745c5c3_Err = templ.JoinStringErrs("Reset " + lane.Title + " lane to Auto")
+			if templ_7745c5c3_Err != nil {
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 639, Col: 59}
+			}
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var136))
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 213, "\" title=\"Reset lane to Auto\" disabled aria-disabled=\"true\">")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -2520,12 +2547,12 @@ func boardLanePicker(view boardView) templ.Component {
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 211, "</button></div></div>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 214, "</button></div></div>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 212, "</div></details>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 215, "</div></details>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -2549,12 +2576,12 @@ func boardLaneScript() templ.Component {
 			}()
 		}
 		ctx = templ.InitializeContext(ctx)
-		templ_7745c5c3_Var136 := templ.GetChildren(ctx)
-		if templ_7745c5c3_Var136 == nil {
-			templ_7745c5c3_Var136 = templ.NopComponent
+		templ_7745c5c3_Var137 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var137 == nil {
+			templ_7745c5c3_Var137 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 213, "<script>\n\t\t(function () {\n\t\t\tvar storagePrefix = \"detent.ui.board.lanes.v2.\";\n\t\t\tvar legacyStoragePrefix = \"detent.ui.board.lanes.\";\n\t\t\tvar storageVersion = 1;\n\t\t\tvar stateAuto = \"auto\";\n\t\t\tvar stateShow = \"show\";\n\t\t\tvar stateHide = \"hide\";\n\t\t\tvar pickerOpen = false;\n\t\t\tvar activeLaneID = \"\";\n\t\t\tvar lanePositionFrame = 0;\n\n\t\t\tfunction visibilityStorage() {\n\t\t\t\ttry {\n\t\t\t\t\treturn window.localStorage;\n\t\t\t\t} catch (err) {\n\t\t\t\t\treturn null;\n\t\t\t\t}\n\t\t\t}\n\t\t\tfunction storageKey(root) {\n\t\t\t\treturn storagePrefix + (root.getAttribute(\"data-board-key\") || \"fleet\");\n\t\t\t}\n\t\t\tfunction legacyStorageKey(root) {\n\t\t\t\treturn legacyStoragePrefix + (root.getAttribute(\"data-board-key\") || \"fleet\");\n\t\t\t}\n\t\t\tfunction emptyPrefs() {\n\t\t\t\treturn { show: new Set(), hide: new Set() };\n\t\t\t}\n\t\t\tfunction laneIDSet(ids) {\n\t\t\t\tvar out = new Set();\n\t\t\t\tif (!Array.isArray(ids)) return out;\n\t\t\t\tids.forEach(function (id) {\n\t\t\t\t\tif (typeof id === \"string\" && id.trim() !== \"\") out.add(id);\n\t\t\t\t});\n\t\t\t\treturn out;\n\t\t\t}\n\t\t\tfunction normalizedPrefs(showIDs, hideIDs) {\n\t\t\t\tvar prefs = emptyPrefs();\n\t\t\t\tlaneIDSet(showIDs).forEach(function (id) {\n\t\t\t\t\tprefs.show.add(id);\n\t\t\t\t});\n\t\t\t\tlaneIDSet(hideIDs).forEach(function (id) {\n\t\t\t\t\tif (!prefs.show.has(id)) prefs.hide.add(id);\n\t\t\t\t});\n\t\t\t\treturn prefs;\n\t\t\t}\n\t\t\tfunction discardLegacyPrefs(root, store) {\n\t\t\t\tvar legacy = legacyStorageKey(root);\n\t\t\t\ttry {\n\t\t\t\t\tif (legacy !== storageKey(root)) store.removeItem(legacy);\n\t\t\t\t} catch (err) {}\n\t\t\t}\n\t\t\tfunction readPrefs(root) {\n\t\t\t\tvar store = visibilityStorage();\n\t\t\t\tif (!store) return emptyPrefs();\n\t\t\t\tdiscardLegacyPrefs(root, store);\n\t\t\t\tvar raw = \"\";\n\t\t\t\ttry {\n\t\t\t\t\traw = store.getItem(storageKey(root));\n\t\t\t\t} catch (err) {\n\t\t\t\t\treturn emptyPrefs();\n\t\t\t\t}\n\t\t\t\tif (!raw) return emptyPrefs();\n\t\t\t\ttry {\n\t\t\t\t\tvar parsed = JSON.parse(raw);\n\t\t\t\t\tif (!parsed || parsed.v !== storageVersion) {\n\t\t\t\t\t\ttry {\n\t\t\t\t\t\t\tstore.removeItem(storageKey(root));\n\t\t\t\t\t\t} catch (err) {}\n\t\t\t\t\t\treturn emptyPrefs();\n\t\t\t\t\t}\n\t\t\t\t\treturn normalizedPrefs(parsed.show, parsed.hide);\n\t\t\t\t} catch (err) {\n\t\t\t\t\ttry {\n\t\t\t\t\t\tstore.removeItem(storageKey(root));\n\t\t\t\t\t} catch (err) {}\n\t\t\t\t\treturn emptyPrefs();\n\t\t\t\t}\n\t\t\t}\n\t\t\tfunction writePrefs(root, prefs) {\n\t\t\t\tvar store = visibilityStorage();\n\t\t\t\tif (!store) return;\n\t\t\t\tvar show = Array.from(prefs.show).filter(Boolean).sort();\n\t\t\t\tvar hide = Array.from(prefs.hide).filter(function (id) {\n\t\t\t\t\treturn Boolean(id) && !prefs.show.has(id);\n\t\t\t\t}).sort();\n\t\t\t\tif (show.length === 0 && hide.length === 0) {\n\t\t\t\t\ttry {\n\t\t\t\t\t\tstore.removeItem(storageKey(root));\n\t\t\t\t\t} catch (err) {}\n\t\t\t\t\treturn;\n\t\t\t\t}\n\t\t\t\ttry {\n\t\t\t\t\tstore.setItem(storageKey(root), JSON.stringify({ v: storageVersion, show: show, hide: hide }));\n\t\t\t\t} catch (err) {}\n\t\t\t}\n\t\t\tfunction prefsHaveOverrides(prefs) {\n\t\t\t\treturn prefs.show.size > 0 || prefs.hide.size > 0;\n\t\t\t}\n\t\t\tfunction queryRoot(scope) {\n\t\t\t\tif (scope && typeof scope.querySelector === \"function\" && typeof scope.querySelectorAll === \"function\") return scope;\n\t\t\t\treturn document;\n\t\t\t}\n\t\t\tfunction boardLanesRoot(scope) {\n\t\t\t\tif (scope instanceof Element && scope.matches(\"[data-board-lanes]\")) return scope;\n\t\t\t\tif (scope && typeof scope.querySelector === \"function\") return scope.querySelector(\"[data-board-lanes]\");\n\t\t\t\treturn null;\n\t\t\t}\n\t\t\tfunction findByData(scope, attr, value) {\n\t\t\t\tvar root = queryRoot(scope);\n\t\t\t\tvar nodes = root.querySelectorAll(\"[\" + attr + \"]\");\n\t\t\t\tfor (var i = 0; i < nodes.length; i += 1) {\n\t\t\t\t\tif (nodes[i].getAttribute(attr) === value) return nodes[i];\n\t\t\t\t}\n\t\t\t\treturn null;\n\t\t\t}\n\t\t\tfunction laneID(lane) {\n\t\t\t\treturn lane.getAttribute(\"data-board-lane\") || \"\";\n\t\t\t}\n\t\t\tfunction laneDefaultVisible(lane) {\n\t\t\t\treturn lane.getAttribute(\"data-board-lane-default\") === \"true\";\n\t\t\t}\n\t\t\tfunction laneCardCount(lane) {\n\t\t\t\tvar parsed = Number.parseInt(lane.getAttribute(\"data-board-lane-card-count\") || \"0\", 10);\n\t\t\t\tif (!Number.isFinite(parsed) || parsed < 0) return 0;\n\t\t\t\treturn parsed;\n\t\t\t}\n\t\t\tfunction laneTitle(lane) {\n\t\t\t\treturn lane.getAttribute(\"data-board-lane-title\") || \"lane\";\n\t\t\t}\n\t\t\tfunction visibleBoardLanes(root) {\n\t\t\t\treturn Array.from(root.querySelectorAll(\"[data-board-lane]\")).filter(function (lane) {\n\t\t\t\t\treturn lane.getAttribute(\"data-lane-hidden\") !== \"true\";\n\t\t\t\t});\n\t\t\t}\n\t\t\tfunction lanePositionIndex(root, lanes, preferredID) {\n\t\t\t\tif (lanes.length === 0) return -1;\n\t\t\t\tif (preferredID) {\n\t\t\t\t\tvar preferred = lanes.findIndex(function (lane) {\n\t\t\t\t\t\treturn laneID(lane) === preferredID;\n\t\t\t\t\t});\n\t\t\t\t\tif (preferred >= 0) return preferred;\n\t\t\t\t}\n\t\t\t\tif (!root.isConnected) return 0;\n\t\t\t\tvar rootRect = root.getBoundingClientRect();\n\t\t\t\tvar center = rootRect.left + root.clientWidth / 2;\n\t\t\t\tvar nearest = 0;\n\t\t\t\tvar nearestDistance = Number.POSITIVE_INFINITY;\n\t\t\t\tlanes.forEach(function (lane, index) {\n\t\t\t\t\tvar rect = lane.getBoundingClientRect();\n\t\t\t\t\tvar distance = Math.abs(rect.left + rect.width / 2 - center);\n\t\t\t\t\tif (distance < nearestDistance) {\n\t\t\t\t\t\tnearest = index;\n\t\t\t\t\t\tnearestDistance = distance;\n\t\t\t\t\t}\n\t\t\t\t});\n\t\t\t\treturn nearest;\n\t\t\t}\n\t\t\tfunction updateLanePosition(scope, root, preferredID) {\n\t\t\t\tvar lanes = visibleBoardLanes(root);\n\t\t\t\tvar index = lanePositionIndex(root, lanes, preferredID);\n\t\t\t\tvar current = index < 0 ? 0 : index + 1;\n\t\t\t\tvar position = queryRoot(scope).querySelector(\"[data-board-lane-position]\");\n\t\t\t\tif (position) {\n\t\t\t\t\tvar currentNode = position.querySelector(\"[data-board-lane-position-current]\");\n\t\t\t\t\tvar totalNode = position.querySelector(\"[data-board-lane-position-total]\");\n\t\t\t\t\tif (currentNode) currentNode.textContent = String(current);\n\t\t\t\t\tif (totalNode) totalNode.textContent = String(lanes.length);\n\t\t\t\t\tposition.setAttribute(\"aria-label\", \"Lane \" + current + \" of \" + lanes.length);\n\t\t\t\t}\n\t\t\t\tif (root.isConnected && index >= 0) activeLaneID = laneID(lanes[index]);\n\t\t\t}\n\t\t\tfunction scheduleLanePosition(root) {\n\t\t\t\tif (!root || !root.isConnected) return;\n\t\t\t\twindow.cancelAnimationFrame(lanePositionFrame);\n\t\t\t\tlanePositionFrame = window.requestAnimationFrame(function () {\n\t\t\t\t\tupdateLanePosition(document, root, \"\");\n\t\t\t\t});\n\t\t\t}\n\t\t\tfunction formatNumber(value) {\n\t\t\t\treturn new Intl.NumberFormat(\"en-US\").format(value);\n\t\t\t}\n\t\t\tfunction cardCountLabel(count, singular, plural) {\n\t\t\t\treturn formatNumber(count) + \" \" + (count === 1 ? singular : plural);\n\t\t\t}\n\t\t\tfunction laneOverrideState(lane, prefs) {\n\t\t\t\tvar id = laneID(lane);\n\t\t\t\tif (prefs.show.has(id)) return stateShow;\n\t\t\t\tif (prefs.hide.has(id)) return stateHide;\n\t\t\t\treturn stateAuto;\n\t\t\t}\n\t\t\tfunction laneVisible(lane, state) {\n\t\t\t\tif (state === stateShow) return true;\n\t\t\t\tif (state === stateHide) return false;\n\t\t\t\treturn laneDefaultVisible(lane);\n\t\t\t}\n\t\t\tfunction stateLabel(lane, state, visible) {\n\t\t\t\tvar label = \"\";\n\t\t\t\tif (state === stateShow) {\n\t\t\t\t\tlabel = \"Always shown\";\n\t\t\t\t} else if (state === stateHide) {\n\t\t\t\t\tlabel = \"Always hidden\";\n\t\t\t\t} else {\n\t\t\t\t\tlabel = visible ? \"Auto shown\" : \"Auto hidden\";\n\t\t\t\t}\n\t\t\t\tif (!visible && laneCardCount(lane) > 0) {\n\t\t\t\t\treturn label + \" - \" + cardCountLabel(laneCardCount(lane), \"hidden card\", \"hidden cards\");\n\t\t\t\t}\n\t\t\t\treturn label;\n\t\t\t}\n\t\t\tfunction stateTitle(lane, state, visible) {\n\t\t\t\tvar title = \"\";\n\t\t\t\tif (state === stateShow) {\n\t\t\t\t\ttitle = \"Always show is saved for this lane.\";\n\t\t\t\t} else if (state === stateHide) {\n\t\t\t\t\ttitle = \"Always hide is saved for this lane.\";\n\t\t\t\t} else {\n\t\t\t\t\ttitle = \"Auto follows the board default.\";\n\t\t\t\t}\n\t\t\t\tif (!visible && laneCardCount(lane) > 0) {\n\t\t\t\t\treturn title + \" \" + cardCountLabel(laneCardCount(lane), \"card is\", \"cards are\") + \" hidden while this lane is off.\";\n\t\t\t\t}\n\t\t\t\treturn title;\n\t\t\t}\n\t\t\tfunction hiddenLaneSummary(lanes) {\n\t\t\t\tif (lanes.length === 0) return \"All populated lanes are visible.\";\n\t\t\t\tif (lanes.length === 1) {\n\t\t\t\t\tvar lane = lanes[0];\n\t\t\t\t\treturn cardCountLabel(lane.count, \"hidden card\", \"hidden cards\") + \" in \" + lane.title + \".\";\n\t\t\t\t}\n\t\t\t\tvar total = lanes.reduce(function (sum, lane) {\n\t\t\t\t\treturn sum + lane.count;\n\t\t\t\t}, 0);\n\t\t\t\tvar labels = lanes.map(function (lane) {\n\t\t\t\t\treturn lane.title + \" (\" + formatNumber(lane.count) + \")\";\n\t\t\t\t}).join(\", \");\n\t\t\t\treturn cardCountLabel(total, \"hidden card\", \"hidden cards\") + \" across \" + cardCountLabel(lanes.length, \"lane\", \"lanes\") + \": \" + labels + \".\";\n\t\t\t}\n\t\t\tfunction setResetDisabled(button, disabled) {\n\t\t\t\tif (!(button instanceof HTMLButtonElement)) return;\n\t\t\t\tbutton.disabled = disabled;\n\t\t\t\tbutton.setAttribute(\"aria-disabled\", disabled ? \"true\" : \"false\");\n\t\t\t}\n\t\t\tfunction updateLaneControls(scope, lane, state, visible) {\n\t\t\t\tvar id = laneID(lane);\n\t\t\t\tvar row = findByData(scope, \"data-board-lane-row\", id);\n\t\t\t\tvar hiddenPopulated = !visible && laneCardCount(lane) > 0;\n\t\t\t\tif (row instanceof HTMLElement) {\n\t\t\t\t\trow.dataset.boardLaneVisibilityState = state;\n\t\t\t\t\trow.dataset.boardLaneVisibilityEffective = visible ? \"visible\" : \"hidden\";\n\t\t\t\t\trow.dataset.boardLaneHiddenPopulated = hiddenPopulated ? \"true\" : \"false\";\n\t\t\t\t\trow.classList.toggle(\"border-warn/45\", hiddenPopulated);\n\t\t\t\t\trow.classList.toggle(\"bg-warn/10\", hiddenPopulated);\n\t\t\t\t\trow.classList.toggle(\"border-transparent\", !hiddenPopulated);\n\t\t\t\t\tvar status = row.querySelector(\"[data-board-lane-visibility-status]\");\n\t\t\t\t\tif (status) {\n\t\t\t\t\t\tstatus.textContent = stateLabel(lane, state, visible);\n\t\t\t\t\t\tstatus.setAttribute(\"title\", stateTitle(lane, state, visible));\n\t\t\t\t\t}\n\t\t\t\t}\n\t\t\t\tvar select = findByData(scope, \"data-board-lane-visibility\", id);\n\t\t\t\tif (select instanceof HTMLSelectElement) {\n\t\t\t\t\tselect.value = state;\n\t\t\t\t\tselect.dataset.boardLaneVisibilityState = state;\n\t\t\t\t\tselect.dataset.boardLaneVisibilityEffective = visible ? \"visible\" : \"hidden\";\n\t\t\t\t\tselect.setAttribute(\"title\", stateTitle(lane, state, visible));\n\t\t\t\t}\n\t\t\t\tsetResetDisabled(findByData(scope, \"data-board-lane-reset\", id), state === stateAuto);\n\t\t\t}\n\t\t\tfunction updateHiddenCardBadge(scope, hiddenCards, hiddenLanes) {\n\t\t\t\tvar root = queryRoot(scope);\n\t\t\t\tvar badge = root.querySelector(\"[data-board-hidden-card-count]\");\n\t\t\t\tif (!badge) return;\n\t\t\t\tvar summary = hiddenLaneSummary(hiddenLanes);\n\t\t\t\tbadge.hidden = hiddenCards === 0;\n\t\t\t\tbadge.textContent = hiddenCards > 0 ? formatNumber(hiddenCards) + \" hidden\" : \"\";\n\t\t\t\tbadge.setAttribute(\"title\", summary);\n\t\t\t\tbadge.setAttribute(\"aria-label\", summary);\n\t\t\t}\n\t\t\tfunction updateResetAll(scope, prefs) {\n\t\t\t\tqueryRoot(scope).querySelectorAll(\"[data-board-lane-reset-all]\").forEach(function (button) {\n\t\t\t\t\tsetResetDisabled(button, !prefsHaveOverrides(prefs));\n\t\t\t\t});\n\t\t\t}\n\t\t\tfunction applyTo(scope) {\n\t\t\t\tvar root = boardLanesRoot(scope);\n\t\t\t\tif (!root) return false;\n\t\t\t\tvar prefs = readPrefs(root);\n\t\t\t\tvar total = 0;\n\t\t\t\tvar visible = 0;\n\t\t\t\tvar hiddenCards = 0;\n\t\t\t\tvar hiddenLanes = [];\n\t\t\t\troot.querySelectorAll(\"[data-board-lane]\").forEach(function (lane) {\n\t\t\t\t\ttotal += 1;\n\t\t\t\t\tvar state = laneOverrideState(lane, prefs);\n\t\t\t\t\tvar show = laneVisible(lane, state);\n\t\t\t\t\tvar cards = laneCardCount(lane);\n\t\t\t\t\tlane.setAttribute(\"data-lane-hidden\", show ? \"false\" : \"true\");\n\t\t\t\t\tlane.setAttribute(\"data-board-lane-visibility-state\", state);\n\t\t\t\t\tlane.setAttribute(\"data-board-lane-pinned\", state === stateAuto ? \"false\" : \"true\");\n\t\t\t\t\tif (show) {\n\t\t\t\t\t\tvisible += 1;\n\t\t\t\t\t} else if (cards > 0) {\n\t\t\t\t\t\thiddenCards += cards;\n\t\t\t\t\t\thiddenLanes.push({ title: laneTitle(lane), count: cards });\n\t\t\t\t\t}\n\t\t\t\t\tupdateLaneControls(scope, lane, state, show);\n\t\t\t\t});\n\t\t\t\tvar count = queryRoot(scope).querySelector(\"[data-board-lane-count]\");\n\t\t\t\tif (count) count.textContent = visible + \"/\" + total;\n\t\t\t\tupdateHiddenCardBadge(scope, hiddenCards, hiddenLanes);\n\t\t\t\tupdateResetAll(scope, prefs);\n\t\t\t\tvar picker = queryRoot(scope).querySelector(\"[data-board-lane-picker]\");\n\t\t\t\tif (picker && pickerOpen) picker.setAttribute(\"open\", \"\");\n\t\t\t\tupdateLanePosition(scope, root, activeLaneID);\n\t\t\t\tif (root.isConnected) scheduleLanePosition(root);\n\t\t\t\tif (typeof window.__detentBoardKanbanDragAdjustSnapshot === \"function\") {\n\t\t\t\t\twindow.__detentBoardKanbanDragAdjustSnapshot(scope);\n\t\t\t\t}\n\t\t\t\treturn true;\n\t\t\t}\n\t\t\tfunction apply() {\n\t\t\t\tapplyTo(document);\n\t\t\t}\n\t\t\tfunction adjustedBoardHTML(html) {\n\t\t\t\tif (typeof html !== \"string\" || html.indexOf(\"data-board-lanes\") < 0) return \"\";\n\t\t\t\tvar template = document.createElement(\"template\");\n\t\t\t\ttemplate.innerHTML = html;\n\t\t\t\tif (!applyTo(template.content)) return \"\";\n\t\t\t\treturn template.innerHTML;\n\t\t\t}\n\t\t\tfunction snapshotSwapTarget(event) {\n\t\t\t\tvar target = event.detail && event.detail.target;\n\t\t\t\tif (!(target instanceof Element)) target = event.target;\n\t\t\t\tif (!(target instanceof Element)) return false;\n\t\t\t\treturn target.id === \"snapshot\" || Boolean(target.closest(\"#snapshot\"));\n\t\t\t}\n\t\t\tfunction applyBeforeSwap(event) {\n\t\t\t\tvar detail = event.detail || {};\n\t\t\t\tif (!snapshotSwapTarget(event) || typeof detail.serverResponse !== \"string\") return;\n\t\t\t\tvar adjusted = adjustedBoardHTML(detail.serverResponse);\n\t\t\t\tif (!adjusted) return;\n\t\t\t\tdetail.serverResponse = adjusted;\n\t\t\t}\n\t\t\tfunction applyBeforeSSEMessage(event) {\n\t\t\t\tvar detail = event.detail || {};\n\t\t\t\tvar target = detail.elt;\n\t\t\t\tif (!(target instanceof Element)) target = event.target;\n\t\t\t\tif (!(target instanceof Element) || target.id !== \"snapshot\") return;\n\t\t\t\tif (!window.htmx || typeof window.htmx.swap !== \"function\") return;\n\t\t\t\tvar adjusted = adjustedBoardHTML(detail.data);\n\t\t\t\tif (!adjusted) return;\n\t\t\t\tevent.preventDefault();\n\t\t\t\twindow.htmx.swap(target, adjusted, { swapStyle: target.getAttribute(\"hx-swap\") || \"innerHTML\" }, { contextElement: target });\n\t\t\t}\n\t\t\tfunction setLaneState(root, id, state) {\n\t\t\t\tvar prefs = readPrefs(root);\n\t\t\t\tprefs.show.delete(id);\n\t\t\t\tprefs.hide.delete(id);\n\t\t\t\tif (state === stateShow) prefs.show.add(id);\n\t\t\t\tif (state === stateHide) prefs.hide.add(id);\n\t\t\t\twritePrefs(root, prefs);\n\t\t\t\tapply();\n\t\t\t}\n\t\t\tdocument.addEventListener(\"change\", function (event) {\n\t\t\t\tvar target = event.target instanceof Element ? event.target : null;\n\t\t\t\tvar select = target ? target.closest(\"[data-board-lane-visibility]\") : null;\n\t\t\t\tif (!(select instanceof HTMLSelectElement)) return;\n\t\t\t\tvar root = document.querySelector(\"[data-board-lanes]\");\n\t\t\t\tif (!root) return;\n\t\t\t\tvar state = select.value;\n\t\t\t\tif (state !== stateShow && state !== stateHide) state = stateAuto;\n\t\t\t\tsetLaneState(root, select.getAttribute(\"data-board-lane-visibility\") || \"\", state);\n\t\t\t});\n\t\t\tdocument.addEventListener(\"toggle\", function (event) {\n\t\t\t\tvar picker = event.target;\n\t\t\t\tif (picker instanceof Element && picker.hasAttribute(\"data-board-lane-picker\")) {\n\t\t\t\t\tpickerOpen = picker.open;\n\t\t\t\t}\n\t\t\t}, true);\n\t\t\tdocument.addEventListener(\"click\", function (event) {\n\t\t\t\tvar target = event.target instanceof Element ? event.target : null;\n\t\t\t\tvar root = document.querySelector(\"[data-board-lanes]\");\n\t\t\t\tvar reset = target ? target.closest(\"[data-board-lane-reset]\") : null;\n\t\t\t\tif (reset instanceof HTMLButtonElement && root) {\n\t\t\t\t\tevent.preventDefault();\n\t\t\t\t\tsetLaneState(root, reset.value || reset.getAttribute(\"data-board-lane-reset\") || \"\", stateAuto);\n\t\t\t\t\treturn;\n\t\t\t\t}\n\t\t\t\tvar resetAll = target ? target.closest(\"[data-board-lane-reset-all]\") : null;\n\t\t\t\tif (resetAll instanceof HTMLButtonElement && root) {\n\t\t\t\t\tevent.preventDefault();\n\t\t\t\t\twritePrefs(root, emptyPrefs());\n\t\t\t\t\tapply();\n\t\t\t\t\treturn;\n\t\t\t\t}\n\t\t\t\tvar picker = document.querySelector(\"[data-board-lane-picker]\");\n\t\t\t\tif (picker && picker.open && !picker.contains(event.target)) {\n\t\t\t\t\tpicker.removeAttribute(\"open\");\n\t\t\t\t\tpickerOpen = false;\n\t\t\t\t}\n\t\t\t});\n\t\t\tdocument.addEventListener(\"keydown\", function (event) {\n\t\t\t\tif (event.key !== \"Escape\") return;\n\t\t\t\tvar picker = document.querySelector(\"[data-board-lane-picker]\");\n\t\t\t\tif (picker && picker.open) {\n\t\t\t\t\tpicker.removeAttribute(\"open\");\n\t\t\t\t\tpickerOpen = false;\n\t\t\t\t}\n\t\t\t});\n\t\t\tdocument.addEventListener(\"htmx:beforeSwap\", applyBeforeSwap);\n\t\t\tdocument.addEventListener(\"htmx:sseBeforeMessage\", applyBeforeSSEMessage);\n\t\t\tdocument.addEventListener(\"htmx:afterSettle\", apply);\n\t\t\tdocument.addEventListener(\"DOMContentLoaded\", apply);\n\t\t\tdocument.addEventListener(\"scroll\", function (event) {\n\t\t\t\tvar root = event.target instanceof Element && event.target.matches(\"[data-board-lanes]\") ? event.target : null;\n\t\t\t\tif (root) scheduleLanePosition(root);\n\t\t\t}, true);\n\t\t\twindow.addEventListener(\"resize\", function () {\n\t\t\t\tscheduleLanePosition(document.querySelector(\"[data-board-lanes]\"));\n\t\t\t});\n\t\t\twindow.addEventListener(\"storage\", function (event) {\n\t\t\t\tif (event.key && event.key.indexOf(storagePrefix) === 0) apply();\n\t\t\t});\n\t\t\tapply();\n\t\t})();\n\t</script>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 216, "<script>\n\t\t(function () {\n\t\t\tvar storagePrefix = \"detent.ui.board.lanes.v2.\";\n\t\t\tvar legacyStoragePrefix = \"detent.ui.board.lanes.\";\n\t\t\tvar storageVersion = 1;\n\t\t\tvar stateAuto = \"auto\";\n\t\t\tvar stateShow = \"show\";\n\t\t\tvar stateHide = \"hide\";\n\t\t\tvar pickerOpen = false;\n\t\t\tvar activeLaneID = \"\";\n\t\t\tvar lanePositionFrame = 0;\n\n\t\t\tfunction visibilityStorage() {\n\t\t\t\ttry {\n\t\t\t\t\treturn window.localStorage;\n\t\t\t\t} catch (err) {\n\t\t\t\t\treturn null;\n\t\t\t\t}\n\t\t\t}\n\t\t\tfunction storageKey(root) {\n\t\t\t\treturn storagePrefix + (root.getAttribute(\"data-board-key\") || \"fleet\");\n\t\t\t}\n\t\t\tfunction legacyStorageKey(root) {\n\t\t\t\treturn legacyStoragePrefix + (root.getAttribute(\"data-board-key\") || \"fleet\");\n\t\t\t}\n\t\t\tfunction emptyPrefs() {\n\t\t\t\treturn { show: new Set(), hide: new Set() };\n\t\t\t}\n\t\t\tfunction laneIDSet(ids) {\n\t\t\t\tvar out = new Set();\n\t\t\t\tif (!Array.isArray(ids)) return out;\n\t\t\t\tids.forEach(function (id) {\n\t\t\t\t\tif (typeof id === \"string\" && id.trim() !== \"\") out.add(id);\n\t\t\t\t});\n\t\t\t\treturn out;\n\t\t\t}\n\t\t\tfunction normalizedPrefs(showIDs, hideIDs) {\n\t\t\t\tvar prefs = emptyPrefs();\n\t\t\t\tlaneIDSet(showIDs).forEach(function (id) {\n\t\t\t\t\tprefs.show.add(id);\n\t\t\t\t});\n\t\t\t\tlaneIDSet(hideIDs).forEach(function (id) {\n\t\t\t\t\tif (!prefs.show.has(id)) prefs.hide.add(id);\n\t\t\t\t});\n\t\t\t\treturn prefs;\n\t\t\t}\n\t\t\tfunction discardLegacyPrefs(root, store) {\n\t\t\t\tvar legacy = legacyStorageKey(root);\n\t\t\t\ttry {\n\t\t\t\t\tif (legacy !== storageKey(root)) store.removeItem(legacy);\n\t\t\t\t} catch (err) {}\n\t\t\t}\n\t\t\tfunction readPrefs(root) {\n\t\t\t\tvar store = visibilityStorage();\n\t\t\t\tif (!store) return emptyPrefs();\n\t\t\t\tdiscardLegacyPrefs(root, store);\n\t\t\t\tvar raw = \"\";\n\t\t\t\ttry {\n\t\t\t\t\traw = store.getItem(storageKey(root));\n\t\t\t\t} catch (err) {\n\t\t\t\t\treturn emptyPrefs();\n\t\t\t\t}\n\t\t\t\tif (!raw) return emptyPrefs();\n\t\t\t\ttry {\n\t\t\t\t\tvar parsed = JSON.parse(raw);\n\t\t\t\t\tif (!parsed || parsed.v !== storageVersion) {\n\t\t\t\t\t\ttry {\n\t\t\t\t\t\t\tstore.removeItem(storageKey(root));\n\t\t\t\t\t\t} catch (err) {}\n\t\t\t\t\t\treturn emptyPrefs();\n\t\t\t\t\t}\n\t\t\t\t\treturn normalizedPrefs(parsed.show, parsed.hide);\n\t\t\t\t} catch (err) {\n\t\t\t\t\ttry {\n\t\t\t\t\t\tstore.removeItem(storageKey(root));\n\t\t\t\t\t} catch (err) {}\n\t\t\t\t\treturn emptyPrefs();\n\t\t\t\t}\n\t\t\t}\n\t\t\tfunction writePrefs(root, prefs) {\n\t\t\t\tvar store = visibilityStorage();\n\t\t\t\tif (!store) return;\n\t\t\t\tvar show = Array.from(prefs.show).filter(Boolean).sort();\n\t\t\t\tvar hide = Array.from(prefs.hide).filter(function (id) {\n\t\t\t\t\treturn Boolean(id) && !prefs.show.has(id);\n\t\t\t\t}).sort();\n\t\t\t\tif (show.length === 0 && hide.length === 0) {\n\t\t\t\t\ttry {\n\t\t\t\t\t\tstore.removeItem(storageKey(root));\n\t\t\t\t\t} catch (err) {}\n\t\t\t\t\treturn;\n\t\t\t\t}\n\t\t\t\ttry {\n\t\t\t\t\tstore.setItem(storageKey(root), JSON.stringify({ v: storageVersion, show: show, hide: hide }));\n\t\t\t\t} catch (err) {}\n\t\t\t}\n\t\t\tfunction prefsHaveOverrides(prefs) {\n\t\t\t\treturn prefs.show.size > 0 || prefs.hide.size > 0;\n\t\t\t}\n\t\t\tfunction queryRoot(scope) {\n\t\t\t\tif (scope && typeof scope.querySelector === \"function\" && typeof scope.querySelectorAll === \"function\") return scope;\n\t\t\t\treturn document;\n\t\t\t}\n\t\t\tfunction boardLanesRoot(scope) {\n\t\t\t\tif (scope instanceof Element && scope.matches(\"[data-board-lanes]\")) return scope;\n\t\t\t\tif (scope && typeof scope.querySelector === \"function\") return scope.querySelector(\"[data-board-lanes]\");\n\t\t\t\treturn null;\n\t\t\t}\n\t\t\tfunction findByData(scope, attr, value) {\n\t\t\t\tvar root = queryRoot(scope);\n\t\t\t\tvar nodes = root.querySelectorAll(\"[\" + attr + \"]\");\n\t\t\t\tfor (var i = 0; i < nodes.length; i += 1) {\n\t\t\t\t\tif (nodes[i].getAttribute(attr) === value) return nodes[i];\n\t\t\t\t}\n\t\t\t\treturn null;\n\t\t\t}\n\t\t\tfunction laneID(lane) {\n\t\t\t\treturn lane.getAttribute(\"data-board-lane\") || \"\";\n\t\t\t}\n\t\t\tfunction laneDefaultVisible(lane) {\n\t\t\t\treturn lane.getAttribute(\"data-board-lane-default\") === \"true\";\n\t\t\t}\n\t\t\tfunction laneCardCount(lane) {\n\t\t\t\tvar parsed = Number.parseInt(lane.getAttribute(\"data-board-lane-card-count\") || \"0\", 10);\n\t\t\t\tif (!Number.isFinite(parsed) || parsed < 0) return 0;\n\t\t\t\treturn parsed;\n\t\t\t}\n\t\t\tfunction laneTitle(lane) {\n\t\t\t\treturn lane.getAttribute(\"data-board-lane-title\") || \"lane\";\n\t\t\t}\n\t\t\tfunction visibleBoardLanes(root) {\n\t\t\t\treturn Array.from(root.querySelectorAll(\"[data-board-lane]\")).filter(function (lane) {\n\t\t\t\t\treturn lane.getAttribute(\"data-lane-hidden\") !== \"true\";\n\t\t\t\t});\n\t\t\t}\n\t\t\tfunction lanePositionIndex(root, lanes, preferredID) {\n\t\t\t\tif (lanes.length === 0) return -1;\n\t\t\t\tif (preferredID) {\n\t\t\t\t\tvar preferred = lanes.findIndex(function (lane) {\n\t\t\t\t\t\treturn laneID(lane) === preferredID;\n\t\t\t\t\t});\n\t\t\t\t\tif (preferred >= 0) return preferred;\n\t\t\t\t}\n\t\t\t\tif (!root.isConnected) return 0;\n\t\t\t\tvar rootRect = root.getBoundingClientRect();\n\t\t\t\tvar center = rootRect.left + root.clientWidth / 2;\n\t\t\t\tvar nearest = 0;\n\t\t\t\tvar nearestDistance = Number.POSITIVE_INFINITY;\n\t\t\t\tlanes.forEach(function (lane, index) {\n\t\t\t\t\tvar rect = lane.getBoundingClientRect();\n\t\t\t\t\tvar distance = Math.abs(rect.left + rect.width / 2 - center);\n\t\t\t\t\tif (distance < nearestDistance) {\n\t\t\t\t\t\tnearest = index;\n\t\t\t\t\t\tnearestDistance = distance;\n\t\t\t\t\t}\n\t\t\t\t});\n\t\t\t\treturn nearest;\n\t\t\t}\n\t\t\tfunction updateLanePosition(scope, root, preferredID) {\n\t\t\t\tvar lanes = visibleBoardLanes(root);\n\t\t\t\tvar index = lanePositionIndex(root, lanes, preferredID);\n\t\t\t\tvar current = index < 0 ? 0 : index + 1;\n\t\t\t\tvar position = queryRoot(scope).querySelector(\"[data-board-lane-position]\");\n\t\t\t\tif (position) {\n\t\t\t\t\tvar currentNode = position.querySelector(\"[data-board-lane-position-current]\");\n\t\t\t\t\tvar totalNode = position.querySelector(\"[data-board-lane-position-total]\");\n\t\t\t\t\tif (currentNode) currentNode.textContent = String(current);\n\t\t\t\t\tif (totalNode) totalNode.textContent = String(lanes.length);\n\t\t\t\t\tposition.setAttribute(\"aria-label\", \"Lane \" + current + \" of \" + lanes.length);\n\t\t\t\t}\n\t\t\t\tif (root.isConnected && index >= 0) activeLaneID = laneID(lanes[index]);\n\t\t\t}\n\t\t\tfunction scheduleLanePosition(root) {\n\t\t\t\tif (!root || !root.isConnected) return;\n\t\t\t\twindow.cancelAnimationFrame(lanePositionFrame);\n\t\t\t\tlanePositionFrame = window.requestAnimationFrame(function () {\n\t\t\t\t\tupdateLanePosition(document, root, \"\");\n\t\t\t\t});\n\t\t\t}\n\t\t\tfunction formatNumber(value) {\n\t\t\t\treturn new Intl.NumberFormat(\"en-US\").format(value);\n\t\t\t}\n\t\t\tfunction cardCountLabel(count, singular, plural) {\n\t\t\t\treturn formatNumber(count) + \" \" + (count === 1 ? singular : plural);\n\t\t\t}\n\t\t\tfunction laneOverrideState(lane, prefs) {\n\t\t\t\tvar id = laneID(lane);\n\t\t\t\tif (prefs.show.has(id)) return stateShow;\n\t\t\t\tif (prefs.hide.has(id)) return stateHide;\n\t\t\t\treturn stateAuto;\n\t\t\t}\n\t\t\tfunction laneVisible(lane, state) {\n\t\t\t\tif (state === stateShow) return true;\n\t\t\t\tif (state === stateHide) return false;\n\t\t\t\treturn laneDefaultVisible(lane);\n\t\t\t}\n\t\t\tfunction stateLabel(lane, state, visible) {\n\t\t\t\tvar label = \"\";\n\t\t\t\tif (state === stateShow) {\n\t\t\t\t\tlabel = \"Always shown\";\n\t\t\t\t} else if (state === stateHide) {\n\t\t\t\t\tlabel = \"Always hidden\";\n\t\t\t\t} else {\n\t\t\t\t\tlabel = visible ? \"Auto shown\" : \"Auto hidden\";\n\t\t\t\t}\n\t\t\t\tif (!visible && laneCardCount(lane) > 0) {\n\t\t\t\t\treturn label + \" - \" + cardCountLabel(laneCardCount(lane), \"hidden card\", \"hidden cards\");\n\t\t\t\t}\n\t\t\t\treturn label;\n\t\t\t}\n\t\t\tfunction stateTitle(lane, state, visible) {\n\t\t\t\tvar title = \"\";\n\t\t\t\tif (state === stateShow) {\n\t\t\t\t\ttitle = \"Always show is saved for this lane.\";\n\t\t\t\t} else if (state === stateHide) {\n\t\t\t\t\ttitle = \"Always hide is saved for this lane.\";\n\t\t\t\t} else {\n\t\t\t\t\ttitle = \"Auto follows the board default.\";\n\t\t\t\t}\n\t\t\t\tif (!visible && laneCardCount(lane) > 0) {\n\t\t\t\t\treturn title + \" \" + cardCountLabel(laneCardCount(lane), \"card is\", \"cards are\") + \" hidden while this lane is off.\";\n\t\t\t\t}\n\t\t\t\treturn title;\n\t\t\t}\n\t\t\tfunction hiddenLaneSummary(lanes) {\n\t\t\t\tif (lanes.length === 0) return \"All populated lanes are visible.\";\n\t\t\t\tif (lanes.length === 1) {\n\t\t\t\t\tvar lane = lanes[0];\n\t\t\t\t\treturn cardCountLabel(lane.count, \"hidden card\", \"hidden cards\") + \" in \" + lane.title + \".\";\n\t\t\t\t}\n\t\t\t\tvar total = lanes.reduce(function (sum, lane) {\n\t\t\t\t\treturn sum + lane.count;\n\t\t\t\t}, 0);\n\t\t\t\tvar labels = lanes.map(function (lane) {\n\t\t\t\t\treturn lane.title + \" (\" + formatNumber(lane.count) + \")\";\n\t\t\t\t}).join(\", \");\n\t\t\t\treturn cardCountLabel(total, \"hidden card\", \"hidden cards\") + \" across \" + cardCountLabel(lanes.length, \"lane\", \"lanes\") + \": \" + labels + \".\";\n\t\t\t}\n\t\t\tfunction setResetDisabled(button, disabled) {\n\t\t\t\tif (!(button instanceof HTMLButtonElement)) return;\n\t\t\t\tbutton.disabled = disabled;\n\t\t\t\tbutton.setAttribute(\"aria-disabled\", disabled ? \"true\" : \"false\");\n\t\t\t}\n\t\t\tfunction updateLaneControls(scope, lane, state, visible) {\n\t\t\t\tvar id = laneID(lane);\n\t\t\t\tvar row = findByData(scope, \"data-board-lane-row\", id);\n\t\t\t\tvar hiddenPopulated = !visible && laneCardCount(lane) > 0;\n\t\t\t\tif (row instanceof HTMLElement) {\n\t\t\t\t\trow.dataset.boardLaneVisibilityState = state;\n\t\t\t\t\trow.dataset.boardLaneVisibilityEffective = visible ? \"visible\" : \"hidden\";\n\t\t\t\t\trow.dataset.boardLaneHiddenPopulated = hiddenPopulated ? \"true\" : \"false\";\n\t\t\t\t\trow.classList.toggle(\"border-warn/45\", hiddenPopulated);\n\t\t\t\t\trow.classList.toggle(\"bg-warn/10\", hiddenPopulated);\n\t\t\t\t\trow.classList.toggle(\"border-transparent\", !hiddenPopulated);\n\t\t\t\t\tvar status = row.querySelector(\"[data-board-lane-visibility-status]\");\n\t\t\t\t\tif (status) {\n\t\t\t\t\t\tstatus.textContent = stateLabel(lane, state, visible);\n\t\t\t\t\t\tstatus.setAttribute(\"title\", stateTitle(lane, state, visible));\n\t\t\t\t\t}\n\t\t\t\t}\n\t\t\t\tvar select = findByData(scope, \"data-board-lane-visibility\", id);\n\t\t\t\tif (select instanceof HTMLSelectElement) {\n\t\t\t\t\tselect.value = state;\n\t\t\t\t\tselect.dataset.boardLaneVisibilityState = state;\n\t\t\t\t\tselect.dataset.boardLaneVisibilityEffective = visible ? \"visible\" : \"hidden\";\n\t\t\t\t\tselect.setAttribute(\"title\", stateTitle(lane, state, visible));\n\t\t\t\t}\n\t\t\t\tsetResetDisabled(findByData(scope, \"data-board-lane-reset\", id), state === stateAuto);\n\t\t\t}\n\t\t\tfunction updateHiddenCardBadge(scope, hiddenCards, hiddenLanes) {\n\t\t\t\tvar root = queryRoot(scope);\n\t\t\t\tvar badge = root.querySelector(\"[data-board-hidden-card-count]\");\n\t\t\t\tif (!badge) return;\n\t\t\t\tvar summary = hiddenLaneSummary(hiddenLanes);\n\t\t\t\tbadge.hidden = hiddenCards === 0;\n\t\t\t\tbadge.textContent = hiddenCards > 0 ? formatNumber(hiddenCards) + \" hidden\" : \"\";\n\t\t\t\tbadge.setAttribute(\"title\", summary);\n\t\t\t\tbadge.setAttribute(\"aria-label\", summary);\n\t\t\t}\n\t\t\tfunction updateResetAll(scope, prefs) {\n\t\t\t\tqueryRoot(scope).querySelectorAll(\"[data-board-lane-reset-all]\").forEach(function (button) {\n\t\t\t\t\tsetResetDisabled(button, !prefsHaveOverrides(prefs));\n\t\t\t\t});\n\t\t\t}\n\t\t\tfunction applyTo(scope) {\n\t\t\t\tvar root = boardLanesRoot(scope);\n\t\t\t\tif (!root) return false;\n\t\t\t\tvar prefs = readPrefs(root);\n\t\t\t\tvar total = 0;\n\t\t\t\tvar visible = 0;\n\t\t\t\tvar hiddenCards = 0;\n\t\t\t\tvar hiddenLanes = [];\n\t\t\t\troot.querySelectorAll(\"[data-board-lane]\").forEach(function (lane) {\n\t\t\t\t\ttotal += 1;\n\t\t\t\t\tvar state = laneOverrideState(lane, prefs);\n\t\t\t\t\tvar show = laneVisible(lane, state);\n\t\t\t\t\tvar cards = laneCardCount(lane);\n\t\t\t\t\tlane.setAttribute(\"data-lane-hidden\", show ? \"false\" : \"true\");\n\t\t\t\t\tlane.setAttribute(\"data-board-lane-visibility-state\", state);\n\t\t\t\t\tlane.setAttribute(\"data-board-lane-pinned\", state === stateAuto ? \"false\" : \"true\");\n\t\t\t\t\tif (show) {\n\t\t\t\t\t\tvisible += 1;\n\t\t\t\t\t} else if (cards > 0) {\n\t\t\t\t\t\thiddenCards += cards;\n\t\t\t\t\t\thiddenLanes.push({ title: laneTitle(lane), count: cards });\n\t\t\t\t\t}\n\t\t\t\t\tupdateLaneControls(scope, lane, state, show);\n\t\t\t\t});\n\t\t\t\tvar count = queryRoot(scope).querySelector(\"[data-board-lane-count]\");\n\t\t\t\tif (count) count.textContent = visible + \"/\" + total;\n\t\t\t\tupdateHiddenCardBadge(scope, hiddenCards, hiddenLanes);\n\t\t\t\tupdateResetAll(scope, prefs);\n\t\t\t\tvar picker = queryRoot(scope).querySelector(\"[data-board-lane-picker]\");\n\t\t\t\tif (picker && pickerOpen) picker.setAttribute(\"open\", \"\");\n\t\t\t\tupdateLanePosition(scope, root, activeLaneID);\n\t\t\t\tif (root.isConnected) scheduleLanePosition(root);\n\t\t\t\tif (typeof window.__detentBoardKanbanDragAdjustSnapshot === \"function\") {\n\t\t\t\t\twindow.__detentBoardKanbanDragAdjustSnapshot(scope);\n\t\t\t\t}\n\t\t\t\treturn true;\n\t\t\t}\n\t\t\tfunction apply() {\n\t\t\t\tapplyTo(document);\n\t\t\t}\n\t\t\tfunction adjustedBoardHTML(html) {\n\t\t\t\tif (typeof html !== \"string\" || html.indexOf(\"data-board-lanes\") < 0) return \"\";\n\t\t\t\tvar template = document.createElement(\"template\");\n\t\t\t\ttemplate.innerHTML = html;\n\t\t\t\tif (!applyTo(template.content)) return \"\";\n\t\t\t\treturn template.innerHTML;\n\t\t\t}\n\t\t\tfunction snapshotSwapTarget(event) {\n\t\t\t\tvar target = event.detail && event.detail.target;\n\t\t\t\tif (!(target instanceof Element)) target = event.target;\n\t\t\t\tif (!(target instanceof Element)) return false;\n\t\t\t\treturn target.id === \"snapshot\" || Boolean(target.closest(\"#snapshot\"));\n\t\t\t}\n\t\t\tfunction applyBeforeSwap(event) {\n\t\t\t\tvar detail = event.detail || {};\n\t\t\t\tif (!snapshotSwapTarget(event) || typeof detail.serverResponse !== \"string\") return;\n\t\t\t\tvar adjusted = adjustedBoardHTML(detail.serverResponse);\n\t\t\t\tif (!adjusted) return;\n\t\t\t\tdetail.serverResponse = adjusted;\n\t\t\t}\n\t\t\tfunction applyBeforeSSEMessage(event) {\n\t\t\t\tvar detail = event.detail || {};\n\t\t\t\tvar target = detail.elt;\n\t\t\t\tif (!(target instanceof Element)) target = event.target;\n\t\t\t\tif (!(target instanceof Element) || target.id !== \"snapshot\") return;\n\t\t\t\tif (!window.htmx || typeof window.htmx.swap !== \"function\") return;\n\t\t\t\tvar adjusted = adjustedBoardHTML(detail.data);\n\t\t\t\tif (!adjusted) return;\n\t\t\t\tevent.preventDefault();\n\t\t\t\twindow.htmx.swap(target, adjusted, { swapStyle: target.getAttribute(\"hx-swap\") || \"innerHTML\" }, { contextElement: target });\n\t\t\t}\n\t\t\tfunction setLaneState(root, id, state) {\n\t\t\t\tvar prefs = readPrefs(root);\n\t\t\t\tprefs.show.delete(id);\n\t\t\t\tprefs.hide.delete(id);\n\t\t\t\tif (state === stateShow) prefs.show.add(id);\n\t\t\t\tif (state === stateHide) prefs.hide.add(id);\n\t\t\t\twritePrefs(root, prefs);\n\t\t\t\tapply();\n\t\t\t}\n\t\t\tdocument.addEventListener(\"change\", function (event) {\n\t\t\t\tvar target = event.target instanceof Element ? event.target : null;\n\t\t\t\tvar select = target ? target.closest(\"[data-board-lane-visibility]\") : null;\n\t\t\t\tif (!(select instanceof HTMLSelectElement)) return;\n\t\t\t\tvar root = document.querySelector(\"[data-board-lanes]\");\n\t\t\t\tif (!root) return;\n\t\t\t\tvar state = select.value;\n\t\t\t\tif (state !== stateShow && state !== stateHide) state = stateAuto;\n\t\t\t\tsetLaneState(root, select.getAttribute(\"data-board-lane-visibility\") || \"\", state);\n\t\t\t});\n\t\t\tdocument.addEventListener(\"toggle\", function (event) {\n\t\t\t\tvar picker = event.target;\n\t\t\t\tif (picker instanceof Element && picker.hasAttribute(\"data-board-lane-picker\")) {\n\t\t\t\t\tpickerOpen = picker.open;\n\t\t\t\t}\n\t\t\t}, true);\n\t\t\tdocument.addEventListener(\"click\", function (event) {\n\t\t\t\tvar target = event.target instanceof Element ? event.target : null;\n\t\t\t\tvar root = document.querySelector(\"[data-board-lanes]\");\n\t\t\t\tvar reset = target ? target.closest(\"[data-board-lane-reset]\") : null;\n\t\t\t\tif (reset instanceof HTMLButtonElement && root) {\n\t\t\t\t\tevent.preventDefault();\n\t\t\t\t\tsetLaneState(root, reset.value || reset.getAttribute(\"data-board-lane-reset\") || \"\", stateAuto);\n\t\t\t\t\treturn;\n\t\t\t\t}\n\t\t\t\tvar resetAll = target ? target.closest(\"[data-board-lane-reset-all]\") : null;\n\t\t\t\tif (resetAll instanceof HTMLButtonElement && root) {\n\t\t\t\t\tevent.preventDefault();\n\t\t\t\t\twritePrefs(root, emptyPrefs());\n\t\t\t\t\tapply();\n\t\t\t\t\treturn;\n\t\t\t\t}\n\t\t\t\tvar picker = document.querySelector(\"[data-board-lane-picker]\");\n\t\t\t\tif (picker && picker.open && !picker.contains(event.target)) {\n\t\t\t\t\tpicker.removeAttribute(\"open\");\n\t\t\t\t\tpickerOpen = false;\n\t\t\t\t}\n\t\t\t});\n\t\t\tdocument.addEventListener(\"keydown\", function (event) {\n\t\t\t\tif (event.key !== \"Escape\") return;\n\t\t\t\tvar picker = document.querySelector(\"[data-board-lane-picker]\");\n\t\t\t\tif (picker && picker.open) {\n\t\t\t\t\tpicker.removeAttribute(\"open\");\n\t\t\t\t\tpickerOpen = false;\n\t\t\t\t}\n\t\t\t});\n\t\t\tdocument.addEventListener(\"htmx:beforeSwap\", applyBeforeSwap);\n\t\t\tdocument.addEventListener(\"htmx:sseBeforeMessage\", applyBeforeSSEMessage);\n\t\t\tdocument.addEventListener(\"htmx:afterSettle\", apply);\n\t\t\tdocument.addEventListener(\"DOMContentLoaded\", apply);\n\t\t\tdocument.addEventListener(\"scroll\", function (event) {\n\t\t\t\tvar root = event.target instanceof Element && event.target.matches(\"[data-board-lanes]\") ? event.target : null;\n\t\t\t\tif (root) scheduleLanePosition(root);\n\t\t\t}, true);\n\t\t\twindow.addEventListener(\"resize\", function () {\n\t\t\t\tscheduleLanePosition(document.querySelector(\"[data-board-lanes]\"));\n\t\t\t});\n\t\t\twindow.addEventListener(\"storage\", function (event) {\n\t\t\t\tif (event.key && event.key.indexOf(storagePrefix) === 0) apply();\n\t\t\t});\n\t\t\tapply();\n\t\t})();\n\t</script>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -2585,12 +2612,12 @@ func boardKanbanDragScript() templ.Component {
 			}()
 		}
 		ctx = templ.InitializeContext(ctx)
-		templ_7745c5c3_Var137 := templ.GetChildren(ctx)
-		if templ_7745c5c3_Var137 == nil {
-			templ_7745c5c3_Var137 = templ.NopComponent
+		templ_7745c5c3_Var138 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var138 == nil {
+			templ_7745c5c3_Var138 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 214, "<script>\n\t\t(function () {\n\t\t\tif (window.__detentBoardKanbanDragHandlersRegistered) return;\n\t\t\twindow.__detentBoardKanbanDragHandlersRegistered = true;\n\t\t\tvar DRAG_THRESHOLD_PX = 6;\n\t\t\tvar TOUCH_MOVE_TOLERANCE_PX = 10;\n\t\t\tvar TOUCH_LONG_PRESS_MS = 450;\n\t\t\tvar TOUCH_EDGE_ZONE_PX = 56;\n\t\t\tvar TOUCH_EDGE_ADVANCE_MS = 500;\n\t\t\t// Real mouse clicks travel a few pixels between press and release,\n\t\t\t// so distance alone cannot separate a click from a drag. A short\n\t\t\t// gesture released back over the source lane is a click: finish the\n\t\t\t// drag without swallowing the click so the detail sheet still opens.\n\t\t\tvar CLICK_GESTURE_MS = 250;\n\t\t\tvar draggedIssueID = \"\";\n\t\t\tvar draggedAllowedTargetKeys = [];\n\t\t\tvar pending = null;\n\t\t\tvar active = null;\n\t\t\tvar recentTouchStart = null;\n\t\t\tfunction clearPending() {\n\t\t\t\tif (pending && pending.longPressTimer) window.clearTimeout(pending.longPressTimer);\n\t\t\t\tpending = null;\n\t\t\t\trecentTouchStart = null;\n\t\t\t}\n\t\t\tfunction touchWithIdentifier(touches, identifier) {\n\t\t\t\tif (!touches || identifier === null || identifier === undefined) return null;\n\t\t\t\tfor (var index = 0; index < touches.length; index += 1) {\n\t\t\t\t\tif (touches[index].identifier === identifier) return touches[index];\n\t\t\t\t}\n\t\t\t\treturn null;\n\t\t\t}\n\t\t\tfunction recentTouchIdentifier(card, event) {\n\t\t\t\tif (event.pointerType !== \"touch\" || !recentTouchStart) return null;\n\t\t\t\tif (Date.now() - recentTouchStart.startedAt >= 100) return null;\n\t\t\t\tif (!(recentTouchStart.target instanceof Node) || !card.contains(recentTouchStart.target)) return null;\n\t\t\t\treturn recentTouchStart.identifier;\n\t\t\t}\n\t\t\tfunction feedback(message, kind) {\n\t\t\t\tvar target = document.getElementById(\"board-feedback\");\n\t\t\t\tif (!target) return;\n\t\t\t\tvar text = String(message || \"\").trim();\n\t\t\t\ttarget.className = \"flex flex-none items-center gap-2 px-5 pt-3.5 text-xs \" + (kind === \"error\" ? \"text-err\" : \"text-sec\");\n\t\t\t\ttarget.textContent = text;\n\t\t\t\ttarget.hidden = text === \"\";\n\t\t\t}\n\t\t\tfunction queryRoot(scope) {\n\t\t\t\tif (scope && typeof scope.querySelector === \"function\" && typeof scope.querySelectorAll === \"function\") return scope;\n\t\t\t\treturn document;\n\t\t\t}\n\t\t\tfunction draggedCard(scope) {\n\t\t\t\tif (!draggedIssueID || !window.CSS || typeof CSS.escape !== \"function\") return null;\n\t\t\t\treturn queryRoot(scope).querySelector(\"[data-kanban-card][data-kanban-issue-id='\" + CSS.escape(draggedIssueID) + \"']\");\n\t\t\t}\n\t\t\tfunction cardByIssueID(scope, issueID) {\n\t\t\t\tvar cards = queryRoot(scope).querySelectorAll(\"[data-kanban-card][data-kanban-issue-id]\");\n\t\t\t\tfor (var index = 0; index < cards.length; index += 1) {\n\t\t\t\t\tif (cards[index].dataset.kanbanIssueId === issueID) return cards[index];\n\t\t\t\t}\n\t\t\t\treturn null;\n\t\t\t}\n\t\t\tfunction laneByState(scope, state) {\n\t\t\t\tvar lanes = queryRoot(scope).querySelectorAll(\"[data-kanban-drop-state]\");\n\t\t\t\tfor (var index = 0; index < lanes.length; index += 1) {\n\t\t\t\t\tif (lanes[index].dataset.kanbanDropState === state) return lanes[index];\n\t\t\t\t}\n\t\t\t\treturn null;\n\t\t\t}\n\t\t\tfunction cardContainer(lane) {\n\t\t\t\treturn lane instanceof HTMLElement ? lane.querySelector(\"[data-kanban-card-container]\") : null;\n\t\t\t}\n\t\t\tfunction updateEmptyLine(container) {\n\t\t\t\tif (!(container instanceof HTMLElement)) return;\n\t\t\t\tvar emptyLine = container.querySelector(\"[data-kanban-empty-line]\");\n\t\t\t\tif (emptyLine instanceof HTMLElement) emptyLine.hidden = Boolean(container.querySelector(\"[data-kanban-card]\"));\n\t\t\t}\n\t\t\tfunction placeCardInLane(card, state, scope) {\n\t\t\t\tvar lane = laneByState(scope, state);\n\t\t\t\tvar container = cardContainer(lane);\n\t\t\t\tif (!(card instanceof HTMLElement) || !(lane instanceof HTMLElement) || !(container instanceof HTMLElement)) return null;\n\t\t\t\tvar previousContainer = card.parentElement;\n\t\t\t\tcontainer.appendChild(card);\n\t\t\t\tlane.dataset.laneHidden = \"false\";\n\t\t\t\tupdateEmptyLine(previousContainer);\n\t\t\t\tupdateEmptyLine(container);\n\t\t\t\treturn lane;\n\t\t\t}\n\t\t\tfunction copyPendingMove(source, target) {\n\t\t\t\t[\n\t\t\t\t\t\"kanbanPendingMove\",\n\t\t\t\t\t\"kanbanPendingOrigin\",\n\t\t\t\t\t\"kanbanPendingSeq\",\n\t\t\t\t\t\"kanbanPendingTargetWasHidden\"\n\t\t\t\t].forEach(function (key) {\n\t\t\t\t\tif (source.dataset[key] === undefined) {\n\t\t\t\t\t\tdelete target.dataset[key];\n\t\t\t\t\t} else {\n\t\t\t\t\t\ttarget.dataset[key] = source.dataset[key];\n\t\t\t\t\t}\n\t\t\t\t});\n\t\t\t}\n\t\t\tfunction clearPendingMove(card) {\n\t\t\t\tif (!(card instanceof HTMLElement)) return;\n\t\t\t\tdelete card.dataset.kanbanPendingMove;\n\t\t\t\tdelete card.dataset.kanbanPendingOrigin;\n\t\t\t\tdelete card.dataset.kanbanPendingSeq;\n\t\t\t\tdelete card.dataset.kanbanPendingTargetWasHidden;\n\t\t\t}\n\t\t\tfunction pendingMoveSuperseded(liveCard, serverCard) {\n\t\t\t\tvar targetState = liveCard.dataset.kanbanPendingMove || \"\";\n\t\t\t\tif ((serverCard.dataset.kanbanCurrentState || \"\") === targetState) return true;\n\t\t\t\tvar pendingSeq = Number.parseInt(liveCard.dataset.kanbanPendingSeq || \"\", 10);\n\t\t\t\tvar serverSeq = Number.parseInt(serverCard.dataset.kanbanDataSeq || \"\", 10);\n\t\t\t\treturn Number.isFinite(pendingSeq) && Number.isFinite(serverSeq) && serverSeq > pendingSeq;\n\t\t\t}\n\t\t\tfunction applyPendingMoveState(scope) {\n\t\t\t\tvar root = queryRoot(scope);\n\t\t\t\tvar applied = false;\n\t\t\t\tdocument.querySelectorAll(\"#snapshot [data-kanban-card][data-kanban-pending-move]\").forEach(function (liveCard) {\n\t\t\t\t\tif (!(liveCard instanceof HTMLElement)) return;\n\t\t\t\t\tvar issueID = liveCard.dataset.kanbanIssueId || \"\";\n\t\t\t\t\tvar serverCard = cardByIssueID(root, issueID);\n\t\t\t\t\tif (!(serverCard instanceof HTMLElement)) return;\n\t\t\t\t\tif (pendingMoveSuperseded(liveCard, serverCard)) {\n\t\t\t\t\t\tif (serverCard === liveCard) clearPendingMove(serverCard);\n\t\t\t\t\t\treturn;\n\t\t\t\t\t}\n\t\t\t\t\tcopyPendingMove(liveCard, serverCard);\n\t\t\t\t\tif (placeCardInLane(serverCard, liveCard.dataset.kanbanPendingMove || \"\", root)) applied = true;\n\t\t\t\t});\n\t\t\t\treturn applied;\n\t\t\t}\n\t\t\tfunction targetKeysFromValue(value) {\n\t\t\t\treturn String(value || \"\").split(/\\s+/).filter(Boolean);\n\t\t\t}\n\t\t\tfunction allowedTargetKeys(card) {\n\t\t\t\tif (card instanceof HTMLElement) {\n\t\t\t\t\tvar keys = targetKeysFromValue(card.dataset.kanbanAllowedTargets || \"\");\n\t\t\t\t\tif (keys.length > 0) return keys;\n\t\t\t\t}\n\t\t\t\treturn draggedAllowedTargetKeys.slice();\n\t\t\t}\n\t\t\tfunction laneAllowed(card, lane) {\n\t\t\t\tif (!(lane instanceof HTMLElement)) return false;\n\t\t\t\tvar key = lane.dataset.kanbanDropKey || \"\";\n\t\t\t\treturn key !== \"\" && allowedTargetKeys(card).includes(key);\n\t\t\t}\n\t\t\tfunction setDropTargetState(card, scope) {\n\t\t\t\tvar sourceLane = card instanceof HTMLElement ? card.closest(\"[data-kanban-drop-state]\") : null;\n\t\t\t\tqueryRoot(scope).querySelectorAll(\"[data-kanban-drop-state]\").forEach(function (lane) {\n\t\t\t\t\tif (!(lane instanceof HTMLElement)) return;\n\t\t\t\t\tif (lane.dataset.kanbanDropWasHidden === undefined) {\n\t\t\t\t\t\tlane.dataset.kanbanDropWasHidden = lane.dataset.laneHidden || \"false\";\n\t\t\t\t\t}\n\t\t\t\t\tlane.dataset.laneHidden = \"false\";\n\t\t\t\t\tif (lane === sourceLane) {\n\t\t\t\t\t\t// The origin lane is not a transition target, but styling\n\t\t\t\t\t\t// it blocked reads as an error; mark it as the source so\n\t\t\t\t\t\t// the operator can see where the card came from.\n\t\t\t\t\t\tlane.dataset.kanbanDropSource = \"true\";\n\t\t\t\t\t\tdelete lane.dataset.kanbanDropAllowed;\n\t\t\t\t\t\tlane.removeAttribute(\"aria-disabled\");\n\t\t\t\t\t\treturn;\n\t\t\t\t\t}\n\t\t\t\t\tdelete lane.dataset.kanbanDropSource;\n\t\t\t\t\tvar allowed = laneAllowed(card, lane);\n\t\t\t\t\tlane.dataset.kanbanDropAllowed = allowed ? \"true\" : \"false\";\n\t\t\t\t\tlane.setAttribute(\"aria-disabled\", allowed ? \"false\" : \"true\");\n\t\t\t\t});\n\t\t\t}\n\t\t\tfunction applyActiveDragState(scope) {\n\t\t\t\tif (!draggedIssueID || draggedAllowedTargetKeys.length === 0) return false;\n\t\t\t\tvar root = queryRoot(scope);\n\t\t\t\tvar card = draggedCard(root);\n\t\t\t\tif (card instanceof HTMLElement) card.dataset.kanbanDragging = \"true\";\n\t\t\t\tsetDropTargetState(card, root);\n\t\t\t\tapplyTouchDragStyles(card, root);\n\t\t\t\treturn true;\n\t\t\t}\n\t\t\tfunction applyDragState(scope) {\n\t\t\t\tvar pendingApplied = applyPendingMoveState(scope);\n\t\t\t\treturn applyActiveDragState(scope) || pendingApplied;\n\t\t\t}\n\t\t\twindow.__detentBoardKanbanDragAdjustSnapshot = applyDragState;\n\t\t\tfunction clearDropTargetState() {\n\t\t\t\tdocument.querySelectorAll(\"[data-kanban-drop-state]\").forEach(function (lane) {\n\t\t\t\t\tif (!(lane instanceof HTMLElement)) return;\n\t\t\t\t\tif (lane.dataset.kanbanDropWasHidden !== undefined) {\n\t\t\t\t\t\tlane.dataset.laneHidden = lane.dataset.kanbanDropWasHidden;\n\t\t\t\t\t\tdelete lane.dataset.kanbanDropWasHidden;\n\t\t\t\t\t}\n\t\t\t\t\tdelete lane.dataset.kanbanDropAllowed;\n\t\t\t\t\tdelete lane.dataset.kanbanDropSource;\n\t\t\t\t\tlane.removeAttribute(\"aria-disabled\");\n\t\t\t\t});\n\t\t\t\tdocument.querySelectorAll(\"[data-kanban-card][data-kanban-dragging='true']\").forEach(function (card) {\n\t\t\t\t\tif (card instanceof HTMLElement) delete card.dataset.kanbanDragging;\n\t\t\t\t});\n\t\t\t}\n\t\t\tfunction responseMessage(response) {\n\t\t\t\tif (!response) return \"\";\n\t\t\t\tvar doc = new DOMParser().parseFromString(response, \"text/html\");\n\t\t\t\treturn (doc.body.textContent || \"\").trim();\n\t\t\t}\n\t\t\tfunction buildGhost(card, rect) {\n\t\t\t\tvar ghost = card.cloneNode(true);\n\t\t\t\tghost.removeAttribute(\"id\");\n\t\t\t\tghost.querySelectorAll(\"[id]\").forEach(function (node) {\n\t\t\t\t\tnode.removeAttribute(\"id\");\n\t\t\t\t});\n\t\t\t\tvar form = ghost.querySelector(\"[data-kanban-drag-move-form]\");\n\t\t\t\tif (form) form.remove();\n\t\t\t\tdelete ghost.dataset.kanbanDragging;\n\t\t\t\tvar origin = document.createElement(\"div\");\n\t\t\t\torigin.className = \"mb-1.5 flex items-center gap-1.5 border-b border-line pb-1.5 font-mono text-2xs font-medium text-accent\";\n\t\t\t\torigin.textContent = \"From \" + (card.dataset.kanbanCurrentState || \"current lane\");\n\t\t\t\tghost.insertBefore(origin, ghost.firstChild);\n\t\t\t\tghost.setAttribute(\"aria-hidden\", \"true\");\n\t\t\t\tghost.style.position = \"fixed\";\n\t\t\t\tghost.style.left = \"0\";\n\t\t\t\tghost.style.top = \"0\";\n\t\t\t\tghost.style.margin = \"0\";\n\t\t\t\tghost.style.width = rect.width + \"px\";\n\t\t\t\tghost.style.height = rect.height + \"px\";\n\t\t\t\tghost.style.pointerEvents = \"none\";\n\t\t\t\tghost.style.zIndex = \"1000\";\n\t\t\t\tghost.style.opacity = \"0.9\";\n\t\t\t\tghost.style.boxShadow = \"0 12px 32px rgba(0, 0, 0, 0.35)\";\n\t\t\t\tghost.style.willChange = \"transform\";\n\t\t\t\tdocument.body.appendChild(ghost);\n\t\t\t\treturn ghost;\n\t\t\t}\n\t\t\tfunction moveGhost(ghost, x, y, offsetX, offsetY) {\n\t\t\t\tghost.style.transform = \"translate(\" + Math.round(x - offsetX) + \"px, \" + Math.round(y - offsetY) + \"px)\";\n\t\t\t}\n\t\t\tfunction laneFromPoint(x, y) {\n\t\t\t\tvar hit = document.elementFromPoint(x, y);\n\t\t\t\treturn hit instanceof Element ? hit.closest(\"[data-kanban-drop-state]\") : null;\n\t\t\t}\n\t\t\tfunction applyTouchStyle(element, styles) {\n\t\t\t\tif (!active || active.pointerType !== \"touch\" || !(element instanceof HTMLElement) || !element.isConnected) return;\n\t\t\t\tif (!active.touchStyles.has(element)) {\n\t\t\t\t\tvar original = {};\n\t\t\t\t\tObject.keys(styles).forEach(function (property) {\n\t\t\t\t\t\toriginal[property] = element.style[property];\n\t\t\t\t\t});\n\t\t\t\t\tactive.touchStyles.set(element, original);\n\t\t\t\t}\n\t\t\t\tObject.keys(styles).forEach(function (property) {\n\t\t\t\t\telement.style[property] = styles[property];\n\t\t\t\t});\n\t\t\t}\n\t\t\tfunction applyTouchDragStyles(card, scope) {\n\t\t\t\tif (!active || active.pointerType !== \"touch\") return;\n\t\t\t\tvar root = queryRoot(scope);\n\t\t\t\tvar lanes = root.querySelector(\"[data-board-lanes]\");\n\t\t\t\tapplyTouchStyle(lanes, { touchAction: \"none\", scrollSnapType: \"none\" });\n\t\t\t\tapplyTouchStyle(card, {\n\t\t\t\t\ttouchAction: \"none\",\n\t\t\t\t\toutline: \"2px solid var(--color-accent)\",\n\t\t\t\t\toutlineOffset: \"2px\"\n\t\t\t\t});\n\t\t\t}\n\t\t\tfunction restoreTouchDragStyles() {\n\t\t\t\tif (!active || !active.touchStyles) return;\n\t\t\t\tactive.touchStyles.forEach(function (styles, element) {\n\t\t\t\t\tObject.keys(styles).forEach(function (property) {\n\t\t\t\t\t\telement.style[property] = styles[property];\n\t\t\t\t\t});\n\t\t\t\t});\n\t\t\t\tactive.touchStyles.clear();\n\t\t\t}\n\t\t\t// Native drags auto-scrolled the lane strip at the viewport edges;\n\t\t\t// pointer drags must do it themselves. Scrolls only while the\n\t\t\t// pointer moves, which is enough to reach off-screen lanes.\n\t\t\tfunction autoScrollLanes(x) {\n\t\t\t\tvar lanes = document.getElementById(\"board-lanes\");\n\t\t\t\tif (!lanes) return;\n\t\t\t\tvar rect = lanes.getBoundingClientRect();\n\t\t\t\tif (x < rect.left + 48) {\n\t\t\t\t\tlanes.scrollLeft -= 16;\n\t\t\t\t} else if (x > rect.right - 48) {\n\t\t\t\t\tlanes.scrollLeft += 16;\n\t\t\t\t}\n\t\t\t}\n\t\t\tfunction visibleDropLanes(lanes) {\n\t\t\t\treturn Array.from(lanes.querySelectorAll(\"[data-kanban-drop-state]\")).filter(function (lane) {\n\t\t\t\t\treturn lane instanceof HTMLElement && lane.dataset.laneHidden !== \"true\";\n\t\t\t\t});\n\t\t\t}\n\t\t\tfunction closestLaneIndex(lanes, laneNodes) {\n\t\t\t\tvar center = lanes.getBoundingClientRect().left + lanes.clientWidth / 2;\n\t\t\t\tvar closest = 0;\n\t\t\t\tvar distance = Infinity;\n\t\t\t\tlaneNodes.forEach(function (lane, index) {\n\t\t\t\t\tvar rect = lane.getBoundingClientRect();\n\t\t\t\t\tvar candidate = Math.abs(rect.left + rect.width / 2 - center);\n\t\t\t\t\tif (candidate < distance) {\n\t\t\t\t\t\tdistance = candidate;\n\t\t\t\t\t\tclosest = index;\n\t\t\t\t\t}\n\t\t\t\t});\n\t\t\t\treturn closest;\n\t\t\t}\n\t\t\tfunction advanceTouchLane(direction) {\n\t\t\t\tif (!active || active.pointerType !== \"touch\" || active.edgeDirection !== direction) return;\n\t\t\t\tactive.edgeTimer = null;\n\t\t\t\tvar lanes = document.getElementById(\"board-lanes\");\n\t\t\t\tif (!lanes) return;\n\t\t\t\tvar laneNodes = visibleDropLanes(lanes);\n\t\t\t\tif (laneNodes.length === 0) return;\n\t\t\t\tvar current = closestLaneIndex(lanes, laneNodes);\n\t\t\t\tvar target = Math.max(0, Math.min(laneNodes.length - 1, current + direction));\n\t\t\t\tif (target !== current) {\n\t\t\t\t\tlaneNodes[target].scrollIntoView({ behavior: \"smooth\", block: \"nearest\", inline: \"start\" });\n\t\t\t\t}\n\t\t\t\tif (active && active.edgeDirection === direction && target !== current) {\n\t\t\t\t\tactive.edgeTimer = window.setTimeout(function () {\n\t\t\t\t\t\tadvanceTouchLane(direction);\n\t\t\t\t\t}, TOUCH_EDGE_ADVANCE_MS);\n\t\t\t\t}\n\t\t\t}\n\t\t\tfunction updateTouchEdgeAdvance(x) {\n\t\t\t\tif (!active || active.pointerType !== \"touch\") return;\n\t\t\t\tvar lanes = document.getElementById(\"board-lanes\");\n\t\t\t\tif (!lanes) return;\n\t\t\t\tvar rect = lanes.getBoundingClientRect();\n\t\t\t\tvar direction = x < rect.left + TOUCH_EDGE_ZONE_PX ? -1 : (x > rect.right - TOUCH_EDGE_ZONE_PX ? 1 : 0);\n\t\t\t\tif (direction === active.edgeDirection) return;\n\t\t\t\tif (active.edgeTimer) window.clearTimeout(active.edgeTimer);\n\t\t\t\tactive.edgeDirection = direction;\n\t\t\t\tactive.edgeTimer = direction === 0 ? null : window.setTimeout(function () {\n\t\t\t\t\tadvanceTouchLane(direction);\n\t\t\t\t}, TOUCH_EDGE_ADVANCE_MS);\n\t\t\t}\n\t\t\tfunction stopTouchEdgeAdvance() {\n\t\t\t\tif (!active) return;\n\t\t\t\tif (active.edgeTimer) window.clearTimeout(active.edgeTimer);\n\t\t\t\tactive.edgeTimer = null;\n\t\t\t\tactive.edgeDirection = 0;\n\t\t\t}\n\t\t\tfunction suppressNextClick() {\n\t\t\t\tvar until = Date.now() + 400;\n\t\t\t\tdocument.addEventListener(\"click\", function suppress(event) {\n\t\t\t\t\tdocument.removeEventListener(\"click\", suppress, true);\n\t\t\t\t\tif (Date.now() > until) return;\n\t\t\t\t\tevent.preventDefault();\n\t\t\t\t\tevent.stopImmediatePropagation();\n\t\t\t\t}, true);\n\t\t\t}\n\t\t\tfunction beginDrag(event) {\n\t\t\t\tvar press = pending;\n\t\t\t\tif (!press) return;\n\t\t\t\tif (press.longPressTimer) window.clearTimeout(press.longPressTimer);\n\t\t\t\tdraggedIssueID = press.issueID;\n\t\t\t\tdraggedAllowedTargetKeys = press.targets;\n\t\t\t\tvar card = draggedCard(document) || press.card;\n\t\t\t\tactive = {\n\t\t\t\t\tpointerId: press.pointerId,\n\t\t\t\t\tpointerType: press.pointerType,\n\t\t\t\t\ttouchIdentifier: press.touchIdentifier,\n\t\t\t\t\toffsetX: press.startX - press.rect.left,\n\t\t\t\t\toffsetY: press.startY - press.rect.top,\n\t\t\t\t\tghost: buildGhost(card, press.rect),\n\t\t\t\t\tlastLaneBlocked: false,\n\t\t\t\t\tstartedAt: press.startedAt,\n\t\t\t\t\tcaptureElement: press.card,\n\t\t\t\t\ttouchStyles: new Map(),\n\t\t\t\t\tedgeDirection: 0,\n\t\t\t\t\tedgeTimer: null\n\t\t\t\t};\n\t\t\t\tpending = null;\n\t\t\t\trecentTouchStart = null;\n\t\t\t\tif (active.pointerType === \"touch\" && typeof active.captureElement.setPointerCapture === \"function\") {\n\t\t\t\t\ttry {\n\t\t\t\t\t\tactive.captureElement.setPointerCapture(active.pointerId);\n\t\t\t\t\t} catch (_) {}\n\t\t\t\t}\n\t\t\t\tcard.dataset.kanbanDragging = \"true\";\n\t\t\t\tsetDropTargetState(card, document);\n\t\t\t\tapplyTouchDragStyles(card, document);\n\t\t\t\tfeedback(\"Moving \" + (card.dataset.kanbanCurrentState || \"card\") + \".\");\n\t\t\t\tmoveGhost(active.ghost, event.clientX, event.clientY, active.offsetX, active.offsetY);\n\t\t\t}\n\t\t\tfunction finishDrag(keepClick) {\n\t\t\t\tif (active) {\n\t\t\t\t\tstopTouchEdgeAdvance();\n\t\t\t\t\trestoreTouchDragStyles();\n\t\t\t\t\tif (active.ghost) active.ghost.remove();\n\t\t\t\t\tif (active.captureElement && typeof active.captureElement.releasePointerCapture === \"function\") {\n\t\t\t\t\t\ttry {\n\t\t\t\t\t\t\tif (active.captureElement.hasPointerCapture(active.pointerId)) active.captureElement.releasePointerCapture(active.pointerId);\n\t\t\t\t\t\t} catch (_) {}\n\t\t\t\t\t}\n\t\t\t\t}\n\t\t\t\tclearPending();\n\t\t\t\tactive = null;\n\t\t\t\tdraggedIssueID = \"\";\n\t\t\t\tdraggedAllowedTargetKeys = [];\n\t\t\t\tclearDropTargetState();\n\t\t\t\t// A drag ends with the pointer still over a card, so the release\n\t\t\t\t// also fires a click; swallow it or the detail sheet opens.\n\t\t\t\tif (!keepClick) suppressNextClick();\n\t\t\t}\n\t\t\tfunction cancelDrag(keepClick) {\n\t\t\t\tif (!active) {\n\t\t\t\t\tclearPending();\n\t\t\t\t\treturn;\n\t\t\t\t}\n\t\t\t\tfinishDrag(keepClick);\n\t\t\t\tfeedback(\"Move cancelled.\", \"error\");\n\t\t\t}\n\t\t\tfunction rollbackPendingMove(card) {\n\t\t\t\tif (!(card instanceof HTMLElement) || !card.dataset.kanbanPendingMove) return;\n\t\t\t\tvar targetLane = card.closest(\"[data-kanban-drop-state]\");\n\t\t\t\tvar targetWasHidden = card.dataset.kanbanPendingTargetWasHidden === \"true\";\n\t\t\t\tvar originState = card.dataset.kanbanPendingOrigin || \"\";\n\t\t\t\tclearPendingMove(card);\n\t\t\t\tplaceCardInLane(card, originState, document);\n\t\t\t\tif (targetLane instanceof HTMLElement) {\n\t\t\t\t\ttargetLane.dataset.laneHidden = targetWasHidden ? \"true\" : \"false\";\n\t\t\t\t\tupdateEmptyLine(cardContainer(targetLane));\n\t\t\t\t}\n\t\t\t}\n\t\t\tfunction moveDragTo(x, y) {\n\t\t\t\tif (!active) return;\n\t\t\t\tmoveGhost(active.ghost, x, y, active.offsetX, active.offsetY);\n\t\t\t\tif (active.pointerType === \"touch\") {\n\t\t\t\t\tupdateTouchEdgeAdvance(x);\n\t\t\t\t} else {\n\t\t\t\t\tautoScrollLanes(x);\n\t\t\t\t}\n\t\t\t\tvar lane = laneFromPoint(x, y);\n\t\t\t\tvar card = draggedCard(document);\n\t\t\t\tvar blocked = lane instanceof HTMLElement && lane.dataset.kanbanDropSource !== \"true\" && !laneAllowed(card, lane);\n\t\t\t\tif (blocked && !active.lastLaneBlocked) {\n\t\t\t\t\tfeedback(\"Move blocked by transition policy.\", \"error\");\n\t\t\t\t} else if (!blocked && active.lastLaneBlocked) {\n\t\t\t\t\tfeedback(\"Moving \" + ((card && card.dataset.kanbanCurrentState) || \"card\") + \".\");\n\t\t\t\t}\n\t\t\t\tactive.lastLaneBlocked = blocked;\n\t\t\t}\n\t\t\tdocument.addEventListener(\"pointerdown\", function (event) {\n\t\t\t\tif (active || event.button !== 0 || event.isPrimary === false) return;\n\t\t\t\tvar card = event.target instanceof Element ? event.target.closest(\"[data-kanban-card][data-kanban-action='move']\") : null;\n\t\t\t\tif (!card) return;\n\t\t\t\tif (card.dataset.kanbanPendingMove) return;\n\t\t\t\tvar issueID = card.dataset.kanbanIssueId || \"\";\n\t\t\t\tif (!issueID) return;\n\t\t\t\tpending = {\n\t\t\t\t\tpointerId: event.pointerId,\n\t\t\t\t\tpointerType: event.pointerType,\n\t\t\t\t\ttouchIdentifier: recentTouchIdentifier(card, event),\n\t\t\t\t\tcard: card,\n\t\t\t\t\tissueID: issueID,\n\t\t\t\t\ttargets: targetKeysFromValue(card.dataset.kanbanAllowedTargets || \"\"),\n\t\t\t\t\trect: card.getBoundingClientRect(),\n\t\t\t\t\tstartX: event.clientX,\n\t\t\t\t\tstartY: event.clientY,\n\t\t\t\t\tlastX: event.clientX,\n\t\t\t\t\tlastY: event.clientY,\n\t\t\t\t\tstartedAt: Date.now(),\n\t\t\t\t\tlongPressTimer: null\n\t\t\t\t};\n\t\t\t\tif (event.pointerType === \"touch\") {\n\t\t\t\t\tvar pointerId = event.pointerId;\n\t\t\t\t\tpending.longPressTimer = window.setTimeout(function () {\n\t\t\t\t\t\tif (!pending || pending.pointerId !== pointerId) return;\n\t\t\t\t\t\tbeginDrag({ clientX: pending.lastX, clientY: pending.lastY });\n\t\t\t\t\t}, TOUCH_LONG_PRESS_MS);\n\t\t\t\t}\n\t\t\t});\n\t\t\tdocument.addEventListener(\"touchstart\", function (event) {\n\t\t\t\tif (active || !event.changedTouches || event.changedTouches.length === 0) return;\n\t\t\t\tvar touch = event.changedTouches[0];\n\t\t\t\trecentTouchStart = {\n\t\t\t\t\tidentifier: touch.identifier,\n\t\t\t\t\ttarget: event.target,\n\t\t\t\t\tstartedAt: Date.now()\n\t\t\t\t};\n\t\t\t\tif (pending && pending.pointerType === \"touch\" && event.target instanceof Node && pending.card.contains(event.target)) {\n\t\t\t\t\tpending.touchIdentifier = touch.identifier;\n\t\t\t\t}\n\t\t\t});\n\t\t\tdocument.addEventListener(\"pointermove\", function (event) {\n\t\t\t\tif (pending && event.pointerId === pending.pointerId) {\n\t\t\t\t\tif (pending.pointerType === \"touch\") {\n\t\t\t\t\t\tif (Math.hypot(event.clientX - pending.startX, event.clientY - pending.startY) >= TOUCH_MOVE_TOLERANCE_PX) {\n\t\t\t\t\t\t\tclearPending();\n\t\t\t\t\t\t\treturn;\n\t\t\t\t\t\t}\n\t\t\t\t\t\tpending.lastX = event.clientX;\n\t\t\t\t\t\tpending.lastY = event.clientY;\n\t\t\t\t\t\treturn;\n\t\t\t\t\t}\n\t\t\t\t\t// A missed pointerup (released outside the window) must not\n\t\t\t\t\t// leave a stale press that turns a later hover into a drag.\n\t\t\t\t\tif (event.buttons === 0) {\n\t\t\t\t\t\tclearPending();\n\t\t\t\t\t\treturn;\n\t\t\t\t\t}\n\t\t\t\t\tif (Math.hypot(event.clientX - pending.startX, event.clientY - pending.startY) < DRAG_THRESHOLD_PX) return;\n\t\t\t\t\tbeginDrag(event);\n\t\t\t\t\treturn;\n\t\t\t\t}\n\t\t\t\tif (!active || event.pointerId !== active.pointerId) return;\n\t\t\t\tif (active.pointerType !== \"touch\" && event.buttons === 0) {\n\t\t\t\t\t// The release happened outside the window, so no click is\n\t\t\t\t\t// coming — cancelling must not arm the click suppressor or\n\t\t\t\t\t// it would eat the next real click after recovery.\n\t\t\t\t\tcancelDrag(true);\n\t\t\t\t\treturn;\n\t\t\t\t}\n\t\t\t\tevent.preventDefault();\n\t\t\t\tmoveDragTo(event.clientX, event.clientY);\n\t\t\t}, { passive: false });\n\t\t\tfunction dropAt(x, y) {\n\t\t\t\tif (!active) return;\n\t\t\t\tvar lane = laneFromPoint(x, y);\n\t\t\t\tvar card = draggedCard(document);\n\t\t\t\tif (!(lane instanceof HTMLElement)) {\n\t\t\t\t\tcancelDrag();\n\t\t\t\t\treturn;\n\t\t\t\t}\n\t\t\t\tif (lane.dataset.kanbanDropSource === \"true\") {\n\t\t\t\t\tif (Date.now() - active.startedAt < CLICK_GESTURE_MS) {\n\t\t\t\t\t\tfinishDrag(true);\n\t\t\t\t\t\tfeedback(\"\");\n\t\t\t\t\t\treturn;\n\t\t\t\t\t}\n\t\t\t\t\tcancelDrag();\n\t\t\t\t\treturn;\n\t\t\t\t}\n\t\t\t\tif (!laneAllowed(card, lane)) {\n\t\t\t\t\tfinishDrag();\n\t\t\t\t\tfeedback(\"Move blocked by transition policy.\", \"error\");\n\t\t\t\t\treturn;\n\t\t\t\t}\n\t\t\t\tvar form = card ? card.querySelector(\"[data-kanban-drag-move-form]\") : null;\n\t\t\t\tvar targetState = form ? form.querySelector(\"[data-kanban-drag-target-state]\") : null;\n\t\t\t\tif (!(form instanceof HTMLFormElement) || !(targetState instanceof HTMLInputElement)) {\n\t\t\t\t\tcancelDrag();\n\t\t\t\t\treturn;\n\t\t\t\t}\n\t\t\t\ttargetState.value = lane.dataset.kanbanDropState || \"\";\n\t\t\t\tcard.dataset.kanbanPendingMove = targetState.value;\n\t\t\t\tcard.dataset.kanbanPendingOrigin = card.dataset.kanbanCurrentState || \"\";\n\t\t\t\tif (card.dataset.kanbanDataSeq) card.dataset.kanbanPendingSeq = card.dataset.kanbanDataSeq;\n\t\t\t\tcard.dataset.kanbanPendingTargetWasHidden = lane.dataset.kanbanDropWasHidden || lane.dataset.laneHidden || \"false\";\n\t\t\t\tplaceCardInLane(card, targetState.value, document);\n\t\t\t\tfinishDrag();\n\t\t\t\tplaceCardInLane(card, targetState.value, document);\n\t\t\t\tform.requestSubmit();\n\t\t\t}\n\t\t\tdocument.addEventListener(\"pointerup\", function (event) {\n\t\t\t\tif (pending && event.pointerId === pending.pointerId) {\n\t\t\t\t\tclearPending();\n\t\t\t\t\treturn;\n\t\t\t\t}\n\t\t\t\tif (!active || event.pointerId !== active.pointerId) return;\n\t\t\t\tdropAt(event.clientX, event.clientY);\n\t\t\t});\n\t\t\tdocument.addEventListener(\"pointercancel\", function (event) {\n\t\t\t\tif (pending && event.pointerId === pending.pointerId) {\n\t\t\t\t\tclearPending();\n\t\t\t\t\treturn;\n\t\t\t\t}\n\t\t\t\tif (active && event.pointerId === active.pointerId && active.pointerType !== \"touch\") cancelDrag();\n\t\t\t});\n\t\t\tdocument.addEventListener(\"touchmove\", function (event) {\n\t\t\t\tif (!active || active.pointerType !== \"touch\") return;\n\t\t\t\tevent.preventDefault();\n\t\t\t\tvar touch = touchWithIdentifier(event.touches, active.touchIdentifier);\n\t\t\t\tif (!touch && active.touchIdentifier === null && event.touches && event.touches.length === 1) touch = event.touches[0];\n\t\t\t\tif (touch) moveDragTo(touch.clientX, touch.clientY);\n\t\t\t}, { passive: false });\n\t\t\tdocument.addEventListener(\"touchend\", function (event) {\n\t\t\t\tif (pending && pending.pointerType === \"touch\") {\n\t\t\t\t\tvar pendingTouch = touchWithIdentifier(event.changedTouches, pending.touchIdentifier);\n\t\t\t\t\tif (!pendingTouch && !(pending.touchIdentifier === null && event.touches && event.touches.length === 0)) return;\n\t\t\t\t\tclearPending();\n\t\t\t\t\treturn;\n\t\t\t\t}\n\t\t\t\tif (!active || active.pointerType !== \"touch\") return;\n\t\t\t\tvar touch = touchWithIdentifier(event.changedTouches, active.touchIdentifier);\n\t\t\t\tif (!touch && active.touchIdentifier === null && event.touches && event.touches.length === 0) touch = event.changedTouches && event.changedTouches[0];\n\t\t\t\tif (touch) dropAt(touch.clientX, touch.clientY);\n\t\t\t});\n\t\t\tdocument.addEventListener(\"touchcancel\", function (event) {\n\t\t\t\tif (pending && pending.pointerType === \"touch\") {\n\t\t\t\t\tvar pendingTouch = touchWithIdentifier(event.changedTouches, pending.touchIdentifier);\n\t\t\t\t\tif (!pendingTouch && !(pending.touchIdentifier === null && event.touches && event.touches.length === 0)) return;\n\t\t\t\t\tclearPending();\n\t\t\t\t\treturn;\n\t\t\t\t}\n\t\t\t\tif (!active || active.pointerType !== \"touch\") return;\n\t\t\t\tvar touch = touchWithIdentifier(event.changedTouches, active.touchIdentifier);\n\t\t\t\tif (touch || (active.touchIdentifier === null && event.touches && event.touches.length === 0)) cancelDrag();\n\t\t\t});\n\t\t\tdocument.addEventListener(\"contextmenu\", function (event) {\n\t\t\t\tvar touchPress = pending && pending.pointerType === \"touch\";\n\t\t\t\tvar touchDrag = active && active.pointerType === \"touch\";\n\t\t\t\tif ((touchPress || touchDrag) && event.target instanceof Element && event.target.closest(\"[data-kanban-card]\")) {\n\t\t\t\t\tevent.preventDefault();\n\t\t\t\t}\n\t\t\t});\n\t\t\tdocument.addEventListener(\"keydown\", function (event) {\n\t\t\t\tif (event.key === \"Escape\" && active) cancelDrag();\n\t\t\t});\n\t\t\twindow.addEventListener(\"blur\", function () {\n\t\t\t\tif (active) cancelDrag();\n\t\t\t});\n\t\t\t// Native HTML5 drags stay disabled inside cards (links, images):\n\t\t\t// they would start a compositor drag session that steals the pointer.\n\t\t\tdocument.addEventListener(\"dragstart\", function (event) {\n\t\t\t\tif (event.target instanceof Element && event.target.closest(\"[data-kanban-card]\")) {\n\t\t\t\t\tevent.preventDefault();\n\t\t\t\t}\n\t\t\t});\n\t\t\tdocument.addEventListener(\"htmx:afterSettle\", function () {\n\t\t\t\tapplyDragState(document);\n\t\t\t});\n\t\t\tfunction handleMoveError(event) {\n\t\t\t\tvar form = event.detail && event.detail.elt;\n\t\t\t\tif (!(form instanceof HTMLFormElement) || !form.matches(\"[data-kanban-drag-move-form]\")) return;\n\t\t\t\tvar issueIDInput = form.querySelector(\"input[name='issue_id']\");\n\t\t\t\tvar issueID = issueIDInput instanceof HTMLInputElement ? issueIDInput.value : \"\";\n\t\t\t\tvar card = form.closest(\"[data-kanban-card][data-kanban-pending-move]\");\n\t\t\t\tif (!(card instanceof HTMLElement) || !card.isConnected) card = cardByIssueID(document, issueID);\n\t\t\t\trollbackPendingMove(card);\n\t\t\t\tvar response = event.detail.xhr ? event.detail.xhr.responseText : \"\";\n\t\t\t\tfeedback(responseMessage(response) || \"Move failed.\", \"error\");\n\t\t\t}\n\t\t\tdocument.body.addEventListener(\"htmx:responseError\", handleMoveError);\n\t\t\tdocument.body.addEventListener(\"htmx:sendError\", handleMoveError);\n\t\t\tdocument.body.addEventListener(\"htmx:timeout\", handleMoveError);\n\t\t})();\n\t</script>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 217, "<script>\n\t\t(function () {\n\t\t\tif (window.__detentBoardKanbanDragHandlersRegistered) return;\n\t\t\twindow.__detentBoardKanbanDragHandlersRegistered = true;\n\t\t\tvar DRAG_THRESHOLD_PX = 6;\n\t\t\tvar TOUCH_MOVE_TOLERANCE_PX = 10;\n\t\t\tvar TOUCH_LONG_PRESS_MS = 450;\n\t\t\tvar TOUCH_EDGE_ZONE_PX = 56;\n\t\t\tvar TOUCH_EDGE_ADVANCE_MS = 500;\n\t\t\t// Real mouse clicks travel a few pixels between press and release,\n\t\t\t// so distance alone cannot separate a click from a drag. A short\n\t\t\t// gesture released back over the source lane is a click: finish the\n\t\t\t// drag without swallowing the click so the detail sheet still opens.\n\t\t\tvar CLICK_GESTURE_MS = 250;\n\t\t\tvar draggedIssueID = \"\";\n\t\t\tvar draggedAllowedTargetKeys = [];\n\t\t\tvar pending = null;\n\t\t\tvar active = null;\n\t\t\tvar recentTouchStart = null;\n\t\t\tfunction clearPending() {\n\t\t\t\tif (pending && pending.longPressTimer) window.clearTimeout(pending.longPressTimer);\n\t\t\t\tpending = null;\n\t\t\t\trecentTouchStart = null;\n\t\t\t}\n\t\t\tfunction touchWithIdentifier(touches, identifier) {\n\t\t\t\tif (!touches || identifier === null || identifier === undefined) return null;\n\t\t\t\tfor (var index = 0; index < touches.length; index += 1) {\n\t\t\t\t\tif (touches[index].identifier === identifier) return touches[index];\n\t\t\t\t}\n\t\t\t\treturn null;\n\t\t\t}\n\t\t\tfunction recentTouchIdentifier(card, event) {\n\t\t\t\tif (event.pointerType !== \"touch\" || !recentTouchStart) return null;\n\t\t\t\tif (Date.now() - recentTouchStart.startedAt >= 100) return null;\n\t\t\t\tif (!(recentTouchStart.target instanceof Node) || !card.contains(recentTouchStart.target)) return null;\n\t\t\t\treturn recentTouchStart.identifier;\n\t\t\t}\n\t\t\tfunction feedback(message, kind) {\n\t\t\t\tvar target = document.getElementById(\"board-feedback\");\n\t\t\t\tif (!target) return;\n\t\t\t\tvar text = String(message || \"\").trim();\n\t\t\t\ttarget.className = \"flex flex-none items-center gap-2 px-5 pt-3.5 text-xs \" + (kind === \"error\" ? \"text-err\" : \"text-sec\");\n\t\t\t\ttarget.textContent = text;\n\t\t\t\ttarget.hidden = text === \"\";\n\t\t\t}\n\t\t\tfunction queryRoot(scope) {\n\t\t\t\tif (scope && typeof scope.querySelector === \"function\" && typeof scope.querySelectorAll === \"function\") return scope;\n\t\t\t\treturn document;\n\t\t\t}\n\t\t\tfunction draggedCard(scope) {\n\t\t\t\tif (!draggedIssueID || !window.CSS || typeof CSS.escape !== \"function\") return null;\n\t\t\t\treturn queryRoot(scope).querySelector(\"[data-kanban-card][data-kanban-issue-id='\" + CSS.escape(draggedIssueID) + \"']\");\n\t\t\t}\n\t\t\tfunction cardByIssueID(scope, issueID) {\n\t\t\t\tvar cards = queryRoot(scope).querySelectorAll(\"[data-kanban-card][data-kanban-issue-id]\");\n\t\t\t\tfor (var index = 0; index < cards.length; index += 1) {\n\t\t\t\t\tif (cards[index].dataset.kanbanIssueId === issueID) return cards[index];\n\t\t\t\t}\n\t\t\t\treturn null;\n\t\t\t}\n\t\t\tfunction laneByState(scope, state) {\n\t\t\t\tvar lanes = queryRoot(scope).querySelectorAll(\"[data-kanban-drop-state]\");\n\t\t\t\tfor (var index = 0; index < lanes.length; index += 1) {\n\t\t\t\t\tif (lanes[index].dataset.kanbanDropState === state) return lanes[index];\n\t\t\t\t}\n\t\t\t\treturn null;\n\t\t\t}\n\t\t\tfunction cardContainer(lane) {\n\t\t\t\treturn lane instanceof HTMLElement ? lane.querySelector(\"[data-kanban-card-container]\") : null;\n\t\t\t}\n\t\t\tfunction updateEmptyLine(container) {\n\t\t\t\tif (!(container instanceof HTMLElement)) return;\n\t\t\t\tvar emptyLine = container.querySelector(\"[data-kanban-empty-line]\");\n\t\t\t\tif (emptyLine instanceof HTMLElement) emptyLine.hidden = Boolean(container.querySelector(\"[data-kanban-card]\"));\n\t\t\t}\n\t\t\tfunction placeCardInLane(card, state, scope) {\n\t\t\t\tvar lane = laneByState(scope, state);\n\t\t\t\tvar container = cardContainer(lane);\n\t\t\t\tif (!(card instanceof HTMLElement) || !(lane instanceof HTMLElement) || !(container instanceof HTMLElement)) return null;\n\t\t\t\tvar previousContainer = card.parentElement;\n\t\t\t\tcontainer.appendChild(card);\n\t\t\t\tlane.dataset.laneHidden = \"false\";\n\t\t\t\tupdateEmptyLine(previousContainer);\n\t\t\t\tupdateEmptyLine(container);\n\t\t\t\treturn lane;\n\t\t\t}\n\t\t\tfunction copyPendingMove(source, target) {\n\t\t\t\t[\n\t\t\t\t\t\"kanbanPendingMove\",\n\t\t\t\t\t\"kanbanPendingOrigin\",\n\t\t\t\t\t\"kanbanPendingSeq\",\n\t\t\t\t\t\"kanbanPendingTargetWasHidden\"\n\t\t\t\t].forEach(function (key) {\n\t\t\t\t\tif (source.dataset[key] === undefined) {\n\t\t\t\t\t\tdelete target.dataset[key];\n\t\t\t\t\t} else {\n\t\t\t\t\t\ttarget.dataset[key] = source.dataset[key];\n\t\t\t\t\t}\n\t\t\t\t});\n\t\t\t}\n\t\t\tfunction clearPendingMove(card) {\n\t\t\t\tif (!(card instanceof HTMLElement)) return;\n\t\t\t\tdelete card.dataset.kanbanPendingMove;\n\t\t\t\tdelete card.dataset.kanbanPendingOrigin;\n\t\t\t\tdelete card.dataset.kanbanPendingSeq;\n\t\t\t\tdelete card.dataset.kanbanPendingTargetWasHidden;\n\t\t\t}\n\t\t\tfunction pendingMoveSuperseded(liveCard, serverCard) {\n\t\t\t\tvar targetState = liveCard.dataset.kanbanPendingMove || \"\";\n\t\t\t\tif ((serverCard.dataset.kanbanCurrentState || \"\") === targetState) return true;\n\t\t\t\tvar pendingSeq = Number.parseInt(liveCard.dataset.kanbanPendingSeq || \"\", 10);\n\t\t\t\tvar serverSeq = Number.parseInt(serverCard.dataset.kanbanDataSeq || \"\", 10);\n\t\t\t\treturn Number.isFinite(pendingSeq) && Number.isFinite(serverSeq) && serverSeq > pendingSeq;\n\t\t\t}\n\t\t\tfunction applyPendingMoveState(scope) {\n\t\t\t\tvar root = queryRoot(scope);\n\t\t\t\tvar applied = false;\n\t\t\t\tdocument.querySelectorAll(\"#snapshot [data-kanban-card][data-kanban-pending-move]\").forEach(function (liveCard) {\n\t\t\t\t\tif (!(liveCard instanceof HTMLElement)) return;\n\t\t\t\t\tvar issueID = liveCard.dataset.kanbanIssueId || \"\";\n\t\t\t\t\tvar serverCard = cardByIssueID(root, issueID);\n\t\t\t\t\tif (!(serverCard instanceof HTMLElement)) return;\n\t\t\t\t\tif (pendingMoveSuperseded(liveCard, serverCard)) {\n\t\t\t\t\t\tif (serverCard === liveCard) clearPendingMove(serverCard);\n\t\t\t\t\t\treturn;\n\t\t\t\t\t}\n\t\t\t\t\tcopyPendingMove(liveCard, serverCard);\n\t\t\t\t\tif (placeCardInLane(serverCard, liveCard.dataset.kanbanPendingMove || \"\", root)) applied = true;\n\t\t\t\t});\n\t\t\t\treturn applied;\n\t\t\t}\n\t\t\tfunction targetKeysFromValue(value) {\n\t\t\t\treturn String(value || \"\").split(/\\s+/).filter(Boolean);\n\t\t\t}\n\t\t\tfunction allowedTargetKeys(card) {\n\t\t\t\tif (card instanceof HTMLElement) {\n\t\t\t\t\tvar keys = targetKeysFromValue(card.dataset.kanbanAllowedTargets || \"\");\n\t\t\t\t\tif (keys.length > 0) return keys;\n\t\t\t\t}\n\t\t\t\treturn draggedAllowedTargetKeys.slice();\n\t\t\t}\n\t\t\tfunction laneAllowed(card, lane) {\n\t\t\t\tif (!(lane instanceof HTMLElement)) return false;\n\t\t\t\tvar key = lane.dataset.kanbanDropKey || \"\";\n\t\t\t\treturn key !== \"\" && allowedTargetKeys(card).includes(key);\n\t\t\t}\n\t\t\tfunction setDropTargetState(card, scope) {\n\t\t\t\tvar sourceLane = card instanceof HTMLElement ? card.closest(\"[data-kanban-drop-state]\") : null;\n\t\t\t\tqueryRoot(scope).querySelectorAll(\"[data-kanban-drop-state]\").forEach(function (lane) {\n\t\t\t\t\tif (!(lane instanceof HTMLElement)) return;\n\t\t\t\t\tif (lane.dataset.kanbanDropWasHidden === undefined) {\n\t\t\t\t\t\tlane.dataset.kanbanDropWasHidden = lane.dataset.laneHidden || \"false\";\n\t\t\t\t\t}\n\t\t\t\t\tlane.dataset.laneHidden = \"false\";\n\t\t\t\t\tif (lane === sourceLane) {\n\t\t\t\t\t\t// The origin lane is not a transition target, but styling\n\t\t\t\t\t\t// it blocked reads as an error; mark it as the source so\n\t\t\t\t\t\t// the operator can see where the card came from.\n\t\t\t\t\t\tlane.dataset.kanbanDropSource = \"true\";\n\t\t\t\t\t\tdelete lane.dataset.kanbanDropAllowed;\n\t\t\t\t\t\tlane.removeAttribute(\"aria-disabled\");\n\t\t\t\t\t\treturn;\n\t\t\t\t\t}\n\t\t\t\t\tdelete lane.dataset.kanbanDropSource;\n\t\t\t\t\tvar allowed = laneAllowed(card, lane);\n\t\t\t\t\tlane.dataset.kanbanDropAllowed = allowed ? \"true\" : \"false\";\n\t\t\t\t\tlane.setAttribute(\"aria-disabled\", allowed ? \"false\" : \"true\");\n\t\t\t\t});\n\t\t\t}\n\t\t\tfunction applyActiveDragState(scope) {\n\t\t\t\tif (!draggedIssueID || draggedAllowedTargetKeys.length === 0) return false;\n\t\t\t\tvar root = queryRoot(scope);\n\t\t\t\tvar card = draggedCard(root);\n\t\t\t\tif (card instanceof HTMLElement) card.dataset.kanbanDragging = \"true\";\n\t\t\t\tsetDropTargetState(card, root);\n\t\t\t\tapplyTouchDragStyles(card, root);\n\t\t\t\treturn true;\n\t\t\t}\n\t\t\tfunction applyDragState(scope) {\n\t\t\t\tvar pendingApplied = applyPendingMoveState(scope);\n\t\t\t\treturn applyActiveDragState(scope) || pendingApplied;\n\t\t\t}\n\t\t\twindow.__detentBoardKanbanDragAdjustSnapshot = applyDragState;\n\t\t\tfunction clearDropTargetState() {\n\t\t\t\tdocument.querySelectorAll(\"[data-kanban-drop-state]\").forEach(function (lane) {\n\t\t\t\t\tif (!(lane instanceof HTMLElement)) return;\n\t\t\t\t\tif (lane.dataset.kanbanDropWasHidden !== undefined) {\n\t\t\t\t\t\tlane.dataset.laneHidden = lane.dataset.kanbanDropWasHidden;\n\t\t\t\t\t\tdelete lane.dataset.kanbanDropWasHidden;\n\t\t\t\t\t}\n\t\t\t\t\tdelete lane.dataset.kanbanDropAllowed;\n\t\t\t\t\tdelete lane.dataset.kanbanDropSource;\n\t\t\t\t\tlane.removeAttribute(\"aria-disabled\");\n\t\t\t\t});\n\t\t\t\tdocument.querySelectorAll(\"[data-kanban-card][data-kanban-dragging='true']\").forEach(function (card) {\n\t\t\t\t\tif (card instanceof HTMLElement) delete card.dataset.kanbanDragging;\n\t\t\t\t});\n\t\t\t}\n\t\t\tfunction responseMessage(response) {\n\t\t\t\tif (!response) return \"\";\n\t\t\t\tvar doc = new DOMParser().parseFromString(response, \"text/html\");\n\t\t\t\treturn (doc.body.textContent || \"\").trim();\n\t\t\t}\n\t\t\tfunction buildGhost(card, rect) {\n\t\t\t\tvar ghost = card.cloneNode(true);\n\t\t\t\tghost.removeAttribute(\"id\");\n\t\t\t\tghost.querySelectorAll(\"[id]\").forEach(function (node) {\n\t\t\t\t\tnode.removeAttribute(\"id\");\n\t\t\t\t});\n\t\t\t\tvar form = ghost.querySelector(\"[data-kanban-drag-move-form]\");\n\t\t\t\tif (form) form.remove();\n\t\t\t\tdelete ghost.dataset.kanbanDragging;\n\t\t\t\tvar origin = document.createElement(\"div\");\n\t\t\t\torigin.className = \"mb-1.5 flex items-center gap-1.5 border-b border-line pb-1.5 font-mono text-2xs font-medium text-accent\";\n\t\t\t\torigin.textContent = \"From \" + (card.dataset.kanbanCurrentState || \"current lane\");\n\t\t\t\tghost.insertBefore(origin, ghost.firstChild);\n\t\t\t\tghost.setAttribute(\"aria-hidden\", \"true\");\n\t\t\t\tghost.style.position = \"fixed\";\n\t\t\t\tghost.style.left = \"0\";\n\t\t\t\tghost.style.top = \"0\";\n\t\t\t\tghost.style.margin = \"0\";\n\t\t\t\tghost.style.width = rect.width + \"px\";\n\t\t\t\tghost.style.height = rect.height + \"px\";\n\t\t\t\tghost.style.pointerEvents = \"none\";\n\t\t\t\tghost.style.zIndex = \"1000\";\n\t\t\t\tghost.style.opacity = \"0.9\";\n\t\t\t\tghost.style.boxShadow = \"0 12px 32px rgba(0, 0, 0, 0.35)\";\n\t\t\t\tghost.style.willChange = \"transform\";\n\t\t\t\tdocument.body.appendChild(ghost);\n\t\t\t\treturn ghost;\n\t\t\t}\n\t\t\tfunction moveGhost(ghost, x, y, offsetX, offsetY) {\n\t\t\t\tghost.style.transform = \"translate(\" + Math.round(x - offsetX) + \"px, \" + Math.round(y - offsetY) + \"px)\";\n\t\t\t}\n\t\t\tfunction laneFromPoint(x, y) {\n\t\t\t\tvar hit = document.elementFromPoint(x, y);\n\t\t\t\treturn hit instanceof Element ? hit.closest(\"[data-kanban-drop-state]\") : null;\n\t\t\t}\n\t\t\tfunction applyTouchStyle(element, styles) {\n\t\t\t\tif (!active || active.pointerType !== \"touch\" || !(element instanceof HTMLElement) || !element.isConnected) return;\n\t\t\t\tif (!active.touchStyles.has(element)) {\n\t\t\t\t\tvar original = {};\n\t\t\t\t\tObject.keys(styles).forEach(function (property) {\n\t\t\t\t\t\toriginal[property] = element.style[property];\n\t\t\t\t\t});\n\t\t\t\t\tactive.touchStyles.set(element, original);\n\t\t\t\t}\n\t\t\t\tObject.keys(styles).forEach(function (property) {\n\t\t\t\t\telement.style[property] = styles[property];\n\t\t\t\t});\n\t\t\t}\n\t\t\tfunction applyTouchDragStyles(card, scope) {\n\t\t\t\tif (!active || active.pointerType !== \"touch\") return;\n\t\t\t\tvar root = queryRoot(scope);\n\t\t\t\tvar lanes = root.querySelector(\"[data-board-lanes]\");\n\t\t\t\tapplyTouchStyle(lanes, { touchAction: \"none\", scrollSnapType: \"none\" });\n\t\t\t\tapplyTouchStyle(card, {\n\t\t\t\t\ttouchAction: \"none\",\n\t\t\t\t\toutline: \"2px solid var(--color-accent)\",\n\t\t\t\t\toutlineOffset: \"2px\"\n\t\t\t\t});\n\t\t\t}\n\t\t\tfunction restoreTouchDragStyles() {\n\t\t\t\tif (!active || !active.touchStyles) return;\n\t\t\t\tactive.touchStyles.forEach(function (styles, element) {\n\t\t\t\t\tObject.keys(styles).forEach(function (property) {\n\t\t\t\t\t\telement.style[property] = styles[property];\n\t\t\t\t\t});\n\t\t\t\t});\n\t\t\t\tactive.touchStyles.clear();\n\t\t\t}\n\t\t\t// Native drags auto-scrolled the lane strip at the viewport edges;\n\t\t\t// pointer drags must do it themselves. Scrolls only while the\n\t\t\t// pointer moves, which is enough to reach off-screen lanes.\n\t\t\tfunction autoScrollLanes(x) {\n\t\t\t\tvar lanes = document.getElementById(\"board-lanes\");\n\t\t\t\tif (!lanes) return;\n\t\t\t\tvar rect = lanes.getBoundingClientRect();\n\t\t\t\tif (x < rect.left + 48) {\n\t\t\t\t\tlanes.scrollLeft -= 16;\n\t\t\t\t} else if (x > rect.right - 48) {\n\t\t\t\t\tlanes.scrollLeft += 16;\n\t\t\t\t}\n\t\t\t}\n\t\t\tfunction visibleDropLanes(lanes) {\n\t\t\t\treturn Array.from(lanes.querySelectorAll(\"[data-kanban-drop-state]\")).filter(function (lane) {\n\t\t\t\t\treturn lane instanceof HTMLElement && lane.dataset.laneHidden !== \"true\";\n\t\t\t\t});\n\t\t\t}\n\t\t\tfunction closestLaneIndex(lanes, laneNodes) {\n\t\t\t\tvar center = lanes.getBoundingClientRect().left + lanes.clientWidth / 2;\n\t\t\t\tvar closest = 0;\n\t\t\t\tvar distance = Infinity;\n\t\t\t\tlaneNodes.forEach(function (lane, index) {\n\t\t\t\t\tvar rect = lane.getBoundingClientRect();\n\t\t\t\t\tvar candidate = Math.abs(rect.left + rect.width / 2 - center);\n\t\t\t\t\tif (candidate < distance) {\n\t\t\t\t\t\tdistance = candidate;\n\t\t\t\t\t\tclosest = index;\n\t\t\t\t\t}\n\t\t\t\t});\n\t\t\t\treturn closest;\n\t\t\t}\n\t\t\tfunction advanceTouchLane(direction) {\n\t\t\t\tif (!active || active.pointerType !== \"touch\" || active.edgeDirection !== direction) return;\n\t\t\t\tactive.edgeTimer = null;\n\t\t\t\tvar lanes = document.getElementById(\"board-lanes\");\n\t\t\t\tif (!lanes) return;\n\t\t\t\tvar laneNodes = visibleDropLanes(lanes);\n\t\t\t\tif (laneNodes.length === 0) return;\n\t\t\t\tvar current = closestLaneIndex(lanes, laneNodes);\n\t\t\t\tvar target = Math.max(0, Math.min(laneNodes.length - 1, current + direction));\n\t\t\t\tif (target !== current) {\n\t\t\t\t\tlaneNodes[target].scrollIntoView({ behavior: \"smooth\", block: \"nearest\", inline: \"start\" });\n\t\t\t\t}\n\t\t\t\tif (active && active.edgeDirection === direction && target !== current) {\n\t\t\t\t\tactive.edgeTimer = window.setTimeout(function () {\n\t\t\t\t\t\tadvanceTouchLane(direction);\n\t\t\t\t\t}, TOUCH_EDGE_ADVANCE_MS);\n\t\t\t\t}\n\t\t\t}\n\t\t\tfunction updateTouchEdgeAdvance(x) {\n\t\t\t\tif (!active || active.pointerType !== \"touch\") return;\n\t\t\t\tvar lanes = document.getElementById(\"board-lanes\");\n\t\t\t\tif (!lanes) return;\n\t\t\t\tvar rect = lanes.getBoundingClientRect();\n\t\t\t\tvar direction = x < rect.left + TOUCH_EDGE_ZONE_PX ? -1 : (x > rect.right - TOUCH_EDGE_ZONE_PX ? 1 : 0);\n\t\t\t\tif (direction === active.edgeDirection) return;\n\t\t\t\tif (active.edgeTimer) window.clearTimeout(active.edgeTimer);\n\t\t\t\tactive.edgeDirection = direction;\n\t\t\t\tactive.edgeTimer = direction === 0 ? null : window.setTimeout(function () {\n\t\t\t\t\tadvanceTouchLane(direction);\n\t\t\t\t}, TOUCH_EDGE_ADVANCE_MS);\n\t\t\t}\n\t\t\tfunction stopTouchEdgeAdvance() {\n\t\t\t\tif (!active) return;\n\t\t\t\tif (active.edgeTimer) window.clearTimeout(active.edgeTimer);\n\t\t\t\tactive.edgeTimer = null;\n\t\t\t\tactive.edgeDirection = 0;\n\t\t\t}\n\t\t\tfunction suppressNextClick() {\n\t\t\t\tvar until = Date.now() + 400;\n\t\t\t\tdocument.addEventListener(\"click\", function suppress(event) {\n\t\t\t\t\tdocument.removeEventListener(\"click\", suppress, true);\n\t\t\t\t\tif (Date.now() > until) return;\n\t\t\t\t\tevent.preventDefault();\n\t\t\t\t\tevent.stopImmediatePropagation();\n\t\t\t\t}, true);\n\t\t\t}\n\t\t\tfunction beginDrag(event) {\n\t\t\t\tvar press = pending;\n\t\t\t\tif (!press) return;\n\t\t\t\tif (press.longPressTimer) window.clearTimeout(press.longPressTimer);\n\t\t\t\tdraggedIssueID = press.issueID;\n\t\t\t\tdraggedAllowedTargetKeys = press.targets;\n\t\t\t\tvar card = draggedCard(document) || press.card;\n\t\t\t\tactive = {\n\t\t\t\t\tpointerId: press.pointerId,\n\t\t\t\t\tpointerType: press.pointerType,\n\t\t\t\t\ttouchIdentifier: press.touchIdentifier,\n\t\t\t\t\toffsetX: press.startX - press.rect.left,\n\t\t\t\t\toffsetY: press.startY - press.rect.top,\n\t\t\t\t\tghost: buildGhost(card, press.rect),\n\t\t\t\t\tlastLaneBlocked: false,\n\t\t\t\t\tstartedAt: press.startedAt,\n\t\t\t\t\tcaptureElement: press.card,\n\t\t\t\t\ttouchStyles: new Map(),\n\t\t\t\t\tedgeDirection: 0,\n\t\t\t\t\tedgeTimer: null\n\t\t\t\t};\n\t\t\t\tpending = null;\n\t\t\t\trecentTouchStart = null;\n\t\t\t\tif (active.pointerType === \"touch\" && typeof active.captureElement.setPointerCapture === \"function\") {\n\t\t\t\t\ttry {\n\t\t\t\t\t\tactive.captureElement.setPointerCapture(active.pointerId);\n\t\t\t\t\t} catch (_) {}\n\t\t\t\t}\n\t\t\t\tcard.dataset.kanbanDragging = \"true\";\n\t\t\t\tsetDropTargetState(card, document);\n\t\t\t\tapplyTouchDragStyles(card, document);\n\t\t\t\tfeedback(\"Moving \" + (card.dataset.kanbanCurrentState || \"card\") + \".\");\n\t\t\t\tmoveGhost(active.ghost, event.clientX, event.clientY, active.offsetX, active.offsetY);\n\t\t\t}\n\t\t\tfunction finishDrag(keepClick) {\n\t\t\t\tif (active) {\n\t\t\t\t\tstopTouchEdgeAdvance();\n\t\t\t\t\trestoreTouchDragStyles();\n\t\t\t\t\tif (active.ghost) active.ghost.remove();\n\t\t\t\t\tif (active.captureElement && typeof active.captureElement.releasePointerCapture === \"function\") {\n\t\t\t\t\t\ttry {\n\t\t\t\t\t\t\tif (active.captureElement.hasPointerCapture(active.pointerId)) active.captureElement.releasePointerCapture(active.pointerId);\n\t\t\t\t\t\t} catch (_) {}\n\t\t\t\t\t}\n\t\t\t\t}\n\t\t\t\tclearPending();\n\t\t\t\tactive = null;\n\t\t\t\tdraggedIssueID = \"\";\n\t\t\t\tdraggedAllowedTargetKeys = [];\n\t\t\t\tclearDropTargetState();\n\t\t\t\t// A drag ends with the pointer still over a card, so the release\n\t\t\t\t// also fires a click; swallow it or the detail sheet opens.\n\t\t\t\tif (!keepClick) suppressNextClick();\n\t\t\t}\n\t\t\tfunction cancelDrag(keepClick) {\n\t\t\t\tif (!active) {\n\t\t\t\t\tclearPending();\n\t\t\t\t\treturn;\n\t\t\t\t}\n\t\t\t\tfinishDrag(keepClick);\n\t\t\t\tfeedback(\"Move cancelled.\", \"error\");\n\t\t\t}\n\t\t\tfunction rollbackPendingMove(card) {\n\t\t\t\tif (!(card instanceof HTMLElement) || !card.dataset.kanbanPendingMove) return;\n\t\t\t\tvar targetLane = card.closest(\"[data-kanban-drop-state]\");\n\t\t\t\tvar targetWasHidden = card.dataset.kanbanPendingTargetWasHidden === \"true\";\n\t\t\t\tvar originState = card.dataset.kanbanPendingOrigin || \"\";\n\t\t\t\tclearPendingMove(card);\n\t\t\t\tplaceCardInLane(card, originState, document);\n\t\t\t\tif (targetLane instanceof HTMLElement) {\n\t\t\t\t\ttargetLane.dataset.laneHidden = targetWasHidden ? \"true\" : \"false\";\n\t\t\t\t\tupdateEmptyLine(cardContainer(targetLane));\n\t\t\t\t}\n\t\t\t}\n\t\t\tfunction moveDragTo(x, y) {\n\t\t\t\tif (!active) return;\n\t\t\t\tmoveGhost(active.ghost, x, y, active.offsetX, active.offsetY);\n\t\t\t\tif (active.pointerType === \"touch\") {\n\t\t\t\t\tupdateTouchEdgeAdvance(x);\n\t\t\t\t} else {\n\t\t\t\t\tautoScrollLanes(x);\n\t\t\t\t}\n\t\t\t\tvar lane = laneFromPoint(x, y);\n\t\t\t\tvar card = draggedCard(document);\n\t\t\t\tvar blocked = lane instanceof HTMLElement && lane.dataset.kanbanDropSource !== \"true\" && !laneAllowed(card, lane);\n\t\t\t\tif (blocked && !active.lastLaneBlocked) {\n\t\t\t\t\tfeedback(\"Move blocked by transition policy.\", \"error\");\n\t\t\t\t} else if (!blocked && active.lastLaneBlocked) {\n\t\t\t\t\tfeedback(\"Moving \" + ((card && card.dataset.kanbanCurrentState) || \"card\") + \".\");\n\t\t\t\t}\n\t\t\t\tactive.lastLaneBlocked = blocked;\n\t\t\t}\n\t\t\tdocument.addEventListener(\"pointerdown\", function (event) {\n\t\t\t\tif (active || event.button !== 0 || event.isPrimary === false) return;\n\t\t\t\tvar card = event.target instanceof Element ? event.target.closest(\"[data-kanban-card][data-kanban-action='move']\") : null;\n\t\t\t\tif (!card) return;\n\t\t\t\tif (card.dataset.kanbanPendingMove) return;\n\t\t\t\tvar issueID = card.dataset.kanbanIssueId || \"\";\n\t\t\t\tif (!issueID) return;\n\t\t\t\tpending = {\n\t\t\t\t\tpointerId: event.pointerId,\n\t\t\t\t\tpointerType: event.pointerType,\n\t\t\t\t\ttouchIdentifier: recentTouchIdentifier(card, event),\n\t\t\t\t\tcard: card,\n\t\t\t\t\tissueID: issueID,\n\t\t\t\t\ttargets: targetKeysFromValue(card.dataset.kanbanAllowedTargets || \"\"),\n\t\t\t\t\trect: card.getBoundingClientRect(),\n\t\t\t\t\tstartX: event.clientX,\n\t\t\t\t\tstartY: event.clientY,\n\t\t\t\t\tlastX: event.clientX,\n\t\t\t\t\tlastY: event.clientY,\n\t\t\t\t\tstartedAt: Date.now(),\n\t\t\t\t\tlongPressTimer: null\n\t\t\t\t};\n\t\t\t\tif (event.pointerType === \"touch\") {\n\t\t\t\t\tvar pointerId = event.pointerId;\n\t\t\t\t\tpending.longPressTimer = window.setTimeout(function () {\n\t\t\t\t\t\tif (!pending || pending.pointerId !== pointerId) return;\n\t\t\t\t\t\tbeginDrag({ clientX: pending.lastX, clientY: pending.lastY });\n\t\t\t\t\t}, TOUCH_LONG_PRESS_MS);\n\t\t\t\t}\n\t\t\t});\n\t\t\tdocument.addEventListener(\"touchstart\", function (event) {\n\t\t\t\tif (active || !event.changedTouches || event.changedTouches.length === 0) return;\n\t\t\t\tvar touch = event.changedTouches[0];\n\t\t\t\trecentTouchStart = {\n\t\t\t\t\tidentifier: touch.identifier,\n\t\t\t\t\ttarget: event.target,\n\t\t\t\t\tstartedAt: Date.now()\n\t\t\t\t};\n\t\t\t\tif (pending && pending.pointerType === \"touch\" && event.target instanceof Node && pending.card.contains(event.target)) {\n\t\t\t\t\tpending.touchIdentifier = touch.identifier;\n\t\t\t\t}\n\t\t\t});\n\t\t\tdocument.addEventListener(\"pointermove\", function (event) {\n\t\t\t\tif (pending && event.pointerId === pending.pointerId) {\n\t\t\t\t\tif (pending.pointerType === \"touch\") {\n\t\t\t\t\t\tif (Math.hypot(event.clientX - pending.startX, event.clientY - pending.startY) >= TOUCH_MOVE_TOLERANCE_PX) {\n\t\t\t\t\t\t\tclearPending();\n\t\t\t\t\t\t\treturn;\n\t\t\t\t\t\t}\n\t\t\t\t\t\tpending.lastX = event.clientX;\n\t\t\t\t\t\tpending.lastY = event.clientY;\n\t\t\t\t\t\treturn;\n\t\t\t\t\t}\n\t\t\t\t\t// A missed pointerup (released outside the window) must not\n\t\t\t\t\t// leave a stale press that turns a later hover into a drag.\n\t\t\t\t\tif (event.buttons === 0) {\n\t\t\t\t\t\tclearPending();\n\t\t\t\t\t\treturn;\n\t\t\t\t\t}\n\t\t\t\t\tif (Math.hypot(event.clientX - pending.startX, event.clientY - pending.startY) < DRAG_THRESHOLD_PX) return;\n\t\t\t\t\tbeginDrag(event);\n\t\t\t\t\treturn;\n\t\t\t\t}\n\t\t\t\tif (!active || event.pointerId !== active.pointerId) return;\n\t\t\t\tif (active.pointerType !== \"touch\" && event.buttons === 0) {\n\t\t\t\t\t// The release happened outside the window, so no click is\n\t\t\t\t\t// coming — cancelling must not arm the click suppressor or\n\t\t\t\t\t// it would eat the next real click after recovery.\n\t\t\t\t\tcancelDrag(true);\n\t\t\t\t\treturn;\n\t\t\t\t}\n\t\t\t\tevent.preventDefault();\n\t\t\t\tmoveDragTo(event.clientX, event.clientY);\n\t\t\t}, { passive: false });\n\t\t\tfunction dropAt(x, y) {\n\t\t\t\tif (!active) return;\n\t\t\t\tvar lane = laneFromPoint(x, y);\n\t\t\t\tvar card = draggedCard(document);\n\t\t\t\tif (!(lane instanceof HTMLElement)) {\n\t\t\t\t\tcancelDrag();\n\t\t\t\t\treturn;\n\t\t\t\t}\n\t\t\t\tif (lane.dataset.kanbanDropSource === \"true\") {\n\t\t\t\t\tif (Date.now() - active.startedAt < CLICK_GESTURE_MS) {\n\t\t\t\t\t\tfinishDrag(true);\n\t\t\t\t\t\tfeedback(\"\");\n\t\t\t\t\t\treturn;\n\t\t\t\t\t}\n\t\t\t\t\tcancelDrag();\n\t\t\t\t\treturn;\n\t\t\t\t}\n\t\t\t\tif (!laneAllowed(card, lane)) {\n\t\t\t\t\tfinishDrag();\n\t\t\t\t\tfeedback(\"Move blocked by transition policy.\", \"error\");\n\t\t\t\t\treturn;\n\t\t\t\t}\n\t\t\t\tvar form = card ? card.querySelector(\"[data-kanban-drag-move-form]\") : null;\n\t\t\t\tvar targetState = form ? form.querySelector(\"[data-kanban-drag-target-state]\") : null;\n\t\t\t\tif (!(form instanceof HTMLFormElement) || !(targetState instanceof HTMLInputElement)) {\n\t\t\t\t\tcancelDrag();\n\t\t\t\t\treturn;\n\t\t\t\t}\n\t\t\t\ttargetState.value = lane.dataset.kanbanDropState || \"\";\n\t\t\t\tcard.dataset.kanbanPendingMove = targetState.value;\n\t\t\t\tcard.dataset.kanbanPendingOrigin = card.dataset.kanbanCurrentState || \"\";\n\t\t\t\tif (card.dataset.kanbanDataSeq) card.dataset.kanbanPendingSeq = card.dataset.kanbanDataSeq;\n\t\t\t\tcard.dataset.kanbanPendingTargetWasHidden = lane.dataset.kanbanDropWasHidden || lane.dataset.laneHidden || \"false\";\n\t\t\t\tplaceCardInLane(card, targetState.value, document);\n\t\t\t\tfinishDrag();\n\t\t\t\tplaceCardInLane(card, targetState.value, document);\n\t\t\t\tform.requestSubmit();\n\t\t\t}\n\t\t\tdocument.addEventListener(\"pointerup\", function (event) {\n\t\t\t\tif (pending && event.pointerId === pending.pointerId) {\n\t\t\t\t\tclearPending();\n\t\t\t\t\treturn;\n\t\t\t\t}\n\t\t\t\tif (!active || event.pointerId !== active.pointerId) return;\n\t\t\t\tdropAt(event.clientX, event.clientY);\n\t\t\t});\n\t\t\tdocument.addEventListener(\"pointercancel\", function (event) {\n\t\t\t\tif (pending && event.pointerId === pending.pointerId) {\n\t\t\t\t\tclearPending();\n\t\t\t\t\treturn;\n\t\t\t\t}\n\t\t\t\tif (active && event.pointerId === active.pointerId && active.pointerType !== \"touch\") cancelDrag();\n\t\t\t});\n\t\t\tdocument.addEventListener(\"touchmove\", function (event) {\n\t\t\t\tif (!active || active.pointerType !== \"touch\") return;\n\t\t\t\tevent.preventDefault();\n\t\t\t\tvar touch = touchWithIdentifier(event.touches, active.touchIdentifier);\n\t\t\t\tif (!touch && active.touchIdentifier === null && event.touches && event.touches.length === 1) touch = event.touches[0];\n\t\t\t\tif (touch) moveDragTo(touch.clientX, touch.clientY);\n\t\t\t}, { passive: false });\n\t\t\tdocument.addEventListener(\"touchend\", function (event) {\n\t\t\t\tif (pending && pending.pointerType === \"touch\") {\n\t\t\t\t\tvar pendingTouch = touchWithIdentifier(event.changedTouches, pending.touchIdentifier);\n\t\t\t\t\tif (!pendingTouch && !(pending.touchIdentifier === null && event.touches && event.touches.length === 0)) return;\n\t\t\t\t\tclearPending();\n\t\t\t\t\treturn;\n\t\t\t\t}\n\t\t\t\tif (!active || active.pointerType !== \"touch\") return;\n\t\t\t\tvar touch = touchWithIdentifier(event.changedTouches, active.touchIdentifier);\n\t\t\t\tif (!touch && active.touchIdentifier === null && event.touches && event.touches.length === 0) touch = event.changedTouches && event.changedTouches[0];\n\t\t\t\tif (touch) dropAt(touch.clientX, touch.clientY);\n\t\t\t});\n\t\t\tdocument.addEventListener(\"touchcancel\", function (event) {\n\t\t\t\tif (pending && pending.pointerType === \"touch\") {\n\t\t\t\t\tvar pendingTouch = touchWithIdentifier(event.changedTouches, pending.touchIdentifier);\n\t\t\t\t\tif (!pendingTouch && !(pending.touchIdentifier === null && event.touches && event.touches.length === 0)) return;\n\t\t\t\t\tclearPending();\n\t\t\t\t\treturn;\n\t\t\t\t}\n\t\t\t\tif (!active || active.pointerType !== \"touch\") return;\n\t\t\t\tvar touch = touchWithIdentifier(event.changedTouches, active.touchIdentifier);\n\t\t\t\tif (touch || (active.touchIdentifier === null && event.touches && event.touches.length === 0)) cancelDrag();\n\t\t\t});\n\t\t\tdocument.addEventListener(\"contextmenu\", function (event) {\n\t\t\t\tvar touchPress = pending && pending.pointerType === \"touch\";\n\t\t\t\tvar touchDrag = active && active.pointerType === \"touch\";\n\t\t\t\tif ((touchPress || touchDrag) && event.target instanceof Element && event.target.closest(\"[data-kanban-card]\")) {\n\t\t\t\t\tevent.preventDefault();\n\t\t\t\t}\n\t\t\t});\n\t\t\tdocument.addEventListener(\"keydown\", function (event) {\n\t\t\t\tif (event.key === \"Escape\" && active) cancelDrag();\n\t\t\t});\n\t\t\twindow.addEventListener(\"blur\", function () {\n\t\t\t\tif (active) cancelDrag();\n\t\t\t});\n\t\t\t// Native HTML5 drags stay disabled inside cards (links, images):\n\t\t\t// they would start a compositor drag session that steals the pointer.\n\t\t\tdocument.addEventListener(\"dragstart\", function (event) {\n\t\t\t\tif (event.target instanceof Element && event.target.closest(\"[data-kanban-card]\")) {\n\t\t\t\t\tevent.preventDefault();\n\t\t\t\t}\n\t\t\t});\n\t\t\tdocument.addEventListener(\"htmx:afterSettle\", function () {\n\t\t\t\tapplyDragState(document);\n\t\t\t});\n\t\t\tfunction handleMoveError(event) {\n\t\t\t\tvar form = event.detail && event.detail.elt;\n\t\t\t\tif (!(form instanceof HTMLFormElement) || !form.matches(\"[data-kanban-drag-move-form]\")) return;\n\t\t\t\tvar issueIDInput = form.querySelector(\"input[name='issue_id']\");\n\t\t\t\tvar issueID = issueIDInput instanceof HTMLInputElement ? issueIDInput.value : \"\";\n\t\t\t\tvar card = form.closest(\"[data-kanban-card][data-kanban-pending-move]\");\n\t\t\t\tif (!(card instanceof HTMLElement) || !card.isConnected) card = cardByIssueID(document, issueID);\n\t\t\t\trollbackPendingMove(card);\n\t\t\t\tvar response = event.detail.xhr ? event.detail.xhr.responseText : \"\";\n\t\t\t\tfeedback(responseMessage(response) || \"Move failed.\", \"error\");\n\t\t\t}\n\t\t\tdocument.body.addEventListener(\"htmx:responseError\", handleMoveError);\n\t\t\tdocument.body.addEventListener(\"htmx:sendError\", handleMoveError);\n\t\t\tdocument.body.addEventListener(\"htmx:timeout\", handleMoveError);\n\t\t})();\n\t</script>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -2616,61 +2643,61 @@ func boardScopeSelect(data DashboardData) templ.Component {
 			}()
 		}
 		ctx = templ.InitializeContext(ctx)
-		templ_7745c5c3_Var138 := templ.GetChildren(ctx)
-		if templ_7745c5c3_Var138 == nil {
-			templ_7745c5c3_Var138 = templ.NopComponent
+		templ_7745c5c3_Var139 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var139 == nil {
+			templ_7745c5c3_Var139 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 215, "<details class=\"group/scope relative min-w-0\"><summary class=\"flex min-w-0 cursor-pointer list-none items-center gap-1.5 rounded-card border border-line px-2.5 py-1 text-xs text-sec hover:text-text [&::-webkit-details-marker]:hidden\"><span class=\"min-w-0 truncate\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 218, "<details class=\"group/scope relative min-w-0\"><summary class=\"flex min-w-0 cursor-pointer list-none items-center gap-1.5 rounded-card border border-line px-2.5 py-1 text-xs text-sec hover:text-text [&::-webkit-details-marker]:hidden\"><span class=\"min-w-0 truncate\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		var templ_7745c5c3_Var139 string
-		templ_7745c5c3_Var139, templ_7745c5c3_Err = templ.JoinStringErrs(boardScopeLabel(data))
+		var templ_7745c5c3_Var140 string
+		templ_7745c5c3_Var140, templ_7745c5c3_Err = templ.JoinStringErrs(boardScopeLabel(data))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 1729, Col: 57}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 1735, Col: 57}
 		}
-		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var139))
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var140))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 216, "</span> <span aria-hidden=\"true\">▾</span></summary><div class=\"absolute left-0 top-full z-40 mt-1 flex w-52 flex-col gap-0.5 rounded-card border border-line bg-elev p-1.5\"><a href=\"/\" class=\"rounded-chip px-2 py-1 text-xs text-text hover:bg-surface\">All projects</a> ")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 219, "</span> <span aria-hidden=\"true\">▾</span></summary><div class=\"absolute left-0 top-full z-40 mt-1 flex w-52 flex-col gap-0.5 rounded-card border border-line bg-elev p-1.5\"><a href=\"/\" class=\"rounded-chip px-2 py-1 text-xs text-text hover:bg-surface\">All projects</a> ")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		for _, project := range appShellProjects(DashboardShellDataFromDashboard(data)) {
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 217, "<a href=\"")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 220, "<a href=\"")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			var templ_7745c5c3_Var140 templ.SafeURL
-			templ_7745c5c3_Var140, templ_7745c5c3_Err = templ.JoinURLErrs(templ.SafeURL(project.Href))
+			var templ_7745c5c3_Var141 templ.SafeURL
+			templ_7745c5c3_Var141, templ_7745c5c3_Err = templ.JoinURLErrs(templ.SafeURL(project.Href))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 1735, Col: 41}
-			}
-			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var140))
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 218, "\" class=\"truncate rounded-chip px-2 py-1 text-xs text-text hover:bg-surface\">")
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
-			var templ_7745c5c3_Var141 string
-			templ_7745c5c3_Var141, templ_7745c5c3_Err = templ.JoinStringErrs(project.Name)
-			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 1735, Col: 133}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 1741, Col: 41}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var141))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 219, "</a>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 221, "\" class=\"truncate rounded-chip px-2 py-1 text-xs text-text hover:bg-surface\">")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			var templ_7745c5c3_Var142 string
+			templ_7745c5c3_Var142, templ_7745c5c3_Err = templ.JoinStringErrs(project.Name)
+			if templ_7745c5c3_Err != nil {
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 1741, Col: 133}
+			}
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var142))
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 222, "</a>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 220, "</div></details>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 223, "</div></details>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}

--- a/internal/web/templates/dashboard_data.go
+++ b/internal/web/templates/dashboard_data.go
@@ -599,6 +599,8 @@ type projectKanbanCard struct {
 	MergeLaneClass        string
 	Stage                 string
 	StageAt               time.Time
+	Origin                string
+	OriginActor           string
 	PriorityRank          int
 	PriorityName          string
 	DispatchPriorityLabel string
@@ -2986,6 +2988,8 @@ func projectKanbanCardForIssue(data DashboardData, issue telemetry.Issue, state 
 		AttentionDetail:       projectKanbanAttentionDetail(issue),
 		Stage:                 chartText(state, "n/a"),
 		StageAt:               stageAt.UTC(),
+		Origin:                strings.TrimSpace(issue.Origin),
+		OriginActor:           strings.TrimSpace(issue.OriginActor),
 		PriorityRank:          projectKanbanPriorityRank(issue.Priority),
 		PriorityName:          strings.TrimSpace(issue.PriorityName),
 		UnblockerCount:        issue.UnblockerCount,

--- a/internal/web/templates/sheet.templ
+++ b/internal/web/templates/sheet.templ
@@ -150,6 +150,9 @@ templ BoardCardSheetCore(data DashboardData, card projectKanbanCard, boardAction
 			if card.TimeInStage != "" && card.TimeInStage != "n/a" {
 				@sheetRowValue("Time in stage", card.TimeInStage, card.TimeInStageTitle)
 			}
+			if card.Origin != "" {
+				@sheetRowValue("Origin", boardCardOriginDetail(card.Origin, card.OriginActor), "Mechanism that placed this issue in its current state")
+			}
 			if card.WaitDetail != "" {
 				@sheetRowValue("Waiting on", card.WaitDetail, card.WaitDetail)
 			}

--- a/internal/web/templates/sheet_templ.go
+++ b/internal/web/templates/sheet_templ.go
@@ -585,6 +585,12 @@ func BoardCardSheetCore(data DashboardData, card projectKanbanCard, boardActions
 				return templ_7745c5c3_Err
 			}
 		}
+		if card.Origin != "" {
+			templ_7745c5c3_Err = sheetRowValue("Origin", boardCardOriginDetail(card.Origin, card.OriginActor), "Mechanism that placed this issue in its current state").Render(ctx, templ_7745c5c3_Buffer)
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+		}
 		if card.WaitDetail != "" {
 			templ_7745c5c3_Err = sheetRowValue("Waiting on", card.WaitDetail, card.WaitDetail).Render(ctx, templ_7745c5c3_Buffer)
 			if templ_7745c5c3_Err != nil {
@@ -709,7 +715,7 @@ func BoardCardSheetCore(data DashboardData, card projectKanbanCard, boardActions
 				var templ_7745c5c3_Var29 string
 				templ_7745c5c3_Var29, templ_7745c5c3_Err = templ.JoinStringErrs(session.State)
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/sheet.templ`, Line: 191, Col: 22}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/sheet.templ`, Line: 194, Col: 22}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var29))
 				if templ_7745c5c3_Err != nil {
@@ -795,7 +801,7 @@ func BoardCardSheetCore(data DashboardData, card projectKanbanCard, boardActions
 				var templ_7745c5c3_Var30 string
 				templ_7745c5c3_Var30, templ_7745c5c3_Err = templ.JoinStringErrs(session.Error)
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/sheet.templ`, Line: 221, Col: 78}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/sheet.templ`, Line: 224, Col: 78}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var30))
 				if templ_7745c5c3_Err != nil {
@@ -847,7 +853,7 @@ func BoardEfficiencyReceiptPending(path string) templ.Component {
 		var templ_7745c5c3_Var32 string
 		templ_7745c5c3_Var32, templ_7745c5c3_Err = templ.JoinStringErrs(path)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/sheet.templ`, Line: 236, Col: 15}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/sheet.templ`, Line: 239, Col: 15}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var32))
 		if templ_7745c5c3_Err != nil {
@@ -904,7 +910,7 @@ func BoardEfficiencyReceipt(receipt efficiency.Receipt, present bool, path strin
 			var templ_7745c5c3_Var34 string
 			templ_7745c5c3_Var34, templ_7745c5c3_Err = templ.JoinStringErrs(message)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/sheet.templ`, Line: 257, Col: 16}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/sheet.templ`, Line: 260, Col: 16}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var34))
 			if templ_7745c5c3_Err != nil {
@@ -917,7 +923,7 @@ func BoardEfficiencyReceipt(receipt efficiency.Receipt, present bool, path strin
 			var templ_7745c5c3_Var35 string
 			templ_7745c5c3_Var35, templ_7745c5c3_Err = templ.JoinStringErrs(path)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/sheet.templ`, Line: 258, Col: 121}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/sheet.templ`, Line: 261, Col: 121}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var35))
 			if templ_7745c5c3_Err != nil {
@@ -1024,7 +1030,7 @@ func detailSheetLoadingRegion(label string, message string, heightClass string) 
 		var templ_7745c5c3_Var39 string
 		templ_7745c5c3_Var39, templ_7745c5c3_Err = templ.JoinStringErrs(label)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/sheet.templ`, Line: 277, Col: 119}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/sheet.templ`, Line: 280, Col: 119}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var39))
 		if templ_7745c5c3_Err != nil {
@@ -1037,7 +1043,7 @@ func detailSheetLoadingRegion(label string, message string, heightClass string) 
 		var templ_7745c5c3_Var40 string
 		templ_7745c5c3_Var40, templ_7745c5c3_Err = templ.JoinStringErrs(label)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/sheet.templ`, Line: 278, Col: 81}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/sheet.templ`, Line: 281, Col: 81}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var40))
 		if templ_7745c5c3_Err != nil {
@@ -1050,7 +1056,7 @@ func detailSheetLoadingRegion(label string, message string, heightClass string) 
 		var templ_7745c5c3_Var41 string
 		templ_7745c5c3_Var41, templ_7745c5c3_Err = templ.JoinStringErrs(message)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/sheet.templ`, Line: 279, Col: 93}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/sheet.templ`, Line: 282, Col: 93}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var41))
 		if templ_7745c5c3_Err != nil {
@@ -1094,7 +1100,7 @@ func sheetIssueAction(data DashboardData, card projectKanbanCard) templ.Componen
 				var templ_7745c5c3_Var43 templ.SafeURL
 				templ_7745c5c3_Var43, templ_7745c5c3_Err = templ.JoinURLErrs(card.URL)
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/sheet.templ`, Line: 286, Col: 21}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/sheet.templ`, Line: 289, Col: 21}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var43))
 				if templ_7745c5c3_Err != nil {
@@ -1112,7 +1118,7 @@ func sheetIssueAction(data DashboardData, card projectKanbanCard) templ.Componen
 				var templ_7745c5c3_Var44 templ.SafeURL
 				templ_7745c5c3_Var44, templ_7745c5c3_Err = templ.JoinURLErrs(card.URL)
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/sheet.templ`, Line: 288, Col: 21}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/sheet.templ`, Line: 291, Col: 21}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var44))
 				if templ_7745c5c3_Err != nil {
@@ -1170,7 +1176,7 @@ func sheetCommentTrigger(data DashboardData, card projectKanbanCard, target stri
 			var templ_7745c5c3_Var47 string
 			templ_7745c5c3_Var47, templ_7745c5c3_Err = templ.JoinStringErrs(projectKanbanCommentDialogPath(data, card, target))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/sheet.templ`, Line: 300, Col: 62}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/sheet.templ`, Line: 303, Col: 62}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var47))
 			if templ_7745c5c3_Err != nil {
@@ -1183,7 +1189,7 @@ func sheetCommentTrigger(data DashboardData, card projectKanbanCard, target stri
 			var templ_7745c5c3_Var48 string
 			templ_7745c5c3_Var48, templ_7745c5c3_Err = templ.JoinStringErrs(kanbanDialogTargetSelector())
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/sheet.templ`, Line: 301, Col: 43}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/sheet.templ`, Line: 304, Col: 43}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var48))
 			if templ_7745c5c3_Err != nil {
@@ -1196,7 +1202,7 @@ func sheetCommentTrigger(data DashboardData, card projectKanbanCard, target stri
 			var templ_7745c5c3_Var49 string
 			templ_7745c5c3_Var49, templ_7745c5c3_Err = templ.JoinStringErrs(label + " " + card.IssueNumber)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/sheet.templ`, Line: 303, Col: 46}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/sheet.templ`, Line: 306, Col: 46}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var49))
 			if templ_7745c5c3_Err != nil {
@@ -1209,7 +1215,7 @@ func sheetCommentTrigger(data DashboardData, card projectKanbanCard, target stri
 			var templ_7745c5c3_Var50 string
 			templ_7745c5c3_Var50, templ_7745c5c3_Err = templ.JoinStringErrs(label)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/sheet.templ`, Line: 304, Col: 16}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/sheet.templ`, Line: 307, Col: 16}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var50))
 			if templ_7745c5c3_Err != nil {
@@ -1272,7 +1278,7 @@ func sheetRowText(label string) templ.Component {
 		var templ_7745c5c3_Var52 string
 		templ_7745c5c3_Var52, templ_7745c5c3_Err = templ.JoinStringErrs(label)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/sheet.templ`, Line: 316, Col: 132}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/sheet.templ`, Line: 319, Col: 132}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var52))
 		if templ_7745c5c3_Err != nil {
@@ -1285,7 +1291,7 @@ func sheetRowText(label string) templ.Component {
 		var templ_7745c5c3_Var53 string
 		templ_7745c5c3_Var53, templ_7745c5c3_Err = templ.JoinStringErrs(label)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/sheet.templ`, Line: 317, Col: 42}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/sheet.templ`, Line: 320, Col: 42}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var53))
 		if templ_7745c5c3_Err != nil {
@@ -1335,7 +1341,7 @@ func sheetRowValue(label string, value string, title string) templ.Component {
 		var templ_7745c5c3_Var55 string
 		templ_7745c5c3_Var55, templ_7745c5c3_Err = templ.JoinStringErrs(label)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/sheet.templ`, Line: 323, Col: 132}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/sheet.templ`, Line: 326, Col: 132}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var55))
 		if templ_7745c5c3_Err != nil {
@@ -1348,7 +1354,7 @@ func sheetRowValue(label string, value string, title string) templ.Component {
 		var templ_7745c5c3_Var56 string
 		templ_7745c5c3_Var56, templ_7745c5c3_Err = templ.JoinStringErrs(label)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/sheet.templ`, Line: 324, Col: 42}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/sheet.templ`, Line: 327, Col: 42}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var56))
 		if templ_7745c5c3_Err != nil {
@@ -1361,7 +1367,7 @@ func sheetRowValue(label string, value string, title string) templ.Component {
 		var templ_7745c5c3_Var57 string
 		templ_7745c5c3_Var57, templ_7745c5c3_Err = templ.JoinStringErrs(title)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/sheet.templ`, Line: 325, Col: 136}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/sheet.templ`, Line: 328, Col: 136}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var57))
 		if templ_7745c5c3_Err != nil {
@@ -1374,7 +1380,7 @@ func sheetRowValue(label string, value string, title string) templ.Component {
 		var templ_7745c5c3_Var58 string
 		templ_7745c5c3_Var58, templ_7745c5c3_Err = templ.JoinStringErrs(value)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/sheet.templ`, Line: 325, Col: 167}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/sheet.templ`, Line: 328, Col: 167}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var58))
 		if templ_7745c5c3_Err != nil {
@@ -1417,7 +1423,7 @@ func sheetRowLink(label string, value string, href string) templ.Component {
 			var templ_7745c5c3_Var60 string
 			templ_7745c5c3_Var60, templ_7745c5c3_Err = templ.JoinStringErrs(label)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/sheet.templ`, Line: 331, Col: 133}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/sheet.templ`, Line: 334, Col: 133}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var60))
 			if templ_7745c5c3_Err != nil {
@@ -1430,7 +1436,7 @@ func sheetRowLink(label string, value string, href string) templ.Component {
 			var templ_7745c5c3_Var61 string
 			templ_7745c5c3_Var61, templ_7745c5c3_Err = templ.JoinStringErrs(label)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/sheet.templ`, Line: 332, Col: 43}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/sheet.templ`, Line: 335, Col: 43}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var61))
 			if templ_7745c5c3_Err != nil {
@@ -1481,7 +1487,7 @@ func sheetTagRow(label string, values []string) templ.Component {
 		var templ_7745c5c3_Var63 string
 		templ_7745c5c3_Var63, templ_7745c5c3_Err = templ.JoinStringErrs(label)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/sheet.templ`, Line: 340, Col: 81}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/sheet.templ`, Line: 343, Col: 81}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var63))
 		if templ_7745c5c3_Err != nil {
@@ -1499,7 +1505,7 @@ func sheetTagRow(label string, values []string) templ.Component {
 			var templ_7745c5c3_Var64 string
 			templ_7745c5c3_Var64, templ_7745c5c3_Err = templ.JoinStringErrs(value)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/sheet.templ`, Line: 343, Col: 227}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/sheet.templ`, Line: 346, Col: 227}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var64))
 			if templ_7745c5c3_Err != nil {
@@ -1512,7 +1518,7 @@ func sheetTagRow(label string, values []string) templ.Component {
 			var templ_7745c5c3_Var65 string
 			templ_7745c5c3_Var65, templ_7745c5c3_Err = templ.JoinStringErrs(value)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/sheet.templ`, Line: 343, Col: 237}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/sheet.templ`, Line: 346, Col: 237}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var65))
 			if templ_7745c5c3_Err != nil {

--- a/internal/workflowmetrics/transition.go
+++ b/internal/workflowmetrics/transition.go
@@ -1,0 +1,153 @@
+package workflowmetrics
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"time"
+
+	"github.com/digitaldrywood/detent/internal/connector"
+)
+
+type Recorder interface {
+	RecordWorkflowPhaseEvent(context.Context, PhaseEvent) (int64, error)
+}
+
+type PhaseType string
+
+const (
+	PhaseTypeLane           PhaseType = "lane"
+	PhaseTypeAgentSession   PhaseType = "agent_session"
+	PhaseTypeLocalCheck     PhaseType = "local_check"
+	PhaseTypeCI             PhaseType = "ci"
+	PhaseTypeGitHubBackoff  PhaseType = "github_backoff"
+	PhaseTypeReview         PhaseType = "review"
+	PhaseTypeMergeQueue     PhaseType = "merge_queue"
+	PhaseTypeRecovery       PhaseType = "recovery"
+	PhaseTypeOperatorAction PhaseType = "operator_action"
+)
+
+type PhaseEvent struct {
+	ID                    int64
+	ProjectID             string
+	RunID                 int64
+	SessionID             int64
+	IssueID               string
+	Identifier            string
+	IssueURL              string
+	PRNumber              *int64
+	PhaseType             PhaseType
+	PhaseName             string
+	PreviousPhaseName     string
+	Reason                string
+	Status                string
+	StartedAt             time.Time
+	FinishedAt            time.Time
+	DurationSeconds       int64
+	CommandName           string
+	ExitCode              *int64
+	Turns                 int64
+	InputTokens           int64
+	CachedInputTokens     int64
+	OutputTokens          int64
+	ReasoningOutputTokens int64
+	TotalTokens           int64
+	ModelContextWindow    *int64
+	EndpointFamily        string
+	MetadataJSON          string
+}
+
+type LaneTransition struct {
+	ProjectID    string
+	Issue        connector.Issue
+	TargetState  string
+	At           time.Time
+	Reason       string
+	MetadataJSON string
+}
+
+func RecordLaneTransition(ctx context.Context, recorder Recorder, transition LaneTransition) error {
+	if recorder == nil {
+		return nil
+	}
+	sourceState := strings.TrimSpace(transition.Issue.State)
+	targetState := strings.TrimSpace(transition.TargetState)
+	if targetState == "" || strings.EqualFold(sourceState, targetState) {
+		return nil
+	}
+	at := transition.At
+	if at.IsZero() {
+		at = time.Now()
+	}
+	reason := strings.TrimSpace(transition.Reason)
+	if reason == "" {
+		reason = "state_transition"
+	}
+	metadataJSON := strings.TrimSpace(transition.MetadataJSON)
+	if metadataJSON == "" {
+		metadataJSON = "{}"
+	}
+	base := PhaseEvent{
+		ProjectID:      strings.TrimSpace(transition.ProjectID),
+		IssueID:        transition.Issue.ID,
+		Identifier:     transition.Issue.Identifier,
+		IssueURL:       transition.Issue.URL,
+		PRNumber:       workflowMetricsPRNumber(transition.Issue),
+		PhaseType:      PhaseTypeLane,
+		Reason:         reason,
+		StartedAt:      at,
+		MetadataJSON:   metadataJSON,
+		EndpointFamily: "tracker",
+	}
+	var resultErr error
+	if sourceState != "" {
+		startedAt := laneStartedAt(transition.Issue, at)
+		exitEvent := base
+		exitEvent.PhaseName = sourceState
+		exitEvent.Status = "exited"
+		exitEvent.StartedAt = startedAt
+		exitEvent.FinishedAt = at
+		exitEvent.DurationSeconds = durationSeconds(startedAt, at)
+		if _, err := recorder.RecordWorkflowPhaseEvent(ctx, exitEvent); err != nil {
+			resultErr = errors.Join(resultErr, err)
+		}
+	}
+	enterEvent := base
+	enterEvent.PhaseName = targetState
+	enterEvent.PreviousPhaseName = sourceState
+	enterEvent.Status = "entered"
+	if _, err := recorder.RecordWorkflowPhaseEvent(ctx, enterEvent); err != nil {
+		resultErr = errors.Join(resultErr, err)
+	}
+	return resultErr
+}
+
+func laneStartedAt(issue connector.Issue, fallback time.Time) time.Time {
+	for _, candidate := range []*time.Time{issue.StageUpdatedAt, issue.UpdatedAt, issue.CreatedAt} {
+		if candidate == nil || candidate.IsZero() || candidate.After(fallback) {
+			continue
+		}
+		return *candidate
+	}
+	return fallback
+}
+
+func durationSeconds(startedAt time.Time, finishedAt time.Time) int64 {
+	if startedAt.IsZero() || finishedAt.IsZero() || finishedAt.Before(startedAt) {
+		return 0
+	}
+	return int64(finishedAt.Sub(startedAt) / time.Second)
+}
+
+func workflowMetricsPRNumber(issue connector.Issue) *int64 {
+	switch {
+	case issue.PRNumber != nil:
+		value := int64(*issue.PRNumber)
+		return &value
+	case issue.PullRequest != nil && issue.PullRequest.Number > 0:
+		value := int64(issue.PullRequest.Number)
+		return &value
+	default:
+		return nil
+	}
+}

--- a/internal/workflowmetrics/transition_test.go
+++ b/internal/workflowmetrics/transition_test.go
@@ -1,0 +1,53 @@
+package workflowmetrics
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/digitaldrywood/detent/internal/connector"
+)
+
+func TestRecordLaneTransitionRecordsExitAndEntry(t *testing.T) {
+	t.Parallel()
+
+	startedAt := time.Date(2026, 7, 29, 12, 0, 0, 0, time.UTC)
+	transitionAt := startedAt.Add(5 * time.Minute)
+	recorder := &transitionRecorder{}
+	err := RecordLaneTransition(context.Background(), recorder, LaneTransition{
+		ProjectID: "detent",
+		Issue: connector.Issue{
+			ID:             "issue-1",
+			Identifier:     "DD-1",
+			State:          "Backlog",
+			StageUpdatedAt: &startedAt,
+		},
+		TargetState:  "Todo",
+		At:           transitionAt,
+		Reason:       "routine",
+		MetadataJSON: `{"provenance":{"origin":"routine"}}`,
+	})
+	if err != nil {
+		t.Fatalf("RecordLaneTransition() error = %v", err)
+	}
+	if len(recorder.events) != 2 {
+		t.Fatalf("events = %#v, want exit and entry", recorder.events)
+	}
+	exit, enter := recorder.events[0], recorder.events[1]
+	if exit.Status != "exited" || exit.PhaseName != "Backlog" || exit.DurationSeconds != 300 {
+		t.Fatalf("exit event = %#v", exit)
+	}
+	if enter.Status != "entered" || enter.PhaseName != "Todo" || enter.PreviousPhaseName != "Backlog" ||
+		enter.Reason != "routine" || enter.MetadataJSON != `{"provenance":{"origin":"routine"}}` {
+		t.Fatalf("enter event = %#v", enter)
+	}
+}
+
+type transitionRecorder struct {
+	events []PhaseEvent
+}
+
+func (r *transitionRecorder) RecordWorkflowPhaseEvent(_ context.Context, event PhaseEvent) (int64, error) {
+	r.events = append(r.events, event)
+	return int64(len(r.events)), nil
+}


### PR DESCRIPTION
## Summary

- Record explicit active-state provenance and tracker actor evidence across orchestrator, routine, retro, dependency, admission, and board transitions.
- Attribute admission decisions only to correlated commands and persisted transitions, with distinct expiry, rejection, supersession, and queryable downstream outcome evidence.
- Surface origin and admission outcome evidence on the board and in detent doctor, with documented trust semantics.

Fixes #1537

## UI Surface Contract

- [x] N/A, or the linked issue explicitly authorizes any high-impact UI surface, layout, density, first-viewport, or responsive visibility tradeoff.
- [x] Persistent top-of-screen messaging is explicitly authorized by the issue, or this PR does not add it.
- [x] Visual changes to primary operator screens include screenshot or browser verification below.

Isolated runtime verification: the project board served provenance on cards as via unknown and the detail sheet served an Origin row. The current-head Browser Visual CI job passed its full Playwright gate.

## Test Plan

- [x] make generate
- [x] Focused tests for admission, CLI, connectors, orchestrator, provenance, project, retro, routine, store, web, templates, and workflow metrics
- [x] Regression tests for acceptance after leaving the target lane and exact persisted event attribution
- [x] make check (build, lint, vet, nilaway, race tests, and 78.0% aggregate coverage)
- [x] Current-head CI: all 11 checks passed