### PR TITLE
feat(admission): add candidate reader contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -1201,9 +1201,15 @@ backlog_admission:
   proposal_expiry_days: 7
 ```
 
-State names come from the project's workflow. Candidate ordering is stable and
-the candidate cap is applied before agent evaluation. Author and excluded-label
-filters are applied locally after fetching source-state issues. A run defers
+State names come from the project's workflow. Admission reads them through the
+candidate-reader contract: the tracker declares selector support, reads pages
+inside a hard per-run bound, filters the requested states exactly, sorts by
+creation time and stable issue identity before applying the result limit, and
+reports whether the source was truncated. Admission keeps a finite over-read
+window of at least 100 issues so its existing priority ordering, author filter,
+excluded-label filter, and `max_candidates_per_run` cap still apply after the
+connector read. A reader truncation is recorded as `candidate_reader` in the
+run ledger instead of making the bounded result look complete. A run defers
 instead of queueing when project or fleet capacity is unavailable or its agent
 would exceed the configured daily budget.
 
@@ -1242,9 +1248,22 @@ without that correlation remains an unattributed transition and does not accept
 the proposal. Rejection, expiry, and supersession are separate outcomes:
 silence can expire a proposal but never accepts or rejects one.
 
-GitHub, `github_local`, `local_sqlite`, and `memory` trackers support
-state-based admission. Linear configurations fail validation because their
-state readers are not implemented. `authors.allow` on `local_sqlite` or
+The only admission selector currently defined is `sources.states`. Capability
+is declared per tracker and per GitHub status source:
+
+| Tracker | Status source | `sources.states` |
+| --- | --- | --- |
+| `github` | `project_v2` | Supported |
+| `github` | `issue_field` | Supported |
+| `github` | `label` | Supported |
+| `github_local` | local SQLite status | Supported |
+| `local_sqlite` | local SQLite status | Supported |
+| `memory` | process-local status | Supported |
+| `linear` | Linear workflow state | Unsupported |
+
+An enabled admission configuration fails validation when its tracker/status
+source does not declare the selector, so Linear never validates cleanly and
+then fails on its first scheduled read. `authors.allow` on `local_sqlite` or
 `memory` produces a doctor warning because those trackers do not discover
 authors. ProjectV2 configurations using `exclude_labels` warn that only the
 first 20 issue labels are fetched. The memory tracker is evaluation-only across

--- a/internal/admission/manager.go
+++ b/internal/admission/manager.go
@@ -56,7 +56,7 @@ type Store interface {
 }
 
 type IssueStore interface {
-	FetchIssuesByStates(context.Context, []string) ([]connector.Issue, error)
+	connector.CandidateReader
 	FetchIssueStatesByIDs(context.Context, []string) ([]connector.Issue, error)
 	CreateComment(context.Context, string, string) error
 }
@@ -318,10 +318,19 @@ func (m *Manager) runOnce(ctx context.Context, settings Settings, scheduledFor t
 		runErr = errors.Join(runErr, release())
 	}()
 
-	candidates, err := settings.Issues.FetchIssuesByStates(ctx, settings.Config.Sources.States)
+	candidateResult, err := settings.Issues.ReadCandidates(ctx, connector.CandidateRequest{
+		Selector: connector.CandidateSelectorStates,
+		States:   settings.Config.Sources.States,
+		Limit:    candidateReadLimit(settings.Config.MaxCandidatesPerRun),
+		PageSize: connector.DefaultCandidatePageSize,
+	})
 	if err != nil {
 		return result, fmt.Errorf("fetch backlog admission candidates: %w", err)
 	}
+	if candidateResult.Truncated {
+		result.Truncated["candidate_reader"]++
+	}
+	candidates := candidateResult.Issues
 	result.CandidatesFound = len(candidates)
 	candidates = filterCandidates(candidates, settings.Config, result.Skipped)
 	sortCandidates(candidates, settings)
@@ -394,6 +403,10 @@ func (m *Manager) runOnce(ctx context.Context, settings Settings, scheduledFor t
 		proposals = proposals[:available]
 	}
 	return m.executeProposals(ctx, settings, candidates, proposals, result, commentsRemaining, startedAt)
+}
+
+func candidateReadLimit(maxCandidates int) int {
+	return max(maxCandidates, connector.DefaultCandidatePageSize)
 }
 
 func (m *Manager) reconcileOpenProposals(

--- a/internal/admission/manager_test.go
+++ b/internal/admission/manager_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"path/filepath"
 	"reflect"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -98,6 +99,47 @@ func TestManagerEnforcesOrderingAndAllCapsBeforeWritingComments(t *testing.T) {
 	}
 	if agent.calls != 1 || second.Skipped["open_proposal_cap"] == 0 {
 		t.Fatalf("second result = %#v, runner calls = %d, want pre-agent open cap", second, agent.calls)
+	}
+}
+
+func TestManagerRecordsCandidateReaderTruncation(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 7, 29, 12, 0, 0, 0, time.UTC)
+	issues := make([]connector.Issue, connector.DefaultCandidatePageSize+2)
+	for index := range issues {
+		issues[index] = admissionIssueFixture(
+			"issue-"+strconv.Itoa(index),
+			"DD-"+strconv.Itoa(index),
+			1,
+			now.Add(time.Duration(index)*time.Minute),
+		)
+		issues[index].Labels = []string{"skip"}
+	}
+	tracker := memory.New(memory.Config{Issues: issues, Stateful: true, Now: func() time.Time { return now }})
+	backend := openManagerTestStore(t)
+	agent := &scriptedAdmissionRunner{propose: proposeEveryCandidate}
+	settings := admissionTestSettings(tracker, agent)
+	settings.Config.ExcludeLabels = []string{"skip"}
+	settings.Config.MaxCandidatesPerRun = 2
+	manager := newAdmissionTestManager(t, settings, backend, func() time.Time { return now })
+
+	result, err := manager.RunOnce(context.Background())
+	if err != nil {
+		t.Fatalf("RunOnce() error = %v", err)
+	}
+	if result.Truncated["candidate_reader"] != 1 || result.CandidatesFound != connector.DefaultCandidatePageSize {
+		t.Fatalf("result = %#v, want reader truncation at %d candidates", result, connector.DefaultCandidatePageSize)
+	}
+	if agent.calls != 0 {
+		t.Fatalf("runner calls = %d, want no eligible candidates", agent.calls)
+	}
+	record, ok, err := backend.LatestAdmissionRun(context.Background(), "detent")
+	if err != nil || !ok {
+		t.Fatalf("LatestAdmissionRun() = %#v, %t, %v", record, ok, err)
+	}
+	if record.Truncated["candidate_reader"] != 1 {
+		t.Fatalf("run ledger truncation = %#v, want candidate_reader=1", record.Truncated)
 	}
 }
 

--- a/internal/config/admission.go
+++ b/internal/config/admission.go
@@ -7,6 +7,8 @@ import (
 	"strings"
 
 	"github.com/robfig/cron/v3"
+
+	"github.com/digitaldrywood/detent/internal/connector"
 )
 
 const (
@@ -106,12 +108,18 @@ func (a BacklogAdmission) Validate(prefix string, states []string, tracker Track
 	validatePositive(prefix+".max_proposals_per_run", a.MaxProposalsPerRun, &problems)
 	validatePositive(prefix+".max_open_proposals", a.MaxOpenProposals, &problems)
 	validatePositive(prefix+".proposal_expiry_days", a.ProposalExpiryDays, &problems)
-	switch tracker.Kind {
-	case TrackerGitHub, TrackerGitHubLocal, TrackerLocalSQLite, TrackerMemory:
-	case TrackerLinear:
-		problems = append(problems, prefix+".enabled does not support tracker.kind linear because FetchIssuesByStates is not implemented")
-	default:
-		problems = append(problems, prefix+".enabled requires tracker.kind github, github_local, local_sqlite, or memory")
+	capabilities := connector.CandidateCapabilitiesFor(connector.Backend(tracker.Kind), tracker.GitHubStatusSource)
+	if !capabilities.Supports(connector.CandidateSelectorStates) {
+		gap := prefix + ".sources.states requires candidate selector states, but tracker.kind " + tracker.Kind
+		if tracker.Kind == TrackerGitHub {
+			gap += " with github_status_source " + tracker.GitHubStatusSource
+		}
+		if tracker.Kind == TrackerLinear {
+			gap += " cannot serve it because FetchIssuesByStates is not implemented"
+		} else {
+			gap += " does not declare it"
+		}
+		problems = append(problems, gap)
 	}
 	return problems
 }

--- a/internal/config/admission_test.go
+++ b/internal/config/admission_test.go
@@ -89,6 +89,12 @@ func TestBacklogAdmissionValidate(t *testing.T) {
 		want    string
 	}{
 		{name: "valid", tracker: Tracker{Kind: TrackerGitHub}},
+		{name: "github project v2", tracker: Tracker{Kind: TrackerGitHub, GitHubStatusSource: GitHubStatusSourceProjectV2}},
+		{name: "github issue field", tracker: Tracker{Kind: TrackerGitHub, GitHubStatusSource: GitHubStatusSourceIssueField}},
+		{name: "github label", tracker: Tracker{Kind: TrackerGitHub, GitHubStatusSource: GitHubStatusSourceLabel}},
+		{name: "github local", tracker: Tracker{Kind: TrackerGitHubLocal}},
+		{name: "local sqlite", tracker: Tracker{Kind: TrackerLocalSQLite}},
+		{name: "memory", tracker: Tracker{Kind: TrackerMemory}},
 		{name: "bad cron", tracker: Tracker{Kind: TrackerGitHub}, mutate: func(cfg *BacklogAdmission) { cfg.Schedule = "not cron" }, want: "valid five-field cron"},
 		{name: "empty sources", tracker: Tracker{Kind: TrackerGitHub}, mutate: func(cfg *BacklogAdmission) { cfg.Sources.States = nil }, want: "must contain at least one state"},
 		{name: "unknown source", tracker: Tracker{Kind: TrackerGitHub}, mutate: func(cfg *BacklogAdmission) { cfg.Sources.States = []string{"Icebox"} }, want: "sources.states[0] must name"},
@@ -100,6 +106,8 @@ func TestBacklogAdmissionValidate(t *testing.T) {
 		{name: "zero open cap", tracker: Tracker{Kind: TrackerGitHub}, mutate: func(cfg *BacklogAdmission) { cfg.MaxOpenProposals = 0 }, want: "max_open_proposals must be greater than 0"},
 		{name: "zero expiry", tracker: Tracker{Kind: TrackerGitHub}, mutate: func(cfg *BacklogAdmission) { cfg.ProposalExpiryDays = 0 }, want: "proposal_expiry_days must be greater than 0"},
 		{name: "linear", tracker: Tracker{Kind: TrackerLinear}, want: "FetchIssuesByStates is not implemented"},
+		{name: "unsupported github source", tracker: Tracker{Kind: TrackerGitHub, GitHubStatusSource: "milestone"}, want: "tracker.kind github with github_status_source milestone does not declare it"},
+		{name: "unsupported tracker", tracker: Tracker{Kind: "gitlab"}, want: "tracker.kind gitlab does not declare it"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/internal/connector/candidate.go
+++ b/internal/connector/candidate.go
@@ -1,0 +1,176 @@
+package connector
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sort"
+	"strings"
+)
+
+const DefaultCandidatePageSize = 100
+
+var (
+	ErrCandidateSelectorUnsupported = errors.New("candidate selector is not supported")
+	ErrInvalidCandidateRequest      = errors.New("candidate request is invalid")
+)
+
+type CandidateSelector string
+
+const CandidateSelectorStates CandidateSelector = "states"
+
+type CandidateCapabilities struct {
+	Selectors []CandidateSelector `json:"selectors" yaml:"selectors"`
+}
+
+func (c CandidateCapabilities) Supports(selector CandidateSelector) bool {
+	for _, candidate := range c.Selectors {
+		if candidate == selector {
+			return true
+		}
+	}
+	return false
+}
+
+func CandidateCapabilitiesFor(backend Backend, statusSource string) CandidateCapabilities {
+	switch backend {
+	case BackendGitHub:
+		switch strings.ToLower(strings.TrimSpace(statusSource)) {
+		case "", "project_v2", "issue_field", "label":
+			return statesCandidateCapabilities()
+		default:
+			return CandidateCapabilities{}
+		}
+	case BackendGitHubLocal, BackendLocalSQLite, BackendMemory:
+		return statesCandidateCapabilities()
+	default:
+		return CandidateCapabilities{}
+	}
+}
+
+type CandidateRequest struct {
+	Selector CandidateSelector `json:"selector" yaml:"selector"`
+	States   []string          `json:"states,omitempty" yaml:"states,omitempty"`
+	Limit    int               `json:"limit" yaml:"limit"`
+	PageSize int               `json:"page_size,omitempty" yaml:"page_size,omitempty"`
+}
+
+func (r CandidateRequest) Validate(capabilities CandidateCapabilities) error {
+	if !capabilities.Supports(r.Selector) {
+		return fmt.Errorf("%w: %s", ErrCandidateSelectorUnsupported, r.Selector)
+	}
+	if r.Limit <= 0 {
+		return fmt.Errorf("%w: limit must be greater than zero", ErrInvalidCandidateRequest)
+	}
+	if r.PageSize < 0 {
+		return fmt.Errorf("%w: page size must not be negative", ErrInvalidCandidateRequest)
+	}
+	switch r.Selector {
+	case CandidateSelectorStates:
+		if len(normalizedCandidateStates(r.States)) == 0 {
+			return fmt.Errorf("%w: states selector requires at least one state", ErrInvalidCandidateRequest)
+		}
+	default:
+		return fmt.Errorf("%w: %s", ErrCandidateSelectorUnsupported, r.Selector)
+	}
+	return nil
+}
+
+func (r CandidateRequest) EffectivePageSize() int {
+	if r.PageSize > 0 {
+		return r.PageSize
+	}
+	return DefaultCandidatePageSize
+}
+
+func (r CandidateRequest) ProbeLimit() int {
+	if r.Limit == int(^uint(0)>>1) {
+		return r.Limit
+	}
+	return r.Limit + 1
+}
+
+type CandidateResult struct {
+	Issues    []Issue `json:"issues" yaml:"issues"`
+	PagesRead int     `json:"pages_read" yaml:"pages_read"`
+	Truncated bool    `json:"truncated" yaml:"truncated"`
+}
+
+type CandidateReader interface {
+	CandidateCapabilities() CandidateCapabilities
+	ReadCandidates(context.Context, CandidateRequest) (CandidateResult, error)
+}
+
+func NewCandidateResult(issues []Issue, request CandidateRequest, pagesRead int, incomplete bool) CandidateResult {
+	issues = append([]Issue(nil), issues...)
+	SortCandidateIssues(issues)
+	truncated := incomplete || len(issues) > request.Limit
+	if len(issues) > request.Limit {
+		issues = issues[:request.Limit]
+	}
+	return CandidateResult{
+		Issues:    issues,
+		PagesRead: pagesRead,
+		Truncated: truncated,
+	}
+}
+
+func SortCandidateIssues(issues []Issue) {
+	sort.SliceStable(issues, func(i, j int) bool {
+		left := issues[i]
+		right := issues[j]
+		if left.CreatedAt != nil && right.CreatedAt != nil && !left.CreatedAt.Equal(*right.CreatedAt) {
+			return left.CreatedAt.Before(*right.CreatedAt)
+		}
+		if left.CreatedAt != nil && right.CreatedAt == nil {
+			return true
+		}
+		if left.CreatedAt == nil && right.CreatedAt != nil {
+			return false
+		}
+		leftIdentifier := strings.TrimSpace(left.Identifier)
+		rightIdentifier := strings.TrimSpace(right.Identifier)
+		if comparison := strings.Compare(strings.ToLower(leftIdentifier), strings.ToLower(rightIdentifier)); comparison != 0 {
+			return comparison < 0
+		}
+		if leftIdentifier != rightIdentifier {
+			return leftIdentifier < rightIdentifier
+		}
+		leftID := strings.TrimSpace(left.ID)
+		rightID := strings.TrimSpace(right.ID)
+		if leftID != rightID {
+			return leftID < rightID
+		}
+		if left.Number != right.Number {
+			return left.Number < right.Number
+		}
+		leftURL := strings.TrimSpace(left.URL)
+		rightURL := strings.TrimSpace(right.URL)
+		if leftURL != rightURL {
+			return leftURL < rightURL
+		}
+		return strings.TrimSpace(left.Title) < strings.TrimSpace(right.Title)
+	})
+}
+
+func statesCandidateCapabilities() CandidateCapabilities {
+	return CandidateCapabilities{Selectors: []CandidateSelector{CandidateSelectorStates}}
+}
+
+func normalizedCandidateStates(states []string) []string {
+	normalized := make([]string, 0, len(states))
+	seen := make(map[string]struct{}, len(states))
+	for _, state := range states {
+		state = strings.TrimSpace(state)
+		key := strings.ToLower(state)
+		if key == "" {
+			continue
+		}
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		seen[key] = struct{}{}
+		normalized = append(normalized, state)
+	}
+	return normalized
+}

--- a/internal/connector/candidate_test.go
+++ b/internal/connector/candidate_test.go
@@ -1,0 +1,127 @@
+package connector
+
+import (
+	"errors"
+	"reflect"
+	"testing"
+	"time"
+)
+
+func TestCandidateCapabilitiesFor(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name         string
+		backend      Backend
+		statusSource string
+		supports     bool
+	}{
+		{name: "github project v2", backend: BackendGitHub, statusSource: "project_v2", supports: true},
+		{name: "github issue field", backend: BackendGitHub, statusSource: "issue_field", supports: true},
+		{name: "github label", backend: BackendGitHub, statusSource: "label", supports: true},
+		{name: "github default", backend: BackendGitHub, supports: true},
+		{name: "github invalid source", backend: BackendGitHub, statusSource: "milestone"},
+		{name: "github local", backend: BackendGitHubLocal, supports: true},
+		{name: "local sqlite", backend: BackendLocalSQLite, supports: true},
+		{name: "memory", backend: BackendMemory, supports: true},
+		{name: "linear", backend: BackendLinear},
+		{name: "gitlab", backend: BackendGitLab},
+		{name: "jira", backend: BackendJira},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			got := CandidateCapabilitiesFor(test.backend, test.statusSource).Supports(CandidateSelectorStates)
+			if got != test.supports {
+				t.Fatalf("Supports(states) = %t, want %t", got, test.supports)
+			}
+		})
+	}
+}
+
+func TestCandidateRequestValidate(t *testing.T) {
+	t.Parallel()
+
+	capabilities := CandidateCapabilitiesFor(BackendMemory, "")
+	tests := []struct {
+		name    string
+		request CandidateRequest
+		want    error
+	}{
+		{
+			name: "valid states selector",
+			request: CandidateRequest{
+				Selector: CandidateSelectorStates,
+				States:   []string{" Backlog ", "backlog"},
+				Limit:    10,
+			},
+		},
+		{
+			name: "unsupported selector",
+			request: CandidateRequest{
+				Selector: CandidateSelector("labels"),
+				Limit:    10,
+			},
+			want: ErrCandidateSelectorUnsupported,
+		},
+		{
+			name: "non-positive limit",
+			request: CandidateRequest{
+				Selector: CandidateSelectorStates,
+				States:   []string{"Backlog"},
+			},
+			want: ErrInvalidCandidateRequest,
+		},
+		{
+			name: "negative page size",
+			request: CandidateRequest{
+				Selector: CandidateSelectorStates,
+				States:   []string{"Backlog"},
+				Limit:    10,
+				PageSize: -1,
+			},
+			want: ErrInvalidCandidateRequest,
+		},
+		{
+			name: "empty states",
+			request: CandidateRequest{
+				Selector: CandidateSelectorStates,
+				States:   []string{"  "},
+				Limit:    10,
+			},
+			want: ErrInvalidCandidateRequest,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			err := test.request.Validate(capabilities)
+			if !errors.Is(err, test.want) {
+				t.Fatalf("Validate() error = %v, want %v", err, test.want)
+			}
+		})
+	}
+}
+
+func TestNewCandidateResultSortsBeforeApplyingLimit(t *testing.T) {
+	t.Parallel()
+
+	earlier := time.Date(2026, 7, 29, 9, 0, 0, 0, time.UTC)
+	later := earlier.Add(time.Hour)
+	issues := []Issue{
+		{ID: "3", Identifier: "DD-3", CreatedAt: &later},
+		{ID: "2", Identifier: "dd-2", CreatedAt: &earlier},
+		{ID: "1", Identifier: "DD-1", CreatedAt: &earlier},
+	}
+	got := NewCandidateResult(issues, CandidateRequest{Limit: 2}, 2, false)
+	ids := []string{got.Issues[0].ID, got.Issues[1].ID}
+	if !reflect.DeepEqual(ids, []string{"1", "2"}) {
+		t.Fatalf("candidate IDs = %#v, want [1 2]", ids)
+	}
+	if !got.Truncated || got.PagesRead != 2 {
+		t.Fatalf("result = %#v, want two pages and truncation", got)
+	}
+	if issues[0].ID != "3" {
+		t.Fatalf("NewCandidateResult mutated input = %#v", issues)
+	}
+}

--- a/internal/connector/github/candidate.go
+++ b/internal/connector/github/candidate.go
@@ -1,0 +1,300 @@
+package github
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/digitaldrywood/detent/internal/connector"
+)
+
+func (c *Connector) CandidateCapabilities() connector.CandidateCapabilities {
+	if c == nil {
+		return connector.CandidateCapabilities{}
+	}
+	return connector.CandidateCapabilitiesFor(connector.BackendGitHub, c.statusSource)
+}
+
+func (c *Connector) ReadCandidates(ctx context.Context, request connector.CandidateRequest) (connector.CandidateResult, error) {
+	if err := request.Validate(c.CandidateCapabilities()); err != nil {
+		return connector.CandidateResult{}, err
+	}
+
+	var (
+		issues     []connector.Issue
+		pagesRead  int
+		incomplete bool
+		err        error
+	)
+	switch {
+	case c.usesLabelStatus():
+		issues, pagesRead, incomplete, err = c.readLabelCandidates(ctx, request)
+	case c.usesIssueFieldStatus():
+		issues, pagesRead, incomplete, err = c.readIssueFieldCandidates(ctx, request)
+	default:
+		issues, pagesRead, incomplete, err = c.readProjectCandidates(ctx, request)
+	}
+	if err != nil {
+		return connector.CandidateResult{}, err
+	}
+
+	result := connector.NewCandidateResult(issues, request, pagesRead, incomplete)
+	if err := c.hydrateCandidateIssues(ctx, result.Issues, request.States); err != nil {
+		return connector.CandidateResult{}, err
+	}
+	return result, nil
+}
+
+func (c *Connector) readLabelCandidates(
+	ctx context.Context,
+	request connector.CandidateRequest,
+) ([]connector.Issue, int, bool, error) {
+	if !validPullRequestRepo(c.repository) {
+		return nil, 0, false, ErrMissingRepository
+	}
+	stateNames := normalizeStateList(request.States, nil)
+	stateLabels := c.statusLabelStates(stateNames)
+	if len(stateLabels) == 0 {
+		return []connector.Issue{}, 0, false, nil
+	}
+	wantedStates := normalizedStateSet(stateNames)
+	scanLimit := request.ProbeLimit()
+	issues := []connector.Issue{}
+	seen := map[string]struct{}{}
+	itemsRead := 0
+	pagesRead := 0
+	pageSize := min(request.EffectivePageSize(), repositoryIssuesPageSize, scanLimit)
+
+	for stateIndex, stateName := range stateNames {
+		labelName := c.statusLabelForState(stateName)
+		externalState, ok := stateLabels[normalizeLabelName(labelName)]
+		if !ok {
+			continue
+		}
+		for page := 1; ; page++ {
+			if itemsRead >= scanLimit {
+				return issues, pagesRead, true, nil
+			}
+			var response []restIssue
+			path := restRepositoryIssuesByLabelPagePath(c.repository, labelName, page, pageSize, true)
+			if err := c.client.REST(ctx, http.MethodGet, path, nil, &response); err != nil {
+				return nil, 0, false, fmt.Errorf("fetch github label candidates: %w", err)
+			}
+			pagesRead++
+			pageItems := response
+			if remaining := scanLimit - itemsRead; len(pageItems) > remaining {
+				pageItems = pageItems[:remaining]
+			}
+			itemsRead += len(pageItems)
+			for _, item := range pageItems {
+				if item.PullRequest != nil {
+					continue
+				}
+				ref := issueRef{Owner: c.repository.Owner, Name: c.repository.Name, Number: item.Number}
+				node := githubIssueNodeFromREST(ref, item)
+				if strings.TrimSpace(node.ID) == "" {
+					continue
+				}
+				if githubIssueClosed(node.State) && !stateInList(c.githubToDetentState(externalState), c.terminalStates) {
+					continue
+				}
+				if _, ok := seen[node.ID]; ok {
+					continue
+				}
+				built := c.buildLabelIssue(node, externalState)
+				if _, ok := wantedStates[normalizeStateName(built.State)]; !ok {
+					continue
+				}
+				seen[node.ID] = struct{}{}
+				c.cacheIssueRef(node)
+				issues = append(issues, built)
+			}
+			if len(pageItems) < len(response) {
+				return issues, pagesRead, true, nil
+			}
+			if len(response) < pageSize {
+				break
+			}
+			if itemsRead >= scanLimit {
+				return issues, pagesRead, true, nil
+			}
+		}
+		if stateIndex < len(stateNames)-1 && itemsRead >= scanLimit {
+			return issues, pagesRead, true, nil
+		}
+	}
+	return issues, pagesRead, false, nil
+}
+
+func (c *Connector) readIssueFieldCandidates(
+	ctx context.Context,
+	request connector.CandidateRequest,
+) ([]connector.Issue, int, bool, error) {
+	if !validPullRequestRepo(c.repository) {
+		return nil, 0, false, ErrMissingRepository
+	}
+	wantedStates := normalizedStateSet(request.States)
+	githubStates := c.detentToGitHubStates(request.States)
+	if len(wantedStates) == 0 || len(githubStates) == 0 {
+		return []connector.Issue{}, 0, false, nil
+	}
+	if err := c.verifyIssueFieldStatusOptions(ctx, request.States); err != nil {
+		return nil, 0, false, err
+	}
+
+	scanLimit := request.ProbeLimit()
+	issues := []connector.Issue{}
+	itemsRead := 0
+	pagesRead := 0
+	pageSize := min(request.EffectivePageSize(), issueSearchPageSize, scanLimit)
+	for page := 1; ; page++ {
+		if itemsRead >= scanLimit {
+			return issues, pagesRead, true, nil
+		}
+		var response restIssueSearchResponse
+		path := restIssueFieldSearchPagePath(
+			c.repository,
+			c.statusField,
+			githubStates,
+			connector.IssueFilterHint{},
+			page,
+			pageSize,
+			true,
+		)
+		if err := c.client.REST(ctx, http.MethodGet, path, nil, &response); err != nil {
+			return nil, 0, false, fmt.Errorf("search github issue field candidates: %w", err)
+		}
+		pagesRead++
+		pageItems := response.Items
+		if remaining := scanLimit - itemsRead; len(pageItems) > remaining {
+			pageItems = pageItems[:remaining]
+		}
+		itemsRead += len(pageItems)
+		for _, item := range pageItems {
+			ref, ok := issueRefFromRESTSearchItem(item, issueRef{Owner: c.repository.Owner, Name: c.repository.Name})
+			if !ok {
+				continue
+			}
+			issue, ok, err := c.fetchIssueFieldIssueFromREST(ctx, ref, item)
+			if err != nil {
+				return nil, 0, false, err
+			}
+			if !ok {
+				continue
+			}
+			if _, ok := wantedStates[normalizeStateName(issue.State)]; ok {
+				issues = append(issues, issue)
+			}
+		}
+		if len(pageItems) < len(response.Items) {
+			return issues, pagesRead, true, nil
+		}
+		exhausted := len(response.Items) < pageSize ||
+			(response.TotalCount > 0 && itemsRead >= response.TotalCount)
+		if exhausted {
+			return issues, pagesRead, false, nil
+		}
+		if itemsRead >= scanLimit {
+			return issues, pagesRead, true, nil
+		}
+	}
+}
+
+func (c *Connector) readProjectCandidates(
+	ctx context.Context,
+	request connector.CandidateRequest,
+) ([]connector.Issue, int, bool, error) {
+	if c.projectID == "" {
+		return nil, 0, false, ErrMissingProject
+	}
+	wantedStates := normalizedStateSet(request.States)
+	if len(wantedStates) == 0 {
+		return []connector.Issue{}, 0, false, nil
+	}
+
+	scanLimit := request.ProbeLimit()
+	var after *string
+	issues := []connector.Issue{}
+	blankStatusItemIDs := []string{}
+	_, repairBlankStatuses := wantedStates[normalizeStateName(defaultProjectItemStatusState)]
+	itemsRead := 0
+	totalItems := 0
+	pagesRead := 0
+	for {
+		if itemsRead >= scanLimit {
+			c.defaultBlankProjectItemStatuses(ctx, blankStatusItemIDs)
+			return issues, pagesRead, true, nil
+		}
+		var response struct {
+			Node *struct {
+				Items projectItemsConnection `json:"items"`
+			} `json:"node"`
+		}
+		pageSize := min(request.EffectivePageSize(), projectItemsPageSize, scanLimit-itemsRead)
+		if err := c.client.GraphQLWithType(ctx, graphQLQueryCandidateIssues, observedStatusProjectItemsQuery, map[string]any{
+			"projectId": c.projectID,
+			"first":     pageSize,
+			"after":     after,
+		}, &response); err != nil {
+			return nil, 0, false, fmt.Errorf("fetch github project candidates: %w", err)
+		}
+		pagesRead++
+		if response.Node == nil {
+			return nil, 0, false, ErrProjectNotFound
+		}
+		pageItems := response.Node.Items.Nodes
+		if remaining := scanLimit - itemsRead; len(pageItems) > remaining {
+			pageItems = pageItems[:remaining]
+		}
+		itemsRead += len(pageItems)
+		totalItems = max(totalItems, response.Node.Items.TotalCount)
+		for _, item := range pageItems {
+			issue, ok, blankStatusItemID, err := c.normalizeProjectItem(item)
+			if err != nil {
+				return nil, 0, false, err
+			}
+			if !ok {
+				continue
+			}
+			if blankStatusItemID != "" && repairBlankStatuses {
+				blankStatusItemIDs = append(blankStatusItemIDs, blankStatusItemID)
+			}
+			if _, ok := wantedStates[normalizeStateName(issue.State)]; ok {
+				issues = append(issues, issue)
+			}
+		}
+		if len(pageItems) < len(response.Node.Items.Nodes) {
+			c.defaultBlankProjectItemStatuses(ctx, blankStatusItemIDs)
+			return issues, pagesRead, true, nil
+		}
+
+		if !response.Node.Items.PageInfo.HasNextPage {
+			c.defaultBlankProjectItemStatuses(ctx, blankStatusItemIDs)
+			return issues, pagesRead, totalItems > itemsRead, nil
+		}
+		if itemsRead >= scanLimit || pagesRead >= scanLimit {
+			c.defaultBlankProjectItemStatuses(ctx, blankStatusItemIDs)
+			return issues, pagesRead, true, nil
+		}
+		cursor := strings.TrimSpace(response.Node.Items.PageInfo.EndCursor)
+		if cursor == "" {
+			return nil, 0, false, ErrInvalidResponse
+		}
+		after = &cursor
+	}
+}
+
+func (c *Connector) hydrateCandidateIssues(ctx context.Context, issues []connector.Issue, stateNames []string) error {
+	wantedStates := normalizedStateSet(stateNames)
+	if _, ok := wantedStates[normalizeStateName("Blocked")]; ok {
+		if err := c.populateBlockerReasons(ctx, issues); err != nil {
+			return err
+		}
+		c.hydrateBlockedByRefs(ctx, issues)
+		if err := c.resolveBlockedByProjectState(ctx, issues); err != nil {
+			return err
+		}
+	}
+	return c.attachStatePullRequests(ctx, issues, true)
+}

--- a/internal/connector/github/candidate.go
+++ b/internal/connector/github/candidate.go
@@ -62,19 +62,27 @@ func (c *Connector) readLabelCandidates(
 	scanLimit := request.ProbeLimit()
 	issues := []connector.Issue{}
 	seen := map[string]struct{}{}
-	itemsRead := 0
+	queriedLabels := map[string]struct{}{}
 	pagesRead := 0
 	pageSize := min(request.EffectivePageSize(), repositoryIssuesPageSize, scanLimit)
+	incomplete := false
 
-	for stateIndex, stateName := range stateNames {
+	for _, stateName := range stateNames {
 		labelName := c.statusLabelForState(stateName)
-		externalState, ok := stateLabels[normalizeLabelName(labelName)]
+		labelKey := normalizeLabelName(labelName)
+		externalState, ok := stateLabels[labelKey]
 		if !ok {
 			continue
 		}
+		if _, ok := queriedLabels[labelKey]; ok {
+			continue
+		}
+		queriedLabels[labelKey] = struct{}{}
+		itemsRead := 0
 		for page := 1; ; page++ {
 			if itemsRead >= scanLimit {
-				return issues, pagesRead, true, nil
+				incomplete = true
+				break
 			}
 			var response []restIssue
 			path := restRepositoryIssuesByLabelPagePath(c.repository, labelName, page, pageSize, true)
@@ -111,20 +119,19 @@ func (c *Connector) readLabelCandidates(
 				issues = append(issues, built)
 			}
 			if len(pageItems) < len(response) {
-				return issues, pagesRead, true, nil
+				incomplete = true
+				break
 			}
 			if len(response) < pageSize {
 				break
 			}
 			if itemsRead >= scanLimit {
-				return issues, pagesRead, true, nil
+				incomplete = true
+				break
 			}
 		}
-		if stateIndex < len(stateNames)-1 && itemsRead >= scanLimit {
-			return issues, pagesRead, true, nil
-		}
 	}
-	return issues, pagesRead, false, nil
+	return issues, pagesRead, incomplete, nil
 }
 
 func (c *Connector) readIssueFieldCandidates(

--- a/internal/connector/github/candidate_test.go
+++ b/internal/connector/github/candidate_test.go
@@ -16,12 +16,12 @@ func TestConnectorReadProjectCandidatesStopsAtBoundAndSorts(t *testing.T) {
 	server := newGraphQLTestServer(t, []graphqlTestResponse{
 		{
 			body: projectItemsPageResponseWithTotal(3, true, "cursor-1", []string{
-				`{"id":"PVTI_2","content":{"__typename":"Issue","id":"I_2","number":2,"title":"Second","state":"OPEN","url":"https://github.com/digitaldrywood/detent/issues/2","repository":{"nameWithOwner":"digitaldrywood/detent"}},"statusValue":{"name":"Backlog"}}`,
+				`{"id":"PVTI_1","content":{"__typename":"Issue","id":"I_1","number":1,"title":"First","state":"OPEN","url":"https://github.com/digitaldrywood/detent/issues/1","createdAt":"2026-01-02T00:00:00Z","repository":{"nameWithOwner":"digitaldrywood/detent"}},"statusValue":{"name":"Backlog"}}`,
 			}),
 		},
 		{
 			body: projectItemsPageResponseWithTotal(3, true, "cursor-2", []string{
-				`{"id":"PVTI_1","content":{"__typename":"Issue","id":"I_1","number":1,"title":"First","state":"OPEN","url":"https://github.com/digitaldrywood/detent/issues/1","repository":{"nameWithOwner":"digitaldrywood/detent"}},"statusValue":{"name":"Backlog"}}`,
+				`{"id":"PVTI_2","content":{"__typename":"Issue","id":"I_2","number":2,"title":"Second","state":"OPEN","url":"https://github.com/digitaldrywood/detent/issues/2","createdAt":"2026-01-01T00:00:00Z","repository":{"nameWithOwner":"digitaldrywood/detent"}},"statusValue":{"name":"Backlog"}}`,
 			}),
 		},
 	})
@@ -39,8 +39,8 @@ func TestConnectorReadProjectCandidatesStopsAtBoundAndSorts(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ReadCandidates() error = %v", err)
 	}
-	if ids := githubIssueIDs(got.Issues); !reflect.DeepEqual(ids, []string{"I_1"}) {
-		t.Fatalf("candidate IDs = %#v, want [I_1]", ids)
+	if ids := githubIssueIDs(got.Issues); !reflect.DeepEqual(ids, []string{"I_2"}) {
+		t.Fatalf("candidate IDs = %#v, want [I_2]", ids)
 	}
 	if !got.Truncated || got.PagesRead != 2 {
 		t.Fatalf("result = %#v, want bounded two-page truncation", got)
@@ -54,6 +54,12 @@ func TestConnectorReadProjectCandidatesStopsAtBoundAndSorts(t *testing.T) {
 	}
 	if after := requests[1]["variables"].(map[string]any)["after"]; after != "cursor-1" {
 		t.Fatalf("second page cursor = %#v, want cursor-1", after)
+	}
+	query := requests[0]["query"].(string)
+	for _, want := range []string{"createdAt", "orderBy: {field: POSITION, direction: ASC}"} {
+		if !strings.Contains(query, want) {
+			t.Fatalf("candidate query missing %q", want)
+		}
 	}
 }
 
@@ -151,6 +157,57 @@ func TestConnectorReadLabelCandidatesKeepsNumericPageSizeAtBound(t *testing.T) {
 	}
 	requests := server.requests()
 	for index, want := range []string{"page=1&per_page=2", "page=2&per_page=2"} {
+		if path := requests[index]["path"].(string); !strings.Contains(path, want) {
+			t.Fatalf("request %d path = %q, missing %q", index, path, want)
+		}
+	}
+}
+
+func TestConnectorReadLabelCandidatesSharesBoundAcrossStates(t *testing.T) {
+	t.Parallel()
+
+	server := newGraphQLTestServer(t, []graphqlTestResponse{
+		{
+			method: http.MethodGet,
+			body: `[
+				{"node_id":"I_2","number":2,"title":"Todo second","state":"open","html_url":"https://github.com/digitaldrywood/detent/issues/2","created_at":"2026-01-02T00:00:00Z","labels":[{"name":"detent:todo"}]},
+				{"node_id":"I_3","number":3,"title":"Todo third","state":"open","html_url":"https://github.com/digitaldrywood/detent/issues/3","created_at":"2026-01-03T00:00:00Z","labels":[{"name":"detent:todo"}]}
+			]`,
+		},
+		{
+			method: http.MethodGet,
+			body: `[
+				{"node_id":"I_1","number":1,"title":"Backlog first","state":"open","html_url":"https://github.com/digitaldrywood/detent/issues/1","created_at":"2026-01-01T00:00:00Z","labels":[{"name":"detent:backlog"}]}
+			]`,
+		},
+	})
+	c := newGitHubTestConnector(t, server, Config{
+		GitHubStatusSource: GitHubStatusSourceLabel,
+		Repository:         "digitaldrywood/detent",
+		ActiveStates:       []string{"Todo"},
+		ObservedStates:     []string{"Backlog"},
+	})
+
+	got, err := c.ReadCandidates(context.Background(), connector.CandidateRequest{
+		Selector: connector.CandidateSelectorStates,
+		States:   []string{"Todo", "Backlog"},
+		Limit:    1,
+		PageSize: 2,
+	})
+	if err != nil {
+		t.Fatalf("ReadCandidates() error = %v", err)
+	}
+	if ids := githubIssueIDs(got.Issues); !reflect.DeepEqual(ids, []string{"I_1"}) {
+		t.Fatalf("candidate IDs = %#v, want [I_1]", ids)
+	}
+	if !got.Truncated || got.PagesRead != 2 {
+		t.Fatalf("result = %#v, want bounded reads from both states", got)
+	}
+	requests := server.requests()
+	if len(requests) != 2 {
+		t.Fatalf("request count = %d, want 2", len(requests))
+	}
+	for index, want := range []string{"labels=detent%3Atodo", "labels=detent%3Abacklog"} {
 		if path := requests[index]["path"].(string); !strings.Contains(path, want) {
 			t.Fatalf("request %d path = %q, missing %q", index, path, want)
 		}

--- a/internal/connector/github/candidate_test.go
+++ b/internal/connector/github/candidate_test.go
@@ -1,0 +1,204 @@
+package github
+
+import (
+	"context"
+	"net/http"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/digitaldrywood/detent/internal/connector"
+)
+
+func TestConnectorReadProjectCandidatesStopsAtBoundAndSorts(t *testing.T) {
+	t.Parallel()
+
+	server := newGraphQLTestServer(t, []graphqlTestResponse{
+		{
+			body: projectItemsPageResponseWithTotal(3, true, "cursor-1", []string{
+				`{"id":"PVTI_2","content":{"__typename":"Issue","id":"I_2","number":2,"title":"Second","state":"OPEN","url":"https://github.com/digitaldrywood/detent/issues/2","repository":{"nameWithOwner":"digitaldrywood/detent"}},"statusValue":{"name":"Backlog"}}`,
+			}),
+		},
+		{
+			body: projectItemsPageResponseWithTotal(3, true, "cursor-2", []string{
+				`{"id":"PVTI_1","content":{"__typename":"Issue","id":"I_1","number":1,"title":"First","state":"OPEN","url":"https://github.com/digitaldrywood/detent/issues/1","repository":{"nameWithOwner":"digitaldrywood/detent"}},"statusValue":{"name":"Backlog"}}`,
+			}),
+		},
+	})
+	c := newGitHubTestConnector(t, server, Config{
+		ProjectSlug:  "PVT_1",
+		ActiveStates: []string{"Todo"},
+	})
+
+	got, err := c.ReadCandidates(context.Background(), connector.CandidateRequest{
+		Selector: connector.CandidateSelectorStates,
+		States:   []string{"Backlog"},
+		Limit:    1,
+		PageSize: 1,
+	})
+	if err != nil {
+		t.Fatalf("ReadCandidates() error = %v", err)
+	}
+	if ids := githubIssueIDs(got.Issues); !reflect.DeepEqual(ids, []string{"I_1"}) {
+		t.Fatalf("candidate IDs = %#v, want [I_1]", ids)
+	}
+	if !got.Truncated || got.PagesRead != 2 {
+		t.Fatalf("result = %#v, want bounded two-page truncation", got)
+	}
+	requests := server.requests()
+	if len(requests) != 2 {
+		t.Fatalf("request count = %d, want 2", len(requests))
+	}
+	if first := requests[0]["variables"].(map[string]any)["first"]; first != float64(1) {
+		t.Fatalf("first page size = %#v, want 1", first)
+	}
+	if after := requests[1]["variables"].(map[string]any)["after"]; after != "cursor-1" {
+		t.Fatalf("second page cursor = %#v, want cursor-1", after)
+	}
+}
+
+func TestConnectorReadProjectCandidatesBoundsEmptyCursorPages(t *testing.T) {
+	t.Parallel()
+
+	server := newGraphQLTestServer(t, []graphqlTestResponse{
+		{body: projectItemsPageResponseWithTotal(3, true, "cursor-1", nil)},
+		{body: projectItemsPageResponseWithTotal(3, true, "cursor-2", nil)},
+	})
+	c := newGitHubTestConnector(t, server, Config{ProjectSlug: "PVT_1"})
+
+	got, err := c.ReadCandidates(context.Background(), connector.CandidateRequest{
+		Selector: connector.CandidateSelectorStates,
+		States:   []string{"Backlog"},
+		Limit:    1,
+		PageSize: 1,
+	})
+	if err != nil {
+		t.Fatalf("ReadCandidates() error = %v", err)
+	}
+	if len(got.Issues) != 0 || !got.Truncated || got.PagesRead != 2 {
+		t.Fatalf("result = %#v, want empty bounded truncation after two pages", got)
+	}
+}
+
+func TestConnectorReadLabelCandidatesFiltersConflictedStateLocally(t *testing.T) {
+	t.Parallel()
+
+	server := newGraphQLTestServer(t, []graphqlTestResponse{{
+		method: http.MethodGet,
+		body: `[{"node_id":"I_1","number":1,"title":"Conflicted","body":"","state":"open","html_url":"https://github.com/digitaldrywood/detent/issues/1",
+			"labels":[{"name":"detent:todo"},{"name":"detent:blocked"}]}]`,
+	}})
+	c := newGitHubTestConnector(t, server, Config{
+		GitHubStatusSource: GitHubStatusSourceLabel,
+		Repository:         "digitaldrywood/detent",
+		ActiveStates:       []string{"Todo"},
+		ObservedStates:     []string{"Blocked"},
+	})
+
+	got, err := c.ReadCandidates(context.Background(), connector.CandidateRequest{
+		Selector: connector.CandidateSelectorStates,
+		States:   []string{"Todo"},
+		Limit:    10,
+		PageSize: 10,
+	})
+	if err != nil {
+		t.Fatalf("ReadCandidates() error = %v", err)
+	}
+	if len(got.Issues) != 0 || got.Truncated {
+		t.Fatalf("result = %#v, want honestly filtered complete result", got)
+	}
+}
+
+func TestConnectorReadLabelCandidatesKeepsNumericPageSizeAtBound(t *testing.T) {
+	t.Parallel()
+
+	server := newGraphQLTestServer(t, []graphqlTestResponse{
+		{
+			method: http.MethodGet,
+			body: `[
+				{"node_id":"I_2","number":2,"title":"Second","state":"open","html_url":"https://github.com/digitaldrywood/detent/issues/2","labels":[{"name":"detent:todo"}]},
+				{"node_id":"I_3","number":3,"title":"Third","state":"open","html_url":"https://github.com/digitaldrywood/detent/issues/3","labels":[{"name":"detent:todo"}]}
+			]`,
+		},
+		{
+			method: http.MethodGet,
+			body: `[
+				{"node_id":"I_1","number":1,"title":"First","state":"open","html_url":"https://github.com/digitaldrywood/detent/issues/1","labels":[{"name":"detent:todo"}]},
+				{"node_id":"I_4","number":4,"title":"Fourth","state":"open","html_url":"https://github.com/digitaldrywood/detent/issues/4","labels":[{"name":"detent:todo"}]}
+			]`,
+		},
+	})
+	c := newGitHubTestConnector(t, server, Config{
+		GitHubStatusSource: GitHubStatusSourceLabel,
+		Repository:         "digitaldrywood/detent",
+		ActiveStates:       []string{"Todo"},
+	})
+
+	got, err := c.ReadCandidates(context.Background(), connector.CandidateRequest{
+		Selector: connector.CandidateSelectorStates,
+		States:   []string{"Todo"},
+		Limit:    2,
+		PageSize: 2,
+	})
+	if err != nil {
+		t.Fatalf("ReadCandidates() error = %v", err)
+	}
+	if ids := githubIssueIDs(got.Issues); !reflect.DeepEqual(ids, []string{"I_1", "I_2"}) {
+		t.Fatalf("candidate IDs = %#v, want [I_1 I_2]", ids)
+	}
+	if !got.Truncated || got.PagesRead != 2 {
+		t.Fatalf("result = %#v, want bounded two-page truncation", got)
+	}
+	requests := server.requests()
+	for index, want := range []string{"page=1&per_page=2", "page=2&per_page=2"} {
+		if path := requests[index]["path"].(string); !strings.Contains(path, want) {
+			t.Fatalf("request %d path = %q, missing %q", index, path, want)
+		}
+	}
+}
+
+func TestConnectorReadIssueFieldCandidatesFiltersAndOrdersSearch(t *testing.T) {
+	t.Parallel()
+
+	server := newGraphQLTestServer(t, []graphqlTestResponse{
+		{
+			method: http.MethodGet,
+			path:   "/orgs/digitaldrywood/issue-fields?per_page=100",
+			body:   `[{"id":10,"node_id":"IFSS_status","name":"Status","data_type":"single_select","options":[{"id":1,"name":"Ready","color":"green"}]}]`,
+		},
+		{
+			method: http.MethodGet,
+			body:   `{"total_count":1,"items":[{"node_id":"I_1","number":1,"title":"Ready issue","body":"","state":"open","html_url":"https://github.com/digitaldrywood/detent/issues/1","labels":[]}]}`,
+		},
+		{
+			method: http.MethodGet,
+			path:   "/repos/digitaldrywood/detent/issues/1/issue-field-values?per_page=100",
+			body:   `[{"issue_field_id":10,"node_id":"IFV_1","data_type":"single_select","value":1,"single_select_option":{"id":1,"name":"Ready","color":"green"}}]`,
+		},
+	})
+	c := newGitHubTestConnector(t, server, Config{
+		GitHubStatusSource: GitHubStatusSourceIssueField,
+		Repository:         "digitaldrywood/detent",
+		StatusField:        "Status",
+		StateMap:           map[string]string{"Todo": "Ready"},
+	})
+
+	got, err := c.ReadCandidates(context.Background(), connector.CandidateRequest{
+		Selector: connector.CandidateSelectorStates,
+		States:   []string{"Todo"},
+		Limit:    10,
+		PageSize: 5,
+	})
+	if err != nil {
+		t.Fatalf("ReadCandidates() error = %v", err)
+	}
+	if ids := githubIssueIDs(got.Issues); !reflect.DeepEqual(ids, []string{"I_1"}) {
+		t.Fatalf("candidate IDs = %#v, want [I_1]", ids)
+	}
+	searchPath := server.requests()[1]["path"].(string)
+	for _, want := range []string{"order=asc", "sort=created", "per_page=5"} {
+		if !strings.Contains(searchPath, want) {
+			t.Fatalf("search path = %q, missing %q", searchPath, want)
+		}
+	}
+}

--- a/internal/connector/github/connector.go
+++ b/internal/connector/github/connector.go
@@ -365,6 +365,7 @@ func (c *Connector) ProjectURL(ctx context.Context) (string, error) {
 }
 
 var _ connector.Connector = (*Connector)(nil)
+var _ connector.CandidateReader = (*Connector)(nil)
 var _ connector.Authenticator = (*Connector)(nil)
 var _ intake.IssueStore = (*Connector)(nil)
 var _ connector.Closer = (*Connector)(nil)

--- a/internal/connector/github/issuefield.go
+++ b/internal/connector/github/issuefield.go
@@ -756,6 +756,18 @@ func restIssueFieldValueString(value restIssueFieldValue) string {
 }
 
 func restIssueFieldSearchPath(repo pullRequestRepo, fieldName string, values []string, hint connector.IssueFilterHint, page int) string {
+	return restIssueFieldSearchPagePath(repo, fieldName, values, hint, page, issueSearchPageSize, false)
+}
+
+func restIssueFieldSearchPagePath(
+	repo pullRequestRepo,
+	fieldName string,
+	values []string,
+	hint connector.IssueFilterHint,
+	page int,
+	pageSize int,
+	deterministic bool,
+) string {
 	params := url.Values{}
 	terms := []string{
 		"repo:" + repo.Owner + "/" + repo.Name,
@@ -769,7 +781,11 @@ func restIssueFieldSearchPath(repo pullRequestRepo, fieldName string, values []s
 	if githubSearchNeedsAdvanced(filterQualifiers) {
 		params.Set("advanced_search", "true")
 	}
-	params.Set("per_page", strconv.Itoa(issueSearchPageSize))
+	if deterministic {
+		params.Set("sort", "created")
+		params.Set("order", "asc")
+	}
+	params.Set("per_page", strconv.Itoa(pageSize))
 	params.Set("page", strconv.Itoa(page))
 	return "/search/issues?" + params.Encode()
 }

--- a/internal/connector/github/projects_v2.go
+++ b/internal/connector/github/projects_v2.go
@@ -63,7 +63,7 @@ query DetentGitHubObservedStatusProjectItems(
 ) {
   node(id: $projectId) {
     ... on ProjectV2 {
-      items(first: $first, after: $after) {
+      items(first: $first, after: $after, orderBy: {field: POSITION, direction: ASC}) {
         totalCount
         pageInfo { hasNextPage endCursor }
         nodes {
@@ -77,6 +77,7 @@ query DetentGitHubObservedStatusProjectItems(
               state
               stateReason
               url
+              createdAt
               author { login }
               assignees(first: 10) { nodes { login } }
               repository { nameWithOwner }

--- a/internal/connector/github/statuslabel.go
+++ b/internal/connector/github/statuslabel.go
@@ -553,10 +553,18 @@ func restRepositoryLabelsListPath(repo pullRequestRepo) string {
 }
 
 func restRepositoryIssuesByLabelPath(repo pullRequestRepo, labelName string, page int) string {
+	return restRepositoryIssuesByLabelPagePath(repo, labelName, page, repositoryIssuesPageSize, false)
+}
+
+func restRepositoryIssuesByLabelPagePath(repo pullRequestRepo, labelName string, page int, pageSize int, deterministic bool) string {
 	values := url.Values{}
 	values.Set("state", "all")
 	values.Set("labels", labelName)
-	values.Set("per_page", strconv.Itoa(repositoryIssuesPageSize))
+	if deterministic {
+		values.Set("sort", "created")
+		values.Set("direction", "asc")
+	}
+	values.Set("per_page", strconv.Itoa(pageSize))
 	values.Set("page", strconv.Itoa(page))
 	return "/repos/" + url.PathEscape(repo.Owner) + "/" + url.PathEscape(repo.Name) + "/issues?" + values.Encode()
 }

--- a/internal/connector/githublocal/candidate_test.go
+++ b/internal/connector/githublocal/candidate_test.go
@@ -1,0 +1,47 @@
+package githublocal
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/digitaldrywood/detent/internal/connector"
+	githubconnector "github.com/digitaldrywood/detent/internal/connector/github"
+	"github.com/digitaldrywood/detent/internal/connector/local"
+)
+
+func TestConnectorReadCandidatesUsesLocalStateStore(t *testing.T) {
+	t.Parallel()
+
+	server := newGitHubLocalTestServer(t)
+	c, err := New(Config{
+		GitHub: githubconnector.Config{
+			Endpoint: server.URL + "/graphql",
+			APIKey:   "token",
+		},
+		Local: local.Config{
+			Path: filepath.Join(t.TempDir(), "candidate.db"),
+		},
+		Repository: "digitaldrywood/detent",
+	})
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	t.Cleanup(func() {
+		if err := c.Close(); err != nil {
+			t.Fatalf("Close() error = %v", err)
+		}
+	})
+
+	got, err := c.ReadCandidates(context.Background(), connector.CandidateRequest{
+		Selector: connector.CandidateSelectorStates,
+		States:   []string{"Backlog"},
+		Limit:    10,
+	})
+	if err != nil {
+		t.Fatalf("ReadCandidates() error = %v", err)
+	}
+	if len(got.Issues) != 0 || got.Truncated {
+		t.Fatalf("result = %#v, want empty complete local result", got)
+	}
+}

--- a/internal/connector/githublocal/githublocal.go
+++ b/internal/connector/githublocal/githublocal.go
@@ -92,6 +92,7 @@ type Connector struct {
 var _ githubBackend = (*githubconnector.Connector)(nil)
 var _ localBackend = (*local.Connector)(nil)
 var _ connector.Connector = (*Connector)(nil)
+var _ connector.CandidateReader = (*Connector)(nil)
 var _ connector.Authenticator = (*Connector)(nil)
 var _ connector.AuthHealthReporter = (*Connector)(nil)
 var _ connector.CandidateIssuesByStatesFetcher = (*Connector)(nil)
@@ -279,6 +280,29 @@ func (c *Connector) ConditionalPollingEnabled() bool {
 	}
 	poller, ok := c.github.(connector.ConditionalPoller)
 	return ok && poller.ConditionalPollingEnabled()
+}
+
+func (*Connector) CandidateCapabilities() connector.CandidateCapabilities {
+	return connector.CandidateCapabilitiesFor(connector.BackendGitHubLocal, "")
+}
+
+func (c *Connector) ReadCandidates(ctx context.Context, request connector.CandidateRequest) (connector.CandidateResult, error) {
+	if err := request.Validate(c.CandidateCapabilities()); err != nil {
+		return connector.CandidateResult{}, err
+	}
+	reader, ok := c.local.(connector.CandidateReader)
+	if !ok {
+		return connector.CandidateResult{}, connector.ErrCandidateSelectorUnsupported
+	}
+	result, err := reader.ReadCandidates(ctx, request)
+	if err != nil {
+		return connector.CandidateResult{}, err
+	}
+	issues, err := c.hydrateLocalIssues(ctx, result.Issues)
+	if err != nil {
+		return connector.CandidateResult{}, err
+	}
+	return connector.NewCandidateResult(issues, request, result.PagesRead, result.Truncated), nil
 }
 
 func (c *Connector) FetchCandidateIssues(ctx context.Context) ([]connector.Issue, error) {

--- a/internal/connector/linear/candidate_test.go
+++ b/internal/connector/linear/candidate_test.go
@@ -1,0 +1,26 @@
+package linear
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/digitaldrywood/detent/internal/connector"
+)
+
+func TestConnectorDeclinesUnsupportedCandidateSelector(t *testing.T) {
+	t.Parallel()
+
+	c := &Connector{}
+	if c.CandidateCapabilities().Supports(connector.CandidateSelectorStates) {
+		t.Fatal("CandidateCapabilities().Supports(states) = true, want false")
+	}
+	_, err := c.ReadCandidates(context.Background(), connector.CandidateRequest{
+		Selector: connector.CandidateSelectorStates,
+		States:   []string{"Backlog"},
+		Limit:    10,
+	})
+	if !errors.Is(err, connector.ErrCandidateSelectorUnsupported) {
+		t.Fatalf("ReadCandidates() error = %v, want ErrCandidateSelectorUnsupported", err)
+	}
+}

--- a/internal/connector/linear/connector.go
+++ b/internal/connector/linear/connector.go
@@ -90,6 +90,7 @@ type Connector struct {
 }
 
 var _ connector.Connector = (*Connector)(nil)
+var _ connector.CandidateReader = (*Connector)(nil)
 var _ connector.CapabilityReporter = (*Connector)(nil)
 var _ connector.IssueCommentReader = (*Connector)(nil)
 
@@ -109,6 +110,17 @@ func NewConnector(cfg Config) (*Connector, error) {
 
 func (c *Connector) Name() string {
 	return connector.BackendLinear.String()
+}
+
+func (*Connector) CandidateCapabilities() connector.CandidateCapabilities {
+	return connector.CandidateCapabilitiesFor(connector.BackendLinear, "")
+}
+
+func (c *Connector) ReadCandidates(_ context.Context, request connector.CandidateRequest) (connector.CandidateResult, error) {
+	if err := request.Validate(c.CandidateCapabilities()); err != nil {
+		return connector.CandidateResult{}, err
+	}
+	return connector.CandidateResult{}, connector.ErrNotImplemented
 }
 
 func (*Connector) Capabilities() connector.Capabilities {

--- a/internal/connector/local/candidate_test.go
+++ b/internal/connector/local/candidate_test.go
@@ -1,0 +1,57 @@
+package local
+
+import (
+	"context"
+	"path/filepath"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/digitaldrywood/detent/internal/connector"
+)
+
+func TestConnectorReadCandidatesUsesDeterministicBoundedOrder(t *testing.T) {
+	t.Parallel()
+
+	at := time.Date(2026, 7, 29, 12, 0, 0, 0, time.UTC)
+	issues := []connector.Issue{
+		{ID: "3", Identifier: "DD-3", State: "Backlog", CreatedAt: localCandidateTime(at.Add(3 * time.Hour))},
+		{ID: "nil", Identifier: "DD-0", State: "Backlog"},
+		{ID: "2", Identifier: "DD-2", State: "Backlog", CreatedAt: localCandidateTime(at.Add(2 * time.Hour))},
+		{ID: "1", Identifier: "DD-1", State: "Backlog", CreatedAt: localCandidateTime(at.Add(time.Hour))},
+	}
+	c, err := New(Config{
+		Path:      filepath.Join(t.TempDir(), "candidate.db"),
+		ProjectID: "detent",
+		Issues:    issues,
+	})
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	t.Cleanup(func() {
+		if err := c.Close(); err != nil {
+			t.Fatalf("Close() error = %v", err)
+		}
+	})
+
+	got, err := c.ReadCandidates(context.Background(), connector.CandidateRequest{
+		Selector: connector.CandidateSelectorStates,
+		States:   []string{"backlog"},
+		Limit:    2,
+		PageSize: 1,
+	})
+	if err != nil {
+		t.Fatalf("ReadCandidates() error = %v", err)
+	}
+	ids := []string{got.Issues[0].ID, got.Issues[1].ID}
+	if !reflect.DeepEqual(ids, []string{"1", "2"}) {
+		t.Fatalf("candidate IDs = %#v, want [1 2]", ids)
+	}
+	if !got.Truncated {
+		t.Fatalf("result = %#v, want truncation", got)
+	}
+}
+
+func localCandidateTime(value time.Time) *time.Time {
+	return &value
+}

--- a/internal/connector/local/local.go
+++ b/internal/connector/local/local.go
@@ -64,6 +64,7 @@ type Connector struct {
 }
 
 var _ connector.Connector = (*Connector)(nil)
+var _ connector.CandidateReader = (*Connector)(nil)
 var _ connector.CandidateIssuesByStatesFetcher = (*Connector)(nil)
 var _ connector.IssuesByStatesLimiter = (*Connector)(nil)
 var _ connector.IssueCloser = (*Connector)(nil)
@@ -168,6 +169,21 @@ func escapeSQLiteURIPath(path string) string {
 
 func (c *Connector) Name() string {
 	return connector.BackendLocalSQLite.String()
+}
+
+func (*Connector) CandidateCapabilities() connector.CandidateCapabilities {
+	return connector.CandidateCapabilitiesFor(connector.BackendLocalSQLite, "")
+}
+
+func (c *Connector) ReadCandidates(ctx context.Context, request connector.CandidateRequest) (connector.CandidateResult, error) {
+	if err := request.Validate(c.CandidateCapabilities()); err != nil {
+		return connector.CandidateResult{}, err
+	}
+	issues, err := c.fetchIssuesWithOrder(ctx, request.States, request.ProbeLimit(), true)
+	if err != nil {
+		return connector.CandidateResult{}, err
+	}
+	return connector.NewCandidateResult(issues, request, 1, false), nil
 }
 
 func (c *Connector) Close() error {
@@ -963,6 +979,10 @@ on conflict(project_id, id) do nothing`,
 }
 
 func (c *Connector) fetchIssues(ctx context.Context, states []string, limit int) ([]connector.Issue, error) {
+	return c.fetchIssuesWithOrder(ctx, states, limit, false)
+}
+
+func (c *Connector) fetchIssuesWithOrder(ctx context.Context, states []string, limit int, candidateOrder bool) ([]connector.Issue, error) {
 	query := `select project_id, id, identifier, number, title, description, priority, state, url,
 author_id, assignee_id, assignees_json, labels_json, fields_json, metadata_json,
 deliverable_kind, deliverable_path, deliverable_review_url, deliverable_validation_status,
@@ -987,7 +1007,11 @@ where project_id = ?`
 		// case-insensitively so items stay visible either way.
 		query += " and state collate nocase in (" + strings.Join(placeholders, ",") + ")" // #nosec G202 -- only generated question-mark placeholders are concatenated; values remain bound parameters.
 	}
-	query += " order by updated_at desc, id asc"
+	if candidateOrder {
+		query += " order by created_at is null asc, created_at asc, lower(identifier) asc, identifier asc, id asc"
+	} else {
+		query += " order by updated_at desc, id asc"
+	}
 	if limit > 0 {
 		query += " limit ?"
 		args = append(args, limit)

--- a/internal/connector/memory/candidate_test.go
+++ b/internal/connector/memory/candidate_test.go
@@ -1,0 +1,43 @@
+package memory
+
+import (
+	"context"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/digitaldrywood/detent/internal/connector"
+)
+
+func TestConnectorReadCandidatesFiltersSortsAndTruncates(t *testing.T) {
+	t.Parallel()
+
+	at := time.Date(2026, 7, 29, 12, 0, 0, 0, time.UTC)
+	c := New(Config{Issues: []connector.Issue{
+		{ID: "3", Identifier: "DD-3", State: "Backlog", CreatedAt: timePointer(at.Add(3 * time.Hour))},
+		{ID: "ignored", Identifier: "DD-0", State: "Todo", CreatedAt: timePointer(at)},
+		{ID: "2", Identifier: "DD-2", State: "backlog", CreatedAt: timePointer(at.Add(2 * time.Hour))},
+		{ID: "1", Identifier: "DD-1", State: "Backlog", CreatedAt: timePointer(at.Add(time.Hour))},
+	}})
+
+	got, err := c.ReadCandidates(context.Background(), connector.CandidateRequest{
+		Selector: connector.CandidateSelectorStates,
+		States:   []string{"BACKLOG"},
+		Limit:    2,
+		PageSize: 1,
+	})
+	if err != nil {
+		t.Fatalf("ReadCandidates() error = %v", err)
+	}
+	ids := []string{got.Issues[0].ID, got.Issues[1].ID}
+	if !reflect.DeepEqual(ids, []string{"1", "2"}) {
+		t.Fatalf("candidate IDs = %#v, want [1 2]", ids)
+	}
+	if !got.Truncated {
+		t.Fatalf("result = %#v, want truncation", got)
+	}
+}
+
+func timePointer(value time.Time) *time.Time {
+	return &value
+}

--- a/internal/connector/memory/memory.go
+++ b/internal/connector/memory/memory.go
@@ -60,6 +60,7 @@ type Connector struct {
 }
 
 var _ connector.Connector = (*Connector)(nil)
+var _ connector.CandidateReader = (*Connector)(nil)
 var _ connector.InstanceIdentifier = (*Connector)(nil)
 var _ connector.IssueChildrenResolver = (*Connector)(nil)
 var _ connector.IssueCloser = (*Connector)(nil)
@@ -89,6 +90,35 @@ func New(cfg Config) *Connector {
 
 func (c *Connector) Name() string {
 	return connector.BackendMemory.String()
+}
+
+func (*Connector) CandidateCapabilities() connector.CandidateCapabilities {
+	return connector.CandidateCapabilitiesFor(connector.BackendMemory, "")
+}
+
+func (c *Connector) ReadCandidates(_ context.Context, request connector.CandidateRequest) (connector.CandidateResult, error) {
+	capabilities := c.CandidateCapabilities()
+	if err := request.Validate(capabilities); err != nil {
+		return connector.CandidateResult{}, err
+	}
+
+	wantedStates := make(map[string]struct{}, len(request.States))
+	for _, stateName := range request.States {
+		if stateName = normalizeState(stateName); stateName != "" {
+			wantedStates[stateName] = struct{}{}
+		}
+	}
+
+	c.mu.RLock()
+	issues := make([]connector.Issue, 0, min(len(c.issues), request.ProbeLimit()))
+	for _, issue := range c.issues {
+		if _, ok := wantedStates[normalizeState(issue.State)]; ok {
+			issues = append(issues, cloneIssue(issue))
+		}
+	}
+	c.mu.RUnlock()
+
+	return connector.NewCandidateResult(issues, request, 1, false), nil
 }
 
 func (c *Connector) InstanceLogin() string {

--- a/internal/project/project.go
+++ b/internal/project/project.go
@@ -1459,7 +1459,11 @@ func admissionIssueStore(projectConnector connector.Connector) admission.IssueSt
 	if projectConnector == nil {
 		return nil
 	}
-	return projectConnector
+	issueStore, ok := projectConnector.(admission.IssueStore)
+	if !ok {
+		return nil
+	}
+	return issueStore
 }
 
 func projectSchedulerCandidate(project globalconfig.Project) scheduler.ProjectCandidate {


### PR DESCRIPTION
## Summary

- add a capability-declared candidate reader with deterministic ordering, finite paging bounds, and explicit truncation
- implement honest state selection for every supported tracker and all GitHub status sources, while making Linear fail config validation
- route backlog admission through the reader and record reader truncation in the run ledger
- document the per-tracker capability table

Fixes #1536

## UI Surface Contract

- [x] N/A; this PR does not change UI surfaces, layout, density, first-viewport behavior, or responsive visibility.
- [x] This PR adds no persistent top-of-screen messaging.
- [x] This PR has no visual changes to primary operator screens.

## Test Plan

- [x] `make check`
