### PR TITLE
fix(admission): admit accepted proposals

### DIFF
--- a/README.md
+++ b/README.md
@@ -1184,7 +1184,8 @@ proposal is a durable record with an expiry and one audit comment. To accept a
 proposal, an operator posts the exact proposal-specific
 `/detent admission accept <proposal-id>` command; Detent then moves the issue to
 the configured target state. To reject it, the operator posts
-`/detent admission reject <proposal-id>`.
+`/detent admission reject <proposal-id>`. GitHub command authors must have
+write, maintain, or admin permission on the repository.
 
 Admission is disabled unless a project opts in:
 

--- a/README.md
+++ b/README.md
@@ -1179,11 +1179,11 @@ before adding it to the board.
 
 Backlog admission evaluates existing issues and proposes which ones should
 become eligible for dispatch. It does not create work like routines, classify
-incoming work like intake, rank eligible work like the scheduler, or change
-issue status. Every proposal is a durable record with an expiry and one audit
-comment. To accept a proposal, an operator posts the exact proposal-specific
-`/detent admission accept <proposal-id>` command and then moves the issue to the
-configured target state. To reject it, the operator posts
+incoming work like intake, or rank eligible work like the scheduler. Every
+proposal is a durable record with an expiry and one audit comment. To accept a
+proposal, an operator posts the exact proposal-specific
+`/detent admission accept <proposal-id>` command; Detent then moves the issue to
+the configured target state. To reject it, the operator posts
 `/detent admission reject <proposal-id>`.
 
 Admission is disabled unless a project opts in:
@@ -1204,6 +1204,8 @@ backlog_admission:
   max_proposals_per_run: 3
   max_open_proposals: 10
   proposal_expiry_days: 7
+  auto_admit: false
+  auto_admit_min_confidence: 0.90
 ```
 
 State names come from the project's workflow. `sources.labels` selects issues
@@ -1251,18 +1253,23 @@ wholesale when another project needs different judgments.
 The agent receives only the resolved criteria and bounded candidate data in a
 fresh read-only session. It emits typed proposals. Detent re-fetches each issue,
 validates every field and verbatim criteria quote, rejects proposals matching no
-dimension, and persists valid records before posting comments. Confidence is
-stored as telemetry and never authorizes a transition. Repeated runs use a
-title/body fingerprint, so the proposal's own comment cannot create a
+dimension, and persists valid records before posting comments. Repeated runs use
+a title/body fingerprint, so the proposal's own comment cannot create a
 duplicate. Unanswered proposals expire; an issue demoted after acceptance is
 not proposed again.
 
-Acceptance is attributed only when the command names an open proposal and a
-subsequent transition enters that proposal's target state. When both events
-include actors, they must identify the same actor. A target-state transition
-without that correlation remains an unattributed transition and does not accept
-the proposal. Rejection, expiry, and supersession are separate outcomes:
-silence can expire a proposal but never accepts or rejects one.
+`auto_admit` is off by default. When enabled, Detent admits proposals whose
+confidence is at least `auto_admit_min_confidence`, after revalidating the source
+state, author allowlist, and excluded labels. Automatic admissions remain
+bounded by `max_proposals_per_run` and `max_open_proposals`. Lower-confidence
+proposals still require an explicit accept command.
+
+Acceptance is attributed to the actor who posted the command. Detent records
+the proposal ID and operator actor on the resulting target-state transition. An
+accept for an issue that has left the configured source states resolves the
+proposal as superseded with a recorded reason and does not move the issue.
+Rejection, expiry, and supersession are separate outcomes: silence can expire a
+proposal but never accepts or rejects one.
 
 Capability is declared per tracker and per GitHub status source:
 

--- a/config.reference.yaml
+++ b/config.reference.yaml
@@ -390,6 +390,8 @@
 #           author_kind: null
 #           # tracker.issues[].comments[].author_display_name | type: string | default: none | required: No | validation: None
 #           author_display_name: null
+#           # tracker.issues[].comments[].author_authorized | type: boolean | default: false when configured | required: No | validation: None
+#           author_authorized: false
 #           # tracker.issues[].comments[].created_at | type: mapping | default: none | required: No | validation: None
 #           created_at: null
 #           # tracker.issues[].comments[].updated_at | type: mapping | default: none | required: No | validation: None
@@ -992,3 +994,7 @@
 #   max_open_proposals: 10
 #   # backlog_admission.proposal_expiry_days | type: integer | default: 7 | required: No | validation: must be greater than 0
 #   proposal_expiry_days: 7
+#   # backlog_admission.auto_admit | type: boolean | default: false | required: No | validation: None
+#   auto_admit: false
+#   # backlog_admission.auto_admit_min_confidence | type: number | default: 0.9 | required: No | validation: None
+#   auto_admit_min_confidence: 0.9

--- a/docs/config.md
+++ b/docs/config.md
@@ -240,6 +240,8 @@ rendering and fails on drift.
 | `backlog_admission` | `object` | `see child fields` | No | None |
 | `backlog_admission.authors` | `object` | `see child fields` | No | None |
 | `backlog_admission.authors.allow` | `list<string>` | `[]` | No | None |
+| `backlog_admission.auto_admit` | `boolean` | `false` | No | None |
+| `backlog_admission.auto_admit_min_confidence` | `number` | `0.9` | No | None |
 | `backlog_admission.criteria_section` | `string` | `none` | Conditional | is required |
 | `backlog_admission.enabled` | `boolean` | `false` | No | None |
 | `backlog_admission.exclude_labels` | `list<string>` | `[]` | No | None |
@@ -455,6 +457,7 @@ rendering and fails on drift.
 | `tracker.issues[].closed` | `boolean` | `false when configured` | No | None |
 | `tracker.issues[].closed_reason` | `string` | `none` | No | None |
 | `tracker.issues[].comments` | `list<object>` | `[]` | No | None |
+| `tracker.issues[].comments[].author_authorized` | `boolean` | `false when configured` | No | None |
 | `tracker.issues[].comments[].author_display_name` | `string` | `none` | No | None |
 | `tracker.issues[].comments[].author_kind` | `string` | `none` | No | None |
 | `tracker.issues[].comments[].author_login` | `string` | `none` | No | None |

--- a/internal/admission/manager.go
+++ b/internal/admission/manager.go
@@ -27,9 +27,14 @@ import (
 )
 
 const (
-	ProposalToolName = "propose_backlog_admission"
-	admissionState   = "Admission"
-	maxRationaleSize = 16 * 1024
+	ProposalToolName                       = "propose_backlog_admission"
+	admissionState                         = "Admission"
+	admissionResolutionExplicitAccept      = "explicit_accept"
+	admissionResolutionExplicitReject      = "explicit_reject"
+	admissionResolutionAutoAdmit           = "auto_admit"
+	admissionResolutionSourceStateChanged  = "source_state_changed_before_acceptance"
+	admissionResolutionAutoAdmitIneligible = "candidate_became_ineligible_before_auto_admit"
+	maxRationaleSize                       = 16 * 1024
 )
 
 var (
@@ -59,6 +64,7 @@ type IssueStore interface {
 	connector.CandidateReader
 	FetchIssueStatesByIDs(context.Context, []string) ([]connector.Issue, error)
 	CreateComment(context.Context, string, string) error
+	UpdateIssueState(context.Context, string, string) error
 }
 
 type Settings struct {
@@ -288,7 +294,14 @@ func (m *Manager) runOnce(ctx context.Context, settings Settings, scheduledFor t
 		result.Skipped["expired"] = expired
 	}
 	commentsRemaining := settings.Config.MaxProposalsPerRun
-	commentsRemaining, err = m.reconcileOpenProposals(ctx, settings, commentsRemaining, startedAt)
+	autoAdmitsRemaining := settings.Config.MaxProposalsPerRun
+	commentsRemaining, autoAdmitsRemaining, err = m.reconcileOpenProposals(
+		ctx,
+		settings,
+		commentsRemaining,
+		autoAdmitsRemaining,
+		startedAt,
+	)
 	if err != nil {
 		return result, err
 	}
@@ -425,7 +438,7 @@ func (m *Manager) runOnce(ctx context.Context, settings Settings, scheduledFor t
 		result.Truncated["open_proposals"] += len(proposals) - available
 		proposals = proposals[:available]
 	}
-	return m.executeProposals(ctx, settings, candidates, proposals, result, commentsRemaining, startedAt)
+	return m.executeProposals(ctx, settings, candidates, proposals, result, commentsRemaining, autoAdmitsRemaining, startedAt)
 }
 
 func candidateReadLimit(maxCandidates int) int {
@@ -436,14 +449,15 @@ func (m *Manager) reconcileOpenProposals(
 	ctx context.Context,
 	settings Settings,
 	commentsRemaining int,
+	autoAdmitsRemaining int,
 	at time.Time,
-) (int, error) {
+) (int, int, error) {
 	proposals, err := m.store.OpenAdmissionProposals(ctx, settings.ProjectID, 0)
 	if err != nil {
-		return commentsRemaining, err
+		return commentsRemaining, autoAdmitsRemaining, err
 	}
 	if len(proposals) == 0 {
-		return commentsRemaining, nil
+		return commentsRemaining, autoAdmitsRemaining, nil
 	}
 	ids := make([]string, 0, len(proposals))
 	for _, proposal := range proposals {
@@ -451,12 +465,12 @@ func (m *Manager) reconcileOpenProposals(
 	}
 	issues, err := settings.Issues.FetchIssueStatesByIDs(ctx, ids)
 	if err != nil {
-		return commentsRemaining, fmt.Errorf("reconcile backlog admission proposals: %w", err)
+		return commentsRemaining, autoAdmitsRemaining, fmt.Errorf("reconcile backlog admission proposals: %w", err)
 	}
 	byID := issueMap(issues)
 	commentReader, ok := settings.Issues.(connector.IssueCommentReader)
 	if !ok {
-		return commentsRemaining, errors.New("backlog admission issue comment reader is required")
+		return commentsRemaining, autoAdmitsRemaining, errors.New("backlog admission issue comment reader is required")
 	}
 	commentsByIssue := map[string][]connector.IssueComment{}
 	for _, proposal := range proposals {
@@ -468,18 +482,20 @@ func (m *Manager) reconcileOpenProposals(
 		if !loaded {
 			comments, err = commentReader.FetchIssueComments(ctx, issue)
 			if err != nil {
-				return commentsRemaining, fmt.Errorf("read backlog admission decision comments: %w", err)
+				return commentsRemaining, autoAdmitsRemaining, fmt.Errorf("read backlog admission decision comments: %w", err)
 			}
 			commentsByIssue[proposal.IssueID] = comments
 		}
 		decision, decided := proposalDecision(proposal, comments)
 		if decided && decision.Outcome == admissionmodel.ProposalRejected {
+			decision.Reason = admissionResolutionExplicitReject
 			if err := m.store.ResolveAdmissionProposal(ctx, decision); err != nil {
-				return commentsRemaining, err
+				return commentsRemaining, autoAdmitsRemaining, err
 			}
 			continue
 		}
 		if decided && decision.Outcome == admissionmodel.ProposalAccepted {
+			decision.Reason = admissionResolutionExplicitAccept
 			transitions, err := m.store.AdmissionTargetTransitions(ctx, admissionmodel.TargetTransitionQuery{
 				ProjectID:   proposal.ProjectID,
 				IssueID:     proposal.IssueID,
@@ -487,21 +503,14 @@ func (m *Manager) reconcileOpenProposals(
 				NotBefore:   decision.DecidedAt,
 			})
 			if err != nil {
-				return commentsRemaining, err
+				return commentsRemaining, autoAdmitsRemaining, err
 			}
 			resolved := false
 			for _, transition := range transitions {
-				if !admissionActorsCorrelate(decision.ActorLogin, transition.ActorLogin) {
-					continue
-				}
 				decision.TransitionAt = transition.EnteredAt
 				decision.TransitionEventID = transition.EventID
-				if strings.TrimSpace(transition.ActorLogin) != "" {
-					decision.ActorLogin = transition.ActorLogin
-					decision.ActorKind = transition.ActorKind
-				}
 				if err := m.store.ResolveAdmissionProposal(ctx, decision); err != nil {
-					return commentsRemaining, err
+					return commentsRemaining, autoAdmitsRemaining, err
 				}
 				resolved = true
 				break
@@ -514,29 +523,72 @@ func (m *Manager) reconcileOpenProposals(
 			strings.EqualFold(strings.TrimSpace(issue.State), proposal.TargetState) {
 			transition, found, err := admissionIssueTransition(ctx, settings.Issues, issue)
 			if err != nil {
-				return commentsRemaining, err
+				return commentsRemaining, autoAdmitsRemaining, err
 			}
-			if found && !transition.EnteredAt.Before(decision.DecidedAt) &&
-				admissionActorsCorrelate(decision.ActorLogin, transition.Actor.Login) {
+			if found && !transition.EnteredAt.Before(decision.DecidedAt) {
 				decision.TransitionAt = transition.EnteredAt
-				if strings.TrimSpace(transition.Actor.Login) != "" {
-					decision.ActorLogin = transition.Actor.Login
-					decision.ActorKind = transition.Actor.Kind
-				}
 				if err := m.store.ResolveAdmissionProposal(ctx, decision); err != nil {
-					return commentsRemaining, err
+					return commentsRemaining, autoAdmitsRemaining, err
 				}
 				continue
 			}
 		}
+		if decided && decision.Outcome == admissionmodel.ProposalAccepted {
+			if !admissionSourceEligible(issue, settings.Config) {
+				decision.Outcome = admissionmodel.ProposalSuperseded
+				decision.Reason = admissionResolutionSourceStateChanged
+				if err := m.store.ResolveAdmissionProposal(ctx, decision); err != nil {
+					return commentsRemaining, autoAdmitsRemaining, err
+				}
+				continue
+			}
+			if err := m.admitProposal(ctx, settings, issue, proposal, decision); err != nil {
+				return commentsRemaining, autoAdmitsRemaining, err
+			}
+			continue
+		}
+		if !decided && autoAdmitProposal(settings.Config, proposal) {
+			if !autoAdmitCandidateEligible(issue, settings.Config) {
+				decision := automaticAdmissionDecision(settings.Issues, proposal, at)
+				decision.Outcome = admissionmodel.ProposalSuperseded
+				decision.Reason = admissionResolutionAutoAdmitIneligible
+				if err := m.store.ResolveAdmissionProposal(ctx, decision); err != nil {
+					return commentsRemaining, autoAdmitsRemaining, err
+				}
+				continue
+			}
+			if proposal.CommentedAt.IsZero() {
+				if commentsRemaining == 0 {
+					continue
+				}
+				if err := m.commentProposal(ctx, settings, proposal); err != nil {
+					return commentsRemaining, autoAdmitsRemaining, err
+				}
+				commentsRemaining--
+			}
+			if autoAdmitsRemaining == 0 {
+				continue
+			}
+			if err := m.admitProposal(
+				ctx,
+				settings,
+				issue,
+				proposal,
+				automaticAdmissionDecision(settings.Issues, proposal, at),
+			); err != nil {
+				return commentsRemaining, autoAdmitsRemaining, err
+			}
+			autoAdmitsRemaining--
+			continue
+		}
 		if proposal.CommentedAt.IsZero() && commentsRemaining > 0 {
 			if err := m.commentProposal(ctx, settings, proposal); err != nil {
-				return commentsRemaining, err
+				return commentsRemaining, autoAdmitsRemaining, err
 			}
 			commentsRemaining--
 		}
 	}
-	return commentsRemaining, nil
+	return commentsRemaining, autoAdmitsRemaining, nil
 }
 
 func (m *Manager) unproposedCandidates(
@@ -579,6 +631,7 @@ func (m *Manager) executeProposals(
 	agentProposals []AgentProposal,
 	result Result,
 	commentsRemaining int,
+	autoAdmitsRemaining int,
 	at time.Time,
 ) (Result, error) {
 	if len(agentProposals) == 0 {
@@ -659,17 +712,83 @@ func (m *Manager) executeProposals(
 			}
 			commentsRemaining--
 		}
+		if autoAdmitsRemaining > 0 && autoAdmitProposal(settings.Config, proposal) {
+			if err := m.admitProposal(
+				ctx,
+				settings,
+				current,
+				proposal,
+				automaticAdmissionDecision(settings.Issues, proposal, at),
+			); err != nil {
+				return result, err
+			}
+			autoAdmitsRemaining--
+		}
 	}
 	return result, nil
 }
 
 func (m *Manager) commentProposal(ctx context.Context, settings Settings, proposal admissionmodel.Proposal) error {
-	if err := settings.Issues.CreateComment(ctx, proposal.IssueID, proposalComment(proposal)); err != nil {
+	if err := settings.Issues.CreateComment(
+		ctx,
+		proposal.IssueID,
+		proposalComment(proposal, autoAdmitProposal(settings.Config, proposal)),
+	); err != nil {
 		return fmt.Errorf("create backlog admission audit comment: %w", err)
 	}
 	if err := m.store.MarkAdmissionProposalCommented(ctx, proposal.ID, m.now().UTC()); err != nil {
 		return fmt.Errorf("mark backlog admission audit comment: %w", err)
 	}
+	return nil
+}
+
+func (m *Manager) admitProposal(
+	ctx context.Context,
+	settings Settings,
+	issue connector.Issue,
+	proposal admissionmodel.Proposal,
+	decision admissionmodel.Decision,
+) error {
+	issues, err := settings.Issues.FetchIssueStatesByIDs(ctx, []string{proposal.IssueID})
+	if err != nil {
+		return fmt.Errorf("revalidate admitted backlog issue %s: %w", proposal.IssueIdentifier, err)
+	}
+	current, found := issueMap(issues)[proposal.IssueID]
+	eligible := found && admissionSourceEligible(current, settings.Config)
+	if decision.Automatic {
+		eligible = found && autoAdmitCandidateEligible(current, settings.Config)
+	}
+	if !eligible {
+		decision.Outcome = admissionmodel.ProposalSuperseded
+		decision.Reason = admissionResolutionSourceStateChanged
+		if decision.Automatic {
+			decision.Reason = admissionResolutionAutoAdmitIneligible
+		}
+		if err := m.store.ResolveAdmissionProposal(ctx, decision); err != nil {
+			return fmt.Errorf("resolve stale backlog proposal %s: %w", proposal.ID, err)
+		}
+		return nil
+	}
+	issue = current
+	if err := settings.Issues.UpdateIssueState(ctx, proposal.IssueID, proposal.TargetState); err != nil {
+		return fmt.Errorf("admit backlog issue %s to %s: %w", proposal.IssueIdentifier, proposal.TargetState, err)
+	}
+	decision.TransitionAt = m.now().UTC()
+	if err := m.store.ResolveAdmissionProposal(ctx, decision); err != nil {
+		return fmt.Errorf("resolve admitted backlog proposal %s: %w", proposal.ID, err)
+	}
+	m.logger.InfoContext(
+		ctx,
+		"backlog admission proposal admitted",
+		"project", proposal.ProjectID,
+		"issue_id", proposal.IssueID,
+		"identifier", proposal.IssueIdentifier,
+		"from_state", issue.State,
+		"target_state", proposal.TargetState,
+		"proposal_id", proposal.ID,
+		"decision_actor", decision.ActorLogin,
+		"resolution_reason", decision.Reason,
+	)
 	return nil
 }
 
@@ -722,10 +841,38 @@ func admissionIssueTransition(ctx context.Context, issues IssueStore, issue conn
 	return connector.IssueStateTransition{EnteredAt: issue.StageUpdatedAt.UTC()}, true, nil
 }
 
-func admissionActorsCorrelate(decisionActor string, transitionActor string) bool {
-	decisionActor = strings.TrimSpace(decisionActor)
-	transitionActor = strings.TrimSpace(transitionActor)
-	return decisionActor == "" || transitionActor == "" || strings.EqualFold(decisionActor, transitionActor)
+func admissionSourceEligible(issue connector.Issue, cfg config.BacklogAdmission) bool {
+	return !issue.Closed && containsFold(cfg.Sources.States, issue.State)
+}
+
+func autoAdmitCandidateEligible(issue connector.Issue, cfg config.BacklogAdmission) bool {
+	return admissionSourceEligible(issue, cfg) && !excludedCandidate(issue, cfg)
+}
+
+func autoAdmitProposal(cfg config.BacklogAdmission, proposal admissionmodel.Proposal) bool {
+	return cfg.AutoAdmit && proposal.Confidence >= cfg.AutoAdmitMinConfidence
+}
+
+func automaticAdmissionDecision(
+	issues IssueStore,
+	proposal admissionmodel.Proposal,
+	at time.Time,
+) admissionmodel.Decision {
+	actorLogin := "detent"
+	if identity, ok := issues.(connector.InstanceIdentifier); ok {
+		if login := strings.TrimSpace(identity.InstanceLogin()); login != "" {
+			actorLogin = login
+		}
+	}
+	return admissionmodel.Decision{
+		ProposalID: proposal.ID,
+		Outcome:    admissionmodel.ProposalAccepted,
+		DecidedAt:  at.UTC(),
+		ActorLogin: actorLogin,
+		ActorKind:  "Bot",
+		Reason:     admissionResolutionAutoAdmit,
+		Automatic:  true,
+	}
 }
 
 func admissionAcceptCommand(proposalID string) string {
@@ -984,18 +1131,22 @@ func proposalID(projectID string, issueID string, fingerprint string, at time.Ti
 	return "admission-" + hex.EncodeToString(sum[:12])
 }
 
-func proposalComment(proposal admissionmodel.Proposal) string {
+func proposalComment(proposal admissionmodel.Proposal, autoAdmit bool) string {
 	var b strings.Builder
 	b.WriteString("## Detent backlog admission proposal\n\n")
 	b.WriteString("Proposal `")
 	b.WriteString(proposal.ID)
 	b.WriteString("` recommends moving this issue to **")
 	b.WriteString(proposal.TargetState)
-	b.WriteString("**. Detent has not changed the issue status. To accept, reply with `")
-	b.WriteString(admissionAcceptCommand(proposal.ID))
-	b.WriteString("` and then move the issue to that state. To reject, reply with `")
-	b.WriteString(admissionRejectCommand(proposal.ID))
-	b.WriteString("`. Leaving it unactioned will expire the proposal without counting as rejection.\n\n")
+	if autoAdmit {
+		b.WriteString("** and meets the configured automatic-admission threshold. Detent will move the issue to that state and record this proposal as the provenance.\n\n")
+	} else {
+		b.WriteString("**. To accept and have Detent move the issue, reply with `")
+		b.WriteString(admissionAcceptCommand(proposal.ID))
+		b.WriteString("`. To reject, reply with `")
+		b.WriteString(admissionRejectCommand(proposal.ID))
+		b.WriteString("`. Leaving it unactioned will expire the proposal without counting as rejection.\n\n")
+	}
 	b.WriteString("Criteria section: **")
 	b.WriteString(proposal.CriteriaSection)
 	b.WriteString("**\n\n")

--- a/internal/admission/manager.go
+++ b/internal/admission/manager.go
@@ -486,7 +486,10 @@ func (m *Manager) reconcileOpenProposals(
 			}
 			commentsByIssue[proposal.IssueID] = comments
 		}
-		decision, decided := proposalDecision(proposal, comments)
+		decision, decided, err := proposalDecision(ctx, settings.Issues, issue, proposal, comments)
+		if err != nil {
+			return commentsRemaining, autoAdmitsRemaining, err
+		}
 		if decided && decision.Outcome == admissionmodel.ProposalRejected {
 			decision.Reason = admissionResolutionExplicitReject
 			if err := m.store.ResolveAdmissionProposal(ctx, decision); err != nil {
@@ -548,6 +551,13 @@ func (m *Manager) reconcileOpenProposals(
 			continue
 		}
 		if !decided && autoAdmitProposal(settings.Config, proposal) {
+			recovered, err := m.recoverAutomaticAdmission(ctx, settings, issue, proposal)
+			if err != nil {
+				return commentsRemaining, autoAdmitsRemaining, err
+			}
+			if recovered {
+				continue
+			}
 			if !autoAdmitCandidateEligible(issue, settings.Config) {
 				decision := automaticAdmissionDecision(settings.Issues, proposal, at)
 				decision.Outcome = admissionmodel.ProposalSuperseded
@@ -792,7 +802,37 @@ func (m *Manager) admitProposal(
 	return nil
 }
 
-func proposalDecision(proposal admissionmodel.Proposal, comments []connector.IssueComment) (admissionmodel.Decision, bool) {
+func (m *Manager) recoverAutomaticAdmission(
+	ctx context.Context,
+	settings Settings,
+	issue connector.Issue,
+	proposal admissionmodel.Proposal,
+) (bool, error) {
+	if !strings.EqualFold(strings.TrimSpace(issue.State), strings.TrimSpace(proposal.TargetState)) {
+		return false, nil
+	}
+	transition, found, err := admissionIssueTransition(ctx, settings.Issues, issue)
+	if err != nil {
+		return false, fmt.Errorf("read automatic backlog admission transition %s: %w", proposal.ID, err)
+	}
+	if !found || transition.EnteredAt.Before(proposal.CreatedAt) {
+		return false, nil
+	}
+	decision := automaticAdmissionDecision(settings.Issues, proposal, transition.EnteredAt)
+	decision.TransitionAt = transition.EnteredAt
+	if err := m.store.ResolveAdmissionProposal(ctx, decision); err != nil {
+		return false, fmt.Errorf("recover automatic backlog admission %s: %w", proposal.ID, err)
+	}
+	return true, nil
+}
+
+func proposalDecision(
+	ctx context.Context,
+	issues IssueStore,
+	issue connector.Issue,
+	proposal admissionmodel.Proposal,
+	comments []connector.IssueComment,
+) (admissionmodel.Decision, bool, error) {
 	notBefore := proposal.CreatedAt
 	if proposal.CommentedAt.After(notBefore) {
 		notBefore = proposal.CommentedAt
@@ -813,6 +853,17 @@ func proposalDecision(proposal admissionmodel.Proposal, comments []connector.Iss
 		default:
 			continue
 		}
+		authorized := comment.AuthorAuthorized
+		if authorizer, ok := issues.(connector.IssueCommentAuthorizer); ok {
+			var err error
+			authorized, err = authorizer.IsIssueCommentAuthorAuthorized(ctx, issue, comment)
+			if err != nil {
+				return admissionmodel.Decision{}, false, err
+			}
+		}
+		if !authorized {
+			continue
+		}
 		if !decision.DecidedAt.IsZero() && !comment.CreatedAt.After(decision.DecidedAt) {
 			continue
 		}
@@ -825,7 +876,7 @@ func proposalDecision(proposal admissionmodel.Proposal, comments []connector.Iss
 			ActorKind:  comment.AuthorKind,
 		}
 	}
-	return decision, !decision.DecidedAt.IsZero()
+	return decision, !decision.DecidedAt.IsZero(), nil
 }
 
 func admissionIssueTransition(ctx context.Context, issues IssueStore, issue connector.Issue) (connector.IssueStateTransition, bool, error) {

--- a/internal/admission/manager_test.go
+++ b/internal/admission/manager_test.go
@@ -357,6 +357,344 @@ func TestManagerTargetTransitionWithoutDecisionRemainsOpen(t *testing.T) {
 	}
 }
 
+func TestManagerAcceptanceTransitionsOrSupersedes(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 7, 29, 12, 0, 0, 0, time.UTC)
+	tests := []struct {
+		name       string
+		current    string
+		wantState  string
+		wantStatus admissionmodel.ProposalStatus
+		wantReason string
+	}{
+		{
+			name:       "source issue is admitted",
+			current:    "Backlog",
+			wantState:  "Todo",
+			wantStatus: admissionmodel.ProposalAccepted,
+			wantReason: admissionResolutionExplicitAccept,
+		},
+		{
+			name:       "issue that left source is superseded",
+			current:    "In Progress",
+			wantState:  "In Progress",
+			wantStatus: admissionmodel.ProposalSuperseded,
+			wantReason: admissionResolutionSourceStateChanged,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			currentTime := now
+			issue := admissionIssueFixture("issue-1", "DD-1", 1, now)
+			tracker := memory.New(memory.Config{
+				Issues:   []connector.Issue{issue},
+				Stateful: true,
+				Now:      func() time.Time { return currentTime },
+			})
+			backend := openManagerTestStore(t)
+			proposal := admissionTestProposalForIssue("proposal-1", issue, now)
+			if created, err := backend.CreateAdmissionProposal(t.Context(), proposal); err != nil || !created {
+				t.Fatalf("CreateAdmissionProposal() = %t, %v", created, err)
+			}
+			currentTime = now.Add(time.Minute)
+			if err := tracker.CreateComment(t.Context(), issue.ID, admissionAcceptCommand(proposal.ID)); err != nil {
+				t.Fatalf("CreateComment() error = %v", err)
+			}
+			if tt.current != issue.State {
+				if err := tracker.UpdateIssueState(t.Context(), issue.ID, tt.current); err != nil {
+					t.Fatalf("UpdateIssueState(%s) error = %v", tt.current, err)
+				}
+			}
+			manager := newAdmissionTestManager(
+				t,
+				admissionTestSettings(tracker, &scriptedAdmissionRunner{propose: proposeEveryCandidate}),
+				backend,
+				func() time.Time { return currentTime },
+			)
+
+			if _, err := manager.RunOnce(t.Context()); err != nil {
+				t.Fatalf("RunOnce() error = %v", err)
+			}
+			issues, err := tracker.FetchIssueStatesByIDs(t.Context(), []string{issue.ID})
+			if err != nil || len(issues) != 1 || issues[0].State != tt.wantState {
+				t.Fatalf("issue state = %#v, %v, want %s", issues, err, tt.wantState)
+			}
+			history, err := backend.AdmissionProposalHistory(t.Context(), proposal.ProjectID, issue.ID)
+			if err != nil || len(history) != 1 {
+				t.Fatalf("AdmissionProposalHistory() = %#v, %v", history, err)
+			}
+			if history[0].Status != tt.wantStatus || history[0].ResolutionReason != tt.wantReason {
+				t.Fatalf("resolved proposal = %#v", history[0])
+			}
+			if tt.wantStatus != admissionmodel.ProposalAccepted {
+				return
+			}
+			timeline, err := backend.IssueWorkflowTimeline(t.Context(), store.IssueIdentity{IssueID: issue.ID})
+			if err != nil || len(timeline.Events) != 1 {
+				t.Fatalf("IssueWorkflowTimeline() = %#v, %v", timeline, err)
+			}
+			metadata, ok := provenance.Parse(timeline.Events[0].MetadataJSON)
+			if !ok || metadata.Provenance.Actor == nil ||
+				metadata.Provenance.Actor.Login != "memory" ||
+				metadata.Admission == nil ||
+				!metadata.Admission.Attributed ||
+				metadata.Admission.ProposalID != proposal.ID {
+				t.Fatalf("admission provenance = %#v", metadata)
+			}
+		})
+	}
+}
+
+func TestManagerAcceptanceRevalidatesImmediatelyBeforeMutation(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 7, 29, 12, 0, 0, 0, time.UTC)
+	currentTime := now
+	issue := admissionIssueFixture("issue-1", "DD-1", 1, now)
+	tracker := &stateChangingAdmissionStore{
+		Connector: memory.New(memory.Config{
+			Issues:   []connector.Issue{issue},
+			Stateful: true,
+			Now:      func() time.Time { return currentTime },
+		}),
+		issueID: issue.ID,
+		state:   "In Progress",
+	}
+	backend := openManagerTestStore(t)
+	proposal := admissionTestProposalForIssue("proposal-1", issue, now)
+	if created, err := backend.CreateAdmissionProposal(t.Context(), proposal); err != nil || !created {
+		t.Fatalf("CreateAdmissionProposal() = %t, %v", created, err)
+	}
+	currentTime = now.Add(time.Minute)
+	if err := tracker.CreateComment(t.Context(), issue.ID, admissionAcceptCommand(proposal.ID)); err != nil {
+		t.Fatalf("CreateComment() error = %v", err)
+	}
+	manager := newAdmissionTestManager(
+		t,
+		admissionTestSettings(tracker, &scriptedAdmissionRunner{propose: proposeEveryCandidate}),
+		backend,
+		func() time.Time { return currentTime },
+	)
+
+	if _, err := manager.RunOnce(t.Context()); err != nil {
+		t.Fatalf("RunOnce() error = %v", err)
+	}
+	issues, err := tracker.Connector.FetchIssueStatesByIDs(t.Context(), []string{issue.ID})
+	if err != nil || len(issues) != 1 || issues[0].State != "In Progress" {
+		t.Fatalf("issue = %#v, %v", issues, err)
+	}
+	history, err := backend.AdmissionProposalHistory(t.Context(), proposal.ProjectID, issue.ID)
+	if err != nil || len(history) != 1 ||
+		history[0].Status != admissionmodel.ProposalSuperseded ||
+		history[0].ResolutionReason != admissionResolutionSourceStateChanged {
+		t.Fatalf("AdmissionProposalHistory() = %#v, %v", history, err)
+	}
+}
+
+func TestManagerAutoAdmissionModes(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 7, 29, 12, 0, 0, 0, time.UTC)
+	tests := []struct {
+		name       string
+		enabled    bool
+		confidence float64
+		wantState  string
+		wantStatus admissionmodel.ProposalStatus
+	}{
+		{
+			name:       "disabled requires explicit acceptance",
+			confidence: 1,
+			wantState:  "Backlog",
+			wantStatus: admissionmodel.ProposalOpen,
+		},
+		{
+			name:       "below threshold remains proposed",
+			enabled:    true,
+			confidence: 0.89,
+			wantState:  "Backlog",
+			wantStatus: admissionmodel.ProposalOpen,
+		},
+		{
+			name:       "threshold match is admitted",
+			enabled:    true,
+			confidence: 0.9,
+			wantState:  "Todo",
+			wantStatus: admissionmodel.ProposalAccepted,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			issue := admissionIssueFixture("issue-1", "DD-1", 1, now)
+			tracker := memory.New(memory.Config{
+				Issues:   []connector.Issue{issue},
+				Stateful: true,
+				Now:      func() time.Time { return now },
+			})
+			backend := openManagerTestStore(t)
+			agent := &scriptedAdmissionRunner{propose: proposeEveryCandidateAtConfidence(tt.confidence)}
+			settings := admissionTestSettings(tracker, agent)
+			settings.Config.AutoAdmit = tt.enabled
+			settings.Config.AutoAdmitMinConfidence = 0.9
+			manager := newAdmissionTestManager(t, settings, backend, func() time.Time { return now })
+
+			result, err := manager.RunOnce(t.Context())
+			if err != nil || len(result.Proposals) != 1 {
+				t.Fatalf("RunOnce() = %#v, %v", result, err)
+			}
+			issues, err := tracker.FetchIssueStatesByIDs(t.Context(), []string{issue.ID})
+			if err != nil || len(issues) != 1 || issues[0].State != tt.wantState {
+				t.Fatalf("issue state = %#v, %v, want %s", issues, err, tt.wantState)
+			}
+			history, err := backend.AdmissionProposalHistory(t.Context(), "detent", issue.ID)
+			if err != nil || len(history) != 1 || history[0].Status != tt.wantStatus {
+				t.Fatalf("AdmissionProposalHistory() = %#v, %v", history, err)
+			}
+			if tt.wantStatus == admissionmodel.ProposalAccepted &&
+				history[0].ResolutionReason != admissionResolutionAutoAdmit {
+				t.Fatalf("auto-admitted proposal = %#v", history[0])
+			}
+		})
+	}
+}
+
+func TestManagerAutoAdmissionRespectsEligibilityAndCaps(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 7, 29, 12, 0, 0, 0, time.UTC)
+	first := admissionIssueFixture("issue-1", "DD-1", 1, now)
+	first.AuthorID = "octocat"
+	second := admissionIssueFixture("issue-2", "DD-2", 2, now)
+	second.AuthorID = "octocat"
+	excluded := admissionIssueFixture("issue-3", "DD-3", 3, now)
+	excluded.AuthorID = "octocat"
+	excluded.Labels = []string{"do-not-admit"}
+	otherAuthor := admissionIssueFixture("issue-4", "DD-4", 4, now)
+	otherAuthor.AuthorID = "hubot"
+	tracker := memory.New(memory.Config{
+		Issues:   []connector.Issue{first, second, excluded, otherAuthor},
+		Stateful: true,
+		Now:      func() time.Time { return now },
+	})
+	backend := openManagerTestStore(t)
+	agent := &scriptedAdmissionRunner{propose: proposeEveryCandidate}
+	settings := admissionTestSettings(tracker, agent)
+	settings.Config.AutoAdmit = true
+	settings.Config.AutoAdmitMinConfidence = 0.8
+	settings.Config.MaxProposalsPerRun = 1
+	settings.Config.MaxOpenProposals = 1
+	settings.Config.ExcludeLabels = []string{"do-not-admit"}
+	settings.Config.Authors.Allow = []string{"octocat"}
+	manager := newAdmissionTestManager(t, settings, backend, func() time.Time { return now })
+
+	result, err := manager.RunOnce(t.Context())
+	if err != nil {
+		t.Fatalf("RunOnce() error = %v", err)
+	}
+	if result.Skipped["excluded_label"] != 1 || result.Skipped["author"] != 1 ||
+		result.Truncated["proposals"] != 1 {
+		t.Fatalf("result = %#v", result)
+	}
+	issues, err := tracker.FetchIssueStatesByIDs(
+		t.Context(),
+		[]string{first.ID, second.ID, excluded.ID, otherAuthor.ID},
+	)
+	if err != nil || len(issues) != 4 {
+		t.Fatalf("FetchIssueStatesByIDs() = %#v, %v", issues, err)
+	}
+	states := map[string]string{}
+	for _, issue := range issues {
+		states[issue.ID] = issue.State
+	}
+	if states[first.ID] != "Todo" ||
+		states[second.ID] != "Backlog" ||
+		states[excluded.ID] != "Backlog" ||
+		states[otherAuthor.ID] != "Backlog" {
+		t.Fatalf("states = %#v", states)
+	}
+}
+
+func TestManagerAutoAdmissionRespectsOpenProposalCap(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 7, 29, 12, 0, 0, 0, time.UTC)
+	first := admissionIssueFixture("issue-1", "DD-1", 1, now)
+	second := admissionIssueFixture("issue-2", "DD-2", 2, now)
+	tracker := memory.New(memory.Config{
+		Issues:   []connector.Issue{first, second},
+		Stateful: true,
+		Now:      func() time.Time { return now },
+	})
+	backend := openManagerTestStore(t)
+	proposal := admissionTestProposalForIssue("proposal-open", first, now)
+	proposal.Confidence = 0.5
+	if created, err := backend.CreateAdmissionProposal(t.Context(), proposal); err != nil || !created {
+		t.Fatalf("CreateAdmissionProposal() = %t, %v", created, err)
+	}
+	agent := &scriptedAdmissionRunner{propose: proposeEveryCandidate}
+	settings := admissionTestSettings(tracker, agent)
+	settings.Config.AutoAdmit = true
+	settings.Config.AutoAdmitMinConfidence = 0.9
+	settings.Config.MaxOpenProposals = 1
+	manager := newAdmissionTestManager(t, settings, backend, func() time.Time { return now })
+
+	result, err := manager.RunOnce(t.Context())
+	if err != nil {
+		t.Fatalf("RunOnce() error = %v", err)
+	}
+	if agent.calls != 0 || result.Skipped["open_proposal_cap"] != 1 {
+		t.Fatalf("result = %#v, runner calls = %d", result, agent.calls)
+	}
+	issues, err := tracker.FetchIssueStatesByIDs(t.Context(), []string{first.ID, second.ID})
+	if err != nil || len(issues) != 2 || issues[0].State != "Backlog" || issues[1].State != "Backlog" {
+		t.Fatalf("issues = %#v, %v", issues, err)
+	}
+}
+
+func TestManagerAutoAdmissionSupersedesIneligibleOpenProposal(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 7, 29, 12, 0, 0, 0, time.UTC)
+	original := admissionIssueFixture("issue-1", "DD-1", 1, now)
+	current := original
+	current.Labels = []string{"do-not-admit"}
+	tracker := memory.New(memory.Config{
+		Issues:   []connector.Issue{current},
+		Stateful: true,
+		Now:      func() time.Time { return now },
+	})
+	backend := openManagerTestStore(t)
+	proposal := admissionTestProposalForIssue("proposal-open", original, now)
+	proposal.Confidence = 1
+	if created, err := backend.CreateAdmissionProposal(t.Context(), proposal); err != nil || !created {
+		t.Fatalf("CreateAdmissionProposal() = %t, %v", created, err)
+	}
+	settings := admissionTestSettings(tracker, &scriptedAdmissionRunner{propose: proposeEveryCandidate})
+	settings.Config.AutoAdmit = true
+	settings.Config.AutoAdmitMinConfidence = 0.9
+	settings.Config.ExcludeLabels = []string{"do-not-admit"}
+	manager := newAdmissionTestManager(t, settings, backend, func() time.Time { return now })
+
+	if _, err := manager.RunOnce(t.Context()); err != nil {
+		t.Fatalf("RunOnce() error = %v", err)
+	}
+	history, err := backend.AdmissionProposalHistory(t.Context(), proposal.ProjectID, proposal.IssueID)
+	if err != nil || len(history) != 1 ||
+		history[0].Status != admissionmodel.ProposalSuperseded ||
+		history[0].ResolutionReason != admissionResolutionAutoAdmitIneligible {
+		t.Fatalf("AdmissionProposalHistory() = %#v, %v", history, err)
+	}
+	issues, err := tracker.FetchIssueStatesByIDs(t.Context(), []string{proposal.IssueID})
+	if err != nil || len(issues) != 1 || issues[0].State != "Backlog" {
+		t.Fatalf("issue = %#v, %v", issues, err)
+	}
+}
+
 func TestManagerFiltersProposalHistoryBeforeCandidateCap(t *testing.T) {
 	t.Parallel()
 
@@ -423,11 +761,12 @@ func TestManagerAcceptedDemotionIsSticky(t *testing.T) {
 	if err := tracker.CreateComment(context.Background(), "issue-1", admissionAcceptCommand(open[0].ID)); err != nil {
 		t.Fatalf("CreateComment() error = %v", err)
 	}
-	if err := tracker.UpdateIssueState(context.Background(), "issue-1", "Todo"); err != nil {
-		t.Fatalf("UpdateIssueState(Todo) error = %v", err)
-	}
 	if _, err := manager.RunOnce(context.Background()); err != nil {
 		t.Fatalf("acceptance reconciliation error = %v", err)
+	}
+	admitted, err := tracker.FetchIssueStatesByIDs(context.Background(), []string{"issue-1"})
+	if err != nil || len(admitted) != 1 || admitted[0].State != "Todo" {
+		t.Fatalf("admitted issue = %#v, %v, want Todo", admitted, err)
 	}
 	if err := tracker.UpdateIssueState(context.Background(), "issue-1", "Backlog"); err != nil {
 		t.Fatalf("UpdateIssueState(Backlog) error = %v", err)
@@ -754,25 +1093,51 @@ type budgetAdmissionRunner struct {
 	status runner.DailyBudgetStatus
 }
 
+type stateChangingAdmissionStore struct {
+	*memory.Connector
+	fetches int
+	issueID string
+	state   string
+}
+
+func (s *stateChangingAdmissionStore) FetchIssueStatesByIDs(
+	ctx context.Context,
+	issueIDs []string,
+) ([]connector.Issue, error) {
+	s.fetches++
+	if s.fetches == 2 {
+		if err := s.UpdateIssueState(ctx, s.issueID, s.state); err != nil {
+			return nil, err
+		}
+	}
+	return s.Connector.FetchIssueStatesByIDs(ctx, issueIDs)
+}
+
 func (r *budgetAdmissionRunner) DailyBudgetStatus(context.Context, time.Time) (runner.DailyBudgetStatus, bool, error) {
 	return r.status, true, nil
 }
 
 func proposeEveryCandidate(request runner.RunRequest) []AgentProposal {
-	proposals := make([]AgentProposal, 0, len(request.Admission.Candidates))
-	for _, candidate := range request.Admission.Candidates {
-		proposals = append(proposals, AgentProposal{
-			IssueID: candidate.ID,
-			Findings: []admissionmodel.Finding{{
-				Dimension:      "Alignment",
-				CriterionQuote: "serves a stated current priority",
-				Matched:        true,
-				Rationale:      "The issue directly supports the stated priority.",
-			}},
-			Confidence: float64Pointer(0.8),
-		})
+	return proposeEveryCandidateAtConfidence(0.8)(request)
+}
+
+func proposeEveryCandidateAtConfidence(confidence float64) func(runner.RunRequest) []AgentProposal {
+	return func(request runner.RunRequest) []AgentProposal {
+		proposals := make([]AgentProposal, 0, len(request.Admission.Candidates))
+		for _, candidate := range request.Admission.Candidates {
+			proposals = append(proposals, AgentProposal{
+				IssueID: candidate.ID,
+				Findings: []admissionmodel.Finding{{
+					Dimension:      "Alignment",
+					CriterionQuote: "serves a stated current priority",
+					Matched:        true,
+					Rationale:      "The issue directly supports the stated priority.",
+				}},
+				Confidence: float64Pointer(confidence),
+			})
+		}
+		return proposals
 	}
-	return proposals
 }
 
 func admissionTestSettings(tracker IssueStore, backend runner.Backend) Settings {
@@ -906,11 +1271,14 @@ func TestProposalCommentQuotesCriteriaAndDoesNotUseStatusLabel(t *testing.T) {
 		Confidence: 0.8,
 		ExpiresAt:  time.Date(2026, 8, 5, 12, 0, 0, 0, time.UTC),
 	}
-	comment := proposalComment(proposal)
-	for _, want := range []string{"serves a stated current priority", "Detent has not changed the issue status", "admission-1"} {
+	comment := proposalComment(proposal, false)
+	for _, want := range []string{"serves a stated current priority", "have Detent move the issue", "admission-1"} {
 		if !strings.Contains(comment, want) {
 			t.Fatalf("proposalComment() missing %q: %s", want, comment)
 		}
+	}
+	if strings.Contains(comment, "then move the issue") {
+		t.Fatalf("proposalComment() still requires a manual move: %s", comment)
 	}
 	if strings.Contains(comment, "detent:admission") {
 		t.Fatalf("proposalComment() introduced a status-prefixed label: %s", comment)

--- a/internal/admission/manager_test.go
+++ b/internal/admission/manager_test.go
@@ -3,6 +3,7 @@ package admission
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"path/filepath"
 	"reflect"
 	"strconv"
@@ -218,11 +219,12 @@ func TestManagerReconcilesAgainstStoredProposalTarget(t *testing.T) {
 	decisionAt := now.Add(time.Minute)
 	issue.StageUpdatedAt = &transitionAt
 	issue.Comments = []connector.IssueComment{{
-		ID:          "decision-1",
-		Body:        admissionAcceptCommand("proposal-1"),
-		AuthorLogin: "ada",
-		AuthorKind:  "User",
-		CreatedAt:   &decisionAt,
+		ID:               "decision-1",
+		Body:             admissionAcceptCommand("proposal-1"),
+		AuthorLogin:      "ada",
+		AuthorKind:       "User",
+		AuthorAuthorized: true,
+		CreatedAt:        &decisionAt,
 	}}
 	tracker := memory.New(memory.Config{Issues: []connector.Issue{issue}, Stateful: true})
 	backend := openManagerTestStore(t)
@@ -448,6 +450,51 @@ func TestManagerAcceptanceTransitionsOrSupersedes(t *testing.T) {
 	}
 }
 
+func TestManagerIgnoresUnauthorizedAdmissionDecision(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 7, 29, 12, 0, 0, 0, time.UTC)
+	decisionAt := now.Add(time.Minute)
+	issue := admissionIssueFixture("issue-1", "DD-1", 1, now)
+	issue.Comments = []connector.IssueComment{{
+		ID:               "decision-1",
+		Backend:          connector.BackendGitHub.String(),
+		Body:             admissionAcceptCommand("proposal-1"),
+		AuthorLogin:      "outsider",
+		AuthorKind:       "User",
+		AuthorAuthorized: true,
+		CreatedAt:        &decisionAt,
+	}}
+	tracker := &authorizingAdmissionIssueStore{
+		Connector:  memory.New(memory.Config{Issues: []connector.Issue{issue}, Stateful: true}),
+		authorized: false,
+	}
+	backend := openManagerTestStore(t)
+	proposal := admissionTestProposalForIssue("proposal-1", issue, now)
+	proposal.CommentedAt = now
+	if created, err := backend.CreateAdmissionProposal(t.Context(), proposal); err != nil || !created {
+		t.Fatalf("CreateAdmissionProposal() = %t, %v", created, err)
+	}
+	manager := newAdmissionTestManager(
+		t,
+		admissionTestSettings(tracker, &scriptedAdmissionRunner{propose: proposeEveryCandidate}),
+		backend,
+		func() time.Time { return decisionAt },
+	)
+
+	if _, err := manager.RunOnce(t.Context()); err != nil {
+		t.Fatalf("RunOnce() error = %v", err)
+	}
+	issues, err := tracker.FetchIssueStatesByIDs(t.Context(), []string{issue.ID})
+	if err != nil || len(issues) != 1 || issues[0].State != "Backlog" {
+		t.Fatalf("issue = %#v, %v", issues, err)
+	}
+	history, err := backend.AdmissionProposalHistory(t.Context(), proposal.ProjectID, proposal.IssueID)
+	if err != nil || len(history) != 1 || history[0].Status != admissionmodel.ProposalOpen {
+		t.Fatalf("AdmissionProposalHistory() = %#v, %v", history, err)
+	}
+}
+
 func TestManagerAcceptanceRevalidatesImmediatelyBeforeMutation(t *testing.T) {
 	t.Parallel()
 
@@ -560,6 +607,53 @@ func TestManagerAutoAdmissionModes(t *testing.T) {
 				t.Fatalf("auto-admitted proposal = %#v", history[0])
 			}
 		})
+	}
+}
+
+func TestManagerRecoversAutoAdmissionAfterResolutionFailure(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 7, 29, 12, 0, 0, 0, time.UTC)
+	issue := admissionIssueFixture("issue-1", "DD-1", 1, now)
+	tracker := memory.New(memory.Config{
+		Issues:   []connector.Issue{issue},
+		Stateful: true,
+		Now:      func() time.Time { return now },
+	})
+	backend := openManagerTestStore(t)
+	failingStore := &failingAdmissionResolutionStore{Store: backend, fail: true}
+	settings := admissionTestSettings(
+		tracker,
+		&scriptedAdmissionRunner{propose: proposeEveryCandidateAtConfidence(1)},
+	)
+	settings.Config.AutoAdmit = true
+	settings.Config.AutoAdmitMinConfidence = 0.9
+	manager := newAdmissionTestManager(t, settings, failingStore, func() time.Time { return now })
+
+	if _, err := manager.RunOnce(t.Context()); !errors.Is(err, errAdmissionResolutionFailure) {
+		t.Fatalf("first RunOnce() error = %v, want %v", err, errAdmissionResolutionFailure)
+	}
+	issues, err := tracker.FetchIssueStatesByIDs(t.Context(), []string{issue.ID})
+	if err != nil || len(issues) != 1 || issues[0].State != "Todo" {
+		t.Fatalf("issue after failed resolution = %#v, %v", issues, err)
+	}
+	if _, err := manager.RunOnce(t.Context()); err != nil {
+		t.Fatalf("second RunOnce() error = %v", err)
+	}
+	history, err := backend.AdmissionProposalHistory(t.Context(), "detent", issue.ID)
+	if err != nil || len(history) != 1 ||
+		history[0].Status != admissionmodel.ProposalAccepted ||
+		history[0].ResolutionReason != admissionResolutionAutoAdmit {
+		t.Fatalf("AdmissionProposalHistory() = %#v, %v", history, err)
+	}
+	stateUpdates := 0
+	for _, event := range tracker.Events() {
+		if event.Kind == memory.EventKindStateUpdate {
+			stateUpdates++
+		}
+	}
+	if stateUpdates != 1 {
+		t.Fatalf("state update events = %d, want 1", stateUpdates)
 	}
 }
 
@@ -1098,6 +1192,37 @@ type stateChangingAdmissionStore struct {
 	fetches int
 	issueID string
 	state   string
+}
+
+type authorizingAdmissionIssueStore struct {
+	*memory.Connector
+	authorized bool
+}
+
+func (s *authorizingAdmissionIssueStore) IsIssueCommentAuthorAuthorized(
+	context.Context,
+	connector.Issue,
+	connector.IssueComment,
+) (bool, error) {
+	return s.authorized, nil
+}
+
+var errAdmissionResolutionFailure = errors.New("admission resolution failed")
+
+type failingAdmissionResolutionStore struct {
+	Store
+	fail bool
+}
+
+func (s *failingAdmissionResolutionStore) ResolveAdmissionProposal(
+	ctx context.Context,
+	decision admissionmodel.Decision,
+) error {
+	if s.fail && decision.Automatic && decision.Outcome == admissionmodel.ProposalAccepted {
+		s.fail = false
+		return errAdmissionResolutionFailure
+	}
+	return s.Store.ResolveAdmissionProposal(ctx, decision)
 }
 
 func (s *stateChangingAdmissionStore) FetchIssueStatesByIDs(

--- a/internal/admission/model/model.go
+++ b/internal/admission/model/model.go
@@ -34,6 +34,7 @@ type Proposal struct {
 	DecisionActorKind  string
 	TransitionAt       time.Time
 	DecisionSeconds    int64
+	ResolutionReason   string
 }
 
 type Finding struct {
@@ -75,6 +76,8 @@ type Decision struct {
 	ActorKind         string
 	TransitionAt      time.Time
 	TransitionEventID int64
+	Reason            string
+	Automatic         bool
 }
 
 type TargetTransitionQuery struct {

--- a/internal/config/admission.go
+++ b/internal/config/admission.go
@@ -12,27 +12,30 @@ import (
 )
 
 const (
-	DefaultBacklogAdmissionSchedule            = "0 6 * * 1-5"
-	DefaultBacklogAdmissionMaxCandidatesPerRun = 50
-	DefaultBacklogAdmissionMaxProposalsPerRun  = 3
-	DefaultBacklogAdmissionMaxOpenProposals    = 10
-	DefaultBacklogAdmissionProposalExpiryDays  = 7
+	DefaultBacklogAdmissionSchedule               = "0 6 * * 1-5"
+	DefaultBacklogAdmissionMaxCandidatesPerRun    = 50
+	DefaultBacklogAdmissionMaxProposalsPerRun     = 3
+	DefaultBacklogAdmissionMaxOpenProposals       = 10
+	DefaultBacklogAdmissionProposalExpiryDays     = 7
+	DefaultBacklogAdmissionAutoAdmitMinConfidence = 0.9
 )
 
 var admissionDimensionPattern = regexp.MustCompile(`^\s*[-*+]\s+\*\*([^*]+)\*\*\s*(?:[—–:-]\s*)?(.+?)\s*$`)
 
 type BacklogAdmission struct {
-	Enabled             bool                    `yaml:"enabled"`
-	Schedule            string                  `yaml:"schedule"`
-	Sources             BacklogAdmissionSources `yaml:"sources"`
-	TargetState         string                  `yaml:"target_state"`
-	CriteriaSection     string                  `yaml:"criteria_section"`
-	ExcludeLabels       []string                `yaml:"exclude_labels,omitempty"`
-	Authors             BacklogAdmissionAuthors `yaml:"authors,omitempty"`
-	MaxCandidatesPerRun int                     `yaml:"max_candidates_per_run"`
-	MaxProposalsPerRun  int                     `yaml:"max_proposals_per_run"`
-	MaxOpenProposals    int                     `yaml:"max_open_proposals"`
-	ProposalExpiryDays  int                     `yaml:"proposal_expiry_days"`
+	Enabled                bool                    `yaml:"enabled"`
+	Schedule               string                  `yaml:"schedule"`
+	Sources                BacklogAdmissionSources `yaml:"sources"`
+	TargetState            string                  `yaml:"target_state"`
+	CriteriaSection        string                  `yaml:"criteria_section"`
+	ExcludeLabels          []string                `yaml:"exclude_labels,omitempty"`
+	Authors                BacklogAdmissionAuthors `yaml:"authors,omitempty"`
+	MaxCandidatesPerRun    int                     `yaml:"max_candidates_per_run"`
+	MaxProposalsPerRun     int                     `yaml:"max_proposals_per_run"`
+	MaxOpenProposals       int                     `yaml:"max_open_proposals"`
+	ProposalExpiryDays     int                     `yaml:"proposal_expiry_days"`
+	AutoAdmit              bool                    `yaml:"auto_admit"`
+	AutoAdmitMinConfidence float64                 `yaml:"auto_admit_min_confidence"`
 }
 
 type BacklogAdmissionSources struct {
@@ -110,6 +113,9 @@ func (a BacklogAdmission) Validate(prefix string, states []string, tracker Track
 	validatePositive(prefix+".max_proposals_per_run", a.MaxProposalsPerRun, &problems)
 	validatePositive(prefix+".max_open_proposals", a.MaxOpenProposals, &problems)
 	validatePositive(prefix+".proposal_expiry_days", a.ProposalExpiryDays, &problems)
+	if a.AutoAdmit && (a.AutoAdmitMinConfidence < 0 || a.AutoAdmitMinConfidence > 1) {
+		problems = append(problems, prefix+".auto_admit_min_confidence must be between 0 and 1")
+	}
 	capabilities := connector.CandidateCapabilitiesFor(connector.Backend(tracker.Kind), tracker.GitHubStatusSource)
 	if len(a.Sources.States) > 0 && !capabilities.Supports(connector.CandidateSelectorStates) {
 		gap := prefix + ".sources.states requires candidate selector states, but tracker.kind " + tracker.Kind

--- a/internal/config/admission_test.go
+++ b/internal/config/admission_test.go
@@ -28,6 +28,8 @@ backlog_admission:
   max_proposals_per_run: 2
   max_open_proposals: 8
   proposal_expiry_days: 5
+  auto_admit: true
+  auto_admit_min_confidence: 0.95
 ---
 ## Admission criteria
 
@@ -45,7 +47,8 @@ backlog_admission:
 	got := workflow.Config.BacklogAdmission
 	if !got.Enabled || got.Schedule != "15 4 * * 1" || got.TargetState != "Todo" ||
 		got.MaxCandidatesPerRun != 20 || got.MaxProposalsPerRun != 2 ||
-		got.MaxOpenProposals != 8 || got.ProposalExpiryDays != 5 {
+		got.MaxOpenProposals != 8 || got.ProposalExpiryDays != 5 ||
+		!got.AutoAdmit || got.AutoAdmitMinConfidence != 0.95 {
 		t.Fatalf("BacklogAdmission = %#v", got)
 	}
 	if len(got.Sources.Labels) != 1 || got.Sources.Labels[0] != "sentry" ||
@@ -107,6 +110,14 @@ func TestBacklogAdmissionValidate(t *testing.T) {
 		{name: "negative proposal cap", tracker: Tracker{Kind: TrackerGitHub}, mutate: func(cfg *BacklogAdmission) { cfg.MaxProposalsPerRun = -1 }, want: "max_proposals_per_run must be greater than 0"},
 		{name: "zero open cap", tracker: Tracker{Kind: TrackerGitHub}, mutate: func(cfg *BacklogAdmission) { cfg.MaxOpenProposals = 0 }, want: "max_open_proposals must be greater than 0"},
 		{name: "zero expiry", tracker: Tracker{Kind: TrackerGitHub}, mutate: func(cfg *BacklogAdmission) { cfg.ProposalExpiryDays = 0 }, want: "proposal_expiry_days must be greater than 0"},
+		{name: "auto admit confidence below range", tracker: Tracker{Kind: TrackerGitHub}, mutate: func(cfg *BacklogAdmission) {
+			cfg.AutoAdmit = true
+			cfg.AutoAdmitMinConfidence = -0.1
+		}, want: "auto_admit_min_confidence must be between 0 and 1"},
+		{name: "auto admit confidence above range", tracker: Tracker{Kind: TrackerGitHub}, mutate: func(cfg *BacklogAdmission) {
+			cfg.AutoAdmit = true
+			cfg.AutoAdmitMinConfidence = 1.1
+		}, want: "auto_admit_min_confidence must be between 0 and 1"},
 		{name: "linear", tracker: Tracker{Kind: TrackerLinear}, want: "FetchIssuesByStates is not implemented"},
 		{name: "unsupported github source", tracker: Tracker{Kind: TrackerGitHub, GitHubStatusSource: "milestone"}, want: "tracker.kind github with github_status_source milestone does not declare it"},
 		{name: "unsupported tracker", tracker: Tracker{Kind: "gitlab"}, want: "tracker.kind gitlab does not declare it"},
@@ -191,6 +202,22 @@ func TestBacklogAdmissionLabelSelectorValidation(t *testing.T) {
 				t.Fatalf("Validate() = %q, want %q", got, test.want)
 			}
 		})
+	}
+}
+
+func TestBacklogAdmissionAutoAdmitDefaultsOff(t *testing.T) {
+	t.Parallel()
+
+	cfg := Default().BacklogAdmission
+	if cfg.AutoAdmit {
+		t.Fatal("BacklogAdmission.AutoAdmit = true, want false")
+	}
+	if cfg.AutoAdmitMinConfidence != DefaultBacklogAdmissionAutoAdmitMinConfidence {
+		t.Fatalf(
+			"BacklogAdmission.AutoAdmitMinConfidence = %v, want %v",
+			cfg.AutoAdmitMinConfidence,
+			DefaultBacklogAdmissionAutoAdmitMinConfidence,
+		)
 	}
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1330,11 +1330,12 @@ func Default() Config {
 		},
 		Budget: budget,
 		BacklogAdmission: BacklogAdmission{
-			Schedule:            DefaultBacklogAdmissionSchedule,
-			MaxCandidatesPerRun: DefaultBacklogAdmissionMaxCandidatesPerRun,
-			MaxProposalsPerRun:  DefaultBacklogAdmissionMaxProposalsPerRun,
-			MaxOpenProposals:    DefaultBacklogAdmissionMaxOpenProposals,
-			ProposalExpiryDays:  DefaultBacklogAdmissionProposalExpiryDays,
+			Schedule:               DefaultBacklogAdmissionSchedule,
+			MaxCandidatesPerRun:    DefaultBacklogAdmissionMaxCandidatesPerRun,
+			MaxProposalsPerRun:     DefaultBacklogAdmissionMaxProposalsPerRun,
+			MaxOpenProposals:       DefaultBacklogAdmissionMaxOpenProposals,
+			ProposalExpiryDays:     DefaultBacklogAdmissionProposalExpiryDays,
+			AutoAdmitMinConfidence: DefaultBacklogAdmissionAutoAdmitMinConfidence,
 		},
 		Hooks: Hooks{
 			Shell:     commandshell.Default(),

--- a/internal/connector/connector.go
+++ b/internal/connector/connector.go
@@ -180,6 +180,10 @@ type IssueCommentReader interface {
 	FetchIssueComments(context.Context, Issue) ([]IssueComment, error)
 }
 
+type IssueCommentAuthorizer interface {
+	IsIssueCommentAuthorAuthorized(context.Context, Issue, IssueComment) (bool, error)
+}
+
 type IssueEventReader interface {
 	FetchIssueEvents(context.Context, Issue) ([]IssueEvent, error)
 }

--- a/internal/connector/github/adapter_test.go
+++ b/internal/connector/github/adapter_test.go
@@ -4140,7 +4140,7 @@ func TestConnectorFetchIssueCommentsMapsRESTMetadata(t *testing.T) {
 	server := newGraphQLTestServer(t, []graphqlTestResponse{{
 		method: http.MethodGet,
 		path:   "/repos/example/repo/issues/1/comments?per_page=100",
-		body:   `[{"id":101,"node_id":"IC_kw1","body":"First note","html_url":"https://github.com/example/repo/issues/1#issuecomment-101","user":{"login":"alice"},"created_at":"2026-07-06T12:00:00Z","updated_at":"2026-07-06T12:05:00Z"}]`,
+		body:   `[{"id":101,"node_id":"IC_kw1","body":"First note","html_url":"https://github.com/example/repo/issues/1#issuecomment-101","user":{"login":"alice"},"author_association":"MEMBER","created_at":"2026-07-06T12:00:00Z","updated_at":"2026-07-06T12:05:00Z"}]`,
 	}})
 	c := newGitHubTestConnector(t, server, Config{})
 
@@ -4158,6 +4158,7 @@ func TestConnectorFetchIssueCommentsMapsRESTMetadata(t *testing.T) {
 		comment.Body != "First note" ||
 		comment.URL != "https://github.com/example/repo/issues/1#issuecomment-101" ||
 		comment.AuthorLogin != "alice" ||
+		!comment.AuthorAuthorized ||
 		comment.Local ||
 		comment.TargetType != connector.IssueCommentTargetIssue {
 		t.Fatalf("FetchIssueComments()[0] = %#v, want normalized GitHub metadata", comment)
@@ -4169,6 +4170,42 @@ func TestConnectorFetchIssueCommentsMapsRESTMetadata(t *testing.T) {
 	}
 	if comment.UpdatedAt == nil || !comment.UpdatedAt.Equal(updatedAt) {
 		t.Fatalf("UpdatedAt = %v, want %v", comment.UpdatedAt, updatedAt)
+	}
+}
+
+func TestConnectorAuthorizesIssueCommentByRepositoryPermission(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		permission string
+		want       bool
+	}{
+		{permission: "admin", want: true},
+		{permission: "maintain", want: true},
+		{permission: "write", want: true},
+		{permission: "read", want: false},
+		{permission: "triage", want: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.permission, func(t *testing.T) {
+			t.Parallel()
+
+			server := newGraphQLTestServer(t, []graphqlTestResponse{{
+				method: http.MethodGet,
+				path:   "/repos/example/repo/collaborators/alice/permission",
+				body:   `{"permission":"` + tt.permission + `"}`,
+			}})
+			c := newGitHubTestConnector(t, server, Config{})
+
+			got, err := c.IsIssueCommentAuthorAuthorized(
+				t.Context(),
+				connector.Issue{Identifier: "example/repo#1"},
+				connector.IssueComment{AuthorLogin: "alice"},
+			)
+			if err != nil || got != tt.want {
+				t.Fatalf("IsIssueCommentAuthorAuthorized() = %t, %v, want %t", got, err, tt.want)
+			}
+		})
 	}
 }
 

--- a/internal/connector/github/issue_read.go
+++ b/internal/connector/github/issue_read.go
@@ -1258,12 +1258,13 @@ func (c *Connector) fetchIssueComments(ctx context.Context, ref issueRef) ([]iss
 	comments := make([]issueComment, 0, len(response))
 	for _, comment := range response {
 		comments = append(comments, issueComment{
-			ID:        restCommentID(comment),
-			Body:      comment.Body,
-			URL:       comment.HTMLURL,
-			Author:    comment.User,
-			CreatedAt: restTimeString(comment.CreatedAt),
-			UpdatedAt: restTimeString(comment.UpdatedAt),
+			ID:                restCommentID(comment),
+			Body:              comment.Body,
+			URL:               comment.HTMLURL,
+			Author:            comment.User,
+			AuthorAssociation: comment.AuthorAssociation,
+			CreatedAt:         restTimeString(comment.CreatedAt),
+			UpdatedAt:         restTimeString(comment.UpdatedAt),
 		})
 	}
 	return comments, nil
@@ -1287,6 +1288,40 @@ func (c *Connector) FetchIssueComments(ctx context.Context, issue connector.Issu
 		out = append(out, connectorIssueComment(comment, connector.IssueCommentTargetIssue))
 	}
 	return out, nil
+}
+
+func (c *Connector) IsIssueCommentAuthorAuthorized(
+	ctx context.Context,
+	issue connector.Issue,
+	comment connector.IssueComment,
+) (bool, error) {
+	ref, ok := issueRefFromIdentifier(issue.Identifier)
+	if !ok {
+		ref, ok = issueRefFromURL(issue.URL)
+	}
+	login := strings.TrimSpace(comment.AuthorLogin)
+	if !ok || login == "" {
+		return false, nil
+	}
+	var response restCollaboratorPermission
+	if err := c.client.REST(
+		ctx,
+		http.MethodGet,
+		restCollaboratorPermissionPath(ref, login),
+		nil,
+		&response,
+	); err != nil {
+		if errors.Is(err, ErrNotFound) {
+			return false, nil
+		}
+		return false, fmt.Errorf("read github issue comment author permission: %w", err)
+	}
+	switch strings.ToLower(strings.TrimSpace(response.Permission)) {
+	case "admin", "maintain", "write", "push":
+		return true, nil
+	default:
+		return false, nil
+	}
 }
 
 func (c *Connector) FetchPullRequestComments(ctx context.Context, repository string, number int) ([]connector.IssueComment, error) {
@@ -1406,15 +1441,25 @@ func connectorIssueComments(comments []issueComment) []connector.IssueComment {
 
 func connectorIssueComment(comment issueComment, targetType string) connector.IssueComment {
 	return connector.IssueComment{
-		ID:          strings.TrimSpace(comment.ID),
-		Backend:     connector.BackendGitHub.String(),
-		Body:        comment.Body,
-		URL:         comment.URL,
-		AuthorLogin: actorLogin(comment.Author),
-		AuthorKind:  actorType(comment.Author),
-		CreatedAt:   parseGitHubTime(comment.CreatedAt),
-		UpdatedAt:   parseGitHubTime(comment.UpdatedAt),
-		TargetType:  targetType,
+		ID:               strings.TrimSpace(comment.ID),
+		Backend:          connector.BackendGitHub.String(),
+		Body:             comment.Body,
+		URL:              comment.URL,
+		AuthorLogin:      actorLogin(comment.Author),
+		AuthorKind:       actorType(comment.Author),
+		AuthorAuthorized: githubAuthorCanOperate(comment.AuthorAssociation),
+		CreatedAt:        parseGitHubTime(comment.CreatedAt),
+		UpdatedAt:        parseGitHubTime(comment.UpdatedAt),
+		TargetType:       targetType,
+	}
+}
+
+func githubAuthorCanOperate(association string) bool {
+	switch strings.ToUpper(strings.TrimSpace(association)) {
+	case "OWNER", "MEMBER", "COLLABORATOR":
+		return true
+	default:
+		return false
 	}
 }
 

--- a/internal/connector/github/rest.go
+++ b/internal/connector/github/rest.go
@@ -42,6 +42,11 @@ func restIssueCommentsListPath(ref issueRef) string {
 	return restIssueCommentsPath(ref) + "?per_page=100"
 }
 
+func restCollaboratorPermissionPath(ref issueRef, login string) string {
+	return "/repos/" + url.PathEscape(ref.Owner) + "/" + url.PathEscape(ref.Name) +
+		"/collaborators/" + url.PathEscape(login) + "/permission"
+}
+
 func restIssueTimelinePath(ref issueRef) string {
 	return restIssuePath(ref) + "/timeline?per_page=100"
 }

--- a/internal/connector/github/types.go
+++ b/internal/connector/github/types.go
@@ -118,12 +118,13 @@ type label struct {
 }
 
 type issueComment struct {
-	ID        string  `json:"id"`
-	Body      string  `json:"body"`
-	URL       string  `json:"url"`
-	Author    *actor  `json:"author"`
-	CreatedAt *string `json:"createdAt"`
-	UpdatedAt *string `json:"updatedAt"`
+	ID                string  `json:"id"`
+	Body              string  `json:"body"`
+	URL               string  `json:"url"`
+	Author            *actor  `json:"author"`
+	AuthorAssociation string  `json:"authorAssociation"`
+	CreatedAt         *string `json:"createdAt"`
+	UpdatedAt         *string `json:"updatedAt"`
 }
 
 type pullRequest struct {
@@ -335,13 +336,18 @@ type pullRequestCI struct {
 }
 
 type restComment struct {
-	ID        int64      `json:"id"`
-	NodeID    string     `json:"node_id"`
-	Body      string     `json:"body"`
-	HTMLURL   string     `json:"html_url"`
-	User      *actor     `json:"user"`
-	CreatedAt *time.Time `json:"created_at"`
-	UpdatedAt *time.Time `json:"updated_at"`
+	ID                int64      `json:"id"`
+	NodeID            string     `json:"node_id"`
+	Body              string     `json:"body"`
+	HTMLURL           string     `json:"html_url"`
+	User              *actor     `json:"user"`
+	AuthorAssociation string     `json:"author_association"`
+	CreatedAt         *time.Time `json:"created_at"`
+	UpdatedAt         *time.Time `json:"updated_at"`
+}
+
+type restCollaboratorPermission struct {
+	Permission string `json:"permission"`
 }
 
 type restIssueTimelineEvent struct {

--- a/internal/connector/githublocal/githublocal.go
+++ b/internal/connector/githublocal/githublocal.go
@@ -44,6 +44,7 @@ type githubBackend interface {
 	connector.InstanceIdentifier
 	connector.IssueChildrenResolver
 	connector.IssueCloser
+	connector.IssueCommentAuthorizer
 	connector.IssueCommentReader
 	connector.IssueFieldClearer
 	connector.IssueFieldSetter
@@ -105,6 +106,7 @@ var _ connector.ProjectURLResolver = (*Connector)(nil)
 var _ connector.IssueChildrenResolver = (*Connector)(nil)
 var _ connector.IssueCloser = (*Connector)(nil)
 var _ connector.IssueCommentDeleter = (*Connector)(nil)
+var _ connector.IssueCommentAuthorizer = (*Connector)(nil)
 var _ connector.IssueCommentReader = (*Connector)(nil)
 var _ connector.IssueCommentUpdater = (*Connector)(nil)
 var _ connector.IssueFieldClearer = (*Connector)(nil)
@@ -423,6 +425,17 @@ func (c *Connector) FetchIssueComments(ctx context.Context, issue connector.Issu
 		return nil, err
 	}
 	return mergeIssueComments(githubComments, localComments), nil
+}
+
+func (c *Connector) IsIssueCommentAuthorAuthorized(
+	ctx context.Context,
+	issue connector.Issue,
+	comment connector.IssueComment,
+) (bool, error) {
+	if comment.Local || strings.EqualFold(comment.Backend, connector.BackendLocalSQLite.String()) {
+		return comment.AuthorAuthorized, nil
+	}
+	return c.github.IsIssueCommentAuthorAuthorized(ctx, issue, comment)
 }
 
 func (c *Connector) CreateComment(ctx context.Context, issueID string, body string) error {

--- a/internal/connector/githublocal/githublocal_test.go
+++ b/internal/connector/githublocal/githublocal_test.go
@@ -735,6 +735,14 @@ func (b *recordingGitHubBackend) FetchIssueComments(context.Context, connector.I
 	panic("unexpected github FetchIssueComments")
 }
 
+func (b *recordingGitHubBackend) IsIssueCommentAuthorAuthorized(
+	context.Context,
+	connector.Issue,
+	connector.IssueComment,
+) (bool, error) {
+	return true, nil
+}
+
 func (b *recordingGitHubBackend) CreatePullRequestComment(context.Context, string, int, string) error {
 	panic("unexpected github CreatePullRequestComment")
 }

--- a/internal/connector/issue.go
+++ b/internal/connector/issue.go
@@ -145,6 +145,7 @@ type IssueComment struct {
 	AuthorLogin       string     `json:"author_login,omitempty" yaml:"author_login,omitempty"`
 	AuthorKind        string     `json:"author_kind,omitempty" yaml:"author_kind,omitempty"`
 	AuthorDisplayName string     `json:"author_display_name,omitempty" yaml:"author_display_name,omitempty"`
+	AuthorAuthorized  bool       `json:"author_authorized,omitempty" yaml:"author_authorized,omitempty"`
 	CreatedAt         *time.Time `json:"created_at,omitempty" yaml:"created_at,omitempty"`
 	UpdatedAt         *time.Time `json:"updated_at,omitempty" yaml:"updated_at,omitempty"`
 	Local             bool       `json:"local,omitempty" yaml:"local,omitempty"`

--- a/internal/connector/linear/connector.go
+++ b/internal/connector/linear/connector.go
@@ -375,6 +375,7 @@ func connectorIssueComment(comment linearComment) connector.IssueComment {
 		AuthorLogin:       linearAuthorLogin(comment),
 		AuthorKind:        linearAuthorKind(comment),
 		AuthorDisplayName: linearAuthorDisplayName(comment),
+		AuthorAuthorized:  true,
 		CreatedAt:         linearTimePtr(comment.CreatedAt),
 		UpdatedAt:         linearTimePtr(comment.UpdatedAt),
 		TargetType:        connector.IssueCommentTargetIssue,

--- a/internal/connector/linear/connector_test.go
+++ b/internal/connector/linear/connector_test.go
@@ -69,6 +69,7 @@ func TestConnectorFetchIssueCommentsMapsLinearMetadata(t *testing.T) {
 		AuthorLogin:       "ada",
 		AuthorKind:        "User",
 		AuthorDisplayName: "Ada Lovelace",
+		AuthorAuthorized:  true,
 		CreatedAt:         &createdAt,
 		UpdatedAt:         &updatedAt,
 		TargetType:        connector.IssueCommentTargetIssue,

--- a/internal/connector/local/local.go
+++ b/internal/connector/local/local.go
@@ -315,6 +315,7 @@ order by id asc`, c.projectID, strings.TrimSpace(issue.ID), eventKindComment, ev
 				AuthorLogin:       "detent",
 				AuthorKind:        "Bot",
 				AuthorDisplayName: "Detent",
+				AuthorAuthorized:  true,
 				CreatedAt:         eventTime,
 				Local:             true,
 				CanEdit:           true,

--- a/internal/connector/memory/memory.go
+++ b/internal/connector/memory/memory.go
@@ -281,13 +281,14 @@ func (c *Connector) CreateComment(_ context.Context, issueID string, body string
 	c.applyIssue(issueID, func(issue *connector.Issue, now time.Time) {
 		createdAt := now.UTC()
 		issue.Comments = append(issue.Comments, connector.IssueComment{
-			ID:          memoryCommentID(*issue, len(issue.Comments)+1),
-			Backend:     connector.BackendMemory.String(),
-			Body:        body,
-			AuthorLogin: "memory",
-			CreatedAt:   &createdAt,
-			Local:       true,
-			TargetType:  connector.IssueCommentTargetIssue,
+			ID:               memoryCommentID(*issue, len(issue.Comments)+1),
+			Backend:          connector.BackendMemory.String(),
+			Body:             body,
+			AuthorLogin:      "memory",
+			AuthorAuthorized: true,
+			CreatedAt:        &createdAt,
+			Local:            true,
+			TargetType:       connector.IssueCommentTargetIssue,
 		})
 		issue.UpdatedAt = &now
 	})

--- a/internal/store/admission.go
+++ b/internal/store/admission.go
@@ -104,7 +104,7 @@ SELECT id, project_id, issue_id, issue_identifier, issue_url, target_state, fing
        expires_at, COALESCE(resolved_at, ''), COALESCE(commented_at, ''),
        COALESCE(decision_comment_id, ''), COALESCE(decision_actor_login, ''),
        COALESCE(decision_actor_kind, ''), COALESCE(transition_at, ''),
-       COALESCE(decision_seconds, 0)
+       COALESCE(decision_seconds, 0), COALESCE(resolution_reason, '')
 FROM backlog_admission_proposals
 WHERE project_id = ? AND status = 'open'
 ORDER BY created_at, id`
@@ -128,7 +128,7 @@ SELECT id, project_id, issue_id, issue_identifier, issue_url, target_state, fing
        expires_at, COALESCE(resolved_at, ''), COALESCE(commented_at, ''),
        COALESCE(decision_comment_id, ''), COALESCE(decision_actor_login, ''),
        COALESCE(decision_actor_kind, ''), COALESCE(transition_at, ''),
-       COALESCE(decision_seconds, 0)
+       COALESCE(decision_seconds, 0), COALESCE(resolution_reason, '')
 FROM backlog_admission_proposals
 WHERE project_id = ? AND issue_id = ?
 ORDER BY created_at DESC, id DESC`,
@@ -265,13 +265,15 @@ func (s *sqliteStore) ResolveAdmissionProposal(ctx context.Context, decision adm
 	if strings.TrimSpace(decision.ProposalID) == "" {
 		return errors.New("backlog admission proposal id is required")
 	}
-	if decision.Outcome != admissionmodel.ProposalAccepted && decision.Outcome != admissionmodel.ProposalRejected {
-		return errors.New("backlog admission decision outcome must be accepted or rejected")
+	if decision.Outcome != admissionmodel.ProposalAccepted &&
+		decision.Outcome != admissionmodel.ProposalRejected &&
+		decision.Outcome != admissionmodel.ProposalSuperseded {
+		return errors.New("backlog admission decision outcome must be accepted, rejected, or superseded")
 	}
 	if decision.DecidedAt.IsZero() {
 		return errors.New("backlog admission decision time is required")
 	}
-	if strings.TrimSpace(decision.CommentID) == "" {
+	if strings.TrimSpace(decision.CommentID) == "" && !decision.Automatic {
 		return errors.New("backlog admission decision comment is required")
 	}
 	if decision.Outcome == admissionmodel.ProposalAccepted && decision.TransitionAt.IsZero() {
@@ -326,7 +328,7 @@ WHERE id = ? AND status = 'open'`,
 	result, err := tx.ExecContext(ctx, `
 UPDATE backlog_admission_proposals
 SET status = ?, resolved_at = ?, decision_comment_id = ?, decision_actor_login = ?,
-    decision_actor_kind = ?, transition_at = ?, decision_seconds = ?
+    decision_actor_kind = ?, transition_at = ?, decision_seconds = ?, resolution_reason = ?
 WHERE id = ? AND status = 'open'`,
 		string(decision.Outcome),
 		decidedAt,
@@ -335,6 +337,7 @@ WHERE id = ? AND status = 'open'`,
 		nullString(decision.ActorKind),
 		transitionAt,
 		decisionSeconds,
+		nullString(decision.Reason),
 		strings.TrimSpace(decision.ProposalID),
 	)
 	if err != nil {
@@ -907,6 +910,7 @@ func scanAdmissionProposal(scan admissionScan) (admissionmodel.Proposal, error) 
 		&proposal.DecisionActorKind,
 		&transitionAt,
 		&proposal.DecisionSeconds,
+		&proposal.ResolutionReason,
 	); err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			return admissionmodel.Proposal{}, ErrNotFound

--- a/internal/store/migrations/00026_add_admission_resolution_reason.sql
+++ b/internal/store/migrations/00026_add_admission_resolution_reason.sql
@@ -1,0 +1,7 @@
+-- +goose Up
+ALTER TABLE backlog_admission_proposals
+ADD COLUMN resolution_reason TEXT;
+
+-- +goose Down
+ALTER TABLE backlog_admission_proposals
+DROP COLUMN resolution_reason;

--- a/internal/store/sqlc/models.go
+++ b/internal/store/sqlc/models.go
@@ -84,6 +84,7 @@ type BacklogAdmissionProposal struct {
 	DecisionActorKind  sql.NullString `json:"decision_actor_kind"`
 	TransitionAt       sql.NullString `json:"transition_at"`
 	DecisionSeconds    sql.NullInt64  `json:"decision_seconds"`
+	ResolutionReason   sql.NullString `json:"resolution_reason"`
 }
 
 type BacklogAdmissionRun struct {


### PR DESCRIPTION
## Summary

- make `/detent admission accept <id>` perform the proposal's target-state transition and preserve the accepting operator in admission provenance
- resolve stale-source accepts with a durable reason instead of overwriting a newer issue state
- add opt-in `backlog_admission.auto_admit` with a configurable confidence floor and the existing proposal, author, and label guards
- update proposal guidance, configuration docs, migration/schema output, and focused table-driven tests

## Root cause

Admission reconciliation only observed a later target-state transition; it never called `UpdateIssueState`. The operator therefore had to both accept the proposal and perform the mutation manually.

Fixes #1558

## Test Plan

- `go test ./internal/admission ./internal/config ./internal/store -count=1`
- `go test ./internal/project ./internal/cli ./internal/connector/... -count=1`
- `make check` (build, lint, vet, nilaway, race suite, coverage and package floors; 78.0% repository coverage)