### PR TITLE
feat(admission): select candidates by label

### DIFF
--- a/README.md
+++ b/README.md
@@ -1194,6 +1194,7 @@ backlog_admission:
   schedule: "0 6 * * 1-5"
   sources:
     states: [Backlog]
+    labels: []
   target_state: Todo
   criteria_section: "Admission criteria"
   exclude_labels: []
@@ -1205,17 +1206,28 @@ backlog_admission:
   proposal_expiry_days: 7
 ```
 
-State names come from the project's workflow. Admission reads them through the
-candidate-reader contract: the tracker declares selector support, reads pages
-inside a hard per-run bound, filters the requested states exactly, sorts by
-creation time and stable issue identity before applying the result limit, and
-reports whether the source was truncated. Admission keeps a finite over-read
-window of at least 100 issues so its existing priority ordering, author filter,
-excluded-label filter, and `max_candidates_per_run` cap still apply after the
-connector read. A reader truncation is recorded as `candidate_reader` in the
-run ledger instead of making the bounded result look complete. A run defers
-instead of queueing when project or fleet capacity is unavailable or its agent
-would exceed the configured daily budget.
+State names come from the project's workflow. `sources.labels` selects issues
+carrying any configured non-status label, independent of workflow state. It
+defaults to empty and does nothing until configured. Labels beginning with
+`tracker.status_label_prefix` are rejected; workflow state selection belongs in
+`sources.states`.
+
+Admission reads each enabled selector through the candidate-reader contract.
+The tracker declares selector support, reads pages inside a hard per-run bound,
+filters the request exactly, sorts by creation time and stable issue identity
+before applying the result limit, and reports whether the source was truncated.
+Selector results form a deduplicated union. Issues already in `target_state`,
+and terminal or blocked issues reached only through `sources.labels`, are
+skipped and counted because label selection does not override the workflow
+state machine. `exclude_labels` is applied after the union.
+
+Admission keeps a finite over-read window of at least 100 issues so its existing
+priority ordering, author filter, excluded-label filter, and
+`max_candidates_per_run` cap still apply after the connector read. A reader
+truncation is recorded as `candidate_reader` in the run ledger instead of making
+the bounded result look complete. A run defers instead of queueing when project
+or fleet capacity is unavailable or its agent would exceed the configured daily
+budget.
 
 Criteria live in one named section of the shared `WORKFLOW.md`, never
 `WORKFLOW.local.md`. Heading matching is case-insensitive, accepts ATX headings
@@ -1252,27 +1264,27 @@ without that correlation remains an unattributed transition and does not accept
 the proposal. Rejection, expiry, and supersession are separate outcomes:
 silence can expire a proposal but never accepts or rejects one.
 
-The only admission selector currently defined is `sources.states`. Capability
-is declared per tracker and per GitHub status source:
+Capability is declared per tracker and per GitHub status source:
 
-| Tracker | Status source | `sources.states` |
-| --- | --- | --- |
-| `github` | `project_v2` | Supported |
-| `github` | `issue_field` | Supported |
-| `github` | `label` | Supported |
-| `github_local` | local SQLite status | Supported |
-| `local_sqlite` | local SQLite status | Supported |
-| `memory` | process-local status | Supported |
-| `linear` | Linear workflow state | Unsupported |
+| Tracker | Status source | `sources.states` | `sources.labels` |
+| --- | --- | --- | --- |
+| `github` | `project_v2` | Supported | Unsupported |
+| `github` | `issue_field` | Supported | Supported |
+| `github` | `label` | Supported | Supported |
+| `github_local` | local SQLite status | Supported | Supported |
+| `local_sqlite` | local SQLite status | Supported | Supported |
+| `memory` | process-local status | Supported | Supported |
+| `linear` | Linear workflow state | Unsupported | Unsupported |
 
 An enabled admission configuration fails validation when its tracker/status
 source does not declare the selector, so Linear never validates cleanly and
-then fails on its first scheduled read. `authors.allow` on `local_sqlite` or
-`memory` produces a doctor warning because those trackers do not discover
-authors. ProjectV2 configurations using `exclude_labels` warn that only the
-first 20 issue labels are fetched. The memory tracker is evaluation-only across
-restarts: durable proposal records can survive while its process-local comments
-and mutations do not.
+then fails on its first scheduled read. ProjectV2 label selection is unsupported
+because its issue query fetches only the first 20 labels; configuring either
+`sources.labels` or `exclude_labels` with ProjectV2 fails validation rather than
+risking a silent miss. `authors.allow` on `local_sqlite` or `memory` produces a
+doctor warning because those trackers do not discover authors. The memory
+tracker is evaluation-only across restarts: durable proposal records can
+survive while its process-local comments and mutations do not.
 
 Every lane-entry event records how the issue reached the state:
 

--- a/config.reference.yaml
+++ b/config.reference.yaml
@@ -968,10 +968,12 @@
 #   enabled: false
 #   # backlog_admission.schedule | type: string | default: "0 6 * * 1-5" | required: No | validation: must be a valid five-field cron expression
 #   schedule: "0 6 * * 1-5"
-#   # backlog_admission.sources | type: object | default: see child fields | required: No | validation: None
+#   # backlog_admission.sources | type: object | default: see child fields | required: No | validation: must configure at least one selector
 #   sources:
-#     # backlog_admission.sources.states | type: list<string> | default: [] | required: Conditional | validation: must contain at least one state; values must differ from target_state; values must name a configured workflow state
+#     # backlog_admission.sources.states | type: list<string> | default: [] | required: No | validation: values must differ from target_state; values must name a configured workflow state
 #     states: []
+#     # backlog_admission.sources.labels | type: list<string> | default: [] | required: No | validation: None
+#     labels: []
 #   # backlog_admission.target_state | type: string | default: none | required: Conditional | validation: is required; must name a configured workflow state
 #   target_state: null
 #   # backlog_admission.criteria_section | type: string | default: none | required: Conditional | validation: is required

--- a/docs/config.md
+++ b/docs/config.md
@@ -248,8 +248,9 @@ rendering and fails on drift.
 | `backlog_admission.max_proposals_per_run` | `integer` | `3` | No | must be greater than 0 |
 | `backlog_admission.proposal_expiry_days` | `integer` | `7` | No | must be greater than 0 |
 | `backlog_admission.schedule` | `string` | `"0 6 * * 1-5"` | No | must be a valid five-field cron expression |
-| `backlog_admission.sources` | `object` | `see child fields` | No | None |
-| `backlog_admission.sources.states` | `list<string>` | `[]` | Conditional | must contain at least one state<br>values must differ from target_state<br>values must name a configured workflow state |
+| `backlog_admission.sources` | `object` | `see child fields` | No | must configure at least one selector |
+| `backlog_admission.sources.labels` | `list<string>` | `[]` | No | None |
+| `backlog_admission.sources.states` | `list<string>` | `[]` | No | values must differ from target_state<br>values must name a configured workflow state |
 | `backlog_admission.target_state` | `string` | `none` | Conditional | is required<br>must name a configured workflow state |
 | `budget` | `object` | `see child fields` | No | None |
 | `budget.billing_mode` | `string` | `none` | No | must be one of metered, subscription |

--- a/internal/admission/manager.go
+++ b/internal/admission/manager.go
@@ -318,21 +318,44 @@ func (m *Manager) runOnce(ctx context.Context, settings Settings, scheduledFor t
 		runErr = errors.Join(runErr, release())
 	}()
 
-	candidateResult, err := settings.Issues.ReadCandidates(ctx, connector.CandidateRequest{
-		Selector: connector.CandidateSelectorStates,
-		States:   settings.Config.Sources.States,
-		Limit:    candidateReadLimit(settings.Config.MaxCandidatesPerRun),
-		PageSize: connector.DefaultCandidatePageSize,
-	})
-	if err != nil {
-		return result, fmt.Errorf("fetch backlog admission candidates: %w", err)
+	requests := make([]connector.CandidateRequest, 0, 2)
+	if len(settings.Config.Sources.States) > 0 {
+		requests = append(requests, connector.CandidateRequest{
+			Selector: connector.CandidateSelectorStates,
+			States:   settings.Config.Sources.States,
+			Limit:    candidateReadLimit(settings.Config.MaxCandidatesPerRun),
+			PageSize: connector.DefaultCandidatePageSize,
+		})
 	}
-	if candidateResult.Truncated {
-		result.Truncated["candidate_reader"]++
+	if len(settings.Config.Sources.Labels) > 0 {
+		requests = append(requests, connector.CandidateRequest{
+			Selector: connector.CandidateSelectorLabels,
+			Labels:   settings.Config.Sources.Labels,
+			Limit:    candidateReadLimit(settings.Config.MaxCandidatesPerRun),
+			PageSize: connector.DefaultCandidatePageSize,
+		})
 	}
-	candidates := candidateResult.Issues
+	candidates := []connector.Issue{}
+	seenCandidates := map[string]struct{}{}
+	for _, request := range requests {
+		candidateResult, err := settings.Issues.ReadCandidates(ctx, request)
+		if err != nil {
+			return result, fmt.Errorf("fetch backlog admission %s candidates: %w", request.Selector, err)
+		}
+		if candidateResult.Truncated {
+			result.Truncated["candidate_reader"]++
+		}
+		for _, candidate := range candidateResult.Issues {
+			key := admissionCandidateKey(candidate)
+			if _, ok := seenCandidates[key]; ok {
+				continue
+			}
+			seenCandidates[key] = struct{}{}
+			candidates = append(candidates, candidate)
+		}
+	}
 	result.CandidatesFound = len(candidates)
-	candidates = filterCandidates(candidates, settings.Config, result.Skipped)
+	candidates = filterCandidates(candidates, settings.Config, settings.TerminalStates, result.Skipped)
 	sortCandidates(candidates, settings)
 	candidates, err = m.unproposedCandidates(ctx, settings, candidates, result.Skipped)
 	if err != nil {
@@ -582,8 +605,7 @@ func (m *Manager) executeProposals(
 		original, supplied := candidateByID[issueID]
 		current, currentFound := freshByID[issueID]
 		if !supplied || !currentFound || issueFingerprint(original) != issueFingerprint(current) ||
-			current.Closed || !containsFold(settings.Config.Sources.States, current.State) ||
-			excludedCandidate(current, settings.Config) {
+			!eligibleCandidate(current, settings.Config, settings.TerminalStates) {
 			result.Skipped["stale_or_ineligible"]++
 			continue
 		}
@@ -791,12 +813,23 @@ func admissionBudgetDeferred(ctx context.Context, backend runner.Backend, now ti
 	return false, "", nil
 }
 
-func filterCandidates(issues []connector.Issue, cfg config.BacklogAdmission, skipped map[string]int) []connector.Issue {
+func filterCandidates(
+	issues []connector.Issue,
+	cfg config.BacklogAdmission,
+	terminalStates []string,
+	skipped map[string]int,
+) []connector.Issue {
 	out := make([]connector.Issue, 0, len(issues))
 	for _, issue := range issues {
 		switch {
 		case issue.Closed:
 			skipped["closed"]++
+		case labelCandidateInTargetState(issue, cfg):
+			skipped["label_target_state"]++
+		case labelCandidateStateBlocked(issue, cfg):
+			skipped["label_blocked_state"]++
+		case labelCandidateStateTerminal(issue, cfg, terminalStates):
+			skipped["label_terminal_state"]++
 		case excludedByLabel(issue, cfg.ExcludeLabels):
 			skipped["excluded_label"]++
 		case !allowedAuthor(issue.AuthorID, cfg.Authors.Allow):
@@ -808,8 +841,49 @@ func filterCandidates(issues []connector.Issue, cfg config.BacklogAdmission, ski
 	return out
 }
 
+func eligibleCandidate(issue connector.Issue, cfg config.BacklogAdmission, terminalStates []string) bool {
+	if issue.Closed || excludedCandidate(issue, cfg) {
+		return false
+	}
+	if strings.EqualFold(strings.TrimSpace(issue.State), strings.TrimSpace(cfg.TargetState)) {
+		return false
+	}
+	if containsFold(cfg.Sources.States, issue.State) {
+		return true
+	}
+	return matchesAnyLabel(issue.Labels, cfg.Sources.Labels) &&
+		!strings.EqualFold(strings.TrimSpace(issue.State), "Blocked") &&
+		!containsFold(terminalStates, issue.State)
+}
+
+func labelCandidateInTargetState(issue connector.Issue, cfg config.BacklogAdmission) bool {
+	return matchesAnyLabel(issue.Labels, cfg.Sources.Labels) &&
+		strings.EqualFold(strings.TrimSpace(issue.State), strings.TrimSpace(cfg.TargetState))
+}
+
+func labelCandidateStateBlocked(issue connector.Issue, cfg config.BacklogAdmission) bool {
+	return !containsFold(cfg.Sources.States, issue.State) &&
+		matchesAnyLabel(issue.Labels, cfg.Sources.Labels) &&
+		strings.EqualFold(strings.TrimSpace(issue.State), "Blocked")
+}
+
+func labelCandidateStateTerminal(issue connector.Issue, cfg config.BacklogAdmission, terminalStates []string) bool {
+	return !containsFold(cfg.Sources.States, issue.State) &&
+		matchesAnyLabel(issue.Labels, cfg.Sources.Labels) &&
+		containsFold(terminalStates, issue.State)
+}
+
 func excludedCandidate(issue connector.Issue, cfg config.BacklogAdmission) bool {
 	return excludedByLabel(issue, cfg.ExcludeLabels) || !allowedAuthor(issue.AuthorID, cfg.Authors.Allow)
+}
+
+func matchesAnyLabel(issueLabels []string, labels []string) bool {
+	for _, issueLabel := range issueLabels {
+		if containsFold(labels, issueLabel) {
+			return true
+		}
+	}
+	return false
 }
 
 func excludedByLabel(issue connector.Issue, labels []string) bool {
@@ -1061,6 +1135,19 @@ func issueMap(issues []connector.Issue) map[string]connector.Issue {
 	return out
 }
 
+func admissionCandidateKey(issue connector.Issue) string {
+	if value := strings.TrimSpace(issue.ID); value != "" {
+		return "id:" + value
+	}
+	if value := strings.TrimSpace(issue.Identifier); value != "" {
+		return "identifier:" + strings.ToLower(value)
+	}
+	if value := strings.TrimSpace(issue.URL); value != "" {
+		return "url:" + strings.ToLower(value)
+	}
+	return issueFingerprint(issue)
+}
+
 func normalizeSettings(settings Settings) Settings {
 	settings.ProjectID = strings.TrimSpace(settings.ProjectID)
 	settings.Config.Normalize()
@@ -1080,6 +1167,7 @@ func normalizeSettings(settings Settings) Settings {
 
 func cloneSettings(settings Settings) Settings {
 	settings.Config.Sources.States = append([]string(nil), settings.Config.Sources.States...)
+	settings.Config.Sources.Labels = append([]string(nil), settings.Config.Sources.Labels...)
 	settings.Config.ExcludeLabels = append([]string(nil), settings.Config.ExcludeLabels...)
 	settings.Config.Authors.Allow = append([]string(nil), settings.Config.Authors.Allow...)
 	settings.Criteria.Dimensions = append([]config.AdmissionDimension(nil), settings.Criteria.Dimensions...)

--- a/internal/admission/manager_test.go
+++ b/internal/admission/manager_test.go
@@ -542,6 +542,57 @@ func TestManagerFiltersLocallyAndRejectsFabricatedCriteria(t *testing.T) {
 	}
 }
 
+func TestManagerUnionsLabelCandidatesAndSkipsIneligibleStates(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 7, 29, 12, 0, 0, 0, time.UTC)
+	stateAndLabel := admissionIssueFixture("both", "DD-1", 1, now)
+	stateAndLabel.Labels = []string{"sentry"}
+	labelOnly := admissionIssueFixture("label", "DD-2", 2, now.Add(time.Minute))
+	labelOnly.State = "Needs Triage"
+	labelOnly.Labels = []string{"needs-decision"}
+	target := admissionIssueFixture("target", "DD-6", 6, now.Add(5*time.Minute))
+	target.State = "Todo"
+	target.Labels = []string{"sentry"}
+	blocked := admissionIssueFixture("blocked", "DD-3", 3, now.Add(2*time.Minute))
+	blocked.State = "Blocked"
+	blocked.Labels = []string{"sentry"}
+	terminal := admissionIssueFixture("terminal", "DD-4", 4, now.Add(3*time.Minute))
+	terminal.State = "Done"
+	terminal.Labels = []string{"sentry"}
+	excluded := admissionIssueFixture("excluded", "DD-5", 5, now.Add(4*time.Minute))
+	excluded.Labels = []string{"sentry", "skip"}
+	tracker := memory.New(memory.Config{
+		Issues:   []connector.Issue{stateAndLabel, labelOnly, target, blocked, terminal, excluded},
+		Stateful: true,
+	})
+	backend := openManagerTestStore(t)
+	agent := &scriptedAdmissionRunner{propose: proposeEveryCandidate}
+	settings := admissionTestSettings(tracker, agent)
+	settings.Config.Sources.Labels = []string{"sentry", "needs-decision"}
+	settings.Config.ExcludeLabels = []string{"skip"}
+	settings.Config.MaxProposalsPerRun = 10
+	settings.TerminalStates = []string{"Done"}
+	manager := newAdmissionTestManager(t, settings, backend, func() time.Time { return now })
+
+	result, err := manager.RunOnce(context.Background())
+	if err != nil {
+		t.Fatalf("RunOnce() error = %v", err)
+	}
+	if result.CandidatesFound != 6 || result.Candidates != 2 || len(result.Proposals) != 2 {
+		t.Fatalf("result = %#v, want deduplicated union with two eligible candidates", result)
+	}
+	if result.Skipped["label_target_state"] != 1 ||
+		result.Skipped["label_blocked_state"] != 1 ||
+		result.Skipped["label_terminal_state"] != 1 ||
+		result.Skipped["excluded_label"] != 1 {
+		t.Fatalf("skipped = %#v", result.Skipped)
+	}
+	if got, want := agent.candidateIDs[0], []string{"both", "label"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("candidate ids = %#v, want %#v", got, want)
+	}
+}
+
 func TestManagerLocalSQLiteStatesOnlyEndToEnd(t *testing.T) {
 	t.Parallel()
 

--- a/internal/config/admission.go
+++ b/internal/config/admission.go
@@ -37,6 +37,7 @@ type BacklogAdmission struct {
 
 type BacklogAdmissionSources struct {
 	States []string `yaml:"states"`
+	Labels []string `yaml:"labels,omitempty"`
 }
 
 type BacklogAdmissionAuthors struct {
@@ -63,6 +64,7 @@ func (a *BacklogAdmission) Normalize() {
 		a.Schedule = DefaultBacklogAdmissionSchedule
 	}
 	a.Sources.States = normalizeStateList(a.Sources.States)
+	a.Sources.Labels = normalizeAdmissionSourceLabels(a.Sources.Labels)
 	a.TargetState = strings.TrimSpace(a.TargetState)
 	a.CriteriaSection = strings.TrimSpace(a.CriteriaSection)
 	a.ExcludeLabels = normalizeLabels(a.ExcludeLabels)
@@ -81,8 +83,8 @@ func (a BacklogAdmission) Validate(prefix string, states []string, tracker Track
 	if _, err := cron.ParseStandard(a.Schedule); err != nil {
 		problems = append(problems, prefix+".schedule must be a valid five-field cron expression")
 	}
-	if len(a.Sources.States) == 0 {
-		problems = append(problems, prefix+".sources.states must contain at least one state")
+	if len(a.Sources.States) == 0 && len(a.Sources.Labels) == 0 {
+		problems = append(problems, prefix+".sources must configure at least one selector")
 	}
 	known := make(map[string]string, len(states))
 	for _, state := range states {
@@ -109,7 +111,7 @@ func (a BacklogAdmission) Validate(prefix string, states []string, tracker Track
 	validatePositive(prefix+".max_open_proposals", a.MaxOpenProposals, &problems)
 	validatePositive(prefix+".proposal_expiry_days", a.ProposalExpiryDays, &problems)
 	capabilities := connector.CandidateCapabilitiesFor(connector.Backend(tracker.Kind), tracker.GitHubStatusSource)
-	if !capabilities.Supports(connector.CandidateSelectorStates) {
+	if len(a.Sources.States) > 0 && !capabilities.Supports(connector.CandidateSelectorStates) {
 		gap := prefix + ".sources.states requires candidate selector states, but tracker.kind " + tracker.Kind
 		if tracker.Kind == TrackerGitHub {
 			gap += " with github_status_source " + tracker.GitHubStatusSource
@@ -120,6 +122,31 @@ func (a BacklogAdmission) Validate(prefix string, states []string, tracker Track
 			gap += " does not declare it"
 		}
 		problems = append(problems, gap)
+	}
+	statusLabelPrefix := strings.TrimSpace(tracker.StatusLabelPrefix)
+	if statusLabelPrefix == "" {
+		statusLabelPrefix = "detent:"
+	}
+	for index, label := range a.Sources.Labels {
+		if strings.HasPrefix(strings.ToLower(label), strings.ToLower(statusLabelPrefix)) {
+			problems = append(problems, fmt.Sprintf(
+				"%s.sources.labels[%d] must not use status label prefix %q; use sources.states instead",
+				prefix,
+				index,
+				statusLabelPrefix,
+			))
+		}
+	}
+	if len(a.Sources.Labels) > 0 && !capabilities.Supports(connector.CandidateSelectorLabels) {
+		gap := prefix + ".sources.labels requires candidate selector labels, but tracker.kind " + tracker.Kind
+		if tracker.Kind == TrackerGitHub {
+			gap += " with github_status_source " + tracker.GitHubStatusSource
+		}
+		gap += " does not declare complete label reads"
+		problems = append(problems, gap)
+	}
+	if len(a.ExcludeLabels) > 0 && tracker.Kind == TrackerGitHub && tracker.GitHubStatusSource == GitHubStatusSourceProjectV2 {
+		problems = append(problems, prefix+".exclude_labels requires complete issue labels, but tracker.kind github with github_status_source project_v2 fetches only the first 20 labels")
 	}
 	return problems
 }
@@ -133,13 +160,21 @@ func BacklogAdmissionWarnings(admission BacklogAdmission, tracker Tracker) []str
 	if len(admission.Authors.Allow) > 0 && (tracker.Kind == TrackerLocalSQLite || tracker.Kind == TrackerMemory) {
 		warnings = append(warnings, "backlog_admission.authors.allow uses AuthorID, but tracker.kind "+tracker.Kind+" does not discover authors")
 	}
-	if len(admission.ExcludeLabels) > 0 && tracker.Kind == TrackerGitHub && tracker.GitHubStatusSource == GitHubStatusSourceProjectV2 {
-		warnings = append(warnings, "backlog_admission.exclude_labels may miss labels under project_v2 because only the first 20 labels per issue are fetched")
-	}
 	if tracker.Kind == TrackerMemory {
 		warnings = append(warnings, "backlog_admission with tracker.kind memory is evaluation-only across restarts because tracker comments and mutations are process-local")
 	}
 	return warnings
+}
+
+func normalizeAdmissionSourceLabels(labels []string) []string {
+	normalized := normalizeLabels(labels)
+	out := make([]string, 0, len(normalized))
+	for _, label := range normalized {
+		if label != "" {
+			out = append(out, label)
+		}
+	}
+	return out
 }
 
 func ResolveAdmissionCriteria(prompt string, section string) (AdmissionCriteria, error) {

--- a/internal/config/admission_test.go
+++ b/internal/config/admission_test.go
@@ -18,6 +18,7 @@ backlog_admission:
   schedule: "15 4 * * 1"
   sources:
     states: [Backlog]
+    labels: [Sentry, sentry]
   target_state: Todo
   criteria_section: Admission criteria
   exclude_labels: [Skip, skip]
@@ -47,9 +48,10 @@ backlog_admission:
 		got.MaxOpenProposals != 8 || got.ProposalExpiryDays != 5 {
 		t.Fatalf("BacklogAdmission = %#v", got)
 	}
-	if len(got.ExcludeLabels) != 1 || got.ExcludeLabels[0] != "skip" ||
+	if len(got.Sources.Labels) != 1 || got.Sources.Labels[0] != "sentry" ||
+		len(got.ExcludeLabels) != 1 || got.ExcludeLabels[0] != "skip" ||
 		len(got.Authors.Allow) != 1 || got.Authors.Allow[0] != "octocat" {
-		t.Fatalf("normalized filters = labels %#v authors %#v", got.ExcludeLabels, got.Authors.Allow)
+		t.Fatalf("normalized filters = sources %#v exclude %#v authors %#v", got.Sources.Labels, got.ExcludeLabels, got.Authors.Allow)
 	}
 }
 
@@ -96,7 +98,7 @@ func TestBacklogAdmissionValidate(t *testing.T) {
 		{name: "local sqlite", tracker: Tracker{Kind: TrackerLocalSQLite}},
 		{name: "memory", tracker: Tracker{Kind: TrackerMemory}},
 		{name: "bad cron", tracker: Tracker{Kind: TrackerGitHub}, mutate: func(cfg *BacklogAdmission) { cfg.Schedule = "not cron" }, want: "valid five-field cron"},
-		{name: "empty sources", tracker: Tracker{Kind: TrackerGitHub}, mutate: func(cfg *BacklogAdmission) { cfg.Sources.States = nil }, want: "must contain at least one state"},
+		{name: "empty sources", tracker: Tracker{Kind: TrackerGitHub}, mutate: func(cfg *BacklogAdmission) { cfg.Sources.States = nil }, want: "must configure at least one selector"},
 		{name: "unknown source", tracker: Tracker{Kind: TrackerGitHub}, mutate: func(cfg *BacklogAdmission) { cfg.Sources.States = []string{"Icebox"} }, want: "sources.states[0] must name"},
 		{name: "source equals target", tracker: Tracker{Kind: TrackerGitHub}, mutate: func(cfg *BacklogAdmission) { cfg.Sources.States = []string{"Todo"} }, want: "must differ from target_state"},
 		{name: "unknown target", tracker: Tracker{Kind: TrackerGitHub}, mutate: func(cfg *BacklogAdmission) { cfg.TargetState = "Ready" }, want: "target_state must name"},
@@ -122,6 +124,71 @@ func TestBacklogAdmissionValidate(t *testing.T) {
 			}
 			if tt.want != "" && !strings.Contains(got, tt.want) {
 				t.Fatalf("Validate() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestBacklogAdmissionLabelSelectorValidation(t *testing.T) {
+	t.Parallel()
+
+	valid := BacklogAdmission{
+		Enabled:             true,
+		Schedule:            "0 6 * * 1-5",
+		Sources:             BacklogAdmissionSources{Labels: []string{"sentry"}},
+		TargetState:         "Todo",
+		CriteriaSection:     "Admission criteria",
+		MaxCandidatesPerRun: 50,
+		MaxProposalsPerRun:  3,
+		MaxOpenProposals:    10,
+		ProposalExpiryDays:  7,
+	}
+	states := []string{"Backlog", "Todo", "Blocked", "Done"}
+	tests := []struct {
+		name    string
+		tracker Tracker
+		mutate  func(*BacklogAdmission)
+		want    string
+	}{
+		{name: "github label", tracker: Tracker{Kind: TrackerGitHub, GitHubStatusSource: GitHubStatusSourceLabel}},
+		{name: "github issue field", tracker: Tracker{Kind: TrackerGitHub, GitHubStatusSource: GitHubStatusSourceIssueField}},
+		{name: "github local", tracker: Tracker{Kind: TrackerGitHubLocal}},
+		{name: "local sqlite", tracker: Tracker{Kind: TrackerLocalSQLite}},
+		{name: "memory", tracker: Tracker{Kind: TrackerMemory}},
+		{name: "github project v2", tracker: Tracker{Kind: TrackerGitHub, GitHubStatusSource: GitHubStatusSourceProjectV2}, want: "does not declare complete label reads"},
+		{name: "linear", tracker: Tracker{Kind: TrackerLinear}, want: "does not declare complete label reads"},
+		{
+			name:    "configured status prefix",
+			tracker: Tracker{Kind: TrackerMemory, StatusLabelPrefix: "workflow/"},
+			mutate: func(cfg *BacklogAdmission) {
+				cfg.Sources.Labels = []string{"Workflow/Ready"}
+			},
+			want: `must not use status label prefix "workflow/"`,
+		},
+		{
+			name:    "project v2 excluded labels",
+			tracker: Tracker{Kind: TrackerGitHub, GitHubStatusSource: GitHubStatusSourceProjectV2},
+			mutate: func(cfg *BacklogAdmission) {
+				cfg.Sources.Labels = nil
+				cfg.Sources.States = []string{"Backlog"}
+				cfg.ExcludeLabels = []string{"skip"}
+			},
+			want: "fetches only the first 20 labels",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			cfg := valid
+			if test.mutate != nil {
+				test.mutate(&cfg)
+			}
+			got := strings.Join(cfg.Validate("backlog_admission", states, test.tracker), "; ")
+			if test.want == "" && got != "" {
+				t.Fatalf("Validate() = %q, want no problems", got)
+			}
+			if test.want != "" && !strings.Contains(got, test.want) {
+				t.Fatalf("Validate() = %q, want %q", got, test.want)
 			}
 		})
 	}
@@ -245,10 +312,6 @@ func TestBacklogAdmissionWarnings(t *testing.T) {
 	localWarnings := strings.Join(BacklogAdmissionWarnings(cfg, Tracker{Kind: TrackerLocalSQLite}), "; ")
 	if !strings.Contains(localWarnings, "does not discover authors") {
 		t.Fatalf("local warnings = %q", localWarnings)
-	}
-	projectWarnings := strings.Join(BacklogAdmissionWarnings(cfg, Tracker{Kind: TrackerGitHub, GitHubStatusSource: GitHubStatusSourceProjectV2}), "; ")
-	if !strings.Contains(projectWarnings, "first 20 labels") {
-		t.Fatalf("project_v2 warnings = %q", projectWarnings)
 	}
 	memoryWarnings := strings.Join(BacklogAdmissionWarnings(cfg, Tracker{Kind: TrackerMemory}), "; ")
 	if !strings.Contains(memoryWarnings, "evaluation-only across restarts") {

--- a/internal/connector/candidate.go
+++ b/internal/connector/candidate.go
@@ -17,7 +17,10 @@ var (
 
 type CandidateSelector string
 
-const CandidateSelectorStates CandidateSelector = "states"
+const (
+	CandidateSelectorStates CandidateSelector = "states"
+	CandidateSelectorLabels CandidateSelector = "labels"
+)
 
 type CandidateCapabilities struct {
 	Selectors []CandidateSelector `json:"selectors" yaml:"selectors"`
@@ -36,13 +39,15 @@ func CandidateCapabilitiesFor(backend Backend, statusSource string) CandidateCap
 	switch backend {
 	case BackendGitHub:
 		switch strings.ToLower(strings.TrimSpace(statusSource)) {
-		case "", "project_v2", "issue_field", "label":
+		case "", "project_v2":
 			return statesCandidateCapabilities()
+		case "issue_field", "label":
+			return statesAndLabelsCandidateCapabilities()
 		default:
 			return CandidateCapabilities{}
 		}
 	case BackendGitHubLocal, BackendLocalSQLite, BackendMemory:
-		return statesCandidateCapabilities()
+		return statesAndLabelsCandidateCapabilities()
 	default:
 		return CandidateCapabilities{}
 	}
@@ -51,6 +56,7 @@ func CandidateCapabilitiesFor(backend Backend, statusSource string) CandidateCap
 type CandidateRequest struct {
 	Selector CandidateSelector `json:"selector" yaml:"selector"`
 	States   []string          `json:"states,omitempty" yaml:"states,omitempty"`
+	Labels   []string          `json:"labels,omitempty" yaml:"labels,omitempty"`
 	Limit    int               `json:"limit" yaml:"limit"`
 	PageSize int               `json:"page_size,omitempty" yaml:"page_size,omitempty"`
 }
@@ -69,6 +75,10 @@ func (r CandidateRequest) Validate(capabilities CandidateCapabilities) error {
 	case CandidateSelectorStates:
 		if len(normalizedCandidateStates(r.States)) == 0 {
 			return fmt.Errorf("%w: states selector requires at least one state", ErrInvalidCandidateRequest)
+		}
+	case CandidateSelectorLabels:
+		if len(normalizedCandidateLabels(r.Labels)) == 0 {
+			return fmt.Errorf("%w: labels selector requires at least one label", ErrInvalidCandidateRequest)
 		}
 	default:
 		return fmt.Errorf("%w: %s", ErrCandidateSelectorUnsupported, r.Selector)
@@ -157,12 +167,24 @@ func statesCandidateCapabilities() CandidateCapabilities {
 	return CandidateCapabilities{Selectors: []CandidateSelector{CandidateSelectorStates}}
 }
 
+func statesAndLabelsCandidateCapabilities() CandidateCapabilities {
+	return CandidateCapabilities{Selectors: []CandidateSelector{CandidateSelectorStates, CandidateSelectorLabels}}
+}
+
 func normalizedCandidateStates(states []string) []string {
-	normalized := make([]string, 0, len(states))
-	seen := make(map[string]struct{}, len(states))
-	for _, state := range states {
-		state = strings.TrimSpace(state)
-		key := strings.ToLower(state)
+	return normalizedCandidateValues(states)
+}
+
+func normalizedCandidateLabels(labels []string) []string {
+	return normalizedCandidateValues(labels)
+}
+
+func normalizedCandidateValues(values []string) []string {
+	normalized := make([]string, 0, len(values))
+	seen := make(map[string]struct{}, len(values))
+	for _, value := range values {
+		value = strings.TrimSpace(value)
+		key := strings.ToLower(value)
 		if key == "" {
 			continue
 		}
@@ -170,7 +192,7 @@ func normalizedCandidateStates(states []string) []string {
 			continue
 		}
 		seen[key] = struct{}{}
-		normalized = append(normalized, state)
+		normalized = append(normalized, value)
 	}
 	return normalized
 }

--- a/internal/connector/candidate_test.go
+++ b/internal/connector/candidate_test.go
@@ -14,16 +14,17 @@ func TestCandidateCapabilitiesFor(t *testing.T) {
 		name         string
 		backend      Backend
 		statusSource string
-		supports     bool
+		states       bool
+		labels       bool
 	}{
-		{name: "github project v2", backend: BackendGitHub, statusSource: "project_v2", supports: true},
-		{name: "github issue field", backend: BackendGitHub, statusSource: "issue_field", supports: true},
-		{name: "github label", backend: BackendGitHub, statusSource: "label", supports: true},
-		{name: "github default", backend: BackendGitHub, supports: true},
+		{name: "github project v2", backend: BackendGitHub, statusSource: "project_v2", states: true},
+		{name: "github issue field", backend: BackendGitHub, statusSource: "issue_field", states: true, labels: true},
+		{name: "github label", backend: BackendGitHub, statusSource: "label", states: true, labels: true},
+		{name: "github default", backend: BackendGitHub, states: true},
 		{name: "github invalid source", backend: BackendGitHub, statusSource: "milestone"},
-		{name: "github local", backend: BackendGitHubLocal, supports: true},
-		{name: "local sqlite", backend: BackendLocalSQLite, supports: true},
-		{name: "memory", backend: BackendMemory, supports: true},
+		{name: "github local", backend: BackendGitHubLocal, states: true, labels: true},
+		{name: "local sqlite", backend: BackendLocalSQLite, states: true, labels: true},
+		{name: "memory", backend: BackendMemory, states: true, labels: true},
 		{name: "linear", backend: BackendLinear},
 		{name: "gitlab", backend: BackendGitLab},
 		{name: "jira", backend: BackendJira},
@@ -31,9 +32,12 @@ func TestCandidateCapabilitiesFor(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
-			got := CandidateCapabilitiesFor(test.backend, test.statusSource).Supports(CandidateSelectorStates)
-			if got != test.supports {
-				t.Fatalf("Supports(states) = %t, want %t", got, test.supports)
+			capabilities := CandidateCapabilitiesFor(test.backend, test.statusSource)
+			if got := capabilities.Supports(CandidateSelectorStates); got != test.states {
+				t.Fatalf("Supports(states) = %t, want %t", got, test.states)
+			}
+			if got := capabilities.Supports(CandidateSelectorLabels); got != test.labels {
+				t.Fatalf("Supports(labels) = %t, want %t", got, test.labels)
 			}
 		})
 	}
@@ -57,9 +61,17 @@ func TestCandidateRequestValidate(t *testing.T) {
 			},
 		},
 		{
+			name: "valid labels selector",
+			request: CandidateRequest{
+				Selector: CandidateSelectorLabels,
+				Labels:   []string{" Sentry ", "sentry"},
+				Limit:    10,
+			},
+		},
+		{
 			name: "unsupported selector",
 			request: CandidateRequest{
-				Selector: CandidateSelector("labels"),
+				Selector: CandidateSelector("authors"),
 				Limit:    10,
 			},
 			want: ErrCandidateSelectorUnsupported,
@@ -87,6 +99,15 @@ func TestCandidateRequestValidate(t *testing.T) {
 			request: CandidateRequest{
 				Selector: CandidateSelectorStates,
 				States:   []string{"  "},
+				Limit:    10,
+			},
+			want: ErrInvalidCandidateRequest,
+		},
+		{
+			name: "empty labels",
+			request: CandidateRequest{
+				Selector: CandidateSelectorLabels,
+				Labels:   []string{"  "},
 				Limit:    10,
 			},
 			want: ErrInvalidCandidateRequest,

--- a/internal/connector/github/candidate.go
+++ b/internal/connector/github/candidate.go
@@ -27,13 +27,18 @@ func (c *Connector) ReadCandidates(ctx context.Context, request connector.Candid
 		incomplete bool
 		err        error
 	)
-	switch {
-	case c.usesLabelStatus():
-		issues, pagesRead, incomplete, err = c.readLabelCandidates(ctx, request)
-	case c.usesIssueFieldStatus():
-		issues, pagesRead, incomplete, err = c.readIssueFieldCandidates(ctx, request)
-	default:
-		issues, pagesRead, incomplete, err = c.readProjectCandidates(ctx, request)
+	switch request.Selector {
+	case connector.CandidateSelectorLabels:
+		issues, pagesRead, incomplete, err = c.readRepositoryLabelCandidates(ctx, request)
+	case connector.CandidateSelectorStates:
+		switch {
+		case c.usesLabelStatus():
+			issues, pagesRead, incomplete, err = c.readLabelCandidates(ctx, request)
+		case c.usesIssueFieldStatus():
+			issues, pagesRead, incomplete, err = c.readIssueFieldCandidates(ctx, request)
+		default:
+			issues, pagesRead, incomplete, err = c.readProjectCandidates(ctx, request)
+		}
 	}
 	if err != nil {
 		return connector.CandidateResult{}, err
@@ -44,6 +49,94 @@ func (c *Connector) ReadCandidates(ctx context.Context, request connector.Candid
 		return connector.CandidateResult{}, err
 	}
 	return result, nil
+}
+
+func (c *Connector) readRepositoryLabelCandidates(
+	ctx context.Context,
+	request connector.CandidateRequest,
+) ([]connector.Issue, int, bool, error) {
+	if !validPullRequestRepo(c.repository) {
+		return nil, 0, false, ErrMissingRepository
+	}
+	labelNames := normalizeStateList(request.Labels, nil)
+	scanLimit := request.ProbeLimit()
+	issues := []connector.Issue{}
+	seenIssues := map[string]struct{}{}
+	queriedLabels := map[string]struct{}{}
+	pagesRead := 0
+	pageSize := min(request.EffectivePageSize(), repositoryIssuesPageSize, scanLimit)
+	incomplete := false
+
+	for _, labelName := range labelNames {
+		labelKey := normalizeLabelName(labelName)
+		if _, ok := queriedLabels[labelKey]; ok {
+			continue
+		}
+		queriedLabels[labelKey] = struct{}{}
+		itemsRead := 0
+		for page := 1; ; page++ {
+			if itemsRead >= scanLimit {
+				incomplete = true
+				break
+			}
+			var response []restIssue
+			path := restRepositoryIssuesByLabelPagePath(c.repository, labelName, page, pageSize, true)
+			if err := c.client.REST(ctx, http.MethodGet, path, nil, &response); err != nil {
+				return nil, 0, false, fmt.Errorf("fetch github label selector candidates: %w", err)
+			}
+			pagesRead++
+			pageItems := response
+			if remaining := scanLimit - itemsRead; len(pageItems) > remaining {
+				pageItems = pageItems[:remaining]
+			}
+			itemsRead += len(pageItems)
+			for _, item := range pageItems {
+				if item.PullRequest != nil {
+					continue
+				}
+				ref := issueRef{Owner: c.repository.Owner, Name: c.repository.Name, Number: item.Number}
+				node := githubIssueNodeFromREST(ref, item)
+				if strings.TrimSpace(node.ID) == "" {
+					continue
+				}
+				if _, ok := seenIssues[node.ID]; ok {
+					continue
+				}
+				var (
+					issue connector.Issue
+					ok    bool
+					err   error
+				)
+				if c.usesIssueFieldStatus() {
+					issue, ok, err = c.fetchIssueFieldIssueFromREST(ctx, ref, item)
+				} else {
+					issue = c.buildLabelIssue(node, c.githubIssueStateToDetentState(node.State))
+					ok = true
+					c.cacheIssueRef(node)
+				}
+				if err != nil {
+					return nil, 0, false, err
+				}
+				if !ok {
+					continue
+				}
+				seenIssues[node.ID] = struct{}{}
+				issues = append(issues, issue)
+			}
+			if len(pageItems) < len(response) {
+				incomplete = true
+				break
+			}
+			if len(response) < pageSize {
+				break
+			}
+			if itemsRead >= scanLimit {
+				incomplete = true
+				break
+			}
+		}
+	}
+	return issues, pagesRead, incomplete, nil
 }
 
 func (c *Connector) readLabelCandidates(

--- a/internal/connector/github/candidate_test.go
+++ b/internal/connector/github/candidate_test.go
@@ -214,6 +214,74 @@ func TestConnectorReadLabelCandidatesSharesBoundAcrossStates(t *testing.T) {
 	}
 }
 
+func TestConnectorReadLabelSelectorCandidatesIndependentOfLabelStatus(t *testing.T) {
+	t.Parallel()
+
+	server := newGraphQLTestServer(t, []graphqlTestResponse{{
+		method: http.MethodGet,
+		body: `[
+			{"node_id":"I_1","number":1,"title":"Labeled done issue","state":"open","html_url":"https://github.com/digitaldrywood/detent/issues/1",
+				"labels":[{"name":"sentry"},{"name":"detent:done"}]}
+		]`,
+	}})
+	c := newGitHubTestConnector(t, server, Config{
+		GitHubStatusSource: GitHubStatusSourceLabel,
+		Repository:         "digitaldrywood/detent",
+		TerminalStates:     []string{"Done"},
+	})
+
+	got, err := c.ReadCandidates(context.Background(), connector.CandidateRequest{
+		Selector: connector.CandidateSelectorLabels,
+		Labels:   []string{"sentry"},
+		Limit:    10,
+	})
+	if err != nil {
+		t.Fatalf("ReadCandidates() error = %v", err)
+	}
+	if len(got.Issues) != 1 || got.Issues[0].ID != "I_1" || got.Issues[0].State != "Done" {
+		t.Fatalf("result = %#v, want label match in terminal workflow state", got)
+	}
+	if path := server.requests()[0]["path"].(string); !strings.Contains(path, "labels=sentry") {
+		t.Fatalf("request path = %q, want sentry label filter", path)
+	}
+}
+
+func TestConnectorReadLabelSelectorCandidatesIndependentOfIssueFieldStatus(t *testing.T) {
+	t.Parallel()
+
+	server := newGraphQLTestServer(t, []graphqlTestResponse{
+		{
+			method: http.MethodGet,
+			body: `[
+				{"node_id":"I_1","number":1,"title":"Needs decision","state":"open","html_url":"https://github.com/digitaldrywood/detent/issues/1",
+					"labels":[{"name":"needs-decision"}]}
+			]`,
+		},
+		{
+			method: http.MethodGet,
+			path:   "/repos/digitaldrywood/detent/issues/1/issue-field-values?per_page=100",
+			body:   `[]`,
+		},
+	})
+	c := newGitHubTestConnector(t, server, Config{
+		GitHubStatusSource: GitHubStatusSourceIssueField,
+		Repository:         "digitaldrywood/detent",
+		StatusField:        "Status",
+	})
+
+	got, err := c.ReadCandidates(context.Background(), connector.CandidateRequest{
+		Selector: connector.CandidateSelectorLabels,
+		Labels:   []string{"needs-decision"},
+		Limit:    10,
+	})
+	if err != nil {
+		t.Fatalf("ReadCandidates() error = %v", err)
+	}
+	if len(got.Issues) != 1 || got.Issues[0].ID != "I_1" || got.Issues[0].State != "Open" {
+		t.Fatalf("result = %#v, want label match with empty status field", got)
+	}
+}
+
 func TestConnectorReadIssueFieldCandidatesFiltersAndOrdersSearch(t *testing.T) {
 	t.Parallel()
 

--- a/internal/connector/githublocal/candidate_test.go
+++ b/internal/connector/githublocal/candidate_test.go
@@ -45,3 +45,45 @@ func TestConnectorReadCandidatesUsesLocalStateStore(t *testing.T) {
 		t.Fatalf("result = %#v, want empty complete local result", got)
 	}
 }
+
+func TestConnectorReadCandidatesSelectsLocalLabelsBeforeHydration(t *testing.T) {
+	t.Parallel()
+
+	server := newGitHubLocalTestServer(t)
+	c, err := New(Config{
+		GitHub: githubconnector.Config{
+			Endpoint: server.URL + "/graphql",
+			APIKey:   "token",
+		},
+		Local: local.Config{
+			Path: filepath.Join(t.TempDir(), "candidate-label.db"),
+			Issues: []connector.Issue{{
+				ID:         "github:123:779",
+				Identifier: "digitaldrywood/detent#779",
+				State:      "Todo",
+				Labels:     []string{"enhancement"},
+			}},
+		},
+		Repository: "digitaldrywood/detent",
+	})
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	t.Cleanup(func() {
+		if err := c.Close(); err != nil {
+			t.Fatalf("Close() error = %v", err)
+		}
+	})
+
+	got, err := c.ReadCandidates(context.Background(), connector.CandidateRequest{
+		Selector: connector.CandidateSelectorLabels,
+		Labels:   []string{"enhancement"},
+		Limit:    10,
+	})
+	if err != nil {
+		t.Fatalf("ReadCandidates() error = %v", err)
+	}
+	if len(got.Issues) != 1 || got.Issues[0].ID != "github:123:779" || got.Issues[0].Title != "Closed upstream issue" {
+		t.Fatalf("result = %#v, want hydrated local label match", got)
+	}
+}

--- a/internal/connector/local/candidate_test.go
+++ b/internal/connector/local/candidate_test.go
@@ -52,6 +52,41 @@ func TestConnectorReadCandidatesUsesDeterministicBoundedOrder(t *testing.T) {
 	}
 }
 
+func TestConnectorReadCandidatesSelectsAnyLabel(t *testing.T) {
+	t.Parallel()
+
+	c, err := New(Config{
+		Path:      filepath.Join(t.TempDir(), "candidate-label.db"),
+		ProjectID: "detent",
+		Issues: []connector.Issue{
+			{ID: "1", Identifier: "DD-1", State: "Backlog", Labels: []string{"needs-decision"}},
+			{ID: "2", Identifier: "DD-2", State: "Todo", Labels: []string{"SENTRY"}},
+			{ID: "3", Identifier: "DD-3", State: "Done", Labels: []string{"unrelated"}},
+		},
+	})
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	t.Cleanup(func() {
+		if err := c.Close(); err != nil {
+			t.Fatalf("Close() error = %v", err)
+		}
+	})
+
+	got, err := c.ReadCandidates(context.Background(), connector.CandidateRequest{
+		Selector: connector.CandidateSelectorLabels,
+		Labels:   []string{"sentry", "needs-decision"},
+		Limit:    10,
+	})
+	if err != nil {
+		t.Fatalf("ReadCandidates() error = %v", err)
+	}
+	ids := []string{got.Issues[0].ID, got.Issues[1].ID}
+	if !reflect.DeepEqual(ids, []string{"1", "2"}) {
+		t.Fatalf("candidate IDs = %#v, want [1 2]", ids)
+	}
+}
+
 func localCandidateTime(value time.Time) *time.Time {
 	return &value
 }

--- a/internal/connector/local/local.go
+++ b/internal/connector/local/local.go
@@ -179,7 +179,14 @@ func (c *Connector) ReadCandidates(ctx context.Context, request connector.Candid
 	if err := request.Validate(c.CandidateCapabilities()); err != nil {
 		return connector.CandidateResult{}, err
 	}
-	issues, err := c.fetchIssuesWithOrder(ctx, request.States, request.ProbeLimit(), true)
+	var states, labels []string
+	switch request.Selector {
+	case connector.CandidateSelectorStates:
+		states = request.States
+	case connector.CandidateSelectorLabels:
+		labels = request.Labels
+	}
+	issues, err := c.fetchIssuesWithOrder(ctx, states, labels, request.ProbeLimit(), true)
 	if err != nil {
 		return connector.CandidateResult{}, err
 	}
@@ -979,10 +986,16 @@ on conflict(project_id, id) do nothing`,
 }
 
 func (c *Connector) fetchIssues(ctx context.Context, states []string, limit int) ([]connector.Issue, error) {
-	return c.fetchIssuesWithOrder(ctx, states, limit, false)
+	return c.fetchIssuesWithOrder(ctx, states, nil, limit, false)
 }
 
-func (c *Connector) fetchIssuesWithOrder(ctx context.Context, states []string, limit int, candidateOrder bool) ([]connector.Issue, error) {
+func (c *Connector) fetchIssuesWithOrder(
+	ctx context.Context,
+	states []string,
+	labels []string,
+	limit int,
+	candidateOrder bool,
+) ([]connector.Issue, error) {
 	query := `select project_id, id, identifier, number, title, description, priority, state, url,
 author_id, assignee_id, assignees_json, labels_json, fields_json, metadata_json,
 deliverable_kind, deliverable_path, deliverable_review_url, deliverable_validation_status,
@@ -1006,6 +1019,18 @@ where project_id = ?`
 		// rows may hold the template's capitalized spellings; compare
 		// case-insensitively so items stay visible either way.
 		query += " and state collate nocase in (" + strings.Join(placeholders, ",") + ")" // #nosec G202 -- only generated question-mark placeholders are concatenated; values remain bound parameters.
+	}
+	if len(normalizedSet(labels)) > 0 {
+		placeholders := make([]string, 0, len(labels))
+		for _, label := range labels {
+			label = strings.TrimSpace(label)
+			if label == "" {
+				continue
+			}
+			placeholders = append(placeholders, "?")
+			args = append(args, strings.ToLower(label))
+		}
+		query += " and exists (select 1 from json_each(labels_json) where lower(trim(cast(json_each.value as text))) in (" + strings.Join(placeholders, ",") + "))" // #nosec G202 -- only generated question-mark placeholders are concatenated; values remain bound parameters.
 	}
 	if candidateOrder {
 		query += " order by created_at is null asc, created_at asc, lower(identifier) asc, identifier asc, id asc"

--- a/internal/connector/memory/candidate_test.go
+++ b/internal/connector/memory/candidate_test.go
@@ -38,6 +38,29 @@ func TestConnectorReadCandidatesFiltersSortsAndTruncates(t *testing.T) {
 	}
 }
 
+func TestConnectorReadCandidatesSelectsAnyLabel(t *testing.T) {
+	t.Parallel()
+
+	c := New(Config{Issues: []connector.Issue{
+		{ID: "1", Identifier: "DD-1", State: "Backlog", Labels: []string{"needs-decision"}},
+		{ID: "2", Identifier: "DD-2", State: "Todo", Labels: []string{"SENTRY"}},
+		{ID: "3", Identifier: "DD-3", State: "Done", Labels: []string{"unrelated"}},
+	}})
+
+	got, err := c.ReadCandidates(context.Background(), connector.CandidateRequest{
+		Selector: connector.CandidateSelectorLabels,
+		Labels:   []string{"sentry", "needs-decision"},
+		Limit:    10,
+	})
+	if err != nil {
+		t.Fatalf("ReadCandidates() error = %v", err)
+	}
+	ids := []string{got.Issues[0].ID, got.Issues[1].ID}
+	if !reflect.DeepEqual(ids, []string{"1", "2"}) {
+		t.Fatalf("candidate IDs = %#v, want [1 2]", ids)
+	}
+}
+
 func timePointer(value time.Time) *time.Time {
 	return &value
 }

--- a/internal/connector/memory/memory.go
+++ b/internal/connector/memory/memory.go
@@ -102,17 +102,32 @@ func (c *Connector) ReadCandidates(_ context.Context, request connector.Candidat
 		return connector.CandidateResult{}, err
 	}
 
-	wantedStates := make(map[string]struct{}, len(request.States))
-	for _, stateName := range request.States {
-		if stateName = normalizeState(stateName); stateName != "" {
-			wantedStates[stateName] = struct{}{}
+	wanted := map[string]struct{}{}
+	values := request.States
+	if request.Selector == connector.CandidateSelectorLabels {
+		values = request.Labels
+	}
+	for _, value := range values {
+		if value = normalizeState(value); value != "" {
+			wanted[value] = struct{}{}
 		}
 	}
 
 	c.mu.RLock()
 	issues := make([]connector.Issue, 0, min(len(c.issues), request.ProbeLimit()))
 	for _, issue := range c.issues {
-		if _, ok := wantedStates[normalizeState(issue.State)]; ok {
+		matches := false
+		switch request.Selector {
+		case connector.CandidateSelectorStates:
+			_, matches = wanted[normalizeState(issue.State)]
+		case connector.CandidateSelectorLabels:
+			for _, label := range issue.Labels {
+				if _, matches = wanted[normalizeState(label)]; matches {
+					break
+				}
+			}
+		}
+		if matches {
 			issues = append(issues, cloneIssue(issue))
 		}
 	}


### PR DESCRIPTION
## Summary

- add opt-in `sources.labels` candidate selection with explicit per-tracker and per-status-source capabilities
- union and deduplicate label candidates with state candidates before applying exclusions
- reject status-prefixed selector labels and incomplete ProjectV2 label reads at config time
- skip label-only terminal and blocked candidates with recorded reasons
- document the selector and support matrix

Fixes #1554

## UI Surface Contract

- [x] N/A; this PR does not change UI surfaces, layout, density, first-viewport behavior, or responsive visibility.
- [x] This PR adds no persistent top-of-screen messaging.
- [x] This PR has no visual changes to primary operator screens.

## Test Plan

- [x] `go test ./internal/connector ./internal/connector/local ./internal/connector/memory ./internal/connector/githublocal ./internal/connector/github ./internal/config ./internal/admission`
- [x] `make check`
