### PR TITLE
feat(admission): select untracked issues

### DIFF
--- a/.detent/skills/refresh-generated-config-reference.md
+++ b/.detent/skills/refresh-generated-config-reference.md
@@ -1,0 +1,14 @@
+---
+name: refresh-generated-config-reference
+description: Keep Detent generated configuration references current after changing YAML-visible config fields, defaults, or validation.
+when_to_use: Use when a Detent config change passes local tests but fresh CI reports stale docs/config.md or config.reference.yaml.
+---
+
+# Refresh generated config references reliably
+
+- Fetch current `origin/main` before diagnosing drift; the configdoc generator may have landed after the feature branch was created.
+- Rebase a clean issue branch when CI tests a newer base that contains configdoc code absent locally.
+- Run `make generate` and review the resulting `docs/config.md` and `config.reference.yaml` diff. Do not hand-edit generated reference text.
+- Clear only Go test-result caching with `go clean -testcache` when a prior local gate passed unexpectedly. The configdoc test inspects repository config sources that may not invalidate Go's package cache.
+- Run `go test ./internal/config/configdoc`, then rerun `make check` from the top.
+- Push the refreshed head and watch CI for that exact commit SHA; ignore failures attached only to the obsolete pre-rebase head.

--- a/README.md
+++ b/README.md
@@ -1196,6 +1196,7 @@ backlog_admission:
   sources:
     states: [Backlog]
     labels: []
+    untracked: false
   target_state: Todo
   criteria_section: "Admission criteria"
   exclude_labels: []
@@ -1213,9 +1214,15 @@ State names come from the project's workflow. `sources.labels` selects issues
 carrying any configured non-status label, independent of workflow state. It
 defaults to empty and does nothing until configured. Labels beginning with
 `tracker.status_label_prefix` are rejected; workflow state selection belongs in
-`sources.states`.
+`sources.states`. `sources.untracked` defaults to `false`. In GitHub label mode,
+enabling it includes open repository issues that carry none of the configured
+status labels. This surfaces work filed directly by external automation such as
+Sentry or Dependabot even when no repository labeling action runs. It is
+unsupported for `project_v2`, `issue_field`, `github_local`, and non-GitHub
+trackers because those status models do not define the same missing-label
+condition.
 
-Admission reads each enabled selector through the candidate-reader contract.
+Admission reads every enabled selector through the candidate-reader contract.
 The tracker declares selector support, reads pages inside a hard per-run bound,
 filters the request exactly, sorts by creation time and stable issue identity
 before applying the result limit, and reports whether the source was truncated.
@@ -1272,26 +1279,31 @@ proposal as superseded with a recorded reason and does not move the issue.
 Rejection, expiry, and supersession are separate outcomes: silence can expire a
 proposal but never accepts or rejects one.
 
+An untracked issue has no status to move from. Its proposal explicitly states
+that acceptance is a two-part change: assigning the target status and admitting
+the work for dispatch.
+
 Capability is declared per tracker and per GitHub status source:
 
-| Tracker | Status source | `sources.states` | `sources.labels` |
-| --- | --- | --- | --- |
-| `github` | `project_v2` | Supported | Unsupported |
-| `github` | `issue_field` | Supported | Supported |
-| `github` | `label` | Supported | Supported |
-| `github_local` | local SQLite status | Supported | Supported |
-| `local_sqlite` | local SQLite status | Supported | Supported |
-| `memory` | process-local status | Supported | Supported |
-| `linear` | Linear workflow state | Unsupported | Unsupported |
+| Tracker | Status source | `sources.states` | `sources.labels` | `sources.untracked` |
+| --- | --- | --- | --- | --- |
+| `github` | `project_v2` | Supported | Unsupported | Unsupported |
+| `github` | `issue_field` | Supported | Supported | Unsupported |
+| `github` | `label` | Supported | Supported | Supported |
+| `github_local` | local SQLite status | Supported | Supported | Unsupported |
+| `local_sqlite` | local SQLite status | Supported | Supported | Unsupported |
+| `memory` | process-local status | Supported | Supported | Unsupported |
+| `linear` | Linear workflow state | Unsupported | Unsupported | Unsupported |
 
 An enabled admission configuration fails validation when its tracker/status
-source does not declare the selector, so Linear never validates cleanly and
-then fails on its first scheduled read. ProjectV2 label selection is unsupported
-because its issue query fetches only the first 20 labels; configuring either
-`sources.labels` or `exclude_labels` with ProjectV2 fails validation rather than
-risking a silent miss. `authors.allow` on `local_sqlite` or `memory` produces a
-doctor warning because those trackers do not discover authors. The memory
-tracker is evaluation-only across restarts: durable proposal records can
+source does not declare every enabled selector, so unsupported combinations
+never validate cleanly and then degrade to an empty first scheduled read.
+ProjectV2 label selection is unsupported because its issue query fetches only
+the first 20 labels; configuring either `sources.labels` or `exclude_labels`
+with ProjectV2 fails validation rather than risking a silent miss.
+`authors.allow` on `local_sqlite` or `memory` produces a doctor warning because
+those trackers do not discover authors. The memory tracker is evaluation-only
+across restarts: durable proposal records can
 survive while its process-local comments and mutations do not.
 
 Every lane-entry event records how the issue reached the state:

--- a/config.reference.yaml
+++ b/config.reference.yaml
@@ -14,7 +14,7 @@
 #   owner_field: null
 # # tracker | type: object | default: see child fields | required: No | validation: intake.sources[].creates.status must name a configured tracker state; retro.target_state must name a configured tracker state
 # tracker:
-#   # tracker.kind | type: string | default: none | required: Yes | validation: intake.sources requires tracker.kind github; is required; must be one of github, github_local, linear, memory, local_sqlite; release.enabled requires tracker.kind github or github_local; tracker.github_status_source must be omitted when tracker.kind is github_local; Detent stores workflow status in tracker.local_sqlite
+#   # tracker.kind | type: string | default: none | required: Yes | validation: backlog_admission.sources.untracked requires candidate selector untracked, but tracker.kind memory does not provide github label status drift; intake.sources requires tracker.kind github; is required; must be one of github, github_local, linear, memory, local_sqlite; release.enabled requires tracker.kind github or github_local; tracker.github_status_source must be omitted when tracker.kind is github_local; Detent stores workflow status in tracker.local_sqlite
 #   kind: null
 #   # tracker.endpoint | type: string | default: "https://api.linear.app/graphql" for linear; "https://api.github.com/graphql" for github or github_local; unused otherwise | required: No | validation: None
 #   endpoint: null
@@ -976,6 +976,8 @@
 #     states: []
 #     # backlog_admission.sources.labels | type: list<string> | default: [] | required: No | validation: None
 #     labels: []
+#     # backlog_admission.sources.untracked | type: boolean | default: false | required: No | validation: requires candidate selector untracked, but tracker.kind memory does not provide github label status drift
+#     untracked: false
 #   # backlog_admission.target_state | type: string | default: none | required: Conditional | validation: is required; must name a configured workflow state
 #   target_state: null
 #   # backlog_admission.criteria_section | type: string | default: none | required: Conditional | validation: is required

--- a/docs/config.md
+++ b/docs/config.md
@@ -253,6 +253,7 @@ rendering and fails on drift.
 | `backlog_admission.sources` | `object` | `see child fields` | No | must configure at least one selector |
 | `backlog_admission.sources.labels` | `list<string>` | `[]` | No | None |
 | `backlog_admission.sources.states` | `list<string>` | `[]` | No | values must differ from target_state<br>values must name a configured workflow state |
+| `backlog_admission.sources.untracked` | `boolean` | `false` | No | requires candidate selector untracked, but tracker.kind memory does not provide github label status drift |
 | `backlog_admission.target_state` | `string` | `none` | Conditional | is required<br>must name a configured workflow state |
 | `budget` | `object` | `see child fields` | No | None |
 | `budget.billing_mode` | `string` | `none` | No | must be one of metered, subscription |
@@ -578,7 +579,7 @@ rendering and fails on drift.
 | `tracker.issues[].updated_at` | `mapping` | `none` | No | None |
 | `tracker.issues[].url` | `string` | `none` | No | None |
 | `tracker.issues[].workpad_signal` | `mapping` | `none` | No | None |
-| `tracker.kind` | `string` | `none` | Yes | intake.sources requires tracker.kind github<br>is required<br>must be one of github, github_local, linear, memory, local_sqlite<br>release.enabled requires tracker.kind github or github_local<br>tracker.github_status_source must be omitted when tracker.kind is github_local; Detent stores workflow status in tracker.local_sqlite |
+| `tracker.kind` | `string` | `none` | Yes | backlog_admission.sources.untracked requires candidate selector untracked, but tracker.kind memory does not provide github label status drift<br>intake.sources requires tracker.kind github<br>is required<br>must be one of github, github_local, linear, memory, local_sqlite<br>release.enabled requires tracker.kind github or github_local<br>tracker.github_status_source must be omitted when tracker.kind is github_local; Detent stores workflow status in tracker.local_sqlite |
 | `tracker.local_sqlite` | `object` | `see child fields` | No | tracker.github_status_source must be omitted when tracker.kind is github_local; Detent stores workflow status in tracker.local_sqlite |
 | `tracker.local_sqlite.path` | `string` | `none` | Conditional | is required for local_sqlite |
 | `tracker.local_sqlite.project_id` | `string` | `none` | No | None |

--- a/internal/admission/manager.go
+++ b/internal/admission/manager.go
@@ -331,41 +331,12 @@ func (m *Manager) runOnce(ctx context.Context, settings Settings, scheduledFor t
 		runErr = errors.Join(runErr, release())
 	}()
 
-	requests := make([]connector.CandidateRequest, 0, 2)
-	if len(settings.Config.Sources.States) > 0 {
-		requests = append(requests, connector.CandidateRequest{
-			Selector: connector.CandidateSelectorStates,
-			States:   settings.Config.Sources.States,
-			Limit:    candidateReadLimit(settings.Config.MaxCandidatesPerRun),
-			PageSize: connector.DefaultCandidatePageSize,
-		})
+	candidates, readerTruncations, err := readAdmissionCandidates(ctx, settings.Issues, settings.Config)
+	if err != nil {
+		return result, fmt.Errorf("fetch backlog admission candidates: %w", err)
 	}
-	if len(settings.Config.Sources.Labels) > 0 {
-		requests = append(requests, connector.CandidateRequest{
-			Selector: connector.CandidateSelectorLabels,
-			Labels:   settings.Config.Sources.Labels,
-			Limit:    candidateReadLimit(settings.Config.MaxCandidatesPerRun),
-			PageSize: connector.DefaultCandidatePageSize,
-		})
-	}
-	candidates := []connector.Issue{}
-	seenCandidates := map[string]struct{}{}
-	for _, request := range requests {
-		candidateResult, err := settings.Issues.ReadCandidates(ctx, request)
-		if err != nil {
-			return result, fmt.Errorf("fetch backlog admission %s candidates: %w", request.Selector, err)
-		}
-		if candidateResult.Truncated {
-			result.Truncated["candidate_reader"]++
-		}
-		for _, candidate := range candidateResult.Issues {
-			key := admissionCandidateKey(candidate)
-			if _, ok := seenCandidates[key]; ok {
-				continue
-			}
-			seenCandidates[key] = struct{}{}
-			candidates = append(candidates, candidate)
-		}
+	if readerTruncations > 0 {
+		result.Truncated["candidate_reader"] += readerTruncations
 	}
 	result.CandidatesFound = len(candidates)
 	candidates = filterCandidates(candidates, settings.Config, settings.TerminalStates, result.Skipped)
@@ -443,6 +414,56 @@ func (m *Manager) runOnce(ctx context.Context, settings Settings, scheduledFor t
 
 func candidateReadLimit(maxCandidates int) int {
 	return max(maxCandidates, connector.DefaultCandidatePageSize)
+}
+
+func readAdmissionCandidates(
+	ctx context.Context,
+	issues IssueStore,
+	cfg config.BacklogAdmission,
+) ([]connector.Issue, int, error) {
+	requests := make([]connector.CandidateRequest, 0, 3)
+	if len(cfg.Sources.States) > 0 {
+		requests = append(requests, connector.CandidateRequest{
+			Selector: connector.CandidateSelectorStates,
+			States:   cfg.Sources.States,
+		})
+	}
+	if len(cfg.Sources.Labels) > 0 {
+		requests = append(requests, connector.CandidateRequest{
+			Selector: connector.CandidateSelectorLabels,
+			Labels:   cfg.Sources.Labels,
+		})
+	}
+	if cfg.Sources.Untracked {
+		requests = append(requests, connector.CandidateRequest{
+			Selector: connector.CandidateSelectorUntracked,
+		})
+	}
+
+	limit := candidateReadLimit(cfg.MaxCandidatesPerRun)
+	candidates := []connector.Issue{}
+	seen := map[string]struct{}{}
+	truncations := 0
+	for _, request := range requests {
+		request.Limit = limit
+		request.PageSize = connector.DefaultCandidatePageSize
+		result, err := issues.ReadCandidates(ctx, request)
+		if err != nil {
+			return nil, 0, fmt.Errorf("read %s selector: %w", request.Selector, err)
+		}
+		if result.Truncated {
+			truncations++
+		}
+		for _, issue := range result.Issues {
+			key := admissionCandidateKey(issue)
+			if _, ok := seen[key]; ok {
+				continue
+			}
+			seen[key] = struct{}{}
+			candidates = append(candidates, issue)
+		}
+	}
+	return candidates, truncations, nil
 }
 
 func (m *Manager) reconcileOpenProposals(
@@ -571,7 +592,7 @@ func (m *Manager) reconcileOpenProposals(
 				if commentsRemaining == 0 {
 					continue
 				}
-				if err := m.commentProposal(ctx, settings, proposal); err != nil {
+				if err := m.commentProposal(ctx, settings, proposal, issue); err != nil {
 					return commentsRemaining, autoAdmitsRemaining, err
 				}
 				commentsRemaining--
@@ -592,7 +613,7 @@ func (m *Manager) reconcileOpenProposals(
 			continue
 		}
 		if proposal.CommentedAt.IsZero() && commentsRemaining > 0 {
-			if err := m.commentProposal(ctx, settings, proposal); err != nil {
+			if err := m.commentProposal(ctx, settings, proposal, issue); err != nil {
 				return commentsRemaining, autoAdmitsRemaining, err
 			}
 			commentsRemaining--
@@ -717,7 +738,7 @@ func (m *Manager) executeProposals(
 		}
 		result.Proposals = append(result.Proposals, proposal)
 		if commentsRemaining > 0 {
-			if err := m.commentProposal(ctx, settings, proposal); err != nil {
+			if err := m.commentProposal(ctx, settings, proposal, current); err != nil {
 				return result, err
 			}
 			commentsRemaining--
@@ -738,11 +759,17 @@ func (m *Manager) executeProposals(
 	return result, nil
 }
 
-func (m *Manager) commentProposal(ctx context.Context, settings Settings, proposal admissionmodel.Proposal) error {
+func (m *Manager) commentProposal(
+	ctx context.Context,
+	settings Settings,
+	proposal admissionmodel.Proposal,
+	issue connector.Issue,
+) error {
+	untracked := settings.Config.Sources.Untracked && strings.TrimSpace(issue.State) == ""
 	if err := settings.Issues.CreateComment(
 		ctx,
 		proposal.IssueID,
-		proposalComment(proposal, autoAdmitProposal(settings.Config, proposal)),
+		proposalComment(proposal, autoAdmitProposal(settings.Config, proposal), untracked),
 	); err != nil {
 		return fmt.Errorf("create backlog admission audit comment: %w", err)
 	}
@@ -1046,6 +1073,9 @@ func eligibleCandidate(issue connector.Issue, cfg config.BacklogAdmission, termi
 	if strings.EqualFold(strings.TrimSpace(issue.State), strings.TrimSpace(cfg.TargetState)) {
 		return false
 	}
+	if cfg.Sources.Untracked && strings.TrimSpace(issue.State) == "" {
+		return true
+	}
 	if containsFold(cfg.Sources.States, issue.State) {
 		return true
 	}
@@ -1182,7 +1212,7 @@ func proposalID(projectID string, issueID string, fingerprint string, at time.Ti
 	return "admission-" + hex.EncodeToString(sum[:12])
 }
 
-func proposalComment(proposal admissionmodel.Proposal, autoAdmit bool) string {
+func proposalComment(proposal admissionmodel.Proposal, autoAdmit bool, untracked bool) string {
 	var b strings.Builder
 	b.WriteString("## Detent backlog admission proposal\n\n")
 	b.WriteString("Proposal `")
@@ -1197,6 +1227,16 @@ func proposalComment(proposal admissionmodel.Proposal, autoAdmit bool) string {
 		b.WriteString("`. To reject, reply with `")
 		b.WriteString(admissionRejectCommand(proposal.ID))
 		b.WriteString("`. Leaving it unactioned will expire the proposal without counting as rejection.\n\n")
+	}
+	if untracked {
+		b.WriteString("This issue has no configured status label. ")
+		if autoAdmit {
+			b.WriteString("Automatic admission is a two-part change: assigning **")
+		} else {
+			b.WriteString("Acceptance is a two-part change: assigning **")
+		}
+		b.WriteString(proposal.TargetState)
+		b.WriteString("** status and admitting the work for dispatch.\n\n")
 	}
 	b.WriteString("Criteria section: **")
 	b.WriteString(proposal.CriteriaSection)

--- a/internal/admission/manager_test.go
+++ b/internal/admission/manager_test.go
@@ -1026,6 +1026,74 @@ func TestManagerUnionsLabelCandidatesAndSkipsIneligibleStates(t *testing.T) {
 	}
 }
 
+func TestManagerUnionsUntrackedCandidatesBeforeDeduplicationAndExclusions(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 7, 29, 12, 0, 0, 0, time.UTC)
+	tracked := admissionIssueFixture("tracked", "DD-1", 1, now)
+	duplicate := tracked
+	duplicate.State = ""
+	untracked := admissionIssueFixture("untracked", "DD-2", 2, now.Add(time.Minute))
+	untracked.State = ""
+	excluded := admissionIssueFixture("excluded", "DD-3", 3, now.Add(2*time.Minute))
+	excluded.State = ""
+	excluded.Labels = []string{"do-not-admit"}
+	tracker := memory.New(memory.Config{
+		Issues:   []connector.Issue{tracked, untracked, excluded},
+		Stateful: true,
+		Now:      func() time.Time { return now },
+	})
+	issues := &selectorAdmissionIssueStore{
+		IssueStore: tracker,
+		results: map[connector.CandidateSelector]connector.CandidateResult{
+			connector.CandidateSelectorStates: {
+				Issues: []connector.Issue{tracked},
+			},
+			connector.CandidateSelectorUntracked: {
+				Issues:    []connector.Issue{duplicate, untracked, excluded},
+				Truncated: true,
+			},
+		},
+	}
+	backend := openManagerTestStore(t)
+	agent := &scriptedAdmissionRunner{propose: proposeEveryCandidate}
+	settings := admissionTestSettings(issues, agent)
+	settings.Config.Sources.Untracked = true
+	settings.Config.ExcludeLabels = []string{"do-not-admit"}
+	manager := newAdmissionTestManager(t, settings, backend, func() time.Time { return now })
+
+	result, err := manager.RunOnce(context.Background())
+	if err != nil {
+		t.Fatalf("RunOnce() error = %v", err)
+	}
+	if result.CandidatesFound != 3 || result.Candidates != 2 || len(result.Proposals) != 2 {
+		t.Fatalf("result = %#v, want three union candidates and two proposals", result)
+	}
+	if result.Skipped["excluded_label"] != 1 || result.Truncated["candidate_reader"] != 1 {
+		t.Fatalf("result filters and truncation = %#v", result)
+	}
+	if len(issues.requests) != 2 ||
+		issues.requests[0].Selector != connector.CandidateSelectorStates ||
+		issues.requests[1].Selector != connector.CandidateSelectorUntracked {
+		t.Fatalf("candidate requests = %#v, want states then untracked", issues.requests)
+	}
+
+	comments := map[string]string{}
+	for _, event := range tracker.Events() {
+		if event.Kind == memory.EventKindComment {
+			comments[event.IssueID] = event.Body
+		}
+	}
+	if strings.Contains(comments["tracked"], "Acceptance is a two-part change") {
+		t.Fatalf("tracked proposal used untracked wording: %s", comments["tracked"])
+	}
+	for _, want := range []string{"no configured status label", "Acceptance is a two-part change", "admitting the work for dispatch"} {
+		if !strings.Contains(comments["untracked"], want) {
+			t.Fatalf("untracked proposal missing %q: %s", want, comments["untracked"])
+		}
+	}
+}
+
 func TestManagerLocalSQLiteStatesOnlyEndToEnd(t *testing.T) {
 	t.Parallel()
 
@@ -1157,6 +1225,20 @@ type scriptedAdmissionRunner struct {
 	propose      func(runner.RunRequest) []AgentProposal
 	calls        int
 	candidateIDs [][]string
+}
+
+type selectorAdmissionIssueStore struct {
+	IssueStore
+	results  map[connector.CandidateSelector]connector.CandidateResult
+	requests []connector.CandidateRequest
+}
+
+func (s *selectorAdmissionIssueStore) ReadCandidates(
+	_ context.Context,
+	request connector.CandidateRequest,
+) (connector.CandidateResult, error) {
+	s.requests = append(s.requests, request)
+	return s.results[request.Selector], nil
 }
 
 func (r *scriptedAdmissionRunner) Run(ctx context.Context, request runner.RunRequest) (runner.RunResult, error) {
@@ -1396,7 +1478,7 @@ func TestProposalCommentQuotesCriteriaAndDoesNotUseStatusLabel(t *testing.T) {
 		Confidence: 0.8,
 		ExpiresAt:  time.Date(2026, 8, 5, 12, 0, 0, 0, time.UTC),
 	}
-	comment := proposalComment(proposal, false)
+	comment := proposalComment(proposal, false, false)
 	for _, want := range []string{"serves a stated current priority", "have Detent move the issue", "admission-1"} {
 		if !strings.Contains(comment, want) {
 			t.Fatalf("proposalComment() missing %q: %s", want, comment)
@@ -1407,5 +1489,11 @@ func TestProposalCommentQuotesCriteriaAndDoesNotUseStatusLabel(t *testing.T) {
 	}
 	if strings.Contains(comment, "detent:admission") {
 		t.Fatalf("proposalComment() introduced a status-prefixed label: %s", comment)
+	}
+	untrackedComment := proposalComment(proposal, false, true)
+	for _, want := range []string{"no configured status label", "Acceptance is a two-part change", "assigning **Todo** status", "admitting the work for dispatch"} {
+		if !strings.Contains(untrackedComment, want) {
+			t.Fatalf("proposalComment(untracked) missing %q: %s", want, untrackedComment)
+		}
 	}
 }

--- a/internal/config/admission.go
+++ b/internal/config/admission.go
@@ -39,8 +39,9 @@ type BacklogAdmission struct {
 }
 
 type BacklogAdmissionSources struct {
-	States []string `yaml:"states"`
-	Labels []string `yaml:"labels,omitempty"`
+	States    []string `yaml:"states"`
+	Labels    []string `yaml:"labels,omitempty"`
+	Untracked bool     `yaml:"untracked,omitempty"`
 }
 
 type BacklogAdmissionAuthors struct {
@@ -86,7 +87,7 @@ func (a BacklogAdmission) Validate(prefix string, states []string, tracker Track
 	if _, err := cron.ParseStandard(a.Schedule); err != nil {
 		problems = append(problems, prefix+".schedule must be a valid five-field cron expression")
 	}
-	if len(a.Sources.States) == 0 && len(a.Sources.Labels) == 0 {
+	if len(a.Sources.States) == 0 && len(a.Sources.Labels) == 0 && !a.Sources.Untracked {
 		problems = append(problems, prefix+".sources must configure at least one selector")
 	}
 	known := make(map[string]string, len(states))
@@ -153,6 +154,19 @@ func (a BacklogAdmission) Validate(prefix string, states []string, tracker Track
 	}
 	if len(a.ExcludeLabels) > 0 && tracker.Kind == TrackerGitHub && tracker.GitHubStatusSource == GitHubStatusSourceProjectV2 {
 		problems = append(problems, prefix+".exclude_labels requires complete issue labels, but tracker.kind github with github_status_source project_v2 fetches only the first 20 labels")
+	}
+	if a.Sources.Untracked && !capabilities.Supports(connector.CandidateSelectorUntracked) {
+		gap := prefix + ".sources.untracked requires candidate selector untracked, but tracker.kind " + tracker.Kind
+		switch tracker.Kind {
+		case TrackerGitHub:
+			gap += " with github_status_source " + tracker.GitHubStatusSource +
+				" cannot serve it because untracked issues are only defined for github label status"
+		case TrackerGitHubLocal:
+			gap += " cannot serve it because github_local status drift does not populate UntrackedOpen"
+		default:
+			gap += " does not provide github label status drift"
+		}
+		problems = append(problems, gap)
 	}
 	return problems
 }

--- a/internal/config/admission_test.go
+++ b/internal/config/admission_test.go
@@ -19,6 +19,7 @@ backlog_admission:
   sources:
     states: [Backlog]
     labels: [Sentry, sentry]
+    untracked: false
   target_state: Todo
   criteria_section: Admission criteria
   exclude_labels: [Skip, skip]
@@ -48,7 +49,7 @@ backlog_admission:
 	if !got.Enabled || got.Schedule != "15 4 * * 1" || got.TargetState != "Todo" ||
 		got.MaxCandidatesPerRun != 20 || got.MaxProposalsPerRun != 2 ||
 		got.MaxOpenProposals != 8 || got.ProposalExpiryDays != 5 ||
-		!got.AutoAdmit || got.AutoAdmitMinConfidence != 0.95 {
+		!got.AutoAdmit || got.AutoAdmitMinConfidence != 0.95 || got.Sources.Untracked {
 		t.Fatalf("BacklogAdmission = %#v", got)
 	}
 	if len(got.Sources.Labels) != 1 || got.Sources.Labels[0] != "sentry" ||
@@ -218,6 +219,75 @@ func TestBacklogAdmissionAutoAdmitDefaultsOff(t *testing.T) {
 			cfg.AutoAdmitMinConfidence,
 			DefaultBacklogAdmissionAutoAdmitMinConfidence,
 		)
+	}
+}
+
+func TestBacklogAdmissionValidateUntrackedSelector(t *testing.T) {
+	t.Parallel()
+
+	valid := BacklogAdmission{
+		Enabled:             true,
+		Schedule:            "0 6 * * 1-5",
+		Sources:             BacklogAdmissionSources{Untracked: true},
+		TargetState:         "Todo",
+		CriteriaSection:     "Admission criteria",
+		MaxCandidatesPerRun: 50,
+		MaxProposalsPerRun:  3,
+		MaxOpenProposals:    10,
+		ProposalExpiryDays:  7,
+	}
+	states := []string{"Backlog", "Todo", "Done"}
+	tests := []struct {
+		name    string
+		tracker Tracker
+		want    string
+	}{
+		{
+			name:    "github label",
+			tracker: Tracker{Kind: TrackerGitHub, GitHubStatusSource: GitHubStatusSourceLabel},
+		},
+		{
+			name:    "github issue field",
+			tracker: Tracker{Kind: TrackerGitHub, GitHubStatusSource: GitHubStatusSourceIssueField},
+			want:    "untracked issues are only defined for github label status",
+		},
+		{
+			name:    "github project v2",
+			tracker: Tracker{Kind: TrackerGitHub, GitHubStatusSource: GitHubStatusSourceProjectV2},
+			want:    "untracked issues are only defined for github label status",
+		},
+		{
+			name:    "github local",
+			tracker: Tracker{Kind: TrackerGitHubLocal},
+			want:    "github_local status drift does not populate UntrackedOpen",
+		},
+		{
+			name:    "linear",
+			tracker: Tracker{Kind: TrackerLinear},
+			want:    "does not provide github label status drift",
+		},
+		{
+			name:    "memory",
+			tracker: Tracker{Kind: TrackerMemory},
+			want:    "does not provide github label status drift",
+		},
+		{
+			name:    "local sqlite",
+			tracker: Tracker{Kind: TrackerLocalSQLite},
+			want:    "does not provide github label status drift",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := strings.Join(valid.Validate("backlog_admission", states, tt.tracker), "; ")
+			if tt.want == "" && got != "" {
+				t.Fatalf("Validate() = %q, want no problems", got)
+			}
+			if tt.want != "" && !strings.Contains(got, tt.want) {
+				t.Fatalf("Validate() = %q, want %q", got, tt.want)
+			}
+		})
 	}
 }
 

--- a/internal/connector/candidate.go
+++ b/internal/connector/candidate.go
@@ -18,8 +18,9 @@ var (
 type CandidateSelector string
 
 const (
-	CandidateSelectorStates CandidateSelector = "states"
-	CandidateSelectorLabels CandidateSelector = "labels"
+	CandidateSelectorStates    CandidateSelector = "states"
+	CandidateSelectorLabels    CandidateSelector = "labels"
+	CandidateSelectorUntracked CandidateSelector = "untracked"
 )
 
 type CandidateCapabilities struct {
@@ -41,7 +42,13 @@ func CandidateCapabilitiesFor(backend Backend, statusSource string) CandidateCap
 		switch strings.ToLower(strings.TrimSpace(statusSource)) {
 		case "", "project_v2":
 			return statesCandidateCapabilities()
-		case "issue_field", "label":
+		case "label":
+			return CandidateCapabilities{Selectors: []CandidateSelector{
+				CandidateSelectorStates,
+				CandidateSelectorLabels,
+				CandidateSelectorUntracked,
+			}}
+		case "issue_field":
 			return statesAndLabelsCandidateCapabilities()
 		default:
 			return CandidateCapabilities{}
@@ -80,6 +87,7 @@ func (r CandidateRequest) Validate(capabilities CandidateCapabilities) error {
 		if len(normalizedCandidateLabels(r.Labels)) == 0 {
 			return fmt.Errorf("%w: labels selector requires at least one label", ErrInvalidCandidateRequest)
 		}
+	case CandidateSelectorUntracked:
 	default:
 		return fmt.Errorf("%w: %s", ErrCandidateSelectorUnsupported, r.Selector)
 	}

--- a/internal/connector/candidate_test.go
+++ b/internal/connector/candidate_test.go
@@ -16,10 +16,11 @@ func TestCandidateCapabilitiesFor(t *testing.T) {
 		statusSource string
 		states       bool
 		labels       bool
+		untracked    bool
 	}{
 		{name: "github project v2", backend: BackendGitHub, statusSource: "project_v2", states: true},
 		{name: "github issue field", backend: BackendGitHub, statusSource: "issue_field", states: true, labels: true},
-		{name: "github label", backend: BackendGitHub, statusSource: "label", states: true, labels: true},
+		{name: "github label", backend: BackendGitHub, statusSource: "label", states: true, labels: true, untracked: true},
 		{name: "github default", backend: BackendGitHub, states: true},
 		{name: "github invalid source", backend: BackendGitHub, statusSource: "milestone"},
 		{name: "github local", backend: BackendGitHubLocal, states: true, labels: true},
@@ -39,6 +40,9 @@ func TestCandidateCapabilitiesFor(t *testing.T) {
 			if got := capabilities.Supports(CandidateSelectorLabels); got != test.labels {
 				t.Fatalf("Supports(labels) = %t, want %t", got, test.labels)
 			}
+			if got := capabilities.Supports(CandidateSelectorUntracked); got != test.untracked {
+				t.Fatalf("Supports(untracked) = %t, want %t", got, test.untracked)
+			}
 		})
 	}
 }
@@ -46,7 +50,7 @@ func TestCandidateCapabilitiesFor(t *testing.T) {
 func TestCandidateRequestValidate(t *testing.T) {
 	t.Parallel()
 
-	capabilities := CandidateCapabilitiesFor(BackendMemory, "")
+	capabilities := CandidateCapabilitiesFor(BackendGitHub, "label")
 	tests := []struct {
 		name    string
 		request CandidateRequest
@@ -65,6 +69,13 @@ func TestCandidateRequestValidate(t *testing.T) {
 			request: CandidateRequest{
 				Selector: CandidateSelectorLabels,
 				Labels:   []string{" Sentry ", "sentry"},
+				Limit:    10,
+			},
+		},
+		{
+			name: "valid untracked selector",
+			request: CandidateRequest{
+				Selector: CandidateSelectorUntracked,
 				Limit:    10,
 			},
 		},

--- a/internal/connector/github/candidate.go
+++ b/internal/connector/github/candidate.go
@@ -30,6 +30,14 @@ func (c *Connector) ReadCandidates(ctx context.Context, request connector.Candid
 	switch request.Selector {
 	case connector.CandidateSelectorLabels:
 		issues, pagesRead, incomplete, err = c.readRepositoryLabelCandidates(ctx, request)
+	case connector.CandidateSelectorUntracked:
+		var drift connector.StatusDrift
+		drift, pagesRead, incomplete, err = c.readLabelStatusDrift(ctx, labelStatusDriftReadOptions{
+			PageSize:      request.EffectivePageSize(),
+			Limit:         request.ProbeLimit(),
+			Deterministic: true,
+		})
+		issues = drift.UntrackedOpen
 	case connector.CandidateSelectorStates:
 		switch {
 		case c.usesLabelStatus():

--- a/internal/connector/github/candidate_test.go
+++ b/internal/connector/github/candidate_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"net/http"
 	"reflect"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -112,6 +113,82 @@ func TestConnectorReadLabelCandidatesFiltersConflictedStateLocally(t *testing.T)
 	}
 	if len(got.Issues) != 0 || got.Truncated {
 		t.Fatalf("result = %#v, want honestly filtered complete result", got)
+	}
+}
+
+func TestConnectorReadUntrackedCandidatesSelectsLabelStatusDrift(t *testing.T) {
+	t.Parallel()
+
+	server := newGraphQLTestServer(t, []graphqlTestResponse{{
+		method: http.MethodGet,
+		body: `[
+			{"node_id":"I_1","number":1,"title":"External alert","state":"open","html_url":"https://github.com/digitaldrywood/detent/issues/1","labels":[{"name":"sentry"}]},
+			{"node_id":"I_2","number":2,"title":"Tracked work","state":"open","html_url":"https://github.com/digitaldrywood/detent/issues/2","labels":[{"name":"detent:backlog"}]}
+		]`,
+	}})
+	c := newGitHubTestConnector(t, server, Config{
+		GitHubStatusSource: GitHubStatusSourceLabel,
+		Repository:         "digitaldrywood/detent",
+		ObservedStates:     []string{"Backlog"},
+		ActiveStates:       []string{"Todo"},
+	})
+
+	got, err := c.ReadCandidates(context.Background(), connector.CandidateRequest{
+		Selector: connector.CandidateSelectorUntracked,
+		Limit:    10,
+		PageSize: 10,
+	})
+	if err != nil {
+		t.Fatalf("ReadCandidates() error = %v", err)
+	}
+	if ids := githubIssueIDs(got.Issues); !reflect.DeepEqual(ids, []string{"I_1"}) {
+		t.Fatalf("candidate IDs = %#v, want [I_1]", ids)
+	}
+	if got.Truncated || got.PagesRead != 1 || got.Issues[0].State != "" {
+		t.Fatalf("result = %#v, want one complete untracked candidate", got)
+	}
+}
+
+func TestConnectorReadUntrackedCandidatesBoundsDeterministicPaging(t *testing.T) {
+	t.Parallel()
+
+	server := newGraphQLTestServer(t, []graphqlTestResponse{
+		{
+			method: http.MethodGet,
+			body:   `[{"node_id":"I_2","number":2,"title":"Second","state":"open","html_url":"https://github.com/digitaldrywood/detent/issues/2","created_at":"2026-01-02T00:00:00Z","labels":[]}]`,
+		},
+		{
+			method: http.MethodGet,
+			body:   `[{"node_id":"I_1","number":1,"title":"First","state":"open","html_url":"https://github.com/digitaldrywood/detent/issues/1","created_at":"2026-01-01T00:00:00Z","labels":[]}]`,
+		},
+	})
+	c := newGitHubTestConnector(t, server, Config{
+		GitHubStatusSource: GitHubStatusSourceLabel,
+		Repository:         "digitaldrywood/detent",
+		ObservedStates:     []string{"Backlog"},
+	})
+
+	got, err := c.ReadCandidates(context.Background(), connector.CandidateRequest{
+		Selector: connector.CandidateSelectorUntracked,
+		Limit:    1,
+		PageSize: 1,
+	})
+	if err != nil {
+		t.Fatalf("ReadCandidates() error = %v", err)
+	}
+	if ids := githubIssueIDs(got.Issues); !reflect.DeepEqual(ids, []string{"I_1"}) {
+		t.Fatalf("candidate IDs = %#v, want [I_1]", ids)
+	}
+	if !got.Truncated || got.PagesRead != 2 {
+		t.Fatalf("result = %#v, want bounded two-page truncation", got)
+	}
+	for index, request := range server.requests() {
+		path := request["path"].(string)
+		for _, want := range []string{"direction=asc", "sort=created", "page=" + strconv.Itoa(index+1), "per_page=1"} {
+			if !strings.Contains(path, want) {
+				t.Fatalf("request %d path = %q, missing %q", index, path, want)
+			}
+		}
 	}
 }
 

--- a/internal/connector/github/issue_read.go
+++ b/internal/connector/github/issue_read.go
@@ -769,7 +769,7 @@ func (c *Connector) FetchIssueStatesByIDs(ctx context.Context, issueIDs []string
 				return nil, fmt.Errorf("fetch github issue states by ids: %w", err)
 			}
 			if ok {
-				issues = append(issues, issue)
+				issues = append(issues, c.normalizeLabelIssueStateRead(issue))
 			}
 		}
 		sortIssuesByRequestedIDs(issues, ids)

--- a/internal/connector/github/statuslabel.go
+++ b/internal/connector/github/statuslabel.go
@@ -23,6 +23,12 @@ type labelStatusResolution struct {
 	ConflictLabels []string
 }
 
+type labelStatusDriftReadOptions struct {
+	PageSize      int
+	Limit         int
+	Deterministic bool
+}
+
 func (r labelStatusResolution) conflicted() bool {
 	return len(r.ConflictLabels) > 1
 }
@@ -89,23 +95,48 @@ func (c *Connector) fetchLabelIssuesByStates(ctx context.Context, stateNames []s
 }
 
 func (c *Connector) FetchStatusDrift(ctx context.Context) (connector.StatusDrift, error) {
+	drift, _, _, err := c.readLabelStatusDrift(ctx, labelStatusDriftReadOptions{
+		PageSize: repositoryIssuesPageSize,
+	})
+	return drift, err
+}
+
+func (c *Connector) readLabelStatusDrift(
+	ctx context.Context,
+	options labelStatusDriftReadOptions,
+) (connector.StatusDrift, int, bool, error) {
 	if !c.usesLabelStatus() {
-		return connector.StatusDrift{}, nil
+		return connector.StatusDrift{}, 0, false, nil
 	}
 	if !validPullRequestRepo(c.repository) {
-		return connector.StatusDrift{}, ErrMissingRepository
+		return connector.StatusDrift{}, 0, false, ErrMissingRepository
 	}
 
+	pageSize := min(max(options.PageSize, 1), repositoryIssuesPageSize)
+	if options.Limit > 0 {
+		pageSize = min(pageSize, options.Limit)
+	}
 	drift := connector.StatusDrift{}
+	pagesRead := 0
+	itemsRead := 0
 	for page := 1; ; page++ {
+		if options.Limit > 0 && itemsRead >= options.Limit {
+			return drift, pagesRead, true, nil
+		}
 		var response []restIssue
-		if err := c.client.REST(ctx, http.MethodGet, restRepositoryOpenIssuesPath(c.repository, page), nil, &response); err != nil {
-			return connector.StatusDrift{}, fmt.Errorf("fetch github label status drift: %w", err)
+		path := restRepositoryOpenIssuesPagePath(c.repository, page, pageSize, options.Deterministic)
+		if err := c.client.REST(ctx, http.MethodGet, path, nil, &response); err != nil {
+			return connector.StatusDrift{}, 0, false, fmt.Errorf("fetch github label status drift: %w", err)
 		}
-		if len(response) == 0 {
-			break
+		pagesRead++
+		pageItems := response
+		if options.Limit > 0 {
+			if remaining := options.Limit - itemsRead; len(pageItems) > remaining {
+				pageItems = pageItems[:remaining]
+			}
 		}
-		for _, item := range response {
+		itemsRead += len(pageItems)
+		for _, item := range pageItems {
 			if item.PullRequest != nil {
 				continue
 			}
@@ -122,11 +153,16 @@ func (c *Connector) FetchStatusDrift(ctx context.Context) (connector.StatusDrift
 				drift.OpenTerminal = append(drift.OpenTerminal, c.buildLabelIssue(issue, terminalStatus))
 			}
 		}
-		if len(response) < repositoryIssuesPageSize {
-			break
+		if len(pageItems) < len(response) {
+			return drift, pagesRead, true, nil
+		}
+		if len(response) < pageSize {
+			return drift, pagesRead, false, nil
+		}
+		if options.Limit > 0 && itemsRead >= options.Limit {
+			return drift, pagesRead, true, nil
 		}
 	}
-	return drift, nil
 }
 
 func (c *Connector) fetchLabelIssueByRef(ctx context.Context, ref issueRef) (connector.Issue, bool, error) {
@@ -139,6 +175,17 @@ func (c *Connector) fetchLabelIssueByRef(ctx context.Context, ref issueRef) (con
 	}
 	c.cacheIssueRef(issue)
 	return c.buildLabelIssue(issue, c.githubIssueStateToDetentState(issue.State)), true, nil
+}
+
+func (c *Connector) normalizeLabelIssueStateRead(issue connector.Issue) connector.Issue {
+	if issue.Closed || c.hasConfiguredStatusLabelNames(issue.Labels) {
+		return issue
+	}
+	issue.State = ""
+	if issue.Fields != nil {
+		issue.Fields[c.statusField] = ""
+	}
+	return issue
 }
 
 func (c *Connector) IssueStateTransition(ctx context.Context, issue connector.Issue) (connector.IssueStateTransition, bool, error) {
@@ -379,6 +426,11 @@ func (c *Connector) hasConfiguredStatusLabel(labels nodeConnection[label]) bool 
 	return resolution.Status != "" || len(resolution.ConflictLabels) > 0
 }
 
+func (c *Connector) hasConfiguredStatusLabelNames(labels []string) bool {
+	resolution := c.labelStatusResolutionFromNames(labels)
+	return resolution.Status != "" || len(resolution.ConflictLabels) > 0
+}
+
 func (c *Connector) terminalStatusFromLabels(labels nodeConnection[label]) string {
 	statesByLabel := c.statusLabelStates(c.terminalStates)
 	for _, labelName := range labelNames(labels) {
@@ -569,10 +621,14 @@ func restRepositoryIssuesByLabelPagePath(repo pullRequestRepo, labelName string,
 	return "/repos/" + url.PathEscape(repo.Owner) + "/" + url.PathEscape(repo.Name) + "/issues?" + values.Encode()
 }
 
-func restRepositoryOpenIssuesPath(repo pullRequestRepo, page int) string {
+func restRepositoryOpenIssuesPagePath(repo pullRequestRepo, page int, pageSize int, deterministic bool) string {
 	values := url.Values{}
 	values.Set("state", "open")
-	values.Set("per_page", strconv.Itoa(repositoryIssuesPageSize))
+	if deterministic {
+		values.Set("sort", "created")
+		values.Set("direction", "asc")
+	}
+	values.Set("per_page", strconv.Itoa(pageSize))
 	values.Set("page", strconv.Itoa(page))
 	return "/repos/" + url.PathEscape(repo.Owner) + "/" + url.PathEscape(repo.Name) + "/issues?" + values.Encode()
 }

--- a/internal/connector/github/statuslabel_test.go
+++ b/internal/connector/github/statuslabel_test.go
@@ -461,6 +461,44 @@ func TestConnectorFetchLabelIssueStateByIDMapsClosedCompletedToDone(t *testing.T
 	}
 }
 
+func TestConnectorFetchLabelIssueStateByIDPreservesUntrackedOpenState(t *testing.T) {
+	t.Parallel()
+
+	server := newGraphQLTestServer(t, []graphqlTestResponse{
+		{
+			body: `{"data":{"nodes":[{"__typename":"Issue","id":"I_771","number":771,"repository":{"nameWithOwner":"digitaldrywood/detent"}}]}}`,
+		},
+		{
+			method: http.MethodGet,
+			path:   "/repos/digitaldrywood/detent/issues/771",
+			body:   `{"node_id":"I_771","number":771,"title":"External alert","body":"","state":"open","html_url":"https://github.com/digitaldrywood/detent/issues/771","assignees":[],"labels":[{"name":"sentry"}]}`,
+		},
+		{
+			status: http.StatusNotFound,
+			method: http.MethodGet,
+			path:   "/repos/digitaldrywood/detent/issues/771/dependencies/blocked_by?per_page=100",
+			body:   `{"message":"not found"}`,
+		},
+	})
+	c := newGitHubTestConnector(t, server, Config{
+		GitHubStatusSource: GitHubStatusSourceLabel,
+		Repository:         "digitaldrywood/detent",
+		ObservedStates:     []string{"Backlog"},
+		ActiveStates:       []string{"Todo"},
+	})
+
+	got, err := c.FetchIssueStatesByIDs(context.Background(), []string{"I_771"})
+	if err != nil {
+		t.Fatalf("FetchIssueStatesByIDs() error = %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("FetchIssueStatesByIDs() len = %d, want 1", len(got))
+	}
+	if got[0].State != "" || got[0].Closed {
+		t.Fatalf("issue = %#v, want open issue with blank state", got[0])
+	}
+}
+
 func TestConnectorUpdateIssueStateReplacesStatusLabels(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

- add `sources.untracked` for bounded GitHub label-mode admission reads
- union and deduplicate enabled selectors before exclusions, with truncation recorded in the run ledger
- reject unsupported tracker/status-source combinations and disclose the two-part status assignment in untracked proposals

Fixes #1553

## UI Surface Contract

- [x] N/A; this change does not alter UI surface, layout, density, first-viewport, or responsive visibility.
- [x] This PR does not add persistent top-of-screen messaging.
- [x] N/A; this PR has no visual changes to primary operator screens.

## Test Plan

- [x] `go test ./internal/connector ./internal/connector/github ./internal/config ./internal/admission`
- [x] `go test -race ./internal/connector/github ./internal/admission`
- [x] `make generate`
- [x] `go clean -testcache && make check`