### PR TITLE
fix(orchestrator): recover blocked causes

### DIFF
--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -54,6 +54,7 @@ type doctorCheck struct {
 	WorkflowSkillSuggestions  []doctorWorkflowSkillSuggestion            `json:"workflow_skill_suggestions,omitempty"`
 	AutoPromoteCandidates     []doctorAutoPromoteCandidateDiagnostic     `json:"auto_promote_candidates,omitempty"`
 	BlockedRecoveryCandidates []doctorBlockedRecoveryCandidateDiagnostic `json:"blocked_recovery_candidates,omitempty"`
+	BlockedWithoutRecovery    []doctorBlockedRecoveryCandidateDiagnostic `json:"blocked_without_recovery,omitempty"`
 	BackendCapacity           []doctorBackendCapacityDiagnostic          `json:"backend_capacity,omitempty"`
 	ArtifactGateConvergence   []doctorArtifactGateConvergenceDiagnostic  `json:"artifact_gate_convergence,omitempty"`
 	ValidatorFailures         []doctorValidatorFailureDiagnostic         `json:"validator_failures,omitempty"`

--- a/internal/cli/doctor_backend_capacity_test.go
+++ b/internal/cli/doctor_backend_capacity_test.go
@@ -156,7 +156,7 @@ func TestDoctorBlockedRecoveryReportsCapacityParkedIssues(t *testing.T) {
 		Codex: workflowconfig.Codex{ModelProvider: "openai"},
 	}
 
-	check := checkDoctorBlockedRecoveryLive(t.Context(), "Project detent blocked recovery", reader, cfg, now)
+	check := checkDoctorBlockedRecoveryLive(t.Context(), "Project detent blocked recovery", reader, cfg, now, nil)
 	if check.Status != doctorWarn || len(check.BackendCapacity) != 1 {
 		t.Fatalf("check = %#v, want capacity warning", check)
 	}

--- a/internal/cli/doctor_dependency.go
+++ b/internal/cli/doctor_dependency.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"context"
+	"database/sql"
 	"errors"
 	"fmt"
 	"regexp"
@@ -16,6 +17,7 @@ import (
 	"github.com/digitaldrywood/detent/internal/connector"
 	"github.com/digitaldrywood/detent/internal/dependencyline"
 	"github.com/digitaldrywood/detent/internal/orchestrator"
+	"github.com/digitaldrywood/detent/internal/workpad"
 )
 
 var (
@@ -25,7 +27,6 @@ var (
 
 const (
 	doctorDependencyAutoUnblockSampleLimit = 5
-	doctorBlockedRecoverySampleLimit       = 5
 )
 
 type doctorBlockedRecoveryCandidateDiagnostic struct {
@@ -60,15 +61,8 @@ type doctorDependencyDiagnostic struct {
 	References []string
 }
 
-func checkDoctorBlockedRecovery(ctx context.Context, id string, cfg workflowconfig.Config, deps doctorDeps) doctorCheck {
+func checkDoctorBlockedRecovery(ctx context.Context, id string, cfg workflowconfig.Config, storePath string, deps doctorDeps) doctorCheck {
 	name := "Project " + id + " blocked recovery"
-	if !cfg.Tracker.BlockedRecovery.Enabled {
-		return doctorCheck{
-			Name:   name,
-			Status: doctorOK,
-			Detail: "tracker.blocked_recovery.enabled=false",
-		}
-	}
 	if !doctorTrackerUsesGitHubReads(cfg.Tracker.Kind) {
 		return doctorCheck{
 			Name:   name,
@@ -77,9 +71,7 @@ func checkDoctorBlockedRecovery(ctx context.Context, id string, cfg workflowconf
 		}
 	}
 
-	if deps.autoPromoteConnector == nil {
-		deps.autoPromoteConnector = defaultDoctorAutoPromoteConnector
-	}
+	deps = deps.withDefaults()
 	projectConnector, err := deps.autoPromoteConnector(cfg)
 	if err != nil {
 		return doctorCheck{
@@ -98,7 +90,25 @@ func checkDoctorBlockedRecovery(ctx context.Context, id string, cfg workflowconf
 		}
 	}
 
-	check := checkDoctorBlockedRecoveryLive(ctx, name, projectConnector, cfg, time.Now())
+	var timelineStore doctorTelemetryStore
+	timelineDetail := ""
+	if strings.TrimSpace(storePath) != "" {
+		timelineStore, err = deps.openSQLiteReadOnly(ctx, storePath)
+		if err != nil {
+			timelineDetail = "durable recovery metadata unavailable: " + err.Error()
+		}
+	}
+
+	check := checkDoctorBlockedRecoveryLive(ctx, name, projectConnector, cfg, time.Now(), timelineStore)
+	if timelineDetail != "" {
+		check.Detail += "; " + timelineDetail
+	}
+	if timelineStore != nil {
+		if err := timelineStore.Close(); err != nil && check.Status != doctorFail {
+			check.Status = doctorWarn
+			check.Detail += "; recovery metadata store close failed: " + err.Error()
+		}
+	}
 	if err := closeDoctorAutoPromoteConnector(projectConnector); err != nil && check.Status != doctorFail {
 		check.Status = doctorWarn
 		check.Detail = check.Detail + "; connector close failed: " + err.Error()
@@ -113,6 +123,7 @@ func checkDoctorBlockedRecoveryLive(
 	projectConnector doctorAutoPromoteConnector,
 	cfg workflowconfig.Config,
 	now time.Time,
+	timelineStore doctorTelemetryStore,
 ) doctorCheck {
 	recoveryConfig := orchestrator.BlockedRecoveryConfig{
 		Enabled:      cfg.Tracker.BlockedRecovery.Enabled,
@@ -123,6 +134,9 @@ func checkDoctorBlockedRecoveryLive(
 	sourceStates := recoveryConfig.SourceStates
 	if len(sourceStates) == 0 {
 		sourceStates = []string{"Blocked"}
+	}
+	if !doctorStateInList("Blocked", sourceStates) {
+		sourceStates = append([]string{"Blocked"}, sourceStates...)
 	}
 	targetState := strings.TrimSpace(recoveryConfig.TargetState)
 	if targetState == "" {
@@ -159,9 +173,24 @@ func checkDoctorBlockedRecoveryLive(
 		candidates = append(candidates, doctorBlockedRecoveryCandidateDiagnosticFromIssue(issue, decision))
 	}
 	capacity := doctorBlockedCapacityDiagnostics(ctx, projectConnector, cfg, issues, now)
+	capacityIssues := doctorParkedCapacityIssueSet(capacity)
+	withoutRecovery := []doctorBlockedRecoveryCandidateDiagnostic{}
+	for _, issue := range issues {
+		if !strings.EqualFold(strings.TrimSpace(issue.State), "Blocked") ||
+			doctorBlockedIssueHasRecoveryPredicate(ctx, issue, recoveryConfig, timelineStore, capacityIssues) {
+			continue
+		}
+		withoutRecovery = append(withoutRecovery, doctorBlockedRecoveryCandidateDiagnostic{
+			IssueID:         strings.TrimSpace(issue.ID),
+			IssueIdentifier: strings.TrimSpace(issue.Identifier),
+			IssueURL:        strings.TrimSpace(issue.URL),
+			Reason:          "no_recovery_predicate",
+			Detail:          "Blocked issue has no dependency relation, human owner, or durable recovery predicate",
+		})
+	}
 
-	detail := fmt.Sprintf("sampled %d blocked-recovery source candidate(s)", len(issues))
-	if len(candidates) == 0 && len(capacity) == 0 {
+	detail := fmt.Sprintf("scanned %d blocked-recovery source candidate(s)", len(issues))
+	if len(candidates) == 0 && len(capacity) == 0 && len(withoutRecovery) == 0 {
 		return doctorCheck{
 			Name:   name,
 			Status: doctorOK,
@@ -178,12 +207,24 @@ func checkDoctorBlockedRecoveryLive(
 			strings.Join(doctorParkedCapacityIssueLabels(capacity), ", "),
 		)
 	}
+	if len(withoutRecovery) > 0 {
+		detail += fmt.Sprintf(
+			"; %d relation-less Blocked issue(s) have no recovery predicate: %s",
+			len(withoutRecovery),
+			strings.Join(doctorBlockedRecoveryIssueLabels(withoutRecovery), ", "),
+		)
+	}
+	hint := fmt.Sprintf("PR-condition matches are diagnostic only; runtime still requires the latest durable source-lane entry reason before recovery to %s. Detent separately recovers quota-parked issues after provider capacity returns.", targetState)
+	if len(withoutRecovery) > 0 {
+		hint += " Add a native dependency, structured human_action, or durable owner and recovery predicate before parking the issue in Blocked."
+	}
 	return doctorCheck{
 		Name:                      name,
 		Status:                    doctorWarn,
 		Detail:                    detail,
-		Hint:                      fmt.Sprintf("PR-condition matches are diagnostic only; runtime still requires the latest durable source-lane entry reason before recovery to %s. Detent separately recovers quota-parked issues after provider capacity returns.", targetState),
+		Hint:                      hint,
 		BlockedRecoveryCandidates: candidates,
+		BlockedWithoutRecovery:    withoutRecovery,
 		BackendCapacity:           capacity,
 	}
 }
@@ -196,6 +237,118 @@ func doctorParkedCapacityIssueLabels(diagnostics []doctorBackendCapacityDiagnost
 				labels = append(labels, issue)
 			}
 		}
+	}
+	return labels
+}
+
+func doctorParkedCapacityIssueSet(diagnostics []doctorBackendCapacityDiagnostic) map[string]struct{} {
+	labels := doctorParkedCapacityIssueLabels(diagnostics)
+	set := make(map[string]struct{}, len(labels))
+	for _, label := range labels {
+		set[label] = struct{}{}
+	}
+	return set
+}
+
+func doctorBlockedIssueHasRecoveryPredicate(
+	ctx context.Context,
+	issue connector.Issue,
+	cfg orchestrator.BlockedRecoveryConfig,
+	timelineStore doctorTelemetryStore,
+	capacityIssues map[string]struct{},
+) bool {
+	decision := orchestrator.EvaluateBlockedRecovery(issue)
+	if decision.Reason == orchestrator.BlockedRecoveryReasonHumanBlocker ||
+		decision.Reason == orchestrator.BlockedRecoveryReasonDependencyBlocker {
+		return true
+	}
+	if signal := issue.WorkpadSignal; signal != nil {
+		if strings.TrimSpace(signal.HumanAction) != "" {
+			return true
+		}
+		if signal.Invalid == nil && signal.Source == workpad.SourceStructured && len(signal.Blockers) > 0 {
+			return true
+		}
+		if cfg.Enabled &&
+			signal.Invalid == nil &&
+			signal.Source == workpad.SourceStructured &&
+			strings.EqualFold(strings.TrimSpace(signal.Status), workpad.StatusBlocked) &&
+			doctorBlockedRecoveryReasonAllowed(signal.ReasonCode, cfg.ReasonCodes) {
+			return true
+		}
+	}
+	if _, ok := capacityIssues[doctorIssueLabel(issue)]; ok {
+		return true
+	}
+	return doctorBlockedRecoveryTimelinePredicate(ctx, timelineStore, issue)
+}
+
+func doctorBlockedRecoveryReasonAllowed(reason string, allowed []string) bool {
+	normalize := func(value string) string {
+		value = strings.ToLower(strings.TrimSpace(value))
+		value = strings.NewReplacer("-", "_", " ", "_").Replace(value)
+		if value == "merge_conflicts" {
+			return "merge_conflict"
+		}
+		return value
+	}
+	reason = normalize(reason)
+	if reason == "" {
+		return false
+	}
+	if len(allowed) == 0 {
+		allowed = []string{"merge_conflict", "stale_base", "missing_current_head_ci"}
+	}
+	for _, candidate := range allowed {
+		if normalize(candidate) == reason {
+			return true
+		}
+	}
+	return false
+}
+
+func doctorBlockedRecoveryTimelinePredicate(
+	ctx context.Context,
+	timelineStore doctorTelemetryStore,
+	issue connector.Issue,
+) bool {
+	if timelineStore == nil {
+		return false
+	}
+	var phaseName string
+	var enteredAtRaw string
+	var metadataJSON string
+	err := timelineStore.QueryRowContext(ctx, `
+SELECT phase_name, started_at, metadata_json
+FROM workflow_phase_events
+WHERE (issue_id = ? OR identifier = ? OR issue_url = ?)
+  AND phase_type = 'lane'
+  AND status = 'entered'
+ORDER BY started_at DESC, id DESC
+LIMIT 1`,
+		doctorBlockedRecoveryIdentity(issue.ID),
+		doctorBlockedRecoveryIdentity(issue.Identifier),
+		doctorBlockedRecoveryIdentity(issue.URL),
+	).Scan(&phaseName, &enteredAtRaw, &metadataJSON)
+	if err != nil {
+		return false
+	}
+	enteredAt, err := time.Parse(time.RFC3339Nano, enteredAtRaw)
+	if err != nil {
+		return false
+	}
+	return orchestrator.BlockedIssueHasCurrentRecoveryPredicate(issue, phaseName, enteredAt, metadataJSON)
+}
+
+func doctorBlockedRecoveryIdentity(value string) sql.NullString {
+	value = strings.TrimSpace(value)
+	return sql.NullString{String: value, Valid: value != ""}
+}
+
+func doctorBlockedRecoveryIssueLabels(diagnostics []doctorBlockedRecoveryCandidateDiagnostic) []string {
+	labels := make([]string, 0, len(diagnostics))
+	for _, diagnostic := range diagnostics {
+		labels = append(labels, doctorBlockedRecoveryIssueLabel(diagnostic))
 	}
 	return labels
 }
@@ -297,17 +450,7 @@ func fetchDoctorBlockedRecoveryIssues(
 	projectConnector doctorAutoPromoteConnector,
 	sourceStates []string,
 ) ([]connector.Issue, error) {
-	if limited, ok := projectConnector.(doctorAutoPromoteLimitedConnector); ok {
-		return limited.FetchIssuesByStatesLimit(ctx, sourceStates, doctorBlockedRecoverySampleLimit)
-	}
-	issues, err := projectConnector.FetchIssuesByStates(ctx, sourceStates)
-	if err != nil {
-		return nil, err
-	}
-	if len(issues) > doctorBlockedRecoverySampleLimit {
-		issues = issues[:doctorBlockedRecoverySampleLimit]
-	}
-	return issues, nil
+	return projectConnector.FetchIssuesByStates(ctx, sourceStates)
 }
 
 func doctorBlockedRecoveryCandidateDiagnosticFromIssue(

--- a/internal/cli/doctor_project.go
+++ b/internal/cli/doctor_project.go
@@ -348,7 +348,7 @@ func checkDoctorProjectWithProgress(
 		setDoctorCurrentCheck("Project " + id + " dependency auto-unblock")
 		checks = append(checks, checkDoctorDependencyAutoUnblock(ctx, id, workflow.Config, deps))
 		setDoctorCurrentCheck("Project " + id + " blocked recovery")
-		checks = append(checks, checkDoctorBlockedRecovery(ctx, id, workflow.Config, deps))
+		checks = append(checks, checkDoctorBlockedRecovery(ctx, id, workflow.Config, storePath, deps))
 	}
 	if workflow.Config.Tracker.Kind == workflowconfig.TrackerLocalSQLite || workflow.Config.Tracker.Kind == workflowconfig.TrackerGitHubLocal {
 		setDoctorCurrentCheck("Project " + id + " local SQLite tracker")

--- a/internal/cli/doctor_test.go
+++ b/internal/cli/doctor_test.go
@@ -2539,7 +2539,7 @@ func TestCheckDoctorBlockedRecovery(t *testing.T) {
 	cfg := validDoctorDependencyWorkflow(true)
 	cfg.Tracker.BlockedRecovery.Enabled = true
 
-	got := checkDoctorBlockedRecovery(context.Background(), "alpha", cfg, doctorDeps{
+	got := checkDoctorBlockedRecovery(context.Background(), "alpha", cfg, "", doctorDeps{
 		autoPromoteConnector: func(workflowconfig.Config) (doctorAutoPromoteConnector, error) {
 			return fake, nil
 		},
@@ -2558,10 +2558,13 @@ func TestCheckDoctorBlockedRecovery(t *testing.T) {
 			t.Fatalf("check missing %q:\nDetail: %s\nHint: %s", want, got.Detail, got.Hint)
 		}
 	}
-	for _, excluded := range []string{"issue-human", "issue-manual"} {
+	for _, excluded := range []string{"issue-human"} {
 		if strings.Contains(got.Detail, excluded) {
 			t.Fatalf("Detail = %q, want %q omitted from condition diagnostics", got.Detail, excluded)
 		}
+	}
+	if !strings.Contains(got.Detail, "issue-manual") || len(got.BlockedWithoutRecovery) != 1 {
+		t.Fatalf("relation-less diagnostics = %#v; detail = %q", got.BlockedWithoutRecovery, got.Detail)
 	}
 	if !stringSliceContains(fake.verifyStates, "Blocked") || !stringSliceContains(fake.verifyStates, "Rework") {
 		t.Fatalf("VerifyStatusOptions states = %#v, want Blocked and Rework", fake.verifyStates)
@@ -2594,7 +2597,7 @@ func TestCheckDoctorBlockedRecoveryUsesConfiguredStates(t *testing.T) {
 	cfg.Tracker.BlockedRecovery.SourceStates = []string{"Parked"}
 	cfg.Tracker.BlockedRecovery.TargetState = "Repair"
 
-	got := checkDoctorBlockedRecovery(context.Background(), "alpha", cfg, doctorDeps{
+	got := checkDoctorBlockedRecovery(context.Background(), "alpha", cfg, "", doctorDeps{
 		autoPromoteConnector: func(workflowconfig.Config) (doctorAutoPromoteConnector, error) {
 			return fake, nil
 		},
@@ -2610,6 +2613,104 @@ func TestCheckDoctorBlockedRecoveryUsesConfiguredStates(t *testing.T) {
 	}
 	if !stringSliceContains(fake.verifyStates, "Parked") || !stringSliceContains(fake.verifyStates, "Repair") {
 		t.Fatalf("VerifyStatusOptions states = %#v, want Parked and Repair", fake.verifyStates)
+	}
+}
+
+func TestCheckDoctorBlockedRecoveryWarnsOnlyWithoutCurrentPredicate(t *testing.T) {
+	t.Parallel()
+
+	db, err := sql.Open("sqlite", ":memory:")
+	if err != nil {
+		t.Fatalf("sql.Open() error = %v", err)
+	}
+	db.SetMaxOpenConns(1)
+	t.Cleanup(func() {
+		_ = db.Close()
+	})
+	if _, err := db.Exec(`
+CREATE TABLE workflow_phase_events (
+  id INTEGER PRIMARY KEY,
+  issue_id TEXT,
+  identifier TEXT,
+  issue_url TEXT,
+  phase_type TEXT,
+  phase_name TEXT,
+  status TEXT,
+  started_at TEXT,
+  metadata_json TEXT
+)`); err != nil {
+		t.Fatalf("CREATE TABLE error = %v", err)
+	}
+
+	currentAt := time.Date(2026, 7, 29, 19, 0, 0, 0, time.UTC)
+	current := doctorDependencyIssue("issue-current-predicate", nil)
+	current.StageUpdatedAt = &currentAt
+	stale := doctorDependencyIssue("issue-stale-predicate", nil)
+	staleAt := currentAt.Add(time.Hour)
+	stale.StageUpdatedAt = &staleAt
+	metadata := `{"blocked_recovery":{"owner":"orchestrator","cause":"no_progress_limit","predicate":"fingerprint_changed","cause_fingerprint":"fingerprint"}}`
+	for _, row := range []struct {
+		issue connector.Issue
+		at    time.Time
+	}{
+		{issue: current, at: currentAt},
+		{issue: stale, at: currentAt},
+	} {
+		if _, err := db.Exec(
+			`INSERT INTO workflow_phase_events (issue_id, identifier, issue_url, phase_type, phase_name, status, started_at, metadata_json) VALUES (?, ?, ?, 'lane', 'Blocked', 'entered', ?, ?)`,
+			row.issue.ID,
+			row.issue.Identifier,
+			row.issue.URL,
+			row.at.Format(time.RFC3339Nano),
+			metadata,
+		); err != nil {
+			t.Fatalf("INSERT error = %v", err)
+		}
+	}
+
+	cfg := validDoctorDependencyWorkflow(true)
+	cfg.Tracker.BlockedRecovery.Enabled = false
+	check := checkDoctorBlockedRecoveryLive(
+		t.Context(),
+		"Project alpha blocked recovery",
+		&fakeDoctorAutoPromoteConnector{issues: []connector.Issue{current, stale}},
+		cfg,
+		currentAt.Add(2*time.Hour),
+		db,
+	)
+
+	if check.Status != doctorWarn || len(check.BlockedWithoutRecovery) != 1 {
+		t.Fatalf("check = %#v, want one stale-predicate warning", check)
+	}
+	if check.BlockedWithoutRecovery[0].IssueID != stale.ID {
+		t.Fatalf("BlockedWithoutRecovery = %#v, want %q", check.BlockedWithoutRecovery, stale.ID)
+	}
+}
+
+func TestCheckDoctorBlockedRecoveryScansEveryBlockedIssue(t *testing.T) {
+	t.Parallel()
+
+	issues := make([]connector.Issue, 0, 7)
+	for index := range 7 {
+		issues = append(issues, doctorDependencyIssue("issue-full-scan-"+strconv.Itoa(index), nil))
+	}
+	tracker := &fakeDoctorAutoPromoteConnector{issues: issues}
+	cfg := validDoctorDependencyWorkflow(true)
+
+	check := checkDoctorBlockedRecoveryLive(
+		t.Context(),
+		"Project alpha blocked recovery",
+		tracker,
+		cfg,
+		time.Date(2026, 7, 29, 19, 0, 0, 0, time.UTC),
+		nil,
+	)
+
+	if check.Status != doctorWarn || len(check.BlockedWithoutRecovery) != len(issues) {
+		t.Fatalf("check = %#v, want all relation-less issues reported", check)
+	}
+	if tracker.limit != 0 {
+		t.Fatalf("FetchIssuesByStatesLimit limit = %d, want full scan", tracker.limit)
 	}
 }
 

--- a/internal/orchestrator/artifact_completion.go
+++ b/internal/orchestrator/artifact_completion.go
@@ -313,7 +313,16 @@ func (o *Orchestrator) parkArtifactGateConvergence(
 		return
 	}
 	issue = cloneIssue(issue)
-	if err := o.updateIssueState(ctx, state, issue, blockedStatusState, completedAt, artifactGateConvergenceReason); err != nil {
+	metadata := o.newBlockedRecoveryMetadata(
+		ctx,
+		issue,
+		RunModeImplement,
+		artifactGateConvergenceReason,
+		blockedRecoveryPredicateFingerprintChange,
+		autoPromoteReworkState,
+		DiffStats{},
+	)
+	if err := o.updateIssueStateByIDWithMetadata(ctx, state, issue.ID, issue, blockedStatusState, completedAt, artifactGateConvergenceReason, metadata); err != nil {
 		if o.logger != nil {
 			o.logger.WarnContext(ctx, "artifact gate convergence breaker state transition failed",
 				"issue_id", issue.ID,
@@ -349,6 +358,7 @@ func (o *Orchestrator) parkArtifactGateConvergence(
 		RecoveryTarget: autoPromoteReworkState,
 		BlockedAt:      completedAt,
 		Source:         BlockedSourceProjectStatus,
+		Recovery:       metadata.BlockedRecovery,
 	}
 	recordStateEvent(state, telemetry.ActivityEvent{
 		At:      completedAt,

--- a/internal/orchestrator/autopromote_tick.go
+++ b/internal/orchestrator/autopromote_tick.go
@@ -2518,6 +2518,16 @@ func (o *Orchestrator) applyAutoPromoteDecision(
 			transitionReason = "rework_limit"
 			body = autoPromoteReworkLimitComment(summary, decision, displayStateName(issue.State), limit)
 			metadata.ReworkBreaker = &workflowLaneReworkBreakerMetadata{Reason: string(decision.Reason)}
+			recovery := o.newBlockedRecoveryMetadata(
+				ctx,
+				issue,
+				RunModeImplement,
+				"rework_limit",
+				blockedRecoveryPredicateManaged,
+				autoPromoteReworkState,
+				DiffStats{},
+			)
+			metadata.BlockedRecovery = recovery.BlockedRecovery
 		}
 	}
 

--- a/internal/orchestrator/blocked_cause_recovery.go
+++ b/internal/orchestrator/blocked_cause_recovery.go
@@ -1,0 +1,371 @@
+package orchestrator
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/digitaldrywood/detent/internal/connector"
+	runpkg "github.com/digitaldrywood/detent/internal/runner"
+	"github.com/digitaldrywood/detent/internal/store"
+	"github.com/digitaldrywood/detent/internal/workpad"
+)
+
+const (
+	blockedRecoveryOwnerOrchestrator           = "orchestrator"
+	blockedRecoveryOwnerHuman                  = "human"
+	blockedRecoveryOwnerOperator               = "operator"
+	blockedRecoveryPredicateFingerprintChange  = "fingerprint_changed"
+	blockedRecoveryPredicateOncePerFingerprint = "once_per_fingerprint"
+	blockedRecoveryPredicateManaged            = "managed"
+	workflowActionCauseBlockedRecovery         = "cause_blocked_recovery"
+)
+
+type blockedCauseSignals struct {
+	ConfigFingerprint    string            `json:"config_fingerprint,omitempty"`
+	ToolingFingerprint   string            `json:"tooling_fingerprint,omitempty"`
+	BaseFingerprint      string            `json:"base_fingerprint,omitempty"`
+	WorkspaceFingerprint string            `json:"workspace_fingerprint,omitempty"`
+	WorkspaceStatus      string            `json:"workspace_status,omitempty"`
+	WorkspacePresent     bool              `json:"workspace_present,omitempty"`
+	WorkspaceFiles       int               `json:"workspace_files,omitempty"`
+	UnpushedCommits      int               `json:"unpushed_commits,omitempty"`
+	Health               string            `json:"health,omitempty"`
+	Description          string            `json:"description,omitempty"`
+	ModelOverride        string            `json:"model_override,omitempty"`
+	Workpad              *workpad.Signal   `json:"workpad,omitempty"`
+	Fields               map[string]string `json:"fields,omitempty"`
+	PRNumber             int               `json:"pr_number,omitempty"`
+	PRHeadSHA            string            `json:"pr_head_sha,omitempty"`
+	PRBaseSHA            string            `json:"pr_base_sha,omitempty"`
+	PRDiffFingerprint    string            `json:"pr_diff_fingerprint,omitempty"`
+}
+
+func (o *Orchestrator) newBlockedRecoveryMetadata(
+	ctx context.Context,
+	issue connector.Issue,
+	runMode string,
+	cause string,
+	predicate string,
+	targetState string,
+	fallback DiffStats,
+) workflowLaneMetadata {
+	signals := o.blockedCauseSignals(ctx, issue, runMode, targetState, fallback)
+	targetState = blockedCauseTargetState(issue, signals, targetState)
+	return workflowLaneMetadata{
+		BlockedRecovery: &workflowLaneBlockedRecoveryMetadata{
+			Owner:            blockedRecoveryOwnerOrchestrator,
+			Cause:            strings.TrimSpace(cause),
+			Predicate:        strings.TrimSpace(predicate),
+			CauseFingerprint: blockedCauseFingerprint(signals),
+			TargetState:      targetState,
+			RunMode:          strings.TrimSpace(runMode),
+			Resumable:        blockedCauseResumable(issue, signals),
+		},
+	}
+}
+
+func (o *Orchestrator) blockedCauseSignals(
+	ctx context.Context,
+	issue connector.Issue,
+	runMode string,
+	targetState string,
+	fallback DiffStats,
+) blockedCauseSignals {
+	inspectionIssue := cloneIssue(issue)
+	if strings.TrimSpace(targetState) != "" {
+		inspectionIssue.State = targetState
+	}
+	snapshot := runpkg.BlockedRecoverySnapshot{Health: "inspection_unavailable", WorkspaceStatus: "unavailable"}
+	if o != nil && o.recoveryInspector != nil {
+		snapshot = o.recoveryInspector.BlockedRecoverySnapshot(ctx, runpkg.RunRequest{
+			Issue:           inspectionIssue,
+			Mode:            runMode,
+			SelectorContext: o.selectorContext(),
+		})
+	}
+	if !snapshot.WorkspacePresent && diffStatsPresent(fallback) {
+		snapshot.WorkspacePresent = true
+		snapshot.WorkspaceFingerprint = strings.TrimSpace(fallback.Fingerprint)
+		if snapshot.WorkspaceFingerprint == "" {
+			snapshot.WorkspaceFingerprint = blockedCauseHash(fmt.Sprintf(
+				"files=%d;added=%d;removed=%d;unpushed=%d;status=%s",
+				fallback.FilesChanged,
+				fallback.AddedLines,
+				fallback.RemovedLines,
+				fallback.UnpushedCommits,
+				strings.TrimSpace(fallback.Status),
+			))
+		}
+		snapshot.UnpushedCommits = fallback.UnpushedCommits
+		snapshot.WorkspaceFiles = fallback.FilesChanged
+		snapshot.WorkspaceStatus = "present"
+	}
+	signals := blockedCauseSignals{
+		ConfigFingerprint:    strings.TrimSpace(snapshot.ConfigFingerprint),
+		ToolingFingerprint:   strings.TrimSpace(snapshot.ToolingFingerprint),
+		BaseFingerprint:      strings.TrimSpace(snapshot.BaseFingerprint),
+		WorkspaceFingerprint: strings.TrimSpace(snapshot.WorkspaceFingerprint),
+		WorkspaceStatus:      strings.TrimSpace(snapshot.WorkspaceStatus),
+		WorkspacePresent:     snapshot.WorkspacePresent,
+		WorkspaceFiles:       snapshot.WorkspaceFiles,
+		UnpushedCommits:      snapshot.UnpushedCommits,
+		Health:               strings.TrimSpace(snapshot.Health),
+		Description:          strings.TrimSpace(issue.Description),
+		ModelOverride:        strings.TrimSpace(issue.ModelOverride),
+		Workpad:              blockedCauseWorkpadSignal(issue.WorkpadSignal),
+		Fields:               blockedCauseFields(issue.Fields),
+	}
+	if issue.PRNumber != nil {
+		signals.PRNumber = *issue.PRNumber
+	}
+	if issue.PullRequest != nil {
+		if issue.PullRequest.Number > 0 {
+			signals.PRNumber = issue.PullRequest.Number
+		}
+		signals.PRHeadSHA = strings.TrimSpace(issue.PullRequest.HeadSHA)
+		signals.PRBaseSHA = strings.TrimSpace(issue.PullRequest.BaseSHA)
+		signals.PRDiffFingerprint = strings.TrimSpace(issue.PullRequest.DiffFingerprint)
+	}
+	return signals
+}
+
+func blockedCauseWorkpadSignal(signal *workpad.Signal) *workpad.Signal {
+	if signal == nil {
+		return nil
+	}
+	cloned := *signal
+	cloned.CommentURL = ""
+	cloned.Blockers = append([]workpad.Blocker(nil), signal.Blockers...)
+	cloned.Fields = blockedCauseFields(signal.Fields)
+	if signal.Invalid != nil {
+		invalid := *signal.Invalid
+		cloned.Invalid = &invalid
+	}
+	return &cloned
+}
+
+func blockedCauseFields(fields map[string]string) map[string]string {
+	if len(fields) == 0 {
+		return nil
+	}
+	cloned := make(map[string]string, len(fields))
+	for key, value := range fields {
+		if normalizeState(key) == "status" {
+			continue
+		}
+		cloned[strings.TrimSpace(key)] = strings.TrimSpace(value)
+	}
+	if len(cloned) == 0 {
+		return nil
+	}
+	return cloned
+}
+
+func blockedCauseFingerprint(signals blockedCauseSignals) string {
+	data, err := json.Marshal(signals)
+	if err != nil {
+		return blockedCauseHash(err.Error())
+	}
+	return blockedCauseHash(string(data))
+}
+
+func blockedCauseHash(value string) string {
+	sum := sha256.Sum256([]byte(value))
+	return hex.EncodeToString(sum[:])
+}
+
+func blockedCauseResumable(issue connector.Issue, signals blockedCauseSignals) bool {
+	return dependencyAutoUnblockStartedSignal(issue) ||
+		(signals.WorkspacePresent && (signals.UnpushedCommits > 0 || signals.WorkspaceFiles > 0))
+}
+
+func blockedCauseTargetState(issue connector.Issue, signals blockedCauseSignals, configured string) string {
+	if blockedCauseResumable(issue, signals) {
+		return autoPromoteReworkState
+	}
+	configured = strings.TrimSpace(configured)
+	if configured != "" {
+		return configured
+	}
+	return "Todo"
+}
+
+func (o *Orchestrator) recoverCauseBlockedIssue(
+	ctx context.Context,
+	state *State,
+	issue connector.Issue,
+	now time.Time,
+) bool {
+	if normalizeState(issue.State) != normalizeState(blockedStatusState) {
+		return false
+	}
+	if reason := blockedCauseHoldReason(issue, state); reason != "" {
+		o.logBlockedRecoveryDecision(issue, "hold", reason, nil, "")
+		return false
+	}
+	if entry, ok := o.latestWorkflowLaneEntry(ctx, issue); ok &&
+		normalizeState(entry.Event.PhaseName) == normalizeState(blockedStatusState) &&
+		blockedEntryMatchesCurrent(issue, entry.Event.StartedAt) &&
+		strings.EqualFold(strings.TrimSpace(entry.Event.Reason), string(store.WorkAttemptTerminalOperatorStopped)) {
+		o.logBlockedRecoveryDecision(issue, "hold", "operator_stop", nil, "")
+		return false
+	}
+	withDependencies := o.issueWithDependencyRefs(issue)
+	if len(withDependencies.BlockedBy) > 0 {
+		o.logBlockedRecoveryDecision(issue, "defer", "dependency_recovery", nil, "")
+		return false
+	}
+	if park, ok := o.latestReworkBreakerPark(ctx, issue); ok {
+		o.logBlockedRecoveryDecision(issue, "defer", "rework_breaker_recovery", nil, park.Signature)
+		return false
+	}
+	park, ok := o.currentBlockedRecoveryPark(ctx, state, issue)
+	if !ok {
+		recoveryCfg := normalizeBlockedRecoveryConfig(o.cfg.BlockedRecovery)
+		reasonCode, reasonFound := o.latestWorkflowLaneReason(ctx, issue, issue.State)
+		if recoveryCfg.Enabled && reasonFound && blockedRecoveryReasonAllowed(recoveryCfg, reasonCode) {
+			o.logBlockedRecoveryDecision(issue, "defer", "pr_maintenance_recovery", nil, "")
+		} else {
+			o.logBlockedRecoveryDecision(issue, "hold", "no_recovery_predicate", nil, "")
+		}
+		return false
+	}
+	if park.Predicate == blockedRecoveryPredicateManaged {
+		o.logBlockedRecoveryDecision(issue, "hold", "managed_recovery", &park, park.CauseFingerprint)
+		return false
+	}
+	signals := o.blockedCauseSignals(ctx, issue, park.RunMode, park.TargetState, DiffStats{})
+	currentFingerprint := blockedCauseFingerprint(signals)
+	if park.Predicate == blockedRecoveryPredicateFingerprintChange && currentFingerprint == park.CauseFingerprint {
+		o.logBlockedRecoveryDecision(issue, "hold", "cause_unchanged", &park, currentFingerprint)
+		return false
+	}
+	if park.Predicate != blockedRecoveryPredicateFingerprintChange &&
+		park.Predicate != blockedRecoveryPredicateOncePerFingerprint {
+		o.logBlockedRecoveryDecision(issue, "hold", "no_recovery_predicate", &park, currentFingerprint)
+		return false
+	}
+	signature := blockedCauseRecoverySignature(park.Cause, currentFingerprint)
+	if _, consumed := o.workflowTimelineActionSignature(ctx, issue, workflowActionCauseBlockedRecovery, signature); consumed {
+		o.logBlockedRecoveryDecision(issue, "hold", "fingerprint_already_consumed", &park, currentFingerprint)
+		return false
+	}
+	targetState := blockedCauseTargetState(issue, signals, park.TargetState)
+	metadata := workflowLaneMetadataWithActionSignature(workflowLaneMetadata{}, workflowActionCauseBlockedRecovery, signature)
+	if err := o.updateIssueStateByIDWithMetadata(ctx, state, issue.ID, issue, targetState, now, "cause_blocked_recovery", metadata); err != nil {
+		o.logBlockedRecoveryDecision(issue, "hold", "transition_failed", &park, currentFingerprint)
+		return false
+	}
+	if o.connector != nil {
+		if err := o.connector.CreateComment(ctx, issue.ID, blockedCauseRecoveryComment(issue, park, targetState, currentFingerprint)); err != nil && o.logger != nil {
+			o.logger.Warn("blocked recovery comment failed", "issue_id", issue.ID, "identifier", issue.Identifier, "error", err)
+		}
+	}
+	delete(state.Blocked, issue.ID)
+	o.logBlockedRecoveryDecision(issue, "transition", "recovery_predicate_satisfied", &park, currentFingerprint)
+	return true
+}
+
+func blockedCauseHoldReason(issue connector.Issue, state *State) string {
+	if issue.WorkpadSignal != nil {
+		if issue.WorkpadSignal.Invalid != nil {
+			return "invalid_workpad_signal"
+		}
+		if strings.TrimSpace(issue.WorkpadSignal.HumanAction) != "" {
+			return "human_action"
+		}
+		if len(issue.WorkpadSignal.Blockers) > 0 {
+			return "workpad_blocker"
+		}
+	}
+	for _, label := range issue.Labels {
+		if normalizeLabel(label) == "requires-human-review" {
+			return "human_action"
+		}
+	}
+	if state != nil {
+		if blocked, ok := state.Blocked[strings.TrimSpace(issue.ID)]; ok && blocked.Source == BlockedSourceOperatorStop {
+			return "operator_stop"
+		}
+	}
+	return ""
+}
+
+func (o *Orchestrator) currentBlockedRecoveryPark(
+	ctx context.Context,
+	state *State,
+	issue connector.Issue,
+) (workflowLaneBlockedRecoveryMetadata, bool) {
+	issueID := strings.TrimSpace(issue.ID)
+	if state != nil && issueID != "" {
+		if blocked, ok := state.Blocked[issueID]; ok &&
+			blocked.Recovery != nil &&
+			blockedEntryMatchesCurrent(issue, blocked.BlockedAt) {
+			return *blocked.Recovery, true
+		}
+	}
+	entry, ok := o.latestWorkflowLaneEntry(ctx, issue)
+	if !ok ||
+		normalizeState(entry.Event.PhaseName) != normalizeState(blockedStatusState) ||
+		!blockedEntryMatchesCurrent(issue, entry.Event.StartedAt) ||
+		entry.Metadata.BlockedRecovery == nil {
+		return workflowLaneBlockedRecoveryMetadata{}, false
+	}
+	return *entry.Metadata.BlockedRecovery, true
+}
+
+func blockedCauseRecoverySignature(cause string, fingerprint string) string {
+	return strings.TrimSpace(cause) + ":" + strings.TrimSpace(fingerprint)
+}
+
+func blockedCauseRecoveryComment(
+	issue connector.Issue,
+	park workflowLaneBlockedRecoveryMetadata,
+	targetState string,
+	fingerprint string,
+) string {
+	return fmt.Sprintf(
+		"Blocked recovery predicate satisfied. Moved %s from %s to %s.\n\n- cause: %s\n- predicate: %s\n- cause_fingerprint: %s",
+		issueLabel(issue),
+		strings.TrimSpace(issue.State),
+		strings.TrimSpace(targetState),
+		strings.TrimSpace(park.Cause),
+		strings.TrimSpace(park.Predicate),
+		strings.TrimSpace(fingerprint),
+	)
+}
+
+func (o *Orchestrator) logBlockedRecoveryDecision(
+	issue connector.Issue,
+	action string,
+	reason string,
+	park *workflowLaneBlockedRecoveryMetadata,
+	fingerprint string,
+) {
+	if o == nil || o.logger == nil {
+		return
+	}
+	attrs := []any{
+		"issue_id", strings.TrimSpace(issue.ID),
+		"identifier", strings.TrimSpace(issue.Identifier),
+		"action", strings.TrimSpace(action),
+		"reason", strings.TrimSpace(reason),
+	}
+	if park != nil {
+		attrs = append(attrs,
+			"owner", strings.TrimSpace(park.Owner),
+			"cause", strings.TrimSpace(park.Cause),
+			"predicate", strings.TrimSpace(park.Predicate),
+			"parked_fingerprint", strings.TrimSpace(park.CauseFingerprint),
+		)
+	}
+	if strings.TrimSpace(fingerprint) != "" {
+		attrs = append(attrs, "cause_fingerprint", strings.TrimSpace(fingerprint))
+	}
+	o.logger.Info("blocked recovery decision", attrs...)
+}

--- a/internal/orchestrator/blocked_cause_recovery.go
+++ b/internal/orchestrator/blocked_cause_recovery.go
@@ -6,6 +6,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
+	"slices"
 	"strings"
 	"time"
 
@@ -37,6 +38,7 @@ type blockedCauseSignals struct {
 	Health               string            `json:"health,omitempty"`
 	Description          string            `json:"description,omitempty"`
 	ModelOverride        string            `json:"model_override,omitempty"`
+	Labels               []string          `json:"labels,omitempty"`
 	Workpad              *workpad.Signal   `json:"workpad,omitempty"`
 	Fields               map[string]string `json:"fields,omitempty"`
 	PRNumber             int               `json:"pr_number,omitempty"`
@@ -117,6 +119,7 @@ func (o *Orchestrator) blockedCauseSignals(
 		Health:               strings.TrimSpace(snapshot.Health),
 		Description:          strings.TrimSpace(issue.Description),
 		ModelOverride:        strings.TrimSpace(issue.ModelOverride),
+		Labels:               blockedCauseLabels(issue.Labels),
 		Workpad:              blockedCauseWorkpadSignal(issue.WorkpadSignal),
 		Fields:               blockedCauseFields(issue.Fields),
 	}
@@ -147,6 +150,12 @@ func blockedCauseWorkpadSignal(signal *workpad.Signal) *workpad.Signal {
 		cloned.Invalid = &invalid
 	}
 	return &cloned
+}
+
+func blockedCauseLabels(labels []string) []string {
+	normalized := normalizeLabels(labels)
+	slices.Sort(normalized)
+	return normalized
 }
 
 func blockedCauseFields(fields map[string]string) map[string]string {

--- a/internal/orchestrator/blocked_cause_recovery_test.go
+++ b/internal/orchestrator/blocked_cause_recovery_test.go
@@ -1,0 +1,268 @@
+package orchestrator
+
+import (
+	"bytes"
+	"context"
+	"log/slog"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/digitaldrywood/detent/internal/connector"
+	runpkg "github.com/digitaldrywood/detent/internal/runner"
+	"github.com/digitaldrywood/detent/internal/store"
+	"github.com/digitaldrywood/detent/internal/workpad"
+)
+
+func TestRecoverBlockedIssuesLogsDecisionForEveryBlockedIssue(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		issue      connector.Issue
+		prepare    func(*State, connector.Issue)
+		wantAction string
+		wantReason string
+	}{
+		{
+			name:       "relation-less park",
+			issue:      dependencyAutoUnblockIssue("issue-no-predicate", blockedStatusState),
+			wantAction: "hold",
+			wantReason: "no_recovery_predicate",
+		},
+		{
+			name: "human action",
+			issue: func() connector.Issue {
+				issue := dependencyAutoUnblockIssue("issue-human-action", blockedStatusState)
+				issue.WorkpadSignal = &workpad.Signal{
+					Source:      workpad.SourceStructured,
+					Status:      workpad.StatusBlocked,
+					HumanAction: "install production credentials",
+				}
+				return issue
+			}(),
+			wantAction: "hold",
+			wantReason: "human_action",
+		},
+		{
+			name: "dependency",
+			issue: func() connector.Issue {
+				issue := dependencyAutoUnblockIssue("issue-dependency", blockedStatusState)
+				issue.BlockedBy = []connector.BlockedRef{{Identifier: "digitaldrywood/detent#59"}}
+				return issue
+			}(),
+			wantAction: "defer",
+			wantReason: "dependency_recovery",
+		},
+		{
+			name: "workpad blocker",
+			issue: func() connector.Issue {
+				issue := dependencyAutoUnblockIssue("issue-workpad-blocker", blockedStatusState)
+				issue.WorkpadSignal = &workpad.Signal{
+					Source:   workpad.SourceStructured,
+					Status:   workpad.StatusBlocked,
+					Blockers: []workpad.Blocker{{Ref: "digitaldrywood/detent#59"}},
+				}
+				return issue
+			}(),
+			wantAction: "hold",
+			wantReason: "workpad_blocker",
+		},
+		{
+			name:  "operator stop",
+			issue: dependencyAutoUnblockIssue("issue-operator-stop", blockedStatusState),
+			prepare: func(state *State, issue connector.Issue) {
+				state.Blocked[issue.ID] = Blocked{
+					Issue:      issue,
+					Source:     BlockedSourceOperatorStop,
+					Reason:     "operator stopped run",
+					StopReason: "operator requested stop",
+				}
+			},
+			wantAction: "hold",
+			wantReason: "operator_stop",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			var logs bytes.Buffer
+			tracker := &dependencyAutoUnblockConnector{}
+			orch := blockedCauseTestOrchestrator(tracker)
+			orch.logger = slog.New(slog.NewTextHandler(&logs, nil))
+			state := newState(orch.cfg)
+			if tt.prepare != nil {
+				tt.prepare(&state, tt.issue)
+			}
+
+			orch.recoverBlockedIssues(t.Context(), &state, []connector.Issue{tt.issue}, time.Date(2026, 7, 29, 18, 0, 0, 0, time.UTC))
+
+			got := logs.String()
+			for _, want := range []string{
+				"msg=\"blocked recovery decision\"",
+				"issue_id=" + tt.issue.ID,
+				"action=" + tt.wantAction,
+				"reason=" + tt.wantReason,
+			} {
+				if !strings.Contains(got, want) {
+					t.Fatalf("logs = %q, want %q", got, want)
+				}
+			}
+			if len(tracker.updates) != 0 {
+				t.Fatalf("updates = %#v, want none", tracker.updates)
+			}
+		})
+	}
+}
+
+func TestCauseBlockedRecoveryPersistsAndBoundsFingerprintAttempts(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name           string
+		predicate      string
+		parked         runpkg.BlockedRecoverySnapshot
+		current        runpkg.BlockedRecoverySnapshot
+		wantTarget     string
+		wantTransition bool
+	}{
+		{
+			name:           "changed configuration fingerprint",
+			predicate:      blockedRecoveryPredicateFingerprintChange,
+			parked:         runpkg.BlockedRecoverySnapshot{ConfigFingerprint: "config-old", Health: "ready", WorkspaceStatus: "missing"},
+			current:        runpkg.BlockedRecoverySnapshot{ConfigFingerprint: "config-new", Health: "ready", WorkspaceStatus: "missing"},
+			wantTarget:     "Todo",
+			wantTransition: true,
+		},
+		{
+			name:      "unchanged no-progress cause",
+			predicate: blockedRecoveryPredicateFingerprintChange,
+			parked:    runpkg.BlockedRecoverySnapshot{ConfigFingerprint: "config-same", Health: "ready", WorkspaceStatus: "missing"},
+			current:   runpkg.BlockedRecoverySnapshot{ConfigFingerprint: "config-same", Health: "ready", WorkspaceStatus: "missing"},
+		},
+		{
+			name:      "stranded workspace once per unchanged fingerprint",
+			predicate: blockedRecoveryPredicateOncePerFingerprint,
+			parked: runpkg.BlockedRecoverySnapshot{
+				ConfigFingerprint:    "config-same",
+				WorkspaceFingerprint: "workspace-same",
+				WorkspaceStatus:      "present",
+				WorkspacePresent:     true,
+				UnpushedCommits:      2,
+				Health:               "ready",
+			},
+			current: runpkg.BlockedRecoverySnapshot{
+				ConfigFingerprint:    "config-same",
+				WorkspaceFingerprint: "workspace-same",
+				WorkspaceStatus:      "present",
+				WorkspacePresent:     true,
+				UnpushedCommits:      2,
+				Health:               "ready",
+			},
+			wantTarget:     autoPromoteReworkState,
+			wantTransition: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			issue := dependencyAutoUnblockIssue("issue-"+strings.ReplaceAll(tt.name, " ", "-"), blockedStatusState)
+			metrics := &autoPromoteWorkflowMetricsRecorder{}
+			parkTracker := &dependencyAutoUnblockConnector{}
+			parkOrch := blockedCauseTestOrchestrator(parkTracker)
+			parkOrch.workflowMetrics = metrics
+			parkOrch.recoveryInspector = staticBlockedRecoveryInspector{snapshot: tt.parked}
+			parkedAt := time.Date(2026, 7, 29, 18, 30, 0, 0, time.UTC)
+			metadata := parkOrch.newBlockedRecoveryMetadata(
+				t.Context(),
+				issue,
+				RunModeImplement,
+				noProgressLimitReason,
+				tt.predicate,
+				"Todo",
+				DiffStats{},
+			)
+			recordBlockedCausePark(t, metrics, issue, parkedAt, metadata)
+
+			tracker := &dependencyAutoUnblockConnector{}
+			orch := blockedCauseTestOrchestrator(tracker)
+			orch.workflowMetrics = metrics
+			orch.recoveryInspector = staticBlockedRecoveryInspector{snapshot: tt.current}
+			state := newState(orch.cfg)
+
+			transitioned := orch.recoverBlockedIssues(t.Context(), &state, []connector.Issue{issue}, parkedAt.Add(time.Minute))
+
+			if tt.wantTransition {
+				if len(tracker.updates) != 1 || tracker.updates[0].state != tt.wantTarget {
+					t.Fatalf("updates = %#v, want target %q", tracker.updates, tt.wantTarget)
+				}
+				if _, ok := transitioned[issue.ID]; !ok {
+					t.Fatalf("transitioned[%q] missing", issue.ID)
+				}
+				currentFingerprint := blockedCauseFingerprint(orch.blockedCauseSignals(t.Context(), issue, RunModeImplement, metadata.BlockedRecovery.TargetState, DiffStats{}))
+				assertWorkflowActionSignature(t, metrics, issue, workflowActionCauseBlockedRecovery, blockedCauseRecoverySignature(noProgressLimitReason, currentFingerprint))
+
+				if tt.predicate == blockedRecoveryPredicateOncePerFingerprint {
+					recordBlockedCausePark(t, metrics, issue, parkedAt.Add(2*time.Minute), metadata)
+					restartedTracker := &dependencyAutoUnblockConnector{}
+					restarted := blockedCauseTestOrchestrator(restartedTracker)
+					restarted.workflowMetrics = metrics
+					restarted.recoveryInspector = staticBlockedRecoveryInspector{snapshot: tt.current}
+					restarted.recoverBlockedIssues(t.Context(), &state, []connector.Issue{issue}, parkedAt.Add(3*time.Minute))
+					if len(restartedTracker.updates) != 0 {
+						t.Fatalf("restart updates = %#v, want consumed fingerprint held", restartedTracker.updates)
+					}
+				}
+				return
+			}
+			if len(tracker.updates) != 0 {
+				t.Fatalf("updates = %#v, want unchanged cause held", tracker.updates)
+			}
+			if _, ok := transitioned[issue.ID]; ok {
+				t.Fatalf("transitioned[%q] present", issue.ID)
+			}
+		})
+	}
+}
+
+func blockedCauseTestOrchestrator(tracker *dependencyAutoUnblockConnector) *Orchestrator {
+	orch := dependencyAutoUnblockOrchestrator(tracker, DependencyAutoUnblockConfig{})
+	orch.cfg.BlockedRecovery.Enabled = false
+	return orch
+}
+
+func recordBlockedCausePark(
+	t *testing.T,
+	metrics *autoPromoteWorkflowMetricsRecorder,
+	issue connector.Issue,
+	at time.Time,
+	metadata workflowLaneMetadata,
+) {
+	t.Helper()
+	if _, err := metrics.RecordWorkflowPhaseEvent(context.Background(), store.WorkflowPhaseEvent{
+		ProjectID:    defaultWorkflowMetricsProjectID,
+		IssueID:      issue.ID,
+		Identifier:   issue.Identifier,
+		IssueURL:     issue.URL,
+		PhaseType:    store.WorkflowPhaseTypeLane,
+		PhaseName:    blockedStatusState,
+		Reason:       noProgressLimitReason,
+		Status:       "entered",
+		StartedAt:    at,
+		MetadataJSON: workflowLaneMetadataJSON(issue, metadata),
+	}); err != nil {
+		t.Fatalf("RecordWorkflowPhaseEvent() error = %v", err)
+	}
+}
+
+type staticBlockedRecoveryInspector struct {
+	snapshot runpkg.BlockedRecoverySnapshot
+}
+
+func (i staticBlockedRecoveryInspector) BlockedRecoverySnapshot(context.Context, runpkg.RunRequest) runpkg.BlockedRecoverySnapshot {
+	return i.snapshot
+}

--- a/internal/orchestrator/blocked_cause_recovery_test.go
+++ b/internal/orchestrator/blocked_cause_recovery_test.go
@@ -229,6 +229,21 @@ func TestCauseBlockedRecoveryPersistsAndBoundsFingerprintAttempts(t *testing.T) 
 	}
 }
 
+func TestBlockedCauseFingerprintTracksNormalizedLabels(t *testing.T) {
+	t.Parallel()
+
+	original := blockedCauseSignals{Labels: blockedCauseLabels([]string{"bug", "detent:blocked"})}
+	reordered := blockedCauseSignals{Labels: blockedCauseLabels([]string{" DETENT:BLOCKED ", "Bug", "bug"})}
+	withOverride := blockedCauseSignals{Labels: blockedCauseLabels([]string{"bug", "detent:blocked", "agent:max-tokens"})}
+
+	if blockedCauseFingerprint(original) != blockedCauseFingerprint(reordered) {
+		t.Fatal("equivalent labels changed the cause fingerprint")
+	}
+	if blockedCauseFingerprint(original) == blockedCauseFingerprint(withOverride) {
+		t.Fatal("recovery-affecting label did not change the cause fingerprint")
+	}
+}
+
 func blockedCauseTestOrchestrator(tracker *dependencyAutoUnblockConnector) *Orchestrator {
 	orch := dependencyAutoUnblockOrchestrator(tracker, DependencyAutoUnblockConfig{})
 	orch.cfg.BlockedRecovery.Enabled = false

--- a/internal/orchestrator/blocked_recovery.go
+++ b/internal/orchestrator/blocked_recovery.go
@@ -188,6 +188,11 @@ func (o *Orchestrator) recoverBlockedIssues(
 		if issueID == "" {
 			continue
 		}
+		if normalizeState(issue.State) == normalizeState(blockedStatusState) &&
+			o.recoverCauseBlockedIssue(ctx, state, issue, now) {
+			transitioned[issueID] = struct{}{}
+			continue
+		}
 		if park, ok := o.latestReworkBreakerPark(ctx, issue); normalizeState(issue.State) == normalizeState(blockedStatusState) && autoPromoteCfg.Enabled && ok {
 			if reworkBreakerAutoUnparkConsumed(park.Timeline, park.Signature) ||
 				!reworkBreakerAutoUnparkReady(issue, park) ||

--- a/internal/orchestrator/dependency_autounblock.go
+++ b/internal/orchestrator/dependency_autounblock.go
@@ -838,15 +838,26 @@ func dependencyRefLabels(refs []connector.BlockedRef) []string {
 func (o *Orchestrator) issueHasStickyBlockReason(ctx context.Context, state *State, issue connector.Issue) bool {
 	issueID := strings.TrimSpace(issue.ID)
 	if state != nil && issueID != "" {
-		if blocked, ok := state.Blocked[issueID]; ok && stickyBlockReason(blocked.Reason) {
+		if blocked, ok := state.Blocked[issueID]; ok &&
+			blockedEntryMatchesCurrent(issue, blocked.BlockedAt) &&
+			stickyBlockReason(blocked.Reason) {
 			return true
 		}
 	}
-	if stickyBlockReason(issue.BlockerReason) {
+	entry, ok := o.latestWorkflowLaneEntry(ctx, issue)
+	if !ok {
+		return stickyBlockReason(issue.BlockerReason)
+	}
+	return normalizeState(entry.Event.PhaseName) == normalizeState(blockedStatusState) &&
+		blockedEntryMatchesCurrent(issue, entry.Event.StartedAt) &&
+		(stickyBlockReason(entry.Event.Reason) || stickyBlockReason(issue.BlockerReason))
+}
+
+func blockedEntryMatchesCurrent(issue connector.Issue, enteredAt time.Time) bool {
+	if issue.StageUpdatedAt == nil || issue.StageUpdatedAt.IsZero() || enteredAt.IsZero() {
 		return true
 	}
-	reason, ok := o.latestWorkflowLaneReason(ctx, issue, blockedStatusState)
-	return ok && stickyBlockReason(reason)
+	return !enteredAt.Before(issue.StageUpdatedAt.Add(-reworkBreakerStageUpdateSkew))
 }
 
 func stickyBlockReason(reason string) bool {

--- a/internal/orchestrator/dependency_autounblock_test.go
+++ b/internal/orchestrator/dependency_autounblock_test.go
@@ -159,6 +159,55 @@ func TestTickAutoUnblockSkipsPersistedReworkLimitBlockedIssue(t *testing.T) {
 	}
 }
 
+func TestTickAutoUnblocksDependencyParkNewerThanStickyHistory(t *testing.T) {
+	t.Parallel()
+
+	waiting := dependencyAutoUnblockIssue("issue-current-dependency-park", "Blocked")
+	waiting.BlockedBy = []connector.BlockedRef{{
+		Identifier: "digitaldrywood/video-studio#59",
+		Source:     connector.BlockedRefSourceNative,
+	}}
+	waiting.BlockerReason = noProgressLimitReason
+	parkedAt := time.Date(2026, 7, 29, 17, 0, 0, 0, time.UTC)
+	waiting.StageUpdatedAt = &parkedAt
+	blocker := dependencyAutoUnblockIssue("issue-closed-blocker", "Done")
+	blocker.Identifier = "digitaldrywood/video-studio#59"
+	blocker.Closed = true
+	tracker := &dependencyAutoUnblockConnector{
+		stateIssues: []connector.Issue{waiting},
+		blockers:    []connector.Issue{blocker},
+	}
+	orch := dependencyAutoUnblockOrchestrator(tracker, DependencyAutoUnblockConfig{
+		Enabled:      true,
+		SourceStates: []string{"Blocked"},
+		TargetState:  "Todo",
+		Readiness:    DependencyReadinessTerminalOrMerged,
+	})
+	metrics := &autoPromoteWorkflowMetricsRecorder{}
+	orch.workflowMetrics = metrics
+	if _, err := metrics.RecordWorkflowPhaseEvent(context.Background(), store.WorkflowPhaseEvent{
+		ProjectID:    defaultWorkflowMetricsProjectID,
+		IssueID:      waiting.ID,
+		Identifier:   waiting.Identifier,
+		IssueURL:     waiting.URL,
+		PhaseType:    store.WorkflowPhaseTypeLane,
+		PhaseName:    "Blocked",
+		Reason:       noProgressLimitReason,
+		Status:       "entered",
+		StartedAt:    parkedAt.Add(-time.Hour),
+		MetadataJSON: "{}",
+	}); err != nil {
+		t.Fatalf("RecordWorkflowPhaseEvent() error = %v", err)
+	}
+	state := newState(orch.cfg)
+
+	orch.tick(context.Background(), &state, parkedAt.Add(time.Minute))
+
+	if got := tracker.updates; len(got) != 1 || got[0] != (dependencyAutoUnblockUpdate{issueID: waiting.ID, state: "Todo"}) {
+		t.Fatalf("updates = %#v, want newer dependency park moved to Todo", got)
+	}
+}
+
 func TestTickAutoUnblocksLightweightDependencyWaitingIssue(t *testing.T) {
 	t.Parallel()
 

--- a/internal/orchestrator/implement_progress.go
+++ b/internal/orchestrator/implement_progress.go
@@ -612,7 +612,26 @@ func (o *Orchestrator) blockImplementProgress(
 	if blockReason == "" {
 		blockReason = noProgressLimitReason
 	}
-	if err := o.updateIssueStateByID(ctx, state, issueID, issue, blockedStatusState, blockedAt, blockReason); err != nil {
+	predicate := blockedRecoveryPredicateFingerprintChange
+	if blockReason == strandedUnpushedWorkReason {
+		predicate = blockedRecoveryPredicateOncePerFingerprint
+	}
+	if strings.TrimSpace(decision.HumanAction) != "" || blockReason == workpadBlockedUnactionedReason {
+		predicate = blockedRecoveryPredicateManaged
+	}
+	metadata := o.newBlockedRecoveryMetadata(
+		ctx,
+		issue,
+		RunModeImplement,
+		blockReason,
+		predicate,
+		autoPromoteReworkState,
+		decision.WorkspaceDiffStats,
+	)
+	if predicate == blockedRecoveryPredicateManaged {
+		metadata.BlockedRecovery.Owner = blockedRecoveryOwnerHuman
+	}
+	if err := o.updateIssueStateByIDWithMetadata(ctx, state, issueID, issue, blockedStatusState, blockedAt, blockReason, metadata); err != nil {
 		if o.logger != nil {
 			o.logger.Warn(
 				"no progress limit state transition failed",
@@ -653,6 +672,7 @@ func (o *Orchestrator) blockImplementProgress(
 		RecoveryTarget: "Rework",
 		BlockedAt:      blockedAt,
 		Source:         BlockedSourceProjectStatus,
+		Recovery:       metadata.BlockedRecovery,
 	}
 	recordStateEvent(state, telemetry.ActivityEvent{
 		At:      blockedAt,

--- a/internal/orchestrator/merge_duration.go
+++ b/internal/orchestrator/merge_duration.go
@@ -85,6 +85,16 @@ func (o *Orchestrator) parkMergeWorkerDurationExceeded(
 ) {
 	issueID := strings.TrimSpace(running.Issue.ID)
 	issue := cloneIssue(running.Issue)
+	metadata := o.newBlockedRecoveryMetadata(
+		ctx,
+		issue,
+		RunModeMerge,
+		mergeWorkerDurationExceededReason,
+		blockedRecoveryPredicateManaged,
+		autoPromoteMergingState,
+		running.DiffStats,
+	)
+	metadata.BlockedRecovery.Owner = blockedRecoveryOwnerHuman
 	transitionErr := o.updateIssueStateByIDStrictWithMetadata(
 		ctx,
 		state,
@@ -93,7 +103,7 @@ func (o *Orchestrator) parkMergeWorkerDurationExceeded(
 		blockedStatusState,
 		completedAt,
 		mergeWorkerDurationExceededReason,
-		workflowLaneMetadata{},
+		metadata,
 	)
 	if transitionErr != nil && o.logger != nil {
 		o.logger.Error(
@@ -146,6 +156,7 @@ func (o *Orchestrator) parkMergeWorkerDurationExceeded(
 		RecoveryTarget: autoPromoteMergingState,
 		BlockedAt:      completedAt,
 		Source:         source,
+		Recovery:       metadata.BlockedRecovery,
 	}
 	recordStateEvent(state, telemetry.ActivityEvent{
 		At:      completedAt,
@@ -199,7 +210,7 @@ func (o *Orchestrator) reconcileMergeDurationHolds(
 			blockedStatusState,
 			now,
 			mergeWorkerDurationExceededReason,
-			workflowLaneMetadata{},
+			workflowLaneMetadata{BlockedRecovery: blocked.Recovery},
 		); err != nil {
 			if o.logger != nil {
 				o.logger.Warn(

--- a/internal/orchestrator/merge_revocation.go
+++ b/internal/orchestrator/merge_revocation.go
@@ -341,6 +341,16 @@ func (o *Orchestrator) parkRepeatedMergeRevocations(
 	}
 
 	decision := autoPromoteDecision(AutoPromoteActionSkip, AutoPromoteReasonMergeRevocationLimit)
+	metadata := o.newBlockedRecoveryMetadata(
+		ctx,
+		issue,
+		RunModeMerge,
+		string(AutoPromoteReasonMergeRevocationLimit),
+		blockedRecoveryPredicateManaged,
+		autoPromoteReworkState,
+		DiffStats{},
+	)
+	metadata.BlockedRecovery.Owner = blockedRecoveryOwnerHuman
 	if err := o.updateIssueStateByIDStrictWithMetadata(
 		ctx,
 		state,
@@ -349,7 +359,7 @@ func (o *Orchestrator) parkRepeatedMergeRevocations(
 		blockedStatusState,
 		now,
 		string(AutoPromoteReasonMergeRevocationLimit),
-		workflowLaneMetadata{},
+		metadata,
 	); err != nil {
 		if o.logger != nil {
 			o.logger.Warn(

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -208,6 +208,7 @@ type Orchestrator struct {
 	capacityController      runpkg.CapacityController
 	capacityStatus          runpkg.CapacityStatusController
 	validatorCapacity       runpkg.ValidatorCapacityController
+	recoveryInspector       runpkg.BlockedRecoveryInspector
 	dailyBudgetStatus       runpkg.DailyBudgetStatusProvider
 	issueBudgetStatus       runpkg.IssueBudgetStatusProvider
 	now                     func() time.Time
@@ -328,6 +329,10 @@ func New(cfg Config, deps Dependencies) (*Orchestrator, error) {
 	var validatorCapacity runpkg.ValidatorCapacityController
 	if candidate, ok := runner.(runpkg.ValidatorCapacityController); ok {
 		validatorCapacity = candidate
+	}
+	var blockedRecoveryInspector runpkg.BlockedRecoveryInspector
+	if candidate, ok := runner.(runpkg.BlockedRecoveryInspector); ok {
+		blockedRecoveryInspector = candidate
 	}
 	var capacityStatus runpkg.CapacityStatusController
 	if candidate, ok := runner.(runpkg.CapacityStatusController); ok {
@@ -454,6 +459,7 @@ func New(cfg Config, deps Dependencies) (*Orchestrator, error) {
 		capacityController:      capacityController,
 		capacityStatus:          capacityStatus,
 		validatorCapacity:       validatorCapacity,
+		recoveryInspector:       blockedRecoveryInspector,
 		dailyBudgetStatus:       dailyBudgetStatus,
 		issueBudgetStatus:       issueBudgetStatus,
 		now:                     now,

--- a/internal/orchestrator/run_completion.go
+++ b/internal/orchestrator/run_completion.go
@@ -610,8 +610,17 @@ func (o *Orchestrator) parkInstantFailure(
 ) {
 	targetState := o.instantFailureParkState()
 	issue := cloneIssue(running.Issue)
+	metadata := o.newBlockedRecoveryMetadata(
+		ctx,
+		issue,
+		running.Mode,
+		"instant_failure_circuit_breaker",
+		blockedRecoveryPredicateFingerprintChange,
+		"Todo",
+		running.DiffStats,
+	)
 	if targetState != "" {
-		if err := o.updateIssueState(ctx, state, issue, targetState, event.CompletedAt, "instant_fail_circuit_breaker"); err != nil {
+		if err := o.updateIssueStateByIDWithMetadata(ctx, state, issue.ID, issue, targetState, event.CompletedAt, "instant_fail_circuit_breaker", metadata); err != nil {
 			if o.logger != nil {
 				o.logger.Error(
 					"instant fail circuit breaker state transition failed",
@@ -644,10 +653,11 @@ func (o *Orchestrator) parkInstantFailure(
 	state.Blocked[issue.ID] = Blocked{
 		Issue:          issue,
 		Reason:         instantFailureBlockedReasonPrefix + failure.Error,
-		RecoveryReason: "fix the pinned agent model or backend configuration, then move the issue back to Todo or Rework",
+		RecoveryReason: blockedRecoveryPredicateFingerprintChange,
 		RecoveryTarget: "Todo",
 		BlockedAt:      event.CompletedAt,
 		Source:         BlockedSourceProjectStatus,
+		Recovery:       metadata.BlockedRecovery,
 	}
 	recordStateEvent(state, telemetry.ActivityEvent{
 		At:      event.CompletedAt,
@@ -697,8 +707,17 @@ func (o *Orchestrator) tripTokenCeilingCircuitBreaker(
 	failure := o.recordRepeatedFailure(state, event, running)
 	targetState := o.instantFailureParkState()
 	issue := cloneIssue(running.Issue)
+	metadata := o.newBlockedRecoveryMetadata(
+		ctx,
+		issue,
+		running.Mode,
+		"token_ceiling_circuit_breaker",
+		blockedRecoveryPredicateFingerprintChange,
+		autoPromoteReworkState,
+		running.DiffStats,
+	)
 	if targetState != "" {
-		if err := o.updateIssueState(ctx, state, issue, targetState, event.CompletedAt, "token_ceiling_circuit_breaker"); err != nil {
+		if err := o.updateIssueStateByIDWithMetadata(ctx, state, issue.ID, issue, targetState, event.CompletedAt, "token_ceiling_circuit_breaker", metadata); err != nil {
 			if o.logger != nil {
 				o.logger.Error(
 					"token ceiling circuit breaker state transition failed",
@@ -734,10 +753,11 @@ func (o *Orchestrator) tripTokenCeilingCircuitBreaker(
 	state.Blocked[issue.ID] = Blocked{
 		Issue:          issue,
 		Reason:         reason,
-		RecoveryReason: string(BlockedRecoveryReasonHumanBlocker),
+		RecoveryReason: blockedRecoveryPredicateFingerprintChange,
 		RecoveryTarget: "Rework",
 		BlockedAt:      event.CompletedAt,
 		Source:         BlockedSourceProjectStatus,
+		Recovery:       metadata.BlockedRecovery,
 	}
 	recordStateEvent(state, telemetry.ActivityEvent{
 		At:      event.CompletedAt,
@@ -789,7 +809,7 @@ func tokenCeilingFailureComment(
 	if targetState = strings.TrimSpace(targetState); targetState != "" {
 		b.WriteString("\n\nIssue parked in `")
 		b.WriteString(targetState)
-		b.WriteString("` for a human decision.")
+		b.WriteString("` until its recovery fingerprint changes.")
 	}
 	b.WriteString("\n\n- issue: ")
 	b.WriteString(issueLabel(issue))
@@ -803,7 +823,7 @@ func tokenCeilingFailureComment(
 	b.WriteString(strconv.FormatInt(ceilingErr.CeilingTokens, 10))
 	b.WriteString("\n- ceiling_source: ")
 	b.WriteString(strings.TrimSpace(ceilingErr.Source))
-	b.WriteString("\n\nChoose one recovery before moving the issue to Rework: split the issue into narrower work, apply the label configured by `agent.max_session_token_override_label` for a deliberate per-issue bypass, or raise `agent.max_session_tokens` (and `agent.max_session_context_multiplier` when it is the active guard).")
+	b.WriteString("\n\nChoose one recovery: split the issue into narrower work, apply the label configured by `agent.max_session_token_override_label` for a deliberate per-issue bypass, or raise `agent.max_session_tokens` (and `agent.max_session_context_multiplier` when it is the active guard). Detent requeues the issue once the responsible model, backend, issue, or configuration fingerprint changes.")
 	return b.String()
 }
 
@@ -858,8 +878,17 @@ func (o *Orchestrator) parkRepeatedFailure(
 ) {
 	targetState := o.instantFailureParkState()
 	issue := cloneIssue(running.Issue)
+	metadata := o.newBlockedRecoveryMetadata(
+		ctx,
+		issue,
+		running.Mode,
+		"repeated_failure_circuit_breaker",
+		blockedRecoveryPredicateFingerprintChange,
+		"Todo",
+		running.DiffStats,
+	)
 	if targetState != "" {
-		if err := o.updateIssueState(ctx, state, issue, targetState, event.CompletedAt, "repeated_failure_circuit_breaker"); err != nil {
+		if err := o.updateIssueStateByIDWithMetadata(ctx, state, issue.ID, issue, targetState, event.CompletedAt, "repeated_failure_circuit_breaker", metadata); err != nil {
 			if o.logger != nil {
 				o.logger.Error(
 					"repeated failure circuit breaker state transition failed",
@@ -893,10 +922,11 @@ func (o *Orchestrator) parkRepeatedFailure(
 	state.Blocked[issue.ID] = Blocked{
 		Issue:          issue,
 		Reason:         repeatedFailureBlockedReasonPrefix + failure.Error,
-		RecoveryReason: "fix the workflow or agent configuration causing every attempt to fail, then move the issue back to Todo or Rework",
+		RecoveryReason: blockedRecoveryPredicateFingerprintChange,
 		RecoveryTarget: "Todo",
 		BlockedAt:      event.CompletedAt,
 		Source:         BlockedSourceProjectStatus,
+		Recovery:       metadata.BlockedRecovery,
 	}
 	recordStateEvent(state, telemetry.ActivityEvent{
 		At:      event.CompletedAt,
@@ -936,7 +966,7 @@ func repeatedFailureComment(issue connector.Issue, err error, failure RepeatedFa
 	b.WriteString("\n- last error:\n\n```text\n")
 	b.WriteString(runtimeoutput.Truncate(strings.TrimSpace(err.Error()), maxBytes).Value)
 	b.WriteString("\n```")
-	b.WriteString("\n\nFix the workflow or agent configuration causing every attempt to fail, then move the issue back to Todo or Rework.")
+	b.WriteString("\n\nFix the workflow or agent configuration causing every attempt to fail. Detent requeues the issue when the cause fingerprint changes.")
 	return b.String()
 }
 
@@ -965,7 +995,7 @@ func instantFailureComment(issue connector.Issue, err error, failure InstantFail
 		b.WriteString(body)
 		b.WriteString("\n```")
 	}
-	b.WriteString("\n\nFix the pinned agent model or backend configuration, then move the issue back to Todo or Rework.")
+	b.WriteString("\n\nFix the pinned agent model or backend configuration. Detent requeues the issue when the cause fingerprint changes.")
 	return b.String()
 }
 
@@ -1736,7 +1766,16 @@ func (o *Orchestrator) blockExhaustedMergeWorker(
 	if issueID == "" || o.connector == nil {
 		return false
 	}
-	if err := o.updateIssueStateByID(ctx, state, issueID, running.Issue, blockedStatusState, completedAt, mergeWorkerRetryExhaustedReason); err != nil {
+	metadata := o.newBlockedRecoveryMetadata(
+		ctx,
+		running.Issue,
+		RunModeMerge,
+		mergeWorkerRetryExhaustedReason,
+		blockedRecoveryPredicateFingerprintChange,
+		autoPromoteReworkState,
+		running.DiffStats,
+	)
+	if err := o.updateIssueStateByIDWithMetadata(ctx, state, issueID, running.Issue, blockedStatusState, completedAt, mergeWorkerRetryExhaustedReason, metadata); err != nil {
 		if o.logger != nil {
 			o.logger.Warn(
 				"merge_worker_block_failed",
@@ -1781,6 +1820,7 @@ func (o *Orchestrator) blockExhaustedMergeWorker(
 		Reason:    mergeWorkerRetryExhaustedReason,
 		BlockedAt: completedAt,
 		Source:    BlockedSourceProjectStatus,
+		Recovery:  metadata.BlockedRecovery,
 	}
 	recordStateEvent(state, telemetry.ActivityEvent{
 		At:      completedAt,

--- a/internal/orchestrator/run_completion_token_ceiling_test.go
+++ b/internal/orchestrator/run_completion_token_ceiling_test.go
@@ -20,6 +20,8 @@ func TestHandleRunResultParksSlowTokenCeilingFailureWithoutRetry(t *testing.T) {
 		TerminalStates: []string{"Done", "Cancelled"},
 	})
 	orch := &Orchestrator{cfg: cfg, connector: tracker}
+	metrics := &autoPromoteWorkflowMetricsRecorder{}
+	orch.workflowMetrics = metrics
 	state := newState(cfg)
 	issue := connector.Issue{
 		ID:         "issue-token-ceiling",
@@ -65,8 +67,26 @@ func TestHandleRunResultParksSlowTokenCeilingFailureWithoutRetry(t *testing.T) {
 	if blocked.Issue.State != blockedStatusState {
 		t.Fatalf("Blocked[%q].Issue.State = %q, want %q", issue.ID, blocked.Issue.State, blockedStatusState)
 	}
-	if blocked.RecoveryReason != "human_blocker" || blocked.RecoveryTarget != "Rework" {
-		t.Fatalf("Blocked[%q] recovery = %q to %q, want human_blocker to Rework", issue.ID, blocked.RecoveryReason, blocked.RecoveryTarget)
+	if blocked.RecoveryReason != blockedRecoveryPredicateFingerprintChange || blocked.RecoveryTarget != "Rework" {
+		t.Fatalf("Blocked[%q] recovery = %q to %q, want fingerprint recovery to Rework", issue.ID, blocked.RecoveryReason, blocked.RecoveryTarget)
+	}
+	if blocked.Recovery == nil ||
+		blocked.Recovery.Owner != blockedRecoveryOwnerOrchestrator ||
+		blocked.Recovery.Cause != "token_ceiling_circuit_breaker" ||
+		blocked.Recovery.Predicate != blockedRecoveryPredicateFingerprintChange ||
+		blocked.Recovery.CauseFingerprint == "" {
+		t.Fatalf("Blocked[%q].Recovery = %#v, want durable token-ceiling predicate", issue.ID, blocked.Recovery)
+	}
+	events := metrics.snapshot()
+	if len(events) != 2 || events[1].PhaseName != blockedStatusState {
+		t.Fatalf("workflow events = %#v, want Blocked lane entry", events)
+	}
+	laneMetadata, ok := workflowLaneMetadataFromJSON(events[1].MetadataJSON)
+	if !ok || laneMetadata.BlockedRecovery == nil ||
+		laneMetadata.BlockedRecovery.Cause != "token_ceiling_circuit_breaker" ||
+		laneMetadata.BlockedRecovery.Predicate != blockedRecoveryPredicateFingerprintChange ||
+		laneMetadata.BlockedRecovery.CauseFingerprint == "" {
+		t.Fatalf("workflow recovery metadata = %#v, want durable token-ceiling predicate", laneMetadata.BlockedRecovery)
 	}
 	for _, want := range []string{"token ceiling", "16100000", "16000000", "max_session_tokens"} {
 		if !strings.Contains(blocked.Reason, want) {
@@ -74,7 +94,7 @@ func TestHandleRunResultParksSlowTokenCeilingFailureWithoutRetry(t *testing.T) {
 		}
 	}
 	if !stickyBlockReason(blocked.Reason) {
-		t.Fatalf("stickyBlockReason(%q) = false, want token ceiling park to require human recovery", blocked.Reason)
+		t.Fatalf("stickyBlockReason(%q) = false, want current token ceiling park to suppress dependency recovery", blocked.Reason)
 	}
 	orch.setBlockedStatusIssue(&state, connector.Issue{
 		ID:         issue.ID,

--- a/internal/orchestrator/runner.go
+++ b/internal/orchestrator/runner.go
@@ -6,6 +6,8 @@ import (
 
 const FinalStateCompleted = runner.FinalStateCompleted
 
+const RunModeImplement = runner.RunModeImplement
+
 const RunModePlan = runner.RunModePlan
 
 const RunModeMerge = runner.RunModeMerge

--- a/internal/orchestrator/spend_progress.go
+++ b/internal/orchestrator/spend_progress.go
@@ -373,7 +373,16 @@ func (o *Orchestrator) blockSpendProgress(
 	if issueID == "" {
 		return false
 	}
-	if err := o.updateIssueStateByID(ctx, state, issueID, issue, blockedStatusState, blockedAt, spendProgressReason); err != nil {
+	metadata := o.newBlockedRecoveryMetadata(
+		ctx,
+		issue,
+		RunModeImplement,
+		spendProgressReason,
+		blockedRecoveryPredicateFingerprintChange,
+		autoPromoteReworkState,
+		DiffStats{},
+	)
+	if err := o.updateIssueStateByIDWithMetadata(ctx, state, issueID, issue, blockedStatusState, blockedAt, spendProgressReason, metadata); err != nil {
 		if o.logger != nil {
 			o.logger.Warn("spend progress circuit breaker state transition failed", "issue_id", issueID, "identifier", issue.Identifier, "error", err)
 		}
@@ -411,6 +420,7 @@ func (o *Orchestrator) blockSpendProgress(
 		RecoveryTarget: "Rework",
 		BlockedAt:      blockedAt,
 		Source:         BlockedSourceProjectStatus,
+		Recovery:       metadata.BlockedRecovery,
 	}
 	recordStateEvent(state, telemetry.ActivityEvent{
 		At:      blockedAt,

--- a/internal/orchestrator/state.go
+++ b/internal/orchestrator/state.go
@@ -156,6 +156,7 @@ type Blocked struct {
 	Priority        int
 	PriorityName    string
 	StopReason      string
+	Recovery        *workflowLaneBlockedRecoveryMetadata
 }
 
 type Completed struct {

--- a/internal/orchestrator/stop_run.go
+++ b/internal/orchestrator/stop_run.go
@@ -376,7 +376,20 @@ func (o *Orchestrator) finishOperatorStopTransition(ctx context.Context, state *
 			return o.failOperatorStopTransition(ctx, state, issue, result, fmt.Errorf("set priority to %s: %w", result.PriorityName, err))
 		}
 	}
-	err := o.updateIssueStateByIDStrictWithMetadata(ctx, state, issue.ID, issue, result.Destination, result.CompletedAt, string(store.WorkAttemptTerminalOperatorStopped), workflowLaneMetadata{})
+	metadata := workflowLaneMetadata{}
+	if normalizeState(result.Destination) == normalizeState(blockedStatusState) {
+		metadata = o.newBlockedRecoveryMetadata(
+			ctx,
+			issue,
+			RunModeImplement,
+			string(store.WorkAttemptTerminalOperatorStopped),
+			blockedRecoveryPredicateManaged,
+			result.Destination,
+			DiffStats{},
+		)
+		metadata.BlockedRecovery.Owner = blockedRecoveryOwnerOperator
+	}
+	err := o.updateIssueStateByIDStrictWithMetadata(ctx, state, issue.ID, issue, result.Destination, result.CompletedAt, string(store.WorkAttemptTerminalOperatorStopped), metadata)
 	if err != nil {
 		return o.failOperatorStopTransition(ctx, state, issue, result, err)
 	}

--- a/internal/orchestrator/tick.go
+++ b/internal/orchestrator/tick.go
@@ -131,12 +131,12 @@ func (o *Orchestrator) tickWithManual(ctx context.Context, state *State, now tim
 		fetched = filterReconciledTickIssues(
 			state,
 			fetched,
-			o.recoverBackendCapacityBlockedIssues(ctx, state, fetched.status, now),
+			o.recoverBlockedIssues(ctx, state, fetched.status, now),
 		)
 		fetched = filterReconciledTickIssues(
 			state,
 			fetched,
-			o.recoverBlockedIssues(ctx, state, fetched.status, now),
+			o.recoverBackendCapacityBlockedIssues(ctx, state, fetched.status, now),
 		)
 		fetched = filterReconciledTickIssues(
 			state,

--- a/internal/orchestrator/workflow_metrics.go
+++ b/internal/orchestrator/workflow_metrics.go
@@ -34,6 +34,7 @@ type workflowLaneMetadata struct {
 	PullRequest           *workflowLanePullRequestMetadata           `json:"pull_request,omitempty"`
 	DependencyAutoUnblock *workflowLaneDependencyAutoUnblockMetadata `json:"dependency_auto_unblock,omitempty"`
 	ReworkBreaker         *workflowLaneReworkBreakerMetadata         `json:"rework_breaker,omitempty"`
+	BlockedRecovery       *workflowLaneBlockedRecoveryMetadata       `json:"blocked_recovery,omitempty"`
 	ActionSignatures      []workflowLaneActionSignatureMetadata      `json:"action_signatures,omitempty"`
 	Provenance            provenance.Attribution                     `json:"provenance"`
 	Admission             *provenance.Admission                      `json:"admission,omitempty"`
@@ -52,6 +53,16 @@ type workflowLaneDependencyAutoUnblockMetadata struct {
 
 type workflowLaneReworkBreakerMetadata struct {
 	Reason string `json:"reason,omitempty"`
+}
+
+type workflowLaneBlockedRecoveryMetadata struct {
+	Owner            string `json:"owner,omitempty"`
+	Cause            string `json:"cause,omitempty"`
+	Predicate        string `json:"predicate,omitempty"`
+	CauseFingerprint string `json:"cause_fingerprint,omitempty"`
+	TargetState      string `json:"target_state,omitempty"`
+	RunMode          string `json:"run_mode,omitempty"`
+	Resumable        bool   `json:"resumable,omitempty"`
 }
 
 type workflowLaneActionSignatureMetadata struct {
@@ -640,6 +651,24 @@ func workflowLaneMetadataFromJSON(raw string) (workflowLaneMetadata, bool) {
 		return workflowLaneMetadata{}, false
 	}
 	return metadata, true
+}
+
+func BlockedIssueHasCurrentRecoveryPredicate(
+	issue connector.Issue,
+	phaseName string,
+	enteredAt time.Time,
+	metadataJSON string,
+) bool {
+	if normalizeState(issue.State) != normalizeState(blockedStatusState) ||
+		normalizeState(phaseName) != normalizeState(blockedStatusState) ||
+		!blockedEntryMatchesCurrent(issue, enteredAt) {
+		return false
+	}
+	metadata, ok := workflowLaneMetadataFromJSON(metadataJSON)
+	return ok &&
+		metadata.BlockedRecovery != nil &&
+		strings.TrimSpace(metadata.BlockedRecovery.Owner) != "" &&
+		strings.TrimSpace(metadata.BlockedRecovery.Predicate) != ""
 }
 
 func workflowLaneMetadataWithActionSignature(metadata workflowLaneMetadata, action string, signature string) workflowLaneMetadata {

--- a/internal/runner/blocked_recovery.go
+++ b/internal/runner/blocked_recovery.go
@@ -1,0 +1,100 @@
+package runner
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+
+	"github.com/digitaldrywood/detent/internal/workspace"
+)
+
+func (r *Runner) BlockedRecoverySnapshot(ctx context.Context, req RunRequest) BlockedRecoverySnapshot {
+	workflow, runtime, _, _ := r.runtimeSnapshot()
+	snapshot := BlockedRecoverySnapshot{
+		ConfigFingerprint: blockedRecoveryHashYAML(workflow.Config),
+		Health:            "ready",
+	}
+	role := runtime.effectiveRunRole(runRole(req.Mode, req.Issue))
+	_, _, backendConfig, err := runtime.selectBackendForRole(req.Issue, selectorContext(req.SelectorContext, workflow), role)
+	if err != nil {
+		snapshot.Health = "route_unavailable:" + blockedRecoveryHash(err.Error())
+	} else {
+		snapshot.ToolingFingerprint, err = blockedRecoveryToolFingerprint(backendConfig.Command)
+		if err != nil {
+			snapshot.Health = "tool_unavailable:" + blockedRecoveryHash(err.Error())
+		}
+	}
+	reader, ok := r.workspace.(workspace.IssueRecoveryStateProvider)
+	if !ok {
+		snapshot.WorkspaceStatus = "unavailable"
+		return snapshot
+	}
+	recovery, err := reader.IssueRecoveryState(ctx, workspaceIssue(r.projectID, req.Issue))
+	if errors.Is(err, workspace.ErrMissingWorkspace) {
+		snapshot.WorkspaceStatus = "missing"
+		return snapshot
+	}
+	if err != nil {
+		snapshot.WorkspaceStatus = "error:" + blockedRecoveryHash(err.Error())
+		return snapshot
+	}
+	snapshot.WorkspacePresent = true
+	snapshot.BaseFingerprint = strings.TrimSpace(recovery.BaseFingerprint)
+	snapshot.WorkspaceFiles = recovery.DiffStat.Files
+	snapshot.UnpushedCommits = recovery.UnpushedCommits
+	snapshot.WorkspaceFingerprint = strings.TrimSpace(recovery.DiffStat.Fingerprint)
+	if snapshot.WorkspaceFingerprint == "" {
+		snapshot.WorkspaceFingerprint = blockedRecoveryHash(fmt.Sprintf(
+			"files=%d;added=%d;removed=%d;unpushed=%d",
+			recovery.DiffStat.Files,
+			recovery.DiffStat.Added,
+			recovery.DiffStat.Removed,
+			recovery.UnpushedCommits,
+		))
+	}
+	snapshot.WorkspaceStatus = "present"
+	return snapshot
+}
+
+func blockedRecoveryHashYAML(value any) string {
+	data, err := yaml.Marshal(value)
+	if err != nil {
+		return "marshal_error:" + blockedRecoveryHash(err.Error())
+	}
+	return blockedRecoveryHash(string(data))
+}
+
+func blockedRecoveryHash(value string) string {
+	sum := sha256.Sum256([]byte(value))
+	return hex.EncodeToString(sum[:])
+}
+
+func blockedRecoveryToolFingerprint(command string) (string, error) {
+	fields := strings.Fields(strings.TrimSpace(command))
+	if len(fields) == 0 {
+		return "", errors.New("agent backend command is empty")
+	}
+	path, err := exec.LookPath(fields[0])
+	if err != nil {
+		return blockedRecoveryHash(command + ":" + err.Error()), err
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		return blockedRecoveryHash(path + ":" + err.Error()), err
+	}
+	return blockedRecoveryHash(fmt.Sprintf(
+		"command=%s;path=%s;size=%d;mode=%s;modified=%d",
+		command,
+		path,
+		info.Size(),
+		info.Mode(),
+		info.ModTime().UnixNano(),
+	)), nil
+}

--- a/internal/runner/blocked_recovery.go
+++ b/internal/runner/blocked_recovery.go
@@ -49,15 +49,9 @@ func (r *Runner) BlockedRecoverySnapshot(ctx context.Context, req RunRequest) Bl
 	snapshot.BaseFingerprint = strings.TrimSpace(recovery.BaseFingerprint)
 	snapshot.WorkspaceFiles = recovery.DiffStat.Files
 	snapshot.UnpushedCommits = recovery.UnpushedCommits
-	snapshot.WorkspaceFingerprint = strings.TrimSpace(recovery.DiffStat.Fingerprint)
+	snapshot.WorkspaceFingerprint = strings.TrimSpace(recovery.WorkspaceFingerprint)
 	if snapshot.WorkspaceFingerprint == "" {
-		snapshot.WorkspaceFingerprint = blockedRecoveryHash(fmt.Sprintf(
-			"files=%d;added=%d;removed=%d;unpushed=%d",
-			recovery.DiffStat.Files,
-			recovery.DiffStat.Added,
-			recovery.DiffStat.Removed,
-			recovery.UnpushedCommits,
-		))
+		snapshot.WorkspaceFingerprint = strings.TrimSpace(recovery.DiffStat.Fingerprint)
 	}
 	snapshot.WorkspaceStatus = "present"
 	return snapshot

--- a/internal/runner/blocked_recovery_test.go
+++ b/internal/runner/blocked_recovery_test.go
@@ -1,0 +1,39 @@
+package runner
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestBlockedRecoveryToolFingerprintTracksExecutable(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join(t.TempDir(), "agent-tool")
+	if err := os.WriteFile(path, []byte("first"), 0o700); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+	first, err := blockedRecoveryToolFingerprint(path + " app-server")
+	if err != nil {
+		t.Fatalf("blockedRecoveryToolFingerprint() error = %v", err)
+	}
+	if err := os.WriteFile(path, []byte("second-version"), 0o700); err != nil {
+		t.Fatalf("WriteFile() update error = %v", err)
+	}
+	second, err := blockedRecoveryToolFingerprint(path + " app-server")
+	if err != nil {
+		t.Fatalf("blockedRecoveryToolFingerprint() update error = %v", err)
+	}
+	if first == second {
+		t.Fatalf("fingerprint = %q after executable change", second)
+	}
+}
+
+func TestBlockedRecoveryToolFingerprintReportsMissingExecutable(t *testing.T) {
+	t.Parallel()
+
+	fingerprint, err := blockedRecoveryToolFingerprint(filepath.Join(t.TempDir(), "missing-agent"))
+	if err == nil || fingerprint == "" {
+		t.Fatalf("blockedRecoveryToolFingerprint() = %q, %v, want durable missing-tool fingerprint", fingerprint, err)
+	}
+}

--- a/internal/runner/blocked_recovery_test.go
+++ b/internal/runner/blocked_recovery_test.go
@@ -3,13 +3,18 @@ package runner
 import (
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 )
 
 func TestBlockedRecoveryToolFingerprintTracksExecutable(t *testing.T) {
 	t.Parallel()
 
-	path := filepath.Join(t.TempDir(), "agent-tool")
+	name := "agent-tool"
+	if runtime.GOOS == "windows" {
+		name += ".exe"
+	}
+	path := filepath.Join(t.TempDir(), name)
 	if err := os.WriteFile(path, []byte("first"), 0o700); err != nil {
 		t.Fatalf("WriteFile() error = %v", err)
 	}

--- a/internal/runner/types.go
+++ b/internal/runner/types.go
@@ -51,6 +51,22 @@ type Backend interface {
 	Run(context.Context, RunRequest) (RunResult, error)
 }
 
+type BlockedRecoveryInspector interface {
+	BlockedRecoverySnapshot(context.Context, RunRequest) BlockedRecoverySnapshot
+}
+
+type BlockedRecoverySnapshot struct {
+	ConfigFingerprint    string
+	ToolingFingerprint   string
+	BaseFingerprint      string
+	WorkspaceFingerprint string
+	WorkspaceStatus      string
+	WorkspacePresent     bool
+	WorkspaceFiles       int
+	UnpushedCommits      int
+	Health               string
+}
+
 type Validator interface {
 	Validate(context.Context, ValidatorRequest) (gate.ValidatorResult, error)
 }

--- a/internal/workspace/diffstat.go
+++ b/internal/workspace/diffstat.go
@@ -66,7 +66,11 @@ func (l *LocalGit) RecoveryState(ctx context.Context, info Info, issue Issue) (R
 	if err != nil {
 		return RecoveryState{}, err
 	}
-	return RecoveryState{DiffStat: stat, UnpushedCommits: unpushedCommits}, nil
+	return RecoveryState{
+		DiffStat:        stat,
+		BaseFingerprint: gitRecoveryBaseFingerprint(ctx, normalized.Path, issue.BaseRef),
+		UnpushedCommits: unpushedCommits,
+	}, nil
 }
 
 func (l *LocalGit) Diff(ctx context.Context, info Info, issue Issue, maxBytes int) (Diff, error) {
@@ -191,6 +195,17 @@ func gitUnpushedCommitCount(ctx context.Context, workspacePath string) (int, err
 		return 0, fmt.Errorf("parse unpushed commit count: %w", err)
 	}
 	return count, nil
+}
+
+func gitRecoveryBaseFingerprint(ctx context.Context, workspacePath string, baseRef string) string {
+	if baseRef = strings.TrimSpace(baseRef); baseRef != "" {
+		return baseRef
+	}
+	output, err := runGitAt(ctx, workspacePath, "rev-parse", "--verify", "refs/remotes/origin/HEAD")
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(output)
 }
 
 func gitDiffStatWithEnv(ctx context.Context, workspacePath string, env []string, diffBase string) (DiffStat, error) {

--- a/internal/workspace/diffstat.go
+++ b/internal/workspace/diffstat.go
@@ -66,10 +66,15 @@ func (l *LocalGit) RecoveryState(ctx context.Context, info Info, issue Issue) (R
 	if err != nil {
 		return RecoveryState{}, err
 	}
+	head, err := runGitAt(ctx, normalized.Path, "rev-parse", "--verify", "HEAD")
+	if err != nil {
+		return RecoveryState{}, fmt.Errorf("git resolve recovery head: %w", err)
+	}
 	return RecoveryState{
-		DiffStat:        stat,
-		BaseFingerprint: gitRecoveryBaseFingerprint(ctx, normalized.Path, issue.BaseRef),
-		UnpushedCommits: unpushedCommits,
+		DiffStat:             stat,
+		BaseFingerprint:      gitRecoveryBaseFingerprint(ctx, normalized.Path, issue.BaseRef),
+		WorkspaceFingerprint: workspaceRecoveryFingerprint(strings.TrimSpace(head), stat.Fingerprint),
+		UnpushedCommits:      unpushedCommits,
 	}, nil
 }
 
@@ -206,6 +211,21 @@ func gitRecoveryBaseFingerprint(ctx context.Context, workspacePath string, baseR
 		return ""
 	}
 	return strings.TrimSpace(output)
+}
+
+func workspaceRecoveryFingerprint(parts ...string) string {
+	framed := make([]string, 0, len(parts)*2)
+	for _, part := range parts {
+		if part == "" {
+			continue
+		}
+		framed = append(framed, strconv.Itoa(len(part))+":", part)
+	}
+	if len(framed) == 0 {
+		return ""
+	}
+	sum := sha256.Sum256([]byte(strings.Join(framed, "")))
+	return hex.EncodeToString(sum[:])
 }
 
 func gitDiffStatWithEnv(ctx context.Context, workspacePath string, env []string, diffBase string) (DiffStat, error) {

--- a/internal/workspace/diffstat_test.go
+++ b/internal/workspace/diffstat_test.go
@@ -224,6 +224,56 @@ func TestLocalGitRecoveryStateDetectsStrandedWork(t *testing.T) {
 	}
 }
 
+func TestLocalGitRecoveryStateDetectsAmendedCommit(t *testing.T) {
+	t.Parallel()
+
+	source := initSourceRepo(t)
+	remote := initBareRemote(t)
+	runGit(t, source, "remote", "add", "origin", remote)
+	runGit(t, source, "push", "-u", "origin", "main")
+	backend, err := NewBackend(KindLocalGit, LocalGitOptions{
+		Root:       filepath.Join(t.TempDir(), "workspaces"),
+		SourceRoot: source,
+		AutoBranch: true,
+	})
+	if err != nil {
+		t.Fatalf("NewBackend() error = %v", err)
+	}
+	provider := backend.(RecoveryStateProvider)
+	issue := Issue{Identifier: "DD-RECOVERY-AMEND"}
+	info, err := backend.Create(context.Background(), issue)
+	if err != nil {
+		t.Fatalf("Create() error = %v", err)
+	}
+
+	path := filepath.Join(info.Path, "work.txt")
+	if err := os.WriteFile(path, []byte("first\n"), 0o600); err != nil {
+		t.Fatalf("write work file: %v", err)
+	}
+	runGit(t, info.Path, "add", "work.txt")
+	runGit(t, info.Path, "commit", "-m", "test: add work")
+	first, err := provider.RecoveryState(context.Background(), info, issue)
+	if err != nil {
+		t.Fatalf("RecoveryState() error = %v", err)
+	}
+
+	if err := os.WriteFile(path, []byte("other\n"), 0o600); err != nil {
+		t.Fatalf("update work file: %v", err)
+	}
+	runGit(t, info.Path, "add", "work.txt")
+	runGit(t, info.Path, "commit", "--amend", "--no-edit")
+	amended, err := provider.RecoveryState(context.Background(), info, issue)
+	if err != nil {
+		t.Fatalf("RecoveryState() after amend error = %v", err)
+	}
+	if first.UnpushedCommits != amended.UnpushedCommits || first.DiffStat != amended.DiffStat {
+		t.Fatalf("amended recovery counts = %+v, want unchanged from %+v", amended, first)
+	}
+	if first.WorkspaceFingerprint == "" || first.WorkspaceFingerprint == amended.WorkspaceFingerprint {
+		t.Fatalf("amended workspace fingerprint = %q, want change from %q", amended.WorkspaceFingerprint, first.WorkspaceFingerprint)
+	}
+}
+
 func TestLocalGitDiffIsBounded(t *testing.T) {
 	t.Parallel()
 

--- a/internal/workspace/diffstat_test.go
+++ b/internal/workspace/diffstat_test.go
@@ -421,6 +421,14 @@ func TestLocalGitDiffUsesBaseRefForCleanBranch(t *testing.T) {
 	}
 }
 
+func TestGitRecoveryBaseFingerprintUsesConfiguredBase(t *testing.T) {
+	t.Parallel()
+
+	if got := gitRecoveryBaseFingerprint(t.Context(), "", "base-sha"); got != "base-sha" {
+		t.Fatalf("gitRecoveryBaseFingerprint() = %q, want base-sha", got)
+	}
+}
+
 func TestGitDiffStatMissingWorkspaceIsClassified(t *testing.T) {
 	t.Parallel()
 

--- a/internal/workspace/filesystem.go
+++ b/internal/workspace/filesystem.go
@@ -187,6 +187,11 @@ func (f *Filesystem) DiffStat(ctx context.Context, info Info, issue Issue) (Diff
 	if !exists || !isDir {
 		return DiffStat{}, ErrMissingWorkspace
 	}
+	root, err := os.OpenRoot(normalized.Path)
+	if err != nil {
+		return DiffStat{}, fmt.Errorf("open filesystem recovery root: %w", err)
+	}
+	defer f.closeRoot("recovery", root)
 	filesChanged := 0
 	hash := sha256.New()
 	err = filepath.WalkDir(normalized.Path, func(path string, entry fs.DirEntry, walkErr error) error {
@@ -211,14 +216,14 @@ func (f *Filesystem) DiffStat(ctx context.Context, info Info, issue Issue) (Diff
 			return err
 		}
 		if entry.Type()&os.ModeSymlink != 0 {
-			target, err := os.Readlink(path)
+			target, err := root.Readlink(relativePath)
 			if err != nil {
 				return err
 			}
 			_, err = io.WriteString(hash, "symlink\x00"+target+"\x00")
 			return err
 		}
-		file, err := os.Open(path)
+		file, err := root.Open(relativePath)
 		if err != nil {
 			return err
 		}

--- a/internal/workspace/filesystem.go
+++ b/internal/workspace/filesystem.go
@@ -3,6 +3,8 @@ package workspace
 import (
 	"bytes"
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"io"
@@ -173,7 +175,7 @@ func (f *Filesystem) AfterRun(ctx context.Context, info Info, issue Issue) {
 	}
 }
 
-func (f *Filesystem) DiffStat(_ context.Context, info Info, issue Issue) (DiffStat, error) {
+func (f *Filesystem) DiffStat(ctx context.Context, info Info, issue Issue) (DiffStat, error) {
 	normalized, err := f.normalizeInfo(info, issue)
 	if err != nil {
 		return DiffStat{}, err
@@ -186,9 +188,13 @@ func (f *Filesystem) DiffStat(_ context.Context, info Info, issue Issue) (DiffSt
 		return DiffStat{}, ErrMissingWorkspace
 	}
 	filesChanged := 0
+	hash := sha256.New()
 	err = filepath.WalkDir(normalized.Path, func(path string, entry fs.DirEntry, walkErr error) error {
 		if walkErr != nil {
 			return walkErr
+		}
+		if err := ctx.Err(); err != nil {
+			return err
 		}
 		if entry.IsDir() && entry.Name() == ".detent" {
 			return filepath.SkipDir
@@ -197,12 +203,43 @@ func (f *Filesystem) DiffStat(_ context.Context, info Info, issue Issue) (DiffSt
 			return nil
 		}
 		filesChanged++
-		return nil
+		relativePath, err := filepath.Rel(normalized.Path, path)
+		if err != nil {
+			return err
+		}
+		if _, err := io.WriteString(hash, filepath.ToSlash(relativePath)+"\x00"); err != nil {
+			return err
+		}
+		if entry.Type()&os.ModeSymlink != 0 {
+			target, err := os.Readlink(path)
+			if err != nil {
+				return err
+			}
+			_, err = io.WriteString(hash, "symlink\x00"+target+"\x00")
+			return err
+		}
+		file, err := os.Open(path)
+		if err != nil {
+			return err
+		}
+		_, copyErr := io.Copy(hash, file)
+		closeErr := file.Close()
+		if copyErr != nil {
+			return copyErr
+		}
+		if closeErr != nil {
+			return closeErr
+		}
+		_, err = io.WriteString(hash, "\x00")
+		return err
 	})
 	if err != nil {
 		return DiffStat{}, err
 	}
-	return DiffStat{Files: filesChanged}, nil
+	if filesChanged == 0 {
+		return DiffStat{}, nil
+	}
+	return DiffStat{Files: filesChanged, Fingerprint: hex.EncodeToString(hash.Sum(nil))}, nil
 }
 
 func (f *Filesystem) infoForIssue(issue Issue) (Info, error) {
@@ -226,7 +263,10 @@ func (f *Filesystem) IssueRecoveryState(ctx context.Context, issue Issue) (Recov
 	if err != nil {
 		return RecoveryState{}, err
 	}
-	return RecoveryState{DiffStat: diffStat}, nil
+	return RecoveryState{
+		DiffStat:             diffStat,
+		WorkspaceFingerprint: diffStat.Fingerprint,
+	}, nil
 }
 
 func (f *Filesystem) normalizeInfo(info Info, issue Issue) (Info, error) {

--- a/internal/workspace/filesystem.go
+++ b/internal/workspace/filesystem.go
@@ -217,6 +217,18 @@ func (f *Filesystem) infoForIssue(issue Issue) (Info, error) {
 	}, nil
 }
 
+func (f *Filesystem) IssueRecoveryState(ctx context.Context, issue Issue) (RecoveryState, error) {
+	info, err := f.infoForIssue(issue)
+	if err != nil {
+		return RecoveryState{}, err
+	}
+	diffStat, err := f.DiffStat(ctx, info, issue)
+	if err != nil {
+		return RecoveryState{}, err
+	}
+	return RecoveryState{DiffStat: diffStat}, nil
+}
+
 func (f *Filesystem) normalizeInfo(info Info, issue Issue) (Info, error) {
 	key := info.Key
 	if key == "" {

--- a/internal/workspace/filesystem_test.go
+++ b/internal/workspace/filesystem_test.go
@@ -49,6 +49,19 @@ func TestFilesystemWorkspaceCreatesArtifactWorkspaceAndOutputRoot(t *testing.T) 
 	if stat.Files != 1 {
 		t.Fatalf("DiffStat().Files = %d, want 1", stat.Files)
 	}
+	if stat.Fingerprint == "" {
+		t.Fatal("DiffStat().Fingerprint is empty")
+	}
+	if err := os.WriteFile(filepath.Join(info.Path, "artifacts", "manifest.json"), []byte("[]\n"), 0o600); err != nil {
+		t.Fatalf("update artifact: %v", err)
+	}
+	updated, err := backend.DiffStat(context.Background(), info, issue)
+	if err != nil {
+		t.Fatalf("updated DiffStat() error = %v", err)
+	}
+	if updated.Files != stat.Files || updated.Fingerprint == stat.Fingerprint {
+		t.Fatalf("updated DiffStat() = %+v, want unchanged count and changed fingerprint from %+v", updated, stat)
+	}
 
 	result, err := backend.CleanupIssue(context.Background(), issue)
 	if err != nil {

--- a/internal/workspace/workspace.go
+++ b/internal/workspace/workspace.go
@@ -63,8 +63,13 @@ type RecoveryStateProvider interface {
 	RecoveryState(context.Context, Info, Issue) (RecoveryState, error)
 }
 
+type IssueRecoveryStateProvider interface {
+	IssueRecoveryState(context.Context, Issue) (RecoveryState, error)
+}
+
 type RecoveryState struct {
 	DiffStat        DiffStat
+	BaseFingerprint string
 	UnpushedCommits int
 }
 
@@ -496,6 +501,14 @@ func (l *LocalGit) infoForIssue(issue Issue) (Info, error) {
 		Key:    key,
 		Branch: l.branchName(issue, key),
 	}, nil
+}
+
+func (l *LocalGit) IssueRecoveryState(ctx context.Context, issue Issue) (RecoveryState, error) {
+	info, err := l.infoForIssue(issue)
+	if err != nil {
+		return RecoveryState{}, err
+	}
+	return l.RecoveryState(ctx, info, issue)
 }
 
 func (l *LocalGit) normalizeInfo(info Info, issue Issue) (Info, error) {

--- a/internal/workspace/workspace.go
+++ b/internal/workspace/workspace.go
@@ -68,9 +68,10 @@ type IssueRecoveryStateProvider interface {
 }
 
 type RecoveryState struct {
-	DiffStat        DiffStat
-	BaseFingerprint string
-	UnpushedCommits int
+	DiffStat             DiffStat
+	BaseFingerprint      string
+	WorkspaceFingerprint string
+	UnpushedCommits      int
 }
 
 type MergePreparer interface {


### PR DESCRIPTION
## Summary

- record durable Blocked recovery owners, cause fingerprints, predicates, targets, and consumed-attempt signatures
- recover changed causes to Todo or Rework while preserving human, dependency, operator-stop, and managed breaker holds
- scope sticky breaker history to the current Blocked entry and emit a decision for every Blocked issue
- make doctor scan every Blocked issue and warn when no current recovery predicate exists

The root cause was that terminal circuit breakers moved issues into a non-dispatching lane while deleting retry state, but persisted no cause-aware release condition. Older sticky lane history could also suppress a newer dependency park.

This makes recoverable failures self-resuming and bounded across restarts while keeping external-authority blockers explicitly held and observable.

Fixes #1566

## UI Surface Contract

- [x] N/A; this PR does not change UI surfaces.
- [x] This PR does not add persistent top-of-screen messaging.
- [x] No visual changes require screenshot or browser verification.

## Test Plan

- [x] `make check`
- [x] `go test ./internal/orchestrator -run '^$' -fuzz=FuzzSafetyCriticalOrchestratorBoundaries -fuzztime=30s`
- [x] exact-file coverage: `implement_progress.go` 91.91%, `spend_progress.go` 91.12%