### PR TITLE
fix(workflow): require non-draft PRs in shared completion templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -1878,6 +1878,14 @@ repo is a real, working instance of this setup to copy from.
    A runnable local example with seeded work items, artifact metadata, API
    payloads, and artifact-gate transitions lives in
    [`docs/examples/non-code-artifact`](docs/examples/non-code-artifact).
+   Existing GitHub-backed `WORKFLOW.md` copies must be migrated manually:
+   require an open pull request that is marked ready for review and is not a
+   draft before declaring `status: complete`, use `gh pr ready <number>` as the
+   remedy, and verify `gh pr view <number> --json isDraft --jq '.isDraft'`
+   returns `false`. Known deployed copies requiring this audit include
+   `digitaldrywood/video-studio` (tracked by
+   [video-studio#57](https://github.com/digitaldrywood/video-studio/issues/57)),
+   `digitaldrywood/ghostreel`, and the `hostlet.click` workflow.
    They set `server.kanban.mode: integration` for trusted project boards;
    change that to `read_only` only for an observer or shared dashboard,
    explicit no-writes choice, or failed post-authorization write probes. They

--- a/docs/templates/WORKFLOW.github_local.md
+++ b/docs/templates/WORKFLOW.github_local.md
@@ -49,8 +49,15 @@ blockers: []
 human_action: null
 ```
 
-Use `complete` only when the pull request is open, references the issue,
-validation is green, and no actionable review comments remain:
+Use `complete` only when the pull request is open, marked ready for review,
+is not a draft, references the issue, validation is green, and no actionable
+review comments remain. If the pull request is a draft, mark it ready and
+verify the resulting state before declaring completion:
+
+```sh
+gh pr ready <number>
+gh pr view <number> --json isDraft --jq '.isDraft' # must be false
+```
 
 ```detent-status
 schema: 1

--- a/docs/templates/WORKFLOW.issue_field.md
+++ b/docs/templates/WORKFLOW.issue_field.md
@@ -34,8 +34,15 @@ blockers: []
 human_action: null
 ```
 
-Use `complete` only when the pull request is open, references the issue,
-validation is green, and no actionable review comments remain:
+Use `complete` only when the pull request is open, marked ready for review,
+is not a draft, references the issue, validation is green, and no actionable
+review comments remain. If the pull request is a draft, mark it ready and
+verify the resulting state before declaring completion:
+
+```sh
+gh pr ready <number>
+gh pr view <number> --json isDraft --jq '.isDraft' # must be false
+```
 
 ```detent-status
 schema: 1

--- a/docs/templates/WORKFLOW.label.md
+++ b/docs/templates/WORKFLOW.label.md
@@ -34,8 +34,15 @@ blockers: []
 human_action: null
 ```
 
-Use `complete` only when the pull request is open, references the issue,
-validation is green, and no actionable review comments remain:
+Use `complete` only when the pull request is open, marked ready for review,
+is not a draft, references the issue, validation is green, and no actionable
+review comments remain. If the pull request is a draft, mark it ready and
+verify the resulting state before declaring completion:
+
+```sh
+gh pr ready <number>
+gh pr view <number> --json isDraft --jq '.isDraft' # must be false
+```
 
 ```detent-status
 schema: 1

--- a/docs/templates/WORKFLOW.project_v2.md
+++ b/docs/templates/WORKFLOW.project_v2.md
@@ -34,8 +34,15 @@ blockers: []
 human_action: null
 ```
 
-Use `complete` only when the pull request is open, references the issue,
-validation is green, and no actionable review comments remain:
+Use `complete` only when the pull request is open, marked ready for review,
+is not a draft, references the issue, validation is green, and no actionable
+review comments remain. If the pull request is a draft, mark it ready and
+verify the resulting state before declaring completion:
+
+```sh
+gh pr ready <number>
+gh pr view <number> --json isDraft --jq '.isDraft' # must be false
+```
 
 ```detent-status
 schema: 1

--- a/onboarding_docs_test.go
+++ b/onboarding_docs_test.go
@@ -641,6 +641,33 @@ func TestWorkflowTemplatesDocumentStatusEnumAndReviewFlow(t *testing.T) {
 	}
 }
 
+func TestRenderedGitHubWorkflowTemplatesRequireReadyNonDraftPR(t *testing.T) {
+	t.Parallel()
+
+	for _, path := range []string{
+		"docs/templates/WORKFLOW.project_v2.md",
+		"docs/templates/WORKFLOW.issue_field.md",
+		"docs/templates/WORKFLOW.label.md",
+		"docs/templates/WORKFLOW.github_local.md",
+	} {
+		t.Run(path, func(t *testing.T) {
+			t.Parallel()
+
+			content := readRepositoryTextFile(t, path)
+			for _, want := range []string{
+				"Use `complete` only when the pull request is open, marked ready for review, is not a draft",
+				"gh pr ready <number>",
+				"gh pr view <number> --json isDraft --jq '.isDraft' # must be false",
+			} {
+				assertContainsWords(t, content, want)
+			}
+
+			assertOrder(t, content, "gh pr ready <number>", "status: complete")
+			assertOrder(t, content, "gh pr view <number> --json isDraft", "status: complete")
+		})
+	}
+}
+
 func TestOnboardingDocumentsWorkerModelAndSessionGuardChoices(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

- require ready-for-review, non-draft pull requests before shared GitHub workflow templates permit `status: complete`
- include the `gh pr ready` remedy and `isDraft` verification command in every GitHub-backed variant
- add rendered-template regression coverage and document migration for known deployed copies

Fixes #1545

## UI Surface Contract

- [x] N/A; this PR changes workflow documentation and tests only.
- [x] This PR does not add persistent top-of-screen messaging.
- [x] This PR does not change primary operator screens.

## Test Plan

- [x] `go test . -run TestRenderedGitHubWorkflowTemplatesRequireReadyNonDraftPR -count=1`
- [x] `make generate`
- [x] `make check`