### PR TITLE
fix(orchestrator): scope merge startup watchdog

### DIFF
--- a/internal/orchestrator/autopromote_tick.go
+++ b/internal/orchestrator/autopromote_tick.go
@@ -1048,7 +1048,7 @@ func (o *Orchestrator) failStalledMergeWorkerStarts(ctx context.Context, state *
 	}
 	for _, issueID := range sortedKeys(state.Running) {
 		running := state.Running[issueID]
-		if !mergeWorkerIssue(running.Issue) || running.StartedAt.IsZero() || mergeWorkerStartupObserved(running) {
+		if strings.TrimSpace(running.Mode) != runpkg.RunModeMerge || running.StartedAt.IsZero() || mergeWorkerStartupObserved(running) {
 			continue
 		}
 		if now.Before(running.StartedAt.Add(timeout)) {

--- a/internal/orchestrator/autopromote_tick_test.go
+++ b/internal/orchestrator/autopromote_tick_test.go
@@ -3429,8 +3429,9 @@ func TestTickFailsAndRetriesStaleMergingWithoutStartupTelemetry(t *testing.T) {
 	issue.State = "Merging"
 	issue.Identifier = "digitaldrywood/creswoodcorners-phone#63"
 	cfg := normalizeConfig(Config{
-		PollInterval:        time.Minute,
-		MaxConcurrentAgents: 1,
+		PollInterval:         time.Minute,
+		MaxConcurrentAgents:  1,
+		MergeFastPathEnabled: true,
 		MaxConcurrentAgentsByState: map[string]int{
 			"Merging": 1,
 		},
@@ -3492,6 +3493,67 @@ func TestTickFailsAndRetriesStaleMergingWithoutStartupTelemetry(t *testing.T) {
 	}
 }
 
+func TestFailStalledMergeWorkerStartsRequiresMergeRunMode(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 7, 29, 5, 0, 6, 0, time.UTC)
+	enteredMergingAt := now.Add(time.Minute + 2*time.Second)
+	tests := []struct {
+		name        string
+		mode        string
+		wantRunning bool
+	}{
+		{name: "implement", mode: runpkg.RunModeImplement, wantRunning: true},
+		{name: "plan", mode: runpkg.RunModePlan, wantRunning: true},
+		{name: "merge", mode: runpkg.RunModeMerge, wantRunning: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			issue := autoPromoteTickIssue("issue-"+tt.name+"-in-merging", []string{"bug"}, nil)
+			issue.State = "Merging"
+			issue.StageUpdatedAt = &enteredMergingAt
+			issue.Identifier = "getparable/parable#1946"
+			cfg := normalizeConfig(Config{PollInterval: time.Minute})
+			orch := &Orchestrator{
+				cfg:    cfg,
+				logger: slog.New(slog.NewTextHandler(io.Discard, nil)),
+			}
+			state := newState(cfg)
+			cancelled := false
+			state.Running[issue.ID] = Running{
+				Issue:     cloneIssue(issue),
+				Mode:      tt.mode,
+				StartedAt: now.Add(-33*time.Minute - 13*time.Second),
+				cancel: func() {
+					cancelled = true
+				},
+			}
+
+			orch.failStalledMergeWorkerStarts(context.Background(), &state, now)
+
+			_, running := state.Running[issue.ID]
+			if running != tt.wantRunning {
+				t.Fatalf("Running[%q] present = %v, want %v", issue.ID, running, tt.wantRunning)
+			}
+			wantCancelled := !tt.wantRunning
+			if cancelled != wantCancelled {
+				t.Fatalf("cancellation called = %v, want %v", cancelled, wantCancelled)
+			}
+			_, retrying := state.Retry[issue.ID]
+			wantRetry := !tt.wantRunning
+			if retrying != wantRetry {
+				t.Fatalf("Retry[%q] present = %v, want %v", issue.ID, retrying, wantRetry)
+			}
+			if timing := state.MergeTimings[issue.ID]; !timing.MergeFailedAt.IsZero() {
+				t.Fatalf("MergeTimings[%q].MergeFailedAt = %v, want zero", issue.ID, timing.MergeFailedAt)
+			}
+		})
+	}
+}
+
 func TestFailStalledMergeWorkerStartsBlocksAfterRetryCap(t *testing.T) {
 	t.Parallel()
 
@@ -3522,6 +3584,7 @@ func TestFailStalledMergeWorkerStartsBlocksAfterRetryCap(t *testing.T) {
 	state.Running[issue.ID] = Running{
 		Issue:     cloneIssue(issue),
 		Attempt:   maxMergeWorkerRunnerFailures,
+		Mode:      runpkg.RunModeMerge,
 		StartedAt: now.Add(-3 * time.Minute),
 	}
 

--- a/internal/orchestrator/merge_timing.go
+++ b/internal/orchestrator/merge_timing.go
@@ -1,6 +1,7 @@
 package orchestrator
 
 import (
+	"fmt"
 	"strconv"
 	"strings"
 	"time"
@@ -165,7 +166,35 @@ func (o *Orchestrator) recordMergeFailed(state *State, issue connector.Issue, at
 	if !mergeWorkerIssue(issue) {
 		return MergeTiming{}
 	}
-	timing := o.completeMergeTiming(state, issue, at, reason, false)
+	timing := MergeTiming{}
+	if state != nil {
+		timing = state.MergeTimings[strings.TrimSpace(issue.ID)]
+	}
+	enteredMergingAt := timing.EnteredMergingAt
+	if enteredMergingAt.IsZero() {
+		enteredMergingAt = mergeQueueEnteredAt(issue, at)
+	}
+	mergeFailedAt := at.UTC()
+	if mergeFailedAt.Before(enteredMergingAt) {
+		timingErr := fmt.Errorf(
+			"merge_failed_at %s precedes entered_merging_at %s",
+			mergeFailedAt.Format(time.RFC3339),
+			enteredMergingAt.Format(time.RFC3339),
+		)
+		if o.logger != nil {
+			o.logger.Error(
+				"merge_failed_rejected",
+				mergeWorkerLogAttrs(issue,
+					"reason", strings.TrimSpace(reason),
+					"entered_merging_at", enteredMergingAt.Format(time.RFC3339),
+					"merge_failed_at", mergeFailedAt.Format(time.RFC3339),
+					"error", timingErr,
+				)...,
+			)
+		}
+		return timing
+	}
+	timing = o.completeMergeTiming(state, issue, at, reason, false)
 	attrs := []any{"reason", strings.TrimSpace(reason)}
 	if err != nil {
 		attrs = append(attrs, "error", err)

--- a/internal/orchestrator/merge_timing_test.go
+++ b/internal/orchestrator/merge_timing_test.go
@@ -51,6 +51,47 @@ func TestRecordMergeQueueEnteredResetsTerminalAttempt(t *testing.T) {
 	}
 }
 
+func TestRecordMergeFailedRejectsFailureBeforeMergeEntry(t *testing.T) {
+	t.Parallel()
+
+	enteredMergingAt := time.Date(2026, 7, 29, 5, 1, 8, 0, time.UTC)
+	failedAt := enteredMergingAt.Add(-time.Minute - 2*time.Second)
+	issue := connector.Issue{
+		ID:             "issue-invalid-merge-timing",
+		Identifier:     "getparable/parable#1946",
+		State:          "Merging",
+		StageUpdatedAt: &enteredMergingAt,
+	}
+	original := MergeTiming{EnteredMergingAt: enteredMergingAt}
+	state := newState(normalizeConfig(Config{}))
+	state.MergeTimings[issue.ID] = original
+	var logs strings.Builder
+	orch := &Orchestrator{logger: slog.New(slog.NewTextHandler(&logs, nil))}
+
+	got := orch.recordMergeFailed(&state, issue, failedAt, "runner_startup_timeout", nil)
+
+	if got != original {
+		t.Fatalf("recordMergeFailed() = %#v, want unchanged %#v", got, original)
+	}
+	if timing := state.MergeTimings[issue.ID]; timing != original {
+		t.Fatalf("MergeTimings[%q] = %#v, want unchanged %#v", issue.ID, timing, original)
+	}
+	for _, fragment := range []string{
+		"level=ERROR",
+		"msg=merge_failed_rejected",
+		"reason=runner_startup_timeout",
+		"entered_merging_at=2026-07-29T05:01:08Z",
+		"merge_failed_at=2026-07-29T05:00:06Z",
+	} {
+		if !strings.Contains(logs.String(), fragment) {
+			t.Fatalf("logs %q missing fragment %q", logs.String(), fragment)
+		}
+	}
+	if strings.Contains(logs.String(), "msg=merge_failed ") {
+		t.Fatalf("logs %q contain merge_failed record", logs.String())
+	}
+}
+
 func TestObserveMergeSlotConcentrationWarnsOncePerWindow(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

- require explicit merge run mode before enforcing the merge-worker startup watchdog
- preserve implement and plan attempts even if their issue moves into Merging
- reject and error-log merge failure telemetry whose failure time precedes merge entry
- add regression coverage for run-mode scoping and timestamp ordering

Fixes #1533

## UI Surface Contract

- [x] N/A; this PR does not change UI surfaces, layout, density, first-viewport content, or responsive visibility.
- [x] This PR does not add persistent top-of-screen messaging.
- [x] N/A; this PR has no visual changes to primary operator screens.

## Test Plan

- [x] Focused merge-startup and merge-timing regression tests
- [x] `go test ./internal/orchestrator -count=1`
- [x] `make check`