### PR TITLE
fix(config): isolate blocked recovery validation

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -9,6 +9,7 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"slices"
 	"sort"
 	"strconv"
 	"strings"
@@ -933,6 +934,7 @@ func (b *BlockedRecovery) Normalize() {
 }
 
 func (b BlockedRecovery) Validate(prefix string) []string {
+	b.ReasonCodes = slices.Clone(b.ReasonCodes)
 	b.Normalize()
 
 	var problems []string

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -10,6 +10,7 @@ import (
 	"slices"
 	"strconv"
 	"strings"
+	"sync"
 	"testing"
 
 	"gopkg.in/yaml.v3"
@@ -2796,6 +2797,48 @@ func TestObservabilityValidation(t *testing.T) {
 				t.Fatalf("Validate() error = %v, want containing %q", err, tt.wantErr)
 			}
 		})
+	}
+}
+
+func TestBlockedRecoveryValidateConcurrentSharedStorage(t *testing.T) {
+	t.Parallel()
+
+	const validatorCount = 2
+	config := BlockedRecovery{
+		Enabled:      true,
+		SourceStates: []string{" Blocked "},
+		TargetState:  " Rework ",
+		ReasonCodes:  []string{" Merge Conflicts ", " Stale Base ", " Missing Current Head CI "},
+	}
+	wantReasonCodes := slices.Clone(config.ReasonCodes)
+	start := make(chan struct{})
+	results := make(chan []string, validatorCount)
+	var wait sync.WaitGroup
+	wait.Add(validatorCount)
+
+	for range validatorCount {
+		configCopy := config
+		go func() {
+			defer wait.Done()
+			<-start
+			for range 1000 {
+				if problems := configCopy.Validate("tracker.blocked_recovery"); len(problems) > 0 {
+					results <- problems
+					return
+				}
+			}
+		}()
+	}
+
+	close(start)
+	wait.Wait()
+	close(results)
+
+	for problems := range results {
+		t.Errorf("Validate() problems = %v, want none", problems)
+	}
+	if !slices.Equal(config.ReasonCodes, wantReasonCodes) {
+		t.Fatalf("Validate() changed ReasonCodes to %q, want %q", config.ReasonCodes, wantReasonCodes)
 	}
 }
 


### PR DESCRIPTION
## Summary

- clone blocked-recovery reason codes before validation normalization so shallow config copies do not share mutable slice storage
- add a synchronized concurrent regression test that verifies validation leaves the source configuration unchanged

Fixes #1564

## UI Surface Contract

- [x] N/A; this PR does not change UI surfaces, layout, density, first-viewport content, or responsive visibility.
- [x] This PR does not add persistent top-of-screen messaging.
- [x] This PR does not change primary operator screens.

## Test Plan

- [x] `go test -race ./internal/config -run ^TestBlockedRecoveryValidateConcurrentSharedStorage$ -count=10`
- [x] `go test -race ./internal/cli ./internal/runner ./tools/checklock -count=10 -timeout=30m`
- [x] `make check`