### PR TITLE
feat(observability): detect fleet staleness

### DIFF
--- a/config.reference.yaml
+++ b/config.reference.yaml
@@ -856,6 +856,35 @@
 #     service_name: "detent"
 #     # observability.otlp.timeout_ms | type: integer | default: 5000 | required: No | validation: None
 #     timeout_ms: 5000
+#   # observability.staleness | type: object | default: see child fields | required: No | validation: None
+#   staleness:
+#     # observability.staleness.enabled | type: boolean | default: true | required: No | validation: None
+#     enabled: true
+#     # observability.staleness.lanes | type: list<object> | default: [{"State":"Human Review","ThresholdHours":72,"HumanGate":true},{"State":"Blocked","ThresholdHours":48,"HumanGate":false},{"State":"Merging","ThresholdHours":2,"HumanGate":false}] | required: No | validation: None
+#     lanes:
+#       -
+#         # observability.staleness.lanes[].state | type: string | default: "Human Review" | required: Conditional | validation: is required
+#         state: "Human Review"
+#         # observability.staleness.lanes[].threshold_hours | type: integer | default: 72 | required: No | validation: must be greater than 0
+#         threshold_hours: 72
+#         # observability.staleness.lanes[].human_gate | type: boolean | default: true | required: No | validation: None
+#         human_gate: true
+#     # observability.staleness.no_completion_hours | type: integer | default: 24 | required: No | validation: must be greater than 0
+#     no_completion_hours: 24
+#     # observability.staleness.no_merge_hours | type: integer | default: 12 | required: No | validation: must be greater than 0
+#     no_merge_hours: 12
+#     # observability.staleness.repeated_decision_count | type: integer | default: 20 | required: No | validation: must be greater than 0
+#     repeated_decision_count: 20
+#     # observability.staleness.repeated_window_hours | type: integer | default: 24 | required: No | validation: must be greater than 0
+#     repeated_window_hours: 24
+#     # observability.staleness.webhook | type: object | default: see child fields | required: No | validation: None
+#     webhook:
+#       # observability.staleness.webhook.url | type: string | default: none | required: No | validation: must be an absolute http or https URL
+#       url: null
+#       # observability.staleness.webhook.headers | type: mapping<string, string> | default: {} | required: No | validation: None
+#       headers: {}
+#       # observability.staleness.webhook.timeout_ms | type: integer | default: 5000 | required: No | validation: None
+#       timeout_ms: 5000
 # # budget | type: object | default: see child fields | required: No | validation: None
 # budget:
 #   # budget.billing_mode | type: string | default: none | required: No | validation: must be one of metered, subscription

--- a/docs/config.md
+++ b/docs/config.md
@@ -99,6 +99,20 @@ source-state membership, distinct target state, tracker support, and positive
 run limits are enforced by the same validators that feed the generated table
 below.
 
+## Fleet staleness warnings
+
+`observability.staleness` detects work items that exceed lane-specific aging
+thresholds, non-empty dispatch or merge queues that stop advancing, and
+repeated identical scheduler decisions. Human-gate lanes remain warnings rather
+than failures, so they provide a single durable reminder without treating a
+deliberate review wait as an unattended stall.
+
+Warnings appear in the dashboard, `/health`, and `detent doctor`. Configure
+`observability.staleness.webhook.url` to push each newly active warning as a
+`detent.staleness.warning` JSON event. The payload includes a stable warning ID,
+the affected project or item, the reason, and age and threshold values in
+seconds. A delivered warning is not sent again on every scheduler tick.
+
 ## Generated field reference
 
 The generated block reflects the YAML-tagged Go structs reachable from the
@@ -346,6 +360,20 @@ rendering and fails on drift.
 | `observability.otlp.timeout_ms` | `integer` | `5000` | No | None |
 | `observability.refresh_ms` | `integer` | `1000` | No | must be greater than 0 |
 | `observability.render_interval_ms` | `integer` | `16` | No | must be greater than 0 |
+| `observability.staleness` | `object` | `see child fields` | No | None |
+| `observability.staleness.enabled` | `boolean` | `true` | No | None |
+| `observability.staleness.lanes` | `list<object>` | `[{"State":"Human Review","ThresholdHours":72,"HumanGate":true},{"State":"Blocked","ThresholdHours":48,"HumanGate":false},{"State":"Merging","ThresholdHours":2,"HumanGate":false}]` | No | None |
+| `observability.staleness.lanes[].human_gate` | `boolean` | `true` | No | None |
+| `observability.staleness.lanes[].state` | `string` | `"Human Review"` | Conditional | is required |
+| `observability.staleness.lanes[].threshold_hours` | `integer` | `72` | No | must be greater than 0 |
+| `observability.staleness.no_completion_hours` | `integer` | `24` | No | must be greater than 0 |
+| `observability.staleness.no_merge_hours` | `integer` | `12` | No | must be greater than 0 |
+| `observability.staleness.repeated_decision_count` | `integer` | `20` | No | must be greater than 0 |
+| `observability.staleness.repeated_window_hours` | `integer` | `24` | No | must be greater than 0 |
+| `observability.staleness.webhook` | `object` | `see child fields` | No | None |
+| `observability.staleness.webhook.headers` | `mapping<string, string>` | `{}` | No | None |
+| `observability.staleness.webhook.timeout_ms` | `integer` | `5000` | No | None |
+| `observability.staleness.webhook.url` | `string` | `none` | No | must be an absolute http or https URL |
 | `plan` | `object` | `see child fields` | No | agents.backends.options.permission_mode must not be plan for unattended workers |
 | `plan.approval_label` | `string` | `"plan-approved"` | No | None |
 | `plan.enabled` | `boolean` | `false` | No | None |

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -62,6 +62,7 @@ type doctorCheck struct {
 	BacklogAdmission          *doctorAdmissionDiagnostic                 `json:"backlog_admission,omitempty"`
 	OverloadRetriesLastHour   int                                        `json:"overload_retries_last_hour,omitempty"`
 	DependencyCapabilities    []connector.DependencyCapability           `json:"dependency_capabilities,omitempty"`
+	StalenessWarnings         []telemetry.StalenessWarning               `json:"staleness_warnings,omitempty"`
 	UntrackedIssues           []doctorStatusDriftIssueDiagnostic         `json:"untracked_issues,omitempty"`
 	OpenTerminalIssues        []doctorStatusDriftIssueDiagnostic         `json:"open_terminal_issues,omitempty"`
 	ProjectDefinition         *doctorProjectDefinitionDiagnostic         `json:"project_definition,omitempty"`
@@ -507,6 +508,12 @@ func runDoctor(ctx context.Context, cfg doctorConfig, opts options, deps doctorD
 			Name: "Backend capacity",
 			Run: func(jobCtx context.Context) []doctorCheck {
 				return []doctorCheck{checkDoctorBackendCapacity(jobCtx, resolution, boot, cfg.ProjectID, deps, time.Now())}
+			},
+		},
+		doctorCheckJob{
+			Name: "Fleet staleness",
+			Run: func(jobCtx context.Context) []doctorCheck {
+				return []doctorCheck{checkDoctorFleetStaleness(jobCtx, boot, cfg.ProjectID, deps)}
 			},
 		},
 		doctorCheckJob{

--- a/internal/cli/doctor_environment.go
+++ b/internal/cli/doctor_environment.go
@@ -19,6 +19,7 @@ import (
 	workflowconfig "github.com/digitaldrywood/detent/internal/config"
 	globalconfig "github.com/digitaldrywood/detent/internal/config/global"
 	"github.com/digitaldrywood/detent/internal/instancelock"
+	"github.com/digitaldrywood/detent/internal/telemetry"
 )
 
 var doctorHealthCheckKeys = []string{"hub", "store", "registry", "connector"}
@@ -685,12 +686,13 @@ type doctorHealthProbe struct {
 }
 
 type doctorHealthResponse struct {
-	Status      string                  `json:"status"`
-	Mode        string                  `json:"mode"`
-	Checks      map[string]string       `json:"checks"`
-	Environment doctorHealthEnvironment `json:"environment"`
-	Budgets     []doctorHealthBudget    `json:"budgets"`
-	Workflows   []doctorHealthWorkflow  `json:"workflows"`
+	Status            string                       `json:"status"`
+	Mode              string                       `json:"mode"`
+	Checks            map[string]string            `json:"checks"`
+	Environment       doctorHealthEnvironment      `json:"environment"`
+	Budgets           []doctorHealthBudget         `json:"budgets"`
+	Workflows         []doctorHealthWorkflow       `json:"workflows"`
+	StalenessWarnings []telemetry.StalenessWarning `json:"staleness_warnings"`
 }
 
 type doctorHealthEnvironment struct {

--- a/internal/cli/doctor_staleness.go
+++ b/internal/cli/doctor_staleness.go
@@ -1,0 +1,48 @@
+package cli
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/digitaldrywood/detent/internal/telemetry"
+)
+
+func checkDoctorFleetStaleness(ctx context.Context, boot BootConfig, projectID string, deps doctorDeps) doctorCheck {
+	check := doctorCheck{
+		Name:   "Fleet staleness",
+		Status: doctorOK,
+		Detail: "no active fleet staleness warnings",
+	}
+	probe, err := probeDoctorHealth(ctx, doctorLiveBoot(boot, &boot.Global), deps)
+	if err != nil {
+		check.Detail = "live warning check skipped because no healthy Detent instance was reachable"
+		return check
+	}
+	projectID = strings.TrimSpace(projectID)
+	warnings := make([]telemetry.StalenessWarning, 0, len(probe.Health.StalenessWarnings))
+	for _, warning := range probe.Health.StalenessWarnings {
+		if projectID == "" || strings.TrimSpace(warning.ProjectID) == projectID {
+			warnings = append(warnings, warning)
+		}
+	}
+	if len(warnings) == 0 {
+		return check
+	}
+	check.Status = doctorWarn
+	check.StalenessWarnings = warnings
+	check.Detail = fmt.Sprintf("%d active fleet staleness warning(s); oldest: %s", len(warnings), doctorStalenessWarningDetail(warnings[0]))
+	check.Hint = "Review the affected items or queues, then rerun detent doctor after work advances."
+	return check
+}
+
+func doctorStalenessWarningDetail(warning telemetry.StalenessWarning) string {
+	target := strings.TrimSpace(warning.Identifier)
+	if target == "" {
+		target = strings.TrimSpace(warning.IssueID)
+	}
+	if target == "" {
+		target = strings.TrimSpace(warning.ProjectID)
+	}
+	return target + " " + strings.TrimSpace(warning.Reason)
+}

--- a/internal/cli/doctor_staleness_test.go
+++ b/internal/cli/doctor_staleness_test.go
@@ -1,0 +1,62 @@
+package cli
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/digitaldrywood/detent/internal/telemetry"
+)
+
+func TestCheckDoctorFleetStalenessSurfacesLiveWarnings(t *testing.T) {
+	t.Parallel()
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, _ *http.Request) {
+		writer.Header().Set("Content-Type", "application/json")
+		_, _ = writer.Write([]byte(`{
+			"status":"ok",
+			"mode":"running",
+			"checks":{"hub":"configured","store":"configured","registry":"configured","connector":"configured"},
+			"staleness_warnings":[
+				{"id":"warning-1","project_id":"detent","kind":"lane_aging","identifier":"digitaldrywood/detent#1574","reason":"lane threshold exceeded","detail":"stale"}
+			]
+		}`))
+	}))
+	t.Cleanup(server.Close)
+	host, portText := splitStalenessTestServerAddress(t, server)
+	port, err := strconv.Atoi(portText)
+	if err != nil {
+		t.Fatalf("parse server port: %v", err)
+	}
+
+	check := checkDoctorFleetStaleness(t.Context(), BootConfig{Host: host, Port: &port}, "detent", doctorDeps{httpDo: server.Client().Do}.withDefaults())
+	if check.Status != doctorWarn || len(check.StalenessWarnings) != 1 {
+		t.Fatalf("check = %#v, want one warning", check)
+	}
+	if !strings.Contains(check.Detail, "digitaldrywood/detent#1574") {
+		t.Fatalf("detail = %q, want issue identifier", check.Detail)
+	}
+
+	filtered := checkDoctorFleetStaleness(t.Context(), BootConfig{Host: host, Port: &port}, "other", doctorDeps{httpDo: server.Client().Do}.withDefaults())
+	if filtered.Status != doctorOK || len(filtered.StalenessWarnings) != 0 {
+		t.Fatalf("filtered check = %#v, want OK", filtered)
+	}
+}
+
+func TestDoctorStalenessWarningDetailFallsBackToProject(t *testing.T) {
+	t.Parallel()
+	if got := doctorStalenessWarningDetail(telemetry.StalenessWarning{ProjectID: "detent", Reason: "not advancing"}); got != "detent not advancing" {
+		t.Fatalf("doctorStalenessWarningDetail() = %q", got)
+	}
+}
+
+func splitStalenessTestServerAddress(t *testing.T, server *httptest.Server) (string, string) {
+	t.Helper()
+	address := strings.TrimPrefix(server.URL, "http://")
+	index := strings.LastIndex(address, ":")
+	if index < 0 {
+		t.Fatalf("server address = %q", address)
+	}
+	return address[:index], address[index+1:]
+}

--- a/internal/cli/runner.go
+++ b/internal/cli/runner.go
@@ -889,6 +889,7 @@ func mergeSnapshot(current, next telemetry.Snapshot) telemetry.Snapshot {
 	current.BackendOutages = append(current.BackendOutages, next.BackendOutages...)
 	current.FailureBreakers = append(current.FailureBreakers, next.FailureBreakers...)
 	current.DispatchRecoveries = append(current.DispatchRecoveries, next.DispatchRecoveries...)
+	current.StalenessWarnings = append(current.StalenessWarnings, next.StalenessWarnings...)
 	current.AgentPools = append(current.AgentPools, next.AgentPools...)
 	current.OverloadRetriesLastHour += next.OverloadRetriesLastHour
 
@@ -1051,6 +1052,11 @@ func stampSnapshotProjectID(snapshot telemetry.Snapshot) telemetry.Snapshot {
 	for i := range snapshot.DispatchRecoveries {
 		if strings.TrimSpace(snapshot.DispatchRecoveries[i].ProjectID) == "" {
 			snapshot.DispatchRecoveries[i].ProjectID = projectID
+		}
+	}
+	for i := range snapshot.StalenessWarnings {
+		if strings.TrimSpace(snapshot.StalenessWarnings[i].ProjectID) == "" {
+			snapshot.StalenessWarnings[i].ProjectID = projectID
 		}
 	}
 	return snapshot

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -74,6 +74,12 @@ const (
 	MinPollingIntervalMS                  = 60000
 	DefaultShutdownDrainTimeoutMS         = 75000
 	DefaultBoardSnapshotStaleAfterSeconds = 15 * 60
+	DefaultStalenessNoCompletionHours     = 24
+	DefaultStalenessNoMergeHours          = 12
+	DefaultStalenessRepeatedCount         = 20
+	DefaultStalenessRepeatedWindowHours   = 24
+	DefaultStalenessWebhookTimeoutMS      = 5000
+	MaxStalenessRepeatedCount             = 500
 
 	defaultCodexProtocol                      = "app-server"
 	defaultClaudeCodeProtocol                 = "headless"
@@ -701,6 +707,7 @@ type Observability struct {
 	RenderIntervalMS int                     `yaml:"render_interval_ms"`
 	Efficiency       EfficiencyObservability `yaml:"efficiency,omitempty"`
 	OTLP             OTLPObservability       `yaml:"otlp,omitempty"`
+	Staleness        StalenessObservability  `yaml:"staleness,omitempty"`
 }
 
 type EfficiencyObservability struct {
@@ -714,6 +721,28 @@ type OTLPObservability struct {
 	Headers     map[string]string `yaml:"headers,omitempty"`
 	ServiceName string            `yaml:"service_name,omitempty"`
 	TimeoutMS   int               `yaml:"timeout_ms,omitempty"`
+}
+
+type StalenessObservability struct {
+	Enabled               bool                     `yaml:"enabled"`
+	Lanes                 []StalenessLaneThreshold `yaml:"lanes,omitempty"`
+	NoCompletionHours     int                      `yaml:"no_completion_hours"`
+	NoMergeHours          int                      `yaml:"no_merge_hours"`
+	RepeatedDecisionCount int                      `yaml:"repeated_decision_count"`
+	RepeatedWindowHours   int                      `yaml:"repeated_window_hours"`
+	Webhook               StalenessWebhook         `yaml:"webhook,omitempty"`
+}
+
+type StalenessLaneThreshold struct {
+	State          string `yaml:"state"`
+	ThresholdHours int    `yaml:"threshold_hours"`
+	HumanGate      bool   `yaml:"human_gate,omitempty"`
+}
+
+type StalenessWebhook struct {
+	URL       string            `yaml:"url,omitempty"`
+	Headers   map[string]string `yaml:"headers,omitempty"`
+	TimeoutMS int               `yaml:"timeout_ms"`
 }
 
 type Release struct {
@@ -1321,6 +1350,19 @@ func Default() Config {
 				AnomalyDwellMultiple:    3,
 			},
 			OTLP: OTLPObservability{TimeoutMS: 5000, ServiceName: "detent"},
+			Staleness: StalenessObservability{
+				Enabled:               true,
+				NoCompletionHours:     DefaultStalenessNoCompletionHours,
+				NoMergeHours:          DefaultStalenessNoMergeHours,
+				RepeatedDecisionCount: DefaultStalenessRepeatedCount,
+				RepeatedWindowHours:   DefaultStalenessRepeatedWindowHours,
+				Lanes: []StalenessLaneThreshold{
+					{State: "Human Review", ThresholdHours: 72, HumanGate: true},
+					{State: "Blocked", ThresholdHours: 48},
+					{State: "Merging", ThresholdHours: 2},
+				},
+				Webhook: StalenessWebhook{TimeoutMS: DefaultStalenessWebhookTimeoutMS},
+			},
 		},
 		Release: Release{
 			MinMergedIssues: 5,
@@ -1602,6 +1644,7 @@ func (c *Config) normalize() {
 		c.Tracker.ObservedStates = appendStateUnique(c.Tracker.ObservedStates, c.Plan.Stop)
 	}
 	c.Server.Normalize()
+	c.Observability.Normalize()
 	c.Hooks.Shell = commandshell.Normalize(c.Hooks.Shell)
 	c.Intake.Normalize()
 	c.Retro.Normalize()
@@ -2488,6 +2531,7 @@ func (o *Observability) validate(problems *[]string) {
 	validatePositiveFloat("observability.efficiency.anomaly_dwell_multiple", o.Efficiency.AnomalyDwellMultiple, problems)
 	o.OTLP.Endpoint = strings.TrimSpace(o.OTLP.Endpoint)
 	o.OTLP.ServiceName = strings.TrimSpace(o.OTLP.ServiceName)
+	o.Staleness.validate(problems)
 	if o.OTLP.Endpoint == "" {
 		return
 	}
@@ -2499,6 +2543,69 @@ func (o *Observability) validate(problems *[]string) {
 	if o.OTLP.ServiceName == "" {
 		*problems = append(*problems, "observability.otlp.service_name is required when OTLP export is enabled")
 	}
+}
+
+func (o *Observability) Normalize() {
+	if o == nil {
+		return
+	}
+	o.OTLP.Endpoint = strings.TrimSpace(o.OTLP.Endpoint)
+	o.OTLP.ServiceName = strings.TrimSpace(o.OTLP.ServiceName)
+	o.Staleness.Normalize()
+}
+
+func (s *StalenessObservability) Normalize() {
+	if s == nil {
+		return
+	}
+	for index := range s.Lanes {
+		s.Lanes[index].State = strings.TrimSpace(s.Lanes[index].State)
+	}
+	s.Webhook.URL = strings.TrimSpace(s.Webhook.URL)
+	headers := make(map[string]string, len(s.Webhook.Headers))
+	for name, value := range s.Webhook.Headers {
+		name = strings.TrimSpace(name)
+		if name == "" {
+			continue
+		}
+		headers[name] = strings.TrimSpace(value)
+	}
+	s.Webhook.Headers = headers
+}
+
+func (s *StalenessObservability) validate(problems *[]string) {
+	s.Normalize()
+	if !s.Enabled {
+		return
+	}
+	validatePositive("observability.staleness.no_completion_hours", s.NoCompletionHours, problems)
+	validatePositive("observability.staleness.no_merge_hours", s.NoMergeHours, problems)
+	validatePositive("observability.staleness.repeated_decision_count", s.RepeatedDecisionCount, problems)
+	if s.RepeatedDecisionCount > MaxStalenessRepeatedCount {
+		*problems = append(*problems, "observability.staleness.repeated_decision_count must be less than or equal to 500")
+	}
+	validatePositive("observability.staleness.repeated_window_hours", s.RepeatedWindowHours, problems)
+	seen := make(map[string]struct{}, len(s.Lanes))
+	for index, lane := range s.Lanes {
+		prefix := fmt.Sprintf("observability.staleness.lanes[%d]", index)
+		if lane.State == "" {
+			*problems = append(*problems, prefix+".state is required")
+		}
+		key := strings.ToLower(lane.State)
+		if _, ok := seen[key]; key != "" && ok {
+			*problems = append(*problems, prefix+".state must be unique")
+		}
+		seen[key] = struct{}{}
+		validatePositive(prefix+".threshold_hours", lane.ThresholdHours, problems)
+	}
+	if s.Webhook.URL == "" {
+		return
+	}
+	parsed, err := url.Parse(s.Webhook.URL)
+	if err != nil || (parsed.Scheme != "http" && parsed.Scheme != "https") || parsed.Host == "" {
+		*problems = append(*problems, "observability.staleness.webhook.url must be an absolute http or https URL")
+	}
+	validatePositive("observability.staleness.webhook.timeout_ms", s.Webhook.TimeoutMS, problems)
 }
 
 func (h *Hooks) validate(problems *[]string) {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1763,6 +1763,23 @@ Prompt
 	}
 }
 
+func TestDefaultStalenessObservability(t *testing.T) {
+	t.Parallel()
+	cfg := Default()
+	if !cfg.Observability.Staleness.Enabled {
+		t.Fatal("Observability.Staleness.Enabled = false, want true")
+	}
+	if cfg.Observability.Staleness.NoCompletionHours != DefaultStalenessNoCompletionHours {
+		t.Fatalf("NoCompletionHours = %d, want %d", cfg.Observability.Staleness.NoCompletionHours, DefaultStalenessNoCompletionHours)
+	}
+	if len(cfg.Observability.Staleness.Lanes) != 3 {
+		t.Fatalf("Staleness.Lanes = %#v, want three defaults", cfg.Observability.Staleness.Lanes)
+	}
+	if !cfg.Observability.Staleness.Lanes[0].HumanGate {
+		t.Fatal("Human Review default is not marked as a human gate")
+	}
+}
+
 func TestKanbanTransitionPolicyAllowsConfiguredOverridesWithoutStateLists(t *testing.T) {
 	t.Parallel()
 

--- a/internal/orchestrator/config.go
+++ b/internal/orchestrator/config.go
@@ -10,6 +10,7 @@ import (
 	"github.com/digitaldrywood/detent/internal/efficiency"
 	"github.com/digitaldrywood/detent/internal/gate"
 	"github.com/digitaldrywood/detent/internal/selector"
+	"github.com/digitaldrywood/detent/internal/staleness"
 )
 
 func ConfigFromWorkflow(cfg workflowconfig.Config) Config {
@@ -114,6 +115,31 @@ func ConfigFromWorkflow(cfg workflowconfig.Config) Config {
 			SessionsMultiple: cfg.Observability.Efficiency.AnomalySessionsMultiple,
 			DwellMultiple:    cfg.Observability.Efficiency.AnomalyDwellMultiple,
 		},
+		Staleness: stalenessConfigFromWorkflow(cfg.Observability.Staleness),
+		StalenessDelivery: staleness.DeliveryConfig{
+			WebhookURL: cfg.Observability.Staleness.Webhook.URL,
+			Headers:    cloneStringMap(cfg.Observability.Staleness.Webhook.Headers),
+			Timeout:    durationFromMillis(cfg.Observability.Staleness.Webhook.TimeoutMS),
+		},
+	}
+}
+
+func stalenessConfigFromWorkflow(cfg workflowconfig.StalenessObservability) staleness.Config {
+	lanes := make([]staleness.LaneThreshold, 0, len(cfg.Lanes))
+	for _, lane := range cfg.Lanes {
+		lanes = append(lanes, staleness.LaneThreshold{
+			State:     lane.State,
+			Threshold: time.Duration(lane.ThresholdHours) * time.Hour,
+			HumanGate: lane.HumanGate,
+		})
+	}
+	return staleness.Config{
+		Enabled:                cfg.Enabled,
+		Lanes:                  lanes,
+		NoCompletionThreshold:  time.Duration(cfg.NoCompletionHours) * time.Hour,
+		NoMergeThreshold:       time.Duration(cfg.NoMergeHours) * time.Hour,
+		RepeatedDecisionCount:  cfg.RepeatedDecisionCount,
+		RepeatedDecisionWindow: time.Duration(cfg.RepeatedWindowHours) * time.Hour,
 	}
 }
 
@@ -207,6 +233,9 @@ func normalizeConfig(cfg Config) Config {
 	cfg.SelectorContext.Persona = strings.TrimSpace(cfg.SelectorContext.Persona)
 	cfg.WorkerHosts = normalizeWorkerHosts(cfg.WorkerHosts)
 	cfg.SelectorPersona = strings.TrimSpace(cfg.SelectorPersona)
+	cfg.Staleness.Lanes = append([]staleness.LaneThreshold(nil), cfg.Staleness.Lanes...)
+	cfg.StalenessDelivery.WebhookURL = strings.TrimSpace(cfg.StalenessDelivery.WebhookURL)
+	cfg.StalenessDelivery.Headers = cloneStringMap(cfg.StalenessDelivery.Headers)
 	if cfg.MaxConcurrentAgentsPerHost < 0 {
 		cfg.MaxConcurrentAgentsPerHost = 0
 	}

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -18,6 +18,7 @@ import (
 	runpkg "github.com/digitaldrywood/detent/internal/runner"
 	"github.com/digitaldrywood/detent/internal/scheduler"
 	"github.com/digitaldrywood/detent/internal/selector"
+	"github.com/digitaldrywood/detent/internal/staleness"
 	"github.com/digitaldrywood/detent/internal/store"
 	"github.com/digitaldrywood/detent/internal/telemetry"
 )
@@ -109,6 +110,8 @@ type Config struct {
 	OutputTruncationMaxBytes      int
 	EfficiencyThresholds          efficiency.Thresholds
 	Lessons                       LessonCaptureConfig
+	Staleness                     staleness.Config
+	StalenessDelivery             staleness.DeliveryConfig
 }
 
 type LessonCaptureConfig struct {
@@ -135,26 +138,27 @@ type ClaimingConfig struct {
 }
 
 type Dependencies struct {
-	Connector          connector.Connector
-	Runner             Runner
-	WorkspaceReaper    WorkspaceReaper
-	WorkflowMetrics    WorkflowMetricsRecorder
-	Efficiency         efficiency.Recorder
-	LifecycleExporter  efficiency.LifecycleExporter
-	WorkAttempts       store.WorkAttemptStore
-	ProgressSpend      store.ProgressSpendStore
-	AgentResume        store.AgentResumeStore
-	OrphanSessions     store.OrphanSessionStore
-	ValidatorMemo      store.ValidatorMemoStore
-	Activity           *activity.Broker
-	Release            releasepkg.Coordinator
-	GlobalDispatchGate scheduler.ProjectDispatchGate
-	Now                func() time.Time
-	Logger             *slog.Logger
-	Retrospector       Retrospector
-	WorkerProcesses    WorkerProcessStore
-	ReapWorkerProcess  WorkerProcessReapFunc
-	WorkerReapGrace    time.Duration
+	Connector            connector.Connector
+	Runner               Runner
+	WorkspaceReaper      WorkspaceReaper
+	WorkflowMetrics      WorkflowMetricsRecorder
+	Efficiency           efficiency.Recorder
+	LifecycleExporter    efficiency.LifecycleExporter
+	WorkAttempts         store.WorkAttemptStore
+	ProgressSpend        store.ProgressSpendStore
+	AgentResume          store.AgentResumeStore
+	OrphanSessions       store.OrphanSessionStore
+	ValidatorMemo        store.ValidatorMemoStore
+	Activity             *activity.Broker
+	Release              releasepkg.Coordinator
+	GlobalDispatchGate   scheduler.ProjectDispatchGate
+	Now                  func() time.Time
+	Logger               *slog.Logger
+	Retrospector         Retrospector
+	WorkerProcesses      WorkerProcessStore
+	ReapWorkerProcess    WorkerProcessReapFunc
+	WorkerReapGrace      time.Duration
+	NewStalenessNotifier func(staleness.DeliveryConfig) (staleness.Notifier, error)
 }
 
 type WorkerProcessStore interface {
@@ -216,6 +220,7 @@ type Orchestrator struct {
 	workerProcesses         WorkerProcessStore
 	reapWorkerProcess       WorkerProcessReapFunc
 	workerReapGrace         time.Duration
+	newStalenessNotifier    func(staleness.DeliveryConfig) (staleness.Notifier, error)
 	mergeWorkerLimit        runDurationLimitFactory
 	heartbeats              *heartbeatManager
 	hydrationSkipStreaks    map[string]int
@@ -417,6 +422,10 @@ func New(cfg Config, deps Dependencies) (*Orchestrator, error) {
 	if workerReapGrace <= 0 {
 		workerReapGrace = procgroup.DefaultTerminationGrace
 	}
+	newStalenessNotifier := deps.NewStalenessNotifier
+	if newStalenessNotifier == nil {
+		newStalenessNotifier = staleness.NewNotifier
+	}
 
 	supervisor, err := runpkg.NewSupervisor(runner, runpkg.SupervisorConfig{
 		MaxRetryBackoff:       cfg.MaxRetryBackoff,
@@ -455,6 +464,7 @@ func New(cfg Config, deps Dependencies) (*Orchestrator, error) {
 		workerProcesses:         workerProcesses,
 		reapWorkerProcess:       reapWorkerProcess,
 		workerReapGrace:         workerReapGrace,
+		newStalenessNotifier:    newStalenessNotifier,
 		projectID:               cfg.Project.ID,
 		capacityController:      capacityController,
 		capacityStatus:          capacityStatus,

--- a/internal/orchestrator/orchestrator_test.go
+++ b/internal/orchestrator/orchestrator_test.go
@@ -1093,7 +1093,7 @@ func TestRunRefreshHydratesRunningIssueComments(t *testing.T) {
 	issue := testIssue("issue-workpad", "digitaldrywood/detent#646", "Todo")
 	tracker := newFakeConnector(issue)
 	runner := newBlockingRunner()
-	orch := newTestOrchestrator(t, tracker, runner)
+	orch := newTestOrchestratorWithPollInterval(t, tracker, runner, time.Hour)
 	stop := runOrchestrator(t, orch)
 	defer stop()
 

--- a/internal/orchestrator/snapshot.go
+++ b/internal/orchestrator/snapshot.go
@@ -104,6 +104,7 @@ func (s State) Snapshot(now time.Time) telemetry.Snapshot {
 		BackendOutages:          backendOutageSnapshots(s.BackendOutages),
 		FailureBreakers:         projectFailureBreakerSnapshots(s.FailureBreaker),
 		DispatchRecoveries:      dispatchRecoverySnapshots(s.DispatchRecoveries, s.PoolName, poolCapacity),
+		StalenessWarnings:       stalenessWarningSnapshots(s.StalenessWarnings),
 		OverloadRetriesLastHour: overloadRetriesLastHour(s.WorkAttempts, now),
 		Tokens:                  tokensFromTokenTotals(s.liveTokenTotals()),
 		Budget: telemetry.Budget{

--- a/internal/orchestrator/staleness.go
+++ b/internal/orchestrator/staleness.go
@@ -1,0 +1,298 @@
+package orchestrator
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/digitaldrywood/detent/internal/connector"
+	"github.com/digitaldrywood/detent/internal/staleness"
+	"github.com/digitaldrywood/detent/internal/store"
+	"github.com/digitaldrywood/detent/internal/telemetry"
+)
+
+const (
+	stalenessDeliveryRetryBase = 5 * time.Minute
+	stalenessDeliveryRetryMax  = time.Hour
+	stalenessDeliveriesPerTick = 1
+)
+
+func (o *Orchestrator) refreshStalenessWarnings(ctx context.Context, state *State, candidates []connector.Issue, now time.Time) {
+	if o == nil || state == nil {
+		return
+	}
+	if !o.cfg.Staleness.Enabled {
+		state.StalenessWarnings = map[string]StalenessWarning{}
+		return
+	}
+	evaluated := staleness.Evaluate(o.cfg.Staleness, staleness.Input{
+		ProjectID:    strings.TrimSpace(o.cfg.Project.ID),
+		Items:        o.stalenessItems(stateLaneEntryIssues(state), state),
+		Dispatchable: o.stalenessDispatchableItems(candidates, state, now),
+		MergeQueue:   o.stalenessMergeQueueItems(state),
+		Completions:  stalenessCompletions(state),
+		Decisions:    stalenessDecisions(state.SchedulerDecisions),
+	}, now)
+	previous := state.StalenessWarnings
+	next := make(map[string]StalenessWarning, len(evaluated))
+	for _, warning := range evaluated {
+		current, exists := previous[warning.ID]
+		if !exists {
+			current = StalenessWarning{
+				Warning:    warning,
+				DetectedAt: now.UTC(),
+			}
+			recordStateEvent(state, telemetry.ActivityEvent{
+				At:      now.UTC(),
+				Event:   "fleet_staleness_warning",
+				Message: stalenessWarningMessage(warning),
+			})
+			if o.logger != nil {
+				o.logger.Warn("fleet staleness warning", "project_id", warning.ProjectID, "kind", warning.Kind, "issue_id", warning.IssueID, "identifier", warning.Identifier, "lane", warning.Lane, "reason", warning.Reason, "age_seconds", warning.AgeSeconds, "threshold_seconds", warning.ThresholdSeconds, "count", warning.Count, "waiting_on_human", warning.WaitingOnHuman)
+			}
+		}
+		current.Warning = warning
+		current.LastObservedAt = now.UTC()
+		next[warning.ID] = current
+	}
+	state.StalenessWarnings = next
+	o.deliverStalenessWarnings(ctx, state, now)
+}
+
+func (o *Orchestrator) stalenessItems(issues []connector.Issue, state *State) []staleness.Item {
+	items := make([]staleness.Item, 0, len(issues))
+	seen := make(map[string]struct{})
+	for _, issue := range issues {
+		key := workflowLaneEntryKey(issue)
+		if key == "" {
+			continue
+		}
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		seen[key] = struct{}{}
+		items = append(items, o.stalenessItem(issue, state))
+	}
+	return items
+}
+
+func (o *Orchestrator) stalenessDispatchableItems(candidates []connector.Issue, state *State, now time.Time) []staleness.Item {
+	items := make([]staleness.Item, 0, len(candidates))
+	seen := make(map[string]struct{})
+	planner := o.dispatchPlanner()
+	for _, issue := range candidates {
+		if !planner.dispatchableIssueDecision(issue, state, false, now, "").dispatchable {
+			continue
+		}
+		key := workflowIssueIdentityKey(issue)
+		if key == "" {
+			continue
+		}
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		seen[key] = struct{}{}
+		items = append(items, o.stalenessItem(issue, state))
+	}
+	return items
+}
+
+func (o *Orchestrator) stalenessMergeQueueItems(state *State) []staleness.Item {
+	issues := append(cloneIssues(state.BoardIssues), state.Pipeline...)
+	items := make([]staleness.Item, 0)
+	seen := make(map[string]struct{})
+	for _, issue := range issues {
+		if normalizeState(issue.State) != normalizeState(autoPromoteMergingState) {
+			continue
+		}
+		key := workflowIssueIdentityKey(issue)
+		if key == "" {
+			continue
+		}
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		seen[key] = struct{}{}
+		items = append(items, o.stalenessItem(issue, state))
+	}
+	return items
+}
+
+func (o *Orchestrator) stalenessItem(issue connector.Issue, state *State) staleness.Item {
+	enteredAt := state.laneEntries[workflowLaneEntryKey(issue)]
+	if enteredAt.IsZero() {
+		enteredAt = workflowLaneFallbackAt(issue)
+	}
+	hasRecovery := len(issue.BlockedBy) > 0
+	if blocked, ok := state.Blocked[strings.TrimSpace(issue.ID)]; ok {
+		hasRecovery = hasRecovery || blocked.Recovery != nil || strings.TrimSpace(blocked.RecoveryReason) != ""
+	}
+	return staleness.Item{
+		ID:                   strings.TrimSpace(issue.ID),
+		Identifier:           strings.TrimSpace(issue.Identifier),
+		URL:                  strings.TrimSpace(issue.URL),
+		Title:                strings.TrimSpace(issue.Title),
+		State:                strings.TrimSpace(issue.State),
+		EnteredAt:            enteredAt.UTC(),
+		WaitingOnHuman:       artifactGateWaitStatusBlocksDispatch(issue, o.cfg.AutoPromote.Gate),
+		HasRecoveryPredicate: hasRecovery,
+	}
+}
+
+func stalenessCompletions(state *State) []staleness.Completion {
+	completions := make([]staleness.Completion, 0, len(state.WorkAttempts)+len(state.Completed)+len(state.MergeTimings))
+	for _, attempt := range state.WorkAttempts {
+		if attempt.TerminalState != string(store.WorkAttemptTerminalSuccess) || attempt.CompletedAt == nil || attempt.CompletedAt.IsZero() {
+			continue
+		}
+		completions = append(completions, staleness.Completion{
+			At:     attempt.CompletedAt.UTC(),
+			Merged: strings.EqualFold(strings.TrimSpace(attempt.WorkerType), "merge"),
+		})
+	}
+	for _, completed := range state.Completed {
+		if completed.CompletedAt.IsZero() {
+			continue
+		}
+		completions = append(completions, staleness.Completion{
+			At:     completed.CompletedAt.UTC(),
+			Merged: !completed.MergeTiming.MergedAt.IsZero(),
+		})
+	}
+	for _, timing := range state.MergeTimings {
+		if timing.MergedAt.IsZero() {
+			continue
+		}
+		completions = append(completions, staleness.Completion{At: timing.MergedAt.UTC(), Merged: true})
+	}
+	return completions
+}
+
+func stalenessDecisions(decisions []telemetry.SchedulerDecision) []staleness.Decision {
+	out := make([]staleness.Decision, 0, len(decisions))
+	for _, decision := range decisions {
+		out = append(out, staleness.Decision{
+			IssueID:    strings.TrimSpace(decision.IssueID),
+			Identifier: strings.TrimSpace(decision.Identifier),
+			IssueURL:   strings.TrimSpace(decision.IssueURL),
+			Reason:     strings.TrimSpace(decision.Reason),
+			At:         decision.DecisionAt.UTC(),
+		})
+	}
+	return out
+}
+
+func (o *Orchestrator) deliverStalenessWarnings(ctx context.Context, state *State, now time.Time) {
+	if o.newStalenessNotifier == nil || strings.TrimSpace(o.cfg.StalenessDelivery.WebhookURL) == "" {
+		return
+	}
+	notifier, err := o.newStalenessNotifier(o.cfg.StalenessDelivery)
+	if err != nil {
+		o.recordStalenessNotifierError(state, now, err)
+		return
+	}
+	if notifier == nil {
+		return
+	}
+	ids := sortedKeys(state.StalenessWarnings)
+	attempted := 0
+	for _, id := range ids {
+		current := state.StalenessWarnings[id]
+		if !current.DeliveredAt.IsZero() || !stalenessDeliveryDue(current, now) {
+			continue
+		}
+		if attempted >= stalenessDeliveriesPerTick {
+			break
+		}
+		attempted++
+		current.DeliveryAttempts++
+		current.LastDeliveryAttemptAt = now.UTC()
+		err := notifier.Notify(ctx, current.Warning)
+		if err != nil {
+			current.DeliveryError = err.Error()
+			if o.logger != nil {
+				o.logger.Warn("deliver fleet staleness warning failed", "warning_id", id, "project_id", current.Warning.ProjectID, "error", err)
+			}
+		} else {
+			current.DeliveredAt = now.UTC()
+			current.DeliveryError = ""
+		}
+		state.StalenessWarnings[id] = current
+	}
+}
+
+func (o *Orchestrator) recordStalenessNotifierError(state *State, now time.Time, err error) {
+	for id, current := range state.StalenessWarnings {
+		if !current.DeliveredAt.IsZero() || !stalenessDeliveryDue(current, now) {
+			continue
+		}
+		current.DeliveryAttempts++
+		current.LastDeliveryAttemptAt = now.UTC()
+		current.DeliveryError = err.Error()
+		state.StalenessWarnings[id] = current
+	}
+}
+
+func stalenessDeliveryDue(warning StalenessWarning, now time.Time) bool {
+	if warning.LastDeliveryAttemptAt.IsZero() {
+		return true
+	}
+	delay := stalenessDeliveryRetryBase
+	for attempt := 1; attempt < warning.DeliveryAttempts && delay < stalenessDeliveryRetryMax; attempt++ {
+		delay *= 2
+	}
+	if delay > stalenessDeliveryRetryMax {
+		delay = stalenessDeliveryRetryMax
+	}
+	return !now.Before(warning.LastDeliveryAttemptAt.Add(delay))
+}
+
+func stalenessWarningMessage(warning staleness.Warning) string {
+	target := strings.TrimSpace(warning.Identifier)
+	if target == "" {
+		target = strings.TrimSpace(warning.IssueID)
+	}
+	if target == "" {
+		target = strings.TrimSpace(warning.ProjectID)
+	}
+	return fmt.Sprintf("%s: %s (%s)", target, warning.Detail, warning.Reason)
+}
+
+func stalenessWarningSnapshots(values map[string]StalenessWarning) []telemetry.StalenessWarning {
+	ids := make([]string, 0, len(values))
+	for id := range values {
+		ids = append(ids, id)
+	}
+	sort.Strings(ids)
+	out := make([]telemetry.StalenessWarning, 0, len(ids))
+	for _, id := range ids {
+		value := values[id]
+		out = append(out, telemetry.StalenessWarning{
+			ID:                    value.Warning.ID,
+			ProjectID:             value.Warning.ProjectID,
+			Kind:                  value.Warning.Kind,
+			IssueID:               value.Warning.IssueID,
+			Identifier:            value.Warning.Identifier,
+			IssueURL:              value.Warning.IssueURL,
+			Title:                 value.Warning.Title,
+			Lane:                  value.Warning.Lane,
+			Reason:                value.Warning.Reason,
+			Detail:                value.Warning.Detail,
+			Since:                 value.Warning.Since,
+			DetectedAt:            value.DetectedAt,
+			LastObservedAt:        value.LastObservedAt,
+			AgeSeconds:            value.Warning.AgeSeconds,
+			ThresholdSeconds:      value.Warning.ThresholdSeconds,
+			Count:                 value.Warning.Count,
+			WaitingOnHuman:        value.Warning.WaitingOnHuman,
+			HasRecoveryPredicate:  value.Warning.HasRecoveryPredicate,
+			DeliveredAt:           timePointer(value.DeliveredAt),
+			DeliveryAttempts:      value.DeliveryAttempts,
+			LastDeliveryAttemptAt: timePointer(value.LastDeliveryAttemptAt),
+			DeliveryError:         value.DeliveryError,
+		})
+	}
+	return out
+}

--- a/internal/orchestrator/staleness_test.go
+++ b/internal/orchestrator/staleness_test.go
@@ -1,0 +1,149 @@
+package orchestrator
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/digitaldrywood/detent/internal/connector"
+	"github.com/digitaldrywood/detent/internal/selector"
+	"github.com/digitaldrywood/detent/internal/staleness"
+)
+
+func TestRefreshStalenessWarningsEmitsAndDeliversOncePerActiveCondition(t *testing.T) {
+	t.Parallel()
+	now := time.Date(2026, 7, 30, 15, 0, 0, 0, time.UTC)
+	enteredAt := now.Add(-3 * time.Hour)
+	issue := connector.Issue{
+		ID:             "issue-1574",
+		Identifier:     "digitaldrywood/detent#1574",
+		State:          "Merging",
+		StageUpdatedAt: &enteredAt,
+	}
+	cfg := normalizeConfig(Config{
+		Staleness: staleness.Config{
+			Enabled: true,
+			Lanes: []staleness.LaneThreshold{{
+				State:     "Merging",
+				Threshold: 2 * time.Hour,
+			}},
+		},
+	})
+	cfg.Project.ID = "detent"
+	deliveries := 0
+	orch := &Orchestrator{
+		cfg: cfg,
+		newStalenessNotifier: func(staleness.DeliveryConfig) (staleness.Notifier, error) {
+			return stalenessNotifierFunc(func(context.Context, staleness.Warning) error {
+				deliveries++
+				return nil
+			}), nil
+		},
+	}
+	orch.cfg.StalenessDelivery.WebhookURL = "https://example.test/warnings"
+	state := newState(cfg)
+	state.BoardIssues = []connector.Issue{issue}
+	state.laneEntries[workflowLaneEntryKey(issue)] = enteredAt
+
+	orch.refreshStalenessWarnings(t.Context(), &state, nil, now)
+	orch.refreshStalenessWarnings(t.Context(), &state, nil, now.Add(time.Minute))
+
+	if len(state.StalenessWarnings) != 1 {
+		t.Fatalf("staleness warnings = %#v, want one active warning", state.StalenessWarnings)
+	}
+	if deliveries != 1 {
+		t.Fatalf("webhook deliveries = %d, want 1", deliveries)
+	}
+	events := 0
+	for _, event := range state.RecentEvents {
+		if event.Event == "fleet_staleness_warning" {
+			events++
+		}
+	}
+	if events != 1 {
+		t.Fatalf("fleet_staleness_warning events = %d, want 1", events)
+	}
+}
+
+func TestDeliverStalenessWarningsBoundsWorkPerTick(t *testing.T) {
+	t.Parallel()
+	now := time.Date(2026, 7, 30, 15, 0, 0, 0, time.UTC)
+	cfg := normalizeConfig(Config{
+		Staleness: staleness.Config{
+			Enabled: true,
+			Lanes: []staleness.LaneThreshold{{
+				State:     "Merging",
+				Threshold: time.Hour,
+			}},
+		},
+	})
+	cfg.Project.ID = "detent"
+	deliveries := 0
+	orch := &Orchestrator{
+		cfg: cfg,
+		newStalenessNotifier: func(staleness.DeliveryConfig) (staleness.Notifier, error) {
+			return stalenessNotifierFunc(func(context.Context, staleness.Warning) error {
+				deliveries++
+				return nil
+			}), nil
+		},
+	}
+	orch.cfg.StalenessDelivery.WebhookURL = "https://example.test/warnings"
+	state := newState(cfg)
+	for _, id := range []string{"issue-a", "issue-b"} {
+		enteredAt := now.Add(-2 * time.Hour)
+		issue := connector.Issue{ID: id, Identifier: id, State: "Merging", StageUpdatedAt: &enteredAt}
+		state.BoardIssues = append(state.BoardIssues, issue)
+		state.laneEntries[workflowLaneEntryKey(issue)] = enteredAt
+	}
+
+	orch.refreshStalenessWarnings(t.Context(), &state, nil, now)
+	if deliveries != 1 {
+		t.Fatalf("first tick webhook deliveries = %d, want 1", deliveries)
+	}
+	orch.refreshStalenessWarnings(t.Context(), &state, nil, now.Add(time.Minute))
+	if deliveries != 2 {
+		t.Fatalf("second tick webhook deliveries = %d, want 2", deliveries)
+	}
+}
+
+func TestStalenessDispatchableItemsUsesDispatchPlannerEligibility(t *testing.T) {
+	t.Parallel()
+	now := time.Date(2026, 7, 30, 15, 0, 0, 0, time.UTC)
+	cfg := normalizeConfig(Config{
+		MaxConcurrentAgents: 1,
+		ActiveStates:        []string{"Todo"},
+		TerminalStates:      []string{"Done"},
+		Authorization: selector.Selector{
+			Labels: selector.Labels{Include: []string{"authorized"}},
+		},
+	})
+	orch := &Orchestrator{cfg: cfg}
+	state := newState(cfg)
+	unauthorized := connector.Issue{
+		ID:               "issue-a",
+		Identifier:       "issue-a",
+		Title:            "Unauthorized issue",
+		State:            "Todo",
+		AssignedToWorker: true,
+	}
+	authorized := connector.Issue{
+		ID:               "issue-b",
+		Identifier:       "issue-b",
+		Title:            "Authorized issue",
+		State:            "Todo",
+		Labels:           []string{"authorized"},
+		AssignedToWorker: true,
+	}
+
+	items := orch.stalenessDispatchableItems([]connector.Issue{unauthorized, authorized}, &state, now)
+	if len(items) != 1 || items[0].ID != authorized.ID {
+		t.Fatalf("dispatchable staleness items = %#v, want only authorized issue", items)
+	}
+}
+
+type stalenessNotifierFunc func(context.Context, staleness.Warning) error
+
+func (fn stalenessNotifierFunc) Notify(ctx context.Context, warning staleness.Warning) error {
+	return fn(ctx, warning)
+}

--- a/internal/orchestrator/state.go
+++ b/internal/orchestrator/state.go
@@ -16,6 +16,7 @@ import (
 	"github.com/digitaldrywood/detent/internal/runtimeoutput"
 	"github.com/digitaldrywood/detent/internal/scheduler"
 	"github.com/digitaldrywood/detent/internal/selector"
+	"github.com/digitaldrywood/detent/internal/staleness"
 	"github.com/digitaldrywood/detent/internal/store"
 	"github.com/digitaldrywood/detent/internal/telemetry"
 	"github.com/digitaldrywood/detent/internal/workpad"
@@ -74,6 +75,7 @@ type State struct {
 	RepeatedFailures         map[string]RepeatedFailure
 	FailureBreaker           ProjectFailureBreaker
 	DispatchRecoveries       map[string]DispatchRecovery
+	StalenessWarnings        map[string]StalenessWarning
 	BackendOutages           map[string]BackendOutage
 	BackendRecoveries        map[string]BackendRecovery
 	DiffStats                map[string]DiffStats
@@ -86,6 +88,16 @@ type State struct {
 	epicTransitionWatch      []connector.Issue
 	pendingEpicParentLookups map[string]connector.Issue
 	tickTransitions          *issueStateSnapshotTransitions
+}
+
+type StalenessWarning struct {
+	Warning               staleness.Warning
+	DetectedAt            time.Time
+	LastObservedAt        time.Time
+	DeliveredAt           time.Time
+	DeliveryAttempts      int
+	LastDeliveryAttemptAt time.Time
+	DeliveryError         string
 }
 
 type Running struct {
@@ -282,6 +294,7 @@ func newState(cfg Config) State {
 		RepeatedFailures:         map[string]RepeatedFailure{},
 		FailureBreaker:           newProjectFailureBreaker(cfg.FailureBreaker),
 		DispatchRecoveries:       map[string]DispatchRecovery{},
+		StalenessWarnings:        map[string]StalenessWarning{},
 		BackendOutages:           map[string]BackendOutage{},
 		BackendRecoveries:        map[string]BackendRecovery{},
 		DiffStats:                map[string]DiffStats{},
@@ -347,6 +360,7 @@ func (s State) clone() State {
 		RepeatedFailures:         make(map[string]RepeatedFailure, len(s.RepeatedFailures)),
 		FailureBreaker:           cloneProjectFailureBreaker(s.FailureBreaker),
 		DispatchRecoveries:       cloneDispatchRecoveries(s.DispatchRecoveries),
+		StalenessWarnings:        maps.Clone(s.StalenessWarnings),
 		BackendOutages:           maps.Clone(s.BackendOutages),
 		BackendRecoveries:        maps.Clone(s.BackendRecoveries),
 		DiffStats:                make(map[string]DiffStats, len(s.DiffStats)),

--- a/internal/orchestrator/tick.go
+++ b/internal/orchestrator/tick.go
@@ -217,6 +217,7 @@ func (o *Orchestrator) tickWithManual(ctx context.Context, state *State, now tim
 			state.tickTransitions.boardIssues,
 		)
 		o.refreshCurrentLaneEntries(ctx, state, now)
+		o.refreshStalenessWarnings(ctx, state, fetched.candidates, now)
 		o.markRefreshSucceeded(state, now)
 	}
 	state.Pipeline = overlayIssueStateSnapshots(state.Pipeline, state.tickTransitions.pipeline)

--- a/internal/orchestrator/work_attempts.go
+++ b/internal/orchestrator/work_attempts.go
@@ -20,7 +20,7 @@ import (
 const (
 	defaultWorkAttemptLeaseTTL      = 10 * time.Minute
 	maxRecentWorkAttemptSnapshots   = 50
-	maxRecentSchedulerDecisions     = 100
+	maxRecentSchedulerDecisions     = 500
 	workAttemptErrorRunner          = "runner_error"
 	workAttemptErrorStartTransition = "start_state_transition_failed"
 	workAttemptErrorMergeIncomplete = "merge_worker_terminal_state_missing"
@@ -82,6 +82,19 @@ func (o *Orchestrator) recoverDurableWorkAttempts(ctx context.Context, state *St
 	} else {
 		for index := len(recent) - 1; index >= 0; index-- {
 			o.upsertWorkAttemptSnapshot(state, telemetryWorkAttempt(recent[index], now))
+		}
+	}
+	decisions, err := o.workAttempts.ListRecentSchedulerDecisions(ctx, store.SchedulerDecisionQuery{
+		ProjectID: projectID,
+		Limit:     maxRecentSchedulerDecisions,
+	})
+	if err != nil {
+		if o.logger != nil {
+			o.logger.Warn("scheduler decision history recovery failed", "project_id", projectID, "error", err)
+		}
+	} else {
+		for _, decision := range slices.Backward(decisions) {
+			appendSchedulerDecisionSnapshot(state, telemetrySchedulerDecision(decision))
 		}
 	}
 	o.recoverOrphanedAgentSessions(ctx, state, orphanedSessions, now)

--- a/internal/staleness/notifier.go
+++ b/internal/staleness/notifier.go
@@ -1,0 +1,108 @@
+package staleness
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+)
+
+type DeliveryConfig struct {
+	WebhookURL string
+	Headers    map[string]string
+	Timeout    time.Duration
+}
+
+type Notification struct {
+	Schema  int     `json:"schema"`
+	Event   string  `json:"event"`
+	Warning Warning `json:"warning"`
+}
+
+type Notifier interface {
+	Notify(context.Context, Warning) error
+}
+
+func NewNotifier(cfg DeliveryConfig) (Notifier, error) {
+	cfg.WebhookURL = strings.TrimSpace(cfg.WebhookURL)
+	if cfg.WebhookURL == "" {
+		return nil, errors.New("staleness webhook URL is required")
+	}
+	if cfg.Timeout <= 0 {
+		cfg.Timeout = 5 * time.Second
+	}
+	return &webhookNotifier{
+		url:     cfg.WebhookURL,
+		headers: cloneHeaders(cfg.Headers),
+		client:  &http.Client{Timeout: cfg.Timeout},
+	}, nil
+}
+
+type webhookNotifier struct {
+	url     string
+	headers map[string]string
+	client  *http.Client
+}
+
+func (n *webhookNotifier) Notify(ctx context.Context, warning Warning) error {
+	if n == nil || n.client == nil {
+		return errors.New("staleness webhook notifier is not configured")
+	}
+	payload, err := json.Marshal(Notification{
+		Schema:  1,
+		Event:   "detent.staleness.warning",
+		Warning: warning,
+	})
+	if err != nil {
+		return fmt.Errorf("marshal staleness webhook: %w", err)
+	}
+	request, err := http.NewRequestWithContext(ctx, http.MethodPost, n.url, bytes.NewReader(payload))
+	if err != nil {
+		return fmt.Errorf("build staleness webhook request: %w", err)
+	}
+	request.Header.Set("Content-Type", "application/json")
+	request.Header.Set("User-Agent", "detent-staleness-watchdog")
+	for name, value := range n.headers {
+		request.Header.Set(name, value)
+	}
+	response, err := n.client.Do(request)
+	if err != nil {
+		return fmt.Errorf("deliver staleness webhook: %w", err)
+	}
+	defer response.Body.Close()
+	if response.StatusCode >= http.StatusOK && response.StatusCode < http.StatusMultipleChoices {
+		if _, err := io.Copy(io.Discard, io.LimitReader(response.Body, 4096)); err != nil {
+			return fmt.Errorf("drain staleness webhook response: %w", err)
+		}
+		return nil
+	}
+	body, err := io.ReadAll(io.LimitReader(response.Body, 4096))
+	if err != nil {
+		return fmt.Errorf("read staleness webhook response: %w", err)
+	}
+	detail := strings.TrimSpace(string(body))
+	if detail == "" {
+		detail = http.StatusText(response.StatusCode)
+	}
+	return fmt.Errorf("deliver staleness webhook: HTTP %d: %s", response.StatusCode, detail)
+}
+
+func cloneHeaders(headers map[string]string) map[string]string {
+	if len(headers) == 0 {
+		return nil
+	}
+	cloned := make(map[string]string, len(headers))
+	for name, value := range headers {
+		name = strings.TrimSpace(name)
+		if name == "" {
+			continue
+		}
+		cloned[name] = strings.TrimSpace(value)
+	}
+	return cloned
+}

--- a/internal/staleness/staleness.go
+++ b/internal/staleness/staleness.go
@@ -1,0 +1,334 @@
+package staleness
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"sort"
+	"strings"
+	"time"
+)
+
+const (
+	KindLaneAging          = "lane_aging"
+	KindProjectLiveness    = "project_liveness"
+	KindMergeLiveness      = "merge_liveness"
+	KindRepeatedDecision   = "repeated_decision"
+	defaultWarningIDLength = 16
+)
+
+type Config struct {
+	Enabled                bool
+	Lanes                  []LaneThreshold
+	NoCompletionThreshold  time.Duration
+	NoMergeThreshold       time.Duration
+	RepeatedDecisionCount  int
+	RepeatedDecisionWindow time.Duration
+}
+
+type LaneThreshold struct {
+	State     string
+	Threshold time.Duration
+	HumanGate bool
+}
+
+type Input struct {
+	ProjectID    string
+	Items        []Item
+	Dispatchable []Item
+	MergeQueue   []Item
+	Completions  []Completion
+	Decisions    []Decision
+}
+
+type Item struct {
+	ID                   string
+	Identifier           string
+	URL                  string
+	Title                string
+	State                string
+	EnteredAt            time.Time
+	WaitingOnHuman       bool
+	HasRecoveryPredicate bool
+}
+
+type Completion struct {
+	At     time.Time
+	Merged bool
+}
+
+type Decision struct {
+	IssueID    string
+	Identifier string
+	IssueURL   string
+	Reason     string
+	At         time.Time
+}
+
+type Warning struct {
+	ID                   string    `json:"id"`
+	ProjectID            string    `json:"project_id,omitempty"`
+	Kind                 string    `json:"kind"`
+	IssueID              string    `json:"issue_id,omitempty"`
+	Identifier           string    `json:"identifier,omitempty"`
+	IssueURL             string    `json:"issue_url,omitempty"`
+	Title                string    `json:"title,omitempty"`
+	Lane                 string    `json:"lane,omitempty"`
+	Reason               string    `json:"reason"`
+	Detail               string    `json:"detail"`
+	Since                time.Time `json:"since"`
+	AgeSeconds           int64     `json:"age_seconds"`
+	ThresholdSeconds     int64     `json:"threshold_seconds"`
+	Count                int       `json:"count,omitempty"`
+	WaitingOnHuman       bool      `json:"waiting_on_human,omitempty"`
+	HasRecoveryPredicate bool      `json:"has_recovery_predicate,omitempty"`
+}
+
+func Evaluate(cfg Config, input Input, now time.Time) []Warning {
+	if !cfg.Enabled || now.IsZero() {
+		return nil
+	}
+	now = now.UTC()
+	warnings := laneWarnings(cfg, input, now)
+	if warning, ok := projectLivenessWarning(cfg, input, now); ok {
+		warnings = append(warnings, warning)
+	}
+	if warning, ok := mergeLivenessWarning(cfg, input, now); ok {
+		warnings = append(warnings, warning)
+	}
+	warnings = append(warnings, repeatedDecisionWarnings(cfg, input, now)...)
+	sort.SliceStable(warnings, func(i, j int) bool {
+		if warnings[i].Since.Equal(warnings[j].Since) {
+			return warnings[i].ID < warnings[j].ID
+		}
+		return warnings[i].Since.Before(warnings[j].Since)
+	})
+	return warnings
+}
+
+func laneWarnings(cfg Config, input Input, now time.Time) []Warning {
+	thresholds := make(map[string]LaneThreshold, len(cfg.Lanes))
+	for _, threshold := range cfg.Lanes {
+		state := normalize(threshold.State)
+		if state == "" || threshold.Threshold <= 0 {
+			continue
+		}
+		thresholds[state] = threshold
+	}
+	warnings := make([]Warning, 0)
+	seen := make(map[string]struct{})
+	for _, item := range input.Items {
+		threshold, ok := thresholds[normalize(item.State)]
+		if !ok || item.EnteredAt.IsZero() || item.EnteredAt.After(now) {
+			continue
+		}
+		age := now.Sub(item.EnteredAt)
+		if age < threshold.Threshold {
+			continue
+		}
+		identity := itemIdentity(item)
+		if identity == "" {
+			continue
+		}
+		key := KindLaneAging + "\x00" + identity + "\x00" + normalize(item.State)
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		seen[key] = struct{}{}
+		waitingOnHuman := threshold.HumanGate || item.WaitingOnHuman
+		warnings = append(warnings, Warning{
+			ID:                   warningID(key),
+			ProjectID:            strings.TrimSpace(input.ProjectID),
+			Kind:                 KindLaneAging,
+			IssueID:              strings.TrimSpace(item.ID),
+			Identifier:           strings.TrimSpace(item.Identifier),
+			IssueURL:             strings.TrimSpace(item.URL),
+			Title:                strings.TrimSpace(item.Title),
+			Lane:                 strings.TrimSpace(item.State),
+			Reason:               "lane threshold exceeded",
+			Detail:               laneWarningDetail(item, waitingOnHuman),
+			Since:                item.EnteredAt.UTC(),
+			AgeSeconds:           int64(age / time.Second),
+			ThresholdSeconds:     int64(threshold.Threshold / time.Second),
+			WaitingOnHuman:       waitingOnHuman,
+			HasRecoveryPredicate: item.HasRecoveryPredicate,
+		})
+	}
+	return warnings
+}
+
+func projectLivenessWarning(cfg Config, input Input, now time.Time) (Warning, bool) {
+	if cfg.NoCompletionThreshold <= 0 || len(input.Dispatchable) == 0 {
+		return Warning{}, false
+	}
+	baseline := latestCompletion(input.Completions, false, now)
+	queueSince := earliestItemTime(input.Dispatchable, now)
+	baseline = laterTime(baseline, queueSince)
+	if baseline.IsZero() || now.Sub(baseline) < cfg.NoCompletionThreshold {
+		return Warning{}, false
+	}
+	projectID := strings.TrimSpace(input.ProjectID)
+	key := KindProjectLiveness + "\x00" + projectID
+	return Warning{
+		ID:               warningID(key),
+		ProjectID:        projectID,
+		Kind:             KindProjectLiveness,
+		Reason:           "dispatchable work has no recent completion",
+		Detail:           "dispatchable work is queued but the project has not completed work",
+		Since:            baseline.UTC(),
+		AgeSeconds:       int64(now.Sub(baseline) / time.Second),
+		ThresholdSeconds: int64(cfg.NoCompletionThreshold / time.Second),
+		Count:            len(input.Dispatchable),
+	}, true
+}
+
+func mergeLivenessWarning(cfg Config, input Input, now time.Time) (Warning, bool) {
+	if cfg.NoMergeThreshold <= 0 || len(input.MergeQueue) == 0 {
+		return Warning{}, false
+	}
+	baseline := latestCompletion(input.Completions, true, now)
+	queueSince := earliestItemTime(input.MergeQueue, now)
+	baseline = laterTime(baseline, queueSince)
+	if baseline.IsZero() || now.Sub(baseline) < cfg.NoMergeThreshold {
+		return Warning{}, false
+	}
+	projectID := strings.TrimSpace(input.ProjectID)
+	key := KindMergeLiveness + "\x00" + projectID
+	return Warning{
+		ID:               warningID(key),
+		ProjectID:        projectID,
+		Kind:             KindMergeLiveness,
+		Lane:             "Merging",
+		Reason:           "merge queue has no recent success",
+		Detail:           "the merge queue is non-empty but the project has no recent successful merge",
+		Since:            baseline.UTC(),
+		AgeSeconds:       int64(now.Sub(baseline) / time.Second),
+		ThresholdSeconds: int64(cfg.NoMergeThreshold / time.Second),
+		Count:            len(input.MergeQueue),
+	}, true
+}
+
+func repeatedDecisionWarnings(cfg Config, input Input, now time.Time) []Warning {
+	if cfg.RepeatedDecisionCount <= 0 || cfg.RepeatedDecisionWindow <= 0 {
+		return nil
+	}
+	type group struct {
+		decision Decision
+		count    int
+		first    time.Time
+		last     time.Time
+	}
+	cutoff := now.Add(-cfg.RepeatedDecisionWindow)
+	groups := make(map[string]group)
+	for _, decision := range input.Decisions {
+		identity := decisionIdentity(decision)
+		reason := strings.TrimSpace(decision.Reason)
+		if identity == "" || reason == "" || decision.At.IsZero() || decision.At.Before(cutoff) || decision.At.After(now) {
+			continue
+		}
+		key := identity + "\x00" + reason
+		current := groups[key]
+		if current.count == 0 {
+			current.decision = decision
+			current.first = decision.At.UTC()
+		}
+		current.count++
+		if current.last.IsZero() || decision.At.After(current.last) {
+			current.last = decision.At.UTC()
+		}
+		if decision.At.Before(current.first) {
+			current.first = decision.At.UTC()
+		}
+		groups[key] = current
+	}
+	warnings := make([]Warning, 0)
+	for key, current := range groups {
+		if current.count < cfg.RepeatedDecisionCount {
+			continue
+		}
+		warnings = append(warnings, Warning{
+			ID:               warningID(KindRepeatedDecision + "\x00" + key),
+			ProjectID:        strings.TrimSpace(input.ProjectID),
+			Kind:             KindRepeatedDecision,
+			IssueID:          strings.TrimSpace(current.decision.IssueID),
+			Identifier:       strings.TrimSpace(current.decision.Identifier),
+			IssueURL:         strings.TrimSpace(current.decision.IssueURL),
+			Reason:           strings.TrimSpace(current.decision.Reason),
+			Detail:           "the same scheduler decision has recurred beyond its configured threshold",
+			Since:            current.first,
+			AgeSeconds:       int64(now.Sub(current.first) / time.Second),
+			ThresholdSeconds: int64(cfg.RepeatedDecisionWindow / time.Second),
+			Count:            current.count,
+		})
+	}
+	return warnings
+}
+
+func laneWarningDetail(item Item, waitingOnHuman bool) string {
+	if waitingOnHuman {
+		return "the item is waiting on a person by design and has exceeded its reminder threshold"
+	}
+	if normalize(item.State) == "blocked" && !item.HasRecoveryPredicate {
+		return "the item is blocked beyond its threshold without a recovery predicate"
+	}
+	return "the item has remained in the same lane beyond its configured threshold"
+}
+
+func latestCompletion(completions []Completion, mergedOnly bool, now time.Time) time.Time {
+	var latest time.Time
+	for _, completion := range completions {
+		if completion.At.IsZero() || completion.At.After(now) || mergedOnly && !completion.Merged {
+			continue
+		}
+		if latest.IsZero() || completion.At.After(latest) {
+			latest = completion.At.UTC()
+		}
+	}
+	return latest
+}
+
+func earliestItemTime(items []Item, now time.Time) time.Time {
+	var earliest time.Time
+	for _, item := range items {
+		if item.EnteredAt.IsZero() || item.EnteredAt.After(now) {
+			continue
+		}
+		if earliest.IsZero() || item.EnteredAt.Before(earliest) {
+			earliest = item.EnteredAt.UTC()
+		}
+	}
+	return earliest
+}
+
+func laterTime(left time.Time, right time.Time) time.Time {
+	if left.IsZero() || right.After(left) {
+		return right
+	}
+	return left
+}
+
+func itemIdentity(item Item) string {
+	for _, value := range []string{item.ID, item.Identifier, item.URL} {
+		if value = strings.TrimSpace(value); value != "" {
+			return value
+		}
+	}
+	return ""
+}
+
+func decisionIdentity(decision Decision) string {
+	for _, value := range []string{decision.IssueID, decision.Identifier, decision.IssueURL} {
+		if value = strings.TrimSpace(value); value != "" {
+			return value
+		}
+	}
+	return ""
+}
+
+func warningID(key string) string {
+	sum := sha256.Sum256([]byte(key))
+	return hex.EncodeToString(sum[:])[:defaultWarningIDLength]
+}
+
+func normalize(value string) string {
+	return strings.ToLower(strings.TrimSpace(value))
+}

--- a/internal/staleness/staleness_test.go
+++ b/internal/staleness/staleness_test.go
@@ -1,0 +1,156 @@
+package staleness
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+func TestEvaluate(t *testing.T) {
+	t.Parallel()
+	now := time.Date(2026, 7, 30, 15, 0, 0, 0, time.UTC)
+	cfg := Config{
+		Enabled: true,
+		Lanes: []LaneThreshold{
+			{State: "Human Review", Threshold: 48 * time.Hour, HumanGate: true},
+			{State: "Blocked", Threshold: 24 * time.Hour},
+		},
+		NoCompletionThreshold:  12 * time.Hour,
+		NoMergeThreshold:       6 * time.Hour,
+		RepeatedDecisionCount:  3,
+		RepeatedDecisionWindow: 24 * time.Hour,
+	}
+
+	tests := []struct {
+		name      string
+		input     Input
+		wantKinds []string
+		wantHuman bool
+	}{
+		{
+			name: "lane threshold emits one human reminder",
+			input: Input{
+				ProjectID: "detent",
+				Items: []Item{
+					{ID: "41", State: "Human Review", EnteredAt: now.Add(-72 * time.Hour)},
+					{ID: "41", State: "Human Review", EnteredAt: now.Add(-72 * time.Hour)},
+				},
+			},
+			wantKinds: []string{KindLaneAging},
+			wantHuman: true,
+		},
+		{
+			name: "dispatchable queue without completions warns",
+			input: Input{
+				ProjectID:    "detent",
+				Dispatchable: []Item{{ID: "1", EnteredAt: now.Add(-13 * time.Hour)}},
+			},
+			wantKinds: []string{KindProjectLiveness},
+		},
+		{
+			name: "empty queue without completions stays quiet",
+			input: Input{
+				ProjectID: "detent",
+			},
+		},
+		{
+			name: "recently populated queue stays quiet",
+			input: Input{
+				ProjectID:    "detent",
+				Dispatchable: []Item{{ID: "1", EnteredAt: now.Add(-time.Hour)}},
+				Completions:  []Completion{{At: now.Add(-48 * time.Hour)}},
+			},
+		},
+		{
+			name: "merge queue without success warns",
+			input: Input{
+				ProjectID:  "detent",
+				MergeQueue: []Item{{ID: "2", EnteredAt: now.Add(-7 * time.Hour)}},
+			},
+			wantKinds: []string{KindMergeLiveness},
+		},
+		{
+			name: "repeated identical decisions warn",
+			input: Input{
+				ProjectID: "detent",
+				Decisions: []Decision{
+					{IssueID: "3", Reason: "merge_slot_revoked", At: now.Add(-3 * time.Hour)},
+					{IssueID: "3", Reason: "merge_slot_revoked", At: now.Add(-2 * time.Hour)},
+					{IssueID: "3", Reason: "merge_slot_revoked", At: now.Add(-time.Hour)},
+					{IssueID: "3", Reason: "other", At: now.Add(-time.Hour)},
+				},
+			},
+			wantKinds: []string{KindRepeatedDecision},
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := Evaluate(cfg, tt.input, now)
+			if len(got) != len(tt.wantKinds) {
+				t.Fatalf("Evaluate() warnings = %#v, want kinds %v", got, tt.wantKinds)
+			}
+			for index, kind := range tt.wantKinds {
+				if got[index].Kind != kind {
+					t.Fatalf("Evaluate()[%d].Kind = %q, want %q", index, got[index].Kind, kind)
+				}
+			}
+			if len(got) > 0 && got[0].WaitingOnHuman != tt.wantHuman {
+				t.Fatalf("Evaluate()[0].WaitingOnHuman = %t, want %t", got[0].WaitingOnHuman, tt.wantHuman)
+			}
+		})
+	}
+}
+
+func TestNewNotifierDeliversWebhook(t *testing.T) {
+	t.Parallel()
+	received := make(chan Notification, 1)
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		if got := request.Header.Get("Authorization"); got != "Bearer example" {
+			t.Errorf("Authorization = %q, want Bearer example", got)
+		}
+		var payload Notification
+		if err := json.NewDecoder(request.Body).Decode(&payload); err != nil {
+			t.Errorf("decode payload: %v", err)
+		}
+		received <- payload
+		writer.WriteHeader(http.StatusNoContent)
+	}))
+	t.Cleanup(server.Close)
+
+	notifier, err := NewNotifier(DeliveryConfig{
+		WebhookURL: server.URL,
+		Headers:    map[string]string{"Authorization": "Bearer example"},
+		Timeout:    time.Second,
+	})
+	if err != nil {
+		t.Fatalf("NewNotifier() error = %v", err)
+	}
+	warning := Warning{
+		ID:               "warning-1",
+		Kind:             KindLaneAging,
+		AgeSeconds:       3600,
+		ThresholdSeconds: 1800,
+	}
+	if err := notifier.Notify(t.Context(), warning); err != nil {
+		t.Fatalf("Notify() error = %v", err)
+	}
+	payload := <-received
+	if payload.Schema != 1 || payload.Event != "detent.staleness.warning" || payload.Warning.ID != warning.ID {
+		t.Fatalf("payload = %#v", payload)
+	}
+	if payload.Warning.AgeSeconds != 3600 || payload.Warning.ThresholdSeconds != 1800 {
+		t.Fatalf("payload warning durations = %#v", payload.Warning)
+	}
+}
+
+func TestNewNotifierRejectsMissingURL(t *testing.T) {
+	t.Parallel()
+	if _, err := NewNotifier(DeliveryConfig{}); err == nil {
+		t.Fatal("NewNotifier() error = nil, want missing URL error")
+	}
+}

--- a/internal/telemetry/snapshot.go
+++ b/internal/telemetry/snapshot.go
@@ -41,6 +41,7 @@ type Snapshot struct {
 	BackendOutages          []BackendOutage     `json:"backend_outages,omitempty"`
 	FailureBreakers         []FailureBreaker    `json:"failure_breakers,omitempty"`
 	DispatchRecoveries      []DispatchRecovery  `json:"dispatch_recoveries,omitempty"`
+	StalenessWarnings       []StalenessWarning  `json:"staleness_warnings,omitempty"`
 	OverloadRetriesLastHour int                 `json:"overload_retries_last_hour,omitempty"`
 	Tokens                  Tokens              `json:"tokens"`
 	Throughput              TokenThroughput     `json:"throughput"`
@@ -74,6 +75,31 @@ type DispatchRecovery struct {
 	MaxConcurrent int       `json:"max_concurrent"`
 	Admitted      int       `json:"admitted"`
 	Progressed    int       `json:"progressed"`
+}
+
+type StalenessWarning struct {
+	ID                    string     `json:"id"`
+	ProjectID             string     `json:"project_id,omitempty"`
+	Kind                  string     `json:"kind"`
+	IssueID               string     `json:"issue_id,omitempty"`
+	Identifier            string     `json:"identifier,omitempty"`
+	IssueURL              string     `json:"issue_url,omitempty"`
+	Title                 string     `json:"title,omitempty"`
+	Lane                  string     `json:"lane,omitempty"`
+	Reason                string     `json:"reason"`
+	Detail                string     `json:"detail"`
+	Since                 time.Time  `json:"since"`
+	DetectedAt            time.Time  `json:"detected_at"`
+	LastObservedAt        time.Time  `json:"last_observed_at"`
+	AgeSeconds            int64      `json:"age_seconds"`
+	ThresholdSeconds      int64      `json:"threshold_seconds"`
+	Count                 int        `json:"count,omitempty"`
+	WaitingOnHuman        bool       `json:"waiting_on_human,omitempty"`
+	HasRecoveryPredicate  bool       `json:"has_recovery_predicate,omitempty"`
+	DeliveredAt           *time.Time `json:"delivered_at,omitempty"`
+	DeliveryAttempts      int        `json:"delivery_attempts,omitempty"`
+	LastDeliveryAttemptAt *time.Time `json:"last_delivery_attempt_at,omitempty"`
+	DeliveryError         string     `json:"delivery_error,omitempty"`
 }
 
 type Update struct {

--- a/internal/web/api.go
+++ b/internal/web/api.go
@@ -469,6 +469,7 @@ func stateResponse(snapshot telemetry.Snapshot, generatedAt time.Time, instanceN
 		BackendOutages:     append([]telemetry.BackendOutage(nil), snapshot.BackendOutages...),
 		FailureBreakers:    append([]telemetry.FailureBreaker(nil), snapshot.FailureBreakers...),
 		DispatchRecoveries: append([]telemetry.DispatchRecovery(nil), snapshot.DispatchRecoveries...),
+		StalenessWarnings:  append([]telemetry.StalenessWarning(nil), snapshot.StalenessWarnings...),
 		Budget:             budgetResponse(snapshot.Budget),
 	}
 }
@@ -1386,6 +1387,7 @@ type stateAPIResponse struct {
 	BackendOutages     []telemetry.BackendOutage    `json:"backend_outages,omitempty"`
 	FailureBreakers    []telemetry.FailureBreaker   `json:"failure_breakers,omitempty"`
 	DispatchRecoveries []telemetry.DispatchRecovery `json:"dispatch_recoveries,omitempty"`
+	StalenessWarnings  []telemetry.StalenessWarning `json:"staleness_warnings,omitempty"`
 	Budget             budgetAPIResponse            `json:"budget"`
 }
 

--- a/internal/web/project_scope.go
+++ b/internal/web/project_scope.go
@@ -73,6 +73,7 @@ func projectScopedSnapshotForProject(snapshot telemetry.Snapshot, selectedProjec
 	out.Completed = scopedCompleted(snapshot.Completed, selectedProjectID, fallbackProjectID)
 	out.FailureBreakers = scopedFailureBreakers(snapshot.FailureBreakers, selectedProjectID, fallbackProjectID)
 	out.DispatchRecoveries = scopedDispatchRecoveries(snapshot.DispatchRecoveries, selectedProjectID, fallbackProjectID)
+	out.StalenessWarnings = scopedStalenessWarnings(snapshot.StalenessWarnings, selectedProjectID, fallbackProjectID)
 	if hasSourceProject {
 		out.Counts = sourceProject.Counts
 		out.Tokens = sourceProject.Tokens
@@ -95,6 +96,20 @@ func projectScopedSnapshotForProject(snapshot telemetry.Snapshot, selectedProjec
 		out.TokenTrend = nil
 	}
 	out.WorkflowMetrics = scopedWorkflowMetrics(out, snapshot.WorkflowMetrics, selectedProjectID)
+	return out
+}
+
+func scopedStalenessWarnings(warnings []telemetry.StalenessWarning, selectedProjectID string, fallbackProjectID string) []telemetry.StalenessWarning {
+	out := make([]telemetry.StalenessWarning, 0, len(warnings))
+	for _, warning := range warnings {
+		projectID := strings.TrimSpace(warning.ProjectID)
+		if projectID == "" {
+			projectID = fallbackProjectID
+		}
+		if projectID == selectedProjectID {
+			out = append(out, warning)
+		}
+	}
 	return out
 }
 

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -1034,10 +1034,12 @@ func (s *Server) health(c echo.Context) error {
 	sessionsRemaining := 0
 	updateStatus := telemetry.Update{}
 	backendOutages := []telemetry.BackendOutage{}
+	stalenessWarnings := []telemetry.StalenessWarning{}
 	if s.hub != nil {
 		if snapshot, ok := s.hub.Latest(); ok {
 			updateStatus = snapshot.Update
 			backendOutages = append(backendOutages, snapshot.BackendOutages...)
+			stalenessWarnings = append(stalenessWarnings, snapshot.StalenessWarnings...)
 			if snapshot.Shutdown.Draining {
 				status = "draining"
 				sessionsRemaining = snapshot.Shutdown.SessionsRemaining
@@ -1073,6 +1075,7 @@ func (s *Server) health(c echo.Context) error {
 		Budgets:           budgets,
 		Workflows:         workflows,
 		BackendOutages:    backendOutages,
+		StalenessWarnings: stalenessWarnings,
 		Projects:          projectHealth,
 	})
 }
@@ -1309,18 +1312,19 @@ func (s *Server) connectorName() string {
 }
 
 type healthResponse struct {
-	Status            string                    `json:"status"`
-	ProjectStatus     string                    `json:"project_status"`
-	Mode              string                    `json:"mode"`
-	Connector         string                    `json:"connector"`
-	SessionsRemaining int                       `json:"sessions_remaining,omitempty"`
-	Update            telemetry.Update          `json:"update,omitzero"`
-	Checks            map[string]string         `json:"checks"`
-	Environment       healthEnvironment         `json:"environment"`
-	Budgets           []healthBudget            `json:"budgets,omitempty"`
-	Workflows         []healthWorkflowSource    `json:"workflows,omitempty"`
-	BackendOutages    []telemetry.BackendOutage `json:"backend_outages,omitempty"`
-	Projects          []healthProject           `json:"projects,omitempty"`
+	Status            string                       `json:"status"`
+	ProjectStatus     string                       `json:"project_status"`
+	Mode              string                       `json:"mode"`
+	Connector         string                       `json:"connector"`
+	SessionsRemaining int                          `json:"sessions_remaining,omitempty"`
+	Update            telemetry.Update             `json:"update,omitzero"`
+	Checks            map[string]string            `json:"checks"`
+	Environment       healthEnvironment            `json:"environment"`
+	Budgets           []healthBudget               `json:"budgets,omitempty"`
+	Workflows         []healthWorkflowSource       `json:"workflows,omitempty"`
+	BackendOutages    []telemetry.BackendOutage    `json:"backend_outages,omitempty"`
+	StalenessWarnings []telemetry.StalenessWarning `json:"staleness_warnings,omitempty"`
+	Projects          []healthProject              `json:"projects,omitempty"`
 }
 
 type healthEnvironment struct {

--- a/internal/web/templates/board_data.go
+++ b/internal/web/templates/board_data.go
@@ -676,8 +676,9 @@ func boardFiguresFromDashboard(data DashboardData) []primitives.Figure {
 // Kanban), so the Review sheet may offer inline Move/Remove; the Fleet and
 // Overview pages pass false so their Review sheets stay read-only.
 func boardExceptions(data DashboardData, boardActions bool) []primitives.Exception {
+	exceptions := stalenessExceptions(data.Snapshot)
 	if boardActions && !data.Kanban.ShowBlockedAlerts {
-		return nil
+		return exceptions
 	}
 
 	retryRows := make([]telemetry.Blocked, 0, len(data.Snapshot.Blocked))
@@ -693,9 +694,8 @@ func boardExceptions(data DashboardData, boardActions bool) []primitives.Excepti
 		reviewRows = append(reviewRows, row)
 	}
 	if len(retryRows) == 0 && len(reviewRows) == 0 {
-		return nil
+		return exceptions
 	}
-	exceptions := make([]primitives.Exception, 0, len(retryRows)+1)
 	for _, row := range retryRows {
 		exceptions = append(exceptions, boardOperatorStopException(data, row))
 	}
@@ -703,6 +703,51 @@ func boardExceptions(data DashboardData, boardActions bool) []primitives.Excepti
 		exceptions = append(exceptions, boardBlockedExceptionSummary(data, reviewRows, boardActions))
 	}
 	return exceptions
+}
+
+func stalenessExceptions(snapshot telemetry.Snapshot) []primitives.Exception {
+	exceptions := make([]primitives.Exception, 0, len(snapshot.StalenessWarnings))
+	for _, warning := range snapshot.StalenessWarnings {
+		repo, ref := splitIssueIdentifier(strings.TrimSpace(warning.Identifier))
+		if repo == "" {
+			repo = strings.TrimSpace(warning.ProjectID)
+		}
+		rest := strings.TrimSpace(warning.Detail)
+		if warning.AgeSeconds > 0 {
+			rest += " · " + formatDuration(float64(warning.AgeSeconds))
+		}
+		exception := primitives.Exception{
+			ID:     "exception-staleness-" + boardCardSlug(warning.ID),
+			Kind:   primitives.KindWarn,
+			Title:  stalenessExceptionTitle(warning),
+			Repo:   repo,
+			Ref:    ref,
+			RefURL: strings.TrimSpace(warning.IssueURL),
+			Rest:   rest,
+		}
+		if exception.RefURL != "" {
+			exception.ActionLabel = "Open"
+			exception.ActionHref = exception.RefURL
+		}
+		exceptions = append(exceptions, exception)
+	}
+	return exceptions
+}
+
+func stalenessExceptionTitle(warning telemetry.StalenessWarning) string {
+	switch warning.Kind {
+	case "project_liveness":
+		return "Project is not advancing"
+	case "merge_liveness":
+		return "Merge queue is not advancing"
+	case "repeated_decision":
+		return "Scheduler decision is repeating"
+	default:
+		if warning.WaitingOnHuman {
+			return "Human gate needs a reminder"
+		}
+		return "Work item is stale"
+	}
 }
 
 func boardOperatorStopException(data DashboardData, row telemetry.Blocked) primitives.Exception {

--- a/internal/web/templates/board_data_test.go
+++ b/internal/web/templates/board_data_test.go
@@ -52,6 +52,31 @@ func TestBoardDetailSheetRendersEfficiencyReceipt(t *testing.T) {
 	}
 }
 
+func TestBoardExceptionsIncludeFleetStalenessWarning(t *testing.T) {
+	t.Parallel()
+	data := DashboardData{
+		Snapshot: telemetry.Snapshot{
+			StalenessWarnings: []telemetry.StalenessWarning{{
+				ID:             "warning-1",
+				ProjectID:      "detent",
+				Kind:           "lane_aging",
+				Identifier:     "digitaldrywood/detent#1574",
+				IssueURL:       "https://github.com/digitaldrywood/detent/issues/1574",
+				Detail:         "the item has remained in Merging",
+				AgeSeconds:     3 * 60 * 60,
+				WaitingOnHuman: false,
+			}},
+		},
+	}
+	exceptions := boardExceptions(data, false)
+	if len(exceptions) != 1 {
+		t.Fatalf("boardExceptions() = %#v, want one", exceptions)
+	}
+	if exceptions[0].Title != "Work item is stale" || exceptions[0].Ref != "#1574" || exceptions[0].ActionLabel != "Open" {
+		t.Fatalf("exception = %#v", exceptions[0])
+	}
+}
+
 func TestBoardCardAndDetailSheetRenderOrigin(t *testing.T) {
 	t.Parallel()
 

--- a/internal/web/templates/health_data.go
+++ b/internal/web/templates/health_data.go
@@ -43,6 +43,12 @@ func healthViewFromDashboard(data DashboardData) healthView {
 		Footnote:  "GitHub quota bars turn amber at 90%; project budget bars warn at 80% and turn red at the cap.",
 		Rows:      append(healthRows(snapshot), healthBudgetRows(data)...),
 	}
+	if len(snapshot.StalenessWarnings) > 0 {
+		view.Kind = primitives.KindWarn
+		view.Verdict = "Fleet work is stale."
+		view.Detail = stalenessHealthDetail(snapshot.StalenessWarnings)
+		return view
+	}
 	outages := backendCapacityOutages(snapshot.BackendOutages)
 	if len(outages) > 0 {
 		view.Kind = primitives.KindWarn
@@ -145,6 +151,9 @@ func healthBudgetRows(data DashboardData) []healthRow {
 
 func healthRows(snapshot telemetry.Snapshot) []healthRow {
 	rows := make([]healthRow, 0, 4)
+	for _, warning := range snapshot.StalenessWarnings {
+		rows = append(rows, healthStalenessRow(warning))
+	}
 	if snapshot.RateLimits != nil {
 		if bucket := snapshot.RateLimits.GitHubREST; bucket != nil {
 			row := healthBucketRow("health-github-rest", "GitHub REST", bucket)
@@ -172,6 +181,45 @@ func healthRows(snapshot telemetry.Snapshot) []healthRow {
 		rows = append(rows, healthBackendOutageRow(outage, snapshot.GeneratedAt))
 	}
 	return rows
+}
+
+func healthStalenessRow(warning telemetry.StalenessWarning) healthRow {
+	component := "Fleet staleness"
+	if projectID := strings.TrimSpace(warning.ProjectID); projectID != "" {
+		component += " · " + projectID
+	}
+	detail := doctorStyleStalenessTarget(warning) + " · " + strings.TrimSpace(warning.Detail)
+	if warning.AgeSeconds > 0 {
+		detail += " · " + formatDuration(float64(warning.AgeSeconds))
+	}
+	status := "Stale"
+	if warning.WaitingOnHuman {
+		status = "Reminder due"
+	}
+	return healthRow{
+		ID:        "health-staleness-" + boardCardSlug(warning.ID),
+		Component: component,
+		Kind:      primitives.KindWarn,
+		Status:    status,
+		Detail:    detail,
+		Resets:    "on progress",
+	}
+}
+
+func stalenessHealthDetail(warnings []telemetry.StalenessWarning) string {
+	if len(warnings) == 1 {
+		return doctorStyleStalenessTarget(warnings[0]) + " needs operator attention."
+	}
+	return formatCount(len(warnings)) + " warnings need operator attention."
+}
+
+func doctorStyleStalenessTarget(warning telemetry.StalenessWarning) string {
+	for _, value := range []string{warning.Identifier, warning.IssueID, warning.ProjectID} {
+		if value = strings.TrimSpace(value); value != "" {
+			return value
+		}
+	}
+	return "fleet"
 }
 
 func healthUpdateRow(update telemetry.Update) healthRow {


### PR DESCRIPTION
## Summary

- detect per-lane aging, dispatch and merge liveness stalls, and repeated identical scheduler decisions
- expose stable active warnings through telemetry, `/health`, `detent doctor`, and existing dashboard exception and health surfaces
- deliver each newly active warning through an optional configurable webhook, with bounded retry after failures
- add generated configuration references and regression coverage for one-warning-per-condition and empty-queue behavior

Fixes #1574

## UI Surface Contract

- [x] Issue #1574 explicitly authorizes dashboard staleness warnings.
- [x] The issue explicitly authorizes operator-facing warning delivery; this reuses existing exception and health surfaces.
- [x] No layout, density, or responsive visibility changes; existing view-model tests cover the added warning row.

## Test Plan

- [x] `go test ./internal/staleness ./internal/config ./internal/orchestrator ./internal/cli ./internal/web/...`
- [x] `make check` before rebase
- [x] `make check` after rebasing onto current `origin/main`
- [x] aggregate coverage 78.0%; `internal/staleness` coverage 78.3%