### PR TITLE
fix(orchestrator): rearm dependency unblock

### DIFF
--- a/internal/cli/doctor_dependency.go
+++ b/internal/cli/doctor_dependency.go
@@ -767,8 +767,12 @@ func doctorDependencyDiagnostics(
 			continue
 		}
 		if doctorDependencyBlockersReady(blockers, cfg, terminalStates) {
+			code := "dependency_ready_but_still_blocked"
+			if doctorDependencyBlockersTerminal(blockers, terminalStates) {
+				code = "dependency_terminal_but_still_blocked"
+			}
 			diagnostics = append(diagnostics, doctorDependencyDiagnostic{
-				Code:       "dependency_ready_but_still_blocked",
+				Code:       code,
 				Issue:      hydrated,
 				References: doctorDependencyBlockerLabels(blockers),
 			})
@@ -891,6 +895,24 @@ func doctorDependencyBlockersReady(
 	return true
 }
 
+func doctorDependencyBlockersTerminal(blockers []doctorDependencyBlocker, terminalStates []string) bool {
+	if len(blockers) == 0 {
+		return false
+	}
+	for _, blocker := range blockers {
+		if blocker.Resolved {
+			if !blocker.Issue.Closed && !doctorStateInList(blocker.Issue.State, terminalStates) {
+				return false
+			}
+			continue
+		}
+		if !doctorStateInList(blocker.Ref.State, terminalStates) {
+			return false
+		}
+	}
+	return true
+}
+
 func doctorDependencyBlockerReady(
 	blocker doctorDependencyBlocker,
 	cfg doctorDependencyAutoUnblockSettings,
@@ -971,6 +993,9 @@ func doctorDependencyAutoUnblockHint(diagnostics []doctorDependencyDiagnostic) s
 	}
 	if _, ok := codes["dependency_ready_but_still_blocked"]; ok {
 		hints = append(hints, "Check tracker.dependency_auto_unblock source_states, target_state, readiness, and GitHub Project Status mappings.")
+	}
+	if _, ok := codes["dependency_terminal_but_still_blocked"]; ok {
+		hints = append(hints, "All dependency blockers are terminal but the issue has not transitioned; inspect dependency auto-unblock decision logs for a consumed-signature latch.")
 	}
 	return strings.Join(hints, " ")
 }

--- a/internal/cli/doctor_test.go
+++ b/internal/cli/doctor_test.go
@@ -2369,10 +2369,10 @@ func TestCheckDoctorDependencyAutoUnblock(t *testing.T) {
 			},
 			want: doctorWarn,
 			wantDetails: []string{
-				"dependency_ready_but_still_blocked",
+				"dependency_terminal_but_still_blocked",
 				"issue-ready",
 				readyRef,
-				"tracker.dependency_auto_unblock",
+				"consumed-signature latch",
 			},
 		},
 		{
@@ -2395,7 +2395,7 @@ func TestCheckDoctorDependencyAutoUnblock(t *testing.T) {
 			},
 			want: doctorWarn,
 			wantDetails: []string{
-				"dependency_ready_but_still_blocked",
+				"dependency_terminal_but_still_blocked",
 				"issue-416",
 				"digitaldrywood/detent#414",
 				"digitaldrywood/detent#415",

--- a/internal/orchestrator/dependency_autounblock.go
+++ b/internal/orchestrator/dependency_autounblock.go
@@ -915,7 +915,9 @@ func (o *Orchestrator) dependencyAutoUnblockAlreadyConsumed(
 	}
 	issueID := strings.TrimSpace(issue.ID)
 	if state != nil && issueID != "" {
-		if record, ok := state.DependencyAutoUnblocks[issueID]; ok && record.BlockerSet == blockerSet {
+		if record, ok := state.DependencyAutoUnblocks[issueID]; ok &&
+			record.BlockerSet == blockerSet &&
+			dependencyAutoUnblockConsumptionCurrent(issue, record.UnblockedAt) {
 			return true
 		}
 	}
@@ -927,13 +929,33 @@ func (o *Orchestrator) workflowTimelineHasDependencyAutoUnblock(
 	issue connector.Issue,
 	blockerSet string,
 ) bool {
-	_, ok := o.workflowTimelineLaneMetadataMatch(ctx, issue, "dependency_auto_unblock", func(metadata workflowLaneMetadata) bool {
-		if metadata.DependencyAutoUnblock == nil {
-			return false
+	timeline, ok := o.issueWorkflowTimeline(ctx, issue)
+	if !ok {
+		return false
+	}
+	for _, event := range timeline.Events {
+		if event.PhaseType != store.WorkflowPhaseTypeLane ||
+			!strings.EqualFold(strings.TrimSpace(event.Status), "entered") ||
+			!strings.EqualFold(strings.TrimSpace(event.Reason), "dependency_auto_unblock") ||
+			!dependencyAutoUnblockConsumptionCurrent(issue, event.StartedAt) {
+			continue
 		}
-		return strings.TrimSpace(metadata.DependencyAutoUnblock.BlockerSet) == blockerSet
-	})
-	return ok
+		metadata, ok := workflowLaneMetadataFromJSON(event.MetadataJSON)
+		if !ok || metadata.DependencyAutoUnblock == nil {
+			continue
+		}
+		if strings.TrimSpace(metadata.DependencyAutoUnblock.BlockerSet) == blockerSet {
+			return true
+		}
+	}
+	return false
+}
+
+func dependencyAutoUnblockConsumptionCurrent(issue connector.Issue, unblockedAt time.Time) bool {
+	if issue.StageUpdatedAt == nil || issue.StageUpdatedAt.IsZero() || unblockedAt.IsZero() {
+		return true
+	}
+	return !unblockedAt.Before(issue.StageUpdatedAt.UTC())
 }
 
 type workflowTimelineMetadataMatch struct {
@@ -1097,20 +1119,25 @@ func dependencyAutoUnblockBlockerSignature(
 		state := blocker.Ref.State
 		closed := false
 		pullRequestState := ""
+		stateUpdatedAt := ""
 		if blocker.Resolved {
 			state = firstNonBlank(blocker.Issue.State, state)
 			closed = blocker.Issue.Closed
+			if blocker.Issue.StageUpdatedAt != nil && !blocker.Issue.StageUpdatedAt.IsZero() {
+				stateUpdatedAt = blocker.Issue.StageUpdatedAt.UTC().Format(time.RFC3339Nano)
+			}
 			if blocker.Issue.PullRequest != nil {
 				pullRequestState = blocker.Issue.PullRequest.State
 			}
 		}
 		keys = append(keys, fmt.Sprintf(
-			"%s|resolved=%t|ready=%t|closed=%t|state=%s|pull_request=%s",
+			"%s|resolved=%t|ready=%t|closed=%t|state=%s|state_updated_at=%s|pull_request=%s",
 			key,
 			blocker.Resolved,
 			dependencyBlockerReady(blocker, cfg, terminalStates),
 			closed,
 			normalizeState(state),
+			stateUpdatedAt,
 			normalizePullRequestState(pullRequestState),
 		))
 	}

--- a/internal/orchestrator/dependency_autounblock.go
+++ b/internal/orchestrator/dependency_autounblock.go
@@ -120,13 +120,19 @@ func (o *Orchestrator) autoUnblockDependencyIssues(
 			o.logDependencyAutoUnblockDecision(hydrated, "skip", "blockers_not_ready", blockers, "")
 			continue
 		}
-		blockerSet := dependencyAutoUnblockBlockerSet(blockers)
-		if o.dependencyAutoUnblockAlreadyConsumed(ctx, state, hydrated, blockerSet) {
-			o.logDependencyAutoUnblockDecision(hydrated, "skip", "blocker_set_already_consumed", blockers, "")
+		blockerSignature := dependencyAutoUnblockBlockerSignature(blockers, cfg, o.cfg.TerminalStates)
+		if o.dependencyAutoUnblockAlreadyConsumed(ctx, state, hydrated, blockerSignature) {
+			action := "skip"
+			reason := "blocker_set_already_consumed"
+			if dependencyBlockersTerminal(blockers, o.cfg.TerminalStates) {
+				action = "error"
+				reason = "terminal_blocker_set_already_consumed"
+			}
+			o.logDependencyAutoUnblockDecision(hydrated, action, reason, blockers, "")
 			continue
 		}
 		targetState := dependencyAutoUnblockTargetState(state, hydrated, cfg.TargetState)
-		if !o.applyDependencyAutoUnblock(ctx, state, hydrated, blockers, blockerSet, targetState, now) {
+		if !o.applyDependencyAutoUnblock(ctx, state, hydrated, blockers, blockerSignature, targetState, now) {
 			o.logDependencyAutoUnblockDecision(hydrated, "skip", "transition_failed", blockers, targetState)
 			continue
 		}
@@ -652,6 +658,24 @@ func dependencyBlockersReady(blockers []dependencyBlocker, cfg DependencyAutoUnb
 	return true
 }
 
+func dependencyBlockersTerminal(blockers []dependencyBlocker, terminalStates []string) bool {
+	if len(blockers) == 0 {
+		return false
+	}
+	for _, blocker := range blockers {
+		if blocker.Resolved {
+			if !blocker.Issue.Closed && !stateIn(blocker.Issue.State, terminalStates) {
+				return false
+			}
+			continue
+		}
+		if !stateIn(blocker.Ref.State, terminalStates) {
+			return false
+		}
+	}
+	return true
+}
+
 func dependencyBlockerReady(blocker dependencyBlocker, cfg DependencyAutoUnblockConfig, terminalStates []string) bool {
 	if blocker.Resolved {
 		if blocker.Issue.Closed || stateIn(blocker.Issue.State, terminalStates) {
@@ -743,7 +767,7 @@ func (o *Orchestrator) applyDependencyAutoUnblock(
 			Blockers:   dependencyAutoUnblockBlockerLabels(blockers),
 		},
 	}
-	if err := o.updateIssueStateByIDWithMetadata(ctx, state, issueID, issue, targetState, now, "dependency_auto_unblock", metadata); err != nil {
+	if err := o.updateIssueStateByIDStrictWithMetadata(ctx, state, issueID, issue, targetState, now, "dependency_auto_unblock", metadata); err != nil {
 		if o.logger != nil {
 			o.logger.Warn("dependency auto-unblock transition failed", "issue_id", issueID, "identifier", issue.Identifier, "from_state", issue.State, "target_state", targetState, "error", err)
 		}
@@ -794,6 +818,10 @@ func (o *Orchestrator) logDependencyAutoUnblockDecision(
 	}
 	if targetState != "" {
 		attrs = append(attrs, "target_state", targetState)
+	}
+	if action == "error" {
+		o.logger.Warn("dependency auto-unblock decision", attrs...)
+		return
 	}
 	o.logger.Info("dependency auto-unblock decision", attrs...)
 }
@@ -1049,6 +1077,42 @@ func dependencyAutoUnblockBlockerSet(blockers []dependencyBlocker) string {
 		if key != "" {
 			keys = append(keys, key)
 		}
+	}
+	keys = uniqueStrings(keys)
+	slices.Sort(keys)
+	return strings.Join(keys, "\n")
+}
+
+func dependencyAutoUnblockBlockerSignature(
+	blockers []dependencyBlocker,
+	cfg DependencyAutoUnblockConfig,
+	terminalStates []string,
+) string {
+	keys := make([]string, 0, len(blockers))
+	for _, blocker := range blockers {
+		key := dependencyAutoUnblockBlockerKey(blocker)
+		if key == "" {
+			continue
+		}
+		state := blocker.Ref.State
+		closed := false
+		pullRequestState := ""
+		if blocker.Resolved {
+			state = firstNonBlank(blocker.Issue.State, state)
+			closed = blocker.Issue.Closed
+			if blocker.Issue.PullRequest != nil {
+				pullRequestState = blocker.Issue.PullRequest.State
+			}
+		}
+		keys = append(keys, fmt.Sprintf(
+			"%s|resolved=%t|ready=%t|closed=%t|state=%s|pull_request=%s",
+			key,
+			blocker.Resolved,
+			dependencyBlockerReady(blocker, cfg, terminalStates),
+			closed,
+			normalizeState(state),
+			normalizePullRequestState(pullRequestState),
+		))
 	}
 	keys = uniqueStrings(keys)
 	slices.Sort(keys)

--- a/internal/orchestrator/dependency_autounblock_test.go
+++ b/internal/orchestrator/dependency_autounblock_test.go
@@ -114,6 +114,144 @@ func TestTickAutoUnblocksDependencyOnlyOnceForSameResolvedBlockerSet(t *testing.
 	}
 }
 
+func TestDependencyAutoUnblockDoesNotConsumeRejectedTransition(t *testing.T) {
+	t.Parallel()
+
+	waiting := dependencyAutoUnblockIssue("issue-rejected-transition", "Blocked")
+	waiting.BlockedBy = []connector.BlockedRef{{Identifier: "digitaldrywood/detent#415"}}
+	blocker := dependencyAutoUnblockIssue("issue-done", "Done")
+	blocker.Identifier = "digitaldrywood/detent#415"
+	tracker := &dependencyAutoUnblockConnector{
+		stateIssues: []connector.Issue{waiting},
+		blockers:    []connector.Issue{blocker},
+	}
+	rejecting := &dependencyAutoUnblockRejectOnceConnector{dependencyAutoUnblockConnector: tracker, reject: true}
+	orch := dependencyAutoUnblockOrchestrator(tracker, DependencyAutoUnblockConfig{
+		Enabled:      true,
+		SourceStates: []string{"Blocked"},
+		TargetState:  "Todo",
+		Readiness:    DependencyReadinessTerminalOrMerged,
+	})
+	orch.connector = rejecting
+	metrics := &autoPromoteWorkflowMetricsRecorder{}
+	orch.workflowMetrics = metrics
+	state := newState(orch.cfg)
+	now := time.Date(2026, 7, 30, 16, 0, 0, 0, time.UTC)
+
+	if transitioned := orch.autoUnblockDependencyIssues(t.Context(), &state, tracker.stateIssues, now); len(transitioned) != 0 {
+		t.Fatalf("first transitioned = %#v, want rejected transition held", transitioned)
+	}
+	if len(tracker.comments) != 0 {
+		t.Fatalf("first comments = %#v, want no success audit", tracker.comments)
+	}
+	if _, ok := state.DependencyAutoUnblocks[waiting.ID]; ok {
+		t.Fatalf("DependencyAutoUnblocks[%q] recorded after rejected transition", waiting.ID)
+	}
+	if orch.workflowTimelineHasDependencyAutoUnblock(t.Context(), waiting, dependencyAutoUnblockBlockerSet([]dependencyBlocker{{
+		Ref:      waiting.BlockedBy[0],
+		Issue:    blocker,
+		Resolved: true,
+	}})) {
+		t.Fatal("rejected transition recorded a consumed blocker set")
+	}
+
+	rejecting.reject = false
+	if transitioned := orch.autoUnblockDependencyIssues(t.Context(), &state, tracker.stateIssues, now.Add(time.Minute)); len(transitioned) != 1 {
+		t.Fatalf("second transitioned = %#v, want successful retry", transitioned)
+	}
+	if len(tracker.updates) != 2 {
+		t.Fatalf("updates = %#v, want rejected attempt and successful retry", tracker.updates)
+	}
+	if len(tracker.comments) != 1 {
+		t.Fatalf("comments = %#v, want one success audit", tracker.comments)
+	}
+}
+
+func TestDependencyAutoUnblockRearmsWhenBlockerReadinessChanges(t *testing.T) {
+	t.Parallel()
+
+	waiting := dependencyAutoUnblockIssue("issue-readiness-change", "Blocked")
+	waiting.BlockedBy = []connector.BlockedRef{{Identifier: "digitaldrywood/detent#415"}}
+	blocker := dependencyAutoUnblockIssue("issue-open", "In Progress")
+	blocker.Identifier = "digitaldrywood/detent#415"
+	tracker := &dependencyAutoUnblockConnector{
+		stateIssues: []connector.Issue{waiting},
+		blockers:    []connector.Issue{blocker},
+	}
+	orch := dependencyAutoUnblockOrchestrator(tracker, DependencyAutoUnblockConfig{
+		Enabled:      true,
+		SourceStates: []string{"Blocked"},
+		TargetState:  "Todo",
+		Readiness:    DependencyReadinessTerminalOrMerged,
+	})
+	metrics := &autoPromoteWorkflowMetricsRecorder{}
+	orch.workflowMetrics = metrics
+	now := time.Date(2026, 7, 30, 16, 0, 0, 0, time.UTC)
+	orch.recordLaneTransition(t.Context(), waiting, "Todo", now.Add(-time.Hour), "dependency_auto_unblock", workflowLaneMetadata{
+		DependencyAutoUnblock: &workflowLaneDependencyAutoUnblockMetadata{
+			BlockerSet: dependencyAutoUnblockBlockerSet([]dependencyBlocker{{
+				Ref:      waiting.BlockedBy[0],
+				Issue:    blocker,
+				Resolved: true,
+			}}),
+			Blockers: []string{blocker.Identifier},
+		},
+	})
+	state := newState(orch.cfg)
+
+	if transitioned := orch.autoUnblockDependencyIssues(t.Context(), &state, tracker.stateIssues, now); len(transitioned) != 0 {
+		t.Fatalf("open blocker transitioned = %#v, want blockers_not_ready", transitioned)
+	}
+	tracker.blockers[0].State = "Done"
+	if transitioned := orch.autoUnblockDependencyIssues(t.Context(), &state, tracker.stateIssues, now.Add(time.Minute)); len(transitioned) != 1 {
+		t.Fatalf("closed blocker transitioned = %#v, want readiness change to re-arm", transitioned)
+	}
+}
+
+func TestDependencyAutoUnblockLoudlySuppressesUnchangedReadyLoop(t *testing.T) {
+	t.Parallel()
+
+	waiting := dependencyAutoUnblockIssue("issue-unchanged-loop", "Blocked")
+	waiting.BlockedBy = []connector.BlockedRef{{Identifier: "digitaldrywood/detent#415"}}
+	blocker := dependencyAutoUnblockIssue("issue-done", "Done")
+	blocker.Identifier = "digitaldrywood/detent#415"
+	tracker := &dependencyAutoUnblockConnector{
+		stateIssues: []connector.Issue{waiting},
+		blockers:    []connector.Issue{blocker},
+	}
+	orch := dependencyAutoUnblockOrchestrator(tracker, DependencyAutoUnblockConfig{
+		Enabled:      true,
+		SourceStates: []string{"Blocked"},
+		TargetState:  "Todo",
+		Readiness:    DependencyReadinessTerminalOrMerged,
+	})
+	var logs bytes.Buffer
+	orch.logger = slog.New(slog.NewTextHandler(&logs, nil))
+	state := newState(orch.cfg)
+	now := time.Date(2026, 7, 30, 16, 0, 0, 0, time.UTC)
+
+	orch.autoUnblockDependencyIssues(t.Context(), &state, tracker.stateIssues, now)
+	orch.autoUnblockDependencyIssues(t.Context(), &state, tracker.stateIssues, now.Add(time.Minute))
+
+	if len(tracker.updates) != 1 {
+		t.Fatalf("updates = %#v, want unchanged ready loop suppressed", tracker.updates)
+	}
+	for _, want := range []string{
+		"level=WARN",
+		"action=error",
+		"reason=terminal_blocker_set_already_consumed",
+	} {
+		if !strings.Contains(logs.String(), want) {
+			t.Fatalf("log missing %q:\n%s", want, logs.String())
+		}
+	}
+	tracker.blockers[0].State = "Cancelled"
+	orch.autoUnblockDependencyIssues(t.Context(), &state, tracker.stateIssues, now.Add(2*time.Minute))
+	if len(tracker.updates) != 2 {
+		t.Fatalf("updates after blocker state change = %#v, want latch re-armed", tracker.updates)
+	}
+}
+
 func TestTickAutoUnblockSkipsPersistedReworkLimitBlockedIssue(t *testing.T) {
 	t.Parallel()
 
@@ -823,6 +961,44 @@ func TestDependencyAutoUnblockBlockerSetIgnoresRefSource(t *testing.T) {
 	}
 }
 
+func TestDependencyAutoUnblockBlockerSignatureIncludesReadinessAndState(t *testing.T) {
+	t.Parallel()
+
+	cfg := normalizeDependencyAutoUnblockConfig(DependencyAutoUnblockConfig{
+		Readiness: DependencyReadinessTerminalOrMerged,
+	})
+	terminalStates := normalizedStates([]string{"Done", "Cancelled"})
+	ref := connector.BlockedRef{Identifier: "digitaldrywood/detent#415"}
+	open := dependencyBlocker{
+		Ref:      ref,
+		Issue:    dependencyAutoUnblockIssue("issue-415", "In Progress"),
+		Resolved: true,
+	}
+	terminal := open
+	terminal.Issue.State = "Done"
+	cancelled := terminal
+	cancelled.Issue.State = "Cancelled"
+
+	openSignature := dependencyAutoUnblockBlockerSignature([]dependencyBlocker{open}, cfg, terminalStates)
+	terminalSignature := dependencyAutoUnblockBlockerSignature([]dependencyBlocker{terminal}, cfg, terminalStates)
+	cancelledSignature := dependencyAutoUnblockBlockerSignature([]dependencyBlocker{cancelled}, cfg, terminalStates)
+
+	if openSignature == terminalSignature {
+		t.Fatalf("open signature = terminal signature = %q, want readiness change to re-arm", openSignature)
+	}
+	if terminalSignature == cancelledSignature {
+		t.Fatalf("Done signature = Cancelled signature = %q, want state change to re-arm", terminalSignature)
+	}
+	for signature, readiness := range map[string]string{
+		openSignature:     "ready=false",
+		terminalSignature: "ready=true",
+	} {
+		if !strings.Contains(signature, readiness) {
+			t.Fatalf("signature %q missing %q", signature, readiness)
+		}
+	}
+}
+
 func TestDependencyAutoUnblockDecisionLogIncludesBlockerSources(t *testing.T) {
 	t.Parallel()
 
@@ -931,6 +1107,19 @@ type dependencyAutoUnblockConnector struct {
 	updates         []dependencyAutoUnblockUpdate
 	comments        []dependencyAutoUnblockAudit
 	identifierCalls []string
+}
+
+type dependencyAutoUnblockRejectOnceConnector struct {
+	*dependencyAutoUnblockConnector
+	reject bool
+}
+
+func (c *dependencyAutoUnblockRejectOnceConnector) UpdateIssueState(ctx context.Context, issueID string, state string) error {
+	if c.reject {
+		c.updates = append(c.updates, dependencyAutoUnblockUpdate{issueID: issueID, state: state})
+		return connector.ErrStateUpdateBlocked
+	}
+	return c.dependencyAutoUnblockConnector.UpdateIssueState(ctx, issueID, state)
 }
 
 func (c *dependencyAutoUnblockConnector) Name() string {

--- a/internal/orchestrator/dependency_autounblock_test.go
+++ b/internal/orchestrator/dependency_autounblock_test.go
@@ -252,6 +252,44 @@ func TestDependencyAutoUnblockLoudlySuppressesUnchangedReadyLoop(t *testing.T) {
 	}
 }
 
+func TestDependencyAutoUnblockRearmsAfterBlockerReopens(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 7, 30, 16, 0, 0, 0, time.UTC)
+	waiting := dependencyAutoUnblockIssue("issue-reopened-blocker", "Blocked")
+	waiting.StageUpdatedAt = timePointer(now.Add(-time.Hour))
+	waiting.BlockedBy = []connector.BlockedRef{{Identifier: "digitaldrywood/detent#415"}}
+	blocker := dependencyAutoUnblockIssue("issue-415", "Done")
+	blocker.Identifier = "digitaldrywood/detent#415"
+	tracker := &dependencyAutoUnblockConnector{
+		stateIssues: []connector.Issue{waiting},
+		blockers:    []connector.Issue{blocker},
+	}
+	orch := dependencyAutoUnblockOrchestrator(tracker, DependencyAutoUnblockConfig{
+		Enabled:      true,
+		SourceStates: []string{"Blocked"},
+		TargetState:  "Todo",
+		Readiness:    DependencyReadinessTerminalOrMerged,
+	})
+	metrics := &autoPromoteWorkflowMetricsRecorder{}
+	orch.workflowMetrics = metrics
+	state := newState(orch.cfg)
+
+	orch.autoUnblockDependencyIssues(t.Context(), &state, tracker.stateIssues, now)
+	tracker.stateIssues[0].StageUpdatedAt = timePointer(now.Add(time.Minute))
+	tracker.blockers[0].State = "In Progress"
+	orch.autoUnblockDependencyIssues(t.Context(), &state, tracker.stateIssues, now.Add(2*time.Minute))
+	tracker.blockers[0].State = "Done"
+	orch.autoUnblockDependencyIssues(t.Context(), &state, tracker.stateIssues, now.Add(3*time.Minute))
+
+	if got, want := tracker.updates, []dependencyAutoUnblockUpdate{
+		{issueID: waiting.ID, state: "Todo"},
+		{issueID: waiting.ID, state: "Todo"},
+	}; !slices.Equal(got, want) {
+		t.Fatalf("updates = %#v, want unblock before and after blocker reopening", got)
+	}
+}
+
 func TestTickAutoUnblockSkipsPersistedReworkLimitBlockedIssue(t *testing.T) {
 	t.Parallel()
 
@@ -976,18 +1014,25 @@ func TestDependencyAutoUnblockBlockerSignatureIncludesReadinessAndState(t *testi
 	}
 	terminal := open
 	terminal.Issue.State = "Done"
+	terminal.Issue.StageUpdatedAt = timePointer(time.Date(2026, 7, 30, 16, 0, 0, 0, time.UTC))
 	cancelled := terminal
 	cancelled.Issue.State = "Cancelled"
+	refreshedTerminal := terminal
+	refreshedTerminal.Issue.StageUpdatedAt = timePointer(time.Date(2026, 7, 30, 17, 0, 0, 0, time.UTC))
 
 	openSignature := dependencyAutoUnblockBlockerSignature([]dependencyBlocker{open}, cfg, terminalStates)
 	terminalSignature := dependencyAutoUnblockBlockerSignature([]dependencyBlocker{terminal}, cfg, terminalStates)
 	cancelledSignature := dependencyAutoUnblockBlockerSignature([]dependencyBlocker{cancelled}, cfg, terminalStates)
+	refreshedTerminalSignature := dependencyAutoUnblockBlockerSignature([]dependencyBlocker{refreshedTerminal}, cfg, terminalStates)
 
 	if openSignature == terminalSignature {
 		t.Fatalf("open signature = terminal signature = %q, want readiness change to re-arm", openSignature)
 	}
 	if terminalSignature == cancelledSignature {
 		t.Fatalf("Done signature = Cancelled signature = %q, want state change to re-arm", terminalSignature)
+	}
+	if terminalSignature == refreshedTerminalSignature {
+		t.Fatalf("Done signatures match across state timestamps = %q, want same-state cycle to re-arm", terminalSignature)
 	}
 	for signature, readiness := range map[string]string{
 		openSignature:     "ready=false",


### PR DESCRIPTION
## Summary

- prevent rejected dependency auto-unblock transitions from consuming their one-shot signature
- include blocker readiness and state in durable signatures so blocker changes re-arm recovery
- warn loudly on terminal consumed-signature latches and surface terminal stalled dependencies in doctor

Fixes #1578

## UI Surface Contract

- [x] N/A, or the linked issue explicitly authorizes any high-impact UI surface, layout, density, first-viewport, or responsive visibility tradeoff.
- [x] Persistent top-of-screen messaging is explicitly authorized by the issue, or this PR does not add it.
- [x] Visual changes to primary operator screens include screenshot or browser verification below.

## Test Plan

- [x] `go test ./internal/orchestrator ./internal/cli -count=1`
- [x] `make check`