### PR TITLE
test(doctor): verify timeout check boundaries

### DIFF
--- a/internal/cli/doctor_test.go
+++ b/internal/cli/doctor_test.go
@@ -5380,12 +5380,13 @@ func TestDoctorProjectCheckJobTimeoutPreservesCompletedChecks(t *testing.T) {
 	tests := []struct {
 		name            string
 		current         string
+		lastCompleted   string
 		blockOverlay    bool
 		blockDependency bool
 	}{
-		{name: "GitHub readiness", current: "GitHub readiness"},
-		{name: "local workflow overlay", current: "local workflow overlay", blockOverlay: true},
-		{name: "dependency auto-unblock", current: "dependency auto-unblock", blockDependency: true},
+		{name: "GitHub readiness", current: "GitHub readiness", lastCompleted: "Project alpha skills"},
+		{name: "local workflow overlay", current: "local workflow overlay", lastCompleted: "Project alpha workflow", blockOverlay: true},
+		{name: "dependency auto-unblock", current: "dependency auto-unblock", lastCompleted: "Project alpha repository merge policy", blockDependency: true},
 	}
 
 	for _, tt := range tests {
@@ -5479,15 +5480,12 @@ func TestDoctorProjectCheckJobTimeoutPreservesCompletedChecks(t *testing.T) {
 			if len(checks) < 2 {
 				t.Fatalf("checks = %#v, want completed checks followed by timeout", checks)
 			}
-			var foundWorkflow bool
-			for _, check := range checks[:len(checks)-1] {
-				if check.Name == "Project alpha workflow" {
-					foundWorkflow = true
-					break
-				}
+			completedChecks := checks[:len(checks)-1]
+			if got := completedChecks[0].Name; got != "Project alpha workflow" {
+				t.Fatalf("first completed check = %q, want Project alpha workflow", got)
 			}
-			if !foundWorkflow {
-				t.Fatalf("checks = %#v, want completed workflow check", checks)
+			if got := completedChecks[len(completedChecks)-1].Name; got != tt.lastCompleted {
+				t.Fatalf("last completed check = %q, want %q", got, tt.lastCompleted)
 			}
 			timeoutCheck := checks[len(checks)-1]
 			for _, want := range []string{"Project alpha checks", "timed out after 20ms", "while running Project alpha " + tt.current} {


### PR DESCRIPTION
## Summary

- verify the doctor timeout regression preserves the completed-check prefix through each intended blocked stage
- retain the controlled timer and explicit stage synchronization already present on main

Fixes #1527

## UI Surface Contract

- [x] N/A; this PR changes only a Go test assertion.
- [x] This PR does not add persistent top-of-screen messaging.
- [x] This PR has no visual changes.

## Test Plan

- [x] `go test -race ./internal/cli -run "^TestDoctorProjectCheckJobTimeoutPreservesCompletedChecks$" -count=100`
- [x] `go test -race ./internal/cli -count=10`
- [x] `make check` (78.0% coverage)