### PR TITLE
fix(orchestrator): add token progress brake

### DIFF
--- a/config.reference.yaml
+++ b/config.reference.yaml
@@ -504,6 +504,8 @@
 #   max_retry_backoff_ms: 300000
 #   # agent.overload_retry_delay_ms | type: integer | default: 45000 | required: No | validation: must be greater than 0
 #   overload_retry_delay_ms: 45000
+#   # agent.no_progress_token_limit | type: integer | default: 25000000 | required: No | validation: must be greater than or equal to 0
+#   no_progress_token_limit: 25000000
 #   # agent.no_progress_spend_limit_usd | type: number | default: 3 | required: No | validation: must be greater than or equal to 0
 #   no_progress_spend_limit_usd: 3
 #   # agent.failure_breaker | type: object | default: see child fields | required: No | validation: None

--- a/db/queries/store.sql
+++ b/db/queries/store.sql
@@ -585,6 +585,7 @@ ORDER BY finished_at, id;
 -- name: IssueSpendSince :one
 SELECT
   CAST(COALESCE(SUM(cost_usd), 0) AS REAL) AS cost_usd,
+  CAST(COALESCE(SUM(total_tokens), 0) AS INTEGER) AS total_tokens,
   CAST(COUNT(*) AS INTEGER) AS sessions,
   CAST(COALESCE(MIN(finished_at), '') AS TEXT) AS first_session_at,
   CAST(COALESCE(MAX(finished_at), '') AS TEXT) AS last_session_at

--- a/docs/ONBOARDING.md
+++ b/docs/ONBOARDING.md
@@ -2294,7 +2294,10 @@ awk 'NF {last=$0} END {exit last == "MUTATION_CONFIRMED=true" ? 0 : 1}' "$ONBOAR
    `agent.no_progress_timeout_ms`; keep `agent.max_session_tokens` as an
    additional token-consumption backstop because cached context is counted
    again on every Codex turn. A small multiplier can terminate otherwise
-   healthy sessions after only a few full-context turns.
+   healthy sessions after only a few full-context turns. Keep
+   `agent.no_progress_token_limit` positive as the cross-session brake,
+   especially when `budget.billing_mode: subscription` makes USD controls
+   inert.
 
    Dependency auto-unblock default:
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -269,6 +269,7 @@ rendering and fails on drift.
 | `agent.merge_worker_startup_timeout_ms` | `integer` | `240000` | No | must be greater than 0 |
 | `agent.no_progress_spend_limit_usd` | `number` | `3` | No | must be greater than or equal to 0 |
 | `agent.no_progress_timeout_ms` | `integer` | `5400000` | No | must be greater than or equal to 0 |
+| `agent.no_progress_token_limit` | `integer` | `25000000` | No | must be greater than or equal to 0 |
 | `agent.output_truncation` | `object` | `see child fields` | No | None |
 | `agent.output_truncation.max_bytes` | `integer` | `0` | No | must be greater than or equal to 0 |
 | `agent.overload_retry_delay_ms` | `integer` | `45000` | No | must be greater than 0 |

--- a/docs/dashboard-api.md
+++ b/docs/dashboard-api.md
@@ -79,39 +79,44 @@ thread-resume behavior is preserving useful context without repeatedly filling
 the window.
 
 `budget.billing_mode` accepts `metered` or `subscription`. Metered mode
-enforces configured USD caps and the spend-progress breaker. Subscription mode
+enforces configured USD caps and the USD progress breaker. Subscription mode
 keeps notional spend telemetry but never refuses dispatch or parks work based
 on USD; Detent instead scales dispatch concurrency with the lowest reported
-primary or secondary provider rate-window percentage. An omitted mode preserves
-legacy metered enforcement when `budget.enabled=true`, and `detent doctor` warns
-until the mode is declared.
+primary or secondary provider rate-window percentage. An omitted mode defaults
+to `subscription`, so USD controls are inert unless metered billing is declared
+explicitly.
+
+`agent.no_progress_token_limit` defaults to `25000000` tokens and is enforced
+in both billing modes. Detent sums persisted `total_tokens` for the issue across
+attempts after its latest accepted lane or PR advancement. Reaching the limit
+parks the issue even when USD is only notional subscription telemetry. Set the
+value to `0` to disable the token breaker.
 
 `agent.no_progress_spend_limit_usd` defaults to a base limit of `3`, below the
-default per-issue budget backstop. The effective limit scales with the session's
-reasoning effort: unknown/low `1x`, medium `1.5x`, high `3x`, xhigh `6x`, and
-max/ultracode `8x`. These multipliers assume one retry at the observed cost
-profile should fit before the breaker fires; `detent doctor` warns when an
-effort tier's effective limit is below its observed p50 per-session cost and
-recommends a base limit with `1.5x` retry-cost headroom.
+default per-issue budget backstop, and is enforced only when
+`billing_mode: metered`. The effective limit scales with the session's reasoning
+effort: unknown/low `1x`, medium `1.5x`, high `3x`, xhigh `6x`, and max/ultracode
+`8x`. These multipliers assume one retry at the observed cost profile should fit
+before the breaker fires; `detent doctor` warns when an effort tier's effective
+limit is below its observed p50 per-session cost and recommends a base limit
+with `1.5x` retry-cost headroom.
 
 Duration limits stop a single overlong turn or session regardless of message
-volume. The no-progress spend limit is a separate runaway control that can stop
-repeated or expensive work even when each individual session stays below its
-duration cap; it is enforced in metered billing mode and advisory in
-subscription mode.
+volume. The cross-session progress breakers can stop repeated or expensive work
+even when each individual session stays below its duration cap. The token
+breaker remains blocking on subscription fleets; the USD breaker is
+metered-only.
 
-Detent sums persisted session cost for each issue after its latest accepted
-lane or PR advancement. PR creation, a new head commit, a dirty-to-clean
-mergeability transition, and a failing-to-passing CI transition each reset the
-spend window. Spend accumulates only while the PR fingerprint remains static.
-In metered mode, when spend exceeds the effective limit, Detent parks the issue
-in `Blocked` and identifies whether no PR evidence was produced or a linked PR
-remained static. The latter points operators toward merge-train capacity and
-serialization tuning; the former recommends narrowing or splitting the task.
-The next worker must explain the missing progress signal in its first Workpad
-update before using tools. Set the value to `0` to disable the breaker and its
-history/spend lookups. In subscription mode, the same calculation is advisory
-telemetry and never parks the issue.
+PR creation, a new head commit, a dirty-to-clean mergeability transition, and a
+failing-to-passing CI transition each reset the shared token and USD window.
+Usage accumulates only while the PR fingerprint remains static. When an
+effective limit trips, Detent parks the issue in `Blocked` and identifies
+whether no PR evidence was produced or a linked PR remained static. The latter
+points operators toward merge-train capacity and serialization tuning; the
+former recommends narrowing or splitting the task. The next worker must explain
+the missing progress signal in its first Workpad update before using tools.
+`detent doctor` reports both effective brakes for every project and warns when
+neither is active.
 
 `agent.failure_breaker` pauses new project dispatches when the same failure
 class reaches `same_class_limit` attempts inside `window_seconds`. The default

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -176,6 +176,7 @@ agent:
   merge_worker_max_duration_ms: 21600000
   max_retry_backoff_ms: 300000
   overload_retry_delay_ms: 45000
+  no_progress_token_limit: 25000000
   no_progress_spend_limit_usd: 3
   failure_breaker:
     same_class_limit: 5

--- a/docs/templates/detent.github_local.yaml
+++ b/docs/templates/detent.github_local.yaml
@@ -81,6 +81,7 @@ agent:
   merge_worker_max_duration_ms: 21600000
   max_retry_backoff_ms: 300000
   overload_retry_delay_ms: 45000
+  no_progress_token_limit: 25000000
   no_progress_spend_limit_usd: 3
   resume_orphaned_sessions: true
   # Per-session ceiling on total_tokens. total_tokens counts input + output +

--- a/docs/templates/detent.issue_field.yaml
+++ b/docs/templates/detent.issue_field.yaml
@@ -82,6 +82,7 @@ agent:
   merge_worker_max_duration_ms: 21600000
   max_retry_backoff_ms: 300000
   overload_retry_delay_ms: 45000
+  no_progress_token_limit: 25000000
   no_progress_spend_limit_usd: 3
   resume_orphaned_sessions: true
   # Per-session ceiling on total_tokens. total_tokens counts input + output +

--- a/docs/templates/detent.label.yaml
+++ b/docs/templates/detent.label.yaml
@@ -82,6 +82,7 @@ agent:
   merge_worker_max_duration_ms: 21600000
   max_retry_backoff_ms: 300000
   overload_retry_delay_ms: 45000
+  no_progress_token_limit: 25000000
   no_progress_spend_limit_usd: 3
   resume_orphaned_sessions: true
   # Per-session ceiling on total_tokens. total_tokens counts input + output +

--- a/docs/templates/detent.non_code_artifact.yaml
+++ b/docs/templates/detent.non_code_artifact.yaml
@@ -28,6 +28,7 @@ deliverable:
     review_url: http://127.0.0.1:8080/review
 agent:
     resume_orphaned_sessions: true
+    no_progress_token_limit: 25000000
     no_progress_spend_limit_usd: 3
     max_turns: 20
     max_session_duration_ms: 7200000

--- a/docs/templates/detent.project_v2.yaml
+++ b/docs/templates/detent.project_v2.yaml
@@ -81,6 +81,7 @@ agent:
   merge_worker_max_duration_ms: 21600000
   max_retry_backoff_ms: 300000
   overload_retry_delay_ms: 45000
+  no_progress_token_limit: 25000000
   no_progress_spend_limit_usd: 3
   resume_orphaned_sessions: true
   # Per-session ceiling on total_tokens. total_tokens counts input + output +

--- a/internal/cli/doctor_project.go
+++ b/internal/cli/doctor_project.go
@@ -310,6 +310,8 @@ func checkDoctorProjectWithProgress(
 	if billingCheck, ok := checkDoctorBillingMode(id, workflow.Config); ok {
 		checks = append(checks, billingCheck)
 	}
+	setDoctorCurrentCheck("Project " + id + " progress brake")
+	checks = append(checks, checkDoctorProgressBrake(id, workflow.Config))
 	setDoctorCurrentCheck("Project " + id + " workflow lint")
 	checks = append(checks, checkDoctorWorkflowLint(ctx, id, project, workflow.Config, workflow.Prompt, workflowTokenThreshold, storePath, deps)...)
 	if len(workflow.Config.Routines) > 0 {
@@ -737,16 +739,10 @@ func doctorLocalDefinitionPaths(workflow workflowconfig.Workflow) []string {
 
 func checkDoctorBillingMode(id string, cfg workflowconfig.Config) (doctorCheck, bool) {
 	mode := cfg.Budget.EffectiveBillingMode()
+	modeDetail := "billing_mode=" + mode
 	if !cfg.Budget.BillingModeConfigured() {
-		if !cfg.Budget.Enabled && cfg.Agent.NoProgressSpendLimitUSD <= 0 {
-			return doctorCheck{}, false
-		}
-		return doctorCheck{
-			Name:   "Project " + id + " billing mode",
-			Status: doctorWarn,
-			Detail: "budget.billing_mode is undeclared; metered billing and USD enforcement are assumed for compatibility",
-			Hint:   "Declare budget.billing_mode: metered or budget.billing_mode: subscription in WORKFLOW.md.",
-		}, true
+		mode = workflowconfig.BillingModeSubscription
+		modeDetail = "budget.billing_mode is undeclared; subscription billing is the default"
 	}
 	if mode != workflowconfig.BillingModeSubscription {
 		return doctorCheck{}, false
@@ -765,9 +761,37 @@ func checkDoctorBillingMode(id string, cfg workflowconfig.Config) (doctorCheck, 
 	return doctorCheck{
 		Name:   "Project " + id + " billing mode",
 		Status: doctorWarn,
-		Detail: "billing_mode=subscription makes USD enforcement advisory; Detent will not refuse or park work from: " + strings.Join(controls, ", "),
+		Detail: modeDetail + " and USD enforcement is inert; Detent will not refuse or park work from: " + strings.Join(controls, ", "),
 		Hint:   "Use provider rate-window pacing and token or outcome-based brakes for subscription auth; set billing_mode=metered only for marginal API billing.",
 	}, true
+}
+
+func checkDoctorProgressBrake(id string, cfg workflowconfig.Config) doctorCheck {
+	mode := cfg.Budget.EffectiveBillingMode()
+	controls := make([]string, 0, 2)
+	if cfg.Agent.NoProgressTokenLimit > 0 {
+		controls = append(controls, fmt.Sprintf("tokens=%d", cfg.Agent.NoProgressTokenLimit))
+	}
+	if mode == workflowconfig.BillingModeMetered && cfg.Agent.NoProgressSpendLimitUSD > 0 {
+		controls = append(controls, fmt.Sprintf("USD=%g", cfg.Agent.NoProgressSpendLimitUSD))
+	}
+	if len(controls) == 0 {
+		return doctorCheck{
+			Name:   "Project " + id + " progress brake",
+			Status: doctorWarn,
+			Detail: "no effective cross-session progress brake is configured",
+			Hint:   "Set agent.no_progress_token_limit to a positive token budget, or use agent.no_progress_spend_limit_usd with budget.billing_mode: metered.",
+		}
+	}
+	detail := "effective cross-session progress brake: " + strings.Join(controls, ", ")
+	if mode == workflowconfig.BillingModeSubscription && cfg.Agent.NoProgressSpendLimitUSD > 0 {
+		detail += fmt.Sprintf("; USD=%g is inert in subscription mode", cfg.Agent.NoProgressSpendLimitUSD)
+	}
+	return doctorCheck{
+		Name:   "Project " + id + " progress brake",
+		Status: doctorOK,
+		Detail: detail,
+	}
 }
 
 func checkDoctorDisabledBudgetCaps(id string, cfg workflowconfig.Budget) (doctorCheck, bool) {
@@ -1434,11 +1458,18 @@ func doctorWorkflowSessionGuardDetail(cfg workflowconfig.Config) string {
 }
 
 func doctorWorkflowSpendBreakerDetail(cfg workflowconfig.Config) string {
-	limit := "disabled"
-	if cfg.Agent.NoProgressSpendLimitUSD > 0 {
-		limit = strconv.FormatFloat(cfg.Agent.NoProgressSpendLimitUSD, 'f', 2, 64)
+	tokenLimit := "disabled"
+	if cfg.Agent.NoProgressTokenLimit > 0 {
+		tokenLimit = strconv.FormatInt(cfg.Agent.NoProgressTokenLimit, 10)
 	}
-	return "spend-breaker=no_progress_spend_limit_usd=" + limit
+	usdLimit := "disabled"
+	if cfg.Agent.NoProgressSpendLimitUSD > 0 {
+		usdLimit = strconv.FormatFloat(cfg.Agent.NoProgressSpendLimitUSD, 'f', 2, 64)
+		if cfg.Budget.EffectiveBillingMode() == workflowconfig.BillingModeSubscription {
+			usdLimit += " (inert)"
+		}
+	}
+	return "progress-breaker=no_progress_token_limit=" + tokenLimit + ", no_progress_spend_limit_usd=" + usdLimit
 }
 
 func doctorWorkflowFindingDetails(findings []doctorWorkflowOptimizationFinding) string {

--- a/internal/cli/doctor_test.go
+++ b/internal/cli/doctor_test.go
@@ -1065,6 +1065,10 @@ func TestCheckDoctorProjects(t *testing.T) {
 	disabledBudgetWorkflow.Budget = parsedDisabledBudget.Config.Budget
 	omittedBudgetWorkflow := validDoctorWorkflow("/repo")
 	omittedBudgetWorkflow.Budget = workflowconfig.Default().Budget
+	disabledProgressWorkflow := validDoctorWorkflow("/repo")
+	disabledProgressWorkflow.Budget.BillingMode = workflowconfig.BillingModeSubscription
+	disabledProgressWorkflow.Agent.NoProgressTokenLimit = 0
+	disabledProgressWorkflow.Agent.NoProgressSpendLimitUSD = 0
 
 	tests := []struct {
 		name       string
@@ -1104,8 +1108,8 @@ func TestCheckDoctorProjects(t *testing.T) {
 				{ID: "alpha", Workflow: "WORKFLOW.md"},
 			},
 			workflow:   workflowconfig.Workflow{Config: disabledBudgetWorkflow},
-			wantStatus: []doctorStatus{doctorOK, doctorWarn, doctorWarn, doctorOK, doctorOK, doctorOK, doctorWarn, doctorOK},
-			wantDetail: []string{"is valid", "metered billing and USD enforcement are assumed", "budget.enabled=false disables configured caps", "enabled=true provides prompt guidance", "validated 0 pinned Codex route model(s)", "is a git worktree", "contain no detent-agent guidance", "loaded=0; dropped=0"},
+			wantStatus: []doctorStatus{doctorOK, doctorWarn, doctorOK, doctorWarn, doctorOK, doctorOK, doctorOK, doctorWarn, doctorOK},
+			wantDetail: []string{"is valid", "subscription billing is the default", "effective cross-session progress brake", "budget.enabled=false disables configured caps", "enabled=true provides prompt guidance", "validated 0 pinned Codex route model(s)", "is a git worktree", "contain no detent-agent guidance", "loaded=0; dropped=0"},
 		},
 		{
 			name: "inherited spend breaker warns about billing ambiguity",
@@ -1113,8 +1117,8 @@ func TestCheckDoctorProjects(t *testing.T) {
 				{ID: "alpha", Workflow: "WORKFLOW.md"},
 			},
 			workflow:   workflowconfig.Workflow{Config: omittedBudgetWorkflow},
-			wantStatus: []doctorStatus{doctorOK, doctorWarn, doctorOK, doctorOK, doctorOK, doctorWarn, doctorOK},
-			wantDetail: []string{"is valid", "metered billing and USD enforcement are assumed", "enabled=true provides prompt guidance", "validated 0 pinned Codex route model(s)", "is a git worktree", "contain no detent-agent guidance", "loaded=0; dropped=0"},
+			wantStatus: []doctorStatus{doctorOK, doctorWarn, doctorOK, doctorOK, doctorOK, doctorOK, doctorWarn, doctorOK},
+			wantDetail: []string{"is valid", "subscription billing is the default", "effective cross-session progress brake", "enabled=true provides prompt guidance", "validated 0 pinned Codex route model(s)", "is a git worktree", "contain no detent-agent guidance", "loaded=0; dropped=0"},
 		},
 		{
 			name: "source repo missing",
@@ -1123,8 +1127,17 @@ func TestCheckDoctorProjects(t *testing.T) {
 			},
 			workflow:   workflowconfig.Workflow{Config: validDoctorWorkflow("/repo")},
 			gitErr:     errors.New("not a git worktree"),
-			wantStatus: []doctorStatus{doctorOK, doctorOK, doctorOK, doctorFail, doctorOK, doctorWarn},
-			wantDetail: []string{"is valid", "enabled=true provides prompt guidance", "validated 0 pinned Codex route model(s)", "not a git worktree", "skipped because source repository is unavailable locally", "skipped because source repository is unavailable locally"},
+			wantStatus: []doctorStatus{doctorOK, doctorOK, doctorOK, doctorOK, doctorFail, doctorOK, doctorWarn},
+			wantDetail: []string{"is valid", "effective cross-session progress brake", "enabled=true provides prompt guidance", "validated 0 pinned Codex route model(s)", "not a git worktree", "skipped because source repository is unavailable locally", "skipped because source repository is unavailable locally"},
+		},
+		{
+			name: "all progress brakes disabled",
+			projects: []globalconfig.Project{
+				{ID: "alpha", Workflow: "WORKFLOW.md"},
+			},
+			workflow:   workflowconfig.Workflow{Config: disabledProgressWorkflow},
+			wantStatus: []doctorStatus{doctorOK, doctorWarn, doctorWarn, doctorOK, doctorOK, doctorOK, doctorWarn, doctorOK},
+			wantDetail: []string{"is valid", "billing_mode=subscription", "no effective cross-session progress brake", "enabled=true provides prompt guidance", "validated 0 pinned Codex route model(s)", "is a git worktree", "contain no detent-agent guidance", "loaded=0; dropped=0"},
 		},
 		{
 			name: "workflow and source repo valid",
@@ -1132,8 +1145,8 @@ func TestCheckDoctorProjects(t *testing.T) {
 				{ID: "alpha", Workflow: "WORKFLOW.md"},
 			},
 			workflow:   workflowconfig.Workflow{Config: validDoctorWorkflow("/repo")},
-			wantStatus: []doctorStatus{doctorOK, doctorOK, doctorOK, doctorOK, doctorWarn, doctorOK},
-			wantDetail: []string{"is valid", "enabled=true provides prompt guidance", "validated 0 pinned Codex route model(s)", "is a git worktree", "contain no detent-agent guidance", "loaded=0; dropped=0"},
+			wantStatus: []doctorStatus{doctorOK, doctorOK, doctorOK, doctorOK, doctorOK, doctorWarn, doctorOK},
+			wantDetail: []string{"is valid", "effective cross-session progress brake", "enabled=true provides prompt guidance", "validated 0 pinned Codex route model(s)", "is a git worktree", "contain no detent-agent guidance", "loaded=0; dropped=0"},
 		},
 	}
 
@@ -1228,16 +1241,16 @@ func TestCheckDoctorBillingMode(t *testing.T) {
 		wantDetail string
 	}{
 		{
-			name:       "legacy enabled budget warns about assumed metered mode",
+			name:       "undeclared enabled budget warns about default subscription mode",
 			budget:     workflowconfig.Budget{Enabled: true},
 			wantOK:     true,
-			wantDetail: "metered billing and USD enforcement are assumed",
+			wantDetail: "subscription billing is the default",
 		},
 		{
-			name:       "legacy spend breaker warns about assumed metered mode",
+			name:       "undeclared spend breaker warns that USD is inert",
 			spendLimit: 3,
 			wantOK:     true,
-			wantDetail: "metered billing and USD enforcement are assumed",
+			wantDetail: "subscription billing is the default",
 		},
 		{
 			name: "undeclared mode without USD controls does not warn",
@@ -1278,6 +1291,65 @@ func TestCheckDoctorBillingMode(t *testing.T) {
 			}
 			if tt.wantOK && (got.Status != doctorWarn || !strings.Contains(got.Detail, tt.wantDetail)) {
 				t.Fatalf("checkDoctorBillingMode() = %#v, want warning containing %q", got, tt.wantDetail)
+			}
+		})
+	}
+}
+
+func TestCheckDoctorProgressBrake(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		budget     workflowconfig.Budget
+		tokenLimit int64
+		spendLimit float64
+		wantStatus doctorStatus
+		wantDetail string
+	}{
+		{
+			name:       "subscription token brake remains effective",
+			budget:     workflowconfig.Budget{BillingMode: workflowconfig.BillingModeSubscription},
+			tokenLimit: 25_000_000,
+			spendLimit: 3,
+			wantStatus: doctorOK,
+			wantDetail: "tokens=25000000; USD=3 is inert",
+		},
+		{
+			name:       "metered reports both effective brakes",
+			budget:     workflowconfig.Budget{BillingMode: workflowconfig.BillingModeMetered},
+			tokenLimit: 25_000_000,
+			spendLimit: 3,
+			wantStatus: doctorOK,
+			wantDetail: "tokens=25000000, USD=3",
+		},
+		{
+			name:       "metered USD brake is effective by itself",
+			budget:     workflowconfig.Budget{BillingMode: workflowconfig.BillingModeMetered},
+			spendLimit: 3,
+			wantStatus: doctorOK,
+			wantDetail: "USD=3",
+		},
+		{
+			name:       "all brakes disabled warns",
+			budget:     workflowconfig.Budget{BillingMode: workflowconfig.BillingModeSubscription},
+			wantStatus: doctorWarn,
+			wantDetail: "no effective cross-session progress brake",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := checkDoctorProgressBrake("detent", workflowconfig.Config{
+				Budget: tt.budget,
+				Agent: workflowconfig.Agent{
+					NoProgressTokenLimit:    tt.tokenLimit,
+					NoProgressSpendLimitUSD: tt.spendLimit,
+				},
+			})
+			if got.Status != tt.wantStatus || !strings.Contains(got.Detail, tt.wantDetail) {
+				t.Fatalf("checkDoctorProgressBrake() = %#v, want %s containing %q", got, tt.wantStatus, tt.wantDetail)
 			}
 		})
 	}
@@ -3023,7 +3095,7 @@ func TestCheckDoctorProjectsExpandsSourceRootBeforeGit(t *testing.T) {
 	if gotPath != wantPath {
 		t.Fatalf("git path = %q, want %q", gotPath, wantPath)
 	}
-	if len(checks) != 6 || checks[3].Status != doctorOK || checks[3].Name != "Project alpha source repo" {
+	if len(checks) != 7 || checks[4].Status != doctorOK || checks[4].Name != "Project alpha source repo" {
 		t.Fatalf("checks = %#v, want source repo OK", checks)
 	}
 }
@@ -4408,18 +4480,23 @@ func TestDoctorWorkflowSpendBreakerDetail(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name  string
-		limit float64
-		want  string
+		name        string
+		billingMode string
+		tokenLimit  int64
+		spendLimit  float64
+		want        string
 	}{
-		{name: "disabled", want: "spend-breaker=no_progress_spend_limit_usd=disabled"},
-		{name: "configured", limit: 7.5, want: "spend-breaker=no_progress_spend_limit_usd=7.50"},
+		{name: "disabled", want: "progress-breaker=no_progress_token_limit=disabled, no_progress_spend_limit_usd=disabled"},
+		{name: "subscription", billingMode: workflowconfig.BillingModeSubscription, tokenLimit: 25_000_000, spendLimit: 7.5, want: "progress-breaker=no_progress_token_limit=25000000, no_progress_spend_limit_usd=7.50 (inert)"},
+		{name: "metered", billingMode: workflowconfig.BillingModeMetered, tokenLimit: 25_000_000, spendLimit: 7.5, want: "progress-breaker=no_progress_token_limit=25000000, no_progress_spend_limit_usd=7.50"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			cfg := workflowconfig.Config{}
-			cfg.Agent.NoProgressSpendLimitUSD = tt.limit
+			cfg.Budget.BillingMode = tt.billingMode
+			cfg.Agent.NoProgressTokenLimit = tt.tokenLimit
+			cfg.Agent.NoProgressSpendLimitUSD = tt.spendLimit
 			if got := doctorWorkflowSpendBreakerDetail(cfg); got != tt.want {
 				t.Fatalf("doctorWorkflowSpendBreakerDetail() = %q, want %q", got, tt.want)
 			}

--- a/internal/cli/doctor_workflow_optimization.go
+++ b/internal/cli/doctor_workflow_optimization.go
@@ -948,7 +948,9 @@ func doctorWorkflowSpendProgressLimitFinding(
 	medianCostByEffort map[string]float64,
 ) (doctorWorkflowOptimizationFinding, bool) {
 	configuredLimit := cfg.Agent.NoProgressSpendLimitUSD
-	if configuredLimit <= 0 || len(medianCostByEffort) == 0 {
+	if cfg.Budget.EffectiveBillingMode() != workflowconfig.BillingModeMetered ||
+		configuredLimit <= 0 ||
+		len(medianCostByEffort) == 0 {
 		return doctorWorkflowOptimizationFinding{}, false
 	}
 	efforts := make([]string, 0, len(medianCostByEffort))

--- a/internal/cli/doctor_workflow_optimization_test.go
+++ b/internal/cli/doctor_workflow_optimization_test.go
@@ -1079,20 +1079,23 @@ func TestDoctorWorkflowOptimizationWarnsWhenSpendProgressLimitIsBelowMedianCost(
 
 	tests := []struct {
 		name        string
+		billingMode string
 		baseLimit   float64
 		medians     map[string]float64
 		wantFinding bool
 		wantPatch   float64
 	}{
-		{name: "xhigh effective limit below median", baseLimit: 3, medians: map[string]float64{"xhigh": 20}, wantFinding: true, wantPatch: 5},
-		{name: "xhigh effective limit above median", baseLimit: 3, medians: map[string]float64{"xhigh": 17}},
-		{name: "custom base covers median", baseLimit: 4, medians: map[string]float64{"high": 11}},
-		{name: "disabled breaker does not warn", baseLimit: 0, medians: map[string]float64{"xhigh": 20}},
+		{name: "xhigh effective limit below median", billingMode: workflowconfig.BillingModeMetered, baseLimit: 3, medians: map[string]float64{"xhigh": 20}, wantFinding: true, wantPatch: 5},
+		{name: "xhigh effective limit above median", billingMode: workflowconfig.BillingModeMetered, baseLimit: 3, medians: map[string]float64{"xhigh": 17}},
+		{name: "custom base covers median", billingMode: workflowconfig.BillingModeMetered, baseLimit: 4, medians: map[string]float64{"high": 11}},
+		{name: "disabled breaker does not warn", billingMode: workflowconfig.BillingModeMetered, baseLimit: 0, medians: map[string]float64{"xhigh": 20}},
+		{name: "subscription USD breaker is inert", billingMode: workflowconfig.BillingModeSubscription, baseLimit: 3, medians: map[string]float64{"xhigh": 20}},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			cfg := workflowconfig.Default()
+			cfg.Budget.BillingMode = tt.billingMode
 			cfg.Agent.NoProgressSpendLimitUSD = tt.baseLimit
 			findings := doctorWorkflowOptimizationFindings("detent", "WORKFLOW.md", cfg, doctorWorkflowOptimizationMetrics{
 				MedianSessionCostUSDByEffort: tt.medians,

--- a/internal/cli/runner_test.go
+++ b/internal/cli/runner_test.go
@@ -337,6 +337,7 @@ func TestBuildBudgetDispatchGuards(t *testing.T) {
 
 	enabled := disabled
 	enabled.Enabled = true
+	enabled.BillingMode = workflowconfig.BillingModeMetered
 	_, _, err = buildBudgetDispatchGuards("alpha", enabled, &runnerSessionStore{}, nil)
 	if !errors.Is(err, budget.ErrMissingSpendStore) {
 		t.Fatalf("buildBudgetDispatchGuards(missing spend store) error = %v, want ErrMissingSpendStore", err)
@@ -411,6 +412,7 @@ func TestBuildBudgetDispatchGuardsIsolatesProjectDailySpend(t *testing.T) {
 
 	cfg := workflowconfig.Default().Budget
 	cfg.Enabled = true
+	cfg.BillingMode = workflowconfig.BillingModeMetered
 	cfg.PerDayMaxUSD = 100
 	pricing := budget.PricingTable{"gpt-test": {USDPerInputToken: 1}}
 	for _, tt := range []struct {

--- a/internal/codex/appserver.go
+++ b/internal/codex/appserver.go
@@ -1226,12 +1226,17 @@ func updateFromMessage(msg Message) (Update, bool, error) {
 			Resolved    string `json:"resolvedModel"`
 			ResolvedAlt string `json:"resolved_model"`
 			TokenUsage  struct {
-				Total              tokenUsageBreakdown `json:"total"`
-				ModelContextWindow *int64              `json:"modelContextWindow"`
+				Total              tokenUsageBreakdown  `json:"total"`
+				Last               *tokenUsageBreakdown `json:"last"`
+				ModelContextWindow *int64               `json:"modelContextWindow"`
 			} `json:"tokenUsage"`
 		}
 		if err := json.Unmarshal(msg.Params, &params); err != nil {
 			return Update{}, false, fmt.Errorf("%w: decode token usage: %w", ErrInvalidResponse, err)
+		}
+		usage := params.TokenUsage.Total
+		if params.TokenUsage.Last != nil {
+			usage = *params.TokenUsage.Last
 		}
 		return Update{
 			Type:     UpdateTokenUsage,
@@ -1240,11 +1245,11 @@ func updateFromMessage(msg Message) (Update, bool, error) {
 			TurnID:   params.TurnID,
 			Model:    firstNonBlank(params.Model, params.Resolved, params.ResolvedAlt, params.ModelID, params.ModelIDAlt),
 			Tokens: TokenUsage{
-				InputTokens:           params.TokenUsage.Total.InputTokens,
-				CachedInputTokens:     params.TokenUsage.Total.CachedInputTokens,
-				OutputTokens:          params.TokenUsage.Total.OutputTokens,
-				ReasoningOutputTokens: params.TokenUsage.Total.ReasoningOutputTokens,
-				TotalTokens:           params.TokenUsage.Total.TotalTokens,
+				InputTokens:           usage.InputTokens,
+				CachedInputTokens:     usage.CachedInputTokens,
+				OutputTokens:          usage.OutputTokens,
+				ReasoningOutputTokens: usage.ReasoningOutputTokens,
+				TotalTokens:           usage.TotalTokens,
 				ModelContextWindow:    params.TokenUsage.ModelContextWindow,
 			},
 			Payload: rawPayload(msg),

--- a/internal/codex/appserver_test.go
+++ b/internal/codex/appserver_test.go
@@ -148,10 +148,10 @@ func TestAppServerRunTurnStartsLifecycleAndStreamsUpdates(t *testing.T) {
 	if updates[3].Type != UpdateAgentMessageDelta || updates[3].Delta != "hello" {
 		t.Fatalf("updates[3] = %#v, want agent message delta", updates[3])
 	}
-	if updates[4].Type != UpdateTokenUsage || updates[4].Tokens.TotalTokens != 27 {
-		t.Fatalf("updates[4] = %#v, want token usage total 27", updates[4])
+	if updates[4].Type != UpdateTokenUsage || updates[4].Tokens.TotalTokens != 5 {
+		t.Fatalf("updates[4] = %#v, want last-turn token usage total 5", updates[4])
 	}
-	if updates[4].Tokens.CachedInputTokens != 5 || updates[4].Tokens.ReasoningOutputTokens != 3 {
+	if updates[4].Tokens.CachedInputTokens != 1 || updates[4].Tokens.ReasoningOutputTokens != 1 {
 		t.Fatalf("updates[4].Tokens = %#v", updates[4].Tokens)
 	}
 	if updates[4].Tokens.ModelContextWindow == nil || *updates[4].Tokens.ModelContextWindow != 200000 {
@@ -168,6 +168,75 @@ func TestAppServerRunTurnStartsLifecycleAndStreamsUpdates(t *testing.T) {
 	}
 	if updates[6].Type != UpdateTurnCompleted || updates[6].TurnID != "turn-1" {
 		t.Fatalf("updates[6] = %#v, want turn completed", updates[6])
+	}
+}
+
+func TestUpdateFromMessageUsesPerTurnTokenUsage(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		tokenUsage string
+		want       TokenUsage
+	}{
+		{
+			name: "last turn available",
+			tokenUsage: `{
+				"total":{"inputTokens":20,"cachedInputTokens":5,"outputTokens":7,"reasoningOutputTokens":3,"totalTokens":27},
+				"last":{"inputTokens":2,"cachedInputTokens":1,"outputTokens":3,"reasoningOutputTokens":1,"totalTokens":5},
+				"modelContextWindow":200000
+			}`,
+			want: TokenUsage{
+				InputTokens:           2,
+				CachedInputTokens:     1,
+				OutputTokens:          3,
+				ReasoningOutputTokens: 1,
+				TotalTokens:           5,
+			},
+		},
+		{
+			name: "legacy total fallback",
+			tokenUsage: `{
+				"total":{"inputTokens":20,"cachedInputTokens":5,"outputTokens":7,"reasoningOutputTokens":3,"totalTokens":27},
+				"modelContextWindow":200000
+			}`,
+			want: TokenUsage{
+				InputTokens:           20,
+				CachedInputTokens:     5,
+				OutputTokens:          7,
+				ReasoningOutputTokens: 3,
+				TotalTokens:           27,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			message := notificationMessage(t, "thread/tokenUsage/updated", `{
+				"threadId":"thread-resumed",
+				"turnId":"turn-new",
+				"tokenUsage":`+tt.tokenUsage+`
+			}`)
+			update, ok, err := updateFromMessage(message)
+			if err != nil {
+				t.Fatalf("updateFromMessage() error = %v", err)
+			}
+			if !ok {
+				t.Fatal("updateFromMessage() ok = false, want true")
+			}
+			if update.Tokens.InputTokens != tt.want.InputTokens ||
+				update.Tokens.CachedInputTokens != tt.want.CachedInputTokens ||
+				update.Tokens.OutputTokens != tt.want.OutputTokens ||
+				update.Tokens.ReasoningOutputTokens != tt.want.ReasoningOutputTokens ||
+				update.Tokens.TotalTokens != tt.want.TotalTokens {
+				t.Fatalf("Tokens = %#v, want %#v", update.Tokens, tt.want)
+			}
+			if update.Tokens.ModelContextWindow == nil || *update.Tokens.ModelContextWindow != 200000 {
+				t.Fatalf("ModelContextWindow = %#v, want 200000", update.Tokens.ModelContextWindow)
+			}
+		})
 	}
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -63,6 +63,7 @@ const (
 	DefaultKnowledgeMaxBytes                 = 64 * 1024
 	DefaultReworkLimit                       = 3
 	DefaultNoProgressLimit                   = 3
+	DefaultNoProgressTokenLimit              = 25_000_000
 	DefaultNoProgressSpendLimitUSD           = 3.0
 	DefaultFailureBreakerSameClassLimit      = 5
 	DefaultFailureBreakerWindowSeconds       = 3600
@@ -282,6 +283,7 @@ type Agent struct {
 	MergeWorkerMaxDurationMS     int                          `yaml:"merge_worker_max_duration_ms"`
 	MaxRetryBackoffMS            int                          `yaml:"max_retry_backoff_ms"`
 	OverloadRetryDelayMS         int                          `yaml:"overload_retry_delay_ms"`
+	NoProgressTokenLimit         int64                        `yaml:"no_progress_token_limit"`
 	NoProgressSpendLimitUSD      float64                      `yaml:"no_progress_spend_limit_usd"`
 	FailureBreaker               FailureBreaker               `yaml:"failure_breaker"`
 	MaxSessionTokens             int64                        `yaml:"max_session_tokens"`
@@ -477,10 +479,10 @@ type Budget struct {
 }
 
 func (b Budget) EffectiveBillingMode() string {
-	if strings.EqualFold(strings.TrimSpace(b.BillingMode), BillingModeSubscription) {
-		return BillingModeSubscription
+	if strings.EqualFold(strings.TrimSpace(b.BillingMode), BillingModeMetered) {
+		return BillingModeMetered
 	}
-	return BillingModeMetered
+	return BillingModeSubscription
 }
 
 func (b Budget) BillingModeConfigured() bool {
@@ -1296,6 +1298,7 @@ func Default() Config {
 			MergeWorkerMaxDurationMS:    DefaultMergeWorkerMaxDurationMS,
 			MaxRetryBackoffMS:           300000,
 			OverloadRetryDelayMS:        DefaultOverloadRetryDelayMS,
+			NoProgressTokenLimit:        DefaultNoProgressTokenLimit,
 			NoProgressSpendLimitUSD:     DefaultNoProgressSpendLimitUSD,
 			StopRun:                     StopRun{TargetState: "Blocked"},
 			MergeFastPath:               MergeFastPath{Enabled: true},
@@ -1995,6 +1998,9 @@ func (a *Agent) validate(prefix string, problems *[]string) {
 	}
 	if a.MaxSessionContextMultiplier < 0 {
 		*problems = append(*problems, prefix+".max_session_context_multiplier must be greater than or equal to 0")
+	}
+	if a.NoProgressTokenLimit < 0 {
+		*problems = append(*problems, prefix+".no_progress_token_limit must be greater than or equal to 0")
 	}
 	if a.NoProgressSpendLimitUSD < 0 {
 		*problems = append(*problems, prefix+".no_progress_spend_limit_usd must be greater than or equal to 0")

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -269,7 +269,7 @@ func TestParseWorkflowBillingMode(t *testing.T) {
 		configured bool
 		wantErr    string
 	}{
-		{name: "omitted assumes metered", want: BillingModeMetered},
+		{name: "omitted defaults to subscription", want: BillingModeSubscription},
 		{name: "metered", value: "metered", want: BillingModeMetered, configured: true},
 		{name: "subscription", value: "subscription", want: BillingModeSubscription, configured: true},
 		{name: "normalizes case and whitespace", value: " Subscription ", want: BillingModeSubscription, configured: true},
@@ -416,6 +416,43 @@ func TestNoProgressSpendLimitConfiguration(t *testing.T) {
 			}
 			if workflow.Config.Agent.NoProgressSpendLimitUSD != tt.want {
 				t.Fatalf("NoProgressSpendLimitUSD = %g, want %g", workflow.Config.Agent.NoProgressSpendLimitUSD, tt.want)
+			}
+		})
+	}
+}
+
+func TestNoProgressTokenLimitConfiguration(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		raw     string
+		want    int64
+		wantErr string
+	}{
+		{name: "default enabled", raw: "---\ntracker:\n  kind: memory\n---\nPrompt\n", want: DefaultNoProgressTokenLimit},
+		{name: "explicitly disabled", raw: "---\ntracker:\n  kind: memory\nagent:\n  no_progress_token_limit: 0\n---\nPrompt\n"},
+		{name: "custom threshold", raw: "---\ntracker:\n  kind: memory\nagent:\n  no_progress_token_limit: 40000000\n---\nPrompt\n", want: 40_000_000},
+		{name: "negative rejected", raw: "---\ntracker:\n  kind: memory\nagent:\n  no_progress_token_limit: -1\n---\nPrompt\n", wantErr: "agent.no_progress_token_limit must be greater than or equal to 0"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			workflow, err := ParseWorkflow([]byte(tt.raw))
+			if tt.wantErr != "" {
+				if err == nil {
+					err = workflow.Config.Validate()
+				}
+				if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
+					t.Fatalf("configuration error = %v, want %q", err, tt.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("ParseWorkflow() error = %v", err)
+			}
+			if workflow.Config.Agent.NoProgressTokenLimit != tt.want {
+				t.Fatalf("NoProgressTokenLimit = %d, want %d", workflow.Config.Agent.NoProgressTokenLimit, tt.want)
 			}
 		})
 	}

--- a/internal/orchestrator/config.go
+++ b/internal/orchestrator/config.go
@@ -38,6 +38,7 @@ func ConfigFromWorkflow(cfg workflowconfig.Config) Config {
 		MaxConcurrentAgentsPerHost: positiveIntValue(cfg.Worker.MaxConcurrentAgentsPerHost),
 		MaxRetryBackoff:            durationFromMillis(cfg.Agent.MaxRetryBackoffMS),
 		OverloadRetryDelay:         durationFromMillis(cfg.Agent.OverloadRetryDelayMS),
+		NoProgressTokenLimit:       cfg.Agent.NoProgressTokenLimit,
 		NoProgressSpendLimitUSD:    cfg.Agent.NoProgressSpendLimitUSD,
 		BillingMode:                cfg.Budget.EffectiveBillingMode(),
 		FailureBreaker: FailureBreakerConfig{
@@ -147,7 +148,7 @@ func stalenessConfigFromWorkflow(cfg workflowconfig.StalenessObservability) stal
 func normalizeConfig(cfg Config) Config {
 	cfg.BillingMode = strings.ToLower(strings.TrimSpace(cfg.BillingMode))
 	if cfg.BillingMode == "" {
-		cfg.BillingMode = workflowconfig.BillingModeMetered
+		cfg.BillingMode = workflowconfig.BillingModeSubscription
 	}
 	if cfg.PollInterval <= 0 {
 		cfg.PollInterval = defaultPollInterval
@@ -280,7 +281,7 @@ func cloneStopRunPriorityNames(values map[int]string) map[int]string {
 }
 
 func (cfg Config) subscriptionBilling() bool {
-	return cfg.BillingMode == workflowconfig.BillingModeSubscription
+	return !strings.EqualFold(strings.TrimSpace(cfg.BillingMode), workflowconfig.BillingModeMetered)
 }
 
 func normalizeClaimingConfig(cfg ClaimingConfig) ClaimingConfig {

--- a/internal/orchestrator/dispatch_parity_test.go
+++ b/internal/orchestrator/dispatch_parity_test.go
@@ -27,6 +27,7 @@ func TestDispatchParityWithElixirRecordedCandidateSets(t *testing.T) {
 			now := mustParseParityTime(t, tt.Now)
 			cfg := normalizeConfig(Config{
 				MaxConcurrentAgents:        tt.Config.MaxConcurrentAgents,
+				BillingMode:                "metered",
 				MaxConcurrentAgentsByState: tt.Config.MaxConcurrentAgentsByState,
 				DispatchPriorityByState:    tt.Config.DispatchPriorityByState,
 				DispatchPriorityByLabel:    tt.Config.DispatchPriorityByLabel,

--- a/internal/orchestrator/dispatch_test.go
+++ b/internal/orchestrator/dispatch_test.go
@@ -288,6 +288,9 @@ func TestConfigFromWorkflowIncludesDispatchControls(t *testing.T) {
 	if got.MergeWorkerMaxDuration != 2*time.Hour {
 		t.Fatalf("MergeWorkerMaxDuration = %s, want 2h", got.MergeWorkerMaxDuration)
 	}
+	if got.NoProgressTokenLimit != workflowconfig.DefaultNoProgressTokenLimit {
+		t.Fatalf("NoProgressTokenLimit = %d, want %d", got.NoProgressTokenLimit, workflowconfig.DefaultNoProgressTokenLimit)
+	}
 	if len(got.WorkerHosts) != 2 || got.WorkerHosts[0] != "worker-a" || got.WorkerHosts[1] != "worker-b" {
 		t.Fatalf("WorkerHosts = %#v, want worker-a and worker-b", got.WorkerHosts)
 	}
@@ -446,6 +449,7 @@ func TestDispatchableFiltersIneligibleCandidates(t *testing.T) {
 	now := time.Now()
 	cfg := normalizeConfig(Config{
 		MaxConcurrentAgents:    2,
+		BillingMode:            workflowconfig.BillingModeMetered,
 		ActiveStates:           []string{"Todo", "In Progress"},
 		TerminalStates:         []string{"Done", "Cancelled"},
 		BudgetRefusalCooldown:  time.Hour,
@@ -694,7 +698,7 @@ func TestPruneBudgetRefusalsReevaluatesDailyCap(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			cfg := normalizeConfig(Config{BudgetRefusalCooldown: time.Hour})
+			cfg := normalizeConfig(Config{BillingMode: workflowconfig.BillingModeMetered, BudgetRefusalCooldown: time.Hour})
 			state := newState(cfg)
 			issue := dispatchTestIssue("issue", "Todo")
 			tt.refusal.Issue = issue
@@ -1024,6 +1028,7 @@ func TestHandleRunResultRecordsBudgetRefusalAndComment(t *testing.T) {
 	now := time.Date(2026, 6, 2, 10, 0, 0, 0, time.UTC)
 	cfg := normalizeConfig(Config{
 		MaxConcurrentAgents:    1,
+		BillingMode:            workflowconfig.BillingModeMetered,
 		ActiveStates:           []string{"Todo"},
 		TerminalStates:         []string{"Done"},
 		BudgetRefusalCooldown:  time.Hour,
@@ -1084,6 +1089,7 @@ func TestHandleRunResultCreatesPerIssueHardHoldWithoutRetry(t *testing.T) {
 	now := time.Date(2026, 7, 12, 12, 0, 0, 0, time.UTC)
 	cfg := normalizeConfig(Config{
 		MaxConcurrentAgents:    1,
+		BillingMode:            workflowconfig.BillingModeMetered,
 		ActiveStates:           []string{"Todo"},
 		TerminalStates:         []string{"Done"},
 		BudgetRefusalCooldown:  time.Hour,

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -81,6 +81,7 @@ type Config struct {
 	MaxConcurrentAgentsPerHost    int
 	MaxRetryBackoff               time.Duration
 	OverloadRetryDelay            time.Duration
+	NoProgressTokenLimit          int64
 	NoProgressSpendLimitUSD       float64
 	BillingMode                   string
 	FailureBreaker                FailureBreakerConfig

--- a/internal/orchestrator/run_completion.go
+++ b/internal/orchestrator/run_completion.go
@@ -232,9 +232,9 @@ func (o *Orchestrator) handleRunResult(ctx context.Context, state *State, event 
 		if spendProgress.Block && !errors.Is(event.Err, runpkg.ErrSessionTokenCeilingExceeded) {
 			terminalState = store.WorkAttemptTerminalNoProgress
 			errorClass = spendProgressReason
-			errorMessage = fmt.Sprintf("spent %s since the last accepted state change; configured limit %s", budget.FormatUSD(spendProgress.Spend.CostUSD), budget.FormatUSD(spendProgress.LimitUSD))
+			errorMessage = spendProgressBlockMessage(spendProgress)
 			phase = "no_progress"
-			statusMessage = "spend-since-progress circuit breaker tripped"
+			statusMessage = "no-progress circuit breaker tripped"
 		}
 		o.recordProjectAttemptOutcome(state, event.IssueID, event.CompletedAt, terminalState, event.Err, errorClass, errorMessage)
 		o.completeDurableWorkAttemptWithMetadata(ctx, state, running, event.CompletedAt, terminalState, errorClass, errorMessage, phase, statusMessage, spendProgressMetadata(spendProgress))
@@ -381,9 +381,9 @@ func (o *Orchestrator) handleRunResult(ctx context.Context, state *State, event 
 		terminalState = store.WorkAttemptTerminalNoProgress
 		progress.Outcome = store.WorkAttemptTerminalNoProgress
 		errorClass = spendProgressReason
-		errorMessage = fmt.Sprintf("spent %s since the last accepted state change; configured limit %s", budget.FormatUSD(spendProgress.Spend.CostUSD), budget.FormatUSD(spendProgress.LimitUSD))
+		errorMessage = spendProgressBlockMessage(spendProgress)
 		phase = "no_progress"
-		statusMessage = "spend-since-progress circuit breaker tripped"
+		statusMessage = "no-progress circuit breaker tripped"
 	}
 	if artifactConvergence.Tripped {
 		phase = "blocked"

--- a/internal/orchestrator/safety_fuzz_test.go
+++ b/internal/orchestrator/safety_fuzz_test.go
@@ -84,6 +84,10 @@ func FuzzSafetyCriticalOrchestratorBoundaries(f *testing.F) {
 		if got := spendProgressPRAdvance(leftFingerprint, rightFingerprint); got != wantAdvance {
 			t.Fatalf("spendProgressPRAdvance(%#v, %#v) = %q, want %q", leftFingerprint, rightFingerprint, got, wantAdvance)
 		}
+		wantTokenLimitReached := rightNumber > 0 && leftNumber >= rightNumber
+		if got := spendProgressTokenLimitReached(leftNumber, rightNumber); got != wantTokenLimitReached {
+			t.Fatalf("spendProgressTokenLimitReached(%d, %d) = %t, want %t", leftNumber, rightNumber, got, wantTokenLimitReached)
+		}
 
 		resetSeconds %= 1_000_000_000
 		nowSeconds %= 1_000_000_000

--- a/internal/orchestrator/soak_test.go
+++ b/internal/orchestrator/soak_test.go
@@ -150,6 +150,7 @@ func TestSoakHardPerIssueCostCeilingInvariant(t *testing.T) {
 	cfg := Config{
 		PollInterval:                  time.Minute,
 		MaxConcurrentAgents:           1,
+		BillingMode:                   "metered",
 		NoProgressSpendLimitUSD:       noProgressSpendLimit,
 		Project:                       scheduler.ProjectCandidate{ID: "soak"},
 		AutoPromote:                   AutoPromoteConfig{NoProgressLimit: 0},

--- a/internal/orchestrator/spend_progress.go
+++ b/internal/orchestrator/spend_progress.go
@@ -25,35 +25,46 @@ const (
 )
 
 type spendProgressDecision struct {
-	Enabled             bool
-	AcceptedStateChange bool
-	AcceptedReason      string
-	Since               time.Time
-	Spend               store.IssueSpendSince
-	ConfiguredLimitUSD  float64
-	LimitUSD            float64
-	Effort              string
-	PRFingerprint       *spendProgressPRFingerprint
-	Case                string
-	Block               bool
-	Warning             string
+	Enabled              bool
+	TokenEnabled         bool
+	USDEnabled           bool
+	AcceptedStateChange  bool
+	AcceptedReason       string
+	Since                time.Time
+	Spend                store.IssueSpendSince
+	ConfiguredTokenLimit int64
+	TokenLimit           int64
+	ConfiguredLimitUSD   float64
+	LimitUSD             float64
+	BillingMode          string
+	Effort               string
+	PRFingerprint        *spendProgressPRFingerprint
+	Case                 string
+	BlockedBy            string
+	Block                bool
+	Warning              string
 }
 
 type spendProgressRecord struct {
-	AcceptedStateChange bool                        `json:"accepted_state_change,omitempty"`
-	AcceptedReason      string                      `json:"accepted_reason,omitempty"`
-	Since               string                      `json:"since,omitempty"`
-	SpendUSD            float64                     `json:"spend_usd,omitempty"`
-	Sessions            int64                       `json:"sessions,omitempty"`
-	FirstSessionAt      string                      `json:"first_session_at,omitempty"`
-	LastSessionAt       string                      `json:"last_session_at,omitempty"`
-	ConfiguredLimitUSD  float64                     `json:"configured_limit_usd,omitempty"`
-	LimitUSD            float64                     `json:"limit_usd,omitempty"`
-	Effort              string                      `json:"effort,omitempty"`
-	PRFingerprint       *spendProgressPRFingerprint `json:"pr_fingerprint,omitempty"`
-	Case                string                      `json:"case,omitempty"`
-	BlockReason         string                      `json:"block_reason,omitempty"`
-	Warning             string                      `json:"warning,omitempty"`
+	AcceptedStateChange  bool                        `json:"accepted_state_change,omitempty"`
+	AcceptedReason       string                      `json:"accepted_reason,omitempty"`
+	Since                string                      `json:"since,omitempty"`
+	TotalTokens          int64                       `json:"total_tokens,omitempty"`
+	SpendUSD             float64                     `json:"spend_usd,omitempty"`
+	Sessions             int64                       `json:"sessions,omitempty"`
+	FirstSessionAt       string                      `json:"first_session_at,omitempty"`
+	LastSessionAt        string                      `json:"last_session_at,omitempty"`
+	ConfiguredTokenLimit int64                       `json:"configured_token_limit,omitempty"`
+	TokenLimit           int64                       `json:"token_limit,omitempty"`
+	ConfiguredLimitUSD   float64                     `json:"configured_limit_usd,omitempty"`
+	LimitUSD             float64                     `json:"limit_usd,omitempty"`
+	BillingMode          string                      `json:"billing_mode,omitempty"`
+	Effort               string                      `json:"effort,omitempty"`
+	PRFingerprint        *spendProgressPRFingerprint `json:"pr_fingerprint,omitempty"`
+	Case                 string                      `json:"case,omitempty"`
+	BlockedBy            string                      `json:"blocked_by,omitempty"`
+	BlockReason          string                      `json:"block_reason,omitempty"`
+	Warning              string                      `json:"warning,omitempty"`
 }
 
 type spendProgressPRFingerprint struct {
@@ -70,14 +81,22 @@ func (o *Orchestrator) evaluateSpendProgress(
 	accepted bool,
 	acceptedReason string,
 ) spendProgressDecision {
-	decision := spendProgressDecision{
-		Enabled:             o != nil && o.cfg.NoProgressSpendLimitUSD > 0,
-		AcceptedStateChange: accepted,
-		AcceptedReason:      strings.TrimSpace(acceptedReason),
+	decision := spendProgressDecision{AcceptedStateChange: accepted, AcceptedReason: strings.TrimSpace(acceptedReason)}
+	if o == nil {
+		return decision
 	}
+	decision.BillingMode = workflowconfig.BillingModeMetered
+	if o.cfg.subscriptionBilling() {
+		decision.BillingMode = workflowconfig.BillingModeSubscription
+	}
+	decision.TokenEnabled = o.cfg.NoProgressTokenLimit > 0
+	decision.USDEnabled = !o.cfg.subscriptionBilling() && o.cfg.NoProgressSpendLimitUSD > 0
+	decision.Enabled = decision.TokenEnabled || decision.USDEnabled
 	if !decision.Enabled {
 		return decision
 	}
+	decision.ConfiguredTokenLimit = o.cfg.NoProgressTokenLimit
+	decision.TokenLimit = decision.ConfiguredTokenLimit
 	decision.ConfiguredLimitUSD = o.cfg.NoProgressSpendLimitUSD
 	decision.Effort = spendProgressEffort(running)
 	decision.LimitUSD = workflowconfig.EffectiveNoProgressSpendLimitUSD(decision.ConfiguredLimitUSD, decision.Effort)
@@ -87,7 +106,7 @@ func (o *Orchestrator) evaluateSpendProgress(
 		return decision
 	}
 	if o.progressSpend == nil {
-		decision.Warning = "progress spend store unavailable"
+		decision.Warning = "progress usage store unavailable"
 		o.warnSpendProgress(running.Issue, decision.Warning, nil)
 		return decision
 	}
@@ -123,7 +142,7 @@ func (o *Orchestrator) evaluateSpendProgress(
 	})
 	if err != nil {
 		decision.Warning = err.Error()
-		o.warnSpendProgress(running.Issue, "spend lookup failed", err)
+		o.warnSpendProgress(running.Issue, "usage lookup failed", err)
 		return decision
 	}
 	decision.Spend = spend
@@ -131,8 +150,18 @@ func (o *Orchestrator) evaluateSpendProgress(
 	if decision.PRFingerprint != nil {
 		decision.Case = spendProgressCaseStatic
 	}
-	decision.Block = !o.cfg.subscriptionBilling() && spend.CostUSD > decision.LimitUSD
+	if spendProgressTokenLimitReached(spend.TotalTokens, decision.TokenLimit) {
+		decision.BlockedBy = "tokens"
+		decision.Block = true
+	} else if decision.USDEnabled && spend.CostUSD > decision.LimitUSD {
+		decision.BlockedBy = "usd"
+		decision.Block = true
+	}
 	return decision
+}
+
+func spendProgressTokenLimitReached(totalTokens int64, tokenLimit int64) bool {
+	return tokenLimit > 0 && totalTokens >= tokenLimit
 }
 
 func spendProgressEffort(running Running) string {
@@ -290,7 +319,7 @@ func spendProgressRecordFromAttempt(attempt store.WorkAttempt) (spendProgressRec
 		return spendProgressRecord{}, false
 	}
 	record := root.SpendProgress
-	if !record.AcceptedStateChange && record.LimitUSD <= 0 && strings.TrimSpace(record.BlockReason) == "" {
+	if !record.AcceptedStateChange && record.TokenLimit <= 0 && record.LimitUSD <= 0 && strings.TrimSpace(record.BlockReason) == "" {
 		return spendProgressRecord{}, false
 	}
 	return record, true
@@ -301,16 +330,21 @@ func spendProgressMetadata(decision spendProgressDecision) map[string]any {
 		return nil
 	}
 	record := spendProgressRecord{
-		AcceptedStateChange: decision.AcceptedStateChange,
-		AcceptedReason:      decision.AcceptedReason,
-		SpendUSD:            decision.Spend.CostUSD,
-		Sessions:            decision.Spend.Sessions,
-		ConfiguredLimitUSD:  decision.ConfiguredLimitUSD,
-		LimitUSD:            decision.LimitUSD,
-		Effort:              decision.Effort,
-		PRFingerprint:       decision.PRFingerprint,
-		Case:                decision.Case,
-		Warning:             strings.TrimSpace(decision.Warning),
+		AcceptedStateChange:  decision.AcceptedStateChange,
+		AcceptedReason:       decision.AcceptedReason,
+		TotalTokens:          decision.Spend.TotalTokens,
+		SpendUSD:             decision.Spend.CostUSD,
+		Sessions:             decision.Spend.Sessions,
+		ConfiguredTokenLimit: decision.ConfiguredTokenLimit,
+		TokenLimit:           decision.TokenLimit,
+		ConfiguredLimitUSD:   decision.ConfiguredLimitUSD,
+		LimitUSD:             decision.LimitUSD,
+		BillingMode:          decision.BillingMode,
+		Effort:               decision.Effort,
+		PRFingerprint:        decision.PRFingerprint,
+		Case:                 decision.Case,
+		BlockedBy:            decision.BlockedBy,
+		Warning:              strings.TrimSpace(decision.Warning),
 	}
 	if !decision.Since.IsZero() {
 		record.Since = decision.Since.UTC().Format(time.RFC3339Nano)
@@ -425,15 +459,19 @@ func (o *Orchestrator) blockSpendProgress(
 	recordStateEvent(state, telemetry.ActivityEvent{
 		At:      blockedAt,
 		Event:   "spend_since_progress_circuit_breaker_tripped",
-		Message: fmt.Sprintf("parked %s after %s: %s", issueLabel(issue), budget.FormatUSD(decision.Spend.CostUSD), spendProgressCaseSummary(decision.Case)),
+		Message: fmt.Sprintf("parked %s after %s: %s", issueLabel(issue), spendProgressUsageSummary(decision), spendProgressCaseSummary(decision.Case)),
 	})
 	if o.logger != nil {
-		o.logger.Error("spend since progress circuit breaker tripped",
+		o.logger.Error("no-progress circuit breaker tripped",
 			"event", "spend_since_progress_circuit_breaker_tripped",
 			"issue_id", issueID,
 			"issue_identifier", issue.Identifier,
+			"blocked_by", decision.BlockedBy,
+			"total_tokens", decision.Spend.TotalTokens,
+			"token_limit", decision.TokenLimit,
 			"spend_usd", decision.Spend.CostUSD,
 			"limit_usd", decision.LimitUSD,
+			"billing_mode", decision.BillingMode,
 			"sessions", decision.Spend.Sessions,
 			"since", decision.Since,
 			"case", decision.Case,
@@ -454,11 +492,29 @@ func spendProgressComment(issue connector.Issue, decision spendProgressDecision)
 	b.WriteString(decision.Case)
 	b.WriteString("\n- issue: ")
 	b.WriteString(issueLabel(issue))
-	b.WriteString("\n- spend_since_last_accepted_progress: ")
-	b.WriteString(budget.FormatUSD(decision.Spend.CostUSD))
-	b.WriteString("\n- no_progress_spend_limit_usd: ")
-	b.WriteString(budget.FormatUSD(decision.LimitUSD))
-	if decision.Effort != "" {
+	b.WriteString("\n- billing_mode: ")
+	b.WriteString(decision.BillingMode)
+	b.WriteString("\n- blocked_by: ")
+	b.WriteString(decision.BlockedBy)
+	b.WriteString("\n- tokens_since_last_accepted_progress: ")
+	b.WriteString(strconv.FormatInt(decision.Spend.TotalTokens, 10))
+	if decision.TokenLimit > 0 {
+		b.WriteString("\n- no_progress_token_limit: ")
+		b.WriteString(strconv.FormatInt(decision.TokenLimit, 10))
+	}
+	if decision.ConfiguredLimitUSD > 0 {
+		b.WriteString("\n- notional_spend_since_last_accepted_progress: ")
+		b.WriteString(budget.FormatUSD(decision.Spend.CostUSD))
+		b.WriteString("\n- usd_breaker: ")
+		if decision.USDEnabled {
+			b.WriteString("active")
+		} else {
+			b.WriteString("inert")
+		}
+		b.WriteString("\n- no_progress_spend_limit_usd: ")
+		b.WriteString(budget.FormatUSD(decision.LimitUSD))
+	}
+	if decision.USDEnabled && decision.Effort != "" {
 		b.WriteString("\n- effective_effort: ")
 		b.WriteString(decision.Effort)
 		b.WriteString("\n- configured_base_limit_usd: ")
@@ -500,9 +556,31 @@ func spendProgressComment(issue connector.Issue, decision spendProgressDecision)
 
 func spendProgressCaseSummary(progressCase string) string {
 	if progressCase == spendProgressCaseStatic {
-		return "spend continued while a linked PR existed but could not merge"
+		return "resource consumption continued while a linked PR existed but could not merge"
 	}
-	return "spend continued without any PR evidence"
+	return "resource consumption continued without any PR evidence"
+}
+
+func spendProgressBlockMessage(decision spendProgressDecision) string {
+	if decision.BlockedBy == "tokens" {
+		return fmt.Sprintf(
+			"consumed %d tokens since the last accepted state change; configured limit %d",
+			decision.Spend.TotalTokens,
+			decision.TokenLimit,
+		)
+	}
+	return fmt.Sprintf(
+		"spent %s since the last accepted state change; configured limit %s",
+		budget.FormatUSD(decision.Spend.CostUSD),
+		budget.FormatUSD(decision.LimitUSD),
+	)
+}
+
+func spendProgressUsageSummary(decision spendProgressDecision) string {
+	if decision.BlockedBy == "tokens" {
+		return fmt.Sprintf("%d tokens", decision.Spend.TotalTokens)
+	}
+	return budget.FormatUSD(decision.Spend.CostUSD)
 }
 
 func spendProgressRecoveryReason(decision spendProgressDecision) string {
@@ -517,18 +595,24 @@ func spendProgressRetryHandoff(decision spendProgressDecision) runpkg.PriorAttem
 	if decision.Case == spendProgressCaseStatic {
 		missingSignal = "new PR head commit, dirty-to-clean mergeability, failing-to-passing CI, or merge-train capacity that lets the linked PR advance"
 	}
-	return runpkg.PriorAttempt{
-		Source:                  spendProgressReason,
-		Reason:                  spendProgressCaseSummary(decision.Case),
-		ExplainBeforeRetry:      true,
-		MissingSignal:           missingSignal,
-		ObservedSpendUSD:        decision.Spend.CostUSD,
-		NoProgressSpendLimitUSD: decision.LimitUSD,
+	prior := runpkg.PriorAttempt{
+		Source:               spendProgressReason,
+		Reason:               spendProgressCaseSummary(decision.Case),
+		ExplainBeforeRetry:   true,
+		MissingSignal:        missingSignal,
+		ObservedTokens:       decision.Spend.TotalTokens,
+		NoProgressTokenLimit: decision.TokenLimit,
 	}
+	if decision.BillingMode == workflowconfig.BillingModeMetered {
+		prior.ObservedSpendUSD = decision.Spend.CostUSD
+		prior.NoProgressSpendLimitUSD = decision.LimitUSD
+	}
+	return prior
 }
 
 func (o *Orchestrator) spendProgressPriorAttempt(ctx context.Context, issue connector.Issue) (runpkg.PriorAttempt, bool) {
-	if o == nil || o.cfg.subscriptionBilling() || o.cfg.NoProgressSpendLimitUSD <= 0 || o.workAttempts == nil {
+	if o == nil || o.workAttempts == nil ||
+		(o.cfg.NoProgressTokenLimit <= 0 && (o.cfg.subscriptionBilling() || o.cfg.NoProgressSpendLimitUSD <= 0)) {
 		return runpkg.PriorAttempt{}, false
 	}
 	attempts, err := o.workAttempts.ListRecentTerminalWorkAttempts(ctx, store.WorkAttemptHistoryQuery{
@@ -546,12 +630,16 @@ func (o *Orchestrator) spendProgressPriorAttempt(ctx context.Context, issue conn
 		return runpkg.PriorAttempt{}, false
 	}
 	return spendProgressRetryHandoff(spendProgressDecision{
-		Spend:              store.IssueSpendSince{CostUSD: record.SpendUSD, Sessions: record.Sessions},
-		ConfiguredLimitUSD: record.ConfiguredLimitUSD,
-		LimitUSD:           record.LimitUSD,
-		Effort:             record.Effort,
-		PRFingerprint:      record.PRFingerprint,
-		Case:               record.Case,
+		Spend:                store.IssueSpendSince{CostUSD: record.SpendUSD, TotalTokens: record.TotalTokens, Sessions: record.Sessions},
+		ConfiguredTokenLimit: record.ConfiguredTokenLimit,
+		TokenLimit:           record.TokenLimit,
+		ConfiguredLimitUSD:   record.ConfiguredLimitUSD,
+		LimitUSD:             record.LimitUSD,
+		BillingMode:          record.BillingMode,
+		Effort:               record.Effort,
+		PRFingerprint:        record.PRFingerprint,
+		Case:                 record.Case,
+		BlockedBy:            record.BlockedBy,
 	}), true
 }
 
@@ -563,7 +651,7 @@ func (o *Orchestrator) warnSpendProgress(issue connector.Issue, message string, 
 	if err != nil {
 		attrs = append(attrs, "error", err)
 	}
-	o.logger.Warn("spend since progress breaker failed open", attrs...)
+	o.logger.Warn("progress usage breaker failed open", attrs...)
 }
 
 func priorAttemptPresent(prior runpkg.PriorAttempt) bool {

--- a/internal/orchestrator/spend_progress_test.go
+++ b/internal/orchestrator/spend_progress_test.go
@@ -36,6 +36,7 @@ func TestEvaluateSpendProgress(t *testing.T) {
 	tests := []struct {
 		name             string
 		billingMode      string
+		tokenLimit       int64
 		limit            float64
 		spend            store.IssueSpendSince
 		history          []store.WorkAttempt
@@ -44,6 +45,7 @@ func TestEvaluateSpendProgress(t *testing.T) {
 		accepted         bool
 		acceptedReason   string
 		wantBlock        bool
+		wantBlockedBy    string
 		wantAccepted     bool
 		wantReason       string
 		wantLimit        float64
@@ -55,9 +57,11 @@ func TestEvaluateSpendProgress(t *testing.T) {
 		{name: "normal three retry sessions stay below default", limit: 3, spend: store.IssueSpendSince{CostUSD: 2.7, Sessions: 3}, wantLimit: 3, wantSpendCalls: 1, wantHistoryCalls: 1, wantSince: createdAt},
 		{name: "below threshold", limit: 5, spend: store.IssueSpendSince{CostUSD: 4.99, Sessions: 3}, wantLimit: 5, wantSpendCalls: 1, wantHistoryCalls: 1, wantSince: createdAt},
 		{name: "at threshold", limit: 5, spend: store.IssueSpendSince{CostUSD: 5, Sessions: 4}, wantLimit: 5, wantSpendCalls: 1, wantHistoryCalls: 1, wantSince: createdAt},
-		{name: "metered blocks above threshold", billingMode: "metered", limit: 5, spend: store.IssueSpendSince{CostUSD: 5.01, Sessions: 4}, wantBlock: true, wantLimit: 5, wantSpendCalls: 1, wantHistoryCalls: 1, wantSince: createdAt},
-		{name: "subscription keeps above-threshold spend advisory", billingMode: "subscription", limit: 5, spend: store.IssueSpendSince{CostUSD: 5.01, Sessions: 4}, wantLimit: 5, wantSpendCalls: 1, wantHistoryCalls: 1, wantSince: createdAt},
-		{name: "July telemetry replay", limit: 5, spend: store.IssueSpendSince{CostUSD: 6.75, Sessions: 5}, wantBlock: true, wantLimit: 5, wantSpendCalls: 1, wantHistoryCalls: 1, wantSince: createdAt},
+		{name: "metered blocks above threshold", billingMode: "metered", limit: 5, spend: store.IssueSpendSince{CostUSD: 5.01, Sessions: 4}, wantBlock: true, wantBlockedBy: "usd", wantLimit: 5, wantSpendCalls: 1, wantHistoryCalls: 1, wantSince: createdAt},
+		{name: "subscription leaves USD breaker inert", billingMode: "subscription", limit: 5, spend: store.IssueSpendSince{CostUSD: 5.01, Sessions: 4}},
+		{name: "subscription token breaker blocks at threshold", billingMode: "subscription", tokenLimit: 25_000_000, limit: 5, spend: store.IssueSpendSince{CostUSD: 5.01, TotalTokens: 25_000_000, Sessions: 4}, wantBlock: true, wantBlockedBy: "tokens", wantLimit: 5, wantSpendCalls: 1, wantHistoryCalls: 1, wantSince: createdAt},
+		{name: "subscription token breaker stays below threshold", billingMode: "subscription", tokenLimit: 25_000_000, spend: store.IssueSpendSince{TotalTokens: 24_999_999, Sessions: 3}, wantSpendCalls: 1, wantHistoryCalls: 1, wantSince: createdAt},
+		{name: "July telemetry replay", limit: 5, spend: store.IssueSpendSince{CostUSD: 6.75, Sessions: 5}, wantBlock: true, wantBlockedBy: "usd", wantLimit: 5, wantSpendCalls: 1, wantHistoryCalls: 1, wantSince: createdAt},
 		{name: "old sessions reset after accepted change", limit: 5, spend: store.IssueSpendSince{CostUSD: 1.25, Sessions: 1}, history: []store.WorkAttempt{acceptedAttempt}, wantLimit: 5, wantSpendCalls: 1, wantHistoryCalls: 1, wantSince: acceptedAt},
 		{name: "current accepted change resets without spend lookup", limit: 5, spend: store.IssueSpendSince{CostUSD: 100}, accepted: true, acceptedReason: "signature_changed", wantAccepted: true, wantReason: "signature_changed", wantLimit: 5, wantSpendCalls: 0, wantHistoryCalls: 0, wantSince: base},
 		{
@@ -135,6 +139,7 @@ func TestEvaluateSpendProgress(t *testing.T) {
 				}),
 			}},
 			wantBlock:        true,
+			wantBlockedBy:    "usd",
 			wantLimit:        5,
 			wantSpendCalls:   1,
 			wantHistoryCalls: 1,
@@ -149,10 +154,15 @@ func TestEvaluateSpendProgress(t *testing.T) {
 
 			spend := &spendProgressStore{result: tt.spend}
 			attempts := &implementProgressAttemptStore{history: tt.history}
+			billingMode := tt.billingMode
+			if billingMode == "" {
+				billingMode = "metered"
+			}
 			orch := &Orchestrator{
 				cfg: Config{
 					Project:                 scheduler.ProjectCandidate{ID: "detent"},
-					BillingMode:             tt.billingMode,
+					BillingMode:             billingMode,
+					NoProgressTokenLimit:    tt.tokenLimit,
 					NoProgressSpendLimitUSD: tt.limit,
 				},
 				progressSpend: spend,
@@ -168,6 +178,9 @@ func TestEvaluateSpendProgress(t *testing.T) {
 
 			if decision.Block != tt.wantBlock {
 				t.Fatalf("Block = %t, want %t", decision.Block, tt.wantBlock)
+			}
+			if decision.BlockedBy != tt.wantBlockedBy {
+				t.Fatalf("BlockedBy = %q, want %q", decision.BlockedBy, tt.wantBlockedBy)
 			}
 			if decision.AcceptedStateChange != tt.wantAccepted {
 				t.Fatalf("AcceptedStateChange = %t, want %t", decision.AcceptedStateChange, tt.wantAccepted)
@@ -218,11 +231,12 @@ func TestSpendProgressCommentNamesEvidenceCase(t *testing.T) {
 		{
 			name: "without PR evidence",
 			decision: spendProgressDecision{
-				Spend:    store.IssueSpendSince{CostUSD: 6.75, Sessions: 2},
-				LimitUSD: 5,
-				Case:     spendProgressCaseNoPR,
+				Spend:     store.IssueSpendSince{CostUSD: 6.75, Sessions: 2},
+				LimitUSD:  5,
+				Case:      spendProgressCaseNoPR,
+				BlockedBy: "usd",
 			},
-			wantContains: []string{"spend continued without any PR evidence", "case: spend_without_pr_evidence", "Shrink the task"},
+			wantContains: []string{"resource consumption continued without any PR evidence", "case: spend_without_pr_evidence", "Shrink the task"},
 		},
 		{
 			name: "static PR evidence",
@@ -230,9 +244,10 @@ func TestSpendProgressCommentNamesEvidenceCase(t *testing.T) {
 				Spend:         store.IssueSpendSince{CostUSD: 6.75, Sessions: 2},
 				LimitUSD:      5,
 				Case:          spendProgressCaseStatic,
+				BlockedBy:     "usd",
 				PRFingerprint: &spendProgressPRFingerprint{Number: 214, HeadSHA: "same-head", MergeableState: "dirty", CIStatus: "failure"},
 			},
-			wantContains: []string{"spend continued while a linked PR existed but could not merge", "case: spend_with_static_pr_evidence", "merge-train capacity", "pr_head_sha: same-head"},
+			wantContains: []string{"resource consumption continued while a linked PR existed but could not merge", "case: spend_with_static_pr_evidence", "merge-train capacity", "pr_head_sha: same-head"},
 		},
 	}
 	for _, tt := range tests {
@@ -360,7 +375,7 @@ func TestDispatchAcceptedStateChange(t *testing.T) {
 	}
 }
 
-func TestHandleRunResultTripsSpendProgressIndependentlyOfContentDetector(t *testing.T) {
+func TestHandleRunResultTripsTokenProgressBreakerOnSubscription(t *testing.T) {
 	t.Parallel()
 
 	base := time.Date(2026, 7, 11, 15, 0, 0, 0, time.UTC)
@@ -371,6 +386,8 @@ func TestHandleRunResultTripsSpendProgressIndependentlyOfContentDetector(t *test
 	attempts := &implementProgressAttemptStore{}
 	cfg := normalizeConfig(Config{
 		Project:                 scheduler.ProjectCandidate{ID: "gopher-ai"},
+		BillingMode:             "subscription",
+		NoProgressTokenLimit:    25_000_000,
 		NoProgressSpendLimitUSD: 5,
 		AutoPromote:             AutoPromoteConfig{NoProgressLimit: 0},
 		ActiveStates:            []string{"Todo", "In Progress", "Rework"},
@@ -383,6 +400,7 @@ func TestHandleRunResultTripsSpendProgressIndependentlyOfContentDetector(t *test
 		workAttempts: attempts,
 		progressSpend: &spendProgressStore{result: store.IssueSpendSince{
 			CostUSD:        6.75,
+			TotalTokens:    25_000_000,
 			Sessions:       5,
 			FirstSessionAt: base.Add(-14 * time.Minute),
 			LastSessionAt:  base,
@@ -417,7 +435,7 @@ func TestHandleRunResultTripsSpendProgressIndependentlyOfContentDetector(t *test
 	if len(tracker.comments) != 1 {
 		t.Fatalf("comments = %#v, want one", tracker.comments)
 	}
-	for _, want := range []string{"$6.75", "$5.00", "Shrink the task", "first tool action"} {
+	for _, want := range []string{"blocked_by: tokens", "25000000", "usd_breaker: inert", "Shrink the task", "first tool action"} {
 		if !strings.Contains(tracker.comments[0].body, want) {
 			t.Fatalf("comment missing %q:\n%s", want, tracker.comments[0].body)
 		}
@@ -430,7 +448,7 @@ func TestHandleRunResultTripsSpendProgressIndependentlyOfContentDetector(t *test
 		t.Fatalf("completion = %#v, want spend no-progress terminal", completion)
 	}
 	record, ok := spendProgressRecordFromAttempt(store.WorkAttempt{WorkerMetadataJSON: completion.WorkerMetadataJSON})
-	if !ok || record.BlockReason != spendProgressReason || math.Abs(record.SpendUSD-6.75) > 0.000001 {
+	if !ok || record.BlockReason != spendProgressReason || record.BlockedBy != "tokens" || record.TotalTokens != 25_000_000 {
 		t.Fatalf("spend metadata = %#v, ok=%t", record, ok)
 	}
 	if !state.PriorAttempts[issue.ID].ExplainBeforeRetry {
@@ -462,6 +480,7 @@ func TestHandleRunResultAcceptsPRAdvanceBeforeWorkerError(t *testing.T) {
 	}}}
 	cfg := normalizeConfig(Config{
 		Project:                 scheduler.ProjectCandidate{ID: "detent"},
+		BillingMode:             "metered",
 		NoProgressSpendLimitUSD: 5,
 		ActiveStates:            []string{"In Progress"},
 		ObservedStates:          []string{"Blocked"},
@@ -511,18 +530,21 @@ func TestSpendProgressPriorAttemptRestoresExplainBeforeRetry(t *testing.T) {
 
 	attempt := store.WorkAttempt{WorkerMetadataJSON: marshalWorkAttemptJSON(map[string]any{
 		spendProgressMetadataKey: spendProgressRecord{
+			TotalTokens: 25_000_000,
 			SpendUSD:    7.25,
 			Sessions:    6,
+			TokenLimit:  25_000_000,
 			LimitUSD:    5,
+			BlockedBy:   "tokens",
 			BlockReason: spendProgressReason,
 		},
 	})}
 	orch := &Orchestrator{
-		cfg:          Config{Project: scheduler.ProjectCandidate{ID: "detent"}, NoProgressSpendLimitUSD: 5},
+		cfg:          Config{Project: scheduler.ProjectCandidate{ID: "detent"}, BillingMode: "subscription", NoProgressTokenLimit: 25_000_000, NoProgressSpendLimitUSD: 5},
 		workAttempts: &implementProgressAttemptStore{history: []store.WorkAttempt{attempt}},
 	}
 	prior, ok := orch.spendProgressPriorAttempt(context.Background(), connector.Issue{ID: "issue-1"})
-	if !ok || !prior.ExplainBeforeRetry || prior.ObservedSpendUSD != 7.25 || prior.NoProgressSpendLimitUSD != 5 {
+	if !ok || !prior.ExplainBeforeRetry || prior.ObservedTokens != 25_000_000 || prior.NoProgressTokenLimit != 25_000_000 {
 		t.Fatalf("prior = %#v, ok=%t", prior, ok)
 	}
 }
@@ -539,7 +561,7 @@ func TestEvaluateSpendProgressFailsOpen(t *testing.T) {
 		missing  bool
 		want     string
 	}{
-		{name: "missing spend store", attempts: &implementProgressAttemptStore{}, missing: true, want: "progress spend store unavailable"},
+		{name: "missing spend store", attempts: &implementProgressAttemptStore{}, missing: true, want: "progress usage store unavailable"},
 		{name: "history lookup failure", attempts: &implementProgressAttemptStore{historyErr: errors.New("history unavailable")}, spend: &spendProgressStore{}, want: "history unavailable"},
 		{name: "spend lookup failure", attempts: &implementProgressAttemptStore{}, spend: &spendProgressStore{err: errors.New("spend unavailable")}, want: "spend unavailable"},
 	}
@@ -548,7 +570,7 @@ func TestEvaluateSpendProgressFailsOpen(t *testing.T) {
 			t.Parallel()
 			var logs bytes.Buffer
 			orch := &Orchestrator{
-				cfg:          Config{NoProgressSpendLimitUSD: 5},
+				cfg:          Config{NoProgressTokenLimit: 25_000_000},
 				workAttempts: tt.attempts,
 				logger:       slog.New(slog.NewTextHandler(&logs, nil)),
 			}

--- a/internal/retro/detector.go
+++ b/internal/retro/detector.go
@@ -162,12 +162,15 @@ func detectSpendSinceProgressTrips(attempts []Attempt, sessions []Session) (Find
 	}
 	occurrences := []Occurrence{}
 	var tokenDelta int64
+	tokenLimitTrip := false
 	for _, attempt := range attempts {
 		if !strings.EqualFold(strings.TrimSpace(attempt.ErrorClass), "spend_since_progress_circuit_breaker") {
 			continue
 		}
 		tokens := sessionTokens[attempt.ID]
 		tokenDelta += tokens
+		tokenLimitTrip = tokenLimitTrip || strings.Contains(strings.ToLower(attempt.ErrorMessage), "consumed") &&
+			strings.Contains(strings.ToLower(attempt.ErrorMessage), "tokens")
 		occurrences = append(occurrences, Occurrence{
 			Issue:  attemptIssue(attempt),
 			At:     attempt.CompletedAt,
@@ -175,16 +178,20 @@ func detectSpendSinceProgressTrips(attempts []Attempt, sessions []Session) (Find
 			Detail: strings.TrimSpace(attempt.ErrorMessage),
 		})
 	}
+	proposalPath := "agent.no_progress_spend_limit_usd"
+	if tokenLimitTrip {
+		proposalPath = "agent.no_progress_token_limit"
+	}
 	return Finding{
 		Pattern:     PatternSpendSinceProgressTrip,
 		Scope:       ScopeProduct,
 		Severity:    SeverityCritical,
-		Title:       "Shrink tasks that spend without accepted progress",
-		Detail:      "Agent spend exceeded the configured limit without a lane, pull request, or recognized content-signature change.",
+		Title:       "Shrink tasks that consume resources without accepted progress",
+		Detail:      "Agent resource consumption exceeded the configured limit without a lane, pull request, or recognized content-signature change.",
 		TokenDelta:  tokenDelta,
 		Occurrences: occurrences,
 		Proposal: &Proposal{
-			Path:   "agent.no_progress_spend_limit_usd",
+			Path:   proposalPath,
 			Change: "Review the limit and narrow the cited task scopes before retrying them.",
 		},
 	}, len(occurrences) > 0

--- a/internal/retro/detector_test.go
+++ b/internal/retro/detector_test.go
@@ -69,7 +69,7 @@ func TestDetectAdditionalPatterns(t *testing.T) {
 			{ID: 3, Identifier: "issue-after-capacity", StartedAt: resetAt.Add(10 * time.Minute), CompletedAt: resetAt.Add(11 * time.Minute), TerminalState: "success"},
 			{ID: 4, Identifier: "issue-gate", StartedAt: base, CompletedAt: base.Add(time.Minute), TerminalState: "timed_out", ErrorClass: "gate_wait_timeout"},
 			{ID: 5, Identifier: "issue-gate-2", StartedAt: base, CompletedAt: base.Add(time.Minute), TerminalState: "timed_out", WaitReason: "gate wait timeout"},
-			{ID: 6, Identifier: "issue-spend", StartedAt: base, CompletedAt: base.Add(time.Minute), TerminalState: "no_progress", ErrorClass: "spend_since_progress_circuit_breaker", ErrorMessage: "spent $6.75; configured limit $5.00"},
+			{ID: 6, Identifier: "issue-spend", StartedAt: base, CompletedAt: base.Add(time.Minute), TerminalState: "no_progress", ErrorClass: "spend_since_progress_circuit_breaker", ErrorMessage: "consumed 25000000 tokens; configured limit 25000000"},
 		},
 		Sessions: []Session{
 			{ID: 1, Identifier: "issue-orphan-a", StartedAt: base, CompletedAt: base.Add(time.Minute), OrphanRecoveryOutcome: "fresh"},
@@ -97,6 +97,9 @@ func TestDetectAdditionalPatterns(t *testing.T) {
 	spend := findingByPattern(t, Detect(snapshot, DetectorOptions{}), PatternSpendSinceProgressTrip)
 	if spend.Scope != ScopeProduct || spend.Severity != SeverityCritical || spend.TokenDelta != 125000 || !Qualifies(spend, 2, SeverityCritical) {
 		t.Fatalf("spend finding = %#v, want qualifying critical trip", spend)
+	}
+	if spend.Proposal == nil || spend.Proposal.Path != "agent.no_progress_token_limit" {
+		t.Fatalf("spend proposal = %#v, want token-limit review", spend.Proposal)
 	}
 	orphan := findingByPattern(t, Detect(snapshot, DetectorOptions{}), PatternFallbackOrphanRecovery)
 	if len(orphan.Occurrences) != 3 || !Qualifies(orphan, 2, SeverityCritical) {

--- a/internal/runner/prompt.go
+++ b/internal/runner/prompt.go
@@ -864,6 +864,14 @@ func appendPriorAttemptBlock(prompt string, prior PriorAttempt) string {
 			b.WriteString("\n\n- missing accepted signal: ")
 			b.WriteString(signal)
 		}
+		if prior.ObservedTokens > 0 {
+			b.WriteString("\n- tokens since last accepted state change: ")
+			b.WriteString(strconv.FormatInt(prior.ObservedTokens, 10))
+		}
+		if prior.NoProgressTokenLimit > 0 {
+			b.WriteString("\n- configured token limit: ")
+			b.WriteString(strconv.FormatInt(prior.NoProgressTokenLimit, 10))
+		}
 		if prior.ObservedSpendUSD > 0 {
 			b.WriteString("\n- spend since last accepted state change: $")
 			b.WriteString(strconv.FormatFloat(prior.ObservedSpendUSD, 'f', 2, 64))

--- a/internal/runner/prompt_test.go
+++ b/internal/runner/prompt_test.go
@@ -601,6 +601,8 @@ func TestBuildPromptRequiresExplanationBeforeBreakerRetry(t *testing.T) {
 		Reason:                  "spend exceeded the configured limit without an accepted state change",
 		ExplainBeforeRetry:      true,
 		MissingSignal:           "lane transition or pull request signature change",
+		ObservedTokens:          25_000_000,
+		NoProgressTokenLimit:    20_000_000,
 		ObservedSpendUSD:        6.75,
 		NoProgressSpendLimitUSD: 5,
 	}})
@@ -612,6 +614,8 @@ func TestBuildPromptRequiresExplanationBeforeBreakerRetry(t *testing.T) {
 		"first tool action must update the Workpad",
 		"Do not use any other tools",
 		"lane transition or pull request signature change",
+		"tokens since last accepted state change: 25000000",
+		"configured token limit: 20000000",
 		"spend since last accepted state change: $6.75",
 		"configured limit: $5.00",
 	} {

--- a/internal/runner/runner_test.go
+++ b/internal/runner/runner_test.go
@@ -749,7 +749,7 @@ func TestRunnerRunRefusesDispatchWhenBudgetExceeded(t *testing.T) {
 	sessionStore := &fakeSessionStore{sessionID: 855}
 	runner, err := NewRunner(Dependencies{
 		Workflow: config.Workflow{
-			Config: config.Config{},
+			Config: config.Config{Budget: config.Budget{BillingMode: config.BillingModeMetered}},
 			Prompt: "Work on {{ issue.identifier }}",
 		},
 		Workspace:         workspaceBackend,
@@ -895,6 +895,7 @@ func TestRunnerRunLogsBudgetRefusalWithDerivedRole(t *testing.T) {
 	runner, err := NewRunner(Dependencies{
 		Workflow: config.Workflow{
 			Config: config.Config{
+				Budget: config.Budget{BillingMode: config.BillingModeMetered},
 				Agents: config.Agents{
 					Backends: []config.AgentBackend{{
 						ID:       "codex-rework",
@@ -2794,6 +2795,7 @@ func TestRunnerRunUsesStageDefaultModelForReworkFallback(t *testing.T) {
 	runner, err := NewRunner(Dependencies{
 		Workflow: config.Workflow{
 			Config: config.Config{
+				Budget: config.Budget{BillingMode: config.BillingModeMetered},
 				Agents: config.Agents{
 					Backends: []config.AgentBackend{
 						{ID: "codex-code", Kind: "codex", Protocol: "app-server", Command: "codex app-server"},
@@ -3349,6 +3351,7 @@ func TestRunnerUpdateWorkflowRefreshesBudgetGuards(t *testing.T) {
 
 	enabled := config.Config{}
 	enabled.Budget.Enabled = true
+	enabled.Budget.BillingMode = config.BillingModeMetered
 	runner.UpdateWorkflow(config.Workflow{
 		Config: enabled,
 		Prompt: "reloaded {{ issue.identifier }}",

--- a/internal/runner/types.go
+++ b/internal/runner/types.go
@@ -467,6 +467,8 @@ type PriorAttempt struct {
 	Reason                  string
 	ExplainBeforeRetry      bool
 	MissingSignal           string
+	ObservedTokens          int64
+	NoProgressTokenLimit    int64
 	ObservedSpendUSD        float64
 	NoProgressSpendLimitUSD float64
 	Validator               gate.ValidatorResult

--- a/internal/store/sqlc/store.sql.go
+++ b/internal/store/sqlc/store.sql.go
@@ -1970,6 +1970,7 @@ func (q *Queries) GetWorkAttempt(ctx context.Context, id int64) (WorkAttempt, er
 const issueSpendSince = `-- name: IssueSpendSince :one
 SELECT
   CAST(COALESCE(SUM(cost_usd), 0) AS REAL) AS cost_usd,
+  CAST(COALESCE(SUM(total_tokens), 0) AS INTEGER) AS total_tokens,
   CAST(COUNT(*) AS INTEGER) AS sessions,
   CAST(COALESCE(MIN(finished_at), '') AS TEXT) AS first_session_at,
   CAST(COALESCE(MAX(finished_at), '') AS TEXT) AS last_session_at
@@ -1991,6 +1992,7 @@ type IssueSpendSinceParams struct {
 
 type IssueSpendSinceRow struct {
 	CostUsd        float64 `json:"cost_usd"`
+	TotalTokens    int64   `json:"total_tokens"`
 	Sessions       int64   `json:"sessions"`
 	FirstSessionAt string  `json:"first_session_at"`
 	LastSessionAt  string  `json:"last_session_at"`
@@ -2006,6 +2008,7 @@ func (q *Queries) IssueSpendSince(ctx context.Context, arg IssueSpendSinceParams
 	var i IssueSpendSinceRow
 	err := row.Scan(
 		&i.CostUsd,
+		&i.TotalTokens,
 		&i.Sessions,
 		&i.FirstSessionAt,
 		&i.LastSessionAt,

--- a/internal/store/sqlite.go
+++ b/internal/store/sqlite.go
@@ -846,8 +846,9 @@ func (s *sqliteStore) IssueSpendSince(ctx context.Context, query IssueSpendSince
 		return IssueSpendSince{}, fmt.Errorf("reading issue spend since accepted progress: %w", err)
 	}
 	spend := IssueSpendSince{
-		CostUSD:  nonNegativeFloat(row.CostUsd),
-		Sessions: nonNegative(row.Sessions),
+		CostUSD:     nonNegativeFloat(row.CostUsd),
+		TotalTokens: nonNegative(row.TotalTokens),
+		Sessions:    nonNegative(row.Sessions),
 	}
 	if row.FirstSessionAt != "" {
 		spend.FirstSessionAt, err = parseTimestamp("first_session_at", row.FirstSessionAt)

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -956,6 +956,7 @@ type IssueSpendSinceQuery struct {
 
 type IssueSpendSince struct {
 	CostUSD        float64
+	TotalTokens    int64
 	Sessions       int64
 	FirstSessionAt time.Time
 	LastSessionAt  time.Time

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -1676,11 +1676,11 @@ func TestIssueSpendSinceUsesAcceptedProgressBoundaryAndIssueIdentity(t *testing.
 	backend := openTestStore(t, ctx)
 	base := time.Date(2026, 7, 11, 12, 0, 0, 0, time.UTC)
 	events := []UsageEvent{
-		{ProjectID: "detent", IssueID: "issue-214", Identifier: "gopherguides/gopher-ai#214", CostUSD: 9, StartedAt: base.Add(-time.Minute), FinishedAt: base, Outcome: "completed"},
-		{ProjectID: "detent", IssueID: "issue-214", Identifier: "gopherguides/gopher-ai#214", CostUSD: 1.25, StartedAt: base.Add(time.Minute), FinishedAt: base.Add(2 * time.Minute), Outcome: "completed"},
-		{ProjectID: "detent", IssueID: "issue-214", Identifier: "gopherguides/gopher-ai#214", CostUSD: 2.5, StartedAt: base.Add(3 * time.Minute), FinishedAt: base.Add(4 * time.Minute), Outcome: "completed"},
-		{ProjectID: "detent", IssueID: "other", Identifier: "gopherguides/gopher-ai#999", CostUSD: 20, StartedAt: base.Add(time.Minute), FinishedAt: base.Add(2 * time.Minute), Outcome: "completed"},
-		{ProjectID: "other-project", IssueID: "issue-214", Identifier: "gopherguides/gopher-ai#214", CostUSD: 30, StartedAt: base.Add(time.Minute), FinishedAt: base.Add(2 * time.Minute), Outcome: "completed"},
+		{ProjectID: "detent", IssueID: "issue-214", Identifier: "gopherguides/gopher-ai#214", CostUSD: 9, TotalTokens: 900, StartedAt: base.Add(-time.Minute), FinishedAt: base, Outcome: "completed"},
+		{ProjectID: "detent", IssueID: "issue-214", Identifier: "gopherguides/gopher-ai#214", CostUSD: 1.25, TotalTokens: 125, StartedAt: base.Add(time.Minute), FinishedAt: base.Add(2 * time.Minute), Outcome: "completed"},
+		{ProjectID: "detent", IssueID: "issue-214", Identifier: "gopherguides/gopher-ai#214", CostUSD: 2.5, TotalTokens: 250, StartedAt: base.Add(3 * time.Minute), FinishedAt: base.Add(4 * time.Minute), Outcome: "completed"},
+		{ProjectID: "detent", IssueID: "other", Identifier: "gopherguides/gopher-ai#999", CostUSD: 20, TotalTokens: 2_000, StartedAt: base.Add(time.Minute), FinishedAt: base.Add(2 * time.Minute), Outcome: "completed"},
+		{ProjectID: "other-project", IssueID: "issue-214", Identifier: "gopherguides/gopher-ai#214", CostUSD: 30, TotalTokens: 3_000, StartedAt: base.Add(time.Minute), FinishedAt: base.Add(2 * time.Minute), Outcome: "completed"},
 	}
 	for _, event := range events {
 		if _, err := backend.RecordUsageEvent(ctx, event); err != nil {
@@ -1696,8 +1696,8 @@ func TestIssueSpendSinceUsesAcceptedProgressBoundaryAndIssueIdentity(t *testing.
 	if err != nil {
 		t.Fatalf("IssueSpendSince() error = %v", err)
 	}
-	if math.Abs(spend.CostUSD-3.75) > 0.000001 || spend.Sessions != 2 {
-		t.Fatalf("IssueSpendSince() = %#v, want $3.75 across two sessions", spend)
+	if math.Abs(spend.CostUSD-3.75) > 0.000001 || spend.TotalTokens != 375 || spend.Sessions != 2 {
+		t.Fatalf("IssueSpendSince() = %#v, want $3.75 and 375 tokens across two sessions", spend)
 	}
 	if !spend.FirstSessionAt.Equal(base.Add(2*time.Minute)) || !spend.LastSessionAt.Equal(base.Add(4*time.Minute)) {
 		t.Fatalf("session range = %s..%s", spend.FirstSessionAt, spend.LastSessionAt)


### PR DESCRIPTION
## Summary

- add a 25M-token cross-session no-progress breaker that remains blocking for subscription billing
- default undeclared billing mode to subscription and keep USD enforcement metered-only
- report each project effective progress brakes in `detent doctor` and warn when none are active
- aggregate persisted issue token usage and keep generated config references and templates synchronized

Fixes #1573

## UI Surface Contract

- [x] N/A, or the linked issue explicitly authorizes any high-impact UI surface, layout, density, first-viewport, or responsive visibility tradeoff.
- [x] Persistent top-of-screen messaging is explicitly authorized by the issue, or this PR does not add it.
- [x] Visual changes to primary operator screens include screenshot or browser verification below. (N/A: CLI/config behavior only.)

## Test Plan

- [x] focused affected-package test suites
- [x] `make generate`
- [x] `go test ./internal/orchestrator -run ^'$' -fuzz=FuzzSafetyCriticalOrchestratorBoundaries -fuzztime=30s`
- [x] `spend_progress.go` exact-file coverage: 90.30%
- [x] `make check` (rebased HEAD; 78.1% total coverage)