### PR TITLE
fix(staleness): filter healthy decisions

### DIFF
--- a/config.reference.yaml
+++ b/config.reference.yaml
@@ -881,6 +881,8 @@
 #     no_merge_hours: 12
 #     # observability.staleness.repeated_decision_count | type: integer | default: 20 | required: No | validation: must be greater than 0
 #     repeated_decision_count: 20
+#     # observability.staleness.repeated_decision_benign_reasons | type: list<string> | default: ["already_running","blocked_by_dependency","github_rest_capacity_paused","github_rest_recovery","global_capacity_full"] | required: No | validation: None
+#     repeated_decision_benign_reasons: ["already_running","blocked_by_dependency","github_rest_capacity_paused","github_rest_recovery","global_capacity_full"]
 #     # observability.staleness.repeated_window_hours | type: integer | default: 24 | required: No | validation: must be greater than 0
 #     repeated_window_hours: 24
 #     # observability.staleness.webhook | type: object | default: see child fields | required: No | validation: None

--- a/docs/config.md
+++ b/docs/config.md
@@ -181,6 +181,20 @@ repeated identical scheduler decisions. Human-gate lanes remain warnings rather
 than failures, so they provide a single durable reminder without treating a
 deliberate review wait as an unattended stall.
 
+The repeated-decision detector considers only current, non-terminal items.
+Closed and merged items and items in a configured terminal state are excluded.
+`observability.staleness.repeated_decision_benign_reasons` lists scheduler
+reasons that represent healthy waits rather than operator-actionable stalls.
+Its defaults cover active workers, dependency waits, global-capacity waits, and
+GitHub REST pacing. Set the list explicitly to replace those defaults for a
+project.
+
+The detector evaluates decisions inside
+`observability.staleness.repeated_window_hours`, but the orchestrator retains
+only the 500 most recent scheduler decisions. Its effective history is
+therefore whichever is smaller: the configured time window or the retained
+500-decision sample.
+
 Warnings appear in the dashboard, `/health`, and `detent doctor`. Configure
 `observability.staleness.webhook.url` to push each newly active warning as a
 `detent.staleness.warning` JSON event. The payload includes a stable warning ID,
@@ -447,6 +461,7 @@ rendering and fails on drift.
 | `observability.staleness.lanes[].threshold_hours` | `integer` | `72` | No | must be greater than 0 |
 | `observability.staleness.no_completion_hours` | `integer` | `24` | No | must be greater than 0 |
 | `observability.staleness.no_merge_hours` | `integer` | `12` | No | must be greater than 0 |
+| `observability.staleness.repeated_decision_benign_reasons` | `list<string>` | `["already_running","blocked_by_dependency","github_rest_capacity_paused","github_rest_recovery","global_capacity_full"]` | No | None |
 | `observability.staleness.repeated_decision_count` | `integer` | `20` | No | must be greater than 0 |
 | `observability.staleness.repeated_window_hours` | `integer` | `24` | No | must be greater than 0 |
 | `observability.staleness.webhook` | `object` | `see child fields` | No | None |

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -732,13 +732,14 @@ type OTLPObservability struct {
 }
 
 type StalenessObservability struct {
-	Enabled               bool                     `yaml:"enabled"`
-	Lanes                 []StalenessLaneThreshold `yaml:"lanes,omitempty"`
-	NoCompletionHours     int                      `yaml:"no_completion_hours"`
-	NoMergeHours          int                      `yaml:"no_merge_hours"`
-	RepeatedDecisionCount int                      `yaml:"repeated_decision_count"`
-	RepeatedWindowHours   int                      `yaml:"repeated_window_hours"`
-	Webhook               StalenessWebhook         `yaml:"webhook,omitempty"`
+	Enabled                       bool                     `yaml:"enabled"`
+	Lanes                         []StalenessLaneThreshold `yaml:"lanes,omitempty"`
+	NoCompletionHours             int                      `yaml:"no_completion_hours"`
+	NoMergeHours                  int                      `yaml:"no_merge_hours"`
+	RepeatedDecisionCount         int                      `yaml:"repeated_decision_count"`
+	RepeatedDecisionBenignReasons []string                 `yaml:"repeated_decision_benign_reasons"`
+	RepeatedWindowHours           int                      `yaml:"repeated_window_hours"`
+	Webhook                       StalenessWebhook         `yaml:"webhook,omitempty"`
 }
 
 type StalenessLaneThreshold struct {
@@ -1364,11 +1365,12 @@ func Default() Config {
 			},
 			OTLP: OTLPObservability{TimeoutMS: 5000, ServiceName: "detent"},
 			Staleness: StalenessObservability{
-				Enabled:               true,
-				NoCompletionHours:     DefaultStalenessNoCompletionHours,
-				NoMergeHours:          DefaultStalenessNoMergeHours,
-				RepeatedDecisionCount: DefaultStalenessRepeatedCount,
-				RepeatedWindowHours:   DefaultStalenessRepeatedWindowHours,
+				Enabled:                       true,
+				NoCompletionHours:             DefaultStalenessNoCompletionHours,
+				NoMergeHours:                  DefaultStalenessNoMergeHours,
+				RepeatedDecisionCount:         DefaultStalenessRepeatedCount,
+				RepeatedDecisionBenignReasons: defaultStalenessRepeatedDecisionBenignReasons(),
+				RepeatedWindowHours:           DefaultStalenessRepeatedWindowHours,
 				Lanes: []StalenessLaneThreshold{
 					{State: "Human Review", ThresholdHours: 72, HumanGate: true},
 					{State: "Blocked", ThresholdHours: 48},
@@ -2581,6 +2583,7 @@ func (s *StalenessObservability) Normalize() {
 	if s == nil {
 		return
 	}
+	s.RepeatedDecisionBenignReasons = normalizeReasonList(s.RepeatedDecisionBenignReasons)
 	for index := range s.Lanes {
 		s.Lanes[index].State = strings.TrimSpace(s.Lanes[index].State)
 	}
@@ -2594,6 +2597,33 @@ func (s *StalenessObservability) Normalize() {
 		headers[name] = strings.TrimSpace(value)
 	}
 	s.Webhook.Headers = headers
+}
+
+func defaultStalenessRepeatedDecisionBenignReasons() []string {
+	return []string{
+		"already_running",
+		"blocked_by_dependency",
+		"github_rest_capacity_paused",
+		"github_rest_recovery",
+		"global_capacity_full",
+	}
+}
+
+func normalizeReasonList(reasons []string) []string {
+	normalized := make([]string, 0, len(reasons))
+	seen := make(map[string]struct{}, len(reasons))
+	for _, reason := range reasons {
+		reason = strings.ToLower(strings.TrimSpace(reason))
+		if reason == "" {
+			continue
+		}
+		if _, ok := seen[reason]; ok {
+			continue
+		}
+		seen[reason] = struct{}{}
+		normalized = append(normalized, reason)
+	}
+	return normalized
 }
 
 func (s *StalenessObservability) validate(problems *[]string) {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1833,6 +1833,26 @@ func TestDefaultStalenessObservability(t *testing.T) {
 	if !cfg.Observability.Staleness.Lanes[0].HumanGate {
 		t.Fatal("Human Review default is not marked as a human gate")
 	}
+	wantReasons := []string{
+		"already_running",
+		"blocked_by_dependency",
+		"github_rest_capacity_paused",
+		"github_rest_recovery",
+		"global_capacity_full",
+	}
+	if got := cfg.Observability.Staleness.RepeatedDecisionBenignReasons; !slices.Equal(got, wantReasons) {
+		t.Fatalf("RepeatedDecisionBenignReasons = %#v, want %#v", got, wantReasons)
+	}
+
+	cfg.Observability.Staleness.RepeatedDecisionBenignReasons = []string{
+		" Planned_Maintenance ",
+		"planned_maintenance",
+		"",
+	}
+	cfg.Observability.Staleness.Normalize()
+	if got, want := cfg.Observability.Staleness.RepeatedDecisionBenignReasons, []string{"planned_maintenance"}; !slices.Equal(got, want) {
+		t.Fatalf("normalized RepeatedDecisionBenignReasons = %#v, want %#v", got, want)
+	}
 }
 
 func TestKanbanTransitionPolicyAllowsConfiguredOverridesWithoutStateLists(t *testing.T) {

--- a/internal/orchestrator/config.go
+++ b/internal/orchestrator/config.go
@@ -117,7 +117,7 @@ func ConfigFromWorkflow(cfg workflowconfig.Config) Config {
 			SessionsMultiple: cfg.Observability.Efficiency.AnomalySessionsMultiple,
 			DwellMultiple:    cfg.Observability.Efficiency.AnomalyDwellMultiple,
 		},
-		Staleness: stalenessConfigFromWorkflow(cfg.Observability.Staleness),
+		Staleness: stalenessConfigFromWorkflow(cfg.Observability.Staleness, cfg.Tracker.TerminalStates),
 		StalenessDelivery: staleness.DeliveryConfig{
 			WebhookURL: cfg.Observability.Staleness.Webhook.URL,
 			Headers:    cloneStringMap(cfg.Observability.Staleness.Webhook.Headers),
@@ -126,7 +126,7 @@ func ConfigFromWorkflow(cfg workflowconfig.Config) Config {
 	}
 }
 
-func stalenessConfigFromWorkflow(cfg workflowconfig.StalenessObservability) staleness.Config {
+func stalenessConfigFromWorkflow(cfg workflowconfig.StalenessObservability, terminalStates []string) staleness.Config {
 	lanes := make([]staleness.LaneThreshold, 0, len(cfg.Lanes))
 	for _, lane := range cfg.Lanes {
 		lanes = append(lanes, staleness.LaneThreshold{
@@ -136,12 +136,14 @@ func stalenessConfigFromWorkflow(cfg workflowconfig.StalenessObservability) stal
 		})
 	}
 	return staleness.Config{
-		Enabled:                cfg.Enabled,
-		Lanes:                  lanes,
-		NoCompletionThreshold:  time.Duration(cfg.NoCompletionHours) * time.Hour,
-		NoMergeThreshold:       time.Duration(cfg.NoMergeHours) * time.Hour,
-		RepeatedDecisionCount:  cfg.RepeatedDecisionCount,
-		RepeatedDecisionWindow: time.Duration(cfg.RepeatedWindowHours) * time.Hour,
+		Enabled:                       cfg.Enabled,
+		Lanes:                         lanes,
+		NoCompletionThreshold:         time.Duration(cfg.NoCompletionHours) * time.Hour,
+		NoMergeThreshold:              time.Duration(cfg.NoMergeHours) * time.Hour,
+		RepeatedDecisionCount:         cfg.RepeatedDecisionCount,
+		RepeatedDecisionWindow:        time.Duration(cfg.RepeatedWindowHours) * time.Hour,
+		RepeatedDecisionBenignReasons: append([]string(nil), cfg.RepeatedDecisionBenignReasons...),
+		TerminalStates:                append([]string(nil), terminalStates...),
 	}
 }
 

--- a/internal/orchestrator/staleness.go
+++ b/internal/orchestrator/staleness.go
@@ -33,7 +33,7 @@ func (o *Orchestrator) refreshStalenessWarnings(ctx context.Context, state *Stat
 		Dispatchable: o.stalenessDispatchableItems(candidates, state, now),
 		MergeQueue:   o.stalenessMergeQueueItems(state),
 		Completions:  stalenessCompletions(state),
-		Decisions:    stalenessDecisions(state.SchedulerDecisions),
+		Decisions:    stalenessDecisions(state.SchedulerDecisions, stalenessDecisionIssueIndex(state, candidates)),
 	}, now)
 	previous := state.StalenessWarnings
 	next := make(map[string]StalenessWarning, len(evaluated))
@@ -170,18 +170,95 @@ func stalenessCompletions(state *State) []staleness.Completion {
 	return completions
 }
 
-func stalenessDecisions(decisions []telemetry.SchedulerDecision) []staleness.Decision {
+func stalenessDecisions(decisions []telemetry.SchedulerDecision, issues map[string]connector.Issue) []staleness.Decision {
 	out := make([]staleness.Decision, 0, len(decisions))
 	for _, decision := range decisions {
+		issue, _ := stalenessDecisionIssue(decision, issues)
 		out = append(out, staleness.Decision{
-			IssueID:    strings.TrimSpace(decision.IssueID),
-			Identifier: strings.TrimSpace(decision.Identifier),
-			IssueURL:   strings.TrimSpace(decision.IssueURL),
-			Reason:     strings.TrimSpace(decision.Reason),
-			At:         decision.DecisionAt.UTC(),
+			IssueID:      strings.TrimSpace(decision.IssueID),
+			Identifier:   strings.TrimSpace(decision.Identifier),
+			IssueURL:     strings.TrimSpace(decision.IssueURL),
+			CurrentState: strings.TrimSpace(issue.State),
+			Closed:       issue.Closed,
+			Merged:       pullRequestMerged(issue.PullRequest),
+			Reason:       strings.TrimSpace(decision.Reason),
+			At:           decision.DecisionAt.UTC(),
 		})
 	}
 	return out
+}
+
+func stalenessDecisionIssueIndex(state *State, candidates []connector.Issue) map[string]connector.Issue {
+	issues := make(map[string]connector.Issue)
+	if state == nil {
+		return issues
+	}
+	for _, completed := range state.Completed {
+		indexStalenessDecisionIssue(issues, completed.Issue)
+	}
+	for _, blocked := range state.Blocked {
+		indexStalenessDecisionIssue(issues, blocked.Issue)
+	}
+	for _, retry := range state.Retry {
+		indexStalenessDecisionIssue(issues, retry.Issue)
+	}
+	for _, running := range state.Running {
+		indexStalenessDecisionIssue(issues, running.Issue)
+	}
+	for _, issue := range state.Pipeline {
+		indexStalenessDecisionIssue(issues, issue)
+	}
+	for _, issue := range state.BoardIssues {
+		indexStalenessDecisionIssue(issues, issue)
+	}
+	for _, issue := range candidates {
+		indexStalenessDecisionIssue(issues, issue)
+	}
+	return issues
+}
+
+func indexStalenessDecisionIssue(issues map[string]connector.Issue, issue connector.Issue) {
+	for _, key := range []string{
+		stalenessDecisionIssueIDKey(issue.ID),
+		stalenessDecisionIdentifierKey(issue.Identifier),
+		stalenessDecisionURLKey(issue.URL),
+	} {
+		if key != "" {
+			issues[key] = issue
+		}
+	}
+}
+
+func stalenessDecisionIssue(decision telemetry.SchedulerDecision, issues map[string]connector.Issue) (connector.Issue, bool) {
+	for _, key := range []string{
+		stalenessDecisionIssueIDKey(decision.IssueID),
+		stalenessDecisionIdentifierKey(decision.Identifier),
+		stalenessDecisionURLKey(decision.IssueURL),
+	} {
+		if issue, ok := issues[key]; key != "" && ok {
+			return issue, true
+		}
+	}
+	return connector.Issue{}, false
+}
+
+func stalenessDecisionIssueIDKey(value string) string {
+	return stalenessDecisionIssueKey("id:", value)
+}
+
+func stalenessDecisionIdentifierKey(value string) string {
+	return stalenessDecisionIssueKey("identifier:", value)
+}
+
+func stalenessDecisionURLKey(value string) string {
+	return stalenessDecisionIssueKey("url:", value)
+}
+
+func stalenessDecisionIssueKey(prefix string, value string) string {
+	if value = strings.TrimSpace(value); value != "" {
+		return prefix + value
+	}
+	return ""
 }
 
 func (o *Orchestrator) deliverStalenessWarnings(ctx context.Context, state *State, now time.Time) {

--- a/internal/orchestrator/staleness.go
+++ b/internal/orchestrator/staleness.go
@@ -193,9 +193,6 @@ func stalenessDecisionIssueIndex(state *State, candidates []connector.Issue) map
 	if state == nil {
 		return issues
 	}
-	for _, completed := range state.Completed {
-		indexStalenessDecisionIssue(issues, completed.Issue)
-	}
 	for _, blocked := range state.Blocked {
 		indexStalenessDecisionIssue(issues, blocked.Issue)
 	}

--- a/internal/orchestrator/staleness_test.go
+++ b/internal/orchestrator/staleness_test.go
@@ -2,12 +2,15 @@ package orchestrator
 
 import (
 	"context"
+	"slices"
 	"testing"
 	"time"
 
+	workflowconfig "github.com/digitaldrywood/detent/internal/config"
 	"github.com/digitaldrywood/detent/internal/connector"
 	"github.com/digitaldrywood/detent/internal/selector"
 	"github.com/digitaldrywood/detent/internal/staleness"
+	"github.com/digitaldrywood/detent/internal/telemetry"
 )
 
 func TestRefreshStalenessWarningsEmitsAndDeliversOncePerActiveCondition(t *testing.T) {
@@ -139,6 +142,65 @@ func TestStalenessDispatchableItemsUsesDispatchPlannerEligibility(t *testing.T) 
 	items := orch.stalenessDispatchableItems([]connector.Issue{unauthorized, authorized}, &state, now)
 	if len(items) != 1 || items[0].ID != authorized.ID {
 		t.Fatalf("dispatchable staleness items = %#v, want only authorized issue", items)
+	}
+}
+
+func TestConfigFromWorkflowIncludesStalenessDecisionPolicy(t *testing.T) {
+	t.Parallel()
+	workflow := workflowconfig.Default()
+	workflow.Observability.Staleness.RepeatedDecisionBenignReasons = []string{"planned_maintenance"}
+	workflow.Tracker.TerminalStates = []string{"Done", "Cancelled"}
+
+	got := ConfigFromWorkflow(workflow).Staleness
+	if !slices.Equal(got.RepeatedDecisionBenignReasons, []string{"planned_maintenance"}) {
+		t.Fatalf("RepeatedDecisionBenignReasons = %#v, want configured reason", got.RepeatedDecisionBenignReasons)
+	}
+	if !slices.Equal(got.TerminalStates, workflow.Tracker.TerminalStates) {
+		t.Fatalf("TerminalStates = %#v, want %#v", got.TerminalStates, workflow.Tracker.TerminalStates)
+	}
+}
+
+func TestStalenessDecisionsCarryCurrentIssueState(t *testing.T) {
+	t.Parallel()
+	now := time.Date(2026, 7, 30, 15, 0, 0, 0, time.UTC)
+	state := State{
+		Completed: map[string]Completed{
+			"issue-closed": {
+				Issue: connector.Issue{
+					ID:     "issue-closed",
+					State:  "Done",
+					Closed: true,
+				},
+			},
+			"issue-merged": {
+				Issue: connector.Issue{
+					ID:    "issue-merged",
+					State: "Merging",
+					PullRequest: &connector.PullRequest{
+						State: "MERGED",
+					},
+				},
+			},
+		},
+	}
+	decisions := []telemetry.SchedulerDecision{
+		{IssueID: "issue-closed", Reason: "merge_slot_revoked", DecisionAt: now},
+		{IssueID: "issue-merged", Reason: "merge_slot_revoked", DecisionAt: now},
+		{IssueID: "issue-gone", Reason: "merge_slot_revoked", DecisionAt: now},
+	}
+
+	got := stalenessDecisions(decisions, stalenessDecisionIssueIndex(&state, nil))
+	if len(got) != len(decisions) {
+		t.Fatalf("stalenessDecisions() = %#v, want %d decisions", got, len(decisions))
+	}
+	if got[0].CurrentState != "Done" || !got[0].Closed {
+		t.Fatalf("closed decision = %#v, want current Done and closed", got[0])
+	}
+	if got[1].CurrentState != "Merging" || !got[1].Merged {
+		t.Fatalf("merged decision = %#v, want current Merging and merged", got[1])
+	}
+	if got[2].CurrentState != "" || got[2].Closed || got[2].Merged {
+		t.Fatalf("absent decision = %#v, want no current item state", got[2])
 	}
 }
 

--- a/internal/orchestrator/staleness_test.go
+++ b/internal/orchestrator/staleness_test.go
@@ -164,21 +164,25 @@ func TestStalenessDecisionsCarryCurrentIssueState(t *testing.T) {
 	t.Parallel()
 	now := time.Date(2026, 7, 30, 15, 0, 0, 0, time.UTC)
 	state := State{
-		Completed: map[string]Completed{
-			"issue-closed": {
-				Issue: connector.Issue{
-					ID:     "issue-closed",
-					State:  "Done",
-					Closed: true,
+		BoardIssues: []connector.Issue{
+			{
+				ID:     "issue-closed",
+				State:  "Done",
+				Closed: true,
+			},
+			{
+				ID:    "issue-merged",
+				State: "Merging",
+				PullRequest: &connector.PullRequest{
+					State: "MERGED",
 				},
 			},
-			"issue-merged": {
+		},
+		Completed: map[string]Completed{
+			"issue-stale-completed": {
 				Issue: connector.Issue{
-					ID:    "issue-merged",
-					State: "Merging",
-					PullRequest: &connector.PullRequest{
-						State: "MERGED",
-					},
+					ID:    "issue-stale-completed",
+					State: "Human Review",
 				},
 			},
 		},
@@ -186,6 +190,7 @@ func TestStalenessDecisionsCarryCurrentIssueState(t *testing.T) {
 	decisions := []telemetry.SchedulerDecision{
 		{IssueID: "issue-closed", Reason: "merge_slot_revoked", DecisionAt: now},
 		{IssueID: "issue-merged", Reason: "merge_slot_revoked", DecisionAt: now},
+		{IssueID: "issue-stale-completed", Reason: "merge_slot_revoked", DecisionAt: now},
 		{IssueID: "issue-gone", Reason: "merge_slot_revoked", DecisionAt: now},
 	}
 
@@ -199,8 +204,10 @@ func TestStalenessDecisionsCarryCurrentIssueState(t *testing.T) {
 	if got[1].CurrentState != "Merging" || !got[1].Merged {
 		t.Fatalf("merged decision = %#v, want current Merging and merged", got[1])
 	}
-	if got[2].CurrentState != "" || got[2].Closed || got[2].Merged {
-		t.Fatalf("absent decision = %#v, want no current item state", got[2])
+	for _, index := range []int{2, 3} {
+		if got[index].CurrentState != "" || got[index].Closed || got[index].Merged {
+			t.Fatalf("historical decision = %#v, want no current item state", got[index])
+		}
 	}
 }
 

--- a/internal/staleness/staleness.go
+++ b/internal/staleness/staleness.go
@@ -17,12 +17,14 @@ const (
 )
 
 type Config struct {
-	Enabled                bool
-	Lanes                  []LaneThreshold
-	NoCompletionThreshold  time.Duration
-	NoMergeThreshold       time.Duration
-	RepeatedDecisionCount  int
-	RepeatedDecisionWindow time.Duration
+	Enabled                       bool
+	Lanes                         []LaneThreshold
+	NoCompletionThreshold         time.Duration
+	NoMergeThreshold              time.Duration
+	RepeatedDecisionCount         int
+	RepeatedDecisionWindow        time.Duration
+	RepeatedDecisionBenignReasons []string
+	TerminalStates                []string
 }
 
 type LaneThreshold struct {
@@ -57,11 +59,14 @@ type Completion struct {
 }
 
 type Decision struct {
-	IssueID    string
-	Identifier string
-	IssueURL   string
-	Reason     string
-	At         time.Time
+	IssueID      string
+	Identifier   string
+	IssueURL     string
+	CurrentState string
+	Closed       bool
+	Merged       bool
+	Reason       string
+	At           time.Time
 }
 
 type Warning struct {
@@ -218,11 +223,23 @@ func repeatedDecisionWarnings(cfg Config, input Input, now time.Time) []Warning 
 		last     time.Time
 	}
 	cutoff := now.Add(-cfg.RepeatedDecisionWindow)
+	benignReasons := normalizedSet(cfg.RepeatedDecisionBenignReasons)
+	terminalStates := normalizedSet(cfg.TerminalStates)
 	groups := make(map[string]group)
 	for _, decision := range input.Decisions {
 		identity := decisionIdentity(decision)
 		reason := strings.TrimSpace(decision.Reason)
-		if identity == "" || reason == "" || decision.At.IsZero() || decision.At.Before(cutoff) || decision.At.After(now) {
+		currentState := normalize(decision.CurrentState)
+		if identity == "" ||
+			reason == "" ||
+			currentState == "" ||
+			decision.Closed ||
+			decision.Merged ||
+			contains(terminalStates, currentState) ||
+			contains(benignReasons, normalize(reason)) ||
+			decision.At.IsZero() ||
+			decision.At.Before(cutoff) ||
+			decision.At.After(now) {
 			continue
 		}
 		key := identity + "\x00" + reason
@@ -261,6 +278,21 @@ func repeatedDecisionWarnings(cfg Config, input Input, now time.Time) []Warning 
 		})
 	}
 	return warnings
+}
+
+func normalizedSet(values []string) map[string]struct{} {
+	set := make(map[string]struct{}, len(values))
+	for _, value := range values {
+		if value = normalize(value); value != "" {
+			set[value] = struct{}{}
+		}
+	}
+	return set
+}
+
+func contains(values map[string]struct{}, value string) bool {
+	_, ok := values[value]
+	return ok
 }
 
 func laneWarningDetail(item Item, waitingOnHuman bool) string {

--- a/internal/staleness/staleness_test.go
+++ b/internal/staleness/staleness_test.go
@@ -76,10 +76,10 @@ func TestEvaluate(t *testing.T) {
 			input: Input{
 				ProjectID: "detent",
 				Decisions: []Decision{
-					{IssueID: "3", Reason: "merge_slot_revoked", At: now.Add(-3 * time.Hour)},
-					{IssueID: "3", Reason: "merge_slot_revoked", At: now.Add(-2 * time.Hour)},
-					{IssueID: "3", Reason: "merge_slot_revoked", At: now.Add(-time.Hour)},
-					{IssueID: "3", Reason: "other", At: now.Add(-time.Hour)},
+					{IssueID: "3", CurrentState: "Merging", Reason: "merge_slot_revoked", At: now.Add(-3 * time.Hour)},
+					{IssueID: "3", CurrentState: "Merging", Reason: "merge_slot_revoked", At: now.Add(-2 * time.Hour)},
+					{IssueID: "3", CurrentState: "Merging", Reason: "merge_slot_revoked", At: now.Add(-time.Hour)},
+					{IssueID: "3", CurrentState: "Merging", Reason: "other", At: now.Add(-time.Hour)},
 				},
 			},
 			wantKinds: []string{KindRepeatedDecision},
@@ -104,6 +104,126 @@ func TestEvaluate(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestEvaluateRepeatedDecisions(t *testing.T) {
+	t.Parallel()
+	now := time.Date(2026, 7, 30, 15, 0, 0, 0, time.UTC)
+	baseConfig := Config{
+		Enabled:                true,
+		RepeatedDecisionCount:  20,
+		RepeatedDecisionWindow: 24 * time.Hour,
+		RepeatedDecisionBenignReasons: []string{
+			"already_running",
+			"blocked_by_dependency",
+			"github_rest_capacity_paused",
+			"github_rest_recovery",
+			"global_capacity_full",
+		},
+		TerminalStates: []string{"Done", "Cancelled", "Canceled"},
+	}
+
+	tests := []struct {
+		name      string
+		configure func(*Config)
+		decisions []Decision
+		want      int
+	}{
+		{
+			name:      "60 minute healthy run stays quiet",
+			decisions: repeatedDecisions(now.Add(-time.Hour), 31, 2*time.Minute, "already_running", "In Progress"),
+		},
+		{
+			name:      "dependency wait stays quiet",
+			decisions: repeatedDecisions(now.Add(-time.Hour), 20, 3*time.Minute, "blocked_by_dependency", "Blocked"),
+		},
+		{
+			name:      "global capacity wait stays quiet",
+			decisions: repeatedDecisions(now.Add(-time.Hour), 20, 3*time.Minute, "global_capacity_full", "Todo"),
+		},
+		{
+			name:      "REST capacity pause stays quiet",
+			decisions: repeatedDecisions(now.Add(-time.Hour), 20, 3*time.Minute, "github_rest_capacity_paused", "Todo"),
+		},
+		{
+			name:      "REST recovery stays quiet",
+			decisions: repeatedDecisions(now.Add(-time.Hour), 20, 3*time.Minute, "github_rest_recovery", "Todo"),
+		},
+		{
+			name: "operator configured reason stays quiet",
+			configure: func(cfg *Config) {
+				cfg.RepeatedDecisionBenignReasons = append(cfg.RepeatedDecisionBenignReasons, "planned_maintenance")
+			},
+			decisions: repeatedDecisions(now.Add(-time.Hour), 20, 3*time.Minute, "planned_maintenance", "Todo"),
+		},
+		{
+			name: "closed issue stays quiet",
+			decisions: mutateDecisions(
+				repeatedDecisions(now.Add(-time.Hour), 20, 3*time.Minute, "merge_slot_revoked", "Merging"),
+				func(decision *Decision) { decision.Closed = true },
+			),
+		},
+		{
+			name: "merged issue stays quiet",
+			decisions: mutateDecisions(
+				repeatedDecisions(now.Add(-time.Hour), 20, 3*time.Minute, "merge_slot_revoked", "Merging"),
+				func(decision *Decision) { decision.Merged = true },
+			),
+		},
+		{
+			name:      "cancelled issue stays quiet",
+			decisions: repeatedDecisions(now.Add(-time.Hour), 20, 3*time.Minute, "merge_slot_revoked", "Cancelled"),
+		},
+		{
+			name:      "historical issue absent from current items stays quiet",
+			decisions: repeatedDecisions(now.Add(-time.Hour), 20, 3*time.Minute, "merge_slot_revoked", ""),
+		},
+		{
+			name:      "genuine stall warns",
+			decisions: repeatedDecisions(now.Add(-time.Hour), 20, 3*time.Minute, "merge_slot_revoked", "Merging"),
+			want:      1,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			cfg := baseConfig
+			cfg.RepeatedDecisionBenignReasons = append([]string(nil), baseConfig.RepeatedDecisionBenignReasons...)
+			if tt.configure != nil {
+				tt.configure(&cfg)
+			}
+			got := Evaluate(cfg, Input{ProjectID: "detent", Decisions: tt.decisions}, now)
+			if len(got) != tt.want {
+				t.Fatalf("Evaluate() warnings = %#v, want %d", got, tt.want)
+			}
+			if tt.want == 1 && (got[0].Kind != KindRepeatedDecision || got[0].Count != 20) {
+				t.Fatalf("Evaluate()[0] = %#v, want repeated decision warning with count 20", got[0])
+			}
+		})
+	}
+}
+
+func repeatedDecisions(start time.Time, count int, interval time.Duration, reason string, state string) []Decision {
+	decisions := make([]Decision, 0, count)
+	for index := range count {
+		decisions = append(decisions, Decision{
+			IssueID:      "issue-1",
+			Identifier:   "digitaldrywood/detent#1",
+			CurrentState: state,
+			Reason:       reason,
+			At:           start.Add(time.Duration(index) * interval),
+		})
+	}
+	return decisions
+}
+
+func mutateDecisions(decisions []Decision, mutate func(*Decision)) []Decision {
+	for index := range decisions {
+		mutate(&decisions[index])
+	}
+	return decisions
 }
 
 func TestNewNotifierDeliversWebhook(t *testing.T) {


### PR DESCRIPTION
## Summary

- classify healthy repeated scheduler decisions with an operator-configurable benign-reason list
- join retained decisions to current item state and exclude closed, merged, terminal, or absent historical items
- document the detector window and 500-decision retention limit

Fixes #1589

## Test Plan

- `go test ./internal/staleness ./internal/config ./internal/orchestrator`
- `go test ./internal/config/configdoc`
- `go test ./internal/cli -run '^TestRuntimeGitHubTokenRefresherResolvesConfiguredGHSentinelWithoutActionsToken$' -count=10`
- `make check`