### PR TITLE
feat(admission): ship a responsive default cadence

### DIFF
--- a/config.reference.yaml
+++ b/config.reference.yaml
@@ -1005,8 +1005,8 @@
 # backlog_admission:
 #   # backlog_admission.enabled | type: boolean | default: false | required: No | validation: None
 #   enabled: false
-#   # backlog_admission.schedule | type: string | default: "0 6 * * 1-5" | required: No | validation: must be a valid five-field cron expression
-#   schedule: "0 6 * * 1-5"
+#   # backlog_admission.schedule | type: string | default: "*/15 * * * *" | required: No | validation: must be a valid five-field cron expression
+#   schedule: "*/15 * * * *"
 #   # backlog_admission.sources | type: object | default: see child fields | required: No | validation: must configure at least one selector
 #   sources:
 #     # backlog_admission.sources.states | type: list<string> | default: [] | required: No | validation: values must differ from target_state; values must name a configured workflow state

--- a/docs/config.md
+++ b/docs/config.md
@@ -173,6 +173,23 @@ define the allowed recommendations. Detent writes a recommended `detent-agent`
 block before the admission transition only when the issue has no existing
 block; the default remains disabled for compatibility.
 
+When enabled, admission defaults to `*/15 * * * *`, which limits normal
+candidate wait time to 15 minutes. An every-30-minute schedule implies up to 30
+minutes of latency, an hourly schedule up to one hour, and a daily schedule up
+to 24 hours. Restricting a daily schedule to weekdays creates a 72-hour weekend
+gap. A slow schedule is valid, but it can make admission look broken because
+issues accumulate in the source state while Detent is simply waiting for the
+next run.
+
+On the host used to establish the default, 20 admission runs and 18 admission
+agent sessions averaged about 25 seconds of wall time per run and 36,000 tokens
+per candidate-bearing run, with 655,368 tokens total. Runs with no eligible
+candidates are cheaper because they do not start an admission agent. At the
+15-minute default, there are at most 96 runs per day; use `detent doctor` to
+compare your schedule with recent candidate-bearing runs and the runtime and
+token cost observed on your own host. Choose a slower explicit schedule when
+that latency/cost tradeoff is intentional.
+
 ## Fleet staleness warnings
 
 `observability.staleness` detects work items that exceed lane-specific aging
@@ -343,7 +360,7 @@ rendering and fails on drift.
 | `backlog_admission.max_proposals_per_run` | `integer` | `3` | No | must be greater than 0 |
 | `backlog_admission.proposal_expiry_days` | `integer` | `7` | No | must be greater than 0 |
 | `backlog_admission.require_effort` | `boolean` | `false` | No | None |
-| `backlog_admission.schedule` | `string` | `"0 6 * * 1-5"` | No | must be a valid five-field cron expression |
+| `backlog_admission.schedule` | `string` | `"*/15 * * * *"` | No | must be a valid five-field cron expression |
 | `backlog_admission.sources` | `object` | `see child fields` | No | must configure at least one selector |
 | `backlog_admission.sources.labels` | `list<string>` | `[]` | No | None |
 | `backlog_admission.sources.states` | `list<string>` | `[]` | No | values must differ from target_state<br>values must name a configured workflow state |

--- a/docs/scheduled-routines.md
+++ b/docs/scheduled-routines.md
@@ -125,7 +125,7 @@ Admission is disabled unless a project opts in:
 ```yaml
 backlog_admission:
   enabled: true
-  schedule: "0 6 * * 1-5"
+  schedule: "*/15 * * * *"
   sources:
     states: [Backlog]
     labels: []

--- a/internal/cli/doctor_admission.go
+++ b/internal/cli/doctor_admission.go
@@ -33,6 +33,7 @@ type doctorAdmissionDiagnostic struct {
 	ObservedRuns          int              `json:"observed_runs,omitempty"`
 	CandidateBearingRuns  int              `json:"candidate_bearing_runs,omitempty"`
 	CandidatesObserved    int              `json:"candidates_observed,omitempty"`
+	EligibleCandidates    int              `json:"eligible_candidates_observed,omitempty"`
 	AverageRunSeconds     int64            `json:"average_run_seconds,omitempty"`
 	AdmissionSessions     int              `json:"admission_sessions,omitempty"`
 	AverageSessionSeconds int64            `json:"average_session_seconds,omitempty"`
@@ -217,9 +218,10 @@ LIMIT ?`, strings.TrimSpace(projectID), doctorAdmissionRecentRunLimit)
 		}
 		diagnostic.ObservedRuns++
 		totalRunSeconds += max(int64(completed.Sub(started)/time.Second), 0)
-		if candidatesFound > 0 {
+		diagnostic.CandidatesObserved += candidatesFound
+		if candidates > 0 {
 			diagnostic.CandidateBearingRuns++
-			diagnostic.CandidatesObserved += candidatesFound
+			diagnostic.EligibleCandidates += candidates
 		}
 		if index == 0 {
 			diagnostic.NeverRun = false
@@ -462,9 +464,10 @@ func doctorAdmissionCadenceWarning(diagnostic doctorAdmissionDiagnostic) string 
 		return ""
 	}
 	guidance := fmt.Sprintf(
-		"backlog admission cadence guidance: %d of %d recent runs found %d candidates after waits up to %s; candidates are accumulating between runs; consider a schedule no slower than every %s",
+		"backlog admission cadence guidance: %d of %d recent runs found %d eligible candidates after filters (%d source candidate observations) after waits up to %s; candidates are accumulating between runs; consider a schedule no slower than every %s",
 		diagnostic.CandidateBearingRuns,
 		diagnostic.ObservedRuns,
+		diagnostic.EligibleCandidates,
 		diagnostic.CandidatesObserved,
 		maximumGap,
 		doctorAdmissionResponsiveCadence,
@@ -496,7 +499,11 @@ func doctorAdmissionObservedCost(diagnostic doctorAdmissionDiagnostic) string {
 }
 
 func doctorAdmissionMaximumGap(scheduleExpression string) time.Duration {
-	schedule, err := cron.ParseStandard("CRON_TZ=UTC " + strings.TrimSpace(scheduleExpression))
+	scheduleExpression = strings.TrimSpace(scheduleExpression)
+	if !strings.HasPrefix(scheduleExpression, "TZ=") && !strings.HasPrefix(scheduleExpression, "CRON_TZ=") {
+		scheduleExpression = "CRON_TZ=UTC " + scheduleExpression
+	}
+	schedule, err := cron.ParseStandard(scheduleExpression)
 	if err != nil {
 		return 0
 	}

--- a/internal/cli/doctor_admission.go
+++ b/internal/cli/doctor_admission.go
@@ -7,6 +7,9 @@ import (
 	"fmt"
 	"sort"
 	"strings"
+	"time"
+
+	"github.com/robfig/cron/v3"
 
 	admissionmodel "github.com/digitaldrywood/detent/internal/admission/model"
 	workflowconfig "github.com/digitaldrywood/detent/internal/config"
@@ -14,33 +17,46 @@ import (
 	"github.com/digitaldrywood/detent/internal/provenance"
 )
 
-const doctorAdmissionFailureThreshold = 3
+const (
+	doctorAdmissionFailureThreshold   = 3
+	doctorAdmissionRecentRunLimit     = 20
+	doctorAdmissionResponsiveCadence  = 30 * time.Minute
+	doctorAdmissionCadenceSampleCount = 512
+)
 
 type doctorAdmissionDiagnostic struct {
-	Schedule             string           `json:"schedule"`
-	CriteriaSection      string           `json:"criteria_section"`
-	Dimensions           []string         `json:"dimensions,omitempty"`
-	NeverRun             bool             `json:"never_run,omitempty"`
-	LastRun              string           `json:"last_run,omitempty"`
-	Outcome              string           `json:"outcome,omitempty"`
-	DeferredReason       string           `json:"deferred_reason,omitempty"`
-	CandidatesFound      int              `json:"candidates_found,omitempty"`
-	CandidatesEvaluated  int              `json:"candidates_evaluated,omitempty"`
-	Proposed             int              `json:"proposed,omitempty"`
-	Skipped              map[string]int   `json:"skipped,omitempty"`
-	Truncated            map[string]int   `json:"truncated,omitempty"`
-	IssueReferences      []string         `json:"issue_references,omitempty"`
-	ConsecutiveFailures  int              `json:"consecutive_failures,omitempty"`
-	LatestError          string           `json:"latest_error,omitempty"`
-	Warnings             []string         `json:"warnings,omitempty"`
-	Origins              map[string]int   `json:"origins,omitempty"`
-	ProposalOutcomes     map[string]int   `json:"proposal_outcomes,omitempty"`
-	DecisionSeconds      map[string]int64 `json:"average_decision_seconds,omitempty"`
-	AcceptedCompleted    int              `json:"accepted_completed,omitempty"`
-	ReworkCount          int              `json:"rework_count,omitempty"`
-	ReviewChurnCount     int              `json:"review_churn_count,omitempty"`
-	SpendUSD             float64          `json:"spend_usd,omitempty"`
-	RepositoryVisibility string           `json:"repository_visibility,omitempty"`
+	Schedule              string           `json:"schedule"`
+	MaximumGapSeconds     int64            `json:"maximum_gap_seconds,omitempty"`
+	CriteriaSection       string           `json:"criteria_section"`
+	Dimensions            []string         `json:"dimensions,omitempty"`
+	NeverRun              bool             `json:"never_run,omitempty"`
+	ObservedRuns          int              `json:"observed_runs,omitempty"`
+	CandidateBearingRuns  int              `json:"candidate_bearing_runs,omitempty"`
+	CandidatesObserved    int              `json:"candidates_observed,omitempty"`
+	AverageRunSeconds     int64            `json:"average_run_seconds,omitempty"`
+	AdmissionSessions     int              `json:"admission_sessions,omitempty"`
+	AverageSessionSeconds int64            `json:"average_session_seconds,omitempty"`
+	AverageSessionTokens  int64            `json:"average_session_tokens,omitempty"`
+	LastRun               string           `json:"last_run,omitempty"`
+	Outcome               string           `json:"outcome,omitempty"`
+	DeferredReason        string           `json:"deferred_reason,omitempty"`
+	CandidatesFound       int              `json:"candidates_found,omitempty"`
+	CandidatesEvaluated   int              `json:"candidates_evaluated,omitempty"`
+	Proposed              int              `json:"proposed,omitempty"`
+	Skipped               map[string]int   `json:"skipped,omitempty"`
+	Truncated             map[string]int   `json:"truncated,omitempty"`
+	IssueReferences       []string         `json:"issue_references,omitempty"`
+	ConsecutiveFailures   int              `json:"consecutive_failures,omitempty"`
+	LatestError           string           `json:"latest_error,omitempty"`
+	Warnings              []string         `json:"warnings,omitempty"`
+	Origins               map[string]int   `json:"origins,omitempty"`
+	ProposalOutcomes      map[string]int   `json:"proposal_outcomes,omitempty"`
+	DecisionSeconds       map[string]int64 `json:"average_decision_seconds,omitempty"`
+	AcceptedCompleted     int              `json:"accepted_completed,omitempty"`
+	ReworkCount           int              `json:"rework_count,omitempty"`
+	ReviewChurnCount      int              `json:"review_churn_count,omitempty"`
+	SpendUSD              float64          `json:"spend_usd,omitempty"`
+	RepositoryVisibility  string           `json:"repository_visibility,omitempty"`
 }
 
 func checkDoctorAdmission(
@@ -54,10 +70,11 @@ func checkDoctorAdmission(
 	name := "Project " + projectID + " backlog admission"
 	deps = deps.withDefaults()
 	diagnostic := doctorAdmissionDiagnostic{
-		Schedule:        cfg.Schedule,
-		CriteriaSection: cfg.CriteriaSection,
-		NeverRun:        true,
-		Warnings:        workflowconfig.BacklogAdmissionWarnings(cfg, workflow.Config.Tracker),
+		Schedule:          cfg.Schedule,
+		MaximumGapSeconds: int64(doctorAdmissionMaximumGap(cfg.Schedule) / time.Second),
+		CriteriaSection:   cfg.CriteriaSection,
+		NeverRun:          true,
+		Warnings:          workflowconfig.BacklogAdmissionWarnings(cfg, workflow.Config.Tracker),
 	}
 	if doctorTrackerUsesGitHubReads(workflow.Config.Tracker.Kind) {
 		repository := strings.TrimSpace(workflow.Config.Tracker.Repository)
@@ -144,13 +161,13 @@ func readDoctorAdmissionDiagnostic(
 	diagnostic doctorAdmissionDiagnostic,
 ) (_ doctorAdmissionDiagnostic, resultErr error) {
 	rows, err := db.QueryContext(ctx, `
-SELECT completed_at, outcome, COALESCE(deferred_reason, ''), candidates_found_count,
+SELECT started_at, completed_at, outcome, COALESCE(deferred_reason, ''), candidates_found_count,
        candidates_count, proposed_count, skipped_json, truncated_json, issues_json,
        COALESCE(error, '')
 FROM backlog_admission_runs
 WHERE project_id = ?
 ORDER BY completed_at DESC, id DESC
-LIMIT ?`, strings.TrimSpace(projectID), doctorAdmissionFailureThreshold)
+LIMIT ?`, strings.TrimSpace(projectID), doctorAdmissionRecentRunLimit)
 	if err != nil {
 		if strings.Contains(strings.ToLower(err.Error()), "no such table: backlog_admission_runs") {
 			return diagnostic, nil
@@ -161,7 +178,10 @@ LIMIT ?`, strings.TrimSpace(projectID), doctorAdmissionFailureThreshold)
 		resultErr = errors.Join(resultErr, rows.Close())
 	}()
 	index := 0
+	failureStreak := true
+	var totalRunSeconds int64
 	for rows.Next() {
+		var startedAt string
 		var completedAt string
 		var outcome string
 		var deferredReason string
@@ -173,6 +193,7 @@ LIMIT ?`, strings.TrimSpace(projectID), doctorAdmissionFailureThreshold)
 		var issuesRaw string
 		var runError string
 		if err := rows.Scan(
+			&startedAt,
 			&completedAt,
 			&outcome,
 			&deferredReason,
@@ -185,6 +206,20 @@ LIMIT ?`, strings.TrimSpace(projectID), doctorAdmissionFailureThreshold)
 			&runError,
 		); err != nil {
 			return diagnostic, err
+		}
+		started, err := time.Parse(time.RFC3339Nano, startedAt)
+		if err != nil {
+			return diagnostic, fmt.Errorf("parse backlog admission started_at: %w", err)
+		}
+		completed, err := time.Parse(time.RFC3339Nano, completedAt)
+		if err != nil {
+			return diagnostic, fmt.Errorf("parse backlog admission completed_at: %w", err)
+		}
+		diagnostic.ObservedRuns++
+		totalRunSeconds += max(int64(completed.Sub(started)/time.Second), 0)
+		if candidatesFound > 0 {
+			diagnostic.CandidateBearingRuns++
+			diagnostic.CandidatesObserved += candidatesFound
 		}
 		if index == 0 {
 			diagnostic.NeverRun = false
@@ -215,10 +250,13 @@ LIMIT ?`, strings.TrimSpace(projectID), doctorAdmissionFailureThreshold)
 			}
 			diagnostic.LatestError = strings.TrimSpace(runError)
 		}
-		if strings.TrimSpace(runError) == "" {
-			break
+		if failureStreak {
+			if strings.TrimSpace(runError) == "" {
+				failureStreak = false
+			} else {
+				diagnostic.ConsecutiveFailures++
+			}
 		}
-		diagnostic.ConsecutiveFailures++
 		index++
 	}
 	if err := rows.Err(); err != nil {
@@ -226,6 +264,9 @@ LIMIT ?`, strings.TrimSpace(projectID), doctorAdmissionFailureThreshold)
 	}
 	if err := rows.Close(); err != nil {
 		return diagnostic, err
+	}
+	if diagnostic.ObservedRuns > 0 {
+		diagnostic.AverageRunSeconds = totalRunSeconds / int64(diagnostic.ObservedRuns)
 	}
 	return readDoctorAdmissionEvidence(ctx, db, projectID, diagnostic)
 }
@@ -236,6 +277,9 @@ func readDoctorAdmissionEvidence(
 	projectID string,
 	diagnostic doctorAdmissionDiagnostic,
 ) (doctorAdmissionDiagnostic, error) {
+	if err := readDoctorAdmissionSessionCost(ctx, db, projectID, &diagnostic); err != nil {
+		return diagnostic, err
+	}
 	diagnostic.ProposalOutcomes = map[string]int{}
 	diagnostic.DecisionSeconds = map[string]int64{}
 	rows, err := db.QueryContext(ctx, `
@@ -308,11 +352,46 @@ ORDER BY id`, strings.TrimSpace(projectID))
 	return diagnostic, originRows.Err()
 }
 
+func readDoctorAdmissionSessionCost(
+	ctx context.Context,
+	db doctorTelemetryStore,
+	projectID string,
+	diagnostic *doctorAdmissionDiagnostic,
+) error {
+	err := db.QueryRowContext(ctx, `
+SELECT COUNT(*),
+       CAST(COALESCE(AVG(runtime_seconds), 0) AS INTEGER),
+       CAST(COALESCE(AVG(total_tokens), 0) AS INTEGER)
+FROM codex_sessions
+WHERE project_id = ? AND identifier = ? AND completed_at IS NOT NULL`,
+		strings.TrimSpace(projectID),
+		strings.TrimSpace(projectID)+"/admission",
+	).Scan(
+		&diagnostic.AdmissionSessions,
+		&diagnostic.AverageSessionSeconds,
+		&diagnostic.AverageSessionTokens,
+	)
+	if err != nil && strings.Contains(strings.ToLower(err.Error()), "no such table: codex_sessions") {
+		return nil
+	}
+	return err
+}
+
 func doctorAdmissionCheck(name string, diagnostic doctorAdmissionDiagnostic, unavailable string) doctorCheck {
+	if warning := doctorAdmissionCadenceWarning(diagnostic); warning != "" {
+		diagnostic.Warnings = append(diagnostic.Warnings, warning)
+	}
 	check := doctorCheck{Name: name, Status: doctorOK, BacklogAdmission: &diagnostic}
 	details := []string{
+		"schedule " + strconvQuote(diagnostic.Schedule),
 		"criteria section " + strconvQuote(diagnostic.CriteriaSection),
 		fmt.Sprintf("%d project-defined dimensions", len(diagnostic.Dimensions)),
+	}
+	if diagnostic.MaximumGapSeconds > 0 {
+		details = append(details, "maximum cadence gap "+(time.Duration(diagnostic.MaximumGapSeconds)*time.Second).String())
+	}
+	if cost := doctorAdmissionObservedCost(diagnostic); cost != "" {
+		details = append(details, "observed cost "+cost)
 	}
 	if !diagnostic.NeverRun {
 		details = append(details, fmt.Sprintf(
@@ -375,6 +454,64 @@ func doctorAdmissionCheck(name string, diagnostic doctorAdmissionDiagnostic, una
 	}
 	check.Detail = strings.Join(details, "; ")
 	return check
+}
+
+func doctorAdmissionCadenceWarning(diagnostic doctorAdmissionDiagnostic) string {
+	maximumGap := time.Duration(diagnostic.MaximumGapSeconds) * time.Second
+	if maximumGap <= doctorAdmissionResponsiveCadence || diagnostic.CandidateBearingRuns == 0 {
+		return ""
+	}
+	guidance := fmt.Sprintf(
+		"backlog admission cadence guidance: %d of %d recent runs found %d candidates after waits up to %s; candidates are accumulating between runs; consider a schedule no slower than every %s",
+		diagnostic.CandidateBearingRuns,
+		diagnostic.ObservedRuns,
+		diagnostic.CandidatesObserved,
+		maximumGap,
+		doctorAdmissionResponsiveCadence,
+	)
+	if cost := doctorAdmissionObservedCost(diagnostic); cost != "" {
+		guidance += "; observed cost " + cost
+	}
+	return guidance
+}
+
+func doctorAdmissionObservedCost(diagnostic doctorAdmissionDiagnostic) string {
+	costs := []string{}
+	if diagnostic.ObservedRuns > 0 {
+		costs = append(costs, fmt.Sprintf(
+			"%s/run across %d recent runs",
+			(time.Duration(diagnostic.AverageRunSeconds)*time.Second).String(),
+			diagnostic.ObservedRuns,
+		))
+	}
+	if diagnostic.AdmissionSessions > 0 {
+		costs = append(costs, fmt.Sprintf(
+			"%s and %d tokens/candidate-bearing run across %d admission agent sessions",
+			(time.Duration(diagnostic.AverageSessionSeconds)*time.Second).String(),
+			diagnostic.AverageSessionTokens,
+			diagnostic.AdmissionSessions,
+		))
+	}
+	return strings.Join(costs, ", ")
+}
+
+func doctorAdmissionMaximumGap(scheduleExpression string) time.Duration {
+	schedule, err := cron.ParseStandard("CRON_TZ=UTC " + strings.TrimSpace(scheduleExpression))
+	if err != nil {
+		return 0
+	}
+	origin := time.Date(2024, time.January, 1, 0, 0, 0, 0, time.UTC)
+	previous := schedule.Next(origin)
+	var maximumGap time.Duration
+	for range doctorAdmissionCadenceSampleCount {
+		next := schedule.Next(previous)
+		if !next.After(previous) {
+			return maximumGap
+		}
+		maximumGap = max(maximumGap, next.Sub(previous))
+		previous = next
+	}
+	return maximumGap
 }
 
 func doctorAdmissionDurations(durations map[string]int64) string {

--- a/internal/cli/doctor_admission_test.go
+++ b/internal/cli/doctor_admission_test.go
@@ -111,7 +111,7 @@ INSERT INTO workflow_phase_events (project_id, phase_type, status, metadata_json
 		`schedule "0 6 * * 1-5"`,
 		"maximum cadence gap 72h0m0s",
 		"observed cost 20s/run across 3 recent runs, 30s and 38000 tokens/candidate-bearing run across 2 admission agent sessions",
-		"3 of 3 recent runs found 30 candidates",
+		"3 of 3 recent runs found 12 eligible candidates after filters (30 source candidate observations)",
 		"candidates are accumulating between runs",
 		`"Admission criteria"`,
 		"2 project-defined dimensions",
@@ -130,7 +130,8 @@ INSERT INTO workflow_phase_events (project_id, phase_type, status, metadata_json
 	}
 	if diagnostic.NeverRun || diagnostic.CandidatesFound != 12 || diagnostic.CandidatesEvaluated != 4 || diagnostic.Proposed != 1 ||
 		diagnostic.ObservedRuns != 3 || diagnostic.CandidateBearingRuns != 3 ||
-		diagnostic.CandidatesObserved != 30 || diagnostic.AverageRunSeconds != 20 ||
+		diagnostic.CandidatesObserved != 30 || diagnostic.EligibleCandidates != 12 ||
+		diagnostic.AverageRunSeconds != 20 ||
 		diagnostic.AdmissionSessions != 2 || diagnostic.AverageSessionSeconds != 30 ||
 		diagnostic.AverageSessionTokens != 38000 {
 		t.Fatalf("diagnostic = %#v", diagnostic)
@@ -153,21 +154,23 @@ func TestDoctorAdmissionCadenceGuidance(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name       string
-		schedule   string
-		observed   int
-		withIssues int
-		candidates int
-		wantStatus doctorStatus
-		wantText   string
+		name               string
+		schedule           string
+		observed           int
+		withEligible       int
+		sourceCandidates   int
+		eligibleCandidates int
+		wantStatus         doctorStatus
+		wantText           string
 	}{
 		{
-			name:       "responsive cadence with candidates",
-			schedule:   "*/15 * * * *",
-			observed:   4,
-			withIssues: 2,
-			candidates: 3,
-			wantStatus: doctorOK,
+			name:               "responsive cadence with candidates",
+			schedule:           "*/15 * * * *",
+			observed:           4,
+			withEligible:       2,
+			sourceCandidates:   3,
+			eligibleCandidates: 2,
+			wantStatus:         doctorOK,
 		},
 		{
 			name:       "slow cadence without candidates",
@@ -176,13 +179,21 @@ func TestDoctorAdmissionCadenceGuidance(t *testing.T) {
 			wantStatus: doctorOK,
 		},
 		{
-			name:       "slow cadence with accumulating candidates",
-			schedule:   "0 6 * * 1-5",
-			observed:   4,
-			withIssues: 2,
-			candidates: 7,
-			wantStatus: doctorWarn,
-			wantText:   "candidates are accumulating between runs",
+			name:             "slow cadence with only filtered candidates",
+			schedule:         "0 6 * * 1-5",
+			observed:         4,
+			sourceCandidates: 7,
+			wantStatus:       doctorOK,
+		},
+		{
+			name:               "slow cadence with accumulating candidates",
+			schedule:           "0 6 * * 1-5",
+			observed:           4,
+			withEligible:       2,
+			sourceCandidates:   7,
+			eligibleCandidates: 5,
+			wantStatus:         doctorWarn,
+			wantText:           "candidates are accumulating between runs",
 		},
 	}
 	for _, tt := range tests {
@@ -195,8 +206,9 @@ func TestDoctorAdmissionCadenceGuidance(t *testing.T) {
 				CriteriaSection:       "Admission criteria",
 				Dimensions:            []string{"Alignment"},
 				ObservedRuns:          tt.observed,
-				CandidateBearingRuns:  tt.withIssues,
-				CandidatesObserved:    tt.candidates,
+				CandidateBearingRuns:  tt.withEligible,
+				CandidatesObserved:    tt.sourceCandidates,
+				EligibleCandidates:    tt.eligibleCandidates,
 				AverageRunSeconds:     25,
 				AdmissionSessions:     3,
 				AverageSessionSeconds: 24,
@@ -236,6 +248,7 @@ func TestDoctorAdmissionMaximumGap(t *testing.T) {
 		{name: "quarter hourly", schedule: "*/15 * * * *", want: 15 * time.Minute},
 		{name: "hourly", schedule: "0 * * * *", want: time.Hour},
 		{name: "weekdays", schedule: "0 6 * * 1-5", want: 72 * time.Hour},
+		{name: "configured timezone", schedule: "CRON_TZ=America/New_York 0 6 * * 1-5", want: 73 * time.Hour},
 		{name: "invalid", schedule: "not cron", want: 0},
 	}
 	for _, tt := range tests {

--- a/internal/cli/doctor_admission_test.go
+++ b/internal/cli/doctor_admission_test.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"strings"
 	"testing"
+	"time"
 
 	workflowconfig "github.com/digitaldrywood/detent/internal/config"
 	ghconnector "github.com/digitaldrywood/detent/internal/connector/github"
@@ -26,6 +27,7 @@ func TestDoctorAdmissionDiagnostics(t *testing.T) {
 CREATE TABLE backlog_admission_runs (
   id INTEGER PRIMARY KEY,
   project_id TEXT NOT NULL,
+  started_at TEXT NOT NULL,
   completed_at TEXT NOT NULL,
   outcome TEXT NOT NULL,
   deferred_reason TEXT,
@@ -38,12 +40,25 @@ CREATE TABLE backlog_admission_runs (
   error TEXT
 );
 INSERT INTO backlog_admission_runs (
-  project_id, completed_at, outcome, deferred_reason, candidates_found_count,
+  project_id, started_at, completed_at, outcome, deferred_reason, candidates_found_count,
   candidates_count, proposed_count, skipped_json, truncated_json, issues_json, error
 ) VALUES
-  ('detent', '2026-07-29T10:03:00Z', 'failed', NULL, 12, 4, 1, '{"excluded_label":2}', '{"candidate_cap":8}', '[{"identifier":"digitaldrywood/detent#1535"}]', 'third failure'),
-  ('detent', '2026-07-29T10:02:00Z', 'failed', NULL, 10, 4, 0, '{}', '{"candidate_cap":6}', '[]', 'second failure'),
-  ('detent', '2026-07-29T10:01:00Z', 'failed', NULL, 8, 4, 0, '{}', '{"candidate_cap":4}', '[]', 'first failure');
+  ('detent', '2026-07-29T10:02:30Z', '2026-07-29T10:03:00Z', 'failed', NULL, 12, 4, 1, '{"excluded_label":2}', '{"candidate_cap":8}', '[{"identifier":"digitaldrywood/detent#1535"}]', 'third failure'),
+  ('detent', '2026-07-29T10:01:40Z', '2026-07-29T10:02:00Z', 'failed', NULL, 10, 4, 0, '{}', '{"candidate_cap":6}', '[]', 'second failure'),
+  ('detent', '2026-07-29T10:00:50Z', '2026-07-29T10:01:00Z', 'failed', NULL, 8, 4, 0, '{}', '{"candidate_cap":4}', '[]', 'first failure');
+CREATE TABLE codex_sessions (
+  project_id TEXT,
+  identifier TEXT,
+  completed_at TEXT,
+  runtime_seconds INTEGER NOT NULL,
+  total_tokens INTEGER NOT NULL
+);
+INSERT INTO codex_sessions (
+  project_id, identifier, completed_at, runtime_seconds, total_tokens
+) VALUES
+  ('detent', 'detent/admission', '2026-07-29T10:02:55Z', 25, 36000),
+  ('detent', 'detent/admission', '2026-07-29T10:01:55Z', 35, 40000),
+  ('detent', 'digitaldrywood/detent#1535', '2026-07-29T11:00:00Z', 900, 2000000);
 CREATE TABLE backlog_admission_proposals (
   project_id TEXT NOT NULL,
   status TEXT NOT NULL,
@@ -78,10 +93,11 @@ INSERT INTO workflow_phase_events (project_id, phase_type, status, metadata_json
 	}
 
 	diagnostic, err := readDoctorAdmissionDiagnostic(ctx, db, "detent", doctorAdmissionDiagnostic{
-		Schedule:        "0 6 * * 1-5",
-		CriteriaSection: "Admission criteria",
-		Dimensions:      []string{"Alignment", "Risk"},
-		NeverRun:        true,
+		Schedule:          "0 6 * * 1-5",
+		MaximumGapSeconds: int64(doctorAdmissionMaximumGap("0 6 * * 1-5") / time.Second),
+		CriteriaSection:   "Admission criteria",
+		Dimensions:        []string{"Alignment", "Risk"},
+		NeverRun:          true,
 	})
 	if err != nil {
 		t.Fatalf("readDoctorAdmissionDiagnostic() error = %v", err)
@@ -92,6 +108,11 @@ INSERT INTO workflow_phase_events (project_id, phase_type, status, metadata_json
 	}
 	for _, want := range []string{
 		"3 consecutive failures",
+		`schedule "0 6 * * 1-5"`,
+		"maximum cadence gap 72h0m0s",
+		"observed cost 20s/run across 3 recent runs, 30s and 38000 tokens/candidate-bearing run across 2 admission agent sessions",
+		"3 of 3 recent runs found 30 candidates",
+		"candidates are accumulating between runs",
 		`"Admission criteria"`,
 		"2 project-defined dimensions",
 		"candidates=12 evaluated=4 proposed=1",
@@ -107,7 +128,11 @@ INSERT INTO workflow_phase_events (project_id, phase_type, status, metadata_json
 			t.Fatalf("Detail = %q, want %q", check.Detail, want)
 		}
 	}
-	if diagnostic.NeverRun || diagnostic.CandidatesFound != 12 || diagnostic.CandidatesEvaluated != 4 || diagnostic.Proposed != 1 {
+	if diagnostic.NeverRun || diagnostic.CandidatesFound != 12 || diagnostic.CandidatesEvaluated != 4 || diagnostic.Proposed != 1 ||
+		diagnostic.ObservedRuns != 3 || diagnostic.CandidateBearingRuns != 3 ||
+		diagnostic.CandidatesObserved != 30 || diagnostic.AverageRunSeconds != 20 ||
+		diagnostic.AdmissionSessions != 2 || diagnostic.AverageSessionSeconds != 30 ||
+		diagnostic.AverageSessionTokens != 38000 {
 		t.Fatalf("diagnostic = %#v", diagnostic)
 	}
 	if diagnostic.Skipped["excluded_label"] != 2 || diagnostic.Truncated["candidate_cap"] != 8 {
@@ -121,6 +146,106 @@ INSERT INTO workflow_phase_events (project_id, phase_type, status, metadata_json
 		diagnostic.ReviewChurnCount != 3 ||
 		diagnostic.SpendUSD != 4.5 {
 		t.Fatalf("evidence diagnostic = %#v", diagnostic)
+	}
+}
+
+func TestDoctorAdmissionCadenceGuidance(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		schedule   string
+		observed   int
+		withIssues int
+		candidates int
+		wantStatus doctorStatus
+		wantText   string
+	}{
+		{
+			name:       "responsive cadence with candidates",
+			schedule:   "*/15 * * * *",
+			observed:   4,
+			withIssues: 2,
+			candidates: 3,
+			wantStatus: doctorOK,
+		},
+		{
+			name:       "slow cadence without candidates",
+			schedule:   "0 6 * * 1-5",
+			observed:   4,
+			wantStatus: doctorOK,
+		},
+		{
+			name:       "slow cadence with accumulating candidates",
+			schedule:   "0 6 * * 1-5",
+			observed:   4,
+			withIssues: 2,
+			candidates: 7,
+			wantStatus: doctorWarn,
+			wantText:   "candidates are accumulating between runs",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			diagnostic := doctorAdmissionDiagnostic{
+				Schedule:              tt.schedule,
+				MaximumGapSeconds:     int64(doctorAdmissionMaximumGap(tt.schedule) / time.Second),
+				CriteriaSection:       "Admission criteria",
+				Dimensions:            []string{"Alignment"},
+				ObservedRuns:          tt.observed,
+				CandidateBearingRuns:  tt.withIssues,
+				CandidatesObserved:    tt.candidates,
+				AverageRunSeconds:     25,
+				AdmissionSessions:     3,
+				AverageSessionSeconds: 24,
+				AverageSessionTokens:  36000,
+			}
+			check := doctorAdmissionCheck("admission", diagnostic, "")
+			if check.Status != tt.wantStatus {
+				t.Fatalf("Status = %q, want %q: %s", check.Status, tt.wantStatus, check.Detail)
+			}
+			if tt.wantText != "" && !strings.Contains(check.Detail, tt.wantText) {
+				t.Fatalf("Detail = %q, want %q", check.Detail, tt.wantText)
+			}
+			if tt.wantText == "" && strings.Contains(check.Detail, "cadence guidance") {
+				t.Fatalf("Detail = %q, want no cadence guidance", check.Detail)
+			}
+			for _, want := range []string{
+				"schedule " + strconvQuote(tt.schedule),
+				"observed cost 25s/run across",
+				"36000 tokens/candidate-bearing run",
+			} {
+				if !strings.Contains(check.Detail, want) {
+					t.Fatalf("Detail = %q, want %q", check.Detail, want)
+				}
+			}
+		})
+	}
+}
+
+func TestDoctorAdmissionMaximumGap(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		schedule string
+		want     time.Duration
+	}{
+		{name: "quarter hourly", schedule: "*/15 * * * *", want: 15 * time.Minute},
+		{name: "hourly", schedule: "0 * * * *", want: time.Hour},
+		{name: "weekdays", schedule: "0 6 * * 1-5", want: 72 * time.Hour},
+		{name: "invalid", schedule: "not cron", want: 0},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			if got := doctorAdmissionMaximumGap(tt.schedule); got != tt.want {
+				t.Fatalf("doctorAdmissionMaximumGap(%q) = %s, want %s", tt.schedule, got, tt.want)
+			}
+		})
 	}
 }
 

--- a/internal/config/admission.go
+++ b/internal/config/admission.go
@@ -12,7 +12,9 @@ import (
 )
 
 const (
-	DefaultBacklogAdmissionSchedule               = "0 6 * * 1-5"
+	// DefaultBacklogAdmissionSchedule keeps proposal latency under 15 minutes.
+	// Observed admission runs cost about 25 seconds and 36,000 tokens each.
+	DefaultBacklogAdmissionSchedule               = "*/15 * * * *"
 	DefaultBacklogAdmissionMaxCandidatesPerRun    = 50
 	DefaultBacklogAdmissionMaxProposalsPerRun     = 3
 	DefaultBacklogAdmissionMaxOpenProposals       = 10

--- a/internal/config/admission_test.go
+++ b/internal/config/admission_test.go
@@ -252,6 +252,31 @@ func TestBacklogAdmissionAutoAdmitDefaultsOff(t *testing.T) {
 	}
 }
 
+func TestBacklogAdmissionScheduleNormalization(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		schedule string
+		want     string
+	}{
+		{name: "default", want: DefaultBacklogAdmissionSchedule},
+		{name: "explicit", schedule: "0 6 * * 1-5", want: "0 6 * * 1-5"},
+		{name: "trim explicit", schedule: "  0 * * * *  ", want: "0 * * * *"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			cfg := BacklogAdmission{Schedule: tt.schedule}
+			cfg.Normalize()
+			if cfg.Schedule != tt.want {
+				t.Fatalf("Schedule = %q, want %q", cfg.Schedule, tt.want)
+			}
+		})
+	}
+}
+
 func TestBacklogAdmissionValidateUntrackedSelector(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

- default backlog admission to a responsive 15-minute cadence while preserving explicit schedules
- report maximum cadence gaps, recent candidate accumulation, and observed runtime/token cost in `detent doctor`
- document cadence latency and cost tradeoffs and refresh generated config references

Fixes #1592

## UI Surface Contract

- [x] N/A, or the linked issue explicitly authorizes any high-impact UI surface, layout, density, first-viewport, or responsive visibility tradeoff.
- [x] Persistent top-of-screen messaging is explicitly authorized by the issue, or this PR does not add it.
- [x] Visual changes to primary operator screens include screenshot or browser verification below.

No operator UI surface changes.

## Test Plan

- [x] `go test ./internal/config ./internal/config/configdoc ./internal/cli`
- [x] `make check`