### PR TITLE
fix(update): persist automatic check schedule

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -43,7 +43,7 @@ Runtime settings resolve in this order: explicit flag, environment variable,
 | Web port | `--port` | `PORT` | `port` | `4000` |
 | Instance name | | | `instance_name` | short hostname |
 | Automatic update checks | | | `update.auto_check_enabled` | `false` |
-| Update check interval | | | `update.check_interval_hours` | `24` |
+| Update check interval | | | `update.check_interval_hours` | `6` |
 | Automatic update apply when idle | | | `update.auto_apply_enabled` | `false` |
 
 The web host resolves from `--host`, then the first registered workflow's
@@ -66,17 +66,21 @@ single-project fallback mode without `global.yaml`, workflow top-level
 single line, and are capped at 40 characters in the web UI.
 
 Automatic update checks are host-specific and disabled by default. When
-enabled, Detent checks on a jittered in-process schedule and reports the last
-check, available or applied version, and next check on `/health` and the Health
-dashboard. `detent doctor` reports whether the host is opted in and suggests
-enabling checks when it is not. Automatic apply remains off unless explicitly
-enabled and only replaces release-installer binaries; other install sources
-remain notification-only. When work attempts are active, Detent shows the
-pending version in the web and terminal dashboards and waits for the next
-fleet-wide idle window before applying it. An operator can instead confirm
-immediate apply from the web notification. A successful apply uses the normal
-graceful drain path, then re-executes the replaced binary on POSIX systems or
-exits cleanly for an external supervisor to restart it on other platforms.
+enabled, Detent persists the last check and schedules the next jittered check
+from that timestamp, so restarts preserve the remaining delay and overdue
+checks run promptly. The six-hour default keeps release uptake within the same
+day while using about four GitHub requests per host per day. Detent reports the
+last check, available or applied version, and next check on `/health` and the
+Health dashboard. `detent doctor` surfaces the last and next check times,
+reports whether the host is opted in, and suggests enabling checks when it is
+not. Automatic apply remains off unless explicitly enabled and only replaces
+release-installer binaries; other install sources remain notification-only.
+When work attempts are active, Detent shows the pending version in the web and
+terminal dashboards and waits for the next fleet-wide idle window before
+applying it. An operator can instead confirm immediate apply from the web
+notification. A successful apply uses the normal graceful drain path, then
+re-executes the replaced binary on POSIX systems or exits cleanly for an
+external supervisor to restart it on other platforms.
 
 `detent doctor` prints the resolved runtime values and their sources, with the
 GitHub token redacted.

--- a/internal/cli/boot.go
+++ b/internal/cli/boot.go
@@ -1411,6 +1411,25 @@ func runtimeBoardSnapshotPath(cfg BootConfig) string {
 	return base + "-board-snapshot.json"
 }
 
+func runtimeUpdateStatePath(cfg BootConfig) string {
+	databasePath := runtimeStorePath(cfg)
+	if runtimeStoreIsMemory(databasePath) {
+		root := filepath.Dir(strings.TrimSpace(cfg.Global.Path))
+		if root == "." || root == "" {
+			root = filepath.Join(mustGetwd(), ".detent")
+		}
+		return filepath.Join(root, "detent-update-state.json")
+	}
+	if uri, ok := runtimeStoreURI(databasePath); ok {
+		if uriPath, pathOK := runtimeStoreURIPath(uri); pathOK {
+			databasePath = uriPath
+		}
+	}
+	extension := filepath.Ext(databasePath)
+	base := strings.TrimSuffix(databasePath, extension)
+	return base + "-update-state.json"
+}
+
 func runtimeLogPath(cfg BootConfig) string {
 	if path := strings.TrimSpace(cfg.RuntimeLogPath); path != "" {
 		return path

--- a/internal/cli/boot_test.go
+++ b/internal/cli/boot_test.go
@@ -802,6 +802,33 @@ func TestRuntimeBoardSnapshotPath(t *testing.T) {
 	}
 }
 
+func TestRuntimeUpdateStatePath(t *testing.T) {
+	t.Parallel()
+
+	home := t.TempDir()
+	tests := []struct {
+		name     string
+		database string
+		want     string
+	}{
+		{name: "memory database", database: ":memory:", want: filepath.Join(home, "detent-update-state.json")},
+		{name: "file database", database: filepath.Join(home, "runtime.db"), want: filepath.Join(home, "runtime-update-state.json")},
+		{name: "file URI", database: "file:" + filepath.ToSlash(filepath.Join(home, "runtime.db")) + "?mode=rwc", want: filepath.Join(home, "runtime-update-state.json")},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			cfg := BootConfig{
+				Global:        globalconfig.Config{Path: filepath.Join(home, "global.yaml")},
+				RuntimeDBPath: tt.database,
+			}
+			if got := runtimeUpdateStatePath(cfg); got != tt.want {
+				t.Fatalf("runtimeUpdateStatePath() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestAcquireRuntimeInstanceLockReportsLiveHolder(t *testing.T) {
 	t.Parallel()
 

--- a/internal/cli/update_runtime.go
+++ b/internal/cli/update_runtime.go
@@ -49,6 +49,7 @@ func newRuntimeUpdateScheduler(cfg BootConfig, logger *slog.Logger, reserveIdle 
 		CheckInterval:    interval,
 		ReserveIdle:      reserveIdle,
 		Logger:           logger,
+		StatePath:        runtimeUpdateStatePath(cfg),
 	}
 	executable, err := os.Executable()
 	if err != nil {

--- a/internal/config/global/config.go
+++ b/internal/config/global/config.go
@@ -22,7 +22,7 @@ import (
 const (
 	APIVersion                      = "detent/v1"
 	Kind                            = "GlobalConfig"
-	DefaultUpdateCheckIntervalHours = 24
+	DefaultUpdateCheckIntervalHours = 6
 
 	SchedulingWeighted              = "weighted"
 	SchedulingStrict                = "strict"

--- a/internal/config/global/config_test.go
+++ b/internal/config/global/config_test.go
@@ -344,6 +344,14 @@ projects:
 	}
 }
 
+func TestUpdateUsesSixHourDefaultInterval(t *testing.T) {
+	t.Parallel()
+
+	if got := (Update{}).NormalizedCheckIntervalHours(); got != 6 {
+		t.Fatalf("NormalizedCheckIntervalHours() = %d, want 6", got)
+	}
+}
+
 func TestReadAllowsRefBackedRelativeWorkflow(t *testing.T) {
 	t.Parallel()
 

--- a/internal/update/scheduler.go
+++ b/internal/update/scheduler.go
@@ -42,6 +42,7 @@ type SchedulerConfig struct {
 	CheckInterval      time.Duration
 	IdlePollInterval   time.Duration
 	LastAppliedVersion string
+	StatePath          string
 	Updater            Updater
 	ReserveIdle        func(context.Context) (func(), bool)
 	RequestRestart     func(string) bool
@@ -83,6 +84,14 @@ func NewScheduler(cfg SchedulerConfig) (*Scheduler, error) {
 	if cfg.IdlePollInterval <= 0 {
 		cfg.IdlePollInterval = defaultIdlePollInterval
 	}
+	loadedLastCheckAt, lastCheckFound, err := loadSchedulerState(cfg.StatePath)
+	if err != nil {
+		cfg.Logger.Warn("load automatic update state failed", "path", cfg.StatePath, "error", err)
+	}
+	var lastCheckAt *time.Time
+	if lastCheckFound {
+		lastCheckAt = &loadedLastCheckAt
+	}
 	state := "disabled"
 	if cfg.Enabled {
 		state = "scheduled"
@@ -94,6 +103,7 @@ func NewScheduler(cfg SchedulerConfig) (*Scheduler, error) {
 			AutoApplyEnabled:   cfg.AutoApplyEnabled,
 			CheckInterval:      cfg.CheckInterval,
 			State:              state,
+			LastCheckAt:        lastCheckAt,
 			LastAppliedVersion: strings.TrimSpace(cfg.LastAppliedVersion),
 		},
 	}, nil
@@ -116,16 +126,12 @@ func (s *Scheduler) Run(ctx context.Context) {
 			}
 			continue
 		}
-		delay := s.cfg.NextDelay(s.cfg.CheckInterval)
-		if delay <= 0 || delay > s.cfg.CheckInterval {
-			delay = s.cfg.CheckInterval
-		}
-		next := s.cfg.Now().Add(delay)
+		delay, next := s.nextCheck()
 		s.updateStatus(func(status *AutoStatus) {
 			status.State = "scheduled"
 			status.NextCheckAt = &next
 		})
-		if !s.cfg.Wait(ctx, delay) {
+		if delay > 0 && !s.cfg.Wait(ctx, delay) {
 			return
 		}
 		if _, err := s.CheckNow(ctx); err != nil && ctx.Err() == nil {
@@ -153,8 +159,15 @@ func (s *Scheduler) CheckNow(ctx context.Context) (Status, error) {
 	checked, err := s.cfg.Updater.Check(ctx)
 	checkedAt := s.cfg.Now()
 	if err != nil {
-		s.recordFailure(checkedAt, err)
-		return checked, fmt.Errorf("check for Detent update: %w", err)
+		if ctx.Err() != nil {
+			s.updateStatus(func(status *AutoStatus) {
+				status.State = "failed"
+				status.LastError = err.Error()
+			})
+			return checked, fmt.Errorf("check for Detent update: %w", err)
+		}
+		persistErr := s.recordFailure(checkedAt, err)
+		return checked, fmt.Errorf("check for Detent update: %w", errors.Join(err, persistErr))
 	}
 	if !checked.UpdateAvailable {
 		s.updateStatus(func(status *AutoStatus) {
@@ -162,8 +175,9 @@ func (s *Scheduler) CheckNow(ctx context.Context) (Status, error) {
 			status.LastCheckAt = &checkedAt
 			status.AvailableVersion = ""
 		})
+		persistErr := s.persistLastCheck(checkedAt)
 		s.cfg.Logger.Info("automatic update check completed", "current_version", checked.CurrentVersion, "update_available", false)
-		return checked, nil
+		return checked, persistErr
 	}
 
 	s.updateStatus(func(status *AutoStatus) {
@@ -171,16 +185,17 @@ func (s *Scheduler) CheckNow(ctx context.Context) (Status, error) {
 		status.LastCheckAt = &checkedAt
 		status.AvailableVersion = checked.LatestVersion
 	})
+	persistErr := s.persistLastCheck(checkedAt)
 	s.cfg.Logger.Info("Detent update available", "current_version", checked.CurrentVersion, "latest_version", checked.LatestVersion, "auto_apply_enabled", s.cfg.AutoApplyEnabled)
 	if !s.cfg.AutoApplyEnabled {
-		return checked, nil
+		return checked, persistErr
 	}
 	if checked.InstallSource != InstallSourceRelease {
 		s.updateStatus(func(status *AutoStatus) {
 			status.State = "available_manual_apply"
 		})
 		s.cfg.Logger.Warn("automatic update apply skipped for non-release install", "install_source", checked.InstallSource, "latest_version", checked.LatestVersion)
-		return checked, nil
+		return checked, persistErr
 	}
 	releaseIdle, idle := s.cfg.ReserveIdle(ctx)
 	if !idle {
@@ -191,10 +206,11 @@ func (s *Scheduler) CheckNow(ctx context.Context) (Status, error) {
 			status.State = "pending_idle"
 		})
 		s.cfg.Logger.Info("automatic update apply deferred until runtime is idle", "version", checked.LatestVersion)
-		return checked, nil
+		return checked, persistErr
 	}
 
-	return s.applyLocked(ctx, releaseIdle)
+	applied, applyErr := s.applyLocked(ctx, releaseIdle)
+	return applied, errors.Join(persistErr, applyErr)
 }
 
 func (s *Scheduler) ApplyPending(ctx context.Context) (Status, error) {
@@ -246,8 +262,8 @@ func (s *Scheduler) applyLocked(ctx context.Context, releaseIdle func()) (Status
 		Stderr:    io.Discard,
 	})
 	if err != nil {
-		s.recordFailure(s.cfg.Now(), err)
-		return applied, fmt.Errorf("apply Detent update: %w", err)
+		persistErr := s.recordFailure(s.cfg.Now(), err)
+		return applied, fmt.Errorf("apply Detent update: %w", errors.Join(err, persistErr))
 	}
 	if applied.Action != ActionUpdated {
 		s.updateStatus(func(status *AutoStatus) {
@@ -294,12 +310,54 @@ func (s *Scheduler) Status() AutoStatus {
 	return cloneAutoStatus(s.status)
 }
 
-func (s *Scheduler) recordFailure(checkedAt time.Time, err error) {
+func (s *Scheduler) recordFailure(checkedAt time.Time, err error) error {
 	s.updateStatus(func(status *AutoStatus) {
 		status.State = "failed"
 		status.LastCheckAt = &checkedAt
 		status.LastError = err.Error()
 	})
+	persistErr := s.persistLastCheck(checkedAt)
+	if persistErr != nil {
+		s.updateStatus(func(status *AutoStatus) {
+			status.LastError = errors.Join(err, persistErr).Error()
+		})
+	}
+	return persistErr
+}
+
+func (s *Scheduler) persistLastCheck(checkedAt time.Time) error {
+	if err := saveSchedulerState(s.cfg.StatePath, checkedAt); err != nil {
+		wrapped := fmt.Errorf("persist automatic update state: %w", err)
+		s.updateStatus(func(status *AutoStatus) {
+			status.LastError = wrapped.Error()
+		})
+		return wrapped
+	}
+	return nil
+}
+
+func (s *Scheduler) nextCheck() (time.Duration, time.Time) {
+	jittered := s.cfg.NextDelay(s.cfg.CheckInterval)
+	if jittered <= 0 || jittered > s.cfg.CheckInterval {
+		jittered = s.cfg.CheckInterval
+	}
+	now := s.cfg.Now()
+	status := s.Status()
+	if status.LastCheckAt == nil {
+		if strings.TrimSpace(s.cfg.StatePath) != "" {
+			return 0, now
+		}
+		return jittered, now.Add(jittered)
+	}
+	next := status.LastCheckAt.Add(jittered)
+	remaining := next.Sub(now)
+	if remaining <= 0 {
+		return 0, now
+	}
+	if remaining > s.cfg.CheckInterval {
+		return s.cfg.CheckInterval, now.Add(s.cfg.CheckInterval)
+	}
+	return remaining, next
 }
 
 func (s *Scheduler) updateStatus(update func(*AutoStatus)) {

--- a/internal/update/scheduler_state.go
+++ b/internal/update/scheduler_state.go
@@ -1,0 +1,101 @@
+package update
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+const schedulerStateSchema = 1
+
+type schedulerState struct {
+	Schema      int       `json:"schema"`
+	LastCheckAt time.Time `json:"last_check_at"`
+}
+
+func loadSchedulerState(path string) (time.Time, bool, error) {
+	path = strings.TrimSpace(path)
+	if path == "" {
+		return time.Time{}, false, nil
+	}
+	raw, err := os.ReadFile(path)
+	if errors.Is(err, os.ErrNotExist) {
+		return time.Time{}, false, nil
+	}
+	if err != nil {
+		return time.Time{}, false, fmt.Errorf("read scheduler state: %w", err)
+	}
+	var state schedulerState
+	if err := json.Unmarshal(raw, &state); err != nil {
+		return time.Time{}, false, fmt.Errorf("decode scheduler state: %w", err)
+	}
+	if state.Schema != schedulerStateSchema {
+		return time.Time{}, false, fmt.Errorf("decode scheduler state: unsupported schema %d", state.Schema)
+	}
+	if state.LastCheckAt.IsZero() {
+		return time.Time{}, false, errors.New("decode scheduler state: last check timestamp is required")
+	}
+	return state.LastCheckAt, true, nil
+}
+
+func saveSchedulerState(path string, lastCheckAt time.Time) (saveErr error) {
+	path = strings.TrimSpace(path)
+	if path == "" {
+		return nil
+	}
+	if lastCheckAt.IsZero() {
+		return errors.New("save scheduler state: last check timestamp is required")
+	}
+	raw, err := json.Marshal(schedulerState{
+		Schema:      schedulerStateSchema,
+		LastCheckAt: lastCheckAt.UTC(),
+	})
+	if err != nil {
+		return fmt.Errorf("encode scheduler state: %w", err)
+	}
+	directory := filepath.Dir(path)
+	if err := os.MkdirAll(directory, 0o755); err != nil {
+		return fmt.Errorf("create scheduler state directory: %w", err)
+	}
+	temporary, err := os.CreateTemp(directory, ".update-scheduler-*")
+	if err != nil {
+		return fmt.Errorf("create temporary scheduler state: %w", err)
+	}
+	temporaryPath := temporary.Name()
+	defer func() {
+		if temporaryPath == "" {
+			return
+		}
+		if err := os.Remove(temporaryPath); err != nil && !errors.Is(err, os.ErrNotExist) {
+			saveErr = errors.Join(saveErr, fmt.Errorf("remove temporary scheduler state: %w", err))
+		}
+	}()
+	if err := temporary.Chmod(0o600); err != nil {
+		return closeSchedulerState(temporary, fmt.Errorf("secure temporary scheduler state: %w", err))
+	}
+	if _, err := temporary.Write(raw); err != nil {
+		return closeSchedulerState(temporary, fmt.Errorf("write temporary scheduler state: %w", err))
+	}
+	if err := temporary.Sync(); err != nil {
+		return closeSchedulerState(temporary, fmt.Errorf("sync temporary scheduler state: %w", err))
+	}
+	if err := temporary.Close(); err != nil {
+		return fmt.Errorf("close temporary scheduler state: %w", err)
+	}
+	if err := os.Rename(temporaryPath, path); err != nil {
+		return fmt.Errorf("replace scheduler state: %w", err)
+	}
+	temporaryPath = ""
+	return nil
+}
+
+func closeSchedulerState(file *os.File, operationErr error) error {
+	if err := file.Close(); err != nil {
+		return errors.Join(operationErr, fmt.Errorf("close temporary scheduler state: %w", err))
+	}
+	return operationErr
+}

--- a/internal/update/scheduler_test.go
+++ b/internal/update/scheduler_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"sync"
 	"testing"
@@ -368,6 +369,9 @@ func TestSchedulerRunPollsPendingUpdateUntilIdle(t *testing.T) {
 		},
 		RequestRestart: func(string) bool { return true },
 		NextDelay:      func(interval time.Duration) time.Duration { return interval },
+		Now: func() time.Time {
+			return time.Date(2026, 7, 30, 12, 0, 0, 0, time.UTC)
+		},
 		Wait: func(_ context.Context, delay time.Duration) bool {
 			delays = append(delays, delay)
 			switch len(delays) {
@@ -439,6 +443,156 @@ func TestSchedulerRunUsesPeriodicWaitAndStopsWithContext(t *testing.T) {
 	}
 }
 
+func TestSchedulerRestartMidIntervalPreservesRemainingDelay(t *testing.T) {
+	t.Parallel()
+
+	statePath := filepath.Join(t.TempDir(), "update-state.json")
+	lastCheckAt := time.Date(2026, 7, 30, 10, 0, 0, 0, time.UTC)
+	seedSchedulerLastCheck(t, statePath, lastCheckAt)
+
+	now := lastCheckAt.Add(time.Hour)
+	var delays []time.Duration
+	updater := &schedulerUpdaterStub{}
+	scheduler, err := NewScheduler(SchedulerConfig{
+		Enabled:       true,
+		CheckInterval: 4 * time.Hour,
+		StatePath:     statePath,
+		Updater:       updater,
+		Now:           func() time.Time { return now },
+		NextDelay:     func(time.Duration) time.Duration { return 3 * time.Hour },
+		Wait: func(_ context.Context, delay time.Duration) bool {
+			delays = append(delays, delay)
+			return false
+		},
+	})
+	if err != nil {
+		t.Fatalf("NewScheduler() error = %v", err)
+	}
+
+	scheduler.Run(context.Background())
+	if updater.checkCalls != 0 {
+		t.Fatalf("Check() calls = %d, want 0 before persisted interval elapses", updater.checkCalls)
+	}
+	if len(delays) != 1 || delays[0] != 2*time.Hour {
+		t.Fatalf("wait delays = %v, want [2h]", delays)
+	}
+	status := scheduler.Status()
+	if status.LastCheckAt == nil || !status.LastCheckAt.Equal(lastCheckAt) {
+		t.Fatalf("LastCheckAt = %v, want %v", status.LastCheckAt, lastCheckAt)
+	}
+	wantNext := lastCheckAt.Add(3 * time.Hour)
+	if status.NextCheckAt == nil || !status.NextCheckAt.Equal(wantNext) {
+		t.Fatalf("NextCheckAt = %v, want %v", status.NextCheckAt, wantNext)
+	}
+}
+
+func TestSchedulerRestartAfterIntervalChecksBeforeWaiting(t *testing.T) {
+	t.Parallel()
+
+	statePath := filepath.Join(t.TempDir(), "update-state.json")
+	lastCheckAt := time.Date(2026, 7, 30, 10, 0, 0, 0, time.UTC)
+	seedSchedulerLastCheck(t, statePath, lastCheckAt)
+
+	now := lastCheckAt.Add(4 * time.Hour)
+	updater := &schedulerUpdaterStub{}
+	scheduler, err := NewScheduler(SchedulerConfig{
+		Enabled:       true,
+		CheckInterval: 4 * time.Hour,
+		StatePath:     statePath,
+		Updater:       updater,
+		Now:           func() time.Time { return now },
+		NextDelay:     func(time.Duration) time.Duration { return 3 * time.Hour },
+		Wait: func(_ context.Context, delay time.Duration) bool {
+			if updater.checkCalls != 1 {
+				t.Fatalf("Check() calls before first wait = %d, want 1", updater.checkCalls)
+			}
+			if delay != 3*time.Hour {
+				t.Fatalf("wait delay after prompt check = %v, want 3h", delay)
+			}
+			return false
+		},
+	})
+	if err != nil {
+		t.Fatalf("NewScheduler() error = %v", err)
+	}
+
+	scheduler.Run(context.Background())
+	if updater.checkCalls != 1 {
+		t.Fatalf("Check() calls = %d, want 1", updater.checkCalls)
+	}
+
+	restarted, err := NewScheduler(SchedulerConfig{
+		Enabled:       true,
+		CheckInterval: 4 * time.Hour,
+		StatePath:     statePath,
+		Updater:       &schedulerUpdaterStub{},
+	})
+	if err != nil {
+		t.Fatalf("NewScheduler() reload error = %v", err)
+	}
+	if got := restarted.Status().LastCheckAt; got == nil || !got.Equal(now) {
+		t.Fatalf("reloaded LastCheckAt = %v, want %v", got, now)
+	}
+}
+
+func TestSchedulerRepeatedRapidRestartsCannotStarveCheck(t *testing.T) {
+	t.Parallel()
+
+	statePath := filepath.Join(t.TempDir(), "update-state.json")
+	lastCheckAt := time.Date(2026, 7, 30, 10, 0, 0, 0, time.UTC)
+	seedSchedulerLastCheck(t, statePath, lastCheckAt)
+
+	for restart, wantDelay := range []time.Duration{2 * time.Hour, time.Hour} {
+		now := lastCheckAt.Add(time.Duration(restart+1) * time.Hour)
+		updater := &schedulerUpdaterStub{}
+		scheduler, err := NewScheduler(SchedulerConfig{
+			Enabled:       true,
+			CheckInterval: 4 * time.Hour,
+			StatePath:     statePath,
+			Updater:       updater,
+			Now:           func() time.Time { return now },
+			NextDelay:     func(time.Duration) time.Duration { return 3 * time.Hour },
+			Wait: func(_ context.Context, delay time.Duration) bool {
+				if delay != wantDelay {
+					t.Fatalf("restart %d delay = %v, want %v", restart+1, delay, wantDelay)
+				}
+				return false
+			},
+		})
+		if err != nil {
+			t.Fatalf("NewScheduler() restart %d error = %v", restart+1, err)
+		}
+		scheduler.Run(context.Background())
+		if updater.checkCalls != 0 {
+			t.Fatalf("restart %d Check() calls = %d, want 0", restart+1, updater.checkCalls)
+		}
+	}
+
+	now := lastCheckAt.Add(3 * time.Hour)
+	updater := &schedulerUpdaterStub{}
+	scheduler, err := NewScheduler(SchedulerConfig{
+		Enabled:       true,
+		CheckInterval: 4 * time.Hour,
+		StatePath:     statePath,
+		Updater:       updater,
+		Now:           func() time.Time { return now },
+		NextDelay:     func(time.Duration) time.Duration { return 3 * time.Hour },
+		Wait: func(_ context.Context, delay time.Duration) bool {
+			if updater.checkCalls != 1 {
+				t.Fatalf("Check() calls before wait = %d, want 1", updater.checkCalls)
+			}
+			return false
+		},
+	})
+	if err != nil {
+		t.Fatalf("NewScheduler() due restart error = %v", err)
+	}
+	scheduler.Run(context.Background())
+	if updater.checkCalls != 1 {
+		t.Fatalf("due restart Check() calls = %d, want 1", updater.checkCalls)
+	}
+}
+
 func TestSchedulerRecordsCheckFailure(t *testing.T) {
 	t.Parallel()
 
@@ -457,6 +611,72 @@ func TestSchedulerRecordsCheckFailure(t *testing.T) {
 	}
 	if got := scheduler.Status(); got.State != "failed" || got.LastError != wantErr.Error() || got.LastCheckAt == nil {
 		t.Fatalf("Status() = %#v, want recorded failure", got)
+	}
+}
+
+func TestSchedulerCanceledCheckPreservesLastCheck(t *testing.T) {
+	t.Parallel()
+
+	statePath := filepath.Join(t.TempDir(), "update-state.json")
+	lastCheckAt := time.Date(2026, 7, 30, 10, 0, 0, 0, time.UTC)
+	seedSchedulerLastCheck(t, statePath, lastCheckAt)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	scheduler, err := NewScheduler(SchedulerConfig{
+		Enabled:       true,
+		CheckInterval: 4 * time.Hour,
+		StatePath:     statePath,
+		Updater:       &schedulerUpdaterStub{checkErr: context.Canceled},
+		Now:           func() time.Time { return lastCheckAt.Add(5 * time.Hour) },
+	})
+	if err != nil {
+		t.Fatalf("NewScheduler() error = %v", err)
+	}
+
+	if _, err := scheduler.CheckNow(ctx); !errors.Is(err, context.Canceled) {
+		t.Fatalf("CheckNow() error = %v, want context cancellation", err)
+	}
+	if got := scheduler.Status().LastCheckAt; got == nil || !got.Equal(lastCheckAt) {
+		t.Fatalf("LastCheckAt = %v, want preserved %v", got, lastCheckAt)
+	}
+
+	restarted, err := NewScheduler(SchedulerConfig{
+		Enabled:       true,
+		CheckInterval: 4 * time.Hour,
+		StatePath:     statePath,
+		Updater:       &schedulerUpdaterStub{},
+	})
+	if err != nil {
+		t.Fatalf("NewScheduler() reload error = %v", err)
+	}
+	if got := restarted.Status().LastCheckAt; got == nil || !got.Equal(lastCheckAt) {
+		t.Fatalf("reloaded LastCheckAt = %v, want preserved %v", got, lastCheckAt)
+	}
+}
+
+func TestSchedulerReportsStatePersistenceFailure(t *testing.T) {
+	t.Parallel()
+
+	statePath := filepath.Join(t.TempDir(), "update-state.json")
+	if err := os.Mkdir(statePath, 0o700); err != nil {
+		t.Fatalf("Mkdir() error = %v", err)
+	}
+	scheduler, err := NewScheduler(SchedulerConfig{
+		Enabled:       true,
+		CheckInterval: time.Hour,
+		StatePath:     statePath,
+		Updater:       &schedulerUpdaterStub{},
+	})
+	if err != nil {
+		t.Fatalf("NewScheduler() error = %v", err)
+	}
+
+	if _, err := scheduler.CheckNow(context.Background()); err == nil || !strings.Contains(err.Error(), "persist automatic update state") {
+		t.Fatalf("CheckNow() error = %v, want persistence failure", err)
+	}
+	if got := scheduler.Status(); !strings.Contains(got.LastError, "persist automatic update state") {
+		t.Fatalf("LastError = %q, want persistence failure", got.LastError)
 	}
 }
 
@@ -485,6 +705,30 @@ func TestSchedulerDisabledPreservesManualOnlyBehavior(t *testing.T) {
 	}
 	if got := scheduler.Status(); got.State != "disabled" || got.Enabled || got.LastAppliedVersion != "1.2.2" {
 		t.Fatalf("Status() = %#v, want disabled", got)
+	}
+}
+
+func seedSchedulerLastCheck(t *testing.T, statePath string, checkedAt time.Time) {
+	t.Helper()
+	scheduler, err := NewScheduler(SchedulerConfig{
+		Enabled:       true,
+		CheckInterval: 4 * time.Hour,
+		StatePath:     statePath,
+		Updater:       &schedulerUpdaterStub{},
+		Now:           func() time.Time { return checkedAt },
+	})
+	if err != nil {
+		t.Fatalf("NewScheduler() seed error = %v", err)
+	}
+	if _, err := scheduler.CheckNow(context.Background()); err != nil {
+		t.Fatalf("CheckNow() seed error = %v", err)
+	}
+	info, err := os.Stat(statePath)
+	if err != nil {
+		t.Fatalf("Stat() scheduler state error = %v", err)
+	}
+	if runtime.GOOS != "windows" && info.Mode().Perm() != 0o600 {
+		t.Fatalf("scheduler state mode = %o, want 600", info.Mode().Perm())
 	}
 }
 


### PR DESCRIPTION
## Summary

- persist the automatic update last-check timestamp in an atomic runtime sidecar
- schedule jittered checks from persisted state so restarts preserve elapsed time and overdue startup checks run promptly
- lower the default interval to six hours and document the release-uptake rationale
- keep last/next check visibility in doctor backed by restored scheduler state

Fixes #1595

## UI Surface Contract

- [x] N/A, or the linked issue explicitly authorizes any high-impact UI surface, layout, density, first-viewport, or responsive visibility tradeoff.
- [x] Persistent top-of-screen messaging is explicitly authorized by the issue, or this PR does not add it.
- [x] Visual changes to primary operator screens include screenshot or browser verification below. N/A: no visual changes.

## Test Plan

- [x] `go test ./internal/update ./internal/cli ./internal/config/global`
- [x] `go test ./internal/config/configdoc`
- [x] `make check`