### PR TITLE
fix(staleness): ignore successful decisions

### DIFF
--- a/config.reference.yaml
+++ b/config.reference.yaml
@@ -881,8 +881,8 @@
 #     no_merge_hours: 12
 #     # observability.staleness.repeated_decision_count | type: integer | default: 20 | required: No | validation: must be greater than 0
 #     repeated_decision_count: 20
-#     # observability.staleness.repeated_decision_benign_reasons | type: list<string> | default: ["already_running","blocked_by_dependency","github_rest_capacity_paused","github_rest_recovery","global_capacity_full"] | required: No | validation: None
-#     repeated_decision_benign_reasons: ["already_running","blocked_by_dependency","github_rest_capacity_paused","github_rest_recovery","global_capacity_full"]
+#     # observability.staleness.repeated_decision_benign_reasons | type: list<string> | default: ["already_running","blocked_by_dependency","github_rest_capacity_paused","github_rest_recovery","global_capacity_full","reserved_for_higher_priority_project"] | required: No | validation: None
+#     repeated_decision_benign_reasons: ["already_running","blocked_by_dependency","github_rest_capacity_paused","github_rest_recovery","global_capacity_full","reserved_for_higher_priority_project"]
 #     # observability.staleness.repeated_window_hours | type: integer | default: 24 | required: No | validation: must be greater than 0
 #     repeated_window_hours: 24
 #     # observability.staleness.webhook | type: object | default: see child fields | required: No | validation: None

--- a/docs/config.md
+++ b/docs/config.md
@@ -482,7 +482,7 @@ rendering and fails on drift.
 | `observability.staleness.lanes[].threshold_hours` | `integer` | `72` | No | must be greater than 0 |
 | `observability.staleness.no_completion_hours` | `integer` | `24` | No | must be greater than 0 |
 | `observability.staleness.no_merge_hours` | `integer` | `12` | No | must be greater than 0 |
-| `observability.staleness.repeated_decision_benign_reasons` | `list<string>` | `["already_running","blocked_by_dependency","github_rest_capacity_paused","github_rest_recovery","global_capacity_full"]` | No | None |
+| `observability.staleness.repeated_decision_benign_reasons` | `list<string>` | `["already_running","blocked_by_dependency","github_rest_capacity_paused","github_rest_recovery","global_capacity_full","reserved_for_higher_priority_project"]` | No | None |
 | `observability.staleness.repeated_decision_count` | `integer` | `20` | No | must be greater than 0 |
 | `observability.staleness.repeated_window_hours` | `integer` | `24` | No | must be greater than 0 |
 | `observability.staleness.webhook` | `object` | `see child fields` | No | None |

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -2606,6 +2606,7 @@ func defaultStalenessRepeatedDecisionBenignReasons() []string {
 		"github_rest_capacity_paused",
 		"github_rest_recovery",
 		"global_capacity_full",
+		"reserved_for_higher_priority_project",
 	}
 }
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1839,6 +1839,7 @@ func TestDefaultStalenessObservability(t *testing.T) {
 		"github_rest_capacity_paused",
 		"github_rest_recovery",
 		"global_capacity_full",
+		"reserved_for_higher_priority_project",
 	}
 	if got := cfg.Observability.Staleness.RepeatedDecisionBenignReasons; !slices.Equal(got, wantReasons) {
 		t.Fatalf("RepeatedDecisionBenignReasons = %#v, want %#v", got, wantReasons)

--- a/internal/orchestrator/staleness.go
+++ b/internal/orchestrator/staleness.go
@@ -181,6 +181,7 @@ func stalenessDecisions(decisions []telemetry.SchedulerDecision, issues map[stri
 			CurrentState: strings.TrimSpace(issue.State),
 			Closed:       issue.Closed,
 			Merged:       pullRequestMerged(issue.PullRequest),
+			Result:       strings.TrimSpace(decision.Result),
 			Reason:       strings.TrimSpace(decision.Reason),
 			At:           decision.DecisionAt.UTC(),
 		})

--- a/internal/orchestrator/staleness_test.go
+++ b/internal/orchestrator/staleness_test.go
@@ -188,7 +188,7 @@ func TestStalenessDecisionsCarryCurrentIssueState(t *testing.T) {
 		},
 	}
 	decisions := []telemetry.SchedulerDecision{
-		{IssueID: "issue-closed", Reason: "merge_slot_revoked", DecisionAt: now},
+		{IssueID: "issue-closed", Result: "skipped", Reason: "merge_slot_revoked", DecisionAt: now},
 		{IssueID: "issue-merged", Reason: "merge_slot_revoked", DecisionAt: now},
 		{IssueID: "issue-stale-completed", Reason: "merge_slot_revoked", DecisionAt: now},
 		{IssueID: "issue-gone", Reason: "merge_slot_revoked", DecisionAt: now},
@@ -200,6 +200,9 @@ func TestStalenessDecisionsCarryCurrentIssueState(t *testing.T) {
 	}
 	if got[0].CurrentState != "Done" || !got[0].Closed {
 		t.Fatalf("closed decision = %#v, want current Done and closed", got[0])
+	}
+	if got[0].Result != "skipped" {
+		t.Fatalf("closed decision result = %q, want skipped", got[0].Result)
 	}
 	if got[1].CurrentState != "Merging" || !got[1].Merged {
 		t.Fatalf("merged decision = %#v, want current Merging and merged", got[1])

--- a/internal/staleness/staleness.go
+++ b/internal/staleness/staleness.go
@@ -65,6 +65,7 @@ type Decision struct {
 	CurrentState string
 	Closed       bool
 	Merged       bool
+	Result       string
 	Reason       string
 	At           time.Time
 }
@@ -228,9 +229,11 @@ func repeatedDecisionWarnings(cfg Config, input Input, now time.Time) []Warning 
 	groups := make(map[string]group)
 	for _, decision := range input.Decisions {
 		identity := decisionIdentity(decision)
+		result := normalize(decision.Result)
 		reason := strings.TrimSpace(decision.Reason)
 		currentState := normalize(decision.CurrentState)
 		if identity == "" ||
+			result != "skipped" ||
 			reason == "" ||
 			currentState == "" ||
 			decision.Closed ||

--- a/internal/staleness/staleness_test.go
+++ b/internal/staleness/staleness_test.go
@@ -76,10 +76,10 @@ func TestEvaluate(t *testing.T) {
 			input: Input{
 				ProjectID: "detent",
 				Decisions: []Decision{
-					{IssueID: "3", CurrentState: "Merging", Reason: "merge_slot_revoked", At: now.Add(-3 * time.Hour)},
-					{IssueID: "3", CurrentState: "Merging", Reason: "merge_slot_revoked", At: now.Add(-2 * time.Hour)},
-					{IssueID: "3", CurrentState: "Merging", Reason: "merge_slot_revoked", At: now.Add(-time.Hour)},
-					{IssueID: "3", CurrentState: "Merging", Reason: "other", At: now.Add(-time.Hour)},
+					{IssueID: "3", CurrentState: "Merging", Result: "skipped", Reason: "merge_slot_revoked", At: now.Add(-3 * time.Hour)},
+					{IssueID: "3", CurrentState: "Merging", Result: "skipped", Reason: "merge_slot_revoked", At: now.Add(-2 * time.Hour)},
+					{IssueID: "3", CurrentState: "Merging", Result: "skipped", Reason: "merge_slot_revoked", At: now.Add(-time.Hour)},
+					{IssueID: "3", CurrentState: "Merging", Result: "skipped", Reason: "other", At: now.Add(-time.Hour)},
 				},
 			},
 			wantKinds: []string{KindRepeatedDecision},
@@ -119,6 +119,7 @@ func TestEvaluateRepeatedDecisions(t *testing.T) {
 			"github_rest_capacity_paused",
 			"github_rest_recovery",
 			"global_capacity_full",
+			"reserved_for_higher_priority_project",
 		},
 		TerminalStates: []string{"Done", "Cancelled", "Canceled"},
 	}
@@ -148,6 +149,17 @@ func TestEvaluateRepeatedDecisions(t *testing.T) {
 		{
 			name:      "REST recovery stays quiet",
 			decisions: repeatedDecisions(now.Add(-time.Hour), 20, 3*time.Minute, "github_rest_recovery", "Todo"),
+		},
+		{
+			name:      "priority reservation stays quiet",
+			decisions: repeatedDecisions(now.Add(-time.Hour), 20, 3*time.Minute, "reserved_for_higher_priority_project", "Todo"),
+		},
+		{
+			name: "successful selections stay quiet regardless of count",
+			decisions: mutateDecisions(
+				repeatedDecisions(now.Add(-4*time.Hour), 104, 2*time.Minute, "selected", "Todo"),
+				func(decision *Decision) { decision.Result = "selected" },
+			),
 		},
 		{
 			name: "operator configured reason stays quiet",
@@ -212,6 +224,7 @@ func repeatedDecisions(start time.Time, count int, interval time.Duration, reaso
 			IssueID:      "issue-1",
 			Identifier:   "digitaldrywood/detent#1",
 			CurrentState: state,
+			Result:       "skipped",
 			Reason:       reason,
 			At:           start.Add(time.Duration(index) * interval),
 		})


### PR DESCRIPTION
## Summary

- restrict repeated-decision warnings to scheduler decisions whose result is `skipped`
- treat `reserved_for_higher_priority_project` as benign by default
- add table-driven coverage for 104 successful selections, priority pacing, configured benign reasons, and genuine stalled skips
- refresh generated configuration references

Fixes #1598

## UI Surface Contract

- [x] N/A, or the linked issue explicitly authorizes any high-impact UI surface, layout, density, first-viewport, or responsive visibility tradeoff.
- [x] Persistent top-of-screen messaging is explicitly authorized by the issue, or this PR does not add it.
- [x] Visual changes to primary operator screens include screenshot or browser verification below. N/A: no visual changes.

## Test Plan

- [x] `go test ./internal/staleness ./internal/config ./internal/orchestrator`
- [x] `make check`