### PR TITLE
fix(scheduler): preserve idle project demand state

### DIFF
--- a/.detent/skills/demand-driven-priority-reservations.md
+++ b/.detent/skills/demand-driven-priority-reservations.md
@@ -1,0 +1,15 @@
+---
+name: demand-driven-priority-reservations
+description: Diagnose and test strict scheduler reservations that confuse project liveness or stale cycle state with pending dispatch demand.
+when_to_use: Use when lower-priority work reports a priority reservation despite free global capacity, no slot holders, or an empty higher-priority queue.
+---
+
+# Keep priority reservations demand-driven
+
+1. Reproduce the contradiction at the capacity gate and capture the decision reason, selected project, capacity, usage, and holders.
+2. Trace every transition of the reserving project's demand state. Include empty scan completion, ready registration, acquisition, release, reconfiguration, and shutdown rather than searching only for explicit idle calls.
+3. Treat an empty completed scan as idle until that same project begins a new scan or registers ready work. Unrelated slot releases must not create demand or invalidate the idle result.
+4. Clear idle state at the earliest project-owned demand signal so a newly ready higher-priority project reclaims precedence immediately.
+5. Use a table-driven regression with three cases: an idle higher-priority project stays idle across another project's acquire and release; pending higher-priority demand reserves capacity; and an idle-to-ready transition restores the reservation.
+6. Assert both admission and diagnostics. A free idle fleet must grant the lower request instead of emitting a priority reservation, while genuine contention must retain the priority reservation reason.
+7. Run the focused test before and after the fix, then run the scheduler race tests and the repository validation gate.

--- a/.detent/skills/demand-driven-priority-reservations.md
+++ b/.detent/skills/demand-driven-priority-reservations.md
@@ -8,8 +8,8 @@ when_to_use: Use when lower-priority work reports a priority reservation despite
 
 1. Reproduce the contradiction at the capacity gate and capture the decision reason, selected project, capacity, usage, and holders.
 2. Trace every transition of the reserving project's demand state. Include empty scan completion, ready registration, acquisition, release, reconfiguration, and shutdown rather than searching only for explicit idle calls.
-3. Treat an empty completed scan as idle until that same project begins a new scan or registers ready work. Unrelated slot releases must not create demand or invalidate the idle result.
+3. Treat an empty completed scan as idle until that same project begins a new scan, registers ready work, or releases one of its own slots and may have capacity for work skipped during the scan. Unrelated slot releases must not create demand or invalidate the idle result.
 4. Clear idle state at the earliest project-owned demand signal so a newly ready higher-priority project reclaims precedence immediately.
-5. Use a table-driven regression with three cases: an idle higher-priority project stays idle across another project's acquire and release; pending higher-priority demand reserves capacity; and an idle-to-ready transition restores the reservation.
+5. Use a table-driven regression with four cases: an idle higher-priority project stays idle across another project's acquire and release; its own slot release invalidates idle state; pending higher-priority demand reserves capacity; and an idle-to-ready transition restores the reservation.
 6. Assert both admission and diagnostics. A free idle fleet must grant the lower request instead of emitting a priority reservation, while genuine contention must retain the priority reservation reason.
 7. Run the focused test before and after the fix, then run the scheduler race tests and the repository validation gate.

--- a/internal/scheduler/global_gate.go
+++ b/internal/scheduler/global_gate.go
@@ -74,8 +74,7 @@ type selectedProjectSlot struct {
 }
 
 type projectCycleState struct {
-	epoch uint64
-	idle  bool
+	idle bool
 }
 
 type GlobalDispatchGate struct {
@@ -90,7 +89,6 @@ type GlobalDispatchGate struct {
 	projects       map[string]ProjectCandidate
 	projectCycles  map[string]projectCycleState
 	dispatchPauses int
-	epoch          uint64
 }
 
 func NewGlobalDispatchGate(global GlobalScheduler, projects ...ProjectCandidate) *GlobalDispatchGate {
@@ -106,7 +104,6 @@ func newGlobalDispatchGate(poolName string, global GlobalScheduler, projects ...
 		selected:      map[string]selectedProjectSlot{},
 		projects:      map[string]ProjectCandidate{},
 		projectCycles: map[string]projectCycleState{},
-		epoch:         1,
 	}
 	gate.SetProjects(projects)
 	return gate
@@ -212,10 +209,6 @@ func (g *GlobalDispatchGate) Reconfigure(cfg Config) error {
 	clear(g.selected)
 	if previousMode != g.global.Mode() {
 		clear(g.projectCycles)
-		g.epoch++
-		if g.epoch == 0 {
-			g.epoch = 1
-		}
 	}
 	return nil
 }
@@ -235,7 +228,7 @@ func (g *GlobalDispatchGate) BeginProjectCycle(project ProjectCandidate) {
 	g.projects[project.ID] = project
 	delete(g.ready, project.ID)
 	delete(g.selected, project.ID)
-	g.projectCycles[project.ID] = projectCycleState{epoch: g.epoch}
+	g.projectCycles[project.ID] = projectCycleState{}
 	if g.global.Mode() != ModeStrictPriority {
 		delete(g.projectCycles, project.ID)
 	}
@@ -254,7 +247,7 @@ func (g *GlobalDispatchGate) EndProjectCycle(projectID string) {
 	defer g.mu.Unlock()
 
 	_, waiting := g.ready[projectID]
-	g.projectCycles[projectID] = projectCycleState{epoch: g.epoch, idle: !waiting}
+	g.projectCycles[projectID] = projectCycleState{idle: !waiting}
 }
 
 func (g *GlobalDispatchGate) MarkReady(project ProjectCandidate) {
@@ -274,7 +267,7 @@ func (g *GlobalDispatchGate) MarkReady(project ProjectCandidate) {
 	ready.ProjectCandidate = project
 	g.ready[project.ID] = ready
 	if g.global.Mode() == ModeStrictPriority {
-		g.projectCycles[project.ID] = projectCycleState{epoch: g.epoch}
+		g.projectCycles[project.ID] = projectCycleState{}
 	}
 }
 
@@ -293,7 +286,7 @@ func (g *GlobalDispatchGate) MarkIdle(projectID string) {
 	delete(g.ready, projectID)
 	delete(g.selected, projectID)
 	if g.global != nil && g.global.Mode() == ModeStrictPriority {
-		g.projectCycles[projectID] = projectCycleState{epoch: g.epoch, idle: true}
+		g.projectCycles[projectID] = projectCycleState{idle: true}
 	}
 }
 
@@ -346,7 +339,7 @@ func (g *GlobalDispatchGate) TryAcquireWithDecision(
 		return Slot{}, false, g.decisionLocked(project.ID, req, DispatchGateReasonPaused), nil
 	}
 	if g.global.Mode() == ModeStrictPriority {
-		g.projectCycles[project.ID] = projectCycleState{epoch: g.epoch}
+		g.projectCycles[project.ID] = projectCycleState{}
 		if reservedProjectID, reservedReq, reserved := g.higherPriorityProjectReservationLocked(project); reserved {
 			return Slot{}, false, g.projectDecisionLocked(project.ID, req, reservedProjectID, reservedReq), nil
 		}
@@ -480,13 +473,6 @@ func (g *GlobalDispatchGate) Release(slot Slot) error {
 		return err
 	}
 	delete(g.running, slot.token)
-	if g.global.Mode() == ModeStrictPriority {
-		g.epoch++
-		if g.epoch == 0 {
-			g.epoch = 1
-			clear(g.projectCycles)
-		}
-	}
 	return nil
 }
 
@@ -701,7 +687,7 @@ func (g *GlobalDispatchGate) higherPriorityProjectReservationLocked(
 			continue
 		}
 		cycle, ok := g.projectCycles[projectID]
-		if ok && cycle.epoch == g.epoch && cycle.idle {
+		if ok && cycle.idle {
 			continue
 		}
 		rank := priorityRank(candidate.Priority)

--- a/internal/scheduler/global_gate.go
+++ b/internal/scheduler/global_gate.go
@@ -466,13 +466,17 @@ func (g *GlobalDispatchGate) Release(slot Slot) error {
 	g.mu.Lock()
 	defer g.mu.Unlock()
 
-	if _, ok := g.running[slot.token]; !ok {
+	running, ok := g.running[slot.token]
+	if !ok {
 		return nil
 	}
 	if err := g.global.ReleaseSlot(slot); err != nil {
 		return err
 	}
 	delete(g.running, slot.token)
+	if cycle, ok := g.projectCycles[running.ProjectID]; ok && cycle.idle {
+		g.projectCycles[running.ProjectID] = projectCycleState{}
+	}
 	return nil
 }
 

--- a/internal/scheduler/global_gate_test.go
+++ b/internal/scheduler/global_gate_test.go
@@ -700,6 +700,30 @@ func TestGlobalDispatchGateStrictProjectReservationTracksDemand(t *testing.T) {
 			wantReason:  scheduler.DispatchGateReasonGranted,
 		},
 		{
+			name: "higher priority project release invalidates its own idle state",
+			arrange: func(t *testing.T, gate *scheduler.GlobalDispatchGate, higher, _ scheduler.ProjectCandidate) {
+				t.Helper()
+				gate.BeginProjectCycle(higher)
+				slot, ok, decision, err := gate.TryAcquireWithDecision(
+					t.Context(),
+					higher,
+					scheduler.SlotRequest{State: "Todo"},
+					time.Date(2026, 7, 30, 9, 0, 0, 0, time.Local),
+				)
+				if err != nil {
+					t.Fatalf("higher TryAcquireWithDecision() error = %v", err)
+				}
+				if !ok {
+					t.Fatalf("higher TryAcquireWithDecision() decision = %#v, want granted", decision)
+				}
+				gate.EndProjectCycle(higher.ID)
+				if err := gate.Release(slot); err != nil {
+					t.Fatalf("higher Release() error = %v", err)
+				}
+			},
+			wantReason: scheduler.DispatchGateReasonReservedForHigherPriorityProject,
+		},
+		{
 			name: "pending higher priority project reserves capacity",
 			arrange: func(_ *testing.T, gate *scheduler.GlobalDispatchGate, higher, _ scheduler.ProjectCandidate) {
 				gate.MarkReady(higher)

--- a/internal/scheduler/global_gate_test.go
+++ b/internal/scheduler/global_gate_test.go
@@ -665,6 +665,99 @@ func TestGlobalDispatchGateStrictProjectPriorityUsesLeftoverCapacity(t *testing.
 	}
 }
 
+func TestGlobalDispatchGateStrictProjectReservationTracksDemand(t *testing.T) {
+	t.Parallel()
+
+	for _, tt := range []struct {
+		name        string
+		arrange     func(*testing.T, *scheduler.GlobalDispatchGate, scheduler.ProjectCandidate, scheduler.ProjectCandidate)
+		wantGranted bool
+		wantReason  string
+	}{
+		{
+			name: "idle higher priority project stays idle after capacity release",
+			arrange: func(t *testing.T, gate *scheduler.GlobalDispatchGate, higher, lower scheduler.ProjectCandidate) {
+				t.Helper()
+				gate.BeginProjectCycle(higher)
+				gate.EndProjectCycle(higher.ID)
+				slot, ok, decision, err := gate.TryAcquireWithDecision(
+					t.Context(),
+					lower,
+					scheduler.SlotRequest{State: "Todo"},
+					time.Date(2026, 7, 30, 9, 0, 0, 0, time.Local),
+				)
+				if err != nil {
+					t.Fatalf("initial lower TryAcquireWithDecision() error = %v", err)
+				}
+				if !ok {
+					t.Fatalf("initial lower TryAcquireWithDecision() decision = %#v, want granted", decision)
+				}
+				if err := gate.Release(slot); err != nil {
+					t.Fatalf("initial lower Release() error = %v", err)
+				}
+			},
+			wantGranted: true,
+			wantReason:  scheduler.DispatchGateReasonGranted,
+		},
+		{
+			name: "pending higher priority project reserves capacity",
+			arrange: func(_ *testing.T, gate *scheduler.GlobalDispatchGate, higher, _ scheduler.ProjectCandidate) {
+				gate.MarkReady(higher)
+			},
+			wantReason: scheduler.DispatchGateReasonReservedForHigherPriorityProject,
+		},
+		{
+			name: "idle to ready higher priority project reclaims reservation",
+			arrange: func(_ *testing.T, gate *scheduler.GlobalDispatchGate, higher, _ scheduler.ProjectCandidate) {
+				gate.BeginProjectCycle(higher)
+				gate.EndProjectCycle(higher.ID)
+				gate.MarkReady(higher)
+			},
+			wantReason: scheduler.DispatchGateReasonReservedForHigherPriorityProject,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			higher := scheduler.ProjectCandidate{ID: "detent", Weight: 1, Priority: 0}
+			lower := scheduler.ProjectCandidate{ID: "gopher-ai", Weight: 1, Priority: 3}
+			gate := scheduler.NewGlobalDispatchGate(
+				scheduler.NewStrictPriority(scheduler.Config{Capacity: 1}),
+				higher,
+				lower,
+			)
+			tt.arrange(t, gate, higher, lower)
+
+			gate.BeginProjectCycle(lower)
+			slot, granted, decision, err := gate.TryAcquireWithDecision(
+				t.Context(),
+				lower,
+				scheduler.SlotRequest{State: "Todo"},
+				time.Date(2026, 7, 30, 9, 1, 0, 0, time.Local),
+			)
+			gate.EndProjectCycle(lower.ID)
+			if err != nil {
+				t.Fatalf("lower TryAcquireWithDecision() error = %v", err)
+			}
+			if granted != tt.wantGranted || decision.Reason != tt.wantReason {
+				t.Fatalf(
+					"lower TryAcquireWithDecision() granted = %t reason = %q, want granted = %t reason = %q; decision = %#v",
+					granted,
+					decision.Reason,
+					tt.wantGranted,
+					tt.wantReason,
+					decision,
+				)
+			}
+			if granted {
+				if err := gate.Release(slot); err != nil {
+					t.Fatalf("lower Release() error = %v", err)
+				}
+			}
+		})
+	}
+}
+
 func TestGlobalDispatchGateNonStrictModesDoNotReserveForProjectPriority(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

- keep completed empty project scans idle across unrelated global slot releases
- clear an idle result when that project releases its own slot and may have newly dispatchable work
- preserve strict priority as soon as a higher-priority project registers demand
- add regression coverage for idle, contended, own-release, and idle-to-ready transitions
- draft a reusable demand-driven reservation debugging skill

Fixes #1600

## UI Surface Contract

- [x] N/A; this PR does not change UI surfaces.
- [x] This PR does not add persistent top-of-screen messaging.
- [x] N/A; this PR has no visual changes.

## Test Plan

- [x] `go test -race ./internal/scheduler -count=1`
- [x] `go test -race ./internal/orchestrator ./internal/cli -count=1`
- [x] `make check`