### PR TITLE
fix(admission): clear released candidate

### DIFF
--- a/internal/admission/manager.go
+++ b/internal/admission/manager.go
@@ -1118,7 +1118,11 @@ func acquireCapacity(ctx context.Context, settings Settings, now time.Time) (fun
 		return func() error { return nil }, false, "fleet_capacity", releaseLocal()
 	}
 	return func() error {
-		return errors.Join(settings.GlobalDispatchGate.Release(slot), releaseLocal())
+		releaseGlobal := settings.GlobalDispatchGate.Release(slot)
+		if releaseGlobal == nil {
+			settings.GlobalDispatchGate.MarkIdle(candidate.ID)
+		}
+		return errors.Join(releaseGlobal, releaseLocal())
 	}, true, "", nil
 }
 

--- a/internal/admission/manager.go
+++ b/internal/admission/manager.go
@@ -1114,13 +1114,13 @@ func acquireCapacity(ctx context.Context, settings Settings, now time.Time) (fun
 		return func() error { return nil }, false, "", errors.Join(err, releaseLocal())
 	}
 	if !acquired {
-		settings.GlobalDispatchGate.MarkIdle(candidate.ID)
+		settings.GlobalDispatchGate.MarkIdle(candidate)
 		return func() error { return nil }, false, "fleet_capacity", releaseLocal()
 	}
 	return func() error {
 		releaseGlobal := settings.GlobalDispatchGate.Release(slot)
 		if releaseGlobal == nil {
-			settings.GlobalDispatchGate.MarkIdle(candidate.ID)
+			settings.GlobalDispatchGate.MarkIdle(candidate)
 		}
 		return errors.Join(releaseGlobal, releaseLocal())
 	}, true, "", nil

--- a/internal/admission/manager_test.go
+++ b/internal/admission/manager_test.go
@@ -1141,6 +1141,100 @@ func TestManagerDefersForCapacityAndBudget(t *testing.T) {
 	}
 }
 
+func TestAcquireCapacityReleaseClearsDerivedAdmissionReservation(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 7, 31, 13, 2, 34, 0, time.UTC)
+	higher := scheduler.ProjectCandidate{ID: "detent", Priority: 0}
+	lower := scheduler.ProjectCandidate{ID: "gopher-ai", Priority: 3}
+	gate := scheduler.NewGlobalDispatchGate(
+		scheduler.NewStrictPriority(scheduler.Config{Capacity: 1}),
+		higher,
+		lower,
+	)
+	gate.BeginProjectCycle(higher)
+	gate.EndProjectCycle(higher.ID)
+	settings := Settings{
+		GlobalDispatchGate: gate,
+		ProjectCandidate:   higher,
+	}
+
+	for run := 1; run <= 2; run++ {
+		release, acquired, reason, err := acquireCapacity(t.Context(), settings, now.Add(time.Duration(run)*time.Minute))
+		if err != nil {
+			t.Fatalf("admission run %d acquireCapacity() error = %v", run, err)
+		}
+		if !acquired || reason != "" {
+			t.Fatalf("admission run %d acquireCapacity() = %t, %q, want true, empty reason", run, acquired, reason)
+		}
+		if err := release(); err != nil {
+			t.Fatalf("admission run %d release() error = %v", run, err)
+		}
+
+		slot, granted, decision, err := gate.TryAcquireWithDecision(
+			t.Context(),
+			lower,
+			scheduler.SlotRequest{State: "Todo"},
+			now.Add(time.Duration(run)*time.Minute+time.Second),
+		)
+		if err != nil {
+			t.Fatalf("lower run %d TryAcquireWithDecision() error = %v", run, err)
+		}
+		if !granted {
+			t.Fatalf("lower run %d TryAcquireWithDecision() decision = %#v, want granted", run, decision)
+		}
+		if err := gate.Release(slot); err != nil {
+			t.Fatalf("lower run %d Release() error = %v", run, err)
+		}
+	}
+}
+
+func TestAcquireCapacityFailedAcquireClearsDerivedAdmissionReservation(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 7, 31, 13, 2, 34, 0, time.UTC)
+	higher := scheduler.ProjectCandidate{ID: "detent", Priority: 0}
+	lower := scheduler.ProjectCandidate{ID: "gopher-ai", Priority: 3}
+	gate := scheduler.NewGlobalDispatchGate(
+		scheduler.NewStrictPriority(scheduler.Config{Capacity: 1}),
+		higher,
+		lower,
+	)
+	gate.BeginProjectCycle(higher)
+	gate.EndProjectCycle(higher.ID)
+	resumeDispatch := gate.PauseDispatch()
+	release, acquired, reason, err := acquireCapacity(t.Context(), Settings{
+		GlobalDispatchGate: gate,
+		ProjectCandidate:   higher,
+	}, now)
+	resumeDispatch()
+	if err != nil {
+		t.Fatalf("acquireCapacity() error = %v", err)
+	}
+	if acquired || reason != "fleet_capacity" {
+		t.Fatalf("acquireCapacity() = %t, %q, want false, fleet_capacity", acquired, reason)
+	}
+	if err := release(); err != nil {
+		t.Fatalf("release() error = %v", err)
+	}
+
+	slot, granted, decision, err := gate.TryAcquireWithDecision(
+		t.Context(),
+		lower,
+		scheduler.SlotRequest{State: "Todo"},
+		now.Add(time.Second),
+	)
+	if err != nil {
+		t.Fatalf("lower TryAcquireWithDecision() error = %v", err)
+	}
+	if !granted {
+		t.Fatalf("lower TryAcquireWithDecision() decision = %#v, want granted", decision)
+	}
+	if err := gate.Release(slot); err != nil {
+		t.Fatalf("lower Release() error = %v", err)
+	}
+}
+
 func TestManagerFiltersLocallyAndRejectsFabricatedCriteria(t *testing.T) {
 	t.Parallel()
 

--- a/internal/admission/manager_test.go
+++ b/internal/admission/manager_test.go
@@ -1144,48 +1144,69 @@ func TestManagerDefersForCapacityAndBudget(t *testing.T) {
 func TestAcquireCapacityReleaseClearsDerivedAdmissionReservation(t *testing.T) {
 	t.Parallel()
 
-	now := time.Date(2026, 7, 31, 13, 2, 34, 0, time.UTC)
-	higher := scheduler.ProjectCandidate{ID: "detent", Priority: 0}
-	lower := scheduler.ProjectCandidate{ID: "gopher-ai", Priority: 3}
-	gate := scheduler.NewGlobalDispatchGate(
-		scheduler.NewStrictPriority(scheduler.Config{Capacity: 1}),
-		higher,
-		lower,
-	)
-	gate.BeginProjectCycle(higher)
-	gate.EndProjectCycle(higher.ID)
-	settings := Settings{
-		GlobalDispatchGate: gate,
-		ProjectCandidate:   higher,
-	}
+	for _, tt := range []struct {
+		name string
+		pool string
+	}{
+		{name: "default pool", pool: scheduler.DefaultPoolName},
+		{name: "non-default pool", pool: "video"},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 
-	for run := 1; run <= 2; run++ {
-		release, acquired, reason, err := acquireCapacity(t.Context(), settings, now.Add(time.Duration(run)*time.Minute))
-		if err != nil {
-			t.Fatalf("admission run %d acquireCapacity() error = %v", run, err)
-		}
-		if !acquired || reason != "" {
-			t.Fatalf("admission run %d acquireCapacity() = %t, %q, want true, empty reason", run, acquired, reason)
-		}
-		if err := release(); err != nil {
-			t.Fatalf("admission run %d release() error = %v", run, err)
-		}
+			now := time.Date(2026, 7, 31, 13, 2, 34, 0, time.UTC)
+			higher := scheduler.ProjectCandidate{ID: "detent", Pool: tt.pool, Priority: 0}
+			lower := scheduler.ProjectCandidate{ID: "gopher-ai", Pool: tt.pool, Priority: 3}
+			pools := []scheduler.PoolConfig{{
+				Name:      scheduler.DefaultPoolName,
+				Scheduler: scheduler.Config{Kind: "strict", Capacity: 1},
+			}}
+			if tt.pool != scheduler.DefaultPoolName {
+				pools = append(pools, scheduler.PoolConfig{
+					Name:      tt.pool,
+					Scheduler: scheduler.Config{Kind: "strict", Capacity: 1},
+				})
+			}
+			gate, err := scheduler.NewPoolRegistry(pools, []scheduler.ProjectCandidate{higher, lower})
+			if err != nil {
+				t.Fatalf("NewPoolRegistry() error = %v", err)
+			}
+			gate.BeginProjectCycle(higher)
+			gate.EndProjectCycle(higher.ID)
+			settings := Settings{
+				GlobalDispatchGate: gate,
+				ProjectCandidate:   higher,
+			}
 
-		slot, granted, decision, err := gate.TryAcquireWithDecision(
-			t.Context(),
-			lower,
-			scheduler.SlotRequest{State: "Todo"},
-			now.Add(time.Duration(run)*time.Minute+time.Second),
-		)
-		if err != nil {
-			t.Fatalf("lower run %d TryAcquireWithDecision() error = %v", run, err)
-		}
-		if !granted {
-			t.Fatalf("lower run %d TryAcquireWithDecision() decision = %#v, want granted", run, decision)
-		}
-		if err := gate.Release(slot); err != nil {
-			t.Fatalf("lower run %d Release() error = %v", run, err)
-		}
+			for run := 1; run <= 2; run++ {
+				release, acquired, reason, err := acquireCapacity(t.Context(), settings, now.Add(time.Duration(run)*time.Minute))
+				if err != nil {
+					t.Fatalf("admission run %d acquireCapacity() error = %v", run, err)
+				}
+				if !acquired || reason != "" {
+					t.Fatalf("admission run %d acquireCapacity() = %t, %q, want true, empty reason", run, acquired, reason)
+				}
+				if err := release(); err != nil {
+					t.Fatalf("admission run %d release() error = %v", run, err)
+				}
+
+				slot, granted, decision, err := gate.TryAcquireWithDecision(
+					t.Context(),
+					lower,
+					scheduler.SlotRequest{State: "Todo"},
+					now.Add(time.Duration(run)*time.Minute+time.Second),
+				)
+				if err != nil {
+					t.Fatalf("lower run %d TryAcquireWithDecision() error = %v", run, err)
+				}
+				if !granted {
+					t.Fatalf("lower run %d TryAcquireWithDecision() decision = %#v, want granted", run, decision)
+				}
+				if err := gate.Release(slot); err != nil {
+					t.Fatalf("lower run %d Release() error = %v", run, err)
+				}
+			}
+		})
 	}
 }
 
@@ -1193,13 +1214,18 @@ func TestAcquireCapacityFailedAcquireClearsDerivedAdmissionReservation(t *testin
 	t.Parallel()
 
 	now := time.Date(2026, 7, 31, 13, 2, 34, 0, time.UTC)
-	higher := scheduler.ProjectCandidate{ID: "detent", Priority: 0}
-	lower := scheduler.ProjectCandidate{ID: "gopher-ai", Priority: 3}
-	gate := scheduler.NewGlobalDispatchGate(
-		scheduler.NewStrictPriority(scheduler.Config{Capacity: 1}),
-		higher,
-		lower,
+	higher := scheduler.ProjectCandidate{ID: "detent", Pool: "video", Priority: 0}
+	lower := scheduler.ProjectCandidate{ID: "gopher-ai", Pool: "video", Priority: 3}
+	gate, err := scheduler.NewPoolRegistry(
+		[]scheduler.PoolConfig{
+			{Name: scheduler.DefaultPoolName, Scheduler: scheduler.Config{Kind: "strict", Capacity: 1}},
+			{Name: "video", Scheduler: scheduler.Config{Kind: "strict", Capacity: 1}},
+		},
+		[]scheduler.ProjectCandidate{higher, lower},
 	)
+	if err != nil {
+		t.Fatalf("NewPoolRegistry() error = %v", err)
+	}
 	gate.BeginProjectCycle(higher)
 	gate.EndProjectCycle(higher.ID)
 	resumeDispatch := gate.PauseDispatch()

--- a/internal/cli/boot.go
+++ b/internal/cli/boot.go
@@ -600,7 +600,7 @@ func syncGlobalDispatchProjects(
 		if ok && runtimeProject.Running() {
 			continue
 		}
-		gate.MarkIdle(candidate.ID)
+		gate.MarkIdle(candidate)
 	}
 }
 

--- a/internal/cli/global_reload_test.go
+++ b/internal/cli/global_reload_test.go
@@ -290,8 +290,8 @@ func TestGlobalConfigReloaderHotAppliesSchedulerCapacityWithoutInterruptingWorke
 	if err != nil {
 		t.Fatalf("buildGlobalDispatchPools() error = %v", err)
 	}
-	gate.MarkIdle(bravo.ID)
-	gate.MarkIdle(charlie.ID)
+	gate.MarkIdle(bravo)
+	gate.MarkIdle(charlie)
 	alphaSlot, ok, err := gate.TryAcquire(ctx, alpha, scheduler.SlotRequest{State: "Todo"}, time.Time{})
 	if err != nil || !ok {
 		t.Fatalf("alpha TryAcquire() = ok %t error %v, want granted", ok, err)

--- a/internal/orchestrator/dispatch.go
+++ b/internal/orchestrator/dispatch.go
@@ -631,7 +631,7 @@ func (o *Orchestrator) markGlobalProjectIdle() {
 	if o.globalDispatchGate == nil {
 		return
 	}
-	o.globalDispatchGate.MarkIdle(o.cfg.Project.ID)
+	o.globalDispatchGate.MarkIdle(o.cfg.Project)
 }
 
 type projectCycleDispatchGate interface {

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -789,7 +789,7 @@ func (o *Orchestrator) BeginDrain() {
 		gate.PauseDispatch()
 	}
 	if o.globalDispatchGate != nil {
-		o.globalDispatchGate.MarkIdle(o.projectID)
+		o.globalDispatchGate.MarkIdle(scheduler.ProjectCandidate{ID: o.projectID})
 	}
 }
 

--- a/internal/scheduler/global_gate.go
+++ b/internal/scheduler/global_gate.go
@@ -20,7 +20,7 @@ const (
 
 type ProjectDispatchGate interface {
 	MarkReady(ProjectCandidate)
-	MarkIdle(string)
+	MarkIdle(ProjectCandidate)
 	TryAcquire(context.Context, ProjectCandidate, SlotRequest, time.Time) (Slot, bool, error)
 	SetPreempt(Slot, func())
 	Release(Slot) error
@@ -271,11 +271,11 @@ func (g *GlobalDispatchGate) MarkReady(project ProjectCandidate) {
 	}
 }
 
-func (g *GlobalDispatchGate) MarkIdle(projectID string) {
+func (g *GlobalDispatchGate) MarkIdle(project ProjectCandidate) {
 	if g == nil {
 		return
 	}
-	projectID = normalizeProjectID(projectID)
+	projectID := normalizeProjectID(project.ID)
 	if projectID == "" {
 		return
 	}

--- a/internal/scheduler/pool_registry.go
+++ b/internal/scheduler/pool_registry.go
@@ -265,13 +265,13 @@ func (r *PoolRegistry) MarkReady(project ProjectCandidate) {
 	}
 }
 
-func (r *PoolRegistry) MarkIdle(projectID string) {
+func (r *PoolRegistry) MarkIdle(project ProjectCandidate) {
 	r.reconfigureMu.Lock()
 	defer r.reconfigureMu.Unlock()
 
-	runtime := r.runtimeForProject(projectID)
+	runtime := r.runtimeForCandidate(project)
 	if runtime != nil {
-		runtime.gate.MarkIdle(projectID)
+		runtime.gate.MarkIdle(project)
 		if !runtime.gate.hasReadyProjects() {
 			r.elastic.remove(runtime.generation)
 		}
@@ -505,8 +505,9 @@ func (g *projectPoolGate) MarkReady(project ProjectCandidate) {
 	g.registry.MarkReady(project)
 }
 
-func (g *projectPoolGate) MarkIdle(string) {
-	g.registry.MarkIdle(g.projectID)
+func (g *projectPoolGate) MarkIdle(project ProjectCandidate) {
+	project.ID = g.projectID
+	g.registry.MarkIdle(project)
 }
 
 func (g *projectPoolGate) BeginProjectCycle(project ProjectCandidate) {

--- a/internal/scheduler/pool_registry_test.go
+++ b/internal/scheduler/pool_registry_test.go
@@ -252,7 +252,7 @@ func TestPoolRegistryElasticStrictPreemptionDoesNotCrossPools(t *testing.T) {
 		},
 		projects,
 	)
-	registry.MarkIdle("code-urgent")
+	registry.MarkIdle(scheduler.ProjectCandidate{ID: "code-urgent"})
 	videoSlots := acquirePoolSlots(t, registry, time.Time{}, projects[1], projects[2])
 	videoPreemptions := 0
 	for _, slot := range videoSlots {
@@ -370,7 +370,7 @@ func TestPoolRegistryStrictPreemptionDoesNotCrossPools(t *testing.T) {
 			{ID: "video-low", Pool: "video", Priority: 4},
 		},
 	)
-	registry.MarkIdle("code-urgent")
+	registry.MarkIdle(scheduler.ProjectCandidate{ID: "code-urgent"})
 	codeSlot := acquirePoolSlots(t, registry, time.Time{}, scheduler.ProjectCandidate{ID: "code-low", Priority: 4})[0]
 	videoSlot := acquirePoolSlots(t, registry, time.Time{}, scheduler.ProjectCandidate{ID: "video-low", Priority: 4})[0]
 	codePreemptions := 0
@@ -622,7 +622,7 @@ func TestProjectPoolGateRoutesLifecycleToCurrentPool(t *testing.T) {
 	if err := gate.Release(slot); err != nil {
 		t.Fatalf("second Release() error = %v", err)
 	}
-	gate.MarkIdle("")
+	gate.MarkIdle(scheduler.ProjectCandidate{})
 
 	registry.SetProjects([]scheduler.ProjectCandidate{{ID: project.ID}})
 	if snapshot := snapshotter.PoolSnapshot(); snapshot.Name != scheduler.DefaultPoolName {


### PR DESCRIPTION
## Summary

- Mark the derived admission candidate idle after its global slot releases successfully.
- Carry candidate pool identity through idle cleanup so derived admission candidates clear from non-default pools as well as the default pool.
- Reproduce two successful admission acquire/release cycles in both pool types and preserve the failed-acquire cleanup path.

Fixes #1602

## UI Surface Contract

- [x] N/A — this PR has no UI surface changes.
- [x] This PR adds no persistent top-of-screen messaging.
- [x] N/A — this PR has no visual changes to operator screens.

## Test Plan

- [x] `go test ./internal/admission -run 'TestAcquireCapacity(Release|Failed)' -count=1 -v`\n- [x] `go test -race ./internal/scheduler -run 'Test(GlobalDispatchGateStrictProjectReservationTracksDemand|PoolRegistry|ProjectPoolGate)' -count=1`\n- [x] `make check`