### PR TITLE
test(install): relax PowerShell deadline

### DIFF
--- a/install_ps1_windows_test.go
+++ b/install_ps1_windows_test.go
@@ -18,6 +18,8 @@ import (
 	"time"
 )
 
+const powerShellInstallTimeout = 2 * time.Minute
+
 func TestPowerShellInstallScriptInstallsReleaseArchive(t *testing.T) {
 	t.Parallel()
 
@@ -229,7 +231,7 @@ type powerShellInstallRun struct {
 func runPowerShellInstall(t *testing.T, root string, env []string) powerShellInstallRun {
 	t.Helper()
 
-	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), powerShellInstallTimeout)
 	defer cancel()
 
 	cmd := exec.CommandContext(ctx, "powershell.exe", "-NoProfile", "-ExecutionPolicy", "Bypass", "-File", "install.ps1")
@@ -242,6 +244,9 @@ func runPowerShellInstall(t *testing.T, root string, env []string) powerShellIns
 	cmd.Stderr = &stderr
 
 	err := cmd.Run()
+	if ctx.Err() != nil {
+		err = fmt.Errorf("PowerShell install exceeded %s: %w", powerShellInstallTimeout, ctx.Err())
+	}
 	return powerShellInstallRun{
 		stdout: stdout.String(),
 		stderr: stderr.String(),


### PR DESCRIPTION
## Summary

- extend the PowerShell install test process guard from 20 seconds to 2 minutes for cold or loaded Windows runners
- report context deadline expiration explicitly instead of surfacing only the terminated process exit code

Fixes #1604

## UI Surface Contract

- [x] N/A, or the linked issue explicitly authorizes any high-impact UI surface, layout, density, first-viewport, or responsive visibility tradeoff.
- [x] Persistent top-of-screen messaging is explicitly authorized by the issue, or this PR does not add it.
- [x] Visual changes to primary operator screens include screenshot or browser verification below. N/A: no UI changes.

## Test Plan

- [x] `GOOS=windows GOARCH=amd64 go test -c -o "$TMPDIR/detent-windows.test.exe" .`
- [x] `go test -race . -run 'InstallScript' -count=10`
- [x] prior current-head GitHub CI (all 11 checks, including Windows and macOS portability)
- [ ] local `make check` after #1617 fixes the deterministic admission failure on current `main`
