### PR TITLE
test(scheduler): cover poisoned-gate restart recovery

### DIFF
--- a/internal/cli/restart_recovery_e2e_test.go
+++ b/internal/cli/restart_recovery_e2e_test.go
@@ -1,0 +1,182 @@
+package cli
+
+import (
+	"context"
+	"errors"
+	"io"
+	"log/slog"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	globalconfig "github.com/digitaldrywood/detent/internal/config/global"
+	"github.com/digitaldrywood/detent/internal/connector"
+	"github.com/digitaldrywood/detent/internal/connector/memory"
+	"github.com/digitaldrywood/detent/internal/orchestrator"
+	"github.com/digitaldrywood/detent/internal/scheduler"
+)
+
+func TestBootRegistryRebuildDispatchesStrandedActiveIssueAfterPoisonedGate(t *testing.T) {
+	t.Parallel()
+
+	configuredProject := globalconfig.Project{ID: "gopher-ai", Weight: 1, Priority: 3}
+	configuredCandidate := globalProjectCandidates([]globalconfig.Project{configuredProject})[0]
+	global := globalconfig.Config{
+		Global: globalconfig.Settings{
+			MaxConcurrentAgents: 1,
+			Scheduling:          globalconfig.SchedulingStrict,
+		},
+		Projects: []globalconfig.Project{configuredProject},
+	}
+	issue := connector.NewIssue()
+	issue.ID = "issue-stranded"
+	issue.Identifier = "gopherguides/gopher-ai#294"
+	issue.Title = "stranded active work"
+	issue.State = "In Progress"
+	tracker := memory.New(memory.Config{Issues: []connector.Issue{issue}})
+
+	poisonedGate, err := buildGlobalDispatchPools(global, nil)
+	if err != nil {
+		t.Fatalf("buildGlobalDispatchPools() error = %v", err)
+	}
+	phantom := scheduler.ProjectCandidate{ID: "detent", Weight: 1, Priority: 0}
+	poisonedGate.MarkReady(phantom)
+	strandedRunner := newRestartRecoveryRunner()
+	stranded, stopStranded := runRestartRecoveryOrchestrator(t, tracker, strandedRunner, poisonedGate, configuredCandidate)
+	strandedState := restartRecoveryState(t, stranded)
+	if len(strandedState.Running) != 0 {
+		t.Fatalf("Running = %#v, want no live work attempt while gate is poisoned", strandedState.Running)
+	}
+	if !restartRecoveryEventContains(
+		strandedState,
+		"dispatch_slot_wait",
+		"reason="+scheduler.DispatchGateReasonReservedForHigherPriorityProject,
+		"selected_project_id="+phantom.ID,
+	) {
+		t.Fatalf("RecentEvents = %#v, want poisoned priority reservation", strandedState.RecentEvents)
+	}
+	select {
+	case request := <-strandedRunner.started:
+		t.Fatalf("unexpected runner request while gate is poisoned = %#v", request)
+	default:
+	}
+	stopStranded()
+
+	restartedGate, err := buildGlobalDispatchPools(global, nil)
+	if err != nil {
+		t.Fatalf("buildGlobalDispatchPools() after restart error = %v", err)
+	}
+	restartedRunner := newRestartRecoveryRunner()
+	restarted, stopRestarted := runRestartRecoveryOrchestrator(t, tracker, restartedRunner, restartedGate, configuredCandidate)
+	defer stopRestarted()
+
+	select {
+	case request := <-restartedRunner.started:
+		if request.Issue.ID != issue.ID || request.Issue.State != issue.State {
+			t.Fatalf("RunRequest.Issue = %#v, want unchanged stranded issue %#v", request.Issue, issue)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for stranded issue dispatch after registry rebuild")
+	}
+	restartedState := restartRecoveryState(t, restarted)
+	if _, ok := restartedState.Running[issue.ID]; !ok {
+		t.Fatalf("Running[%q] missing after automatic restart recovery", issue.ID)
+	}
+}
+
+type restartRecoveryRunner struct {
+	started chan orchestrator.RunRequest
+}
+
+func newRestartRecoveryRunner() *restartRecoveryRunner {
+	return &restartRecoveryRunner{started: make(chan orchestrator.RunRequest, 1)}
+}
+
+func (r *restartRecoveryRunner) Run(ctx context.Context, request orchestrator.RunRequest) (orchestrator.RunResult, error) {
+	select {
+	case r.started <- request:
+	case <-ctx.Done():
+		return orchestrator.RunResult{}, ctx.Err()
+	}
+	<-ctx.Done()
+	return orchestrator.RunResult{}, ctx.Err()
+}
+
+func runRestartRecoveryOrchestrator(
+	t *testing.T,
+	tracker connector.Connector,
+	runner orchestrator.Runner,
+	gate scheduler.ProjectDispatchGate,
+	project scheduler.ProjectCandidate,
+) (*orchestrator.Orchestrator, func()) {
+	t.Helper()
+
+	orch, err := orchestrator.New(orchestrator.Config{
+		PollInterval:        time.Hour,
+		MaxConcurrentAgents: 1,
+		Project:             project,
+		ActiveStates:        []string{"In Progress"},
+		TerminalStates:      []string{"Done", "Cancelled"},
+	}, orchestrator.Dependencies{
+		Connector:          tracker,
+		Runner:             runner,
+		GlobalDispatchGate: gate,
+		Logger:             slog.New(slog.NewTextHandler(io.Discard, nil)),
+	})
+	if err != nil {
+		t.Fatalf("orchestrator.New() error = %v", err)
+	}
+	ctx, cancel := context.WithCancel(t.Context())
+	done := make(chan error, 1)
+	go func() {
+		done <- orch.Run(ctx)
+	}()
+	var stopOnce sync.Once
+	stop := func() {
+		stopOnce.Do(func() {
+			cancel()
+			select {
+			case runErr := <-done:
+				if runErr != nil && !errors.Is(runErr, context.Canceled) {
+					t.Fatalf("Orchestrator.Run() error = %v", runErr)
+				}
+			case <-time.After(5 * time.Second):
+				t.Fatal("timed out waiting for orchestrator shutdown")
+			}
+		})
+	}
+	t.Cleanup(stop)
+	return orch, stop
+}
+
+func restartRecoveryState(t *testing.T, orch *orchestrator.Orchestrator) orchestrator.State {
+	t.Helper()
+
+	ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
+	defer cancel()
+	state, err := orch.State(ctx)
+	if err != nil {
+		t.Fatalf("Orchestrator.State() error = %v", err)
+	}
+	return state
+}
+
+func restartRecoveryEventContains(state orchestrator.State, event string, fragments ...string) bool {
+	for _, candidate := range state.RecentEvents {
+		if candidate.Event != event {
+			continue
+		}
+		matched := true
+		for _, fragment := range fragments {
+			if !strings.Contains(candidate.Message, fragment) {
+				matched = false
+				break
+			}
+		}
+		if matched {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/scheduler/global_gate.go
+++ b/internal/scheduler/global_gate.go
@@ -170,6 +170,11 @@ func (g *GlobalDispatchGate) SetProjects(projects []ProjectCandidate) {
 		delete(g.selected, projectID)
 		delete(g.projectCycles, projectID)
 	}
+	for projectID := range g.projectCycles {
+		if _, ok := next[projectID]; !ok {
+			delete(g.projectCycles, projectID)
+		}
+	}
 	g.projects = next
 }
 

--- a/internal/scheduler/global_gate_internal_test.go
+++ b/internal/scheduler/global_gate_internal_test.go
@@ -1,0 +1,37 @@
+package scheduler
+
+import "testing"
+
+func TestGlobalDispatchGateSetProjectsCleansCycleRecords(t *testing.T) {
+	t.Parallel()
+
+	configured := ProjectCandidate{ID: "configured", Weight: 1}
+	orphan := ProjectCandidate{ID: "orphan", Weight: 1}
+	for _, tt := range []struct {
+		name      string
+		cycle     ProjectCandidate
+		wantCycle bool
+	}{
+		{name: "configured project cycle remains", cycle: configured, wantCycle: true},
+		{name: "cycle-only orphan is removed", cycle: orphan},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			gate := NewGlobalDispatchGate(
+				NewStrictPriority(Config{Capacity: 1}),
+				configured,
+			)
+			gate.MarkIdle(tt.cycle)
+			gate.SetProjects([]ProjectCandidate{configured})
+
+			cycle, ok := gate.projectCycles[tt.cycle.ID]
+			if ok != tt.wantCycle {
+				t.Fatalf("projectCycles[%q] present = %t, want %t", tt.cycle.ID, ok, tt.wantCycle)
+			}
+			if ok && !cycle.idle {
+				t.Fatalf("projectCycles[%q].idle = false, want true", tt.cycle.ID)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- add a boot-level integration test proving an unchanged stranded `In Progress` issue dispatches after a poisoned dynamic reservation is removed by restart
- remove cycle-only orphan records during `SetProjects` while retaining configured project cycle state

Fixes #1609

## UI Surface Contract

- [x] N/A; this PR does not change UI surfaces, layout, density, first-viewport behavior, or responsive visibility.
- [x] This PR does not add persistent top-of-screen messaging.
- [x] N/A; this PR has no visual changes to primary operator screens.

## Test Plan

- [x] `go test -race ./internal/scheduler ./internal/cli -run 'TestGlobalDispatchGateSetProjectsCleansCycleRecords|TestGlobalDispatchGateStrictProjectReservationTracksDemand|TestBootRegistryRebuildDispatchesStrandedActiveIssueAfterPoisonedGate|TestSyncGlobalDispatchProjectsMarksUnstartedProjectsIdle' -count=1`
- [x] `make check`