### PR TITLE
fix(admission): clear failed release reservation

### DIFF
--- a/internal/admission/manager.go
+++ b/internal/admission/manager.go
@@ -1119,9 +1119,7 @@ func acquireCapacity(ctx context.Context, settings Settings, now time.Time) (fun
 	}
 	return func() error {
 		releaseGlobal := settings.GlobalDispatchGate.Release(slot)
-		if releaseGlobal == nil {
-			settings.GlobalDispatchGate.MarkIdle(candidate)
-		}
+		settings.GlobalDispatchGate.MarkIdle(candidate)
 		return errors.Join(releaseGlobal, releaseLocal())
 	}, true, "", nil
 }

--- a/internal/admission/manager_test.go
+++ b/internal/admission/manager_test.go
@@ -23,6 +23,20 @@ import (
 	"github.com/digitaldrywood/detent/internal/workspace"
 )
 
+type releaseErrorGlobalScheduler struct {
+	scheduler.GlobalScheduler
+	err error
+}
+
+func (s *releaseErrorGlobalScheduler) ReleaseSlot(slot scheduler.Slot) error {
+	if err := s.GlobalScheduler.ReleaseSlot(slot); err != nil {
+		return err
+	}
+	err := s.err
+	s.err = nil
+	return err
+}
+
 func TestManagerDisabledRegistersNoSchedule(t *testing.T) {
 	t.Parallel()
 
@@ -1205,6 +1219,64 @@ func TestAcquireCapacityReleaseClearsDerivedAdmissionReservation(t *testing.T) {
 				if err := gate.Release(slot); err != nil {
 					t.Fatalf("lower run %d Release() error = %v", run, err)
 				}
+			}
+		})
+	}
+}
+
+func TestAcquireCapacityReleaseErrorClearsDerivedAdmissionReservation(t *testing.T) {
+	t.Parallel()
+
+	releaseErr := errors.New("release slot")
+	for _, tt := range []struct {
+		name       string
+		releaseErr error
+	}{
+		{name: "release succeeds"},
+		{name: "release fails", releaseErr: releaseErr},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			now := time.Date(2026, 7, 31, 13, 2, 34, 0, time.UTC)
+			higher := scheduler.ProjectCandidate{ID: "detent", Priority: 0}
+			lower := scheduler.ProjectCandidate{ID: "gopher-ai", Priority: 3}
+			global := &releaseErrorGlobalScheduler{
+				GlobalScheduler: scheduler.NewStrictPriority(scheduler.Config{Capacity: 1}),
+				err:             tt.releaseErr,
+			}
+			gate := scheduler.NewGlobalDispatchGate(global, higher, lower)
+			gate.BeginProjectCycle(higher)
+			gate.EndProjectCycle(higher.ID)
+
+			release, acquired, reason, err := acquireCapacity(t.Context(), Settings{
+				GlobalDispatchGate: gate,
+				ProjectCandidate:   higher,
+			}, now)
+			if err != nil {
+				t.Fatalf("acquireCapacity() error = %v", err)
+			}
+			if !acquired || reason != "" {
+				t.Fatalf("acquireCapacity() = %t, %q, want true, empty reason", acquired, reason)
+			}
+			if err := release(); !errors.Is(err, tt.releaseErr) {
+				t.Fatalf("release() error = %v, want %v", err, tt.releaseErr)
+			}
+
+			slot, granted, decision, err := gate.TryAcquireWithDecision(
+				t.Context(),
+				lower,
+				scheduler.SlotRequest{State: "Todo"},
+				now.Add(time.Second),
+			)
+			if err != nil {
+				t.Fatalf("lower TryAcquireWithDecision() error = %v", err)
+			}
+			if !granted {
+				t.Fatalf("lower TryAcquireWithDecision() decision = %#v, want granted", decision)
+			}
+			if err := gate.Release(slot); err != nil {
+				t.Fatalf("lower Release() error = %v", err)
 			}
 		})
 	}

--- a/internal/scheduler/global_gate.go
+++ b/internal/scheduler/global_gate.go
@@ -470,7 +470,7 @@ func (g *GlobalDispatchGate) Release(slot Slot) error {
 	if !ok {
 		return nil
 	}
-	if err := g.global.ReleaseSlot(slot); err != nil {
+	if err := g.global.ReleaseSlot(slot); err != nil && !errors.Is(err, ErrSlotNotHeld) {
 		return err
 	}
 	delete(g.running, slot.token)

--- a/internal/scheduler/global_gate_test.go
+++ b/internal/scheduler/global_gate_test.go
@@ -49,6 +49,53 @@ func TestGlobalDispatchGateUsesConfiguredProjectSelection(t *testing.T) {
 	}
 }
 
+func TestGlobalDispatchGateReleaseIsIdempotentWhenSlotIsNotHeld(t *testing.T) {
+	t.Parallel()
+
+	for _, tt := range []struct {
+		name             string
+		releaseOutOfBand bool
+	}{
+		{name: "held slot"},
+		{name: "slot released out of band", releaseOutOfBand: true},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			global := scheduler.NewStrictPriority(scheduler.Config{Capacity: 1})
+			gate := scheduler.NewGlobalDispatchGate(global)
+			project := scheduler.ProjectCandidate{ID: "alpha", Weight: 1}
+			slot, acquired, err := gate.TryAcquire(
+				t.Context(),
+				project,
+				scheduler.SlotRequest{State: "Todo"},
+				time.Date(2026, 7, 31, 13, 2, 34, 0, time.UTC),
+			)
+			if err != nil {
+				t.Fatalf("TryAcquire() error = %v", err)
+			}
+			if !acquired {
+				t.Fatal("TryAcquire() acquired = false, want true")
+			}
+			if tt.releaseOutOfBand {
+				if err := global.ReleaseSlot(slot); err != nil {
+					t.Fatalf("out-of-band ReleaseSlot() error = %v", err)
+				}
+			}
+
+			if err := gate.Release(slot); err != nil {
+				t.Fatalf("Release() error = %v, want nil", err)
+			}
+			if snapshot := gate.PoolSnapshot(); snapshot.Used != 0 || len(snapshot.Holders) != 0 {
+				t.Fatalf("PoolSnapshot() = %#v, want no usage or holders", snapshot)
+			}
+			if err := gate.Release(slot); err != nil {
+				t.Fatalf("duplicate Release() error = %v, want nil", err)
+			}
+		})
+	}
+}
+
 func TestGlobalDispatchGatePauseBlocksNewSlotsUntilEveryReservationReleases(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

- mark derived admission candidates idle even when global slot release returns an error
- treat `ErrSlotNotHeld` gate cleanup as idempotent and clear gate-local holder state
- add table-driven injected-failure and out-of-band-release regression coverage

Fixes #1608

## UI Surface Contract

- [x] N/A, or the linked issue explicitly authorizes any high-impact UI surface, layout, density, first-viewport, or responsive visibility tradeoff.
- [x] Persistent top-of-screen messaging is explicitly authorized by the issue, or this PR does not add it.
- [x] Visual changes to primary operator screens include screenshot or browser verification below. N/A: no UI changes.

## Test Plan

- [x] `go test ./internal/admission -run "^TestAcquireCapacity(ReleaseClearsDerivedAdmissionReservation|ReleaseErrorClearsDerivedAdmissionReservation|FailedAcquireClearsDerivedAdmissionReservation)$" -count=1`
- [x] `go test ./internal/scheduler -run "^TestGlobalDispatchGate(ReleaseIsIdempotentWhenSlotIsNotHeld|StrictProjectReservationTracksDemand)$" -count=1`
- [x] `go test -race ./internal/admission ./internal/scheduler -count=1`
- [x] `make check`