### PR TITLE
fix(admission): preserve demand on gate release failure

### DIFF
--- a/internal/admission/manager.go
+++ b/internal/admission/manager.go
@@ -1119,7 +1119,9 @@ func acquireCapacity(ctx context.Context, settings Settings, now time.Time) (fun
 	}
 	return func() error {
 		releaseGlobal := settings.GlobalDispatchGate.Release(slot)
-		settings.GlobalDispatchGate.MarkIdle(candidate)
+		if releaseGlobal == nil {
+			settings.GlobalDispatchGate.MarkIdle(candidate)
+		}
 		return errors.Join(releaseGlobal, releaseLocal())
 	}, true, "", nil
 }

--- a/internal/admission/manager_test.go
+++ b/internal/admission/manager_test.go
@@ -1224,61 +1224,46 @@ func TestAcquireCapacityReleaseClearsDerivedAdmissionReservation(t *testing.T) {
 	}
 }
 
-func TestAcquireCapacityReleaseErrorClearsDerivedAdmissionReservation(t *testing.T) {
+func TestAcquireCapacityReleaseErrorPreservesDerivedAdmissionDemand(t *testing.T) {
 	t.Parallel()
 
 	releaseErr := errors.New("release slot")
-	for _, tt := range []struct {
-		name       string
-		releaseErr error
-	}{
-		{name: "release succeeds"},
-		{name: "release fails", releaseErr: releaseErr},
-	} {
-		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
+	now := time.Date(2026, 7, 31, 13, 2, 34, 0, time.UTC)
+	higher := scheduler.ProjectCandidate{ID: "detent", Priority: 0}
+	lower := scheduler.ProjectCandidate{ID: "gopher-ai", Priority: 3}
+	global := &releaseErrorGlobalScheduler{
+		GlobalScheduler: scheduler.NewStrictPriority(scheduler.Config{Capacity: 1}),
+		err:             releaseErr,
+	}
+	gate := scheduler.NewGlobalDispatchGate(global, higher, lower)
+	gate.BeginProjectCycle(higher)
+	gate.EndProjectCycle(higher.ID)
 
-			now := time.Date(2026, 7, 31, 13, 2, 34, 0, time.UTC)
-			higher := scheduler.ProjectCandidate{ID: "detent", Priority: 0}
-			lower := scheduler.ProjectCandidate{ID: "gopher-ai", Priority: 3}
-			global := &releaseErrorGlobalScheduler{
-				GlobalScheduler: scheduler.NewStrictPriority(scheduler.Config{Capacity: 1}),
-				err:             tt.releaseErr,
-			}
-			gate := scheduler.NewGlobalDispatchGate(global, higher, lower)
-			gate.BeginProjectCycle(higher)
-			gate.EndProjectCycle(higher.ID)
+	release, acquired, reason, err := acquireCapacity(t.Context(), Settings{
+		GlobalDispatchGate: gate,
+		ProjectCandidate:   higher,
+	}, now)
+	if err != nil {
+		t.Fatalf("acquireCapacity() error = %v", err)
+	}
+	if !acquired || reason != "" {
+		t.Fatalf("acquireCapacity() = %t, %q, want true, empty reason", acquired, reason)
+	}
+	if err := release(); !errors.Is(err, releaseErr) {
+		t.Fatalf("release() error = %v, want %v", err, releaseErr)
+	}
 
-			release, acquired, reason, err := acquireCapacity(t.Context(), Settings{
-				GlobalDispatchGate: gate,
-				ProjectCandidate:   higher,
-			}, now)
-			if err != nil {
-				t.Fatalf("acquireCapacity() error = %v", err)
-			}
-			if !acquired || reason != "" {
-				t.Fatalf("acquireCapacity() = %t, %q, want true, empty reason", acquired, reason)
-			}
-			if err := release(); !errors.Is(err, tt.releaseErr) {
-				t.Fatalf("release() error = %v, want %v", err, tt.releaseErr)
-			}
-
-			slot, granted, decision, err := gate.TryAcquireWithDecision(
-				t.Context(),
-				lower,
-				scheduler.SlotRequest{State: "Todo"},
-				now.Add(time.Second),
-			)
-			if err != nil {
-				t.Fatalf("lower TryAcquireWithDecision() error = %v", err)
-			}
-			if !granted {
-				t.Fatalf("lower TryAcquireWithDecision() decision = %#v, want granted", decision)
-			}
-			if err := gate.Release(slot); err != nil {
-				t.Fatalf("lower Release() error = %v", err)
-			}
-		})
+	_, granted, decision, err := gate.TryAcquireWithDecision(
+		t.Context(),
+		lower,
+		scheduler.SlotRequest{State: "Todo"},
+		now.Add(time.Second),
+	)
+	if err != nil {
+		t.Fatalf("lower TryAcquireWithDecision() error = %v", err)
+	}
+	if granted || decision.Reason != scheduler.DispatchGateReasonReservedForHigherPriorityProject {
+		t.Fatalf("lower TryAcquireWithDecision() decision = %#v, want priority reservation", decision)
 	}
 }
 

--- a/internal/orchestrator/safety_fuzz_test.go
+++ b/internal/orchestrator/safety_fuzz_test.go
@@ -1,6 +1,7 @@
 package orchestrator
 
 import (
+	"errors"
 	"strings"
 	"testing"
 	"time"
@@ -9,6 +10,18 @@ import (
 	"github.com/digitaldrywood/detent/internal/scheduler"
 	"github.com/digitaldrywood/detent/internal/store"
 )
+
+type releaseErrorSafetyScheduler struct {
+	scheduler.GlobalScheduler
+	err error
+}
+
+func (s *releaseErrorSafetyScheduler) ReleaseSlot(slot scheduler.Slot) error {
+	if err := s.GlobalScheduler.ReleaseSlot(slot); err != nil {
+		return err
+	}
+	return s.err
+}
 
 func FuzzSafetyCriticalOrchestratorBoundaries(f *testing.F) {
 	f.Add(0, 0, 0, "", "clean", int64(1), " head ", "lint,test", int64(1), "head", "test,lint", int64(60), int64(0), true, int64(0), int64(1), int64(2), true, uint8(0))
@@ -152,7 +165,7 @@ func FuzzSafetyCriticalOrchestratorBoundaries(f *testing.F) {
 			t.Fatalf("ranking depends on input order: forward=%#v reverse=%#v", rankingIssueIDs(forward), rankingIssueIDs(reverse))
 		}
 
-		assertDemandDrivenPriorityReservation(t, gateScenario%3, now)
+		assertDemandDrivenPriorityReservation(t, gateScenario%4, now)
 	})
 }
 
@@ -200,6 +213,21 @@ func assertDemandDrivenPriorityReservation(t *testing.T, scenario uint8, now tim
 			t.Fatalf("release higher-priority candidate: %v", err)
 		}
 		requireSafetyGateReserved(t, gate, lower, now.Add(5*time.Second))
+	case 3:
+		releaseErr := errors.New("release failed")
+		global := &releaseErrorSafetyScheduler{
+			GlobalScheduler: scheduler.NewStrictPriority(scheduler.Config{Capacity: 1}),
+			err:             releaseErr,
+		}
+		gate = scheduler.NewGlobalDispatchGate(global, higher, lower)
+		gate.BeginProjectCycle(higher)
+		gate.EndProjectCycle(higher.ID)
+		candidate := scheduler.ProjectCandidate{ID: higher.ID + "/admission", Weight: 1, Priority: higher.Priority}
+		slot := requireSafetyGateGranted(t, gate, candidate, now)
+		if err := gate.Release(slot); !errors.Is(err, releaseErr) {
+			t.Fatalf("release dynamic candidate: %v, want %v", err, releaseErr)
+		}
+		requireSafetyGateReserved(t, gate, lower, now.Add(time.Second))
 	}
 }
 


### PR DESCRIPTION
## Summary

- Preserve derived admission demand when the global gate release fails while still releasing local capacity and returning joined cleanup errors.
- Keep successful cleanup and gate-refusal idle transitions, with integration and fuzz coverage for the failed-release reservation boundary.

Fixes #1617

## UI Surface Contract

- [x] N/A; this PR does not change UI behavior or layout.
- [x] This PR adds no persistent top-of-screen messaging.
- [x] This PR changes no primary operator screen.

## Test Plan

- [x] Focused admission capacity boundary tests
- [x] `internal/admission/manager.go` exact-file coverage: 90.1%
- [x] `go test ./internal/orchestrator -run '^$' -fuzz=. -fuzztime=30s`
- [x] `make check`
