### PR TITLE
feat(health): surface stranded active work

### DIFF
--- a/config.reference.yaml
+++ b/config.reference.yaml
@@ -844,6 +844,8 @@
 #   refresh_ms: 1000
 #   # observability.render_interval_ms | type: integer | default: 16 | required: No | validation: must be greater than 0
 #   render_interval_ms: 16
+#   # observability.stranded_active_threshold_seconds | type: integer | default: 600 | required: No | validation: must be greater than 0
+#   stranded_active_threshold_seconds: 600
 #   # observability.efficiency | type: object | default: see child fields | required: No | validation: None
 #   efficiency:
 #     # observability.efficiency.anomaly_tokens_multiple | type: number | default: 3 | required: No | validation: must be greater than 0

--- a/docs/config.md
+++ b/docs/config.md
@@ -155,6 +155,11 @@ optional OTLP export. `budget` is the project-wide spend policy;
 `agent.budget` can further constrain agent sessions. `release` enables
 release-readiness automation after merged work accumulates.
 
+`observability.stranded_active_threshold_seconds` controls when Health and
+`detent doctor` report an issue that remains in `In Progress` without a live
+worker while project capacity is available. The default is 600 seconds, which
+tolerates normal gaps between a completed session and prompt re-dispatch.
+
 `hooks` run lifecycle commands around worktree creation, agent execution, and
 cleanup. Treat them as trusted code: they run with the Detent process
 permissions and should be short, deterministic, and safe to retry.
@@ -489,6 +494,7 @@ rendering and fails on drift.
 | `observability.staleness.webhook.headers` | `mapping<string, string>` | `{}` | No | None |
 | `observability.staleness.webhook.timeout_ms` | `integer` | `5000` | No | None |
 | `observability.staleness.webhook.url` | `string` | `none` | No | must be an absolute http or https URL |
+| `observability.stranded_active_threshold_seconds` | `integer` | `600` | No | must be greater than 0 |
 | `plan` | `object` | `see child fields` | No | agents.backends.options.permission_mode must not be plan for unattended workers |
 | `plan.approval_label` | `string` | `"plan-approved"` | No | None |
 | `plan.enabled` | `boolean` | `false` | No | None |

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -63,6 +63,7 @@ type doctorCheck struct {
 	OverloadRetriesLastHour   int                                        `json:"overload_retries_last_hour,omitempty"`
 	DependencyCapabilities    []connector.DependencyCapability           `json:"dependency_capabilities,omitempty"`
 	StalenessWarnings         []telemetry.StalenessWarning               `json:"staleness_warnings,omitempty"`
+	StrandedIssues            []telemetry.StrandedIssue                  `json:"stranded_active_issues,omitempty"`
 	UntrackedIssues           []doctorStatusDriftIssueDiagnostic         `json:"untracked_issues,omitempty"`
 	OpenTerminalIssues        []doctorStatusDriftIssueDiagnostic         `json:"open_terminal_issues,omitempty"`
 	ProjectDefinition         *doctorProjectDefinitionDiagnostic         `json:"project_definition,omitempty"`
@@ -514,6 +515,12 @@ func runDoctor(ctx context.Context, cfg doctorConfig, opts options, deps doctorD
 			Name: "Fleet staleness",
 			Run: func(jobCtx context.Context) []doctorCheck {
 				return []doctorCheck{checkDoctorFleetStaleness(jobCtx, boot, cfg.ProjectID, deps)}
+			},
+		},
+		doctorCheckJob{
+			Name: "Stranded active work",
+			Run: func(jobCtx context.Context) []doctorCheck {
+				return []doctorCheck{checkDoctorStrandedActive(jobCtx, boot, cfg.ProjectID, deps)}
 			},
 		},
 		doctorCheckJob{

--- a/internal/cli/doctor_environment.go
+++ b/internal/cli/doctor_environment.go
@@ -693,6 +693,7 @@ type doctorHealthResponse struct {
 	Budgets           []doctorHealthBudget         `json:"budgets"`
 	Workflows         []doctorHealthWorkflow       `json:"workflows"`
 	StalenessWarnings []telemetry.StalenessWarning `json:"staleness_warnings"`
+	StrandedIssues    []telemetry.StrandedIssue    `json:"stranded_active_issues"`
 }
 
 type doctorHealthEnvironment struct {

--- a/internal/cli/doctor_stranded_active.go
+++ b/internal/cli/doctor_stranded_active.go
@@ -1,0 +1,60 @@
+package cli
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/digitaldrywood/detent/internal/telemetry"
+)
+
+func checkDoctorStrandedActive(ctx context.Context, boot BootConfig, projectID string, deps doctorDeps) doctorCheck {
+	check := doctorCheck{
+		Name:   "Stranded active work",
+		Status: doctorOK,
+		Detail: "no active issues are stranded without a live worker",
+	}
+	probe, err := probeDoctorHealth(ctx, doctorLiveBoot(boot, &boot.Global), deps)
+	if err != nil {
+		check.Detail = "live stranded-work check skipped because no healthy Detent instance was reachable"
+		return check
+	}
+	projectID = strings.TrimSpace(projectID)
+	issues := make([]telemetry.StrandedIssue, 0, len(probe.Health.StrandedIssues))
+	for _, issue := range probe.Health.StrandedIssues {
+		if projectID == "" || strings.TrimSpace(issue.ProjectID) == projectID {
+			issues = append(issues, issue)
+		}
+	}
+	if len(issues) == 0 {
+		return check
+	}
+	check.Status = doctorWarn
+	check.StrandedIssues = issues
+	details := make([]string, 0, len(issues))
+	for _, issue := range issues {
+		details = append(details, doctorStrandedActiveDetail(issue))
+	}
+	check.Detail = fmt.Sprintf("%d active issue(s) without a live worker: %s", len(issues), strings.Join(details, "; "))
+	check.Hint = "Review the last dispatch refusal and project capacity, then rerun detent doctor after dispatch resumes."
+	return check
+}
+
+func doctorStrandedActiveDetail(issue telemetry.StrandedIssue) string {
+	target := strings.TrimSpace(issue.Identifier)
+	if target == "" {
+		target = strings.TrimSpace(issue.IssueID)
+	}
+	if target == "" {
+		target = strings.TrimSpace(issue.IssueURL)
+	}
+	if target == "" {
+		target = "issue"
+	}
+	reason := strings.TrimSpace(issue.LastRefusalReason)
+	if reason == "" {
+		reason = "none recorded"
+	}
+	return target + " stranded for " + (time.Duration(issue.DurationSeconds) * time.Second).String() + "; last refusal: " + reason
+}

--- a/internal/cli/doctor_stranded_active_test.go
+++ b/internal/cli/doctor_stranded_active_test.go
@@ -1,0 +1,70 @@
+package cli
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+func TestCheckDoctorStrandedActive(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, _ *http.Request) {
+		writer.Header().Set("Content-Type", "application/json")
+		_, _ = writer.Write([]byte(`{
+			"status":"ok",
+			"mode":"running",
+			"checks":{"hub":"configured","store":"configured","registry":"configured","connector":"configured"},
+			"stranded_active_issues":[
+				{"project_id":"detent","issue_id":"issue-1","identifier":"digitaldrywood/detent#1606","duration_seconds":900,"last_refusal_reason":"priority reservation"}
+			]
+		}`))
+	}))
+	t.Cleanup(server.Close)
+	host, portText := splitStalenessTestServerAddress(t, server)
+	port, err := strconv.Atoi(portText)
+	if err != nil {
+		t.Fatalf("parse server port: %v", err)
+	}
+	deps := doctorDeps{httpDo: server.Client().Do}.withDefaults()
+
+	tests := []struct {
+		name        string
+		projectID   string
+		wantStatus  doctorStatus
+		wantIssues  int
+		wantDetails []string
+	}{
+		{
+			name:        "reports matching project",
+			projectID:   "detent",
+			wantStatus:  doctorWarn,
+			wantIssues:  1,
+			wantDetails: []string{"digitaldrywood/detent#1606", "15m0s", "priority reservation"},
+		},
+		{
+			name:       "filters other project",
+			projectID:  "other",
+			wantStatus: doctorOK,
+			wantIssues: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			check := checkDoctorStrandedActive(t.Context(), BootConfig{Host: host, Port: &port}, tt.projectID, deps)
+			if check.Status != tt.wantStatus || len(check.StrandedIssues) != tt.wantIssues {
+				t.Fatalf("check = %#v, want status %q and %d issue(s)", check, tt.wantStatus, tt.wantIssues)
+			}
+			for _, detail := range tt.wantDetails {
+				if !strings.Contains(check.Detail, detail) {
+					t.Fatalf("detail = %q, want %q", check.Detail, detail)
+				}
+			}
+		})
+	}
+}

--- a/internal/cli/runner.go
+++ b/internal/cli/runner.go
@@ -890,6 +890,7 @@ func mergeSnapshot(current, next telemetry.Snapshot) telemetry.Snapshot {
 	current.FailureBreakers = append(current.FailureBreakers, next.FailureBreakers...)
 	current.DispatchRecoveries = append(current.DispatchRecoveries, next.DispatchRecoveries...)
 	current.StalenessWarnings = append(current.StalenessWarnings, next.StalenessWarnings...)
+	current.StrandedActiveIssues = append(current.StrandedActiveIssues, next.StrandedActiveIssues...)
 	current.AgentPools = append(current.AgentPools, next.AgentPools...)
 	current.OverloadRetriesLastHour += next.OverloadRetriesLastHour
 
@@ -1057,6 +1058,11 @@ func stampSnapshotProjectID(snapshot telemetry.Snapshot) telemetry.Snapshot {
 	for i := range snapshot.StalenessWarnings {
 		if strings.TrimSpace(snapshot.StalenessWarnings[i].ProjectID) == "" {
 			snapshot.StalenessWarnings[i].ProjectID = projectID
+		}
+	}
+	for i := range snapshot.StrandedActiveIssues {
+		if strings.TrimSpace(snapshot.StrandedActiveIssues[i].ProjectID) == "" {
+			snapshot.StrandedActiveIssues[i].ProjectID = projectID
 		}
 	}
 	return snapshot

--- a/internal/cli/runner_test.go
+++ b/internal/cli/runner_test.go
@@ -117,6 +117,9 @@ func TestStampSnapshotProjectIDPreservesDegradedFreshness(t *testing.T) {
 	now := time.Date(2026, 7, 17, 15, 0, 0, 0, time.UTC)
 	snapshot := stampSnapshotProjectID(telemetry.Snapshot{
 		Project: telemetry.Project{ID: "docs"},
+		StrandedActiveIssues: []telemetry.StrandedIssue{{
+			Identifier: "digitaldrywood/docs#1",
+		}},
 		Refresh: telemetry.Refresh{
 			Status:      telemetry.RefreshStatusDegraded,
 			LastError:   "project runtime unavailable",
@@ -136,6 +139,9 @@ func TestStampSnapshotProjectIDPreservesDegradedFreshness(t *testing.T) {
 	}
 	if !snapshot.Refresh.Stale(now) {
 		t.Fatal("Refresh.Stale() = false, want true")
+	}
+	if len(snapshot.StrandedActiveIssues) != 1 || snapshot.StrandedActiveIssues[0].ProjectID != "docs" {
+		t.Fatalf("StrandedActiveIssues = %#v, want docs project ID", snapshot.StrandedActiveIssues)
 	}
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -84,6 +84,7 @@ const (
 	DefaultStalenessRepeatedCount         = 20
 	DefaultStalenessRepeatedWindowHours   = 24
 	DefaultStalenessWebhookTimeoutMS      = 5000
+	DefaultStrandedActiveThresholdSeconds = 10 * 60
 	MaxStalenessRepeatedCount             = 500
 
 	defaultCodexProtocol                      = "app-server"
@@ -710,12 +711,13 @@ type Kanban struct {
 }
 
 type Observability struct {
-	DashboardEnabled bool                    `yaml:"dashboard_enabled"`
-	RefreshMS        int                     `yaml:"refresh_ms"`
-	RenderIntervalMS int                     `yaml:"render_interval_ms"`
-	Efficiency       EfficiencyObservability `yaml:"efficiency,omitempty"`
-	OTLP             OTLPObservability       `yaml:"otlp,omitempty"`
-	Staleness        StalenessObservability  `yaml:"staleness,omitempty"`
+	DashboardEnabled               bool                    `yaml:"dashboard_enabled"`
+	RefreshMS                      int                     `yaml:"refresh_ms"`
+	RenderIntervalMS               int                     `yaml:"render_interval_ms"`
+	StrandedActiveThresholdSeconds int                     `yaml:"stranded_active_threshold_seconds"`
+	Efficiency                     EfficiencyObservability `yaml:"efficiency,omitempty"`
+	OTLP                           OTLPObservability       `yaml:"otlp,omitempty"`
+	Staleness                      StalenessObservability  `yaml:"staleness,omitempty"`
 }
 
 type EfficiencyObservability struct {
@@ -1355,9 +1357,10 @@ func Default() Config {
 			Kanban:                         Kanban{Mode: KanbanModeReadOnly},
 		},
 		Observability: Observability{
-			DashboardEnabled: true,
-			RefreshMS:        1000,
-			RenderIntervalMS: 16,
+			DashboardEnabled:               true,
+			RefreshMS:                      1000,
+			RenderIntervalMS:               16,
+			StrandedActiveThresholdSeconds: DefaultStrandedActiveThresholdSeconds,
 			Efficiency: EfficiencyObservability{
 				AnomalyTokensMultiple:   3,
 				AnomalySessionsMultiple: 3,
@@ -2551,6 +2554,7 @@ func (s *Server) validate(problems *[]string) {
 func (o *Observability) validate(problems *[]string) {
 	validatePositive("observability.refresh_ms", o.RefreshMS, problems)
 	validatePositive("observability.render_interval_ms", o.RenderIntervalMS, problems)
+	validatePositive("observability.stranded_active_threshold_seconds", o.StrandedActiveThresholdSeconds, problems)
 	validatePositiveFloat("observability.efficiency.anomaly_tokens_multiple", o.Efficiency.AnomalyTokensMultiple, problems)
 	validatePositiveFloat("observability.efficiency.anomaly_sessions_multiple", o.Efficiency.AnomalySessionsMultiple, problems)
 	validatePositiveFloat("observability.efficiency.anomaly_dwell_multiple", o.Efficiency.AnomalyDwellMultiple, problems)

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1439,6 +1439,9 @@ func TestParseWorkflowDefaults(t *testing.T) {
 	if !cfg.Observability.DashboardEnabled {
 		t.Fatal("Observability.DashboardEnabled = false, want true")
 	}
+	if cfg.Observability.StrandedActiveThresholdSeconds != DefaultStrandedActiveThresholdSeconds {
+		t.Fatalf("Observability.StrandedActiveThresholdSeconds = %d, want %d", cfg.Observability.StrandedActiveThresholdSeconds, DefaultStrandedActiveThresholdSeconds)
+	}
 	if cfg.Observability.Efficiency.AnomalyTokensMultiple != 3 || cfg.Observability.Efficiency.AnomalySessionsMultiple != 3 || cfg.Observability.Efficiency.AnomalyDwellMultiple != 3 {
 		t.Fatalf("Observability.Efficiency = %#v, want 3x defaults", cfg.Observability.Efficiency)
 	}
@@ -2877,6 +2880,13 @@ func TestObservabilityValidation(t *testing.T) {
 				cfg.Observability.Efficiency.AnomalyTokensMultiple = 0
 			},
 			wantErr: "observability.efficiency.anomaly_tokens_multiple must be greater than 0",
+		},
+		{
+			name: "nonpositive stranded active threshold",
+			mutate: func(cfg *Config) {
+				cfg.Observability.StrandedActiveThresholdSeconds = 0
+			},
+			wantErr: "observability.stranded_active_threshold_seconds must be greater than 0",
 		},
 	}
 	for _, tt := range tests {

--- a/internal/orchestrator/config.go
+++ b/internal/orchestrator/config.go
@@ -123,6 +123,7 @@ func ConfigFromWorkflow(cfg workflowconfig.Config) Config {
 			Headers:    cloneStringMap(cfg.Observability.Staleness.Webhook.Headers),
 			Timeout:    durationFromMillis(cfg.Observability.Staleness.Webhook.TimeoutMS),
 		},
+		StrandedActiveThreshold: durationFromSeconds(cfg.Observability.StrandedActiveThresholdSeconds),
 	}
 }
 
@@ -163,6 +164,9 @@ func normalizeConfig(cfg Config) Config {
 	}
 	if cfg.OverloadRetryDelay <= 0 {
 		cfg.OverloadRetryDelay = defaultOverloadRetryDelay
+	}
+	if cfg.StrandedActiveThreshold <= 0 {
+		cfg.StrandedActiveThreshold = durationFromSeconds(workflowconfig.DefaultStrandedActiveThresholdSeconds)
 	}
 	if cfg.MergeWorkerStartupTimeout <= 0 {
 		cfg.MergeWorkerStartupTimeout = durationFromMillis(workflowconfig.DefaultMergeWorkerStartupTimeoutMS)

--- a/internal/orchestrator/dispatch_test.go
+++ b/internal/orchestrator/dispatch_test.go
@@ -245,6 +245,7 @@ func TestConfigFromWorkflowIncludesDispatchControls(t *testing.T) {
 	cfg.Agent.OverloadRetryDelayMS = 60000
 	cfg.Agent.MergeWorkerStartupTimeoutMS = 180000
 	cfg.Agent.MergeWorkerMaxDurationMS = 7200000
+	cfg.Observability.StrandedActiveThresholdSeconds = 42
 	cfg.Deliverable.MergeMethod = workflowconfig.MergeMethodRebase
 	cfg.Agent.OutputTruncation.MaxBytes = 4096
 	cfg.Identity.Name = "release-captain"
@@ -287,6 +288,9 @@ func TestConfigFromWorkflowIncludesDispatchControls(t *testing.T) {
 	}
 	if got.MergeWorkerMaxDuration != 2*time.Hour {
 		t.Fatalf("MergeWorkerMaxDuration = %s, want 2h", got.MergeWorkerMaxDuration)
+	}
+	if got.StrandedActiveThreshold != 42*time.Second {
+		t.Fatalf("StrandedActiveThreshold = %s, want 42s", got.StrandedActiveThreshold)
 	}
 	if got.NoProgressTokenLimit != workflowconfig.DefaultNoProgressTokenLimit {
 		t.Fatalf("NoProgressTokenLimit = %d, want %d", got.NoProgressTokenLimit, workflowconfig.DefaultNoProgressTokenLimit)

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -114,6 +114,7 @@ type Config struct {
 	Lessons                       LessonCaptureConfig
 	Staleness                     staleness.Config
 	StalenessDelivery             staleness.DeliveryConfig
+	StrandedActiveThreshold       time.Duration
 }
 
 type LessonCaptureConfig struct {
@@ -707,6 +708,8 @@ func (o *Orchestrator) State(ctx context.Context) (State, error) {
 		pool := o.dispatchPoolSnapshot()
 		state.PoolName = pool.Name
 		state.PoolCapacity = pool.Capacity
+		state.PoolAvailable = pool.Available
+		state.PoolDraining = pool.Draining
 		return state, nil
 	}
 }
@@ -868,6 +871,7 @@ func (o *Orchestrator) applyRuntimeUpdate(state *State, update RuntimeUpdate, ti
 	})
 	state.PollInterval = cfg.PollInterval
 	state.MaxConcurrentAgents = cfg.MaxConcurrentAgents
+	state.StrandedActiveThreshold = cfg.StrandedActiveThreshold
 	state.AutoPromoteQuietDuration = cfg.AutoPromote.QuietDuration
 	state.AutoPromote = cloneAutoPromoteConfig(cfg.AutoPromote)
 	state.ActiveStates = append([]string(nil), cfg.ActiveStates...)

--- a/internal/orchestrator/retry_test.go
+++ b/internal/orchestrator/retry_test.go
@@ -74,12 +74,13 @@ func TestApplyRuntimeUpdateRefreshesSupervisorRetryConfig(t *testing.T) {
 
 	orch.applyRuntimeUpdate(&state, RuntimeUpdate{
 		Config: Config{
-			PollInterval:          time.Hour,
-			MaxConcurrentAgents:   1,
-			MaxRetryBackoff:       2 * time.Second,
-			FailureRetryBaseDelay: time.Second,
-			ActiveStates:          []string{"Todo"},
-			TerminalStates:        []string{"Done"},
+			PollInterval:            time.Hour,
+			MaxConcurrentAgents:     1,
+			MaxRetryBackoff:         2 * time.Second,
+			FailureRetryBaseDelay:   time.Second,
+			StrandedActiveThreshold: 42 * time.Second,
+			ActiveStates:            []string{"Todo"},
+			TerminalStates:          []string{"Done"},
 		},
 	}, ticker)
 
@@ -88,6 +89,9 @@ func TestApplyRuntimeUpdateRefreshesSupervisorRetryConfig(t *testing.T) {
 	}
 	if state.PrioritizeUnblockers {
 		t.Fatal("State.PrioritizeUnblockers = true, want reloaded false")
+	}
+	if state.StrandedActiveThreshold != 42*time.Second {
+		t.Fatalf("State.StrandedActiveThreshold = %s, want reloaded 42s", state.StrandedActiveThreshold)
 	}
 }
 

--- a/internal/orchestrator/snapshot.go
+++ b/internal/orchestrator/snapshot.go
@@ -79,6 +79,7 @@ func (s State) Snapshot(now time.Time) telemetry.Snapshot {
 	s.applyGatePendingSnapshots(boardIssueSnapshots, boardIssues)
 	s.applyAutoPromoteDecisionSnapshots(boardIssueSnapshots, boardIssues, now)
 	s.applyArtifactGateWaitDispatchSnapshots(boardIssueSnapshots, boardIssues)
+	strandedActiveIssues := strandedActiveIssueSnapshots(s, boardIssueSnapshots, now)
 	pipelineIssueSnapshots := pipelineSnapshots(pipeline, s.AutoPromoteQuietDuration, s.PollInterval, s.MergeTimings, now, s.laneEntries)
 	applyIssueRuntimeIdentities(pipelineIssueSnapshots, s.Running, s.WorkAttempts)
 	s.applyAutoPromoteDecisionSnapshots(pipelineIssueSnapshots, pipeline, now)
@@ -105,6 +106,7 @@ func (s State) Snapshot(now time.Time) telemetry.Snapshot {
 		FailureBreakers:         projectFailureBreakerSnapshots(s.FailureBreaker),
 		DispatchRecoveries:      dispatchRecoverySnapshots(s.DispatchRecoveries, s.PoolName, poolCapacity),
 		StalenessWarnings:       stalenessWarningSnapshots(s.StalenessWarnings),
+		StrandedActiveIssues:    strandedActiveIssues,
 		OverloadRetriesLastHour: overloadRetriesLastHour(s.WorkAttempts, now),
 		Tokens:                  tokensFromTokenTotals(s.liveTokenTotals()),
 		Budget: telemetry.Budget{

--- a/internal/orchestrator/state.go
+++ b/internal/orchestrator/state.go
@@ -25,8 +25,12 @@ import (
 type State struct {
 	PollInterval             time.Duration
 	MaxConcurrentAgents      int
+	MaxAgentsByState         map[string]int
 	PoolName                 string
 	PoolCapacity             int
+	PoolAvailable            int
+	PoolDraining             bool
+	StrandedActiveThreshold  time.Duration
 	AutoPromoteQuietDuration time.Duration
 	AutoPromote              AutoPromoteConfig
 	ActiveStates             []string
@@ -265,6 +269,8 @@ func newState(cfg Config) State {
 	return State{
 		PollInterval:             cfg.PollInterval,
 		MaxConcurrentAgents:      cfg.MaxConcurrentAgents,
+		MaxAgentsByState:         cloneStateLimits(cfg.MaxConcurrentAgentsByState),
+		StrandedActiveThreshold:  cfg.StrandedActiveThreshold,
 		AutoPromoteQuietDuration: cfg.AutoPromote.QuietDuration,
 		AutoPromote:              cloneAutoPromoteConfig(cfg.AutoPromote),
 		ActiveStates:             append([]string(nil), cfg.ActiveStates...),
@@ -310,8 +316,12 @@ func (s State) clone() State {
 	cloned := State{
 		PollInterval:             s.PollInterval,
 		MaxConcurrentAgents:      s.MaxConcurrentAgents,
+		MaxAgentsByState:         cloneStateLimits(s.MaxAgentsByState),
 		PoolName:                 s.PoolName,
 		PoolCapacity:             s.PoolCapacity,
+		PoolAvailable:            s.PoolAvailable,
+		PoolDraining:             s.PoolDraining,
+		StrandedActiveThreshold:  s.StrandedActiveThreshold,
 		AutoPromoteQuietDuration: s.AutoPromoteQuietDuration,
 		AutoPromote:              cloneAutoPromoteConfig(s.AutoPromote),
 		ActiveStates:             append([]string(nil), s.ActiveStates...),

--- a/internal/orchestrator/stranded_active.go
+++ b/internal/orchestrator/stranded_active.go
@@ -1,0 +1,184 @@
+package orchestrator
+
+import (
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/digitaldrywood/detent/internal/store"
+	"github.com/digitaldrywood/detent/internal/telemetry"
+)
+
+const strandedActiveState = "in progress"
+
+func strandedActiveIssueSnapshots(state State, issues []telemetry.Issue, now time.Time) []telemetry.StrandedIssue {
+	if state.StrandedActiveThreshold <= 0 || state.PoolAvailable <= 0 || state.PoolDraining || now.IsZero() {
+		return nil
+	}
+	if len(state.Running) >= state.MaxConcurrentAgents {
+		return nil
+	}
+
+	stateLimit := state.MaxConcurrentAgents
+	if configured, ok := state.MaxAgentsByState[strandedActiveState]; ok {
+		stateLimit = configured
+	}
+	stateUsed := 0
+	for _, running := range state.Running {
+		if normalizeState(running.Issue.State) == strandedActiveState {
+			stateUsed++
+		}
+	}
+	if stateUsed >= stateLimit {
+		return nil
+	}
+
+	diagnostics := make([]telemetry.StrandedIssue, 0)
+	for _, issue := range issues {
+		if normalizeState(issue.State) != strandedActiveState || strandedActiveIssueHasWorker(issue, state.Running, state.WorkAttempts, now) {
+			continue
+		}
+		since, ok := strandedActiveSince(issue, state.WorkAttempts, now)
+		if !ok {
+			continue
+		}
+		duration := now.Sub(since)
+		if duration <= state.StrandedActiveThreshold {
+			continue
+		}
+		reason, refusedAt := latestStrandedActiveRefusal(issue, state.SchedulerDecisions)
+		diagnostics = append(diagnostics, telemetry.StrandedIssue{
+			IssueID:           strings.TrimSpace(issue.ID),
+			Identifier:        strings.TrimSpace(issue.Identifier),
+			IssueURL:          strings.TrimSpace(issue.URL),
+			Title:             strings.TrimSpace(issue.Title),
+			State:             strings.TrimSpace(issue.State),
+			Since:             since.UTC(),
+			DurationSeconds:   int64(duration / time.Second),
+			ThresholdSeconds:  int64(state.StrandedActiveThreshold / time.Second),
+			LastRefusalReason: reason,
+			LastRefusalAt:     refusedAt,
+		})
+	}
+	sort.Slice(diagnostics, func(i, j int) bool {
+		return strandedActiveTarget(diagnostics[i]) < strandedActiveTarget(diagnostics[j])
+	})
+	return diagnostics
+}
+
+func strandedActiveIssueHasWorker(issue telemetry.Issue, running map[string]Running, attempts []telemetry.WorkAttempt, now time.Time) bool {
+	for _, worker := range running {
+		if strandedActiveIdentityMatches(
+			issue.ID,
+			issue.Identifier,
+			issue.URL,
+			worker.Issue.ID,
+			worker.Issue.Identifier,
+			worker.Issue.URL,
+		) {
+			return true
+		}
+	}
+	for _, attempt := range attempts {
+		if !strandedActiveWorkAttemptIsLive(attempt, now) {
+			continue
+		}
+		if strandedActiveIdentityMatches(
+			issue.ID,
+			issue.Identifier,
+			issue.URL,
+			attempt.IssueID,
+			attempt.Identifier,
+			attempt.IssueURL,
+		) {
+			return true
+		}
+	}
+	return false
+}
+
+func strandedActiveWorkAttemptIsLive(attempt telemetry.WorkAttempt, now time.Time) bool {
+	if !strings.EqualFold(strings.TrimSpace(attempt.Status), string(store.WorkAttemptStatusActive)) || attempt.Stale {
+		return false
+	}
+	return attempt.LeaseExpiresAt == nil || attempt.LeaseExpiresAt.After(now)
+}
+
+func strandedActiveSince(issue telemetry.Issue, attempts []telemetry.WorkAttempt, now time.Time) (time.Time, bool) {
+	if issue.CurrentLaneEnteredAt == nil || issue.CurrentLaneEnteredAt.IsZero() || now.Before(*issue.CurrentLaneEnteredAt) {
+		return time.Time{}, false
+	}
+	since := *issue.CurrentLaneEnteredAt
+	for _, attempt := range attempts {
+		if !strandedActiveIdentityMatches(
+			issue.ID,
+			issue.Identifier,
+			issue.URL,
+			attempt.IssueID,
+			attempt.Identifier,
+			attempt.IssueURL,
+		) {
+			continue
+		}
+		if attempt.CompletedAt != nil && !attempt.CompletedAt.After(now) && attempt.CompletedAt.After(since) {
+			since = *attempt.CompletedAt
+		}
+		if strings.EqualFold(strings.TrimSpace(attempt.Status), string(store.WorkAttemptStatusActive)) &&
+			attempt.LeaseExpiresAt != nil && !attempt.LeaseExpiresAt.After(now) && attempt.LeaseExpiresAt.After(since) {
+			since = *attempt.LeaseExpiresAt
+		}
+	}
+	return since, true
+}
+
+func latestStrandedActiveRefusal(issue telemetry.Issue, decisions []telemetry.SchedulerDecision) (string, *time.Time) {
+	var latest telemetry.SchedulerDecision
+	for _, decision := range decisions {
+		if !strings.EqualFold(strings.TrimSpace(decision.Result), "skipped") ||
+			!strandedActiveIdentityMatches(
+				issue.ID,
+				issue.Identifier,
+				issue.URL,
+				decision.IssueID,
+				decision.Identifier,
+				decision.IssueURL,
+			) {
+			continue
+		}
+		if latest.DecisionAt.IsZero() || decision.DecisionAt.After(latest.DecisionAt) {
+			latest = decision
+		}
+	}
+	if latest.DecisionAt.IsZero() {
+		return "", nil
+	}
+	reason := strings.TrimSpace(latest.Reason)
+	if reason == "" {
+		reason = strings.TrimSpace(latest.WaitReason)
+	}
+	return reason, timePointer(latest.DecisionAt)
+}
+
+func strandedActiveIdentityMatches(leftID, leftIdentifier, leftURL, rightID, rightIdentifier, rightURL string) bool {
+	for _, pair := range [][2]string{
+		{leftID, rightID},
+		{leftIdentifier, rightIdentifier},
+		{leftURL, rightURL},
+	} {
+		left := strings.TrimSpace(pair[0])
+		right := strings.TrimSpace(pair[1])
+		if left != "" && right != "" && left == right {
+			return true
+		}
+	}
+	return false
+}
+
+func strandedActiveTarget(issue telemetry.StrandedIssue) string {
+	for _, value := range []string{issue.Identifier, issue.IssueID, issue.IssueURL} {
+		if value = strings.TrimSpace(value); value != "" {
+			return value
+		}
+	}
+	return "issue"
+}

--- a/internal/orchestrator/stranded_active_test.go
+++ b/internal/orchestrator/stranded_active_test.go
@@ -1,0 +1,150 @@
+package orchestrator
+
+import (
+	"testing"
+	"time"
+
+	"github.com/digitaldrywood/detent/internal/connector"
+	"github.com/digitaldrywood/detent/internal/telemetry"
+)
+
+func TestStrandedActiveIssueSnapshots(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 7, 31, 16, 0, 0, 0, time.UTC)
+	laneEnteredAt := now.Add(-30 * time.Minute)
+	completedLongAgo := now.Add(-15 * time.Minute)
+	completedRecently := now.Add(-5 * time.Minute)
+	liveLease := now.Add(time.Minute)
+	staleLease := now.Add(-12 * time.Minute)
+	issue := telemetry.Issue{
+		ID:                   "issue-1",
+		Identifier:           "digitaldrywood/detent#1606",
+		URL:                  "https://github.com/digitaldrywood/detent/issues/1606",
+		Title:                "Surface stranded active work",
+		State:                "In Progress",
+		CurrentLaneEnteredAt: &laneEnteredAt,
+	}
+	baseState := State{
+		MaxConcurrentAgents:     3,
+		PoolAvailable:           1,
+		StrandedActiveThreshold: 10 * time.Minute,
+		Running:                 map[string]Running{},
+		SchedulerDecisions: []telemetry.SchedulerDecision{
+			{IssueID: issue.ID, Result: "skipped", Reason: "older refusal", DecisionAt: now.Add(-20 * time.Minute)},
+			{Identifier: issue.Identifier, Result: "skipped", WaitReason: "priority reservation", DecisionAt: now.Add(-time.Minute)},
+		},
+	}
+
+	tests := []struct {
+		name         string
+		state        State
+		issue        telemetry.Issue
+		wantCount    int
+		wantDuration int64
+		wantSince    time.Time
+		wantReason   string
+	}{
+		{
+			name:         "reports gap after latest completed attempt",
+			state:        withStrandedActiveAttempts(baseState, telemetry.WorkAttempt{IssueID: issue.ID, Status: "completed", CompletedAt: &completedLongAgo}),
+			issue:        issue,
+			wantCount:    1,
+			wantDuration: int64((15 * time.Minute) / time.Second),
+			wantSince:    completedLongAgo,
+			wantReason:   "priority reservation",
+		},
+		{
+			name:      "suppresses normal between-session gap",
+			state:     withStrandedActiveAttempts(baseState, telemetry.WorkAttempt{Identifier: issue.Identifier, Status: "completed", CompletedAt: &completedRecently}),
+			issue:     issue,
+			wantCount: 0,
+		},
+		{
+			name: "suppresses issue with running worker",
+			state: withStrandedActiveRunning(baseState, Running{Issue: connector.Issue{
+				ID: issue.ID, Identifier: issue.Identifier, URL: issue.URL, State: issue.State,
+			}}),
+			issue: issue,
+		},
+		{
+			name:      "suppresses issue with live persisted attempt",
+			state:     withStrandedActiveAttempts(baseState, telemetry.WorkAttempt{IssueURL: issue.URL, Status: "active", LeaseExpiresAt: &liveLease}),
+			issue:     issue,
+			wantCount: 0,
+		},
+		{
+			name: "reports from expired active attempt lease",
+			state: withStrandedActiveAttempts(baseState, telemetry.WorkAttempt{
+				IssueID: issue.ID, Status: "active", LeaseExpiresAt: &staleLease,
+			}),
+			issue:        issue,
+			wantCount:    1,
+			wantDuration: int64((12 * time.Minute) / time.Second),
+			wantSince:    staleLease,
+			wantReason:   "priority reservation",
+		},
+		{
+			name:      "suppresses gap when pool has no capacity",
+			state:     withStrandedActivePoolAvailable(baseState, 0),
+			issue:     issue,
+			wantCount: 0,
+		},
+		{
+			name:      "suppresses gap when project state capacity is full",
+			state:     withStrandedActiveStateLimit(baseState, 1, Running{Issue: connector.Issue{ID: "other", State: "In Progress"}}),
+			issue:     issue,
+			wantCount: 0,
+		},
+		{
+			name:  "suppresses non-working state",
+			state: baseState,
+			issue: func() telemetry.Issue {
+				other := issue
+				other.State = "Todo"
+				return other
+			}(),
+			wantCount: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := strandedActiveIssueSnapshots(tt.state, []telemetry.Issue{tt.issue}, now)
+			if len(got) != tt.wantCount {
+				t.Fatalf("strandedActiveIssueSnapshots() = %#v, want %d issue(s)", got, tt.wantCount)
+			}
+			if tt.wantCount == 0 {
+				return
+			}
+			if got[0].DurationSeconds != tt.wantDuration || !got[0].Since.Equal(tt.wantSince) {
+				t.Fatalf("diagnostic timing = %ds since %s, want %ds since %s", got[0].DurationSeconds, got[0].Since, tt.wantDuration, tt.wantSince)
+			}
+			if got[0].LastRefusalReason != tt.wantReason {
+				t.Fatalf("LastRefusalReason = %q, want %q", got[0].LastRefusalReason, tt.wantReason)
+			}
+		})
+	}
+}
+
+func withStrandedActiveAttempts(state State, attempts ...telemetry.WorkAttempt) State {
+	state.WorkAttempts = attempts
+	return state
+}
+
+func withStrandedActiveRunning(state State, running Running) State {
+	state.Running = map[string]Running{running.Issue.ID: running}
+	return state
+}
+
+func withStrandedActivePoolAvailable(state State, available int) State {
+	state.PoolAvailable = available
+	return state
+}
+
+func withStrandedActiveStateLimit(state State, limit int, running Running) State {
+	state.MaxAgentsByState = map[string]int{strandedActiveState: limit}
+	return withStrandedActiveRunning(state, running)
+}

--- a/internal/telemetry/snapshot.go
+++ b/internal/telemetry/snapshot.go
@@ -42,6 +42,7 @@ type Snapshot struct {
 	FailureBreakers         []FailureBreaker    `json:"failure_breakers,omitempty"`
 	DispatchRecoveries      []DispatchRecovery  `json:"dispatch_recoveries,omitempty"`
 	StalenessWarnings       []StalenessWarning  `json:"staleness_warnings,omitempty"`
+	StrandedActiveIssues    []StrandedIssue     `json:"stranded_active_issues,omitempty"`
 	OverloadRetriesLastHour int                 `json:"overload_retries_last_hour,omitempty"`
 	Tokens                  Tokens              `json:"tokens"`
 	Throughput              TokenThroughput     `json:"throughput"`
@@ -100,6 +101,20 @@ type StalenessWarning struct {
 	DeliveryAttempts      int        `json:"delivery_attempts,omitempty"`
 	LastDeliveryAttemptAt *time.Time `json:"last_delivery_attempt_at,omitempty"`
 	DeliveryError         string     `json:"delivery_error,omitempty"`
+}
+
+type StrandedIssue struct {
+	ProjectID         string     `json:"project_id,omitempty"`
+	IssueID           string     `json:"issue_id,omitempty"`
+	Identifier        string     `json:"identifier,omitempty"`
+	IssueURL          string     `json:"issue_url,omitempty"`
+	Title             string     `json:"title,omitempty"`
+	State             string     `json:"state,omitempty"`
+	Since             time.Time  `json:"since"`
+	DurationSeconds   int64      `json:"duration_seconds"`
+	ThresholdSeconds  int64      `json:"threshold_seconds"`
+	LastRefusalReason string     `json:"last_refusal_reason,omitempty"`
+	LastRefusalAt     *time.Time `json:"last_refusal_at,omitempty"`
 }
 
 type Update struct {

--- a/internal/web/project_scope.go
+++ b/internal/web/project_scope.go
@@ -74,6 +74,7 @@ func projectScopedSnapshotForProject(snapshot telemetry.Snapshot, selectedProjec
 	out.FailureBreakers = scopedFailureBreakers(snapshot.FailureBreakers, selectedProjectID, fallbackProjectID)
 	out.DispatchRecoveries = scopedDispatchRecoveries(snapshot.DispatchRecoveries, selectedProjectID, fallbackProjectID)
 	out.StalenessWarnings = scopedStalenessWarnings(snapshot.StalenessWarnings, selectedProjectID, fallbackProjectID)
+	out.StrandedActiveIssues = scopedStrandedActiveIssues(snapshot.StrandedActiveIssues, selectedProjectID, fallbackProjectID)
 	if hasSourceProject {
 		out.Counts = sourceProject.Counts
 		out.Tokens = sourceProject.Tokens
@@ -96,6 +97,20 @@ func projectScopedSnapshotForProject(snapshot telemetry.Snapshot, selectedProjec
 		out.TokenTrend = nil
 	}
 	out.WorkflowMetrics = scopedWorkflowMetrics(out, snapshot.WorkflowMetrics, selectedProjectID)
+	return out
+}
+
+func scopedStrandedActiveIssues(issues []telemetry.StrandedIssue, selectedProjectID string, fallbackProjectID string) []telemetry.StrandedIssue {
+	out := make([]telemetry.StrandedIssue, 0, len(issues))
+	for _, issue := range issues {
+		projectID := strings.TrimSpace(issue.ProjectID)
+		if projectID == "" {
+			projectID = fallbackProjectID
+		}
+		if projectID == selectedProjectID {
+			out = append(out, issue)
+		}
+	}
 	return out
 }
 

--- a/internal/web/project_scope_test.go
+++ b/internal/web/project_scope_test.go
@@ -75,6 +75,10 @@ func TestProjectScopedSnapshotFiltersRowsAndUsesProjectTotals(t *testing.T) {
 			{ProjectID: "detent", Kind: "github_rest", Status: "ramping"},
 			{ProjectID: "pyroapex", Kind: "backend_capacity", Status: "waiting"},
 		},
+		StrandedActiveIssues: []telemetry.StrandedIssue{
+			{ProjectID: "detent", IssueID: "detent-stranded"},
+			{ProjectID: "pyroapex", IssueID: "pyro-stranded"},
+		},
 	}, "detent")
 
 	if !ok {
@@ -124,6 +128,9 @@ func TestProjectScopedSnapshotFiltersRowsAndUsesProjectTotals(t *testing.T) {
 	}
 	if len(got.DispatchRecoveries) != 1 || got.DispatchRecoveries[0].Kind != "github_rest" {
 		t.Fatalf("DispatchRecoveries = %#v, want only detent row", got.DispatchRecoveries)
+	}
+	if len(got.StrandedActiveIssues) != 1 || got.StrandedActiveIssues[0].IssueID != "detent-stranded" {
+		t.Fatalf("StrandedActiveIssues = %#v, want only detent row", got.StrandedActiveIssues)
 	}
 }
 

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -1035,11 +1035,13 @@ func (s *Server) health(c echo.Context) error {
 	updateStatus := telemetry.Update{}
 	backendOutages := []telemetry.BackendOutage{}
 	stalenessWarnings := []telemetry.StalenessWarning{}
+	strandedActiveIssues := []telemetry.StrandedIssue{}
 	if s.hub != nil {
 		if snapshot, ok := s.hub.Latest(); ok {
 			updateStatus = snapshot.Update
 			backendOutages = append(backendOutages, snapshot.BackendOutages...)
 			stalenessWarnings = append(stalenessWarnings, snapshot.StalenessWarnings...)
+			strandedActiveIssues = append(strandedActiveIssues, snapshot.StrandedActiveIssues...)
 			if snapshot.Shutdown.Draining {
 				status = "draining"
 				sessionsRemaining = snapshot.Shutdown.SessionsRemaining
@@ -1076,6 +1078,7 @@ func (s *Server) health(c echo.Context) error {
 		Workflows:         workflows,
 		BackendOutages:    backendOutages,
 		StalenessWarnings: stalenessWarnings,
+		StrandedIssues:    strandedActiveIssues,
 		Projects:          projectHealth,
 	})
 }
@@ -1324,6 +1327,7 @@ type healthResponse struct {
 	Workflows         []healthWorkflowSource       `json:"workflows,omitempty"`
 	BackendOutages    []telemetry.BackendOutage    `json:"backend_outages,omitempty"`
 	StalenessWarnings []telemetry.StalenessWarning `json:"staleness_warnings,omitempty"`
+	StrandedIssues    []telemetry.StrandedIssue    `json:"stranded_active_issues,omitempty"`
 	Projects          []healthProject              `json:"projects,omitempty"`
 }
 

--- a/internal/web/server_test.go
+++ b/internal/web/server_test.go
@@ -6601,6 +6601,33 @@ func TestHealthReportsDraining(t *testing.T) {
 	}
 }
 
+func TestHealthReportsStrandedActiveIssues(t *testing.T) {
+	t.Parallel()
+
+	deps := testDeps(t)
+	if err := deps.Hub.Publish(telemetry.Snapshot{
+		StrandedActiveIssues: []telemetry.StrandedIssue{{
+			ProjectID: "detent", Identifier: "digitaldrywood/detent#1606", DurationSeconds: 900, LastRefusalReason: "priority reservation",
+		}},
+	}); err != nil {
+		t.Fatalf("Publish() error = %v", err)
+	}
+	server, err := web.NewServer(web.Config{}, deps)
+	if err != nil {
+		t.Fatalf("NewServer() error = %v", err)
+	}
+
+	payload := requestJSON(t, server, http.MethodGet, "/health", http.StatusOK)
+	issues, ok := payload["stranded_active_issues"].([]any)
+	if !ok || len(issues) != 1 {
+		t.Fatalf("stranded_active_issues = %#v, want one issue", payload["stranded_active_issues"])
+	}
+	issue, ok := issues[0].(map[string]any)
+	if !ok || issue["identifier"] != "digitaldrywood/detent#1606" || issue["last_refusal_reason"] != "priority reservation" {
+		t.Fatalf("stranded_active_issues[0] = %#v", issues[0])
+	}
+}
+
 func TestHealthDistinguishesProcessHealthFromProjectConnectorDegradation(t *testing.T) {
 	t.Parallel()
 

--- a/internal/web/templates/health_data.go
+++ b/internal/web/templates/health_data.go
@@ -1,6 +1,7 @@
 package templates
 
 import (
+	"sort"
 	"strings"
 	"time"
 
@@ -47,6 +48,12 @@ func healthViewFromDashboard(data DashboardData) healthView {
 		view.Kind = primitives.KindWarn
 		view.Verdict = "Fleet work is stale."
 		view.Detail = stalenessHealthDetail(snapshot.StalenessWarnings)
+		return view
+	}
+	if len(snapshot.StrandedActiveIssues) > 0 {
+		view.Kind = primitives.KindWarn
+		view.Verdict = "Active work has no live worker."
+		view.Detail = strandedActiveHealthDetail(snapshot.StrandedActiveIssues)
 		return view
 	}
 	outages := backendCapacityOutages(snapshot.BackendOutages)
@@ -154,6 +161,7 @@ func healthRows(snapshot telemetry.Snapshot) []healthRow {
 	for _, warning := range snapshot.StalenessWarnings {
 		rows = append(rows, healthStalenessRow(warning))
 	}
+	rows = append(rows, healthStrandedActiveRows(snapshot.StrandedActiveIssues)...)
 	if snapshot.RateLimits != nil {
 		if bucket := snapshot.RateLimits.GitHubREST; bucket != nil {
 			row := healthBucketRow("health-github-rest", "GitHub REST", bucket)
@@ -181,6 +189,68 @@ func healthRows(snapshot telemetry.Snapshot) []healthRow {
 		rows = append(rows, healthBackendOutageRow(outage, snapshot.GeneratedAt))
 	}
 	return rows
+}
+
+func healthStrandedActiveRows(issues []telemetry.StrandedIssue) []healthRow {
+	byProject := make(map[string][]telemetry.StrandedIssue)
+	for _, issue := range issues {
+		projectID := strings.TrimSpace(issue.ProjectID)
+		if projectID == "" {
+			projectID = "project"
+		}
+		byProject[projectID] = append(byProject[projectID], issue)
+	}
+	projects := make([]string, 0, len(byProject))
+	for projectID := range byProject {
+		projects = append(projects, projectID)
+	}
+	sort.Strings(projects)
+
+	rows := make([]healthRow, 0, len(projects))
+	for _, projectID := range projects {
+		projectIssues := byProject[projectID]
+		sort.Slice(projectIssues, func(i, j int) bool {
+			return strandedActiveHealthTarget(projectIssues[i]) < strandedActiveHealthTarget(projectIssues[j])
+		})
+		details := make([]string, 0, len(projectIssues))
+		for _, issue := range projectIssues {
+			details = append(details, strandedActiveHealthIssueDetail(issue))
+		}
+		rows = append(rows, healthRow{
+			ID:        "health-stranded-active-" + boardCardSlug(projectID),
+			Component: "Active work · " + projectID,
+			Kind:      primitives.KindWarn,
+			Status:    "No live worker",
+			Detail:    strings.Join(details, "; "),
+			Resets:    "on dispatch",
+		})
+	}
+	return rows
+}
+
+func strandedActiveHealthDetail(issues []telemetry.StrandedIssue) string {
+	if len(issues) == 1 {
+		return strandedActiveHealthIssueDetail(issues[0]) + "."
+	}
+	return formatCount(len(issues)) + " active issues have no live worker."
+}
+
+func strandedActiveHealthIssueDetail(issue telemetry.StrandedIssue) string {
+	detail := strandedActiveHealthTarget(issue) + " · " + formatDuration(float64(issue.DurationSeconds))
+	reason := strings.TrimSpace(issue.LastRefusalReason)
+	if reason == "" {
+		reason = "none recorded"
+	}
+	return detail + " · last refusal: " + reason
+}
+
+func strandedActiveHealthTarget(issue telemetry.StrandedIssue) string {
+	for _, value := range []string{issue.Identifier, issue.IssueID, issue.IssueURL} {
+		if value = strings.TrimSpace(value); value != "" {
+			return value
+		}
+	}
+	return "issue"
 }
 
 func healthStalenessRow(warning telemetry.StalenessWarning) healthRow {

--- a/internal/web/templates/health_data_test.go
+++ b/internal/web/templates/health_data_test.go
@@ -71,6 +71,17 @@ func TestHealthViewVerdicts(t *testing.T) {
 			wantKind:    primitives.KindWarn,
 			wantVerdict: "Dispatch is waiting on capacity.",
 		},
+		{
+			name: "stranded active issue warns",
+			snapshot: telemetry.Snapshot{
+				GeneratedAt: now,
+				StrandedActiveIssues: []telemetry.StrandedIssue{{
+					ProjectID: "detent", Identifier: "digitaldrywood/detent#1606", DurationSeconds: 900,
+				}},
+			},
+			wantKind:    primitives.KindWarn,
+			wantVerdict: "Active work has no live worker.",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -85,6 +96,31 @@ func TestHealthViewVerdicts(t *testing.T) {
 				t.Fatalf("checked at = %s", view.CheckedAt)
 			}
 		})
+	}
+}
+
+func TestHealthStrandedActiveRowsGroupByProject(t *testing.T) {
+	t.Parallel()
+
+	rows := healthStrandedActiveRows([]telemetry.StrandedIssue{
+		{ProjectID: "pyroapex", Identifier: "digitaldrywood/pyroapex#10", DurationSeconds: 1200},
+		{ProjectID: "detent", Identifier: "digitaldrywood/detent#1607", DurationSeconds: 720, LastRefusalReason: "budget cooldown"},
+		{ProjectID: "detent", Identifier: "digitaldrywood/detent#1606", DurationSeconds: 900, LastRefusalReason: "priority reservation"},
+	})
+
+	if len(rows) != 2 {
+		t.Fatalf("healthStrandedActiveRows() = %#v, want two project rows", rows)
+	}
+	if rows[0].Component != "Active work · detent" || rows[0].Status != "No live worker" {
+		t.Fatalf("detent row = %#v", rows[0])
+	}
+	for _, want := range []string{"digitaldrywood/detent#1606", "15m", "priority reservation", "digitaldrywood/detent#1607", "12m", "budget cooldown"} {
+		if !strings.Contains(rows[0].Detail, want) {
+			t.Fatalf("detent detail = %q, want %q", rows[0].Detail, want)
+		}
+	}
+	if rows[1].Component != "Active work · pyroapex" || !strings.Contains(rows[1].Detail, "none recorded") {
+		t.Fatalf("pyroapex row = %#v", rows[1])
 	}
 }
 


### PR DESCRIPTION
## Summary

- detect In Progress issues with no live attempt once a configurable threshold elapses while project capacity is free
- surface the issue duration and latest dispatch refusal in per-project Health rows and `detent doctor`
- document the 600-second default through the generated config reference without adding a board banner

Fixes #1606

## UI Surface Contract

- [x] The linked issue explicitly authorizes the per-project Health row; no high-impact layout or density change is introduced.
- [x] This PR does not add persistent top-of-screen messaging or a board banner.
- [x] Health rendering is verified below through focused view-data and endpoint tests; the change reuses the existing Health row component and adds no new markup or layout.

## Test Plan

- [x] `make generate`
- [x] focused configdoc, detector, doctor, Health API/scoping, and Health row tests
- [x] `make check` (race suite and 78.3% coverage green)
