### PR TITLE
test(project): make watcher wait deterministic

### DIFF
--- a/internal/project/workflow_source_test.go
+++ b/internal/project/workflow_source_test.go
@@ -301,8 +301,8 @@ func readWorkflowSourceUpdate(t *testing.T, updates <-chan configwatcher.Update)
 	select {
 	case update := <-updates:
 		return update
-	case <-time.After(time.Second):
-		t.Fatal("timed out waiting for workflow update")
+	case <-time.After(30 * time.Second):
+		t.Fatal("deadlocked waiting for workflow update")
 		return configwatcher.Update{}
 	}
 }


### PR DESCRIPTION
## Summary

- replace the workflow update helper's one-second scheduler margin with a 30-second deadlock-only guard
- preserve fsnotify lifecycle coverage for local overlay creation and deletion

Fixes #1586

## UI Surface Contract

- [x] N/A, or the linked issue explicitly authorizes any high-impact UI surface, layout, density, first-viewport, or responsive visibility tradeoff.
- [x] Persistent top-of-screen messaging is explicitly authorized by the issue, or this PR does not add it.
- [x] Visual changes to primary operator screens include screenshot or browser verification below.

## Test Plan

- [x] `go test -race ./internal/project -run '^TestGitRefWorkflowWatcherReloadsLocalOverlayLifecycle$' -count=20`
- [x] `go test -race ./internal/project -count=10`
- [x] `make check`