### PR TITLE
fix(admission): reconcile manual proposal moves

### DIFF
--- a/internal/admission/manager.go
+++ b/internal/admission/manager.go
@@ -683,6 +683,34 @@ func (m *Manager) resolveProposalFromIssueState(
 	proposal admissionmodel.Proposal,
 	at time.Time,
 ) (bool, error) {
+	transitions, err := m.store.AdmissionTargetTransitions(ctx, admissionmodel.TargetTransitionQuery{
+		ProjectID:   proposal.ProjectID,
+		IssueID:     proposal.IssueID,
+		TargetState: proposal.TargetState,
+		NotBefore:   proposal.CreatedAt,
+	})
+	if err != nil {
+		return false, err
+	}
+	if len(transitions) > 0 {
+		transition := transitions[0]
+		decision := admissionmodel.Decision{
+			ProposalID:        proposal.ID,
+			Outcome:           admissionmodel.ProposalAccepted,
+			DecidedAt:         transition.EnteredAt.UTC(),
+			ActorLogin:        transition.ActorLogin,
+			ActorKind:         transition.ActorKind,
+			TransitionAt:      transition.EnteredAt.UTC(),
+			TransitionEventID: transition.EventID,
+			Reason:            admissionResolutionImplicitAccept,
+			Implicit:          true,
+		}
+		if err := m.store.ResolveAdmissionProposal(ctx, decision); err != nil {
+			return false, err
+		}
+		return true, nil
+	}
+
 	var reason string
 	outcome := admissionmodel.ProposalSuperseded
 	if strings.EqualFold(strings.TrimSpace(issue.State), strings.TrimSpace(proposal.TargetState)) {

--- a/internal/admission/manager.go
+++ b/internal/admission/manager.go
@@ -32,6 +32,9 @@ const (
 	admissionState                         = "Admission"
 	admissionResolutionExplicitAccept      = "explicit_accept"
 	admissionResolutionExplicitReject      = "explicit_reject"
+	admissionResolutionImplicitAccept      = "implicit_accept"
+	admissionResolutionIssueClosed         = "issue_closed"
+	admissionResolutionTerminalState       = "terminal_state_reached"
 	admissionResolutionAutoAdmit           = "auto_admit"
 	admissionResolutionSourceStateChanged  = "source_state_changed_before_acceptance"
 	admissionResolutionAutoAdmitIneligible = "candidate_became_ineligible_before_auto_admit"
@@ -550,6 +553,24 @@ func (m *Manager) reconcileOpenProposals(
 			}
 			continue
 		}
+		if !decided && autoAdmitProposal(settings.Config, proposal) {
+			recovered, err := m.recoverAutomaticAdmission(ctx, settings, issue, proposal)
+			if err != nil {
+				return commentsRemaining, autoAdmitsRemaining, err
+			}
+			if recovered {
+				continue
+			}
+		}
+		if !decided {
+			resolved, err := m.resolveProposalFromIssueState(ctx, settings, issue, proposal, at)
+			if err != nil {
+				return commentsRemaining, autoAdmitsRemaining, err
+			}
+			if resolved {
+				continue
+			}
+		}
 		if decided && decision.Outcome == admissionmodel.ProposalAccepted {
 			decision.Reason = admissionResolutionExplicitAccept
 			transitions, err := m.store.AdmissionTargetTransitions(ctx, admissionmodel.TargetTransitionQuery{
@@ -590,6 +611,14 @@ func (m *Manager) reconcileOpenProposals(
 			}
 		}
 		if decided && decision.Outcome == admissionmodel.ProposalAccepted {
+			if reason := inactiveProposalResolution(issue, settings.TerminalStates); reason != "" {
+				decision.Outcome = admissionmodel.ProposalSuperseded
+				decision.Reason = reason
+				if err := m.store.ResolveAdmissionProposal(ctx, decision); err != nil {
+					return commentsRemaining, autoAdmitsRemaining, err
+				}
+				continue
+			}
 			if !admissionSourceEligible(issue, settings.Config) {
 				decision.Outcome = admissionmodel.ProposalSuperseded
 				decision.Reason = admissionResolutionSourceStateChanged
@@ -604,13 +633,6 @@ func (m *Manager) reconcileOpenProposals(
 			continue
 		}
 		if !decided && autoAdmitProposal(settings.Config, proposal) {
-			recovered, err := m.recoverAutomaticAdmission(ctx, settings, issue, proposal)
-			if err != nil {
-				return commentsRemaining, autoAdmitsRemaining, err
-			}
-			if recovered {
-				continue
-			}
 			if !autoAdmitCandidateEligible(issue, settings.Config) {
 				decision := automaticAdmissionDecision(settings.Issues, proposal, at)
 				decision.Outcome = admissionmodel.ProposalSuperseded
@@ -652,6 +674,60 @@ func (m *Manager) reconcileOpenProposals(
 		}
 	}
 	return commentsRemaining, autoAdmitsRemaining, nil
+}
+
+func (m *Manager) resolveProposalFromIssueState(
+	ctx context.Context,
+	settings Settings,
+	issue connector.Issue,
+	proposal admissionmodel.Proposal,
+	at time.Time,
+) (bool, error) {
+	var reason string
+	outcome := admissionmodel.ProposalSuperseded
+	if strings.EqualFold(strings.TrimSpace(issue.State), strings.TrimSpace(proposal.TargetState)) {
+		reason = admissionResolutionImplicitAccept
+		outcome = admissionmodel.ProposalAccepted
+	} else {
+		reason = inactiveProposalResolution(issue, settings.TerminalStates)
+	}
+	if reason == "" {
+		return false, nil
+	}
+
+	decision := admissionmodel.Decision{
+		ProposalID: proposal.ID,
+		Outcome:    outcome,
+		DecidedAt:  at.UTC(),
+		Reason:     reason,
+		Implicit:   true,
+	}
+	if outcome == admissionmodel.ProposalAccepted {
+		transition, found, err := admissionIssueTransition(ctx, settings.Issues, issue)
+		if err != nil {
+			return false, err
+		}
+		if found && !transition.EnteredAt.IsZero() && !transition.EnteredAt.Before(proposal.CreatedAt) {
+			decision.DecidedAt = transition.EnteredAt.UTC()
+			decision.ActorLogin = transition.Actor.Login
+			decision.ActorKind = transition.Actor.Kind
+		}
+		decision.TransitionAt = decision.DecidedAt
+	}
+	if err := m.store.ResolveAdmissionProposal(ctx, decision); err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
+func inactiveProposalResolution(issue connector.Issue, terminalStates []string) string {
+	if issue.Closed {
+		return admissionResolutionIssueClosed
+	}
+	if containsFold(terminalStates, issue.State) {
+		return admissionResolutionTerminalState
+	}
+	return ""
 }
 
 func (m *Manager) unproposedCandidates(

--- a/internal/admission/manager_test.go
+++ b/internal/admission/manager_test.go
@@ -341,36 +341,89 @@ func TestManagerReconcilesAcceptanceAfterIssueLeavesTargetState(t *testing.T) {
 	}
 }
 
-func TestManagerTargetTransitionWithoutDecisionRemainsOpen(t *testing.T) {
+func TestManagerReconcilesOpenProposalFromIssueState(t *testing.T) {
 	t.Parallel()
 
 	now := time.Date(2026, 7, 29, 12, 0, 0, 0, time.UTC)
-	issue := admissionIssueFixture("issue-1", "DD-1", 1, now)
-	issue.State = "Todo"
 	transitionAt := now.Add(time.Minute)
-	issue.StageUpdatedAt = &transitionAt
-	tracker := memory.New(memory.Config{Issues: []connector.Issue{issue}, Stateful: true})
-	backend := openManagerTestStore(t)
-	proposal := admissionTestProposalForIssue("proposal-1", issue, now)
-	if created, err := backend.CreateAdmissionProposal(context.Background(), proposal); err != nil || !created {
-		t.Fatalf("CreateAdmissionProposal() = %t, %v", created, err)
+	tests := []struct {
+		name       string
+		state      string
+		closed     bool
+		transition bool
+		wantStatus admissionmodel.ProposalStatus
+		wantReason string
+	}{
+		{
+			name:       "target state implicitly accepts",
+			state:      "Todo",
+			transition: true,
+			wantStatus: admissionmodel.ProposalAccepted,
+			wantReason: admissionResolutionImplicitAccept,
+		},
+		{
+			name:       "closed issue supersedes",
+			state:      "Backlog",
+			closed:     true,
+			transition: true,
+			wantStatus: admissionmodel.ProposalSuperseded,
+			wantReason: admissionResolutionIssueClosed,
+		},
+		{
+			name:       "terminal issue supersedes",
+			state:      "Done",
+			transition: true,
+			wantStatus: admissionmodel.ProposalSuperseded,
+			wantReason: admissionResolutionTerminalState,
+		},
+		{
+			name:       "unactioned proposal stays open",
+			state:      "Backlog",
+			wantStatus: admissionmodel.ProposalOpen,
+		},
 	}
-	manager := newAdmissionTestManager(
-		t,
-		admissionTestSettings(tracker, &scriptedAdmissionRunner{propose: proposeEveryCandidate}),
-		backend,
-		func() time.Time { return transitionAt },
-	)
-	if _, err := manager.RunOnce(context.Background()); err != nil {
-		t.Fatalf("RunOnce() error = %v", err)
-	}
-	open, err := backend.OpenAdmissionProposals(context.Background(), "detent", 0)
-	if err != nil || len(open) != 1 || open[0].ID != proposal.ID {
-		t.Fatalf("OpenAdmissionProposals() = %#v, %v, want proposal open", open, err)
-	}
-	outcomes, err := backend.AdmissionDownstreamOutcomes(context.Background(), "detent")
-	if err != nil || len(outcomes) != 0 {
-		t.Fatalf("AdmissionDownstreamOutcomes() = %#v, %v, want none", outcomes, err)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			issue := admissionIssueFixture("issue-1", "DD-1", 1, now)
+			proposal := admissionTestProposalForIssue("proposal-1", issue, now)
+			issue.State = tt.state
+			issue.Closed = tt.closed
+			issue.StageUpdatedAt = &transitionAt
+			tracker := &transitionAdmissionIssueStore{
+				Connector: memory.New(memory.Config{Issues: []connector.Issue{issue}, Stateful: true}),
+				transition: connector.IssueStateTransition{
+					EnteredAt: transitionAt,
+					Actor:     connector.IssueActor{Login: "ada", Kind: "User"},
+				},
+				found: tt.transition,
+			}
+			backend := openManagerTestStore(t)
+			if created, err := backend.CreateAdmissionProposal(t.Context(), proposal); err != nil || !created {
+				t.Fatalf("CreateAdmissionProposal() = %t, %v", created, err)
+			}
+			settings := admissionTestSettings(tracker, &scriptedAdmissionRunner{propose: proposeEveryCandidate})
+			settings.TerminalStates = []string{"Done"}
+			manager := newAdmissionTestManager(t, settings, backend, func() time.Time { return transitionAt })
+
+			if _, err := manager.RunOnce(t.Context()); err != nil {
+				t.Fatalf("RunOnce() error = %v", err)
+			}
+			history, err := backend.AdmissionProposalHistory(t.Context(), proposal.ProjectID, proposal.IssueID)
+			if err != nil || len(history) != 1 {
+				t.Fatalf("AdmissionProposalHistory() = %#v, %v", history, err)
+			}
+			got := history[0]
+			if got.Status != tt.wantStatus || got.ResolutionReason != tt.wantReason {
+				t.Fatalf("resolved proposal = %#v", got)
+			}
+			if tt.wantStatus == admissionmodel.ProposalAccepted &&
+				(got.DecisionActorLogin != "ada" || got.DecisionActorKind != "User" ||
+					!got.TransitionAt.Equal(transitionAt) || got.DecisionCommentID != "") {
+				t.Fatalf("implicit acceptance evidence = %#v", got)
+			}
+		})
 	}
 }
 
@@ -969,6 +1022,46 @@ func TestManagerAutoAdmissionRespectsOpenProposalCap(t *testing.T) {
 	issues, err := tracker.FetchIssueStatesByIDs(t.Context(), []string{first.ID, second.ID})
 	if err != nil || len(issues) != 2 || issues[0].State != "Backlog" || issues[1].State != "Backlog" {
 		t.Fatalf("issues = %#v, %v", issues, err)
+	}
+}
+
+func TestManagerImplicitAcceptanceReleasesOpenProposalCapacity(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 7, 29, 12, 0, 0, 0, time.UTC)
+	first := admissionIssueFixture("issue-1", "DD-1", 1, now)
+	proposal := admissionTestProposalForIssue("proposal-open", first, now)
+	transitionAt := now.Add(time.Minute)
+	first.State = proposal.TargetState
+	first.StageUpdatedAt = &transitionAt
+	second := admissionIssueFixture("issue-2", "DD-2", 2, now)
+	tracker := &transitionAdmissionIssueStore{
+		Connector: memory.New(memory.Config{Issues: []connector.Issue{first, second}, Stateful: true}),
+		transition: connector.IssueStateTransition{
+			EnteredAt: transitionAt,
+			Actor:     connector.IssueActor{Login: "ada", Kind: "User"},
+		},
+		found: true,
+	}
+	backend := openManagerTestStore(t)
+	if created, err := backend.CreateAdmissionProposal(t.Context(), proposal); err != nil || !created {
+		t.Fatalf("CreateAdmissionProposal() = %t, %v", created, err)
+	}
+	agent := &scriptedAdmissionRunner{propose: proposeEveryCandidate}
+	settings := admissionTestSettings(tracker, agent)
+	settings.Config.MaxOpenProposals = 1
+	manager := newAdmissionTestManager(t, settings, backend, func() time.Time { return transitionAt })
+
+	result, err := manager.RunOnce(t.Context())
+	if err != nil {
+		t.Fatalf("RunOnce() error = %v", err)
+	}
+	if agent.calls != 1 || len(result.Proposals) != 1 || result.Proposals[0].IssueID != second.ID {
+		t.Fatalf("result = %#v, runner calls = %d", result, agent.calls)
+	}
+	open, err := backend.OpenAdmissionProposals(t.Context(), proposal.ProjectID, 0)
+	if err != nil || len(open) != 1 || open[0].IssueID != second.ID {
+		t.Fatalf("OpenAdmissionProposals() = %#v, %v", open, err)
 	}
 }
 
@@ -2487,6 +2580,19 @@ type stateChangingAdmissionStore struct {
 	fetches int
 	issueID string
 	state   string
+}
+
+type transitionAdmissionIssueStore struct {
+	*memory.Connector
+	transition connector.IssueStateTransition
+	found      bool
+}
+
+func (s *transitionAdmissionIssueStore) IssueStateTransition(
+	context.Context,
+	connector.Issue,
+) (connector.IssueStateTransition, bool, error) {
+	return s.transition, s.found, nil
 }
 
 type authorizingAdmissionIssueStore struct {

--- a/internal/admission/manager_test.go
+++ b/internal/admission/manager_test.go
@@ -347,19 +347,33 @@ func TestManagerReconcilesOpenProposalFromIssueState(t *testing.T) {
 	now := time.Date(2026, 7, 29, 12, 0, 0, 0, time.UTC)
 	transitionAt := now.Add(time.Minute)
 	tests := []struct {
-		name       string
-		state      string
-		closed     bool
-		transition bool
-		wantStatus admissionmodel.ProposalStatus
-		wantReason string
+		name           string
+		state          string
+		closed         bool
+		transition     bool
+		recordedTarget bool
+		wantStatus     admissionmodel.ProposalStatus
+		wantReason     string
+		wantActorLogin string
+		wantActorKind  string
 	}{
 		{
-			name:       "target state implicitly accepts",
-			state:      "Todo",
-			transition: true,
-			wantStatus: admissionmodel.ProposalAccepted,
-			wantReason: admissionResolutionImplicitAccept,
+			name:           "target state implicitly accepts",
+			state:          "Todo",
+			transition:     true,
+			wantStatus:     admissionmodel.ProposalAccepted,
+			wantReason:     admissionResolutionImplicitAccept,
+			wantActorLogin: "ada",
+			wantActorKind:  "User",
+		},
+		{
+			name:           "recorded target transition accepts after issue moves onward",
+			state:          "In Progress",
+			recordedTarget: true,
+			wantStatus:     admissionmodel.ProposalAccepted,
+			wantReason:     admissionResolutionImplicitAccept,
+			wantActorLogin: "grace",
+			wantActorKind:  "User",
 		},
 		{
 			name:       "closed issue supersedes",
@@ -403,6 +417,28 @@ func TestManagerReconcilesOpenProposalFromIssueState(t *testing.T) {
 			if created, err := backend.CreateAdmissionProposal(t.Context(), proposal); err != nil || !created {
 				t.Fatalf("CreateAdmissionProposal() = %t, %v", created, err)
 			}
+			if tt.recordedTarget {
+				if _, err := backend.RecordWorkflowPhaseEvent(t.Context(), store.WorkflowPhaseEvent{
+					ProjectID:  proposal.ProjectID,
+					IssueID:    proposal.IssueID,
+					Identifier: proposal.IssueIdentifier,
+					IssueURL:   proposal.IssueURL,
+					PhaseType:  store.WorkflowPhaseTypeLane,
+					PhaseName:  proposal.TargetState,
+					Reason:     "tracker_state_observed",
+					Status:     "entered",
+					StartedAt:  transitionAt,
+					MetadataJSON: provenance.Apply("{}", provenance.Attribution{
+						Origin: provenance.OriginUnknown,
+						Actor: &provenance.Actor{
+							Login: "grace",
+							Kind:  "User",
+						},
+					}, nil),
+				}); err != nil {
+					t.Fatalf("RecordWorkflowPhaseEvent() error = %v", err)
+				}
+			}
 			settings := admissionTestSettings(tracker, &scriptedAdmissionRunner{propose: proposeEveryCandidate})
 			settings.TerminalStates = []string{"Done"}
 			manager := newAdmissionTestManager(t, settings, backend, func() time.Time { return transitionAt })
@@ -419,11 +455,36 @@ func TestManagerReconcilesOpenProposalFromIssueState(t *testing.T) {
 				t.Fatalf("resolved proposal = %#v", got)
 			}
 			if tt.wantStatus == admissionmodel.ProposalAccepted &&
-				(got.DecisionActorLogin != "ada" || got.DecisionActorKind != "User" ||
+				(got.DecisionActorLogin != tt.wantActorLogin || got.DecisionActorKind != tt.wantActorKind ||
 					!got.TransitionAt.Equal(transitionAt) || got.DecisionCommentID != "") {
 				t.Fatalf("implicit acceptance evidence = %#v", got)
 			}
 		})
+	}
+}
+
+func TestManagerReturnsImplicitTransitionLookupError(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 7, 29, 12, 0, 0, 0, time.UTC)
+	issue := admissionIssueFixture("issue-1", "DD-1", 1, now)
+	tracker := memory.New(memory.Config{Issues: []connector.Issue{issue}, Stateful: true})
+	backend := openManagerTestStore(t)
+	proposal := admissionTestProposalForIssue("proposal-1", issue, now)
+	if created, err := backend.CreateAdmissionProposal(t.Context(), proposal); err != nil || !created {
+		t.Fatalf("CreateAdmissionProposal() = %t, %v", created, err)
+	}
+	wantErr := errors.New("target transition lookup failed")
+	store := &faultAdmissionStore{Store: backend, targetTransitionErr: wantErr}
+	manager := newAdmissionTestManager(
+		t,
+		admissionTestSettings(tracker, &scriptedAdmissionRunner{propose: proposeEveryCandidate}),
+		store,
+		func() time.Time { return now },
+	)
+
+	if _, err := manager.RunOnce(t.Context()); !errors.Is(err, wantErr) {
+		t.Fatalf("RunOnce() error = %v, want %v", err, wantErr)
 	}
 }
 
@@ -2462,12 +2523,13 @@ func (g *capacityGate) Release(scheduler.Slot) error {
 
 type faultAdmissionStore struct {
 	Store
-	expireErr  error
-	refreshErr error
-	recordErr  error
-	latestErr  error
-	latest     admissionmodel.RunRecord
-	latestOK   bool
+	expireErr           error
+	refreshErr          error
+	recordErr           error
+	latestErr           error
+	targetTransitionErr error
+	latest              admissionmodel.RunRecord
+	latestOK            bool
 }
 
 func (s *faultAdmissionStore) ExpireAdmissionProposals(context.Context, string, time.Time) (int, error) {
@@ -2496,6 +2558,16 @@ func (s *faultAdmissionStore) LatestAdmissionRun(ctx context.Context, projectID 
 		return s.latest, s.latestOK, s.latestErr
 	}
 	return s.Store.LatestAdmissionRun(ctx, projectID)
+}
+
+func (s *faultAdmissionStore) AdmissionTargetTransitions(
+	ctx context.Context,
+	query admissionmodel.TargetTransitionQuery,
+) ([]admissionmodel.TargetTransition, error) {
+	if s.targetTransitionErr != nil {
+		return nil, s.targetTransitionErr
+	}
+	return s.Store.AdmissionTargetTransitions(ctx, query)
 }
 
 type boundaryBudgetRunner struct {

--- a/internal/admission/model/model.go
+++ b/internal/admission/model/model.go
@@ -80,6 +80,7 @@ type Decision struct {
 	TransitionEventID int64
 	Reason            string
 	Automatic         bool
+	Implicit          bool
 }
 
 type TargetTransitionQuery struct {

--- a/internal/store/admission.go
+++ b/internal/store/admission.go
@@ -280,7 +280,7 @@ func (s *sqliteStore) ResolveAdmissionProposal(ctx context.Context, decision adm
 	if decision.DecidedAt.IsZero() {
 		return errors.New("backlog admission decision time is required")
 	}
-	if strings.TrimSpace(decision.CommentID) == "" && !decision.Automatic {
+	if strings.TrimSpace(decision.CommentID) == "" && !decision.Automatic && !decision.Implicit {
 		return errors.New("backlog admission decision comment is required")
 	}
 	if decision.Outcome == admissionmodel.ProposalAccepted && decision.TransitionAt.IsZero() {


### PR DESCRIPTION
## Summary

- resolve open proposals as implicitly accepted when the issue reaches the stored target state
- preserve transition actor evidence and distinguish implicit, explicit, closed, and terminal resolutions
- release proposal capacity before candidate selection while preserving automatic-admission recovery

Fixes #1622

## UI Surface Contract

- [x] N/A, or the linked issue explicitly authorizes any high-impact UI surface, layout, density, first-viewport, or responsive visibility tradeoff.
- [x] Persistent top-of-screen messaging is explicitly authorized by the issue, or this PR does not add it.
- [x] Visual changes to primary operator screens include screenshot or browser verification below. N/A: no UI changes.

## Test Plan

- [x] `go test ./internal/admission ./internal/store`
- [x] `make check`
- [x] `go test ./internal/orchestrator -run '^$' -fuzz=. -fuzztime=30s`