### PR TITLE
docs(cli): refresh version output example

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -97,7 +97,7 @@ Structured command objects:
 
 | Command | JSON object |
 | --- | --- |
-| `detent version` | `{"version":"v0.1.0","commit":"abc1234","build_date":"2026-06-13T00:00:00Z","go_version":"go1.26.4","os":"linux","arch":"amd64"}` |
+| `detent version` | `{"version":"v0.55.0","commit":"abc1234","build_date":"2026-08-01T00:00:00Z","go_version":"go1.26.4","os":"linux","arch":"amd64"}` |
 | `detent update` | The update status object, including `current_version`, `latest_version`, `latest_tag`, `update_available`, `install_source`, `action`, `message`, and `command` when present. |
 | `detent init` | `{"status":"ok","path":"/path/global.yaml","rule":"--config"}` |
 | `detent add-project` | `{"id":"api","workflow":"/repo/WORKFLOW.md","workdir":"/repo","weight":1,"priority":0,"paused":false,"credential_ref":"github"}` |


### PR DESCRIPTION
## Summary

- refresh the `detent version` JSON example to current-era version and build-date values
- preserve the command actual six-field JSON output shape

Fixes #1627

## UI Surface Contract

- [x] N/A, or the linked issue explicitly authorizes any high-impact UI surface, layout, density, first-viewport, or responsive visibility tradeoff.
- [x] Persistent top-of-screen messaging is explicitly authorized by the issue, or this PR does not add it.
- [x] Visual changes to primary operator screens include screenshot or browser verification below. (N/A: documentation-only change.)

## Test Plan

- [x] Extracted example parses with `jq` and matches the six real output fields
- [x] `make check`
