### PR TITLE
test(admission): forward expiry cutoff

### DIFF
--- a/internal/admission/manager_test.go
+++ b/internal/admission/manager_test.go
@@ -2532,11 +2532,11 @@ type faultAdmissionStore struct {
 	latestOK            bool
 }
 
-func (s *faultAdmissionStore) ExpireAdmissionProposals(context.Context, string, time.Time) (int, error) {
+func (s *faultAdmissionStore) ExpireAdmissionProposals(ctx context.Context, projectID string, cutoff time.Time) (int, error) {
 	if s.expireErr != nil {
 		return 0, s.expireErr
 	}
-	return s.Store.ExpireAdmissionProposals(context.Background(), "detent", time.Now())
+	return s.Store.ExpireAdmissionProposals(ctx, projectID, cutoff)
 }
 
 func (s *faultAdmissionStore) RefreshAdmissionOutcomes(ctx context.Context, refresh admissionmodel.OutcomeRefresh) error {


### PR DESCRIPTION
## Summary

- forward the manager-injected expiry context, project, and cutoff through the admission test fault store
- keep the implicit transition lookup error regression test independent of the wall date

Fixes #1630

## UI Surface Contract

- [x] N/A, or the linked issue explicitly authorizes any high-impact UI surface, layout, density, first-viewport, or responsive visibility tradeoff.
- [x] Persistent top-of-screen messaging is explicitly authorized by the issue, or this PR does not add it.
- [x] Visual changes to primary operator screens include screenshot or browser verification below. (N/A: no visual changes.)

## Test Plan

- [x] `go test -race ./internal/admission -run ^TestManagerReturnsImplicitTransitionLookupError$ -count=3`
- [x] `make check`