### PR TITLE
fix(doctor): detect workflow source drift

### DIFF
--- a/docs/multi-project.md
+++ b/docs/multi-project.md
@@ -152,7 +152,12 @@ that ref. `WORKFLOW.local.md` remains machine-local in the working tree and is
 applied over the ref-backed shared file. When `workflow_ref` is omitted, Detent
 keeps reading the working-tree shared file. If `workflow_ref` points at a ref
 that does not contain the workflow file, `detent doctor` reports a load failure
-for `<ref>:WORKFLOW.md`.
+for `<ref>:WORKFLOW.md`. For GitHub pull-request projects, doctor also warns
+when `workflow_ref` is omitted and compares the checked-out branch and
+`detent.yaml` with the source repository's default branch. For a configured
+remote-tracking ref, doctor compares the local ref revision with its remote
+counterpart. This freshness check uses `git ls-remote` but does not fetch;
+fetch the ref so Detent can load the new revision when doctor reports it stale.
 
 Use the project administration commands to edit `global.yaml`:
 

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -245,6 +245,7 @@ type doctorDeps struct {
 	gitWorkTree          func(context.Context, string) error
 	gitRemoteURL         func(context.Context, string) (string, error)
 	gitTracked           func(context.Context, string) (bool, error)
+	workflowSourcePolicy doctorWorkflowSourcePolicyFunc
 	autoPromoteConnector func(workflowconfig.Config) (doctorAutoPromoteConnector, error)
 	proposalConnector    func(workflowconfig.Config) (doctorWorkflowProposalConnector, error)
 	modelProbe           func(context.Context, doctorRouteModelProbeRequest) error
@@ -1121,6 +1122,9 @@ func (d doctorDeps) withDefaults() doctorDeps {
 	if d.gitTracked == nil {
 		d.gitTracked = defaults.gitTracked
 	}
+	if d.workflowSourcePolicy == nil {
+		d.workflowSourcePolicy = defaults.workflowSourcePolicy
+	}
 	if d.autoPromoteConnector == nil {
 		d.autoPromoteConnector = defaults.autoPromoteConnector
 	}
@@ -1165,6 +1169,7 @@ func defaultDoctorDeps() doctorDeps {
 		gitWorkTree:          defaultGitWorkTree,
 		gitRemoteURL:         defaultGitRemoteURL,
 		gitTracked:           defaultGitTracked,
+		workflowSourcePolicy: defaultDoctorWorkflowSourcePolicy,
 		autoPromoteConnector: defaultDoctorAutoPromoteConnector,
 		proposalConnector:    defaultDoctorProposalConnector,
 		modelProbe:           defaultDoctorRouteModelProbe,

--- a/internal/cli/doctor_project.go
+++ b/internal/cli/doctor_project.go
@@ -302,6 +302,10 @@ func checkDoctorProjectWithProgress(
 		}
 	}
 	checks = append(checks, workflowCheck)
+	setDoctorCurrentCheck("Project " + id + " workflow source policy")
+	if sourcePolicyCheck, ok := checkDoctorWorkflowSourcePolicy(ctx, id, project, workflow.Config, projectSourceRoot(project, workflow.Config), deps); ok {
+		checks = append(checks, sourcePolicyCheck)
+	}
 	setDoctorCurrentCheck("Project " + id + " local workflow overlay")
 	if overlayCheck, ok := checkDoctorLocalWorkflowOverlay(ctx, id, workflow, deps); ok {
 		checks = append(checks, overlayCheck)
@@ -405,12 +409,6 @@ func checkDoctorProjectWithProgress(
 		Status: doctorOK,
 		Detail: expandedSourceRoot + " is a git worktree",
 	})
-	if doctorTrackerUsesGitHubReads(workflow.Config.Tracker.Kind) && workflow.Config.Deliverable.Kind == workflowconfig.DeliverablePullRequest {
-		setDoctorCurrentCheck("Project " + id + " workflow source policy")
-		if sourcePolicyCheck, ok := checkDoctorWorkflowSourcePolicy(ctx, id, project, workflow.Config, expandedSourceRoot, deps); ok {
-			checks = append(checks, sourcePolicyCheck)
-		}
-	}
 	setDoctorCurrentCheck("Project " + id + " issue effort guidance")
 	checks = append(checks, checkDoctorIssueEffortGuidance(id, expandedSourceRoot))
 	setDoctorCurrentCheck("Project " + id + " skills")

--- a/internal/cli/doctor_project.go
+++ b/internal/cli/doctor_project.go
@@ -405,6 +405,12 @@ func checkDoctorProjectWithProgress(
 		Status: doctorOK,
 		Detail: expandedSourceRoot + " is a git worktree",
 	})
+	if doctorTrackerUsesGitHubReads(workflow.Config.Tracker.Kind) && workflow.Config.Deliverable.Kind == workflowconfig.DeliverablePullRequest {
+		setDoctorCurrentCheck("Project " + id + " workflow source policy")
+		if sourcePolicyCheck, ok := checkDoctorWorkflowSourcePolicy(ctx, id, project, workflow.Config, expandedSourceRoot, deps); ok {
+			checks = append(checks, sourcePolicyCheck)
+		}
+	}
 	setDoctorCurrentCheck("Project " + id + " issue effort guidance")
 	checks = append(checks, checkDoctorIssueEffortGuidance(id, expandedSourceRoot))
 	setDoctorCurrentCheck("Project " + id + " skills")

--- a/internal/cli/doctor_test.go
+++ b/internal/cli/doctor_test.go
@@ -5968,6 +5968,15 @@ func successfulDoctorDeps() doctorDeps {
 		githubMergeSettings: func(context.Context, workflowconfig.Config, string) (ghconnector.RepositoryMergeSettings, error) {
 			return ghconnector.RepositoryMergeSettings{AllowSquashMerge: true}, nil
 		},
+		githubRepositoryInfo: func(_ context.Context, _ workflowconfig.Config, repository string) (ghconnector.RepositoryInfo, error) {
+			return ghconnector.RepositoryInfo{
+				ID:            1,
+				NameWithOwner: repository,
+				Private:       true,
+				Visibility:    "private",
+				DefaultBranch: "main",
+			}, nil
+		},
 		listen: func(string, string) (net.Listener, error) {
 			return fakeDoctorListener{addr: fakeDoctorAddr("127.0.0.1:49152")}, nil
 		},
@@ -5976,6 +5985,13 @@ func successfulDoctorDeps() doctorDeps {
 		},
 		gitWorkTree: func(context.Context, string) error {
 			return nil
+		},
+		workflowSourcePolicy: func(_ context.Context, projectID string, _ globalconfig.Project, _ string, _ string) doctorCheck {
+			return doctorCheck{
+				Name:   "Project " + projectID + " workflow source policy",
+				Status: doctorOK,
+				Detail: "workflow source policy verified",
+			}
 		},
 		executable: func() (string, error) {
 			return filepath.Join("Users", "corylanou", "go", "bin", "detent"), nil

--- a/internal/cli/doctor_workflow_source.go
+++ b/internal/cli/doctor_workflow_source.go
@@ -215,7 +215,7 @@ func checkDoctorMutableWorkflowSource(
 	if err != nil {
 		status = doctorFail
 		details = append(details, fmt.Sprintf("read detent.yaml from %s: %v", comparisonRef, err))
-	} else if !bytes.Equal(workingConfig, []byte(defaultConfig)) {
+	} else if !bytes.Equal(doctorNormalizedWorkflowPolicy(workingConfig), doctorNormalizedWorkflowPolicy([]byte(defaultConfig))) {
 		status = doctorFail
 		details = append(details, "effective detent.yaml differs from "+comparisonRef)
 	} else {
@@ -228,6 +228,10 @@ func checkDoctorMutableWorkflowSource(
 		Detail: strings.Join(details, "; "),
 		Hint:   fmt.Sprintf("Set projects[].workflow_ref to origin/%s after fetching that ref, then rerun detent doctor.", defaultBranch),
 	}
+}
+
+func doctorNormalizedWorkflowPolicy(raw []byte) []byte {
+	return bytes.ReplaceAll(raw, []byte("\r\n"), []byte("\n"))
 }
 
 func doctorWorkflowConfigPaths(project globalconfig.Project, sourceRoot string) (string, string, error) {

--- a/internal/cli/doctor_workflow_source.go
+++ b/internal/cli/doctor_workflow_source.go
@@ -1,0 +1,315 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	workflowconfig "github.com/digitaldrywood/detent/internal/config"
+	globalconfig "github.com/digitaldrywood/detent/internal/config/global"
+)
+
+type doctorWorkflowSourcePolicyFunc func(context.Context, string, globalconfig.Project, string, string) doctorCheck
+
+func checkDoctorWorkflowSourcePolicy(
+	ctx context.Context,
+	projectID string,
+	project globalconfig.Project,
+	cfg workflowconfig.Config,
+	sourceRoot string,
+	deps doctorDeps,
+) (doctorCheck, bool) {
+	if deps.workflowSourcePolicy == nil {
+		return doctorCheck{}, false
+	}
+	workflowSourceRoot := sourceRoot
+	if strings.TrimSpace(project.Workdir) != "" {
+		expandedWorkdir, err := expandDoctorWorkspacePath(project.Workdir)
+		if err != nil {
+			return doctorCheck{
+				Name:   "Project " + projectID + " workflow source policy",
+				Status: doctorFail,
+				Detail: fmt.Sprintf("project %s workflow source workdir could not be resolved: %v", projectID, err),
+				Hint:   "Fix projects[].workdir, then rerun detent doctor.",
+			}, true
+		}
+		workflowSourceRoot = expandedWorkdir
+	}
+	if strings.TrimSpace(project.WorkflowRef) != "" {
+		return deps.workflowSourcePolicy(ctx, projectID, project, workflowSourceRoot, ""), true
+	}
+
+	name := "Project " + projectID + " workflow source policy"
+	repository := ""
+	if deps.gitRemoteURL != nil {
+		if remote, err := deps.gitRemoteURL(ctx, workflowSourceRoot); err == nil {
+			repository, _ = doctorGitHubRepositoryFromRemoteURL(remote)
+		}
+	}
+	if repository == "" {
+		repository = strings.TrimSpace(cfg.Tracker.Repository)
+	}
+	if repository == "" {
+		return doctorCheck{
+			Name:   name,
+			Status: doctorWarn,
+			Detail: "project " + projectID + " omits workflow_ref and reads merge policy from a mutable working tree; source repository default branch could not be resolved",
+			Hint:   "Configure a GitHub origin remote and set projects[].workflow_ref to its default remote-tracking branch.",
+		}, true
+	}
+	if deps.githubRepositoryInfo == nil {
+		return doctorCheck{
+			Name:   name,
+			Status: doctorWarn,
+			Detail: "project " + projectID + " omits workflow_ref and reads merge policy from a mutable working tree; GitHub repository metadata is unavailable",
+			Hint:   "Rerun detent doctor with GitHub repository access, then set projects[].workflow_ref to the default remote-tracking branch.",
+		}, true
+	}
+	info, err := deps.githubRepositoryInfo(ctx, cfg, repository)
+	if err != nil {
+		return doctorCheck{
+			Name:   name,
+			Status: doctorWarn,
+			Detail: fmt.Sprintf("project %s omits workflow_ref and reads merge policy from a mutable working tree; read %s default branch: %v", projectID, repository, err),
+			Hint:   "Fix GitHub repository access, then rerun detent doctor.",
+		}, true
+	}
+	defaultBranch := strings.TrimSpace(info.DefaultBranch)
+	if defaultBranch == "" {
+		return doctorCheck{
+			Name:   name,
+			Status: doctorWarn,
+			Detail: "project " + projectID + " omits workflow_ref and reads merge policy from a mutable working tree; GitHub returned no default branch for " + repository,
+			Hint:   "Set a repository default branch, then rerun detent doctor.",
+		}, true
+	}
+	return deps.workflowSourcePolicy(ctx, projectID, project, workflowSourceRoot, defaultBranch), true
+}
+
+func defaultDoctorWorkflowSourcePolicy(
+	ctx context.Context,
+	projectID string,
+	project globalconfig.Project,
+	sourceRoot string,
+	defaultBranch string,
+) doctorCheck {
+	if strings.TrimSpace(project.WorkflowRef) != "" {
+		return checkDoctorWorkflowRefFreshness(ctx, projectID, project, sourceRoot)
+	}
+	return checkDoctorMutableWorkflowSource(ctx, projectID, project, sourceRoot, defaultBranch)
+}
+
+func checkDoctorWorkflowRefFreshness(ctx context.Context, projectID string, project globalconfig.Project, sourceRoot string) doctorCheck {
+	name := "Project " + projectID + " workflow source policy"
+	ref := strings.TrimSpace(project.WorkflowRef)
+	localRevision, err := doctorWorkflowSourceGit(ctx, sourceRoot, "rev-parse", "--verify", ref+"^{commit}")
+	if err != nil {
+		return doctorCheck{Name: name, Status: doctorFail, Detail: fmt.Sprintf("project %s workflow_ref %s could not be resolved: %v", projectID, ref, err), Hint: "Fetch the configured workflow ref, then rerun detent doctor."}
+	}
+	localRevision = strings.TrimSpace(localRevision)
+	fullRef, err := doctorWorkflowSourceGit(ctx, sourceRoot, "rev-parse", "--symbolic-full-name", ref)
+	if err != nil {
+		return doctorCheck{Name: name, Status: doctorWarn, Detail: fmt.Sprintf("project %s workflow_ref %s resolved to %s but its remote counterpart could not be identified: %v", projectID, ref, doctorShortRevision(localRevision), err), Hint: "Use a remote-tracking workflow_ref such as origin/main so doctor can verify freshness."}
+	}
+	remote, branch, ok := doctorWorkflowRemoteBranch(strings.TrimSpace(fullRef))
+	if !ok {
+		return doctorCheck{Name: name, Status: doctorWarn, Detail: fmt.Sprintf("project %s workflow_ref %s resolves to %s but is not a remote-tracking branch; remote freshness was not verified", projectID, ref, doctorShortRevision(localRevision)), Hint: "Use a remote-tracking workflow_ref such as origin/main so doctor can verify freshness."}
+	}
+	remoteRevision, err := doctorWorkflowRemoteRevision(ctx, sourceRoot, remote, branch)
+	if err != nil {
+		return doctorCheck{Name: name, Status: doctorWarn, Detail: fmt.Sprintf("project %s workflow_ref %s resolves to %s; read remote counterpart %s/%s: %v", projectID, ref, doctorShortRevision(localRevision), remote, branch, err), Hint: "Restore remote access and fetch the configured ref, then rerun detent doctor."}
+	}
+	if localRevision != remoteRevision {
+		return doctorCheck{
+			Name:   name,
+			Status: doctorFail,
+			Detail: fmt.Sprintf("project %s workflow_ref %s is stale at %s; remote counterpart %s/%s is %s", projectID, ref, doctorShortRevision(localRevision), remote, branch, doctorShortRevision(remoteRevision)),
+			Hint:   fmt.Sprintf("Fetch %s/%s so the configured workflow ref advances, then rerun detent doctor.", remote, branch),
+		}
+	}
+	return doctorCheck{
+		Name:   name,
+		Status: doctorOK,
+		Detail: fmt.Sprintf("project %s workflow_ref %s is fresh at %s and ignores the working-tree branch", projectID, ref, doctorShortRevision(localRevision)),
+	}
+}
+
+func checkDoctorMutableWorkflowSource(
+	ctx context.Context,
+	projectID string,
+	project globalconfig.Project,
+	sourceRoot string,
+	defaultBranch string,
+) doctorCheck {
+	name := "Project " + projectID + " workflow source policy"
+	status := doctorWarn
+	details := []string{"project " + projectID + " omits workflow_ref and reads merge policy from a mutable working tree"}
+	branch, err := doctorWorkflowSourceGit(ctx, sourceRoot, "branch", "--show-current")
+	if err != nil {
+		return doctorCheck{Name: name, Status: doctorFail, Detail: details[0] + "; inspect checkout branch: " + err.Error(), Hint: "Repair the source checkout, then rerun detent doctor."}
+	}
+	branch = strings.TrimSpace(branch)
+	if branch == "" {
+		head, headErr := doctorWorkflowSourceGit(ctx, sourceRoot, "rev-parse", "--short", "HEAD")
+		if headErr != nil {
+			return doctorCheck{Name: name, Status: doctorFail, Detail: details[0] + "; inspect detached HEAD: " + headErr.Error(), Hint: "Repair the source checkout, then rerun detent doctor."}
+		}
+		details = append(details, "checkout is detached at "+strings.TrimSpace(head))
+	} else if branch != defaultBranch {
+		details = append(details, fmt.Sprintf("checkout branch %s differs from default branch %s", branch, defaultBranch))
+	} else {
+		details = append(details, fmt.Sprintf("checkout branch %s matches default branch %s", branch, defaultBranch))
+	}
+
+	configPath, relativeConfigPath, err := doctorWorkflowConfigPaths(project, sourceRoot)
+	if err != nil {
+		return doctorCheck{Name: name, Status: doctorFail, Detail: strings.Join(append(details, err.Error()), "; "), Hint: "Keep WORKFLOW.md and detent.yaml inside the configured project workdir."}
+	}
+	workingConfig, err := os.ReadFile(configPath)
+	if err != nil {
+		detail := "read effective detent.yaml at " + configPath + ": " + err.Error()
+		if errors.Is(err, os.ErrNotExist) {
+			detail = "effective detent.yaml is missing at " + configPath
+		}
+		return doctorCheck{Name: name, Status: doctorFail, Detail: strings.Join(append(details, detail), "; "), Hint: "Restore a readable detent.yaml, then rerun detent doctor."}
+	}
+
+	remoteRevision, remoteErr := doctorWorkflowRemoteRevision(ctx, sourceRoot, "origin", defaultBranch)
+	trackingRef := "refs/remotes/origin/" + defaultBranch
+	trackingRevision, trackingErr := doctorWorkflowSourceGit(ctx, sourceRoot, "rev-parse", "--verify", trackingRef+"^{commit}")
+	trackingRevision = strings.TrimSpace(trackingRevision)
+	comparisonRevision := trackingRevision
+	comparisonRef := "origin/" + defaultBranch
+	if remoteErr != nil {
+		details = append(details, fmt.Sprintf("remote default branch freshness could not be verified: %v", remoteErr))
+	} else if trackingErr != nil {
+		if doctorWorkflowObjectExists(ctx, sourceRoot, remoteRevision) {
+			comparisonRevision = remoteRevision
+			comparisonRef = remoteRevision
+		} else {
+			status = doctorFail
+			details = append(details, fmt.Sprintf("local %s is unavailable and remote %s is not present locally", comparisonRef, doctorShortRevision(remoteRevision)))
+		}
+	} else if trackingRevision != remoteRevision {
+		status = doctorFail
+		details = append(details, fmt.Sprintf("local %s is stale at %s; remote %s is %s", comparisonRef, doctorShortRevision(trackingRevision), defaultBranch, doctorShortRevision(remoteRevision)))
+		if doctorWorkflowObjectExists(ctx, sourceRoot, remoteRevision) {
+			comparisonRevision = remoteRevision
+			comparisonRef = remoteRevision
+		} else {
+			details = append(details, "remote default-branch commit is not available locally")
+		}
+	} else {
+		details = append(details, fmt.Sprintf("local %s matches its remote at %s", comparisonRef, doctorShortRevision(remoteRevision)))
+	}
+	if comparisonRevision == "" {
+		return doctorCheck{Name: name, Status: doctorFail, Detail: strings.Join(details, "; "), Hint: fmt.Sprintf("Fetch origin/%s, then rerun detent doctor.", defaultBranch)}
+	}
+
+	defaultConfig, err := doctorWorkflowSourceGit(ctx, sourceRoot, "show", comparisonRevision+":"+relativeConfigPath)
+	if err != nil {
+		status = doctorFail
+		details = append(details, fmt.Sprintf("read detent.yaml from %s: %v", comparisonRef, err))
+	} else if !bytes.Equal(workingConfig, []byte(defaultConfig)) {
+		status = doctorFail
+		details = append(details, "effective detent.yaml differs from "+comparisonRef)
+	} else {
+		details = append(details, "effective detent.yaml matches "+comparisonRef)
+	}
+
+	return doctorCheck{
+		Name:   name,
+		Status: status,
+		Detail: strings.Join(details, "; "),
+		Hint:   fmt.Sprintf("Set projects[].workflow_ref to origin/%s after fetching that ref, then rerun detent doctor.", defaultBranch),
+	}
+}
+
+func doctorWorkflowConfigPaths(project globalconfig.Project, sourceRoot string) (string, string, error) {
+	workflowPath := strings.TrimSpace(project.Workflow)
+	if filepath.IsAbs(workflowPath) || workflowPath == "~" || strings.HasPrefix(workflowPath, "~/") {
+		expanded, err := expandDoctorWorkspacePath(workflowPath)
+		if err != nil {
+			return "", "", fmt.Errorf("resolve workflow path: %w", err)
+		}
+		workflowPath = expanded
+	} else {
+		workflowPath = filepath.Join(sourceRoot, workflowPath)
+	}
+	configPath := workflowconfig.DefinitionPath(workflowPath)
+	relativePath, err := filepath.Rel(sourceRoot, configPath)
+	if err != nil {
+		return "", "", fmt.Errorf("resolve detent.yaml path relative to source root: %w", err)
+	}
+	if relativePath == ".." || strings.HasPrefix(relativePath, ".."+string(filepath.Separator)) {
+		return "", "", fmt.Errorf("effective detent.yaml %s is outside source root %s", configPath, sourceRoot)
+	}
+	return configPath, filepath.ToSlash(relativePath), nil
+}
+
+func doctorWorkflowRemoteBranch(fullRef string) (string, string, bool) {
+	value, ok := strings.CutPrefix(strings.TrimSpace(fullRef), "refs/remotes/")
+	if !ok {
+		return "", "", false
+	}
+	remote, branch, ok := strings.Cut(value, "/")
+	if !ok || strings.TrimSpace(remote) == "" || strings.TrimSpace(branch) == "" {
+		return "", "", false
+	}
+	return remote, branch, true
+}
+
+func doctorWorkflowRemoteRevision(ctx context.Context, sourceRoot string, remote string, branch string) (string, error) {
+	ref := "refs/heads/" + branch
+	output, err := doctorWorkflowSourceGit(ctx, sourceRoot, "ls-remote", "--exit-code", remote, ref)
+	if err != nil {
+		return "", err
+	}
+	for _, line := range strings.Split(output, "\n") {
+		fields := strings.Fields(line)
+		if len(fields) >= 2 && fields[1] == ref {
+			return fields[0], nil
+		}
+	}
+	return "", fmt.Errorf("remote %s branch %s returned no revision", remote, branch)
+}
+
+func doctorWorkflowObjectExists(ctx context.Context, sourceRoot string, revision string) bool {
+	if strings.TrimSpace(revision) == "" {
+		return false
+	}
+	_, err := doctorWorkflowSourceGit(ctx, sourceRoot, "cat-file", "-e", revision+"^{commit}")
+	return err == nil
+}
+
+func doctorWorkflowSourceGit(ctx context.Context, sourceRoot string, args ...string) (string, error) {
+	commandCtx, cancel := context.WithTimeout(ctx, doctorCommandTimeout)
+	defer cancel()
+
+	commandArgs := append([]string{"-C", sourceRoot}, args...)
+	cmd := exec.CommandContext(commandCtx, "git", commandArgs...) // #nosec G204 -- doctor passes configured refs and paths as fixed git arguments without a shell.
+	output, err := cmd.CombinedOutput()
+	if commandCtx.Err() != nil {
+		return "", commandCtx.Err()
+	}
+	if err != nil {
+		if detail := strings.TrimSpace(string(output)); detail != "" {
+			return "", fmt.Errorf("git %s: %w: %s", strings.Join(args, " "), err, detail)
+		}
+		return "", fmt.Errorf("git %s: %w", strings.Join(args, " "), err)
+	}
+	return string(output), nil
+}
+
+func doctorShortRevision(revision string) string {
+	revision = strings.TrimSpace(revision)
+	if len(revision) > 12 {
+		return revision[:12]
+	}
+	return revision
+}

--- a/internal/cli/doctor_workflow_source.go
+++ b/internal/cli/doctor_workflow_source.go
@@ -46,15 +46,19 @@ func checkDoctorWorkflowSourcePolicy(
 
 	name := "Project " + projectID + " workflow source policy"
 	repository := ""
+	trackerUsesGitHub := doctorTrackerUsesGitHubReads(cfg.Tracker.Kind)
 	if deps.gitRemoteURL != nil {
 		if remote, err := deps.gitRemoteURL(ctx, workflowSourceRoot); err == nil {
 			repository, _ = doctorGitHubRepositoryFromRemoteURL(remote)
 		}
 	}
-	if repository == "" {
+	if repository == "" && trackerUsesGitHub {
 		repository = strings.TrimSpace(cfg.Tracker.Repository)
 	}
 	if repository == "" {
+		if !trackerUsesGitHub {
+			return doctorCheck{}, false
+		}
 		return doctorCheck{
 			Name:   name,
 			Status: doctorWarn,

--- a/internal/cli/doctor_workflow_source_test.go
+++ b/internal/cli/doctor_workflow_source_test.go
@@ -174,6 +174,95 @@ func TestCheckDoctorWorkflowSourcePolicyUsesGitHubDefaultBranch(t *testing.T) {
 	}
 }
 
+func TestCheckDoctorProjectRunsWorkflowSourcePolicyBeforeMutableKinds(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		mutate func(*workflowconfig.Config)
+	}{
+		{
+			name: "tracker kind drifted",
+			mutate: func(cfg *workflowconfig.Config) {
+				cfg.Tracker.Kind = workflowconfig.TrackerMemory
+			},
+		},
+		{
+			name: "deliverable kind drifted",
+			mutate: func(cfg *workflowconfig.Config) {
+				cfg.Deliverable.Kind = workflowconfig.DeliverableArtifact
+			},
+		},
+		{
+			name: "workspace kind drifted",
+			mutate: func(cfg *workflowconfig.Config) {
+				cfg.Workspace.Kind = workflowconfig.WorkspaceFilesystem
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			sourceRoot := t.TempDir()
+			workflow := validDoctorDependencyWorkflow(false)
+			workflow.Workspace.Root = sourceRoot
+			tt.mutate(&workflow)
+
+			deps := successfulDoctorDeps()
+			deps.loadWorkflow = func(string) (workflowconfig.Workflow, error) {
+				return workflowconfig.Workflow{Config: workflow}, nil
+			}
+			deps.gitRemoteURL = func(context.Context, string) (string, error) {
+				return "https://github.com/source/repository.git", nil
+			}
+			called := false
+			deps.workflowSourcePolicy = func(_ context.Context, projectID string, _ globalconfig.Project, gotSourceRoot string, defaultBranch string) doctorCheck {
+				called = true
+				if projectID != "alpha" || gotSourceRoot != sourceRoot || defaultBranch != "main" {
+					t.Fatalf("policy inputs = project %q, root %q, branch %q", projectID, gotSourceRoot, defaultBranch)
+				}
+				return doctorCheck{Name: "Project alpha workflow source policy", Status: doctorFail, Detail: "policy drift detected"}
+			}
+
+			checks := checkDoctorProject(context.Background(), globalconfig.Project{
+				ID:       "alpha",
+				Workflow: filepath.Join(sourceRoot, "WORKFLOW.md"),
+				Workdir:  sourceRoot,
+			}, deps, RuntimeSecret{}, false)
+			if !called {
+				t.Fatal("workflow source policy was skipped")
+			}
+			assertDoctorCheck(t, doctorReport{Checks: checks}, "Project alpha workflow source policy", doctorFail, "policy drift detected")
+		})
+	}
+}
+
+func TestCheckDoctorWorkflowSourcePolicySkipsNonGitHubMutableProject(t *testing.T) {
+	t.Parallel()
+
+	_, ok := checkDoctorWorkflowSourcePolicy(
+		context.Background(),
+		"alpha",
+		globalconfig.Project{Workflow: "WORKFLOW.md", Workdir: "/repo"},
+		workflowconfig.Config{Tracker: workflowconfig.Tracker{Kind: workflowconfig.TrackerMemory}},
+		"/repo",
+		doctorDeps{
+			gitRemoteURL: func(context.Context, string) (string, error) {
+				return "file:///tmp/repository.git", nil
+			},
+			workflowSourcePolicy: func(context.Context, string, globalconfig.Project, string, string) doctorCheck {
+				t.Fatal("workflow source policy should not run")
+				return doctorCheck{}
+			},
+		},
+	)
+	if ok {
+		t.Fatal("checkDoctorWorkflowSourcePolicy() ok = true, want false")
+	}
+}
+
 func initDoctorWorkflowSourceRepository(t *testing.T) (string, string) {
 	t.Helper()
 

--- a/internal/cli/doctor_workflow_source_test.go
+++ b/internal/cli/doctor_workflow_source_test.go
@@ -38,6 +38,14 @@ func TestDefaultDoctorWorkflowSourcePolicy(t *testing.T) {
 			wantDetail: []string{"project alpha", "omits workflow_ref", "branch main matches default branch main", "effective detent.yaml matches origin/main"},
 		},
 		{
+			name: "line ending difference is not drift",
+			mutate: func(t *testing.T, repo string, _ string, _ *globalconfig.Project) {
+				writeDoctorWorkflowSourceFile(t, filepath.Join(repo, "detent.yaml"), "schema: 1\r\ntracker:\r\n  kind: memory\r\n")
+			},
+			wantStatus: doctorWarn,
+			wantDetail: []string{"project alpha", "effective detent.yaml matches origin/main"},
+		},
+		{
 			name: "workflow ref skips working tree",
 			mutate: func(t *testing.T, repo string, _ string, project *globalconfig.Project) {
 				project.WorkflowRef = "origin/main"
@@ -136,10 +144,11 @@ func TestCheckDoctorWorkflowSourcePolicyUsesGitHubDefaultBranch(t *testing.T) {
 	var gotRepository string
 	var gotDefaultBranch string
 	var gotSourceRoot string
+	workdir := filepath.Join(t.TempDir(), "repo")
 	check, ok := checkDoctorWorkflowSourcePolicy(
 		context.Background(),
 		"alpha",
-		globalconfig.Project{Workflow: "/repo/WORKFLOW.md", Workdir: "/repo"},
+		globalconfig.Project{Workflow: filepath.Join(workdir, "WORKFLOW.md"), Workdir: workdir},
 		workflowconfig.Config{Tracker: workflowconfig.Tracker{Repository: "fallback/repository"}},
 		"/workspace-root",
 		doctorDeps{
@@ -160,7 +169,7 @@ func TestCheckDoctorWorkflowSourcePolicyUsesGitHubDefaultBranch(t *testing.T) {
 	if !ok {
 		t.Fatal("checkDoctorWorkflowSourcePolicy() ok = false, want true")
 	}
-	if check.Name != "Project alpha workflow source policy" || gotRepository != "source/repository" || gotDefaultBranch != "trunk" || gotSourceRoot != "/repo" {
+	if check.Name != "Project alpha workflow source policy" || gotRepository != "source/repository" || gotDefaultBranch != "trunk" || gotSourceRoot != workdir {
 		t.Fatalf("check = %#v, repository = %q, default branch = %q, source root = %q", check, gotRepository, gotDefaultBranch, gotSourceRoot)
 	}
 }

--- a/internal/cli/doctor_workflow_source_test.go
+++ b/internal/cli/doctor_workflow_source_test.go
@@ -1,0 +1,209 @@
+package cli
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	workflowconfig "github.com/digitaldrywood/detent/internal/config"
+	globalconfig "github.com/digitaldrywood/detent/internal/config/global"
+	ghconnector "github.com/digitaldrywood/detent/internal/connector/github"
+)
+
+func TestDefaultDoctorWorkflowSourcePolicy(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		mutate     func(*testing.T, string, string, *globalconfig.Project)
+		wantStatus doctorStatus
+		wantDetail []string
+		notDetail  []string
+	}{
+		{
+			name: "drift present",
+			mutate: func(t *testing.T, repo string, _ string, _ *globalconfig.Project) {
+				runDoctorWorkflowSourceGit(t, repo, "checkout", "-b", "feature")
+				writeDoctorWorkflowSourceFile(t, filepath.Join(repo, "detent.yaml"), "schema: 1\ntracker:\n  kind: github\n")
+			},
+			wantStatus: doctorFail,
+			wantDetail: []string{"project alpha", "omits workflow_ref", "branch feature differs from default branch main", "effective detent.yaml differs from origin/main"},
+		},
+		{
+			name:       "no drift",
+			wantStatus: doctorWarn,
+			wantDetail: []string{"project alpha", "omits workflow_ref", "branch main matches default branch main", "effective detent.yaml matches origin/main"},
+		},
+		{
+			name: "workflow ref skips working tree",
+			mutate: func(t *testing.T, repo string, _ string, project *globalconfig.Project) {
+				project.WorkflowRef = "origin/main"
+				runDoctorWorkflowSourceGit(t, repo, "checkout", "-b", "feature")
+				writeDoctorWorkflowSourceFile(t, filepath.Join(repo, "detent.yaml"), "schema: 1\ntracker:\n  kind: github\n")
+			},
+			wantStatus: doctorOK,
+			wantDetail: []string{"project alpha", "workflow_ref origin/main is fresh", "ignores the working-tree branch"},
+			notDetail:  []string{"mutable working tree", "detent.yaml"},
+		},
+		{
+			name: "detached head",
+			mutate: func(t *testing.T, repo string, _ string, _ *globalconfig.Project) {
+				runDoctorWorkflowSourceGit(t, repo, "checkout", "--detach")
+			},
+			wantStatus: doctorWarn,
+			wantDetail: []string{"project alpha", "checkout is detached", "effective detent.yaml matches origin/main"},
+		},
+		{
+			name: "missing detent yaml",
+			mutate: func(t *testing.T, repo string, _ string, _ *globalconfig.Project) {
+				if err := os.Remove(filepath.Join(repo, "detent.yaml")); err != nil {
+					t.Fatalf("Remove(detent.yaml) error = %v", err)
+				}
+			},
+			wantStatus: doctorFail,
+			wantDetail: []string{"project alpha", "effective detent.yaml is missing"},
+		},
+		{
+			name: "unreadable detent yaml",
+			mutate: func(t *testing.T, repo string, _ string, _ *globalconfig.Project) {
+				path := filepath.Join(repo, "detent.yaml")
+				if err := os.Remove(path); err != nil {
+					t.Fatalf("Remove(detent.yaml) error = %v", err)
+				}
+				if err := os.Mkdir(path, 0o755); err != nil {
+					t.Fatalf("Mkdir(detent.yaml) error = %v", err)
+				}
+			},
+			wantStatus: doctorFail,
+			wantDetail: []string{"project alpha", "read effective detent.yaml"},
+		},
+		{
+			name: "stale workflow ref",
+			mutate: func(t *testing.T, _ string, remote string, project *globalconfig.Project) {
+				project.WorkflowRef = "origin/main"
+				updater := filepath.Join(t.TempDir(), "updater")
+				runDoctorWorkflowSourceGit(t, "", "clone", remote, updater)
+				runDoctorWorkflowSourceGit(t, updater, "config", "user.name", "Detent Test")
+				runDoctorWorkflowSourceGit(t, updater, "config", "user.email", "detent@example.com")
+				writeDoctorWorkflowSourceFile(t, filepath.Join(updater, "detent.yaml"), "schema: 1\ntracker:\n  kind: github\n")
+				runDoctorWorkflowSourceGit(t, updater, "add", "detent.yaml")
+				runDoctorWorkflowSourceGit(t, updater, "commit", "-m", "advance workflow policy")
+				runDoctorWorkflowSourceGit(t, updater, "push", "origin", "main")
+			},
+			wantStatus: doctorFail,
+			wantDetail: []string{"project alpha", "workflow_ref origin/main is stale", "remote counterpart origin/main"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			repo, remote := initDoctorWorkflowSourceRepository(t)
+			project := globalconfig.Project{
+				ID:       "alpha",
+				Workflow: filepath.Join(repo, "WORKFLOW.md"),
+				Workdir:  repo,
+			}
+			if tt.mutate != nil {
+				tt.mutate(t, repo, remote, &project)
+			}
+
+			check := defaultDoctorWorkflowSourcePolicy(context.Background(), "alpha", project, repo, "main")
+			if check.Status != tt.wantStatus {
+				t.Fatalf("Status = %s, want %s; detail = %q", check.Status, tt.wantStatus, check.Detail)
+			}
+			for _, want := range tt.wantDetail {
+				if !strings.Contains(check.Detail, want) {
+					t.Fatalf("Detail = %q, want containing %q", check.Detail, want)
+				}
+			}
+			for _, unwanted := range tt.notDetail {
+				if strings.Contains(check.Detail, unwanted) {
+					t.Fatalf("Detail = %q, want not containing %q", check.Detail, unwanted)
+				}
+			}
+		})
+	}
+}
+
+func TestCheckDoctorWorkflowSourcePolicyUsesGitHubDefaultBranch(t *testing.T) {
+	t.Parallel()
+
+	var gotRepository string
+	var gotDefaultBranch string
+	var gotSourceRoot string
+	check, ok := checkDoctorWorkflowSourcePolicy(
+		context.Background(),
+		"alpha",
+		globalconfig.Project{Workflow: "/repo/WORKFLOW.md", Workdir: "/repo"},
+		workflowconfig.Config{Tracker: workflowconfig.Tracker{Repository: "fallback/repository"}},
+		"/workspace-root",
+		doctorDeps{
+			gitRemoteURL: func(context.Context, string) (string, error) {
+				return "git@github.com:source/repository.git", nil
+			},
+			githubRepositoryInfo: func(_ context.Context, _ workflowconfig.Config, repository string) (ghconnector.RepositoryInfo, error) {
+				gotRepository = repository
+				return ghconnector.RepositoryInfo{DefaultBranch: "trunk"}, nil
+			},
+			workflowSourcePolicy: func(_ context.Context, projectID string, _ globalconfig.Project, sourceRoot string, defaultBranch string) doctorCheck {
+				gotDefaultBranch = defaultBranch
+				gotSourceRoot = sourceRoot
+				return doctorCheck{Name: "Project " + projectID + " workflow source policy", Status: doctorWarn}
+			},
+		},
+	)
+	if !ok {
+		t.Fatal("checkDoctorWorkflowSourcePolicy() ok = false, want true")
+	}
+	if check.Name != "Project alpha workflow source policy" || gotRepository != "source/repository" || gotDefaultBranch != "trunk" || gotSourceRoot != "/repo" {
+		t.Fatalf("check = %#v, repository = %q, default branch = %q, source root = %q", check, gotRepository, gotDefaultBranch, gotSourceRoot)
+	}
+}
+
+func initDoctorWorkflowSourceRepository(t *testing.T) (string, string) {
+	t.Helper()
+
+	root := t.TempDir()
+	remote := filepath.Join(root, "remote.git")
+	seed := filepath.Join(root, "seed")
+	repo := filepath.Join(root, "checkout")
+	runDoctorWorkflowSourceGit(t, "", "init", "--bare", "--initial-branch=main", remote)
+	runDoctorWorkflowSourceGit(t, "", "init", "--initial-branch=main", seed)
+	runDoctorWorkflowSourceGit(t, seed, "config", "user.name", "Detent Test")
+	runDoctorWorkflowSourceGit(t, seed, "config", "user.email", "detent@example.com")
+	writeDoctorWorkflowSourceFile(t, filepath.Join(seed, "WORKFLOW.md"), "Agent direction.\n")
+	writeDoctorWorkflowSourceFile(t, filepath.Join(seed, "detent.yaml"), "schema: 1\ntracker:\n  kind: memory\n")
+	runDoctorWorkflowSourceGit(t, seed, "add", "WORKFLOW.md", "detent.yaml")
+	runDoctorWorkflowSourceGit(t, seed, "commit", "-m", "initial workflow policy")
+	runDoctorWorkflowSourceGit(t, seed, "remote", "add", "origin", remote)
+	runDoctorWorkflowSourceGit(t, seed, "push", "-u", "origin", "main")
+	runDoctorWorkflowSourceGit(t, "", "clone", remote, repo)
+	runDoctorWorkflowSourceGit(t, repo, "config", "user.name", "Detent Test")
+	runDoctorWorkflowSourceGit(t, repo, "config", "user.email", "detent@example.com")
+	return repo, remote
+}
+
+func writeDoctorWorkflowSourceFile(t *testing.T, path string, content string) {
+	t.Helper()
+
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("WriteFile(%s) error = %v", filepath.Base(path), err)
+	}
+}
+
+func runDoctorWorkflowSourceGit(t *testing.T, dir string, args ...string) string {
+	t.Helper()
+
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("git %s error = %v\n%s", strings.Join(args, " "), err, output)
+	}
+	return strings.TrimSpace(string(output))
+}

--- a/internal/connector/github/repository.go
+++ b/internal/connector/github/repository.go
@@ -13,6 +13,7 @@ type RepositoryInfo struct {
 	HTMLURL       string
 	Private       bool
 	Visibility    string
+	DefaultBranch string
 }
 
 func (c *Connector) FetchRepositoryInfo(ctx context.Context, repository string) (RepositoryInfo, error) {
@@ -21,11 +22,12 @@ func (c *Connector) FetchRepositoryInfo(ctx context.Context, repository string) 
 		return RepositoryInfo{}, ErrMissingRepository
 	}
 	var response struct {
-		ID         int64  `json:"id"`
-		FullName   string `json:"full_name"`
-		HTMLURL    string `json:"html_url"`
-		Private    bool   `json:"private"`
-		Visibility string `json:"visibility"`
+		ID            int64  `json:"id"`
+		FullName      string `json:"full_name"`
+		HTMLURL       string `json:"html_url"`
+		Private       bool   `json:"private"`
+		Visibility    string `json:"visibility"`
+		DefaultBranch string `json:"default_branch"`
 	}
 	if err := c.client.REST(ctx, http.MethodGet, restRepositoryPath(repository), nil, &response); err != nil {
 		return RepositoryInfo{}, fmt.Errorf("fetch github repository info: %w", err)
@@ -39,6 +41,7 @@ func (c *Connector) FetchRepositoryInfo(ctx context.Context, repository string) 
 		HTMLURL:       strings.TrimSpace(response.HTMLURL),
 		Private:       response.Private,
 		Visibility:    strings.ToLower(strings.TrimSpace(response.Visibility)),
+		DefaultBranch: strings.TrimSpace(response.DefaultBranch),
 	}
 	if info.Visibility == "" {
 		if info.Private {

--- a/internal/connector/github/repository_test.go
+++ b/internal/connector/github/repository_test.go
@@ -14,11 +14,13 @@ func TestFetchRepositoryInfoSurfacesVisibility(t *testing.T) {
 		response       string
 		wantPrivate    bool
 		wantVisibility string
+		wantBranch     string
 	}{
 		{
 			name:           "public",
-			response:       `{"id":1,"full_name":"digitaldrywood/detent","html_url":"https://github.com/digitaldrywood/detent","private":false,"visibility":"public"}`,
+			response:       `{"id":1,"full_name":"digitaldrywood/detent","html_url":"https://github.com/digitaldrywood/detent","private":false,"visibility":"public","default_branch":"main"}`,
 			wantVisibility: "public",
+			wantBranch:     "main",
 		},
 		{
 			name:           "private fallback",
@@ -41,7 +43,7 @@ func TestFetchRepositoryInfoSurfacesVisibility(t *testing.T) {
 			if err != nil {
 				t.Fatalf("FetchRepositoryInfo() error = %v", err)
 			}
-			if got.Private != test.wantPrivate || got.Visibility != test.wantVisibility {
+			if got.Private != test.wantPrivate || got.Visibility != test.wantVisibility || got.DefaultBranch != test.wantBranch {
 				t.Fatalf("FetchRepositoryInfo() = %#v", got)
 			}
 		})


### PR DESCRIPTION
## Summary

- detect mutable GitHub pull-request workflow policy that is off the default branch or has a drifting `detent.yaml`
- report stale configured remote-tracking `workflow_ref` values without fetching or mutating the checkout
- document the read-only freshness requirement and cover branch, drift, detached, file-error, skip, and stale-ref cases

Fixes #1633

## UI Surface Contract

- [x] N/A, or the linked issue explicitly authorizes any high-impact UI surface, layout, density, first-viewport, or responsive visibility tradeoff.
- [x] Persistent top-of-screen messaging is explicitly authorized by the issue, or this PR does not add it.
- [x] Visual changes to primary operator screens include screenshot or browser verification below.

## Test Plan

- [x] `make check`