### PR TITLE
fix(merge): block persistent missing checks

### DIFF
--- a/internal/orchestrator/merge_required_checks.go
+++ b/internal/orchestrator/merge_required_checks.go
@@ -1,0 +1,231 @@
+package orchestrator
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/digitaldrywood/detent/internal/connector"
+	"github.com/digitaldrywood/detent/internal/gate"
+	runpkg "github.com/digitaldrywood/detent/internal/runner"
+	"github.com/digitaldrywood/detent/internal/store"
+	"github.com/digitaldrywood/detent/internal/telemetry"
+)
+
+const (
+	mergeWorkerMissingRequiredCheckLimit            = 3
+	mergeWorkerPersistentMissingRequiredCheckReason = "merge_worker_required_checks_persistently_missing"
+)
+
+func (o *Orchestrator) evaluateMergeRequiredCheckStreaks(
+	ctx context.Context,
+	issue connector.Issue,
+	missingChecks []string,
+	evaluatedAt time.Time,
+) []store.MergeRequiredCheckStreak {
+	if o == nil || o.mergeRequiredChecks == nil || pullRequestHydrationBlocksProgress(issue.PullRequest) {
+		return nil
+	}
+	issueID := strings.TrimSpace(issue.ID)
+	prNumber := pullRequestNumber(issue)
+	if issueID == "" || prNumber <= 0 {
+		return nil
+	}
+	if evaluatedAt.IsZero() {
+		evaluatedAt = o.clockNow()
+	}
+	requiredChecks := gate.Effective(o.cfg.AutoPromote.Gate).RequiredStatusChecks
+	streaks, err := o.mergeRequiredChecks.EvaluateMergeRequiredChecks(ctx, store.MergeRequiredCheckEvaluation{
+		ProjectID:                 o.workflowMetricsProjectID(),
+		IssueID:                   issueID,
+		Repository:                pullRequestRepository(issue),
+		PRNumber:                  prNumber,
+		RequiredChecksFingerprint: mergeRequiredCheckConfigFingerprint(requiredChecks),
+		MissingChecks:             missingChecks,
+		EvaluatedAt:               evaluatedAt,
+	})
+	if err != nil {
+		if o.logger != nil {
+			o.logger.Warn(
+				"merge required check streak evaluation failed",
+				"issue_id", issueID,
+				"identifier", issue.Identifier,
+				"pull_request_number", prNumber,
+				"error", err,
+			)
+		}
+		return nil
+	}
+	return streaks
+}
+
+func mergeRequiredCheckConfigFingerprint(checkNames []string) string {
+	normalized := gate.NormalizeRequiredStatusChecks(checkNames)
+	sort.Strings(normalized)
+	var encoded strings.Builder
+	for _, checkName := range normalized {
+		encoded.WriteString(strconv.Itoa(len(checkName)))
+		encoded.WriteByte(':')
+		encoded.WriteString(checkName)
+	}
+	digest := sha256.Sum256([]byte(encoded.String()))
+	return hex.EncodeToString(digest[:])
+}
+
+func persistentMissingRequiredCheckStreaks(streaks []store.MergeRequiredCheckStreak) []store.MergeRequiredCheckStreak {
+	persistent := make([]store.MergeRequiredCheckStreak, 0, len(streaks))
+	for _, streak := range streaks {
+		if streak.ConsecutiveMissing >= mergeWorkerMissingRequiredCheckLimit {
+			persistent = append(persistent, streak)
+		}
+	}
+	return persistent
+}
+
+func (o *Orchestrator) blockPersistentlyMissingRequiredChecks(
+	ctx context.Context,
+	state *State,
+	event runpkg.Completion,
+	running Running,
+	issue connector.Issue,
+	streaks []store.MergeRequiredCheckStreak,
+) {
+	issueID := strings.TrimSpace(event.IssueID)
+	running.Issue = issue
+	reason := persistentMissingRequiredCheckReason(streaks)
+	metadata := o.newBlockedRecoveryMetadata(
+		ctx,
+		issue,
+		RunModeMerge,
+		reason,
+		blockedRecoveryPredicateManaged,
+		autoPromoteMergingState,
+		running.DiffStats,
+	)
+	metadata.BlockedRecovery.Owner = blockedRecoveryOwnerHuman
+	if err := o.updateIssueStateByIDStrictWithMetadata(
+		ctx,
+		state,
+		issueID,
+		issue,
+		blockedStatusState,
+		event.CompletedAt,
+		reason,
+		metadata,
+	); err != nil {
+		o.failProgrammaticMergeWorkerResult(ctx, state, event, running, "merge_worker_persistent_missing_required_check_block_failed", err)
+		return
+	}
+	o.clearMergeRequiredCheckStreaks(ctx, issue)
+
+	if comment := persistentMissingRequiredCheckComment(issue, streaks); comment != "" {
+		if err := o.connector.CreateComment(ctx, issueID, comment); err != nil && o.logger != nil {
+			o.logger.Warn("persistent missing required check comment failed", "issue_id", issueID, "reason", reason, "error", err)
+		}
+	}
+	o.recordProjectAttemptOutcome(state, event.IssueID, event.CompletedAt, store.WorkAttemptTerminalSuccess, nil, "", "")
+	o.completeDurableWorkAttempt(ctx, state, running, event.CompletedAt, store.WorkAttemptTerminalSuccess, "", "", "blocked", "required checks persistently missing")
+	o.logMergeWorkerFailure(issue, reason, nil)
+	o.recordMergeFailed(state, issue, event.CompletedAt, reason, nil)
+	if err := o.abandonClaim(ctx, issueID); err != nil && o.logger != nil {
+		o.logger.Warn("abandon persistent missing required check claim failed", "issue_id", issueID, "error", err)
+	}
+	delete(state.Claimed, issueID)
+	delete(state.Retry, issueID)
+	delete(state.BudgetRefusals, issueID)
+	delete(state.PriorAttempts, issueID)
+	delete(state.Completed, issueID)
+	delete(state.AutoPromoteDecisions, issueID)
+	delete(state.InstantFailures, issueID)
+	delete(state.RepeatedFailures, issueID)
+
+	blockedIssue := cloneIssue(issue)
+	blockedIssue.State = blockedStatusState
+	blockedIssue.BlockerReason = reason
+	blockedAt := event.CompletedAt.UTC()
+	blockedIssue.StageUpdatedAt = &blockedAt
+	if state.Blocked == nil {
+		state.Blocked = map[string]Blocked{}
+	}
+	state.Blocked[issueID] = Blocked{
+		Issue:          blockedIssue,
+		Reason:         reason,
+		RecoveryReason: string(BlockedRecoveryReasonHumanBlocker),
+		RecoveryTarget: autoPromoteMergingState,
+		BlockedAt:      event.CompletedAt,
+		Source:         BlockedSourceProjectStatus,
+		Recovery:       metadata.BlockedRecovery,
+	}
+	recordStateEvent(state, telemetry.ActivityEvent{
+		At:      event.CompletedAt,
+		Event:   mergeWorkerPersistentMissingRequiredCheckReason,
+		Message: "parked " + issueLabel(issue) + " after required checks remained missing: " + persistentMissingRequiredCheckNames(streaks),
+	})
+}
+
+func persistentMissingRequiredCheckReason(streaks []store.MergeRequiredCheckStreak) string {
+	return mergeWorkerPersistentMissingRequiredCheckReason + ": " + persistentMissingRequiredCheckNames(streaks)
+}
+
+func persistentMissingRequiredCheckNames(streaks []store.MergeRequiredCheckStreak) string {
+	names := make([]string, 0, len(streaks))
+	for _, streak := range streaks {
+		name := strings.TrimSpace(streak.CheckName)
+		if name != "" {
+			names = append(names, name)
+		}
+	}
+	return strings.Join(names, ", ")
+}
+
+func persistentMissingRequiredCheckComment(issue connector.Issue, streaks []store.MergeRequiredCheckStreak) string {
+	if len(streaks) == 0 {
+		return ""
+	}
+	var body strings.Builder
+	body.WriteString("Detent parked this issue in Blocked because required checks remained missing across merge evaluations.")
+	body.WriteString("\n\n- reason: ")
+	body.WriteString(persistentMissingRequiredCheckReason(streaks))
+	body.WriteString("\n- missing_required_checks:")
+	for _, streak := range streaks {
+		body.WriteString("\n  - ")
+		body.WriteString(strings.TrimSpace(streak.CheckName))
+		body.WriteString(" (consecutive evaluations: ")
+		body.WriteString(strconv.Itoa(streak.ConsecutiveMissing))
+		body.WriteString(")")
+	}
+	if issue.PullRequest != nil {
+		if url := strings.TrimSpace(issue.PullRequest.URL); url != "" {
+			body.WriteString("\n- pull request: ")
+			body.WriteString(url)
+		}
+		if headSHA := strings.TrimSpace(issue.PullRequest.HeadSHA); headSHA != "" {
+			body.WriteString("\n- head_sha: ")
+			body.WriteString(headSHA)
+		}
+	}
+	body.WriteString("\n\nRestore or update the required-check configuration, then move the issue back to Merging.")
+	return body.String()
+}
+
+func (o *Orchestrator) clearMergeRequiredCheckStreaks(ctx context.Context, issue connector.Issue) {
+	if o == nil || o.mergeRequiredChecks == nil {
+		return
+	}
+	issueID := strings.TrimSpace(issue.ID)
+	if issueID == "" {
+		return
+	}
+	if err := o.mergeRequiredChecks.ClearMergeRequiredCheckStreaks(ctx, o.workflowMetricsProjectID(), issueID); err != nil && o.logger != nil {
+		o.logger.Warn(
+			"clear merge required check streaks failed",
+			"issue_id", issueID,
+			"identifier", issue.Identifier,
+			"error", err,
+		)
+	}
+}

--- a/internal/orchestrator/merge_required_checks_test.go
+++ b/internal/orchestrator/merge_required_checks_test.go
@@ -1,0 +1,274 @@
+package orchestrator
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/digitaldrywood/detent/internal/connector"
+	"github.com/digitaldrywood/detent/internal/gate"
+	runpkg "github.com/digitaldrywood/detent/internal/runner"
+	"github.com/digitaldrywood/detent/internal/store"
+)
+
+func TestMergeRequiredCheckStreakEscalation(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name               string
+		autoPromoteEnabled bool
+		steps              []mergeRequiredCheckEvaluationStep
+		wantBlocked        bool
+	}{
+		{
+			name:               "check arrives before threshold",
+			autoPromoteEnabled: true,
+			steps: []mergeRequiredCheckEvaluationStep{
+				{missing: true, headSHA: "head-a", requiredChecks: []string{"Test"}},
+				{headSHA: "head-a", requiredChecks: []string{"Test"}},
+				{missing: true, headSHA: "head-a", requiredChecks: []string{"Test"}},
+				{missing: true, headSHA: "head-a", requiredChecks: []string{"Test"}},
+			},
+		},
+		{
+			name:               "check never arrives",
+			autoPromoteEnabled: true,
+			steps: []mergeRequiredCheckEvaluationStep{
+				{missing: true, headSHA: "head-a", requiredChecks: []string{"Test"}},
+				{missing: true, headSHA: "head-a", requiredChecks: []string{"Test"}},
+				{missing: true, headSHA: "head-a", requiredChecks: []string{"Test"}},
+			},
+			wantBlocked: true,
+		},
+		{
+			name:               "config change mid-count",
+			autoPromoteEnabled: true,
+			steps: []mergeRequiredCheckEvaluationStep{
+				{missing: true, headSHA: "head-a", requiredChecks: []string{"Test", "Lint"}},
+				{missing: true, headSHA: "head-a", requiredChecks: []string{"Test", "Lint"}},
+				{missing: true, headSHA: "head-a", requiredChecks: []string{"Test", "Checks"}},
+			},
+		},
+		{
+			name:               "head SHA change mid-count",
+			autoPromoteEnabled: true,
+			steps: []mergeRequiredCheckEvaluationStep{
+				{missing: true, headSHA: "head-a", requiredChecks: []string{"Test"}},
+				{missing: true, headSHA: "head-a", requiredChecks: []string{"Test"}},
+				{missing: true, headSHA: "head-b", requiredChecks: []string{"Test"}},
+			},
+			wantBlocked: true,
+		},
+		{
+			name: "auto-promote disabled",
+			steps: []mergeRequiredCheckEvaluationStep{
+				{missing: true, headSHA: "head-a", requiredChecks: []string{"Test"}},
+				{missing: true, headSHA: "head-a", requiredChecks: []string{"Test"}},
+				{missing: true, headSHA: "head-a", requiredChecks: []string{"Test"}},
+			},
+			wantBlocked: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			orch, tracker, state, closeStore := newMergeRequiredCheckTestOrchestrator(t, tt.autoPromoteEnabled)
+			defer closeStore()
+			now := time.Date(2026, 8, 7, 15, 0, 0, 0, time.UTC)
+			for index, step := range tt.steps {
+				runMergeRequiredCheckEvaluation(t, orch, tracker, &state, step, now.Add(time.Duration(index)*time.Minute))
+			}
+
+			blocked, ok := state.Blocked[mergeRequiredCheckTestIssueID]
+			if ok != tt.wantBlocked {
+				t.Fatalf("Blocked[%q] present = %t, want %t", mergeRequiredCheckTestIssueID, ok, tt.wantBlocked)
+			}
+			if !tt.wantBlocked {
+				if len(tracker.updates) == 0 || tracker.updates[len(tracker.updates)-1].state != autoPromoteReworkState {
+					t.Fatalf("updates = %#v, want final Rework transition", tracker.updates)
+				}
+				return
+			}
+			if !strings.Contains(blocked.Reason, "Test") {
+				t.Fatalf("Blocked[%q].Reason = %q, want missing check name", mergeRequiredCheckTestIssueID, blocked.Reason)
+			}
+			if blocked.RecoveryReason != string(BlockedRecoveryReasonHumanBlocker) {
+				t.Fatalf("Blocked[%q].RecoveryReason = %q, want needs-human signal", mergeRequiredCheckTestIssueID, blocked.RecoveryReason)
+			}
+			snapshot := state.Snapshot(now.Add(time.Hour))
+			if len(snapshot.Blocked) != 1 || !strings.Contains(snapshot.Blocked[0].Error, "Test") || snapshot.Blocked[0].RecoveryReason != string(BlockedRecoveryReasonHumanBlocker) {
+				t.Fatalf("snapshot.Blocked = %#v, want board-visible named needs-human reason", snapshot.Blocked)
+			}
+			if len(tracker.updates) == 0 || tracker.updates[len(tracker.updates)-1].state != blockedStatusState {
+				t.Fatalf("updates = %#v, want final Blocked transition", tracker.updates)
+			}
+			if len(tracker.comments) == 0 || !strings.Contains(tracker.comments[len(tracker.comments)-1].body, "Test") {
+				t.Fatalf("comments = %#v, want persistent missing-check detail", tracker.comments)
+			}
+		})
+	}
+}
+
+func TestMergeRequiredCheckStreakClearsOnTerminalCompletion(t *testing.T) {
+	t.Parallel()
+
+	orch, tracker, state, closeStore := newMergeRequiredCheckTestOrchestrator(t, true)
+	defer closeStore()
+	now := time.Date(2026, 8, 7, 16, 0, 0, 0, time.UTC)
+	step := mergeRequiredCheckEvaluationStep{missing: true, headSHA: "head-a", requiredChecks: []string{"Test"}}
+	runMergeRequiredCheckEvaluation(t, orch, tracker, &state, step, now)
+	runMergeRequiredCheckEvaluation(t, orch, tracker, &state, step, now.Add(time.Minute))
+
+	terminalIssue := mergeRequiredCheckTestIssue(step)
+	terminalIssue.State = "Done"
+	orch.completeTerminalRunning(t.Context(), &state, terminalIssue.ID, Running{
+		Issue:     terminalIssue,
+		Attempt:   1,
+		StartedAt: now.Add(2 * time.Minute),
+		Mode:      runpkg.RunModeMerge,
+	}, now.Add(3*time.Minute), TokenTotals{})
+	runMergeRequiredCheckEvaluation(t, orch, tracker, &state, step, now.Add(4*time.Minute))
+
+	if _, ok := state.Blocked[mergeRequiredCheckTestIssueID]; ok {
+		t.Fatalf("Blocked[%q] present after terminal reset and one missing evaluation", mergeRequiredCheckTestIssueID)
+	}
+	if len(tracker.updates) == 0 || tracker.updates[len(tracker.updates)-1].state != autoPromoteReworkState {
+		t.Fatalf("updates = %#v, want Rework after reset", tracker.updates)
+	}
+}
+
+func TestMergeRequiredCheckStreakClearsWhenBlocked(t *testing.T) {
+	t.Parallel()
+
+	orch, tracker, state, closeStore := newMergeRequiredCheckTestOrchestrator(t, true)
+	defer closeStore()
+	now := time.Date(2026, 8, 7, 16, 30, 0, 0, time.UTC)
+	step := mergeRequiredCheckEvaluationStep{missing: true, headSHA: "head-a", requiredChecks: []string{"Test"}}
+	for evaluation := range mergeWorkerMissingRequiredCheckLimit {
+		runMergeRequiredCheckEvaluation(t, orch, tracker, &state, step, now.Add(time.Duration(evaluation)*time.Minute))
+	}
+
+	if _, ok := state.Blocked[mergeRequiredCheckTestIssueID]; !ok {
+		t.Fatalf("Blocked[%q] missing after threshold", mergeRequiredCheckTestIssueID)
+	}
+	delete(state.Blocked, mergeRequiredCheckTestIssueID)
+	runMergeRequiredCheckEvaluation(t, orch, tracker, &state, step, now.Add(time.Hour))
+
+	if _, ok := state.Blocked[mergeRequiredCheckTestIssueID]; ok {
+		t.Fatalf("Blocked[%q] present on first recovery evaluation", mergeRequiredCheckTestIssueID)
+	}
+	if len(tracker.updates) == 0 || tracker.updates[len(tracker.updates)-1].state != autoPromoteReworkState {
+		t.Fatalf("updates = %#v, want fresh Rework propagation window", tracker.updates)
+	}
+}
+
+const mergeRequiredCheckTestIssueID = "issue-persistent-missing-check"
+
+type mergeRequiredCheckEvaluationStep struct {
+	missing        bool
+	headSHA        string
+	requiredChecks []string
+}
+
+func newMergeRequiredCheckTestOrchestrator(
+	t *testing.T,
+	autoPromoteEnabled bool,
+) (*Orchestrator, *autoPromoteTickMergeConnector, State, func()) {
+	t.Helper()
+	runtimeStore, err := store.Open(t.Context(), store.Config{Path: filepath.Join(t.TempDir(), "detent.db")})
+	if err != nil {
+		t.Fatalf("store.Open() error = %v", err)
+	}
+	cfg := normalizeConfig(Config{
+		MaxConcurrentAgents:    1,
+		FailureRetryBaseDelay:  time.Minute,
+		MaxRetryBackoff:        time.Hour,
+		ContinuationRetryDelay: 5 * time.Second,
+		MergeFastPathEnabled:   true,
+		ActiveStates:           []string{"Todo", "In Progress", "Rework", "Merging"},
+		ObservedStates:         []string{"Merging"},
+		TerminalStates:         []string{"Done", "Cancelled"},
+		AutoPromote: AutoPromoteConfig{
+			Enabled: autoPromoteEnabled,
+			Gate: gate.Config{
+				Kind:                 gate.KindCommand,
+				RequiredStatusChecks: []string{"Test"},
+			},
+		},
+	})
+	tracker := &autoPromoteTickMergeConnector{
+		autoPromoteTickConnector: &autoPromoteTickConnector{},
+	}
+	orch := &Orchestrator{
+		cfg:                 cfg,
+		connector:           tracker,
+		workflowMetrics:     runtimeStore,
+		mergeRequiredChecks: runtimeStore,
+		logger:              slog.New(slog.NewTextHandler(io.Discard, nil)),
+	}
+	return orch, tracker, newState(cfg), func() {
+		if err := runtimeStore.Close(); err != nil {
+			t.Fatalf("Close() error = %v", err)
+		}
+	}
+}
+
+func runMergeRequiredCheckEvaluation(
+	t *testing.T,
+	orch *Orchestrator,
+	tracker *autoPromoteTickMergeConnector,
+	state *State,
+	step mergeRequiredCheckEvaluationStep,
+	at time.Time,
+) {
+	t.Helper()
+	orch.cfg.AutoPromote.Gate.RequiredStatusChecks = append([]string(nil), step.requiredChecks...)
+	issue := mergeRequiredCheckTestIssue(step)
+	tracker.stateIssues = []connector.Issue{cloneIssue(issue)}
+	state.Running[issue.ID] = Running{
+		Issue:      cloneIssue(issue),
+		Attempt:    maxMergeWorkerRunnerFailures,
+		StartedAt:  at.Add(-time.Minute),
+		WorkerHost: "worker-a",
+		Mode:       runpkg.RunModeMerge,
+	}
+	state.Claimed[issue.ID] = Claimed{Issue: cloneIssue(issue), ClaimedAt: at.Add(-time.Minute)}
+	orch.handleRunResult(context.Background(), state, runpkg.Completion{
+		IssueID:     issue.ID,
+		CompletedAt: at,
+		Request:     runpkg.RunRequest{Mode: runpkg.RunModeMerge},
+		Result: runpkg.RunResult{
+			FinalState: runpkg.FinalStateCompleted,
+			Output:     runpkg.RunOutputMergeFastPathClean,
+		},
+	})
+}
+
+func mergeRequiredCheckTestIssue(step mergeRequiredCheckEvaluationStep) connector.Issue {
+	pullRequest := &connector.PullRequest{
+		Number:         1634,
+		URL:            "https://github.test/digitaldrywood/detent/pull/1634",
+		BranchName:     "detent/1634",
+		State:          "OPEN",
+		MergeableState: "blocked",
+		CIStatus:       "pending",
+		HeadSHA:        step.headSHA,
+	}
+	if step.missing {
+		pullRequest.RequiredCheckFailures = []connector.PullRequestCheck{{Name: "Test", Status: "missing", Conclusion: "missing"}}
+	} else {
+		pullRequest.RunningChecks = []string{"Test"}
+	}
+	return connector.Issue{
+		ID:           mergeRequiredCheckTestIssueID,
+		Identifier:   "digitaldrywood/detent#1634",
+		State:        autoPromoteMergingState,
+		PRRepository: "digitaldrywood/detent",
+		PullRequest:  pullRequest,
+	}
+}

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -148,6 +148,7 @@ type Dependencies struct {
 	Efficiency           efficiency.Recorder
 	LifecycleExporter    efficiency.LifecycleExporter
 	WorkAttempts         store.WorkAttemptStore
+	MergeRequiredChecks  store.MergeRequiredCheckStore
 	ProgressSpend        store.ProgressSpendStore
 	AgentResume          store.AgentResumeStore
 	OrphanSessions       store.OrphanSessionStore
@@ -201,6 +202,7 @@ type Orchestrator struct {
 	efficiency              efficiency.Recorder
 	lifecycleExporter       efficiency.LifecycleExporter
 	workAttempts            store.WorkAttemptStore
+	mergeRequiredChecks     store.MergeRequiredCheckStore
 	operatorStops           store.OperatorStopStore
 	progressSpend           store.ProgressSpendStore
 	agentResume             store.AgentResumeStore
@@ -404,6 +406,17 @@ func New(cfg Config, deps Dependencies) (*Orchestrator, error) {
 			progressSpend = candidate
 		}
 	}
+	mergeRequiredChecks := deps.MergeRequiredChecks
+	if mergeRequiredChecks == nil {
+		if candidate, ok := deps.WorkAttempts.(store.MergeRequiredCheckStore); ok {
+			mergeRequiredChecks = candidate
+		}
+	}
+	if mergeRequiredChecks == nil {
+		if candidate, ok := deps.WorkflowMetrics.(store.MergeRequiredCheckStore); ok {
+			mergeRequiredChecks = candidate
+		}
+	}
 	var operatorStops store.OperatorStopStore
 	if candidate, ok := deps.WorkAttempts.(store.OperatorStopStore); ok {
 		operatorStops = candidate
@@ -455,6 +468,7 @@ func New(cfg Config, deps Dependencies) (*Orchestrator, error) {
 		efficiency:              deps.Efficiency,
 		lifecycleExporter:       deps.LifecycleExporter,
 		workAttempts:            deps.WorkAttempts,
+		mergeRequiredChecks:     mergeRequiredChecks,
 		operatorStops:           operatorStops,
 		progressSpend:           progressSpend,
 		agentResume:             agentResume,

--- a/internal/orchestrator/reconcile.go
+++ b/internal/orchestrator/reconcile.go
@@ -507,6 +507,7 @@ func (o *Orchestrator) setBlockedStatusIssue(state *State, issue connector.Issue
 			strings.HasPrefix(existing.Reason, tokenCeilingBlockedReasonPrefix) ||
 			strings.HasPrefix(existing.Reason, artifactGateConvergenceBlockedReasonPrefix) ||
 			strings.HasPrefix(existing.Reason, mergeWorkerRetryExhaustedReason) ||
+			strings.HasPrefix(existing.Reason, mergeWorkerPersistentMissingRequiredCheckReason) ||
 			strings.HasPrefix(existing.Reason, mergeWorkerDurationExceededReason)) &&
 		strings.TrimSpace(issue.BlockerReason) == "" {
 		existing.Issue = cloneIssue(issue)

--- a/internal/orchestrator/run_completion.go
+++ b/internal/orchestrator/run_completion.go
@@ -1092,6 +1092,12 @@ func (o *Orchestrator) completeProgrammaticMergeWorkerResult(
 		o.finishMergeRevocation(ctx, state, event, running, revocation)
 		return true
 	}
+	missingChecks := mergeWorkerMissingRequiredChecks(issue)
+	streaks := o.evaluateMergeRequiredCheckStreaks(ctx, issue, missingChecks, event.CompletedAt)
+	if persistent := persistentMissingRequiredCheckStreaks(streaks); len(persistent) > 0 {
+		o.blockPersistentlyMissingRequiredChecks(ctx, state, event, running, issue, persistent)
+		return true
+	}
 	if event.Result.PullRequestHeadPushed {
 		triggerPending := false
 		if !event.Result.CITriggerLabelReapplied {
@@ -1109,7 +1115,7 @@ func (o *Orchestrator) completeProgrammaticMergeWorkerResult(
 			o.waitForMergeWorkerPullRequestHydration(ctx, state, event, running, issue)
 			return true
 		}
-		if missingChecks := mergeWorkerMissingRequiredChecks(issue); len(missingChecks) > 0 {
+		if len(missingChecks) > 0 {
 			triggerPending := o.scheduleCITriggerLabel(ctx, issue, missingChecks, running.Attempt, false, false)
 			if triggerPending || mergeWorkerMissingRequiredChecksPropagating(issue, running.Attempt) {
 				o.waitForMergeWorkerRequiredCheckPropagation(ctx, state, event, running, issue)
@@ -2003,6 +2009,7 @@ func (o *Orchestrator) completeTerminalRunning(
 	tokens TokenTotals,
 ) {
 	o.heartbeats.remove(issueID)
+	o.clearMergeRequiredCheckStreaks(ctx, running.Issue)
 	o.completeDurableWorkAttempt(ctx, state, running, completedAt, store.WorkAttemptTerminalSuccess, "", "", "completed", "worker reached terminal state")
 	o.releaseGlobalDispatchSlot(running.globalSlot)
 	if running.cancel != nil {

--- a/internal/orchestrator/workflow_metrics.go
+++ b/internal/orchestrator/workflow_metrics.go
@@ -144,6 +144,13 @@ func (o *Orchestrator) updateIssueStateByIDWithMetadataMode(
 		}
 		return err
 	}
+	if stateIn(targetState, o.cfg.TerminalStates) {
+		terminalIssue := cloneIssue(issue)
+		if strings.TrimSpace(terminalIssue.ID) == "" {
+			terminalIssue.ID = issueID
+		}
+		o.clearMergeRequiredCheckStreaks(ctx, terminalIssue)
+	}
 	updateIssueStateSnapshots(state, issueID, issue, targetState, at)
 	if strings.TrimSpace(issue.ID) == "" {
 		issue.ID = issueID

--- a/internal/store/merge_required_checks.go
+++ b/internal/store/merge_required_checks.go
@@ -1,0 +1,165 @@
+package store
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"sort"
+	"strings"
+)
+
+type mergeRequiredCheckRow struct {
+	repository                string
+	prNumber                  int
+	checkName                 string
+	requiredChecksFingerprint string
+	consecutiveMissing        int
+}
+
+func (s *sqliteStore) EvaluateMergeRequiredChecks(ctx context.Context, evaluation MergeRequiredCheckEvaluation) ([]MergeRequiredCheckStreak, error) {
+	projectID := strings.TrimSpace(evaluation.ProjectID)
+	if projectID == "" {
+		return nil, errors.New("project_id is required")
+	}
+	issueID := strings.TrimSpace(evaluation.IssueID)
+	if issueID == "" {
+		return nil, errors.New("issue_id is required")
+	}
+	if evaluation.PRNumber <= 0 {
+		return nil, errors.New("pr_number must be greater than zero")
+	}
+	fingerprint := strings.TrimSpace(evaluation.RequiredChecksFingerprint)
+	if fingerprint == "" {
+		return nil, errors.New("required_checks_fingerprint is required")
+	}
+	evaluatedAt, err := requiredTimestamp("evaluated_at", evaluation.EvaluatedAt)
+	if err != nil {
+		return nil, err
+	}
+
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return nil, fmt.Errorf("begin merge required check evaluation: %w", err)
+	}
+	committed := false
+	defer func() {
+		if !committed {
+			_ = tx.Rollback()
+		}
+	}()
+
+	previous, err := mergeRequiredCheckRows(ctx, tx, projectID, issueID)
+	if err != nil {
+		return nil, err
+	}
+	if _, err := tx.ExecContext(ctx, `
+DELETE FROM merge_required_check_streaks
+WHERE project_id = ? AND issue_id = ?`, projectID, issueID); err != nil {
+		return nil, fmt.Errorf("reset merge required check streaks: %w", err)
+	}
+
+	repository := strings.TrimSpace(evaluation.Repository)
+	missingChecks := normalizedMergeRequiredCheckNames(evaluation.MissingChecks)
+	streaks := make([]MergeRequiredCheckStreak, 0, len(missingChecks))
+	for _, checkName := range missingChecks {
+		count := 1
+		if row, ok := previous[checkName]; ok &&
+			row.repository == repository &&
+			row.prNumber == evaluation.PRNumber &&
+			row.requiredChecksFingerprint == fingerprint {
+			count = row.consecutiveMissing + 1
+		}
+		if _, err := tx.ExecContext(ctx, `
+INSERT INTO merge_required_check_streaks (
+  project_id, issue_id, repository, pr_number, check_name,
+  required_checks_fingerprint, consecutive_missing, updated_at
+) VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+			projectID,
+			issueID,
+			repository,
+			evaluation.PRNumber,
+			checkName,
+			fingerprint,
+			count,
+			evaluatedAt,
+		); err != nil {
+			return nil, fmt.Errorf("record merge required check streak: %w", err)
+		}
+		streaks = append(streaks, MergeRequiredCheckStreak{
+			CheckName:          checkName,
+			ConsecutiveMissing: count,
+		})
+	}
+
+	if err := tx.Commit(); err != nil {
+		return nil, fmt.Errorf("commit merge required check evaluation: %w", err)
+	}
+	committed = true
+	return streaks, nil
+}
+
+func (s *sqliteStore) ClearMergeRequiredCheckStreaks(ctx context.Context, projectID string, issueID string) error {
+	projectID = strings.TrimSpace(projectID)
+	if projectID == "" {
+		return errors.New("project_id is required")
+	}
+	issueID = strings.TrimSpace(issueID)
+	if issueID == "" {
+		return errors.New("issue_id is required")
+	}
+	if _, err := s.db.ExecContext(ctx, `
+DELETE FROM merge_required_check_streaks
+WHERE project_id = ? AND issue_id = ?`, projectID, issueID); err != nil {
+		return fmt.Errorf("clear merge required check streaks: %w", err)
+	}
+	return nil
+}
+
+func mergeRequiredCheckRows(ctx context.Context, tx *sql.Tx, projectID string, issueID string) (map[string]mergeRequiredCheckRow, error) {
+	rows, err := tx.QueryContext(ctx, `
+SELECT repository, pr_number, check_name, required_checks_fingerprint, consecutive_missing
+FROM merge_required_check_streaks
+WHERE project_id = ? AND issue_id = ?`, projectID, issueID)
+	if err != nil {
+		return nil, fmt.Errorf("read merge required check streaks: %w", err)
+	}
+	defer rows.Close()
+
+	streaks := map[string]mergeRequiredCheckRow{}
+	for rows.Next() {
+		var row mergeRequiredCheckRow
+		if err := rows.Scan(
+			&row.repository,
+			&row.prNumber,
+			&row.checkName,
+			&row.requiredChecksFingerprint,
+			&row.consecutiveMissing,
+		); err != nil {
+			return nil, fmt.Errorf("scan merge required check streak: %w", err)
+		}
+		streaks[row.checkName] = row
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("read merge required check streak rows: %w", err)
+	}
+	return streaks, nil
+}
+
+func normalizedMergeRequiredCheckNames(names []string) []string {
+	seen := map[string]struct{}{}
+	out := make([]string, 0, len(names))
+	for _, name := range names {
+		name = strings.TrimSpace(name)
+		if name == "" {
+			continue
+		}
+		if _, ok := seen[name]; ok {
+			continue
+		}
+		seen[name] = struct{}{}
+		out = append(out, name)
+	}
+	sort.Strings(out)
+	return out
+}

--- a/internal/store/merge_required_checks_test.go
+++ b/internal/store/merge_required_checks_test.go
@@ -1,0 +1,202 @@
+package store
+
+import (
+	"context"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestMergeRequiredCheckStreakLifecycle(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		steps []mergeRequiredCheckTestStep
+	}{
+		{
+			name: "increments independent checks",
+			steps: []mergeRequiredCheckTestStep{
+				{missing: []string{"Test", "Lint"}, want: map[string]int{"Lint": 1, "Test": 1}},
+				{missing: []string{"Test"}, want: map[string]int{"Test": 2}},
+			},
+		},
+		{
+			name: "appearance resets",
+			steps: []mergeRequiredCheckTestStep{
+				{missing: []string{"Test"}, want: map[string]int{"Test": 1}},
+				{want: map[string]int{}},
+				{missing: []string{"Test"}, want: map[string]int{"Test": 1}},
+			},
+		},
+		{
+			name: "config change resets",
+			steps: []mergeRequiredCheckTestStep{
+				{fingerprint: "config-a", missing: []string{"Test"}, want: map[string]int{"Test": 1}},
+				{fingerprint: "config-a", missing: []string{"Test"}, want: map[string]int{"Test": 2}},
+				{fingerprint: "config-b", missing: []string{"Test"}, want: map[string]int{"Test": 1}},
+			},
+		},
+		{
+			name: "pull request change resets",
+			steps: []mergeRequiredCheckTestStep{
+				{prNumber: 41, missing: []string{"Test"}, want: map[string]int{"Test": 1}},
+				{prNumber: 41, missing: []string{"Test"}, want: map[string]int{"Test": 2}},
+				{prNumber: 42, missing: []string{"Test"}, want: map[string]int{"Test": 1}},
+			},
+		},
+		{
+			name: "terminal clear resets",
+			steps: []mergeRequiredCheckTestStep{
+				{missing: []string{"Test"}, want: map[string]int{"Test": 1}},
+				{missing: []string{"Test"}, want: map[string]int{"Test": 2}},
+				{clear: true},
+				{missing: []string{"Test"}, want: map[string]int{"Test": 1}},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			backend, err := Open(t.Context(), Config{Path: filepath.Join(t.TempDir(), "detent.db")})
+			if err != nil {
+				t.Fatalf("Open() error = %v", err)
+			}
+			t.Cleanup(func() {
+				if err := backend.Close(); err != nil {
+					t.Fatalf("Close() error = %v", err)
+				}
+			})
+
+			for index, step := range tt.steps {
+				if step.clear {
+					if err := backend.ClearMergeRequiredCheckStreaks(t.Context(), "detent", "issue-1634"); err != nil {
+						t.Fatalf("step %d ClearMergeRequiredCheckStreaks() error = %v", index, err)
+					}
+					continue
+				}
+				fingerprint := step.fingerprint
+				if fingerprint == "" {
+					fingerprint = "config"
+				}
+				prNumber := step.prNumber
+				if prNumber == 0 {
+					prNumber = 41
+				}
+				streaks, err := backend.EvaluateMergeRequiredChecks(t.Context(), MergeRequiredCheckEvaluation{
+					ProjectID:                 "detent",
+					IssueID:                   "issue-1634",
+					Repository:                "digitaldrywood/detent",
+					PRNumber:                  prNumber,
+					RequiredChecksFingerprint: fingerprint,
+					MissingChecks:             step.missing,
+					EvaluatedAt:               time.Date(2026, 8, 7, 15, index, 0, 0, time.UTC),
+				})
+				if err != nil {
+					t.Fatalf("step %d EvaluateMergeRequiredChecks() error = %v", index, err)
+				}
+				got := map[string]int{}
+				for _, streak := range streaks {
+					got[streak.CheckName] = streak.ConsecutiveMissing
+				}
+				if !reflect.DeepEqual(got, step.want) {
+					t.Fatalf("step %d streaks = %#v, want %#v", index, got, step.want)
+				}
+			}
+		})
+	}
+}
+
+type mergeRequiredCheckTestStep struct {
+	prNumber    int
+	fingerprint string
+	missing     []string
+	clear       bool
+	want        map[string]int
+}
+
+func TestMergeRequiredCheckStreakValidation(t *testing.T) {
+	t.Parallel()
+
+	backend, err := Open(context.Background(), Config{Path: filepath.Join(t.TempDir(), "detent.db")})
+	if err != nil {
+		t.Fatalf("Open() error = %v", err)
+	}
+	t.Cleanup(func() {
+		if err := backend.Close(); err != nil {
+			t.Fatalf("Close() error = %v", err)
+		}
+	})
+
+	tests := []struct {
+		name       string
+		evaluation MergeRequiredCheckEvaluation
+		want       string
+	}{
+		{name: "project", evaluation: MergeRequiredCheckEvaluation{}, want: "project_id"},
+		{name: "issue", evaluation: MergeRequiredCheckEvaluation{ProjectID: "detent"}, want: "issue_id"},
+		{name: "pull request", evaluation: MergeRequiredCheckEvaluation{ProjectID: "detent", IssueID: "issue"}, want: "pr_number"},
+		{name: "fingerprint", evaluation: MergeRequiredCheckEvaluation{ProjectID: "detent", IssueID: "issue", PRNumber: 1}, want: "required_checks_fingerprint"},
+		{name: "timestamp", evaluation: MergeRequiredCheckEvaluation{ProjectID: "detent", IssueID: "issue", PRNumber: 1, RequiredChecksFingerprint: "config"}, want: "evaluated_at"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := backend.EvaluateMergeRequiredChecks(t.Context(), tt.evaluation)
+			if err == nil || !strings.Contains(err.Error(), tt.want) {
+				t.Fatalf("EvaluateMergeRequiredChecks() error = %v, want %q", err, tt.want)
+			}
+		})
+	}
+}
+
+func TestMergeRequiredCheckStreakPersistsAcrossStoreRestart(t *testing.T) {
+	t.Parallel()
+
+	dbPath := filepath.Join(t.TempDir(), "detent.db")
+	backend, err := Open(t.Context(), Config{Path: dbPath})
+	if err != nil {
+		t.Fatalf("Open() error = %v", err)
+	}
+	evaluation := MergeRequiredCheckEvaluation{
+		ProjectID:                 "detent",
+		IssueID:                   "issue-1634",
+		Repository:                "digitaldrywood/detent",
+		PRNumber:                  41,
+		RequiredChecksFingerprint: "config",
+		MissingChecks:             []string{"Test"},
+		EvaluatedAt:               time.Date(2026, 8, 7, 16, 0, 0, 0, time.UTC),
+	}
+	for count := 1; count <= 2; count++ {
+		streaks, err := backend.EvaluateMergeRequiredChecks(t.Context(), evaluation)
+		if err != nil {
+			t.Fatalf("EvaluateMergeRequiredChecks() error = %v", err)
+		}
+		if len(streaks) != 1 || streaks[0].ConsecutiveMissing != count {
+			t.Fatalf("streaks = %#v, want count %d", streaks, count)
+		}
+	}
+	if err := backend.Close(); err != nil {
+		t.Fatalf("Close() error = %v", err)
+	}
+
+	backend, err = Open(t.Context(), Config{Path: dbPath})
+	if err != nil {
+		t.Fatalf("reopen error = %v", err)
+	}
+	t.Cleanup(func() {
+		if err := backend.Close(); err != nil {
+			t.Fatalf("Close() error = %v", err)
+		}
+	})
+	evaluation.EvaluatedAt = evaluation.EvaluatedAt.Add(time.Minute)
+	streaks, err := backend.EvaluateMergeRequiredChecks(t.Context(), evaluation)
+	if err != nil {
+		t.Fatalf("EvaluateMergeRequiredChecks() after restart error = %v", err)
+	}
+	if len(streaks) != 1 || streaks[0].ConsecutiveMissing != 3 {
+		t.Fatalf("streaks after restart = %#v, want count 3", streaks)
+	}
+}

--- a/internal/store/migrations/00028_create_merge_required_check_streaks.sql
+++ b/internal/store/migrations/00028_create_merge_required_check_streaks.sql
@@ -1,0 +1,20 @@
+-- +goose Up
+CREATE TABLE merge_required_check_streaks (
+  project_id TEXT NOT NULL,
+  issue_id TEXT NOT NULL,
+  repository TEXT NOT NULL,
+  pr_number INTEGER NOT NULL,
+  check_name TEXT NOT NULL,
+  required_checks_fingerprint TEXT NOT NULL,
+  consecutive_missing INTEGER NOT NULL,
+  updated_at TEXT NOT NULL,
+  PRIMARY KEY (project_id, issue_id, repository, pr_number, check_name),
+  CHECK (pr_number > 0),
+  CHECK (consecutive_missing > 0)
+);
+
+CREATE INDEX merge_required_check_streaks_issue_idx
+ON merge_required_check_streaks(project_id, issue_id);
+
+-- +goose Down
+DROP TABLE IF EXISTS merge_required_check_streaks;

--- a/internal/store/sqlc/models.go
+++ b/internal/store/sqlc/models.go
@@ -216,6 +216,17 @@ type FairShareUsage struct {
 	UpdatedAt      string `json:"updated_at"`
 }
 
+type MergeRequiredCheckStreak struct {
+	ProjectID                 string `json:"project_id"`
+	IssueID                   string `json:"issue_id"`
+	Repository                string `json:"repository"`
+	PrNumber                  int64  `json:"pr_number"`
+	CheckName                 string `json:"check_name"`
+	RequiredChecksFingerprint string `json:"required_checks_fingerprint"`
+	ConsecutiveMissing        int64  `json:"consecutive_missing"`
+	UpdatedAt                 string `json:"updated_at"`
+}
+
 type RetroRun struct {
 	ID            int64          `json:"id"`
 	ProjectID     string         `json:"project_id"`

--- a/internal/store/sqlite.go
+++ b/internal/store/sqlite.go
@@ -87,6 +87,7 @@ func (s *sqliteStore) RuntimeEvidence(ctx context.Context, query RuntimeEvidence
 		{name: "efficiency_receipts", projectScoped: true},
 		{name: "work_attempts", projectScoped: true},
 		{name: "scheduler_decisions", projectScoped: true},
+		{name: "merge_required_check_streaks", projectScoped: true},
 		{name: "validator_verdicts", projectScoped: true},
 		{name: "retro_runs", projectScoped: true},
 		{name: "routine_runs", projectScoped: true},
@@ -1225,6 +1226,8 @@ func (s *sqliteStore) runtimeTableCount(ctx context.Context, tableName string, p
 			row = s.db.QueryRowContext(ctx, "SELECT COUNT(*) FROM work_attempts WHERE project_id = ?", projectID)
 		case "scheduler_decisions":
 			row = s.db.QueryRowContext(ctx, "SELECT COUNT(*) FROM scheduler_decisions WHERE project_id = ?", projectID)
+		case "merge_required_check_streaks":
+			row = s.db.QueryRowContext(ctx, "SELECT COUNT(*) FROM merge_required_check_streaks WHERE project_id = ?", projectID)
 		case "validator_verdicts":
 			row = s.db.QueryRowContext(ctx, "SELECT COUNT(*) FROM validator_verdicts WHERE project_id = ?", projectID)
 		case "retro_runs":
@@ -1256,6 +1259,8 @@ func (s *sqliteStore) runtimeTableCount(ctx context.Context, tableName string, p
 			row = s.db.QueryRowContext(ctx, "SELECT COUNT(*) FROM work_attempts")
 		case "scheduler_decisions":
 			row = s.db.QueryRowContext(ctx, "SELECT COUNT(*) FROM scheduler_decisions")
+		case "merge_required_check_streaks":
+			row = s.db.QueryRowContext(ctx, "SELECT COUNT(*) FROM merge_required_check_streaks")
 		case "validator_verdicts":
 			row = s.db.QueryRowContext(ctx, "SELECT COUNT(*) FROM validator_verdicts")
 		case "retro_runs":

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -52,6 +52,7 @@ type Store interface {
 	WorkflowMetricsStore
 	WorkAttemptStore
 	WorkAttemptCapacityReleaseStore
+	MergeRequiredCheckStore
 	OperatorStopStore
 	ValidatorMemoStore
 	RuntimeEvidenceStore
@@ -154,6 +155,11 @@ type IssueSchedulerDecisionStore interface {
 type WorkAttemptCapacityReleaseStore interface {
 	ListPendingWorkAttemptCapacityReleases(context.Context, string) ([]WorkAttempt, error)
 	ClearWorkAttemptCapacityRelease(context.Context, int64) error
+}
+
+type MergeRequiredCheckStore interface {
+	EvaluateMergeRequiredChecks(context.Context, MergeRequiredCheckEvaluation) ([]MergeRequiredCheckStreak, error)
+	ClearMergeRequiredCheckStreaks(context.Context, string, string) error
 }
 
 type OperatorStopStore interface {
@@ -679,6 +685,21 @@ type WorkAttemptReclaim struct {
 	TerminalState WorkAttemptTerminalState
 	ErrorClass    string
 	ErrorMessage  string
+}
+
+type MergeRequiredCheckEvaluation struct {
+	ProjectID                 string
+	IssueID                   string
+	Repository                string
+	PRNumber                  int
+	RequiredChecksFingerprint string
+	MissingChecks             []string
+	EvaluatedAt               time.Time
+}
+
+type MergeRequiredCheckStreak struct {
+	CheckName          string
+	ConsecutiveMissing int
 }
 
 type OperatorStopUpdate struct {

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -47,8 +47,8 @@ func TestOpenSQLiteAppliesMigrationsAndPragmas(t *testing.T) {
 	if got := queryInt(t, sqliteBackend.db, "PRAGMA busy_timeout"); got != 5000 {
 		t.Fatalf("busy_timeout = %d, want 5000", got)
 	}
-	if got := queryInt(t, sqliteBackend.db, "SELECT COUNT(*) FROM sqlite_master WHERE type = 'table' AND name IN ('detent_runs', 'codex_sessions', 'fair_share_usage', 'usage_events', 'workflow_phase_events', 'work_attempts', 'scheduler_decisions', 'validator_verdicts', 'api_keys', 'api_usage_logs', 'efficiency_receipts', 'budget_overrides', 'auth_magic_links', 'auth_sessions', 'routine_runs')"); got != 15 {
-		t.Fatalf("migrated table count = %d, want 15", got)
+	if got := queryInt(t, sqliteBackend.db, "SELECT COUNT(*) FROM sqlite_master WHERE type = 'table' AND name IN ('detent_runs', 'codex_sessions', 'fair_share_usage', 'usage_events', 'workflow_phase_events', 'work_attempts', 'scheduler_decisions', 'merge_required_check_streaks', 'validator_verdicts', 'api_keys', 'api_usage_logs', 'efficiency_receipts', 'budget_overrides', 'auth_magic_links', 'auth_sessions', 'routine_runs')"); got != 16 {
+		t.Fatalf("migrated table count = %d, want 16", got)
 	}
 }
 


### PR DESCRIPTION
## Summary

- persist per-PR, per-check consecutive missing-required-check evaluations in SQLite
- reset streaks when checks appear, required-check configuration or PR identity changes, work reaches a terminal state, or a threshold breach is parked
- park persistently missing checks in human-owned Blocked state with named, board-visible diagnostics
- preserve a fresh propagation window when a human recovers a blocked issue

Fixes #1634

## Test Plan

- go test ./internal/store ./internal/orchestrator -run '^(TestMergeRequiredCheck|TestMergingFastPathMissingRequiredChecks)' -count=1
- go test ./internal/orchestrator -run '^$' -fuzz=. -fuzztime=30s
- make check