### PR TITLE
feat(telemetry): add lifecycle correlation keys

### DIFF
--- a/internal/admission/manager.go
+++ b/internal/admission/manager.go
@@ -25,6 +25,7 @@ import (
 	"github.com/digitaldrywood/detent/internal/dispatchpriority"
 	"github.com/digitaldrywood/detent/internal/runner"
 	"github.com/digitaldrywood/detent/internal/scheduler"
+	"github.com/digitaldrywood/detent/internal/telemetry"
 )
 
 const (
@@ -91,6 +92,7 @@ type Settings struct {
 }
 
 type Result struct {
+	ProjectID       string
 	CandidatesFound int
 	Candidates      int
 	Proposals       []admissionmodel.Proposal
@@ -267,6 +269,7 @@ func (m *Manager) run(ctx context.Context, scheduledFor time.Time, scheduled boo
 
 func (m *Manager) runOnce(ctx context.Context, settings Settings, scheduledFor time.Time) (result Result, runErr error) {
 	result = newResult()
+	result.ProjectID = strings.TrimSpace(settings.ProjectID)
 	startedAt := m.now().UTC()
 	record := admissionmodel.RunRecord{
 		ProjectID:    settings.ProjectID,
@@ -970,12 +973,11 @@ func (m *Manager) admitProposal(
 	if err := m.store.ResolveAdmissionProposal(ctx, decision); err != nil {
 		return fmt.Errorf("resolve admitted backlog proposal %s: %w", proposal.ID, err)
 	}
-	m.logger.InfoContext(
-		ctx,
-		"backlog admission proposal admitted",
-		"project", proposal.ProjectID,
-		"issue_id", proposal.IssueID,
-		"identifier", proposal.IssueIdentifier,
+	telemetry.LogLifecycleMessageContext(ctx, m.logger, slog.LevelInfo, telemetry.LifecycleAdmission, "backlog_admission_proposal_admitted", "backlog admission proposal admitted", telemetry.LifecycleCorrelation{
+		ProjectID:       proposal.ProjectID,
+		IssueID:         proposal.IssueID,
+		IssueIdentifier: proposal.IssueIdentifier,
+	},
 		"from_state", issue.State,
 		"target_state", proposal.TargetState,
 		"proposal_id", proposal.ID,
@@ -1742,7 +1744,7 @@ func (m *Manager) runAndLog(ctx context.Context, scheduledFor time.Time) {
 		}
 		return
 	}
-	m.logger.InfoContext(ctx, "scheduled backlog admission completed",
+	telemetry.LogLifecycleMessageContext(ctx, m.logger, slog.LevelInfo, telemetry.LifecycleAdmission, "scheduled_backlog_admission_completed", "scheduled backlog admission completed", telemetry.LifecycleCorrelation{ProjectID: result.ProjectID},
 		"candidates", result.Candidates,
 		"proposals", len(result.Proposals),
 		"deferred_reason", result.DeferredReason,

--- a/internal/orchestrator/backend_capacity.go
+++ b/internal/orchestrator/backend_capacity.go
@@ -3,6 +3,7 @@ package orchestrator
 import (
 	"context"
 	"errors"
+	"log/slog"
 	"strings"
 	"time"
 
@@ -80,14 +81,12 @@ func (o *Orchestrator) handleBackendCapacityError(
 		Message: backendCapacityStatusMessage(outage),
 	})
 	if o.logger != nil {
-		o.logger.Warn(
-			"backend capacity paused",
+		telemetry.LogLifecycleMessage(o.logger, slog.LevelWarn, telemetry.LifecycleSafetyControl, "backend_capacity_paused", "backend capacity paused", o.runningLifecycleCorrelation(running.Issue, running),
 			"backend_id", outage.Scope.BackendID,
 			"backend_kind", outage.Scope.BackendKind,
 			"provider", outage.Scope.Provider,
 			"reset_at", outage.ResetAt,
 			"resume_at", outage.ResumeAt,
-			"issue_id", running.Issue.ID,
 			"error", event.Err,
 		)
 	}
@@ -314,8 +313,7 @@ func (o *Orchestrator) handleValidatorCapacityEvent(state *State, event validato
 			Message: backendCapacityStatusMessage(outage),
 		})
 		if o.logger != nil {
-			o.logger.Warn(
-				"validator backend capacity paused",
+			telemetry.LogLifecycleMessage(o.logger, slog.LevelWarn, telemetry.LifecycleSafetyControl, "backend_capacity_paused", "validator backend capacity paused", telemetry.LifecycleCorrelation{ProjectID: o.cfg.Project.ID},
 				"backend_id", outage.Scope.BackendID,
 				"provider", outage.Scope.Provider,
 				"resume_at", outage.ResumeAt,
@@ -376,12 +374,13 @@ func (o *Orchestrator) markBackendCapacityProbe(state *State, key string, issueI
 		Message: "backend " + outage.Scope.BackendID + " capacity probe started with " + strings.TrimSpace(issueID),
 	})
 	if o.logger != nil {
-		o.logger.Info(
-			"backend capacity probe started",
+		telemetry.LogLifecycleMessage(o.logger, slog.LevelInfo, telemetry.LifecycleSafetyControl, "backend_capacity_probe_started", "backend capacity probe started", telemetry.LifecycleCorrelation{
+			ProjectID: o.cfg.Project.ID,
+			IssueID:   issueID,
+		},
 			"backend_id", outage.Scope.BackendID,
 			"backend_kind", outage.Scope.BackendKind,
 			"provider", outage.Scope.Provider,
-			"issue_id", strings.TrimSpace(issueID),
 			"probe_attempt", outage.ProbeAttempts,
 			"provider_resume_at", outage.ResumeAt,
 		)
@@ -461,8 +460,7 @@ func (o *Orchestrator) completeBackendCapacityRecovery(
 		Message: "backend " + outage.Scope.BackendID + " capacity recovered via " + source,
 	})
 	if o.logger != nil {
-		o.logger.Info(
-			"backend capacity recovered",
+		telemetry.LogLifecycleMessage(o.logger, slog.LevelInfo, telemetry.LifecycleSafetyControl, "backend_capacity_recovered", "backend capacity recovered", telemetry.LifecycleCorrelation{ProjectID: o.cfg.Project.ID},
 			"backend_id", outage.Scope.BackendID,
 			"backend_kind", outage.Scope.BackendKind,
 			"provider", outage.Scope.Provider,
@@ -500,8 +498,7 @@ func (o *Orchestrator) deferBackendCapacityProbe(state *State, running Running, 
 		Message: "backend " + outage.Scope.BackendID + " capacity probe failed; retrying at " + outage.NextProbeAt.Format(time.RFC3339),
 	})
 	if o.logger != nil {
-		o.logger.Warn(
-			"backend capacity probe deferred",
+		telemetry.LogLifecycleMessage(o.logger, slog.LevelWarn, telemetry.LifecycleSafetyControl, "backend_capacity_probe_deferred", "backend capacity probe deferred", o.runningLifecycleCorrelation(running.Issue, running),
 			"backend_id", outage.Scope.BackendID,
 			"backend_kind", outage.Scope.BackendKind,
 			"provider", outage.Scope.Provider,
@@ -555,8 +552,7 @@ func (o *Orchestrator) clearBackendCapacity(state *State, scopeFilter string, cl
 			Message: "operator cleared backend " + outage.Scope.BackendID + " capacity outage",
 		})
 		if o.logger != nil {
-			o.logger.Info(
-				"operator cleared backend capacity outage",
+			telemetry.LogLifecycleMessage(o.logger, slog.LevelInfo, telemetry.LifecycleSafetyControl, "backend_capacity_operator_cleared", "operator cleared backend capacity outage", telemetry.LifecycleCorrelation{ProjectID: o.cfg.Project.ID},
 				"backend_id", outage.Scope.BackendID,
 				"backend_kind", outage.Scope.BackendKind,
 				"provider", outage.Scope.Provider,
@@ -756,6 +752,12 @@ func (o *Orchestrator) applyBackendCapacityBlockedRecovery(
 		Event:   "backend_capacity_blocked_issue_recovered",
 		Message: "recovered " + issueLabel(issue) + " from Blocked to " + targetState,
 	})
+	telemetry.LogLifecycleMessage(o.logger, slog.LevelInfo, telemetry.LifecycleSafetyControl, "backend_capacity_blocked_issue_recovered", "backend capacity blocked issue recovered", o.issueLifecycleCorrelation(issue),
+		"backend_id", outage.Scope.BackendID,
+		"backend_kind", outage.Scope.BackendKind,
+		"provider", outage.Scope.Provider,
+		"target_state", targetState,
+	)
 	return true
 }
 

--- a/internal/orchestrator/diagnostics.go
+++ b/internal/orchestrator/diagnostics.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log/slog"
 	"net/url"
 	"sort"
 	"strings"
@@ -13,6 +14,7 @@ import (
 	runpkg "github.com/digitaldrywood/detent/internal/runner"
 	"github.com/digitaldrywood/detent/internal/scheduler"
 	"github.com/digitaldrywood/detent/internal/store"
+	"github.com/digitaldrywood/detent/internal/telemetry"
 )
 
 const (
@@ -59,7 +61,7 @@ func (o *Orchestrator) logDispatchPlanDecision(ctx context.Context, state *State
 		"worker_host", strings.TrimSpace(decision.WorkerHost),
 		"unblocker_count", decision.UnblockerCount,
 	)
-	o.logger.Debug("scheduler_dispatch_decision", attrs...)
+	telemetry.LogLifecycle(o.logger, slog.LevelDebug, telemetry.LifecycleDispatch, "scheduler_dispatch_decision", o.issueLifecycleCorrelation(decision.Issue), attrs...)
 }
 
 func unblockerDecisionReason(count int) string {
@@ -77,10 +79,9 @@ func (o *Orchestrator) logSchedulerSlotDecision(issue connector.Issue, outcome s
 	if reason == "" {
 		reason = "slot_" + strings.TrimSpace(outcome)
 	}
-	attrs := o.issueLogAttrs(issue,
+	attrs := []any{
 		"outcome", strings.TrimSpace(outcome),
 		"reason", reason,
-		"project_id", strings.TrimSpace(o.cfg.Project.ID),
 		"pool", strings.TrimSpace(decision.PoolName),
 		"project_weight", o.cfg.Project.Weight,
 		"project_priority", o.cfg.Project.Priority,
@@ -101,8 +102,8 @@ func (o *Orchestrator) logSchedulerSlotDecision(issue connector.Issue, outcome s
 		"lower_priority_running", decision.LowerPriorityRunning,
 		"ready_projects", decision.ReadyProjects,
 		"running_projects", decision.RunningProjects,
-	)
-	o.logger.Debug("scheduler_dispatch_slot_decision", attrs...)
+	}
+	telemetry.LogLifecycle(o.logger, slog.LevelDebug, telemetry.LifecycleDispatch, "scheduler_dispatch_slot_decision", o.issueLifecycleCorrelation(issue), attrs...)
 }
 
 func (o *Orchestrator) recordDispatchGateRefusal(
@@ -253,17 +254,42 @@ func (o *Orchestrator) logWorkerLifecycle(issue connector.Issue, event string, a
 	if o == nil || o.logger == nil {
 		return
 	}
-	all := o.issueLogAttrs(issue, "event", strings.TrimSpace(event))
-	all = append(all, attrs...)
-	o.logger.Debug(strings.TrimSpace(event), all...)
+	correlation := o.issueLifecycleCorrelation(issue)
+	remaining := make([]any, 0, len(attrs))
+	for index := 0; index < len(attrs); {
+		if index+1 >= len(attrs) {
+			remaining = append(remaining, attrs[index])
+			break
+		}
+		key, ok := attrs[index].(string)
+		if !ok {
+			remaining = append(remaining, attrs[index], attrs[index+1])
+			index += 2
+			continue
+		}
+		value := attrs[index+1]
+		switch key {
+		case telemetry.WorkAttemptIDKey:
+			correlation.WorkAttemptID = lifecycleCorrelationInt64(value)
+		case telemetry.DetentSessionIDKey:
+			correlation.DetentSessionID = lifecycleCorrelationInt64(value)
+		case telemetry.ProviderSessionIDKey:
+			if providerSessionID, ok := value.(string); ok {
+				correlation.ProviderSessionID = providerSessionID
+			}
+		default:
+			remaining = append(remaining, key, value)
+		}
+		index += 2
+	}
+	telemetry.LogLifecycle(o.logger, slog.LevelDebug, telemetry.LifecycleWorkAttempt, event, correlation, remaining...)
 }
 
 func (o *Orchestrator) schedulerDecisionAttrs(state *State, now time.Time, issue connector.Issue, attrs ...any) []any {
 	projectStats := o.projectStateSlotStats(issue, state)
 	pool := o.dispatchPoolSnapshot()
-	all := o.issueLogAttrs(issue,
+	all := []any{
 		"lane", normalizeState(issue.State),
-		"project_id", strings.TrimSpace(o.cfg.Project.ID),
 		"pool", pool.Name,
 		"project_weight", o.cfg.Project.Weight,
 		"project_priority", o.cfg.Project.Priority,
@@ -276,22 +302,41 @@ func (o *Orchestrator) schedulerDecisionAttrs(state *State, now time.Time, issue
 		"guaranteed_capacity", pool.Guaranteed,
 		"burst_capacity", pool.BurstTo,
 		"borrowed_slots", pool.Borrowed,
-	)
+	}
 	all = append(all, snapshotAgeAttrs(issue, now)...)
 	all = append(all, pullRequestDiagnosticAttrs(issue, now)...)
 	all = append(all, attrs...)
 	return all
 }
 
-func (o *Orchestrator) issueLogAttrs(issue connector.Issue, attrs ...any) []any {
-	all := []any{
-		"issue_id", strings.TrimSpace(issue.ID),
-		"issue_identifier", strings.TrimSpace(issue.Identifier),
-		"issue_repo", issueRepository(issue),
-		"issue_state", strings.TrimSpace(issue.State),
+func (o *Orchestrator) issueLifecycleCorrelation(issue connector.Issue) telemetry.LifecycleCorrelation {
+	correlation := telemetry.LifecycleCorrelation{
+		IssueID:         issue.ID,
+		IssueIdentifier: issue.Identifier,
 	}
-	all = append(all, attrs...)
-	return all
+	if o != nil {
+		correlation.ProjectID = o.cfg.Project.ID
+	}
+	return correlation
+}
+
+func (o *Orchestrator) runningLifecycleCorrelation(issue connector.Issue, running Running) telemetry.LifecycleCorrelation {
+	correlation := o.issueLifecycleCorrelation(issue)
+	correlation.WorkAttemptID = running.WorkAttemptID
+	correlation.DetentSessionID = running.DetentSessionID
+	correlation.ProviderSessionID = running.SessionID
+	return correlation
+}
+
+func lifecycleCorrelationInt64(value any) int64 {
+	switch value := value.(type) {
+	case int:
+		return int64(value)
+	case int64:
+		return value
+	default:
+		return 0
+	}
 }
 
 func snapshotAgeAttrs(issue connector.Issue, now time.Time) []any {

--- a/internal/orchestrator/dispatch.go
+++ b/internal/orchestrator/dispatch.go
@@ -14,6 +14,7 @@ import (
 	"github.com/digitaldrywood/detent/internal/scheduler"
 	"github.com/digitaldrywood/detent/internal/selector"
 	"github.com/digitaldrywood/detent/internal/store"
+	"github.com/digitaldrywood/detent/internal/telemetry"
 )
 
 func (o *Orchestrator) dispatchPlanner() dispatchPlanner {
@@ -436,6 +437,7 @@ func (o *Orchestrator) dispatchIssueWithOutcome(
 				WorkerHost:    workerHost,
 			}, now, store.WorkAttemptTerminalFailure, workAttemptErrorStartTransition, err.Error(), "starting", "start state transition failed")
 			o.logWorkerLifecycle(issue, "worker_capacity_released",
+				telemetry.WorkAttemptIDKey, workAttemptID,
 				"attempt", attempt,
 				"worker_host", strings.TrimSpace(workerHost),
 				"reason", dispatchIssueFailureStartStateTransition,
@@ -524,6 +526,7 @@ func (o *Orchestrator) dispatchIssueWithOutcome(
 	delete(state.Completed, issue.ID)
 
 	request := RunRequest{
+		ProjectID:           strings.TrimSpace(o.cfg.Project.ID),
 		Issue:               issue,
 		Attempt:             attempt,
 		WorkAttemptID:       workAttemptID,
@@ -548,6 +551,7 @@ func (o *Orchestrator) dispatchIssueWithOutcome(
 	}
 	o.logMergeWorkerAttempt(issue, attempt, workerHost)
 	o.logWorkerLifecycle(issue, "worker_attempt_started",
+		telemetry.WorkAttemptIDKey, workAttemptID,
 		"attempt", attempt,
 		"worker_host", strings.TrimSpace(workerHost),
 		"mode", strings.TrimSpace(runMode),

--- a/internal/orchestrator/implement_progress.go
+++ b/internal/orchestrator/implement_progress.go
@@ -3,6 +3,7 @@ package orchestrator
 import (
 	"context"
 	"encoding/json"
+	"log/slog"
 	"slices"
 	"strconv"
 	"strings"
@@ -600,6 +601,7 @@ func (o *Orchestrator) warnImplementProgressRefresh(issue connector.Issue, messa
 func (o *Orchestrator) blockImplementProgress(
 	ctx context.Context,
 	state *State,
+	running Running,
 	decision implementCompletionProgressDecision,
 	blockedAt time.Time,
 ) bool {
@@ -679,6 +681,11 @@ func (o *Orchestrator) blockImplementProgress(
 		Event:   "implement_worker_no_progress_limit",
 		Message: "parked " + issueLabel(issue) + " after implement progress breaker " + blockReason,
 	})
+	telemetry.LogLifecycle(o.logger, slog.LevelError, telemetry.LifecycleSafetyControl, "implement_worker_no_progress_limit", o.runningLifecycleCorrelation(issue, running),
+		"block_reason", blockReason,
+		"consecutive_no_progress", decision.ConsecutiveNoProgress,
+		"no_progress_limit", decision.NoProgressLimit,
+	)
 	return true
 }
 

--- a/internal/orchestrator/merge_revocation.go
+++ b/internal/orchestrator/merge_revocation.go
@@ -298,6 +298,9 @@ func (o *Orchestrator) finishMergeRevocation(
 	o.routeMergeRevocation(ctx, state, &revocation, completedAt)
 	o.commentMergeRevocation(ctx, state, revocation, completedAt)
 	o.logWorkerLifecycle(running.Issue, "worker_merge_revoked",
+		telemetry.WorkAttemptIDKey, running.WorkAttemptID,
+		telemetry.DetentSessionIDKey, running.DetentSessionID,
+		telemetry.ProviderSessionIDKey, running.SessionID,
 		"attempt", running.Attempt,
 		"worker_host", strings.TrimSpace(running.WorkerHost),
 		"reason", revocation.reason,

--- a/internal/orchestrator/run_completion.go
+++ b/internal/orchestrator/run_completion.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log/slog"
 	"strconv"
 	"strings"
 	"time"
@@ -117,6 +118,9 @@ func (o *Orchestrator) handleRunResult(ctx context.Context, state *State, event 
 	}
 	o.releaseGlobalDispatchSlot(running.globalSlot)
 	o.logWorkerLifecycle(running.Issue, "worker_capacity_released",
+		telemetry.WorkAttemptIDKey, running.WorkAttemptID,
+		telemetry.DetentSessionIDKey, running.DetentSessionID,
+		telemetry.ProviderSessionIDKey, running.SessionID,
 		"attempt", running.Attempt,
 		"worker_host", strings.TrimSpace(running.WorkerHost),
 		"reason", "run_completed",
@@ -188,6 +192,9 @@ func (o *Orchestrator) handleRunResult(ctx context.Context, state *State, event 
 			running.DiffStats = event.Result.DiffStats
 		}
 		o.logWorkerLifecycle(running.Issue, "worker_"+workerOutcome(event.Err, event.Result.FinalState),
+			telemetry.WorkAttemptIDKey, running.WorkAttemptID,
+			telemetry.DetentSessionIDKey, running.DetentSessionID,
+			telemetry.ProviderSessionIDKey, running.SessionID,
 			"attempt", running.Attempt,
 			"worker_host", strings.TrimSpace(running.WorkerHost),
 			"final_state", strings.TrimSpace(running.Issue.State),
@@ -198,6 +205,9 @@ func (o *Orchestrator) handleRunResult(ctx context.Context, state *State, event 
 
 	if event.Err != nil {
 		o.logWorkerLifecycle(running.Issue, "worker_"+workerOutcome(event.Err, event.Result.FinalState),
+			telemetry.WorkAttemptIDKey, running.WorkAttemptID,
+			telemetry.DetentSessionIDKey, running.DetentSessionID,
+			telemetry.ProviderSessionIDKey, running.SessionID,
 			"attempt", running.Attempt,
 			"worker_host", strings.TrimSpace(running.WorkerHost),
 			"retry_attempt", event.RetryAttempt,
@@ -245,7 +255,7 @@ func (o *Orchestrator) handleRunResult(ctx context.Context, state *State, event 
 		if o.tripTokenCeilingCircuitBreaker(ctx, state, event, running, attempt) {
 			return
 		}
-		if spendProgress.Block && o.blockSpendProgress(ctx, state, running.Issue, spendProgress, event.CompletedAt) {
+		if spendProgress.Block && o.blockSpendProgress(ctx, state, running, spendProgress, event.CompletedAt) {
 			return
 		}
 		if mergeWorkerIssue(running.Issue) {
@@ -290,6 +300,9 @@ func (o *Orchestrator) handleRunResult(ctx context.Context, state *State, event 
 
 	if event.Request.Mode == runpkg.RunModePlan {
 		o.logWorkerLifecycle(running.Issue, "worker_"+workerOutcome(event.Err, event.Result.FinalState),
+			telemetry.WorkAttemptIDKey, running.WorkAttemptID,
+			telemetry.DetentSessionIDKey, running.DetentSessionID,
+			telemetry.ProviderSessionIDKey, running.SessionID,
 			"attempt", running.Attempt,
 			"worker_host", strings.TrimSpace(running.WorkerHost),
 			"mode", strings.TrimSpace(event.Request.Mode),
@@ -322,6 +335,9 @@ func (o *Orchestrator) handleRunResult(ctx context.Context, state *State, event 
 		finalState = FinalStateCompleted
 	}
 	o.logWorkerLifecycle(running.Issue, "worker_"+workerOutcome(nil, finalState),
+		telemetry.WorkAttemptIDKey, running.WorkAttemptID,
+		telemetry.DetentSessionIDKey, running.DetentSessionID,
+		telemetry.ProviderSessionIDKey, running.SessionID,
 		"attempt", running.Attempt,
 		"worker_host", strings.TrimSpace(running.WorkerHost),
 		"mode", strings.TrimSpace(event.Request.Mode),
@@ -432,11 +448,11 @@ func (o *Orchestrator) handleRunResult(ctx context.Context, state *State, event 
 		o.finishCompletedGateWaitRun(ctx, state, running.Issue)
 		return
 	}
-	if spendProgress.Block && o.blockSpendProgress(ctx, state, running.Issue, spendProgress, event.CompletedAt) {
+	if spendProgress.Block && o.blockSpendProgress(ctx, state, running, spendProgress, event.CompletedAt) {
 		return
 	}
 	if terminalState == store.WorkAttemptTerminalNoProgress && progress.Block {
-		if o.blockImplementProgress(ctx, state, progress, event.CompletedAt) {
+		if o.blockImplementProgress(ctx, state, running, progress, event.CompletedAt) {
 			return
 		}
 	}
@@ -672,9 +688,6 @@ func (o *Orchestrator) parkInstantFailure(
 	})
 	if o.logger != nil {
 		attrs := []any{
-			"event", "worker_instant_fail_circuit_breaker_tripped",
-			"issue_id", issue.ID,
-			"issue_identifier", issue.Identifier,
 			"attempt", attempt,
 			"instant_failures", failure.Count,
 			"target_state", targetState,
@@ -691,7 +704,7 @@ func (o *Orchestrator) parkInstantFailure(
 				attrs = append(attrs, "backend_error_message", message)
 			}
 		}
-		o.logger.Error("worker instant fail circuit breaker tripped", attrs...)
+		telemetry.LogLifecycleMessage(o.logger, slog.LevelError, telemetry.LifecycleSafetyControl, "worker_instant_fail_circuit_breaker_tripped", "worker instant fail circuit breaker tripped", o.runningLifecycleCorrelation(issue, running), attrs...)
 	}
 }
 
@@ -771,11 +784,7 @@ func (o *Orchestrator) tripTokenCeilingCircuitBreaker(
 		Message: "parked " + issueLabel(issue) + " after a session token ceiling failure: " + reason,
 	})
 	if o.logger != nil {
-		o.logger.Error(
-			"worker token ceiling circuit breaker tripped",
-			"event", "worker_token_ceiling_circuit_breaker_tripped",
-			"issue_id", issue.ID,
-			"issue_identifier", issue.Identifier,
+		telemetry.LogLifecycleMessage(o.logger, slog.LevelError, telemetry.LifecycleSafetyControl, "worker_token_ceiling_circuit_breaker_tripped", "worker token ceiling circuit breaker tripped", o.runningLifecycleCorrelation(issue, running),
 			"failed_attempt", running.Attempt,
 			"prevented_retry_attempt", attempt,
 			"repeated_failures", failure.Count,
@@ -940,10 +949,7 @@ func (o *Orchestrator) parkRepeatedFailure(
 		Message: "parked " + issueLabel(issue) + " after repeated worker failures: " + failure.Error,
 	})
 	if o.logger != nil {
-		o.logger.Error("worker repeated failure circuit breaker tripped",
-			"event", "worker_repeated_failure_circuit_breaker_tripped",
-			"issue_id", issue.ID,
-			"issue_identifier", issue.Identifier,
+		telemetry.LogLifecycleMessage(o.logger, slog.LevelError, telemetry.LifecycleSafetyControl, "worker_repeated_failure_circuit_breaker_tripped", "worker repeated failure circuit breaker tripped", o.runningLifecycleCorrelation(issue, running),
 			"attempt", attempt,
 			"repeated_failures", failure.Count,
 			"first_failure_at", failure.FirstFailureAt,

--- a/internal/orchestrator/session_brake.go
+++ b/internal/orchestrator/session_brake.go
@@ -3,6 +3,7 @@ package orchestrator
 import (
 	"context"
 	"errors"
+	"log/slog"
 	"strconv"
 	"strings"
 	"time"
@@ -63,11 +64,7 @@ func (o *Orchestrator) handleSessionBrake(
 	targetState := sessionBrakeTargetState(o.cfg, resumable)
 
 	if o.logger != nil {
-		o.logger.Warn(
-			"session_brake_tripped",
-			"event", "session_brake_tripped",
-			"issue_id", running.Issue.ID,
-			"issue_identifier", running.Issue.Identifier,
+		telemetry.LogLifecycle(o.logger, slog.LevelWarn, telemetry.LifecycleSafetyControl, "session_brake_tripped", o.runningLifecycleCorrelation(running.Issue, running),
 			"reason", brake.Reason,
 			"cause_fingerprint", brake.CauseFingerprint,
 			"elapsed", brake.Elapsed,

--- a/internal/orchestrator/spend_progress.go
+++ b/internal/orchestrator/spend_progress.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"log/slog"
 	"strconv"
 	"strings"
 	"time"
@@ -398,11 +399,11 @@ func dispatchAcceptedStateChange(running Running) (bool, string) {
 func (o *Orchestrator) blockSpendProgress(
 	ctx context.Context,
 	state *State,
-	issue connector.Issue,
+	running Running,
 	decision spendProgressDecision,
 	blockedAt time.Time,
 ) bool {
-	issue = cloneIssue(issue)
+	issue := cloneIssue(running.Issue)
 	issueID := strings.TrimSpace(issue.ID)
 	if issueID == "" {
 		return false
@@ -462,10 +463,7 @@ func (o *Orchestrator) blockSpendProgress(
 		Message: fmt.Sprintf("parked %s after %s: %s", issueLabel(issue), spendProgressUsageSummary(decision), spendProgressCaseSummary(decision.Case)),
 	})
 	if o.logger != nil {
-		o.logger.Error("no-progress circuit breaker tripped",
-			"event", "spend_since_progress_circuit_breaker_tripped",
-			"issue_id", issueID,
-			"issue_identifier", issue.Identifier,
+		telemetry.LogLifecycleMessage(o.logger, slog.LevelError, telemetry.LifecycleSafetyControl, "spend_since_progress_circuit_breaker_tripped", "no-progress circuit breaker tripped", o.runningLifecycleCorrelation(issue, running),
 			"blocked_by", decision.BlockedBy,
 			"total_tokens", decision.Spend.TotalTokens,
 			"token_limit", decision.TokenLimit,

--- a/internal/runner/agent.go
+++ b/internal/runner/agent.go
@@ -559,6 +559,7 @@ func (r *Runner) prepareMergeFastPath(
 	switch precheck.Status {
 	case workspace.MergePrepareStatusClean:
 		r.logWorkerEvent(req.Issue, "worker_merge_fast_path_clean",
+			telemetry.WorkAttemptIDKey, req.WorkAttemptID,
 			"workspace_path", info.Path,
 			"workspace_branch", info.Branch,
 		)
@@ -570,6 +571,7 @@ func (r *Runner) prepareMergeFastPath(
 		}, precheck, true, nil
 	case workspace.MergePrepareStatusConflict, workspace.MergePrepareStatusDirty:
 		r.logWorkerEvent(req.Issue, "worker_merge_fast_path_fallback",
+			telemetry.WorkAttemptIDKey, req.WorkAttemptID,
 			"workspace_path", info.Path,
 			"workspace_branch", info.Branch,
 			"status", string(precheck.Status),
@@ -792,7 +794,7 @@ func (r *Runner) runAgentTurn(
 		if update.Type == AgentUpdateTurnStarted || strings.TrimSpace(update.TurnID) != "" {
 			turnStarted = true
 		}
-		r.logAgentUpdate(runRequest.Issue, update)
+		r.logAgentUpdate(runRequest, detentSessionID, update)
 		if err := r.persistSessionWorkerProcess(updateCtx, detentSessionID, update); err != nil {
 			return err
 		}
@@ -966,6 +968,7 @@ func (r *Runner) Run(ctx context.Context, req RunRequest) (RunResult, error) {
 	mode := normalizeRunMode(req.Mode)
 	if mode == RunModeMerge && mergeFastPathCheckedHead(req.Issue) {
 		r.logWorkerEvent(req.Issue, "worker_merge_fast_path_checked_head",
+			telemetry.WorkAttemptIDKey, req.WorkAttemptID,
 			"workspace_branch", strings.TrimSpace(req.Issue.BranchName),
 		)
 		return RunResult{
@@ -979,7 +982,7 @@ func (r *Runner) Run(ctx context.Context, req RunRequest) (RunResult, error) {
 		runWorkspace = &admissionWorkspace{logger: r.logger}
 	}
 	workspaceIssue := workspaceIssue(r.projectID, req.Issue)
-	r.logWorkerEvent(req.Issue, "worker_workspace_create_started")
+	r.logWorkerEvent(req.Issue, "worker_workspace_create_started", telemetry.WorkAttemptIDKey, req.WorkAttemptID)
 	if err := r.publishWorkspaceCreateStarted(req); err != nil {
 		return RunResult{}, err
 	}
@@ -988,6 +991,7 @@ func (r *Runner) Run(ctx context.Context, req RunRequest) (RunResult, error) {
 		return RunResult{}, fmt.Errorf("create workspace: %w", err)
 	}
 	r.logWorkerEvent(req.Issue, "worker_workspace_created",
+		telemetry.WorkAttemptIDKey, req.WorkAttemptID,
 		"workspace_path", info.Path,
 		"workspace_branch", info.Branch,
 	)
@@ -996,6 +1000,7 @@ func (r *Runner) Run(ctx context.Context, req RunRequest) (RunResult, error) {
 		return RunResult{}, fmt.Errorf("workspace before_run: %w", err)
 	}
 	r.logWorkerEvent(req.Issue, "worker_before_run_finished",
+		telemetry.WorkAttemptIDKey, req.WorkAttemptID,
 		"workspace_path", info.Path,
 	)
 
@@ -1018,6 +1023,7 @@ func (r *Runner) Run(ctx context.Context, req RunRequest) (RunResult, error) {
 			r.afterRun(runWorkspace, info, workspaceIssue)
 			afterRunPending = false
 			r.logWorkerEvent(req.Issue, "worker_after_run_finished",
+				telemetry.WorkAttemptIDKey, req.WorkAttemptID,
 				"workspace_path", info.Path,
 			)
 			return precheckResult, nil
@@ -1100,6 +1106,7 @@ func (r *Runner) Run(ctx context.Context, req RunRequest) (RunResult, error) {
 			return RunResult{}, err
 		} else if refused {
 			r.logWorkerEvent(req.Issue, "worker_budget_refused",
+				telemetry.WorkAttemptIDKey, req.WorkAttemptID,
 				"workspace_path", info.Path,
 				"backend_id", selection.BackendID,
 				"route", selection.RouteName,
@@ -1131,6 +1138,7 @@ func (r *Runner) Run(ctx context.Context, req RunRequest) (RunResult, error) {
 		if verifyErr != nil {
 			orphanRecoveryFallbackReason = errorString(verifyErr)
 			r.logWorkerEvent(req.Issue, "worker_orphan_resume_preflight_failed_fallback",
+				telemetry.WorkAttemptIDKey, req.WorkAttemptID,
 				"workspace_path", info.Path,
 				"backend_id", selection.BackendID,
 				"route", selection.RouteName,
@@ -1218,6 +1226,8 @@ func (r *Runner) Run(ctx context.Context, req RunRequest) (RunResult, error) {
 	}
 	if execution.err != nil && !IsCapacityError(execution.err) && !durationLimitError(execution.err) && !agentResumeEmpty(turnRequest.Resume) && !execution.turnStarted {
 		r.logWorkerEvent(req.Issue, "worker_resume_failed_fallback",
+			telemetry.WorkAttemptIDKey, req.WorkAttemptID,
+			telemetry.DetentSessionIDKey, sessionID,
 			"workspace_path", info.Path,
 			"backend_id", selection.BackendID,
 			"route", selection.RouteName,
@@ -1282,6 +1292,8 @@ func (r *Runner) Run(ctx context.Context, req RunRequest) (RunResult, error) {
 	r.afterRun(runWorkspace, info, workspaceIssue)
 	afterRunPending = false
 	r.logWorkerEvent(req.Issue, "worker_after_run_finished",
+		telemetry.WorkAttemptIDKey, req.WorkAttemptID,
+		telemetry.DetentSessionIDKey, sessionID,
 		"workspace_path", info.Path,
 	)
 
@@ -1294,7 +1306,7 @@ func (r *Runner) Run(ctx context.Context, req RunRequest) (RunResult, error) {
 		}
 		return result, errors.Join(
 			fmt.Errorf("run agent turn: %w", turnErr),
-			r.finishSession(finishContext, sessionID, sessionStarted, req.Issue, startedAt, finishedAt, result, sessionModel, backendConfig.Kind, 1, turnResult, resumeState.DetentSessionID),
+			r.finishSession(finishContext, sessionID, sessionStarted, req.WorkAttemptID, req.Issue, startedAt, finishedAt, result, sessionModel, backendConfig.Kind, 1, turnResult, resumeState.DetentSessionID),
 		)
 	}
 
@@ -1311,7 +1323,7 @@ func (r *Runner) Run(ctx context.Context, req RunRequest) (RunResult, error) {
 			)
 			finishedAt := r.now().UTC()
 			result.Tokens.RuntimeSeconds = runtimeSeconds(runStartedAt, finishedAt)
-			if err := r.finishSession(ctx, sessionID, sessionStarted, req.Issue, startedAt, finishedAt, result, sessionModel, backendConfig.Kind, 1, turnResult, resumeState.DetentSessionID); err != nil {
+			if err := r.finishSession(ctx, sessionID, sessionStarted, req.WorkAttemptID, req.Issue, startedAt, finishedAt, result, sessionModel, backendConfig.Kind, 1, turnResult, resumeState.DetentSessionID); err != nil {
 				return result, err
 			}
 			return result, nil
@@ -1324,7 +1336,7 @@ func (r *Runner) Run(ctx context.Context, req RunRequest) (RunResult, error) {
 		result.Tokens.RuntimeSeconds = runtimeSeconds(runStartedAt, finishedAt)
 		return result, errors.Join(
 			fmt.Errorf("workspace diff stat: %w", err),
-			r.finishSession(ctx, sessionID, sessionStarted, req.Issue, startedAt, finishedAt, result, sessionModel, backendConfig.Kind, 1, turnResult, resumeState.DetentSessionID),
+			r.finishSession(ctx, sessionID, sessionStarted, req.WorkAttemptID, req.Issue, startedAt, finishedAt, result, sessionModel, backendConfig.Kind, 1, turnResult, resumeState.DetentSessionID),
 		)
 	}
 
@@ -1336,7 +1348,7 @@ func (r *Runner) Run(ctx context.Context, req RunRequest) (RunResult, error) {
 	}
 	finishedAt := r.now().UTC()
 	result.Tokens.RuntimeSeconds = runtimeSeconds(runStartedAt, finishedAt)
-	if err := r.finishSession(ctx, sessionID, sessionStarted, req.Issue, startedAt, finishedAt, result, sessionModel, backendConfig.Kind, 1, turnResult, resumeState.DetentSessionID); err != nil {
+	if err := r.finishSession(ctx, sessionID, sessionStarted, req.WorkAttemptID, req.Issue, startedAt, finishedAt, result, sessionModel, backendConfig.Kind, 1, turnResult, resumeState.DetentSessionID); err != nil {
 		return result, err
 	}
 	return result, nil
@@ -1546,7 +1558,7 @@ func (r *Runner) Validate(ctx context.Context, req ValidatorRequest) (gate.Valid
 		if !update.RuntimeIdentity.IsZero() {
 			update.RuntimeIdentity = update.RuntimeIdentity.ObserveAt(eventAt)
 		}
-		r.logAgentUpdate(req.Issue, update)
+		r.logAgentUpdate(runReq, sessionID, update)
 		if err := r.persistSessionWorkerProcess(updateCtx, sessionID, update); err != nil {
 			return err
 		}
@@ -1613,6 +1625,7 @@ func (r *Runner) Validate(ctx context.Context, req ValidatorRequest) (gate.Valid
 	r.afterRun(r.workspace, info, workspaceIssue)
 	afterRunPending = false
 	r.logWorkerEvent(req.Issue, "worker_check_after_run_finished",
+		telemetry.DetentSessionIDKey, sessionID,
 		"workspace_path", info.Path,
 	)
 
@@ -1622,7 +1635,7 @@ func (r *Runner) Validate(ctx context.Context, req ValidatorRequest) (gate.Valid
 		runResult.FinalState = finalStateForTurnError(turnErr)
 		return gate.ValidatorResult{}, errors.Join(
 			fmt.Errorf("run validator turn: %w", turnErr),
-			r.finishSession(ctx, sessionID, sessionStarted, req.Issue, startedAt, finishedAt, runResult, sessionModel, backendConfig.Kind, 1, turnResult, 0),
+			r.finishSession(ctx, sessionID, sessionStarted, runReq.WorkAttemptID, req.Issue, startedAt, finishedAt, runResult, sessionModel, backendConfig.Kind, 1, turnResult, 0),
 		)
 	}
 
@@ -1631,10 +1644,10 @@ func (r *Runner) Validate(ctx context.Context, req ValidatorRequest) (gate.Valid
 		runResult.FinalState = FinalStateFailed
 		return gate.ValidatorResult{}, errors.Join(
 			fmt.Errorf("parse validator result: %w", err),
-			r.finishSession(ctx, sessionID, sessionStarted, req.Issue, startedAt, finishedAt, runResult, sessionModel, backendConfig.Kind, 1, turnResult, 0),
+			r.finishSession(ctx, sessionID, sessionStarted, runReq.WorkAttemptID, req.Issue, startedAt, finishedAt, runResult, sessionModel, backendConfig.Kind, 1, turnResult, 0),
 		)
 	}
-	if err := r.finishSession(ctx, sessionID, sessionStarted, req.Issue, startedAt, finishedAt, runResult, sessionModel, backendConfig.Kind, 1, turnResult, 0); err != nil {
+	if err := r.finishSession(ctx, sessionID, sessionStarted, runReq.WorkAttemptID, req.Issue, startedAt, finishedAt, runResult, sessionModel, backendConfig.Kind, 1, turnResult, 0); err != nil {
 		return gate.ValidatorResult{}, err
 	}
 	return validation, nil
@@ -1975,6 +1988,7 @@ func (r *Runner) finishSession(
 	ctx context.Context,
 	sessionID int64,
 	started bool,
+	workAttemptID int64,
 	issue connector.Issue,
 	startedAt time.Time,
 	finishedAt time.Time,
@@ -2016,6 +2030,7 @@ func (r *Runner) finishSession(
 		return fmt.Errorf("finish agent session: %w", err)
 	}
 	attrs := []any{
+		telemetry.WorkAttemptIDKey, workAttemptID,
 		"detent_session_id", sessionID,
 		"provider_thread_id", turnResult.ThreadID,
 		"provider_session_id", turnResult.SessionID,
@@ -2996,39 +3011,35 @@ func (r *Runner) logWorkerEventLevel(level slog.Level, issue connector.Issue, ev
 	if r == nil || r.logger == nil {
 		return
 	}
+	correlation, attrs := workerLifecycleCorrelation(r.projectID, issue, attrs)
 	all := []any{
-		"event", strings.TrimSpace(event),
-		"project_id", strings.TrimSpace(r.projectID),
-		"issue_id", strings.TrimSpace(issue.ID),
-		"issue_identifier", strings.TrimSpace(issue.Identifier),
 		"issue_state", strings.TrimSpace(issue.State),
 	}
 	all = append(all, attrs...)
-	message := strings.TrimSpace(event)
-	switch {
-	case level >= slog.LevelError:
-		r.logger.Error(message, all...)
-	case level >= slog.LevelWarn:
-		r.logger.Warn(message, all...)
-	case level >= slog.LevelInfo:
-		r.logger.Info(message, all...)
-	default:
-		r.logger.Debug(message, all...)
-	}
+	telemetry.LogLifecycle(r.logger, level, workerLifecycleClass(event), event, correlation, all...)
 }
 
-func (r *Runner) logAgentUpdate(issue connector.Issue, update AgentUpdate) {
+func (r *Runner) logAgentUpdate(req RunRequest, detentSessionID int64, update AgentUpdate) {
 	event := strings.TrimSpace(string(update.Type))
 	if event == "" {
 		event = strings.TrimSpace(update.Method)
 	}
+	logEvent := func(level slog.Level, lifecycleEvent string, attrs ...any) {
+		correlation := []any{
+			telemetry.WorkAttemptIDKey, req.WorkAttemptID,
+			telemetry.DetentSessionIDKey, detentSessionID,
+			telemetry.ProviderSessionIDKey, update.ProviderSessionID,
+		}
+		correlation = append(correlation, attrs...)
+		r.logWorkerEventLevel(level, req.Issue, lifecycleEvent, correlation...)
+	}
 	switch update.Type {
 	case AgentUpdateProcessStarted:
-		r.logWorkerEvent(issue, "worker_process_started",
+		logEvent(slog.LevelDebug, "worker_process_started",
 			"process_identity", strings.TrimSpace(update.ProcessIdentity),
 		)
 	case AgentUpdateTurnStarted:
-		r.logWorkerEvent(issue, "worker_turn_started",
+		logEvent(slog.LevelDebug, "worker_turn_started",
 			"thread_id", strings.TrimSpace(update.ThreadID),
 			"turn_id", strings.TrimSpace(update.TurnID),
 		)
@@ -3040,12 +3051,12 @@ func (r *Runner) logAgentUpdate(issue connector.Issue, update AgentUpdate) {
 		}
 		attrs = append(attrs, agentUpdateBackendErrorAttrs(update)...)
 		if failedAgentTurnStatus(update.Status) {
-			r.logWorkerEventLevel(slog.LevelWarn, issue, "worker_turn_finished", attrs...)
+			logEvent(slog.LevelWarn, "worker_turn_finished", attrs...)
 		} else {
-			r.logWorkerEvent(issue, "worker_turn_finished", attrs...)
+			logEvent(slog.LevelDebug, "worker_turn_finished", attrs...)
 		}
 	case AgentUpdateTokenUsage:
-		r.logWorkerEvent(issue, "worker_usage_updated",
+		logEvent(slog.LevelDebug, "worker_usage_updated",
 			"thread_id", strings.TrimSpace(update.ThreadID),
 			"turn_id", strings.TrimSpace(update.TurnID),
 			"total_tokens", update.Tokens.TotalTokens,
@@ -3053,12 +3064,12 @@ func (r *Runner) logAgentUpdate(issue connector.Issue, update AgentUpdate) {
 			"output_tokens", update.Tokens.OutputTokens,
 		)
 	case AgentUpdateRateLimits:
-		r.logWorkerEvent(issue, "worker_rate_limits_updated",
+		logEvent(slog.LevelDebug, "worker_rate_limits_updated",
 			"thread_id", strings.TrimSpace(update.ThreadID),
 			"turn_id", strings.TrimSpace(update.TurnID),
 		)
 	case AgentUpdateModelUpdated:
-		r.logWorkerEvent(issue, "worker_model_updated",
+		logEvent(slog.LevelDebug, "worker_model_updated",
 			"thread_id", strings.TrimSpace(update.ThreadID),
 			"turn_id", strings.TrimSpace(update.TurnID),
 			"model", strings.TrimSpace(update.Model),
@@ -3067,12 +3078,73 @@ func (r *Runner) logAgentUpdate(issue connector.Issue, update AgentUpdate) {
 		return
 	default:
 		if event != "" && update.Type != AgentUpdateMessageDelta {
-			r.logWorkerEvent(issue, "worker_agent_update",
+			logEvent(slog.LevelDebug, "worker_agent_update",
 				"agent_event", event,
 				"thread_id", strings.TrimSpace(update.ThreadID),
 				"turn_id", strings.TrimSpace(update.TurnID),
 			)
 		}
+	}
+}
+
+func workerLifecycleClass(event string) telemetry.LifecycleClass {
+	switch strings.TrimSpace(event) {
+	case "worker_workspace_create_started", "worker_workspace_created", "worker_before_run_finished", "worker_after_run_finished",
+		"worker_check_workspace_create_started", "worker_check_workspace_created", "worker_check_before_run_finished", "worker_check_after_run_finished":
+		return telemetry.LifecycleWorkspace
+	case "worker_session_started", "worker_session_finished", "worker_command_started", "worker_command_finished", "worker_check_started", "worker_check_finished":
+		return telemetry.LifecycleDetentSession
+	case "worker_process_started", "worker_turn_started", "worker_turn_finished", "worker_usage_updated", "worker_rate_limits_updated", "worker_model_updated", "worker_agent_update", "worker_runtime_identity_resolved", "worker_runtime_identity_changed":
+		return telemetry.LifecycleProviderSession
+	default:
+		return telemetry.LifecycleWorkAttempt
+	}
+}
+
+func workerLifecycleCorrelation(projectID string, issue connector.Issue, attrs []any) (telemetry.LifecycleCorrelation, []any) {
+	correlation := telemetry.LifecycleCorrelation{
+		ProjectID:       projectID,
+		IssueID:         issue.ID,
+		IssueIdentifier: issue.Identifier,
+	}
+	remaining := make([]any, 0, len(attrs))
+	for index := 0; index < len(attrs); {
+		if index+1 >= len(attrs) {
+			remaining = append(remaining, attrs[index])
+			break
+		}
+		key, ok := attrs[index].(string)
+		if !ok {
+			remaining = append(remaining, attrs[index], attrs[index+1])
+			index += 2
+			continue
+		}
+		value := attrs[index+1]
+		switch key {
+		case telemetry.WorkAttemptIDKey:
+			correlation.WorkAttemptID = lifecycleInt64(value)
+		case telemetry.DetentSessionIDKey:
+			correlation.DetentSessionID = lifecycleInt64(value)
+		case telemetry.ProviderSessionIDKey:
+			if providerSessionID, ok := value.(string); ok {
+				correlation.ProviderSessionID = providerSessionID
+			}
+		default:
+			remaining = append(remaining, key, value)
+		}
+		index += 2
+	}
+	return correlation, remaining
+}
+
+func lifecycleInt64(value any) int64 {
+	switch value := value.(type) {
+	case int:
+		return int64(value)
+	case int64:
+		return value
+	default:
+		return 0
 	}
 }
 

--- a/internal/runner/agent.go
+++ b/internal/runner/agent.go
@@ -3028,7 +3028,7 @@ func (r *Runner) logAgentUpdate(req RunRequest, detentSessionID int64, update Ag
 		correlation := []any{
 			telemetry.WorkAttemptIDKey, req.WorkAttemptID,
 			telemetry.DetentSessionIDKey, detentSessionID,
-			telemetry.ProviderSessionIDKey, update.ProviderSessionID,
+			telemetry.ProviderSessionIDKey, agentUpdateProviderSessionID(update),
 		}
 		correlation = append(correlation, attrs...)
 		r.logWorkerEventLevel(level, req.Issue, lifecycleEvent, correlation...)
@@ -3085,6 +3085,21 @@ func (r *Runner) logAgentUpdate(req RunRequest, detentSessionID int64, update Ag
 			)
 		}
 	}
+}
+
+func agentUpdateProviderSessionID(update AgentUpdate) string {
+	if providerSessionID := strings.TrimSpace(update.ProviderSessionID); providerSessionID != "" {
+		return providerSessionID
+	}
+	threadID := strings.TrimSpace(update.ThreadID)
+	turnID := strings.TrimSpace(update.TurnID)
+	if threadID == "" || turnID == "" {
+		return ""
+	}
+	if threadID == turnID {
+		return threadID
+	}
+	return threadID + "-" + turnID
 }
 
 func workerLifecycleClass(event string) telemetry.LifecycleClass {

--- a/internal/runner/runner_test.go
+++ b/internal/runner/runner_test.go
@@ -2422,6 +2422,83 @@ func TestLogRuntimeIdentityChangeUsesCanonicalFieldsWithoutPayloadSecrets(t *tes
 	}
 }
 
+func TestLogAgentUpdateNormalizesProviderSessionID(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		update     AgentUpdate
+		want       string
+		wantAbsent bool
+	}{
+		{
+			name: "explicit provider session",
+			update: AgentUpdate{
+				Type:              AgentUpdateTokenUsage,
+				ThreadID:          "thread-1",
+				TurnID:            "turn-1",
+				ProviderSessionID: "provider-session-1",
+			},
+			want: "provider-session-1",
+		},
+		{
+			name: "Claude session uses shared thread and turn ID",
+			update: AgentUpdate{
+				Type:     AgentUpdateTokenUsage,
+				ThreadID: "claude-session-1",
+				TurnID:   "claude-session-1",
+			},
+			want: "claude-session-1",
+		},
+		{
+			name: "Codex session combines thread and turn IDs",
+			update: AgentUpdate{
+				Type:     AgentUpdateTokenUsage,
+				ThreadID: "thread-1",
+				TurnID:   "turn-1",
+			},
+			want: "thread-1-turn-1",
+		},
+		{
+			name: "incomplete identity remains absent",
+			update: AgentUpdate{
+				Type:     AgentUpdateTokenUsage,
+				ThreadID: "thread-1",
+			},
+			wantAbsent: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			var logs bytes.Buffer
+			r := &Runner{
+				projectID: "detent",
+				logger: slog.New(slog.NewTextHandler(&logs, &slog.HandlerOptions{
+					Level: slog.LevelDebug,
+				})),
+			}
+			r.logAgentUpdate(RunRequest{
+				Issue:         connector.Issue{ID: "issue-1645", Identifier: "digitaldrywood/detent#1645"},
+				WorkAttemptID: 1645,
+			}, 1652, tt.update)
+
+			got := logs.String()
+			if tt.wantAbsent {
+				if strings.Contains(got, telemetry.ProviderSessionIDKey+"=") {
+					t.Fatalf("provider session ID unexpectedly logged:\n%s", got)
+				}
+				return
+			}
+			if !strings.Contains(got, telemetry.ProviderSessionIDKey+"="+tt.want) {
+				t.Fatalf("provider session ID missing from log:\n%s", got)
+			}
+		})
+	}
+}
+
 func TestRunnerRunCompletesSuccessfulTurnWithCleanupError(t *testing.T) {
 	t.Parallel()
 

--- a/internal/runner/supervisor.go
+++ b/internal/runner/supervisor.go
@@ -8,6 +8,8 @@ import (
 	"log/slog"
 	"sync"
 	"time"
+
+	"github.com/digitaldrywood/detent/internal/telemetry"
 )
 
 const (
@@ -162,9 +164,6 @@ func (s *Supervisor) Run(ctx context.Context, request RunRequest) (completion Co
 			completion.RetryDelay = s.RetryDelay(completion.RetryAttempt)
 		}
 		attrs := []any{
-			"event", "worker_attempt_finished",
-			"issue_id", request.Issue.ID,
-			"issue_identifier", request.Issue.Identifier,
 			"issue_state", request.Issue.State,
 			"attempt", request.Attempt,
 			"worker_host", request.WorkerHost,
@@ -176,14 +175,19 @@ func (s *Supervisor) Run(ctx context.Context, request RunRequest) (completion Co
 			"error", completion.Err,
 		}
 		attrs = append(attrs, backendErrorAttrs(completion.Err)...)
+		level := slog.LevelDebug
 		if IsTransientOverload(completion.Err) {
 			attrs = append(attrs, "reason", "transient_overload")
-			s.logger.Info("worker_attempt_finished", attrs...)
+			level = slog.LevelInfo
 		} else if completion.Err != nil {
-			s.logger.Warn("worker_attempt_finished", attrs...)
-		} else {
-			s.logger.Debug("worker_attempt_finished", attrs...)
+			level = slog.LevelWarn
 		}
+		telemetry.LogLifecycle(s.logger, level, telemetry.LifecycleWorkAttempt, "worker_attempt_finished", telemetry.LifecycleCorrelation{
+			ProjectID:       request.ProjectID,
+			IssueID:         request.Issue.ID,
+			IssueIdentifier: request.Issue.Identifier,
+			WorkAttemptID:   request.WorkAttemptID,
+		}, attrs...)
 	}()
 
 	result, err := s.backend.Run(ctx, request)

--- a/internal/runner/types.go
+++ b/internal/runner/types.go
@@ -297,6 +297,7 @@ func (e *agentDurationLimitError) Is(target error) bool {
 }
 
 type RunRequest struct {
+	ProjectID           string
 	Issue               connector.Issue
 	Attempt             int
 	WorkAttemptID       int64

--- a/internal/telemetry/lifecycle.go
+++ b/internal/telemetry/lifecycle.go
@@ -1,0 +1,149 @@
+package telemetry
+
+import (
+	"context"
+	"log/slog"
+	"strings"
+)
+
+const (
+	LifecycleClassKey    = "lifecycle_class"
+	LifecycleEventKey    = "event"
+	ProjectIDKey         = "project_id"
+	IssueIDKey           = "issue_id"
+	IssueIdentifierKey   = "issue_identifier"
+	WorkAttemptIDKey     = "work_attempt_id"
+	DetentSessionIDKey   = "detent_session_id"
+	ProviderSessionIDKey = "provider_session_id"
+)
+
+type LifecycleClass string
+
+const (
+	LifecycleDispatch        LifecycleClass = "dispatch"
+	LifecycleWorkAttempt     LifecycleClass = "work_attempt"
+	LifecycleWorkspace       LifecycleClass = "workspace"
+	LifecycleDetentSession   LifecycleClass = "detent_session"
+	LifecycleProviderSession LifecycleClass = "provider_session"
+	LifecycleSafetyControl   LifecycleClass = "safety_control"
+	LifecycleAdmission       LifecycleClass = "admission"
+)
+
+var lifecycleClasses = [...]LifecycleClass{
+	LifecycleDispatch,
+	LifecycleWorkAttempt,
+	LifecycleWorkspace,
+	LifecycleDetentSession,
+	LifecycleProviderSession,
+	LifecycleSafetyControl,
+	LifecycleAdmission,
+}
+
+type LifecycleCorrelation struct {
+	ProjectID         string
+	IssueID           string
+	IssueIdentifier   string
+	WorkAttemptID     int64
+	DetentSessionID   int64
+	ProviderSessionID string
+}
+
+func LifecycleClasses() []LifecycleClass {
+	classes := make([]LifecycleClass, len(lifecycleClasses))
+	copy(classes, lifecycleClasses[:])
+	return classes
+}
+
+func LogLifecycle(logger *slog.Logger, level slog.Level, class LifecycleClass, event string, correlation LifecycleCorrelation, attrs ...any) {
+	LogLifecycleMessage(logger, level, class, event, event, correlation, attrs...)
+}
+
+func LogLifecycleContext(ctx context.Context, logger *slog.Logger, level slog.Level, class LifecycleClass, event string, correlation LifecycleCorrelation, attrs ...any) {
+	LogLifecycleMessageContext(ctx, logger, level, class, event, event, correlation, attrs...)
+}
+
+func LogLifecycleMessage(logger *slog.Logger, level slog.Level, class LifecycleClass, event string, message string, correlation LifecycleCorrelation, attrs ...any) {
+	if logger == nil {
+		return
+	}
+	all := lifecycleLogAttrs(class, event, correlation, attrs)
+	message = strings.TrimSpace(message)
+	switch {
+	case level >= slog.LevelError:
+		logger.Error(message, all...)
+	case level >= slog.LevelWarn:
+		logger.Warn(message, all...)
+	case level >= slog.LevelInfo:
+		logger.Info(message, all...)
+	default:
+		logger.Debug(message, all...)
+	}
+}
+
+func LogLifecycleMessageContext(ctx context.Context, logger *slog.Logger, level slog.Level, class LifecycleClass, event string, message string, correlation LifecycleCorrelation, attrs ...any) {
+	if logger == nil {
+		return
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	logger.Log(ctx, level, strings.TrimSpace(message), lifecycleLogAttrs(class, event, correlation, attrs)...)
+}
+
+func lifecycleLogAttrs(class LifecycleClass, event string, correlation LifecycleCorrelation, attrs []any) []any {
+	all := []any{
+		LifecycleClassKey, string(class),
+		LifecycleEventKey, strings.TrimSpace(event),
+	}
+	all = appendLifecycleString(all, ProjectIDKey, correlation.ProjectID)
+	all = appendLifecycleString(all, IssueIDKey, correlation.IssueID)
+	all = appendLifecycleString(all, IssueIdentifierKey, correlation.IssueIdentifier)
+	if correlation.WorkAttemptID > 0 {
+		all = append(all, WorkAttemptIDKey, correlation.WorkAttemptID)
+	}
+	if correlation.DetentSessionID > 0 {
+		all = append(all, DetentSessionIDKey, correlation.DetentSessionID)
+	}
+	all = appendLifecycleString(all, ProviderSessionIDKey, correlation.ProviderSessionID)
+	all = appendLifecycleAttrs(all, attrs)
+	return all
+}
+
+func appendLifecycleString(attrs []any, key string, value string) []any {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return attrs
+	}
+	return append(attrs, key, value)
+}
+
+func appendLifecycleAttrs(destination []any, attrs []any) []any {
+	for index := 0; index < len(attrs); {
+		if attr, ok := attrs[index].(slog.Attr); ok {
+			if !lifecycleReservedKey(attr.Key) {
+				destination = append(destination, attr)
+			}
+			index++
+			continue
+		}
+		if index+1 >= len(attrs) {
+			destination = append(destination, attrs[index])
+			break
+		}
+		key, ok := attrs[index].(string)
+		if !ok || !lifecycleReservedKey(key) {
+			destination = append(destination, attrs[index], attrs[index+1])
+		}
+		index += 2
+	}
+	return destination
+}
+
+func lifecycleReservedKey(key string) bool {
+	switch key {
+	case LifecycleClassKey, LifecycleEventKey, ProjectIDKey, IssueIDKey, IssueIdentifierKey, WorkAttemptIDKey, DetentSessionIDKey, ProviderSessionIDKey:
+		return true
+	default:
+		return false
+	}
+}

--- a/internal/telemetry/lifecycle_test.go
+++ b/internal/telemetry/lifecycle_test.go
@@ -1,0 +1,159 @@
+package telemetry
+
+import (
+	"context"
+	"log/slog"
+	"slices"
+	"testing"
+)
+
+func TestLogLifecycleCorrelationContract(t *testing.T) {
+	t.Parallel()
+
+	wantClasses := []LifecycleClass{
+		LifecycleDispatch,
+		LifecycleWorkAttempt,
+		LifecycleWorkspace,
+		LifecycleDetentSession,
+		LifecycleProviderSession,
+		LifecycleSafetyControl,
+		LifecycleAdmission,
+	}
+	if got := LifecycleClasses(); !slices.Equal(got, wantClasses) {
+		t.Fatalf("LifecycleClasses() = %v, want %v", got, wantClasses)
+	}
+
+	for _, class := range wantClasses {
+		t.Run(string(class), func(t *testing.T) {
+			t.Parallel()
+
+			handler := &capturedLifecycleHandler{}
+			LogLifecycle(slog.New(handler), slog.LevelInfo, class, " lifecycle_event ", LifecycleCorrelation{
+				ProjectID:         " project-1 ",
+				IssueID:           " issue-2 ",
+				IssueIdentifier:   " owner/repo#2 ",
+				WorkAttemptID:     3,
+				DetentSessionID:   4,
+				ProviderSessionID: " provider-session-5 ",
+			})
+
+			record := handler.record(t)
+			if record.message != "lifecycle_event" || record.level != slog.LevelInfo {
+				t.Errorf("record message/level = %q/%s, want lifecycle_event/INFO", record.message, record.level)
+			}
+			want := map[string]any{
+				LifecycleClassKey:    string(class),
+				LifecycleEventKey:    "lifecycle_event",
+				ProjectIDKey:         "project-1",
+				IssueIDKey:           "issue-2",
+				IssueIdentifierKey:   "owner/repo#2",
+				WorkAttemptIDKey:     int64(3),
+				DetentSessionIDKey:   int64(4),
+				ProviderSessionIDKey: "provider-session-5",
+			}
+			for key, value := range want {
+				if got := record.attrs[key]; got != value {
+					t.Errorf("attribute %q = %#v, want %#v", key, got, value)
+				}
+			}
+		})
+	}
+}
+
+func TestLogLifecycleOmitsUnknownCorrelation(t *testing.T) {
+	t.Parallel()
+
+	handler := &capturedLifecycleHandler{}
+	LogLifecycle(slog.New(handler), slog.LevelInfo, LifecycleWorkAttempt, "worker_attempt_started", LifecycleCorrelation{
+		ProjectID:         " ",
+		IssueID:           "",
+		IssueIdentifier:   " ",
+		WorkAttemptID:     0,
+		DetentSessionID:   -1,
+		ProviderSessionID: " ",
+	})
+
+	record := handler.record(t)
+	for _, key := range []string{
+		ProjectIDKey,
+		IssueIDKey,
+		IssueIdentifierKey,
+		WorkAttemptIDKey,
+		DetentSessionIDKey,
+		ProviderSessionIDKey,
+	} {
+		if _, ok := record.attrs[key]; ok {
+			t.Errorf("unknown correlation attribute %q was emitted", key)
+		}
+	}
+}
+
+func TestLogLifecycleProtectsCanonicalAttributes(t *testing.T) {
+	t.Parallel()
+
+	handler := &capturedLifecycleHandler{}
+	LogLifecycle(slog.New(handler), slog.LevelInfo, LifecycleWorkAttempt, "worker_attempt_started", LifecycleCorrelation{
+		ProjectID:     "project-1",
+		IssueID:       "issue-2",
+		WorkAttemptID: 3,
+	},
+		ProjectIDKey, "wrong-project",
+		WorkAttemptIDKey, "wrong-type",
+		slog.String(IssueIDKey, "wrong-issue"),
+	)
+
+	record := handler.record(t)
+	if got := record.attrs[ProjectIDKey]; got != "project-1" {
+		t.Errorf("%s = %#v, want project-1", ProjectIDKey, got)
+	}
+	if got := record.attrs[IssueIDKey]; got != "issue-2" {
+		t.Errorf("%s = %#v, want issue-2", IssueIDKey, got)
+	}
+	if got := record.attrs[WorkAttemptIDKey]; got != int64(3) {
+		t.Errorf("%s = %#v, want int64(3)", WorkAttemptIDKey, got)
+	}
+}
+
+type capturedLifecycleRecord struct {
+	message string
+	level   slog.Level
+	attrs   map[string]any
+}
+
+type capturedLifecycleHandler struct {
+	records []capturedLifecycleRecord
+}
+
+func (h *capturedLifecycleHandler) Enabled(context.Context, slog.Level) bool {
+	return true
+}
+
+func (h *capturedLifecycleHandler) Handle(_ context.Context, record slog.Record) error {
+	attrs := map[string]any{}
+	record.Attrs(func(attr slog.Attr) bool {
+		attrs[attr.Key] = attr.Value.Any()
+		return true
+	})
+	h.records = append(h.records, capturedLifecycleRecord{
+		message: record.Message,
+		level:   record.Level,
+		attrs:   attrs,
+	})
+	return nil
+}
+
+func (h *capturedLifecycleHandler) WithAttrs([]slog.Attr) slog.Handler {
+	return h
+}
+
+func (h *capturedLifecycleHandler) WithGroup(string) slog.Handler {
+	return h
+}
+
+func (h *capturedLifecycleHandler) record(t *testing.T) capturedLifecycleRecord {
+	t.Helper()
+	if len(h.records) != 1 {
+		t.Fatalf("captured %d records, want 1", len(h.records))
+	}
+	return h.records[0]
+}


### PR DESCRIPTION
## Summary

- define canonical typed lifecycle correlation keys and seven explicit lifecycle event classes
- route runner, orchestrator, safety-control, and admission records through the shared contract
- omit unknown correlation values and protect canonical attributes from overrides
- add captured-handler table coverage for every lifecycle class

Fixes #1645

## UI Surface Contract

- [x] N/A; this PR changes structured telemetry only.
- [x] This PR does not add persistent top-of-screen messaging.
- [x] This PR does not change an operator UI surface.

## Test Plan

- [x] `go test ./internal/telemetry ./internal/runner ./internal/orchestrator ./internal/admission`
- [x] `go test ./internal/orchestrator -run '^$' -fuzz=. -fuzztime=30s`
- [x] `make check`