### PR TITLE
feat(explain): add issue explanation read model

### DIFF
--- a/db/queries/store.sql
+++ b/db/queries/store.sql
@@ -235,6 +235,7 @@ LIMIT 1;
 -- name: GetLatestIssueAgentResumeState :one
 SELECT
   id,
+  CAST(COALESCE(project_id, '') AS TEXT) AS project_id,
   CAST(COALESCE(provider_thread_id, '') AS TEXT) AS provider_thread_id,
   CAST(COALESCE(provider_session_id, '') AS TEXT) AS provider_session_id,
   CAST(COALESCE(requested_model, '') AS TEXT) AS requested_model,
@@ -246,6 +247,7 @@ SELECT
 FROM codex_sessions
 WHERE completed_at IS NOT NULL
   AND lower(trim(COALESCE(final_state, ''))) = 'completed'
+  AND COALESCE(project_id, '') = sqlc.arg(project_id)
   AND (COALESCE(provider_thread_id, '') != '' OR COALESCE(provider_session_id, '') != '')
   AND (
     (sqlc.arg(issue_id) != '' AND COALESCE(issue_id, '') = sqlc.arg(issue_id))
@@ -258,12 +260,14 @@ LIMIT 1;
 -- name: GetLatestIssueAgentSession :one
 SELECT
   id,
+  CAST(COALESCE(project_id, '') AS TEXT) AS project_id,
   CAST(COALESCE(provider_thread_id, '') AS TEXT) AS provider_thread_id,
   CAST(COALESCE(provider_session_id, '') AS TEXT) AS provider_session_id,
   CAST(COALESCE(agent_backend_kind, '') AS TEXT) AS agent_backend_kind,
   CAST(completed_at AS TEXT) AS completed_at
 FROM codex_sessions
 WHERE completed_at IS NOT NULL
+  AND COALESCE(project_id, '') = sqlc.arg(project_id)
   AND (COALESCE(provider_thread_id, '') != '' OR COALESCE(provider_session_id, '') != '')
   AND (
     (sqlc.arg(issue_id) != '' AND COALESCE(issue_id, '') = sqlc.arg(issue_id))
@@ -450,9 +454,12 @@ SELECT
   CAST(COALESCE(SUM(total_tokens), 0) AS INTEGER) AS total_tokens,
   CAST(COUNT(*) AS INTEGER) AS sessions
 FROM codex_sessions
-WHERE issue_id = sqlc.arg(issue_id)
-   OR identifier = sqlc.arg(identifier)
-   OR issue_url = sqlc.arg(issue_url)
+WHERE COALESCE(project_id, '') = sqlc.arg(project_id)
+  AND (
+    issue_id = sqlc.arg(issue_id)
+    OR identifier = sqlc.arg(identifier)
+    OR issue_url = sqlc.arg(issue_url)
+  )
 GROUP BY COALESCE(NULLIF(model, ''), NULLIF(requested_model, ''), '')
 ORDER BY COALESCE(NULLIF(model, ''), NULLIF(requested_model, ''), '');
 
@@ -692,9 +699,12 @@ ORDER BY event.project_id, event.phase_type, event.phase_name, event.finished_at
 -- name: IssueWorkflowTimelineRows :many
 SELECT *
 FROM workflow_phase_events
-WHERE issue_id = sqlc.arg(issue_id)
-   OR identifier = sqlc.arg(identifier)
-   OR issue_url = sqlc.arg(issue_url)
+WHERE project_id = sqlc.arg(project_id)
+  AND (
+    issue_id = sqlc.arg(issue_id)
+    OR identifier = sqlc.arg(identifier)
+    OR issue_url = sqlc.arg(issue_url)
+  )
 ORDER BY started_at, id;
 
 -- name: CreateWorkAttempt :one
@@ -902,6 +912,18 @@ RETURNING *;
 SELECT *
 FROM scheduler_decisions
 WHERE sqlc.arg(filter_project_id) = '' OR project_id = sqlc.arg(filter_project_id)
+ORDER BY decision_at DESC, id DESC
+LIMIT sqlc.arg(limit);
+
+-- name: ListIssueSchedulerDecisions :many
+SELECT *
+FROM scheduler_decisions
+WHERE project_id = sqlc.arg(project_id)
+  AND (
+    (sqlc.arg(issue_id) != '' AND issue_id = sqlc.arg(issue_id))
+    OR (sqlc.arg(identifier) != '' AND identifier = sqlc.arg(identifier))
+    OR (sqlc.arg(issue_url) != '' AND issue_url = sqlc.arg(issue_url))
+  )
 ORDER BY decision_at DESC, id DESC
 LIMIT sqlc.arg(limit);
 

--- a/internal/admission/manager_test.go
+++ b/internal/admission/manager_test.go
@@ -334,7 +334,7 @@ func TestManagerReconcilesAcceptanceAfterIssueLeavesTargetState(t *testing.T) {
 	if history[0].Status != admissionmodel.ProposalAccepted || !history[0].TransitionAt.Equal(targetAt) {
 		t.Fatalf("accepted proposal = %#v", history[0])
 	}
-	timeline, err := backend.IssueWorkflowTimeline(ctx, store.IssueIdentity{IssueID: proposal.IssueID})
+	timeline, err := backend.IssueWorkflowTimeline(ctx, store.IssueIdentity{ProjectID: proposal.ProjectID, IssueID: proposal.IssueID})
 	if err != nil || len(timeline.Events) != 1 ||
 		timeline.Events[0].Reason != "admission_proposal_accepted" {
 		t.Fatalf("IssueWorkflowTimeline() = %#v, %v", timeline, err)
@@ -563,7 +563,7 @@ func TestManagerAcceptanceTransitionsOrSupersedes(t *testing.T) {
 			if tt.wantStatus != admissionmodel.ProposalAccepted {
 				return
 			}
-			timeline, err := backend.IssueWorkflowTimeline(t.Context(), store.IssueIdentity{IssueID: issue.ID})
+			timeline, err := backend.IssueWorkflowTimeline(t.Context(), store.IssueIdentity{ProjectID: proposal.ProjectID, IssueID: issue.ID})
 			if err != nil || len(timeline.Events) != 1 {
 				t.Fatalf("IssueWorkflowTimeline() = %#v, %v", timeline, err)
 			}

--- a/internal/budget/budget.go
+++ b/internal/budget/budget.go
@@ -174,6 +174,7 @@ func (c *Checker) CheckDispatch(ctx context.Context, req DispatchRequest) (Decis
 	if capActive(effective.PerIssueMaxUSD) {
 		currentSpend := 0.0
 		identity := store.IssueIdentity{
+			ProjectID:  c.cfg.ProjectID,
 			IssueID:    req.IssueID,
 			Identifier: req.Identifier,
 			IssueURL:   req.IssueURL,
@@ -231,6 +232,9 @@ func (c *Checker) IssueStatus(ctx context.Context, identity store.IssueIdentity)
 	}
 	if missingSpendStore(c.spend) {
 		return IssueStatus{}, ErrMissingSpendStore
+	}
+	if strings.TrimSpace(identity.ProjectID) == "" {
+		identity.ProjectID = c.cfg.ProjectID
 	}
 
 	issueSpend, err := c.spend.IssueTokenSpend(ctx, identity)

--- a/internal/explain/model.go
+++ b/internal/explain/model.go
@@ -1,0 +1,222 @@
+package explain
+
+import (
+	"errors"
+	"fmt"
+	"slices"
+	"strings"
+	"time"
+)
+
+const SchemaVersion = 1
+
+var (
+	ErrProjectRequired      = errors.New("project reference is required")
+	ErrIssueReferenceNeeded = errors.New("issue reference is required")
+	ErrNotFound             = errors.New("issue explanation not found")
+)
+
+type SourceState string
+
+const (
+	SourceAvailable   SourceState = "available"
+	SourceLive        SourceState = "live"
+	SourceLastKnown   SourceState = "last_known"
+	SourceExpired     SourceState = "expired"
+	SourceUnavailable SourceState = "unavailable"
+	SourceCorrupt     SourceState = "corrupt"
+)
+
+type EligibilityState string
+
+const (
+	EligibilityUnknown  EligibilityState = "unknown"
+	EligibilityEligible EligibilityState = "eligible"
+	EligibilityRefused  EligibilityState = "refused"
+)
+
+type GateState string
+
+const (
+	GateUnknown       GateState = "unknown"
+	GateUnavailable   GateState = "unavailable"
+	GateNotApplicable GateState = "not_applicable"
+	GatePending       GateState = "pending"
+	GateFailed        GateState = "failed"
+	GatePassed        GateState = "passed"
+)
+
+type EvidenceKind string
+
+const (
+	EvidenceSnapshot    EvidenceKind = "snapshot"
+	EvidenceWorkflow    EvidenceKind = "workflow"
+	EvidenceAttempt     EvidenceKind = "attempt"
+	EvidenceScheduler   EvidenceKind = "scheduler"
+	EvidenceAdmission   EvidenceKind = "admission"
+	EvidenceSession     EvidenceKind = "session"
+	EvidenceProvider    EvidenceKind = "provider_session"
+	EvidencePullRequest EvidenceKind = "pull_request"
+)
+
+type Query struct {
+	ProjectID  string
+	Reference  string
+	IssueID    string
+	Identifier string
+	IssueURL   string
+}
+
+type IssueExplanation struct {
+	Schema           int                 `json:"schema"`
+	Found            bool                `json:"found"`
+	ObservedAt       time.Time           `json:"observed_at"`
+	Identity         Identity            `json:"identity"`
+	CurrentLane      Lane                `json:"current_lane"`
+	LatestTransition *Transition         `json:"latest_transition,omitempty"`
+	Eligibility      Eligibility         `json:"eligibility"`
+	Attempt          *Attempt            `json:"attempt,omitempty"`
+	Sessions         Sessions            `json:"sessions"`
+	PullRequest      *PullRequest        `json:"pull_request,omitempty"`
+	RequiredGate     Gate                `json:"required_gate"`
+	Sources          []SourceStatus      `json:"sources"`
+	Evidence         []EvidenceReference `json:"evidence"`
+}
+
+type Identity struct {
+	ProjectID  string `json:"project_id"`
+	IssueID    string `json:"issue_id,omitempty"`
+	Identifier string `json:"identifier,omitempty"`
+	IssueURL   string `json:"issue_url,omitempty"`
+	Number     int    `json:"number,omitempty"`
+	Title      string `json:"title,omitempty"`
+}
+
+type Lane struct {
+	Name       string      `json:"name,omitempty"`
+	ObservedAt *time.Time  `json:"observed_at,omitempty"`
+	Freshness  SourceState `json:"freshness"`
+	Degraded   bool        `json:"degraded"`
+	EvidenceID string      `json:"evidence_id,omitempty"`
+}
+
+type Transition struct {
+	EvidenceID string     `json:"evidence_id"`
+	From       string     `json:"from,omitempty"`
+	To         string     `json:"to"`
+	At         time.Time  `json:"at"`
+	Source     string     `json:"source,omitempty"`
+	Actor      *Actor     `json:"actor,omitempty"`
+	Reason     string     `json:"reason,omitempty"`
+	Provenance Provenance `json:"provenance"`
+	PRNumber   *int64     `json:"pr_number,omitempty"`
+	SessionID  int64      `json:"session_id,omitempty"`
+}
+
+type Actor struct {
+	Login string `json:"login,omitempty"`
+	Kind  string `json:"kind,omitempty"`
+}
+
+type Provenance struct {
+	State     SourceState `json:"state"`
+	Origin    string      `json:"origin"`
+	Admission *Admission  `json:"admission,omitempty"`
+}
+
+type Admission struct {
+	ProposalID string `json:"proposal_id,omitempty"`
+	Attributed bool   `json:"attributed"`
+}
+
+type Eligibility struct {
+	State    EligibilityState      `json:"state"`
+	Latest   *EligibilityDecision  `json:"latest,omitempty"`
+	Refusals []EligibilityDecision `json:"refusals"`
+	Source   SourceState           `json:"source_state"`
+}
+
+type EligibilityDecision struct {
+	EvidenceID string           `json:"evidence_id"`
+	Source     string           `json:"source"`
+	State      EligibilityState `json:"state"`
+	Outcome    string           `json:"outcome"`
+	Reason     string           `json:"reason,omitempty"`
+	At         time.Time        `json:"at"`
+}
+
+type Attempt struct {
+	EvidenceID        string     `json:"evidence_id"`
+	ID                int64      `json:"id"`
+	Selection         string     `json:"selection"`
+	Status            string     `json:"status"`
+	TerminalState     string     `json:"terminal_state,omitempty"`
+	AttemptNumber     int        `json:"attempt_number,omitempty"`
+	Lane              string     `json:"lane,omitempty"`
+	Phase             string     `json:"phase,omitempty"`
+	StatusMessage     string     `json:"status_message,omitempty"`
+	WaitReason        string     `json:"wait_reason,omitempty"`
+	StartedAt         time.Time  `json:"started_at"`
+	HeartbeatAt       *time.Time `json:"heartbeat_at,omitempty"`
+	CompletedAt       *time.Time `json:"completed_at,omitempty"`
+	DetentSessionID   int64      `json:"detent_session_id,omitempty"`
+	ProviderSessionID string     `json:"provider_session_id,omitempty"`
+}
+
+type Sessions struct {
+	Detent   *Session    `json:"detent,omitempty"`
+	Provider *Session    `json:"provider,omitempty"`
+	Source   SourceState `json:"source_state"`
+}
+
+type Session struct {
+	EvidenceID  string     `json:"evidence_id"`
+	ID          string     `json:"id"`
+	Backend     string     `json:"backend,omitempty"`
+	Selection   string     `json:"selection"`
+	CompletedAt *time.Time `json:"completed_at,omitempty"`
+}
+
+type PullRequest struct {
+	EvidenceID string     `json:"evidence_id"`
+	Number     int64      `json:"number"`
+	URL        string     `json:"url,omitempty"`
+	State      string     `json:"state,omitempty"`
+	HeadSHA    string     `json:"head_sha,omitempty"`
+	Source     string     `json:"source"`
+	ObservedAt *time.Time `json:"observed_at,omitempty"`
+}
+
+type Gate struct {
+	State       GateState   `json:"state"`
+	SourceState SourceState `json:"source_state"`
+	EvidenceID  string      `json:"evidence_id,omitempty"`
+	Source      string      `json:"source,omitempty"`
+	ObservedAt  *time.Time  `json:"observed_at,omitempty"`
+	Failures    []string    `json:"failures"`
+	Running     []string    `json:"running"`
+}
+
+type SourceStatus struct {
+	Name  string      `json:"name"`
+	State SourceState `json:"state"`
+	Code  string      `json:"code,omitempty"`
+}
+
+type EvidenceReference struct {
+	ID         string       `json:"id"`
+	Kind       EvidenceKind `json:"kind"`
+	ObservedAt *time.Time   `json:"observed_at,omitempty"`
+}
+
+type AmbiguousIdentityError struct {
+	ProjectID string
+	Field     string
+	Values    []string
+}
+
+func (e *AmbiguousIdentityError) Error() string {
+	values := append([]string(nil), e.Values...)
+	slices.Sort(values)
+	return fmt.Sprintf("ambiguous issue identity in project %q: %s has values %s", strings.TrimSpace(e.ProjectID), e.Field, strings.Join(values, ", "))
+}

--- a/internal/explain/select.go
+++ b/internal/explain/select.go
@@ -1,0 +1,945 @@
+package explain
+
+import (
+	"fmt"
+	"slices"
+	"strconv"
+	"strings"
+	"time"
+
+	admissionmodel "github.com/digitaldrywood/detent/internal/admission/model"
+	"github.com/digitaldrywood/detent/internal/provenance"
+	"github.com/digitaldrywood/detent/internal/store"
+	"github.com/digitaldrywood/detent/internal/telemetry"
+)
+
+type snapshotIssue struct {
+	issue  telemetry.Issue
+	rank   int
+	source string
+}
+
+func normalizeSnapshotObservation(observation SnapshotObservation, now time.Time) SnapshotObservation {
+	if observation.ExpiresAt == nil && !observation.Snapshot.LastKnownUntil.IsZero() {
+		expiresAt := observation.Snapshot.LastKnownUntil.UTC()
+		observation.ExpiresAt = &expiresAt
+	}
+	if observation.ExpiresAt != nil && now.After(observation.ExpiresAt.UTC()) {
+		observation.State = SourceExpired
+		return observation
+	}
+	if observation.State != "" {
+		if (observation.State == SourceLive || observation.State == SourceLastKnown) && observation.Snapshot.GeneratedAt.IsZero() {
+			observation.State = SourceCorrupt
+		}
+		return observation
+	}
+	if observation.Snapshot.GeneratedAt.IsZero() {
+		observation.State = SourceUnavailable
+		return observation
+	}
+	if observation.Snapshot.LastKnown {
+		observation.State = SourceLastKnown
+		return observation
+	}
+	observation.State = SourceLive
+	return observation
+}
+
+func matchingSnapshotIssues(snapshot telemetry.Snapshot, query Query) []snapshotIssue {
+	candidates := make([]snapshotIssue, 0, len(snapshot.BoardIssues)+len(snapshot.Pipeline)+len(snapshot.Running)+len(snapshot.Queue)+len(snapshot.Blocked)+len(snapshot.Completed))
+	for _, issue := range snapshot.BoardIssues {
+		candidates = append(candidates, snapshotIssue{issue: issue, rank: 0, source: "board"})
+	}
+	for _, issue := range snapshot.Pipeline {
+		candidates = append(candidates, snapshotIssue{issue: issue, rank: 1, source: "pipeline"})
+	}
+	for _, issue := range snapshot.Running {
+		candidates = append(candidates, snapshotIssue{issue: issue.Issue, rank: 2, source: "running"})
+	}
+	for _, issue := range snapshot.Queue {
+		candidates = append(candidates, snapshotIssue{issue: issue.Issue, rank: 3, source: "queue"})
+	}
+	for _, issue := range snapshot.Blocked {
+		candidates = append(candidates, snapshotIssue{issue: issue.Issue, rank: 4, source: "blocked"})
+	}
+	for _, issue := range snapshot.Completed {
+		candidates = append(candidates, snapshotIssue{issue: issue.Issue, rank: 5, source: "completed"})
+	}
+
+	matches := make([]snapshotIssue, 0, 1)
+	for _, candidate := range candidates {
+		projectID := strings.TrimSpace(candidate.issue.ProjectID)
+		if projectID == "" {
+			projectID = strings.TrimSpace(snapshot.Project.ID)
+		}
+		if projectID != query.ProjectID || !queryMatchesIssue(query, candidate.issue) {
+			continue
+		}
+		candidate.issue.ProjectID = projectID
+		matches = append(matches, candidate)
+	}
+	slices.SortStableFunc(matches, compareSnapshotIssues)
+	return matches
+}
+
+func compareSnapshotIssues(left snapshotIssue, right snapshotIssue) int {
+	if left.rank != right.rank {
+		return left.rank - right.rank
+	}
+	leftUpdated := issueObservationTime(left.issue)
+	rightUpdated := issueObservationTime(right.issue)
+	if !leftUpdated.Equal(rightUpdated) {
+		if leftUpdated.After(rightUpdated) {
+			return -1
+		}
+		return 1
+	}
+	return strings.Compare(issueIdentityKey(left.issue), issueIdentityKey(right.issue))
+}
+
+func queryMatchesIssue(query Query, issue telemetry.Issue) bool {
+	values := []string{strings.TrimSpace(issue.ID), strings.TrimSpace(issue.Identifier), strings.TrimSpace(issue.URL)}
+	for _, queryValue := range []string{query.IssueID, query.Identifier, query.IssueURL, query.Reference} {
+		queryValue = strings.TrimSpace(queryValue)
+		if queryValue == "" {
+			continue
+		}
+		for _, value := range values {
+			if queryValue == value {
+				return true
+			}
+		}
+		if issue.Number > 0 {
+			number := strconv.Itoa(issue.Number)
+			if queryValue == number || queryValue == "#"+number {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func identitiesFromSnapshot(issues []snapshotIssue) []store.IssueIdentity {
+	identities := make([]store.IssueIdentity, 0, len(issues))
+	for _, candidate := range issues {
+		identities = append(identities, store.IssueIdentity{
+			ProjectID:  candidate.issue.ProjectID,
+			IssueID:    candidate.issue.ID,
+			Identifier: candidate.issue.Identifier,
+			IssueURL:   candidate.issue.URL,
+		})
+	}
+	return identities
+}
+
+func identitiesFromWorkflow(events []store.WorkflowPhaseEvent) []store.IssueIdentity {
+	identities := make([]store.IssueIdentity, 0, len(events))
+	for _, event := range events {
+		identities = append(identities, store.IssueIdentity{ProjectID: event.ProjectID, IssueID: event.IssueID, Identifier: event.Identifier, IssueURL: event.IssueURL})
+	}
+	return identities
+}
+
+func identitiesFromAttempts(groups ...[]store.WorkAttempt) []store.IssueIdentity {
+	identities := []store.IssueIdentity{}
+	for _, attempts := range groups {
+		for _, attempt := range attempts {
+			identities = append(identities, store.IssueIdentity{ProjectID: attempt.ProjectID, IssueID: attempt.IssueID, Identifier: attempt.Identifier, IssueURL: attempt.IssueURL})
+		}
+	}
+	return identities
+}
+
+func identitiesFromScheduler(decisions []store.SchedulerDecision) []store.IssueIdentity {
+	identities := make([]store.IssueIdentity, 0, len(decisions))
+	for _, decision := range decisions {
+		identities = append(identities, store.IssueIdentity{ProjectID: decision.ProjectID, IssueID: decision.IssueID, Identifier: decision.Identifier, IssueURL: decision.IssueURL})
+	}
+	return identities
+}
+
+func projectWorkflowEvents(projectID string, events []store.WorkflowPhaseEvent) []store.WorkflowPhaseEvent {
+	filtered := make([]store.WorkflowPhaseEvent, 0, len(events))
+	for _, event := range events {
+		if strings.TrimSpace(event.ProjectID) == projectID {
+			filtered = append(filtered, event)
+		}
+	}
+	return filtered
+}
+
+func matchingAttempts(identity store.IssueIdentity, attempts []store.WorkAttempt) []store.WorkAttempt {
+	filtered := make([]store.WorkAttempt, 0, len(attempts))
+	for _, attempt := range attempts {
+		if strings.TrimSpace(attempt.ProjectID) != identity.ProjectID {
+			continue
+		}
+		if issueValuesMatch(identity, attempt.IssueID, attempt.Identifier, attempt.IssueURL) {
+			filtered = append(filtered, attempt)
+		}
+	}
+	return filtered
+}
+
+func matchingSchedulerDecisions(identity store.IssueIdentity, decisions []store.SchedulerDecision) []store.SchedulerDecision {
+	filtered := make([]store.SchedulerDecision, 0, len(decisions))
+	for _, decision := range decisions {
+		if strings.TrimSpace(decision.ProjectID) != identity.ProjectID {
+			continue
+		}
+		if issueValuesMatch(identity, decision.IssueID, decision.Identifier, decision.IssueURL) {
+			filtered = append(filtered, decision)
+		}
+	}
+	return filtered
+}
+
+func issueValuesMatch(identity store.IssueIdentity, issueID string, identifier string, issueURL string) bool {
+	pairs := [][2]string{
+		{identity.IssueID, issueID},
+		{identity.Identifier, identifier},
+		{identity.IssueURL, issueURL},
+	}
+	for _, pair := range pairs {
+		if strings.TrimSpace(pair[0]) != "" && strings.TrimSpace(pair[0]) == strings.TrimSpace(pair[1]) {
+			return true
+		}
+	}
+	return false
+}
+
+func resolveIdentity(query Query, collected collectedEvidence) (Identity, error) {
+	issueIDs := map[string]struct{}{}
+	identifiers := map[string]struct{}{}
+	issueURLs := map[string]struct{}{}
+	add := func(identity store.IssueIdentity) {
+		addIdentityValue(issueIDs, identity.IssueID)
+		addIdentityValue(identifiers, identity.Identifier)
+		addIdentityValue(issueURLs, identity.IssueURL)
+	}
+	if query.IssueID != "" || query.Identifier != "" || query.IssueURL != "" {
+		add(store.IssueIdentity{IssueID: query.IssueID, Identifier: query.Identifier, IssueURL: query.IssueURL})
+	}
+	for _, identity := range identitiesFromSnapshot(collected.snapshotIssues) {
+		add(identity)
+	}
+	for _, identity := range identitiesFromWorkflow(collected.workflow) {
+		add(identity)
+	}
+	for _, identity := range identitiesFromAttempts(collected.activeAttempts, collected.terminalAttempts) {
+		add(identity)
+	}
+	for _, identity := range identitiesFromScheduler(collected.schedulerDecisions) {
+		add(identity)
+	}
+	for _, field := range []struct {
+		name   string
+		values map[string]struct{}
+	}{
+		{name: "issue_id", values: issueIDs},
+		{name: "identifier", values: identifiers},
+		{name: "issue_url", values: issueURLs},
+	} {
+		if len(field.values) > 1 {
+			return Identity{}, &AmbiguousIdentityError{ProjectID: query.ProjectID, Field: field.name, Values: identityValues(field.values)}
+		}
+	}
+
+	identity := Identity{
+		ProjectID:  query.ProjectID,
+		IssueID:    firstIdentityValue(issueIDs, query.IssueID),
+		Identifier: firstIdentityValue(identifiers, query.Identifier),
+		IssueURL:   firstIdentityValue(issueURLs, query.IssueURL),
+	}
+	if len(collected.snapshotIssues) > 0 {
+		identity.Number = collected.snapshotIssues[0].issue.Number
+		identity.Title = strings.TrimSpace(collected.snapshotIssues[0].issue.Title)
+	}
+	return identity, nil
+}
+
+func addIdentityValue(values map[string]struct{}, value string) {
+	if value = strings.TrimSpace(value); value != "" {
+		values[value] = struct{}{}
+	}
+}
+
+func identityValues(values map[string]struct{}) []string {
+	result := make([]string, 0, len(values))
+	for value := range values {
+		result = append(result, value)
+	}
+	slices.Sort(result)
+	return result
+}
+
+func firstIdentityValue(values map[string]struct{}, fallback string) string {
+	for value := range values {
+		return value
+	}
+	return strings.TrimSpace(fallback)
+}
+
+func collectedHasEvidence(collected collectedEvidence) bool {
+	return len(collected.snapshotIssues) > 0 ||
+		len(collected.workflow) > 0 ||
+		len(collected.activeAttempts) > 0 ||
+		len(collected.terminalAttempts) > 0 ||
+		len(collected.schedulerDecisions) > 0 ||
+		collected.session != nil ||
+		len(collected.admissionProposals) > 0
+}
+
+func buildExplanation(observedAt time.Time, identity Identity, found bool, collected collectedEvidence) IssueExplanation {
+	selectedAttempt, selection := selectAttempt(collected.activeAttempts, collected.terminalAttempts)
+	transition := selectTransition(collected.workflow)
+	eligibility := buildEligibility(collected)
+	sessions := buildSessions(selectedAttempt, selection, collected)
+	pullRequest := selectPullRequest(identity.ProjectID, selectedAttempt, selection, transition, collected)
+	gate := selectGate(selectedAttempt, selection, collected)
+	lane := selectCurrentLane(collected, observedAt)
+
+	explanation := IssueExplanation{
+		Schema:           SchemaVersion,
+		Found:            found,
+		ObservedAt:       observedAt,
+		Identity:         identity,
+		CurrentLane:      lane,
+		LatestTransition: transition,
+		Eligibility:      eligibility,
+		Attempt:          attemptModel(selectedAttempt, selection),
+		Sessions:         sessions,
+		PullRequest:      pullRequest,
+		RequiredGate:     gate,
+		Sources:          append([]SourceStatus(nil), collected.sources...),
+	}
+	explanation.Evidence = explanationEvidence(explanation, collected)
+	return explanation
+}
+
+func selectCurrentLane(collected collectedEvidence, observedAt time.Time) Lane {
+	state := collected.snapshot.State
+	if state == "" {
+		state = sourceState(collected.sources, "snapshot")
+	}
+	lane := Lane{
+		Freshness: state,
+		Degraded:  state != SourceLive,
+	}
+	if state == SourceUnavailable || state == SourceCorrupt || len(collected.snapshotIssues) == 0 {
+		return lane
+	}
+	issue := collected.snapshotIssues[0].issue
+	lane.Name = strings.TrimSpace(issue.State)
+	if !collected.snapshot.Snapshot.GeneratedAt.IsZero() {
+		observedAt := collected.snapshot.Snapshot.GeneratedAt.UTC()
+		lane.ObservedAt = &observedAt
+		lane.EvidenceID = snapshotEvidenceID(issue.ProjectID, collected.snapshot.Snapshot)
+	}
+	if collected.snapshot.Snapshot.Refresh.Degraded() || collected.snapshot.Snapshot.Refresh.Stale(observedAt) {
+		lane.Degraded = true
+	}
+	return lane
+}
+
+func selectTransition(events []store.WorkflowPhaseEvent) *Transition {
+	var selected *store.WorkflowPhaseEvent
+	for index := range events {
+		event := &events[index]
+		if event.PhaseType != store.WorkflowPhaseTypeLane || !strings.EqualFold(strings.TrimSpace(event.Status), "entered") {
+			continue
+		}
+		if selected == nil || event.StartedAt.After(selected.StartedAt) || (event.StartedAt.Equal(selected.StartedAt) && event.ID > selected.ID) {
+			selected = event
+		}
+	}
+	if selected == nil {
+		return nil
+	}
+	metadata, parsed := provenance.Parse(selected.MetadataJSON)
+	transitionProvenance := Provenance{State: SourceCorrupt, Origin: string(provenance.OriginUnknown)}
+	var actor *Actor
+	if parsed {
+		transitionProvenance.State = SourceAvailable
+		transitionProvenance.Origin = string(metadata.Provenance.Origin)
+		if metadata.Provenance.Actor != nil {
+			actor = &Actor{Login: strings.TrimSpace(metadata.Provenance.Actor.Login), Kind: strings.TrimSpace(metadata.Provenance.Actor.Kind)}
+		}
+		if metadata.Admission != nil {
+			transitionProvenance.Admission = &Admission{ProposalID: strings.TrimSpace(metadata.Admission.ProposalID), Attributed: metadata.Admission.Attributed}
+		}
+	}
+	source := strings.TrimSpace(selected.EndpointFamily)
+	if source == "" {
+		source = "workflow"
+	}
+	return &Transition{
+		EvidenceID: fmt.Sprintf("workflow:%d", selected.ID),
+		From:       strings.TrimSpace(selected.PreviousPhaseName),
+		To:         strings.TrimSpace(selected.PhaseName),
+		At:         selected.StartedAt.UTC(),
+		Source:     source,
+		Actor:      actor,
+		Reason:     strings.TrimSpace(selected.Reason),
+		Provenance: transitionProvenance,
+		PRNumber:   selected.PRNumber,
+		SessionID:  selected.SessionID,
+	}
+}
+
+func buildEligibility(collected collectedEvidence) Eligibility {
+	decisions := make([]EligibilityDecision, 0, len(collected.schedulerDecisions)+len(collected.admissionProposals))
+	for _, decision := range collected.schedulerDecisions {
+		state := EligibilityUnknown
+		switch {
+		case decision.Selected || decision.Result == store.SchedulerDecisionResultSelected:
+			state = EligibilityEligible
+		case decision.Result == store.SchedulerDecisionResultSkipped:
+			state = EligibilityRefused
+		}
+		if state == EligibilityUnknown {
+			continue
+		}
+		decisions = append(decisions, EligibilityDecision{
+			EvidenceID: fmt.Sprintf("scheduler:%d", decision.ID),
+			Source:     "scheduler",
+			State:      state,
+			Outcome:    string(decision.Result),
+			Reason:     firstNonEmpty(decision.WaitReason, decision.Reason),
+			At:         decision.DecisionAt.UTC(),
+		})
+	}
+	for _, proposal := range collected.admissionProposals {
+		state := EligibilityUnknown
+		switch proposal.Status {
+		case admissionmodel.ProposalAccepted:
+			state = EligibilityEligible
+		case admissionmodel.ProposalRejected:
+			state = EligibilityRefused
+		}
+		if state == EligibilityUnknown {
+			continue
+		}
+		at := proposal.ResolvedAt
+		if at.IsZero() {
+			at = proposal.CreatedAt
+		}
+		decisions = append(decisions, EligibilityDecision{
+			EvidenceID: "admission:" + strings.TrimSpace(proposal.ID),
+			Source:     "admission",
+			State:      state,
+			Outcome:    string(proposal.Status),
+			Reason:     strings.TrimSpace(proposal.ResolutionReason),
+			At:         at.UTC(),
+		})
+	}
+	slices.SortStableFunc(decisions, compareEligibilityDecisions)
+	eligibility := Eligibility{
+		State:    EligibilityUnknown,
+		Refusals: []EligibilityDecision{},
+		Source:   combinedSourceState(collected.sources, "scheduler", "admission"),
+	}
+	if len(decisions) > 0 {
+		latest := decisions[0]
+		eligibility.Latest = &latest
+		eligibility.State = latest.State
+	}
+	for _, decision := range decisions {
+		if decision.State == EligibilityRefused {
+			eligibility.Refusals = append(eligibility.Refusals, decision)
+		}
+	}
+	return eligibility
+}
+
+func compareEligibilityDecisions(left EligibilityDecision, right EligibilityDecision) int {
+	if !left.At.Equal(right.At) {
+		if left.At.After(right.At) {
+			return -1
+		}
+		return 1
+	}
+	if left.Source != right.Source {
+		if left.Source == "scheduler" {
+			return -1
+		}
+		if right.Source == "scheduler" {
+			return 1
+		}
+	}
+	return -strings.Compare(left.EvidenceID, right.EvidenceID)
+}
+
+func selectAttempt(active []store.WorkAttempt, terminal []store.WorkAttempt) (*store.WorkAttempt, string) {
+	var selected *store.WorkAttempt
+	for index := range active {
+		attempt := &active[index]
+		if selected == nil || attempt.StartedAt.After(selected.StartedAt) || (attempt.StartedAt.Equal(selected.StartedAt) && attempt.ID > selected.ID) {
+			selected = attempt
+		}
+	}
+	if selected != nil {
+		return selected, "active"
+	}
+	for index := range terminal {
+		attempt := &terminal[index]
+		if selected == nil || attempt.CompletedAt.After(selected.CompletedAt) || (attempt.CompletedAt.Equal(selected.CompletedAt) && attempt.ID > selected.ID) {
+			selected = attempt
+		}
+	}
+	if selected != nil {
+		return selected, "latest_terminal"
+	}
+	return nil, ""
+}
+
+func attemptModel(attempt *store.WorkAttempt, selection string) *Attempt {
+	if attempt == nil {
+		return nil
+	}
+	model := &Attempt{
+		EvidenceID:        fmt.Sprintf("attempt:%d", attempt.ID),
+		ID:                attempt.ID,
+		Selection:         selection,
+		Status:            string(attempt.Status),
+		TerminalState:     string(attempt.TerminalState),
+		AttemptNumber:     attempt.AttemptNumber,
+		Lane:              strings.TrimSpace(attempt.Lane),
+		Phase:             strings.TrimSpace(attempt.Phase),
+		StatusMessage:     strings.TrimSpace(attempt.StatusMessage),
+		WaitReason:        strings.TrimSpace(attempt.WaitReason),
+		StartedAt:         attempt.StartedAt.UTC(),
+		DetentSessionID:   attempt.DetentSessionID,
+		ProviderSessionID: strings.TrimSpace(attempt.ProviderSessionID),
+	}
+	if !attempt.HeartbeatAt.IsZero() {
+		heartbeatAt := attempt.HeartbeatAt.UTC()
+		model.HeartbeatAt = &heartbeatAt
+	}
+	if !attempt.CompletedAt.IsZero() {
+		completedAt := attempt.CompletedAt.UTC()
+		model.CompletedAt = &completedAt
+	}
+	return model
+}
+
+func buildSessions(attempt *store.WorkAttempt, selection string, collected collectedEvidence) Sessions {
+	sessions := Sessions{Source: combinedSourceState(collected.sources, "active_attempt", "terminal_attempt", "session")}
+	if attempt != nil && attempt.DetentSessionID > 0 {
+		sessions.Detent = &Session{
+			EvidenceID: fmt.Sprintf("session:%d", attempt.DetentSessionID),
+			ID:         strconv.FormatInt(attempt.DetentSessionID, 10),
+			Backend:    strings.TrimSpace(attempt.WorkerType),
+			Selection:  selection,
+		}
+	}
+	if attempt != nil && strings.TrimSpace(attempt.ProviderSessionID) != "" {
+		providerID := strings.TrimSpace(attempt.ProviderSessionID)
+		sessions.Provider = &Session{
+			EvidenceID: providerEvidenceID(attempt.WorkerType, providerID),
+			ID:         providerID,
+			Backend:    strings.TrimSpace(attempt.WorkerType),
+			Selection:  selection,
+		}
+	}
+	if collected.session != nil {
+		completedAt := collected.session.CompletedAt.UTC()
+		if sessions.Detent == nil && collected.session.DetentSessionID > 0 {
+			sessions.Detent = &Session{
+				EvidenceID:  fmt.Sprintf("session:%d", collected.session.DetentSessionID),
+				ID:          strconv.FormatInt(collected.session.DetentSessionID, 10),
+				Backend:     strings.TrimSpace(collected.session.AgentBackendKind),
+				Selection:   "latest_completed",
+				CompletedAt: &completedAt,
+			}
+		}
+		providerID := firstNonEmpty(collected.session.ProviderThreadID, collected.session.ProviderSessionID)
+		if sessions.Provider == nil && providerID != "" {
+			sessions.Provider = &Session{
+				EvidenceID:  providerEvidenceID(collected.session.AgentBackendKind, providerID),
+				ID:          providerID,
+				Backend:     strings.TrimSpace(collected.session.AgentBackendKind),
+				Selection:   "latest_completed",
+				CompletedAt: &completedAt,
+			}
+		}
+	}
+	if sessions.Detent != nil || sessions.Provider != nil {
+		sessions.Source = SourceAvailable
+	}
+	return sessions
+}
+
+func selectPullRequest(projectID string, attempt *store.WorkAttempt, selection string, transition *Transition, collected collectedEvidence) *PullRequest {
+	snapshotPR := snapshotPullRequest(projectID, collected)
+	attemptPR := attemptPullRequest(projectID, attempt, selection)
+	latestScheduler := latestSchedulerPR(projectID, collected.schedulerDecisions)
+	workflowPR := workflowPullRequest(projectID, collected.workflow, transition)
+
+	switch collected.snapshot.State {
+	case SourceLive:
+		return firstPullRequest(snapshotPR, attemptPR, latestScheduler, workflowPR)
+	case SourceLastKnown:
+		if selection == "active" {
+			return firstPullRequest(attemptPR, snapshotPR, latestScheduler, workflowPR)
+		}
+		return firstPullRequest(snapshotPR, attemptPR, latestScheduler, workflowPR)
+	case SourceExpired:
+		return firstPullRequest(attemptPR, latestScheduler, workflowPR, snapshotPR)
+	default:
+		return firstPullRequest(attemptPR, latestScheduler, workflowPR)
+	}
+}
+
+func snapshotPullRequest(projectID string, collected collectedEvidence) *PullRequest {
+	if len(collected.snapshotIssues) == 0 || collected.snapshotIssues[0].issue.PullRequest == nil {
+		return nil
+	}
+	pr := collected.snapshotIssues[0].issue.PullRequest
+	if pr.Number <= 0 {
+		return nil
+	}
+	observedAt := collected.snapshot.Snapshot.GeneratedAt.UTC()
+	return &PullRequest{
+		EvidenceID: pullRequestEvidenceID(projectID, int64(pr.Number)),
+		Number:     int64(pr.Number),
+		URL:        strings.TrimSpace(pr.URL),
+		State:      strings.TrimSpace(pr.State),
+		HeadSHA:    strings.TrimSpace(pr.HeadSHA),
+		Source:     "snapshot",
+		ObservedAt: timePointer(observedAt),
+	}
+}
+
+func attemptPullRequest(projectID string, attempt *store.WorkAttempt, selection string) *PullRequest {
+	if attempt == nil || attempt.PRNumber == nil || *attempt.PRNumber <= 0 {
+		return nil
+	}
+	at := attempt.CompletedAt
+	if selection == "active" {
+		at = attempt.HeartbeatAt
+		if at.IsZero() {
+			at = attempt.StartedAt
+		}
+	}
+	return &PullRequest{
+		EvidenceID: pullRequestEvidenceID(projectID, *attempt.PRNumber),
+		Number:     *attempt.PRNumber,
+		Source:     "attempt",
+		ObservedAt: timePointer(at.UTC()),
+	}
+}
+
+func latestSchedulerPR(projectID string, decisions []store.SchedulerDecision) *PullRequest {
+	var selected *store.SchedulerDecision
+	for index := range decisions {
+		decision := &decisions[index]
+		if decision.PRNumber == nil || *decision.PRNumber <= 0 {
+			continue
+		}
+		if selected == nil || decision.DecisionAt.After(selected.DecisionAt) || (decision.DecisionAt.Equal(selected.DecisionAt) && decision.ID > selected.ID) {
+			selected = decision
+		}
+	}
+	if selected == nil {
+		return nil
+	}
+	return &PullRequest{
+		EvidenceID: pullRequestEvidenceID(projectID, *selected.PRNumber),
+		Number:     *selected.PRNumber,
+		Source:     "scheduler",
+		ObservedAt: timePointer(selected.DecisionAt.UTC()),
+	}
+}
+
+func workflowPullRequest(projectID string, events []store.WorkflowPhaseEvent, transition *Transition) *PullRequest {
+	var selected *store.WorkflowPhaseEvent
+	for index := range events {
+		event := &events[index]
+		if event.PRNumber == nil || *event.PRNumber <= 0 {
+			continue
+		}
+		if selected == nil || event.StartedAt.After(selected.StartedAt) || (event.StartedAt.Equal(selected.StartedAt) && event.ID > selected.ID) {
+			selected = event
+		}
+	}
+	if selected == nil && transition != nil && transition.PRNumber != nil {
+		return &PullRequest{
+			EvidenceID: pullRequestEvidenceID(projectID, *transition.PRNumber),
+			Number:     *transition.PRNumber,
+			Source:     "workflow",
+			ObservedAt: timePointer(transition.At),
+		}
+	}
+	if selected == nil {
+		return nil
+	}
+	return &PullRequest{
+		EvidenceID: pullRequestEvidenceID(projectID, *selected.PRNumber),
+		Number:     *selected.PRNumber,
+		Source:     "workflow",
+		ObservedAt: timePointer(selected.StartedAt.UTC()),
+	}
+}
+
+func firstPullRequest(candidates ...*PullRequest) *PullRequest {
+	for _, candidate := range candidates {
+		if candidate != nil {
+			return candidate
+		}
+	}
+	return nil
+}
+
+func selectGate(attempt *store.WorkAttempt, selection string, collected collectedEvidence) Gate {
+	snapshotGate, snapshotRecorded := gateFromSnapshot(collected)
+	attemptGate, attemptRecorded := gateFromAttempt(attempt, selection)
+
+	if collected.snapshot.State == SourceLive && snapshotRecorded {
+		return snapshotGate
+	}
+	if selection == "active" && attemptRecorded {
+		return attemptGate
+	}
+	if collected.snapshot.State == SourceLastKnown && snapshotRecorded {
+		return snapshotGate
+	}
+	if attemptRecorded {
+		return attemptGate
+	}
+	if collected.snapshot.State == SourceExpired && snapshotRecorded {
+		return snapshotGate
+	}
+	state := combinedSourceState(collected.sources, "snapshot", "active_attempt", "terminal_attempt")
+	gate := Gate{State: GateUnknown, SourceState: state, Failures: []string{}, Running: []string{}}
+	if state == SourceUnavailable || state == SourceCorrupt {
+		gate.State = GateUnavailable
+	}
+	return gate
+}
+
+func gateFromSnapshot(collected collectedEvidence) (Gate, bool) {
+	if len(collected.snapshotIssues) == 0 {
+		return Gate{}, false
+	}
+	issue := collected.snapshotIssues[0].issue
+	observedAt := collected.snapshot.Snapshot.GeneratedAt.UTC()
+	gate := Gate{
+		State:       GateUnknown,
+		SourceState: collected.snapshot.State,
+		EvidenceID:  snapshotEvidenceID(issue.ProjectID, collected.snapshot.Snapshot),
+		Source:      "snapshot",
+		ObservedAt:  timePointer(observedAt),
+		Failures:    []string{},
+		Running:     []string{},
+	}
+	if issue.PullRequest == nil {
+		if collected.snapshot.State == SourceLive || collected.snapshot.State == SourceLastKnown {
+			gate.State = GateNotApplicable
+		}
+		return gate, true
+	}
+	pr := issue.PullRequest
+	gate.EvidenceID = pullRequestEvidenceID(issue.ProjectID, int64(pr.Number))
+	for _, check := range pr.RequiredCheckFailures {
+		if name := strings.TrimSpace(check.Name); name != "" {
+			gate.Failures = append(gate.Failures, name)
+		}
+	}
+	gate.Running = append(gate.Running, pr.RunningChecks...)
+	if strings.TrimSpace(pr.HydrationUnavailableReason) != "" || strings.TrimSpace(pr.HydrationDegradedReason) != "" {
+		gate.State = GateUnavailable
+		return gate, true
+	}
+	if len(gate.Failures) > 0 {
+		gate.State = GateFailed
+		return gate, true
+	}
+	gate.State = normalizedGateState(pr.CIStatus)
+	if gate.State == GateUnknown && (issue.GatePending || len(gate.Running) > 0) {
+		gate.State = GatePending
+	}
+	return gate, true
+}
+
+func gateFromAttempt(attempt *store.WorkAttempt, selection string) (Gate, bool) {
+	if attempt == nil || (attempt.PRNumber == nil && strings.TrimSpace(attempt.CIState) == "") {
+		return Gate{}, false
+	}
+	at := attempt.CompletedAt
+	if selection == "active" {
+		at = attempt.HeartbeatAt
+		if at.IsZero() {
+			at = attempt.StartedAt
+		}
+	}
+	evidenceID := fmt.Sprintf("attempt:%d", attempt.ID)
+	if attempt.PRNumber != nil && *attempt.PRNumber > 0 {
+		evidenceID = pullRequestEvidenceID(attempt.ProjectID, *attempt.PRNumber)
+	}
+	return Gate{
+		State:       normalizedGateState(attempt.CIState),
+		SourceState: SourceAvailable,
+		EvidenceID:  evidenceID,
+		Source:      "attempt",
+		ObservedAt:  timePointer(at.UTC()),
+		Failures:    []string{},
+		Running:     []string{},
+	}, true
+}
+
+func normalizedGateState(value string) GateState {
+	switch strings.ToLower(strings.TrimSpace(value)) {
+	case "success", "succeeded", "passed", "pass":
+		return GatePassed
+	case "failure", "failed", "error", "cancelled", "canceled", "timed_out":
+		return GateFailed
+	case "pending", "queued", "in_progress", "running", "expected", "waiting":
+		return GatePending
+	default:
+		return GateUnknown
+	}
+}
+
+func explanationEvidence(explanation IssueExplanation, collected collectedEvidence) []EvidenceReference {
+	collector := map[string]EvidenceReference{}
+	add := func(reference EvidenceReference) {
+		if reference.ID == "" {
+			return
+		}
+		collector[reference.ID] = reference
+	}
+	if len(collected.snapshotIssues) > 0 {
+		observedAt := collected.snapshot.Snapshot.GeneratedAt.UTC()
+		add(EvidenceReference{ID: snapshotEvidenceID(explanation.Identity.ProjectID, collected.snapshot.Snapshot), Kind: EvidenceSnapshot, ObservedAt: timePointer(observedAt)})
+	}
+	if explanation.LatestTransition != nil {
+		add(EvidenceReference{ID: explanation.LatestTransition.EvidenceID, Kind: EvidenceWorkflow, ObservedAt: timePointer(explanation.LatestTransition.At)})
+	}
+	if explanation.Attempt != nil {
+		add(EvidenceReference{ID: explanation.Attempt.EvidenceID, Kind: EvidenceAttempt, ObservedAt: timePointer(explanation.Attempt.StartedAt)})
+	}
+	if explanation.Eligibility.Latest != nil {
+		add(eligibilityEvidence(*explanation.Eligibility.Latest))
+	}
+	for _, refusal := range explanation.Eligibility.Refusals {
+		add(eligibilityEvidence(refusal))
+	}
+	if explanation.Sessions.Detent != nil {
+		add(EvidenceReference{ID: explanation.Sessions.Detent.EvidenceID, Kind: EvidenceSession, ObservedAt: explanation.Sessions.Detent.CompletedAt})
+	}
+	if explanation.Sessions.Provider != nil {
+		add(EvidenceReference{ID: explanation.Sessions.Provider.EvidenceID, Kind: EvidenceProvider, ObservedAt: explanation.Sessions.Provider.CompletedAt})
+	}
+	if explanation.PullRequest != nil {
+		add(EvidenceReference{ID: explanation.PullRequest.EvidenceID, Kind: EvidencePullRequest, ObservedAt: explanation.PullRequest.ObservedAt})
+	}
+	evidence := make([]EvidenceReference, 0, len(collector))
+	for _, reference := range collector {
+		evidence = append(evidence, reference)
+	}
+	slices.SortFunc(evidence, func(left EvidenceReference, right EvidenceReference) int {
+		if left.Kind != right.Kind {
+			return strings.Compare(string(left.Kind), string(right.Kind))
+		}
+		return strings.Compare(left.ID, right.ID)
+	})
+	return evidence
+}
+
+func eligibilityEvidence(decision EligibilityDecision) EvidenceReference {
+	kind := EvidenceScheduler
+	if decision.Source == "admission" {
+		kind = EvidenceAdmission
+	}
+	return EvidenceReference{ID: decision.EvidenceID, Kind: kind, ObservedAt: timePointer(decision.At)}
+}
+
+func sourceState(sources []SourceStatus, name string) SourceState {
+	for _, source := range sources {
+		if source.Name == name {
+			return source.State
+		}
+	}
+	return SourceUnavailable
+}
+
+func combinedSourceState(sources []SourceStatus, names ...string) SourceState {
+	state := SourceUnavailable
+	for _, name := range names {
+		candidate := sourceState(sources, name)
+		switch candidate {
+		case SourceAvailable, SourceLive:
+			return SourceAvailable
+		case SourceLastKnown:
+			if state != SourceAvailable {
+				state = SourceLastKnown
+			}
+		case SourceExpired:
+			if state == SourceUnavailable || state == SourceCorrupt {
+				state = SourceExpired
+			}
+		case SourceCorrupt:
+			if state == SourceUnavailable {
+				state = SourceCorrupt
+			}
+		}
+	}
+	return state
+}
+
+func snapshotEvidenceID(projectID string, snapshot telemetry.Snapshot) string {
+	if snapshot.GeneratedAt.IsZero() {
+		return ""
+	}
+	if snapshot.Seq > 0 {
+		return fmt.Sprintf("snapshot:%s:%d", strings.TrimSpace(projectID), snapshot.Seq)
+	}
+	return fmt.Sprintf("snapshot:%s:%d", strings.TrimSpace(projectID), snapshot.GeneratedAt.UTC().UnixNano())
+}
+
+func pullRequestEvidenceID(projectID string, number int64) string {
+	if number <= 0 {
+		return ""
+	}
+	return fmt.Sprintf("pull-request:%s:%d", strings.TrimSpace(projectID), number)
+}
+
+func providerEvidenceID(backend string, id string) string {
+	backend = strings.ToLower(strings.TrimSpace(backend))
+	if backend == "" {
+		backend = "unknown"
+	}
+	return "provider-session:" + backend + ":" + strings.TrimSpace(id)
+}
+
+func timePointer(value time.Time) *time.Time {
+	if value.IsZero() {
+		return nil
+	}
+	value = value.UTC()
+	return &value
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, value := range values {
+		if value = strings.TrimSpace(value); value != "" {
+			return value
+		}
+	}
+	return ""
+}
+
+func issueObservationTime(issue telemetry.Issue) time.Time {
+	for _, value := range []*time.Time{issue.UpdatedAt, issue.StageUpdatedAt, issue.CurrentLaneEnteredAt, issue.CreatedAt} {
+		if value != nil {
+			return value.UTC()
+		}
+	}
+	return time.Time{}
+}
+
+func issueIdentityKey(issue telemetry.Issue) string {
+	return strings.Join([]string{strings.TrimSpace(issue.ID), strings.TrimSpace(issue.Identifier), strings.TrimSpace(issue.URL)}, "\x00")
+}

--- a/internal/explain/select.go
+++ b/internal/explain/select.go
@@ -696,11 +696,14 @@ func selectGate(attempt *store.WorkAttempt, selection string, collected collecte
 	snapshotGate, snapshotRecorded := gateFromSnapshot(collected)
 	attemptGate, attemptRecorded := gateFromAttempt(attempt, selection)
 
-	if collected.snapshot.State == SourceLive && snapshotRecorded {
+	if collected.snapshot.State == SourceLive && snapshotRecorded && gateIsUsable(snapshotGate) {
 		return snapshotGate
 	}
-	if selection == "active" && attemptRecorded {
+	if selection == "active" && attemptRecorded && gateIsUsable(attemptGate) {
 		return attemptGate
+	}
+	if collected.snapshot.State == SourceLive && snapshotRecorded {
+		return snapshotGate
 	}
 	if collected.snapshot.State == SourceLastKnown && snapshotRecorded {
 		return snapshotGate
@@ -717,6 +720,10 @@ func selectGate(attempt *store.WorkAttempt, selection string, collected collecte
 		gate.State = GateUnavailable
 	}
 	return gate
+}
+
+func gateIsUsable(gate Gate) bool {
+	return gate.State == GatePending || gate.State == GateFailed || gate.State == GatePassed
 }
 
 func gateFromSnapshot(collected collectedEvidence) (Gate, bool) {

--- a/internal/explain/service.go
+++ b/internal/explain/service.go
@@ -1,0 +1,393 @@
+package explain
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"time"
+
+	admissionmodel "github.com/digitaldrywood/detent/internal/admission/model"
+	"github.com/digitaldrywood/detent/internal/store"
+	"github.com/digitaldrywood/detent/internal/telemetry"
+)
+
+var ErrCorruptSource = errors.New("explanation evidence source is corrupt")
+
+type SnapshotObservation struct {
+	State     SourceState
+	Snapshot  telemetry.Snapshot
+	ExpiresAt *time.Time
+}
+
+type SnapshotSource interface {
+	Snapshot(context.Context) (SnapshotObservation, error)
+}
+
+type WorkflowReader interface {
+	IssueWorkflowTimeline(context.Context, store.IssueIdentity) (store.WorkflowTimeline, error)
+}
+
+type AttemptReader interface {
+	ListActiveWorkAttempts(context.Context, store.WorkAttemptQuery) ([]store.WorkAttempt, error)
+	ListRecentTerminalWorkAttempts(context.Context, store.WorkAttemptHistoryQuery) ([]store.WorkAttempt, error)
+}
+
+type SchedulerReader interface {
+	ListIssueSchedulerDecisions(context.Context, store.IssueSchedulerDecisionQuery) ([]store.SchedulerDecision, error)
+}
+
+type SessionReader interface {
+	LatestIssueAgentSession(context.Context, store.IssueIdentity) (store.IssueAgentSession, error)
+}
+
+type AdmissionReader interface {
+	AdmissionProposalHistory(context.Context, string, string) ([]admissionmodel.Proposal, error)
+}
+
+type Dependencies struct {
+	Snapshots SnapshotSource
+	Workflow  WorkflowReader
+	Attempts  AttemptReader
+	Scheduler SchedulerReader
+	Sessions  SessionReader
+	Admission AdmissionReader
+	Now       func() time.Time
+}
+
+type Service struct {
+	snapshots SnapshotSource
+	workflow  WorkflowReader
+	attempts  AttemptReader
+	scheduler SchedulerReader
+	sessions  SessionReader
+	admission AdmissionReader
+	now       func() time.Time
+}
+
+type collectedEvidence struct {
+	snapshot           SnapshotObservation
+	snapshotIssues     []snapshotIssue
+	workflow           []store.WorkflowPhaseEvent
+	activeAttempts     []store.WorkAttempt
+	terminalAttempts   []store.WorkAttempt
+	schedulerDecisions []store.SchedulerDecision
+	session            *store.IssueAgentSession
+	admissionProposals []admissionmodel.Proposal
+	sources            []SourceStatus
+	configuredSources  int
+	successfulSources  int
+}
+
+func New(deps Dependencies) *Service {
+	now := deps.Now
+	if now == nil {
+		now = time.Now
+	}
+	return &Service{
+		snapshots: deps.Snapshots,
+		workflow:  deps.Workflow,
+		attempts:  deps.Attempts,
+		scheduler: deps.Scheduler,
+		sessions:  deps.Sessions,
+		admission: deps.Admission,
+		now:       now,
+	}
+}
+
+func (s *Service) Explain(ctx context.Context, query Query) (IssueExplanation, error) {
+	query = normalizeQuery(query)
+	if query.ProjectID == "" {
+		return IssueExplanation{}, ErrProjectRequired
+	}
+	if !queryHasIssueReference(query) {
+		return IssueExplanation{}, ErrIssueReferenceNeeded
+	}
+	if err := ctx.Err(); err != nil {
+		return IssueExplanation{}, err
+	}
+
+	observedAt := s.now().UTC()
+	lookup := queryStoreIdentity(query)
+	collected := collectedEvidence{}
+
+	if err := s.collectSnapshot(ctx, observedAt, query, &collected); err != nil {
+		return IssueExplanation{}, err
+	}
+	lookup = mergeLookupIdentity(lookup, identitiesFromSnapshot(collected.snapshotIssues))
+	if err := s.collectWorkflow(ctx, lookup, &collected); err != nil {
+		return IssueExplanation{}, err
+	}
+	lookup = mergeLookupIdentity(lookup, identitiesFromWorkflow(collected.workflow))
+	if err := s.collectAttempts(ctx, lookup, &collected); err != nil {
+		return IssueExplanation{}, err
+	}
+	lookup = mergeLookupIdentity(lookup, identitiesFromAttempts(collected.activeAttempts, collected.terminalAttempts))
+	if err := s.collectScheduler(ctx, lookup, &collected); err != nil {
+		return IssueExplanation{}, err
+	}
+
+	identity, err := resolveIdentity(query, collected)
+	if err != nil {
+		return IssueExplanation{}, err
+	}
+	resolvedLookup := store.IssueIdentity{
+		ProjectID:  identity.ProjectID,
+		IssueID:    identity.IssueID,
+		Identifier: identity.Identifier,
+		IssueURL:   identity.IssueURL,
+	}
+	if err := s.collectSession(ctx, resolvedLookup, &collected); err != nil {
+		return IssueExplanation{}, err
+	}
+	if err := s.collectAdmission(ctx, resolvedLookup, &collected); err != nil {
+		return IssueExplanation{}, err
+	}
+
+	found := collectedHasEvidence(collected)
+	if !found && collected.configuredSources > 0 && collected.successfulSources == collected.configuredSources {
+		return IssueExplanation{}, ErrNotFound
+	}
+
+	return buildExplanation(observedAt, identity, found, collected), nil
+}
+
+func (s *Service) collectSnapshot(ctx context.Context, now time.Time, query Query, collected *collectedEvidence) error {
+	if s.snapshots == nil {
+		collected.sources = append(collected.sources, unavailableSource("snapshot", "not_configured"))
+		return nil
+	}
+	collected.configuredSources++
+	observation, err := s.snapshots.Snapshot(ctx)
+	if err != nil {
+		if contextError(err) != nil {
+			return contextError(err)
+		}
+		collected.sources = append(collected.sources, failedSource("snapshot", err))
+		return nil
+	}
+	observation = normalizeSnapshotObservation(observation, now)
+	if observation.State == SourceLive {
+		collected.successfulSources++
+	}
+	collected.snapshot = observation
+	if observation.State != SourceUnavailable && observation.State != SourceCorrupt {
+		collected.snapshotIssues = matchingSnapshotIssues(observation.Snapshot, query)
+	}
+	status := SourceStatus{Name: "snapshot", State: observation.State}
+	if observation.State == SourceLive && observation.Snapshot.Refresh.Degraded() {
+		status.Code = "refresh_degraded"
+	}
+	collected.sources = append(collected.sources, status)
+	return nil
+}
+
+func (s *Service) collectWorkflow(ctx context.Context, identity store.IssueIdentity, collected *collectedEvidence) error {
+	if s.workflow == nil {
+		collected.sources = append(collected.sources, unavailableSource("workflow", "not_configured"))
+		return nil
+	}
+	collected.configuredSources++
+	timeline, err := s.workflow.IssueWorkflowTimeline(ctx, identity)
+	if err != nil {
+		if contextError(err) != nil {
+			return contextError(err)
+		}
+		collected.sources = append(collected.sources, failedSource("workflow", err))
+		return nil
+	}
+	collected.successfulSources++
+	collected.workflow = projectWorkflowEvents(identity.ProjectID, timeline.Events)
+	collected.sources = append(collected.sources, availableSource("workflow"))
+	return nil
+}
+
+func (s *Service) collectAttempts(ctx context.Context, identity store.IssueIdentity, collected *collectedEvidence) error {
+	if s.attempts == nil {
+		collected.sources = append(collected.sources,
+			unavailableSource("active_attempt", "not_configured"),
+			unavailableSource("terminal_attempt", "not_configured"),
+		)
+		return nil
+	}
+
+	collected.configuredSources += 2
+	active, err := s.attempts.ListActiveWorkAttempts(ctx, store.WorkAttemptQuery{ProjectID: identity.ProjectID})
+	if err != nil {
+		if contextError(err) != nil {
+			return contextError(err)
+		}
+		collected.sources = append(collected.sources, failedSource("active_attempt", err))
+	} else {
+		collected.successfulSources++
+		collected.activeAttempts = matchingAttempts(identity, active)
+		collected.sources = append(collected.sources, availableSource("active_attempt"))
+	}
+
+	terminal, err := s.attempts.ListRecentTerminalWorkAttempts(ctx, store.WorkAttemptHistoryQuery{
+		ProjectID:  identity.ProjectID,
+		IssueID:    identity.IssueID,
+		Identifier: identity.Identifier,
+		IssueURL:   identity.IssueURL,
+		Limit:      50,
+	})
+	if err != nil {
+		if contextError(err) != nil {
+			return contextError(err)
+		}
+		collected.sources = append(collected.sources, failedSource("terminal_attempt", err))
+	} else {
+		collected.successfulSources++
+		collected.terminalAttempts = matchingAttempts(identity, terminal)
+		collected.sources = append(collected.sources, availableSource("terminal_attempt"))
+	}
+	return nil
+}
+
+func (s *Service) collectScheduler(ctx context.Context, identity store.IssueIdentity, collected *collectedEvidence) error {
+	if s.scheduler == nil {
+		collected.sources = append(collected.sources, unavailableSource("scheduler", "not_configured"))
+		return nil
+	}
+	collected.configuredSources++
+	decisions, err := s.scheduler.ListIssueSchedulerDecisions(ctx, store.IssueSchedulerDecisionQuery{Identity: identity, Limit: 50})
+	if err != nil {
+		if contextError(err) != nil {
+			return contextError(err)
+		}
+		collected.sources = append(collected.sources, failedSource("scheduler", err))
+		return nil
+	}
+	collected.successfulSources++
+	collected.schedulerDecisions = matchingSchedulerDecisions(identity, decisions)
+	collected.sources = append(collected.sources, availableSource("scheduler"))
+	return nil
+}
+
+func (s *Service) collectSession(ctx context.Context, identity store.IssueIdentity, collected *collectedEvidence) error {
+	if s.sessions == nil {
+		collected.sources = append(collected.sources, unavailableSource("session", "not_configured"))
+		return nil
+	}
+	collected.configuredSources++
+	session, err := s.sessions.LatestIssueAgentSession(ctx, identity)
+	if errors.Is(err, store.ErrNotFound) {
+		collected.successfulSources++
+		collected.sources = append(collected.sources, availableSource("session"))
+		return nil
+	}
+	if err != nil {
+		if contextError(err) != nil {
+			return contextError(err)
+		}
+		collected.sources = append(collected.sources, failedSource("session", err))
+		return nil
+	}
+	collected.successfulSources++
+	if strings.TrimSpace(session.ProjectID) == identity.ProjectID {
+		collected.session = &session
+	}
+	collected.sources = append(collected.sources, availableSource("session"))
+	return nil
+}
+
+func (s *Service) collectAdmission(ctx context.Context, identity store.IssueIdentity, collected *collectedEvidence) error {
+	if s.admission == nil {
+		collected.sources = append(collected.sources, unavailableSource("admission", "not_configured"))
+		return nil
+	}
+	if identity.IssueID == "" {
+		collected.sources = append(collected.sources, unavailableSource("admission", "issue_id_unresolved"))
+		return nil
+	}
+	collected.configuredSources++
+	proposals, err := s.admission.AdmissionProposalHistory(ctx, identity.ProjectID, identity.IssueID)
+	if err != nil {
+		if contextError(err) != nil {
+			return contextError(err)
+		}
+		collected.sources = append(collected.sources, failedSource("admission", err))
+		return nil
+	}
+	collected.successfulSources++
+	for _, proposal := range proposals {
+		if strings.TrimSpace(proposal.ProjectID) == identity.ProjectID && strings.TrimSpace(proposal.IssueID) == identity.IssueID {
+			collected.admissionProposals = append(collected.admissionProposals, proposal)
+		}
+	}
+	collected.sources = append(collected.sources, availableSource("admission"))
+	return nil
+}
+
+func normalizeQuery(query Query) Query {
+	return Query{
+		ProjectID:  strings.TrimSpace(query.ProjectID),
+		Reference:  strings.TrimSpace(query.Reference),
+		IssueID:    strings.TrimSpace(query.IssueID),
+		Identifier: strings.TrimSpace(query.Identifier),
+		IssueURL:   strings.TrimSpace(query.IssueURL),
+	}
+}
+
+func queryHasIssueReference(query Query) bool {
+	return query.Reference != "" || query.IssueID != "" || query.Identifier != "" || query.IssueURL != ""
+}
+
+func queryStoreIdentity(query Query) store.IssueIdentity {
+	identity := store.IssueIdentity{
+		ProjectID:  query.ProjectID,
+		IssueID:    query.IssueID,
+		Identifier: query.Identifier,
+		IssueURL:   query.IssueURL,
+	}
+	if identity.IssueID == "" && identity.Identifier == "" && identity.IssueURL == "" {
+		identity.IssueID = query.Reference
+		identity.Identifier = query.Reference
+		identity.IssueURL = query.Reference
+	}
+	return identity
+}
+
+func mergeLookupIdentity(identity store.IssueIdentity, candidates []store.IssueIdentity) store.IssueIdentity {
+	if len(candidates) > 0 && identity.IssueID != "" && identity.IssueID == identity.Identifier && identity.Identifier == identity.IssueURL {
+		identity.IssueID = ""
+		identity.Identifier = ""
+		identity.IssueURL = ""
+	}
+	for _, candidate := range candidates {
+		if identity.IssueID == "" {
+			identity.IssueID = strings.TrimSpace(candidate.IssueID)
+		}
+		if identity.Identifier == "" {
+			identity.Identifier = strings.TrimSpace(candidate.Identifier)
+		}
+		if identity.IssueURL == "" {
+			identity.IssueURL = strings.TrimSpace(candidate.IssueURL)
+		}
+	}
+	return identity
+}
+
+func availableSource(name string) SourceStatus {
+	return SourceStatus{Name: name, State: SourceAvailable}
+}
+
+func unavailableSource(name string, code string) SourceStatus {
+	return SourceStatus{Name: name, State: SourceUnavailable, Code: code}
+}
+
+func failedSource(name string, err error) SourceStatus {
+	if errors.Is(err, ErrCorruptSource) {
+		return SourceStatus{Name: name, State: SourceCorrupt, Code: "corrupt_source"}
+	}
+	return unavailableSource(name, "read_failed")
+}
+
+func contextError(err error) error {
+	if errors.Is(err, context.Canceled) {
+		return context.Canceled
+	}
+	if errors.Is(err, context.DeadlineExceeded) {
+		return context.DeadlineExceeded
+	}
+	return nil
+}

--- a/internal/explain/service_test.go
+++ b/internal/explain/service_test.go
@@ -1,0 +1,437 @@
+package explain
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+
+	admissionmodel "github.com/digitaldrywood/detent/internal/admission/model"
+	"github.com/digitaldrywood/detent/internal/provenance"
+	"github.com/digitaldrywood/detent/internal/store"
+	"github.com/digitaldrywood/detent/internal/telemetry"
+)
+
+func TestServiceRequiresScopedIdentity(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		query Query
+		want  error
+	}{
+		{name: "missing project", query: Query{IssueID: "issue-1"}, want: ErrProjectRequired},
+		{name: "missing issue", query: Query{ProjectID: "detent"}, want: ErrIssueReferenceNeeded},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			_, err := New(Dependencies{}).Explain(context.Background(), tt.query)
+			if !errors.Is(err, tt.want) {
+				t.Fatalf("Explain() error = %v, want %v", err, tt.want)
+			}
+		})
+	}
+}
+
+func TestServiceKeepsProjectsIsolated(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 8, 7, 18, 0, 0, 0, time.UTC)
+	reader := &evidenceReader{
+		observation: SnapshotObservation{
+			State: SourceLive,
+			Snapshot: telemetry.Snapshot{
+				GeneratedAt: now,
+				BoardIssues: []telemetry.Issue{
+					{ID: "same-id", Identifier: "owner/a#1", ProjectID: "project-a", State: "Todo", Title: "A"},
+					{ID: "same-id", Identifier: "owner/b#1", ProjectID: "project-b", State: "Blocked", Title: "B"},
+				},
+			},
+		},
+		workflow: []store.WorkflowPhaseEvent{
+			{ID: 1, ProjectID: "project-a", IssueID: "same-id", Identifier: "owner/a#1", PhaseType: store.WorkflowPhaseTypeLane, PhaseName: "Todo", Status: "entered", StartedAt: now.Add(-time.Minute), MetadataJSON: `{"provenance":{"origin":"human"}}`},
+			{ID: 2, ProjectID: "project-b", IssueID: "same-id", Identifier: "owner/b#1", PhaseType: store.WorkflowPhaseTypeLane, PhaseName: "Blocked", Status: "entered", StartedAt: now, MetadataJSON: `{"provenance":{"origin":"routine"}}`},
+		},
+		active: []store.WorkAttempt{
+			{ID: 11, ProjectID: "project-a", IssueID: "same-id", Identifier: "owner/a#1", Status: store.WorkAttemptStatusActive, StartedAt: now},
+			{ID: 12, ProjectID: "project-b", IssueID: "same-id", Identifier: "owner/b#1", Status: store.WorkAttemptStatusActive, StartedAt: now.Add(time.Minute)},
+		},
+		decisions: []store.SchedulerDecision{
+			{ID: 21, ProjectID: "project-a", IssueID: "same-id", Identifier: "owner/a#1", Result: store.SchedulerDecisionResultSelected, Selected: true, DecisionAt: now},
+			{ID: 22, ProjectID: "project-b", IssueID: "same-id", Identifier: "owner/b#1", Result: store.SchedulerDecisionResultSkipped, DecisionAt: now.Add(time.Minute)},
+		},
+		session: &store.IssueAgentSession{ProjectID: "project-b", DetentSessionID: 99, ProviderSessionID: "wrong-project", CompletedAt: now},
+		proposals: []admissionmodel.Proposal{
+			{ID: "a", ProjectID: "project-a", IssueID: "same-id", Status: admissionmodel.ProposalAccepted, ResolvedAt: now},
+			{ID: "b", ProjectID: "project-b", IssueID: "same-id", Status: admissionmodel.ProposalRejected, ResolvedAt: now.Add(time.Minute)},
+		},
+	}
+
+	got, err := newTestService(now, reader).Explain(context.Background(), Query{ProjectID: "project-a", IssueID: "same-id"})
+	if err != nil {
+		t.Fatalf("Explain() error = %v", err)
+	}
+	if got.Identity.Identifier != "owner/a#1" || got.Identity.Title != "A" || got.CurrentLane.Name != "Todo" {
+		t.Fatalf("identity/lane = %#v / %#v, want project-a", got.Identity, got.CurrentLane)
+	}
+	if got.LatestTransition == nil || got.LatestTransition.EvidenceID != "workflow:1" {
+		t.Fatalf("latest transition = %#v, want workflow:1", got.LatestTransition)
+	}
+	if got.Attempt == nil || got.Attempt.ID != 11 || got.Eligibility.State != EligibilityEligible {
+		t.Fatalf("attempt/eligibility = %#v / %#v, want project-a evidence", got.Attempt, got.Eligibility)
+	}
+	if got.Sessions.Detent != nil || got.Sessions.Provider != nil {
+		t.Fatalf("sessions = %#v, want cross-project session ignored", got.Sessions)
+	}
+	for _, evidence := range got.Evidence {
+		if strings.Contains(evidence.ID, "wrong-project") || evidence.ID == "workflow:2" || evidence.ID == "attempt:12" || evidence.ID == "scheduler:22" {
+			t.Fatalf("cross-project evidence leaked: %#v", got.Evidence)
+		}
+	}
+}
+
+func TestServiceSeparatesCurrentLaneFromEnteredTransition(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 8, 7, 18, 0, 0, 0, time.UTC)
+	transitionAt := now.Add(-time.Minute)
+	metadata := provenance.Apply(`{"private":"never-return"}`, provenance.Attribution{
+		Origin: provenance.OriginHuman,
+		Actor:  &provenance.Actor{Login: "ada", Kind: "User"},
+	}, &provenance.Admission{ProposalID: "proposal-1", Attributed: true})
+	reader := &evidenceReader{
+		observation: liveIssueObservation(now, telemetry.Issue{ID: "issue-1", Identifier: "owner/repo#1", ProjectID: "detent", State: "Rework"}),
+		workflow: []store.WorkflowPhaseEvent{
+			{ID: 40, ProjectID: "detent", IssueID: "issue-1", PhaseType: store.WorkflowPhaseTypeLane, PhaseName: "Merging", Status: "exited", StartedAt: now.Add(-time.Hour), FinishedAt: transitionAt, MetadataJSON: metadata},
+			{ID: 41, ProjectID: "detent", IssueID: "issue-1", PhaseType: store.WorkflowPhaseTypeLane, PhaseName: "Blocked", PreviousPhaseName: "Merging", Reason: "required_checks_missing", Status: "entered", StartedAt: transitionAt, EndpointFamily: "tracker", MetadataJSON: metadata},
+		},
+	}
+
+	got, err := newTestService(now, reader).Explain(context.Background(), Query{ProjectID: "detent", IssueID: "issue-1"})
+	if err != nil {
+		t.Fatalf("Explain() error = %v", err)
+	}
+	if got.CurrentLane.Name != "Rework" || got.CurrentLane.Freshness != SourceLive || got.CurrentLane.Degraded {
+		t.Fatalf("current lane = %#v, want live Rework snapshot", got.CurrentLane)
+	}
+	if got.LatestTransition == nil || got.LatestTransition.EvidenceID != "workflow:41" || got.LatestTransition.To != "Blocked" || got.LatestTransition.From != "Merging" {
+		t.Fatalf("latest transition = %#v, want entered workflow:41", got.LatestTransition)
+	}
+	if got.LatestTransition.Actor == nil || got.LatestTransition.Actor.Login != "ada" || got.LatestTransition.Provenance.Origin != "human" || got.LatestTransition.Provenance.Admission == nil {
+		t.Fatalf("parsed provenance = %#v", got.LatestTransition)
+	}
+	raw, err := json.Marshal(got)
+	if err != nil {
+		t.Fatalf("json.Marshal() error = %v", err)
+	}
+	if strings.Contains(string(raw), "never-return") || strings.Contains(string(raw), "metadata_json") {
+		t.Fatalf("IssueExplanation leaked raw metadata: %s", raw)
+	}
+}
+
+func TestServiceDistinguishesSnapshotFreshness(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 8, 7, 18, 0, 0, 0, time.UTC)
+	issue := telemetry.Issue{ID: "issue-1", ProjectID: "detent", State: "Rework"}
+	workflow := []store.WorkflowPhaseEvent{{ID: 1, ProjectID: "detent", IssueID: "issue-1", PhaseType: store.WorkflowPhaseTypeLane, PhaseName: "Todo", Status: "entered", StartedAt: now.Add(-time.Hour), MetadataJSON: `{"provenance":{"origin":"unknown"}}`}}
+	tests := []struct {
+		name        string
+		observation SnapshotObservation
+		wantState   SourceState
+		wantLane    string
+	}{
+		{name: "live", observation: liveIssueObservation(now, issue), wantState: SourceLive, wantLane: "Rework"},
+		{name: "last known", observation: SnapshotObservation{State: SourceLastKnown, Snapshot: telemetry.Snapshot{GeneratedAt: now.Add(-time.Minute), BoardIssues: []telemetry.Issue{issue}}}, wantState: SourceLastKnown, wantLane: "Rework"},
+		{name: "expired", observation: SnapshotObservation{State: SourceLastKnown, ExpiresAt: timePointer(now.Add(-time.Second)), Snapshot: telemetry.Snapshot{GeneratedAt: now.Add(-time.Hour), BoardIssues: []telemetry.Issue{issue}}}, wantState: SourceExpired, wantLane: "Rework"},
+		{name: "unavailable", observation: SnapshotObservation{State: SourceUnavailable, Snapshot: telemetry.Snapshot{GeneratedAt: now, BoardIssues: []telemetry.Issue{issue}}}, wantState: SourceUnavailable},
+		{name: "corrupt", observation: SnapshotObservation{State: SourceCorrupt, Snapshot: telemetry.Snapshot{GeneratedAt: now, BoardIssues: []telemetry.Issue{issue}}}, wantState: SourceCorrupt},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			reader := &evidenceReader{observation: tt.observation, workflow: workflow}
+			got, err := newTestService(now, reader).Explain(context.Background(), Query{ProjectID: "detent", IssueID: "issue-1"})
+			if err != nil {
+				t.Fatalf("Explain() error = %v", err)
+			}
+			if got.CurrentLane.Freshness != tt.wantState || got.CurrentLane.Name != tt.wantLane {
+				t.Fatalf("current lane = %#v, want state %q lane %q", got.CurrentLane, tt.wantState, tt.wantLane)
+			}
+			if tt.wantState != SourceLive && !got.CurrentLane.Degraded {
+				t.Fatalf("current lane degraded = false for %q", tt.wantState)
+			}
+		})
+	}
+}
+
+func TestServiceReportsOnlyRecordedEligibility(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 8, 7, 18, 0, 0, 0, time.UTC)
+	tests := []struct {
+		name      string
+		decisions []store.SchedulerDecision
+		proposals []admissionmodel.Proposal
+		want      EligibilityState
+		refusals  int
+	}{
+		{name: "no recorded decision", want: EligibilityUnknown},
+		{name: "scheduler refusal", decisions: []store.SchedulerDecision{{ID: 2, ProjectID: "detent", IssueID: "issue-1", Result: store.SchedulerDecisionResultSkipped, Reason: "capacity", DecisionAt: now}}, want: EligibilityRefused, refusals: 1},
+		{name: "scheduler selection", decisions: []store.SchedulerDecision{{ID: 3, ProjectID: "detent", IssueID: "issue-1", Result: store.SchedulerDecisionResultSelected, Selected: true, DecisionAt: now}}, want: EligibilityEligible},
+		{name: "admission rejection", proposals: []admissionmodel.Proposal{{ID: "proposal-1", ProjectID: "detent", IssueID: "issue-1", Status: admissionmodel.ProposalRejected, ResolvedAt: now}}, want: EligibilityRefused, refusals: 1},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			reader := &evidenceReader{
+				observation: liveIssueObservation(now, telemetry.Issue{ID: "issue-1", ProjectID: "detent", State: "Todo"}),
+				decisions:   tt.decisions,
+				proposals:   tt.proposals,
+			}
+			got, err := newTestService(now, reader).Explain(context.Background(), Query{ProjectID: "detent", IssueID: "issue-1"})
+			if err != nil {
+				t.Fatalf("Explain() error = %v", err)
+			}
+			if got.Eligibility.State != tt.want || len(got.Eligibility.Refusals) != tt.refusals {
+				t.Fatalf("eligibility = %#v, want state %q refusals %d", got.Eligibility, tt.want, tt.refusals)
+			}
+		})
+	}
+}
+
+func TestServiceAttemptSessionAndGatePrecedence(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 8, 7, 18, 0, 0, 0, time.UTC)
+	prNumber := int64(11)
+	reader := &evidenceReader{
+		observation: SnapshotObservation{
+			State: SourceLastKnown,
+			Snapshot: telemetry.Snapshot{GeneratedAt: now.Add(-time.Minute), BoardIssues: []telemetry.Issue{{
+				ID: "issue-1", ProjectID: "detent", State: "Merging", PullRequest: &telemetry.PullRequest{Number: 10, CIStatus: "pending"},
+			}}},
+		},
+		active: []store.WorkAttempt{
+			{ID: 4, ProjectID: "detent", IssueID: "issue-1", Status: store.WorkAttemptStatusActive, StartedAt: now.Add(-2 * time.Minute)},
+			{ID: 5, ProjectID: "detent", IssueID: "issue-1", PRNumber: &prNumber, WorkerType: "codex", Status: store.WorkAttemptStatusActive, StartedAt: now.Add(-time.Minute), HeartbeatAt: now, CIState: "passed", DetentSessionID: 50, ProviderSessionID: "provider-active"},
+		},
+		terminal: []store.WorkAttempt{{ID: 6, ProjectID: "detent", IssueID: "issue-1", Status: store.WorkAttemptStatusTerminal, CompletedAt: now.Add(time.Minute), DetentSessionID: 60}},
+		session:  &store.IssueAgentSession{ProjectID: "detent", DetentSessionID: 70, ProviderSessionID: "provider-completed", AgentBackendKind: "codex", CompletedAt: now.Add(2 * time.Minute)},
+	}
+
+	got, err := newTestService(now, reader).Explain(context.Background(), Query{ProjectID: "detent", IssueID: "issue-1"})
+	if err != nil {
+		t.Fatalf("Explain() error = %v", err)
+	}
+	if got.Attempt == nil || got.Attempt.ID != 5 || got.Attempt.Selection != "active" {
+		t.Fatalf("attempt = %#v, want newest active attempt 5", got.Attempt)
+	}
+	if got.Sessions.Detent == nil || got.Sessions.Detent.ID != "50" || got.Sessions.Provider == nil || got.Sessions.Provider.ID != "provider-active" {
+		t.Fatalf("sessions = %#v, want active attempt pointers", got.Sessions)
+	}
+	if got.PullRequest == nil || got.PullRequest.Number != 11 || got.PullRequest.Source != "attempt" {
+		t.Fatalf("pull request = %#v, want active attempt PR 11", got.PullRequest)
+	}
+	if got.RequiredGate.State != GatePassed || got.RequiredGate.Source != "attempt" {
+		t.Fatalf("required gate = %#v, want active attempt passed", got.RequiredGate)
+	}
+}
+
+func TestServiceDistinguishesRequiredGateStates(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 8, 7, 18, 0, 0, 0, time.UTC)
+	tests := []struct {
+		name  string
+		issue telemetry.Issue
+		want  GateState
+	}{
+		{name: "unknown", issue: telemetry.Issue{PullRequest: &telemetry.PullRequest{Number: 1}}, want: GateUnknown},
+		{name: "unavailable", issue: telemetry.Issue{PullRequest: &telemetry.PullRequest{Number: 1, HydrationUnavailableReason: "rate_limit"}}, want: GateUnavailable},
+		{name: "not applicable", issue: telemetry.Issue{}, want: GateNotApplicable},
+		{name: "pending", issue: telemetry.Issue{PullRequest: &telemetry.PullRequest{Number: 1, CIStatus: "pending"}}, want: GatePending},
+		{name: "failed", issue: telemetry.Issue{PullRequest: &telemetry.PullRequest{Number: 1, RequiredCheckFailures: []telemetry.PullRequestCheck{{Name: "test"}}}}, want: GateFailed},
+		{name: "passed", issue: telemetry.Issue{PullRequest: &telemetry.PullRequest{Number: 1, CIStatus: "success"}}, want: GatePassed},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			issue := tt.issue
+			issue.ID = "issue-1"
+			issue.ProjectID = "detent"
+			reader := &evidenceReader{observation: liveIssueObservation(now, issue)}
+			got, err := newTestService(now, reader).Explain(context.Background(), Query{ProjectID: "detent", IssueID: "issue-1"})
+			if err != nil {
+				t.Fatalf("Explain() error = %v", err)
+			}
+			if got.RequiredGate.State != tt.want {
+				t.Fatalf("required gate = %#v, want %q", got.RequiredGate, tt.want)
+			}
+		})
+	}
+}
+
+func TestServiceDegradesOnlyFailedSection(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 8, 7, 18, 0, 0, 0, time.UTC)
+	reader := &evidenceReader{
+		observation: liveIssueObservation(now, telemetry.Issue{ID: "issue-1", ProjectID: "detent", State: "Rework"}),
+		workflowErr: errors.New("database unavailable"),
+	}
+	got, err := newTestService(now, reader).Explain(context.Background(), Query{ProjectID: "detent", IssueID: "issue-1"})
+	if err != nil {
+		t.Fatalf("Explain() error = %v", err)
+	}
+	if !got.Found || got.CurrentLane.Name != "Rework" || got.LatestTransition != nil {
+		t.Fatalf("partial explanation = %#v, want known lane with unavailable workflow", got)
+	}
+	status := findSourceStatus(got.Sources, "workflow")
+	if status.State != SourceUnavailable || status.Code != "read_failed" {
+		t.Fatalf("workflow status = %#v", status)
+	}
+}
+
+func TestServiceMarksMalformedProvenanceUnknown(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 8, 7, 18, 0, 0, 0, time.UTC)
+	reader := &evidenceReader{
+		observation: liveIssueObservation(now, telemetry.Issue{ID: "issue-1", ProjectID: "detent", State: "Rework"}),
+		workflow:    []store.WorkflowPhaseEvent{{ID: 7, ProjectID: "detent", IssueID: "issue-1", PhaseType: store.WorkflowPhaseTypeLane, PhaseName: "Rework", Status: "entered", StartedAt: now, MetadataJSON: "not-json"}},
+	}
+	got, err := newTestService(now, reader).Explain(context.Background(), Query{ProjectID: "detent", IssueID: "issue-1"})
+	if err != nil {
+		t.Fatalf("Explain() error = %v", err)
+	}
+	if got.LatestTransition == nil || got.LatestTransition.Provenance.State != SourceCorrupt || got.LatestTransition.Provenance.Origin != "unknown" || got.LatestTransition.Actor != nil {
+		t.Fatalf("transition provenance = %#v", got.LatestTransition)
+	}
+}
+
+func TestServiceRejectsAmbiguousIssueIdentity(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 8, 7, 18, 0, 0, 0, time.UTC)
+	reader := &evidenceReader{observation: SnapshotObservation{State: SourceLive, Snapshot: telemetry.Snapshot{
+		GeneratedAt: now,
+		BoardIssues: []telemetry.Issue{
+			{ID: "issue-a", Identifier: "owner/repo#1", Number: 1, ProjectID: "detent"},
+			{ID: "issue-b", Identifier: "owner/repo-renamed#1", Number: 1, ProjectID: "detent"},
+		},
+	}}}
+	_, err := newTestService(now, reader).Explain(context.Background(), Query{ProjectID: "detent", Reference: "#1"})
+	var ambiguous *AmbiguousIdentityError
+	if !errors.As(err, &ambiguous) || ambiguous.Field != "issue_id" || !reflect.DeepEqual(ambiguous.Values, []string{"issue-a", "issue-b"}) {
+		t.Fatalf("Explain() error = %#v, want deterministic issue_id ambiguity", err)
+	}
+}
+
+func TestServiceEvidenceIDsAreDeterministicAndNamespaced(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 8, 7, 18, 0, 0, 0, time.UTC)
+	reader := &evidenceReader{
+		observation: liveIssueObservation(now, telemetry.Issue{ID: "issue-1", ProjectID: "detent", State: "Todo", PullRequest: &telemetry.PullRequest{Number: 42}}),
+		workflow:    []store.WorkflowPhaseEvent{{ID: 8, ProjectID: "detent", IssueID: "issue-1", PhaseType: store.WorkflowPhaseTypeLane, PhaseName: "Todo", Status: "entered", StartedAt: now, MetadataJSON: `{"provenance":{"origin":"routine"}}`}},
+		decisions:   []store.SchedulerDecision{{ID: 9, ProjectID: "detent", IssueID: "issue-1", Result: store.SchedulerDecisionResultSkipped, DecisionAt: now}},
+	}
+	service := newTestService(now, reader)
+	first, err := service.Explain(context.Background(), Query{ProjectID: "detent", IssueID: "issue-1"})
+	if err != nil {
+		t.Fatalf("Explain(first) error = %v", err)
+	}
+	second, err := service.Explain(context.Background(), Query{ProjectID: "detent", IssueID: "issue-1"})
+	if err != nil {
+		t.Fatalf("Explain(second) error = %v", err)
+	}
+	if !reflect.DeepEqual(first.Evidence, second.Evidence) {
+		t.Fatalf("evidence changed: %#v != %#v", first.Evidence, second.Evidence)
+	}
+	for _, evidence := range first.Evidence {
+		if !strings.Contains(evidence.ID, ":") {
+			t.Fatalf("evidence ID is not namespaced: %q", evidence.ID)
+		}
+	}
+}
+
+type evidenceReader struct {
+	observation  SnapshotObservation
+	snapshotErr  error
+	workflow     []store.WorkflowPhaseEvent
+	workflowErr  error
+	active       []store.WorkAttempt
+	activeErr    error
+	terminal     []store.WorkAttempt
+	terminalErr  error
+	decisions    []store.SchedulerDecision
+	decisionsErr error
+	session      *store.IssueAgentSession
+	sessionErr   error
+	proposals    []admissionmodel.Proposal
+	proposalsErr error
+}
+
+func (r *evidenceReader) Snapshot(context.Context) (SnapshotObservation, error) {
+	return r.observation, r.snapshotErr
+}
+
+func (r *evidenceReader) IssueWorkflowTimeline(context.Context, store.IssueIdentity) (store.WorkflowTimeline, error) {
+	return store.WorkflowTimeline{Events: append([]store.WorkflowPhaseEvent(nil), r.workflow...)}, r.workflowErr
+}
+
+func (r *evidenceReader) ListActiveWorkAttempts(context.Context, store.WorkAttemptQuery) ([]store.WorkAttempt, error) {
+	return append([]store.WorkAttempt(nil), r.active...), r.activeErr
+}
+
+func (r *evidenceReader) ListRecentTerminalWorkAttempts(context.Context, store.WorkAttemptHistoryQuery) ([]store.WorkAttempt, error) {
+	return append([]store.WorkAttempt(nil), r.terminal...), r.terminalErr
+}
+
+func (r *evidenceReader) ListIssueSchedulerDecisions(context.Context, store.IssueSchedulerDecisionQuery) ([]store.SchedulerDecision, error) {
+	return append([]store.SchedulerDecision(nil), r.decisions...), r.decisionsErr
+}
+
+func (r *evidenceReader) LatestIssueAgentSession(context.Context, store.IssueIdentity) (store.IssueAgentSession, error) {
+	if r.sessionErr != nil {
+		return store.IssueAgentSession{}, r.sessionErr
+	}
+	if r.session == nil {
+		return store.IssueAgentSession{}, store.ErrNotFound
+	}
+	return *r.session, nil
+}
+
+func (r *evidenceReader) AdmissionProposalHistory(context.Context, string, string) ([]admissionmodel.Proposal, error) {
+	return append([]admissionmodel.Proposal(nil), r.proposals...), r.proposalsErr
+}
+
+func newTestService(now time.Time, reader *evidenceReader) *Service {
+	return New(Dependencies{
+		Snapshots: reader,
+		Workflow:  reader,
+		Attempts:  reader,
+		Scheduler: reader,
+		Sessions:  reader,
+		Admission: reader,
+		Now:       func() time.Time { return now },
+	})
+}
+
+func liveIssueObservation(at time.Time, issue telemetry.Issue) SnapshotObservation {
+	return SnapshotObservation{State: SourceLive, Snapshot: telemetry.Snapshot{GeneratedAt: at, BoardIssues: []telemetry.Issue{issue}}}
+}
+
+func findSourceStatus(statuses []SourceStatus, name string) SourceStatus {
+	for _, status := range statuses {
+		if status.Name == name {
+			return status
+		}
+	}
+	return SourceStatus{}
+}

--- a/internal/explain/service_test.go
+++ b/internal/explain/service_test.go
@@ -242,6 +242,46 @@ func TestServiceAttemptSessionAndGatePrecedence(t *testing.T) {
 	}
 }
 
+func TestServiceActiveAttemptGateFallback(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 8, 7, 18, 0, 0, 0, time.UTC)
+	prNumber := int64(11)
+	tests := []struct {
+		name       string
+		issue      telemetry.Issue
+		wantState  GateState
+		wantSource string
+	}{
+		{name: "snapshot has no pull request", issue: telemetry.Issue{}, wantState: GatePassed, wantSource: "attempt"},
+		{name: "snapshot hydration unavailable", issue: telemetry.Issue{PullRequest: &telemetry.PullRequest{Number: 11, HydrationUnavailableReason: "rate_limit"}}, wantState: GatePassed, wantSource: "attempt"},
+		{name: "snapshot gate unknown", issue: telemetry.Issue{PullRequest: &telemetry.PullRequest{Number: 11}}, wantState: GatePassed, wantSource: "attempt"},
+		{name: "snapshot gate is usable", issue: telemetry.Issue{PullRequest: &telemetry.PullRequest{Number: 11, CIStatus: "pending"}}, wantState: GatePending, wantSource: "snapshot"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			issue := tt.issue
+			issue.ID = "issue-1"
+			issue.ProjectID = "detent"
+			reader := &evidenceReader{
+				observation: liveIssueObservation(now, issue),
+				active: []store.WorkAttempt{{
+					ID: 5, ProjectID: "detent", IssueID: "issue-1", PRNumber: &prNumber,
+					Status: store.WorkAttemptStatusActive, StartedAt: now.Add(-time.Minute), HeartbeatAt: now, CIState: "passed",
+				}},
+			}
+			got, err := newTestService(now, reader).Explain(context.Background(), Query{ProjectID: "detent", IssueID: "issue-1"})
+			if err != nil {
+				t.Fatalf("Explain() error = %v", err)
+			}
+			if got.RequiredGate.State != tt.wantState || got.RequiredGate.Source != tt.wantSource {
+				t.Fatalf("required gate = %#v, want state %q from %q", got.RequiredGate, tt.wantState, tt.wantSource)
+			}
+		})
+	}
+}
+
 func TestServiceDistinguishesRequiredGateStates(t *testing.T) {
 	t.Parallel()
 

--- a/internal/orchestrator/autopromote_integration_test.go
+++ b/internal/orchestrator/autopromote_integration_test.go
@@ -262,7 +262,7 @@ func TestRunAutoPromoteBlocksAfterPersistedReworkLimitSurvivesRestart(t *testing
 				}
 			}
 		case <-deadline:
-			timeline, timelineErr := restartedStore.IssueWorkflowTimeline(ctx, store.IssueIdentity{IssueID: issue.ID})
+			timeline, timelineErr := restartedStore.IssueWorkflowTimeline(ctx, store.IssueIdentity{ProjectID: "detent", IssueID: issue.ID})
 			t.Fatalf(
 				"timed out waiting for Blocked auto-promote events; state_update=%v comment=%v tracker_events=%#v workflow_timeline=%#v workflow_timeline_error=%v",
 				gotStateUpdate,

--- a/internal/orchestrator/autopromote_tick.go
+++ b/internal/orchestrator/autopromote_tick.go
@@ -2538,6 +2538,7 @@ func (o *Orchestrator) autoPromoteReworkLimit(
 	}
 
 	timeline, err := reader.IssueWorkflowTimeline(ctx, store.IssueIdentity{
+		ProjectID:  o.workflowMetricsProjectID(),
 		IssueID:    issue.ID,
 		Identifier: issue.Identifier,
 		IssueURL:   issue.URL,

--- a/internal/orchestrator/blocked_recovery_test.go
+++ b/internal/orchestrator/blocked_recovery_test.go
@@ -327,7 +327,7 @@ func TestObservedStructuredBlockedRecoveryReasonAuthorizesRecovery(t *testing.T)
 	if _, ok := transitioned[after.ID]; !ok {
 		t.Fatalf("transitioned[%q] missing", after.ID)
 	}
-	timeline, err := metrics.IssueWorkflowTimeline(context.Background(), store.IssueIdentity{IssueID: after.ID})
+	timeline, err := metrics.IssueWorkflowTimeline(context.Background(), store.IssueIdentity{ProjectID: defaultWorkflowMetricsProjectID, IssueID: after.ID})
 	if err != nil {
 		t.Fatalf("IssueWorkflowTimeline() error = %v", err)
 	}
@@ -644,6 +644,7 @@ func metricsTimeline(
 	t.Helper()
 
 	timeline, err := metrics.IssueWorkflowTimeline(context.Background(), store.IssueIdentity{
+		ProjectID:  defaultWorkflowMetricsProjectID,
 		IssueID:    issue.ID,
 		Identifier: issue.Identifier,
 		IssueURL:   issue.URL,

--- a/internal/orchestrator/dependency_autounblock.go
+++ b/internal/orchestrator/dependency_autounblock.go
@@ -1079,6 +1079,7 @@ func (o *Orchestrator) issueWorkflowTimeline(ctx context.Context, issue connecto
 		return store.WorkflowTimeline{}, false
 	}
 	timeline, err := reader.IssueWorkflowTimeline(ctx, store.IssueIdentity{
+		ProjectID:  o.workflowMetricsProjectID(),
 		IssueID:    issue.ID,
 		Identifier: issue.Identifier,
 		IssueURL:   issue.URL,

--- a/internal/orchestrator/e2e_test.go
+++ b/internal/orchestrator/e2e_test.go
@@ -134,7 +134,7 @@ func TestMemoryConnectorRunnerE2EGateCreatesBranchDiffStatAndSQLiteTokens(t *tes
 		t.Fatalf("agent-output.txt = %q, want done", got)
 	}
 
-	spend, err := storeBackend.IssueTokenSpend(ctx, store.IssueIdentity{Identifier: issue.Identifier})
+	spend, err := storeBackend.IssueTokenSpend(ctx, store.IssueIdentity{ProjectID: "detent", Identifier: issue.Identifier})
 	if err != nil {
 		t.Fatalf("IssueTokenSpend() error = %v", err)
 	}

--- a/internal/orchestrator/stop_run_integration_test.go
+++ b/internal/orchestrator/stop_run_integration_test.go
@@ -68,7 +68,7 @@ func TestStopRunTargetsOneRunAndBlocksRedispatch(t *testing.T) {
 	if receipt.TerminalState != store.WorkAttemptTerminalOperatorStopped || receipt.Phase != "operator_stop_succeeded" {
 		t.Fatalf("work attempt = %#v, want successful operator stop", receipt)
 	}
-	timeline, err := runtimeStore.IssueWorkflowTimeline(t.Context(), store.IssueIdentity{IssueID: issue.ID})
+	timeline, err := runtimeStore.IssueWorkflowTimeline(t.Context(), store.IssueIdentity{ProjectID: "detent", IssueID: issue.ID})
 	if err != nil {
 		t.Fatalf("IssueWorkflowTimeline() error = %v", err)
 	}
@@ -233,7 +233,7 @@ func TestStopRunAppliesTodoPriorityBeforeRedispatch(t *testing.T) {
 		t.Fatalf("tracker operations = %#v, want first priority before first state", operations)
 	}
 	waitForOperatorStopRunnerIssue(t, runner.started, issue.ID)
-	timeline, err := runtimeStore.IssueWorkflowTimeline(t.Context(), store.IssueIdentity{IssueID: issue.ID})
+	timeline, err := runtimeStore.IssueWorkflowTimeline(t.Context(), store.IssueIdentity{ProjectID: "detent", IssueID: issue.ID})
 	if err != nil {
 		t.Fatalf("IssueWorkflowTimeline() error = %v", err)
 	}

--- a/internal/orchestrator/work_attempt_recovery.go
+++ b/internal/orchestrator/work_attempt_recovery.go
@@ -376,6 +376,7 @@ func (o *Orchestrator) latestWorkAttemptResumeState(ctx context.Context, attempt
 		return nil, false
 	}
 	state, err := o.agentResume.LatestIssueAgentResumeState(ctx, store.IssueIdentity{
+		ProjectID:  attempt.ProjectID,
 		IssueID:    attempt.IssueID,
 		Identifier: attempt.Identifier,
 		IssueURL:   attempt.IssueURL,

--- a/internal/orchestrator/work_attempt_recovery_test.go
+++ b/internal/orchestrator/work_attempt_recovery_test.go
@@ -106,6 +106,7 @@ func TestHandleWorkAttemptRecoveryQueuesResumeRetryWhenEligible(t *testing.T) {
 	issue := recoveryTestIssue()
 	attemptID := startRecoveryWorkAttempt(t, ctx, runtimeStore, issue, store.WorkAttemptStatusTerminal, store.WorkAttemptTerminalFailure, now.Add(-10*time.Minute))
 	sessionID, err := runtimeStore.StartSession(ctx, store.SessionStart{
+		ProjectID:        "detent",
 		IssueID:          issue.ID,
 		Identifier:       issue.Identifier,
 		IssueURL:         issue.URL,
@@ -279,7 +280,7 @@ func recoveryTimelineEvent(
 ) store.WorkflowPhaseEvent {
 	t.Helper()
 
-	timeline, err := runtimeStore.IssueWorkflowTimeline(ctx, store.IssueIdentity{IssueID: issueID})
+	timeline, err := runtimeStore.IssueWorkflowTimeline(ctx, store.IssueIdentity{ProjectID: "detent", IssueID: issueID})
 	if err != nil {
 		t.Fatalf("IssueWorkflowTimeline() error = %v", err)
 	}

--- a/internal/orchestrator/workflow_metrics_test.go
+++ b/internal/orchestrator/workflow_metrics_test.go
@@ -281,7 +281,7 @@ func TestRefreshCurrentLaneEntriesPersistsPollObservationAcrossRestart(t *testin
 	orch := &Orchestrator{cfg: normalizeConfig(Config{}), workflowMetrics: backend}
 	orch.refreshCurrentLaneEntries(ctx, &state, enteredAt)
 
-	timeline, err := backend.IssueWorkflowTimeline(ctx, store.IssueIdentity{IssueID: "issue-1162"})
+	timeline, err := backend.IssueWorkflowTimeline(ctx, store.IssueIdentity{ProjectID: defaultWorkflowMetricsProjectID, IssueID: "issue-1162"})
 	if err != nil {
 		t.Fatalf("IssueWorkflowTimeline() error = %v", err)
 	}
@@ -353,7 +353,7 @@ func TestRefreshCurrentLaneEntriesUsesTrackerTransitionAcrossPollsAndRestart(t *
 	if got := first.BoardIssues[0].Origin; got != string(provenance.OriginHuman) {
 		t.Fatalf("first Origin = %q, want %q", got, provenance.OriginHuman)
 	}
-	timeline, err := backend.IssueWorkflowTimeline(ctx, store.IssueIdentity{IssueID: "issue-1162"})
+	timeline, err := backend.IssueWorkflowTimeline(ctx, store.IssueIdentity{ProjectID: defaultWorkflowMetricsProjectID, IssueID: "issue-1162"})
 	if err != nil {
 		t.Fatalf("IssueWorkflowTimeline() error = %v", err)
 	}
@@ -423,13 +423,14 @@ func TestRefreshCurrentLaneEntriesSurvivesStoreRestart(t *testing.T) {
 			t.Fatalf("store.Open(restart %d) error = %v", index+1, err)
 		}
 
-		state := newState(normalizeConfig(Config{}))
+		cfg := normalizeConfig(Config{Project: scheduler.ProjectCandidate{ID: "detent"}})
+		state := newState(cfg)
 		state.BoardIssues = []connector.Issue{{
 			ID:        "issue-1130",
 			State:     "In Progress",
 			UpdatedAt: &updatedAt,
 		}}
-		orch := &Orchestrator{workflowMetrics: backend}
+		orch := &Orchestrator{cfg: cfg, workflowMetrics: backend}
 		orch.refreshCurrentLaneEntries(ctx, &state, updatedAt)
 		snapshot := state.Snapshot(updatedAt.Add(time.Minute))
 		if snapshot.BoardIssues[0].CurrentLaneEnteredAt == nil || !snapshot.BoardIssues[0].CurrentLaneEnteredAt.Equal(enteredAt) {

--- a/internal/runner/agent.go
+++ b/internal/runner/agent.go
@@ -292,6 +292,7 @@ func (r *Runner) IssueBudgetStatus(ctx context.Context, issue connector.Issue) (
 	}
 
 	status, err := provider.IssueStatus(ctx, store.IssueIdentity{
+		ProjectID:  r.projectID,
 		IssueID:    issue.ID,
 		Identifier: issue.Identifier,
 		IssueURL:   issue.URL,

--- a/internal/store/activity.go
+++ b/internal/store/activity.go
@@ -70,11 +70,15 @@ func (s *sqliteStore) ListIssueActivity(ctx context.Context, query IssueActivity
 
 func (s *sqliteStore) LatestIssueAgentSession(ctx context.Context, identity IssueIdentity) (IssueAgentSession, error) {
 	identity = normalizeIssueIdentity(identity)
+	if identity.ProjectID == "" {
+		return IssueAgentSession{}, ErrProjectRequired
+	}
 	if identity.IssueID == "" && identity.Identifier == "" && identity.IssueURL == "" {
 		return IssueAgentSession{}, ErrNotFound
 	}
 
 	row, err := s.queries.GetLatestIssueAgentSession(ctx, sqlc.GetLatestIssueAgentSessionParams{
+		ProjectID:  nullString(identity.ProjectID),
 		IssueID:    identity.IssueID,
 		Identifier: identity.Identifier,
 		IssueURL:   identity.IssueURL,
@@ -90,6 +94,7 @@ func (s *sqliteStore) LatestIssueAgentSession(ctx context.Context, identity Issu
 		return IssueAgentSession{}, err
 	}
 	return IssueAgentSession{
+		ProjectID:         strings.TrimSpace(row.ProjectID),
 		DetentSessionID:   row.ID,
 		ProviderThreadID:  strings.TrimSpace(row.ProviderThreadID),
 		ProviderSessionID: strings.TrimSpace(row.ProviderSessionID),

--- a/internal/store/activity_test.go
+++ b/internal/store/activity_test.go
@@ -146,6 +146,7 @@ func TestLatestIssueAgentSessionIncludesTerminalFailures(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			issueID := "issue-history-" + tt.name
 			sessionID, err := backend.StartSession(ctx, SessionStart{
+				ProjectID:        "detent",
 				IssueID:          issueID,
 				Identifier:       "digitaldrywood/detent#" + tt.name,
 				StartedAt:        base.Add(time.Duration(index) * time.Minute),
@@ -162,7 +163,7 @@ func TestLatestIssueAgentSessionIncludesTerminalFailures(t *testing.T) {
 				t.Fatalf("FinishSession() error = %v", err)
 			}
 
-			got, err := backend.(ActivityStore).LatestIssueAgentSession(ctx, IssueIdentity{IssueID: issueID})
+			got, err := backend.(ActivityStore).LatestIssueAgentSession(ctx, IssueIdentity{ProjectID: "detent", IssueID: issueID})
 			if err != nil {
 				t.Fatalf("LatestIssueAgentSession() error = %v", err)
 			}

--- a/internal/store/admission_test.go
+++ b/internal/store/admission_test.go
@@ -247,7 +247,7 @@ func TestAdmissionAcceptanceAttributionAndDownstreamOutcomes(t *testing.T) {
 		!got.TransitionAt.Equal(transitionAt) {
 		t.Fatalf("accepted proposal = %#v", got)
 	}
-	timeline, err := backend.IssueWorkflowTimeline(ctx, IssueIdentity{IssueID: proposal.IssueID})
+	timeline, err := backend.IssueWorkflowTimeline(ctx, IssueIdentity{ProjectID: proposal.ProjectID, IssueID: proposal.IssueID})
 	if err != nil {
 		t.Fatalf("IssueWorkflowTimeline() error = %v", err)
 	}

--- a/internal/store/issue_identity_test.go
+++ b/internal/store/issue_identity_test.go
@@ -1,0 +1,114 @@
+package store
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+)
+
+func TestIssueIdentityReadsAreProjectScoped(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	backend := openTestStore(t, ctx)
+	base := time.Date(2026, 8, 7, 18, 0, 0, 0, time.UTC)
+	for index, projectID := range []string{"project-a", "project-b"} {
+		at := base.Add(time.Duration(index) * time.Minute)
+		if _, err := backend.RecordWorkflowPhaseEvent(ctx, WorkflowPhaseEvent{
+			ProjectID:    projectID,
+			IssueID:      "same-id",
+			Identifier:   "owner/repo#1",
+			PhaseType:    WorkflowPhaseTypeLane,
+			PhaseName:    projectID,
+			Status:       "entered",
+			StartedAt:    at,
+			MetadataJSON: `{"provenance":{"origin":"unknown"}}`,
+		}); err != nil {
+			t.Fatalf("RecordWorkflowPhaseEvent(%s) error = %v", projectID, err)
+		}
+		if _, err := backend.RecordSchedulerDecision(ctx, SchedulerDecision{
+			ProjectID:  projectID,
+			IssueID:    "same-id",
+			Result:     SchedulerDecisionResultSkipped,
+			Reason:     projectID,
+			DecisionAt: at,
+		}); err != nil {
+			t.Fatalf("RecordSchedulerDecision(%s) error = %v", projectID, err)
+		}
+		sessionID, err := backend.StartSession(ctx, SessionStart{
+			ProjectID:        projectID,
+			IssueID:          "same-id",
+			Identifier:       "owner/repo#1",
+			StartedAt:        at,
+			AgentBackendKind: "codex",
+		})
+		if err != nil {
+			t.Fatalf("StartSession(%s) error = %v", projectID, err)
+		}
+		if err := backend.FinishSession(ctx, sessionID, SessionFinish{
+			CompletedAt:       at.Add(30 * time.Second),
+			FinalState:        "completed",
+			ProviderSessionID: projectID + "-provider",
+			InputTokens:       int64((index + 1) * 100),
+			TotalTokens:       int64((index + 1) * 100),
+		}); err != nil {
+			t.Fatalf("FinishSession(%s) error = %v", projectID, err)
+		}
+	}
+
+	identity := IssueIdentity{ProjectID: "project-a", IssueID: "same-id"}
+	timeline, err := backend.IssueWorkflowTimeline(ctx, identity)
+	if err != nil || len(timeline.Events) != 1 || timeline.Events[0].ProjectID != "project-a" {
+		t.Fatalf("IssueWorkflowTimeline() = %#v, %v", timeline, err)
+	}
+	decisions, err := backend.(IssueSchedulerDecisionStore).ListIssueSchedulerDecisions(ctx, IssueSchedulerDecisionQuery{Identity: identity})
+	if err != nil || len(decisions) != 1 || decisions[0].ProjectID != "project-a" {
+		t.Fatalf("ListIssueSchedulerDecisions() = %#v, %v", decisions, err)
+	}
+	session, err := backend.(ActivityStore).LatestIssueAgentSession(ctx, identity)
+	if err != nil || session.ProjectID != "project-a" || session.ProviderSessionID != "project-a-provider" {
+		t.Fatalf("LatestIssueAgentSession() = %#v, %v", session, err)
+	}
+	spend, err := backend.IssueTokenSpend(ctx, identity)
+	if err != nil || spend.TotalTokens != 100 || spend.Sessions != 1 {
+		t.Fatalf("IssueTokenSpend() = %#v, %v", spend, err)
+	}
+}
+
+func TestIssueIdentityReadsRequireProject(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	backend := openTestStore(t, ctx)
+	tests := []struct {
+		name string
+		read func() error
+	}{
+		{name: "workflow", read: func() error {
+			_, err := backend.IssueWorkflowTimeline(ctx, IssueIdentity{IssueID: "issue-1"})
+			return err
+		}},
+		{name: "scheduler", read: func() error {
+			_, err := backend.(IssueSchedulerDecisionStore).ListIssueSchedulerDecisions(ctx, IssueSchedulerDecisionQuery{Identity: IssueIdentity{IssueID: "issue-1"}})
+			return err
+		}},
+		{name: "session", read: func() error {
+			_, err := backend.(ActivityStore).LatestIssueAgentSession(ctx, IssueIdentity{IssueID: "issue-1"})
+			return err
+		}},
+		{name: "resume", read: func() error {
+			_, err := backend.LatestIssueAgentResumeState(ctx, IssueIdentity{IssueID: "issue-1"})
+			return err
+		}},
+		{name: "spend", read: func() error { _, err := backend.IssueTokenSpend(ctx, IssueIdentity{IssueID: "issue-1"}); return err }},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if err := tt.read(); !errors.Is(err, ErrProjectRequired) {
+				t.Fatalf("read error = %v, want ErrProjectRequired", err)
+			}
+		})
+	}
+}

--- a/internal/store/metrics.go
+++ b/internal/store/metrics.go
@@ -132,11 +132,15 @@ func (s *sqliteStore) WorkflowMetricsReport(ctx context.Context, query WorkflowM
 
 func (s *sqliteStore) IssueWorkflowTimeline(ctx context.Context, identity IssueIdentity) (WorkflowTimeline, error) {
 	identity = normalizeIssueIdentity(identity)
+	if identity.ProjectID == "" {
+		return WorkflowTimeline{}, ErrProjectRequired
+	}
 	if identity.IssueID == "" && identity.Identifier == "" && identity.IssueURL == "" {
 		return WorkflowTimeline{Events: []WorkflowPhaseEvent{}}, nil
 	}
 
 	rows, err := s.queries.IssueWorkflowTimelineRows(ctx, sqlc.IssueWorkflowTimelineRowsParams{
+		ProjectID:  identity.ProjectID,
 		IssueID:    nullString(identity.IssueID),
 		Identifier: nullString(identity.Identifier),
 		IssueURL:   nullString(identity.IssueURL),

--- a/internal/store/sqlc/store.sql.go
+++ b/internal/store/sqlc/store.sql.go
@@ -1719,6 +1719,7 @@ func (q *Queries) GetLatestCompletedAgentResumeState(ctx context.Context, arg Ge
 const getLatestIssueAgentResumeState = `-- name: GetLatestIssueAgentResumeState :one
 SELECT
   id,
+  CAST(COALESCE(project_id, '') AS TEXT) AS project_id,
   CAST(COALESCE(provider_thread_id, '') AS TEXT) AS provider_thread_id,
   CAST(COALESCE(provider_session_id, '') AS TEXT) AS provider_session_id,
   CAST(COALESCE(requested_model, '') AS TEXT) AS requested_model,
@@ -1730,24 +1731,27 @@ SELECT
 FROM codex_sessions
 WHERE completed_at IS NOT NULL
   AND lower(trim(COALESCE(final_state, ''))) = 'completed'
+  AND COALESCE(project_id, '') = ?1
   AND (COALESCE(provider_thread_id, '') != '' OR COALESCE(provider_session_id, '') != '')
   AND (
-    (?1 != '' AND COALESCE(issue_id, '') = ?1)
-    OR (?2 != '' AND COALESCE(identifier, '') = ?2)
-    OR (?3 != '' AND COALESCE(issue_url, '') = ?3)
+    (?2 != '' AND COALESCE(issue_id, '') = ?2)
+    OR (?3 != '' AND COALESCE(identifier, '') = ?3)
+    OR (?4 != '' AND COALESCE(issue_url, '') = ?4)
   )
 ORDER BY completed_at DESC, id DESC
 LIMIT 1
 `
 
 type GetLatestIssueAgentResumeStateParams struct {
-	IssueID    interface{} `json:"issue_id"`
-	Identifier interface{} `json:"identifier"`
-	IssueURL   interface{} `json:"issue_url"`
+	ProjectID  sql.NullString `json:"project_id"`
+	IssueID    interface{}    `json:"issue_id"`
+	Identifier interface{}    `json:"identifier"`
+	IssueURL   interface{}    `json:"issue_url"`
 }
 
 type GetLatestIssueAgentResumeStateRow struct {
 	ID                int64  `json:"id"`
+	ProjectID         string `json:"project_id"`
 	ProviderThreadID  string `json:"provider_thread_id"`
 	ProviderSessionID string `json:"provider_session_id"`
 	RequestedModel    string `json:"requested_model"`
@@ -1759,10 +1763,16 @@ type GetLatestIssueAgentResumeStateRow struct {
 }
 
 func (q *Queries) GetLatestIssueAgentResumeState(ctx context.Context, arg GetLatestIssueAgentResumeStateParams) (GetLatestIssueAgentResumeStateRow, error) {
-	row := q.db.QueryRowContext(ctx, getLatestIssueAgentResumeState, arg.IssueID, arg.Identifier, arg.IssueURL)
+	row := q.db.QueryRowContext(ctx, getLatestIssueAgentResumeState,
+		arg.ProjectID,
+		arg.IssueID,
+		arg.Identifier,
+		arg.IssueURL,
+	)
 	var i GetLatestIssueAgentResumeStateRow
 	err := row.Scan(
 		&i.ID,
+		&i.ProjectID,
 		&i.ProviderThreadID,
 		&i.ProviderSessionID,
 		&i.RequestedModel,
@@ -1778,30 +1788,34 @@ func (q *Queries) GetLatestIssueAgentResumeState(ctx context.Context, arg GetLat
 const getLatestIssueAgentSession = `-- name: GetLatestIssueAgentSession :one
 SELECT
   id,
+  CAST(COALESCE(project_id, '') AS TEXT) AS project_id,
   CAST(COALESCE(provider_thread_id, '') AS TEXT) AS provider_thread_id,
   CAST(COALESCE(provider_session_id, '') AS TEXT) AS provider_session_id,
   CAST(COALESCE(agent_backend_kind, '') AS TEXT) AS agent_backend_kind,
   CAST(completed_at AS TEXT) AS completed_at
 FROM codex_sessions
 WHERE completed_at IS NOT NULL
+  AND COALESCE(project_id, '') = ?1
   AND (COALESCE(provider_thread_id, '') != '' OR COALESCE(provider_session_id, '') != '')
   AND (
-    (?1 != '' AND COALESCE(issue_id, '') = ?1)
-    OR (?2 != '' AND COALESCE(identifier, '') = ?2)
-    OR (?3 != '' AND COALESCE(issue_url, '') = ?3)
+    (?2 != '' AND COALESCE(issue_id, '') = ?2)
+    OR (?3 != '' AND COALESCE(identifier, '') = ?3)
+    OR (?4 != '' AND COALESCE(issue_url, '') = ?4)
   )
 ORDER BY completed_at DESC, id DESC
 LIMIT 1
 `
 
 type GetLatestIssueAgentSessionParams struct {
-	IssueID    interface{} `json:"issue_id"`
-	Identifier interface{} `json:"identifier"`
-	IssueURL   interface{} `json:"issue_url"`
+	ProjectID  sql.NullString `json:"project_id"`
+	IssueID    interface{}    `json:"issue_id"`
+	Identifier interface{}    `json:"identifier"`
+	IssueURL   interface{}    `json:"issue_url"`
 }
 
 type GetLatestIssueAgentSessionRow struct {
 	ID                int64  `json:"id"`
+	ProjectID         string `json:"project_id"`
 	ProviderThreadID  string `json:"provider_thread_id"`
 	ProviderSessionID string `json:"provider_session_id"`
 	AgentBackendKind  string `json:"agent_backend_kind"`
@@ -1809,10 +1823,16 @@ type GetLatestIssueAgentSessionRow struct {
 }
 
 func (q *Queries) GetLatestIssueAgentSession(ctx context.Context, arg GetLatestIssueAgentSessionParams) (GetLatestIssueAgentSessionRow, error) {
-	row := q.db.QueryRowContext(ctx, getLatestIssueAgentSession, arg.IssueID, arg.Identifier, arg.IssueURL)
+	row := q.db.QueryRowContext(ctx, getLatestIssueAgentSession,
+		arg.ProjectID,
+		arg.IssueID,
+		arg.Identifier,
+		arg.IssueURL,
+	)
 	var i GetLatestIssueAgentSessionRow
 	err := row.Scan(
 		&i.ID,
+		&i.ProjectID,
 		&i.ProviderThreadID,
 		&i.ProviderSessionID,
 		&i.AgentBackendKind,
@@ -2026,14 +2046,18 @@ SELECT
   CAST(COALESCE(SUM(total_tokens), 0) AS INTEGER) AS total_tokens,
   CAST(COUNT(*) AS INTEGER) AS sessions
 FROM codex_sessions
-WHERE issue_id = ?1
-   OR identifier = ?2
-   OR issue_url = ?3
+WHERE COALESCE(project_id, '') = ?1
+  AND (
+    issue_id = ?2
+    OR identifier = ?3
+    OR issue_url = ?4
+  )
 GROUP BY COALESCE(NULLIF(model, ''), NULLIF(requested_model, ''), '')
 ORDER BY COALESCE(NULLIF(model, ''), NULLIF(requested_model, ''), '')
 `
 
 type IssueTokenSpendParams struct {
+	ProjectID  sql.NullString `json:"project_id"`
 	IssueID    sql.NullString `json:"issue_id"`
 	Identifier sql.NullString `json:"identifier"`
 	IssueURL   sql.NullString `json:"issue_url"`
@@ -2050,7 +2074,12 @@ type IssueTokenSpendRow struct {
 }
 
 func (q *Queries) IssueTokenSpend(ctx context.Context, arg IssueTokenSpendParams) ([]IssueTokenSpendRow, error) {
-	rows, err := q.db.QueryContext(ctx, issueTokenSpend, arg.IssueID, arg.Identifier, arg.IssueURL)
+	rows, err := q.db.QueryContext(ctx, issueTokenSpend,
+		arg.ProjectID,
+		arg.IssueID,
+		arg.Identifier,
+		arg.IssueURL,
+	)
 	if err != nil {
 		return nil, err
 	}
@@ -2083,20 +2112,29 @@ func (q *Queries) IssueTokenSpend(ctx context.Context, arg IssueTokenSpendParams
 const issueWorkflowTimelineRows = `-- name: IssueWorkflowTimelineRows :many
 SELECT id, project_id, run_id, session_id, issue_id, identifier, issue_url, pr_number, phase_type, phase_name, previous_phase_name, reason, status, started_at, finished_at, duration_seconds, event_day, command_name, exit_code, turns, input_tokens, output_tokens, total_tokens, endpoint_family, metadata_json, cached_input_tokens, reasoning_output_tokens, model_context_window
 FROM workflow_phase_events
-WHERE issue_id = ?1
-   OR identifier = ?2
-   OR issue_url = ?3
+WHERE project_id = ?1
+  AND (
+    issue_id = ?2
+    OR identifier = ?3
+    OR issue_url = ?4
+  )
 ORDER BY started_at, id
 `
 
 type IssueWorkflowTimelineRowsParams struct {
+	ProjectID  string         `json:"project_id"`
 	IssueID    sql.NullString `json:"issue_id"`
 	Identifier sql.NullString `json:"identifier"`
 	IssueURL   sql.NullString `json:"issue_url"`
 }
 
 func (q *Queries) IssueWorkflowTimelineRows(ctx context.Context, arg IssueWorkflowTimelineRowsParams) ([]WorkflowPhaseEvent, error) {
-	rows, err := q.db.QueryContext(ctx, issueWorkflowTimelineRows, arg.IssueID, arg.Identifier, arg.IssueURL)
+	rows, err := q.db.QueryContext(ctx, issueWorkflowTimelineRows,
+		arg.ProjectID,
+		arg.IssueID,
+		arg.Identifier,
+		arg.IssueURL,
+	)
 	if err != nil {
 		return nil, err
 	}
@@ -2740,6 +2778,77 @@ func (q *Queries) ListIssueActivityEvents(ctx context.Context, arg ListIssueActi
 			&i.Turns,
 			&i.TotalTokens,
 			&i.Verbose,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+const listIssueSchedulerDecisions = `-- name: ListIssueSchedulerDecisions :many
+SELECT id, project_id, issue_id, identifier, issue_url, pr_number, repo, lane, queue_position, result, reason, selected, retry, attempt_number, worker_host, decision_at, wait_reason, capacity_snapshot_json, github_rate_snapshot_json, metadata_json
+FROM scheduler_decisions
+WHERE project_id = ?1
+  AND (
+    (?2 != '' AND issue_id = ?2)
+    OR (?3 != '' AND identifier = ?3)
+    OR (?4 != '' AND issue_url = ?4)
+  )
+ORDER BY decision_at DESC, id DESC
+LIMIT ?5
+`
+
+type ListIssueSchedulerDecisionsParams struct {
+	ProjectID  string      `json:"project_id"`
+	IssueID    interface{} `json:"issue_id"`
+	Identifier interface{} `json:"identifier"`
+	IssueURL   interface{} `json:"issue_url"`
+	Limit      int64       `json:"limit"`
+}
+
+func (q *Queries) ListIssueSchedulerDecisions(ctx context.Context, arg ListIssueSchedulerDecisionsParams) ([]SchedulerDecision, error) {
+	rows, err := q.db.QueryContext(ctx, listIssueSchedulerDecisions,
+		arg.ProjectID,
+		arg.IssueID,
+		arg.Identifier,
+		arg.IssueURL,
+		arg.Limit,
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []SchedulerDecision{}
+	for rows.Next() {
+		var i SchedulerDecision
+		if err := rows.Scan(
+			&i.ID,
+			&i.ProjectID,
+			&i.IssueID,
+			&i.Identifier,
+			&i.IssueURL,
+			&i.PrNumber,
+			&i.Repo,
+			&i.Lane,
+			&i.QueuePosition,
+			&i.Result,
+			&i.Reason,
+			&i.Selected,
+			&i.Retry,
+			&i.AttemptNumber,
+			&i.WorkerHost,
+			&i.DecisionAt,
+			&i.WaitReason,
+			&i.CapacitySnapshotJson,
+			&i.GithubRateSnapshotJson,
+			&i.MetadataJson,
 		); err != nil {
 			return nil, err
 		}

--- a/internal/store/sqlite.go
+++ b/internal/store/sqlite.go
@@ -449,11 +449,15 @@ func (s *sqliteStore) LatestCompletedAgentResumeState(ctx context.Context, attrs
 
 func (s *sqliteStore) LatestIssueAgentResumeState(ctx context.Context, identity IssueIdentity) (AgentResumeState, error) {
 	identity = normalizeIssueIdentity(identity)
+	if identity.ProjectID == "" {
+		return AgentResumeState{}, ErrProjectRequired
+	}
 	if identity.IssueID == "" && identity.Identifier == "" && identity.IssueURL == "" {
 		return AgentResumeState{}, ErrNotFound
 	}
 
 	row, err := s.queries.GetLatestIssueAgentResumeState(ctx, sqlc.GetLatestIssueAgentResumeStateParams{
+		ProjectID:  nullString(identity.ProjectID),
 		IssueID:    identity.IssueID,
 		Identifier: identity.Identifier,
 		IssueURL:   identity.IssueURL,
@@ -984,11 +988,15 @@ func (s *sqliteStore) BackfillSessionProjectIDs(ctx context.Context, attribution
 
 func (s *sqliteStore) IssueTokenSpend(ctx context.Context, identity IssueIdentity) (TokenSpend, error) {
 	identity = normalizeIssueIdentity(identity)
+	if identity.ProjectID == "" {
+		return TokenSpend{}, ErrProjectRequired
+	}
 	if identity.IssueID == "" && identity.Identifier == "" && identity.IssueURL == "" {
 		return TokenSpend{ByModel: []ModelTokenSpend{}}, nil
 	}
 
 	rows, err := s.queries.IssueTokenSpend(ctx, sqlc.IssueTokenSpendParams{
+		ProjectID:  nullString(identity.ProjectID),
 		IssueID:    nullString(identity.IssueID),
 		Identifier: nullString(identity.Identifier),
 		IssueURL:   nullString(identity.IssueURL),
@@ -1136,6 +1144,7 @@ func (s *sqliteStore) RecordFairShareDispatch(ctx context.Context, attrs FairSha
 
 func normalizeIssueIdentity(identity IssueIdentity) IssueIdentity {
 	return IssueIdentity{
+		ProjectID:  strings.TrimSpace(identity.ProjectID),
 		IssueID:    strings.TrimSpace(identity.IssueID),
 		Identifier: strings.TrimSpace(identity.Identifier),
 		IssueURL:   strings.TrimSpace(identity.IssueURL),

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -32,7 +32,10 @@ const (
 
 const defaultBusyTimeout = 5 * time.Second
 
-var ErrNotFound = errors.New("store record not found")
+var (
+	ErrNotFound        = errors.New("store record not found")
+	ErrProjectRequired = errors.New("project_id is required")
+)
 
 type Config struct {
 	Backend     Backend
@@ -142,6 +145,10 @@ type WorkAttemptStore interface {
 	ReclaimActiveWorkAttempts(context.Context, WorkAttemptReclaim) ([]WorkAttempt, error)
 	RecordSchedulerDecision(context.Context, SchedulerDecision) (int64, error)
 	ListRecentSchedulerDecisions(context.Context, SchedulerDecisionQuery) ([]SchedulerDecision, error)
+}
+
+type IssueSchedulerDecisionStore interface {
+	ListIssueSchedulerDecisions(context.Context, IssueSchedulerDecisionQuery) ([]SchedulerDecision, error)
 }
 
 type WorkAttemptCapacityReleaseStore interface {
@@ -710,6 +717,11 @@ type SchedulerDecisionQuery struct {
 	Limit     int
 }
 
+type IssueSchedulerDecisionQuery struct {
+	Identity IssueIdentity
+	Limit    int
+}
+
 type WorkflowMetricsQuery struct {
 	ProjectID string
 	From      time.Time
@@ -855,6 +867,7 @@ type CycleTimeBucket struct {
 }
 
 type IssueIdentity struct {
+	ProjectID  string
 	IssueID    string
 	Identifier string
 	IssueURL   string
@@ -888,6 +901,7 @@ type IssueActivityEvent struct {
 }
 
 type IssueAgentSession struct {
+	ProjectID         string
 	DetentSessionID   int64
 	ProviderThreadID  string
 	ProviderSessionID string

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -909,6 +909,7 @@ func TestStatsStoreRoundTrip(t *testing.T) {
 
 			sessionID, err := backend.StartSession(ctx, SessionStart{
 				RunID:      runID,
+				ProjectID:  "detent",
 				IssueID:    "I_kwDOSskuwc8AAAABD42c3Q",
 				Identifier: "digitaldrywood/detent#6",
 				IssueURL:   "https://github.com/digitaldrywood/detent/issues/6",
@@ -1004,7 +1005,7 @@ func TestStatsStoreRoundTrip(t *testing.T) {
 				t.Fatalf("DailyTokenSpend().ByModel = %#v", spend.ByModel)
 			}
 
-			issueSpend, err := backend.IssueTokenSpend(ctx, IssueIdentity{IssueID: "I_kwDOSskuwc8AAAABD42c3Q"})
+			issueSpend, err := backend.IssueTokenSpend(ctx, IssueIdentity{ProjectID: "detent", IssueID: "I_kwDOSskuwc8AAAABD42c3Q"})
 			if err != nil {
 				t.Fatalf("IssueTokenSpend() error = %v", err)
 			}
@@ -1015,7 +1016,7 @@ func TestStatsStoreRoundTrip(t *testing.T) {
 				t.Fatalf("IssueTokenSpend().ByModel = %#v", issueSpend.ByModel)
 			}
 
-			identifierSpend, err := backend.IssueTokenSpend(ctx, IssueIdentity{Identifier: "digitaldrywood/detent#6"})
+			identifierSpend, err := backend.IssueTokenSpend(ctx, IssueIdentity{ProjectID: "detent", Identifier: "digitaldrywood/detent#6"})
 			if err != nil {
 				t.Fatalf("IssueTokenSpend(identifier) error = %v", err)
 			}
@@ -1023,7 +1024,7 @@ func TestStatsStoreRoundTrip(t *testing.T) {
 				t.Fatalf("IssueTokenSpend(identifier).TotalTokens = %d, want 125", identifierSpend.TotalTokens)
 			}
 
-			urlSpend, err := backend.IssueTokenSpend(ctx, IssueIdentity{IssueURL: "https://github.com/digitaldrywood/detent/issues/6"})
+			urlSpend, err := backend.IssueTokenSpend(ctx, IssueIdentity{ProjectID: "detent", IssueURL: "https://github.com/digitaldrywood/detent/issues/6"})
 			if err != nil {
 				t.Fatalf("IssueTokenSpend(url) error = %v", err)
 			}
@@ -1229,6 +1230,7 @@ func TestLatestCompletedAgentResumeStateMatchesIssueBackendAndModel(t *testing.T
 	backend := openTestStore(t, ctx)
 	startedAt := time.Date(2026, 7, 2, 17, 0, 0, 0, time.UTC)
 	failedID, err := backend.StartSession(ctx, SessionStart{
+		ProjectID:        "detent",
 		IssueID:          "issue-859",
 		Identifier:       "digitaldrywood/detent#859",
 		IssueURL:         "https://github.com/digitaldrywood/detent/issues/859",
@@ -1253,6 +1255,7 @@ func TestLatestCompletedAgentResumeStateMatchesIssueBackendAndModel(t *testing.T
 	}
 
 	firstID, err := backend.StartSession(ctx, SessionStart{
+		ProjectID:        "detent",
 		IssueID:          "issue-859",
 		Identifier:       "digitaldrywood/detent#859",
 		IssueURL:         "https://github.com/digitaldrywood/detent/issues/859",
@@ -1277,6 +1280,7 @@ func TestLatestCompletedAgentResumeStateMatchesIssueBackendAndModel(t *testing.T
 	}
 
 	secondID, err := backend.StartSession(ctx, SessionStart{
+		ProjectID:        "detent",
 		IssueID:          "issue-859",
 		Identifier:       "digitaldrywood/detent#859",
 		IssueURL:         "https://github.com/digitaldrywood/detent/issues/859",
@@ -1302,6 +1306,7 @@ func TestLatestCompletedAgentResumeStateMatchesIssueBackendAndModel(t *testing.T
 	}
 
 	validatorID, err := backend.StartSession(ctx, SessionStart{
+		ProjectID:        "detent",
 		IssueID:          "issue-859",
 		Identifier:       "digitaldrywood/detent#859",
 		IssueURL:         "https://github.com/digitaldrywood/detent/issues/859",
@@ -1344,6 +1349,7 @@ func TestLatestCompletedAgentResumeStateMatchesIssueBackendAndModel(t *testing.T
 		t.Fatalf("resume models = %#v, want requested and resolved model", got)
 	}
 	latestForIssue, err := backend.LatestIssueAgentResumeState(ctx, IssueIdentity{
+		ProjectID:  "detent",
 		Identifier: "digitaldrywood/detent#859",
 	})
 	if err != nil {
@@ -1994,7 +2000,7 @@ func TestWorkflowMetricsStoreRoundTripAndAggregates(t *testing.T) {
 		t.Fatalf("subphase metric = %#v, want 480s agent_active", subphase)
 	}
 
-	timeline, err := backend.IssueWorkflowTimeline(ctx, IssueIdentity{Identifier: "digitaldrywood/detent#722"})
+	timeline, err := backend.IssueWorkflowTimeline(ctx, IssueIdentity{ProjectID: "detent", Identifier: "digitaldrywood/detent#722"})
 	if err != nil {
 		t.Fatalf("IssueWorkflowTimeline() error = %v", err)
 	}

--- a/internal/store/work_attempts.go
+++ b/internal/store/work_attempts.go
@@ -418,6 +418,39 @@ func (s *sqliteStore) ListRecentSchedulerDecisions(ctx context.Context, query Sc
 	return decisions, nil
 }
 
+func (s *sqliteStore) ListIssueSchedulerDecisions(ctx context.Context, query IssueSchedulerDecisionQuery) ([]SchedulerDecision, error) {
+	identity := normalizeIssueIdentity(query.Identity)
+	if identity.ProjectID == "" {
+		return nil, ErrProjectRequired
+	}
+	if identity.IssueID == "" && identity.Identifier == "" && identity.IssueURL == "" {
+		return []SchedulerDecision{}, nil
+	}
+	limit := query.Limit
+	if limit <= 0 {
+		limit = defaultSchedulerDecisionLimit
+	}
+	rows, err := s.queries.ListIssueSchedulerDecisions(ctx, sqlc.ListIssueSchedulerDecisionsParams{
+		ProjectID:  identity.ProjectID,
+		IssueID:    identity.IssueID,
+		Identifier: identity.Identifier,
+		IssueURL:   identity.IssueURL,
+		Limit:      int64(limit),
+	})
+	if err != nil {
+		return nil, fmt.Errorf("listing issue scheduler decisions: %w", err)
+	}
+	decisions := make([]SchedulerDecision, 0, len(rows))
+	for _, row := range rows {
+		decision, err := schedulerDecisionFromRow(row)
+		if err != nil {
+			return nil, err
+		}
+		decisions = append(decisions, decision)
+	}
+	return decisions, nil
+}
+
 func workAttemptsFromRows(rows []sqlc.WorkAttempt) ([]WorkAttempt, error) {
 	attempts := make([]WorkAttempt, 0, len(rows))
 	for _, row := range rows {

--- a/internal/web/activity.go
+++ b/internal/web/activity.go
@@ -568,7 +568,7 @@ func (s *Server) latestIssueAgentSession(ctx context.Context, issue telemetry.Is
 	if !ok {
 		return store.IssueAgentSession{}, store.ErrNotFound
 	}
-	return activityStore.LatestIssueAgentSession(ctx, store.IssueIdentity{IssueID: issue.ID, Identifier: issue.Identifier, IssueURL: issue.URL})
+	return activityStore.LatestIssueAgentSession(ctx, store.IssueIdentity{ProjectID: issue.ProjectID, IssueID: issue.ID, Identifier: issue.Identifier, IssueURL: issue.URL})
 }
 
 func boardSessionEvent(event activity.Event) templates.BoardSessionEvent {

--- a/internal/web/api.go
+++ b/internal/web/api.go
@@ -399,9 +399,13 @@ func (s *Server) apiUsage(c echo.Context) error {
 
 func (s *Server) apiWorkflowTimeline(c echo.Context) error {
 	identity := store.IssueIdentity{
+		ProjectID:  strings.TrimSpace(c.QueryParam("project_id")),
 		IssueID:    strings.TrimSpace(c.QueryParam("issue_id")),
 		Identifier: strings.TrimSpace(c.QueryParam("identifier")),
 		IssueURL:   strings.TrimSpace(c.QueryParam("issue_url")),
+	}
+	if identity.ProjectID == "" {
+		return c.JSON(http.StatusBadRequest, errorResponse("missing_project_id", "project_id is required"))
 	}
 	if identity.IssueID == "" && identity.Identifier == "" && identity.IssueURL == "" {
 		return c.JSON(http.StatusBadRequest, errorResponse("missing_issue_identity", "issue_id, identifier, or issue_url is required"))

--- a/internal/web/board_card_test.go
+++ b/internal/web/board_card_test.go
@@ -269,6 +269,7 @@ func TestAPIBoardSessionPagesFailedRolloutHistory(t *testing.T) {
 	issue := telemetry.Issue{ID: "issue-1156", Identifier: "digitaldrywood/detent#1156", ProjectID: "detent", URL: "https://github.com/digitaldrywood/detent/issues/1156", Title: "Closed transcript", State: "Done"}
 	backend := openWebTestStore(t)
 	sessionID, err := backend.StartSession(ctx, store.SessionStart{
+		ProjectID:        issue.ProjectID,
 		IssueID:          issue.ID,
 		Identifier:       issue.Identifier,
 		IssueURL:         issue.URL,

--- a/internal/web/server_test.go
+++ b/internal/web/server_test.go
@@ -9949,11 +9949,15 @@ func TestServerWorkflowTimelineAPI(t *testing.T) {
 	}
 
 	missing := requestJSON(t, server, http.MethodGet, "/api/v1/workflow/timeline", http.StatusBadRequest)
+	if got := nestedString(t, missing, "error", "code"); got != "missing_project_id" {
+		t.Fatalf("error.code = %q, want missing_project_id", got)
+	}
+	missing = requestJSON(t, server, http.MethodGet, "/api/v1/workflow/timeline?project_id=detent", http.StatusBadRequest)
 	if got := nestedString(t, missing, "error", "code"); got != "missing_issue_identity" {
 		t.Fatalf("error.code = %q, want missing_issue_identity", got)
 	}
 
-	payload := requestJSON(t, server, http.MethodGet, "/api/v1/workflow/timeline?identifier=digitaldrywood/detent%23722", http.StatusOK)
+	payload := requestJSON(t, server, http.MethodGet, "/api/v1/workflow/timeline?project_id=detent&identifier=digitaldrywood/detent%23722", http.StatusOK)
 	events := payload["events"].([]any)
 	if len(events) != 1 {
 		t.Fatalf("events len = %d, want 1", len(events))


### PR DESCRIPTION
## Summary

- add a schema-v1 `IssueExplanation` domain read model with deterministic evidence, freshness, eligibility, attempt/session, PR, and required-gate state
- resolve issue evidence through project-scoped snapshot and durable readers without invoking dispatch policy
- scope issue identity SQL reads by project and preserve parsed workflow provenance without exposing raw metadata

Fixes #1638

## UI Surface Contract

- [x] N/A, or the linked issue explicitly authorizes any high-impact UI surface, layout, density, first-viewport, or responsive visibility tradeoff.
- [x] Persistent top-of-screen messaging is explicitly authorized by the issue, or this PR does not add it.
- [x] Visual changes to primary operator screens include screenshot or browser verification below.

No UI changes.

## Test Plan

- [x] `make generate`
- [x] focused tests for `internal/explain`, `internal/store`, `internal/orchestrator`, and `internal/web`
- [x] `make check`