### PR TITLE
refactor(chat): extract operator tool executor

### DIFF
--- a/internal/chat/tools.go
+++ b/internal/chat/tools.go
@@ -4,19 +4,22 @@ import (
 	"encoding/json"
 	"fmt"
 	"strings"
+
+	"github.com/digitaldrywood/detent/internal/operatortool"
 )
 
 func Tools() []Tool {
-	return []Tool{
-		tool("board_state", "Read live board items, lanes, priorities, blockers, and active run identity. Use this before answering board questions or proposing item actions.", `{"type":"object","properties":{"project_id":{"type":"string"},"state":{"type":"string"},"limit":{"type":"integer","minimum":1,"maximum":200}},"additionalProperties":false}`),
-		tool("fleet_health", "Read live fleet health, capacity outages, failure breakers, rate limits, refresh state, and running counts.", `{"type":"object","properties":{},"additionalProperties":false}`),
-		tool("telemetry_usage", "Read live token, spend, throughput, and per-project usage telemetry.", `{"type":"object","properties":{"project_id":{"type":"string"}},"additionalProperties":false}`),
-		tool("recent_activity", "Read recent live activity and completed work, including merge timestamps.", `{"type":"object","properties":{"project_id":{"type":"string"},"limit":{"type":"integer","minimum":1,"maximum":200}},"additionalProperties":false}`),
+	definitions := operatortool.Catalog()
+	tools := make([]Tool, 0, len(definitions)+4)
+	for _, definition := range definitions {
+		tools = append(tools, Tool{Name: definition.Name, Description: definition.Description, InputSchema: definition.InputSchema})
+	}
+	return append(tools,
 		tool("propose_move_item", "Propose moving an item to another configured board state. This never executes the move; operator confirmation is required.", `{"type":"object","required":["project_id","identifier","target_state"],"properties":{"project_id":{"type":"string"},"identifier":{"type":"string"},"target_state":{"type":"string"}},"additionalProperties":false}`),
 		tool("propose_set_priority", "Propose setting an item's configured tracker priority. This never executes the change; operator confirmation is required.", `{"type":"object","required":["project_id","identifier","priority"],"properties":{"project_id":{"type":"string"},"identifier":{"type":"string"},"priority":{"type":"string"}},"additionalProperties":false}`),
 		tool("propose_stop_run", "Propose stopping an active run and atomically routing its item to Blocked, Backlog, Cancelled, or Todo with priority. This never stops a run; operator confirmation is required.", `{"type":"object","required":["project_id","identifier","destination"],"properties":{"project_id":{"type":"string"},"identifier":{"type":"string"},"destination":{"type":"string","enum":["Blocked","Backlog","Cancelled","Todo"]},"priority":{"type":"integer","minimum":1,"maximum":4},"reason":{"type":"string","maxLength":280}},"additionalProperties":false}`),
 		tool("propose_file_issue", "Propose filing a new issue or work item on a configured project. This never files it; operator confirmation is required.", `{"type":"object","required":["project_id","title","description"],"properties":{"project_id":{"type":"string"},"title":{"type":"string"},"description":{"type":"string"},"state":{"type":"string"},"labels":{"type":"array","items":{"type":"string"}},"priority":{"type":"integer","minimum":1,"maximum":4}},"additionalProperties":false}`),
-	}
+	)
 }
 
 func ActionSummary(action Action) string {

--- a/internal/chat/tools_test.go
+++ b/internal/chat/tools_test.go
@@ -1,6 +1,24 @@
 package chat
 
-import "testing"
+import (
+	"strings"
+	"testing"
+)
+
+func TestToolsIncludesReusableReadOnlyCatalog(t *testing.T) {
+	t.Parallel()
+
+	tools := Tools()
+	wantNames := []string{"board_state", "fleet_health", "telemetry_usage", "recent_activity", "explain_item"}
+	for index, name := range wantNames {
+		if tools[index].Name != name {
+			t.Fatalf("Tools()[%d].Name = %q, want %q", index, tools[index].Name, name)
+		}
+	}
+	if !strings.Contains(tools[3].Description, "live-only") {
+		t.Fatalf("recent_activity description = %q", tools[3].Description)
+	}
+}
 
 func TestActionSummaryDescribesOperatorActions(t *testing.T) {
 	t.Parallel()

--- a/internal/operatortool/catalog.go
+++ b/internal/operatortool/catalog.go
@@ -1,0 +1,39 @@
+package operatortool
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+const (
+	BoardState       = "board_state"
+	FleetHealth      = "fleet_health"
+	TelemetryUsage   = "telemetry_usage"
+	RecentActivity   = "recent_activity"
+	ExplainItem      = "explain_item"
+	DefaultItemLimit = 100
+	MaxItemLimit     = 200
+	MaxResultBytes   = 256 * 1024
+)
+
+type Definition struct {
+	Name        string
+	Description string
+	InputSchema json.RawMessage
+}
+
+func Catalog() []Definition {
+	limitedSchema := fmt.Sprintf(`{"type":"object","properties":{"project_id":{"type":"string"},"state":{"type":"string"},"limit":{"type":"integer","minimum":1,"maximum":%d}},"additionalProperties":false}`, MaxItemLimit)
+	activitySchema := fmt.Sprintf(`{"type":"object","properties":{"project_id":{"type":"string"},"limit":{"type":"integer","minimum":1,"maximum":%d}},"additionalProperties":false}`, MaxItemLimit)
+	return []Definition{
+		definition(BoardState, "Read live board items, lanes, priorities, blockers, and active run identity. Use this before answering board questions or proposing item actions.", limitedSchema),
+		definition(FleetHealth, "Read live fleet health, capacity outages, failure breakers, rate limits, refresh state, and running counts.", `{"type":"object","properties":{},"additionalProperties":false}`),
+		definition(TelemetryUsage, "Read live token, spend, throughput, and per-project usage telemetry.", `{"type":"object","properties":{"project_id":{"type":"string"}},"additionalProperties":false}`),
+		definition(RecentActivity, "Read recent events and completed work retained in the current live telemetry snapshot, including merge timestamps. This is live-only activity, not the durable issue activity stream.", activitySchema),
+		definition(ExplainItem, "Explain an issue's current lane, latest transition reason, eligibility, active or latest attempt, sessions, pull request, required gate, freshness, and evidence from the versioned issue explanation read model.", `{"type":"object","required":["project_id","reference"],"properties":{"project_id":{"type":"string","minLength":1},"reference":{"type":"string","minLength":1}},"additionalProperties":false}`),
+	}
+}
+
+func definition(name string, description string, schema string) Definition {
+	return Definition{Name: name, Description: description, InputSchema: json.RawMessage(schema)}
+}

--- a/internal/operatortool/executor.go
+++ b/internal/operatortool/executor.go
@@ -1,0 +1,360 @@
+package operatortool
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"slices"
+	"strings"
+	"time"
+
+	"github.com/digitaldrywood/detent/internal/explain"
+	"github.com/digitaldrywood/detent/internal/telemetry"
+)
+
+type Call struct {
+	Name      string
+	Arguments json.RawMessage
+}
+
+type Result struct {
+	Content json.RawMessage
+}
+
+type SnapshotSource interface {
+	Snapshot(context.Context) (telemetry.Snapshot, error)
+}
+
+type SnapshotFunc func(context.Context) (telemetry.Snapshot, error)
+
+func (f SnapshotFunc) Snapshot(ctx context.Context) (telemetry.Snapshot, error) {
+	return f(ctx)
+}
+
+type Explainer interface {
+	Explain(context.Context, explain.Query) (explain.IssueExplanation, error)
+}
+
+type Dependencies struct {
+	Snapshots SnapshotSource
+	Explainer Explainer
+}
+
+type Executor struct {
+	snapshots SnapshotSource
+	explainer Explainer
+}
+
+func NewExecutor(deps Dependencies) *Executor {
+	return &Executor{snapshots: deps.Snapshots, explainer: deps.Explainer}
+}
+
+func (e *Executor) Execute(ctx context.Context, call Call) (Result, error) {
+	switch call.Name {
+	case BoardState:
+		return e.boardState(ctx, call.Arguments)
+	case FleetHealth:
+		return e.fleetHealth(ctx, call.Arguments)
+	case TelemetryUsage:
+		return e.telemetryUsage(ctx, call.Arguments)
+	case RecentActivity:
+		return e.recentActivity(ctx, call.Arguments)
+	case ExplainItem:
+		return e.explainItem(ctx, call.Arguments)
+	default:
+		return Result{}, fmt.Errorf("unknown read-only operator tool %q", call.Name)
+	}
+}
+
+func (e *Executor) boardState(ctx context.Context, raw json.RawMessage) (Result, error) {
+	var request struct {
+		ProjectID string `json:"project_id"`
+		State     string `json:"state"`
+		Limit     int    `json:"limit"`
+	}
+	if err := decodeArguments(raw, &request); err != nil {
+		return Result{}, err
+	}
+	snapshot, err := e.snapshot(ctx)
+	if err != nil {
+		return Result{}, err
+	}
+	items := boardItems(snapshot, request.ProjectID, request.State)
+	items = bounded(items, itemLimit(request.Limit))
+	return encodeResult(BoardStateResult{GeneratedAt: snapshot.GeneratedAt, Counts: snapshot.Counts, Items: items})
+}
+
+func (e *Executor) fleetHealth(ctx context.Context, _ json.RawMessage) (Result, error) {
+	snapshot, err := e.snapshot(ctx)
+	if err != nil {
+		return Result{}, err
+	}
+	return encodeResult(FleetHealthResult{
+		GeneratedAt:        snapshot.GeneratedAt,
+		Auth:               snapshot.Auth,
+		Shutdown:           snapshot.Shutdown,
+		Refresh:            snapshot.Refresh,
+		Counts:             snapshot.Counts,
+		RateLimits:         boundedRateLimits(snapshot.RateLimits),
+		BackendOutages:     boundedClone(snapshot.BackendOutages, MaxItemLimit),
+		FailureBreakers:    boundedClone(snapshot.FailureBreakers, MaxItemLimit),
+		DispatchRecoveries: boundedClone(snapshot.DispatchRecoveries, MaxItemLimit),
+	})
+}
+
+func (e *Executor) telemetryUsage(ctx context.Context, raw json.RawMessage) (Result, error) {
+	var request struct {
+		ProjectID string `json:"project_id"`
+	}
+	if err := decodeArguments(raw, &request); err != nil {
+		return Result{}, err
+	}
+	snapshot, err := e.snapshot(ctx)
+	if err != nil {
+		return Result{}, err
+	}
+	projects := slices.Clone(snapshot.Projects)
+	if request.ProjectID != "" {
+		projects = slices.DeleteFunc(projects, func(candidate telemetry.ProjectSnapshot) bool {
+			return !strings.EqualFold(candidate.Project.ID, strings.TrimSpace(request.ProjectID))
+		})
+	}
+	projects = bounded(projects, MaxItemLimit)
+	return encodeResult(TelemetryUsageResult{
+		GeneratedAt:    snapshot.GeneratedAt,
+		Projects:       projects,
+		Tokens:         snapshot.Tokens,
+		Throughput:     snapshot.Throughput,
+		LifetimeTotals: snapshot.LifetimeTotals,
+		Budget:         boundedBudget(snapshot.Budget),
+	})
+}
+
+func (e *Executor) recentActivity(ctx context.Context, raw json.RawMessage) (Result, error) {
+	var request struct {
+		ProjectID string `json:"project_id"`
+		Limit     int    `json:"limit"`
+	}
+	if err := decodeArguments(raw, &request); err != nil {
+		return Result{}, err
+	}
+	snapshot, err := e.snapshot(ctx)
+	if err != nil {
+		return Result{}, err
+	}
+	events := slices.Clone(snapshot.Events)
+	completed := slices.Clone(snapshot.Completed)
+	if request.ProjectID != "" {
+		projectID := strings.TrimSpace(request.ProjectID)
+		completed = slices.DeleteFunc(completed, func(candidate telemetry.Completed) bool {
+			return !strings.EqualFold(candidate.ProjectID, projectID)
+		})
+	}
+	limit := itemLimit(request.Limit)
+	if len(events) > limit {
+		events = events[len(events)-limit:]
+	}
+	completed = bounded(completed, limit)
+	return encodeResult(RecentActivityResult{GeneratedAt: snapshot.GeneratedAt, Events: events, Completed: completed})
+}
+
+func (e *Executor) explainItem(ctx context.Context, raw json.RawMessage) (Result, error) {
+	var request struct {
+		ProjectID string `json:"project_id"`
+		Reference string `json:"reference"`
+	}
+	if err := decodeArguments(raw, &request); err != nil {
+		return Result{}, err
+	}
+	if e.explainer == nil {
+		return Result{}, errors.New("issue explanation is unavailable")
+	}
+	result, err := e.explainer.Explain(ctx, explain.Query{ProjectID: request.ProjectID, Reference: request.Reference})
+	if err != nil {
+		return Result{}, err
+	}
+	return encodeResult(result)
+}
+
+func (e *Executor) snapshot(ctx context.Context) (telemetry.Snapshot, error) {
+	if e.snapshots == nil {
+		return telemetry.Snapshot{}, errors.New("operator telemetry snapshot is unavailable")
+	}
+	return e.snapshots.Snapshot(ctx)
+}
+
+func decodeArguments(raw json.RawMessage, target any) error {
+	if len(raw) == 0 || string(raw) == "null" {
+		raw = json.RawMessage(`{}`)
+	}
+	if err := json.Unmarshal(raw, target); err != nil {
+		return fmt.Errorf("invalid tool arguments: %w", err)
+	}
+	return nil
+}
+
+func encodeResult(value any) (Result, error) {
+	data, err := json.Marshal(value)
+	if err != nil {
+		return Result{}, fmt.Errorf("encode operator tool result: %w", err)
+	}
+	if len(data) > MaxResultBytes {
+		return Result{}, fmt.Errorf("operator tool result exceeds %d bytes", MaxResultBytes)
+	}
+	return Result{Content: data}, nil
+}
+
+func itemLimit(limit int) int {
+	if limit <= 0 {
+		return DefaultItemLimit
+	}
+	return min(limit, MaxItemLimit)
+}
+
+func bounded[T any](values []T, limit int) []T {
+	if len(values) > limit {
+		return values[:limit]
+	}
+	return values
+}
+
+func boundedClone[T any](values []T, limit int) []T {
+	return bounded(slices.Clone(values), limit)
+}
+
+func boundedRateLimits(rateLimits *telemetry.RateLimits) *telemetry.RateLimits {
+	if rateLimits == nil {
+		return nil
+	}
+	result := *rateLimits
+	if rateLimits.GraphQLCost != nil {
+		graphql := *rateLimits.GraphQLCost
+		graphql.Contributors = boundedClone(graphql.Contributors, MaxItemLimit)
+		result.GraphQLCost = &graphql
+	}
+	if rateLimits.RESTUsage != nil {
+		rest := *rateLimits.RESTUsage
+		rest.Contributors = boundedClone(rest.Contributors, MaxItemLimit)
+		result.RESTUsage = &rest
+	}
+	return &result
+}
+
+func boundedBudget(budget telemetry.Budget) telemetry.Budget {
+	budget.SpendPoints = boundedClone(budget.SpendPoints, MaxItemLimit)
+	budget.Days = boundedClone(budget.Days, MaxItemLimit)
+	budget.Refusals = boundedClone(budget.Refusals, MaxItemLimit)
+	return budget
+}
+
+type BoardStateResult struct {
+	GeneratedAt time.Time        `json:"generated_at"`
+	Counts      telemetry.Counts `json:"counts"`
+	Items       []BoardItem      `json:"items"`
+}
+
+type BoardItem struct {
+	ProjectID         string     `json:"project_id,omitempty"`
+	IssueID           string     `json:"issue_id"`
+	Identifier        string     `json:"identifier,omitempty"`
+	Title             string     `json:"title,omitempty"`
+	State             string     `json:"state,omitempty"`
+	Priority          *int       `json:"priority,omitempty"`
+	PriorityName      string     `json:"priority_name,omitempty"`
+	BlockedReason     string     `json:"blocked_reason,omitempty"`
+	BlockedSource     string     `json:"blocked_source,omitempty"`
+	Active            bool       `json:"active,omitempty"`
+	Attempt           int        `json:"attempt,omitempty"`
+	WorkAttemptID     int64      `json:"work_attempt_id,omitempty"`
+	DetentSessionID   int64      `json:"detent_session_id,omitempty"`
+	ProviderSessionID string     `json:"provider_session_id,omitempty"`
+	CompletedAt       *time.Time `json:"completed_at,omitempty"`
+}
+
+type FleetHealthResult struct {
+	GeneratedAt        time.Time                    `json:"generated_at"`
+	Auth               telemetry.AuthHealth         `json:"auth"`
+	Shutdown           telemetry.Shutdown           `json:"shutdown"`
+	Refresh            telemetry.Refresh            `json:"refresh"`
+	Counts             telemetry.Counts             `json:"counts"`
+	RateLimits         *telemetry.RateLimits        `json:"rate_limits"`
+	BackendOutages     []telemetry.BackendOutage    `json:"backend_outages"`
+	FailureBreakers    []telemetry.FailureBreaker   `json:"failure_breakers"`
+	DispatchRecoveries []telemetry.DispatchRecovery `json:"dispatch_recoveries"`
+}
+
+type TelemetryUsageResult struct {
+	GeneratedAt    time.Time                   `json:"generated_at"`
+	Projects       []telemetry.ProjectSnapshot `json:"projects"`
+	Tokens         telemetry.Tokens            `json:"tokens"`
+	Throughput     telemetry.TokenThroughput   `json:"throughput"`
+	LifetimeTotals telemetry.LifetimeTotals    `json:"lifetime_totals"`
+	Budget         telemetry.Budget            `json:"budget"`
+}
+
+type RecentActivityResult struct {
+	GeneratedAt time.Time                 `json:"generated_at"`
+	Events      []telemetry.ActivityEvent `json:"events"`
+	Completed   []telemetry.Completed     `json:"completed"`
+}
+
+func boardItems(snapshot telemetry.Snapshot, projectID string, state string) []BoardItem {
+	rows := make(map[string]BoardItem)
+	add := func(issue telemetry.Issue) {
+		key := issue.ProjectID + "\x00" + issue.ID
+		rows[key] = BoardItem{ProjectID: issue.ProjectID, IssueID: issue.ID, Identifier: issue.Identifier, Title: issue.Title, State: issue.State, Priority: issue.Priority, PriorityName: issue.PriorityName}
+	}
+	for _, issue := range snapshot.BoardIssues {
+		add(issue)
+	}
+	for _, issue := range snapshot.Pipeline {
+		add(issue)
+	}
+	for _, running := range snapshot.Running {
+		add(running.Issue)
+		key := running.ProjectID + "\x00" + running.ID
+		row := rows[key]
+		row.Active = true
+		row.Attempt = running.Attempt
+		row.WorkAttemptID = running.WorkAttemptID
+		row.DetentSessionID = running.DetentSessionID
+		row.ProviderSessionID = running.SessionID
+		rows[key] = row
+	}
+	for _, queued := range snapshot.Queue {
+		add(queued.Issue)
+	}
+	for _, blocked := range snapshot.Blocked {
+		issue := blocked.Issue
+		issue.State = "Blocked"
+		add(issue)
+		key := blocked.ProjectID + "\x00" + blocked.ID
+		row := rows[key]
+		row.BlockedReason = blocked.Error
+		row.BlockedSource = string(blocked.Source)
+		rows[key] = row
+	}
+	for _, completed := range snapshot.Completed {
+		add(completed.Issue)
+		key := completed.ProjectID + "\x00" + completed.ID
+		row := rows[key]
+		completedAt := completed.CompletedAt
+		row.CompletedAt = &completedAt
+		rows[key] = row
+	}
+	out := make([]BoardItem, 0, len(rows))
+	for _, row := range rows {
+		if projectID != "" && !strings.EqualFold(row.ProjectID, strings.TrimSpace(projectID)) {
+			continue
+		}
+		if state != "" && !strings.EqualFold(row.State, strings.TrimSpace(state)) {
+			continue
+		}
+		out = append(out, row)
+	}
+	slices.SortFunc(out, func(left BoardItem, right BoardItem) int {
+		return strings.Compare(left.Identifier, right.Identifier)
+	})
+	return out
+}

--- a/internal/operatortool/executor_test.go
+++ b/internal/operatortool/executor_test.go
@@ -1,0 +1,372 @@
+package operatortool
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"math"
+	"reflect"
+	"strconv"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/digitaldrywood/detent/internal/explain"
+	"github.com/digitaldrywood/detent/internal/telemetry"
+)
+
+func TestCatalogDefinesReadOnlySurface(t *testing.T) {
+	t.Parallel()
+
+	definitions := Catalog()
+	wantNames := []string{BoardState, FleetHealth, TelemetryUsage, RecentActivity, ExplainItem}
+	if len(definitions) != len(wantNames) {
+		t.Fatalf("Catalog() length = %d, want %d", len(definitions), len(wantNames))
+	}
+	for index, definition := range definitions {
+		if definition.Name != wantNames[index] {
+			t.Fatalf("Catalog()[%d].Name = %q, want %q", index, definition.Name, wantNames[index])
+		}
+		var schema map[string]any
+		if err := json.Unmarshal(definition.InputSchema, &schema); err != nil {
+			t.Fatalf("Catalog()[%d] schema error = %v", index, err)
+		}
+		if strings.HasPrefix(definition.Name, "propose_") {
+			t.Fatalf("Catalog() exposed mutation %q", definition.Name)
+		}
+	}
+	if !strings.Contains(definitions[3].Description, "live-only") || !strings.Contains(definitions[3].Description, "not the durable") {
+		t.Fatalf("recent_activity description = %q", definitions[3].Description)
+	}
+	var boardSchema struct {
+		Properties struct {
+			Limit struct {
+				Maximum int `json:"maximum"`
+			} `json:"limit"`
+		} `json:"properties"`
+	}
+	if err := json.Unmarshal(definitions[0].InputSchema, &boardSchema); err != nil {
+		t.Fatalf("decode board schema: %v", err)
+	}
+	if boardSchema.Properties.Limit.Maximum != MaxItemLimit {
+		t.Fatalf("board limit maximum = %d, want %d", boardSchema.Properties.Limit.Maximum, MaxItemLimit)
+	}
+}
+
+func TestExecutorReturnsTypedResultsWithObservationTime(t *testing.T) {
+	t.Parallel()
+
+	observedAt := time.Date(2026, 8, 7, 20, 15, 0, 0, time.UTC)
+	explanation := explain.IssueExplanation{
+		Schema:     explain.SchemaVersion,
+		Found:      true,
+		ObservedAt: observedAt,
+		Identity:   explain.Identity{ProjectID: "detent", IssueID: "issue-1", Identifier: "owner/repo#1"},
+		CurrentLane: explain.Lane{
+			Name:      "Rework",
+			Freshness: explain.SourceLive,
+		},
+	}
+	snapshot := telemetry.Snapshot{
+		GeneratedAt: observedAt,
+		BoardIssues: []telemetry.Issue{{ID: "issue-1", Identifier: "owner/repo#1", ProjectID: "detent", State: "Rework"}},
+		Events:      []telemetry.ActivityEvent{{At: observedAt, Event: "agent finished"}},
+		Completed:   []telemetry.Completed{{Issue: telemetry.Issue{ID: "issue-1", ProjectID: "detent"}, CompletedAt: observedAt}},
+	}
+	executor := newTestExecutor(snapshot, explanation)
+	tests := []struct {
+		name      string
+		call      Call
+		timestamp string
+	}{
+		{name: "board state", call: Call{Name: BoardState, Arguments: json.RawMessage(`{"project_id":"detent"}`)}, timestamp: "generated_at"},
+		{name: "fleet health", call: Call{Name: FleetHealth, Arguments: json.RawMessage(`{}`)}, timestamp: "generated_at"},
+		{name: "telemetry usage", call: Call{Name: TelemetryUsage, Arguments: json.RawMessage(`{}`)}, timestamp: "generated_at"},
+		{name: "recent activity", call: Call{Name: RecentActivity, Arguments: json.RawMessage(`{"limit":1}`)}, timestamp: "generated_at"},
+		{name: "explain item", call: Call{Name: ExplainItem, Arguments: json.RawMessage(`{"project_id":"detent","reference":"owner/repo#1"}`)}, timestamp: "observed_at"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			result, err := executor.Execute(context.Background(), test.call)
+			if err != nil {
+				t.Fatalf("Execute() error = %v", err)
+			}
+			var payload any
+			if err := json.Unmarshal(result.Content, &payload); err != nil {
+				t.Fatalf("result JSON error = %v", err)
+			}
+			object, ok := payload.(map[string]any)
+			if !ok {
+				t.Fatalf("result payload = %T, want JSON object", payload)
+			}
+			if object[test.timestamp] != observedAt.Format(time.RFC3339) {
+				t.Fatalf("result %s = %#v, want %q", test.timestamp, object[test.timestamp], observedAt.Format(time.RFC3339))
+			}
+		})
+	}
+
+	result, err := executor.Execute(context.Background(), Call{Name: ExplainItem, Arguments: json.RawMessage(`{"project_id":"detent","reference":"owner/repo#1"}`)})
+	if err != nil {
+		t.Fatalf("Execute(explain_item) error = %v", err)
+	}
+	var got explain.IssueExplanation
+	if err := json.Unmarshal(result.Content, &got); err != nil {
+		t.Fatalf("decode explain result: %v", err)
+	}
+	if !reflect.DeepEqual(got, explanation) {
+		t.Fatalf("explain result = %#v, want read model %#v", got, explanation)
+	}
+}
+
+func TestExecutorEnforcesDispatchAndBounds(t *testing.T) {
+	t.Parallel()
+
+	observedAt := time.Date(2026, 8, 7, 20, 15, 0, 0, time.UTC)
+	issues := make([]telemetry.Issue, MaxItemLimit+5)
+	for index := range issues {
+		identifier := strconv.Itoa(index)
+		issues[index] = telemetry.Issue{ID: "issue-" + identifier, Identifier: "owner/repo#" + identifier, ProjectID: "detent", State: "Todo"}
+	}
+	contributors := make([]telemetry.GraphQLCostContributor, MaxItemLimit+5)
+	spendPoints := make([]telemetry.BudgetSpendPoint, MaxItemLimit+5)
+	executor := newTestExecutor(telemetry.Snapshot{
+		GeneratedAt: observedAt,
+		BoardIssues: issues,
+		RateLimits:  &telemetry.RateLimits{GraphQLCost: &telemetry.GraphQLCost{Contributors: contributors}},
+		Budget:      telemetry.Budget{SpendPoints: spendPoints},
+	}, explain.IssueExplanation{})
+	unsupported := []string{"propose_move_item", "propose_set_priority", "unknown"}
+	for _, name := range unsupported {
+		t.Run("reject "+name, func(t *testing.T) {
+			t.Parallel()
+			_, err := executor.Execute(context.Background(), Call{Name: name})
+			if err == nil || !strings.Contains(err.Error(), "unknown read-only operator tool") {
+				t.Fatalf("Execute(%q) error = %v", name, err)
+			}
+		})
+	}
+
+	result, err := executor.Execute(context.Background(), Call{Name: BoardState, Arguments: json.RawMessage(`{"limit":999}`)})
+	if err != nil {
+		t.Fatalf("Execute(board_state) error = %v", err)
+	}
+	var board BoardStateResult
+	if err := json.Unmarshal(result.Content, &board); err != nil {
+		t.Fatalf("decode board result: %v", err)
+	}
+	if len(board.Items) != MaxItemLimit {
+		t.Fatalf("board items = %d, want %d", len(board.Items), MaxItemLimit)
+	}
+	result, err = executor.Execute(context.Background(), Call{Name: FleetHealth})
+	if err != nil {
+		t.Fatalf("Execute(fleet_health) error = %v", err)
+	}
+	var fleet FleetHealthResult
+	if err := json.Unmarshal(result.Content, &fleet); err != nil {
+		t.Fatalf("decode fleet result: %v", err)
+	}
+	if len(fleet.RateLimits.GraphQLCost.Contributors) != MaxItemLimit {
+		t.Fatalf("fleet contributors = %d, want %d", len(fleet.RateLimits.GraphQLCost.Contributors), MaxItemLimit)
+	}
+	result, err = executor.Execute(context.Background(), Call{Name: TelemetryUsage})
+	if err != nil {
+		t.Fatalf("Execute(telemetry_usage) error = %v", err)
+	}
+	var usage TelemetryUsageResult
+	if err := json.Unmarshal(result.Content, &usage); err != nil {
+		t.Fatalf("decode usage result: %v", err)
+	}
+	if len(usage.Budget.SpendPoints) != MaxItemLimit {
+		t.Fatalf("budget spend points = %d, want %d", len(usage.Budget.SpendPoints), MaxItemLimit)
+	}
+
+	oversized := newTestExecutor(telemetry.Snapshot{
+		GeneratedAt: observedAt,
+		BoardIssues: []telemetry.Issue{{ID: "issue-1", ProjectID: "detent", Title: strings.Repeat("x", MaxResultBytes)}},
+	}, explain.IssueExplanation{})
+	_, err = oversized.Execute(context.Background(), Call{Name: BoardState})
+	if err == nil || !strings.Contains(err.Error(), "result exceeds") {
+		t.Fatalf("oversized Execute() error = %v", err)
+	}
+}
+
+func TestExecutorAggregatesAndFiltersSnapshotResults(t *testing.T) {
+	t.Parallel()
+
+	observedAt := time.Date(2026, 8, 7, 20, 15, 0, 0, time.UTC)
+	completedAt := observedAt.Add(-time.Minute)
+	snapshot := telemetry.Snapshot{
+		GeneratedAt: observedAt,
+		BoardIssues: []telemetry.Issue{{ID: "board", Identifier: "owner/repo#1", ProjectID: "detent", State: "Todo"}},
+		Pipeline:    []telemetry.Issue{{ID: "pipeline", Identifier: "owner/repo#2", ProjectID: "detent", State: "Todo"}},
+		Running: []telemetry.Running{{
+			Issue:   telemetry.Issue{ID: "running", Identifier: "owner/repo#3", ProjectID: "detent", State: "Todo"},
+			Attempt: 2, WorkAttemptID: 3, DetentSessionID: 4, SessionID: "provider-5",
+		}},
+		Queue: []telemetry.Queued{{Issue: telemetry.Issue{ID: "queued", Identifier: "owner/repo#4", ProjectID: "detent", State: "Todo"}}},
+		Blocked: []telemetry.Blocked{{
+			Issue: telemetry.Issue{ID: "blocked", Identifier: "owner/repo#5", ProjectID: "detent", State: "Todo"},
+			Error: "waiting for dependency", Source: telemetry.BlockedSourceDependency,
+		}},
+		Completed: []telemetry.Completed{
+			{Issue: telemetry.Issue{ID: "completed", Identifier: "owner/repo#6", ProjectID: "detent", State: "Done"}, CompletedAt: completedAt},
+			{Issue: telemetry.Issue{ID: "other", Identifier: "other/repo#1", ProjectID: "other", State: "Done"}, CompletedAt: completedAt},
+		},
+		Events: []telemetry.ActivityEvent{
+			{At: observedAt.Add(-2 * time.Minute), Event: "old"},
+			{At: observedAt.Add(-time.Minute), Event: "middle"},
+			{At: observedAt, Event: "new"},
+		},
+		Projects: []telemetry.ProjectSnapshot{
+			{Project: telemetry.Project{ID: "detent"}},
+			{Project: telemetry.Project{ID: "other"}},
+		},
+	}
+	executor := newTestExecutor(snapshot, explain.IssueExplanation{})
+
+	result, err := executor.Execute(context.Background(), Call{Name: BoardState, Arguments: json.RawMessage(`{"project_id":"detent"}`)})
+	if err != nil {
+		t.Fatalf("Execute(board_state) error = %v", err)
+	}
+	var board BoardStateResult
+	if err := json.Unmarshal(result.Content, &board); err != nil {
+		t.Fatalf("decode board result: %v", err)
+	}
+	if len(board.Items) != 6 || board.Items[2].Identifier != "owner/repo#3" || !board.Items[2].Active || board.Items[2].ProviderSessionID != "provider-5" {
+		t.Fatalf("board items = %#v", board.Items)
+	}
+	if board.Items[4].State != "Blocked" || board.Items[4].BlockedReason != "waiting for dependency" {
+		t.Fatalf("blocked item = %#v", board.Items[4])
+	}
+	if board.Items[5].CompletedAt == nil || !board.Items[5].CompletedAt.Equal(completedAt) {
+		t.Fatalf("completed item = %#v", board.Items[5])
+	}
+
+	result, err = executor.Execute(context.Background(), Call{Name: TelemetryUsage, Arguments: json.RawMessage(`{"project_id":"detent"}`)})
+	if err != nil {
+		t.Fatalf("Execute(telemetry_usage) error = %v", err)
+	}
+	var usage TelemetryUsageResult
+	if err := json.Unmarshal(result.Content, &usage); err != nil {
+		t.Fatalf("decode usage result: %v", err)
+	}
+	if len(usage.Projects) != 1 || usage.Projects[0].Project.ID != "detent" {
+		t.Fatalf("usage projects = %#v", usage.Projects)
+	}
+
+	result, err = executor.Execute(context.Background(), Call{Name: RecentActivity, Arguments: json.RawMessage(`{"project_id":"detent","limit":2}`)})
+	if err != nil {
+		t.Fatalf("Execute(recent_activity) error = %v", err)
+	}
+	var activity RecentActivityResult
+	if err := json.Unmarshal(result.Content, &activity); err != nil {
+		t.Fatalf("decode activity result: %v", err)
+	}
+	if len(activity.Events) != 2 || activity.Events[0].Event != "middle" || len(activity.Completed) != 1 || activity.Completed[0].ProjectID != "detent" {
+		t.Fatalf("activity result = %#v", activity)
+	}
+}
+
+func TestExecutorReportsInvalidInputsAndUnavailableDependencies(t *testing.T) {
+	t.Parallel()
+
+	dependencyErr := errors.New("dependency failed")
+	tests := []struct {
+		name     string
+		executor *Executor
+		call     Call
+		want     string
+	}{
+		{name: "invalid board arguments", executor: newTestExecutor(telemetry.Snapshot{}, explain.IssueExplanation{}), call: Call{Name: BoardState, Arguments: json.RawMessage(`{"limit":`)}, want: "invalid tool arguments"},
+		{name: "missing snapshot", executor: NewExecutor(Dependencies{}), call: Call{Name: BoardState}, want: "snapshot is unavailable"},
+		{name: "snapshot failure", executor: NewExecutor(Dependencies{Snapshots: failingSnapshot{err: dependencyErr}}), call: Call{Name: FleetHealth}, want: dependencyErr.Error()},
+		{name: "missing explainer", executor: NewExecutor(Dependencies{}), call: Call{Name: ExplainItem}, want: "explanation is unavailable"},
+		{name: "explainer failure", executor: NewExecutor(Dependencies{Explainer: failingExplainer{err: dependencyErr}}), call: Call{Name: ExplainItem}, want: dependencyErr.Error()},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			_, err := test.executor.Execute(context.Background(), test.call)
+			if err == nil || !strings.Contains(err.Error(), test.want) {
+				t.Fatalf("Execute() error = %v, want containing %q", err, test.want)
+			}
+		})
+	}
+	if _, err := encodeResult(math.Inf(1)); err == nil || !strings.Contains(err.Error(), "encode operator tool result") {
+		t.Fatalf("encodeResult() error = %v", err)
+	}
+}
+
+func TestExecutorConcurrentCallsAreSafe(t *testing.T) {
+	t.Parallel()
+
+	observedAt := time.Date(2026, 8, 7, 20, 15, 0, 0, time.UTC)
+	executor := newTestExecutor(
+		telemetry.Snapshot{GeneratedAt: observedAt, BoardIssues: []telemetry.Issue{{ID: "issue-1", ProjectID: "detent", State: "Todo"}}},
+		explain.IssueExplanation{Schema: explain.SchemaVersion, Found: true, ObservedAt: observedAt},
+	)
+	calls := []Call{
+		{Name: BoardState},
+		{Name: FleetHealth},
+		{Name: TelemetryUsage},
+		{Name: RecentActivity},
+		{Name: ExplainItem, Arguments: json.RawMessage(`{"project_id":"detent","reference":"issue-1"}`)},
+	}
+	const workers = 32
+	errorsFound := make(chan error, workers*len(calls))
+	var group sync.WaitGroup
+	for range workers {
+		for _, call := range calls {
+			group.Add(1)
+			go func() {
+				defer group.Done()
+				result, err := executor.Execute(context.Background(), call)
+				if err != nil {
+					errorsFound <- err
+					return
+				}
+				if !json.Valid(result.Content) {
+					errorsFound <- errors.New("result is not valid JSON")
+				}
+			}()
+		}
+	}
+	group.Wait()
+	close(errorsFound)
+	for err := range errorsFound {
+		t.Errorf("concurrent Execute() error = %v", err)
+	}
+}
+
+type staticExplainer struct {
+	result explain.IssueExplanation
+}
+
+type failingSnapshot struct {
+	err error
+}
+
+func (s failingSnapshot) Snapshot(context.Context) (telemetry.Snapshot, error) {
+	return telemetry.Snapshot{}, s.err
+}
+
+type failingExplainer struct {
+	err error
+}
+
+func (e failingExplainer) Explain(context.Context, explain.Query) (explain.IssueExplanation, error) {
+	return explain.IssueExplanation{}, e.err
+}
+
+func (e staticExplainer) Explain(context.Context, explain.Query) (explain.IssueExplanation, error) {
+	return e.result, nil
+}
+
+func newTestExecutor(snapshot telemetry.Snapshot, explanation explain.IssueExplanation) *Executor {
+	return NewExecutor(Dependencies{
+		Snapshots: SnapshotFunc(func(context.Context) (telemetry.Snapshot, error) { return snapshot, nil }),
+		Explainer: staticExplainer{result: explanation},
+	})
+}

--- a/internal/web/chat.go
+++ b/internal/web/chat.go
@@ -23,7 +23,9 @@ import (
 	"github.com/digitaldrywood/detent/internal/apikey"
 	chatpkg "github.com/digitaldrywood/detent/internal/chat"
 	workflowconfig "github.com/digitaldrywood/detent/internal/config"
+	"github.com/digitaldrywood/detent/internal/explain"
 	kanbanstate "github.com/digitaldrywood/detent/internal/kanban"
+	"github.com/digitaldrywood/detent/internal/operatortool"
 	"github.com/digitaldrywood/detent/internal/orchestrator"
 	"github.com/digitaldrywood/detent/internal/project"
 	"github.com/digitaldrywood/detent/internal/store"
@@ -35,31 +37,12 @@ import (
 const (
 	chatSessionCookieName = "detent_chat_session"
 	chatSessionMaxAge     = int((24 * time.Hour) / time.Second)
-	defaultChatToolLimit  = 100
 )
 
 type chatScenarioContextKey struct{}
 
 type chatMessageRequest struct {
 	Message string `form:"message" json:"message"`
-}
-
-type chatBoardRow struct {
-	ProjectID         string     `json:"project_id,omitempty"`
-	IssueID           string     `json:"issue_id"`
-	Identifier        string     `json:"identifier,omitempty"`
-	Title             string     `json:"title,omitempty"`
-	State             string     `json:"state,omitempty"`
-	Priority          *int       `json:"priority,omitempty"`
-	PriorityName      string     `json:"priority_name,omitempty"`
-	BlockedReason     string     `json:"blocked_reason,omitempty"`
-	BlockedSource     string     `json:"blocked_source,omitempty"`
-	Active            bool       `json:"active,omitempty"`
-	Attempt           int        `json:"attempt,omitempty"`
-	WorkAttemptID     int64      `json:"work_attempt_id,omitempty"`
-	DetentSessionID   int64      `json:"detent_session_id,omitempty"`
-	ProviderSessionID string     `json:"provider_session_id,omitempty"`
-	CompletedAt       *time.Time `json:"completed_at,omitempty"`
 }
 
 func (s *Server) apiChatPanel(c echo.Context) error {
@@ -198,117 +181,72 @@ func (s *Server) chatSnapshot(ctx context.Context) telemetry.Snapshot {
 	return s.latestSnapshot(ctx)
 }
 
-func (s *Server) ExecuteTool(ctx context.Context, call chatpkg.ToolCall) (chatpkg.ToolResult, error) {
+type dashboardToolExecutor struct {
+	readOnly *operatortool.Executor
+	server   *Server
+}
+
+func (e *dashboardToolExecutor) ExecuteTool(ctx context.Context, call chatpkg.ToolCall) (chatpkg.ToolResult, error) {
 	switch call.Name {
-	case "board_state":
-		return s.chatBoardState(ctx, call.Arguments)
-	case "fleet_health":
-		return s.chatFleetHealth(ctx)
-	case "telemetry_usage":
-		return s.chatTelemetryUsage(ctx, call.Arguments)
-	case "recent_activity":
-		return s.chatRecentActivity(ctx, call.Arguments)
 	case "propose_move_item":
-		return s.chatMoveProposal(ctx, call.Arguments)
+		return e.server.chatMoveProposal(ctx, call.Arguments)
 	case "propose_set_priority":
-		return s.chatPriorityProposal(ctx, call.Arguments)
+		return e.server.chatPriorityProposal(ctx, call.Arguments)
 	case "propose_stop_run":
-		return s.chatStopProposal(ctx, call.Arguments)
+		return e.server.chatStopProposal(ctx, call.Arguments)
 	case "propose_file_issue":
-		return s.chatFileIssueProposal(ctx, call.Arguments)
+		return e.server.chatFileIssueProposal(ctx, call.Arguments)
 	default:
-		return chatpkg.ToolResult{}, fmt.Errorf("unknown chat tool %q", call.Name)
+		result, err := e.readOnly.Execute(ctx, operatortool.Call{Name: call.Name, Arguments: call.Arguments})
+		return chatpkg.ToolResult{Content: string(result.Content)}, err
 	}
 }
 
-func (s *Server) chatBoardState(ctx context.Context, raw json.RawMessage) (chatpkg.ToolResult, error) {
-	var request struct {
-		ProjectID string `json:"project_id"`
-		State     string `json:"state"`
-		Limit     int    `json:"limit"`
-	}
-	if err := decodeChatToolArguments(raw, &request); err != nil {
-		return chatpkg.ToolResult{}, err
-	}
-	limit := chatToolLimit(request.Limit)
-	snapshot := s.chatSnapshot(ctx)
-	rows := chatBoardRows(snapshot, request.ProjectID, request.State)
-	if len(rows) > limit {
-		rows = rows[:limit]
-	}
-	return chatJSONResult(struct {
-		GeneratedAt time.Time        `json:"generated_at"`
-		Counts      telemetry.Counts `json:"counts"`
-		Items       []chatBoardRow   `json:"items"`
-	}{GeneratedAt: snapshot.GeneratedAt, Counts: snapshot.Counts, Items: rows})
+func (s *Server) newChatToolExecutor() *dashboardToolExecutor {
+	readOnly := operatortool.NewExecutor(operatortool.Dependencies{
+		Snapshots: operatortool.SnapshotFunc(func(ctx context.Context) (telemetry.Snapshot, error) {
+			return s.chatSnapshot(ctx), nil
+		}),
+		Explainer: explain.New(s.explainDependencies()),
+	})
+	return &dashboardToolExecutor{readOnly: readOnly, server: s}
 }
 
-func (s *Server) chatFleetHealth(ctx context.Context) (chatpkg.ToolResult, error) {
-	snapshot := s.chatSnapshot(ctx)
-	return chatJSONResult(struct {
-		GeneratedAt        time.Time                    `json:"generated_at"`
-		Auth               telemetry.AuthHealth         `json:"auth"`
-		Shutdown           telemetry.Shutdown           `json:"shutdown"`
-		Refresh            telemetry.Refresh            `json:"refresh"`
-		Counts             telemetry.Counts             `json:"counts"`
-		RateLimits         *telemetry.RateLimits        `json:"rate_limits"`
-		BackendOutages     []telemetry.BackendOutage    `json:"backend_outages"`
-		FailureBreakers    []telemetry.FailureBreaker   `json:"failure_breakers"`
-		DispatchRecoveries []telemetry.DispatchRecovery `json:"dispatch_recoveries"`
-	}{snapshot.GeneratedAt, snapshot.Auth, snapshot.Shutdown, snapshot.Refresh, snapshot.Counts, snapshot.RateLimits, snapshot.BackendOutages, snapshot.FailureBreakers, snapshot.DispatchRecoveries})
+func (s *Server) explainDependencies() explain.Dependencies {
+	deps := explain.Dependencies{Snapshots: chatExplanationSnapshots{server: s}}
+	if s.store == nil {
+		return deps
+	}
+	deps.Workflow = s.store
+	deps.Attempts = s.store
+	deps.Admission = s.store
+	if scheduler, ok := s.store.(explain.SchedulerReader); ok {
+		deps.Scheduler = scheduler
+	}
+	if sessions, ok := s.store.(explain.SessionReader); ok {
+		deps.Sessions = sessions
+	}
+	return deps
 }
 
-func (s *Server) chatTelemetryUsage(ctx context.Context, raw json.RawMessage) (chatpkg.ToolResult, error) {
-	var request struct {
-		ProjectID string `json:"project_id"`
-	}
-	if err := decodeChatToolArguments(raw, &request); err != nil {
-		return chatpkg.ToolResult{}, err
-	}
-	snapshot := s.chatSnapshot(ctx)
-	projects := slices.Clone(snapshot.Projects)
-	if request.ProjectID != "" {
-		projects = slices.DeleteFunc(projects, func(candidate telemetry.ProjectSnapshot) bool {
-			return !strings.EqualFold(candidate.Project.ID, strings.TrimSpace(request.ProjectID))
-		})
-	}
-	return chatJSONResult(struct {
-		GeneratedAt    time.Time                   `json:"generated_at"`
-		Projects       []telemetry.ProjectSnapshot `json:"projects"`
-		Tokens         telemetry.Tokens            `json:"tokens"`
-		Throughput     telemetry.TokenThroughput   `json:"throughput"`
-		LifetimeTotals telemetry.LifetimeTotals    `json:"lifetime_totals"`
-		Budget         telemetry.Budget            `json:"budget"`
-	}{snapshot.GeneratedAt, projects, snapshot.Tokens, snapshot.Throughput, snapshot.LifetimeTotals, snapshot.Budget})
+type chatExplanationSnapshots struct {
+	server *Server
 }
 
-func (s *Server) chatRecentActivity(ctx context.Context, raw json.RawMessage) (chatpkg.ToolResult, error) {
-	var request struct {
-		ProjectID string `json:"project_id"`
-		Limit     int    `json:"limit"`
+func (s chatExplanationSnapshots) Snapshot(ctx context.Context) (explain.SnapshotObservation, error) {
+	snapshot := s.server.chatSnapshot(ctx)
+	observation := explain.SnapshotObservation{State: explain.SourceLive, Snapshot: snapshot}
+	if snapshot.GeneratedAt.IsZero() {
+		observation.State = explain.SourceUnavailable
 	}
-	if err := decodeChatToolArguments(raw, &request); err != nil {
-		return chatpkg.ToolResult{}, err
+	if snapshot.LastKnown {
+		observation.State = explain.SourceLastKnown
+		if !snapshot.LastKnownUntil.IsZero() {
+			expiresAt := snapshot.LastKnownUntil
+			observation.ExpiresAt = &expiresAt
+		}
 	}
-	snapshot := s.chatSnapshot(ctx)
-	events := slices.Clone(snapshot.Events)
-	completed := slices.Clone(snapshot.Completed)
-	if request.ProjectID != "" {
-		projectID := strings.TrimSpace(request.ProjectID)
-		completed = slices.DeleteFunc(completed, func(candidate telemetry.Completed) bool { return !strings.EqualFold(candidate.ProjectID, projectID) })
-	}
-	limit := chatToolLimit(request.Limit)
-	if len(events) > limit {
-		events = events[len(events)-limit:]
-	}
-	if len(completed) > limit {
-		completed = completed[:limit]
-	}
-	return chatJSONResult(struct {
-		GeneratedAt time.Time                 `json:"generated_at"`
-		Events      []telemetry.ActivityEvent `json:"events"`
-		Completed   []telemetry.Completed     `json:"completed"`
-	}{snapshot.GeneratedAt, events, completed})
+	return observation, nil
 }
 
 func (s *Server) chatMoveProposal(ctx context.Context, raw json.RawMessage) (chatpkg.ToolResult, error) {
@@ -613,66 +551,6 @@ func demoChatAction(action chatpkg.Action) string {
 	}
 }
 
-func chatBoardRows(snapshot telemetry.Snapshot, projectID string, state string) []chatBoardRow {
-	rows := make(map[string]chatBoardRow)
-	add := func(issue telemetry.Issue) {
-		key := issue.ProjectID + "\x00" + issue.ID
-		rows[key] = chatBoardRow{ProjectID: issue.ProjectID, IssueID: issue.ID, Identifier: issue.Identifier, Title: issue.Title, State: issue.State, Priority: issue.Priority, PriorityName: issue.PriorityName}
-	}
-	for _, issue := range snapshot.BoardIssues {
-		add(issue)
-	}
-	for _, issue := range snapshot.Pipeline {
-		add(issue)
-	}
-	for _, running := range snapshot.Running {
-		add(running.Issue)
-		key := running.ProjectID + "\x00" + running.ID
-		row := rows[key]
-		row.Active = true
-		row.Attempt = running.Attempt
-		row.WorkAttemptID = running.WorkAttemptID
-		row.DetentSessionID = running.DetentSessionID
-		row.ProviderSessionID = running.SessionID
-		rows[key] = row
-	}
-	for _, queued := range snapshot.Queue {
-		add(queued.Issue)
-	}
-	for _, blocked := range snapshot.Blocked {
-		issue := blocked.Issue
-		issue.State = "Blocked"
-		add(issue)
-		key := blocked.ProjectID + "\x00" + blocked.ID
-		row := rows[key]
-		row.BlockedReason = blocked.Error
-		row.BlockedSource = string(blocked.Source)
-		rows[key] = row
-	}
-	for _, completed := range snapshot.Completed {
-		add(completed.Issue)
-		key := completed.ProjectID + "\x00" + completed.ID
-		row := rows[key]
-		completedAt := completed.CompletedAt
-		row.CompletedAt = &completedAt
-		rows[key] = row
-	}
-	out := make([]chatBoardRow, 0, len(rows))
-	for _, row := range rows {
-		if projectID != "" && !strings.EqualFold(row.ProjectID, strings.TrimSpace(projectID)) {
-			continue
-		}
-		if state != "" && !strings.EqualFold(row.State, strings.TrimSpace(state)) {
-			continue
-		}
-		out = append(out, row)
-	}
-	slices.SortFunc(out, func(left chatBoardRow, right chatBoardRow) int {
-		return strings.Compare(left.Identifier, right.Identifier)
-	})
-	return out
-}
-
 func chatFindIssue(snapshot telemetry.Snapshot, projectID string, identifier string) (telemetry.Issue, bool) {
 	projectID = strings.TrimSpace(projectID)
 	identifier = strings.TrimSpace(identifier)
@@ -718,21 +596,6 @@ func decodeChatToolArguments(raw json.RawMessage, target any) error {
 	return nil
 }
 
-func chatJSONResult(value any) (chatpkg.ToolResult, error) {
-	data, err := json.Marshal(value)
-	if err != nil {
-		return chatpkg.ToolResult{}, err
-	}
-	return chatpkg.ToolResult{Content: string(data)}, nil
-}
-
-func chatToolLimit(limit int) int {
-	if limit <= 0 {
-		return defaultChatToolLimit
-	}
-	return min(limit, 200)
-}
-
 func trimChatStrings(values []string) []string {
 	out := make([]string, 0, len(values))
 	for _, value := range values {
@@ -743,5 +606,5 @@ func trimChatStrings(values []string) []string {
 	return out
 }
 
-var _ chatpkg.ToolExecutor = (*Server)(nil)
+var _ chatpkg.ToolExecutor = (*dashboardToolExecutor)(nil)
 var _ chatpkg.ActionExecutor = (*Server)(nil)

--- a/internal/web/chat_test.go
+++ b/internal/web/chat_test.go
@@ -3,6 +3,7 @@ package web_test
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/url"
 	"regexp"
@@ -57,6 +58,63 @@ func TestChatQuestionUsesLiveBoardToolAndPersistsSession(t *testing.T) {
 	reloaded := performDashboardHTMXRequest(t, server.Handler(), dashboardHTMXRequest{path: "/api/v1/chat", cookies: []*http.Cookie{cookie}, headers: map[string]string{"Authorization": "Bearer detent_test_token"}})
 	if !strings.Contains(reloaded.Body.String(), "What is blocked?") || !strings.Contains(reloaded.Body.String(), "Issue #1362 is blocked") {
 		t.Fatalf("reloaded conversation = %s", reloaded.Body.String())
+	}
+}
+
+func TestChatExplainItemUsesIssueExplanationReadModel(t *testing.T) {
+	t.Parallel()
+
+	observedAt := time.Date(2026, 8, 7, 20, 15, 0, 0, time.UTC)
+	toolCalled := false
+	deps := testDeps(t)
+	deps.Store = openWebTestStore(t)
+	deps.Chat = chatpkg.ProviderFunc(func(ctx context.Context, request chatpkg.TurnRequest) (chatpkg.TurnResponse, error) {
+		found := false
+		for _, tool := range request.Tools {
+			if tool.Name == "explain_item" {
+				found = true
+				break
+			}
+		}
+		if !found {
+			return chatpkg.TurnResponse{}, errors.New("explain_item was not discovered")
+		}
+		result, err := request.Handle(ctx, chatpkg.ToolCall{Name: "explain_item", Arguments: json.RawMessage(`{"project_id":"detent","reference":"digitaldrywood/detent#1647"}`)})
+		if err != nil {
+			return chatpkg.TurnResponse{}, err
+		}
+		var explanation struct {
+			Schema      int       `json:"schema"`
+			ObservedAt  time.Time `json:"observed_at"`
+			CurrentLane struct {
+				Name string `json:"name"`
+			} `json:"current_lane"`
+		}
+		if err := json.Unmarshal([]byte(result.Content), &explanation); err != nil {
+			return chatpkg.TurnResponse{}, err
+		}
+		toolCalled = explanation.Schema == 1 && !explanation.ObservedAt.IsZero() && explanation.CurrentLane.Name == "Rework"
+		return chatpkg.TurnResponse{Content: "Issue #1647 is in Rework because its latest transition requires another pass."}, nil
+	})
+	if err := deps.Hub.Publish(telemetry.Snapshot{
+		GeneratedAt: observedAt,
+		BoardIssues: []telemetry.Issue{{ID: "issue-1647", Identifier: "digitaldrywood/detent#1647", ProjectID: "detent", Title: "Extract operator tool executor", State: "Rework"}},
+	}); err != nil {
+		t.Fatalf("Publish() error = %v", err)
+	}
+	server, err := web.NewServer(web.Config{GlobalConfig: globalconfig.Config{APIToken: "detent_test_token"}}, deps)
+	if err != nil {
+		t.Fatalf("NewServer() error = %v", err)
+	}
+
+	panel := performDashboardHTMXRequest(t, server.Handler(), dashboardHTMXRequest{path: "/api/v1/chat", headers: map[string]string{"Authorization": "Bearer detent_test_token"}})
+	cookie := panel.Result().Cookies()[0]
+	message := performDashboardHTMXRequest(t, server.Handler(), dashboardHTMXRequest{method: http.MethodPost, path: "/api/v1/chat/messages", form: url.Values{"message": {"Why is issue 1647 in Rework?"}}, cookies: []*http.Cookie{cookie}, headers: map[string]string{"Authorization": "Bearer detent_test_token"}})
+	if message.Code != http.StatusOK || !strings.Contains(message.Body.String(), "latest transition") {
+		t.Fatalf("message status/body = %d/%s", message.Code, message.Body.String())
+	}
+	if !toolCalled {
+		t.Fatal("provider did not receive the versioned issue explanation result")
 	}
 }
 

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -272,7 +272,7 @@ func NewServer(cfg Config, deps Dependencies) (*Server, error) {
 	if server.demo != nil {
 		chatProvider = server.demoChatProvider()
 	}
-	server.chat = chatpkg.NewService(chatProvider, server, server)
+	server.chat = chatpkg.NewService(chatProvider, server.newChatToolExecutor(), server)
 	e.HTTPErrorHandler = server.handleHTTPError
 	e.Use(server.privateDashboardAccess, server.uiAPICookie, server.sessionGate)
 	server.registerRoutes()


### PR DESCRIPTION
## Summary

- Extract the read-only operator catalog, typed result contracts, bounds, and dependency-injected executor into a reusable component.
- Add `explain_item` backed directly by the versioned issue explanation read model, with live snapshot freshness and durable recorded evidence.
- Migrate dashboard chat to the reusable executor while keeping confirmation-gated mutation proposals dashboard-only.

Fixes #1647

## UI Surface Contract

- [x] N/A, or the linked issue explicitly authorizes any high-impact UI surface, layout, density, first-viewport, or responsive visibility tradeoff.
- [x] Persistent top-of-screen messaging is explicitly authorized by the issue, or this PR does not add it.
- [x] Visual changes to primary operator screens include screenshot or browser verification below.

No visual UI changes.

## Test Plan

- [x] `go test ./internal/operatortool ./internal/chat ./internal/web -count=1`
- [x] `go test -race ./internal/operatortool -count=1`
- [x] `make check`