### PR TITLE
fix(api): resolve idle issues in wildcard API

### DIFF
--- a/docs/dashboard-api.md
+++ b/docs/dashboard-api.md
@@ -186,7 +186,16 @@ Useful endpoints:
 | `/api/v1/projects/<id>/work-items` | Create a runtime work item with `POST` for `local_sqlite` and `github_local` trackers. |
 | `/api/v1/refresh` | Request an orchestrator refresh with `POST`. |
 | `/api/v1/webhooks/github` | Accept signed GitHub webhook deliveries with `POST`. |
-| `/api/v1/<issue>` | JSON detail for a running, retrying, or blocked issue. |
+| `/api/v1/<issue>` | JSON detail for a known board, pipeline, running, retrying, or blocked issue. |
+
+The wildcard issue route accepts an issue ID, canonical identifier, issue URL,
+bare number, or `#number`. Add `?project=<id>` when a number or other reference
+exists in more than one project; an unscoped collision returns
+`ambiguous_issue_reference`. The response reports the board `lane` separately
+from runtime `activity` (`idle`, `running`, `retrying`, or `blocked`). Board data
+takes precedence over pipeline and runtime copies for lane and identity, while
+runtime activity uses running, retrying, then blocked precedence. Completed and
+tracker-drift-only items are not part of this route.
 
 ### Dashboard Magic-Link Authentication
 

--- a/internal/explain/select.go
+++ b/internal/explain/select.go
@@ -70,11 +70,57 @@ func ResolveSnapshotIssue(snapshot telemetry.Snapshot, query Query, scope Snapsh
 	if len(matches) == 0 {
 		return SnapshotIssueSelection{}, ErrNotFound
 	}
-	identity, err := resolveIdentity(query, collectedEvidence{snapshotIssues: matches})
+	projectMatches, err := resolveSnapshotProject(query, matches)
 	if err != nil {
 		return SnapshotIssueSelection{}, err
 	}
-	return SnapshotIssueSelection{Identity: identity, Issue: matches[0].issue, Source: matches[0].source}, nil
+	if len(projectMatches) == 0 {
+		return SnapshotIssueSelection{}, ErrNotFound
+	}
+	selectedRank := projectMatches[0].rank
+	selectedMatches := []snapshotIssue{projectMatches[0]}
+	for _, match := range projectMatches[1:] {
+		if match.rank != selectedRank {
+			break
+		}
+		selectedMatches = append(selectedMatches, match)
+	}
+	identity, err := resolveIdentity(query, collectedEvidence{snapshotIssues: selectedMatches})
+	if err != nil {
+		return SnapshotIssueSelection{}, err
+	}
+	lookup := mergeLookupIdentity(store.IssueIdentity{
+		ProjectID:  identity.ProjectID,
+		IssueID:    identity.IssueID,
+		Identifier: identity.Identifier,
+		IssueURL:   identity.IssueURL,
+	}, identitiesFromSnapshot(projectMatches))
+	identity.ProjectID = lookup.ProjectID
+	identity.IssueID = lookup.IssueID
+	identity.Identifier = lookup.Identifier
+	identity.IssueURL = lookup.IssueURL
+	return SnapshotIssueSelection{Identity: identity, Issue: selectedMatches[0].issue, Source: selectedMatches[0].source}, nil
+}
+
+func resolveSnapshotProject(query Query, matches []snapshotIssue) ([]snapshotIssue, error) {
+	projectEvidence := make([]snapshotIssue, len(matches))
+	for index, match := range matches {
+		match.issue.ID = ""
+		match.issue.Identifier = ""
+		match.issue.URL = ""
+		projectEvidence[index] = match
+	}
+	identity, err := resolveIdentity(Query{ProjectID: query.ProjectID}, collectedEvidence{snapshotIssues: projectEvidence})
+	if err != nil {
+		return nil, err
+	}
+	projectMatches := make([]snapshotIssue, 0, len(matches))
+	for _, match := range matches {
+		if match.issue.ProjectID == identity.ProjectID {
+			projectMatches = append(projectMatches, match)
+		}
+	}
+	return projectMatches, nil
 }
 
 func matchingSnapshotIssuesInScope(snapshot telemetry.Snapshot, query Query, scope SnapshotIssueScope) []snapshotIssue {

--- a/internal/explain/select.go
+++ b/internal/explain/select.go
@@ -19,6 +19,16 @@ type snapshotIssue struct {
 	source string
 }
 
+type SnapshotIssueScope struct {
+	IncludeCompleted bool
+}
+
+type SnapshotIssueSelection struct {
+	Identity Identity
+	Issue    telemetry.Issue
+	Source   string
+}
+
 func normalizeSnapshotObservation(observation SnapshotObservation, now time.Time) SnapshotObservation {
 	if observation.ExpiresAt == nil && !observation.Snapshot.LastKnownUntil.IsZero() {
 		expiresAt := observation.Snapshot.LastKnownUntil.UTC()
@@ -47,7 +57,32 @@ func normalizeSnapshotObservation(observation SnapshotObservation, now time.Time
 }
 
 func matchingSnapshotIssues(snapshot telemetry.Snapshot, query Query) []snapshotIssue {
-	candidates := make([]snapshotIssue, 0, len(snapshot.BoardIssues)+len(snapshot.Pipeline)+len(snapshot.Running)+len(snapshot.Queue)+len(snapshot.Blocked)+len(snapshot.Completed))
+	return matchingSnapshotIssuesInScope(snapshot, query, SnapshotIssueScope{IncludeCompleted: true})
+}
+
+func ResolveSnapshotIssue(snapshot telemetry.Snapshot, query Query, scope SnapshotIssueScope) (SnapshotIssueSelection, error) {
+	query = normalizeQuery(query)
+	if !queryHasIssueReference(query) {
+		return SnapshotIssueSelection{}, ErrIssueReferenceNeeded
+	}
+
+	matches := matchingSnapshotIssuesInScope(snapshot, query, scope)
+	if len(matches) == 0 {
+		return SnapshotIssueSelection{}, ErrNotFound
+	}
+	identity, err := resolveIdentity(query, collectedEvidence{snapshotIssues: matches})
+	if err != nil {
+		return SnapshotIssueSelection{}, err
+	}
+	return SnapshotIssueSelection{Identity: identity, Issue: matches[0].issue, Source: matches[0].source}, nil
+}
+
+func matchingSnapshotIssuesInScope(snapshot telemetry.Snapshot, query Query, scope SnapshotIssueScope) []snapshotIssue {
+	capacity := len(snapshot.BoardIssues) + len(snapshot.Pipeline) + len(snapshot.Running) + len(snapshot.Queue) + len(snapshot.Blocked)
+	if scope.IncludeCompleted {
+		capacity += len(snapshot.Completed)
+	}
+	candidates := make([]snapshotIssue, 0, capacity)
 	for _, issue := range snapshot.BoardIssues {
 		candidates = append(candidates, snapshotIssue{issue: issue, rank: 0, source: "board"})
 	}
@@ -63,8 +98,10 @@ func matchingSnapshotIssues(snapshot telemetry.Snapshot, query Query) []snapshot
 	for _, issue := range snapshot.Blocked {
 		candidates = append(candidates, snapshotIssue{issue: issue.Issue, rank: 4, source: "blocked"})
 	}
-	for _, issue := range snapshot.Completed {
-		candidates = append(candidates, snapshotIssue{issue: issue.Issue, rank: 5, source: "completed"})
+	if scope.IncludeCompleted {
+		for _, issue := range snapshot.Completed {
+			candidates = append(candidates, snapshotIssue{issue: issue.Issue, rank: 5, source: "completed"})
+		}
 	}
 
 	matches := make([]snapshotIssue, 0, 1)
@@ -73,7 +110,10 @@ func matchingSnapshotIssues(snapshot telemetry.Snapshot, query Query) []snapshot
 		if projectID == "" {
 			projectID = strings.TrimSpace(snapshot.Project.ID)
 		}
-		if projectID != query.ProjectID || !queryMatchesIssue(query, candidate.issue) {
+		if query.ProjectID != "" && projectID != query.ProjectID {
+			continue
+		}
+		if !queryMatchesIssue(query, candidate.issue) {
 			continue
 		}
 		candidate.issue.ProjectID = projectID
@@ -210,16 +250,18 @@ func issueValuesMatch(identity store.IssueIdentity, issueID string, identifier s
 }
 
 func resolveIdentity(query Query, collected collectedEvidence) (Identity, error) {
+	projectIDs := map[string]struct{}{}
 	issueIDs := map[string]struct{}{}
 	identifiers := map[string]struct{}{}
 	issueURLs := map[string]struct{}{}
 	add := func(identity store.IssueIdentity) {
+		addIdentityValue(projectIDs, identity.ProjectID)
 		addIdentityValue(issueIDs, identity.IssueID)
 		addIdentityValue(identifiers, identity.Identifier)
 		addIdentityValue(issueURLs, identity.IssueURL)
 	}
 	if query.IssueID != "" || query.Identifier != "" || query.IssueURL != "" {
-		add(store.IssueIdentity{IssueID: query.IssueID, Identifier: query.Identifier, IssueURL: query.IssueURL})
+		add(store.IssueIdentity{ProjectID: query.ProjectID, IssueID: query.IssueID, Identifier: query.Identifier, IssueURL: query.IssueURL})
 	}
 	for _, identity := range identitiesFromSnapshot(collected.snapshotIssues) {
 		add(identity)
@@ -237,6 +279,7 @@ func resolveIdentity(query Query, collected collectedEvidence) (Identity, error)
 		name   string
 		values map[string]struct{}
 	}{
+		{name: "project_id", values: projectIDs},
 		{name: "issue_id", values: issueIDs},
 		{name: "identifier", values: identifiers},
 		{name: "issue_url", values: issueURLs},
@@ -247,7 +290,7 @@ func resolveIdentity(query Query, collected collectedEvidence) (Identity, error)
 	}
 
 	identity := Identity{
-		ProjectID:  query.ProjectID,
+		ProjectID:  firstIdentityValue(projectIDs, query.ProjectID),
 		IssueID:    firstIdentityValue(issueIDs, query.IssueID),
 		Identifier: firstIdentityValue(identifiers, query.Identifier),
 		IssueURL:   firstIdentityValue(issueURLs, query.IssueURL),

--- a/internal/explain/select_test.go
+++ b/internal/explain/select_test.go
@@ -1,0 +1,122 @@
+package explain
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/digitaldrywood/detent/internal/telemetry"
+)
+
+func TestResolveSnapshotIssueReferenceForms(t *testing.T) {
+	t.Parallel()
+
+	issue := telemetry.Issue{
+		ID:         "issue-1640",
+		Identifier: "digitaldrywood/detent#1640",
+		Number:     1640,
+		ProjectID:  "detent",
+		URL:        "https://github.com/digitaldrywood/detent/issues/1640",
+		State:      "Rework",
+	}
+	snapshot := telemetry.Snapshot{BoardIssues: []telemetry.Issue{issue}}
+	tests := []struct {
+		name      string
+		reference string
+	}{
+		{name: "ID", reference: issue.ID},
+		{name: "canonical identifier", reference: issue.Identifier},
+		{name: "URL", reference: issue.URL},
+		{name: "bare number", reference: "1640"},
+		{name: "hash number", reference: "#1640"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := ResolveSnapshotIssue(snapshot, Query{Reference: tt.reference}, SnapshotIssueScope{})
+			if err != nil {
+				t.Fatalf("ResolveSnapshotIssue() error = %v", err)
+			}
+			if got.Identity.IssueID != issue.ID || got.Identity.ProjectID != issue.ProjectID || got.Source != "board" {
+				t.Fatalf("ResolveSnapshotIssue() = %#v, want board identity", got)
+			}
+		})
+	}
+}
+
+func TestResolveSnapshotIssuePrecedenceAndScope(t *testing.T) {
+	t.Parallel()
+
+	base := telemetry.Issue{ID: "issue-1", Identifier: "example/repo#1", Number: 1, ProjectID: "detent"}
+	board := base
+	board.State = "Rework"
+	pipeline := base
+	pipeline.State = "Todo"
+	runtime := base
+	runtime.State = "In Progress"
+	completed := base
+	completed.State = "Done"
+	tests := []struct {
+		name       string
+		snapshot   telemetry.Snapshot
+		scope      SnapshotIssueScope
+		wantSource string
+		wantLane   string
+		wantErr    error
+	}{
+		{
+			name: "board precedes pipeline and runtime duplicates",
+			snapshot: telemetry.Snapshot{
+				BoardIssues: []telemetry.Issue{board},
+				Pipeline:    []telemetry.Issue{pipeline},
+				Running:     []telemetry.Running{{Issue: runtime}},
+			},
+			wantSource: "board",
+			wantLane:   "Rework",
+		},
+		{
+			name:     "completed excluded by default",
+			snapshot: telemetry.Snapshot{Completed: []telemetry.Completed{{Issue: completed}}},
+			wantErr:  ErrNotFound,
+		},
+		{
+			name:       "completed included explicitly",
+			snapshot:   telemetry.Snapshot{Completed: []telemetry.Completed{{Issue: completed}}},
+			scope:      SnapshotIssueScope{IncludeCompleted: true},
+			wantSource: "completed",
+			wantLane:   "Done",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := ResolveSnapshotIssue(tt.snapshot, Query{ProjectID: "detent", Reference: "#1"}, tt.scope)
+			if !errors.Is(err, tt.wantErr) {
+				t.Fatalf("ResolveSnapshotIssue() error = %v, want %v", err, tt.wantErr)
+			}
+			if tt.wantErr != nil {
+				return
+			}
+			if got.Source != tt.wantSource || got.Issue.State != tt.wantLane {
+				t.Fatalf("ResolveSnapshotIssue() = %#v, want %s/%s", got, tt.wantSource, tt.wantLane)
+			}
+		})
+	}
+}
+
+func TestResolveSnapshotIssueRejectsProjectCollision(t *testing.T) {
+	t.Parallel()
+
+	snapshot := telemetry.Snapshot{BoardIssues: []telemetry.Issue{
+		{ID: "alpha-1", Identifier: "example/alpha#1", Number: 1, ProjectID: "alpha"},
+		{ID: "beta-1", Identifier: "example/beta#1", Number: 1, ProjectID: "beta"},
+	}}
+	_, err := ResolveSnapshotIssue(snapshot, Query{Reference: "#1"}, SnapshotIssueScope{})
+	var ambiguous *AmbiguousIdentityError
+	if !errors.As(err, &ambiguous) || ambiguous.Field != "project_id" {
+		t.Fatalf("ResolveSnapshotIssue() error = %#v, want project ambiguity", err)
+	}
+}

--- a/internal/explain/select_test.go
+++ b/internal/explain/select_test.go
@@ -57,6 +57,9 @@ func TestResolveSnapshotIssuePrecedenceAndScope(t *testing.T) {
 	runtime.State = "In Progress"
 	completed := base
 	completed.State = "Done"
+	staleRuntime := runtime
+	staleRuntime.Identifier = "example/renamed#1"
+	staleRuntime.URL = "https://example.com/renamed/issues/1"
 	tests := []struct {
 		name       string
 		snapshot   telemetry.Snapshot
@@ -71,6 +74,15 @@ func TestResolveSnapshotIssuePrecedenceAndScope(t *testing.T) {
 				BoardIssues: []telemetry.Issue{board},
 				Pipeline:    []telemetry.Issue{pipeline},
 				Running:     []telemetry.Running{{Issue: runtime}},
+			},
+			wantSource: "board",
+			wantLane:   "Rework",
+		},
+		{
+			name: "stale lower precedence identity does not create ambiguity",
+			snapshot: telemetry.Snapshot{
+				BoardIssues: []telemetry.Issue{board},
+				Running:     []telemetry.Running{{Issue: staleRuntime}},
 			},
 			wantSource: "board",
 			wantLane:   "Rework",

--- a/internal/web/api.go
+++ b/internal/web/api.go
@@ -13,6 +13,7 @@ import (
 	"github.com/labstack/echo/v4"
 
 	"github.com/digitaldrywood/detent/internal/budget"
+	"github.com/digitaldrywood/detent/internal/explain"
 	"github.com/digitaldrywood/detent/internal/orchestrator"
 	"github.com/digitaldrywood/detent/internal/runtimeoutput"
 	"github.com/digitaldrywood/detent/internal/store"
@@ -186,21 +187,31 @@ func (s *Server) apiIssue(c echo.Context) error {
 	if scenario, ok, err := s.demoScenarioOrError(c); err != nil {
 		return err
 	} else if ok {
-		payload, found := issueResponse(issueIdentifier(c), demofixtures.SnapshotForScenario(scenario.ProjectID, scenario.Variant))
-		if !found {
-			return c.JSON(http.StatusNotFound, errorResponse("issue_not_found", "Issue not found"))
-		}
-		return c.JSON(http.StatusOK, payload)
+		return apiIssueResponse(c, demofixtures.SnapshotForScenario(scenario.ProjectID, scenario.Variant))
 	}
 	snapshot, ok := s.hub.Latest()
 	if !ok {
-		return c.JSON(http.StatusNotFound, errorResponse("issue_not_found", "Issue not found"))
+		return c.JSON(http.StatusServiceUnavailable, errorResponse("snapshot_unavailable", "Snapshot unavailable"))
 	}
 	snapshot = s.cachedEnrichedSnapshot(c.Request().Context(), snapshot)
 
-	payload, ok := issueResponse(issueIdentifier(c), snapshot)
-	if !ok {
+	return apiIssueResponse(c, snapshot)
+}
+
+func apiIssueResponse(c echo.Context, snapshot telemetry.Snapshot) error {
+	payload, err := issueResponse(issueIdentifier(c), c.QueryParam("project"), snapshot)
+	if errors.Is(err, explain.ErrIssueReferenceNeeded) {
+		return c.JSON(http.StatusBadRequest, errorResponse("issue_reference_required", "Issue reference is required"))
+	}
+	var ambiguous *explain.AmbiguousIdentityError
+	if errors.As(err, &ambiguous) {
+		return c.JSON(http.StatusConflict, errorResponse("ambiguous_issue_reference", "Issue reference is ambiguous; specify project"))
+	}
+	if errors.Is(err, explain.ErrNotFound) {
 		return c.JSON(http.StatusNotFound, errorResponse("issue_not_found", "Issue not found"))
+	}
+	if err != nil {
+		return c.JSON(http.StatusInternalServerError, errorResponse("issue_resolution_failed", "Issue resolution failed"))
 	}
 
 	return c.JSON(http.StatusOK, payload)
@@ -535,62 +546,59 @@ func boardResponse(snapshot telemetry.Snapshot) boardAPIResponse {
 	}
 }
 
-func issueResponse(identifier string, snapshot telemetry.Snapshot) (issueAPIResponse, bool) {
-	if running, ok := findRunning(identifier, snapshot.Running); ok {
-		return issueAPIResponse{
-			IssueIdentifier: running.Identifier,
-			IssueID:         running.ID,
-			Status:          "running",
-			Workspace:       workspaceResponse(running.WorkspacePath, running.WorkerHost),
-			Attempts:        attemptsAPIResponse{},
-			Running:         runningIssueResponse(running),
-			Retry:           nil,
-			Blocked:         nil,
-			Logs:            logsAPIResponse{CodexSessionLogs: []logAPIResponse{}},
-			RecentEvents:    recentEventsFromTelemetry(running.RecentEvents, running.LastEventAt, running.LastEvent, running.LastMessage),
-			LastError:       nil,
-			Tracked:         map[string]any{},
-		}, true
+func issueResponse(reference string, projectID string, snapshot telemetry.Snapshot) (issueAPIResponse, error) {
+	resolved, err := explain.ResolveSnapshotIssue(snapshot, explain.Query{ProjectID: projectID, Reference: reference}, explain.SnapshotIssueScope{})
+	if err != nil {
+		return issueAPIResponse{}, err
 	}
-	if retry, ok := findRetry(identifier, snapshot.Queue); ok {
-		err := optionalString(retry.Error)
-		return issueAPIResponse{
-			IssueIdentifier: retry.Identifier,
-			IssueID:         retry.ID,
-			Status:          "retrying",
-			Workspace:       workspaceResponse(retry.WorkspacePath, retry.WorkerHost),
-			Attempts: attemptsAPIResponse{
-				RestartCount:        max(retry.Attempt-1, 0),
-				CurrentRetryAttempt: retry.Attempt,
-			},
-			Running:      nil,
-			Retry:        retryIssueResponse(retry),
-			Blocked:      nil,
-			Logs:         logsAPIResponse{CodexSessionLogs: []logAPIResponse{}},
-			RecentEvents: []recentEventAPIResponse{},
-			LastError:    err,
-			Tracked:      map[string]any{},
-		}, true
+	payload := issueAPIResponse{
+		IssueIdentifier: resolved.Identity.Identifier,
+		IssueID:         resolved.Identity.IssueID,
+		ProjectID:       resolved.Identity.ProjectID,
+		Status:          "idle",
+		Lane:            resolved.Issue.State,
+		Activity:        "idle",
+		Workspace:       workspaceResponse("", ""),
+		Attempts:        attemptsAPIResponse{},
+		Running:         nil,
+		Retry:           nil,
+		Blocked:         nil,
+		Logs:            logsAPIResponse{CodexSessionLogs: []logAPIResponse{}},
+		RecentEvents:    []recentEventAPIResponse{},
+		LastError:       nil,
+		Tracked:         map[string]any{},
 	}
-	if blocked, ok := findBlocked(identifier, snapshot.Blocked); ok {
-		err := optionalString(blocked.Error)
-		return issueAPIResponse{
-			IssueIdentifier: blocked.Identifier,
-			IssueID:         blocked.ID,
-			Status:          "blocked",
-			Workspace:       workspaceResponse(blocked.WorkspacePath, blocked.WorkerHost),
-			Attempts:        attemptsAPIResponse{},
-			Running:         nil,
-			Retry:           nil,
-			Blocked:         blockedIssueResponse(blocked),
-			Logs:            logsAPIResponse{CodexSessionLogs: []logAPIResponse{}},
-			RecentEvents:    recentEvents(blocked.LastEventAt, blocked.LastEvent, blocked.LastMessage),
-			LastError:       err,
-			Tracked:         map[string]any{},
-		}, true
+	if running, ok := findRunning(resolved.Identity, snapshot.Running); ok {
+		payload.Status = "running"
+		payload.Activity = "running"
+		payload.Workspace = workspaceResponse(running.WorkspacePath, running.WorkerHost)
+		payload.Running = runningIssueResponse(running)
+		payload.RecentEvents = recentEventsFromTelemetry(running.RecentEvents, running.LastEventAt, running.LastEvent, running.LastMessage)
+		return payload, nil
+	}
+	if retry, ok := findRetry(resolved.Identity, snapshot.Queue); ok {
+		payload.Status = "retrying"
+		payload.Activity = "retrying"
+		payload.Workspace = workspaceResponse(retry.WorkspacePath, retry.WorkerHost)
+		payload.Attempts = attemptsAPIResponse{
+			RestartCount:        max(retry.Attempt-1, 0),
+			CurrentRetryAttempt: retry.Attempt,
+		}
+		payload.Retry = retryIssueResponse(retry)
+		payload.LastError = optionalString(retry.Error)
+		return payload, nil
+	}
+	if blocked, ok := findBlocked(resolved.Identity, snapshot.Blocked); ok {
+		payload.Status = "blocked"
+		payload.Activity = "blocked"
+		payload.Workspace = workspaceResponse(blocked.WorkspacePath, blocked.WorkerHost)
+		payload.Blocked = blockedIssueResponse(blocked)
+		payload.RecentEvents = recentEvents(blocked.LastEventAt, blocked.LastEvent, blocked.LastMessage)
+		payload.LastError = optionalString(blocked.Error)
+		return payload, nil
 	}
 
-	return issueAPIResponse{}, false
+	return payload, nil
 }
 
 func countsResponse(snapshot telemetry.Snapshot) countsAPIResponse {
@@ -818,35 +826,41 @@ func recentEventsFromTelemetry(events []telemetry.ActivityEvent, fallbackAt *tim
 	return payload
 }
 
-func findRunning(identifier string, entries []telemetry.Running) (telemetry.Running, bool) {
+func findRunning(identity explain.Identity, entries []telemetry.Running) (telemetry.Running, bool) {
 	for _, entry := range entries {
-		if issueMatches(entry.Issue, identifier) {
+		if issueMatchesIdentity(entry.Issue, identity) {
 			return entry, true
 		}
 	}
 	return telemetry.Running{}, false
 }
 
-func findRetry(identifier string, entries []telemetry.Queued) (telemetry.Queued, bool) {
+func findRetry(identity explain.Identity, entries []telemetry.Queued) (telemetry.Queued, bool) {
 	for _, entry := range entries {
-		if issueMatches(entry.Issue, identifier) {
+		if issueMatchesIdentity(entry.Issue, identity) {
 			return entry, true
 		}
 	}
 	return telemetry.Queued{}, false
 }
 
-func findBlocked(identifier string, entries []telemetry.Blocked) (telemetry.Blocked, bool) {
+func findBlocked(identity explain.Identity, entries []telemetry.Blocked) (telemetry.Blocked, bool) {
 	for _, entry := range entries {
-		if issueMatches(entry.Issue, identifier) {
+		if issueMatchesIdentity(entry.Issue, identity) {
 			return entry, true
 		}
 	}
 	return telemetry.Blocked{}, false
 }
 
-func issueMatches(issue telemetry.Issue, value string) bool {
-	return value != "" && (issue.Identifier == value || issue.ID == value)
+func issueMatchesIdentity(issue telemetry.Issue, identity explain.Identity) bool {
+	if issue.ProjectID != "" && identity.ProjectID != "" && issue.ProjectID != identity.ProjectID {
+		return false
+	}
+	return issue.ID != "" && issue.ID == identity.IssueID ||
+		issue.Identifier != "" && issue.Identifier == identity.Identifier ||
+		issue.URL != "" && issue.URL == identity.IssueURL ||
+		issue.Number > 0 && issue.Number == identity.Number
 }
 
 func workspaceResponse(path string, host string) workspaceAPIResponse {
@@ -1340,10 +1354,15 @@ func generatedAt(snapshot telemetry.Snapshot, fallback time.Time) time.Time {
 }
 
 func issueIdentifier(c echo.Context) string {
+	value := c.Param("*")
 	if issue := c.Param("issue"); issue != "" {
-		return issue
+		value = issue
 	}
-	return c.Param("*")
+	decoded, err := url.PathUnescape(value)
+	if err != nil {
+		return value
+	}
+	return decoded
 }
 
 func errorResponse(code string, message string) apiErrorResponse {
@@ -1686,7 +1705,10 @@ type workflowPhaseEventAPIResponse struct {
 type issueAPIResponse struct {
 	IssueIdentifier string                   `json:"issue_identifier"`
 	IssueID         string                   `json:"issue_id"`
+	ProjectID       string                   `json:"project_id,omitempty"`
 	Status          string                   `json:"status"`
+	Lane            string                   `json:"lane,omitempty"`
+	Activity        string                   `json:"activity"`
 	Workspace       workspaceAPIResponse     `json:"workspace"`
 	Attempts        attemptsAPIResponse      `json:"attempts"`
 	Running         *runningIssueAPIResponse `json:"running"`

--- a/internal/web/api_issue_test.go
+++ b/internal/web/api_issue_test.go
@@ -1,0 +1,203 @@
+package web_test
+
+import (
+	"net/http"
+	"net/url"
+	"testing"
+
+	"github.com/digitaldrywood/detent/internal/hub"
+	"github.com/digitaldrywood/detent/internal/telemetry"
+	"github.com/digitaldrywood/detent/internal/web"
+)
+
+func TestAPIIssueResolvesIdleBoardReferences(t *testing.T) {
+	t.Parallel()
+
+	issue := telemetry.Issue{
+		ID:         "issue-1640",
+		Identifier: "digitaldrywood/detent#1640",
+		Number:     1640,
+		ProjectID:  "detent",
+		URL:        "https://github.com/digitaldrywood/detent/issues/1640",
+		State:      "Rework",
+	}
+	tests := []struct {
+		name      string
+		reference string
+	}{
+		{name: "ID", reference: issue.ID},
+		{name: "canonical identifier", reference: issue.Identifier},
+		{name: "URL", reference: issue.URL},
+		{name: "bare number", reference: "1640"},
+		{name: "hash number", reference: "#1640"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			snapshots := hub.New[telemetry.Snapshot]()
+			if err := snapshots.Publish(telemetry.Snapshot{BoardIssues: []telemetry.Issue{issue}}); err != nil {
+				t.Fatalf("Publish() error = %v", err)
+			}
+			deps := testDeps(t)
+			deps.Hub = snapshots
+			server, err := web.NewServer(web.Config{}, deps)
+			if err != nil {
+				t.Fatalf("NewServer() error = %v", err)
+			}
+
+			payload := requestJSON(t, server, http.MethodGet, "/api/v1/"+url.PathEscape(tt.reference), http.StatusOK)
+			if payload["issue_id"] != issue.ID || payload["issue_identifier"] != issue.Identifier {
+				t.Fatalf("identity = %#v, want %s / %s", payload, issue.ID, issue.Identifier)
+			}
+			if payload["lane"] != "Rework" || payload["activity"] != "idle" {
+				t.Fatalf("lane/activity = %#v/%#v, want Rework/idle", payload["lane"], payload["activity"])
+			}
+		})
+	}
+}
+
+func TestAPIIssuePrecedenceAndScope(t *testing.T) {
+	t.Parallel()
+
+	base := telemetry.Issue{
+		ID:         "issue-42",
+		Identifier: "digitaldrywood/detent#42",
+		Number:     42,
+		ProjectID:  "detent",
+		URL:        "https://github.com/digitaldrywood/detent/issues/42",
+	}
+	board := base
+	board.State = "Rework"
+	pipeline := base
+	pipeline.State = "Todo"
+	running := base
+	running.State = "In Progress"
+	snapshots := hub.New[telemetry.Snapshot]()
+	if err := snapshots.Publish(telemetry.Snapshot{
+		BoardIssues: []telemetry.Issue{board},
+		Pipeline:    []telemetry.Issue{pipeline},
+		Running:     []telemetry.Running{{Issue: running}},
+		Queue:       []telemetry.Queued{{Issue: running}},
+		Blocked:     []telemetry.Blocked{{Issue: running}},
+	}); err != nil {
+		t.Fatalf("Publish() error = %v", err)
+	}
+	deps := testDeps(t)
+	deps.Hub = snapshots
+	server, err := web.NewServer(web.Config{}, deps)
+	if err != nil {
+		t.Fatalf("NewServer() error = %v", err)
+	}
+
+	payload := requestJSON(t, server, http.MethodGet, "/api/v1/%2342", http.StatusOK)
+	if payload["lane"] != "Rework" || payload["activity"] != "running" || payload["status"] != "running" {
+		t.Fatalf("precedence payload = %#v, want board lane and running activity", payload)
+	}
+	if payload["retry"] != nil || payload["blocked"] != nil {
+		t.Fatalf("runtime precedence payload = %#v, want exactly one running overlay", payload)
+	}
+}
+
+func TestAPIIssueProjectCollision(t *testing.T) {
+	t.Parallel()
+
+	issues := []telemetry.Issue{
+		{ID: "alpha-42", Identifier: "example/alpha#42", Number: 42, ProjectID: "alpha", State: "Todo"},
+		{ID: "beta-42", Identifier: "example/beta#42", Number: 42, ProjectID: "beta", State: "Rework"},
+	}
+	snapshots := hub.New[telemetry.Snapshot]()
+	if err := snapshots.Publish(telemetry.Snapshot{BoardIssues: issues}); err != nil {
+		t.Fatalf("Publish() error = %v", err)
+	}
+	deps := testDeps(t)
+	deps.Hub = snapshots
+	server, err := web.NewServer(web.Config{}, deps)
+	if err != nil {
+		t.Fatalf("NewServer() error = %v", err)
+	}
+
+	ambiguous := requestJSON(t, server, http.MethodGet, "/api/v1/%2342", http.StatusConflict)
+	if nestedString(t, ambiguous, "error", "code") != "ambiguous_issue_reference" {
+		t.Fatalf("ambiguity payload = %#v", ambiguous)
+	}
+	scoped := requestJSON(t, server, http.MethodGet, "/api/v1/%2342?project=beta", http.StatusOK)
+	if scoped["issue_id"] != "beta-42" || scoped["project_id"] != "beta" {
+		t.Fatalf("scoped payload = %#v, want beta issue", scoped)
+	}
+}
+
+func TestAPIIssueScopeAndUnavailableSnapshot(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		snapshot   *telemetry.Snapshot
+		path       string
+		wantStatus int
+		wantCode   string
+	}{
+		{
+			name: "completed is excluded",
+			snapshot: &telemetry.Snapshot{Completed: []telemetry.Completed{{Issue: telemetry.Issue{
+				ID: "completed-1", Identifier: "example/repo#1", Number: 1, ProjectID: "detent", State: "Done",
+			}}}},
+			path:       "/api/v1/completed-1",
+			wantStatus: http.StatusNotFound,
+			wantCode:   "issue_not_found",
+		},
+		{
+			name: "drift-only is excluded",
+			snapshot: &telemetry.Snapshot{TrackerDrift: telemetry.TrackerDrift{
+				UntrackedOpen: []telemetry.Issue{{ID: "drift-only", ProjectID: "detent", State: "Todo"}},
+			}},
+			path:       "/api/v1/drift-only",
+			wantStatus: http.StatusNotFound,
+			wantCode:   "issue_not_found",
+		},
+		{
+			name:       "snapshot unavailable",
+			path:       "/api/v1/issue-1",
+			wantStatus: http.StatusServiceUnavailable,
+			wantCode:   "snapshot_unavailable",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			snapshots := hub.New[telemetry.Snapshot]()
+			if tt.snapshot != nil {
+				if err := snapshots.Publish(*tt.snapshot); err != nil {
+					t.Fatalf("Publish() error = %v", err)
+				}
+			}
+			deps := testDeps(t)
+			deps.Hub = snapshots
+			server, err := web.NewServer(web.Config{}, deps)
+			if err != nil {
+				t.Fatalf("NewServer() error = %v", err)
+			}
+
+			payload := requestJSON(t, server, http.MethodGet, tt.path, tt.wantStatus)
+			if got := nestedString(t, payload, "error", "code"); got != tt.wantCode {
+				t.Fatalf("error code = %q, want %q; payload = %#v", got, tt.wantCode, payload)
+			}
+		})
+	}
+}
+
+func TestAPIIssueExplicitRoutesPrecedeCatchAll(t *testing.T) {
+	t.Parallel()
+
+	server, err := web.NewServer(web.Config{}, testDeps(t))
+	if err != nil {
+		t.Fatalf("NewServer() error = %v", err)
+	}
+	payload := requestJSON(t, server, http.MethodGet, "/api/v1/state", http.StatusOK)
+	if _, ok := payload["generated_at"]; !ok || payload["issue_id"] != nil {
+		t.Fatalf("state route payload = %#v, want explicit state handler", payload)
+	}
+}


### PR DESCRIPTION
## Summary

- resolve wildcard issue references through the canonical explanation snapshot resolver
- return idle board and pipeline items with separate lane and runtime activity fields
- reject cross-project collisions, distinguish unavailable snapshots, and keep completed/drift-only items out of scope

Fixes #1640

## UI Surface Contract

- [x] N/A, or the linked issue explicitly authorizes any high-impact UI surface, layout, density, first-viewport, or responsive visibility tradeoff.
- [x] Persistent top-of-screen messaging is explicitly authorized by the issue, or this PR does not add it.
- [x] Visual changes to primary operator screens include screenshot or browser verification below.

No UI changes.

## Test Plan

- [x] `go test ./internal/explain ./internal/web -count=1`
- [x] `make check`