### PR TITLE
feat(auth): add opt-in loopback peer read trust

### DIFF
--- a/docs/ONBOARDING.md
+++ b/docs/ONBOARDING.md
@@ -3023,7 +3023,7 @@ awk 'NF {last=$0} END {exit last == "MUTATION_CONFIRMED=true" ? 0 : 1}' "$ONBOAR
    | Field | Reload behavior |
    | --- | --- |
    | Project list and project settings | Live reload |
-   | Credentials: `github_token` and project credentials | Live reload |
+   | Credentials: `github_token`, `trust_loopback_peer_read`, and project credentials | Live reload |
    | `global.startup` | Live reload |
    | `instance_name` | Live reload |
    | `global.identity` | Live reload; project runtimes restart in-process and `/api/v1/state.instance.name` updates after the next telemetry snapshot |

--- a/docs/config.md
+++ b/docs/config.md
@@ -39,6 +39,7 @@ Runtime settings resolve in this order: explicit flag, environment variable,
 | Log backups | | `LOG_MAX_BACKUPS`, then `DETENT_LOG_MAX_BACKUPS` | `log_max_backups` | `5` |
 | GitHub token | | `GITHUB_TOKEN` | `github_token` | required for GitHub projects |
 | API token | | `DETENT_API_TOKEN` | `api_token` | open on loopback, fail closed on non-loopback |
+| Loopback peer read trust | | | `trust_loopback_peer_read` | `false` |
 | Private dashboard URL | | | `dashboard_access` | disabled |
 | Web port | `--port` | `PORT` | `port` | `4000` |
 | Instance name | | | `instance_name` | short hostname |
@@ -56,6 +57,15 @@ committed. `github_token: gh-auth`, `${gh auth token}`, and
 `$(gh auth token)` are accepted aliases. If neither `GITHUB_TOKEN` nor
 `github_token` is set, Detent falls back to existing per-workflow
 `tracker.api_key` handling.
+
+Set `trust_loopback_peer_read: true` to grant tokenless read-scope API access
+to direct loopback TCP peers even when Detent binds a non-loopback address or
+has an `api_token`. The setting hot-reloads and applies only to `GET` routes;
+admin routes and mutations still require credentials. Authentication uses only
+the request's direct peer address and never trusts forwarded-client headers.
+Do not enable this setting when a reverse proxy runs on the same host: every
+request relayed by that proxy has a loopback direct peer, including requests
+that originally came from remote clients.
 
 Use `instance_name` to distinguish browser tabs and the dashboard navbar when
 several Detent instances are open at once. Detent resolves the display name

--- a/docs/dashboard-api.md
+++ b/docs/dashboard-api.md
@@ -347,6 +347,18 @@ API routes fail closed and mutating routes return `403` until a token is
 configured. With no token on loopback, read-only API routes remain open for
 local development.
 
+For a non-loopback bind that still needs tokenless same-host reads, opt in with
+`trust_loopback_peer_read: true` in `global.yaml`. Detent then grants a
+read-only credential to `GET` requests whose raw TCP peer address is loopback,
+even when `api_token` is configured. A supplied invalid, expired, or revoked
+token still fails authentication. `X-Forwarded-For`, `Forwarded`,
+`X-Real-IP`, and other forwarded-client metadata never affect this decision.
+The setting hot-reloads.
+
+Do not enable `trust_loopback_peer_read` behind a reverse proxy on the same
+host. Every remote request relayed by that proxy appears to Detent to have a
+loopback direct peer and would receive read access.
+
 ### Private Dashboard URL Access
 
 For a personal deployment that needs remote dashboard access without a VPN,

--- a/docs/multi-project.md
+++ b/docs/multi-project.md
@@ -240,7 +240,7 @@ can include `--workflow-ref origin/main` during registration or add
 | Field | Reload behavior |
 | --- | --- |
 | Project list and project settings, including active hours and overrides | Live reload |
-| Credentials: `github_token` and project credentials | Live reload |
+| Credentials: `github_token`, `trust_loopback_peer_read`, and project credentials | Live reload |
 | `dashboard_access` mode, token, and write access | Live reload; token changes invalidate private dashboard sessions |
 | `auth` | Restart required; persisted sessions remain valid until their configured expiry |
 | `global.startup` | Live reload |

--- a/internal/apikey/service.go
+++ b/internal/apikey/service.go
@@ -15,9 +15,10 @@ import (
 )
 
 const (
-	DefaultExpiresIn = "90d"
-	DefaultMaxKeys   = 25
-	StaticKeyID      = "static"
+	DefaultExpiresIn      = "90d"
+	DefaultMaxKeys        = 25
+	StaticKeyID           = "static"
+	LoopbackPeerReadKeyID = "loopback-peer-read"
 )
 
 var (
@@ -199,6 +200,16 @@ func StaticCredential() Credential {
 		Name:        "Static API token",
 		PrefixLast4: StaticKeyID,
 		Scopes:      []string{string(ScopeAdmin)},
+		Static:      true,
+	}
+}
+
+func LoopbackPeerReadCredential() Credential {
+	return Credential{
+		ID:          LoopbackPeerReadKeyID,
+		Name:        "Loopback peer read trust",
+		PrefixLast4: LoopbackPeerReadKeyID,
+		Scopes:      []string{string(ScopeRead)},
 		Static:      true,
 	}
 }

--- a/internal/apikey/service_test.go
+++ b/internal/apikey/service_test.go
@@ -55,6 +55,18 @@ func TestScopeHierarchyAndProjects(t *testing.T) {
 	}
 }
 
+func TestLoopbackPeerReadCredential(t *testing.T) {
+	t.Parallel()
+
+	credential := LoopbackPeerReadCredential()
+	if credential.ID != LoopbackPeerReadKeyID || !credential.Static {
+		t.Fatalf("LoopbackPeerReadCredential() = %#v, want static credential with ID %q", credential, LoopbackPeerReadKeyID)
+	}
+	if !HasScope(credential.Scopes, ScopeRead) || HasScope(credential.Scopes, ScopeWrite) || HasScope(credential.Scopes, ScopeAdmin) {
+		t.Fatalf("LoopbackPeerReadCredential() scopes = %v, want read only", credential.Scopes)
+	}
+}
+
 func TestAuthenticateRejectsChecksumInvalidTokenWithoutLookup(t *testing.T) {
 	t.Parallel()
 

--- a/internal/cli/global_reload.go
+++ b/internal/cli/global_reload.go
@@ -260,6 +260,9 @@ func changedGlobalConfigFields(previous globalconfig.Config, next globalconfig.C
 	if previous.GitHubToken != next.GitHubToken {
 		fields = append(fields, globalConfigChange{Field: "github_token", Old: "<redacted>", New: "<redacted>"})
 	}
+	if previous.TrustLoopbackPeerRead != next.TrustLoopbackPeerRead {
+		fields = append(fields, globalConfigChange{Field: "trust_loopback_peer_read", Old: previous.TrustLoopbackPeerRead, New: next.TrustLoopbackPeerRead})
+	}
 	if previous.DashboardAccess.Mode != next.DashboardAccess.Mode {
 		fields = append(fields, globalConfigChange{Field: "dashboard_access.mode", Old: previous.DashboardAccess.Mode, New: next.DashboardAccess.Mode})
 	}

--- a/internal/cli/global_reload_test.go
+++ b/internal/cli/global_reload_test.go
@@ -235,6 +235,7 @@ func TestChangedGlobalConfigFieldsReloadClassification(t *testing.T) {
 		{name: "log max size", field: "log_max_size_bytes", requiresRestart: true, mutate: func(cfg *globalconfig.Config) { value := 2048; cfg.LogMaxSizeBytes = &value }},
 		{name: "log backups", field: "log_max_backups", requiresRestart: true, mutate: func(cfg *globalconfig.Config) { value := 2; cfg.LogMaxBackups = &value }},
 		{name: "GitHub token", field: "github_token", mutate: func(cfg *globalconfig.Config) { cfg.GitHubToken = "gh" }},
+		{name: "loopback peer read trust", field: "trust_loopback_peer_read", mutate: func(cfg *globalconfig.Config) { cfg.TrustLoopbackPeerRead = true }},
 		{name: "dashboard access mode", field: "dashboard_access.mode", mutate: func(cfg *globalconfig.Config) {
 			cfg.DashboardAccess.Mode = globalconfig.DashboardAccessModePrivateToken
 		}},

--- a/internal/config/global/config.go
+++ b/internal/config/global/config.go
@@ -62,22 +62,23 @@ type PathResolution struct {
 }
 
 type Config struct {
-	Path            string          `yaml:"-"`
-	APIVersion      string          `yaml:"apiVersion"`
-	Kind            string          `yaml:"kind"`
-	Env             string          `yaml:"env,omitempty"`
-	LogLevel        string          `yaml:"log_level,omitempty"`
-	LogMaxSizeBytes *int            `yaml:"log_max_size_bytes,omitempty"`
-	LogMaxBackups   *int            `yaml:"log_max_backups,omitempty"`
-	GitHubToken     string          `yaml:"github_token,omitempty"`
-	APIToken        string          `yaml:"api_token,omitempty"`
-	DashboardAccess DashboardAccess `yaml:"dashboard_access,omitempty"`
-	Port            *int            `yaml:"port,omitempty"`
-	InstanceName    string          `yaml:"instance_name,omitempty"`
-	Update          Update          `yaml:"update,omitempty"`
-	Auth            Auth            `yaml:"auth,omitempty"`
-	Global          Settings        `yaml:"global"`
-	Projects        []Project       `yaml:"projects"`
+	Path                  string          `yaml:"-"`
+	APIVersion            string          `yaml:"apiVersion"`
+	Kind                  string          `yaml:"kind"`
+	Env                   string          `yaml:"env,omitempty"`
+	LogLevel              string          `yaml:"log_level,omitempty"`
+	LogMaxSizeBytes       *int            `yaml:"log_max_size_bytes,omitempty"`
+	LogMaxBackups         *int            `yaml:"log_max_backups,omitempty"`
+	GitHubToken           string          `yaml:"github_token,omitempty"`
+	APIToken              string          `yaml:"api_token,omitempty"`
+	TrustLoopbackPeerRead bool            `yaml:"trust_loopback_peer_read,omitempty"`
+	DashboardAccess       DashboardAccess `yaml:"dashboard_access,omitempty"`
+	Port                  *int            `yaml:"port,omitempty"`
+	InstanceName          string          `yaml:"instance_name,omitempty"`
+	Update                Update          `yaml:"update,omitempty"`
+	Auth                  Auth            `yaml:"auth,omitempty"`
+	Global                Settings        `yaml:"global"`
+	Projects              []Project       `yaml:"projects"`
 }
 
 type DashboardAccess struct {
@@ -941,6 +942,9 @@ func validateRaw(attrs map[string]any, opts options) []string {
 	problems = append(problems, optionalStringTypeError(attrs, "github_token")...)
 	problems = append(problems, optionalStringTypeError(attrs, "api_token")...)
 	problems = append(problems, optionalSingleLineStringError(attrs, "api_token")...)
+	if _, err := optionalBool(attrs["trust_loopback_peer_read"], "trust_loopback_peer_read"); err != nil {
+		problems = append(problems, err.Error())
+	}
 	problems = append(problems, dashboardAccessRawErrors(attrs["dashboard_access"])...)
 	problems = append(problems, optionalStringTypeError(attrs, "instance_name")...)
 	problems = append(problems, optionalSingleLineStringError(attrs, "instance_name")...)
@@ -1716,6 +1720,10 @@ func build(attrs map[string]any, path string, opts options) (Config, error) {
 	if err != nil {
 		return Config{}, buildValidationError(path, err)
 	}
+	trustLoopbackPeerRead, err := optionalBool(attrs["trust_loopback_peer_read"], "trust_loopback_peer_read")
+	if err != nil {
+		return Config{}, buildValidationError(path, err)
+	}
 	dashboardAccess, err := buildDashboardAccess(attrs["dashboard_access"])
 	if err != nil {
 		return Config{}, buildValidationError(path, err)
@@ -1746,22 +1754,23 @@ func build(attrs map[string]any, path string, opts options) (Config, error) {
 	}
 
 	return Config{
-		Path:            path,
-		APIVersion:      apiVersion,
-		Kind:            kind,
-		Env:             env,
-		LogLevel:        logLevel,
-		LogMaxSizeBytes: logMaxSizeBytes,
-		LogMaxBackups:   logMaxBackups,
-		GitHubToken:     githubToken,
-		APIToken:        apiToken,
-		DashboardAccess: dashboardAccess,
-		Port:            port,
-		InstanceName:    instanceName,
-		Update:          update,
-		Auth:            auth,
-		Global:          settings,
-		Projects:        builtProjects,
+		Path:                  path,
+		APIVersion:            apiVersion,
+		Kind:                  kind,
+		Env:                   env,
+		LogLevel:              logLevel,
+		LogMaxSizeBytes:       logMaxSizeBytes,
+		LogMaxBackups:         logMaxBackups,
+		GitHubToken:           githubToken,
+		APIToken:              apiToken,
+		TrustLoopbackPeerRead: trustLoopbackPeerRead,
+		DashboardAccess:       dashboardAccess,
+		Port:                  port,
+		InstanceName:          instanceName,
+		Update:                update,
+		Auth:                  auth,
+		Global:                settings,
+		Projects:              builtProjects,
 	}, nil
 }
 

--- a/internal/config/global/config_test.go
+++ b/internal/config/global/config_test.go
@@ -211,6 +211,9 @@ func TestDefaultConfig(t *testing.T) {
 	if cfg.Kind != Kind {
 		t.Fatalf("Kind = %q, want %q", cfg.Kind, Kind)
 	}
+	if cfg.TrustLoopbackPeerRead {
+		t.Fatal("TrustLoopbackPeerRead = true, want default false")
+	}
 	if cfg.Global.MaxConcurrentAgents != 8 {
 		t.Fatalf("Global.MaxConcurrentAgents = %d, want 8", cfg.Global.MaxConcurrentAgents)
 	}
@@ -245,6 +248,7 @@ log_max_size_bytes: 4096
 log_max_backups: 3
 github_token: gh
 api_token: detent_test_api_token
+trust_loopback_peer_read: true
 port: 4100
 instance_name: " buildbox "
 update:
@@ -286,6 +290,9 @@ projects:
 	}
 	if cfg.APIToken != "detent_test_api_token" {
 		t.Fatalf("APIToken = %q, want detent_test_api_token", cfg.APIToken)
+	}
+	if !cfg.TrustLoopbackPeerRead {
+		t.Fatal("TrustLoopbackPeerRead = false, want true")
 	}
 	if cfg.Port == nil || *cfg.Port != 4100 {
 		t.Fatalf("Port = %v, want 4100", cfg.Port)
@@ -530,16 +537,17 @@ func TestWriteRoundTripsConfig(t *testing.T) {
 	logMaxBackups := 3
 
 	cfg := Config{
-		Path:            configPath,
-		APIVersion:      APIVersion,
-		Kind:            Kind,
-		Env:             "dev",
-		LogLevel:        "debug",
-		LogMaxSizeBytes: &logMaxSizeBytes,
-		LogMaxBackups:   &logMaxBackups,
-		GitHubToken:     "gh",
-		APIToken:        "detent_test_api_token",
-		Port:            &port,
+		Path:                  configPath,
+		APIVersion:            APIVersion,
+		Kind:                  Kind,
+		Env:                   "dev",
+		LogLevel:              "debug",
+		LogMaxSizeBytes:       &logMaxSizeBytes,
+		LogMaxBackups:         &logMaxBackups,
+		GitHubToken:           "gh",
+		APIToken:              "detent_test_api_token",
+		TrustLoopbackPeerRead: true,
+		Port:                  &port,
 		Global: Settings{
 			MaxConcurrentAgents: 3,
 			Scheduling:          SchedulingStrict,
@@ -607,6 +615,9 @@ func TestWriteRoundTripsConfig(t *testing.T) {
 	}
 	if got.APIToken != cfg.APIToken {
 		t.Fatalf("APIToken = %q, want %q", got.APIToken, cfg.APIToken)
+	}
+	if got.TrustLoopbackPeerRead != cfg.TrustLoopbackPeerRead {
+		t.Fatalf("TrustLoopbackPeerRead = %t, want %t", got.TrustLoopbackPeerRead, cfg.TrustLoopbackPeerRead)
 	}
 	if got.Port == nil || *got.Port != *cfg.Port {
 		t.Fatalf("Port = %v, want %d", got.Port, *cfg.Port)
@@ -1333,6 +1344,7 @@ func TestReadReportsInvalidConfig(t *testing.T) {
 			raw: `apiVersion: detent/v2
 kind: SomethingElse
 instance_name: []
+trust_loopback_peer_read: maybe
 global:
   max_concurrent_agents: 0
   scheduling: random
@@ -1355,6 +1367,7 @@ projects:
 				"apiVersion: must equal detent/v1",
 				"kind: must equal GlobalConfig",
 				"instance_name: must be a string",
+				"trust_loopback_peer_read: must be a boolean",
 				"global.max_concurrent_agents: must be a positive integer",
 				"global.scheduling: must be one of weighted, strict, round_robin, fair_share",
 				"global.fair_share: must be a mapping",

--- a/internal/web/auth.go
+++ b/internal/web/auth.go
@@ -10,6 +10,7 @@ import (
 	"errors"
 	"net"
 	"net/http"
+	"net/netip"
 	"net/url"
 	"os"
 	"strconv"
@@ -94,6 +95,9 @@ func (s *Server) authorizeAPIRequest(c echo.Context, opts apiAuthOptions) (apike
 		}
 		return apikey.Credential{}, writeAPIAuthError(c, http.StatusUnauthorized, "unauthorized", "Valid API token is required")
 	}
+	if s.trustLoopbackPeerRead() && requestAPICredentialsSupplied(c.Request()) {
+		return apikey.Credential{}, writeAPIAuthError(c, http.StatusUnauthorized, "unauthorized", "Valid API token is required")
+	}
 
 	if _, ok := webSessionFromContext(c.Request().Context()); ok {
 		if opts.requireDashboardManagementToken && !s.authorizeAPIKeyDashboardToken(c) {
@@ -139,6 +143,12 @@ func (s *Server) authorizeAPIRequest(c echo.Context, opts apiAuthOptions) (apike
 		return credential, nil
 	}
 
+	if s.authorizeLoopbackPeerRead(c, opts) {
+		credential := apikey.LoopbackPeerReadCredential()
+		s.setAPICredential(c, credential)
+		return credential, nil
+	}
+
 	if token != "" {
 		return apikey.Credential{}, writeAPIAuthError(c, http.StatusUnauthorized, "unauthorized", "Valid API token is required")
 	}
@@ -152,6 +162,13 @@ func (s *Server) authorizeAPIRequest(c echo.Context, opts apiAuthOptions) (apike
 		message = "configure api_token or use an API key to enable API mutations on non-loopback hosts"
 	}
 	return apikey.Credential{}, writeAPIAuthError(c, http.StatusForbidden, "api_token_required", message)
+}
+
+func (s *Server) authorizeLoopbackPeerRead(c echo.Context, opts apiAuthOptions) bool {
+	if c == nil || c.Request() == nil || opts.mutating || c.Request().Method != http.MethodGet || serverAddressLoopback(s.serverAddr) {
+		return false
+	}
+	return s.trustLoopbackPeerRead() && requestRemoteAddrLoopback(c.Request().RemoteAddr)
 }
 
 func (s *Server) authenticateCandidate(ctx context.Context, candidate string, staticToken string) (apikey.Credential, error) {
@@ -238,8 +255,23 @@ func (s *Server) apiToken() string {
 	return strings.TrimSpace(cfg.APIToken)
 }
 
+func (s *Server) trustLoopbackPeerRead() bool {
+	if s == nil {
+		return false
+	}
+	cfg := s.globalConfig
+	if s.globalConfigSource != nil {
+		cfg = s.globalConfigSource()
+	}
+	return cfg.TrustLoopbackPeerRead
+}
+
 func (s *Server) warnIfAPITokenMissingOnNonLoopback() {
 	if s == nil || s.apiToken() != "" || serverAddressLoopback(s.serverAddr) {
+		return
+	}
+	if s.trustLoopbackPeerRead() {
+		s.logger.Warn("api_token is not configured; trusted loopback peers have read-only API access and all other API access without scoped API keys will fail closed", "addr", s.serverAddr)
 		return
 	}
 	s.logger.Warn("api_token is not configured; API routes without scoped API keys will fail closed on non-loopback hosts", "addr", s.serverAddr)
@@ -260,6 +292,13 @@ func requestAPITokens(req *http.Request) []string {
 		tokens = append(tokens, apiKey)
 	}
 	return tokens
+}
+
+func requestAPICredentialsSupplied(req *http.Request) bool {
+	if req == nil {
+		return false
+	}
+	return len(req.Header.Values("Authorization")) > 0 || len(req.Header.Values("X-API-Key")) > 0
 }
 
 func serverAddressLoopback(addr string) bool {
@@ -316,8 +355,8 @@ func requestHostLoopback(host string) bool {
 }
 
 func requestRemoteAddrLoopback(remoteAddr string) bool {
-	remoteAddr = strings.TrimSpace(remoteAddr)
-	return remoteAddr != "" && serverAddressLoopback(remoteAddr)
+	peer, err := netip.ParseAddrPort(remoteAddr)
+	return err == nil && peer.Addr().Unmap().IsLoopback()
 }
 
 func requestDashboardHTMXTarget(req *http.Request) bool {

--- a/internal/web/auth_sse_test.go
+++ b/internal/web/auth_sse_test.go
@@ -1,12 +1,147 @@
 package web
 
 import (
+	"context"
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	"github.com/labstack/echo/v4"
+
+	"github.com/digitaldrywood/detent/internal/apikey"
+	globalconfig "github.com/digitaldrywood/detent/internal/config/global"
+	"github.com/digitaldrywood/detent/internal/store"
 )
+
+func TestRequestRemoteAddrLoopback(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		remoteAddr string
+		want       bool
+	}{
+		{name: "IPv4", remoteAddr: "127.0.0.1:49152", want: true},
+		{name: "IPv4 loopback range", remoteAddr: "127.255.255.254:1", want: true},
+		{name: "IPv6", remoteAddr: "[::1]:49152", want: true},
+		{name: "IPv4-mapped IPv6", remoteAddr: "[::ffff:127.0.0.1]:49152", want: true},
+		{name: "non-loopback IPv4", remoteAddr: "192.0.2.10:49152"},
+		{name: "non-loopback IPv6", remoteAddr: "[2001:db8::10]:49152"},
+		{name: "empty"},
+		{name: "missing port", remoteAddr: "127.0.0.1"},
+		{name: "hostname", remoteAddr: "localhost:49152"},
+		{name: "invalid port", remoteAddr: "127.0.0.1:not-a-port"},
+		{name: "leading whitespace", remoteAddr: " 127.0.0.1:49152"},
+		{name: "unbracketed IPv6", remoteAddr: "::1:49152"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := requestRemoteAddrLoopback(tt.remoteAddr); got != tt.want {
+				t.Fatalf("requestRemoteAddrLoopback(%q) = %t, want %t", tt.remoteAddr, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestLoopbackPeerReadTrustPreservesRateLimits(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		configure func(*Server)
+	}{
+		{
+			name: "pre-auth IP limiter",
+			configure: func(server *Server) {
+				server.ipLimiter = newAPIRateLimiter(1, 1)
+			},
+		},
+		{
+			name: "credential limiter",
+			configure: func(server *Server) {
+				server.keyLimiter = newAPIRateLimiter(1, 1)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			cfg := globalconfig.Config{TrustLoopbackPeerRead: true}
+			server := &Server{
+				globalConfig:       cfg,
+				globalConfigSource: func() globalconfig.Config { return cfg },
+				lookupEnv:          func(string) string { return "" },
+				serverAddr:         "0.0.0.0:0",
+			}
+			tt.configure(server)
+			t.Cleanup(func() {
+				if server.ipLimiter != nil {
+					server.ipLimiter.Stop()
+				}
+				if server.keyLimiter != nil {
+					server.keyLimiter.Stop()
+				}
+			})
+
+			e := echo.New()
+			handler := server.apiAuth(false)(func(c echo.Context) error {
+				return c.NoContent(http.StatusNoContent)
+			})
+			for index, want := range []int{http.StatusNoContent, http.StatusTooManyRequests} {
+				req := httptest.NewRequest(http.MethodGet, "/api/v1/state", nil)
+				req.RemoteAddr = "127.0.0.1:49152"
+				rec := httptest.NewRecorder()
+				err := handler(e.NewContext(req, rec))
+				if index == 0 && err != nil {
+					t.Fatalf("request %d error = %v", index+1, err)
+				}
+				if rec.Code != want {
+					t.Fatalf("request %d status = %d, want %d", index+1, rec.Code, want)
+				}
+				if index == 1 && (rec.Header().Get("X-RateLimit-Limit") == "" || rec.Header().Get("Retry-After") == "") {
+					t.Fatalf("rate limit headers = %#v", rec.Header())
+				}
+			}
+		})
+	}
+}
+
+func TestLoopbackPeerReadTrustSkipsPersistentAPIKeyUsage(t *testing.T) {
+	t.Parallel()
+
+	usageStore := &loopbackPeerReadUsageStore{}
+	server := &Server{store: usageStore}
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/state", nil)
+	rec := httptest.NewRecorder()
+	c := echo.New().NewContext(req, rec)
+	credential := apikey.LoopbackPeerReadCredential()
+
+	server.markAPIKeyLastUsed(credential)
+	server.recordAPIUsage(c, credential, time.Now(), nil)
+	if usageStore.lastUsedCalls != 0 || usageStore.usageCalls != 0 {
+		t.Fatalf("persistent usage calls = last-used %d usage %d, want 0", usageStore.lastUsedCalls, usageStore.usageCalls)
+	}
+}
+
+type loopbackPeerReadUsageStore struct {
+	store.Store
+	lastUsedCalls int
+	usageCalls    int
+}
+
+func (s *loopbackPeerReadUsageStore) MarkAPIKeyLastUsed(context.Context, string, time.Time) error {
+	s.lastUsedCalls++
+	return nil
+}
+
+func (s *loopbackPeerReadUsageStore) RecordAPIUsageLog(context.Context, store.APIUsageLog) error {
+	s.usageCalls++
+	return nil
+}
 
 func TestAuthorizeDashboardSSE(t *testing.T) {
 	t.Parallel()

--- a/internal/web/server_test.go
+++ b/internal/web/server_test.go
@@ -398,8 +398,197 @@ func TestAPIFailsClosedWithoutTokenOnNonLoopbackBind(t *testing.T) {
 
 	requestJSON(t, server, http.MethodGet, "/api/v1/state", http.StatusForbidden)
 	requestJSON(t, server, http.MethodPost, "/api/v1/refresh", http.StatusForbidden)
+	loopback := performJSONWithRemote(t, server.Handler(), http.MethodGet, "/api/v1/state", "", "127.0.0.1:49152", nil)
+	if loopback.Code != http.StatusForbidden {
+		t.Fatalf("loopback peer status = %d, want %d; body = %s", loopback.Code, http.StatusForbidden, loopback.Body.String())
+	}
 	if !strings.Contains(logs.String(), "api_token") {
 		t.Fatalf("startup warning missing api_token detail:\n%s", logs.String())
+	}
+}
+
+func TestLoopbackPeerReadTrustRestrictsRoutesAndPeers(t *testing.T) {
+	t.Parallel()
+
+	server, err := web.NewServer(web.Config{
+		ServerAddress: "0.0.0.0:0",
+		GlobalConfig:  globalconfig.Config{TrustLoopbackPeerRead: true},
+	}, testDeps(t))
+	if err != nil {
+		t.Fatalf("NewServer() error = %v", err)
+	}
+
+	forwarded := map[string]string{
+		"Forwarded":       "for=127.0.0.1",
+		"X-Forwarded-For": "127.0.0.1",
+		"X-Real-IP":       "127.0.0.1",
+	}
+	tests := []struct {
+		name       string
+		method     string
+		path       string
+		remoteAddr string
+		headers    map[string]string
+		want       int
+	}{
+		{name: "IPv4 read", method: http.MethodGet, path: "/api/v1/state", remoteAddr: "127.0.0.1:49152", want: http.StatusOK},
+		{name: "IPv6 read", method: http.MethodGet, path: "/api/v1/state", remoteAddr: "[::1]:49152", want: http.StatusOK},
+		{name: "IPv4-mapped IPv6 read", method: http.MethodGet, path: "/api/v1/state", remoteAddr: "[::ffff:127.0.0.1]:49152", want: http.StatusOK},
+		{name: "forwarded loopback ignored", method: http.MethodGet, path: "/api/v1/state", remoteAddr: "192.0.2.10:49152", headers: forwarded, want: http.StatusForbidden},
+		{name: "malformed peer", method: http.MethodGet, path: "/api/v1/state", remoteAddr: "127.0.0.1", want: http.StatusForbidden},
+		{name: "admin GET", method: http.MethodGet, path: "/api/v1/keys", remoteAddr: "127.0.0.1:49152", want: http.StatusForbidden},
+		{name: "POST", method: http.MethodPost, path: "/api/v1/refresh", remoteAddr: "127.0.0.1:49152", want: http.StatusForbidden},
+		{name: "DELETE", method: http.MethodDelete, path: "/api/v1/projects/detent/budget/override", remoteAddr: "127.0.0.1:49152", want: http.StatusForbidden},
+		{name: "PUT", method: http.MethodPut, path: "/api/v1/state", remoteAddr: "127.0.0.1:49152", want: http.StatusMethodNotAllowed},
+		{name: "PATCH", method: http.MethodPatch, path: "/api/v1/state", remoteAddr: "127.0.0.1:49152", want: http.StatusMethodNotAllowed},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			rec := performJSONWithRemote(t, server.Handler(), tt.method, tt.path, "", tt.remoteAddr, tt.headers)
+			if rec.Code != tt.want {
+				t.Fatalf("status = %d, want %d; body = %s", rec.Code, tt.want, rec.Body.String())
+			}
+		})
+	}
+}
+
+func TestLoopbackPeerReadTrustPreservesLoopbackBindAccess(t *testing.T) {
+	t.Parallel()
+
+	deps := testDeps(t)
+	deps.Store = openWebTestStore(t)
+	deps.Refresher = &refreshProbe{}
+	server, err := web.NewServer(web.Config{
+		ServerAddress: "127.0.0.1:0",
+		GlobalConfig:  globalconfig.Config{TrustLoopbackPeerRead: true},
+	}, deps)
+	if err != nil {
+		t.Fatalf("NewServer() error = %v", err)
+	}
+
+	for _, test := range []struct {
+		name   string
+		method string
+		path   string
+		want   int
+	}{
+		{name: "read route", method: http.MethodGet, path: "/api/v1/state", want: http.StatusOK},
+		{name: "admin GET", method: http.MethodGet, path: "/api/v1/keys", want: http.StatusOK},
+		{name: "mutation", method: http.MethodPost, path: "/api/v1/refresh", want: http.StatusAccepted},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			rec := performJSONWithRemote(t, server.Handler(), test.method, test.path, "", "127.0.0.1:49152", nil)
+			if rec.Code != test.want {
+				t.Fatalf("status = %d, want %d; body = %s", rec.Code, test.want, rec.Body.String())
+			}
+		})
+	}
+}
+
+func TestLoopbackPeerReadTrustLiveReload(t *testing.T) {
+	cfg := globalconfig.Config{}
+	server, err := web.NewServer(web.Config{
+		ServerAddress:      "0.0.0.0:0",
+		GlobalConfig:       cfg,
+		GlobalConfigSource: func() globalconfig.Config { return cfg },
+	}, testDeps(t))
+	if err != nil {
+		t.Fatalf("NewServer() error = %v", err)
+	}
+
+	for _, step := range []struct {
+		name    string
+		enabled bool
+		want    int
+	}{
+		{name: "disabled initially", want: http.StatusForbidden},
+		{name: "enabled after reload", enabled: true, want: http.StatusOK},
+		{name: "disabled after reload", want: http.StatusForbidden},
+	} {
+		t.Run(step.name, func(t *testing.T) {
+			cfg.TrustLoopbackPeerRead = step.enabled
+			rec := performJSONWithRemote(t, server.Handler(), http.MethodGet, "/api/v1/state", "", "127.0.0.1:49152", nil)
+			if rec.Code != step.want {
+				t.Fatalf("status = %d, want %d; body = %s", rec.Code, step.want, rec.Body.String())
+			}
+		})
+	}
+}
+
+func TestLoopbackPeerReadTrustHonorsStaticTokenAndRejectsSuppliedFailures(t *testing.T) {
+	t.Parallel()
+
+	backend := openWebTestStore(t)
+	deps := testDeps(t)
+	deps.Store = backend
+	server, err := web.NewServer(web.Config{
+		ServerAddress: "0.0.0.0:0",
+		GlobalConfig: globalconfig.Config{
+			APIToken:              "detent_admin_token",
+			TrustLoopbackPeerRead: true,
+		},
+	}, deps)
+	if err != nil {
+		t.Fatalf("NewServer() error = %v", err)
+	}
+
+	tokenless := performJSONWithRemote(t, server.Handler(), http.MethodGet, "/api/v1/state", "", "127.0.0.1:49152", nil)
+	if tokenless.Code != http.StatusOK {
+		t.Fatalf("tokenless status = %d, want %d; body = %s", tokenless.Code, http.StatusOK, tokenless.Body.String())
+	}
+	for name, headers := range map[string]map[string]string{
+		"empty bearer":  {"Authorization": "Bearer "},
+		"empty API key": {"X-API-Key": " "},
+	} {
+		t.Run(name, func(t *testing.T) {
+			rec := performJSONWithRemote(t, server.Handler(), http.MethodGet, "/api/v1/state", "", "127.0.0.1:49152", headers)
+			if rec.Code != http.StatusUnauthorized {
+				t.Fatalf("status = %d, want %d; body = %s", rec.Code, http.StatusUnauthorized, rec.Body.String())
+			}
+		})
+	}
+
+	revokedToken, revokedID := createAPIKeyThroughHTTP(t, server, `{
+		"name": "Revoked loopback client",
+		"scopes": ["read"],
+		"expires_in": "90d"
+	}`)
+	revoke := performJSON(t, server.Handler(), http.MethodDelete, "/api/v1/keys/"+revokedID, "", map[string]string{
+		"Authorization": "Bearer detent_admin_token",
+	})
+	if revoke.Code != http.StatusNoContent {
+		t.Fatalf("revoke status = %d, want %d; body = %s", revoke.Code, http.StatusNoContent, revoke.Body.String())
+	}
+	expiredToken := createExpiredAPIKey(t, backend)
+
+	tests := []struct {
+		name  string
+		token string
+		code  string
+	}{
+		{name: "invalid", token: "invalid", code: "invalid_token"},
+		{name: "expired", token: expiredToken, code: "token_expired"},
+		{name: "revoked", token: revokedToken, code: "token_revoked"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			rec := performJSONWithRemote(t, server.Handler(), http.MethodGet, "/api/v1/state", "", "127.0.0.1:49152", map[string]string{
+				"Authorization": "Bearer " + tt.token,
+			})
+			if rec.Code != http.StatusUnauthorized {
+				t.Fatalf("status = %d, want %d; body = %s", rec.Code, http.StatusUnauthorized, rec.Body.String())
+			}
+			var payload map[string]any
+			if err := json.Unmarshal(rec.Body.Bytes(), &payload); err != nil {
+				t.Fatalf("Unmarshal() error = %v; body = %s", err, rec.Body.String())
+			}
+			if got := nestedString(t, payload, "error", "code"); got != tt.code {
+				t.Fatalf("error code = %q, want %q", got, tt.code)
+			}
+		})
 	}
 }
 
@@ -11109,6 +11298,20 @@ func performJSON(t *testing.T, handler http.Handler, method string, path string,
 
 	rec := httptest.NewRecorder()
 	req := httptest.NewRequest(method, path, strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	for key, value := range headers {
+		req.Header.Set(key, value)
+	}
+	handler.ServeHTTP(rec, req)
+	return rec
+}
+
+func performJSONWithRemote(t *testing.T, handler http.Handler, method string, path string, body string, remoteAddr string, headers map[string]string) *httptest.ResponseRecorder {
+	t.Helper()
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(method, path, strings.NewReader(body))
+	req.RemoteAddr = remoteAddr
 	req.Header.Set("Content-Type", "application/json")
 	for key, value := range headers {
 		req.Header.Set(key, value)


### PR DESCRIPTION
## Summary

- add the default-off `trust_loopback_peer_read` host config with validation, round-trip serialization, live reload classification, and documentation
- authenticate direct raw loopback TCP peers with a dedicated read-only credential after explicit token handling
- cover malformed and spoofed peers, route scope, static-token precedence, credential failures, rate limiting, and persistent usage behavior

Fixes #1641

## UI Surface Contract

- [x] N/A, or the linked issue explicitly authorizes any high-impact UI surface, layout, density, first-viewport, or responsive visibility tradeoff.
- [x] Persistent top-of-screen messaging is explicitly authorized by the issue, or this PR does not add it.
- [x] Visual changes to primary operator screens include screenshot or browser verification below.

No UI changes.

## Test Plan

- [x] `make generate`
- [x] `go test ./internal/config/configdoc -count=1`
- [x] `go test ./internal/apikey ./internal/config/global ./internal/cli ./internal/web -count=1`
- [x] `make check` after rebasing onto current `origin/main` (78.5% coverage)
