### PR TITLE
fix(merge): bound current-head CI waits

### DIFF
--- a/internal/orchestrator/autopromote_tick.go
+++ b/internal/orchestrator/autopromote_tick.go
@@ -1348,7 +1348,7 @@ func (o *Orchestrator) staleMergingQueueDispatchCandidates(state *State, issues 
 }
 
 func staleMergingIssueReadyForDispatch(issue connector.Issue, cfg Config) bool {
-	if strings.TrimSpace(issue.ID) == "" || issue.PullRequest == nil {
+	if strings.TrimSpace(issue.ID) == "" || issue.Closed || issue.PullRequest == nil {
 		return false
 	}
 	if _, revoked := mergeApprovalLabelRevoked(issue, cfg); revoked {

--- a/internal/orchestrator/autopromote_tick_test.go
+++ b/internal/orchestrator/autopromote_tick_test.go
@@ -4016,6 +4016,7 @@ func TestStaleMergingQueueDispatchCandidatesFiltersUnsafePullRequests(t *testing
 	tests := []struct {
 		name        string
 		pullRequest *connector.PullRequest
+		closed      bool
 		want        bool
 	}{
 		{
@@ -4032,10 +4033,20 @@ func TestStaleMergingQueueDispatchCandidatesFiltersUnsafePullRequests(t *testing
 			pullRequest: nil,
 		},
 		{
-			name: "merged pull request",
+			name:   "closed issue with merged pull request",
+			closed: true,
 			pullRequest: &connector.PullRequest{
 				State:    "MERGED",
 				CIStatus: "success",
+			},
+		},
+		{
+			name:   "closed issue with stale open pull request",
+			closed: true,
+			pullRequest: &connector.PullRequest{
+				State:          "OPEN",
+				MergeableState: "clean",
+				CIStatus:       "success",
 			},
 		},
 		{
@@ -4109,6 +4120,7 @@ func TestStaleMergingQueueDispatchCandidatesFiltersUnsafePullRequests(t *testing
 			orch := &Orchestrator{cfg: cfg}
 			issue := autoPromoteTickIssue("issue-"+strings.ReplaceAll(tt.name, " ", "-"), []string{"bug"}, tt.pullRequest)
 			issue.State = "Merging"
+			issue.Closed = tt.closed
 			got := orch.staleMergingQueueDispatchCandidates(&state, []connector.Issue{issue})
 			if tt.want {
 				if len(got) != 1 || got[0].ID != issue.ID {

--- a/internal/orchestrator/merge_fast_path_test.go
+++ b/internal/orchestrator/merge_fast_path_test.go
@@ -381,8 +381,8 @@ func TestMergingFallbackPushWaitsAfterWorkerReappliesCITriggerWhenHydrationIsGre
 	if !ok {
 		t.Fatalf("Retry[%q] missing while current-head checks run", issue.ID)
 	}
-	if retry.Attempt != 1 {
-		t.Fatalf("Retry[%q].Attempt = %d, want unchanged attempt 1", issue.ID, retry.Attempt)
+	if retry.Attempt != 2 {
+		t.Fatalf("Retry[%q].Attempt = %d, want 2", issue.ID, retry.Attempt)
 	}
 	if !strings.Contains(retry.Error, "current-head CI") {
 		t.Fatalf("Retry[%q].Error = %q, want current-head CI wait", issue.ID, retry.Error)
@@ -634,6 +634,7 @@ func completeMergeFastPathTestRun(
 	now time.Time,
 	attempt int,
 	gateConfig gate.Config,
+	ciWaitAge ...time.Duration,
 ) (*autoPromoteTickMergeConnector, State) {
 	t.Helper()
 
@@ -657,6 +658,9 @@ func completeMergeFastPathTestRun(
 		logger:    slog.New(slog.NewTextHandler(io.Discard, nil)),
 	}
 	state := newState(cfg)
+	if len(ciWaitAge) > 0 {
+		state.MergeTimings[issue.ID] = MergeTiming{CIWaitStartedAt: now.Add(-ciWaitAge[0])}
+	}
 	state.Running[issue.ID] = Running{
 		Issue:      cloneIssue(issue),
 		Attempt:    attempt,
@@ -803,8 +807,8 @@ func TestMergingFastPathCleanPrecheckWaitsForCurrentHeadCI(t *testing.T) {
 	if !ok {
 		t.Fatalf("Retry[%q] missing while CI is pending", issue.ID)
 	}
-	if retry.Attempt != 1 || retry.WorkerHost != "worker-a" {
-		t.Fatalf("Retry[%q] = %#v, want same-attempt retry on worker-a", issue.ID, retry)
+	if retry.Attempt != 2 || retry.WorkerHost != "worker-a" {
+		t.Fatalf("Retry[%q] = %#v, want attempt 2 retry on worker-a", issue.ID, retry)
 	}
 	if !strings.Contains(retry.Error, "current-head CI") {
 		t.Fatalf("Retry[%q].Error = %q, want current-head CI wait", issue.ID, retry.Error)
@@ -814,6 +818,140 @@ func TestMergingFastPathCleanPrecheckWaitsForCurrentHeadCI(t *testing.T) {
 	}
 	if _, ok := state.Claimed[issue.ID]; !ok {
 		t.Fatalf("Claimed[%q] missing while waiting for CI", issue.ID)
+	}
+}
+
+func TestMergeWorkerCurrentHeadCIRetryBound(t *testing.T) {
+	t.Parallel()
+
+	const pendingCheck = "Portability Verify (windows-latest)"
+	tests := []struct {
+		name          string
+		attempt       int
+		ciStatus      string
+		mergeable     string
+		runningChecks []string
+		failures      []connector.PullRequestCheck
+		ciWaitAge     time.Duration
+		wantRetry     int
+		wantBlocked   bool
+		wantMerged    bool
+	}{
+		{
+			name:          "attempt increments across waits",
+			attempt:       1,
+			ciStatus:      "pending",
+			mergeable:     "blocked",
+			runningChecks: []string{pendingCheck},
+			failures: []connector.PullRequestCheck{{
+				Name:   pendingCheck,
+				Status: "in_progress",
+			}},
+			ciWaitAge: time.Minute,
+			wantRetry: 2,
+		},
+		{
+			name:          "successive wait increments again",
+			attempt:       2,
+			ciStatus:      "pending",
+			mergeable:     "blocked",
+			runningChecks: []string{pendingCheck},
+			failures: []connector.PullRequestCheck{{
+				Name:   pendingCheck,
+				Status: "in_progress",
+			}},
+			ciWaitAge: 30 * time.Minute,
+			wantRetry: 3,
+		},
+		{
+			name:          "pending check escalates at bound",
+			attempt:       maxMergeWorkerRunnerFailures,
+			ciStatus:      "pending",
+			mergeable:     "blocked",
+			runningChecks: []string{pendingCheck},
+			failures: []connector.PullRequestCheck{{
+				Name:   pendingCheck,
+				Status: "in_progress",
+			}},
+			ciWaitAge:   mergeWorkerCurrentHeadCIWaitTimeout,
+			wantBlocked: true,
+		},
+		{
+			name:          "pending check remains retryable before elapsed bound",
+			attempt:       maxMergeWorkerRunnerFailures,
+			ciStatus:      "pending",
+			mergeable:     "blocked",
+			runningChecks: []string{pendingCheck},
+			failures: []connector.PullRequestCheck{{
+				Name:   pendingCheck,
+				Status: "in_progress",
+			}},
+			ciWaitAge: mergeWorkerCurrentHeadCIWaitTimeout - time.Second,
+			wantRetry: maxMergeWorkerRunnerFailures + 1,
+		},
+		{
+			name:       "green check before bound merges",
+			attempt:    maxMergeWorkerRunnerFailures,
+			ciStatus:   "success",
+			mergeable:  "clean",
+			ciWaitAge:  mergeWorkerCurrentHeadCIWaitTimeout - time.Second,
+			wantMerged: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			now := time.Date(2026, 8, 7, 22, 14, 45, 0, time.UTC)
+			issue := autoPromoteTickIssue("issue-current-head-ci-"+strings.ReplaceAll(tt.name, " ", "-"), []string{"bug"}, &connector.PullRequest{
+				Number:                1636,
+				URL:                   "https://github.test/digitaldrywood/detent/pull/1636",
+				State:                 "OPEN",
+				MergeableState:        tt.mergeable,
+				CIStatus:              tt.ciStatus,
+				HeadSHA:               "29869e149edf099f34e92136199c5ee45056fddf",
+				RunningChecks:         append([]string(nil), tt.runningChecks...),
+				RequiredCheckFailures: append([]connector.PullRequestCheck(nil), tt.failures...),
+			})
+			issue.State = "Merging"
+			issue.Identifier = "digitaldrywood/detent#1634"
+			issue.PRRepository = "digitaldrywood/detent"
+
+			tracker, state := completeMergeFastPathTestRun(t, issue, now, tt.attempt, gate.Config{
+				RequiredStatusChecks: []string{pendingCheck},
+			}, tt.ciWaitAge)
+
+			if tt.wantRetry > 0 {
+				retry, ok := state.Retry[issue.ID]
+				if !ok {
+					t.Fatalf("Retry[%q] missing", issue.ID)
+				}
+				if retry.Attempt != tt.wantRetry {
+					t.Fatalf("Retry[%q].Attempt = %d, want %d", issue.ID, retry.Attempt, tt.wantRetry)
+				}
+				return
+			}
+			if _, ok := state.Retry[issue.ID]; ok {
+				t.Fatalf("Retry[%q] present after terminal disposition", issue.ID)
+			}
+			if tt.wantBlocked {
+				blocked, ok := state.Blocked[issue.ID]
+				if !ok {
+					t.Fatalf("Blocked[%q] missing", issue.ID)
+				}
+				if !strings.Contains(blocked.Reason, pendingCheck) {
+					t.Fatalf("Blocked[%q].Reason = %q, want pending check %q", issue.ID, blocked.Reason, pendingCheck)
+				}
+				if len(tracker.comments) != 1 || !strings.Contains(tracker.comments[0].body, pendingCheck) {
+					t.Fatalf("comments = %#v, want pending check %q", tracker.comments, pendingCheck)
+				}
+				return
+			}
+			if tt.wantMerged && len(tracker.merges) != 1 {
+				t.Fatalf("merges = %#v, want one merge", tracker.merges)
+			}
+		})
 	}
 }
 

--- a/internal/orchestrator/merge_startup.go
+++ b/internal/orchestrator/merge_startup.go
@@ -59,7 +59,7 @@ func (o *Orchestrator) handleMergeWorkerStartupTimeout(
 	)
 	attempt := nextAttempt(running.Attempt)
 	if attempt > maxMergeWorkerRunnerFailures &&
-		o.blockExhaustedMergeWorker(ctx, state, running, completedAt, attempt, err) {
+		o.blockExhaustedMergeWorker(ctx, state, running, completedAt, mergeWorkerRetryExhaustedReason, attempt, err) {
 		return true
 	}
 	o.scheduleRetry(

--- a/internal/orchestrator/merge_timing.go
+++ b/internal/orchestrator/merge_timing.go
@@ -142,7 +142,9 @@ func (o *Orchestrator) markMergeStarted(state *State, issue connector.Issue, now
 	timing.MergeStartedAt = now.UTC()
 	timing.BaseRefreshStartedAt = timing.MergeStartedAt
 	timing.BaseRefreshFinishedAt = time.Time{}
-	timing.CIWaitStartedAt = timing.MergeStartedAt
+	if timing.CIWaitStartedAt.IsZero() {
+		timing.CIWaitStartedAt = timing.MergeStartedAt
+	}
 	timing.CIWaitFinishedAt = time.Time{}
 	timing = timing.withDurations(now)
 	state.MergeTimings[strings.TrimSpace(issue.ID)] = timing

--- a/internal/orchestrator/merge_timing_test.go
+++ b/internal/orchestrator/merge_timing_test.go
@@ -51,6 +51,34 @@ func TestRecordMergeQueueEnteredResetsTerminalAttempt(t *testing.T) {
 	}
 }
 
+func TestMarkMergeStartedPreservesCurrentHeadCIWaitDeadline(t *testing.T) {
+	t.Parallel()
+
+	firstStart := time.Date(2026, 8, 7, 18, 24, 27, 0, time.UTC)
+	retryStart := firstStart.Add(2*time.Minute + 17*time.Second)
+	issue := connector.Issue{
+		ID:         "issue-current-head-ci-wait",
+		Identifier: "digitaldrywood/detent#1634",
+		State:      "Merging",
+		PullRequest: &connector.PullRequest{
+			Number: 1636,
+			State:  "OPEN",
+		},
+	}
+	state := newState(normalizeConfig(Config{}))
+	orch := &Orchestrator{}
+
+	orch.markMergeStarted(&state, issue, firstStart)
+	got := orch.markMergeStarted(&state, issue, retryStart)
+
+	if !got.CIWaitStartedAt.Equal(firstStart) {
+		t.Fatalf("CIWaitStartedAt = %s, want original start %s", got.CIWaitStartedAt, firstStart)
+	}
+	if !got.MergeStartedAt.Equal(retryStart) {
+		t.Fatalf("MergeStartedAt = %s, want current attempt start %s", got.MergeStartedAt, retryStart)
+	}
+}
+
 func TestRecordMergeFailedRejectsFailureBeforeMergeEntry(t *testing.T) {
 	t.Parallel()
 

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -24,39 +24,41 @@ import (
 )
 
 const (
-	defaultPollInterval                 = 30 * time.Second
-	defaultRunningReconcileInterval     = 2 * time.Minute
-	defaultWorkspaceCleanupIdleTTL      = 24 * time.Hour
-	defaultWorkspaceCleanupSweep        = 10 * time.Minute
-	gitHubGraphQLPauseRemaining         = 100
-	gitHubGraphQLBackoffRemaining       = 500
-	defaultGitHubGraphQLWarnRemaining   = 500
-	defaultGitHubGraphQLMinReserve      = 1000
-	defaultGitHubRESTMinReserve         = 1000
-	defaultMaxConcurrentAgents          = 1
-	defaultMaxRetryBackoff              = 5 * time.Minute
-	defaultOverloadRetryDelay           = 45 * time.Second
-	defaultContinuationRetry            = time.Second
-	defaultFailureRetryBaseDelay        = 10 * time.Second
-	defaultFailureBreakerSameClassLimit = 5
-	defaultFailureBreakerWindow         = time.Hour
-	defaultFailureBreakerCooldown       = time.Hour
-	maxMergeWorkerRunnerFailures        = 3
-	instantFailureThreshold             = 5
-	instantFailureMaxDuration           = 10 * time.Second
-	instantFailureBlockedReasonPrefix   = "instant fail circuit breaker: "
-	repeatedFailureThreshold            = 5
-	repeatedFailureBlockedReasonPrefix  = "repeated failure circuit breaker: "
-	tokenCeilingBlockedReasonPrefix     = "token ceiling circuit breaker: "
-	continuationDispatchBackoff         = 100 * time.Millisecond
-	runUpdateBufferSize                 = 128
-	maxRecentEvents                     = 50
-	blockedStatusState                  = "Blocked"
-	blockedReasonDependency             = "blocked by non-terminal dependency"
-	blockedReasonProjectStatus          = "blocked by project status"
-	mergeWorkerTerminalStateMissing     = "merge worker completed without reaching a terminal issue or pull request state"
-	mergeWorkerRetryExhaustedReason     = "merge_worker_retry_exhausted"
-	mergeWorkerDurationExceededReason   = "merge_worker_duration_exceeded"
+	defaultPollInterval                        = 30 * time.Second
+	defaultRunningReconcileInterval            = 2 * time.Minute
+	defaultWorkspaceCleanupIdleTTL             = 24 * time.Hour
+	defaultWorkspaceCleanupSweep               = 10 * time.Minute
+	gitHubGraphQLPauseRemaining                = 100
+	gitHubGraphQLBackoffRemaining              = 500
+	defaultGitHubGraphQLWarnRemaining          = 500
+	defaultGitHubGraphQLMinReserve             = 1000
+	defaultGitHubRESTMinReserve                = 1000
+	defaultMaxConcurrentAgents                 = 1
+	defaultMaxRetryBackoff                     = 5 * time.Minute
+	defaultOverloadRetryDelay                  = 45 * time.Second
+	defaultContinuationRetry                   = time.Second
+	defaultFailureRetryBaseDelay               = 10 * time.Second
+	defaultFailureBreakerSameClassLimit        = 5
+	defaultFailureBreakerWindow                = time.Hour
+	defaultFailureBreakerCooldown              = time.Hour
+	maxMergeWorkerRunnerFailures               = 3
+	mergeWorkerCurrentHeadCIWaitTimeout        = time.Hour
+	instantFailureThreshold                    = 5
+	instantFailureMaxDuration                  = 10 * time.Second
+	instantFailureBlockedReasonPrefix          = "instant fail circuit breaker: "
+	repeatedFailureThreshold                   = 5
+	repeatedFailureBlockedReasonPrefix         = "repeated failure circuit breaker: "
+	tokenCeilingBlockedReasonPrefix            = "token ceiling circuit breaker: "
+	continuationDispatchBackoff                = 100 * time.Millisecond
+	runUpdateBufferSize                        = 128
+	maxRecentEvents                            = 50
+	blockedStatusState                         = "Blocked"
+	blockedReasonDependency                    = "blocked by non-terminal dependency"
+	blockedReasonProjectStatus                 = "blocked by project status"
+	mergeWorkerTerminalStateMissing            = "merge worker completed without reaching a terminal issue or pull request state"
+	mergeWorkerRetryExhaustedReason            = "merge_worker_retry_exhausted"
+	mergeWorkerCurrentHeadCIWaitExceededReason = "merge_worker_current_head_ci_wait_exceeded"
+	mergeWorkerDurationExceededReason          = "merge_worker_duration_exceeded"
 )
 
 var (

--- a/internal/orchestrator/run_completion.go
+++ b/internal/orchestrator/run_completion.go
@@ -266,7 +266,7 @@ func (o *Orchestrator) handleRunResult(ctx context.Context, state *State, event 
 			o.recordMergeFailed(state, running.Issue, event.CompletedAt, "runner_failed", event.Err)
 		}
 		if mergeWorkerIssue(running.Issue) && attempt > maxMergeWorkerRunnerFailures {
-			if o.blockExhaustedMergeWorker(ctx, state, running, event.CompletedAt, attempt, event.Err) {
+			if o.blockExhaustedMergeWorker(ctx, state, running, event.CompletedAt, mergeWorkerRetryExhaustedReason, attempt, event.Err) {
 				return
 			}
 		}
@@ -1210,14 +1210,22 @@ func (o *Orchestrator) waitForMergeWorkerCurrentHeadCI(
 	running Running,
 	issue connector.Issue,
 ) {
+	attempt := nextAttempt(running.Attempt)
+	retryError := mergeWorkerCurrentHeadCIWaitReason(issue)
+	if o.mergeWorkerCurrentHeadCIWaitExceeded(state, issue.ID, event.CompletedAt) {
+		err := fmt.Errorf("current-head CI wait exceeded %s: %s", mergeWorkerCurrentHeadCIWaitTimeout, retryError)
+		if o.blockExhaustedMergeWorker(ctx, state, running, event.CompletedAt, mergeWorkerCurrentHeadCIWaitExceededReason, attempt, err) {
+			return
+		}
+	}
 	o.waitForMergeWorkerRetry(
 		ctx,
 		state,
 		event,
 		running,
 		issue,
-		running.Attempt,
-		"waiting for current-head CI",
+		attempt,
+		retryError,
 		"merge_worker_waiting_current_head_ci",
 		"merge worker is waiting for current-head CI for ",
 	)
@@ -1322,13 +1330,47 @@ func (o *Orchestrator) waitForMergeWorkerRetry(
 	}
 	o.scheduleRetry(state, issue, attempt, event.CompletedAt, retryError, true, running.WorkerHost)
 	if o.logger != nil {
-		o.logger.Info(eventName, mergeWorkerLogAttrs(issue, "attempt", attempt)...)
+		o.logger.Info(eventName, mergeWorkerLogAttrs(issue, "attempt", attempt, "reason", retryError)...)
 	}
 	recordStateEvent(state, telemetry.ActivityEvent{
 		At:      event.CompletedAt,
 		Event:   eventName,
 		Message: eventMessage + issueLabel(issue),
 	})
+}
+
+func (o *Orchestrator) mergeWorkerCurrentHeadCIWaitExceeded(state *State, issueID string, completedAt time.Time) bool {
+	if state == nil || completedAt.IsZero() {
+		return false
+	}
+	issueID = strings.TrimSpace(issueID)
+	timing := state.MergeTimings[issueID]
+	if timing.CIWaitStartedAt.IsZero() {
+		timing.CIWaitStartedAt = completedAt.UTC()
+		state.MergeTimings[issueID] = timing
+		return false
+	}
+	return !completedAt.Before(timing.CIWaitStartedAt.Add(mergeWorkerCurrentHeadCIWaitTimeout))
+}
+
+func mergeWorkerCurrentHeadCIWaitReason(issue connector.Issue) string {
+	const reason = "waiting for current-head CI"
+	if issue.PullRequest == nil {
+		return reason
+	}
+	pendingRequiredChecks := make([]string, 0, len(issue.PullRequest.RequiredCheckFailures))
+	for _, check := range issue.PullRequest.RequiredCheckFailures {
+		if autoPromoteCheckPending(check) && strings.TrimSpace(check.Name) != "" {
+			pendingRequiredChecks = append(pendingRequiredChecks, check.Name)
+		}
+	}
+	if pendingRequiredChecks = uniqueStrings(pendingRequiredChecks); len(pendingRequiredChecks) > 0 {
+		return reason + ": pending required checks: " + strings.Join(pendingRequiredChecks, ", ")
+	}
+	if runningChecks := uniqueStrings(issue.PullRequest.RunningChecks); len(runningChecks) > 0 {
+		return reason + ": pending checks: " + strings.Join(runningChecks, ", ")
+	}
+	return reason
 }
 
 func (o *Orchestrator) failProgrammaticMergeWorkerResult(
@@ -1345,7 +1387,7 @@ func (o *Orchestrator) failProgrammaticMergeWorkerResult(
 	o.recordMergeFailed(state, running.Issue, event.CompletedAt, reason, err)
 	attempt := nextAttempt(running.Attempt)
 	if attempt > maxMergeWorkerRunnerFailures {
-		if o.blockExhaustedMergeWorker(ctx, state, running, event.CompletedAt, attempt, err) {
+		if o.blockExhaustedMergeWorker(ctx, state, running, event.CompletedAt, mergeWorkerRetryExhaustedReason, attempt, err) {
 			return
 		}
 	}
@@ -1755,7 +1797,7 @@ func (o *Orchestrator) handleIncompleteMergeWorkerResult(
 	o.recordMergeFailed(state, running.Issue, event.CompletedAt, "terminal_state_missing", err)
 	attempt := nextAttempt(running.Attempt)
 	if attempt > maxMergeWorkerRunnerFailures {
-		if o.blockExhaustedMergeWorker(ctx, state, running, event.CompletedAt, attempt, err) {
+		if o.blockExhaustedMergeWorker(ctx, state, running, event.CompletedAt, mergeWorkerRetryExhaustedReason, attempt, err) {
 			return
 		}
 	}
@@ -1780,6 +1822,7 @@ func (o *Orchestrator) blockExhaustedMergeWorker(
 	state *State,
 	running Running,
 	completedAt time.Time,
+	reasonCode string,
 	attempt int,
 	err error,
 ) bool {
@@ -1787,35 +1830,43 @@ func (o *Orchestrator) blockExhaustedMergeWorker(
 	if issueID == "" || o.connector == nil {
 		return false
 	}
+	reasonCode = strings.TrimSpace(reasonCode)
+	if reasonCode == "" {
+		reasonCode = mergeWorkerRetryExhaustedReason
+	}
+	reason := reasonCode
+	if detail := errorString(err); detail != "" {
+		reason += ": " + detail
+	}
 	metadata := o.newBlockedRecoveryMetadata(
 		ctx,
 		running.Issue,
 		RunModeMerge,
-		mergeWorkerRetryExhaustedReason,
+		reason,
 		blockedRecoveryPredicateFingerprintChange,
 		autoPromoteReworkState,
 		running.DiffStats,
 	)
-	if err := o.updateIssueStateByIDWithMetadata(ctx, state, issueID, running.Issue, blockedStatusState, completedAt, mergeWorkerRetryExhaustedReason, metadata); err != nil {
+	if err := o.updateIssueStateByIDWithMetadata(ctx, state, issueID, running.Issue, blockedStatusState, completedAt, reason, metadata); err != nil {
 		if o.logger != nil {
 			o.logger.Warn(
 				"merge_worker_block_failed",
 				"issue_id", issueID,
 				"identifier", running.Issue.Identifier,
-				"reason", mergeWorkerRetryExhaustedReason,
+				"reason", reason,
 				"target_state", blockedStatusState,
 				"error", err,
 			)
 		}
 		return false
 	}
-	if comment := mergeWorkerRetryExhaustedComment(running.Issue, attempt, err); strings.TrimSpace(comment) != "" {
+	if comment := mergeWorkerRetryExhaustedComment(running.Issue, reasonCode, attempt, err); strings.TrimSpace(comment) != "" {
 		if err := o.connector.CreateComment(ctx, issueID, comment); err != nil && o.logger != nil {
 			o.logger.Warn(
 				"merge_worker_block_comment_failed",
 				"issue_id", issueID,
 				"identifier", running.Issue.Identifier,
-				"reason", mergeWorkerRetryExhaustedReason,
+				"reason", reason,
 				"error", err,
 			)
 		}
@@ -1830,7 +1881,7 @@ func (o *Orchestrator) blockExhaustedMergeWorker(
 	delete(state.Completed, issueID)
 	issue := cloneIssue(running.Issue)
 	issue.State = blockedStatusState
-	issue.BlockerReason = mergeWorkerRetryExhaustedReason + ": " + errorString(err)
+	issue.BlockerReason = reason
 	blockedAt := completedAt.UTC()
 	issue.StageUpdatedAt = &blockedAt
 	if state.Blocked == nil {
@@ -1838,24 +1889,28 @@ func (o *Orchestrator) blockExhaustedMergeWorker(
 	}
 	state.Blocked[issueID] = Blocked{
 		Issue:     issue,
-		Reason:    mergeWorkerRetryExhaustedReason,
+		Reason:    reason,
 		BlockedAt: completedAt,
 		Source:    BlockedSourceProjectStatus,
 		Recovery:  metadata.BlockedRecovery,
 	}
 	recordStateEvent(state, telemetry.ActivityEvent{
 		At:      completedAt,
-		Event:   "merge_worker_retry_exhausted",
-		Message: "merge worker retries exhausted for " + issueLabel(running.Issue) + ": " + errorString(err),
+		Event:   reasonCode,
+		Message: reasonCode + " for " + issueLabel(running.Issue) + ": " + errorString(err),
 	})
 	return true
 }
 
-func mergeWorkerRetryExhaustedComment(issue connector.Issue, attempt int, err error) string {
+func mergeWorkerRetryExhaustedComment(issue connector.Issue, reasonCode string, attempt int, err error) string {
 	var b strings.Builder
-	b.WriteString("Merge worker retries were exhausted; parked this issue in Blocked to stop automatic redispatch.")
+	if reasonCode == mergeWorkerCurrentHeadCIWaitExceededReason {
+		b.WriteString("The current-head CI wait exceeded its bounded deadline; parked this issue in Blocked to stop automatic redispatch.")
+	} else {
+		b.WriteString("Merge worker retries were exhausted; parked this issue in Blocked to stop automatic redispatch.")
+	}
 	b.WriteString("\n\n- reason: ")
-	b.WriteString(mergeWorkerRetryExhaustedReason)
+	b.WriteString(reasonCode)
 	if attempt > 0 {
 		b.WriteString("\n- attempt: ")
 		b.WriteString(strconv.Itoa(attempt))


### PR DESCRIPTION
## Summary

- advance current-head CI continuation attempts on every redispatch
- bound the wait with a one-hour elapsed deadline that persists across attempts
- park deadline-exceeded waits in Blocked with the pending required-check name in the reason
- exclude closed issues from stale merge-worker dispatch candidates
- add standard-library table-driven regressions for incrementing, elapsed-bound escalation, green-before-bound merging, and closed/merged dispatch suppression

Fixes #1660

## UI Surface Contract

- [x] N/A, or the linked issue explicitly authorizes any high-impact UI surface, layout, density, first-viewport, or responsive visibility tradeoff.
- [x] Persistent top-of-screen messaging is explicitly authorized by the issue, or this PR does not add it.
- [x] Visual changes to primary operator screens include screenshot or browser verification below. N/A — no UI changes.

## Test Plan

- [x] `go test ./internal/orchestrator -count=1`
- [x] `make check`