### PR TITLE
fix(dispatch): stop token throttle blocking merge fast paths

### DIFF
--- a/internal/orchestrator/dispatch.go
+++ b/internal/orchestrator/dispatch.go
@@ -144,8 +144,8 @@ func (o *Orchestrator) dispatchReadyIssues(ctx context.Context, state *State, is
 			}
 			return waitForDispatchBackoff(ctx, continuationDelay(continuationIndex))
 		},
-		dispatch: func(issue connector.Issue, attempt int, workerHost string) bool {
-			outcome := o.dispatchIssueWithOutcome(ctx, state, issue, attempt, now, workerHost)
+		dispatch: func(action dispatchAction) bool {
+			outcome := o.dispatchIssueWithAction(ctx, state, action, now)
 			if !outcome.dispatched {
 				lastDispatchFailure = outcome.reason
 			} else {
@@ -161,6 +161,7 @@ func (o *Orchestrator) dispatchReadyIssues(ctx context.Context, state *State, is
 			rescheduled := state.Retry[issue.ID]
 			rescheduled.RetryMode = retry.RetryMode
 			rescheduled.ResumeState = retry.ResumeState
+			rescheduled.MergePrecheck = cloneMergePrecheck(retry.MergePrecheck)
 			state.Retry[issue.ID] = rescheduled
 		},
 		preserveMissingDueRetry: func(retry Retry) bool {
@@ -205,7 +206,7 @@ func (o *Orchestrator) dispatchCandidates(ctx context.Context, state *State, iss
 		return
 	}
 	for _, issue := range issues {
-		if o.dispatchPlanner().availableSlots(state) == 0 {
+		if o.dispatchPlanner().hardAvailableSlots(state) == 0 {
 			return
 		}
 		issue, ok := o.hydrateDispatchIssue(ctx, issue)
@@ -263,6 +264,24 @@ func (o *Orchestrator) dispatchIssue(
 	return o.dispatchIssueWithOutcome(ctx, state, issue, attempt, now, preferredWorkerHost).dispatched
 }
 
+func (o *Orchestrator) dispatchIssueWithAction(
+	ctx context.Context,
+	state *State,
+	action dispatchAction,
+	now time.Time,
+) dispatchIssueOutcome {
+	return o.dispatchIssueWithAdmission(
+		ctx,
+		state,
+		action.issue,
+		action.attempt,
+		now,
+		action.workerHost,
+		action.modelPermitRequired,
+		action.retryState,
+	)
+}
+
 func (o *Orchestrator) dispatchIssueWithOutcome(
 	ctx context.Context,
 	state *State,
@@ -270,6 +289,28 @@ func (o *Orchestrator) dispatchIssueWithOutcome(
 	attempt int,
 	now time.Time,
 	preferredWorkerHost string,
+) dispatchIssueOutcome {
+	return o.dispatchIssueWithAdmission(
+		ctx,
+		state,
+		issue,
+		attempt,
+		now,
+		preferredWorkerHost,
+		o.dispatchPlanner().modelPermitRequiredAtDispatch(issue),
+		nil,
+	)
+}
+
+func (o *Orchestrator) dispatchIssueWithAdmission(
+	ctx context.Context,
+	state *State,
+	issue connector.Issue,
+	attempt int,
+	now time.Time,
+	preferredWorkerHost string,
+	modelPermitRequired bool,
+	retryState *Retry,
 ) dispatchIssueOutcome {
 	if !o.beginDispatchStart() {
 		return dispatchIssueOutcome{reason: dispatchIssueFailureDraining}
@@ -288,6 +329,10 @@ func (o *Orchestrator) dispatchIssueWithOutcome(
 		return dispatchIssueOutcome{reason: reason}
 	}
 	queuedRetry, retryQueued := state.Retry[issue.ID]
+	if retryState != nil {
+		queuedRetry = *retryState
+		retryQueued = true
+	}
 	runMode := o.dispatchMode(ctx, state, issue)
 	capacityRequest := runpkg.RunRequest{Issue: issue, Mode: runMode, SelectorContext: o.selectorContext()}
 	capacityScope, capacityProbeKey, capacityPaused := o.backendCapacityDispatch(state, capacityRequest, now)
@@ -299,7 +344,7 @@ func (o *Orchestrator) dispatchIssueWithOutcome(
 	if targetState != "" {
 		slotIssue = cloneIssue(issue)
 		slotIssue.State = targetState
-		if !o.dispatchPlanner().slotsAvailable(slotIssue, state, preferredWorkerHost) {
+		if !o.dispatchPlanner().slotsAvailableForModelRequirement(slotIssue, state, preferredWorkerHost, modelPermitRequired) {
 			return dispatchIssueOutcome{reason: dispatchIssueFailureLocalSlotUnavailable}
 		}
 	}
@@ -511,6 +556,7 @@ func (o *Orchestrator) dispatchIssueWithOutcome(
 		WorkerHost:          workerHost,
 		CapacityScope:       capacityScope,
 		CapacityProbe:       capacityProbeKey != "",
+		ModelPermitExempt:   !modelPermitRequired,
 		StopDestination:     o.cfg.StopRunTargetState,
 		StopPriorityOptions: stopRunPriorityOptions(o.cfg.StopRunPriorityNames),
 		globalSlot:          globalSlot,
@@ -541,6 +587,10 @@ func (o *Orchestrator) dispatchIssueWithOutcome(
 		OnActivityUpdate:    o.activityUpdateHandler(runCtx, issue),
 		OnOverrideRejected:  o.agentOverrideRejectionHandler(runCtx, issue),
 		ProgressProbe:       o.sessionProgressProbe(issue),
+		MergePrecheck:       cloneMergePrecheck(queuedRetry.MergePrecheck),
+	}
+	if !modelPermitRequired {
+		request.AcquireModelPermit = o.modelPermitAcquirer(issue.ID)
 	}
 	if retryQueued {
 		request.RetryMode = queuedRetry.RetryMode

--- a/internal/orchestrator/dispatch_planner.go
+++ b/internal/orchestrator/dispatch_planner.go
@@ -21,7 +21,7 @@ type dispatchPlanner struct {
 type dispatchPlanHooks struct {
 	hydrate                 func(connector.Issue) (connector.Issue, bool)
 	beforeDispatch          func(connector.Issue, int) bool
-	dispatch                func(connector.Issue, int, string) bool
+	dispatch                func(dispatchAction) bool
 	dispatchFailed          func(connector.Issue) bool
 	retryDispatchFailed     func(connector.Issue, Retry)
 	preserveMissingDueRetry func(Retry) bool
@@ -29,10 +29,12 @@ type dispatchPlanHooks struct {
 }
 
 type dispatchAction struct {
-	issue      connector.Issue
-	attempt    int
-	workerHost string
-	retry      bool
+	issue               connector.Issue
+	attempt             int
+	workerHost          string
+	retry               bool
+	modelPermitRequired bool
+	retryState          *Retry
 }
 
 type dispatchPlanDecision struct {
@@ -108,16 +110,12 @@ func (p dispatchPlanner) plan(
 			}
 			continue
 		}
-		if p.availableSlots(state) == 0 {
-			reason := dispatchSkipGlobalCapacityFull
-			if p.rateWindowBackpressureActive(state) {
-				reason = dispatchSkipRateWindowBackpressure
-			}
+		if p.hardAvailableSlots(state) == 0 {
 			for skipIndex := index; skipIndex < len(plannedCandidates); skipIndex++ {
 				p.logDecision(hooks, dispatchPlanDecision{
 					Issue:         plannedCandidates[skipIndex],
 					QueuePosition: skipIndex + 1,
-					SkipReason:    reason,
+					SkipReason:    dispatchSkipGlobalCapacityFull,
 				})
 			}
 			break
@@ -203,9 +201,9 @@ func (p dispatchPlanner) applyDispatchAction(
 	hooks dispatchPlanHooks,
 ) bool {
 	if hooks.dispatch != nil {
-		return hooks.dispatch(action.issue, action.attempt, action.workerHost)
+		return hooks.dispatch(action)
 	}
-	p.markDispatched(state, action.issue, action.attempt, now, action.workerHost)
+	p.markDispatched(state, action, now)
 	return true
 }
 
@@ -234,14 +232,22 @@ func (p dispatchPlanner) retryAction(
 	}
 	delete(state.Retry, retry.Issue.ID)
 
-	decision := p.dispatchableIssueDecision(issue, state, true, now, retry.WorkerHost)
+	modelPermitRequired := p.modelPermitRequiredAtDispatch(issue) || retry.MergePrecheck != nil
+	decision := p.dispatchableIssueDecisionForModelRequirement(
+		issue,
+		state,
+		true,
+		now,
+		retry.WorkerHost,
+		modelPermitRequired,
+	)
 	if !decision.dispatchable {
 		if p.budgetCooldownActive(state, issue.ID, now) {
-			p.scheduleRetry(state, issue, retry.Attempt, now, "budget cooldown active", false, retry.WorkerHost)
+			p.rescheduleRetry(state, retry, now, "budget cooldown active", false)
 			return dispatchAction{}, false, decision.reason
 		}
-		if !p.slotsAvailable(issue, state, retry.WorkerHost) {
-			p.scheduleRetry(state, issue, retry.Attempt, now, "no available orchestrator slots", false, retry.WorkerHost)
+		if !p.slotsAvailableForModelRequirement(issue, state, retry.WorkerHost, modelPermitRequired) {
+			p.rescheduleRetry(state, retry, now, "no available orchestrator slots", false)
 			return dispatchAction{}, false, decision.reason
 		}
 		if _, blocked := state.Blocked[issue.ID]; blocked {
@@ -253,7 +259,7 @@ func (p dispatchPlanner) retryAction(
 		return dispatchAction{}, false, decision.reason
 	}
 
-	action, ok := p.newDispatchAction(state, issue, retry.Attempt, retry.WorkerHost, true)
+	action, ok := p.newDispatchAction(state, issue, retry.Attempt, retry.WorkerHost, true, modelPermitRequired, &retry)
 	if !ok {
 		return dispatchAction{}, false, dispatchSkipWorkerHostUnavailable
 	}
@@ -274,7 +280,7 @@ func (p dispatchPlanner) dispatchAction(state *State, issue connector.Issue, now
 		return dispatchAction{}, false, decision.reason
 	}
 
-	action, ok := p.newDispatchAction(state, issue, 0, "", false)
+	action, ok := p.newDispatchAction(state, issue, 0, "", false, p.modelPermitRequiredAtDispatch(issue), nil)
 	if !ok {
 		return dispatchAction{}, false, dispatchSkipWorkerHostUnavailable
 	}
@@ -287,6 +293,8 @@ func (p dispatchPlanner) newDispatchAction(
 	attempt int,
 	preferredWorkerHost string,
 	retry bool,
+	modelPermitRequired bool,
+	retryState *Retry,
 ) (dispatchAction, bool) {
 	workerHost, ok := p.selectWorkerHost(state, preferredWorkerHost)
 	if !ok {
@@ -294,26 +302,23 @@ func (p dispatchPlanner) newDispatchAction(
 	}
 
 	return dispatchAction{
-		issue:      cloneIssue(issue),
-		attempt:    attempt,
-		workerHost: workerHost,
-		retry:      retry,
+		issue:               cloneIssue(issue),
+		attempt:             attempt,
+		workerHost:          workerHost,
+		retry:               retry,
+		modelPermitRequired: modelPermitRequired,
+		retryState:          retryState,
 	}, true
 }
 
-func (p dispatchPlanner) markDispatched(
-	state *State,
-	issue connector.Issue,
-	attempt int,
-	now time.Time,
-	workerHost string,
-) {
-	issue = cloneIssue(issue)
+func (p dispatchPlanner) markDispatched(state *State, action dispatchAction, now time.Time) {
+	issue := cloneIssue(action.issue)
 	state.Running[issue.ID] = Running{
-		Issue:      issue,
-		Attempt:    attempt,
-		StartedAt:  now,
-		WorkerHost: workerHost,
+		Issue:             issue,
+		Attempt:           action.attempt,
+		StartedAt:         now,
+		WorkerHost:        action.workerHost,
+		ModelPermitExempt: !action.modelPermitRequired,
 	}
 	state.Claimed[issue.ID] = Claimed{
 		Issue:     issue,
@@ -520,6 +525,24 @@ func (p dispatchPlanner) dispatchableIssueDecision(
 	now time.Time,
 	preferredWorkerHost string,
 ) dispatchableDecision {
+	return p.dispatchableIssueDecisionForModelRequirement(
+		issue,
+		state,
+		allowClaimed,
+		now,
+		preferredWorkerHost,
+		p.modelPermitRequiredAtDispatch(issue),
+	)
+}
+
+func (p dispatchPlanner) dispatchableIssueDecisionForModelRequirement(
+	issue connector.Issue,
+	state *State,
+	allowClaimed bool,
+	now time.Time,
+	preferredWorkerHost string,
+	modelPermitRequired bool,
+) dispatchableDecision {
 	if !validCandidate(issue) {
 		return dispatchableDecision{reason: dispatchSkipInvalidCandidate}
 	}
@@ -574,7 +597,10 @@ func (p dispatchPlanner) dispatchableIssueDecision(
 	if p.budgetCooldownActive(state, issue.ID, now) {
 		return dispatchableDecision{reason: dispatchSkipBudgetCooldown}
 	}
-	if p.availableSlots(state) == 0 {
+	if p.hardAvailableSlots(state) == 0 {
+		return dispatchableDecision{reason: dispatchSkipGlobalCapacityFull}
+	}
+	if modelPermitRequired && p.availableSlots(state) == 0 {
 		if p.rateWindowBackpressureActive(state) {
 			return dispatchableDecision{reason: dispatchSkipRateWindowBackpressure}
 		}
@@ -644,13 +670,37 @@ func (p dispatchPlanner) authorized(issue connector.Issue) bool {
 	return selector.Match(issue, p.cfg.Authorization, p.cfg.SelectorContext)
 }
 
-func (p dispatchPlanner) slotsAvailable(issue connector.Issue, state *State, preferredWorkerHost string) bool {
-	return p.availableSlots(state) > 0 &&
-		p.stateSlotsAvailable(issue, state) &&
+func (p dispatchPlanner) slotsAvailableForModelRequirement(
+	issue connector.Issue,
+	state *State,
+	preferredWorkerHost string,
+	modelPermitRequired bool,
+) bool {
+	if p.hardAvailableSlots(state) == 0 {
+		return false
+	}
+	if modelPermitRequired && p.availableSlots(state) == 0 {
+		return false
+	}
+	return p.stateSlotsAvailable(issue, state) &&
 		p.workerSlotsAvailable(state, preferredWorkerHost)
 }
 
 func (p dispatchPlanner) availableSlots(state *State) int {
+	return min(p.hardAvailableSlots(state), p.providerModelPermitSlots(state))
+}
+
+func (p dispatchPlanner) hardAvailableSlots(state *State) int {
+	if state == nil {
+		return 0
+	}
+	return max(0, state.MaxConcurrentAgents-len(state.Running))
+}
+
+func (p dispatchPlanner) providerModelPermitSlots(state *State) int {
+	if state == nil {
+		return 0
+	}
 	limit := state.MaxConcurrentAgents
 	if p.cfg.subscriptionBilling() {
 		if remaining, ok := providerRateWindowRemainingPercent(state); ok {
@@ -658,12 +708,33 @@ func (p dispatchPlanner) availableSlots(state *State) int {
 			limit = max(1, limit)
 		}
 	}
-	available := limit - len(state.Running)
+	available := limit - modelPermitsUsed(state)
 	return max(0, available)
 }
 
 func (p dispatchPlanner) rateWindowBackpressureActive(state *State) bool {
-	return p.cfg.subscriptionBilling() && availableSlots(state) > 0 && p.availableSlots(state) == 0
+	return p.cfg.subscriptionBilling() && p.hardAvailableSlots(state) > 0 && p.providerModelPermitSlots(state) == 0
+}
+
+func (p dispatchPlanner) modelPermitRequiredAtDispatch(issue connector.Issue) bool {
+	return !p.mechanicalMergeAdmission(issue)
+}
+
+func (p dispatchPlanner) mechanicalMergeAdmission(issue connector.Issue) bool {
+	return p.cfg.MergeFastPathEnabled && normalizeState(issue.State) == normalizeState(autoPromoteMergingState)
+}
+
+func modelPermitsUsed(state *State) int {
+	if state == nil {
+		return 0
+	}
+	used := 0
+	for _, running := range state.Running {
+		if !running.ModelPermitExempt {
+			used++
+		}
+	}
+	return used
 }
 
 func providerRateWindowRemainingPercent(state *State) (float64, bool) {
@@ -752,6 +823,22 @@ func (p dispatchPlanner) scheduleRetry(
 	}
 
 	p.scheduleRetryAfter(state, issue, attempt, now, p.retryDelay(attempt, continuation), err, workerHost)
+}
+
+func (p dispatchPlanner) rescheduleRetry(
+	state *State,
+	retry Retry,
+	now time.Time,
+	err string,
+	continuation bool,
+) {
+	if retry.Attempt < 1 {
+		retry.Attempt = 1
+	}
+	retry.DueAt = now.Add(p.retryDelay(retry.Attempt, continuation))
+	retry.Error = p.operatorText(err)
+	retry.MergePrecheck = cloneMergePrecheck(retry.MergePrecheck)
+	state.Retry[retry.Issue.ID] = retry
 }
 
 func (p dispatchPlanner) scheduleRetryAfter(

--- a/internal/orchestrator/dispatch_recovery_test.go
+++ b/internal/orchestrator/dispatch_recovery_test.go
@@ -25,7 +25,8 @@ func TestDispatchRecoveryRampBoundsDispatchUntilProgress(t *testing.T) {
 		dispatchTestIssue("issue-3", "Todo"),
 	}
 	dispatched := []string{}
-	hooks := dispatchPlanHooks{dispatch: func(issue connector.Issue, _ int, _ string) bool {
+	hooks := dispatchPlanHooks{dispatch: func(action dispatchAction) bool {
+		issue := action.issue
 		_, allowed, _ := tryReserveDispatchRecovery(&state, issue.ID, now)
 		if allowed {
 			dispatched = append(dispatched, issue.ID)

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -257,6 +257,7 @@ type Orchestrator struct {
 	capacityClearRequests   chan capacityClearRequest
 	failureCanaryRequests   chan failureBreakerCanaryRequest
 	stopRequests            chan stopRunRequest
+	modelPermitRequests     chan modelPermitRequest
 	runResults              chan runpkg.Completion
 	runUpdates              chan runUpdate
 	validatorCapacityEvents chan validatorCapacityEvent
@@ -281,6 +282,11 @@ type validatorStageFailure struct {
 
 type stateRequest struct {
 	reply chan State
+}
+
+type modelPermitRequest struct {
+	issueID string
+	reply   chan error
 }
 
 type drainRequest struct {
@@ -510,6 +516,7 @@ func New(cfg Config, deps Dependencies) (*Orchestrator, error) {
 		capacityClearRequests:   make(chan capacityClearRequest),
 		failureCanaryRequests:   make(chan failureBreakerCanaryRequest),
 		stopRequests:            make(chan stopRunRequest),
+		modelPermitRequests:     make(chan modelPermitRequest),
 		runResults:              make(chan runpkg.Completion, max(cfg.MaxConcurrentAgents, 1)),
 		runUpdates:              make(chan runUpdate, runUpdateBufferSize),
 		validatorCapacityEvents: make(chan validatorCapacityEvent, max(cfg.MaxConcurrentAgents, 1)),
@@ -583,6 +590,8 @@ func (o *Orchestrator) Run(ctx context.Context) error {
 			}
 		case request := <-o.stopRequests:
 			o.handleStopRunRequest(ctx, &state, request)
+		case request := <-o.modelPermitRequests:
+			request.reply <- o.handleModelPermitRequest(&state, request.issueID)
 		case result := <-o.runResults:
 			o.handleRunResult(ctx, &state, result)
 		case update := <-o.runUpdates:

--- a/internal/orchestrator/provider_window_admission.go
+++ b/internal/orchestrator/provider_window_admission.go
@@ -1,0 +1,59 @@
+package orchestrator
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	runpkg "github.com/digitaldrywood/detent/internal/runner"
+)
+
+func (o *Orchestrator) modelPermitAcquirer(issueID string) runpkg.ModelPermitAcquirer {
+	if o == nil || o.modelPermitRequests == nil {
+		return nil
+	}
+	return func(ctx context.Context) error {
+		if ctx == nil {
+			ctx = context.Background()
+		}
+		request := modelPermitRequest{
+			issueID: strings.TrimSpace(issueID),
+			reply:   make(chan error, 1),
+		}
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-o.done:
+			return ErrStopped
+		case o.modelPermitRequests <- request:
+		}
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-o.done:
+			return ErrStopped
+		case err := <-request.reply:
+			return err
+		}
+	}
+}
+
+func (o *Orchestrator) handleModelPermitRequest(state *State, issueID string) error {
+	issueID = strings.TrimSpace(issueID)
+	if state == nil {
+		return fmt.Errorf("acquire model permit for %s: orchestrator state unavailable", issueID)
+	}
+	running, ok := state.Running[issueID]
+	if !ok {
+		return fmt.Errorf("acquire model permit for %s: run unavailable", issueID)
+	}
+	if !running.ModelPermitExempt {
+		return nil
+	}
+	if o.dispatchPlanner().providerModelPermitSlots(state) == 0 {
+		return runpkg.ErrModelPermitUnavailable
+	}
+	running.ModelPermitExempt = false
+	state.Running[issueID] = running
+	return nil
+}

--- a/internal/orchestrator/provider_window_admission_test.go
+++ b/internal/orchestrator/provider_window_admission_test.go
@@ -10,6 +10,7 @@ import (
 	workflowconfig "github.com/digitaldrywood/detent/internal/config"
 	"github.com/digitaldrywood/detent/internal/connector"
 	runpkg "github.com/digitaldrywood/detent/internal/runner"
+	"github.com/digitaldrywood/detent/internal/store"
 )
 
 func TestProviderWindowAdmissionDecisions(t *testing.T) {
@@ -222,11 +223,22 @@ func TestModelPermitDeferralReleasesHardCapacityAndPreservesPrecheck(t *testing.
 		ModelPermitExempt: true,
 	}
 	precheck := &runpkg.MergePrecheck{Status: "dirty", Message: "local changes", DiffStats: DiffStats{FilesChanged: 1}}
+	resumeState := store.AgentResumeState{
+		DetentSessionID:   1659,
+		ProviderThreadID:  "thread-1659",
+		ProviderSessionID: "session-1659",
+		Orphaned:          true,
+	}
 	orch := &Orchestrator{cfg: cfg}
 
 	orch.handleRunResult(context.Background(), &state, runpkg.Completion{
-		IssueID:     issue.ID,
-		Request:     runpkg.RunRequest{Issue: issue, Mode: runpkg.RunModeMerge},
+		IssueID: issue.ID,
+		Request: runpkg.RunRequest{
+			Issue:       issue,
+			Mode:        runpkg.RunModeMerge,
+			RetryMode:   runpkg.RetryModeResume,
+			ResumeState: resumeState,
+		},
 		Result:      runpkg.RunResult{Output: runpkg.RunOutputMergeFallbackDeferred, MergePrecheck: precheck},
 		Err:         runpkg.ErrModelPermitUnavailable,
 		CompletedAt: now,
@@ -241,6 +253,9 @@ func TestModelPermitDeferralReleasesHardCapacityAndPreservesPrecheck(t *testing.
 	retry := state.Retry[issue.ID]
 	if retry.MergePrecheck == nil || retry.MergePrecheck.Status != precheck.Status || retry.MergePrecheck.Message != precheck.Message {
 		t.Fatalf("retry = %#v, want preserved precheck", retry)
+	}
+	if retry.RetryMode != runpkg.RetryModeResume || retry.ResumeState != resumeState {
+		t.Fatalf("retry = %#v, want preserved resume metadata", retry)
 	}
 }
 

--- a/internal/orchestrator/provider_window_admission_test.go
+++ b/internal/orchestrator/provider_window_admission_test.go
@@ -1,0 +1,280 @@
+package orchestrator
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+	"time"
+
+	workflowconfig "github.com/digitaldrywood/detent/internal/config"
+	"github.com/digitaldrywood/detent/internal/connector"
+	runpkg "github.com/digitaldrywood/detent/internal/runner"
+)
+
+func TestProviderWindowAdmissionDecisions(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name                string
+		issue               connector.Issue
+		running             int
+		modelPermitRequired *bool
+		wantDispatchable    bool
+		wantReason          string
+	}{
+		{
+			name:             "checked head starts mechanically",
+			issue:            providerWindowMergeIssue("fast-path"),
+			running:          3,
+			wantDispatchable: true,
+		},
+		{
+			name:                "prechecked fallback needs model permit",
+			issue:               providerWindowMergeIssue("fallback"),
+			running:             3,
+			modelPermitRequired: boolPointer(true),
+			wantReason:          dispatchSkipRateWindowBackpressure,
+		},
+		{
+			name:       "ordinary work needs model permit",
+			issue:      dispatchTestIssue("ordinary", "Todo"),
+			running:    3,
+			wantReason: dispatchSkipRateWindowBackpressure,
+		},
+		{
+			name:       "mechanical work still obeys hard project cap",
+			issue:      providerWindowMergeIssue("hard-cap"),
+			running:    5,
+			wantReason: dispatchSkipGlobalCapacityFull,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			cfg := providerWindowTestConfig()
+			state := providerWindowState(cfg, tt.running)
+			planner := newDispatchPlanner(cfg)
+			var decision dispatchableDecision
+			if tt.modelPermitRequired == nil {
+				decision = planner.dispatchableIssueDecision(tt.issue, &state, false, time.Now(), "")
+			} else {
+				decision = planner.dispatchableIssueDecisionForModelRequirement(
+					tt.issue,
+					&state,
+					false,
+					time.Now(),
+					"",
+					*tt.modelPermitRequired,
+				)
+			}
+			if decision.dispatchable != tt.wantDispatchable || decision.reason != tt.wantReason {
+				t.Fatalf("dispatchable decision = %#v, want dispatchable=%t reason=%q", decision, tt.wantDispatchable, tt.wantReason)
+			}
+		})
+	}
+}
+
+func TestProviderWindowPlanAdmitsMechanicalMerge(t *testing.T) {
+	t.Parallel()
+
+	cfg := providerWindowTestConfig()
+	state := providerWindowState(cfg, 3)
+	ordinary := dispatchTestIssue("ordinary", "Todo")
+	merge := providerWindowMergeIssue("merge")
+	var decisions []dispatchPlanDecision
+
+	plan := newDispatchPlanner(cfg).plan(
+		&state,
+		[]connector.Issue{ordinary, merge},
+		time.Now(),
+		dispatchPlanHooks{decision: func(decision dispatchPlanDecision) {
+			decisions = append(decisions, decision)
+		}},
+	)
+
+	if len(plan.Dispatches) != 1 || plan.Dispatches[0].IssueID != merge.ID {
+		t.Fatalf("dispatches = %#v, want only mechanical merge", plan.Dispatches)
+	}
+	if running := state.Running[merge.ID]; !running.ModelPermitExempt {
+		t.Fatalf("merge Running = %#v, want model permit exempt during precheck", running)
+	}
+	if len(decisions) != 2 || !decisions[0].Selected || decisions[1].SkipReason != dispatchSkipRateWindowBackpressure {
+		t.Fatalf("decisions = %#v, want selected merge then model backpressure", decisions)
+	}
+}
+
+func TestProviderWindowFallbackRetryRemainsDeferred(t *testing.T) {
+	t.Parallel()
+
+	cfg := providerWindowTestConfig()
+	state := providerWindowState(cfg, 3)
+	issue := providerWindowMergeIssue("fallback")
+	precheck := &runpkg.MergePrecheck{Status: "conflict", Message: "README conflict"}
+	state.Retry[issue.ID] = Retry{
+		Issue:         issue,
+		Attempt:       1,
+		DueAt:         time.Now().Add(-time.Second),
+		MergePrecheck: precheck,
+	}
+	var decision dispatchPlanDecision
+
+	plan := newDispatchPlanner(cfg).plan(&state, []connector.Issue{issue}, time.Now(), dispatchPlanHooks{
+		decision: func(got dispatchPlanDecision) {
+			decision = got
+		},
+	})
+
+	if len(plan.Dispatches) != 0 || decision.SkipReason != dispatchSkipRateWindowBackpressure {
+		t.Fatalf("plan = %#v decision = %#v, want deferred provider backpressure", plan, decision)
+	}
+	retry := state.Retry[issue.ID]
+	if retry.MergePrecheck == nil || retry.MergePrecheck.Status != precheck.Status || retry.MergePrecheck.Message != precheck.Message {
+		t.Fatalf("retry = %#v, want preserved merge precheck", retry)
+	}
+}
+
+func TestProviderWindowMechanicalToModelTransition(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name            string
+		modelRuns       int
+		wantErr         error
+		wantExempt      bool
+		wantPermitsUsed int
+	}{
+		{name: "defer at scaled cap", modelRuns: 3, wantErr: runpkg.ErrModelPermitUnavailable, wantExempt: true, wantPermitsUsed: 3},
+		{name: "acquire below scaled cap", modelRuns: 2, wantExempt: false, wantPermitsUsed: 3},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			cfg := providerWindowTestConfig()
+			state := providerWindowState(cfg, tt.modelRuns)
+			issue := providerWindowMergeIssue("transition")
+			state.Running[issue.ID] = Running{Issue: issue, ModelPermitExempt: true}
+			orch := &Orchestrator{cfg: cfg}
+
+			err := orch.handleModelPermitRequest(&state, issue.ID)
+			if !errors.Is(err, tt.wantErr) {
+				t.Fatalf("handleModelPermitRequest() error = %v, want %v", err, tt.wantErr)
+			}
+			if got := state.Running[issue.ID].ModelPermitExempt; got != tt.wantExempt {
+				t.Fatalf("ModelPermitExempt = %t, want %t", got, tt.wantExempt)
+			}
+			if got := modelPermitsUsed(&state); got != tt.wantPermitsUsed {
+				t.Fatalf("modelPermitsUsed() = %d, want %d", got, tt.wantPermitsUsed)
+			}
+		})
+	}
+}
+
+func TestProviderWindowScaledCap(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		remaining int64
+		want      int
+	}{
+		{remaining: 100, want: 5},
+		{remaining: 81, want: 5},
+		{remaining: 80, want: 4},
+		{remaining: 61, want: 4},
+		{remaining: 60, want: 3},
+		{remaining: 41, want: 3},
+		{remaining: 40, want: 2},
+		{remaining: 21, want: 2},
+		{remaining: 20, want: 1},
+		{remaining: 1, want: 1},
+		{remaining: 0, want: 1},
+	}
+
+	for _, tt := range tests {
+		t.Run(fmt.Sprintf("remaining_%d", tt.remaining), func(t *testing.T) {
+			t.Parallel()
+
+			cfg := providerWindowTestConfig()
+			state := newState(cfg)
+			state.RateLimits = providerRateLimits(tt.remaining, 100)
+			if got := newDispatchPlanner(cfg).providerModelPermitSlots(&state); got != tt.want {
+				t.Fatalf("providerModelPermitSlots() = %d, want %d", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestModelPermitDeferralReleasesHardCapacityAndPreservesPrecheck(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 8, 7, 22, 41, 0, 0, time.UTC)
+	cfg := providerWindowTestConfig()
+	state := providerWindowState(cfg, 3)
+	issue := providerWindowMergeIssue("deferred")
+	state.Running[issue.ID] = Running{
+		Issue:             issue,
+		Attempt:           1,
+		StartedAt:         now.Add(-time.Second),
+		ModelPermitExempt: true,
+	}
+	precheck := &runpkg.MergePrecheck{Status: "dirty", Message: "local changes", DiffStats: DiffStats{FilesChanged: 1}}
+	orch := &Orchestrator{cfg: cfg}
+
+	orch.handleRunResult(context.Background(), &state, runpkg.Completion{
+		IssueID:     issue.ID,
+		Request:     runpkg.RunRequest{Issue: issue, Mode: runpkg.RunModeMerge},
+		Result:      runpkg.RunResult{Output: runpkg.RunOutputMergeFallbackDeferred, MergePrecheck: precheck},
+		Err:         runpkg.ErrModelPermitUnavailable,
+		CompletedAt: now,
+	})
+
+	if _, ok := state.Running[issue.ID]; ok {
+		t.Fatalf("Running[%q] present after fallback deferral", issue.ID)
+	}
+	if got := newDispatchPlanner(cfg).hardAvailableSlots(&state); got != 2 {
+		t.Fatalf("hardAvailableSlots() = %d, want 2 after mechanical slot release", got)
+	}
+	retry := state.Retry[issue.ID]
+	if retry.MergePrecheck == nil || retry.MergePrecheck.Status != precheck.Status || retry.MergePrecheck.Message != precheck.Message {
+		t.Fatalf("retry = %#v, want preserved precheck", retry)
+	}
+}
+
+func providerWindowTestConfig() Config {
+	return normalizeConfig(Config{
+		BillingMode:          workflowconfig.BillingModeSubscription,
+		MaxConcurrentAgents:  5,
+		MergeFastPathEnabled: true,
+		ActiveStates:         []string{"Todo", "In Progress", "Rework", "Merging"},
+		TerminalStates:       []string{"Done", "Cancelled"},
+	})
+}
+
+func providerWindowState(cfg Config, runningCount int) State {
+	state := newState(cfg)
+	state.RateLimits = providerRateLimits(48, 100)
+	for index := range runningCount {
+		issue := dispatchTestIssue(fmt.Sprintf("running-%d", index), "In Progress")
+		state.Running[issue.ID] = Running{Issue: issue}
+	}
+	return state
+}
+
+func providerWindowMergeIssue(id string) connector.Issue {
+	issue := dispatchTestIssue(id, "Merging")
+	issue.PullRequest = &connector.PullRequest{
+		State:          "open",
+		MergeableState: "clean",
+		CIStatus:       "success",
+		HeadSHA:        "checked-head",
+	}
+	return issue
+}
+
+func boolPointer(value bool) *bool {
+	return &value
+}

--- a/internal/orchestrator/provider_window_completion.go
+++ b/internal/orchestrator/provider_window_completion.go
@@ -1,0 +1,58 @@
+package orchestrator
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	runpkg "github.com/digitaldrywood/detent/internal/runner"
+	"github.com/digitaldrywood/detent/internal/store"
+	"github.com/digitaldrywood/detent/internal/telemetry"
+)
+
+func (o *Orchestrator) handleModelPermitDeferred(
+	ctx context.Context,
+	state *State,
+	event runpkg.Completion,
+	running Running,
+) bool {
+	if !errors.Is(event.Err, runpkg.ErrModelPermitUnavailable) {
+		return false
+	}
+	releaseBackendCapacityProbe(state, running)
+	releaseDispatchRecoveryAdmission(state, event.IssueID)
+	releaseProjectFailureBreakerCanary(state, event.IssueID)
+	o.completeDurableWorkAttempt(
+		ctx,
+		state,
+		running,
+		event.CompletedAt,
+		store.WorkAttemptTerminalCapacity,
+		dispatchSkipRateWindowBackpressure,
+		event.Err.Error(),
+		"deferred",
+		"merge fallback waiting for provider model capacity",
+	)
+	delay := o.cfg.ContinuationRetryDelay
+	if delay < 0 {
+		delay = 0
+	}
+	completedAt := event.CompletedAt
+	if completedAt.IsZero() {
+		completedAt = time.Now()
+	}
+	state.Retry[event.IssueID] = Retry{
+		Issue:         cloneIssue(running.Issue),
+		Attempt:       max(1, running.Attempt),
+		DueAt:         completedAt.Add(delay),
+		Error:         dispatchSkipRateWindowBackpressure,
+		WorkerHost:    running.WorkerHost,
+		MergePrecheck: cloneMergePrecheck(event.Result.MergePrecheck),
+	}
+	recordStateEvent(state, telemetry.ActivityEvent{
+		At:      completedAt,
+		Event:   "merge_fallback_deferred",
+		Message: "deferred merge fallback for " + issueLabel(running.Issue) + " until provider model capacity is available",
+	})
+	return true
+}

--- a/internal/orchestrator/provider_window_completion.go
+++ b/internal/orchestrator/provider_window_completion.go
@@ -47,6 +47,8 @@ func (o *Orchestrator) handleModelPermitDeferred(
 		DueAt:         completedAt.Add(delay),
 		Error:         dispatchSkipRateWindowBackpressure,
 		WorkerHost:    running.WorkerHost,
+		RetryMode:     event.Request.RetryMode,
+		ResumeState:   event.Request.ResumeState,
 		MergePrecheck: cloneMergePrecheck(event.Result.MergePrecheck),
 	}
 	recordStateEvent(state, telemetry.ActivityEvent{

--- a/internal/orchestrator/rate_limit_test.go
+++ b/internal/orchestrator/rate_limit_test.go
@@ -498,7 +498,7 @@ func TestGitHubRESTCapacityOutagePausesDispatchAndResumesAtReset(t *testing.T) {
 	orch.syncGitHubRESTCapacityOutage(&state, now)
 
 	dispatches := 0
-	hooks := dispatchPlanHooks{dispatch: func(connector.Issue, int, string) bool {
+	hooks := dispatchPlanHooks{dispatch: func(dispatchAction) bool {
 		dispatches++
 		return true
 	}}

--- a/internal/orchestrator/run_completion.go
+++ b/internal/orchestrator/run_completion.go
@@ -137,6 +137,9 @@ func (o *Orchestrator) handleRunResult(ctx context.Context, state *State, event 
 		running.cancel()
 	}
 	delete(state.Running, event.IssueID)
+	if o.handleModelPermitDeferred(ctx, state, event, running) {
+		return
+	}
 	if event.Err != nil {
 		o.releaseTerminalAttemptClaim(ctx, state, running.Issue, event.CompletedAt)
 	}

--- a/internal/orchestrator/state.go
+++ b/internal/orchestrator/state.go
@@ -132,6 +132,7 @@ type Running struct {
 	Tokens                TokenTotals
 	CapacityScope         backendcapacity.Scope
 	CapacityProbe         bool
+	ModelPermitExempt     bool
 	StopDestination       string
 	StopPriorityOptions   []telemetry.StopRunPriorityOption
 	globalSlot            scheduler.Slot
@@ -211,6 +212,7 @@ type Retry struct {
 	CapacityScope backendcapacity.Scope
 	RetryMode     runpkg.RetryMode
 	ResumeState   store.AgentResumeState
+	MergePrecheck *runpkg.MergePrecheck
 }
 
 type InstantFailure struct {
@@ -409,6 +411,7 @@ func (s State) clone() State {
 	}
 	for id, retry := range s.Retry {
 		retry.Issue = cloneIssue(retry.Issue)
+		retry.MergePrecheck = cloneMergePrecheck(retry.MergePrecheck)
 		cloned.Retry[id] = retry
 	}
 	for id, failure := range s.InstantFailures {
@@ -436,6 +439,14 @@ func (s State) clone() State {
 	maps.Copy(cloned.planRework, s.planRework)
 
 	return cloned
+}
+
+func cloneMergePrecheck(precheck *runpkg.MergePrecheck) *runpkg.MergePrecheck {
+	if precheck == nil {
+		return nil
+	}
+	cloned := *precheck
+	return &cloned
 }
 
 func cloneAutoPromoteConfig(cfg AutoPromoteConfig) AutoPromoteConfig {

--- a/internal/runner/agent.go
+++ b/internal/runner/agent.go
@@ -583,6 +583,23 @@ func (r *Runner) prepareMergeFastPath(
 	}
 }
 
+func mergePrecheckFromWorkspace(precheck workspace.MergePrepareResult) MergePrecheck {
+	return MergePrecheck{
+		Status:      string(precheck.Status),
+		Message:     precheck.Message,
+		DiffStats:   diffStatsFromWorkspace(precheck.DiffStat),
+		HeadChanged: precheck.HeadChanged,
+	}
+}
+
+func cloneMergePrecheck(precheck *MergePrecheck) *MergePrecheck {
+	if precheck == nil {
+		return nil
+	}
+	cloned := *precheck
+	return &cloned
+}
+
 func mergeFastPathCheckedHead(issue connector.Issue) bool {
 	if issue.PullRequest == nil {
 		return false
@@ -1012,22 +1029,26 @@ func (r *Runner) Run(ctx context.Context, req RunRequest) (RunResult, error) {
 		}
 	}()
 
-	mergePrecheck := workspace.MergePrepareResult{}
+	mergePrecheck := MergePrecheck{}
 	mergeFallback := false
 	if mode == RunModeMerge {
-		precheckResult, precheck, handled, err := r.prepareMergeFastPath(ctx, req, info, workspaceIssue)
-		if err != nil {
-			return RunResult{}, err
-		}
-		mergePrecheck = precheck
-		if handled {
-			r.afterRun(runWorkspace, info, workspaceIssue)
-			afterRunPending = false
-			r.logWorkerEvent(req.Issue, "worker_after_run_finished",
-				telemetry.WorkAttemptIDKey, req.WorkAttemptID,
-				"workspace_path", info.Path,
-			)
-			return precheckResult, nil
+		if req.MergePrecheck != nil {
+			mergePrecheck = *req.MergePrecheck
+		} else {
+			precheckResult, precheck, handled, err := r.prepareMergeFastPath(ctx, req, info, workspaceIssue)
+			if err != nil {
+				return RunResult{}, err
+			}
+			mergePrecheck = mergePrecheckFromWorkspace(precheck)
+			if handled {
+				r.afterRun(runWorkspace, info, workspaceIssue)
+				afterRunPending = false
+				r.logWorkerEvent(req.Issue, "worker_after_run_finished",
+					telemetry.WorkAttemptIDKey, req.WorkAttemptID,
+					"workspace_path", info.Path,
+				)
+				return precheckResult, nil
+			}
 		}
 		mergeFallback = true
 	}
@@ -1048,7 +1069,7 @@ func (r *Runner) Run(ctx context.Context, req RunRequest) (RunResult, error) {
 		Attempt:              &attempt,
 		PlanOnly:             mode == RunModePlan,
 		MergeFallback:        mergeFallback,
-		MergePrecheckStatus:  string(mergePrecheck.Status),
+		MergePrecheckStatus:  mergePrecheck.Status,
 		MergePrecheckMessage: mergePrecheck.Message,
 		WorkspacePath:        info.Path,
 		Branch:               info.Branch,
@@ -1150,6 +1171,24 @@ func (r *Runner) Run(ctx context.Context, req RunRequest) (RunResult, error) {
 			)
 			resumeState = store.AgentResumeState{}
 			orphanRecoveryOutcome = store.OrphanRecoveryFresh
+		}
+	}
+	if req.AcquireModelPermit != nil {
+		if err := req.AcquireModelPermit(ctx); err != nil {
+			result := RunResult{
+				Output:        RunOutputMergeFallbackDeferred,
+				DiffStats:     mergePrecheck.DiffStats,
+				MergePrecheck: cloneMergePrecheck(&mergePrecheck),
+			}
+			if errors.Is(err, ErrModelPermitUnavailable) {
+				r.logWorkerEvent(req.Issue, "worker_merge_fallback_deferred",
+					telemetry.WorkAttemptIDKey, req.WorkAttemptID,
+					"workspace_path", info.Path,
+					"status", mergePrecheck.Status,
+				)
+				return result, err
+			}
+			return result, fmt.Errorf("acquire model permit: %w", err)
 		}
 	}
 	sessionID, sessionStarted, err := r.startSession(ctx, req, startedAt, runtimeIdentity, resumeState, orphanRecoveryOutcome, orphanRecoveryFallbackReason)

--- a/internal/runner/runner_test.go
+++ b/internal/runner/runner_test.go
@@ -2222,6 +2222,113 @@ func TestRunnerMergeModeConflictUsesFocusedPrompt(t *testing.T) {
 	}
 }
 
+func TestRunnerMergeFallbackModelPermit(t *testing.T) {
+	t.Parallel()
+
+	precheck := &MergePrecheck{
+		Status:  string(workspace.MergePrepareStatusConflict),
+		Message: "CONFLICT (content): Merge conflict in README.md",
+	}
+	tests := []struct {
+		name          string
+		savedPrecheck *MergePrecheck
+		permit        ModelPermitAcquirer
+		wantPermit    int
+		wantPrepare   bool
+		wantAgent     int
+		wantDeferred  bool
+	}{
+		{
+			name: "unavailable permit defers fresh precheck",
+			permit: func(context.Context) error {
+				return ErrModelPermitUnavailable
+			},
+			wantPermit:   1,
+			wantPrepare:  true,
+			wantDeferred: true,
+		},
+		{
+			name: "available permit starts fallback",
+			permit: func(context.Context) error {
+				return nil
+			},
+			wantPermit:  1,
+			wantPrepare: true,
+			wantAgent:   1,
+		},
+		{
+			name:          "prechecked retry starts fallback without repeating preparation",
+			savedPrecheck: precheck,
+			wantAgent:     1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			workspaceBackend := &fakeMergeWorkspaceBackend{
+				fakeWorkspaceBackend: fakeWorkspaceBackend{
+					info: workspace.Info{
+						Path:   t.TempDir(),
+						Key:    "digitaldrywood_detent_1659",
+						Branch: "detent/provider-window-admission",
+					},
+				},
+				prepareResult: workspace.MergePrepareResult{
+					Status:  workspace.MergePrepareStatusConflict,
+					Message: precheck.Message,
+				},
+			}
+			agentBackend := &fakeCodexClient{}
+			runner, err := NewRunner(Dependencies{
+				Workflow:     config.Workflow{Config: config.Config{}},
+				Workspace:    workspaceBackend,
+				AgentBackend: agentBackend,
+			})
+			if err != nil {
+				t.Fatalf("NewRunner() error = %v", err)
+			}
+			permitCalls := 0
+			var acquire ModelPermitAcquirer
+			if tt.permit != nil {
+				acquire = func(ctx context.Context) error {
+					permitCalls++
+					return tt.permit(ctx)
+				}
+			}
+
+			result, runErr := runner.Run(t.Context(), RunRequest{
+				Issue: connector.Issue{
+					ID:         "issue-1659",
+					Identifier: "digitaldrywood/detent#1659",
+					BranchName: "detent/provider-window-admission",
+				},
+				Mode:               RunModeMerge,
+				AcquireModelPermit: acquire,
+				MergePrecheck:      tt.savedPrecheck,
+			})
+			if got := errors.Is(runErr, ErrModelPermitUnavailable); got != tt.wantDeferred {
+				t.Fatalf("Run() error = %v, deferred=%t want %t", runErr, got, tt.wantDeferred)
+			}
+			if permitCalls != tt.wantPermit {
+				t.Fatalf("model permit calls = %d, want %d", permitCalls, tt.wantPermit)
+			}
+			if workspaceBackend.prepareCalled != tt.wantPrepare {
+				t.Fatalf("PrepareMerge() called = %t, want %t", workspaceBackend.prepareCalled, tt.wantPrepare)
+			}
+			if agentBackend.calls != tt.wantAgent {
+				t.Fatalf("AgentBackend.RunTurn() calls = %d, want %d", agentBackend.calls, tt.wantAgent)
+			}
+			if tt.wantDeferred {
+				if result.Output != RunOutputMergeFallbackDeferred || result.MergePrecheck == nil || result.MergePrecheck.Status != precheck.Status || result.MergePrecheck.Message != precheck.Message {
+					t.Fatalf("Run() result = %#v, want deferred result with preserved precheck", result)
+				}
+			}
+		})
+	}
+}
+
 func TestRunnerRunAddsGitMetadataExtraRootsForManagedWorkspace(t *testing.T) {
 	t.Parallel()
 

--- a/internal/runner/supervisor.go
+++ b/internal/runner/supervisor.go
@@ -207,6 +207,7 @@ func (s *Supervisor) Run(ctx context.Context, request RunRequest) (completion Co
 func cooperativeStopError(err error) bool {
 	return errors.Is(err, ErrOperatorStopped) ||
 		errors.Is(err, ErrMergeRevoked) ||
+		errors.Is(err, ErrModelPermitUnavailable) ||
 		errors.Is(err, ErrMergeWorkerStartupTimeout) ||
 		errors.Is(err, ErrMergeWorkerDurationExceeded) ||
 		errors.Is(err, ErrSessionDurationExceeded) ||

--- a/internal/runner/types.go
+++ b/internal/runner/types.go
@@ -34,6 +34,7 @@ const (
 
 	RunOutputMergeFastPathClean       = "merge_fast_path_clean"
 	RunOutputMergeFastPathCheckedHead = "merge_fast_path_checked_head"
+	RunOutputMergeFallbackDeferred    = "merge_fallback_deferred"
 )
 
 var (
@@ -44,6 +45,7 @@ var (
 	ErrMergeRevoked                = errors.New("merge eligibility revoked")
 	ErrMergeWorkerStartupTimeout   = errors.New("merge worker startup timed out")
 	ErrMergeWorkerDurationExceeded = errors.New("merge worker duration exceeded")
+	ErrModelPermitUnavailable      = errors.New("provider model permit unavailable")
 	ErrAgentTurnCleanup            = errors.New("agent turn cleanup failed")
 	ErrAgentResumeUnsupported      = errors.New("agent backend does not support resume verification")
 )
@@ -318,10 +320,21 @@ type RunRequest struct {
 	Admission           *AdmissionRequest
 	AgentTools          []AgentTool
 	AgentToolHandler    AgentToolHandler
+	AcquireModelPermit  ModelPermitAcquirer
+	MergePrecheck       *MergePrecheck
 	sessionBrake        *sessionBrakeController
 }
 
 type SessionProgressProbe func(context.Context) (string, error)
+
+type ModelPermitAcquirer func(context.Context) error
+
+type MergePrecheck struct {
+	Status      string
+	Message     string
+	DiffStats   DiffStats
+	HeadChanged bool
+}
 
 type RoutineRequest struct {
 	Name     string
@@ -393,6 +406,7 @@ type RunResult struct {
 	PullRequestUpdated      bool
 	PullRequestHeadPushed   bool
 	CITriggerLabelReapplied bool
+	MergePrecheck           *MergePrecheck
 }
 
 type UsageUpdateHandler func(UsageUpdate) error


### PR DESCRIPTION
## Summary

- split unscaled project capacity from provider-scaled model permits
- let merge fast paths finish without a model permit while gating conflict/dirty fallback turns
- preserve merge precheck results across capacity deferral and release lane, worker, project, and global slots

Fixes #1659

## UI Surface Contract

- [x] N/A; this PR has no UI changes.
- [x] This PR adds no persistent top-of-screen messaging.
- [x] This PR changes no primary operator screen.

## Test Plan

- [x] `go test ./internal/runner ./internal/orchestrator -count=1`
- [x] `go test ./internal/orchestrator -run ^'^$' -fuzz=. -fuzztime=30s`
- [x] `make check`