### PR TITLE
fix(staleness): classify provider pacing

### DIFF
--- a/config.reference.yaml
+++ b/config.reference.yaml
@@ -889,8 +889,8 @@
 #     no_merge_hours: 12
 #     # observability.staleness.repeated_decision_count | type: integer | default: 20 | required: No | validation: must be greater than 0
 #     repeated_decision_count: 20
-#     # observability.staleness.repeated_decision_benign_reasons | type: list<string> | default: ["already_running","blocked_by_dependency","github_rest_capacity_paused","github_rest_recovery","global_capacity_full","outside_active_window","reserved_for_higher_priority_project"] | required: No | validation: None
-#     repeated_decision_benign_reasons: ["already_running","blocked_by_dependency","github_rest_capacity_paused","github_rest_recovery","global_capacity_full","outside_active_window","reserved_for_higher_priority_project"]
+#     # observability.staleness.repeated_decision_benign_reasons | type: list<string> | default: ["already_running","blocked_by_dependency","github_rest_capacity_paused","github_rest_recovery","global_capacity_full","outside_active_window","provider_rate_window_backpressure","reserved_for_higher_priority_project"] | required: No | validation: None
+#     repeated_decision_benign_reasons: ["already_running","blocked_by_dependency","github_rest_capacity_paused","github_rest_recovery","global_capacity_full","outside_active_window","provider_rate_window_backpressure","reserved_for_higher_priority_project"]
 #     # observability.staleness.repeated_window_hours | type: integer | default: 24 | required: No | validation: must be greater than 0
 #     repeated_window_hours: 24
 #     # observability.staleness.webhook | type: object | default: see child fields | required: No | validation: None

--- a/docs/config.md
+++ b/docs/config.md
@@ -516,7 +516,7 @@ rendering and fails on drift.
 | `observability.staleness.lanes[].threshold_hours` | `integer` | `72` | No | must be greater than 0 |
 | `observability.staleness.no_completion_hours` | `integer` | `24` | No | must be greater than 0 |
 | `observability.staleness.no_merge_hours` | `integer` | `12` | No | must be greater than 0 |
-| `observability.staleness.repeated_decision_benign_reasons` | `list<string>` | `["already_running","blocked_by_dependency","github_rest_capacity_paused","github_rest_recovery","global_capacity_full","outside_active_window","reserved_for_higher_priority_project"]` | No | None |
+| `observability.staleness.repeated_decision_benign_reasons` | `list<string>` | `["already_running","blocked_by_dependency","github_rest_capacity_paused","github_rest_recovery","global_capacity_full","outside_active_window","provider_rate_window_backpressure","reserved_for_higher_priority_project"]` | No | None |
 | `observability.staleness.repeated_decision_count` | `integer` | `20` | No | must be greater than 0 |
 | `observability.staleness.repeated_window_hours` | `integer` | `24` | No | must be greater than 0 |
 | `observability.staleness.webhook` | `object` | `see child fields` | No | None |

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -2615,6 +2615,7 @@ func defaultStalenessRepeatedDecisionBenignReasons() []string {
 		"github_rest_recovery",
 		"global_capacity_full",
 		"outside_active_window",
+		"provider_rate_window_backpressure",
 		"reserved_for_higher_priority_project",
 	}
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1893,6 +1893,7 @@ func TestDefaultStalenessObservability(t *testing.T) {
 		"github_rest_recovery",
 		"global_capacity_full",
 		"outside_active_window",
+		"provider_rate_window_backpressure",
 		"reserved_for_higher_priority_project",
 	}
 	if got := cfg.Observability.Staleness.RepeatedDecisionBenignReasons; !slices.Equal(got, wantReasons) {
@@ -1907,6 +1908,45 @@ func TestDefaultStalenessObservability(t *testing.T) {
 	cfg.Observability.Staleness.Normalize()
 	if got, want := cfg.Observability.Staleness.RepeatedDecisionBenignReasons, []string{"planned_maintenance"}; !slices.Equal(got, want) {
 		t.Fatalf("normalized RepeatedDecisionBenignReasons = %#v, want %#v", got, want)
+	}
+}
+
+func TestStalenessRepeatedDecisionBenignReasonsOverride(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		yaml string
+		want []string
+	}{
+		{
+			name: "project override replaces defaults",
+			yaml: `---
+tracker:
+  kind: memory
+observability:
+  staleness:
+    repeated_decision_benign_reasons:
+      - planned_maintenance
+      - provider_rate_window_backpressure
+---
+Prompt
+`,
+			want: []string{"planned_maintenance", "provider_rate_window_backpressure"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			workflow, err := ParseWorkflow([]byte(tt.yaml))
+			if err != nil {
+				t.Fatalf("ParseWorkflow() error = %v", err)
+			}
+			if got := workflow.Config.Observability.Staleness.RepeatedDecisionBenignReasons; !slices.Equal(got, tt.want) {
+				t.Fatalf("RepeatedDecisionBenignReasons = %#v, want %#v", got, tt.want)
+			}
+		})
 	}
 }
 

--- a/internal/orchestrator/staleness.go
+++ b/internal/orchestrator/staleness.go
@@ -83,7 +83,8 @@ func (o *Orchestrator) stalenessDispatchableItems(candidates []connector.Issue, 
 	seen := make(map[string]struct{})
 	planner := o.dispatchPlanner()
 	for _, issue := range candidates {
-		if !planner.dispatchableIssueDecision(issue, state, false, now, "").dispatchable {
+		decision := planner.dispatchableIssueDecision(issue, state, false, now, "")
+		if !decision.dispatchable && decision.reason != dispatchSkipRateWindowBackpressure {
 			continue
 		}
 		key := workflowIssueIdentityKey(issue)

--- a/internal/orchestrator/staleness_test.go
+++ b/internal/orchestrator/staleness_test.go
@@ -2,6 +2,7 @@ package orchestrator
 
 import (
 	"context"
+	"fmt"
 	"slices"
 	"testing"
 	"time"
@@ -142,6 +143,84 @@ func TestStalenessDispatchableItemsUsesDispatchPlannerEligibility(t *testing.T) 
 	items := orch.stalenessDispatchableItems([]connector.Issue{unauthorized, authorized}, &state, now)
 	if len(items) != 1 || items[0].ID != authorized.ID {
 		t.Fatalf("dispatchable staleness items = %#v, want only authorized issue", items)
+	}
+}
+
+func TestRefreshStalenessWarningsProviderRateWindowPacing(t *testing.T) {
+	t.Parallel()
+	now := time.Date(2026, 8, 7, 15, 0, 0, 0, time.UTC)
+	enteredAt := now.Add(-13 * time.Hour)
+	candidate := dispatchTestIssue("issue-paced", "Todo")
+	candidate.StageUpdatedAt = &enteredAt
+
+	tests := []struct {
+		name       string
+		completion *time.Time
+		wantKind   string
+	}{
+		{
+			name:       "paced but progressing",
+			completion: timePointer(now.Add(-time.Hour)),
+		},
+		{
+			name:     "paced and stalled",
+			wantKind: staleness.KindProjectLiveness,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			cfg := normalizeConfig(Config{
+				BillingMode:         workflowconfig.BillingModeSubscription,
+				MaxConcurrentAgents: 10,
+				ActiveStates:        []string{"Todo"},
+				TerminalStates:      []string{"Done"},
+				Staleness: staleness.Config{
+					Enabled:                       true,
+					NoCompletionThreshold:         12 * time.Hour,
+					RepeatedDecisionCount:         20,
+					RepeatedDecisionWindow:        24 * time.Hour,
+					RepeatedDecisionBenignReasons: []string{dispatchSkipRateWindowBackpressure},
+				},
+			})
+			cfg.Project.ID = "detent"
+			orch := &Orchestrator{cfg: cfg}
+			state := newState(cfg)
+			state.RateLimits = providerRateLimits(50, 100)
+			for index := range 5 {
+				id := fmt.Sprintf("running-%d", index)
+				state.Running[id] = Running{Issue: dispatchTestIssue(id, "Todo")}
+			}
+			if tt.completion != nil {
+				state.Completed["completed"] = Completed{CompletedAt: *tt.completion}
+			}
+			for index := range 20 {
+				state.SchedulerDecisions = append(state.SchedulerDecisions, telemetry.SchedulerDecision{
+					IssueID:    candidate.ID,
+					Identifier: candidate.Identifier,
+					Result:     "skipped",
+					Reason:     dispatchSkipRateWindowBackpressure,
+					DecisionAt: now.Add(-time.Hour).Add(time.Duration(index) * 3 * time.Minute),
+				})
+			}
+
+			orch.refreshStalenessWarnings(t.Context(), &state, []connector.Issue{candidate}, now)
+			if tt.wantKind == "" {
+				if len(state.StalenessWarnings) != 0 {
+					t.Fatalf("staleness warnings = %#v, want none", state.StalenessWarnings)
+				}
+				return
+			}
+			if len(state.StalenessWarnings) != 1 {
+				t.Fatalf("staleness warnings = %#v, want one %s warning", state.StalenessWarnings, tt.wantKind)
+			}
+			for _, warning := range state.StalenessWarnings {
+				if warning.Warning.Kind != tt.wantKind {
+					t.Fatalf("warning kind = %q, want %q", warning.Warning.Kind, tt.wantKind)
+				}
+			}
+		})
 	}
 }
 

--- a/internal/staleness/staleness_test.go
+++ b/internal/staleness/staleness_test.go
@@ -119,6 +119,7 @@ func TestEvaluateRepeatedDecisions(t *testing.T) {
 			"github_rest_capacity_paused",
 			"github_rest_recovery",
 			"global_capacity_full",
+			"provider_rate_window_backpressure",
 			"reserved_for_higher_priority_project",
 		},
 		TerminalStates: []string{"Done", "Cancelled", "Canceled"},
@@ -141,6 +142,10 @@ func TestEvaluateRepeatedDecisions(t *testing.T) {
 		{
 			name:      "global capacity wait stays quiet",
 			decisions: repeatedDecisions(now.Add(-time.Hour), 20, 3*time.Minute, "global_capacity_full", "Todo"),
+		},
+		{
+			name:      "provider rate window pacing stays quiet",
+			decisions: repeatedDecisions(now.Add(-time.Hour), 20, 3*time.Minute, "provider_rate_window_backpressure", "Todo"),
 		},
 		{
 			name:      "REST capacity pause stays quiet",
@@ -212,6 +217,54 @@ func TestEvaluateRepeatedDecisions(t *testing.T) {
 			}
 			if tt.want == 1 && (got[0].Kind != KindRepeatedDecision || got[0].Count != 20) {
 				t.Fatalf("Evaluate()[0] = %#v, want repeated decision warning with count 20", got[0])
+			}
+		})
+	}
+}
+
+func TestEvaluateProviderRateWindowPacing(t *testing.T) {
+	t.Parallel()
+	now := time.Date(2026, 8, 7, 15, 0, 0, 0, time.UTC)
+	cfg := Config{
+		Enabled:                       true,
+		NoCompletionThreshold:         12 * time.Hour,
+		RepeatedDecisionCount:         20,
+		RepeatedDecisionWindow:        24 * time.Hour,
+		RepeatedDecisionBenignReasons: []string{"provider_rate_window_backpressure"},
+	}
+
+	tests := []struct {
+		name        string
+		completions []Completion
+		wantKind    string
+	}{
+		{
+			name:        "paced but progressing",
+			completions: []Completion{{At: now.Add(-time.Hour)}},
+		},
+		{
+			name:     "paced and stalled",
+			wantKind: KindProjectLiveness,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			warnings := Evaluate(cfg, Input{
+				ProjectID:    "detent",
+				Dispatchable: []Item{{ID: "issue-1", EnteredAt: now.Add(-13 * time.Hour)}},
+				Completions:  tt.completions,
+				Decisions:    repeatedDecisions(now.Add(-time.Hour), 20, 3*time.Minute, "provider_rate_window_backpressure", "Todo"),
+			}, now)
+			if tt.wantKind == "" {
+				if len(warnings) != 0 {
+					t.Fatalf("Evaluate() warnings = %#v, want none", warnings)
+				}
+				return
+			}
+			if len(warnings) != 1 || warnings[0].Kind != tt.wantKind {
+				t.Fatalf("Evaluate() warnings = %#v, want one %s warning", warnings, tt.wantKind)
 			}
 		})
 	}

--- a/internal/web/templates/health_data.go
+++ b/internal/web/templates/health_data.go
@@ -212,6 +212,18 @@ func healthRows(snapshot telemetry.Snapshot) []healthRow {
 	}
 	rows = append(rows, healthStrandedActiveRows(snapshot.StrandedActiveIssues)...)
 	if snapshot.RateLimits != nil {
+		for _, provider := range []struct {
+			id        string
+			component string
+			bucket    *telemetry.RateLimitBucket
+		}{
+			{id: "health-provider-primary", component: "Provider primary window", bucket: snapshot.RateLimits.Primary},
+			{id: "health-provider-secondary", component: "Provider secondary window", bucket: snapshot.RateLimits.Secondary},
+		} {
+			if provider.bucket != nil {
+				rows = append(rows, healthProviderBucketRow(provider.id, provider.component, provider.bucket))
+			}
+		}
 		if bucket := snapshot.RateLimits.GitHubREST; bucket != nil {
 			row := healthBucketRow("health-github-rest", "GitHub REST", bucket)
 			// Keep the exhaustion/backoff detail on unhealthy rows rather than
@@ -239,6 +251,32 @@ func healthRows(snapshot telemetry.Snapshot) []healthRow {
 		rows = append(rows, healthBackendOutageRow(outage, snapshot.GeneratedAt))
 	}
 	return rows
+}
+
+func healthProviderBucketRow(id string, component string, bucket *telemetry.RateLimitBucket) healthRow {
+	row := healthRow{
+		ID:        id,
+		Component: component,
+		Kind:      primitives.KindOK,
+		Status:    "Healthy",
+		Detail:    "Provider window has full dispatch capacity",
+		Resets:    "—",
+	}
+	if bucket.Limit > 0 {
+		remaining := max(int64(0), min(bucket.Remaining, bucket.Limit))
+		used := bucket.Limit - remaining
+		remainingPct := int(float64(remaining) / float64(bucket.Limit) * 100)
+		row.Quota = formatInt(used) + " / " + formatInt(bucket.Limit)
+		row.QuotaPct = 100 - remainingPct
+		if remaining < bucket.Limit {
+			row.Status = "Pacing"
+			row.Detail = formatCount(remainingPct) + "% remaining · dispatch capacity scales with the provider window"
+		}
+	}
+	if bucket.ResetAt != nil {
+		row.ResetAt = *bucket.ResetAt
+	}
+	return row
 }
 
 func healthAdmissionProposalRows(proposals []telemetry.AdmissionProposal, observedAt time.Time) []healthRow {

--- a/internal/web/templates/health_data_test.go
+++ b/internal/web/templates/health_data_test.go
@@ -353,6 +353,55 @@ func TestHealthRows(t *testing.T) {
 	}
 }
 
+func TestHealthRowsShowProviderRateWindowPacing(t *testing.T) {
+	t.Parallel()
+	resetAt := time.Date(2026, 8, 7, 17, 0, 0, 0, time.UTC)
+
+	tests := []struct {
+		name      string
+		limits    *telemetry.RateLimits
+		wantRows  int
+		wantNames []string
+	}{
+		{
+			name: "primary depressed",
+			limits: &telemetry.RateLimits{
+				Primary: &telemetry.RateLimitBucket{Remaining: 48, Limit: 100, ResetAt: &resetAt},
+			},
+			wantRows:  1,
+			wantNames: []string{"Provider primary window"},
+		},
+		{
+			name: "primary and secondary depressed",
+			limits: &telemetry.RateLimits{
+				Primary:   &telemetry.RateLimitBucket{Remaining: 80, Limit: 100},
+				Secondary: &telemetry.RateLimitBucket{Remaining: 30, Limit: 100},
+			},
+			wantRows:  2,
+			wantNames: []string{"Provider primary window", "Provider secondary window"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			rows := healthRows(telemetry.Snapshot{RateLimits: tt.limits})
+			providerRows := rows[:len(rows)-3]
+			if len(providerRows) != tt.wantRows {
+				t.Fatalf("provider rows = %#v, want %d", providerRows, tt.wantRows)
+			}
+			for index, row := range providerRows {
+				if row.Component != tt.wantNames[index] || row.Kind != primitives.KindOK || row.Status != "Pacing" {
+					t.Fatalf("provider row %d = %#v", index, row)
+				}
+				if row.Quota == "" || row.QuotaPct == 0 || row.QuotaWarn {
+					t.Fatalf("provider quota row %d = %#v", index, row)
+				}
+			}
+		})
+	}
+}
+
 func TestHealthRowsExhaustedByRemainingCount(t *testing.T) {
 	// Zero remaining with no explicit status must read Exhausted so the
 	// details row matches the exhaustion verdict.


### PR DESCRIPTION
## Summary

- classify provider_rate_window_backpressure as benign repeated-decision pacing by default
- keep provider primary and secondary windows visible as informational Health quota rows
- preserve stalled-project escalation through the independent project-liveness interval
- verify explicit project benign-reason overrides replace shipped defaults

Fixes #1661

## UI Surface Contract

- [x] The linked issue explicitly authorizes the Health-page pacing/quota row.
- [x] This PR does not add persistent top-of-screen messaging.
- [x] Current-head Browser Visual CI passed; TestHealthRowsShowProviderRateWindowPacing verifies the Health row data contract.

## Test Plan

- [x] go test ./internal/config ./internal/staleness ./internal/web/templates
- [x] make generate
- [x] make check (78.6% coverage; all checks passed)
- [x] Current-head CI (11 checks)