### PR TITLE
feat(cli): add issue explanation client

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -62,6 +62,15 @@ Stable JSON error codes:
 | <a id="doctor-failed"></a>`doctor_failed` | `https://detent.dev/errors/doctor_failed` | 1 | `ErrDoctorFailed`. |
 | <a id="shutdown-forced"></a>`shutdown_forced` | `https://detent.dev/errors/shutdown_forced` | 1 | `ErrShutdownForced`. |
 | <a id="shutdown-timeout"></a>`shutdown_timeout` | `https://detent.dev/errors/shutdown_timeout` | 1 | `ErrShutdownTimeout`. |
+| <a id="dashboard-unreachable"></a>`dashboard_unreachable` | `https://detent.dev/errors/dashboard_unreachable` | 1 | The configured Detent service is stopped or unreachable. |
+| <a id="dashboard-timeout"></a>`dashboard_timeout` | `https://detent.dev/errors/dashboard_timeout` | 1 | The bounded dashboard API request timed out. |
+| <a id="dashboard-unauthorized"></a>`dashboard_unauthorized` | `https://detent.dev/errors/dashboard_unauthorized` | 2 | The dashboard API rejected the supplied credential. |
+| <a id="dashboard-forbidden"></a>`dashboard_forbidden` | `https://detent.dev/errors/dashboard_forbidden` | 2 | The credential does not allow the requested read. |
+| <a id="ambiguous-reference"></a>`ambiguous_reference` | `https://detent.dev/errors/ambiguous_reference` | 3 | The selected project contains more than one matching identity. |
+| <a id="issue-not-found"></a>`issue_not_found` | `https://detent.dev/errors/issue_not_found` | 4 | The selected project has no matching issue. |
+| <a id="unsupported-model-version"></a>`unsupported_model_version` | `https://detent.dev/errors/unsupported_model_version` | 1 | The CLI and service do not share an issue explanation schema version. |
+| <a id="runtime-unavailable"></a>`runtime_unavailable` | `https://detent.dev/errors/runtime_unavailable` | 1 | The running service cannot currently produce the issue explanation read model. |
+| <a id="dashboard-request-failed"></a>`dashboard_request_failed` | `https://detent.dev/errors/dashboard_request_failed` | 1 | The dashboard API returned another unsuccessful response. |
 
 
 ## Logging
@@ -108,4 +117,24 @@ Structured command objects:
 | `detent work-item add api --title "..." --body "..."` | `{"id":"wi-...","identifier":"wi-...","url":"/projects/api/kanban"}` |
 | `detent config path` | `{"path":"/path/global.yaml","rule":"--config"}` |
 | `detent auth token enable` / `detent auth token rotate` | `{"url":"https://detent.example.com/?token=..."}` |
+| `detent issue '#1643' --explain --project detent` | The exact versioned issue explanation DTO returned by the running service, with no wrapper. |
 | `detent doctor` | `{"checks":[{"name":"Config resolution","status":"OK","detail":"...","hint":"..."}],"summary":{"ok":8,"warn":0,"fail":0},"result":"PASS"}` |
+
+### Issue explanation reads
+
+`detent issue <ref> --explain --project <project-id>` reads the versioned issue
+explanation model from the running Detent service. `--project` is always
+required, including for `#number`, so issue numbers are never treated as
+globally unique. Issue IDs, canonical identifiers, and full tracker URLs are
+accepted as `<ref>`.
+
+The command resolves the configured host and port, maps wildcard bind hosts to
+loopback for dialing, and uses `DETENT_API_TOKEN` before the resolved
+`api_token`. If either source supplies a credential, the client sends it; a
+rejected credential is reported as `dashboard_unauthorized` and is not retried
+without authentication. Requests have a ten-second client timeout and honor
+caller cancellation.
+
+JSON mode writes exactly one issue explanation DTO to stdout. Pretty mode is a
+human-readable projection of the same DTO. Diagnostics and JSON problem objects
+remain on stderr.

--- a/internal/cli/capacity.go
+++ b/internal/cli/capacity.go
@@ -67,14 +67,14 @@ func runCapacityClear(
 	scope string,
 	opts options,
 ) (capacityClearResult, error) {
-	boot, err := resolveCapacityClearBoot(ctx, configPath, host, port, portSet, opts)
+	boot, err := resolveDashboardBoot(ctx, configPath, host, port, portSet, opts)
 	if err != nil {
 		return capacityClearResult{}, err
 	}
 	form := url.Values{}
 	form.Set("project_id", strings.TrimSpace(projectID))
 	form.Set("scope", strings.TrimSpace(scope))
-	request, err := http.NewRequestWithContext(ctx, http.MethodPost, "http://"+capacityClearServerAddr(boot)+"/api/v1/capacity/clear", strings.NewReader(form.Encode()))
+	request, err := http.NewRequestWithContext(ctx, http.MethodPost, "http://"+dashboardServerAddr(boot)+"/api/v1/capacity/clear", strings.NewReader(form.Encode()))
 	if err != nil {
 		return capacityClearResult{}, fmt.Errorf("create capacity clear request: %w", err)
 	}
@@ -105,7 +105,7 @@ func runCapacityClear(
 	return result, nil
 }
 
-func capacityClearServerAddr(boot BootConfig) string {
+func dashboardServerAddr(boot BootConfig) string {
 	host := unbracketIPv6Host(strings.TrimSpace(boot.Host))
 	switch host {
 	case "", "0.0.0.0", "::":
@@ -115,7 +115,7 @@ func capacityClearServerAddr(boot BootConfig) string {
 	return serverAddr(boot)
 }
 
-func resolveCapacityClearBoot(
+func resolveDashboardBoot(
 	ctx context.Context,
 	configPath string,
 	host string,

--- a/internal/cli/capacity_test.go
+++ b/internal/cli/capacity_test.go
@@ -58,7 +58,7 @@ func TestRunCapacityClear(t *testing.T) {
 	}
 }
 
-func TestCapacityClearServerAddrNormalizesWildcardHosts(t *testing.T) {
+func TestDashboardServerAddrNormalizesWildcardHosts(t *testing.T) {
 	t.Parallel()
 
 	port := 4101
@@ -77,8 +77,8 @@ func TestCapacityClearServerAddrNormalizesWildcardHosts(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			if got := capacityClearServerAddr(BootConfig{Host: tt.host, Port: &port}); got != tt.want {
-				t.Fatalf("capacityClearServerAddr() = %q, want %q", got, tt.want)
+			if got := dashboardServerAddr(BootConfig{Host: tt.host, Port: &port}); got != tt.want {
+				t.Fatalf("dashboardServerAddr() = %q, want %q", got, tt.want)
 			}
 		})
 	}

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -384,7 +384,10 @@ JSON errors:
   Optional fields: suggested_fix, did_you_mean, docs_url.
   Stable codes: general, validation, unknown_command, unknown_flag, github_auth,
   config_exists, project_exists, project_not_found, doctor_failed, shutdown_forced,
-  shutdown_timeout.
+  shutdown_timeout, dashboard_unreachable, dashboard_timeout,
+  dashboard_unauthorized, dashboard_forbidden, ambiguous_reference,
+  issue_not_found, unsupported_model_version, runtime_unavailable,
+  dashboard_request_failed.
 
 Exit codes:
   0  success
@@ -460,6 +463,7 @@ detent --format json config path`),
 		newKeyCommand(&configPath, opts),
 		newConfigCommand(&configPath, opts),
 		newCapacityCommand(&configPath, &host, &port, opts),
+		newIssueCommand(&configPath, &host, &port, opts),
 		newOnboardingCommand(&configPath, opts),
 		newPromoteCommand(&configPath, opts),
 		newRemoveProjectCommand(&configPath, opts),

--- a/internal/cli/dashboard_client.go
+++ b/internal/cli/dashboard_client.go
@@ -1,0 +1,204 @@
+package cli
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/digitaldrywood/detent/internal/explain"
+)
+
+const (
+	dashboardReadTimeout     = 10 * time.Second
+	dashboardResponseBodyMax = 1 << 20
+)
+
+type dashboardHTTPClient interface {
+	Do(*http.Request) (*http.Response, error)
+}
+
+type DashboardReadClient struct {
+	baseURL    *url.URL
+	credential string
+	http       dashboardHTTPClient
+	timeout    time.Duration
+}
+
+type dashboardAPIProblem struct {
+	Error struct {
+		Code    string `json:"code"`
+		Message string `json:"message"`
+	} `json:"error"`
+}
+
+type DashboardResponseError struct {
+	StatusCode int
+	Code       string
+	Message    string
+}
+
+func (e *DashboardResponseError) Error() string {
+	if e == nil {
+		return ""
+	}
+	if strings.TrimSpace(e.Message) != "" {
+		return e.Message
+	}
+	return fmt.Sprintf("dashboard API returned HTTP %d", e.StatusCode)
+}
+
+type DashboardTransportError struct {
+	Timeout bool
+	Err     error
+}
+
+func (e *DashboardTransportError) Error() string {
+	if e == nil {
+		return ""
+	}
+	if e.Timeout {
+		return "dashboard API request timed out"
+	}
+	return "dashboard API is unreachable"
+}
+
+func (e *DashboardTransportError) Unwrap() error {
+	if e == nil {
+		return nil
+	}
+	return e.Err
+}
+
+func newDashboardReadClient(
+	ctx context.Context,
+	configPath string,
+	host string,
+	port int,
+	portSet bool,
+	opts options,
+) (*DashboardReadClient, error) {
+	boot, err := resolveDashboardBoot(ctx, configPath, host, port, portSet, opts)
+	if err != nil {
+		return nil, err
+	}
+	baseURL, err := url.Parse("http://" + dashboardServerAddr(boot))
+	if err != nil {
+		return nil, fmt.Errorf("resolve dashboard API URL: %w", err)
+	}
+	credential := strings.TrimSpace(opts.lookupEnv("DETENT_API_TOKEN"))
+	if credential == "" {
+		credential = strings.TrimSpace(boot.Global.APIToken)
+	}
+	if opts.httpDo == nil {
+		return nil, errors.New("dashboard API HTTP client is not configured")
+	}
+	return &DashboardReadClient{
+		baseURL:    baseURL,
+		credential: credential,
+		http:       dashboardHTTPClientFunc(opts.httpDo),
+		timeout:    dashboardReadTimeout,
+	}, nil
+}
+
+func (c *DashboardReadClient) ExplainIssue(ctx context.Context, projectID string, reference string) (explain.IssueExplanation, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if err := ctx.Err(); err != nil {
+		return explain.IssueExplanation{}, err
+	}
+	projectID = strings.TrimSpace(projectID)
+	reference = strings.TrimSpace(reference)
+	if projectID == "" || reference == "" {
+		return explain.IssueExplanation{}, ValidationError("--project and issue reference are required")
+	}
+	if c == nil || c.baseURL == nil || c.http == nil {
+		return explain.IssueExplanation{}, errors.New("dashboard API client is not configured")
+	}
+
+	requestURL := *c.baseURL
+	requestURL.Path = "/api/v1/projects/" + projectID + "/issues/explanation"
+	requestURL.RawPath = "/api/v1/projects/" + url.PathEscape(projectID) + "/issues/explanation"
+	query := requestURL.Query()
+	query.Set("reference", reference)
+	query.Set("schema", strconv.Itoa(explain.SchemaVersion))
+	requestURL.RawQuery = query.Encode()
+
+	timeout := c.timeout
+	if timeout <= 0 {
+		timeout = dashboardReadTimeout
+	}
+	requestContext, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+	request, err := http.NewRequestWithContext(requestContext, http.MethodGet, requestURL.String(), nil)
+	if err != nil {
+		return explain.IssueExplanation{}, fmt.Errorf("create dashboard API request: %w", err)
+	}
+	request.Header.Set("Accept", "application/json")
+	if c.credential != "" {
+		request.Header.Set("Authorization", "Bearer "+c.credential)
+	}
+
+	response, err := c.http.Do(request)
+	if err != nil {
+		if ctx.Err() != nil {
+			return explain.IssueExplanation{}, ctx.Err()
+		}
+		return explain.IssueExplanation{}, &DashboardTransportError{
+			Timeout: errors.Is(requestContext.Err(), context.DeadlineExceeded),
+			Err:     err,
+		}
+	}
+	defer response.Body.Close()
+	if response.StatusCode < http.StatusOK || response.StatusCode >= http.StatusMultipleChoices {
+		return explain.IssueExplanation{}, decodeDashboardResponseError(response)
+	}
+
+	var result explain.IssueExplanation
+	decoder := json.NewDecoder(io.LimitReader(response.Body, dashboardResponseBodyMax))
+	if err := decoder.Decode(&result); err != nil {
+		return explain.IssueExplanation{}, fmt.Errorf("decode dashboard API response: %w", err)
+	}
+	var trailing any
+	if err := decoder.Decode(&trailing); !errors.Is(err, io.EOF) {
+		if err == nil {
+			err = errors.New("multiple JSON values")
+		}
+		return explain.IssueExplanation{}, fmt.Errorf("decode dashboard API response: %w", err)
+	}
+	if result.Schema != explain.SchemaVersion {
+		return explain.IssueExplanation{}, &DashboardResponseError{
+			StatusCode: response.StatusCode,
+			Code:       "version_conflict",
+			Message:    fmt.Sprintf("dashboard returned unsupported issue explanation schema %d", result.Schema),
+		}
+	}
+	return result, nil
+}
+
+func decodeDashboardResponseError(response *http.Response) error {
+	problem := dashboardAPIProblem{}
+	err := json.NewDecoder(io.LimitReader(response.Body, dashboardResponseBodyMax)).Decode(&problem)
+	code := strings.TrimSpace(problem.Error.Code)
+	message := strings.TrimSpace(problem.Error.Message)
+	if err != nil || code == "" {
+		code = "http_error"
+	}
+	if message == "" {
+		message = fmt.Sprintf("dashboard API returned HTTP %d", response.StatusCode)
+	}
+	return &DashboardResponseError{StatusCode: response.StatusCode, Code: code, Message: message}
+}
+
+type dashboardHTTPClientFunc func(*http.Request) (*http.Response, error)
+
+func (f dashboardHTTPClientFunc) Do(request *http.Request) (*http.Response, error) {
+	return f(request)
+}

--- a/internal/cli/dashboard_client_test.go
+++ b/internal/cli/dashboard_client_test.go
@@ -1,0 +1,399 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"reflect"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	globalconfig "github.com/digitaldrywood/detent/internal/config/global"
+	"github.com/digitaldrywood/detent/internal/explain"
+)
+
+func TestDashboardReadClientExplainIssueReferences(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		reference string
+	}{
+		{name: "issue ID", reference: "I_kwDOSskuwc8AAAABL5igFw"},
+		{name: "canonical identifier", reference: "digitaldrywood/detent#1643"},
+		{name: "URL with reserved query and fragment", reference: "https://github.com/digitaldrywood/detent/issues/1643?notification=thread#event/one"},
+		{name: "hash number", reference: "#1643"},
+		{name: "reserved query characters", reference: "issue?/path#fragment&next=value"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			want := dashboardExplanationFixture(false)
+			server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+				if request.Method != http.MethodGet {
+					t.Errorf("method = %q, want GET", request.Method)
+				}
+				if request.URL.Path != "/api/v1/projects/detent/issues/explanation" {
+					t.Errorf("path = %q", request.URL.Path)
+				}
+				if got := request.URL.Query().Get("reference"); got != tt.reference {
+					t.Errorf("reference = %q, want %q", got, tt.reference)
+				}
+				if got := request.URL.Query().Get("schema"); got != strconv.Itoa(explain.SchemaVersion) {
+					t.Errorf("schema = %q", got)
+				}
+				if got := request.Header.Get("Accept"); got != "application/json" {
+					t.Errorf("Accept = %q", got)
+				}
+				writer.Header().Set("Content-Type", "application/json")
+				if err := json.NewEncoder(writer).Encode(want); err != nil {
+					t.Errorf("Encode() error = %v", err)
+				}
+			}))
+			t.Cleanup(server.Close)
+
+			client := dashboardClientForServer(t, server, "")
+			got, err := client.ExplainIssue(t.Context(), " detent ", " "+tt.reference+" ")
+			if err != nil {
+				t.Fatalf("ExplainIssue() error = %v", err)
+			}
+			if !reflect.DeepEqual(got, want) {
+				t.Fatalf("result = %#v, want %#v", got, want)
+			}
+		})
+	}
+}
+
+func TestDashboardReadClientCredentialPrecedence(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		environment string
+		configured  string
+		wantHeader  string
+	}{
+		{name: "environment wins", environment: "environment-token", configured: "config-token", wantHeader: "Bearer environment-token"},
+		{name: "config fallback", configured: "config-token", wantHeader: "Bearer config-token"},
+		{name: "peer trust without credential", wantHeader: ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+				if got := request.Header.Get("Authorization"); got != tt.wantHeader {
+					t.Errorf("Authorization = %q, want %q", got, tt.wantHeader)
+				}
+				_ = json.NewEncoder(writer).Encode(dashboardExplanationFixture(false))
+			}))
+			t.Cleanup(server.Close)
+			parsed, err := url.Parse(server.URL)
+			if err != nil {
+				t.Fatalf("Parse() error = %v", err)
+			}
+			port, err := strconv.Atoi(parsed.Port())
+			if err != nil {
+				t.Fatalf("Atoi() error = %v", err)
+			}
+			opts := dashboardClientOptions(server.Client().Do, tt.environment, tt.configured)
+			client, err := newDashboardReadClient(t.Context(), "/config/global.yaml", "0.0.0.0", port, true, opts)
+			if err != nil {
+				t.Fatalf("newDashboardReadClient() error = %v", err)
+			}
+			if _, err := client.ExplainIssue(t.Context(), "detent", "#1643"); err != nil {
+				t.Fatalf("ExplainIssue() error = %v", err)
+			}
+		})
+	}
+}
+
+func TestDashboardReadClientSuppliedBadCredentialIsNotMasked(t *testing.T) {
+	t.Parallel()
+
+	const badToken = "supplied-bad-token"
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		if request.Header.Get("Authorization") == "Bearer "+badToken {
+			writer.WriteHeader(http.StatusUnauthorized)
+			_, _ = io.WriteString(writer, `{"error":{"code":"unauthorized","message":"Valid API token is required"}}`)
+			return
+		}
+		_ = json.NewEncoder(writer).Encode(dashboardExplanationFixture(false))
+	}))
+	t.Cleanup(server.Close)
+	parsed, err := url.Parse(server.URL)
+	if err != nil {
+		t.Fatalf("Parse() error = %v", err)
+	}
+	port, err := strconv.Atoi(parsed.Port())
+	if err != nil {
+		t.Fatalf("Atoi() error = %v", err)
+	}
+	opts := dashboardClientOptions(server.Client().Do, badToken, "valid-config-token")
+	client, err := newDashboardReadClient(t.Context(), "/config/global.yaml", parsed.Hostname(), port, true, opts)
+	if err != nil {
+		t.Fatalf("newDashboardReadClient() error = %v", err)
+	}
+	_, err = client.ExplainIssue(t.Context(), "detent", "#1643")
+	problem := ProblemForError(classifyDashboardReadError(err))
+	if problem.Code != errorCodeDashboardUnauthorized || problem.ExitCode != ExitAuth {
+		t.Fatalf("problem = %#v", problem)
+	}
+	if strings.Contains(problem.Detail, badToken) || strings.Contains(problem.SuggestedFix, badToken) {
+		t.Fatalf("problem leaked credential: %#v", problem)
+	}
+}
+
+func TestDashboardReadClientTransportAndCancellation(t *testing.T) {
+	t.Parallel()
+
+	t.Run("unreachable", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
+		client := dashboardClientForServer(t, server, "")
+		server.Close()
+		_, err := client.ExplainIssue(t.Context(), "detent", "#1643")
+		var transport *DashboardTransportError
+		if !errors.As(err, &transport) || transport.Timeout {
+			t.Fatalf("error = %#v, want unreachable transport error", err)
+		}
+		problem := ProblemForError(classifyDashboardReadError(err))
+		if problem.Code != errorCodeDashboardUnreachable || problem.ExitCode != ExitGeneral {
+			t.Fatalf("problem = %#v", problem)
+		}
+	})
+
+	t.Run("timeout", func(t *testing.T) {
+		client := &DashboardReadClient{
+			baseURL: &url.URL{Scheme: "http", Host: "127.0.0.1:1"},
+			http: dashboardHTTPClientFunc(func(request *http.Request) (*http.Response, error) {
+				<-request.Context().Done()
+				return nil, request.Context().Err()
+			}),
+			timeout: time.Millisecond,
+		}
+		_, err := client.ExplainIssue(t.Context(), "detent", "#1643")
+		var transport *DashboardTransportError
+		if !errors.As(err, &transport) || !transport.Timeout {
+			t.Fatalf("error = %#v, want timeout transport error", err)
+		}
+		problem := ProblemForError(classifyDashboardReadError(err))
+		if problem.Code != errorCodeDashboardTimeout || problem.ExitCode != ExitGeneral {
+			t.Fatalf("problem = %#v", problem)
+		}
+	})
+
+	t.Run("caller cancellation", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(t.Context())
+		cancel()
+		client := &DashboardReadClient{}
+		_, err := client.ExplainIssue(ctx, "detent", "#1643")
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("error = %v, want context.Canceled", err)
+		}
+	})
+}
+
+func TestDashboardReadClientRejectsUnsupportedSuccessfulModel(t *testing.T) {
+	t.Parallel()
+
+	result := dashboardExplanationFixture(false)
+	result.Schema = explain.SchemaVersion + 1
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		_ = json.NewEncoder(writer).Encode(result)
+	}))
+	t.Cleanup(server.Close)
+	client := dashboardClientForServer(t, server, "")
+	_, err := client.ExplainIssue(t.Context(), "detent", "#1643")
+	problem := ProblemForError(classifyDashboardReadError(err))
+	if problem.Code != errorCodeUnsupportedModelVersion || problem.ExitCode != ExitGeneral {
+		t.Fatalf("problem = %#v", problem)
+	}
+}
+
+func TestClassifyDashboardReadProblems(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		err        error
+		wantCode   string
+		wantExit   int
+		wantDetail string
+	}{
+		{name: "unauthorized", err: &DashboardResponseError{StatusCode: http.StatusUnauthorized, Code: "unauthorized", Message: "bad credential"}, wantCode: errorCodeDashboardUnauthorized, wantExit: ExitAuth, wantDetail: "bad credential"},
+		{name: "forbidden", err: &DashboardResponseError{StatusCode: http.StatusForbidden, Code: "forbidden", Message: "scope denied"}, wantCode: errorCodeDashboardForbidden, wantExit: ExitAuth, wantDetail: "scope denied"},
+		{name: "ambiguous", err: &DashboardResponseError{StatusCode: http.StatusConflict, Code: "ambiguous_reference", Message: "ambiguous"}, wantCode: errorCodeAmbiguousReference, wantExit: ExitValidation, wantDetail: "ambiguous"},
+		{name: "not found", err: &DashboardResponseError{StatusCode: http.StatusNotFound, Code: "issue_not_found", Message: "missing"}, wantCode: errorCodeIssueNotFound, wantExit: ExitNotFoundOrConfig, wantDetail: "missing"},
+		{name: "unsupported model", err: &DashboardResponseError{StatusCode: http.StatusConflict, Code: "version_conflict", Message: "unsupported"}, wantCode: errorCodeUnsupportedModelVersion, wantExit: ExitGeneral, wantDetail: "unsupported"},
+		{name: "runtime unavailable", err: &DashboardResponseError{StatusCode: http.StatusServiceUnavailable, Code: "runtime_unavailable", Message: "not ready"}, wantCode: errorCodeRuntimeUnavailable, wantExit: ExitGeneral, wantDetail: "not ready"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			problem := ProblemForError(classifyDashboardReadError(tt.err))
+			if problem.Code != tt.wantCode || problem.ExitCode != tt.wantExit || problem.Detail != tt.wantDetail {
+				t.Fatalf("problem = %#v", problem)
+			}
+		})
+	}
+}
+
+func dashboardClientForServer(t *testing.T, server *httptest.Server, credential string) *DashboardReadClient {
+	t.Helper()
+	parsed, err := url.Parse(server.URL)
+	if err != nil {
+		t.Fatalf("Parse() error = %v", err)
+	}
+	return &DashboardReadClient{baseURL: parsed, credential: credential, http: server.Client(), timeout: time.Second}
+}
+
+func dashboardClientOptions(do func(*http.Request) (*http.Response, error), environmentToken string, configToken string) options {
+	opts := defaultOptions()
+	opts.resolvePath = func(string) (globalconfig.PathResolution, error) {
+		return globalconfig.PathResolution{Path: "/config/global.yaml", Rule: globalconfig.PathRuleFlag}, nil
+	}
+	opts.read = func(string) (globalconfig.Config, error) {
+		return globalconfig.Config{APIToken: configToken}, nil
+	}
+	opts.lookupEnv = func(key string) string {
+		if key == "DETENT_API_TOKEN" {
+			return environmentToken
+		}
+		return ""
+	}
+	opts.httpDo = do
+	return opts
+}
+
+func dashboardExplanationFixture(degraded bool) explain.IssueExplanation {
+	return explain.IssueExplanation{
+		Schema:       explain.SchemaVersion,
+		Found:        true,
+		ObservedAt:   time.Date(2026, 8, 7, 20, 0, 0, 0, time.UTC),
+		Identity:     explain.Identity{ProjectID: "detent", IssueID: "issue-1643", Identifier: "digitaldrywood/detent#1643", Number: 1643, Title: "Add issue explain command"},
+		CurrentLane:  explain.Lane{Name: "In Progress", Freshness: explain.SourceLive, Degraded: degraded},
+		Eligibility:  explain.Eligibility{State: explain.EligibilityEligible, Refusals: []explain.EligibilityDecision{}, Source: explain.SourceAvailable},
+		Sessions:     explain.Sessions{Source: explain.SourceAvailable},
+		RequiredGate: explain.Gate{State: explain.GatePending, SourceState: explain.SourceAvailable, Failures: []string{}, Running: []string{}},
+		Sources:      []explain.SourceStatus{{Name: "snapshot", State: explain.SourceLive}},
+		Evidence:     []explain.EvidenceReference{},
+	}
+}
+
+func TestIssueCommandOutputAndScoping(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		args       []string
+		stdoutTTY  bool
+		wantError  string
+		wantPretty []string
+	}{
+		{name: "project required", args: []string{"#1643", "--explain"}, wantError: "--project is required"},
+		{name: "operation required", args: []string{"#1643", "--project", "detent"}, wantError: "issue operation is required"},
+		{name: "pretty projection", args: []string{"#1643", "--explain", "--project", "detent"}, stdoutTTY: true, wantPretty: []string{"Issue: digitaldrywood/detent#1643", "Lane: In Progress", "Lane degraded: true", "Source snapshot: unavailable (not_published)"}},
+		{name: "JSON DTO", args: []string{"#1643", "--explain", "--project", "detent"}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			want := dashboardExplanationFixture(true)
+			want.Sources[0] = explain.SourceStatus{Name: "snapshot", State: explain.SourceUnavailable, Code: "not_published"}
+			server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+				_ = json.NewEncoder(writer).Encode(want)
+			}))
+			t.Cleanup(server.Close)
+			parsed, err := url.Parse(server.URL)
+			if err != nil {
+				t.Fatalf("Parse() error = %v", err)
+			}
+			port, err := strconv.Atoi(parsed.Port())
+			if err != nil {
+				t.Fatalf("Atoi() error = %v", err)
+			}
+			opts := dashboardClientOptions(server.Client().Do, "", "")
+			opts.read = func(string) (globalconfig.Config, error) {
+				return globalconfig.Config{Port: &port}, nil
+			}
+			configPath := "/config/global.yaml"
+			host := parsed.Hostname()
+			cmd := newIssueCommand(&configPath, &host, &port, opts)
+			cmd.SilenceUsage = true
+			cmd.SetContext(withCommandOutputOptions(t.Context(), commandOutputOptions{
+				lookupEnv: opts.lookupEnv,
+				stdoutTTY: func() bool { return tt.stdoutTTY },
+			}))
+			var stdout bytes.Buffer
+			cmd.SetOut(&stdout)
+			cmd.SetErr(&bytes.Buffer{})
+			cmd.SetArgs(tt.args)
+			err = cmd.Execute()
+			if tt.wantError != "" {
+				if err == nil || !strings.Contains(err.Error(), tt.wantError) {
+					t.Fatalf("Execute() error = %v, want %q", err, tt.wantError)
+				}
+				if stdout.Len() != 0 {
+					t.Fatalf("stdout = %q, want empty", stdout.String())
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("Execute() error = %v", err)
+			}
+			for _, expected := range tt.wantPretty {
+				if !strings.Contains(stdout.String(), expected) {
+					t.Fatalf("stdout missing %q:\n%s", expected, stdout.String())
+				}
+			}
+			if tt.stdoutTTY {
+				return
+			}
+			var got explain.IssueExplanation
+			if err := json.Unmarshal(stdout.Bytes(), &got); err != nil {
+				t.Fatalf("Unmarshal() error = %v; stdout = %s", err, stdout.String())
+			}
+			if !reflect.DeepEqual(got, want) {
+				t.Fatalf("JSON result = %#v, want exact DTO %#v", got, want)
+			}
+			var object map[string]json.RawMessage
+			if err := json.Unmarshal(stdout.Bytes(), &object); err != nil {
+				t.Fatalf("Unmarshal(map) error = %v", err)
+			}
+			if _, wrapped := object["data"]; wrapped {
+				t.Fatalf("JSON output has wrapper: %s", stdout.String())
+			}
+		})
+	}
+}
+
+func TestIssueCommandHelpCoversScopingAndJSON(t *testing.T) {
+	t.Parallel()
+
+	cmd := NewRootCommand(t.Context(), WithStdoutTTY(func() bool { return true }))
+	var stdout bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&bytes.Buffer{})
+	cmd.SetArgs([]string{"issue", "--help"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+	for _, want := range []string{"detent issue '#1643' --explain --project detent", "--format json", "--project string", "running Detent service"} {
+		if !strings.Contains(stdout.String(), want) {
+			t.Fatalf("help missing %q:\n%s", want, stdout.String())
+		}
+	}
+}

--- a/internal/cli/dashboard_client_test.go
+++ b/internal/cli/dashboard_client_test.go
@@ -234,6 +234,7 @@ func TestClassifyDashboardReadProblems(t *testing.T) {
 		{name: "forbidden", err: &DashboardResponseError{StatusCode: http.StatusForbidden, Code: "forbidden", Message: "scope denied"}, wantCode: errorCodeDashboardForbidden, wantExit: ExitAuth, wantDetail: "scope denied"},
 		{name: "ambiguous", err: &DashboardResponseError{StatusCode: http.StatusConflict, Code: "ambiguous_reference", Message: "ambiguous"}, wantCode: errorCodeAmbiguousReference, wantExit: ExitValidation, wantDetail: "ambiguous"},
 		{name: "not found", err: &DashboardResponseError{StatusCode: http.StatusNotFound, Code: "issue_not_found", Message: "missing"}, wantCode: errorCodeIssueNotFound, wantExit: ExitNotFoundOrConfig, wantDetail: "missing"},
+		{name: "route unsupported", err: &DashboardResponseError{StatusCode: http.StatusNotFound, Code: "project_not_found", Message: "Project not found"}, wantCode: errorCodeUnsupportedModelVersion, wantExit: ExitGeneral, wantDetail: "running service does not support the issue explanation API"},
 		{name: "unsupported model", err: &DashboardResponseError{StatusCode: http.StatusConflict, Code: "version_conflict", Message: "unsupported"}, wantCode: errorCodeUnsupportedModelVersion, wantExit: ExitGeneral, wantDetail: "unsupported"},
 		{name: "runtime unavailable", err: &DashboardResponseError{StatusCode: http.StatusServiceUnavailable, Code: "runtime_unavailable", Message: "not ready"}, wantCode: errorCodeRuntimeUnavailable, wantExit: ExitGeneral, wantDetail: "not ready"},
 	}

--- a/internal/cli/errors.go
+++ b/internal/cli/errors.go
@@ -10,17 +10,26 @@ import (
 )
 
 const (
-	errorCodeGeneral         = "general"
-	errorCodeValidation      = "validation"
-	errorCodeUnknownCommand  = "unknown_command"
-	errorCodeUnknownFlag     = "unknown_flag"
-	errorCodeGitHubAuth      = "github_auth"
-	errorCodeConfigExists    = "config_exists"
-	errorCodeProjectExists   = "project_exists"
-	errorCodeProjectNotFound = "project_not_found"
-	errorCodeDoctorFailed    = "doctor_failed"
-	errorCodeShutdownForced  = "shutdown_forced"
-	errorCodeShutdownTimeout = "shutdown_timeout"
+	errorCodeGeneral                 = "general"
+	errorCodeValidation              = "validation"
+	errorCodeUnknownCommand          = "unknown_command"
+	errorCodeUnknownFlag             = "unknown_flag"
+	errorCodeGitHubAuth              = "github_auth"
+	errorCodeConfigExists            = "config_exists"
+	errorCodeProjectExists           = "project_exists"
+	errorCodeProjectNotFound         = "project_not_found"
+	errorCodeDoctorFailed            = "doctor_failed"
+	errorCodeShutdownForced          = "shutdown_forced"
+	errorCodeShutdownTimeout         = "shutdown_timeout"
+	errorCodeDashboardUnreachable    = "dashboard_unreachable"
+	errorCodeDashboardTimeout        = "dashboard_timeout"
+	errorCodeDashboardUnauthorized   = "dashboard_unauthorized"
+	errorCodeDashboardForbidden      = "dashboard_forbidden"
+	errorCodeAmbiguousReference      = "ambiguous_reference"
+	errorCodeIssueNotFound           = "issue_not_found"
+	errorCodeUnsupportedModelVersion = "unsupported_model_version"
+	errorCodeRuntimeUnavailable      = "runtime_unavailable"
+	errorCodeDashboardRequestFailed  = "dashboard_request_failed"
 )
 
 type ClassifiedError struct {

--- a/internal/cli/exitcode.go
+++ b/internal/cli/exitcode.go
@@ -23,8 +23,17 @@ const (
 )
 
 var (
-	ErrGitHubAuth = errors.New("github auth failed")
-	ErrValidation = errors.New("input validation failed")
+	ErrGitHubAuth                  = errors.New("github auth failed")
+	ErrValidation                  = errors.New("input validation failed")
+	ErrDashboardUnreachable        = errors.New("dashboard unreachable")
+	ErrDashboardTimeout            = errors.New("dashboard request timed out")
+	ErrDashboardUnauthorized       = errors.New("dashboard authentication failed")
+	ErrDashboardForbidden          = errors.New("dashboard access forbidden")
+	ErrDashboardAmbiguousReference = errors.New("ambiguous issue reference")
+	ErrDashboardIssueNotFound      = errors.New("dashboard issue not found")
+	ErrDashboardUnsupportedModel   = errors.New("unsupported dashboard model version")
+	ErrDashboardRuntimeUnavailable = errors.New("dashboard runtime unavailable")
+	ErrDashboardRequestFailed      = errors.New("dashboard request failed")
 )
 
 type ErrorClass struct {
@@ -44,6 +53,69 @@ var (
 )
 
 var errorClassifiers = []errorClass{
+	{
+		ErrorClass: ErrorClass{Slug: errorCodeDashboardUnreachable, ExitCode: ExitGeneral},
+		Title:      "Dashboard unreachable",
+		match: func(err error) bool {
+			return errors.Is(err, ErrDashboardUnreachable)
+		},
+	},
+	{
+		ErrorClass: ErrorClass{Slug: errorCodeDashboardTimeout, ExitCode: ExitGeneral},
+		Title:      "Dashboard request timed out",
+		match: func(err error) bool {
+			return errors.Is(err, ErrDashboardTimeout)
+		},
+	},
+	{
+		ErrorClass: ErrorClass{Slug: errorCodeDashboardUnauthorized, ExitCode: ExitAuth},
+		Title:      "Dashboard authentication failed",
+		match: func(err error) bool {
+			return errors.Is(err, ErrDashboardUnauthorized)
+		},
+	},
+	{
+		ErrorClass: ErrorClass{Slug: errorCodeDashboardForbidden, ExitCode: ExitAuth},
+		Title:      "Dashboard access forbidden",
+		match: func(err error) bool {
+			return errors.Is(err, ErrDashboardForbidden)
+		},
+	},
+	{
+		ErrorClass: ErrorClass{Slug: errorCodeAmbiguousReference, ExitCode: ExitValidation},
+		Title:      "Issue reference is ambiguous",
+		match: func(err error) bool {
+			return errors.Is(err, ErrDashboardAmbiguousReference)
+		},
+	},
+	{
+		ErrorClass: ErrorClass{Slug: errorCodeIssueNotFound, ExitCode: ExitNotFoundOrConfig},
+		Title:      "Issue not found",
+		match: func(err error) bool {
+			return errors.Is(err, ErrDashboardIssueNotFound)
+		},
+	},
+	{
+		ErrorClass: ErrorClass{Slug: errorCodeUnsupportedModelVersion, ExitCode: ExitGeneral},
+		Title:      "Issue explanation schema is unsupported",
+		match: func(err error) bool {
+			return errors.Is(err, ErrDashboardUnsupportedModel)
+		},
+	},
+	{
+		ErrorClass: ErrorClass{Slug: errorCodeRuntimeUnavailable, ExitCode: ExitGeneral},
+		Title:      "Issue explanation runtime unavailable",
+		match: func(err error) bool {
+			return errors.Is(err, ErrDashboardRuntimeUnavailable)
+		},
+	},
+	{
+		ErrorClass: ErrorClass{Slug: errorCodeDashboardRequestFailed, ExitCode: ExitGeneral},
+		Title:      "Dashboard request failed",
+		match: func(err error) bool {
+			return errors.Is(err, ErrDashboardRequestFailed)
+		},
+	},
 	{
 		ErrorClass: ErrorClass{Slug: errorCodeUnknownCommand, ExitCode: ExitValidation},
 		Title:      "Unknown command",

--- a/internal/cli/issue.go
+++ b/internal/cli/issue.go
@@ -1,0 +1,131 @@
+package cli
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/digitaldrywood/detent/internal/explain"
+)
+
+func newIssueCommand(configPath *string, host *string, port *int, opts options) *cobra.Command {
+	var explainIssue bool
+	var projectID string
+	cmd := &cobra.Command{
+		Use:   "issue <ref>",
+		Short: "Inspect an issue through the running Detent service",
+		Long:  "Inspect an issue through the running Detent service. Issue explanation reads are bounded HTTP requests and never open the runtime database or contact the tracker directly.",
+		Example: strings.TrimSpace(`detent issue '#1643' --explain --project detent
+detent issue digitaldrywood/detent#1643 --explain --project detent --format json
+detent issue https://github.com/digitaldrywood/detent/issues/1643 --explain --project detent | jq '.current_lane'`),
+		Args: ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if !explainIssue {
+				return NewValidationError("issue operation is required", "Use --explain to read the issue explanation model.", nil)
+			}
+			if strings.TrimSpace(projectID) == "" {
+				return NewValidationError("--project is required", "Pass the Detent project ID that owns the issue, for example --project detent.", nil)
+			}
+			out, err := OutputForCommand(cmd)
+			if err != nil {
+				return err
+			}
+			client, err := newDashboardReadClient(cmd.Context(), derefString(configPath), derefString(host), derefInt(port, -1), flagChanged(cmd, "port"), opts)
+			if err != nil {
+				return err
+			}
+			result, err := client.ExplainIssue(cmd.Context(), projectID, args[0])
+			if err != nil {
+				return classifyDashboardReadError(err)
+			}
+			return out.Write(func(writer io.Writer) error {
+				return writeIssueExplanationPretty(writer, result)
+			}, result)
+		},
+	}
+	cmd.Flags().BoolVar(&explainIssue, "explain", false, "show the versioned issue explanation read model")
+	cmd.Flags().StringVar(&projectID, "project", "", "Detent project ID that owns the issue (required)")
+	return cmd
+}
+
+func classifyDashboardReadError(err error) error {
+	if err == nil || errors.Is(err, context.Canceled) {
+		return err
+	}
+	if errors.Is(err, context.DeadlineExceeded) {
+		return NewClassifiedError(ErrDashboardTimeout, errorCodeDashboardTimeout, "dashboard API request timed out", "Confirm Detent is responsive, or retry the command.", nil)
+	}
+	var transport *DashboardTransportError
+	if errors.As(err, &transport) {
+		if transport.Timeout {
+			return NewClassifiedError(ErrDashboardTimeout, errorCodeDashboardTimeout, "dashboard API request timed out", "Confirm Detent is responsive, or retry the command.", nil)
+		}
+		return NewClassifiedError(ErrDashboardUnreachable, errorCodeDashboardUnreachable, "dashboard service is stopped or unreachable", "Start Detent or verify the configured host and port.", nil)
+	}
+	var response *DashboardResponseError
+	if !errors.As(err, &response) {
+		return err
+	}
+	detail := strings.TrimSpace(response.Message)
+	switch {
+	case response.StatusCode == http.StatusUnauthorized:
+		return NewClassifiedError(ErrDashboardUnauthorized, errorCodeDashboardUnauthorized, detail, "Set DETENT_API_TOKEN to a valid read credential or update api_token in the resolved config.", nil)
+	case response.StatusCode == http.StatusForbidden:
+		return NewClassifiedError(ErrDashboardForbidden, errorCodeDashboardForbidden, detail, "Use a credential with read scope for the requested project.", nil)
+	case response.Code == "ambiguous_reference":
+		return NewClassifiedError(ErrDashboardAmbiguousReference, errorCodeAmbiguousReference, detail, "Use an issue ID, canonical identifier, or full issue URL within the selected project.", nil)
+	case response.StatusCode == http.StatusNotFound || response.Code == "issue_not_found":
+		return NewClassifiedError(ErrDashboardIssueNotFound, errorCodeIssueNotFound, detail, "Verify --project and the issue reference.", nil)
+	case response.Code == "version_conflict":
+		return NewClassifiedError(ErrDashboardUnsupportedModel, errorCodeUnsupportedModelVersion, detail, "Upgrade Detent so the CLI and running service support the same read-model schema.", nil)
+	case response.Code == "bad_request":
+		return NewClassifiedError(ErrValidation, errorCodeValidation, detail, "Verify --project and the issue reference.", nil)
+	case response.Code == "runtime_unavailable":
+		return NewClassifiedError(ErrDashboardRuntimeUnavailable, errorCodeRuntimeUnavailable, detail, "Retry after the running Detent service publishes its issue explanation runtime.", nil)
+	default:
+		return NewClassifiedError(ErrDashboardRequestFailed, errorCodeDashboardRequestFailed, detail, "Inspect the running Detent service and retry the command.", nil)
+	}
+}
+
+func writeIssueExplanationPretty(writer io.Writer, result explain.IssueExplanation) error {
+	identity := result.Identity.Identifier
+	if identity == "" {
+		identity = result.Identity.IssueID
+	}
+	if identity == "" && result.Identity.Number > 0 {
+		identity = fmt.Sprintf("#%d", result.Identity.Number)
+	}
+	lines := []string{
+		"Issue: " + identity,
+		"Project: " + result.Identity.ProjectID,
+		"Lane: " + result.CurrentLane.Name,
+		"Lane freshness: " + string(result.CurrentLane.Freshness),
+		fmt.Sprintf("Lane degraded: %t", result.CurrentLane.Degraded),
+		"Eligibility: " + string(result.Eligibility.State),
+		"Required gate: " + string(result.RequiredGate.State),
+		"Observed: " + result.ObservedAt.Format(time.RFC3339),
+	}
+	if result.Identity.Title != "" {
+		lines = append(lines, "")
+		copy(lines[2:], lines[1:])
+		lines[1] = "Title: " + result.Identity.Title
+	}
+	if result.Attempt != nil {
+		lines = append(lines, fmt.Sprintf("Attempt: %d (%s)", result.Attempt.ID, result.Attempt.Status))
+	}
+	for _, source := range result.Sources {
+		value := string(source.State)
+		if source.Code != "" {
+			value += " (" + source.Code + ")"
+		}
+		lines = append(lines, "Source "+source.Name+": "+value)
+	}
+	_, err := fmt.Fprintln(writer, strings.Join(lines, "\n"))
+	return err
+}

--- a/internal/cli/issue.go
+++ b/internal/cli/issue.go
@@ -80,8 +80,10 @@ func classifyDashboardReadError(err error) error {
 		return NewClassifiedError(ErrDashboardForbidden, errorCodeDashboardForbidden, detail, "Use a credential with read scope for the requested project.", nil)
 	case response.Code == "ambiguous_reference":
 		return NewClassifiedError(ErrDashboardAmbiguousReference, errorCodeAmbiguousReference, detail, "Use an issue ID, canonical identifier, or full issue URL within the selected project.", nil)
-	case response.StatusCode == http.StatusNotFound || response.Code == "issue_not_found":
+	case response.Code == "issue_not_found":
 		return NewClassifiedError(ErrDashboardIssueNotFound, errorCodeIssueNotFound, detail, "Verify --project and the issue reference.", nil)
+	case response.StatusCode == http.StatusNotFound:
+		return NewClassifiedError(ErrDashboardUnsupportedModel, errorCodeUnsupportedModelVersion, "running service does not support the issue explanation API", "Upgrade or restart Detent so the running service provides the issue explanation endpoint.", nil)
 	case response.Code == "version_conflict":
 		return NewClassifiedError(ErrDashboardUnsupportedModel, errorCodeUnsupportedModelVersion, detail, "Upgrade Detent so the CLI and running service support the same read-model schema.", nil)
 	case response.Code == "bad_request":


### PR DESCRIPTION
## Summary

- add a shared bounded dashboard read client that resolves the daemon address and credential precedence
- add `detent issue <ref> --explain --project <id>` with exact DTO JSON and a pretty projection
- document stable dashboard problem codes and cover reference encoding, auth, timeout, cancellation, degraded output, and help

Fixes #1643

## UI Surface Contract

- [x] N/A, or the linked issue explicitly authorizes any high-impact UI surface, layout, density, first-viewport, or responsive visibility tradeoff.
- [x] Persistent top-of-screen messaging is explicitly authorized by the issue, or this PR does not add it.
- [x] Visual changes to primary operator screens include screenshot or browser verification below.

No visual UI changes.

## Test Plan

- [x] `go test ./internal/cli -count=1`
- [x] `go test ./cmd/detent -count=1`
- [x] `make check`