### PR TITLE
feat(cli): add bounded log filter

### DIFF
--- a/cmd/detent/main_test.go
+++ b/cmd/detent/main_test.go
@@ -72,6 +72,7 @@ func TestRootCommandHelpCatalogJSON(t *testing.T) {
 		"add-project": false,
 		"config path": false,
 		"doctor":      false,
+		"logs":        false,
 		"start":       false,
 		"status":      false,
 		"update":      false,

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -78,6 +78,26 @@ Detent logs with `log/slog`.
 - The terminal dashboard writes JSON logs to `detent.log` next to the runtime
   database. `log_max_size_bytes` defaults to 52428800 and `log_max_backups`
   defaults to 5.
+- `detent logs` reads that resolved dashboard log and its numbered backups.
+  Headless runs stream JSON or development text logs to stdout or stderr
+  instead of a file, so the command reports the dashboard log as unavailable
+  when no file exists. It never switches to an arbitrary path or parses text
+  logs.
+- Log filters use the canonical fields `project_id`, `issue_id`,
+  `issue_identifier`, `work_attempt_id`, `detent_session_id`, and
+  `provider_session_id`. All supplied filters combine conjunctively. `--since`
+  and `--until` are inclusive RFC3339 boundaries compared in UTC, and `--level`
+  means the selected level or higher.
+- With no overrides, the command examines at most the most recent 8 MiB, keeps
+  at most the latest 1,000 matching records in chronological order, and uses a
+  24-hour UTC window ending at invocation time. The JSON summary reports byte
+  or record truncation explicitly.
+- `--output json` writes `{ "records": [...], "summary": {...} }`.
+  `--output jsonl` writes one original JSON log record per line to stdout.
+  Malformed and partial records are skipped and reported as bounded JSON
+  diagnostics on stderr without echoing their contents. JSONL reports
+  truncation with an `output_truncated` diagnostic on stderr; the full counts
+  are available in the JSON summary.
 - Per-request GitHub REST request/response debug logs are off by default. Set
   `tracker.github_rest_debug_logging: true` only while diagnosing REST traffic.
 

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -441,6 +441,7 @@ detent --format json config path`),
 	cmd.AddCommand(
 		newStartCommand(&configPath, &host, &port, opts),
 		newStatusCommand(&configPath, &host, &port, opts),
+		newLogsCommand(&configPath, opts),
 		newAuthCommand(&configPath, &host, &port, opts),
 		newDoctorCommand(&configPath, &env, &logLevel, &host, &port, opts),
 		newFixCommand(&configPath, opts),

--- a/internal/cli/logs.go
+++ b/internal/cli/logs.go
@@ -1,0 +1,663 @@
+package cli
+
+import (
+	"bufio"
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	globalconfig "github.com/digitaldrywood/detent/internal/config/global"
+	"github.com/digitaldrywood/detent/internal/telemetry"
+)
+
+const (
+	defaultLogsWindow      = 24 * time.Hour
+	defaultLogsLimit       = 1000
+	defaultLogsMaxBytes    = int64(8 << 20)
+	logsLineBufferSize     = 64 << 10
+	logsMaxLineBytes       = 1 << 20
+	logsMaxDiagnostics     = 100
+	logsOutputJSON         = "json"
+	logsOutputJSONL        = "jsonl"
+	logsTruncationBytes    = "bytes"
+	logsTruncationRecords  = "records"
+	logsDiagnosticSeverity = "warning"
+)
+
+type logsFilter struct {
+	ProjectID       string
+	IssueID         string
+	IssueIdentifier string
+	WorkAttemptID   int64
+	DetentSessionID int64
+	ProviderSession string
+	Since           time.Time
+	Until           time.Time
+	MinimumLevel    slog.Level
+	MinimumLevelSet bool
+	Limit           int
+	MaxBytes        int64
+}
+
+type logsResult struct {
+	Records []json.RawMessage `json:"records"`
+	Summary logsSummary       `json:"summary"`
+}
+
+type logsSummary struct {
+	MatchedRecords    int      `json:"matched_records"`
+	ReturnedRecords   int      `json:"returned_records"`
+	ScannedRecords    int      `json:"scanned_records"`
+	ScannedBytes      int64    `json:"scanned_bytes"`
+	MalformedRecords  int      `json:"malformed_records"`
+	SuppressedDetails int      `json:"suppressed_diagnostics,omitempty"`
+	Since             string   `json:"since"`
+	Until             string   `json:"until"`
+	Truncated         bool     `json:"truncated"`
+	TruncationReasons []string `json:"truncation_reasons,omitempty"`
+}
+
+type logsDiagnostic struct {
+	Severity string   `json:"severity"`
+	Code     string   `json:"code"`
+	Source   string   `json:"source,omitempty"`
+	Record   int      `json:"record,omitempty"`
+	Count    int      `json:"count,omitempty"`
+	Reasons  []string `json:"reasons,omitempty"`
+}
+
+type logsSnapshotFile struct {
+	name   string
+	file   *os.File
+	info   os.FileInfo
+	active bool
+}
+
+type logsSegment struct {
+	source *logsSnapshotFile
+	offset int64
+	size   int64
+}
+
+type logsCollector struct {
+	filter      logsFilter
+	result      logsResult
+	diagnostics []logsDiagnostic
+}
+
+type logsCommandOptions struct {
+	ProjectID       string
+	IssueID         string
+	IssueIdentifier string
+	WorkAttemptID   int64
+	DetentSessionID int64
+	ProviderSession string
+	Since           string
+	Until           string
+	Level           string
+	Limit           int
+	MaxBytes        int64
+	Output          string
+}
+
+func newLogsCommand(configPath *string, opts options) *cobra.Command {
+	values := logsCommandOptions{
+		Limit:    defaultLogsLimit,
+		MaxBytes: defaultLogsMaxBytes,
+		Output:   logsOutputJSON,
+	}
+	cmd := &cobra.Command{
+		Use:   "logs",
+		Short: "Filter bounded runtime logs",
+		Long: "Filter the active Detent dashboard JSON log and its numbered backups. " +
+			"Filters combine conjunctively and results remain in chronological order.",
+		Example: `detent logs --project-id detent --issue-identifier digitaldrywood/detent#1646 --output jsonl`,
+		Args:    NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			filter, err := parseLogsFilter(values, time.Now())
+			if err != nil {
+				return err
+			}
+			path, maxBackups, err := resolveLogsSource(derefString(configPath), opts)
+			if err != nil {
+				return err
+			}
+			result, diagnostics, err := filterLogs(path, maxBackups, filter)
+			if err != nil {
+				return err
+			}
+			if err := writeLogsDiagnostics(cmd.ErrOrStderr(), diagnostics, result.Summary); err != nil {
+				return fmt.Errorf("write log diagnostics: %w", err)
+			}
+			return writeLogsOutput(cmd.OutOrStdout(), values.Output, result)
+		},
+	}
+	flags := cmd.Flags()
+	flags.StringVar(&values.ProjectID, "project-id", "", "match project_id exactly")
+	flags.StringVar(&values.IssueID, "issue-id", "", "match issue_id exactly")
+	flags.StringVar(&values.IssueIdentifier, "issue-identifier", "", "match issue_identifier exactly")
+	flags.Int64Var(&values.WorkAttemptID, "work-attempt-id", 0, "match work_attempt_id exactly")
+	flags.Int64Var(&values.DetentSessionID, "detent-session-id", 0, "match detent_session_id exactly")
+	flags.StringVar(&values.ProviderSession, "provider-session-id", "", "match provider_session_id exactly")
+	flags.StringVar(&values.Since, "since", "", "inclusive RFC3339 start time (default: 24 hours ago)")
+	flags.StringVar(&values.Until, "until", "", "inclusive RFC3339 end time (default: now)")
+	flags.StringVar(&values.Level, "level", "", "minimum level: debug, info, warn, or error")
+	flags.IntVar(&values.Limit, "limit", defaultLogsLimit, "maximum matching records")
+	flags.Int64Var(&values.MaxBytes, "max-bytes", defaultLogsMaxBytes, "maximum source bytes scanned")
+	flags.StringVar(&values.Output, "output", logsOutputJSON, "output shape: json or jsonl")
+	return cmd
+}
+
+func parseLogsFilter(values logsCommandOptions, now time.Time) (logsFilter, error) {
+	if values.Limit <= 0 {
+		return logsFilter{}, ValidationError("--limit must be greater than 0")
+	}
+	if values.MaxBytes <= 0 {
+		return logsFilter{}, ValidationError("--max-bytes must be greater than 0")
+	}
+	values.Output = strings.ToLower(strings.TrimSpace(values.Output))
+	if values.Output != logsOutputJSON && values.Output != logsOutputJSONL {
+		return logsFilter{}, ValidationError("--output must be json or jsonl")
+	}
+	now = now.UTC()
+	since, err := parseLogsTime(values.Since, now.Add(-defaultLogsWindow), "--since")
+	if err != nil {
+		return logsFilter{}, err
+	}
+	until, err := parseLogsTime(values.Until, now, "--until")
+	if err != nil {
+		return logsFilter{}, err
+	}
+	if since.After(until) {
+		return logsFilter{}, ValidationError("--since must be before or equal to --until")
+	}
+	minimumLevel, minimumLevelSet, err := parseLogsLevel(values.Level)
+	if err != nil {
+		return logsFilter{}, err
+	}
+	if values.WorkAttemptID < 0 {
+		return logsFilter{}, ValidationError("--work-attempt-id must be greater than or equal to 0")
+	}
+	if values.DetentSessionID < 0 {
+		return logsFilter{}, ValidationError("--detent-session-id must be greater than or equal to 0")
+	}
+	return logsFilter{
+		ProjectID:       strings.TrimSpace(values.ProjectID),
+		IssueID:         strings.TrimSpace(values.IssueID),
+		IssueIdentifier: strings.TrimSpace(values.IssueIdentifier),
+		WorkAttemptID:   values.WorkAttemptID,
+		DetentSessionID: values.DetentSessionID,
+		ProviderSession: strings.TrimSpace(values.ProviderSession),
+		Since:           since,
+		Until:           until,
+		MinimumLevel:    minimumLevel,
+		MinimumLevelSet: minimumLevelSet,
+		Limit:           values.Limit,
+		MaxBytes:        values.MaxBytes,
+	}, nil
+}
+
+func parseLogsTime(value string, fallback time.Time, flag string) (time.Time, error) {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return fallback.UTC(), nil
+	}
+	parsed, err := time.Parse(time.RFC3339Nano, value)
+	if err != nil {
+		return time.Time{}, ValidationError(flag + " must be an RFC3339 timestamp")
+	}
+	return parsed.UTC(), nil
+}
+
+func parseLogsLevel(value string) (slog.Level, bool, error) {
+	switch strings.ToLower(strings.TrimSpace(value)) {
+	case "":
+		return 0, false, nil
+	case "debug":
+		return slog.LevelDebug, true, nil
+	case "info":
+		return slog.LevelInfo, true, nil
+	case "warn", "warning":
+		return slog.LevelWarn, true, nil
+	case "error":
+		return slog.LevelError, true, nil
+	default:
+		return 0, false, ValidationError("--level must be debug, info, warn, or error")
+	}
+}
+
+func resolveLogsSource(configPath string, opts options) (string, int, error) {
+	resolution, err := resolveConfigPathResolution(configPath, opts)
+	if err != nil {
+		return "", 0, err
+	}
+	read := opts.readDoctor
+	if read == nil {
+		read = func(path string) (globalconfig.Config, error) {
+			return globalconfig.Read(path, globalconfig.WithMissingWorkflowFiles())
+		}
+	}
+	cfg, err := read(resolution.Path)
+	if err != nil {
+		if !missingGlobalConfig(err) {
+			return "", 0, err
+		}
+		cfg, err = globalconfig.DefaultAt(resolution.Path, globalconfig.WithMissingWorkflowFiles())
+		if err != nil {
+			return "", 0, err
+		}
+	}
+	maxBackups := defaultRuntimeLogMaxBackups
+	if cfg.LogMaxBackups != nil {
+		maxBackups = max(0, *cfg.LogMaxBackups)
+	}
+	path, backups := logsSourceFromBoot(BootConfig{
+		Global: cfg,
+		Runtime: RuntimeSettings{
+			LogMaxBackups: RuntimeIntValue{Value: maxBackups},
+		},
+	})
+	return path, backups, nil
+}
+
+func logsSourceFromBoot(cfg BootConfig) (string, int) {
+	return runtimeLogPath(cfg), max(0, cfg.Runtime.LogMaxBackups.Value)
+}
+
+func filterLogs(path string, maxBackups int, filter logsFilter) (logsResult, []logsDiagnostic, error) {
+	files, err := openLogsSnapshot(path, maxBackups)
+	if err != nil {
+		return logsResult{}, nil, err
+	}
+	if len(files) == 0 {
+		return logsResult{}, nil, NewClassifiedError(
+			os.ErrNotExist,
+			errorCodeGeneral,
+			"runtime log file is unavailable",
+			"File logs are written only in terminal-dashboard mode; headless and text modes write to stdout or stderr.",
+			nil,
+		)
+	}
+	result, diagnostics := filterLogsSnapshot(files, filter)
+	if err := closeLogsSnapshot(files); err != nil {
+		return logsResult{}, diagnostics, fmt.Errorf("close runtime log snapshot: %w", err)
+	}
+	return result, diagnostics, nil
+}
+
+func filterLogsSnapshot(files []*logsSnapshotFile, filter logsFilter) (logsResult, []logsDiagnostic) {
+	segments, scannedBytes, byteTruncated := boundedLogsSegments(files, filter.MaxBytes)
+	collector := logsCollector{
+		filter: filter,
+		result: logsResult{
+			Records: make([]json.RawMessage, 0),
+			Summary: logsSummary{
+				ScannedBytes: scannedBytes,
+				Since:        filter.Since.Format(time.RFC3339Nano),
+				Until:        filter.Until.Format(time.RFC3339Nano),
+			},
+		},
+	}
+	if byteTruncated {
+		collector.truncate(logsTruncationBytes)
+	}
+	for _, segment := range segments {
+		collector.scan(segment)
+	}
+	collector.result.Summary.ReturnedRecords = len(collector.result.Records)
+	collector.result.Summary.SuppressedDetails = max(0, collector.result.Summary.MalformedRecords-len(collector.diagnostics))
+	return collector.result, collector.diagnostics
+}
+
+func openLogsSnapshot(path string, maxBackups int) ([]*logsSnapshotFile, error) {
+	paths := make([]string, 0, maxBackups+1)
+	for index := maxBackups; index >= 1; index-- {
+		paths = append(paths, rotatedLogPath(path, index))
+	}
+	paths = append(paths, path)
+	files := make([]*logsSnapshotFile, 0, len(paths))
+	for _, candidate := range paths {
+		file, err := os.Open(candidate)
+		if errors.Is(err, os.ErrNotExist) {
+			continue
+		}
+		if err != nil {
+			return nil, errors.Join(fmt.Errorf("open runtime log: %w", err), closeLogsSnapshot(files))
+		}
+		info, err := file.Stat()
+		if err != nil {
+			return nil, errors.Join(fmt.Errorf("inspect runtime log: %w", err), file.Close(), closeLogsSnapshot(files))
+		}
+		if slices.ContainsFunc(files, func(existing *logsSnapshotFile) bool {
+			return os.SameFile(existing.info, info)
+		}) {
+			if err := file.Close(); err != nil {
+				return nil, errors.Join(fmt.Errorf("close duplicate runtime log: %w", err), closeLogsSnapshot(files))
+			}
+			continue
+		}
+		files = append(files, &logsSnapshotFile{
+			name:   filepath.Base(candidate),
+			file:   file,
+			info:   info,
+			active: candidate == path,
+		})
+	}
+	return files, nil
+}
+
+func closeLogsSnapshot(files []*logsSnapshotFile) error {
+	var result error
+	for _, source := range files {
+		if source != nil && source.file != nil {
+			result = errors.Join(result, source.file.Close())
+		}
+	}
+	return result
+}
+
+func boundedLogsSegments(files []*logsSnapshotFile, maxBytes int64) ([]logsSegment, int64, bool) {
+	remaining := maxBytes
+	segments := make([]logsSegment, 0, len(files))
+	var scanned int64
+	truncated := false
+	for index := len(files) - 1; index >= 0; index-- {
+		size := max(int64(0), files[index].info.Size())
+		if remaining <= 0 {
+			if size > 0 {
+				truncated = true
+			}
+			continue
+		}
+		take := min(size, remaining)
+		if take < size {
+			truncated = true
+		}
+		segments = append(segments, logsSegment{source: files[index], offset: size - take, size: take})
+		remaining -= take
+		scanned += take
+	}
+	slices.Reverse(segments)
+	return segments, scanned, truncated
+}
+
+func (c *logsCollector) scan(segment logsSegment) {
+	if segment.size <= 0 {
+		return
+	}
+	reader := bufio.NewReaderSize(io.NewSectionReader(segment.source.file, segment.offset, segment.size), logsLineBufferSize)
+	if logsSegmentStartsMidLine(segment) {
+		_, _, _, err := readLogsLine(reader)
+		if err != nil {
+			return
+		}
+	}
+	for record := 1; ; record++ {
+		raw, complete, tooLong, err := readLogsLine(reader)
+		if len(raw) == 0 && errors.Is(err, io.EOF) {
+			return
+		}
+		if tooLong {
+			c.malformed(segment.source.name, record, "line_too_long")
+		} else if len(bytes.TrimSpace(raw)) > 0 {
+			if !complete && segment.source.active {
+				if json.Valid(bytes.TrimSpace(raw)) {
+					c.scanRecord(segment.source.name, record, bytes.TrimSpace(raw))
+				} else {
+					c.malformed(segment.source.name, record, "partial_final_line")
+				}
+			} else {
+				c.scanRecord(segment.source.name, record, bytes.TrimSpace(raw))
+			}
+		}
+		if err != nil {
+			return
+		}
+	}
+}
+
+func logsSegmentStartsMidLine(segment logsSegment) bool {
+	if segment.offset <= 0 {
+		return false
+	}
+	var previous [1]byte
+	n, err := segment.source.file.ReadAt(previous[:], segment.offset-1)
+	return err != nil || n != 1 || previous[0] != '\n'
+}
+
+func readLogsLine(reader *bufio.Reader) ([]byte, bool, bool, error) {
+	var line []byte
+	tooLong := false
+	for {
+		fragment, err := reader.ReadSlice('\n')
+		if !tooLong {
+			if len(line)+len(fragment) <= logsMaxLineBytes {
+				line = append(line, fragment...)
+			} else {
+				line = nil
+				tooLong = true
+			}
+		}
+		switch {
+		case err == nil:
+			return line, true, tooLong, nil
+		case errors.Is(err, bufio.ErrBufferFull):
+			continue
+		case errors.Is(err, io.EOF):
+			return line, false, tooLong, io.EOF
+		default:
+			return line, false, tooLong, err
+		}
+	}
+}
+
+func (c *logsCollector) scanRecord(source string, record int, raw []byte) {
+	c.result.Summary.ScannedRecords++
+	var fields map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &fields); err != nil || fields == nil {
+		c.malformed(source, record, "malformed_json")
+		return
+	}
+	matches, code := logsRecordMatches(fields, c.filter)
+	if code != "" {
+		c.malformed(source, record, code)
+		return
+	}
+	if !matches {
+		return
+	}
+	c.result.Summary.MatchedRecords++
+	copyOfRaw := append(json.RawMessage(nil), raw...)
+	if len(c.result.Records) == c.filter.Limit {
+		copy(c.result.Records, c.result.Records[1:])
+		c.result.Records[len(c.result.Records)-1] = copyOfRaw
+		c.truncate(logsTruncationRecords)
+		return
+	}
+	c.result.Records = append(c.result.Records, copyOfRaw)
+}
+
+func logsRecordMatches(fields map[string]json.RawMessage, filter logsFilter) (bool, string) {
+	timestamp, ok := logsString(fields, "time")
+	if !ok {
+		return false, "invalid_time"
+	}
+	recordedAt, err := time.Parse(time.RFC3339Nano, timestamp)
+	if err != nil {
+		return false, "invalid_time"
+	}
+	recordedAt = recordedAt.UTC()
+	if recordedAt.Before(filter.Since) || recordedAt.After(filter.Until) {
+		return false, ""
+	}
+	for _, match := range []struct {
+		key  string
+		want string
+	}{
+		{telemetry.ProjectIDKey, filter.ProjectID},
+		{telemetry.IssueIDKey, filter.IssueID},
+		{telemetry.IssueIdentifierKey, filter.IssueIdentifier},
+		{telemetry.ProviderSessionIDKey, filter.ProviderSession},
+	} {
+		if match.want == "" {
+			continue
+		}
+		if _, exists := fields[match.key]; !exists {
+			return false, ""
+		}
+		got, valid := logsString(fields, match.key)
+		if !valid {
+			return false, "invalid_" + match.key
+		}
+		if got != match.want {
+			return false, ""
+		}
+	}
+	for _, match := range []struct {
+		key  string
+		want int64
+	}{
+		{telemetry.WorkAttemptIDKey, filter.WorkAttemptID},
+		{telemetry.DetentSessionIDKey, filter.DetentSessionID},
+	} {
+		if match.want == 0 {
+			continue
+		}
+		if _, exists := fields[match.key]; !exists {
+			return false, ""
+		}
+		got, valid := logsInt64(fields, match.key)
+		if !valid {
+			return false, "invalid_" + match.key
+		}
+		if got != match.want {
+			return false, ""
+		}
+	}
+	if filter.MinimumLevelSet {
+		level, valid := logsRecordLevel(fields)
+		if !valid {
+			return false, "invalid_level"
+		}
+		if level < filter.MinimumLevel {
+			return false, ""
+		}
+	}
+	return true, ""
+}
+
+func logsString(fields map[string]json.RawMessage, key string) (string, bool) {
+	raw, ok := fields[key]
+	if !ok {
+		return "", false
+	}
+	var value string
+	if err := json.Unmarshal(raw, &value); err != nil {
+		return "", false
+	}
+	return value, true
+}
+
+func logsInt64(fields map[string]json.RawMessage, key string) (int64, bool) {
+	raw, ok := fields[key]
+	if !ok {
+		return 0, false
+	}
+	var value int64
+	if err := json.Unmarshal(raw, &value); err != nil {
+		return 0, false
+	}
+	return value, true
+}
+
+func logsRecordLevel(fields map[string]json.RawMessage) (slog.Level, bool) {
+	value, ok := logsString(fields, "level")
+	if !ok {
+		return 0, false
+	}
+	var level slog.Level
+	if err := level.UnmarshalText([]byte(strings.ToUpper(strings.TrimSpace(value)))); err != nil {
+		return 0, false
+	}
+	return level, true
+}
+
+func (c *logsCollector) malformed(source string, record int, code string) {
+	c.result.Summary.MalformedRecords++
+	if len(c.diagnostics) < logsMaxDiagnostics {
+		c.diagnostics = append(c.diagnostics, logsDiagnostic{
+			Severity: logsDiagnosticSeverity,
+			Code:     code,
+			Source:   source,
+			Record:   record,
+		})
+	}
+}
+
+func (c *logsCollector) truncate(reason string) {
+	if slices.Contains(c.result.Summary.TruncationReasons, reason) {
+		return
+	}
+	c.result.Summary.Truncated = true
+	c.result.Summary.TruncationReasons = append(c.result.Summary.TruncationReasons, reason)
+}
+
+func writeLogsOutput(out io.Writer, output string, result logsResult) error {
+	if out == nil {
+		out = io.Discard
+	}
+	switch strings.ToLower(strings.TrimSpace(output)) {
+	case logsOutputJSON:
+		return WriteJSON(out, result)
+	case logsOutputJSONL:
+		for _, record := range result.Records {
+			line := append([]byte(nil), record...)
+			line = append(line, '\n')
+			if _, err := out.Write(line); err != nil {
+				return err
+			}
+		}
+		return nil
+	default:
+		return ValidationError("--output must be json or jsonl")
+	}
+}
+
+func writeLogsDiagnostics(out io.Writer, diagnostics []logsDiagnostic, summary logsSummary) error {
+	if out == nil {
+		out = io.Discard
+	}
+	encoder := json.NewEncoder(out)
+	for _, diagnostic := range diagnostics {
+		if err := encoder.Encode(diagnostic); err != nil {
+			return err
+		}
+	}
+	if summary.SuppressedDetails > 0 {
+		if err := encoder.Encode(logsDiagnostic{
+			Severity: logsDiagnosticSeverity,
+			Code:     "diagnostics_suppressed",
+			Count:    summary.SuppressedDetails,
+		}); err != nil {
+			return err
+		}
+	}
+	if summary.Truncated {
+		return encoder.Encode(logsDiagnostic{
+			Severity: logsDiagnosticSeverity,
+			Code:     "output_truncated",
+			Reasons:  summary.TruncationReasons,
+		})
+	}
+	return nil
+}

--- a/internal/cli/logs.go
+++ b/internal/cli/logs.go
@@ -27,6 +27,7 @@ const (
 	logsLineBufferSize     = 64 << 10
 	logsMaxLineBytes       = 1 << 20
 	logsMaxDiagnostics     = 100
+	logsSnapshotAttempts   = 3
 	logsOutputJSON         = "json"
 	logsOutputJSONL        = "jsonl"
 	logsTruncationBytes    = "bytes"
@@ -320,11 +321,48 @@ func filterLogsSnapshot(files []*logsSnapshotFile, filter logsFilter) (logsResul
 }
 
 func openLogsSnapshot(path string, maxBackups int) ([]*logsSnapshotFile, error) {
+	paths := logsSnapshotPaths(path, maxBackups)
+	return openLogsSnapshotWithHook(paths, nil)
+}
+
+func logsSnapshotPaths(path string, maxBackups int) []string {
 	paths := make([]string, 0, maxBackups+1)
 	for index := maxBackups; index >= 1; index-- {
 		paths = append(paths, rotatedLogPath(path, index))
 	}
 	paths = append(paths, path)
+	return paths
+}
+
+func openLogsSnapshotWithHook(paths []string, afterOpen func(int) error) ([]*logsSnapshotFile, error) {
+	for attempt := range logsSnapshotAttempts {
+		files, err := openLogsSnapshotFiles(paths)
+		if err != nil {
+			return nil, err
+		}
+		if afterOpen != nil {
+			if err := afterOpen(attempt); err != nil {
+				return nil, errors.Join(err, closeLogsSnapshot(files))
+			}
+		}
+		stable, err := logsSnapshotStable(files, paths)
+		if err == nil && stable {
+			stable, err = logsSnapshotStable(files, paths)
+		}
+		if err != nil {
+			return nil, errors.Join(err, closeLogsSnapshot(files))
+		}
+		if stable {
+			return files, nil
+		}
+		if err := closeLogsSnapshot(files); err != nil {
+			return nil, fmt.Errorf("close rotated runtime log snapshot: %w", err)
+		}
+	}
+	return nil, errors.New("runtime logs changed repeatedly while creating a snapshot; retry the command")
+}
+
+func openLogsSnapshotFiles(paths []string) ([]*logsSnapshotFile, error) {
 	files := make([]*logsSnapshotFile, 0, len(paths))
 	for _, candidate := range paths {
 		file, err := openLogsFile(candidate)
@@ -350,10 +388,48 @@ func openLogsSnapshot(path string, maxBackups int) ([]*logsSnapshotFile, error) 
 			name:   filepath.Base(candidate),
 			file:   file,
 			info:   info,
-			active: candidate == path,
+			active: len(paths) > 0 && candidate == paths[len(paths)-1],
 		})
 	}
 	return files, nil
+}
+
+func logsSnapshotStable(files []*logsSnapshotFile, paths []string) (bool, error) {
+	opened := make([]os.FileInfo, 0, len(files))
+	for _, file := range files {
+		opened = appendUniqueLogsFileInfo(opened, file.info)
+	}
+	current := make([]os.FileInfo, 0, len(paths))
+	for _, path := range paths {
+		info, err := os.Stat(path)
+		if errors.Is(err, os.ErrNotExist) {
+			continue
+		}
+		if err != nil {
+			return false, fmt.Errorf("revalidate runtime log snapshot: %w", err)
+		}
+		current = appendUniqueLogsFileInfo(current, info)
+	}
+	if len(opened) != len(current) {
+		return false, nil
+	}
+	for _, info := range opened {
+		if !slices.ContainsFunc(current, func(candidate os.FileInfo) bool {
+			return os.SameFile(info, candidate)
+		}) {
+			return false, nil
+		}
+	}
+	return true, nil
+}
+
+func appendUniqueLogsFileInfo(infos []os.FileInfo, candidate os.FileInfo) []os.FileInfo {
+	if slices.ContainsFunc(infos, func(existing os.FileInfo) bool {
+		return os.SameFile(existing, candidate)
+	}) {
+		return infos
+	}
+	return append(infos, candidate)
 }
 
 func closeLogsSnapshot(files []*logsSnapshotFile) error {

--- a/internal/cli/logs.go
+++ b/internal/cli/logs.go
@@ -327,7 +327,7 @@ func openLogsSnapshot(path string, maxBackups int) ([]*logsSnapshotFile, error) 
 	paths = append(paths, path)
 	files := make([]*logsSnapshotFile, 0, len(paths))
 	for _, candidate := range paths {
-		file, err := os.Open(candidate)
+		file, err := openLogsFile(candidate)
 		if errors.Is(err, os.ErrNotExist) {
 			continue
 		}

--- a/internal/cli/logs_open.go
+++ b/internal/cli/logs_open.go
@@ -1,0 +1,9 @@
+//go:build !windows
+
+package cli
+
+import "os"
+
+func openLogsFile(name string) (*os.File, error) {
+	return os.Open(name)
+}

--- a/internal/cli/logs_open_windows.go
+++ b/internal/cli/logs_open_windows.go
@@ -1,0 +1,36 @@
+//go:build windows
+
+package cli
+
+import (
+	"errors"
+	"os"
+	"syscall"
+)
+
+func openLogsFile(name string) (*os.File, error) {
+	path, err := syscall.UTF16PtrFromString(name)
+	if err != nil {
+		return nil, &os.PathError{Op: "open", Path: name, Err: err}
+	}
+	handle, err := syscall.CreateFile(
+		path,
+		syscall.GENERIC_READ,
+		syscall.FILE_SHARE_READ|syscall.FILE_SHARE_WRITE|syscall.FILE_SHARE_DELETE,
+		nil,
+		syscall.OPEN_EXISTING,
+		syscall.FILE_ATTRIBUTE_NORMAL,
+		0,
+	)
+	if err != nil {
+		return nil, &os.PathError{Op: "open", Path: name, Err: err}
+	}
+	file := os.NewFile(uintptr(handle), name)
+	if file == nil {
+		if closeErr := syscall.CloseHandle(handle); closeErr != nil {
+			return nil, errors.Join(errors.New("create runtime log file handle"), closeErr)
+		}
+		return nil, errors.New("create runtime log file handle")
+	}
+	return file, nil
+}

--- a/internal/cli/logs_test.go
+++ b/internal/cli/logs_test.go
@@ -1,0 +1,528 @@
+package cli
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+
+	globalconfig "github.com/digitaldrywood/detent/internal/config/global"
+)
+
+func TestParseLogsFilter(t *testing.T) {
+	t.Parallel()
+	now := time.Date(2026, time.August, 7, 12, 0, 0, 0, time.UTC)
+	tests := []struct {
+		name        string
+		values      logsCommandOptions
+		wantSince   time.Time
+		wantUntil   time.Time
+		wantLevel   bool
+		wantErrText string
+	}{
+		{
+			name:      "default bounded window",
+			values:    logsCommandOptions{Limit: defaultLogsLimit, MaxBytes: defaultLogsMaxBytes, Output: logsOutputJSON},
+			wantSince: now.Add(-defaultLogsWindow),
+			wantUntil: now,
+		},
+		{
+			name: "normalizes explicit boundaries to UTC",
+			values: logsCommandOptions{
+				Since: "2026-08-07T06:00:00-05:00", Until: "2026-08-07T07:00:00-05:00",
+				Level: "warning", Limit: 2, MaxBytes: 1024, Output: logsOutputJSONL,
+			},
+			wantSince: time.Date(2026, time.August, 7, 11, 0, 0, 0, time.UTC),
+			wantUntil: time.Date(2026, time.August, 7, 12, 0, 0, 0, time.UTC),
+			wantLevel: true,
+		},
+		{name: "rejects zero limit", values: logsCommandOptions{MaxBytes: 1, Output: logsOutputJSON}, wantErrText: "--limit must be greater than 0"},
+		{name: "rejects zero byte bound", values: logsCommandOptions{Limit: 1, Output: logsOutputJSON}, wantErrText: "--max-bytes must be greater than 0"},
+		{name: "rejects output", values: logsCommandOptions{Limit: 1, MaxBytes: 1, Output: "pretty"}, wantErrText: "--output must be json or jsonl"},
+		{name: "rejects start syntax", values: logsCommandOptions{Since: "yesterday", Limit: 1, MaxBytes: 1, Output: logsOutputJSON}, wantErrText: "--since must be an RFC3339 timestamp"},
+		{name: "rejects end before start", values: logsCommandOptions{Since: now.Format(time.RFC3339), Until: now.Add(-time.Second).Format(time.RFC3339), Limit: 1, MaxBytes: 1, Output: logsOutputJSON}, wantErrText: "--since must be before or equal to --until"},
+		{name: "rejects level", values: logsCommandOptions{Level: "notice", Limit: 1, MaxBytes: 1, Output: logsOutputJSON}, wantErrText: "--level must be debug, info, warn, or error"},
+		{name: "rejects negative attempt", values: logsCommandOptions{WorkAttemptID: -1, Limit: 1, MaxBytes: 1, Output: logsOutputJSON}, wantErrText: "--work-attempt-id must be greater than or equal to 0"},
+		{name: "rejects negative session", values: logsCommandOptions{DetentSessionID: -1, Limit: 1, MaxBytes: 1, Output: logsOutputJSON}, wantErrText: "--detent-session-id must be greater than or equal to 0"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := parseLogsFilter(tt.values, now)
+			if tt.wantErrText != "" {
+				if err == nil || !strings.Contains(err.Error(), tt.wantErrText) {
+					t.Fatalf("parseLogsFilter() error = %v, want containing %q", err, tt.wantErrText)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("parseLogsFilter() error = %v", err)
+			}
+			if !got.Since.Equal(tt.wantSince) || !got.Until.Equal(tt.wantUntil) {
+				t.Fatalf("window = %s..%s, want %s..%s", got.Since, got.Until, tt.wantSince, tt.wantUntil)
+			}
+			if got.MinimumLevelSet != tt.wantLevel {
+				t.Fatalf("MinimumLevelSet = %t, want %t", got.MinimumLevelSet, tt.wantLevel)
+			}
+		})
+	}
+}
+
+func TestFilterLogsCombinesFiltersAndOrdersLevels(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "detent.log")
+	base := time.Date(2026, time.August, 7, 10, 0, 0, 0, time.UTC)
+	records := []string{
+		testLogRecord(base, "DEBUG", "debug", "alpha", "1", "owner/repo#1", 10, 20, "provider-a"),
+		testLogRecord(base.Add(time.Minute), "INFO", "info", "alpha", "1", "owner/repo#1", 10, 20, "provider-a"),
+		testLogRecord(base.Add(2*time.Minute), "WARN", "warn", "alpha", "1", "owner/repo#1", 10, 20, "provider-a"),
+		testLogRecord(base.Add(3*time.Minute), "ERROR", "error", "beta", "2", "owner/repo#2", 11, 21, "provider-b"),
+	}
+	writeLogLines(t, path, records...)
+	tests := []struct {
+		name   string
+		filter logsFilter
+		want   []string
+	}{
+		{
+			name:   "UTC boundaries are inclusive",
+			filter: testLogsFilter(base.Add(time.Minute), base.Add(2*time.Minute)),
+			want:   []string{"info", "warn"},
+		},
+		{
+			name: "canonical filters combine conjunctively",
+			filter: func() logsFilter {
+				filter := testLogsFilter(base, base.Add(4*time.Minute))
+				filter.ProjectID = "alpha"
+				filter.IssueID = "1"
+				filter.IssueIdentifier = "owner/repo#1"
+				filter.WorkAttemptID = 10
+				filter.DetentSessionID = 20
+				filter.ProviderSession = "provider-a"
+				filter.MinimumLevel, filter.MinimumLevelSet, _ = parseLogsLevel("warn")
+				return filter
+			}(),
+			want: []string{"warn"},
+		},
+		{
+			name: "project scope is exact",
+			filter: func() logsFilter {
+				filter := testLogsFilter(base, base.Add(4*time.Minute))
+				filter.ProjectID = "beta"
+				return filter
+			}(),
+			want: []string{"error"},
+		},
+	}
+	for _, level := range []struct {
+		name string
+		want []string
+	}{
+		{name: "debug", want: []string{"debug", "info", "warn", "error"}},
+		{name: "info", want: []string{"info", "warn", "error"}},
+		{name: "warn", want: []string{"warn", "error"}},
+		{name: "error", want: []string{"error"}},
+	} {
+		filter := testLogsFilter(base, base.Add(4*time.Minute))
+		filter.MinimumLevel, filter.MinimumLevelSet, _ = parseLogsLevel(level.name)
+		tests = append(tests, struct {
+			name   string
+			filter logsFilter
+			want   []string
+		}{name: "minimum level " + level.name, filter: filter, want: level.want})
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			result, diagnostics, err := filterLogs(path, 0, tt.filter)
+			if err != nil {
+				t.Fatalf("filterLogs() error = %v", err)
+			}
+			if len(diagnostics) != 0 {
+				t.Fatalf("diagnostics = %#v, want none", diagnostics)
+			}
+			if got := logMessages(t, result.Records); !reflect.DeepEqual(got, tt.want) {
+				t.Fatalf("messages = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestFilterLogsReadsRotationAndReportsMalformedRecordsSafely(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "detent.log")
+	base := time.Date(2026, time.August, 7, 10, 0, 0, 0, time.UTC)
+	writeLogLines(t, path+".2", testLogRecord(base, "INFO", "oldest", "alpha", "1", "owner/repo#1", 0, 0, ""))
+	active := testLogRecord(base.Add(time.Minute), "INFO", "newest", "alpha", "1", "owner/repo#1", 0, 0, "") + "\n" +
+		`{"time":"2026-08-07T10:02:00Z","secret":"DO-NOT-ECHO",}` + "\n" +
+		`{"time":"2026-08-07T10:02:30Z","level":"INFO","project_id":42,"secret":"WRONG-TYPE"}` + "\n" +
+		`{"time":"2026-08-07T10:03:00Z","secret":"ALSO-SECRET"`
+	if err := os.WriteFile(path, []byte(active), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	filter := testLogsFilter(base.Add(-time.Hour), base.Add(time.Hour))
+	filter.ProjectID = "alpha"
+	result, diagnostics, err := filterLogs(path, 2, filter)
+	if err != nil {
+		t.Fatalf("filterLogs() error = %v", err)
+	}
+	if got, want := logMessages(t, result.Records), []string{"oldest", "newest"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("messages = %v, want %v", got, want)
+	}
+	if result.Summary.MalformedRecords != 3 {
+		t.Fatalf("MalformedRecords = %d, want 3", result.Summary.MalformedRecords)
+	}
+	if got, want := []string{diagnostics[0].Code, diagnostics[1].Code, diagnostics[2].Code}, []string{"malformed_json", "invalid_project_id", "partial_final_line"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("diagnostic codes = %v, want %v", got, want)
+	}
+	var stderr bytes.Buffer
+	if err := writeLogsDiagnostics(&stderr, diagnostics, result.Summary); err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(stderr.String(), "DO-NOT-ECHO") || strings.Contains(stderr.String(), "WRONG-TYPE") || strings.Contains(stderr.String(), "ALSO-SECRET") {
+		t.Fatalf("diagnostics leaked record contents: %s", stderr.String())
+	}
+}
+
+func TestOpenLogsSnapshotPinsFilesAcrossRotationAndDeduplicates(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "detent.log")
+	base := time.Date(2026, time.August, 7, 10, 0, 0, 0, time.UTC)
+	writeLogLines(t, path+".1", testLogRecord(base, "INFO", "backup", "alpha", "1", "", 0, 0, ""))
+	writeLogLines(t, path, testLogRecord(base.Add(time.Minute), "INFO", "active", "alpha", "1", "", 0, 0, ""))
+	files, err := openLogsSnapshot(path, 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		if err := closeLogsSnapshot(files); err != nil {
+			t.Errorf("closeLogsSnapshot() error = %v", err)
+		}
+	})
+	if err := os.Rename(path, path+".1"); err != nil {
+		t.Fatal(err)
+	}
+	writeLogLines(t, path, testLogRecord(base.Add(2*time.Minute), "INFO", "after snapshot", "alpha", "1", "", 0, 0, ""))
+	result, diagnostics := filterLogsSnapshot(files, testLogsFilter(base.Add(-time.Hour), base.Add(time.Hour)))
+	if len(diagnostics) != 0 {
+		t.Fatalf("diagnostics = %#v, want none", diagnostics)
+	}
+	if got, want := logMessages(t, result.Records), []string{"backup", "active"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("snapshot messages = %v, want %v", got, want)
+	}
+
+	linked := filepath.Join(dir, "linked.log")
+	writeLogLines(t, linked, testLogRecord(base, "INFO", "once", "alpha", "1", "", 0, 0, ""))
+	if err := os.Link(linked, linked+".1"); err != nil {
+		t.Fatal(err)
+	}
+	deduplicated, err := openLogsSnapshot(linked, 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		if err := closeLogsSnapshot(deduplicated); err != nil {
+			t.Errorf("closeLogsSnapshot() error = %v", err)
+		}
+	})
+	if len(deduplicated) != 1 {
+		t.Fatalf("snapshot file count = %d, want 1", len(deduplicated))
+	}
+}
+
+func TestFilterLogsEnforcesByteAndRecordBounds(t *testing.T) {
+	t.Parallel()
+	base := time.Date(2026, time.August, 7, 10, 0, 0, 0, time.UTC)
+	tests := []struct {
+		name         string
+		lines        []string
+		filter       logsFilter
+		wantMessages []string
+		wantMatched  int
+		wantReason   string
+	}{
+		{
+			name: "byte tail starts on record boundary",
+			lines: []string{
+				testLogRecord(base, "INFO", "old", "alpha", "1", "", 0, 0, ""),
+				testLogRecord(base.Add(time.Minute), "INFO", "new", "alpha", "1", "", 0, 0, ""),
+			},
+			filter: func() logsFilter {
+				filter := testLogsFilter(base.Add(-time.Hour), base.Add(time.Hour))
+				filter.MaxBytes = int64(len(testLogRecord(base.Add(time.Minute), "INFO", "new", "alpha", "1", "", 0, 0, "")) + 1)
+				return filter
+			}(),
+			wantMessages: []string{"new"},
+			wantMatched:  1,
+			wantReason:   logsTruncationBytes,
+		},
+		{
+			name: "record limit retains latest matches in order",
+			lines: []string{
+				testLogRecord(base, "INFO", "one", "alpha", "1", "", 0, 0, ""),
+				testLogRecord(base.Add(time.Minute), "INFO", "two", "alpha", "1", "", 0, 0, ""),
+				testLogRecord(base.Add(2*time.Minute), "INFO", "three", "alpha", "1", "", 0, 0, ""),
+			},
+			filter: func() logsFilter {
+				filter := testLogsFilter(base.Add(-time.Hour), base.Add(time.Hour))
+				filter.Limit = 2
+				return filter
+			}(),
+			wantMessages: []string{"two", "three"},
+			wantMatched:  3,
+			wantReason:   logsTruncationRecords,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			path := filepath.Join(t.TempDir(), "detent.log")
+			writeLogLines(t, path, tt.lines...)
+			result, diagnostics, err := filterLogs(path, 0, tt.filter)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got := logMessages(t, result.Records); !reflect.DeepEqual(got, tt.wantMessages) {
+				t.Fatalf("messages = %v, want %v", got, tt.wantMessages)
+			}
+			if result.Summary.MatchedRecords != tt.wantMatched || result.Summary.ReturnedRecords != len(tt.wantMessages) {
+				t.Fatalf("summary counts = matched %d returned %d", result.Summary.MatchedRecords, result.Summary.ReturnedRecords)
+			}
+			if !result.Summary.Truncated || !reflect.DeepEqual(result.Summary.TruncationReasons, []string{tt.wantReason}) {
+				t.Fatalf("truncation = %t %v, want %q", result.Summary.Truncated, result.Summary.TruncationReasons, tt.wantReason)
+			}
+			var stderr bytes.Buffer
+			if err := writeLogsDiagnostics(&stderr, diagnostics, result.Summary); err != nil {
+				t.Fatal(err)
+			}
+			if !strings.Contains(stderr.String(), `"code":"output_truncated"`) {
+				t.Fatalf("stderr does not signal truncation: %s", stderr.String())
+			}
+		})
+	}
+}
+
+func TestWriteLogsOutputShapes(t *testing.T) {
+	t.Parallel()
+	record := json.RawMessage(`{"time":"2026-08-07T10:00:00Z","level":"INFO","msg":"ready"}`)
+	result := logsResult{Records: []json.RawMessage{record}, Summary: logsSummary{ReturnedRecords: 1}}
+	tests := []struct {
+		name   string
+		output string
+		check  func(*testing.T, []byte)
+	}{
+		{
+			name:   "JSON envelope",
+			output: logsOutputJSON,
+			check: func(t *testing.T, raw []byte) {
+				var decoded struct {
+					Records []json.RawMessage `json:"records"`
+					Summary logsSummary       `json:"summary"`
+				}
+				if err := json.Unmarshal(raw, &decoded); err != nil {
+					t.Fatal(err)
+				}
+				if len(decoded.Records) != 1 || decoded.Summary.ReturnedRecords != 1 {
+					t.Fatalf("decoded output = %#v", decoded)
+				}
+			},
+		},
+		{
+			name:   "JSONL raw records",
+			output: logsOutputJSONL,
+			check: func(t *testing.T, raw []byte) {
+				if got, want := string(raw), string(record)+"\n"; got != want {
+					t.Fatalf("output = %q, want %q", got, want)
+				}
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			var output bytes.Buffer
+			if err := writeLogsOutput(&output, tt.output, result); err != nil {
+				t.Fatal(err)
+			}
+			tt.check(t, output.Bytes())
+		})
+	}
+}
+
+func TestLogsSourceUsesRuntimeResolutionAndOverride(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "global.yaml")
+	backups := 3
+	opts := defaultOptions()
+	opts.resolvePath = func(string) (globalconfig.PathResolution, error) {
+		return globalconfig.PathResolution{Path: configPath, Rule: globalconfig.PathRuleFlag}, nil
+	}
+	opts.readDoctor = func(string) (globalconfig.Config, error) {
+		return globalconfig.Config{Path: configPath, LogMaxBackups: &backups}, nil
+	}
+	path, gotBackups, err := resolveLogsSource("ignored", opts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if want := filepath.Join(dir, "detent.log"); path != want || gotBackups != backups {
+		t.Fatalf("source = %q, %d, want %q, %d", path, gotBackups, want, backups)
+	}
+
+	override := filepath.Join(dir, "runtime", "operator.jsonl")
+	path, gotBackups = logsSourceFromBoot(BootConfig{
+		RuntimeDBPath:  filepath.Join(dir, "runtime", "state.db"),
+		RuntimeLogPath: override,
+		Runtime:        RuntimeSettings{LogMaxBackups: RuntimeIntValue{Value: 7}},
+	})
+	if path != override || gotBackups != 7 {
+		t.Fatalf("overridden source = %q, %d, want %q, 7", path, gotBackups, override)
+	}
+}
+
+func TestFilterLogsExplainsNoFileLoggingModes(t *testing.T) {
+	t.Parallel()
+	path := filepath.Join(t.TempDir(), "detent.log")
+	_, _, err := filterLogs(path, 5, testLogsFilter(time.Unix(0, 0), time.Now().Add(time.Hour)))
+	if err == nil {
+		t.Fatal("filterLogs() error = nil")
+	}
+	for _, want := range []string{"runtime log file is unavailable", "terminal-dashboard mode", "headless and text modes"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("error missing %q: %v", want, err)
+		}
+	}
+}
+
+func TestFilterLogsBoundsMalformedDiagnostics(t *testing.T) {
+	t.Parallel()
+	path := filepath.Join(t.TempDir(), "detent.log")
+	lines := make([]string, logsMaxDiagnostics+2)
+	for index := range lines {
+		lines[index] = `{"secret":"NEVER-ECHO",}`
+	}
+	writeLogLines(t, path, lines...)
+	result, diagnostics, err := filterLogs(path, 0, testLogsFilter(time.Unix(0, 0), time.Now().Add(time.Hour)))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(diagnostics) != logsMaxDiagnostics || result.Summary.SuppressedDetails != 2 {
+		t.Fatalf("diagnostics = %d, suppressed = %d, want %d and 2", len(diagnostics), result.Summary.SuppressedDetails, logsMaxDiagnostics)
+	}
+	var stderr bytes.Buffer
+	if err := writeLogsDiagnostics(&stderr, diagnostics, result.Summary); err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(stderr.String(), "NEVER-ECHO") || !strings.Contains(stderr.String(), `"code":"diagnostics_suppressed","count":2`) {
+		t.Fatalf("bounded diagnostics = %s", stderr.String())
+	}
+}
+
+func TestLogsCommandReadsResolvedRuntimeLog(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "global.yaml")
+	path := filepath.Join(dir, "detent.log")
+	at := time.Date(2026, time.August, 7, 10, 0, 0, 0, time.UTC)
+	writeLogLines(t, path, testLogRecord(at, "INFO", "command", "alpha", "1", "owner/repo#1", 0, 0, ""))
+	opts := defaultOptions()
+	opts.resolvePath = func(string) (globalconfig.PathResolution, error) {
+		return globalconfig.PathResolution{Path: configPath, Rule: globalconfig.PathRuleFlag}, nil
+	}
+	opts.readDoctor = func(string) (globalconfig.Config, error) {
+		return globalconfig.Config{Path: configPath}, nil
+	}
+	cmd := NewRootCommand(t.Context(), func(configured *options) { *configured = opts })
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stderr)
+	cmd.SetArgs([]string{
+		"logs",
+		"--project-id", "alpha",
+		"--since", at.Format(time.RFC3339),
+		"--until", at.Format(time.RFC3339),
+		"--output", "jsonl",
+	})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+	if !strings.Contains(stdout.String(), `"msg":"command"`) {
+		t.Fatalf("stdout = %s", stdout.String())
+	}
+	if stderr.Len() != 0 {
+		t.Fatalf("stderr = %s, want empty", stderr.String())
+	}
+}
+
+func testLogsFilter(since time.Time, until time.Time) logsFilter {
+	return logsFilter{
+		Since:    since.UTC(),
+		Until:    until.UTC(),
+		Limit:    100,
+		MaxBytes: 1 << 20,
+	}
+}
+
+func testLogRecord(at time.Time, level string, message string, projectID string, issueID string, issueIdentifier string, workAttemptID int64, detentSessionID int64, providerSessionID string) string {
+	fields := map[string]any{
+		"time":                at.Format(time.RFC3339Nano),
+		"level":               level,
+		"msg":                 message,
+		"project_id":          projectID,
+		"issue_id":            issueID,
+		"issue_identifier":    issueIdentifier,
+		"work_attempt_id":     workAttemptID,
+		"detent_session_id":   detentSessionID,
+		"provider_session_id": providerSessionID,
+	}
+	raw, err := json.Marshal(fields)
+	if err != nil {
+		panic(err)
+	}
+	return string(raw)
+}
+
+func writeLogLines(t *testing.T, path string, lines ...string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte(strings.Join(lines, "\n")+"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func logMessages(t *testing.T, records []json.RawMessage) []string {
+	t.Helper()
+	messages := make([]string, 0, len(records))
+	for _, record := range records {
+		var fields map[string]any
+		if err := json.Unmarshal(record, &fields); err != nil {
+			t.Fatal(err)
+		}
+		message, ok := fields["msg"].(string)
+		if !ok {
+			t.Fatalf("record has no string msg: %s", record)
+		}
+		messages = append(messages, message)
+	}
+	return messages
+}
+
+func TestLogsErrorsRemainClassified(t *testing.T) {
+	t.Parallel()
+	_, err := parseLogsFilter(logsCommandOptions{Limit: -1, MaxBytes: 1, Output: logsOutputJSON}, time.Now())
+	if !errors.Is(err, ErrValidation) {
+		t.Fatalf("error = %v, want ErrValidation", err)
+	}
+	if got := ClassifyError(err).ExitCode; got != 3 {
+		t.Fatalf("exit code = %d, want 3", got)
+	}
+}

--- a/internal/cli/logs_test.go
+++ b/internal/cli/logs_test.go
@@ -192,14 +192,25 @@ func TestFilterLogsReadsRotationAndReportsMalformedRecordsSafely(t *testing.T) {
 	}
 }
 
-func TestOpenLogsSnapshotPinsFilesAcrossRotationAndDeduplicates(t *testing.T) {
+func TestOpenLogsSnapshotRetriesConcurrentRotationAndDeduplicates(t *testing.T) {
 	t.Parallel()
 	dir := t.TempDir()
 	path := filepath.Join(dir, "detent.log")
 	base := time.Date(2026, time.August, 7, 10, 0, 0, 0, time.UTC)
 	writeLogLines(t, path+".1", testLogRecord(base, "INFO", "backup", "alpha", "1", "", 0, 0, ""))
 	writeLogLines(t, path, testLogRecord(base.Add(time.Minute), "INFO", "active", "alpha", "1", "", 0, 0, ""))
-	files, err := openLogsSnapshot(path, 1)
+	attempts := 0
+	files, err := openLogsSnapshotWithHook(logsSnapshotPaths(path, 2), func(attempt int) error {
+		attempts++
+		if attempt > 0 {
+			return nil
+		}
+		if err := rotateLogFiles(path, 2); err != nil {
+			return err
+		}
+		writeLogLines(t, path, testLogRecord(base.Add(2*time.Minute), "INFO", "after rotation", "alpha", "1", "", 0, 0, ""))
+		return nil
+	})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -208,18 +219,14 @@ func TestOpenLogsSnapshotPinsFilesAcrossRotationAndDeduplicates(t *testing.T) {
 			t.Errorf("closeLogsSnapshot() error = %v", err)
 		}
 	})
-	if err := os.Rename(path+".1", path+".2"); err != nil {
-		t.Fatal(err)
+	if attempts != 2 {
+		t.Fatalf("snapshot attempts = %d, want 2", attempts)
 	}
-	if err := os.Rename(path, path+".1"); err != nil {
-		t.Fatal(err)
-	}
-	writeLogLines(t, path, testLogRecord(base.Add(2*time.Minute), "INFO", "after snapshot", "alpha", "1", "", 0, 0, ""))
 	result, diagnostics := filterLogsSnapshot(files, testLogsFilter(base.Add(-time.Hour), base.Add(time.Hour)))
 	if len(diagnostics) != 0 {
 		t.Fatalf("diagnostics = %#v, want none", diagnostics)
 	}
-	if got, want := logMessages(t, result.Records), []string{"backup", "active"}; !reflect.DeepEqual(got, want) {
+	if got, want := logMessages(t, result.Records), []string{"backup", "active", "after rotation"}; !reflect.DeepEqual(got, want) {
 		t.Fatalf("snapshot messages = %v, want %v", got, want)
 	}
 

--- a/internal/cli/logs_test.go
+++ b/internal/cli/logs_test.go
@@ -208,6 +208,9 @@ func TestOpenLogsSnapshotPinsFilesAcrossRotationAndDeduplicates(t *testing.T) {
 			t.Errorf("closeLogsSnapshot() error = %v", err)
 		}
 	})
+	if err := os.Rename(path+".1", path+".2"); err != nil {
+		t.Fatal(err)
+	}
 	if err := os.Rename(path, path+".1"); err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
## Summary

- Add a bounded `detent logs` command over the resolved dashboard JSON log and numbered backups.
- Support conjunctive canonical-correlation, inclusive UTC time, and minimum-level filters with stable JSON or JSONL output.
- Preserve a pinned rotation snapshot, cap bytes, records, and diagnostics, and report malformed input and truncation without echoing raw malformed content.

Fixes #1646

## UI Surface Contract

- [x] N/A, or the linked issue explicitly authorizes any high-impact UI surface, layout, density, first-viewport, or responsive visibility tradeoff.
- [x] Persistent top-of-screen messaging is explicitly authorized by the issue, or this PR does not add it.
- [x] N/A — this PR has no visual changes to primary operator screens.

## Test Plan

- [x] `go test ./internal/cli ./cmd/detent`
- [x] `make check`