### PR TITLE
feat(skills): add operator introspection skill

### DIFF
--- a/embed.go
+++ b/embed.go
@@ -5,13 +5,23 @@ import (
 	"io/fs"
 )
 
-//go:embed static/**
-var embeddedStaticFiles embed.FS
+const operatorSkillPath = "internal/operatorskill/detent-operator-introspection/SKILL.md"
+
+//go:embed static/** internal/operatorskill/detent-operator-introspection/SKILL.md
+var embeddedFiles embed.FS
 
 func StaticFS() fs.FS {
-	staticFS, err := fs.Sub(embeddedStaticFiles, "static")
+	staticFS, err := fs.Sub(embeddedFiles, "static")
 	if err != nil {
 		panic(err)
 	}
 	return staticFS
+}
+
+func OperatorSkillContent() []byte {
+	content, err := fs.ReadFile(embeddedFiles, operatorSkillPath)
+	if err != nil {
+		panic(err)
+	}
+	return content
 }

--- a/embed_test.go
+++ b/embed_test.go
@@ -4,6 +4,8 @@ import (
 	"bytes"
 	"io/fs"
 	"testing"
+
+	"github.com/digitaldrywood/detent/internal/operatorskill"
 )
 
 func TestStaticFSContainsCSSOutput(t *testing.T) {
@@ -16,5 +18,11 @@ func TestStaticFSContainsCSSOutput(t *testing.T) {
 	}
 	if !bytes.Contains(data, []byte("tailwindcss")) {
 		t.Fatalf("css/output.css missing Tailwind marker:\n%s", data)
+	}
+}
+
+func TestOperatorSkillContentMatchesBundle(t *testing.T) {
+	if content := OperatorSkillContent(); !bytes.Equal(content, operatorskill.Content()) {
+		t.Fatal("OperatorSkillContent() does not match the source bundle")
 	}
 }

--- a/internal/operatorskill/bundle.go
+++ b/internal/operatorskill/bundle.go
@@ -1,0 +1,20 @@
+package operatorskill
+
+import (
+	"bytes"
+	_ "embed"
+)
+
+const (
+	Name      = "detent-operator-introspection"
+	Version   = 1
+	Directory = Name
+	SkillFile = "SKILL.md"
+)
+
+//go:embed detent-operator-introspection/SKILL.md
+var content []byte
+
+func Content() []byte {
+	return bytes.Clone(content)
+}

--- a/internal/operatorskill/bundle_test.go
+++ b/internal/operatorskill/bundle_test.go
@@ -129,6 +129,8 @@ func assertSafetyContract(t *testing.T, document string) {
 	for _, required := range []string{
 		"api_token_required",
 		"A successful response with degraded fields is still a success",
+		"Treat only `live` evidence as current",
+		"Treat `available` as readable",
 		"Never substitute raw database access",
 		"dashboard HTML scraping",
 		"plaintext credential recovery",

--- a/internal/operatorskill/bundle_test.go
+++ b/internal/operatorskill/bundle_test.go
@@ -1,0 +1,180 @@
+package operatorskill
+
+import (
+	"bytes"
+	"context"
+	"regexp"
+	"slices"
+	"strings"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+
+	"github.com/digitaldrywood/detent/internal/cli"
+	"github.com/digitaldrywood/detent/internal/explain"
+)
+
+func TestContentReturnsCopy(t *testing.T) {
+	first := Content()
+	second := Content()
+	if len(first) == 0 {
+		t.Fatal("Content() is empty")
+	}
+	first[0] ^= 0xff
+	if bytes.Equal(first, second) {
+		t.Fatal("Content() returned shared mutable storage")
+	}
+}
+
+func TestSkillDocumentContract(t *testing.T) {
+	document := string(Content())
+	frontmatter, body := splitSkillDocument(t, document)
+
+	var metadata map[string]any
+	if err := yaml.Unmarshal([]byte(frontmatter), &metadata); err != nil {
+		t.Fatalf("Unmarshal() error = %v", err)
+	}
+	if len(metadata) != 2 || metadata["name"] != Name || strings.TrimSpace(stringValue(metadata["description"])) == "" {
+		t.Fatalf("frontmatter = %#v, want only name and description", metadata)
+	}
+	if !strings.Contains(body, "Bundle version: 1") {
+		t.Fatalf("body missing bundle version %d", Version)
+	}
+	if Version != 1 {
+		t.Fatalf("Version = %d, update the version stamp contract", Version)
+	}
+	if !strings.Contains(body, "Expected response schema: 1") || explain.SchemaVersion != 1 {
+		t.Fatalf("response schema stamp does not match explain.SchemaVersion = %d", explain.SchemaVersion)
+	}
+
+	assertDecisionTreeContract(t, body)
+	assertCommandCatalogContract(t, body)
+	assertSafetyContract(t, document)
+}
+
+func assertDecisionTreeContract(t *testing.T, body string) {
+	t.Helper()
+	_, decisionTree, found := strings.Cut(body, "## Decision tree\n")
+	if !found {
+		t.Fatal("skill is missing the decision tree")
+	}
+	decisionTree, _, _ = strings.Cut(decisionTree, "\n## ")
+	rawSections := strings.Split(strings.TrimSpace(decisionTree), "\n### ")
+	wantNames := []string{
+		"Current lane or latest transition",
+		"Active work",
+		"Eligibility or required gate",
+		"Evidence confidence",
+	}
+	if len(rawSections) != len(wantNames) {
+		t.Fatalf("decision sections = %d, want %d", len(rawSections), len(wantNames))
+	}
+	for index, rawSection := range rawSections {
+		rawSection = strings.TrimPrefix(rawSection, "### ")
+		name, section, found := strings.Cut(rawSection, "\n")
+		if !found || name != wantNames[index] {
+			t.Fatalf("decision section %d = %q, want %q", index, name, wantNames[index])
+		}
+		for _, marker := range []string{"Call once:", "Stop:", "Escalate:"} {
+			if got := strings.Count(section, marker); got != 1 {
+				t.Fatalf("section %q contains %q %d times, want 1", name, marker, got)
+			}
+		}
+	}
+}
+
+func assertCommandCatalogContract(t *testing.T, body string) {
+	t.Helper()
+	commandPattern := regexp.MustCompile(`(?m)^detent --format json issue '<issue-ref>' --explain --project '<project-id>'$`)
+	if got := len(commandPattern.FindAllString(body, -1)); got != 4 {
+		t.Fatalf("recommended command count = %d, want one for each decision class", got)
+	}
+	if other := regexp.MustCompile(`(?m)^detent .+$`).FindAllString(body, -1); len(other) != 4 {
+		t.Fatalf("named Detent commands = %q, want only the four recommended calls", other)
+	}
+
+	root := cli.NewRootCommand(context.Background())
+	issue, _, err := root.Find([]string{"issue"})
+	if err != nil || issue == nil || issue.Name() != "issue" {
+		t.Fatalf("issue command lookup = %v, %v", issue, err)
+	}
+	for _, name := range []string{"explain", "project"} {
+		if issue.Flags().Lookup(name) == nil {
+			t.Fatalf("issue command does not catalog --%s", name)
+		}
+	}
+	if root.PersistentFlags().Lookup("format") == nil {
+		t.Fatal("root command does not catalog --format")
+	}
+
+	for _, code := range []string{
+		"dashboard_unauthorized",
+		"dashboard_forbidden",
+		"ambiguous_reference",
+		"issue_not_found",
+		"runtime_unavailable",
+		"dashboard_unreachable",
+		"dashboard_timeout",
+		"unsupported_model_version",
+		"dashboard_request_failed",
+	} {
+		if !strings.Contains(root.Long, code) {
+			t.Fatalf("CLI catalog does not contain named outcome %q", code)
+		}
+	}
+}
+
+func assertSafetyContract(t *testing.T, document string) {
+	t.Helper()
+	for _, required := range []string{
+		"api_token_required",
+		"A successful response with degraded fields is still a success",
+		"Never substitute raw database access",
+		"dashboard HTML scraping",
+		"plaintext credential recovery",
+		"mutating commands",
+		"proposal tools",
+		"outside repository `.detent/skills` directories",
+	} {
+		if !strings.Contains(document, required) {
+			t.Fatalf("skill missing safety contract %q", required)
+		}
+	}
+	for _, prohibited := range []*regexp.Regexp{
+		regexp.MustCompile(`(?i)/api/`),
+		regexp.MustCompile(`(?i)(?:^|[[:space:]\x60(])/(?:Users|home|var|tmp|etc)/`),
+		regexp.MustCompile(`(?i)[A-Z]:\\`),
+		regexp.MustCompile(`(?i)bearer[[:space:]]+[A-Za-z0-9._~-]+`),
+		regexp.MustCompile(`(?i)digitaldrywood|corylanou`),
+	} {
+		if match := prohibited.FindString(document); match != "" {
+			t.Fatalf("skill contains prohibited local or uncataloged content %q", match)
+		}
+	}
+	if strings.Contains(document, "operationId") || strings.Contains(document, "tool name") {
+		t.Fatal("skill names an API or tool surface without a catalog contract")
+	}
+}
+
+func splitSkillDocument(t *testing.T, document string) (string, string) {
+	t.Helper()
+	parts := strings.SplitN(document, "---\n", 3)
+	if len(parts) != 3 || parts[0] != "" {
+		t.Fatal("skill document does not have YAML frontmatter")
+	}
+	return parts[1], parts[2]
+}
+
+func stringValue(value any) string {
+	text, _ := value.(string)
+	return text
+}
+
+func TestBundlePathContract(t *testing.T) {
+	if Directory != Name || SkillFile != "SKILL.md" {
+		t.Fatalf("bundle path = %q/%q", Directory, SkillFile)
+	}
+	if slices.Contains(strings.Split(Directory, "/"), ".detent") {
+		t.Fatalf("bundle directory %q must not use worker metadata", Directory)
+	}
+}

--- a/internal/operatorskill/bundle_test.go
+++ b/internal/operatorskill/bundle_test.go
@@ -158,11 +158,24 @@ func assertSafetyContract(t *testing.T, document string) {
 
 func splitSkillDocument(t *testing.T, document string) (string, string) {
 	t.Helper()
+	document = strings.ReplaceAll(document, "\r\n", "\n")
 	parts := strings.SplitN(document, "---\n", 3)
 	if len(parts) != 3 || parts[0] != "" {
 		t.Fatal("skill document does not have YAML frontmatter")
 	}
 	return parts[1], parts[2]
+}
+
+func TestSplitSkillDocumentAcceptsPlatformLineEndings(t *testing.T) {
+	for _, document := range []string{
+		"---\nname: example\n---\nbody\n",
+		"---\r\nname: example\r\n---\r\nbody\r\n",
+	} {
+		frontmatter, body := splitSkillDocument(t, document)
+		if frontmatter != "name: example\n" || body != "body\n" {
+			t.Fatalf("splitSkillDocument() = %q, %q", frontmatter, body)
+		}
+	}
 }
 
 func stringValue(value any) string {

--- a/internal/operatorskill/detent-operator-introspection/SKILL.md
+++ b/internal/operatorskill/detent-operator-introspection/SKILL.md
@@ -65,7 +65,7 @@ Call once:
 detent --format json issue '<issue-ref>' --explain --project '<project-id>'
 ```
 
-Stop: Treat `available` and `live` as current evidence. Label `last_known`, `expired`, `unavailable`, or `corrupt` evidence explicitly instead of presenting it as current.
+Stop: Treat only `live` evidence as current. Treat `available` as readable, then assess its observation, selection, heartbeat, and completion timestamps before describing it as current. Label `last_known`, `expired`, `unavailable`, or `corrupt` evidence explicitly.
 
 Escalate: Escalate when degraded or missing evidence prevents the requested conclusion. A successful response with degraded fields is still a success, not permission to use another data source.
 

--- a/internal/operatorskill/detent-operator-introspection/SKILL.md
+++ b/internal/operatorskill/detent-operator-introspection/SKILL.md
@@ -1,0 +1,86 @@
+---
+name: detent-operator-introspection
+description: Answer read-only operator questions about one issue in a running Detent instance, including its lane, latest transition, active work, eligibility, required gate, and evidence freshness. Use when asked why an issue is stuck, whether it is being worked, why it is not advancing, or how trustworthy Detent's current answer is.
+---
+
+# Detent operator introspection
+
+Bundle version: 1
+
+Expected response schema: 1
+
+Select the one question class that matches the request. Make its call once. The command returns one JSON object and enforces a request timeout and response-size limit. Keep diagnostics on stderr. Do not add filtering commands before inspecting the complete object.
+
+## Decision tree
+
+### Current lane or latest transition
+
+Use for questions such as "Why is this issue in this lane?" Read `current_lane` and `latest_transition`, including `from`, `to`, `reason`, `at`, and `provenance`.
+
+Call once:
+
+```sh
+detent --format json issue '<issue-ref>' --explain --project '<project-id>'
+```
+
+Stop: Report the lane and transition with their observation times when the evidence is available or live.
+
+Escalate: Ask the operator for the project ID or an unambiguous issue reference if either is missing. Escalate with the returned source limitations when no transition evidence supports a conclusion.
+
+### Active work
+
+Use for questions such as "Is this issue actually being worked on?" Read `attempt`, `sessions`, and their status, phase, heartbeat, completion, and source fields. Do not infer active work from the lane alone.
+
+Call once:
+
+```sh
+detent --format json issue '<issue-ref>' --explain --project '<project-id>'
+```
+
+Stop: Report whether the model shows a current attempt or session, and distinguish an absent record from unavailable evidence.
+
+Escalate: Escalate with the exact unavailable or stale source when the returned evidence cannot establish liveness.
+
+### Eligibility or required gate
+
+Use for questions such as "Why is this issue not advancing?" Read `eligibility`, `required_gate`, and their evidence references. Prefer recorded refusal, wait, and gate reasons over inference.
+
+Call once:
+
+```sh
+detent --format json issue '<issue-ref>' --explain --project '<project-id>'
+```
+
+Stop: Report the recorded eligibility and gate states and their reasons when the model supplies them.
+
+Escalate: Escalate with the unknown or unavailable fields when the model does not record a reason. Do not invent fleet policy to explain the gap.
+
+### Evidence confidence
+
+Use for questions such as "How current or trustworthy is this answer?" Read `observed_at`, `current_lane.freshness`, `current_lane.degraded`, `sources`, and `evidence`.
+
+Call once:
+
+```sh
+detent --format json issue '<issue-ref>' --explain --project '<project-id>'
+```
+
+Stop: Treat `available` and `live` as current evidence. Label `last_known`, `expired`, `unavailable`, or `corrupt` evidence explicitly instead of presenting it as current.
+
+Escalate: Escalate when degraded or missing evidence prevents the requested conclusion. A successful response with degraded fields is still a success, not permission to use another data source.
+
+## Interpret command outcomes
+
+- Success: Require `schema` to equal 1. Answer from the returned fields and cite degraded or last-known sources.
+- `dashboard_unauthorized` (HTTP 401): A supplied credential is invalid or expired. Stop; do not retry anonymously. Escalate for a valid supported read credential.
+- `dashboard_forbidden` (HTTP 403): The request is understood but not allowed. If the diagnostic identifies `api_token_required`, API access requires an operator-configured credential; this is not a missing issue. Otherwise the credential lacks the required read access. Stop and escalate without attempting to recover credential plaintext.
+- `ambiguous_reference`: The reference matches more than one issue. Stop and ask for an issue ID, canonical identifier, or full issue URL in the selected project.
+- `issue_not_found`: No issue matches the reference in the selected project. Stop and ask the operator to verify both values.
+- `runtime_unavailable`: The running service cannot currently build the explanation model. Stop this investigation; retry later, or escalate if an immediate answer is required.
+- `dashboard_unreachable` or `dashboard_timeout`: The service is stopped, unreachable, or unresponsive. Stop and escalate with the diagnostic.
+- `unsupported_model_version`: The CLI and running service do not share this response model. Stop and escalate for an upgrade or restart.
+- `dashboard_request_failed`: The service returned an unclassified failure. Stop and escalate with the diagnostic.
+
+## Boundaries
+
+Use only the read command above. Never substitute raw database access, dashboard HTML scraping, log searches, plaintext credential recovery, mutating commands, or proposal tools. Keep installation outside repository `.detent/skills` directories; those files are worker-task metadata, not ambient operator skills. Follow any fleet-specific process only from the operator's own workflow documentation.


### PR DESCRIPTION
## Summary

- embed a versioned, client-neutral Detent operator introspection skill
- provide one bounded read call per operator question class with stop and escalation guidance
- contract-test every named CLI flag and outcome against shipped catalogs while excluding unsafe surfaces

Fixes #1650

## UI Surface Contract

- [x] N/A; this PR does not change a UI surface.
- [x] This PR does not add persistent top-of-screen messaging.
- [x] This PR has no visual changes.

## Test Plan

- [x] skill `quick_validate.py`
- [x] `go test ./internal/operatorskill`
- [x] `make check`