### PR TITLE
feat(cli): add detent skill install

### DIFF
--- a/cmd/detent/main.go
+++ b/cmd/detent/main.go
@@ -115,6 +115,7 @@ func newRootCommandWithRestart(ctx context.Context, shutdownController *cli.Shut
 	cmd.AddCommand(
 		newVersionCommand(),
 		newUpdateCommand(ctx, newDefaultUpdateRunner),
+		newSkillCommand(build),
 		newShadowRunCommand(),
 	)
 	cli.ConfigureExamplesFirstHelp(cmd)

--- a/cmd/detent/skill.go
+++ b/cmd/detent/skill.go
@@ -85,11 +85,28 @@ func newSkillInstallCommand(deps skillInstallDeps) *cobra.Command {
 			if installErr == nil {
 				return nil
 			}
-			hint := "No files were changed. Review the reported path and retry."
-			if errors.Is(installErr, skillinstall.ErrConflict) {
-				hint = "Review the reported differences, then rerun with --force to create deterministic backups and replace managed files."
+			switch {
+			case errors.Is(installErr, skillinstall.ErrConflict):
+				return cli.NewValidationError(
+					installErr.Error(),
+					"Review the reported differences, then rerun with --force to create deterministic backups and replace managed files.",
+					nil,
+				)
+			case errors.Is(installErr, skillinstall.ErrUnsafePath):
+				return cli.NewValidationError(installErr.Error(), "No files were changed. Review the reported unsafe path and retry.", nil)
+			case result.Status == "rollback_failed":
+				return &cli.HintedError{
+					Err:     installErr,
+					Message: installErr.Error(),
+					Hint:    "Rollback did not restore every path. Inspect the reported rollback failures and repair the listed paths before retrying.",
+				}
+			default:
+				return &cli.HintedError{
+					Err:     installErr,
+					Message: installErr.Error(),
+					Hint:    "The installer rolled back completed actions. Review the operational error and retry when the filesystem is healthy.",
+				}
 			}
-			return cli.NewValidationError(installErr.Error(), hint, nil)
 		},
 	}
 	cmd.Flags().StringSliceVar(&targetValues, "target", nil, "agent client target: claude-code, codex, or antigravity (repeatable)")

--- a/cmd/detent/skill.go
+++ b/cmd/detent/skill.go
@@ -1,0 +1,132 @@
+package main
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/spf13/cobra"
+
+	"github.com/digitaldrywood/detent/internal/buildinfo"
+	"github.com/digitaldrywood/detent/internal/cli"
+	"github.com/digitaldrywood/detent/internal/skillinstall"
+)
+
+type skillInstallFunc func(skillinstall.Config) (skillinstall.Result, error)
+
+type skillInstallDeps struct {
+	homeDir func() (string, error)
+	install skillInstallFunc
+	build   buildinfo.Info
+}
+
+func newSkillCommand(build buildinfo.Info) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "skill",
+		Short:   "Manage Detent agent skills",
+		Example: "detent skill install --target codex --dry-run",
+	}
+	cmd.AddCommand(newSkillInstallCommand(skillInstallDeps{
+		homeDir: os.UserHomeDir,
+		install: skillinstall.Install,
+		build:   build,
+	}))
+	return cmd
+}
+
+func newSkillInstallCommand(deps skillInstallDeps) *cobra.Command {
+	var targetValues []string
+	var dryRun bool
+	var force bool
+
+	cmd := &cobra.Command{
+		Use:          "install",
+		Short:        "Install the embedded operator skill",
+		Example:      "detent skill install --target claude-code --target codex --dry-run",
+		Args:         cli.NoArgs,
+		SilenceUsage: true,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			if len(targetValues) == 0 {
+				return cli.NewValidationError("skill install --target is required", "Pass --target claude-code, --target codex, or --target antigravity.", nil)
+			}
+			targets, err := skillinstall.ParseTargets(targetValues)
+			if err != nil {
+				return cli.NewValidationError(err.Error(), "Use only claude-code, codex, or antigravity as target values.", nil)
+			}
+			if deps.homeDir == nil || deps.install == nil {
+				return errors.New("skill installer dependencies are incomplete")
+			}
+			home, err := deps.homeDir()
+			if err != nil {
+				return fmt.Errorf("resolve user home: %w", err)
+			}
+			roots, err := skillinstall.Roots(home)
+			if err != nil {
+				return cli.NewValidationError(err.Error(), "Use an absolute user home directory without symlink escapes.", nil)
+			}
+			out, err := cli.OutputForCommand(cmd)
+			if err != nil {
+				return err
+			}
+			result, installErr := deps.install(skillinstall.Config{
+				Roots:   roots,
+				Targets: targets,
+				Build:   deps.build,
+				DryRun:  dryRun,
+				Force:   force,
+			})
+			writeErr := out.Write(func(writer io.Writer) error {
+				return writeSkillInstallText(writer, result)
+			}, result)
+			if writeErr != nil {
+				return errors.Join(installErr, writeErr)
+			}
+			if installErr == nil {
+				return nil
+			}
+			hint := "No files were changed. Review the reported path and retry."
+			if errors.Is(installErr, skillinstall.ErrConflict) {
+				hint = "Review the reported differences, then rerun with --force to create deterministic backups and replace managed files."
+			}
+			return cli.NewValidationError(installErr.Error(), hint, nil)
+		},
+	}
+	cmd.Flags().StringSliceVar(&targetValues, "target", nil, "agent client target: claude-code, codex, or antigravity (repeatable)")
+	cmd.Flags().BoolVar(&dryRun, "dry-run", false, "plan and validate every action without writing files")
+	cmd.Flags().BoolVar(&force, "force", false, "back up and replace differing managed files")
+	return cmd
+}
+
+func writeSkillInstallText(writer io.Writer, result skillinstall.Result) error {
+	if _, err := fmt.Fprintf(
+		writer,
+		"skill: %s bundle=%d detent=%s status=%s\n",
+		result.Bundle.Name,
+		result.Bundle.Version,
+		result.Build.Version,
+		result.Status,
+	); err != nil {
+		return err
+	}
+	for _, target := range result.Targets {
+		if _, err := fmt.Fprintf(writer, "target: %s intent=%s status=%s destination=%s\n", target.Target, target.Intent, target.Status, target.Destination); err != nil {
+			return err
+		}
+	}
+	for _, action := range result.Actions {
+		path := action.Path
+		if action.BackupPath != "" {
+			path += " -> " + action.BackupPath
+		}
+		if _, err := fmt.Fprintf(writer, "action: %s %s %s [%s]\n", action.Target, action.Action, path, action.Status); err != nil {
+			return err
+		}
+	}
+	for _, action := range result.Rollback {
+		if _, err := fmt.Fprintf(writer, "rollback: %s %s %s [%s]\n", action.Target, action.Action, action.Path, action.Status); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/cmd/detent/skill_test.go
+++ b/cmd/detent/skill_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 
 	"github.com/digitaldrywood/detent/internal/buildinfo"
+	"github.com/digitaldrywood/detent/internal/cli"
 	"github.com/digitaldrywood/detent/internal/operatorskill"
 	"github.com/digitaldrywood/detent/internal/skillinstall"
 )
@@ -120,6 +121,46 @@ func TestSkillInstallCommandJSONConflictNeverPrompts(t *testing.T) {
 	got := readSkillCLIFile(t, skillPath)
 	if result.Status != "failed" || !bytes.Equal(got, modified) {
 		t.Fatalf("result = %#v, content = %q, want safe conflict", result, got)
+	}
+}
+
+func TestSkillInstallCommandPreservesOperationalFailureClassification(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		status   string
+		wantHint string
+		dontWant string
+	}{
+		{name: "rollback succeeded", status: "failed", wantHint: "rolled back completed actions", dontWant: "No files were changed"},
+		{name: "rollback failed", status: "rollback_failed", wantHint: "Rollback did not restore every path", dontWant: "No files were changed"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			cmd := newSkillInstallCommand(skillInstallDeps{
+				homeDir: func() (string, error) { return t.TempDir(), nil },
+				install: func(skillinstall.Config) (skillinstall.Result, error) {
+					return skillinstall.Result{Status: tt.status}, errors.New("disk write failed")
+				},
+			})
+			cmd.SetOut(&bytes.Buffer{})
+			cmd.SetErr(&bytes.Buffer{})
+			cmd.SetArgs([]string{"--target", "codex"})
+
+			err := cmd.ExecuteContext(context.Background())
+			if err == nil {
+				t.Fatal("ExecuteContext() error = nil, want operational error")
+			}
+			if got := cli.ExitCode(err); got != cli.ExitGeneral {
+				t.Fatalf("ExitCode() = %d, want %d", got, cli.ExitGeneral)
+			}
+			hint := cli.ErrorHint(err)
+			if !strings.Contains(hint, tt.wantHint) || strings.Contains(hint, tt.dontWant) {
+				t.Fatalf("hint = %q, want %q and not %q", hint, tt.wantHint, tt.dontWant)
+			}
+		})
 	}
 }
 

--- a/cmd/detent/skill_test.go
+++ b/cmd/detent/skill_test.go
@@ -1,0 +1,160 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/digitaldrywood/detent/internal/buildinfo"
+	"github.com/digitaldrywood/detent/internal/operatorskill"
+	"github.com/digitaldrywood/detent/internal/skillinstall"
+)
+
+func TestSkillInstallCommandRequiresExplicitTarget(t *testing.T) {
+	t.Parallel()
+
+	called := false
+	cmd := newSkillInstallCommand(skillInstallDeps{
+		homeDir: func() (string, error) { return t.TempDir(), nil },
+		install: func(skillinstall.Config) (skillinstall.Result, error) {
+			called = true
+			return skillinstall.Result{}, nil
+		},
+	})
+	cmd.SetOut(&bytes.Buffer{})
+	cmd.SetErr(&bytes.Buffer{})
+	cmd.SetArgs(nil)
+
+	err := cmd.ExecuteContext(context.Background())
+	if err == nil || !strings.Contains(err.Error(), "--target is required") {
+		t.Fatalf("ExecuteContext() error = %v, want required target", err)
+	}
+	if called {
+		t.Fatal("installer called without --target")
+	}
+}
+
+func TestSkillInstallCommandDryRunJSONListsEveryAction(t *testing.T) {
+	t.Parallel()
+
+	home := t.TempDir()
+	cmd := newSkillInstallCommand(skillInstallDeps{
+		homeDir: func() (string, error) { return home, nil },
+		install: skillinstall.Install,
+		build: buildinfo.Info{
+			Version: "v1.2.3",
+			Commit:  "abcdef1",
+			Date:    "2026-08-08T00:00:00Z",
+		},
+	})
+	var stdout bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&bytes.Buffer{})
+	cmd.SetArgs([]string{"--target", "antigravity", "--target", "claude-code", "--dry-run"})
+
+	if err := cmd.ExecuteContext(context.Background()); err != nil {
+		t.Fatalf("ExecuteContext() error = %v", err)
+	}
+	var result skillinstall.Result
+	if err := json.Unmarshal(stdout.Bytes(), &result); err != nil {
+		t.Fatalf("Unmarshal() error = %v\n%s", err, stdout.String())
+	}
+	if result.Status != "dry_run" || len(result.Targets) != 2 || len(result.Actions) == 0 {
+		t.Fatalf("result = %#v, want two-target dry run with actions", result)
+	}
+	for _, target := range result.Targets {
+		if _, err := os.Lstat(target.Destination); !errors.Is(err, os.ErrNotExist) {
+			t.Fatalf("dry-run destination %q exists or returned %v", target.Destination, err)
+		}
+		for _, name := range []string{operatorskill.SkillFile, skillinstall.ManifestFile} {
+			path := filepath.Join(target.Destination, name)
+			if !resultHasActionPath(result, path) {
+				t.Fatalf("result actions do not list %s: %#v", path, result.Actions)
+			}
+		}
+	}
+}
+
+func TestSkillInstallCommandJSONConflictNeverPrompts(t *testing.T) {
+	t.Parallel()
+
+	home := t.TempDir()
+	roots, err := skillinstall.Roots(home)
+	if err != nil {
+		t.Fatalf("Roots() error = %v", err)
+	}
+	destination := filepath.Join(roots[skillinstall.TargetCodex].Skills, operatorskill.Directory)
+	if err := os.MkdirAll(destination, 0o700); err != nil {
+		t.Fatalf("MkdirAll() error = %v", err)
+	}
+	skillPath := filepath.Join(destination, operatorskill.SkillFile)
+	modified := []byte("user content\n")
+	if err := os.WriteFile(skillPath, modified, 0o600); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+
+	cmd := newSkillInstallCommand(skillInstallDeps{
+		homeDir: func() (string, error) { return home, nil },
+		install: skillinstall.Install,
+		build:   buildinfo.Info{Version: "v1.2.3", Commit: "abcdef1", Date: "2026-08-08T00:00:00Z"},
+	})
+	var stdout bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&bytes.Buffer{})
+	cmd.SetIn(strings.NewReader("yes\n"))
+	cmd.SetArgs([]string{"--target", "codex"})
+
+	err = cmd.ExecuteContext(context.Background())
+	if err == nil || !strings.Contains(err.Error(), "--force") {
+		t.Fatalf("ExecuteContext() error = %v, want explicit --force hint", err)
+	}
+	var result skillinstall.Result
+	if decodeErr := json.Unmarshal(stdout.Bytes(), &result); decodeErr != nil {
+		t.Fatalf("Unmarshal() error = %v\n%s", decodeErr, stdout.String())
+	}
+	got := readSkillCLIFile(t, skillPath)
+	if result.Status != "failed" || !bytes.Equal(got, modified) {
+		t.Fatalf("result = %#v, content = %q, want safe conflict", result, got)
+	}
+}
+
+func TestRootCommandCatalogsSkillInstall(t *testing.T) {
+	t.Parallel()
+
+	root := newRootCommand(context.Background())
+	command, _, err := root.Find([]string{"skill", "install"})
+	if err != nil {
+		t.Fatalf("Find() error = %v", err)
+	}
+	if command == nil || command.CommandPath() != "detent skill install" {
+		t.Fatalf("command = %#v, want detent skill install", command)
+	}
+	for _, flag := range []string{"target", "dry-run", "force"} {
+		if command.Flags().Lookup(flag) == nil {
+			t.Fatalf("skill install does not catalog --%s", flag)
+		}
+	}
+}
+
+func resultHasActionPath(result skillinstall.Result, path string) bool {
+	for _, action := range result.Actions {
+		if action.Path == path || action.BackupPath == path {
+			return true
+		}
+	}
+	return false
+}
+
+func readSkillCLIFile(t *testing.T, path string) []byte {
+	t.Helper()
+	content, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile(%s) error = %v", path, err)
+	}
+	return content
+}

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -139,6 +139,7 @@ Structured command objects:
 | `detent auth token enable` / `detent auth token rotate` | `{"url":"https://detent.example.com/?token=..."}` |
 | `detent issue '#1643' --explain --project detent` | The exact versioned issue explanation DTO returned by the running service, with no wrapper. |
 | `detent state [--project detent]` | A bounded projection of the public state response, plus `truncation`; internal `board_issues` are excluded. |
+| `detent skill install --target codex --dry-run` | The complete skill install result, including bundle/build stamps, target intent and status, every planned filesystem action, and any rollback actions. |
 | `detent doctor` | `{"checks":[{"name":"Config resolution","status":"OK","detail":"...","hint":"..."}],"summary":{"ok":8,"warn":0,"fail":0},"result":"PASS"}` |
 
 ### MCP stdio server
@@ -162,6 +163,45 @@ include `generated_at` and `freshness`; last-known results also include
 The exposed tools are `board_state`, `fleet_health`, `telemetry_usage`,
 `recent_activity`, and `explain_item`. Names, descriptions, input schemas,
 limits, and result shapes come from the shared operator catalog and executor.
+
+### Operator skill installation
+
+`detent skill install` installs the embedded read-only operator introspection
+skill for explicitly selected local agent clients. `--target` is required and
+repeatable; supported values are `claude-code`, `codex`, and `antigravity`.
+
+| Target | Discovery scope | Deterministic installed entrypoint |
+| --- | --- | --- |
+| `claude-code` | Claude Code personal skill | `~/.claude/skills/detent-operator-introspection/SKILL.md` |
+| `codex` | Codex user skill | `~/.agents/skills/detent-operator-introspection/SKILL.md` |
+| `antigravity` | Antigravity global skill | `~/.gemini/config/skills/detent-operator-introspection/SKILL.md` |
+
+The locations intentionally follow each client's own discovery contract. The
+portable bundle body does not imply a shared client home layout, and the
+installer never writes repository `.detent/skills` worker metadata.
+
+Use `--dry-run` to validate all selected roots and print every directory,
+managed file, backup path, and action without writing. JSON output returns the
+same complete plan and result model. The command preflights every selected
+target before applying any action, so a conflict or unsafe path prevents all
+targets from changing.
+
+An exact reinstall is a no-op. A changed skill, changed install manifest,
+upgrade, downgrade, or partial prior install fails without `--force`; the
+command does not prompt in JSON mode. `--force` first creates deterministic
+content-addressed backups beside changed managed files, then atomically replaces
+only `SKILL.md` and `.detent-install.json`. Other files in the skill directory
+are preserved. If a later action fails, earlier managed-file and directory
+changes are rolled back across all selected targets, and rollback results are
+included in output.
+
+Every existing path component from the user home through the destination must
+be a real directory. Symlinked roots, directories, managed files, backup files,
+and lexical escapes are rejected. New directories use mode `0700`; managed and
+backup files use mode `0600`. The install manifest records the embedded bundle
+version and SHA-256 plus the running binary's resolved build version, commit,
+date, and dirty state. It contains no credentials, Detent config, or runtime
+filesystem paths.
 
 ### Issue explanation reads
 

--- a/internal/skillinstall/install.go
+++ b/internal/skillinstall/install.go
@@ -1,0 +1,709 @@
+package skillinstall
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+
+	"github.com/digitaldrywood/detent/internal/buildinfo"
+	"github.com/digitaldrywood/detent/internal/operatorskill"
+)
+
+const (
+	ManifestFile  = ".detent-install.json"
+	SchemaVersion = 1
+	fileMode      = 0o600
+	directoryMode = 0o700
+)
+
+var (
+	ErrConflict   = errors.New("installed skill content differs")
+	ErrUnsafePath = errors.New("unsafe skill install path")
+)
+
+type Target string
+
+const (
+	TargetClaudeCode  Target = "claude-code"
+	TargetCodex       Target = "codex"
+	TargetAntigravity Target = "antigravity"
+)
+
+type Compatibility struct {
+	Target       Target   `json:"target"`
+	Client       string   `json:"client"`
+	RootSegments []string `json:"root_segments"`
+	Discovery    string   `json:"discovery"`
+}
+
+type Root struct {
+	Base   string
+	Skills string
+}
+
+type Config struct {
+	Roots   map[Target]Root
+	Targets []Target
+	Build   buildinfo.Info
+	DryRun  bool
+	Force   bool
+}
+
+type Bundle struct {
+	Name    string `json:"name"`
+	Version int    `json:"version"`
+	SHA256  string `json:"sha256"`
+}
+
+type Manifest struct {
+	Schema        int            `json:"schema"`
+	Skill         string         `json:"skill"`
+	BundleVersion int            `json:"bundle_version"`
+	BundleSHA256  string         `json:"bundle_sha256"`
+	DetentBuild   buildinfo.Info `json:"detent_build"`
+}
+
+type Action struct {
+	Target     Target `json:"target"`
+	Action     string `json:"action"`
+	Path       string `json:"path"`
+	BackupPath string `json:"backup_path,omitempty"`
+	Status     string `json:"status"`
+	Error      string `json:"error,omitempty"`
+}
+
+type TargetResult struct {
+	Target      Target `json:"target"`
+	Root        string `json:"root"`
+	Destination string `json:"destination"`
+	Intent      string `json:"intent"`
+	Status      string `json:"status"`
+	Error       string `json:"error,omitempty"`
+}
+
+type Result struct {
+	Schema   int            `json:"schema"`
+	Status   string         `json:"status"`
+	DryRun   bool           `json:"dry_run"`
+	Forced   bool           `json:"forced"`
+	Bundle   Bundle         `json:"bundle"`
+	Build    buildinfo.Info `json:"build"`
+	Targets  []TargetResult `json:"targets"`
+	Actions  []Action       `json:"actions"`
+	Rollback []Action       `json:"rollback,omitempty"`
+}
+
+type plannedOperation struct {
+	actionIndex  int
+	targetIndex  int
+	kind         string
+	path         string
+	data         []byte
+	existed      bool
+	previous     []byte
+	mode         os.FileMode
+	previousMode os.FileMode
+}
+
+type installPlan struct {
+	result     Result
+	operations []plannedOperation
+}
+
+type fileOperations struct {
+	mkdir       func(string, os.FileMode) error
+	remove      func(string) error
+	atomicWrite func(string, []byte, os.FileMode) error
+}
+
+func CompatibilityMatrix() []Compatibility {
+	return []Compatibility{
+		{
+			Target:       TargetClaudeCode,
+			Client:       "Claude Code",
+			RootSegments: []string{".claude", "skills"},
+			Discovery:    "personal skills",
+		},
+		{
+			Target:       TargetCodex,
+			Client:       "Codex",
+			RootSegments: []string{".agents", "skills"},
+			Discovery:    "user skills",
+		},
+		{
+			Target:       TargetAntigravity,
+			Client:       "Antigravity",
+			RootSegments: []string{".gemini", "config", "skills"},
+			Discovery:    "global skills",
+		},
+	}
+}
+
+func Roots(home string) (map[Target]Root, error) {
+	home = filepath.Clean(strings.TrimSpace(home))
+	if home == "." || !filepath.IsAbs(home) {
+		return nil, fmt.Errorf("%w: user home must be absolute", ErrUnsafePath)
+	}
+	roots := make(map[Target]Root, len(CompatibilityMatrix()))
+	for _, compatibility := range CompatibilityMatrix() {
+		segments := append([]string{home}, compatibility.RootSegments...)
+		roots[compatibility.Target] = Root{
+			Base:   home,
+			Skills: filepath.Join(segments...),
+		}
+	}
+	return roots, nil
+}
+
+func ParseTargets(values []string) ([]Target, error) {
+	selected := make(map[Target]bool, len(values))
+	var errs []error
+	for _, value := range values {
+		target := Target(strings.ToLower(strings.TrimSpace(value)))
+		switch target {
+		case TargetClaudeCode, TargetCodex, TargetAntigravity:
+			selected[target] = true
+		default:
+			errs = append(errs, fmt.Errorf("unsupported skill target %q", value))
+		}
+	}
+	if len(errs) > 0 {
+		return nil, errors.Join(errs...)
+	}
+	targets := make([]Target, 0, len(selected))
+	for _, compatibility := range CompatibilityMatrix() {
+		if selected[compatibility.Target] {
+			targets = append(targets, compatibility.Target)
+		}
+	}
+	return targets, nil
+}
+
+func Install(config Config) (Result, error) {
+	return install(config, fileOperations{
+		mkdir:       os.Mkdir,
+		remove:      os.Remove,
+		atomicWrite: atomicWrite,
+	})
+}
+
+func install(config Config, operations fileOperations) (Result, error) {
+	plan, err := planInstall(config)
+	if err != nil {
+		return plan.result, err
+	}
+	if config.DryRun {
+		plan.result.Status = "dry_run"
+		for index := range plan.result.Targets {
+			plan.result.Targets[index].Status = "dry_run"
+		}
+		return plan.result, nil
+	}
+	return applyPlan(plan, operations)
+}
+
+func planInstall(config Config) (installPlan, error) {
+	bundleContent := operatorskill.Content()
+	bundleDigest := digest(bundleContent)
+	build := buildinfo.Normalize(config.Build)
+	manifestContent, err := encodeManifest(Manifest{
+		Schema:        SchemaVersion,
+		Skill:         operatorskill.Name,
+		BundleVersion: operatorskill.Version,
+		BundleSHA256:  bundleDigest,
+		DetentBuild:   build,
+	})
+	if err != nil {
+		return installPlan{}, fmt.Errorf("encode skill install manifest: %w", err)
+	}
+
+	plan := installPlan{result: Result{
+		Schema: SchemaVersion,
+		Status: "planned",
+		DryRun: config.DryRun,
+		Forced: config.Force,
+		Bundle: Bundle{Name: operatorskill.Name, Version: operatorskill.Version, SHA256: bundleDigest},
+		Build:  build,
+	}}
+	if len(config.Targets) == 0 {
+		plan.result.Status = "failed"
+		return plan, errors.New("at least one skill install target is required")
+	}
+
+	var planErrors []error
+	seen := make(map[Target]bool, len(config.Targets))
+	for _, target := range config.Targets {
+		if seen[target] {
+			continue
+		}
+		seen[target] = true
+		root, ok := config.Roots[target]
+		if !ok {
+			planErrors = append(planErrors, fmt.Errorf("%s: target root is not configured", target))
+			continue
+		}
+		targetIndex := len(plan.result.Targets)
+		targetPlanErr := planTarget(&plan, targetIndex, target, root, config.Force, bundleContent, manifestContent)
+		if targetPlanErr != nil {
+			planErrors = append(planErrors, targetPlanErr)
+		}
+	}
+
+	if len(planErrors) > 0 {
+		plan.result.Status = "failed"
+		for index := range plan.result.Targets {
+			if plan.result.Targets[index].Status == "planned" {
+				plan.result.Targets[index].Status = "not_applied"
+			}
+		}
+		for index := range plan.result.Actions {
+			if plan.result.Actions[index].Status == "planned" {
+				plan.result.Actions[index].Status = "not_applied"
+			}
+		}
+		return plan, errors.Join(planErrors...)
+	}
+	return plan, nil
+}
+
+func planTarget(plan *installPlan, targetIndex int, target Target, root Root, force bool, bundleContent []byte, manifestContent []byte) error {
+	base := filepath.Clean(strings.TrimSpace(root.Base))
+	skillsRoot := filepath.Clean(strings.TrimSpace(root.Skills))
+	destination := filepath.Join(skillsRoot, operatorskill.Directory)
+	targetResult := TargetResult{
+		Target:      target,
+		Root:        skillsRoot,
+		Destination: destination,
+		Status:      "planned",
+	}
+	plan.result.Targets = append(plan.result.Targets, targetResult)
+
+	if !filepath.IsAbs(base) || !filepath.IsAbs(skillsRoot) || !within(base, skillsRoot) || !within(skillsRoot, destination) {
+		err := fmt.Errorf("%w: %s destination escapes its configured root", ErrUnsafePath, target)
+		plan.reject(targetIndex, destination, err)
+		return err
+	}
+	if err := requireDirectory(base); err != nil {
+		wrapped := fmt.Errorf("%w: %s base %s: %w", ErrUnsafePath, target, base, err)
+		plan.reject(targetIndex, base, wrapped)
+		return wrapped
+	}
+	if err := planDirectories(plan, targetIndex, target, base, destination); err != nil {
+		plan.reject(targetIndex, destination, err)
+		return err
+	}
+
+	expected := []struct {
+		name string
+		data []byte
+	}{
+		{name: operatorskill.SkillFile, data: bundleContent},
+		{name: ManifestFile, data: manifestContent},
+	}
+	existing := make(map[string][]byte, len(expected))
+	existingModes := make(map[string]os.FileMode, len(expected))
+	for _, file := range expected {
+		path := filepath.Join(destination, file.name)
+		data, mode, found, readErr := readRegularFile(path)
+		if readErr != nil {
+			err := fmt.Errorf("%w: %s: %w", ErrUnsafePath, path, readErr)
+			plan.reject(targetIndex, path, err)
+			return err
+		}
+		if found {
+			existing[file.name] = data
+			existingModes[file.name] = mode
+		}
+	}
+	plan.result.Targets[targetIndex].Intent = classifyIntent(existing, bundleContent, manifestContent)
+
+	var targetErrors []error
+	for _, file := range expected {
+		path := filepath.Join(destination, file.name)
+		current, found := existing[file.name]
+		if found && bytes.Equal(current, file.data) && safeFileMode(existingModes[file.name]) {
+			plan.result.Actions = append(plan.result.Actions, Action{
+				Target: target,
+				Action: "noop",
+				Path:   path,
+				Status: "unchanged",
+			})
+			continue
+		}
+		if found && bytes.Equal(current, file.data) {
+			actionIndex := len(plan.result.Actions)
+			plan.result.Actions = append(plan.result.Actions, Action{
+				Target: target,
+				Action: "secure_permissions",
+				Path:   path,
+				Status: "planned",
+			})
+			plan.operations = append(plan.operations, plannedOperation{
+				actionIndex:  actionIndex,
+				targetIndex:  targetIndex,
+				kind:         "file",
+				path:         path,
+				data:         file.data,
+				existed:      true,
+				previous:     slices.Clone(current),
+				mode:         fileMode,
+				previousMode: existingModes[file.name],
+			})
+			continue
+		}
+		if found && !force {
+			err := fmt.Errorf("%w at %s", ErrConflict, path)
+			plan.result.Actions = append(plan.result.Actions, Action{
+				Target: target,
+				Action: "conflict",
+				Path:   path,
+				Status: "failed",
+				Error:  err.Error(),
+			})
+			plan.result.Targets[targetIndex].Status = "failed"
+			plan.result.Targets[targetIndex].Error = err.Error()
+			targetErrors = append(targetErrors, err)
+			continue
+		}
+		if found {
+			backupPath := backupPath(path, current)
+			backup, backupMode, backupFound, backupErr := readRegularFile(backupPath)
+			if backupErr != nil {
+				err := fmt.Errorf("%w: backup %s: %w", ErrUnsafePath, backupPath, backupErr)
+				plan.reject(targetIndex, backupPath, err)
+				targetErrors = append(targetErrors, err)
+				continue
+			}
+			if backupFound && !bytes.Equal(backup, current) {
+				err := fmt.Errorf("%w: backup path %s does not match its content digest", ErrConflict, backupPath)
+				plan.reject(targetIndex, backupPath, err)
+				targetErrors = append(targetErrors, err)
+				continue
+			}
+			if backupFound && !safeFileMode(backupMode) {
+				err := fmt.Errorf("%w: backup path %s has mode %o, want %o", ErrUnsafePath, backupPath, backupMode.Perm(), fileMode)
+				plan.reject(targetIndex, backupPath, err)
+				targetErrors = append(targetErrors, err)
+				continue
+			}
+			status := "planned"
+			if backupFound {
+				status = "unchanged"
+			}
+			actionIndex := len(plan.result.Actions)
+			plan.result.Actions = append(plan.result.Actions, Action{
+				Target:     target,
+				Action:     "backup",
+				Path:       path,
+				BackupPath: backupPath,
+				Status:     status,
+			})
+			if !backupFound {
+				plan.operations = append(plan.operations, plannedOperation{
+					actionIndex: actionIndex,
+					targetIndex: targetIndex,
+					kind:        "file",
+					path:        backupPath,
+					data:        current,
+					mode:        fileMode,
+				})
+			}
+		}
+		actionIndex := len(plan.result.Actions)
+		plan.result.Actions = append(plan.result.Actions, Action{
+			Target: target,
+			Action: "write",
+			Path:   path,
+			Status: "planned",
+		})
+		plan.operations = append(plan.operations, plannedOperation{
+			actionIndex:  actionIndex,
+			targetIndex:  targetIndex,
+			kind:         "file",
+			path:         path,
+			data:         file.data,
+			existed:      found,
+			previous:     slices.Clone(current),
+			mode:         fileMode,
+			previousMode: existingModes[file.name],
+		})
+	}
+	return errors.Join(targetErrors...)
+}
+
+func planDirectories(plan *installPlan, targetIndex int, target Target, base string, destination string) error {
+	relative, err := filepath.Rel(base, destination)
+	if err != nil || relative == "." || strings.HasPrefix(relative, ".."+string(filepath.Separator)) || relative == ".." {
+		return fmt.Errorf("%w: destination %s is not beneath %s", ErrUnsafePath, destination, base)
+	}
+	current := base
+	for _, segment := range strings.Split(relative, string(filepath.Separator)) {
+		if segment == "" || segment == "." || segment == ".." {
+			return fmt.Errorf("%w: invalid path segment %q", ErrUnsafePath, segment)
+		}
+		current = filepath.Join(current, segment)
+		info, statErr := os.Lstat(current)
+		switch {
+		case statErr == nil && info.Mode()&os.ModeSymlink != 0:
+			return fmt.Errorf("%w: symlink path component %s", ErrUnsafePath, current)
+		case statErr == nil && !info.IsDir():
+			return fmt.Errorf("%w: non-directory path component %s", ErrUnsafePath, current)
+		case statErr == nil:
+			plan.result.Actions = append(plan.result.Actions, Action{Target: target, Action: "ensure_directory", Path: current, Status: "unchanged"})
+		case errors.Is(statErr, os.ErrNotExist):
+			actionIndex := len(plan.result.Actions)
+			plan.result.Actions = append(plan.result.Actions, Action{Target: target, Action: "ensure_directory", Path: current, Status: "planned"})
+			plan.operations = append(plan.operations, plannedOperation{
+				actionIndex: actionIndex,
+				targetIndex: targetIndex,
+				kind:        "directory",
+				path:        current,
+				mode:        directoryMode,
+			})
+		default:
+			return fmt.Errorf("inspect path component %s: %w", current, statErr)
+		}
+	}
+	return nil
+}
+
+func applyPlan(plan installPlan, operations fileOperations) (Result, error) {
+	if operations.mkdir == nil || operations.remove == nil || operations.atomicWrite == nil {
+		return plan.result, errors.New("skill installer file operations are incomplete")
+	}
+	applied := make([]plannedOperation, 0, len(plan.operations))
+	for _, operation := range plan.operations {
+		var err error
+		switch operation.kind {
+		case "directory":
+			err = operations.mkdir(operation.path, operation.mode)
+		case "file":
+			err = operations.atomicWrite(operation.path, operation.data, normalizedMode(operation.mode))
+		default:
+			err = fmt.Errorf("unknown install operation %q", operation.kind)
+		}
+		if err != nil {
+			plan.result.Status = "failed"
+			plan.result.Actions[operation.actionIndex].Status = "failed"
+			plan.result.Actions[operation.actionIndex].Error = err.Error()
+			plan.result.Targets[operation.targetIndex].Status = "failed"
+			plan.result.Targets[operation.targetIndex].Error = err.Error()
+			rollbackErr := rollback(&plan.result, applied, operations)
+			if rollbackErr != nil {
+				plan.result.Status = "rollback_failed"
+			}
+			for index := range plan.result.Actions {
+				if plan.result.Actions[index].Status == "planned" {
+					plan.result.Actions[index].Status = "not_applied"
+				}
+			}
+			for index := range plan.result.Targets {
+				if plan.result.Targets[index].Status == "planned" {
+					plan.result.Targets[index].Status = "not_applied"
+				}
+			}
+			return plan.result, errors.Join(fmt.Errorf("apply skill install operation %s: %w", operation.path, err), rollbackErr)
+		}
+		plan.result.Actions[operation.actionIndex].Status = "completed"
+		applied = append(applied, operation)
+	}
+
+	plan.result.Status = "complete"
+	for index := range plan.result.Targets {
+		status := "unchanged"
+		for _, action := range plan.result.Actions {
+			if action.Target == plan.result.Targets[index].Target && action.Status == "completed" {
+				status = "installed"
+				break
+			}
+		}
+		plan.result.Targets[index].Status = status
+	}
+	return plan.result, nil
+}
+
+func rollback(result *Result, applied []plannedOperation, operations fileOperations) error {
+	var rollbackErrors []error
+	for index := len(applied) - 1; index >= 0; index-- {
+		operation := applied[index]
+		action := Action{
+			Target: result.Targets[operation.targetIndex].Target,
+			Path:   operation.path,
+			Status: "completed",
+		}
+		var err error
+		switch {
+		case operation.kind == "directory":
+			action.Action = "remove_directory"
+			err = operations.remove(operation.path)
+		case operation.existed:
+			action.Action = "restore"
+			err = operations.atomicWrite(operation.path, operation.previous, normalizedMode(operation.previousMode))
+		default:
+			action.Action = "remove"
+			err = operations.remove(operation.path)
+		}
+		if err != nil && (operation.kind != "directory" || !errors.Is(err, os.ErrNotExist)) {
+			action.Status = "failed"
+			action.Error = err.Error()
+			rollbackErrors = append(rollbackErrors, fmt.Errorf("rollback %s: %w", operation.path, err))
+		}
+		result.Rollback = append(result.Rollback, action)
+		if result.Targets[operation.targetIndex].Status != "failed" {
+			result.Targets[operation.targetIndex].Status = "rolled_back"
+		}
+	}
+	return errors.Join(rollbackErrors...)
+}
+
+func (plan *installPlan) reject(targetIndex int, path string, err error) {
+	target := plan.result.Targets[targetIndex].Target
+	plan.result.Actions = append(plan.result.Actions, Action{
+		Target: target,
+		Action: "reject",
+		Path:   path,
+		Status: "failed",
+		Error:  err.Error(),
+	})
+	plan.result.Targets[targetIndex].Status = "failed"
+	plan.result.Targets[targetIndex].Error = err.Error()
+}
+
+func classifyIntent(existing map[string][]byte, bundleContent []byte, manifestContent []byte) string {
+	if len(existing) == 0 {
+		return "install"
+	}
+	if bytes.Equal(existing[operatorskill.SkillFile], bundleContent) && bytes.Equal(existing[ManifestFile], manifestContent) {
+		return "reinstall"
+	}
+	var manifest Manifest
+	if raw, ok := existing[ManifestFile]; ok && json.Unmarshal(raw, &manifest) == nil && manifest.Skill == operatorskill.Name {
+		switch {
+		case manifest.BundleVersion < operatorskill.Version:
+			return "upgrade"
+		case manifest.BundleVersion > operatorskill.Version:
+			return "downgrade"
+		}
+	}
+	return "repair"
+}
+
+func encodeManifest(manifest Manifest) ([]byte, error) {
+	var buffer bytes.Buffer
+	encoder := json.NewEncoder(&buffer)
+	encoder.SetIndent("", "  ")
+	if err := encoder.Encode(manifest); err != nil {
+		return nil, err
+	}
+	return buffer.Bytes(), nil
+}
+
+func requireDirectory(path string) error {
+	info, err := os.Lstat(path)
+	if err != nil {
+		return err
+	}
+	if info.Mode()&os.ModeSymlink != 0 {
+		return errors.New("is a symlink")
+	}
+	if !info.IsDir() {
+		return errors.New("is not a directory")
+	}
+	return nil
+}
+
+func readRegularFile(path string) ([]byte, os.FileMode, bool, error) {
+	info, err := os.Lstat(path)
+	if errors.Is(err, os.ErrNotExist) {
+		return nil, 0, false, nil
+	}
+	if err != nil {
+		return nil, 0, false, err
+	}
+	if info.Mode()&os.ModeSymlink != 0 {
+		return nil, 0, false, errors.New("is a symlink")
+	}
+	if !info.Mode().IsRegular() {
+		return nil, 0, false, errors.New("is not a regular file")
+	}
+	file, err := os.Open(path)
+	if err != nil {
+		return nil, 0, false, err
+	}
+	data, readErr := io.ReadAll(file)
+	openedInfo, statErr := file.Stat()
+	closeErr := file.Close()
+	if readErr != nil || statErr != nil || closeErr != nil {
+		return nil, 0, false, errors.Join(readErr, statErr, closeErr)
+	}
+	if !os.SameFile(info, openedInfo) {
+		return nil, 0, false, errors.New("changed while being inspected")
+	}
+	return data, info.Mode().Perm(), true, nil
+}
+
+func backupPath(path string, content []byte) string {
+	return path + ".detent-backup-" + digest(content)[:16]
+}
+
+func digest(content []byte) string {
+	sum := sha256.Sum256(content)
+	return hex.EncodeToString(sum[:])
+}
+
+func within(base string, path string) bool {
+	relative, err := filepath.Rel(base, path)
+	if err != nil {
+		return false
+	}
+	return relative == "." || (relative != ".." && !strings.HasPrefix(relative, ".."+string(filepath.Separator)))
+}
+
+func normalizedMode(mode os.FileMode) os.FileMode {
+	if mode.Perm() == 0 {
+		return fileMode
+	}
+	return mode.Perm()
+}
+
+func atomicWrite(path string, content []byte, mode os.FileMode) (returnErr error) {
+	directory := filepath.Dir(path)
+	temporary, err := os.CreateTemp(directory, ".detent-skill-install-*")
+	if err != nil {
+		return err
+	}
+	temporaryPath := temporary.Name()
+	defer func() {
+		if temporaryPath == "" {
+			return
+		}
+		if cleanupErr := os.Remove(temporaryPath); cleanupErr != nil && !errors.Is(cleanupErr, os.ErrNotExist) {
+			returnErr = errors.Join(returnErr, fmt.Errorf("remove temporary file: %w", cleanupErr))
+		}
+	}()
+	if err := temporary.Chmod(normalizedMode(mode)); err != nil {
+		return errors.Join(err, temporary.Close())
+	}
+	if _, err := temporary.Write(content); err != nil {
+		return errors.Join(err, temporary.Close())
+	}
+	if err := temporary.Sync(); err != nil {
+		return errors.Join(err, temporary.Close())
+	}
+	if err := temporary.Close(); err != nil {
+		return err
+	}
+	if err := replaceFile(temporaryPath, path); err != nil {
+		return err
+	}
+	temporaryPath = ""
+	return nil
+}

--- a/internal/skillinstall/install.go
+++ b/internal/skillinstall/install.go
@@ -555,9 +555,11 @@ func rollback(result *Result, applied []plannedOperation, operations fileOperati
 			action.Status = "failed"
 			action.Error = err.Error()
 			rollbackErrors = append(rollbackErrors, fmt.Errorf("rollback %s: %w", operation.path, err))
+			result.Targets[operation.targetIndex].Status = "rollback_failed"
+			result.Targets[operation.targetIndex].Error = err.Error()
 		}
 		result.Rollback = append(result.Rollback, action)
-		if result.Targets[operation.targetIndex].Status != "failed" {
+		if result.Targets[operation.targetIndex].Status != "failed" && result.Targets[operation.targetIndex].Status != "rollback_failed" {
 			result.Targets[operation.targetIndex].Status = "rolled_back"
 		}
 	}

--- a/internal/skillinstall/install_test.go
+++ b/internal/skillinstall/install_test.go
@@ -564,6 +564,50 @@ func TestInstallRollsBackPartialMultiTargetFailure(t *testing.T) {
 	}
 }
 
+func TestInstallReportsRollbackFailurePerTarget(t *testing.T) {
+	t.Parallel()
+
+	config := testConfig(t, TargetClaudeCode, TargetCodex)
+	writeFailed := false
+	claudeSkill := filepath.Join(config.Roots[TargetClaudeCode].Skills, operatorskill.Directory, operatorskill.SkillFile)
+	result, err := install(config, fileOperations{
+		mkdir: os.Mkdir,
+		remove: func(path string) error {
+			if path == claudeSkill {
+				return errors.New("injected rollback failure")
+			}
+			return os.Remove(path)
+		},
+		atomicWrite: func(path string, content []byte, mode os.FileMode) error {
+			codexSkill := filepath.Join(config.Roots[TargetCodex].Skills, operatorskill.Directory, operatorskill.SkillFile)
+			if path == codexSkill && !writeFailed {
+				writeFailed = true
+				return errors.New("injected write failure")
+			}
+			return atomicWrite(path, content, mode)
+		},
+	})
+	if err == nil || !strings.Contains(err.Error(), "injected rollback failure") {
+		t.Fatalf("install() error = %v, want rollback failure", err)
+	}
+	if result.Status != "rollback_failed" || result.Targets[0].Status != "rollback_failed" {
+		t.Fatalf("result = %#v, want first target and result rollback_failed", result)
+	}
+	if result.Targets[1].Status != "failed" {
+		t.Fatalf("failed apply target status = %q, want failed", result.Targets[1].Status)
+	}
+	rollbackFailure := false
+	for _, action := range result.Rollback {
+		if action.Target == TargetClaudeCode && action.Status == "failed" {
+			rollbackFailure = true
+			break
+		}
+	}
+	if !rollbackFailure {
+		t.Fatalf("rollback actions = %#v, want failed Claude Code rollback", result.Rollback)
+	}
+}
+
 func testConfig(t *testing.T, targets ...Target) Config {
 	t.Helper()
 	home := t.TempDir()

--- a/internal/skillinstall/install_test.go
+++ b/internal/skillinstall/install_test.go
@@ -1,0 +1,634 @@
+package skillinstall
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"runtime"
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/digitaldrywood/detent/internal/buildinfo"
+	"github.com/digitaldrywood/detent/internal/operatorskill"
+)
+
+var testBuild = buildinfo.Info{
+	Version: "v1.2.3",
+	Commit:  "abcdef1234567890",
+	Date:    "2026-08-08T00:00:00Z",
+}
+
+func TestCompatibilityMatrix(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		target    Target
+		client    string
+		segments  []string
+		discovery string
+	}{
+		{target: TargetClaudeCode, client: "Claude Code", segments: []string{".claude", "skills"}, discovery: "personal skills"},
+		{target: TargetCodex, client: "Codex", segments: []string{".agents", "skills"}, discovery: "user skills"},
+		{target: TargetAntigravity, client: "Antigravity", segments: []string{".gemini", "config", "skills"}, discovery: "global skills"},
+	}
+	matrix := CompatibilityMatrix()
+	if len(matrix) != len(tests) {
+		t.Fatalf("CompatibilityMatrix() length = %d, want %d", len(matrix), len(tests))
+	}
+	for index, tt := range tests {
+		got := matrix[index]
+		if got.Target != tt.target || got.Client != tt.client || !slices.Equal(got.RootSegments, tt.segments) || got.Discovery != tt.discovery {
+			t.Fatalf("CompatibilityMatrix()[%d] = %#v, want target=%q client=%q segments=%q discovery=%q", index, got, tt.target, tt.client, tt.segments, tt.discovery)
+		}
+	}
+}
+
+func TestRootsUseInjectedHome(t *testing.T) {
+	t.Parallel()
+
+	home := t.TempDir()
+	roots, err := Roots(home)
+	if err != nil {
+		t.Fatalf("Roots() error = %v", err)
+	}
+	tests := []struct {
+		target Target
+		want   string
+	}{
+		{target: TargetClaudeCode, want: filepath.Join(home, ".claude", "skills")},
+		{target: TargetCodex, want: filepath.Join(home, ".agents", "skills")},
+		{target: TargetAntigravity, want: filepath.Join(home, ".gemini", "config", "skills")},
+	}
+	for _, tt := range tests {
+		t.Run(string(tt.target), func(t *testing.T) {
+			t.Parallel()
+			if got := roots[tt.target]; got.Base != home || got.Skills != tt.want {
+				t.Fatalf("root = %#v, want base %q skills %q", got, home, tt.want)
+			}
+		})
+	}
+}
+
+func TestParseTargets(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		values  []string
+		want    []Target
+		wantErr bool
+	}{
+		{name: "matrix order and deduplication", values: []string{"antigravity", "codex", "claude-code", "codex"}, want: []Target{TargetClaudeCode, TargetCodex, TargetAntigravity}},
+		{name: "case and whitespace", values: []string{" Codex ", "CLAUDE-CODE"}, want: []Target{TargetClaudeCode, TargetCodex}},
+		{name: "path traversal", values: []string{"../codex"}, wantErr: true},
+		{name: "absolute path", values: []string{"/tmp/codex"}, wantErr: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := ParseTargets(tt.values)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("ParseTargets() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if !slices.Equal(got, tt.want) {
+				t.Fatalf("ParseTargets() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestInstallWritesDeterministicTargetPaths(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		target Target
+	}{
+		{target: TargetClaudeCode},
+		{target: TargetCodex},
+		{target: TargetAntigravity},
+	}
+	for _, tt := range tests {
+		t.Run(string(tt.target), func(t *testing.T) {
+			t.Parallel()
+			config := testConfig(t, tt.target)
+			result, err := Install(config)
+			if err != nil {
+				t.Fatalf("Install() error = %v", err)
+			}
+			if result.Status != "complete" || len(result.Targets) != 1 || result.Targets[0].Status != "installed" || result.Targets[0].Intent != "install" {
+				t.Fatalf("result = %#v, want completed install", result)
+			}
+
+			destination := filepath.Join(config.Roots[tt.target].Skills, operatorskill.Directory)
+			assertFile(t, filepath.Join(destination, operatorskill.SkillFile), operatorskill.Content(), fileMode)
+			manifestPath := filepath.Join(destination, ManifestFile)
+			manifestRaw := readFile(t, manifestPath)
+			var manifest Manifest
+			if err := json.Unmarshal(manifestRaw, &manifest); err != nil {
+				t.Fatalf("Unmarshal(%s) error = %v", manifestPath, err)
+			}
+			if manifest.Schema != SchemaVersion || manifest.Skill != operatorskill.Name || manifest.BundleVersion != operatorskill.Version || manifest.BundleSHA256 != digest(operatorskill.Content()) || manifest.DetentBuild != testBuild {
+				t.Fatalf("manifest = %#v, want embedded bundle and build stamp", manifest)
+			}
+			if bytes.Contains(manifestRaw, []byte(config.Roots[tt.target].Base)) {
+				t.Fatalf("manifest contains runtime path %q", config.Roots[tt.target].Base)
+			}
+			assertFileMode(t, manifestPath, fileMode)
+			assertFileMode(t, destination, directoryMode)
+			if strings.Contains(destination, filepath.Join(".detent", "skills")) {
+				t.Fatalf("destination %q uses worker metadata", destination)
+			}
+			assertActionsCoverManagedPaths(t, result, destination)
+		})
+	}
+}
+
+func TestInstallDryRunAndIdempotency(t *testing.T) {
+	t.Parallel()
+
+	config := testConfig(t, TargetClaudeCode, TargetCodex, TargetAntigravity)
+	dryRunConfig := config
+	dryRunConfig.DryRun = true
+	dryRun, err := Install(dryRunConfig)
+	if err != nil {
+		t.Fatalf("Install(dry run) error = %v", err)
+	}
+	if dryRun.Status != "dry_run" || len(dryRun.Targets) != 3 {
+		t.Fatalf("dry run result = %#v", dryRun)
+	}
+	for _, target := range dryRun.Targets {
+		if target.Status != "dry_run" {
+			t.Fatalf("target %q status = %q, want dry_run", target.Target, target.Status)
+		}
+		if _, statErr := os.Lstat(target.Destination); !errors.Is(statErr, os.ErrNotExist) {
+			t.Fatalf("dry run destination %q exists or returned %v", target.Destination, statErr)
+		}
+	}
+
+	if _, err := Install(config); err != nil {
+		t.Fatalf("Install() error = %v", err)
+	}
+	result, err := Install(config)
+	if err != nil {
+		t.Fatalf("Install(reinstall) error = %v", err)
+	}
+	if result.Status != "complete" {
+		t.Fatalf("reinstall status = %q, want complete", result.Status)
+	}
+	for _, target := range result.Targets {
+		if target.Intent != "reinstall" || target.Status != "unchanged" {
+			t.Fatalf("reinstall target = %#v, want unchanged reinstall", target)
+		}
+	}
+	for _, action := range result.Actions {
+		if action.Status == "completed" || action.Action == "write" || action.Action == "backup" {
+			t.Fatalf("idempotent reinstall action = %#v", action)
+		}
+	}
+}
+
+func TestInstallRefusesDifferingManagedContent(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		file string
+	}{
+		{name: "modified skill", file: operatorskill.SkillFile},
+		{name: "modified manifest", file: ManifestFile},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			config := testConfig(t, TargetCodex)
+			if _, err := Install(config); err != nil {
+				t.Fatalf("Install() error = %v", err)
+			}
+			destination := filepath.Join(config.Roots[TargetCodex].Skills, operatorskill.Directory)
+			path := filepath.Join(destination, tt.file)
+			modified := []byte("user-modified\n")
+			if err := os.WriteFile(path, modified, fileMode); err != nil {
+				t.Fatalf("WriteFile() error = %v", err)
+			}
+
+			result, err := Install(config)
+			if !errors.Is(err, ErrConflict) {
+				t.Fatalf("Install() error = %v, want %v", err, ErrConflict)
+			}
+			if result.Status != "failed" || result.Targets[0].Status != "failed" {
+				t.Fatalf("result = %#v, want failed conflict", result)
+			}
+			if got := readFile(t, path); !bytes.Equal(got, modified) {
+				t.Fatalf("modified content = %q, want preserved %q", got, modified)
+			}
+			matches, globErr := filepath.Glob(path + ".detent-backup-*")
+			if globErr != nil || len(matches) != 0 {
+				t.Fatalf("backup matches = %q, error = %v, want none", matches, globErr)
+			}
+		})
+	}
+}
+
+func TestInstallPreflightsEveryTargetBeforeWriting(t *testing.T) {
+	t.Parallel()
+
+	config := testConfig(t, TargetClaudeCode, TargetCodex)
+	codexDestination := filepath.Join(config.Roots[TargetCodex].Skills, operatorskill.Directory)
+	if err := os.MkdirAll(codexDestination, directoryMode); err != nil {
+		t.Fatalf("MkdirAll() error = %v", err)
+	}
+	modified := []byte("existing user skill\n")
+	if err := os.WriteFile(filepath.Join(codexDestination, operatorskill.SkillFile), modified, fileMode); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+
+	result, err := Install(config)
+	if !errors.Is(err, ErrConflict) {
+		t.Fatalf("Install() error = %v, want %v", err, ErrConflict)
+	}
+	claudeDestination := filepath.Join(config.Roots[TargetClaudeCode].Skills, operatorskill.Directory)
+	if _, statErr := os.Lstat(claudeDestination); !errors.Is(statErr, os.ErrNotExist) {
+		t.Fatalf("first target destination exists or returned %v", statErr)
+	}
+	if got := readFile(t, filepath.Join(codexDestination, operatorskill.SkillFile)); !bytes.Equal(got, modified) {
+		t.Fatalf("conflicting target changed to %q", got)
+	}
+	if result.Targets[0].Status != "not_applied" || result.Targets[1].Status != "failed" {
+		t.Fatalf("target results = %#v, want not_applied then failed", result.Targets)
+	}
+}
+
+func TestInstallForceBacksUpAndPreservesUnrelatedFiles(t *testing.T) {
+	t.Parallel()
+
+	config := testConfig(t, TargetAntigravity)
+	if _, err := Install(config); err != nil {
+		t.Fatalf("Install() error = %v", err)
+	}
+	destination := filepath.Join(config.Roots[TargetAntigravity].Skills, operatorskill.Directory)
+	skillPath := filepath.Join(destination, operatorskill.SkillFile)
+	modified := []byte("user-modified skill\n")
+	if err := os.WriteFile(skillPath, modified, 0o644); err != nil {
+		t.Fatalf("WriteFile(skill) error = %v", err)
+	}
+	unrelatedPath := filepath.Join(destination, "operator-notes.md")
+	unrelated := []byte("preserve me\n")
+	if err := os.WriteFile(unrelatedPath, unrelated, 0o644); err != nil {
+		t.Fatalf("WriteFile(unrelated) error = %v", err)
+	}
+
+	config.Force = true
+	result, err := Install(config)
+	if err != nil {
+		t.Fatalf("Install(force) error = %v", err)
+	}
+	if result.Targets[0].Intent != "repair" || result.Targets[0].Status != "installed" {
+		t.Fatalf("target result = %#v, want installed repair", result.Targets[0])
+	}
+	assertFile(t, skillPath, operatorskill.Content(), fileMode)
+	assertFile(t, backupPath(skillPath, modified), modified, fileMode)
+	assertFile(t, unrelatedPath, unrelated, 0o644)
+}
+
+func TestInstallSecuresExactManagedFilePermissions(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Windows does not expose POSIX permission bits")
+	}
+	t.Parallel()
+
+	config := testConfig(t, TargetCodex)
+	if _, err := Install(config); err != nil {
+		t.Fatalf("Install() error = %v", err)
+	}
+	destination := filepath.Join(config.Roots[TargetCodex].Skills, operatorskill.Directory)
+	skillPath := filepath.Join(destination, operatorskill.SkillFile)
+	if err := os.Chmod(skillPath, 0o644); err != nil {
+		t.Fatalf("Chmod() error = %v", err)
+	}
+
+	result, err := Install(config)
+	if err != nil {
+		t.Fatalf("Install(reinstall) error = %v", err)
+	}
+	if result.Targets[0].Intent != "reinstall" || result.Targets[0].Status != "installed" {
+		t.Fatalf("target = %#v, want permission repair", result.Targets[0])
+	}
+	assertFile(t, skillPath, operatorskill.Content(), fileMode)
+	for _, action := range result.Actions {
+		if action.Path == skillPath && action.Action != "secure_permissions" {
+			t.Fatalf("skill action = %#v, want secure_permissions", action)
+		}
+	}
+}
+
+func TestInstallUpgradeAndDowngradeRequireForce(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name          string
+		bundleVersion int
+		intent        string
+	}{
+		{name: "upgrade", bundleVersion: operatorskill.Version - 1, intent: "upgrade"},
+		{name: "downgrade", bundleVersion: operatorskill.Version + 1, intent: "downgrade"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			config := testConfig(t, TargetClaudeCode)
+			if _, err := Install(config); err != nil {
+				t.Fatalf("Install() error = %v", err)
+			}
+			destination := filepath.Join(config.Roots[TargetClaudeCode].Skills, operatorskill.Directory)
+			manifestPath := filepath.Join(destination, ManifestFile)
+			oldManifest, err := encodeManifest(Manifest{
+				Schema:        SchemaVersion,
+				Skill:         operatorskill.Name,
+				BundleVersion: tt.bundleVersion,
+				BundleSHA256:  strings.Repeat("a", 64),
+				DetentBuild:   buildinfo.Info{Version: "v0.9.0", Commit: "old", Date: "2026-01-01T00:00:00Z"},
+			})
+			if err != nil {
+				t.Fatalf("encodeManifest() error = %v", err)
+			}
+			if err := os.WriteFile(manifestPath, oldManifest, fileMode); err != nil {
+				t.Fatalf("WriteFile() error = %v", err)
+			}
+
+			refused, err := Install(config)
+			if !errors.Is(err, ErrConflict) || refused.Targets[0].Intent != tt.intent {
+				t.Fatalf("Install() result = %#v, error = %v, want %s conflict", refused, err, tt.intent)
+			}
+			config.Force = true
+			installed, err := Install(config)
+			if err != nil {
+				t.Fatalf("Install(force) error = %v", err)
+			}
+			if installed.Targets[0].Intent != tt.intent || installed.Targets[0].Status != "installed" {
+				t.Fatalf("Install(force) target = %#v", installed.Targets[0])
+			}
+			assertFile(t, backupPath(manifestPath, oldManifest), oldManifest, fileMode)
+		})
+	}
+}
+
+func TestInstallRejectsSymlinkEscapes(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		setup func(*testing.T, Config) string
+	}{
+		{
+			name: "skills root component",
+			setup: func(t *testing.T, config Config) string {
+				claudeRoot := filepath.Join(config.Roots[TargetClaudeCode].Base, ".claude")
+				if err := os.MkdirAll(claudeRoot, directoryMode); err != nil {
+					t.Fatalf("MkdirAll() error = %v", err)
+				}
+				link := filepath.Join(claudeRoot, "skills")
+				createSymlink(t, t.TempDir(), link)
+				return link
+			},
+		},
+		{
+			name: "destination",
+			setup: func(t *testing.T, config Config) string {
+				if err := os.MkdirAll(config.Roots[TargetClaudeCode].Skills, directoryMode); err != nil {
+					t.Fatalf("MkdirAll() error = %v", err)
+				}
+				link := filepath.Join(config.Roots[TargetClaudeCode].Skills, operatorskill.Directory)
+				createSymlink(t, t.TempDir(), link)
+				return link
+			},
+		},
+		{
+			name: "skill file",
+			setup: func(t *testing.T, config Config) string {
+				destination := filepath.Join(config.Roots[TargetClaudeCode].Skills, operatorskill.Directory)
+				if err := os.MkdirAll(destination, directoryMode); err != nil {
+					t.Fatalf("MkdirAll() error = %v", err)
+				}
+				victim := filepath.Join(t.TempDir(), "victim")
+				if err := os.WriteFile(victim, []byte("do not replace"), fileMode); err != nil {
+					t.Fatalf("WriteFile() error = %v", err)
+				}
+				link := filepath.Join(destination, operatorskill.SkillFile)
+				createSymlink(t, victim, link)
+				return link
+			},
+		},
+		{
+			name: "manifest file",
+			setup: func(t *testing.T, config Config) string {
+				destination := filepath.Join(config.Roots[TargetClaudeCode].Skills, operatorskill.Directory)
+				if err := os.MkdirAll(destination, directoryMode); err != nil {
+					t.Fatalf("MkdirAll() error = %v", err)
+				}
+				victim := filepath.Join(t.TempDir(), "victim")
+				if err := os.WriteFile(victim, []byte("do not replace"), fileMode); err != nil {
+					t.Fatalf("WriteFile() error = %v", err)
+				}
+				link := filepath.Join(destination, ManifestFile)
+				createSymlink(t, victim, link)
+				return link
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			config := testConfig(t, TargetClaudeCode)
+			path := tt.setup(t, config)
+			result, err := Install(config)
+			if !errors.Is(err, ErrUnsafePath) {
+				t.Fatalf("Install() error = %v, want %v", err, ErrUnsafePath)
+			}
+			if result.Status != "failed" || result.Targets[0].Status != "failed" {
+				t.Fatalf("result = %#v, want unsafe-path failure", result)
+			}
+			info, statErr := os.Lstat(path)
+			if statErr != nil || info.Mode()&os.ModeSymlink == 0 {
+				t.Fatalf("Lstat(%s) = %v, %v, want preserved symlink", path, info, statErr)
+			}
+		})
+	}
+}
+
+func TestInstallRejectsTraversalAndSymlinkedBase(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		root func(*testing.T) Root
+	}{
+		{
+			name: "skills root outside base",
+			root: func(t *testing.T) Root {
+				base := t.TempDir()
+				return Root{Base: base, Skills: filepath.Join(filepath.Dir(base), "escaped-skills")}
+			},
+		},
+		{
+			name: "symlinked base",
+			root: func(t *testing.T) Root {
+				realBase := t.TempDir()
+				link := filepath.Join(t.TempDir(), "home")
+				createSymlink(t, realBase, link)
+				return Root{Base: link, Skills: filepath.Join(link, ".agents", "skills")}
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			root := tt.root(t)
+			result, err := Install(Config{
+				Roots:   map[Target]Root{TargetCodex: root},
+				Targets: []Target{TargetCodex},
+				Build:   testBuild,
+			})
+			if !errors.Is(err, ErrUnsafePath) {
+				t.Fatalf("Install() error = %v, want %v", err, ErrUnsafePath)
+			}
+			if result.Status != "failed" {
+				t.Fatalf("status = %q, want failed", result.Status)
+			}
+		})
+	}
+}
+
+func TestInstallRejectsSymlinkedBackupPath(t *testing.T) {
+	t.Parallel()
+
+	config := testConfig(t, TargetClaudeCode)
+	if _, err := Install(config); err != nil {
+		t.Fatalf("Install() error = %v", err)
+	}
+	destination := filepath.Join(config.Roots[TargetClaudeCode].Skills, operatorskill.Directory)
+	skillPath := filepath.Join(destination, operatorskill.SkillFile)
+	modified := []byte("user-modified skill\n")
+	if err := os.WriteFile(skillPath, modified, fileMode); err != nil {
+		t.Fatalf("WriteFile(skill) error = %v", err)
+	}
+	victim := filepath.Join(t.TempDir(), "victim")
+	victimContent := []byte("do not replace\n")
+	if err := os.WriteFile(victim, victimContent, fileMode); err != nil {
+		t.Fatalf("WriteFile(victim) error = %v", err)
+	}
+	backup := backupPath(skillPath, modified)
+	createSymlink(t, victim, backup)
+
+	config.Force = true
+	result, err := Install(config)
+	if !errors.Is(err, ErrUnsafePath) {
+		t.Fatalf("Install(force) error = %v, want %v", err, ErrUnsafePath)
+	}
+	if result.Status != "failed" || result.Targets[0].Status != "failed" {
+		t.Fatalf("result = %#v, want rejected backup symlink", result)
+	}
+	assertFile(t, skillPath, modified, fileMode)
+	assertFile(t, victim, victimContent, fileMode)
+}
+
+func TestInstallRollsBackPartialMultiTargetFailure(t *testing.T) {
+	t.Parallel()
+
+	config := testConfig(t, TargetClaudeCode, TargetCodex)
+	failed := false
+	result, err := install(config, fileOperations{
+		mkdir:  os.Mkdir,
+		remove: os.Remove,
+		atomicWrite: func(path string, content []byte, mode os.FileMode) error {
+			codexSkill := filepath.Join(config.Roots[TargetCodex].Skills, operatorskill.Directory, operatorskill.SkillFile)
+			if path == codexSkill && !failed {
+				failed = true
+				return errors.New("injected write failure")
+			}
+			return atomicWrite(path, content, mode)
+		},
+	})
+	if err == nil || !strings.Contains(err.Error(), "injected write failure") {
+		t.Fatalf("install() error = %v, want injected failure", err)
+	}
+	if result.Status != "failed" || len(result.Rollback) == 0 {
+		t.Fatalf("result = %#v, want failed result with rollback actions", result)
+	}
+	for _, target := range result.Targets {
+		if _, statErr := os.Lstat(target.Destination); !errors.Is(statErr, os.ErrNotExist) {
+			t.Fatalf("rolled-back destination %q exists or returned %v", target.Destination, statErr)
+		}
+	}
+}
+
+func testConfig(t *testing.T, targets ...Target) Config {
+	t.Helper()
+	home := t.TempDir()
+	roots, err := Roots(home)
+	if err != nil {
+		t.Fatalf("Roots() error = %v", err)
+	}
+	return Config{Roots: roots, Targets: slices.Clone(targets), Build: testBuild}
+}
+
+func createSymlink(t *testing.T, target string, link string) {
+	t.Helper()
+	if err := os.Symlink(target, link); err != nil {
+		if runtime.GOOS == "windows" {
+			t.Skipf("create symlink: %v", err)
+		}
+		t.Fatalf("Symlink() error = %v", err)
+	}
+}
+
+func readFile(t *testing.T, path string) []byte {
+	t.Helper()
+	content, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile(%s) error = %v", path, err)
+	}
+	return content
+}
+
+func assertFile(t *testing.T, path string, want []byte, mode os.FileMode) {
+	t.Helper()
+	if got := readFile(t, path); !bytes.Equal(got, want) {
+		t.Fatalf("file %s = %q, want %q", path, got, want)
+	}
+	assertFileMode(t, path, mode)
+}
+
+func assertFileMode(t *testing.T, path string, want os.FileMode) {
+	t.Helper()
+	if runtime.GOOS == "windows" {
+		return
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("Stat(%s) error = %v", path, err)
+	}
+	if got := info.Mode().Perm(); got != want.Perm() {
+		t.Fatalf("mode(%s) = %o, want %o", path, got, want)
+	}
+}
+
+func assertActionsCoverManagedPaths(t *testing.T, result Result, destination string) {
+	t.Helper()
+	want := map[string]bool{
+		filepath.Join(destination, operatorskill.SkillFile): false,
+		filepath.Join(destination, ManifestFile):            false,
+	}
+	for _, action := range result.Actions {
+		if _, ok := want[action.Path]; ok {
+			want[action.Path] = true
+		}
+	}
+	for path, covered := range want {
+		if !covered {
+			t.Fatalf("actions do not include managed path %s: %#v", path, result.Actions)
+		}
+	}
+}

--- a/internal/skillinstall/replace_posix.go
+++ b/internal/skillinstall/replace_posix.go
@@ -1,0 +1,13 @@
+//go:build !windows
+
+package skillinstall
+
+import "os"
+
+func replaceFile(source string, destination string) error {
+	return os.Rename(source, destination)
+}
+
+func safeFileMode(mode os.FileMode) bool {
+	return mode.Perm() == fileMode
+}

--- a/internal/skillinstall/replace_windows.go
+++ b/internal/skillinstall/replace_windows.go
@@ -1,0 +1,25 @@
+//go:build windows
+
+package skillinstall
+
+import (
+	"os"
+
+	"golang.org/x/sys/windows"
+)
+
+func replaceFile(source string, destination string) error {
+	sourcePointer, err := windows.UTF16PtrFromString(source)
+	if err != nil {
+		return err
+	}
+	destinationPointer, err := windows.UTF16PtrFromString(destination)
+	if err != nil {
+		return err
+	}
+	return windows.MoveFileEx(sourcePointer, destinationPointer, windows.MOVEFILE_REPLACE_EXISTING|windows.MOVEFILE_WRITE_THROUGH)
+}
+
+func safeFileMode(os.FileMode) bool {
+	return true
+}


### PR DESCRIPTION
## Summary

- add explicit multi-target installation for the embedded operator skill
- preflight non-destructive writes with deterministic backups and transactional rollback
- document and test Claude Code, Codex, and Antigravity discovery compatibility

Fixes #1651

## UI Surface Contract

- [x] N/A; this change has no UI surface.
- [x] This change adds no persistent top-of-screen messaging.
- [x] No visual changes require screenshots or browser verification.

## Test Plan

- [x] `go test -race ./internal/skillinstall ./cmd/detent ./internal/operatorskill`
- [x] Windows amd64 cross-compilation for `./internal/skillinstall` and `./cmd/detent`
- [x] `golangci-lint run --timeout=5m`
- [x] `go vet ./internal/skillinstall ./cmd/detent`
- [x] `make check` after rebasing onto current `origin/main`