### PR TITLE
feat(mcp): serve MCP over authenticated HTTP

### DIFF
--- a/docs/dashboard-api.md
+++ b/docs/dashboard-api.md
@@ -371,6 +371,33 @@ Do not enable `trust_loopback_peer_read` behind a reverse proxy on the same
 host. Every remote request relayed by that proxy appears to Detent to have a
 loopback direct peer and would receive read access.
 
+### Remote MCP
+
+The running Detent web server exposes the shared read-only operator catalog at
+`/mcp` using MCP Streamable HTTP. It uses the web server's existing listener and
+shutdown lifecycle; no second port or credential system is created. Configure a
+remote MCP client with a URL such as `https://detent.example.com/mcp` and send a
+scoped API key as `Authorization: Bearer <key>` or `X-API-Key: <key>`.
+
+Remote MCP requires an all-projects key whose only scope is `read`. Static
+`api_token` values, dashboard sessions and cookies, loopback peer trust,
+write/admin-only keys, and project-scoped keys are not accepted. Create a
+dedicated key from the API Keys dashboard or `POST /api/v1/keys`; the server
+applies the existing per-IP and per-key API rate limits to every MCP request.
+
+The endpoint supports the same protocol revisions and exactly the same five
+tools as `detent mcp` over stdio. Requests, tool arguments, tool results, and
+HTTP response envelopes are bounded. GET streaming is not needed by this
+read-only surface and returns `405`; clients receive each JSON-RPC response on
+the POST that submitted its request. Clients can end a session with `DELETE
+/mcp` and its `Mcp-Session-Id` header.
+
+Terminate TLS at Detent or a trusted reverse proxy for remote access. Public
+MCP URLs must use HTTPS; plain HTTP is acceptable only when testing through a
+loopback URL. Configure proxies and tracing systems to redact `Authorization`
+and `X-API-Key` headers; Detent never includes either credential in protocol
+errors, API usage records, or application logs.
+
 ### Private Dashboard URL Access
 
 For a personal deployment that needs remote dashboard access without a VPN,

--- a/internal/mcp/http.go
+++ b/internal/mcp/http.go
@@ -1,0 +1,642 @@
+package mcp
+
+import (
+	"bytes"
+	"context"
+	"crypto/rand"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"io"
+	"mime"
+	"net/http"
+	"net/url"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/digitaldrywood/detent/internal/operatortool"
+)
+
+const (
+	MaxHTTPRequestBytes  = maxFrameBytes
+	MaxHTTPResponseBytes = operatortool.MaxResultBytes + 64*1024
+
+	defaultMaxHTTPSessions = 1024
+	defaultHTTPSessionIdle = 30 * time.Minute
+	httpSessionHeader      = "Mcp-Session-Id"
+	httpProtocolHeader     = "Mcp-Protocol-Version"
+	codeInternalError      = -32603
+)
+
+type HTTPConfig struct {
+	Principal          func(*http.Request) string
+	MaxSessions        int
+	SessionIdleTimeout time.Duration
+	Now                func() time.Time
+	GenerateSessionID  func() (string, error)
+}
+
+type HTTPHandler struct {
+	executor           Executor
+	version            string
+	principal          func(*http.Request) string
+	maxSessions        int
+	sessionIdleTimeout time.Duration
+	now                func() time.Time
+	generateSessionID  func() (string, error)
+
+	mu       sync.Mutex
+	sessions map[string]*httpProtocolSession
+	stopped  bool
+}
+
+func NewHTTPHandler(executor Executor, version string, cfg HTTPConfig) *HTTPHandler {
+	maxSessions := cfg.MaxSessions
+	if maxSessions <= 0 {
+		maxSessions = defaultMaxHTTPSessions
+	}
+	sessionIdleTimeout := cfg.SessionIdleTimeout
+	if sessionIdleTimeout <= 0 {
+		sessionIdleTimeout = defaultHTTPSessionIdle
+	}
+	now := cfg.Now
+	if now == nil {
+		now = time.Now
+	}
+	generateSessionID := cfg.GenerateSessionID
+	if generateSessionID == nil {
+		generateSessionID = newHTTPSessionID
+	}
+	return &HTTPHandler{
+		executor:           executor,
+		version:            version,
+		principal:          cfg.Principal,
+		maxSessions:        maxSessions,
+		sessionIdleTimeout: sessionIdleTimeout,
+		now:                now,
+		generateSessionID:  generateSessionID,
+		sessions:           make(map[string]*httpProtocolSession),
+	}
+}
+
+func (h *HTTPHandler) ServeHTTP(writer http.ResponseWriter, req *http.Request) {
+	writer.Header().Set("Cache-Control", "no-store")
+	if !sameOriginRequest(req) {
+		writeHTTPTransportError(writer, http.StatusForbidden, "request origin is not allowed")
+		return
+	}
+	switch req.Method {
+	case http.MethodPost:
+		h.servePost(writer, req)
+	case http.MethodDelete:
+		h.serveDelete(writer, req)
+	case http.MethodGet:
+		writer.Header().Set("Allow", "POST, DELETE")
+		writeHTTPTransportError(writer, http.StatusMethodNotAllowed, "server-sent events are not supported")
+	default:
+		writer.Header().Set("Allow", "POST, DELETE")
+		writeHTTPTransportError(writer, http.StatusMethodNotAllowed, "method is not allowed")
+	}
+}
+
+func (h *HTTPHandler) servePost(writer http.ResponseWriter, req *http.Request) {
+	if !isJSONContentType(req.Header.Get("Content-Type")) {
+		writeHTTPTransportError(writer, http.StatusUnsupportedMediaType, "Content-Type must be application/json")
+		return
+	}
+	body, err := readHTTPRequest(writer, req)
+	if err != nil {
+		var tooLarge *http.MaxBytesError
+		if errors.As(err, &tooLarge) {
+			writeHTTPTransportError(writer, http.StatusRequestEntityTooLarge, "MCP request exceeds the size limit")
+			return
+		}
+		writeHTTPTransportError(writer, http.StatusBadRequest, "MCP request could not be read")
+		return
+	}
+	message, direct := parseHTTPRequest(body)
+	if direct != nil {
+		writeHTTPResponse(writer, http.StatusOK, direct)
+		return
+	}
+
+	principal := h.requestPrincipal(req)
+	sessionID := strings.TrimSpace(req.Header.Get(httpSessionHeader))
+	if sessionID == "" {
+		if message.Method != "initialize" || len(message.ID) == 0 {
+			writeHTTPTransportError(writer, http.StatusBadRequest, "valid MCP session ID is required")
+			return
+		}
+		h.initializeSession(writer, req, principal, message, body)
+		return
+	}
+
+	session := h.session(sessionID, principal)
+	if session == nil {
+		writeHTTPTransportError(writer, http.StatusNotFound, "MCP session not found")
+		return
+	}
+	if version := strings.TrimSpace(req.Header.Get(httpProtocolHeader)); version != "" && version != session.protocolVersion() {
+		writeHTTPTransportError(writer, http.StatusBadRequest, "MCP protocol version does not match the session")
+		return
+	}
+	h.dispatch(writer, req, session, message, body)
+}
+
+func (h *HTTPHandler) initializeSession(writer http.ResponseWriter, req *http.Request, principal string, message request, body []byte) {
+	sessionID, err := h.generateSessionID()
+	if err != nil {
+		writeHTTPTransportError(writer, http.StatusServiceUnavailable, "MCP session could not be created")
+		return
+	}
+	session := newHTTPProtocolSession(sessionID, principal, h.executor, h.version, h.now())
+	frame, notification, err := session.dispatch(req.Context(), message, body)
+	if err != nil {
+		session.stop()
+		session.wait()
+		writeHTTPTransportError(writer, http.StatusServiceUnavailable, "MCP session could not be initialized")
+		return
+	}
+	if notification || responseHasError(frame) {
+		session.stop()
+		session.wait()
+		writeHTTPResponse(writer, http.StatusOK, frame)
+		return
+	}
+	if !h.addSession(session) {
+		session.stop()
+		session.wait()
+		writeHTTPTransportError(writer, http.StatusServiceUnavailable, "MCP session capacity is unavailable")
+		return
+	}
+	writer.Header().Set(httpSessionHeader, sessionID)
+	writeHTTPResponse(writer, http.StatusOK, frame)
+}
+
+func (h *HTTPHandler) dispatch(writer http.ResponseWriter, req *http.Request, session *httpProtocolSession, message request, body []byte) {
+	frame, notification, err := session.dispatch(req.Context(), message, body)
+	if err != nil {
+		if errors.Is(err, errHTTPSessionClosed) {
+			h.removeSession(session.id, session)
+			writeHTTPTransportError(writer, http.StatusNotFound, "MCP session not found")
+			return
+		}
+		writeHTTPTransportError(writer, http.StatusServiceUnavailable, "MCP request could not be completed")
+		return
+	}
+	if notification {
+		writer.WriteHeader(http.StatusAccepted)
+		return
+	}
+	writeHTTPResponse(writer, http.StatusOK, frame)
+}
+
+func (h *HTTPHandler) serveDelete(writer http.ResponseWriter, req *http.Request) {
+	sessionID := strings.TrimSpace(req.Header.Get(httpSessionHeader))
+	if sessionID == "" {
+		writeHTTPTransportError(writer, http.StatusBadRequest, "valid MCP session ID is required")
+		return
+	}
+	session := h.takeSession(sessionID, h.requestPrincipal(req))
+	if session == nil {
+		writeHTTPTransportError(writer, http.StatusNotFound, "MCP session not found")
+		return
+	}
+	session.stop()
+	done := make(chan struct{})
+	go func() {
+		session.wait()
+		close(done)
+	}()
+	select {
+	case <-done:
+		writer.WriteHeader(http.StatusNoContent)
+	case <-req.Context().Done():
+		writeHTTPTransportError(writer, http.StatusServiceUnavailable, "MCP session shutdown did not complete")
+	}
+}
+
+func (h *HTTPHandler) Shutdown(ctx context.Context) error {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	h.mu.Lock()
+	if h.stopped {
+		h.mu.Unlock()
+		return nil
+	}
+	h.stopped = true
+	sessions := make([]*httpProtocolSession, 0, len(h.sessions))
+	for _, session := range h.sessions {
+		sessions = append(sessions, session)
+	}
+	clear(h.sessions)
+	h.mu.Unlock()
+
+	for _, session := range sessions {
+		session.stop()
+	}
+	done := make(chan struct{})
+	go func() {
+		for _, session := range sessions {
+			session.wait()
+		}
+		close(done)
+	}()
+	select {
+	case <-done:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+func (h *HTTPHandler) addSession(session *httpProtocolSession) bool {
+	now := h.now()
+	var expired []*httpProtocolSession
+	h.mu.Lock()
+	if h.stopped {
+		h.mu.Unlock()
+		return false
+	}
+	for id, candidate := range h.sessions {
+		if now.Sub(candidate.lastSeen()) >= h.sessionIdleTimeout {
+			delete(h.sessions, id)
+			expired = append(expired, candidate)
+		}
+	}
+	if len(h.sessions) >= h.maxSessions || h.sessions[session.id] != nil {
+		h.mu.Unlock()
+		stopHTTPSessions(expired)
+		return false
+	}
+	h.sessions[session.id] = session
+	h.mu.Unlock()
+	stopHTTPSessions(expired)
+	return true
+}
+
+func (h *HTTPHandler) session(id string, principal string) *httpProtocolSession {
+	now := h.now()
+	h.mu.Lock()
+	if h.stopped {
+		h.mu.Unlock()
+		return nil
+	}
+	session := h.sessions[id]
+	if session == nil || session.principal != principal {
+		h.mu.Unlock()
+		return nil
+	}
+	if now.Sub(session.lastSeen()) >= h.sessionIdleTimeout {
+		delete(h.sessions, id)
+		h.mu.Unlock()
+		session.stop()
+		go session.wait()
+		return nil
+	}
+	session.touch(now)
+	h.mu.Unlock()
+	return session
+}
+
+func (h *HTTPHandler) takeSession(id string, principal string) *httpProtocolSession {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	session := h.sessions[id]
+	if session == nil || session.principal != principal {
+		return nil
+	}
+	delete(h.sessions, id)
+	return session
+}
+
+func (h *HTTPHandler) removeSession(id string, session *httpProtocolSession) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	if h.sessions[id] == session {
+		delete(h.sessions, id)
+	}
+}
+
+func (h *HTTPHandler) requestPrincipal(req *http.Request) string {
+	if h.principal == nil {
+		return ""
+	}
+	return strings.TrimSpace(h.principal(req))
+}
+
+func stopHTTPSessions(sessions []*httpProtocolSession) {
+	for _, session := range sessions {
+		session.stop()
+		go session.wait()
+	}
+}
+
+var errHTTPSessionClosed = errors.New("MCP HTTP session is closed")
+
+type httpProtocolSession struct {
+	id        string
+	principal string
+	done      <-chan struct{}
+	cancel    context.CancelFunc
+	protocol  *session
+	router    *httpResponseRouter
+
+	mu       sync.Mutex
+	closing  bool
+	inflight sync.WaitGroup
+	seenAt   atomic.Int64
+}
+
+func newHTTPProtocolSession(id string, principal string, executor Executor, version string, now time.Time) *httpProtocolSession {
+	ctx, cancel := context.WithCancel(context.Background())
+	router := newHTTPResponseRouter()
+	protocol := &session{
+		done:     ctx.Done(),
+		cancel:   cancel,
+		executor: executor,
+		version:  strings.TrimSpace(version),
+		output:   router,
+		state:    stateNew,
+		active:   make(map[string]*activeRequest),
+	}
+	if protocol.version == "" {
+		protocol.version = "dev"
+	}
+	result := &httpProtocolSession{id: id, principal: principal, done: ctx.Done(), cancel: cancel, protocol: protocol, router: router}
+	result.touch(now)
+	return result
+}
+
+func (s *httpProtocolSession) dispatch(ctx context.Context, message request, frame []byte) ([]byte, bool, error) {
+	if !s.begin() {
+		return nil, false, errHTTPSessionClosed
+	}
+	defer s.inflight.Done()
+	if len(message.ID) == 0 {
+		if err := s.protocol.handle(s.sessionContext(), frame); err != nil {
+			return nil, true, err
+		}
+		return nil, true, nil
+	}
+	key, ok := requestIDKey(message.ID)
+	if !ok {
+		return marshalHTTPResponse(response{JSONRPC: "2.0", ID: json.RawMessage(`null`), Error: &rpcError{Code: codeInvalidRequest, Message: "Invalid Request"}}), false, nil
+	}
+	responses, ok := s.router.register(key)
+	if !ok {
+		return marshalHTTPResponse(response{JSONRPC: "2.0", ID: responseID(message.ID), Error: &rpcError{Code: codeInvalidRequest, Message: "Duplicate request ID"}}), false, nil
+	}
+	defer s.router.unregister(key, responses)
+	if err := s.protocol.handle(s.sessionContext(), frame); err != nil {
+		return nil, false, err
+	}
+	select {
+	case result := <-responses:
+		return result, false, nil
+	case <-ctx.Done():
+		if err := s.cancelRequest(s.sessionContext(), message.ID); err != nil {
+			return nil, false, errors.Join(ctx.Err(), err)
+		}
+		return nil, false, ctx.Err()
+	case <-s.done:
+		return nil, false, errHTTPSessionClosed
+	}
+}
+
+func (s *httpProtocolSession) cancelRequest(ctx context.Context, id json.RawMessage) error {
+	params, err := json.Marshal(struct {
+		RequestID json.RawMessage `json:"requestId"`
+	}{RequestID: id})
+	if err != nil {
+		return err
+	}
+	frame, err := json.Marshal(request{JSONRPC: "2.0", Method: "notifications/cancelled", Params: params})
+	if err != nil {
+		return err
+	}
+	return s.protocol.handle(ctx, frame)
+}
+
+func (s *httpProtocolSession) sessionContext() context.Context {
+	return httpSessionContext{done: s.done}
+}
+
+func (s *httpProtocolSession) begin() bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.closing {
+		return false
+	}
+	s.inflight.Add(1)
+	return true
+}
+
+func (s *httpProtocolSession) stop() {
+	s.mu.Lock()
+	if s.closing {
+		s.mu.Unlock()
+		return
+	}
+	s.closing = true
+	s.cancel()
+	s.protocol.cancelActive()
+	s.mu.Unlock()
+}
+
+func (s *httpProtocolSession) wait() {
+	s.inflight.Wait()
+	s.protocol.calls.Wait()
+	s.router.stop()
+}
+
+func (s *httpProtocolSession) protocolVersion() string {
+	s.protocol.mu.Lock()
+	defer s.protocol.mu.Unlock()
+	return s.protocol.protocolVersion
+}
+
+func (s *httpProtocolSession) touch(now time.Time) {
+	s.seenAt.Store(now.UnixNano())
+}
+
+func (s *httpProtocolSession) lastSeen() time.Time {
+	return time.Unix(0, s.seenAt.Load())
+}
+
+type httpResponseRouter struct {
+	mu      sync.Mutex
+	pending map[string]chan []byte
+	stopped bool
+}
+
+func newHTTPResponseRouter() *httpResponseRouter {
+	return &httpResponseRouter{pending: make(map[string]chan []byte)}
+}
+
+func (r *httpResponseRouter) register(key string) (chan []byte, bool) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.stopped || r.pending[key] != nil {
+		return nil, false
+	}
+	responses := make(chan []byte, 1)
+	r.pending[key] = responses
+	return responses, true
+}
+
+func (r *httpResponseRouter) unregister(key string, responses chan []byte) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.pending[key] == responses {
+		delete(r.pending, key)
+	}
+}
+
+func (r *httpResponseRouter) Write(frame []byte) (int, error) {
+	trimmed := bytes.TrimSpace(frame)
+	var message struct {
+		ID json.RawMessage `json:"id"`
+	}
+	if err := json.Unmarshal(trimmed, &message); err != nil {
+		return 0, err
+	}
+	key, ok := requestIDKey(message.ID)
+	if !ok {
+		return len(frame), nil
+	}
+	if len(trimmed) > MaxHTTPResponseBytes {
+		trimmed = marshalHTTPResponse(response{
+			JSONRPC: "2.0",
+			ID:      responseID(message.ID),
+			Error:   &rpcError{Code: codeInternalError, Message: "MCP response exceeds the size limit"},
+		})
+	}
+	r.mu.Lock()
+	responses := r.pending[key]
+	stopped := r.stopped
+	r.mu.Unlock()
+	if stopped || responses == nil {
+		return len(frame), nil
+	}
+	responses <- append([]byte(nil), trimmed...)
+	return len(frame), nil
+}
+
+func (r *httpResponseRouter) stop() {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.stopped = true
+	clear(r.pending)
+}
+
+func parseHTTPRequest(body []byte) (request, []byte) {
+	trimmed := bytes.TrimSpace(body)
+	if !json.Valid(trimmed) {
+		return request{}, marshalHTTPResponse(response{JSONRPC: "2.0", ID: json.RawMessage(`null`), Error: &rpcError{Code: codeParseError, Message: "Parse error"}})
+	}
+	if len(trimmed) == 0 || trimmed[0] != '{' {
+		return request{}, marshalHTTPResponse(response{JSONRPC: "2.0", ID: json.RawMessage(`null`), Error: &rpcError{Code: codeInvalidRequest, Message: "Invalid Request"}})
+	}
+	var message request
+	if err := json.Unmarshal(trimmed, &message); err != nil {
+		return request{}, marshalHTTPResponse(response{JSONRPC: "2.0", ID: json.RawMessage(`null`), Error: &rpcError{Code: codeInvalidRequest, Message: "Invalid Request"}})
+	}
+	if message.JSONRPC != "2.0" || strings.TrimSpace(message.Method) == "" {
+		if len(message.ID) == 0 {
+			return message, nil
+		}
+		return request{}, marshalHTTPResponse(response{JSONRPC: "2.0", ID: json.RawMessage(`null`), Error: &rpcError{Code: codeInvalidRequest, Message: "Invalid Request"}})
+	}
+	if len(message.ID) > 0 {
+		if _, ok := requestIDKey(message.ID); !ok {
+			return request{}, marshalHTTPResponse(response{JSONRPC: "2.0", ID: json.RawMessage(`null`), Error: &rpcError{Code: codeInvalidRequest, Message: "Invalid Request"}})
+		}
+	}
+	return message, nil
+}
+
+func readHTTPRequest(writer http.ResponseWriter, req *http.Request) ([]byte, error) {
+	body := http.MaxBytesReader(writer, req.Body, MaxHTTPRequestBytes)
+	defer body.Close()
+	return io.ReadAll(body)
+}
+
+func isJSONContentType(value string) bool {
+	mediaType, _, err := mime.ParseMediaType(strings.TrimSpace(value))
+	return err == nil && mediaType == "application/json"
+}
+
+func sameOriginRequest(req *http.Request) bool {
+	origin := strings.TrimSpace(req.Header.Get("Origin"))
+	if origin == "" {
+		return true
+	}
+	parsed, err := url.Parse(origin)
+	return err == nil && parsed != nil && parsed.Host != "" && strings.EqualFold(parsed.Host, req.Host)
+}
+
+func responseHasError(frame []byte) bool {
+	var message struct {
+		Error *rpcError `json:"error"`
+	}
+	return json.Unmarshal(frame, &message) != nil || message.Error != nil
+}
+
+func writeHTTPTransportError(writer http.ResponseWriter, status int, message string) {
+	writeHTTPResponse(writer, status, marshalHTTPResponse(response{
+		JSONRPC: "2.0",
+		ID:      json.RawMessage(`null`),
+		Error:   &rpcError{Code: -32000, Message: message},
+	}))
+}
+
+func writeHTTPResponse(writer http.ResponseWriter, status int, frame []byte) {
+	writer.Header().Set("Content-Type", "application/json")
+	writer.WriteHeader(status)
+	_, _ = writer.Write(frame)
+}
+
+func marshalHTTPResponse(message response) []byte {
+	frame, err := json.Marshal(message)
+	if err != nil {
+		return []byte(`{"jsonrpc":"2.0","id":null,"error":{"code":-32603,"message":"Internal error"}}`)
+	}
+	return frame
+}
+
+func newHTTPSessionID() (string, error) {
+	random := make([]byte, 32)
+	if _, err := rand.Read(random); err != nil {
+		return "", err
+	}
+	return base64.RawURLEncoding.EncodeToString(random), nil
+}
+
+type httpSessionContext struct {
+	done <-chan struct{}
+}
+
+func (c httpSessionContext) Deadline() (time.Time, bool) {
+	return time.Time{}, false
+}
+
+func (c httpSessionContext) Done() <-chan struct{} {
+	return c.done
+}
+
+func (c httpSessionContext) Err() error {
+	select {
+	case <-c.done:
+		return context.Canceled
+	default:
+		return nil
+	}
+}
+
+func (c httpSessionContext) Value(any) any {
+	return nil
+}

--- a/internal/mcp/http_test.go
+++ b/internal/mcp/http_test.go
@@ -1,0 +1,206 @@
+package mcp
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/digitaldrywood/detent/internal/operatortool"
+)
+
+func TestHTTPTransportUsesSharedProtocolCatalog(t *testing.T) {
+	t.Parallel()
+
+	handler := newTestHTTPHandler(nil)
+	initialize := performMCPRequest(t, handler, http.MethodPost, initializeRequest, "", "read-key", nil)
+	if initialize.Code != http.StatusOK {
+		t.Fatalf("initialize status = %d, want %d; body = %s", initialize.Code, http.StatusOK, initialize.Body.String())
+	}
+	sessionID := initialize.Header().Get(httpSessionHeader)
+	if sessionID != "test-session" {
+		t.Fatalf("session ID = %q, want test-session", sessionID)
+	}
+
+	initialized := performMCPRequest(t, handler, http.MethodPost, initializedNotice, sessionID, "read-key", nil)
+	if initialized.Code != http.StatusAccepted || initialized.Body.Len() != 0 {
+		t.Fatalf("initialized response = %d %q, want 202 with empty body", initialized.Code, initialized.Body.String())
+	}
+	list := performMCPRequest(t, handler, http.MethodPost, `{"jsonrpc":"2.0","id":"list","method":"tools/list","params":{}}`, sessionID, "read-key", nil)
+	if list.Code != http.StatusOK {
+		t.Fatalf("tools/list status = %d, want %d; body = %s", list.Code, http.StatusOK, list.Body.String())
+	}
+	var response rpcResponse
+	if err := json.Unmarshal(list.Body.Bytes(), &response); err != nil {
+		t.Fatalf("decode tools/list response: %v", err)
+	}
+	var result struct {
+		Tools []listedTool `json:"tools"`
+	}
+	decodeResult(t, response, &result)
+	want := operatortool.Catalog()
+	if len(result.Tools) != len(want) {
+		t.Fatalf("HTTP tools = %d, want %d", len(result.Tools), len(want))
+	}
+	for index, definition := range want {
+		got := result.Tools[index]
+		if got.Name != definition.Name || got.Description != definition.Description || !jsonEqual(got.InputSchema, definition.InputSchema) {
+			t.Fatalf("HTTP tool[%d] = %#v, want %#v", index, got, definition)
+		}
+	}
+
+	deleted := performMCPRequest(t, handler, http.MethodDelete, "", sessionID, "read-key", nil)
+	if deleted.Code != http.StatusNoContent {
+		t.Fatalf("DELETE status = %d, want %d; body = %s", deleted.Code, http.StatusNoContent, deleted.Body.String())
+	}
+}
+
+func TestHTTPTransportRequestBoundaries(t *testing.T) {
+	t.Parallel()
+
+	handler := newTestHTTPHandler(nil)
+	initialize := performMCPRequest(t, handler, http.MethodPost, initializeRequest, "", "read-key", nil)
+	sessionID := initialize.Header().Get(httpSessionHeader)
+	tests := []struct {
+		name       string
+		method     string
+		body       string
+		sessionID  string
+		principal  string
+		headers    map[string]string
+		wantStatus int
+	}{
+		{name: "GET streaming unsupported", method: http.MethodGet, sessionID: sessionID, principal: "read-key", wantStatus: http.StatusMethodNotAllowed},
+		{name: "wrong content type", method: http.MethodPost, body: initializeRequest, principal: "read-key", headers: map[string]string{"Content-Type": "text/plain"}, wantStatus: http.StatusUnsupportedMediaType},
+		{name: "request too large", method: http.MethodPost, body: strings.Repeat(" ", MaxHTTPRequestBytes+1), principal: "read-key", wantStatus: http.StatusRequestEntityTooLarge},
+		{name: "cross origin", method: http.MethodPost, body: initializeRequest, principal: "read-key", headers: map[string]string{"Origin": "https://attacker.example"}, wantStatus: http.StatusForbidden},
+		{name: "missing session", method: http.MethodPost, body: `{"jsonrpc":"2.0","id":2,"method":"tools/list"}`, principal: "read-key", wantStatus: http.StatusBadRequest},
+		{name: "unknown session", method: http.MethodPost, body: `{"jsonrpc":"2.0","id":2,"method":"tools/list"}`, sessionID: "missing", principal: "read-key", wantStatus: http.StatusNotFound},
+		{name: "session bound to principal", method: http.MethodPost, body: `{"jsonrpc":"2.0","id":2,"method":"tools/list"}`, sessionID: sessionID, principal: "different-key", wantStatus: http.StatusNotFound},
+		{name: "protocol mismatch", method: http.MethodPost, body: `{"jsonrpc":"2.0","id":2,"method":"tools/list"}`, sessionID: sessionID, principal: "read-key", headers: map[string]string{httpProtocolHeader: "2024-11-05"}, wantStatus: http.StatusBadRequest},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			recorder := performMCPRequest(t, handler, test.method, test.body, test.sessionID, test.principal, test.headers)
+			if recorder.Code != test.wantStatus {
+				t.Fatalf("status = %d, want %d; body = %s", recorder.Code, test.wantStatus, recorder.Body.String())
+			}
+		})
+	}
+}
+
+func TestHTTPTransportResultLimits(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name          string
+		executor      Executor
+		wantRPCError  bool
+		wantToolError bool
+	}{
+		{
+			name:          "tool result limit",
+			executor:      &staticExecutor{result: operatortool.Result{Content: json.RawMessage(`{"value":"` + strings.Repeat("x", operatortool.MaxResultBytes) + `"}`)}},
+			wantToolError: true,
+		},
+		{
+			name:         "HTTP envelope limit",
+			executor:     &staticExecutor{err: errors.New(strings.Repeat("x", MaxHTTPResponseBytes))},
+			wantRPCError: true,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			handler := newTestHTTPHandler(test.executor)
+			initialize := performMCPRequest(t, handler, http.MethodPost, initializeRequest, "", "read-key", nil)
+			sessionID := initialize.Header().Get(httpSessionHeader)
+			performMCPRequest(t, handler, http.MethodPost, initializedNotice, sessionID, "read-key", nil)
+			call := performMCPRequest(t, handler, http.MethodPost, `{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"fleet_health","arguments":{}}}`, sessionID, "read-key", nil)
+			if call.Code != http.StatusOK || call.Body.Len() > MaxHTTPResponseBytes {
+				t.Fatalf("call response = %d bytes=%d; body prefix = %.120s", call.Code, call.Body.Len(), call.Body.String())
+			}
+			var response rpcResponse
+			if err := json.Unmarshal(call.Body.Bytes(), &response); err != nil {
+				t.Fatalf("decode call response: %v", err)
+			}
+			if test.wantRPCError {
+				if response.Error == nil || response.Error.Code != codeInternalError {
+					t.Fatalf("response error = %#v, want code %d", response.Error, codeInternalError)
+				}
+				return
+			}
+			var result toolCallResult
+			decodeResult(t, response, &result)
+			if test.wantToolError != result.IsError {
+				t.Fatalf("tool result IsError = %t, want %t", result.IsError, test.wantToolError)
+			}
+		})
+	}
+}
+
+func TestHTTPTransportShutdownCancelsCallsAndRejectsSessions(t *testing.T) {
+	t.Parallel()
+
+	executor := newBlockingExecutor()
+	handler := newTestHTTPHandler(executor)
+	initialize := performMCPRequest(t, handler, http.MethodPost, initializeRequest, "", "read-key", nil)
+	sessionID := initialize.Header().Get(httpSessionHeader)
+	performMCPRequest(t, handler, http.MethodPost, initializedNotice, sessionID, "read-key", nil)
+
+	callDone := make(chan *httptest.ResponseRecorder, 1)
+	go func() {
+		callDone <- performMCPRequest(t, handler, http.MethodPost, `{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"fleet_health","arguments":{}}}`, sessionID, "read-key", nil)
+	}()
+	executor.waitStarted(t)
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if err := handler.Shutdown(ctx); err != nil {
+		t.Fatalf("Shutdown() error = %v", err)
+	}
+	executor.waitCancelled(t)
+	select {
+	case response := <-callDone:
+		if response.Code != http.StatusNotFound && response.Code != http.StatusServiceUnavailable {
+			t.Fatalf("in-flight response status = %d, want 404 or 503", response.Code)
+		}
+	case <-ctx.Done():
+		t.Fatal("in-flight HTTP call did not return during shutdown")
+	}
+	newSession := performMCPRequest(t, handler, http.MethodPost, initializeRequest, "", "read-key", nil)
+	if newSession.Code != http.StatusServiceUnavailable {
+		t.Fatalf("post-shutdown initialize status = %d, want %d", newSession.Code, http.StatusServiceUnavailable)
+	}
+}
+
+func newTestHTTPHandler(executor Executor) *HTTPHandler {
+	return NewHTTPHandler(executor, "test-version", HTTPConfig{
+		Principal: func(req *http.Request) string {
+			return req.Header.Get("X-Test-Principal")
+		},
+		GenerateSessionID: func() (string, error) {
+			return "test-session", nil
+		},
+	})
+}
+
+func performMCPRequest(t *testing.T, handler http.Handler, method string, body string, sessionID string, principal string, headers map[string]string) *httptest.ResponseRecorder {
+	t.Helper()
+	recorder := httptest.NewRecorder()
+	request := httptest.NewRequest(method, "http://detent.example/mcp", bytes.NewBufferString(body))
+	request.Header.Set("Content-Type", "application/json")
+	request.Header.Set("X-Test-Principal", principal)
+	if sessionID != "" {
+		request.Header.Set(httpSessionHeader, sessionID)
+	}
+	for name, value := range headers {
+		request.Header.Set(name, value)
+	}
+	handler.ServeHTTP(recorder, request)
+	return recorder
+}

--- a/internal/web/auth.go
+++ b/internal/web/auth.go
@@ -64,6 +64,68 @@ func (s *Server) apiAuthWithOptions(opts apiAuthOptions) echo.MiddlewareFunc {
 	}
 }
 
+func (s *Server) mcpAPIAuth() echo.MiddlewareFunc {
+	return func(next echo.HandlerFunc) echo.HandlerFunc {
+		return func(c echo.Context) error {
+			started := time.Now()
+			credential, err := s.authorizeMCPRequest(c)
+			if err != nil {
+				return err
+			}
+			if err := s.applyAPIKeyRateLimit(c, credential); err != nil {
+				s.recordAPIUsage(c, credential, started, err)
+				return err
+			}
+			s.markAPIKeyLastUsed(credential)
+			err = next(c)
+			s.recordAPIUsage(c, credential, started, err)
+			return err
+		}
+	}
+}
+
+func (s *Server) authorizeMCPRequest(c echo.Context) (apikey.Credential, error) {
+	if err := s.applyPreAuthIPRateLimit(c); err != nil {
+		return apikey.Credential{}, err
+	}
+	candidates := requestAPITokens(c.Request())
+	if len(candidates) == 0 {
+		return apikey.Credential{}, writeAPIAuthError(c, http.StatusUnauthorized, "unauthorized", "Valid read-scoped API key is required")
+	}
+	var lastAuthErr *apikey.AuthError
+	for _, candidate := range candidates {
+		credential, err := s.authenticateCandidate(c.Request().Context(), candidate, "")
+		if err != nil {
+			var authErr *apikey.AuthError
+			if errors.As(err, &authErr) {
+				if authErr.Code == "token_expired" || authErr.Code == "token_revoked" {
+					return apikey.Credential{}, writeAPIAuthError(c, http.StatusUnauthorized, authErr.Code, authErr.Message)
+				}
+				lastAuthErr = authErr
+				continue
+			}
+			s.logger.Warn("MCP API key lookup failed", "error", err)
+			return apikey.Credential{}, writeAPIAuthError(c, http.StatusServiceUnavailable, "service_unavailable", "API key authentication temporarily unavailable")
+		}
+		if !mcpReadScopeOnly(credential.Scopes) {
+			return apikey.Credential{}, writeAPIAuthError(c, http.StatusForbidden, "read_scope_required", "MCP requires an API key with read scope only")
+		}
+		if len(credential.ProjectIDs) > 0 {
+			return apikey.Credential{}, writeAPIAuthError(c, http.StatusForbidden, "global_scope_required", "MCP requires an API key authorized for all projects")
+		}
+		s.setAPICredential(c, credential)
+		return credential, nil
+	}
+	if lastAuthErr != nil {
+		return apikey.Credential{}, writeAPIAuthError(c, http.StatusUnauthorized, lastAuthErr.Code, lastAuthErr.Message)
+	}
+	return apikey.Credential{}, writeAPIAuthError(c, http.StatusUnauthorized, "unauthorized", "Valid read-scoped API key is required")
+}
+
+func mcpReadScopeOnly(scopes []string) bool {
+	return len(scopes) == 1 && strings.EqualFold(strings.TrimSpace(scopes[0]), string(apikey.ScopeRead))
+}
+
 func (s *Server) authorizeAPIRequest(c echo.Context, opts apiAuthOptions) (apikey.Credential, error) {
 	if err := s.applyPreAuthIPRateLimit(c); err != nil {
 		return apikey.Credential{}, err

--- a/internal/web/mcp_http_test.go
+++ b/internal/web/mcp_http_test.go
@@ -80,6 +80,50 @@ func TestRemoteMCPRequiresGlobalReadScopedAPIKey(t *testing.T) {
 	}
 }
 
+func TestRemoteMCPBypassesDashboardAuthenticationGates(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		config globalconfig.Config
+	}{
+		{
+			name: "magic link",
+			config: globalconfig.Config{Auth: globalconfig.Auth{
+				Mode:          globalconfig.AuthModeMagicLink,
+				AllowedEmails: []string{"operator@example.com"},
+				LinkTTL:       "15m",
+				SessionTTL:    "1h",
+			}},
+		},
+		{
+			name: "private dashboard",
+			config: globalconfig.Config{DashboardAccess: globalconfig.DashboardAccess{
+				Mode:  globalconfig.DashboardAccessModePrivateToken,
+				Token: privateDashboardTestToken(9),
+			}},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			server, _ := newRemoteMCPTestServerWithConfig(t, nil, test.config)
+			token, _ := createRemoteMCPKey(t, server, "Global read", []string{"read"}, nil)
+			authorized := performJSON(t, server.Handler(), http.MethodPost, "/mcp", mcpInitializeRequest, map[string]string{
+				"Authorization": "Bearer " + token,
+			})
+			if authorized.Code != http.StatusOK || authorized.Header().Get("Mcp-Session-Id") == "" {
+				t.Fatalf("authorized response = %d %s, want initialized MCP session", authorized.Code, authorized.Body.String())
+			}
+			unauthorized := performJSON(t, server.Handler(), http.MethodPost, "/mcp", mcpInitializeRequest, nil)
+			if unauthorized.Code != http.StatusUnauthorized {
+				t.Fatalf("unauthorized response = %d %s, want 401", unauthorized.Code, unauthorized.Body.String())
+			}
+		})
+	}
+}
+
 func TestRemoteMCPBearerTokenIsNotLoggedOrEchoed(t *testing.T) {
 	t.Parallel()
 
@@ -151,15 +195,20 @@ func TestRemoteMCPUsesWebServerShutdown(t *testing.T) {
 
 func newRemoteMCPTestServer(t *testing.T, logger *slog.Logger) (*web.Server, store.Store) {
 	t.Helper()
+	return newRemoteMCPTestServerWithConfig(t, logger, globalconfig.Config{})
+}
+
+func newRemoteMCPTestServerWithConfig(t *testing.T, logger *slog.Logger, config globalconfig.Config) (*web.Server, store.Store) {
+	t.Helper()
 	backend := openWebTestStore(t)
 	deps := testDeps(t)
 	deps.Store = backend
+	deps.MagicLinkSender = &webAuthSender{}
+	config.APIToken = "detent_admin_token"
 	server, err := web.NewServer(web.Config{
 		Logger:        logger,
 		ServerAddress: "127.0.0.1:0",
-		GlobalConfig: globalconfig.Config{
-			APIToken: "detent_admin_token",
-		},
+		GlobalConfig:  config,
 	}, deps)
 	if err != nil {
 		t.Fatalf("NewServer() error = %v", err)

--- a/internal/web/mcp_http_test.go
+++ b/internal/web/mcp_http_test.go
@@ -1,0 +1,220 @@
+package web_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	globalconfig "github.com/digitaldrywood/detent/internal/config/global"
+	"github.com/digitaldrywood/detent/internal/store"
+	"github.com/digitaldrywood/detent/internal/web"
+)
+
+const mcpInitializeRequest = `{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-11-25","capabilities":{},"clientInfo":{"name":"test-client","version":"1.0.0"}}}`
+
+func TestRemoteMCPRequiresGlobalReadScopedAPIKey(t *testing.T) {
+	t.Parallel()
+
+	server, backend := newRemoteMCPTestServer(t, nil)
+	readToken, _ := createRemoteMCPKey(t, server, "Global read", []string{"read"}, nil)
+	writeToken, _ := createRemoteMCPKey(t, server, "Global write", []string{"write"}, nil)
+	adminToken, _ := createRemoteMCPKey(t, server, "Global admin", []string{"admin"}, nil)
+	projectToken, _ := createRemoteMCPKey(t, server, "Project read", []string{"read"}, []string{"detent"})
+	revokedToken, revokedID := createRemoteMCPKey(t, server, "Revoked read", []string{"read"}, nil)
+	if err := backend.RevokeAPIKey(context.Background(), revokedID, time.Now()); err != nil {
+		t.Fatalf("RevokeAPIKey() error = %v", err)
+	}
+	expiredToken := createExpiredAPIKey(t, backend)
+
+	tests := []struct {
+		name       string
+		token      string
+		wantStatus int
+		wantCode   string
+	}{
+		{name: "global read", token: readToken, wantStatus: http.StatusOK},
+		{name: "missing", wantStatus: http.StatusUnauthorized, wantCode: "unauthorized"},
+		{name: "static API token", token: "detent_admin_token", wantStatus: http.StatusUnauthorized, wantCode: "invalid_token"},
+		{name: "revoked", token: revokedToken, wantStatus: http.StatusUnauthorized, wantCode: "token_revoked"},
+		{name: "expired", token: expiredToken, wantStatus: http.StatusUnauthorized, wantCode: "token_expired"},
+		{name: "write scope", token: writeToken, wantStatus: http.StatusForbidden, wantCode: "read_scope_required"},
+		{name: "admin scope", token: adminToken, wantStatus: http.StatusForbidden, wantCode: "read_scope_required"},
+		{name: "project scoped", token: projectToken, wantStatus: http.StatusForbidden, wantCode: "global_scope_required"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			headers := map[string]string{}
+			if test.token != "" {
+				headers["Authorization"] = "Bearer " + test.token
+			}
+			recorder := performJSON(t, server.Handler(), http.MethodPost, "/mcp", mcpInitializeRequest, headers)
+			if recorder.Code != test.wantStatus {
+				t.Fatalf("status = %d, want %d; body = %s", recorder.Code, test.wantStatus, recorder.Body.String())
+			}
+			if test.wantCode == "" {
+				if recorder.Header().Get("Mcp-Session-Id") == "" {
+					t.Fatal("successful initialization omitted Mcp-Session-Id")
+				}
+				return
+			}
+			var problem struct {
+				Error struct {
+					Code string `json:"code"`
+				} `json:"error"`
+			}
+			if err := json.Unmarshal(recorder.Body.Bytes(), &problem); err != nil {
+				t.Fatalf("decode auth problem: %v; body = %s", err, recorder.Body.String())
+			}
+			if problem.Error.Code != test.wantCode {
+				t.Fatalf("problem code = %q, want %q", problem.Error.Code, test.wantCode)
+			}
+			if test.token != "" && strings.Contains(recorder.Body.String(), test.token) {
+				t.Fatalf("response leaked bearer token: %s", recorder.Body.String())
+			}
+		})
+	}
+}
+
+func TestRemoteMCPBearerTokenIsNotLoggedOrEchoed(t *testing.T) {
+	t.Parallel()
+
+	var logs bytes.Buffer
+	logger := slog.New(slog.NewTextHandler(&logs, nil))
+	server, backend := newRemoteMCPTestServer(t, logger)
+	token, keyID := createRemoteMCPKey(t, server, "Revoked secret", []string{"read"}, nil)
+	if err := backend.RevokeAPIKey(context.Background(), keyID, time.Now()); err != nil {
+		t.Fatalf("RevokeAPIKey() error = %v", err)
+	}
+	recorder := performJSON(t, server.Handler(), http.MethodPost, "/mcp", mcpInitializeRequest, map[string]string{
+		"Authorization": "Bearer " + token,
+	})
+	if recorder.Code != http.StatusUnauthorized {
+		t.Fatalf("status = %d, want %d; body = %s", recorder.Code, http.StatusUnauthorized, recorder.Body.String())
+	}
+	if strings.Contains(recorder.Body.String(), token) || strings.Contains(logs.String(), token) {
+		t.Fatalf("bearer token appeared in response or logs")
+	}
+}
+
+func TestRemoteMCPUsesExistingRateLimits(t *testing.T) {
+	t.Parallel()
+
+	server, _ := newRemoteMCPTestServer(t, nil)
+	token, _ := createRemoteMCPKey(t, server, "Rate limited read", []string{"read"}, nil)
+	var limited bool
+	for range 40 {
+		recorder := performJSON(t, server.Handler(), http.MethodPost, "/mcp", mcpInitializeRequest, map[string]string{
+			"Authorization": "Bearer " + token,
+		})
+		if recorder.Code != http.StatusTooManyRequests {
+			continue
+		}
+		limited = true
+		if recorder.Header().Get("X-RateLimit-Limit") == "" || recorder.Header().Get("X-RateLimit-Remaining") == "" || recorder.Header().Get("Retry-After") == "" {
+			t.Fatalf("rate limit response omitted headers: %#v", recorder.Header())
+		}
+		break
+	}
+	if !limited {
+		t.Fatal("MCP rate limit did not engage")
+	}
+}
+
+func TestRemoteMCPUsesWebServerShutdown(t *testing.T) {
+	t.Parallel()
+
+	server, _ := newRemoteMCPTestServer(t, nil)
+	token, _ := createRemoteMCPKey(t, server, "Shutdown read", []string{"read"}, nil)
+	initialize := performJSON(t, server.Handler(), http.MethodPost, "/mcp", mcpInitializeRequest, map[string]string{
+		"Authorization": "Bearer " + token,
+	})
+	if initialize.Code != http.StatusOK || initialize.Header().Get("Mcp-Session-Id") == "" {
+		t.Fatalf("initialize response = %d %s", initialize.Code, initialize.Body.String())
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if err := server.Shutdown(ctx); err != nil {
+		t.Fatalf("Shutdown() error = %v", err)
+	}
+	afterShutdown := performJSON(t, server.Handler(), http.MethodPost, "/mcp", mcpInitializeRequest, map[string]string{
+		"Authorization": "Bearer " + token,
+	})
+	if afterShutdown.Code != http.StatusServiceUnavailable {
+		t.Fatalf("post-shutdown response = %d %s, want 503", afterShutdown.Code, afterShutdown.Body.String())
+	}
+}
+
+func newRemoteMCPTestServer(t *testing.T, logger *slog.Logger) (*web.Server, store.Store) {
+	t.Helper()
+	backend := openWebTestStore(t)
+	deps := testDeps(t)
+	deps.Store = backend
+	server, err := web.NewServer(web.Config{
+		Logger:        logger,
+		ServerAddress: "127.0.0.1:0",
+		GlobalConfig: globalconfig.Config{
+			APIToken: "detent_admin_token",
+		},
+	}, deps)
+	if err != nil {
+		t.Fatalf("NewServer() error = %v", err)
+	}
+	t.Cleanup(func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		if err := server.Shutdown(ctx); err != nil {
+			t.Errorf("Shutdown() error = %v", err)
+		}
+	})
+	return server, backend
+}
+
+func createRemoteMCPKey(t *testing.T, server *web.Server, name string, scopes []string, projects []string) (string, string) {
+	t.Helper()
+	body, err := json.Marshal(map[string]any{
+		"name":        name,
+		"scopes":      scopes,
+		"project_ids": projects,
+		"expires_in":  "90d",
+	})
+	if err != nil {
+		t.Fatalf("marshal API key request: %v", err)
+	}
+	recorder := performJSON(t, server.Handler(), http.MethodPost, "/api/v1/keys", string(body), map[string]string{
+		"Authorization": "Bearer detent_admin_token",
+	})
+	if recorder.Code != http.StatusCreated {
+		t.Fatalf("create API key status = %d, want %d; body = %s", recorder.Code, http.StatusCreated, recorder.Body.String())
+	}
+	var created struct {
+		Token string `json:"token"`
+		Key   struct {
+			ID string `json:"id"`
+		} `json:"key"`
+	}
+	if err := json.Unmarshal(recorder.Body.Bytes(), &created); err != nil {
+		t.Fatalf("decode API key response: %v", err)
+	}
+	if created.Token == "" || created.Key.ID == "" {
+		t.Fatalf("API key response omitted token or ID: %s", recorder.Body.String())
+	}
+	return created.Token, created.Key.ID
+}
+
+func TestRemoteMCPAcceptsXAPIKeyHeader(t *testing.T) {
+	t.Parallel()
+
+	server, _ := newRemoteMCPTestServer(t, nil)
+	token, _ := createRemoteMCPKey(t, server, "Header read", []string{"read"}, nil)
+	recorder := performJSON(t, server.Handler(), http.MethodPost, "/mcp", mcpInitializeRequest, map[string]string{
+		"X-API-Key": token,
+	})
+	if recorder.Code != http.StatusOK || recorder.Header().Get("Mcp-Session-Id") == "" {
+		t.Fatalf("response = %d %s, want initialized MCP session", recorder.Code, recorder.Body.String())
+	}
+}

--- a/internal/web/private_access.go
+++ b/internal/web/private_access.go
@@ -59,7 +59,7 @@ func dashboardAccessPublicRequest(req *http.Request) bool {
 		return false
 	}
 	path := req.URL.Path
-	if path == "/health" || path == openAPIPath || strings.HasPrefix(path, "/static/") {
+	if path == "/health" || path == openAPIPath || path == "/mcp" || strings.HasPrefix(path, "/static/") {
 		return true
 	}
 	if path == "/api/v1/webhooks/github" || strings.HasPrefix(path, "/api/v1/intake/") {

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -29,6 +29,7 @@ import (
 	"github.com/digitaldrywood/detent/internal/efficiency"
 	"github.com/digitaldrywood/detent/internal/hub"
 	kanbanstate "github.com/digitaldrywood/detent/internal/kanban"
+	"github.com/digitaldrywood/detent/internal/mcp"
 	"github.com/digitaldrywood/detent/internal/operatortool"
 	"github.com/digitaldrywood/detent/internal/project"
 	"github.com/digitaldrywood/detent/internal/store"
@@ -164,6 +165,7 @@ type Server struct {
 	chat                *chatpkg.Service
 	issueExplainer      IssueExplainer
 	operatorTools       *operatortool.Executor
+	mcpHTTP             *mcp.HTTPHandler
 }
 
 func NewServer(cfg Config, deps Dependencies) (*Server, error) {
@@ -278,6 +280,12 @@ func NewServer(cfg Config, deps Dependencies) (*Server, error) {
 		chatProvider = server.demoChatProvider()
 	}
 	server.operatorTools = server.newReadOnlyToolExecutor()
+	server.mcpHTTP = mcp.NewHTTPHandler(server.operatorTools, server.version, mcp.HTTPConfig{
+		Principal: func(req *http.Request) string {
+			credential, _ := apiCredentialFromContext(req.Context())
+			return credential.ID
+		},
+	})
 	server.chat = chatpkg.NewService(chatProvider, server.newChatToolExecutor(), server)
 	e.HTTPErrorHandler = server.handleHTTPError
 	e.Use(server.privateDashboardAccess, server.uiAPICookie, server.sessionGate)
@@ -313,7 +321,11 @@ func (s *Server) Shutdown(ctx context.Context) error {
 	if s.keyLimiter != nil {
 		s.keyLimiter.Stop()
 	}
-	err := s.echo.Shutdown(ctx)
+	var err error
+	if s.mcpHTTP != nil {
+		err = s.mcpHTTP.Shutdown(ctx)
+	}
+	err = errors.Join(err, s.echo.Shutdown(ctx))
 	if s.asyncWrites != nil {
 		if closeErr := s.asyncWrites.Close(ctx); closeErr != nil {
 			return errors.Join(err, closeErr)
@@ -368,6 +380,7 @@ func (s *Server) registerRoutes() {
 	s.echo.POST("/onboarding/agent", s.onboardingAgent)
 	s.echo.POST("/onboarding/write", s.onboardingWrite)
 	apiReadAuth := s.apiAuth(false)
+	mcpReadAuth := s.mcpAPIAuth()
 	apiMutateAuth := s.apiAuth(true)
 	apiDashboardReadAuth := s.apiAuthWithOptions(apiAuthOptions{allowUICookie: true, allowDashboardHTMX: true})
 	apiDashboardSSEReadAuth := s.apiAuthWithOptions(apiAuthOptions{allowUICookie: true, allowDashboardSSE: true})
@@ -382,6 +395,7 @@ func (s *Server) registerRoutes() {
 	s.echo.GET("/api/v1/demo/scenarios", s.apiDemoScenarios, apiReadAuth, apiReadScope)
 	s.echo.GET("/api/v1/timeseries", s.apiTimeSeries, apiReadAuth, apiReadScope)
 	s.echo.POST("/api/v1/operator-tools/:tool_name", s.apiOperatorTool, apiReadAuth, apiReadScope)
+	s.echo.Any("/mcp", echo.WrapHandler(s.mcpHTTP), mcpReadAuth)
 	s.echo.POST("/api/v1/projects/:project_id/work-items", s.apiCreateWorkItem, apiMutateAuth, apiProjectWriteScope)
 	s.echo.POST("/api/v1/projects/:project_id/budget/override", s.apiBudgetOverrideSet, apiDashboardMutateAuth, apiProjectWriteScope)
 	s.echo.DELETE("/api/v1/projects/:project_id/budget/override", s.apiBudgetOverrideClear, apiDashboardMutateAuth, apiProjectWriteScope)

--- a/internal/web/session_auth.go
+++ b/internal/web/session_auth.go
@@ -93,7 +93,7 @@ func sessionRouteExempt(request *http.Request) bool {
 		return false
 	}
 	path := request.URL.Path
-	return path == "/health" || path == "/login" || path == "/auth/magic-link" || path == "/auth/oidc/start" || path == "/auth/oidc/callback" || strings.HasPrefix(path, "/static/") || path == openAPIPath || path == "/api/v1/webhooks/github" || strings.HasPrefix(path, "/api/v1/intake/")
+	return path == "/health" || path == "/login" || path == "/auth/magic-link" || path == "/auth/oidc/start" || path == "/auth/oidc/callback" || strings.HasPrefix(path, "/static/") || path == openAPIPath || path == "/mcp" || path == "/api/v1/webhooks/github" || strings.HasPrefix(path, "/api/v1/intake/")
 }
 
 func alternativeAPIAuth(request *http.Request) bool {


### PR DESCRIPTION
## Summary

- serve stateful MCP Streamable HTTP at `/mcp` on the existing web listener
- require global read-only scoped API keys and reuse API rate limits and usage recording
- bound transport resources, cancel sessions during graceful shutdown, and document HTTPS expectations

Fixes #1649

## UI Surface Contract

- [x] N/A, or the linked issue explicitly authorizes any high-impact UI surface, layout, density, first-viewport, or responsive visibility tradeoff.
- [x] Persistent top-of-screen messaging is explicitly authorized by the issue, or this PR does not add it.
- [x] Visual changes to primary operator screens include screenshot or browser verification below.

## Test Plan

- [x] `make check`