### PR TITLE
feat(onboarding): align repository merge policy

### DIFF
--- a/docs/ONBOARDING.md
+++ b/docs/ONBOARDING.md
@@ -826,7 +826,51 @@ recommendations before asking what to change.
    jq -e 'type == "array"' "$ONBOARDING_DIR/priority-counts.json"
    ```
 
-8. **Record recommendations before the interview.** The recommendation must
+8. **Inspect repository merge settings.** Read the target repository's enabled
+   pull request merge methods and save them with the other discovery artifacts.
+   For an existing `detent.yaml`, use its configured
+   `deliverable.merge_method`; otherwise use the maintained template default of
+   `squash`. The artifact records whether the selected method is disabled or
+   whether additional methods remain enabled, either of which would make the
+   repository fail the merge-policy doctor check. Verify:
+
+   ```sh
+   TARGET_REPOSITORY="$(awk -F= '/^TARGET_REPOSITORY=/ {value=$2} END {print value}' "$ONBOARDING_DIR/answers.env")"
+   TARGET_SOURCE_ROOT="$(awk -F= '/^TARGET_SOURCE_ROOT=/ {value=$2} END {print value}' "$ONBOARDING_DIR/answers.env")"
+   DELIVERABLE_MERGE_METHOD="$(sed -n 's/^  merge_method: //p' "$TARGET_SOURCE_ROOT/detent.yaml" 2>/dev/null | tail -n 1)"
+   DELIVERABLE_MERGE_METHOD="${DELIVERABLE_MERGE_METHOD:-squash}"
+   case "$DELIVERABLE_MERGE_METHOD" in
+     squash|merge|rebase) ;;
+     *) printf 'invalid deliverable.merge_method: %s\n' "$DELIVERABLE_MERGE_METHOD" >&2; exit 1 ;;
+   esac
+   gh api "repos/$TARGET_REPOSITORY" \
+     --jq '{allow_merge_commit,allow_squash_merge,allow_rebase_merge}' \
+     > "$ONBOARDING_DIR/repository-merge-settings.json"
+   jq --arg selected "$DELIVERABLE_MERGE_METHOD" '
+     . + {
+       selected_merge_method: $selected,
+       selected_method_enabled: (
+         if $selected == "merge" then .allow_merge_commit
+         elif $selected == "squash" then .allow_squash_merge
+         else .allow_rebase_merge
+         end
+       ),
+       additional_methods_enabled: ([
+         if .allow_merge_commit then "merge" else empty end,
+         if .allow_squash_merge then "squash" else empty end,
+         if .allow_rebase_merge then "rebase" else empty end
+       ] | map(select(. != $selected)) | length > 0)
+     }
+   ' "$ONBOARDING_DIR/repository-merge-settings.json" \
+     > "$ONBOARDING_DIR/repository-merge-policy.json"
+   jq -e '
+     (.selected_merge_method == "squash" or .selected_merge_method == "merge" or .selected_merge_method == "rebase")
+     and (.selected_method_enabled | type == "boolean")
+     and (.additional_methods_enabled | type == "boolean")
+   ' "$ONBOARDING_DIR/repository-merge-policy.json"
+   ```
+
+9. **Record recommendations before the interview.** The recommendation must
    cite the discovery artifact that produced it. Verify:
 
    ```sh
@@ -840,12 +884,13 @@ recommendations before asking what to change.
      'gate: <gate recommendation, from gate-diagnostic.json and gate.txt>' \
      'concurrency: <max agents and Merging cap recommendation>' \
      'review_policy: <hard stop or auto-promote recommendation>' \
+     'merge_policy: <align-or-leave recommendation, from repository-merge-policy.json>' \
      'prompt: <template or repo-specific recommendation, from repo docs>' \
      'backfill: <bulk-add filter and initial Status recommendation>' \
      > "$ONBOARDING_DIR/recommendations.md"
    rg -n '^(mode|board|rate_budget|scheduling|authorization|dashboard_bind):' \
      "$ONBOARDING_DIR/recommendations.md"
-   rg -n '^(gate|concurrency|review_policy|prompt|backfill):' \
+   rg -n '^(gate|concurrency|review_policy|merge_policy|prompt|backfill):' \
      "$ONBOARDING_DIR/recommendations.md"
    ```
 
@@ -1411,7 +1456,30 @@ probes.
    rg '^PROMPT_MODE=' "$ONBOARDING_DIR/answers.env"
    ```
 
-19. **Issue backfill.** Ask: "Which issue filter should be bulk-added, should the
+19. **Repository merge settings.** Read the selected method and mismatch flags
+   from `$ONBOARDING_DIR/repository-merge-policy.json`. When additional methods
+   are enabled, ask: "GitHub currently permits methods beyond the selected
+   `<merge-method>` strategy. Agent-side auto-detection can choose different
+   methods and produce mixed history. Should onboarding align the repository so
+   only `<merge-method>` is enabled?" When the selected method itself is
+   disabled, explain that agents cannot complete the configured delivery
+   strategy and ask the same alignment question. Recommend alignment so the
+   first post-onboarding `detent doctor` run is clean, but make clear that this
+   changes repository settings and still requires Phase 2.5 mutation approval.
+   Declining is valid and does not block onboarding. Ask no question when the
+   repository already enables exactly the selected method. Record every
+   operator answer when a mismatch exists:
+
+   ```sh
+   jq '{selected_merge_method,selected_method_enabled,additional_methods_enabled}' \
+     "$ONBOARDING_DIR/repository-merge-policy.json"
+   printf '%s\n' \
+     'ALIGN_REPOSITORY_MERGE_SETTINGS=<true|false>' \
+     >> "$ONBOARDING_DIR/answers.env"
+   rg '^ALIGN_REPOSITORY_MERGE_SETTINGS=(true|false)$' "$ONBOARDING_DIR/answers.env"
+   ```
+
+20. **Issue backfill.** Ask: "Which issue filter should be bulk-added, should the
    initial `Status` be `Backlog` or `Todo`, and should the human enable the
    auto-add workflow?" Recommendation source: `$ONBOARDING_DIR/issue-counts.json`
    and the authorization answer. Default if silent: bulk-add the narrowest safe
@@ -1440,6 +1508,10 @@ values mutation steps will read:
 
 ```sh
 detent onboarding normalize-answers --answers "$ONBOARDING_DIR/answers.env" --write
+if jq -e '.selected_method_enabled == false or .additional_methods_enabled == true' \
+  "$ONBOARDING_DIR/repository-merge-policy.json" >/dev/null; then
+  rg '^ALIGN_REPOSITORY_MERGE_SETTINGS=(true|false)$' "$ONBOARDING_DIR/answers.env"
+fi
 ```
 
 Show the operator `$ONBOARDING_DIR/recommendations.md`, the plain-English
@@ -1514,6 +1586,45 @@ case "$GITHUB_MODE" in
     exit 1
     ;;
 esac
+```
+
+If the interview found repository merge-policy drift and the operator selected
+`ALIGN_REPOSITORY_MERGE_SETTINGS=true`, apply the alignment only after the gate
+above passes. These are the same three-flag PATCH forms that `detent doctor`
+recommends. Save the resulting settings as a post-mutation artifact. A recorded
+`false` answer skips this mutation and does not block the remaining onboarding
+steps:
+
+```sh
+ALIGN_REPOSITORY_MERGE_SETTINGS="$(awk -F= '/^ALIGN_REPOSITORY_MERGE_SETTINGS=/ {value=$2} END {print value}' "$ONBOARDING_DIR/answers.env")"
+if test "$ALIGN_REPOSITORY_MERGE_SETTINGS" = "true"; then
+  detent onboarding validate-answers --answers "$ONBOARDING_DIR/answers.env" --phase mutation
+  rg '^MUTATION_CONFIRMED=true$' "$ONBOARDING_DIR/answers.env"
+  awk 'NF {last=$0} END {exit last == "MUTATION_CONFIRMED=true" ? 0 : 1}' "$ONBOARDING_DIR/answers.env"
+  TARGET_REPOSITORY="$(awk -F= '/^TARGET_REPOSITORY=/ {value=$2} END {print value}' "$ONBOARDING_DIR/answers.env")"
+  DELIVERABLE_MERGE_METHOD="$(jq -r '.selected_merge_method' "$ONBOARDING_DIR/repository-merge-policy.json")"
+  case "$DELIVERABLE_MERGE_METHOD" in
+    merge)
+      gh api --method PATCH "repos/$TARGET_REPOSITORY" -F allow_merge_commit=true -F allow_squash_merge=false -F allow_rebase_merge=false
+      ;;
+    squash)
+      gh api --method PATCH "repos/$TARGET_REPOSITORY" -F allow_merge_commit=false -F allow_squash_merge=true -F allow_rebase_merge=false
+      ;;
+    rebase)
+      gh api --method PATCH "repos/$TARGET_REPOSITORY" -F allow_merge_commit=false -F allow_squash_merge=false -F allow_rebase_merge=true
+      ;;
+    *)
+      printf 'invalid selected merge method: %s\n' "$DELIVERABLE_MERGE_METHOD" >&2
+      exit 1
+      ;;
+  esac
+  gh api "repos/$TARGET_REPOSITORY" \
+    --jq '{allow_merge_commit,allow_squash_merge,allow_rebase_merge}' \
+    > "$ONBOARDING_DIR/repository-merge-settings.after.json"
+else
+  printf '{"applied":false,"reason":"operator declined or alignment was not needed"}\n' \
+    > "$ONBOARDING_DIR/repository-merge-settings.after.json"
+fi
 ```
 
 Only after this gate passes and the operator has confirmed mutation may doctor
@@ -3149,7 +3260,7 @@ the card instead of auto-resolving it.
 | Human validation label | `gate.kind: human_review` and `gate.approval_label` in `detent.yaml`. |
 | Per-project concurrency | `agent.max_concurrent_agents` in `detent.yaml`. |
 | Per-role reasoning effort | Optional `agent.effort.code`, `agent.effort.rework`, and `agent.effort.merge` defaults in `detent.yaml`. |
-| Pull request merge strategy | `deliverable.merge_method: squash`, `merge`, or `rebase`; defaults to `squash`. |
+| Pull request merge strategy | `deliverable.merge_method: squash`, `merge`, or `rebase`; defaults to `squash`. Onboarding records the repository's enabled methods and, with explicit interview and mutation approval, aligns GitHub to the selected method. |
 | Merge serialization | `agent.max_concurrent_agents_by_state.Merging: 1` in `detent.yaml`. |
 | Session catastrophe bounds | `agent.max_turns`, `agent.max_session_duration_ms`, and `agent.no_progress_timeout_ms`; keep `agent.max_session_tokens` as an additional token-consumption backstop, while `agent.max_session_context_multiplier` remains absent unless explicitly requested as a coarse ceiling. |
 | Hard-stop review policy | `agent.auto_promote.enabled: false` in `detent.yaml`. |

--- a/docs/ONBOARDING.md
+++ b/docs/ONBOARDING.md
@@ -828,45 +828,28 @@ recommendations before asking what to change.
 
 8. **Inspect repository merge settings.** Read the target repository's enabled
    pull request merge methods and save them with the other discovery artifacts.
-   For an existing `detent.yaml`, use its configured
-   `deliverable.merge_method`; otherwise use the maintained template default of
-   `squash`. The artifact records whether the selected method is disabled or
-   whether additional methods remain enabled, either of which would make the
-   repository fail the merge-policy doctor check. Verify:
+   For an existing project definition, use the effective
+   `deliverable.merge_method`, including any `detent.local.yaml` override;
+   otherwise use the maintained template default of `squash`. The artifact
+   records whether the selected method is disabled or whether additional
+   methods remain enabled, either of which would make the repository fail the
+   merge-policy doctor check. Verify:
 
    ```sh
    TARGET_REPOSITORY="$(awk -F= '/^TARGET_REPOSITORY=/ {value=$2} END {print value}' "$ONBOARDING_DIR/answers.env")"
    TARGET_SOURCE_ROOT="$(awk -F= '/^TARGET_SOURCE_ROOT=/ {value=$2} END {print value}' "$ONBOARDING_DIR/answers.env")"
-   DELIVERABLE_MERGE_METHOD="$(sed -n 's/^  merge_method: //p' "$TARGET_SOURCE_ROOT/detent.yaml" 2>/dev/null | tail -n 1)"
-   DELIVERABLE_MERGE_METHOD="${DELIVERABLE_MERGE_METHOD:-squash}"
-   case "$DELIVERABLE_MERGE_METHOD" in
-     squash|merge|rebase) ;;
-     *) printf 'invalid deliverable.merge_method: %s\n' "$DELIVERABLE_MERGE_METHOD" >&2; exit 1 ;;
-   esac
-   gh api "repos/$TARGET_REPOSITORY" \
-     --jq '{allow_merge_commit,allow_squash_merge,allow_rebase_merge}' \
-     > "$ONBOARDING_DIR/repository-merge-settings.json"
-   jq --arg selected "$DELIVERABLE_MERGE_METHOD" '
-     . + {
-       selected_merge_method: $selected,
-       selected_method_enabled: (
-         if $selected == "merge" then .allow_merge_commit
-         elif $selected == "squash" then .allow_squash_merge
-         else .allow_rebase_merge
-         end
-       ),
-       additional_methods_enabled: ([
-         if .allow_merge_commit then "merge" else empty end,
-         if .allow_squash_merge then "squash" else empty end,
-         if .allow_rebase_merge then "rebase" else empty end
-       ] | map(select(. != $selected)) | length > 0)
-     }
-   ' "$ONBOARDING_DIR/repository-merge-settings.json" \
+   detent --format json onboarding inspect-merge-policy \
+     --source-root "$TARGET_SOURCE_ROOT" \
+     --repository "$TARGET_REPOSITORY" \
      > "$ONBOARDING_DIR/repository-merge-policy.json"
    jq -e '
      (.selected_merge_method == "squash" or .selected_merge_method == "merge" or .selected_merge_method == "rebase")
+     and (.selection_source == "template_default" or .selection_source == "effective_project_definition")
      and (.selected_method_enabled | type == "boolean")
      and (.additional_methods_enabled | type == "boolean")
+     and (.allow_merge_commit | type == "boolean")
+     and (.allow_squash_merge | type == "boolean")
+     and (.allow_rebase_merge | type == "boolean")
    ' "$ONBOARDING_DIR/repository-merge-policy.json"
    ```
 
@@ -1456,7 +1439,7 @@ probes.
    rg '^PROMPT_MODE=' "$ONBOARDING_DIR/answers.env"
    ```
 
-19. **Repository merge settings.** Read the selected method and mismatch flags
+18a. **Repository merge settings.** Read the selected method and mismatch flags
    from `$ONBOARDING_DIR/repository-merge-policy.json`. When additional methods
    are enabled, ask: "GitHub currently permits methods beyond the selected
    `<merge-method>` strategy. Agent-side auto-detection can choose different
@@ -1479,7 +1462,7 @@ probes.
    rg '^ALIGN_REPOSITORY_MERGE_SETTINGS=(true|false)$' "$ONBOARDING_DIR/answers.env"
    ```
 
-20. **Issue backfill.** Ask: "Which issue filter should be bulk-added, should the
+19. **Issue backfill.** Ask: "Which issue filter should be bulk-added, should the
    initial `Status` be `Backlog` or `Todo`, and should the human enable the
    auto-add workflow?" Recommendation source: `$ONBOARDING_DIR/issue-counts.json`
    and the authorization answer. Default if silent: bulk-add the narrowest safe

--- a/internal/cli/onboarding.go
+++ b/internal/cli/onboarding.go
@@ -168,6 +168,7 @@ func newOnboardingCommand(configPath *string, opts options) *cobra.Command {
 		newOnboardingDraftAnswersCommand(configPath, opts),
 		newOnboardingBuildWorkflowCommand(),
 		newOnboardingDiagnoseGateCommand(),
+		newOnboardingInspectMergePolicyCommand(),
 	)
 	return cmd
 }

--- a/internal/cli/onboarding_merge_policy.go
+++ b/internal/cli/onboarding_merge_policy.go
@@ -1,0 +1,164 @@
+package cli
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	workflowconfig "github.com/digitaldrywood/detent/internal/config"
+	ghconnector "github.com/digitaldrywood/detent/internal/connector/github"
+)
+
+type onboardingMergePolicyInspectionConfig struct {
+	SourceRoot string
+	Repository string
+}
+
+type onboardingMergePolicyInspectionResult struct {
+	Repository               string `json:"repository"`
+	SelectedMergeMethod      string `json:"selected_merge_method"`
+	SelectedMethodEnabled    bool   `json:"selected_method_enabled"`
+	AdditionalMethodsEnabled bool   `json:"additional_methods_enabled"`
+	AllowMergeCommit         bool   `json:"allow_merge_commit"`
+	AllowSquashMerge         bool   `json:"allow_squash_merge"`
+	AllowRebaseMerge         bool   `json:"allow_rebase_merge"`
+	SelectionSource          string `json:"selection_source"`
+}
+
+type onboardingMergePolicyInspectionDeps struct {
+	loadWorkflow        func(string) (workflowconfig.Workflow, error)
+	githubMergeSettings func(context.Context, workflowconfig.Config, string) (ghconnector.RepositoryMergeSettings, error)
+}
+
+func newOnboardingInspectMergePolicyCommand() *cobra.Command {
+	var sourceRoot string
+	var repository string
+	cmd := &cobra.Command{
+		Use:          "inspect-merge-policy",
+		Short:        "Inspect the effective onboarding merge policy and GitHub settings",
+		Example:      `detent --format json onboarding inspect-merge-policy --source-root /path/to/repo --repository owner/repo`,
+		Args:         NoArgs,
+		SilenceUsage: true,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			out, err := OutputForCommand(cmd)
+			if err != nil {
+				return err
+			}
+			result, err := inspectOnboardingMergePolicy(cmd.Context(), onboardingMergePolicyInspectionConfig{
+				SourceRoot: sourceRoot,
+				Repository: repository,
+			}, onboardingMergePolicyInspectionDeps{})
+			if err != nil {
+				return err
+			}
+			return out.Write(func(w io.Writer) error {
+				return writeOnboardingMergePolicyInspectionPretty(w, result)
+			}, result)
+		},
+	}
+	cmd.Flags().StringVar(&sourceRoot, "source-root", ".", "target repository checkout root")
+	cmd.Flags().StringVar(&repository, "repository", "", "target GitHub repository in owner/name form")
+	return cmd
+}
+
+func inspectOnboardingMergePolicy(
+	ctx context.Context,
+	cfg onboardingMergePolicyInspectionConfig,
+	deps onboardingMergePolicyInspectionDeps,
+) (onboardingMergePolicyInspectionResult, error) {
+	repository := strings.TrimSpace(cfg.Repository)
+	if !onboardingAnswerRepositoryPattern.MatchString(repository) {
+		return onboardingMergePolicyInspectionResult{}, NewValidationError(
+			"--repository must look like owner/name",
+			"Pass the confirmed TARGET_REPOSITORY value from answers.env.",
+			nil,
+		)
+	}
+	sourceRoot, err := resolveOnboardingGateSourceRoot(cfg.SourceRoot)
+	if err != nil {
+		return onboardingMergePolicyInspectionResult{}, err
+	}
+	if deps.loadWorkflow == nil {
+		deps.loadWorkflow = workflowconfig.LoadWorkflow
+	}
+	if deps.githubMergeSettings == nil {
+		deps.githubMergeSettings = defaultDoctorGitHubMergeSettings
+	}
+
+	workflowPath := filepath.Join(sourceRoot, defaultWorkflowFile)
+	effective := workflowconfig.Default()
+	selectionSource := "template_default"
+	present, err := onboardingProjectDefinitionPresent(workflowPath)
+	if err != nil {
+		return onboardingMergePolicyInspectionResult{}, err
+	}
+	if present {
+		workflow, err := deps.loadWorkflow(workflowPath)
+		if err != nil {
+			return onboardingMergePolicyInspectionResult{}, fmt.Errorf("load effective project definition: %w", err)
+		}
+		effective = workflow.Config
+		selectionSource = "effective_project_definition"
+	}
+
+	settings, err := deps.githubMergeSettings(ctx, effective, repository)
+	if err != nil {
+		return onboardingMergePolicyInspectionResult{}, fmt.Errorf("read %s merge settings: %w", repository, err)
+	}
+	selected := effective.Deliverable.EffectiveMergeMethod()
+	return onboardingMergePolicyInspectionResult{
+		Repository:               repository,
+		SelectedMergeMethod:      selected,
+		SelectedMethodEnabled:    doctorRepositoryMergeMethodEnabled(settings, selected),
+		AdditionalMethodsEnabled: onboardingAdditionalMergeMethodsEnabled(settings, selected),
+		AllowMergeCommit:         settings.AllowMergeCommit,
+		AllowSquashMerge:         settings.AllowSquashMerge,
+		AllowRebaseMerge:         settings.AllowRebaseMerge,
+		SelectionSource:          selectionSource,
+	}, nil
+}
+
+func onboardingProjectDefinitionPresent(workflowPath string) (bool, error) {
+	for _, path := range []string{
+		workflowPath,
+		workflowconfig.DefinitionPath(workflowPath),
+		workflowconfig.LocalWorkflowPath(workflowPath),
+		workflowconfig.LocalDefinitionPath(workflowPath),
+	} {
+		_, err := os.Stat(path)
+		if err == nil {
+			return true, nil
+		}
+		if !os.IsNotExist(err) {
+			return false, fmt.Errorf("inspect project definition %s: %w", path, err)
+		}
+	}
+	return false, nil
+}
+
+func onboardingAdditionalMergeMethodsEnabled(settings ghconnector.RepositoryMergeSettings, selected string) bool {
+	return selected != workflowconfig.MergeMethodMerge && settings.AllowMergeCommit ||
+		selected != workflowconfig.MergeMethodSquash && settings.AllowSquashMerge ||
+		selected != workflowconfig.MergeMethodRebase && settings.AllowRebaseMerge
+}
+
+func writeOnboardingMergePolicyInspectionPretty(w io.Writer, result onboardingMergePolicyInspectionResult) error {
+	_, err := fmt.Fprintf(
+		w,
+		"repository: %s\nselected_merge_method: %s\nselection_source: %s\nselected_method_enabled: %t\nadditional_methods_enabled: %t\nallow_merge_commit: %t\nallow_squash_merge: %t\nallow_rebase_merge: %t\n",
+		result.Repository,
+		result.SelectedMergeMethod,
+		result.SelectionSource,
+		result.SelectedMethodEnabled,
+		result.AdditionalMethodsEnabled,
+		result.AllowMergeCommit,
+		result.AllowSquashMerge,
+		result.AllowRebaseMerge,
+	)
+	return err
+}

--- a/internal/cli/onboarding_merge_policy_test.go
+++ b/internal/cli/onboarding_merge_policy_test.go
@@ -1,0 +1,113 @@
+package cli
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	workflowconfig "github.com/digitaldrywood/detent/internal/config"
+	ghconnector "github.com/digitaldrywood/detent/internal/connector/github"
+)
+
+func TestInspectOnboardingMergePolicy(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name                 string
+		sharedMergeMethod    string
+		localMergeMethod     string
+		settings             ghconnector.RepositoryMergeSettings
+		wantMethod           string
+		wantSource           string
+		wantSelectedEnabled  bool
+		wantAdditionalEnable bool
+	}{
+		{
+			name:                "template default",
+			settings:            ghconnector.RepositoryMergeSettings{AllowSquashMerge: true},
+			wantMethod:          workflowconfig.MergeMethodSquash,
+			wantSource:          "template_default",
+			wantSelectedEnabled: true,
+		},
+		{
+			name:                 "effective local override",
+			sharedMergeMethod:    workflowconfig.MergeMethodSquash,
+			localMergeMethod:     workflowconfig.MergeMethodRebase,
+			settings:             ghconnector.RepositoryMergeSettings{AllowMergeCommit: true, AllowRebaseMerge: true},
+			wantMethod:           workflowconfig.MergeMethodRebase,
+			wantSource:           "effective_project_definition",
+			wantSelectedEnabled:  true,
+			wantAdditionalEnable: true,
+		},
+		{
+			name:                 "configured method forbidden",
+			sharedMergeMethod:    workflowconfig.MergeMethodMerge,
+			settings:             ghconnector.RepositoryMergeSettings{AllowSquashMerge: true},
+			wantMethod:           workflowconfig.MergeMethodMerge,
+			wantSource:           "effective_project_definition",
+			wantAdditionalEnable: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			root := t.TempDir()
+			if tt.sharedMergeMethod != "" {
+				writeOnboardingMergePolicyDefinition(t, root, tt.sharedMergeMethod, tt.localMergeMethod)
+			}
+
+			var effectiveMethod string
+			result, err := inspectOnboardingMergePolicy(t.Context(), onboardingMergePolicyInspectionConfig{
+				SourceRoot: root,
+				Repository: "digitaldrywood/detent",
+			}, onboardingMergePolicyInspectionDeps{
+				loadWorkflow: workflowconfig.LoadWorkflow,
+				githubMergeSettings: func(_ context.Context, cfg workflowconfig.Config, repository string) (ghconnector.RepositoryMergeSettings, error) {
+					if repository != "digitaldrywood/detent" {
+						t.Fatalf("repository = %q, want digitaldrywood/detent", repository)
+					}
+					effectiveMethod = cfg.Deliverable.EffectiveMergeMethod()
+					return tt.settings, nil
+				},
+			})
+			if err != nil {
+				t.Fatalf("inspectOnboardingMergePolicy() error = %v", err)
+			}
+			if result.SelectedMergeMethod != tt.wantMethod || effectiveMethod != tt.wantMethod {
+				t.Fatalf("selected methods = result %q, reader %q, want %q", result.SelectedMergeMethod, effectiveMethod, tt.wantMethod)
+			}
+			if result.SelectionSource != tt.wantSource {
+				t.Fatalf("SelectionSource = %q, want %q", result.SelectionSource, tt.wantSource)
+			}
+			if result.SelectedMethodEnabled != tt.wantSelectedEnabled {
+				t.Fatalf("SelectedMethodEnabled = %t, want %t", result.SelectedMethodEnabled, tt.wantSelectedEnabled)
+			}
+			if result.AdditionalMethodsEnabled != tt.wantAdditionalEnable {
+				t.Fatalf("AdditionalMethodsEnabled = %t, want %t", result.AdditionalMethodsEnabled, tt.wantAdditionalEnable)
+			}
+			if result.AllowMergeCommit != tt.settings.AllowMergeCommit ||
+				result.AllowSquashMerge != tt.settings.AllowSquashMerge ||
+				result.AllowRebaseMerge != tt.settings.AllowRebaseMerge {
+				t.Fatalf("repository settings = %#v, want %#v", result, tt.settings)
+			}
+		})
+	}
+}
+
+func writeOnboardingMergePolicyDefinition(t *testing.T, root string, sharedMethod string, localMethod string) {
+	t.Helper()
+	files := map[string]string{
+		"WORKFLOW.md": "Shared direction.\n",
+		"detent.yaml": "schema: 1\ntracker:\n  kind: memory\ndeliverable:\n  merge_method: " + sharedMethod + "\n",
+	}
+	if localMethod != "" {
+		files["detent.local.yaml"] = "schema: 1\ndeliverable:\n  merge_method: " + localMethod + "\n"
+	}
+	for name, content := range files {
+		if err := os.WriteFile(filepath.Join(root, name), []byte(content), 0o600); err != nil {
+			t.Fatalf("WriteFile(%s) error = %v", name, err)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

- add a read-only onboarding command that records GitHub merge settings with the effective project merge method
- ask operators whether to align drift, state the mixed-history consequence, and accept decline
- gate doctor-equivalent repository PATCH commands behind Phase 2.5 approval
- document repository merge-policy alignment in onboarding discovery and reference guidance

Fixes #1679

## UI Surface Contract

- [x] N/A, or the linked issue explicitly authorizes any high-impact UI surface, layout, density, first-viewport, or responsive visibility tradeoff.
- [x] Persistent top-of-screen messaging is explicitly authorized by the issue, or this PR does not add it.
- [x] Visual changes to primary operator screens include screenshot or browser verification below.

## Test Plan

- [x] `go test . -run '^TestOnboardingDocsDistinguishIssueBackfillFromIntakeSources$'`
- [x] `go test ./internal/cli -run '^TestInspectOnboardingMergePolicy$'`
- [x] `env -u DETENT_API_TOKEN make check`
