### PR TITLE
feat(doctor): report config git status

### DIFF
--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -128,17 +128,18 @@ type configPathResult struct {
 }
 
 type projectResult struct {
-	ID               string `json:"id"`
-	Workflow         string `json:"workflow"`
-	WorkflowRef      string `json:"workflow_ref,omitempty"`
-	Workdir          string `json:"workdir"`
-	Weight           int    `json:"weight"`
-	Priority         int    `json:"priority"`
-	Paused           bool   `json:"paused"`
-	PausedReason     string `json:"paused_reason,omitempty"`
-	PausedUntilIssue string `json:"paused_until_issue,omitempty"`
-	PausedUntil      string `json:"paused_until,omitempty"`
-	CredentialRef    string `json:"credential_ref,omitempty"`
+	ID                    string                 `json:"id"`
+	Workflow              string                 `json:"workflow"`
+	WorkflowRef           string                 `json:"workflow_ref,omitempty"`
+	Workdir               string                 `json:"workdir"`
+	Weight                int                    `json:"weight"`
+	Priority              int                    `json:"priority"`
+	Paused                bool                   `json:"paused"`
+	PausedReason          string                 `json:"paused_reason,omitempty"`
+	PausedUntilIssue      string                 `json:"paused_until_issue,omitempty"`
+	PausedUntil           string                 `json:"paused_until,omitempty"`
+	CredentialRef         string                 `json:"credential_ref,omitempty"`
+	GlobalConfigGitStatus *globalConfigGitStatus `json:"global_config_git,omitempty"`
 }
 
 type projectPausedResult struct {
@@ -786,6 +787,7 @@ func newAddProjectCommand(configPath *string, opts options) *cobra.Command {
 			if err := opts.write(path, global); err != nil {
 				return err
 			}
+			gitStatus := inspectGlobalConfigGit(cmd.Context(), path, opts.runCommand)
 			if err := opts.signal(cmd.Context(), Signal{
 				Operation: OperationAddProject,
 				ProjectID: cfg.ID,
@@ -793,7 +795,11 @@ func newAddProjectCommand(configPath *string, opts options) *cobra.Command {
 			}); err != nil {
 				return err
 			}
-			return out.Write(nil, newProjectResult(cfg))
+			result := newProjectResult(cfg)
+			result.GlobalConfigGitStatus = gitStatus
+			return out.Write(func(w io.Writer) error {
+				return writeProjectRegistrationPretty(w, path, result)
+			}, result)
 		},
 	}
 	cmd.Flags().StringVar(&cfg.ID, "id", "", "project id")
@@ -1158,6 +1164,23 @@ func newProjectResult(project globalconfig.Project) projectResult {
 		PausedUntil:      project.PausedUntil,
 		CredentialRef:    project.CredentialRef,
 	}
+}
+
+func writeProjectRegistrationPretty(w io.Writer, path string, result projectResult) error {
+	if result.GlobalConfigGitStatus == nil {
+		return nil
+	}
+	status := result.GlobalConfigGitStatus
+	lines := []string{
+		fmt.Sprintf("project %s registered in %s", result.ID, path),
+		"global_config_repository: " + status.RepositoryRoot,
+		"global_config_status: " + status.trackedStatus(),
+	}
+	if status.Dirty {
+		lines = append(lines, "warning: "+globalConfigGitDurabilityWarning(status.RepositoryRoot))
+	}
+	_, err := fmt.Fprintln(w, strings.Join(lines, "\n"))
+	return err
 }
 
 func projectEditResult(operation Operation, project globalconfig.Project) any {

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -1214,6 +1214,10 @@ func TestAddProjectReportsDirtyGlobalConfigRepository(t *testing.T) {
 			writeGlobalConfig(t, targetPath, nil)
 			runCLITestGit(t, repo, "init")
 			repositoryRoot := runCLITestGit(t, repo, "rev-parse", "--show-toplevel")
+			repositoryRoot, err := filepath.Abs(repositoryRoot)
+			if err != nil {
+				t.Fatalf("Abs(%q) error = %v", repositoryRoot, err)
+			}
 			runCLITestGit(t, repo, "add", "global.yaml")
 			runCLITestGit(t, repo, "-c", "user.name=Detent Test", "-c", "user.email=detent@example.com", "commit", "-m", "initial")
 

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -1243,7 +1243,15 @@ func TestAddProjectReportsDirtyGlobalConfigRepository(t *testing.T) {
 			if err := cmd.Execute(); err != nil {
 				t.Fatalf("Execute() error = %v", err)
 			}
-			for _, want := range append([]string{repositoryRoot}, tt.want...) {
+			repositoryRootOutput := repositoryRoot
+			if len(tt.formatArgs) > 0 {
+				encodedRepositoryRoot, err := json.Marshal(repositoryRoot)
+				if err != nil {
+					t.Fatalf("Marshal(%q) error = %v", repositoryRoot, err)
+				}
+				repositoryRootOutput = `"repository_root": ` + string(encodedRepositoryRoot)
+			}
+			for _, want := range append([]string{repositoryRootOutput}, tt.want...) {
 				if !strings.Contains(stdout.String(), want) {
 					t.Fatalf("stdout missing %q:\n%s", want, stdout.String())
 				}

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -1213,6 +1213,7 @@ func TestAddProjectReportsDirtyGlobalConfigRepository(t *testing.T) {
 			targetPath := filepath.Join(repo, "global.yaml")
 			writeGlobalConfig(t, targetPath, nil)
 			runCLITestGit(t, repo, "init")
+			repositoryRoot := runCLITestGit(t, repo, "rev-parse", "--show-toplevel")
 			runCLITestGit(t, repo, "add", "global.yaml")
 			runCLITestGit(t, repo, "-c", "user.name=Detent Test", "-c", "user.email=detent@example.com", "commit", "-m", "initial")
 
@@ -1238,7 +1239,7 @@ func TestAddProjectReportsDirtyGlobalConfigRepository(t *testing.T) {
 			if err := cmd.Execute(); err != nil {
 				t.Fatalf("Execute() error = %v", err)
 			}
-			for _, want := range append([]string{repo}, tt.want...) {
+			for _, want := range append([]string{repositoryRoot}, tt.want...) {
 				if !strings.Contains(stdout.String(), want) {
 					t.Fatalf("stdout missing %q:\n%s", want, stdout.String())
 				}
@@ -1917,7 +1918,7 @@ func writeGlobalConfig(t *testing.T, path string, projects []globalconfig.Projec
 	}
 }
 
-func runCLITestGit(t *testing.T, dir string, args ...string) {
+func runCLITestGit(t *testing.T, dir string, args ...string) string {
 	t.Helper()
 
 	cmd := exec.Command("git", args...)
@@ -1926,6 +1927,7 @@ func runCLITestGit(t *testing.T, dir string, args ...string) {
 	if err != nil {
 		t.Fatalf("git %s error = %v\n%s", strings.Join(args, " "), err, output)
 	}
+	return strings.TrimSpace(string(output))
 }
 
 func assertProject(t *testing.T, configPath string, id string, assert func(globalconfig.Project)) {

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"reflect"
 	"strings"
@@ -879,7 +880,9 @@ func TestProjectCommandsWriteJSONResults(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			cmd := cli.NewRootCommand(context.Background())
+			cmd := cli.NewRootCommand(context.Background(), cli.WithCommandRunner(func(context.Context, string, ...string) (string, error) {
+				return "", errors.New("not a git repository")
+			}))
 			var stdout bytes.Buffer
 			cmd.SetOut(&stdout)
 			cmd.SetErr(&bytes.Buffer{})
@@ -1181,6 +1184,66 @@ func TestAddProjectCommandEmitsJSONResult(t *testing.T) {
 	}
 	if got.Weight != 5 || !got.Paused {
 		t.Fatalf("project weight/paused = %d/%v, want 5/true", got.Weight, got.Paused)
+	}
+}
+
+func TestAddProjectReportsDirtyGlobalConfigRepository(t *testing.T) {
+	tests := []struct {
+		name       string
+		formatArgs []string
+		stdoutTTY  bool
+		want       []string
+	}{
+		{
+			name:      "pretty",
+			stdoutTTY: true,
+			want:      []string{"global_config_repository:", "global_config_status: tracked", "not durably recorded", "git checkout", "git reset"},
+		},
+		{
+			name:       "json",
+			formatArgs: []string{"--format", "json"},
+			want:       []string{`"global_config_git"`, `"tracked": true`, `"dirty": true`, `"status": " M global.yaml"`},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			paths := createProjectFiles(t)
+			repo := paths.root
+			targetPath := filepath.Join(repo, "global.yaml")
+			writeGlobalConfig(t, targetPath, nil)
+			runCLITestGit(t, repo, "init")
+			runCLITestGit(t, repo, "add", "global.yaml")
+			runCLITestGit(t, repo, "-c", "user.name=Detent Test", "-c", "user.email=detent@example.com", "commit", "-m", "initial")
+
+			linkPath := filepath.Join(t.TempDir(), "global.yaml")
+			if err := os.Symlink(targetPath, linkPath); err != nil {
+				t.Skipf("symlink unavailable: %v", err)
+			}
+
+			cmd := cli.NewRootCommand(context.Background(), cli.WithStdoutTTY(func() bool { return tt.stdoutTTY }))
+			var stdout bytes.Buffer
+			cmd.SetOut(&stdout)
+			cmd.SetErr(&bytes.Buffer{})
+			args := append([]string{}, tt.formatArgs...)
+			args = append(args,
+				"--config", linkPath,
+				"add-project",
+				"--id", "detent",
+				"--workflow", paths.workflowPath,
+				"--workdir", paths.workdirPath,
+			)
+			cmd.SetArgs(args)
+
+			if err := cmd.Execute(); err != nil {
+				t.Fatalf("Execute() error = %v", err)
+			}
+			for _, want := range append([]string{repo}, tt.want...) {
+				if !strings.Contains(stdout.String(), want) {
+					t.Fatalf("stdout missing %q:\n%s", want, stdout.String())
+				}
+			}
+		})
 	}
 }
 
@@ -1851,6 +1914,17 @@ func writeGlobalConfig(t *testing.T, path string, projects []globalconfig.Projec
 	}
 	if err := globalconfig.Write(path, cfg); err != nil {
 		t.Fatalf("Write() error = %v", err)
+	}
+}
+
+func runCLITestGit(t *testing.T, dir string, args ...string) {
+	t.Helper()
+
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("git %s error = %v\n%s", strings.Join(args, " "), err, output)
 	}
 }
 

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -417,7 +417,7 @@ func runDoctor(ctx context.Context, cfg doctorConfig, opts options, deps doctorD
 		boot.Global = *global
 		boot.Host = bootHost(ctx, cfg.Host, firstGlobalProject(*global))
 		writeDoctorProgressStart(progressOut, "Global config reload")
-		check := checkDoctorConfigReload(*global)
+		check := checkDoctorConfigReload(ctx, *global, opts.runCommand)
 		writeDoctorProgressDone(progressOut, check)
 		report.Add(check)
 		writeDoctorProgressStart(progressOut, "Instance identity")

--- a/internal/cli/doctor_environment.go
+++ b/internal/cli/doctor_environment.go
@@ -78,7 +78,7 @@ func resolveDoctorBinaryEnvironment(ctx context.Context, resolution globalconfig
 	return fallback("orchestrator PATH is unavailable because the running instance did not report it")
 }
 
-func checkDoctorConfigReload(cfg globalconfig.Config) doctorCheck {
+func checkDoctorConfigReload(ctx context.Context, cfg globalconfig.Config, run CommandRunner) doctorCheck {
 	path := strings.TrimSpace(cfg.Path)
 	if path == "" {
 		return doctorCheck{
@@ -98,28 +98,36 @@ func checkDoctorConfigReload(cfg globalconfig.Config) doctorCheck {
 			Hint:   "Fix the global config path before relying on live reload.",
 		}
 	}
-	if info.Mode()&os.ModeSymlink == 0 {
-		return doctorCheck{
-			Name:   "Global config reload",
-			Status: doctorOK,
-			Detail: path + " is watched for live reload",
+	target := path
+	detail := path + " is watched for live reload"
+	if info.Mode()&os.ModeSymlink != 0 {
+		target, err = filepath.EvalSymlinks(path)
+		if err != nil {
+			return doctorCheck{
+				Name:   "Global config reload",
+				Status: doctorWarn,
+				Detail: fmt.Sprintf("%s is a symlink but its target cannot be resolved: %v", path, err),
+				Hint:   "Fix the symlink target before relying on live reload.",
+			}
 		}
+		detail = fmt.Sprintf("%s is a symlink to %s; live reload watches the configured path and target", path, target)
 	}
 
-	target, err := filepath.EvalSymlinks(path)
-	if err != nil {
-		return doctorCheck{
-			Name:   "Global config reload",
-			Status: doctorWarn,
-			Detail: fmt.Sprintf("%s is a symlink but its target cannot be resolved: %v", path, err),
-			Hint:   "Fix the symlink target before relying on live reload.",
-		}
-	}
-	return doctorCheck{
+	check := doctorCheck{
 		Name:   "Global config reload",
 		Status: doctorOK,
-		Detail: fmt.Sprintf("%s is a symlink to %s; live reload watches the configured path and target", path, target),
+		Detail: detail,
 	}
+	gitStatus := inspectGlobalConfigGit(ctx, target, run)
+	if gitStatus == nil {
+		return check
+	}
+	check.Detail += fmt.Sprintf("; resolved config %s is in git repository %s and is %s", gitStatus.ResolvedPath, gitStatus.RepositoryRoot, gitStatus.trackedStatus())
+	if gitStatus.Dirty {
+		check.Status = doctorWarn
+		check.Hint = globalConfigGitDurabilityWarning(gitStatus.RepositoryRoot)
+	}
+	return check
 }
 
 func checkDoctorInstanceIdentity(cfg globalconfig.Config) doctorCheck {

--- a/internal/cli/doctor_test.go
+++ b/internal/cli/doctor_test.go
@@ -1819,7 +1819,9 @@ func TestCheckDoctorConfigReload(t *testing.T) {
 		t.Fatalf("WriteFile() error = %v", err)
 	}
 
-	got := checkDoctorConfigReload(globalconfig.Config{Path: path})
+	got := checkDoctorConfigReload(context.Background(), globalconfig.Config{Path: path}, func(context.Context, string, ...string) (string, error) {
+		return "", errors.New("not a git repository")
+	})
 	if got.Status != doctorOK {
 		t.Fatalf("Status = %s, want %s", got.Status, doctorOK)
 	}
@@ -1846,7 +1848,9 @@ func TestCheckDoctorConfigReloadReportsSymlinkTarget(t *testing.T) {
 		t.Fatalf("EvalSymlinks() error = %v", err)
 	}
 
-	got := checkDoctorConfigReload(globalconfig.Config{Path: linkPath})
+	got := checkDoctorConfigReload(context.Background(), globalconfig.Config{Path: linkPath}, func(context.Context, string, ...string) (string, error) {
+		return "", errors.New("not a git repository")
+	})
 	if got.Status != doctorOK {
 		t.Fatalf("Status = %s, want %s", got.Status, doctorOK)
 	}
@@ -1854,6 +1858,117 @@ func TestCheckDoctorConfigReloadReportsSymlinkTarget(t *testing.T) {
 		if !strings.Contains(got.Detail, want) {
 			t.Fatalf("Detail = %q, want containing %q", got.Detail, want)
 		}
+	}
+}
+
+func TestCheckDoctorConfigReloadReportsGitStatus(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		setup      func(*testing.T) (globalconfig.Config, CommandRunner)
+		wantStatus doctorStatus
+		wantDetail []string
+		wantHint   []string
+		avoid      []string
+	}{
+		{
+			name: "regular tracked config is clean",
+			setup: func(t *testing.T) (globalconfig.Config, CommandRunner) {
+				repo := t.TempDir()
+				path := filepath.Join(repo, "global.yaml")
+				if err := os.WriteFile(path, []byte("global"), 0o600); err != nil {
+					t.Fatalf("WriteFile() error = %v", err)
+				}
+				runDoctorWorkflowSourceGit(t, repo, "init")
+				runDoctorWorkflowSourceGit(t, repo, "add", "global.yaml")
+				runDoctorWorkflowSourceGit(t, repo, "-c", "user.name=Detent Test", "-c", "user.email=detent@example.com", "commit", "-m", "initial")
+				return globalconfig.Config{Path: path}, defaultCommandRunner
+			},
+			wantStatus: doctorOK,
+			wantDetail: []string{"is watched for live reload", "git repository", "global.yaml", "tracked and clean"},
+		},
+		{
+			name: "symlink target has tracked changes",
+			setup: func(t *testing.T) (globalconfig.Config, CommandRunner) {
+				repo := t.TempDir()
+				targetPath := filepath.Join(repo, "global.yaml")
+				if err := os.WriteFile(targetPath, []byte("before"), 0o600); err != nil {
+					t.Fatalf("WriteFile() error = %v", err)
+				}
+				runDoctorWorkflowSourceGit(t, repo, "init")
+				runDoctorWorkflowSourceGit(t, repo, "add", "global.yaml")
+				runDoctorWorkflowSourceGit(t, repo, "-c", "user.name=Detent Test", "-c", "user.email=detent@example.com", "commit", "-m", "initial")
+				if err := os.WriteFile(targetPath, []byte("after"), 0o600); err != nil {
+					t.Fatalf("WriteFile() error = %v", err)
+				}
+				linkPath := filepath.Join(t.TempDir(), "global.yaml")
+				if err := os.Symlink(targetPath, linkPath); err != nil {
+					t.Skipf("symlink unavailable: %v", err)
+				}
+				return globalconfig.Config{Path: linkPath}, defaultCommandRunner
+			},
+			wantStatus: doctorWarn,
+			wantDetail: []string{"symlink", "git repository", "global.yaml", "tracked status", " M global.yaml"},
+			wantHint:   []string{"not durably recorded", "git checkout", "git reset", "discard"},
+		},
+		{
+			name: "config outside repository is skipped",
+			setup: func(t *testing.T) (globalconfig.Config, CommandRunner) {
+				path := filepath.Join(t.TempDir(), "global.yaml")
+				if err := os.WriteFile(path, []byte("global"), 0o600); err != nil {
+					t.Fatalf("WriteFile() error = %v", err)
+				}
+				return globalconfig.Config{Path: path}, func(context.Context, string, ...string) (string, error) {
+					return "", errors.New("not a git repository")
+				}
+			},
+			wantStatus: doctorOK,
+			wantDetail: []string{"is watched for live reload"},
+			avoid:      []string{"git repository", "not durably recorded"},
+		},
+		{
+			name: "git unavailable is skipped",
+			setup: func(t *testing.T) (globalconfig.Config, CommandRunner) {
+				path := filepath.Join(t.TempDir(), "global.yaml")
+				if err := os.WriteFile(path, []byte("global"), 0o600); err != nil {
+					t.Fatalf("WriteFile() error = %v", err)
+				}
+				return globalconfig.Config{Path: path}, func(context.Context, string, ...string) (string, error) {
+					return "", errors.New("git unavailable")
+				}
+			},
+			wantStatus: doctorOK,
+			wantDetail: []string{"is watched for live reload"},
+			avoid:      []string{"git repository", "not durably recorded"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			cfg, runner := tt.setup(t)
+			got := checkDoctorConfigReload(context.Background(), cfg, runner)
+			if got.Status != tt.wantStatus {
+				t.Fatalf("Status = %s, want %s: %#v", got.Status, tt.wantStatus, got)
+			}
+			for _, want := range tt.wantDetail {
+				if !strings.Contains(got.Detail, want) {
+					t.Fatalf("Detail = %q, want containing %q", got.Detail, want)
+				}
+			}
+			for _, want := range tt.wantHint {
+				if !strings.Contains(got.Hint, want) {
+					t.Fatalf("Hint = %q, want containing %q", got.Hint, want)
+				}
+			}
+			for _, avoid := range tt.avoid {
+				if strings.Contains(got.Detail+got.Hint, avoid) {
+					t.Fatalf("check output = %q, want not containing %q", got.Detail+got.Hint, avoid)
+				}
+			}
+		})
 	}
 }
 

--- a/internal/cli/global_config_git.go
+++ b/internal/cli/global_config_git.go
@@ -1,0 +1,91 @@
+package cli
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"strings"
+)
+
+type globalConfigGitStatus struct {
+	RepositoryRoot string `json:"repository_root"`
+	ResolvedPath   string `json:"resolved_path"`
+	Tracked        bool   `json:"tracked"`
+	Dirty          bool   `json:"dirty"`
+	Status         string `json:"status"`
+}
+
+func inspectGlobalConfigGit(ctx context.Context, path string, run CommandRunner) *globalConfigGitStatus {
+	if ctx == nil || run == nil || strings.TrimSpace(path) == "" {
+		return nil
+	}
+
+	resolved, err := filepath.EvalSymlinks(path)
+	if err != nil {
+		return nil
+	}
+	resolved, err = filepath.Abs(resolved)
+	if err != nil {
+		return nil
+	}
+	resolved = filepath.Clean(resolved)
+
+	rootOutput, err := run(ctx, "git", "-C", filepath.Dir(resolved), "rev-parse", "--show-toplevel")
+	if err != nil {
+		return nil
+	}
+	repositoryRoot := strings.TrimSpace(rootOutput)
+	if repositoryRoot == "" {
+		return nil
+	}
+	repositoryRoot, err = filepath.Abs(repositoryRoot)
+	if err != nil {
+		return nil
+	}
+	repositoryRoot = filepath.Clean(repositoryRoot)
+	relativePath, err := filepath.Rel(repositoryRoot, resolved)
+	if err != nil || relativePath == ".." || strings.HasPrefix(relativePath, ".."+string(filepath.Separator)) {
+		return nil
+	}
+	relativePath = filepath.ToSlash(relativePath)
+
+	_, trackedErr := run(ctx, "git", "-C", repositoryRoot, "ls-files", "--error-unmatch", "--", relativePath)
+	statusOutput, err := run(ctx, "git", "-C", repositoryRoot, "status", "--short", "--untracked-files=all", "--", relativePath)
+	if err != nil {
+		return nil
+	}
+	status := strings.TrimRight(statusOutput, "\r\n")
+	tracked := trackedErr == nil
+	if status == "" {
+		if tracked {
+			status = "clean"
+		} else {
+			status = "untracked"
+		}
+	}
+
+	return &globalConfigGitStatus{
+		RepositoryRoot: repositoryRoot,
+		ResolvedPath:   resolved,
+		Tracked:        tracked,
+		Dirty:          !tracked || status != "clean",
+		Status:         status,
+	}
+}
+
+func (s globalConfigGitStatus) trackedStatus() string {
+	switch {
+	case s.Tracked && !s.Dirty:
+		return "tracked and clean"
+	case s.Tracked:
+		return fmt.Sprintf("tracked status %q", s.Status)
+	case s.Status == "untracked":
+		return "untracked"
+	default:
+		return fmt.Sprintf("untracked status %q", s.Status)
+	}
+}
+
+func globalConfigGitDurabilityWarning(repositoryRoot string) string {
+	return fmt.Sprintf("The registration is not durably recorded; a later git checkout or git reset in %s can discard it. Commit the global config change in that repository when ready.", repositoryRoot)
+}


### PR DESCRIPTION
## Summary

- inspect the resolved global config path for its containing git repository and file status
- warn when tracked or untracked config changes are not durably recorded
- surface the same repository and status details from onboarding registration through `detent add-project`

Fixes #1682

## UI Surface Contract

- [x] N/A, or the linked issue explicitly authorizes any high-impact UI surface, layout, density, first-viewport, or responsive visibility tradeoff.
- [x] Persistent top-of-screen messaging is explicitly authorized by the issue, or this PR does not add it.
- [x] Visual changes to primary operator screens include screenshot or browser verification below.

## Test Plan

- [x] Focused doctor and add-project tests
- [x] `go test ./internal/cli`
- [x] `make check`