### PR TITLE
fix(onboarding): wire escape-hatch labels

### DIFF
--- a/docs/ONBOARDING.md
+++ b/docs/ONBOARDING.md
@@ -1539,6 +1539,40 @@ rg '^MUTATION_CONFIRMED=true$' "$ONBOARDING_DIR/answers.env"
 awk 'NF {last=$0} END {exit last == "MUTATION_CONFIRMED=true" ? 0 : 1}' "$ONBOARDING_DIR/answers.env"
 ```
 
+Create the repository labels referenced by the generated escape-hatch config
+for every GitHub status-source mode. Read the existing inventory first and do
+not pass `--force`: an existing label with the same case-insensitive name must
+be left unchanged. The helper also remains available for the status-label step
+below when `GITHUB_MODE=label`:
+
+```sh
+TARGET_REPOSITORY="$(awk -F= '/^TARGET_REPOSITORY=/ {value=$2} END {print value}' "$ONBOARDING_DIR/answers.env")"
+AUTO_PROMOTE_OPTOUT_LABEL="$(awk -F= '/^AUTO_PROMOTE_OPTOUT_LABEL=/ {value=$2} END {print value}' "$ONBOARDING_DIR/answers.env")"
+MAX_SESSION_TOKEN_OVERRIDE_LABEL="$(awk -F= '/^MAX_SESSION_TOKEN_OVERRIDE_LABEL=/ {value=$2} END {print value}' "$ONBOARDING_DIR/answers.env")"
+test -n "$AUTO_PROMOTE_OPTOUT_LABEL" || AUTO_PROMOTE_OPTOUT_LABEL=requires-human-review
+test -n "$MAX_SESSION_TOKEN_OVERRIDE_LABEL" || MAX_SESSION_TOKEN_OVERRIDE_LABEL=allow-large-session
+
+gh api "repos/$TARGET_REPOSITORY/labels" --paginate --jq '.[].name' \
+  > "$ONBOARDING_DIR/repo-labels.txt"
+
+create_label_if_missing() {
+  label_name="$1"
+  label_color="$2"
+  label_description="$3"
+  if rg -Fxi -- "$label_name" "$ONBOARDING_DIR/repo-labels.txt" >/dev/null; then
+    return
+  fi
+  gh label create "$label_name" --repo "$TARGET_REPOSITORY" \
+    --color "$label_color" --description "$label_description"
+  printf '%s\n' "$label_name" >> "$ONBOARDING_DIR/repo-labels.txt"
+}
+
+create_label_if_missing "$AUTO_PROMOTE_OPTOUT_LABEL" b60205 \
+  "Excludes an issue from Detent auto-promotion."
+create_label_if_missing "$MAX_SESSION_TOKEN_OVERRIDE_LABEL" fbca04 \
+  "Allows an issue to exceed the configured agent session token ceiling."
+```
+
 Before any ProjectV2 board mutation such as `gh project create`, `gh project
 link`, `gh project field-create`, or `gh project item-edit`, also run:
 
@@ -1841,26 +1875,27 @@ awk 'NF {last=$0} END {exit last == "MUTATION_CONFIRMED=true" ? 0 : 1}' "$ONBOAR
      "$ONBOARDING_DIR/repo-labels.sorted.txt"
    ```
 
-   If `comm` prints missing labels and you are using the default prefix, create
-   them before starting Detent:
+   If `comm` prints missing labels, create them before starting Detent. Reuse
+   the idempotent `create_label_if_missing` helper defined above so existing
+   labels are not overwritten:
 
    ```sh
-   gh label create detent:backlog --repo <repo-owner>/<repo-name> \
-     --color cfd3d7 --description "Not ready for Detent dispatch."
-   gh label create detent:todo --repo <repo-owner>/<repo-name> \
-     --color cfd3d7 --description "Ready for Detent dispatch."
-   gh label create detent:in-progress --repo <repo-owner>/<repo-name> \
-     --color fbca04 --description "Work is currently active."
-   gh label create detent:blocked --repo <repo-owner>/<repo-name> \
-     --color d73a4a --description "Cannot continue without human input."
-   gh label create detent:human-review --repo <repo-owner>/<repo-name> \
-     --color 6f42c1 --description "Waiting for human review."
-   gh label create detent:rework --repo <repo-owner>/<repo-name> \
-     --color d93f0b --description "Changes are requested before review can continue."
-   gh label create detent:merging --repo <repo-owner>/<repo-name> \
-     --color 6f42c1 --description "Approved work is being integrated."
-   gh label create detent:done --repo <repo-owner>/<repo-name> \
-     --color 0e8a16 --description "Work is complete."
+   create_label_if_missing "${STATUS_LABEL_PREFIX}backlog" cfd3d7 \
+     "Not ready for Detent dispatch."
+   create_label_if_missing "${STATUS_LABEL_PREFIX}todo" cfd3d7 \
+     "Ready for Detent dispatch."
+   create_label_if_missing "${STATUS_LABEL_PREFIX}in-progress" fbca04 \
+     "Work is currently active."
+   create_label_if_missing "${STATUS_LABEL_PREFIX}blocked" d73a4a \
+     "Cannot continue without human input."
+   create_label_if_missing "${STATUS_LABEL_PREFIX}human-review" 6f42c1 \
+     "Waiting for human review."
+   create_label_if_missing "${STATUS_LABEL_PREFIX}rework" d93f0b \
+     "Changes are requested before review can continue."
+   create_label_if_missing "${STATUS_LABEL_PREFIX}merging" 6f42c1 \
+     "Approved work is being integrated."
+   create_label_if_missing "${STATUS_LABEL_PREFIX}done" 0e8a16 \
+     "Work is complete."
    ```
 
    For a custom `STATUS_LABEL_PREFIX` or custom workflow states, generate the
@@ -2294,7 +2329,18 @@ awk 'NF {last=$0} END {exit last == "MUTATION_CONFIRMED=true" ? 0 : 1}' "$ONBOAR
    `agent.no_progress_timeout_ms`; keep `agent.max_session_tokens` as an
    additional token-consumption backstop because cached context is counted
    again on every Codex turn. A small multiplier can terminate otherwise
-   healthy sessions after only a few full-context turns. Keep
+   healthy sessions after only a few full-context turns. Whenever
+   `MAX_SESSION_TOKENS` is positive, record the per-issue escape hatch that the
+   generated config will reference:
+
+   ```sh
+   printf '%s\n' \
+     'MAX_SESSION_TOKEN_OVERRIDE_LABEL=allow-large-session' \
+     >> "$ONBOARDING_DIR/answers.env"
+   rg '^MAX_SESSION_TOKEN_OVERRIDE_LABEL=' "$ONBOARDING_DIR/answers.env"
+   ```
+
+   Keep
    `agent.no_progress_token_limit` positive as the cross-session brake,
    especially when `budget.billing_mode: subscription` makes USD controls
    inert.

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -238,6 +238,7 @@ type doctorDeps struct {
 	githubReadiness      doctorGitHubReadinessFunc
 	githubMergeSettings  func(context.Context, workflowconfig.Config, string) (ghconnector.RepositoryMergeSettings, error)
 	githubRepositoryInfo func(context.Context, workflowconfig.Config, string) (ghconnector.RepositoryInfo, error)
+	githubLabels         func(context.Context, workflowconfig.Config, string) ([]string, error)
 	ghAuthToken          func(context.Context) (string, error)
 	listen               func(string, string) (net.Listener, error)
 	openSQLite           func(context.Context, string) (doctorStore, error)
@@ -1101,6 +1102,9 @@ func (d doctorDeps) withDefaults() doctorDeps {
 	if d.githubRepositoryInfo == nil {
 		d.githubRepositoryInfo = defaults.githubRepositoryInfo
 	}
+	if d.githubLabels == nil {
+		d.githubLabels = defaults.githubLabels
+	}
 	if d.ghAuthToken == nil {
 		d.ghAuthToken = defaults.ghAuthToken
 	}
@@ -1162,6 +1166,7 @@ func defaultDoctorDeps() doctorDeps {
 		githubReadiness:      ghconnector.CheckReadiness,
 		githubMergeSettings:  defaultDoctorGitHubMergeSettings,
 		githubRepositoryInfo: defaultDoctorGitHubRepositoryInfo,
+		githubLabels:         defaultDoctorGitHubRepositoryLabels,
 		ghAuthToken:          defaultGHAuthToken,
 		listen:               net.Listen,
 		openSQLite:           openDoctorSQLite,

--- a/internal/cli/doctor_labels.go
+++ b/internal/cli/doctor_labels.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"sort"
 	"strings"
 
 	workflowconfig "github.com/digitaldrywood/detent/internal/config"
@@ -38,7 +37,7 @@ func defaultDoctorGitHubRepositoryLabels(
 func checkDoctorConfiguredLabels(
 	ctx context.Context,
 	projectID string,
-	project globalconfig.Project,
+	_ globalconfig.Project,
 	cfg workflowconfig.Config,
 	deps doctorDeps,
 ) doctorCheck {
@@ -56,8 +55,8 @@ func checkDoctorConfiguredLabels(
 		}
 	}
 
-	repositories := doctorGitHubRepositories(ctx, project, cfg, deps, projectSourceRoot(project, cfg))
-	if len(repositories) == 0 {
+	repository := strings.TrimSpace(cfg.Tracker.Repository)
+	if repository == "" {
 		return doctorCheck{
 			Name:   name,
 			Status: doctorWarn,
@@ -65,45 +64,37 @@ func checkDoctorConfiguredLabels(
 			Hint:   "Set tracker.repository to owner/repo in detent.yaml.",
 		}
 	}
-	sort.Strings(repositories)
 
 	missing := make([]string, 0)
 	fixes := make([]string, 0)
-	seenFixes := map[string]struct{}{}
 	status := doctorOK
-	for _, repository := range repositories {
-		existing, err := deps.githubLabels(ctx, cfg, repository)
-		if err != nil {
-			return doctorCheck{
-				Name:   name,
-				Status: doctorFail,
-				Detail: fmt.Sprintf("read %s labels: %v", repository, err),
-				Hint:   "Fix GitHub repository label read access, then rerun detent doctor.",
-			}
+	existing, err := deps.githubLabels(ctx, cfg, repository)
+	if err != nil {
+		return doctorCheck{
+			Name:   name,
+			Status: doctorFail,
+			Detail: fmt.Sprintf("read %s labels: %v", repository, err),
+			Hint:   "Fix GitHub repository label read access, then rerun detent doctor.",
 		}
-		existingSet := doctorNormalizedLabelSet(existing)
-		for _, label := range required {
-			if _, ok := existingSet[strings.ToLower(label.Name)]; ok {
-				continue
-			}
-			missing = append(missing, fmt.Sprintf("%s missing label %q referenced by %s", repository, label.Name, label.ConfigKey))
-			if label.Critical {
-				status = doctorFail
-			} else if status == doctorOK {
-				status = doctorWarn
-			}
-			fix := doctorConfiguredLabelFix(repository, label)
-			if _, ok := seenFixes[fix]; !ok {
-				seenFixes[fix] = struct{}{}
-				fixes = append(fixes, fix)
-			}
+	}
+	existingSet := doctorNormalizedLabelSet(existing)
+	for _, label := range required {
+		if _, ok := existingSet[strings.ToLower(label.Name)]; ok {
+			continue
 		}
+		missing = append(missing, fmt.Sprintf("%s missing label %q referenced by %s", repository, label.Name, label.ConfigKey))
+		if label.Critical {
+			status = doctorFail
+		} else if status == doctorOK {
+			status = doctorWarn
+		}
+		fixes = append(fixes, doctorConfiguredLabelFix(repository, label))
 	}
 	if len(missing) == 0 {
 		return doctorCheck{
 			Name:   name,
 			Status: doctorOK,
-			Detail: fmt.Sprintf("verified %d configured labels in %s", len(required)*len(repositories), strings.Join(repositories, ", ")),
+			Detail: fmt.Sprintf("verified %d configured labels in %s", len(required), repository),
 		}
 	}
 	return doctorCheck{
@@ -147,8 +138,8 @@ func doctorNormalizedLabelSet(labels []string) map[string]struct{} {
 }
 
 func doctorConfiguredLabelFix(repository string, label doctorConfiguredLabel) string {
-	return "gh label create " + doctorShellQuote(label.Name) +
-		" --repo " + doctorShellQuote(repository) +
+	return "gh label create --repo " + doctorShellQuote(repository) +
 		" --color " + label.Color +
-		" --description " + doctorShellQuote(label.Description)
+		" --description " + doctorShellQuote(label.Description) +
+		" -- " + doctorShellQuote(label.Name)
 }

--- a/internal/cli/doctor_labels.go
+++ b/internal/cli/doctor_labels.go
@@ -1,0 +1,154 @@
+package cli
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sort"
+	"strings"
+
+	workflowconfig "github.com/digitaldrywood/detent/internal/config"
+	globalconfig "github.com/digitaldrywood/detent/internal/config/global"
+	ghconnector "github.com/digitaldrywood/detent/internal/connector/github"
+)
+
+type doctorConfiguredLabel struct {
+	ConfigKey   string
+	Name        string
+	Description string
+	Color       string
+	Critical    bool
+}
+
+func defaultDoctorGitHubRepositoryLabels(
+	ctx context.Context,
+	cfg workflowconfig.Config,
+	repository string,
+) (_ []string, resultErr error) {
+	conn, err := ghconnector.NewConnector(doctorGitHubConnectorConfig(cfg))
+	if err != nil {
+		return nil, err
+	}
+	defer func() {
+		resultErr = errors.Join(resultErr, conn.Close())
+	}()
+	return conn.FetchRepositoryLabels(ctx, repository)
+}
+
+func checkDoctorConfiguredLabels(
+	ctx context.Context,
+	projectID string,
+	project globalconfig.Project,
+	cfg workflowconfig.Config,
+	deps doctorDeps,
+) doctorCheck {
+	name := "Project " + projectID + " configured labels"
+	required := doctorConfiguredLabels(cfg)
+	if len(required) == 0 {
+		return doctorCheck{Name: name, Status: doctorOK, Detail: "no escape-hatch labels are configured"}
+	}
+	if deps.githubLabels == nil {
+		return doctorCheck{
+			Name:   name,
+			Status: doctorWarn,
+			Detail: "configured label verification skipped because the GitHub label reader is unavailable",
+			Hint:   "Rerun detent doctor with GitHub repository access.",
+		}
+	}
+
+	repositories := doctorGitHubRepositories(ctx, project, cfg, deps, projectSourceRoot(project, cfg))
+	if len(repositories) == 0 {
+		return doctorCheck{
+			Name:   name,
+			Status: doctorWarn,
+			Detail: "configured label verification skipped because no GitHub repository could be resolved",
+			Hint:   "Set tracker.repository to owner/repo in detent.yaml.",
+		}
+	}
+	sort.Strings(repositories)
+
+	missing := make([]string, 0)
+	fixes := make([]string, 0)
+	seenFixes := map[string]struct{}{}
+	status := doctorOK
+	for _, repository := range repositories {
+		existing, err := deps.githubLabels(ctx, cfg, repository)
+		if err != nil {
+			return doctorCheck{
+				Name:   name,
+				Status: doctorFail,
+				Detail: fmt.Sprintf("read %s labels: %v", repository, err),
+				Hint:   "Fix GitHub repository label read access, then rerun detent doctor.",
+			}
+		}
+		existingSet := doctorNormalizedLabelSet(existing)
+		for _, label := range required {
+			if _, ok := existingSet[strings.ToLower(label.Name)]; ok {
+				continue
+			}
+			missing = append(missing, fmt.Sprintf("%s missing label %q referenced by %s", repository, label.Name, label.ConfigKey))
+			if label.Critical {
+				status = doctorFail
+			} else if status == doctorOK {
+				status = doctorWarn
+			}
+			fix := doctorConfiguredLabelFix(repository, label)
+			if _, ok := seenFixes[fix]; !ok {
+				seenFixes[fix] = struct{}{}
+				fixes = append(fixes, fix)
+			}
+		}
+	}
+	if len(missing) == 0 {
+		return doctorCheck{
+			Name:   name,
+			Status: doctorOK,
+			Detail: fmt.Sprintf("verified %d configured labels in %s", len(required)*len(repositories), strings.Join(repositories, ", ")),
+		}
+	}
+	return doctorCheck{
+		Name:   name,
+		Status: status,
+		Detail: strings.Join(missing, "; "),
+		Hint:   strings.Join(fixes, "; "),
+	}
+}
+
+func doctorConfiguredLabels(cfg workflowconfig.Config) []doctorConfiguredLabel {
+	labels := make([]doctorConfiguredLabel, 0, 2)
+	if name := strings.TrimSpace(cfg.Agent.AutoPromote.OptoutLabel); name != "" {
+		labels = append(labels, doctorConfiguredLabel{
+			ConfigKey:   "agent.auto_promote.optout_label",
+			Name:        name,
+			Description: "Excludes an issue from Detent auto-promotion.",
+			Color:       "b60205",
+			Critical:    true,
+		})
+	}
+	if name := strings.TrimSpace(cfg.Agent.MaxSessionTokenOverrideLabel); name != "" {
+		labels = append(labels, doctorConfiguredLabel{
+			ConfigKey:   "agent.max_session_token_override_label",
+			Name:        name,
+			Description: "Allows an issue to exceed the configured agent session token ceiling.",
+			Color:       "fbca04",
+		})
+	}
+	return labels
+}
+
+func doctorNormalizedLabelSet(labels []string) map[string]struct{} {
+	set := make(map[string]struct{}, len(labels))
+	for _, label := range labels {
+		if normalized := strings.ToLower(strings.TrimSpace(label)); normalized != "" {
+			set[normalized] = struct{}{}
+		}
+	}
+	return set
+}
+
+func doctorConfiguredLabelFix(repository string, label doctorConfiguredLabel) string {
+	return "gh label create " + doctorShellQuote(label.Name) +
+		" --repo " + doctorShellQuote(repository) +
+		" --color " + label.Color +
+		" --description " + doctorShellQuote(label.Description)
+}

--- a/internal/cli/doctor_labels_test.go
+++ b/internal/cli/doctor_labels_test.go
@@ -133,6 +133,52 @@ func TestCheckDoctorConfiguredLabelsReportsInventoryFailure(t *testing.T) {
 	}
 }
 
+func TestCheckDoctorConfiguredLabelsUsesTrackerRepository(t *testing.T) {
+	t.Parallel()
+
+	cfg := workflowconfig.Default()
+	cfg.Tracker.Kind = workflowconfig.TrackerGitHub
+	cfg.Tracker.Repository = "digitaldrywood/detent"
+	cfg.Tracker.WriteProbeIssue = "digitaldrywood/scratch#1"
+	repositories := []string{}
+	check := checkDoctorConfiguredLabels(
+		context.Background(),
+		"detent",
+		globalconfig.Project{Workdir: "digitaldrywood/worktree#1"},
+		cfg,
+		doctorDeps{
+			githubLabels: func(_ context.Context, _ workflowconfig.Config, repository string) ([]string, error) {
+				repositories = append(repositories, repository)
+				return []string{"requires-human-review", "allow-large-session"}, nil
+			},
+			gitRemoteURL: func(context.Context, string) (string, error) {
+				return "https://github.com/digitaldrywood/checkout.git", nil
+			},
+		},
+	)
+
+	if check.Status != doctorOK {
+		t.Fatalf("Status = %s, want %s: %#v", check.Status, doctorOK, check)
+	}
+	if len(repositories) != 1 || repositories[0] != cfg.Tracker.Repository {
+		t.Fatalf("repository label reads = %v, want [%s]", repositories, cfg.Tracker.Repository)
+	}
+}
+
+func TestDoctorConfiguredLabelFixTerminatesFlagParsing(t *testing.T) {
+	t.Parallel()
+
+	fix := doctorConfiguredLabelFix("digitaldrywood/detent", doctorConfiguredLabel{
+		Name:        "-escape",
+		Description: "Escape hatch.",
+		Color:       "b60205",
+	})
+	want := "gh label create --repo 'digitaldrywood/detent' --color b60205 --description 'Escape hatch.' -- '-escape'"
+	if fix != want {
+		t.Fatalf("fix = %q, want %q", fix, want)
+	}
+}
+
 func TestCheckDoctorProjectIncludesConfiguredLabelCheck(t *testing.T) {
 	t.Parallel()
 

--- a/internal/cli/doctor_labels_test.go
+++ b/internal/cli/doctor_labels_test.go
@@ -1,0 +1,162 @@
+package cli
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	workflowconfig "github.com/digitaldrywood/detent/internal/config"
+	globalconfig "github.com/digitaldrywood/detent/internal/config/global"
+)
+
+func TestCheckDoctorConfiguredLabels(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		configure  func(*workflowconfig.Config)
+		labels     []string
+		wantStatus doctorStatus
+		wantDetail []string
+		wantHint   []string
+		wantReads  int
+	}{
+		{
+			name: "labels present",
+			configure: func(cfg *workflowconfig.Config) {
+				cfg.Agent.AutoPromote.OptoutLabel = "requires-human-review"
+				cfg.Agent.MaxSessionTokenOverrideLabel = "allow-large-session"
+			},
+			labels:     []string{"Requires-Human-Review", "allow-large-session"},
+			wantStatus: doctorOK,
+			wantDetail: []string{"verified 2 configured labels", "digitaldrywood/detent"},
+			wantReads:  1,
+		},
+		{
+			name: "opt-out label absent",
+			configure: func(cfg *workflowconfig.Config) {
+				cfg.Agent.AutoPromote.OptoutLabel = "requires-human-review"
+			},
+			labels:     []string{"bug"},
+			wantStatus: doctorFail,
+			wantDetail: []string{`missing label "requires-human-review"`, "agent.auto_promote.optout_label"},
+			wantHint:   []string{"gh label create", "requires-human-review", "--repo", "digitaldrywood/detent"},
+			wantReads:  1,
+		},
+		{
+			name: "config keys unset",
+			configure: func(cfg *workflowconfig.Config) {
+				cfg.Agent.AutoPromote.OptoutLabel = ""
+				cfg.Agent.MaxSessionTokenOverrideLabel = ""
+			},
+			wantStatus: doctorOK,
+			wantDetail: []string{"no escape-hatch labels are configured"},
+		},
+		{
+			name: "multiple labels missing",
+			configure: func(cfg *workflowconfig.Config) {
+				cfg.Agent.AutoPromote.OptoutLabel = "requires-human-review"
+				cfg.Agent.MaxSessionTokenOverrideLabel = "allow-large-session"
+			},
+			wantStatus: doctorFail,
+			wantDetail: []string{
+				`missing label "requires-human-review" referenced by agent.auto_promote.optout_label`,
+				`missing label "allow-large-session" referenced by agent.max_session_token_override_label`,
+			},
+			wantHint:  []string{"gh label create", "requires-human-review", "allow-large-session"},
+			wantReads: 1,
+		},
+		{
+			name: "session override label absent warns",
+			configure: func(cfg *workflowconfig.Config) {
+				cfg.Agent.AutoPromote.OptoutLabel = ""
+				cfg.Agent.MaxSessionTokenOverrideLabel = "allow-large-session"
+			},
+			wantStatus: doctorWarn,
+			wantDetail: []string{"agent.max_session_token_override_label"},
+			wantHint:   []string{"gh label create", "allow-large-session"},
+			wantReads:  1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			cfg := workflowconfig.Default()
+			cfg.Tracker.Kind = workflowconfig.TrackerGitHub
+			cfg.Tracker.Repository = "digitaldrywood/detent"
+			tt.configure(&cfg)
+			reads := 0
+			check := checkDoctorConfiguredLabels(context.Background(), "detent", globalconfig.Project{}, cfg, doctorDeps{
+				githubLabels: func(context.Context, workflowconfig.Config, string) ([]string, error) {
+					reads++
+					return tt.labels, nil
+				},
+			})
+
+			if check.Status != tt.wantStatus {
+				t.Fatalf("Status = %s, want %s: %#v", check.Status, tt.wantStatus, check)
+			}
+			for _, want := range tt.wantDetail {
+				if !strings.Contains(check.Detail, want) {
+					t.Fatalf("Detail = %q, want containing %q", check.Detail, want)
+				}
+			}
+			for _, want := range tt.wantHint {
+				if !strings.Contains(check.Hint, want) {
+					t.Fatalf("Hint = %q, want containing %q", check.Hint, want)
+				}
+			}
+			if reads != tt.wantReads {
+				t.Fatalf("repository label reads = %d, want %d", reads, tt.wantReads)
+			}
+		})
+	}
+}
+
+func TestCheckDoctorConfiguredLabelsReportsInventoryFailure(t *testing.T) {
+	t.Parallel()
+
+	cfg := workflowconfig.Default()
+	cfg.Tracker.Kind = workflowconfig.TrackerGitHub
+	cfg.Tracker.Repository = "digitaldrywood/detent"
+	check := checkDoctorConfiguredLabels(context.Background(), "detent", globalconfig.Project{}, cfg, doctorDeps{
+		githubLabels: func(context.Context, workflowconfig.Config, string) ([]string, error) {
+			return nil, errors.New("permission denied")
+		},
+	})
+
+	if check.Status != doctorFail || !strings.Contains(check.Detail, "permission denied") {
+		t.Fatalf("check = %#v, want failed repository label inventory", check)
+	}
+}
+
+func TestCheckDoctorProjectIncludesConfiguredLabelCheck(t *testing.T) {
+	t.Parallel()
+
+	cfg := validDoctorWorkflow("/repo")
+	cfg.Tracker.Kind = workflowconfig.TrackerGitHub
+	cfg.Tracker.APIKey = "token"
+	cfg.Tracker.ProjectSlug = "PVT_1"
+	cfg.Tracker.Repository = "digitaldrywood/detent"
+	deps := successfulDoctorDeps()
+	deps.loadWorkflow = func(string) (workflowconfig.Workflow, error) {
+		return workflowconfig.Workflow{Config: cfg}, nil
+	}
+	deps.githubLabels = func(context.Context, workflowconfig.Config, string) ([]string, error) {
+		return []string{"bug"}, nil
+	}
+
+	checks := checkDoctorProject(context.Background(), globalconfig.Project{ID: "detent", Workflow: "WORKFLOW.md"}, deps, RuntimeSecret{}, false)
+	for _, check := range checks {
+		if check.Name == "Project detent configured labels" {
+			if check.Status != doctorFail || !strings.Contains(check.Detail, "agent.auto_promote.optout_label") {
+				t.Fatalf("configured label check = %#v, want missing opt-out failure", check)
+			}
+			return
+		}
+	}
+	t.Fatalf("checks = %#v, want configured label check", checks)
+}

--- a/internal/cli/doctor_project.go
+++ b/internal/cli/doctor_project.go
@@ -340,6 +340,8 @@ func checkDoctorProjectWithProgress(
 	if doctorTrackerUsesGitHubReads(workflow.Config.Tracker.Kind) {
 		setDoctorCurrentCheck("Project " + id + " issue agent models")
 		checks = append(checks, checkDoctorIssueAgentModels(ctx, id, project, workflow.Config, deps))
+		setDoctorCurrentCheck("Project " + id + " configured labels")
+		checks = append(checks, checkDoctorConfiguredLabels(ctx, id, project, workflow.Config, deps))
 	}
 	if workflow.Config.Agent.AutoPromote.Enabled {
 		setDoctorCurrentCheck("Project " + id + " auto-promote")

--- a/internal/cli/doctor_test.go
+++ b/internal/cli/doctor_test.go
@@ -5977,6 +5977,12 @@ func successfulDoctorDeps() doctorDeps {
 				DefaultBranch: "main",
 			}, nil
 		},
+		githubLabels: func(_ context.Context, cfg workflowconfig.Config, _ string) ([]string, error) {
+			return []string{
+				cfg.Agent.AutoPromote.OptoutLabel,
+				cfg.Agent.MaxSessionTokenOverrideLabel,
+			}, nil
+		},
 		listen: func(string, string) (net.Listener, error) {
 			return fakeDoctorListener{addr: fakeDoctorAddr("127.0.0.1:49152")}, nil
 		},

--- a/internal/connector/github/repository.go
+++ b/internal/connector/github/repository.go
@@ -16,6 +16,24 @@ type RepositoryInfo struct {
 	DefaultBranch string
 }
 
+func (c *Connector) FetchRepositoryLabels(ctx context.Context, repository string) ([]string, error) {
+	repo, ok := pullRequestRepoFromName(repository)
+	if !ok {
+		return nil, fmt.Errorf("invalid GitHub repository %q", repository)
+	}
+	labels, err := fetchRESTList[label](ctx, c.client, restRepositoryLabelsListPath(repo))
+	if err != nil {
+		return nil, fmt.Errorf("fetch github repository labels: %w", err)
+	}
+	names := make([]string, 0, len(labels))
+	for _, label := range labels {
+		if name := strings.TrimSpace(label.Name); name != "" {
+			names = append(names, name)
+		}
+	}
+	return names, nil
+}
+
 func (c *Connector) FetchRepositoryInfo(ctx context.Context, repository string) (RepositoryInfo, error) {
 	repository = strings.TrimSpace(repository)
 	if repository == "" {

--- a/internal/connector/github/repository_test.go
+++ b/internal/connector/github/repository_test.go
@@ -3,8 +3,28 @@ package github
 import (
 	"context"
 	"net/http"
+	"slices"
 	"testing"
 )
+
+func TestFetchRepositoryLabels(t *testing.T) {
+	t.Parallel()
+
+	server := newGraphQLTestServer(t, []graphqlTestResponse{{
+		method: http.MethodGet,
+		path:   "/repos/digitaldrywood/detent/labels?per_page=100",
+		body:   `[{"name":"bug"},{"name":" requires-human-review "},{"name":""}]`,
+	}})
+	c := newGitHubTestConnector(t, server, Config{})
+	got, err := c.FetchRepositoryLabels(context.Background(), "digitaldrywood/detent")
+	if err != nil {
+		t.Fatalf("FetchRepositoryLabels() error = %v", err)
+	}
+	want := []string{"bug", "requires-human-review"}
+	if !slices.Equal(got, want) {
+		t.Fatalf("FetchRepositoryLabels() = %#v, want %#v", got, want)
+	}
+}
 
 func TestFetchRepositoryInfoSurfacesVisibility(t *testing.T) {
 	t.Parallel()

--- a/onboarding_docs_test.go
+++ b/onboarding_docs_test.go
@@ -109,6 +109,27 @@ func TestOnboardingDocsDescribeNoPersistentLabelWriteProbes(t *testing.T) {
 	}
 }
 
+func TestOnboardingDocsCreateEscapeHatchLabelsIdempotently(t *testing.T) {
+	t.Parallel()
+
+	onboarding := readRepositoryTextFile(t, "docs/ONBOARDING.md")
+
+	for _, want := range []string{
+		"AUTO_PROMOTE_OPTOUT_LABEL",
+		"MAX_SESSION_TOKEN_OVERRIDE_LABEL",
+		"create_label_if_missing",
+		`rg -Fxi -- "$label_name" "$ONBOARDING_DIR/repo-labels.txt"`,
+		`gh label create "$label_name" --repo "$TARGET_REPOSITORY"`,
+		"Excludes an issue from Detent auto-promotion.",
+		"Allows an issue to exceed the configured agent session token ceiling.",
+	} {
+		assertContains(t, onboarding, want)
+	}
+
+	assertOrder(t, onboarding, "## Phase 2.5", "create_label_if_missing")
+	assertOrder(t, onboarding, "create_label_if_missing", "## Phase 4")
+}
+
 func TestOnboardingDocsRequireIdentityGateBeforeDiscovery(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

- create generated-config escape-hatch labels idempotently during onboarding for every GitHub status-source mode
- add a doctor check that inventories repository labels, fails for a missing auto-promotion opt-out, and provides copy-paste `gh label create` fixes
- cover label presence, absence, unset config, multiple missing labels, connector inventory, and project-check wiring

Fixes #1680

## UI Surface Contract

- [x] N/A, or the linked issue explicitly authorizes any high-impact UI surface, layout, density, first-viewport, or responsive visibility tradeoff.
- [x] Persistent top-of-screen messaging is explicitly authorized by the issue, or this PR does not add it.
- [x] N/A — this PR has no visual changes to primary operator screens.

## Test Plan

- [x] `go test ./internal/cli ./internal/connector/github . -count=1`
- [x] `make check`