### PR TITLE
fix(security): suppress false-positive G705

### DIFF
--- a/internal/mcp/http.go
+++ b/internal/mcp/http.go
@@ -597,7 +597,7 @@ func writeHTTPTransportError(writer http.ResponseWriter, status int, message str
 func writeHTTPResponse(writer http.ResponseWriter, status int, frame []byte) {
 	writer.Header().Set("Content-Type", "application/json")
 	writer.WriteHeader(status)
-	_, _ = writer.Write(frame)
+	_, _ = writer.Write(frame) // #nosec G705 -- application/json response containing encoding/json output, not HTML
 }
 
 func marshalHTTPResponse(message response) []byte {

--- a/internal/mcp/http_test.go
+++ b/internal/mcp/http_test.go
@@ -94,6 +94,51 @@ func TestHTTPTransportRequestBoundaries(t *testing.T) {
 	}
 }
 
+func TestHTTPTransportEscapesHTMLInJSONResponses(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		value     string
+		forbidden string
+		want      string
+	}{
+		{name: "HTML tag", value: `<script>alert("xss")</script>`, forbidden: "<", want: `\u003cscript\u003ealert(\"xss\")\u003c/script\u003e`},
+		{name: "ampersand", value: "left&right", forbidden: "&", want: `left\u0026right`},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			content, err := json.Marshal(map[string]string{"value": test.value})
+			if err != nil {
+				t.Fatalf("marshal tool result: %v", err)
+			}
+			handler := newTestHTTPHandler(&staticExecutor{result: operatortool.Result{Content: content}})
+			t.Cleanup(func() {
+				if err := handler.Shutdown(context.Background()); err != nil {
+					t.Errorf("Shutdown() error = %v", err)
+				}
+			})
+
+			initialize := performMCPRequest(t, handler, http.MethodPost, initializeRequest, "", "read-key", nil)
+			sessionID := initialize.Header().Get(httpSessionHeader)
+			performMCPRequest(t, handler, http.MethodPost, initializedNotice, sessionID, "read-key", nil)
+			response := performMCPRequest(t, handler, http.MethodPost, `{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"fleet_health","arguments":{}}}`, sessionID, "read-key", nil)
+
+			if got := response.Header().Get("Content-Type"); got != "application/json" {
+				t.Errorf("Content-Type = %q, want application/json", got)
+			}
+			body := response.Body.String()
+			if strings.Contains(body, test.forbidden) {
+				t.Errorf("response contains unescaped %q: %s", test.forbidden, body)
+			}
+			if !strings.Contains(body, test.want) {
+				t.Errorf("response = %s, want escaped value %q", body, test.want)
+			}
+		})
+	}
+}
+
 func TestHTTPTransportResultLimits(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

- suppress the line-local G705 false positive on the MCP JSON response write
- verify MCP responses retain `application/json` and `encoding/json` HTML escaping
- record the analyzer pass/fail inconsistency in follow-up #1699

The response write is not an HTML sink: all frames are produced by `encoding/json.Marshal`, and the handler explicitly sets `Content-Type: application/json`. gosec v2.28.0 recognizes `encoding/json.Marshal` as a G705 sanitizer but loses that fact across the response-router path.

Fixes #1684

## UI Surface Contract

- [x] N/A, or the linked issue explicitly authorizes any high-impact UI surface, layout, density, first-viewport, or responsive visibility tradeoff.
- [x] Persistent top-of-screen messaging is explicitly authorized by the issue, or this PR does not add it.
- [x] Visual changes to primary operator screens include screenshot or browser verification below. N/A: no UI changes.

## Test Plan

- [x] `go test ./internal/mcp -run ^TestHTTPTransportEscapesHTMLInJSONResponses$ -count=1`
- [x] `make security` (clean patched clone)
- [x] `env -u DETENT_API_TOKEN make check` (78.6% aggregate coverage)