### PR TITLE
fix(merge): preserve first slot acquisition

### DIFF
--- a/internal/orchestrator/autopromote_tick_test.go
+++ b/internal/orchestrator/autopromote_tick_test.go
@@ -3960,7 +3960,7 @@ func TestMergeWorkerLogsRunResultSuccessAndFailure(t *testing.T) {
 		"reason=runner_failed",
 		"merge command failed",
 		"queue_wait_seconds=120",
-		"active_merge_duration_seconds=300",
+		"active_merge_duration_seconds=360",
 		"total_merging_seconds=480",
 		"head_sha=head-merge-log",
 		"base_sha=base-merge-log",
@@ -3995,7 +3995,7 @@ func TestMergeWorkerLogsRunResultSuccessAndFailure(t *testing.T) {
 		"final_state=Done",
 		"pull_request_number=73",
 		"queue_wait_seconds=120",
-		"active_merge_duration_seconds=300",
+		"active_merge_duration_seconds=360",
 		"total_merging_seconds=480",
 		"head_sha=head-merge-log",
 		"base_sha=base-merge-log",
@@ -4005,7 +4005,7 @@ func TestMergeWorkerLogsRunResultSuccessAndFailure(t *testing.T) {
 		}
 	}
 	completed := successState.Completed[successIssue.ID]
-	if completed.MergeTiming.MergedAt.IsZero() || completed.MergeTiming.ActiveMergeDurationSeconds != 300 {
+	if completed.MergeTiming.MergedAt.IsZero() || completed.MergeTiming.ActiveMergeDurationSeconds != 360 {
 		t.Fatalf("Completed[%q].MergeTiming = %#v, want successful terminal durations", successIssue.ID, completed.MergeTiming)
 	}
 }

--- a/internal/orchestrator/merge_timing.go
+++ b/internal/orchestrator/merge_timing.go
@@ -60,7 +60,9 @@ func (o *Orchestrator) markMergeWorkerSlotAcquired(state *State, issue connector
 	slotAlreadyAcquired := !timing.MergeWorkerSlotAcquiredAt.IsZero() &&
 		timing.MergedAt.IsZero() &&
 		timing.MergeFailedAt.IsZero()
-	timing.MergeWorkerSlotAcquiredAt = now.UTC()
+	if !slotAlreadyAcquired {
+		timing.MergeWorkerSlotAcquiredAt = now.UTC()
+	}
 	timing.MergedAt = time.Time{}
 	timing.MergeFailedAt = time.Time{}
 	timing.MergeFailureReason = ""
@@ -257,7 +259,7 @@ func (t MergeTiming) withDurations(now time.Time) MergeTiming {
 	now = now.UTC()
 	queueEnd := firstNonZeroTime(t.MergeWorkerSlotAcquiredAt, t.MergeStartedAt, t.MergedAt, t.MergeFailedAt, now)
 	t.QueueWaitSeconds = durationSeconds(t.EnteredMergingAt, queueEnd)
-	activeStart := firstNonZeroTime(t.MergeStartedAt, t.MergeWorkerSlotAcquiredAt)
+	activeStart := firstNonZeroTime(t.MergeWorkerSlotAcquiredAt, t.MergeStartedAt)
 	activeEnd := firstNonZeroTime(t.MergedAt, t.MergeFailedAt, now)
 	t.ActiveMergeDurationSeconds = durationSeconds(activeStart, activeEnd)
 	totalEnd := firstNonZeroTime(t.MergedAt, t.MergeFailedAt, now)

--- a/internal/orchestrator/merge_timing_test.go
+++ b/internal/orchestrator/merge_timing_test.go
@@ -51,6 +51,182 @@ func TestRecordMergeQueueEnteredResetsTerminalAttempt(t *testing.T) {
 	}
 }
 
+func TestMarkMergeWorkerSlotAcquiredPreservesAttemptBoundary(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 8, 7, 22, 13, 0, 0, time.UTC)
+	firstAcquiredAt := now.Add(-9 * time.Minute)
+	oldEnteredAt := now.Add(-30 * time.Minute)
+	stageUpdatedAt := now.Add(-10 * time.Minute)
+	completedAt := now.Add(-20 * time.Minute)
+	tests := []struct {
+		name         string
+		initial      MergeTiming
+		acquisitions []time.Time
+		wantAcquired time.Time
+		wantQueue    int64
+		wantActive   int64
+		wantTotal    int64
+	}{
+		{
+			name:         "single acquisition",
+			acquisitions: []time.Time{now},
+			wantAcquired: now,
+			wantQueue:    600,
+			wantTotal:    600,
+		},
+		{
+			name:         "repeated acquisition preserves original timestamp",
+			acquisitions: []time.Time{firstAcquiredAt, now},
+			wantAcquired: firstAcquiredAt,
+			wantQueue:    60,
+			wantActive:   540,
+			wantTotal:    600,
+		},
+		{
+			name: "completed merge starts fresh",
+			initial: MergeTiming{
+				EnteredMergingAt:          oldEnteredAt,
+				MergeWorkerSlotAcquiredAt: oldEnteredAt.Add(time.Minute),
+				MergedAt:                  completedAt,
+			},
+			acquisitions: []time.Time{now},
+			wantAcquired: now,
+			wantQueue:    600,
+			wantTotal:    600,
+		},
+		{
+			name: "failed merge starts fresh",
+			initial: MergeTiming{
+				EnteredMergingAt:          oldEnteredAt,
+				MergeWorkerSlotAcquiredAt: oldEnteredAt.Add(time.Minute),
+				MergeFailedAt:             completedAt,
+				MergeFailureReason:        "merge_conflicts",
+			},
+			acquisitions: []time.Time{now},
+			wantAcquired: now,
+			wantQueue:    600,
+			wantTotal:    600,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			issue := connector.Issue{
+				ID:             "issue-1634-" + strings.ReplaceAll(tt.name, " ", "-"),
+				Identifier:     "digitaldrywood/detent#1634",
+				State:          "Merging",
+				StageUpdatedAt: &stageUpdatedAt,
+				PullRequest:    &connector.PullRequest{Number: 1636, State: "OPEN"},
+			}
+			state := newState(normalizeConfig(Config{}))
+			state.MergeTimings[issue.ID] = tt.initial
+			orch := &Orchestrator{}
+
+			var got MergeTiming
+			for _, acquiredAt := range tt.acquisitions {
+				got = orch.markMergeWorkerSlotAcquired(&state, issue, acquiredAt)
+			}
+
+			if !got.MergeWorkerSlotAcquiredAt.Equal(tt.wantAcquired) {
+				t.Fatalf("MergeWorkerSlotAcquiredAt = %s, want %s", got.MergeWorkerSlotAcquiredAt, tt.wantAcquired)
+			}
+			if got.QueueWaitSeconds != tt.wantQueue || got.ActiveMergeDurationSeconds != tt.wantActive || got.TotalMergingSeconds != tt.wantTotal {
+				t.Fatalf(
+					"durations = queue %d active %d total %d, want %d/%d/%d",
+					got.QueueWaitSeconds,
+					got.ActiveMergeDurationSeconds,
+					got.TotalMergingSeconds,
+					tt.wantQueue,
+					tt.wantActive,
+					tt.wantTotal,
+				)
+			}
+		})
+	}
+}
+
+func TestMergeTimingWithDurationsUsesFirstSlotAcquisition(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 8, 7, 22, 13, 0, 0, time.UTC)
+	enteredAt := now.Add(-10 * time.Minute)
+	acquiredAt := now.Add(-9 * time.Minute)
+	retryStartedAt := now.Add(-time.Minute)
+	tests := []struct {
+		name       string
+		timing     MergeTiming
+		wantQueue  int64
+		wantActive int64
+		wantTotal  int64
+	}{
+		{
+			name: "queued",
+			timing: MergeTiming{
+				EnteredMergingAt: enteredAt,
+			},
+			wantQueue: 600,
+			wantTotal: 600,
+		},
+		{
+			name: "active retry remains anchored to first slot",
+			timing: MergeTiming{
+				EnteredMergingAt:          enteredAt,
+				MergeWorkerSlotAcquiredAt: acquiredAt,
+				MergeStartedAt:            retryStartedAt,
+			},
+			wantQueue:  60,
+			wantActive: 540,
+			wantTotal:  600,
+		},
+		{
+			name: "completed",
+			timing: MergeTiming{
+				EnteredMergingAt:          enteredAt,
+				MergeWorkerSlotAcquiredAt: acquiredAt,
+				MergeStartedAt:            retryStartedAt,
+				MergedAt:                  now,
+			},
+			wantQueue:  60,
+			wantActive: 540,
+			wantTotal:  600,
+		},
+		{
+			name: "failed",
+			timing: MergeTiming{
+				EnteredMergingAt:          enteredAt,
+				MergeWorkerSlotAcquiredAt: acquiredAt,
+				MergeStartedAt:            retryStartedAt,
+				MergeFailedAt:             now,
+			},
+			wantQueue:  60,
+			wantActive: 540,
+			wantTotal:  600,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := tt.timing.withDurations(now)
+			if got.QueueWaitSeconds != tt.wantQueue || got.ActiveMergeDurationSeconds != tt.wantActive || got.TotalMergingSeconds != tt.wantTotal {
+				t.Fatalf(
+					"durations = queue %d active %d total %d, want %d/%d/%d",
+					got.QueueWaitSeconds,
+					got.ActiveMergeDurationSeconds,
+					got.TotalMergingSeconds,
+					tt.wantQueue,
+					tt.wantActive,
+					tt.wantTotal,
+				)
+			}
+		})
+	}
+}
+
 func TestMarkMergeStartedPreservesCurrentHeadCIWaitDeadline(t *testing.T) {
 	t.Parallel()
 

--- a/internal/orchestrator/snapshot_test.go
+++ b/internal/orchestrator/snapshot_test.go
@@ -1216,14 +1216,14 @@ func TestStateSnapshotIncludesMergeTimingTelemetry(t *testing.T) {
 		t.Fatalf("Running = %#v, want active merge timing", snapshot.Running)
 	}
 	active := snapshot.Running[0].MergeTiming
-	if active.QueueWaitSeconds != 120 || active.ActiveMergeDurationSeconds != 360 || active.TotalMergingSeconds != 540 {
+	if active.QueueWaitSeconds != 120 || active.ActiveMergeDurationSeconds != 420 || active.TotalMergingSeconds != 540 {
 		t.Fatalf("active MergeTiming = %#v, want live active durations", active)
 	}
 	if len(snapshot.Completed) != 1 || snapshot.Completed[0].MergeTiming == nil {
 		t.Fatalf("Completed = %#v, want completed merge timing", snapshot.Completed)
 	}
 	done := snapshot.Completed[0].MergeTiming
-	if done.QueueWaitSeconds != 120 || done.ActiveMergeDurationSeconds != 240 || done.TotalMergingSeconds != 420 || done.MergedAt == nil {
+	if done.QueueWaitSeconds != 120 || done.ActiveMergeDurationSeconds != 300 || done.TotalMergingSeconds != 420 || done.MergedAt == nil {
 		t.Fatalf("completed MergeTiming = %#v, want terminal durations", done)
 	}
 }

--- a/internal/web/templates/dashboard_data.go
+++ b/internal/web/templates/dashboard_data.go
@@ -4200,14 +4200,29 @@ func prPipelineMergeWaitDetail(issue telemetry.Issue) string {
 		if timing.MergeWorkerSlotAcquiredAt == nil {
 			return prPipelineMergeSubstate("waiting for merge worker slot", timing.EnteredMergingAt)
 		}
-		if checks := prPipelineMergeBlockingChecks(issue.PullRequest); checks != "" {
+		checks := prPipelineMergeBlockingChecks(issue.PullRequest)
+		if checks != "" || issue.PullRequest != nil && prPipelineCIStatus(issue, "merging") == "pending" {
 			state := prPipelineMergeSubstate(
 				"waiting on current-head CI",
 				timing.CIWaitStartedAt,
 				timing.MergeStartedAt,
 				timing.MergeWorkerSlotAcquiredAt,
 			)
+			if checks == "" {
+				checks = "check name unavailable"
+			}
 			return state + ": " + checks
+		}
+		if issue.PullRequest != nil {
+			switch strings.ToLower(strings.TrimSpace(issue.PullRequest.MergeableState)) {
+			case "", "unknown":
+				return prPipelineMergeSubstate(
+					"waiting for GitHub mergeability",
+					timing.CIWaitStartedAt,
+					timing.MergeStartedAt,
+					timing.MergeWorkerSlotAcquiredAt,
+				)
+			}
 		}
 		return prPipelineMergeSubstate("active merge", timing.MergeWorkerSlotAcquiredAt)
 	}

--- a/internal/web/templates/dashboard_data.go
+++ b/internal/web/templates/dashboard_data.go
@@ -4079,6 +4079,7 @@ func prPipelineCardForIssue(issue telemetry.Issue, state string, laneID string, 
 
 func prPipelineWaitDetail(issue telemetry.Issue) string {
 	parts := []string{}
+	mergeDetail := prPipelineMergeWaitDetail(issue)
 	if reason := prPipelineDispatchSkipWaitReason(issue); reason != "" {
 		parts = append(parts, reason)
 	} else if reason := prPipelineAutoPromoteWaitReason(issue); reason != "" {
@@ -4109,12 +4110,12 @@ func prPipelineWaitDetail(issue telemetry.Issue) string {
 		if slowChecks := prPipelineSlowChecks(issue.PullRequest.SlowChecks); slowChecks != "" {
 			parts = append(parts, "slow "+slowChecks)
 		}
-		if runningChecks := prPipelineRunningChecks(issue.PullRequest.RunningChecks); runningChecks != "" {
+		if runningChecks := prPipelineRunningChecks(issue.PullRequest.RunningChecks); runningChecks != "" && mergeDetail == "" {
 			parts = append(parts, "running "+runningChecks)
 		}
 	}
-	if merge := prPipelineMergeWaitDetail(issue.MergeTiming); merge != "" {
-		parts = append(parts, merge)
+	if mergeDetail != "" {
+		parts = append(parts, mergeDetail)
 	}
 	return strings.Join(parts, " / ")
 }
@@ -4190,9 +4191,25 @@ func prPipelineHumanReviewWaitReason(issue telemetry.Issue) string {
 	return "waiting for auto-promote"
 }
 
-func prPipelineMergeWaitDetail(timing *telemetry.MergeTiming) string {
+func prPipelineMergeWaitDetail(issue telemetry.Issue) string {
+	timing := issue.MergeTiming
 	if timing == nil {
 		return ""
+	}
+	if timing.MergedAt == nil && timing.MergeFailedAt == nil && prPipelineLaneID(issue.State) == "merging" {
+		if timing.MergeWorkerSlotAcquiredAt == nil {
+			return prPipelineMergeSubstate("waiting for merge worker slot", timing.EnteredMergingAt)
+		}
+		if checks := prPipelineMergeBlockingChecks(issue.PullRequest); checks != "" {
+			state := prPipelineMergeSubstate(
+				"waiting on current-head CI",
+				timing.CIWaitStartedAt,
+				timing.MergeStartedAt,
+				timing.MergeWorkerSlotAcquiredAt,
+			)
+			return state + ": " + checks
+		}
+		return prPipelineMergeSubstate("active merge", timing.MergeWorkerSlotAcquiredAt)
 	}
 	parts := []string{}
 	if timing.QueueWaitSeconds > 0 {
@@ -4205,6 +4222,41 @@ func prPipelineMergeWaitDetail(timing *telemetry.MergeTiming) string {
 		parts = append(parts, "total Merging "+formatDuration(float64(timing.TotalMergingSeconds)))
 	}
 	return strings.Join(parts, " / ")
+}
+
+func prPipelineMergeSubstate(state string, sinceCandidates ...*time.Time) string {
+	for _, since := range sinceCandidates {
+		if since != nil && !since.IsZero() {
+			return state + " since " + localTimeToken(*since, LocalTimeOnly)
+		}
+	}
+	return state
+}
+
+func prPipelineMergeBlockingChecks(pullRequest *telemetry.PullRequest) string {
+	if pullRequest == nil {
+		return ""
+	}
+	checks := make([]string, 0, len(pullRequest.RequiredCheckFailures)+len(pullRequest.RunningChecks))
+	for _, check := range pullRequest.RequiredCheckFailures {
+		if prPipelineCheckPending(check) {
+			checks = append(checks, check.Name)
+		}
+	}
+	checks = append(checks, pullRequest.RunningChecks...)
+	return strings.Join(uniqueStrings(checks), ", ")
+}
+
+func prPipelineCheckPending(check telemetry.PullRequestCheck) bool {
+	if strings.EqualFold(strings.TrimSpace(check.Conclusion), "missing") {
+		return true
+	}
+	switch strings.ToLower(strings.TrimSpace(check.Status)) {
+	case "missing", "pending", "queued", "waiting", "in_progress", "in progress", "requested", "expected":
+		return true
+	default:
+		return false
+	}
 }
 
 func pullRequestHydrationWaitDetail(unavailableReason string, degradedReason string, nextRetryAt *time.Time) string {

--- a/internal/web/templates/dashboard_data_test.go
+++ b/internal/web/templates/dashboard_data_test.go
@@ -2960,6 +2960,86 @@ func TestPRPipelineWaitDetailIncludesDispatchSkipReason(t *testing.T) {
 	}
 }
 
+func TestPRPipelineWaitDetailShowsCurrentMergeSubstate(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 8, 7, 22, 13, 0, 0, time.UTC)
+	enteredAt := now.Add(-10 * time.Minute)
+	acquiredAt := now.Add(-9 * time.Minute)
+	ciWaitStartedAt := now.Add(-8 * time.Minute)
+	completedAt := now.Add(-time.Minute)
+	tests := []struct {
+		name  string
+		issue telemetry.Issue
+		want  string
+	}{
+		{
+			name: "waiting for merge worker slot",
+			issue: telemetry.Issue{
+				State:       "Merging",
+				MergeTiming: &telemetry.MergeTiming{EnteredMergingAt: &enteredAt},
+			},
+			want: "waiting for merge worker slot since " + localTimeToken(enteredAt, LocalTimeOnly),
+		},
+		{
+			name: "waiting on named current-head checks",
+			issue: telemetry.Issue{
+				State: "Merging",
+				PullRequest: &telemetry.PullRequest{
+					RunningChecks: []string{"Test Coverage", "Release"},
+					RequiredCheckFailures: []telemetry.PullRequestCheck{
+						{Name: "Test Coverage", Status: "in_progress"},
+						{Name: "Release", Status: "queued"},
+					},
+				},
+				MergeTiming: &telemetry.MergeTiming{
+					EnteredMergingAt:          &enteredAt,
+					MergeWorkerSlotAcquiredAt: &acquiredAt,
+					CIWaitStartedAt:           &ciWaitStartedAt,
+				},
+			},
+			want: "waiting on current-head CI since " + localTimeToken(ciWaitStartedAt, LocalTimeOnly) + ": Test Coverage, Release",
+		},
+		{
+			name: "active merge without a blocking check",
+			issue: telemetry.Issue{
+				State: "Merging",
+				PullRequest: &telemetry.PullRequest{
+					CIStatus: "success",
+				},
+				MergeTiming: &telemetry.MergeTiming{
+					EnteredMergingAt:          &enteredAt,
+					MergeWorkerSlotAcquiredAt: &acquiredAt,
+				},
+			},
+			want: "active merge since " + localTimeToken(acquiredAt, LocalTimeOnly),
+		},
+		{
+			name: "terminal merge retains duration detail",
+			issue: telemetry.Issue{
+				State: "Done",
+				MergeTiming: &telemetry.MergeTiming{
+					MergedAt:                   &completedAt,
+					QueueWaitSeconds:           60,
+					ActiveMergeDurationSeconds: 480,
+					TotalMergingSeconds:        540,
+				},
+			},
+			want: "merge queue 1m 0s / active merge 8m 0s / total Merging 9m 0s",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			if got := prPipelineWaitDetail(tt.issue); got != tt.want {
+				t.Fatalf("prPipelineWaitDetail() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestPRPipelineCardIncludesIssueAndPullRequestIdentity(t *testing.T) {
 	t.Parallel()
 

--- a/internal/web/templates/dashboard_data_test.go
+++ b/internal/web/templates/dashboard_data_test.go
@@ -3005,7 +3005,8 @@ func TestPRPipelineWaitDetailShowsCurrentMergeSubstate(t *testing.T) {
 			issue: telemetry.Issue{
 				State: "Merging",
 				PullRequest: &telemetry.PullRequest{
-					CIStatus: "success",
+					CIStatus:       "success",
+					MergeableState: "clean",
 				},
 				MergeTiming: &telemetry.MergeTiming{
 					EnteredMergingAt:          &enteredAt,
@@ -3013,6 +3014,38 @@ func TestPRPipelineWaitDetailShowsCurrentMergeSubstate(t *testing.T) {
 				},
 			},
 			want: "active merge since " + localTimeToken(acquiredAt, LocalTimeOnly),
+		},
+		{
+			name: "pending ci without a named check",
+			issue: telemetry.Issue{
+				State: "Merging",
+				PullRequest: &telemetry.PullRequest{
+					CIStatus:       "pending",
+					MergeableState: "clean",
+				},
+				MergeTiming: &telemetry.MergeTiming{
+					EnteredMergingAt:          &enteredAt,
+					MergeWorkerSlotAcquiredAt: &acquiredAt,
+					CIWaitStartedAt:           &ciWaitStartedAt,
+				},
+			},
+			want: "waiting on current-head CI since " + localTimeToken(ciWaitStartedAt, LocalTimeOnly) + ": check name unavailable",
+		},
+		{
+			name: "waiting for mergeability computation",
+			issue: telemetry.Issue{
+				State: "Merging",
+				PullRequest: &telemetry.PullRequest{
+					CIStatus:       "success",
+					MergeableState: "unknown",
+				},
+				MergeTiming: &telemetry.MergeTiming{
+					EnteredMergingAt:          &enteredAt,
+					MergeWorkerSlotAcquiredAt: &acquiredAt,
+					MergeStartedAt:            &ciWaitStartedAt,
+				},
+			},
+			want: "waiting for GitHub mergeability since " + localTimeToken(ciWaitStartedAt, LocalTimeOnly),
 		},
 		{
 			name: "terminal merge retains duration detail",


### PR DESCRIPTION
## Summary

- Preserve the first merge-worker slot acquisition across retries so queue and active durations remain anchored to the real attempt boundary.
- Start a fresh timing measurement after a completed or failed merge.
- Replace live aggregate-only merge timing with the current merge sub-state, its start time, and named blocking checks.

Fixes #1691

## UI Surface Contract

- [x] The linked issue explicitly authorizes the operator-visible merge wait detail change; it does not alter layout, density, first-viewport content, or responsive visibility.
- [x] This PR does not add persistent top-of-screen messaging.
- [x] Visual changes to primary operator screens were verified with the isolated Playwright demo harness below.

## Test Plan

- [x] `make check` with the live runtime API-token variable removed from the test environment (race suite green; 78.6% aggregate coverage)
- [x] `make visual-e2e` (116 passed; 32 expected project-specific skips)
- [x] Focused table-driven orchestrator and dashboard template tests