### PR TITLE
fix(merge): defer wasteful base refreshes

### DIFF
--- a/internal/orchestrator/autopromote_tick.go
+++ b/internal/orchestrator/autopromote_tick.go
@@ -29,6 +29,9 @@ const (
 	autoPromoteGateWaitTimeoutHumanReview = "human_review"
 	defaultAutoPromoteGateWaitTimeout     = time.Hour
 	mergeWorkerProjectStateFull           = "project_state_capacity_full"
+	mergeBaseRefreshRequiredChecksPending = "required_checks_pending"
+	mergeBaseRefreshLaneUnavailable       = "merge_lane_capacity_unavailable"
+	mergeBaseRefreshGlobalUnavailable     = "global_capacity_unavailable"
 )
 
 type autoPromoteTickResult struct {
@@ -39,6 +42,12 @@ type autoPromoteTickResult struct {
 type staleMergingPullRequestDecision struct {
 	targetState string
 	reason      string
+}
+
+type mergeBaseRefreshDecision struct {
+	applicable bool
+	proceed    bool
+	reason     string
 }
 
 type autoPromoteReworkLimitSummary struct {
@@ -1188,6 +1197,7 @@ func (o *Orchestrator) mergeWorkerDispatchCandidates(state *State, issues []conn
 			}
 		}
 		if projectStats.available <= 0 {
+			o.logMergeBaseRefreshDeferred(issue, mergeBaseRefreshLaneUnavailable)
 			o.logMergeWorkerSlotWait(
 				issue,
 				scheduler.DispatchGateDecision{Reason: mergeWorkerProjectStateFull},
@@ -1338,6 +1348,10 @@ func (o *Orchestrator) staleMergingQueueDispatchCandidates(state *State, issues 
 			continue
 		}
 		if !staleMergingIssueReadyForDispatch(issue, o.cfg) {
+			decision := decideMergeBaseRefresh(issue, true, true)
+			if decision.applicable && !decision.proceed {
+				o.logMergeBaseRefreshDeferred(issue, decision.reason)
+			}
 			consumedRepositories = consumeMergeWorkerRepository(consumedRepositories, repository)
 			continue
 		}
@@ -1370,7 +1384,35 @@ func staleMergingIssueReadyForDispatch(issue connector.Issue, cfg Config) bool {
 	if pullRequest.Draft {
 		return false
 	}
-	return !staleMergingCIRed(pullRequest.CIStatus)
+	if staleMergingCIRed(pullRequest.CIStatus) {
+		return false
+	}
+	decision := decideMergeBaseRefresh(issue, true, true)
+	return !decision.applicable || decision.proceed
+}
+
+func decideMergeBaseRefresh(issue connector.Issue, laneAvailable bool, globalAvailable bool) mergeBaseRefreshDecision {
+	if issue.PullRequest == nil || !strings.EqualFold(strings.TrimSpace(issue.PullRequest.MergeableState), "behind") {
+		return mergeBaseRefreshDecision{}
+	}
+	if !mergeWorkerCIGreen(issue.PullRequest.CIStatus) || len(issue.PullRequest.RequiredCheckFailures) > 0 {
+		return mergeBaseRefreshDecision{applicable: true, reason: mergeBaseRefreshRequiredChecksPending}
+	}
+	if !laneAvailable {
+		return mergeBaseRefreshDecision{applicable: true, reason: mergeBaseRefreshLaneUnavailable}
+	}
+	if !globalAvailable {
+		return mergeBaseRefreshDecision{applicable: true, reason: mergeBaseRefreshGlobalUnavailable}
+	}
+	return mergeBaseRefreshDecision{applicable: true, proceed: true}
+}
+
+func (o *Orchestrator) logMergeBaseRefreshDeferred(issue connector.Issue, reason string) {
+	if o.logger == nil || issue.PullRequest == nil ||
+		!strings.EqualFold(strings.TrimSpace(issue.PullRequest.MergeableState), "behind") {
+		return
+	}
+	o.logger.Info("merge_base_refresh_deferred", mergeWorkerLogAttrs(issue, "reason", strings.TrimSpace(reason))...)
 }
 
 func staleMergingCIRed(status string) bool {

--- a/internal/orchestrator/autopromote_tick.go
+++ b/internal/orchestrator/autopromote_tick.go
@@ -1395,7 +1395,7 @@ func decideMergeBaseRefresh(issue connector.Issue, laneAvailable bool, globalAva
 	if issue.PullRequest == nil || !strings.EqualFold(strings.TrimSpace(issue.PullRequest.MergeableState), "behind") {
 		return mergeBaseRefreshDecision{}
 	}
-	if !mergeWorkerCIGreen(issue.PullRequest.CIStatus) || len(issue.PullRequest.RequiredCheckFailures) > 0 {
+	if len(issue.PullRequest.RequiredCheckFailures) > 0 {
 		return mergeBaseRefreshDecision{applicable: true, reason: mergeBaseRefreshRequiredChecksPending}
 	}
 	if !laneAvailable {

--- a/internal/orchestrator/autopromote_tick_test.go
+++ b/internal/orchestrator/autopromote_tick_test.go
@@ -4029,6 +4029,27 @@ func TestStaleMergingQueueDispatchCandidatesFiltersUnsafePullRequests(t *testing
 			want: true,
 		},
 		{
+			name: "behind and ready for base refresh",
+			pullRequest: &connector.PullRequest{
+				State:          "OPEN",
+				MergeableState: "behind",
+				CIStatus:       "success",
+			},
+			want: true,
+		},
+		{
+			name: "behind with pending required check",
+			pullRequest: &connector.PullRequest{
+				State:          "OPEN",
+				MergeableState: "behind",
+				CIStatus:       "pending",
+				RequiredCheckFailures: []connector.PullRequestCheck{{
+					Name:   "Portability Verify (windows-latest)",
+					Status: "in_progress",
+				}},
+			},
+		},
+		{
 			name:        "missing pull request",
 			pullRequest: nil,
 		},
@@ -4388,6 +4409,73 @@ func TestMergeWorkerHeadReady(t *testing.T) {
 			}
 			if got := mergeWorkerHeadReady(issue); got != tt.want {
 				t.Fatalf("mergeWorkerHeadReady() = %t, want %t", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestDecideMergeBaseRefresh(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name            string
+		mergeableState  string
+		ciStatus        string
+		requiredChecks  []connector.PullRequestCheck
+		laneAvailable   bool
+		globalAvailable bool
+		want            mergeBaseRefreshDecision
+	}{
+		{
+			name:            "behind and ready",
+			mergeableState:  "behind",
+			ciStatus:        "success",
+			laneAvailable:   true,
+			globalAvailable: true,
+			want:            mergeBaseRefreshDecision{applicable: true, proceed: true},
+		},
+		{
+			name:           "behind with pending required check",
+			mergeableState: "behind",
+			ciStatus:       "pending",
+			requiredChecks: []connector.PullRequestCheck{{Name: "Portability Verify", Status: "in_progress"}},
+			laneAvailable:  true,
+			want:           mergeBaseRefreshDecision{applicable: true, reason: mergeBaseRefreshRequiredChecksPending},
+		},
+		{
+			name:            "behind with occupied merge lane",
+			mergeableState:  "behind",
+			ciStatus:        "success",
+			globalAvailable: true,
+			want:            mergeBaseRefreshDecision{applicable: true, reason: mergeBaseRefreshLaneUnavailable},
+		},
+		{
+			name:           "behind without global capacity",
+			mergeableState: "behind",
+			ciStatus:       "success",
+			laneAvailable:  true,
+			want:           mergeBaseRefreshDecision{applicable: true, reason: mergeBaseRefreshGlobalUnavailable},
+		},
+		{
+			name:            "not behind",
+			mergeableState:  "clean",
+			ciStatus:        "success",
+			laneAvailable:   true,
+			globalAvailable: true,
+			want:            mergeBaseRefreshDecision{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			issue := nativeMergeQueueTestIssue(1692, tt.ciStatus)
+			issue.PullRequest.MergeableState = tt.mergeableState
+			issue.PullRequest.RequiredCheckFailures = tt.requiredChecks
+			got := decideMergeBaseRefresh(issue, tt.laneAvailable, tt.globalAvailable)
+			if got != tt.want {
+				t.Fatalf("decideMergeBaseRefresh() = %#v, want %#v", got, tt.want)
 			}
 		})
 	}

--- a/internal/orchestrator/autopromote_tick_test.go
+++ b/internal/orchestrator/autopromote_tick_test.go
@@ -4050,6 +4050,15 @@ func TestStaleMergingQueueDispatchCandidatesFiltersUnsafePullRequests(t *testing
 			},
 		},
 		{
+			name: "behind with pending optional check",
+			pullRequest: &connector.PullRequest{
+				State:          "OPEN",
+				MergeableState: "behind",
+				CIStatus:       "pending",
+			},
+			want: true,
+		},
+		{
 			name:        "missing pull request",
 			pullRequest: nil,
 		},
@@ -4441,6 +4450,14 @@ func TestDecideMergeBaseRefresh(t *testing.T) {
 			requiredChecks: []connector.PullRequestCheck{{Name: "Portability Verify", Status: "in_progress"}},
 			laneAvailable:  true,
 			want:           mergeBaseRefreshDecision{applicable: true, reason: mergeBaseRefreshRequiredChecksPending},
+		},
+		{
+			name:            "behind with pending optional check",
+			mergeableState:  "behind",
+			ciStatus:        "pending",
+			laneAvailable:   true,
+			globalAvailable: true,
+			want:            mergeBaseRefreshDecision{applicable: true, proceed: true},
 		},
 		{
 			name:            "behind with occupied merge lane",

--- a/internal/orchestrator/dispatch.go
+++ b/internal/orchestrator/dispatch.go
@@ -362,6 +362,7 @@ func (o *Orchestrator) dispatchIssueWithAdmission(
 		o.recordDispatchGateRefusal(ctx, state, issue, attempt, workerHost, now, decision, projectStats)
 		o.logSchedulerSlotDecision(issue, "waiting", decision, projectStats)
 		if mergeWorkerIssue(issue) {
+			o.logMergeBaseRefreshDeferred(issue, mergeBaseRefreshGlobalUnavailable)
 			o.logMergeWorkerSlotWait(issue, decision, projectStats)
 		} else {
 			o.logDispatchSlotWait(issue, decision, projectStats)

--- a/internal/orchestrator/merge_fast_path_test.go
+++ b/internal/orchestrator/merge_fast_path_test.go
@@ -20,7 +20,7 @@ import (
 	"github.com/digitaldrywood/detent/internal/workspace"
 )
 
-func TestMergingFastPathBehindCheckedHeadMergesWithoutRebaseOrAgentDispatch(t *testing.T) {
+func TestMergingFastPathBehindReadyRefreshesThenMerges(t *testing.T) {
 	t.Parallel()
 
 	now := time.Date(2026, 6, 26, 13, 20, 0, 0, time.UTC)
@@ -97,14 +97,14 @@ func TestMergingFastPathBehindCheckedHeadMergesWithoutRebaseOrAgentDispatch(t *t
 	}
 	orch.handleRunResult(context.Background(), &state, completion)
 
-	if got := workspaceBackend.createCalls.Load(); got != 0 {
-		t.Fatalf("Create() calls = %d, want 0", got)
+	if got := workspaceBackend.createCalls.Load(); got != 1 {
+		t.Fatalf("Create() calls = %d, want 1", got)
 	}
-	if got := workspaceBackend.prepareCalls.Load(); got != 0 {
-		t.Fatalf("PrepareMerge() calls = %d, want 0", got)
+	if got := workspaceBackend.prepareCalls.Load(); got != 1 {
+		t.Fatalf("PrepareMerge() calls = %d, want 1", got)
 	}
-	if got := workspaceBackend.afterRunCalls.Load(); got != 0 {
-		t.Fatalf("AfterRun() calls = %d, want 0", got)
+	if got := workspaceBackend.afterRunCalls.Load(); got != 1 {
+		t.Fatalf("AfterRun() calls = %d, want 1", got)
 	}
 	if got := agentBackend.calls.Load(); got != 0 {
 		t.Fatalf("AgentBackend.RunTurn() calls = %d, want 0", got)

--- a/internal/orchestrator/merge_timing.go
+++ b/internal/orchestrator/merge_timing.go
@@ -140,15 +140,21 @@ func (o *Orchestrator) markMergeStarted(state *State, issue connector.Issue, now
 	}
 	timing := o.markMergeWorkerSlotAcquired(state, issue, now)
 	timing.MergeStartedAt = now.UTC()
-	timing.BaseRefreshStartedAt = timing.MergeStartedAt
-	timing.BaseRefreshFinishedAt = time.Time{}
+	baseRefreshStarted := issue.PullRequest != nil &&
+		strings.EqualFold(strings.TrimSpace(issue.PullRequest.MergeableState), "behind")
+	if baseRefreshStarted {
+		timing.BaseRefreshStartedAt = timing.MergeStartedAt
+		timing.BaseRefreshFinishedAt = time.Time{}
+	}
 	if timing.CIWaitStartedAt.IsZero() {
 		timing.CIWaitStartedAt = timing.MergeStartedAt
 	}
 	timing.CIWaitFinishedAt = time.Time{}
 	timing = timing.withDurations(now)
 	state.MergeTimings[strings.TrimSpace(issue.ID)] = timing
-	o.logMergeTimingInfo("merge_base_refresh_started", issue, timing)
+	if baseRefreshStarted {
+		o.logMergeTimingInfo("merge_base_refresh_started", issue, timing)
+	}
 	o.logMergeTimingInfo("merge_ci_wait_started", issue, timing)
 	return timing
 }
@@ -157,8 +163,11 @@ func (o *Orchestrator) recordMergeCompleted(state *State, issue connector.Issue,
 	if !mergeWorkerIssue(issue) {
 		return MergeTiming{}
 	}
+	refreshPending := mergeBaseRefreshPending(state, issue)
 	timing := o.completeMergeTiming(state, issue, at, "", true)
-	o.logMergeTimingInfo("merge_base_refresh_finished", issue, timing, "final_state", strings.TrimSpace(finalState))
+	if refreshPending {
+		o.logMergeTimingInfo("merge_base_refresh_finished", issue, timing, "final_state", strings.TrimSpace(finalState))
+	}
 	o.logMergeTimingInfo("merge_ci_wait_finished", issue, timing, "final_state", strings.TrimSpace(finalState))
 	o.logMergeTimingInfo("merge_completed", issue, timing, "final_state", strings.TrimSpace(finalState))
 	return timing
@@ -196,12 +205,15 @@ func (o *Orchestrator) recordMergeFailed(state *State, issue connector.Issue, at
 		}
 		return timing
 	}
+	refreshPending := !timing.BaseRefreshStartedAt.IsZero() && timing.BaseRefreshFinishedAt.IsZero()
 	timing = o.completeMergeTiming(state, issue, at, reason, false)
 	attrs := []any{"reason", strings.TrimSpace(reason)}
 	if err != nil {
 		attrs = append(attrs, "error", err)
 	}
-	o.logMergeTimingInfo("merge_base_refresh_finished", issue, timing, attrs...)
+	if refreshPending {
+		o.logMergeTimingInfo("merge_base_refresh_finished", issue, timing, attrs...)
+	}
 	o.logMergeTimingInfo("merge_ci_wait_finished", issue, timing, attrs...)
 	o.logMergeTimingWarn("merge_failed", issue, timing, attrs...)
 	return timing
@@ -227,9 +239,6 @@ func (o *Orchestrator) completeMergeTiming(state *State, issue connector.Issue, 
 		timing.MergeFailedAt = completedAt
 		timing.MergeFailureReason = strings.TrimSpace(reason)
 	}
-	if timing.BaseRefreshStartedAt.IsZero() && !timing.MergeStartedAt.IsZero() {
-		timing.BaseRefreshStartedAt = timing.MergeStartedAt
-	}
 	if timing.CIWaitStartedAt.IsZero() && !timing.MergeStartedAt.IsZero() {
 		timing.CIWaitStartedAt = timing.MergeStartedAt
 	}
@@ -242,6 +251,14 @@ func (o *Orchestrator) completeMergeTiming(state *State, issue connector.Issue, 
 	timing = timing.withDurations(completedAt)
 	state.MergeTimings[strings.TrimSpace(issue.ID)] = timing
 	return timing
+}
+
+func mergeBaseRefreshPending(state *State, issue connector.Issue) bool {
+	if state == nil {
+		return false
+	}
+	timing := state.MergeTimings[strings.TrimSpace(issue.ID)]
+	return !timing.BaseRefreshStartedAt.IsZero() && timing.BaseRefreshFinishedAt.IsZero()
 }
 
 func mergeQueueEnteredAt(issue connector.Issue, fallback time.Time) time.Time {

--- a/internal/orchestrator/merge_timing_test.go
+++ b/internal/orchestrator/merge_timing_test.go
@@ -79,6 +79,49 @@ func TestMarkMergeStartedPreservesCurrentHeadCIWaitDeadline(t *testing.T) {
 	}
 }
 
+func TestMarkMergeStartedRecordsOnlyActualBaseRefresh(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 8, 8, 15, 0, 0, 0, time.UTC)
+	tests := []struct {
+		name           string
+		mergeableState string
+		wantRefresh    bool
+	}{
+		{name: "behind head", mergeableState: "behind", wantRefresh: true},
+		{name: "current head", mergeableState: "clean"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			issue := connector.Issue{
+				ID:         "issue-" + strings.ReplaceAll(tt.name, " ", "-"),
+				Identifier: "digitaldrywood/detent#1692",
+				State:      "Merging",
+				PullRequest: &connector.PullRequest{
+					Number:         1694,
+					State:          "OPEN",
+					MergeableState: tt.mergeableState,
+				},
+			}
+			state := newState(normalizeConfig(Config{}))
+			var logs strings.Builder
+			orch := &Orchestrator{logger: slog.New(slog.NewTextHandler(&logs, nil))}
+
+			got := orch.markMergeStarted(&state, issue, now)
+
+			if got.BaseRefreshStartedAt.IsZero() == tt.wantRefresh {
+				t.Fatalf("BaseRefreshStartedAt = %v, want refresh recorded %t", got.BaseRefreshStartedAt, tt.wantRefresh)
+			}
+			if strings.Contains(logs.String(), "merge_base_refresh_started") != tt.wantRefresh {
+				t.Fatalf("logs %q, want refresh event %t", logs.String(), tt.wantRefresh)
+			}
+		})
+	}
+}
+
 func TestRecordMergeFailedRejectsFailureBeforeMergeEntry(t *testing.T) {
 	t.Parallel()
 

--- a/internal/runner/agent.go
+++ b/internal/runner/agent.go
@@ -608,8 +608,7 @@ func mergeFastPathCheckedHead(issue connector.Issue) bool {
 	if !strings.EqualFold(strings.TrimSpace(pullRequest.State), "open") || pullRequest.Draft {
 		return false
 	}
-	mergeableState := strings.ToLower(strings.TrimSpace(pullRequest.MergeableState))
-	if mergeableState != "behind" && mergeableState != "clean" {
+	if !strings.EqualFold(strings.TrimSpace(pullRequest.MergeableState), "clean") {
 		return false
 	}
 	if strings.TrimSpace(pullRequest.HeadSHA) == "" {

--- a/internal/runner/runner_test.go
+++ b/internal/runner/runner_test.go
@@ -2047,7 +2047,7 @@ func TestMergeFastPathCheckedHead(t *testing.T) {
 
 	base := connector.PullRequest{
 		State:          "open",
-		MergeableState: "behind",
+		MergeableState: "clean",
 		CIStatus:       "success",
 		HeadSHA:        "checked-head",
 	}
@@ -2056,8 +2056,9 @@ func TestMergeFastPathCheckedHead(t *testing.T) {
 		mutate func(*connector.PullRequest)
 		want   bool
 	}{
-		{name: "behind green head", want: true},
-		{name: "current head", mutate: func(pr *connector.PullRequest) { pr.MergeableState = " CLEAN " }, want: true},
+		{name: "current green head", want: true},
+		{name: "normalized current head", mutate: func(pr *connector.PullRequest) { pr.MergeableState = " CLEAN " }, want: true},
+		{name: "behind green head", mutate: func(pr *connector.PullRequest) { pr.MergeableState = "behind" }},
 		{name: "pending checks", mutate: func(pr *connector.PullRequest) { pr.CIStatus = "pending" }},
 		{name: "draft", mutate: func(pr *connector.PullRequest) { pr.Draft = true }},
 		{name: "closed", mutate: func(pr *connector.PullRequest) { pr.State = "closed" }},
@@ -2078,7 +2079,7 @@ func TestMergeFastPathCheckedHead(t *testing.T) {
 	}
 }
 
-func TestRunnerMergeCheckedHeadSkipsWorkspace(t *testing.T) {
+func TestRunnerMergeCurrentHeadSkipsWorkspace(t *testing.T) {
 	t.Parallel()
 
 	workspaceBackend := &fakeMergeWorkspaceBackend{}
@@ -2098,7 +2099,7 @@ func TestRunnerMergeCheckedHeadSkipsWorkspace(t *testing.T) {
 			BranchName: "detent/checked-head",
 			PullRequest: &connector.PullRequest{
 				State:          "open",
-				MergeableState: "behind",
+				MergeableState: "clean",
 				CIStatus:       "success",
 				HeadSHA:        "checked-head",
 			},


### PR DESCRIPTION
## Summary

- defer `BEHIND` base refreshes until required checks and merge capacity are ready
- preserve strict-base refresh for ready behind heads while keeping clean checked heads on the zero-workspace path
- record deferred-refresh reasons and limit base-refresh timing to actual behind-head attempts

Fixes #1692

## UI Surface Contract

- [x] N/A; this change does not affect UI surfaces or layout.
- [x] This PR adds no persistent top-of-screen messaging.
- [x] This PR has no visual changes to primary operator screens.

## Test Plan

- [x] `env -u DETENT_API_TOKEN CHECK_LOCK_WAIT=60m make check`