### PR TITLE
docs(config): add worked multi-project example

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,10 +151,11 @@ criteria, review gates, and merge rules — and Detent runs that process with
 rigor, isolation, and parallelism across many issues at once. The intelligence
 stays in your spec; the runtime supplies the discipline.
 
-**See it for real:**
-[`digitaldrywood/detent-orchestration`](https://github.com/digitaldrywood/detent-orchestration)
-is Detent's own production config — it dispatches the agents that build Detent
-itself. Copy it as a template, and use
+**See it for real:** Detent uses the same host-and-project configuration model
+to dispatch the agents that build Detent itself. The in-repository
+[worked multi-project configuration](docs/examples/multi-project/README.md)
+shows that setup with complete, annotated, and sanitized files you can copy.
+Use
 [Bootstrap On A New Machine](docs/bootstrap.md#bootstrap-on-a-new-machine-humans-and-ai-agents)
 to go from a bare machine to a running board. To onboard a repository, verify an
 existing install, or add a new project to an existing Detent host, use the

--- a/docs/ONBOARDING.md
+++ b/docs/ONBOARDING.md
@@ -482,9 +482,9 @@ git -C <source-root> rev-parse --show-toplevel
 ```
 
 Do not use a reference or tooling repository as the target. A wrong target repository failure example looks like this: the operator mentions
-`digitaldrywood/detent-orchestration` as an example config and
+`example/reference-config` as an example config and
 `customer/api` as the actual project, but the agent runs issue, label, board,
-or validation discovery against `digitaldrywood/detent-orchestration`. Stop,
+or validation discovery against `example/reference-config`. Stop,
 rewrite `TARGET_REPOSITORY=customer/api`, verify `TARGET_SOURCE_ROOT` points to
 that checkout, and rerun `detent onboarding validate-answers --phase identity`
 before discovery resumes.

--- a/docs/bootstrap.md
+++ b/docs/bootstrap.md
@@ -5,8 +5,8 @@
 A complete, ordered runbook to take a bare machine to a running Detent. Every
 step has a verification command — do not proceed until it passes. An AI agent
 can execute these steps top to bottom; replace each `<...>` placeholder. The
-[`detent-orchestration`](https://github.com/digitaldrywood/detent-orchestration)
-repo is a real, working instance of this setup to copy from.
+[worked multi-project configuration](examples/multi-project/README.md) is a
+complete, annotated reference instance to compare against as you work.
 
 1. **Install Detent.** `brew install digitaldrywood/tap/detent` (macOS/Linux),
    `go install github.com/digitaldrywood/detent/cmd/detent@latest`, or a

--- a/docs/config.md
+++ b/docs/config.md
@@ -101,6 +101,9 @@ GitHub token redacted.
   project config.
 - [`config.annotated.yaml`](../config.annotated.yaml) is a realistic GitHub
   setup with explanations beside each deliberate choice.
+- The [worked multi-project configuration](examples/multi-project/README.md)
+  pairs an annotated host config with two complete project configs and explains
+  the operator rationale behind their scheduling and isolation choices.
 - [`config.reference.yaml`](../config.reference.yaml) contains every supported
   project key. It is fully commented so you can copy only what you need.
 

--- a/docs/examples/multi-project/README.md
+++ b/docs/examples/multi-project/README.md
@@ -1,0 +1,78 @@
+# Worked Multi-Project Configuration
+
+[Back to configuration](../../config.md#choose-a-starting-point)
+
+This example shows the same two-layer arrangement Detent uses to orchestrate
+its own development: one machine-local `global.yaml` registers every project,
+while each repository owns a portable `detent.yaml` and `WORKFLOW.md` contract.
+The repositories, paths, host name, and colors here are intentionally
+fictitious; no operator identity or private infrastructure is required to
+understand the choices.
+
+The example assumes this host layout:
+
+```text
+/srv/detent/
+├── config/global.yaml
+├── repos/
+│   ├── orders-api/
+│   │   ├── detent.yaml
+│   │   └── WORKFLOW.md
+│   └── storefront/
+│       ├── detent.yaml
+│       └── WORKFLOW.md
+└── worktrees/
+    ├── orders-api/
+    └── storefront/
+```
+
+The files in this directory map to that layout as follows:
+
+| Example file | Installed location |
+| --- | --- |
+| [`global.yaml`](global.yaml) | `/srv/detent/config/global.yaml` |
+| [`orders-api/detent.yaml`](orders-api/detent.yaml) | `/srv/detent/repos/orders-api/detent.yaml` |
+| [`storefront/detent.yaml`](storefront/detent.yaml) | `/srv/detent/repos/storefront/detent.yaml` |
+
+Copy a maintained label-mode
+[`WORKFLOW.md`](../../templates/WORKFLOW.label.md) beside each project config,
+then adapt its instructions and acceptance gates to that repository. Keep
+`global.yaml` outside the source repositories because it contains host-local
+paths and credentials. Check each `detent.yaml` into its project repository so
+the orchestration policy changes with the code it governs.
+
+## Why the host config looks this way
+
+- `github_token: gh` reuses the authenticated GitHub CLI credential instead of
+  storing a token in YAML.
+- Five host slots bound total process concurrency. Project caps divide that
+  capacity into three API slots and two storefront slots, so either repository
+  can stay responsive without exhausting the host.
+- Weighted scheduling gives the API twice the dispatch share when both queues
+  are ready. Equal priority keeps that weight meaningful; lower numeric
+  priority can still be assigned temporarily with `detent promote`.
+- Source checkouts and generated worktrees have separate roots. Agents work in
+  isolated worktrees and never mutate the long-lived source checkout.
+- Each project has its own color for dashboard scanning, but IDs remain the
+  primary identifier.
+
+## Why the project configs differ
+
+Both projects use repository labels as their status source, auto-provision the
+expected labels, serialize the merge lane, require `make check`, and keep the
+dashboard on loopback. The API may run three agents concurrently because its
+queue receives the larger scheduling share; the storefront is capped at two.
+Everything else stays intentionally aligned so operators can reason about one
+workflow across both repositories.
+
+The files include every setting needed for this deployment model. Optional
+subsystems such as intake, scheduled routines, model routing, budgets, and
+telemetry remain omitted until the operator has a reason to enable them. See
+the [complete configuration reference](../../config.md) before adding one.
+
+After replacing the fictitious repositories and service paths, verify the
+resolved installation before starting the server:
+
+```sh
+detent --config /srv/detent/config/global.yaml doctor --allow-write-probes
+```

--- a/docs/examples/multi-project/README.md
+++ b/docs/examples/multi-project/README.md
@@ -45,12 +45,14 @@ the orchestration policy changes with the code it governs.
 
 - `github_token: gh` reuses the authenticated GitHub CLI credential instead of
   storing a token in YAML.
-- Five host slots bound total process concurrency. Project caps divide that
-  capacity into three API slots and two storefront slots, so either repository
-  can stay responsive without exhausting the host.
-- Weighted scheduling gives the API twice the dispatch share when both queues
-  are ready. Equal priority keeps that weight meaningful; lower numeric
-  priority can still be assigned temporarily with `detent promote`.
+- Five host slots bound total process concurrency. Project caps limit the API
+  to three agents and the storefront to two, so either repository can stay
+  responsive without exhausting the host.
+- Weighted scheduling prefers the API two to one when both queues are ready and
+  a host and project slot are available. Once both projects reach their caps,
+  running concurrency is bounded at three to two; weights do not override
+  those caps. Equal priority keeps weight meaningful before saturation. Use
+  `detent promote` to assign a temporarily lower numeric priority.
 - Source checkouts and generated worktrees have separate roots. Agents work in
   isolated worktrees and never mutate the long-lived source checkout.
 - Each project has its own color for dashboard scanning, but IDs remain the
@@ -61,9 +63,10 @@ the orchestration policy changes with the code it governs.
 Both projects use repository labels as their status source, auto-provision the
 expected labels, serialize the merge lane, require `make check`, and keep the
 dashboard on loopback. The API may run three agents concurrently because its
-queue receives the larger scheduling share; the storefront is capped at two.
-Everything else stays intentionally aligned so operators can reason about one
-workflow across both repositories.
+project cap is three; the storefront is capped at two. Scheduling weights
+choose between ready projects while capacity remains. Everything else stays
+intentionally aligned so operators can reason about one workflow across both
+repositories.
 
 The files include every setting needed for this deployment model. Optional
 subsystems such as intake, scheduled routines, model routing, budgets, and

--- a/docs/examples/multi-project/global.yaml
+++ b/docs/examples/multi-project/global.yaml
@@ -1,0 +1,45 @@
+apiVersion: detent/v1
+kind: GlobalConfig
+
+# Host-wide values stay outside project repositories. Resolve GitHub access
+# through the authenticated CLI instead of placing a token in this file.
+env: prod
+log_level: info
+github_token: gh
+port: 4000
+instance_name: build-host
+
+# Check for releases, but leave binary replacement to an explicit operator
+# action so running work drains on the operator's schedule.
+update:
+  auto_check_enabled: true
+  check_interval_hours: 24
+  auto_apply_enabled: false
+
+global:
+  # Bound total subprocess pressure on this host. Per-project caps below split
+  # these five slots between the two repositories.
+  max_concurrent_agents: 5
+  scheduling: weighted
+  fair_share:
+    half_life: 1h
+  startup:
+    jitter_seconds: 10
+    max_spawn_per_second: 2
+    max_concurrent_starts: 2
+
+projects:
+  - id: orders-api
+    workflow: /srv/detent/repos/orders-api/WORKFLOW.md
+    workdir: /srv/detent/repos/orders-api
+    color: "#1192e8"
+    # Equal priority lets weight control the steady-state dispatch share.
+    weight: 2
+    priority: 2
+
+  - id: storefront
+    workflow: /srv/detent/repos/storefront/WORKFLOW.md
+    workdir: /srv/detent/repos/storefront
+    color: "#9f7aea"
+    weight: 1
+    priority: 2

--- a/docs/examples/multi-project/orders-api/detent.yaml
+++ b/docs/examples/multi-project/orders-api/detent.yaml
@@ -1,0 +1,88 @@
+schema: 1
+
+# Repository labels keep this project independent of a shared ProjectV2 board.
+# Auto-provisioning creates any missing detent:* status labels at startup.
+tracker:
+  kind: github
+  github_status_source: label
+  repository: example-org/orders-api
+  status_label_prefix: "detent:"
+  auto_provision: true
+  active_states:
+    - Todo
+    - In Progress
+    - Rework
+    - Merging
+  observed_states:
+    - Backlog
+    - Human Review
+    - Blocked
+  terminal_states:
+    - Done
+    - Cancelled
+  state_map:
+    Cancelled: Done
+  priority_map:
+    Urgent: 1
+    High: 2
+    Medium: 3
+    Low: 4
+    No priority: null
+
+# Conditional polling preserves REST budget when GitHub reports no changes.
+polling:
+  interval_ms: 60000
+  conditional: true
+
+# Source and worktree roots are separate. Every dispatched issue receives an
+# isolated checkout beneath this project-specific worktree directory.
+workspace:
+  root: /srv/detent/worktrees/orders-api
+  source_root: /srv/detent/repos/orders-api
+  cache_strategy: isolated
+  auto_branch: true
+
+deliverable:
+  merge_method: squash
+
+agent:
+  # This cap matches the larger share assigned in global.yaml. Merges stay
+  # serialized even when implementation work runs concurrently.
+  max_concurrent_agents: 3
+  max_concurrent_agents_by_state:
+    Merging: 1
+  dispatch_priority_by_state:
+    - Merging
+    - Rework
+    - In Progress
+    - Todo
+  auto_promote:
+    enabled: true
+    quiet_seconds: 600
+    optout_label: requires-human-review
+    source_state: Human Review
+    pass_state: Merging
+    rework_state: Rework
+
+codex:
+  command: codex app-server
+  approval_policy: never
+  thread_sandbox: workspace-write
+  turn_sandbox_policy:
+    type: workspaceWrite
+    networkAccess: true
+
+# The same local command gates agent completion and pull-request promotion.
+gate:
+  kind: command
+  run: make check
+  require_automated_review: true
+  ci_failure_action: rework
+
+# Loopback binding keeps the operator dashboard private unless it is
+# deliberately exposed through a trusted tunnel or reverse proxy.
+server:
+  host: 127.0.0.1
+  port: 4000
+  kanban:
+    mode: integration

--- a/docs/examples/multi-project/storefront/detent.yaml
+++ b/docs/examples/multi-project/storefront/detent.yaml
@@ -1,0 +1,81 @@
+schema: 1
+
+# Each repository owns its status labels and project policy even though both
+# projects share one Detent host.
+tracker:
+  kind: github
+  github_status_source: label
+  repository: example-org/storefront
+  status_label_prefix: "detent:"
+  auto_provision: true
+  active_states:
+    - Todo
+    - In Progress
+    - Rework
+    - Merging
+  observed_states:
+    - Backlog
+    - Human Review
+    - Blocked
+  terminal_states:
+    - Done
+    - Cancelled
+  state_map:
+    Cancelled: Done
+  priority_map:
+    Urgent: 1
+    High: 2
+    Medium: 3
+    Low: 4
+    No priority: null
+
+polling:
+  interval_ms: 60000
+  conditional: true
+
+workspace:
+  root: /srv/detent/worktrees/storefront
+  source_root: /srv/detent/repos/storefront
+  cache_strategy: isolated
+  auto_branch: true
+
+deliverable:
+  merge_method: squash
+
+agent:
+  # Two project slots complete the host's five-slot capacity budget.
+  max_concurrent_agents: 2
+  max_concurrent_agents_by_state:
+    Merging: 1
+  dispatch_priority_by_state:
+    - Merging
+    - Rework
+    - In Progress
+    - Todo
+  auto_promote:
+    enabled: true
+    quiet_seconds: 600
+    optout_label: requires-human-review
+    source_state: Human Review
+    pass_state: Merging
+    rework_state: Rework
+
+codex:
+  command: codex app-server
+  approval_policy: never
+  thread_sandbox: workspace-write
+  turn_sandbox_policy:
+    type: workspaceWrite
+    networkAccess: true
+
+gate:
+  kind: command
+  run: make check
+  require_automated_review: true
+  ci_failure_action: rework
+
+server:
+  host: 127.0.0.1
+  port: 4000
+  kanban:
+    mode: integration

--- a/onboarding_docs_test.go
+++ b/onboarding_docs_test.go
@@ -2,10 +2,12 @@ package detent
 
 import (
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
 	workflowconfig "github.com/digitaldrywood/detent/internal/config"
+	globalconfig "github.com/digitaldrywood/detent/internal/config/global"
 )
 
 func TestOnboardingDocsRequireMutationAuthorization(t *testing.T) {
@@ -571,6 +573,48 @@ func TestWorkflowTemplatesAreCurrentAndModeSpecific(t *testing.T) {
 			}
 			if !tt.wantWriteProbe && strings.TrimSpace(cfg.Tracker.WriteProbeIssue) != "" {
 				t.Fatalf("WriteProbeIssue = %q, want blank", cfg.Tracker.WriteProbeIssue)
+			}
+		})
+	}
+}
+
+func TestWorkedMultiProjectConfigsLoadAndValidate(t *testing.T) {
+	t.Parallel()
+
+	globalPath := "docs/examples/multi-project/global.yaml"
+	globalRaw, err := os.ReadFile(globalPath)
+	if err != nil {
+		t.Fatalf("ReadFile(%q) error = %v", globalPath, err)
+	}
+	repositoryRoot, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("Getwd() error = %v", err)
+	}
+	localGlobal := strings.ReplaceAll(string(globalRaw), "/srv/detent/repos/orders-api", repositoryRoot)
+	localGlobal = strings.ReplaceAll(localGlobal, "/srv/detent/repos/storefront", repositoryRoot)
+	if _, err := globalconfig.Parse([]byte(localGlobal), globalPath, globalconfig.WithMissingWorkflowFiles()); err != nil {
+		t.Fatalf("globalconfig.Parse() error = %v", err)
+	}
+
+	for _, project := range []string{"orders-api", "storefront"} {
+		project := project
+		t.Run(project, func(t *testing.T) {
+			t.Parallel()
+
+			configPath := filepath.Join("docs", "examples", "multi-project", project, "detent.yaml")
+			configRaw, err := os.ReadFile(configPath)
+			if err != nil {
+				t.Fatalf("ReadFile(%q) error = %v", configPath, err)
+			}
+			_, err = workflowconfig.ParseProjectDefinition(workflowconfig.ProjectDefinitionSources{
+				WorkflowPath: filepath.Join(filepath.Dir(configPath), "WORKFLOW.md"),
+				Workflow:     []byte("# Example workflow\n"),
+				ConfigPath:   configPath,
+				Config:       configRaw,
+				HasConfig:    true,
+			})
+			if err != nil {
+				t.Fatalf("ParseProjectDefinition() error = %v", err)
 			}
 		})
 	}


### PR DESCRIPTION
## Summary

- replace public references to the soon-private orchestration repository with a self-contained worked example
- document a sanitized multi-project host layout with two parser-validated project configurations and operator rationale
- use a neutral reference repository in the onboarding wrong-target example

Fixes #1693

## UI Surface Contract

- [x] N/A; this PR changes documentation and configuration examples only.
- [x] This PR does not add persistent top-of-screen messaging.
- [x] N/A; this PR does not change a primary operator screen.

## Test Plan

- [x] `env -u DETENT_API_TOKEN make CHECK_LOCK_WAIT=60m check`
- [x] `rg -n 'detent-orchestration' README.md docs/` returns no matches
- [x] worked-example YAML parses and validates through the production config loaders