### PR TITLE
feat(routines): bound findings per run and open findings

### DIFF
--- a/config.reference.yaml
+++ b/config.reference.yaml
@@ -1011,6 +1011,10 @@
 #     schedule: null
 #     # routines[].prompt | type: string | default: none | required: Conditional | validation: is required
 #     prompt: null
+#     # routines[].max_findings_per_run | type: integer | default: 3 when configured | required: No | validation: must be greater than 0
+#     max_findings_per_run: 3
+#     # routines[].max_open_findings | type: integer | default: 10 when configured | required: No | validation: must be greater than 0
+#     max_open_findings: 10
 # # backlog_admission | type: object | default: see child fields | required: No | validation: None
 # backlog_admission:
 #   # backlog_admission.enabled | type: boolean | default: false | required: No | validation: None

--- a/docs/config.md
+++ b/docs/config.md
@@ -553,6 +553,8 @@ rendering and fails on drift.
 | `retro.single_occurrence_severity` | `string` | `"critical" when configured` | No | must be one of info, warning, high, critical |
 | `retro.target_state` | `string` | `"Backlog" when configured` | No | must name a configured tracker state |
 | `routines` | `list<object>` | `[]` | No | None |
+| `routines[].max_findings_per_run` | `integer` | `3 when configured` | No | must be greater than 0 |
+| `routines[].max_open_findings` | `integer` | `10 when configured` | No | must be greater than 0 |
 | `routines[].name` | `string` | `none` | No | must be a sanitized label containing only letters, numbers, dots, underscores, or hyphens |
 | `routines[].prompt` | `string` | `none` | Conditional | is required |
 | `routines[].schedule` | `string` | `none` | Conditional | is required<br>must be a valid five-field cron expression |

--- a/docs/scheduled-routines.md
+++ b/docs/scheduled-routines.md
@@ -70,6 +70,8 @@ instead of built-in Go behavior.
 routines:
   - name: dependency-audit
     schedule: "0 3 * * 1"
+    max_findings_per_run: 3
+    max_open_findings: 10
     prompt: |
       Apply the dependency-audit criteria in the Maintenance section below.
       Propose only actionable upgrades with repository evidence and explicit
@@ -88,6 +90,13 @@ directly or point the agent to a named section or file in the repository.
 Invalid blocks fail workflow validation and appear as `detent doctor` workflow
 errors.
 
+`max_findings_per_run` defaults to `3` and is the hard maximum Detent will file
+from one run. `max_open_findings` defaults to `10` and stops a routine from
+filing more work when that many issues filed by the same routine remain open.
+Both values must be greater than zero. These limits are enforced after proposal
+validation and deduplication and immediately before issue creation, regardless
+of what the routine prompt asks the agent to do.
+
 When a routine is enabled or its schedule changes, its first run is the next
 scheduled occurrence; Detent does not replay missed occurrences. Each run uses
 a fresh read-only agent session. The agent proposes zero or more findings with
@@ -95,16 +104,21 @@ a stable `dedup_key`, title, and issue body. Detent validates those proposals,
 files accepted findings with the `detent:todo` label in `Todo`, and leaves
 normal onboarding to the existing board loop.
 
+Routine findings bypass Backlog and backlog admission, including admission's
+author allowlist and proposal decision step. They become dispatchable Todo work
+as soon as Detent files them.
+
 Filed issue bodies carry a project/routine/key fingerprint. A later run with the
 same fingerprint skips filing while the matching issue is open, including when
 that issue has moved to another configured board state. Closing the issue allows
 a future recurrence to file a new issue. Multiple identical proposals in one
 run are also collapsed.
 
-The runtime store records the scheduled, started, and completed times, filed
-and deduplicated counts, issue references, and any failure for every run.
-`detent doctor` shows the latest result for each configured routine, warns when
-a routine has never run, and flags three consecutive failures. ProjectV2
+The runtime store records the scheduled, started, and completed times; proposed,
+filed, deduplicated, and safety-limited counts; issue references; and any failure
+for every run. `detent doctor` shows the latest result for each configured
+routine, warns when a routine has never run, and flags three consecutive
+failures or three consecutive runs that hit a finding ceiling. ProjectV2
 trackers must set `tracker.repository` so Detent can create the repository issue
 before adding it to the board.
 

--- a/internal/cli/doctor_routine.go
+++ b/internal/cli/doctor_routine.go
@@ -13,14 +13,19 @@ import (
 const doctorRoutineFailureThreshold = 3
 
 type doctorRoutineDiagnostic struct {
-	Name                string `json:"name"`
-	Schedule            string `json:"schedule"`
-	NeverRun            bool   `json:"never_run,omitempty"`
-	LastRun             string `json:"last_run,omitempty"`
-	IssuesFiled         int    `json:"issues_filed,omitempty"`
-	IssuesDeduplicated  int    `json:"issues_deduplicated,omitempty"`
-	ConsecutiveFailures int    `json:"consecutive_failures,omitempty"`
-	LatestError         string `json:"latest_error,omitempty"`
+	Name                   string `json:"name"`
+	Schedule               string `json:"schedule"`
+	MaxFindingsPerRun      int    `json:"max_findings_per_run"`
+	MaxOpenFindings        int    `json:"max_open_findings"`
+	NeverRun               bool   `json:"never_run,omitempty"`
+	LastRun                string `json:"last_run,omitempty"`
+	IssuesProposed         int    `json:"issues_proposed,omitempty"`
+	IssuesFiled            int    `json:"issues_filed,omitempty"`
+	IssuesDeduplicated     int    `json:"issues_deduplicated,omitempty"`
+	IssuesLimited          int    `json:"issues_limited,omitempty"`
+	ConsecutiveFailures    int    `json:"consecutive_failures,omitempty"`
+	ConsecutiveLimitedRuns int    `json:"consecutive_limited_runs,omitempty"`
+	LatestError            string `json:"latest_error,omitempty"`
 }
 
 func checkDoctorRoutines(ctx context.Context, projectID string, definitions []workflowconfig.Routine, storePath string, deps doctorDeps) doctorCheck {
@@ -68,7 +73,8 @@ func doctorRoutineDiagnostics(ctx context.Context, db doctorTelemetryStore, proj
 
 func readDoctorRoutineDiagnostic(ctx context.Context, db doctorTelemetryStore, projectID string, diagnostic doctorRoutineDiagnostic) (_ doctorRoutineDiagnostic, resultErr error) {
 	rows, err := db.QueryContext(ctx, `
-SELECT completed_at, filed_count, deduplicated_count, COALESCE(error, '')
+SELECT completed_at, proposed_count, filed_count, deduplicated_count, limited_count,
+       COALESCE(error, '')
 FROM routine_runs
 WHERE project_id = ? AND routine_name = ?
 ORDER BY completed_at DESC, id DESC
@@ -80,25 +86,41 @@ LIMIT ?`, strings.TrimSpace(projectID), diagnostic.Name, doctorRoutineFailureThr
 		resultErr = errors.Join(resultErr, rows.Close())
 	}()
 	rowIndex := 0
+	failureStreak := true
+	limitedStreak := true
 	for rows.Next() {
 		var completedAt string
+		var proposed int
 		var filed int
 		var deduplicated int
+		var limited int
 		var runError string
-		if err := rows.Scan(&completedAt, &filed, &deduplicated, &runError); err != nil {
+		if err := rows.Scan(&completedAt, &proposed, &filed, &deduplicated, &limited, &runError); err != nil {
 			return diagnostic, err
 		}
 		if rowIndex == 0 {
 			diagnostic.NeverRun = false
 			diagnostic.LastRun = completedAt
+			diagnostic.IssuesProposed = proposed
 			diagnostic.IssuesFiled = filed
 			diagnostic.IssuesDeduplicated = deduplicated
+			diagnostic.IssuesLimited = limited
 			diagnostic.LatestError = strings.TrimSpace(runError)
 		}
-		if strings.TrimSpace(runError) == "" {
-			break
+		if failureStreak {
+			if strings.TrimSpace(runError) == "" {
+				failureStreak = false
+			} else {
+				diagnostic.ConsecutiveFailures++
+			}
 		}
-		diagnostic.ConsecutiveFailures++
+		if limitedStreak {
+			if limited == 0 {
+				limitedStreak = false
+			} else {
+				diagnostic.ConsecutiveLimitedRuns++
+			}
+		}
 		rowIndex++
 	}
 	return diagnostic, rows.Err()
@@ -107,7 +129,13 @@ LIMIT ?`, strings.TrimSpace(projectID), diagnostic.Name, doctorRoutineFailureThr
 func initialDoctorRoutineDiagnostics(definitions []workflowconfig.Routine) []doctorRoutineDiagnostic {
 	diagnostics := make([]doctorRoutineDiagnostic, 0, len(definitions))
 	for _, definition := range workflowconfig.NormalizeRoutines(definitions) {
-		diagnostics = append(diagnostics, doctorRoutineDiagnostic{Name: definition.Name, Schedule: definition.Schedule, NeverRun: true})
+		diagnostics = append(diagnostics, doctorRoutineDiagnostic{
+			Name:              definition.Name,
+			Schedule:          definition.Schedule,
+			MaxFindingsPerRun: definition.MaxFindingsPerRun,
+			MaxOpenFindings:   definition.MaxOpenFindings,
+			NeverRun:          true,
+		})
 	}
 	sort.Slice(diagnostics, func(i, j int) bool { return diagnostics[i].Name < diagnostics[j].Name })
 	return diagnostics
@@ -116,19 +144,23 @@ func initialDoctorRoutineDiagnostics(definitions []workflowconfig.Routine) []doc
 func doctorRoutineCheck(name string, diagnostics []doctorRoutineDiagnostic, unavailable string) doctorCheck {
 	never := []string{}
 	failing := []string{}
+	limited := []string{}
 	latest := []string{}
 	for _, diagnostic := range diagnostics {
 		if diagnostic.NeverRun {
 			never = append(never, diagnostic.Name)
 			continue
 		}
-		latestResult := fmt.Sprintf("%s at %s filed=%d deduplicated=%d", diagnostic.Name, diagnostic.LastRun, diagnostic.IssuesFiled, diagnostic.IssuesDeduplicated)
+		latestResult := fmt.Sprintf("%s at %s proposed=%d filed=%d deduplicated=%d limited=%d", diagnostic.Name, diagnostic.LastRun, diagnostic.IssuesProposed, diagnostic.IssuesFiled, diagnostic.IssuesDeduplicated, diagnostic.IssuesLimited)
 		if diagnostic.LatestError != "" {
 			latestResult += " error=" + diagnostic.LatestError
 		}
 		latest = append(latest, latestResult)
 		if diagnostic.ConsecutiveFailures >= doctorRoutineFailureThreshold {
 			failing = append(failing, fmt.Sprintf("%s (%d consecutive: %s)", diagnostic.Name, diagnostic.ConsecutiveFailures, diagnostic.LatestError))
+		}
+		if diagnostic.ConsecutiveLimitedRuns >= doctorRoutineFailureThreshold {
+			limited = append(limited, fmt.Sprintf("%s (%d consecutive runs, max_findings_per_run=%d, max_open_findings=%d)", diagnostic.Name, diagnostic.ConsecutiveLimitedRuns, diagnostic.MaxFindingsPerRun, diagnostic.MaxOpenFindings))
 		}
 	}
 	details := []string{fmt.Sprintf("%d configured routine(s)", len(diagnostics))}
@@ -141,13 +173,16 @@ func doctorRoutineCheck(name string, diagnostics []doctorRoutineDiagnostic, unav
 	if len(failing) > 0 {
 		details = append(details, "repeatedly failing: "+strings.Join(failing, ", "))
 	}
+	if len(limited) > 0 {
+		details = append(details, "repeatedly hitting finding ceilings: "+strings.Join(limited, ", "))
+	}
 	if len(latest) > 0 {
 		details = append(details, "latest: "+strings.Join(latest, "; "))
 	}
 	check := doctorCheck{Name: name, Status: doctorOK, Detail: strings.Join(details, "; "), Routines: diagnostics}
-	if len(never) > 0 || len(failing) > 0 {
+	if len(never) > 0 || len(failing) > 0 || len(limited) > 0 {
 		check.Status = doctorWarn
-		check.Hint = "Inspect the configured cron schedule and recent routine agent errors; successful runs remain visible in the routine run ledger."
+		check.Hint = "Inspect the configured cron schedule, finding ceilings, and recent routine agent errors; successful runs remain visible in the routine run ledger."
 	}
 	return check
 }

--- a/internal/cli/doctor_routine_test.go
+++ b/internal/cli/doctor_routine_test.go
@@ -27,15 +27,19 @@ CREATE TABLE routine_runs (
   project_id TEXT NOT NULL,
   routine_name TEXT NOT NULL,
   completed_at TEXT NOT NULL,
+  proposed_count INTEGER NOT NULL,
   filed_count INTEGER NOT NULL,
   deduplicated_count INTEGER NOT NULL,
+  limited_count INTEGER NOT NULL,
   error TEXT
 );
-INSERT INTO routine_runs (project_id, routine_name, completed_at, filed_count, deduplicated_count, error) VALUES
-  ('detent', 'dependencies', '2026-07-17T10:00:00Z', 2, 1, NULL),
-  ('detent', 'flaky-tests', '2026-07-17T10:03:00Z', 0, 0, 'third failure'),
-  ('detent', 'flaky-tests', '2026-07-17T10:02:00Z', 0, 0, 'second failure'),
-  ('detent', 'flaky-tests', '2026-07-17T10:01:00Z', 0, 0, 'first failure');
+INSERT INTO routine_runs (project_id, routine_name, completed_at, proposed_count, filed_count, deduplicated_count, limited_count, error) VALUES
+  ('detent', 'dependencies', '2026-07-17T10:00:00Z', 4, 2, 1, 1, NULL),
+  ('detent', 'dependencies', '2026-07-17T09:00:00Z', 4, 2, 1, 1, NULL),
+  ('detent', 'dependencies', '2026-07-17T08:00:00Z', 4, 2, 1, 1, NULL),
+  ('detent', 'flaky-tests', '2026-07-17T10:03:00Z', 0, 0, 0, 0, 'third failure'),
+  ('detent', 'flaky-tests', '2026-07-17T10:02:00Z', 0, 0, 0, 0, 'second failure'),
+  ('detent', 'flaky-tests', '2026-07-17T10:01:00Z', 0, 0, 0, 0, 'first failure');
 `); err != nil {
 		t.Fatalf("seed routine_runs error = %v", err)
 	}
@@ -52,7 +56,12 @@ INSERT INTO routine_runs (project_id, routine_name, completed_at, filed_count, d
 	if check.Status != doctorWarn {
 		t.Fatalf("Status = %q, want %q", check.Status, doctorWarn)
 	}
-	for _, want := range []string{"never run: never", "repeatedly failing: flaky-tests (3 consecutive", "dependencies at 2026-07-17T10:00:00Z filed=2 deduplicated=1"} {
+	for _, want := range []string{
+		"never run: never",
+		"repeatedly failing: flaky-tests (3 consecutive",
+		"repeatedly hitting finding ceilings: dependencies (3 consecutive runs",
+		"dependencies at 2026-07-17T10:00:00Z proposed=4 filed=2 deduplicated=1 limited=1",
+	} {
 		if !strings.Contains(check.Detail, want) {
 			t.Fatalf("Detail = %q, want %q", check.Detail, want)
 		}

--- a/internal/config/routine.go
+++ b/internal/config/routine.go
@@ -5,12 +5,51 @@ import (
 	"strings"
 
 	"github.com/robfig/cron/v3"
+	"gopkg.in/yaml.v3"
+)
+
+const (
+	DefaultRoutineMaxFindingsPerRun = 3
+	DefaultRoutineMaxOpenFindings   = 10
 )
 
 type Routine struct {
-	Name     string `yaml:"name"`
-	Schedule string `yaml:"schedule"`
-	Prompt   string `yaml:"prompt"`
+	Name                  string `yaml:"name"`
+	Schedule              string `yaml:"schedule"`
+	Prompt                string `yaml:"prompt"`
+	MaxFindingsPerRun     int    `yaml:"max_findings_per_run,omitempty"`
+	MaxOpenFindings       int    `yaml:"max_open_findings,omitempty"`
+	maxFindingsConfigured bool
+	maxOpenConfigured     bool
+}
+
+func (r *Routine) UnmarshalYAML(node *yaml.Node) error {
+	var decoded struct {
+		Name              string `yaml:"name"`
+		Schedule          string `yaml:"schedule"`
+		Prompt            string `yaml:"prompt"`
+		MaxFindingsPerRun *int   `yaml:"max_findings_per_run"`
+		MaxOpenFindings   *int   `yaml:"max_open_findings"`
+	}
+	if err := node.Decode(&decoded); err != nil {
+		return err
+	}
+	*r = Routine{
+		Name:                  decoded.Name,
+		Schedule:              decoded.Schedule,
+		Prompt:                decoded.Prompt,
+		MaxFindingsPerRun:     DefaultRoutineMaxFindingsPerRun,
+		MaxOpenFindings:       DefaultRoutineMaxOpenFindings,
+		maxFindingsConfigured: decoded.MaxFindingsPerRun != nil,
+		maxOpenConfigured:     decoded.MaxOpenFindings != nil,
+	}
+	if decoded.MaxFindingsPerRun != nil {
+		r.MaxFindingsPerRun = *decoded.MaxFindingsPerRun
+	}
+	if decoded.MaxOpenFindings != nil {
+		r.MaxOpenFindings = *decoded.MaxOpenFindings
+	}
+	return nil
 }
 
 func NormalizeRoutines(routines []Routine) []Routine {
@@ -19,6 +58,12 @@ func NormalizeRoutines(routines []Routine) []Routine {
 		routine.Name = strings.ToLower(strings.TrimSpace(routine.Name))
 		routine.Schedule = strings.TrimSpace(routine.Schedule)
 		routine.Prompt = strings.TrimSpace(routine.Prompt)
+		if routine.MaxFindingsPerRun == 0 && !routine.maxFindingsConfigured {
+			routine.MaxFindingsPerRun = DefaultRoutineMaxFindingsPerRun
+		}
+		if routine.MaxOpenFindings == 0 && !routine.maxOpenConfigured {
+			routine.MaxOpenFindings = DefaultRoutineMaxOpenFindings
+		}
 		out[index] = routine
 	}
 	return out
@@ -48,6 +93,8 @@ func ValidateRoutines(prefix string, routines []Routine) []string {
 		if routine.Prompt == "" {
 			problems = append(problems, field+".prompt is required")
 		}
+		validatePositive(field+".max_findings_per_run", routine.MaxFindingsPerRun, &problems)
+		validatePositive(field+".max_open_findings", routine.MaxOpenFindings, &problems)
 	}
 	return problems
 }

--- a/internal/config/routine_test.go
+++ b/internal/config/routine_test.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"strconv"
 	"strings"
 	"testing"
 )
@@ -13,6 +14,8 @@ tracker:
 routines:
   - name: Dependency-Audit
     schedule: "0 3 * * 1"
+    max_findings_per_run: 2
+    max_open_findings: 8
     prompt: |
       Follow the dependency criteria in WORKFLOW.md.
 ---
@@ -28,8 +31,63 @@ Prompt
 		t.Fatalf("Routines = %#v", workflow.Config.Routines)
 	}
 	routine := workflow.Config.Routines[0]
-	if routine.Name != "dependency-audit" || routine.Schedule != "0 3 * * 1" || routine.Prompt != "Follow the dependency criteria in WORKFLOW.md." {
+	if routine.Name != "dependency-audit" || routine.Schedule != "0 3 * * 1" ||
+		routine.Prompt != "Follow the dependency criteria in WORKFLOW.md." ||
+		routine.MaxFindingsPerRun != 2 || routine.MaxOpenFindings != 8 {
 		t.Fatalf("Routine = %#v", routine)
+	}
+}
+
+func TestParseWorkflowRoutineLimitDefaults(t *testing.T) {
+	t.Parallel()
+	workflow, err := ParseWorkflow([]byte(`---
+tracker:
+  kind: memory
+routines:
+  - name: audit
+    schedule: "0 * * * *"
+    prompt: Inspect.
+---
+Prompt
+`))
+	if err != nil {
+		t.Fatalf("ParseWorkflow() error = %v", err)
+	}
+	if err := workflow.Config.Validate(); err != nil {
+		t.Fatalf("Validate() error = %v", err)
+	}
+	routine := workflow.Config.Routines[0]
+	if routine.MaxFindingsPerRun != DefaultRoutineMaxFindingsPerRun || routine.MaxOpenFindings != DefaultRoutineMaxOpenFindings {
+		t.Fatalf("Routine limits = %d, %d", routine.MaxFindingsPerRun, routine.MaxOpenFindings)
+	}
+}
+
+func TestValidateRoutinesRejectsNonPositiveLimits(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name  string
+		field string
+		value int
+	}{
+		{name: "zero findings per run", field: "max_findings_per_run", value: 0},
+		{name: "negative findings per run", field: "max_findings_per_run", value: -1},
+		{name: "zero open findings", field: "max_open_findings", value: 0},
+		{name: "negative open findings", field: "max_open_findings", value: -1},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			raw := []byte("---\ntracker:\n  kind: memory\nroutines:\n  - name: audit\n    schedule: \"0 * * * *\"\n    prompt: Inspect.\n    " + tt.field + ": " + strconv.Itoa(tt.value) + "\n---\nPrompt\n")
+			workflow, err := ParseWorkflow(raw)
+			if err != nil {
+				t.Fatalf("ParseWorkflow() error = %v", err)
+			}
+			err = workflow.Config.Validate()
+			want := "routines[0]." + tt.field + " must be greater than 0"
+			if err == nil || !strings.Contains(err.Error(), want) {
+				t.Fatalf("Validate() error = %v, want %q", err, want)
+			}
+		})
 	}
 }
 

--- a/internal/connector/github/intake.go
+++ b/internal/connector/github/intake.go
@@ -63,7 +63,7 @@ func (c *Connector) CreateIntakeIssue(ctx context.Context, draft intake.IssueDra
 	}
 	if !c.usesLabelStatus() && !c.usesIssueFieldStatus() {
 		if err := c.addIntakeIssueToProject(ctx, issue.ID); err != nil {
-			return intake.Issue{}, err
+			return intakeIssue(issue), err
 		}
 	}
 	return intakeIssue(issue), nil
@@ -165,5 +165,6 @@ func intakeIssue(issue connector.Issue) intake.Issue {
 		Number:     number,
 		URL:        strings.TrimSpace(issue.URL),
 		Body:       issue.Description,
+		Closed:     issue.Closed,
 	}
 }

--- a/internal/connector/github/intake_test.go
+++ b/internal/connector/github/intake_test.go
@@ -139,6 +139,33 @@ func TestConnectorCreateIntakeIssueAddsProjectV2Item(t *testing.T) {
 	}
 }
 
+func TestConnectorCreateIntakeIssueReturnsPartialIssueWhenProjectAddFails(t *testing.T) {
+	t.Parallel()
+
+	server := newGraphQLTestServer(t, []graphqlTestResponse{
+		{
+			method: http.MethodPost,
+			path:   "/repos/example/repo/issues",
+			body:   `{"node_id":"I_2","number":2,"title":"Alert","body":"body","state":"open","html_url":"https://github.com/example/repo/issues/2"}`,
+		},
+		{
+			method: http.MethodPost,
+			path:   "/",
+			status: http.StatusInternalServerError,
+			body:   `{"message":"project unavailable"}`,
+		},
+	})
+	connector := newGitHubTestConnector(t, server, Config{Repository: "example/repo", ProjectSlug: "PVT_1"})
+
+	issue, err := connector.CreateIntakeIssue(context.Background(), intake.IssueDraft{Title: "Alert", Body: "body"})
+	if err == nil {
+		t.Fatal("CreateIntakeIssue() error = nil")
+	}
+	if issue.ID != "I_2" || issue.Number != 2 {
+		t.Fatalf("CreateIntakeIssue() issue = %#v", issue)
+	}
+}
+
 func TestConnectorSetIntakeIssueStateResolvesUncachedProjectItem(t *testing.T) {
 	t.Parallel()
 

--- a/internal/connector/memory/memory.go
+++ b/internal/connector/memory/memory.go
@@ -564,6 +564,7 @@ func memoryIntakeIssue(issue connector.Issue) intake.Issue {
 		Number:     issue.Number,
 		URL:        issue.URL,
 		Body:       issue.Description,
+		Closed:     issue.Closed,
 	}
 }
 

--- a/internal/intake/intake.go
+++ b/internal/intake/intake.go
@@ -41,6 +41,7 @@ type Issue struct {
 	Number     int    `json:"number,omitempty"`
 	URL        string `json:"url,omitempty"`
 	Body       string `json:"-"`
+	Closed     bool   `json:"-"`
 }
 
 type IssueDraft struct {

--- a/internal/project/project_test.go
+++ b/internal/project/project_test.go
@@ -1348,6 +1348,27 @@ func (s *projectRoutineStore) RecordRoutineRun(_ context.Context, record routine
 	return nil
 }
 
+func (s *projectRoutineStore) OpenRoutineIssueIDs(_ context.Context, projectID string, name string) ([]string, error) {
+	var issueIDs []string
+	for _, record := range s.records {
+		if record.ProjectID != projectID || record.RoutineName != name {
+			continue
+		}
+		for _, issue := range record.Issues {
+			issueIDs = append(issueIDs, issue.ID)
+		}
+	}
+	return issueIDs, nil
+}
+
+func (s *projectRoutineStore) RecordRoutineIssue(context.Context, string, string, routinemodel.IssueRecord) error {
+	return nil
+}
+
+func (s *projectRoutineStore) CloseRoutineIssues(context.Context, string, string, []string) error {
+	return nil
+}
+
 func (blockingRunner) Run(ctx context.Context, _ orchestrator.RunRequest) (orchestrator.RunResult, error) {
 	<-ctx.Done()
 	return orchestrator.RunResult{}, ctx.Err()

--- a/internal/routine/manager.go
+++ b/internal/routine/manager.go
@@ -45,11 +45,16 @@ var (
 
 type Store interface {
 	LatestRoutineRun(context.Context, string, string) (RunRecord, bool, error)
+	OpenRoutineIssueIDs(context.Context, string, string) ([]string, error)
+	RecordRoutineIssue(context.Context, string, string, IssueRecord) error
+	CloseRoutineIssues(context.Context, string, string, []string) error
 	RecordRoutineRun(context.Context, RunRecord) error
 }
 
 type IssueStore interface {
 	FetchIssuesByStates(context.Context, []string) ([]connector.Issue, error)
+	FetchIssueStatesByIDs(context.Context, []string) ([]connector.Issue, error)
+	FindIntakeIssue(context.Context, string) (intake.Issue, bool, error)
 	CreateIntakeIssue(context.Context, intake.IssueDraft) (intake.Issue, error)
 	SetIntakeIssueState(context.Context, string, string) error
 }
@@ -65,8 +70,10 @@ type Proposal struct {
 }
 
 type Result struct {
+	Proposed     int
 	Filed        []IssueRecord
 	Deduplicated int
+	Limited      int
 }
 
 type Settings struct {
@@ -265,8 +272,10 @@ func (m *Manager) runOnce(ctx context.Context, settings Settings, definition con
 	}
 	defer func() {
 		record.CompletedAt = m.now().UTC()
+		record.Proposed = result.Proposed
 		record.Filed = len(result.Filed)
 		record.Deduplicated = result.Deduplicated
+		record.Limited = result.Limited
 		record.Issues = append([]IssueRecord{}, result.Filed...)
 		if runErr != nil {
 			record.Error = runErr.Error()
@@ -306,17 +315,57 @@ func (m *Manager) runOnce(ctx context.Context, settings Settings, definition con
 }
 
 func (m *Manager) fileProposals(ctx context.Context, settings Settings, definition config.Routine, proposals []Proposal) (Result, error) {
+	result := Result{Proposed: len(proposals)}
 	if len(proposals) == 0 {
-		return Result{}, nil
+		return result, nil
 	}
 	issues, err := settings.Issues.FetchIssuesByStates(ctx, settings.SearchStates)
 	if err != nil {
-		return Result{}, fmt.Errorf("find open routine issues: %w", err)
+		return result, fmt.Errorf("find open routine issues: %w", err)
+	}
+	filedIssueIDs, err := m.store.OpenRoutineIssueIDs(ctx, settings.ProjectID, definition.Name)
+	if err != nil {
+		return result, fmt.Errorf("find filed routine issues: %w", err)
+	}
+	filedIssueSet := make(map[string]struct{}, len(filedIssueIDs))
+	for _, issueID := range filedIssueIDs {
+		filedIssueSet[strings.TrimSpace(issueID)] = struct{}{}
+	}
+	filedIssues, err := settings.Issues.FetchIssueStatesByIDs(ctx, filedIssueIDs)
+	if err != nil {
+		return result, fmt.Errorf("refresh filed routine issues: %w", err)
+	}
+	closedIssueIDs := make([]string, 0, len(filedIssues))
+	for _, issue := range filedIssues {
+		issueID := strings.TrimSpace(issue.ID)
+		if !issue.Closed {
+			continue
+		}
+		if _, ok := filedIssueSet[issueID]; !ok {
+			continue
+		}
+		delete(filedIssueSet, issueID)
+		closedIssueIDs = append(closedIssueIDs, issueID)
+	}
+	if err := m.store.CloseRoutineIssues(ctx, settings.ProjectID, definition.Name, closedIssueIDs); err != nil {
+		return result, fmt.Errorf("close filed routine issues: %w", err)
 	}
 	openMarkers := map[string]struct{}{}
+	openFindings := len(filedIssueSet)
+	scopeMarker := routineScopeMarker(settings.ProjectID, definition.Name)
 	for _, issue := range issues {
 		if issue.Closed {
 			continue
+		}
+		issueID := strings.TrimSpace(issue.ID)
+		_, filedByRoutine := filedIssueSet[issueID]
+		if !filedByRoutine && strings.Contains(issue.Description, scopeMarker) {
+			record := IssueRecord{ID: issueID, Identifier: issue.Identifier, URL: issue.URL}
+			if err := m.store.RecordRoutineIssue(ctx, settings.ProjectID, definition.Name, record); err != nil {
+				return result, fmt.Errorf("record existing routine issue: %w", err)
+			}
+			filedIssueSet[issueID] = struct{}{}
+			openFindings++
 		}
 		for _, proposal := range proposals {
 			marker := proposalMarker(settings.ProjectID, definition.Name, proposal.DedupKey)
@@ -326,8 +375,8 @@ func (m *Manager) fileProposals(ctx context.Context, settings Settings, definiti
 		}
 	}
 
-	result := Result{}
 	var runErr error
+	fileAttempts := 0
 	for _, proposal := range proposals {
 		proposal, err = normalizeProposal(proposal)
 		if err != nil {
@@ -339,18 +388,58 @@ func (m *Manager) fileProposals(ctx context.Context, settings Settings, definiti
 			result.Deduplicated++
 			continue
 		}
+		if fileAttempts >= definition.MaxFindingsPerRun || openFindings >= definition.MaxOpenFindings {
+			result.Limited++
+			continue
+		}
+		existing, found, findErr := settings.Issues.FindIntakeIssue(ctx, marker)
+		if findErr != nil {
+			runErr = errors.Join(runErr, fmt.Errorf("reconcile routine issue %s: %w", proposal.DedupKey, findErr))
+			break
+		}
+		if found && !existing.Closed {
+			record := IssueRecord{ID: existing.ID, Identifier: existing.Identifier, URL: existing.URL}
+			if strings.TrimSpace(record.ID) != "" {
+				if _, ok := filedIssueSet[strings.TrimSpace(record.ID)]; !ok {
+					if err := m.store.RecordRoutineIssue(ctx, settings.ProjectID, definition.Name, record); err != nil {
+						runErr = errors.Join(runErr, fmt.Errorf("record reconciled routine issue %s: %w", proposal.DedupKey, err))
+						break
+					}
+					filedIssueSet[strings.TrimSpace(record.ID)] = struct{}{}
+					openFindings++
+				}
+			} else {
+				openFindings++
+			}
+			openMarkers[marker] = struct{}{}
+			result.Deduplicated++
+			continue
+		}
+		if fileAttempts >= definition.MaxFindingsPerRun || openFindings >= definition.MaxOpenFindings {
+			result.Limited++
+			continue
+		}
+		fileAttempts++
 		issue, createErr := settings.Issues.CreateIntakeIssue(ctx, intake.IssueDraft{
 			Title:  proposal.Title,
-			Body:   marker + "\n\n" + proposal.Body,
+			Body:   scopeMarker + "\n" + marker + "\n\n" + proposal.Body,
 			Labels: []string{IssueLabel},
 		})
+		openFindings++
+		openMarkers[marker] = struct{}{}
+		record := IssueRecord{ID: issue.ID, Identifier: issue.Identifier, URL: issue.URL}
+		if strings.TrimSpace(record.ID) != "" {
+			result.Filed = append(result.Filed, record)
+			filedIssueSet[strings.TrimSpace(record.ID)] = struct{}{}
+			if err := m.store.RecordRoutineIssue(ctx, settings.ProjectID, definition.Name, record); err != nil {
+				runErr = errors.Join(runErr, fmt.Errorf("record routine issue %s: %w", proposal.DedupKey, err))
+				break
+			}
+		}
 		if createErr != nil {
 			runErr = errors.Join(runErr, fmt.Errorf("file routine issue %s: %w", proposal.DedupKey, createErr))
 			continue
 		}
-		record := IssueRecord{ID: issue.ID, Identifier: issue.Identifier, URL: issue.URL}
-		result.Filed = append(result.Filed, record)
-		openMarkers[marker] = struct{}{}
 		if stateErr := settings.Issues.SetIntakeIssueState(ctx, issue.ID, IssueState); stateErr != nil {
 			runErr = errors.Join(runErr, fmt.Errorf("set routine issue %s state: %w", proposal.DedupKey, stateErr))
 			continue
@@ -369,6 +458,18 @@ func (m *Manager) fileProposals(ctx context.Context, settings Settings, definiti
 		}); metricsErr != nil {
 			runErr = errors.Join(runErr, fmt.Errorf("record routine issue %s state provenance: %w", proposal.DedupKey, metricsErr))
 		}
+	}
+	if result.Limited > 0 {
+		m.logger.WarnContext(ctx, "routine findings dropped by safety limits",
+			"routine", definition.Name,
+			"proposed", result.Proposed,
+			"filed", len(result.Filed),
+			"deduplicated", result.Deduplicated,
+			"limited", result.Limited,
+			"max_findings_per_run", definition.MaxFindingsPerRun,
+			"max_open_findings", definition.MaxOpenFindings,
+			"open_findings", openFindings,
+		)
 	}
 	return result, runErr
 }
@@ -549,6 +650,12 @@ func proposalMarker(projectID string, routineName string, dedupKey string) strin
 	return "<!-- detent:routine fingerprint=" + hex.EncodeToString(sum[:]) + " -->"
 }
 
+func routineScopeMarker(projectID string, routineName string) string {
+	raw := strings.ToLower(strings.TrimSpace(projectID)) + "\x00" + strings.ToLower(strings.TrimSpace(routineName))
+	sum := sha256.Sum256([]byte(raw))
+	return "<!-- detent:routine scope=" + hex.EncodeToString(sum[:]) + " -->"
+}
+
 func routineIssue(projectID string, definition config.Routine) connector.Issue {
 	issue := connector.NewIssue()
 	issue.ID = "routine:" + strings.TrimSpace(projectID) + ":" + definition.Name
@@ -623,11 +730,11 @@ func (m *Manager) runAndLog(ctx context.Context, name string, scheduledFor time.
 	result, err := m.runNamed(ctx, name, scheduledFor, true)
 	if err != nil {
 		if ctx.Err() == nil {
-			m.logger.ErrorContext(ctx, "scheduled routine failed", "routine", name, "filed", len(result.Filed), "deduplicated", result.Deduplicated, "error", err)
+			m.logger.ErrorContext(ctx, "scheduled routine failed", "routine", name, "proposed", result.Proposed, "filed", len(result.Filed), "deduplicated", result.Deduplicated, "limited", result.Limited, "error", err)
 		}
 		return
 	}
-	m.logger.InfoContext(ctx, "scheduled routine completed", "routine", name, "filed", len(result.Filed), "deduplicated", result.Deduplicated)
+	m.logger.InfoContext(ctx, "scheduled routine completed", "routine", name, "proposed", result.Proposed, "filed", len(result.Filed), "deduplicated", result.Deduplicated, "limited", result.Limited)
 }
 
 func stopTimer(timer *time.Timer) {

--- a/internal/routine/manager_test.go
+++ b/internal/routine/manager_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"strings"
 	"testing"
 	"time"
@@ -270,6 +271,110 @@ func TestManagerRunOnceDeduplicatesRepeatedProposalInSameRun(t *testing.T) {
 	}
 }
 
+func TestManagerRunOnceEnforcesFindingLimits(t *testing.T) {
+	t.Parallel()
+	proposals := []Proposal{
+		{DedupKey: "finding/one", Title: "Finding one", Body: "Evidence one."},
+		{DedupKey: "finding/two", Title: "Finding two", Body: "Evidence two."},
+		{DedupKey: "finding/three", Title: "Finding three", Body: "Evidence three."},
+	}
+	tests := []struct {
+		name         string
+		maxPerRun    int
+		maxOpen      int
+		proposals    int
+		existingOpen int
+		wantFiled    int
+		wantLimited  int
+	}{
+		{name: "under per-run cap", maxPerRun: 3, maxOpen: 10, proposals: 2, wantFiled: 2},
+		{name: "exactly at per-run cap", maxPerRun: 2, maxOpen: 10, proposals: 2, wantFiled: 2},
+		{name: "over per-run cap", maxPerRun: 2, maxOpen: 10, proposals: 3, wantFiled: 2, wantLimited: 1},
+		{name: "over open-finding cap with existing issues", maxPerRun: 3, maxOpen: 2, proposals: 1, existingOpen: 2, wantLimited: 1},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			issues := &fakeIssueStore{}
+			for index := range tt.existingOpen {
+				issues.issues = append(issues.issues, connector.Issue{
+					ID: fmt.Sprintf("existing-%d", index),
+				})
+			}
+			store := &fakeStore{}
+			if tt.existingOpen > 0 {
+				record := RunRecord{ProjectID: "detent", RoutineName: "maintenance"}
+				for index := range tt.existingOpen {
+					record.Issues = append(record.Issues, IssueRecord{ID: fmt.Sprintf("existing-%d", index)})
+				}
+				store.records = append(store.records, record)
+			}
+			manager, err := New(Settings{
+				ProjectID: "detent",
+				Definitions: []config.Routine{{
+					Name: "maintenance", Schedule: "0 * * * *", Prompt: "Inspect.",
+					MaxFindingsPerRun: tt.maxPerRun, MaxOpenFindings: tt.maxOpen,
+				}},
+				SearchStates: []string{"Backlog", "Todo", "Done"},
+				Runner:       fakeRunner{proposals: proposals[:tt.proposals]},
+				Issues:       issues,
+			}, store, nil, func() time.Time { return time.Date(2026, time.July, 17, 10, 0, 0, 0, time.UTC) })
+			if err != nil {
+				t.Fatalf("New() error = %v", err)
+			}
+			result, err := manager.RunOnce(context.Background(), "maintenance")
+			if err != nil {
+				t.Fatalf("RunOnce() error = %v", err)
+			}
+			if result.Proposed != tt.proposals || len(result.Filed) != tt.wantFiled || result.Limited != tt.wantLimited {
+				t.Fatalf("Result = %#v, want proposed=%d filed=%d limited=%d", result, tt.proposals, tt.wantFiled, tt.wantLimited)
+			}
+			gotRecord := store.records[len(store.records)-1]
+			if gotRecord.Proposed != tt.proposals || gotRecord.Filed != tt.wantFiled || gotRecord.Limited != tt.wantLimited {
+				t.Fatalf("Run records = %#v", store.records)
+			}
+		})
+	}
+}
+
+func TestManagerRunOnceCountsPartialCreationsAgainstLimits(t *testing.T) {
+	t.Parallel()
+	proposals := []Proposal{
+		{DedupKey: "finding/one", Title: "Finding one", Body: "Evidence one."},
+		{DedupKey: "finding/two", Title: "Finding two", Body: "Evidence two."},
+		{DedupKey: "finding/three", Title: "Finding three", Body: "Evidence three."},
+	}
+	issues := &fakeIssueStore{createErr: errors.New("project add failed"), partialCreate: true, hideFromBoard: true}
+	store := &fakeStore{}
+	manager, err := New(Settings{
+		ProjectID: "detent",
+		Definitions: []config.Routine{{
+			Name: "maintenance", Schedule: "0 * * * *", Prompt: "Inspect.", MaxFindingsPerRun: 2, MaxOpenFindings: 2,
+		}},
+		SearchStates: []string{"Todo"},
+		Runner:       fakeRunner{proposals: proposals},
+		Issues:       issues,
+	}, store, nil, func() time.Time { return time.Date(2026, time.July, 17, 10, 0, 0, 0, time.UTC) })
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	result, err := manager.RunOnce(context.Background(), "maintenance")
+	if err == nil || !strings.Contains(err.Error(), "project add failed") {
+		t.Fatalf("RunOnce() error = %v", err)
+	}
+	if issues.createCalls != 2 || len(result.Filed) != 2 || result.Limited != 1 || len(store.trackedIssues) != 2 {
+		t.Fatalf("first result = %#v, create calls = %d, tracked = %#v", result, issues.createCalls, store.trackedIssues)
+	}
+
+	result, err = manager.RunOnce(context.Background(), "maintenance")
+	if err != nil {
+		t.Fatalf("second RunOnce() error = %v", err)
+	}
+	if issues.createCalls != 2 || len(result.Filed) != 0 || result.Limited != 3 {
+		t.Fatalf("second result = %#v, create calls = %d", result, issues.createCalls)
+	}
+}
+
 func TestManagerRunOnceRecordsFailures(t *testing.T) {
 	t.Parallel()
 	now := time.Date(2026, time.July, 17, 10, 0, 0, 0, time.UTC)
@@ -356,8 +461,10 @@ func (f fakeRunner) Run(ctx context.Context, request runner.RunRequest) (runner.
 }
 
 type fakeStore struct {
-	records   []RunRecord
-	recordErr error
+	records       []RunRecord
+	trackedIssues []IssueRecord
+	closedIssues  map[string]bool
+	recordErr     error
 }
 
 func (s *fakeStore) LatestRoutineRun(_ context.Context, projectID string, routineName string) (RunRecord, bool, error) {
@@ -374,13 +481,56 @@ func (s *fakeStore) RecordRoutineRun(_ context.Context, record RunRecord) error 
 	return s.recordErr
 }
 
+func (s *fakeStore) OpenRoutineIssueIDs(_ context.Context, projectID string, routineName string) ([]string, error) {
+	seen := map[string]struct{}{}
+	var issueIDs []string
+	for _, record := range s.records {
+		if record.ProjectID != projectID || record.RoutineName != routineName {
+			continue
+		}
+		for _, issue := range record.Issues {
+			if !s.closedIssues[issue.ID] {
+				seen[issue.ID] = struct{}{}
+			}
+		}
+	}
+	for _, issue := range s.trackedIssues {
+		if !s.closedIssues[issue.ID] {
+			seen[issue.ID] = struct{}{}
+		}
+	}
+	for issueID := range seen {
+		issueIDs = append(issueIDs, issueID)
+	}
+	return issueIDs, nil
+}
+
+func (s *fakeStore) RecordRoutineIssue(_ context.Context, _ string, _ string, issue IssueRecord) error {
+	s.trackedIssues = append(s.trackedIssues, issue)
+	return nil
+}
+
+func (s *fakeStore) CloseRoutineIssues(_ context.Context, _ string, _ string, issueIDs []string) error {
+	if s.closedIssues == nil {
+		s.closedIssues = map[string]bool{}
+	}
+	for _, issueID := range issueIDs {
+		s.closedIssues[issueID] = true
+	}
+	return nil
+}
+
 type fakeIssueStore struct {
-	issues    []connector.Issue
-	drafts    []intake.IssueDraft
-	states    []string
-	fetchErr  error
-	createErr error
-	stateErr  error
+	issues        []connector.Issue
+	drafts        []intake.IssueDraft
+	states        []string
+	fetchErr      error
+	createErr     error
+	stateErr      error
+	findErr       error
+	partialCreate bool
+	hideFromBoard bool
+	createCalls   int
 }
 
 type routineMetricsRecorder struct {
@@ -393,17 +543,48 @@ func (r *routineMetricsRecorder) RecordWorkflowPhaseEvent(_ context.Context, eve
 }
 
 func (s *fakeIssueStore) FetchIssuesByStates(context.Context, []string) ([]connector.Issue, error) {
+	if s.hideFromBoard {
+		return nil, s.fetchErr
+	}
 	return append([]connector.Issue(nil), s.issues...), s.fetchErr
 }
 
+func (s *fakeIssueStore) FetchIssueStatesByIDs(_ context.Context, issueIDs []string) ([]connector.Issue, error) {
+	wanted := map[string]struct{}{}
+	for _, issueID := range issueIDs {
+		wanted[issueID] = struct{}{}
+	}
+	var issues []connector.Issue
+	for _, issue := range s.issues {
+		if _, ok := wanted[issue.ID]; ok {
+			issues = append(issues, issue)
+		}
+	}
+	return issues, s.fetchErr
+}
+
+func (s *fakeIssueStore) FindIntakeIssue(_ context.Context, marker string) (intake.Issue, bool, error) {
+	if s.findErr != nil {
+		return intake.Issue{}, false, s.findErr
+	}
+	for _, issue := range s.issues {
+		if strings.Contains(issue.Description, marker) {
+			return intake.Issue{ID: issue.ID, Identifier: issue.Identifier, URL: issue.URL, Body: issue.Description, Closed: issue.Closed}, true, nil
+		}
+	}
+	return intake.Issue{}, false, nil
+}
+
 func (s *fakeIssueStore) CreateIntakeIssue(_ context.Context, draft intake.IssueDraft) (intake.Issue, error) {
-	if s.createErr != nil {
+	s.createCalls++
+	if s.createErr != nil && !s.partialCreate {
 		return intake.Issue{}, s.createErr
 	}
 	s.drafts = append(s.drafts, draft)
 	id := "issue-" + time.Now().Format("150405.000000000")
 	s.issues = append(s.issues, connector.Issue{ID: id, Identifier: "DET-1", Description: draft.Body, Labels: append([]string(nil), draft.Labels...)})
-	return intake.Issue{ID: id, Identifier: "DET-1", URL: "https://example.test/issues/1", Body: draft.Body}, nil
+	issue := intake.Issue{ID: id, Identifier: "DET-1", URL: "https://example.test/issues/1", Body: draft.Body}
+	return issue, s.createErr
 }
 
 func (s *fakeIssueStore) SetIntakeIssueState(_ context.Context, _ string, state string) error {

--- a/internal/routine/model/model.go
+++ b/internal/routine/model/model.go
@@ -8,8 +8,10 @@ type RunRecord struct {
 	ScheduledFor time.Time
 	StartedAt    time.Time
 	CompletedAt  time.Time
+	Proposed     int
 	Filed        int
 	Deduplicated int
+	Limited      int
 	Issues       []IssueRecord
 	Error        string
 }

--- a/internal/store/migrations/00029_add_routine_run_limits.sql
+++ b/internal/store/migrations/00029_add_routine_run_limits.sql
@@ -1,0 +1,31 @@
+-- +goose Up
+ALTER TABLE routine_runs ADD COLUMN proposed_count INTEGER NOT NULL DEFAULT 0;
+ALTER TABLE routine_runs ADD COLUMN limited_count INTEGER NOT NULL DEFAULT 0;
+
+CREATE TABLE routine_findings (
+  project_id TEXT NOT NULL,
+  routine_name TEXT NOT NULL,
+  issue_id TEXT NOT NULL,
+  identifier TEXT NOT NULL DEFAULT '',
+  url TEXT NOT NULL DEFAULT '',
+  open INTEGER NOT NULL DEFAULT 1 CHECK (open IN (0, 1)),
+  PRIMARY KEY (project_id, routine_name, issue_id)
+);
+
+CREATE INDEX routine_findings_open_idx
+ON routine_findings(project_id, routine_name, open, issue_id);
+
+INSERT OR IGNORE INTO routine_findings (project_id, routine_name, issue_id, identifier, url)
+SELECT
+  routine_runs.project_id,
+  routine_runs.routine_name,
+  trim(json_extract(issue.value, '$.id')),
+  COALESCE(trim(json_extract(issue.value, '$.identifier')), ''),
+  COALESCE(trim(json_extract(issue.value, '$.url')), '')
+FROM routine_runs, json_each(routine_runs.issues_json) AS issue
+WHERE trim(json_extract(issue.value, '$.id')) != '';
+
+-- +goose Down
+DROP TABLE IF EXISTS routine_findings;
+ALTER TABLE routine_runs DROP COLUMN limited_count;
+ALTER TABLE routine_runs DROP COLUMN proposed_count;

--- a/internal/store/routine.go
+++ b/internal/store/routine.go
@@ -14,7 +14,8 @@ import (
 func (s *sqliteStore) LatestRoutineRun(ctx context.Context, projectID string, routineName string) (routinemodel.RunRecord, bool, error) {
 	row := s.db.QueryRowContext(ctx, `
 SELECT project_id, routine_name, scheduled_for, started_at, completed_at,
-       filed_count, deduplicated_count, issues_json, COALESCE(error, '')
+       proposed_count, filed_count, deduplicated_count, limited_count,
+       issues_json, COALESCE(error, '')
 FROM routine_runs
 WHERE project_id = ? AND routine_name = ?
 ORDER BY completed_at DESC, id DESC
@@ -53,13 +54,74 @@ func (s *sqliteStore) RecordRoutineRun(ctx context.Context, record routinemodel.
 	_, err = s.db.ExecContext(ctx, `
 INSERT INTO routine_runs (
   project_id, routine_name, scheduled_for, started_at, completed_at,
-  filed_count, deduplicated_count, issues_json, error
-) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+  proposed_count, filed_count, deduplicated_count, limited_count, issues_json, error
+) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
 		strings.TrimSpace(record.ProjectID), strings.TrimSpace(record.RoutineName), scheduledFor, startedAt,
-		completedAt, nonNegative(int64(record.Filed)), nonNegative(int64(record.Deduplicated)), string(issuesJSON),
-		nullString(record.Error))
+		completedAt, nonNegative(int64(record.Proposed)), nonNegative(int64(record.Filed)),
+		nonNegative(int64(record.Deduplicated)), nonNegative(int64(record.Limited)), string(issuesJSON), nullString(record.Error))
 	if err != nil {
 		return fmt.Errorf("recording routine run: %w", err)
+	}
+	return nil
+}
+
+func (s *sqliteStore) OpenRoutineIssueIDs(ctx context.Context, projectID string, routineName string) (_ []string, resultErr error) {
+	rows, err := s.db.QueryContext(ctx, `
+SELECT issue_id
+FROM routine_findings
+WHERE project_id = ? AND routine_name = ? AND open = 1
+ORDER BY issue_id`, strings.TrimSpace(projectID), strings.TrimSpace(routineName))
+	if err != nil {
+		return nil, fmt.Errorf("reading routine issue ids: %w", err)
+	}
+	defer func() {
+		resultErr = errors.Join(resultErr, rows.Close())
+	}()
+	var issueIDs []string
+	for rows.Next() {
+		var issueID string
+		if err := rows.Scan(&issueID); err != nil {
+			return nil, err
+		}
+		issueIDs = append(issueIDs, issueID)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return issueIDs, nil
+}
+
+func (s *sqliteStore) RecordRoutineIssue(ctx context.Context, projectID string, routineName string, issue routinemodel.IssueRecord) error {
+	issueID := strings.TrimSpace(issue.ID)
+	if issueID == "" {
+		return errors.New("routine issue id is required")
+	}
+	_, err := s.db.ExecContext(ctx, `
+INSERT INTO routine_findings (project_id, routine_name, issue_id, identifier, url, open)
+VALUES (?, ?, ?, ?, ?, 1)
+ON CONFLICT(project_id, routine_name, issue_id) DO UPDATE SET
+  identifier = excluded.identifier,
+  url = excluded.url,
+  open = 1`, strings.TrimSpace(projectID), strings.TrimSpace(routineName), issueID,
+		strings.TrimSpace(issue.Identifier), strings.TrimSpace(issue.URL))
+	if err != nil {
+		return fmt.Errorf("recording routine issue: %w", err)
+	}
+	return nil
+}
+
+func (s *sqliteStore) CloseRoutineIssues(ctx context.Context, projectID string, routineName string, issueIDs []string) error {
+	for _, issueID := range issueIDs {
+		if strings.TrimSpace(issueID) == "" {
+			continue
+		}
+		if _, err := s.db.ExecContext(ctx, `
+UPDATE routine_findings
+SET open = 0
+WHERE project_id = ? AND routine_name = ? AND issue_id = ?`,
+			strings.TrimSpace(projectID), strings.TrimSpace(routineName), strings.TrimSpace(issueID)); err != nil {
+			return fmt.Errorf("closing routine issue: %w", err)
+		}
 	}
 	return nil
 }
@@ -74,7 +136,7 @@ func scanRoutineRun(scan routineRunScan) (routinemodel.RunRecord, error) {
 	var issuesJSON string
 	if err := scan(
 		&record.ProjectID, &record.RoutineName, &scheduledFor, &startedAt, &completedAt,
-		&record.Filed, &record.Deduplicated, &issuesJSON, &record.Error,
+		&record.Proposed, &record.Filed, &record.Deduplicated, &record.Limited, &issuesJSON, &record.Error,
 	); err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			return routinemodel.RunRecord{}, ErrNotFound

--- a/internal/store/routine_test.go
+++ b/internal/store/routine_test.go
@@ -15,7 +15,7 @@ func TestRoutineRunRoundTrip(t *testing.T) {
 	base := time.Date(2026, time.July, 17, 10, 0, 0, 0, time.UTC)
 	record := routinemodel.RunRecord{
 		ProjectID: "detent", RoutineName: "dependencies", ScheduledFor: base,
-		StartedAt: base.Add(time.Minute), CompletedAt: base.Add(2 * time.Minute), Filed: 1, Deduplicated: 2,
+		StartedAt: base.Add(time.Minute), CompletedAt: base.Add(2 * time.Minute), Proposed: 5, Filed: 1, Deduplicated: 2, Limited: 2,
 		Issues: []routinemodel.IssueRecord{{ID: "I_1", Identifier: "#1400", URL: "https://example.test/issues/1400"}},
 		Error:  "one proposal failed",
 	}
@@ -26,7 +26,8 @@ func TestRoutineRunRoundTrip(t *testing.T) {
 	if err != nil {
 		t.Fatalf("LatestRoutineRun() error = %v", err)
 	}
-	if !found || got.ProjectID != record.ProjectID || got.RoutineName != record.RoutineName || got.Filed != 1 || got.Deduplicated != 2 || got.Error != record.Error {
+	if !found || got.ProjectID != record.ProjectID || got.RoutineName != record.RoutineName ||
+		got.Proposed != 5 || got.Filed != 1 || got.Deduplicated != 2 || got.Limited != 2 || got.Error != record.Error {
 		t.Fatalf("LatestRoutineRun() = %#v, %t", got, found)
 	}
 	if !got.ScheduledFor.Equal(record.ScheduledFor) || !got.StartedAt.Equal(record.StartedAt) || !got.CompletedAt.Equal(record.CompletedAt) {
@@ -34,6 +35,23 @@ func TestRoutineRunRoundTrip(t *testing.T) {
 	}
 	if len(got.Issues) != 1 || got.Issues[0] != record.Issues[0] {
 		t.Fatalf("issues = %#v, want %#v", got.Issues, record.Issues)
+	}
+	if err := backend.RecordRoutineIssue(ctx, "detent", "dependencies", record.Issues[0]); err != nil {
+		t.Fatalf("RecordRoutineIssue() error = %v", err)
+	}
+	issueIDs, err := backend.OpenRoutineIssueIDs(ctx, "detent", "dependencies")
+	if err != nil {
+		t.Fatalf("OpenRoutineIssueIDs() error = %v", err)
+	}
+	if len(issueIDs) != 1 || issueIDs[0] != "I_1" {
+		t.Fatalf("OpenRoutineIssueIDs() = %#v", issueIDs)
+	}
+	if err := backend.CloseRoutineIssues(ctx, "detent", "dependencies", issueIDs); err != nil {
+		t.Fatalf("CloseRoutineIssues() error = %v", err)
+	}
+	issueIDs, err = backend.OpenRoutineIssueIDs(ctx, "detent", "dependencies")
+	if err != nil || len(issueIDs) != 0 {
+		t.Fatalf("closed OpenRoutineIssueIDs() = %#v, %v", issueIDs, err)
 	}
 	_, found, err = backend.LatestRoutineRun(ctx, "detent", "missing")
 	if err != nil || found {

--- a/internal/store/sqlc/models.go
+++ b/internal/store/sqlc/models.go
@@ -240,6 +240,15 @@ type RetroRun struct {
 	EventDay      string         `json:"event_day"`
 }
 
+type RoutineFinding struct {
+	ProjectID   string `json:"project_id"`
+	RoutineName string `json:"routine_name"`
+	IssueID     string `json:"issue_id"`
+	Identifier  string `json:"identifier"`
+	Url         string `json:"url"`
+	Open        int64  `json:"open"`
+}
+
 type RoutineRun struct {
 	ID                int64          `json:"id"`
 	ProjectID         string         `json:"project_id"`
@@ -251,6 +260,8 @@ type RoutineRun struct {
 	DeduplicatedCount int64          `json:"deduplicated_count"`
 	IssuesJson        string         `json:"issues_json"`
 	Error             sql.NullString `json:"error"`
+	ProposedCount     int64          `json:"proposed_count"`
+	LimitedCount      int64          `json:"limited_count"`
 }
 
 type SchedulerDecision struct {

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -199,6 +199,9 @@ type RetroStore interface {
 
 type RoutineStore interface {
 	LatestRoutineRun(context.Context, string, string) (routinemodel.RunRecord, bool, error)
+	OpenRoutineIssueIDs(context.Context, string, string) ([]string, error)
+	RecordRoutineIssue(context.Context, string, string, routinemodel.IssueRecord) error
+	CloseRoutineIssues(context.Context, string, string, []string) error
 	RecordRoutineRun(context.Context, routinemodel.RunRecord) error
 }
 


### PR DESCRIPTION
## Summary

- add safe per-run and open-finding limits to scheduled routine configuration
- enforce both limits after validation and deduplication, with durable open-issue attribution and run-ledger counts
- surface repeated ceiling hits in doctor diagnostics and document that routine findings bypass Backlog and admission

Fixes #1695

## UI Surface Contract

- [x] N/A, or the linked issue explicitly authorizes any high-impact UI surface, layout, density, first-viewport, or responsive visibility tradeoff.
- [x] Persistent top-of-screen messaging is explicitly authorized by the issue, or this PR does not add it.
- [x] Visual changes to primary operator screens include screenshot or browser verification below. N/A: no UI changes.

## Test Plan

- [x] `make generate`
- [x] `go test ./internal/config ./internal/routine ./internal/store`
- [x] `go test ./internal/cli -run "^TestDoctorRoutine" -count=1`
- [x] `go test ./internal/config/configdoc -count=1`
- [x] `env -u DETENT_API_TOKEN make check`