### PR TITLE
test: isolate HTTP tests from ambient auth

### DIFF
--- a/.detent/skills/ambient-auth-test-isolation.md
+++ b/.detent/skills/ambient-auth-test-isolation.md
@@ -1,0 +1,15 @@
+---
+name: ambient-auth-test-isolation
+description: Diagnose HTTP test timeouts, EOF responses, and unexpected authorization statuses caused by inherited production credentials.
+when_to_use: Use when local HTTP tests fail only inside an authenticated agent or CI environment, especially when a healthy listener appears unready or handlers receive an unexpected bearer token.
+---
+
+# Isolate HTTP tests from ambient authentication
+
+- Inspect response status and body before treating a readiness deadline as a listener failure. Record credential presence or length without printing secret values.
+- Trace client and server credential precedence, including environment overrides, configured test tokens, and default lookup functions.
+- Rerun the unchanged failing command with only the suspected credential variable blanked. Treat a pass as evidence of environment contamination, not proof that production precedence is wrong.
+- Remember that `t.Fatalf` in an HTTP handler exits that handler goroutine before it writes a response, which can surface to the client as EOF.
+- Preserve production environment defaults. Inject an empty lookup for a targeted test, or clear the ambient credential once in package `TestMain` when the package broadly assumes unauthenticated defaults.
+- Do not mutate environment variables from parallel tests. Keep a separate explicit test proving that the production environment override still wins when configured.
+- Validate with the original ambient credential present: repeat the focused test under `-race`, run the explicit authentication contract tests, repeat affected packages under `-race`, and run the repository gate.

--- a/internal/cli/boot_test.go
+++ b/internal/cli/boot_test.go
@@ -35,6 +35,13 @@ import (
 	"github.com/digitaldrywood/detent/internal/web"
 )
 
+func TestMain(m *testing.M) {
+	if err := os.Unsetenv("DETENT_API_TOKEN"); err != nil {
+		panic("clear DETENT_API_TOKEN: " + err.Error())
+	}
+	os.Exit(m.Run())
+}
+
 func TestShouldLaunchTerminalDashboard(t *testing.T) {
 	t.Parallel()
 

--- a/internal/web/server_test.go
+++ b/internal/web/server_test.go
@@ -51,6 +51,13 @@ import (
 
 const sseTestReadTimeout = 5 * time.Second
 
+func TestMain(m *testing.M) {
+	if err := os.Unsetenv("DETENT_API_TOKEN"); err != nil {
+		panic("clear DETENT_API_TOKEN: " + err.Error())
+	}
+	os.Exit(m.Run())
+}
+
 func TestNewServerValidatesDependencies(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

- clear inherited `DETENT_API_TOKEN` values before CLI and web package tests run, preventing authenticated worker environments from contaminating HTTP expectations
- preserve production authentication precedence and its explicit tests while leaving server startup and authentication code unchanged
- add a reusable skill draft for diagnosing ambient-credential timeouts, EOF responses, and authorization mismatches

The server was healthy: readiness polling received protected responses until its deadline, while the capacity handler rejected the unexpected ambient bearer token with `t.Fatalf`, which surfaced to the client as EOF.

Fixes #1698
Fixes #1696

## UI Surface Contract

- [x] N/A; this PR changes test-process isolation only.
- [x] This PR does not add persistent top-of-screen messaging.
- [x] This PR makes no visual changes to primary operator screens.

## Test Plan

- [x] `go test -race ./internal/cli -run '^(TestRunCapacityClear|TestStartRunningPublishesStartupSnapshotBeforeProjectStartCompletes)$' -count=10`
- [x] `go test -race ./internal/web -run '^(TestAPITokenAuthProtectsAPIRoutes|TestAPITokenEnvOverride)$' -count=10`
- [x] `go test -race ./internal/cli ./internal/web -count=10 -timeout=30m`
- [x] `make check`
