### PR TITLE
feat(ci): distinguish unstarted checks

### DIFF
--- a/config.reference.yaml
+++ b/config.reference.yaml
@@ -42,6 +42,8 @@
 #   github_rest_fanout_max_requests: 80
 #   # tracker.github_rest_debug_logging | type: boolean | default: false | required: No | validation: None
 #   github_rest_debug_logging: false
+#   # tracker.github_unstarted_check_threshold_seconds | type: integer | default: 900 | required: No | validation: must be greater than 0
+#   github_unstarted_check_threshold_seconds: 900
 #   # tracker.github_app_id | type: string | default: none | required: Conditional | validation: is required for github app
 #   github_app_id: null
 #   # tracker.github_app_private_key | type: string | default: none | required: Conditional | validation: or tracker.github_app_private_key_path is required for github app
@@ -247,6 +249,25 @@
 #             duration_seconds: 0
 #         # tracker.issues[].pull_request.running_checks | type: list<string> | default: [] | required: No | validation: None
 #         running_checks: []
+#         # tracker.issues[].pull_request.unstarted_checks | type: list<object> | default: [] | required: No | validation: None
+#         unstarted_checks:
+#           -
+#             # tracker.issues[].pull_request.unstarted_checks[].id | type: integer | default: 0 when configured | required: No | validation: None
+#             id: 0
+#             # tracker.issues[].pull_request.unstarted_checks[].workflow_run_id | type: integer | default: 0 when configured | required: No | validation: None
+#             workflow_run_id: 0
+#             # tracker.issues[].pull_request.unstarted_checks[].name | type: string | default: none | required: No | validation: None
+#             name: null
+#             # tracker.issues[].pull_request.unstarted_checks[].status | type: string | default: none | required: No | validation: None
+#             status: null
+#             # tracker.issues[].pull_request.unstarted_checks[].conclusion | type: string | default: none | required: No | validation: None
+#             conclusion: null
+#             # tracker.issues[].pull_request.unstarted_checks[].details_url | type: string | default: none | required: No | validation: None
+#             details_url: null
+#             # tracker.issues[].pull_request.unstarted_checks[].queue_seconds | type: integer | default: 0 when configured | required: No | validation: None
+#             queue_seconds: 0
+#             # tracker.issues[].pull_request.unstarted_checks[].duration_seconds | type: integer | default: 0 when configured | required: No | validation: None
+#             duration_seconds: 0
 #         # tracker.issues[].pull_request.stale_successful_checks | type: list<object> | default: [] | required: No | validation: None
 #         stale_successful_checks:
 #           -

--- a/docs/config.md
+++ b/docs/config.md
@@ -253,6 +253,14 @@ Warnings appear in the dashboard, `/health`, and `detent doctor`. Configure
 the affected project or item, the reason, and age and threshold values in
 seconds. A delivered warning is not sent again on every scheduler tick.
 
+## Unstarted GitHub checks
+
+`tracker.github_unstarted_check_threshold_seconds` controls when a GitHub check
+that remains queued without a `started_at` timestamp appears as unstarted. The
+15-minute default is intentionally non-zero because a cold or busy runner pool
+can legitimately take several minutes to pick up a job; setting the threshold
+too low would turn ordinary queueing into an operator-facing signal.
+
 ## Generated field reference
 
 The generated block reflects the YAML-tagged Go structs reachable from the
@@ -613,6 +621,7 @@ rendering and fails on drift.
 | `tracker.github_rest_fanout_max_requests` | `integer` | `80` | No | must be greater than or equal to 0 |
 | `tracker.github_rest_min_remaining_reserve` | `integer` | `1000` | No | must be greater than 0 |
 | `tracker.github_status_source` | `string` | `"project_v2"` | No | must be omitted when tracker.kind is github_local; Detent stores workflow status in tracker.local_sqlite |
+| `tracker.github_unstarted_check_threshold_seconds` | `integer` | `900` | No | must be greater than 0 |
 | `tracker.github_webhook_secret` | `string` | `none` | No | None |
 | `tracker.http_idle_conn_timeout_ms` | `integer` | `90000` | No | must be greater than 0 |
 | `tracker.http_max_idle_conns` | `integer` | `100` | No | must be greater than 0 |
@@ -751,6 +760,15 @@ rendering and fails on drift.
 | `tracker.issues[].pull_request.transient_failed_checks[].queue_seconds` | `integer` | `0 when configured` | No | None |
 | `tracker.issues[].pull_request.transient_failed_checks[].status` | `string` | `none` | No | None |
 | `tracker.issues[].pull_request.transient_failed_checks[].workflow_run_id` | `integer` | `0 when configured` | No | None |
+| `tracker.issues[].pull_request.unstarted_checks` | `list<object>` | `[]` | No | None |
+| `tracker.issues[].pull_request.unstarted_checks[].conclusion` | `string` | `none` | No | None |
+| `tracker.issues[].pull_request.unstarted_checks[].details_url` | `string` | `none` | No | None |
+| `tracker.issues[].pull_request.unstarted_checks[].duration_seconds` | `integer` | `0 when configured` | No | None |
+| `tracker.issues[].pull_request.unstarted_checks[].id` | `integer` | `0 when configured` | No | None |
+| `tracker.issues[].pull_request.unstarted_checks[].name` | `string` | `none` | No | None |
+| `tracker.issues[].pull_request.unstarted_checks[].queue_seconds` | `integer` | `0 when configured` | No | None |
+| `tracker.issues[].pull_request.unstarted_checks[].status` | `string` | `none` | No | None |
+| `tracker.issues[].pull_request.unstarted_checks[].workflow_run_id` | `integer` | `0 when configured` | No | None |
 | `tracker.issues[].pull_request.url` | `string` | `none` | No | None |
 | `tracker.issues[].stage_updated_at` | `mapping` | `none` | No | None |
 | `tracker.issues[].state` | `string` | `none` | No | None |

--- a/internal/cli/doctor_autopromote.go
+++ b/internal/cli/doctor_autopromote.go
@@ -773,6 +773,7 @@ func defaultDoctorAutoPromoteConnector(cfg workflowconfig.Config) (doctorAutoPro
 		HTTPIdleConnTimeoutMS:       cfg.Tracker.HTTPIdleConnTimeoutMS,
 		GitHubRESTMinReserve:        cfg.Tracker.GitHubRESTMinReserve,
 		GitHubRESTFanoutMaxRequests: cfg.Tracker.GitHubRESTFanoutMaxRequests,
+		GitHubUnstartedSeconds:      cfg.Tracker.GitHubUnstartedSeconds,
 		GitHubRESTDebugLogging:      cfg.Tracker.GitHubRESTDebugLogging,
 		GitHubAppID:                 cfg.Tracker.GitHubAppID,
 		GitHubAppPrivateKey:         cfg.Tracker.GitHubAppPrivateKey,

--- a/internal/cli/doctor_self_improvement.go
+++ b/internal/cli/doctor_self_improvement.go
@@ -503,6 +503,7 @@ func defaultDoctorProposalConnector(cfg workflowconfig.Config) (doctorWorkflowPr
 		HTTPIdleConnTimeoutMS:       cfg.Tracker.HTTPIdleConnTimeoutMS,
 		GitHubRESTMinReserve:        cfg.Tracker.GitHubRESTMinReserve,
 		GitHubRESTFanoutMaxRequests: cfg.Tracker.GitHubRESTFanoutMaxRequests,
+		GitHubUnstartedSeconds:      cfg.Tracker.GitHubUnstartedSeconds,
 		GitHubRESTDebugLogging:      cfg.Tracker.GitHubRESTDebugLogging,
 		GitHubAppID:                 cfg.Tracker.GitHubAppID,
 		GitHubAppPrivateKey:         cfg.Tracker.GitHubAppPrivateKey,

--- a/internal/cli/github_local.go
+++ b/internal/cli/github_local.go
@@ -180,6 +180,7 @@ func githubLocalConnectorFromWorkflow(ctx context.Context, cfg workflowconfig.Co
 		HTTPIdleConnTimeoutMS:       cfg.Tracker.HTTPIdleConnTimeoutMS,
 		GitHubRESTMinReserve:        cfg.Tracker.GitHubRESTMinReserve,
 		GitHubRESTFanoutMaxRequests: cfg.Tracker.GitHubRESTFanoutMaxRequests,
+		GitHubUnstartedSeconds:      cfg.Tracker.GitHubUnstartedSeconds,
 		GitHubRESTDebugLogging:      cfg.Tracker.GitHubRESTDebugLogging,
 		GitHubAppID:                 cfg.Tracker.GitHubAppID,
 		GitHubAppPrivateKey:         cfg.Tracker.GitHubAppPrivateKey,

--- a/internal/cli/work_item.go
+++ b/internal/cli/work_item.go
@@ -176,6 +176,7 @@ func workItemConnectorFromWorkflow(ctx context.Context, cfg workflowconfig.Confi
 		HTTPIdleConnTimeoutMS:       cfg.Tracker.HTTPIdleConnTimeoutMS,
 		GitHubRESTMinReserve:        cfg.Tracker.GitHubRESTMinReserve,
 		GitHubRESTFanoutMaxRequests: cfg.Tracker.GitHubRESTFanoutMaxRequests,
+		GitHubUnstartedSeconds:      cfg.Tracker.GitHubUnstartedSeconds,
 		GitHubRESTDebugLogging:      cfg.Tracker.GitHubRESTDebugLogging,
 		GitHubAppID:                 cfg.Tracker.GitHubAppID,
 		GitHubAppPrivateKey:         cfg.Tracker.GitHubAppPrivateKey,

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -86,6 +86,7 @@ const (
 	DefaultStalenessRepeatedWindowHours   = 24
 	DefaultStalenessWebhookTimeoutMS      = 5000
 	DefaultStrandedActiveThresholdSeconds = 10 * 60
+	DefaultGitHubUnstartedSeconds         = 15 * 60
 	MaxStalenessRepeatedCount             = 500
 
 	defaultCodexProtocol                      = "app-server"
@@ -170,6 +171,7 @@ type Tracker struct {
 	GitHubRESTMinReserve        int                   `yaml:"github_rest_min_remaining_reserve"`
 	GitHubRESTFanoutMaxRequests int                   `yaml:"github_rest_fanout_max_requests"`
 	GitHubRESTDebugLogging      bool                  `yaml:"github_rest_debug_logging,omitempty"`
+	GitHubUnstartedSeconds      int                   `yaml:"github_unstarted_check_threshold_seconds"`
 	GitHubAppID                 string                `yaml:"github_app_id"`
 	GitHubAppPrivateKey         string                `yaml:"github_app_private_key"`
 	GitHubAppPrivateKeyPath     string                `yaml:"github_app_private_key_path"`
@@ -1248,6 +1250,7 @@ func Default() Config {
 			GitHubGraphQLMinReserve:     1000,
 			GitHubRESTMinReserve:        1000,
 			GitHubRESTFanoutMaxRequests: 80,
+			GitHubUnstartedSeconds:      DefaultGitHubUnstartedSeconds,
 			GitHubStatusSource:          GitHubStatusSourceProjectV2,
 			StatusField:                 "Status",
 			StatusLabelPrefix:           "detent:",
@@ -1717,6 +1720,7 @@ func (c *Config) validateTracker(problems *[]string) {
 	validatePositive("tracker.github_graphql_min_remaining_reserve", c.Tracker.GitHubGraphQLMinReserve, problems)
 	validatePositive("tracker.github_rest_min_remaining_reserve", c.Tracker.GitHubRESTMinReserve, problems)
 	validateNonNegative("tracker.github_rest_fanout_max_requests", c.Tracker.GitHubRESTFanoutMaxRequests, problems)
+	validatePositive("tracker.github_unstarted_check_threshold_seconds", c.Tracker.GitHubUnstartedSeconds, problems)
 	*problems = append(*problems, c.Tracker.Claims.Validate("tracker.claims")...)
 	*problems = append(*problems, c.Tracker.Authorization.Validate("tracker.authorization")...)
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -671,6 +671,50 @@ func TestRESTFanoutMaxRequestsConfiguration(t *testing.T) {
 	}
 }
 
+func TestGitHubUnstartedCheckThresholdConfiguration(t *testing.T) {
+	t.Parallel()
+
+	intPointer := func(value int) *int { return &value }
+	tests := []struct {
+		name    string
+		value   *int
+		want    int
+		wantErr string
+	}{
+		{name: "default", want: DefaultGitHubUnstartedSeconds},
+		{name: "custom", value: intPointer(300), want: 300},
+		{name: "zero rejected", value: intPointer(0), wantErr: "tracker.github_unstarted_check_threshold_seconds must be greater than 0"},
+		{name: "negative rejected", value: intPointer(-1), wantErr: "tracker.github_unstarted_check_threshold_seconds must be greater than 0"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			raw := "---\ntracker:\n  kind: memory\n"
+			if tt.value != nil {
+				raw += "  github_unstarted_check_threshold_seconds: " + strconv.Itoa(*tt.value) + "\n"
+			}
+			raw += "---\nPrompt\n"
+			workflow, err := ParseWorkflow([]byte(raw))
+			if err == nil {
+				err = workflow.Config.Validate()
+			}
+			if tt.wantErr != "" {
+				if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
+					t.Fatalf("configuration error = %v, want %q", err, tt.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("ParseWorkflow() error = %v", err)
+			}
+			if got := workflow.Config.Tracker.GitHubUnstartedSeconds; got != tt.want {
+				t.Fatalf("GitHubUnstartedSeconds = %d, want %d", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestParseWorkflowFrontmatter(t *testing.T) {
 	t.Parallel()
 

--- a/internal/connector/factory/factory.go
+++ b/internal/connector/factory/factory.go
@@ -33,6 +33,7 @@ type Config struct {
 	GitHubRESTMinReserve        int
 	GitHubRESTFanoutMaxRequests int
 	GitHubRESTDebugLogging      bool
+	GitHubUnstartedSeconds      int
 	ConditionalRequests         *bool
 	GitHubAppID                 string
 	GitHubAppPrivateKey         string
@@ -85,6 +86,7 @@ func NewFromConfig(cfg Config) (connector.Connector, error) {
 			RESTMinRemainingReserve:    cfg.GitHubRESTMinReserve,
 			RESTFanoutMaxRequests:      cfg.GitHubRESTFanoutMaxRequests,
 			RESTDebugLogging:           cfg.GitHubRESTDebugLogging,
+			UnstartedThreshold:         time.Duration(cfg.GitHubUnstartedSeconds) * time.Second,
 			DisableConditionalRequests: conditionalRequestsDisabled(cfg.ConditionalRequests),
 			GitHubAppID:                cfg.GitHubAppID,
 			GitHubAppPrivateKey:        cfg.GitHubAppPrivateKey,
@@ -132,6 +134,7 @@ func NewFromConfig(cfg Config) (connector.Connector, error) {
 				RESTMinRemainingReserve:    cfg.GitHubRESTMinReserve,
 				RESTFanoutMaxRequests:      cfg.GitHubRESTFanoutMaxRequests,
 				RESTDebugLogging:           cfg.GitHubRESTDebugLogging,
+				UnstartedThreshold:         time.Duration(cfg.GitHubUnstartedSeconds) * time.Second,
 				DisableConditionalRequests: conditionalRequestsDisabled(cfg.ConditionalRequests),
 				GitHubAppID:                cfg.GitHubAppID,
 				GitHubAppPrivateKey:        cfg.GitHubAppPrivateKey,

--- a/internal/connector/github/adapter_test.go
+++ b/internal/connector/github/adapter_test.go
@@ -11,6 +11,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"reflect"
+	"slices"
 	"strings"
 	"sync"
 	"testing"
@@ -2313,7 +2314,7 @@ func TestConnectorFetchIssuesByStatesAttachesPipelinePullRequest(t *testing.T) {
 		{
 			method: http.MethodGet,
 			path:   "/repos/digitaldrywood/detent/commits/sha-190/check-runs?per_page=100",
-			body:   `{"check_runs":[{"name":"Verify (ubuntu-latest)","status":"completed","conclusion":"success","created_at":"2026-06-05T10:59:00Z","started_at":"2026-06-05T11:00:00Z","completed_at":"2026-06-05T11:03:00Z"},{"name":"GoReleaser Snapshot","status":"completed","conclusion":"failure","created_at":"2026-06-05T11:00:30Z","started_at":"2026-06-05T11:03:30Z","completed_at":"2026-06-05T11:11:30Z"},{"name":"Windows Core","status":"in_progress","conclusion":"","created_at":"2026-06-05T11:04:00Z","started_at":"2026-06-05T11:05:00Z","completed_at":null}]}`,
+			body:   `{"check_runs":[{"name":"Verify (ubuntu-latest)","status":"completed","conclusion":"success","created_at":"2026-06-05T10:59:00Z","started_at":"2026-06-05T11:00:00Z","completed_at":"2026-06-05T11:03:00Z"},{"name":"GoReleaser Snapshot","status":"completed","conclusion":"failure","created_at":"2026-06-05T11:00:30Z","started_at":"2026-06-05T11:03:30Z","completed_at":"2026-06-05T11:11:30Z"},{"name":"Portability Verify","status":"queued","conclusion":"","created_at":"2026-06-05T11:04:00Z","started_at":null,"completed_at":null},{"name":"Windows Core","status":"in_progress","conclusion":"","created_at":"2026-06-05T11:04:00Z","started_at":"2026-06-05T11:05:00Z","completed_at":null}]}`,
 		},
 		{
 			method: http.MethodGet,
@@ -2329,6 +2330,7 @@ func TestConnectorFetchIssuesByStatesAttachesPipelinePullRequest(t *testing.T) {
 
 	c := newGitHubTestConnector(t, server, Config{
 		ProjectSlug: "PVT_1",
+		Now:         func() time.Time { return time.Date(2026, 6, 5, 12, 0, 0, 0, time.UTC) },
 		StateMap: map[string]string{
 			"Human Review": "Reviewing",
 		},
@@ -2366,6 +2368,9 @@ func TestConnectorFetchIssuesByStatesAttachesPipelinePullRequest(t *testing.T) {
 	if len(pr.RunningChecks) != 1 || pr.RunningChecks[0] != "Windows Core" {
 		t.Fatalf("RunningChecks = %#v, want Windows Core", pr.RunningChecks)
 	}
+	if len(pr.UnstartedChecks) != 1 || pr.UnstartedChecks[0].Name != "Portability Verify" || pr.UnstartedChecks[0].QueueSeconds != 56*60 {
+		t.Fatalf("UnstartedChecks = %#v, want Portability Verify queued 56 minutes", pr.UnstartedChecks)
+	}
 	if len(pr.CodexReviewFindings) != 1 ||
 		pr.CodexReviewFindings[0].Body != "[P1] Unsafe migration." ||
 		pr.CodexReviewFindings[0].URL != "https://github.com/digitaldrywood/detent/pull/190#pullrequestreview-2" {
@@ -2386,7 +2391,7 @@ func TestCheckRunTelemetryReportsQueueAndCompletedSpan(t *testing.T) {
 	summary := checkRunTelemetry([]restCheckRun{
 		{Name: "Verify (ubuntu-latest)", Status: "completed", Conclusion: "success", CreatedAt: &created, StartedAt: &start, CompletedAt: &verifyDone},
 		{Name: "GoReleaser Snapshot", Status: "completed", Conclusion: "success", CreatedAt: &snapshotCreated, StartedAt: &snapshotStart, CompletedAt: &snapshotDone},
-	}, nil)
+	}, nil, time.Time{}, defaultUnstartedCheckThreshold)
 
 	if summary.QueueSeconds != 120 {
 		t.Fatalf("QueueSeconds = %d, want 120", summary.QueueSeconds)
@@ -2399,6 +2404,79 @@ func TestCheckRunTelemetryReportsQueueAndCompletedSpan(t *testing.T) {
 	}
 	if len(summary.RunningChecks) != 0 {
 		t.Fatalf("RunningChecks = %#v, want none", summary.RunningChecks)
+	}
+}
+
+func TestCheckRunTelemetryDistinguishesUnstartedChecks(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 8, 8, 20, 0, 0, 0, time.UTC)
+	threshold := 15 * time.Minute
+	oldQueuedAt := now.Add(-47 * time.Minute)
+	recentQueuedAt := now.Add(-5 * time.Minute)
+	oldStartedAt := now.Add(-2 * time.Hour)
+	recentStartedAt := now.Add(-time.Minute)
+	tests := []struct {
+		name          string
+		checkRuns     []restCheckRun
+		wantRunning   []string
+		wantUnstarted []connector.PullRequestCheck
+	}{
+		{
+			name: "all checks in progress",
+			checkRuns: []restCheckRun{
+				{Name: "Portability Verify", Status: "in_progress", CreatedAt: &oldQueuedAt, StartedAt: &oldStartedAt},
+				{Name: "Test", Status: "in_progress", CreatedAt: &oldQueuedAt, StartedAt: &recentStartedAt},
+			},
+			wantRunning: []string{"Portability Verify", "Test"},
+		},
+		{
+			name: "all checks queued past threshold",
+			checkRuns: []restCheckRun{
+				{ID: 1, Name: "Portability Verify", Status: "queued", CreatedAt: &oldQueuedAt},
+				{ID: 2, Name: "Test", Status: "queued", CreatedAt: &oldQueuedAt},
+			},
+			wantUnstarted: []connector.PullRequestCheck{
+				{ID: 1, Name: "Portability Verify", Status: "queued", QueueSeconds: 47 * 60},
+				{ID: 2, Name: "Test", Status: "queued", QueueSeconds: 47 * 60},
+			},
+		},
+		{
+			name:        "queued under threshold",
+			checkRuns:   []restCheckRun{{Name: "Portability Verify", Status: "queued", CreatedAt: &recentQueuedAt}},
+			wantRunning: []string{"Portability Verify"},
+		},
+		{
+			name: "mixed queued and running",
+			checkRuns: []restCheckRun{
+				{ID: 1, Name: "Portability Verify", Status: "queued", CreatedAt: &oldQueuedAt},
+				{Name: "Test", Status: "in_progress", CreatedAt: &oldQueuedAt, StartedAt: &recentStartedAt},
+			},
+			wantRunning: []string{"Test"},
+			wantUnstarted: []connector.PullRequestCheck{
+				{ID: 1, Name: "Portability Verify", Status: "queued", QueueSeconds: 47 * 60},
+			},
+		},
+		{
+			name:        "queued check that later starts",
+			checkRuns:   []restCheckRun{{Name: "Portability Verify", Status: "in_progress", CreatedAt: &oldQueuedAt, StartedAt: &recentStartedAt}},
+			wantRunning: []string{"Portability Verify"},
+		},
+		{name: "empty check run list"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			summary := checkRunTelemetry(tt.checkRuns, nil, now, threshold)
+			if !slices.Equal(summary.RunningChecks, tt.wantRunning) {
+				t.Fatalf("RunningChecks = %#v, want %#v", summary.RunningChecks, tt.wantRunning)
+			}
+			if !slices.Equal(summary.UnstartedChecks, tt.wantUnstarted) {
+				t.Fatalf("UnstartedChecks = %#v, want %#v", summary.UnstartedChecks, tt.wantUnstarted)
+			}
+		})
 	}
 }
 
@@ -2419,7 +2497,7 @@ func TestCheckRunsStateTreatsStaleSuccessfulCheckRunAsSuccess(t *testing.T) {
 	if got := checkRunsState(checkRuns); got != "success" {
 		t.Fatalf("checkRunsState() = %q, want success", got)
 	}
-	telemetry := checkRunTelemetry(checkRuns, nil)
+	telemetry := checkRunTelemetry(checkRuns, nil, time.Time{}, defaultUnstartedCheckThreshold)
 	if len(telemetry.RunningChecks) != 0 {
 		t.Fatalf("RunningChecks = %#v, want none", telemetry.RunningChecks)
 	}
@@ -2583,7 +2661,7 @@ func TestCheckRunTelemetryExcludesSupersededFailures(t *testing.T) {
 	summary := checkRunTelemetry([]restCheckRun{
 		{ID: 1, Name: "Checks", Status: "completed", Conclusion: "failure", StartedAt: &older, CompletedAt: &olderDone},
 		{ID: 2, Name: "Checks", Status: "completed", Conclusion: "success", StartedAt: &newer, CompletedAt: &newerDone},
-	}, nil)
+	}, nil, time.Time{}, defaultUnstartedCheckThreshold)
 
 	if len(summary.SlowChecks) != 1 || summary.SlowChecks[0].Conclusion != "success" {
 		t.Fatalf("SlowChecks = %#v, want only latest settled success", summary.SlowChecks)
@@ -2622,7 +2700,7 @@ func TestCheckRunTelemetryUsesWorkflowRunTimingForQueue(t *testing.T) {
 		{Name: "Verify (ubuntu-latest)", Status: "completed", Conclusion: "success", StartedAt: &checkStarted, CompletedAt: &checkCompleted},
 	}, []restWorkflowRun{
 		{ID: 28196652213, CreatedAt: &runCreated, RunStartedAt: &runStarted},
-	})
+	}, time.Time{}, defaultUnstartedCheckThreshold)
 
 	if summary.QueueSeconds != 90 {
 		t.Fatalf("QueueSeconds = %d, want 90", summary.QueueSeconds)

--- a/internal/connector/github/adapter_test.go
+++ b/internal/connector/github/adapter_test.go
@@ -2462,6 +2462,24 @@ func TestCheckRunTelemetryDistinguishesUnstartedChecks(t *testing.T) {
 			checkRuns:   []restCheckRun{{Name: "Portability Verify", Status: "in_progress", CreatedAt: &oldQueuedAt, StartedAt: &recentStartedAt}},
 			wantRunning: []string{"Portability Verify"},
 		},
+		{
+			name: "unstarted checks are sorted and limited",
+			checkRuns: []restCheckRun{
+				{ID: 6, Name: "F", Status: "queued", CreatedAt: &oldQueuedAt},
+				{ID: 1, Name: "A", Status: "queued", CreatedAt: &oldQueuedAt},
+				{ID: 5, Name: "E", Status: "queued", CreatedAt: &oldQueuedAt},
+				{ID: 2, Name: "B", Status: "queued", CreatedAt: &oldQueuedAt},
+				{ID: 4, Name: "D", Status: "queued", CreatedAt: &oldQueuedAt},
+				{ID: 3, Name: "C", Status: "queued", CreatedAt: &oldQueuedAt},
+			},
+			wantUnstarted: []connector.PullRequestCheck{
+				{ID: 1, Name: "A", Status: "queued", QueueSeconds: 47 * 60},
+				{ID: 2, Name: "B", Status: "queued", QueueSeconds: 47 * 60},
+				{ID: 3, Name: "C", Status: "queued", QueueSeconds: 47 * 60},
+				{ID: 4, Name: "D", Status: "queued", QueueSeconds: 47 * 60},
+				{ID: 5, Name: "E", Status: "queued", QueueSeconds: 47 * 60},
+			},
+		},
 		{name: "empty check run list"},
 	}
 

--- a/internal/connector/github/connector.go
+++ b/internal/connector/github/connector.go
@@ -88,6 +88,7 @@ type Config struct {
 	RESTMinRemainingReserve    int
 	RESTFanoutMaxRequests      int
 	RESTDebugLogging           bool
+	UnstartedThreshold         time.Duration
 	DisableConditionalRequests bool
 	Logger                     *slog.Logger
 	Now                        func() time.Time
@@ -108,6 +109,7 @@ type Connector struct {
 	stateMap           map[string]string
 	priorityMap        map[string]*int
 	requiredChecks     []string
+	unstartedThreshold time.Duration
 	dependencySource   string
 	dependencyCaps     map[string]nativeDependencyCapability
 	statusCache        *statusCache
@@ -119,6 +121,7 @@ type Connector struct {
 	prDiffFingerprints map[pullRequestDiffFingerprintCacheKey]string
 	triggerLabelDir    string
 	logger             *slog.Logger
+	now                func() time.Time
 	mu                 sync.RWMutex
 	writeMu            sync.Mutex
 	instanceLogin      string
@@ -169,6 +172,14 @@ func NewConnector(cfg Config) (*Connector, error) {
 	if logger == nil {
 		logger = slog.Default()
 	}
+	now := cfg.Now
+	if now == nil {
+		now = time.Now
+	}
+	unstartedThreshold := cfg.UnstartedThreshold
+	if unstartedThreshold <= 0 {
+		unstartedThreshold = defaultUnstartedCheckThreshold
+	}
 
 	client, err := NewClient(ClientConfig{
 		Endpoint:    cfg.Endpoint,
@@ -209,6 +220,7 @@ func NewConnector(cfg Config) (*Connector, error) {
 		stateMap:           cloneStateMap(cfg.StateMap),
 		priorityMap:        clonePriorityMapWithDefault(cfg.PriorityMap),
 		requiredChecks:     normalizeRequiredStatusChecks(cfg.RequiredStatusChecks),
+		unstartedThreshold: unstartedThreshold,
 		dependencySource:   normalizeDependencySource(cfg.DependencySource),
 		dependencyCaps:     map[string]nativeDependencyCapability{},
 		statusCache:        newStatusCache(githubCacheTTL, cfg.Now),
@@ -219,6 +231,7 @@ func NewConnector(cfg Config) (*Connector, error) {
 		prHydrationCursor:  map[string]string{},
 		prDiffFingerprints: map[pullRequestDiffFingerprintCacheKey]string{},
 		logger:             logger,
+		now:                now,
 	}, nil
 }
 

--- a/internal/connector/github/pull_request_checks.go
+++ b/internal/connector/github/pull_request_checks.go
@@ -17,6 +17,7 @@ type checkRunTelemetrySummary struct {
 	DurationSeconds int64
 	SlowChecks      []connector.PullRequestCheck
 	RunningChecks   []string
+	UnstartedChecks []connector.PullRequestCheck
 }
 
 type checkRunContextResult struct {
@@ -42,7 +43,11 @@ func (c *Connector) fetchPullRequestCI(ctx context.Context, repo pullRequestRepo
 	if err != nil {
 		return pullRequestCI{}, fmt.Errorf("fetch github commit statuses: %w", err)
 	}
-	telemetry := checkRunTelemetry(effectiveRuns, workflowRuns)
+	now := time.Now()
+	if c.now != nil {
+		now = c.now()
+	}
+	telemetry := checkRunTelemetry(effectiveRuns, workflowRuns, now, c.unstartedThreshold)
 	staleSuccessfulChecks := staleSuccessfulCheckRuns(checkRuns)
 	c.logStaleSuccessfulCheckRuns(ctx, repo, sha, staleSuccessfulChecks)
 	requiredFailures := requiredStatusCheckFailures(checkRuns, statuses, c.requiredChecks)
@@ -64,6 +69,7 @@ func (c *Connector) fetchPullRequestCI(ctx context.Context, repo pullRequestRepo
 		CIDurationSeconds:     telemetry.DurationSeconds,
 		SlowChecks:            telemetry.SlowChecks,
 		RunningChecks:         telemetry.RunningChecks,
+		UnstartedChecks:       telemetry.UnstartedChecks,
 		StaleSuccessfulChecks: staleSuccessfulChecks,
 		RequiredFailures:      requiredFailures,
 		TransientFailures:     transientFailures,
@@ -398,7 +404,7 @@ func requiredStatusCheckPending(status string, conclusion string) bool {
 	}
 }
 
-func checkRunTelemetry(checkRuns []restCheckRun, workflowRuns []restWorkflowRun) checkRunTelemetrySummary {
+func checkRunTelemetry(checkRuns []restCheckRun, workflowRuns []restWorkflowRun, now time.Time, unstartedThreshold time.Duration) checkRunTelemetrySummary {
 	var queueCreatedAt *time.Time
 	var queueStartedAt *time.Time
 	var checkStartedAt *time.Time
@@ -406,6 +412,7 @@ func checkRunTelemetry(checkRuns []restCheckRun, workflowRuns []restWorkflowRun)
 	hasRunning := false
 	slowChecks := make([]connector.PullRequestCheck, 0, len(checkRuns))
 	runningChecks := make([]string, 0, len(checkRuns))
+	unstartedChecks := make([]connector.PullRequestCheck, 0, len(checkRuns))
 
 	for _, run := range workflowRuns {
 		queueCreatedAt = earliestGitHubTime(queueCreatedAt, run.CreatedAt)
@@ -421,6 +428,19 @@ func checkRunTelemetry(checkRuns []restCheckRun, workflowRuns []restWorkflowRun)
 		name := strings.TrimSpace(checkRun.Name)
 		status := normalizedCheckRunStatus(checkRun)
 		conclusion := strings.ToLower(strings.TrimSpace(checkRun.Conclusion))
+		if queueSeconds, unstarted := unstartedCheckRunQueueSeconds(checkRun, now, unstartedThreshold); unstarted {
+			hasRunning = true
+			unstartedChecks = append(unstartedChecks, connector.PullRequestCheck{
+				ID:            checkRun.ID,
+				WorkflowRunID: checkRunWorkflowRunID(checkRun),
+				Name:          name,
+				Status:        status,
+				Conclusion:    conclusion,
+				DetailsURL:    firstNonBlank(checkRun.DetailsURL, checkRun.HTMLURL),
+				QueueSeconds:  queueSeconds,
+			})
+			continue
+		}
 		if (status != "" && status != "completed") || conclusion == "" {
 			hasRunning = true
 			runningChecks = append(runningChecks, name)
@@ -456,7 +476,12 @@ func checkRunTelemetry(checkRuns []restCheckRun, workflowRuns []restWorkflowRun)
 	if len(runningChecks) > pullRequestRunningCheckLimit {
 		runningChecks = runningChecks[:pullRequestRunningCheckLimit]
 	}
-
+	sort.SliceStable(unstartedChecks, func(i, j int) bool {
+		if unstartedChecks[i].QueueSeconds != unstartedChecks[j].QueueSeconds {
+			return unstartedChecks[i].QueueSeconds > unstartedChecks[j].QueueSeconds
+		}
+		return unstartedChecks[i].Name < unstartedChecks[j].Name
+	})
 	var durationSeconds int64
 	if !hasRunning && checkStartedAt != nil && completedAt != nil && !completedAt.Before(*checkStartedAt) {
 		durationSeconds = int64(completedAt.Sub(*checkStartedAt) / time.Second)
@@ -470,7 +495,19 @@ func checkRunTelemetry(checkRuns []restCheckRun, workflowRuns []restWorkflowRun)
 		DurationSeconds: durationSeconds,
 		SlowChecks:      slowChecks,
 		RunningChecks:   runningChecks,
+		UnstartedChecks: unstartedChecks,
 	}
+}
+
+func unstartedCheckRunQueueSeconds(checkRun restCheckRun, now time.Time, threshold time.Duration) (int64, bool) {
+	if threshold <= 0 || normalizedCheckRunStatus(checkRun) != "queued" || checkRun.StartedAt != nil || checkRun.CreatedAt == nil {
+		return 0, false
+	}
+	age := now.Sub(*checkRun.CreatedAt)
+	if age < threshold {
+		return 0, false
+	}
+	return int64(age / time.Second), true
 }
 
 func groupedCheckRuns(checkRuns []restCheckRun) [][]restCheckRun {

--- a/internal/connector/github/pull_request_checks.go
+++ b/internal/connector/github/pull_request_checks.go
@@ -482,6 +482,9 @@ func checkRunTelemetry(checkRuns []restCheckRun, workflowRuns []restWorkflowRun,
 		}
 		return unstartedChecks[i].Name < unstartedChecks[j].Name
 	})
+	if len(unstartedChecks) > pullRequestUnstartedCheckLimit {
+		unstartedChecks = unstartedChecks[:pullRequestUnstartedCheckLimit]
+	}
 	var durationSeconds int64
 	if !hasRunning && checkStartedAt != nil && completedAt != nil && !completedAt.Before(*checkStartedAt) {
 		durationSeconds = int64(completedAt.Sub(*checkStartedAt) / time.Second)

--- a/internal/connector/github/pull_requests.go
+++ b/internal/connector/github/pull_requests.go
@@ -819,6 +819,7 @@ func attachPullRequestToIssue(issue *connector.Issue, repo pullRequestRepo, pull
 		CIDurationSeconds:            pullRequest.CI.CIDurationSeconds,
 		SlowChecks:                   append([]connector.PullRequestCheck(nil), pullRequest.CI.SlowChecks...),
 		RunningChecks:                append([]string(nil), pullRequest.CI.RunningChecks...),
+		UnstartedChecks:              append([]connector.PullRequestCheck(nil), pullRequest.CI.UnstartedChecks...),
 		StaleSuccessfulChecks:        append([]connector.PullRequestCheck(nil), pullRequest.CI.StaleSuccessfulChecks...),
 		RequiredCheckFailures:        append([]connector.PullRequestCheck(nil), pullRequest.CI.RequiredFailures...),
 		TransientFailedChecks:        append([]connector.PullRequestCheck(nil), pullRequest.CI.TransientFailures...),

--- a/internal/connector/github/pullrequestcache.go
+++ b/internal/connector/github/pullrequestcache.go
@@ -232,6 +232,7 @@ func clonePullRequestCI(ci pullRequestCI) pullRequestCI {
 		CIDurationSeconds:     ci.CIDurationSeconds,
 		SlowChecks:            append([]connector.PullRequestCheck(nil), ci.SlowChecks...),
 		RunningChecks:         append([]string(nil), ci.RunningChecks...),
+		UnstartedChecks:       append([]connector.PullRequestCheck(nil), ci.UnstartedChecks...),
 		StaleSuccessfulChecks: append([]connector.PullRequestCheck(nil), ci.StaleSuccessfulChecks...),
 		RequiredFailures:      append([]connector.PullRequestCheck(nil), ci.RequiredFailures...),
 		TransientFailures:     append([]connector.PullRequestCheck(nil), ci.TransientFailures...),

--- a/internal/connector/github/types.go
+++ b/internal/connector/github/types.go
@@ -19,6 +19,7 @@ const (
 	pullRequestsPageLimit                     = 3
 	pullRequestSlowCheckLimit                 = 3
 	pullRequestRunningCheckLimit              = 5
+	defaultUnstartedCheckThreshold            = 15 * time.Minute
 	defaultProjectItemStatusState             = "Backlog"
 	defaultProjectItemStatusWriteParallelism  = 4
 	defaultProjectItemStatusWriteTimeout      = 2 * time.Minute
@@ -332,6 +333,7 @@ type pullRequestCI struct {
 	CIDurationSeconds     int64
 	SlowChecks            []connector.PullRequestCheck
 	RunningChecks         []string
+	UnstartedChecks       []connector.PullRequestCheck
 	StaleSuccessfulChecks []connector.PullRequestCheck
 	RequiredFailures      []connector.PullRequestCheck
 	TransientFailures     []connector.PullRequestCheck

--- a/internal/connector/github/types.go
+++ b/internal/connector/github/types.go
@@ -19,6 +19,7 @@ const (
 	pullRequestsPageLimit                     = 3
 	pullRequestSlowCheckLimit                 = 3
 	pullRequestRunningCheckLimit              = 5
+	pullRequestUnstartedCheckLimit            = 5
 	defaultUnstartedCheckThreshold            = 15 * time.Minute
 	defaultProjectItemStatusState             = "Backlog"
 	defaultProjectItemStatusWriteParallelism  = 4

--- a/internal/connector/issue.go
+++ b/internal/connector/issue.go
@@ -123,6 +123,7 @@ type PullRequest struct {
 	CIDurationSeconds            int64                       `json:"ci_duration_seconds,omitempty" yaml:"ci_duration_seconds,omitempty"`
 	SlowChecks                   []PullRequestCheck          `json:"slow_checks,omitempty" yaml:"slow_checks,omitempty"`
 	RunningChecks                []string                    `json:"running_checks,omitempty" yaml:"running_checks,omitempty"`
+	UnstartedChecks              []PullRequestCheck          `json:"unstarted_checks,omitempty" yaml:"unstarted_checks,omitempty"`
 	StaleSuccessfulChecks        []PullRequestCheck          `json:"stale_successful_checks,omitempty" yaml:"stale_successful_checks,omitempty"`
 	RequiredCheckFailures        []PullRequestCheck          `json:"required_check_failures,omitempty" yaml:"required_check_failures,omitempty"`
 	TransientFailedChecks        []PullRequestCheck          `json:"transient_failed_checks,omitempty" yaml:"transient_failed_checks,omitempty"`

--- a/internal/kanban/snapshot.go
+++ b/internal/kanban/snapshot.go
@@ -147,6 +147,7 @@ func clonePullRequest(pr *telemetry.PullRequest) *telemetry.PullRequest {
 	out.HydrationNextRetryAt = CloneTimePointer(pr.HydrationNextRetryAt)
 	out.SlowChecks = append([]telemetry.PullRequestCheck(nil), pr.SlowChecks...)
 	out.RunningChecks = append([]string(nil), pr.RunningChecks...)
+	out.UnstartedChecks = append([]telemetry.PullRequestCheck(nil), pr.UnstartedChecks...)
 	out.RequiredCheckFailures = append([]telemetry.PullRequestCheck(nil), pr.RequiredCheckFailures...)
 	return &out
 }

--- a/internal/orchestrator/autopromote_tick.go
+++ b/internal/orchestrator/autopromote_tick.go
@@ -2396,6 +2396,7 @@ func autoPromotePendingChecksFromPullRequest(pullRequest *connector.PullRequest)
 		return nil
 	}
 	checks := append([]string(nil), pullRequest.RunningChecks...)
+	checks = append(checks, pullRequestCheckNames(pullRequest.UnstartedChecks)...)
 	for _, check := range pullRequest.RequiredCheckFailures {
 		if !autoPromoteCheckPending(check) {
 			continue
@@ -2403,6 +2404,14 @@ func autoPromotePendingChecksFromPullRequest(pullRequest *connector.PullRequest)
 		checks = append(checks, check.Name)
 	}
 	return uniqueStrings(checks)
+}
+
+func pullRequestCheckNames(checks []connector.PullRequestCheck) []string {
+	names := make([]string, 0, len(checks))
+	for _, check := range checks {
+		names = append(names, check.Name)
+	}
+	return uniqueStrings(names)
 }
 
 func autoPromoteCheckPending(check connector.PullRequestCheck) bool {

--- a/internal/orchestrator/blocked_recovery.go
+++ b/internal/orchestrator/blocked_recovery.go
@@ -441,7 +441,7 @@ func reworkBreakerIssueHeld(issue connector.Issue) bool {
 }
 
 func reworkBreakerCIGreen(pr *connector.PullRequest) bool {
-	if pr == nil || len(pr.RunningChecks) > 0 || len(pr.RequiredCheckFailures) > 0 {
+	if pr == nil || len(pr.RunningChecks) > 0 || len(pr.UnstartedChecks) > 0 || len(pr.RequiredCheckFailures) > 0 {
 		return false
 	}
 	switch strings.ToLower(strings.TrimSpace(pr.CIStatus)) {

--- a/internal/orchestrator/diagnostics.go
+++ b/internal/orchestrator/diagnostics.go
@@ -372,6 +372,7 @@ func pullRequestDiagnosticAttrs(issue connector.Issue, now time.Time) []any {
 		"pr_check_run_count", pr.CheckRunCount,
 		"pr_status_context_count", pr.StatusContextCount,
 		"pr_running_check_count", len(pr.RunningChecks),
+		"pr_unstarted_check_count", len(pr.UnstartedChecks),
 		"pr_slow_check_count", len(pr.SlowChecks),
 		"pr_codex_review_state", strings.TrimSpace(pr.CodexReviewState),
 		"pr_latest_codex_review_state", strings.TrimSpace(pr.LatestCodexReviewState),

--- a/internal/orchestrator/merge_required_checks_test.go
+++ b/internal/orchestrator/merge_required_checks_test.go
@@ -167,6 +167,49 @@ func TestMergeRequiredCheckStreakClearsWhenBlocked(t *testing.T) {
 	}
 }
 
+func TestMergeWorkerCurrentHeadCIWaitReason(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		pullRequest *connector.PullRequest
+		want        string
+	}{
+		{name: "missing pull request", want: "waiting for current-head CI"},
+		{
+			name: "unstarted check takes priority",
+			pullRequest: &connector.PullRequest{
+				UnstartedChecks:       []connector.PullRequestCheck{{Name: "Portability Verify", Status: "queued"}},
+				RequiredCheckFailures: []connector.PullRequestCheck{{Name: "Portability Verify", Status: "queued"}},
+				RunningChecks:         []string{"Test"},
+			},
+			want: "waiting for current-head CI: unstarted checks: Portability Verify",
+		},
+		{
+			name: "pending required check",
+			pullRequest: &connector.PullRequest{
+				RequiredCheckFailures: []connector.PullRequestCheck{{Name: "Test", Status: "queued"}},
+			},
+			want: "waiting for current-head CI: pending required checks: Test",
+		},
+		{
+			name:        "running check",
+			pullRequest: &connector.PullRequest{RunningChecks: []string{"Test"}},
+			want:        "waiting for current-head CI: pending checks: Test",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			issue := connector.Issue{PullRequest: tt.pullRequest}
+			if got := mergeWorkerCurrentHeadCIWaitReason(issue); got != tt.want {
+				t.Fatalf("mergeWorkerCurrentHeadCIWaitReason() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
 const mergeRequiredCheckTestIssueID = "issue-persistent-missing-check"
 
 type mergeRequiredCheckEvaluationStep struct {

--- a/internal/orchestrator/run_completion.go
+++ b/internal/orchestrator/run_completion.go
@@ -1358,6 +1358,9 @@ func mergeWorkerCurrentHeadCIWaitReason(issue connector.Issue) string {
 	if issue.PullRequest == nil {
 		return reason
 	}
+	if unstartedChecks := pullRequestCheckNames(issue.PullRequest.UnstartedChecks); len(unstartedChecks) > 0 {
+		return reason + ": unstarted checks: " + strings.Join(unstartedChecks, ", ")
+	}
 	pendingRequiredChecks := make([]string, 0, len(issue.PullRequest.RequiredCheckFailures))
 	for _, check := range issue.PullRequest.RequiredCheckFailures {
 		if autoPromoteCheckPending(check) && strings.TrimSpace(check.Name) != "" {
@@ -1369,9 +1372,6 @@ func mergeWorkerCurrentHeadCIWaitReason(issue connector.Issue) string {
 	}
 	if runningChecks := uniqueStrings(issue.PullRequest.RunningChecks); len(runningChecks) > 0 {
 		return reason + ": pending checks: " + strings.Join(runningChecks, ", ")
-	}
-	if unstartedChecks := pullRequestCheckNames(issue.PullRequest.UnstartedChecks); len(unstartedChecks) > 0 {
-		return reason + ": unstarted checks: " + strings.Join(unstartedChecks, ", ")
 	}
 	return reason
 }

--- a/internal/orchestrator/run_completion.go
+++ b/internal/orchestrator/run_completion.go
@@ -1370,6 +1370,9 @@ func mergeWorkerCurrentHeadCIWaitReason(issue connector.Issue) string {
 	if runningChecks := uniqueStrings(issue.PullRequest.RunningChecks); len(runningChecks) > 0 {
 		return reason + ": pending checks: " + strings.Join(runningChecks, ", ")
 	}
+	if unstartedChecks := pullRequestCheckNames(issue.PullRequest.UnstartedChecks); len(unstartedChecks) > 0 {
+		return reason + ": unstarted checks: " + strings.Join(unstartedChecks, ", ")
+	}
 	return reason
 }
 
@@ -1486,7 +1489,7 @@ func mergeWorkerProgrammaticMergeWaiting(issue connector.Issue) bool {
 	if mergeable != "" && mergeable != "clean" && mergeable != "unknown" && mergeable != "behind" && mergeable != "blocked" {
 		return false
 	}
-	if mergeable == "blocked" && len(pullRequest.RunningChecks) == 0 {
+	if mergeable == "blocked" && len(pullRequest.RunningChecks) == 0 && len(pullRequest.UnstartedChecks) == 0 {
 		return false
 	}
 	if pullRequestRepository(issue) == "" || pullRequestNumber(issue) <= 0 || strings.TrimSpace(pullRequest.HeadSHA) == "" {

--- a/internal/orchestrator/snapshot.go
+++ b/internal/orchestrator/snapshot.go
@@ -822,6 +822,7 @@ func telemetryPullRequest(issue connector.Issue, quietDuration time.Duration, po
 		QuietWaitSeconds:           pullRequestQuietWaitSeconds(issue, quietDuration, pollInterval),
 		SlowChecks:                 telemetryPullRequestChecks(pullRequest.SlowChecks),
 		RunningChecks:              append([]string(nil), pullRequest.RunningChecks...),
+		UnstartedChecks:            telemetryPullRequestChecks(pullRequest.UnstartedChecks),
 		RequiredCheckFailures:      telemetryPullRequestChecks(pullRequest.RequiredCheckFailures),
 		CodexReviewState:           pullRequest.CodexReviewState,
 	}

--- a/internal/orchestrator/snapshot_test.go
+++ b/internal/orchestrator/snapshot_test.go
@@ -890,7 +890,10 @@ func TestStateSnapshotPopulated(t *testing.T) {
 				SlowChecks: []connector.PullRequestCheck{
 					{Name: "GoReleaser Snapshot", DurationSeconds: 247, QueueSeconds: 60},
 				},
-				RunningChecks:    []string{"Test Coverage"},
+				RunningChecks: []string{"Test Coverage"},
+				UnstartedChecks: []connector.PullRequestCheck{
+					{Name: "Portability Verify", Status: "queued", QueueSeconds: 47 * 60},
+				},
 				CodexReviewState: "P2",
 			},
 		},
@@ -992,6 +995,9 @@ func TestStateSnapshotPopulated(t *testing.T) {
 	}
 	if len(pipeline.PullRequest.RunningChecks) != 1 || pipeline.PullRequest.RunningChecks[0] != "Test Coverage" {
 		t.Fatalf("Pipeline[0].PullRequest.RunningChecks = %#v", pipeline.PullRequest.RunningChecks)
+	}
+	if len(pipeline.PullRequest.UnstartedChecks) != 1 || pipeline.PullRequest.UnstartedChecks[0].Name != "Portability Verify" || pipeline.PullRequest.UnstartedChecks[0].QueueSeconds != 47*60 {
+		t.Fatalf("Pipeline[0].PullRequest.UnstartedChecks = %#v", pipeline.PullRequest.UnstartedChecks)
 	}
 
 	if len(snapshot.Running) != 2 {

--- a/internal/orchestrator/state.go
+++ b/internal/orchestrator/state.go
@@ -561,6 +561,7 @@ func cloneIssue(issue connector.Issue) connector.Issue {
 		}
 		pullRequest.SlowChecks = append([]connector.PullRequestCheck(nil), issue.PullRequest.SlowChecks...)
 		pullRequest.RunningChecks = append([]string(nil), issue.PullRequest.RunningChecks...)
+		pullRequest.UnstartedChecks = append([]connector.PullRequestCheck(nil), issue.PullRequest.UnstartedChecks...)
 		pullRequest.StaleSuccessfulChecks = append([]connector.PullRequestCheck(nil), issue.PullRequest.StaleSuccessfulChecks...)
 		pullRequest.RequiredCheckFailures = append([]connector.PullRequestCheck(nil), issue.PullRequest.RequiredCheckFailures...)
 		pullRequest.TransientFailedChecks = append([]connector.PullRequestCheck(nil), issue.PullRequest.TransientFailedChecks...)

--- a/internal/orchestrator/tick.go
+++ b/internal/orchestrator/tick.go
@@ -777,6 +777,9 @@ func applyPullRequestHydrationBlock(target *connector.PullRequest, source connec
 	if len(target.RequiredCheckFailures) == 0 {
 		target.RequiredCheckFailures = append([]connector.PullRequestCheck(nil), source.RequiredCheckFailures...)
 	}
+	if len(target.UnstartedChecks) == 0 {
+		target.UnstartedChecks = append([]connector.PullRequestCheck(nil), source.UnstartedChecks...)
+	}
 	if len(target.StaleSuccessfulChecks) == 0 {
 		target.StaleSuccessfulChecks = append([]connector.PullRequestCheck(nil), source.StaleSuccessfulChecks...)
 	}

--- a/internal/project/project.go
+++ b/internal/project/project.go
@@ -1828,6 +1828,7 @@ func defaultConnectorFactoryWithRefresh(cfg workflowconfig.Config, refreshGitHub
 		HTTPIdleConnTimeoutMS:       cfg.Tracker.HTTPIdleConnTimeoutMS,
 		GitHubRESTMinReserve:        cfg.Tracker.GitHubRESTMinReserve,
 		GitHubRESTFanoutMaxRequests: cfg.Tracker.GitHubRESTFanoutMaxRequests,
+		GitHubUnstartedSeconds:      cfg.Tracker.GitHubUnstartedSeconds,
 		GitHubRESTDebugLogging:      cfg.Tracker.GitHubRESTDebugLogging,
 		ConditionalRequests:         &cfg.Polling.Conditional,
 		GitHubAppID:                 cfg.Tracker.GitHubAppID,

--- a/internal/telemetry/snapshot.go
+++ b/internal/telemetry/snapshot.go
@@ -512,6 +512,7 @@ type PullRequest struct {
 	QuietWaitSeconds           int64                       `json:"quiet_wait_seconds,omitempty"`
 	SlowChecks                 []PullRequestCheck          `json:"slow_checks,omitempty"`
 	RunningChecks              []string                    `json:"running_checks,omitempty"`
+	UnstartedChecks            []PullRequestCheck          `json:"unstarted_checks,omitempty"`
 	RequiredCheckFailures      []PullRequestCheck          `json:"required_check_failures,omitempty"`
 	CodexReviewState           string                      `json:"codex_review_state,omitempty"`
 	MergeQueueEntry            *PullRequestMergeQueueEntry `json:"merge_queue_entry,omitempty"`

--- a/internal/web/templates/dashboard_data.go
+++ b/internal/web/templates/dashboard_data.go
@@ -4110,6 +4110,9 @@ func prPipelineWaitDetail(issue telemetry.Issue) string {
 		if slowChecks := prPipelineSlowChecks(issue.PullRequest.SlowChecks); slowChecks != "" {
 			parts = append(parts, "slow "+slowChecks)
 		}
+		if unstartedChecks := prPipelineUnstartedChecks(issue.PullRequest.UnstartedChecks); unstartedChecks != "" && mergeDetail == "" {
+			parts = append(parts, "unstarted "+unstartedChecks)
+		}
 		if runningChecks := prPipelineRunningChecks(issue.PullRequest.RunningChecks); runningChecks != "" && mergeDetail == "" {
 			parts = append(parts, "running "+runningChecks)
 		}
@@ -4252,13 +4255,27 @@ func prPipelineMergeBlockingChecks(pullRequest *telemetry.PullRequest) string {
 	if pullRequest == nil {
 		return ""
 	}
-	checks := make([]string, 0, len(pullRequest.RequiredCheckFailures)+len(pullRequest.RunningChecks))
+	unstartedNames := make(map[string]struct{}, len(pullRequest.UnstartedChecks))
+	for _, check := range pullRequest.UnstartedChecks {
+		if name := strings.ToLower(strings.TrimSpace(check.Name)); name != "" {
+			unstartedNames[name] = struct{}{}
+		}
+	}
+	checks := make([]string, 0, len(pullRequest.UnstartedChecks)+len(pullRequest.RequiredCheckFailures)+len(pullRequest.RunningChecks))
+	if unstartedChecks := prPipelineUnstartedChecks(pullRequest.UnstartedChecks); unstartedChecks != "" {
+		checks = append(checks, unstartedChecks)
+	}
 	for _, check := range pullRequest.RequiredCheckFailures {
-		if prPipelineCheckPending(check) {
+		_, unstarted := unstartedNames[strings.ToLower(strings.TrimSpace(check.Name))]
+		if prPipelineCheckPending(check) && !unstarted {
 			checks = append(checks, check.Name)
 		}
 	}
-	checks = append(checks, pullRequest.RunningChecks...)
+	for _, check := range pullRequest.RunningChecks {
+		if _, unstarted := unstartedNames[strings.ToLower(strings.TrimSpace(check))]; !unstarted {
+			checks = append(checks, check)
+		}
+	}
 	return strings.Join(uniqueStrings(checks), ", ")
 }
 
@@ -4318,6 +4335,21 @@ func prPipelineSlowChecks(checks []telemetry.PullRequestCheck) string {
 
 func prPipelineRunningChecks(checks []string) string {
 	return strings.Join(uniqueStrings(checks), ", ")
+}
+
+func prPipelineUnstartedChecks(checks []telemetry.PullRequestCheck) string {
+	labels := make([]string, 0, len(checks))
+	for _, check := range checks {
+		name := strings.TrimSpace(check.Name)
+		if name == "" {
+			continue
+		}
+		if check.QueueSeconds > 0 {
+			name += " queued " + formatDuration(float64(check.QueueSeconds))
+		}
+		labels = append(labels, name+", never started")
+	}
+	return strings.Join(labels, "; ")
 }
 
 func uniqueStrings(values []string) []string {

--- a/internal/web/templates/dashboard_data_test.go
+++ b/internal/web/templates/dashboard_data_test.go
@@ -2687,7 +2687,10 @@ func TestPRPipelineLanesMapSnapshotRows(t *testing.T) {
 							SlowChecks: []telemetry.PullRequestCheck{
 								{Name: "GoReleaser Snapshot", DurationSeconds: 247, QueueSeconds: 60},
 							},
-							RunningChecks:    []string{"Test Coverage"},
+							RunningChecks: []string{"Test Coverage"},
+							UnstartedChecks: []telemetry.PullRequestCheck{
+								{Name: "Portability Verify", Status: "queued", QueueSeconds: 47 * 60},
+							},
 							CodexReviewState: "P2",
 						},
 					},
@@ -2737,7 +2740,7 @@ func TestPRPipelineLanesMapSnapshotRows(t *testing.T) {
 			},
 			want: []pipelineCardSnapshot{
 				{Lane: "Human Review", IssueNumber: "#142", Title: "Review lane PR", CIStatus: "pass", CodexReviewState: "clean", TimeInStage: "2h 0m", WaitDetail: "PR hydration using stale cached data until " + localTimeToken(retryAt, LocalTimeOnly)},
-				{Lane: "Merging", IssueNumber: "#143", Title: "Merge lane PR", CIStatus: "pending", CodexReviewState: "P2", TimeInStage: "15m 0s", WaitDetail: "quiet 10m 0s / queued 2m 0s / CI 8m 30s / slow GoReleaser Snapshot 4m 7s (queued 1m 0s) / running Test Coverage", MergeLaneStatus: "Queued #1", MergeLaneDetail: "1st in merge queue; waiting for repo merge lane"},
+				{Lane: "Merging", IssueNumber: "#143", Title: "Merge lane PR", CIStatus: "pending", CodexReviewState: "P2", TimeInStage: "15m 0s", WaitDetail: "quiet 10m 0s / queued 2m 0s / CI 8m 30s / slow GoReleaser Snapshot 4m 7s (queued 1m 0s) / unstarted Portability Verify queued 47m 0s, never started / running Test Coverage", MergeLaneStatus: "Queued #1", MergeLaneDetail: "1st in merge queue; waiting for repo merge lane"},
 				{Lane: "Done today", IssueNumber: "#144", Title: "Done lane PR", CIStatus: "pass", CodexReviewState: "P1", TimeInStage: "45m 0s"},
 				{Lane: "Done today", IssueNumber: "#145", Title: "Done lane unverified PR", CIStatus: "pending", CodexReviewState: "clean", TimeInStage: "45m 0s"},
 				{Lane: "Done today", IssueNumber: "#146", Title: "Cancelled today PR", CIStatus: "pass", CodexReviewState: "clean", TimeInStage: "45m 0s"},
@@ -2999,6 +3002,27 @@ func TestPRPipelineWaitDetailShowsCurrentMergeSubstate(t *testing.T) {
 				},
 			},
 			want: "waiting on current-head CI since " + localTimeToken(ciWaitStartedAt, LocalTimeOnly) + ": Test Coverage, Release",
+		},
+		{
+			name: "waiting on unstarted current-head check",
+			issue: telemetry.Issue{
+				State: "Merging",
+				PullRequest: &telemetry.PullRequest{
+					CIStatus: "pending",
+					UnstartedChecks: []telemetry.PullRequestCheck{
+						{Name: "Portability Verify", Status: "queued", QueueSeconds: 47 * 60},
+					},
+					RequiredCheckFailures: []telemetry.PullRequestCheck{
+						{Name: "Portability Verify", Status: "queued"},
+					},
+				},
+				MergeTiming: &telemetry.MergeTiming{
+					EnteredMergingAt:          &enteredAt,
+					MergeWorkerSlotAcquiredAt: &acquiredAt,
+					CIWaitStartedAt:           &ciWaitStartedAt,
+				},
+			},
+			want: "waiting on current-head CI since " + localTimeToken(ciWaitStartedAt, LocalTimeOnly) + ": Portability Verify queued 47m 0s, never started",
 		},
 		{
 			name: "active merge without a blocking check",

--- a/internal/web/workflow_metrics.go
+++ b/internal/web/workflow_metrics.go
@@ -448,7 +448,7 @@ func workflowCIBottleneck(snapshot telemetry.Snapshot) telemetry.WorkflowBottlen
 func workflowCIWaiting(pr *telemetry.PullRequest) bool {
 	status := strings.ToLower(strings.TrimSpace(pr.CIStatus))
 	if status == "" {
-		return len(pr.RunningChecks) > 0
+		return len(pr.RunningChecks) > 0 || len(pr.UnstartedChecks) > 0
 	}
 	switch status {
 	case "pending", "queued", "in_progress", "waiting", "expected":


### PR DESCRIPTION
## Summary

- preserve backward-compatible `ci_status` while exposing aged queued checks as `unstarted_checks`
- add a configurable 15-minute default threshold and propagate check names/queue ages through snapshots and dashboard wait detail
- preserve pending-CI orchestration behavior and integrate the signal with current merge-substate reporting

Fixes #1706

## UI Surface Contract

- [x] The linked issue explicitly authorizes this dashboard CI-detail change; it makes no layout, density, first-viewport, or responsive visibility tradeoff.
- [x] This PR does not add persistent top-of-screen messaging.
- [ ] Browser screenshot unavailable because the installed browser-control runtime was not callable in this worker session. The exact dashboard text path is covered by focused rendering tests.

## Test Plan

- [x] `env -u DETENT_API_TOKEN make check`
- [x] `go test ./internal/connector/github ./internal/config ./internal/connector/factory ./internal/orchestrator ./internal/kanban ./internal/web/templates`
- [x] `go test ./internal/config/configdoc`
- [x] focused post-rebase dashboard tests

## Validation Notes

- Full-gate coverage: 78.7%; all configured package and exact-file floors passed.
- `DETENT_API_TOKEN` was unset for validation so fixture credentials remain isolated; follow-up #1711 tracks making the gate do this automatically.