### PR TITLE
feat(onboarding): generate project guidance

### DIFF
--- a/docs/ONBOARDING.md
+++ b/docs/ONBOARDING.md
@@ -1182,11 +1182,50 @@ probes.
    ```
 
    Admission-enabled profiles require the named shared `WORKFLOW.md` criteria
-   section. The workflow builder emits `## Admission Criteria` with a bounded
-   baseline rubric and sets `criteria_section` to the exact heading, so the
-   generated project definition passes admission validation. The four run
-   ceilings are always written explicitly. For Custom/advanced, omit
-   `INTAKE_PROFILE` and record the underlying keys directly.
+   section. For Custom/advanced, omit `INTAKE_PROFILE` and record the
+   underlying keys directly.
+
+   Before leaving the work-intake interview, collect the project-owned prose
+   that onboarding will generate. For assisted or autonomous intake, ask the
+   operator what makes work aligned, ready, small enough for one agent run, and
+   safe to admit. Offer the repository discovery evidence as a starting point,
+   but require the operator to adapt or approve each criterion. Record each
+   answer as one sentence:
+
+   ```sh
+   printf '%s\n' \
+     'ADMISSION_ALIGNMENT_CRITERIA=<project goals, supported work, and explicit exclusions>' \
+     'ADMISSION_READINESS_CRITERIA=<required evidence and checkable completion conditions>' \
+     'ADMISSION_SIZE_CRITERIA=<largest acceptable single-agent change>' \
+     'ADMISSION_SAFETY_GATES=<dependencies, credentials, destructive actions, and project-specific safety checks>' \
+     >> "$ONBOARDING_DIR/answers.env"
+   rg '^ADMISSION_(ALIGNMENT_CRITERIA|READINESS_CRITERIA|SIZE_CRITERIA|SAFETY_GATES)=' \
+     "$ONBOARDING_DIR/answers.env"
+   ```
+
+   Ask every project, including manual-intake projects, how issue authors
+   should select reasoning effort. Calibrate the four tiers against concrete
+   repository examples and reserve `max` for explicit operator designation.
+   Record the operator-approved rubric:
+
+   ```sh
+   printf '%s\n' \
+     'EFFORT_MEDIUM_CRITERIA=<small, mechanical, tightly specified work>' \
+     'EFFORT_HIGH_CRITERIA=<standard feature or fix with ambiguity or cross-cutting impact>' \
+     'EFFORT_XHIGH_CRITERIA=<new subsystem or tricky state, concurrency, restart, recovery, or interaction work>' \
+     'EFFORT_MAX_CRITERIA=<exceptional work that only an operator may designate>' \
+     >> "$ONBOARDING_DIR/answers.env"
+   rg '^EFFORT_(MEDIUM|HIGH|XHIGH|MAX)_CRITERIA=' \
+     "$ONBOARDING_DIR/answers.env"
+   ```
+
+   The workflow builder turns the admission answers into `## Admission
+   Criteria` with `### Alignment`, `### Readiness`, `### Size`, and `### Safety
+   Gates`, and sets `criteria_section` to the exact heading. It writes no
+   admission heading or dangling `criteria_section` key when admission is off.
+   It always creates or appends the operator-approved four-tier rubric in
+   `AGENTS.md`, without replacing existing content, and leaves `model` unset.
+   The four admission run ceilings are always written explicitly.
 
 7. **Kanban interaction.** Ask this only for Custom/advanced. If the operator
    wants to override a selected profile's `KANBAN_MODE`, switch to
@@ -2096,8 +2135,8 @@ awk 'NF {last=$0} END {exit last == "MUTATION_CONFIRMED=true" ? 0 : 1}' "$ONBOAR
 
 ## Phase 4 — Author detent.yaml And WORKFLOW.md
 
-Before writing, overwriting, or editing `<source-root>/detent.yaml` or
-`<source-root>/WORKFLOW.md`, rerun:
+Before writing, overwriting, or editing `<source-root>/detent.yaml`,
+`<source-root>/WORKFLOW.md`, or `<source-root>/AGENTS.md`, rerun:
 
 ```sh
 test -f "$ONBOARDING_DIR/answers.env"
@@ -2107,8 +2146,8 @@ rg '^MUTATION_CONFIRMED=true$' "$ONBOARDING_DIR/answers.env"
 awk 'NF {last=$0} END {exit last == "MUTATION_CONFIRMED=true" ? 0 : 1}' "$ONBOARDING_DIR/answers.env"
 ```
 
-1. **Fetch the selected mode template pair.** Read both existing files first if
-   either is
+1. **Build from the selected mode template pair.** Read all three existing files
+   first if any are
    present; this runbook is for from-zero repositories, so do not overwrite a
    human-authored contract without explicit approval. The maintained templates
    are paired `docs/templates/detent.project_v2.yaml` and
@@ -2136,13 +2175,25 @@ awk 'NF {last=$0} END {exit last == "MUTATION_CONFIRMED=true" ? 0 : 1}' "$ONBOAR
      project_v2|issue_field|label) ;;
      *) printf 'invalid GITHUB_MODE: %s\n' "$GITHUB_MODE" >&2; exit 1 ;;
    esac
-   curl -fsSL "https://raw.githubusercontent.com/digitaldrywood/detent/main/docs/templates/WORKFLOW.${GITHUB_MODE}.md" \
-     -o <source-root>/WORKFLOW.md
-   curl -fsSL "https://raw.githubusercontent.com/digitaldrywood/detent/main/docs/templates/detent.${GITHUB_MODE}.yaml" \
-     -o <source-root>/detent.yaml
+   detent onboarding build-workflow \
+     --answers "$ONBOARDING_DIR/answers.env" \
+     --target-source-root <source-root> \
+     --output <source-root>/WORKFLOW.md
+   detent onboarding build-workflow \
+     --answers "$ONBOARDING_DIR/answers.env" \
+     --target-source-root <source-root> \
+     --output <source-root>/WORKFLOW.md \
+     --write
    rg -n "github_status_source: ${GITHUB_MODE}|^tracker:|^workspace:|^agent:" <source-root>/detent.yaml
    test -s <source-root>/WORKFLOW.md
+   test -s <source-root>/AGENTS.md
    ```
+
+   The preview shows all three generated artifacts. With `--write`, the builder
+   creates `detent.yaml` and `WORKFLOW.md`, creates `AGENTS.md` when absent, or
+   appends the effort section to the existing file after reading it. Do not use
+   the raw template download path for mutation because it omits the
+   operator-owned generated sections.
 
    When adding Detent to a repository that already has a `WORKFLOW.md`, audit
    the existing prompt body instead of replacing it blindly. Add or tighten the
@@ -2819,11 +2870,32 @@ awk 'NF {last=$0} END {exit last == "MUTATION_CONFIRMED=true" ? 0 : 1}' "$ONBOAR
    issue by default. Set `tracker.write_probe_issue` in label mode only for
    legacy/deep issue-object proof; after switching away from an old scratch
    issue, remove its Detent status label or close it so it stops appearing as
-   board work.
+   board work. Before doctor, verify the generated project guidance. Admission
+   must name the exact generated heading and all four subsections when enabled;
+   admission-disabled projects must not retain a dangling `criteria_section`.
+   Every project must carry the four-tier effort rubric in `AGENTS.md`.
    Verify:
 
    ```sh
-   detent doctor --allow-write-probes
+   test -s <source-root>/AGENTS.md
+   rg -n '^## Issue effort selection$|^```detent-agent$|^- `(medium|high|xhigh|max)`' \
+     <source-root>/AGENTS.md
+   if rg -q '^backlog_admission:' <source-root>/detent.yaml; then
+     CRITERIA_SECTION="$(
+       sed -n 's/^[[:space:]]*criteria_section:[[:space:]]*//p' \
+         <source-root>/detent.yaml | head -n 1 | tr -d '"'
+     )"
+     test -n "$CRITERIA_SECTION"
+     rg -Fx "## $CRITERIA_SECTION" <source-root>/WORKFLOW.md
+     rg -n '^### (Alignment|Readiness|Size|Safety Gates)$' \
+       <source-root>/WORKFLOW.md
+   else
+     ! rg -q '^[[:space:]]*criteria_section:' <source-root>/detent.yaml
+   fi
+   detent doctor --allow-write-probes \
+     | tee "$ONBOARDING_DIR/doctor-preflight.txt"
+   ! rg -q 'contain no detent-agent guidance' \
+     "$ONBOARDING_DIR/doctor-preflight.txt"
    ```
 
 5. **Verify the systemd service PATH when Detent runs as a user service.**
@@ -3394,6 +3466,8 @@ the card instead of auto-resolving it.
 | Backlog admission path | `BACKLOG_ADMISSION_SOURCE_STATE`, `BACKLOG_ADMISSION_TARGET_STATE`, and `BACKLOG_ADMISSION_CRITERIA_SECTION` map to `backlog_admission.sources.states`, `target_state`, and `criteria_section`. |
 | Backlog admission ceilings | `BACKLOG_ADMISSION_MAX_CANDIDATES_PER_RUN`, `BACKLOG_ADMISSION_MAX_PROPOSALS_PER_RUN`, `BACKLOG_ADMISSION_MAX_OPEN_PROPOSALS`, and `BACKLOG_ADMISSION_PROPOSAL_EXPIRY_DAYS` map to the same-named lower-case `backlog_admission` keys. |
 | Backlog auto-admission | `BACKLOG_ADMISSION_AUTO_ADMIT` and `BACKLOG_ADMISSION_AUTO_ADMIT_MIN_CONFIDENCE` map to `backlog_admission.auto_admit` and `auto_admit_min_confidence`; `BACKLOG_ADMISSION_AUTHORS_ALLOW_ASSOCIATION` maps to the trusted `backlog_admission.authors.allow_association` scopes. |
+| Admission criteria prose | `ADMISSION_ALIGNMENT_CRITERIA`, `ADMISSION_READINESS_CRITERIA`, `ADMISSION_SIZE_CRITERIA`, and `ADMISSION_SAFETY_GATES` generate the matching `WORKFLOW.md` subsections when admission is enabled. |
+| Issue effort rubric | `EFFORT_MEDIUM_CRITERIA`, `EFFORT_HIGH_CRITERIA`, `EFFORT_XHIGH_CRITERIA`, and `EFFORT_MAX_CRITERIA` generate the four-tier `detent-agent` rubric in `AGENTS.md`; `model` remains unset. |
 | Scheduled repository routine | `ROUTINES_ENABLED`, `ROUTINE_NAME`, `ROUTINE_SCHEDULE`, and `ROUTINE_PROMPT` control the generated `routines` entry. |
 | Built-in stale-TODO intake | `STALE_TODOS_ENABLED` and `STALE_TODOS_SCHEDULE` control the generated scheduled `intake.sources` scanner. |
 | Prompt body | The complete Markdown content of prose-only `WORKFLOW.md`. |

--- a/internal/cli/onboarding.go
+++ b/internal/cli/onboarding.go
@@ -1441,6 +1441,9 @@ func validateOnboardingAnswers(ctx context.Context, opts options, answers onboar
 
 	problems = append(problems, validateOnboardingDeliveryProfileAnswers(answers, phase, result)...)
 	problems = append(problems, validateOnboardingIntakeProfileAnswers(answers, phase, result)...)
+	if phase == onboardingAnswersPhaseMutation {
+		problems = append(problems, validateOnboardingGuidanceAnswers(answers)...)
+	}
 
 	mode := answers.Values["GITHUB_MODE"]
 	switch mode {
@@ -1453,6 +1456,22 @@ func validateOnboardingAnswers(ctx context.Context, opts options, answers onboar
 		problems = append(problems, validateOnboardingMutationAnswers(answers, mode, result)...)
 	}
 	return problems
+}
+
+func validateOnboardingGuidanceAnswers(answers onboardingAnswers) []string {
+	problems := requireOnboardingAnswers(answers, onboardingGuidanceKeys(onboardingEffortGuidanceFields())...)
+	if strings.EqualFold(strings.TrimSpace(answers.Values["BACKLOG_ADMISSION_ENABLED"]), "true") {
+		problems = append(problems, requireOnboardingAnswers(answers, onboardingGuidanceKeys(onboardingAdmissionGuidanceFields())...)...)
+	}
+	return problems
+}
+
+func onboardingGuidanceKeys(fields []onboardingGuidanceField) []string {
+	keys := make([]string, 0, len(fields))
+	for _, field := range fields {
+		keys = append(keys, field.Key)
+	}
+	return keys
 }
 
 func validateOnboardingDeliveryProfileAnswers(answers onboardingAnswers, phase string, result *onboardingAnswersValidationResult) []string {

--- a/internal/cli/onboarding_test.go
+++ b/internal/cli/onboarding_test.go
@@ -1723,6 +1723,14 @@ func validIdentityOnboardingAnswers(t *testing.T) string {
 		"REFERENCE_REPOSITORIES=digitaldrywood/detent-orchestration,corylanou/website-template",
 		"DETENT_ONBOARDING_MODE=add-project",
 		"IDENTITY_CONFIRMED=true",
+		"ADMISSION_ALIGNMENT_CRITERIA=Repairs customer-visible defects and advances documented product goals.",
+		"ADMISSION_READINESS_CRITERIA=Requires repository evidence, resolved dependencies, and checkable completion criteria.",
+		"ADMISSION_SIZE_CRITERIA=Fits implementation and validation within one agent run.",
+		"ADMISSION_SAFETY_GATES=Requires credentials and destructive actions to be explicitly authorized before admission.",
+		"EFFORT_MEDIUM_CRITERIA=Small mechanical work with exact acceptance criteria.",
+		"EFFORT_HIGH_CRITERIA=Standard features and fixes with some ambiguity or cross-cutting impact.",
+		"EFFORT_XHIGH_CRITERIA=New subsystems or tricky state, concurrency, restart, recovery, or interaction work.",
+		"EFFORT_MAX_CRITERIA=Exceptional operator-designated work that must never be selected automatically.",
 		"",
 	}, "\n")
 }

--- a/internal/cli/onboarding_workflow_builder.go
+++ b/internal/cli/onboarding_workflow_builder.go
@@ -16,6 +16,7 @@ import (
 	"gopkg.in/yaml.v3"
 
 	workflowtemplates "github.com/digitaldrywood/detent/docs/templates"
+	"github.com/digitaldrywood/detent/internal/agentoverride"
 	workflowconfig "github.com/digitaldrywood/detent/internal/config"
 	"github.com/digitaldrywood/detent/internal/gate"
 	"github.com/digitaldrywood/detent/internal/intake"
@@ -1093,7 +1094,7 @@ func readOnboardingAgentsFile(path string) (string, error) {
 }
 
 func renderOnboardingAgentGuidance(existing string, answers onboardingAnswers) (string, error) {
-	if hasOnboardingMarkdownHeading(existing, "## "+onboardingEffortRubricHeading) {
+	if hasOnboardingEffortGuidance(existing) {
 		return existing, nil
 	}
 	fields := onboardingEffortGuidanceFields()
@@ -1157,13 +1158,42 @@ func missingOnboardingGuidanceAnswers(answers onboardingAnswers, fields []onboar
 	return missing
 }
 
-func hasOnboardingMarkdownHeading(text string, heading string) bool {
-	for _, line := range strings.Split(strings.ReplaceAll(text, "\r\n", "\n"), "\n") {
-		if strings.TrimSpace(line) == heading {
-			return true
+func hasOnboardingEffortGuidance(text string) bool {
+	section, found := onboardingMarkdownSection(text, "## "+onboardingEffortRubricHeading)
+	if !found {
+		return false
+	}
+	override, found, err := agentoverride.FromIssueBody(section)
+	if err != nil || !found || override.Effort == "" || override.Model != "" {
+		return false
+	}
+	for _, field := range onboardingEffortGuidanceFields() {
+		if !strings.Contains(section, "`"+field.Heading+"`") {
+			return false
 		}
 	}
-	return false
+	return true
+}
+
+func onboardingMarkdownSection(text string, heading string) (string, bool) {
+	lines := strings.Split(strings.ReplaceAll(text, "\r\n", "\n"), "\n")
+	start := -1
+	for index, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		if start < 0 {
+			if trimmed == heading {
+				start = index + 1
+			}
+			continue
+		}
+		if strings.HasPrefix(trimmed, "# ") || strings.HasPrefix(trimmed, "## ") {
+			return strings.Join(lines[start:index], "\n"), true
+		}
+	}
+	if start < 0 {
+		return "", false
+	}
+	return strings.Join(lines[start:], "\n"), true
 }
 
 func onboardingYAMLScalarValue(node *yaml.Node, key string) string {

--- a/internal/cli/onboarding_workflow_builder.go
+++ b/internal/cli/onboarding_workflow_builder.go
@@ -27,6 +27,8 @@ const (
 	onboardingWorkflowWorkerModelPinned           = "pinned"
 	onboardingWorkflowDefaultSessionTokens        = int64(2000000)
 	onboardingWorkflowDefaultSessionOverrideLabel = "allow-large-session"
+	onboardingAdmissionCriteriaHeading            = "Admission Criteria"
+	onboardingEffortRubricHeading                 = "Issue effort selection"
 )
 
 type onboardingBuildWorkflowConfig struct {
@@ -42,11 +44,18 @@ type onboardingBuildWorkflowResult struct {
 	Preset     string                       `json:"preset"`
 	Path       string                       `json:"path"`
 	ConfigPath string                       `json:"config_path"`
+	AgentsPath string                       `json:"agents_path"`
 	Written    bool                         `json:"written"`
 	Probe      onboardingRepoProbe          `json:"probe"`
 	Decisions  []onboardingWorkflowDecision `json:"decisions"`
 	Workflow   string                       `json:"workflow"`
 	Config     string                       `json:"config"`
+	Agents     string                       `json:"agents"`
+}
+
+type onboardingGuidanceField struct {
+	Key     string
+	Heading string
 }
 
 type onboardingWorkflowDecision struct {
@@ -93,7 +102,7 @@ func newOnboardingBuildWorkflowCommand() *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:          "build-workflow",
-		Short:        "Build detent.yaml and WORKFLOW.md from onboarding answers and repository probes",
+		Short:        "Build detent.yaml, WORKFLOW.md, and AGENTS.md from onboarding answers and repository probes",
 		Example:      `detent onboarding build-workflow --answers "$ONBOARDING_DIR/answers.env" --output WORKFLOW.md --write`,
 		Args:         NoArgs,
 		SilenceUsage: true,
@@ -121,7 +130,7 @@ func newOnboardingBuildWorkflowCommand() *cobra.Command {
 	cmd.Flags().StringVar(&outputPath, "output", "WORKFLOW.md", "WORKFLOW.md anchor path; detent.yaml is written beside it")
 	cmd.Flags().StringVar(&targetSourceRoot, "target-source-root", "", "explicit target repository checkout root")
 	cmd.Flags().StringVar(&preset, "preset", "", "workflow preset: project_v2, issue_field, label, github_local, or non_code_artifact")
-	cmd.Flags().BoolVar(&write, "write", false, "write the generated detent.yaml and WORKFLOW.md")
+	cmd.Flags().BoolVar(&write, "write", false, "write the generated detent.yaml, WORKFLOW.md, and AGENTS.md")
 	return cmd
 }
 
@@ -148,6 +157,15 @@ func buildOnboardingWorkflow(ctx context.Context, cfg onboardingBuildWorkflowCon
 	}
 
 	projectConfig, workflow, decisions, err := renderOnboardingWorkflow(ctx, preset, answers, validation, probe)
+	if err != nil {
+		return onboardingBuildWorkflowResult{}, err
+	}
+	agentsPath := filepath.Join(sourceRoot, "AGENTS.md")
+	existingAgents, err := readOnboardingAgentsFile(agentsPath)
+	if err != nil {
+		return onboardingBuildWorkflowResult{}, err
+	}
+	agents, err := renderOnboardingAgentGuidance(existingAgents, answers)
 	if err != nil {
 		return onboardingBuildWorkflowResult{}, err
 	}
@@ -180,6 +198,9 @@ func buildOnboardingWorkflow(ctx context.Context, cfg onboardingBuildWorkflowCon
 		if err := os.WriteFile(projectConfigPath, []byte(projectConfig), 0o600); err != nil {
 			return onboardingBuildWorkflowResult{}, fmt.Errorf("write project config %s: %w", projectConfigPath, err)
 		}
+		if err := os.WriteFile(agentsPath, []byte(agents), 0o600); err != nil {
+			return onboardingBuildWorkflowResult{}, fmt.Errorf("write agent guidance %s: %w", agentsPath, err)
+		}
 	}
 
 	return onboardingBuildWorkflowResult{
@@ -187,11 +208,13 @@ func buildOnboardingWorkflow(ctx context.Context, cfg onboardingBuildWorkflowCon
 		Preset:     preset.Name,
 		Path:       outputPath,
 		ConfigPath: projectConfigPath,
+		AgentsPath: agentsPath,
 		Written:    cfg.Write,
 		Probe:      probe,
 		Decisions:  decisions,
 		Workflow:   workflow,
 		Config:     projectConfig,
+		Agents:     agents,
 	}, nil
 }
 
@@ -317,7 +340,10 @@ func renderOnboardingWorkflow(
 		return "", "", nil, err
 	}
 	renderedPrompt := renderOnboardingWorkflowPrompt(preset.Name, preset.PromptRaw, reviewFlow)
-	renderedPrompt = renderOnboardingWorkflowAdmissionCriteria(renderedPrompt, root)
+	renderedPrompt, err = renderOnboardingWorkflowAdmissionCriteria(renderedPrompt, root, answers)
+	if err != nil {
+		return "", "", nil, err
+	}
 
 	rawConfig, err := yaml.Marshal(root)
 	if err != nil {
@@ -737,7 +763,7 @@ func applyOnboardingWorkflowAdmissionDecisions(root *yaml.Node, answers onboardi
 	schedule, scheduleProvenance, scheduleWhy := onboardingWorkflowIntakeStringDecision(answers, profileAnswers, "BACKLOG_ADMISSION_SCHEDULE", workflowconfig.DefaultBacklogAdmissionSchedule, "preset", "bounded admission polling cadence")
 	sourceState, sourceProvenance, sourceWhy := onboardingWorkflowIntakeStringDecision(answers, profileAnswers, "BACKLOG_ADMISSION_SOURCE_STATE", "Backlog", "preset", "evaluate work waiting in Backlog")
 	targetState, targetProvenance, targetWhy := onboardingWorkflowIntakeStringDecision(answers, profileAnswers, "BACKLOG_ADMISSION_TARGET_STATE", "Todo", "preset", "admitted work becomes dispatch eligible")
-	criteriaSection, criteriaProvenance, criteriaWhy := onboardingWorkflowIntakeStringDecision(answers, profileAnswers, "BACKLOG_ADMISSION_CRITERIA_SECTION", "", "preset", "admission requires project-owned criteria")
+	criteriaSection, criteriaProvenance, criteriaWhy := onboardingWorkflowIntakeStringDecision(answers, profileAnswers, "BACKLOG_ADMISSION_CRITERIA_SECTION", onboardingAdmissionCriteriaHeading, "preset", "generated project-owned admission criteria heading")
 	if strings.TrimSpace(criteriaSection) == "" {
 		return NewValidationError(
 			"BACKLOG_ADMISSION_CRITERIA_SECTION is required when BACKLOG_ADMISSION_ENABLED=true",
@@ -1023,26 +1049,121 @@ func renderOnboardingWorkflowPrompt(preset string, prompt []byte, flow onboardin
 	return replaceOnboardingWorkflowSection(text, "## Required Execution Flow", section)
 }
 
-func renderOnboardingWorkflowAdmissionCriteria(prompt string, root *yaml.Node) string {
+func renderOnboardingWorkflowAdmissionCriteria(prompt string, root *yaml.Node, answers onboardingAnswers) (string, error) {
 	admission := onboardingYAMLMappingValue(root, "backlog_admission")
 	if admission == nil || strings.TrimSpace(onboardingYAMLScalarValue(admission, "enabled")) != "true" {
-		return prompt
+		return prompt, nil
 	}
 	section := strings.TrimSpace(onboardingYAMLScalarValue(admission, "criteria_section"))
 	if section == "" {
-		return prompt
+		return prompt, nil
 	}
 	if _, err := workflowconfig.ResolveAdmissionCriteria(prompt, section); err == nil || !strings.Contains(err.Error(), "was not found") {
-		return prompt
+		return prompt, nil
 	}
-	return strings.TrimRight(prompt, "\n") + "\n\n" + markdownLines(
-		"## "+section,
+	fields := onboardingAdmissionGuidanceFields()
+	missing := missingOnboardingGuidanceAnswers(answers, fields)
+	if len(missing) > 0 {
+		return "", NewValidationError(
+			strings.Join(missing, ", ")+" required when backlog admission is enabled",
+			"Record project-specific Alignment, Readiness, Size, and Safety Gates criteria in answers.env.",
+			nil,
+		)
+	}
+	lines := []string{
+		"## " + section,
 		"",
-		"- **Alignment** — Admit work that advances explicit project goals or repairs a reproducible defect.",
-		"- **Readiness** — Admit only issues with clear expected behavior and checkable completion criteria.",
-		"- **Size** — Admit only work that can be completed and validated in one agent run.",
-		"- **Safety** — Leave destructive, credential-gated, ambiguous, or dependency-blocked work in Backlog.",
-	)
+		"Detent evaluates work for admission using the project-specific criteria recorded during onboarding.",
+	}
+	for _, field := range fields {
+		lines = append(lines, "", "### "+field.Heading, "", strings.TrimSpace(answers.Values[field.Key]))
+	}
+	return strings.TrimRight(prompt, "\n") + "\n\n" + markdownLines(lines...), nil
+}
+
+func readOnboardingAgentsFile(path string) (string, error) {
+	raw, err := os.ReadFile(path)
+	if err == nil {
+		return string(raw), nil
+	}
+	if errors.Is(err, os.ErrNotExist) {
+		return "", nil
+	}
+	return "", fmt.Errorf("read agent guidance %s: %w", path, err)
+}
+
+func renderOnboardingAgentGuidance(existing string, answers onboardingAnswers) (string, error) {
+	if hasOnboardingMarkdownHeading(existing, "## "+onboardingEffortRubricHeading) {
+		return existing, nil
+	}
+	fields := onboardingEffortGuidanceFields()
+	missing := missingOnboardingGuidanceAnswers(answers, fields)
+	if len(missing) > 0 {
+		return "", NewValidationError(
+			strings.Join(missing, ", ")+" required to generate AGENTS.md effort guidance",
+			"Record project-specific medium, high, xhigh, and max effort criteria in answers.env.",
+			nil,
+		)
+	}
+	lines := []string{
+		"## " + onboardingEffortRubricHeading,
+		"",
+		"Every issue created for this repository must include an explicit reasoning effort override:",
+		"",
+		"```detent-agent",
+		"schema: 1",
+		"effort: high",
+		"```",
+		"",
+		"Choose the effort from this project-specific rubric:",
+		"",
+	}
+	for _, field := range fields {
+		lines = append(lines, "- `"+field.Heading+"` — "+strings.TrimSpace(answers.Values[field.Key]))
+	}
+	lines = append(lines, "", "Leave `model` unset so the issue inherits the fleet-standard model.")
+	rubric := markdownLines(lines...)
+	if strings.TrimSpace(existing) == "" {
+		return rubric, nil
+	}
+	return strings.TrimRight(existing, "\n") + "\n\n" + rubric, nil
+}
+
+func onboardingAdmissionGuidanceFields() []onboardingGuidanceField {
+	return []onboardingGuidanceField{
+		{Key: "ADMISSION_ALIGNMENT_CRITERIA", Heading: "Alignment"},
+		{Key: "ADMISSION_READINESS_CRITERIA", Heading: "Readiness"},
+		{Key: "ADMISSION_SIZE_CRITERIA", Heading: "Size"},
+		{Key: "ADMISSION_SAFETY_GATES", Heading: "Safety Gates"},
+	}
+}
+
+func onboardingEffortGuidanceFields() []onboardingGuidanceField {
+	return []onboardingGuidanceField{
+		{Key: "EFFORT_MEDIUM_CRITERIA", Heading: "medium"},
+		{Key: "EFFORT_HIGH_CRITERIA", Heading: "high"},
+		{Key: "EFFORT_XHIGH_CRITERIA", Heading: "xhigh"},
+		{Key: "EFFORT_MAX_CRITERIA", Heading: "max"},
+	}
+}
+
+func missingOnboardingGuidanceAnswers(answers onboardingAnswers, fields []onboardingGuidanceField) []string {
+	var missing []string
+	for _, field := range fields {
+		if strings.TrimSpace(answers.Values[field.Key]) == "" {
+			missing = append(missing, field.Key)
+		}
+	}
+	return missing
+}
+
+func hasOnboardingMarkdownHeading(text string, heading string) bool {
+	for _, line := range strings.Split(strings.ReplaceAll(text, "\r\n", "\n"), "\n") {
+		if strings.TrimSpace(line) == heading {
+			return true
+		}
+	}
+	return false
 }
 
 func onboardingYAMLScalarValue(node *yaml.Node, key string) string {
@@ -1454,6 +1575,7 @@ func writeOnboardingBuildWorkflowPretty(w io.Writer, result onboardingBuildWorkf
 		"preset: " + result.Preset,
 		"path: " + result.Path,
 		"config_path: " + result.ConfigPath,
+		"agents_path: " + result.AgentsPath,
 		"written: " + strconv.FormatBool(result.Written),
 		"source_root: " + result.Probe.SourceRoot,
 	}
@@ -1475,6 +1597,9 @@ func writeOnboardingBuildWorkflowPretty(w io.Writer, result onboardingBuildWorkf
 			"",
 			"WORKFLOW.md preview:",
 			strings.TrimSpace(result.Workflow),
+			"",
+			"AGENTS.md preview:",
+			strings.TrimSpace(result.Agents),
 		)
 	}
 	_, err := fmt.Fprintln(w, strings.Join(lines, "\n"))

--- a/internal/cli/onboarding_workflow_builder.go
+++ b/internal/cli/onboarding_workflow_builder.go
@@ -1082,7 +1082,7 @@ func renderOnboardingWorkflowAdmissionCriteria(prompt string, root *yaml.Node, a
 }
 
 func readOnboardingAgentsFile(path string) (string, error) {
-	raw, err := os.ReadFile(path)
+	raw, err := os.ReadFile(path) // #nosec G703 -- path is AGENTS.md under the resolved operator-selected source root.
 	if err == nil {
 		return string(raw), nil
 	}

--- a/internal/cli/onboarding_workflow_builder_test.go
+++ b/internal/cli/onboarding_workflow_builder_test.go
@@ -590,11 +590,41 @@ func TestBuildOnboardingWorkflowWritesEffortRubric(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name     string
-		existing string
+		name             string
+		existing         string
+		wantHeadingCount int
+		wantUnchanged    bool
 	}{
-		{name: "creates AGENTS.md when absent"},
-		{name: "appends to existing AGENTS.md", existing: "# Repository agent guidance\n\nPreserve this project-owned content.\n"},
+		{name: "creates AGENTS.md when absent", wantHeadingCount: 1},
+		{name: "appends to existing AGENTS.md", existing: "# Repository agent guidance\n\nPreserve this project-owned content.\n", wantHeadingCount: 1},
+		{
+			name:             "appends when matching heading lacks guidance",
+			existing:         "# Repository agent guidance\n\n## Issue effort selection\n\nRecord estimates here.\n",
+			wantHeadingCount: 2,
+		},
+		{
+			name: "preserves complete existing guidance",
+			existing: strings.Join([]string{
+				"# Repository agent guidance",
+				"",
+				"## Issue effort selection",
+				"",
+				"```detent-agent",
+				"schema: 1",
+				"effort: high",
+				"```",
+				"",
+				"- `medium` — Small work.",
+				"- `high` — Standard work.",
+				"- `xhigh` — Complex work.",
+				"- `max` — Operator-designated work.",
+				"",
+				"Leave `model` unset.",
+				"",
+			}, "\n"),
+			wantHeadingCount: 1,
+			wantUnchanged:    true,
+		},
 	}
 
 	for _, tt := range tests {
@@ -623,11 +653,14 @@ func TestBuildOnboardingWorkflowWritesEffortRubric(t *testing.T) {
 				t.Fatalf("ReadFile(AGENTS.md) error = %v", err)
 			}
 			got := string(raw)
+			if tt.wantUnchanged && got != tt.existing {
+				t.Fatalf("AGENTS.md changed complete existing guidance:\n%s", got)
+			}
 			if tt.existing != "" && !strings.HasPrefix(got, strings.TrimRight(tt.existing, "\n")) {
 				t.Fatalf("AGENTS.md did not preserve existing content:\n%s", got)
 			}
-			if count := strings.Count(got, "## Issue effort selection"); count != 1 {
-				t.Fatalf("effort heading count = %d, want 1:\n%s", count, got)
+			if count := strings.Count(got, "## Issue effort selection"); count != tt.wantHeadingCount {
+				t.Fatalf("effort heading count = %d, want %d:\n%s", count, tt.wantHeadingCount, got)
 			}
 			for _, want := range []string{"```detent-agent", "effort: high", "`medium`", "`high`", "`xhigh`", "`max`", "Leave `model` unset"} {
 				if !strings.Contains(got, want) {

--- a/internal/cli/onboarding_workflow_builder_test.go
+++ b/internal/cli/onboarding_workflow_builder_test.go
@@ -141,7 +141,7 @@ func TestBuildOnboardingWorkflowPreservesArtifactPresetGate(t *testing.T) {
 	t.Parallel()
 
 	root := initOnboardingWorkflowBuilderGitRepository(t, "https://github.com/acme/artifacts.git")
-	answersPath := writeOnboardingWorkflowBuilderAnswers(t, strings.Join([]string{
+	answerLines := []string{
 		"CUSTOMER_ID=acme",
 		"DETENT_PROJECT_ID=artifact-production",
 		"TARGET_REPOSITORY=acme/artifacts",
@@ -150,8 +150,9 @@ func TestBuildOnboardingWorkflowPreservesArtifactPresetGate(t *testing.T) {
 		"DETENT_ONBOARDING_MODE=add-project",
 		"IDENTITY_CONFIRMED=true",
 		"WORKFLOW_PRESET=non_code_artifact",
-		"",
-	}, "\n"))
+	}
+	answerLines = append(answerLines, onboardingWorkflowGuidanceAnswerLines()...)
+	answersPath := writeOnboardingWorkflowBuilderAnswers(t, strings.Join(append(answerLines, ""), "\n"))
 
 	result, err := buildOnboardingWorkflow(context.Background(), onboardingBuildWorkflowConfig{
 		AnswersPath: answersPath,
@@ -540,11 +541,22 @@ func TestBuildOnboardingWorkflowRendersIntakeProfiles(t *testing.T) {
 			if len(workflow.Config.Intake.Sources) != tt.wantIntakeSources {
 				t.Fatalf("len(Intake.Sources) = %d, want %d", len(workflow.Config.Intake.Sources), tt.wantIntakeSources)
 			}
+			for _, want := range []string{"## Issue effort selection", "```detent-agent", "`medium`", "`high`", "`xhigh`", "`max`", "Leave `model` unset"} {
+				if !strings.Contains(result.Agents, want) {
+					t.Fatalf("generated AGENTS.md missing %q:\n%s", want, result.Agents)
+				}
+			}
 			assertOnboardingWorkflowDecision(t, result.Decisions, "answers.intake_profile", "answer")
 			assertOnboardingWorkflowDecision(t, result.Decisions, "agent.followups.enabled", "answer")
 			if !tt.wantAdmission {
 				if strings.Contains(result.Config, "backlog_admission:") {
 					t.Fatalf("manual intake emitted backlog_admission block:\n%s", result.Config)
+				}
+				if strings.Contains(result.Workflow, "## Admission Criteria") {
+					t.Fatalf("manual intake emitted admission criteria:\n%s", result.Workflow)
+				}
+				if strings.Contains(result.Config, "criteria_section:") {
+					t.Fatalf("manual intake emitted dangling criteria_section:\n%s", result.Config)
 				}
 				assertOnboardingWorkflowDecision(t, result.Decisions, "backlog_admission", "answer")
 				return
@@ -555,13 +567,73 @@ func TestBuildOnboardingWorkflowRendersIntakeProfiles(t *testing.T) {
 				"max_open_proposals: 10",
 				"proposal_expiry_days: 7",
 				"## Admission Criteria",
+				"### Alignment",
+				"### Readiness",
+				"### Size",
+				"### Safety Gates",
+				"Repairs customer-visible defects and advances documented product goals.",
 			} {
 				if !strings.Contains(result.Config+result.Workflow, want) {
 					t.Fatalf("generated output missing %q\nconfig:\n%s\nworkflow:\n%s", want, result.Config, result.Workflow)
 				}
 			}
+			if workflow.Config.BacklogAdmission.CriteriaSection != onboardingAdmissionCriteriaHeading {
+				t.Fatalf("CriteriaSection = %q, want exact generated heading %q", workflow.Config.BacklogAdmission.CriteriaSection, onboardingAdmissionCriteriaHeading)
+			}
 			assertOnboardingWorkflowDecision(t, result.Decisions, "backlog_admission.enabled", "answer")
 			assertOnboardingWorkflowDecision(t, result.Decisions, "backlog_admission.max_candidates_per_run", "answer")
+		})
+	}
+}
+
+func TestBuildOnboardingWorkflowWritesEffortRubric(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		existing string
+	}{
+		{name: "creates AGENTS.md when absent"},
+		{name: "appends to existing AGENTS.md", existing: "# Repository agent guidance\n\nPreserve this project-owned content.\n"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			root := initOnboardingWorkflowBuilderGitRepository(t, "https://github.com/acme/api.git")
+			agentsPath := filepath.Join(root, "AGENTS.md")
+			if tt.existing != "" {
+				writeOnboardingWorkflowBuilderFile(t, agentsPath, tt.existing)
+			}
+			answersPath := writeOnboardingWorkflowBuilderAnswers(t, onboardingWorkflowBuilderVariantAnswers(root, "github_local", "review_gate", "INTAKE_PROFILE=manual_intake"))
+
+			result, err := buildOnboardingWorkflow(context.Background(), onboardingBuildWorkflowConfig{
+				AnswersPath: answersPath,
+				Write:       true,
+			})
+			if err != nil {
+				t.Fatalf("buildOnboardingWorkflow() error = %v", err)
+			}
+			if result.AgentsPath != agentsPath {
+				t.Fatalf("AgentsPath = %q, want %q", result.AgentsPath, agentsPath)
+			}
+			raw, err := os.ReadFile(agentsPath)
+			if err != nil {
+				t.Fatalf("ReadFile(AGENTS.md) error = %v", err)
+			}
+			got := string(raw)
+			if tt.existing != "" && !strings.HasPrefix(got, strings.TrimRight(tt.existing, "\n")) {
+				t.Fatalf("AGENTS.md did not preserve existing content:\n%s", got)
+			}
+			if count := strings.Count(got, "## Issue effort selection"); count != 1 {
+				t.Fatalf("effort heading count = %d, want 1:\n%s", count, got)
+			}
+			for _, want := range []string{"```detent-agent", "effort: high", "`medium`", "`high`", "`xhigh`", "`max`", "Leave `model` unset"} {
+				if !strings.Contains(got, want) {
+					t.Fatalf("AGENTS.md missing %q:\n%s", want, got)
+				}
+			}
 		})
 	}
 }
@@ -629,7 +701,7 @@ func TestBuildOnboardingWorkflowGeneratesParseablePausedProject(t *testing.T) {
 	root := initOnboardingWorkflowBuilderGitRepository(t, "https://github.com/acme/api.git")
 	writeOnboardingWorkflowBuilderFile(t, filepath.Join(root, "go.mod"), "module example.com/api\n\ngo 1.26\n")
 	writeOnboardingWorkflowBuilderFile(t, filepath.Join(root, "Makefile"), ".PHONY: check\ncheck:\n\tgo test ./...\n")
-	answersPath := writeOnboardingWorkflowBuilderAnswers(t, strings.Join([]string{
+	answerLines := []string{
 		"CUSTOMER_ID=acme",
 		"DETENT_PROJECT_ID=api",
 		"TARGET_REPOSITORY=acme/api",
@@ -639,8 +711,9 @@ func TestBuildOnboardingWorkflowGeneratesParseablePausedProject(t *testing.T) {
 		"IDENTITY_CONFIRMED=true",
 		"WORKFLOW_PRESET=github_local",
 		"DELIVERY_PROFILE=review_gate",
-		"",
-	}, "\n"))
+	}
+	answerLines = append(answerLines, onboardingWorkflowGuidanceAnswerLines()...)
+	answersPath := writeOnboardingWorkflowBuilderAnswers(t, strings.Join(append(answerLines, ""), "\n"))
 	outputPath := filepath.Join(root, "WORKFLOW.md")
 
 	result, err := buildOnboardingWorkflow(context.Background(), onboardingBuildWorkflowConfig{
@@ -653,6 +726,13 @@ func TestBuildOnboardingWorkflowGeneratesParseablePausedProject(t *testing.T) {
 	}
 	if !result.Written || result.Path != outputPath {
 		t.Fatalf("result = %#v, want written workflow at %s", result, outputPath)
+	}
+	agentsRaw, err := os.ReadFile(filepath.Join(root, "AGENTS.md"))
+	if err != nil {
+		t.Fatalf("ReadFile(AGENTS.md) error = %v", err)
+	}
+	if !strings.Contains(string(agentsRaw), "## Issue effort selection") {
+		t.Fatalf("AGENTS.md missing generated effort rubric:\n%s", string(agentsRaw))
 	}
 	raw, err := os.ReadFile(outputPath)
 	if err != nil {
@@ -788,8 +868,22 @@ func onboardingWorkflowBuilderVariantAnswers(root string, preset string, profile
 	if preset == "project_v2" {
 		lines = append(lines, "PROJECT_SLUG=PVT_test")
 	}
+	lines = append(lines, onboardingWorkflowGuidanceAnswerLines()...)
 	lines = append(lines, extra...)
 	return strings.Join(append(lines, ""), "\n")
+}
+
+func onboardingWorkflowGuidanceAnswerLines() []string {
+	return []string{
+		"ADMISSION_ALIGNMENT_CRITERIA=Repairs customer-visible defects and advances documented product goals.",
+		"ADMISSION_READINESS_CRITERIA=Requires repository evidence, resolved dependencies, and checkable completion criteria.",
+		"ADMISSION_SIZE_CRITERIA=Fits implementation and validation within one agent run.",
+		"ADMISSION_SAFETY_GATES=Requires credentials and destructive actions to be explicitly authorized before admission.",
+		"EFFORT_MEDIUM_CRITERIA=Small mechanical work with exact acceptance criteria.",
+		"EFFORT_HIGH_CRITERIA=Standard features and fixes with some ambiguity or cross-cutting impact.",
+		"EFFORT_XHIGH_CRITERIA=New subsystems or tricky state, concurrency, restart, recovery, or interaction work.",
+		"EFFORT_MAX_CRITERIA=Exceptional operator-designated work that must never be selected automatically.",
+	}
 }
 
 func initOnboardingWorkflowBuilderGitRepository(t *testing.T, remote string) string {

--- a/onboarding_docs_test.go
+++ b/onboarding_docs_test.go
@@ -446,6 +446,39 @@ func TestOnboardingDocsPresentDeliveryProfilesBeforeAnswersEnvFields(t *testing.
 	assertOrder(t, onboarding, "Conservative/manual expands to:", "GATE_REQUIRE_AUTOMATED_REVIEW=true")
 }
 
+func TestOnboardingDocsGenerateAdmissionAndEffortGuidance(t *testing.T) {
+	t.Parallel()
+
+	onboarding := readRepositoryTextFile(t, "docs/ONBOARDING.md")
+
+	for _, want := range []string{
+		"ADMISSION_ALIGNMENT_CRITERIA",
+		"ADMISSION_READINESS_CRITERIA",
+		"ADMISSION_SIZE_CRITERIA",
+		"ADMISSION_SAFETY_GATES",
+		"EFFORT_MEDIUM_CRITERIA",
+		"EFFORT_HIGH_CRITERIA",
+		"EFFORT_XHIGH_CRITERIA",
+		"EFFORT_MAX_CRITERIA",
+		"## Admission Criteria",
+		"### Alignment",
+		"### Readiness",
+		"### Size",
+		"### Safety Gates",
+		"creates or appends the operator-approved four-tier rubric in `AGENTS.md`",
+		"leaves `model` unset",
+		`detent onboarding build-workflow`,
+		"contain no detent-agent guidance",
+	} {
+		assertContainsWords(t, onboarding, want)
+	}
+
+	assertOrder(t, onboarding, "For assisted or autonomous intake", "ADMISSION_ALIGNMENT_CRITERIA")
+	assertOrder(t, onboarding, "Ask every project", "EFFORT_MEDIUM_CRITERIA")
+	assertOrder(t, onboarding, "## Phase 4", "detent onboarding build-workflow")
+	assertOrder(t, onboarding, "detent onboarding build-workflow", "## Phase 5")
+}
+
 func TestOnboardingDocsSkipDuplicateProfileSuppliedQuestions(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

- generate project-specific Admission Criteria subsections from operator answers when backlog admission is enabled
- create or append the four-tier detent-agent effort rubric in AGENTS.md for every intake profile
- verify both generated sections and the doctor effort-guidance result during Phase 5 preflight

Fixes #1683

## Test Plan

- `go test ./internal/cli`
- `go test .`
- `env -u DETENT_API_TOKEN make check`
