### PR TITLE
feat(doctor): report unused capabilities

### DIFF
--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -67,6 +67,7 @@ type doctorCheck struct {
 	UntrackedIssues           []doctorStatusDriftIssueDiagnostic         `json:"untracked_issues,omitempty"`
 	OpenTerminalIssues        []doctorStatusDriftIssueDiagnostic         `json:"open_terminal_issues,omitempty"`
 	ProjectDefinition         *doctorProjectDefinitionDiagnostic         `json:"project_definition,omitempty"`
+	Capabilities              *doctorCapabilityReport                    `json:"capabilities,omitempty"`
 	WorkflowOptimization      doctorWorkflowOptimizationReport           `json:"-"`
 }
 
@@ -913,6 +914,13 @@ func writeDoctorReport(out io.Writer, report doctorReport, format ...OutputForma
 	for _, check := range report.Checks {
 		if _, err := fmt.Fprintf(out, "%-5s  %-28s  %s\n", check.Status, check.Name, check.Detail); err != nil {
 			return err
+		}
+		if check.Capabilities != nil {
+			for _, capability := range check.Capabilities.Capabilities {
+				if _, err := fmt.Fprintf(out, "%-5s  %-28s  %s\n", "", strings.ToUpper(string(capability.State))+" "+capability.Name, capability.Detail); err != nil {
+					return err
+				}
+			}
 		}
 		if strings.TrimSpace(check.Hint) != "" {
 			if _, err := fmt.Fprintf(out, "%-5s  %-28s  Hint: %s\n", "", "", check.Hint); err != nil {

--- a/internal/cli/doctor_capabilities.go
+++ b/internal/cli/doctor_capabilities.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"fmt"
 	"os"
-	"path/filepath"
 	"strings"
 
 	workflowconfig "github.com/digitaldrywood/detent/internal/config"
@@ -253,9 +252,20 @@ func doctorEnabledCapability(name string, enabled bool, configuredDetail string,
 	return doctorCapability{Name: name, State: doctorCapabilityUnused, Detail: unusedDetail}
 }
 
-func findDoctorIssueEffortGuidance(sourceRoot string) (string, error) {
+func findDoctorIssueEffortGuidance(sourceRoot string) (_ string, resultErr error) {
+	root, err := os.OpenRoot(sourceRoot)
+	if errors.Is(err, os.ErrNotExist) {
+		return "", nil
+	}
+	if err != nil {
+		return "", fmt.Errorf("source root could not be opened: %w", err)
+	}
+	defer func() {
+		resultErr = errors.Join(resultErr, root.Close())
+	}()
+
 	for _, path := range []string{"AGENTS.md", "CLAUDE.md"} {
-		content, err := os.ReadFile(filepath.Join(sourceRoot, path))
+		content, err := root.ReadFile(path)
 		if errors.Is(err, os.ErrNotExist) {
 			continue
 		}

--- a/internal/cli/doctor_capabilities.go
+++ b/internal/cli/doctor_capabilities.go
@@ -103,11 +103,21 @@ func doctorBacklogAdmissionCapability(cfg workflowconfig.Config, sharedPrompt st
 			Detail: "tracker.kind " + cfg.Tracker.Kind + " does not provide candidate selectors required for backlog admission.",
 		}
 	}
+	prerequisites := make([]string, 0, 3)
+	if len(cfg.BacklogAdmission.Sources.States) == 0 && len(cfg.BacklogAdmission.Sources.Labels) == 0 && !cfg.BacklogAdmission.Sources.Untracked {
+		prerequisites = append(prerequisites, "configure backlog_admission.sources with at least one selector")
+	}
+	if strings.TrimSpace(cfg.BacklogAdmission.TargetState) == "" {
+		prerequisites = append(prerequisites, "set backlog_admission.target_state to a configured workflow state")
+	}
 	if _, err := workflowconfig.ResolveAdmissionCriteria(sharedPrompt, cfg.BacklogAdmission.CriteriaSection); err != nil {
+		prerequisites = append(prerequisites, "set backlog_admission.criteria_section to a shared WORKFLOW.md heading with at least one admission dimension ("+err.Error()+")")
+	}
+	if len(prerequisites) > 0 {
 		return doctorCapability{
 			Name:   "backlog_admission",
 			State:  doctorCapabilityUnavailable,
-			Detail: "Prerequisite: set backlog_admission.criteria_section to a shared WORKFLOW.md heading with at least one admission dimension; enabling then evaluates backlog candidates and proposes or admits matching work. Current prerequisite: " + err.Error() + ".",
+			Detail: "Prerequisites: " + strings.Join(prerequisites, "; ") + ". Once satisfied, enabling evaluates backlog candidates and proposes or admits matching work.",
 		}
 	}
 	return doctorCapability{
@@ -169,18 +179,18 @@ func doctorRoutineCapability(cfg workflowconfig.Config) doctorCapability {
 }
 
 func doctorIntakeCapability(cfg workflowconfig.Config, enabled bool, count int) doctorCapability {
-	if enabled {
-		return doctorCapability{
-			Name:   "intake.sources",
-			State:  doctorCapabilityConfigured,
-			Detail: fmt.Sprintf("%d source(s) turn external or scheduled signals into tracker issues.", count),
-		}
-	}
 	if cfg.Tracker.Kind != workflowconfig.TrackerGitHub {
 		return doctorCapability{
 			Name:   "intake.sources",
 			State:  doctorCapabilityUnavailable,
 			Detail: "tracker.kind " + cfg.Tracker.Kind + " cannot create intake issues; intake.sources requires github.",
+		}
+	}
+	if enabled {
+		return doctorCapability{
+			Name:   "intake.sources",
+			State:  doctorCapabilityConfigured,
+			Detail: fmt.Sprintf("%d source(s) turn external or scheduled signals into tracker issues.", count),
 		}
 	}
 	return doctorCapability{Name: "intake.sources", State: doctorCapabilityUnused, Detail: "Enable to turn external webhook or scheduled signals into tracker issues."}

--- a/internal/cli/doctor_capabilities.go
+++ b/internal/cli/doctor_capabilities.go
@@ -1,0 +1,270 @@
+package cli
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	workflowconfig "github.com/digitaldrywood/detent/internal/config"
+	globalconfig "github.com/digitaldrywood/detent/internal/config/global"
+	"github.com/digitaldrywood/detent/internal/connector"
+)
+
+type doctorCapabilityState string
+
+const (
+	doctorCapabilityConfigured  doctorCapabilityState = "configured"
+	doctorCapabilityUnused      doctorCapabilityState = "unused"
+	doctorCapabilityUnavailable doctorCapabilityState = "unavailable"
+)
+
+type doctorCapability struct {
+	Name   string                `json:"name"`
+	State  doctorCapabilityState `json:"state"`
+	Detail string                `json:"detail"`
+}
+
+type doctorCapabilityReport struct {
+	ProjectID    string             `json:"project_id"`
+	Capabilities []doctorCapability `json:"items"`
+}
+
+func checkDoctorCapabilities(project globalconfig.Project, workflow workflowconfig.Workflow) doctorCheck {
+	projectID := doctorProjectID(project)
+	capabilities := doctorProjectCapabilities(project, workflow)
+	counts := map[doctorCapabilityState]int{}
+	for _, capability := range capabilities {
+		counts[capability.State]++
+	}
+	return doctorCheck{
+		Name:   "Project " + projectID + " capabilities",
+		Status: doctorOK,
+		Detail: fmt.Sprintf(
+			"advisory: %d configured, %d unused, %d unavailable",
+			counts[doctorCapabilityConfigured],
+			counts[doctorCapabilityUnused],
+			counts[doctorCapabilityUnavailable],
+		),
+		Capabilities: &doctorCapabilityReport{
+			ProjectID:    projectID,
+			Capabilities: capabilities,
+		},
+	}
+}
+
+func doctorProjectCapabilities(project globalconfig.Project, workflow workflowconfig.Workflow) []doctorCapability {
+	cfg := workflow.Config
+	intakeEnabled := cfg.Intake.Enabled()
+	intakeCount := len(cfg.Intake.Sources)
+	if project.IntakeConfigured {
+		intakeEnabled = project.Intake.Enabled()
+		intakeCount = len(project.Intake.Sources)
+	}
+
+	return []doctorCapability{
+		doctorBacklogAdmissionCapability(cfg, workflow.SharedPrompt),
+		doctorUntrackedAdmissionCapability(cfg),
+		doctorExcludeLabelsAdmissionCapability(cfg),
+		doctorRoutineCapability(cfg),
+		doctorIntakeCapability(cfg, intakeEnabled, intakeCount),
+		doctorEnabledCapability(
+			"agent.followups",
+			cfg.Agent.Followups.Enabled,
+			"enabled; agents receive guidance to file separate backlog issues for meaningful out-of-scope discoveries.",
+			"Enable to prompt agents to file separate backlog issues for meaningful out-of-scope discoveries.",
+		),
+		doctorEnabledCapability(
+			"agent.auto_promote",
+			cfg.Agent.AutoPromote.Enabled,
+			"enabled; review-ready work advances automatically after configured gates and quiet windows.",
+			"Enable to advance review-ready work automatically after configured gates and quiet windows.",
+		),
+		doctorRetroCapability(cfg),
+		doctorReleaseCapability(cfg),
+		doctorEffortRubricCapability(project, cfg),
+	}
+}
+
+func doctorBacklogAdmissionCapability(cfg workflowconfig.Config, sharedPrompt string) doctorCapability {
+	if cfg.BacklogAdmission.Enabled {
+		return doctorCapability{
+			Name:   "backlog_admission",
+			State:  doctorCapabilityConfigured,
+			Detail: "enabled; Detent evaluates configured backlog sources against WORKFLOW.md admission criteria.",
+		}
+	}
+
+	candidateCapabilities := connector.CandidateCapabilitiesFor(connector.Backend(cfg.Tracker.Kind), cfg.Tracker.GitHubStatusSource)
+	if len(candidateCapabilities.Selectors) == 0 {
+		return doctorCapability{
+			Name:   "backlog_admission",
+			State:  doctorCapabilityUnavailable,
+			Detail: "tracker.kind " + cfg.Tracker.Kind + " does not provide candidate selectors required for backlog admission.",
+		}
+	}
+	if _, err := workflowconfig.ResolveAdmissionCriteria(sharedPrompt, cfg.BacklogAdmission.CriteriaSection); err != nil {
+		return doctorCapability{
+			Name:   "backlog_admission",
+			State:  doctorCapabilityUnavailable,
+			Detail: "Prerequisite: set backlog_admission.criteria_section to a shared WORKFLOW.md heading with at least one admission dimension; enabling then evaluates backlog candidates and proposes or admits matching work. Current prerequisite: " + err.Error() + ".",
+		}
+	}
+	return doctorCapability{
+		Name:   "backlog_admission",
+		State:  doctorCapabilityUnused,
+		Detail: "Enable to evaluate backlog candidates against WORKFLOW.md criteria and propose or admit matching work.",
+	}
+}
+
+func doctorUntrackedAdmissionCapability(cfg workflowconfig.Config) doctorCapability {
+	capabilities := connector.CandidateCapabilitiesFor(connector.Backend(cfg.Tracker.Kind), cfg.Tracker.GitHubStatusSource)
+	if !capabilities.Supports(connector.CandidateSelectorUntracked) {
+		reason := "tracker.kind " + cfg.Tracker.Kind + " does not provide GitHub label-status drift needed to identify untracked issues."
+		if cfg.Tracker.Kind == workflowconfig.TrackerGitHub && cfg.Tracker.GitHubStatusSource == workflowconfig.GitHubStatusSourceProjectV2 {
+			reason = "github project_v2 status cannot identify untracked repository issues; use github label status to enable this selector."
+		}
+		return doctorCapability{Name: "backlog_admission.sources.untracked", State: doctorCapabilityUnavailable, Detail: reason}
+	}
+	return doctorEnabledCapability(
+		"backlog_admission.sources.untracked",
+		cfg.BacklogAdmission.Sources.Untracked,
+		"configured; admission can consider repository issues outside Detent's tracked status lanes.",
+		"Enable to admit open repository issues not represented in Detent's label-status lanes.",
+	)
+}
+
+func doctorExcludeLabelsAdmissionCapability(cfg workflowconfig.Config) doctorCapability {
+	if cfg.Tracker.Kind == workflowconfig.TrackerGitHub && cfg.Tracker.GitHubStatusSource == workflowconfig.GitHubStatusSourceProjectV2 {
+		return doctorCapability{
+			Name:   "backlog_admission.exclude_labels",
+			State:  doctorCapabilityUnavailable,
+			Detail: "github project_v2 fetches only the first 20 issue labels, so Detent cannot apply exclude_labels completely.",
+		}
+	}
+	return doctorEnabledCapability(
+		"backlog_admission.exclude_labels",
+		len(cfg.BacklogAdmission.ExcludeLabels) > 0,
+		fmt.Sprintf("configured with %d label exclusion(s); matching issues stay out of admission candidates.", len(cfg.BacklogAdmission.ExcludeLabels)),
+		"Configure to keep issues with selected labels out of backlog admission candidates.",
+	)
+}
+
+func doctorRoutineCapability(cfg workflowconfig.Config) doctorCapability {
+	if len(cfg.Routines) > 0 {
+		return doctorCapability{
+			Name:   "routines",
+			State:  doctorCapabilityConfigured,
+			Detail: fmt.Sprintf("%d scheduled routine(s) run recurring agent prompts.", len(cfg.Routines)),
+		}
+	}
+	if cfg.Tracker.Kind != workflowconfig.TrackerGitHub && cfg.Tracker.Kind != workflowconfig.TrackerMemory {
+		return doctorCapability{
+			Name:   "routines",
+			State:  doctorCapabilityUnavailable,
+			Detail: "tracker.kind " + cfg.Tracker.Kind + " does not support scheduled routine issue creation; routines require github or memory.",
+		}
+	}
+	return doctorCapability{Name: "routines", State: doctorCapabilityUnused, Detail: "Enable to run recurring agent prompts on a schedule."}
+}
+
+func doctorIntakeCapability(cfg workflowconfig.Config, enabled bool, count int) doctorCapability {
+	if enabled {
+		return doctorCapability{
+			Name:   "intake.sources",
+			State:  doctorCapabilityConfigured,
+			Detail: fmt.Sprintf("%d source(s) turn external or scheduled signals into tracker issues.", count),
+		}
+	}
+	if cfg.Tracker.Kind != workflowconfig.TrackerGitHub {
+		return doctorCapability{
+			Name:   "intake.sources",
+			State:  doctorCapabilityUnavailable,
+			Detail: "tracker.kind " + cfg.Tracker.Kind + " cannot create intake issues; intake.sources requires github.",
+		}
+	}
+	return doctorCapability{Name: "intake.sources", State: doctorCapabilityUnused, Detail: "Enable to turn external webhook or scheduled signals into tracker issues."}
+}
+
+func doctorRetroCapability(cfg workflowconfig.Config) doctorCapability {
+	if cfg.Retro.Enabled {
+		return doctorCapability{
+			Name:   "retro",
+			State:  doctorCapabilityConfigured,
+			Detail: "enabled; recurring failure telemetry can become governed improvement issues.",
+		}
+	}
+	if cfg.Tracker.Kind != workflowconfig.TrackerGitHub && cfg.Tracker.Kind != workflowconfig.TrackerMemory {
+		return doctorCapability{
+			Name:   "retro",
+			State:  doctorCapabilityUnavailable,
+			Detail: "tracker.kind " + cfg.Tracker.Kind + " cannot create retrospective issues; retro requires github or memory.",
+		}
+	}
+	return doctorCapability{Name: "retro", State: doctorCapabilityUnused, Detail: "Enable to turn recurring failure telemetry into governed improvement issues."}
+}
+
+func doctorReleaseCapability(cfg workflowconfig.Config) doctorCapability {
+	if cfg.Release.Enabled {
+		return doctorCapability{
+			Name:   "release",
+			State:  doctorCapabilityConfigured,
+			Detail: "enabled; Detent cuts releases after configured merge-count, age, and CI gates.",
+		}
+	}
+	if cfg.Tracker.Kind != workflowconfig.TrackerGitHub && cfg.Tracker.Kind != workflowconfig.TrackerGitHubLocal {
+		return doctorCapability{
+			Name:   "release",
+			State:  doctorCapabilityUnavailable,
+			Detail: "tracker.kind " + cfg.Tracker.Kind + " cannot inspect and tag GitHub repositories; release requires github or github_local.",
+		}
+	}
+	return doctorCapability{Name: "release", State: doctorCapabilityUnused, Detail: "Enable to cut releases automatically after merge-count, age, and CI gates."}
+}
+
+func doctorEffortRubricCapability(project globalconfig.Project, cfg workflowconfig.Config) doctorCapability {
+	root := projectSourceRoot(project, cfg)
+	if root == "" {
+		return doctorCapability{Name: "detent-agent effort rubric", State: doctorCapabilityUnavailable, Detail: "source root is not configured, so AGENTS.md and CLAUDE.md cannot be inspected."}
+	}
+	expandedRoot, err := expandDoctorWorkspacePath(root)
+	if err != nil {
+		return doctorCapability{Name: "detent-agent effort rubric", State: doctorCapabilityUnavailable, Detail: "source root could not be resolved: " + err.Error() + "."}
+	}
+	info, err := os.Stat(expandedRoot)
+	if err != nil || !info.IsDir() {
+		return doctorCapability{Name: "detent-agent effort rubric", State: doctorCapabilityUnavailable, Detail: "source repository is unavailable locally, so AGENTS.md and CLAUDE.md cannot be inspected."}
+	}
+	path, err := findDoctorIssueEffortGuidance(expandedRoot)
+	if err != nil {
+		return doctorCapability{Name: "detent-agent effort rubric", State: doctorCapabilityUnavailable, Detail: err.Error() + "."}
+	}
+	if path != "" {
+		return doctorCapability{Name: "detent-agent effort rubric", State: doctorCapabilityConfigured, Detail: path + " provides project-specific detent-agent effort guidance."}
+	}
+	return doctorCapability{Name: "detent-agent effort rubric", State: doctorCapabilityUnused, Detail: "Add a project-specific detent-agent effort rubric so issues receive deliberate reasoning effort."}
+}
+
+func doctorEnabledCapability(name string, enabled bool, configuredDetail string, unusedDetail string) doctorCapability {
+	if enabled {
+		return doctorCapability{Name: name, State: doctorCapabilityConfigured, Detail: configuredDetail}
+	}
+	return doctorCapability{Name: name, State: doctorCapabilityUnused, Detail: unusedDetail}
+}
+
+func findDoctorIssueEffortGuidance(sourceRoot string) (string, error) {
+	for _, path := range []string{"AGENTS.md", "CLAUDE.md"} {
+		content, err := os.ReadFile(filepath.Join(sourceRoot, path))
+		if errors.Is(err, os.ErrNotExist) {
+			continue
+		}
+		if err != nil {
+			return "", fmt.Errorf("%s could not be read: %w", path, err)
+		}
+		if strings.Contains(strings.ToLower(string(content)), "detent-agent") {
+			return path, nil
+		}
+	}
+	return "", nil
+}

--- a/internal/cli/doctor_capabilities_test.go
+++ b/internal/cli/doctor_capabilities_test.go
@@ -22,7 +22,7 @@ func TestCheckDoctorCapabilities(t *testing.T) {
 		sharedPrompt   string
 		effortGuidance bool
 		wantStates     map[string]doctorCapabilityState
-		wantDetails    map[string]string
+		wantDetails    map[string][]string
 	}{
 		{
 			name: "fully configured project",
@@ -32,6 +32,7 @@ func TestCheckDoctorCapabilities(t *testing.T) {
 				cfg.BacklogAdmission.Enabled = true
 				cfg.BacklogAdmission.CriteriaSection = "Admission Criteria"
 				cfg.BacklogAdmission.Sources.Untracked = true
+				cfg.BacklogAdmission.TargetState = "Todo"
 				cfg.BacklogAdmission.ExcludeLabels = []string{"skip-admission"}
 				cfg.Routines = []workflowconfig.Routine{{Name: "dependency-audit"}}
 				cfg.Intake.Sources = []intake.Source{{Name: "alerts"}}
@@ -75,15 +76,19 @@ func TestCheckDoctorCapabilities(t *testing.T) {
 				"release":                             doctorCapabilityUnused,
 				"detent-agent effort rubric":          doctorCapabilityUnused,
 			},
-			wantDetails: map[string]string{
-				"backlog_admission":          "criteria_section to a shared WORKFLOW.md heading",
-				"routines":                   "recurring agent prompts",
-				"intake.sources":             "external webhook or scheduled signals",
-				"agent.followups":            "meaningful out-of-scope discoveries",
-				"agent.auto_promote":         "review-ready work automatically",
-				"retro":                      "recurring failure telemetry",
-				"release":                    "cut releases automatically",
-				"detent-agent effort rubric": "deliberate reasoning effort",
+			wantDetails: map[string][]string{
+				"backlog_admission": {
+					"backlog_admission.sources with at least one selector",
+					"backlog_admission.target_state to a configured workflow state",
+					"backlog_admission.criteria_section to a shared WORKFLOW.md heading",
+				},
+				"routines":                   {"recurring agent prompts"},
+				"intake.sources":             {"external webhook or scheduled signals"},
+				"agent.followups":            {"meaningful out-of-scope discoveries"},
+				"agent.auto_promote":         {"review-ready work automatically"},
+				"retro":                      {"recurring failure telemetry"},
+				"release":                    {"cut releases automatically"},
+				"detent-agent effort rubric": {"deliberate reasoning effort"},
 			},
 		},
 		{
@@ -93,6 +98,8 @@ func TestCheckDoctorCapabilities(t *testing.T) {
 				cfg.Tracker.GitHubStatusSource = workflowconfig.GitHubStatusSourceProjectV2
 				cfg.Agent.Followups.Enabled = false
 				cfg.BacklogAdmission.CriteriaSection = "Admission Criteria"
+				cfg.BacklogAdmission.Sources.States = []string{"Backlog"}
+				cfg.BacklogAdmission.TargetState = "Todo"
 			},
 			sharedPrompt: "## Admission Criteria\n\n- **Alignment** — Prefer operator-visible work.\n",
 			wantStates: map[string]doctorCapabilityState{
@@ -107,9 +114,9 @@ func TestCheckDoctorCapabilities(t *testing.T) {
 				"release":                             doctorCapabilityUnused,
 				"detent-agent effort rubric":          doctorCapabilityUnused,
 			},
-			wantDetails: map[string]string{
-				"backlog_admission.sources.untracked": "project_v2 status cannot identify untracked",
-				"backlog_admission.exclude_labels":    "first 20 issue labels",
+			wantDetails: map[string][]string{
+				"backlog_admission.sources.untracked": {"project_v2 status cannot identify untracked"},
+				"backlog_admission.exclude_labels":    {"first 20 issue labels"},
 			},
 		},
 	}
@@ -150,8 +157,10 @@ func TestCheckDoctorCapabilities(t *testing.T) {
 				if capability.State != wantState {
 					t.Errorf("%s state = %s, want %s", capability.Name, capability.State, wantState)
 				}
-				if wantDetail := tt.wantDetails[capability.Name]; wantDetail != "" && !strings.Contains(capability.Detail, wantDetail) {
-					t.Errorf("%s detail = %q, want containing %q", capability.Name, capability.Detail, wantDetail)
+				for _, wantDetail := range tt.wantDetails[capability.Name] {
+					if !strings.Contains(capability.Detail, wantDetail) {
+						t.Errorf("%s detail = %q, want containing %q", capability.Name, capability.Detail, wantDetail)
+					}
 				}
 			}
 
@@ -182,29 +191,59 @@ func TestCheckDoctorCapabilities(t *testing.T) {
 func TestCheckDoctorCapabilitiesUsesProjectIntakeOverride(t *testing.T) {
 	t.Parallel()
 
-	root := t.TempDir()
-	cfg := workflowconfig.Default()
-	cfg.Tracker.Kind = workflowconfig.TrackerGitHub
-	cfg.Tracker.GitHubStatusSource = workflowconfig.GitHubStatusSourceLabel
-	cfg.Intake.Sources = []intake.Source{{Name: "workflow-source"}}
-	check := checkDoctorCapabilities(
-		globalconfig.Project{
-			ID:               "alpha",
-			Workdir:          root,
-			IntakeConfigured: true,
-			Intake:           intake.Config{},
+	tests := []struct {
+		name          string
+		trackerKind   string
+		projectIntake intake.Config
+		wantState     doctorCapabilityState
+		wantDetail    string
+	}{
+		{
+			name:        "disabled override replaces workflow sources",
+			trackerKind: workflowconfig.TrackerGitHub,
+			wantState:   doctorCapabilityUnused,
 		},
-		workflowconfig.Workflow{Config: cfg},
-	)
-
-	for _, capability := range check.Capabilities.Capabilities {
-		if capability.Name != "intake.sources" {
-			continue
-		}
-		if capability.State != doctorCapabilityUnused {
-			t.Fatalf("intake.sources state = %s, want %s", capability.State, doctorCapabilityUnused)
-		}
-		return
+		{
+			name:          "enabled override is unavailable for non github tracker",
+			trackerKind:   workflowconfig.TrackerMemory,
+			projectIntake: intake.Config{Sources: []intake.Source{{Name: "project-source"}}},
+			wantState:     doctorCapabilityUnavailable,
+			wantDetail:    "intake.sources requires github",
+		},
 	}
-	t.Fatal("intake.sources capability missing")
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			root := t.TempDir()
+			cfg := workflowconfig.Default()
+			cfg.Tracker.Kind = tt.trackerKind
+			cfg.Tracker.GitHubStatusSource = workflowconfig.GitHubStatusSourceLabel
+			cfg.Intake.Sources = []intake.Source{{Name: "workflow-source"}}
+			check := checkDoctorCapabilities(
+				globalconfig.Project{
+					ID:               "alpha",
+					Workdir:          root,
+					IntakeConfigured: true,
+					Intake:           tt.projectIntake,
+				},
+				workflowconfig.Workflow{Config: cfg},
+			)
+
+			for _, capability := range check.Capabilities.Capabilities {
+				if capability.Name != "intake.sources" {
+					continue
+				}
+				if capability.State != tt.wantState {
+					t.Fatalf("intake.sources state = %s, want %s", capability.State, tt.wantState)
+				}
+				if !strings.Contains(capability.Detail, tt.wantDetail) {
+					t.Fatalf("intake.sources detail = %q, want containing %q", capability.Detail, tt.wantDetail)
+				}
+				return
+			}
+			t.Fatal("intake.sources capability missing")
+		})
+	}
 }

--- a/internal/cli/doctor_capabilities_test.go
+++ b/internal/cli/doctor_capabilities_test.go
@@ -1,0 +1,210 @@
+package cli
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	workflowconfig "github.com/digitaldrywood/detent/internal/config"
+	globalconfig "github.com/digitaldrywood/detent/internal/config/global"
+	"github.com/digitaldrywood/detent/internal/intake"
+)
+
+func TestCheckDoctorCapabilities(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name           string
+		configure      func(*workflowconfig.Config)
+		sharedPrompt   string
+		effortGuidance bool
+		wantStates     map[string]doctorCapabilityState
+		wantDetails    map[string]string
+	}{
+		{
+			name: "fully configured project",
+			configure: func(cfg *workflowconfig.Config) {
+				cfg.Tracker.Kind = workflowconfig.TrackerGitHub
+				cfg.Tracker.GitHubStatusSource = workflowconfig.GitHubStatusSourceLabel
+				cfg.BacklogAdmission.Enabled = true
+				cfg.BacklogAdmission.CriteriaSection = "Admission Criteria"
+				cfg.BacklogAdmission.Sources.Untracked = true
+				cfg.BacklogAdmission.ExcludeLabels = []string{"skip-admission"}
+				cfg.Routines = []workflowconfig.Routine{{Name: "dependency-audit"}}
+				cfg.Intake.Sources = []intake.Source{{Name: "alerts"}}
+				cfg.Agent.Followups.Enabled = true
+				cfg.Agent.AutoPromote.Enabled = true
+				cfg.Retro.Enabled = true
+				cfg.Release.Enabled = true
+			},
+			sharedPrompt:   "## Admission Criteria\n\n- **Alignment** — Prefer operator-visible work.\n",
+			effortGuidance: true,
+			wantStates: map[string]doctorCapabilityState{
+				"backlog_admission":                   doctorCapabilityConfigured,
+				"backlog_admission.sources.untracked": doctorCapabilityConfigured,
+				"backlog_admission.exclude_labels":    doctorCapabilityConfigured,
+				"routines":                            doctorCapabilityConfigured,
+				"intake.sources":                      doctorCapabilityConfigured,
+				"agent.followups":                     doctorCapabilityConfigured,
+				"agent.auto_promote":                  doctorCapabilityConfigured,
+				"retro":                               doctorCapabilityConfigured,
+				"release":                             doctorCapabilityConfigured,
+				"detent-agent effort rubric":          doctorCapabilityConfigured,
+			},
+		},
+		{
+			name: "minimally configured project",
+			configure: func(cfg *workflowconfig.Config) {
+				cfg.Tracker.Kind = workflowconfig.TrackerGitHub
+				cfg.Tracker.GitHubStatusSource = workflowconfig.GitHubStatusSourceLabel
+				cfg.Agent.Followups.Enabled = false
+			},
+			sharedPrompt: "# Workflow\n",
+			wantStates: map[string]doctorCapabilityState{
+				"backlog_admission":                   doctorCapabilityUnavailable,
+				"backlog_admission.sources.untracked": doctorCapabilityUnused,
+				"backlog_admission.exclude_labels":    doctorCapabilityUnused,
+				"routines":                            doctorCapabilityUnused,
+				"intake.sources":                      doctorCapabilityUnused,
+				"agent.followups":                     doctorCapabilityUnused,
+				"agent.auto_promote":                  doctorCapabilityUnused,
+				"retro":                               doctorCapabilityUnused,
+				"release":                             doctorCapabilityUnused,
+				"detent-agent effort rubric":          doctorCapabilityUnused,
+			},
+			wantDetails: map[string]string{
+				"backlog_admission":          "criteria_section to a shared WORKFLOW.md heading",
+				"routines":                   "recurring agent prompts",
+				"intake.sources":             "external webhook or scheduled signals",
+				"agent.followups":            "meaningful out-of-scope discoveries",
+				"agent.auto_promote":         "review-ready work automatically",
+				"retro":                      "recurring failure telemetry",
+				"release":                    "cut releases automatically",
+				"detent-agent effort rubric": "deliberate reasoning effort",
+			},
+		},
+		{
+			name: "project v2 unavailable capabilities",
+			configure: func(cfg *workflowconfig.Config) {
+				cfg.Tracker.Kind = workflowconfig.TrackerGitHub
+				cfg.Tracker.GitHubStatusSource = workflowconfig.GitHubStatusSourceProjectV2
+				cfg.Agent.Followups.Enabled = false
+				cfg.BacklogAdmission.CriteriaSection = "Admission Criteria"
+			},
+			sharedPrompt: "## Admission Criteria\n\n- **Alignment** — Prefer operator-visible work.\n",
+			wantStates: map[string]doctorCapabilityState{
+				"backlog_admission":                   doctorCapabilityUnused,
+				"backlog_admission.sources.untracked": doctorCapabilityUnavailable,
+				"backlog_admission.exclude_labels":    doctorCapabilityUnavailable,
+				"routines":                            doctorCapabilityUnused,
+				"intake.sources":                      doctorCapabilityUnused,
+				"agent.followups":                     doctorCapabilityUnused,
+				"agent.auto_promote":                  doctorCapabilityUnused,
+				"retro":                               doctorCapabilityUnused,
+				"release":                             doctorCapabilityUnused,
+				"detent-agent effort rubric":          doctorCapabilityUnused,
+			},
+			wantDetails: map[string]string{
+				"backlog_admission.sources.untracked": "project_v2 status cannot identify untracked",
+				"backlog_admission.exclude_labels":    "first 20 issue labels",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			root := t.TempDir()
+			if tt.effortGuidance {
+				if err := os.WriteFile(filepath.Join(root, "AGENTS.md"), []byte("Use a detent-agent effort rubric for every issue.\n"), 0o600); err != nil {
+					t.Fatalf("WriteFile() error = %v", err)
+				}
+			}
+			cfg := workflowconfig.Default()
+			cfg.Workspace.Root = root
+			tt.configure(&cfg)
+			check := checkDoctorCapabilities(
+				globalconfig.Project{ID: "alpha", Workdir: root},
+				workflowconfig.Workflow{Config: cfg, SharedPrompt: tt.sharedPrompt},
+			)
+
+			if check.Status != doctorOK {
+				t.Fatalf("Status = %s, want %s", check.Status, doctorOK)
+			}
+			if check.Capabilities == nil {
+				t.Fatal("Capabilities = nil")
+			}
+			if len(check.Capabilities.Capabilities) != len(tt.wantStates) {
+				t.Fatalf("capabilities len = %d, want %d", len(check.Capabilities.Capabilities), len(tt.wantStates))
+			}
+			for _, capability := range check.Capabilities.Capabilities {
+				wantState, ok := tt.wantStates[capability.Name]
+				if !ok {
+					t.Errorf("unexpected capability %q", capability.Name)
+					continue
+				}
+				if capability.State != wantState {
+					t.Errorf("%s state = %s, want %s", capability.Name, capability.State, wantState)
+				}
+				if wantDetail := tt.wantDetails[capability.Name]; wantDetail != "" && !strings.Contains(capability.Detail, wantDetail) {
+					t.Errorf("%s detail = %q, want containing %q", capability.Name, capability.Detail, wantDetail)
+				}
+			}
+
+			report := doctorReport{Checks: []doctorCheck{check}, strict: true}
+			if report.hasExitFailure() {
+				t.Fatal("advisory capability report changed strict doctor exit status")
+			}
+			var pretty bytes.Buffer
+			if err := writeDoctorReport(&pretty, report); err != nil {
+				t.Fatalf("writeDoctorReport() error = %v", err)
+			}
+			for name, state := range tt.wantStates {
+				if !strings.Contains(pretty.String(), strings.ToUpper(string(state))+" "+name) {
+					t.Errorf("pretty report missing %s %s:\n%s", state, name, pretty.String())
+				}
+			}
+			raw, err := json.Marshal(check)
+			if err != nil {
+				t.Fatalf("json.Marshal() error = %v", err)
+			}
+			if !bytes.Contains(raw, []byte(`"capabilities"`)) || !bytes.Contains(raw, []byte(`"items"`)) {
+				t.Fatalf("JSON report missing structured capabilities: %s", raw)
+			}
+		})
+	}
+}
+
+func TestCheckDoctorCapabilitiesUsesProjectIntakeOverride(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	cfg := workflowconfig.Default()
+	cfg.Tracker.Kind = workflowconfig.TrackerGitHub
+	cfg.Tracker.GitHubStatusSource = workflowconfig.GitHubStatusSourceLabel
+	cfg.Intake.Sources = []intake.Source{{Name: "workflow-source"}}
+	check := checkDoctorCapabilities(
+		globalconfig.Project{
+			ID:               "alpha",
+			Workdir:          root,
+			IntakeConfigured: true,
+			Intake:           intake.Config{},
+		},
+		workflowconfig.Workflow{Config: cfg},
+	)
+
+	for _, capability := range check.Capabilities.Capabilities {
+		if capability.Name != "intake.sources" {
+			continue
+		}
+		if capability.State != doctorCapabilityUnused {
+			t.Fatalf("intake.sources state = %s, want %s", capability.State, doctorCapabilityUnused)
+		}
+		return
+	}
+	t.Fatal("intake.sources capability missing")
+}

--- a/internal/cli/doctor_project.go
+++ b/internal/cli/doctor_project.go
@@ -309,6 +309,8 @@ func checkDoctorProjectWithProgress(
 		}
 	}
 	checks = append(checks, workflowCheck)
+	setDoctorCurrentCheck("Project " + id + " capabilities")
+	checks = append(checks, checkDoctorCapabilities(project, workflow))
 	setDoctorCurrentCheck("Project " + id + " workflow source policy")
 	if sourcePolicyCheck, ok := checkDoctorWorkflowSourcePolicy(ctx, id, project, workflow.Config, projectSourceRoot(project, workflow.Config), deps); ok {
 		checks = append(checks, sourcePolicyCheck)
@@ -907,25 +909,19 @@ func checkDoctorIssueEffortGuidanceForSource(id string, project globalconfig.Pro
 
 func checkDoctorIssueEffortGuidance(id string, sourceRoot string) doctorCheck {
 	name := "Project " + id + " issue effort guidance"
-	paths := []string{"AGENTS.md", "CLAUDE.md"}
-	for _, path := range paths {
-		content, err := os.ReadFile(filepath.Join(sourceRoot, path))
-		if errors.Is(err, os.ErrNotExist) {
-			continue
+	path, err := findDoctorIssueEffortGuidance(sourceRoot)
+	if err != nil {
+		return doctorCheck{
+			Name:   name,
+			Status: doctorOK,
+			Detail: "skipped because " + err.Error(),
 		}
-		if err != nil {
-			return doctorCheck{
-				Name:   name,
-				Status: doctorOK,
-				Detail: fmt.Sprintf("skipped because %s could not be read: %v", path, err),
-			}
-		}
-		if strings.Contains(strings.ToLower(string(content)), "detent-agent") {
-			return doctorCheck{
-				Name:   name,
-				Status: doctorOK,
-				Detail: path + " mentions detent-agent effort guidance",
-			}
+	}
+	if path != "" {
+		return doctorCheck{
+			Name:   name,
+			Status: doctorOK,
+			Detail: path + " mentions detent-agent effort guidance",
 		}
 	}
 	return doctorCheck{

--- a/internal/cli/doctor_test.go
+++ b/internal/cli/doctor_test.go
@@ -1108,8 +1108,8 @@ func TestCheckDoctorProjects(t *testing.T) {
 				{ID: "alpha", Workflow: "WORKFLOW.md"},
 			},
 			workflow:   workflowconfig.Workflow{Config: disabledBudgetWorkflow},
-			wantStatus: []doctorStatus{doctorOK, doctorWarn, doctorOK, doctorWarn, doctorOK, doctorOK, doctorOK, doctorWarn, doctorOK},
-			wantDetail: []string{"is valid", "subscription billing is the default", "effective cross-session progress brake", "budget.enabled=false disables configured caps", "enabled=true provides prompt guidance", "validated 0 pinned Codex route model(s)", "is a git worktree", "contain no detent-agent guidance", "loaded=0; dropped=0"},
+			wantStatus: []doctorStatus{doctorOK, doctorOK, doctorWarn, doctorOK, doctorWarn, doctorOK, doctorOK, doctorOK, doctorWarn, doctorOK},
+			wantDetail: []string{"is valid", "advisory:", "subscription billing is the default", "effective cross-session progress brake", "budget.enabled=false disables configured caps", "enabled=true provides prompt guidance", "validated 0 pinned Codex route model(s)", "is a git worktree", "contain no detent-agent guidance", "loaded=0; dropped=0"},
 		},
 		{
 			name: "inherited spend breaker warns about billing ambiguity",
@@ -1117,8 +1117,8 @@ func TestCheckDoctorProjects(t *testing.T) {
 				{ID: "alpha", Workflow: "WORKFLOW.md"},
 			},
 			workflow:   workflowconfig.Workflow{Config: omittedBudgetWorkflow},
-			wantStatus: []doctorStatus{doctorOK, doctorWarn, doctorOK, doctorOK, doctorOK, doctorOK, doctorWarn, doctorOK},
-			wantDetail: []string{"is valid", "subscription billing is the default", "effective cross-session progress brake", "enabled=true provides prompt guidance", "validated 0 pinned Codex route model(s)", "is a git worktree", "contain no detent-agent guidance", "loaded=0; dropped=0"},
+			wantStatus: []doctorStatus{doctorOK, doctorOK, doctorWarn, doctorOK, doctorOK, doctorOK, doctorOK, doctorWarn, doctorOK},
+			wantDetail: []string{"is valid", "advisory:", "subscription billing is the default", "effective cross-session progress brake", "enabled=true provides prompt guidance", "validated 0 pinned Codex route model(s)", "is a git worktree", "contain no detent-agent guidance", "loaded=0; dropped=0"},
 		},
 		{
 			name: "source repo missing",
@@ -1127,8 +1127,8 @@ func TestCheckDoctorProjects(t *testing.T) {
 			},
 			workflow:   workflowconfig.Workflow{Config: validDoctorWorkflow("/repo")},
 			gitErr:     errors.New("not a git worktree"),
-			wantStatus: []doctorStatus{doctorOK, doctorOK, doctorOK, doctorOK, doctorFail, doctorOK, doctorWarn},
-			wantDetail: []string{"is valid", "effective cross-session progress brake", "enabled=true provides prompt guidance", "validated 0 pinned Codex route model(s)", "not a git worktree", "skipped because source repository is unavailable locally", "skipped because source repository is unavailable locally"},
+			wantStatus: []doctorStatus{doctorOK, doctorOK, doctorOK, doctorOK, doctorOK, doctorFail, doctorOK, doctorWarn},
+			wantDetail: []string{"is valid", "advisory:", "effective cross-session progress brake", "enabled=true provides prompt guidance", "validated 0 pinned Codex route model(s)", "not a git worktree", "skipped because source repository is unavailable locally", "skipped because source repository is unavailable locally"},
 		},
 		{
 			name: "all progress brakes disabled",
@@ -1136,8 +1136,8 @@ func TestCheckDoctorProjects(t *testing.T) {
 				{ID: "alpha", Workflow: "WORKFLOW.md"},
 			},
 			workflow:   workflowconfig.Workflow{Config: disabledProgressWorkflow},
-			wantStatus: []doctorStatus{doctorOK, doctorWarn, doctorWarn, doctorOK, doctorOK, doctorOK, doctorWarn, doctorOK},
-			wantDetail: []string{"is valid", "billing_mode=subscription", "no effective cross-session progress brake", "enabled=true provides prompt guidance", "validated 0 pinned Codex route model(s)", "is a git worktree", "contain no detent-agent guidance", "loaded=0; dropped=0"},
+			wantStatus: []doctorStatus{doctorOK, doctorOK, doctorWarn, doctorWarn, doctorOK, doctorOK, doctorOK, doctorWarn, doctorOK},
+			wantDetail: []string{"is valid", "advisory:", "billing_mode=subscription", "no effective cross-session progress brake", "enabled=true provides prompt guidance", "validated 0 pinned Codex route model(s)", "is a git worktree", "contain no detent-agent guidance", "loaded=0; dropped=0"},
 		},
 		{
 			name: "workflow and source repo valid",
@@ -1145,8 +1145,8 @@ func TestCheckDoctorProjects(t *testing.T) {
 				{ID: "alpha", Workflow: "WORKFLOW.md"},
 			},
 			workflow:   workflowconfig.Workflow{Config: validDoctorWorkflow("/repo")},
-			wantStatus: []doctorStatus{doctorOK, doctorOK, doctorOK, doctorOK, doctorOK, doctorWarn, doctorOK},
-			wantDetail: []string{"is valid", "effective cross-session progress brake", "enabled=true provides prompt guidance", "validated 0 pinned Codex route model(s)", "is a git worktree", "contain no detent-agent guidance", "loaded=0; dropped=0"},
+			wantStatus: []doctorStatus{doctorOK, doctorOK, doctorOK, doctorOK, doctorOK, doctorOK, doctorWarn, doctorOK},
+			wantDetail: []string{"is valid", "advisory:", "effective cross-session progress brake", "enabled=true provides prompt guidance", "validated 0 pinned Codex route model(s)", "is a git worktree", "contain no detent-agent guidance", "loaded=0; dropped=0"},
 		},
 	}
 
@@ -3210,7 +3210,7 @@ func TestCheckDoctorProjectsExpandsSourceRootBeforeGit(t *testing.T) {
 	if gotPath != wantPath {
 		t.Fatalf("git path = %q, want %q", gotPath, wantPath)
 	}
-	if len(checks) != 7 || checks[4].Status != doctorOK || checks[4].Name != "Project alpha source repo" {
+	if len(checks) != 8 || checks[5].Status != doctorOK || checks[5].Name != "Project alpha source repo" {
 		t.Fatalf("checks = %#v, want source repo OK", checks)
 	}
 }
@@ -5632,7 +5632,7 @@ func TestDoctorProjectCheckJobTimeoutPreservesCompletedChecks(t *testing.T) {
 		blockDependency bool
 	}{
 		{name: "GitHub readiness", current: "GitHub readiness", lastCompleted: "Project alpha skills"},
-		{name: "local workflow overlay", current: "local workflow overlay", lastCompleted: "Project alpha workflow", blockOverlay: true},
+		{name: "local workflow overlay", current: "local workflow overlay", lastCompleted: "Project alpha capabilities", blockOverlay: true},
 		{name: "dependency auto-unblock", current: "dependency auto-unblock", lastCompleted: "Project alpha repository merge policy", blockDependency: true},
 	}
 


### PR DESCRIPTION
## Summary

- add an advisory per-project capability inventory to `detent doctor`
- distinguish configured, unused, and tracker-unavailable capabilities with operator benefits and prerequisites
- emit the capability inventory in both pretty and structured JSON output without changing doctor exit behavior
- cover fully configured, minimal, ProjectV2-unavailable, and project intake override scenarios

Fixes #1687

## UI Surface Contract

- [x] N/A, or the linked issue explicitly authorizes any high-impact UI surface, layout, density, first-viewport, or responsive visibility tradeoff.
- [x] Persistent top-of-screen messaging is explicitly authorized by the issue, or this PR does not add it.
- [x] Visual changes to primary operator screens include screenshot or browser verification below.

No primary operator UI surface changes; this is CLI pretty/JSON output only.

## Test Plan

- [x] `go test ./internal/cli -run '^(TestCheckDoctorCapabilities|TestCheckDoctorCapabilitiesUsesProjectIntakeOverride|TestCheckDoctorProjects|TestCheckDoctorProjectsExpandsSourceRootBeforeGit|TestDoctorProjectCheckJobTimeoutPreservesCompletedChecks|TestCheckDoctorIssueEffortGuidance)$' -count=1`
- [x] `go test -race ./internal/cli -run '^(TestCheckDoctorCapabilities|TestCheckDoctorCapabilitiesUsesProjectIntakeOverride|TestCheckDoctorProjects|TestCheckDoctorProjectsExpandsSourceRootBeforeGit|TestDoctorProjectCheckJobTimeoutPreservesCompletedChecks|TestCheckDoctorIssueEffortGuidance)$' -count=1`
- [x] `make check CHECK_LOCK_WAIT=30m`
