### PR TITLE
feat(routines): gate proposal classes safely

### DIFF
--- a/config.reference.yaml
+++ b/config.reference.yaml
@@ -1042,6 +1042,10 @@
 #     schedule: null
 #     # routines[].prompt | type: string | default: none | required: Conditional | validation: is required
 #     prompt: null
+#     # routines[].target_state | type: string | default: "Todo" when configured | required: No | validation: must name a configured workflow state
+#     target_state: "Todo"
+#     # routines[].labels | type: list<string> | default: [] | required: Conditional | validation: labels must not be blank
+#     labels: []
 #     # routines[].max_findings_per_run | type: integer | default: 3 when configured | required: No | validation: must be greater than 0
 #     max_findings_per_run: 3
 #     # routines[].max_open_findings | type: integer | default: 10 when configured | required: No | validation: must be greater than 0
@@ -1086,5 +1090,7 @@
 #   proposal_expiry_days: 7
 #   # backlog_admission.auto_admit | type: boolean | default: false | required: No | validation: None
 #   auto_admit: false
+#   # backlog_admission.auto_admit_by_label | type: mapping<string, boolean> | default: {} | required: No | validation: None
+#   auto_admit_by_label: {}
 #   # backlog_admission.auto_admit_min_confidence | type: number | default: 0.9 | required: No | validation: None
 #   auto_admit_min_confidence: 0.9

--- a/docs/config.md
+++ b/docs/config.md
@@ -462,6 +462,7 @@ rendering and fails on drift.
 | `backlog_admission.authors.allow` | `list<string>` | `[]` | No | None |
 | `backlog_admission.authors.allow_association` | `list<string>` | `[]` | No | requires author association, but tracker.kind memory cannot supply it<br>values must be one of OWNER, MEMBER, COLLABORATOR, CONTRIBUTOR, FIRST_TIME_CONTRIBUTOR, NONE |
 | `backlog_admission.auto_admit` | `boolean` | `false` | No | None |
+| `backlog_admission.auto_admit_by_label` | `mapping<string, boolean>` | `{}` | No | None |
 | `backlog_admission.auto_admit_min_confidence` | `number` | `0.9` | No | None |
 | `backlog_admission.criteria_section` | `string` | `none` | Conditional | is required |
 | `backlog_admission.effort_section` | `string` | `none` | Conditional | is required when require_effort is true |
@@ -613,11 +614,13 @@ rendering and fails on drift.
 | `retro.single_occurrence_severity` | `string` | `"critical" when configured` | No | must be one of info, warning, high, critical |
 | `retro.target_state` | `string` | `"Backlog" when configured` | No | must name a configured tracker state |
 | `routines` | `list<object>` | `[]` | No | None |
+| `routines[].labels` | `list<string>` | `[]` | Conditional | labels must not be blank |
 | `routines[].max_findings_per_run` | `integer` | `3 when configured` | No | must be greater than 0 |
 | `routines[].max_open_findings` | `integer` | `10 when configured` | No | must be greater than 0 |
 | `routines[].name` | `string` | `none` | No | must be a sanitized label containing only letters, numbers, dots, underscores, or hyphens |
 | `routines[].prompt` | `string` | `none` | Conditional | is required |
 | `routines[].schedule` | `string` | `none` | Conditional | is required<br>must be a valid five-field cron expression |
+| `routines[].target_state` | `string` | `"Todo" when configured` | No | must name a configured workflow state |
 | `server` | `object` | `see child fields` | No | None |
 | `server.board_snapshot_stale_after_seconds` | `integer` | `900` | No | must be greater than 0 |
 | `server.host` | `string` | `"127.0.0.1"` | No | is required |

--- a/docs/scheduled-routines.md
+++ b/docs/scheduled-routines.md
@@ -70,6 +70,8 @@ instead of built-in Go behavior.
 routines:
   - name: dependency-audit
     schedule: "0 3 * * 1"
+    target_state: Todo
+    labels: [dependency, bug]
     max_findings_per_run: 3
     max_open_findings: 10
     prompt: |
@@ -81,6 +83,13 @@ routines:
     prompt: |
       Inspect the configured test history and repository guidance for repeatable
       flaky-test findings. Ignore isolated failures without supporting evidence.
+  - name: feature-sweep
+    schedule: "0 5 * * 1"
+    target_state: Backlog
+    labels: [feature, requires-human-review]
+    prompt: |
+      Propose only features supported by the configured product-intent source.
+      Label each proposal feature and requires-human-review.
 ```
 
 Names are normalized labels and must be unique. Schedules are standard
@@ -97,16 +106,29 @@ Both values must be greater than zero. These limits are enforced after proposal
 validation and deduplication and immediately before issue creation, regardless
 of what the routine prompt asks the agent to do.
 
+`target_state` names any configured workflow state and defaults to `Todo`.
+`labels` is the allowlist for labels requested by that routine's agent
+proposals. Detent normalizes and deduplicates the configured labels, intersects
+each proposal's labels with that allowlist, and drops labels the agent was not
+authorized to grant itself. An empty allowlist therefore permits no
+agent-supplied labels. A routine that targets `Todo` retains the existing
+`detent:todo` filing behavior when both fields are omitted.
+
 When a routine is enabled or its schedule changes, its first run is the next
 scheduled occurrence; Detent does not replay missed occurrences. Each run uses
 a fresh read-only agent session. The agent proposes zero or more findings with
-a stable `dedup_key`, title, and issue body. Detent validates those proposals,
-files accepted findings with the `detent:todo` label in `Todo`, and leaves
-normal onboarding to the existing board loop.
+a stable `dedup_key`, title, issue body, and optional labels. Detent validates
+those proposals, files accepted findings in the configured target state with
+only allowed labels, and leaves normal onboarding to the existing board loop.
 
-Routine findings bypass Backlog and backlog admission, including admission's
-author allowlist and proposal decision step. They become dispatchable Todo work
-as soon as Detent files them.
+The default `Todo` target bypasses Backlog and backlog admission, including
+admission's author allowlist and proposal decision step, exactly as before.
+A routine targeting `Backlog` instead enters the normal admission path. For a
+feature routine, allowlist the project's `agent.auto_promote.optout_label`,
+require proposals to request it, and keep the admission default propose-only so
+an omitted or unknown label also remains held. The opt-out label stays on an
+accepted issue and makes `agent.auto_promote` wait for human review later in the
+delivery flow.
 
 Filed issue bodies carry a project/routine/key fingerprint. A later run with the
 same fingerprint skips filing while the matching issue is open, including when
@@ -157,6 +179,9 @@ backlog_admission:
   max_open_proposals: 10
   proposal_expiry_days: 7
   auto_admit: false
+  auto_admit_by_label:
+    evidenced-defect: true
+    requires-human-review: false
   auto_admit_min_confidence: 0.90
 ```
 
@@ -171,6 +196,24 @@ Sentry or Dependabot even when no repository labeling action runs. It is
 unsupported for `project_v2`, `issue_field`, `github_local`, and non-GitHub
 trackers because those status models do not define the same missing-label
 condition.
+
+`auto_admit` remains the project default and accepts the same boolean form as
+before. `auto_admit_by_label` optionally overrides that default for issues
+carrying a configured label. A matching `true` rule enables automatic admission
+when the proposal also meets `auto_admit_min_confidence`; a matching `false`
+rule always holds the proposal regardless of confidence. If several rules
+match, any `false` rule wins. Issues with only unknown labels use the project
+default. Label policies require a tracker mode that supplies complete issue
+labels, so GitHub ProjectV2 rejects this configuration rather than evaluating a
+partial label set.
+
+Use automatic admission only for classes whose evidence is contained in the
+artifact and can be falsified during implementation, such as reproducible bugs
+or bounded technical debt. Keep feature and product-direction classes
+propose-only: their legitimacy depends on user needs, roadmap, support signal,
+or other product intent that source code and model confidence cannot establish.
+The safest mixed policy is `auto_admit: false` with explicit `true` overrides
+for evidenced classes and explicit `false` rules for product-decision labels.
 
 Admission reads every enabled selector through the candidate-reader contract.
 The tracker declares selector support, reads pages inside a hard per-run bound,

--- a/internal/admission/manager.go
+++ b/internal/admission/manager.go
@@ -571,7 +571,7 @@ func (m *Manager) reconcileOpenProposals(
 			}
 			continue
 		}
-		if !decided && autoAdmitProposal(settings.Config, settings.Criteria, proposal) {
+		if !decided && autoAdmitProposal(settings.Config, settings.Criteria, proposal, issue.Labels) {
 			recovered, err := m.recoverAutomaticAdmission(ctx, settings, issue, proposal)
 			if err != nil {
 				return commentsRemaining, autoAdmitsRemaining, err
@@ -650,7 +650,7 @@ func (m *Manager) reconcileOpenProposals(
 			}
 			continue
 		}
-		if !decided && autoAdmitProposal(settings.Config, settings.Criteria, proposal) {
+		if !decided && autoAdmitProposal(settings.Config, settings.Criteria, proposal, issue.Labels) {
 			if !autoAdmitCandidateEligible(issue, settings.Config) {
 				decision := automaticAdmissionDecision(settings.Issues, proposal, at)
 				decision.Outcome = admissionmodel.ProposalSuperseded
@@ -909,7 +909,7 @@ func (m *Manager) executeProposals(
 			}
 			commentsRemaining--
 		}
-		if autoAdmitsRemaining > 0 && autoAdmitProposal(settings.Config, settings.Criteria, proposal) {
+		if autoAdmitsRemaining > 0 && autoAdmitProposal(settings.Config, settings.Criteria, proposal, current.Labels) {
 			if err := m.admitProposal(
 				ctx,
 				settings,
@@ -938,7 +938,7 @@ func (m *Manager) commentProposal(
 		proposalComment(
 			proposal,
 			settings.Criteria,
-			autoAdmitProposal(settings.Config, settings.Criteria, proposal),
+			autoAdmitProposal(settings.Config, settings.Criteria, proposal, issue.Labels),
 			untracked,
 			issue.State,
 		),
@@ -965,7 +965,8 @@ func (m *Manager) admitProposal(
 	current, found := issueMap(issues)[proposal.IssueID]
 	eligible := found && admissionSourceEligible(current, settings.Config)
 	if decision.Automatic {
-		eligible = found && autoAdmitCandidateEligible(current, settings.Config)
+		eligible = found && autoAdmitCandidateEligible(current, settings.Config) &&
+			autoAdmitProposal(settings.Config, settings.Criteria, proposal, current.Labels)
 	}
 	if !eligible {
 		decision.Outcome = admissionmodel.ProposalSuperseded
@@ -1157,8 +1158,9 @@ func autoAdmitProposal(
 	cfg config.BacklogAdmission,
 	criteria config.AdmissionCriteria,
 	proposal admissionmodel.Proposal,
+	labels []string,
 ) bool {
-	return cfg.AutoAdmit &&
+	return cfg.AutoAdmitForLabels(labels) &&
 		proposal.Confidence >= cfg.AutoAdmitMinConfidence &&
 		len(failedAdmissionDimensions(proposal.Findings, criteria)) == 0
 }
@@ -1761,6 +1763,7 @@ func cloneSettings(settings Settings) Settings {
 	settings.Config.Sources.States = append([]string(nil), settings.Config.Sources.States...)
 	settings.Config.Sources.Labels = append([]string(nil), settings.Config.Sources.Labels...)
 	settings.Config.ExcludeLabels = append([]string(nil), settings.Config.ExcludeLabels...)
+	settings.Config.AutoAdmitByLabel = cloneLabelPolicies(settings.Config.AutoAdmitByLabel)
 	settings.Config.Authors.Allow = append([]string(nil), settings.Config.Authors.Allow...)
 	settings.Config.Authors.AllowAssociation = append([]string(nil), settings.Config.Authors.AllowAssociation...)
 	settings.Criteria.Dimensions = append([]config.AdmissionDimension(nil), settings.Criteria.Dimensions...)
@@ -1770,6 +1773,14 @@ func cloneSettings(settings Settings) Settings {
 	settings.TerminalStates = append([]string(nil), settings.TerminalStates...)
 	settings.ProjectCandidate.ActiveHours = settings.ProjectCandidate.ActiveHours.Normalize()
 	return settings
+}
+
+func cloneLabelPolicies(policies map[string]bool) map[string]bool {
+	out := make(map[string]bool, len(policies))
+	for label, enabled := range policies {
+		out[label] = enabled
+	}
+	return out
 }
 
 func normalizeStrings(values []string) []string {

--- a/internal/admission/manager_test.go
+++ b/internal/admission/manager_test.go
@@ -724,6 +724,8 @@ func TestManagerAutoAdmissionModes(t *testing.T) {
 	tests := []struct {
 		name       string
 		enabled    bool
+		policies   map[string]bool
+		labels     []string
 		confidence float64
 		wantState  string
 		wantStatus admissionmodel.ProposalStatus
@@ -748,12 +750,38 @@ func TestManagerAutoAdmissionModes(t *testing.T) {
 			wantState:  "Todo",
 			wantStatus: admissionmodel.ProposalAccepted,
 		},
+		{
+			name:       "defect class is auto-admitted",
+			policies:   map[string]bool{"defect": true},
+			labels:     []string{"defect"},
+			confidence: 1,
+			wantState:  "Todo",
+			wantStatus: admissionmodel.ProposalAccepted,
+		},
+		{
+			name:       "feature class is proposed and held regardless of confidence",
+			enabled:    true,
+			policies:   map[string]bool{"feature": false},
+			labels:     []string{"feature"},
+			confidence: 1,
+			wantState:  "Backlog",
+			wantStatus: admissionmodel.ProposalOpen,
+		},
+		{
+			name:       "unknown label falls back to project default",
+			policies:   map[string]bool{"defect": true},
+			labels:     []string{"docs"},
+			confidence: 1,
+			wantState:  "Backlog",
+			wantStatus: admissionmodel.ProposalOpen,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
 			issue := admissionIssueFixture("issue-1", "DD-1", 1, now)
+			issue.Labels = append([]string(nil), tt.labels...)
 			tracker := memory.New(memory.Config{
 				Issues:   []connector.Issue{issue},
 				Stateful: true,
@@ -763,6 +791,7 @@ func TestManagerAutoAdmissionModes(t *testing.T) {
 			agent := &scriptedAdmissionRunner{propose: proposeEveryCandidateAtConfidence(tt.confidence)}
 			settings := admissionTestSettings(tracker, agent)
 			settings.Config.AutoAdmit = tt.enabled
+			settings.Config.AutoAdmitByLabel = tt.policies
 			settings.Config.AutoAdmitMinConfidence = 0.9
 			manager := newAdmissionTestManager(t, settings, backend, func() time.Time { return now })
 
@@ -857,6 +886,45 @@ Child issues decompose the implementation work. Marketing and operations staff m
 		if !strings.Contains(comment, want) {
 			t.Fatalf("proposal comment missing %q: %s", want, comment)
 		}
+	}
+}
+
+func TestManagerAutomaticAdmissionRechecksLabelPolicy(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 7, 29, 12, 0, 0, 0, time.UTC)
+	issue := admissionIssueFixture("issue-1", "DD-1", 1, now)
+	issue.Labels = []string{"feature"}
+	tracker := memory.New(memory.Config{Issues: []connector.Issue{issue}, Stateful: true, Now: func() time.Time { return now }})
+	backend := openManagerTestStore(t)
+	settings := admissionTestSettings(tracker, &scriptedAdmissionRunner{})
+	settings.Config.AutoAdmit = true
+	settings.Config.AutoAdmitByLabel = map[string]bool{"feature": false}
+	settings.Config.AutoAdmitMinConfidence = 0.9
+	manager := newAdmissionTestManager(t, settings, backend, func() time.Time { return now })
+	proposal := admissionTestProposalForIssue("proposal-1", issue, now)
+	proposal.Confidence = 1
+	if created, err := backend.CreateAdmissionProposal(t.Context(), proposal); err != nil || !created {
+		t.Fatalf("CreateAdmissionProposal() = %t, %v", created, err)
+	}
+
+	if err := manager.admitProposal(
+		t.Context(),
+		settings,
+		connector.Issue{ID: issue.ID, State: "Backlog"},
+		proposal,
+		automaticAdmissionDecision(tracker, proposal, now),
+	); err != nil {
+		t.Fatalf("admitProposal() error = %v", err)
+	}
+	issues, err := tracker.FetchIssueStatesByIDs(t.Context(), []string{issue.ID})
+	if err != nil || len(issues) != 1 || issues[0].State != "Backlog" {
+		t.Fatalf("issue state = %#v, %v", issues, err)
+	}
+	history, err := backend.AdmissionProposalHistory(t.Context(), "detent", issue.ID)
+	if err != nil || len(history) != 1 || history[0].Status != admissionmodel.ProposalSuperseded ||
+		history[0].ResolutionReason != admissionResolutionAutoAdmitIneligible {
+		t.Fatalf("AdmissionProposalHistory() = %#v, %v", history, err)
 	}
 }
 

--- a/internal/config/admission.go
+++ b/internal/config/admission.go
@@ -43,6 +43,7 @@ type BacklogAdmission struct {
 	MaxOpenProposals       int                     `yaml:"max_open_proposals"`
 	ProposalExpiryDays     int                     `yaml:"proposal_expiry_days"`
 	AutoAdmit              bool                    `yaml:"auto_admit"`
+	AutoAdmitByLabel       map[string]bool         `yaml:"auto_admit_by_label,omitempty"`
 	AutoAdmitMinConfidence float64                 `yaml:"auto_admit_min_confidence"`
 }
 
@@ -92,6 +93,7 @@ func (a *BacklogAdmission) Normalize() {
 	a.CriteriaSection = strings.TrimSpace(a.CriteriaSection)
 	a.EffortSection = strings.TrimSpace(a.EffortSection)
 	a.ExcludeLabels = normalizeLabels(a.ExcludeLabels)
+	a.AutoAdmitByLabel = normalizeAdmissionLabelPolicies(a.AutoAdmitByLabel)
 	a.Authors.Allow = normalizeAdmissionAuthors(a.Authors.Allow)
 	a.Authors.AllowAssociation = normalizeAdmissionAssociations(a.Authors.AllowAssociation)
 }
@@ -138,8 +140,14 @@ func (a BacklogAdmission) Validate(prefix string, states []string, tracker Track
 	validatePositive(prefix+".max_proposals_per_run", a.MaxProposalsPerRun, &problems)
 	validatePositive(prefix+".max_open_proposals", a.MaxOpenProposals, &problems)
 	validatePositive(prefix+".proposal_expiry_days", a.ProposalExpiryDays, &problems)
-	if a.AutoAdmit && (a.AutoAdmitMinConfidence < 0 || a.AutoAdmitMinConfidence > 1) {
+	if a.autoAdmitEnabled() && (a.AutoAdmitMinConfidence < 0 || a.AutoAdmitMinConfidence > 1) {
 		problems = append(problems, prefix+".auto_admit_min_confidence must be between 0 and 1")
+	}
+	for label := range a.AutoAdmitByLabel {
+		if strings.TrimSpace(label) == "" {
+			problems = append(problems, prefix+".auto_admit_by_label labels must not be blank")
+			break
+		}
 	}
 	capabilities := connector.CandidateCapabilitiesFor(connector.Backend(tracker.Kind), tracker.GitHubStatusSource)
 	for index, association := range a.Authors.AllowAssociation {
@@ -192,6 +200,9 @@ func (a BacklogAdmission) Validate(prefix string, states []string, tracker Track
 	if len(a.ExcludeLabels) > 0 && tracker.Kind == TrackerGitHub && tracker.GitHubStatusSource == GitHubStatusSourceProjectV2 {
 		problems = append(problems, prefix+".exclude_labels requires complete issue labels, but tracker.kind github with github_status_source project_v2 fetches only the first 20 labels")
 	}
+	if len(a.AutoAdmitByLabel) > 0 && tracker.Kind == TrackerGitHub && tracker.GitHubStatusSource == GitHubStatusSourceProjectV2 {
+		problems = append(problems, prefix+".auto_admit_by_label requires complete issue labels, but tracker.kind github with github_status_source project_v2 fetches only the first 20 labels")
+	}
 	if a.Sources.Untracked && !capabilities.Supports(connector.CandidateSelectorUntracked) {
 		gap := prefix + ".sources.untracked requires candidate selector untracked, but tracker.kind " + tracker.Kind
 		switch tracker.Kind {
@@ -206,6 +217,36 @@ func (a BacklogAdmission) Validate(prefix string, states []string, tracker Track
 		problems = append(problems, gap)
 	}
 	return problems
+}
+
+func (a BacklogAdmission) AutoAdmitForLabels(labels []string) bool {
+	matched := false
+	for _, label := range labels {
+		value, ok := a.AutoAdmitByLabel[normalizeLabel(label)]
+		if !ok {
+			continue
+		}
+		if !value {
+			return false
+		}
+		matched = true
+	}
+	if matched {
+		return true
+	}
+	return a.AutoAdmit
+}
+
+func (a BacklogAdmission) autoAdmitEnabled() bool {
+	if a.AutoAdmit {
+		return true
+	}
+	for _, enabled := range a.AutoAdmitByLabel {
+		if enabled {
+			return true
+		}
+	}
+	return false
 }
 
 func BacklogAdmissionWarnings(admission BacklogAdmission, tracker Tracker) []string {
@@ -235,6 +276,18 @@ func normalizeAdmissionSourceLabels(labels []string) []string {
 		}
 	}
 	return out
+}
+
+func normalizeAdmissionLabelPolicies(policies map[string]bool) map[string]bool {
+	normalized := make(map[string]bool, len(policies))
+	for label, enabled := range policies {
+		label = normalizeLabel(label)
+		current, exists := normalized[label]
+		if !exists || current {
+			normalized[label] = enabled
+		}
+	}
+	return normalized
 }
 
 func BacklogAdmissionPublicExposureWarning(admission BacklogAdmission, visibility string) string {

--- a/internal/config/admission_test.go
+++ b/internal/config/admission_test.go
@@ -36,6 +36,9 @@ backlog_admission:
   max_open_proposals: 8
   proposal_expiry_days: 5
   auto_admit: true
+  auto_admit_by_label:
+    Defect: true
+    Requires-Human-Review: false
   auto_admit_min_confidence: 0.95
 ---
 ## Admission criteria
@@ -63,6 +66,9 @@ backlog_admission:
 		!got.AutoAdmit || got.AutoAdmitMinConfidence != 0.95 || got.Sources.Untracked ||
 		!got.RequireEffort || got.EffortSection != "Issue effort selection" {
 		t.Fatalf("BacklogAdmission = %#v", got)
+	}
+	if len(got.AutoAdmitByLabel) != 2 || !got.AutoAdmitByLabel["defect"] || got.AutoAdmitByLabel["requires-human-review"] {
+		t.Fatalf("AutoAdmitByLabel = %#v", got.AutoAdmitByLabel)
 	}
 	if len(got.Sources.Labels) != 1 || got.Sources.Labels[0] != "sentry" ||
 		len(got.ExcludeLabels) != 1 || got.ExcludeLabels[0] != "skip" ||
@@ -137,6 +143,16 @@ func TestBacklogAdmissionValidate(t *testing.T) {
 			cfg.AutoAdmit = true
 			cfg.AutoAdmitMinConfidence = 1.1
 		}, want: "auto_admit_min_confidence must be between 0 and 1"},
+		{name: "label auto admit confidence outside range", tracker: Tracker{Kind: TrackerGitHub}, mutate: func(cfg *BacklogAdmission) {
+			cfg.AutoAdmitByLabel = map[string]bool{"defect": true}
+			cfg.AutoAdmitMinConfidence = -0.1
+		}, want: "auto_admit_min_confidence must be between 0 and 1"},
+		{name: "blank auto admit label", tracker: Tracker{Kind: TrackerGitHub}, mutate: func(cfg *BacklogAdmission) {
+			cfg.AutoAdmitByLabel = map[string]bool{" ": false}
+		}, want: "auto_admit_by_label labels must not be blank"},
+		{name: "project v2 label policy", tracker: Tracker{Kind: TrackerGitHub, GitHubStatusSource: GitHubStatusSourceProjectV2}, mutate: func(cfg *BacklogAdmission) {
+			cfg.AutoAdmitByLabel = map[string]bool{"feature": false}
+		}, want: "auto_admit_by_label requires complete issue labels"},
 		{name: "linear", tracker: Tracker{Kind: TrackerLinear}, want: "FetchIssuesByStates is not implemented"},
 		{name: "unsupported github source", tracker: Tracker{Kind: TrackerGitHub, GitHubStatusSource: "milestone"}, want: "tracker.kind github with github_status_source milestone does not declare it"},
 		{name: "unsupported tracker", tracker: Tracker{Kind: "gitlab"}, want: "tracker.kind gitlab does not declare it"},
@@ -163,6 +179,34 @@ func TestBacklogAdmissionValidate(t *testing.T) {
 			}
 			if tt.want != "" && !strings.Contains(got, tt.want) {
 				t.Fatalf("Validate() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestBacklogAdmissionAutoAdmitForLabels(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		fallback bool
+		policies map[string]bool
+		labels   []string
+		want     bool
+	}{
+		{name: "defect override admits", policies: map[string]bool{"defect": true}, labels: []string{"Defect"}, want: true},
+		{name: "feature override holds", fallback: true, policies: map[string]bool{"feature": false}, labels: []string{"feature"}},
+		{name: "propose-only wins over admit class", fallback: true, policies: map[string]bool{"defect": true, "feature": false}, labels: []string{"defect", "feature"}},
+		{name: "unknown label uses enabled default", fallback: true, policies: map[string]bool{"defect": true}, labels: []string{"docs"}, want: true},
+		{name: "unknown label uses disabled default", policies: map[string]bool{"defect": true}, labels: []string{"docs"}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			cfg := BacklogAdmission{AutoAdmit: tt.fallback, AutoAdmitByLabel: tt.policies}
+			cfg.Normalize()
+			if got := cfg.AutoAdmitForLabels(tt.labels); got != tt.want {
+				t.Fatalf("AutoAdmitForLabels(%#v) = %t, want %t", tt.labels, got, tt.want)
 			}
 		})
 	}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1493,7 +1493,7 @@ func (c *Config) Validate() error {
 	if c.Retro.Enabled && c.Tracker.Kind == TrackerGitHub && !validRepositoryName(c.Tracker.Repository) {
 		problems = append(problems, "tracker.repository is required for retro")
 	}
-	problems = append(problems, ValidateRoutines("routines", c.Routines)...)
+	problems = append(problems, ValidateRoutines("routines", c.Routines, states)...)
 	if len(c.Routines) > 0 && c.Tracker.Kind != TrackerGitHub && c.Tracker.Kind != TrackerMemory {
 		problems = append(problems, "routines requires tracker.kind github or memory")
 	}

--- a/internal/config/routine.go
+++ b/internal/config/routine.go
@@ -11,25 +11,30 @@ import (
 const (
 	DefaultRoutineMaxFindingsPerRun = 3
 	DefaultRoutineMaxOpenFindings   = 10
+	DefaultRoutineTargetState       = "Todo"
 )
 
 type Routine struct {
-	Name                  string `yaml:"name"`
-	Schedule              string `yaml:"schedule"`
-	Prompt                string `yaml:"prompt"`
-	MaxFindingsPerRun     int    `yaml:"max_findings_per_run,omitempty"`
-	MaxOpenFindings       int    `yaml:"max_open_findings,omitempty"`
+	Name                  string   `yaml:"name"`
+	Schedule              string   `yaml:"schedule"`
+	Prompt                string   `yaml:"prompt"`
+	TargetState           string   `yaml:"target_state,omitempty"`
+	Labels                []string `yaml:"labels,omitempty"`
+	MaxFindingsPerRun     int      `yaml:"max_findings_per_run,omitempty"`
+	MaxOpenFindings       int      `yaml:"max_open_findings,omitempty"`
 	maxFindingsConfigured bool
 	maxOpenConfigured     bool
 }
 
 func (r *Routine) UnmarshalYAML(node *yaml.Node) error {
 	var decoded struct {
-		Name              string `yaml:"name"`
-		Schedule          string `yaml:"schedule"`
-		Prompt            string `yaml:"prompt"`
-		MaxFindingsPerRun *int   `yaml:"max_findings_per_run"`
-		MaxOpenFindings   *int   `yaml:"max_open_findings"`
+		Name              string   `yaml:"name"`
+		Schedule          string   `yaml:"schedule"`
+		Prompt            string   `yaml:"prompt"`
+		TargetState       string   `yaml:"target_state"`
+		Labels            []string `yaml:"labels"`
+		MaxFindingsPerRun *int     `yaml:"max_findings_per_run"`
+		MaxOpenFindings   *int     `yaml:"max_open_findings"`
 	}
 	if err := node.Decode(&decoded); err != nil {
 		return err
@@ -38,6 +43,8 @@ func (r *Routine) UnmarshalYAML(node *yaml.Node) error {
 		Name:                  decoded.Name,
 		Schedule:              decoded.Schedule,
 		Prompt:                decoded.Prompt,
+		TargetState:           decoded.TargetState,
+		Labels:                decoded.Labels,
 		MaxFindingsPerRun:     DefaultRoutineMaxFindingsPerRun,
 		MaxOpenFindings:       DefaultRoutineMaxOpenFindings,
 		maxFindingsConfigured: decoded.MaxFindingsPerRun != nil,
@@ -58,6 +65,11 @@ func NormalizeRoutines(routines []Routine) []Routine {
 		routine.Name = strings.ToLower(strings.TrimSpace(routine.Name))
 		routine.Schedule = strings.TrimSpace(routine.Schedule)
 		routine.Prompt = strings.TrimSpace(routine.Prompt)
+		routine.TargetState = strings.TrimSpace(routine.TargetState)
+		if routine.TargetState == "" {
+			routine.TargetState = DefaultRoutineTargetState
+		}
+		routine.Labels = normalizeLabels(routine.Labels)
 		if routine.MaxFindingsPerRun == 0 && !routine.maxFindingsConfigured {
 			routine.MaxFindingsPerRun = DefaultRoutineMaxFindingsPerRun
 		}
@@ -69,13 +81,17 @@ func NormalizeRoutines(routines []Routine) []Routine {
 	return out
 }
 
-func ValidateRoutines(prefix string, routines []Routine) []string {
+func ValidateRoutines(prefix string, routines []Routine, states []string) []string {
 	if prefix == "" {
 		prefix = "routines"
 	}
 	routines = NormalizeRoutines(routines)
 	problems := []string{}
 	seen := map[string]struct{}{}
+	knownStates := make(map[string]struct{}, len(states))
+	for _, state := range states {
+		knownStates[strings.ToLower(strings.TrimSpace(state))] = struct{}{}
+	}
 	for index, routine := range routines {
 		field := fmt.Sprintf("%s[%d]", prefix, index)
 		if !validAgentIdentityLabel(routine.Name) {
@@ -93,6 +109,12 @@ func ValidateRoutines(prefix string, routines []Routine) []string {
 		if routine.Prompt == "" {
 			problems = append(problems, field+".prompt is required")
 		}
+		if len(knownStates) > 0 {
+			if _, ok := knownStates[strings.ToLower(routine.TargetState)]; !ok {
+				problems = append(problems, field+".target_state must name a configured workflow state")
+			}
+		}
+		validateLabelList(field+".labels", routine.Labels, &problems)
 		validatePositive(field+".max_findings_per_run", routine.MaxFindingsPerRun, &problems)
 		validatePositive(field+".max_open_findings", routine.MaxOpenFindings, &problems)
 	}

--- a/internal/config/routine_test.go
+++ b/internal/config/routine_test.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"reflect"
 	"strconv"
 	"strings"
 	"testing"
@@ -14,6 +15,8 @@ tracker:
 routines:
   - name: Dependency-Audit
     schedule: "0 3 * * 1"
+    target_state: Backlog
+    labels: [Feature, Requires-Human-Review, feature]
     max_findings_per_run: 2
     max_open_findings: 8
     prompt: |
@@ -33,6 +36,8 @@ Prompt
 	routine := workflow.Config.Routines[0]
 	if routine.Name != "dependency-audit" || routine.Schedule != "0 3 * * 1" ||
 		routine.Prompt != "Follow the dependency criteria in WORKFLOW.md." ||
+		routine.TargetState != "Backlog" ||
+		!reflect.DeepEqual(routine.Labels, []string{"feature", "requires-human-review"}) ||
 		routine.MaxFindingsPerRun != 2 || routine.MaxOpenFindings != 8 {
 		t.Fatalf("Routine = %#v", routine)
 	}
@@ -57,6 +62,9 @@ Prompt
 		t.Fatalf("Validate() error = %v", err)
 	}
 	routine := workflow.Config.Routines[0]
+	if routine.TargetState != DefaultRoutineTargetState || len(routine.Labels) != 0 {
+		t.Fatalf("Routine target = %q, labels = %#v", routine.TargetState, routine.Labels)
+	}
 	if routine.MaxFindingsPerRun != DefaultRoutineMaxFindingsPerRun || routine.MaxOpenFindings != DefaultRoutineMaxOpenFindings {
 		t.Fatalf("Routine limits = %d, %d", routine.MaxFindingsPerRun, routine.MaxOpenFindings)
 	}
@@ -104,6 +112,8 @@ func TestValidateRoutinesRejectsMalformedBlocks(t *testing.T) {
 		{name: "missing schedule", routines: []Routine{{Name: "audit", Prompt: "Inspect."}}, wantDetail: "routines[0].schedule is required"},
 		{name: "six field schedule", routines: []Routine{{Name: "audit", Schedule: "0 0 3 * * 1", Prompt: "Inspect."}}, wantDetail: "five-field cron"},
 		{name: "missing prompt", routines: []Routine{{Name: "audit", Schedule: "0 * * * *"}}, wantDetail: "routines[0].prompt is required"},
+		{name: "unknown target state", routines: []Routine{{Name: "audit", Schedule: "0 * * * *", Prompt: "Inspect.", TargetState: "Icebox"}}, wantDetail: "routines[0].target_state must name a configured workflow state"},
+		{name: "blank label", routines: []Routine{{Name: "audit", Schedule: "0 * * * *", Prompt: "Inspect.", Labels: []string{" "}}}, wantDetail: "routines[0].labels labels must not be blank"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/internal/routine/manager.go
+++ b/internal/routine/manager.go
@@ -64,9 +64,10 @@ type RunRecord = routinemodel.RunRecord
 type IssueRecord = routinemodel.IssueRecord
 
 type Proposal struct {
-	DedupKey string `json:"dedup_key"`
-	Title    string `json:"title"`
-	Body     string `json:"body"`
+	DedupKey string   `json:"dedup_key"`
+	Title    string   `json:"title"`
+	Body     string   `json:"body"`
+	Labels   []string `json:"labels,omitempty"`
 }
 
 type Result struct {
@@ -124,7 +125,7 @@ func (m *Manager) Update(settings Settings) error {
 	defer m.processMu.Unlock()
 
 	settings = normalizeSettings(settings)
-	if problems := config.ValidateRoutines("routines", settings.Definitions); len(problems) > 0 {
+	if problems := config.ValidateRoutines("routines", settings.Definitions, settings.SearchStates); len(problems) > 0 {
 		return errors.New(strings.Join(problems, "; "))
 	}
 	if len(settings.Definitions) > 0 {
@@ -420,10 +421,11 @@ func (m *Manager) fileProposals(ctx context.Context, settings Settings, definiti
 			continue
 		}
 		fileAttempts++
+		labels := proposalLabels(definition, proposal)
 		issue, createErr := settings.Issues.CreateIntakeIssue(ctx, intake.IssueDraft{
 			Title:  proposal.Title,
 			Body:   scopeMarker + "\n" + marker + "\n\n" + proposal.Body,
-			Labels: []string{IssueLabel},
+			Labels: labels,
 		})
 		openFindings++
 		openMarkers[marker] = struct{}{}
@@ -440,7 +442,7 @@ func (m *Manager) fileProposals(ctx context.Context, settings Settings, definiti
 			runErr = errors.Join(runErr, fmt.Errorf("file routine issue %s: %w", proposal.DedupKey, createErr))
 			continue
 		}
-		if stateErr := settings.Issues.SetIntakeIssueState(ctx, issue.ID, IssueState); stateErr != nil {
+		if stateErr := settings.Issues.SetIntakeIssueState(ctx, issue.ID, definition.TargetState); stateErr != nil {
 			runErr = errors.Join(runErr, fmt.Errorf("set routine issue %s state: %w", proposal.DedupKey, stateErr))
 			continue
 		}
@@ -451,7 +453,7 @@ func (m *Manager) fileProposals(ctx context.Context, settings Settings, definiti
 				Identifier: issue.Identifier,
 				URL:        issue.URL,
 			},
-			TargetState:  IssueState,
+			TargetState:  definition.TargetState,
 			At:           m.now().UTC(),
 			Reason:       "routine",
 			MetadataJSON: provenance.Apply("{}", provenance.Attribution{Origin: provenance.OriginRoutine}, nil),
@@ -530,7 +532,7 @@ func proposalTool() runner.AgentTool {
 	return runner.AgentTool{
 		Name:        ProposalToolName,
 		Description: "Record one actionable maintenance issue proposal for Detent to validate, deduplicate, and file after the routine finishes.",
-		InputSchema: json.RawMessage(`{"type":"object","additionalProperties":false,"required":["dedup_key","title","body"],"properties":{"dedup_key":{"type":"string","minLength":1,"maxLength":256},"title":{"type":"string","minLength":1,"maxLength":256},"body":{"type":"string","minLength":1,"maxLength":262144}}}`),
+		InputSchema: json.RawMessage(`{"type":"object","additionalProperties":false,"required":["dedup_key","title","body"],"properties":{"dedup_key":{"type":"string","minLength":1,"maxLength":256},"title":{"type":"string","minLength":1,"maxLength":256},"body":{"type":"string","minLength":1,"maxLength":262144},"labels":{"type":"array","items":{"type":"string","minLength":1},"uniqueItems":true}}}`),
 	}
 }
 
@@ -624,6 +626,7 @@ func normalizeProposal(proposal Proposal) (Proposal, error) {
 	proposal.DedupKey = strings.TrimSpace(proposal.DedupKey)
 	proposal.Title = strings.TrimSpace(proposal.Title)
 	proposal.Body = strings.TrimSpace(proposal.Body)
+	proposal.Labels = normalizeLabels(proposal.Labels)
 	switch {
 	case proposal.DedupKey == "":
 		return Proposal{}, fmt.Errorf("%w: dedup_key is required", ErrInvalidProposal)
@@ -678,8 +681,45 @@ func normalizeSettings(settings Settings) Settings {
 
 func cloneSettings(settings Settings) Settings {
 	settings.Definitions = append([]config.Routine(nil), settings.Definitions...)
+	for index := range settings.Definitions {
+		settings.Definitions[index].Labels = append([]string(nil), settings.Definitions[index].Labels...)
+	}
 	settings.SearchStates = append([]string(nil), settings.SearchStates...)
 	return settings
+}
+
+func proposalLabels(definition config.Routine, proposal Proposal) []string {
+	allowed := make(map[string]struct{}, len(definition.Labels))
+	for _, label := range definition.Labels {
+		allowed[strings.ToLower(strings.TrimSpace(label))] = struct{}{}
+	}
+	labels := make([]string, 0, len(proposal.Labels)+1)
+	for _, label := range proposal.Labels {
+		if _, ok := allowed[strings.ToLower(strings.TrimSpace(label))]; ok {
+			labels = append(labels, label)
+		}
+	}
+	if strings.EqualFold(definition.TargetState, IssueState) && !containsFold(labels, IssueLabel) {
+		labels = append([]string{IssueLabel}, labels...)
+	}
+	return labels
+}
+
+func normalizeLabels(labels []string) []string {
+	out := make([]string, 0, len(labels))
+	seen := map[string]struct{}{}
+	for _, label := range labels {
+		label = strings.ToLower(strings.TrimSpace(label))
+		if label == "" {
+			continue
+		}
+		if _, ok := seen[label]; ok {
+			continue
+		}
+		seen[label] = struct{}{}
+		out = append(out, label)
+	}
+	return out
 }
 
 func routineByName(definitions []config.Routine, name string) (config.Routine, bool) {

--- a/internal/routine/manager_test.go
+++ b/internal/routine/manager_test.go
@@ -5,13 +5,16 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"reflect"
 	"strings"
 	"testing"
 	"time"
 
 	"github.com/digitaldrywood/detent/internal/config"
 	"github.com/digitaldrywood/detent/internal/connector"
+	"github.com/digitaldrywood/detent/internal/connector/memory"
 	"github.com/digitaldrywood/detent/internal/intake"
+	"github.com/digitaldrywood/detent/internal/orchestrator"
 	"github.com/digitaldrywood/detent/internal/provenance"
 	"github.com/digitaldrywood/detent/internal/runner"
 	"github.com/digitaldrywood/detent/internal/workflowmetrics"
@@ -204,6 +207,92 @@ func TestManagerRunOnceFilesAndDeduplicatesOpenIssue(t *testing.T) {
 	}
 	if len(store.records) != 2 || store.records[0].Filed != 1 || store.records[1].Deduplicated != 1 {
 		t.Fatalf("run records = %#v", store.records)
+	}
+}
+
+func TestManagerRoutineProposalLabelAllowlist(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		allowed  []string
+		proposed []string
+		want     []string
+	}{
+		{name: "configured label is applied", allowed: []string{"bug"}, proposed: []string{"Bug"}, want: []string{IssueLabel, "bug"}},
+		{name: "label outside allowlist is dropped", allowed: []string{"bug"}, proposed: []string{"security"}, want: []string{IssueLabel}},
+		{name: "allowed subset is applied", allowed: []string{"bug"}, proposed: []string{"bug", "security"}, want: []string{IssueLabel, "bug"}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			issues := &fakeIssueStore{}
+			manager, err := New(Settings{
+				ProjectID: "detent",
+				Definitions: []config.Routine{{
+					Name: "maintenance", Schedule: "0 * * * *", Prompt: "Inspect.", Labels: tt.allowed,
+				}},
+				SearchStates: []string{"Backlog", "Todo", "Done"},
+				Runner: fakeRunner{proposals: []Proposal{{
+					DedupKey: "finding", Title: "Finding", Body: "Evidence.", Labels: tt.proposed,
+				}}},
+				Issues: issues,
+			}, &fakeStore{}, nil, nil)
+			if err != nil {
+				t.Fatalf("New() error = %v", err)
+			}
+			if _, err := manager.RunOnce(t.Context(), "maintenance"); err != nil {
+				t.Fatalf("RunOnce() error = %v", err)
+			}
+			if len(issues.drafts) != 1 || !reflect.DeepEqual(issues.drafts[0].Labels, tt.want) {
+				t.Fatalf("draft labels = %#v, want %#v", issues.drafts, tt.want)
+			}
+		})
+	}
+}
+
+func TestManagerRoutineOptoutLabelPreventsAutoPromote(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, time.August, 8, 12, 0, 0, 0, time.UTC)
+	workflow := config.Default()
+	workflow.Agent.AutoPromote.Enabled = true
+	optoutLabel := workflow.Agent.AutoPromote.OptoutLabel
+	tracker := memory.New(memory.Config{Stateful: true, Now: func() time.Time { return now }})
+	manager, err := New(Settings{
+		ProjectID: "detent",
+		Definitions: []config.Routine{{
+			Name: "feature-sweep", Schedule: "0 * * * *", Prompt: "Inspect product intent.",
+			TargetState: "Backlog", Labels: []string{optoutLabel},
+		}},
+		SearchStates: workflow.KanbanStateNames(),
+		Runner: fakeRunner{proposals: []Proposal{{
+			DedupKey: "feature", Title: "Propose feature", Body: "Product evidence.", Labels: []string{optoutLabel},
+		}}},
+		Issues: tracker,
+	}, &fakeStore{}, nil, func() time.Time { return now })
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	result, err := manager.RunOnce(t.Context(), "feature-sweep")
+	if err != nil || len(result.Filed) != 1 {
+		t.Fatalf("RunOnce() = %#v, %v", result, err)
+	}
+	issues, err := tracker.FetchIssueStatesByIDs(t.Context(), []string{result.Filed[0].ID})
+	if err != nil || len(issues) != 1 {
+		t.Fatalf("FetchIssueStatesByIDs() = %#v, %v", issues, err)
+	}
+	if issues[0].State != "Backlog" || !containsFold(issues[0].Labels, optoutLabel) {
+		t.Fatalf("routine issue = %#v", issues[0])
+	}
+	decision := orchestrator.EvaluateAutoPromote(
+		issues[0],
+		orchestrator.AutoPromoteSummary{},
+		orchestrator.ConfigFromWorkflow(workflow).AutoPromote,
+		now,
+	)
+	if decision.Action != orchestrator.AutoPromoteActionAwaitReview || decision.Reason != orchestrator.AutoPromoteReasonOptoutLabel {
+		t.Fatalf("EvaluateAutoPromote() = %#v", decision)
 	}
 }
 


### PR DESCRIPTION
## Summary

- add validated routine target states and allowlisted agent-proposed issue labels while preserving the existing Todo default
- add per-label backlog auto-admit overrides with propose-only precedence and mutation-time label revalidation
- document safe evidenced-defect and feature proposal policies and refresh generated config references

Fixes #1697

## UI Surface Contract

- [x] N/A; this change has no UI surface, layout, density, first-viewport, or responsive visibility impact.
- [x] This PR does not add persistent top-of-screen messaging.
- [x] N/A; this PR does not change primary operator screens.

## Test Plan

- [x] `go test -count=1 ./internal/config ./internal/routine ./internal/admission`
- [x] `make check` on rebased tree `472538c4` (78.8% aggregate coverage; 90.4% admission coverage)
- [x] Current-head CI run [31323195251](https://github.com/digitaldrywood/detent/actions/runs/31323195251) (all 11 jobs passed)