### PR TITLE
fix(github): attribute REST budget by credential

### DIFF
--- a/internal/cli/runner.go
+++ b/internal/cli/runner.go
@@ -938,8 +938,12 @@ func mergeFleetRateLimits(current *telemetry.RateLimits, incoming *telemetry.Rat
 	}
 
 	merged := *current
-	merged.GitHubREST = mergeFleetRESTBucket(current.GitHubREST, incoming.GitHubREST)
 	merged.GitHubRESTBudgets = mergeFleetRESTBudgets(current.GitHubRESTBudgets, incoming.GitHubRESTBudgets)
+	merged.GitHubREST = mergeFleetRESTBucket(current.GitHubREST, incoming.GitHubREST)
+	if bucket := fleetRESTBucketFromBudgets(merged.GitHubRESTBudgets); bucket != nil {
+		bucket.Cost = rateLimitBucketCost(current.GitHubREST) + rateLimitBucketCost(incoming.GitHubREST)
+		merged.GitHubREST = bucket
+	}
 	merged.RESTUsage = mergeFleetRESTUsage(current.RESTUsage, incoming.RESTUsage)
 	if merged.GitHubGraphQL == nil {
 		merged.GitHubGraphQL = incoming.GitHubGraphQL
@@ -948,6 +952,13 @@ func mergeFleetRateLimits(current *telemetry.RateLimits, incoming *telemetry.Rat
 		merged.GraphQLCost = incoming.GraphQLCost
 	}
 	return &merged
+}
+
+func rateLimitBucketCost(bucket *telemetry.RateLimitBucket) int64 {
+	if bucket == nil {
+		return 0
+	}
+	return bucket.Cost
 }
 
 func mergeFleetRESTBucket(current *telemetry.RateLimitBucket, incoming *telemetry.RateLimitBucket) *telemetry.RateLimitBucket {
@@ -1037,6 +1048,67 @@ func cloneFleetRESTBudget(budget telemetry.RESTBudget) telemetry.RESTBudget {
 		budget.ObservedAt = &observedAt
 	}
 	return budget
+}
+
+func fleetRESTBucketFromBudgets(budgets []telemetry.RESTBudget) *telemetry.RateLimitBucket {
+	currentByCredentialResource := make(map[string]telemetry.RESTBudget, len(budgets))
+	for _, budget := range budgets {
+		key := strings.TrimSpace(budget.CredentialIdentity) + "\x00" + strings.TrimSpace(budget.Resource)
+		existing, ok := currentByCredentialResource[key]
+		if !ok || restBudgetObservedAfter(budget, existing) || (restBudgetObservedTogether(budget, existing) && restBudgetRemainingRatio(budget) < restBudgetRemainingRatio(existing)) {
+			currentByCredentialResource[key] = budget
+		}
+	}
+	candidates := make([]telemetry.RESTBudget, 0, len(currentByCredentialResource))
+	hasCore := false
+	for _, budget := range currentByCredentialResource {
+		if strings.EqualFold(strings.TrimSpace(budget.Resource), "core") {
+			hasCore = true
+		}
+		candidates = append(candidates, budget)
+	}
+	var selected *telemetry.RESTBudget
+	for index := range candidates {
+		candidate := &candidates[index]
+		if hasCore && !strings.EqualFold(strings.TrimSpace(candidate.Resource), "core") {
+			continue
+		}
+		if selected == nil || restBudgetRemainingRatio(*candidate) < restBudgetRemainingRatio(*selected) {
+			selected = candidate
+		}
+	}
+	if selected == nil {
+		return nil
+	}
+	return &telemetry.RateLimitBucket{
+		Remaining:  selected.Remaining,
+		Used:       selected.Used,
+		Limit:      selected.Limit,
+		ResetAt:    cloneTimePointer(selected.ResetAt),
+		ObservedAt: cloneTimePointer(selected.ObservedAt),
+	}
+}
+
+func restBudgetObservedTogether(left telemetry.RESTBudget, right telemetry.RESTBudget) bool {
+	if left.ObservedAt == nil || right.ObservedAt == nil {
+		return left.ObservedAt == nil && right.ObservedAt == nil
+	}
+	return left.ObservedAt.Equal(*right.ObservedAt)
+}
+
+func restBudgetRemainingRatio(budget telemetry.RESTBudget) float64 {
+	if budget.Limit <= 0 {
+		return 2
+	}
+	return float64(budget.Remaining) / float64(budget.Limit)
+}
+
+func cloneTimePointer(value *time.Time) *time.Time {
+	if value == nil {
+		return nil
+	}
+	cloned := *value
+	return &cloned
 }
 
 func mergeFleetRESTUsage(current *telemetry.RESTUsage, incoming *telemetry.RESTUsage) *telemetry.RESTUsage {

--- a/internal/cli/runner.go
+++ b/internal/cli/runner.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log/slog"
 	"os/exec"
+	"sort"
 	"strings"
 	"sync/atomic"
 	"time"
@@ -920,10 +921,181 @@ func mergeSnapshot(current, next telemetry.Snapshot) telemetry.Snapshot {
 	current.Tokens.Total += next.Tokens.Total
 	current.Tokens.RuntimeSeconds += next.Tokens.RuntimeSeconds
 
-	if current.RateLimits == nil && next.RateLimits != nil {
-		current.RateLimits = next.RateLimits
-	}
+	current.RateLimits = mergeFleetRateLimits(current.RateLimits, next.RateLimits)
 	return current
+}
+
+func mergeFleetRateLimits(current *telemetry.RateLimits, incoming *telemetry.RateLimits) *telemetry.RateLimits {
+	if incoming == nil {
+		return current
+	}
+	if current == nil {
+		cloned := *incoming
+		cloned.GitHubREST = cloneFleetRateLimitBucket(incoming.GitHubREST)
+		cloned.GitHubRESTBudgets = mergeFleetRESTBudgets(nil, incoming.GitHubRESTBudgets)
+		cloned.RESTUsage = mergeFleetRESTUsage(nil, incoming.RESTUsage)
+		return &cloned
+	}
+
+	merged := *current
+	merged.GitHubREST = mergeFleetRESTBucket(current.GitHubREST, incoming.GitHubREST)
+	merged.GitHubRESTBudgets = mergeFleetRESTBudgets(current.GitHubRESTBudgets, incoming.GitHubRESTBudgets)
+	merged.RESTUsage = mergeFleetRESTUsage(current.RESTUsage, incoming.RESTUsage)
+	if merged.GitHubGraphQL == nil {
+		merged.GitHubGraphQL = incoming.GitHubGraphQL
+	}
+	if merged.GraphQLCost == nil {
+		merged.GraphQLCost = incoming.GraphQLCost
+	}
+	return &merged
+}
+
+func mergeFleetRESTBucket(current *telemetry.RateLimitBucket, incoming *telemetry.RateLimitBucket) *telemetry.RateLimitBucket {
+	if current == nil {
+		return cloneFleetRateLimitBucket(incoming)
+	}
+	if incoming == nil {
+		return cloneFleetRateLimitBucket(current)
+	}
+	chosen := current
+	if rateLimitRemainingRatio(incoming) < rateLimitRemainingRatio(current) {
+		chosen = incoming
+	} else if rateLimitRemainingRatio(incoming) == rateLimitRemainingRatio(current) && rateLimitObservedAfter(incoming, current) {
+		chosen = incoming
+	}
+	merged := cloneFleetRateLimitBucket(chosen)
+	merged.Cost = current.Cost + incoming.Cost
+	return merged
+}
+
+func rateLimitRemainingRatio(bucket *telemetry.RateLimitBucket) float64 {
+	if bucket == nil || bucket.Limit <= 0 {
+		return 2
+	}
+	return float64(bucket.Remaining) / float64(bucket.Limit)
+}
+
+func rateLimitObservedAfter(left *telemetry.RateLimitBucket, right *telemetry.RateLimitBucket) bool {
+	return left != nil && left.ObservedAt != nil && (right == nil || right.ObservedAt == nil || left.ObservedAt.After(*right.ObservedAt))
+}
+
+func cloneFleetRateLimitBucket(bucket *telemetry.RateLimitBucket) *telemetry.RateLimitBucket {
+	if bucket == nil {
+		return nil
+	}
+	cloned := *bucket
+	if bucket.ResetAt != nil {
+		resetAt := *bucket.ResetAt
+		cloned.ResetAt = &resetAt
+	}
+	if bucket.ObservedAt != nil {
+		observedAt := *bucket.ObservedAt
+		cloned.ObservedAt = &observedAt
+	}
+	return &cloned
+}
+
+func mergeFleetRESTBudgets(current []telemetry.RESTBudget, incoming []telemetry.RESTBudget) []telemetry.RESTBudget {
+	byKey := make(map[string]telemetry.RESTBudget, len(current)+len(incoming))
+	for _, budget := range append(append([]telemetry.RESTBudget(nil), current...), incoming...) {
+		key := strings.TrimSpace(budget.CredentialIdentity) + "\x00" + strings.TrimSpace(budget.EndpointFamily) + "\x00" + strings.TrimSpace(budget.Resource)
+		existing, ok := byKey[key]
+		if !ok || restBudgetObservedAfter(budget, existing) {
+			byKey[key] = cloneFleetRESTBudget(budget)
+		}
+	}
+	if len(byKey) == 0 {
+		return nil
+	}
+	budgets := make([]telemetry.RESTBudget, 0, len(byKey))
+	for _, budget := range byKey {
+		budgets = append(budgets, budget)
+	}
+	sort.Slice(budgets, func(i, j int) bool {
+		if budgets[i].CredentialIdentity != budgets[j].CredentialIdentity {
+			return budgets[i].CredentialIdentity < budgets[j].CredentialIdentity
+		}
+		if budgets[i].EndpointFamily != budgets[j].EndpointFamily {
+			return budgets[i].EndpointFamily < budgets[j].EndpointFamily
+		}
+		return budgets[i].Resource < budgets[j].Resource
+	})
+	return budgets
+}
+
+func restBudgetObservedAfter(left telemetry.RESTBudget, right telemetry.RESTBudget) bool {
+	return left.ObservedAt != nil && (right.ObservedAt == nil || left.ObservedAt.After(*right.ObservedAt))
+}
+
+func cloneFleetRESTBudget(budget telemetry.RESTBudget) telemetry.RESTBudget {
+	if budget.ResetAt != nil {
+		resetAt := *budget.ResetAt
+		budget.ResetAt = &resetAt
+	}
+	if budget.ObservedAt != nil {
+		observedAt := *budget.ObservedAt
+		budget.ObservedAt = &observedAt
+	}
+	return budget
+}
+
+func mergeFleetRESTUsage(current *telemetry.RESTUsage, incoming *telemetry.RESTUsage) *telemetry.RESTUsage {
+	if current == nil && incoming == nil {
+		return nil
+	}
+	merged := &telemetry.RESTUsage{}
+	contributors := make(map[string]telemetry.RESTUsageContributor)
+	for _, usage := range []*telemetry.RESTUsage{current, incoming} {
+		if usage == nil {
+			continue
+		}
+		merged.TotalRequests += usage.TotalRequests
+		merged.ConditionalRequests += usage.ConditionalRequests
+		merged.NotModifiedRequests += usage.NotModifiedRequests
+		merged.BillableRequests += usage.BillableRequests
+		merged.RateLimited = merged.RateLimited || usage.RateLimited
+		if usage.BackoffUntil != nil && (merged.BackoffUntil == nil || usage.BackoffUntil.After(*merged.BackoffUntil)) {
+			backoffUntil := *usage.BackoffUntil
+			merged.BackoffUntil = &backoffUntil
+		}
+		for _, contributor := range usage.Contributors {
+			key := contributor.CredentialIdentity + "\x00" + contributor.EndpointFamily + "\x00" + contributor.Resource
+			existing := contributors[key]
+			existing.CredentialIdentity = contributor.CredentialIdentity
+			existing.EndpointFamily = contributor.EndpointFamily
+			existing.Resource = contributor.Resource
+			existing.Count += contributor.Count
+			existing.Conditional += contributor.Conditional
+			existing.NotModified += contributor.NotModified
+			existing.Billable += contributor.Billable
+			existing.RateLimited = existing.RateLimited || contributor.RateLimited
+			if contributor.LastStatus != 0 {
+				existing.LastStatus = contributor.LastStatus
+			}
+			if contributor.Limit > 0 || contributor.Remaining > 0 {
+				existing.Limit = contributor.Limit
+				existing.Remaining = contributor.Remaining
+			}
+			if contributor.ResetAt != nil {
+				resetAt := *contributor.ResetAt
+				existing.ResetAt = &resetAt
+			}
+			if contributor.RetryAfterMS > existing.RetryAfterMS {
+				existing.RetryAfterMS = contributor.RetryAfterMS
+			}
+			contributors[key] = existing
+		}
+	}
+	for _, contributor := range contributors {
+		merged.Contributors = append(merged.Contributors, contributor)
+	}
+	sort.Slice(merged.Contributors, func(i, j int) bool {
+		if merged.Contributors[i].CredentialIdentity != merged.Contributors[j].CredentialIdentity {
+			return merged.Contributors[i].CredentialIdentity < merged.Contributors[j].CredentialIdentity
+		}
+		return merged.Contributors[i].EndpointFamily < merged.Contributors[j].EndpointFamily
+	})
+	return merged
 }
 
 func issueKey(issue telemetry.Issue) string {

--- a/internal/cli/runner_test.go
+++ b/internal/cli/runner_test.go
@@ -1270,6 +1270,54 @@ func TestMergeSnapshotMergesInstanceScope(t *testing.T) {
 	}
 }
 
+func TestMergeSnapshotAttributesFleetRESTBudgets(t *testing.T) {
+	t.Parallel()
+
+	firstObserved := time.Date(2026, 8, 8, 18, 0, 0, 0, time.UTC)
+	secondObserved := firstObserved.Add(time.Minute)
+	coreReset := firstObserved.Add(time.Hour)
+	searchReset := firstObserved.Add(2 * time.Minute)
+	got := mergeSnapshot(telemetry.Snapshot{}, telemetry.Snapshot{
+		RateLimits: &telemetry.RateLimits{
+			GitHubREST: &telemetry.RateLimitBucket{Limit: 5000, Remaining: 4200, ObservedAt: &firstObserved},
+			GitHubRESTBudgets: []telemetry.RESTBudget{
+				{CredentialIdentity: "github-rest:shared", EndpointFamily: "issues", Resource: "core", Limit: 5000, Remaining: 4200, ResetAt: &coreReset, ObservedAt: &firstObserved},
+			},
+			RESTUsage: &telemetry.RESTUsage{TotalRequests: 3, BillableRequests: 3},
+		},
+	})
+	got = mergeSnapshot(got, telemetry.Snapshot{
+		BackendOutages: []telemetry.BackendOutage{{Kind: "github_rest_rate_limit", Reason: "dispatch paused"}},
+		RateLimits: &telemetry.RateLimits{
+			GitHubREST: &telemetry.RateLimitBucket{Limit: 5000, Remaining: 300, ObservedAt: &secondObserved},
+			GitHubRESTBudgets: []telemetry.RESTBudget{
+				{CredentialIdentity: "github-rest:shared", EndpointFamily: "issues", Resource: "core", Limit: 5000, Remaining: 300, ResetAt: &coreReset, ObservedAt: &secondObserved},
+				{CredentialIdentity: "github-rest:search", EndpointFamily: "issue search", Resource: "search", Limit: 30, Remaining: 20, ResetAt: &searchReset, ObservedAt: &secondObserved},
+			},
+			RESTUsage: &telemetry.RESTUsage{TotalRequests: 2, BillableRequests: 1},
+		},
+	})
+
+	if got.RateLimits == nil || len(got.RateLimits.GitHubRESTBudgets) != 2 {
+		t.Fatalf("RateLimits = %#v, want two credential endpoint budgets", got.RateLimits)
+	}
+	if budget := got.RateLimits.GitHubRESTBudgets[0]; budget.CredentialIdentity != "github-rest:search" || budget.ResetAt == nil || !budget.ResetAt.Equal(searchReset) {
+		t.Fatalf("GitHubRESTBudgets[0] = %#v, want search credential and reset", budget)
+	}
+	if budget := got.RateLimits.GitHubRESTBudgets[1]; budget.CredentialIdentity != "github-rest:shared" || budget.Remaining != 300 || budget.ResetAt == nil || !budget.ResetAt.Equal(coreReset) {
+		t.Fatalf("GitHubRESTBudgets[1] = %#v, want latest shared credential core budget", budget)
+	}
+	if got.RateLimits.RESTUsage == nil || got.RateLimits.RESTUsage.TotalRequests != 5 || got.RateLimits.RESTUsage.BillableRequests != 4 {
+		t.Fatalf("RESTUsage = %#v, want aggregated project request counts", got.RateLimits.RESTUsage)
+	}
+	if got.RateLimits.GitHubREST == nil || got.RateLimits.GitHubREST.Remaining != 300 {
+		t.Fatalf("GitHubREST = %#v, want most constrained compatibility bucket", got.RateLimits.GitHubREST)
+	}
+	if len(got.BackendOutages) != 1 || got.BackendOutages[0].Kind != "github_rest_rate_limit" {
+		t.Fatalf("BackendOutages = %#v, want fleet-visible REST dispatch condition", got.BackendOutages)
+	}
+}
+
 func TestDedupeSnapshotIssues(t *testing.T) {
 	t.Parallel()
 

--- a/internal/cli/runner_test.go
+++ b/internal/cli/runner_test.go
@@ -1318,6 +1318,59 @@ func TestMergeSnapshotAttributesFleetRESTBudgets(t *testing.T) {
 	}
 }
 
+func TestFleetRESTBucketFromBudgetsUsesCurrentCredentialResourceSnapshot(t *testing.T) {
+	t.Parallel()
+
+	oldObserved := time.Date(2026, 8, 8, 18, 0, 0, 0, time.UTC)
+	newObserved := oldObserved.Add(time.Hour)
+	oldReset := oldObserved.Add(30 * time.Minute)
+	newReset := newObserved.Add(time.Hour)
+	tests := []struct {
+		name          string
+		budgets       []telemetry.RESTBudget
+		wantRemaining int64
+		wantReset     time.Time
+	}{
+		{
+			name: "new post-reset observation replaces stale exhausted family",
+			budgets: []telemetry.RESTBudget{
+				{CredentialIdentity: "shared", EndpointFamily: "issues", Resource: "core", Limit: 5000, Remaining: 0, ResetAt: &oldReset, ObservedAt: &oldObserved},
+				{CredentialIdentity: "shared", EndpointFamily: "pull requests", Resource: "core", Limit: 5000, Remaining: 4990, ResetAt: &newReset, ObservedAt: &newObserved},
+			},
+			wantRemaining: 4990,
+			wantReset:     newReset,
+		},
+		{
+			name: "distinct credential keeps most constrained core budget",
+			budgets: []telemetry.RESTBudget{
+				{CredentialIdentity: "first", EndpointFamily: "issues", Resource: "core", Limit: 5000, Remaining: 4000, ResetAt: &newReset, ObservedAt: &newObserved},
+				{CredentialIdentity: "second", EndpointFamily: "issues", Resource: "core", Limit: 5000, Remaining: 300, ResetAt: &newReset, ObservedAt: &newObserved},
+			},
+			wantRemaining: 300,
+			wantReset:     newReset,
+		},
+		{
+			name: "core compatibility bucket outranks search resource",
+			budgets: []telemetry.RESTBudget{
+				{CredentialIdentity: "shared", EndpointFamily: "issues", Resource: "core", Limit: 5000, Remaining: 4000, ResetAt: &newReset, ObservedAt: &newObserved},
+				{CredentialIdentity: "shared", EndpointFamily: "issue search", Resource: "search", Limit: 30, Remaining: 0, ResetAt: &oldReset, ObservedAt: &newObserved},
+			},
+			wantRemaining: 4000,
+			wantReset:     newReset,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			bucket := fleetRESTBucketFromBudgets(test.budgets)
+			if bucket == nil || bucket.Remaining != test.wantRemaining || bucket.ResetAt == nil || !bucket.ResetAt.Equal(test.wantReset) {
+				t.Fatalf("bucket = %#v, want remaining %d reset %v", bucket, test.wantRemaining, test.wantReset)
+			}
+		})
+	}
+}
+
 func TestDedupeSnapshotIssues(t *testing.T) {
 	t.Parallel()
 

--- a/internal/connector/github/app_token.go
+++ b/internal/connector/github/app_token.go
@@ -115,6 +115,15 @@ func (s *InstallationTokenSource) Token(ctx context.Context) (string, error) {
 	return details.Token, nil
 }
 
+func (s *InstallationTokenSource) CredentialIdentity(token string) string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if strings.TrimSpace(token) == "" || strings.TrimSpace(token) != strings.TrimSpace(s.cachedToken) {
+		return ""
+	}
+	return "github-app-installation:" + s.installationID
+}
+
 func (s *InstallationTokenSource) TokenDetails(ctx context.Context) (InstallationTokenDetails, error) {
 	if err := ctx.Err(); err != nil {
 		return InstallationTokenDetails{}, err

--- a/internal/connector/github/client.go
+++ b/internal/connector/github/client.go
@@ -34,6 +34,7 @@ const (
 	restRateLimitResetSkew              = 5 * time.Second
 	restBudgetGateFanoutCap             = "fanout_cap"
 	restBudgetGateReserve               = "reserve"
+	restDivergenceMinUnexplained        = int64(10)
 )
 
 var defaultRESTBackoffs = newRESTBackoffRegistry()
@@ -73,6 +74,8 @@ type Client struct {
 	graphQLRateLimitStatus string
 	restRateLimit          connector.RESTRateLimit
 	restRateLimits         map[string]connector.RESTRateLimit
+	restCredentialLimits   map[string]connector.RESTRateLimit
+	restBudgets            map[string]connector.RESTRateLimitBudget
 	restRequests           map[string]connector.RESTEndpointUsage
 	restFanoutUnits        int64
 	restCache              map[string]restCacheEntry
@@ -267,6 +270,7 @@ func (c *Client) restProbeWithTokenRefresh(ctx context.Context, method string, p
 		return restProbeResult{}, ErrMissingToken
 	}
 	backoffKey := c.restSharedBackoffKey(token)
+	credentialIdentity := c.restCredentialIdentity(token)
 	c.rememberRESTBackoffKey(backoffKey)
 
 	var requestBody io.Reader
@@ -314,7 +318,7 @@ func (c *Client) restProbeWithTokenRefresh(ctx context.Context, method string, p
 	}
 	connector.ReportProgress(ctx)
 	receivedAt := time.Now()
-	c.recordRESTRateLimitFromHeaders(backoffKey, method, path, resp.StatusCode, resp.Header, receivedAt, false)
+	c.recordRESTRateLimitFromHeaders(backoffKey, credentialIdentity, method, path, resp.StatusCode, resp.Header, receivedAt, false)
 	c.logRESTResponse(ctx, "github rest probe response", method, path, family, resp.StatusCode)
 	result := restProbeResult{
 		StatusCode: resp.StatusCode,
@@ -345,6 +349,7 @@ func (c *Client) restWithTokenRefresh(ctx context.Context, method string, path s
 		return nil, ErrMissingToken
 	}
 	backoffKey := c.restSharedBackoffKey(token)
+	credentialIdentity := c.restCredentialIdentity(token)
 	c.rememberRESTBackoffKey(backoffKey)
 	cached, conditional := c.restConditionalEntry(method, path)
 	now := time.Now()
@@ -359,7 +364,7 @@ func (c *Client) restWithTokenRefresh(ctx context.Context, method string, path s
 		)
 		return nil, err
 	}
-	if err := c.restBudgetPolicyError(method, path, conditional, now); err != nil {
+	if err := c.restBudgetPolicyError(credentialIdentity, method, path, conditional, now); err != nil {
 		c.logger.DebugContext(ctx, "github rest budget reserved",
 			"method", strings.ToUpper(strings.TrimSpace(method)),
 			"path", path,
@@ -419,7 +424,7 @@ func (c *Client) restWithTokenRefresh(ctx context.Context, method string, path s
 	}
 	connector.ReportProgress(ctx)
 	receivedAt := time.Now()
-	c.recordRESTRateLimitFromHeaders(backoffKey, method, path, resp.StatusCode, resp.Header, receivedAt, conditional)
+	c.recordRESTRateLimitFromHeaders(backoffKey, credentialIdentity, method, path, resp.StatusCode, resp.Header, receivedAt, conditional)
 	if resp.StatusCode == http.StatusNotModified {
 		if !conditional {
 			return nil, ErrInvalidResponse
@@ -612,6 +617,7 @@ func (c *Client) FlushRESTRateLimitUsage() connector.RESTRateLimitUsage {
 		RateLimit:    rateLimit,
 		HasRateLimit: c.hasRestRateLimit,
 		Requests:     sortedRESTEndpointUsages(c.restRequests),
+		Budgets:      sortedRESTRateLimitBudgets(c.restBudgets),
 		BackoffUntil: backoffUntil,
 	}
 	for _, request := range usage.Requests {
@@ -658,7 +664,7 @@ func normalizeRESTBudgetPolicy(policy RESTBudgetPolicy) RESTBudgetPolicy {
 	return policy
 }
 
-func (c *Client) restBudgetPolicyError(method string, path string, conditional bool, now time.Time) error {
+func (c *Client) restBudgetPolicyError(credentialIdentity string, method string, path string, conditional bool, now time.Time) error {
 	family := restEndpointFamily(method, path)
 	if !restFanoutEndpointFamily(family) {
 		return nil
@@ -674,7 +680,7 @@ func (c *Client) restBudgetPolicyError(method string, path string, conditional b
 	}
 	if c.restPolicy.FanoutMaxRequests > 0 &&
 		c.restFanoutUnits+requestCost > c.restPolicy.FanoutMaxRequests*restFanoutCostUnitsPerRequest {
-		c.recordRESTBudgetThrottleLocked(method, path, family, restBudgetGateFanoutCap, rateLimit, hasRateLimit, now)
+		c.recordRESTBudgetThrottleLocked(credentialIdentity, method, path, family, restBudgetGateFanoutCap, rateLimit, hasRateLimit, now)
 		return &StatusError{
 			StatusCode: http.StatusTooManyRequests,
 			Body:       "REST fanout request cap reached for " + family,
@@ -687,7 +693,7 @@ func (c *Client) restBudgetPolicyError(method string, path string, conditional b
 		rateLimit.Limit > 0 &&
 		!restRateLimitSnapshotExpired(rateLimit, now) &&
 		rateLimit.Remaining <= c.restPolicy.MinRemainingReserve {
-		c.recordRESTBudgetThrottleLocked(method, path, family, restBudgetGateReserve, rateLimit, hasRateLimit, now)
+		c.recordRESTBudgetThrottleLocked(credentialIdentity, method, path, family, restBudgetGateReserve, rateLimit, hasRateLimit, now)
 		return &StatusError{
 			StatusCode: http.StatusTooManyRequests,
 			Body:       "REST remaining budget is reserved for shared GitHub work",
@@ -715,7 +721,7 @@ func (c *Client) restRateLimitForResourceLocked(resource string) (connector.REST
 	return connector.RESTRateLimit{}, false
 }
 
-func (c *Client) recordRESTBudgetThrottleLocked(method string, path string, family string, branch string, rateLimit connector.RESTRateLimit, hasRateLimit bool, now time.Time) {
+func (c *Client) recordRESTBudgetThrottleLocked(credentialIdentity string, method string, path string, family string, branch string, rateLimit connector.RESTRateLimit, hasRateLimit bool, now time.Time) {
 	fanoutCount := float64(c.restFanoutUnits) / float64(restFanoutCostUnitsPerRequest)
 	snapshotAge := "unknown"
 	if !rateLimit.UpdatedAt.IsZero() {
@@ -728,7 +734,9 @@ func (c *Client) recordRESTBudgetThrottleLocked(method string, path string, fami
 	if c.restRequests == nil {
 		c.restRequests = make(map[string]connector.RESTEndpointUsage)
 	}
-	request := c.restRequests[family]
+	requestKey := restCredentialFamilyKey(credentialIdentity, family)
+	request := c.restRequests[requestKey]
+	request.CredentialIdentity = credentialIdentity
 	request.EndpointFamily = family
 	request.Count++
 	request.RateLimited = true
@@ -741,12 +749,13 @@ func (c *Client) recordRESTBudgetThrottleLocked(method string, path string, fami
 		request.ResetAt = rateLimit.ResetAt
 		request.RetryAfter = rateLimit.RetryAfter
 	}
-	c.restRequests[family] = request
+	c.restRequests[requestKey] = request
 	c.logger.Warn(
 		"github rest budget preserved",
 		"method", strings.ToUpper(strings.TrimSpace(method)),
 		"path", path,
 		"endpoint_family", family,
+		"credential_identity", credentialIdentity,
 		"resource", rateLimit.Resource,
 		"remaining", rateLimit.Remaining,
 		"reserve", c.restPolicy.MinRemainingReserve,
@@ -762,6 +771,11 @@ func (c *Client) restSharedBackoffKey(token string) string {
 	return c.restEndpoint + "\x00" + string(sum[:])
 }
 
+func (c *Client) restCredentialIdentity(token string) string {
+	sum := sha256.Sum256([]byte(c.restEndpoint + "\x00" + token))
+	return fmt.Sprintf("github-rest:%x", sum[:6])
+}
+
 func (c *Client) rememberRESTBackoffKey(backoffKey string) {
 	if strings.TrimSpace(backoffKey) == "" {
 		return
@@ -771,7 +785,7 @@ func (c *Client) rememberRESTBackoffKey(backoffKey string) {
 	c.mu.Unlock()
 }
 
-func (c *Client) recordRESTRateLimitFromHeaders(backoffKey string, method string, path string, status int, headers http.Header, now time.Time, conditional bool) {
+func (c *Client) recordRESTRateLimitFromHeaders(backoffKey string, credentialIdentity string, method string, path string, status int, headers http.Header, now time.Time, conditional bool) {
 	limit, hasLimit := int64Header(headers, "X-RateLimit-Limit")
 	used, hasUsed := int64Header(headers, "X-RateLimit-Used")
 	remaining, hasRemaining := int64Header(headers, "X-RateLimit-Remaining")
@@ -827,6 +841,25 @@ func (c *Client) recordRESTRateLimitFromHeaders(backoffKey string, method string
 	}
 	if hasSnapshot {
 		snapshot.UpdatedAt = now
+		credentialLimitKey := restCredentialResourceKey(credentialIdentity, resource)
+		if previous, ok := c.restCredentialLimits[credentialLimitKey]; ok {
+			if divergence, ok := restBudgetDivergence(previous, snapshot, status != http.StatusNotModified); ok {
+				c.logger.Warn(
+					"github rest observed usage diverged from detent requests",
+					"credential_identity", credentialIdentity,
+					"endpoint_family", family,
+					"resource", resource,
+					"observed_drop", divergence.ObservedDrop,
+					"detent_billable_requests", divergence.DetentBillableRequests,
+					"unexplained_requests", divergence.UnexplainedRequests,
+					"likely_external_consumer", "worker gh subprocess sharing credential",
+				)
+			}
+		}
+		if c.restCredentialLimits == nil {
+			c.restCredentialLimits = make(map[string]connector.RESTRateLimit)
+		}
+		c.restCredentialLimits[credentialLimitKey] = snapshot
 		c.restRateLimit = snapshot
 		if resource != "" {
 			if c.restRateLimits == nil {
@@ -835,12 +868,23 @@ func (c *Client) recordRESTRateLimitFromHeaders(backoffKey string, method string
 			c.restRateLimits[resource] = snapshot
 		}
 		c.hasRestRateLimit = true
+		if c.restBudgets == nil {
+			c.restBudgets = make(map[string]connector.RESTRateLimitBudget)
+		}
+		budgetKey := restCredentialFamilyKey(credentialIdentity, family)
+		c.restBudgets[budgetKey] = connector.RESTRateLimitBudget{
+			CredentialIdentity: credentialIdentity,
+			EndpointFamily:     family,
+			RateLimit:          snapshot,
+		}
 	}
 
 	if c.restRequests == nil {
 		c.restRequests = make(map[string]connector.RESTEndpointUsage)
 	}
-	request := c.restRequests[family]
+	requestKey := restCredentialFamilyKey(credentialIdentity, family)
+	request := c.restRequests[requestKey]
+	request.CredentialIdentity = credentialIdentity
 	request.EndpointFamily = family
 	request.Count++
 	if conditional {
@@ -874,7 +918,7 @@ func (c *Client) recordRESTRateLimitFromHeaders(backoffKey string, method string
 	if hasRetryAfter {
 		request.RetryAfter = retryAfter
 	}
-	c.restRequests[family] = request
+	c.restRequests[requestKey] = request
 
 	if sharedBackoff {
 		backoffUntil := restBackoffUntil(now, retryAfter, hasRetryAfter, resetAt, hasReset, remaining, hasRemaining)
@@ -1516,9 +1560,62 @@ func sortedRESTEndpointUsages(usages map[string]connector.RESTEndpointUsage) []c
 		if out[i].RateLimited != out[j].RateLimited {
 			return !out[i].RateLimited
 		}
+		if out[i].CredentialIdentity != out[j].CredentialIdentity {
+			return out[i].CredentialIdentity < out[j].CredentialIdentity
+		}
 		return out[i].EndpointFamily < out[j].EndpointFamily
 	})
 	return out
+}
+
+func sortedRESTRateLimitBudgets(budgets map[string]connector.RESTRateLimitBudget) []connector.RESTRateLimitBudget {
+	if len(budgets) == 0 {
+		return nil
+	}
+
+	out := make([]connector.RESTRateLimitBudget, 0, len(budgets))
+	for _, budget := range budgets {
+		out = append(out, budget)
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].CredentialIdentity != out[j].CredentialIdentity {
+			return out[i].CredentialIdentity < out[j].CredentialIdentity
+		}
+		return out[i].EndpointFamily < out[j].EndpointFamily
+	})
+	return out
+}
+
+type restUsageDivergence struct {
+	ObservedDrop           int64
+	DetentBillableRequests int64
+	UnexplainedRequests    int64
+}
+
+func restBudgetDivergence(previous connector.RESTRateLimit, current connector.RESTRateLimit, billable bool) (restUsageDivergence, bool) {
+	if previous.Limit <= 0 || current.Limit != previous.Limit || previous.ResetAt.IsZero() || !current.ResetAt.Equal(previous.ResetAt) {
+		return restUsageDivergence{}, false
+	}
+	observedDrop := previous.Remaining - current.Remaining
+	detentRequests := int64(0)
+	if billable {
+		detentRequests = 1
+	}
+	unexplained := observedDrop - detentRequests
+	divergence := restUsageDivergence{
+		ObservedDrop:           observedDrop,
+		DetentBillableRequests: detentRequests,
+		UnexplainedRequests:    unexplained,
+	}
+	return divergence, unexplained >= restDivergenceMinUnexplained
+}
+
+func restCredentialFamilyKey(credentialIdentity string, family string) string {
+	return credentialIdentity + "\x00" + family
+}
+
+func restCredentialResourceKey(credentialIdentity string, resource string) string {
+	return credentialIdentity + "\x00" + resource
 }
 
 type restBackoffRegistry struct {

--- a/internal/connector/github/client.go
+++ b/internal/connector/github/client.go
@@ -772,6 +772,11 @@ func (c *Client) restSharedBackoffKey(token string) string {
 }
 
 func (c *Client) restCredentialIdentity(token string) string {
+	if source, ok := c.tokenSource.(CredentialIdentitySource); ok {
+		if identity := strings.TrimSpace(source.CredentialIdentity(token)); identity != "" {
+			return identity
+		}
+	}
 	sum := sha256.Sum256([]byte(c.restEndpoint + "\x00" + token))
 	return fmt.Sprintf("github-rest:%x", sum[:6])
 }

--- a/internal/connector/github/client_test.go
+++ b/internal/connector/github/client_test.go
@@ -1152,6 +1152,34 @@ func TestClientFlushRESTRateLimitUsageAttributesEndpointBudgets(t *testing.T) {
 	}
 }
 
+func TestClientRESTCredentialIdentityStaysStableAcrossInstallationTokenRotation(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		source func(*InstallationTokenSource) TokenSource
+	}{
+		{name: "installation source", source: func(source *InstallationTokenSource) TokenSource { return source }},
+		{name: "token resolver", source: func(source *InstallationTokenSource) TokenSource { return &TokenResolver{app: source} }},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			source := &InstallationTokenSource{installationID: "4242", cachedToken: "first-token"}
+			client := &Client{restEndpoint: "https://api.github.com", tokenSource: test.source(source)}
+			first := client.restCredentialIdentity("first-token")
+			source.mu.Lock()
+			source.cachedToken = "second-token"
+			source.mu.Unlock()
+			second := client.restCredentialIdentity("second-token")
+			if first != "github-app-installation:4242" || second != first {
+				t.Fatalf("identities = %q, %q, want stable installation identity", first, second)
+			}
+		})
+	}
+}
+
 func TestClientWarnsOnUnexplainedRESTBudgetDivergence(t *testing.T) {
 	t.Parallel()
 

--- a/internal/connector/github/client_test.go
+++ b/internal/connector/github/client_test.go
@@ -1076,6 +1076,154 @@ func TestClientFlushRESTRateLimitUsagePrefersCoreBudget(t *testing.T) {
 	}
 }
 
+func TestClientFlushRESTRateLimitUsageAttributesEndpointBudgets(t *testing.T) {
+	t.Parallel()
+
+	now := time.Now().UTC().Truncate(time.Second)
+	tests := []struct {
+		path      string
+		resource  string
+		remaining string
+		resetAt   time.Time
+	}{
+		{path: "/repos/digitaldrywood/detent/issues", resource: "core", remaining: "4800", resetAt: now.Add(time.Hour)},
+		{path: "/search/issues?q=repo%3Adigitaldrywood%2Fdetent", resource: "search", remaining: "20", resetAt: now.Add(2 * time.Minute)},
+	}
+	responses := make(map[string]struct {
+		resource  string
+		remaining string
+		resetAt   time.Time
+	}, len(tests))
+	for _, test := range tests {
+		responses[test.path] = struct {
+			resource  string
+			remaining string
+			resetAt   time.Time
+		}{resource: test.resource, remaining: test.remaining, resetAt: test.resetAt}
+	}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		response := responses[r.URL.RequestURI()]
+		w.Header().Set("X-RateLimit-Limit", "5000")
+		w.Header().Set("X-RateLimit-Used", "200")
+		w.Header().Set("X-RateLimit-Remaining", response.remaining)
+		w.Header().Set("X-RateLimit-Reset", strconv.FormatInt(response.resetAt.Unix(), 10))
+		w.Header().Set("X-RateLimit-Resource", response.resource)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`[]`))
+	}))
+	t.Cleanup(server.Close)
+
+	client, err := NewClient(ClientConfig{
+		Endpoint:    server.URL,
+		TokenSource: StaticTokenSource("attribution-token"),
+		HTTPClient:  server.Client(),
+	})
+	if err != nil {
+		t.Fatalf("NewClient() error = %v", err)
+	}
+	for _, test := range tests {
+		if err := client.REST(context.Background(), http.MethodGet, test.path, nil, &[]json.RawMessage{}); err != nil {
+			t.Fatalf("REST(%q) error = %v", test.path, err)
+		}
+	}
+
+	usage := client.FlushRESTRateLimitUsage()
+	if len(usage.Budgets) != len(tests) {
+		t.Fatalf("Budgets len = %d, want %d: %#v", len(usage.Budgets), len(tests), usage.Budgets)
+	}
+	credentialIdentity := usage.Budgets[0].CredentialIdentity
+	if !strings.HasPrefix(credentialIdentity, "github-rest:") {
+		t.Fatalf("CredentialIdentity = %q, want redacted github-rest identity", credentialIdentity)
+	}
+	for _, test := range tests {
+		t.Run(test.resource, func(t *testing.T) {
+			family := restEndpointFamily(http.MethodGet, test.path)
+			for _, budget := range usage.Budgets {
+				if budget.EndpointFamily != family {
+					continue
+				}
+				if budget.CredentialIdentity != credentialIdentity || budget.RateLimit.Resource != test.resource || budget.RateLimit.ResetAt.Unix() != test.resetAt.Unix() {
+					t.Fatalf("budget = %#v, want credential %q resource %q reset %v", budget, credentialIdentity, test.resource, test.resetAt)
+				}
+				return
+			}
+			t.Fatalf("Budgets = %#v, want endpoint family %q", usage.Budgets, family)
+		})
+	}
+}
+
+func TestClientWarnsOnUnexplainedRESTBudgetDivergence(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name            string
+		remaining       []string
+		wantWarning     bool
+		wantUnexplained string
+	}{
+		{name: "detent request explains drop", remaining: []string{"4999", "4998"}},
+		{name: "small external drop stays quiet", remaining: []string{"4999", "4990"}},
+		{name: "worker consumption emits warning", remaining: []string{"4999", "4988"}, wantWarning: true, wantUnexplained: "10"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			resetAt := time.Now().UTC().Add(time.Hour).Truncate(time.Second)
+			var calls atomic.Int64
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				index := int(calls.Add(1)) - 1
+				w.Header().Set("X-RateLimit-Limit", "5000")
+				w.Header().Set("X-RateLimit-Used", strconv.Itoa(5000-mustAtoi(t, test.remaining[index])))
+				w.Header().Set("X-RateLimit-Remaining", test.remaining[index])
+				w.Header().Set("X-RateLimit-Reset", strconv.FormatInt(resetAt.Unix(), 10))
+				w.Header().Set("X-RateLimit-Resource", "core")
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = w.Write([]byte(`[]`))
+			}))
+			t.Cleanup(server.Close)
+
+			var logs bytes.Buffer
+			client, err := NewClient(ClientConfig{
+				Endpoint:    server.URL,
+				TokenSource: StaticTokenSource("divergence-" + test.name),
+				HTTPClient:  server.Client(),
+				Logger:      slog.New(slog.NewTextHandler(&logs, nil)),
+			})
+			if err != nil {
+				t.Fatalf("NewClient() error = %v", err)
+			}
+			for range test.remaining {
+				if err := client.REST(context.Background(), http.MethodGet, "/repos/digitaldrywood/detent/issues", nil, &[]json.RawMessage{}); err != nil {
+					t.Fatalf("REST() error = %v", err)
+				}
+			}
+
+			output := logs.String()
+			warning := strings.Contains(output, "github rest observed usage diverged from detent requests")
+			if warning != test.wantWarning {
+				t.Fatalf("warning = %v, want %v; logs = %s", warning, test.wantWarning, output)
+			}
+			if test.wantWarning {
+				for _, want := range []string{"credential_identity=github-rest:", "unexplained_requests=" + test.wantUnexplained, `likely_external_consumer="worker gh subprocess sharing credential"`} {
+					if !strings.Contains(output, want) {
+						t.Fatalf("logs = %s, want %q", output, want)
+					}
+				}
+			}
+		})
+	}
+}
+
+func mustAtoi(t *testing.T, value string) int {
+	t.Helper()
+	parsed, err := strconv.Atoi(value)
+	if err != nil {
+		t.Fatalf("strconv.Atoi(%q) error = %v", value, err)
+	}
+	return parsed
+}
+
 func TestClientRESTBackoffAppliesAcrossClientsWithSharedToken(t *testing.T) {
 	t.Parallel()
 

--- a/internal/connector/github/token.go
+++ b/internal/connector/github/token.go
@@ -15,6 +15,10 @@ type TokenSource interface {
 	Token(context.Context) (string, error)
 }
 
+type CredentialIdentitySource interface {
+	CredentialIdentity(string) string
+}
+
 type RefreshableTokenSource interface {
 	TokenSource
 	RefreshToken(context.Context) (string, error)
@@ -150,6 +154,15 @@ func (r *TokenResolver) Token(ctx context.Context) (string, error) {
 		return "", appErr
 	}
 	return "", ErrMissingToken
+}
+
+func (r *TokenResolver) CredentialIdentity(token string) string {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.app == nil {
+		return ""
+	}
+	return r.app.CredentialIdentity(token)
 }
 
 func (r *TokenResolver) gitHubAppToken(ctx context.Context) (string, error) {

--- a/internal/connector/ratelimit.go
+++ b/internal/connector/ratelimit.go
@@ -53,25 +53,33 @@ type RESTRateLimit struct {
 }
 
 type RESTEndpointUsage struct {
-	EndpointFamily string
-	Count          int64
-	Conditional    int64
-	NotModified    int64
-	Billable       int64
-	Limit          int64
-	Used           int64
-	Remaining      int64
-	Resource       string
-	ResetAt        time.Time
-	RetryAfter     time.Duration
-	RateLimited    bool
-	LastStatus     int
+	CredentialIdentity string
+	EndpointFamily     string
+	Count              int64
+	Conditional        int64
+	NotModified        int64
+	Billable           int64
+	Limit              int64
+	Used               int64
+	Remaining          int64
+	Resource           string
+	ResetAt            time.Time
+	RetryAfter         time.Duration
+	RateLimited        bool
+	LastStatus         int
+}
+
+type RESTRateLimitBudget struct {
+	CredentialIdentity string
+	EndpointFamily     string
+	RateLimit          RESTRateLimit
 }
 
 type RESTRateLimitUsage struct {
 	RateLimit           RESTRateLimit
 	HasRateLimit        bool
 	Requests            []RESTEndpointUsage
+	Budgets             []RESTRateLimitBudget
 	TotalRequests       int64
 	ConditionalRequests int64
 	NotModifiedRequests int64

--- a/internal/operatortool/executor.go
+++ b/internal/operatortool/executor.go
@@ -294,6 +294,7 @@ func boundedRateLimits(rateLimits *telemetry.RateLimits) *telemetry.RateLimits {
 		return nil
 	}
 	result := *rateLimits
+	result.GitHubRESTBudgets = boundedClone(rateLimits.GitHubRESTBudgets, MaxItemLimit)
 	if rateLimits.GraphQLCost != nil {
 		graphql := *rateLimits.GraphQLCost
 		graphql.Contributors = boundedClone(graphql.Contributors, MaxItemLimit)

--- a/internal/orchestrator/rate_limit_test.go
+++ b/internal/orchestrator/rate_limit_test.go
@@ -386,8 +386,12 @@ func TestTickPublishesGitHubRESTUsageAndBackoff(t *testing.T) {
 				UpdatedAt:  now,
 			},
 			Requests: []connector.RESTEndpointUsage{
-				{EndpointFamily: "label issues", Count: 1, Conditional: 1, NotModified: 1, Remaining: 4879, Limit: 5000, Resource: "core"},
-				{EndpointFamily: "issue comments", Count: 1, Billable: 1, Remaining: 4878, Limit: 5000, Resource: "core", RateLimited: true},
+				{CredentialIdentity: "github-rest:shared", EndpointFamily: "label issues", Count: 1, Conditional: 1, NotModified: 1, Remaining: 4879, Limit: 5000, Resource: "core"},
+				{CredentialIdentity: "github-rest:shared", EndpointFamily: "issue comments", Count: 1, Billable: 1, Remaining: 4878, Limit: 5000, Resource: "core", RateLimited: true},
+			},
+			Budgets: []connector.RESTRateLimitBudget{
+				{CredentialIdentity: "github-rest:shared", EndpointFamily: "label issues", RateLimit: connector.RESTRateLimit{Limit: 5000, Remaining: 4879, Resource: "core", ResetAt: now.Add(time.Hour), UpdatedAt: now}},
+				{CredentialIdentity: "github-rest:shared", EndpointFamily: "issue comments", RateLimit: connector.RESTRateLimit{Limit: 5000, Remaining: 4878, Resource: "core", ResetAt: now.Add(2 * time.Hour), UpdatedAt: now}},
 			},
 			TotalRequests:       2,
 			ConditionalRequests: 1,
@@ -421,6 +425,12 @@ func TestTickPublishesGitHubRESTUsageAndBackoff(t *testing.T) {
 	}
 	if len(state.RateLimits.RESTUsage.Contributors) != 2 || state.RateLimits.RESTUsage.Contributors[1].EndpointFamily != "issue comments" {
 		t.Fatalf("RESTUsage.Contributors = %#v, want issue comments contributor", state.RateLimits.RESTUsage.Contributors)
+	}
+	if len(state.RateLimits.GitHubRESTBudgets) != 2 || state.RateLimits.GitHubRESTBudgets[0].CredentialIdentity != "github-rest:shared" {
+		t.Fatalf("GitHubRESTBudgets = %#v, want attributed endpoint budgets", state.RateLimits.GitHubRESTBudgets)
+	}
+	if state.RateLimits.GitHubRESTBudgets[0].ResetAt == nil || state.RateLimits.GitHubRESTBudgets[1].ResetAt == nil || state.RateLimits.GitHubRESTBudgets[0].ResetAt.Equal(*state.RateLimits.GitHubRESTBudgets[1].ResetAt) {
+		t.Fatalf("GitHubRESTBudgets = %#v, want distinct endpoint reset windows", state.RateLimits.GitHubRESTBudgets)
 	}
 	if state.PollInterval != time.Minute {
 		t.Fatalf("PollInterval = %s, want REST retry-after pause 1m", state.PollInterval)

--- a/internal/orchestrator/rate_limits.go
+++ b/internal/orchestrator/rate_limits.go
@@ -26,6 +26,7 @@ type graphQLRateLimitCycle struct {
 
 type restRateLimitCycle struct {
 	Bucket     *telemetry.RateLimitBucket
+	Budgets    []telemetry.RESTBudget
 	Usage      *telemetry.RESTUsage
 	HasSummary bool
 }
@@ -83,14 +84,17 @@ func (o *Orchestrator) captureConnectorRESTRateLimits(state *State, now time.Tim
 	}
 
 	bucket := gitHubRESTBucket(usage, now)
+	budgets := restBudgetSummaries(usage.Budgets)
 	summary := restUsageSummary(usage)
 	if state.RateLimits == nil {
 		state.RateLimits = &telemetry.RateLimits{}
 	}
 	state.RateLimits.GitHubREST = bucket
+	state.RateLimits.GitHubRESTBudgets = budgets
 	state.RateLimits.RESTUsage = summary
 	return restRateLimitCycle{
 		Bucket:     bucket,
+		Budgets:    budgets,
 		Usage:      summary,
 		HasSummary: true,
 	}
@@ -115,16 +119,17 @@ func restUsageSummary(usage connector.RESTRateLimitUsage) *telemetry.RESTUsage {
 	}
 	for _, request := range usage.Requests {
 		contributor := telemetry.RESTUsageContributor{
-			EndpointFamily: request.EndpointFamily,
-			Count:          request.Count,
-			Conditional:    request.Conditional,
-			NotModified:    request.NotModified,
-			Billable:       request.Billable,
-			Remaining:      request.Remaining,
-			Limit:          request.Limit,
-			Resource:       request.Resource,
-			RateLimited:    request.RateLimited,
-			LastStatus:     request.LastStatus,
+			CredentialIdentity: request.CredentialIdentity,
+			EndpointFamily:     request.EndpointFamily,
+			Count:              request.Count,
+			Conditional:        request.Conditional,
+			NotModified:        request.NotModified,
+			Billable:           request.Billable,
+			Remaining:          request.Remaining,
+			Limit:              request.Limit,
+			Resource:           request.Resource,
+			RateLimited:        request.RateLimited,
+			LastStatus:         request.LastStatus,
 		}
 		if !request.ResetAt.IsZero() {
 			resetAt := request.ResetAt
@@ -134,6 +139,33 @@ func restUsageSummary(usage connector.RESTRateLimitUsage) *telemetry.RESTUsage {
 			contributor.RetryAfterMS = request.RetryAfter.Milliseconds()
 		}
 		out.Contributors = append(out.Contributors, contributor)
+	}
+	return out
+}
+
+func restBudgetSummaries(budgets []connector.RESTRateLimitBudget) []telemetry.RESTBudget {
+	if len(budgets) == 0 {
+		return nil
+	}
+	out := make([]telemetry.RESTBudget, 0, len(budgets))
+	for _, budget := range budgets {
+		summary := telemetry.RESTBudget{
+			CredentialIdentity: budget.CredentialIdentity,
+			EndpointFamily:     budget.EndpointFamily,
+			Resource:           budget.RateLimit.Resource,
+			Remaining:          budget.RateLimit.Remaining,
+			Used:               budget.RateLimit.Used,
+			Limit:              budget.RateLimit.Limit,
+		}
+		if !budget.RateLimit.ResetAt.IsZero() {
+			resetAt := budget.RateLimit.ResetAt
+			summary.ResetAt = &resetAt
+		}
+		if !budget.RateLimit.UpdatedAt.IsZero() {
+			observedAt := budget.RateLimit.UpdatedAt
+			summary.ObservedAt = &observedAt
+		}
+		out = append(out, summary)
 	}
 	return out
 }
@@ -208,6 +240,7 @@ func (o *Orchestrator) logRESTRateLimitCycle(cycle restRateLimitCycle) {
 		"remaining", cycle.Bucket.Remaining,
 		"limit", cycle.Bucket.Limit,
 		"reset_at", resetAt,
+		"credential_budgets", cycle.Budgets,
 		"contributors", contributors,
 	)
 }

--- a/internal/orchestrator/state.go
+++ b/internal/orchestrator/state.go
@@ -688,6 +688,7 @@ func cloneRateLimits(rateLimits *telemetry.RateLimits) *telemetry.RateLimits {
 	cloned.Credits = cloneRateLimitBucket(rateLimits.Credits)
 	cloned.GitHubGraphQL = cloneRateLimitBucket(rateLimits.GitHubGraphQL)
 	cloned.GitHubREST = cloneRateLimitBucket(rateLimits.GitHubREST)
+	cloned.GitHubRESTBudgets = cloneRESTBudgets(rateLimits.GitHubRESTBudgets)
 	cloned.GraphQLCost = cloneGraphQLCost(rateLimits.GraphQLCost)
 	cloned.RESTUsage = cloneRESTUsage(rateLimits.RESTUsage)
 	return &cloned
@@ -706,6 +707,9 @@ func mergeRateLimits(current *telemetry.RateLimits, incoming *telemetry.RateLimi
 	}
 	if current != nil && current.GitHubREST != nil && merged.GitHubREST == nil {
 		merged.GitHubREST = cloneRateLimitBucket(current.GitHubREST)
+	}
+	if current != nil && len(current.GitHubRESTBudgets) > 0 && len(merged.GitHubRESTBudgets) == 0 {
+		merged.GitHubRESTBudgets = cloneRESTBudgets(current.GitHubRESTBudgets)
 	}
 	if current != nil && current.RESTUsage != nil && merged.RESTUsage == nil {
 		merged.RESTUsage = cloneRESTUsage(current.RESTUsage)
@@ -763,6 +767,24 @@ func cloneRESTUsage(usage *telemetry.RESTUsage) *telemetry.RESTUsage {
 		}
 	}
 	return &cloned
+}
+
+func cloneRESTBudgets(budgets []telemetry.RESTBudget) []telemetry.RESTBudget {
+	if len(budgets) == 0 {
+		return nil
+	}
+	cloned := append([]telemetry.RESTBudget(nil), budgets...)
+	for index := range cloned {
+		if budgets[index].ResetAt != nil {
+			resetAt := *budgets[index].ResetAt
+			cloned[index].ResetAt = &resetAt
+		}
+		if budgets[index].ObservedAt != nil {
+			observedAt := *budgets[index].ObservedAt
+			cloned[index].ObservedAt = &observedAt
+		}
+	}
+	return cloned
 }
 
 func cloneTelemetryWorkAttempts(values []telemetry.WorkAttempt) []telemetry.WorkAttempt {

--- a/internal/telemetry/snapshot.go
+++ b/internal/telemetry/snapshot.go
@@ -756,16 +756,17 @@ type BudgetRefusal struct {
 }
 
 type RateLimits struct {
-	LimitID       string           `json:"limit_id,omitempty"`
-	LimitName     string           `json:"limit_name,omitempty"`
-	ReachedType   string           `json:"reached_type,omitempty"`
-	Primary       *RateLimitBucket `json:"primary,omitempty"`
-	Secondary     *RateLimitBucket `json:"secondary,omitempty"`
-	Credits       *RateLimitBucket `json:"credits,omitempty"`
-	GitHubGraphQL *RateLimitBucket `json:"github_graphql,omitempty"`
-	GitHubREST    *RateLimitBucket `json:"github_rest,omitempty"`
-	GraphQLCost   *GraphQLCost     `json:"graphql_cost,omitempty"`
-	RESTUsage     *RESTUsage       `json:"rest_usage,omitempty"`
+	LimitID           string           `json:"limit_id,omitempty"`
+	LimitName         string           `json:"limit_name,omitempty"`
+	ReachedType       string           `json:"reached_type,omitempty"`
+	Primary           *RateLimitBucket `json:"primary,omitempty"`
+	Secondary         *RateLimitBucket `json:"secondary,omitempty"`
+	Credits           *RateLimitBucket `json:"credits,omitempty"`
+	GitHubGraphQL     *RateLimitBucket `json:"github_graphql,omitempty"`
+	GitHubREST        *RateLimitBucket `json:"github_rest,omitempty"`
+	GitHubRESTBudgets []RESTBudget     `json:"github_rest_budgets,omitempty"`
+	GraphQLCost       *GraphQLCost     `json:"graphql_cost,omitempty"`
+	RESTUsage         *RESTUsage       `json:"rest_usage,omitempty"`
 }
 
 type BackendOutage struct {
@@ -830,18 +831,30 @@ type RESTUsage struct {
 }
 
 type RESTUsageContributor struct {
-	EndpointFamily string     `json:"endpoint_family"`
-	Count          int64      `json:"count"`
-	Conditional    int64      `json:"conditional,omitempty"`
-	NotModified    int64      `json:"not_modified,omitempty"`
-	Billable       int64      `json:"billable,omitempty"`
-	Remaining      int64      `json:"remaining,omitempty"`
-	Limit          int64      `json:"limit,omitempty"`
-	Resource       string     `json:"resource,omitempty"`
-	ResetAt        *time.Time `json:"reset_at,omitempty"`
-	RetryAfterMS   int64      `json:"retry_after_ms,omitempty"`
-	RateLimited    bool       `json:"rate_limited,omitempty"`
-	LastStatus     int        `json:"last_status,omitempty"`
+	CredentialIdentity string     `json:"credential_identity,omitempty"`
+	EndpointFamily     string     `json:"endpoint_family"`
+	Count              int64      `json:"count"`
+	Conditional        int64      `json:"conditional,omitempty"`
+	NotModified        int64      `json:"not_modified,omitempty"`
+	Billable           int64      `json:"billable,omitempty"`
+	Remaining          int64      `json:"remaining,omitempty"`
+	Limit              int64      `json:"limit,omitempty"`
+	Resource           string     `json:"resource,omitempty"`
+	ResetAt            *time.Time `json:"reset_at,omitempty"`
+	RetryAfterMS       int64      `json:"retry_after_ms,omitempty"`
+	RateLimited        bool       `json:"rate_limited,omitempty"`
+	LastStatus         int        `json:"last_status,omitempty"`
+}
+
+type RESTBudget struct {
+	CredentialIdentity string     `json:"credential_identity"`
+	EndpointFamily     string     `json:"endpoint_family"`
+	Resource           string     `json:"resource,omitempty"`
+	Remaining          int64      `json:"remaining,omitempty"`
+	Used               int64      `json:"used,omitempty"`
+	Limit              int64      `json:"limit,omitempty"`
+	ResetAt            *time.Time `json:"reset_at,omitempty"`
+	ObservedAt         *time.Time `json:"observed_at,omitempty"`
 }
 
 type Tokens struct {

--- a/internal/web/templates/dashboard.templ
+++ b/internal/web/templates/dashboard.templ
@@ -4344,17 +4344,30 @@ templ restBudgetCard(data DashboardData) {
 				<span class="shrink-0 rounded-full bg-warn/15 px-2 py-1 font-mono text-xs font-medium text-warn">{ restBudgetRequestCount(data.Snapshot.RateLimits) }</span>
 			}
 			<div class="mt-5 grid gap-3">
-				<div class="grid grid-cols-2 gap-3 text-sm">
-					<div class="grid gap-1">
-						<span class="text-sec">Remaining</span>
-						<strong class="break-all font-mono text-base font-semibold text-text">{ restBudgetRemaining(data.Snapshot.RateLimits) }</strong>
+				if len(data.Snapshot.RateLimits.GitHubRESTBudgets) > 0 {
+					<div class="grid grid-cols-2 gap-3 text-sm">
+						<div class="grid gap-1">
+							<span class="text-sec">Credentials</span>
+							<strong class="font-mono text-base font-semibold text-text">{ formatInt(restBudgetCredentialCount(data.Snapshot.RateLimits)) }</strong>
+						</div>
+						<div class="grid gap-1">
+							<span class="text-sec">Endpoint budgets</span>
+							<strong class="font-mono text-base font-semibold text-text">{ formatInt(int64(len(data.Snapshot.RateLimits.GitHubRESTBudgets))) }</strong>
+						</div>
 					</div>
-					<div class="grid gap-1">
-						<span class="text-sec">Reset</span>
-						<strong class="font-mono text-base font-semibold text-text">{ restBudgetReset(data.Snapshot.RateLimits, data.Snapshot.GeneratedAt) }</strong>
-						<span class="font-mono text-xs text-sec">{ restBudgetResetAt(data.Snapshot.RateLimits) }</span>
+				} else {
+					<div class="grid grid-cols-2 gap-3 text-sm">
+						<div class="grid gap-1">
+							<span class="text-sec">Remaining</span>
+							<strong class="break-all font-mono text-base font-semibold text-text">{ restBudgetRemaining(data.Snapshot.RateLimits) }</strong>
+						</div>
+						<div class="grid gap-1">
+							<span class="text-sec">Reset</span>
+							<strong class="font-mono text-base font-semibold text-text">{ restBudgetReset(data.Snapshot.RateLimits, data.Snapshot.GeneratedAt) }</strong>
+							<span class="font-mono text-xs text-sec">{ restBudgetResetAt(data.Snapshot.RateLimits) }</span>
+						</div>
 					</div>
-				</div>
+				}
 				if len(restBudgetContributorRows(data.Snapshot.RateLimits)) == 0 {
 					@dashboardEmptyState("No REST requests this cycle.", "REST contributors will appear after GitHub REST endpoints are called.", "bg-warn")
 				} else {
@@ -4370,9 +4383,11 @@ templ restBudgetCard(data DashboardData) {
 							for _, row := range restBudgetContributorRows(data.Snapshot.RateLimits) {
 								<div class="grid grid-cols-[minmax(0,1fr)_auto] items-center gap-x-3 gap-y-1 text-sm">
 									<span class="truncate font-mono font-medium text-text">{ row.EndpointFamily }</span>
-									<span class="font-mono text-sec">{ row.Count }</span>
-									<span class="font-mono text-xs text-sec">{ row.Remaining }</span>
-									<span class="text-right font-mono text-xs text-sec">{ row.Status }</span>
+									<span class="font-mono text-sec">{ row.Remaining }</span>
+									<span class="truncate font-mono text-xs text-sec">{ row.CredentialIdentity }</span>
+									<span class="text-right font-mono text-xs text-sec">{ row.Reset }</span>
+									<span class="truncate font-mono text-xs text-sec">{ row.Resource }</span>
+									<span class="text-right font-mono text-xs text-sec">{ row.Count + " · " + row.Status }</span>
 								</div>
 							}
 						</div>

--- a/internal/web/templates/dashboard_data.go
+++ b/internal/web/templates/dashboard_data.go
@@ -193,11 +193,13 @@ type graphQLBudgetContributorRow struct {
 }
 
 type restBudgetContributorRow struct {
-	EndpointFamily string
-	Count          string
-	Remaining      string
-	Reset          string
-	Status         string
+	CredentialIdentity string
+	EndpointFamily     string
+	Resource           string
+	Count              string
+	Remaining          string
+	Reset              string
+	Status             string
 }
 
 type gitHubAPIHealthState string
@@ -7063,7 +7065,7 @@ func hasGraphQLBudget(limits *telemetry.RateLimits) bool {
 }
 
 func hasRESTBudget(limits *telemetry.RateLimits) bool {
-	return limits != nil && (limits.GitHubREST != nil || limits.RESTUsage != nil)
+	return limits != nil && (limits.GitHubREST != nil || len(limits.GitHubRESTBudgets) > 0 || limits.RESTUsage != nil)
 }
 
 func graphQLBudgetRemaining(limits *telemetry.RateLimits) string {
@@ -7185,20 +7187,73 @@ func restBudgetRequestCount(limits *telemetry.RateLimits) string {
 }
 
 func restBudgetContributorRows(limits *telemetry.RateLimits) []restBudgetContributorRow {
+	if limits != nil && len(limits.GitHubRESTBudgets) > 0 {
+		contributors := make(map[string]telemetry.RESTUsageContributor)
+		if limits.RESTUsage != nil {
+			for _, contributor := range limits.RESTUsage.Contributors {
+				contributors[restBudgetRowKey(contributor.CredentialIdentity, contributor.EndpointFamily, contributor.Resource)] = contributor
+			}
+		}
+		rows := make([]restBudgetContributorRow, 0, len(limits.GitHubRESTBudgets))
+		for _, budget := range limits.GitHubRESTBudgets {
+			contributor := contributors[restBudgetRowKey(budget.CredentialIdentity, budget.EndpointFamily, budget.Resource)]
+			rows = append(rows, restBudgetContributorRow{
+				CredentialIdentity: strings.TrimSpace(budget.CredentialIdentity),
+				EndpointFamily:     strings.TrimSpace(budget.EndpointFamily),
+				Resource:           strings.TrimSpace(budget.Resource),
+				Count:              formatInt(contributor.Count) + " " + pluralize("request", contributor.Count),
+				Remaining:          restBudgetRowRemaining(budget),
+				Reset:              restBudgetRowReset(budget),
+				Status:             restContributorStatus(contributor),
+			})
+		}
+		return rows
+	}
 	if limits == nil || limits.RESTUsage == nil || len(limits.RESTUsage.Contributors) == 0 {
 		return nil
 	}
 	rows := make([]restBudgetContributorRow, 0, len(limits.RESTUsage.Contributors))
 	for _, contributor := range limits.RESTUsage.Contributors {
 		rows = append(rows, restBudgetContributorRow{
-			EndpointFamily: strings.TrimSpace(contributor.EndpointFamily),
-			Count:          formatInt(contributor.Count) + " " + pluralize("request", contributor.Count),
-			Remaining:      restContributorRemaining(contributor),
-			Reset:          restContributorReset(contributor),
-			Status:         restContributorStatus(contributor),
+			CredentialIdentity: strings.TrimSpace(contributor.CredentialIdentity),
+			EndpointFamily:     strings.TrimSpace(contributor.EndpointFamily),
+			Resource:           strings.TrimSpace(contributor.Resource),
+			Count:              formatInt(contributor.Count) + " " + pluralize("request", contributor.Count),
+			Remaining:          restContributorRemaining(contributor),
+			Reset:              restContributorReset(contributor),
+			Status:             restContributorStatus(contributor),
 		})
 	}
 	return rows
+}
+
+func restBudgetRowKey(credentialIdentity string, endpointFamily string, resource string) string {
+	return strings.TrimSpace(credentialIdentity) + "\x00" + strings.TrimSpace(endpointFamily) + "\x00" + strings.TrimSpace(resource)
+}
+
+func restBudgetRowRemaining(budget telemetry.RESTBudget) string {
+	if budget.Limit > 0 {
+		return formatInt(budget.Remaining) + " / " + formatInt(budget.Limit)
+	}
+	return formatInt(budget.Remaining) + " left"
+}
+
+func restBudgetRowReset(budget telemetry.RESTBudget) string {
+	if budget.ResetAt == nil {
+		return "reset n/a"
+	}
+	return localTimeToken(*budget.ResetAt, LocalTimeOnly)
+}
+
+func restBudgetCredentialCount(limits *telemetry.RateLimits) int64 {
+	if limits == nil {
+		return 0
+	}
+	identities := make(map[string]struct{}, len(limits.GitHubRESTBudgets))
+	for _, budget := range limits.GitHubRESTBudgets {
+		identities[strings.TrimSpace(budget.CredentialIdentity)] = struct{}{}
+	}
+	return int64(len(identities))
 }
 
 func restContributorRemaining(contributor telemetry.RESTUsageContributor) string {

--- a/internal/web/templates/dashboard_data_test.go
+++ b/internal/web/templates/dashboard_data_test.go
@@ -491,6 +491,50 @@ func TestGitHubAPIHealthDerivesStatus(t *testing.T) {
 	}
 }
 
+func TestRESTBudgetContributorRowsPreserveCredentialAndEndpointWindows(t *testing.T) {
+	t.Parallel()
+
+	coreReset := time.Date(2026, 8, 8, 19, 0, 0, 0, time.UTC)
+	searchReset := coreReset.Add(-45 * time.Minute)
+	limits := &telemetry.RateLimits{
+		GitHubRESTBudgets: []telemetry.RESTBudget{
+			{CredentialIdentity: "github-rest:user", EndpointFamily: "issues", Resource: "core", Remaining: 300, Limit: 5000, ResetAt: &coreReset},
+			{CredentialIdentity: "github-rest:app", EndpointFamily: "issue search", Resource: "search", Remaining: 20, Limit: 30, ResetAt: &searchReset},
+		},
+		RESTUsage: &telemetry.RESTUsage{Contributors: []telemetry.RESTUsageContributor{
+			{CredentialIdentity: "github-rest:user", EndpointFamily: "issues", Resource: "core", Count: 4, LastStatus: 200},
+			{CredentialIdentity: "github-rest:app", EndpointFamily: "issue search", Resource: "search", Count: 1, LastStatus: 200},
+		}},
+	}
+
+	rows := restBudgetContributorRows(limits)
+	if len(rows) != 2 {
+		t.Fatalf("rows len = %d, want 2: %#v", len(rows), rows)
+	}
+	tests := []struct {
+		index      int
+		credential string
+		family     string
+		resource   string
+		remaining  string
+		resetAt    time.Time
+	}{
+		{index: 0, credential: "github-rest:user", family: "issues", resource: "core", remaining: "300 / 5,000", resetAt: coreReset},
+		{index: 1, credential: "github-rest:app", family: "issue search", resource: "search", remaining: "20 / 30", resetAt: searchReset},
+	}
+	for _, test := range tests {
+		t.Run(test.family, func(t *testing.T) {
+			row := rows[test.index]
+			if row.CredentialIdentity != test.credential || row.EndpointFamily != test.family || row.Resource != test.resource || row.Remaining != test.remaining || row.Reset != localTimeToken(test.resetAt, LocalTimeOnly) {
+				t.Fatalf("row = %#v, want credential %q family %q resource %q remaining %q reset %v", row, test.credential, test.family, test.resource, test.remaining, test.resetAt)
+			}
+		})
+	}
+	if got := restBudgetCredentialCount(limits); got != 2 {
+		t.Fatalf("restBudgetCredentialCount() = %d, want 2", got)
+	}
+}
+
 func TestGraphQLUnknownStatusFormatsBudgetLabels(t *testing.T) {
 	t.Parallel()
 

--- a/internal/web/templates/dashboard_templ.go
+++ b/internal/web/templates/dashboard_templ.go
@@ -15581,48 +15581,85 @@ func restBudgetCard(data DashboardData) templ.Component {
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1143, "<div class=\"mt-5 grid gap-3\"><div class=\"grid grid-cols-2 gap-3 text-sm\"><div class=\"grid gap-1\"><span class=\"text-sec\">Remaining</span> <strong class=\"break-all font-mono text-base font-semibold text-text\">")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1143, "<div class=\"mt-5 grid gap-3\">")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			var templ_7745c5c3_Var752 string
-			templ_7745c5c3_Var752, templ_7745c5c3_Err = templ.JoinStringErrs(restBudgetRemaining(data.Snapshot.RateLimits))
-			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/dashboard.templ`, Line: 4350, Col: 123}
-			}
-			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var752))
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1144, "</strong></div><div class=\"grid gap-1\"><span class=\"text-sec\">Reset</span> <strong class=\"font-mono text-base font-semibold text-text\">")
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
-			var templ_7745c5c3_Var753 string
-			templ_7745c5c3_Var753, templ_7745c5c3_Err = templ.JoinStringErrs(restBudgetReset(data.Snapshot.RateLimits, data.Snapshot.GeneratedAt))
-			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/dashboard.templ`, Line: 4354, Col: 136}
-			}
-			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var753))
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1145, "</strong> <span class=\"font-mono text-xs text-sec\">")
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
-			var templ_7745c5c3_Var754 string
-			templ_7745c5c3_Var754, templ_7745c5c3_Err = templ.JoinStringErrs(restBudgetResetAt(data.Snapshot.RateLimits))
-			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/dashboard.templ`, Line: 4355, Col: 92}
-			}
-			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var754))
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1146, "</span></div></div>")
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
+			if len(data.Snapshot.RateLimits.GitHubRESTBudgets) > 0 {
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1144, "<div class=\"grid grid-cols-2 gap-3 text-sm\"><div class=\"grid gap-1\"><span class=\"text-sec\">Credentials</span> <strong class=\"font-mono text-base font-semibold text-text\">")
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+				var templ_7745c5c3_Var752 string
+				templ_7745c5c3_Var752, templ_7745c5c3_Err = templ.JoinStringErrs(formatInt(restBudgetCredentialCount(data.Snapshot.RateLimits)))
+				if templ_7745c5c3_Err != nil {
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/dashboard.templ`, Line: 4351, Col: 131}
+				}
+				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var752))
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1145, "</strong></div><div class=\"grid gap-1\"><span class=\"text-sec\">Endpoint budgets</span> <strong class=\"font-mono text-base font-semibold text-text\">")
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+				var templ_7745c5c3_Var753 string
+				templ_7745c5c3_Var753, templ_7745c5c3_Err = templ.JoinStringErrs(formatInt(int64(len(data.Snapshot.RateLimits.GitHubRESTBudgets))))
+				if templ_7745c5c3_Err != nil {
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/dashboard.templ`, Line: 4355, Col: 134}
+				}
+				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var753))
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1146, "</strong></div></div>")
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+			} else {
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1147, "<div class=\"grid grid-cols-2 gap-3 text-sm\"><div class=\"grid gap-1\"><span class=\"text-sec\">Remaining</span> <strong class=\"break-all font-mono text-base font-semibold text-text\">")
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+				var templ_7745c5c3_Var754 string
+				templ_7745c5c3_Var754, templ_7745c5c3_Err = templ.JoinStringErrs(restBudgetRemaining(data.Snapshot.RateLimits))
+				if templ_7745c5c3_Err != nil {
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/dashboard.templ`, Line: 4362, Col: 124}
+				}
+				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var754))
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1148, "</strong></div><div class=\"grid gap-1\"><span class=\"text-sec\">Reset</span> <strong class=\"font-mono text-base font-semibold text-text\">")
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+				var templ_7745c5c3_Var755 string
+				templ_7745c5c3_Var755, templ_7745c5c3_Err = templ.JoinStringErrs(restBudgetReset(data.Snapshot.RateLimits, data.Snapshot.GeneratedAt))
+				if templ_7745c5c3_Err != nil {
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/dashboard.templ`, Line: 4366, Col: 137}
+				}
+				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var755))
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1149, "</strong> <span class=\"font-mono text-xs text-sec\">")
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+				var templ_7745c5c3_Var756 string
+				templ_7745c5c3_Var756, templ_7745c5c3_Err = templ.JoinStringErrs(restBudgetResetAt(data.Snapshot.RateLimits))
+				if templ_7745c5c3_Err != nil {
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/dashboard.templ`, Line: 4367, Col: 93}
+				}
+				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var756))
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1150, "</span></div></div>")
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
 			}
 			if len(restBudgetContributorRows(data.Snapshot.RateLimits)) == 0 {
 				templ_7745c5c3_Err = dashboardEmptyState("No REST requests this cycle.", "REST contributors will appear after GitHub REST endpoints are called.", "bg-warn").Render(ctx, templ_7745c5c3_Buffer)
@@ -15630,20 +15667,20 @@ func restBudgetCard(data DashboardData) templ.Component {
 					return templ_7745c5c3_Err
 				}
 			} else {
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1147, "<details class=\"group border-t border-line pt-3\" data-preserve-details=\"rest-budget-contributors\"><summary class=\"flex cursor-pointer list-none items-center justify-between gap-3 text-sm text-sec marker:hidden\"><span class=\"font-medium text-text\">Endpoint details</span> <span class=\"inline-flex shrink-0 items-center gap-2\"><span class=\"rounded-md bg-elev px-2 py-1 font-mono text-xs text-sec\">")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1151, "<details class=\"group border-t border-line pt-3\" data-preserve-details=\"rest-budget-contributors\"><summary class=\"flex cursor-pointer list-none items-center justify-between gap-3 text-sm text-sec marker:hidden\"><span class=\"font-medium text-text\">Endpoint details</span> <span class=\"inline-flex shrink-0 items-center gap-2\"><span class=\"rounded-md bg-elev px-2 py-1 font-mono text-xs text-sec\">")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				var templ_7745c5c3_Var755 string
-				templ_7745c5c3_Var755, templ_7745c5c3_Err = templ.JoinStringErrs(formatInt(int64(len(restBudgetContributorRows(data.Snapshot.RateLimits)))))
+				var templ_7745c5c3_Var757 string
+				templ_7745c5c3_Var757, templ_7745c5c3_Err = templ.JoinStringErrs(formatInt(int64(len(restBudgetContributorRows(data.Snapshot.RateLimits)))))
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/dashboard.templ`, Line: 4365, Col: 154}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/dashboard.templ`, Line: 4378, Col: 154}
 				}
-				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var755))
+				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var757))
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1148, "</span>")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1152, "</span>")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
@@ -15651,74 +15688,100 @@ func restBudgetCard(data DashboardData) templ.Component {
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1149, "</span></summary><div class=\"mt-3 grid gap-2\">")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1153, "</span></summary><div class=\"mt-3 grid gap-2\">")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
 				for _, row := range restBudgetContributorRows(data.Snapshot.RateLimits) {
-					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1150, "<div class=\"grid grid-cols-[minmax(0,1fr)_auto] items-center gap-x-3 gap-y-1 text-sm\"><span class=\"truncate font-mono font-medium text-text\">")
-					if templ_7745c5c3_Err != nil {
-						return templ_7745c5c3_Err
-					}
-					var templ_7745c5c3_Var756 string
-					templ_7745c5c3_Var756, templ_7745c5c3_Err = templ.JoinStringErrs(row.EndpointFamily)
-					if templ_7745c5c3_Err != nil {
-						return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/dashboard.templ`, Line: 4372, Col: 84}
-					}
-					_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var756))
-					if templ_7745c5c3_Err != nil {
-						return templ_7745c5c3_Err
-					}
-					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1151, "</span> <span class=\"font-mono text-sec\">")
-					if templ_7745c5c3_Err != nil {
-						return templ_7745c5c3_Err
-					}
-					var templ_7745c5c3_Var757 string
-					templ_7745c5c3_Var757, templ_7745c5c3_Err = templ.JoinStringErrs(row.Count)
-					if templ_7745c5c3_Err != nil {
-						return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/dashboard.templ`, Line: 4373, Col: 53}
-					}
-					_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var757))
-					if templ_7745c5c3_Err != nil {
-						return templ_7745c5c3_Err
-					}
-					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1152, "</span> <span class=\"font-mono text-xs text-sec\">")
+					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1154, "<div class=\"grid grid-cols-[minmax(0,1fr)_auto] items-center gap-x-3 gap-y-1 text-sm\"><span class=\"truncate font-mono font-medium text-text\">")
 					if templ_7745c5c3_Err != nil {
 						return templ_7745c5c3_Err
 					}
 					var templ_7745c5c3_Var758 string
-					templ_7745c5c3_Var758, templ_7745c5c3_Err = templ.JoinStringErrs(row.Remaining)
+					templ_7745c5c3_Var758, templ_7745c5c3_Err = templ.JoinStringErrs(row.EndpointFamily)
 					if templ_7745c5c3_Err != nil {
-						return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/dashboard.templ`, Line: 4374, Col: 65}
+						return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/dashboard.templ`, Line: 4385, Col: 84}
 					}
 					_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var758))
 					if templ_7745c5c3_Err != nil {
 						return templ_7745c5c3_Err
 					}
-					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1153, "</span> <span class=\"text-right font-mono text-xs text-sec\">")
+					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1155, "</span> <span class=\"font-mono text-sec\">")
 					if templ_7745c5c3_Err != nil {
 						return templ_7745c5c3_Err
 					}
 					var templ_7745c5c3_Var759 string
-					templ_7745c5c3_Var759, templ_7745c5c3_Err = templ.JoinStringErrs(row.Status)
+					templ_7745c5c3_Var759, templ_7745c5c3_Err = templ.JoinStringErrs(row.Remaining)
 					if templ_7745c5c3_Err != nil {
-						return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/dashboard.templ`, Line: 4375, Col: 73}
+						return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/dashboard.templ`, Line: 4386, Col: 57}
 					}
 					_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var759))
 					if templ_7745c5c3_Err != nil {
 						return templ_7745c5c3_Err
 					}
-					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1154, "</span></div>")
+					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1156, "</span> <span class=\"truncate font-mono text-xs text-sec\">")
+					if templ_7745c5c3_Err != nil {
+						return templ_7745c5c3_Err
+					}
+					var templ_7745c5c3_Var760 string
+					templ_7745c5c3_Var760, templ_7745c5c3_Err = templ.JoinStringErrs(row.CredentialIdentity)
+					if templ_7745c5c3_Err != nil {
+						return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/dashboard.templ`, Line: 4387, Col: 83}
+					}
+					_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var760))
+					if templ_7745c5c3_Err != nil {
+						return templ_7745c5c3_Err
+					}
+					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1157, "</span> <span class=\"text-right font-mono text-xs text-sec\">")
+					if templ_7745c5c3_Err != nil {
+						return templ_7745c5c3_Err
+					}
+					var templ_7745c5c3_Var761 string
+					templ_7745c5c3_Var761, templ_7745c5c3_Err = templ.JoinStringErrs(row.Reset)
+					if templ_7745c5c3_Err != nil {
+						return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/dashboard.templ`, Line: 4388, Col: 72}
+					}
+					_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var761))
+					if templ_7745c5c3_Err != nil {
+						return templ_7745c5c3_Err
+					}
+					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1158, "</span> <span class=\"truncate font-mono text-xs text-sec\">")
+					if templ_7745c5c3_Err != nil {
+						return templ_7745c5c3_Err
+					}
+					var templ_7745c5c3_Var762 string
+					templ_7745c5c3_Var762, templ_7745c5c3_Err = templ.JoinStringErrs(row.Resource)
+					if templ_7745c5c3_Err != nil {
+						return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/dashboard.templ`, Line: 4389, Col: 73}
+					}
+					_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var762))
+					if templ_7745c5c3_Err != nil {
+						return templ_7745c5c3_Err
+					}
+					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1159, "</span> <span class=\"text-right font-mono text-xs text-sec\">")
+					if templ_7745c5c3_Err != nil {
+						return templ_7745c5c3_Err
+					}
+					var templ_7745c5c3_Var763 string
+					templ_7745c5c3_Var763, templ_7745c5c3_Err = templ.JoinStringErrs(row.Count + " · " + row.Status)
+					if templ_7745c5c3_Err != nil {
+						return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/dashboard.templ`, Line: 4390, Col: 94}
+					}
+					_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var763))
+					if templ_7745c5c3_Err != nil {
+						return templ_7745c5c3_Err
+					}
+					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1160, "</span></div>")
 					if templ_7745c5c3_Err != nil {
 						return templ_7745c5c3_Err
 					}
 				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1155, "</div></details>")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1161, "</div></details>")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1156, "</div></section>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1162, "</div></section>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -15743,16 +15806,16 @@ func tokenCard(data DashboardData) templ.Component {
 			}()
 		}
 		ctx = templ.InitializeContext(ctx)
-		templ_7745c5c3_Var760 := templ.GetChildren(ctx)
-		if templ_7745c5c3_Var760 == nil {
-			templ_7745c5c3_Var760 = templ.NopComponent
+		templ_7745c5c3_Var764 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var764 == nil {
+			templ_7745c5c3_Var764 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1157, "<section class=\"dashboard-panel min-w-0 rounded-md border border-line bg-surface p-4 shadow-sm sm:p-5\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1163, "<section class=\"dashboard-panel min-w-0 rounded-md border border-line bg-surface p-4 shadow-sm sm:p-5\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Var761 := templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
+		templ_7745c5c3_Var765 := templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
 			templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
 			templ_7745c5c3_Buffer, templ_7745c5c3_IsBuffer := templruntime.GetBuffer(templ_7745c5c3_W)
 			if !templ_7745c5c3_IsBuffer {
@@ -15764,56 +15827,56 @@ func tokenCard(data DashboardData) templ.Component {
 				}()
 			}
 			ctx = templ.InitializeContext(ctx)
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1158, "<span class=\"shrink-0 rounded-full bg-elev px-2 py-1 font-mono text-xs font-medium text-sec\">")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1164, "<span class=\"shrink-0 rounded-full bg-elev px-2 py-1 font-mono text-xs font-medium text-sec\">")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			var templ_7745c5c3_Var762 string
-			templ_7745c5c3_Var762, templ_7745c5c3_Err = templ.JoinStringErrs(tokenRate(data.Snapshot))
+			var templ_7745c5c3_Var766 string
+			templ_7745c5c3_Var766, templ_7745c5c3_Err = templ.JoinStringErrs(tokenRate(data.Snapshot))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/dashboard.templ`, Line: 4389, Col: 122}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/dashboard.templ`, Line: 4404, Col: 122}
 			}
-			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var762))
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var766))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1159, "</span>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1165, "</span>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			return nil
 		})
-		templ_7745c5c3_Err = panelHeader(icon.Coins(icon.Props{Class: "size-4 shrink-0"}), "Tokens", helpTokens, "tokens-card").Render(templ.WithChildren(ctx, templ_7745c5c3_Var761), templ_7745c5c3_Buffer)
+		templ_7745c5c3_Err = panelHeader(icon.Coins(icon.Props{Class: "size-4 shrink-0"}), "Tokens", helpTokens, "tokens-card").Render(templ.WithChildren(ctx, templ_7745c5c3_Var765), templ_7745c5c3_Buffer)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1160, "<div class=\"mt-5 grid gap-2\"><div class=\"break-all font-mono text-2xl font-semibold text-text sm:text-3xl\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1166, "<div class=\"mt-5 grid gap-2\"><div class=\"break-all font-mono text-2xl font-semibold text-text sm:text-3xl\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		var templ_7745c5c3_Var763 string
-		templ_7745c5c3_Var763, templ_7745c5c3_Err = templ.JoinStringErrs(formatTokens(data.Snapshot.Tokens))
+		var templ_7745c5c3_Var767 string
+		templ_7745c5c3_Var767, templ_7745c5c3_Err = templ.JoinStringErrs(formatTokens(data.Snapshot.Tokens))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/dashboard.templ`, Line: 4392, Col: 117}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/dashboard.templ`, Line: 4407, Col: 117}
 		}
-		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var763))
-		if templ_7745c5c3_Err != nil {
-			return templ_7745c5c3_Err
-		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1161, "</div><div class=\"font-mono text-sm text-sec\">")
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var767))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		var templ_7745c5c3_Var764 string
-		templ_7745c5c3_Var764, templ_7745c5c3_Err = templ.JoinStringErrs(formatTokenBreakdown(data.Snapshot.Tokens))
-		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/dashboard.templ`, Line: 4393, Col: 87}
-		}
-		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var764))
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1167, "</div><div class=\"font-mono text-sm text-sec\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1162, "</div></div><div class=\"mt-5\"><div class=\"mb-2 flex items-center justify-between gap-3 text-sm\">")
+		var templ_7745c5c3_Var768 string
+		templ_7745c5c3_Var768, templ_7745c5c3_Err = templ.JoinStringErrs(formatTokenBreakdown(data.Snapshot.Tokens))
+		if templ_7745c5c3_Err != nil {
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/dashboard.templ`, Line: 4408, Col: 87}
+		}
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var768))
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1168, "</div></div><div class=\"mt-5\"><div class=\"mb-2 flex items-center justify-between gap-3 text-sm\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -15821,20 +15884,20 @@ func tokenCard(data DashboardData) templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1163, "<span class=\"font-mono text-xs text-sec\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1169, "<span class=\"font-mono text-xs text-sec\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		var templ_7745c5c3_Var765 string
-		templ_7745c5c3_Var765, templ_7745c5c3_Err = templ.JoinStringErrs(formatDuration(data.Snapshot.Tokens.RuntimeSeconds))
+		var templ_7745c5c3_Var769 string
+		templ_7745c5c3_Var769, templ_7745c5c3_Err = templ.JoinStringErrs(formatDuration(data.Snapshot.Tokens.RuntimeSeconds))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/dashboard.templ`, Line: 4398, Col: 98}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/dashboard.templ`, Line: 4413, Col: 98}
 		}
-		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var765))
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var769))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1164, "</span></div>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1170, "</span></div>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -15848,12 +15911,12 @@ func tokenCard(data DashboardData) templ.Component {
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1165, " <div class=\"mt-3 flex flex-wrap items-center gap-4 text-xs font-medium text-sec\"><span class=\"inline-flex items-center gap-2\"><span class=\"h-2 w-2 rounded-full bg-accent\"></span>Input</span> <span class=\"inline-flex items-center gap-2\"><span class=\"h-2 w-2 rounded-full bg-ok\"></span>Output</span></div>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1171, " <div class=\"mt-3 flex flex-wrap items-center gap-4 text-xs font-medium text-sec\"><span class=\"inline-flex items-center gap-2\"><span class=\"h-2 w-2 rounded-full bg-accent\"></span>Input</span> <span class=\"inline-flex items-center gap-2\"><span class=\"h-2 w-2 rounded-full bg-ok\"></span>Output</span></div>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1166, "</div></section>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1172, "</div></section>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}


### PR DESCRIPTION
## Summary

- attribute GitHub REST observations to redacted credential identities and retain distinct endpoint-family budgets/reset windows
- detect quota drops that Detent request counts cannot explain and warn about worker `gh` consumers sharing the credential
- merge all project REST telemetry into the fleet snapshot and render credential-level budgets while retaining the existing fleet REST-capacity outage condition

Fixes #1719

## UI Surface Contract

- [x] The linked issue explicitly authorizes the REST budget dashboard change.
- [x] This PR does not add persistent top-of-screen messaging.
- [x] Current-head CI Browser Visual passed; table-driven dashboard data tests and generated Templ compilation cover credential/reset content.

## Test Plan

- [x] `make generate`
- [x] `go test ./internal/connector/github ./internal/orchestrator ./internal/cli ./internal/web/templates ./internal/operatortool`
- [x] `go test ./internal/connector/github ./internal/cli`
- [x] `make check`
- [x] Current-head CI run `31281061238`
