### PR TITLE
fix(usage): restore cumulative session accounting

### DIFF
--- a/internal/codex/appserver.go
+++ b/internal/codex/appserver.go
@@ -252,7 +252,16 @@ type TokenUsage struct {
 	OutputTokens          int64
 	ReasoningOutputTokens int64
 	TotalTokens           int64
+	Last                  *TokenUsageBreakdown
 	ModelContextWindow    *int64
+}
+
+type TokenUsageBreakdown struct {
+	InputTokens           int64 `json:"inputTokens"`
+	CachedInputTokens     int64 `json:"cachedInputTokens"`
+	OutputTokens          int64 `json:"outputTokens"`
+	ReasoningOutputTokens int64 `json:"reasoningOutputTokens"`
+	TotalTokens           int64 `json:"totalTokens"`
 }
 
 type RateLimitSnapshot struct {
@@ -1226,17 +1235,13 @@ func updateFromMessage(msg Message) (Update, bool, error) {
 			Resolved    string `json:"resolvedModel"`
 			ResolvedAlt string `json:"resolved_model"`
 			TokenUsage  struct {
-				Total              tokenUsageBreakdown  `json:"total"`
-				Last               *tokenUsageBreakdown `json:"last"`
+				Total              TokenUsageBreakdown  `json:"total"`
+				Last               *TokenUsageBreakdown `json:"last"`
 				ModelContextWindow *int64               `json:"modelContextWindow"`
 			} `json:"tokenUsage"`
 		}
 		if err := json.Unmarshal(msg.Params, &params); err != nil {
 			return Update{}, false, fmt.Errorf("%w: decode token usage: %w", ErrInvalidResponse, err)
-		}
-		usage := params.TokenUsage.Total
-		if params.TokenUsage.Last != nil {
-			usage = *params.TokenUsage.Last
 		}
 		return Update{
 			Type:     UpdateTokenUsage,
@@ -1245,11 +1250,12 @@ func updateFromMessage(msg Message) (Update, bool, error) {
 			TurnID:   params.TurnID,
 			Model:    firstNonBlank(params.Model, params.Resolved, params.ResolvedAlt, params.ModelID, params.ModelIDAlt),
 			Tokens: TokenUsage{
-				InputTokens:           usage.InputTokens,
-				CachedInputTokens:     usage.CachedInputTokens,
-				OutputTokens:          usage.OutputTokens,
-				ReasoningOutputTokens: usage.ReasoningOutputTokens,
-				TotalTokens:           usage.TotalTokens,
+				InputTokens:           params.TokenUsage.Total.InputTokens,
+				CachedInputTokens:     params.TokenUsage.Total.CachedInputTokens,
+				OutputTokens:          params.TokenUsage.Total.OutputTokens,
+				ReasoningOutputTokens: params.TokenUsage.Total.ReasoningOutputTokens,
+				TotalTokens:           params.TokenUsage.Total.TotalTokens,
+				Last:                  params.TokenUsage.Last,
 				ModelContextWindow:    params.TokenUsage.ModelContextWindow,
 			},
 			Payload: rawPayload(msg),
@@ -1573,14 +1579,6 @@ func looksLikeErrorEvent(raw json.RawMessage) bool {
 		return false
 	}
 	return strings.EqualFold(strings.TrimSpace(decoded.Type), "error") || len(bytes.TrimSpace(decoded.Error)) > 0
-}
-
-type tokenUsageBreakdown struct {
-	InputTokens           int64 `json:"inputTokens"`
-	CachedInputTokens     int64 `json:"cachedInputTokens"`
-	OutputTokens          int64 `json:"outputTokens"`
-	ReasoningOutputTokens int64 `json:"reasoningOutputTokens"`
-	TotalTokens           int64 `json:"totalTokens"`
 }
 
 type rateLimitSnapshotPayload struct {

--- a/internal/codex/appserver_test.go
+++ b/internal/codex/appserver_test.go
@@ -148,11 +148,14 @@ func TestAppServerRunTurnStartsLifecycleAndStreamsUpdates(t *testing.T) {
 	if updates[3].Type != UpdateAgentMessageDelta || updates[3].Delta != "hello" {
 		t.Fatalf("updates[3] = %#v, want agent message delta", updates[3])
 	}
-	if updates[4].Type != UpdateTokenUsage || updates[4].Tokens.TotalTokens != 5 {
-		t.Fatalf("updates[4] = %#v, want last-turn token usage total 5", updates[4])
+	if updates[4].Type != UpdateTokenUsage || updates[4].Tokens.TotalTokens != 27 {
+		t.Fatalf("updates[4] = %#v, want cumulative token usage total 27", updates[4])
 	}
-	if updates[4].Tokens.CachedInputTokens != 1 || updates[4].Tokens.ReasoningOutputTokens != 1 {
+	if updates[4].Tokens.CachedInputTokens != 5 || updates[4].Tokens.ReasoningOutputTokens != 3 {
 		t.Fatalf("updates[4].Tokens = %#v", updates[4].Tokens)
+	}
+	if updates[4].Tokens.Last == nil || updates[4].Tokens.Last.TotalTokens != 5 || updates[4].Tokens.Last.CachedInputTokens != 1 {
+		t.Fatalf("updates[4].Tokens.Last = %#v, want last-call token usage", updates[4].Tokens.Last)
 	}
 	if updates[4].Tokens.ModelContextWindow == nil || *updates[4].Tokens.ModelContextWindow != 200000 {
 		t.Fatalf("updates[4].Tokens.ModelContextWindow = %#v", updates[4].Tokens.ModelContextWindow)
@@ -171,13 +174,14 @@ func TestAppServerRunTurnStartsLifecycleAndStreamsUpdates(t *testing.T) {
 	}
 }
 
-func TestUpdateFromMessageUsesPerTurnTokenUsage(t *testing.T) {
+func TestUpdateFromMessagePreservesCumulativeAndLastTokenUsage(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
 		name       string
 		tokenUsage string
 		want       TokenUsage
+		wantLast   *TokenUsageBreakdown
 	}{
 		{
 			name: "last turn available",
@@ -187,6 +191,13 @@ func TestUpdateFromMessageUsesPerTurnTokenUsage(t *testing.T) {
 				"modelContextWindow":200000
 			}`,
 			want: TokenUsage{
+				InputTokens:           20,
+				CachedInputTokens:     5,
+				OutputTokens:          7,
+				ReasoningOutputTokens: 3,
+				TotalTokens:           27,
+			},
+			wantLast: &TokenUsageBreakdown{
 				InputTokens:           2,
 				CachedInputTokens:     1,
 				OutputTokens:          3,
@@ -232,6 +243,9 @@ func TestUpdateFromMessageUsesPerTurnTokenUsage(t *testing.T) {
 				update.Tokens.ReasoningOutputTokens != tt.want.ReasoningOutputTokens ||
 				update.Tokens.TotalTokens != tt.want.TotalTokens {
 				t.Fatalf("Tokens = %#v, want %#v", update.Tokens, tt.want)
+			}
+			if !reflect.DeepEqual(update.Tokens.Last, tt.wantLast) {
+				t.Fatalf("Tokens.Last = %#v, want %#v", update.Tokens.Last, tt.wantLast)
 			}
 			if update.Tokens.ModelContextWindow == nil || *update.Tokens.ModelContextWindow != 200000 {
 				t.Fatalf("ModelContextWindow = %#v, want 200000", update.Tokens.ModelContextWindow)

--- a/internal/codex/backend.go
+++ b/internal/codex/backend.go
@@ -188,6 +188,13 @@ func agentUpdateFromCodex(update Update) runner.AgentUpdate {
 	if update.ThreadID != "" && update.TurnID != "" {
 		providerSessionID = update.ThreadID + "-" + update.TurnID
 	}
+	threadTotal := runner.AgentTokenCounts{
+		InputTokens:           update.Tokens.InputTokens,
+		CachedInputTokens:     update.Tokens.CachedInputTokens,
+		OutputTokens:          update.Tokens.OutputTokens,
+		ReasoningOutputTokens: update.Tokens.ReasoningOutputTokens,
+		TotalTokens:           update.Tokens.TotalTokens,
+	}
 	return runner.AgentUpdate{
 		Type:                runner.AgentUpdateType(update.Type),
 		Method:              update.Method,
@@ -210,9 +217,24 @@ func agentUpdateFromCodex(update Update) runner.AgentUpdate {
 			OutputTokens:          update.Tokens.OutputTokens,
 			ReasoningOutputTokens: update.Tokens.ReasoningOutputTokens,
 			TotalTokens:           update.Tokens.TotalTokens,
+			ThreadTotal:           &threadTotal,
+			Last:                  agentTokenCountsFromCodex(update.Tokens.Last),
 			ModelContextWindow:    update.Tokens.ModelContextWindow,
 		},
 		RateLimits: rateLimitsFromCodex(update.RateLimits),
+	}
+}
+
+func agentTokenCountsFromCodex(tokens *TokenUsageBreakdown) *runner.AgentTokenCounts {
+	if tokens == nil {
+		return nil
+	}
+	return &runner.AgentTokenCounts{
+		InputTokens:           tokens.InputTokens,
+		CachedInputTokens:     tokens.CachedInputTokens,
+		OutputTokens:          tokens.OutputTokens,
+		ReasoningOutputTokens: tokens.ReasoningOutputTokens,
+		TotalTokens:           tokens.TotalTokens,
 	}
 }
 

--- a/internal/codex/backend_test.go
+++ b/internal/codex/backend_test.go
@@ -128,6 +128,40 @@ func TestToolTurnInstructions(t *testing.T) {
 	}
 }
 
+func TestAgentUpdateFromCodexCarriesCumulativeAndLastTokenUsage(t *testing.T) {
+	t.Parallel()
+
+	contextWindow := int64(200_000)
+	update := agentUpdateFromCodex(Update{
+		Type:     UpdateTokenUsage,
+		ThreadID: "thread-1716",
+		TurnID:   "turn-2",
+		Tokens: TokenUsage{
+			InputTokens:        14_300_000,
+			CachedInputTokens:  13_900_000,
+			OutputTokens:       119_042,
+			TotalTokens:        14_419_042,
+			ModelContextWindow: &contextWindow,
+			Last: &TokenUsageBreakdown{
+				InputTokens:       78_500,
+				CachedInputTokens: 76_000,
+				OutputTokens:      1_048,
+				TotalTokens:       79_548,
+			},
+		},
+	})
+
+	if update.Tokens.ThreadTotal == nil || update.Tokens.ThreadTotal.TotalTokens != 14_419_042 {
+		t.Fatalf("ThreadTotal = %#v, want cumulative provider total", update.Tokens.ThreadTotal)
+	}
+	if update.Tokens.Last == nil || update.Tokens.Last.TotalTokens != 79_548 {
+		t.Fatalf("Last = %#v, want last-call usage", update.Tokens.Last)
+	}
+	if update.ProviderSessionID != "thread-1716-turn-2" {
+		t.Fatalf("ProviderSessionID = %q, want thread-turn identity", update.ProviderSessionID)
+	}
+}
+
 func TestAgentBackendEnforcesConfiguredStallTimeout(t *testing.T) {
 	t.Parallel()
 

--- a/internal/orchestrator/e2e_test.go
+++ b/internal/orchestrator/e2e_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
+	"math"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -13,6 +14,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/digitaldrywood/detent/internal/budget"
 	"github.com/digitaldrywood/detent/internal/config"
 	"github.com/digitaldrywood/detent/internal/connector"
 	"github.com/digitaldrywood/detent/internal/connector/memory"
@@ -63,11 +65,23 @@ func TestMemoryConnectorRunnerE2EGateCreatesBranchDiffStatAndSQLiteTokens(t *tes
 		},
 		Workspace: workspaceBackend,
 		AgentBackend: &e2eAgentBackend{
-			inputTokens:  321,
-			outputTokens: 45,
-			totalTokens:  366,
+			inputTokens:       321,
+			cachedInputTokens: 300,
+			outputTokens:      45,
+			totalTokens:       366,
+			lastInputTokens:   50,
+			lastCachedTokens:  45,
+			lastOutputTokens:  5,
+			lastTotalTokens:   55,
 		},
-		Store:  storeBackend,
+		Store: storeBackend,
+		Pricing: budget.PricingTable{
+			"gpt-5-codex": {
+				USDPerInputToken:       0.001,
+				USDPerCachedInputToken: 0.0001,
+				USDPerOutputToken:      0.01,
+			},
+		},
 		Logger: slog.New(slog.NewTextHandler(io.Discard, nil)),
 	})
 	if err != nil {
@@ -81,6 +95,8 @@ func TestMemoryConnectorRunnerE2EGateCreatesBranchDiffStatAndSQLiteTokens(t *tes
 	issue.State = "Todo"
 	issue.URL = "https://github.com/digitaldrywood/detent/issues/23"
 	issue.ModelOverride = "gpt-5-codex"
+	createdAt := time.Now().UTC().Add(-time.Hour)
+	issue.CreatedAt = &createdAt
 
 	orch, err := New(Config{
 		PollInterval:           time.Hour,
@@ -111,6 +127,9 @@ func TestMemoryConnectorRunnerE2EGateCreatesBranchDiffStatAndSQLiteTokens(t *tes
 	completed := state.Completed[issue.ID]
 	if completed.FinalState != runpkg.FinalStateCompleted {
 		t.Fatalf("completed final state = %q, want %q", completed.FinalState, runpkg.FinalStateCompleted)
+	}
+	if completed.Tokens.Last == nil || completed.Tokens.Last.TotalTokens != 55 {
+		t.Fatalf("completed last-call tokens = %#v, want 55", completed.Tokens.Last)
 	}
 	diffStat := state.DiffStats[issue.ID]
 	if diffStat.FilesChanged != 1 || diffStat.AddedLines != 1 || diffStat.RemovedLines != 0 || diffStat.Status != "changed" {
@@ -144,12 +163,38 @@ func TestMemoryConnectorRunnerE2EGateCreatesBranchDiffStatAndSQLiteTokens(t *tes
 	if len(spend.ByModel) != 1 || spend.ByModel[0].Model != "gpt-5-codex" {
 		t.Fatalf("IssueTokenSpend().ByModel = %#v, want gpt-5-codex", spend.ByModel)
 	}
+	issueSpend, err := storeBackend.IssueSpendSince(ctx, store.IssueSpendSinceQuery{
+		ProjectID:  "detent",
+		IssueID:    issue.ID,
+		Identifier: issue.Identifier,
+		Since:      createdAt,
+	})
+	if err != nil {
+		t.Fatalf("IssueSpendSince() error = %v", err)
+	}
+	if issueSpend.TotalTokens != 366 || issueSpend.Sessions != 1 || math.Abs(issueSpend.CostUSD-0.501) > 0.000001 {
+		t.Fatalf("IssueSpendSince() = %#v, want cumulative tokens and cost", issueSpend)
+	}
+	orch.cfg.Project.ID = "detent"
+	orch.cfg.BillingMode = config.BillingModeSubscription
+	orch.cfg.NoProgressTokenLimit = 366
+	orch.progressSpend = storeBackend
+	orch.workAttempts = nil
+	decision := orch.evaluateSpendProgress(ctx, Running{Issue: issue}, time.Now().UTC(), false, "")
+	if !decision.Block || decision.BlockedBy != "tokens" || decision.Spend.TotalTokens != 366 {
+		t.Fatalf("spend progress decision = %#v, want cumulative token block", decision)
+	}
 }
 
 type e2eAgentBackend struct {
-	inputTokens  int64
-	outputTokens int64
-	totalTokens  int64
+	inputTokens       int64
+	cachedInputTokens int64
+	outputTokens      int64
+	totalTokens       int64
+	lastInputTokens   int64
+	lastCachedTokens  int64
+	lastOutputTokens  int64
+	lastTotalTokens   int64
 }
 
 func (c *e2eAgentBackend) RunTurn(_ context.Context, req runpkg.AgentTurnRequest, onUpdate runpkg.AgentUpdateHandler) (runpkg.AgentTurnResult, error) {
@@ -160,12 +205,26 @@ func (c *e2eAgentBackend) RunTurn(_ context.Context, req runpkg.AgentTurnRequest
 		return runpkg.AgentTurnResult{}, fmt.Errorf("write agent output: %w", err)
 	}
 	if onUpdate != nil {
+		threadTotal := &runpkg.AgentTokenCounts{
+			InputTokens:       c.inputTokens,
+			CachedInputTokens: c.cachedInputTokens,
+			OutputTokens:      c.outputTokens,
+			TotalTokens:       c.totalTokens,
+		}
 		if err := onUpdate(runpkg.AgentUpdate{
 			Type: runpkg.AgentUpdateTokenUsage,
 			Tokens: runpkg.AgentTokenUsage{
-				InputTokens:  c.inputTokens,
-				OutputTokens: c.outputTokens,
-				TotalTokens:  c.totalTokens,
+				InputTokens:       c.inputTokens,
+				CachedInputTokens: c.cachedInputTokens,
+				OutputTokens:      c.outputTokens,
+				TotalTokens:       c.totalTokens,
+				ThreadTotal:       threadTotal,
+				Last: &runpkg.AgentTokenCounts{
+					InputTokens:       c.lastInputTokens,
+					CachedInputTokens: c.lastCachedTokens,
+					OutputTokens:      c.lastOutputTokens,
+					TotalTokens:       c.lastTotalTokens,
+				},
 			},
 		}); err != nil {
 			return runpkg.AgentTurnResult{}, err

--- a/internal/orchestrator/snapshot.go
+++ b/internal/orchestrator/snapshot.go
@@ -913,12 +913,23 @@ func latestBefore(current *time.Time, candidate *time.Time, before time.Time) *t
 }
 
 func tokensFromTokenTotals(totals TokenTotals) telemetry.Tokens {
+	var last *telemetry.TokenBreakdown
+	if totals.Last != nil {
+		last = &telemetry.TokenBreakdown{
+			Input:           totals.Last.InputTokens,
+			CachedInput:     totals.Last.CachedInputTokens,
+			Output:          totals.Last.OutputTokens,
+			ReasoningOutput: totals.Last.ReasoningOutputTokens,
+			Total:           totals.Last.TotalTokens,
+		}
+	}
 	return telemetry.Tokens{
 		Input:              totals.InputTokens,
 		CachedInput:        totals.CachedInputTokens,
 		Output:             totals.OutputTokens,
 		ReasoningOutput:    totals.ReasoningOutputTokens,
 		Total:              totals.TotalTokens,
+		Last:               last,
 		ModelContextWindow: totals.ModelContextWindow,
 		RuntimeSeconds:     totals.RuntimeSeconds,
 	}

--- a/internal/runner/agent.go
+++ b/internal/runner/agent.go
@@ -32,11 +32,13 @@ import (
 )
 
 const (
-	defaultAfterRunTimeout = time.Minute
-	liveDiffStatsInterval  = 2 * time.Second
-	recentActivityLimit    = 5
-	defaultProjectID       = "default"
-	orphanResumePrompt     = "The Detent process restarted while this session was running. Continue from your last state and complete the assigned work."
+	defaultAfterRunTimeout         = time.Minute
+	liveDiffStatsInterval          = 2 * time.Second
+	recentActivityLimit            = 5
+	defaultProjectID               = "default"
+	orphanResumePrompt             = "The Detent process restarted while this session was running. Continue from your last state and complete the assigned work."
+	implausibleUsageRuntimeSeconds = int64(1800)
+	implausibleUsageOutputTokens   = int64(1000)
 )
 
 var (
@@ -795,6 +797,7 @@ func (r *Runner) runAgentTurn(
 		strings.TrimSpace(runRequest.Issue.PRRepository),
 		ciTriggerPullRequestNumber(runRequest.Issue),
 	)
+	usage := newSessionTokenUsage(!agentResumeEmpty(turnRequest.Resume))
 	if !result.RuntimeIdentity.IsZero() {
 		eventAt := r.now()
 		progress.apply(AgentUpdate{Type: AgentUpdateRuntimeIdentity, RuntimeIdentity: result.RuntimeIdentity}, eventAt)
@@ -805,6 +808,9 @@ func (r *Runner) runAgentTurn(
 	turnStarted := false
 	turnResult, turnErr, scratchCleanupErr := runAgentBackendTurnWithToolsUsingLimit(ctx, backend, turnRequest, runRequest.AgentTools, runRequest.AgentToolHandler, func(updateCtx context.Context, update AgentUpdate) error {
 		eventAt := r.now()
+		if update.Type == AgentUpdateTokenUsage {
+			update.Tokens = usage.normalize(update.Tokens)
+		}
 		if !update.RuntimeIdentity.IsZero() {
 			update.RuntimeIdentity = update.RuntimeIdentity.ObserveAt(eventAt)
 		}
@@ -1578,6 +1584,7 @@ func (r *Runner) Validate(ctx context.Context, req ValidatorRequest) (gate.Valid
 		return gate.ValidatorResult{}, err
 	}
 	var output strings.Builder
+	usage := newSessionTokenUsage(false)
 	modelProvider, serviceTier, effort := agentTurnIdentityOptions(backendConfig)
 	turnResult, turnErr, scratchCleanupErr := runAgentBackendTurnWithToolsUsingLimit(sessionCtx, backend, AgentTurnRequest{
 		Workspace:          info.Path,
@@ -1594,6 +1601,9 @@ func (r *Runner) Validate(ctx context.Context, req ValidatorRequest) (gate.Valid
 		projectID:          r.projectID,
 	}, nil, nil, func(updateCtx context.Context, update AgentUpdate) error {
 		eventAt := r.now()
+		if update.Type == AgentUpdateTokenUsage {
+			update.Tokens = usage.normalize(update.Tokens)
+		}
 		if !update.RuntimeIdentity.IsZero() {
 			update.RuntimeIdentity = update.RuntimeIdentity.ObserveAt(eventAt)
 		}
@@ -2079,6 +2089,7 @@ func (r *Runner) finishSession(
 	}
 	attrs = append(attrs, runtimeIdentityLogAttrs(result.RuntimeIdentity)...)
 	r.logWorkerEvent(issue, "worker_session_finished", attrs...)
+	r.warnImplausibleCompletedSessionUsage(issue, workAttemptID, sessionID, turns, result)
 	if _, err := r.store.RecordUsageEvent(ctx, store.UsageEvent{
 		ProjectID:             r.projectID,
 		SessionID:             sessionID,
@@ -2104,6 +2115,26 @@ func (r *Runner) finishSession(
 		return err
 	}
 	return nil
+}
+
+func (r *Runner) warnImplausibleCompletedSessionUsage(issue connector.Issue, workAttemptID int64, sessionID int64, turns int64, result RunResult) {
+	runtimeSeconds := int64(math.Round(result.Tokens.RuntimeSeconds))
+	if result.FinalState != FinalStateCompleted || turns <= 0 || runtimeSeconds < implausibleUsageRuntimeSeconds || result.Tokens.OutputTokens >= implausibleUsageOutputTokens {
+		return
+	}
+	r.logWorkerEventLevel(slog.LevelWarn, issue, "worker_session_usage_implausible",
+		telemetry.WorkAttemptIDKey, workAttemptID,
+		telemetry.DetentSessionIDKey, sessionID,
+		"turns", turns,
+		"runtime_seconds", runtimeSeconds,
+		"input_tokens", result.Tokens.InputTokens,
+		"cached_input_tokens", result.Tokens.CachedInputTokens,
+		"output_tokens", result.Tokens.OutputTokens,
+		"reasoning_output_tokens", result.Tokens.ReasoningOutputTokens,
+		"total_tokens", result.Tokens.TotalTokens,
+		"minimum_runtime_seconds", implausibleUsageRuntimeSeconds,
+		"output_token_threshold", implausibleUsageOutputTokens,
+	)
 }
 
 func (r *Runner) recordAgentSessionPhase(
@@ -2175,12 +2206,13 @@ func (r *Runner) enforceSessionTokenCeiling(cfg config.Agent, issue connector.Is
 		return nil
 	}
 	ceiling, ok := sessionTokenCeilingForUsage(cfg, update.Tokens)
-	if !ok || update.Tokens.TotalTokens <= ceiling.tokens {
+	observedTokens := sessionTokenCeilingObservedTokens(ceiling, update.Tokens)
+	if !ok || observedTokens <= ceiling.tokens {
 		return nil
 	}
 
 	err := &SessionTokenCeilingError{
-		TotalTokens:        update.Tokens.TotalTokens,
+		TotalTokens:        observedTokens,
 		CeilingTokens:      ceiling.tokens,
 		Source:             ceiling.source,
 		ModelContextWindow: ceiling.modelContextWindow,
@@ -2194,25 +2226,44 @@ func (r *Runner) enforceSessionTokenCeiling(cfg config.Agent, issue connector.Is
 }
 
 func sessionTokenCeilingForUsage(cfg config.Agent, tokens AgentTokenUsage) (sessionTokenCeiling, bool) {
-	var ceiling sessionTokenCeiling
+	candidates := make([]sessionTokenCeiling, 0, 2)
 	if cfg.MaxSessionTokens > 0 {
-		ceiling = sessionTokenCeiling{
+		candidates = append(candidates, sessionTokenCeiling{
 			tokens: cfg.MaxSessionTokens,
 			source: TokenCeilingSourceAbsolute,
-		}
+		})
 	}
 	if cfg.MaxSessionContextMultiplier > 0 && tokens.ModelContextWindow != nil && *tokens.ModelContextWindow > 0 {
 		limit := int64(math.Ceil(float64(*tokens.ModelContextWindow) * cfg.MaxSessionContextMultiplier))
-		if limit > 0 && (ceiling.tokens == 0 || limit < ceiling.tokens) {
-			ceiling = sessionTokenCeiling{
+		if limit > 0 {
+			candidates = append(candidates, sessionTokenCeiling{
 				tokens:             limit,
 				source:             TokenCeilingSourceContextWindow,
 				modelContextWindow: *tokens.ModelContextWindow,
 				contextMultiplier:  cfg.MaxSessionContextMultiplier,
-			}
+			})
 		}
 	}
-	return ceiling, ceiling.tokens > 0
+	if len(candidates) == 0 {
+		return sessionTokenCeiling{}, false
+	}
+	selected := candidates[0]
+	selectedBreached := sessionTokenCeilingObservedTokens(selected, tokens) > selected.tokens
+	for _, candidate := range candidates[1:] {
+		breached := sessionTokenCeilingObservedTokens(candidate, tokens) > candidate.tokens
+		if breached && !selectedBreached || breached == selectedBreached && candidate.tokens < selected.tokens {
+			selected = candidate
+			selectedBreached = breached
+		}
+	}
+	return selected, true
+}
+
+func sessionTokenCeilingObservedTokens(ceiling sessionTokenCeiling, tokens AgentTokenUsage) int64 {
+	if ceiling.source == TokenCeilingSourceContextWindow && tokens.Last != nil {
+		return tokens.Last.TotalTokens
+	}
+	return tokens.TotalTokens
 }
 
 func sessionTokenCeilingBypassed(cfg config.Agent, issue connector.Issue) bool {
@@ -2357,10 +2408,65 @@ func applyAgentUpdate(result *RunResult, update AgentUpdate) {
 		result.Tokens.OutputTokens = update.Tokens.OutputTokens
 		result.Tokens.ReasoningOutputTokens = update.Tokens.ReasoningOutputTokens
 		result.Tokens.TotalTokens = update.Tokens.TotalTokens
+		result.Tokens.Last = cloneAgentTokenCounts(update.Tokens.Last)
 		result.Tokens.ModelContextWindow = update.Tokens.ModelContextWindow
 	case AgentUpdateRateLimits:
 		result.RateLimits = update.RateLimits
 	}
+}
+
+type sessionTokenUsage struct {
+	resumed  bool
+	baseline *AgentTokenCounts
+}
+
+func newSessionTokenUsage(resumed bool) *sessionTokenUsage {
+	return &sessionTokenUsage{resumed: resumed}
+}
+
+func (s *sessionTokenUsage) normalize(tokens AgentTokenUsage) AgentTokenUsage {
+	if tokens.ThreadTotal == nil {
+		return tokens
+	}
+	threadTotal := *tokens.ThreadTotal
+	if !s.resumed {
+		return agentTokenUsageWithCounts(tokens, threadTotal)
+	}
+	if s.baseline == nil {
+		baseline := AgentTokenCounts{}
+		if tokens.Last != nil {
+			baseline = subtractAgentTokenCounts(threadTotal, *tokens.Last)
+		}
+		s.baseline = &baseline
+	}
+	return agentTokenUsageWithCounts(tokens, subtractAgentTokenCounts(threadTotal, *s.baseline))
+}
+
+func agentTokenUsageWithCounts(tokens AgentTokenUsage, counts AgentTokenCounts) AgentTokenUsage {
+	tokens.InputTokens = counts.InputTokens
+	tokens.CachedInputTokens = counts.CachedInputTokens
+	tokens.OutputTokens = counts.OutputTokens
+	tokens.ReasoningOutputTokens = counts.ReasoningOutputTokens
+	tokens.TotalTokens = counts.TotalTokens
+	return tokens
+}
+
+func subtractAgentTokenCounts(total AgentTokenCounts, baseline AgentTokenCounts) AgentTokenCounts {
+	return AgentTokenCounts{
+		InputTokens:           max(0, total.InputTokens-baseline.InputTokens),
+		CachedInputTokens:     max(0, total.CachedInputTokens-baseline.CachedInputTokens),
+		OutputTokens:          max(0, total.OutputTokens-baseline.OutputTokens),
+		ReasoningOutputTokens: max(0, total.ReasoningOutputTokens-baseline.ReasoningOutputTokens),
+		TotalTokens:           max(0, total.TotalTokens-baseline.TotalTokens),
+	}
+}
+
+func cloneAgentTokenCounts(tokens *AgentTokenCounts) *AgentTokenCounts {
+	if tokens == nil {
+		return nil
+	}
+	clone := *tokens
+	return &clone
 }
 
 type agentRunProgress struct {
@@ -3098,13 +3204,40 @@ func (r *Runner) logAgentUpdate(req RunRequest, detentSessionID int64, update Ag
 			logEvent(slog.LevelDebug, "worker_turn_finished", attrs...)
 		}
 	case AgentUpdateTokenUsage:
-		logEvent(slog.LevelDebug, "worker_usage_updated",
+		threadTotal := AgentTokenCounts{
+			InputTokens:           update.Tokens.InputTokens,
+			CachedInputTokens:     update.Tokens.CachedInputTokens,
+			OutputTokens:          update.Tokens.OutputTokens,
+			ReasoningOutputTokens: update.Tokens.ReasoningOutputTokens,
+			TotalTokens:           update.Tokens.TotalTokens,
+		}
+		if update.Tokens.ThreadTotal != nil {
+			threadTotal = *update.Tokens.ThreadTotal
+		}
+		attrs := []any{
 			"thread_id", strings.TrimSpace(update.ThreadID),
 			"turn_id", strings.TrimSpace(update.TurnID),
 			"total_tokens", update.Tokens.TotalTokens,
 			"input_tokens", update.Tokens.InputTokens,
+			"cached_input_tokens", update.Tokens.CachedInputTokens,
 			"output_tokens", update.Tokens.OutputTokens,
-		)
+			"reasoning_output_tokens", update.Tokens.ReasoningOutputTokens,
+			"thread_total_tokens", threadTotal.TotalTokens,
+			"thread_input_tokens", threadTotal.InputTokens,
+			"thread_cached_input_tokens", threadTotal.CachedInputTokens,
+			"thread_output_tokens", threadTotal.OutputTokens,
+			"thread_reasoning_output_tokens", threadTotal.ReasoningOutputTokens,
+		}
+		if update.Tokens.Last != nil {
+			attrs = append(attrs,
+				"last_total_tokens", update.Tokens.Last.TotalTokens,
+				"last_input_tokens", update.Tokens.Last.InputTokens,
+				"last_cached_input_tokens", update.Tokens.Last.CachedInputTokens,
+				"last_output_tokens", update.Tokens.Last.OutputTokens,
+				"last_reasoning_output_tokens", update.Tokens.Last.ReasoningOutputTokens,
+			)
+		}
+		logEvent(slog.LevelDebug, "worker_usage_updated", attrs...)
 	case AgentUpdateRateLimits:
 		logEvent(slog.LevelDebug, "worker_rate_limits_updated",
 			"thread_id", strings.TrimSpace(update.ThreadID),

--- a/internal/runner/runner_test.go
+++ b/internal/runner/runner_test.go
@@ -1298,6 +1298,184 @@ func TestRunnerRunRetryResumeUsesRequestedState(t *testing.T) {
 	}
 }
 
+func TestSessionTokenUsageNormalizesFreshAndResumedThreads(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		resumed bool
+		updates []AgentTokenUsage
+		want    AgentTokenCounts
+	}{
+		{
+			name: "fresh session uses cumulative thread total",
+			updates: []AgentTokenUsage{{
+				ThreadTotal: &AgentTokenCounts{InputTokens: 20, CachedInputTokens: 5, OutputTokens: 7, TotalTokens: 27},
+				Last:        &AgentTokenCounts{InputTokens: 2, CachedInputTokens: 1, OutputTokens: 3, TotalTokens: 5},
+			}},
+			want: AgentTokenCounts{InputTokens: 20, CachedInputTokens: 5, OutputTokens: 7, TotalTokens: 27},
+		},
+		{
+			name:    "resumed session establishes baseline from first last call",
+			resumed: true,
+			updates: []AgentTokenUsage{{
+				ThreadTotal: &AgentTokenCounts{InputTokens: 1000, CachedInputTokens: 800, OutputTokens: 100, TotalTokens: 1100},
+				Last:        &AgentTokenCounts{InputTokens: 100, CachedInputTokens: 80, OutputTokens: 10, TotalTokens: 110},
+			}},
+			want: AgentTokenCounts{InputTokens: 100, CachedInputTokens: 80, OutputTokens: 10, TotalTokens: 110},
+		},
+		{
+			name:    "resumed session accumulates later calls without prior thread usage",
+			resumed: true,
+			updates: []AgentTokenUsage{
+				{
+					ThreadTotal: &AgentTokenCounts{InputTokens: 1000, CachedInputTokens: 800, OutputTokens: 100, TotalTokens: 1100},
+					Last:        &AgentTokenCounts{InputTokens: 100, CachedInputTokens: 80, OutputTokens: 10, TotalTokens: 110},
+				},
+				{
+					ThreadTotal: &AgentTokenCounts{InputTokens: 1200, CachedInputTokens: 900, OutputTokens: 130, TotalTokens: 1330},
+					Last:        &AgentTokenCounts{InputTokens: 200, CachedInputTokens: 150, OutputTokens: 30, TotalTokens: 230},
+				},
+			},
+			want: AgentTokenCounts{InputTokens: 300, CachedInputTokens: 180, OutputTokens: 40, TotalTokens: 340},
+		},
+		{
+			name:    "legacy backend usage remains unchanged",
+			resumed: true,
+			updates: []AgentTokenUsage{{InputTokens: 70, OutputTokens: 9, TotalTokens: 79}},
+			want:    AgentTokenCounts{InputTokens: 70, OutputTokens: 9, TotalTokens: 79},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			usage := newSessionTokenUsage(tt.resumed)
+			var got AgentTokenUsage
+			for _, update := range tt.updates {
+				got = usage.normalize(update)
+			}
+			gotCounts := AgentTokenCounts{
+				InputTokens:           got.InputTokens,
+				CachedInputTokens:     got.CachedInputTokens,
+				OutputTokens:          got.OutputTokens,
+				ReasoningOutputTokens: got.ReasoningOutputTokens,
+				TotalTokens:           got.TotalTokens,
+			}
+			if gotCounts != tt.want {
+				t.Fatalf("normalize() = %#v, want %#v", gotCounts, tt.want)
+			}
+		})
+	}
+}
+
+func TestRunnerRunPersistsResumedSessionDeltaAndCumulativeCost(t *testing.T) {
+	t.Parallel()
+
+	startedAt := time.Date(2026, 8, 8, 15, 8, 7, 0, time.UTC)
+	contextWindow := int64(200)
+	agentBackend := &fakeCodexClient{
+		updates: []AgentUpdate{
+			{Type: AgentUpdateTurnStarted, ThreadID: "thread-1716", TurnID: "turn-2"},
+			{
+				Type:     AgentUpdateTokenUsage,
+				ThreadID: "thread-1716",
+				TurnID:   "turn-2",
+				Tokens: AgentTokenUsage{
+					InputTokens:        1000,
+					CachedInputTokens:  800,
+					OutputTokens:       100,
+					TotalTokens:        1100,
+					ThreadTotal:        &AgentTokenCounts{InputTokens: 1000, CachedInputTokens: 800, OutputTokens: 100, TotalTokens: 1100},
+					Last:               &AgentTokenCounts{InputTokens: 100, CachedInputTokens: 80, OutputTokens: 10, TotalTokens: 110},
+					ModelContextWindow: &contextWindow,
+				},
+			},
+			{
+				Type:     AgentUpdateTokenUsage,
+				ThreadID: "thread-1716",
+				TurnID:   "turn-2",
+				Tokens: AgentTokenUsage{
+					InputTokens:        1200,
+					CachedInputTokens:  900,
+					OutputTokens:       130,
+					TotalTokens:        1330,
+					ThreadTotal:        &AgentTokenCounts{InputTokens: 1200, CachedInputTokens: 900, OutputTokens: 130, TotalTokens: 1330},
+					Last:               &AgentTokenCounts{InputTokens: 200, CachedInputTokens: 150, OutputTokens: 30, TotalTokens: 230},
+					ModelContextWindow: &contextWindow,
+				},
+			},
+		},
+		result: AgentTurnResult{ThreadID: "thread-1716", TurnID: "turn-2", SessionID: "thread-1716-turn-2"},
+	}
+	sessionStore := &fakeSessionStore{sessionID: 1716}
+	runner, err := NewRunner(Dependencies{
+		ProjectID: "detent",
+		Workflow:  config.Workflow{Config: config.Config{}, Prompt: "Work"},
+		Workspace: &fakeWorkspaceBackend{
+			info: workspace.Info{Path: t.TempDir(), Key: "issue-1716", Branch: "detent/issue-1716"},
+		},
+		AgentBackend: agentBackend,
+		Store:        sessionStore,
+		Pricing: budget.PricingTable{
+			"gpt-priced": {
+				USDPerInputToken:       0.001,
+				USDPerCachedInputToken: 0.0001,
+				USDPerOutputToken:      0.01,
+			},
+		},
+		Now: newFakeClock(
+			startedAt,
+			startedAt.Add(time.Second),
+			startedAt.Add(2*time.Second),
+			startedAt.Add(3*time.Second),
+			startedAt.Add(4*time.Second),
+			startedAt.Add(5*time.Second),
+			startedAt.Add(6*time.Second),
+		).Now,
+	})
+	if err != nil {
+		t.Fatalf("NewRunner() error = %v", err)
+	}
+
+	result, err := runner.Run(context.Background(), RunRequest{
+		Issue: connector.Issue{
+			ID:            "issue-1716",
+			Identifier:    "digitaldrywood/detent#1716",
+			Title:         "Restore cumulative usage",
+			ModelOverride: "gpt-priced",
+		},
+		StartedAt: startedAt,
+		RetryMode: RetryModeResume,
+		ResumeState: store.AgentResumeState{
+			DetentSessionID:   1700,
+			ProviderThreadID:  "thread-1716",
+			ProviderSessionID: "thread-1716-turn-1",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+	if result.Tokens.InputTokens != 300 || result.Tokens.CachedInputTokens != 180 || result.Tokens.OutputTokens != 40 || result.Tokens.TotalTokens != 340 {
+		t.Fatalf("RunResult.Tokens = %#v, want resumed session delta", result.Tokens)
+	}
+	if result.Tokens.Last == nil || result.Tokens.Last.TotalTokens != 230 {
+		t.Fatalf("RunResult.Tokens.Last = %#v, want last-call usage", result.Tokens.Last)
+	}
+	if sessionStore.finished.TotalTokens != 340 || sessionStore.finished.InputTokens != 300 || sessionStore.finished.OutputTokens != 40 {
+		t.Fatalf("SessionFinish = %#v, want cumulative resumed session usage", sessionStore.finished)
+	}
+	if sessionStore.usage.TotalTokens != 340 || sessionStore.usage.InputTokens != 300 || sessionStore.usage.OutputTokens != 40 {
+		t.Fatalf("UsageEvent = %#v, want cumulative resumed session usage", sessionStore.usage)
+	}
+	if math.Abs(sessionStore.usage.CostUSD-0.538) > 0.000001 {
+		t.Fatalf("UsageEvent.CostUSD = %f, want 0.538", sessionStore.usage.CostUSD)
+	}
+	if sessionStore.finished.ResumedFromSessionID != 1700 {
+		t.Fatalf("ResumedFromSessionID = %d, want 1700", sessionStore.finished.ResumedFromSessionID)
+	}
+}
+
 func TestRunnerRunResumesOrphanedSessionWithRestartPrompt(t *testing.T) {
 	t.Parallel()
 
@@ -1984,6 +2162,69 @@ func TestSessionTokenCeilingForUsageUsesTightestConfiguredLimit(t *testing.T) {
 	}
 }
 
+func TestSessionTokenCeilingUsesCumulativeSessionAndLastCallSemantics(t *testing.T) {
+	t.Parallel()
+
+	contextWindow := int64(100)
+	tests := []struct {
+		name         string
+		cfg          config.Agent
+		tokens       AgentTokenUsage
+		wantSource   string
+		wantObserved int64
+		wantBreached bool
+	}{
+		{
+			name:         "absolute ceiling uses cumulative session total",
+			cfg:          config.Agent{MaxSessionTokens: 300},
+			tokens:       AgentTokenUsage{TotalTokens: 340, Last: &AgentTokenCounts{TotalTokens: 150}, ModelContextWindow: &contextWindow},
+			wantSource:   TokenCeilingSourceAbsolute,
+			wantObserved: 340,
+			wantBreached: true,
+		},
+		{
+			name:         "context ceiling stays below on small last call",
+			cfg:          config.Agent{MaxSessionContextMultiplier: 2},
+			tokens:       AgentTokenUsage{TotalTokens: 340, Last: &AgentTokenCounts{TotalTokens: 150}, ModelContextWindow: &contextWindow},
+			wantSource:   TokenCeilingSourceContextWindow,
+			wantObserved: 150,
+		},
+		{
+			name:         "context ceiling blocks large last call",
+			cfg:          config.Agent{MaxSessionContextMultiplier: 2},
+			tokens:       AgentTokenUsage{TotalTokens: 340, Last: &AgentTokenCounts{TotalTokens: 230}, ModelContextWindow: &contextWindow},
+			wantSource:   TokenCeilingSourceContextWindow,
+			wantObserved: 230,
+			wantBreached: true,
+		},
+		{
+			name:         "breached absolute ceiling wins over tighter unbreached context ceiling",
+			cfg:          config.Agent{MaxSessionTokens: 300, MaxSessionContextMultiplier: 2},
+			tokens:       AgentTokenUsage{TotalTokens: 340, Last: &AgentTokenCounts{TotalTokens: 150}, ModelContextWindow: &contextWindow},
+			wantSource:   TokenCeilingSourceAbsolute,
+			wantObserved: 340,
+			wantBreached: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			ceiling, ok := sessionTokenCeilingForUsage(tt.cfg, tt.tokens)
+			if !ok {
+				t.Fatal("sessionTokenCeilingForUsage() ok = false, want true")
+			}
+			observed := sessionTokenCeilingObservedTokens(ceiling, tt.tokens)
+			if ceiling.source != tt.wantSource || observed != tt.wantObserved {
+				t.Fatalf("ceiling = %#v observed = %d, want source %q observed %d", ceiling, observed, tt.wantSource, tt.wantObserved)
+			}
+			if breached := observed > ceiling.tokens; breached != tt.wantBreached {
+				t.Fatalf("breached = %t, want %t", breached, tt.wantBreached)
+			}
+		})
+	}
+}
+
 func TestRunnerMergeModeCleanPrecheckSkipsAgent(t *testing.T) {
 	t.Parallel()
 
@@ -2403,7 +2644,18 @@ func TestRunnerRunLogsLifecycleWithoutPromptOrMessageBody(t *testing.T) {
 				RuntimeIdentity: agentidentity.RuntimeUpdate("gpt-5.6-sol", "openai", "xhigh", "priority", time.Time{}),
 			},
 			{Type: AgentUpdateMessageDelta, Delta: "do not log this message body"},
-			{Type: AgentUpdateTokenUsage, ThreadID: "thread-1", TurnID: "turn-1", Tokens: AgentTokenUsage{InputTokens: 10, OutputTokens: 5, TotalTokens: 15}},
+			{
+				Type:     AgentUpdateTokenUsage,
+				ThreadID: "thread-1",
+				TurnID:   "turn-1",
+				Tokens: AgentTokenUsage{
+					InputTokens:  10,
+					OutputTokens: 5,
+					TotalTokens:  15,
+					ThreadTotal:  &AgentTokenCounts{InputTokens: 100, CachedInputTokens: 80, OutputTokens: 25, TotalTokens: 125},
+					Last:         &AgentTokenCounts{InputTokens: 10, CachedInputTokens: 8, OutputTokens: 5, TotalTokens: 15},
+				},
+			},
 			{Type: AgentUpdateTurnCompleted, ThreadID: "thread-1", TurnID: "turn-1", Status: "completed"},
 		},
 		result: AgentTurnResult{ThreadID: "thread-1", TurnID: "turn-1", SessionID: "session-1"},
@@ -2448,6 +2700,10 @@ func TestRunnerRunLogsLifecycleWithoutPromptOrMessageBody(t *testing.T) {
 		"worker_process_started",
 		"worker_turn_started",
 		"worker_usage_updated",
+		"thread_total_tokens=125",
+		"thread_cached_input_tokens=80",
+		"last_total_tokens=15",
+		"last_cached_input_tokens=8",
 		"worker_turn_finished",
 		"worker_command_finished",
 		"worker_after_run_finished",
@@ -2472,6 +2728,74 @@ func TestRunnerRunLogsLifecycleWithoutPromptOrMessageBody(t *testing.T) {
 		if strings.Contains(logText, leaked) {
 			t.Fatalf("logs leaked %q:\n%s", leaked, logText)
 		}
+	}
+}
+
+func TestRunnerFinishSessionWarnsOnImplausibleCompletedUsage(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		finalState string
+		runtime    float64
+		output     int64
+		wantWarn   bool
+	}{
+		{name: "long completed session with low output", finalState: FinalStateCompleted, runtime: 3600, output: 391, wantWarn: true},
+		{name: "short completed session", finalState: FinalStateCompleted, runtime: 120, output: 391},
+		{name: "long completed session at output threshold", finalState: FinalStateCompleted, runtime: 3600, output: implausibleUsageOutputTokens},
+		{name: "failed session", finalState: FinalStateFailed, runtime: 3600, output: 391},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			var logs bytes.Buffer
+			sessionStore := &fakeSessionStore{sessionID: 1716}
+			r := &Runner{
+				projectID: "detent",
+				store:     sessionStore,
+				logger:    slog.New(slog.NewTextHandler(&logs, nil)),
+			}
+			startedAt := time.Date(2026, 8, 8, 12, 0, 0, 0, time.UTC)
+			err := r.finishSession(
+				context.Background(),
+				1716,
+				true,
+				88,
+				connector.Issue{ID: "issue-1716", Identifier: "digitaldrywood/detent#1716"},
+				startedAt,
+				startedAt.Add(time.Duration(tt.runtime)*time.Second),
+				RunResult{
+					FinalState: tt.finalState,
+					Tokens: TokenTotals{
+						InputTokens:    113_000,
+						OutputTokens:   tt.output,
+						TotalTokens:    113_000 + tt.output,
+						RuntimeSeconds: tt.runtime,
+					},
+				},
+				"gpt-test",
+				"codex",
+				1,
+				AgentTurnResult{ThreadID: "thread-1716", TurnID: "turn-1", SessionID: "thread-1716-turn-1"},
+				0,
+			)
+			if err != nil {
+				t.Fatalf("finishSession() error = %v", err)
+			}
+			gotWarn := strings.Contains(logs.String(), "worker_session_usage_implausible")
+			if gotWarn != tt.wantWarn {
+				t.Fatalf("warning present = %t, want %t\n%s", gotWarn, tt.wantWarn, logs.String())
+			}
+			if tt.wantWarn {
+				for _, want := range []string{"runtime_seconds=3600", "turns=1", "output_tokens=391", "total_tokens=113391"} {
+					if !strings.Contains(logs.String(), want) {
+						t.Fatalf("warning missing %q:\n%s", want, logs.String())
+					}
+				}
+			}
+		})
 	}
 }
 

--- a/internal/runner/types.go
+++ b/internal/runner/types.go
@@ -257,7 +257,17 @@ type AgentTokenUsage struct {
 	OutputTokens          int64
 	ReasoningOutputTokens int64
 	TotalTokens           int64
+	ThreadTotal           *AgentTokenCounts
+	Last                  *AgentTokenCounts
 	ModelContextWindow    *int64
+}
+
+type AgentTokenCounts struct {
+	InputTokens           int64
+	CachedInputTokens     int64
+	OutputTokens          int64
+	ReasoningOutputTokens int64
+	TotalTokens           int64
 }
 
 type SessionTokenCeilingError struct {
@@ -475,6 +485,7 @@ type TokenTotals struct {
 	OutputTokens          int64
 	ReasoningOutputTokens int64
 	TotalTokens           int64
+	Last                  *AgentTokenCounts
 	ModelContextWindow    *int64
 	RuntimeSeconds        float64
 }

--- a/internal/telemetry/snapshot.go
+++ b/internal/telemetry/snapshot.go
@@ -732,7 +732,16 @@ type Budget struct {
 	PeriodEnd         time.Time          `json:"period_end,omitzero"`
 	SpendPoints       []BudgetSpendPoint `json:"spend_points,omitempty"`
 	Days              []BudgetDay        `json:"days,omitempty"`
+	SpendRegression   *SpendRegression   `json:"spend_regression,omitempty"`
 	Refusals          []BudgetRefusal    `json:"refusals,omitempty"`
+}
+
+type SpendRegression struct {
+	Date              string  `json:"date"`
+	PreviousSpendUSD  float64 `json:"previous_spend_usd"`
+	ProjectedSpendUSD float64 `json:"projected_spend_usd"`
+	DropPercent       float64 `json:"drop_percent"`
+	ThresholdPercent  float64 `json:"threshold_percent"`
 }
 
 type BudgetOverride struct {
@@ -870,13 +879,22 @@ type RESTBudget struct {
 }
 
 type Tokens struct {
-	Input              int64   `json:"input_tokens"`
-	CachedInput        int64   `json:"cached_input_tokens,omitempty"`
-	Output             int64   `json:"output_tokens"`
-	ReasoningOutput    int64   `json:"reasoning_output_tokens,omitempty"`
-	Total              int64   `json:"total_tokens"`
-	ModelContextWindow *int64  `json:"model_context_window,omitempty"`
-	RuntimeSeconds     float64 `json:"seconds_running,omitempty"`
+	Input              int64           `json:"input_tokens"`
+	CachedInput        int64           `json:"cached_input_tokens,omitempty"`
+	Output             int64           `json:"output_tokens"`
+	ReasoningOutput    int64           `json:"reasoning_output_tokens,omitempty"`
+	Total              int64           `json:"total_tokens"`
+	Last               *TokenBreakdown `json:"last,omitempty"`
+	ModelContextWindow *int64          `json:"model_context_window,omitempty"`
+	RuntimeSeconds     float64         `json:"seconds_running,omitempty"`
+}
+
+type TokenBreakdown struct {
+	Input           int64 `json:"input_tokens"`
+	CachedInput     int64 `json:"cached_input_tokens,omitempty"`
+	Output          int64 `json:"output_tokens"`
+	ReasoningOutput int64 `json:"reasoning_output_tokens,omitempty"`
+	Total           int64 `json:"total_tokens"`
 }
 
 type ContextPressureState string
@@ -902,6 +920,7 @@ func (t Tokens) MarshalJSON() ([]byte, error) {
 		Output             int64            `json:"output_tokens"`
 		ReasoningOutput    int64            `json:"reasoning_output_tokens,omitempty"`
 		Total              int64            `json:"total_tokens"`
+		Last               *TokenBreakdown  `json:"last,omitempty"`
 		ModelContextWindow *int64           `json:"model_context_window,omitempty"`
 		ContextPressure    *ContextPressure `json:"context_pressure,omitempty"`
 		CacheReadFraction  float64          `json:"cache_read_fraction,omitempty"`
@@ -920,6 +939,7 @@ func (t Tokens) MarshalJSON() ([]byte, error) {
 		Output:             t.Output,
 		ReasoningOutput:    t.ReasoningOutput,
 		Total:              t.Total,
+		Last:               t.Last,
 		ModelContextWindow: t.ModelContextWindow,
 		ContextPressure:    pressure,
 		CacheReadFraction:  cacheReadFraction,
@@ -933,6 +953,9 @@ func (t Tokens) ContextPressure() (ContextPressure, bool) {
 	}
 	limit := *t.ModelContextWindow
 	total := t.Total
+	if t.Last != nil {
+		total = t.Last.Total
+	}
 	if total < 0 {
 		total = 0
 	}

--- a/internal/telemetry/snapshot_test.go
+++ b/internal/telemetry/snapshot_test.go
@@ -394,7 +394,7 @@ func TestSnapshotOmitsUnavailableRuntimeIdentityFields(t *testing.T) {
 	}
 }
 
-func TestTokensJSONIncludesContextPressureWhenWindowKnown(t *testing.T) {
+func TestTokensJSONUsesLastCallForContextPressureWhenWindowKnown(t *testing.T) {
 	t.Parallel()
 
 	contextWindow := int64(200)
@@ -403,6 +403,7 @@ func TestTokensJSONIncludesContextPressureWhenWindowKnown(t *testing.T) {
 		CachedInput:        25,
 		Output:             40,
 		Total:              170,
+		Last:               &telemetry.TokenBreakdown{Input: 75, CachedInput: 20, Output: 15, Total: 90},
 		ModelContextWindow: &contextWindow,
 	}
 
@@ -417,14 +418,30 @@ func TestTokensJSONIncludesContextPressureWhenWindowKnown(t *testing.T) {
 	}
 
 	pressure := got["context_pressure"].(map[string]any)
-	if pressure["total_tokens"] != float64(170) || pressure["context_limit_tokens"] != float64(200) {
+	if pressure["total_tokens"] != float64(90) || pressure["context_limit_tokens"] != float64(200) {
 		t.Fatalf("context_pressure token fields = %#v", pressure)
 	}
-	if pressure["percent_used"] != 85.0 || pressure["threshold_state"] != string(telemetry.ContextPressureWarning) {
+	if pressure["percent_used"] != 45.0 || pressure["threshold_state"] != string(telemetry.ContextPressureNormal) {
 		t.Fatalf("context_pressure threshold fields = %#v", pressure)
+	}
+	last := got["last"].(map[string]any)
+	if last["total_tokens"] != float64(90) || last["cached_input_tokens"] != float64(20) {
+		t.Fatalf("last token fields = %#v", last)
 	}
 	if got["cache_read_fraction"] != 0.25 {
 		t.Fatalf("cache_read_fraction = %#v, want 0.25", got["cache_read_fraction"])
+	}
+
+	var restored telemetry.Tokens
+	if err := json.Unmarshal(data, &restored); err != nil {
+		t.Fatalf("Unmarshal(Tokens) error = %v", err)
+	}
+	if restored.Last == nil || restored.Last.Total != 90 || restored.Last.CachedInput != 20 {
+		t.Fatalf("restored Last = %#v, want last-call token fields", restored.Last)
+	}
+	restoredPressure, ok := restored.ContextPressure()
+	if !ok || restoredPressure.TotalTokens != 90 || restoredPressure.PercentUsed != 45 {
+		t.Fatalf("restored ContextPressure() = %#v, %t; want last-call pressure", restoredPressure, ok)
 	}
 }
 

--- a/internal/web/api.go
+++ b/internal/web/api.go
@@ -966,6 +966,7 @@ func budgetResponse(budget telemetry.Budget) budgetAPIResponse {
 		PeriodEnd:         optionalTime(budget.PeriodEnd),
 		SpendPoints:       budget.SpendPoints,
 		Days:              days,
+		SpendRegression:   budget.SpendRegression,
 		Refusals:          budget.Refusals,
 	}
 }
@@ -1614,6 +1615,7 @@ type budgetAPIResponse struct {
 	PeriodEnd         *time.Time                   `json:"period_end,omitempty"`
 	SpendPoints       []telemetry.BudgetSpendPoint `json:"spend_points,omitempty"`
 	Days              []telemetry.BudgetDay        `json:"days"`
+	SpendRegression   *telemetry.SpendRegression   `json:"spend_regression,omitempty"`
 	Refusals          []telemetry.BudgetRefusal    `json:"refusals,omitempty"`
 }
 

--- a/internal/web/budget.go
+++ b/internal/web/budget.go
@@ -15,8 +15,11 @@ import (
 )
 
 const (
-	budgetHistoryWindowDays      = 7
-	budgetSpendQueryFailedReason = "budget spend query failed"
+	budgetHistoryWindowDays                = 7
+	budgetSpendQueryFailedReason           = "budget spend query failed"
+	dailySpendRegressionThresholdPercent   = 90.0
+	dailySpendRegressionMinimumBaselineUSD = 1.0
+	dailySpendRegressionMinimumElapsed     = 6 * time.Hour
 )
 
 type configuredBudget struct {
@@ -32,6 +35,15 @@ type snapshotEnrichmentCache struct {
 	raw      telemetry.Snapshot
 	enriched telemetry.Snapshot
 	loading  bool
+}
+
+type spendRegressionMonitor struct {
+	mu         sync.Mutex
+	warnedDate string
+}
+
+func newSpendRegressionMonitor() *spendRegressionMonitor {
+	return &spendRegressionMonitor{}
 }
 
 func newSnapshotEnrichmentCache() *snapshotEnrichmentCache {
@@ -158,9 +170,11 @@ func admissionProposalTelemetry(proposal admissionmodel.Proposal) telemetry.Admi
 
 func (s *Server) snapshotBudget(ctx context.Context, now time.Time) (telemetry.Budget, bool) {
 	projects := s.configuredBudgets()
-	if len(projects) == 0 {
+	projectIDs := s.configuredProjectIDs()
+	if len(projectIDs) == 0 {
 		return telemetry.Budget{}, false
 	}
+	enabled := len(projects) > 0
 	if now.IsZero() {
 		now = time.Now().UTC().Truncate(time.Second)
 	}
@@ -169,14 +183,14 @@ func (s *Server) snapshotBudget(ctx context.Context, now time.Time) (telemetry.B
 	queryFrom := periodStart.AddDate(0, 0, -(budgetHistoryWindowDays - 1))
 
 	events, err := s.store.BudgetCostEvents(ctx, store.BudgetCostQuery{
-		ProjectIDs: budgetProjectIDs(projects),
+		ProjectIDs: projectIDs,
 		From:       queryFrom,
 		To:         periodEnd,
 	})
 	if err != nil {
 		s.logger.Warn("budget spend query failed", slog.Any("error", err))
 		return telemetry.Budget{
-			Enabled:        true,
+			Enabled:        enabled,
 			DegradedReason: budgetSpendQueryFailedReason,
 			PerDayMaxUSD:   positiveFloatPtr(totalDailyBudgetCap(projects)),
 			PerIssueMaxUSD: issueBudgetCap(projects),
@@ -187,7 +201,7 @@ func (s *Server) snapshotBudget(ctx context.Context, now time.Time) (telemetry.B
 
 	points, currentSpend := currentBudgetSpendPoints(events, periodStart, periodEnd)
 	budget := telemetry.Budget{
-		Enabled:           true,
+		Enabled:           enabled,
 		PerDayMaxUSD:      positiveFloatPtr(totalDailyBudgetCap(projects)),
 		PerIssueMaxUSD:    issueBudgetCap(projects),
 		CurrentSpendUSD:   currentSpend,
@@ -197,7 +211,60 @@ func (s *Server) snapshotBudget(ctx context.Context, now time.Time) (telemetry.B
 		SpendPoints:       points,
 		Days:              budgetSpendDays(events),
 	}
+	budget.SpendRegression = budgetSpendRegression(budget, now)
+	s.logSpendRegression(budget.SpendRegression)
 	return budget, true
+}
+
+func budgetSpendRegression(budget telemetry.Budget, now time.Time) *telemetry.SpendRegression {
+	periodStart := budget.PeriodStart.UTC()
+	if periodStart.IsZero() || now.UTC().Sub(periodStart) < dailySpendRegressionMinimumElapsed {
+		return nil
+	}
+	previousDate := periodStart.AddDate(0, 0, -1).Format("2006-01-02")
+	previousSpend := 0.0
+	for _, day := range budget.Days {
+		if day.Date == previousDate {
+			previousSpend = day.SpendUSD
+			break
+		}
+	}
+	if previousSpend < dailySpendRegressionMinimumBaselineUSD {
+		return nil
+	}
+	projectedSpend := max(0, budget.ProjectedSpendUSD)
+	dropPercent := (previousSpend - projectedSpend) / previousSpend * 100
+	if dropPercent < dailySpendRegressionThresholdPercent {
+		return nil
+	}
+	return &telemetry.SpendRegression{
+		Date:              periodStart.Format("2006-01-02"),
+		PreviousSpendUSD:  previousSpend,
+		ProjectedSpendUSD: projectedSpend,
+		DropPercent:       dropPercent,
+		ThresholdPercent:  dailySpendRegressionThresholdPercent,
+	}
+}
+
+func (s *Server) logSpendRegression(regression *telemetry.SpendRegression) {
+	if s == nil || s.logger == nil || s.spendRegressions == nil || regression == nil {
+		return
+	}
+	s.spendRegressions.mu.Lock()
+	if s.spendRegressions.warnedDate == regression.Date {
+		s.spendRegressions.mu.Unlock()
+		return
+	}
+	s.spendRegressions.warnedDate = regression.Date
+	s.spendRegressions.mu.Unlock()
+	s.logger.Warn("fleet daily spend regression",
+		slog.String("event", "fleet_daily_spend_regression"),
+		slog.String("date", regression.Date),
+		slog.Float64("previous_spend_usd", regression.PreviousSpendUSD),
+		slog.Float64("projected_spend_usd", regression.ProjectedSpendUSD),
+		slog.Float64("drop_percent", regression.DropPercent),
+		slog.Float64("threshold_percent", regression.ThresholdPercent),
+	)
 }
 
 func degradedSnapshotBudget(snapshotBudget telemetry.Budget, degradedBudget telemetry.Budget) telemetry.Budget {
@@ -249,18 +316,27 @@ func (s *Server) configuredBudgets() []configuredBudget {
 	return budgets
 }
 
+func (s *Server) configuredProjectIDs() []string {
+	if s == nil || s.registry == nil {
+		return nil
+	}
+	projects := s.registry.List()
+	ids := make([]string, 0, len(projects))
+	for _, project := range projects {
+		if project == nil {
+			continue
+		}
+		if projectID := strings.TrimSpace(string(project.ID())); projectID != "" {
+			ids = append(ids, projectID)
+		}
+	}
+	return ids
+}
+
 func dailyBudgetPeriod(now time.Time) (time.Time, time.Time) {
 	year, month, day := now.UTC().Date()
 	start := time.Date(year, month, day, 0, 0, 0, 0, time.UTC)
 	return start, start.AddDate(0, 0, 1)
-}
-
-func budgetProjectIDs(projects []configuredBudget) []string {
-	ids := make([]string, 0, len(projects))
-	for _, project := range projects {
-		ids = append(ids, project.ProjectID)
-	}
-	return ids
 }
 
 func totalDailyBudgetCap(projects []configuredBudget) float64 {

--- a/internal/web/budget_test.go
+++ b/internal/web/budget_test.go
@@ -1,0 +1,117 @@
+package web
+
+import (
+	"bytes"
+	"log/slog"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/digitaldrywood/detent/internal/telemetry"
+)
+
+func TestBudgetSpendRegression(t *testing.T) {
+	t.Parallel()
+
+	periodStart := time.Date(2026, 8, 8, 0, 0, 0, 0, time.UTC)
+	previousDay := telemetry.BudgetDay{Date: "2026-08-07", SpendUSD: 100}
+	tests := []struct {
+		name      string
+		now       time.Time
+		budget    telemetry.Budget
+		want      bool
+		wantDrop  float64
+		wantSpend float64
+	}{
+		{
+			name: "waits for a meaningful portion of the day",
+			now:  periodStart.Add(5 * time.Hour),
+			budget: telemetry.Budget{
+				PeriodStart:       periodStart,
+				ProjectedSpendUSD: 1,
+				Days:              []telemetry.BudgetDay{previousDay},
+			},
+		},
+		{
+			name: "requires previous day baseline",
+			now:  periodStart.Add(12 * time.Hour),
+			budget: telemetry.Budget{
+				PeriodStart:       periodStart,
+				ProjectedSpendUSD: 1,
+			},
+		},
+		{
+			name: "ignores drop below threshold",
+			now:  periodStart.Add(12 * time.Hour),
+			budget: telemetry.Budget{
+				PeriodStart:       periodStart,
+				ProjectedSpendUSD: 11,
+				Days:              []telemetry.BudgetDay{previousDay},
+			},
+		},
+		{
+			name: "detects ninety percent projected drop",
+			now:  periodStart.Add(12 * time.Hour),
+			budget: telemetry.Budget{
+				PeriodStart:       periodStart,
+				ProjectedSpendUSD: 10,
+				Days:              []telemetry.BudgetDay{previousDay},
+			},
+			want:      true,
+			wantDrop:  90,
+			wantSpend: 10,
+		},
+		{
+			name: "detects complete same-day collapse",
+			now:  periodStart.Add(12 * time.Hour),
+			budget: telemetry.Budget{
+				PeriodStart: periodStart,
+				Days:        []telemetry.BudgetDay{previousDay},
+			},
+			want:     true,
+			wantDrop: 100,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := budgetSpendRegression(tt.budget, tt.now)
+			if (got != nil) != tt.want {
+				t.Fatalf("budgetSpendRegression() = %#v, want present %t", got, tt.want)
+			}
+			if got != nil && (got.DropPercent != tt.wantDrop || got.ProjectedSpendUSD != tt.wantSpend || got.Date != "2026-08-08") {
+				t.Fatalf("budgetSpendRegression() = %#v, want drop %.0f spend %.2f", got, tt.wantDrop, tt.wantSpend)
+			}
+		})
+	}
+}
+
+func TestLogSpendRegressionWarnsOncePerDay(t *testing.T) {
+	t.Parallel()
+
+	var logs bytes.Buffer
+	server := &Server{
+		logger:           slog.New(slog.NewTextHandler(&logs, nil)),
+		spendRegressions: newSpendRegressionMonitor(),
+	}
+	regression := &telemetry.SpendRegression{
+		Date:              "2026-08-08",
+		PreviousSpendUSD:  363.50,
+		ProjectedSpendUSD: 3.22,
+		DropPercent:       99.1,
+		ThresholdPercent:  90,
+	}
+	server.logSpendRegression(regression)
+	server.logSpendRegression(regression)
+
+	got := logs.String()
+	if strings.Count(got, "fleet daily spend regression") != 1 {
+		t.Fatalf("warning count = %d, want 1\n%s", strings.Count(got, "fleet daily spend regression"), got)
+	}
+	for _, want := range []string{"event=fleet_daily_spend_regression", "previous_spend_usd=363.5", "projected_spend_usd=3.22", "drop_percent=99.1", "threshold_percent=90"} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("warning missing %q:\n%s", want, got)
+		}
+	}
+}

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -147,6 +147,7 @@ type Server struct {
 	assets              staticAssets
 	projects            *projectSmallMultipleRecorder
 	snapshots           *snapshotEnrichmentCache
+	spendRegressions    *spendRegressionMonitor
 	kanbanMutations     *kanbanstate.MutationTracker
 	kanbanRefreshes     *kanbanRefreshFeedbackTracker
 	kanbanRetryInFlight atomic.Bool
@@ -256,6 +257,7 @@ func NewServer(cfg Config, deps Dependencies) (*Server, error) {
 		assets:              newStaticAssets(cfg.staticDir()),
 		projects:            newProjectSmallMultipleRecorder(),
 		snapshots:           newSnapshotEnrichmentCache(),
+		spendRegressions:    newSpendRegressionMonitor(),
 		kanbanMutations:     kanbanstate.NewMutationTracker(),
 		kanbanRefreshes:     newKanbanRefreshFeedbackTracker(),
 		refreshes:           newManualRefreshTracker(),

--- a/internal/web/server_test.go
+++ b/internal/web/server_test.go
@@ -9787,6 +9787,46 @@ func TestServerPreservesSnapshotBudgetWhenSpendQueryFails(t *testing.T) {
 	}
 }
 
+func TestServerSurfacesFleetSpendWhenBudgetCapsAreDisabled(t *testing.T) {
+	t.Parallel()
+
+	generatedAt := time.Date(2026, 8, 8, 12, 0, 0, 0, time.UTC)
+	registry := project.NewRegistry()
+	mustSetWebProject(t, registry, "detent", false)
+	var gotQuery store.BudgetCostQuery
+	deps := testDeps(t)
+	deps.Registry = registry
+	deps.Store = storeProbe{
+		budgetCostEvents: func(_ context.Context, query store.BudgetCostQuery) ([]store.BudgetCostEvent, error) {
+			gotQuery = query
+			return []store.BudgetCostEvent{
+				{ProjectID: "detent", At: generatedAt.Add(-time.Hour), CostUSD: 3.22},
+				{ProjectID: "detent", At: generatedAt.AddDate(0, 0, -1), CostUSD: 363.50},
+			}, nil
+		},
+	}
+	if err := deps.Hub.Publish(telemetry.Snapshot{GeneratedAt: generatedAt}); err != nil {
+		t.Fatalf("Publish() error = %v", err)
+	}
+	server, err := web.NewServer(web.Config{}, deps)
+	if err != nil {
+		t.Fatalf("NewServer() error = %v", err)
+	}
+
+	state := requestJSON(t, server, http.MethodGet, "/api/v1/state", http.StatusOK)
+	budgetState := state["budget"].(map[string]any)
+	if budgetState["enabled"] != false || budgetState["today_spend_usd"] != float64(3.22) {
+		t.Fatalf("budget = %#v, want uncapped fleet spend", budgetState)
+	}
+	regression := budgetState["spend_regression"].(map[string]any)
+	if regression["drop_percent"].(float64) < 98 || regression["previous_spend_usd"] != float64(363.50) || regression["projected_spend_usd"] != float64(6.44) {
+		t.Fatalf("spend regression = %#v, want same-day fleet regression", regression)
+	}
+	if len(gotQuery.ProjectIDs) != 1 || gotQuery.ProjectIDs[0] != "detent" {
+		t.Fatalf("BudgetCostQuery.ProjectIDs = %#v, want all configured projects", gotQuery.ProjectIDs)
+	}
+}
+
 func TestServerDistinguishesNoBudgetSpendFromSpendQueryFailure(t *testing.T) {
 	t.Parallel()
 

--- a/internal/web/templates/fleet_data.go
+++ b/internal/web/templates/fleet_data.go
@@ -1,6 +1,7 @@
 package templates
 
 import (
+	"fmt"
 	"math"
 	"sort"
 	"strconv"
@@ -462,6 +463,10 @@ func fleetMetricsFromSnapshot(data DashboardData) fleetMetrics {
 		if budget.CurrentSpendUSD <= 0 && len(budget.Days) == 0 {
 			metrics.SpendNote = "No budget spend yet."
 		}
+	}
+	if regression := budget.SpendRegression; regression != nil {
+		metrics.SpendWarn = true
+		metrics.SpendNote = fmt.Sprintf("%.0f%% below yesterday's pace (%s projected vs %s yesterday).", regression.DropPercent, formatUSD(regression.ProjectedSpendUSD), formatUSD(regression.PreviousSpendUSD))
 	}
 
 	// Gate on the points the chart actually plots (throughputTrendPoints

--- a/internal/web/templates/fleet_data_test.go
+++ b/internal/web/templates/fleet_data_test.go
@@ -556,6 +556,26 @@ func TestFleetAllClearLine(t *testing.T) {
 	}
 }
 
+func TestFleetViewSurfacesDailySpendRegression(t *testing.T) {
+	t.Parallel()
+
+	data := fleetTestData()
+	data.Snapshot.Budget.SpendRegression = &telemetry.SpendRegression{
+		Date:              "2026-08-08",
+		PreviousSpendUSD:  363.50,
+		ProjectedSpendUSD: 3.22,
+		DropPercent:       99.1,
+		ThresholdPercent:  90,
+	}
+	view := fleetViewFromDashboard(data)
+	if view.Spend != "$45.50 today" {
+		t.Fatalf("Spend = %q, want fleet daily spend figure", view.Spend)
+	}
+	if !view.Metrics.SpendWarn || !strings.Contains(view.Metrics.SpendNote, "99% below yesterday's pace") || !strings.Contains(view.Metrics.SpendNote, "$3.22 projected vs $363.50 yesterday") {
+		t.Fatalf("spend regression metrics = %#v", view.Metrics)
+	}
+}
+
 func TestSplitIssueIdentifier(t *testing.T) {
 	tests := []struct {
 		identifier string


### PR DESCRIPTION
## Summary

- preserve cumulative Codex thread totals and last-call usage as separate values
- attribute resumed threads with a session baseline so persistence, cost, budgets, and spend brakes do not double count
- add per-notification usage diagnostics, implausible completion warnings, and fleet daily-spend regression visibility

Fixes #1716

## UI Surface Contract

- [x] N/A, or the linked issue explicitly authorizes any high-impact UI surface, layout, density, first-viewport, or responsive visibility tradeoff.
- [x] Persistent top-of-screen messaging is explicitly authorized by the issue, or this PR does not add it.
- [x] Visual changes to primary operator screens include screenshot or browser verification below.

Browser verification: the existing fleet dashboard visual test passed against an isolated port-0 runtime and confirmed the spend metric card remains visible without document overflow.

## Test Plan

- [x] `make check`
- [x] `node_modules/.bin/playwright test layout.spec.js --project=chromium --grep 'fleet page shows agent hero'`