### PR TITLE
fix(orchestrator): defer dependency waits

### DIFF
--- a/.detent/skills/durable-machine-deferrals.md
+++ b/.detent/skills/durable-machine-deferrals.md
@@ -1,0 +1,15 @@
+---
+name: durable-machine-deferrals
+description: Preserve machine-resolvable worker waits without charging terminal progress brakes or repeatedly launching full sessions.
+when_to_use: Use when a worker correctly stops on tracked dependencies, remote capacity, or another machine-resolvable condition that must survive orchestrator restart.
+---
+
+# Durable machine deferrals
+
+1. Reproduce the wait being misclassified as failure or no progress before changing the brake.
+2. Accept only a structured wait signal with no human action. Validate every declared reference through the owning backend and require at least one unresolved real resource.
+3. Log and reject malformed, fabricated, self-referential, or missing references. Preserve the original brake behavior for rejected signals.
+4. Persist a distinct deferral reason and the validated resource identities in durable attempt metadata. Do not rely on an in-memory retry entry for restart safety.
+5. Release the worker claim without scheduling another full session.
+6. Before dispatch, inspect only the latest applicable attempt, batch-refresh its recorded resources, and suppress launch while any remain unresolved. Treat refresh failures as continued deferral and release the issue when every resource becomes terminal.
+7. Test the terminal-brake boundary, human-action precedence, rejected references, restart reconstruction, unresolved suppression, and terminal release.

--- a/internal/orchestrator/dispatch.go
+++ b/internal/orchestrator/dispatch.go
@@ -131,6 +131,7 @@ func (o *Orchestrator) dispatchReadyIssues(ctx context.Context, state *State, is
 	if state.Draining || o.dispatchQuiesced() {
 		return
 	}
+	issues = o.filterImplementDependencyDeferrals(ctx, issues)
 	o.observePullRequestHydrationRecovery(state, issues, now)
 	planner := o.dispatchPlanner()
 	var lastDispatchFailure string
@@ -205,6 +206,7 @@ func (o *Orchestrator) dispatchCandidates(ctx context.Context, state *State, iss
 	if state.Draining || o.dispatchQuiesced() {
 		return
 	}
+	issues = o.filterImplementDependencyDeferrals(ctx, issues)
 	for _, issue := range issues {
 		if o.dispatchPlanner().hardAvailableSlots(state) == 0 {
 			return

--- a/internal/orchestrator/dispatch_test.go
+++ b/internal/orchestrator/dispatch_test.go
@@ -2471,6 +2471,90 @@ func TestDispatchReadyIssuesHydratesLightweightCandidateBeforeDependencyGate(t *
 	}
 }
 
+func TestFilterImplementDependencyDeferralsUsesDurableAttemptHistory(t *testing.T) {
+	t.Parallel()
+
+	issue := implementProgressIssueWithoutPR()
+	issue.Fields = map[string]string{"Status": "In Progress"}
+	history := []store.WorkAttempt{implementProgressDependencyDeferralHistoryAttempt(1, "digitaldrywood/detent#134", "Todo")}
+	tests := []struct {
+		name          string
+		blockerState  string
+		wantCandidate bool
+	}{
+		{name: "unresolved blocker suppresses worker after restart", blockerState: "Todo"},
+		{name: "terminal blocker releases worker after restart", blockerState: "Done", wantCandidate: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			cfg := normalizeConfig(Config{
+				MaxConcurrentAgents: 1,
+				Project:             scheduler.ProjectCandidate{ID: "detent"},
+				ActiveStates:        []string{"Todo", "In Progress"},
+				TerminalStates:      []string{"Done", "Cancelled"},
+			})
+			tracker := hydratingDispatchConnector{
+				issue:    issue,
+				blockers: []connector.Issue{{ID: "blocker-134", Identifier: "digitaldrywood/detent#134", State: tt.blockerState}},
+			}
+			orch := Orchestrator{
+				cfg:          cfg,
+				connector:    tracker,
+				workAttempts: &recordingWorkAttemptStore{history: history},
+			}
+
+			filtered := orch.filterImplementDependencyDeferrals(t.Context(), []connector.Issue{issue})
+			if got := len(filtered) == 1; got != tt.wantCandidate {
+				t.Fatalf("candidate retained = %v, want %v", got, tt.wantCandidate)
+			}
+		})
+	}
+}
+
+func TestDispatchReadyIssuesDoesNotLaunchDurableDependencyDeferral(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 8, 8, 19, 0, 0, 0, time.UTC)
+	issue := implementProgressIssueWithoutPR()
+	issue.AssignedToWorker = true
+	issue.Fields = map[string]string{"Status": "In Progress"}
+	cfg := normalizeConfig(Config{
+		MaxConcurrentAgents: 1,
+		Project:             scheduler.ProjectCandidate{ID: "detent"},
+		ActiveStates:        []string{"Todo", "In Progress"},
+		TerminalStates:      []string{"Done", "Cancelled"},
+	})
+	runner := newWorkerHostRunner()
+	orch := Orchestrator{
+		cfg: cfg,
+		connector: hydratingDispatchConnector{
+			issue:    issue,
+			blockers: []connector.Issue{{ID: "blocker-134", Identifier: "digitaldrywood/detent#134", State: "Todo"}},
+		},
+		workAttempts: &recordingWorkAttemptStore{history: []store.WorkAttempt{
+			implementProgressDependencyDeferralHistoryAttempt(1, "digitaldrywood/detent#134", "Todo"),
+		}},
+		supervisor: newTestSupervisor(t, runner, cfg),
+		runResults: make(chan runpkg.Completion, 1),
+	}
+	state := newState(cfg)
+	if !orch.dispatchable(issue, &state, now) {
+		t.Fatal("control candidate is not independently dispatchable")
+	}
+
+	orch.dispatchReadyIssues(t.Context(), &state, []connector.Issue{issue}, now)
+	select {
+	case request := <-runner.started:
+		t.Fatalf("unexpected worker launch for durable dependency deferral: %#v", request)
+	default:
+	}
+	if _, blocked := state.Blocked[issue.ID]; blocked {
+		t.Fatalf("Blocked[%q] present for dependency deferral", issue.ID)
+	}
+}
+
 func TestDispatchReadyIssuesLogsDebugDecisionAndWorkerLifecycle(t *testing.T) {
 	t.Parallel()
 
@@ -3032,7 +3116,8 @@ func (c *budgetRefusalCommentConnector) SetField(context.Context, string, string
 var _ connector.Connector = (*budgetRefusalCommentConnector)(nil)
 
 type hydratingDispatchConnector struct {
-	issue connector.Issue
+	issue    connector.Issue
+	blockers []connector.Issue
 }
 
 func (c hydratingDispatchConnector) Name() string {
@@ -3052,6 +3137,10 @@ func (c hydratingDispatchConnector) FetchIssueStatesByIDs(_ context.Context, ids
 		return []connector.Issue{c.issue}, nil
 	}
 	return nil, nil
+}
+
+func (c hydratingDispatchConnector) FetchIssueStatesByIdentifiers(context.Context, []string) ([]connector.Issue, error) {
+	return cloneIssues(c.blockers), nil
 }
 
 func (c hydratingDispatchConnector) CreateComment(context.Context, string, string) error {

--- a/internal/orchestrator/dispatch_test.go
+++ b/internal/orchestrator/dispatch_test.go
@@ -2480,10 +2480,12 @@ func TestFilterImplementDependencyDeferralsUsesDurableAttemptHistory(t *testing.
 	tests := []struct {
 		name          string
 		blockerState  string
+		historyErr    error
 		wantCandidate bool
 	}{
 		{name: "unresolved blocker suppresses worker after restart", blockerState: "Todo"},
 		{name: "terminal blocker releases worker after restart", blockerState: "Done", wantCandidate: true},
+		{name: "history lookup failure suppresses worker", blockerState: "Todo", historyErr: errors.New("attempt store unavailable")},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -2502,7 +2504,7 @@ func TestFilterImplementDependencyDeferralsUsesDurableAttemptHistory(t *testing.
 			orch := Orchestrator{
 				cfg:          cfg,
 				connector:    tracker,
-				workAttempts: &recordingWorkAttemptStore{history: history},
+				workAttempts: &recordingWorkAttemptStore{history: history, historyErr: tt.historyErr},
 			}
 
 			filtered := orch.filterImplementDependencyDeferrals(t.Context(), []connector.Issue{issue})
@@ -3209,6 +3211,7 @@ type recordingWorkAttemptStore struct {
 	reclaimed               []store.WorkAttempt
 	recent                  []store.WorkAttempt
 	history                 []store.WorkAttempt
+	historyErr              error
 	historyQueries          []store.WorkAttemptHistoryQuery
 	pendingCapacityReleases []store.WorkAttempt
 	clearedCapacityReleases []int64
@@ -3278,6 +3281,9 @@ func (s *recordingWorkAttemptStore) ClearWorkAttemptCapacityRelease(_ context.Co
 
 func (s *recordingWorkAttemptStore) ListRecentTerminalWorkAttempts(_ context.Context, query store.WorkAttemptHistoryQuery) ([]store.WorkAttempt, error) {
 	s.historyQueries = append(s.historyQueries, query)
+	if s.historyErr != nil {
+		return nil, s.historyErr
+	}
 	if s.history == nil {
 		return append([]store.WorkAttempt(nil), s.recent...), nil
 	}

--- a/internal/orchestrator/implement_dependency_deferral.go
+++ b/internal/orchestrator/implement_dependency_deferral.go
@@ -11,9 +11,10 @@ import (
 )
 
 type deferredCandidate struct {
-	issue   connector.Issue
-	record  implementProgressRecord
-	blocked bool
+	issue              connector.Issue
+	record             implementProgressRecord
+	blocked            bool
+	historyUnavailable bool
 }
 
 func (o *Orchestrator) evaluateImplementDependencyDeferral(
@@ -96,6 +97,7 @@ func (o *Orchestrator) filterImplementDependencyDeferrals(
 			if o.logger != nil {
 				o.logger.Warn("implement dependency deferral history lookup failed", "issue_id", issue.ID, "identifier", issue.Identifier, "error", err)
 			}
+			candidates[issue.ID] = &deferredCandidate{issue: issue, blocked: true, historyUnavailable: true}
 			continue
 		}
 		if len(attempts) == 0 {
@@ -123,6 +125,9 @@ func (o *Orchestrator) filterImplementDependencyDeferrals(
 	if len(candidates) == 0 {
 		return issues
 	}
+	if len(identifiers) == 0 {
+		return removeDeferredImplementCandidates(issues, candidates)
+	}
 	resolver, ok := o.connector.(connector.IssueReferenceResolver)
 	if !ok {
 		o.warnImplementDependencyDeferralRefresh(candidates, errors.New("issue reference resolver unavailable"))
@@ -140,6 +145,9 @@ func (o *Orchestrator) filterImplementDependencyDeferrals(
 		}
 	}
 	for _, candidate := range candidates {
+		if candidate.historyUnavailable {
+			continue
+		}
 		candidate.blocked = false
 		for _, blocker := range candidate.record.DependencyBlockers {
 			resolvedIssue, found := byIdentifier[normalizedIssueIdentifier(blocker.Identifier)]

--- a/internal/orchestrator/implement_dependency_deferral.go
+++ b/internal/orchestrator/implement_dependency_deferral.go
@@ -1,0 +1,243 @@
+package orchestrator
+
+import (
+	"context"
+	"errors"
+	"strings"
+
+	"github.com/digitaldrywood/detent/internal/connector"
+	runpkg "github.com/digitaldrywood/detent/internal/runner"
+	"github.com/digitaldrywood/detent/internal/workpad"
+)
+
+type deferredCandidate struct {
+	issue   connector.Issue
+	record  implementProgressRecord
+	blocked bool
+}
+
+func (o *Orchestrator) evaluateImplementDependencyDeferral(
+	ctx context.Context,
+	issue connector.Issue,
+) ([]implementDependencyBlocker, []string, bool) {
+	signal, ok := autoPromoteIssueWorkpadSignal(issue)
+	if !ok || signal == nil || signal.Source != workpad.SourceStructured {
+		return nil, nil, false
+	}
+	if signal.Invalid != nil {
+		rejected := []string{strings.TrimSpace(signal.Invalid.Message)}
+		o.warnRejectedImplementDependencyRefs(issue, rejected, nil)
+		return nil, rejected, false
+	}
+	if strings.TrimSpace(signal.Status) != workpad.StatusBlocked ||
+		strings.TrimSpace(signal.HumanAction) != "" ||
+		len(signal.Blockers) == 0 {
+		return nil, nil, false
+	}
+	resolver, ok := o.connector.(connector.IssueReferenceResolver)
+	if !ok {
+		rejected := implementDependencyIdentifiers(signal.Blockers)
+		o.warnRejectedImplementDependencyRefs(issue, rejected, errors.New("issue reference resolver unavailable"))
+		return nil, rejected, false
+	}
+	identifiers := implementDependencyIdentifiers(signal.Blockers)
+	resolved, err := resolver.FetchIssueStatesByIdentifiers(ctx, identifiers)
+	if err != nil {
+		o.warnRejectedImplementDependencyRefs(issue, identifiers, err)
+		return nil, identifiers, false
+	}
+	byIdentifier := make(map[string]connector.Issue, len(resolved))
+	for _, blocker := range resolved {
+		identifier := normalizedIssueIdentifier(blocker.Identifier)
+		if identifier != "" && strings.TrimSpace(blocker.ID) != "" {
+			byIdentifier[identifier] = blocker
+		}
+	}
+	self := normalizedIssueIdentifier(issue.Identifier)
+	blockers := make([]implementDependencyBlocker, 0, len(identifiers))
+	rejected := make([]string, 0)
+	unresolved := false
+	for _, identifier := range identifiers {
+		key := normalizedIssueIdentifier(identifier)
+		blocker, found := byIdentifier[key]
+		if key == "" || key == self || !found {
+			rejected = append(rejected, identifier)
+			continue
+		}
+		blockers = append(blockers, implementDependencyBlocker{
+			ID:         strings.TrimSpace(blocker.ID),
+			Identifier: strings.TrimSpace(blocker.Identifier),
+			State:      strings.TrimSpace(blocker.State),
+		})
+		if !implementDependencyTerminal(blocker, o.cfg.TerminalStates) {
+			unresolved = true
+		}
+	}
+	if len(rejected) > 0 {
+		o.warnRejectedImplementDependencyRefs(issue, rejected, nil)
+		return blockers, rejected, false
+	}
+	return blockers, nil, len(blockers) > 0 && unresolved
+}
+
+func (o *Orchestrator) filterImplementDependencyDeferrals(
+	ctx context.Context,
+	issues []connector.Issue,
+) []connector.Issue {
+	if o == nil || o.workAttempts == nil || len(issues) == 0 {
+		return issues
+	}
+	candidates := make(map[string]*deferredCandidate)
+	identifiers := make([]string, 0)
+	seenIdentifiers := make(map[string]struct{})
+	for _, issue := range issues {
+		attempts, err := o.recentImplementCompletionAttempts(ctx, issue, Running{Issue: issue, Mode: runpkg.RunModeImplement})
+		if err != nil {
+			if o.logger != nil {
+				o.logger.Warn("implement dependency deferral history lookup failed", "issue_id", issue.ID, "identifier", issue.Identifier, "error", err)
+			}
+			continue
+		}
+		if len(attempts) == 0 {
+			continue
+		}
+		record, ok := implementProgressRecordFromAttempt(attempts[0])
+		if !ok || !record.DependencyDeferral || record.Reason != implementDependencyDeferralReason || len(record.DependencyBlockers) == 0 {
+			continue
+		}
+		candidate := &deferredCandidate{issue: issue, record: record, blocked: true}
+		candidates[issue.ID] = candidate
+		for _, blocker := range record.DependencyBlockers {
+			identifier := strings.TrimSpace(blocker.Identifier)
+			key := normalizedIssueIdentifier(identifier)
+			if key == "" {
+				continue
+			}
+			if _, ok := seenIdentifiers[key]; ok {
+				continue
+			}
+			seenIdentifiers[key] = struct{}{}
+			identifiers = append(identifiers, identifier)
+		}
+	}
+	if len(candidates) == 0 {
+		return issues
+	}
+	resolver, ok := o.connector.(connector.IssueReferenceResolver)
+	if !ok {
+		o.warnImplementDependencyDeferralRefresh(candidates, errors.New("issue reference resolver unavailable"))
+		return removeDeferredImplementCandidates(issues, candidates)
+	}
+	resolved, err := resolver.FetchIssueStatesByIdentifiers(ctx, identifiers)
+	if err != nil {
+		o.warnImplementDependencyDeferralRefresh(candidates, err)
+		return removeDeferredImplementCandidates(issues, candidates)
+	}
+	byIdentifier := make(map[string]connector.Issue, len(resolved))
+	for _, issue := range resolved {
+		if identifier := normalizedIssueIdentifier(issue.Identifier); identifier != "" {
+			byIdentifier[identifier] = issue
+		}
+	}
+	for _, candidate := range candidates {
+		candidate.blocked = false
+		for _, blocker := range candidate.record.DependencyBlockers {
+			resolvedIssue, found := byIdentifier[normalizedIssueIdentifier(blocker.Identifier)]
+			if !found || !implementDependencyTerminal(resolvedIssue, o.cfg.TerminalStates) {
+				candidate.blocked = true
+				break
+			}
+		}
+		if o.logger != nil {
+			o.logger.Debug(
+				"implement dependency deferral evaluated",
+				"issue_id", candidate.issue.ID,
+				"identifier", candidate.issue.Identifier,
+				"blocked", candidate.blocked,
+				"blocker_refs", implementDependencyBlockerLabels(candidate.record.DependencyBlockers),
+			)
+		}
+	}
+	return removeDeferredImplementCandidates(issues, candidates)
+}
+
+func removeDeferredImplementCandidates(
+	issues []connector.Issue,
+	candidates map[string]*deferredCandidate,
+) []connector.Issue {
+	filtered := make([]connector.Issue, 0, len(issues))
+	for _, issue := range issues {
+		candidate, ok := candidates[issue.ID]
+		if ok && candidate.blocked {
+			continue
+		}
+		filtered = append(filtered, issue)
+	}
+	return filtered
+}
+
+func implementDependencyIdentifiers(blockers []workpad.Blocker) []string {
+	identifiers := make([]string, 0, len(blockers))
+	seen := make(map[string]struct{}, len(blockers))
+	for _, blocker := range blockers {
+		identifier := strings.TrimSpace(blocker.Identifier)
+		key := normalizedIssueIdentifier(identifier)
+		if key == "" {
+			identifier = strings.TrimSpace(blocker.Ref)
+			key = strings.ToLower(identifier)
+		}
+		if key == "" {
+			continue
+		}
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		seen[key] = struct{}{}
+		identifiers = append(identifiers, identifier)
+	}
+	return identifiers
+}
+
+func implementDependencyTerminal(issue connector.Issue, terminalStates []string) bool {
+	return issue.Closed || stateIn(issue.State, terminalStates) || pullRequestMerged(issue.PullRequest)
+}
+
+func implementDependencyBlockerLabels(blockers []implementDependencyBlocker) string {
+	labels := make([]string, 0, len(blockers))
+	for _, blocker := range blockers {
+		if identifier := strings.TrimSpace(blocker.Identifier); identifier != "" {
+			labels = append(labels, identifier)
+		}
+	}
+	return strings.Join(labels, ",")
+}
+
+func (o *Orchestrator) warnRejectedImplementDependencyRefs(issue connector.Issue, refs []string, err error) {
+	if o == nil || o.logger == nil || len(refs) == 0 {
+		return
+	}
+	attrs := []any{
+		"issue_id", strings.TrimSpace(issue.ID),
+		"identifier", strings.TrimSpace(issue.Identifier),
+		"rejected_refs", strings.Join(refs, ","),
+	}
+	if err != nil {
+		attrs = append(attrs, "error", err)
+	}
+	o.logger.Warn("implement dependency deferral rejected", attrs...)
+}
+
+func (o *Orchestrator) warnImplementDependencyDeferralRefresh(candidates map[string]*deferredCandidate, err error) {
+	if o == nil || o.logger == nil {
+		return
+	}
+	for _, candidate := range candidates {
+		o.logger.Warn(
+			"implement dependency deferral refresh failed",
+			"issue_id", candidate.issue.ID,
+			"identifier", candidate.issue.Identifier,
+			"blocker_refs", implementDependencyBlockerLabels(candidate.record.DependencyBlockers),
+			"error", err,
+		)
+	}
+}

--- a/internal/orchestrator/implement_progress.go
+++ b/internal/orchestrator/implement_progress.go
@@ -18,6 +18,7 @@ import (
 const (
 	implementProgressMetadataKey       = "completion_progress"
 	implementProgressOutcomeNoProgress = "no_progress"
+	implementDependencyDeferralReason  = "dependency_deferral"
 	noProgressLimitReason              = "no_progress_limit"
 	strandedUnpushedWorkReason         = "stranded_unpushed_work"
 	workpadBlockedUnactionedReason     = "workpad_blocked_unactioned"
@@ -43,6 +44,9 @@ type implementCompletionProgressDecision struct {
 	BlockReason            string
 	Block                  bool
 	Warning                string
+	DependencyDeferral     bool
+	DependencyBlockers     []implementDependencyBlocker
+	RejectedBlockerRefs    []string
 }
 
 type implementProgressRecord struct {
@@ -63,6 +67,15 @@ type implementProgressRecord struct {
 	NoProgressLimit        int                               `json:"no_progress_limit,omitempty"`
 	BlockReason            string                            `json:"block_reason,omitempty"`
 	Warning                string                            `json:"warning,omitempty"`
+	DependencyDeferral     bool                              `json:"dependency_deferral,omitempty"`
+	DependencyBlockers     []implementDependencyBlocker      `json:"dependency_blockers,omitempty"`
+	RejectedBlockerRefs    []string                          `json:"rejected_blocker_refs,omitempty"`
+}
+
+type implementDependencyBlocker struct {
+	ID         string `json:"id,omitempty"`
+	Identifier string `json:"identifier"`
+	State      string `json:"state,omitempty"`
 }
 
 type implementProgressSignatureRecord struct {
@@ -150,6 +163,18 @@ func (o *Orchestrator) evaluateImplementCompletionProgress(
 		if !diffStatsPresent(running.DiffStats) {
 			decision.Reason = "workspace_diffstat_unavailable_without_pull_request"
 			return decision
+		}
+		if implementProgressDiffStatsClean(running.DiffStats) {
+			blockers, rejected, deferred := o.evaluateImplementDependencyDeferral(ctx, issue)
+			decision.DependencyBlockers = blockers
+			decision.RejectedBlockerRefs = rejected
+			if deferred {
+				decision.Outcome = store.WorkAttemptTerminalSuccess
+				decision.Reason = implementDependencyDeferralReason
+				decision.DependencyDeferral = true
+				decision.WorkpadStatus = workpad.StatusBlocked
+				return decision
+			}
 		}
 		if !implementProgressDiffStatsClean(running.DiffStats) {
 			if strings.TrimSpace(running.DiffStats.Fingerprint) == "" {
@@ -483,6 +508,9 @@ func implementCompletionProgressMetadata(decision implementCompletionProgressDec
 		NoProgressLimit:        decision.NoProgressLimit,
 		BlockReason:            strings.TrimSpace(decision.BlockReason),
 		Warning:                strings.TrimSpace(decision.Warning),
+		DependencyDeferral:     decision.DependencyDeferral,
+		DependencyBlockers:     append([]implementDependencyBlocker(nil), decision.DependencyBlockers...),
+		RejectedBlockerRefs:    append([]string(nil), decision.RejectedBlockerRefs...),
 	}
 	if decision.PreviousSignatureFound {
 		previous := implementProgressSignatureRecordFromSignature(decision.PreviousSignature)
@@ -687,6 +715,23 @@ func (o *Orchestrator) blockImplementProgress(
 		"no_progress_limit", decision.NoProgressLimit,
 	)
 	return true
+}
+
+func (o *Orchestrator) finishImplementDependencyDeferral(
+	ctx context.Context,
+	state *State,
+	issue connector.Issue,
+	completedAt time.Time,
+) {
+	if err := o.abandonClaim(ctx, issue.ID); err != nil && o.logger != nil {
+		o.logger.Warn("implement dependency deferral claim release failed", "issue_id", issue.ID, "identifier", issue.Identifier, "error", err)
+	}
+	o.releaseClaim(state, issue.ID)
+	recordStateEvent(state, telemetry.ActivityEvent{
+		At:      completedAt,
+		Event:   "implement_dependency_deferred",
+		Message: "deferred " + issueLabel(issue) + " while declared dependencies remain unresolved",
+	})
 }
 
 func implementProgressRecoveryReason(decision implementCompletionProgressDecision) string {

--- a/internal/orchestrator/implement_progress_test.go
+++ b/internal/orchestrator/implement_progress_test.go
@@ -50,7 +50,10 @@ func TestHandleRunResultClassifiesImplementWorkerProgress(t *testing.T) {
 		wantFailedRemoved  []string
 		wantConsecutive    int
 		wantBlockReason    string
+		wantRejectedRef    string
 		workpadHumanAction string
+		workpadBlockerRef  string
+		resolvedBlockers   []connector.Issue
 		refreshedState     string
 		pullRequestUpdated bool
 	}{
@@ -171,6 +174,62 @@ func TestHandleRunResultClassifiesImplementWorkerProgress(t *testing.T) {
 			wantRetry:       true,
 		},
 		{
+			name:         "third clean dependency wait defers without tripping limit",
+			runningIssue: implementProgressIssueWithoutPR(),
+			history: []store.WorkAttempt{
+				implementProgressDependencyDeferralHistoryAttempt(2, "digitaldrywood/detent#134", "Todo"),
+				implementProgressDependencyDeferralHistoryAttempt(1, "digitaldrywood/detent#134", "Todo"),
+			},
+			diffStats:         DiffStats{Status: "clean"},
+			noProgressLimit:   3,
+			wantTerminal:      store.WorkAttemptTerminalSuccess,
+			wantReason:        "dependency_deferral",
+			workpadBlockerRef: "digitaldrywood/detent#134",
+			resolvedBlockers:  []connector.Issue{{ID: "blocker-134", Identifier: "digitaldrywood/detent#134", State: "Todo"}},
+			wantLogContains:   "",
+			wantConsecutive:   0,
+			wantBlocked:       false,
+			wantRetry:         false,
+		},
+		{
+			name:              "malformed blocker ref counts as no progress",
+			runningIssue:      implementProgressIssueWithoutPR(),
+			diffStats:         DiffStats{Status: "clean"},
+			noProgressLimit:   3,
+			wantTerminal:      store.WorkAttemptTerminalNoProgress,
+			wantReason:        "completed_clean_diff_without_pull_request",
+			wantConsecutive:   1,
+			workpadBlockerRef: "fabricated-ref",
+			wantRejectedRef:   "fabricated-ref",
+			wantLogContains:   "fabricated-ref",
+			wantRetry:         true,
+		},
+		{
+			name:              "unresolvable blocker ref counts as no progress",
+			runningIssue:      implementProgressIssueWithoutPR(),
+			diffStats:         DiffStats{Status: "clean"},
+			noProgressLimit:   3,
+			wantTerminal:      store.WorkAttemptTerminalNoProgress,
+			wantReason:        "completed_clean_diff_without_pull_request",
+			wantConsecutive:   1,
+			workpadBlockerRef: "digitaldrywood/detent#9999",
+			wantRejectedRef:   "digitaldrywood/detent#9999",
+			wantLogContains:   "digitaldrywood/detent#9999",
+			wantRetry:         true,
+		},
+		{
+			name:              "already terminal blocker does not defer empty attempt",
+			runningIssue:      implementProgressIssueWithoutPR(),
+			diffStats:         DiffStats{Status: "clean"},
+			noProgressLimit:   3,
+			wantTerminal:      store.WorkAttemptTerminalNoProgress,
+			wantReason:        "completed_clean_diff_without_pull_request",
+			wantConsecutive:   1,
+			workpadBlockerRef: "digitaldrywood/detent#134",
+			resolvedBlockers:  []connector.Issue{{ID: "blocker-134", Identifier: "digitaldrywood/detent#134", State: "Done"}},
+			wantRetry:         true,
+		},
+		{
 			name:         "July telemetry replay trips third clean completion without linked PR",
 			runningIssue: implementProgressIssueWithoutPR(),
 			history: []store.WorkAttempt{
@@ -245,6 +304,7 @@ func TestHandleRunResultClassifiesImplementWorkerProgress(t *testing.T) {
 			wantBlockReason:    "workpad_blocked_unactioned",
 			wantComment:        "> Choose the exhaustive review path.",
 			workpadHumanAction: "Choose the exhaustive review path.",
+			workpadBlockerRef:  "digitaldrywood/detent#134",
 		},
 		{
 			name:         "changing blocked human action does not trip",
@@ -328,13 +388,18 @@ func TestHandleRunResultClassifiesImplementWorkerProgress(t *testing.T) {
 			if tt.refreshedState != "" {
 				refreshed.State = tt.refreshedState
 			}
-			if tt.workpadHumanAction != "" {
+			if tt.workpadHumanAction != "" || tt.workpadBlockerRef != "" {
 				refreshed.Comments = []connector.IssueComment{{
-					Body: "## Codex Workpad\n\n```detent-status\nschema: 1\nstatus: blocked\nblockers: []\nhuman_action: \"" + tt.workpadHumanAction + "\"\n```",
+					Body: implementProgressWorkpadComment(tt.workpadBlockerRef, tt.workpadHumanAction),
 					URL:  "https://github.test/workpad",
 				}}
 			}
-			tracker := &implementProgressConnector{hydrated: tt.hydratedIssue, refreshed: refreshed, hydrateErr: tt.hydrateErr}
+			tracker := &implementProgressConnector{
+				hydrated:         tt.hydratedIssue,
+				refreshed:        refreshed,
+				hydrateErr:       tt.hydrateErr,
+				resolvedBlockers: tt.resolvedBlockers,
+			}
 			attempts := &implementProgressAttemptStore{history: tt.history}
 			cfg := normalizeConfig(Config{
 				Project:                scheduler.ProjectCandidate{ID: "detent"},
@@ -395,6 +460,9 @@ func TestHandleRunResultClassifiesImplementWorkerProgress(t *testing.T) {
 			}
 			if record.BlockReason != tt.wantBlockReason {
 				t.Fatalf("block reason = %q, want %q", record.BlockReason, tt.wantBlockReason)
+			}
+			if tt.wantRejectedRef != "" && !strings.Contains(strings.Join(record.RejectedBlockerRefs, ","), tt.wantRejectedRef) {
+				t.Fatalf("rejected blocker refs = %#v, want %q", record.RejectedBlockerRefs, tt.wantRejectedRef)
 			}
 			if !slicesEqual(record.FailedChecksAdded, tt.wantFailedAdded) {
 				t.Fatalf("failed checks added = %#v, want %#v", record.FailedChecksAdded, tt.wantFailedAdded)
@@ -1017,6 +1085,26 @@ func implementProgressIssueWithoutPR() connector.Issue {
 	}
 }
 
+func implementProgressWorkpadComment(blockerRef string, humanAction string) string {
+	var body strings.Builder
+	body.WriteString("## Codex Workpad\n\n```detent-status\nschema: 1\nstatus: blocked\n")
+	if strings.TrimSpace(blockerRef) == "" {
+		body.WriteString("blockers: []\n")
+	} else {
+		body.WriteString("blockers:\n  - ref: \"")
+		body.WriteString(blockerRef)
+		body.WriteString("\"\n    reason: \"waiting for dependency\"\n")
+	}
+	if strings.TrimSpace(humanAction) == "" {
+		body.WriteString("human_action: null\n```")
+	} else {
+		body.WriteString("human_action: \"")
+		body.WriteString(humanAction)
+		body.WriteString("\"\n```")
+	}
+	return body.String()
+}
+
 func implementProgressHistoryAttempt(id int64, signature autoPromoteReworkSignature, terminal store.WorkAttemptTerminalState) store.WorkAttempt {
 	return store.WorkAttempt{
 		ID:                 id,
@@ -1048,6 +1136,30 @@ func implementProgressLegacyNoPRHistoryAttempt(id int64) store.WorkAttempt {
 			implementProgressMetadataKey: implementProgressRecord{
 				Outcome:            string(store.WorkAttemptTerminalSuccess),
 				Reason:             "no_linked_pull_request",
+				WorkspaceDiffStats: implementProgressDiffStats{Status: "clean"},
+			},
+		}),
+	}
+}
+
+func implementProgressDependencyDeferralHistoryAttempt(id int64, identifier string, state string) store.WorkAttempt {
+	return store.WorkAttempt{
+		ID:            id,
+		ProjectID:     "detent",
+		IssueID:       "issue-plan",
+		Identifier:    "digitaldrywood/detent#1200",
+		IssueURL:      "https://github.test/digitaldrywood/detent/issues/1200",
+		WorkerType:    "agent",
+		Status:        store.WorkAttemptStatusTerminal,
+		TerminalState: store.WorkAttemptTerminalSuccess,
+		CompletedAt:   time.Date(2026, 8, 8, 18, int(id), 0, 0, time.UTC),
+		WorkerMetadataJSON: marshalWorkAttemptJSON(map[string]any{
+			"run_mode": runpkg.RunModeImplement,
+			implementProgressMetadataKey: implementProgressRecord{
+				Outcome:            string(store.WorkAttemptTerminalSuccess),
+				Reason:             implementDependencyDeferralReason,
+				DependencyDeferral: true,
+				DependencyBlockers: []implementDependencyBlocker{{ID: "blocker", Identifier: identifier, State: state}},
 				WorkspaceDiffStats: implementProgressDiffStats{Status: "clean"},
 			},
 		}),
@@ -1134,16 +1246,17 @@ func implementProgressRecordFromCompletion(t *testing.T, completion store.WorkAt
 }
 
 type implementProgressConnector struct {
-	hydrated       connector.Issue
-	refreshed      connector.Issue
-	hydrateErr     error
-	hydrateErrs    []error
-	refreshErr     error
-	hydrations     int
-	updates        []implementProgressUpdate
-	comments       []implementProgressComment
-	relabelStarted chan autoPromoteTickRelabel
-	relabelRelease chan struct{}
+	hydrated         connector.Issue
+	refreshed        connector.Issue
+	hydrateErr       error
+	hydrateErrs      []error
+	refreshErr       error
+	hydrations       int
+	updates          []implementProgressUpdate
+	comments         []implementProgressComment
+	relabelStarted   chan autoPromoteTickRelabel
+	relabelRelease   chan struct{}
+	resolvedBlockers []connector.Issue
 }
 
 type implementProgressUpdate struct {
@@ -1180,6 +1293,10 @@ func (c *implementProgressConnector) FetchIssueStatesByIDs(context.Context, []st
 
 func (c *implementProgressConnector) FetchIssueComments(context.Context, connector.Issue) ([]connector.IssueComment, error) {
 	return cloneIssueComments(c.refreshed.Comments), nil
+}
+
+func (c *implementProgressConnector) FetchIssueStatesByIdentifiers(context.Context, []string) ([]connector.Issue, error) {
+	return cloneIssues(c.resolvedBlockers), nil
 }
 
 func (c *implementProgressConnector) CreateComment(_ context.Context, issueID string, body string) error {

--- a/internal/orchestrator/implement_progress_test.go
+++ b/internal/orchestrator/implement_progress_test.go
@@ -54,6 +54,8 @@ func TestHandleRunResultClassifiesImplementWorkerProgress(t *testing.T) {
 		workpadHumanAction string
 		workpadBlockerRef  string
 		resolvedBlockers   []connector.Issue
+		completionErr      error
+		wantClaimed        bool
 		refreshedState     string
 		pullRequestUpdated bool
 	}{
@@ -190,6 +192,19 @@ func TestHandleRunResultClassifiesImplementWorkerProgress(t *testing.T) {
 			wantConsecutive:   0,
 			wantBlocked:       false,
 			wantRetry:         false,
+		},
+		{
+			name:              "dependency deferral persistence failure retains claim",
+			runningIssue:      implementProgressIssueWithoutPR(),
+			diffStats:         DiffStats{Status: "clean"},
+			noProgressLimit:   3,
+			wantTerminal:      store.WorkAttemptTerminalSuccess,
+			wantReason:        "dependency_deferral",
+			workpadBlockerRef: "digitaldrywood/detent#134",
+			resolvedBlockers:  []connector.Issue{{ID: "blocker-134", Identifier: "digitaldrywood/detent#134", State: "Todo"}},
+			completionErr:     errors.New("attempt store unavailable"),
+			wantClaimed:       true,
+			wantLogContains:   "complete work attempt failed",
 		},
 		{
 			name:              "malformed blocker ref counts as no progress",
@@ -400,7 +415,7 @@ func TestHandleRunResultClassifiesImplementWorkerProgress(t *testing.T) {
 				hydrateErr:       tt.hydrateErr,
 				resolvedBlockers: tt.resolvedBlockers,
 			}
-			attempts := &implementProgressAttemptStore{history: tt.history}
+			attempts := &implementProgressAttemptStore{history: tt.history, completionErr: tt.completionErr}
 			cfg := normalizeConfig(Config{
 				Project:                scheduler.ProjectCandidate{ID: "detent"},
 				AutoPromote:            AutoPromoteConfig{NoProgressLimit: tt.noProgressLimit},
@@ -488,6 +503,9 @@ func TestHandleRunResultClassifiesImplementWorkerProgress(t *testing.T) {
 				}
 			} else if _, ok := state.Retry[tt.runningIssue.ID]; ok != tt.wantRetry {
 				t.Fatalf("retry present = %v, want %v", ok, tt.wantRetry)
+			}
+			if _, ok := state.Claimed[tt.runningIssue.ID]; ok != tt.wantClaimed {
+				t.Fatalf("claimed present = %v, want %v", ok, tt.wantClaimed)
 			}
 			if tt.wantLogContains != "" && !strings.Contains(logs.String(), tt.wantLogContains) {
 				t.Fatalf("logs did not contain %q:\n%s", tt.wantLogContains, logs.String())
@@ -1344,11 +1362,12 @@ func (c *implementProgressConnector) ReapplyPullRequestLabel(ctx context.Context
 }
 
 type implementProgressAttemptStore struct {
-	history      []store.WorkAttempt
-	historyErr   error
-	completions  []store.WorkAttemptCompletion
-	historyCalls int
-	queries      []store.WorkAttemptHistoryQuery
+	history       []store.WorkAttempt
+	historyErr    error
+	completionErr error
+	completions   []store.WorkAttemptCompletion
+	historyCalls  int
+	queries       []store.WorkAttemptHistoryQuery
 }
 
 func (s *implementProgressAttemptStore) StartWorkAttempt(context.Context, store.WorkAttemptStart) (int64, error) {
@@ -1365,7 +1384,7 @@ func (s *implementProgressAttemptStore) RecordWorkAttemptHeartbeat(context.Conte
 
 func (s *implementProgressAttemptStore) CompleteWorkAttempt(_ context.Context, attrs store.WorkAttemptCompletion) error {
 	s.completions = append(s.completions, attrs)
-	return nil
+	return s.completionErr
 }
 
 func (s *implementProgressAttemptStore) ListActiveWorkAttempts(context.Context, store.WorkAttemptQuery) ([]store.WorkAttempt, error) {

--- a/internal/orchestrator/run_completion.go
+++ b/internal/orchestrator/run_completion.go
@@ -409,7 +409,7 @@ func (o *Orchestrator) handleRunResult(ctx context.Context, state *State, event 
 		statusMessage = "artifact gate convergence breaker tripped"
 	}
 	o.recordProjectAttemptOutcome(state, event.IssueID, event.CompletedAt, terminalState, nil, errorClass, errorMessage)
-	o.completeDurableWorkAttemptWithMetadata(ctx, state, running, event.CompletedAt, terminalState, errorClass, errorMessage, phase, statusMessage, mergeWorkAttemptMetadata(
+	attemptCompleted := o.completeDurableWorkAttemptWithMetadata(ctx, state, running, event.CompletedAt, terminalState, errorClass, errorMessage, phase, statusMessage, mergeWorkAttemptMetadata(
 		implementCompletionProgressMetadata(progress),
 		spendProgressMetadata(spendProgress),
 		artifactGateConvergenceMetadata(artifactConvergence),
@@ -460,7 +460,15 @@ func (o *Orchestrator) handleRunResult(ctx context.Context, state *State, event 
 		}
 	}
 	if progress.DependencyDeferral {
-		o.finishImplementDependencyDeferral(ctx, state, running.Issue, event.CompletedAt)
+		if attemptCompleted {
+			o.finishImplementDependencyDeferral(ctx, state, running.Issue, event.CompletedAt)
+		} else {
+			recordStateEvent(state, telemetry.ActivityEvent{
+				At:      event.CompletedAt,
+				Event:   "implement_dependency_deferral_persist_failed",
+				Message: "retained claim for " + issueLabel(running.Issue) + " after dependency deferral persistence failed",
+			})
+		}
 		return
 	}
 	if event.Result.BudgetRefusal != nil && !o.cfg.subscriptionBilling() && event.Result.BudgetRefusal.Code == string(budget.ReasonPerIssueMaxUSD) {

--- a/internal/orchestrator/run_completion.go
+++ b/internal/orchestrator/run_completion.go
@@ -459,6 +459,10 @@ func (o *Orchestrator) handleRunResult(ctx context.Context, state *State, event 
 			return
 		}
 	}
+	if progress.DependencyDeferral {
+		o.finishImplementDependencyDeferral(ctx, state, running.Issue, event.CompletedAt)
+		return
+	}
 	if event.Result.BudgetRefusal != nil && !o.cfg.subscriptionBilling() && event.Result.BudgetRefusal.Code == string(budget.ReasonPerIssueMaxUSD) {
 		if err := o.abandonClaim(ctx, event.IssueID); err != nil && o.logger != nil {
 			o.logger.Warn("per-issue budget hold claim release failed", "issue_id", event.IssueID, "error", err)

--- a/internal/orchestrator/work_attempts.go
+++ b/internal/orchestrator/work_attempts.go
@@ -392,9 +392,9 @@ func (o *Orchestrator) completeDurableWorkAttemptWithMetadata(
 	phase string,
 	statusMessage string,
 	metadata map[string]any,
-) {
+) bool {
 	if o == nil || o.workAttempts == nil || running.WorkAttemptID <= 0 {
-		return
+		return false
 	}
 	if completedAt.IsZero() {
 		completedAt = time.Now()
@@ -431,9 +431,10 @@ func (o *Orchestrator) completeDurableWorkAttemptWithMetadata(
 		if o.logger != nil {
 			o.logger.Warn("complete work attempt failed", "attempt_id", running.WorkAttemptID, "issue_id", running.Issue.ID, "error", err)
 		}
-		return
+		return false
 	}
 	o.applyWorkAttemptCompletionSnapshot(state, running, completion)
+	return true
 }
 
 func (o *Orchestrator) runningWorkAttemptHeartbeat(state *State, running Running, now time.Time) store.WorkAttemptHeartbeat {


### PR DESCRIPTION
## Summary

- Treat resolvable structured dependency waits as successful deferrals instead of no-progress attempts.
- Persist validated blocker identities and suppress full worker redispatch until every dependency becomes terminal, including across restart.
- Preserve actionable-human and genuine no-progress behavior while logging malformed, fabricated, self-referential, or terminal blocker claims.

Fixes #1728

## UI Surface Contract

- [x] N/A; this change has no UI surface, layout, density, first-viewport, or responsive visibility tradeoff.
- [x] This PR does not add persistent top-of-screen messaging.
- [x] N/A; this PR has no visual changes to primary operator screens.

## Test Plan

- [x] `make check` (passed twice, including after the skill draft)
- [x] Safety-critical implement-progress exact-file coverage: 92.2% (356/386 statements; 90% floor preserved)
- [x] `go test ./internal/orchestrator -run "^$" -fuzz=. -fuzztime=30s` (1,623,249 executions)