### PR TITLE
feat(resilience): treat CI outages as fleet condition

### DIFF
--- a/config.reference.yaml
+++ b/config.reference.yaml
@@ -249,6 +249,8 @@
 #             duration_seconds: 0
 #         # tracker.issues[].pull_request.running_checks | type: list<string> | default: [] | required: No | validation: None
 #         running_checks: []
+#         # tracker.issues[].pull_request.unstarted_check_count | type: integer | default: 0 when configured | required: No | validation: None
+#         unstarted_check_count: 0
 #         # tracker.issues[].pull_request.unstarted_checks | type: list<object> | default: [] | required: No | validation: None
 #         unstarted_checks:
 #           -

--- a/docs/config.md
+++ b/docs/config.md
@@ -793,6 +793,7 @@ rendering and fails on drift.
 | `tracker.issues[].pull_request.transient_failed_checks[].queue_seconds` | `integer` | `0 when configured` | No | None |
 | `tracker.issues[].pull_request.transient_failed_checks[].status` | `string` | `none` | No | None |
 | `tracker.issues[].pull_request.transient_failed_checks[].workflow_run_id` | `integer` | `0 when configured` | No | None |
+| `tracker.issues[].pull_request.unstarted_check_count` | `integer` | `0 when configured` | No | None |
 | `tracker.issues[].pull_request.unstarted_checks` | `list<object>` | `[]` | No | None |
 | `tracker.issues[].pull_request.unstarted_checks[].conclusion` | `string` | `none` | No | None |
 | `tracker.issues[].pull_request.unstarted_checks[].details_url` | `string` | `none` | No | None |

--- a/internal/cli/runner.go
+++ b/internal/cli/runner.go
@@ -903,6 +903,7 @@ func mergeSnapshot(current, next telemetry.Snapshot) telemetry.Snapshot {
 	current.TrackerDrift.UntrackedOpen = append(current.TrackerDrift.UntrackedOpen, next.TrackerDrift.UntrackedOpen...)
 	current.TrackerDrift.OpenTerminal = append(current.TrackerDrift.OpenTerminal, next.TrackerDrift.OpenTerminal...)
 	current.Budget.Refusals = append(current.Budget.Refusals, next.Budget.Refusals...)
+	current.CIUnavailable = append(current.CIUnavailable, next.CIUnavailable...)
 	current.BackendOutages = append(current.BackendOutages, next.BackendOutages...)
 	current.FailureBreakers = append(current.FailureBreakers, next.FailureBreakers...)
 	current.DispatchRecoveries = append(current.DispatchRecoveries, next.DispatchRecoveries...)
@@ -1303,6 +1304,11 @@ func stampSnapshotProjectID(snapshot telemetry.Snapshot) telemetry.Snapshot {
 	for i := range snapshot.BackendOutages {
 		if strings.TrimSpace(snapshot.BackendOutages[i].ProjectID) == "" {
 			snapshot.BackendOutages[i].ProjectID = projectID
+		}
+	}
+	for i := range snapshot.CIUnavailable {
+		if strings.TrimSpace(snapshot.CIUnavailable[i].ProjectID) == "" {
+			snapshot.CIUnavailable[i].ProjectID = projectID
 		}
 	}
 	for i := range snapshot.FailureBreakers {

--- a/internal/cli/runner_test.go
+++ b/internal/cli/runner_test.go
@@ -1572,6 +1572,7 @@ func TestMergeSnapshotStampsProjectIDOnIssueRows(t *testing.T) {
 		Completed: []telemetry.Completed{
 			{Issue: telemetry.Issue{ID: "completed", Identifier: "digitaldrywood/detent#5"}, CompletedAt: completedAt},
 		},
+		CIUnavailable:      []telemetry.CICondition{{UnstartedCheckCount: 4, PullRequestCount: 2}},
 		FailureBreakers:    []telemetry.FailureBreaker{{Class: "session_token_ceiling"}},
 		DispatchRecoveries: []telemetry.DispatchRecovery{{Kind: "github_rest", Status: "ramping"}},
 	})
@@ -1588,6 +1589,7 @@ func TestMergeSnapshotStampsProjectIDOnIssueRows(t *testing.T) {
 		{name: "queued", got: got.Queue[0].ProjectID},
 		{name: "blocked", got: got.Blocked[0].ProjectID},
 		{name: "completed", got: got.Completed[0].ProjectID},
+		{name: "CI unavailable", got: got.CIUnavailable[0].ProjectID},
 		{name: "failure breaker", got: got.FailureBreakers[0].ProjectID},
 		{name: "dispatch recovery", got: got.DispatchRecoveries[0].ProjectID},
 	}

--- a/internal/connector/github/adapter_test.go
+++ b/internal/connector/github/adapter_test.go
@@ -2371,6 +2371,9 @@ func TestConnectorFetchIssuesByStatesAttachesPipelinePullRequest(t *testing.T) {
 	if len(pr.UnstartedChecks) != 1 || pr.UnstartedChecks[0].Name != "Portability Verify" || pr.UnstartedChecks[0].QueueSeconds != 56*60 {
 		t.Fatalf("UnstartedChecks = %#v, want Portability Verify queued 56 minutes", pr.UnstartedChecks)
 	}
+	if pr.UnstartedCheckCount != 1 {
+		t.Fatalf("UnstartedCheckCount = %d, want 1", pr.UnstartedCheckCount)
+	}
 	if len(pr.CodexReviewFindings) != 1 ||
 		pr.CodexReviewFindings[0].Body != "[P1] Unsafe migration." ||
 		pr.CodexReviewFindings[0].URL != "https://github.com/digitaldrywood/detent/pull/190#pullrequestreview-2" {
@@ -2421,6 +2424,7 @@ func TestCheckRunTelemetryDistinguishesUnstartedChecks(t *testing.T) {
 		checkRuns     []restCheckRun
 		wantRunning   []string
 		wantUnstarted []connector.PullRequestCheck
+		wantCount     int
 	}{
 		{
 			name: "all checks in progress",
@@ -2479,6 +2483,7 @@ func TestCheckRunTelemetryDistinguishesUnstartedChecks(t *testing.T) {
 				{ID: 4, Name: "D", Status: "queued", QueueSeconds: 47 * 60},
 				{ID: 5, Name: "E", Status: "queued", QueueSeconds: 47 * 60},
 			},
+			wantCount: 6,
 		},
 		{name: "empty check run list"},
 	}
@@ -2493,6 +2498,13 @@ func TestCheckRunTelemetryDistinguishesUnstartedChecks(t *testing.T) {
 			}
 			if !slices.Equal(summary.UnstartedChecks, tt.wantUnstarted) {
 				t.Fatalf("UnstartedChecks = %#v, want %#v", summary.UnstartedChecks, tt.wantUnstarted)
+			}
+			wantCount := tt.wantCount
+			if wantCount == 0 {
+				wantCount = len(tt.wantUnstarted)
+			}
+			if summary.UnstartedCount != wantCount {
+				t.Fatalf("UnstartedCount = %d, want %d", summary.UnstartedCount, wantCount)
 			}
 		})
 	}

--- a/internal/connector/github/pull_request_checks.go
+++ b/internal/connector/github/pull_request_checks.go
@@ -17,6 +17,7 @@ type checkRunTelemetrySummary struct {
 	DurationSeconds int64
 	SlowChecks      []connector.PullRequestCheck
 	RunningChecks   []string
+	UnstartedCount  int
 	UnstartedChecks []connector.PullRequestCheck
 }
 
@@ -69,6 +70,7 @@ func (c *Connector) fetchPullRequestCI(ctx context.Context, repo pullRequestRepo
 		CIDurationSeconds:     telemetry.DurationSeconds,
 		SlowChecks:            telemetry.SlowChecks,
 		RunningChecks:         telemetry.RunningChecks,
+		UnstartedCheckCount:   telemetry.UnstartedCount,
 		UnstartedChecks:       telemetry.UnstartedChecks,
 		StaleSuccessfulChecks: staleSuccessfulChecks,
 		RequiredFailures:      requiredFailures,
@@ -482,6 +484,7 @@ func checkRunTelemetry(checkRuns []restCheckRun, workflowRuns []restWorkflowRun,
 		}
 		return unstartedChecks[i].Name < unstartedChecks[j].Name
 	})
+	unstartedCount := len(unstartedChecks)
 	if len(unstartedChecks) > pullRequestUnstartedCheckLimit {
 		unstartedChecks = unstartedChecks[:pullRequestUnstartedCheckLimit]
 	}
@@ -498,6 +501,7 @@ func checkRunTelemetry(checkRuns []restCheckRun, workflowRuns []restWorkflowRun,
 		DurationSeconds: durationSeconds,
 		SlowChecks:      slowChecks,
 		RunningChecks:   runningChecks,
+		UnstartedCount:  unstartedCount,
 		UnstartedChecks: unstartedChecks,
 	}
 }

--- a/internal/connector/github/pull_requests.go
+++ b/internal/connector/github/pull_requests.go
@@ -819,6 +819,7 @@ func attachPullRequestToIssue(issue *connector.Issue, repo pullRequestRepo, pull
 		CIDurationSeconds:            pullRequest.CI.CIDurationSeconds,
 		SlowChecks:                   append([]connector.PullRequestCheck(nil), pullRequest.CI.SlowChecks...),
 		RunningChecks:                append([]string(nil), pullRequest.CI.RunningChecks...),
+		UnstartedCheckCount:          pullRequest.CI.UnstartedCheckCount,
 		UnstartedChecks:              append([]connector.PullRequestCheck(nil), pullRequest.CI.UnstartedChecks...),
 		StaleSuccessfulChecks:        append([]connector.PullRequestCheck(nil), pullRequest.CI.StaleSuccessfulChecks...),
 		RequiredCheckFailures:        append([]connector.PullRequestCheck(nil), pullRequest.CI.RequiredFailures...),

--- a/internal/connector/github/pullrequestcache.go
+++ b/internal/connector/github/pullrequestcache.go
@@ -232,6 +232,7 @@ func clonePullRequestCI(ci pullRequestCI) pullRequestCI {
 		CIDurationSeconds:     ci.CIDurationSeconds,
 		SlowChecks:            append([]connector.PullRequestCheck(nil), ci.SlowChecks...),
 		RunningChecks:         append([]string(nil), ci.RunningChecks...),
+		UnstartedCheckCount:   ci.UnstartedCheckCount,
 		UnstartedChecks:       append([]connector.PullRequestCheck(nil), ci.UnstartedChecks...),
 		StaleSuccessfulChecks: append([]connector.PullRequestCheck(nil), ci.StaleSuccessfulChecks...),
 		RequiredFailures:      append([]connector.PullRequestCheck(nil), ci.RequiredFailures...),

--- a/internal/connector/github/types.go
+++ b/internal/connector/github/types.go
@@ -334,6 +334,7 @@ type pullRequestCI struct {
 	CIDurationSeconds     int64
 	SlowChecks            []connector.PullRequestCheck
 	RunningChecks         []string
+	UnstartedCheckCount   int
 	UnstartedChecks       []connector.PullRequestCheck
 	StaleSuccessfulChecks []connector.PullRequestCheck
 	RequiredFailures      []connector.PullRequestCheck

--- a/internal/connector/issue.go
+++ b/internal/connector/issue.go
@@ -124,6 +124,7 @@ type PullRequest struct {
 	CIDurationSeconds            int64                       `json:"ci_duration_seconds,omitempty" yaml:"ci_duration_seconds,omitempty"`
 	SlowChecks                   []PullRequestCheck          `json:"slow_checks,omitempty" yaml:"slow_checks,omitempty"`
 	RunningChecks                []string                    `json:"running_checks,omitempty" yaml:"running_checks,omitempty"`
+	UnstartedCheckCount          int                         `json:"unstarted_check_count,omitempty" yaml:"unstarted_check_count,omitempty"`
 	UnstartedChecks              []PullRequestCheck          `json:"unstarted_checks,omitempty" yaml:"unstarted_checks,omitempty"`
 	StaleSuccessfulChecks        []PullRequestCheck          `json:"stale_successful_checks,omitempty" yaml:"stale_successful_checks,omitempty"`
 	RequiredCheckFailures        []PullRequestCheck          `json:"required_check_failures,omitempty" yaml:"required_check_failures,omitempty"`

--- a/internal/orchestrator/ci_availability.go
+++ b/internal/orchestrator/ci_availability.go
@@ -73,7 +73,7 @@ func evaluateCIAvailability(issues []connector.Issue, now time.Time) (CIConditio
 	pullRequests := make(map[string]ciUnavailablePullRequest)
 	for _, issue := range issues {
 		pullRequest := issue.PullRequest
-		if pullRequest == nil {
+		if pullRequest == nil || normalizePullRequestState(pullRequest.State) != "open" {
 			continue
 		}
 		checkCount := max(pullRequest.UnstartedCheckCount, len(pullRequest.UnstartedChecks))

--- a/internal/orchestrator/ci_availability.go
+++ b/internal/orchestrator/ci_availability.go
@@ -1,0 +1,248 @@
+package orchestrator
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/digitaldrywood/detent/internal/connector"
+	runpkg "github.com/digitaldrywood/detent/internal/runner"
+	"github.com/digitaldrywood/detent/internal/store"
+	"github.com/digitaldrywood/detent/internal/telemetry"
+)
+
+const (
+	ciUnavailableMinimumChecks       = 2
+	ciUnavailableMinimumPullRequests = 2
+	ciUnavailableErrorClass          = "ci_unavailable"
+)
+
+type CICondition = telemetry.CICondition
+
+type ciUnavailablePullRequest struct {
+	checkCount        int
+	oldestQueueSecond int64
+}
+
+func (o *Orchestrator) syncCIAvailability(state *State, issues []connector.Issue, now time.Time) {
+	if state == nil {
+		return
+	}
+	if now.IsZero() {
+		now = o.clockNow()
+	}
+	condition, unavailable := evaluateCIAvailability(issues, now)
+	if !unavailable {
+		if state.CIUnavailable != nil {
+			recordStateEvent(state, telemetry.ActivityEvent{
+				At:      now.UTC(),
+				Event:   "ci_availability_recovered",
+				Message: "CI checks started moving again; CI-gated dispatch resumed",
+			})
+		}
+		state.CIUnavailable = nil
+		return
+	}
+	condition.ProjectID = strings.TrimSpace(o.cfg.Project.ID)
+	if state.CIUnavailable != nil && !state.CIUnavailable.DetectedAt.IsZero() {
+		condition.DetectedAt = state.CIUnavailable.DetectedAt
+	} else {
+		recordStateEvent(state, telemetry.ActivityEvent{
+			At:      now.UTC(),
+			Event:   "ci_unavailable",
+			Message: ciUnavailableMessage(condition),
+		})
+		if o.logger != nil {
+			o.logger.Warn(
+				"CI unavailable",
+				"project_id", condition.ProjectID,
+				"unstarted_checks", condition.UnstartedCheckCount,
+				"pull_requests", condition.PullRequestCount,
+				"oldest_queue_seconds", condition.OldestQueueSeconds,
+			)
+		}
+	}
+	state.CIUnavailable = &condition
+	o.parkCIUnavailableWaiters(state, issues, now)
+}
+
+func evaluateCIAvailability(issues []connector.Issue, now time.Time) (CICondition, bool) {
+	pullRequests := make(map[string]ciUnavailablePullRequest)
+	for _, issue := range issues {
+		pullRequest := issue.PullRequest
+		if pullRequest == nil {
+			continue
+		}
+		checkCount := max(pullRequest.UnstartedCheckCount, len(pullRequest.UnstartedChecks))
+		if checkCount == 0 {
+			continue
+		}
+		key := ciAvailabilityPullRequestKey(issue)
+		if key == "" {
+			continue
+		}
+		observation := pullRequests[key]
+		observation.checkCount = max(observation.checkCount, checkCount)
+		for _, check := range pullRequest.UnstartedChecks {
+			observation.oldestQueueSecond = max(observation.oldestQueueSecond, check.QueueSeconds)
+		}
+		pullRequests[key] = observation
+	}
+
+	condition := CICondition{
+		PullRequestCount: len(pullRequests),
+		DetectedAt:       now.UTC(),
+		LastObservedAt:   now.UTC(),
+	}
+	for _, observation := range pullRequests {
+		condition.UnstartedCheckCount += observation.checkCount
+		condition.OldestQueueSeconds = max(condition.OldestQueueSeconds, observation.oldestQueueSecond)
+	}
+	return condition, condition.UnstartedCheckCount >= ciUnavailableMinimumChecks &&
+		condition.PullRequestCount >= ciUnavailableMinimumPullRequests
+}
+
+func ciAvailabilityPullRequestKey(issue connector.Issue) string {
+	pullRequest := issue.PullRequest
+	if pullRequest == nil {
+		return ""
+	}
+	if repository, number := strings.TrimSpace(pullRequestRepository(issue)), pullRequestNumber(issue); repository != "" && number > 0 {
+		return repository + "#" + strconv.Itoa(number)
+	}
+	if value := strings.TrimSpace(pullRequest.URL); value != "" {
+		return value
+	}
+	if number := pullRequestNumber(issue); number > 0 {
+		return "#" + strconv.Itoa(number)
+	}
+	return strings.TrimSpace(issue.ID)
+}
+
+func activeCIUnavailable(state *State) bool {
+	return state != nil && state.CIUnavailable != nil
+}
+
+func ciDependentDispatch(issue connector.Issue) bool {
+	return mergeWorkerIssue(issue)
+}
+
+func ciUnavailableRetry(state *State, issueID string) bool {
+	if state == nil {
+		return false
+	}
+	return state.Retry[issueID].CIUnavailable
+}
+
+func (o *Orchestrator) parkCIUnavailableWaiters(state *State, issues []connector.Issue, now time.Time) {
+	if state == nil {
+		return
+	}
+	fresh := make(map[string]connector.Issue, len(issues))
+	for _, issue := range issues {
+		if id := strings.TrimSpace(issue.ID); id != "" {
+			fresh[id] = issue
+		}
+	}
+	parked := 0
+	for issueID, running := range state.Running {
+		if issue, ok := fresh[issueID]; ok {
+			running.Issue = mergeIssueTrackerFields(running.Issue, issue)
+		}
+		if !ciUnavailableWaitingRun(running, state) {
+			state.Running[issueID] = running
+			continue
+		}
+		parked++
+		if running.CIStopRequested || running.stop == nil {
+			state.Running[issueID] = running
+			continue
+		}
+		running.CIStopRequested = true
+		state.Running[issueID] = running
+		running.stop(runpkg.ErrCIUnavailable)
+		recordStateEvent(state, telemetry.ActivityEvent{
+			At:      now.UTC(),
+			Event:   "ci_unavailable_attempt_parking",
+			Message: "parking " + issueLabel(running.Issue) + " until CI checks start moving",
+		})
+	}
+	if state.CIUnavailable != nil {
+		state.CIUnavailable.ParkedAttemptCount = parked
+	}
+}
+
+func ciUnavailableWaitingRun(running Running, state *State) bool {
+	pullRequest := running.Issue.PullRequest
+	if pullRequest == nil || max(pullRequest.UnstartedCheckCount, len(pullRequest.UnstartedChecks)) == 0 {
+		return false
+	}
+	if mergeWorkerIssue(running.Issue) || strings.TrimSpace(running.Mode) == runpkg.RunModeMerge {
+		return true
+	}
+	if strings.TrimSpace(running.Mode) == runpkg.RunModePlan {
+		return false
+	}
+	return running.WorkProductPushed || runningWorkAttemptPhase(running, state) == "waiting_ci"
+}
+
+func (o *Orchestrator) handleCIUnavailableCompletion(
+	ctx context.Context,
+	state *State,
+	event runpkg.Completion,
+	running Running,
+) bool {
+	if !errors.Is(event.Err, runpkg.ErrCIUnavailable) {
+		return false
+	}
+	message := "CI unavailable; attempt parked until checks start moving"
+	o.completeDurableWorkAttempt(
+		ctx,
+		state,
+		running,
+		event.CompletedAt,
+		store.WorkAttemptTerminalCapacity,
+		ciUnavailableErrorClass,
+		message,
+		"waiting",
+		message,
+	)
+	if workspaceIssueTerminal(running.Issue, o.cfg.TerminalStates) {
+		o.releaseClaim(state, running.Issue.ID)
+		return true
+	}
+	state.Retry[running.Issue.ID] = Retry{
+		Issue:         cloneIssue(running.Issue),
+		Attempt:       running.Attempt,
+		DueAt:         event.CompletedAt,
+		Error:         message,
+		WorkerHost:    running.WorkerHost,
+		CIUnavailable: true,
+	}
+	recordStateEvent(state, telemetry.ActivityEvent{
+		At:      event.CompletedAt.UTC(),
+		Event:   "ci_unavailable_attempt_parked",
+		Message: "parked " + issueLabel(running.Issue) + " without holding an agent slot",
+	})
+	return true
+}
+
+func ciUnavailableMessage(condition CICondition) string {
+	return fmt.Sprintf(
+		"CI unavailable: %d checks queued and unstarted across %d PRs; oldest queued %s",
+		condition.UnstartedCheckCount,
+		condition.PullRequestCount,
+		time.Duration(condition.OldestQueueSeconds)*time.Second,
+	)
+}
+
+func cloneCICondition(condition *CICondition) *CICondition {
+	if condition == nil {
+		return nil
+	}
+	cloned := *condition
+	return &cloned
+}

--- a/internal/orchestrator/ci_availability_test.go
+++ b/internal/orchestrator/ci_availability_test.go
@@ -38,6 +38,16 @@ func TestSyncCIAvailability(t *testing.T) {
 			},
 		},
 		{
+			name: "inactive pull requests do not raise condition",
+			issues: func() []connector.Issue {
+				closed := ciAvailabilityIssue("closed", 15, 2, []connector.PullRequestCheck{{Name: "Verify", Status: "queued", QueueSeconds: 3_600}})
+				closed.PullRequest.State = "CLOSED"
+				merged := ciAvailabilityIssue("merged", 16, 3, []connector.PullRequestCheck{{Name: "Lint", Status: "queued", QueueSeconds: 2_700}})
+				merged.PullRequest.State = "MERGED"
+				return []connector.Issue{closed, merged}
+			}(),
+		},
+		{
 			name: "sustained unstarted checks across PRs raise condition",
 			issues: []connector.Issue{
 				ciAvailabilityIssue("first", 13, 2, []connector.PullRequestCheck{{Name: "Verify", Status: "queued", QueueSeconds: 3_600}}),

--- a/internal/orchestrator/ci_availability_test.go
+++ b/internal/orchestrator/ci_availability_test.go
@@ -1,0 +1,218 @@
+package orchestrator
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/digitaldrywood/detent/internal/connector"
+	runpkg "github.com/digitaldrywood/detent/internal/runner"
+	"github.com/digitaldrywood/detent/internal/scheduler"
+)
+
+func TestSyncCIAvailability(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 8, 8, 18, 0, 0, 0, time.UTC)
+	orch := Orchestrator{cfg: normalizeConfig(Config{Project: scheduler.ProjectCandidate{ID: "detent"}})}
+	state := newState(orch.cfg)
+	tests := []struct {
+		name       string
+		issues     []connector.Issue
+		wantActive bool
+		wantChecks int
+		wantPRs    int
+		wantOldest int64
+	}{
+		{
+			name: "healthy CI",
+			issues: []connector.Issue{
+				ciAvailabilityIssue("healthy", 11, 0, nil),
+			},
+		},
+		{
+			name: "one slow check does not raise condition",
+			issues: []connector.Issue{
+				ciAvailabilityIssue("slow", 12, 1, []connector.PullRequestCheck{{Name: "Verify", Status: "queued", QueueSeconds: 1_800}}),
+			},
+		},
+		{
+			name: "sustained unstarted checks across PRs raise condition",
+			issues: []connector.Issue{
+				ciAvailabilityIssue("first", 13, 2, []connector.PullRequestCheck{{Name: "Verify", Status: "queued", QueueSeconds: 3_600}}),
+				ciAvailabilityIssue("second", 14, 3, []connector.PullRequestCheck{{Name: "Lint", Status: "queued", QueueSeconds: 2_700}}),
+			},
+			wantActive: true,
+			wantChecks: 5,
+			wantPRs:    2,
+			wantOldest: 3_600,
+		},
+		{
+			name: "recovery clears condition",
+			issues: []connector.Issue{
+				ciAvailabilityIssue("first", 13, 0, nil),
+				ciAvailabilityIssue("second", 14, 0, nil),
+			},
+		},
+	}
+
+	for index, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			observedAt := now.Add(time.Duration(index) * time.Minute)
+			orch.syncCIAvailability(&state, tt.issues, observedAt)
+			if got := state.CIUnavailable != nil; got != tt.wantActive {
+				t.Fatalf("CIUnavailable active = %v, want %v", got, tt.wantActive)
+			}
+			if !tt.wantActive {
+				return
+			}
+			if got := state.CIUnavailable.UnstartedCheckCount; got != tt.wantChecks {
+				t.Fatalf("UnstartedCheckCount = %d, want %d", got, tt.wantChecks)
+			}
+			if got := state.CIUnavailable.PullRequestCount; got != tt.wantPRs {
+				t.Fatalf("PullRequestCount = %d, want %d", got, tt.wantPRs)
+			}
+			if got := state.CIUnavailable.OldestQueueSeconds; got != tt.wantOldest {
+				t.Fatalf("OldestQueueSeconds = %d, want %d", got, tt.wantOldest)
+			}
+		})
+	}
+}
+
+func TestCIUnavailableDispatchPolicy(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 8, 8, 18, 0, 0, 0, time.UTC)
+	cfg := normalizeConfig(Config{
+		Project:             scheduler.ProjectCandidate{ID: "detent"},
+		MaxConcurrentAgents: 3,
+		ActiveStates:        []string{"Todo", "In Progress", "Rework", "Merging"},
+		TerminalStates:      []string{"Done", "Cancelled"},
+	})
+	tests := []struct {
+		name          string
+		condition     bool
+		stateName     string
+		withPR        bool
+		wantAllowed   bool
+		wantSkipCause string
+	}{
+		{name: "merge waits while CI unavailable", condition: true, stateName: "Merging", withPR: true, wantSkipCause: dispatchSkipCIUnavailable},
+		{name: "Todo still dispatches while CI unavailable", condition: true, stateName: "Todo", wantAllowed: true},
+		{name: "Rework still dispatches while CI unavailable", condition: true, stateName: "Rework", withPR: true, wantAllowed: true},
+		{name: "merge resumes after CI recovery", stateName: "Merging", withPR: true, wantAllowed: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			state := newState(cfg)
+			if tt.condition {
+				state.CIUnavailable = &CICondition{DetectedAt: now}
+			}
+			issue := dispatchTestIssue("issue", tt.stateName)
+			if tt.withPR {
+				issue = dispatchTestIssueWithPullRequest("issue", tt.stateName, "open")
+				issue.PullRequest.CIStatus = "pending"
+			}
+			decision := newDispatchPlanner(cfg).dispatchableIssueDecision(issue, &state, false, now, "")
+			if decision.dispatchable != tt.wantAllowed || decision.reason != tt.wantSkipCause {
+				t.Fatalf("dispatch decision = %#v, want allowed %v reason %q", decision, tt.wantAllowed, tt.wantSkipCause)
+			}
+		})
+	}
+}
+
+func TestParkCIUnavailableWaiters(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 8, 8, 18, 0, 0, 0, time.UTC)
+	cfg := normalizeConfig(Config{
+		Project:             scheduler.ProjectCandidate{ID: "detent"},
+		MaxConcurrentAgents: 2,
+		ActiveStates:        []string{"Todo", "In Progress", "Rework", "Merging"},
+	})
+	orch := Orchestrator{cfg: cfg}
+	state := newState(cfg)
+	waitingCtx, waitingStop := context.WithCancelCause(context.Background())
+	workingCtx, workingStop := context.WithCancelCause(context.Background())
+	waiting := ciAvailabilityIssue("waiting", 21, 1, []connector.PullRequestCheck{{Name: "Verify", Status: "queued", QueueSeconds: 3_600}})
+	waiting.State = "In Progress"
+	working := ciAvailabilityIssue("working", 22, 1, []connector.PullRequestCheck{{Name: "Lint", Status: "queued", QueueSeconds: 3_600}})
+	working.State = "In Progress"
+	state.Running[waiting.ID] = Running{Issue: waiting, LastMessage: "waiting for CI checks", stop: waitingStop}
+	state.Running[working.ID] = Running{Issue: working, LastMessage: "editing implementation", stop: workingStop}
+
+	orch.parkCIUnavailableWaiters(&state, []connector.Issue{waiting, working}, now)
+
+	if cause := context.Cause(waitingCtx); !errors.Is(cause, runpkg.ErrCIUnavailable) {
+		t.Fatalf("waiting context cause = %v, want ErrCIUnavailable", cause)
+	}
+	if cause := context.Cause(workingCtx); cause != nil {
+		t.Fatalf("working context cause = %v, want nil", cause)
+	}
+	if !state.Running[waiting.ID].CIStopRequested {
+		t.Fatal("waiting run was not marked for CI-unavailable parking")
+	}
+}
+
+func TestCIUnavailableCompletionResumesAfterRecovery(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 8, 8, 18, 0, 0, 0, time.UTC)
+	cfg := normalizeConfig(Config{
+		Project:             scheduler.ProjectCandidate{ID: "detent"},
+		MaxConcurrentAgents: 1,
+		ActiveStates:        []string{"Todo", "In Progress", "Rework", "Merging"},
+	})
+	orch := Orchestrator{cfg: cfg}
+	state := newState(cfg)
+	state.CIUnavailable = &CICondition{DetectedAt: now.Add(-time.Hour)}
+	issue := ciAvailabilityIssue("parked", 23, 1, []connector.PullRequestCheck{{Name: "Verify", Status: "queued", QueueSeconds: 3_600}})
+	issue.State = "In Progress"
+	running := Running{Issue: issue, Attempt: 2, WorkerHost: "worker-a"}
+
+	if !orch.handleCIUnavailableCompletion(t.Context(), &state, runpkg.Completion{
+		IssueID:     issue.ID,
+		CompletedAt: now,
+		Err:         runpkg.ErrCIUnavailable,
+	}, running) {
+		t.Fatal("handleCIUnavailableCompletion() = false, want true")
+	}
+	retry, ok := state.Retry[issue.ID]
+	if !ok || retry.Attempt != running.Attempt || !retry.DueAt.Equal(now) || !retry.CIUnavailable {
+		t.Fatalf("Retry[%q] = %#v, want parked same-attempt retry", issue.ID, retry)
+	}
+	_, allowed, reason := newDispatchPlanner(cfg).retryAction(&state, issue, retry, now)
+	if allowed || reason != dispatchSkipCIUnavailable {
+		t.Fatalf("retry during outage = allowed %v reason %q, want paused", allowed, reason)
+	}
+
+	orch.syncCIAvailability(&state, []connector.Issue{ciAvailabilityIssue("healthy", 24, 0, nil)}, now.Add(time.Minute))
+	if state.CIUnavailable != nil {
+		t.Fatalf("CIUnavailable = %#v, want recovery", state.CIUnavailable)
+	}
+	_, allowed, reason = newDispatchPlanner(cfg).retryAction(&state, issue, retry, now.Add(time.Minute))
+	if !allowed || reason != "" {
+		t.Fatalf("retry after recovery = allowed %v reason %q, want allowed", allowed, reason)
+	}
+}
+
+func ciAvailabilityIssue(id string, number int, count int, checks []connector.PullRequestCheck) connector.Issue {
+	return connector.Issue{
+		ID:               id,
+		Identifier:       "digitaldrywood/detent#" + id,
+		Title:            id,
+		State:            "Merging",
+		AssignedToWorker: true,
+		PRRepository:     "digitaldrywood/detent",
+		PullRequest: &connector.PullRequest{
+			Number:              number,
+			URL:                 "https://github.com/digitaldrywood/detent/pull/" + id,
+			State:               "OPEN",
+			CIStatus:            "pending",
+			UnstartedCheckCount: count,
+			UnstartedChecks:     checks,
+		},
+	}
+}

--- a/internal/orchestrator/dispatch.go
+++ b/internal/orchestrator/dispatch.go
@@ -247,6 +247,7 @@ const (
 	dispatchIssueFailureStartStateTransition  = "start_state_transition_failed"
 	dispatchIssueFailureBackendCapacityPaused = "backend_capacity_paused"
 	dispatchIssueFailureGitHubRESTPaused      = "github_rest_capacity_paused"
+	dispatchIssueFailureCIUnavailable         = "ci_unavailable"
 	dispatchIssueFailureRecoveryRamp          = "dispatch_recovery_ramp"
 )
 
@@ -320,6 +321,9 @@ func (o *Orchestrator) dispatchIssueWithAdmission(
 	defer o.finishDispatchStart()
 	if state.Draining {
 		return dispatchIssueOutcome{reason: dispatchIssueFailureDraining}
+	}
+	if activeCIUnavailable(state) && (ciDependentDispatch(issue) || ciUnavailableRetry(state, issue.ID)) {
+		return dispatchIssueOutcome{reason: dispatchIssueFailureCIUnavailable}
 	}
 	if _, paused := activeGitHubRESTCapacityOutage(state, now); paused {
 		return dispatchIssueOutcome{reason: dispatchIssueFailureGitHubRESTPaused}

--- a/internal/orchestrator/dispatch_planner.go
+++ b/internal/orchestrator/dispatch_planner.go
@@ -213,6 +213,9 @@ func (p dispatchPlanner) retryAction(
 	retry Retry,
 	now time.Time,
 ) (dispatchAction, bool, string) {
+	if activeCIUnavailable(state) && (ciDependentDispatch(issue) || retry.CIUnavailable) {
+		return dispatchAction{}, false, dispatchSkipCIUnavailable
+	}
 	if outage, paused := activeGitHubRESTCapacityOutage(state, now); paused {
 		if retry.DueAt.Before(outage.ResumeAt) {
 			retry.DueAt = outage.ResumeAt
@@ -514,6 +517,7 @@ const (
 	dispatchSkipHydrationFailed          = "hydrate_failed"
 	dispatchSkipDispatchBackoffCancelled = "dispatch_backoff_cancelled"
 	dispatchSkipGitHubRESTCapacity       = "github_rest_capacity_paused"
+	dispatchSkipCIUnavailable            = "ci_unavailable"
 	dispatchSkipProjectFailureBreaker    = projectFailureBreakerDispatchPaused
 	dispatchSkipRateWindowBackpressure   = "provider_rate_window_backpressure"
 )
@@ -551,6 +555,9 @@ func (p dispatchPlanner) dispatchableIssueDecisionForModelRequirement(
 	}
 	if stateIn(issue.State, p.cfg.TerminalStates) {
 		return dispatchableDecision{reason: dispatchSkipTerminalState}
+	}
+	if activeCIUnavailable(state) && ciDependentDispatch(issue) {
+		return dispatchableDecision{reason: dispatchSkipCIUnavailable}
 	}
 	if _, paused := activeGitHubRESTCapacityOutage(state, now); paused {
 		return dispatchableDecision{reason: dispatchSkipGitHubRESTCapacity}

--- a/internal/orchestrator/run_completion.go
+++ b/internal/orchestrator/run_completion.go
@@ -154,6 +154,9 @@ func (o *Orchestrator) handleRunResult(ctx context.Context, state *State, event 
 		o.backoffDispatchRecovery(state, event.IssueID, event.CompletedAt, delay)
 	}
 	releaseDispatchRecoveryAdmission(state, event.IssueID)
+	if o.handleCIUnavailableCompletion(ctx, state, event, running) {
+		return
+	}
 	if o.handleMergeRevocationCompletion(ctx, state, event, running) {
 		return
 	}

--- a/internal/orchestrator/snapshot.go
+++ b/internal/orchestrator/snapshot.go
@@ -102,6 +102,7 @@ func (s State) Snapshot(now time.Time) telemetry.Snapshot {
 		Blocked:                 blockedSnapshots(s.Blocked, s.Claimed, now, s.laneEntries),
 		Completed:               completedSnapshots(s.Completed, s.Claimed, now, s.laneEntries),
 		RateLimits:              cloneRateLimits(s.RateLimits),
+		CIUnavailable:           ciUnavailableSnapshots(s.CIUnavailable),
 		BackendOutages:          backendOutageSnapshots(s.BackendOutages),
 		FailureBreakers:         projectFailureBreakerSnapshots(s.FailureBreaker),
 		DispatchRecoveries:      dispatchRecoverySnapshots(s.DispatchRecoveries, s.PoolName, poolCapacity),
@@ -121,6 +122,13 @@ func (s State) Snapshot(now time.Time) telemetry.Snapshot {
 	}
 	applySnapshotLaneProvenance(&snapshot, s.laneProvenance)
 	return snapshot
+}
+
+func ciUnavailableSnapshots(condition *CICondition) []telemetry.CICondition {
+	if condition == nil {
+		return nil
+	}
+	return []telemetry.CICondition{*condition}
 }
 
 func applySnapshotLaneProvenance(snapshot *telemetry.Snapshot, laneProvenance map[string]provenance.Attribution) {
@@ -822,6 +830,7 @@ func telemetryPullRequest(issue connector.Issue, quietDuration time.Duration, po
 		QuietWaitSeconds:           pullRequestQuietWaitSeconds(issue, quietDuration, pollInterval),
 		SlowChecks:                 telemetryPullRequestChecks(pullRequest.SlowChecks),
 		RunningChecks:              append([]string(nil), pullRequest.RunningChecks...),
+		UnstartedCheckCount:        pullRequest.UnstartedCheckCount,
 		UnstartedChecks:            telemetryPullRequestChecks(pullRequest.UnstartedChecks),
 		RequiredCheckFailures:      telemetryPullRequestChecks(pullRequest.RequiredCheckFailures),
 		CodexReviewState:           pullRequest.CodexReviewState,

--- a/internal/orchestrator/state.go
+++ b/internal/orchestrator/state.go
@@ -80,6 +80,7 @@ type State struct {
 	FailureBreaker           ProjectFailureBreaker
 	DispatchRecoveries       map[string]DispatchRecovery
 	StalenessWarnings        map[string]StalenessWarning
+	CIUnavailable            *CICondition
 	BackendOutages           map[string]BackendOutage
 	BackendRecoveries        map[string]BackendRecovery
 	DiffStats                map[string]DiffStats
@@ -133,6 +134,7 @@ type Running struct {
 	CapacityScope         backendcapacity.Scope
 	CapacityProbe         bool
 	ModelPermitExempt     bool
+	CIStopRequested       bool
 	StopDestination       string
 	StopPriorityOptions   []telemetry.StopRunPriorityOption
 	globalSlot            scheduler.Slot
@@ -213,6 +215,7 @@ type Retry struct {
 	RetryMode     runpkg.RetryMode
 	ResumeState   store.AgentResumeState
 	MergePrecheck *runpkg.MergePrecheck
+	CIUnavailable bool
 }
 
 type InstantFailure struct {
@@ -373,6 +376,7 @@ func (s State) clone() State {
 		FailureBreaker:           cloneProjectFailureBreaker(s.FailureBreaker),
 		DispatchRecoveries:       cloneDispatchRecoveries(s.DispatchRecoveries),
 		StalenessWarnings:        maps.Clone(s.StalenessWarnings),
+		CIUnavailable:            cloneCICondition(s.CIUnavailable),
 		BackendOutages:           maps.Clone(s.BackendOutages),
 		BackendRecoveries:        maps.Clone(s.BackendRecoveries),
 		DiffStats:                make(map[string]DiffStats, len(s.DiffStats)),

--- a/internal/orchestrator/tick.go
+++ b/internal/orchestrator/tick.go
@@ -112,6 +112,13 @@ func (o *Orchestrator) tickWithManual(ctx context.Context, state *State, now tim
 	timing.next("reconciliation")
 	fetched = retainUnavailablePullRequestsFromPrevious(fetched, previous)
 	fetched = applyStatusPullRequestHydrationBlocksToCandidates(fetched)
+	if fetched.statusOK {
+		ciIssues := mergeIssueSlices(fetched.candidates, fetched.status)
+		for _, running := range state.Running {
+			ciIssues = mergeIssueSlices(ciIssues, []connector.Issue{running.Issue})
+		}
+		o.syncCIAvailability(state, ciIssues, now)
+	}
 	terminalRetryTransitions := o.reconcileTerminalAttemptRetryStates(ctx, state, mergeIssueSlices(fetched.candidates, fetched.status), now)
 	fetched.candidates = overlayIssueStateSnapshots(fetched.candidates, terminalRetryTransitions)
 	fetched.status = overlayIssueStateSnapshots(fetched.status, terminalRetryTransitions)

--- a/internal/orchestrator/work_attempts.go
+++ b/internal/orchestrator/work_attempts.go
@@ -780,6 +780,9 @@ func (o *Orchestrator) capacitySnapshotJSON(state *State, issue connector.Issue)
 	if state != nil && len(state.BackendOutages) > 0 {
 		snapshot["backend_outages"] = backendOutagesCapacitySnapshot(state.BackendOutages)
 	}
+	if state != nil && state.CIUnavailable != nil {
+		snapshot["ci_unavailable"] = *state.CIUnavailable
+	}
 	if state != nil && len(state.DispatchRecoveries) > 0 {
 		snapshot["dispatch_recoveries"] = dispatchRecoveriesCapacitySnapshot(state.DispatchRecoveries, pool.Name, pool.Capacity)
 	}

--- a/internal/runner/agent.go
+++ b/internal/runner/agent.go
@@ -2278,6 +2278,9 @@ func finalStateForTurnError(err error) string {
 	if errors.Is(err, ErrMergeRevoked) {
 		return FinalStateMergeRevoked
 	}
+	if errors.Is(err, ErrCIUnavailable) {
+		return FinalStateCIUnavailable
+	}
 	if errors.Is(err, ErrMergeWorkerDurationExceeded) {
 		return FinalStateMergeDurationExceeded
 	}

--- a/internal/runner/supervisor.go
+++ b/internal/runner/supervisor.go
@@ -207,6 +207,7 @@ func (s *Supervisor) Run(ctx context.Context, request RunRequest) (completion Co
 func cooperativeStopError(err error) bool {
 	return errors.Is(err, ErrOperatorStopped) ||
 		errors.Is(err, ErrMergeRevoked) ||
+		errors.Is(err, ErrCIUnavailable) ||
 		errors.Is(err, ErrModelPermitUnavailable) ||
 		errors.Is(err, ErrMergeWorkerStartupTimeout) ||
 		errors.Is(err, ErrMergeWorkerDurationExceeded) ||

--- a/internal/runner/supervisor.go
+++ b/internal/runner/supervisor.go
@@ -192,7 +192,8 @@ func (s *Supervisor) Run(ctx context.Context, request RunRequest) (completion Co
 
 	result, err := s.backend.Run(ctx, request)
 	if cause := context.Cause(ctx); errors.Is(cause, ErrMergeWorkerStartupTimeout) ||
-		errors.Is(cause, ErrMergeWorkerDurationExceeded) {
+		errors.Is(cause, ErrMergeWorkerDurationExceeded) ||
+		errors.Is(cause, ErrCIUnavailable) {
 		err = errors.Join(cause, err)
 		if errors.Is(cause, ErrMergeWorkerDurationExceeded) {
 			result.FinalState = FinalStateMergeDurationExceeded

--- a/internal/runner/supervisor_test.go
+++ b/internal/runner/supervisor_test.go
@@ -157,6 +157,47 @@ func TestCIUnavailableIsCooperativeStop(t *testing.T) {
 	}
 }
 
+func TestSupervisorPropagatesCancellationCause(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name          string
+		cause         error
+		wantCI        bool
+		wantRetryable bool
+	}{
+		{name: "CI unavailable remains cooperative", cause: ErrCIUnavailable, wantCI: true},
+		{name: "ordinary cancellation remains retryable", cause: context.Canceled, wantRetryable: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			ctx, cancel := context.WithCancelCause(context.Background())
+			cancel(tt.cause)
+			supervisor, err := NewSupervisor(contextErrorBackend{}, SupervisorConfig{})
+			if err != nil {
+				t.Fatalf("NewSupervisor() error = %v", err)
+			}
+
+			completion := supervisor.Run(ctx, RunRequest{
+				Issue:   connector.Issue{ID: "issue-canceled"},
+				Attempt: 3,
+			})
+			if got := errors.Is(completion.Err, ErrCIUnavailable); got != tt.wantCI {
+				t.Fatalf("errors.Is(Err, ErrCIUnavailable) = %v, want %v; Err = %v", got, tt.wantCI, completion.Err)
+			}
+			if completion.Retryable != tt.wantRetryable {
+				t.Fatalf("Retryable = %v, want %v", completion.Retryable, tt.wantRetryable)
+			}
+			if !tt.wantRetryable && (completion.RetryAttempt != 0 || completion.RetryDelay != 0) {
+				t.Fatalf("retry state = attempt %d delay %s, want no retry", completion.RetryAttempt, completion.RetryDelay)
+			}
+		})
+	}
+}
+
 func TestSupervisorUsesFlatSameAttemptRetryForTransientOverload(t *testing.T) {
 	t.Parallel()
 
@@ -484,6 +525,12 @@ type mergeRevokedBackend struct{}
 
 func (mergeRevokedBackend) Run(context.Context, RunRequest) (RunResult, error) {
 	return RunResult{FinalState: FinalStateMergeRevoked}, ErrMergeRevoked
+}
+
+type contextErrorBackend struct{}
+
+func (contextErrorBackend) Run(ctx context.Context, _ RunRequest) (RunResult, error) {
+	return RunResult{}, ctx.Err()
 }
 
 type capacityBackend struct {

--- a/internal/runner/supervisor_test.go
+++ b/internal/runner/supervisor_test.go
@@ -146,6 +146,17 @@ func TestMergeWorkerDurationExceededFinalState(t *testing.T) {
 	}
 }
 
+func TestCIUnavailableIsCooperativeStop(t *testing.T) {
+	t.Parallel()
+
+	if !cooperativeStopError(ErrCIUnavailable) {
+		t.Fatal("cooperativeStopError(ErrCIUnavailable) = false, want true")
+	}
+	if got := finalStateForTurnError(ErrCIUnavailable); got != FinalStateCIUnavailable {
+		t.Fatalf("finalStateForTurnError() = %q, want %q", got, FinalStateCIUnavailable)
+	}
+}
+
 func TestSupervisorUsesFlatSameAttemptRetryForTransientOverload(t *testing.T) {
 	t.Parallel()
 

--- a/internal/runner/types.go
+++ b/internal/runner/types.go
@@ -23,6 +23,7 @@ const (
 	FinalStateTokenCeilingExceeded  = "token_ceiling_exceeded"
 	FinalStateOperatorStopped       = "operator_stopped"
 	FinalStateMergeRevoked          = "merge_revoked"
+	FinalStateCIUnavailable         = "ci_unavailable"
 	FinalStateMergeDurationExceeded = "merge_duration_exceeded"
 	TokenCeilingSourceAbsolute      = "max_session_tokens"
 	TokenCeilingSourceContextWindow = "max_session_context_multiplier"
@@ -43,6 +44,7 @@ var (
 	ErrSessionDurationExceeded     = errors.New("agent session duration exceeded")
 	ErrOperatorStopped             = errors.New("operator stopped run")
 	ErrMergeRevoked                = errors.New("merge eligibility revoked")
+	ErrCIUnavailable               = errors.New("CI unavailable")
 	ErrMergeWorkerStartupTimeout   = errors.New("merge worker startup timed out")
 	ErrMergeWorkerDurationExceeded = errors.New("merge worker duration exceeded")
 	ErrModelPermitUnavailable      = errors.New("provider model permit unavailable")

--- a/internal/store/capacity_constraints.go
+++ b/internal/store/capacity_constraints.go
@@ -19,6 +19,7 @@ const (
 	CapacityConstraintLane           CapacityConstraintReason = "lane_capacity_full"
 	CapacityConstraintWorkerHost     CapacityConstraintReason = "worker_host_capacity_full"
 	CapacityConstraintRateWindow     CapacityConstraintReason = "provider_rate_window_backpressure"
+	CapacityConstraintCIUnavailable  CapacityConstraintReason = "ci_unavailable"
 )
 
 type CapacityConstraintQuery struct {
@@ -52,7 +53,7 @@ func QueryCapacityConstraintWaits(
 SELECT project_id, COALESCE(lane, ''), wait_reason, decision_at, capacity_snapshot_json
 FROM scheduler_decisions
 WHERE result = ?
-  AND wait_reason IN (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+  AND wait_reason IN (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
   AND decision_at >= ?`,
 		string(SchedulerDecisionResultSkipped),
 		poolCapacityWaitReason,
@@ -64,6 +65,7 @@ WHERE result = ?
 		string(CapacityConstraintWorkerHost),
 		"worker_host_unavailable",
 		string(CapacityConstraintRateWindow),
+		string(CapacityConstraintCIUnavailable),
 		"local_slot_unavailable",
 		since,
 	)
@@ -162,6 +164,8 @@ func capacityConstraintReason(waitReason string, globalAvailable *int) (Capacity
 		return CapacityConstraintWorkerHost, true
 	case string(CapacityConstraintRateWindow):
 		return CapacityConstraintRateWindow, true
+	case string(CapacityConstraintCIUnavailable):
+		return CapacityConstraintCIUnavailable, true
 	default:
 		return "", false
 	}

--- a/internal/store/capacity_constraints_test.go
+++ b/internal/store/capacity_constraints_test.go
@@ -68,6 +68,12 @@ func TestCapacityConstraintReason(t *testing.T) {
 			wantOK:     true,
 		},
 		{
+			name:       "CI unavailable",
+			waitReason: "ci_unavailable",
+			want:       CapacityConstraintCIUnavailable,
+			wantOK:     true,
+		},
+		{
 			name:       "unrelated scheduler reason",
 			waitReason: "blocked_by_dependency",
 		},

--- a/internal/telemetry/snapshot.go
+++ b/internal/telemetry/snapshot.go
@@ -39,6 +39,7 @@ type Snapshot struct {
 	Completed               []Completed         `json:"completed"`
 	Budget                  Budget              `json:"budget"`
 	RateLimits              *RateLimits         `json:"rate_limits"`
+	CIUnavailable           []CICondition       `json:"ci_unavailable,omitempty"`
 	BackendOutages          []BackendOutage     `json:"backend_outages,omitempty"`
 	FailureBreakers         []FailureBreaker    `json:"failure_breakers,omitempty"`
 	DispatchRecoveries      []DispatchRecovery  `json:"dispatch_recoveries,omitempty"`
@@ -52,6 +53,16 @@ type Snapshot struct {
 	CycleTime               CycleTimeReport     `json:"cycle_time"`
 	WorkflowMetrics         WorkflowMetrics     `json:"workflow_metrics"`
 	TokenTrend              []TokenTrendPoint   `json:"token_trend,omitempty"`
+}
+
+type CICondition struct {
+	ProjectID           string    `json:"project_id,omitempty"`
+	UnstartedCheckCount int       `json:"unstarted_check_count"`
+	PullRequestCount    int       `json:"pull_request_count"`
+	OldestQueueSeconds  int64     `json:"oldest_queue_seconds"`
+	DetectedAt          time.Time `json:"detected_at"`
+	LastObservedAt      time.Time `json:"last_observed_at"`
+	ParkedAttemptCount  int       `json:"parked_attempt_count,omitempty"`
 }
 
 type AdmissionProposal struct {
@@ -512,6 +523,7 @@ type PullRequest struct {
 	QuietWaitSeconds           int64                       `json:"quiet_wait_seconds,omitempty"`
 	SlowChecks                 []PullRequestCheck          `json:"slow_checks,omitempty"`
 	RunningChecks              []string                    `json:"running_checks,omitempty"`
+	UnstartedCheckCount        int                         `json:"unstarted_check_count,omitempty"`
 	UnstartedChecks            []PullRequestCheck          `json:"unstarted_checks,omitempty"`
 	RequiredCheckFailures      []PullRequestCheck          `json:"required_check_failures,omitempty"`
 	CodexReviewState           string                      `json:"codex_review_state,omitempty"`

--- a/internal/web/api.go
+++ b/internal/web/api.go
@@ -481,6 +481,7 @@ func stateResponse(snapshot telemetry.Snapshot, generatedAt time.Time, instanceN
 		WorkflowMetrics:    snapshot.WorkflowMetrics,
 		RecentSessions:     recentSessionEntries(snapshot.Completed),
 		RateLimits:         snapshot.RateLimits,
+		CIUnavailable:      append([]telemetry.CICondition(nil), snapshot.CIUnavailable...),
 		BackendOutages:     append([]telemetry.BackendOutage(nil), snapshot.BackendOutages...),
 		FailureBreakers:    append([]telemetry.FailureBreaker(nil), snapshot.FailureBreakers...),
 		DispatchRecoveries: append([]telemetry.DispatchRecovery(nil), snapshot.DispatchRecoveries...),
@@ -1407,6 +1408,7 @@ type stateAPIResponse struct {
 	WorkflowMetrics    telemetry.WorkflowMetrics    `json:"workflow_metrics"`
 	RecentSessions     []recentSessionAPIResponse   `json:"recent_sessions"`
 	RateLimits         *telemetry.RateLimits        `json:"rate_limits"`
+	CIUnavailable      []telemetry.CICondition      `json:"ci_unavailable,omitempty"`
 	BackendOutages     []telemetry.BackendOutage    `json:"backend_outages,omitempty"`
 	FailureBreakers    []telemetry.FailureBreaker   `json:"failure_breakers,omitempty"`
 	DispatchRecoveries []telemetry.DispatchRecovery `json:"dispatch_recoveries,omitempty"`

--- a/internal/web/project_scope.go
+++ b/internal/web/project_scope.go
@@ -71,6 +71,7 @@ func projectScopedSnapshotForProject(snapshot telemetry.Snapshot, selectedProjec
 	out.Queue = scopedQueue(snapshot.Queue, selectedProjectID, fallbackProjectID)
 	out.Blocked = scopedBlocked(snapshot.Blocked, selectedProjectID, fallbackProjectID)
 	out.Completed = scopedCompleted(snapshot.Completed, selectedProjectID, fallbackProjectID)
+	out.CIUnavailable = scopedCIUnavailable(snapshot.CIUnavailable, selectedProjectID, fallbackProjectID)
 	out.FailureBreakers = scopedFailureBreakers(snapshot.FailureBreakers, selectedProjectID, fallbackProjectID)
 	out.DispatchRecoveries = scopedDispatchRecoveries(snapshot.DispatchRecoveries, selectedProjectID, fallbackProjectID)
 	out.StalenessWarnings = scopedStalenessWarnings(snapshot.StalenessWarnings, selectedProjectID, fallbackProjectID)
@@ -98,6 +99,20 @@ func projectScopedSnapshotForProject(snapshot telemetry.Snapshot, selectedProjec
 		out.TokenTrend = nil
 	}
 	out.WorkflowMetrics = scopedWorkflowMetrics(out, snapshot.WorkflowMetrics, selectedProjectID)
+	return out
+}
+
+func scopedCIUnavailable(conditions []telemetry.CICondition, selectedProjectID string, fallbackProjectID string) []telemetry.CICondition {
+	out := make([]telemetry.CICondition, 0, len(conditions))
+	for _, condition := range conditions {
+		projectID := strings.TrimSpace(condition.ProjectID)
+		if projectID == "" {
+			projectID = fallbackProjectID
+		}
+		if projectID == selectedProjectID {
+			out = append(out, condition)
+		}
+	}
 	return out
 }
 

--- a/internal/web/project_scope_test.go
+++ b/internal/web/project_scope_test.go
@@ -67,6 +67,10 @@ func TestProjectScopedSnapshotFiltersRowsAndUsesProjectTotals(t *testing.T) {
 			{Issue: telemetry.Issue{ID: "detent-completed", Identifier: "digitaldrywood/detent#5", ProjectID: "detent"}},
 			{Issue: telemetry.Issue{ID: "pyro-completed", Identifier: "digitaldrywood/pyroapex#5", ProjectID: "pyroapex"}},
 		},
+		CIUnavailable: []telemetry.CICondition{
+			{ProjectID: "detent", UnstartedCheckCount: 4, PullRequestCount: 2},
+			{ProjectID: "pyroapex", UnstartedCheckCount: 3, PullRequestCount: 2},
+		},
 		FailureBreakers: []telemetry.FailureBreaker{
 			{ProjectID: "detent", Class: "session_token_ceiling"},
 			{ProjectID: "pyroapex", Class: "deliverable_command_failure"},
@@ -129,6 +133,9 @@ func TestProjectScopedSnapshotFiltersRowsAndUsesProjectTotals(t *testing.T) {
 	}
 	if len(got.AdmissionProposals) != 1 || got.AdmissionProposals[0].ID != "detent-proposal" {
 		t.Fatalf("AdmissionProposals = %#v, want only detent proposal", got.AdmissionProposals)
+	}
+	if len(got.CIUnavailable) != 1 || got.CIUnavailable[0].ProjectID != "detent" {
+		t.Fatalf("CIUnavailable = %#v, want only detent condition", got.CIUnavailable)
 	}
 	if len(got.FailureBreakers) != 1 || got.FailureBreakers[0].Class != "session_token_ceiling" {
 		t.Fatalf("FailureBreakers = %#v, want only detent row", got.FailureBreakers)

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -1057,12 +1057,14 @@ func (s *Server) health(c echo.Context) error {
 	sessionsRemaining := 0
 	updateStatus := telemetry.Update{}
 	backendOutages := []telemetry.BackendOutage{}
+	ciUnavailable := []telemetry.CICondition{}
 	stalenessWarnings := []telemetry.StalenessWarning{}
 	strandedActiveIssues := []telemetry.StrandedIssue{}
 	if s.hub != nil {
 		if snapshot, ok := s.hub.Latest(); ok {
 			updateStatus = snapshot.Update
 			backendOutages = append(backendOutages, snapshot.BackendOutages...)
+			ciUnavailable = append(ciUnavailable, snapshot.CIUnavailable...)
 			stalenessWarnings = append(stalenessWarnings, snapshot.StalenessWarnings...)
 			strandedActiveIssues = append(strandedActiveIssues, snapshot.StrandedActiveIssues...)
 			if snapshot.Shutdown.Draining {
@@ -1087,6 +1089,9 @@ func (s *Server) health(c echo.Context) error {
 	if status != "draining" {
 		budgets = s.enforcedBudgets()
 		workflows = s.workflowSources()
+		if len(ciUnavailable) > 0 {
+			status = "needs_attention"
+		}
 	}
 	return c.JSON(http.StatusOK, healthResponse{
 		Status:            status,
@@ -1099,6 +1104,7 @@ func (s *Server) health(c echo.Context) error {
 		Environment:       healthEnvironment{Path: os.Getenv("PATH")},
 		Budgets:           budgets,
 		Workflows:         workflows,
+		CIUnavailable:     ciUnavailable,
 		BackendOutages:    backendOutages,
 		StalenessWarnings: stalenessWarnings,
 		StrandedIssues:    strandedActiveIssues,
@@ -1359,6 +1365,7 @@ type healthResponse struct {
 	Environment       healthEnvironment            `json:"environment"`
 	Budgets           []healthBudget               `json:"budgets,omitempty"`
 	Workflows         []healthWorkflowSource       `json:"workflows,omitempty"`
+	CIUnavailable     []telemetry.CICondition      `json:"ci_unavailable,omitempty"`
 	BackendOutages    []telemetry.BackendOutage    `json:"backend_outages,omitempty"`
 	StalenessWarnings []telemetry.StalenessWarning `json:"staleness_warnings,omitempty"`
 	StrandedIssues    []telemetry.StrandedIssue    `json:"stranded_active_issues,omitempty"`

--- a/internal/web/server_test.go
+++ b/internal/web/server_test.go
@@ -6680,6 +6680,46 @@ func TestStateAPIIncludesGitHubGraphQLRateLimitStatus(t *testing.T) {
 	}
 }
 
+func TestHealthReportsCICondition(t *testing.T) {
+	t.Parallel()
+
+	deps := testDeps(t)
+	now := time.Date(2026, 8, 8, 20, 0, 0, 0, time.UTC)
+	if err := deps.Hub.Publish(telemetry.Snapshot{
+		GeneratedAt: now,
+		CIUnavailable: []telemetry.CICondition{{
+			ProjectID:           "detent",
+			UnstartedCheckCount: 6,
+			PullRequestCount:    2,
+			OldestQueueSeconds:  47 * 60,
+			DetectedAt:          now.Add(-32 * time.Minute),
+			LastObservedAt:      now,
+		}},
+	}); err != nil {
+		t.Fatalf("Publish() error = %v", err)
+	}
+
+	server, err := web.NewServer(web.Config{}, deps)
+	if err != nil {
+		t.Fatalf("NewServer() error = %v", err)
+	}
+
+	health := requestJSON(t, server, http.MethodGet, "/health", http.StatusOK)
+	if got := nestedString(t, health, "status"); got != "needs_attention" {
+		t.Fatalf("health status = %q, want needs_attention", got)
+	}
+	conditions := health["ci_unavailable"].([]any)
+	if len(conditions) != 1 || nestedString(t, conditions[0].(map[string]any), "unstarted_check_count") != "6" {
+		t.Fatalf("health ci_unavailable = %#v", conditions)
+	}
+
+	state := requestJSON(t, server, http.MethodGet, "/api/v1/state", http.StatusOK)
+	conditions = state["ci_unavailable"].([]any)
+	if len(conditions) != 1 || nestedString(t, conditions[0].(map[string]any), "pull_request_count") != "2" {
+		t.Fatalf("state ci_unavailable = %#v", conditions)
+	}
+}
+
 func TestProjectStateAPIRendersConfiguredProjectWithoutTelemetryRows(t *testing.T) {
 	t.Parallel()
 

--- a/internal/web/templates/board_data.go
+++ b/internal/web/templates/board_data.go
@@ -34,6 +34,7 @@ type boardAlertKind string
 const (
 	boardAlertKindLastKnown             boardAlertKind = "board-last-known"
 	boardAlertKindFailureBreaker        boardAlertKind = "project-failure-breaker"
+	boardAlertKindCIUnavailable         boardAlertKind = "ci-unavailable"
 	boardAlertKindStaleness             boardAlertKind = "staleness-warning"
 	boardAlertKindTrackerStale          boardAlertKind = "board-stale-data"
 	boardAlertKindAdmissionProposal     boardAlertKind = "admission-proposal"
@@ -48,6 +49,7 @@ const (
 	boardAlertSeverityTrackerStale                     = 400
 	boardAlertSeverityStaleness                        = 450
 	boardAlertSeverityFailureBreaker                   = 500
+	boardAlertSeverityCIUnavailable                    = 550
 	boardAlertSeverityLastKnown                        = 600
 )
 
@@ -88,6 +90,9 @@ func boardAlerts(snapshot telemetry.Snapshot) []boardAlert {
 	if alert, ok := boardFailureBreakerAlert(snapshot); ok {
 		alerts = append(alerts, alert)
 	}
+	if alert, ok := boardCIUnavailableAlert(snapshot); ok {
+		alerts = append(alerts, alert)
+	}
 	alerts = append(alerts, boardStalenessAlerts(snapshot.StalenessWarnings)...)
 	if alert, ok := boardTrackerStaleAlert(snapshot); ok {
 		alerts = append(alerts, alert)
@@ -108,6 +113,48 @@ func boardAlerts(snapshot telemetry.Snapshot) []boardAlert {
 		return alerts[i].Severity > alerts[j].Severity
 	})
 	return alerts
+}
+
+func boardCIUnavailableAlert(snapshot telemetry.Snapshot) (boardAlert, bool) {
+	if len(snapshot.CIUnavailable) == 0 {
+		return boardAlert{}, false
+	}
+	rows := make([]boardAlertDetailRow, 0, len(snapshot.CIUnavailable))
+	for index, condition := range snapshot.CIUnavailable {
+		label := strings.TrimSpace(condition.ProjectID)
+		if label == "" {
+			label = "CI"
+		}
+		rows = append(rows, boardAlertDetailRow{
+			ID:      "board-alert-ci-unavailable-" + boardAlertRowSlug(label, index),
+			Label:   label,
+			Summary: boardCountLabel(condition.UnstartedCheckCount, "queued check", "queued checks") + " never started",
+			Detail:  ciUnavailableConditionDetail(condition),
+		})
+	}
+	rows, overflow := capBoardAlertRows(rows)
+	return boardAlert{
+		ID:            "board-alert-ci-unavailable",
+		Kind:          boardAlertKindCIUnavailable,
+		Severity:      boardAlertSeverityCIUnavailable,
+		Tone:          primitives.KindErr,
+		TerseSummary:  "CI unavailable (" + boardCountLabel(len(snapshot.CIUnavailable), "project", "projects") + ")",
+		DetailSummary: "Runner attention required; CI-gated dispatch is paused.",
+		DetailRows:    rows,
+		Overflow:      overflow,
+		DeepLink:      "/health/ui",
+	}, true
+}
+
+func ciUnavailableConditionDetail(condition telemetry.CICondition) string {
+	detail := "across " + boardCountLabel(condition.PullRequestCount, "PR", "PRs")
+	if condition.OldestQueueSeconds > 0 {
+		detail += " · oldest queued " + formatDuration(float64(condition.OldestQueueSeconds))
+	}
+	if condition.ParkedAttemptCount > 0 {
+		detail += " · " + boardCountLabel(condition.ParkedAttemptCount, "attempt parked", "attempts parked")
+	}
+	return detail
 }
 
 func boardAdmissionProposalAlert(snapshot telemetry.Snapshot) (boardAlert, bool) {

--- a/internal/web/templates/board_data_test.go
+++ b/internal/web/templates/board_data_test.go
@@ -2036,6 +2036,32 @@ func TestBoardAlertsCollapseStalenessWarnings(t *testing.T) {
 	}
 }
 
+func TestBoardAlertsSurfaceCIUnavailableEvidence(t *testing.T) {
+	t.Parallel()
+
+	snapshot := telemetry.Snapshot{
+		GeneratedAt: time.Date(2026, 8, 8, 20, 0, 0, 0, time.UTC),
+		CIUnavailable: []telemetry.CICondition{{
+			ProjectID:           "detent",
+			UnstartedCheckCount: 6,
+			PullRequestCount:    2,
+			OldestQueueSeconds:  47 * 60,
+			ParkedAttemptCount:  2,
+		}},
+	}
+
+	alerts := boardAlerts(snapshot)
+	if len(alerts) != 1 || alerts[0].Kind != boardAlertKindCIUnavailable || alerts[0].Tone != primitives.KindErr {
+		t.Fatalf("boardAlerts() = %#v, want one CI-unavailable error", alerts)
+	}
+	for _, want := range []string{"6 queued checks", "2 PRs", "47m", "2 attempts parked"} {
+		combined := alerts[0].DetailRows[0].Summary + " " + alerts[0].DetailRows[0].Detail
+		if !strings.Contains(combined, want) {
+			t.Fatalf("CI alert detail = %q, want %q", combined, want)
+		}
+	}
+}
+
 func TestBoardAlertsRenderOneLineOverlayContract(t *testing.T) {
 	t.Parallel()
 

--- a/internal/web/templates/health_data.go
+++ b/internal/web/templates/health_data.go
@@ -44,6 +44,12 @@ func healthViewFromDashboard(data DashboardData) healthView {
 		Footnote:  "GitHub quota bars turn amber at 90%; project budget bars warn at 80% and turn red at the cap.",
 		Rows:      append(append(healthRows(snapshot), healthActiveHoursRows(data)...), healthBudgetRows(data)...),
 	}
+	if len(snapshot.CIUnavailable) > 0 {
+		view.Kind = primitives.KindErr
+		view.Verdict = "CI is unavailable."
+		view.Detail = ciUnavailableHealthDetail(snapshot.CIUnavailable)
+		return view
+	}
 	if len(snapshot.StalenessWarnings) > 0 {
 		view.Kind = primitives.KindWarn
 		view.Verdict = "Fleet work is stale."
@@ -207,6 +213,7 @@ func healthBudgetRows(data DashboardData) []healthRow {
 
 func healthRows(snapshot telemetry.Snapshot) []healthRow {
 	rows := make([]healthRow, 0, 4)
+	rows = append(rows, healthCIUnavailableRows(snapshot.CIUnavailable)...)
 	for _, warning := range snapshot.StalenessWarnings {
 		rows = append(rows, healthStalenessRow(warning))
 	}
@@ -251,6 +258,44 @@ func healthRows(snapshot telemetry.Snapshot) []healthRow {
 		rows = append(rows, healthBackendOutageRow(outage, snapshot.GeneratedAt))
 	}
 	return rows
+}
+
+func healthCIUnavailableRows(conditions []telemetry.CICondition) []healthRow {
+	rows := make([]healthRow, 0, len(conditions))
+	for index, condition := range conditions {
+		projectID := strings.TrimSpace(condition.ProjectID)
+		if projectID == "" {
+			projectID = "project"
+		}
+		rows = append(rows, healthRow{
+			ID:        "health-ci-unavailable-" + boardAlertRowSlug(projectID, index),
+			Component: "CI · " + projectID,
+			Kind:      primitives.KindErr,
+			Status:    "Unavailable",
+			Detail: boardCountLabel(condition.UnstartedCheckCount, "queued check", "queued checks") +
+				" never started " + ciUnavailableConditionDetail(condition),
+			Resets:   "when checks start",
+			DetailAt: condition.LastObservedAt,
+		})
+	}
+	return rows
+}
+
+func ciUnavailableHealthDetail(conditions []telemetry.CICondition) string {
+	checkCount := 0
+	pullRequestCount := 0
+	oldestQueueSeconds := int64(0)
+	for _, condition := range conditions {
+		checkCount += condition.UnstartedCheckCount
+		pullRequestCount += condition.PullRequestCount
+		oldestQueueSeconds = max(oldestQueueSeconds, condition.OldestQueueSeconds)
+	}
+	detail := boardCountLabel(checkCount, "check is", "checks are") + " queued and unstarted across " +
+		boardCountLabel(pullRequestCount, "PR", "PRs")
+	if oldestQueueSeconds > 0 {
+		detail += "; oldest queued " + formatDuration(float64(oldestQueueSeconds))
+	}
+	return detail + "."
 }
 
 func healthProviderBucketRow(id string, component string, bucket *telemetry.RateLimitBucket) healthRow {

--- a/internal/web/templates/health_data_test.go
+++ b/internal/web/templates/health_data_test.go
@@ -35,6 +35,17 @@ func TestHealthViewVerdicts(t *testing.T) {
 			wantVerdict: "Waiting for the first health snapshot.",
 		},
 		{
+			name: "CI unavailability requires attention",
+			snapshot: telemetry.Snapshot{
+				GeneratedAt: now,
+				CIUnavailable: []telemetry.CICondition{{
+					ProjectID: "detent", UnstartedCheckCount: 6, PullRequestCount: 2, OldestQueueSeconds: 2_820,
+				}},
+			},
+			wantKind:    primitives.KindErr,
+			wantVerdict: "CI is unavailable.",
+		},
+		{
 			name: "backend capacity outage warns",
 			snapshot: telemetry.Snapshot{
 				GeneratedAt: now,


### PR DESCRIPTION
## Summary

- detect sustained queued-but-unstarted checks across multiple pull requests and expose exact fleet evidence
- surface CI unavailability in health APIs, the health view, board alerts, and capacity telemetry
- park attempts waiting on CI without holding agent slots while preserving non-CI dispatch and automatic recovery

Fixes #1707

## UI Surface Contract

- [x] The linked issue explicitly authorizes the operator-visible CI alert added here.
- [x] Persistent top-of-screen messaging is explicitly authorized by the issue.
- [x] The shared alert presentation is unchanged; current-head Browser Visual CI passed, with API and render tests covering the alert contract.

## Test Plan

- [x] `make generate`
- [x] `make check`
