### PR TITLE
fix(runner): wait for process group exit before workspace removal

### DIFF
--- a/internal/codex/transport_unix_test.go
+++ b/internal/codex/transport_unix_test.go
@@ -36,7 +36,9 @@ func TestLocalTransportReapsChildAfterParentExits(t *testing.T) {
 	if err := transport.Close(closeCtx); err != nil {
 		t.Fatalf("Close() error = %v", err)
 	}
-	waitForProcessExit(t, pid)
+	if processAlive(pid) {
+		t.Fatalf("Close() returned while child process %d was still alive", pid)
+	}
 }
 
 func TestLocalTransportCloseKillsChildProcessGroup(t *testing.T) {

--- a/internal/procgroup/process_group_unix.go
+++ b/internal/procgroup/process_group_unix.go
@@ -84,14 +84,23 @@ func Cleanup(processGroupID int) error {
 	if waitForProcessGroupExit(processGroupID, DefaultTerminationGrace) {
 		return nil
 	}
-	survivingProcesses := describeProcessGroup(processGroupID)
+	members, inspectErr := inspectProcessGroup(processGroupID)
+	if inspectErr == nil && processGroupExited(members) {
+		return nil
+	}
 	if !processTargetAlive(0, processGroupID) {
 		return nil
+	}
+	if inspectErr == nil {
+		members, inspectErr = inspectProcessGroup(processGroupID)
+		if inspectErr == nil && processGroupExited(members) {
+			return nil
+		}
 	}
 	return fmt.Errorf(
 		"process group %d remained alive after SIGKILL: surviving_processes=%s",
 		processGroupID,
-		survivingProcesses,
+		describeProcessGroup(members, inspectErr),
 	)
 }
 
@@ -115,32 +124,73 @@ func waitForProcessGroupExit(processGroupID int, grace time.Duration) bool {
 	}
 }
 
-func describeProcessGroup(processGroupID int) string {
+type processGroupMember struct {
+	pid     string
+	ppid    string
+	state   string
+	command string
+}
+
+func inspectProcessGroup(processGroupID int) ([]processGroupMember, error) {
 	path, err := exec.LookPath("ps")
 	if err != nil {
-		return "unavailable (locate ps: " + err.Error() + ")"
+		return nil, fmt.Errorf("locate ps: %w", err)
 	}
 	cmd := &exec.Cmd{
 		Path: path,
-		Args: []string{"ps", "-axo", "pid=,ppid=,pgid=,comm="},
+		Args: []string{"ps", "-axo", "pid=,ppid=,pgid=,stat=,comm="},
 		Env:  append(os.Environ(), "LC_ALL=C"),
 	}
 	output, err := cmd.Output()
 	if err != nil {
-		return "unavailable (inspect process group: " + err.Error() + ")"
+		return nil, fmt.Errorf("inspect process group: %w", err)
 	}
-	members := make([]string, 0)
+	members := make([]processGroupMember, 0)
 	for line := range strings.Lines(string(output)) {
 		fields := strings.Fields(line)
-		if len(fields) < 4 || fields[2] != strconv.Itoa(processGroupID) {
+		if len(fields) < 5 || fields[2] != strconv.Itoa(processGroupID) {
 			continue
 		}
-		members = append(members, fmt.Sprintf("pid=%s ppid=%s command=%s", fields[0], fields[1], strings.Join(fields[3:], " ")))
+		members = append(members, processGroupMember{
+			pid:     fields[0],
+			ppid:    fields[1],
+			state:   fields[3],
+			command: strings.Join(fields[4:], " "),
+		})
+	}
+	return members, nil
+}
+
+func processGroupExited(members []processGroupMember) bool {
+	if len(members) == 0 {
+		return true
+	}
+	for _, member := range members {
+		if !strings.HasPrefix(member.state, "Z") {
+			return false
+		}
+	}
+	return true
+}
+
+func describeProcessGroup(members []processGroupMember, err error) string {
+	if err != nil {
+		return "unavailable (" + err.Error() + ")"
 	}
 	if len(members) == 0 {
 		return "none listed"
 	}
-	return strings.Join(members, "; ")
+	descriptions := make([]string, 0, len(members))
+	for _, member := range members {
+		descriptions = append(descriptions, fmt.Sprintf(
+			"pid=%s ppid=%s state=%s command=%s",
+			member.pid,
+			member.ppid,
+			member.state,
+			member.command,
+		))
+	}
+	return strings.Join(descriptions, "; ")
 }
 
 func Terminate(ctx context.Context, identity Identity, grace time.Duration) (TerminationOutcome, error) {

--- a/internal/procgroup/process_group_unix.go
+++ b/internal/procgroup/process_group_unix.go
@@ -75,10 +75,72 @@ func Cleanup(processGroupID int) error {
 		return nil
 	}
 	err := syscall.Kill(-processGroupID, syscall.SIGKILL)
-	if err == nil || errors.Is(err, syscall.ESRCH) {
+	if errors.Is(err, syscall.ESRCH) {
 		return nil
 	}
-	return err
+	if err != nil {
+		return err
+	}
+	if waitForProcessGroupExit(processGroupID, DefaultTerminationGrace) {
+		return nil
+	}
+	survivingProcesses := describeProcessGroup(processGroupID)
+	if !processTargetAlive(0, processGroupID) {
+		return nil
+	}
+	return fmt.Errorf(
+		"process group %d remained alive after SIGKILL: surviving_processes=%s",
+		processGroupID,
+		survivingProcesses,
+	)
+}
+
+func waitForProcessGroupExit(processGroupID int, grace time.Duration) bool {
+	if grace <= 0 {
+		grace = DefaultTerminationGrace
+	}
+	timer := time.NewTimer(grace)
+	defer timer.Stop()
+	ticker := time.NewTicker(10 * time.Millisecond)
+	defer ticker.Stop()
+	for {
+		if !processTargetAlive(0, processGroupID) {
+			return true
+		}
+		select {
+		case <-timer.C:
+			return false
+		case <-ticker.C:
+		}
+	}
+}
+
+func describeProcessGroup(processGroupID int) string {
+	path, err := exec.LookPath("ps")
+	if err != nil {
+		return "unavailable (locate ps: " + err.Error() + ")"
+	}
+	cmd := &exec.Cmd{
+		Path: path,
+		Args: []string{"ps", "-axo", "pid=,ppid=,pgid=,comm="},
+		Env:  append(os.Environ(), "LC_ALL=C"),
+	}
+	output, err := cmd.Output()
+	if err != nil {
+		return "unavailable (inspect process group: " + err.Error() + ")"
+	}
+	members := make([]string, 0)
+	for line := range strings.Lines(string(output)) {
+		fields := strings.Fields(line)
+		if len(fields) < 4 || fields[2] != strconv.Itoa(processGroupID) {
+			continue
+		}
+		members = append(members, fmt.Sprintf("pid=%s ppid=%s command=%s", fields[0], fields[1], strings.Join(fields[3:], " ")))
+	}
+	if len(members) == 0 {
+		return "none listed"
+	}
+	return strings.Join(members, "; ")
 }
 
 func Terminate(ctx context.Context, identity Identity, grace time.Duration) (TerminationOutcome, error) {

--- a/internal/procgroup/process_group_unix_test.go
+++ b/internal/procgroup/process_group_unix_test.go
@@ -236,6 +236,8 @@ func TestCleanup(t *testing.T) {
 			name: "live group",
 			pgid: func(t *testing.T) (int, func(t *testing.T)) {
 				proc := startSleepGroup(t)
+				go func() { _ = proc.Wait() }()
+				go func() { _ = proc.WaitGroupMember() }()
 				return GroupID(proc.cmd), func(t *testing.T) {
 					assertProcessGroupKilled(t, proc)
 				}
@@ -252,6 +254,43 @@ func TestCleanup(t *testing.T) {
 			}
 			if wait != nil {
 				wait(t)
+			}
+		})
+	}
+}
+
+func TestCleanupWaitsForOrphanedGroupMembers(t *testing.T) {
+	tests := []struct {
+		name    string
+		command string
+	}{
+		{name: "single descendant", command: "sleep 30 &"},
+		{name: "multiple descendants", command: "sleep 30 & sleep 30 &"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cmd := exec.CommandContext(context.Background(), "sh", "-c", tt.command)
+			Configure(cmd)
+			if err := cmd.Start(); err != nil {
+				t.Fatalf("Start() error = %v", err)
+			}
+			pgid := GroupID(cmd)
+			if err := cmd.Wait(); err != nil {
+				t.Fatalf("Wait() error = %v", err)
+			}
+			t.Cleanup(func() {
+				_ = TerminateTree(nil, pgid)
+			})
+
+			if !processTargetAlive(0, pgid) {
+				t.Fatal("process group exited before Cleanup()")
+			}
+			if err := Cleanup(pgid); err != nil {
+				t.Fatalf("Cleanup() error = %v", err)
+			}
+			if processTargetAlive(0, pgid) {
+				t.Fatal("Cleanup() returned while process group was still alive")
 			}
 		})
 	}

--- a/internal/procgroup/process_group_unix_test.go
+++ b/internal/procgroup/process_group_unix_test.go
@@ -296,6 +296,47 @@ func TestCleanupWaitsForOrphanedGroupMembers(t *testing.T) {
 	}
 }
 
+func TestCleanupTreatsZombieOnlyGroupAsExited(t *testing.T) {
+	cmd := exec.CommandContext(context.Background(), "sleep", "30")
+	Configure(cmd)
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("Start() error = %v", err)
+	}
+	pgid := GroupID(cmd)
+	t.Cleanup(func() { _ = cmd.Wait() })
+
+	if err := Cleanup(pgid); err != nil {
+		t.Fatalf("Cleanup() error = %v, want zombie-only group ignored", err)
+	}
+	if !processTargetAlive(0, pgid) {
+		t.Fatal("process group no longer exists, want unreaped zombie to remain observable")
+	}
+	assertKilled(t, cmd.Wait())
+}
+
+func TestProcessGroupExited(t *testing.T) {
+	tests := []struct {
+		name    string
+		members []processGroupMember
+		want    bool
+	}{
+		{name: "no members", want: true},
+		{name: "single zombie", members: []processGroupMember{{state: "Z"}}, want: true},
+		{name: "zombie with flags", members: []processGroupMember{{state: "Z+"}}, want: true},
+		{name: "multiple zombies", members: []processGroupMember{{state: "Z"}, {state: "Zs"}}, want: true},
+		{name: "running member", members: []processGroupMember{{state: "R"}}},
+		{name: "mixed group", members: []processGroupMember{{state: "Z"}, {state: "S"}}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := processGroupExited(tt.members); got != tt.want {
+				t.Fatalf("processGroupExited() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestInspectAndTerminate(t *testing.T) {
 	tests := []struct {
 		name        string

--- a/internal/runner/admission_workspace.go
+++ b/internal/runner/admission_workspace.go
@@ -3,17 +3,39 @@ package runner
 import (
 	"context"
 	"errors"
+	"io/fs"
 	"log/slog"
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
+	"time"
 
 	"github.com/digitaldrywood/detent/internal/workspace"
 )
 
+const (
+	admissionWorkspaceRemoveAttempts = 4
+	admissionWorkspaceRetryDelay     = 10 * time.Millisecond
+	admissionWorkspacePathLimit      = 20
+)
+
 type admissionWorkspace struct {
-	logger *slog.Logger
-	path   string
+	logger    *slog.Logger
+	leaks     *admissionWorkspaceLeakTracker
+	path      string
+	removeAll func(string) error
+	wait      func(context.Context, time.Duration) error
+}
+
+type admissionWorkspaceLeakTracker struct {
+	mu    sync.Mutex
+	paths map[string]struct{}
+}
+
+type admissionWorkspaceLeakSnapshot struct {
+	count int
+	bytes int64
 }
 
 func (w *admissionWorkspace) Create(ctx context.Context, issue workspace.Issue) (workspace.Info, error) {
@@ -32,15 +54,62 @@ func (w *admissionWorkspace) Create(ctx context.Context, issue workspace.Issue) 
 	}, nil
 }
 
-func (w *admissionWorkspace) Cleanup(_ context.Context, path string) error {
+func (w *admissionWorkspace) Cleanup(ctx context.Context, path string) error {
 	if w.path == "" || filepath.Clean(path) != filepath.Clean(w.path) {
 		return errors.New("backlog admission workspace cleanup path does not match the created workspace")
 	}
-	if err := os.RemoveAll(w.path); err != nil {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	removeAll := w.removeAll
+	if removeAll == nil {
+		removeAll = os.RemoveAll
+	}
+	wait := w.wait
+	if wait == nil {
+		wait = waitForAdmissionWorkspaceRetry
+	}
+	if err := removeAdmissionWorkspace(ctx, w.path, removeAll, wait); err != nil {
 		return err
+	}
+	if w.leaks != nil {
+		w.leaks.remove(w.path)
 	}
 	w.path = ""
 	return nil
+}
+
+func removeAdmissionWorkspace(
+	ctx context.Context,
+	path string,
+	removeAll func(string) error,
+	wait func(context.Context, time.Duration) error,
+) error {
+	var err error
+	for attempt := range admissionWorkspaceRemoveAttempts {
+		err = removeAll(path)
+		if err == nil {
+			return nil
+		}
+		if !errors.Is(err, fs.ErrExist) || attempt == admissionWorkspaceRemoveAttempts-1 {
+			return err
+		}
+		if waitErr := wait(ctx, admissionWorkspaceRetryDelay<<attempt); waitErr != nil {
+			return errors.Join(err, waitErr)
+		}
+	}
+	return err
+}
+
+func waitForAdmissionWorkspaceRetry(ctx context.Context, delay time.Duration) error {
+	timer := time.NewTimer(delay)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-timer.C:
+		return nil
+	}
 }
 
 func (*admissionWorkspace) BeforeRun(context.Context, workspace.Info, workspace.Issue) error {
@@ -49,8 +118,94 @@ func (*admissionWorkspace) BeforeRun(context.Context, workspace.Info, workspace.
 
 func (w *admissionWorkspace) AfterRun(ctx context.Context, info workspace.Info, _ workspace.Issue) {
 	if err := w.Cleanup(ctx, info.Path); err != nil && w.logger != nil {
-		w.logger.Warn("remove backlog admission workspace failed", "workspace_path", info.Path, "error", err)
+		tracker := w.leaks
+		if tracker == nil {
+			tracker = &admissionWorkspaceLeakTracker{}
+		}
+		snapshot := tracker.record(info.Path)
+		w.logger.Warn(
+			"remove backlog admission workspace failed after retries",
+			"workspace_path", info.Path,
+			"leaked_workspace_count", snapshot.count,
+			"leaked_workspace_bytes", snapshot.bytes,
+			"surviving_paths", survivingAdmissionWorkspacePaths(info.Path, admissionWorkspacePathLimit),
+			"error", err,
+		)
 	}
+}
+
+func (t *admissionWorkspaceLeakTracker) record(path string) admissionWorkspaceLeakSnapshot {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	if t.paths == nil {
+		t.paths = make(map[string]struct{})
+	}
+	t.paths[path] = struct{}{}
+	snapshot := admissionWorkspaceLeakSnapshot{}
+	for leakedPath := range t.paths {
+		bytes, err := admissionWorkspaceSize(leakedPath)
+		if errors.Is(err, fs.ErrNotExist) {
+			delete(t.paths, leakedPath)
+			continue
+		}
+		snapshot.count++
+		snapshot.bytes += bytes
+	}
+	return snapshot
+}
+
+func (t *admissionWorkspaceLeakTracker) remove(path string) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	delete(t.paths, path)
+}
+
+func admissionWorkspaceSize(path string) (int64, error) {
+	var total int64
+	err := filepath.WalkDir(path, func(_ string, entry fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if entry.IsDir() {
+			return nil
+		}
+		info, err := entry.Info()
+		if err != nil {
+			return err
+		}
+		total += info.Size()
+		return nil
+	})
+	return total, err
+}
+
+func survivingAdmissionWorkspacePaths(path string, limit int) []string {
+	if limit <= 0 {
+		return nil
+	}
+	paths := make([]string, 0, min(limit, 8))
+	err := filepath.WalkDir(path, func(current string, entry fs.DirEntry, walkErr error) error {
+		if len(paths) >= limit {
+			return fs.SkipAll
+		}
+		if walkErr != nil {
+			paths = append(paths, current+": "+walkErr.Error())
+			return nil
+		}
+		if current == path || entry.IsDir() {
+			return nil
+		}
+		relative, err := filepath.Rel(path, current)
+		if err != nil {
+			relative = current
+		}
+		paths = append(paths, filepath.ToSlash(relative))
+		return nil
+	})
+	if err != nil && len(paths) < limit {
+		paths = append(paths, path+": "+err.Error())
+	}
+	return paths
 }
 
 func (*admissionWorkspace) DiffStat(context.Context, workspace.Info, workspace.Issue) (workspace.DiffStat, error) {

--- a/internal/runner/admission_workspace_test.go
+++ b/internal/runner/admission_workspace_test.go
@@ -1,11 +1,16 @@
 package runner
 
 import (
+	"bytes"
 	"context"
 	"errors"
+	"log/slog"
 	"os"
 	"path/filepath"
+	"strings"
+	"syscall"
 	"testing"
+	"time"
 
 	"github.com/digitaldrywood/detent/internal/workspace"
 )
@@ -31,5 +36,150 @@ func TestAdmissionWorkspaceCleanupIsScopedToCreatedPath(t *testing.T) {
 	backend.AfterRun(context.Background(), info, workspace.Issue{})
 	if _, err := os.Stat(info.Path); !errors.Is(err, os.ErrNotExist) {
 		t.Fatalf("workspace stat error = %v, want os.ErrNotExist", err)
+	}
+}
+
+func TestAdmissionWorkspaceCleanupRetriesENOTEMPTY(t *testing.T) {
+	tests := []struct {
+		name        string
+		failures    int
+		failure     error
+		wantCalls   int
+		wantWaits   []time.Duration
+		wantRemoved bool
+	}{
+		{name: "first attempt succeeds", wantCalls: 1, wantRemoved: true},
+		{
+			name:        "ENOTEMPTY self heals",
+			failures:    2,
+			failure:     &os.PathError{Op: "unlinkat", Path: "cache", Err: syscall.ENOTEMPTY},
+			wantCalls:   3,
+			wantWaits:   []time.Duration{10 * time.Millisecond, 20 * time.Millisecond},
+			wantRemoved: true,
+		},
+		{
+			name:      "ENOTEMPTY exhausts bound",
+			failures:  4,
+			failure:   &os.PathError{Op: "unlinkat", Path: "cache", Err: syscall.ENOTEMPTY},
+			wantCalls: 4,
+			wantWaits: []time.Duration{10 * time.Millisecond, 20 * time.Millisecond, 40 * time.Millisecond},
+		},
+		{
+			name:      "permission failure is not retried",
+			failures:  1,
+			failure:   &os.PathError{Op: "unlinkat", Path: "cache", Err: syscall.EPERM},
+			wantCalls: 1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			backend := &admissionWorkspace{}
+			info, err := backend.Create(context.Background(), workspace.Issue{ID: "detent/admission"})
+			if err != nil {
+				t.Fatalf("Create() error = %v", err)
+			}
+			t.Cleanup(func() {
+				_ = os.RemoveAll(info.Path)
+			})
+
+			calls := 0
+			backend.removeAll = func(path string) error {
+				calls++
+				if calls <= tt.failures {
+					return tt.failure
+				}
+				return os.RemoveAll(path)
+			}
+			var waits []time.Duration
+			backend.wait = func(_ context.Context, delay time.Duration) error {
+				waits = append(waits, delay)
+				return nil
+			}
+
+			err = backend.Cleanup(context.Background(), info.Path)
+			if tt.wantRemoved && err != nil {
+				t.Fatalf("Cleanup() error = %v", err)
+			}
+			if !tt.wantRemoved && !errors.Is(err, errors.Unwrap(tt.failure)) {
+				t.Fatalf("Cleanup() error = %v, want %v", err, tt.failure)
+			}
+			if calls != tt.wantCalls {
+				t.Fatalf("remove calls = %d, want %d", calls, tt.wantCalls)
+			}
+			if len(waits) != len(tt.wantWaits) {
+				t.Fatalf("waits = %v, want %v", waits, tt.wantWaits)
+			}
+			for i := range waits {
+				if waits[i] != tt.wantWaits[i] {
+					t.Fatalf("waits = %v, want %v", waits, tt.wantWaits)
+				}
+			}
+			_, statErr := os.Stat(info.Path)
+			if tt.wantRemoved && !errors.Is(statErr, os.ErrNotExist) {
+				t.Fatalf("workspace stat error = %v, want os.ErrNotExist", statErr)
+			}
+			if !tt.wantRemoved && statErr != nil {
+				t.Fatalf("workspace stat error = %v, want workspace retained", statErr)
+			}
+		})
+	}
+}
+
+func TestAdmissionWorkspacePersistentFailuresReportAccumulation(t *testing.T) {
+	var logs bytes.Buffer
+	tracker := &admissionWorkspaceLeakTracker{}
+	logger := slog.New(slog.NewTextHandler(&logs, nil))
+	var leakedPaths []string
+	t.Cleanup(func() {
+		for _, path := range leakedPaths {
+			_ = os.RemoveAll(path)
+		}
+	})
+	tests := []struct {
+		name      string
+		contents  string
+		wantCount string
+		wantBytes string
+	}{
+		{name: "first leak", contents: "one", wantCount: "leaked_workspace_count=1", wantBytes: "leaked_workspace_bytes=3"},
+		{name: "second leak", contents: "three", wantCount: "leaked_workspace_count=2", wantBytes: "leaked_workspace_bytes=8"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			backend := &admissionWorkspace{logger: logger, leaks: tracker}
+			info, err := backend.Create(context.Background(), workspace.Issue{ID: "detent/admission"})
+			if err != nil {
+				t.Fatalf("Create() error = %v", err)
+			}
+			leakedPaths = append(leakedPaths, info.Path)
+			cachePath := filepath.Join(info.Path, ".detent", "tmp", "node-compile-cache", "cache-entry")
+			if err := os.MkdirAll(filepath.Dir(cachePath), 0o755); err != nil {
+				t.Fatalf("MkdirAll() error = %v", err)
+			}
+			if err := os.WriteFile(cachePath, []byte(tt.contents), 0o644); err != nil {
+				t.Fatalf("WriteFile() error = %v", err)
+			}
+			backend.removeAll = func(string) error {
+				return &os.PathError{Op: "unlinkat", Path: cachePath, Err: syscall.ENOTEMPTY}
+			}
+			backend.wait = func(context.Context, time.Duration) error { return nil }
+
+			logs.Reset()
+			backend.AfterRun(context.Background(), info, workspace.Issue{})
+			got := logs.String()
+			for _, want := range []string{
+				"remove backlog admission workspace failed after retries",
+				tt.wantCount,
+				tt.wantBytes,
+				".detent/tmp/node-compile-cache/cache-entry",
+				"directory not empty",
+			} {
+				if !strings.Contains(got, want) {
+					t.Fatalf("log = %q, want %q", got, want)
+				}
+			}
+		})
 	}
 }

--- a/internal/runner/agent.go
+++ b/internal/runner/agent.go
@@ -134,6 +134,7 @@ type Runner struct {
 	sessionLimit        durationLimitContextFactory
 	turnLimit           durationLimitContextFactory
 	progressTicker      sessionProgressTickerFactory
+	admissionLeaks      admissionWorkspaceLeakTracker
 }
 
 func NewRunner(deps Dependencies) (*Runner, error) {
@@ -1002,7 +1003,7 @@ func (r *Runner) Run(ctx context.Context, req RunRequest) (RunResult, error) {
 
 	runWorkspace := r.workspace
 	if req.Admission != nil {
-		runWorkspace = &admissionWorkspace{logger: r.logger}
+		runWorkspace = &admissionWorkspace{logger: r.logger, leaks: &r.admissionLeaks}
 	}
 	workspaceIssue := workspaceIssue(r.projectID, req.Issue)
 	r.logWorkerEvent(req.Issue, "worker_workspace_create_started", telemetry.WorkAttemptIDKey, req.WorkAttemptID)


### PR DESCRIPTION
## Summary

- wait boundedly for killed Unix process groups to disappear before transport shutdown completes
- retry admission workspace `ENOTEMPTY` removal failures with bounded context-aware backoff
- report persistent leak accumulation as workspace count/bytes with surviving process and path diagnostics

Fixes #1718

## UI Surface Contract

- [x] N/A, or the linked issue explicitly authorizes any high-impact UI surface, layout, density, first-viewport, or responsive visibility tradeoff.
- [x] Persistent top-of-screen messaging is explicitly authorized by the issue, or this PR does not add it.
- [x] Visual changes to primary operator screens include screenshot or browser verification below.

No UI changes.

## Test Plan

- [x] `make check`
- [x] `go test ./internal/procgroup ./internal/codex ./internal/runner -count=1`
- [x] focused race tests and 20 repeated orphaned-process cleanup tests