### PR TITLE
test(cli): stop detached git maintenance cleanup race

### DIFF
--- a/internal/cli/doctor_workflow_source_test.go
+++ b/internal/cli/doctor_workflow_source_test.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	workflowconfig "github.com/digitaldrywood/detent/internal/config"
 	globalconfig "github.com/digitaldrywood/detent/internal/config/global"
@@ -267,23 +268,7 @@ func initDoctorWorkflowSourceRepository(t *testing.T) (string, string) {
 	t.Helper()
 
 	root := t.TempDir()
-	t.Cleanup(func() {
-		if err := os.RemoveAll(root); err != nil {
-			remaining := make([]string, 0)
-			walkErr := filepath.WalkDir(root, func(path string, _ os.DirEntry, walkErr error) error {
-				if walkErr != nil {
-					return walkErr
-				}
-				relative, err := filepath.Rel(root, path)
-				if err != nil {
-					return err
-				}
-				remaining = append(remaining, relative)
-				return nil
-			})
-			t.Errorf("RemoveAll(%s) error = %v; remaining paths = %q; inspect error = %v", root, err, remaining, walkErr)
-		}
-	})
+	t.Cleanup(func() { cleanupDoctorWorkflowSourceRepository(t, root) })
 	remote := filepath.Join(root, "remote.git")
 	seed := filepath.Join(root, "seed")
 	repo := filepath.Join(root, "checkout")
@@ -301,6 +286,37 @@ func initDoctorWorkflowSourceRepository(t *testing.T) (string, string) {
 	runDoctorWorkflowSourceGit(t, repo, "config", "user.name", "Detent Test")
 	runDoctorWorkflowSourceGit(t, repo, "config", "user.email", "detent@example.com")
 	return repo, remote
+}
+
+func cleanupDoctorWorkflowSourceRepository(t *testing.T, root string) {
+	t.Helper()
+
+	deadline := time.Now().Add(2 * time.Second)
+	var err error
+	for {
+		err = os.RemoveAll(root)
+		if err == nil {
+			return
+		}
+		if !time.Now().Before(deadline) {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	remaining := make([]string, 0)
+	walkErr := filepath.WalkDir(root, func(path string, _ os.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		relative, relativeErr := filepath.Rel(root, path)
+		if relativeErr != nil {
+			return relativeErr
+		}
+		remaining = append(remaining, relative)
+		return nil
+	})
+	t.Errorf("RemoveAll(%s) error = %v; remaining paths = %q; inspect error = %v", root, err, remaining, walkErr)
 }
 
 func writeDoctorWorkflowSourceFile(t *testing.T, path string, content string) {

--- a/internal/cli/doctor_workflow_source_test.go
+++ b/internal/cli/doctor_workflow_source_test.go
@@ -267,6 +267,23 @@ func initDoctorWorkflowSourceRepository(t *testing.T) (string, string) {
 	t.Helper()
 
 	root := t.TempDir()
+	t.Cleanup(func() {
+		if err := os.RemoveAll(root); err != nil {
+			remaining := make([]string, 0)
+			walkErr := filepath.WalkDir(root, func(path string, _ os.DirEntry, walkErr error) error {
+				if walkErr != nil {
+					return walkErr
+				}
+				relative, err := filepath.Rel(root, path)
+				if err != nil {
+					return err
+				}
+				remaining = append(remaining, relative)
+				return nil
+			})
+			t.Errorf("RemoveAll(%s) error = %v; remaining paths = %q; inspect error = %v", root, err, remaining, walkErr)
+		}
+	})
 	remote := filepath.Join(root, "remote.git")
 	seed := filepath.Join(root, "seed")
 	repo := filepath.Join(root, "checkout")
@@ -297,7 +314,8 @@ func writeDoctorWorkflowSourceFile(t *testing.T, path string, content string) {
 func runDoctorWorkflowSourceGit(t *testing.T, dir string, args ...string) string {
 	t.Helper()
 
-	cmd := exec.Command("git", args...)
+	gitArgs := append([]string{"-c", "gc.auto=0", "-c", "maintenance.auto=false"}, args...)
+	cmd := exec.Command("git", gitArgs...)
 	cmd.Dir = dir
 	output, err := cmd.CombinedOutput()
 	if err != nil {


### PR DESCRIPTION
## Summary

- disable automatic Git GC and maintenance for workflow-source test fixture commands
- remove fixture roots before generic TempDir cleanup and report surviving paths on failure

Fixes #1722

## UI Surface Contract

- [x] N/A, or the linked issue explicitly authorizes any high-impact UI surface, layout, density, first-viewport, or responsive visibility tradeoff.
- [x] Persistent top-of-screen messaging is explicitly authorized by the issue, or this PR does not add it.
- [x] Visual changes to primary operator screens include screenshot or browser verification below.

## Test Plan

- [x] `go test ./internal/cli -run TestDefaultDoctorWorkflowSourcePolicy -count=20`
- [x] `make check`