### PR TITLE
perf(web): fingerprint SSE components

### DIFF
--- a/internal/web/demo_scenarios.go
+++ b/internal/web/demo_scenarios.go
@@ -849,7 +849,8 @@ func (s *Server) demoEvents(c echo.Context, scenario demoScenario) error {
 	res.Header().Set("Connection", "keep-alive")
 	res.Header().Set("X-Accel-Buffering", "no")
 	res.WriteHeader(http.StatusOK)
-	if err := s.writeDemoSSE(ctx, res, scenario, demoBaseTime, selectedProjectID, selectedNav, selectedView); err != nil {
+	stream := newSSEStream(s.logger, s.sseMetricsInterval)
+	if _, err := s.writeDemoSSE(ctx, res, stream, scenario, demoBaseTime, selectedProjectID, selectedNav, selectedView); err != nil {
 		return err
 	}
 	flusher.Flush()
@@ -861,25 +862,35 @@ func (s *Server) demoEvents(c echo.Context, scenario demoScenario) error {
 		case <-ctx.Done():
 			return nil
 		case <-ticker.C:
+			sent, err := stream.flushPending(ctx, res.Writer)
+			if err != nil {
+				return err
+			}
 			now := demoBaseTime
 			if s.demo.clock == DemoClockPlay || scenario.Variant == "play" {
 				now = demoBaseTime.Add(time.Duration(step) * time.Minute)
 				step++
 			}
-			if err := writeSSEComponent(ctx, res.Writer, sseEventTick, templates.LiveTick(now)); err != nil {
+			if ok, err := stream.sendComponent(ctx, res.Writer, sseEventTick, templates.LiveTick(now), 0); err != nil {
 				return err
+			} else if ok {
+				sent = true
 			}
 			if s.demo.clock == DemoClockPlay || scenario.Variant == "play" {
-				if err := s.writeDemoSSE(ctx, res, scenario, now, selectedProjectID, selectedNav, selectedView); err != nil {
+				if ok, err := s.writeDemoSSE(ctx, res, stream, scenario, now, selectedProjectID, selectedNav, selectedView); err != nil {
 					return err
+				} else if ok {
+					sent = true
 				}
 			}
-			flusher.Flush()
+			if sent {
+				flusher.Flush()
+			}
 		}
 	}
 }
 
-func (s *Server) writeDemoSSE(ctx context.Context, res *echo.Response, scenario demoScenario, now time.Time, selectedProjectID string, selectedNav string, selectedView string) error {
+func (s *Server) writeDemoSSE(ctx context.Context, res *echo.Response, stream *sseStream, scenario demoScenario, now time.Time, selectedProjectID string, selectedNav string, selectedView string) (bool, error) {
 	data := s.demoDashboardData(ctx, scenario)
 	if selectedProjectID == "" {
 		selectedProjectID = strings.TrimSpace(scenario.ProjectID)
@@ -938,16 +949,30 @@ func (s *Server) writeDemoSSE(ctx context.Context, res *echo.Response, scenario 
 	case sseViewConfiguration:
 		data.ActiveNav = "configuration"
 	}
-	if err := writeSSEComponent(ctx, res.Writer, sseEventSnapshot, snapshotComponent); err != nil {
-		return err
+	sent, err := stream.sendComponent(ctx, res.Writer, sseEventSnapshot, snapshotComponent, 0)
+	if err != nil {
+		return false, err
 	}
-	if err := writeSSEComponent(ctx, res.Writer, sseEventSidebar, templates.DashboardSidebarContent(templates.DashboardShellDataFromDashboard(data))); err != nil {
-		return err
+	shellData := templates.DashboardShellDataFromDashboard(data)
+	healthFingerprint, err := templates.GitHubAPIHealthSidebarFingerprint(shellData)
+	if err != nil {
+		return false, err
 	}
-	if err := writeSSEComponent(ctx, res.Writer, sseEventGitHubAPI, templates.GitHubAPIHealthSidebarItem(templates.DashboardShellDataFromDashboard(data))); err != nil {
-		return err
+	if ok, err := stream.sendFingerprintedComponent(ctx, res.Writer, sseEventGitHubAPI, healthFingerprint, templates.GitHubAPIHealthSidebarItem(shellData), 0); err != nil {
+		return false, err
+	} else if ok {
+		sent = true
 	}
-	return writeSSEComponent(ctx, res.Writer, sseEventSidebarV2, templates.AppSidebarContent(templates.DashboardShellDataFromDashboard(data)))
+	sidebarFingerprint, err := templates.AppSidebarFingerprint(shellData)
+	if err != nil {
+		return false, err
+	}
+	if ok, err := stream.sendFingerprintedComponent(ctx, res.Writer, sseEventSidebarV2, sidebarFingerprint, templates.AppSidebarContent(shellData), 0); err != nil {
+		return false, err
+	} else if ok {
+		sent = true
+	}
+	return sent, nil
 }
 
 func demoSSEViewForScenario(scenario demoScenario) string {

--- a/internal/web/server_test.go
+++ b/internal/web/server_test.go
@@ -6326,6 +6326,7 @@ func TestProjectKanbanEventsSendBoardOnlySnapshot(t *testing.T) {
 	mustSetKanbanProject(t, deps.Registry, "detent", workflowconfig.Kanban{
 		Mode: workflowconfig.KanbanModeReadOnly,
 	}, &kanbanActionConnector{name: "github"})
+	mustSetWebProject(t, deps.Registry, "docs", false)
 	server, err := web.NewServer(web.Config{SSETickInterval: time.Hour}, deps)
 	if err != nil {
 		t.Fatalf("NewServer() error = %v", err)
@@ -6340,6 +6341,7 @@ func TestProjectKanbanEventsSendBoardOnlySnapshot(t *testing.T) {
 		GeneratedAt: now,
 		Projects: []telemetry.ProjectSnapshot{
 			{Project: telemetry.Project{ID: "detent", DisplayName: "Detent"}},
+			{Project: telemetry.Project{ID: "docs", DisplayName: "Docs"}},
 		},
 		BoardIssues: []telemetry.Issue{
 			{
@@ -6378,14 +6380,10 @@ func TestProjectKanbanEventsSendBoardOnlySnapshot(t *testing.T) {
 		}
 	}
 
-	sidebarEvent := readRawSSEEvent(t, conn, reader)
-	if sidebarEvent.name != "sidebar" {
-		t.Fatalf("event name = %q, want sidebar", sidebarEvent.name)
-	}
+	sidebarEvent := readRawSSEEventNamed(t, conn, reader, "sidebar-v2")
 	for _, want := range []string{
 		`href="/projects/detent/kanban"`,
-		`data-dashboard-view="kanban"`,
-		`data-tui-sidebar-active="true"`,
+		`data-sidebar-project="detent"`,
 		`aria-current="page"`,
 	} {
 		if !strings.Contains(sidebarEvent.data, want) {
@@ -6466,21 +6464,17 @@ func TestFleetKanbanEventsSendBoardOnlySnapshot(t *testing.T) {
 		}
 	}
 
-	sidebarEvent := readRawSSEEvent(t, conn, reader)
-	if sidebarEvent.name != "sidebar" {
-		t.Fatalf("event name = %q, want sidebar", sidebarEvent.name)
-	}
+	sidebarEvent := readRawSSEEventNamed(t, conn, reader, "sidebar-v2")
 	for _, want := range []string{
-		`href="/kanban"`,
-		`data-dashboard-static-nav="kanban"`,
-		`data-tui-sidebar-active="true"`,
+		`href="/"`,
+		`data-sidebar-nav-item="board"`,
 		`aria-current="page"`,
 	} {
 		if !strings.Contains(sidebarEvent.data, want) {
 			t.Fatalf("fleet Kanban sidebar event missing %q:\n%s", want, sidebarEvent.data)
 		}
 	}
-	assertInactiveSidebarLink(t, sidebarEvent.data, "/")
+	assertAppSidebarLinkActive(t, sidebarEvent.data, "/")
 }
 
 func TestProjectRoutesAllowEscapedSlashIDs(t *testing.T) {
@@ -7865,18 +7859,12 @@ func TestServerEventsStreamsSidebarGitHubAPIHealth(t *testing.T) {
 	defer conn.Close()
 	defer body.Close()
 
-	if event := readRawSSEEvent(t, conn, reader); event.name != "snapshot" {
-		t.Fatalf("first event name = %q, want snapshot", event.name)
-	}
-	if event := readRawSSEEvent(t, conn, reader); event.name != "sidebar" {
-		t.Fatalf("second event name = %q, want sidebar", event.name)
-	}
-	if event := readRawSSEEvent(t, conn, reader); event.name != "live-status" {
-		t.Fatalf("third event name = %q, want live-status", event.name)
-	}
-	event := readRawSSEEvent(t, conn, reader)
-	if event.name != "github-api-health" {
-		t.Fatalf("fourth event name = %q, want github-api-health", event.name)
+	var event sseEvent
+	for index, want := range []string{"snapshot", "live-status", "github-api-health"} {
+		event = readRawSSEEvent(t, conn, reader)
+		if event.name != want {
+			t.Fatalf("event %d name = %q, want %q", index+1, event.name, want)
+		}
 	}
 	for _, want := range []string{
 		`id="github-api-health"`,
@@ -7891,6 +7879,9 @@ func TestServerEventsStreamsSidebarGitHubAPIHealth(t *testing.T) {
 		if !strings.Contains(event.data, want) {
 			t.Fatalf("github api health event missing %q:\n%s", want, event.data)
 		}
+	}
+	if event := readRawSSEEvent(t, conn, reader); event.name != "sidebar-v2" {
+		t.Fatalf("fourth event name = %q, want sidebar-v2", event.name)
 	}
 	for _, forbidden := range []string{
 		`data-preserve-details="github-api-health"`,
@@ -8076,10 +8067,6 @@ func TestServerEventsProjectKanbanUsesReloadedConfigOnRepublishedSnapshot(t *tes
 	if strings.Contains(event.data, `hx-get="/api/v1/kanban/move?`) {
 		t.Fatalf("board snapshot rendered move controls:\n%s", event.data)
 	}
-	sidebarEvent := readRawSSEEvent(t, conn, reader)
-	if sidebarEvent.name != "sidebar" {
-		t.Fatalf("event name = %q, want sidebar", sidebarEvent.name)
-	}
 	liveStatusEvent := readRawSSEEvent(t, conn, reader)
 	if liveStatusEvent.name != "live-status" {
 		t.Fatalf("event name = %q, want live-status", liveStatusEvent.name)
@@ -8146,6 +8133,12 @@ func TestServerEventsStreamsSidebarUpdates(t *testing.T) {
 					Running: 7,
 				},
 			},
+			{
+				Project: telemetry.Project{
+					ID:          "docs",
+					DisplayName: "Docs",
+				},
+			},
 		},
 	}); err != nil {
 		t.Fatalf("Publish() error = %v", err)
@@ -8155,16 +8148,13 @@ func TestServerEventsStreamsSidebarUpdates(t *testing.T) {
 	if snapshotEvent.name != "snapshot" {
 		t.Fatalf("event name = %q, want snapshot", snapshotEvent.name)
 	}
-	sidebarEvent := readRawSSEEvent(t, conn, reader)
-	if sidebarEvent.name != "sidebar" {
-		t.Fatalf("event name = %q, want sidebar", sidebarEvent.name)
-	}
+	sidebarEvent := readRawSSEEventNamed(t, conn, reader, "sidebar-v2")
 	for _, want := range []string{
 		"Detent",
 		`href="/projects/detent/kanban"`,
-		"Detent - 0 todo · 7 active · 0 waiting · 0 blocked",
-		`data-dashboard-project-entry`,
-		`data-tui-sidebar="menu-badge"`,
+		`data-sidebar-project="detent"`,
+		`data-sidebar-project-status="active"`,
+		`data-sidebar-project-badge`,
 		`aria-label="7 board load"`,
 		">7</span>",
 	} {
@@ -8175,6 +8165,7 @@ func TestServerEventsStreamsSidebarUpdates(t *testing.T) {
 	for _, forbidden := range []string{
 		`data-tui-sidebar-state=`,
 		`data-tui-sidebar-trigger`,
+		`sse-swap="sidebar"`,
 	} {
 		if strings.Contains(sidebarEvent.data, forbidden) {
 			t.Fatalf("sidebar event rendered wrapper marker %q:\n%s", forbidden, sidebarEvent.data)
@@ -8206,15 +8197,12 @@ func TestServerEventsPreservesStaticSidebarNavigation(t *testing.T) {
 	if snapshotEvent.name != "snapshot" {
 		t.Fatalf("event name = %q, want snapshot", snapshotEvent.name)
 	}
-	sidebarEvent := readRawSSEEvent(t, conn, reader)
-	if sidebarEvent.name != "sidebar" {
-		t.Fatalf("event name = %q, want sidebar", sidebarEvent.name)
-	}
-	assertActiveSidebarLink(t, sidebarEvent.data, "/reports")
-	assertInactiveSidebarLink(t, sidebarEvent.data, "/")
-	assertInactiveSidebarLink(t, sidebarEvent.data, "/health/ui")
-	assertInactiveSidebarLink(t, sidebarEvent.data, "/analytics")
-	assertInactiveSidebarLink(t, sidebarEvent.data, "/settings")
+	sidebarEvent := readRawSSEEventNamed(t, conn, reader, "sidebar-v2")
+	assertAppSidebarLinkActive(t, sidebarEvent.data, "/reports")
+	assertAppSidebarLinkInactive(t, sidebarEvent.data, "/")
+	assertAppSidebarLinkInactive(t, sidebarEvent.data, "/health/ui")
+	assertAppSidebarLinkInactive(t, sidebarEvent.data, "/analytics")
+	assertAppSidebarLinkInactive(t, sidebarEvent.data, "/settings")
 }
 
 func TestServerEventsStreamsAnalyticsSnapshotForAnalyticsNav(t *testing.T) {
@@ -8260,14 +8248,11 @@ func TestServerEventsStreamsAnalyticsSnapshotForAnalyticsNav(t *testing.T) {
 		}
 	}
 
-	sidebarEvent := readRawSSEEvent(t, conn, reader)
-	if sidebarEvent.name != "sidebar" {
-		t.Fatalf("event name = %q, want sidebar", sidebarEvent.name)
-	}
-	assertActiveSidebarLink(t, sidebarEvent.data, "/analytics")
-	assertInactiveSidebarLink(t, sidebarEvent.data, "/")
-	assertInactiveSidebarLink(t, sidebarEvent.data, "/health/ui")
-	assertInactiveSidebarLink(t, sidebarEvent.data, "/reports")
+	sidebarEvent := readRawSSEEventNamed(t, conn, reader, "sidebar-v2")
+	assertAppSidebarLinkActive(t, sidebarEvent.data, "/analytics")
+	assertAppSidebarLinkInactive(t, sidebarEvent.data, "/")
+	assertAppSidebarLinkInactive(t, sidebarEvent.data, "/health/ui")
+	assertAppSidebarLinkInactive(t, sidebarEvent.data, "/reports")
 }
 
 func TestServerEventsStreamsHealthSnapshotForHealthNav(t *testing.T) {
@@ -8320,35 +8305,26 @@ func TestServerEventsStreamsHealthSnapshotForHealthNav(t *testing.T) {
 		}
 	}
 
-	sidebarEvent := readRawSSEEvent(t, conn, reader)
-	if sidebarEvent.name != "sidebar" {
-		t.Fatalf("event name = %q, want sidebar", sidebarEvent.name)
-	}
-	assertActiveSidebarLink(t, sidebarEvent.data, "/health/ui")
-	assertInactiveSidebarLink(t, sidebarEvent.data, "/")
-	assertInactiveSidebarLink(t, sidebarEvent.data, "/analytics")
+	sidebarEvent := readRawSSEEventNamed(t, conn, reader, "sidebar-v2")
+	assertAppSidebarLinkActive(t, sidebarEvent.data, "/health/ui")
+	assertAppSidebarLinkInactive(t, sidebarEvent.data, "/")
+	assertAppSidebarLinkInactive(t, sidebarEvent.data, "/analytics")
 }
 
 func TestServerEventsPreserveProjectContextForStaticSidebarNavigation(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name         string
-		path         string
-		activeHref   string
-		inactiveHref []string
+		name string
+		path string
 	}{
 		{
-			name:         "reports",
-			path:         "/events?nav=reports&project=detent",
-			activeHref:   "/reports?project=detent",
-			inactiveHref: []string{"/analytics", "/projects/detent/kanban", "/settings?project=detent"},
+			name: "reports",
+			path: "/events?nav=reports&project=detent",
 		},
 		{
-			name:         "settings",
-			path:         "/events?nav=settings&project=detent",
-			activeHref:   "/projects/detent/configuration",
-			inactiveHref: []string{"/analytics", "/reports?project=detent", "/settings?project=detent"},
+			name: "settings",
+			path: "/events?nav=settings&project=detent",
 		},
 	}
 
@@ -8358,6 +8334,7 @@ func TestServerEventsPreserveProjectContextForStaticSidebarNavigation(t *testing
 
 			deps := testDeps(t)
 			mustSetWebProject(t, deps.Registry, "detent", false)
+			mustSetWebProject(t, deps.Registry, "docs", false)
 			server, err := web.NewServer(web.Config{SSETickInterval: time.Hour}, deps)
 			if err != nil {
 				t.Fatalf("NewServer() error = %v", err)
@@ -8375,6 +8352,7 @@ func TestServerEventsPreserveProjectContextForStaticSidebarNavigation(t *testing
 						Project: telemetry.Project{ID: "detent", DisplayName: "Detent"},
 						Counts:  telemetry.Counts{Running: 7},
 					},
+					{Project: telemetry.Project{ID: "docs", DisplayName: "Docs"}},
 				},
 			}); err != nil {
 				t.Fatalf("Publish() error = %v", err)
@@ -8384,30 +8362,22 @@ func TestServerEventsPreserveProjectContextForStaticSidebarNavigation(t *testing
 			if snapshotEvent.name != "snapshot" {
 				t.Fatalf("event name = %q, want snapshot", snapshotEvent.name)
 			}
-			sidebarEvent := readRawSSEEvent(t, conn, reader)
-			if sidebarEvent.name != "sidebar" {
-				t.Fatalf("event name = %q, want sidebar", sidebarEvent.name)
-			}
+			sidebarEvent := readRawSSEEventNamed(t, conn, reader, "sidebar-v2")
 			for _, want := range []string{
-				`aria-label="Project views"`,
-				`href="/projects/detent"`,
 				`href="/projects/detent/kanban"`,
-				`href="/projects/detent/runs"`,
-				`href="/projects/detent/configuration"`,
-				`href="/projects/detent/diagnostics"`,
+				`data-sidebar-project="detent"`,
 				`href="/health/ui"`,
 				`href="/analytics"`,
-				`href="/reports?project=detent"`,
-				`href="/settings?project=detent"`,
+				`href="/reports"`,
+				`href="/settings"`,
 			} {
 				if !strings.Contains(sidebarEvent.data, want) {
 					t.Fatalf("sidebar event missing project-context marker %q:\n%s", want, sidebarEvent.data)
 				}
 			}
-			assertActiveSidebarLink(t, sidebarEvent.data, tt.activeHref)
-			assertInactiveSidebarLink(t, sidebarEvent.data, "/health/ui")
-			for _, href := range tt.inactiveHref {
-				assertInactiveSidebarLink(t, sidebarEvent.data, href)
+			assertAppSidebarLinkActive(t, sidebarEvent.data, "/projects/detent/kanban")
+			for _, href := range []string{"/", "/health/ui", "/analytics", "/reports", "/settings"} {
+				assertAppSidebarLinkInactive(t, sidebarEvent.data, href)
 			}
 		})
 	}
@@ -10656,6 +10626,22 @@ func assertInactiveSidebarLink(t *testing.T, body string, href string) {
 	}
 }
 
+func assertAppSidebarLinkActive(t *testing.T, body string, href string) {
+	t.Helper()
+
+	if !appSidebarLinkActive(body, href) {
+		t.Fatalf("body missing active app sidebar link %q:\n%s", href, body)
+	}
+}
+
+func assertAppSidebarLinkInactive(t *testing.T, body string, href string) {
+	t.Helper()
+
+	if appSidebarLinkActive(body, href) {
+		t.Fatalf("body rendered inactive app sidebar link %q as active:\n%s", href, body)
+	}
+}
+
 func assertSingleCurrentSidebarItem(t *testing.T, body string) {
 	t.Helper()
 
@@ -10686,6 +10672,16 @@ func sidebarLinkActive(body string, href string) bool {
 	pattern := `<a[^>]*href="` + regexp.QuoteMeta(href) + `"[^>]*>`
 	for _, link := range regexp.MustCompile(pattern).FindAllString(body, -1) {
 		if strings.Contains(link, `data-tui-sidebar-active="true"`) && strings.Contains(link, `aria-current="page"`) {
+			return true
+		}
+	}
+	return false
+}
+
+func appSidebarLinkActive(body string, href string) bool {
+	pattern := `<a[^>]*href="` + regexp.QuoteMeta(href) + `"[^>]*>`
+	for _, link := range regexp.MustCompile(pattern).FindAllString(body, -1) {
+		if strings.Contains(link, `aria-current="page"`) {
 			return true
 		}
 	}
@@ -12571,6 +12567,17 @@ func readRawSSEEvent(t *testing.T, conn net.Conn, reader *bufio.Reader) sseEvent
 	for {
 		event := readRawSSEFrame(t, conn, reader)
 		if event.name != "build" {
+			return event
+		}
+	}
+}
+
+func readRawSSEEventNamed(t *testing.T, conn net.Conn, reader *bufio.Reader, name string) sseEvent {
+	t.Helper()
+
+	for {
+		event := readRawSSEEvent(t, conn, reader)
+		if event.name == name {
 			return event
 		}
 	}

--- a/internal/web/sse.go
+++ b/internal/web/sse.go
@@ -20,7 +20,6 @@ import (
 const (
 	sseEventBuild        = "build"
 	sseEventSnapshot     = "snapshot"
-	sseEventSidebar      = "sidebar"
 	sseEventGitHubAPI    = "github-api-health"
 	sseEventTick         = "tick"
 	sseEventLiveStatus   = "live-status"
@@ -156,22 +155,26 @@ func (s *Server) events(c echo.Context) error {
 			if err != nil {
 				return err
 			}
-			if ok, err := stream.sendComponent(ctx, res.Writer, sseEventSidebar, templates.DashboardSidebarContent(templates.DashboardShellDataFromDashboard(data)), s.sseFragmentInterval); err != nil {
+			shellData := templates.DashboardShellDataFromDashboard(data)
+			if ok, err := stream.sendComponent(ctx, res.Writer, sseEventLiveStatus, templates.LiveStatus(shellData), s.sseFragmentInterval); err != nil {
 				return err
 			} else if ok {
 				sent = true
 			}
-			if ok, err := stream.sendComponent(ctx, res.Writer, sseEventLiveStatus, templates.LiveStatus(templates.DashboardShellDataFromDashboard(data)), s.sseFragmentInterval); err != nil {
+			healthFingerprint, err := templates.GitHubAPIHealthSidebarFingerprint(shellData)
+			if err != nil {
+				return err
+			}
+			if ok, err := stream.sendFingerprintedComponent(ctx, res.Writer, sseEventGitHubAPI, healthFingerprint, templates.GitHubAPIHealthSidebarItem(shellData), s.sseHealthInterval); err != nil {
 				return err
 			} else if ok {
 				sent = true
 			}
-			if ok, err := stream.sendComponent(ctx, res.Writer, sseEventGitHubAPI, templates.GitHubAPIHealthSidebarItem(templates.DashboardShellDataFromDashboard(data)), s.sseHealthInterval); err != nil {
+			sidebarFingerprint, err := templates.AppSidebarFingerprint(shellData)
+			if err != nil {
 				return err
-			} else if ok {
-				sent = true
 			}
-			if ok, err := stream.sendComponent(ctx, res.Writer, sseEventSidebarV2, templates.AppSidebarContent(templates.DashboardShellDataFromDashboard(data)), s.sseFragmentInterval); err != nil {
+			if ok, err := stream.sendFingerprintedComponent(ctx, res.Writer, sseEventSidebarV2, sidebarFingerprint, templates.AppSidebarContent(shellData), s.sseFragmentInterval); err != nil {
 				return err
 			} else if ok {
 				sent = true
@@ -250,6 +253,7 @@ type sseStream struct {
 	startedAt         time.Time
 	nextMetricsAt     time.Time
 	last              map[string]sseSentEvent
+	lastFingerprint   map[string]templates.SSEFingerprint
 	pending           map[string]ssePendingEvent
 	metrics           map[string]*sseEventMetrics
 	pendingFlushOrder []string
@@ -274,13 +278,14 @@ type ssePendingEvent struct {
 }
 
 type sseEventMetrics struct {
-	rendered         int64
-	renderedBytes    int64
-	renderDuration   time.Duration
-	sent             int64
-	sentBytes        int64
-	skippedUnchanged int64
-	coalesced        int64
+	rendered           int64
+	renderedBytes      int64
+	renderDuration     time.Duration
+	sent               int64
+	sentBytes          int64
+	skippedUnchanged   int64
+	skippedFingerprint int64
+	coalesced          int64
 }
 
 func newSSEStream(logger *slog.Logger, metricsEvery time.Duration) *sseStream {
@@ -295,9 +300,10 @@ func newSSEStream(logger *slog.Logger, metricsEvery time.Duration) *sseStream {
 		startedAt:         now,
 		nextMetricsAt:     now.Add(metricsEvery),
 		last:              make(map[string]sseSentEvent),
+		lastFingerprint:   make(map[string]templates.SSEFingerprint),
 		pending:           make(map[string]ssePendingEvent),
 		metrics:           make(map[string]*sseEventMetrics),
-		pendingFlushOrder: []string{sseEventSnapshot, sseEventSidebar, sseEventLiveStatus, sseEventGitHubAPI, sseEventSidebarV2},
+		pendingFlushOrder: []string{sseEventSnapshot, sseEventLiveStatus, sseEventGitHubAPI, sseEventSidebarV2},
 	}
 }
 
@@ -307,6 +313,25 @@ func (s *sseStream) sendComponent(ctx context.Context, w io.Writer, name string,
 		return false, err
 	}
 	return s.sendRendered(ctx, w, event, minInterval)
+}
+
+func (s *sseStream) sendFingerprintedComponent(ctx context.Context, w io.Writer, name string, fingerprint templates.SSEFingerprint, component templ.Component, minInterval time.Duration) (bool, error) {
+	if last, ok := s.lastFingerprint[name]; ok && fingerprint == last {
+		now := s.currentTime()
+		s.metricsFor(name).skippedFingerprint++
+		s.logMetricsIfDue(now)
+		return false, nil
+	}
+	event, err := renderSSEComponent(ctx, name, component)
+	if err != nil {
+		return false, err
+	}
+	sent, err := s.sendRendered(ctx, w, event, minInterval)
+	if err != nil {
+		return false, err
+	}
+	s.lastFingerprint[name] = fingerprint
+	return sent, nil
 }
 
 func (s *sseStream) sendRendered(ctx context.Context, w io.Writer, event sseRenderedEvent, minInterval time.Duration) (bool, error) {
@@ -415,11 +440,24 @@ func (s *sseStream) logMetricsIfDue(now time.Time) {
 			"sent_payload_bytes", metrics.sentBytes,
 			"render_duration", metrics.renderDuration,
 			"skipped_unchanged", metrics.skippedUnchanged,
+			"skipped_fingerprint", metrics.skippedFingerprint,
+			"discard_ratio", metrics.discardRatio(),
 			"coalesced", metrics.coalesced,
 			"pending", s.pendingEventQueued(name),
 		)
 	}
 	s.nextMetricsAt = now.Add(s.metricsEvery)
+}
+
+func (m *sseEventMetrics) discardRatio() float64 {
+	if m == nil || m.rendered == 0 {
+		return 0
+	}
+	discarded := m.rendered - m.sent
+	if discarded <= 0 {
+		return 0
+	}
+	return float64(discarded) / float64(m.rendered)
 }
 
 func (s *sseStream) pendingEventQueued(name string) bool {

--- a/internal/web/sse_test.go
+++ b/internal/web/sse_test.go
@@ -288,6 +288,90 @@ func TestSSEStreamSkipsUnchangedFragments(t *testing.T) {
 	}
 }
 
+func TestSSEStreamSkipsMatchingFingerprintBeforeRender(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name                   string
+		fingerprint            templates.SSEFingerprint
+		secondBody             string
+		wantRenders            int
+		wantSent               int64
+		wantSkippedFingerprint int64
+		wantSkippedUnchanged   int64
+		wantDiscardRatio       float64
+	}{
+		{
+			name:                   "matching fingerprint bypasses renderer",
+			fingerprint:            templates.SSEFingerprint{1},
+			secondBody:             "changed but unreachable",
+			wantRenders:            1,
+			wantSent:               1,
+			wantSkippedFingerprint: 1,
+		},
+		{
+			name:                 "changed fingerprint renders identical output",
+			fingerprint:          templates.SSEFingerprint{2},
+			secondBody:           "initial",
+			wantRenders:          2,
+			wantSent:             1,
+			wantSkippedUnchanged: 1,
+			wantDiscardRatio:     0.5,
+		},
+		{
+			name:        "changed fingerprint renders changed output",
+			fingerprint: templates.SSEFingerprint{2},
+			secondBody:  "changed",
+			wantRenders: 2,
+			wantSent:    2,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			now := time.Date(2026, 8, 8, 12, 0, 0, 0, time.UTC)
+			stream := newTestSSEStream(&now)
+			var out bytes.Buffer
+			renders := 0
+			component := func(body string) templ.Component {
+				return templ.ComponentFunc(func(_ context.Context, w io.Writer) error {
+					renders++
+					_, err := io.WriteString(w, body)
+					return err
+				})
+			}
+
+			if sent, err := stream.sendFingerprintedComponent(context.Background(), &out, sseEventSidebarV2, templates.SSEFingerprint{1}, component("initial"), 0); err != nil {
+				t.Fatalf("first sendFingerprintedComponent() error = %v", err)
+			} else if !sent {
+				t.Fatal("first sendFingerprintedComponent() sent = false, want true")
+			}
+			if _, err := stream.sendFingerprintedComponent(context.Background(), &out, sseEventSidebarV2, tt.fingerprint, component(tt.secondBody), 0); err != nil {
+				t.Fatalf("second sendFingerprintedComponent() error = %v", err)
+			}
+
+			metrics := stream.metricsFor(sseEventSidebarV2)
+			if renders != tt.wantRenders {
+				t.Fatalf("render calls = %d, want %d", renders, tt.wantRenders)
+			}
+			if metrics.sent != tt.wantSent {
+				t.Fatalf("sent = %d, want %d", metrics.sent, tt.wantSent)
+			}
+			if metrics.skippedFingerprint != tt.wantSkippedFingerprint {
+				t.Fatalf("skippedFingerprint = %d, want %d", metrics.skippedFingerprint, tt.wantSkippedFingerprint)
+			}
+			if metrics.skippedUnchanged != tt.wantSkippedUnchanged {
+				t.Fatalf("skippedUnchanged = %d, want %d", metrics.skippedUnchanged, tt.wantSkippedUnchanged)
+			}
+			if got := metrics.discardRatio(); got != tt.wantDiscardRatio {
+				t.Fatalf("discardRatio() = %v, want %v", got, tt.wantDiscardRatio)
+			}
+		})
+	}
+}
+
 func TestSSEStreamCoalescesPendingFragments(t *testing.T) {
 	t.Parallel()
 
@@ -351,6 +435,9 @@ func TestSSEStreamCoalescesPendingFragments(t *testing.T) {
 	if metrics.sent != 2 {
 		t.Fatalf("sent = %d, want 2", metrics.sent)
 	}
+	if got, want := metrics.discardRatio(), float64(1)/3; got != want {
+		t.Fatalf("discardRatio() = %v, want %v", got, want)
+	}
 }
 
 func TestSSEStreamLogsMetricsByEvent(t *testing.T) {
@@ -384,6 +471,8 @@ func TestSSEStreamLogsMetricsByEvent(t *testing.T) {
 		"sent_per_second",
 		"sent_payload_bytes",
 		"rendered_payload_bytes",
+		"skipped_fingerprint=0",
+		"discard_ratio=0",
 	} {
 		if !strings.Contains(logs.String(), want) {
 			t.Fatalf("metrics log missing %q:\n%s", want, logs.String())

--- a/internal/web/templates/shell_data.go
+++ b/internal/web/templates/shell_data.go
@@ -1,6 +1,9 @@
 package templates
 
 import (
+	"crypto/sha256"
+	"encoding/json"
+	"fmt"
 	"strconv"
 	"strings"
 	"time"
@@ -25,6 +28,57 @@ type appNavGroup struct {
 	ID    string
 	Label string
 	Items []appNavItem
+}
+
+type SSEFingerprint [sha256.Size]byte
+
+type appSidebarFingerprint struct {
+	NavGroups  []appNavGroup
+	HealthKind primitives.Kind
+	Projects   []appShellProject
+}
+
+type gitHubAPIHealthSidebarFingerprint struct {
+	State  gitHubAPIHealthState
+	Label  string
+	Active bool
+}
+
+func AppSidebarFingerprint(data DashboardShellData) (SSEFingerprint, error) {
+	projects := appShellProjects(data)
+	if len(projects) <= 1 {
+		projects = nil
+	}
+	fingerprint, err := sseFingerprint(appSidebarFingerprint{
+		NavGroups:  appShellNavGroups(data),
+		HealthKind: appShellHealthKind(data),
+		Projects:   projects,
+	})
+	if err != nil {
+		return SSEFingerprint{}, fmt.Errorf("fingerprint app sidebar: %w", err)
+	}
+	return fingerprint, nil
+}
+
+func GitHubAPIHealthSidebarFingerprint(data DashboardShellData) (SSEFingerprint, error) {
+	health := gitHubAPIHealth(data.Snapshot)
+	fingerprint, err := sseFingerprint(gitHubAPIHealthSidebarFingerprint{
+		State:  health.State,
+		Label:  health.Label,
+		Active: sidebarStaticNavActive(data, "health"),
+	})
+	if err != nil {
+		return SSEFingerprint{}, fmt.Errorf("fingerprint GitHub API health sidebar item: %w", err)
+	}
+	return fingerprint, nil
+}
+
+func sseFingerprint(value any) (SSEFingerprint, error) {
+	encoded, err := json.Marshal(value)
+	if err != nil {
+		return SSEFingerprint{}, fmt.Errorf("marshal component view: %w", err)
+	}
+	return sha256.Sum256(encoded), nil
 }
 
 func appShellNavGroups(data DashboardShellData) []appNavGroup {

--- a/internal/web/templates/shell_data_test.go
+++ b/internal/web/templates/shell_data_test.go
@@ -3,9 +3,12 @@ package templates
 import (
 	"bytes"
 	"context"
+	"io"
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/a-h/templ"
 
 	"github.com/digitaldrywood/detent/internal/telemetry"
 	"github.com/digitaldrywood/detent/internal/web/ui/primitives"
@@ -42,6 +45,154 @@ func TestAppShellScriptRefreshesOpenDetailCoreAfterSnapshotSettle(t *testing.T) 
 	if strings.Contains(html, `htmx.ajax("GET", host.dataset.detailSheetURL`) {
 		t.Fatalf("app shell script still refreshes the complete detail sheet:\n%s", html)
 	}
+}
+
+func TestSSEFingerprintsTrackRenderedComponentInputs(t *testing.T) {
+	t.Parallel()
+
+	type fingerprintCase struct {
+		name        string
+		component   func(DashboardShellData) templ.Component
+		fingerprint func(DashboardShellData) (SSEFingerprint, error)
+		mutate      func(*DashboardShellData)
+		wantChanged bool
+	}
+
+	tests := []fingerprintCase{
+		{
+			name:        "app sidebar ignores snapshot sequence",
+			component:   AppSidebarContent,
+			fingerprint: AppSidebarFingerprint,
+			mutate: func(data *DashboardShellData) {
+				data.Snapshot.Seq++
+			},
+		},
+		{
+			name:        "app sidebar tracks active navigation",
+			component:   AppSidebarContent,
+			fingerprint: AppSidebarFingerprint,
+			mutate: func(data *DashboardShellData) {
+				data.ActiveNav = "reports"
+			},
+			wantChanged: true,
+		},
+		{
+			name:        "app sidebar tracks project counts",
+			component:   AppSidebarContent,
+			fingerprint: AppSidebarFingerprint,
+			mutate: func(data *DashboardShellData) {
+				data.Projects[0].BoardActive++
+				data.Projects[0].BoardLoad++
+			},
+			wantChanged: true,
+		},
+		{
+			name:        "health item ignores snapshot sequence",
+			component:   GitHubAPIHealthSidebarItem,
+			fingerprint: GitHubAPIHealthSidebarFingerprint,
+			mutate: func(data *DashboardShellData) {
+				data.Snapshot.Seq++
+			},
+		},
+		{
+			name:        "health item tracks health state",
+			component:   GitHubAPIHealthSidebarItem,
+			fingerprint: GitHubAPIHealthSidebarFingerprint,
+			mutate: func(data *DashboardShellData) {
+				data.Snapshot.RateLimits.GitHubREST.Remaining = 100
+			},
+			wantChanged: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			data := DashboardShellData{
+				ActiveNav: "board",
+				Projects: []ProjectSmallMultiple{
+					{ID: "detent", Name: "Detent", BoardLoad: 1, BoardTodo: 1},
+					{ID: "docs", Name: "Docs"},
+				},
+				Snapshot: telemetry.Snapshot{
+					Seq: 1,
+					RateLimits: &telemetry.RateLimits{
+						GitHubREST:    &telemetry.RateLimitBucket{Remaining: 4_000, Limit: 5_000},
+						GitHubGraphQL: &telemetry.RateLimitBucket{Remaining: 4_000, Limit: 5_000},
+					},
+				},
+			}
+			beforeFingerprint, err := tt.fingerprint(data)
+			if err != nil {
+				t.Fatalf("fingerprint before mutation error = %v", err)
+			}
+			beforeHTML := renderSSEFingerprintComponent(t, tt.component(data))
+
+			tt.mutate(&data)
+			afterFingerprint, err := tt.fingerprint(data)
+			if err != nil {
+				t.Fatalf("fingerprint after mutation error = %v", err)
+			}
+			afterHTML := renderSSEFingerprintComponent(t, tt.component(data))
+
+			if got := beforeFingerprint != afterFingerprint; got != tt.wantChanged {
+				t.Fatalf("fingerprint changed = %t, want %t", got, tt.wantChanged)
+			}
+			if got := beforeHTML != afterHTML; got != tt.wantChanged {
+				t.Fatalf("rendered component changed = %t, want %t", got, tt.wantChanged)
+			}
+		})
+	}
+}
+
+func renderSSEFingerprintComponent(t *testing.T, component templ.Component) string {
+	t.Helper()
+	var buf bytes.Buffer
+	if err := component.Render(context.Background(), &buf); err != nil {
+		t.Fatalf("Render() error = %v", err)
+	}
+	return buf.String()
+}
+
+var benchmarkSSEFingerprint SSEFingerprint
+
+func BenchmarkAppSidebarChangeDetection(b *testing.B) {
+	data := DashboardShellData{
+		ActiveNav: "board",
+		Projects: []ProjectSmallMultiple{
+			{ID: "detent", Name: "Detent", BoardLoad: 5, BoardTodo: 2, BoardActive: 2, BoardWaiting: 1, Running: 1},
+			{ID: "docs", Name: "Docs", BoardLoad: 3, BoardTodo: 1, BoardActive: 1, BoardBlocked: 1},
+			{ID: "website", Name: "Website", BoardLoad: 1, BoardWaiting: 1},
+		},
+		Snapshot: telemetry.Snapshot{
+			RateLimits: &telemetry.RateLimits{
+				GitHubREST:    &telemetry.RateLimitBucket{Remaining: 4_000, Limit: 5_000},
+				GitHubGraphQL: &telemetry.RateLimitBucket{Remaining: 4_000, Limit: 5_000},
+			},
+		},
+	}
+	ctx := b.Context()
+	component := AppSidebarContent(data)
+
+	b.Run("render", func(b *testing.B) {
+		b.ReportAllocs()
+		for b.Loop() {
+			if err := component.Render(ctx, io.Discard); err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
+	b.Run("fingerprint", func(b *testing.B) {
+		b.ReportAllocs()
+		for b.Loop() {
+			fingerprint, err := AppSidebarFingerprint(data)
+			if err != nil {
+				b.Fatal(err)
+			}
+			benchmarkSSEFingerprint = fingerprint
+		}
+	})
 }
 
 func TestAppShellRendersActionNotice(t *testing.T) {

--- a/tests/visual/layout.spec.js
+++ b/tests/visual/layout.spec.js
@@ -123,13 +123,6 @@ test("sidebar groups global navigation and hides a single project", async ({
   await expect
     .poll(() => sidebarSequence(content))
     .toEqual(groupedSidebarSequence);
-  expect(await waitForSidebarMorph(page)).toEqual({
-    preserved: true,
-    swap: "morph:innerHTML",
-  });
-  await expect
-    .poll(() => sidebarSequence(content))
-    .toEqual(groupedSidebarSequence);
 
   await sidebar.getByRole("button", { name: "Toggle sidebar" }).click();
   await expect(sidebar).toHaveAttribute("data-rail", "true");
@@ -185,7 +178,7 @@ test("sidebar groups global navigation and hides a single project", async ({
 
   const collapsedAnalytics = content.locator('[data-sidebar-nav-item="analytics"]');
   await collapsedAnalytics.hover();
-  await waitForSidebarMorph(page);
+  await waitForSnapshotWithoutSidebarMorph(page);
   await expect(tooltip).toBeVisible();
   await expect(tooltip).toContainText("Analytics");
 
@@ -206,6 +199,32 @@ test("sidebar groups global navigation and hides a single project", async ({
   const singleProjectContent = page.locator("#app-sidebar-content");
   await expect(singleProjectContent.locator('[data-sidebar-section="projects"]')).toHaveCount(0);
   await expect(singleProjectContent.locator("[data-sidebar-project]")).toHaveCount(0);
+});
+
+test("unchanged SSE inputs skip sidebar and health region morphs", async ({
+  page,
+}) => {
+  await openScenario(page, {
+    runtime: sidebarRuntime,
+    scenario: "fleet-healthy-parallel-work",
+    route: "/",
+    waitSelector: "#board-lanes",
+    viewport: desktopViewport,
+  });
+
+  const snapshot = page.locator("#snapshot");
+  const sidebar = page.locator("#app-sidebar-content");
+  await expect(snapshot).toHaveAttribute("hx-swap", "morph:innerHTML");
+  await expect(sidebar).toHaveAttribute("sse-swap", "sidebar-v2");
+  await expect(sidebar).toHaveAttribute("hx-swap", "morph:innerHTML");
+  await expect(page.locator('[sse-swap="sidebar"]')).toHaveCount(0);
+  await expect(page.locator("#github-api-health")).toHaveCount(0);
+
+  expect(await waitForSnapshotWithoutSidebarMorph(page)).toEqual({
+    healthSwaps: 0,
+    preserved: true,
+    sidebarSwaps: 0,
+  });
 });
 
 test("sidebar project badges keep load, activity, blocked tint, and breakdown distinct", async ({
@@ -265,7 +284,7 @@ test("sidebar project badges keep load, activity, blocked tint, and breakdown di
   await expect(tooltip).toContainText(
     "1 todo · 3 active · 0 waiting · 1 blocked",
   );
-  await waitForSidebarMorph(page);
+  await waitForSnapshotWithoutSidebarMorph(page);
   await expect(tooltip).toBeVisible();
   await expect(tooltip).toContainText(
     "1 todo · 3 active · 0 waiting · 1 blocked",
@@ -2102,27 +2121,35 @@ async function sidebarSequence(content) {
     );
 }
 
-async function waitForSidebarMorph(page) {
-  const swaps = await page.evaluate(() => {
+async function waitForSnapshotWithoutSidebarMorph(page) {
+  const baseline = await page.evaluate(() => {
     window.__detentSidebarNode = document.getElementById("app-sidebar-content");
-    return window.__detentSSEMetrics?.snapshot()?.["sidebar-v2"]?.swaps || 0;
+    const metrics = window.__detentSSEMetrics?.snapshot() || {};
+    return {
+      health: metrics["github-api-health"]?.swaps || 0,
+      sidebar: metrics["sidebar-v2"]?.swaps || 0,
+      snapshot: metrics.snapshot?.swaps || 0,
+    };
   });
   await expect
     .poll(
       () =>
         page.evaluate(
-          () => window.__detentSSEMetrics?.snapshot()?.["sidebar-v2"]?.swaps || 0,
+          () => window.__detentSSEMetrics?.snapshot()?.snapshot?.swaps || 0,
         ),
       { timeout: 15_000 },
     )
-    .toBeGreaterThan(swaps);
-  return page.evaluate(() => {
+    .toBeGreaterThan(baseline.snapshot);
+  return page.evaluate((baseline) => {
     const target = document.getElementById("app-sidebar-content");
+    const metrics = window.__detentSSEMetrics?.snapshot() || {};
     return {
+      healthSwaps:
+        (metrics["github-api-health"]?.swaps || 0) - baseline.health,
       preserved: target === window.__detentSidebarNode,
-      swap: target?.getAttribute("hx-swap"),
+      sidebarSwaps: (metrics["sidebar-v2"]?.swaps || 0) - baseline.sidebar,
     };
-  });
+  }, baseline);
 }
 
 async function startLaneHiddenRecorder(page, laneID) {


### PR DESCRIPTION
## Summary

- fingerprint sidebar and GitHub API health inputs before rendering unchanged SSE components
- remove the legacy `sidebar` event and keep `sidebar-v2` as the current in-place morph target
- expose pre-render skips and rendered-output discard ratio in SSE metrics
- cover production/demo streams with Go tests and desktop Playwright regression coverage

Fixes #1723

## UI Surface Contract

- [x] The linked issue explicitly authorizes the affected SSE dashboard regions; no layout, density, or first-viewport tradeoff is introduced.
- [x] This PR does not add persistent top-of-screen messaging.
- [x] Browser verification confirms `#snapshot` and `#app-sidebar-content` continue using `morph:innerHTML`; unchanged sidebar/health inputs do not morph.

## Test Plan

- [x] `make generate`
- [x] focused Go SSE, template, and server tests
- [x] `env -u DETENT_API_TOKEN npx playwright test tests/visual/layout.spec.js --project chromium` (43 passed)
- [x] isolated Chrome DevTools verification against the demo runtime
- [x] `make check` (78.7% overall coverage)