### PR TITLE
fix(codex): drain output before stdin close

### DIFF
--- a/.detent/skills/deterministic-blocked-pipe-close-testing.md
+++ b/.detent/skills/deterministic-blocked-pipe-close-testing.md
@@ -1,0 +1,15 @@
+---
+name: deterministic-blocked-pipe-close-testing
+description: Reproduce and prevent subprocess pipe-close deadlocks when close waits for blocked I/O on only some operating systems.
+when_to_use: Use when a transport or subprocess test hangs because one direction is blocked on pipe I/O while shutdown must release another backpressured direction.
+---
+
+# Test blocked pipe close deterministically
+
+- Build the wait-for graph from complete goroutine stacks before changing shutdown code. Identify the in-flight I/O, the close waiting for it, and the independent backpressure preventing the peer from exiting.
+- Wrap the pipe writer with a test closer that observes write start and waits for that active write to return before delegating close. Use this to model platforms whose file close waits for concurrent pipe I/O.
+- Drive each direction into backpressure with observable conditions such as write-start and full-buffer signals. Do not use sleeps to arrange the deadlock.
+- Start close with a generous context deadline and assert that both the blocked operation and close return. Keep the deadline as a deadlock guard, not a performance assertion.
+- Add failure-only recovery that releases publication backpressure, terminates the test subprocess through `internal/procgroup`, and boundedly joins started goroutines before failing. A broken regression must not hold the package until its global timeout.
+- Prove the regression red against the old shutdown ordering, then make shutdown release consumers or drainers before closing a resource that may wait for their I/O.
+- Repeat the focused test normally and under `-race`, cross-compile the test package for the affected platform, run the repository validation gate, and require real affected-platform CI before completion.

--- a/internal/codex/transport.go
+++ b/internal/codex/transport.go
@@ -264,8 +264,8 @@ func (t *localTransport) Receive(ctx context.Context) (Message, error) {
 func (t *localTransport) Close(ctx context.Context) error {
 	ctx = contextOrBackground(ctx)
 
-	closeErr := t.closeStdin()
 	t.stopReading()
+	closeErr := t.closeStdin()
 
 	select {
 	case <-t.done:

--- a/internal/codex/transport_test.go
+++ b/internal/codex/transport_test.go
@@ -353,8 +353,9 @@ func TestLocalTransportCloseUnblocksBlockedWriteAndPublish(t *testing.T) {
 		_ = transport.Close(closeCtx)
 	})
 
-	writeObserver := newWriteObserver(local.stdin)
-	local.codec.writer = bufio.NewWriter(writeObserver)
+	stdin := newCloseWaitsForWriteCloser(local.stdin)
+	local.stdin = stdin
+	local.codec.writer = bufio.NewWriter(stdin)
 
 	sendDone := make(chan error, 1)
 	go func() {
@@ -366,7 +367,7 @@ func TestLocalTransportCloseUnblocksBlockedWriteAndPublish(t *testing.T) {
 	}()
 
 	select {
-	case <-writeObserver.started:
+	case <-stdin.writeStarted:
 	case <-time.After(10 * time.Second):
 		t.Fatal("Send() did not start writing")
 	}
@@ -390,6 +391,18 @@ func TestLocalTransportCloseUnblocksBlockedWriteAndPublish(t *testing.T) {
 			t.Fatal("Send() error = nil, want blocked write interrupted by close")
 		}
 	case <-closeCtx.Done():
+		local.stopReading()
+		_ = procgroup.TerminateTree(local.cmd, local.processGroupID)
+		select {
+		case <-sendDone:
+		case <-time.After(5 * time.Second):
+			t.Fatal("Send() could not be recovered after Close() blocked")
+		}
+		select {
+		case <-closeDone:
+		case <-time.After(5 * time.Second):
+			t.Fatal("Close() could not be recovered after blocked write")
+		}
 		t.Fatalf("Send() stayed blocked after Close(): %v", closeCtx.Err())
 	}
 
@@ -734,24 +747,36 @@ func (noopWriteCloser) Close() error {
 	return nil
 }
 
-type writeObserver struct {
-	writer  io.Writer
-	started chan struct{}
-	once    sync.Once
+type closeWaitsForWriteCloser struct {
+	writer       io.WriteCloser
+	writeStarted chan struct{}
+	writeDone    chan struct{}
+	startOnce    sync.Once
+	doneOnce     sync.Once
 }
 
-func newWriteObserver(writer io.Writer) *writeObserver {
-	return &writeObserver{
-		writer:  writer,
-		started: make(chan struct{}),
+func newCloseWaitsForWriteCloser(writer io.WriteCloser) *closeWaitsForWriteCloser {
+	return &closeWaitsForWriteCloser{
+		writer:       writer,
+		writeStarted: make(chan struct{}),
+		writeDone:    make(chan struct{}),
 	}
 }
 
-func (w *writeObserver) Write(p []byte) (int, error) {
-	w.once.Do(func() {
-		close(w.started)
+func (w *closeWaitsForWriteCloser) Write(p []byte) (int, error) {
+	w.startOnce.Do(func() {
+		close(w.writeStarted)
 	})
-	return w.writer.Write(p)
+	n, err := w.writer.Write(p)
+	w.doneOnce.Do(func() {
+		close(w.writeDone)
+	})
+	return n, err
+}
+
+func (w *closeWaitsForWriteCloser) Close() error {
+	<-w.writeDone
+	return w.writer.Close()
 }
 
 type capturingLocalTransportFactory struct {


### PR DESCRIPTION
## Summary

- release receive backpressure before closing stdin so Windows pipe close cannot deadlock behind an in-flight JSON-RPC write
- make the blocked-write/publish regression model close-waits-for-write behavior on every platform with bounded failure recovery
- add a reusable skill draft for deterministic subprocess pipe-close deadlock testing

Fixes #1735

## UI Surface Contract

- [x] N/A; this change has no UI surface, layout, density, first-viewport, or responsive visibility impact.
- [x] This change adds no persistent top-of-screen messaging.
- [x] N/A; this change has no visual surface requiring screenshot or browser verification.

## Test Plan

- [x] `go test ./internal/codex -run '^TestLocalTransportCloseUnblocksBlockedWriteAndPublish$' -count=100`
- [x] `go test -race ./internal/codex -run '^TestLocalTransportCloseUnblocksBlockedWriteAndPublish$' -count=10 -v`
- [x] related local transport close/send tests, 20 repetitions
- [x] `go test ./internal/codex -count=1`
- [x] Windows amd64 test-binary cross-compilation
- [x] `make check` after the implementation and again after the skill draft (78.7% aggregate coverage)