### PR TITLE
fix(github): govern worker credentials

### DIFF
--- a/config.annotated.yaml
+++ b/config.annotated.yaml
@@ -36,6 +36,13 @@ workspace:
   cache_strategy: isolated
   auto_branch: true
 
+# Use a separate bot-user token for worker gh/curl calls. A second token for
+# the orchestrator's GitHub user still shares its REST budget and is rejected.
+worker:
+  github_token: $DETENT_WORKER_GITHUB_TOKEN
+  github_rest_min_remaining_reserve: 1000
+  github_rest_poll_interval_ms: 60000
+
 # Bound fleet concurrency globally and serialize only the merge lane.
 agent:
   max_concurrent_agents: 4

--- a/config.reference.yaml
+++ b/config.reference.yaml
@@ -513,6 +513,12 @@
 #   ssh_hosts: []
 #   # worker.max_concurrent_agents_per_host | type: integer | default: none | required: No | validation: must be greater than 0
 #   max_concurrent_agents_per_host: null
+#   # worker.github_token | type: string | default: none | required: No | validation: None
+#   github_token: null
+#   # worker.github_rest_min_remaining_reserve | type: integer | default: 1000 | required: No | validation: must be greater than 0
+#   github_rest_min_remaining_reserve: 1000
+#   # worker.github_rest_poll_interval_ms | type: integer | default: 60000 | required: No | validation: must be greater than or equal to 60000
+#   github_rest_poll_interval_ms: 60000
 # # agent | type: object | default: see child fields | required: No | validation: None
 # agent:
 #   # agent.max_concurrent_agents | type: integer | default: 10 | required: No | validation: must be greater than 0

--- a/docs/config.md
+++ b/docs/config.md
@@ -137,6 +137,26 @@ sharing, and cleanup. `deliverable` selects pull requests or file artifacts and
 their review destination. `worker` distributes sessions across optional SSH
 hosts; per-state and global concurrency limits remain under `agent`.
 
+GitHub-capable workers never inherit `GITHUB_TOKEN`, `GH_TOKEN`, their
+enterprise variants, or the host's GitHub CLI login. Leave
+`worker.github_token` empty to run workers with GitHub authentication disabled,
+or point it at a dedicated environment variable in a machine-local overlay:
+
+```yaml
+worker:
+  github_token: $DETENT_WORKER_GITHUB_TOKEN
+  github_rest_min_remaining_reserve: 1000
+  github_rest_poll_interval_ms: 60000
+```
+
+The worker token must belong to a different GitHub user than the orchestrator
+token; a second token for the same user still shares that user's primary REST
+budget and is rejected before launch. Detent verifies the principals through
+GraphQL, probes the dedicated worker REST budget at launch and no more often
+than the configured interval, and stops or refuses a worker at the reserve.
+Worker and orchestrator budget rows carry an explicit `consumer` in telemetry.
+Keep the token itself out of checked-in project files.
+
 `workpad.structured_only` requires machine-readable workpad status instead of
 accepting legacy narrative signals. `dependencies.source` chooses whether
 native tracker dependencies, merged pull requests, or both determine
@@ -826,6 +846,9 @@ rendering and fails on drift.
 | `tracker.terminal_states` | `list<string>` | `["Closed","Cancelled","Canceled","Duplicate","Done"]` | No | state names must be unique<br>state names must not be blank<br>tracker.active_states, tracker.observed_states, or tracker.terminal_states must include Blocked when agent.auto_promote.no_progress_limit is greater than 0 |
 | `tracker.write_probe_issue` | `string` | `none` | No | None |
 | `worker` | `object` | `see child fields` | No | None |
+| `worker.github_rest_min_remaining_reserve` | `integer` | `1000` | No | must be greater than 0 |
+| `worker.github_rest_poll_interval_ms` | `integer` | `60000` | No | must be greater than or equal to 60000 |
+| `worker.github_token` | `string` | `none` | No | None |
 | `worker.max_concurrent_agents_per_host` | `integer` | `none` | No | must be greater than 0 |
 | `worker.ssh_hosts` | `list<string>` | `[]` | No | None |
 | `workpad` | `object` | `see child fields` | No | None |

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -159,6 +159,11 @@ tracker:
     target_state: Todo
 polling:
   interval_ms: 120000
+worker:
+  # Put the environment reference in detent.local.yaml for a dedicated bot user.
+  github_token: $DETENT_WORKER_GITHUB_TOKEN
+  github_rest_min_remaining_reserve: 1000
+  github_rest_poll_interval_ms: 60000
 workspace:
   root: /absolute/path/to/detent-workspaces
   source_root: /absolute/path/to/project-checkout

--- a/internal/cli/runner.go
+++ b/internal/cli/runner.go
@@ -71,6 +71,12 @@ func withRunnerFactory(
 			workflow.Config.Identity = cfg.Identity
 			workflow.Config.Identity.Normalize()
 		}
+		if len(githubTokenSource) > 0 && githubTokenSource[0] != nil {
+			token := strings.TrimSpace(githubTokenSource[0]())
+			if token != "" && (workflow.Config.Tracker.Kind == workflowconfig.TrackerGitHub || workflow.Config.Tracker.Kind == workflowconfig.TrackerGitHubLocal) {
+				workflow.Config.Tracker.APIKey = token
+			}
+		}
 
 		run := deps.Runner
 		if run == nil {
@@ -1010,7 +1016,7 @@ func cloneFleetRateLimitBucket(bucket *telemetry.RateLimitBucket) *telemetry.Rat
 func mergeFleetRESTBudgets(current []telemetry.RESTBudget, incoming []telemetry.RESTBudget) []telemetry.RESTBudget {
 	byKey := make(map[string]telemetry.RESTBudget, len(current)+len(incoming))
 	for _, budget := range append(append([]telemetry.RESTBudget(nil), current...), incoming...) {
-		key := strings.TrimSpace(budget.CredentialIdentity) + "\x00" + strings.TrimSpace(budget.EndpointFamily) + "\x00" + strings.TrimSpace(budget.Resource)
+		key := restBudgetConsumer(budget.Consumer) + "\x00" + strings.TrimSpace(budget.CredentialIdentity) + "\x00" + strings.TrimSpace(budget.EndpointFamily) + "\x00" + strings.TrimSpace(budget.Resource)
 		existing, ok := byKey[key]
 		if !ok || restBudgetObservedAfter(budget, existing) {
 			byKey[key] = cloneFleetRESTBudget(budget)
@@ -1024,6 +1030,9 @@ func mergeFleetRESTBudgets(current []telemetry.RESTBudget, incoming []telemetry.
 		budgets = append(budgets, budget)
 	}
 	sort.Slice(budgets, func(i, j int) bool {
+		if restBudgetConsumer(budgets[i].Consumer) != restBudgetConsumer(budgets[j].Consumer) {
+			return restBudgetConsumer(budgets[i].Consumer) < restBudgetConsumer(budgets[j].Consumer)
+		}
 		if budgets[i].CredentialIdentity != budgets[j].CredentialIdentity {
 			return budgets[i].CredentialIdentity < budgets[j].CredentialIdentity
 		}
@@ -1054,6 +1063,9 @@ func cloneFleetRESTBudget(budget telemetry.RESTBudget) telemetry.RESTBudget {
 func fleetRESTBucketFromBudgets(budgets []telemetry.RESTBudget) *telemetry.RateLimitBucket {
 	currentByCredentialResource := make(map[string]telemetry.RESTBudget, len(budgets))
 	for _, budget := range budgets {
+		if restBudgetConsumer(budget.Consumer) != telemetry.RESTConsumerOrchestrator {
+			continue
+		}
 		key := strings.TrimSpace(budget.CredentialIdentity) + "\x00" + strings.TrimSpace(budget.Resource)
 		existing, ok := currentByCredentialResource[key]
 		if !ok || restBudgetObservedAfter(budget, existing) || (restBudgetObservedTogether(budget, existing) && restBudgetRemainingRatio(budget) < restBudgetRemainingRatio(existing)) {
@@ -1088,6 +1100,14 @@ func fleetRESTBucketFromBudgets(budgets []telemetry.RESTBudget) *telemetry.RateL
 		ResetAt:    cloneTimePointer(selected.ResetAt),
 		ObservedAt: cloneTimePointer(selected.ObservedAt),
 	}
+}
+
+func restBudgetConsumer(consumer string) string {
+	consumer = strings.TrimSpace(consumer)
+	if consumer == "" {
+		return telemetry.RESTConsumerOrchestrator
+	}
+	return consumer
 }
 
 func restBudgetObservedTogether(left telemetry.RESTBudget, right telemetry.RESTBudget) bool {
@@ -1132,8 +1152,9 @@ func mergeFleetRESTUsage(current *telemetry.RESTUsage, incoming *telemetry.RESTU
 			merged.BackoffUntil = &backoffUntil
 		}
 		for _, contributor := range usage.Contributors {
-			key := contributor.CredentialIdentity + "\x00" + contributor.EndpointFamily + "\x00" + contributor.Resource
+			key := restBudgetConsumer(contributor.Consumer) + "\x00" + contributor.CredentialIdentity + "\x00" + contributor.EndpointFamily + "\x00" + contributor.Resource
 			existing := contributors[key]
+			existing.Consumer = restBudgetConsumer(contributor.Consumer)
 			existing.CredentialIdentity = contributor.CredentialIdentity
 			existing.EndpointFamily = contributor.EndpointFamily
 			existing.Resource = contributor.Resource
@@ -1163,6 +1184,9 @@ func mergeFleetRESTUsage(current *telemetry.RESTUsage, incoming *telemetry.RESTU
 		merged.Contributors = append(merged.Contributors, contributor)
 	}
 	sort.Slice(merged.Contributors, func(i, j int) bool {
+		if restBudgetConsumer(merged.Contributors[i].Consumer) != restBudgetConsumer(merged.Contributors[j].Consumer) {
+			return restBudgetConsumer(merged.Contributors[i].Consumer) < restBudgetConsumer(merged.Contributors[j].Consumer)
+		}
 		if merged.Contributors[i].CredentialIdentity != merged.Contributors[j].CredentialIdentity {
 			return merged.Contributors[i].CredentialIdentity < merged.Contributors[j].CredentialIdentity
 		}

--- a/internal/cli/runner_test.go
+++ b/internal/cli/runner_test.go
@@ -1358,6 +1358,15 @@ func TestFleetRESTBucketFromBudgetsUsesCurrentCredentialResourceSnapshot(t *test
 			wantRemaining: 4000,
 			wantReset:     newReset,
 		},
+		{
+			name: "exhausted worker budget does not constrain orchestrator dispatch",
+			budgets: []telemetry.RESTBudget{
+				{Consumer: telemetry.RESTConsumerOrchestrator, CredentialIdentity: "orchestrator", EndpointFamily: "issues", Resource: "core", Limit: 5000, Remaining: 4000, ResetAt: &newReset, ObservedAt: &newObserved},
+				{Consumer: telemetry.RESTConsumerWorker, CredentialIdentity: "worker", EndpointFamily: "worker credential", Resource: "core", Limit: 5000, Remaining: 0, ResetAt: &newReset, ObservedAt: &newObserved},
+			},
+			wantRemaining: 4000,
+			wantReset:     newReset,
+		},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -277,6 +277,9 @@ type Deliverable struct {
 type Worker struct {
 	SSHHosts                   []string `yaml:"ssh_hosts"`
 	MaxConcurrentAgentsPerHost *int     `yaml:"max_concurrent_agents_per_host"`
+	GitHubToken                string   `yaml:"github_token,omitempty"`
+	GitHubRESTMinReserve       int      `yaml:"github_rest_min_remaining_reserve"`
+	GitHubRESTPollIntervalMS   int      `yaml:"github_rest_poll_interval_ms"`
 }
 
 type Agent struct {
@@ -1297,7 +1300,9 @@ func Default() Config {
 			Source: DependencySourceMerged,
 		},
 		Worker: Worker{
-			SSHHosts: []string{},
+			SSHHosts:                 []string{},
+			GitHubRESTMinReserve:     1000,
+			GitHubRESTPollIntervalMS: 60000,
 		},
 		Agent: Agent{
 			MaxConcurrentAgents:         10,
@@ -1439,6 +1444,14 @@ func (c *Config) Validate() error {
 	c.Workspace.validate(&problems)
 	if c.Worker.MaxConcurrentAgentsPerHost != nil {
 		validatePositive("worker.max_concurrent_agents_per_host", *c.Worker.MaxConcurrentAgentsPerHost, &problems)
+	}
+	validatePositive("worker.github_rest_min_remaining_reserve", c.Worker.GitHubRESTMinReserve, &problems)
+	if c.Worker.GitHubRESTPollIntervalMS < 60000 {
+		problems = append(problems, "worker.github_rest_poll_interval_ms must be greater than or equal to 60000")
+	}
+	switch strings.ToLower(strings.TrimSpace(c.Worker.GitHubToken)) {
+	case "gh", "gh-auth", "${gh auth token}", "$(gh auth token)":
+		problems = append(problems, "worker.github_token must use a dedicated credential instead of ambient gh authentication")
 	}
 	c.Agent.validate("agent", &problems)
 	c.validateStopRun(&problems)

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -119,6 +119,69 @@ func TestParseWorkflowOverlayPrecedence(t *testing.T) {
 	}
 }
 
+func TestWorkerGitHubPolicyConfiguration(t *testing.T) {
+	t.Parallel()
+
+	workflow, err := ParseWorkflow([]byte("---\ntracker:\n  kind: memory\nworker:\n  github_token: $DETENT_WORKER_GITHUB_TOKEN\n  github_rest_min_remaining_reserve: 1250\n  github_rest_poll_interval_ms: 90000\n---\nPrompt\n"))
+	if err != nil {
+		t.Fatalf("ParseWorkflow() error = %v", err)
+	}
+	if workflow.Config.Worker.GitHubToken != "$DETENT_WORKER_GITHUB_TOKEN" {
+		t.Fatalf("Worker.GitHubToken = %q, want environment reference", workflow.Config.Worker.GitHubToken)
+	}
+	if workflow.Config.Worker.GitHubRESTMinReserve != 1250 {
+		t.Fatalf("Worker.GitHubRESTMinReserve = %d, want 1250", workflow.Config.Worker.GitHubRESTMinReserve)
+	}
+	if workflow.Config.Worker.GitHubRESTPollIntervalMS != 90000 {
+		t.Fatalf("Worker.GitHubRESTPollIntervalMS = %d, want 90000", workflow.Config.Worker.GitHubRESTPollIntervalMS)
+	}
+}
+
+func TestWorkerGitHubPolicyValidation(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		mutate func(*Config)
+		want   string
+	}{
+		{
+			name: "reserve must be positive",
+			mutate: func(cfg *Config) {
+				cfg.Worker.GitHubRESTMinReserve = 0
+			},
+			want: "worker.github_rest_min_remaining_reserve must be greater than 0",
+		},
+		{
+			name: "poll interval protects REST budget",
+			mutate: func(cfg *Config) {
+				cfg.Worker.GitHubRESTPollIntervalMS = 59999
+			},
+			want: "worker.github_rest_poll_interval_ms must be greater than or equal to 60000",
+		},
+		{
+			name: "ambient gh credential rejected",
+			mutate: func(cfg *Config) {
+				cfg.Worker.GitHubToken = "gh"
+			},
+			want: "worker.github_token must use a dedicated credential instead of ambient gh authentication",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			cfg := Default()
+			cfg.Tracker.Kind = TrackerMemory
+			tt.mutate(&cfg)
+			err := cfg.Validate()
+			if err == nil || !strings.Contains(err.Error(), tt.want) {
+				t.Fatalf("Validate() error = %v, want containing %q", err, tt.want)
+			}
+		})
+	}
+}
+
 func TestParseWorkflowActiveHours(t *testing.T) {
 	t.Parallel()
 	tests := []struct {

--- a/internal/orchestrator/rate_limit_test.go
+++ b/internal/orchestrator/rate_limit_test.go
@@ -437,6 +437,29 @@ func TestTickPublishesGitHubRESTUsageAndBackoff(t *testing.T) {
 	}
 }
 
+func TestReplaceRESTConsumerBudgetsPreservesWorkerBudget(t *testing.T) {
+	t.Parallel()
+
+	current := []telemetry.RESTBudget{
+		{Consumer: telemetry.RESTConsumerOrchestrator, CredentialIdentity: "orchestrator-old", Remaining: 100},
+		{Consumer: telemetry.RESTConsumerWorker, CredentialIdentity: "worker", Remaining: 3000},
+	}
+	replacement := []telemetry.RESTBudget{
+		{Consumer: telemetry.RESTConsumerOrchestrator, CredentialIdentity: "orchestrator-new", Remaining: 4000},
+	}
+
+	got := replaceRESTConsumerBudgets(current, replacement, telemetry.RESTConsumerOrchestrator)
+	if len(got) != 2 {
+		t.Fatalf("replaceRESTConsumerBudgets() = %#v, want two budgets", got)
+	}
+	if got[0].Consumer != telemetry.RESTConsumerWorker || got[0].CredentialIdentity != "worker" {
+		t.Fatalf("preserved budget = %#v, want worker budget", got[0])
+	}
+	if got[1].Consumer != telemetry.RESTConsumerOrchestrator || got[1].CredentialIdentity != "orchestrator-new" {
+		t.Fatalf("replacement budget = %#v, want new orchestrator budget", got[1])
+	}
+}
+
 func TestTickSkipsConnectorPollingDuringGitHubRESTBackoff(t *testing.T) {
 	t.Parallel()
 

--- a/internal/orchestrator/rate_limits.go
+++ b/internal/orchestrator/rate_limits.go
@@ -90,7 +90,7 @@ func (o *Orchestrator) captureConnectorRESTRateLimits(state *State, now time.Tim
 		state.RateLimits = &telemetry.RateLimits{}
 	}
 	state.RateLimits.GitHubREST = bucket
-	state.RateLimits.GitHubRESTBudgets = budgets
+	state.RateLimits.GitHubRESTBudgets = replaceRESTConsumerBudgets(state.RateLimits.GitHubRESTBudgets, budgets, telemetry.RESTConsumerOrchestrator)
 	state.RateLimits.RESTUsage = summary
 	return restRateLimitCycle{
 		Bucket:     bucket,
@@ -98,6 +98,20 @@ func (o *Orchestrator) captureConnectorRESTRateLimits(state *State, now time.Tim
 		Usage:      summary,
 		HasSummary: true,
 	}
+}
+
+func replaceRESTConsumerBudgets(current []telemetry.RESTBudget, replacement []telemetry.RESTBudget, consumer string) []telemetry.RESTBudget {
+	out := make([]telemetry.RESTBudget, 0, len(current)+len(replacement))
+	for _, budget := range current {
+		budgetConsumer := strings.TrimSpace(budget.Consumer)
+		if budgetConsumer == "" {
+			budgetConsumer = telemetry.RESTConsumerOrchestrator
+		}
+		if budgetConsumer != consumer {
+			out = append(out, budget)
+		}
+	}
+	return append(out, replacement...)
 }
 
 func restUsageSummary(usage connector.RESTRateLimitUsage) *telemetry.RESTUsage {
@@ -119,6 +133,7 @@ func restUsageSummary(usage connector.RESTRateLimitUsage) *telemetry.RESTUsage {
 	}
 	for _, request := range usage.Requests {
 		contributor := telemetry.RESTUsageContributor{
+			Consumer:           telemetry.RESTConsumerOrchestrator,
 			CredentialIdentity: request.CredentialIdentity,
 			EndpointFamily:     request.EndpointFamily,
 			Count:              request.Count,
@@ -150,6 +165,7 @@ func restBudgetSummaries(budgets []connector.RESTRateLimitBudget) []telemetry.RE
 	out := make([]telemetry.RESTBudget, 0, len(budgets))
 	for _, budget := range budgets {
 		summary := telemetry.RESTBudget{
+			Consumer:           telemetry.RESTConsumerOrchestrator,
 			CredentialIdentity: budget.CredentialIdentity,
 			EndpointFamily:     budget.EndpointFamily,
 			Resource:           budget.RateLimit.Resource,
@@ -233,6 +249,7 @@ func (o *Orchestrator) logRESTRateLimitCycle(cycle restRateLimitCycle) {
 
 	o.logger.Info(
 		"github rest budget summary",
+		"consumer", telemetry.RESTConsumerOrchestrator,
 		"request_count", totalRequests,
 		"billable_request_count", billableRequests,
 		"not_modified_request_count", notModifiedRequests,

--- a/internal/orchestrator/state.go
+++ b/internal/orchestrator/state.go
@@ -3,6 +3,8 @@ package orchestrator
 import (
 	"context"
 	"maps"
+	"sort"
+	"strings"
 	"time"
 
 	"github.com/digitaldrywood/detent/internal/agentidentity"
@@ -723,8 +725,8 @@ func mergeRateLimits(current *telemetry.RateLimits, incoming *telemetry.RateLimi
 	if current != nil && current.GitHubREST != nil && merged.GitHubREST == nil {
 		merged.GitHubREST = cloneRateLimitBucket(current.GitHubREST)
 	}
-	if current != nil && len(current.GitHubRESTBudgets) > 0 && len(merged.GitHubRESTBudgets) == 0 {
-		merged.GitHubRESTBudgets = cloneRESTBudgets(current.GitHubRESTBudgets)
+	if current != nil {
+		merged.GitHubRESTBudgets = mergeRESTBudgets(current.GitHubRESTBudgets, merged.GitHubRESTBudgets)
 	}
 	if current != nil && current.RESTUsage != nil && merged.RESTUsage == nil {
 		merged.RESTUsage = cloneRESTUsage(current.RESTUsage)
@@ -790,16 +792,55 @@ func cloneRESTBudgets(budgets []telemetry.RESTBudget) []telemetry.RESTBudget {
 	}
 	cloned := append([]telemetry.RESTBudget(nil), budgets...)
 	for index := range cloned {
-		if budgets[index].ResetAt != nil {
-			resetAt := *budgets[index].ResetAt
-			cloned[index].ResetAt = &resetAt
-		}
-		if budgets[index].ObservedAt != nil {
-			observedAt := *budgets[index].ObservedAt
-			cloned[index].ObservedAt = &observedAt
-		}
+		cloned[index] = cloneRESTBudget(budgets[index])
 	}
 	return cloned
+}
+
+func cloneRESTBudget(budget telemetry.RESTBudget) telemetry.RESTBudget {
+	if budget.ResetAt != nil {
+		resetAt := *budget.ResetAt
+		budget.ResetAt = &resetAt
+	}
+	if budget.ObservedAt != nil {
+		observedAt := *budget.ObservedAt
+		budget.ObservedAt = &observedAt
+	}
+	return budget
+}
+
+func mergeRESTBudgets(current []telemetry.RESTBudget, incoming []telemetry.RESTBudget) []telemetry.RESTBudget {
+	if len(current) == 0 {
+		return cloneRESTBudgets(incoming)
+	}
+	if len(incoming) == 0 {
+		return cloneRESTBudgets(current)
+	}
+	merged := make(map[string]telemetry.RESTBudget, len(current)+len(incoming))
+	for _, budget := range append(append([]telemetry.RESTBudget(nil), current...), incoming...) {
+		consumer := strings.TrimSpace(budget.Consumer)
+		if consumer == "" {
+			consumer = telemetry.RESTConsumerOrchestrator
+		}
+		key := consumer + "\x00" + strings.TrimSpace(budget.CredentialIdentity) + "\x00" + strings.TrimSpace(budget.EndpointFamily) + "\x00" + strings.TrimSpace(budget.Resource)
+		merged[key] = cloneRESTBudget(budget)
+	}
+	out := make([]telemetry.RESTBudget, 0, len(merged))
+	for _, budget := range merged {
+		out = append(out, budget)
+	}
+	sort.Slice(out, func(i, j int) bool {
+		return restBudgetStateKey(out[i]) < restBudgetStateKey(out[j])
+	})
+	return out
+}
+
+func restBudgetStateKey(budget telemetry.RESTBudget) string {
+	consumer := strings.TrimSpace(budget.Consumer)
+	if consumer == "" {
+		consumer = telemetry.RESTConsumerOrchestrator
+	}
+	return consumer + "\x00" + strings.TrimSpace(budget.CredentialIdentity) + "\x00" + strings.TrimSpace(budget.EndpointFamily) + "\x00" + strings.TrimSpace(budget.Resource)
 }
 
 func cloneTelemetryWorkAttempts(values []telemetry.WorkAttempt) []telemetry.WorkAttempt {

--- a/internal/runner/agent.go
+++ b/internal/runner/agent.go
@@ -10,6 +10,7 @@ import (
 	"log/slog"
 	"maps"
 	"math"
+	"os"
 	"strconv"
 	"strings"
 	"sync"
@@ -112,6 +113,7 @@ type Dependencies struct {
 	sessionLimit        durationLimitContextFactory
 	turnLimit           durationLimitContextFactory
 	progressTicker      sessionProgressTickerFactory
+	lookupEnv           func(string) string
 }
 
 type Runner struct {
@@ -135,6 +137,7 @@ type Runner struct {
 	turnLimit           durationLimitContextFactory
 	progressTicker      sessionProgressTickerFactory
 	admissionLeaks      admissionWorkspaceLeakTracker
+	lookupEnv           func(string) string
 }
 
 func NewRunner(deps Dependencies) (*Runner, error) {
@@ -158,6 +161,9 @@ func NewRunner(deps Dependencies) (*Runner, error) {
 	}
 	if deps.progressTicker == nil {
 		deps.progressTicker = newSessionProgressTicker
+	}
+	if deps.lookupEnv == nil {
+		deps.lookupEnv = os.Getenv
 	}
 	projectID := strings.TrimSpace(deps.ProjectID)
 	if projectID == "" {
@@ -204,6 +210,7 @@ func NewRunner(deps Dependencies) (*Runner, error) {
 		sessionLimit:        deps.sessionLimit,
 		turnLimit:           deps.turnLimit,
 		progressTicker:      deps.progressTicker,
+		lookupEnv:           deps.lookupEnv,
 	}, nil
 }
 
@@ -707,26 +714,34 @@ func runAgentBackendTurnWithToolsUsingLimit(
 		defer cancel()
 
 		var boundedUpdateHandler AgentUpdateHandler
+		var updateMu sync.Mutex
 		if onUpdate != nil {
 			boundedUpdateHandler = func(update AgentUpdate) error {
+				updateMu.Lock()
+				defer updateMu.Unlock()
 				return onUpdate(turnCtx, update)
 			}
 		}
+		governedCtx, stopGovernor, err := startWorkerGitHubGovernor(turnCtx, request.workerGitHub, boundedUpdateHandler)
+		if err != nil {
+			return AgentTurnResult{}, err
+		}
 		var result AgentTurnResult
-		var err error
+		var runErr error
 		if len(tools) > 0 {
 			if toolBackend, ok := backend.(AgentToolBackend); ok {
-				result, err = toolBackend.RunTurnWithTools(turnCtx, request, tools, toolHandler, boundedUpdateHandler)
+				result, runErr = toolBackend.RunTurnWithTools(governedCtx, request, tools, toolHandler, boundedUpdateHandler)
 			} else {
-				result, err = backend.RunTurn(turnCtx, request, boundedUpdateHandler)
+				result, runErr = backend.RunTurn(governedCtx, request, boundedUpdateHandler)
 			}
 		} else {
-			result, err = backend.RunTurn(turnCtx, request, boundedUpdateHandler)
+			result, runErr = backend.RunTurn(governedCtx, request, boundedUpdateHandler)
 		}
+		runErr = errors.Join(runErr, stopGovernor())
 		if cause := context.Cause(turnCtx); errors.Is(cause, ErrTurnDurationExceeded) {
-			return result, errors.Join(cause, err)
+			return result, errors.Join(cause, runErr)
 		}
-		return result, err
+		return result, runErr
 	}
 	workspacePath := strings.TrimSpace(request.Workspace)
 	if workspacePath == "" {
@@ -743,6 +758,10 @@ func runAgentBackendTurnWithToolsUsingLimit(
 		return AgentTurnResult{}, fmt.Errorf("prepare worker scratch: %w", err), nil
 	}
 	request.TempDir = tempDir
+	if err := configureWorkerGitHubEnvironment(&request); err != nil {
+		cleanupErr := workspace.CleanupWorkerScratch(workspacePath)
+		return AgentTurnResult{}, fmt.Errorf("prepare worker github environment: %w", err), cleanupErr
+	}
 	if err := configureWorkerCache(&request); err != nil {
 		cleanupErr := workspace.CleanupWorkerScratch(workspacePath)
 		return AgentTurnResult{}, fmt.Errorf("prepare worker cache: %w", err), cleanupErr
@@ -1000,6 +1019,11 @@ func (r *Runner) Run(ctx context.Context, req RunRequest) (RunResult, error) {
 			Output:     RunOutputMergeFastPathCheckedHead,
 		}, nil
 	}
+	workerGitHub, err := r.workerGitHubPolicy(workflow.Config, req.Issue.Identifier)
+	if err != nil {
+		r.logWorkerEvent(req.Issue, "worker_github_credential_refused", "error", err)
+		return RunResult{}, err
+	}
 
 	runWorkspace := r.workspace
 	if req.Admission != nil {
@@ -1232,6 +1256,8 @@ func (r *Runner) Run(ctx context.Context, req RunRequest) (RunResult, error) {
 		"work_attempt_id", req.WorkAttemptID,
 		"detent_session_id", sessionID,
 		"mode", mode,
+		"github_credential_policy", workerGitHubPolicyName(workerGitHub),
+		"github_credential_identity", workerGitHub.CredentialIdentity,
 	}
 	commandStartedAttrs = append(commandStartedAttrs, runtimeIdentityLogAttrs(runtimeIdentity)...)
 	r.logWorkerEvent(req.Issue, "worker_command_started", commandStartedAttrs...)
@@ -1257,6 +1283,7 @@ func (r *Runner) Run(ctx context.Context, req RunRequest) (RunResult, error) {
 		ExtraWritableRoots: extraWritableRoots,
 		cacheStrategy:      workflow.Config.Workspace.CacheStrategy,
 		projectID:          r.projectID,
+		workerGitHub:       workerGitHub,
 	}
 	if mode == RunModeRoutine {
 		turnRequest.ToolInstructions = routineToolInstructions
@@ -1488,6 +1515,11 @@ func (r *Runner) Validate(ctx context.Context, req ValidatorRequest) (gate.Valid
 		ctx = context.Background()
 	}
 	workflow, agentRuntime, _, _ := r.runtimeSnapshot()
+	workerGitHub, err := r.workerGitHubPolicy(workflow.Config, req.Issue.Identifier)
+	if err != nil {
+		r.logWorkerEvent(req.Issue, "worker_github_credential_refused", "error", err)
+		return gate.ValidatorResult{}, err
+	}
 
 	workspaceIssue := workspaceIssue(r.projectID, req.Issue)
 	r.logWorkerEvent(req.Issue, "worker_check_workspace_create_started")
@@ -1574,6 +1606,8 @@ func (r *Runner) Validate(ctx context.Context, req ValidatorRequest) (gate.Valid
 	checkStartedAttrs := []any{
 		"workspace_path", info.Path,
 		"detent_session_id", sessionID,
+		"github_credential_policy", workerGitHubPolicyName(workerGitHub),
+		"github_credential_identity", workerGitHub.CredentialIdentity,
 	}
 	checkStartedAttrs = append(checkStartedAttrs, runtimeIdentityLogAttrs(runtimeIdentity)...)
 	r.logWorkerEvent(req.Issue, "worker_check_started", checkStartedAttrs...)
@@ -1600,6 +1634,7 @@ func (r *Runner) Validate(ctx context.Context, req ValidatorRequest) (gate.Valid
 		ExtraWritableRoots: extraWritableRootsForWorkspace(sessionCtx, info.Path, r.logger),
 		cacheStrategy:      workflow.Config.Workspace.CacheStrategy,
 		projectID:          r.projectID,
+		workerGitHub:       workerGitHub,
 	}, nil, nil, func(updateCtx context.Context, update AgentUpdate) error {
 		eventAt := r.now()
 		if update.Type == AgentUpdateTokenUsage {
@@ -2412,7 +2447,7 @@ func applyAgentUpdate(result *RunResult, update AgentUpdate) {
 		result.Tokens.Last = cloneAgentTokenCounts(update.Tokens.Last)
 		result.Tokens.ModelContextWindow = update.Tokens.ModelContextWindow
 	case AgentUpdateRateLimits:
-		result.RateLimits = update.RateLimits
+		result.RateLimits = mergeAgentRateLimits(result.RateLimits, update.RateLimits)
 	}
 }
 

--- a/internal/runner/types.go
+++ b/internal/runner/types.go
@@ -170,6 +170,7 @@ type AgentTurnRequest struct {
 	Environment        procgroup.Environment
 	cacheStrategy      string
 	projectID          string
+	workerGitHub       workerGitHubPolicy
 }
 
 type AgentResume struct {

--- a/internal/runner/worker_github.go
+++ b/internal/runner/worker_github.go
@@ -1,0 +1,481 @@
+package runner
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/url"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/digitaldrywood/detent/internal/config"
+	"github.com/digitaldrywood/detent/internal/telemetry"
+)
+
+const workerGitHubRateLimitBodyMaxBytes = 64 * 1024
+
+var (
+	ErrWorkerGitHubCredentialShared = errors.New("worker github credential shares the orchestrator credential")
+	ErrWorkerGitHubRESTReserved     = errors.New("worker github REST budget reached reserved headroom")
+	ErrWorkerGitHubBudgetMonitor    = errors.New("worker github REST budget monitor failed")
+	workerGitHubEnvNamePattern      = regexp.MustCompile(`^[A-Za-z_][A-Za-z0-9_]*$`)
+)
+
+type workerGitHubHTTPClient interface {
+	Do(*http.Request) (*http.Response, error)
+}
+
+type workerGitHubPolicy struct {
+	Enabled            bool
+	Token              string
+	OrchestratorToken  string
+	CredentialIdentity string
+	RateLimitURL       string
+	GraphQLURL         string
+	MinRemaining       int64
+	PollInterval       time.Duration
+	HTTPClient         workerGitHubHTTPClient
+	Poll               <-chan time.Time
+	Logger             *slog.Logger
+	ProjectID          string
+	IssueIdentifier    string
+}
+
+type workerGitHubBudget struct {
+	Limit      int64
+	Used       int64
+	Remaining  int64
+	ResetAt    time.Time
+	ObservedAt time.Time
+}
+
+func (r *Runner) workerGitHubPolicy(cfg config.Config, issueIdentifier string) (workerGitHubPolicy, error) {
+	return newWorkerGitHubPolicy(cfg, r.projectID, issueIdentifier, r.lookupEnv, nil, r.logger)
+}
+
+func workerGitHubPolicyName(policy workerGitHubPolicy) string {
+	if policy.Enabled {
+		return "dedicated"
+	}
+	return "isolated_disabled"
+}
+
+func mergeAgentRateLimits(current *telemetry.RateLimits, incoming *telemetry.RateLimits) *telemetry.RateLimits {
+	if incoming == nil {
+		return current
+	}
+	if current == nil {
+		cloned := *incoming
+		cloned.GitHubRESTBudgets = mergeAgentRESTBudgets(nil, incoming.GitHubRESTBudgets)
+		return &cloned
+	}
+	merged := *current
+	if incoming.LimitID != "" {
+		merged.LimitID = incoming.LimitID
+	}
+	if incoming.LimitName != "" {
+		merged.LimitName = incoming.LimitName
+	}
+	if incoming.ReachedType != "" {
+		merged.ReachedType = incoming.ReachedType
+	}
+	if incoming.Primary != nil {
+		merged.Primary = incoming.Primary
+	}
+	if incoming.Secondary != nil {
+		merged.Secondary = incoming.Secondary
+	}
+	if incoming.Credits != nil {
+		merged.Credits = incoming.Credits
+	}
+	if incoming.GitHubGraphQL != nil {
+		merged.GitHubGraphQL = incoming.GitHubGraphQL
+	}
+	if incoming.GitHubREST != nil {
+		merged.GitHubREST = incoming.GitHubREST
+	}
+	merged.GitHubRESTBudgets = mergeAgentRESTBudgets(current.GitHubRESTBudgets, incoming.GitHubRESTBudgets)
+	if incoming.GraphQLCost != nil {
+		merged.GraphQLCost = incoming.GraphQLCost
+	}
+	if incoming.RESTUsage != nil {
+		merged.RESTUsage = incoming.RESTUsage
+	}
+	return &merged
+}
+
+func mergeAgentRESTBudgets(current []telemetry.RESTBudget, incoming []telemetry.RESTBudget) []telemetry.RESTBudget {
+	budgets := make(map[string]telemetry.RESTBudget, len(current)+len(incoming))
+	for _, budget := range append(append([]telemetry.RESTBudget(nil), current...), incoming...) {
+		consumer := strings.TrimSpace(budget.Consumer)
+		if consumer == "" {
+			consumer = telemetry.RESTConsumerOrchestrator
+		}
+		key := consumer + "\x00" + strings.TrimSpace(budget.CredentialIdentity) + "\x00" + strings.TrimSpace(budget.EndpointFamily) + "\x00" + strings.TrimSpace(budget.Resource)
+		existing, ok := budgets[key]
+		if !ok || budget.ObservedAt == nil || existing.ObservedAt == nil || !budget.ObservedAt.Before(*existing.ObservedAt) {
+			budgets[key] = budget
+		}
+	}
+	out := make([]telemetry.RESTBudget, 0, len(budgets))
+	for _, budget := range budgets {
+		out = append(out, budget)
+	}
+	sort.Slice(out, func(i, j int) bool {
+		left := strings.TrimSpace(out[i].Consumer) + "\x00" + out[i].CredentialIdentity + "\x00" + out[i].EndpointFamily
+		right := strings.TrimSpace(out[j].Consumer) + "\x00" + out[j].CredentialIdentity + "\x00" + out[j].EndpointFamily
+		return left < right
+	})
+	return out
+}
+
+func newWorkerGitHubPolicy(cfg config.Config, projectID string, issueIdentifier string, lookupEnv func(string) string, httpClient workerGitHubHTTPClient, logger *slog.Logger) (workerGitHubPolicy, error) {
+	if lookupEnv == nil {
+		lookupEnv = os.Getenv
+	}
+	if httpClient == nil {
+		httpClient = http.DefaultClient
+	}
+	if logger == nil {
+		logger = slog.New(slog.NewTextHandler(io.Discard, nil))
+	}
+
+	rawWorkerToken := strings.TrimSpace(cfg.Worker.GitHubToken)
+	if rawWorkerToken == "" {
+		return workerGitHubPolicy{
+			MinRemaining:    int64(cfg.Worker.GitHubRESTMinReserve),
+			PollInterval:    time.Duration(cfg.Worker.GitHubRESTPollIntervalMS) * time.Millisecond,
+			HTTPClient:      httpClient,
+			Logger:          logger,
+			ProjectID:       strings.TrimSpace(projectID),
+			IssueIdentifier: strings.TrimSpace(issueIdentifier),
+		}, nil
+	}
+
+	workerToken, err := resolveWorkerGitHubSecret(rawWorkerToken, lookupEnv)
+	if err != nil {
+		return workerGitHubPolicy{}, err
+	}
+	orchestratorToken, err := resolveWorkerGitHubSecret(strings.TrimSpace(cfg.Tracker.APIKey), lookupEnv)
+	if err != nil {
+		return workerGitHubPolicy{}, fmt.Errorf("resolve orchestrator github credential for worker isolation: %w", err)
+	}
+	if orchestratorToken == "" {
+		orchestratorToken = strings.TrimSpace(lookupEnv("GITHUB_TOKEN"))
+	}
+	if orchestratorToken != "" && workerToken == orchestratorToken {
+		return workerGitHubPolicy{}, ErrWorkerGitHubCredentialShared
+	}
+
+	rateLimitURL, graphQLURL, endpointIdentity, err := workerGitHubEndpoints(cfg.Tracker.Endpoint)
+	if err != nil {
+		return workerGitHubPolicy{}, err
+	}
+	sum := sha256.Sum256([]byte(endpointIdentity + "\x00" + workerToken))
+	return workerGitHubPolicy{
+		Enabled:            true,
+		Token:              workerToken,
+		OrchestratorToken:  orchestratorToken,
+		CredentialIdentity: fmt.Sprintf("github-rest:%x", sum[:6]),
+		RateLimitURL:       rateLimitURL,
+		GraphQLURL:         graphQLURL,
+		MinRemaining:       int64(cfg.Worker.GitHubRESTMinReserve),
+		PollInterval:       time.Duration(cfg.Worker.GitHubRESTPollIntervalMS) * time.Millisecond,
+		HTTPClient:         httpClient,
+		Logger:             logger,
+		ProjectID:          strings.TrimSpace(projectID),
+		IssueIdentifier:    strings.TrimSpace(issueIdentifier),
+	}, nil
+}
+
+func resolveWorkerGitHubSecret(value string, lookupEnv func(string) string) (string, error) {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return "", nil
+	}
+	name, referenced := strings.CutPrefix(value, "$")
+	if !referenced || !workerGitHubEnvNamePattern.MatchString(name) {
+		return value, nil
+	}
+	resolved := strings.TrimSpace(lookupEnv(name))
+	if resolved == "" {
+		return "", fmt.Errorf("worker github credential environment variable %s is empty", name)
+	}
+	return resolved, nil
+}
+
+func workerGitHubEndpoints(graphQLEndpoint string) (string, string, string, error) {
+	graphQLEndpoint = strings.TrimSpace(graphQLEndpoint)
+	if graphQLEndpoint == "" {
+		graphQLEndpoint = "https://api.github.com/graphql"
+	}
+	parsed, err := url.Parse(graphQLEndpoint)
+	if err != nil || parsed.Scheme == "" || parsed.Host == "" {
+		return "", "", "", fmt.Errorf("invalid worker github endpoint %q", graphQLEndpoint)
+	}
+	parsed.RawQuery = ""
+	parsed.Fragment = ""
+	graphQLURL := parsed.String()
+	parsed.Path = strings.TrimSuffix(strings.TrimRight(parsed.Path, "/"), "/graphql")
+	endpointIdentity := strings.TrimRight(parsed.String(), "/")
+	parsed.Path += "/rate_limit"
+	rateLimitURL := parsed.String()
+	return rateLimitURL, graphQLURL, endpointIdentity, nil
+}
+
+func configureWorkerGitHubEnvironment(request *AgentTurnRequest) error {
+	if request == nil || strings.TrimSpace(request.TempDir) == "" {
+		return nil
+	}
+	configDir := filepath.Join(request.TempDir, "github-cli")
+	if err := os.MkdirAll(configDir, 0o700); err != nil {
+		return fmt.Errorf("create worker github config directory: %w", err)
+	}
+	variables := make(map[string]string, len(request.Environment.Variables)+5)
+	for key, value := range request.Environment.Variables {
+		variables[key] = value
+	}
+	variables["GH_CONFIG_DIR"] = configDir
+	variables["GH_TOKEN"] = request.workerGitHub.Token
+	variables["GITHUB_TOKEN"] = request.workerGitHub.Token
+	variables["GH_ENTERPRISE_TOKEN"] = request.workerGitHub.Token
+	variables["GITHUB_ENTERPRISE_TOKEN"] = request.workerGitHub.Token
+	request.Environment.Variables = variables
+	return nil
+}
+
+func startWorkerGitHubGovernor(ctx context.Context, policy workerGitHubPolicy, onUpdate AgentUpdateHandler) (context.Context, func() error, error) {
+	if !policy.Enabled {
+		return ctx, func() error { return nil }, nil
+	}
+	if err := policy.verifyDistinctPrincipal(ctx); err != nil {
+		return ctx, func() error { return nil }, err
+	}
+	budget, err := policy.probe(ctx)
+	if err != nil {
+		return ctx, func() error { return nil }, fmt.Errorf("%w: %w", ErrWorkerGitHubBudgetMonitor, err)
+	}
+	if err := policy.observe(budget, onUpdate); err != nil {
+		return ctx, func() error { return nil }, err
+	}
+	if err := policy.reserveError(budget); err != nil {
+		return ctx, func() error { return nil }, err
+	}
+
+	governedCtx, cancel := context.WithCancelCause(ctx)
+	done := make(chan struct{})
+	pollInterval := policy.PollInterval
+	if pollInterval <= 0 {
+		pollInterval = time.Minute
+	}
+	poll := policy.Poll
+	stopPoll := func() {}
+	if poll == nil {
+		ticker := time.NewTicker(pollInterval)
+		poll = ticker.C
+		stopPoll = ticker.Stop
+	}
+	go func() {
+		defer close(done)
+		defer stopPoll()
+		for {
+			select {
+			case <-governedCtx.Done():
+				return
+			case <-poll:
+				budget, probeErr := policy.probe(governedCtx)
+				if probeErr != nil {
+					cancel(fmt.Errorf("%w: %w", ErrWorkerGitHubBudgetMonitor, probeErr))
+					return
+				}
+				if observeErr := policy.observe(budget, onUpdate); observeErr != nil {
+					cancel(fmt.Errorf("%w: publish worker github budget: %w", ErrWorkerGitHubBudgetMonitor, observeErr))
+					return
+				}
+				if reserveErr := policy.reserveError(budget); reserveErr != nil {
+					cancel(reserveErr)
+					return
+				}
+			}
+		}
+	}()
+
+	stop := func() error {
+		cause := context.Cause(governedCtx)
+		cancel(context.Canceled)
+		<-done
+		if errors.Is(cause, ErrWorkerGitHubRESTReserved) || errors.Is(cause, ErrWorkerGitHubBudgetMonitor) {
+			return cause
+		}
+		return nil
+	}
+	return governedCtx, stop, nil
+}
+
+func (p workerGitHubPolicy) verifyDistinctPrincipal(ctx context.Context) error {
+	workerID, err := p.authenticatedUserID(ctx, p.Token)
+	if err != nil {
+		return fmt.Errorf("%w: verify worker credential principal: %w", ErrWorkerGitHubBudgetMonitor, err)
+	}
+	if strings.TrimSpace(p.OrchestratorToken) == "" {
+		return nil
+	}
+	orchestratorID, err := p.authenticatedUserID(ctx, p.OrchestratorToken)
+	if err != nil {
+		return fmt.Errorf("%w: verify orchestrator credential principal: %w", ErrWorkerGitHubBudgetMonitor, err)
+	}
+	if workerID == orchestratorID {
+		return ErrWorkerGitHubCredentialShared
+	}
+	return nil
+}
+
+func (p workerGitHubPolicy) authenticatedUserID(ctx context.Context, token string) (int64, error) {
+	body := bytes.NewBufferString(`{"query":"query WorkerCredentialIdentity { viewer { databaseId } }"}`)
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, p.GraphQLURL, body)
+	if err != nil {
+		return 0, err
+	}
+	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("Accept", "application/vnd.github+json")
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-GitHub-Api-Version", "2026-03-10")
+	req.Header.Set("User-Agent", "detent-worker-github-governor")
+	resp, err := p.HTTPClient.Do(req)
+	if err != nil {
+		return 0, err
+	}
+	defer resp.Body.Close()
+	raw, err := io.ReadAll(io.LimitReader(resp.Body, workerGitHubRateLimitBodyMaxBytes))
+	if err != nil {
+		return 0, err
+	}
+	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
+		return 0, fmt.Errorf("github authenticated user graphql probe returned HTTP %d", resp.StatusCode)
+	}
+	var payload struct {
+		Data struct {
+			Viewer struct {
+				DatabaseID int64 `json:"databaseId"`
+			} `json:"viewer"`
+		} `json:"data"`
+		Errors []json.RawMessage `json:"errors"`
+	}
+	if err := json.Unmarshal(raw, &payload); err != nil {
+		return 0, fmt.Errorf("decode github authenticated user graphql probe: %w", err)
+	}
+	if len(payload.Errors) > 0 || payload.Data.Viewer.DatabaseID <= 0 {
+		return 0, errors.New("github authenticated user graphql probe omitted the user id")
+	}
+	return payload.Data.Viewer.DatabaseID, nil
+}
+
+func (p workerGitHubPolicy) probe(ctx context.Context) (workerGitHubBudget, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, p.RateLimitURL, nil)
+	if err != nil {
+		return workerGitHubBudget{}, err
+	}
+	req.Header.Set("Authorization", "Bearer "+p.Token)
+	req.Header.Set("Accept", "application/vnd.github+json")
+	req.Header.Set("X-GitHub-Api-Version", "2026-03-10")
+	req.Header.Set("User-Agent", "detent-worker-github-governor")
+	resp, err := p.HTTPClient.Do(req)
+	if err != nil {
+		return workerGitHubBudget{}, err
+	}
+	defer resp.Body.Close()
+	raw, err := io.ReadAll(io.LimitReader(resp.Body, workerGitHubRateLimitBodyMaxBytes))
+	if err != nil {
+		return workerGitHubBudget{}, err
+	}
+	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
+		return workerGitHubBudget{}, fmt.Errorf("github rate limit probe returned HTTP %d", resp.StatusCode)
+	}
+	var payload struct {
+		Resources struct {
+			Core struct {
+				Limit     int64 `json:"limit"`
+				Used      int64 `json:"used"`
+				Remaining int64 `json:"remaining"`
+				Reset     int64 `json:"reset"`
+			} `json:"core"`
+		} `json:"resources"`
+	}
+	if err := json.Unmarshal(raw, &payload); err != nil {
+		return workerGitHubBudget{}, fmt.Errorf("decode github rate limit probe: %w", err)
+	}
+	if payload.Resources.Core.Limit <= 0 {
+		return workerGitHubBudget{}, errors.New("github rate limit probe omitted the core budget")
+	}
+	return workerGitHubBudget{
+		Limit:      payload.Resources.Core.Limit,
+		Used:       payload.Resources.Core.Used,
+		Remaining:  payload.Resources.Core.Remaining,
+		ResetAt:    time.Unix(payload.Resources.Core.Reset, 0).UTC(),
+		ObservedAt: time.Now().UTC(),
+	}, nil
+}
+
+func (p workerGitHubPolicy) observe(budget workerGitHubBudget, onUpdate AgentUpdateHandler) error {
+	p.Logger.Info(
+		"github rest budget summary",
+		"consumer", telemetry.RESTConsumerWorker,
+		"project_id", p.ProjectID,
+		"issue_identifier", p.IssueIdentifier,
+		"credential_identity", p.CredentialIdentity,
+		"remaining", budget.Remaining,
+		"used", budget.Used,
+		"limit", budget.Limit,
+		"reserve", p.MinRemaining,
+		"reset_at", budget.ResetAt,
+	)
+	if onUpdate == nil {
+		return nil
+	}
+	resetAt := budget.ResetAt
+	observedAt := budget.ObservedAt
+	return onUpdate(AgentUpdate{
+		Type: AgentUpdateRateLimits,
+		RateLimits: &telemetry.RateLimits{GitHubRESTBudgets: []telemetry.RESTBudget{{
+			Consumer:            telemetry.RESTConsumerWorker,
+			CredentialIdentity:  p.CredentialIdentity,
+			EndpointFamily:      "worker credential",
+			Resource:            "core",
+			Remaining:           budget.Remaining,
+			Used:                budget.Used,
+			Limit:               budget.Limit,
+			MinRemainingReserve: p.MinRemaining,
+			ResetAt:             &resetAt,
+			ObservedAt:          &observedAt,
+		}}},
+	})
+}
+
+func (p workerGitHubPolicy) reserveError(budget workerGitHubBudget) error {
+	if p.MinRemaining <= 0 || budget.Remaining > p.MinRemaining {
+		return nil
+	}
+	p.Logger.Warn(
+		"worker github rest budget reached reserved headroom",
+		"consumer", telemetry.RESTConsumerWorker,
+		"project_id", p.ProjectID,
+		"issue_identifier", p.IssueIdentifier,
+		"credential_identity", p.CredentialIdentity,
+		"remaining", budget.Remaining,
+		"orchestrator_reserved_headroom", p.MinRemaining,
+		"limit", budget.Limit,
+		"reset_at", budget.ResetAt,
+	)
+	return fmt.Errorf("%w: remaining=%s reserve=%s reset_at=%s", ErrWorkerGitHubRESTReserved, strconv.FormatInt(budget.Remaining, 10), strconv.FormatInt(p.MinRemaining, 10), budget.ResetAt.Format(time.RFC3339))
+}

--- a/internal/runner/worker_github.go
+++ b/internal/runner/worker_github.go
@@ -23,7 +23,10 @@ import (
 	"github.com/digitaldrywood/detent/internal/telemetry"
 )
 
-const workerGitHubRateLimitBodyMaxBytes = 64 * 1024
+const (
+	workerGitHubRateLimitBodyMaxBytes = 64 * 1024
+	workerGitHubProbeTimeout          = 10 * time.Second
+)
 
 var (
 	ErrWorkerGitHubCredentialShared = errors.New("worker github credential shares the orchestrator credential")
@@ -36,6 +39,8 @@ type workerGitHubHTTPClient interface {
 	Do(*http.Request) (*http.Response, error)
 }
 
+type workerGitHubProbeContextFactory func(context.Context) (context.Context, context.CancelFunc)
+
 type workerGitHubPolicy struct {
 	Enabled            bool
 	Token              string
@@ -46,6 +51,7 @@ type workerGitHubPolicy struct {
 	MinRemaining       int64
 	PollInterval       time.Duration
 	HTTPClient         workerGitHubHTTPClient
+	ProbeContext       workerGitHubProbeContextFactory
 	Poll               <-chan time.Time
 	Logger             *slog.Logger
 	ProjectID          string
@@ -167,18 +173,21 @@ func newWorkerGitHubPolicy(cfg config.Config, projectID string, issueIdentifier 
 	if err != nil {
 		return workerGitHubPolicy{}, err
 	}
-	orchestratorToken, err := resolveWorkerGitHubSecret(strings.TrimSpace(cfg.Tracker.APIKey), lookupEnv)
+	graphQLEndpoint := ""
+	orchestratorCredential := ""
+	if cfg.Tracker.Kind == config.TrackerGitHub || cfg.Tracker.Kind == config.TrackerGitHubLocal {
+		graphQLEndpoint = cfg.Tracker.Endpoint
+		orchestratorCredential = cfg.Tracker.APIKey
+	}
+	orchestratorToken, err := resolveWorkerGitHubSecret(strings.TrimSpace(orchestratorCredential), lookupEnv)
 	if err != nil {
 		return workerGitHubPolicy{}, fmt.Errorf("resolve orchestrator github credential for worker isolation: %w", err)
-	}
-	if orchestratorToken == "" {
-		orchestratorToken = strings.TrimSpace(lookupEnv("GITHUB_TOKEN"))
 	}
 	if orchestratorToken != "" && workerToken == orchestratorToken {
 		return workerGitHubPolicy{}, ErrWorkerGitHubCredentialShared
 	}
 
-	rateLimitURL, graphQLURL, endpointIdentity, err := workerGitHubEndpoints(cfg.Tracker.Endpoint)
+	rateLimitURL, graphQLURL, endpointIdentity, err := workerGitHubEndpoints(graphQLEndpoint)
 	if err != nil {
 		return workerGitHubPolicy{}, err
 	}
@@ -193,10 +202,15 @@ func newWorkerGitHubPolicy(cfg config.Config, projectID string, issueIdentifier 
 		MinRemaining:       int64(cfg.Worker.GitHubRESTMinReserve),
 		PollInterval:       time.Duration(cfg.Worker.GitHubRESTPollIntervalMS) * time.Millisecond,
 		HTTPClient:         httpClient,
+		ProbeContext:       withWorkerGitHubProbeTimeout,
 		Logger:             logger,
 		ProjectID:          strings.TrimSpace(projectID),
 		IssueIdentifier:    strings.TrimSpace(issueIdentifier),
 	}, nil
+}
+
+func withWorkerGitHubProbeTimeout(ctx context.Context) (context.Context, context.CancelFunc) {
+	return context.WithTimeout(ctx, workerGitHubProbeTimeout)
 }
 
 func resolveWorkerGitHubSecret(value string, lookupEnv func(string) string) (string, error) {
@@ -342,6 +356,8 @@ func (p workerGitHubPolicy) verifyDistinctPrincipal(ctx context.Context) error {
 }
 
 func (p workerGitHubPolicy) authenticatedUserID(ctx context.Context, token string) (int64, error) {
+	ctx, cancel := p.probeContext(ctx)
+	defer cancel()
 	body := bytes.NewBufferString(`{"query":"query WorkerCredentialIdentity { viewer { databaseId } }"}`)
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, p.GraphQLURL, body)
 	if err != nil {
@@ -382,6 +398,8 @@ func (p workerGitHubPolicy) authenticatedUserID(ctx context.Context, token strin
 }
 
 func (p workerGitHubPolicy) probe(ctx context.Context) (workerGitHubBudget, error) {
+	ctx, cancel := p.probeContext(ctx)
+	defer cancel()
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, p.RateLimitURL, nil)
 	if err != nil {
 		return workerGitHubBudget{}, err
@@ -425,6 +443,13 @@ func (p workerGitHubPolicy) probe(ctx context.Context) (workerGitHubBudget, erro
 		ResetAt:    time.Unix(payload.Resources.Core.Reset, 0).UTC(),
 		ObservedAt: time.Now().UTC(),
 	}, nil
+}
+
+func (p workerGitHubPolicy) probeContext(ctx context.Context) (context.Context, context.CancelFunc) {
+	if p.ProbeContext != nil {
+		return p.ProbeContext(ctx)
+	}
+	return withWorkerGitHubProbeTimeout(ctx)
 }
 
 func (p workerGitHubPolicy) observe(budget workerGitHubBudget, onUpdate AgentUpdateHandler) error {

--- a/internal/runner/worker_github_test.go
+++ b/internal/runner/worker_github_test.go
@@ -1,0 +1,326 @@
+package runner
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/digitaldrywood/detent/internal/config"
+	"github.com/digitaldrywood/detent/internal/procgroup"
+	"github.com/digitaldrywood/detent/internal/telemetry"
+)
+
+func TestNewWorkerGitHubPolicy(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name              string
+		workerToken       string
+		orchestratorToken string
+		environment       map[string]string
+		wantEnabled       bool
+		wantErr           error
+		wantErrText       string
+	}{
+		{name: "disabled isolates ambient authentication"},
+		{name: "dedicated literal", workerToken: "worker-token", orchestratorToken: "orchestrator-token", wantEnabled: true},
+		{name: "dedicated environment reference", workerToken: "$WORKER_TOKEN", orchestratorToken: "orchestrator-token", environment: map[string]string{"WORKER_TOKEN": "worker-token"}, wantEnabled: true},
+		{name: "shared credential rejected", workerToken: "$WORKER_TOKEN", orchestratorToken: "shared-token", environment: map[string]string{"WORKER_TOKEN": "shared-token"}, wantErr: ErrWorkerGitHubCredentialShared},
+		{name: "missing referenced credential", workerToken: "$WORKER_TOKEN", orchestratorToken: "orchestrator-token", wantErrText: "WORKER_TOKEN is empty"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			cfg := config.Default()
+			cfg.Tracker.Endpoint = "https://api.github.com/graphql"
+			cfg.Tracker.APIKey = tt.orchestratorToken
+			cfg.Worker.GitHubToken = tt.workerToken
+			policy, err := newWorkerGitHubPolicy(cfg, "detent", "digitaldrywood/detent#1724", func(key string) string {
+				return tt.environment[key]
+			}, nil, nil)
+			if tt.wantErr != nil {
+				if !errors.Is(err, tt.wantErr) {
+					t.Fatalf("newWorkerGitHubPolicy() error = %v, want %v", err, tt.wantErr)
+				}
+				return
+			}
+			if tt.wantErrText != "" {
+				if err == nil || !strings.Contains(err.Error(), tt.wantErrText) {
+					t.Fatalf("newWorkerGitHubPolicy() error = %v, want containing %q", err, tt.wantErrText)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("newWorkerGitHubPolicy() error = %v", err)
+			}
+			if policy.Enabled != tt.wantEnabled {
+				t.Fatalf("Enabled = %t, want %t", policy.Enabled, tt.wantEnabled)
+			}
+			if tt.wantEnabled && (!strings.HasPrefix(policy.CredentialIdentity, "github-rest:") || policy.Token != "worker-token") {
+				t.Fatalf("policy = %#v, want redacted identity and resolved worker token", policy)
+			}
+		})
+	}
+}
+
+func TestConfigureWorkerGitHubEnvironment(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		token string
+	}{
+		{name: "disabled clears ambient tokens"},
+		{name: "dedicated token overrides ambient tokens", token: "worker-token"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			tempDir := t.TempDir()
+			request := AgentTurnRequest{
+				TempDir: tempDir,
+				Environment: procgroup.Environment{Variables: map[string]string{
+					"GH_TOKEN":                "ambient-gh",
+					"GITHUB_TOKEN":            "ambient-github",
+					"GH_ENTERPRISE_TOKEN":     "ambient-gh-enterprise",
+					"GITHUB_ENTERPRISE_TOKEN": "ambient-github-enterprise",
+					"EXISTING":                "value",
+				}},
+				workerGitHub: workerGitHubPolicy{Token: tt.token},
+			}
+			if err := configureWorkerGitHubEnvironment(&request); err != nil {
+				t.Fatalf("configureWorkerGitHubEnvironment() error = %v", err)
+			}
+			if request.Environment.Variables["GH_TOKEN"] != tt.token || request.Environment.Variables["GITHUB_TOKEN"] != tt.token {
+				t.Fatalf("token environment = %#v, want %q", request.Environment.Variables, tt.token)
+			}
+			if request.Environment.Variables["GH_ENTERPRISE_TOKEN"] != tt.token || request.Environment.Variables["GITHUB_ENTERPRISE_TOKEN"] != tt.token {
+				t.Fatalf("enterprise token environment = %#v, want %q", request.Environment.Variables, tt.token)
+			}
+			if request.Environment.Variables["EXISTING"] != "value" {
+				t.Fatalf("EXISTING = %q, want value", request.Environment.Variables["EXISTING"])
+			}
+			configDir := filepath.Join(tempDir, "github-cli")
+			if request.Environment.Variables["GH_CONFIG_DIR"] != configDir {
+				t.Fatalf("GH_CONFIG_DIR = %q, want %q", request.Environment.Variables["GH_CONFIG_DIR"], configDir)
+			}
+			if info, err := os.Stat(configDir); err != nil || !info.IsDir() {
+				t.Fatalf("worker github config directory = %v, %v", info, err)
+			}
+		})
+	}
+}
+
+func TestRunAgentBackendTurnAppliesWorkerGitHubPolicy(t *testing.T) {
+	t.Parallel()
+
+	server := workerGitHubRateLimitServer(t, func(int64) int64 { return 4200 })
+	t.Cleanup(server.Close)
+	tests := []struct {
+		name   string
+		policy workerGitHubPolicy
+		token  string
+	}{
+		{name: "disabled"},
+		{name: "dedicated", policy: workerGitHubTestPolicy(server, new(bytes.Buffer)), token: "worker-token"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			backend := &workerGitHubCaptureBackend{}
+			_, runErr, cleanupErr := runAgentBackendTurn(context.Background(), backend, AgentTurnRequest{
+				Workspace: t.TempDir(),
+				Environment: procgroup.Environment{Variables: map[string]string{
+					"GH_TOKEN":     "ambient-gh",
+					"GITHUB_TOKEN": "ambient-github",
+				}},
+				workerGitHub: tt.policy,
+			}, nil)
+			if runErr != nil || cleanupErr != nil {
+				t.Fatalf("runAgentBackendTurn() errors = %v, %v", runErr, cleanupErr)
+			}
+			variables := backend.request.Environment.Variables
+			if variables["GH_TOKEN"] != tt.token || variables["GITHUB_TOKEN"] != tt.token {
+				t.Fatalf("worker token environment = %#v, want %q", variables, tt.token)
+			}
+			if variables["GH_ENTERPRISE_TOKEN"] != tt.token || variables["GITHUB_ENTERPRISE_TOKEN"] != tt.token {
+				t.Fatalf("worker enterprise token environment = %#v, want %q", variables, tt.token)
+			}
+			if !strings.Contains(variables["GH_CONFIG_DIR"], filepath.Join(".detent", "tmp")) {
+				t.Fatalf("GH_CONFIG_DIR = %q, want isolated worker scratch", variables["GH_CONFIG_DIR"])
+			}
+		})
+	}
+}
+
+func TestWorkerGitHubGovernorPublishesAttributedBudget(t *testing.T) {
+	t.Parallel()
+
+	server := workerGitHubRateLimitServer(t, func(int64) int64 { return 4200 })
+	defer server.Close()
+	var logs bytes.Buffer
+	policy := workerGitHubTestPolicy(server, &logs)
+	var update AgentUpdate
+	governedCtx, stop, err := startWorkerGitHubGovernor(context.Background(), policy, func(got AgentUpdate) error {
+		update = got
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("startWorkerGitHubGovernor() error = %v", err)
+	}
+	if governedCtx == nil {
+		t.Fatal("governed context is nil")
+	}
+	if err := stop(); err != nil {
+		t.Fatalf("stop governor error = %v", err)
+	}
+	if update.RateLimits == nil || len(update.RateLimits.GitHubRESTBudgets) != 1 {
+		t.Fatalf("RateLimits = %#v, want worker budget", update.RateLimits)
+	}
+	budget := update.RateLimits.GitHubRESTBudgets[0]
+	if budget.Consumer != telemetry.RESTConsumerWorker || budget.Remaining != 4200 || budget.MinRemainingReserve != 1000 {
+		t.Fatalf("budget = %#v, want attributed governed worker budget", budget)
+	}
+	for _, want := range []string{"consumer=worker", "remaining=4200", "reserve=1000", "credential_identity=github-rest:"} {
+		if !strings.Contains(logs.String(), want) {
+			t.Fatalf("logs = %q, want containing %q", logs.String(), want)
+		}
+	}
+}
+
+func TestWorkerGitHubGovernorStopsAtReserve(t *testing.T) {
+	t.Parallel()
+
+	server := workerGitHubRateLimitServer(t, func(call int64) int64 {
+		if call == 1 {
+			return 1200
+		}
+		return 1000
+	})
+	defer server.Close()
+	var logs bytes.Buffer
+	poll := make(chan time.Time, 1)
+	policy := workerGitHubTestPolicy(server, &logs)
+	policy.Poll = poll
+	governedCtx, stop, err := startWorkerGitHubGovernor(context.Background(), policy, nil)
+	if err != nil {
+		t.Fatalf("startWorkerGitHubGovernor() error = %v", err)
+	}
+	poll <- time.Now()
+	<-governedCtx.Done()
+	if !errors.Is(context.Cause(governedCtx), ErrWorkerGitHubRESTReserved) {
+		t.Fatalf("context cause = %v, want ErrWorkerGitHubRESTReserved", context.Cause(governedCtx))
+	}
+	if err := stop(); !errors.Is(err, ErrWorkerGitHubRESTReserved) {
+		t.Fatalf("stop governor error = %v, want ErrWorkerGitHubRESTReserved", err)
+	}
+	if !strings.Contains(logs.String(), "orchestrator_reserved_headroom=1000") {
+		t.Fatalf("logs = %q, want reserved headroom warning", logs.String())
+	}
+}
+
+func TestWorkerGitHubGovernorRefusesLaunchAtReserve(t *testing.T) {
+	t.Parallel()
+
+	server := workerGitHubRateLimitServer(t, func(int64) int64 { return 1000 })
+	defer server.Close()
+	var logs bytes.Buffer
+	policy := workerGitHubTestPolicy(server, &logs)
+	_, _, err := startWorkerGitHubGovernor(context.Background(), policy, nil)
+	if !errors.Is(err, ErrWorkerGitHubRESTReserved) {
+		t.Fatalf("startWorkerGitHubGovernor() error = %v, want ErrWorkerGitHubRESTReserved", err)
+	}
+	if !strings.Contains(logs.String(), "orchestrator_reserved_headroom=1000") {
+		t.Fatalf("logs = %q, want reserved headroom warning", logs.String())
+	}
+}
+
+func TestWorkerGitHubGovernorRejectsTokensForSameUser(t *testing.T) {
+	t.Parallel()
+
+	server := workerGitHubRateLimitServer(t, func(int64) int64 { return 4200 })
+	defer server.Close()
+	policy := workerGitHubTestPolicy(server, new(bytes.Buffer))
+	policy.OrchestratorToken = "orchestrator-token"
+	_, _, err := startWorkerGitHubGovernor(context.Background(), policy, nil)
+	if !errors.Is(err, ErrWorkerGitHubCredentialShared) {
+		t.Fatalf("startWorkerGitHubGovernor() error = %v, want ErrWorkerGitHubCredentialShared", err)
+	}
+}
+
+func TestMergeAgentRateLimitsPreservesWorkerAndProviderBudgets(t *testing.T) {
+	t.Parallel()
+
+	worker := &telemetry.RateLimits{GitHubRESTBudgets: []telemetry.RESTBudget{{Consumer: telemetry.RESTConsumerWorker, CredentialIdentity: "worker", Remaining: 4000}}}
+	provider := &telemetry.RateLimits{LimitID: "codex", Primary: &telemetry.RateLimitBucket{Remaining: 50}}
+	merged := mergeAgentRateLimits(worker, provider)
+	if merged.LimitID != "codex" || merged.Primary == nil || merged.Primary.Remaining != 50 {
+		t.Fatalf("merged provider rate limits = %#v", merged)
+	}
+	if len(merged.GitHubRESTBudgets) != 1 || merged.GitHubRESTBudgets[0].Consumer != telemetry.RESTConsumerWorker {
+		t.Fatalf("merged worker budgets = %#v", merged.GitHubRESTBudgets)
+	}
+}
+
+func workerGitHubRateLimitServer(t *testing.T, remaining func(int64) int64) *httptest.Server {
+	t.Helper()
+	var calls atomic.Int64
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/graphql":
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"data":{"viewer":{"databaseId":42}}}`))
+		case "/rate_limit":
+			if r.Header.Get("Authorization") != "Bearer worker-token" {
+				t.Errorf("Authorization = %q, want worker bearer token", r.Header.Get("Authorization"))
+			}
+			value := remaining(calls.Add(1))
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = fmt.Fprintf(w, `{"resources":{"core":{"limit":5000,"used":%s,"remaining":%s,"reset":%s}}}`,
+				strconv.FormatInt(5000-value, 10),
+				strconv.FormatInt(value, 10),
+				strconv.FormatInt(time.Now().Add(time.Hour).Unix(), 10),
+			)
+		default:
+			t.Errorf("path = %q, want /graphql or /rate_limit", r.URL.Path)
+			http.NotFound(w, r)
+		}
+	}))
+}
+
+func workerGitHubTestPolicy(server *httptest.Server, logs *bytes.Buffer) workerGitHubPolicy {
+	return workerGitHubPolicy{
+		Enabled:            true,
+		Token:              "worker-token",
+		CredentialIdentity: "github-rest:worker",
+		RateLimitURL:       server.URL + "/rate_limit",
+		GraphQLURL:         server.URL + "/graphql",
+		MinRemaining:       1000,
+		PollInterval:       time.Hour,
+		HTTPClient:         server.Client(),
+		Logger:             slog.New(slog.NewTextHandler(logs, nil)),
+		ProjectID:          "detent",
+		IssueIdentifier:    "digitaldrywood/detent#1724",
+	}
+}
+
+type workerGitHubCaptureBackend struct {
+	request AgentTurnRequest
+}
+
+func (b *workerGitHubCaptureBackend) RunTurn(_ context.Context, request AgentTurnRequest, _ AgentUpdateHandler) (AgentTurnResult, error) {
+	b.request = request
+	return AgentTurnResult{}, nil
+}

--- a/internal/runner/worker_github_test.go
+++ b/internal/runner/worker_github_test.go
@@ -44,6 +44,7 @@ func TestNewWorkerGitHubPolicy(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			cfg := config.Default()
+			cfg.Tracker.Kind = config.TrackerGitHub
 			cfg.Tracker.Endpoint = "https://api.github.com/graphql"
 			cfg.Tracker.APIKey = tt.orchestratorToken
 			cfg.Worker.GitHubToken = tt.workerToken
@@ -71,7 +72,38 @@ func TestNewWorkerGitHubPolicy(t *testing.T) {
 			if tt.wantEnabled && (!strings.HasPrefix(policy.CredentialIdentity, "github-rest:") || policy.Token != "worker-token") {
 				t.Fatalf("policy = %#v, want redacted identity and resolved worker token", policy)
 			}
+			if tt.wantEnabled {
+				probeCtx, cancel := policy.ProbeContext(context.Background())
+				_, hasDeadline := probeCtx.Deadline()
+				cancel()
+				if !hasDeadline {
+					t.Fatal("worker github probe context has no deadline")
+				}
+			}
 		})
+	}
+}
+
+func TestNewWorkerGitHubPolicyUsesGitHubEndpointForNonGitHubTracker(t *testing.T) {
+	t.Parallel()
+
+	cfg := config.Default()
+	cfg.Tracker.Kind = config.TrackerLinear
+	cfg.Tracker.Endpoint = "https://api.linear.app/graphql"
+	cfg.Tracker.APIKey = "linear-secret"
+	cfg.Worker.GitHubToken = "worker-token"
+	policy, err := newWorkerGitHubPolicy(cfg, "detent", "digitaldrywood/detent#1724", func(string) string { return "" }, nil, nil)
+	if err != nil {
+		t.Fatalf("newWorkerGitHubPolicy() error = %v", err)
+	}
+	if policy.GraphQLURL != "https://api.github.com/graphql" {
+		t.Fatalf("GraphQLURL = %q, want public GitHub API", policy.GraphQLURL)
+	}
+	if policy.RateLimitURL != "https://api.github.com/rate_limit" {
+		t.Fatalf("RateLimitURL = %q, want public GitHub API", policy.RateLimitURL)
+	}
+	if policy.OrchestratorToken != "" {
+		t.Fatalf("OrchestratorToken = %q, want non-GitHub tracker credential excluded", policy.OrchestratorToken)
 	}
 }
 
@@ -260,6 +292,55 @@ func TestWorkerGitHubGovernorRejectsTokensForSameUser(t *testing.T) {
 	}
 }
 
+func TestWorkerGitHubGovernorBoundsStalledProbe(t *testing.T) {
+	t.Parallel()
+
+	requestStarted := make(chan struct{}, 1)
+	cancelProbe := make(chan context.CancelFunc, 1)
+	policy := workerGitHubPolicy{
+		Enabled:      true,
+		Token:        "worker-token",
+		GraphQLURL:   "https://api.github.test/graphql",
+		RateLimitURL: "https://api.github.test/rate_limit",
+		HTTPClient: workerGitHubHTTPClientFunc(func(request *http.Request) (*http.Response, error) {
+			requestStarted <- struct{}{}
+			<-request.Context().Done()
+			return nil, request.Context().Err()
+		}),
+		ProbeContext: func(ctx context.Context) (context.Context, context.CancelFunc) {
+			probeCtx, cancel := context.WithCancel(ctx)
+			cancelProbe <- cancel
+			return probeCtx, cancel
+		},
+	}
+	result := make(chan error, 1)
+	go func() {
+		_, _, err := startWorkerGitHubGovernor(context.Background(), policy, nil)
+		result <- err
+	}()
+
+	var cancel context.CancelFunc
+	select {
+	case cancel = <-cancelProbe:
+	case <-time.After(2 * time.Second):
+		t.Fatal("probe context was not created")
+	}
+	select {
+	case <-requestStarted:
+	case <-time.After(2 * time.Second):
+		t.Fatal("probe request did not start")
+	}
+	cancel()
+	select {
+	case err := <-result:
+		if !errors.Is(err, ErrWorkerGitHubBudgetMonitor) || !errors.Is(err, context.Canceled) {
+			t.Fatalf("startWorkerGitHubGovernor() error = %v, want bounded canceled probe", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("governor did not return after the probe context was canceled")
+	}
+}
+
 func TestMergeAgentRateLimitsPreservesWorkerAndProviderBudgets(t *testing.T) {
 	t.Parallel()
 
@@ -318,6 +399,12 @@ func workerGitHubTestPolicy(server *httptest.Server, logs *bytes.Buffer) workerG
 
 type workerGitHubCaptureBackend struct {
 	request AgentTurnRequest
+}
+
+type workerGitHubHTTPClientFunc func(*http.Request) (*http.Response, error)
+
+func (f workerGitHubHTTPClientFunc) Do(request *http.Request) (*http.Response, error) {
+	return f(request)
 }
 
 func (b *workerGitHubCaptureBackend) RunTurn(_ context.Context, request AgentTurnRequest, _ AgentUpdateHandler) (AgentTurnResult, error) {

--- a/internal/telemetry/snapshot.go
+++ b/internal/telemetry/snapshot.go
@@ -862,7 +862,13 @@ type RESTUsage struct {
 	Contributors        []RESTUsageContributor `json:"contributors,omitempty"`
 }
 
+const (
+	RESTConsumerOrchestrator = "orchestrator"
+	RESTConsumerWorker       = "worker"
+)
+
 type RESTUsageContributor struct {
+	Consumer           string     `json:"consumer,omitempty"`
 	CredentialIdentity string     `json:"credential_identity,omitempty"`
 	EndpointFamily     string     `json:"endpoint_family"`
 	Count              int64      `json:"count"`
@@ -879,14 +885,16 @@ type RESTUsageContributor struct {
 }
 
 type RESTBudget struct {
-	CredentialIdentity string     `json:"credential_identity"`
-	EndpointFamily     string     `json:"endpoint_family"`
-	Resource           string     `json:"resource,omitempty"`
-	Remaining          int64      `json:"remaining,omitempty"`
-	Used               int64      `json:"used,omitempty"`
-	Limit              int64      `json:"limit,omitempty"`
-	ResetAt            *time.Time `json:"reset_at,omitempty"`
-	ObservedAt         *time.Time `json:"observed_at,omitempty"`
+	Consumer            string     `json:"consumer,omitempty"`
+	CredentialIdentity  string     `json:"credential_identity"`
+	EndpointFamily      string     `json:"endpoint_family"`
+	Resource            string     `json:"resource,omitempty"`
+	Remaining           int64      `json:"remaining,omitempty"`
+	Used                int64      `json:"used,omitempty"`
+	Limit               int64      `json:"limit,omitempty"`
+	MinRemainingReserve int64      `json:"min_remaining_reserve,omitempty"`
+	ResetAt             *time.Time `json:"reset_at,omitempty"`
+	ObservedAt          *time.Time `json:"observed_at,omitempty"`
 }
 
 type Tokens struct {

--- a/internal/web/templates/dashboard.templ
+++ b/internal/web/templates/dashboard.templ
@@ -4392,7 +4392,7 @@ templ restBudgetCard(data DashboardData) {
 								<div class="grid grid-cols-[minmax(0,1fr)_auto] items-center gap-x-3 gap-y-1 text-sm">
 									<span class="truncate font-mono font-medium text-text">{ row.EndpointFamily }</span>
 									<span class="font-mono text-sec">{ row.Remaining }</span>
-									<span class="truncate font-mono text-xs text-sec">{ row.CredentialIdentity }</span>
+									<span class="truncate font-mono text-xs text-sec">{ row.Consumer + " · " + row.CredentialIdentity }</span>
 									<span class="text-right font-mono text-xs text-sec">{ row.Reset }</span>
 									<span class="truncate font-mono text-xs text-sec">{ row.Resource }</span>
 									<span class="text-right font-mono text-xs text-sec">{ row.Count + " · " + row.Status }</span>

--- a/internal/web/templates/dashboard_data.go
+++ b/internal/web/templates/dashboard_data.go
@@ -193,6 +193,7 @@ type graphQLBudgetContributorRow struct {
 }
 
 type restBudgetContributorRow struct {
+	Consumer           string
 	CredentialIdentity string
 	EndpointFamily     string
 	Resource           string
@@ -7206,20 +7207,22 @@ func restBudgetContributorRows(limits *telemetry.RateLimits) []restBudgetContrib
 		contributors := make(map[string]telemetry.RESTUsageContributor)
 		if limits.RESTUsage != nil {
 			for _, contributor := range limits.RESTUsage.Contributors {
-				contributors[restBudgetRowKey(contributor.CredentialIdentity, contributor.EndpointFamily, contributor.Resource)] = contributor
+				contributors[restBudgetRowKey(contributor.Consumer, contributor.CredentialIdentity, contributor.EndpointFamily, contributor.Resource)] = contributor
 			}
 		}
 		rows := make([]restBudgetContributorRow, 0, len(limits.GitHubRESTBudgets))
 		for _, budget := range limits.GitHubRESTBudgets {
-			contributor := contributors[restBudgetRowKey(budget.CredentialIdentity, budget.EndpointFamily, budget.Resource)]
+			consumer := restBudgetConsumerLabel(budget.Consumer)
+			contributor := contributors[restBudgetRowKey(consumer, budget.CredentialIdentity, budget.EndpointFamily, budget.Resource)]
 			rows = append(rows, restBudgetContributorRow{
+				Consumer:           consumer,
 				CredentialIdentity: strings.TrimSpace(budget.CredentialIdentity),
 				EndpointFamily:     strings.TrimSpace(budget.EndpointFamily),
 				Resource:           strings.TrimSpace(budget.Resource),
-				Count:              formatInt(contributor.Count) + " " + pluralize("request", contributor.Count),
+				Count:              restBudgetRowCount(budget, contributor),
 				Remaining:          restBudgetRowRemaining(budget),
 				Reset:              restBudgetRowReset(budget),
-				Status:             restContributorStatus(contributor),
+				Status:             restBudgetRowStatus(budget, contributor),
 			})
 		}
 		return rows
@@ -7230,6 +7233,7 @@ func restBudgetContributorRows(limits *telemetry.RateLimits) []restBudgetContrib
 	rows := make([]restBudgetContributorRow, 0, len(limits.RESTUsage.Contributors))
 	for _, contributor := range limits.RESTUsage.Contributors {
 		rows = append(rows, restBudgetContributorRow{
+			Consumer:           restBudgetConsumerLabel(contributor.Consumer),
 			CredentialIdentity: strings.TrimSpace(contributor.CredentialIdentity),
 			EndpointFamily:     strings.TrimSpace(contributor.EndpointFamily),
 			Resource:           strings.TrimSpace(contributor.Resource),
@@ -7242,8 +7246,33 @@ func restBudgetContributorRows(limits *telemetry.RateLimits) []restBudgetContrib
 	return rows
 }
 
-func restBudgetRowKey(credentialIdentity string, endpointFamily string, resource string) string {
-	return strings.TrimSpace(credentialIdentity) + "\x00" + strings.TrimSpace(endpointFamily) + "\x00" + strings.TrimSpace(resource)
+func restBudgetRowKey(consumer string, credentialIdentity string, endpointFamily string, resource string) string {
+	return restBudgetConsumerLabel(consumer) + "\x00" + strings.TrimSpace(credentialIdentity) + "\x00" + strings.TrimSpace(endpointFamily) + "\x00" + strings.TrimSpace(resource)
+}
+
+func restBudgetConsumerLabel(consumer string) string {
+	consumer = strings.TrimSpace(consumer)
+	if consumer == "" {
+		return telemetry.RESTConsumerOrchestrator
+	}
+	return consumer
+}
+
+func restBudgetRowCount(budget telemetry.RESTBudget, contributor telemetry.RESTUsageContributor) string {
+	if restBudgetConsumerLabel(budget.Consumer) == telemetry.RESTConsumerWorker {
+		return formatInt(budget.Used) + " used"
+	}
+	return formatInt(contributor.Count) + " " + pluralize("request", contributor.Count)
+}
+
+func restBudgetRowStatus(budget telemetry.RESTBudget, contributor telemetry.RESTUsageContributor) string {
+	if budget.MinRemainingReserve > 0 && budget.Remaining <= budget.MinRemainingReserve {
+		return "reserved"
+	}
+	if restBudgetConsumerLabel(budget.Consumer) == telemetry.RESTConsumerWorker {
+		return "governed"
+	}
+	return restContributorStatus(contributor)
 }
 
 func restBudgetRowRemaining(budget telemetry.RESTBudget) string {

--- a/internal/web/templates/dashboard_data_test.go
+++ b/internal/web/templates/dashboard_data_test.go
@@ -522,12 +522,11 @@ func TestRESTBudgetContributorRowsPreserveCredentialAndEndpointWindows(t *testin
 	searchReset := coreReset.Add(-45 * time.Minute)
 	limits := &telemetry.RateLimits{
 		GitHubRESTBudgets: []telemetry.RESTBudget{
-			{CredentialIdentity: "github-rest:user", EndpointFamily: "issues", Resource: "core", Remaining: 300, Limit: 5000, ResetAt: &coreReset},
-			{CredentialIdentity: "github-rest:app", EndpointFamily: "issue search", Resource: "search", Remaining: 20, Limit: 30, ResetAt: &searchReset},
+			{Consumer: telemetry.RESTConsumerOrchestrator, CredentialIdentity: "github-rest:user", EndpointFamily: "issues", Resource: "core", Remaining: 300, Limit: 5000, ResetAt: &coreReset},
+			{Consumer: telemetry.RESTConsumerWorker, CredentialIdentity: "github-rest:app", EndpointFamily: "worker credential", Resource: "core", Used: 4980, Remaining: 20, Limit: 5000, MinRemainingReserve: 1000, ResetAt: &searchReset},
 		},
 		RESTUsage: &telemetry.RESTUsage{Contributors: []telemetry.RESTUsageContributor{
-			{CredentialIdentity: "github-rest:user", EndpointFamily: "issues", Resource: "core", Count: 4, LastStatus: 200},
-			{CredentialIdentity: "github-rest:app", EndpointFamily: "issue search", Resource: "search", Count: 1, LastStatus: 200},
+			{Consumer: telemetry.RESTConsumerOrchestrator, CredentialIdentity: "github-rest:user", EndpointFamily: "issues", Resource: "core", Count: 4, LastStatus: 200},
 		}},
 	}
 
@@ -537,19 +536,22 @@ func TestRESTBudgetContributorRowsPreserveCredentialAndEndpointWindows(t *testin
 	}
 	tests := []struct {
 		index      int
+		consumer   string
 		credential string
 		family     string
 		resource   string
+		count      string
+		status     string
 		remaining  string
 		resetAt    time.Time
 	}{
-		{index: 0, credential: "github-rest:user", family: "issues", resource: "core", remaining: "300 / 5,000", resetAt: coreReset},
-		{index: 1, credential: "github-rest:app", family: "issue search", resource: "search", remaining: "20 / 30", resetAt: searchReset},
+		{index: 0, consumer: telemetry.RESTConsumerOrchestrator, credential: "github-rest:user", family: "issues", resource: "core", count: "4 requests", status: "200", remaining: "300 / 5,000", resetAt: coreReset},
+		{index: 1, consumer: telemetry.RESTConsumerWorker, credential: "github-rest:app", family: "worker credential", resource: "core", count: "4,980 used", status: "reserved", remaining: "20 / 5,000", resetAt: searchReset},
 	}
 	for _, test := range tests {
 		t.Run(test.family, func(t *testing.T) {
 			row := rows[test.index]
-			if row.CredentialIdentity != test.credential || row.EndpointFamily != test.family || row.Resource != test.resource || row.Remaining != test.remaining || row.Reset != localTimeToken(test.resetAt, LocalTimeOnly) {
+			if row.Consumer != test.consumer || row.CredentialIdentity != test.credential || row.EndpointFamily != test.family || row.Resource != test.resource || row.Count != test.count || row.Status != test.status || row.Remaining != test.remaining || row.Reset != localTimeToken(test.resetAt, LocalTimeOnly) {
 				t.Fatalf("row = %#v, want credential %q family %q resource %q remaining %q reset %v", row, test.credential, test.family, test.resource, test.remaining, test.resetAt)
 			}
 		})

--- a/internal/web/templates/dashboard_templ.go
+++ b/internal/web/templates/dashboard_templ.go
@@ -15794,9 +15794,9 @@ func restBudgetCard(data DashboardData) templ.Component {
 						return templ_7745c5c3_Err
 					}
 					var templ_7745c5c3_Var766 string
-					templ_7745c5c3_Var766, templ_7745c5c3_Err = templ.JoinStringErrs(row.CredentialIdentity)
+					templ_7745c5c3_Var766, templ_7745c5c3_Err = templ.JoinStringErrs(row.Consumer + " · " + row.CredentialIdentity)
 					if templ_7745c5c3_Err != nil {
-						return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/dashboard.templ`, Line: 4395, Col: 83}
+						return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/dashboard.templ`, Line: 4395, Col: 107}
 					}
 					_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var766))
 					if templ_7745c5c3_Err != nil {


### PR DESCRIPTION
## Summary

- isolate worker GitHub CLI authentication from the orchestrator and require a dedicated credential owned by a different GitHub user
- govern the worker REST bucket with launch-time and bounded-interval probes, a reserved-headroom stop, and explicit worker/orchestrator telemetry attribution
- keep worker depletion out of fleet dispatch capacity while documenting and rendering the new credential policy

Fixes #1724

## UI Surface Contract

- [x] The issue explicitly requires visible worker-versus-orchestrator REST attribution; the REST budget detail adds that label without changing primary layout, density, or responsive visibility.
- [x] This PR does not add persistent top-of-screen messaging.
- [x] Browser verification: `env -u DETENT_API_TOKEN DETENT_BINARY="$PWD/tmp/detent" node_modules/.bin/playwright test --project=chromium --grep 'fleet page shows agent hero'` (passed on the isolated port-0 demo runtime).

## Test Plan

- [x] `make generate`
- [x] focused affected-package tests
- [x] targeted race tests for worker launch, governor, telemetry, and fleet merging
- [x] `make check` (78.7% aggregate coverage)
- [x] isolated Playwright fleet-page verification
