### PR TITLE
test(routine): make fake issue IDs deterministic

### DIFF
--- a/internal/routine/manager_test.go
+++ b/internal/routine/manager_test.go
@@ -581,7 +581,7 @@ func (s *fakeIssueStore) CreateIntakeIssue(_ context.Context, draft intake.Issue
 		return intake.Issue{}, s.createErr
 	}
 	s.drafts = append(s.drafts, draft)
-	id := "issue-" + time.Now().Format("150405.000000000")
+	id := fmt.Sprintf("issue-%d", s.createCalls)
 	s.issues = append(s.issues, connector.Issue{ID: id, Identifier: "DET-1", Description: draft.Body, Labels: append([]string(nil), draft.Labels...)})
 	issue := intake.Issue{ID: id, Identifier: "DET-1", URL: "https://example.test/issues/1", Body: draft.Body}
 	return issue, s.createErr


### PR DESCRIPTION
## Summary

- Generate fake routine issue IDs from the creation counter instead of wall-clock time.
- Keep partial-creation limit accounting deterministic across clock resolutions and platforms.

Fixes #1746

## UI Surface Contract

- [x] N/A; this PR does not change a UI surface.
- [x] This PR does not add persistent top-of-screen messaging.
- [x] N/A; this PR has no visual changes to primary operator screens.

## Test Plan

- [x] `go test ./internal/routine -run "^TestManagerRunOnceCountsPartialCreationsAgainstLimits$" -count=1000`
- [x] `make check`