### PR TITLE
fix(orchestrator): prevent merge queue starvation

### DIFF
--- a/config.reference.yaml
+++ b/config.reference.yaml
@@ -585,6 +585,8 @@
 #   merge_fast_path:
 #     # agent.merge_fast_path.enabled | type: boolean | default: true | required: No | validation: None
 #     enabled: true
+#     # agent.merge_fast_path.fairness_age_seconds | type: integer | default: 7200 | required: No | validation: must be greater than 0
+#     fairness_age_seconds: 7200
 #   # agent.auto_promote | type: object | default: see child fields | required: No | validation: None
 #   auto_promote:
 #     # agent.auto_promote.enabled | type: boolean | default: false | required: No | validation: None

--- a/docs/config.md
+++ b/docs/config.md
@@ -373,6 +373,7 @@ rendering and fails on drift.
 | `agent.max_turns` | `integer` | `20` | No | must be greater than 0 |
 | `agent.merge_fast_path` | `object` | `see child fields` | No | None |
 | `agent.merge_fast_path.enabled` | `boolean` | `true` | No | None |
+| `agent.merge_fast_path.fairness_age_seconds` | `integer` | `7200` | No | must be greater than 0 |
 | `agent.merge_worker_max_duration_ms` | `integer` | `21600000` | No | must be greater than 0 |
 | `agent.merge_worker_startup_timeout_ms` | `integer` | `240000` | No | must be greater than 0 |
 | `agent.no_progress_spend_limit_usd` | `number` | `3` | No | must be greater than or equal to 0 |

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -73,6 +73,7 @@ const (
 	DefaultOverloadRetryDelayMS              = 45000
 	DefaultMergeWorkerStartupTimeoutMS       = 4 * 60 * 1000
 	DefaultMergeWorkerMaxDurationMS          = 6 * 60 * 60 * 1000
+	DefaultMergeFairnessAgeSeconds           = 2 * 60 * 60
 	DefaultMaxSessionDurationMS              = 2 * 60 * 60 * 1000
 	DefaultNoProgressTimeoutMS               = 90 * 60 * 1000
 
@@ -353,7 +354,8 @@ type Shutdown struct {
 }
 
 type MergeFastPath struct {
-	Enabled bool `yaml:"enabled"`
+	Enabled            bool `yaml:"enabled"`
+	FairnessAgeSeconds int  `yaml:"fairness_age_seconds"`
 }
 
 type Agents struct {
@@ -1309,7 +1311,10 @@ func Default() Config {
 			NoProgressTokenLimit:        DefaultNoProgressTokenLimit,
 			NoProgressSpendLimitUSD:     DefaultNoProgressSpendLimitUSD,
 			StopRun:                     StopRun{TargetState: "Blocked"},
-			MergeFastPath:               MergeFastPath{Enabled: true},
+			MergeFastPath: MergeFastPath{
+				Enabled:            true,
+				FairnessAgeSeconds: DefaultMergeFairnessAgeSeconds,
+			},
 			FailureBreaker: FailureBreaker{
 				SameClassLimit:  DefaultFailureBreakerSameClassLimit,
 				WindowSeconds:   DefaultFailureBreakerWindowSeconds,
@@ -1624,6 +1629,9 @@ func (c *Config) normalize() {
 	}
 	if c.Agent.MergeWorkerMaxDurationMS == 0 {
 		c.Agent.MergeWorkerMaxDurationMS = DefaultMergeWorkerMaxDurationMS
+	}
+	if c.Agent.MergeFastPath.FairnessAgeSeconds == 0 {
+		c.Agent.MergeFastPath.FairnessAgeSeconds = DefaultMergeFairnessAgeSeconds
 	}
 	if c.Agent.FailureBreaker.SameClassLimit == 0 {
 		c.Agent.FailureBreaker.SameClassLimit = DefaultFailureBreakerSameClassLimit
@@ -2026,6 +2034,7 @@ func (a *Agent) validate(prefix string, problems *[]string) {
 	validateStateLimits(prefix+".max_concurrent_agents_by_state", a.MaxConcurrentAgentsByState, problems)
 	validateStateList(prefix+".dispatch_priority_by_state", a.DispatchPriorityByState, problems)
 	validateLabelList(prefix+".dispatch_priority_by_label", a.DispatchPriorityByLabel, problems)
+	validatePositive(prefix+".merge_fast_path.fairness_age_seconds", a.MergeFastPath.FairnessAgeSeconds, problems)
 	a.AutoPromote.validate(prefix+".auto_promote", problems)
 	a.OutputTruncation.validate(prefix+".output_truncation", problems)
 	a.Budget.validate(prefix+".budget", problems)

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1467,6 +1467,9 @@ func TestParseWorkflowDefaults(t *testing.T) {
 	if !cfg.Agent.MergeFastPath.Enabled {
 		t.Fatal("Agent.MergeFastPath.Enabled = false, want true default")
 	}
+	if cfg.Agent.MergeFastPath.FairnessAgeSeconds != DefaultMergeFairnessAgeSeconds {
+		t.Fatalf("Agent.MergeFastPath.FairnessAgeSeconds = %d, want %d", cfg.Agent.MergeFastPath.FairnessAgeSeconds, DefaultMergeFairnessAgeSeconds)
+	}
 	if cfg.Agent.ExperimentalThreadResume {
 		t.Fatal("Agent.ExperimentalThreadResume = true, want disabled default")
 	}
@@ -1764,12 +1767,13 @@ func TestParseWorkflowAgentMergeFastPath(t *testing.T) {
 	t.Parallel()
 
 	for _, tt := range []struct {
-		name    string
-		enabled string
-		want    bool
+		name               string
+		enabled            string
+		fairnessAgeSeconds int
+		want               bool
 	}{
-		{name: "enabled", enabled: "true", want: true},
-		{name: "disabled", enabled: "false", want: false},
+		{name: "enabled", enabled: "true", fairnessAgeSeconds: 5400, want: true},
+		{name: "disabled", enabled: "false", fairnessAgeSeconds: 900, want: false},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
@@ -1778,6 +1782,7 @@ func TestParseWorkflowAgentMergeFastPath(t *testing.T) {
 agent:
   merge_fast_path:
     enabled: ` + tt.enabled + `
+    fairness_age_seconds: ` + strconv.Itoa(tt.fairnessAgeSeconds) + `
 ---
 Body
 `))
@@ -1787,7 +1792,22 @@ Body
 			if workflow.Config.Agent.MergeFastPath.Enabled != tt.want {
 				t.Fatalf("Agent.MergeFastPath.Enabled = %t, want %t", workflow.Config.Agent.MergeFastPath.Enabled, tt.want)
 			}
+			if workflow.Config.Agent.MergeFastPath.FairnessAgeSeconds != tt.fairnessAgeSeconds {
+				t.Fatalf("Agent.MergeFastPath.FairnessAgeSeconds = %d, want %d", workflow.Config.Agent.MergeFastPath.FairnessAgeSeconds, tt.fairnessAgeSeconds)
+			}
 		})
+	}
+}
+
+func TestValidateMergeFastPathRejectsNegativeFairnessAge(t *testing.T) {
+	t.Parallel()
+
+	cfg := Default()
+	cfg.Agent.MergeFastPath.FairnessAgeSeconds = -1
+
+	err := cfg.Validate()
+	if err == nil || !strings.Contains(err.Error(), "agent.merge_fast_path.fairness_age_seconds must be greater than 0") {
+		t.Fatalf("Validate() error = %v, want fairness age validation", err)
 	}
 }
 

--- a/internal/orchestrator/autopromote_tick.go
+++ b/internal/orchestrator/autopromote_tick.go
@@ -32,6 +32,10 @@ const (
 	mergeBaseRefreshRequiredChecksPending = "required_checks_pending"
 	mergeBaseRefreshLaneUnavailable       = "merge_lane_capacity_unavailable"
 	mergeBaseRefreshGlobalUnavailable     = "global_capacity_unavailable"
+	mergeSelectionReasonStickyAged        = "sticky_aged_head"
+	mergeSelectionReasonAged              = "aged_head"
+	mergeSelectionReasonClean             = "clean_head"
+	mergeSelectionReasonQueue             = "queue_order"
 )
 
 type autoPromoteTickResult struct {
@@ -48,6 +52,11 @@ type mergeBaseRefreshDecision struct {
 	applicable bool
 	proceed    bool
 	reason     string
+}
+
+type mergingIssuePriority struct {
+	reasons       map[string]string
+	stickyIssueID string
 }
 
 type autoPromoteReworkLimitSummary struct {
@@ -717,7 +726,7 @@ func (o *Orchestrator) reconcileStaleMergingPullRequestIssues(
 	transitioned := map[string]struct{}{}
 	o.recordMergeQueueEntries(state, issues, now, "tracker")
 	consumedRepositories := activeMergeWorkerRepositories(state)
-	for _, issue := range staleMergingQueueIssues(issues, o.cfg) {
+	for _, issue := range staleMergingQueueIssues(issues, o.cfg, state, now) {
 		issueID := strings.TrimSpace(issue.ID)
 		if issueID == "" {
 			continue
@@ -895,7 +904,7 @@ func (o *Orchestrator) logStaleMergingPullRequestDeferred(issue connector.Issue,
 	o.logger.Info("stale_merging_pr_reconciliation_deferred", attrs...)
 }
 
-func (o *Orchestrator) logMergeWorkerPickup(issue connector.Issue, source string) {
+func (o *Orchestrator) logMergeWorkerPickup(issue connector.Issue, source string, attrs ...any) {
 	if !o.beginDispatchStart() {
 		return
 	}
@@ -903,8 +912,9 @@ func (o *Orchestrator) logMergeWorkerPickup(issue connector.Issue, source string
 	if o.logger == nil || !mergeWorkerIssue(issue) {
 		return
 	}
-	attrs := mergeWorkerLogAttrs(issue, "source", strings.TrimSpace(source))
-	o.logger.Info("merge_worker_pickup", attrs...)
+	values := mergeWorkerLogAttrs(issue, "source", strings.TrimSpace(source))
+	values = append(values, attrs...)
+	o.logger.Info("merge_worker_pickup", values...)
 }
 
 func (o *Orchestrator) logMergeWorkerAttempt(issue connector.Issue, attempt int, workerHost string) {
@@ -1106,10 +1116,10 @@ func staleMergingPullRequestDispatchActive(state *State, issueID string) bool {
 	return false
 }
 
-func staleMergingQueueIssues(issues []connector.Issue, cfg Config) []connector.Issue {
+func staleMergingQueueIssues(issues []connector.Issue, cfg Config, state *State, now time.Time) []connector.Issue {
 	queue := issuesInStates(issues, []string{autoPromoteMergingState})
 	sortIssuesForDispatch(queue, cfg.DispatchPriorityByState, cfg.DispatchPriorityByLabel, cfg.PrioritizeUnblockers)
-	prioritizeReadyMergingIssues(queue)
+	prioritizeReadyMergingIssues(queue, state, now, cfg.MergeFairnessAge)
 	return queue
 }
 
@@ -1169,7 +1179,10 @@ func (o *Orchestrator) mergeWorkerDispatchCandidates(state *State, issues []conn
 		return nil
 	}
 	o.logMergeWorkerQueueCycle(state, issues, now)
-	candidates := o.staleMergingQueueDispatchCandidates(state, issues)
+	if stickyMergingIssueID(state, issues, now, o.cfg.MergeFairnessAge) != "" {
+		return nil
+	}
+	candidates := o.staleMergingQueueDispatchCandidates(state, issues, now)
 	if len(candidates) == 0 {
 		return nil
 	}
@@ -1207,7 +1220,13 @@ func (o *Orchestrator) mergeWorkerDispatchCandidates(state *State, issues []conn
 		}
 		selectedByState[stateKey] = selected + 1
 		o.clearAutoPromotedIssueDispatchMemory(state, issueID)
-		o.logMergeWorkerPickup(issue, "stale_merging")
+		laneAge := mergeWorkerIssueLaneAge(issue, now)
+		o.logMergeWorkerPickup(issue, "stale_merging",
+			"selection_position", len(out)+1,
+			"selection_reason", mergeWorkerSelectionReason(issue, state, now, o.cfg.MergeFairnessAge),
+			"lane_age_seconds", int64(laneAge/time.Second),
+			"fairness_age_seconds", int64(o.cfg.MergeFairnessAge/time.Second),
+		)
 		out = append(out, issue)
 	}
 	return out
@@ -1219,6 +1238,8 @@ func (o *Orchestrator) logMergeWorkerQueueCycle(state *State, issues []connector
 	}
 	queueDepth := 0
 	readyCount := 0
+	agedCount := 0
+	oldestLaneAge := time.Duration(0)
 	queueIssueIDs := map[string]struct{}{}
 	for _, issue := range issues {
 		if !mergeWorkerIssue(issue) {
@@ -1228,6 +1249,13 @@ func (o *Orchestrator) logMergeWorkerQueueCycle(state *State, issues []connector
 		queueIssueIDs[strings.TrimSpace(issue.ID)] = struct{}{}
 		if mergeWorkerHeadReady(issue) {
 			readyCount++
+		}
+		laneAge := mergeWorkerIssueLaneAge(issue, now)
+		if laneAge > oldestLaneAge {
+			oldestLaneAge = laneAge
+		}
+		if mergeWorkerIssueAged(issue, now, o.cfg.MergeFairnessAge) {
+			agedCount++
 		}
 	}
 	projectStats := o.projectStateSlotStats(connector.Issue{State: autoPromoteMergingState}, state)
@@ -1244,6 +1272,9 @@ func (o *Orchestrator) logMergeWorkerQueueCycle(state *State, issues []connector
 	attrs := []any{
 		"queue_depth", queueDepth,
 		"ready_count", readyCount,
+		"aged_count", agedCount,
+		"oldest_lane_age_seconds", int64(oldestLaneAge / time.Second),
+		"fairness_age_seconds", int64(o.cfg.MergeFairnessAge / time.Second),
 		"lane_occupied", occupantCount > 0,
 		"lane_saturated", projectStats.available <= 0,
 		"lane_occupant_count", occupantCount,
@@ -1260,6 +1291,9 @@ func (o *Orchestrator) logMergeWorkerQueueCycle(state *State, issues []connector
 			"occupying_issue_number", issueNumberFromIdentifier(occupant.Issue.Identifier),
 			"occupancy_seconds", occupancySeconds,
 		)
+	}
+	if stickyIssueID := stickyMergingIssueID(state, issues, now, o.cfg.MergeFairnessAge); stickyIssueID != "" {
+		attrs = append(attrs, "sticky_issue_id", stickyIssueID)
 	}
 	o.logger.Info("merge_worker_queue_cycle", attrs...)
 }
@@ -1283,37 +1317,75 @@ func mergeWorkerLaneOccupant(state *State) (Running, int) {
 	return occupant, count
 }
 
-func prioritizeReadyMergingIssues(issues []connector.Issue) {
+func prioritizeReadyMergingIssues(issues []connector.Issue, state *State, now time.Time, fairnessAge time.Duration) mergingIssuePriority {
+	priority := mergingIssuePriority{
+		reasons:       map[string]string{},
+		stickyIssueID: stickyMergingIssueID(state, issues, now, fairnessAge),
+	}
 	ordered := make([]connector.Issue, 0, len(issues))
-	readyHeads := make(map[string]struct{})
-	seenRepositories := make(map[string]struct{})
-	for _, issue := range issues {
+	appended := make([]bool, len(issues))
+	repositoryHeads := make(map[string]int)
+	for index, issue := range issues {
 		if !mergeWorkerIssue(issue) {
 			continue
 		}
 		repository := mergeWorkerRepositoryKey(issue)
-		if repository != "" {
-			if _, seen := seenRepositories[repository]; seen {
+		if repository == "" {
+			continue
+		}
+		if _, seen := repositoryHeads[repository]; !seen {
+			repositoryHeads[repository] = index
+		}
+	}
+	appendMatching := func(reason string, matches func(int, connector.Issue) bool) {
+		for index, issue := range issues {
+			if appended[index] || !mergeWorkerIssue(issue) || !matches(index, issue) {
 				continue
 			}
-			seenRepositories[repository] = struct{}{}
-		}
-		if mergeWorkerHeadReady(issue) {
-			readyHeads[issue.ID] = struct{}{}
+			appended[index] = true
 			ordered = append(ordered, issue)
+			if issueID := strings.TrimSpace(issue.ID); issueID != "" {
+				priority.reasons[issueID] = reason
+			}
 		}
 	}
-	for _, issue := range issues {
-		if !mergeWorkerIssue(issue) {
-			continue
+	appendMatching(mergeSelectionReasonStickyAged, func(_ int, issue connector.Issue) bool {
+		return strings.TrimSpace(issue.ID) == priority.stickyIssueID
+	})
+	agedIssues := make([]connector.Issue, 0, len(issues))
+	for index, issue := range issues {
+		if !appended[index] && mergeWorkerIssueAged(issue, now, fairnessAge) {
+			appended[index] = true
+			agedIssues = append(agedIssues, issue)
 		}
-		if _, ready := readyHeads[issue.ID]; ready {
-			continue
+	}
+	slices.SortStableFunc(agedIssues, func(leftIssue connector.Issue, rightIssue connector.Issue) int {
+		left := mergeQueueEnteredAt(leftIssue, time.Time{})
+		right := mergeQueueEnteredAt(rightIssue, time.Time{})
+		if left.Before(right) {
+			return -1
 		}
+		if left.After(right) {
+			return 1
+		}
+		return 0
+	})
+	for _, issue := range agedIssues {
 		ordered = append(ordered, issue)
+		if issueID := strings.TrimSpace(issue.ID); issueID != "" {
+			priority.reasons[issueID] = mergeSelectionReasonAged
+		}
 	}
+	appendMatching(mergeSelectionReasonClean, func(index int, issue connector.Issue) bool {
+		repository := mergeWorkerRepositoryKey(issue)
+		if repository != "" && repositoryHeads[repository] != index {
+			return false
+		}
+		return mergeWorkerHeadReady(issue)
+	})
+	appendMatching(mergeSelectionReasonQueue, func(_ int, _ connector.Issue) bool { return true })
 	if len(ordered) == 0 {
-		return
+		return priority
 	}
 	next := 0
 	for index := range issues {
@@ -1323,6 +1395,70 @@ func prioritizeReadyMergingIssues(issues []connector.Issue) {
 		issues[index] = ordered[next]
 		next++
 	}
+	return priority
+}
+
+func stickyMergingIssueID(state *State, issues []connector.Issue, now time.Time, fairnessAge time.Duration) string {
+	if state == nil || (len(state.Retry) == 0 && len(state.Running) == 0) {
+		return ""
+	}
+	current := make(map[string]connector.Issue, len(issues))
+	for _, issue := range issues {
+		if issueID := strings.TrimSpace(issue.ID); issueID != "" {
+			current[issueID] = issue
+		}
+	}
+	selectedID := ""
+	selectedEnteredAt := time.Time{}
+	consider := func(issueID string, issue connector.Issue) {
+		issueID = strings.TrimSpace(issueID)
+		if refreshed, ok := current[issueID]; ok {
+			issue = refreshed
+		}
+		if !mergeWorkerIssueAged(issue, now, fairnessAge) {
+			return
+		}
+		enteredAt := mergeQueueEnteredAt(issue, time.Time{})
+		if selectedID == "" || enteredAt.Before(selectedEnteredAt) || enteredAt.Equal(selectedEnteredAt) && issueID < selectedID {
+			selectedID = issueID
+			selectedEnteredAt = enteredAt
+		}
+	}
+	for issueID, running := range state.Running {
+		consider(issueID, running.Issue)
+	}
+	for issueID, retry := range state.Retry {
+		consider(issueID, retry.Issue)
+	}
+	return selectedID
+}
+
+func mergeWorkerSelectionReason(issue connector.Issue, state *State, now time.Time, fairnessAge time.Duration) string {
+	if strings.TrimSpace(issue.ID) == stickyMergingIssueID(state, []connector.Issue{issue}, now, fairnessAge) {
+		return mergeSelectionReasonStickyAged
+	}
+	if mergeWorkerIssueAged(issue, now, fairnessAge) {
+		return mergeSelectionReasonAged
+	}
+	if mergeWorkerHeadReady(issue) {
+		return mergeSelectionReasonClean
+	}
+	return mergeSelectionReasonQueue
+}
+
+func mergeWorkerIssueAged(issue connector.Issue, now time.Time, fairnessAge time.Duration) bool {
+	return mergeWorkerIssue(issue) && fairnessAge > 0 && mergeWorkerIssueLaneAge(issue, now) >= fairnessAge
+}
+
+func mergeWorkerIssueLaneAge(issue connector.Issue, now time.Time) time.Duration {
+	if now.IsZero() {
+		return 0
+	}
+	enteredAt := mergeQueueEnteredAt(issue, time.Time{})
+	if enteredAt.IsZero() || now.Before(enteredAt) {
+		return 0
+	}
+	return now.Sub(enteredAt)
 }
 
 func mergeWorkerHeadReady(issue connector.Issue) bool {
@@ -1334,10 +1470,10 @@ func mergeWorkerHeadReady(issue connector.Issue) bool {
 		len(issue.PullRequest.RequiredCheckFailures) == 0
 }
 
-func (o *Orchestrator) staleMergingQueueDispatchCandidates(state *State, issues []connector.Issue) []connector.Issue {
+func (o *Orchestrator) staleMergingQueueDispatchCandidates(state *State, issues []connector.Issue, now time.Time) []connector.Issue {
 	candidates := []connector.Issue{}
 	consumedRepositories := activeMergeWorkerRepositories(state)
-	for _, issue := range staleMergingQueueIssues(issues, o.cfg) {
+	for _, issue := range staleMergingQueueIssues(issues, o.cfg, state, now) {
 		issueID := strings.TrimSpace(issue.ID)
 		repository := mergeWorkerRepositoryKey(issue)
 		if staleMergingPullRequestDispatchActive(state, issueID) {

--- a/internal/orchestrator/autopromote_tick_test.go
+++ b/internal/orchestrator/autopromote_tick_test.go
@@ -4151,7 +4151,7 @@ func TestStaleMergingQueueDispatchCandidatesFiltersUnsafePullRequests(t *testing
 			issue := autoPromoteTickIssue("issue-"+strings.ReplaceAll(tt.name, " ", "-"), []string{"bug"}, tt.pullRequest)
 			issue.State = "Merging"
 			issue.Closed = tt.closed
-			got := orch.staleMergingQueueDispatchCandidates(&state, []connector.Issue{issue})
+			got := orch.staleMergingQueueDispatchCandidates(&state, []connector.Issue{issue}, time.Date(2026, 8, 9, 0, 0, 0, 0, time.UTC))
 			if tt.want {
 				if len(got) != 1 || got[0].ID != issue.ID {
 					t.Fatalf("staleMergingQueueDispatchCandidates() = %#v, want %s", got, issue.ID)
@@ -4190,7 +4190,7 @@ func TestStaleMergingQueueDispatchCandidatesRequiresApprovalLabel(t *testing.T) 
 	orch := &Orchestrator{cfg: cfg}
 	state := newState(cfg)
 
-	if got := orch.staleMergingQueueDispatchCandidates(&state, []connector.Issue{issue}); len(got) != 0 {
+	if got := orch.staleMergingQueueDispatchCandidates(&state, []connector.Issue{issue}, time.Date(2026, 8, 9, 0, 0, 0, 0, time.UTC)); len(got) != 0 {
 		t.Fatalf("staleMergingQueueDispatchCandidates() = %#v, want none without approval label", got)
 	}
 }
@@ -4287,6 +4287,157 @@ func TestMergeWorkerDispatchCandidatesPrefersReadyHead(t *testing.T) {
 	}
 }
 
+func TestMergeWorkerDispatchCandidatesAgesWaitingHeadAheadOfReadyHead(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 8, 9, 4, 20, 0, 0, time.UTC)
+	cfg := normalizeConfig(Config{
+		MaxConcurrentAgents: 1,
+		MaxConcurrentAgentsByState: map[string]int{
+			"Merging": 1,
+		},
+		ActiveStates:   []string{"Merging"},
+		TerminalStates: []string{"Done"},
+	})
+	agedAt := now.Add(-3 * time.Hour)
+	recentAt := now.Add(-time.Minute)
+	aged := nativeMergeQueueTestIssue(1748, "pending")
+	aged.ID = "issue-aged-head"
+	aged.StageUpdatedAt = &agedAt
+	recent := nativeMergeQueueTestIssue(1749, "success")
+	recent.ID = "issue-recent-ready-head"
+	recent.Identifier = "digitaldrywood/pyroapex#1749"
+	recent.PRRepository = "digitaldrywood/pyroapex"
+	recent.PullRequest.URL = "https://github.test/digitaldrywood/pyroapex/pull/1749"
+	recent.StageUpdatedAt = &recentAt
+	state := newState(cfg)
+	var logs strings.Builder
+	orch := &Orchestrator{
+		cfg:    cfg,
+		logger: slog.New(slog.NewTextHandler(&logs, nil)),
+	}
+
+	got := orch.mergeWorkerDispatchCandidates(&state, []connector.Issue{aged, recent}, now)
+	if len(got) != 1 || got[0].ID != aged.ID {
+		t.Fatalf("mergeWorkerDispatchCandidates() = %#v, want aged issue %q", got, aged.ID)
+	}
+	for _, fragment := range []string{
+		"selection_position=1",
+		"selection_reason=aged_head",
+		"lane_age_seconds=10800",
+		"fairness_age_seconds=7200",
+	} {
+		if !strings.Contains(logs.String(), fragment) {
+			t.Fatalf("logs %q missing fragment %q", logs.String(), fragment)
+		}
+	}
+}
+
+func TestPrioritizeReadyMergingIssuesFairness(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 8, 9, 4, 20, 0, 0, time.UTC)
+	threshold := 2 * time.Hour
+	issue := func(id string, number int, repository string, ciStatus string, enteredAt time.Time) connector.Issue {
+		value := nativeMergeQueueTestIssue(number, ciStatus)
+		value.ID = id
+		value.Identifier = fmt.Sprintf("%s#%d", repository, number)
+		value.PRRepository = repository
+		value.PullRequest.URL = fmt.Sprintf("https://github.test/%s/pull/%d", repository, number)
+		value.StageUpdatedAt = &enteredAt
+		return value
+	}
+	aged := issue("aged", 1748, "digitaldrywood/detent", "pending", now.Add(-threshold-time.Second))
+	oldestAged := issue("oldest-aged", 1747, "digitaldrywood/archive", "pending", now.Add(-threshold-time.Hour))
+	boundary := issue("boundary", 1749, "digitaldrywood/pyroapex", "pending", now.Add(-threshold))
+	cleanFirst := issue("clean-first", 1750, "digitaldrywood/phone", "success", now.Add(-time.Hour))
+	cleanSecond := issue("clean-second", 1751, "digitaldrywood/outlet", "success", now.Add(-time.Minute))
+	invalidated := cloneIssue(aged)
+	invalidated.ID = "invalidated"
+	invalidated.Identifier = "digitaldrywood/detent#1752"
+	invalidated.PullRequest.Number = 1752
+	invalidated.PullRequest.MergeableState = "behind"
+	invalidated.PullRequest.CIStatus = "pending"
+
+	tests := []struct {
+		name        string
+		issues      []connector.Issue
+		state       func() *State
+		wantOrder   []string
+		wantReasons map[string]string
+		wantSticky  string
+	}{
+		{
+			name:        "empty queue",
+			wantOrder:   []string{},
+			wantReasons: map[string]string{},
+		},
+		{
+			name:        "all clean queue preserves order",
+			issues:      []connector.Issue{cleanFirst, cleanSecond},
+			wantOrder:   []string{"clean-first", "clean-second"},
+			wantReasons: map[string]string{"clean-first": mergeSelectionReasonClean, "clean-second": mergeSelectionReasonClean},
+		},
+		{
+			name:        "aged head outranks clean head",
+			issues:      []connector.Issue{cleanSecond, aged},
+			wantOrder:   []string{"aged", "clean-second"},
+			wantReasons: map[string]string{"aged": mergeSelectionReasonAged, "clean-second": mergeSelectionReasonClean},
+		},
+		{
+			name:        "age boundary is inclusive",
+			issues:      []connector.Issue{cleanFirst, boundary},
+			wantOrder:   []string{"boundary", "clean-first"},
+			wantReasons: map[string]string{"boundary": mergeSelectionReasonAged, "clean-first": mergeSelectionReasonClean},
+		},
+		{
+			name:        "continuous clean arrivals stay behind oldest aged head",
+			issues:      []connector.Issue{cleanFirst, aged, cleanSecond, oldestAged},
+			wantOrder:   []string{"oldest-aged", "aged", "clean-first", "clean-second"},
+			wantReasons: map[string]string{"oldest-aged": mergeSelectionReasonAged, "aged": mergeSelectionReasonAged, "clean-first": mergeSelectionReasonClean, "clean-second": mergeSelectionReasonClean},
+		},
+		{
+			name:   "invalidated aged retry remains sticky",
+			issues: []connector.Issue{cleanFirst, invalidated},
+			state: func() *State {
+				state := State{Retry: map[string]Retry{
+					invalidated.ID: {Issue: invalidated, DueAt: now.Add(time.Minute)},
+				}}
+				return &state
+			},
+			wantOrder:   []string{"invalidated", "clean-first"},
+			wantReasons: map[string]string{"invalidated": mergeSelectionReasonStickyAged, "clean-first": mergeSelectionReasonClean},
+			wantSticky:  "invalidated",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			issues := cloneIssues(tt.issues)
+			var state *State
+			if tt.state != nil {
+				state = tt.state()
+			}
+			priority := prioritizeReadyMergingIssues(issues, state, now, threshold)
+			gotOrder := make([]string, 0, len(issues))
+			for _, issue := range issues {
+				gotOrder = append(gotOrder, issue.ID)
+			}
+			if !reflect.DeepEqual(gotOrder, tt.wantOrder) {
+				t.Fatalf("order = %#v, want %#v", gotOrder, tt.wantOrder)
+			}
+			if !reflect.DeepEqual(priority.reasons, tt.wantReasons) {
+				t.Fatalf("reasons = %#v, want %#v", priority.reasons, tt.wantReasons)
+			}
+			if priority.stickyIssueID != tt.wantSticky {
+				t.Fatalf("sticky issue = %q, want %q", priority.stickyIssueID, tt.wantSticky)
+			}
+		})
+	}
+}
+
 func TestLogMergeWorkerQueueCycle(t *testing.T) {
 	t.Parallel()
 
@@ -4315,6 +4466,7 @@ func TestLogMergeWorkerQueueCycle(t *testing.T) {
 	occupant := readyIssue("issue-occupant", "digitaldrywood/detent#1540", 1550)
 	firstWaiting := readyIssue("issue-first-waiting", "digitaldrywood/detent#1541", 1551)
 	secondWaiting := readyIssue("issue-second-waiting", "digitaldrywood/detent#1542", 1552)
+	firstWaiting.StageUpdatedAt = timePointer(now.Add(-3 * time.Hour))
 
 	tests := []struct {
 		name        string
@@ -4337,6 +4489,9 @@ func TestLogMergeWorkerQueueCycle(t *testing.T) {
 			want: []string{
 				"queue_depth=3",
 				"ready_count=3",
+				"aged_count=1",
+				"oldest_lane_age_seconds=10800",
+				"fairness_age_seconds=7200",
 				"lane_occupied=true",
 				"lane_saturated=true",
 				"lane_occupant_count=1",
@@ -4354,6 +4509,9 @@ func TestLogMergeWorkerQueueCycle(t *testing.T) {
 			want: []string{
 				"queue_depth=0",
 				"ready_count=0",
+				"aged_count=0",
+				"oldest_lane_age_seconds=0",
+				"fairness_age_seconds=7200",
 				"lane_occupied=false",
 				"lane_saturated=false",
 				"lane_occupant_count=0",

--- a/internal/orchestrator/config.go
+++ b/internal/orchestrator/config.go
@@ -29,6 +29,7 @@ func ConfigFromWorkflow(cfg workflowconfig.Config) Config {
 		DispatchPriorityByLabel:    append([]string(nil), cfg.Agent.DispatchPriorityByLabel...),
 		PrioritizeUnblockers:       cfg.Agent.PrioritizeUnblockers,
 		MergeFastPathEnabled:       cfg.Agent.MergeFastPath.Enabled,
+		MergeFairnessAge:           durationFromSeconds(cfg.Agent.MergeFastPath.FairnessAgeSeconds),
 		MergeMethod:                cfg.Deliverable.EffectiveMergeMethod(),
 		MergeWorkerStartupTimeout:  durationFromMillis(cfg.Agent.MergeWorkerStartupTimeoutMS),
 		MergeWorkerMaxDuration:     durationFromMillis(cfg.Agent.MergeWorkerMaxDurationMS),
@@ -173,6 +174,9 @@ func normalizeConfig(cfg Config) Config {
 	}
 	if cfg.MergeWorkerMaxDuration <= 0 {
 		cfg.MergeWorkerMaxDuration = durationFromMillis(workflowconfig.DefaultMergeWorkerMaxDurationMS)
+	}
+	if cfg.MergeFairnessAge <= 0 {
+		cfg.MergeFairnessAge = durationFromSeconds(workflowconfig.DefaultMergeFairnessAgeSeconds)
 	}
 	if cfg.ContinuationRetryDelay < 0 {
 		cfg.ContinuationRetryDelay = 0

--- a/internal/orchestrator/diagnostics.go
+++ b/internal/orchestrator/diagnostics.go
@@ -41,6 +41,8 @@ func (o *Orchestrator) logDispatchPlanDecision(ctx context.Context, state *State
 		result = "selected"
 		if decision.UnblockerCount > 0 {
 			reason = unblockerDecisionReason(decision.UnblockerCount)
+		} else if strings.TrimSpace(decision.SelectionReason) != "" {
+			reason = strings.TrimSpace(decision.SelectionReason)
 		} else if reason == "" {
 			reason = "selected"
 		}
@@ -55,6 +57,7 @@ func (o *Orchestrator) logDispatchPlanDecision(ctx context.Context, state *State
 	attrs := o.schedulerDecisionAttrs(state, now, decision.Issue,
 		"result", result,
 		"skip_reason", reason,
+		"selection_reason", strings.TrimSpace(decision.SelectionReason),
 		"queue_position", decision.QueuePosition,
 		"retry", decision.Retry,
 		"attempt", decision.Attempt,

--- a/internal/orchestrator/dispatch_planner.go
+++ b/internal/orchestrator/dispatch_planner.go
@@ -38,14 +38,15 @@ type dispatchAction struct {
 }
 
 type dispatchPlanDecision struct {
-	Issue          connector.Issue
-	QueuePosition  int
-	Attempt        int
-	WorkerHost     string
-	Retry          bool
-	Selected       bool
-	SkipReason     string
-	UnblockerCount int
+	Issue           connector.Issue
+	QueuePosition   int
+	Attempt         int
+	WorkerHost      string
+	Retry           bool
+	Selected        bool
+	SkipReason      string
+	SelectionReason string
+	UnblockerCount  int
 }
 
 func newDispatchPlanner(cfg Config) dispatchPlanner {
@@ -74,18 +75,31 @@ func (p dispatchPlanner) plan(
 	)
 	clearBlockedUnblockerCounts(plannedCandidates, state.Blocked)
 	sortIssuesForDispatch(plannedCandidates, p.cfg.DispatchPriorityByState, p.cfg.DispatchPriorityByLabel, p.cfg.PrioritizeUnblockers)
-	prioritizeReadyMergingIssues(plannedCandidates)
 	dueRetries := dueRetriesByIssue(state, now)
 	p.releaseMissingDueRetries(state, plannedCandidates, dueRetries, hooks)
+	dueRetries = dueRetriesByIssue(state, now)
+	mergePriority := prioritizeReadyMergingIssues(plannedCandidates, state, now, p.cfg.MergeFairnessAge)
+	logDecision := func(decision dispatchPlanDecision) {
+		decision.SelectionReason = mergePriority.reasons[strings.TrimSpace(decision.Issue.ID)]
+		p.logDecision(hooks, decision)
+	}
 
 	plan := DispatchPlan{}
 	continuations := 0
 	for index, issue := range plannedCandidates {
 		queuePosition := index + 1
+		if mergePriority.stickyIssueID != "" && mergeWorkerIssue(issue) && strings.TrimSpace(issue.ID) != mergePriority.stickyIssueID {
+			logDecision(dispatchPlanDecision{
+				Issue:         issue,
+				QueuePosition: queuePosition,
+				SkipReason:    dispatchSkipMergeFairnessReserved,
+			})
+			continue
+		}
 		if retry, ok := dueRetries[issue.ID]; ok {
 			action, ok, reason := p.retryAction(state, issue, retry, now)
 			if !ok {
-				p.logDecision(hooks, dispatchPlanDecision{
+				logDecision(dispatchPlanDecision{
 					Issue:         issue,
 					QueuePosition: queuePosition,
 					Attempt:       retry.Attempt,
@@ -95,7 +109,7 @@ func (p dispatchPlanner) plan(
 				})
 				continue
 			}
-			p.logDecision(hooks, dispatchPlanDecision{
+			logDecision(dispatchPlanDecision{
 				Issue:         action.issue,
 				QueuePosition: queuePosition,
 				Attempt:       action.attempt,
@@ -112,7 +126,7 @@ func (p dispatchPlanner) plan(
 		}
 		if p.hardAvailableSlots(state) == 0 {
 			for skipIndex := index; skipIndex < len(plannedCandidates); skipIndex++ {
-				p.logDecision(hooks, dispatchPlanDecision{
+				logDecision(dispatchPlanDecision{
 					Issue:         plannedCandidates[skipIndex],
 					QueuePosition: skipIndex + 1,
 					SkipReason:    dispatchSkipGlobalCapacityFull,
@@ -124,7 +138,7 @@ func (p dispatchPlanner) plan(
 			var ok bool
 			issue, ok = hooks.hydrate(issue)
 			if !ok {
-				p.logDecision(hooks, dispatchPlanDecision{
+				logDecision(dispatchPlanDecision{
 					Issue:         issue,
 					QueuePosition: queuePosition,
 					SkipReason:    dispatchSkipHydrationFailed,
@@ -134,7 +148,7 @@ func (p dispatchPlanner) plan(
 		}
 		action, ok, reason := p.dispatchAction(state, issue, now)
 		if !ok {
-			p.logDecision(hooks, dispatchPlanDecision{
+			logDecision(dispatchPlanDecision{
 				Issue:         issue,
 				QueuePosition: queuePosition,
 				SkipReason:    reason,
@@ -147,7 +161,7 @@ func (p dispatchPlanner) plan(
 			continuations++
 		}
 		if hooks.beforeDispatch != nil && !hooks.beforeDispatch(action.issue, continuationIndex) {
-			p.logDecision(hooks, dispatchPlanDecision{
+			logDecision(dispatchPlanDecision{
 				Issue:         action.issue,
 				QueuePosition: queuePosition,
 				Attempt:       action.attempt,
@@ -157,7 +171,7 @@ func (p dispatchPlanner) plan(
 			})
 			break
 		}
-		p.logDecision(hooks, dispatchPlanDecision{
+		logDecision(dispatchPlanDecision{
 			Issue:         action.issue,
 			QueuePosition: queuePosition,
 			Attempt:       action.attempt,
@@ -516,6 +530,7 @@ const (
 	dispatchSkipGlobalCapacityFull       = "global_capacity_full"
 	dispatchSkipHydrationFailed          = "hydrate_failed"
 	dispatchSkipDispatchBackoffCancelled = "dispatch_backoff_cancelled"
+	dispatchSkipMergeFairnessReserved    = "merge_fairness_head_reserved"
 	dispatchSkipGitHubRESTCapacity       = "github_rest_capacity_paused"
 	dispatchSkipCIUnavailable            = "ci_unavailable"
 	dispatchSkipProjectFailureBreaker    = projectFailureBreakerDispatchPaused

--- a/internal/orchestrator/dispatch_test.go
+++ b/internal/orchestrator/dispatch_test.go
@@ -245,6 +245,7 @@ func TestConfigFromWorkflowIncludesDispatchControls(t *testing.T) {
 	cfg.Agent.OverloadRetryDelayMS = 60000
 	cfg.Agent.MergeWorkerStartupTimeoutMS = 180000
 	cfg.Agent.MergeWorkerMaxDurationMS = 7200000
+	cfg.Agent.MergeFastPath.FairnessAgeSeconds = 5400
 	cfg.Observability.StrandedActiveThresholdSeconds = 42
 	cfg.Deliverable.MergeMethod = workflowconfig.MergeMethodRebase
 	cfg.Agent.OutputTruncation.MaxBytes = 4096
@@ -341,6 +342,9 @@ func TestConfigFromWorkflowIncludesDispatchControls(t *testing.T) {
 	}
 	if !got.MergeFastPathEnabled {
 		t.Fatal("MergeFastPathEnabled = false, want true")
+	}
+	if got.MergeFairnessAge != 90*time.Minute {
+		t.Fatalf("MergeFairnessAge = %s, want 1h30m0s", got.MergeFairnessAge)
 	}
 	if got.MergeMethod != workflowconfig.MergeMethodRebase {
 		t.Fatalf("MergeMethod = %q, want rebase", got.MergeMethod)

--- a/internal/orchestrator/merge_queue.go
+++ b/internal/orchestrator/merge_queue.go
@@ -41,14 +41,18 @@ func (o *Orchestrator) delegateNativeMergeQueueIssues(
 		return out
 	}
 	pruneNativeMergeQueueEntries(state, out)
+	stickyIssueID := stickyMergingIssueID(state, out, now, o.cfg.MergeFairnessAge)
 
-	for _, candidate := range staleMergingQueueIssues(out, o.cfg) {
+	for _, candidate := range staleMergingQueueIssues(out, o.cfg, state, now) {
 		issueID := strings.TrimSpace(candidate.ID)
 		if !nativeMergeQueueCandidate(candidate, o.cfg) || staleMergingPullRequestDispatchActive(state, issueID) {
 			continue
 		}
 		if cached, ok := state.nativeMergeQueueEntries[issueID]; ok && now.Sub(cached.CheckedAt) < nativeMergeQueueEntryRefresh {
 			applyNativeMergeQueueEntry(out, issueID, cached.Entry)
+			continue
+		}
+		if stickyIssueID != "" && issueID != stickyIssueID {
 			continue
 		}
 

--- a/internal/orchestrator/merge_queue_test.go
+++ b/internal/orchestrator/merge_queue_test.go
@@ -72,6 +72,76 @@ func TestDelegateNativeMergeQueueIssuesEnqueuesGreenTrainWithoutWorkerDispatch(t
 	}
 }
 
+func TestDelegateNativeMergeQueueIssuesHonorsAgedHeadReservation(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 8, 9, 4, 20, 0, 0, time.UTC)
+	agedAt := now.Add(-3 * time.Hour)
+	aged := nativeMergeQueueTestIssue(1748, "pending")
+	aged.ID = "issue-aged-native-head"
+	aged.StageUpdatedAt = &agedAt
+	recent := nativeMergeQueueTestIssue(1749, "success")
+	recent.ID = "issue-recent-native-head"
+	recent.Identifier = "digitaldrywood/pyroapex#1749"
+	recent.PRRepository = "digitaldrywood/pyroapex"
+	recent.PullRequest.URL = "https://github.test/digitaldrywood/pyroapex/pull/1749"
+	recentAt := now.Add(-time.Minute)
+	recent.StageUpdatedAt = &recentAt
+	cfg := normalizeConfig(Config{
+		MergeFastPathEnabled: true,
+		MaxConcurrentAgents:  1,
+		MaxConcurrentAgentsByState: map[string]int{
+			"Merging": 1,
+		},
+		ActiveStates:   []string{"Merging"},
+		TerminalStates: []string{"Done"},
+	})
+
+	tests := []struct {
+		name  string
+		setup func(*State)
+	}{
+		{
+			name: "running aged head",
+			setup: func(state *State) {
+				state.Running[aged.ID] = Running{Issue: aged, StartedAt: now.Add(-time.Minute)}
+			},
+		},
+		{
+			name: "retrying aged head",
+			setup: func(state *State) {
+				state.Retry[aged.ID] = Retry{Issue: aged, DueAt: now.Add(time.Minute)}
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			tracker := &nativeMergeQueueConnector{
+				autoPromoteTickMergeConnector: &autoPromoteTickMergeConnector{
+					autoPromoteTickConnector: &autoPromoteTickConnector{},
+				},
+			}
+			orch := &Orchestrator{cfg: cfg, connector: tracker}
+			state := newState(cfg)
+			tt.setup(&state)
+
+			queued := orch.delegateNativeMergeQueueIssues(context.Background(), &state, []connector.Issue{aged, recent}, now)
+
+			if len(tracker.enqueued) != 0 || tracker.inspections != 0 {
+				t.Fatalf("native queue activity = enqueued %#v, inspections %d; want none", tracker.enqueued, tracker.inspections)
+			}
+			for _, issue := range queued {
+				if issue.PullRequest != nil && issue.PullRequest.MergeQueueEntry != nil {
+					t.Fatalf("issue %q merge queue entry = %#v, want none", issue.ID, issue.PullRequest.MergeQueueEntry)
+				}
+			}
+		})
+	}
+}
+
 func TestTickDelegatesNativeMergeQueueTrainWithoutAgentDispatch(t *testing.T) {
 	t.Parallel()
 

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -74,6 +74,7 @@ type Config struct {
 	DispatchPriorityByLabel       []string
 	PrioritizeUnblockers          bool
 	MergeFastPathEnabled          bool
+	MergeFairnessAge              time.Duration
 	MergeMethod                   string
 	MergeWorkerStartupTimeout     time.Duration
 	MergeWorkerMaxDuration        time.Duration

--- a/internal/orchestrator/retry_test.go
+++ b/internal/orchestrator/retry_test.go
@@ -194,6 +194,149 @@ func TestDispatchReadyIssuesDefersNotReadyMergeRetryBehindReadyHead(t *testing.T
 	}
 }
 
+func TestDispatchReadyIssuesMergeFairnessReservation(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 8, 9, 4, 20, 0, 0, time.UTC)
+	threshold := 2 * time.Hour
+	tests := []struct {
+		name             string
+		enteredAt        time.Time
+		wantReadyRunning bool
+		wantReadyReason  string
+	}{
+		{
+			name:             "non-aged retry yields to clean head",
+			enteredAt:        now.Add(-threshold + time.Second),
+			wantReadyRunning: true,
+			wantReadyReason:  mergeSelectionReasonClean,
+		},
+		{
+			name:            "aged retry reserves lane after invalidation",
+			enteredAt:       now.Add(-threshold),
+			wantReadyReason: dispatchSkipMergeFairnessReserved,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			cfg := normalizeConfig(Config{
+				MaxConcurrentAgents: 1,
+				MaxConcurrentAgentsByState: map[string]int{
+					"Merging": 1,
+				},
+				DispatchPriorityByState: []string{"Merging"},
+				ActiveStates:            []string{"Merging"},
+				TerminalStates:          []string{"Done"},
+				MergeFairnessAge:        threshold,
+			})
+			orch := Orchestrator{
+				cfg:        cfg,
+				supervisor: newTestSupervisor(t, FakeRunner{}, cfg),
+				runResults: make(chan runpkg.Completion, 1),
+			}
+			state := newState(cfg)
+			invalidated := nativeMergeQueueTestIssue(1748, "pending")
+			invalidated.ID = "issue-invalidated-aged-head"
+			invalidated.StageUpdatedAt = timePointer(tt.enteredAt)
+			invalidated.PullRequest.MergeableState = "behind"
+			ready := nativeMergeQueueTestIssue(1749, "success")
+			ready.ID = "issue-new-clean-head"
+			ready.Identifier = "digitaldrywood/pyroapex#1749"
+			ready.PRRepository = "digitaldrywood/pyroapex"
+			ready.PullRequest.URL = "https://github.test/digitaldrywood/pyroapex/pull/1749"
+			ready.StageUpdatedAt = timePointer(now.Add(-time.Minute))
+
+			state.Claimed[invalidated.ID] = Claimed{Issue: invalidated, ClaimedAt: now.Add(-time.Minute)}
+			state.Retry[invalidated.ID] = Retry{
+				Issue:   invalidated,
+				Attempt: 1,
+				DueAt:   now.Add(time.Minute),
+				Error:   "waiting for current-head CI",
+			}
+
+			orch.dispatchReadyIssues(context.Background(), &state, []connector.Issue{invalidated, ready}, now)
+
+			_, readyRunning := state.Running[ready.ID]
+			if readyRunning != tt.wantReadyRunning {
+				t.Fatalf("ready running = %t, want %t", readyRunning, tt.wantReadyRunning)
+			}
+			if _, ok := state.Retry[invalidated.ID]; !ok {
+				t.Fatalf("Retry[%q] missing", invalidated.ID)
+			}
+			gotReason := ""
+			for _, decision := range state.SchedulerDecisions {
+				if decision.IssueID == ready.ID {
+					gotReason = decision.Reason
+				}
+			}
+			if gotReason != tt.wantReadyReason {
+				t.Fatalf("ready decision reason = %q, want %q", gotReason, tt.wantReadyReason)
+			}
+		})
+	}
+}
+
+func TestDispatchReadyIssuesReleasesMissingAgedRetryBeforeFairnessReservation(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 8, 9, 5, 0, 0, 0, time.UTC)
+	threshold := 2 * time.Hour
+	cfg := normalizeConfig(Config{
+		MaxConcurrentAgents: 1,
+		MaxConcurrentAgentsByState: map[string]int{
+			"Merging": 1,
+		},
+		DispatchPriorityByState: []string{"Merging"},
+		ActiveStates:            []string{"Merging"},
+		TerminalStates:          []string{"Done"},
+		MergeFairnessAge:        threshold,
+	})
+	orch := Orchestrator{
+		cfg:        cfg,
+		supervisor: newTestSupervisor(t, FakeRunner{}, cfg),
+		runResults: make(chan runpkg.Completion, 1),
+	}
+	state := newState(cfg)
+	missing := nativeMergeQueueTestIssue(1748, "pending")
+	missing.ID = "issue-missing-aged-retry"
+	missing.StageUpdatedAt = timePointer(now.Add(-threshold))
+	ready := nativeMergeQueueTestIssue(1751, "success")
+	ready.ID = "issue-current-clean-head"
+	ready.Identifier = "digitaldrywood/pyroapex#1751"
+	ready.PRRepository = "digitaldrywood/pyroapex"
+	ready.PullRequest.URL = "https://github.test/digitaldrywood/pyroapex/pull/1751"
+	ready.StageUpdatedAt = timePointer(now.Add(-time.Minute))
+
+	state.Claimed[missing.ID] = Claimed{Issue: missing, ClaimedAt: now.Add(-time.Minute)}
+	state.Retry[missing.ID] = Retry{
+		Issue:   missing,
+		Attempt: 1,
+		DueAt:   now.Add(-time.Millisecond),
+		Error:   "waiting for current-head CI",
+	}
+
+	orch.dispatchReadyIssues(context.Background(), &state, []connector.Issue{ready}, now)
+
+	if _, ok := state.Retry[missing.ID]; ok {
+		t.Fatalf("Retry[%q] present after missing due retry cleanup", missing.ID)
+	}
+	if _, ok := state.Running[ready.ID]; !ok {
+		t.Fatalf("Running[%q] missing after stale reservation cleanup", ready.ID)
+	}
+	gotReason := ""
+	for _, decision := range state.SchedulerDecisions {
+		if decision.IssueID == ready.ID {
+			gotReason = decision.Reason
+		}
+	}
+	if gotReason != mergeSelectionReasonClean {
+		t.Fatalf("ready decision reason = %q, want %q", gotReason, mergeSelectionReasonClean)
+	}
+}
+
 func TestDispatchReadyIssuesRevisitsDeferredMergeWhenCurrentHeadBecomesReady(t *testing.T) {
 	t.Parallel()
 

--- a/internal/orchestrator/snapshot_test.go
+++ b/internal/orchestrator/snapshot_test.go
@@ -1214,6 +1214,9 @@ func TestStateSnapshotIncludesMergeTimingTelemetry(t *testing.T) {
 	if len(snapshot.Pipeline) != 1 || snapshot.Pipeline[0].MergeTiming == nil {
 		t.Fatalf("Pipeline = %#v, want queued merge timing", snapshot.Pipeline)
 	}
+	if snapshot.Pipeline[0].CurrentLaneAgeSeconds != 540 {
+		t.Fatalf("Pipeline current lane age = %d, want 540 seconds", snapshot.Pipeline[0].CurrentLaneAgeSeconds)
+	}
 	queued := snapshot.Pipeline[0].MergeTiming
 	if queued.QueueWaitSeconds != 540 || queued.TotalMergingSeconds != 540 || queued.HeadSHA != "queued-head" || queued.BaseSHA != "queued-base" {
 		t.Fatalf("queued MergeTiming = %#v, want queue duration and PR SHAs", queued)


### PR DESCRIPTION
## Summary

- Age Merging work ahead of newer clean heads after a configurable threshold so continuous arrivals cannot starve older PRs.
- Reserve an aged running or retrying head through its update-and-CI cycle, including native merge-queue delegation.
- Expose queue age, selection order, and selection reason in structured telemetry while preserving the board lane-age read model.

Fixes #1748

## UI Surface Contract

- [x] N/A, or the linked issue explicitly authorizes any high-impact UI surface, layout, density, first-viewport, or responsive visibility tradeoff.
- [x] Persistent top-of-screen messaging is explicitly authorized by the issue, or this PR does not add it.
- [x] Visual changes to primary operator screens include screenshot or browser verification below.

No visual UI changes; the existing board lane-age data is now backed by fair queue selection telemetry.

## Test Plan

- [x] `make check`
