### PR TITLE
ci: move portability stress off merge gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -224,16 +224,6 @@ jobs:
       - name: Test
         run: go test ./...
 
-      - name: Stress local SQLite artifact lifecycle
-        if: runner.os == 'Windows'
-        run: go test ./internal/orchestrator -run '^TestLocalSQLiteArtifactLifecycleEndToEnd$' -count=20
-
-      - name: Stress timing-sensitive packages
-        run: go test -race ./internal/cli ./internal/runner ./tools/checklock -count=10 -timeout=30m
-
-      - name: Race test
-        run: go test -race ./...
-
   windows-core:
     name: Windows Core
     runs-on: windows-latest

--- a/.github/workflows/portability-stress.yml
+++ b/.github/workflows/portability-stress.yml
@@ -1,0 +1,39 @@
+name: Portability Stress
+
+on:
+  schedule:
+    - cron: '41 10 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  portability-stress:
+    name: Portability Stress (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 45
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [macos-latest, windows-latest]
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: actions/setup-go@v6
+        with:
+          go-version: '1.26.5'
+          cache: true
+
+      - name: Download modules
+        run: go mod download
+
+      - name: Stress local SQLite artifact lifecycle
+        if: runner.os == 'Windows'
+        run: go test ./internal/orchestrator -run '^TestLocalSQLiteArtifactLifecycleEndToEnd$' -count=20
+
+      - name: Stress timing-sensitive packages
+        run: go test -race ./internal/cli ./internal/runner ./tools/checklock -count=10 -timeout=30m
+
+      - name: Race test
+        run: go test -race ./...

--- a/ci_workflow_test.go
+++ b/ci_workflow_test.go
@@ -48,14 +48,14 @@ var requiredPRStatusChecks = []requiredStatusCheck{
 		budget:   "8m",
 		jobStart: "  portability-verify:",
 		jobEnd:   "  windows-core:",
-		markers:  []string{"name: Portability Verify (${{ matrix.os }})", "os: [macos-latest, windows-latest]"},
+		markers:  []string{"name: Portability Verify (${{ matrix.os }})", "os: [macos-latest, windows-latest]", "go build ./...", "go vet ./...", "go test ./..."},
 	},
 	{
 		name:     "Portability Verify (windows-latest)",
 		budget:   "8m",
 		jobStart: "  portability-verify:",
 		jobEnd:   "  windows-core:",
-		markers:  []string{"name: Portability Verify (${{ matrix.os }})", "os: [macos-latest, windows-latest]"},
+		markers:  []string{"name: Portability Verify (${{ matrix.os }})", "os: [macos-latest, windows-latest]", "go build ./...", "go vet ./...", "go test ./..."},
 	},
 	{
 		name:     "Windows Core",
@@ -178,6 +178,36 @@ func TestRequiredChecksDoNotUseEventDependentGreenNoops(t *testing.T) {
 				t.Fatalf("required check %q contains green no-op marker %q", check.name, forbidden)
 			}
 		}
+	}
+}
+
+func TestPortabilityStressRunsOutsidePullRequestGate(t *testing.T) {
+	t.Parallel()
+
+	requiredWorkflow := readNormalizedFile(t, ".github/workflows/ci.yml")
+	requiredJob := workflowBetween(t, requiredWorkflow, "  portability-verify:", "\n  windows-core:")
+	for _, forbidden := range []string{"go test -race", "-count=10", "-count=20"} {
+		if strings.Contains(requiredJob, forbidden) {
+			t.Fatalf("required portability job contains heavy coverage %q", forbidden)
+		}
+	}
+
+	stressWorkflow := readNormalizedFile(t, ".github/workflows/portability-stress.yml")
+	for _, want := range []string{
+		"schedule:",
+		"workflow_dispatch:",
+		"timeout-minutes: 45",
+		"os: [macos-latest, windows-latest]",
+		"go test ./internal/orchestrator -run '^TestLocalSQLiteArtifactLifecycleEndToEnd$' -count=20",
+		"go test -race ./internal/cli ./internal/runner ./tools/checklock -count=10 -timeout=30m",
+		"go test -race ./...",
+	} {
+		if !strings.Contains(stressWorkflow, want) {
+			t.Fatalf("portability stress workflow missing %q", want)
+		}
+	}
+	if strings.Contains(stressWorkflow, "pull_request:") {
+		t.Fatal("portability stress workflow must not run for every pull request")
 	}
 }
 

--- a/docs/execution-seams.md
+++ b/docs/execution-seams.md
@@ -138,11 +138,29 @@ Required PR merge checks, branch protection/rulesets, and
 - `Installer Smoke (windows-latest)` - budget: `6m`
 - `GoReleaser Snapshot` - budget: `8m`
 
-Release and portability checks also run on `main`, on `v*` release tags, on the
-nightly CI schedule, and from manual workflow dispatch. They are still
-release-blocking for pull requests; Detent must not promote or merge a PR head
-where one of these checks is missing, skipped, failed, cancelled, neutral, or
-still running.
+The required portability checks are limited to build, vet, and the non-race
+test suite so each platform stays within its `8m` merge-path budget. Repeated
+race loops, the full race suite on macOS and Windows, and the Windows SQLite
+artifact lifecycle stress loop run nightly and on manual dispatch in
+`.github/workflows/portability-stress.yml`. That workflow has a `45m` ceiling;
+failures are surfaced as failed `Portability Stress` workflow runs with the
+failing command output in the job log.
+
+Release and required portability checks also run on `main`, on `v*` release
+tags, on the nightly CI schedule, and from manual workflow dispatch. They are
+still release-blocking for pull requests; Detent must not promote or merge a PR
+head where one of these checks is missing, skipped, failed, cancelled, neutral,
+or still running.
+
+GitHub merge queue adoption is deferred. Detent currently owns merge ordering,
+rebases each head onto current `main`, validates that exact head, and merges it
+through the REST API. GitHub merge queue would require Detent to enqueue rather
+than merge, validate `merge_group` commits, and reconcile queue ejections back
+to tracker state. That larger delivery-state change is not justified merely to
+remove the long portability checks from this critical path. The trade-off is
+that strict current-base validation still invalidates other open heads after a
+merge; keeping all required jobs within their written budgets bounds that cost
+without weakening `required_status_checks.strict: true`.
 
 The CI workflow keeps pull request runs cancellable by newer pushes to the same
 PR through `cancel-in-progress: ${{ github.event_name == 'pull_request' }}`.

--- a/internal/project/project_test.go
+++ b/internal/project/project_test.go
@@ -863,6 +863,7 @@ func TestProjectHotReloadAppliesRuntimeGitHubTokenBeforeValidation(t *testing.T)
 	}
 
 	connectorConfigs := make(chan workflowconfig.Config, 2)
+	var logs lockedBuffer
 	got, err := project.New(project.Config{
 		Project: globalconfig.Project{
 			ID:       "pyroapex",
@@ -872,6 +873,7 @@ func TestProjectHotReloadAppliesRuntimeGitHubTokenBeforeValidation(t *testing.T)
 		Workflow: workflow,
 	}, project.Dependencies{
 		GitHubToken: "global-token",
+		Logger:      slog.New(slog.NewTextHandler(&logs, nil)),
 		ConnectorFactory: func(cfg workflowconfig.Config) (connector.Connector, error) {
 			connectorConfigs <- cfg
 			return provisioningConnector{}, nil
@@ -894,11 +896,10 @@ func TestProjectHotReloadAppliesRuntimeGitHubTokenBeforeValidation(t *testing.T)
 		}
 	}()
 
-	watcherDelay := time.NewTimer(25 * time.Millisecond)
-	<-watcherDelay.C
+	waitForWorkflowWatcherArmed(t, got)
 
 	writeProjectGitHubWorkflow(t, workflowPath, 60000, "reloaded")
-	waitForWorkflowPrompt(t, got, "reloaded\n")
+	waitForProjectLog(t, &logs, "workflow reloaded")
 
 	reloaded := receiveConnectorConfig(t, connectorConfigs)
 	if reloaded.Tracker.APIKey != "global-token" {
@@ -911,10 +912,11 @@ func TestProjectHotReloadAppliesRuntimeGitHubTokenBeforeValidation(t *testing.T)
 	if err := os.WriteFile(workflowPath, []byte("---\ntracker: [\n"), 0o600); err != nil {
 		t.Fatalf("WriteFile(%s) error = %v", workflowPath, err)
 	}
+	waitForProjectLog(t, &logs, "workflow reload failed")
 	select {
 	case extra := <-connectorConfigs:
 		t.Fatalf("connector rebuilt after invalid reload = %#v", extra)
-	case <-time.After(250 * time.Millisecond):
+	default:
 	}
 	if got.Workflow().Prompt != "reloaded\n" {
 		t.Fatalf("Workflow().Prompt after invalid reload = %q, want last valid workflow", got.Workflow().Prompt)
@@ -1566,8 +1568,27 @@ func waitForWorkflowWatcher(t *testing.T, ready <-chan struct{}) {
 
 	select {
 	case <-ready:
-	case <-time.After(time.Second):
+	case <-time.After(10 * time.Second):
 		t.Fatal("timed out waiting for workflow watcher")
+	}
+}
+
+func waitForProjectLog(t *testing.T, logs *lockedBuffer, want string) {
+	t.Helper()
+
+	ticker := time.NewTicker(10 * time.Millisecond)
+	defer ticker.Stop()
+	deadline := time.After(10 * time.Second)
+
+	for {
+		if strings.Contains(logs.String(), want) {
+			return
+		}
+		select {
+		case <-ticker.C:
+		case <-deadline:
+			t.Fatalf("timed out waiting for project log %q; logs = %q", want, logs.String())
+		}
 	}
 }
 
@@ -1576,7 +1597,7 @@ func waitForWorkflowWatcherArmed(t *testing.T, got *project.Project) {
 
 	ticker := time.NewTicker(10 * time.Millisecond)
 	defer ticker.Stop()
-	deadline := time.After(time.Second)
+	deadline := time.After(10 * time.Second)
 
 	for {
 		if got.WorkflowSourceStatus().WatcherArmed {


### PR DESCRIPTION
## Summary

- Keep the existing required macOS and Windows portability contexts, but limit them to build, vet, and non-race tests so they fit the documented 8-minute merge-path budget.
- Move the full cross-platform race suites and repeated stress loops to a nightly/manual `Portability Stress` workflow with a 45-minute ceiling and visible workflow failures.
- Stabilize the runtime GitHub-token hot-reload regression by synchronizing watcher readiness and reload completion instead of relying on fixed wall-clock margins.
- Record the decision to defer GitHub merge queue adoption while Detent owns exact-head rebase, validation, and REST merge state.

The slow required job was cumulative by construction: it ran build, vet, all tests, repeated race stress, and the full race suite on every pull request. The reported test also guessed fsnotify readiness with a 25 ms sleep and inferred invalid-reload completion from a 250 ms wait, which was unreliable on loaded Windows runners.

Fixes #1749

## UI Surface Contract

- [x] N/A, or the linked issue explicitly authorizes any high-impact UI surface, layout, density, first-viewport, or responsive visibility tradeoff.
- [x] Persistent top-of-screen messaging is explicitly authorized by the issue, or this PR does not add it.
- [x] Visual changes to primary operator screens include screenshot or browser verification below. N/A: no UI changes.

## Test Plan

- [x] `make check`
- [x] `go test -race ./internal/project -run '^TestProjectHotReloadAppliesRuntimeGitHubTokenBeforeValidation$' -count=100`
- [x] `go test -race ./internal/project -count=10`
- [x] workflow contract tests and Actions workflow lint
