### PR TITLE
fix(codex): allow browser MCP elicitation

### DIFF
--- a/internal/codex/appserver.go
+++ b/internal/codex/appserver.go
@@ -1158,10 +1158,7 @@ func mcpElicitationResponse(params json.RawMessage) (map[string]any, mcpElicitat
 		ServerName      string          `json:"serverName"`
 		Mode            string          `json:"mode"`
 		Meta            json.RawMessage `json:"_meta"`
-		RequestedSchema struct {
-			Type       string                     `json:"type"`
-			Properties map[string]json.RawMessage `json:"properties"`
-		} `json:"requestedSchema"`
+		RequestedSchema json.RawMessage `json:"requestedSchema"`
 	}
 	if err := json.Unmarshal(params, &request); err != nil {
 		return decline()
@@ -1190,9 +1187,7 @@ func mcpElicitationResponse(params json.RawMessage) (map[string]any, mcpElicitat
 		decision.Reason = "unsupported_approval_kind"
 		return decline()
 	}
-	if request.RequestedSchema.Type != "object" ||
-		request.RequestedSchema.Properties == nil ||
-		len(request.RequestedSchema.Properties) != 0 {
+	if !isEmptyObjectSchema(request.RequestedSchema) {
 		decision.Reason = "unsupported_schema"
 		return decline()
 	}
@@ -1200,6 +1195,24 @@ func mcpElicitationResponse(params json.RawMessage) (map[string]any, mcpElicitat
 	decision.Action = "accept"
 	decision.Reason = "supported_browser_tool_approval"
 	return map[string]any{"action": "accept", "content": map[string]any{}}, decision
+}
+
+func isEmptyObjectSchema(data json.RawMessage) bool {
+	var schema map[string]json.RawMessage
+	if err := json.Unmarshal(data, &schema); err != nil || len(schema) != 2 {
+		return false
+	}
+
+	var schemaType string
+	if err := json.Unmarshal(schema["type"], &schemaType); err != nil || schemaType != "object" {
+		return false
+	}
+
+	var properties map[string]json.RawMessage
+	if err := json.Unmarshal(schema["properties"], &properties); err != nil {
+		return false
+	}
+	return properties != nil && len(properties) == 0
 }
 
 func logMCPElicitationDecision(ctx context.Context, logger *slog.Logger, decision mcpElicitationDecision) {

--- a/internal/codex/appserver.go
+++ b/internal/codex/appserver.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"log/slog"
 	"strconv"
 	"strings"
 	"time"
@@ -23,6 +24,8 @@ const (
 	modelListRequestID    = 6
 	threadReadRequestID   = 7
 	methodNotFoundCode    = -32601
+	chromeDevToolsServer  = "chrome-devtools"
+	mcpToolApprovalKind   = "mcp_tool_call"
 
 	defaultClientName    = "detent-orchestrator"
 	defaultClientTitle   = "Detent Orchestrator"
@@ -144,6 +147,7 @@ func (e *TurnFailedError) BackendErrorMessage() string {
 type AppServer struct {
 	transportFactory TransportFactory
 	clientInfo       ClientInfo
+	logger           *slog.Logger
 	readTimeout      time.Duration
 	turnTimeout      time.Duration
 }
@@ -297,6 +301,7 @@ func NewAppServer(factory TransportFactory, opts ...AppServerOption) (*AppServer
 			Title:   defaultClientTitle,
 			Version: defaultClientVersion,
 		},
+		logger:      slog.Default(),
 		readTimeout: defaultReadTimeout,
 		turnTimeout: defaultTurnTimeout,
 	}
@@ -309,6 +314,9 @@ func NewAppServer(factory TransportFactory, opts ...AppServerOption) (*AppServer
 	}
 	if server.clientInfo.Version == "" {
 		server.clientInfo.Version = defaultClientVersion
+	}
+	if server.logger == nil {
+		server.logger = slog.Default()
 	}
 	if server.readTimeout <= 0 {
 		server.readTimeout = defaultReadTimeout
@@ -323,6 +331,12 @@ func NewAppServer(factory TransportFactory, opts ...AppServerOption) (*AppServer
 func WithClientInfo(info ClientInfo) AppServerOption {
 	return func(server *AppServer) {
 		server.clientInfo = info
+	}
+}
+
+func WithLogger(logger *slog.Logger) AppServerOption {
+	return func(server *AppServer) {
+		server.logger = logger
 	}
 }
 
@@ -940,7 +954,7 @@ func (s *AppServer) awaitResponse(
 			return msg.Result, nil
 		}
 
-		handled, err := handleServerRequest(ctx, transport, msg, toolHandler)
+		handled, err := handleServerRequest(ctx, transport, msg, toolHandler, s.logger)
 		if err != nil {
 			return nil, err
 		}
@@ -974,7 +988,7 @@ func (s *AppServer) streamTurn(
 			return fmt.Errorf("stream turn: %w", err)
 		}
 
-		handled, err := handleServerRequest(ctx, transport, msg, toolHandler)
+		handled, err := handleServerRequest(ctx, transport, msg, toolHandler, s.logger)
 		if err != nil {
 			return err
 		}
@@ -1040,7 +1054,13 @@ func sendRequest(ctx context.Context, transport Transport, id int, method string
 	})
 }
 
-func handleServerRequest(ctx context.Context, transport Transport, msg Message, toolHandler DynamicToolHandler) (bool, error) {
+func handleServerRequest(
+	ctx context.Context,
+	transport Transport,
+	msg Message,
+	toolHandler DynamicToolHandler,
+	logger *slog.Logger,
+) (bool, error) {
 	if msg.Method == "" || len(msg.ID) == 0 {
 		return false, nil
 	}
@@ -1048,7 +1068,7 @@ func handleServerRequest(ctx context.Context, transport Transport, msg Message, 
 	response := Message{
 		ID: msg.ID,
 	}
-	result, ok, err := serverRequestResult(ctx, msg, toolHandler)
+	result, ok, err := serverRequestResult(ctx, msg, toolHandler, logger)
 	if err != nil {
 		return true, err
 	}
@@ -1067,7 +1087,12 @@ func handleServerRequest(ctx context.Context, transport Transport, msg Message, 
 	return true, nil
 }
 
-func serverRequestResult(ctx context.Context, msg Message, toolHandler DynamicToolHandler) (json.RawMessage, bool, error) {
+func serverRequestResult(
+	ctx context.Context,
+	msg Message,
+	toolHandler DynamicToolHandler,
+	logger *slog.Logger,
+) (json.RawMessage, bool, error) {
 	var result any
 	switch msg.Method {
 	case "item/commandExecution/requestApproval", "item/fileChange/requestApproval":
@@ -1077,7 +1102,9 @@ func serverRequestResult(ctx context.Context, msg Message, toolHandler DynamicTo
 	case "item/tool/requestUserInput":
 		result = map[string]any{"answers": map[string]any{}}
 	case "mcpServer/elicitation/request":
-		result = map[string]any{"action": "decline", "content": nil}
+		response, decision := mcpElicitationResponse(msg.Params)
+		logMCPElicitationDecision(ctx, logger, decision)
+		result = response
 	case "item/tool/call":
 		if toolHandler == nil {
 			result = map[string]any{
@@ -1108,6 +1135,89 @@ func serverRequestResult(ctx context.Context, msg Message, toolHandler DynamicTo
 		return nil, true, fmt.Errorf("marshal %s server request response: %w", msg.Method, err)
 	}
 	return data, true, nil
+}
+
+type mcpElicitationDecision struct {
+	Server       string
+	Mode         string
+	ApprovalKind string
+	Action       string
+	Reason       string
+}
+
+func mcpElicitationResponse(params json.RawMessage) (map[string]any, mcpElicitationDecision) {
+	decision := mcpElicitationDecision{
+		Action: "decline",
+		Reason: "invalid_request",
+	}
+	decline := func() (map[string]any, mcpElicitationDecision) {
+		return map[string]any{"action": "decline", "content": nil}, decision
+	}
+
+	var request struct {
+		ServerName      string          `json:"serverName"`
+		Mode            string          `json:"mode"`
+		Meta            json.RawMessage `json:"_meta"`
+		RequestedSchema struct {
+			Type       string                     `json:"type"`
+			Properties map[string]json.RawMessage `json:"properties"`
+		} `json:"requestedSchema"`
+	}
+	if err := json.Unmarshal(params, &request); err != nil {
+		return decline()
+	}
+
+	decision.Server = request.ServerName
+	decision.Mode = request.Mode
+	if request.ServerName != chromeDevToolsServer {
+		decision.Reason = "unsupported_server"
+		return decline()
+	}
+	if request.Mode != "form" {
+		decision.Reason = "unsupported_mode"
+		return decline()
+	}
+
+	var meta struct {
+		ApprovalKind string `json:"codex_approval_kind"`
+	}
+	if err := json.Unmarshal(request.Meta, &meta); err != nil {
+		decision.Reason = "invalid_metadata"
+		return decline()
+	}
+	decision.ApprovalKind = meta.ApprovalKind
+	if meta.ApprovalKind != mcpToolApprovalKind {
+		decision.Reason = "unsupported_approval_kind"
+		return decline()
+	}
+	if request.RequestedSchema.Type != "object" ||
+		request.RequestedSchema.Properties == nil ||
+		len(request.RequestedSchema.Properties) != 0 {
+		decision.Reason = "unsupported_schema"
+		return decline()
+	}
+
+	decision.Action = "accept"
+	decision.Reason = "supported_browser_tool_approval"
+	return map[string]any{"action": "accept", "content": map[string]any{}}, decision
+}
+
+func logMCPElicitationDecision(ctx context.Context, logger *slog.Logger, decision mcpElicitationDecision) {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	level := slog.LevelInfo
+	if decision.Action != "accept" {
+		level = slog.LevelWarn
+	}
+	logger.LogAttrs(ctx, level, "codex MCP elicitation decision",
+		slog.String("method", "mcpServer/elicitation/request"),
+		slog.String("server", decision.Server),
+		slog.String("mode", decision.Mode),
+		slog.String("approval_kind", decision.ApprovalKind),
+		slog.String("action", decision.Action),
+		slog.String("reason", decision.Reason),
+	)
 }
 
 func dynamicToolResponse(content string, success bool) map[string]any {

--- a/internal/codex/appserver_test.go
+++ b/internal/codex/appserver_test.go
@@ -1,10 +1,12 @@
 package codex
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
 	"io"
+	"log/slog"
 	"reflect"
 	"strconv"
 	"strings"
@@ -985,6 +987,7 @@ func TestReceiveTurnMessageTimeoutSelection(t *testing.T) {
 func TestAppServerRunTurnRespondsToServerRequests(t *testing.T) {
 	t.Parallel()
 
+	var logs bytes.Buffer
 	transport := newFakeAppServerTransport([]Message{
 		responseMessage(t, 1, `{"userAgent":"codex-cli/0.135.0"}`),
 		responseMessage(t, 2, `{"thread":{"id":"thread-1"}}`),
@@ -994,11 +997,29 @@ func TestAppServerRunTurnRespondsToServerRequests(t *testing.T) {
 		serverRequestMessage(t, 41, "item/commandExecution/requestApproval", `{"threadId":"thread-1","turnId":"turn-1"}`),
 		serverRequestMessage(t, 42, "item/fileChange/requestApproval", `{"threadId":"thread-1","turnId":"turn-1"}`),
 		serverRequestMessage(t, 43, "item/permissions/requestApproval", `{"threadId":"thread-1","turnId":"turn-1"}`),
-		serverRequestMessage(t, 44, "mcpServer/elicitation/request", `{"threadId":"thread-1","turnId":"turn-1"}`),
-		serverRequestMessage(t, 45, "custom/request", `{"threadId":"thread-1","turnId":"turn-1"}`),
+		serverRequestMessage(t, 44, "mcpServer/elicitation/request", `{
+			"threadId":"thread-1",
+			"turnId":"turn-1",
+			"serverName":"chrome-devtools",
+			"mode":"form",
+			"message":"Allow the chrome-devtools MCP server to run tool \"navigate_page\"?",
+			"requestedSchema":{"type":"object","properties":{}},
+			"_meta":{"codex_approval_kind":"mcp_tool_call"}
+		}`),
+		serverRequestMessage(t, 45, "mcpServer/elicitation/request", `{
+			"threadId":"thread-1",
+			"turnId":"turn-1",
+			"serverName":"other-server",
+			"mode":"form",
+			"message":"Allow another MCP tool call?",
+			"requestedSchema":{"type":"object","properties":{}},
+			"_meta":{"codex_approval_kind":"mcp_tool_call"}
+		}`),
+		serverRequestMessage(t, 46, "custom/request", `{"threadId":"thread-1","turnId":"turn-1"}`),
 		notificationMessage(t, "turn/completed", `{"threadId":"thread-1","turn":{"id":"turn-1","status":"completed"}}`),
 	})
 	server, err := NewAppServer(staticTransportFactory{transport: transport},
+		WithLogger(slog.New(slog.NewTextHandler(&logs, nil))),
 		WithReadTimeout(time.Second),
 		WithTurnTimeout(time.Second),
 	)
@@ -1015,8 +1036,8 @@ func TestAppServerRunTurnRespondsToServerRequests(t *testing.T) {
 	}
 
 	sent := transport.sentMessages()
-	if len(sent) != 11 {
-		t.Fatalf("sent messages = %d, want 11: %#v", len(sent), sent)
+	if len(sent) != 12 {
+		t.Fatalf("sent messages = %d, want 12: %#v", len(sent), sent)
 	}
 
 	assertRequest(t, sent[3], 5, "config/read")
@@ -1024,9 +1045,117 @@ func TestAppServerRunTurnRespondsToServerRequests(t *testing.T) {
 	assertResponseResultContains(t, sent[6], 41, "decision", "decline")
 	assertResponseResultContains(t, sent[7], 42, "decision", "decline")
 	assertResponseResultContains(t, sent[8], 43, "permissions", map[string]any{})
-	assertResponseResultContains(t, sent[9], 44, "action", "decline")
-	assertResponseResultContains(t, sent[9], 44, "content", nil)
-	assertErrorResponse(t, sent[10], 45, methodNotFoundCode, "unsupported server request: custom/request")
+	assertResponseResultContains(t, sent[9], 44, "action", "accept")
+	assertResponseResultContains(t, sent[9], 44, "content", map[string]any{})
+	assertResponseResultContains(t, sent[10], 45, "action", "decline")
+	assertResponseResultContains(t, sent[10], 45, "content", nil)
+	assertErrorResponse(t, sent[11], 46, methodNotFoundCode, "unsupported server request: custom/request")
+
+	for _, want := range []string{
+		"method=mcpServer/elicitation/request server=chrome-devtools mode=form approval_kind=mcp_tool_call action=accept reason=supported_browser_tool_approval",
+		"method=mcpServer/elicitation/request server=other-server mode=form approval_kind=\"\" action=decline reason=unsupported_server",
+	} {
+		if !strings.Contains(logs.String(), want) {
+			t.Errorf("logs = %q, missing %q", logs.String(), want)
+		}
+	}
+}
+
+func TestMCPElicitationResponse(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		params     string
+		wantAction string
+		wantReason string
+	}{
+		{
+			name: "browser tool approval",
+			params: `{
+				"serverName":"chrome-devtools",
+				"mode":"form",
+				"requestedSchema":{"type":"object","properties":{}},
+				"_meta":{"codex_approval_kind":"mcp_tool_call"}
+			}`,
+			wantAction: "accept",
+			wantReason: "supported_browser_tool_approval",
+		},
+		{
+			name: "unsupported server",
+			params: `{
+				"serverName":"filesystem",
+				"mode":"form",
+				"requestedSchema":{"type":"object","properties":{}},
+				"_meta":{"codex_approval_kind":"mcp_tool_call"}
+			}`,
+			wantAction: "decline",
+			wantReason: "unsupported_server",
+		},
+		{
+			name: "browser URL elicitation",
+			params: `{
+				"serverName":"chrome-devtools",
+				"mode":"url",
+				"url":"https://example.com/authorize",
+				"elicitationId":"elicitation-1"
+			}`,
+			wantAction: "decline",
+			wantReason: "unsupported_mode",
+		},
+		{
+			name: "browser input form",
+			params: `{
+				"serverName":"chrome-devtools",
+				"mode":"form",
+				"requestedSchema":{"type":"object","properties":{"value":{"type":"string"}}},
+				"_meta":{"codex_approval_kind":"mcp_tool_call"}
+			}`,
+			wantAction: "decline",
+			wantReason: "unsupported_schema",
+		},
+		{
+			name: "unsupported browser form",
+			params: `{
+				"serverName":"chrome-devtools",
+				"mode":"form",
+				"requestedSchema":{"type":"object","properties":{}},
+				"_meta":{"codex_approval_kind":"tool_suggestion"}
+			}`,
+			wantAction: "decline",
+			wantReason: "unsupported_approval_kind",
+		},
+		{
+			name:       "malformed request",
+			params:     `{`,
+			wantAction: "decline",
+			wantReason: "invalid_request",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			response, decision := mcpElicitationResponse(json.RawMessage(tt.params))
+			if got := response["action"]; got != tt.wantAction {
+				t.Errorf("action = %v, want %q", got, tt.wantAction)
+			}
+			if decision.Action != tt.wantAction {
+				t.Errorf("decision action = %q, want %q", decision.Action, tt.wantAction)
+			}
+			if decision.Reason != tt.wantReason {
+				t.Errorf("decision reason = %q, want %q", decision.Reason, tt.wantReason)
+			}
+			if tt.wantAction == "accept" {
+				if got, ok := response["content"].(map[string]any); !ok || len(got) != 0 {
+					t.Errorf("content = %#v, want empty object", response["content"])
+				}
+			} else if response["content"] != nil {
+				t.Errorf("content = %#v, want nil", response["content"])
+			}
+		})
+	}
 }
 
 func TestAppServerRunTurnReportsResponseErrors(t *testing.T) {

--- a/internal/codex/appserver_test.go
+++ b/internal/codex/appserver_test.go
@@ -1115,6 +1115,17 @@ func TestMCPElicitationResponse(t *testing.T) {
 			wantReason: "unsupported_schema",
 		},
 		{
+			name: "browser constrained empty form",
+			params: `{
+				"serverName":"chrome-devtools",
+				"mode":"form",
+				"requestedSchema":{"type":"object","properties":{},"required":["confirmation"]},
+				"_meta":{"codex_approval_kind":"mcp_tool_call"}
+			}`,
+			wantAction: "decline",
+			wantReason: "unsupported_schema",
+		},
+		{
 			name: "unsupported browser form",
 			params: `{
 				"serverName":"chrome-devtools",


### PR DESCRIPTION
## Summary

- accept only exact empty-object MCP tool-approval elicitations from the configured `chrome-devtools` server
- keep unsupported servers, modes, schemas, approval kinds, malformed requests, and schemas with additional constraints deny-by-default
- log structured elicitation decisions with the method, server, mode, action, and reason
- cover the allowed browser path and denied unsupported paths through the app-server request loop and table-driven unit tests

Fixes #1754

## UI Surface Contract

- [x] N/A; this change has no UI surface, layout, density, first-viewport, or responsive visibility impact.
- [x] This PR does not add persistent top-of-screen messaging.
- [x] No primary operator screen changes require screenshot or browser verification.

## Test Plan

- [x] `go test ./internal/codex -run '^(TestAppServerRunTurnRespondsToServerRequests|TestMCPElicitationResponse)$' -count=1`
- [x] `go test ./internal/codex -count=1`
- [x] `make check` after the review fix (78.8% overall coverage; 77.9% `internal/codex` coverage)
