### PR TITLE
fix(scheduler): surface ownership blockers

### DIFF
--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -66,6 +66,7 @@ type doctorCheck struct {
 	StrandedIssues            []telemetry.StrandedIssue                  `json:"stranded_active_issues,omitempty"`
 	UntrackedIssues           []doctorStatusDriftIssueDiagnostic         `json:"untracked_issues,omitempty"`
 	OpenTerminalIssues        []doctorStatusDriftIssueDiagnostic         `json:"open_terminal_issues,omitempty"`
+	OwnershipAttention        []doctorOwnershipAttentionDiagnostic       `json:"ownership_attention,omitempty"`
 	ProjectDefinition         *doctorProjectDefinitionDiagnostic         `json:"project_definition,omitempty"`
 	Capabilities              *doctorCapabilityReport                    `json:"capabilities,omitempty"`
 	WorkflowOptimization      doctorWorkflowOptimizationReport           `json:"-"`

--- a/internal/cli/doctor_ownership.go
+++ b/internal/cli/doctor_ownership.go
@@ -1,0 +1,93 @@
+package cli
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	workflowconfig "github.com/digitaldrywood/detent/internal/config"
+	globalconfig "github.com/digitaldrywood/detent/internal/config/global"
+	"github.com/digitaldrywood/detent/internal/connector"
+	"github.com/digitaldrywood/detent/internal/selector"
+)
+
+type doctorOwnershipAttentionDiagnostic struct {
+	IssueID         string `json:"issue_id,omitempty"`
+	IssueIdentifier string `json:"issue_identifier,omitempty"`
+	IssueURL        string `json:"issue_url,omitempty"`
+	State           string `json:"state,omitempty"`
+	Remedy          string `json:"remedy"`
+}
+
+func checkDoctorOwnershipEligibility(
+	ctx context.Context,
+	projectID string,
+	project globalconfig.Project,
+	cfg workflowconfig.Config,
+	deps doctorDeps,
+) doctorCheck {
+	name := "Project " + projectID + " ownership eligibility"
+	identity := cfg.Identity
+	identity.Normalize()
+	if !identity.Configured() || identity.OwnershipMode != workflowconfig.IdentityOwnershipAssignee {
+		return doctorCheck{Name: name, Status: doctorOK, Detail: "ownership_mode is not assignee"}
+	}
+	if deps.autoPromoteConnector == nil {
+		deps.autoPromoteConnector = defaultDoctorAutoPromoteConnector
+	}
+	projectConnector, err := deps.autoPromoteConnector(cfg)
+	if err != nil {
+		return doctorCheck{Name: name, Status: doctorWarn, Detail: fmt.Sprintf("ownership eligibility could not be checked: %v", err), Hint: "Fix tracker credentials and rerun detent doctor."}
+	}
+	issues, fetchErr := projectConnector.FetchIssuesByStates(ctx, cfg.Tracker.ActiveStates)
+	closeErr := closeDoctorAutoPromoteConnector(projectConnector)
+	if fetchErr != nil {
+		return doctorCheck{Name: name, Status: doctorWarn, Detail: fmt.Sprintf("active issues could not be checked for ownership eligibility: %v", fetchErr), Hint: "Fix tracker connectivity and rerun detent doctor."}
+	}
+	if closeErr != nil {
+		return doctorCheck{Name: name, Status: doctorWarn, Detail: fmt.Sprintf("ownership diagnostic connector could not be closed: %v", closeErr), Hint: "Rerun detent doctor and check local network resources."}
+	}
+
+	ctxSelector := selector.Context{InstanceLogin: identity.GitHubLogin, Persona: identity.Name}
+	diagnostics := make([]doctorOwnershipAttentionDiagnostic, 0)
+	for _, issue := range issues {
+		if !doctorOwnershipAuthorized(issue, project.Authorization, cfg.Tracker.Authorization, ctxSelector) || doctorIssueHasAssignee(issue) {
+			continue
+		}
+		diagnostics = append(diagnostics, doctorOwnershipAttentionDiagnostic{
+			IssueID:         strings.TrimSpace(issue.ID),
+			IssueIdentifier: strings.TrimSpace(issue.Identifier),
+			IssueURL:        strings.TrimSpace(issue.URL),
+			State:           strings.TrimSpace(issue.State),
+			Remedy:          "assign the issue",
+		})
+	}
+	if len(diagnostics) == 0 {
+		return doctorCheck{Name: name, Status: doctorOK, Detail: "all label-eligible active issues have an assignee"}
+	}
+
+	return doctorCheck{
+		Name:               name,
+		Status:             doctorWarn,
+		Detail:             fmt.Sprintf("%d label-eligible active issue(s) cannot dispatch under ownership_mode: assignee", len(diagnostics)),
+		Hint:               "Assign each reported issue, then rerun detent doctor.",
+		OwnershipAttention: diagnostics,
+	}
+}
+
+func doctorOwnershipAuthorized(issue connector.Issue, projectSelector selector.Selector, workflowSelector selector.Selector, ctx selector.Context) bool {
+	return (!projectSelector.Configured() || selector.Match(issue, projectSelector, ctx)) &&
+		(!workflowSelector.Configured() || selector.Match(issue, workflowSelector, ctx))
+}
+
+func doctorIssueHasAssignee(issue connector.Issue) bool {
+	if strings.TrimSpace(issue.AssigneeID) != "" {
+		return true
+	}
+	for _, assignee := range issue.Assignees {
+		if strings.TrimSpace(assignee) != "" {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/cli/doctor_ownership_test.go
+++ b/internal/cli/doctor_ownership_test.go
@@ -1,0 +1,57 @@
+package cli
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	workflowconfig "github.com/digitaldrywood/detent/internal/config"
+	globalconfig "github.com/digitaldrywood/detent/internal/config/global"
+	"github.com/digitaldrywood/detent/internal/connector"
+	"github.com/digitaldrywood/detent/internal/selector"
+)
+
+func TestDoctorOwnershipEligibility(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		mode       string
+		assignees  []string
+		labels     []string
+		wantStatus doctorStatus
+		wantCount  int
+	}{
+		{name: "assignee present", mode: workflowconfig.IdentityOwnershipAssignee, assignees: []string{"operator"}, labels: []string{"detent"}, wantStatus: doctorOK},
+		{name: "assignee absent", mode: workflowconfig.IdentityOwnershipAssignee, labels: []string{"detent"}, wantStatus: doctorWarn, wantCount: 1},
+		{name: "other ownership mode", mode: workflowconfig.IdentityOwnershipField, labels: []string{"detent"}, wantStatus: doctorOK},
+		{name: "authorization label absent", mode: workflowconfig.IdentityOwnershipAssignee, wantStatus: doctorOK},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			cfg := workflowconfig.Default()
+			cfg.Identity = workflowconfig.Identity{Name: "operator", OwnershipMode: tt.mode, OwnerField: "Owner"}
+			if tt.mode == workflowconfig.IdentityOwnershipAssignee {
+				cfg.Identity.OwnerField = ""
+			}
+			cfg.Tracker.ActiveStates = []string{"Todo"}
+			cfg.Tracker.Authorization = selector.Selector{Labels: selector.Labels{Include: []string{"detent"}}}
+			issue := connector.Issue{ID: "issue-473", Identifier: "gopherguides/corp#473", State: "Todo", Labels: tt.labels, Assignees: tt.assignees}
+			check := checkDoctorOwnershipEligibility(context.Background(), "corp", globalconfig.Project{}, cfg, doctorDeps{
+				autoPromoteConnector: func(workflowconfig.Config) (doctorAutoPromoteConnector, error) {
+					return &fakeDoctorAutoPromoteConnector{issues: []connector.Issue{issue}}, nil
+				},
+			})
+
+			if check.Status != tt.wantStatus || len(check.OwnershipAttention) != tt.wantCount {
+				t.Fatalf("check = %#v, want status %s and %d diagnostics", check, tt.wantStatus, tt.wantCount)
+			}
+			if tt.wantCount > 0 && (!strings.Contains(check.Detail, "cannot dispatch") || check.OwnershipAttention[0].Remedy != "assign the issue") {
+				t.Fatalf("check = %#v, want dispatch failure with assignee remedy", check)
+			}
+		})
+	}
+}

--- a/internal/cli/doctor_project.go
+++ b/internal/cli/doctor_project.go
@@ -37,6 +37,7 @@ func checkDoctorProjects(ctx context.Context, cfg globalconfig.Config, deps doct
 	checks := make([]doctorCheck, 0, len(cfg.Projects)*2)
 	for _, project := range cfg.Projects {
 		project.GlobalActiveHours = cfg.Global.ActiveHours
+		project.Identity = cfg.Global.Identity
 		checks = append(checks, checkDoctorProjectWithStore(ctx, project, doctorRuntimeStorePath(cfg.Path), deps, githubToken, allowWriteProbes)...)
 	}
 
@@ -186,6 +187,7 @@ func doctorProjectCheckJobs(cfg globalconfig.Config, deps doctorDeps, githubToke
 	jobs := make([]doctorCheckJob, 0, len(cfg.Projects))
 	for _, project := range cfg.Projects {
 		project.GlobalActiveHours = cfg.Global.ActiveHours
+		project.Identity = cfg.Global.Identity
 		id := doctorProjectID(project)
 		progress := newDoctorCheckProgress()
 		jobs = append(jobs, doctorCheckJob{
@@ -244,6 +246,11 @@ func checkDoctorProjectWithProgress(
 		}
 	}
 	workflow.Config = doctorWorkflowConfigWithRuntimeGitHubToken(workflow.Config, runtimeGlobalGitHubToken(githubToken))
+	if project.Identity.Configured() {
+		identity := project.Identity
+		identity.Normalize()
+		workflow.Config.Identity = identity
+	}
 	workflow.Config.ActiveHours = projectpkg.EffectiveActiveHours(project, workflow.Config.ActiveHours)
 	if err := workflow.Config.Validate(); err != nil {
 		return []doctorCheck{
@@ -342,6 +349,8 @@ func checkDoctorProjectWithProgress(
 	if doctorTrackerUsesGitHubReads(workflow.Config.Tracker.Kind) {
 		setDoctorCurrentCheck("Project " + id + " issue agent models")
 		checks = append(checks, checkDoctorIssueAgentModels(ctx, id, project, workflow.Config, deps))
+		setDoctorCurrentCheck("Project " + id + " ownership eligibility")
+		checks = append(checks, checkDoctorOwnershipEligibility(ctx, id, project, workflow.Config, deps))
 		setDoctorCurrentCheck("Project " + id + " configured labels")
 		checks = append(checks, checkDoctorConfiguredLabels(ctx, id, project, workflow.Config, deps))
 	}

--- a/internal/orchestrator/config.go
+++ b/internal/orchestrator/config.go
@@ -49,6 +49,7 @@ func ConfigFromWorkflow(cfg workflowconfig.Config) Config {
 		},
 		Claiming: ClaimingConfig{
 			Enabled:           cfg.Tracker.Claims.Enabled,
+			OwnershipSet:      identity.Configured(),
 			OwnershipMode:     identity.OwnershipMode,
 			Owner:             identity.Name,
 			AssigneeLogin:     identity.GitHubLogin,

--- a/internal/orchestrator/diagnostics.go
+++ b/internal/orchestrator/diagnostics.go
@@ -23,7 +23,8 @@ const (
 	workerOutcomeCancelled = "cancelled"
 	workerOutcomeTimedOut  = "timed_out"
 
-	dispatchGateSampleInterval = 5 * time.Minute
+	dispatchGateSampleInterval                  = 5 * time.Minute
+	defaultCorrectableDispatchDecisionThreshold = 20
 )
 
 type dispatchGateSampleKey struct {
@@ -50,7 +51,13 @@ func (o *Orchestrator) logDispatchPlanDecision(ctx context.Context, state *State
 	if o == nil {
 		return
 	}
+	if reason == dispatchSkipOwnershipAssigneeRequired && correctableDispatchEscalated(state, decision.Issue.ID, reason) {
+		return
+	}
 	o.recordSchedulerDecision(ctx, state, now, decision, result, reason)
+	if reason == dispatchSkipOwnershipAssigneeRequired && o.escalateCorrectableDispatchDecision(state, now, decision.Issue, reason) {
+		return
+	}
 	if o.logger == nil || reason == dispatchSkipCurrentHeadCIWait || reason == mergeWorkerCurrentHeadCIWaitExceededReason {
 		return
 	}
@@ -65,6 +72,64 @@ func (o *Orchestrator) logDispatchPlanDecision(ctx context.Context, state *State
 		"unblocker_count", decision.UnblockerCount,
 	)
 	telemetry.LogLifecycle(o.logger, slog.LevelDebug, telemetry.LifecycleDispatch, "scheduler_dispatch_decision", o.issueLifecycleCorrelation(decision.Issue), attrs...)
+}
+
+func correctableDispatchEscalationKey(issueID string, reason string) string {
+	return strings.TrimSpace(issueID) + "\x00" + strings.TrimSpace(reason)
+}
+
+func correctableDispatchEscalated(state *State, issueID string, reason string) bool {
+	if state == nil {
+		return false
+	}
+	_, ok := state.DispatchEscalations[correctableDispatchEscalationKey(issueID, reason)]
+	return ok
+}
+
+func (o *Orchestrator) escalateCorrectableDispatchDecision(state *State, now time.Time, issue connector.Issue, reason string) bool {
+	if state == nil {
+		return false
+	}
+	threshold := o.cfg.Staleness.RepeatedDecisionCount
+	if threshold <= 0 {
+		threshold = defaultCorrectableDispatchDecisionThreshold
+	}
+	incidentStartedAt := time.Time{}
+	if blocked, ok := state.Blocked[issue.ID]; ok && blocked.Source == BlockedSourceOwnership {
+		incidentStartedAt = blocked.BlockedAt
+	}
+	if window := o.cfg.Staleness.RepeatedDecisionWindow; window > 0 {
+		windowStartedAt := now.Add(-window)
+		if incidentStartedAt.Before(windowStartedAt) {
+			incidentStartedAt = windowStartedAt
+		}
+	}
+	count := 0
+	for _, decision := range state.SchedulerDecisions {
+		inCurrentIncident := !decision.DecisionAt.Before(incidentStartedAt)
+		sameIssue := strings.TrimSpace(decision.IssueID) == strings.TrimSpace(issue.ID)
+		sameReason := strings.TrimSpace(decision.Reason) == strings.TrimSpace(reason)
+		if inCurrentIncident && sameIssue && sameReason {
+			count++
+		}
+	}
+	if count < threshold {
+		return false
+	}
+	key := correctableDispatchEscalationKey(issue.ID, reason)
+	if _, ok := state.DispatchEscalations[key]; ok {
+		return true
+	}
+	state.DispatchEscalations[key] = now.UTC()
+	recordStateEvent(state, telemetry.ActivityEvent{
+		At:      now.UTC(),
+		Event:   "scheduler_dispatch_needs_human_attention",
+		Message: strings.TrimSpace(issue.Identifier) + " needs an assignee under ownership_mode: assignee",
+	})
+	if o.logger != nil {
+		o.logger.Warn("scheduler dispatch needs human attention", "issue_id", issue.ID, "identifier", issue.Identifier, "reason", reason, "remedy", "assign the issue", "decision_count", count)
+	}
+	return true
 }
 
 func unblockerDecisionReason(count int) string {

--- a/internal/orchestrator/dispatch_planner.go
+++ b/internal/orchestrator/dispatch_planner.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/digitaldrywood/detent/internal/budget"
+	workflowconfig "github.com/digitaldrywood/detent/internal/config"
 	"github.com/digitaldrywood/detent/internal/connector"
 	"github.com/digitaldrywood/detent/internal/gate"
 	"github.com/digitaldrywood/detent/internal/runtimeoutput"
@@ -61,6 +62,7 @@ func (p dispatchPlanner) plan(
 	hooks dispatchPlanHooks,
 ) DispatchPlan {
 	state.ensureInitialized(p.cfg)
+	p.trackOwnershipAttentionCandidates(state, candidates, now)
 
 	plannedCandidates := cloneIssues(candidates)
 	rankingIssues := cloneIssues(candidates)
@@ -89,6 +91,9 @@ func (p dispatchPlanner) plan(
 	continuations := 0
 	for index, issue := range plannedCandidates {
 		queuePosition := index + 1
+		if correctableDispatchEscalated(state, issue.ID, dispatchSkipOwnershipAssigneeRequired) {
+			continue
+		}
 		if mergePriority.stickyIssueID != "" && mergeWorkerIssue(issue) && strings.TrimSpace(issue.ID) != mergePriority.stickyIssueID {
 			logDecision(dispatchPlanDecision{
 				Issue:         issue,
@@ -544,33 +549,34 @@ type dispatchableDecision struct {
 }
 
 const (
-	dispatchSkipInvalidCandidate         = "invalid_candidate"
-	dispatchSkipInactiveState            = "inactive_state"
-	dispatchSkipTerminalState            = "terminal_state"
-	dispatchSkipPullRequestHydration     = "pull_request_hydration_unavailable"
-	dispatchSkipAwaitingGate             = "awaiting_gate"
-	dispatchSkipArtifactGateWaitStatus   = "artifact_gate_wait_status"
-	dispatchSkipMergedPullRequest        = "merged_pull_request_reconciliation_pending"
-	dispatchSkipDuplicatePullRequest     = "duplicate_pull_request_work"
-	dispatchSkipUnauthorized             = "unauthorized"
-	dispatchSkipBlockedByDependency      = "blocked_by_dependency"
-	dispatchSkipAlreadyRunning           = "already_running"
-	dispatchSkipRetryPending             = "retry_pending"
-	dispatchSkipAlreadyClaimed           = "already_claimed"
-	dispatchSkipBlocked                  = "blocked"
-	dispatchSkipBudgetCooldown           = "budget_cooldown"
-	dispatchSkipBudgetHardHold           = "budget_hard_hold"
-	dispatchSkipLocalSlotUnavailable     = "local_slot_unavailable"
-	dispatchSkipWorkerHostUnavailable    = "worker_host_unavailable"
-	dispatchSkipGlobalCapacityFull       = "global_capacity_full"
-	dispatchSkipHydrationFailed          = "hydrate_failed"
-	dispatchSkipDispatchBackoffCancelled = "dispatch_backoff_cancelled"
-	dispatchSkipMergeFairnessReserved    = "merge_fairness_head_reserved"
-	dispatchSkipGitHubRESTCapacity       = "github_rest_capacity_paused"
-	dispatchSkipCIUnavailable            = "ci_unavailable"
-	dispatchSkipProjectFailureBreaker    = projectFailureBreakerDispatchPaused
-	dispatchSkipRateWindowBackpressure   = "provider_rate_window_backpressure"
-	dispatchSkipCurrentHeadCIWait        = "current_head_ci_wait"
+	dispatchSkipInvalidCandidate          = "invalid_candidate"
+	dispatchSkipInactiveState             = "inactive_state"
+	dispatchSkipTerminalState             = "terminal_state"
+	dispatchSkipPullRequestHydration      = "pull_request_hydration_unavailable"
+	dispatchSkipAwaitingGate              = "awaiting_gate"
+	dispatchSkipArtifactGateWaitStatus    = "artifact_gate_wait_status"
+	dispatchSkipMergedPullRequest         = "merged_pull_request_reconciliation_pending"
+	dispatchSkipDuplicatePullRequest      = "duplicate_pull_request_work"
+	dispatchSkipUnauthorized              = "unauthorized"
+	dispatchSkipOwnershipAssigneeRequired = "ownership_assignee_required"
+	dispatchSkipBlockedByDependency       = "blocked_by_dependency"
+	dispatchSkipAlreadyRunning            = "already_running"
+	dispatchSkipRetryPending              = "retry_pending"
+	dispatchSkipAlreadyClaimed            = "already_claimed"
+	dispatchSkipBlocked                   = "blocked"
+	dispatchSkipBudgetCooldown            = "budget_cooldown"
+	dispatchSkipBudgetHardHold            = "budget_hard_hold"
+	dispatchSkipLocalSlotUnavailable      = "local_slot_unavailable"
+	dispatchSkipWorkerHostUnavailable     = "worker_host_unavailable"
+	dispatchSkipGlobalCapacityFull        = "global_capacity_full"
+	dispatchSkipHydrationFailed           = "hydrate_failed"
+	dispatchSkipDispatchBackoffCancelled  = "dispatch_backoff_cancelled"
+	dispatchSkipMergeFairnessReserved     = "merge_fairness_head_reserved"
+	dispatchSkipGitHubRESTCapacity        = "github_rest_capacity_paused"
+	dispatchSkipCIUnavailable             = "ci_unavailable"
+	dispatchSkipProjectFailureBreaker     = projectFailureBreakerDispatchPaused
+	dispatchSkipRateWindowBackpressure    = "provider_rate_window_backpressure"
+	dispatchSkipCurrentHeadCIWait         = "current_head_ci_wait"
 )
 
 func (p dispatchPlanner) previewCurrentHeadCIWait(
@@ -657,6 +663,9 @@ func (p dispatchPlanner) dispatchableIssueDecisionForModelRequirement(
 	}
 	if !p.authorized(issue) {
 		return dispatchableDecision{reason: dispatchSkipUnauthorized}
+	}
+	if p.needsAssignee(issue) {
+		return dispatchableDecision{reason: dispatchSkipOwnershipAssigneeRequired}
 	}
 	if todoBlockedByNonTerminal(issue, p.cfg.TerminalStates) {
 		return dispatchableDecision{reason: dispatchSkipBlockedByDependency}
@@ -747,6 +756,54 @@ func (p dispatchPlanner) authorized(issue connector.Issue) bool {
 		return true
 	}
 	return selector.Match(issue, p.cfg.Authorization, p.cfg.SelectorContext)
+}
+
+func (p dispatchPlanner) needsAssignee(issue connector.Issue) bool {
+	if !p.cfg.Claiming.OwnershipSet || p.cfg.Claiming.OwnershipMode != workflowconfig.IdentityOwnershipAssignee {
+		return false
+	}
+	if strings.TrimSpace(issue.AssigneeID) != "" {
+		return false
+	}
+	for _, assignee := range issue.Assignees {
+		if strings.TrimSpace(assignee) != "" {
+			return false
+		}
+	}
+	return true
+}
+
+func (p dispatchPlanner) trackOwnershipAttentionCandidates(state *State, issues []connector.Issue, now time.Time) {
+	seen := make(map[string]struct{})
+	for _, issue := range issues {
+		if strings.TrimSpace(issue.ID) == "" || !validCandidate(issue) || !stateIn(issue.State, p.cfg.ActiveStates) || stateIn(issue.State, p.cfg.TerminalStates) || !p.authorized(issue) || !p.needsAssignee(issue) {
+			continue
+		}
+		seen[issue.ID] = struct{}{}
+		existing, ok := state.Blocked[issue.ID]
+		if ok && existing.Source == BlockedSourceOwnership {
+			existing.Issue = cloneIssue(issue)
+			state.Blocked[issue.ID] = existing
+			continue
+		}
+		state.Blocked[issue.ID] = Blocked{
+			Issue:          cloneIssue(issue),
+			Reason:         "issue needs an assignee under ownership_mode: assignee",
+			RecoveryReason: "human_blocker",
+			BlockedAt:      now,
+			Source:         BlockedSourceOwnership,
+		}
+	}
+	for issueID, blocked := range state.Blocked {
+		if blocked.Source != BlockedSourceOwnership {
+			continue
+		}
+		if _, ok := seen[issueID]; ok {
+			continue
+		}
+		delete(state.Blocked, issueID)
+		delete(state.DispatchEscalations, correctableDispatchEscalationKey(issueID, dispatchSkipOwnershipAssigneeRequired))
+	}
 }
 
 func (p dispatchPlanner) slotsAvailableForModelRequirement(

--- a/internal/orchestrator/dispatch_test.go
+++ b/internal/orchestrator/dispatch_test.go
@@ -20,6 +20,7 @@ import (
 	runpkg "github.com/digitaldrywood/detent/internal/runner"
 	"github.com/digitaldrywood/detent/internal/scheduler"
 	"github.com/digitaldrywood/detent/internal/selector"
+	"github.com/digitaldrywood/detent/internal/staleness"
 	"github.com/digitaldrywood/detent/internal/store"
 	"github.com/digitaldrywood/detent/internal/telemetry"
 )
@@ -363,6 +364,9 @@ func TestConfigFromWorkflowIncludesDispatchControls(t *testing.T) {
 	}
 	if !got.Claiming.Enabled {
 		t.Fatal("Claiming.Enabled = false, want true")
+	}
+	if !got.Claiming.OwnershipSet {
+		t.Fatal("Claiming.OwnershipSet = false, want true")
 	}
 	if got.Claiming.OwnershipMode != workflowconfig.IdentityOwnershipAssignee {
 		t.Fatalf("Claiming.OwnershipMode = %q, want assignee", got.Claiming.OwnershipMode)
@@ -1255,6 +1259,138 @@ func TestDispatchableFiltersUnauthorizedCandidates(t *testing.T) {
 				t.Fatalf("dispatchable() = %v, want %v", got, tt.want)
 			}
 		})
+	}
+}
+
+func TestDispatchPlanOwnershipEligibility(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 8, 12, 12, 0, 0, 0, time.UTC)
+	tests := []struct {
+		name          string
+		ownershipMode string
+		assignees     []string
+		wantDispatch  bool
+		wantAttention bool
+	}{
+		{name: "assignee present dispatches", ownershipMode: workflowconfig.IdentityOwnershipAssignee, assignees: []string{"operator"}, wantDispatch: true},
+		{name: "assignee absent surfaces", ownershipMode: workflowconfig.IdentityOwnershipAssignee, wantAttention: true},
+		{name: "assignee absent in field mode dispatches", ownershipMode: workflowconfig.IdentityOwnershipField, wantDispatch: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			cfg := normalizeConfig(Config{
+				MaxConcurrentAgents: 1,
+				ActiveStates:        []string{"Todo"},
+				TerminalStates:      []string{"Done"},
+				Claiming: ClaimingConfig{
+					OwnershipSet:  true,
+					OwnershipMode: tt.ownershipMode,
+				},
+			})
+			state := newState(cfg)
+			issue := dispatchTestIssue("issue-ownership", "Todo")
+			issue.Assignees = append([]string(nil), tt.assignees...)
+
+			plan := newDispatchPlanner(cfg).plan(&state, []connector.Issue{issue}, now, dispatchPlanHooks{})
+			if got := len(plan.Dispatches) == 1; got != tt.wantDispatch {
+				t.Fatalf("dispatch = %t, want %t; plan = %#v", got, tt.wantDispatch, plan)
+			}
+			blocked, gotAttention := state.Blocked[issue.ID]
+			if gotAttention != tt.wantAttention {
+				t.Fatalf("ownership attention = %t, want %t; blocked = %#v", gotAttention, tt.wantAttention, state.Blocked)
+			}
+			if tt.wantAttention {
+				if blocked.RecoveryReason != "human_blocker" || !strings.Contains(blocked.Reason, "needs an assignee") {
+					t.Fatalf("ownership attention = %#v, want human blocker with assignee remedy", blocked)
+				}
+			}
+		})
+	}
+}
+
+func TestOwnershipAttentionEscalatesOnce(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 8, 12, 12, 0, 0, 0, time.UTC)
+	cfg := normalizeConfig(Config{
+		MaxConcurrentAgents: 1,
+		ActiveStates:        []string{"Todo"},
+		TerminalStates:      []string{"Done"},
+		Claiming: ClaimingConfig{
+			OwnershipSet:  true,
+			OwnershipMode: workflowconfig.IdentityOwnershipAssignee,
+		},
+		Staleness: staleness.Config{RepeatedDecisionCount: 3},
+	})
+	attempts := &recordingWorkAttemptStore{}
+	orch := Orchestrator{cfg: cfg, workAttempts: attempts}
+	state := newState(cfg)
+	issue := dispatchTestIssue("issue-unassigned", "Todo")
+	state.BoardIssues = []connector.Issue{issue}
+
+	for tick := range 10 {
+		newDispatchPlanner(cfg).plan(&state, []connector.Issue{issue}, now.Add(time.Duration(tick)*time.Minute), dispatchPlanHooks{
+			decision: func(decision dispatchPlanDecision) {
+				orch.logDispatchPlanDecision(t.Context(), &state, now.Add(time.Duration(tick)*time.Minute), decision)
+			},
+		})
+	}
+
+	if len(attempts.decisions) != 3 {
+		t.Fatalf("recorded ownership decisions = %d, want threshold 3", len(attempts.decisions))
+	}
+	escalations := 0
+	for _, event := range state.RecentEvents {
+		if event.Event == "scheduler_dispatch_needs_human_attention" {
+			escalations++
+		}
+	}
+	if escalations != 1 {
+		t.Fatalf("ownership escalations = %d, want 1; events = %#v", escalations, state.RecentEvents)
+	}
+	snapshot := state.Snapshot(now.Add(10 * time.Minute))
+	if snapshot.Counts.Blocked != 1 {
+		t.Fatalf("dashboard blocked count = %d, want 1", snapshot.Counts.Blocked)
+	}
+	counts := telemetry.BoardStateCounts(snapshot)
+	if len(counts) != 1 || counts[0].State != "Blocked" || counts[0].Count != 1 {
+		t.Fatalf("dashboard lane counts = %#v, want one Blocked issue", counts)
+	}
+
+	issue.Assignees = []string{"operator"}
+	plan := newDispatchPlanner(cfg).plan(&state, []connector.Issue{issue}, now.Add(11*time.Minute), dispatchPlanHooks{})
+	if len(plan.Dispatches) != 1 {
+		t.Fatalf("dispatches after assignee remedy = %#v, want one", plan.Dispatches)
+	}
+
+	delete(state.Claimed, issue.ID)
+	delete(state.Running, issue.ID)
+	issue.Assignees = nil
+	for tick := range 3 {
+		newDispatchPlanner(cfg).plan(&state, []connector.Issue{issue}, now.Add(time.Duration(12+tick)*time.Minute), dispatchPlanHooks{
+			decision: func(decision dispatchPlanDecision) {
+				orch.logDispatchPlanDecision(t.Context(), &state, now.Add(time.Duration(12+tick)*time.Minute), decision)
+			},
+		})
+		if tick == 0 && correctableDispatchEscalated(&state, issue.ID, dispatchSkipOwnershipAssigneeRequired) {
+			t.Fatal("new ownership incident escalated before reaching threshold")
+		}
+	}
+	if len(attempts.decisions) != 6 {
+		t.Fatalf("recorded ownership decisions across incidents = %d, want 6", len(attempts.decisions))
+	}
+	escalations = 0
+	for _, event := range state.RecentEvents {
+		if event.Event == "scheduler_dispatch_needs_human_attention" {
+			escalations++
+		}
+	}
+	if escalations != 2 {
+		t.Fatalf("ownership escalations across two incidents = %d, want 2; events = %#v", escalations, state.RecentEvents)
 	}
 }
 

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -134,6 +134,7 @@ type FailureBreakerConfig struct {
 
 type ClaimingConfig struct {
 	Enabled           bool
+	OwnershipSet      bool
 	OwnershipMode     string
 	Owner             string
 	AssigneeLogin     string

--- a/internal/orchestrator/shadow.go
+++ b/internal/orchestrator/shadow.go
@@ -63,6 +63,9 @@ func (s *State) ensureInitialized(cfg Config) {
 	if s.Blocked == nil {
 		s.Blocked = map[string]Blocked{}
 	}
+	if s.DispatchEscalations == nil {
+		s.DispatchEscalations = map[string]time.Time{}
+	}
 	if s.Completed == nil {
 		s.Completed = map[string]Completed{}
 	}

--- a/internal/orchestrator/state.go
+++ b/internal/orchestrator/state.go
@@ -62,6 +62,7 @@ type State struct {
 	Running                  map[string]Running
 	WorkAttempts             []telemetry.WorkAttempt
 	SchedulerDecisions       []telemetry.SchedulerDecision
+	DispatchEscalations      map[string]time.Time
 	Release                  releasepkg.Status
 	Claimed                  map[string]Claimed
 	Blocked                  map[string]Blocked
@@ -160,6 +161,7 @@ const (
 	BlockedSourceMergeDuration = telemetry.BlockedSourceMergeDuration
 	BlockedSourceProjectStatus = telemetry.BlockedSourceProjectStatus
 	BlockedSourceOperatorStop  = telemetry.BlockedSourceOperatorStop
+	BlockedSourceOwnership     = telemetry.BlockedSourceOwnership
 )
 
 type Blocked struct {
@@ -302,6 +304,7 @@ func newState(cfg Config) State {
 		Running:                  map[string]Running{},
 		Claimed:                  map[string]Claimed{},
 		Blocked:                  map[string]Blocked{},
+		DispatchEscalations:      map[string]time.Time{},
 		Completed:                map[string]Completed{},
 		Retry:                    map[string]Retry{},
 		MergeTimings:             map[string]MergeTiming{},
@@ -367,6 +370,7 @@ func (s State) clone() State {
 		AutoPromoteDecisions:     cloneAutoPromoteDecisions(s.AutoPromoteDecisions),
 		WorkAttempts:             cloneTelemetryWorkAttempts(s.WorkAttempts),
 		SchedulerDecisions:       cloneTelemetrySchedulerDecisions(s.SchedulerDecisions),
+		DispatchEscalations:      maps.Clone(s.DispatchEscalations),
 		Release:                  s.Release,
 		Running:                  make(map[string]Running, len(s.Running)),
 		Claimed:                  make(map[string]Claimed, len(s.Claimed)),

--- a/internal/telemetry/snapshot.go
+++ b/internal/telemetry/snapshot.go
@@ -695,6 +695,7 @@ const (
 	BlockedSourceMergeDuration BlockedSource = "merge_duration_reconciliation"
 	BlockedSourceProjectStatus BlockedSource = "project_status"
 	BlockedSourceOperatorStop  BlockedSource = "operator_stop_reconciliation"
+	BlockedSourceOwnership     BlockedSource = "ownership"
 )
 
 type Blocked struct {


### PR DESCRIPTION
## Summary

- surface label-eligible issues missing an assignee as human-attention blockers with an explicit remedy
- cap repeated ownership decisions at the configured threshold and emit one escalation until corrected
- report active authorized issues missing assignees in `detent doctor`

Fixes #1759

## UI Surface Contract

- [x] N/A, or the linked issue explicitly authorizes any high-impact UI surface, layout, density, first-viewport, or responsive visibility tradeoff.
- [x] Persistent top-of-screen messaging is explicitly authorized by the issue, or this PR does not add it.
- [x] Visual changes to primary operator screens include screenshot or browser verification below. No visual layout or component changes; the existing Blocked lane/count and needs-review treatment render the new condition.

## Test Plan

- [x] `go test ./internal/orchestrator ./internal/cli ./internal/telemetry ./internal/web/templates -count=1`
- [x] `make check` (78.8% total coverage; 70% required)