### PR TITLE
fix(budget): distinguish per-issue hard holds

### DIFF
--- a/db/queries/store.sql
+++ b/db/queries/store.sql
@@ -528,12 +528,14 @@ INSERT INTO usage_events (
   total_tokens,
   model_context_window,
   cost_usd,
+  projected_cost_usd,
+  projection_overshoot_usd,
   runtime_seconds,
   started_at,
   finished_at,
   event_day,
   outcome
-) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 RETURNING *;
 
 -- name: GetUsageEvent :one

--- a/docs/config.md
+++ b/docs/config.md
@@ -324,6 +324,15 @@ Run `go generate ./...` after changing the config structs, defaults, or
 validators. `make check` compares the committed generated artifacts with fresh
 rendering and fails on drift.
 
+`budget.per_issue_max_usd` and `agent.budget.per_issue_max_usd` are
+estimate-based admission backstops, not mid-session spend ceilings. Detent
+checks cumulative issue spend plus a preflight session estimate before starting
+the agent. Actual session cost can exceed that estimate and the configured
+backstop. Once the next projected dispatch would exceed the backstop, Detent
+parks the issue on a hard hold until an operator raises or disables the cap, or
+explicitly retries after resetting the hold. `refusal_cooldown_seconds` applies
+only to resettable budget pacing and never clears a per-issue hard hold.
+
 <!-- BEGIN GENERATED CONFIG REFERENCE -->
 
 | Key | Type | Default | Required | Validation |

--- a/docs/templates/detent.github_local.yaml
+++ b/docs/templates/detent.github_local.yaml
@@ -181,7 +181,10 @@ budget:
   billing_mode: metered
   enabled: true
   per_day_max_usd: 50
+  # Preflight estimate backstop, not a spend ceiling: sessions may overshoot.
+  # A breach parks the issue until an operator acts.
   per_issue_max_usd: 5
+  # Applies only to resettable budget pacing; it does not clear per-issue hard holds.
   refusal_cooldown_seconds: 3600
   pricing_path: priv/pricing/models.yaml
 hooks:

--- a/docs/templates/detent.issue_field.yaml
+++ b/docs/templates/detent.issue_field.yaml
@@ -188,7 +188,10 @@ budget:
   billing_mode: metered
   enabled: true
   per_day_max_usd: 50
+  # Preflight estimate backstop, not a spend ceiling: sessions may overshoot.
+  # A breach parks the issue until an operator acts.
   per_issue_max_usd: 5
+  # Applies only to resettable budget pacing; it does not clear per-issue hard holds.
   refusal_cooldown_seconds: 3600
   pricing_path: priv/pricing/models.yaml
 hooks:

--- a/docs/templates/detent.label.yaml
+++ b/docs/templates/detent.label.yaml
@@ -188,7 +188,10 @@ budget:
   billing_mode: metered
   enabled: true
   per_day_max_usd: 50
+  # Preflight estimate backstop, not a spend ceiling: sessions may overshoot.
+  # A breach parks the issue until an operator acts.
   per_issue_max_usd: 5
+  # Applies only to resettable budget pacing; it does not clear per-issue hard holds.
   refusal_cooldown_seconds: 3600
   pricing_path: priv/pricing/models.yaml
 hooks:

--- a/docs/templates/detent.non_code_artifact.yaml
+++ b/docs/templates/detent.non_code_artifact.yaml
@@ -144,6 +144,9 @@ budget:
     billing_mode: metered
     enabled: true
     per_day_max_usd: 50
+    # Preflight estimate backstop, not a spend ceiling: sessions may overshoot.
+    # A breach parks the issue until an operator acts.
     per_issue_max_usd: 5
+    # Applies only to resettable budget pacing; it does not clear per-issue hard holds.
     refusal_cooldown_seconds: 3600
     pricing_path: priv/pricing/models.yaml

--- a/docs/templates/detent.project_v2.yaml
+++ b/docs/templates/detent.project_v2.yaml
@@ -187,7 +187,10 @@ budget:
   billing_mode: metered
   enabled: true
   per_day_max_usd: 50
+  # Preflight estimate backstop, not a spend ceiling: sessions may overshoot.
+  # A breach parks the issue until an operator acts.
   per_issue_max_usd: 5
+  # Applies only to resettable budget pacing; it does not clear per-issue hard holds.
   refusal_cooldown_seconds: 3600
   pricing_path: priv/pricing/models.yaml
 hooks:

--- a/internal/budget/budget.go
+++ b/internal/budget/budget.go
@@ -61,8 +61,14 @@ type TokenEstimate struct {
 }
 
 type Decision struct {
-	Allowed bool
-	Refusal *Refusal
+	Allowed    bool
+	Refusal    *Refusal
+	Projection *Projection
+}
+
+type Projection struct {
+	Estimate TokenEstimate
+	CostUSD  float64
 }
 
 type DailyStatus struct {
@@ -154,7 +160,9 @@ func (c *Checker) CheckDispatch(ctx context.Context, req DispatchRequest) (Decis
 		return Decision{}, err
 	}
 
-	projectedCost := tokenCostUSD(req.Estimate.normalized(), modelPricing)
+	estimate := req.Estimate.normalized()
+	projectedCost := tokenCostUSD(estimate, modelPricing)
+	projection := &Projection{Estimate: estimate, CostUSD: projectedCost}
 	if capActive(effective.PerDayMaxUSD) {
 		if missingSpendStore(c.spend) {
 			return Decision{}, ErrMissingSpendStore
@@ -166,7 +174,8 @@ func (c *Checker) CheckDispatch(ctx context.Context, req DispatchRequest) (Decis
 		currentSpend := SpendUSD(dailySpend, c.pricing)
 		if currentSpend+projectedCost > effective.PerDayMaxUSD {
 			return Decision{
-				Refusal: c.refusal(ReasonPerDayMaxUSD, req, now, currentSpend, projectedCost, effective.PerDayMaxUSD, nextDailyReset(now)),
+				Refusal:    c.refusal(ReasonPerDayMaxUSD, req, now, currentSpend, projectedCost, effective.PerDayMaxUSD, nextDailyReset(now)),
+				Projection: projection,
 			}, nil
 		}
 	}
@@ -191,12 +200,13 @@ func (c *Checker) CheckDispatch(ctx context.Context, req DispatchRequest) (Decis
 		}
 		if currentSpend+projectedCost > effective.PerIssueMaxUSD {
 			return Decision{
-				Refusal: c.refusal(ReasonPerIssueMaxUSD, req, now, currentSpend, projectedCost, effective.PerIssueMaxUSD, nil),
+				Refusal:    c.refusal(ReasonPerIssueMaxUSD, req, now, currentSpend, projectedCost, effective.PerIssueMaxUSD, nil),
+				Projection: projection,
 			}, nil
 		}
 	}
 
-	return Decision{Allowed: true}, nil
+	return Decision{Allowed: true, Projection: projection}, nil
 }
 
 func (c *Checker) DailyStatus(ctx context.Context, now time.Time) (DailyStatus, error) {
@@ -355,14 +365,15 @@ This issue will be reconsidered after: %s
 `, currentSpend, projectedCost, projectedSpend, max, model, resetAt, dueAt))
 	case ReasonPerIssueMaxUSD:
 		return strings.TrimSpace(fmt.Sprintf(`
-Detent refused to dispatch this issue because the projected dispatch would exceed the per-issue budget.
+Detent refused to dispatch this issue because the preflight estimate would exceed the per-issue budget backstop.
 
 Current issue spend: %s
 Projected dispatch cost: %s
 Projected issue spend: %s / %s
 Model: %s
-The per-issue budget has no automatic reset.
-This issue is on a hard budget hold and needs an operator decision. Raise or disable the per-issue cap, or explicitly retry the issue after resetting its budget hold.
+This is an estimate-based admission check, not a mid-session spend ceiling. Actual session cost can exceed both the estimate and the configured backstop.
+The per-issue budget has no automatic reset, and refusal_cooldown_seconds does not apply.
+This issue is parked on a hard budget hold and needs an operator decision. Raise or disable the per-issue cap, or explicitly retry the issue after resetting its budget hold.
 `, currentSpend, projectedCost, projectedSpend, max, model))
 	default:
 		return strings.TrimSpace(fmt.Sprintf(`

--- a/internal/budget/budget_test.go
+++ b/internal/budget/budget_test.go
@@ -23,17 +23,19 @@ func TestCheckerCheckDispatch(t *testing.T) {
 	}
 
 	tests := []struct {
-		name       string
-		cfg        Config
-		spend      *fakeSpendStore
-		req        DispatchRequest
-		wantCode   ReasonCode
-		wantSpend  float64
-		wantMax    float64
-		wantErr    string
-		wantAllow  bool
-		wantDaily  int
-		wantIssues int
+		name        string
+		cfg         Config
+		spend       *fakeSpendStore
+		req         DispatchRequest
+		wantCode    ReasonCode
+		wantSpend   float64
+		wantMax     float64
+		wantErr     string
+		wantAllow   bool
+		wantCost    float64
+		wantProject bool
+		wantDaily   int
+		wantIssues  int
 	}{
 		{
 			name:      "disabled budget allows without spend store",
@@ -69,10 +71,12 @@ func TestCheckerCheckDispatch(t *testing.T) {
 				Enabled:      true,
 				PerDayMaxUSD: 0.01,
 			},
-			spend:     &fakeSpendStore{},
-			req:       DispatchRequest{Model: "missing-model", Now: now, Estimate: TokenEstimate{InputTokens: 10}},
-			wantAllow: true,
-			wantDaily: 1,
+			spend:       &fakeSpendStore{},
+			req:         DispatchRequest{Model: "missing-model", Now: now, Estimate: TokenEstimate{InputTokens: 10}},
+			wantAllow:   true,
+			wantCost:    0.00005,
+			wantProject: true,
+			wantDaily:   1,
 		},
 		{
 			name: "daily cap refuses when projection exceeds limit",
@@ -96,10 +100,12 @@ func TestCheckerCheckDispatch(t *testing.T) {
 				Now:        now,
 				Estimate:   TokenEstimate{InputTokens: 10},
 			},
-			wantCode:  ReasonPerDayMaxUSD,
-			wantSpend: 1.05,
-			wantMax:   1.0,
-			wantDaily: 1,
+			wantCode:    ReasonPerDayMaxUSD,
+			wantSpend:   1.05,
+			wantMax:     1.0,
+			wantCost:    0.1,
+			wantProject: true,
+			wantDaily:   1,
 		},
 		{
 			name: "per issue cap refuses only matching issue spend",
@@ -125,10 +131,12 @@ func TestCheckerCheckDispatch(t *testing.T) {
 				Now:        now,
 				Estimate:   TokenEstimate{InputTokens: 10},
 			},
-			wantCode:   ReasonPerIssueMaxUSD,
-			wantSpend:  0.55,
-			wantMax:    0.5,
-			wantIssues: 1,
+			wantCode:    ReasonPerIssueMaxUSD,
+			wantSpend:   0.55,
+			wantMax:     0.5,
+			wantCost:    0.1,
+			wantProject: true,
+			wantIssues:  1,
 		},
 		{
 			name: "per issue cap uses identifier when issue id is missing",
@@ -151,10 +159,12 @@ func TestCheckerCheckDispatch(t *testing.T) {
 				Now:        now,
 				Estimate:   TokenEstimate{InputTokens: 10},
 			},
-			wantCode:   ReasonPerIssueMaxUSD,
-			wantSpend:  0.55,
-			wantMax:    0.5,
-			wantIssues: 1,
+			wantCode:    ReasonPerIssueMaxUSD,
+			wantSpend:   0.55,
+			wantMax:     0.5,
+			wantCost:    0.1,
+			wantProject: true,
+			wantIssues:  1,
 		},
 		{
 			name: "caps allow when projected spend is below limits",
@@ -170,9 +180,11 @@ func TestCheckerCheckDispatch(t *testing.T) {
 				Now:      now,
 				Estimate: TokenEstimate{InputTokens: 10},
 			},
-			wantAllow:  true,
-			wantDaily:  1,
-			wantIssues: 1,
+			wantAllow:   true,
+			wantCost:    0.1,
+			wantProject: true,
+			wantDaily:   1,
+			wantIssues:  1,
 		},
 		{
 			name: "enabled cap requires spend store",
@@ -219,6 +231,12 @@ func TestCheckerCheckDispatch(t *testing.T) {
 
 			if decision.Allowed != tt.wantAllow {
 				t.Fatalf("Decision.Allowed = %v, want %v", decision.Allowed, tt.wantAllow)
+			}
+			if got := decision.Projection != nil; got != tt.wantProject {
+				t.Fatalf("Decision.Projection present = %t, want %t", got, tt.wantProject)
+			}
+			if decision.Projection != nil {
+				assertInDelta(t, decision.Projection.CostUSD, tt.wantCost)
 			}
 			if tt.wantCode == "" {
 				if decision.Refusal != nil {
@@ -445,8 +463,16 @@ func TestPerIssueRefusalCommentDescribesHardHold(t *testing.T) {
 		MaxUSD:            &maxUSD,
 		RefusedAt:         time.Date(2026, 7, 12, 12, 0, 0, 0, time.UTC),
 	}).Comment()
-	if !strings.Contains(comment, "hard budget hold") || !strings.Contains(comment, "needs an operator decision") {
-		t.Fatalf("Refusal.Comment() = %q, want hard-hold guidance", comment)
+	for _, want := range []string{
+		"hard budget hold",
+		"needs an operator decision",
+		"not a mid-session spend ceiling",
+		"Actual session cost can exceed both the estimate and the configured backstop",
+		"refusal_cooldown_seconds does not apply",
+	} {
+		if !strings.Contains(comment, want) {
+			t.Fatalf("Refusal.Comment() = %q, want %q", comment, want)
+		}
 	}
 	if strings.Contains(comment, "will be reconsidered after") {
 		t.Fatalf("Refusal.Comment() = %q, must not promise automatic reconsideration", comment)

--- a/internal/orchestrator/dispatch_planner.go
+++ b/internal/orchestrator/dispatch_planner.go
@@ -283,8 +283,12 @@ func (p dispatchPlanner) retryAction(
 		modelPermitRequired,
 	)
 	if !decision.dispatchable {
-		if p.budgetCooldownActive(state, issue.ID, now) {
-			p.rescheduleRetry(state, retry, now, "budget cooldown active", false)
+		if reason := p.budgetRefusalWaitReason(state, issue.ID, now); reason != "" {
+			if reason == dispatchSkipBudgetCooldown {
+				p.rescheduleRetry(state, retry, now, "budget cooldown active", false)
+			} else {
+				p.parkBudgetHardHold(state, issue.ID)
+			}
 			return dispatchAction{}, false, decision.reason
 		}
 		if !p.slotsAvailableForModelRequirement(issue, state, retry.WorkerHost, modelPermitRequired) {
@@ -418,16 +422,22 @@ func (p dispatchPlanner) pruneInactiveIssueBudgetRefusals(state *State, candidat
 	}
 }
 
-func (p dispatchPlanner) budgetCooldownActive(state *State, issueID string, now time.Time) bool {
+func (p dispatchPlanner) budgetRefusalWaitReason(state *State, issueID string, now time.Time) string {
 	if p.cfg.subscriptionBilling() {
-		return false
+		return ""
 	}
 	refusal, ok := state.BudgetRefusals[issueID]
 	if !ok {
-		return false
+		return ""
 	}
 
-	return p.budgetRefusalActive(refusal, now, nil, nil)
+	if !p.budgetRefusalActive(refusal, now, nil, nil) {
+		return ""
+	}
+	if refusal.Code == string(budget.ReasonPerIssueMaxUSD) {
+		return dispatchSkipBudgetHardHold
+	}
+	return dispatchSkipBudgetCooldown
 }
 
 func (p dispatchPlanner) budgetRefusalActive(
@@ -549,6 +559,7 @@ const (
 	dispatchSkipAlreadyClaimed           = "already_claimed"
 	dispatchSkipBlocked                  = "blocked"
 	dispatchSkipBudgetCooldown           = "budget_cooldown"
+	dispatchSkipBudgetHardHold           = "budget_hard_hold"
 	dispatchSkipLocalSlotUnavailable     = "local_slot_unavailable"
 	dispatchSkipWorkerHostUnavailable    = "worker_host_unavailable"
 	dispatchSkipGlobalCapacityFull       = "global_capacity_full"
@@ -662,8 +673,8 @@ func (p dispatchPlanner) dispatchableIssueDecisionForModelRequirement(
 	if _, ok := state.Blocked[issue.ID]; ok {
 		return dispatchableDecision{reason: dispatchSkipBlocked}
 	}
-	if p.budgetCooldownActive(state, issue.ID, now) {
-		return dispatchableDecision{reason: dispatchSkipBudgetCooldown}
+	if reason := p.budgetRefusalWaitReason(state, issue.ID, now); reason != "" {
+		return dispatchableDecision{reason: reason}
 	}
 	if p.hardAvailableSlots(state) == 0 {
 		return dispatchableDecision{reason: dispatchSkipGlobalCapacityFull}
@@ -962,6 +973,13 @@ func (p dispatchPlanner) releaseIssue(state *State, issueID string) {
 	delete(state.Blocked, issueID)
 	delete(state.Retry, issueID)
 	delete(state.BudgetRefusals, issueID)
+}
+
+func (p dispatchPlanner) parkBudgetHardHold(state *State, issueID string) {
+	cancelRunning(state, issueID)
+	delete(state.Running, issueID)
+	delete(state.Claimed, issueID)
+	delete(state.Retry, issueID)
 }
 
 func (p dispatchPlanner) releaseClaim(state *State, issueID string) {

--- a/internal/orchestrator/dispatch_test.go
+++ b/internal/orchestrator/dispatch_test.go
@@ -592,6 +592,66 @@ func TestDispatchableFiltersIneligibleCandidates(t *testing.T) {
 	}
 }
 
+func TestDispatchableBudgetRefusalWaitReasons(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 8, 12, 12, 0, 0, 0, time.UTC)
+	resetAt := now.Add(12 * time.Hour)
+	tests := []struct {
+		name       string
+		code       budget.ReasonCode
+		refusedAt  time.Time
+		resetAt    *time.Time
+		wantReason string
+	}{
+		{
+			name:       "daily refusal is a cooldown",
+			code:       budget.ReasonPerDayMaxUSD,
+			refusedAt:  now.Add(-time.Minute),
+			resetAt:    &resetAt,
+			wantReason: dispatchSkipBudgetCooldown,
+		},
+		{
+			name:       "per issue refusal is a hard hold",
+			code:       budget.ReasonPerIssueMaxUSD,
+			refusedAt:  now.Add(-time.Minute),
+			wantReason: dispatchSkipBudgetHardHold,
+		},
+		{
+			name:       "per issue hold survives cooldown expiry",
+			code:       budget.ReasonPerIssueMaxUSD,
+			refusedAt:  now.Add(-48 * time.Hour),
+			wantReason: dispatchSkipBudgetHardHold,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			cfg := normalizeConfig(Config{
+				MaxConcurrentAgents:   1,
+				BillingMode:           workflowconfig.BillingModeMetered,
+				ActiveStates:          []string{"Todo"},
+				BudgetRefusalCooldown: time.Hour,
+			})
+			issue := dispatchTestIssue("issue-budget", "Todo")
+			state := newState(cfg)
+			state.BudgetRefusals[issue.ID] = BudgetRefusal{
+				Issue:     issue,
+				Code:      string(tt.code),
+				RefusedAt: tt.refusedAt,
+				ResetAt:   tt.resetAt,
+			}
+
+			decision := newDispatchPlanner(cfg).dispatchableIssueDecision(issue, &state, false, now, "")
+			if decision.dispatchable || decision.reason != tt.wantReason {
+				t.Fatalf("dispatch decision = %#v, want skipped for %q", decision, tt.wantReason)
+			}
+		})
+	}
+}
+
 func TestPruneBudgetRefusalsReevaluatesDailyCap(t *testing.T) {
 	t.Parallel()
 

--- a/internal/runner/agent.go
+++ b/internal/runner/agent.go
@@ -1153,8 +1153,9 @@ func (r *Runner) Run(ctx context.Context, req RunRequest) (RunResult, error) {
 	if effort != "" {
 		runtimeIdentity.ReasoningEffort = agentidentity.NewValue(effort, agentidentity.ProvenanceConfigured)
 	}
+	var budgetProjection *dispatchBudgetProjection
 	if workflow.Config.Budget.EffectiveBillingMode() != config.BillingModeSubscription {
-		if result, refused, err := r.checkDispatchBudget(ctx, budgetChecker, dispatchEstimator, req.Issue, sessionModel, startedAt); err != nil {
+		if admission, refused, err := r.checkDispatchBudget(ctx, budgetChecker, dispatchEstimator, req.Issue, sessionModel, startedAt); err != nil {
 			return RunResult{}, err
 		} else if refused {
 			r.logWorkerEvent(req.Issue, "worker_budget_refused",
@@ -1164,9 +1165,11 @@ func (r *Runner) Run(ctx context.Context, req RunRequest) (RunResult, error) {
 				"route", selection.RouteName,
 				"role", role,
 				"model", sessionModel,
-				"code", result.BudgetRefusal.Code,
+				"code", admission.BudgetRefusal.Code,
 			)
-			return result, nil
+			return admission, nil
+		} else {
+			budgetProjection = admission.budgetProjection
 		}
 	}
 	resumeState := store.AgentResumeState{}
@@ -1331,6 +1334,7 @@ func (r *Runner) Run(ctx context.Context, req RunRequest) (RunResult, error) {
 	turnErr := execution.err
 	cleanupErr := execution.cleanupErr
 	result := execution.result
+	result.budgetProjection = budgetProjection
 	if brakeDiff := sessionBrake.resultDiffStats(); brakeDiff != (DiffStats{}) {
 		result.DiffStats = brakeDiff
 	}
@@ -1478,12 +1482,19 @@ func (r *Runner) checkDispatchBudget(ctx context.Context, checker BudgetChecker,
 		return RunResult{}, false, fmt.Errorf("check dispatch budget: %w", err)
 	}
 	if decision.Allowed || decision.Refusal == nil {
-		return RunResult{}, false, nil
+		return runResultWithBudgetProjection(decision.Projection), false, nil
 	}
-	return RunResult{
-		FinalState:    FinalStateCompleted,
-		BudgetRefusal: budgetRefusalFromDecision(issue, *decision.Refusal),
-	}, true, nil
+	result := runResultWithBudgetProjection(decision.Projection)
+	result.FinalState = FinalStateCompleted
+	result.BudgetRefusal = budgetRefusalFromDecision(issue, *decision.Refusal)
+	return result, true, nil
+}
+
+func runResultWithBudgetProjection(projection *budget.Projection) RunResult {
+	if projection == nil {
+		return RunResult{}
+	}
+	return RunResult{budgetProjection: &dispatchBudgetProjection{CostUSD: projection.CostUSD}}
 }
 
 func budgetRefusalFromDecision(issue connector.Issue, refusal budget.Refusal) *BudgetRefusal {
@@ -2093,6 +2104,8 @@ func (r *Runner) finishSession(
 	requestedModel := strings.TrimSpace(model)
 	resolvedModel := effectiveModel(result.RuntimeIdentity.ResolvedModel.Value, result.Model)
 	usageModel := effectiveModel(resolvedModel, requestedModel)
+	actualCostUSD := r.usageCostUSD(usageModel, result.Tokens.InputTokens, result.Tokens.CachedInputTokens, result.Tokens.OutputTokens, backendKind)
+	projectedCostUSD, projectionOvershootUSD := budgetProjectionCosts(result.budgetProjection, actualCostUSD)
 
 	if err := r.store.FinishSession(ctx, sessionID, store.SessionFinish{
 		CompletedAt:           finishedAt,
@@ -2126,24 +2139,36 @@ func (r *Runner) finishSession(
 	attrs = append(attrs, runtimeIdentityLogAttrs(result.RuntimeIdentity)...)
 	r.logWorkerEvent(issue, "worker_session_finished", attrs...)
 	r.warnImplausibleCompletedSessionUsage(issue, workAttemptID, sessionID, turns, result)
+	if projectionOvershootUSD > 0 && projectedCostUSD != nil {
+		r.logWorkerEventLevel(slog.LevelWarn, issue, "worker_budget_projection_overshoot",
+			telemetry.WorkAttemptIDKey, workAttemptID,
+			telemetry.DetentSessionIDKey, sessionID,
+			"model", usageModel,
+			"projected_cost_usd", *projectedCostUSD,
+			"actual_cost_usd", actualCostUSD,
+			"projection_overshoot_usd", projectionOvershootUSD,
+		)
+	}
 	if _, err := r.store.RecordUsageEvent(ctx, store.UsageEvent{
-		ProjectID:             r.projectID,
-		SessionID:             sessionID,
-		IssueID:               issue.ID,
-		Identifier:            issue.Identifier,
-		PRNumber:              pullRequestNumber(issue),
-		Model:                 usageModel,
-		InputTokens:           result.Tokens.InputTokens,
-		CachedInputTokens:     result.Tokens.CachedInputTokens,
-		OutputTokens:          result.Tokens.OutputTokens,
-		ReasoningOutputTokens: result.Tokens.ReasoningOutputTokens,
-		TotalTokens:           result.Tokens.TotalTokens,
-		ModelContextWindow:    result.Tokens.ModelContextWindow,
-		CostUSD:               r.usageCostUSD(usageModel, result.Tokens.InputTokens, result.Tokens.CachedInputTokens, result.Tokens.OutputTokens, backendKind),
-		RuntimeSeconds:        int64(math.Round(result.Tokens.RuntimeSeconds)),
-		StartedAt:             startedAt,
-		FinishedAt:            finishedAt,
-		Outcome:               result.FinalState,
+		ProjectID:              r.projectID,
+		SessionID:              sessionID,
+		IssueID:                issue.ID,
+		Identifier:             issue.Identifier,
+		PRNumber:               pullRequestNumber(issue),
+		Model:                  usageModel,
+		InputTokens:            result.Tokens.InputTokens,
+		CachedInputTokens:      result.Tokens.CachedInputTokens,
+		OutputTokens:           result.Tokens.OutputTokens,
+		ReasoningOutputTokens:  result.Tokens.ReasoningOutputTokens,
+		TotalTokens:            result.Tokens.TotalTokens,
+		ModelContextWindow:     result.Tokens.ModelContextWindow,
+		CostUSD:                actualCostUSD,
+		ProjectedCostUSD:       projectedCostUSD,
+		ProjectionOvershootUSD: projectionOvershootUSD,
+		RuntimeSeconds:         int64(math.Round(result.Tokens.RuntimeSeconds)),
+		StartedAt:              startedAt,
+		FinishedAt:             finishedAt,
+		Outcome:                result.FinalState,
 	}); err != nil {
 		return fmt.Errorf("record usage event: %w", err)
 	}
@@ -2151,6 +2176,14 @@ func (r *Runner) finishSession(
 		return err
 	}
 	return nil
+}
+
+func budgetProjectionCosts(projection *dispatchBudgetProjection, actualCostUSD float64) (*float64, float64) {
+	if projection == nil {
+		return nil, 0
+	}
+	projectedCostUSD := max(0, projection.CostUSD)
+	return &projectedCostUSD, max(0, actualCostUSD-projectedCostUSD)
 }
 
 func (r *Runner) warnImplausibleCompletedSessionUsage(issue connector.Issue, workAttemptID int64, sessionID int64, turns int64, result RunResult) {

--- a/internal/runner/runner_test.go
+++ b/internal/runner/runner_test.go
@@ -2801,6 +2801,78 @@ func TestRunnerFinishSessionWarnsOnImplausibleCompletedUsage(t *testing.T) {
 	}
 }
 
+func TestRunnerFinishSessionRecordsBudgetProjectionOvershoot(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name          string
+		projectedCost float64
+		inputTokens   int64
+		wantOvershoot float64
+		wantWarning   bool
+	}{
+		{name: "actual cost exceeds admitted projection", projectedCost: 0.10, inputTokens: 20, wantOvershoot: 0.10, wantWarning: true},
+		{name: "actual cost stays below admitted projection", projectedCost: 0.25, inputTokens: 20},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			var logs bytes.Buffer
+			sessionStore := &fakeSessionStore{sessionID: 1757}
+			r := &Runner{
+				projectID: "detent",
+				store:     sessionStore,
+				pricing: budget.PricingTable{
+					"gpt-test": {USDPerInputToken: 0.01},
+				},
+				logger: slog.New(slog.NewTextHandler(&logs, nil)),
+			}
+			startedAt := time.Date(2026, 8, 12, 12, 0, 0, 0, time.UTC)
+			err := r.finishSession(
+				context.Background(),
+				1757,
+				true,
+				91,
+				connector.Issue{ID: "issue-1757", Identifier: "digitaldrywood/detent#1757"},
+				startedAt,
+				startedAt.Add(time.Minute),
+				RunResult{
+					FinalState:       FinalStateCompleted,
+					Tokens:           TokenTotals{InputTokens: tt.inputTokens, TotalTokens: tt.inputTokens, RuntimeSeconds: 60},
+					budgetProjection: &dispatchBudgetProjection{CostUSD: tt.projectedCost},
+				},
+				"gpt-test",
+				"codex",
+				1,
+				AgentTurnResult{},
+				0,
+			)
+			if err != nil {
+				t.Fatalf("finishSession() error = %v", err)
+			}
+			if sessionStore.usage.ProjectedCostUSD == nil || math.Abs(*sessionStore.usage.ProjectedCostUSD-tt.projectedCost) > 0.000001 {
+				t.Fatalf("ProjectedCostUSD = %v, want %.2f", sessionStore.usage.ProjectedCostUSD, tt.projectedCost)
+			}
+			if math.Abs(sessionStore.usage.ProjectionOvershootUSD-tt.wantOvershoot) > 0.000001 {
+				t.Fatalf("ProjectionOvershootUSD = %.6f, want %.6f", sessionStore.usage.ProjectionOvershootUSD, tt.wantOvershoot)
+			}
+			gotWarning := strings.Contains(logs.String(), "worker_budget_projection_overshoot")
+			if gotWarning != tt.wantWarning {
+				t.Fatalf("overshoot warning present = %t, want %t\n%s", gotWarning, tt.wantWarning, logs.String())
+			}
+			if tt.wantWarning {
+				for _, want := range []string{"projected_cost_usd=0.1", "actual_cost_usd=0.2", "projection_overshoot_usd=0.1"} {
+					if !strings.Contains(logs.String(), want) {
+						t.Fatalf("overshoot warning missing %q:\n%s", want, logs.String())
+					}
+				}
+			}
+		})
+	}
+}
+
 func TestLogRuntimeIdentityChangeUsesCanonicalFieldsWithoutPayloadSecrets(t *testing.T) {
 	t.Parallel()
 

--- a/internal/runner/types.go
+++ b/internal/runner/types.go
@@ -420,6 +420,11 @@ type RunResult struct {
 	PullRequestHeadPushed   bool
 	CITriggerLabelReapplied bool
 	MergePrecheck           *MergePrecheck
+	budgetProjection        *dispatchBudgetProjection
+}
+
+type dispatchBudgetProjection struct {
+	CostUSD float64
 }
 
 type UsageUpdateHandler func(UsageUpdate) error

--- a/internal/store/migrations/00030_add_usage_budget_projection.sql
+++ b/internal/store/migrations/00030_add_usage_budget_projection.sql
@@ -1,0 +1,13 @@
+-- +goose Up
+ALTER TABLE usage_events
+ADD COLUMN projected_cost_usd REAL;
+
+ALTER TABLE usage_events
+ADD COLUMN projection_overshoot_usd REAL NOT NULL DEFAULT 0.0;
+
+-- +goose Down
+ALTER TABLE usage_events
+DROP COLUMN projection_overshoot_usd;
+
+ALTER TABLE usage_events
+DROP COLUMN projected_cost_usd;

--- a/internal/store/sqlc/models.go
+++ b/internal/store/sqlc/models.go
@@ -288,26 +288,28 @@ type SchedulerDecision struct {
 }
 
 type UsageEvent struct {
-	ID                    int64          `json:"id"`
-	ProjectID             string         `json:"project_id"`
-	RunID                 sql.NullInt64  `json:"run_id"`
-	SessionID             sql.NullInt64  `json:"session_id"`
-	IssueID               sql.NullString `json:"issue_id"`
-	Identifier            sql.NullString `json:"identifier"`
-	PrNumber              sql.NullInt64  `json:"pr_number"`
-	Model                 string         `json:"model"`
-	InputTokens           int64          `json:"input_tokens"`
-	OutputTokens          int64          `json:"output_tokens"`
-	TotalTokens           int64          `json:"total_tokens"`
-	RuntimeSeconds        int64          `json:"runtime_seconds"`
-	StartedAt             string         `json:"started_at"`
-	FinishedAt            string         `json:"finished_at"`
-	EventDay              string         `json:"event_day"`
-	Outcome               string         `json:"outcome"`
-	CostUsd               float64        `json:"cost_usd"`
-	CachedInputTokens     sql.NullInt64  `json:"cached_input_tokens"`
-	ReasoningOutputTokens sql.NullInt64  `json:"reasoning_output_tokens"`
-	ModelContextWindow    sql.NullInt64  `json:"model_context_window"`
+	ID                     int64           `json:"id"`
+	ProjectID              string          `json:"project_id"`
+	RunID                  sql.NullInt64   `json:"run_id"`
+	SessionID              sql.NullInt64   `json:"session_id"`
+	IssueID                sql.NullString  `json:"issue_id"`
+	Identifier             sql.NullString  `json:"identifier"`
+	PrNumber               sql.NullInt64   `json:"pr_number"`
+	Model                  string          `json:"model"`
+	InputTokens            int64           `json:"input_tokens"`
+	OutputTokens           int64           `json:"output_tokens"`
+	TotalTokens            int64           `json:"total_tokens"`
+	RuntimeSeconds         int64           `json:"runtime_seconds"`
+	StartedAt              string          `json:"started_at"`
+	FinishedAt             string          `json:"finished_at"`
+	EventDay               string          `json:"event_day"`
+	Outcome                string          `json:"outcome"`
+	CostUsd                float64         `json:"cost_usd"`
+	CachedInputTokens      sql.NullInt64   `json:"cached_input_tokens"`
+	ReasoningOutputTokens  sql.NullInt64   `json:"reasoning_output_tokens"`
+	ModelContextWindow     sql.NullInt64   `json:"model_context_window"`
+	ProjectedCostUsd       sql.NullFloat64 `json:"projected_cost_usd"`
+	ProjectionOvershootUsd float64         `json:"projection_overshoot_usd"`
 }
 
 type ValidatorVerdict struct {

--- a/internal/store/sqlc/store.sql.go
+++ b/internal/store/sqlc/store.sql.go
@@ -779,35 +779,39 @@ INSERT INTO usage_events (
   total_tokens,
   model_context_window,
   cost_usd,
+  projected_cost_usd,
+  projection_overshoot_usd,
   runtime_seconds,
   started_at,
   finished_at,
   event_day,
   outcome
-) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-RETURNING id, project_id, run_id, session_id, issue_id, identifier, pr_number, model, input_tokens, output_tokens, total_tokens, runtime_seconds, started_at, finished_at, event_day, outcome, cost_usd, cached_input_tokens, reasoning_output_tokens, model_context_window
+) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+RETURNING id, project_id, run_id, session_id, issue_id, identifier, pr_number, model, input_tokens, output_tokens, total_tokens, runtime_seconds, started_at, finished_at, event_day, outcome, cost_usd, cached_input_tokens, reasoning_output_tokens, model_context_window, projected_cost_usd, projection_overshoot_usd
 `
 
 type CreateUsageEventParams struct {
-	ProjectID             string         `json:"project_id"`
-	RunID                 sql.NullInt64  `json:"run_id"`
-	SessionID             sql.NullInt64  `json:"session_id"`
-	IssueID               sql.NullString `json:"issue_id"`
-	Identifier            sql.NullString `json:"identifier"`
-	PrNumber              sql.NullInt64  `json:"pr_number"`
-	Model                 string         `json:"model"`
-	InputTokens           int64          `json:"input_tokens"`
-	CachedInputTokens     sql.NullInt64  `json:"cached_input_tokens"`
-	OutputTokens          int64          `json:"output_tokens"`
-	ReasoningOutputTokens sql.NullInt64  `json:"reasoning_output_tokens"`
-	TotalTokens           int64          `json:"total_tokens"`
-	ModelContextWindow    sql.NullInt64  `json:"model_context_window"`
-	CostUsd               float64        `json:"cost_usd"`
-	RuntimeSeconds        int64          `json:"runtime_seconds"`
-	StartedAt             string         `json:"started_at"`
-	FinishedAt            string         `json:"finished_at"`
-	EventDay              string         `json:"event_day"`
-	Outcome               string         `json:"outcome"`
+	ProjectID              string          `json:"project_id"`
+	RunID                  sql.NullInt64   `json:"run_id"`
+	SessionID              sql.NullInt64   `json:"session_id"`
+	IssueID                sql.NullString  `json:"issue_id"`
+	Identifier             sql.NullString  `json:"identifier"`
+	PrNumber               sql.NullInt64   `json:"pr_number"`
+	Model                  string          `json:"model"`
+	InputTokens            int64           `json:"input_tokens"`
+	CachedInputTokens      sql.NullInt64   `json:"cached_input_tokens"`
+	OutputTokens           int64           `json:"output_tokens"`
+	ReasoningOutputTokens  sql.NullInt64   `json:"reasoning_output_tokens"`
+	TotalTokens            int64           `json:"total_tokens"`
+	ModelContextWindow     sql.NullInt64   `json:"model_context_window"`
+	CostUsd                float64         `json:"cost_usd"`
+	ProjectedCostUsd       sql.NullFloat64 `json:"projected_cost_usd"`
+	ProjectionOvershootUsd float64         `json:"projection_overshoot_usd"`
+	RuntimeSeconds         int64           `json:"runtime_seconds"`
+	StartedAt              string          `json:"started_at"`
+	FinishedAt             string          `json:"finished_at"`
+	EventDay               string          `json:"event_day"`
+	Outcome                string          `json:"outcome"`
 }
 
 func (q *Queries) CreateUsageEvent(ctx context.Context, arg CreateUsageEventParams) (UsageEvent, error) {
@@ -826,6 +830,8 @@ func (q *Queries) CreateUsageEvent(ctx context.Context, arg CreateUsageEventPara
 		arg.TotalTokens,
 		arg.ModelContextWindow,
 		arg.CostUsd,
+		arg.ProjectedCostUsd,
+		arg.ProjectionOvershootUsd,
 		arg.RuntimeSeconds,
 		arg.StartedAt,
 		arg.FinishedAt,
@@ -854,6 +860,8 @@ func (q *Queries) CreateUsageEvent(ctx context.Context, arg CreateUsageEventPara
 		&i.CachedInputTokens,
 		&i.ReasoningOutputTokens,
 		&i.ModelContextWindow,
+		&i.ProjectedCostUsd,
+		&i.ProjectionOvershootUsd,
 	)
 	return i, err
 }
@@ -1842,7 +1850,7 @@ func (q *Queries) GetLatestIssueAgentSession(ctx context.Context, arg GetLatestI
 }
 
 const getUsageEvent = `-- name: GetUsageEvent :one
-SELECT id, project_id, run_id, session_id, issue_id, identifier, pr_number, model, input_tokens, output_tokens, total_tokens, runtime_seconds, started_at, finished_at, event_day, outcome, cost_usd, cached_input_tokens, reasoning_output_tokens, model_context_window
+SELECT id, project_id, run_id, session_id, issue_id, identifier, pr_number, model, input_tokens, output_tokens, total_tokens, runtime_seconds, started_at, finished_at, event_day, outcome, cost_usd, cached_input_tokens, reasoning_output_tokens, model_context_window, projected_cost_usd, projection_overshoot_usd
 FROM usage_events
 WHERE id = ?
 `
@@ -1871,6 +1879,8 @@ func (q *Queries) GetUsageEvent(ctx context.Context, id int64) (UsageEvent, erro
 		&i.CachedInputTokens,
 		&i.ReasoningOutputTokens,
 		&i.ModelContextWindow,
+		&i.ProjectedCostUsd,
+		&i.ProjectionOvershootUsd,
 	)
 	return i, err
 }

--- a/internal/store/sqlite.go
+++ b/internal/store/sqlite.go
@@ -579,25 +579,27 @@ func (s *sqliteStore) RecordUsageEvent(ctx context.Context, attrs UsageEvent) (i
 	}
 
 	event, err := s.queries.CreateUsageEvent(ctx, sqlc.CreateUsageEventParams{
-		ProjectID:             projectID,
-		RunID:                 nullPositiveInt64(attrs.RunID),
-		SessionID:             nullPositiveInt64(attrs.SessionID),
-		IssueID:               nullString(attrs.IssueID),
-		Identifier:            nullString(attrs.Identifier),
-		PrNumber:              nullOptionalInt64(attrs.PRNumber),
-		Model:                 strings.TrimSpace(attrs.Model),
-		InputTokens:           nonNegative(attrs.InputTokens),
-		CachedInputTokens:     nullNonNegativeInt64(attrs.CachedInputTokens),
-		OutputTokens:          nonNegative(attrs.OutputTokens),
-		ReasoningOutputTokens: nullNonNegativeInt64(attrs.ReasoningOutputTokens),
-		TotalTokens:           nonNegative(attrs.TotalTokens),
-		ModelContextWindow:    nullOptionalInt64(attrs.ModelContextWindow),
-		CostUsd:               nonNegativeFloat(attrs.CostUSD),
-		RuntimeSeconds:        nonNegative(attrs.RuntimeSeconds),
-		StartedAt:             startedAt,
-		FinishedAt:            finishedAt,
-		EventDay:              attrs.FinishedAt.UTC().Format("2006-01-02"),
-		Outcome:               outcome,
+		ProjectID:              projectID,
+		RunID:                  nullPositiveInt64(attrs.RunID),
+		SessionID:              nullPositiveInt64(attrs.SessionID),
+		IssueID:                nullString(attrs.IssueID),
+		Identifier:             nullString(attrs.Identifier),
+		PrNumber:               nullOptionalInt64(attrs.PRNumber),
+		Model:                  strings.TrimSpace(attrs.Model),
+		InputTokens:            nonNegative(attrs.InputTokens),
+		CachedInputTokens:      nullNonNegativeInt64(attrs.CachedInputTokens),
+		OutputTokens:           nonNegative(attrs.OutputTokens),
+		ReasoningOutputTokens:  nullNonNegativeInt64(attrs.ReasoningOutputTokens),
+		TotalTokens:            nonNegative(attrs.TotalTokens),
+		ModelContextWindow:     nullOptionalInt64(attrs.ModelContextWindow),
+		CostUsd:                nonNegativeFloat(attrs.CostUSD),
+		ProjectedCostUsd:       nullableNonNegativeFloat(attrs.ProjectedCostUSD),
+		ProjectionOvershootUsd: nonNegativeFloat(attrs.ProjectionOvershootUSD),
+		RuntimeSeconds:         nonNegative(attrs.RuntimeSeconds),
+		StartedAt:              startedAt,
+		FinishedAt:             finishedAt,
+		EventDay:               attrs.FinishedAt.UTC().Format("2006-01-02"),
+		Outcome:                outcome,
 	})
 	if err != nil {
 		return 0, fmt.Errorf("recording usage event: %w", err)
@@ -1409,6 +1411,13 @@ func nonNegativeFloat(value float64) float64 {
 		return 0
 	}
 	return value
+}
+
+func nullableNonNegativeFloat(value *float64) sql.NullFloat64 {
+	if value == nil {
+		return sql.NullFloat64{}
+	}
+	return sql.NullFloat64{Float64: nonNegativeFloat(*value), Valid: true}
 }
 
 func positiveWeight(value int) int {

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -486,24 +486,26 @@ type APIUsageLog struct {
 }
 
 type UsageEvent struct {
-	ProjectID             string
-	RunID                 int64
-	SessionID             int64
-	IssueID               string
-	Identifier            string
-	PRNumber              *int64
-	Model                 string
-	InputTokens           int64
-	CachedInputTokens     int64
-	OutputTokens          int64
-	ReasoningOutputTokens int64
-	TotalTokens           int64
-	ModelContextWindow    *int64
-	CostUSD               float64
-	RuntimeSeconds        int64
-	StartedAt             time.Time
-	FinishedAt            time.Time
-	Outcome               string
+	ProjectID              string
+	RunID                  int64
+	SessionID              int64
+	IssueID                string
+	Identifier             string
+	PRNumber               *int64
+	Model                  string
+	InputTokens            int64
+	CachedInputTokens      int64
+	OutputTokens           int64
+	ReasoningOutputTokens  int64
+	TotalTokens            int64
+	ModelContextWindow     *int64
+	CostUSD                float64
+	ProjectedCostUSD       *float64
+	ProjectionOvershootUSD float64
+	RuntimeSeconds         int64
+	StartedAt              time.Time
+	FinishedAt             time.Time
+	Outcome                string
 }
 
 type WorkflowPhaseEvent = workflowmetrics.PhaseEvent

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -2350,6 +2350,7 @@ func TestUsageLedgerRoundTrip(t *testing.T) {
 	t.Parallel()
 
 	modelContextWindow := int64(128000)
+	projectedCost := 0.0008
 	tests := []struct {
 		name  string
 		event UsageEvent
@@ -2357,24 +2358,26 @@ func TestUsageLedgerRoundTrip(t *testing.T) {
 		{
 			name: "persists usage event across reopen",
 			event: UsageEvent{
-				ProjectID:             " detent ",
-				RunID:                 11,
-				SessionID:             42,
-				IssueID:               " I_kwDOSskuwc8AAAABD6psJQ ",
-				Identifier:            " digitaldrywood/detent#117 ",
-				PRNumber:              int64Ptr(91),
-				Model:                 " gpt-5-codex ",
-				InputTokens:           123,
-				CachedInputTokens:     67,
-				OutputTokens:          45,
-				ReasoningOutputTokens: 9,
-				TotalTokens:           168,
-				ModelContextWindow:    &modelContextWindow,
-				CostUSD:               0.00123,
-				RuntimeSeconds:        73,
-				StartedAt:             time.Date(2026, 5, 31, 13, 0, 0, 0, time.UTC),
-				FinishedAt:            time.Date(2026, 5, 31, 13, 1, 13, 0, time.UTC),
-				Outcome:               " completed ",
+				ProjectID:              " detent ",
+				RunID:                  11,
+				SessionID:              42,
+				IssueID:                " I_kwDOSskuwc8AAAABD6psJQ ",
+				Identifier:             " digitaldrywood/detent#117 ",
+				PRNumber:               int64Ptr(91),
+				Model:                  " gpt-5-codex ",
+				InputTokens:            123,
+				CachedInputTokens:      67,
+				OutputTokens:           45,
+				ReasoningOutputTokens:  9,
+				TotalTokens:            168,
+				ModelContextWindow:     &modelContextWindow,
+				CostUSD:                0.00123,
+				ProjectedCostUSD:       &projectedCost,
+				ProjectionOvershootUSD: 0.00043,
+				RuntimeSeconds:         73,
+				StartedAt:              time.Date(2026, 5, 31, 13, 0, 0, 0, time.UTC),
+				FinishedAt:             time.Date(2026, 5, 31, 13, 1, 13, 0, time.UTC),
+				Outcome:                " completed ",
 			},
 		},
 	}
@@ -2432,6 +2435,12 @@ func TestUsageLedgerRoundTrip(t *testing.T) {
 			}
 			if got.CostUsd != 0.00123 {
 				t.Fatalf("cost_usd = %.12f, want 0.001230000000", got.CostUsd)
+			}
+			if !got.ProjectedCostUsd.Valid || got.ProjectedCostUsd.Float64 != projectedCost {
+				t.Fatalf("projected_cost_usd = %#v, want %.12f", got.ProjectedCostUsd, projectedCost)
+			}
+			if got.ProjectionOvershootUsd != 0.00043 {
+				t.Fatalf("projection_overshoot_usd = %.12f, want 0.000430000000", got.ProjectionOvershootUsd)
 			}
 			if got.StartedAt != "2026-05-31T13:00:00Z" || got.FinishedAt != "2026-05-31T13:01:13Z" {
 				t.Fatalf("timestamps = %q/%q", got.StartedAt, got.FinishedAt)


### PR DESCRIPTION
## Summary

- report non-expiring per-issue budget refusals as `budget_hard_hold` while retaining `budget_cooldown` for resettable daily pacing
- persist the projection that admitted a session, record actual projection overshoot in usage events, and emit a structured overshoot warning
- clarify configuration, generated templates, and operator guidance that the per-issue limit is an estimate-based preflight backstop whose breach parks the issue until operator action

## Root cause

Per-issue refusals intentionally bypass cooldown expiry, but dispatch classification mapped every active budget refusal to `budget_cooldown`. The runner also discarded the admitted projection before session completion, making actual overshoot unobservable.

## Test Plan

- `make generate`
- `env -u DETENT_API_TOKEN go test ./internal/budget ./internal/orchestrator ./internal/runner ./internal/store -count=1`
- `go test ./internal/web/templates -run '^TestDashboardDistinguishesBudgetHoldLifecycle$'`
- `make check` (78.8% coverage)

Fixes #1757