### PR TITLE
fix(runner): recover failed PR delivery

### DIFF
--- a/internal/codex/activity_test.go
+++ b/internal/codex/activity_test.go
@@ -6,12 +6,14 @@ func TestUpdateFromMessageEmitsToolActivity(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name        string
-		method      string
-		params      string
-		wantType    UpdateType
-		wantTool    string
-		wantContent string
+		name             string
+		method           string
+		params           string
+		wantType         UpdateType
+		wantTool         string
+		wantContent      string
+		wantErrorBody    string
+		wantErrorMessage string
 	}{
 		{
 			name:        "command starts",
@@ -37,6 +39,24 @@ func TestUpdateFromMessageEmitsToolActivity(t *testing.T) {
 			wantTool:    "github/get_issue",
 			wantContent: `{"content":[{"type":"text","text":"issue body"}]}`,
 		},
+		{
+			name:        "mcp start preserves attempted arguments",
+			method:      "item/started",
+			params:      `{"threadId":"thread-1","turnId":"turn-1","item":{"id":"item-3","type":"mcpToolCall","server":"codex_apps","tool":"github.create_pull_request","arguments":{"repository_full_name":"acme/widgets","head":"detent/widgets-18"},"result":null,"status":"inProgress"}}`,
+			wantType:    UpdateToolStarted,
+			wantTool:    "codex_apps/github.create_pull_request",
+			wantContent: `{"repository_full_name":"acme/widgets","head":"detent/widgets-18"}`,
+		},
+		{
+			name:             "failed mcp result surfaces structured error instead of null",
+			method:           "item/completed",
+			params:           `{"threadId":"thread-1","turnId":"turn-1","item":{"id":"item-3","type":"mcpToolCall","server":"codex_apps","tool":"github.create_pull_request","arguments":{"repository_full_name":"acme/widgets","head":"detent/widgets-18"},"result":null,"error":{"message":"HTTP 502: upstream unavailable"},"status":"failed"}}`,
+			wantType:         UpdateToolCompleted,
+			wantTool:         "codex_apps/github.create_pull_request",
+			wantContent:      "HTTP 502: upstream unavailable",
+			wantErrorBody:    `{"message":"HTTP 502: upstream unavailable"}`,
+			wantErrorMessage: "HTTP 502: upstream unavailable",
+		},
 	}
 
 	for _, tt := range tests {
@@ -49,7 +69,8 @@ func TestUpdateFromMessageEmitsToolActivity(t *testing.T) {
 			if !ok {
 				t.Fatal("updateFromMessage() ok = false, want true")
 			}
-			if update.Type != tt.wantType || update.Tool != tt.wantTool || update.Delta != tt.wantContent {
+			if update.Type != tt.wantType || update.Tool != tt.wantTool || update.Delta != tt.wantContent ||
+				update.BackendErrorBody != tt.wantErrorBody || update.BackendErrorMessage != tt.wantErrorMessage {
 				t.Fatalf("update = %#v, want type %q tool %q content %q", update, tt.wantType, tt.wantTool, tt.wantContent)
 			}
 		})

--- a/internal/codex/appserver.go
+++ b/internal/codex/appserver.go
@@ -1616,11 +1616,13 @@ func toolLifecycleUpdate(msg Message) (Update, bool, error) {
 			ID               string          `json:"id"`
 			Type             string          `json:"type"`
 			Command          string          `json:"command"`
+			Arguments        json.RawMessage `json:"arguments"`
 			Status           string          `json:"status"`
 			AggregatedOutput string          `json:"aggregatedOutput"`
 			Server           string          `json:"server"`
 			Tool             string          `json:"tool"`
 			Result           json.RawMessage `json:"result"`
+			Error            json.RawMessage `json:"error"`
 			Changes          json.RawMessage `json:"changes"`
 			ContentItems     json.RawMessage `json:"contentItems"`
 		} `json:"item"`
@@ -1635,29 +1637,61 @@ func toolLifecycleUpdate(msg Message) (Update, bool, error) {
 	if params.Item.Server != "" && params.Item.Tool != "" {
 		tool = params.Item.Server + "/" + params.Item.Tool
 	}
-	content := strings.TrimSpace(params.Item.Command)
+	content := firstNonBlank(
+		params.Item.Command,
+		compactNonNullJSON(params.Item.Arguments),
+	)
+	errorBody := ""
+	errorMessage := ""
 	updateType := UpdateToolStarted
 	if msg.Method == "item/completed" {
 		updateType = UpdateToolCompleted
+		errorBody = compactNonNullJSON(params.Item.Error)
+		errorMessage = errorMessageFromJSON(params.Item.Error)
+		if failedToolStatus(params.Item.Status) && errorBody == "" {
+			errorBody = firstNonBlank(
+				compactNonNullJSON(params.Item.Result),
+				compactNonNullJSON(params.Item.ContentItems),
+			)
+		}
+		if failedToolStatus(params.Item.Status) && errorMessage == "" {
+			errorMessage = firstNonBlank(
+				errorMessageFromJSON(params.Item.Result),
+				errorMessageFromJSON(params.Item.ContentItems),
+			)
+		}
 		content = firstNonBlank(
 			params.Item.AggregatedOutput,
-			compactJSON(params.Item.Result),
-			compactJSON(params.Item.ContentItems),
-			compactJSON(params.Item.Changes),
+			errorMessage,
+			compactNonNullJSON(params.Item.Result),
+			compactNonNullJSON(params.Item.ContentItems),
+			compactNonNullJSON(params.Item.Changes),
 			params.Item.Command,
+			params.Item.Status,
 		)
 	}
 	return Update{
-		Type:     updateType,
-		Method:   msg.Method,
-		ThreadID: params.ThreadID,
-		TurnID:   params.TurnID,
-		ItemID:   params.Item.ID,
-		Tool:     tool,
-		Delta:    content,
-		Status:   params.Item.Status,
-		Payload:  rawPayload(msg),
+		Type:                updateType,
+		Method:              msg.Method,
+		ThreadID:            params.ThreadID,
+		TurnID:              params.TurnID,
+		ItemID:              params.Item.ID,
+		Tool:                tool,
+		Delta:               content,
+		Status:              params.Item.Status,
+		BackendErrorBody:    errorBody,
+		BackendErrorMessage: errorMessage,
+		Payload:             rawPayload(msg),
 	}, true, nil
+}
+
+func failedToolStatus(status string) bool {
+	switch strings.ToLower(strings.TrimSpace(status)) {
+	case "failed", "error", "cancelled", "canceled", "timed_out":
+		return true
+	default:
+		return false
+	}
 }
 
 func toolItemType(value string) bool {
@@ -1729,6 +1763,14 @@ func compactJSON(raw json.RawMessage) string {
 		return string(raw)
 	}
 	return buf.String()
+}
+
+func compactNonNullJSON(raw json.RawMessage) string {
+	raw = bytes.TrimSpace(raw)
+	if len(raw) == 0 || bytes.Equal(raw, []byte("null")) {
+		return ""
+	}
+	return compactJSON(raw)
 }
 
 func errorMessageFromJSON(raw json.RawMessage) string {

--- a/internal/orchestrator/deliverable_recovery.go
+++ b/internal/orchestrator/deliverable_recovery.go
@@ -1,0 +1,107 @@
+package orchestrator
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"strings"
+
+	runpkg "github.com/digitaldrywood/detent/internal/runner"
+	"github.com/digitaldrywood/detent/internal/telemetry"
+)
+
+const deliverableRecoveryNeedsHumanReason = "deliverable_recovery_needs_human_attention"
+
+func (o *Orchestrator) blockDeliverableRecoveryFailure(ctx context.Context, state *State, event runpkg.Completion, running Running) bool {
+	var recoveryErr *runpkg.DeliverableRecoveryError
+	if state == nil || !errors.As(event.Err, &recoveryErr) || recoveryErr == nil {
+		return false
+	}
+	branch := deliverableRecoveryBranch(recoveryErr, running)
+	reason := deliverableRecoveryNeedsHumanReason + ": pushed branch " + branch + " has no recoverable pull request"
+	humanAction := "open or adopt a pull request manually for pushed branch " + branch + ", then move the issue to Rework"
+	issue := cloneIssue(running.Issue)
+	metadata := o.newBlockedRecoveryMetadata(
+		ctx,
+		issue,
+		running.Mode,
+		reason,
+		blockedRecoveryPredicateManaged,
+		autoPromoteReworkState,
+		running.DiffStats,
+	)
+	metadata.BlockedRecovery.Owner = blockedRecoveryOwnerHuman
+	if err := o.updateIssueStateByIDWithMetadata(ctx, state, issue.ID, issue, blockedStatusState, event.CompletedAt, reason, metadata); err != nil {
+		if o.logger != nil {
+			o.logger.Warn(
+				"deliverable recovery block transition failed",
+				"issue_id", issue.ID,
+				"identifier", issue.Identifier,
+				"workspace_branch", branch,
+				"error", err,
+			)
+		}
+		return false
+	}
+	issue.State = blockedStatusState
+	issue.BlockerReason = reason
+	blockedAt := event.CompletedAt.UTC()
+	issue.StageUpdatedAt = &blockedAt
+	if o.connector != nil {
+		comment := "Pull request delivery remains unrecoverable and needs human attention.\n\n- pushed branch: `" + branch + "`\n- failing command: `" + deliverableRecoveryCommand(recoveryErr) + "`\n- recovery: " + humanAction + "\n- error: " + o.operatorText(recoveryErr.Error())
+		if err := o.connector.CreateComment(ctx, issue.ID, comment); err != nil && o.logger != nil {
+			o.logger.Warn("deliverable recovery block comment failed", "issue_id", issue.ID, "identifier", issue.Identifier, "error", err)
+		}
+	}
+	delete(state.Claimed, issue.ID)
+	delete(state.Retry, issue.ID)
+	delete(state.BudgetRefusals, issue.ID)
+	delete(state.PriorAttempts, issue.ID)
+	delete(state.InstantFailures, issue.ID)
+	delete(state.RepeatedFailures, issue.ID)
+	if state.Blocked == nil {
+		state.Blocked = map[string]Blocked{}
+	}
+	state.Blocked[issue.ID] = Blocked{
+		Issue:          issue,
+		Reason:         reason,
+		RecoveryReason: humanAction,
+		RecoveryTarget: autoPromoteReworkState,
+		BlockedAt:      event.CompletedAt,
+		Source:         BlockedSourceProjectStatus,
+		Recovery:       metadata.BlockedRecovery,
+	}
+	recordStateEvent(state, telemetry.ActivityEvent{
+		At:      event.CompletedAt,
+		Event:   deliverableRecoveryNeedsHumanReason,
+		Message: "parked " + issueLabel(issue) + " with recoverable pushed branch " + branch,
+	})
+	telemetry.LogLifecycle(o.logger, slog.LevelError, telemetry.LifecycleSafetyControl, deliverableRecoveryNeedsHumanReason, o.runningLifecycleCorrelation(issue, running),
+		"workspace_branch", branch,
+		"deliverable_command", deliverableRecoveryCommand(recoveryErr),
+		"error", recoveryErr,
+	)
+	return true
+}
+
+func deliverableRecoveryBranch(recoveryErr *runpkg.DeliverableRecoveryError, running Running) string {
+	if recoveryErr != nil {
+		if branch := strings.TrimSpace(recoveryErr.Branch); branch != "" {
+			return branch
+		}
+	}
+	if branch := strings.TrimSpace(running.Issue.BranchName); branch != "" {
+		return branch
+	}
+	return "unknown"
+}
+
+func deliverableRecoveryCommand(recoveryErr *runpkg.DeliverableRecoveryError) string {
+	var deliverableErr *runpkg.DeliverableCommandError
+	if recoveryErr != nil && errors.As(recoveryErr, &deliverableErr) && deliverableErr != nil {
+		if command := strings.TrimSpace(deliverableErr.Operation); command != "" {
+			return command
+		}
+	}
+	return "pull request creation"
+}

--- a/internal/orchestrator/failure_breaker.go
+++ b/internal/orchestrator/failure_breaker.go
@@ -346,8 +346,11 @@ func projectAttemptFailureClass(
 	if errors.Is(err, runpkg.ErrSessionTokenCeilingExceeded) || strings.Contains(combined, "session token ceiling exceeded") {
 		return projectFailureClassSessionTokenCeiling
 	}
+	if command := deliverableFailureCommand(err, combined); command != "" {
+		return projectFailureClassDeliverableCommand + ":" + command
+	}
 	if strings.Contains(combined, "deliverable command failed") {
-		return projectFailureClassDeliverableCommand
+		return projectFailureClassDeliverableCommand + ":unknown"
 	}
 	var backendError interface {
 		BackendErrorBody() string
@@ -384,6 +387,31 @@ func projectAttemptFailureClass(
 		return ""
 	}
 	return projectFailureClassRunnerError + ":" + projectFailureHash(message)
+}
+
+func deliverableFailureCommand(err error, message string) string {
+	var deliverableErr *runpkg.DeliverableCommandError
+	if errors.As(err, &deliverableErr) && deliverableErr != nil {
+		return normalizeDeliverableFailureCommand(deliverableErr.Operation)
+	}
+	const prefix = "deliverable command failed ("
+	index := strings.Index(message, prefix)
+	if index < 0 {
+		return ""
+	}
+	command := message[index+len(prefix):]
+	if end := strings.Index(command, ")"); end >= 0 {
+		command = command[:end]
+	}
+	return normalizeDeliverableFailureCommand(command)
+}
+
+func normalizeDeliverableFailureCommand(command string) string {
+	command = strings.Join(strings.Fields(strings.TrimSpace(command)), " ")
+	if len(command) > 160 {
+		command = command[:160]
+	}
+	return command
 }
 
 func normalizeProjectFailureClass(value string) string {

--- a/internal/orchestrator/failure_breaker_internal_test.go
+++ b/internal/orchestrator/failure_breaker_internal_test.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/digitaldrywood/detent/internal/backendcapacity"
+	runpkg "github.com/digitaldrywood/detent/internal/runner"
 	"github.com/digitaldrywood/detent/internal/store"
 )
 
@@ -39,10 +40,21 @@ func TestProjectAttemptFailureClass(t *testing.T) {
 			want:          projectFailureClassSessionTokenCeiling,
 		},
 		{
-			name:          "deliverable command has stable class",
+			name:          "legacy deliverable command names the failing command",
 			err:           errors.New("deliverable command failed (gh pr create): exit status 1"),
 			terminalState: store.WorkAttemptTerminalFailure,
-			want:          projectFailureClassDeliverableCommand,
+			want:          projectFailureClassDeliverableCommand + ":gh pr create",
+		},
+		{
+			name: "structured deliverable command names the failing command",
+			err: &runpkg.DeliverableCommandError{
+				Operation: "codex_apps/github.create_pull_request",
+				Arguments: `{"head":"detent/acme_widgets_18"}`,
+				Status:    "failed",
+				Message:   "HTTP 503: unavailable",
+			},
+			terminalState: store.WorkAttemptTerminalFailure,
+			want:          projectFailureClassDeliverableCommand + ":codex_apps/github.create_pull_request",
 		},
 		{
 			name:          "backend body is hashed",

--- a/internal/orchestrator/run_completion.go
+++ b/internal/orchestrator/run_completion.go
@@ -247,7 +247,13 @@ func (o *Orchestrator) handleRunResult(ctx context.Context, state *State, event 
 		errorMessage := event.Err.Error()
 		phase := "failed"
 		statusMessage := "worker failed"
-		if spendProgress.Block && !errors.Is(event.Err, runpkg.ErrSessionTokenCeilingExceeded) {
+		var deliverableRecoveryErr *runpkg.DeliverableRecoveryError
+		if errors.As(event.Err, &deliverableRecoveryErr) && deliverableRecoveryErr != nil {
+			errorClass = deliverableRecoveryNeedsHumanReason
+			phase = "blocked"
+			statusMessage = "pushed branch " + deliverableRecoveryBranch(deliverableRecoveryErr, running) + " needs human attention"
+		}
+		if spendProgress.Block && deliverableRecoveryErr == nil && !errors.Is(event.Err, runpkg.ErrSessionTokenCeilingExceeded) {
 			terminalState = store.WorkAttemptTerminalNoProgress
 			errorClass = spendProgressReason
 			errorMessage = spendProgressBlockMessage(spendProgress)
@@ -259,6 +265,9 @@ func (o *Orchestrator) handleRunResult(ctx context.Context, state *State, event 
 		attempt := event.RetryAttempt
 		if attempt < 1 {
 			attempt = nextAttempt(running.Attempt)
+		}
+		if o.blockDeliverableRecoveryFailure(ctx, state, event, running) {
+			return
 		}
 		if o.tripTokenCeilingCircuitBreaker(ctx, state, event, running, attempt) {
 			return

--- a/internal/orchestrator/terminal_attempt_retry_test.go
+++ b/internal/orchestrator/terminal_attempt_retry_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"slices"
+	"strings"
 	"testing"
 	"time"
 
@@ -121,6 +122,65 @@ func TestHandleRunResultRoutesTerminalRetryByWorkProduct(t *testing.T) {
 			}
 			if got := terminalRetryMetadataPushed(attempts.completions[0].WorkerMetadataJSON); got != tt.result.PullRequestHeadPushed {
 				t.Fatalf("persisted work_product_pushed = %v, want %v", got, tt.result.PullRequestHeadPushed)
+			}
+		})
+	}
+}
+
+func TestHandleRunResultParksUnrecoverableDeliverableWithBranch(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		branch string
+	}{
+		{name: "named pushed branch", branch: "detent/acme_widgets_18"},
+		{name: "fallback workspace branch", branch: "detent/acme_widgets_19"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			now := time.Date(2026, 8, 12, 18, 0, 0, 0, time.UTC)
+			issue := terminalRetryTestIssue(tt.name)
+			issue.BranchName = tt.branch
+			tracker := &terminalRetryConnector{issues: map[string]connector.Issue{issue.ID: cloneIssue(issue)}}
+			attempts := &terminalRetryWorkAttemptStore{}
+			cfg := normalizeConfig(Config{ActiveStates: []string{"Todo", "In Progress"}, TerminalStates: []string{"Done"}})
+			o := &Orchestrator{cfg: cfg, connector: tracker, workAttempts: attempts}
+			state := newState(cfg)
+			state.Running[issue.ID] = Running{
+				Issue: issue, Attempt: 1, WorkAttemptID: 42, Mode: runpkg.RunModeImplement,
+				StartedAt: now.Add(-time.Minute), WorkProductPushed: true, WorkspacePath: "/work/" + tt.branch,
+			}
+			state.Claimed[issue.ID] = Claimed{Issue: issue, ClaimedAt: now.Add(-time.Minute)}
+			commandErr := &runpkg.DeliverableCommandError{
+				Operation: "codex_apps/github.create_pull_request", Arguments: `{"head":"` + tt.branch + `"}`,
+				Status: "failed", Message: "HTTP 503: unavailable",
+			}
+
+			o.handleRunResult(t.Context(), &state, runpkg.Completion{
+				IssueID:     issue.ID,
+				Result:      runpkg.RunResult{FinalState: runpkg.FinalStateNeedsHumanAttention, PullRequestHeadPushed: true},
+				Err:         &runpkg.DeliverableRecoveryError{Branch: tt.branch, Err: commandErr},
+				CompletedAt: now,
+			})
+
+			if _, retrying := state.Retry[issue.ID]; retrying {
+				t.Fatalf("Retry[%q] present after unrecoverable PR delivery", issue.ID)
+			}
+			blocked, ok := state.Blocked[issue.ID]
+			if !ok || blocked.Issue.State != blockedStatusState || !strings.Contains(blocked.Reason, tt.branch) || !strings.Contains(blocked.RecoveryReason, tt.branch) {
+				t.Fatalf("Blocked[%q] = %#v, want needs-human recovery naming branch %q", issue.ID, blocked, tt.branch)
+			}
+			if got := tracker.transitionStates(); !slices.Equal(got, []string{blockedStatusState}) {
+				t.Fatalf("state transitions = %v, want [%s]", got, blockedStatusState)
+			}
+			if len(tracker.comments) != 1 || !strings.Contains(tracker.comments[0], tt.branch) || !strings.Contains(tracker.comments[0], "needs human attention") {
+				t.Fatalf("comments = %#v, want needs-human message naming branch", tracker.comments)
+			}
+			if len(attempts.completions) != 1 || attempts.completions[0].Phase != "blocked" || !strings.Contains(attempts.completions[0].StatusMessage, tt.branch) {
+				t.Fatalf("work attempt completions = %#v, want blocked phase naming branch", attempts.completions)
 			}
 		})
 	}
@@ -267,6 +327,7 @@ func terminalRetryTestIssueWithPullRequest(suffix string) connector.Issue {
 type terminalRetryConnector struct {
 	issues      map[string]connector.Issue
 	transitions []string
+	comments    []string
 }
 
 func (c *terminalRetryConnector) Name() string { return "terminal-retry" }
@@ -289,7 +350,10 @@ func (c *terminalRetryConnector) FetchIssueStatesByIDs(_ context.Context, ids []
 	return issues, nil
 }
 
-func (c *terminalRetryConnector) CreateComment(context.Context, string, string) error { return nil }
+func (c *terminalRetryConnector) CreateComment(_ context.Context, _ string, body string) error {
+	c.comments = append(c.comments, body)
+	return nil
+}
 
 func (c *terminalRetryConnector) UpdateIssueState(_ context.Context, issueID string, state string) error {
 	issue := c.issues[issueID]

--- a/internal/runner/agent.go
+++ b/internal/runner/agent.go
@@ -655,6 +655,7 @@ type agentTurnExecution struct {
 	err         error
 	cleanupErr  error
 	turnStarted bool
+	turnCount   int
 }
 
 func runAgentBackendTurn(
@@ -817,6 +818,7 @@ func (r *Runner) runAgentTurn(
 		strings.TrimSpace(runRequest.Issue.PRRepository),
 		ciTriggerPullRequestNumber(runRequest.Issue),
 		runRequest.deliverableRecoveryBranch,
+		runRequest.sessionTurnOffset,
 	)
 	usage := newSessionTokenUsage(!agentResumeEmpty(turnRequest.Resume))
 	if !result.RuntimeIdentity.IsZero() {
@@ -899,6 +901,7 @@ func (r *Runner) runAgentTurn(
 		err:         turnErr,
 		cleanupErr:  cleanupErr,
 		turnStarted: turnStarted,
+		turnCount:   progress.turnCount(),
 	}
 }
 
@@ -1330,7 +1333,7 @@ func (r *Runner) Run(ctx context.Context, req RunRequest) (RunResult, error) {
 			execution.err = classifyAgentCapacityError(backend, selection, backendConfig, execution.result.RuntimeIdentity, execution.err, execution.result.RateLimits, runStartedAt)
 		}
 	}
-	turns := int64(1)
+	turns := int64(max(execution.turnCount, 1))
 	if deliverableErr, ok := recoverablePullRequestDeliverable(execution); ok {
 		branch := strings.TrimSpace(info.Branch)
 		if branch == "" {
@@ -1350,22 +1353,38 @@ func (r *Runner) Run(ctx context.Context, req RunRequest) (RunResult, error) {
 		}
 		recoveryRunRequest := req
 		recoveryRunRequest.deliverableRecoveryBranch = branch
+		recoveryRunRequest.sessionTurnOffset = execution.turnCount
 		recovery := r.runAgentTurn(sessionCtx, backend, recoveryRequest, recoveryRunRequest, info, workspaceIssue, workflow.Config.Agent, workflow.Config.Gate.CITriggerLabel, runStartedAt, sessionID, execution.result.RuntimeIdentity)
 		recovery.err = sessionBrake.wrapTurnLimit(ctx, recovery.err)
 		recovery.err = sessionBrake.wrapDuration(ctx, recovery.err, durationFromMillis(workflow.Config.Agent.MaxSessionDurationMS))
-		turns++
+		if recovery.err != nil {
+			recovery.err = classifyAgentCapacityError(backend, selection, backendConfig, recovery.result.RuntimeIdentity, recovery.err, recovery.result.RateLimits, runStartedAt)
+		}
 		initialErr := execution.err
 		execution = mergeAgentTurnExecutions(execution, recovery)
+		turns = int64(max(execution.turnCount, 1))
 		if recovery.err != nil {
-			execution.err = &DeliverableRecoveryError{Branch: branch, Err: errors.Join(initialErr, recovery.err)}
-			execution.result.FinalState = FinalStateNeedsHumanAttention
-			r.logWorkerEventLevel(slog.LevelWarn, req.Issue, "worker_deliverable_recovery_failed",
-				telemetry.WorkAttemptIDKey, req.WorkAttemptID,
-				telemetry.DetentSessionIDKey, sessionID,
-				"workspace_branch", branch,
-				"deliverable_command", deliverableErr.Operation,
-				"error", execution.err,
-			)
+			if recoveryFailure, exhausted := pullRequestDeliverableFailure(recovery.err); exhausted {
+				execution.err = &DeliverableRecoveryError{Branch: branch, Err: errors.Join(initialErr, recovery.err)}
+				execution.result.FinalState = FinalStateNeedsHumanAttention
+				r.logWorkerEventLevel(slog.LevelWarn, req.Issue, "worker_deliverable_recovery_failed",
+					telemetry.WorkAttemptIDKey, req.WorkAttemptID,
+					telemetry.DetentSessionIDKey, sessionID,
+					"workspace_branch", branch,
+					"deliverable_command", recoveryFailure.Operation,
+					"error", execution.err,
+				)
+			} else {
+				execution.err = recovery.err
+				execution.result.FinalState = finalStateForTurnError(recovery.err)
+				r.logWorkerEventLevel(slog.LevelWarn, req.Issue, "worker_deliverable_recovery_interrupted",
+					telemetry.WorkAttemptIDKey, req.WorkAttemptID,
+					telemetry.DetentSessionIDKey, sessionID,
+					"workspace_branch", branch,
+					"deliverable_command", deliverableErr.Operation,
+					"error", execution.err,
+				)
+			}
 		} else {
 			execution.err = nil
 			execution.result.FinalState = FinalStateCompleted
@@ -1483,7 +1502,11 @@ func recoverablePullRequestDeliverable(execution agentTurnExecution) (*Deliverab
 	if execution.err == nil || !execution.result.PullRequestHeadPushed {
 		return nil, false
 	}
-	errorsFound, onlyDeliverableErrors := deliverableCommandErrors(execution.err)
+	return pullRequestDeliverableFailure(execution.err)
+}
+
+func pullRequestDeliverableFailure(err error) (*DeliverableCommandError, bool) {
+	errorsFound, onlyDeliverableErrors := deliverableCommandErrors(err)
 	if !onlyDeliverableErrors || len(errorsFound) == 0 {
 		return nil, false
 	}
@@ -1549,7 +1572,7 @@ func deliverableRecoveryPrompt(branch string, repository string, deliverableErr 
 		prompt.WriteString(repository)
 		prompt.WriteString("`")
 	}
-	prompt.WriteString(". If one exists, adopt it and do not create a duplicate. If none exists, retry `")
+	prompt.WriteString(". Adopt it only after a tool result explicitly reports that exact head branch; if a search result omits the head, inspect the pull request before adopting it. If no exact-head pull request exists, retry `")
 	prompt.WriteString(operation)
 	prompt.WriteString("` with these attempted arguments:\n\n")
 	prompt.WriteString(arguments)
@@ -1577,6 +1600,7 @@ func mergeAgentTurnExecutions(initial agentTurnExecution, recovery agentTurnExec
 		err:         recovery.err,
 		cleanupErr:  errors.Join(initial.cleanupErr, recovery.cleanupErr),
 		turnStarted: initial.turnStarted || recovery.turnStarted,
+		turnCount:   max(initial.turnCount, recovery.turnCount),
 	}
 }
 
@@ -1804,7 +1828,7 @@ func (r *Runner) Validate(ctx context.Context, req ValidatorRequest) (gate.Valid
 	checkStartedAttrs = append(checkStartedAttrs, runtimeIdentityLogAttrs(runtimeIdentity)...)
 	r.logWorkerEvent(req.Issue, "worker_check_started", checkStartedAttrs...)
 	runResult := RunResult{FinalState: FinalStateCompleted, RuntimeIdentity: runtimeIdentity}
-	progress := newAgentRunProgress(runtimeoutput.Policy{MaxBytes: workflow.Config.Agent.OutputTruncation.MaxBytes}, "", "", 0, "")
+	progress := newAgentRunProgress(runtimeoutput.Policy{MaxBytes: workflow.Config.Agent.OutputTruncation.MaxBytes}, "", "", 0, "", 0)
 	eventAt := r.now()
 	progress.apply(AgentUpdate{Type: AgentUpdateRuntimeIdentity, RuntimeIdentity: runtimeIdentity}, eventAt)
 	if err := r.publishRunUpdate(sessionCtx, runReq, info, workspaceIssue, progress, runResult, eventAt, runStartedAt, sessionID); err != nil {
@@ -2746,9 +2770,10 @@ type agentRunProgress struct {
 	ciTriggerPushSequence     int
 	ciTriggerLabelValid       bool
 	deliverableRecoveryBranch string
+	turnOffset                int
 }
 
-func newAgentRunProgress(outputPolicy runtimeoutput.Policy, ciTriggerLabel string, ciTriggerRepository string, ciTriggerPRNumber int, deliverableRecoveryBranch string) *agentRunProgress {
+func newAgentRunProgress(outputPolicy runtimeoutput.Policy, ciTriggerLabel string, ciTriggerRepository string, ciTriggerPRNumber int, deliverableRecoveryBranch string, turnOffset int) *agentRunProgress {
 	return &agentRunProgress{
 		turnIDs:                   map[string]struct{}{},
 		messages:                  map[string]*runtimeoutput.Buffer{},
@@ -2761,6 +2786,7 @@ func newAgentRunProgress(outputPolicy runtimeoutput.Policy, ciTriggerLabel strin
 		ciTriggerRepository:       strings.TrimSpace(ciTriggerRepository),
 		ciTriggerPRNumber:         ciTriggerPRNumber,
 		deliverableRecoveryBranch: strings.TrimSpace(deliverableRecoveryBranch),
+		turnOffset:                max(turnOffset, 0),
 	}
 }
 
@@ -2901,7 +2927,7 @@ func (p *agentRunProgress) recordDeliverableToolCompletion(update AgentUpdate) {
 			delete(p.deliverableFailures, "pull_request")
 			p.deliverableSuccesses["pull_request"] = true
 		case "pull_request_lookup":
-			if pullRequestLookupAdopts(update) {
+			if pullRequestLookupAdopts(update, p.deliverableRecoveryBranch) {
 				delete(p.deliverableFailures, "pull_request")
 				p.deliverableSuccesses["pull_request"] = true
 			}
@@ -3028,9 +3054,82 @@ func pullRequestLookupCommand(tool string, arguments string, branch string) bool
 	return strings.Contains(tool, "search_issues") && (strings.Contains(arguments, "is:pr") || strings.Contains(arguments, "pull_request"))
 }
 
-func pullRequestLookupAdopts(update AgentUpdate) bool {
-	result := strings.ToLower(strings.Join([]string{update.Delta, update.BackendErrorMessage, update.BackendErrorBody}, " "))
-	return strings.Contains(result, "/pull/") || strings.Contains(result, `"pull_request"`)
+func pullRequestLookupAdopts(update AgentUpdate, branch string) bool {
+	branch = strings.TrimSpace(branch)
+	if branch == "" {
+		return false
+	}
+	for _, raw := range []string{update.Delta, update.BackendErrorBody, update.BackendErrorMessage} {
+		var payload any
+		if json.Unmarshal([]byte(strings.TrimSpace(raw)), &payload) == nil && pullRequestPayloadMatchesHead(payload, branch) {
+			return true
+		}
+	}
+	return false
+}
+
+func pullRequestPayloadMatchesHead(payload any, branch string) bool {
+	switch value := payload.(type) {
+	case []any:
+		for _, item := range value {
+			if pullRequestPayloadMatchesHead(item, branch) {
+				return true
+			}
+		}
+	case map[string]any:
+		if pullRequestObjectMatchesHead(value, branch) {
+			return true
+		}
+		for _, nested := range value {
+			if pullRequestPayloadMatchesHead(nested, branch) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func pullRequestObjectMatchesHead(value map[string]any, branch string) bool {
+	if !pullRequestObject(value) {
+		return false
+	}
+	for _, key := range []string{"head_ref_name", "headRefName", "head_branch", "headBranch", "source_branch", "sourceBranch"} {
+		if stringValue(value[key]) == branch {
+			return true
+		}
+	}
+	switch head := value["head"].(type) {
+	case string:
+		return strings.TrimSpace(head) == branch
+	case map[string]any:
+		for _, key := range []string{"ref", "name", "branch"} {
+			if stringValue(head[key]) == branch {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func pullRequestObject(value map[string]any) bool {
+	for _, key := range []string{"url", "html_url", "htmlUrl"} {
+		if strings.Contains(strings.ToLower(stringValue(value[key])), "/pull/") {
+			return true
+		}
+	}
+	if strings.EqualFold(stringValue(value["type"]), "pull_request") || strings.EqualFold(stringValue(value["kind"]), "pull_request") {
+		return true
+	}
+	_, ok := value["pull_request"]
+	return ok
+}
+
+func stringValue(value any) string {
+	text, ok := value.(string)
+	if !ok {
+		return ""
+	}
+	return strings.TrimSpace(text)
 }
 
 func deliverableInvocationOperation(invocation deliverableToolInvocation) string {
@@ -3263,7 +3362,7 @@ func modelUpdatedActivityMessage(model string) string {
 }
 
 func (p *agentRunProgress) turnCount() int {
-	return len(p.turnIDs)
+	return p.turnOffset + len(p.turnIDs)
 }
 
 func (p *agentRunProgress) addRecentEvent(event telemetry.ActivityEvent) {

--- a/internal/runner/agent.go
+++ b/internal/runner/agent.go
@@ -816,6 +816,7 @@ func (r *Runner) runAgentTurn(
 		ciTriggerLabel,
 		strings.TrimSpace(runRequest.Issue.PRRepository),
 		ciTriggerPullRequestNumber(runRequest.Issue),
+		runRequest.deliverableRecoveryBranch,
 	)
 	usage := newSessionTokenUsage(!agentResumeEmpty(turnRequest.Resume))
 	if !result.RuntimeIdentity.IsZero() {
@@ -1329,6 +1330,53 @@ func (r *Runner) Run(ctx context.Context, req RunRequest) (RunResult, error) {
 			execution.err = classifyAgentCapacityError(backend, selection, backendConfig, execution.result.RuntimeIdentity, execution.err, execution.result.RateLimits, runStartedAt)
 		}
 	}
+	turns := int64(1)
+	if deliverableErr, ok := recoverablePullRequestDeliverable(execution); ok {
+		branch := strings.TrimSpace(info.Branch)
+		if branch == "" {
+			branch = strings.TrimSpace(req.Issue.BranchName)
+		}
+		r.logWorkerEvent(req.Issue, "worker_deliverable_recovery_started",
+			telemetry.WorkAttemptIDKey, req.WorkAttemptID,
+			telemetry.DetentSessionIDKey, sessionID,
+			"workspace_branch", branch,
+			"deliverable_command", deliverableErr.Operation,
+		)
+		recoveryRequest := turnRequest
+		recoveryRequest.Prompt = deliverableRecoveryPrompt(branch, req.Issue.PRRepository, deliverableErr)
+		recoveryRequest.Resume = AgentResume{
+			ThreadID:  execution.turnResult.ThreadID,
+			SessionID: execution.turnResult.SessionID,
+		}
+		recoveryRunRequest := req
+		recoveryRunRequest.deliverableRecoveryBranch = branch
+		recovery := r.runAgentTurn(sessionCtx, backend, recoveryRequest, recoveryRunRequest, info, workspaceIssue, workflow.Config.Agent, workflow.Config.Gate.CITriggerLabel, runStartedAt, sessionID, execution.result.RuntimeIdentity)
+		recovery.err = sessionBrake.wrapTurnLimit(ctx, recovery.err)
+		recovery.err = sessionBrake.wrapDuration(ctx, recovery.err, durationFromMillis(workflow.Config.Agent.MaxSessionDurationMS))
+		turns++
+		initialErr := execution.err
+		execution = mergeAgentTurnExecutions(execution, recovery)
+		if recovery.err != nil {
+			execution.err = &DeliverableRecoveryError{Branch: branch, Err: errors.Join(initialErr, recovery.err)}
+			execution.result.FinalState = FinalStateNeedsHumanAttention
+			r.logWorkerEventLevel(slog.LevelWarn, req.Issue, "worker_deliverable_recovery_failed",
+				telemetry.WorkAttemptIDKey, req.WorkAttemptID,
+				telemetry.DetentSessionIDKey, sessionID,
+				"workspace_branch", branch,
+				"deliverable_command", deliverableErr.Operation,
+				"error", execution.err,
+			)
+		} else {
+			execution.err = nil
+			execution.result.FinalState = FinalStateCompleted
+			r.logWorkerEvent(req.Issue, "worker_deliverable_recovery_succeeded",
+				telemetry.WorkAttemptIDKey, req.WorkAttemptID,
+				telemetry.DetentSessionIDKey, sessionID,
+				"workspace_branch", branch,
+				"deliverable_command", deliverableErr.Operation,
+			)
+		}
+	}
 	sessionBrake.Stop()
 	turnResult := execution.turnResult
 	turnErr := execution.err
@@ -1383,7 +1431,7 @@ func (r *Runner) Run(ctx context.Context, req RunRequest) (RunResult, error) {
 		}
 		return result, errors.Join(
 			fmt.Errorf("run agent turn: %w", turnErr),
-			r.finishSession(finishContext, sessionID, sessionStarted, req.WorkAttemptID, req.Issue, startedAt, finishedAt, result, sessionModel, backendConfig.Kind, 1, turnResult, resumeState.DetentSessionID),
+			r.finishSession(finishContext, sessionID, sessionStarted, req.WorkAttemptID, req.Issue, startedAt, finishedAt, result, sessionModel, backendConfig.Kind, turns, turnResult, resumeState.DetentSessionID),
 		)
 	}
 
@@ -1400,7 +1448,7 @@ func (r *Runner) Run(ctx context.Context, req RunRequest) (RunResult, error) {
 			)
 			finishedAt := r.now().UTC()
 			result.Tokens.RuntimeSeconds = runtimeSeconds(runStartedAt, finishedAt)
-			if err := r.finishSession(ctx, sessionID, sessionStarted, req.WorkAttemptID, req.Issue, startedAt, finishedAt, result, sessionModel, backendConfig.Kind, 1, turnResult, resumeState.DetentSessionID); err != nil {
+			if err := r.finishSession(ctx, sessionID, sessionStarted, req.WorkAttemptID, req.Issue, startedAt, finishedAt, result, sessionModel, backendConfig.Kind, turns, turnResult, resumeState.DetentSessionID); err != nil {
 				return result, err
 			}
 			return result, nil
@@ -1413,7 +1461,7 @@ func (r *Runner) Run(ctx context.Context, req RunRequest) (RunResult, error) {
 		result.Tokens.RuntimeSeconds = runtimeSeconds(runStartedAt, finishedAt)
 		return result, errors.Join(
 			fmt.Errorf("workspace diff stat: %w", err),
-			r.finishSession(ctx, sessionID, sessionStarted, req.WorkAttemptID, req.Issue, startedAt, finishedAt, result, sessionModel, backendConfig.Kind, 1, turnResult, resumeState.DetentSessionID),
+			r.finishSession(ctx, sessionID, sessionStarted, req.WorkAttemptID, req.Issue, startedAt, finishedAt, result, sessionModel, backendConfig.Kind, turns, turnResult, resumeState.DetentSessionID),
 		)
 	}
 
@@ -1425,10 +1473,143 @@ func (r *Runner) Run(ctx context.Context, req RunRequest) (RunResult, error) {
 	}
 	finishedAt := r.now().UTC()
 	result.Tokens.RuntimeSeconds = runtimeSeconds(runStartedAt, finishedAt)
-	if err := r.finishSession(ctx, sessionID, sessionStarted, req.WorkAttemptID, req.Issue, startedAt, finishedAt, result, sessionModel, backendConfig.Kind, 1, turnResult, resumeState.DetentSessionID); err != nil {
+	if err := r.finishSession(ctx, sessionID, sessionStarted, req.WorkAttemptID, req.Issue, startedAt, finishedAt, result, sessionModel, backendConfig.Kind, turns, turnResult, resumeState.DetentSessionID); err != nil {
 		return result, err
 	}
 	return result, nil
+}
+
+func recoverablePullRequestDeliverable(execution agentTurnExecution) (*DeliverableCommandError, bool) {
+	if execution.err == nil || !execution.result.PullRequestHeadPushed {
+		return nil, false
+	}
+	errorsFound, onlyDeliverableErrors := deliverableCommandErrors(execution.err)
+	if !onlyDeliverableErrors || len(errorsFound) == 0 {
+		return nil, false
+	}
+	for _, deliverableErr := range errorsFound {
+		if deliverableErr == nil || deliverableErr.OperationClass != "pull_request" {
+			return nil, false
+		}
+	}
+	return errorsFound[0], true
+}
+
+func deliverableCommandErrors(err error) ([]*DeliverableCommandError, bool) {
+	if err == nil {
+		return nil, true
+	}
+	var result []*DeliverableCommandError
+	var visit func(error) bool
+	visit = func(current error) bool {
+		if current == nil {
+			return true
+		}
+		if joined, ok := current.(interface{ Unwrap() []error }); ok {
+			for _, nested := range joined.Unwrap() {
+				if !visit(nested) {
+					return false
+				}
+			}
+			return true
+		}
+		if wrapped := errors.Unwrap(current); wrapped != nil {
+			return visit(wrapped)
+		}
+		var deliverableErr *DeliverableCommandError
+		if errors.As(current, &deliverableErr) {
+			result = append(result, deliverableErr)
+			return true
+		}
+		return false
+	}
+	return result, visit(err)
+}
+
+func deliverableRecoveryPrompt(branch string, repository string, deliverableErr *DeliverableCommandError) string {
+	branch = strings.TrimSpace(branch)
+	repository = strings.TrimSpace(repository)
+	operation := "pull request creation"
+	arguments := "{}"
+	if deliverableErr != nil {
+		if value := strings.TrimSpace(deliverableErr.Operation); value != "" {
+			operation = value
+		}
+		if value := strings.TrimSpace(deliverableErr.Arguments); value != "" {
+			arguments = value
+		}
+	}
+	var prompt strings.Builder
+	prompt.WriteString("The implementation is complete and the branch is already pushed. Recover only the pull request deliverable.\n\n")
+	prompt.WriteString("Search first for an existing open pull request whose head branch is exactly `")
+	prompt.WriteString(branch)
+	prompt.WriteString("`")
+	if repository != "" {
+		prompt.WriteString(" in `")
+		prompt.WriteString(repository)
+		prompt.WriteString("`")
+	}
+	prompt.WriteString(". If one exists, adopt it and do not create a duplicate. If none exists, retry `")
+	prompt.WriteString(operation)
+	prompt.WriteString("` with these attempted arguments:\n\n")
+	prompt.WriteString(arguments)
+	prompt.WriteString("\n\nDo not edit files, change commits, push the branch, rerun implementation, or perform unrelated work.")
+	return prompt.String()
+}
+
+func mergeAgentTurnExecutions(initial agentTurnExecution, recovery agentTurnExecution) agentTurnExecution {
+	result := recovery.result
+	result.Output = joinAgentOutputs(initial.result.Output, recovery.result.Output)
+	result.Model = effectiveModel(recovery.result.Model, initial.result.Model)
+	result.RuntimeIdentity = initial.result.RuntimeIdentity.Merge(recovery.result.RuntimeIdentity)
+	result.Tokens = addAgentTokenTotals(initial.result.Tokens, recovery.result.Tokens)
+	result.RateLimits = mergeAgentRateLimits(initial.result.RateLimits, recovery.result.RateLimits)
+	result.SkillDraftProposed = initial.result.SkillDraftProposed || recovery.result.SkillDraftProposed
+	result.PullRequestUpdated = initial.result.PullRequestUpdated || recovery.result.PullRequestUpdated
+	result.PullRequestHeadPushed = initial.result.PullRequestHeadPushed || recovery.result.PullRequestHeadPushed
+	result.CITriggerLabelReapplied = initial.result.CITriggerLabelReapplied || recovery.result.CITriggerLabelReapplied
+	if result.DiffStats == (DiffStats{}) {
+		result.DiffStats = initial.result.DiffStats
+	}
+	return agentTurnExecution{
+		turnResult:  recovery.turnResult,
+		result:      result,
+		err:         recovery.err,
+		cleanupErr:  errors.Join(initial.cleanupErr, recovery.cleanupErr),
+		turnStarted: initial.turnStarted || recovery.turnStarted,
+	}
+}
+
+func joinAgentOutputs(initial string, recovery string) string {
+	initial = strings.TrimSpace(initial)
+	recovery = strings.TrimSpace(recovery)
+	if initial == "" {
+		return recovery
+	}
+	if recovery == "" {
+		return initial
+	}
+	return initial + "\n" + recovery
+}
+
+func addAgentTokenTotals(initial TokenTotals, recovery TokenTotals) TokenTotals {
+	result := TokenTotals{
+		InputTokens:           initial.InputTokens + recovery.InputTokens,
+		CachedInputTokens:     initial.CachedInputTokens + recovery.CachedInputTokens,
+		OutputTokens:          initial.OutputTokens + recovery.OutputTokens,
+		ReasoningOutputTokens: initial.ReasoningOutputTokens + recovery.ReasoningOutputTokens,
+		TotalTokens:           initial.TotalTokens + recovery.TotalTokens,
+		RuntimeSeconds:        initial.RuntimeSeconds + recovery.RuntimeSeconds,
+		Last:                  cloneAgentTokenCounts(recovery.Last),
+		ModelContextWindow:    recovery.ModelContextWindow,
+	}
+	if result.Last == nil {
+		result.Last = cloneAgentTokenCounts(initial.Last)
+	}
+	if result.ModelContextWindow == nil {
+		result.ModelContextWindow = initial.ModelContextWindow
+	}
+	return result
 }
 
 func (r *Runner) workspaceRecoveryState(
@@ -1623,7 +1804,7 @@ func (r *Runner) Validate(ctx context.Context, req ValidatorRequest) (gate.Valid
 	checkStartedAttrs = append(checkStartedAttrs, runtimeIdentityLogAttrs(runtimeIdentity)...)
 	r.logWorkerEvent(req.Issue, "worker_check_started", checkStartedAttrs...)
 	runResult := RunResult{FinalState: FinalStateCompleted, RuntimeIdentity: runtimeIdentity}
-	progress := newAgentRunProgress(runtimeoutput.Policy{MaxBytes: workflow.Config.Agent.OutputTruncation.MaxBytes}, "", "", 0)
+	progress := newAgentRunProgress(runtimeoutput.Policy{MaxBytes: workflow.Config.Agent.OutputTruncation.MaxBytes}, "", "", 0, "")
 	eventAt := r.now()
 	progress.apply(AgentUpdate{Type: AgentUpdateRuntimeIdentity, RuntimeIdentity: runtimeIdentity}, eventAt)
 	if err := r.publishRunUpdate(sessionCtx, runReq, info, workspaceIssue, progress, runResult, eventAt, runStartedAt, sessionID); err != nil {
@@ -2539,45 +2720,47 @@ func cloneAgentTokenCounts(tokens *AgentTokenCounts) *AgentTokenCounts {
 }
 
 type agentRunProgress struct {
-	sessionID             string
-	processIdentity       string
-	workerProcess         procgroup.Identity
-	turnIDs               map[string]struct{}
-	messages              map[string]*runtimeoutput.Buffer
-	messageOrder          []string
-	outputPolicy          runtimeoutput.Policy
-	output                *runtimeoutput.Buffer
-	lastEventAt           time.Time
-	lastEvent             string
-	lastMessage           string
-	lastMessageTruncation *runtimeoutput.Truncation
-	recentEvents          []telemetry.ActivityEvent
-	diffStats             DiffStats
-	diffStatsCollected    bool
-	diffStatsCheckedAt    time.Time
-	toolInvocations       map[string]deliverableToolInvocation
-	deliverableFailures   map[string]error
-	deliverableSuccesses  map[string]bool
-	ciTriggerLabel        string
-	ciTriggerRepository   string
-	ciTriggerPRNumber     int
-	successfulPushes      int
-	ciTriggerPushSequence int
-	ciTriggerLabelValid   bool
+	sessionID                 string
+	processIdentity           string
+	workerProcess             procgroup.Identity
+	turnIDs                   map[string]struct{}
+	messages                  map[string]*runtimeoutput.Buffer
+	messageOrder              []string
+	outputPolicy              runtimeoutput.Policy
+	output                    *runtimeoutput.Buffer
+	lastEventAt               time.Time
+	lastEvent                 string
+	lastMessage               string
+	lastMessageTruncation     *runtimeoutput.Truncation
+	recentEvents              []telemetry.ActivityEvent
+	diffStats                 DiffStats
+	diffStatsCollected        bool
+	diffStatsCheckedAt        time.Time
+	toolInvocations           map[string]deliverableToolInvocation
+	deliverableFailures       map[string]error
+	deliverableSuccesses      map[string]bool
+	ciTriggerLabel            string
+	ciTriggerRepository       string
+	ciTriggerPRNumber         int
+	successfulPushes          int
+	ciTriggerPushSequence     int
+	ciTriggerLabelValid       bool
+	deliverableRecoveryBranch string
 }
 
-func newAgentRunProgress(outputPolicy runtimeoutput.Policy, ciTriggerLabel string, ciTriggerRepository string, ciTriggerPRNumber int) *agentRunProgress {
+func newAgentRunProgress(outputPolicy runtimeoutput.Policy, ciTriggerLabel string, ciTriggerRepository string, ciTriggerPRNumber int, deliverableRecoveryBranch string) *agentRunProgress {
 	return &agentRunProgress{
-		turnIDs:              map[string]struct{}{},
-		messages:             map[string]*runtimeoutput.Buffer{},
-		outputPolicy:         outputPolicy,
-		output:               runtimeoutput.NewBuffer(outputPolicy),
-		toolInvocations:      map[string]deliverableToolInvocation{},
-		deliverableFailures:  map[string]error{},
-		deliverableSuccesses: map[string]bool{},
-		ciTriggerLabel:       strings.TrimSpace(ciTriggerLabel),
-		ciTriggerRepository:  strings.TrimSpace(ciTriggerRepository),
-		ciTriggerPRNumber:    ciTriggerPRNumber,
+		turnIDs:                   map[string]struct{}{},
+		messages:                  map[string]*runtimeoutput.Buffer{},
+		outputPolicy:              outputPolicy,
+		output:                    runtimeoutput.NewBuffer(outputPolicy),
+		toolInvocations:           map[string]deliverableToolInvocation{},
+		deliverableFailures:       map[string]error{},
+		deliverableSuccesses:      map[string]bool{},
+		ciTriggerLabel:            strings.TrimSpace(ciTriggerLabel),
+		ciTriggerRepository:       strings.TrimSpace(ciTriggerRepository),
+		ciTriggerPRNumber:         ciTriggerPRNumber,
+		deliverableRecoveryBranch: strings.TrimSpace(deliverableRecoveryBranch),
 	}
 }
 
@@ -2673,7 +2856,7 @@ type deliverableToolInvocation struct {
 }
 
 func (p *agentRunProgress) recordDeliverableToolStart(update AgentUpdate) {
-	invocation := newDeliverableToolInvocation(update.Tool, update.Delta, p.ciTriggerLabel, p.ciTriggerRepository, p.ciTriggerPRNumber)
+	invocation := newDeliverableToolInvocation(update.Tool, update.Delta, p.ciTriggerLabel, p.ciTriggerRepository, p.ciTriggerPRNumber, p.deliverableRecoveryBranch)
 	if invocation.class == "" {
 		return
 	}
@@ -2684,7 +2867,7 @@ func (p *agentRunProgress) recordDeliverableToolCompletion(update AgentUpdate) {
 	key := deliverableToolKey(update)
 	invocation, ok := p.toolInvocations[key]
 	if !ok {
-		invocation = newDeliverableToolInvocation(update.Tool, update.Delta, p.ciTriggerLabel, p.ciTriggerRepository, p.ciTriggerPRNumber)
+		invocation = newDeliverableToolInvocation(update.Tool, update.Delta, p.ciTriggerLabel, p.ciTriggerRepository, p.ciTriggerPRNumber, p.deliverableRecoveryBranch)
 	}
 	if invocation.class == "" {
 		return
@@ -2717,6 +2900,11 @@ func (p *agentRunProgress) recordDeliverableToolCompletion(update AgentUpdate) {
 		case "pull_request":
 			delete(p.deliverableFailures, "pull_request")
 			p.deliverableSuccesses["pull_request"] = true
+		case "pull_request_lookup":
+			if pullRequestLookupAdopts(update) {
+				delete(p.deliverableFailures, "pull_request")
+				p.deliverableSuccesses["pull_request"] = true
+			}
 		}
 		return
 	}
@@ -2730,28 +2918,29 @@ func (p *agentRunProgress) recordDeliverableToolCompletion(update AgentUpdate) {
 			p.successfulPushes++
 		}
 	}
+	if invocation.class == "pull_request_lookup" {
+		failureClass = "pull_request"
+	}
 	delete(p.deliverableSuccesses, failureClass)
 	if invocation.class == "ci_trigger_label" || invocation.class == "push_ci_trigger_label" {
 		p.ciTriggerLabelValid = false
 	}
-	detail := strings.TrimSpace(update.Delta)
-	if detail == "" {
-		detail = strings.TrimSpace(update.BackendErrorMessage)
+	message := meaningfulDeliverableDetail(update.BackendErrorMessage)
+	body := meaningfulDeliverableDetail(update.BackendErrorBody)
+	if message == "" {
+		message = meaningfulDeliverableDetail(update.Delta)
 	}
-	if detail == "" {
-		detail = strings.TrimSpace(update.BackendErrorBody)
+	if body == "" && strings.HasPrefix(strings.TrimSpace(update.Delta), "{") {
+		body = meaningfulDeliverableDetail(update.Delta)
 	}
-	if detail == "" {
-		detail = strings.TrimSpace(update.Status)
+	p.deliverableFailures[failureClass] = &DeliverableCommandError{
+		OperationClass: failureClass,
+		Operation:      deliverableInvocationOperation(invocation),
+		Arguments:      truncateDeliverableDetail(invocation.command),
+		Status:         strings.TrimSpace(update.Status),
+		Message:        truncateDeliverableDetail(message),
+		Body:           truncateDeliverableDetail(body),
 	}
-	if len(detail) > 4096 {
-		detail = detail[len(detail)-4096:]
-	}
-	operation := invocation.command
-	if operation == "" {
-		operation = invocation.tool
-	}
-	p.deliverableFailures[failureClass] = fmt.Errorf("deliverable command failed (%s): %s", strings.TrimSpace(operation), detail)
 }
 
 func (p *agentRunProgress) pullRequestUpdated() bool {
@@ -2773,6 +2962,15 @@ func (p *agentRunProgress) deliverableError() error {
 			errs = append(errs, err)
 		}
 	}
+	if len(errs) == 0 && p.deliverableRecoveryBranch != "" && !p.deliverableSuccesses["pull_request"] {
+		errs = append(errs, &DeliverableCommandError{
+			OperationClass: "pull_request",
+			Operation:      "pull request recovery",
+			Arguments:      `{"head":` + strconv.Quote(p.deliverableRecoveryBranch) + `}`,
+			Status:         "failed",
+			Message:        "recovery turn completed without creating or adopting a pull request",
+		})
+	}
 	return errors.Join(errs...)
 }
 
@@ -2783,7 +2981,7 @@ func deliverableToolKey(update AgentUpdate) string {
 	return strings.TrimSpace(update.TurnID) + "\x00" + strings.TrimSpace(update.Tool)
 }
 
-func deliverableOperationClass(tool string, command string) string {
+func deliverableOperationClass(tool string, command string, deliverableRecoveryBranch string) string {
 	lowerTool := strings.ToLower(strings.TrimSpace(tool))
 	lowerCommand := strings.ToLower(strings.TrimSpace(command))
 	push := gitPushCommand(lowerCommand)
@@ -2797,6 +2995,9 @@ func deliverableOperationClass(tool string, command string) string {
 	if push {
 		return "push"
 	}
+	if pullRequestLookupCommand(lowerTool, lowerCommand, deliverableRecoveryBranch) {
+		return "pull_request_lookup"
+	}
 	if pullRequestCommand(lowerCommand) ||
 		(strings.Contains(lowerTool, "pull_request") &&
 			(strings.Contains(lowerTool, "create") || strings.Contains(lowerTool, "update") || strings.Contains(lowerTool, "edit"))) {
@@ -2805,15 +3006,65 @@ func deliverableOperationClass(tool string, command string) string {
 	return ""
 }
 
-func newDeliverableToolInvocation(tool string, command string, ciTriggerLabel string, ciTriggerRepository string, ciTriggerPRNumber int) deliverableToolInvocation {
+func newDeliverableToolInvocation(tool string, command string, ciTriggerLabel string, ciTriggerRepository string, ciTriggerPRNumber int, deliverableRecoveryBranch string) deliverableToolInvocation {
 	command = strings.TrimSpace(command)
 	return deliverableToolInvocation{
-		class:                 deliverableOperationClass(tool, command),
+		class:                 deliverableOperationClass(tool, command, deliverableRecoveryBranch),
 		command:               command,
 		tool:                  strings.TrimSpace(tool),
 		ciTriggerLabelMatches: ciTriggerLabelCommandMatches(command, ciTriggerLabel, ciTriggerRepository, ciTriggerPRNumber),
 		ciTriggerAfterPush:    ciTriggerLabelRunsAfterPush(command),
 	}
+}
+
+func pullRequestLookupCommand(tool string, arguments string, branch string) bool {
+	branch = strings.ToLower(strings.TrimSpace(branch))
+	if branch == "" || !strings.Contains(arguments, branch) {
+		return false
+	}
+	if strings.Contains(tool, "list_pull_requests") {
+		return true
+	}
+	return strings.Contains(tool, "search_issues") && (strings.Contains(arguments, "is:pr") || strings.Contains(arguments, "pull_request"))
+}
+
+func pullRequestLookupAdopts(update AgentUpdate) bool {
+	result := strings.ToLower(strings.Join([]string{update.Delta, update.BackendErrorMessage, update.BackendErrorBody}, " "))
+	return strings.Contains(result, "/pull/") || strings.Contains(result, `"pull_request"`)
+}
+
+func deliverableInvocationOperation(invocation deliverableToolInvocation) string {
+	tool := strings.TrimSpace(invocation.tool)
+	lowerTool := strings.ToLower(tool)
+	if strings.Contains(lowerTool, "pull_request") || strings.Contains(lowerTool, "search_issues") || strings.Contains(lowerTool, "list_pull_requests") {
+		return tool
+	}
+	lowerCommand := strings.ToLower(invocation.command)
+	for _, operation := range []string{"gh pr create", "gh pr edit", "gh pr ready", "git push", "detent ci-trigger-label"} {
+		if strings.Contains(lowerCommand, operation) {
+			return operation
+		}
+	}
+	if tool != "" {
+		return tool
+	}
+	return "unknown"
+}
+
+func meaningfulDeliverableDetail(value string) string {
+	value = strings.TrimSpace(value)
+	if strings.EqualFold(value, "null") {
+		return ""
+	}
+	return value
+}
+
+func truncateDeliverableDetail(value string) string {
+	value = meaningfulDeliverableDetail(value)
+	if len(value) > 4096 {
+		return value[len(value)-4096:]
+	}
+	return value
 }
 
 func ciTriggerLabelCommand(command string) bool {

--- a/internal/runner/runner_test.go
+++ b/internal/runner/runner_test.go
@@ -12,6 +12,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"reflect"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -605,6 +606,186 @@ func TestRunAgentTurnFailsForUnrecoveredDeliverableCommandError(t *testing.T) {
 			}
 			if execution.result.CITriggerLabelReapplied != tt.wantCITriggerLabelReapplied {
 				t.Fatalf("CITriggerLabelReapplied = %v, want %v", execution.result.CITriggerLabelReapplied, tt.wantCITriggerLabelReapplied)
+			}
+		})
+	}
+}
+
+func TestRunnerRunRecoversPushedPullRequestDeliverable(t *testing.T) {
+	t.Parallel()
+
+	const branch = "detent/acme_widgets_18"
+	const arguments = `{"base":"main","body":"Fixes #18","head":"detent/acme_widgets_18","repository_full_name":"acme/widgets","title":"fix(runner): recover delivery"}`
+	tests := []struct {
+		name                   string
+		recoveryUpdates        []AgentUpdate
+		wantErr                bool
+		wantPullRequestUpdated bool
+	}{
+		{
+			name: "retry creates pull request",
+			recoveryUpdates: []AgentUpdate{
+				{Type: AgentUpdateToolStarted, ItemID: "lookup", Tool: "codex_apps/github.search_issues", Delta: `{"query":"repo:acme/widgets is:pr is:open head:detent/acme_widgets_18"}`},
+				{Type: AgentUpdateToolCompleted, ItemID: "lookup", Tool: "codex_apps/github.search_issues", Status: "completed", Delta: `{"issues":[]}`},
+				{Type: AgentUpdateToolStarted, ItemID: "create", Tool: "codex_apps/github.create_pull_request", Delta: arguments},
+				{Type: AgentUpdateToolCompleted, ItemID: "create", Tool: "codex_apps/github.create_pull_request", Status: "completed", Delta: `{"url":"https://github.test/acme/widgets/pull/18"}`},
+				{Type: AgentUpdateTurnCompleted, TurnID: "turn-2", Status: "completed"},
+			},
+			wantPullRequestUpdated: true,
+		},
+		{
+			name: "retry adopts existing pull request",
+			recoveryUpdates: []AgentUpdate{
+				{Type: AgentUpdateToolStarted, ItemID: "lookup", Tool: "codex_apps/github.search_issues", Delta: `{"query":"repo:acme/widgets is:pr is:open head:detent/acme_widgets_18"}`},
+				{Type: AgentUpdateToolCompleted, ItemID: "lookup", Tool: "codex_apps/github.search_issues", Status: "completed", Delta: `{"issues":[{"head_ref_name":"detent/acme_widgets_18","url":"https://github.test/acme/widgets/pull/17"}]}`},
+				{Type: AgentUpdateTurnCompleted, TurnID: "turn-2", Status: "completed"},
+			},
+			wantPullRequestUpdated: true,
+		},
+		{
+			name: "unrecoverable retry surfaces pushed branch",
+			recoveryUpdates: []AgentUpdate{
+				{Type: AgentUpdateToolStarted, ItemID: "lookup", Tool: "codex_apps/github.search_issues", Delta: `{"query":"repo:acme/widgets is:pr is:open head:detent/acme_widgets_18"}`},
+				{Type: AgentUpdateToolCompleted, ItemID: "lookup", Tool: "codex_apps/github.search_issues", Status: "completed", Delta: `{"issues":[]}`},
+				{Type: AgentUpdateToolStarted, ItemID: "create", Tool: "codex_apps/github.create_pull_request", Delta: arguments},
+				{Type: AgentUpdateToolCompleted, ItemID: "create", Tool: "codex_apps/github.create_pull_request", Status: "failed", BackendErrorMessage: "HTTP 503: unavailable", BackendErrorBody: `{"status":503,"message":"unavailable"}`},
+				{Type: AgentUpdateTurnCompleted, TurnID: "turn-2", Status: "completed"},
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			workspaceBackend := &fakeWorkspaceBackend{info: workspace.Info{Path: t.TempDir(), Branch: branch}}
+			backend := &deliverableRecoveryAgentBackend{turns: [][]AgentUpdate{
+				{
+					{Type: AgentUpdateToolStarted, ItemID: "push", Tool: "commandExecution", Delta: "git push -u origin HEAD"},
+					{Type: AgentUpdateToolCompleted, ItemID: "push", Tool: "commandExecution", Status: "completed", Delta: "branch pushed"},
+					{Type: AgentUpdateToolStarted, ItemID: "create", Tool: "codex_apps/github.create_pull_request", Delta: arguments},
+					{Type: AgentUpdateToolCompleted, ItemID: "create", Tool: "codex_apps/github.create_pull_request", Status: "failed", BackendErrorMessage: "HTTP 502: upstream unavailable", BackendErrorBody: `{"status":502,"message":"upstream unavailable"}`},
+					{Type: AgentUpdateTurnCompleted, TurnID: "turn-1", Status: "completed"},
+				},
+				tt.recoveryUpdates,
+			}}
+			runner, err := NewRunner(Dependencies{
+				Workflow:     config.Workflow{Config: config.Config{}, Prompt: "Work on {{ issue.identifier }}"},
+				Workspace:    workspaceBackend,
+				AgentBackend: backend,
+			})
+			if err != nil {
+				t.Fatalf("NewRunner() error = %v", err)
+			}
+
+			result, runErr := runner.Run(t.Context(), RunRequest{Issue: connector.Issue{
+				ID: "issue-18", Identifier: "acme/widgets#18", Title: "Recover delivery", State: "In Progress",
+				BranchName: branch, PRRepository: "acme/widgets",
+			}})
+			if tt.wantErr {
+				var recoveryErr *DeliverableRecoveryError
+				if !errors.As(runErr, &recoveryErr) {
+					t.Fatalf("Run() error = %T %v, want DeliverableRecoveryError", runErr, runErr)
+				}
+				if recoveryErr.Branch != branch || !strings.Contains(runErr.Error(), branch) || result.FinalState != FinalStateNeedsHumanAttention {
+					t.Fatalf("recovery error/result = %#v/%#v, want branch %q and needs-human state", recoveryErr, result, branch)
+				}
+				for _, want := range []string{"codex_apps/github.create_pull_request", "status=failed", arguments, "HTTP 503: unavailable", `{"status":503,"message":"unavailable"}`} {
+					if !strings.Contains(runErr.Error(), want) {
+						t.Fatalf("recovery error missing %q: %v", want, runErr)
+					}
+				}
+				if strings.Contains(runErr.Error(), ": null") {
+					t.Fatalf("recovery error contains terminal null detail: %v", runErr)
+				}
+			} else if runErr != nil || result.FinalState != FinalStateCompleted {
+				t.Fatalf("Run() = state %q error %v, want completed", result.FinalState, runErr)
+			}
+			if result.PullRequestUpdated != tt.wantPullRequestUpdated || !result.PullRequestHeadPushed {
+				t.Fatalf("delivery result = updated %v pushed %v, want updated %v pushed true", result.PullRequestUpdated, result.PullRequestHeadPushed, tt.wantPullRequestUpdated)
+			}
+			if len(backend.requests) != 2 {
+				t.Fatalf("RunTurn requests = %d, want implementation and one deliverable retry", len(backend.requests))
+			}
+			recoveryRequest := backend.requests[1]
+			if recoveryRequest.Resume.ThreadID != "thread-1" || recoveryRequest.Resume.SessionID != "session-1" {
+				t.Fatalf("recovery resume = %#v, want first turn identity", recoveryRequest.Resume)
+			}
+			for _, want := range []string{branch, arguments, "existing open pull request", "Do not edit"} {
+				if !strings.Contains(recoveryRequest.Prompt, want) {
+					t.Fatalf("recovery prompt missing %q:\n%s", want, recoveryRequest.Prompt)
+				}
+			}
+		})
+	}
+}
+
+func TestDeliverableCommandErrorNeverReportsNullDetail(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		err  *DeliverableCommandError
+		want []string
+	}{
+		{
+			name: "structured response",
+			err: &DeliverableCommandError{
+				Operation: "codex_apps/github.create_pull_request", Arguments: `{"head":"detent/acme_widgets_18"}`,
+				Status: "failed", Message: "HTTP 502: unavailable", Body: `{"status":502}`,
+			},
+			want: []string{"status=failed", `arguments={"head":"detent/acme_widgets_18"}`, "HTTP 502: unavailable", `response={"status":502}`},
+		},
+		{
+			name: "null payload",
+			err: &DeliverableCommandError{
+				Operation: "codex_apps/github.create_pull_request", Arguments: "null", Status: "failed", Message: "null", Body: "null",
+			},
+			want: []string{"status=failed"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := tt.err.Error()
+			for _, want := range tt.want {
+				if !strings.Contains(got, want) {
+					t.Fatalf("Error() = %q, want containing %q", got, want)
+				}
+			}
+			if strings.Contains(got, "null") {
+				t.Fatalf("Error() = %q, want no null detail", got)
+			}
+		})
+	}
+}
+
+func TestRecoverablePullRequestDeliverableRequiresOnlyPullRequestFailure(t *testing.T) {
+	t.Parallel()
+
+	pullRequestErr := &DeliverableCommandError{OperationClass: "pull_request", Operation: "codex_apps/github.create_pull_request"}
+	pushErr := &DeliverableCommandError{OperationClass: "push", Operation: "git push"}
+	tests := []struct {
+		name   string
+		err    error
+		pushed bool
+		want   bool
+	}{
+		{name: "only pull request failed after push", err: pullRequestErr, pushed: true, want: true},
+		{name: "branch was not pushed", err: pullRequestErr, pushed: false},
+		{name: "push also failed", err: errors.Join(pullRequestErr, pushErr), pushed: true},
+		{name: "unrelated turn error also occurred", err: errors.Join(pullRequestErr, errors.New("agent transport failed")), pushed: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			_, got := recoverablePullRequestDeliverable(agentTurnExecution{
+				result: RunResult{PullRequestHeadPushed: tt.pushed},
+				err:    tt.err,
+			})
+			if got != tt.want {
+				t.Fatalf("recoverablePullRequestDeliverable() = %v, want %v", got, tt.want)
 			}
 		})
 	}
@@ -4771,6 +4952,11 @@ type toolUpdateAgentBackend struct {
 	updates []AgentUpdate
 }
 
+type deliverableRecoveryAgentBackend struct {
+	turns    [][]AgentUpdate
+	requests []AgentTurnRequest
+}
+
 type scratchWritingAgentBackend struct {
 	runErr  error
 	tempDir string
@@ -4798,6 +4984,25 @@ func (b *toolUpdateAgentBackend) RunTurn(_ context.Context, _ AgentTurnRequest, 
 		}
 	}
 	return AgentTurnResult{ThreadID: "thread-1211", TurnID: "turn-1211", SessionID: "thread-1211-turn-1211"}, nil
+}
+
+func (b *deliverableRecoveryAgentBackend) RunTurn(_ context.Context, req AgentTurnRequest, onUpdate AgentUpdateHandler) (AgentTurnResult, error) {
+	index := len(b.requests)
+	b.requests = append(b.requests, req)
+	if index >= len(b.turns) {
+		return AgentTurnResult{}, fmt.Errorf("unexpected turn %d", index+1)
+	}
+	for _, update := range b.turns[index] {
+		if err := onUpdate(update); err != nil {
+			return AgentTurnResult{}, err
+		}
+	}
+	turn := index + 1
+	return AgentTurnResult{
+		ThreadID:  "thread-" + strconv.Itoa(turn),
+		TurnID:    "turn-" + strconv.Itoa(turn),
+		SessionID: "session-" + strconv.Itoa(turn),
+	}, nil
 }
 
 func (c *fakeCodexClient) RunTurn(_ context.Context, req AgentTurnRequest, onUpdate AgentUpdateHandler) (AgentTurnResult, error) {

--- a/internal/runner/runner_test.go
+++ b/internal/runner/runner_test.go
@@ -619,7 +619,9 @@ func TestRunnerRunRecoversPushedPullRequestDeliverable(t *testing.T) {
 	tests := []struct {
 		name                   string
 		recoveryUpdates        []AgentUpdate
+		recoveryErr            error
 		wantErr                bool
+		wantInterrupted        error
 		wantPullRequestUpdated bool
 	}{
 		{
@@ -641,6 +643,14 @@ func TestRunnerRunRecoversPushedPullRequestDeliverable(t *testing.T) {
 				{Type: AgentUpdateTurnCompleted, TurnID: "turn-2", Status: "completed"},
 			},
 			wantPullRequestUpdated: true,
+		},
+		{
+			name: "retry interruption remains retryable",
+			recoveryUpdates: []AgentUpdate{
+				{Type: AgentUpdateTurnStarted, ThreadID: "thread-1", TurnID: "turn-2"},
+			},
+			recoveryErr:     context.Canceled,
+			wantInterrupted: context.Canceled,
 		},
 		{
 			name: "unrecoverable retry surfaces pushed branch",
@@ -669,7 +679,7 @@ func TestRunnerRunRecoversPushedPullRequestDeliverable(t *testing.T) {
 					{Type: AgentUpdateTurnCompleted, TurnID: "turn-1", Status: "completed"},
 				},
 				tt.recoveryUpdates,
-			}}
+			}, errors: []error{nil, tt.recoveryErr}}
 			runner, err := NewRunner(Dependencies{
 				Workflow:     config.Workflow{Config: config.Config{}, Prompt: "Work on {{ issue.identifier }}"},
 				Workspace:    workspaceBackend,
@@ -683,7 +693,12 @@ func TestRunnerRunRecoversPushedPullRequestDeliverable(t *testing.T) {
 				ID: "issue-18", Identifier: "acme/widgets#18", Title: "Recover delivery", State: "In Progress",
 				BranchName: branch, PRRepository: "acme/widgets",
 			}})
-			if tt.wantErr {
+			if tt.wantInterrupted != nil {
+				var recoveryErr *DeliverableRecoveryError
+				if !errors.Is(runErr, tt.wantInterrupted) || errors.As(runErr, &recoveryErr) || result.FinalState == FinalStateNeedsHumanAttention {
+					t.Fatalf("Run() interruption = state %q error %T %v, want preserved %v", result.FinalState, runErr, runErr, tt.wantInterrupted)
+				}
+			} else if tt.wantErr {
 				var recoveryErr *DeliverableRecoveryError
 				if !errors.As(runErr, &recoveryErr) {
 					t.Fatalf("Run() error = %T %v, want DeliverableRecoveryError", runErr, runErr)
@@ -716,6 +731,71 @@ func TestRunnerRunRecoversPushedPullRequestDeliverable(t *testing.T) {
 				if !strings.Contains(recoveryRequest.Prompt, want) {
 					t.Fatalf("recovery prompt missing %q:\n%s", want, recoveryRequest.Prompt)
 				}
+			}
+		})
+	}
+}
+
+func TestRunnerDeliverableRecoveryCountsTurnsAcrossSessionBrake(t *testing.T) {
+	t.Parallel()
+
+	const branch = "detent/acme_widgets_18"
+	const arguments = `{"head":"detent/acme_widgets_18","repository_full_name":"acme/widgets"}`
+	backend := &deliverableRecoveryAgentBackend{turns: [][]AgentUpdate{
+		{
+			{Type: AgentUpdateToolStarted, ItemID: "push", Tool: "commandExecution", Delta: "git push origin HEAD"},
+			{Type: AgentUpdateToolCompleted, ItemID: "push", Tool: "commandExecution", Status: "completed", Delta: "branch pushed"},
+			{Type: AgentUpdateToolStarted, ItemID: "create", Tool: "codex_apps/github.create_pull_request", Delta: arguments},
+			{Type: AgentUpdateToolCompleted, ItemID: "create", Tool: "codex_apps/github.create_pull_request", Status: "failed", BackendErrorMessage: "HTTP 502"},
+			{Type: AgentUpdateTurnCompleted, ThreadID: "thread-1", TurnID: "turn-1", Status: "completed"},
+		},
+		{{Type: AgentUpdateTurnStarted, ThreadID: "thread-1", TurnID: "turn-2"}},
+	}}
+	runner, err := NewRunner(Dependencies{
+		Workflow:     config.Workflow{Config: config.Config{Agent: config.Agent{MaxTurns: 1}}, Prompt: "Work"},
+		Workspace:    &fakeWorkspaceBackend{info: workspace.Info{Path: t.TempDir(), Branch: branch}},
+		AgentBackend: backend,
+	})
+	if err != nil {
+		t.Fatalf("NewRunner() error = %v", err)
+	}
+
+	result, runErr := runner.Run(t.Context(), RunRequest{Issue: connector.Issue{
+		ID: "issue-18", Identifier: "acme/widgets#18", BranchName: branch, PRRepository: "acme/widgets",
+	}})
+	var brake *SessionBrakeError
+	var recoveryErr *DeliverableRecoveryError
+	if !errors.Is(runErr, ErrSessionTurnLimitExceeded) || !errors.As(runErr, &brake) || errors.As(runErr, &recoveryErr) {
+		t.Fatalf("Run() error = %T %v, want preserved session brake", runErr, runErr)
+	}
+	if brake.Turns != 2 || brake.MaxTurns != 1 || result.FinalState != FinalStateTurnLimitExceeded {
+		t.Fatalf("session brake/result = %#v/%#v, want turn 2 beyond limit 1", brake, result)
+	}
+	if len(backend.requests) != 2 {
+		t.Fatalf("RunTurn requests = %d, want initial and interrupted recovery", len(backend.requests))
+	}
+}
+
+func TestPullRequestLookupAdoptsExactHead(t *testing.T) {
+	t.Parallel()
+
+	const branch = "detent/acme_widgets_18"
+	tests := []struct {
+		name string
+		body string
+		want bool
+	}{
+		{name: "exact head", body: `{"issues":[{"head_ref_name":"detent/acme_widgets_18","url":"https://github.test/acme/widgets/pull/18"}]}`, want: true},
+		{name: "nested exact head", body: `{"pull_requests":[{"url":"https://github.test/acme/widgets/pull/18","head":{"ref":"detent/acme_widgets_18"}}]}`, want: true},
+		{name: "unrelated head", body: `{"issues":[{"head_ref_name":"detent/acme_widgets_17","url":"https://github.test/acme/widgets/pull/17"}]}`},
+		{name: "url without head", body: `{"issues":[{"url":"https://github.test/acme/widgets/pull/18","pull_request":{}}]}`},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := pullRequestLookupAdopts(AgentUpdate{Delta: tt.body}, branch)
+			if got != tt.want {
+				t.Fatalf("pullRequestLookupAdopts() = %v, want %v for %s", got, tt.want, tt.body)
 			}
 		})
 	}
@@ -4954,6 +5034,7 @@ type toolUpdateAgentBackend struct {
 
 type deliverableRecoveryAgentBackend struct {
 	turns    [][]AgentUpdate
+	errors   []error
 	requests []AgentTurnRequest
 }
 
@@ -4998,11 +5079,15 @@ func (b *deliverableRecoveryAgentBackend) RunTurn(_ context.Context, req AgentTu
 		}
 	}
 	turn := index + 1
+	var runErr error
+	if index < len(b.errors) {
+		runErr = b.errors[index]
+	}
 	return AgentTurnResult{
 		ThreadID:  "thread-" + strconv.Itoa(turn),
 		TurnID:    "turn-" + strconv.Itoa(turn),
 		SessionID: "session-" + strconv.Itoa(turn),
-	}, nil
+	}, runErr
 }
 
 func (c *fakeCodexClient) RunTurn(_ context.Context, req AgentTurnRequest, onUpdate AgentUpdateHandler) (AgentTurnResult, error) {

--- a/internal/runner/types.go
+++ b/internal/runner/types.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/digitaldrywood/detent/internal/agentidentity"
@@ -25,6 +26,7 @@ const (
 	FinalStateMergeRevoked          = "merge_revoked"
 	FinalStateCIUnavailable         = "ci_unavailable"
 	FinalStateMergeDurationExceeded = "merge_duration_exceeded"
+	FinalStateNeedsHumanAttention   = "needs_human_attention"
 	TokenCeilingSourceAbsolute      = "max_session_tokens"
 	TokenCeilingSourceContextWindow = "max_session_context_multiplier"
 
@@ -39,18 +41,99 @@ const (
 )
 
 var (
-	ErrSessionTokenCeilingExceeded = errors.New("session token ceiling exceeded")
-	ErrTurnDurationExceeded        = errors.New("agent turn duration exceeded")
-	ErrSessionDurationExceeded     = errors.New("agent session duration exceeded")
-	ErrOperatorStopped             = errors.New("operator stopped run")
-	ErrMergeRevoked                = errors.New("merge eligibility revoked")
-	ErrCIUnavailable               = errors.New("CI unavailable")
-	ErrMergeWorkerStartupTimeout   = errors.New("merge worker startup timed out")
-	ErrMergeWorkerDurationExceeded = errors.New("merge worker duration exceeded")
-	ErrModelPermitUnavailable      = errors.New("provider model permit unavailable")
-	ErrAgentTurnCleanup            = errors.New("agent turn cleanup failed")
-	ErrAgentResumeUnsupported      = errors.New("agent backend does not support resume verification")
+	ErrSessionTokenCeilingExceeded  = errors.New("session token ceiling exceeded")
+	ErrTurnDurationExceeded         = errors.New("agent turn duration exceeded")
+	ErrSessionDurationExceeded      = errors.New("agent session duration exceeded")
+	ErrOperatorStopped              = errors.New("operator stopped run")
+	ErrMergeRevoked                 = errors.New("merge eligibility revoked")
+	ErrCIUnavailable                = errors.New("CI unavailable")
+	ErrMergeWorkerStartupTimeout    = errors.New("merge worker startup timed out")
+	ErrMergeWorkerDurationExceeded  = errors.New("merge worker duration exceeded")
+	ErrModelPermitUnavailable       = errors.New("provider model permit unavailable")
+	ErrAgentTurnCleanup             = errors.New("agent turn cleanup failed")
+	ErrAgentResumeUnsupported       = errors.New("agent backend does not support resume verification")
+	ErrDeliverableRecoveryExhausted = errors.New("deliverable recovery exhausted")
 )
+
+type DeliverableCommandError struct {
+	OperationClass string
+	Operation      string
+	Arguments      string
+	Status         string
+	Message        string
+	Body           string
+}
+
+func (e *DeliverableCommandError) Error() string {
+	if e == nil {
+		return "deliverable command failed: no error detail returned"
+	}
+	operation := strings.TrimSpace(e.Operation)
+	if operation == "" {
+		operation = "unknown"
+	}
+	parts := []string{"deliverable command failed (" + operation + ")"}
+	if status := strings.TrimSpace(e.Status); status != "" {
+		parts = append(parts, "status="+status)
+	}
+	if arguments := strings.TrimSpace(e.Arguments); arguments != "" && !strings.EqualFold(arguments, "null") {
+		parts = append(parts, "arguments="+arguments)
+	}
+	if message := strings.TrimSpace(e.Message); message != "" && !strings.EqualFold(message, "null") {
+		parts = append(parts, "message="+message)
+	}
+	if body := strings.TrimSpace(e.Body); body != "" && !strings.EqualFold(body, "null") && body != strings.TrimSpace(e.Message) {
+		parts = append(parts, "response="+body)
+	}
+	if len(parts) == 1 {
+		parts = append(parts, "detail=no error detail returned")
+	}
+	return strings.Join(parts, ": ")
+}
+
+func (e *DeliverableCommandError) BackendErrorBody() string {
+	if e == nil {
+		return ""
+	}
+	return strings.TrimSpace(e.Body)
+}
+
+func (e *DeliverableCommandError) BackendErrorMessage() string {
+	if e == nil {
+		return ""
+	}
+	return strings.TrimSpace(e.Message)
+}
+
+type DeliverableRecoveryError struct {
+	Branch string
+	Err    error
+}
+
+func (e *DeliverableRecoveryError) Error() string {
+	if e == nil {
+		return ErrDeliverableRecoveryExhausted.Error()
+	}
+	message := ErrDeliverableRecoveryExhausted.Error()
+	if branch := strings.TrimSpace(e.Branch); branch != "" {
+		message += " for pushed branch " + branch
+	}
+	if e.Err != nil {
+		message += ": " + e.Err.Error()
+	}
+	return message
+}
+
+func (e *DeliverableRecoveryError) Unwrap() error {
+	if e == nil {
+		return nil
+	}
+	return e.Err
+}
+
+func (e *DeliverableRecoveryError) Is(target error) bool {
+	return target == ErrDeliverableRecoveryExhausted
+}
 
 type Backend interface {
 	Run(context.Context, RunRequest) (RunResult, error)
@@ -312,30 +395,31 @@ func (e *agentDurationLimitError) Is(target error) bool {
 }
 
 type RunRequest struct {
-	ProjectID           string
-	Issue               connector.Issue
-	Attempt             int
-	WorkAttemptID       int64
-	Mode                string
-	DispatchSourceState string
-	DispatchTargetState string
-	PriorAttempt        PriorAttempt
-	StartedAt           time.Time
-	WorkerHost          string
-	RetryMode           RetryMode
-	ResumeState         store.AgentResumeState
-	SelectorContext     selector.Context
-	OnUsageUpdate       UsageUpdateHandler
-	OnActivityUpdate    AgentActivityUpdateHandler
-	OnOverrideRejected  AgentOverrideRejectionHandler
-	ProgressProbe       SessionProgressProbe
-	Routine             *RoutineRequest
-	Admission           *AdmissionRequest
-	AgentTools          []AgentTool
-	AgentToolHandler    AgentToolHandler
-	AcquireModelPermit  ModelPermitAcquirer
-	MergePrecheck       *MergePrecheck
-	sessionBrake        *sessionBrakeController
+	ProjectID                 string
+	Issue                     connector.Issue
+	Attempt                   int
+	WorkAttemptID             int64
+	Mode                      string
+	DispatchSourceState       string
+	DispatchTargetState       string
+	PriorAttempt              PriorAttempt
+	StartedAt                 time.Time
+	WorkerHost                string
+	RetryMode                 RetryMode
+	ResumeState               store.AgentResumeState
+	SelectorContext           selector.Context
+	OnUsageUpdate             UsageUpdateHandler
+	OnActivityUpdate          AgentActivityUpdateHandler
+	OnOverrideRejected        AgentOverrideRejectionHandler
+	ProgressProbe             SessionProgressProbe
+	Routine                   *RoutineRequest
+	Admission                 *AdmissionRequest
+	AgentTools                []AgentTool
+	AgentToolHandler          AgentToolHandler
+	AcquireModelPermit        ModelPermitAcquirer
+	MergePrecheck             *MergePrecheck
+	sessionBrake              *sessionBrakeController
+	deliverableRecoveryBranch string
 }
 
 type SessionProgressProbe func(context.Context) (string, error)

--- a/internal/runner/types.go
+++ b/internal/runner/types.go
@@ -420,6 +420,7 @@ type RunRequest struct {
 	MergePrecheck             *MergePrecheck
 	sessionBrake              *sessionBrakeController
 	deliverableRecoveryBranch string
+	sessionTurnOffset         int
 }
 
 type SessionProgressProbe func(context.Context) (string, error)

--- a/internal/web/templates/board_data_test.go
+++ b/internal/web/templates/board_data_test.go
@@ -2585,6 +2585,28 @@ func TestBoardSnapshotRendersProjectFailureBreakerBanner(t *testing.T) {
 	}
 }
 
+func TestBoardSnapshotAttributesDeliverableFailureBreakerCommand(t *testing.T) {
+	t.Parallel()
+
+	data := boardTestData()
+	data.Snapshot.FailureBreakers = []telemetry.FailureBreaker{{
+		ProjectID:     "detent.build",
+		Class:         "deliverable_command_failure:codex_apps/github.create_pull_request",
+		Count:         5,
+		WindowSeconds: 3600,
+		ResumeAt:      data.Snapshot.GeneratedAt.Add(time.Hour),
+	}}
+	html := renderBoardComponent(t, BoardSnapshot(data))
+	for _, want := range []string{
+		"deliverable command failure:codex apps/github.create pull request",
+		"deliverable_command_failure:codex_apps/github.create_pull_request",
+	} {
+		if !strings.Contains(html, want) {
+			t.Fatalf("failure breaker attribution missing %q:\n%s", want, html)
+		}
+	}
+}
+
 func TestBoardSnapshotHidesRampActiveDispatchRecovery(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

- preserve MCP deliverable arguments and structured backend error details instead of reporting a terminal `null`
- retry an isolated PR deliverable failure after a successful push, adopting only a PR whose result explicitly reports the exact head
- preserve retryable recovery interruptions, enforce cumulative session brakes, and park only completed unrecoverable PR delivery
- name pushed branches for human recovery and attribute breaker state to the failing command

Fixes #1766

## UI Surface Contract

- [x] N/A, or the linked issue explicitly authorizes any high-impact UI surface, layout, density, first-viewport, or responsive visibility tradeoff.
- [x] Persistent top-of-screen messaging is explicitly authorized by the issue, or this PR does not add it.
- [x] Visual changes to primary operator screens include screenshot or browser verification below. N/A — no visual layout changes.

## Test Plan

- [x] `go test ./internal/runner ./internal/orchestrator ./internal/codex ./internal/web/templates -count=1`
- [x] `golangci-lint run --timeout=5m ./internal/runner/...`
- [x] `make check` after review fixes on commit `39fbb2d3`
