### PR TITLE
fix(dispatch): gate assignee eligibility

### DIFF
--- a/config.reference.yaml
+++ b/config.reference.yaml
@@ -10,6 +10,8 @@
 #   github_login: null
 #   # identity.ownership_mode | type: string | default: none | required: No | validation: identity.owner_field must be blank when identity.ownership_mode is assignee; must be one of assignee, field
 #   ownership_mode: null
+#   # identity.assignee_required | type: boolean | default: false | required: No | validation: None
+#   assignee_required: false
 #   # identity.owner_field | type: string | default: none | required: No | validation: must be blank when identity.ownership_mode is assignee
 #   owner_field: null
 # # active_hours | type: object | default: see child fields | required: Conditional | validation: .timezone: is required when active_hours is set; .timezone: must be a valid IANA timezone; .windows: must contain at least one recurring window

--- a/docs/config.md
+++ b/docs/config.md
@@ -547,6 +547,7 @@ only to resettable budget pacing and never clears a per-issue hard hold.
 | `hooks.shell` | `string` | `platform default shell` | No | None |
 | `hooks.timeout_ms` | `integer` | `60000` | No | must be greater than 0 |
 | `identity` | `object` | `see child fields` | No | None |
+| `identity.assignee_required` | `boolean` | `false` | No | None |
 | `identity.github_login` | `string` | `none` | No | None |
 | `identity.name` | `string` | `none` | Conditional | must not be blank |
 | `identity.owner_field` | `string` | `none` | No | must be blank when identity.ownership_mode is assignee |

--- a/docs/multi-project.md
+++ b/docs/multi-project.md
@@ -362,6 +362,12 @@ a fresh lease, the issue is skipped. When the lease timestamp is stale by
 refreshes running claim leases every `heartbeat_seconds`; that value must be
 greater than zero and less than or equal to `ttl_seconds`.
 
+Setting `identity.assignee_required: true` separately makes an assignee a
+dispatch eligibility requirement. The default is `false` so upgrading Detent
+cannot silently make an existing `ownership_mode: assignee` declaration begin
+blocking unassigned work. Run `detent doctor` before enabling the requirement;
+it lists active issues that would stop dispatching.
+
 Task-to-model routing also lives in `detent.yaml`. If `agents.backends` is
 omitted, routes can reference the legacy `codex` backend built from the top-level
 `codex` block. Routes are evaluated in order, skipping defaults first; the first

--- a/internal/cli/doctor_ownership.go
+++ b/internal/cli/doctor_ownership.go
@@ -63,7 +63,19 @@ func checkDoctorOwnershipEligibility(
 		})
 	}
 	if len(diagnostics) == 0 {
-		return doctorCheck{Name: name, Status: doctorOK, Detail: "all label-eligible active issues have an assignee"}
+		if identity.AssigneeRequired {
+			return doctorCheck{Name: name, Status: doctorOK, Detail: "all label-eligible active issues have an assignee"}
+		}
+		return doctorCheck{Name: name, Status: doctorOK, Detail: "ownership eligibility compatibility grace is active; no issue would be blocked by identity.assignee_required"}
+	}
+	if !identity.AssigneeRequired {
+		return doctorCheck{
+			Name:               name,
+			Status:             doctorWarn,
+			Detail:             fmt.Sprintf("%d label-eligible active issue(s) would stop dispatching if identity.assignee_required were enabled; compatibility grace is active and dispatch remains eligible", len(diagnostics)),
+			Hint:               "Assign each reported issue before setting identity.assignee_required: true, then rerun detent doctor.",
+			OwnershipAttention: diagnostics,
+		}
 	}
 
 	return doctorCheck{

--- a/internal/cli/doctor_ownership_test.go
+++ b/internal/cli/doctor_ownership_test.go
@@ -17,13 +17,16 @@ func TestDoctorOwnershipEligibility(t *testing.T) {
 	tests := []struct {
 		name       string
 		mode       string
+		required   bool
 		assignees  []string
 		labels     []string
 		wantStatus doctorStatus
 		wantCount  int
+		wantDetail string
 	}{
-		{name: "assignee present", mode: workflowconfig.IdentityOwnershipAssignee, assignees: []string{"operator"}, labels: []string{"detent"}, wantStatus: doctorOK},
-		{name: "assignee absent", mode: workflowconfig.IdentityOwnershipAssignee, labels: []string{"detent"}, wantStatus: doctorWarn, wantCount: 1},
+		{name: "assigned steady state", mode: workflowconfig.IdentityOwnershipAssignee, required: true, assignees: []string{"operator"}, labels: []string{"detent"}, wantStatus: doctorOK, wantDetail: "all label-eligible active issues have an assignee"},
+		{name: "upgrade grace preflight", mode: workflowconfig.IdentityOwnershipAssignee, labels: []string{"detent"}, wantStatus: doctorWarn, wantCount: 1, wantDetail: "would stop dispatching"},
+		{name: "acknowledged rule blocks", mode: workflowconfig.IdentityOwnershipAssignee, required: true, labels: []string{"detent"}, wantStatus: doctorWarn, wantCount: 1, wantDetail: "cannot dispatch"},
 		{name: "other ownership mode", mode: workflowconfig.IdentityOwnershipField, labels: []string{"detent"}, wantStatus: doctorOK},
 		{name: "authorization label absent", mode: workflowconfig.IdentityOwnershipAssignee, wantStatus: doctorOK},
 	}
@@ -33,7 +36,7 @@ func TestDoctorOwnershipEligibility(t *testing.T) {
 			t.Parallel()
 
 			cfg := workflowconfig.Default()
-			cfg.Identity = workflowconfig.Identity{Name: "operator", OwnershipMode: tt.mode, OwnerField: "Owner"}
+			cfg.Identity = workflowconfig.Identity{Name: "operator", OwnershipMode: tt.mode, AssigneeRequired: tt.required, OwnerField: "Owner"}
 			if tt.mode == workflowconfig.IdentityOwnershipAssignee {
 				cfg.Identity.OwnerField = ""
 			}
@@ -49,8 +52,11 @@ func TestDoctorOwnershipEligibility(t *testing.T) {
 			if check.Status != tt.wantStatus || len(check.OwnershipAttention) != tt.wantCount {
 				t.Fatalf("check = %#v, want status %s and %d diagnostics", check, tt.wantStatus, tt.wantCount)
 			}
-			if tt.wantCount > 0 && (!strings.Contains(check.Detail, "cannot dispatch") || check.OwnershipAttention[0].Remedy != "assign the issue") {
-				t.Fatalf("check = %#v, want dispatch failure with assignee remedy", check)
+			if tt.wantDetail != "" && !strings.Contains(check.Detail, tt.wantDetail) {
+				t.Fatalf("check = %#v, want detail containing %q", check, tt.wantDetail)
+			}
+			if tt.wantCount > 0 && check.OwnershipAttention[0].Remedy != "assign the issue" {
+				t.Fatalf("check = %#v, want assignee remedy", check)
 			}
 		})
 	}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -234,10 +234,11 @@ type BlockerAutoPromote struct {
 }
 
 type Identity struct {
-	Name          string `yaml:"name"`
-	GitHubLogin   string `yaml:"github_login,omitempty"`
-	OwnershipMode string `yaml:"ownership_mode,omitempty"`
-	OwnerField    string `yaml:"owner_field,omitempty"`
+	Name             string `yaml:"name"`
+	GitHubLogin      string `yaml:"github_login,omitempty"`
+	OwnershipMode    string `yaml:"ownership_mode,omitempty"`
+	AssigneeRequired bool   `yaml:"assignee_required,omitempty"`
+	OwnerField       string `yaml:"owner_field,omitempty"`
 }
 
 type Polling struct {
@@ -865,6 +866,7 @@ func (i Identity) Configured() bool {
 	return strings.TrimSpace(i.Name) != "" ||
 		strings.TrimSpace(i.GitHubLogin) != "" ||
 		strings.TrimSpace(i.OwnershipMode) != "" ||
+		i.AssigneeRequired ||
 		strings.TrimSpace(i.OwnerField) != ""
 }
 

--- a/internal/orchestrator/config.go
+++ b/internal/orchestrator/config.go
@@ -51,6 +51,7 @@ func ConfigFromWorkflow(cfg workflowconfig.Config) Config {
 			Enabled:           cfg.Tracker.Claims.Enabled,
 			OwnershipSet:      identity.Configured(),
 			OwnershipMode:     identity.OwnershipMode,
+			AssigneeRequired:  identity.AssigneeRequired,
 			Owner:             identity.Name,
 			AssigneeLogin:     identity.GitHubLogin,
 			OwnerField:        identity.OwnerField,

--- a/internal/orchestrator/dispatch.go
+++ b/internal/orchestrator/dispatch.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/digitaldrywood/detent/internal/activity"
 	"github.com/digitaldrywood/detent/internal/budget"
+	workflowconfig "github.com/digitaldrywood/detent/internal/config"
 	"github.com/digitaldrywood/detent/internal/connector"
 	"github.com/digitaldrywood/detent/internal/dispatchpriority"
 	"github.com/digitaldrywood/detent/internal/gate"
@@ -134,6 +135,7 @@ func (o *Orchestrator) dispatchReadyIssues(ctx context.Context, state *State, is
 	issues = o.filterImplementDependencyDeferrals(ctx, issues)
 	o.observePullRequestHydrationRecovery(state, issues, now)
 	planner := o.dispatchPlanner()
+	o.logOwnershipEligibilityStartup(planner, issues)
 	var lastDispatchFailure string
 	decisions := make([]dispatchPlanDecision, 0, len(issues))
 	outcomes := make(map[string]dispatchIssueOutcome, len(issues))
@@ -182,6 +184,35 @@ func (o *Orchestrator) dispatchReadyIssues(ctx context.Context, state *State, is
 		},
 	})
 	o.observeProjectDispatchStatus(ctx, state, issues, decisions, outcomes, now)
+}
+
+func (o *Orchestrator) logOwnershipEligibilityStartup(planner dispatchPlanner, issues []connector.Issue) {
+	if o == nil || o.ownershipStartupLogged || o.logger == nil || !planner.cfg.Claiming.OwnershipSet || planner.cfg.Claiming.OwnershipMode != workflowconfig.IdentityOwnershipAssignee {
+		return
+	}
+	o.ownershipStartupLogged = true
+	candidates := planner.assigneeEligibilityCandidates(issues)
+	identifiers := make([]string, 0, len(candidates))
+	for _, issue := range candidates {
+		identifier := strings.TrimSpace(issue.Identifier)
+		if identifier == "" {
+			identifier = strings.TrimSpace(issue.ID)
+		}
+		identifiers = append(identifiers, identifier)
+	}
+	message := "ownership eligibility compatibility grace active"
+	if planner.cfg.Claiming.AssigneeRequired {
+		message = "ownership eligibility enforcement active"
+	}
+	o.logger.Warn(
+		message,
+		"project_id", strings.TrimSpace(o.projectID),
+		"config_key", "identity.assignee_required",
+		"ownership_mode", workflowconfig.IdentityOwnershipAssignee,
+		"enforced", planner.cfg.Claiming.AssigneeRequired,
+		"blocked_issue_count", len(candidates),
+		"affected_issues", strings.Join(identifiers, ","),
+	)
 }
 
 func dispatchFailureRetryReason(reason string) string {

--- a/internal/orchestrator/dispatch_planner.go
+++ b/internal/orchestrator/dispatch_planner.go
@@ -759,6 +759,10 @@ func (p dispatchPlanner) authorized(issue connector.Issue) bool {
 }
 
 func (p dispatchPlanner) needsAssignee(issue connector.Issue) bool {
+	return p.cfg.Claiming.AssigneeRequired && p.assigneeEligibilityApplies(issue)
+}
+
+func (p dispatchPlanner) assigneeEligibilityApplies(issue connector.Issue) bool {
 	if !p.cfg.Claiming.OwnershipSet || p.cfg.Claiming.OwnershipMode != workflowconfig.IdentityOwnershipAssignee {
 		return false
 	}
@@ -771,6 +775,17 @@ func (p dispatchPlanner) needsAssignee(issue connector.Issue) bool {
 		}
 	}
 	return true
+}
+
+func (p dispatchPlanner) assigneeEligibilityCandidates(issues []connector.Issue) []connector.Issue {
+	candidates := make([]connector.Issue, 0)
+	for _, issue := range issues {
+		if strings.TrimSpace(issue.ID) == "" || !validCandidate(issue) || !stateIn(issue.State, p.cfg.ActiveStates) || stateIn(issue.State, p.cfg.TerminalStates) || !p.authorized(issue) || !p.assigneeEligibilityApplies(issue) {
+			continue
+		}
+		candidates = append(candidates, cloneIssue(issue))
+	}
+	return candidates
 }
 
 func (p dispatchPlanner) trackOwnershipAttentionCandidates(state *State, issues []connector.Issue, now time.Time) {

--- a/internal/orchestrator/dispatch_test.go
+++ b/internal/orchestrator/dispatch_test.go
@@ -1,6 +1,7 @@
 package orchestrator
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
@@ -252,6 +253,7 @@ func TestConfigFromWorkflowIncludesDispatchControls(t *testing.T) {
 	cfg.Agent.OutputTruncation.MaxBytes = 4096
 	cfg.Identity.Name = "release-captain"
 	cfg.Identity.GitHubLogin = "detent-bot"
+	cfg.Identity.AssigneeRequired = true
 	cfg.Tracker.Authorization = selector.Selector{
 		AssigneeIn: []string{"@me"},
 	}
@@ -370,6 +372,9 @@ func TestConfigFromWorkflowIncludesDispatchControls(t *testing.T) {
 	}
 	if got.Claiming.OwnershipMode != workflowconfig.IdentityOwnershipAssignee {
 		t.Fatalf("Claiming.OwnershipMode = %q, want assignee", got.Claiming.OwnershipMode)
+	}
+	if !got.Claiming.AssigneeRequired {
+		t.Fatal("Claiming.AssigneeRequired = false, want true")
 	}
 	if got.Claiming.Owner != "release-captain" {
 		t.Fatalf("Claiming.Owner = %q, want release-captain", got.Claiming.Owner)
@@ -1269,12 +1274,14 @@ func TestDispatchPlanOwnershipEligibility(t *testing.T) {
 	tests := []struct {
 		name          string
 		ownershipMode string
+		assigneeGate  bool
 		assignees     []string
 		wantDispatch  bool
 		wantAttention bool
 	}{
-		{name: "assignee present dispatches", ownershipMode: workflowconfig.IdentityOwnershipAssignee, assignees: []string{"operator"}, wantDispatch: true},
-		{name: "assignee absent surfaces", ownershipMode: workflowconfig.IdentityOwnershipAssignee, wantAttention: true},
+		{name: "upgrade grace dispatches unassigned issue", ownershipMode: workflowconfig.IdentityOwnershipAssignee, wantDispatch: true},
+		{name: "acknowledged rule blocks unassigned issue", ownershipMode: workflowconfig.IdentityOwnershipAssignee, assigneeGate: true, wantAttention: true},
+		{name: "assigned steady state dispatches", ownershipMode: workflowconfig.IdentityOwnershipAssignee, assigneeGate: true, assignees: []string{"operator"}, wantDispatch: true},
 		{name: "assignee absent in field mode dispatches", ownershipMode: workflowconfig.IdentityOwnershipField, wantDispatch: true},
 	}
 
@@ -1287,8 +1294,9 @@ func TestDispatchPlanOwnershipEligibility(t *testing.T) {
 				ActiveStates:        []string{"Todo"},
 				TerminalStates:      []string{"Done"},
 				Claiming: ClaimingConfig{
-					OwnershipSet:  true,
-					OwnershipMode: tt.ownershipMode,
+					OwnershipSet:     true,
+					OwnershipMode:    tt.ownershipMode,
+					AssigneeRequired: tt.assigneeGate,
 				},
 			})
 			state := newState(cfg)
@@ -1312,6 +1320,62 @@ func TestDispatchPlanOwnershipEligibility(t *testing.T) {
 	}
 }
 
+func TestOwnershipEligibilityStartupLogOncePerProject(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		enforced    bool
+		wantMessage string
+	}{
+		{name: "upgrade grace", wantMessage: "ownership eligibility compatibility grace active"},
+		{name: "acknowledged enforcement", enforced: true, wantMessage: "ownership eligibility enforcement active"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			var logs bytes.Buffer
+			cfg := normalizeConfig(Config{
+				Project:        scheduler.ProjectCandidate{ID: "detent.build"},
+				ActiveStates:   []string{"Todo"},
+				TerminalStates: []string{"Done"},
+				Claiming: ClaimingConfig{
+					OwnershipSet:     true,
+					OwnershipMode:    workflowconfig.IdentityOwnershipAssignee,
+					AssigneeRequired: tt.enforced,
+				},
+			})
+			orch := Orchestrator{
+				cfg:       cfg,
+				projectID: "detent.build",
+				logger:    slog.New(slog.NewTextHandler(&logs, nil)),
+			}
+			issue := dispatchTestIssue("issue-10", "Todo")
+
+			orch.logOwnershipEligibilityStartup(newDispatchPlanner(cfg), []connector.Issue{issue})
+			orch.logOwnershipEligibilityStartup(newDispatchPlanner(cfg), []connector.Issue{issue})
+
+			output := logs.String()
+			if got := strings.Count(output, tt.wantMessage); got != 1 {
+				t.Fatalf("startup log count = %d, want 1; logs = %q", got, output)
+			}
+			for _, want := range []string{
+				"project_id=detent.build",
+				"config_key=identity.assignee_required",
+				fmt.Sprintf("enforced=%t", tt.enforced),
+				"blocked_issue_count=1",
+				"affected_issues=digitaldrywood/detent#issue-10",
+			} {
+				if !strings.Contains(output, want) {
+					t.Fatalf("startup log = %q, want %q", output, want)
+				}
+			}
+		})
+	}
+}
+
 func TestOwnershipAttentionEscalatesOnce(t *testing.T) {
 	t.Parallel()
 
@@ -1321,8 +1385,9 @@ func TestOwnershipAttentionEscalatesOnce(t *testing.T) {
 		ActiveStates:        []string{"Todo"},
 		TerminalStates:      []string{"Done"},
 		Claiming: ClaimingConfig{
-			OwnershipSet:  true,
-			OwnershipMode: workflowconfig.IdentityOwnershipAssignee,
+			OwnershipSet:     true,
+			OwnershipMode:    workflowconfig.IdentityOwnershipAssignee,
+			AssigneeRequired: true,
 		},
 		Staleness: staleness.Config{RepeatedDecisionCount: 3},
 	})

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -137,6 +137,7 @@ type ClaimingConfig struct {
 	Enabled           bool
 	OwnershipSet      bool
 	OwnershipMode     string
+	AssigneeRequired  bool
 	Owner             string
 	AssigneeLogin     string
 	OwnerField        string
@@ -242,6 +243,7 @@ type Orchestrator struct {
 	heartbeats              *heartbeatManager
 	hydrationSkipStreaks    map[string]int
 	hydrationWarned         bool
+	ownershipStartupLogged  bool
 	dispatchStartMu         sync.Mutex
 	dispatchStarts          int
 	dispatchStartsDone      chan struct{}
@@ -876,6 +878,10 @@ func (o *Orchestrator) dispatchQuiesced() bool {
 
 func (o *Orchestrator) applyRuntimeUpdate(state *State, update RuntimeUpdate, ticker *time.Ticker) {
 	cfg := normalizeConfig(update.Config)
+	if o.cfg.Claiming.OwnershipMode != cfg.Claiming.OwnershipMode ||
+		o.cfg.Claiming.AssigneeRequired != cfg.Claiming.AssigneeRequired {
+		o.ownershipStartupLogged = false
+	}
 	o.cfg = cfg
 	now := time.Now
 	if o.now != nil {


### PR DESCRIPTION
## Summary

- add `identity.assignee_required` as an explicit acknowledgement for strict assignee eligibility
- keep existing `ownership_mode: assignee` fleets in compatibility grace so restarts continue dispatching unassigned work
- report would-be blockers in `detent doctor` and log one startup migration line per project with the affected count

Fixes #1770

## UI Surface Contract

- [x] N/A, or the linked issue explicitly authorizes any high-impact UI surface, layout, density, first-viewport, or responsive visibility tradeoff.
- [x] Persistent top-of-screen messaging is explicitly authorized by the issue, or this PR does not add it.
- [x] Visual changes to primary operator screens include screenshot or browser verification below. No visual layout or component changes.

## Test Plan

- [x] `go test ./internal/config/... ./internal/orchestrator ./internal/cli -count=1`
- [x] `make generate`
- [x] `make check` (78.9% aggregate coverage; 70% required)