### PR TITLE
feat(health): expose running process build

### DIFF
--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -496,6 +496,12 @@ func runDoctor(ctx context.Context, cfg doctorConfig, opts options, deps doctorD
 	}
 	jobs = append(jobs,
 		doctorCheckJob{
+			Name: "Remote Detent service",
+			Run: func(jobCtx context.Context) []doctorCheck {
+				return []doctorCheck{checkDoctorDetentService(jobCtx, liveBoot, deps)}
+			},
+		},
+		doctorCheckJob{
 			Name: "Instance lock",
 			Run: func(_ context.Context) []doctorCheck {
 				return []doctorCheck{checkDoctorInstanceLock(resolution)}

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -498,7 +498,7 @@ func runDoctor(ctx context.Context, cfg doctorConfig, opts options, deps doctorD
 		doctorCheckJob{
 			Name: "Remote Detent service",
 			Run: func(jobCtx context.Context) []doctorCheck {
-				return []doctorCheck{checkDoctorDetentService(jobCtx, liveBoot, deps)}
+				return checkDoctorDetentService(jobCtx, liveBoot, deps)
 			},
 		},
 		doctorCheckJob{

--- a/internal/cli/doctor_environment.go
+++ b/internal/cli/doctor_environment.go
@@ -828,7 +828,7 @@ type doctorHealthResponse struct {
 	DispatchStalls    []telemetry.DispatchStatus   `json:"dispatch_stalls"`
 }
 
-func checkDoctorDetentService(ctx context.Context, cfg BootConfig, deps doctorDeps) doctorCheck {
+func checkDoctorDetentService(ctx context.Context, cfg BootConfig, deps doctorDeps) []doctorCheck {
 	probe, err := probeDoctorHealth(ctx, cfg, deps)
 	version := strings.TrimSpace(probe.Health.Version)
 	commit := strings.TrimSpace(probe.Health.Commit)
@@ -843,22 +843,17 @@ func checkDoctorDetentService(ctx context.Context, cfg BootConfig, deps doctorDe
 			check.Detail += "; health check: " + err.Error()
 			check.Hint = "Review the running Detent service health, then rerun detent doctor."
 		}
-		return check
+		return []doctorCheck{check}
 	}
 	if err != nil {
-		return doctorCheck{
-			Name:   "Remote Detent service",
-			Status: doctorWarn,
-			Detail: fmt.Sprintf("remote service build unavailable from %s: %v", probe.URL, err),
-			Hint:   "Start the configured Detent service, then rerun detent doctor.",
-		}
+		return nil
 	}
-	return doctorCheck{
+	return []doctorCheck{{
 		Name:   "Remote Detent service",
 		Status: doctorWarn,
 		Detail: fmt.Sprintf("remote service at %s did not report its complete build", probe.URL),
 		Hint:   "Upgrade the running Detent service, then rerun detent doctor.",
-	}
+	}}
 }
 
 type doctorHealthEnvironment struct {

--- a/internal/cli/doctor_environment.go
+++ b/internal/cli/doctor_environment.go
@@ -815,6 +815,8 @@ type doctorHealthProbe struct {
 
 type doctorHealthResponse struct {
 	Status            string                       `json:"status"`
+	Version           string                       `json:"version"`
+	Commit            string                       `json:"commit"`
 	Mode              string                       `json:"mode"`
 	Checks            map[string]string            `json:"checks"`
 	Environment       doctorHealthEnvironment      `json:"environment"`
@@ -824,6 +826,39 @@ type doctorHealthResponse struct {
 	StrandedIssues    []telemetry.StrandedIssue    `json:"stranded_active_issues"`
 	Dispatch          telemetry.DispatchStatus     `json:"dispatch"`
 	DispatchStalls    []telemetry.DispatchStatus   `json:"dispatch_stalls"`
+}
+
+func checkDoctorDetentService(ctx context.Context, cfg BootConfig, deps doctorDeps) doctorCheck {
+	probe, err := probeDoctorHealth(ctx, cfg, deps)
+	version := strings.TrimSpace(probe.Health.Version)
+	commit := strings.TrimSpace(probe.Health.Commit)
+	if version != "" && commit != "" {
+		check := doctorCheck{
+			Name:   "Remote Detent service",
+			Status: doctorOK,
+			Detail: fmt.Sprintf("remote service build %s (%s) at %s", version, commit, probe.URL),
+		}
+		if err != nil {
+			check.Status = doctorWarn
+			check.Detail += "; health check: " + err.Error()
+			check.Hint = "Review the running Detent service health, then rerun detent doctor."
+		}
+		return check
+	}
+	if err != nil {
+		return doctorCheck{
+			Name:   "Remote Detent service",
+			Status: doctorWarn,
+			Detail: fmt.Sprintf("remote service build unavailable from %s: %v", probe.URL, err),
+			Hint:   "Start the configured Detent service, then rerun detent doctor.",
+		}
+	}
+	return doctorCheck{
+		Name:   "Remote Detent service",
+		Status: doctorWarn,
+		Detail: fmt.Sprintf("remote service at %s did not report its complete build", probe.URL),
+		Hint:   "Upgrade the running Detent service, then rerun detent doctor.",
+	}
 }
 
 type doctorHealthEnvironment struct {

--- a/internal/cli/doctor_test.go
+++ b/internal/cli/doctor_test.go
@@ -4326,6 +4326,56 @@ func TestCheckDoctorDetentExecutableReportsRunningBinary(t *testing.T) {
 	}
 }
 
+func TestCheckDoctorDetentServiceReportsRemoteBuild(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		version string
+		commit  string
+	}{
+		{name: "release build", version: "v1.3.0", commit: "abcdef123456"},
+		{name: "development build", version: "dev", commit: "123456abcdef"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			payload, err := json.Marshal(map[string]any{
+				"status":  "ok",
+				"version": tt.version,
+				"commit":  tt.commit,
+				"mode":    "running",
+				"checks": map[string]string{
+					"hub": "configured", "store": "configured", "registry": "configured", "connector": "configured",
+				},
+			})
+			if err != nil {
+				t.Fatalf("Marshal() error = %v", err)
+			}
+			port := 4017
+			got := checkDoctorDetentService(t.Context(), BootConfig{Host: "127.0.0.1", Port: &port}, doctorDeps{
+				httpDo: func(request *http.Request) (*http.Response, error) {
+					if request.URL.String() != "http://127.0.0.1:4017/health" {
+						t.Errorf("URL = %q, want configured health endpoint", request.URL)
+					}
+					return &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(bytes.NewReader(payload))}, nil
+				},
+			})
+
+			if got.Name != "Remote Detent service" || got.Status != doctorOK {
+				t.Fatalf("check = %#v, want remote service OK", got)
+			}
+			for _, want := range []string{"remote service build", tt.version, tt.commit, "http://127.0.0.1:4017/health"} {
+				if !strings.Contains(got.Detail, want) {
+					t.Fatalf("Detail = %q, want containing %q", got.Detail, want)
+				}
+			}
+		})
+	}
+}
+
 func TestCheckDoctorGitHub(t *testing.T) {
 	t.Parallel()
 

--- a/internal/cli/doctor_test.go
+++ b/internal/cli/doctor_test.go
@@ -4355,7 +4355,7 @@ func TestCheckDoctorDetentServiceReportsRemoteBuild(t *testing.T) {
 				t.Fatalf("Marshal() error = %v", err)
 			}
 			port := 4017
-			got := checkDoctorDetentService(t.Context(), BootConfig{Host: "127.0.0.1", Port: &port}, doctorDeps{
+			checks := checkDoctorDetentService(t.Context(), BootConfig{Host: "127.0.0.1", Port: &port}, doctorDeps{
 				httpDo: func(request *http.Request) (*http.Response, error) {
 					if request.URL.String() != "http://127.0.0.1:4017/health" {
 						t.Errorf("URL = %q, want configured health endpoint", request.URL)
@@ -4364,6 +4364,10 @@ func TestCheckDoctorDetentServiceReportsRemoteBuild(t *testing.T) {
 				},
 			})
 
+			if len(checks) != 1 {
+				t.Fatalf("checks = %#v, want one remote service check", checks)
+			}
+			got := checks[0]
 			if got.Name != "Remote Detent service" || got.Status != doctorOK {
 				t.Fatalf("check = %#v, want remote service OK", got)
 			}
@@ -4371,6 +4375,33 @@ func TestCheckDoctorDetentServiceReportsRemoteBuild(t *testing.T) {
 				if !strings.Contains(got.Detail, want) {
 					t.Fatalf("Detail = %q, want containing %q", got.Detail, want)
 				}
+			}
+		})
+	}
+}
+
+func TestCheckDoctorDetentServiceSkipsAbsentService(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		err  error
+	}{
+		{name: "connection refused", err: errors.New("connection refused")},
+		{name: "request timeout", err: context.DeadlineExceeded},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			checks := checkDoctorDetentService(t.Context(), BootConfig{}, doctorDeps{
+				httpDo: func(*http.Request) (*http.Response, error) {
+					return nil, tt.err
+				},
+			})
+			if len(checks) != 0 {
+				t.Fatalf("checks = %#v, want absent service omitted", checks)
 			}
 		})
 	}

--- a/internal/cli/state_test.go
+++ b/internal/cli/state_test.go
@@ -205,12 +205,13 @@ func TestStateCommandOutput(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name       string
-		stdoutTTY  bool
-		args       []string
-		wantPretty []string
+		name          string
+		stdoutTTY     bool
+		args          []string
+		wantPretty    []string
+		wantJSONBuild bool
 	}{
-		{name: "JSON projection", args: []string{"--project", "detent"}},
+		{name: "JSON projection", args: []string{"--project", "detent"}, wantJSONBuild: true},
 		{name: "pretty projection", stdoutTTY: true, args: []string{"--project", "detent"}, wantPretty: []string{"Status: running", "Generated at: 2026-08-08T03:00:00Z", "Degraded: true", "Refresh status: degraded", "Running: 2", "Truncated: false"}},
 	}
 
@@ -273,6 +274,15 @@ func TestStateCommandOutput(t *testing.T) {
 					t.Fatalf("JSON output missing %q: %s", key, stdout.String())
 				}
 			}
+			if tt.wantJSONBuild {
+				var instance map[string]string
+				if err := json.Unmarshal(object["instance"], &instance); err != nil {
+					t.Fatalf("Unmarshal(instance) error = %v", err)
+				}
+				if instance["version"] != "v1.3.0" || instance["commit"] != "abcdef123456" {
+					t.Fatalf("instance = %#v, want running build", instance)
+				}
+			}
 		})
 	}
 }
@@ -332,6 +342,7 @@ func stateFixture() map[string]any {
 	return map[string]any{
 		"generated_at": "2026-08-08T03:00:00Z",
 		"status":       "running",
+		"instance":     map[string]any{"version": "v1.3.0", "commit": "abcdef123456"},
 		"refresh": map[string]any{
 			"status":              "degraded",
 			"last_refresh_at":     "2026-08-08T02:59:30Z",

--- a/internal/web/api.go
+++ b/internal/web/api.go
@@ -13,6 +13,7 @@ import (
 	"github.com/labstack/echo/v4"
 
 	"github.com/digitaldrywood/detent/internal/budget"
+	"github.com/digitaldrywood/detent/internal/buildinfo"
 	"github.com/digitaldrywood/detent/internal/explain"
 	"github.com/digitaldrywood/detent/internal/orchestrator"
 	"github.com/digitaldrywood/detent/internal/runtimeoutput"
@@ -68,7 +69,7 @@ func (s *Server) apiState(c echo.Context) error {
 			return c.JSON(http.StatusOK, snapshotErrorResponse(demoBaseTime, "snapshot_unavailable", "Snapshot unavailable"))
 		}
 		snapshot := demofixtures.SnapshotForScenario(scenario.ProjectID, scenario.Variant)
-		return c.JSON(http.StatusOK, stateResponse(snapshot, generatedAt(snapshot, demoBaseTime), s.instanceName()))
+		return c.JSON(http.StatusOK, stateResponse(snapshot, generatedAt(snapshot, demoBaseTime), s.instanceName(), s.build))
 	}
 	now := apiNow()
 	snapshot, ok := s.hub.Latest()
@@ -80,7 +81,7 @@ func (s *Server) apiState(c echo.Context) error {
 		snapshot = s.withManualRefresh(snapshot)
 	}
 
-	return c.JSON(http.StatusOK, stateResponse(snapshot, generatedAt(snapshot, now), s.instanceName()))
+	return c.JSON(http.StatusOK, stateResponse(snapshot, generatedAt(snapshot, now), s.instanceName(), s.build))
 }
 
 func (s *Server) apiProject(c echo.Context) error {
@@ -114,7 +115,7 @@ func (s *Server) apiProjectState(c echo.Context, projectID string) error {
 			return c.JSON(http.StatusNotFound, errorResponse("project_not_found", "Project not found"))
 		}
 		scoped := projectScopedSnapshotForProject(snapshot, telemetry.Project{ID: project.ID, DisplayName: project.Name, URL: project.URL, Pool: project.Pool})
-		return c.JSON(http.StatusOK, stateResponse(scoped, generatedAt(scoped, demoBaseTime), s.instanceName()))
+		return c.JSON(http.StatusOK, stateResponse(scoped, generatedAt(scoped, demoBaseTime), s.instanceName(), s.build))
 	}
 	now := apiNow()
 	snapshot, ok := s.hub.Latest()
@@ -136,7 +137,7 @@ func (s *Server) apiProjectState(c echo.Context, projectID string) error {
 	scopedSnapshot.WorkflowMetrics = s.snapshotWorkflowMetrics(c.Request().Context(), scopedSnapshot)
 	scopedSnapshot = s.withManualRefresh(scopedSnapshot)
 
-	return c.JSON(http.StatusOK, stateResponse(scopedSnapshot, generatedAt(scopedSnapshot, now), s.instanceName()))
+	return c.JSON(http.StatusOK, stateResponse(scopedSnapshot, generatedAt(scopedSnapshot, now), s.instanceName(), s.build))
 }
 
 func (s *Server) apiTimeSeries(c echo.Context) error {
@@ -457,13 +458,13 @@ func (s *Server) handleHTTPError(err error, c echo.Context) {
 	}
 }
 
-func stateResponse(snapshot telemetry.Snapshot, generatedAt time.Time, instanceName string) stateAPIResponse {
+func stateResponse(snapshot telemetry.Snapshot, generatedAt time.Time, instanceName string, build buildinfo.Info) stateAPIResponse {
 	return stateAPIResponse{
 		GeneratedAt:        generatedAt,
 		Status:             runtimeStatus(snapshot),
 		Shutdown:           shutdownResponse(snapshot.Shutdown),
 		Update:             snapshot.Update,
-		Instance:           instanceResponse(snapshot.Instance, instanceName),
+		Instance:           instanceResponse(snapshot.Instance, instanceName, build),
 		Projects:           projectsAPIResponse(snapshot),
 		Refresh:            snapshot.Refresh,
 		Events:             recentEventsFromTelemetry(snapshot.Events, nil, "", ""),
@@ -532,10 +533,12 @@ func shutdownResponse(shutdown telemetry.Shutdown) shutdownAPIResponse {
 	}
 }
 
-func instanceResponse(instance telemetry.Instance, displayName string) instanceAPIResponse {
+func instanceResponse(instance telemetry.Instance, displayName string, build buildinfo.Info) instanceAPIResponse {
 	return instanceAPIResponse{
 		DisplayName:             strings.TrimSpace(displayName),
 		Name:                    strings.TrimSpace(instance.Name),
+		Version:                 strings.TrimSpace(build.Version),
+		Commit:                  strings.TrimSpace(build.Commit),
 		GitHubLogin:             strings.TrimSpace(instance.GitHubLogin),
 		AuthorizationScope:      strings.TrimSpace(instance.AuthorizationScope),
 		AuthorizationConfigured: instance.AuthorizationConfigured,
@@ -1445,6 +1448,8 @@ type shutdownAPIResponse struct {
 type instanceAPIResponse struct {
 	DisplayName             string `json:"display_name,omitempty"`
 	Name                    string `json:"name,omitempty"`
+	Version                 string `json:"version"`
+	Commit                  string `json:"commit"`
 	GitHubLogin             string `json:"github_login,omitempty"`
 	AuthorizationScope      string `json:"authorization_scope,omitempty"`
 	AuthorizationConfigured bool   `json:"authorization_configured"`

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -1102,6 +1102,8 @@ func (s *Server) health(c echo.Context) error {
 	}
 	return c.JSON(http.StatusOK, healthResponse{
 		Status:            status,
+		Version:           s.build.Version,
+		Commit:            s.build.Commit,
 		ProjectStatus:     projectStatus,
 		Mode:              string(s.mode),
 		Connector:         s.connectorName(),
@@ -1380,6 +1382,8 @@ func (s *Server) connectorName() string {
 
 type healthResponse struct {
 	Status            string                       `json:"status"`
+	Version           string                       `json:"version"`
+	Commit            string                       `json:"commit"`
 	ProjectStatus     string                       `json:"project_status"`
 	Mode              string                       `json:"mode"`
 	Connector         string                       `json:"connector"`

--- a/internal/web/server_test.go
+++ b/internal/web/server_test.go
@@ -4995,6 +4995,43 @@ func TestAPIStateSurfacesProjectAuthHealth(t *testing.T) {
 	}
 }
 
+func TestAPIStateProjectsRunningBuildUnderInstance(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		version string
+		commit  string
+	}{
+		{name: "release build", version: "v1.3.0", commit: "abcdef123456"},
+		{name: "development build", version: "dev", commit: "123456abcdef"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			deps := testDeps(t)
+			if err := deps.Hub.Publish(telemetry.Snapshot{GeneratedAt: time.Date(2026, 8, 13, 12, 0, 0, 0, time.UTC)}); err != nil {
+				t.Fatalf("Publish() error = %v", err)
+			}
+			server, err := web.NewServer(web.Config{Build: buildinfo.Info{Version: tt.version, Commit: tt.commit}}, deps)
+			if err != nil {
+				t.Fatalf("NewServer() error = %v", err)
+			}
+
+			state := requestJSON(t, server, http.MethodGet, "/api/v1/state", http.StatusOK)
+			instance, ok := state["instance"].(map[string]any)
+			if !ok {
+				t.Fatalf("instance = %#v, want object", state["instance"])
+			}
+			if instance["version"] != tt.version || instance["commit"] != tt.commit {
+				t.Fatalf("instance build = version %#v commit %#v, want %q %q", instance["version"], instance["commit"], tt.version, tt.commit)
+			}
+		})
+	}
+}
+
 func TestAPIStateSurfacesSingleProjectAuthHealth(t *testing.T) {
 	t.Parallel()
 
@@ -7006,37 +7043,55 @@ func TestHealthRespondsDuringDrainWithoutSupplementalProjectReads(t *testing.T) 
 	}
 }
 
-func TestHealthReportsUpdateCheckStatus(t *testing.T) {
+func TestHealthReportsRunningBuildDistinctFromAppliedUpdate(t *testing.T) {
 	t.Parallel()
 
-	lastCheck := time.Date(2026, 7, 11, 15, 0, 0, 0, time.UTC)
-	nextCheck := lastCheck.Add(24 * time.Hour)
-	deps := testDeps(t)
-	if err := deps.Hub.Publish(telemetry.Snapshot{
-		GeneratedAt: lastCheck,
-		Update: telemetry.Update{
-			Enabled:            true,
-			CheckIntervalHours: 24,
-			State:              "scheduled",
-			LastCheckAt:        &lastCheck,
-			LastAppliedVersion: "1.2.4",
-			NextCheckAt:        &nextCheck,
-		},
-	}); err != nil {
-		t.Fatalf("Publish() error = %v", err)
+	tests := []struct {
+		name    string
+		version string
+		commit  string
+	}{
+		{name: "release build", version: "v1.3.0", commit: "abcdef123456"},
+		{name: "development build", version: "dev", commit: "123456abcdef"},
 	}
 
-	server, err := web.NewServer(web.Config{}, deps)
-	if err != nil {
-		t.Fatalf("NewServer() error = %v", err)
-	}
-	payload := requestJSON(t, server, http.MethodGet, "/health", http.StatusOK)
-	update, ok := payload["update"].(map[string]any)
-	if !ok {
-		t.Fatalf("update payload = %#v, want object", payload["update"])
-	}
-	if update["state"] != "scheduled" || update["last_applied_version"] != "1.2.4" || update["next_check_at"] == nil {
-		t.Fatalf("update payload = %#v", update)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			lastCheck := time.Date(2026, 7, 11, 15, 0, 0, 0, time.UTC)
+			nextCheck := lastCheck.Add(24 * time.Hour)
+			deps := testDeps(t)
+			if err := deps.Hub.Publish(telemetry.Snapshot{
+				GeneratedAt: lastCheck,
+				Update: telemetry.Update{
+					Enabled:            true,
+					CheckIntervalHours: 24,
+					State:              "scheduled",
+					LastCheckAt:        &lastCheck,
+					LastAppliedVersion: "v1.2.4",
+					NextCheckAt:        &nextCheck,
+				},
+			}); err != nil {
+				t.Fatalf("Publish() error = %v", err)
+			}
+
+			server, err := web.NewServer(web.Config{Build: buildinfo.Info{Version: tt.version, Commit: tt.commit}}, deps)
+			if err != nil {
+				t.Fatalf("NewServer() error = %v", err)
+			}
+			payload := requestJSON(t, server, http.MethodGet, "/health", http.StatusOK)
+			if payload["version"] != tt.version || payload["commit"] != tt.commit {
+				t.Fatalf("running build = version %#v commit %#v, want %q %q", payload["version"], payload["commit"], tt.version, tt.commit)
+			}
+			update, ok := payload["update"].(map[string]any)
+			if !ok {
+				t.Fatalf("update payload = %#v, want object", payload["update"])
+			}
+			if update["state"] != "scheduled" || update["last_applied_version"] != "v1.2.4" || update["next_check_at"] == nil {
+				t.Fatalf("update payload = %#v", update)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## Summary

- expose the running process version and commit from the server build through `/health`
- project the same remote build under the existing `instance` object returned by `detent state`
- add a distinct remote-service build check to doctor while retaining the local executable check

Fixes #1777

## UI Surface Contract

- [x] N/A, or the linked issue explicitly authorizes any high-impact UI surface, layout, density, first-viewport, or responsive visibility tradeoff.
- [x] Persistent top-of-screen messaging is explicitly authorized by the issue, or this PR does not add it.
- [x] Visual changes to primary operator screens include screenshot or browser verification below.

## Test Plan

- [x] `make check`