### PR TITLE
fix(runner): surface tool failure activity

### DIFF
--- a/internal/codex/activity_test.go
+++ b/internal/codex/activity_test.go
@@ -1,6 +1,10 @@
 package codex
 
-import "testing"
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
 
 func TestUpdateFromMessageEmitsToolActivity(t *testing.T) {
 	t.Parallel()
@@ -14,6 +18,9 @@ func TestUpdateFromMessageEmitsToolActivity(t *testing.T) {
 		wantContent      string
 		wantErrorBody    string
 		wantErrorMessage string
+		wantOmitted      []string
+		wantMaxBytes     int
+		contentFromError bool
 	}{
 		{
 			name:        "command starts",
@@ -57,6 +64,28 @@ func TestUpdateFromMessageEmitsToolActivity(t *testing.T) {
 			wantErrorBody:    `{"message":"HTTP 502: upstream unavailable"}`,
 			wantErrorMessage: "HTTP 502: upstream unavailable",
 		},
+		{
+			name:             "failed mcp result sanitizes raw diagnostic fallback",
+			method:           "item/completed",
+			params:           `{"threadId":"thread-1","turnId":"turn-1","item":{"id":"item-4","type":"mcpToolCall","server":"codex_apps","tool":"github.create_pull_request","arguments":{"body":"Fixes #1775","credential":"argument-secret","message":"argument message"},"result":null,"error":null,"diagnostic":{"code":"mcp_elicitation_rejected","detail":{"message":"user rejected MCP tool call","httpStatus":403,"authorization":"Bearer secret","body":"private PR body"},"credentials":"connector-secret"},"status":"failed"}}`,
+			wantType:         UpdateToolCompleted,
+			wantTool:         "codex_apps/github.create_pull_request",
+			wantContent:      `{"code":"mcp_elicitation_rejected","message":"user rejected MCP tool call","http_status":403}`,
+			wantErrorMessage: `{"code":"mcp_elicitation_rejected","message":"user rejected MCP tool call","http_status":403}`,
+			wantOmitted:      []string{"Fixes #1775", "argument-secret", "argument message", "Bearer secret", "private PR body", "connector-secret", "authorization", "credentials"},
+			wantMaxBytes:     2048,
+		},
+		{
+			name:             "failed mcp result bounds raw diagnostic fallback",
+			method:           "item/completed",
+			params:           `{"threadId":"thread-1","turnId":"turn-1","item":{"id":"item-5","type":"mcpToolCall","server":"codex_apps","tool":"github.create_pull_request","result":null,"error":null,"diagnostic":{"code":"connector_failure","message":"` + strings.Repeat("x", 4096) + `","statusCode":502,"body":"private connector payload"},"status":"failed"}}`,
+			wantType:         UpdateToolCompleted,
+			wantTool:         "codex_apps/github.create_pull_request",
+			wantErrorMessage: `{"code":"connector_failure","message":"` + strings.Repeat("x", 64),
+			wantOmitted:      []string{"private connector payload"},
+			wantMaxBytes:     2048,
+			contentFromError: true,
+		},
 	}
 
 	for _, tt := range tests {
@@ -69,9 +98,28 @@ func TestUpdateFromMessageEmitsToolActivity(t *testing.T) {
 			if !ok {
 				t.Fatal("updateFromMessage() ok = false, want true")
 			}
-			if update.Type != tt.wantType || update.Tool != tt.wantTool || update.Delta != tt.wantContent ||
-				update.BackendErrorBody != tt.wantErrorBody || update.BackendErrorMessage != tt.wantErrorMessage {
+			if update.Type != tt.wantType || update.Tool != tt.wantTool || (!tt.contentFromError && update.Delta != tt.wantContent) ||
+				update.BackendErrorBody != tt.wantErrorBody || (tt.wantMaxBytes == 0 && update.BackendErrorMessage != tt.wantErrorMessage) {
 				t.Fatalf("update = %#v, want type %q tool %q content %q", update, tt.wantType, tt.wantTool, tt.wantContent)
+			}
+			if tt.contentFromError && update.Delta != update.BackendErrorMessage {
+				t.Fatalf("Delta = %q, want sanitized BackendErrorMessage %q", update.Delta, update.BackendErrorMessage)
+			}
+			if tt.wantMaxBytes > 0 {
+				if len(update.BackendErrorMessage) > tt.wantMaxBytes {
+					t.Fatalf("BackendErrorMessage bytes = %d, want <= %d", len(update.BackendErrorMessage), tt.wantMaxBytes)
+				}
+				if !strings.HasPrefix(update.BackendErrorMessage, tt.wantErrorMessage) {
+					t.Fatalf("BackendErrorMessage = %q, want prefix %q", update.BackendErrorMessage, tt.wantErrorMessage)
+				}
+				if !json.Valid([]byte(update.BackendErrorMessage)) {
+					t.Fatalf("BackendErrorMessage = %q, want valid JSON", update.BackendErrorMessage)
+				}
+			}
+			for _, omitted := range tt.wantOmitted {
+				if strings.Contains(update.BackendErrorMessage, omitted) {
+					t.Fatalf("BackendErrorMessage = %q, want %q omitted", update.BackendErrorMessage, omitted)
+				}
 			}
 		})
 	}

--- a/internal/codex/activity_test.go
+++ b/internal/codex/activity_test.go
@@ -86,6 +86,17 @@ func TestUpdateFromMessageEmitsToolActivity(t *testing.T) {
 			wantMaxBytes:     2048,
 			contentFromError: true,
 		},
+		{
+			name:             "failed mcp result skips compound sensitive containers",
+			method:           "item/completed",
+			params:           `{"threadId":"thread-1","turnId":"turn-1","item":{"id":"item-6","type":"mcpToolCall","server":"codex_apps","tool":"github.create_pull_request","result":null,"error":null,"diagnostic":{"code":"connector_failure","requestBody":{"message":"private request"},"authTokenData":{"message":"private token"},"clientSecretValue":{"message":"private secret"},"credentialEnvelope":{"message":"private credential"}},"status":"failed"}}`,
+			wantType:         UpdateToolCompleted,
+			wantTool:         "codex_apps/github.create_pull_request",
+			wantContent:      `{"code":"connector_failure"}`,
+			wantErrorMessage: `{"code":"connector_failure"}`,
+			wantOmitted:      []string{"private request", "private token", "private secret", "private credential"},
+			wantMaxBytes:     2048,
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/codex/appserver.go
+++ b/internal/codex/appserver.go
@@ -1887,12 +1887,14 @@ func toolFailureDiagnosticKey(key string) string {
 
 func toolFailureDiagnosticSensitiveKey(key string) bool {
 	key = strings.ToLower(strings.ReplaceAll(strings.ReplaceAll(strings.TrimSpace(key), "_", ""), "-", ""))
-	switch key {
-	case "aggregatedoutput", "arguments", "authorization", "body", "changes", "command", "credential", "credentials", "headers", "input", "payload", "request", "token", "tokens":
-		return true
-	default:
-		return false
+	for _, fragment := range []string{
+		"argument", "auth", "body", "command", "cookie", "credential", "header", "input", "password", "payload", "request", "secret", "token",
+	} {
+		if strings.Contains(key, fragment) {
+			return true
+		}
 	}
+	return key == "aggregatedoutput" || key == "changes"
 }
 
 func toolFailureDiagnosticKeyRank(key string) int {

--- a/internal/codex/appserver.go
+++ b/internal/codex/appserver.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -34,6 +35,8 @@ const (
 
 	defaultReadTimeout = 5 * time.Second
 	defaultTurnTimeout = time.Hour
+
+	maxToolFailureDiagnosticBytes = 2048
 )
 
 var (
@@ -1660,6 +1663,9 @@ func toolLifecycleUpdate(msg Message) (Update, bool, error) {
 				errorMessageFromJSON(params.Item.ContentItems),
 			)
 		}
+		if failedToolStatus(params.Item.Status) && errorMessage == "" {
+			errorMessage = toolFailureDiagnosticMessage(msg.Params)
+		}
 		content = firstNonBlank(
 			params.Item.AggregatedOutput,
 			errorMessage,
@@ -1788,6 +1794,190 @@ func errorMessageFromJSON(raw json.RawMessage) string {
 		return ""
 	}
 	return firstNonBlank(decoded.Message, decoded.Error.Message)
+}
+
+type toolFailureDiagnostic struct {
+	Code       string `json:"code,omitempty"`
+	Message    string `json:"message,omitempty"`
+	HTTPStatus int    `json:"http_status,omitempty"`
+}
+
+func toolFailureDiagnosticMessage(raw json.RawMessage) string {
+	decoder := json.NewDecoder(bytes.NewReader(raw))
+	decoder.UseNumber()
+	var value any
+	if err := decoder.Decode(&value); err != nil {
+		return ""
+	}
+	diagnostic := toolFailureDiagnostic{}
+	collectToolFailureDiagnostic(value, &diagnostic)
+	if diagnostic == (toolFailureDiagnostic{}) {
+		return ""
+	}
+	return marshalToolFailureDiagnostic(diagnostic)
+}
+
+func collectToolFailureDiagnostic(value any, diagnostic *toolFailureDiagnostic) {
+	if diagnostic == nil {
+		return
+	}
+	switch value := value.(type) {
+	case map[string]any:
+		keys := make([]string, 0, len(value))
+		for key := range value {
+			keys = append(keys, key)
+		}
+		sort.Slice(keys, func(i, j int) bool {
+			leftRank := toolFailureDiagnosticKeyRank(keys[i])
+			rightRank := toolFailureDiagnosticKeyRank(keys[j])
+			if leftRank != rightRank {
+				return leftRank < rightRank
+			}
+			return keys[i] < keys[j]
+		})
+		for _, key := range keys {
+			collectToolFailureDiagnosticField(key, value[key], diagnostic)
+		}
+		for _, key := range keys {
+			if toolFailureDiagnosticSensitiveKey(key) {
+				continue
+			}
+			collectToolFailureDiagnostic(value[key], diagnostic)
+		}
+	case []any:
+		for _, item := range value {
+			collectToolFailureDiagnostic(item, diagnostic)
+		}
+	}
+}
+
+func collectToolFailureDiagnosticField(key string, value any, diagnostic *toolFailureDiagnostic) {
+	switch toolFailureDiagnosticKey(key) {
+	case "code":
+		if diagnostic.Code == "" {
+			diagnostic.Code = toolFailureDiagnosticText(value)
+		}
+	case "message":
+		if diagnostic.Message == "" {
+			message, ok := value.(string)
+			if ok {
+				diagnostic.Message = strings.TrimSpace(message)
+			}
+		}
+	case "httpstatus":
+		if diagnostic.HTTPStatus == 0 {
+			diagnostic.HTTPStatus = toolFailureHTTPStatus(value)
+		}
+	}
+}
+
+func toolFailureDiagnosticKey(key string) string {
+	key = strings.ToLower(strings.ReplaceAll(strings.ReplaceAll(strings.TrimSpace(key), "_", ""), "-", ""))
+	switch key {
+	case "code", "errorcode":
+		return "code"
+	case "message", "errormessage":
+		return "message"
+	case "httpstatus", "statuscode", "status":
+		return "httpstatus"
+	default:
+		return ""
+	}
+}
+
+func toolFailureDiagnosticSensitiveKey(key string) bool {
+	key = strings.ToLower(strings.ReplaceAll(strings.ReplaceAll(strings.TrimSpace(key), "_", ""), "-", ""))
+	switch key {
+	case "aggregatedoutput", "arguments", "authorization", "body", "changes", "command", "credential", "credentials", "headers", "input", "payload", "request", "token", "tokens":
+		return true
+	default:
+		return false
+	}
+}
+
+func toolFailureDiagnosticKeyRank(key string) int {
+	switch strings.ToLower(strings.ReplaceAll(strings.ReplaceAll(strings.TrimSpace(key), "_", ""), "-", "")) {
+	case "error":
+		return 0
+	case "failure":
+		return 1
+	case "diagnostic", "diagnostics":
+		return 2
+	case "detail", "details":
+		return 3
+	case "result":
+		return 4
+	case "contentitems":
+		return 5
+	default:
+		return 6
+	}
+}
+
+func toolFailureDiagnosticText(value any) string {
+	switch value := value.(type) {
+	case string:
+		return strings.TrimSpace(value)
+	case json.Number:
+		return strings.TrimSpace(value.String())
+	default:
+		return ""
+	}
+}
+
+func toolFailureHTTPStatus(value any) int {
+	text := toolFailureDiagnosticText(value)
+	status, err := strconv.Atoi(text)
+	if err != nil || status < 100 || status > 599 {
+		return 0
+	}
+	return status
+}
+
+func marshalToolFailureDiagnostic(diagnostic toolFailureDiagnostic) string {
+	encoded, err := json.Marshal(diagnostic)
+	if err != nil {
+		return ""
+	}
+	if len(encoded) <= maxToolFailureDiagnosticBytes {
+		return string(encoded)
+	}
+	fitToolFailureDiagnosticField(&diagnostic, diagnostic.Message, func(value string) {
+		diagnostic.Message = value
+	})
+	encoded, err = json.Marshal(diagnostic)
+	if err != nil {
+		return ""
+	}
+	if len(encoded) <= maxToolFailureDiagnosticBytes {
+		return string(encoded)
+	}
+	fitToolFailureDiagnosticField(&diagnostic, diagnostic.Code, func(value string) {
+		diagnostic.Code = value
+	})
+	encoded, err = json.Marshal(diagnostic)
+	if err != nil || len(encoded) > maxToolFailureDiagnosticBytes {
+		return ""
+	}
+	return string(encoded)
+}
+
+func fitToolFailureDiagnosticField(diagnostic *toolFailureDiagnostic, value string, set func(string)) {
+	runes := []rune(value)
+	best := ""
+	for low, high := 0, len(runes); low <= high; {
+		middle := low + (high-low)/2
+		candidate := string(runes[:middle])
+		set(candidate)
+		encoded, err := json.Marshal(diagnostic)
+		if err == nil && len(encoded) <= maxToolFailureDiagnosticBytes {
+			best = candidate
+			low = middle + 1
+		} else {
+			high = middle - 1
+		}
+	}
+	set(best)
 }
 
 func looksLikeErrorEvent(raw json.RawMessage) bool {

--- a/internal/runner/activity_test.go
+++ b/internal/runner/activity_test.go
@@ -5,27 +5,72 @@ import (
 	"time"
 )
 
-func TestPublishAgentActivityForwardsFullToolOutput(t *testing.T) {
+func TestPublishAgentActivityContent(t *testing.T) {
 	t.Parallel()
 
-	var got AgentActivityUpdate
-	req := RunRequest{OnActivityUpdate: func(update AgentActivityUpdate) error {
-		got = update
-		return nil
-	}}
-	at := time.Date(2026, 7, 10, 15, 0, 0, 0, time.UTC)
-	err := publishAgentActivity(req, 1156, AgentUpdate{
-		Type:     AgentUpdateToolOutput,
-		ThreadID: "thread-1",
-		TurnID:   "turn-1",
-		ItemID:   "item-1",
-		Tool:     "exec_command",
-		Delta:    "complete command output",
-	}, at)
-	if err != nil {
-		t.Fatalf("publishAgentActivity() error = %v", err)
+	tests := []struct {
+		name        string
+		update      AgentUpdate
+		wantContent string
+	}{
+		{
+			name: "forwards full tool output",
+			update: AgentUpdate{
+				Type:     AgentUpdateToolOutput,
+				ThreadID: "thread-1",
+				TurnID:   "turn-1",
+				ItemID:   "item-1",
+				Tool:     "exec_command",
+				Delta:    "complete command output",
+			},
+			wantContent: "complete command output",
+		},
+		{
+			name: "forwards failed tool backend error",
+			update: AgentUpdate{
+				Type:                AgentUpdateToolCompleted,
+				ThreadID:            "thread-2",
+				TurnID:              "turn-2",
+				ItemID:              "item-2",
+				Tool:                "codex_apps/github.create_pull_request",
+				Delta:               "null",
+				Status:              "failed",
+				BackendErrorMessage: "user rejected MCP tool call",
+			},
+			wantContent: "user rejected MCP tool call",
+		},
+		{
+			name: "preserves successful tool content",
+			update: AgentUpdate{
+				Type:                AgentUpdateToolCompleted,
+				ThreadID:            "thread-3",
+				TurnID:              "turn-3",
+				ItemID:              "item-3",
+				Tool:                "codex_apps/github.create_pull_request",
+				Delta:               `{"url":"https://github.test/acme/widgets/pull/18"}`,
+				Status:              "completed",
+				BackendErrorMessage: "stale backend error",
+			},
+			wantContent: `{"url":"https://github.test/acme/widgets/pull/18"}`,
+		},
 	}
-	if got.DetentSessionID != 1156 || got.ProviderSessionID != "thread-1" || got.Type != AgentUpdateToolOutput || got.Tool != "exec_command" || got.Content != "complete command output" || got.At != at {
-		t.Fatalf("activity update = %#v", got)
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			var got AgentActivityUpdate
+			req := RunRequest{OnActivityUpdate: func(update AgentActivityUpdate) error {
+				got = update
+				return nil
+			}}
+			at := time.Date(2026, 7, 10, 15, 0, 0, 0, time.UTC)
+			err := publishAgentActivity(req, 1156, tt.update, at)
+			if err != nil {
+				t.Fatalf("publishAgentActivity() error = %v", err)
+			}
+			if got.DetentSessionID != 1156 || got.ProviderSessionID != tt.update.ThreadID || got.Type != tt.update.Type || got.Tool != tt.update.Tool || got.Content != tt.wantContent || got.At != at {
+				t.Fatalf("activity update = %#v, want content %q", got, tt.wantContent)
+			}
+		})
 	}
 }

--- a/internal/runner/agent.go
+++ b/internal/runner/agent.go
@@ -3447,6 +3447,12 @@ func publishAgentActivity(req RunRequest, detentSessionID int64, update AgentUpd
 	if req.OnActivityUpdate == nil {
 		return nil
 	}
+	content := update.Delta
+	if update.Type == AgentUpdateToolCompleted && failedAgentToolStatus(update.Status) {
+		if message := meaningfulDeliverableDetail(update.BackendErrorMessage); message != "" {
+			content = message
+		}
+	}
 	return req.OnActivityUpdate(AgentActivityUpdate{
 		At:                at.UTC(),
 		DetentSessionID:   detentSessionID,
@@ -3455,11 +3461,20 @@ func publishAgentActivity(req RunRequest, detentSessionID int64, update AgentUpd
 		ItemID:            strings.TrimSpace(update.ItemID),
 		Type:              update.Type,
 		Tool:              strings.TrimSpace(update.Tool),
-		Content:           update.Delta,
+		Content:           content,
 		Status:            strings.TrimSpace(update.Status),
 		Model:             strings.TrimSpace(update.Model),
 		TotalTokens:       update.Tokens.TotalTokens,
 	})
+}
+
+func failedAgentToolStatus(status string) bool {
+	switch strings.ToLower(strings.TrimSpace(status)) {
+	case "failed", "error", "cancelled", "canceled", "timed_out":
+		return true
+	default:
+		return false
+	}
 }
 
 func (r *Runner) liveDiffStats(

--- a/internal/runner/runner_test.go
+++ b/internal/runner/runner_test.go
@@ -824,6 +824,11 @@ func TestDeliverableCommandErrorNeverReportsNullDetail(t *testing.T) {
 			},
 			want: []string{"status=failed"},
 		},
+		{
+			name: "no detail",
+			err:  &DeliverableCommandError{Operation: "codex_apps/github.create_pull_request"},
+			want: []string{"detail=no error detail returned"},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
## Summary

- Show failed tool backend messages in the in-memory live session activity feed instead of opaque result content such as `null`.
- Derive a valid-JSON diagnostic fallback from allowlisted code, message, and HTTP status fields, capped at 2,048 bytes while excluding request bodies, arguments, credentials, headers, and tokens.
- Preserve successful tool activity and the existing durable terminal error fallback.

Fixes #1775

## UI Surface Contract

- [x] N/A, or the linked issue explicitly authorizes any high-impact UI surface, layout, density, first-viewport, or responsive visibility tradeoff.
- [x] Persistent top-of-screen messaging is explicitly authorized by the issue, or this PR does not add it.
- [x] Visual changes to primary operator screens include screenshot or browser verification below. N/A: this changes existing live activity content only; no layout or template changed.

## Test Plan

- [x] `go test ./internal/codex ./internal/runner -count=1`
- [x] `make check` (race tests, 78.9% aggregate coverage, package/file floors)
