### PR TITLE
feat(notify): deliver health transitions

### DIFF
--- a/db/queries/store.sql
+++ b/db/queries/store.sql
@@ -962,6 +962,21 @@ SELECT *
 FROM project_dispatch_status
 WHERE project_id = ?;
 
+-- name: ListHealthNotificationStates :many
+SELECT *
+FROM health_notification_states
+ORDER BY identity;
+
+-- name: UpsertHealthNotificationState :exec
+INSERT INTO health_notification_states (
+  identity,
+  state_json,
+  updated_at
+) VALUES (?, ?, ?)
+ON CONFLICT(identity) DO UPDATE SET
+  state_json = excluded.state_json,
+  updated_at = excluded.updated_at;
+
 -- name: ListIssueActivityEvents :many
 WITH issue_events AS (
   SELECT

--- a/docs/config.md
+++ b/docs/config.md
@@ -43,6 +43,9 @@ Runtime settings resolve in this order: explicit flag, environment variable,
 | Private dashboard URL | | | `dashboard_access` | disabled |
 | Web port | `--port` | `PORT` | `port` | `4000` |
 | Instance name | | | `instance_name` | short hostname |
+| Health webhook | | | `notifications.health.webhook.url` | disabled |
+| Health notification debounce | | | `notifications.health.debounce_seconds` | `300` |
+| Health webhook timeout | | | `notifications.health.webhook.timeout_ms` | `5000` |
 | Automatic update checks | | | `update.auto_check_enabled` | `false` |
 | Update check interval | | | `update.check_interval_hours` | `6` |
 | Automatic update apply when idle | | | `update.auto_apply_enabled` | `false` |
@@ -74,6 +77,42 @@ from the first non-empty value in this order: top-level `instance_name` in
 single-project fallback mode without `global.yaml`, workflow top-level
 `identity.name` is used before the short hostname. Names are trimmed, must be a
 single line, and are capped at 40 characters in the web UI.
+
+Health notifications deliver fleet and project needs-attention transitions to
+one generic webhook. They are disabled when
+`notifications.health.webhook.url` is absent, preserving the silent default.
+Configure the host-wide channel in `global.yaml`:
+
+```yaml
+notifications:
+  health:
+    debounce_seconds: 300
+    webhook:
+      url: https://alerts.example.com/detent
+      headers:
+        Authorization: Bearer replace-me
+      timeout_ms: 5000
+```
+
+The five-minute default debounce applies independently to entry and recovery.
+Project identities are stable per project and cause, currently
+`ci_unavailable` and `dispatch_stall`; a separate fleet identity represents
+the aggregate transition while any project cause remains active. A flap that
+clears before the debounce expires emits neither entry nor recovery. Once an
+entry is emitted, exactly one recovery is emitted after the identity remains
+healthy for the debounce window.
+
+Webhook payloads use event name `detent.health.transition` and include a stable
+event ID, host and instance names, scope, optional project ID, entered state,
+causes, optional wait reasons, and entry timestamps. Delivery state and pending
+events are stored in the runtime SQLite database before sending, so a restart
+does not re-fire active conditions or discard unsent transitions. Failed sends
+retry at most five times with exponential backoff starting at 30 seconds and
+capped at 15 minutes. Every failure is logged and appears in
+`health_notification_failures` on `/health`; `detent doctor` reports both
+retrying and exhausted deliveries. Notification configuration changes require
+a restart. Treat configured headers as secrets and keep host-specific values
+out of checked-in project configuration.
 
 Automatic update checks are host-specific and disabled by default. When
 enabled, Detent persists the last check and schedules the next jittered check

--- a/internal/cli/boot.go
+++ b/internal/cli/boot.go
@@ -29,8 +29,10 @@ import (
 	globalconfig "github.com/digitaldrywood/detent/internal/config/global"
 	"github.com/digitaldrywood/detent/internal/connector"
 	"github.com/digitaldrywood/detent/internal/connector/memory"
+	"github.com/digitaldrywood/detent/internal/healthnotify"
 	"github.com/digitaldrywood/detent/internal/hub"
 	"github.com/digitaldrywood/detent/internal/instancelock"
+	"github.com/digitaldrywood/detent/internal/notify"
 	"github.com/digitaldrywood/detent/internal/orchestrator"
 	"github.com/digitaldrywood/detent/internal/procgroup"
 	"github.com/digitaldrywood/detent/internal/project"
@@ -323,6 +325,10 @@ func startRunningWithDependencies(ctx context.Context, cfg BootConfig, deps star
 
 	snapshotHub := hub.New[telemetry.Snapshot]()
 	snapshotSeq := &atomic.Uint64{}
+	healthNotifications, err := newHealthNotificationManager(cfg.Global, runtimeStore, logger)
+	if err != nil {
+		return err
+	}
 	updateScheduler, err := newRuntimeUpdateScheduler(cfg, logger, func(ctx context.Context) (func(), bool) {
 		return runtimeUpdateIdleReservation(ctx, manager.Registry(), globalDispatchGate)
 	})
@@ -366,6 +372,11 @@ func startRunningWithDependencies(ctx context.Context, cfg BootConfig, deps star
 	resourceWorkers.Go(func() {
 		publishSnapshots(runCtx, manager.Registry(), globalDispatchGate, snapshotHub, snapshotSeq, cfg.Shutdown, runtimeStore, displayURL, defaultSnapshotInterval, time.Now, updateScheduler)
 	})
+	if healthNotifications.Enabled() {
+		resourceWorkers.Go(func() {
+			healthNotifications.Run(runCtx, snapshotHub, manager.Registry().Health)
+		})
+	}
 	go republishSnapshotsOnProjectEvents(runCtx, events, snapshotHub, logger) // #nosec G118 -- runCtx is the service-lifetime context canceled during shutdown.
 	resourceWorkers.Go(func() {
 		persistBoardSnapshots(runCtx, snapshotHub, boardSnapshotStore, deps.boardSnapshotInterval, logger)
@@ -390,18 +401,19 @@ func startRunningWithDependencies(ctx context.Context, cfg BootConfig, deps star
 			Clock: isolatedDemoClock(cfg),
 		},
 	}, web.Dependencies{
-		Hub:            snapshotHub,
-		Store:          runtimeStore,
-		Registry:       manager.Registry(),
-		Connector:      firstConnector(manager),
-		Refresher:      refresherForRegistry(manager.Registry()),
-		OperatorMoves:  registryRefresher{registry: manager.Registry()},
-		Recovery:       recoveryForRegistry(manager.Registry()),
-		RunStopper:     registryRefresher{registry: manager.Registry()},
-		UpdateApplier:  updateScheduler,
-		Activity:       activityBroker,
-		Chat:           chatProvider,
-		IssueExplainer: newIssueExplainer(snapshotHub, runtimeStore),
+		Hub:                 snapshotHub,
+		Store:               runtimeStore,
+		Registry:            manager.Registry(),
+		Connector:           firstConnector(manager),
+		Refresher:           refresherForRegistry(manager.Registry()),
+		OperatorMoves:       registryRefresher{registry: manager.Registry()},
+		Recovery:            recoveryForRegistry(manager.Registry()),
+		RunStopper:          registryRefresher{registry: manager.Registry()},
+		UpdateApplier:       updateScheduler,
+		Activity:            activityBroker,
+		Chat:                chatProvider,
+		IssueExplainer:      newIssueExplainer(snapshotHub, runtimeStore),
+		HealthNotifications: healthNotifications,
 	})
 	if err != nil {
 		return err
@@ -523,6 +535,41 @@ func startRunningWithDependencies(ctx context.Context, cfg BootConfig, deps star
 			return serve(ctx, server, listener)
 		})
 	})
+}
+
+func newHealthNotificationManager(cfg globalconfig.Config, stateStore store.HealthNotificationStateStore, logger *slog.Logger) (*healthnotify.Manager, error) {
+	health := cfg.Notifications.Health
+	if strings.TrimSpace(health.Webhook.URL) == "" {
+		return healthnotify.NewManager(healthnotify.Config{}, healthnotify.Dependencies{})
+	}
+	hostname, err := os.Hostname()
+	if err != nil {
+		if logger != nil {
+			logger.Warn("resolve health notification hostname failed", "error", err)
+		}
+		hostname = ""
+	}
+	instance := strings.TrimSpace(cfg.InstanceName)
+	if instance == "" {
+		instance = strings.TrimSpace(cfg.Global.Identity.Name)
+	}
+	if instance == "" {
+		instance = strings.TrimSpace(strings.SplitN(hostname, ".", 2)[0])
+	}
+	manager, err := healthnotify.NewManager(healthnotify.Config{
+		Webhook: notify.WebhookConfig{
+			URL:     health.Webhook.URL,
+			Headers: health.Webhook.Headers,
+			Timeout: health.Webhook.Timeout(),
+		},
+		Instance: instance,
+		Host:     hostname,
+		Debounce: health.Debounce(),
+	}, healthnotify.Dependencies{Store: stateStore, Logger: logger})
+	if err != nil {
+		return nil, fmt.Errorf("configure health notifications: %w", err)
+	}
+	return manager, nil
 }
 
 type sessionProjectBackfiller interface {

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -28,6 +28,7 @@ import (
 	globalconfig "github.com/digitaldrywood/detent/internal/config/global"
 	"github.com/digitaldrywood/detent/internal/connector"
 	ghconnector "github.com/digitaldrywood/detent/internal/connector/github"
+	"github.com/digitaldrywood/detent/internal/healthnotify"
 	"github.com/digitaldrywood/detent/internal/telemetry"
 )
 
@@ -47,32 +48,33 @@ const (
 )
 
 type doctorCheck struct {
-	Name                      string                                     `json:"name"`
-	Status                    doctorStatus                               `json:"status"`
-	Detail                    string                                     `json:"detail"`
-	Hint                      string                                     `json:"hint,omitempty"`
-	BinaryResolution          *doctorBinaryResolution                    `json:"binary_resolution,omitempty"`
-	WorkflowSkillSuggestions  []doctorWorkflowSkillSuggestion            `json:"workflow_skill_suggestions,omitempty"`
-	AutoPromoteCandidates     []doctorAutoPromoteCandidateDiagnostic     `json:"auto_promote_candidates,omitempty"`
-	BlockedRecoveryCandidates []doctorBlockedRecoveryCandidateDiagnostic `json:"blocked_recovery_candidates,omitempty"`
-	PermanentlyHeldRecoveries []doctorBlockedRecoveryCandidateDiagnostic `json:"permanently_held_recoveries,omitempty"`
-	BlockedWithoutRecovery    []doctorBlockedRecoveryCandidateDiagnostic `json:"blocked_without_recovery,omitempty"`
-	BackendCapacity           []doctorBackendCapacityDiagnostic          `json:"backend_capacity,omitempty"`
-	ArtifactGateConvergence   []doctorArtifactGateConvergenceDiagnostic  `json:"artifact_gate_convergence,omitempty"`
-	ValidatorFailures         []doctorValidatorFailureDiagnostic         `json:"validator_failures,omitempty"`
-	Routines                  []doctorRoutineDiagnostic                  `json:"routines,omitempty"`
-	BacklogAdmission          *doctorAdmissionDiagnostic                 `json:"backlog_admission,omitempty"`
-	OverloadRetriesLastHour   int                                        `json:"overload_retries_last_hour,omitempty"`
-	DependencyCapabilities    []connector.DependencyCapability           `json:"dependency_capabilities,omitempty"`
-	StalenessWarnings         []telemetry.StalenessWarning               `json:"staleness_warnings,omitempty"`
-	StrandedIssues            []telemetry.StrandedIssue                  `json:"stranded_active_issues,omitempty"`
-	DispatchStalls            []telemetry.DispatchStatus                 `json:"dispatch_stalls,omitempty"`
-	UntrackedIssues           []doctorStatusDriftIssueDiagnostic         `json:"untracked_issues,omitempty"`
-	OpenTerminalIssues        []doctorStatusDriftIssueDiagnostic         `json:"open_terminal_issues,omitempty"`
-	OwnershipAttention        []doctorOwnershipAttentionDiagnostic       `json:"ownership_attention,omitempty"`
-	ProjectDefinition         *doctorProjectDefinitionDiagnostic         `json:"project_definition,omitempty"`
-	Capabilities              *doctorCapabilityReport                    `json:"capabilities,omitempty"`
-	WorkflowOptimization      doctorWorkflowOptimizationReport           `json:"-"`
+	Name                       string                                     `json:"name"`
+	Status                     doctorStatus                               `json:"status"`
+	Detail                     string                                     `json:"detail"`
+	Hint                       string                                     `json:"hint,omitempty"`
+	BinaryResolution           *doctorBinaryResolution                    `json:"binary_resolution,omitempty"`
+	WorkflowSkillSuggestions   []doctorWorkflowSkillSuggestion            `json:"workflow_skill_suggestions,omitempty"`
+	AutoPromoteCandidates      []doctorAutoPromoteCandidateDiagnostic     `json:"auto_promote_candidates,omitempty"`
+	BlockedRecoveryCandidates  []doctorBlockedRecoveryCandidateDiagnostic `json:"blocked_recovery_candidates,omitempty"`
+	PermanentlyHeldRecoveries  []doctorBlockedRecoveryCandidateDiagnostic `json:"permanently_held_recoveries,omitempty"`
+	BlockedWithoutRecovery     []doctorBlockedRecoveryCandidateDiagnostic `json:"blocked_without_recovery,omitempty"`
+	BackendCapacity            []doctorBackendCapacityDiagnostic          `json:"backend_capacity,omitempty"`
+	ArtifactGateConvergence    []doctorArtifactGateConvergenceDiagnostic  `json:"artifact_gate_convergence,omitempty"`
+	ValidatorFailures          []doctorValidatorFailureDiagnostic         `json:"validator_failures,omitempty"`
+	Routines                   []doctorRoutineDiagnostic                  `json:"routines,omitempty"`
+	BacklogAdmission           *doctorAdmissionDiagnostic                 `json:"backlog_admission,omitempty"`
+	OverloadRetriesLastHour    int                                        `json:"overload_retries_last_hour,omitempty"`
+	DependencyCapabilities     []connector.DependencyCapability           `json:"dependency_capabilities,omitempty"`
+	StalenessWarnings          []telemetry.StalenessWarning               `json:"staleness_warnings,omitempty"`
+	StrandedIssues             []telemetry.StrandedIssue                  `json:"stranded_active_issues,omitempty"`
+	DispatchStalls             []telemetry.DispatchStatus                 `json:"dispatch_stalls,omitempty"`
+	HealthNotificationFailures []healthnotify.Failure                     `json:"health_notification_failures,omitempty"`
+	UntrackedIssues            []doctorStatusDriftIssueDiagnostic         `json:"untracked_issues,omitempty"`
+	OpenTerminalIssues         []doctorStatusDriftIssueDiagnostic         `json:"open_terminal_issues,omitempty"`
+	OwnershipAttention         []doctorOwnershipAttentionDiagnostic       `json:"ownership_attention,omitempty"`
+	ProjectDefinition          *doctorProjectDefinitionDiagnostic         `json:"project_definition,omitempty"`
+	Capabilities               *doctorCapabilityReport                    `json:"capabilities,omitempty"`
+	WorkflowOptimization       doctorWorkflowOptimizationReport           `json:"-"`
 }
 
 type doctorProjectDefinitionDiagnostic struct {
@@ -535,6 +537,12 @@ func runDoctor(ctx context.Context, cfg doctorConfig, opts options, deps doctorD
 			Name: "Fleet staleness",
 			Run: func(jobCtx context.Context) []doctorCheck {
 				return []doctorCheck{checkDoctorFleetStaleness(jobCtx, boot, cfg.ProjectID, deps)}
+			},
+		},
+		doctorCheckJob{
+			Name: "Health notification delivery",
+			Run: func(jobCtx context.Context) []doctorCheck {
+				return []doctorCheck{checkDoctorHealthNotificationDelivery(jobCtx, boot, cfg.ProjectID, deps)}
 			},
 		},
 		doctorCheckJob{

--- a/internal/cli/doctor_environment.go
+++ b/internal/cli/doctor_environment.go
@@ -18,6 +18,7 @@ import (
 	"github.com/digitaldrywood/detent/internal/codex"
 	workflowconfig "github.com/digitaldrywood/detent/internal/config"
 	globalconfig "github.com/digitaldrywood/detent/internal/config/global"
+	"github.com/digitaldrywood/detent/internal/healthnotify"
 	"github.com/digitaldrywood/detent/internal/instancelock"
 	commandshell "github.com/digitaldrywood/detent/internal/shell"
 	"github.com/digitaldrywood/detent/internal/telemetry"
@@ -814,18 +815,19 @@ type doctorHealthProbe struct {
 }
 
 type doctorHealthResponse struct {
-	Status            string                       `json:"status"`
-	Version           string                       `json:"version"`
-	Commit            string                       `json:"commit"`
-	Mode              string                       `json:"mode"`
-	Checks            map[string]string            `json:"checks"`
-	Environment       doctorHealthEnvironment      `json:"environment"`
-	Budgets           []doctorHealthBudget         `json:"budgets"`
-	Workflows         []doctorHealthWorkflow       `json:"workflows"`
-	StalenessWarnings []telemetry.StalenessWarning `json:"staleness_warnings"`
-	StrandedIssues    []telemetry.StrandedIssue    `json:"stranded_active_issues"`
-	Dispatch          telemetry.DispatchStatus     `json:"dispatch"`
-	DispatchStalls    []telemetry.DispatchStatus   `json:"dispatch_stalls"`
+	Status                     string                       `json:"status"`
+	Version                    string                       `json:"version"`
+	Commit                     string                       `json:"commit"`
+	Mode                       string                       `json:"mode"`
+	Checks                     map[string]string            `json:"checks"`
+	Environment                doctorHealthEnvironment      `json:"environment"`
+	Budgets                    []doctorHealthBudget         `json:"budgets"`
+	Workflows                  []doctorHealthWorkflow       `json:"workflows"`
+	StalenessWarnings          []telemetry.StalenessWarning `json:"staleness_warnings"`
+	StrandedIssues             []telemetry.StrandedIssue    `json:"stranded_active_issues"`
+	Dispatch                   telemetry.DispatchStatus     `json:"dispatch"`
+	DispatchStalls             []telemetry.DispatchStatus   `json:"dispatch_stalls"`
+	HealthNotificationFailures []healthnotify.Failure       `json:"health_notification_failures"`
 }
 
 func checkDoctorDetentService(ctx context.Context, cfg BootConfig, deps doctorDeps) []doctorCheck {

--- a/internal/cli/doctor_health_notifications.go
+++ b/internal/cli/doctor_health_notifications.go
@@ -1,0 +1,69 @@
+package cli
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/digitaldrywood/detent/internal/healthnotify"
+)
+
+func checkDoctorHealthNotificationDelivery(ctx context.Context, boot BootConfig, projectID string, deps doctorDeps) doctorCheck {
+	check := doctorCheck{
+		Name:   "Health notification delivery",
+		Status: doctorOK,
+		Detail: "no health notification delivery failures",
+	}
+	found, err := readDoctorHealthNotificationFailures(ctx, doctorLiveBoot(boot, &boot.Global), deps)
+	if err != nil {
+		check.Detail = "live notification check skipped because no healthy Detent instance was reachable"
+		return check
+	}
+	projectID = strings.TrimSpace(projectID)
+	failures := make([]healthnotify.Failure, 0, len(found))
+	for _, failure := range found {
+		if projectID == "" || strings.TrimSpace(failure.ProjectID) == "" || strings.TrimSpace(failure.ProjectID) == projectID {
+			failures = append(failures, failure)
+		}
+	}
+	if len(failures) == 0 {
+		return check
+	}
+	check.Status = doctorWarn
+	check.HealthNotificationFailures = failures
+	exhausted := 0
+	for _, failure := range failures {
+		if failure.FailedAt != nil || failure.Attempts >= failure.MaxAttempts {
+			exhausted++
+		}
+	}
+	check.Detail = fmt.Sprintf("%d health notification delivery failure(s), %d exhausted bounded retry", len(failures), exhausted)
+	check.Hint = "Restore the configured webhook receiver, then restart Detent or wait for the next retry; exhausted events remain visible for operator review."
+	return check
+}
+
+func readDoctorHealthNotificationFailures(ctx context.Context, boot BootConfig, deps doctorDeps) ([]healthnotify.Failure, error) {
+	request, err := http.NewRequestWithContext(ctx, http.MethodGet, doctorHealthProbeURL(boot), nil)
+	if err != nil {
+		return nil, err
+	}
+	response, err := deps.httpDo(request)
+	if err != nil {
+		return nil, err
+	}
+	defer response.Body.Close()
+	if response.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("health returned HTTP %d", response.StatusCode)
+	}
+	var health doctorHealthResponse
+	if err := json.NewDecoder(response.Body).Decode(&health); err != nil {
+		return nil, err
+	}
+	if strings.TrimSpace(health.Mode) == "" || !doctorHealthHasDetentChecks(health.Checks) {
+		return nil, errors.New("response was not Detent health")
+	}
+	return health.HealthNotificationFailures, nil
+}

--- a/internal/cli/doctor_health_notifications_test.go
+++ b/internal/cli/doctor_health_notifications_test.go
@@ -1,0 +1,44 @@
+package cli
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+func TestCheckDoctorHealthNotificationDelivery(t *testing.T) {
+	t.Parallel()
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, _ *http.Request) {
+		writer.Header().Set("Content-Type", "application/json")
+		_, _ = writer.Write([]byte(`{
+			"status":"needs_attention",
+			"mode":"running",
+			"checks":{"hub":"configured","store":"configured","registry":"configured","connector":"configured"},
+			"health_notification_failures":[
+				{"event_id":"health-1","identity":"project:detent:dispatch_stall","scope":"project","project_id":"detent","transition":"entry","attempts":5,"max_attempts":5,"last_error":"receiver unavailable","failed_at":"2026-08-13T18:00:00Z"},
+				{"event_id":"health-2","identity":"fleet","scope":"fleet","transition":"entry","attempts":1,"max_attempts":5,"last_error":"receiver unavailable","next_attempt_at":"2026-08-13T18:01:00Z"}
+			]
+		}`))
+	}))
+	t.Cleanup(server.Close)
+	host, portText := splitStalenessTestServerAddress(t, server)
+	port, err := strconv.Atoi(portText)
+	if err != nil {
+		t.Fatalf("parse server port: %v", err)
+	}
+
+	check := checkDoctorHealthNotificationDelivery(t.Context(), BootConfig{Host: host, Port: &port}, "detent", doctorDeps{httpDo: server.Client().Do}.withDefaults())
+	if check.Status != doctorWarn || len(check.HealthNotificationFailures) != 2 {
+		t.Fatalf("check = %#v, want project and fleet failures", check)
+	}
+	if !strings.Contains(check.Detail, "1 exhausted") {
+		t.Fatalf("detail = %q, want exhausted count", check.Detail)
+	}
+
+	filtered := checkDoctorHealthNotificationDelivery(t.Context(), BootConfig{Host: host, Port: &port}, "other", doctorDeps{httpDo: server.Client().Do}.withDefaults())
+	if filtered.Status != doctorWarn || len(filtered.HealthNotificationFailures) != 1 || filtered.HealthNotificationFailures[0].Scope != "fleet" {
+		t.Fatalf("filtered = %#v, want fleet failure", filtered)
+	}
+}

--- a/internal/cli/global_reload.go
+++ b/internal/cli/global_reload.go
@@ -276,7 +276,7 @@ func changedGlobalConfigFields(previous globalconfig.Config, next globalconfig.C
 		fields = append(fields, globalConfigChange{Field: "port", RequiresRestart: true})
 	}
 	if previous.InstanceName != next.InstanceName {
-		fields = append(fields, globalConfigChange{Field: "instance_name", Old: previous.InstanceName, New: next.InstanceName})
+		fields = append(fields, globalConfigChange{Field: "instance_name", RequiresRestart: true})
 	}
 	if !reflect.DeepEqual(previous.Notifications, next.Notifications) {
 		fields = append(fields, globalConfigChange{Field: "notifications", RequiresRestart: true})
@@ -306,7 +306,7 @@ func changedGlobalSettings(previous globalconfig.Settings, next globalconfig.Set
 		fields = append(fields, globalConfigChange{Field: "global.active_hours", Old: previous.ActiveHours, New: next.ActiveHours})
 	}
 	if !reflect.DeepEqual(previous.Identity, next.Identity) {
-		fields = append(fields, globalConfigChange{Field: "global.identity", Old: previous.Identity, New: next.Identity})
+		fields = append(fields, globalConfigChange{Field: "global.identity", RequiresRestart: true})
 	}
 	if !reflect.DeepEqual(previous.FairShare, next.FairShare) {
 		fields = append(fields, globalConfigChange{Field: "global.fair_share", Old: previous.FairShare, New: next.FairShare})

--- a/internal/cli/global_reload.go
+++ b/internal/cli/global_reload.go
@@ -278,6 +278,9 @@ func changedGlobalConfigFields(previous globalconfig.Config, next globalconfig.C
 	if previous.InstanceName != next.InstanceName {
 		fields = append(fields, globalConfigChange{Field: "instance_name", Old: previous.InstanceName, New: next.InstanceName})
 	}
+	if !reflect.DeepEqual(previous.Notifications, next.Notifications) {
+		fields = append(fields, globalConfigChange{Field: "notifications", RequiresRestart: true})
+	}
 	if !reflect.DeepEqual(previous.Auth, next.Auth) {
 		fields = append(fields, globalConfigChange{Field: "auth", RequiresRestart: true})
 	}

--- a/internal/cli/global_reload_test.go
+++ b/internal/cli/global_reload_test.go
@@ -241,7 +241,7 @@ func TestChangedGlobalConfigFieldsReloadClassification(t *testing.T) {
 		}},
 		{name: "dashboard write access", field: "dashboard_access.allow_write", mutate: func(cfg *globalconfig.Config) { cfg.DashboardAccess.AllowWrite = true }},
 		{name: "port", field: "port", requiresRestart: true, mutate: func(cfg *globalconfig.Config) { value := 4101; cfg.Port = &value }},
-		{name: "instance name", field: "instance_name", mutate: func(cfg *globalconfig.Config) { cfg.InstanceName = "buildbox" }},
+		{name: "instance name", field: "instance_name", requiresRestart: true, mutate: func(cfg *globalconfig.Config) { cfg.InstanceName = "buildbox" }},
 		{name: "notifications", field: "notifications", requiresRestart: true, mutate: func(cfg *globalconfig.Config) {
 			cfg.Notifications.Health.Webhook.URL = "https://alerts.example.test/detent"
 		}},
@@ -255,7 +255,7 @@ func TestChangedGlobalConfigFieldsReloadClassification(t *testing.T) {
 		{name: "active hours", field: "global.active_hours", mutate: func(cfg *globalconfig.Config) {
 			cfg.Global.ActiveHours = &activehours.Config{Timezone: "UTC", Windows: []string{"Mon-Sun 22:00-06:00"}}
 		}},
-		{name: "identity", field: "global.identity", mutate: func(cfg *globalconfig.Config) {
+		{name: "identity", field: "global.identity", requiresRestart: true, mutate: func(cfg *globalconfig.Config) {
 			cfg.Global.Identity = globalconfig.Identity{Name: "new-worker", GitHubLogin: "new-bot"}
 		}},
 		{name: "fair share", field: "global.fair_share", mutate: func(cfg *globalconfig.Config) { cfg.Global.FairShare = map[string]any{"half_life": "2h"} }},

--- a/internal/cli/global_reload_test.go
+++ b/internal/cli/global_reload_test.go
@@ -242,6 +242,9 @@ func TestChangedGlobalConfigFieldsReloadClassification(t *testing.T) {
 		{name: "dashboard write access", field: "dashboard_access.allow_write", mutate: func(cfg *globalconfig.Config) { cfg.DashboardAccess.AllowWrite = true }},
 		{name: "port", field: "port", requiresRestart: true, mutate: func(cfg *globalconfig.Config) { value := 4101; cfg.Port = &value }},
 		{name: "instance name", field: "instance_name", mutate: func(cfg *globalconfig.Config) { cfg.InstanceName = "buildbox" }},
+		{name: "notifications", field: "notifications", requiresRestart: true, mutate: func(cfg *globalconfig.Config) {
+			cfg.Notifications.Health.Webhook.URL = "https://alerts.example.test/detent"
+		}},
 		{name: "projects", field: "projects", mutate: func(cfg *globalconfig.Config) { cfg.Projects = []globalconfig.Project{{ID: "bravo", Weight: 2}} }},
 		{name: "project pool", field: "projects", mutate: func(cfg *globalconfig.Config) { cfg.Projects[0].Pool = "video" }},
 		{name: "maximum concurrent agents", field: "global.max_concurrent_agents", mutate: func(cfg *globalconfig.Config) { cfg.Global.MaxConcurrentAgents = 4 }},

--- a/internal/config/global/config.go
+++ b/internal/config/global/config.go
@@ -75,6 +75,7 @@ type Config struct {
 	DashboardAccess       DashboardAccess `yaml:"dashboard_access,omitempty"`
 	Port                  *int            `yaml:"port,omitempty"`
 	InstanceName          string          `yaml:"instance_name,omitempty"`
+	Notifications         Notifications   `yaml:"notifications,omitempty"`
 	Update                Update          `yaml:"update,omitempty"`
 	Auth                  Auth            `yaml:"auth,omitempty"`
 	Global                Settings        `yaml:"global"`
@@ -640,6 +641,7 @@ func (c Config) Validate(opts ...Option) error {
 	if strings.ContainsAny(c.APIToken, "\r\n") {
 		problems = append(problems, "api_token: must be a single line")
 	}
+	problems = append(problems, c.Notifications.Validate()...)
 	problems = append(problems, dashboardAccessProblems(c.DashboardAccess)...)
 	if c.Update.CheckIntervalHours < 0 {
 		problems = append(problems, "update.check_interval_hours: must be a positive integer")
@@ -948,6 +950,7 @@ func validateRaw(attrs map[string]any, opts options) []string {
 	problems = append(problems, dashboardAccessRawErrors(attrs["dashboard_access"])...)
 	problems = append(problems, optionalStringTypeError(attrs, "instance_name")...)
 	problems = append(problems, optionalSingleLineStringError(attrs, "instance_name")...)
+	problems = append(problems, notificationsRawErrors(attrs["notifications"])...)
 	problems = append(problems, optionalNonNegativeIntegerError(attrs["port"], "port")...)
 	problems = append(problems, updateErrors(attrs["update"])...)
 	problems = append(problems, authErrors(attrs["auth"])...)
@@ -1732,6 +1735,10 @@ func build(attrs map[string]any, path string, opts options) (Config, error) {
 	if err != nil {
 		return Config{}, buildValidationError(path, err)
 	}
+	notifications, err := buildNotifications(attrs["notifications"])
+	if err != nil {
+		return Config{}, buildValidationError(path, err)
+	}
 	port, err := optionalIntPointer(attrs["port"], "port")
 	if err != nil {
 		return Config{}, buildValidationError(path, err)
@@ -1767,6 +1774,7 @@ func build(attrs map[string]any, path string, opts options) (Config, error) {
 		DashboardAccess:       dashboardAccess,
 		Port:                  port,
 		InstanceName:          instanceName,
+		Notifications:         notifications,
 		Update:                update,
 		Auth:                  auth,
 		Global:                settings,

--- a/internal/config/global/notifications.go
+++ b/internal/config/global/notifications.go
@@ -1,0 +1,155 @@
+package global
+
+import (
+	"fmt"
+	"net/url"
+	"strings"
+	"time"
+)
+
+const (
+	DefaultHealthNotificationDebounceSeconds = 300
+	DefaultNotificationWebhookTimeoutMS      = 5000
+)
+
+type Notifications struct {
+	Health HealthNotifications `yaml:"health,omitempty"`
+}
+
+type HealthNotifications struct {
+	DebounceSeconds int                 `yaml:"debounce_seconds,omitempty"`
+	Webhook         NotificationWebhook `yaml:"webhook,omitempty"`
+}
+
+type NotificationWebhook struct {
+	URL       string            `yaml:"url,omitempty"`
+	Headers   map[string]string `yaml:"headers,omitempty"`
+	TimeoutMS int               `yaml:"timeout_ms,omitempty"`
+}
+
+func (n Notifications) IsZero() bool {
+	return n.Health.IsZero()
+}
+
+func (h HealthNotifications) IsZero() bool {
+	return h.DebounceSeconds == 0 && h.Webhook.IsZero()
+}
+
+func (w NotificationWebhook) IsZero() bool {
+	return strings.TrimSpace(w.URL) == "" && len(w.Headers) == 0 && w.TimeoutMS == 0
+}
+
+func (h HealthNotifications) Debounce() time.Duration {
+	if h.DebounceSeconds <= 0 {
+		return time.Duration(DefaultHealthNotificationDebounceSeconds) * time.Second
+	}
+	return time.Duration(h.DebounceSeconds) * time.Second
+}
+
+func (w NotificationWebhook) Timeout() time.Duration {
+	if w.TimeoutMS <= 0 {
+		return time.Duration(DefaultNotificationWebhookTimeoutMS) * time.Millisecond
+	}
+	return time.Duration(w.TimeoutMS) * time.Millisecond
+}
+
+func (n Notifications) Validate() []string {
+	var problems []string
+	health := n.Health
+	if health.DebounceSeconds < 0 {
+		problems = append(problems, "notifications.health.debounce_seconds must be greater than 0")
+	}
+	webhook := health.Webhook
+	webhook.URL = strings.TrimSpace(webhook.URL)
+	if webhook.URL == "" {
+		if len(webhook.Headers) > 0 || webhook.TimeoutMS != 0 {
+			problems = append(problems, "notifications.health.webhook.url is required when webhook settings are configured")
+		}
+		return problems
+	}
+	parsed, err := url.Parse(webhook.URL)
+	if err != nil || !parsed.IsAbs() || (parsed.Scheme != "http" && parsed.Scheme != "https") || strings.TrimSpace(parsed.Host) == "" {
+		problems = append(problems, "notifications.health.webhook.url must be an absolute http or https URL")
+	}
+	if webhook.TimeoutMS < 0 {
+		problems = append(problems, "notifications.health.webhook.timeout_ms must be greater than 0")
+	}
+	return problems
+}
+
+func notificationsRawErrors(value any) []string {
+	if value == nil {
+		return nil
+	}
+	attrs, ok := value.(map[string]any)
+	if !ok {
+		return []string{"notifications: must be a mapping"}
+	}
+	healthValue, configured := attrs["health"]
+	if !configured || healthValue == nil {
+		return nil
+	}
+	health, ok := healthValue.(map[string]any)
+	if !ok {
+		return []string{"notifications.health: must be a mapping"}
+	}
+	var problems []string
+	if debounce, configured := health["debounce_seconds"]; configured && !positiveInteger(debounce) {
+		problems = append(problems, "notifications.health.debounce_seconds: must be a positive integer")
+	}
+	problems = append(problems, notificationWebhookRawErrors(health["webhook"])...)
+	return problems
+}
+
+func notificationWebhookRawErrors(value any) []string {
+	if value == nil {
+		return nil
+	}
+	attrs, ok := value.(map[string]any)
+	if !ok {
+		return []string{"notifications.health.webhook: must be a mapping"}
+	}
+	var problems []string
+	problems = append(problems, optionalStringTypeError(attrs, "url")...)
+	if timeout, configured := attrs["timeout_ms"]; configured && !positiveInteger(timeout) {
+		problems = append(problems, "notifications.health.webhook.timeout_ms: must be a positive integer")
+	}
+	if headersValue, configured := attrs["headers"]; configured {
+		headers, ok := headersValue.(map[string]any)
+		if !ok {
+			problems = append(problems, "notifications.health.webhook.headers: must be a mapping")
+		} else {
+			for name, value := range headers {
+				if _, ok := value.(string); !ok {
+					problems = append(problems, fmt.Sprintf("notifications.health.webhook.headers.%s: must be a string", name))
+				}
+			}
+		}
+	}
+	return problems
+}
+
+func buildNotifications(value any) (Notifications, error) {
+	if value == nil {
+		return Notifications{}, nil
+	}
+	if _, err := mapValue(value, "notifications"); err != nil {
+		return Notifications{}, err
+	}
+	var notifications Notifications
+	if err := decodeYAMLValue(value, &notifications); err != nil {
+		return Notifications{}, fmt.Errorf("notifications: %w", err)
+	}
+	notifications.Health.Webhook.URL = strings.TrimSpace(notifications.Health.Webhook.URL)
+	if len(notifications.Health.Webhook.Headers) > 0 {
+		headers := make(map[string]string, len(notifications.Health.Webhook.Headers))
+		for name, value := range notifications.Health.Webhook.Headers {
+			name = strings.TrimSpace(name)
+			if name != "" {
+				headers[name] = strings.TrimSpace(value)
+			}
+		}
+		notifications.Health.Webhook.Headers = headers
+	}
+	return notifications, nil
+}

--- a/internal/config/global/notifications_test.go
+++ b/internal/config/global/notifications_test.go
@@ -1,0 +1,55 @@
+package global
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestHealthNotificationConfig(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name         string
+		yaml         string
+		wantErr      string
+		wantDebounce time.Duration
+		wantTimeout  time.Duration
+	}{
+		{
+			name:         "configured webhook",
+			yaml:         "notifications:\n  health:\n    debounce_seconds: 30\n    webhook:\n      url: https://alerts.example.test/detent\n      headers:\n        Authorization: Bearer example\n      timeout_ms: 1200\n",
+			wantDebounce: 30 * time.Second,
+			wantTimeout:  1200 * time.Millisecond,
+		},
+		{
+			name:         "omitted uses documented defaults",
+			wantDebounce: time.Duration(DefaultHealthNotificationDebounceSeconds) * time.Second,
+			wantTimeout:  time.Duration(DefaultNotificationWebhookTimeoutMS) * time.Millisecond,
+		},
+		{name: "relative URL", yaml: "notifications:\n  health:\n    webhook:\n      url: /alerts\n", wantErr: "absolute http or https URL"},
+		{name: "zero debounce", yaml: "notifications:\n  health:\n    debounce_seconds: 0\n", wantErr: "must be a positive integer"},
+		{name: "non-string header", yaml: "notifications:\n  health:\n    webhook:\n      url: https://alerts.example.test\n      headers:\n        Attempts: 3\n", wantErr: "must be a string"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			raw := []byte("apiVersion: detent/v1\nkind: GlobalConfig\nglobal:\n  max_concurrent_agents: 1\n  scheduling: weighted\nprojects: []\n" + tt.yaml)
+			cfg, err := Parse(raw, "/tmp/global.yaml", WithProjectPathLiterals())
+			if tt.wantErr != "" {
+				if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
+					t.Fatalf("Parse() error = %v, want containing %q", err, tt.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("Parse() error = %v", err)
+			}
+			if got := cfg.Notifications.Health.Debounce(); got != tt.wantDebounce {
+				t.Fatalf("Debounce() = %s, want %s", got, tt.wantDebounce)
+			}
+			if got := cfg.Notifications.Health.Webhook.Timeout(); got != tt.wantTimeout {
+				t.Fatalf("Timeout() = %s, want %s", got, tt.wantTimeout)
+			}
+		})
+	}
+}

--- a/internal/healthnotify/manager.go
+++ b/internal/healthnotify/manager.go
@@ -206,6 +206,7 @@ func (m *Manager) Reconcile(ctx context.Context, snapshot telemetry.Snapshot, he
 		return err
 	}
 	observed := map[string]struct{}{}
+	changed := map[string]*durableState{}
 	for _, current := range observations(snapshot, health) {
 		observed[current.Identity] = struct{}{}
 		state := states[current.Identity]
@@ -217,21 +218,26 @@ func (m *Manager) Reconcile(ctx context.Context, snapshot telemetry.Snapshot, he
 				ProjectID: current.ProjectID,
 			}
 			states[current.Identity] = state
+			changed[current.Identity] = state
 		}
-		m.applyObservation(state, current, now)
+		if m.applyObservation(state, current, now) {
+			changed[current.Identity] = state
+		}
 	}
 	for identity, state := range states {
 		if _, ok := observed[identity]; ok || (!state.StableActive && (state.Pending == nil || !state.Pending.Active)) {
 			continue
 		}
-		m.applyObservation(state, observation{
+		if m.applyObservation(state, observation{
 			Identity:  identity,
 			Scope:     state.Scope,
 			ProjectID: state.ProjectID,
 			State:     unknownProjectRecoveryStatus,
-		}, now)
+		}, now) {
+			changed[identity] = state
+		}
 	}
-	if err := m.saveStates(ctx, states, now); err != nil {
+	if err := m.saveStates(ctx, changed, now); err != nil {
 		return err
 	}
 	return m.deliverDue(ctx, states, now)
@@ -271,13 +277,16 @@ func (m *Manager) Failures(ctx context.Context) ([]Failure, error) {
 	return failures, nil
 }
 
-func (m *Manager) applyObservation(state *durableState, current observation, now time.Time) {
+func (m *Manager) applyObservation(state *durableState, current observation, now time.Time) bool {
+	deliveryCount := len(state.Deliveries)
 	state.Deliveries = slices.DeleteFunc(state.Deliveries, func(delivery deliveryState) bool {
 		return delivery.DeliveredAt != nil
 	})
+	changed := len(state.Deliveries) != deliveryCount
 	if current.Active == state.StableActive {
+		changed = changed || state.Pending != nil
 		state.Pending = nil
-		return
+		return changed
 	}
 	if state.Pending == nil || state.Pending.Active != current.Active {
 		state.Pending = &pendingState{
@@ -287,13 +296,18 @@ func (m *Manager) applyObservation(state *durableState, current observation, now
 			WaitReasons: compactSorted(current.WaitReasons),
 			Since:       now,
 		}
-		return
+		return true
 	}
-	state.Pending.State = current.State
-	state.Pending.Causes = compactSorted(current.Causes)
-	state.Pending.WaitReasons = compactSorted(current.WaitReasons)
+	causes := compactSorted(current.Causes)
+	waitReasons := compactSorted(current.WaitReasons)
+	if state.Pending.State != current.State || !slices.Equal(state.Pending.Causes, causes) || !slices.Equal(state.Pending.WaitReasons, waitReasons) {
+		changed = true
+		state.Pending.State = current.State
+		state.Pending.Causes = causes
+		state.Pending.WaitReasons = waitReasons
+	}
 	if now.Before(state.Pending.Since.Add(m.cfg.Debounce)) {
-		return
+		return changed
 	}
 	pending := *state.Pending
 	state.Pending = nil
@@ -303,12 +317,13 @@ func (m *Manager) applyObservation(state *durableState, current observation, now
 		state.Causes = append([]string(nil), pending.Causes...)
 		state.WaitReasons = append([]string(nil), pending.WaitReasons...)
 		state.Deliveries = append(state.Deliveries, deliveryState{Event: m.event(state, TransitionEntry, pending.State, pending.Since, pending.Since, now)})
-		return
+		return true
 	}
 	state.Deliveries = append(state.Deliveries, deliveryState{Event: m.event(state, TransitionRecovery, pending.State, pending.Since, state.NeedsAttentionEnteredAt, now)})
 	state.NeedsAttentionEnteredAt = time.Time{}
 	state.Causes = nil
 	state.WaitReasons = nil
+	return true
 }
 
 func (m *Manager) event(state *durableState, transition string, enteredState string, enteredAt time.Time, attentionEnteredAt time.Time, observedAt time.Time) Event {
@@ -338,6 +353,7 @@ func eventID(identity string, transition string, enteredAt time.Time) string {
 
 func (m *Manager) deliverDue(ctx context.Context, states map[string]*durableState, now time.Time) error {
 	type queued struct {
+		state    *durableState
 		delivery *deliveryState
 	}
 	queue := []queued{}
@@ -347,7 +363,7 @@ func (m *Manager) deliverDue(ctx context.Context, states map[string]*durableStat
 			if delivery.DeliveredAt != nil || delivery.FailedAt != nil || (delivery.NextAttemptAt != nil && now.Before(*delivery.NextAttemptAt)) {
 				continue
 			}
-			queue = append(queue, queued{delivery: delivery})
+			queue = append(queue, queued{state: state, delivery: delivery})
 		}
 	}
 	slices.SortFunc(queue, func(left queued, right queued) int {
@@ -359,9 +375,9 @@ func (m *Manager) deliverDue(ctx context.Context, states map[string]*durableStat
 	if len(queue) > maxDeliveriesPerCycle {
 		queue = queue[:maxDeliveriesPerCycle]
 	}
-	changed := false
+	changed := map[string]*durableState{}
 	for _, item := range queue {
-		changed = true
+		changed[item.state.Identity] = item.state
 		delivery := item.delivery
 		delivery.Attempts++
 		attemptedAt := now
@@ -384,10 +400,7 @@ func (m *Manager) deliverDue(ctx context.Context, states map[string]*durableStat
 		delivery.FailedAt = nil
 		delivery.LastError = ""
 	}
-	if !changed {
-		return nil
-	}
-	return m.saveStates(ctx, states, now)
+	return m.saveStates(ctx, changed, now)
 }
 
 func (m *Manager) retryDelay(attempts int) time.Duration {
@@ -424,6 +437,9 @@ func (m *Manager) loadStates(ctx context.Context) (map[string]*durableState, err
 }
 
 func (m *Manager) saveStates(ctx context.Context, states map[string]*durableState, now time.Time) error {
+	if len(states) == 0 {
+		return nil
+	}
 	identities := make([]string, 0, len(states))
 	for identity := range states {
 		identities = append(identities, identity)

--- a/internal/healthnotify/manager.go
+++ b/internal/healthnotify/manager.go
@@ -1,0 +1,456 @@
+package healthnotify
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log/slog"
+	"slices"
+	"strings"
+	"time"
+
+	"github.com/digitaldrywood/detent/internal/hub"
+	"github.com/digitaldrywood/detent/internal/notify"
+	"github.com/digitaldrywood/detent/internal/project"
+	"github.com/digitaldrywood/detent/internal/store"
+	"github.com/digitaldrywood/detent/internal/telemetry"
+)
+
+const (
+	SchemaVersion           = 1
+	EventName               = "detent.health.transition"
+	DefaultDebounce         = 5 * time.Minute
+	defaultMaxAttempts      = 5
+	defaultRetryBase        = 30 * time.Second
+	defaultRetryMax         = 15 * time.Minute
+	maxDeliveriesPerCycle   = 10
+	healthNotifierUserAgent = "detent-health-notifier"
+)
+
+type Config struct {
+	Webhook     notify.WebhookConfig
+	Instance    string
+	Host        string
+	Debounce    time.Duration
+	MaxAttempts int
+	RetryBase   time.Duration
+	RetryMax    time.Duration
+}
+
+type Dependencies struct {
+	Store  store.HealthNotificationStateStore
+	Sender notify.Sender
+	Logger *slog.Logger
+}
+
+type Event struct {
+	Schema                  int       `json:"schema"`
+	Event                   string    `json:"event"`
+	ID                      string    `json:"id"`
+	Identity                string    `json:"identity"`
+	Transition              string    `json:"transition"`
+	Instance                string    `json:"instance"`
+	Host                    string    `json:"host"`
+	Scope                   string    `json:"scope"`
+	ProjectID               string    `json:"project_id,omitempty"`
+	State                   string    `json:"state"`
+	Causes                  []string  `json:"causes,omitempty"`
+	WaitReasons             []string  `json:"wait_reasons,omitempty"`
+	EnteredAt               time.Time `json:"entered_at"`
+	NeedsAttentionEnteredAt time.Time `json:"needs_attention_entered_at"`
+	ObservedAt              time.Time `json:"observed_at"`
+}
+
+type Failure struct {
+	EventID       string     `json:"event_id"`
+	Identity      string     `json:"identity"`
+	Scope         string     `json:"scope"`
+	ProjectID     string     `json:"project_id,omitempty"`
+	Transition    string     `json:"transition"`
+	Attempts      int        `json:"attempts"`
+	MaxAttempts   int        `json:"max_attempts"`
+	LastError     string     `json:"last_error"`
+	NextAttemptAt *time.Time `json:"next_attempt_at,omitempty"`
+	FailedAt      *time.Time `json:"failed_at,omitempty"`
+}
+
+type FailureReader interface {
+	Failures(context.Context) ([]Failure, error)
+}
+
+type Manager struct {
+	cfg    Config
+	store  store.HealthNotificationStateStore
+	sender notify.Sender
+	logger *slog.Logger
+}
+
+type durableState struct {
+	Schema                  int             `json:"schema"`
+	Identity                string          `json:"identity"`
+	Scope                   string          `json:"scope"`
+	ProjectID               string          `json:"project_id,omitempty"`
+	StableActive            bool            `json:"stable_active"`
+	Pending                 *pendingState   `json:"pending,omitempty"`
+	NeedsAttentionEnteredAt time.Time       `json:"needs_attention_entered_at,omitzero"`
+	Causes                  []string        `json:"causes,omitempty"`
+	WaitReasons             []string        `json:"wait_reasons,omitempty"`
+	Deliveries              []deliveryState `json:"deliveries,omitempty"`
+}
+
+type pendingState struct {
+	Active      bool      `json:"active"`
+	State       string    `json:"state"`
+	Causes      []string  `json:"causes,omitempty"`
+	WaitReasons []string  `json:"wait_reasons,omitempty"`
+	Since       time.Time `json:"since"`
+}
+
+type deliveryState struct {
+	Event         Event      `json:"event"`
+	Attempts      int        `json:"attempts"`
+	LastAttemptAt *time.Time `json:"last_attempt_at,omitempty"`
+	NextAttemptAt *time.Time `json:"next_attempt_at,omitempty"`
+	DeliveredAt   *time.Time `json:"delivered_at,omitempty"`
+	FailedAt      *time.Time `json:"failed_at,omitempty"`
+	LastError     string     `json:"last_error,omitempty"`
+}
+
+func NewManager(cfg Config, deps Dependencies) (*Manager, error) {
+	if strings.TrimSpace(cfg.Webhook.URL) == "" {
+		return &Manager{}, nil
+	}
+	if deps.Store == nil {
+		return nil, errors.New("health notification state store is required")
+	}
+	if cfg.Debounce <= 0 {
+		cfg.Debounce = DefaultDebounce
+	}
+	if cfg.MaxAttempts <= 0 {
+		cfg.MaxAttempts = defaultMaxAttempts
+	}
+	if cfg.RetryBase <= 0 {
+		cfg.RetryBase = defaultRetryBase
+	}
+	if cfg.RetryMax <= 0 {
+		cfg.RetryMax = defaultRetryMax
+	}
+	sender := deps.Sender
+	if sender == nil {
+		cfg.Webhook.UserAgent = healthNotifierUserAgent
+		webhook, err := notify.NewWebhook(cfg.Webhook)
+		if err != nil {
+			return nil, fmt.Errorf("configure health notification webhook: %w", err)
+		}
+		sender = webhook
+	}
+	logger := deps.Logger
+	if logger == nil {
+		logger = slog.Default()
+	}
+	return &Manager{cfg: cfg, store: deps.Store, sender: sender, logger: logger}, nil
+}
+
+func (m *Manager) Enabled() bool {
+	return m != nil && m.sender != nil && m.store != nil
+}
+
+func (m *Manager) Run(ctx context.Context, snapshots *hub.Hub[telemetry.Snapshot], healthSource func() []project.Health) {
+	if !m.Enabled() || snapshots == nil {
+		return
+	}
+	subscription, err := snapshots.Subscribe(ctx)
+	if err != nil {
+		if ctx.Err() == nil {
+			m.logger.Error("subscribe health notifications failed", "error", err)
+		}
+		return
+	}
+	defer subscription.Close()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case snapshot, ok := <-subscription.C():
+			if !ok {
+				return
+			}
+			if snapshot.LastKnown || snapshot.Seq == 0 {
+				continue
+			}
+			health := []project.Health(nil)
+			if healthSource != nil {
+				health = healthSource()
+			}
+			now := snapshot.GeneratedAt.UTC()
+			if now.IsZero() {
+				now = time.Now().UTC()
+			}
+			if err := m.Reconcile(ctx, snapshot, health, now); err != nil && ctx.Err() == nil {
+				m.logger.Error("reconcile health notifications failed", "error", err)
+			}
+		}
+	}
+}
+
+func (m *Manager) Reconcile(ctx context.Context, snapshot telemetry.Snapshot, health []project.Health, now time.Time) error {
+	if !m.Enabled() {
+		return nil
+	}
+	now = now.UTC()
+	states, err := m.loadStates(ctx)
+	if err != nil {
+		return err
+	}
+	observed := map[string]struct{}{}
+	for _, current := range observations(snapshot, health) {
+		observed[current.Identity] = struct{}{}
+		state := states[current.Identity]
+		if state == nil {
+			state = &durableState{
+				Schema:    SchemaVersion,
+				Identity:  current.Identity,
+				Scope:     current.Scope,
+				ProjectID: current.ProjectID,
+			}
+			states[current.Identity] = state
+		}
+		m.applyObservation(state, current, now)
+	}
+	for identity, state := range states {
+		if _, ok := observed[identity]; ok || (!state.StableActive && (state.Pending == nil || !state.Pending.Active)) {
+			continue
+		}
+		m.applyObservation(state, observation{
+			Identity:  identity,
+			Scope:     state.Scope,
+			ProjectID: state.ProjectID,
+			State:     unknownProjectRecoveryStatus,
+		}, now)
+	}
+	if err := m.saveStates(ctx, states, now); err != nil {
+		return err
+	}
+	return m.deliverDue(ctx, states, now)
+}
+
+func (m *Manager) Failures(ctx context.Context) ([]Failure, error) {
+	if !m.Enabled() {
+		return nil, nil
+	}
+	states, err := m.loadStates(ctx)
+	if err != nil {
+		return nil, err
+	}
+	failures := []Failure{}
+	for _, state := range states {
+		for _, delivery := range state.Deliveries {
+			if delivery.DeliveredAt != nil || strings.TrimSpace(delivery.LastError) == "" {
+				continue
+			}
+			failures = append(failures, Failure{
+				EventID:       delivery.Event.ID,
+				Identity:      delivery.Event.Identity,
+				Scope:         delivery.Event.Scope,
+				ProjectID:     delivery.Event.ProjectID,
+				Transition:    delivery.Event.Transition,
+				Attempts:      delivery.Attempts,
+				MaxAttempts:   m.cfg.MaxAttempts,
+				LastError:     delivery.LastError,
+				NextAttemptAt: cloneTime(delivery.NextAttemptAt),
+				FailedAt:      cloneTime(delivery.FailedAt),
+			})
+		}
+	}
+	slices.SortFunc(failures, func(left Failure, right Failure) int {
+		return strings.Compare(left.EventID, right.EventID)
+	})
+	return failures, nil
+}
+
+func (m *Manager) applyObservation(state *durableState, current observation, now time.Time) {
+	state.Deliveries = slices.DeleteFunc(state.Deliveries, func(delivery deliveryState) bool {
+		return delivery.DeliveredAt != nil
+	})
+	if current.Active == state.StableActive {
+		state.Pending = nil
+		return
+	}
+	if state.Pending == nil || state.Pending.Active != current.Active {
+		state.Pending = &pendingState{
+			Active:      current.Active,
+			State:       current.State,
+			Causes:      compactSorted(current.Causes),
+			WaitReasons: compactSorted(current.WaitReasons),
+			Since:       now,
+		}
+		return
+	}
+	state.Pending.State = current.State
+	state.Pending.Causes = compactSorted(current.Causes)
+	state.Pending.WaitReasons = compactSorted(current.WaitReasons)
+	if now.Before(state.Pending.Since.Add(m.cfg.Debounce)) {
+		return
+	}
+	pending := *state.Pending
+	state.Pending = nil
+	state.StableActive = pending.Active
+	if pending.Active {
+		state.NeedsAttentionEnteredAt = pending.Since
+		state.Causes = append([]string(nil), pending.Causes...)
+		state.WaitReasons = append([]string(nil), pending.WaitReasons...)
+		state.Deliveries = append(state.Deliveries, deliveryState{Event: m.event(state, TransitionEntry, pending.State, pending.Since, pending.Since, now)})
+		return
+	}
+	state.Deliveries = append(state.Deliveries, deliveryState{Event: m.event(state, TransitionRecovery, pending.State, pending.Since, state.NeedsAttentionEnteredAt, now)})
+	state.NeedsAttentionEnteredAt = time.Time{}
+	state.Causes = nil
+	state.WaitReasons = nil
+}
+
+func (m *Manager) event(state *durableState, transition string, enteredState string, enteredAt time.Time, attentionEnteredAt time.Time, observedAt time.Time) Event {
+	return Event{
+		Schema:                  SchemaVersion,
+		Event:                   EventName,
+		ID:                      eventID(state.Identity, transition, attentionEnteredAt),
+		Identity:                state.Identity,
+		Transition:              transition,
+		Instance:                strings.TrimSpace(m.cfg.Instance),
+		Host:                    strings.TrimSpace(m.cfg.Host),
+		Scope:                   state.Scope,
+		ProjectID:               state.ProjectID,
+		State:                   strings.TrimSpace(enteredState),
+		Causes:                  append([]string(nil), state.Causes...),
+		WaitReasons:             append([]string(nil), state.WaitReasons...),
+		EnteredAt:               enteredAt.UTC(),
+		NeedsAttentionEnteredAt: attentionEnteredAt.UTC(),
+		ObservedAt:              observedAt.UTC(),
+	}
+}
+
+func eventID(identity string, transition string, enteredAt time.Time) string {
+	sum := sha256.Sum256([]byte(identity + "\x00" + transition + "\x00" + enteredAt.UTC().Format(time.RFC3339Nano)))
+	return "health-" + hex.EncodeToString(sum[:12])
+}
+
+func (m *Manager) deliverDue(ctx context.Context, states map[string]*durableState, now time.Time) error {
+	type queued struct {
+		delivery *deliveryState
+	}
+	queue := []queued{}
+	for _, state := range states {
+		for index := range state.Deliveries {
+			delivery := &state.Deliveries[index]
+			if delivery.DeliveredAt != nil || delivery.FailedAt != nil || (delivery.NextAttemptAt != nil && now.Before(*delivery.NextAttemptAt)) {
+				continue
+			}
+			queue = append(queue, queued{delivery: delivery})
+		}
+	}
+	slices.SortFunc(queue, func(left queued, right queued) int {
+		if compared := left.delivery.Event.EnteredAt.Compare(right.delivery.Event.EnteredAt); compared != 0 {
+			return compared
+		}
+		return strings.Compare(left.delivery.Event.ID, right.delivery.Event.ID)
+	})
+	if len(queue) > maxDeliveriesPerCycle {
+		queue = queue[:maxDeliveriesPerCycle]
+	}
+	changed := false
+	for _, item := range queue {
+		changed = true
+		delivery := item.delivery
+		delivery.Attempts++
+		attemptedAt := now
+		delivery.LastAttemptAt = &attemptedAt
+		if err := m.sender.Send(ctx, delivery.Event); err != nil {
+			delivery.LastError = err.Error()
+			if delivery.Attempts >= m.cfg.MaxAttempts {
+				delivery.FailedAt = &attemptedAt
+				delivery.NextAttemptAt = nil
+				m.logger.Error("health notification delivery exhausted", "event_id", delivery.Event.ID, "identity", delivery.Event.Identity, "attempts", delivery.Attempts, "error", err)
+			} else {
+				nextAttemptAt := now.Add(m.retryDelay(delivery.Attempts))
+				delivery.NextAttemptAt = &nextAttemptAt
+				m.logger.Warn("health notification delivery failed", "event_id", delivery.Event.ID, "identity", delivery.Event.Identity, "attempt", delivery.Attempts, "next_attempt_at", nextAttemptAt, "error", err)
+			}
+			continue
+		}
+		delivery.DeliveredAt = &attemptedAt
+		delivery.NextAttemptAt = nil
+		delivery.FailedAt = nil
+		delivery.LastError = ""
+	}
+	if !changed {
+		return nil
+	}
+	return m.saveStates(ctx, states, now)
+}
+
+func (m *Manager) retryDelay(attempts int) time.Duration {
+	delay := m.cfg.RetryBase
+	for attempt := 1; attempt < attempts && delay < m.cfg.RetryMax; attempt++ {
+		delay *= 2
+	}
+	if delay > m.cfg.RetryMax {
+		return m.cfg.RetryMax
+	}
+	return delay
+}
+
+func (m *Manager) loadStates(ctx context.Context) (map[string]*durableState, error) {
+	records, err := m.store.ListHealthNotificationStates(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("load health notification states: %w", err)
+	}
+	states := make(map[string]*durableState, len(records))
+	for _, record := range records {
+		var state durableState
+		if err := json.Unmarshal(record.StateJSON, &state); err != nil {
+			return nil, fmt.Errorf("decode health notification state %s: %w", record.Identity, err)
+		}
+		if state.Schema != SchemaVersion {
+			return nil, fmt.Errorf("health notification state %s has unsupported schema %d", record.Identity, state.Schema)
+		}
+		if strings.TrimSpace(state.Identity) != strings.TrimSpace(record.Identity) {
+			return nil, fmt.Errorf("health notification state identity %q does not match record %q", state.Identity, record.Identity)
+		}
+		states[state.Identity] = &state
+	}
+	return states, nil
+}
+
+func (m *Manager) saveStates(ctx context.Context, states map[string]*durableState, now time.Time) error {
+	identities := make([]string, 0, len(states))
+	for identity := range states {
+		identities = append(identities, identity)
+	}
+	slices.Sort(identities)
+	records := make([]store.HealthNotificationState, 0, len(identities))
+	for _, identity := range identities {
+		encoded, err := json.Marshal(states[identity])
+		if err != nil {
+			return fmt.Errorf("encode health notification state %s: %w", identity, err)
+		}
+		records = append(records, store.HealthNotificationState{
+			Identity:  identity,
+			StateJSON: encoded,
+			UpdatedAt: now,
+		})
+	}
+	if err := m.store.SaveHealthNotificationStates(ctx, records); err != nil {
+		return fmt.Errorf("save health notification states: %w", err)
+	}
+	return nil
+}
+
+func cloneTime(value *time.Time) *time.Time {
+	if value == nil {
+		return nil
+	}
+	cloned := *value
+	return &cloned
+}

--- a/internal/healthnotify/manager_test.go
+++ b/internal/healthnotify/manager_test.go
@@ -310,6 +310,23 @@ func TestManagerDeliveryRetriesAreBoundedAndSurfaced(t *testing.T) {
 	}
 }
 
+func TestManagerSkipsUnchangedStateWrites(t *testing.T) {
+	t.Parallel()
+	now := time.Date(2026, 8, 13, 18, 0, 0, 0, time.UTC)
+	stateStore := newMemoryStateStore()
+	manager := newTestManager(t, stateStore, &recordingSender{}, Config{Debounce: 10 * time.Minute})
+	health := readyHealth("detent")
+
+	managerReconcile(t, manager, telemetry.Snapshot{}, health, now)
+	if got := stateStore.SaveCalls(); got != 1 {
+		t.Fatalf("save calls after initial observation = %d, want 1", got)
+	}
+	managerReconcile(t, manager, telemetry.Snapshot{}, health, now.Add(time.Second))
+	if got := stateStore.SaveCalls(); got != 1 {
+		t.Fatalf("save calls after unchanged observation = %d, want 1", got)
+	}
+}
+
 func TestNewManagerUnconfiguredIsSilent(t *testing.T) {
 	t.Parallel()
 	manager, err := NewManager(Config{}, Dependencies{})
@@ -325,8 +342,9 @@ func TestNewManagerUnconfiguredIsSilent(t *testing.T) {
 }
 
 type memoryStateStore struct {
-	mu      sync.Mutex
-	records map[string]store.HealthNotificationState
+	mu        sync.Mutex
+	records   map[string]store.HealthNotificationState
+	saveCalls int
 }
 
 func newMemoryStateStore() *memoryStateStore {
@@ -347,11 +365,18 @@ func (s *memoryStateStore) ListHealthNotificationStates(context.Context) ([]stor
 func (s *memoryStateStore) SaveHealthNotificationStates(_ context.Context, records []store.HealthNotificationState) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
+	s.saveCalls++
 	for _, record := range records {
 		record.StateJSON = append([]byte(nil), record.StateJSON...)
 		s.records[record.Identity] = record
 	}
 	return nil
+}
+
+func (s *memoryStateStore) SaveCalls() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.saveCalls
 }
 
 type recordingSender struct {

--- a/internal/healthnotify/manager_test.go
+++ b/internal/healthnotify/manager_test.go
@@ -1,0 +1,428 @@
+package healthnotify
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"slices"
+	"sync"
+	"testing"
+	"time"
+
+	globalconfig "github.com/digitaldrywood/detent/internal/config/global"
+	"github.com/digitaldrywood/detent/internal/notify"
+	"github.com/digitaldrywood/detent/internal/project"
+	"github.com/digitaldrywood/detent/internal/store"
+	"github.com/digitaldrywood/detent/internal/telemetry"
+)
+
+func TestManagerDeliversConfiguredWebhook(t *testing.T) {
+	t.Parallel()
+	received := make(chan Event, 2)
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		if got := request.Header.Get("User-Agent"); got != healthNotifierUserAgent {
+			t.Errorf("User-Agent = %q, want %q", got, healthNotifierUserAgent)
+		}
+		var event Event
+		if err := json.NewDecoder(request.Body).Decode(&event); err != nil {
+			t.Errorf("decode event: %v", err)
+		}
+		received <- event
+		writer.WriteHeader(http.StatusNoContent)
+	}))
+	t.Cleanup(server.Close)
+	stateStore := newMemoryStateStore()
+	manager, err := NewManager(Config{
+		Webhook:  notify.WebhookConfig{URL: server.URL, Timeout: time.Second},
+		Instance: "buildbox",
+		Host:     "buildbox.example.test",
+		Debounce: time.Second,
+	}, Dependencies{Store: stateStore, Logger: slog.New(slog.NewTextHandler(io.Discard, nil))})
+	if err != nil {
+		t.Fatalf("NewManager() error = %v", err)
+	}
+	now := time.Date(2026, 8, 13, 18, 0, 0, 0, time.UTC)
+	health := readyHealth("detent")
+	active := dispatchSnapshot("detent", "github_rest_capacity_paused")
+	managerReconcile(t, manager, active, health, now)
+	managerReconcile(t, manager, active, health, now.Add(time.Second))
+
+	first := <-received
+	second := <-received
+	if first.Event != EventName || second.Event != EventName || first.ID == second.ID {
+		t.Fatalf("received events = %#v, %#v", first, second)
+	}
+}
+
+func TestManagerEntryPayloadsFireOncePerIdentity(t *testing.T) {
+	t.Parallel()
+	now := time.Date(2026, 8, 13, 18, 0, 0, 0, time.UTC)
+	tests := []struct {
+		name            string
+		snapshot        telemetry.Snapshot
+		cause           string
+		wantWaitReasons []string
+	}{
+		{
+			name: "dispatch payload carries wait reason",
+			snapshot: telemetry.Snapshot{DispatchStalls: []telemetry.DispatchStatus{{
+				ProjectID: "detent", Stalled: true, WaitReason: "github_rest_capacity_paused",
+			}}},
+			cause:           CauseDispatchStall,
+			wantWaitReasons: []string{"github_rest_capacity_paused"},
+		},
+		{
+			name:     "CI payload omits wait reason",
+			snapshot: telemetry.Snapshot{CIUnavailable: []telemetry.CICondition{{ProjectID: "detent"}}},
+			cause:    CauseCIUnavailable,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			stateStore := newMemoryStateStore()
+			sender := &recordingSender{}
+			manager := newTestManager(t, stateStore, sender, Config{Debounce: 10 * time.Minute})
+			health := readyHealth("detent")
+
+			managerReconcile(t, manager, tt.snapshot, health, now)
+			managerReconcile(t, manager, tt.snapshot, health, now.Add(10*time.Minute))
+			managerReconcile(t, manager, tt.snapshot, health, now.Add(20*time.Minute))
+
+			events := sender.Events()
+			if len(events) != 2 {
+				t.Fatalf("events = %#v, want project and fleet entry", events)
+			}
+			slices.SortFunc(events, func(left Event, right Event) int { return left.ScopeCompare(right) })
+			projectEvent := events[1]
+			fleetEvent := events[0]
+			if fleetEvent.Scope != ScopeFleet || fleetEvent.State != StateFleetNeedsAttention || fleetEvent.ProjectID != "" {
+				t.Fatalf("fleet event = %#v", fleetEvent)
+			}
+			if projectEvent.Scope != ScopeProject || projectEvent.ProjectID != "detent" || projectEvent.State != StateProjectNeedsAttention {
+				t.Fatalf("project event = %#v", projectEvent)
+			}
+			for _, event := range events {
+				if event.Schema != SchemaVersion || event.Event != EventName || event.Transition != TransitionEntry || event.Instance != "buildbox" || event.Host != "buildbox.example.test" {
+					t.Fatalf("event envelope = %#v", event)
+				}
+				if !slices.Equal(event.Causes, []string{tt.cause}) || !slices.Equal(event.WaitReasons, tt.wantWaitReasons) {
+					t.Fatalf("event causes/waits = %v/%v, want %v/%v", event.Causes, event.WaitReasons, []string{tt.cause}, tt.wantWaitReasons)
+				}
+				if !event.EnteredAt.Equal(now) || !event.NeedsAttentionEnteredAt.Equal(now) || event.ID == "" {
+					t.Fatalf("event timestamps/id = %#v", event)
+				}
+			}
+		})
+	}
+}
+
+func TestManagerSuppressesFlapInsideDebounce(t *testing.T) {
+	t.Parallel()
+	now := time.Date(2026, 8, 13, 18, 0, 0, 0, time.UTC)
+	stateStore := newMemoryStateStore()
+	sender := &recordingSender{}
+	manager := newTestManager(t, stateStore, sender, Config{Debounce: 10 * time.Minute})
+	health := readyHealth("detent")
+	active := dispatchSnapshot("detent", "provider_rate_window_backpressure")
+
+	managerReconcile(t, manager, active, health, now)
+	managerReconcile(t, manager, telemetry.Snapshot{}, health, now.Add(5*time.Minute))
+	managerReconcile(t, manager, active, health, now.Add(6*time.Minute))
+	managerReconcile(t, manager, telemetry.Snapshot{}, health, now.Add(7*time.Minute))
+	managerReconcile(t, manager, telemetry.Snapshot{}, health, now.Add(30*time.Minute))
+
+	if events := sender.Events(); len(events) != 0 {
+		t.Fatalf("events = %#v, want none", events)
+	}
+}
+
+func TestManagerPairsOneRecoveryWithEachEntry(t *testing.T) {
+	t.Parallel()
+	now := time.Date(2026, 8, 13, 18, 0, 0, 0, time.UTC)
+	stateStore := newMemoryStateStore()
+	sender := &recordingSender{}
+	manager := newTestManager(t, stateStore, sender, Config{Debounce: 10 * time.Minute})
+	health := readyHealth("detent")
+	active := dispatchSnapshot("detent", "github_rest_capacity_paused")
+
+	managerReconcile(t, manager, active, health, now)
+	managerReconcile(t, manager, active, health, now.Add(10*time.Minute))
+	managerReconcile(t, manager, telemetry.Snapshot{}, health, now.Add(11*time.Minute))
+	managerReconcile(t, manager, telemetry.Snapshot{}, health, now.Add(21*time.Minute))
+	managerReconcile(t, manager, telemetry.Snapshot{}, health, now.Add(31*time.Minute))
+
+	byIdentity := map[string][]Event{}
+	for _, event := range sender.Events() {
+		byIdentity[event.Identity] = append(byIdentity[event.Identity], event)
+	}
+	if len(byIdentity) != 2 {
+		t.Fatalf("events by identity = %#v, want project and fleet", byIdentity)
+	}
+	for identity, events := range byIdentity {
+		if len(events) != 2 || events[0].Transition != TransitionEntry || events[1].Transition != TransitionRecovery {
+			t.Fatalf("events[%s] = %#v, want entry then recovery", identity, events)
+		}
+		if events[0].ID == events[1].ID || !events[1].NeedsAttentionEnteredAt.Equal(events[0].NeedsAttentionEnteredAt) {
+			t.Fatalf("events[%s] pairing = %#v", identity, events)
+		}
+		if events[1].State != "ready" && events[1].State != "ok" {
+			t.Fatalf("events[%s] recovery state = %q", identity, events[1].State)
+		}
+		if !events[1].EnteredAt.Equal(now.Add(11 * time.Minute)) {
+			t.Fatalf("events[%s] recovery entered_at = %s", identity, events[1].EnteredAt)
+		}
+	}
+}
+
+func TestManagerFleetRecoveryWaitsForEveryProjectCause(t *testing.T) {
+	t.Parallel()
+	now := time.Date(2026, 8, 13, 18, 0, 0, 0, time.UTC)
+	stateStore := newMemoryStateStore()
+	sender := &recordingSender{}
+	manager := newTestManager(t, stateStore, sender, Config{Debounce: 10 * time.Minute})
+	health := readyHealth("detent")
+	both := dispatchSnapshot("detent", "github_rest_capacity_paused")
+	both.CIUnavailable = []telemetry.CICondition{{ProjectID: "detent"}}
+	ciOnly := telemetry.Snapshot{CIUnavailable: []telemetry.CICondition{{ProjectID: "detent"}}}
+
+	managerReconcile(t, manager, both, health, now)
+	managerReconcile(t, manager, both, health, now.Add(10*time.Minute))
+	managerReconcile(t, manager, ciOnly, health, now.Add(11*time.Minute))
+	managerReconcile(t, manager, ciOnly, health, now.Add(21*time.Minute))
+
+	events := sender.Events()
+	if len(events) != 4 {
+		t.Fatalf("events after one cause clears = %#v, want three entries and project dispatch recovery", events)
+	}
+	for _, event := range events {
+		if event.Scope == ScopeFleet && event.Transition == TransitionRecovery {
+			t.Fatalf("fleet recovered while CI cause remained active: %#v", event)
+		}
+	}
+
+	managerReconcile(t, manager, telemetry.Snapshot{}, health, now.Add(22*time.Minute))
+	managerReconcile(t, manager, telemetry.Snapshot{}, health, now.Add(32*time.Minute))
+	var fleetRecoveries int
+	for _, event := range sender.Events() {
+		if event.Scope == ScopeFleet && event.Transition == TransitionRecovery {
+			fleetRecoveries++
+		}
+	}
+	if fleetRecoveries != 1 {
+		t.Fatalf("fleet recoveries = %d, want 1", fleetRecoveries)
+	}
+}
+
+func TestManagerRestartPreservesActiveAndPendingDelivery(t *testing.T) {
+	t.Parallel()
+	now := time.Date(2026, 8, 13, 18, 0, 0, 0, time.UTC)
+	stateStore := newMemoryStateStore()
+	failing := &recordingSender{err: errors.New("receiver unavailable")}
+	cfg := Config{Debounce: 10 * time.Minute, RetryBase: time.Minute, RetryMax: time.Minute}
+	first := newTestManager(t, stateStore, failing, cfg)
+	health := readyHealth("detent")
+	active := dispatchSnapshot("detent", "github_rest_capacity_paused")
+
+	managerReconcile(t, first, active, health, now)
+	managerReconcile(t, first, active, health, now.Add(10*time.Minute))
+	if got := len(failing.Events()); got != 2 {
+		t.Fatalf("first manager attempts = %d, want 2", got)
+	}
+	failures, err := first.Failures(t.Context())
+	if err != nil || len(failures) != 2 {
+		t.Fatalf("Failures() = %#v, %v", failures, err)
+	}
+
+	succeeding := &recordingSender{}
+	second := newTestManager(t, stateStore, succeeding, cfg)
+	managerReconcile(t, second, active, health, now.Add(11*time.Minute))
+	managerReconcile(t, second, active, health, now.Add(20*time.Minute))
+	if got := len(succeeding.Events()); got != 2 {
+		t.Fatalf("second manager deliveries = %d, want preserved project and fleet entries only", got)
+	}
+}
+
+func TestManagerRestartDoesNotRefireDeliveredActiveCondition(t *testing.T) {
+	t.Parallel()
+	now := time.Date(2026, 8, 13, 18, 0, 0, 0, time.UTC)
+	stateStore := newMemoryStateStore()
+	firstSender := &recordingSender{}
+	cfg := Config{Debounce: 10 * time.Minute}
+	first := newTestManager(t, stateStore, firstSender, cfg)
+	health := readyHealth("detent")
+	active := dispatchSnapshot("detent", "github_rest_capacity_paused")
+
+	managerReconcile(t, first, active, health, now)
+	managerReconcile(t, first, active, health, now.Add(10*time.Minute))
+	if got := len(firstSender.Events()); got != 2 {
+		t.Fatalf("first manager deliveries = %d, want project and fleet entries", got)
+	}
+
+	secondSender := &recordingSender{}
+	second := newTestManager(t, stateStore, secondSender, cfg)
+	managerReconcile(t, second, active, health, now.Add(20*time.Minute))
+	if events := secondSender.Events(); len(events) != 0 {
+		t.Fatalf("events after restart = %#v, want none", events)
+	}
+}
+
+func TestManagerDeliveryRetriesAreBoundedAndSurfaced(t *testing.T) {
+	t.Parallel()
+	now := time.Date(2026, 8, 13, 18, 0, 0, 0, time.UTC)
+	stateStore := newMemoryStateStore()
+	sender := &recordingSender{err: errors.New("receiver unavailable")}
+	manager := newTestManager(t, stateStore, sender, Config{
+		Debounce:    10 * time.Minute,
+		MaxAttempts: 2,
+		RetryBase:   time.Minute,
+		RetryMax:    time.Minute,
+	})
+	health := readyHealth("detent")
+	active := dispatchSnapshot("detent", "github_rest_capacity_paused")
+
+	managerReconcile(t, manager, active, health, now)
+	managerReconcile(t, manager, active, health, now.Add(10*time.Minute))
+	managerReconcile(t, manager, active, health, now.Add(10*time.Minute+30*time.Second))
+	if got := len(sender.Events()); got != 2 {
+		t.Fatalf("attempts before backoff = %d, want 2", got)
+	}
+	managerReconcile(t, manager, active, health, now.Add(11*time.Minute))
+	managerReconcile(t, manager, active, health, now.Add(30*time.Minute))
+	if got := len(sender.Events()); got != 4 {
+		t.Fatalf("bounded attempts = %d, want 4", got)
+	}
+	failures, err := manager.Failures(t.Context())
+	if err != nil {
+		t.Fatalf("Failures() error = %v", err)
+	}
+	if len(failures) != 2 {
+		t.Fatalf("failures = %#v, want project and fleet", failures)
+	}
+	for _, failure := range failures {
+		if failure.Attempts != 2 || failure.MaxAttempts != 2 || failure.FailedAt == nil || failure.NextAttemptAt != nil || failure.LastError != "receiver unavailable" {
+			t.Fatalf("failure = %#v", failure)
+		}
+	}
+}
+
+func TestNewManagerUnconfiguredIsSilent(t *testing.T) {
+	t.Parallel()
+	manager, err := NewManager(Config{}, Dependencies{})
+	if err != nil {
+		t.Fatalf("NewManager() error = %v", err)
+	}
+	if manager == nil || manager.Enabled() {
+		t.Fatalf("NewManager() = %#v, want disabled manager", manager)
+	}
+	if err := manager.Reconcile(t.Context(), telemetry.Snapshot{}, nil, time.Now()); err != nil {
+		t.Fatalf("disabled Reconcile() error = %v", err)
+	}
+}
+
+type memoryStateStore struct {
+	mu      sync.Mutex
+	records map[string]store.HealthNotificationState
+}
+
+func newMemoryStateStore() *memoryStateStore {
+	return &memoryStateStore{records: map[string]store.HealthNotificationState{}}
+}
+
+func (s *memoryStateStore) ListHealthNotificationStates(context.Context) ([]store.HealthNotificationState, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	records := make([]store.HealthNotificationState, 0, len(s.records))
+	for _, record := range s.records {
+		record.StateJSON = append([]byte(nil), record.StateJSON...)
+		records = append(records, record)
+	}
+	return records, nil
+}
+
+func (s *memoryStateStore) SaveHealthNotificationStates(_ context.Context, records []store.HealthNotificationState) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for _, record := range records {
+		record.StateJSON = append([]byte(nil), record.StateJSON...)
+		s.records[record.Identity] = record
+	}
+	return nil
+}
+
+type recordingSender struct {
+	mu     sync.Mutex
+	events []Event
+	err    error
+}
+
+func (s *recordingSender) Send(_ context.Context, payload any) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	event, ok := payload.(Event)
+	if !ok {
+		return errors.New("unexpected payload type")
+	}
+	s.events = append(s.events, event)
+	return s.err
+}
+
+func (s *recordingSender) Events() []Event {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return append([]Event(nil), s.events...)
+}
+
+func newTestManager(t *testing.T, stateStore store.HealthNotificationStateStore, sender notify.Sender, cfg Config) *Manager {
+	t.Helper()
+	cfg.Webhook.URL = "https://alerts.example.test/detent"
+	cfg.Instance = "buildbox"
+	cfg.Host = "buildbox.example.test"
+	manager, err := NewManager(cfg, Dependencies{
+		Store:  stateStore,
+		Sender: sender,
+		Logger: slog.New(slog.NewTextHandler(io.Discard, nil)),
+	})
+	if err != nil {
+		t.Fatalf("NewManager() error = %v", err)
+	}
+	return manager
+}
+
+func managerReconcile(t *testing.T, manager *Manager, snapshot telemetry.Snapshot, health []project.Health, now time.Time) {
+	t.Helper()
+	snapshot.GeneratedAt = now
+	snapshot.Seq = 1
+	if err := manager.Reconcile(t.Context(), snapshot, health, now); err != nil {
+		t.Fatalf("Reconcile(%s) error = %v", now, err)
+	}
+}
+
+func readyHealth(projectID string) []project.Health {
+	return []project.Health{{
+		Project: globalconfig.Project{ID: projectID},
+		Status:  project.HealthStatusReady,
+	}}
+}
+
+func dispatchSnapshot(projectID string, waitReason string) telemetry.Snapshot {
+	return telemetry.Snapshot{DispatchStalls: []telemetry.DispatchStatus{{
+		ProjectID:  projectID,
+		Stalled:    true,
+		WaitReason: waitReason,
+	}}}
+}
+
+func (e Event) ScopeCompare(other Event) int {
+	if e.Scope == other.Scope {
+		return 0
+	}
+	if e.Scope == ScopeFleet {
+		return -1
+	}
+	return 1
+}

--- a/internal/healthnotify/observations.go
+++ b/internal/healthnotify/observations.go
@@ -1,0 +1,152 @@
+package healthnotify
+
+import (
+	"net/url"
+	"slices"
+	"strings"
+
+	"github.com/digitaldrywood/detent/internal/project"
+	"github.com/digitaldrywood/detent/internal/telemetry"
+)
+
+const (
+	ScopeFleet                   = "fleet"
+	ScopeProject                 = "project"
+	CauseCIUnavailable           = "ci_unavailable"
+	CauseDispatchStall           = "dispatch_stall"
+	StateFleetNeedsAttention     = "needs_attention"
+	StateProjectNeedsAttention   = "needs_human_attention"
+	TransitionEntry              = "entry"
+	TransitionRecovery           = "recovery"
+	fleetIdentity                = "fleet"
+	unknownProjectRecoveryStatus = "unknown"
+)
+
+type observation struct {
+	Identity    string
+	Scope       string
+	ProjectID   string
+	Active      bool
+	State       string
+	Causes      []string
+	WaitReasons []string
+}
+
+func observations(snapshot telemetry.Snapshot, health []project.Health) []observation {
+	projectStatuses := make(map[string]string, len(health))
+	for _, current := range health {
+		projectID := strings.TrimSpace(current.Project.ID)
+		if projectID == "" {
+			continue
+		}
+		projectStatuses[projectID] = strings.TrimSpace(string(current.Status))
+	}
+	projectCauses := map[string]map[string][]string{}
+	fleetCauses := []string{}
+	fleetWaitReasons := []string{}
+	for _, stall := range snapshot.DispatchStalls {
+		if !stall.Stalled {
+			continue
+		}
+		projectID := strings.TrimSpace(stall.ProjectID)
+		if projectID == "" {
+			continue
+		}
+		if projectCauses[projectID] == nil {
+			projectCauses[projectID] = map[string][]string{}
+		}
+		waitReasons := compactSorted([]string{stall.WaitReason})
+		projectCauses[projectID][CauseDispatchStall] = waitReasons
+		fleetCauses = append(fleetCauses, CauseDispatchStall)
+		fleetWaitReasons = append(fleetWaitReasons, waitReasons...)
+	}
+	for _, condition := range snapshot.CIUnavailable {
+		projectID := strings.TrimSpace(condition.ProjectID)
+		if projectID == "" {
+			continue
+		}
+		if projectCauses[projectID] == nil {
+			projectCauses[projectID] = map[string][]string{}
+		}
+		projectCauses[projectID][CauseCIUnavailable] = nil
+		fleetCauses = append(fleetCauses, CauseCIUnavailable)
+	}
+
+	projectIDs := make([]string, 0, len(projectStatuses)+len(projectCauses))
+	seen := map[string]struct{}{}
+	for projectID := range projectStatuses {
+		seen[projectID] = struct{}{}
+		projectIDs = append(projectIDs, projectID)
+	}
+	for projectID := range projectCauses {
+		if _, ok := seen[projectID]; ok {
+			continue
+		}
+		projectIDs = append(projectIDs, projectID)
+	}
+	slices.Sort(projectIDs)
+	result := make([]observation, 0, len(projectIDs)*2+1)
+	for _, projectID := range projectIDs {
+		recoveryState := strings.TrimSpace(projectStatuses[projectID])
+		if recoveryState == "" {
+			recoveryState = unknownProjectRecoveryStatus
+		}
+		for _, cause := range []string{CauseCIUnavailable, CauseDispatchStall} {
+			waitReasons, active := projectCauses[projectID][cause]
+			state := recoveryState
+			causes := []string(nil)
+			if active {
+				state = StateProjectNeedsAttention
+				causes = []string{cause}
+			}
+			result = append(result, observation{
+				Identity:    projectIdentity(projectID, cause),
+				Scope:       ScopeProject,
+				ProjectID:   projectID,
+				Active:      active,
+				State:       state,
+				Causes:      causes,
+				WaitReasons: compactSorted(waitReasons),
+			})
+		}
+	}
+	fleetState := "ok"
+	if snapshot.Shutdown.Draining {
+		fleetState = "draining"
+	}
+	fleetCauses = compactSorted(fleetCauses)
+	if len(fleetCauses) > 0 {
+		fleetState = StateFleetNeedsAttention
+	}
+	result = append(result, observation{
+		Identity:    fleetIdentity,
+		Scope:       ScopeFleet,
+		Active:      len(fleetCauses) > 0,
+		State:       fleetState,
+		Causes:      fleetCauses,
+		WaitReasons: compactSorted(fleetWaitReasons),
+	})
+	return result
+}
+
+func projectIdentity(projectID string, cause string) string {
+	return "project:" + url.QueryEscape(strings.TrimSpace(projectID)) + ":" + strings.TrimSpace(cause)
+}
+
+func compactSorted(values []string) []string {
+	result := make([]string, 0, len(values))
+	seen := map[string]struct{}{}
+	for _, value := range values {
+		value = strings.TrimSpace(value)
+		if value == "" {
+			continue
+		}
+		if _, ok := seen[value]; ok {
+			continue
+		}
+		seen[value] = struct{}{}
+		result = append(result, value)
+	}
+	slices.Sort(result)
+	return result
+}

--- a/internal/notify/webhook.go
+++ b/internal/notify/webhook.go
@@ -72,21 +72,17 @@ func (w *Webhook) Send(ctx context.Context, payload any) error {
 		return fmt.Errorf("deliver webhook: %w", err)
 	}
 	defer response.Body.Close()
+	if _, err := io.Copy(io.Discard, io.LimitReader(response.Body, 4096)); err != nil {
+		return fmt.Errorf("drain webhook response: %w", err)
+	}
 	if response.StatusCode >= http.StatusOK && response.StatusCode < http.StatusMultipleChoices {
-		if _, err := io.Copy(io.Discard, io.LimitReader(response.Body, 4096)); err != nil {
-			return fmt.Errorf("drain webhook response: %w", err)
-		}
 		return nil
 	}
-	body, err = io.ReadAll(io.LimitReader(response.Body, 4096))
-	if err != nil {
-		return fmt.Errorf("read webhook response: %w", err)
-	}
-	detail := strings.TrimSpace(string(body))
+	detail := http.StatusText(response.StatusCode)
 	if detail == "" {
-		detail = http.StatusText(response.StatusCode)
+		return fmt.Errorf("deliver webhook: HTTP %d", response.StatusCode)
 	}
-	return fmt.Errorf("deliver webhook: HTTP %d: %s", response.StatusCode, detail)
+	return fmt.Errorf("deliver webhook: HTTP %d %s", response.StatusCode, detail)
 }
 
 func cloneHeaders(headers map[string]string) map[string]string {

--- a/internal/notify/webhook.go
+++ b/internal/notify/webhook.go
@@ -1,0 +1,105 @@
+package notify
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+)
+
+const defaultWebhookTimeout = 5 * time.Second
+
+type WebhookConfig struct {
+	URL       string
+	Headers   map[string]string
+	Timeout   time.Duration
+	UserAgent string
+}
+
+type Sender interface {
+	Send(context.Context, any) error
+}
+
+type Webhook struct {
+	url       string
+	headers   map[string]string
+	userAgent string
+	client    *http.Client
+}
+
+func NewWebhook(cfg WebhookConfig) (*Webhook, error) {
+	cfg.URL = strings.TrimSpace(cfg.URL)
+	if cfg.URL == "" {
+		return nil, errors.New("webhook URL is required")
+	}
+	if cfg.Timeout <= 0 {
+		cfg.Timeout = defaultWebhookTimeout
+	}
+	return &Webhook{
+		url:       cfg.URL,
+		headers:   cloneHeaders(cfg.Headers),
+		userAgent: strings.TrimSpace(cfg.UserAgent),
+		client:    &http.Client{Timeout: cfg.Timeout},
+	}, nil
+}
+
+func (w *Webhook) Send(ctx context.Context, payload any) error {
+	if w == nil || w.client == nil {
+		return errors.New("webhook is not configured")
+	}
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return fmt.Errorf("marshal webhook payload: %w", err)
+	}
+	request, err := http.NewRequestWithContext(ctx, http.MethodPost, w.url, bytes.NewReader(body))
+	if err != nil {
+		return fmt.Errorf("build webhook request: %w", err)
+	}
+	request.Header.Set("Content-Type", "application/json")
+	if w.userAgent != "" {
+		request.Header.Set("User-Agent", w.userAgent)
+	}
+	for name, value := range w.headers {
+		request.Header.Set(name, value)
+	}
+	response, err := w.client.Do(request)
+	if err != nil {
+		return fmt.Errorf("deliver webhook: %w", err)
+	}
+	defer response.Body.Close()
+	if response.StatusCode >= http.StatusOK && response.StatusCode < http.StatusMultipleChoices {
+		if _, err := io.Copy(io.Discard, io.LimitReader(response.Body, 4096)); err != nil {
+			return fmt.Errorf("drain webhook response: %w", err)
+		}
+		return nil
+	}
+	body, err = io.ReadAll(io.LimitReader(response.Body, 4096))
+	if err != nil {
+		return fmt.Errorf("read webhook response: %w", err)
+	}
+	detail := strings.TrimSpace(string(body))
+	if detail == "" {
+		detail = http.StatusText(response.StatusCode)
+	}
+	return fmt.Errorf("deliver webhook: HTTP %d: %s", response.StatusCode, detail)
+}
+
+func cloneHeaders(headers map[string]string) map[string]string {
+	if len(headers) == 0 {
+		return nil
+	}
+	cloned := make(map[string]string, len(headers))
+	for name, value := range headers {
+		name = strings.TrimSpace(name)
+		if name == "" {
+			continue
+		}
+		cloned[name] = strings.TrimSpace(value)
+	}
+	return cloned
+}

--- a/internal/notify/webhook_test.go
+++ b/internal/notify/webhook_test.go
@@ -1,0 +1,81 @@
+package notify
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestWebhookSend(t *testing.T) {
+	t.Parallel()
+	received := make(chan map[string]any, 1)
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		if got := request.Header.Get("Authorization"); got != "Bearer example" {
+			t.Errorf("Authorization = %q, want Bearer example", got)
+		}
+		if got := request.Header.Get("User-Agent"); got != "detent-test" {
+			t.Errorf("User-Agent = %q, want detent-test", got)
+		}
+		var payload map[string]any
+		if err := json.NewDecoder(request.Body).Decode(&payload); err != nil {
+			t.Errorf("decode payload: %v", err)
+		}
+		received <- payload
+		writer.WriteHeader(http.StatusNoContent)
+	}))
+	t.Cleanup(server.Close)
+
+	webhook, err := NewWebhook(WebhookConfig{
+		URL:       server.URL,
+		Headers:   map[string]string{"Authorization": "Bearer example"},
+		Timeout:   time.Second,
+		UserAgent: "detent-test",
+	})
+	if err != nil {
+		t.Fatalf("NewWebhook() error = %v", err)
+	}
+	if err := webhook.Send(t.Context(), map[string]string{"event": "test"}); err != nil {
+		t.Fatalf("Send() error = %v", err)
+	}
+	if got := (<-received)["event"]; got != "test" {
+		t.Fatalf("event = %#v, want test", got)
+	}
+}
+
+func TestWebhookErrors(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name string
+		url  string
+		want string
+	}{
+		{name: "missing URL", want: "webhook URL is required"},
+		{name: "HTTP failure", url: "server", want: "HTTP 503: unavailable"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			url := tt.url
+			if url == "server" {
+				server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, _ *http.Request) {
+					http.Error(writer, "unavailable", http.StatusServiceUnavailable)
+				}))
+				t.Cleanup(server.Close)
+				url = server.URL
+			}
+			webhook, err := NewWebhook(WebhookConfig{URL: url})
+			if err != nil {
+				if err.Error() != tt.want {
+					t.Fatalf("NewWebhook() error = %q, want %q", err, tt.want)
+				}
+				return
+			}
+			if err := webhook.Send(t.Context(), struct{}{}); err == nil || !strings.Contains(err.Error(), tt.want) {
+				t.Fatalf("Send() error = %v, want containing %q", err, tt.want)
+			}
+		})
+	}
+}

--- a/internal/notify/webhook_test.go
+++ b/internal/notify/webhook_test.go
@@ -48,12 +48,13 @@ func TestWebhookSend(t *testing.T) {
 func TestWebhookErrors(t *testing.T) {
 	t.Parallel()
 	tests := []struct {
-		name string
-		url  string
-		want string
+		name    string
+		url     string
+		want    string
+		notWant string
 	}{
 		{name: "missing URL", want: "webhook URL is required"},
-		{name: "HTTP failure", url: "server", want: "HTTP 503: unavailable"},
+		{name: "HTTP failure", url: "server", want: "HTTP 503 Service Unavailable", notWant: "receiver-secret"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -61,7 +62,7 @@ func TestWebhookErrors(t *testing.T) {
 			url := tt.url
 			if url == "server" {
 				server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, _ *http.Request) {
-					http.Error(writer, "unavailable", http.StatusServiceUnavailable)
+					http.Error(writer, "receiver-secret", http.StatusServiceUnavailable)
 				}))
 				t.Cleanup(server.Close)
 				url = server.URL
@@ -73,7 +74,7 @@ func TestWebhookErrors(t *testing.T) {
 				}
 				return
 			}
-			if err := webhook.Send(t.Context(), struct{}{}); err == nil || !strings.Contains(err.Error(), tt.want) {
+			if err := webhook.Send(t.Context(), struct{}{}); err == nil || !strings.Contains(err.Error(), tt.want) || (tt.notWant != "" && strings.Contains(err.Error(), tt.notWant)) {
 				t.Fatalf("Send() error = %v, want containing %q", err, tt.want)
 			}
 		})

--- a/internal/staleness/notifier.go
+++ b/internal/staleness/notifier.go
@@ -1,15 +1,13 @@
 package staleness
 
 import (
-	"bytes"
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
-	"io"
-	"net/http"
 	"strings"
 	"time"
+
+	"github.com/digitaldrywood/detent/internal/notify"
 )
 
 type DeliveryConfig struct {
@@ -36,73 +34,32 @@ func NewNotifier(cfg DeliveryConfig) (Notifier, error) {
 	if cfg.Timeout <= 0 {
 		cfg.Timeout = 5 * time.Second
 	}
-	return &webhookNotifier{
-		url:     cfg.WebhookURL,
-		headers: cloneHeaders(cfg.Headers),
-		client:  &http.Client{Timeout: cfg.Timeout},
-	}, nil
+	webhook, err := notify.NewWebhook(notify.WebhookConfig{
+		URL:       cfg.WebhookURL,
+		Headers:   cfg.Headers,
+		Timeout:   cfg.Timeout,
+		UserAgent: "detent-staleness-watchdog",
+	})
+	if err != nil {
+		return nil, err
+	}
+	return &webhookNotifier{webhook: webhook}, nil
 }
 
 type webhookNotifier struct {
-	url     string
-	headers map[string]string
-	client  *http.Client
+	webhook *notify.Webhook
 }
 
 func (n *webhookNotifier) Notify(ctx context.Context, warning Warning) error {
-	if n == nil || n.client == nil {
+	if n == nil || n.webhook == nil {
 		return errors.New("staleness webhook notifier is not configured")
 	}
-	payload, err := json.Marshal(Notification{
+	if err := n.webhook.Send(ctx, Notification{
 		Schema:  1,
 		Event:   "detent.staleness.warning",
 		Warning: warning,
-	})
-	if err != nil {
-		return fmt.Errorf("marshal staleness webhook: %w", err)
-	}
-	request, err := http.NewRequestWithContext(ctx, http.MethodPost, n.url, bytes.NewReader(payload))
-	if err != nil {
-		return fmt.Errorf("build staleness webhook request: %w", err)
-	}
-	request.Header.Set("Content-Type", "application/json")
-	request.Header.Set("User-Agent", "detent-staleness-watchdog")
-	for name, value := range n.headers {
-		request.Header.Set(name, value)
-	}
-	response, err := n.client.Do(request)
-	if err != nil {
+	}); err != nil {
 		return fmt.Errorf("deliver staleness webhook: %w", err)
 	}
-	defer response.Body.Close()
-	if response.StatusCode >= http.StatusOK && response.StatusCode < http.StatusMultipleChoices {
-		if _, err := io.Copy(io.Discard, io.LimitReader(response.Body, 4096)); err != nil {
-			return fmt.Errorf("drain staleness webhook response: %w", err)
-		}
-		return nil
-	}
-	body, err := io.ReadAll(io.LimitReader(response.Body, 4096))
-	if err != nil {
-		return fmt.Errorf("read staleness webhook response: %w", err)
-	}
-	detail := strings.TrimSpace(string(body))
-	if detail == "" {
-		detail = http.StatusText(response.StatusCode)
-	}
-	return fmt.Errorf("deliver staleness webhook: HTTP %d: %s", response.StatusCode, detail)
-}
-
-func cloneHeaders(headers map[string]string) map[string]string {
-	if len(headers) == 0 {
-		return nil
-	}
-	cloned := make(map[string]string, len(headers))
-	for name, value := range headers {
-		name = strings.TrimSpace(name)
-		if name == "" {
-			continue
-		}
-		cloned[name] = strings.TrimSpace(value)
-	}
-	return cloned
+	return nil
 }

--- a/internal/store/health_notifications.go
+++ b/internal/store/health_notifications.go
@@ -1,0 +1,65 @@
+package store
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/digitaldrywood/detent/internal/store/sqlc"
+)
+
+func (s *sqliteStore) ListHealthNotificationStates(ctx context.Context) ([]HealthNotificationState, error) {
+	rows, err := s.queries.ListHealthNotificationStates(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("list health notification states: %w", err)
+	}
+	states := make([]HealthNotificationState, 0, len(rows))
+	for _, row := range rows {
+		updatedAt, err := parseTimestamp("updated_at", row.UpdatedAt)
+		if err != nil {
+			return nil, fmt.Errorf("parse health notification state %s updated_at: %w", row.Identity, err)
+		}
+		states = append(states, HealthNotificationState{
+			Identity:  row.Identity,
+			StateJSON: []byte(row.StateJson),
+			UpdatedAt: updatedAt,
+		})
+	}
+	return states, nil
+}
+
+func (s *sqliteStore) SaveHealthNotificationStates(ctx context.Context, states []HealthNotificationState) error {
+	if len(states) == 0 {
+		return nil
+	}
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("begin health notification state transaction: %w", err)
+	}
+	defer func() {
+		_ = tx.Rollback()
+	}()
+	queries := s.queries.WithTx(tx)
+	for _, state := range states {
+		identity := strings.TrimSpace(state.Identity)
+		if identity == "" {
+			return errors.New("health notification identity is required")
+		}
+		updatedAt, err := requiredTimestamp("updated_at", state.UpdatedAt)
+		if err != nil {
+			return err
+		}
+		if err := queries.UpsertHealthNotificationState(ctx, sqlc.UpsertHealthNotificationStateParams{
+			Identity:  identity,
+			StateJson: string(state.StateJSON),
+			UpdatedAt: updatedAt,
+		}); err != nil {
+			return fmt.Errorf("save health notification state %s: %w", identity, err)
+		}
+	}
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("commit health notification states: %w", err)
+	}
+	return nil
+}

--- a/internal/store/health_notifications_test.go
+++ b/internal/store/health_notifications_test.go
@@ -1,0 +1,44 @@
+package store
+
+import (
+	"bytes"
+	"context"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestHealthNotificationStatesPersistAcrossReopen(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	path := filepath.Join(t.TempDir(), "runtime.db")
+	now := time.Date(2026, 8, 13, 18, 0, 0, 0, time.UTC)
+
+	first, err := Open(ctx, Config{Path: path})
+	if err != nil {
+		t.Fatalf("Open(first) error = %v", err)
+	}
+	if err := first.SaveHealthNotificationStates(ctx, []HealthNotificationState{{
+		Identity:  "project:detent:dispatch_stall",
+		StateJSON: []byte(`{"schema":1,"active":true}`),
+		UpdatedAt: now,
+	}}); err != nil {
+		t.Fatalf("SaveHealthNotificationStates() error = %v", err)
+	}
+	if err := first.Close(); err != nil {
+		t.Fatalf("Close(first) error = %v", err)
+	}
+
+	second, err := Open(ctx, Config{Path: path})
+	if err != nil {
+		t.Fatalf("Open(second) error = %v", err)
+	}
+	t.Cleanup(func() { _ = second.Close() })
+	states, err := second.ListHealthNotificationStates(ctx)
+	if err != nil {
+		t.Fatalf("ListHealthNotificationStates() error = %v", err)
+	}
+	if len(states) != 1 || states[0].Identity != "project:detent:dispatch_stall" || !bytes.Equal(states[0].StateJSON, []byte(`{"schema":1,"active":true}`)) || !states[0].UpdatedAt.Equal(now) {
+		t.Fatalf("states = %#v", states)
+	}
+}

--- a/internal/store/migrations/00033_create_health_notification_states.sql
+++ b/internal/store/migrations/00033_create_health_notification_states.sql
@@ -1,0 +1,9 @@
+-- +goose Up
+CREATE TABLE health_notification_states (
+  identity TEXT PRIMARY KEY,
+  state_json TEXT NOT NULL,
+  updated_at TEXT NOT NULL
+);
+
+-- +goose Down
+DROP TABLE IF EXISTS health_notification_states;

--- a/internal/store/sqlc/models.go
+++ b/internal/store/sqlc/models.go
@@ -216,6 +216,12 @@ type FairShareUsage struct {
 	UpdatedAt      string `json:"updated_at"`
 }
 
+type HealthNotificationState struct {
+	Identity  string `json:"identity"`
+	StateJson string `json:"state_json"`
+	UpdatedAt string `json:"updated_at"`
+}
+
 type MergeRequiredCheckStreak struct {
 	ProjectID                 string `json:"project_id"`
 	IssueID                   string `json:"issue_id"`

--- a/internal/store/sqlc/store.sql.go
+++ b/internal/store/sqlc/store.sql.go
@@ -2552,6 +2552,35 @@ func (q *Queries) ListFairShareUsage(ctx context.Context) ([]FairShareUsage, err
 	return items, nil
 }
 
+const listHealthNotificationStates = `-- name: ListHealthNotificationStates :many
+SELECT identity, state_json, updated_at
+FROM health_notification_states
+ORDER BY identity
+`
+
+func (q *Queries) ListHealthNotificationStates(ctx context.Context) ([]HealthNotificationState, error) {
+	rows, err := q.db.QueryContext(ctx, listHealthNotificationStates)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []HealthNotificationState{}
+	for rows.Next() {
+		var i HealthNotificationState
+		if err := rows.Scan(&i.Identity, &i.StateJson, &i.UpdatedAt); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const listIssueActivityEvents = `-- name: ListIssueActivityEvents :many
 WITH issue_events AS (
   SELECT
@@ -4287,6 +4316,28 @@ func (q *Queries) UpsertFairShareUsage(ctx context.Context, arg UpsertFairShareU
 		&i.UpdatedAt,
 	)
 	return i, err
+}
+
+const upsertHealthNotificationState = `-- name: UpsertHealthNotificationState :exec
+INSERT INTO health_notification_states (
+  identity,
+  state_json,
+  updated_at
+) VALUES (?, ?, ?)
+ON CONFLICT(identity) DO UPDATE SET
+  state_json = excluded.state_json,
+  updated_at = excluded.updated_at
+`
+
+type UpsertHealthNotificationStateParams struct {
+	Identity  string `json:"identity"`
+	StateJson string `json:"state_json"`
+	UpdatedAt string `json:"updated_at"`
+}
+
+func (q *Queries) UpsertHealthNotificationState(ctx context.Context, arg UpsertHealthNotificationStateParams) error {
+	_, err := q.db.ExecContext(ctx, upsertHealthNotificationState, arg.Identity, arg.StateJson, arg.UpdatedAt)
+	return err
 }
 
 const upsertProjectDispatchStatus = `-- name: UpsertProjectDispatchStatus :one

--- a/internal/store/sqlite.go
+++ b/internal/store/sqlite.go
@@ -93,6 +93,7 @@ func (s *sqliteStore) RuntimeEvidence(ctx context.Context, query RuntimeEvidence
 		{name: "routine_runs", projectScoped: true},
 		{name: "backlog_admission_proposals", projectScoped: true},
 		{name: "backlog_admission_runs", projectScoped: true},
+		{name: "health_notification_states"},
 		{name: "api_keys"},
 		{name: "api_usage_logs"},
 		{name: "auth_magic_links"},
@@ -1273,6 +1274,8 @@ func (s *sqliteStore) runtimeTableCount(ctx context.Context, tableName string, p
 			row = s.db.QueryRowContext(ctx, "SELECT COUNT(*) FROM backlog_admission_proposals")
 		case "backlog_admission_runs":
 			row = s.db.QueryRowContext(ctx, "SELECT COUNT(*) FROM backlog_admission_runs")
+		case "health_notification_states":
+			row = s.db.QueryRowContext(ctx, "SELECT COUNT(*) FROM health_notification_states")
 		case "api_keys":
 			row = s.db.QueryRowContext(ctx, "SELECT COUNT(*) FROM api_keys")
 		case "api_usage_logs":

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -53,6 +53,7 @@ type Store interface {
 	ProvenanceStore
 	WorkAttemptStore
 	ProjectDispatchStatusStore
+	HealthNotificationStateStore
 	WorkAttemptCapacityReleaseStore
 	MergeRequiredCheckStore
 	OperatorStopStore
@@ -161,6 +162,11 @@ type IssueSchedulerDecisionStore interface {
 type ProjectDispatchStatusStore interface {
 	RecordProjectDispatchStatus(context.Context, ProjectDispatchStatus) error
 	ProjectDispatchStatus(context.Context, string) (ProjectDispatchStatus, error)
+}
+
+type HealthNotificationStateStore interface {
+	ListHealthNotificationStates(context.Context) ([]HealthNotificationState, error)
+	SaveHealthNotificationStates(context.Context, []HealthNotificationState) error
 }
 
 type WorkAttemptCapacityReleaseStore interface {
@@ -764,6 +770,12 @@ type ProjectDispatchStatus struct {
 	AllSkippedSince      *time.Time
 	LastSelectedAt       *time.Time
 	ObservedAt           time.Time
+}
+
+type HealthNotificationState struct {
+	Identity  string
+	StateJSON []byte
+	UpdatedAt time.Time
 }
 
 type IssueSchedulerDecisionQuery struct {

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -27,6 +27,7 @@ import (
 	globalconfig "github.com/digitaldrywood/detent/internal/config/global"
 	"github.com/digitaldrywood/detent/internal/connector"
 	"github.com/digitaldrywood/detent/internal/efficiency"
+	"github.com/digitaldrywood/detent/internal/healthnotify"
 	"github.com/digitaldrywood/detent/internal/hub"
 	kanbanstate "github.com/digitaldrywood/detent/internal/kanban"
 	"github.com/digitaldrywood/detent/internal/mcp"
@@ -45,21 +46,22 @@ var (
 )
 
 type Dependencies struct {
-	Hub              *hub.Hub[telemetry.Snapshot]
-	Store            store.Store
-	Registry         *project.Registry
-	Connector        connector.Connector
-	Refresher        Refresher
-	OperatorMoves    OperatorMoveReconciler
-	Recovery         WorkAttemptRecovery
-	RunStopper       RunStopper
-	UpdateApplier    UpdateApplier
-	Activity         *activity.Broker
-	History          activity.HistoryReader
-	MagicLinkSender  auth.Sender
-	IdentityProvider auth.IdentityProvider
-	Chat             chatpkg.Provider
-	IssueExplainer   IssueExplainer
+	Hub                 *hub.Hub[telemetry.Snapshot]
+	Store               store.Store
+	Registry            *project.Registry
+	Connector           connector.Connector
+	Refresher           Refresher
+	OperatorMoves       OperatorMoveReconciler
+	Recovery            WorkAttemptRecovery
+	RunStopper          RunStopper
+	UpdateApplier       UpdateApplier
+	Activity            *activity.Broker
+	History             activity.HistoryReader
+	MagicLinkSender     auth.Sender
+	IdentityProvider    auth.IdentityProvider
+	Chat                chatpkg.Provider
+	IssueExplainer      IssueExplainer
+	HealthNotifications healthnotify.FailureReader
 }
 
 type Mode string
@@ -165,6 +167,7 @@ type Server struct {
 	identityAllowlist   *auth.Allowlist
 	chat                *chatpkg.Service
 	issueExplainer      IssueExplainer
+	healthNotifications healthnotify.FailureReader
 	operatorTools       *operatortool.Executor
 	mcpHTTP             *mcp.HTTPHandler
 }
@@ -273,6 +276,7 @@ func NewServer(cfg Config, deps Dependencies) (*Server, error) {
 		identityProvider:    identityProvider,
 		identityAllowlist:   identityAllowlist,
 		issueExplainer:      deps.IssueExplainer,
+		healthNotifications: deps.HealthNotifications,
 	}
 	if !magicLinksEnabled && !oidcEnabled {
 		server.sessions = nil
@@ -1064,6 +1068,7 @@ func (s *Server) health(c echo.Context) error {
 	strandedActiveIssues := []telemetry.StrandedIssue{}
 	dispatch := telemetry.DispatchStatus{}
 	dispatchStalls := []telemetry.DispatchStatus{}
+	notificationFailures := []healthnotify.Failure{}
 	if s.hub != nil {
 		if snapshot, ok := s.hub.Latest(); ok {
 			updateStatus = snapshot.Update
@@ -1079,6 +1084,14 @@ func (s *Server) health(c echo.Context) error {
 			}
 		}
 	}
+	if s.healthNotifications != nil {
+		failures, err := s.healthNotifications.Failures(c.Request().Context())
+		if err != nil {
+			s.logger.Warn("read health notification failures failed", "error", err)
+		} else {
+			notificationFailures = failures
+		}
+	}
 	checks := map[string]string{
 		"hub":       configuredStatus(s.hub),
 		"store":     configuredStatus(s.store),
@@ -1090,7 +1103,7 @@ func (s *Server) health(c echo.Context) error {
 		checks["demo_clock"] = s.demo.clock
 	}
 	projectStatus, projectHealth := s.projectHealth()
-	projectHealth = applyDispatchStallsToProjectHealth(projectHealth, dispatchStalls)
+	projectHealth = applyNeedsAttentionToProjectHealth(projectHealth, dispatchStalls, ciUnavailable)
 	var budgets []healthBudget
 	var workflows []healthWorkflowSource
 	if status != "draining" {
@@ -1101,37 +1114,43 @@ func (s *Server) health(c echo.Context) error {
 		}
 	}
 	return c.JSON(http.StatusOK, healthResponse{
-		Status:            status,
-		Version:           s.build.Version,
-		Commit:            s.build.Commit,
-		ProjectStatus:     projectStatus,
-		Mode:              string(s.mode),
-		Connector:         s.connectorName(),
-		SessionsRemaining: sessionsRemaining,
-		Update:            updateStatus,
-		Checks:            checks,
-		Environment:       healthEnvironment{Path: os.Getenv("PATH")},
-		Budgets:           budgets,
-		Workflows:         workflows,
-		CIUnavailable:     ciUnavailable,
-		BackendOutages:    backendOutages,
-		StalenessWarnings: stalenessWarnings,
-		StrandedIssues:    strandedActiveIssues,
-		Dispatch:          dispatch,
-		DispatchStalls:    dispatchStalls,
-		Projects:          projectHealth,
+		Status:               status,
+		Version:              s.build.Version,
+		Commit:               s.build.Commit,
+		ProjectStatus:        projectStatus,
+		Mode:                 string(s.mode),
+		Connector:            s.connectorName(),
+		SessionsRemaining:    sessionsRemaining,
+		Update:               updateStatus,
+		Checks:               checks,
+		Environment:          healthEnvironment{Path: os.Getenv("PATH")},
+		Budgets:              budgets,
+		Workflows:            workflows,
+		CIUnavailable:        ciUnavailable,
+		BackendOutages:       backendOutages,
+		StalenessWarnings:    stalenessWarnings,
+		StrandedIssues:       strandedActiveIssues,
+		Dispatch:             dispatch,
+		DispatchStalls:       dispatchStalls,
+		NotificationFailures: notificationFailures,
+		Projects:             projectHealth,
 	})
 }
 
-func applyDispatchStallsToProjectHealth(projects []healthProject, stalls []telemetry.DispatchStatus) []healthProject {
-	stalled := make(map[string]struct{}, len(stalls))
+func applyNeedsAttentionToProjectHealth(projects []healthProject, stalls []telemetry.DispatchStatus, ciUnavailable []telemetry.CICondition) []healthProject {
+	needsAttention := make(map[string]struct{}, len(stalls)+len(ciUnavailable))
 	for _, stall := range stalls {
 		if projectID := strings.TrimSpace(stall.ProjectID); projectID != "" && stall.Stalled {
-			stalled[projectID] = struct{}{}
+			needsAttention[projectID] = struct{}{}
+		}
+	}
+	for _, condition := range ciUnavailable {
+		if projectID := strings.TrimSpace(condition.ProjectID); projectID != "" {
+			needsAttention[projectID] = struct{}{}
 		}
 	}
 	for index := range projects {
-		if _, ok := stalled[strings.TrimSpace(projects[index].ProjectID)]; ok {
+		if _, ok := needsAttention[strings.TrimSpace(projects[index].ProjectID)]; ok {
 			projects[index].Status = "needs_human_attention"
 		}
 	}
@@ -1381,25 +1400,26 @@ func (s *Server) connectorName() string {
 }
 
 type healthResponse struct {
-	Status            string                       `json:"status"`
-	Version           string                       `json:"version"`
-	Commit            string                       `json:"commit"`
-	ProjectStatus     string                       `json:"project_status"`
-	Mode              string                       `json:"mode"`
-	Connector         string                       `json:"connector"`
-	SessionsRemaining int                          `json:"sessions_remaining,omitempty"`
-	Update            telemetry.Update             `json:"update,omitzero"`
-	Checks            map[string]string            `json:"checks"`
-	Environment       healthEnvironment            `json:"environment"`
-	Budgets           []healthBudget               `json:"budgets,omitempty"`
-	Workflows         []healthWorkflowSource       `json:"workflows,omitempty"`
-	CIUnavailable     []telemetry.CICondition      `json:"ci_unavailable,omitempty"`
-	BackendOutages    []telemetry.BackendOutage    `json:"backend_outages,omitempty"`
-	StalenessWarnings []telemetry.StalenessWarning `json:"staleness_warnings,omitempty"`
-	StrandedIssues    []telemetry.StrandedIssue    `json:"stranded_active_issues,omitempty"`
-	Dispatch          telemetry.DispatchStatus     `json:"dispatch"`
-	DispatchStalls    []telemetry.DispatchStatus   `json:"dispatch_stalls,omitempty"`
-	Projects          []healthProject              `json:"projects,omitempty"`
+	Status               string                       `json:"status"`
+	Version              string                       `json:"version"`
+	Commit               string                       `json:"commit"`
+	ProjectStatus        string                       `json:"project_status"`
+	Mode                 string                       `json:"mode"`
+	Connector            string                       `json:"connector"`
+	SessionsRemaining    int                          `json:"sessions_remaining,omitempty"`
+	Update               telemetry.Update             `json:"update,omitzero"`
+	Checks               map[string]string            `json:"checks"`
+	Environment          healthEnvironment            `json:"environment"`
+	Budgets              []healthBudget               `json:"budgets,omitempty"`
+	Workflows            []healthWorkflowSource       `json:"workflows,omitempty"`
+	CIUnavailable        []telemetry.CICondition      `json:"ci_unavailable,omitempty"`
+	BackendOutages       []telemetry.BackendOutage    `json:"backend_outages,omitempty"`
+	StalenessWarnings    []telemetry.StalenessWarning `json:"staleness_warnings,omitempty"`
+	StrandedIssues       []telemetry.StrandedIssue    `json:"stranded_active_issues,omitempty"`
+	Dispatch             telemetry.DispatchStatus     `json:"dispatch"`
+	DispatchStalls       []telemetry.DispatchStatus   `json:"dispatch_stalls,omitempty"`
+	NotificationFailures []healthnotify.Failure       `json:"health_notification_failures,omitempty"`
+	Projects             []healthProject              `json:"projects,omitempty"`
 }
 
 type healthEnvironment struct {

--- a/internal/web/server_test.go
+++ b/internal/web/server_test.go
@@ -37,6 +37,7 @@ import (
 	"github.com/digitaldrywood/detent/internal/connector/local"
 	"github.com/digitaldrywood/detent/internal/efficiency"
 	"github.com/digitaldrywood/detent/internal/gate"
+	"github.com/digitaldrywood/detent/internal/healthnotify"
 	"github.com/digitaldrywood/detent/internal/hub"
 	"github.com/digitaldrywood/detent/internal/orchestrator"
 	"github.com/digitaldrywood/detent/internal/project"
@@ -6715,6 +6716,7 @@ func TestHealthReportsCICondition(t *testing.T) {
 	t.Parallel()
 
 	deps := testDeps(t)
+	mustSetWebProject(t, deps.Registry, "detent", true)
 	now := time.Date(2026, 8, 8, 20, 0, 0, 0, time.UTC)
 	if err := deps.Hub.Publish(telemetry.Snapshot{
 		GeneratedAt: now,
@@ -6743,11 +6745,38 @@ func TestHealthReportsCICondition(t *testing.T) {
 	if len(conditions) != 1 || nestedString(t, conditions[0].(map[string]any), "unstarted_check_count") != "6" {
 		t.Fatalf("health ci_unavailable = %#v", conditions)
 	}
+	projects := health["projects"].([]any)
+	if len(projects) != 1 || projects[0].(map[string]any)["status"] != "needs_human_attention" {
+		t.Fatalf("health projects = %#v, want detent needs_human_attention", projects)
+	}
 
 	state := requestJSON(t, server, http.MethodGet, "/api/v1/state", http.StatusOK)
 	conditions = state["ci_unavailable"].([]any)
 	if len(conditions) != 1 || nestedString(t, conditions[0].(map[string]any), "pull_request_count") != "2" {
 		t.Fatalf("state ci_unavailable = %#v", conditions)
+	}
+}
+
+func TestHealthReportsNotificationDeliveryFailures(t *testing.T) {
+	t.Parallel()
+	deps := testDeps(t)
+	deps.HealthNotifications = healthNotificationFailureReader{failures: []healthnotify.Failure{{
+		EventID:     "health-event-1",
+		Identity:    "fleet",
+		Scope:       healthnotify.ScopeFleet,
+		Transition:  healthnotify.TransitionEntry,
+		Attempts:    2,
+		MaxAttempts: 5,
+		LastError:   "receiver unavailable",
+	}}}
+	server, err := web.NewServer(web.Config{}, deps)
+	if err != nil {
+		t.Fatalf("NewServer() error = %v", err)
+	}
+	health := requestJSON(t, server, http.MethodGet, "/health", http.StatusOK)
+	failures := health["health_notification_failures"].([]any)
+	if len(failures) != 1 || failures[0].(map[string]any)["event_id"] != "health-event-1" {
+		t.Fatalf("health notification failures = %#v", failures)
 	}
 }
 
@@ -11829,6 +11858,14 @@ type storeProbe struct {
 	budgetCostEvents  func(context.Context, store.BudgetCostQuery) ([]store.BudgetCostEvent, error)
 	runtimeEvidence   func(context.Context, store.RuntimeEvidenceQuery) (store.RuntimeEvidence, error)
 	validatorVerdicts func(context.Context, store.ValidatorVerdictQuery) ([]store.ValidatorVerdict, error)
+}
+
+type healthNotificationFailureReader struct {
+	failures []healthnotify.Failure
+}
+
+func (r healthNotificationFailureReader) Failures(context.Context) ([]healthnotify.Failure, error) {
+	return append([]healthnotify.Failure(nil), r.failures...), nil
 }
 
 type renderBlockingStore struct {


### PR DESCRIPTION
## Summary

- deliver debounced fleet and per-project health entry and recovery events through a generic webhook
- persist transition and bounded-retry delivery state in SQLite across restarts
- surface delivery failures through logs, `/health`, and `detent doctor`
- share webhook transport with staleness notifications and document host configuration

Fixes #1772

## UI Surface Contract

- [x] N/A; this PR does not change a UI surface, layout, density, first viewport, or responsive visibility.
- [x] This PR does not add persistent top-of-screen messaging.
- [x] N/A; there are no visual changes to primary operator screens.

## Test Plan

- [x] `make generate`
- [x] `go test -race ./internal/healthnotify -count=10`
- [x] `make check` (78.9% total coverage; all package/file floors passed)
