### PR TITLE
fix(codex): accept oversized app-server frames

### DIFF
--- a/internal/codex/jsonrpc.go
+++ b/internal/codex/jsonrpc.go
@@ -2,6 +2,7 @@ package codex
 
 import (
 	"bufio"
+	"bytes"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -11,8 +12,9 @@ import (
 )
 
 const (
-	JSONRPCVersion   = "2.0"
-	MaxScanTokenSize = 2 * 1024 * 1024
+	JSONRPCVersion          = "2.0"
+	maxFrameDiagnosticBytes = 2 * 1024
+	maxFrameIdentityBytes   = 256
 )
 
 var ErrInvalidFrame = errors.New("invalid json-rpc frame")
@@ -33,7 +35,7 @@ type RPCError struct {
 }
 
 type Codec struct {
-	scanner *bufio.Scanner
+	reader  *bufio.Reader
 	writer  *bufio.Writer
 	writeMu sync.Mutex
 }
@@ -46,37 +48,73 @@ func NewCodec(r io.Reader, w io.Writer) *Codec {
 		w = io.Discard
 	}
 
-	scanner := bufio.NewScanner(r)
-	scanner.Buffer(make([]byte, 0, 64*1024), MaxScanTokenSize)
-
 	return &Codec{
-		scanner: scanner,
-		writer:  bufio.NewWriter(w),
+		reader: bufio.NewReaderSize(r, 64*1024),
+		writer: bufio.NewWriter(w),
 	}
 }
 
 func (c *Codec) ReadMessage() (Message, error) {
-	if !c.scanner.Scan() {
-		if err := c.scanner.Err(); err != nil {
-			return Message{}, fmt.Errorf("%w: scan: %w", ErrInvalidFrame, err)
-		}
+	frame, err := c.reader.ReadBytes('\n')
+	if len(frame) == 0 && errors.Is(err, io.EOF) {
 		return Message{}, io.EOF
 	}
+	if err != nil && !errors.Is(err, io.EOF) {
+		return Message{}, fmt.Errorf("%w: read: %w", ErrInvalidFrame, err)
+	}
 
-	line := strings.TrimSpace(string(c.scanner.Bytes()))
-	if line == "" {
+	line := bytes.TrimSpace(frame)
+	if len(line) == 0 {
 		return Message{}, fmt.Errorf("%w: empty frame", ErrInvalidFrame)
 	}
 
 	var msg Message
-	if err := json.Unmarshal([]byte(line), &msg); err != nil {
-		return Message{}, fmt.Errorf("%w: decode: %w: frame %s", ErrInvalidFrame, err, line)
+	if err := json.Unmarshal(line, &msg); err != nil {
+		return Message{}, fmt.Errorf("%w: decode: %w: %s", ErrInvalidFrame, err, frameDiagnostic(line, msg))
 	}
 	if err := validateMessage(msg); err != nil {
-		return Message{}, fmt.Errorf("%w: frame %s", err, line)
+		return Message{}, fmt.Errorf("%w: %s", err, frameDiagnostic(line, msg))
 	}
 
 	return msg, nil
+}
+
+func (c *Codec) drain() error {
+	if _, err := io.Copy(io.Discard, c.reader); err != nil {
+		return fmt.Errorf("drain json-rpc stream: %w", err)
+	}
+	return nil
+}
+
+func frameDiagnostic(frame []byte, msg Message) string {
+	details := []string{fmt.Sprintf("frame_bytes=%d", len(frame))}
+	if method := strings.TrimSpace(msg.Method); method != "" {
+		excerpt, truncated := diagnosticExcerpt([]byte(method), maxFrameIdentityBytes)
+		details = append(details, fmt.Sprintf("method=%q", excerpt))
+		if truncated {
+			details = append(details, "method_truncated=true")
+		}
+	}
+	if id := bytes.TrimSpace(msg.ID); len(id) > 0 {
+		excerpt, truncated := diagnosticExcerpt(id, maxFrameIdentityBytes)
+		details = append(details, fmt.Sprintf("id=%s", excerpt))
+		if truncated {
+			details = append(details, "id_truncated=true")
+		}
+	}
+	excerpt, truncated := diagnosticExcerpt(frame, maxFrameDiagnosticBytes)
+	details = append(details, fmt.Sprintf("frame_excerpt=%q", excerpt))
+	if truncated {
+		details = append(details, "frame_truncated=true")
+	}
+	return strings.Join(details, " ")
+}
+
+func diagnosticExcerpt(value []byte, limit int) ([]byte, bool) {
+	if len(value) <= limit {
+		return value, false
+	}
+	return value[:limit], true
 }
 
 func (c *Codec) WriteMessage(msg Message) error {

--- a/internal/codex/jsonrpc_test.go
+++ b/internal/codex/jsonrpc_test.go
@@ -4,10 +4,14 @@ import (
 	"bytes"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
 	"strings"
 	"testing"
 )
+
+const legacyScannerLimit = 2 * 1024 * 1024
+const frameDiagnosticTestLimit = 4 * 1024
 
 func TestCodecWriteMessageFramesJSONLine(t *testing.T) {
 	t.Parallel()
@@ -160,30 +164,84 @@ func TestCodecReadMessageReturnsEOF(t *testing.T) {
 	}
 }
 
+func TestCodecReadMessageBoundsInvalidFrameDiagnostics(t *testing.T) {
+	t.Parallel()
+
+	largeText := strings.Repeat("x", 16*frameDiagnosticTestLimit)
+	tests := []struct {
+		name string
+		line string
+		want []string
+	}{
+		{
+			name: "invalid json",
+			line: `{"jsonrpc":"2.0","method":"broken","params":{"text":"` + largeText + `"` + "\n",
+		},
+		{
+			name: "invalid message shape",
+			line: `{"jsonrpc":"2.0","id":"request-17","method":"mixed","result":"` + largeText + `"}` + "\n",
+			want: []string{`method="mixed"`, `id="request-17"`},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			codec := NewCodec(strings.NewReader(tt.line), io.Discard)
+			_, err := codec.ReadMessage()
+			if !errors.Is(err, ErrInvalidFrame) {
+				t.Fatalf("ReadMessage() error = %v, want ErrInvalidFrame", err)
+			}
+			for _, want := range append([]string{
+				fmt.Sprintf("frame_bytes=%d", len(strings.TrimSpace(tt.line))),
+				"frame_truncated=true",
+			}, tt.want...) {
+				if !strings.Contains(err.Error(), want) {
+					t.Fatalf("ReadMessage() error = %v, want containing %q", err, want)
+				}
+			}
+			if len(err.Error()) > frameDiagnosticTestLimit+1024 {
+				t.Fatalf("ReadMessage() error length = %d, want at most %d", len(err.Error()), frameDiagnosticTestLimit+1024)
+			}
+		})
+	}
+}
+
 func TestCodecReadsLargeFrame(t *testing.T) {
 	t.Parallel()
 
-	if MaxScanTokenSize < 1024*1024 {
-		t.Fatalf("MaxScanTokenSize = %d, want at least 1 MiB", MaxScanTokenSize)
+	tests := []struct {
+		name string
+		size int
+	}{
+		{name: "below scanner ceiling", size: 1024 * 1024},
+		{name: "above scanner ceiling", size: 2 * legacyScannerLimit},
 	}
 
-	wantText := strings.Repeat("x", 1024*1024)
-	frame := `{"jsonrpc":"2.0","method":"item/agentMessage","params":{"text":"` + wantText + `"}}` + "\n"
-	codec := NewCodec(strings.NewReader(frame), io.Discard)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 
-	got, err := codec.ReadMessage()
-	if err != nil {
-		t.Fatalf("ReadMessage() error = %v", err)
-	}
+			wantText := strings.Repeat("x", tt.size)
+			frame := `{"jsonrpc":"2.0","method":"item/agentMessage","params":{"text":"` + wantText + `"}}` + "\n"
+			codec := NewCodec(strings.NewReader(frame), io.Discard)
 
-	var params struct {
-		Text string `json:"text"`
-	}
-	if err := json.Unmarshal(got.Params, &params); err != nil {
-		t.Fatalf("unmarshal params: %v", err)
-	}
-	if params.Text != wantText {
-		t.Fatalf("params text length = %d, want %d", len(params.Text), len(wantText))
+			got, err := codec.ReadMessage()
+			if err != nil {
+				t.Fatalf("ReadMessage() error = %v", err)
+			}
+
+			var params struct {
+				Text string `json:"text"`
+			}
+			if err := json.Unmarshal(got.Params, &params); err != nil {
+				t.Fatalf("unmarshal params: %v", err)
+			}
+			if params.Text != wantText {
+				t.Fatalf("params text length = %d, want %d", len(params.Text), len(wantText))
+			}
+		})
 	}
 }
 

--- a/internal/codex/transport.go
+++ b/internal/codex/transport.go
@@ -53,6 +53,7 @@ type localTransport struct {
 	readStopOnce   sync.Once
 	closeOnce      sync.Once
 	closeErr       error
+	readDrainErr   error
 }
 
 type transportResult struct {
@@ -361,6 +362,9 @@ func (t *localTransport) readLoop() {
 			if !t.readingStopped() {
 				t.publishReceived(transportResult{err: err})
 			}
+			if !errors.Is(err, io.EOF) {
+				t.readDrainErr = t.codec.drain()
+			}
 			return
 		}
 
@@ -382,6 +386,9 @@ func (t *localTransport) wait() {
 		err = errors.Join(err, cleanupErr)
 	}
 	<-t.readDone
+	if t.readDrainErr != nil {
+		err = errors.Join(err, t.readDrainErr)
+	}
 	if stderrErr := <-t.stderrDone; stderrErr != nil {
 		err = errors.Join(err, fmt.Errorf("read codex stderr: %w", stderrErr))
 	}

--- a/internal/codex/transport_test.go
+++ b/internal/codex/transport_test.go
@@ -18,6 +18,8 @@ import (
 	"github.com/digitaldrywood/detent/internal/procgroup"
 )
 
+const oversizedJSONRPCPayloadSize = 4 * 1024 * 1024
+
 func TestLocalTransportRoundTrip(t *testing.T) {
 	t.Parallel()
 
@@ -63,6 +65,100 @@ func TestLocalTransportRoundTrip(t *testing.T) {
 		t.Fatalf("ID = %s, want 42", response.ID)
 	}
 	assertJSONEqual(t, response.Result, json.RawMessage(`{"echoedMethod":"ping","ok":true}`))
+}
+
+func TestLocalTransportReceivesOversizedFrame(t *testing.T) {
+	t.Parallel()
+
+	factory, err := NewLocalTransportFactory(func(ctx context.Context) *exec.Cmd {
+		return helperCommand(ctx, "oversized-frame")
+	})
+	if err != nil {
+		t.Fatalf("NewLocalTransportFactory() error = %v", err)
+	}
+	transport, err := factory.NewTransport(context.Background())
+	if err != nil {
+		t.Fatalf("NewTransport() error = %v", err)
+	}
+	t.Cleanup(func() {
+		closeCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		_ = transport.Close(closeCtx)
+	})
+
+	receiveCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	msg, err := transport.Receive(receiveCtx)
+	if err != nil {
+		t.Fatalf("Receive() error = %v", err)
+	}
+	if msg.Method != "item/agentMessage" {
+		t.Fatalf("Method = %q, want item/agentMessage", msg.Method)
+	}
+	var params struct {
+		Text string `json:"text"`
+	}
+	if err := json.Unmarshal(msg.Params, &params); err != nil {
+		t.Fatalf("unmarshal params: %v", err)
+	}
+	if len(params.Text) != oversizedJSONRPCPayloadSize {
+		t.Fatalf("params text length = %d, want %d", len(params.Text), oversizedJSONRPCPayloadSize)
+	}
+}
+
+func TestLocalTransportCloseDrainsAfterReadFailure(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name               string
+		mode               string
+		receiveBeforeClose bool
+	}{
+		{name: "failure reported before close", mode: "invalid-frame-backpressure", receiveBeforeClose: true},
+		{name: "failure arrives after close starts", mode: "close-before-invalid-frame-backpressure"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			factory, err := NewLocalTransportFactory(func(ctx context.Context) *exec.Cmd {
+				return helperCommand(ctx, tt.mode)
+			})
+			if err != nil {
+				t.Fatalf("NewLocalTransportFactory() error = %v", err)
+			}
+			transport, err := factory.NewTransport(context.Background())
+			if err != nil {
+				t.Fatalf("NewTransport() error = %v", err)
+			}
+			local, ok := transport.(*localTransport)
+			if !ok {
+				t.Fatalf("transport = %T, want *localTransport", transport)
+			}
+			t.Cleanup(func() {
+				closeCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+				defer cancel()
+				_ = transport.Close(closeCtx)
+			})
+
+			if tt.receiveBeforeClose {
+				receiveCtx, cancelReceive := context.WithTimeout(context.Background(), 5*time.Second)
+				defer cancelReceive()
+				_, err = transport.Receive(receiveCtx)
+				if !errors.Is(err, ErrInvalidFrame) {
+					t.Fatalf("Receive() error = %v, want ErrInvalidFrame", err)
+				}
+			}
+
+			closeCtx, cancelClose := context.WithTimeout(context.Background(), 5*time.Second)
+			defer cancelClose()
+			if err := transport.Close(closeCtx); err != nil {
+				t.Fatalf("Close() error = %v", err)
+			}
+			assertLocalTransportClosed(t, local, tt.name)
+		})
+	}
 }
 
 func TestLocalTransportReceiveHonorsContext(t *testing.T) {
@@ -203,7 +299,7 @@ func TestLocalTransportSendHonorsContextDuringBlockedWrite(t *testing.T) {
 		}
 	})
 
-	params, err := json.Marshal(strings.Repeat("x", 2*MaxScanTokenSize))
+	params, err := json.Marshal(strings.Repeat("x", oversizedJSONRPCPayloadSize))
 	if err != nil {
 		t.Fatalf("Marshal() error = %v", err)
 	}
@@ -327,7 +423,7 @@ func TestLocalTransportPublishReceivedStopsDuringBackpressure(t *testing.T) {
 func TestLocalTransportCloseUnblocksBlockedWriteAndPublish(t *testing.T) {
 	t.Parallel()
 
-	params, err := json.Marshal(strings.Repeat("x", 2*MaxScanTokenSize))
+	params, err := json.Marshal(strings.Repeat("x", oversizedJSONRPCPayloadSize))
 	if err != nil {
 		t.Fatalf("Marshal() error = %v", err)
 	}
@@ -564,6 +660,15 @@ func TestLocalTransportHelperProcess(t *testing.T) {
 	switch mode {
 	case "roundtrip":
 		helperRoundTrip()
+	case "oversized-frame":
+		helperOversizedFrame()
+	case "invalid-frame-backpressure":
+		helperInvalidFrameBackpressure()
+	case "close-before-invalid-frame-backpressure":
+		if _, err := io.Copy(io.Discard, os.Stdin); err != nil {
+			helperBackpressureExit("wait for stdin close", err)
+		}
+		helperInvalidFrameBackpressure()
 	case "silent":
 		_, _ = io.Copy(io.Discard, os.Stdin)
 	case "block-send":
@@ -641,6 +746,43 @@ func helperFloodOutput(codec *Codec, blockAfterFlood bool) {
 	}
 }
 
+func helperOversizedFrame() {
+	params, err := json.Marshal(map[string]string{
+		"text": strings.Repeat("x", oversizedJSONRPCPayloadSize),
+	})
+	if err != nil {
+		helperBackpressureExit("marshal oversized frame", err)
+	}
+	if err := NewCodec(os.Stdin, os.Stdout).WriteMessage(Message{
+		Method: "item/agentMessage",
+		Params: params,
+	}); err != nil {
+		helperBackpressureExit("write oversized frame", err)
+	}
+}
+
+func helperInvalidFrameBackpressure() {
+	if _, err := fmt.Fprintln(os.Stdout, "{not-json}"); err != nil {
+		helperBackpressureExit("write invalid frame", err)
+	}
+
+	params, err := json.Marshal(map[string]string{
+		"text": strings.Repeat("x", 256*1024),
+	})
+	if err != nil {
+		helperBackpressureExit("marshal backpressure frame", err)
+	}
+	codec := NewCodec(os.Stdin, os.Stdout)
+	for range 64 {
+		if err := codec.WriteMessage(Message{
+			Method: "item/agentMessage/delta",
+			Params: params,
+		}); err != nil {
+			helperBackpressureExit("write backpressure frame", err)
+		}
+	}
+}
+
 func helperBackpressureRespond(codec *Codec, id int, method string, result json.RawMessage) {
 	helperBackpressureExpect(codec, id, method)
 	if err := codec.WriteMessage(Message{
@@ -674,7 +816,7 @@ func helperBackpressureExit(stage string, err error) {
 
 func helperRoundTrip() {
 	scanner := bufio.NewScanner(os.Stdin)
-	scanner.Buffer(make([]byte, 0, 64*1024), MaxScanTokenSize)
+	scanner.Buffer(make([]byte, 0, 64*1024), oversizedJSONRPCPayloadSize)
 
 	if !scanner.Scan() {
 		os.Exit(3)


### PR DESCRIPTION
## Summary

- replace the 2 MiB `bufio.Scanner` ceiling with unbounded newline-delimited JSON-RPC reads
- continue draining app-server stdout after a read/decode failure so provider shutdown and reaping can complete
- cover 4 MiB valid frames and malformed-frame backpressure through the subprocess transport

Fixes #1781

## Test Plan

- `go test ./internal/codex -count=1`
- focused `go test -race ./internal/codex ... -count=10`
- `GOOS=windows GOARCH=amd64 go test -c ./internal/codex`
- `make check`