### PR TITLE
fix(orchestrator): stabilize cause fingerprint

### DIFF
--- a/internal/orchestrator/blocked_cause_recovery.go
+++ b/internal/orchestrator/blocked_cause_recovery.go
@@ -50,6 +50,22 @@ type blockedCauseSignals struct {
 	PRDiffFingerprint    string            `json:"pr_diff_fingerprint,omitempty"`
 }
 
+type blockedCauseIdentity struct {
+	Cause              string            `json:"cause,omitempty"`
+	ConfigFingerprint  string            `json:"config_fingerprint,omitempty"`
+	ToolingFingerprint string            `json:"tooling_fingerprint,omitempty"`
+	BaseFingerprint    string            `json:"base_fingerprint,omitempty"`
+	Health             string            `json:"health,omitempty"`
+	Description        string            `json:"description,omitempty"`
+	ModelOverride      string            `json:"model_override,omitempty"`
+	Labels             []string          `json:"labels,omitempty"`
+	Fields             map[string]string `json:"fields,omitempty"`
+	PRNumber           int               `json:"pr_number,omitempty"`
+	PRHeadSHA          string            `json:"pr_head_sha,omitempty"`
+	PRBaseSHA          string            `json:"pr_base_sha,omitempty"`
+	PRDiffFingerprint  string            `json:"pr_diff_fingerprint,omitempty"`
+}
+
 func (o *Orchestrator) newBlockedRecoveryMetadata(
 	ctx context.Context,
 	issue connector.Issue,
@@ -59,14 +75,15 @@ func (o *Orchestrator) newBlockedRecoveryMetadata(
 	targetState string,
 	fallback DiffStats,
 ) workflowLaneMetadata {
+	cause = strings.TrimSpace(cause)
 	signals := o.blockedCauseSignals(ctx, issue, runMode, targetState, fallback)
 	targetState = blockedCauseTargetState(issue, signals, targetState)
 	return workflowLaneMetadata{
 		BlockedRecovery: &workflowLaneBlockedRecoveryMetadata{
 			Owner:            blockedRecoveryOwnerOrchestrator,
-			Cause:            strings.TrimSpace(cause),
+			Cause:            cause,
 			Predicate:        strings.TrimSpace(predicate),
-			CauseFingerprint: blockedCauseFingerprint(signals),
+			CauseFingerprint: blockedCauseFingerprint(cause, signals),
 			TargetState:      targetState,
 			RunMode:          strings.TrimSpace(runMode),
 			IntentResumable:  blockedCauseResumable(issue, signals),
@@ -123,7 +140,7 @@ func (o *Orchestrator) blockedCauseSignals(
 		Health:               strings.TrimSpace(snapshot.Health),
 		Description:          strings.TrimSpace(issue.Description),
 		ModelOverride:        strings.TrimSpace(issue.ModelOverride),
-		Labels:               blockedCauseLabels(issue.Labels),
+		Labels:               blockedCauseLabels(issue.Labels, o.cfg.StatusLabelPrefix),
 		Workpad:              blockedCauseWorkpadSignal(issue.WorkpadSignal),
 		Fields:               blockedCauseFields(issue.Fields),
 	}
@@ -156,8 +173,14 @@ func blockedCauseWorkpadSignal(signal *workpad.Signal) *workpad.Signal {
 	return &cloned
 }
 
-func blockedCauseLabels(labels []string) []string {
+func blockedCauseLabels(labels []string, statusLabelPrefix string) []string {
 	normalized := normalizeLabels(labels)
+	statusLabelPrefix = strings.ToLower(strings.TrimSpace(statusLabelPrefix))
+	if statusLabelPrefix != "" {
+		normalized = slices.DeleteFunc(normalized, func(label string) bool {
+			return strings.HasPrefix(label, statusLabelPrefix)
+		})
+	}
 	slices.Sort(normalized)
 	return normalized
 }
@@ -179,8 +202,23 @@ func blockedCauseFields(fields map[string]string) map[string]string {
 	return cloned
 }
 
-func blockedCauseFingerprint(signals blockedCauseSignals) string {
-	data, err := json.Marshal(signals)
+func blockedCauseFingerprint(cause string, signals blockedCauseSignals) string {
+	identity := blockedCauseIdentity{
+		Cause:              strings.TrimSpace(cause),
+		ConfigFingerprint:  signals.ConfigFingerprint,
+		ToolingFingerprint: signals.ToolingFingerprint,
+		BaseFingerprint:    signals.BaseFingerprint,
+		Health:             signals.Health,
+		Description:        signals.Description,
+		ModelOverride:      signals.ModelOverride,
+		Labels:             signals.Labels,
+		Fields:             signals.Fields,
+		PRNumber:           signals.PRNumber,
+		PRHeadSHA:          signals.PRHeadSHA,
+		PRBaseSHA:          signals.PRBaseSHA,
+		PRDiffFingerprint:  signals.PRDiffFingerprint,
+	}
+	data, err := json.Marshal(identity)
 	if err != nil {
 		return blockedCauseHash(err.Error())
 	}
@@ -274,7 +312,7 @@ func (o *Orchestrator) recoverCauseBlockedIssue(
 		return false
 	}
 	signals := o.blockedCauseSignals(ctx, issue, park.RunMode, park.TargetState, DiffStats{})
-	currentFingerprint := blockedCauseFingerprint(signals)
+	currentFingerprint := blockedCauseFingerprint(park.Cause, signals)
 	if park.Predicate == blockedRecoveryPredicateFingerprintChange && currentFingerprint == park.CauseFingerprint {
 		o.recordBlockedRecoveryDecision(ctx, state, issue, "hold", "cause_unchanged", &park, currentFingerprint)
 		return false

--- a/internal/orchestrator/blocked_cause_recovery.go
+++ b/internal/orchestrator/blocked_cause_recovery.go
@@ -361,7 +361,7 @@ func (o *Orchestrator) reconcileBlockedReadyPullRequest(
 	}
 	signals := o.blockedCauseSignals(ctx, issue, park.RunMode, park.TargetState, DiffStats{})
 	if reason := o.blockedReadyPullRequestDeferredReason(ctx, state, issue, signals, now); reason != "" {
-		o.recordBlockedRecoveryDecision(ctx, state, issue, "defer", reason, &park, blockedCauseFingerprint(signals))
+		o.recordBlockedRecoveryDecision(ctx, state, issue, "defer", reason, &park, blockedCauseFingerprint(park.Cause, signals))
 		return true, false
 	}
 	signature := blockedReadyPullRequestSignature(issue, park)

--- a/internal/orchestrator/blocked_cause_recovery.go
+++ b/internal/orchestrator/blocked_cause_recovery.go
@@ -24,6 +24,7 @@ const (
 	blockedRecoveryPredicateFingerprintChange  = "fingerprint_changed"
 	blockedRecoveryPredicateOncePerFingerprint = "once_per_fingerprint"
 	blockedRecoveryPredicateManaged            = "managed"
+	blockedCauseFingerprintVersion             = 2
 	workflowActionCauseBlockedRecovery         = "cause_blocked_recovery"
 	workflowActionBlockedReadyPRReconciliation = "blocked_ready_pr_reconciliation"
 )
@@ -80,13 +81,14 @@ func (o *Orchestrator) newBlockedRecoveryMetadata(
 	targetState = blockedCauseTargetState(issue, signals, targetState)
 	return workflowLaneMetadata{
 		BlockedRecovery: &workflowLaneBlockedRecoveryMetadata{
-			Owner:            blockedRecoveryOwnerOrchestrator,
-			Cause:            cause,
-			Predicate:        strings.TrimSpace(predicate),
-			CauseFingerprint: blockedCauseFingerprint(cause, signals),
-			TargetState:      targetState,
-			RunMode:          strings.TrimSpace(runMode),
-			IntentResumable:  blockedCauseResumable(issue, signals),
+			Owner:                   blockedRecoveryOwnerOrchestrator,
+			Cause:                   cause,
+			Predicate:               strings.TrimSpace(predicate),
+			CauseFingerprint:        blockedCauseFingerprint(cause, signals),
+			CauseFingerprintVersion: blockedCauseFingerprintVersion,
+			TargetState:             targetState,
+			RunMode:                 strings.TrimSpace(runMode),
+			IntentResumable:         blockedCauseResumable(issue, signals),
 		},
 	}
 }
@@ -311,15 +313,19 @@ func (o *Orchestrator) recoverCauseBlockedIssue(
 		o.recordBlockedRecoveryDecision(ctx, state, issue, "hold", "managed_recovery", &park, park.CauseFingerprint)
 		return false
 	}
+	if park.Predicate != blockedRecoveryPredicateFingerprintChange &&
+		park.Predicate != blockedRecoveryPredicateOncePerFingerprint {
+		o.recordBlockedRecoveryDecision(ctx, state, issue, "hold", "no_recovery_predicate", &park, park.CauseFingerprint)
+		return false
+	}
+	if park.CauseFingerprintVersion != blockedCauseFingerprintVersion {
+		o.recordBlockedRecoveryDecision(ctx, state, issue, "hold", "legacy_cause_fingerprint", &park, park.CauseFingerprint)
+		return false
+	}
 	signals := o.blockedCauseSignals(ctx, issue, park.RunMode, park.TargetState, DiffStats{})
 	currentFingerprint := blockedCauseFingerprint(park.Cause, signals)
 	if park.Predicate == blockedRecoveryPredicateFingerprintChange && currentFingerprint == park.CauseFingerprint {
 		o.recordBlockedRecoveryDecision(ctx, state, issue, "hold", "cause_unchanged", &park, currentFingerprint)
-		return false
-	}
-	if park.Predicate != blockedRecoveryPredicateFingerprintChange &&
-		park.Predicate != blockedRecoveryPredicateOncePerFingerprint {
-		o.recordBlockedRecoveryDecision(ctx, state, issue, "hold", "no_recovery_predicate", &park, currentFingerprint)
 		return false
 	}
 	signature := blockedCauseRecoverySignature(park.Cause, currentFingerprint)
@@ -647,6 +653,8 @@ func BlockedRecoveryOperatorRemedy(issue connector.Issue, reason string) string 
 		return "Change the blocking cause, or move the issue to a lane that starts fresh work."
 	case "fingerprint_already_consumed":
 		return "Change the blocking cause, or move the issue to a lane that starts fresh work."
+	case "legacy_cause_fingerprint":
+		return "Review the blocking cause, then move the issue to a lane that starts fresh work."
 	case "transition_failed":
 		return "Retry the lane transition after restoring tracker write access."
 	case "managed_recovery":

--- a/internal/orchestrator/blocked_cause_recovery_test.go
+++ b/internal/orchestrator/blocked_cause_recovery_test.go
@@ -472,6 +472,55 @@ func TestBlockedCauseFingerprintIgnoresAttemptMutatedSignals(t *testing.T) {
 	}
 }
 
+func TestCauseBlockedRecoveryHoldsLegacyFingerprint(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		predicate string
+	}{
+		{name: "fingerprint change", predicate: blockedRecoveryPredicateFingerprintChange},
+		{name: "once per fingerprint", predicate: blockedRecoveryPredicateOncePerFingerprint},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			issue := dependencyAutoUnblockIssue("issue-legacy-"+strings.ReplaceAll(tt.name, " ", "-"), blockedStatusState)
+			metrics := &autoPromoteWorkflowMetricsRecorder{}
+			parkOrch := blockedCauseTestOrchestrator(&dependencyAutoUnblockConnector{})
+			parkOrch.recoveryInspector = staticBlockedRecoveryInspector{snapshot: runpkg.BlockedRecoverySnapshot{ConfigFingerprint: "config-old", Health: "ready"}}
+			metadata := parkOrch.newBlockedRecoveryMetadata(t.Context(), issue, RunModeImplement, noProgressLimitReason, tt.predicate, "Todo", DiffStats{})
+			metadata.BlockedRecovery.CauseFingerprint = "legacy-fingerprint"
+			metadata.BlockedRecovery.CauseFingerprintVersion = 0
+			parkedAt := time.Date(2026, 8, 13, 18, 0, 0, 0, time.UTC)
+			recordBlockedCausePark(t, metrics, issue, parkedAt, metadata)
+
+			tracker := &dependencyAutoUnblockConnector{}
+			orch := blockedCauseTestOrchestrator(tracker)
+			orch.workflowMetrics = metrics
+			orch.recoveryInspector = staticBlockedRecoveryInspector{snapshot: runpkg.BlockedRecoverySnapshot{ConfigFingerprint: "config-new", Health: "ready"}}
+			state := newState(orch.cfg)
+			state.Blocked[issue.ID] = Blocked{
+				Issue:     issue,
+				Source:    BlockedSourceProjectStatus,
+				BlockedAt: parkedAt,
+				Recovery:  metadata.BlockedRecovery,
+			}
+
+			transitioned := orch.recoverBlockedIssues(t.Context(), &state, []connector.Issue{issue}, parkedAt.Add(time.Minute))
+
+			if len(tracker.updates) != 0 || len(transitioned) != 0 {
+				t.Fatalf("updates = %#v, transitioned = %#v, want legacy fingerprint held", tracker.updates, transitioned)
+			}
+			blocked := state.Blocked[issue.ID]
+			if blocked.RecoveryAction != "hold" || blocked.RecoveryReason != "legacy_cause_fingerprint" || !blocked.NeedsHumanAttention {
+				t.Fatalf("blocked recovery = %#v, want visible legacy-fingerprint hold", blocked)
+			}
+		})
+	}
+}
+
 func TestBlockedRecoveryMetadataSeparatesIntentFromReachability(t *testing.T) {
 	t.Parallel()
 
@@ -494,6 +543,9 @@ func TestBlockedRecoveryMetadataSeparatesIntentFromReachability(t *testing.T) {
 	)
 	raw := workflowLaneMetadataJSON(issue, metadata)
 	if !strings.Contains(raw, `"intent_resumable":true`) {
+		t.Fatalf("metadata = %s", raw)
+	}
+	if !strings.Contains(raw, `"cause_fingerprint_version":2`) {
 		t.Fatalf("metadata = %s", raw)
 	}
 	if strings.Contains(raw, `"resumable":true`) {

--- a/internal/orchestrator/blocked_cause_recovery_test.go
+++ b/internal/orchestrator/blocked_cause_recovery_test.go
@@ -228,12 +228,17 @@ func TestCauseBlockedRecoveryPersistsAndBoundsFingerprintAttempts(t *testing.T) 
 	t.Parallel()
 
 	tests := []struct {
-		name           string
-		predicate      string
-		parked         runpkg.BlockedRecoverySnapshot
-		current        runpkg.BlockedRecoverySnapshot
-		wantTarget     string
-		wantTransition bool
+		name                  string
+		predicate             string
+		parked                runpkg.BlockedRecoverySnapshot
+		current               runpkg.BlockedRecoverySnapshot
+		parkedLabels          []string
+		currentLabels         []string
+		parkedWorkpad         *workpad.Signal
+		currentWorkpad        *workpad.Signal
+		wantTarget            string
+		wantTransition        bool
+		wantStableFingerprint bool
 	}{
 		{
 			name:           "changed configuration fingerprint",
@@ -244,10 +249,43 @@ func TestCauseBlockedRecoveryPersistsAndBoundsFingerprintAttempts(t *testing.T) 
 			wantTransition: true,
 		},
 		{
-			name:      "unchanged no-progress cause",
+			name:                  "unchanged no-progress cause",
+			predicate:             blockedRecoveryPredicateFingerprintChange,
+			parked:                runpkg.BlockedRecoverySnapshot{ConfigFingerprint: "config-same", Health: "ready", WorkspaceStatus: "missing"},
+			current:               runpkg.BlockedRecoverySnapshot{ConfigFingerprint: "config-same", Health: "ready", WorkspaceStatus: "missing"},
+			wantStableFingerprint: true,
+		},
+		{
+			name:      "attempt workspace churn leaves failure cause unchanged",
 			predicate: blockedRecoveryPredicateFingerprintChange,
-			parked:    runpkg.BlockedRecoverySnapshot{ConfigFingerprint: "config-same", Health: "ready", WorkspaceStatus: "missing"},
-			current:   runpkg.BlockedRecoverySnapshot{ConfigFingerprint: "config-same", Health: "ready", WorkspaceStatus: "missing"},
+			parked: runpkg.BlockedRecoverySnapshot{
+				ConfigFingerprint:    "config-same",
+				WorkspaceFingerprint: "workspace-before-failure",
+				WorkspaceStatus:      "clean",
+				WorkspacePresent:     true,
+				Health:               "ready",
+			},
+			current: runpkg.BlockedRecoverySnapshot{
+				ConfigFingerprint:    "config-same",
+				WorkspaceFingerprint: "workspace-after-failure",
+				WorkspaceStatus:      "dirty",
+				WorkspacePresent:     true,
+				WorkspaceFiles:       1,
+				Health:               "ready",
+			},
+			parkedLabels:  []string{"bug", "detent:in-progress"},
+			currentLabels: []string{"bug", "detent:blocked"},
+			parkedWorkpad: &workpad.Signal{
+				Source: workpad.SourceStructured,
+				Status: workpad.StatusInProgress,
+				Fields: map[string]string{"attempt": "4"},
+			},
+			currentWorkpad: &workpad.Signal{
+				Source: workpad.SourceStructured,
+				Status: workpad.StatusInProgress,
+				Fields: map[string]string{"attempt": "5"},
+			},
+			wantStableFingerprint: true,
 		},
 		{
 			name:      "stranded workspace once per unchanged fingerprint",
@@ -278,6 +316,8 @@ func TestCauseBlockedRecoveryPersistsAndBoundsFingerprintAttempts(t *testing.T) 
 			t.Parallel()
 
 			issue := dependencyAutoUnblockIssue("issue-"+strings.ReplaceAll(tt.name, " ", "-"), blockedStatusState)
+			issue.Labels = append([]string(nil), tt.parkedLabels...)
+			issue.WorkpadSignal = tt.parkedWorkpad
 			metrics := &autoPromoteWorkflowMetricsRecorder{}
 			parkTracker := &dependencyAutoUnblockConnector{}
 			parkOrch := blockedCauseTestOrchestrator(parkTracker)
@@ -294,14 +334,31 @@ func TestCauseBlockedRecoveryPersistsAndBoundsFingerprintAttempts(t *testing.T) 
 				DiffStats{},
 			)
 			recordBlockedCausePark(t, metrics, issue, parkedAt, metadata)
+			currentIssue := cloneIssue(issue)
+			if tt.currentLabels != nil {
+				currentIssue.Labels = append([]string(nil), tt.currentLabels...)
+			}
+			if tt.currentWorkpad != nil {
+				currentIssue.WorkpadSignal = tt.currentWorkpad
+			}
 
 			tracker := &dependencyAutoUnblockConnector{}
 			orch := blockedCauseTestOrchestrator(tracker)
 			orch.workflowMetrics = metrics
 			orch.recoveryInspector = staticBlockedRecoveryInspector{snapshot: tt.current}
 			state := newState(orch.cfg)
+			state.Blocked[issue.ID] = Blocked{
+				Issue:     currentIssue,
+				Source:    BlockedSourceProjectStatus,
+				BlockedAt: parkedAt,
+				Recovery:  metadata.BlockedRecovery,
+			}
+			currentFingerprint := blockedCauseFingerprint(noProgressLimitReason, orch.blockedCauseSignals(t.Context(), currentIssue, RunModeImplement, metadata.BlockedRecovery.TargetState, DiffStats{}))
+			if tt.wantStableFingerprint && currentFingerprint != metadata.BlockedRecovery.CauseFingerprint {
+				t.Fatalf("current fingerprint = %q, parked fingerprint = %q", currentFingerprint, metadata.BlockedRecovery.CauseFingerprint)
+			}
 
-			transitioned := orch.recoverBlockedIssues(t.Context(), &state, []connector.Issue{issue}, parkedAt.Add(time.Minute))
+			transitioned := orch.recoverBlockedIssues(t.Context(), &state, []connector.Issue{currentIssue}, parkedAt.Add(time.Minute))
 
 			if tt.wantTransition {
 				if len(tracker.updates) != 1 || tracker.updates[0].state != tt.wantTarget {
@@ -310,7 +367,6 @@ func TestCauseBlockedRecoveryPersistsAndBoundsFingerprintAttempts(t *testing.T) 
 				if _, ok := transitioned[issue.ID]; !ok {
 					t.Fatalf("transitioned[%q] missing", issue.ID)
 				}
-				currentFingerprint := blockedCauseFingerprint(orch.blockedCauseSignals(t.Context(), issue, RunModeImplement, metadata.BlockedRecovery.TargetState, DiffStats{}))
 				assertWorkflowActionSignature(t, metrics, issue, workflowActionCauseBlockedRecovery, blockedCauseRecoverySignature(noProgressLimitReason, currentFingerprint))
 
 				if tt.predicate == blockedRecoveryPredicateOncePerFingerprint {
@@ -319,7 +375,7 @@ func TestCauseBlockedRecoveryPersistsAndBoundsFingerprintAttempts(t *testing.T) 
 					restarted := blockedCauseTestOrchestrator(restartedTracker)
 					restarted.workflowMetrics = metrics
 					restarted.recoveryInspector = staticBlockedRecoveryInspector{snapshot: tt.current}
-					restarted.recoverBlockedIssues(t.Context(), &state, []connector.Issue{issue}, parkedAt.Add(3*time.Minute))
+					restarted.recoverBlockedIssues(t.Context(), &state, []connector.Issue{currentIssue}, parkedAt.Add(3*time.Minute))
 					if len(restartedTracker.updates) != 0 {
 						t.Fatalf("restart updates = %#v, want consumed fingerprint held", restartedTracker.updates)
 					}
@@ -332,6 +388,12 @@ func TestCauseBlockedRecoveryPersistsAndBoundsFingerprintAttempts(t *testing.T) 
 			if _, ok := transitioned[issue.ID]; ok {
 				t.Fatalf("transitioned[%q] present", issue.ID)
 			}
+			if tt.wantStableFingerprint {
+				blocked := state.Blocked[issue.ID]
+				if blocked.RecoveryAction != "hold" || blocked.RecoveryReason != "cause_unchanged" || !blocked.NeedsHumanAttention {
+					t.Fatalf("blocked recovery = %#v, want visible cause-unchanged hold", blocked)
+				}
+			}
 		})
 	}
 }
@@ -339,15 +401,74 @@ func TestCauseBlockedRecoveryPersistsAndBoundsFingerprintAttempts(t *testing.T) 
 func TestBlockedCauseFingerprintTracksNormalizedLabels(t *testing.T) {
 	t.Parallel()
 
-	original := blockedCauseSignals{Labels: blockedCauseLabels([]string{"bug", "detent:blocked"})}
-	reordered := blockedCauseSignals{Labels: blockedCauseLabels([]string{" DETENT:BLOCKED ", "Bug", "bug"})}
-	withOverride := blockedCauseSignals{Labels: blockedCauseLabels([]string{"bug", "detent:blocked", "agent:max-tokens"})}
+	original := blockedCauseSignals{Labels: blockedCauseLabels([]string{"bug", "detent:in-progress"}, "detent:")}
+	reordered := blockedCauseSignals{Labels: blockedCauseLabels([]string{" DETENT:BLOCKED ", "Bug", "bug"}, "detent:")}
+	withOverride := blockedCauseSignals{Labels: blockedCauseLabels([]string{"bug", "detent:blocked", "agent:max-tokens"}, "detent:")}
 
-	if blockedCauseFingerprint(original) != blockedCauseFingerprint(reordered) {
-		t.Fatal("equivalent labels changed the cause fingerprint")
+	if blockedCauseFingerprint(noProgressLimitReason, original) != blockedCauseFingerprint(noProgressLimitReason, reordered) {
+		t.Fatal("status label transition changed the cause fingerprint")
 	}
-	if blockedCauseFingerprint(original) == blockedCauseFingerprint(withOverride) {
+	if blockedCauseFingerprint(noProgressLimitReason, original) == blockedCauseFingerprint(noProgressLimitReason, withOverride) {
 		t.Fatal("recovery-affecting label did not change the cause fingerprint")
+	}
+	if blockedCauseFingerprint(noProgressLimitReason, original) == blockedCauseFingerprint(spendProgressReason, original) {
+		t.Fatal("failure cause did not change the cause fingerprint")
+	}
+}
+
+func TestBlockedCauseFingerprintIgnoresAttemptMutatedSignals(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		current blockedCauseSignals
+	}{
+		{
+			name: "workspace churn",
+			current: blockedCauseSignals{
+				ConfigFingerprint:    "config-same",
+				WorkspaceFingerprint: "workspace-after-failure",
+				WorkspaceStatus:      "dirty",
+				WorkspacePresent:     true,
+				WorkspaceFiles:       1,
+				UnpushedCommits:      1,
+				Health:               "ready",
+			},
+		},
+		{
+			name: "workpad churn",
+			current: blockedCauseSignals{
+				ConfigFingerprint: "config-same",
+				Health:            "ready",
+				Workpad: &workpad.Signal{
+					Source: workpad.SourceStructured,
+					Status: workpad.StatusInProgress,
+					Fields: map[string]string{"attempt": "5"},
+				},
+			},
+		},
+	}
+
+	parked := blockedCauseSignals{
+		ConfigFingerprint:    "config-same",
+		WorkspaceFingerprint: "workspace-before-failure",
+		WorkspaceStatus:      "clean",
+		WorkspacePresent:     true,
+		Health:               "ready",
+		Workpad: &workpad.Signal{
+			Source: workpad.SourceStructured,
+			Status: workpad.StatusInProgress,
+			Fields: map[string]string{"attempt": "4"},
+		},
+	}
+	want := blockedCauseFingerprint("instant_failure_circuit_breaker", parked)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := blockedCauseFingerprint("instant_failure_circuit_breaker", tt.current); got != want {
+				t.Fatalf("fingerprint = %q, want %q", got, want)
+			}
+		})
 	}
 }
 
@@ -628,6 +749,7 @@ func blockedReadyPullRequestIssue() connector.Issue {
 func blockedCauseTestOrchestrator(tracker *dependencyAutoUnblockConnector) *Orchestrator {
 	orch := dependencyAutoUnblockOrchestrator(tracker, DependencyAutoUnblockConfig{})
 	orch.cfg.BlockedRecovery.Enabled = false
+	orch.cfg.StatusLabelPrefix = "detent:"
 	return orch
 }
 

--- a/internal/orchestrator/config.go
+++ b/internal/orchestrator/config.go
@@ -76,8 +76,9 @@ func ConfigFromWorkflow(cfg workflowconfig.Config) Config {
 			WorkpadStructuredOnly: cfg.Workpad.StructuredOnly,
 			Gate:                  gate.Effective(cfg.Gate),
 		}),
-		Plan:             gate.EffectivePlan(cfg.Plan),
-		DependencySource: normalizeDependencySource(cfg.Dependencies.Source),
+		Plan:              gate.EffectivePlan(cfg.Plan),
+		DependencySource:  normalizeDependencySource(cfg.Dependencies.Source),
+		StatusLabelPrefix: blockedCauseStatusLabelPrefix(cfg),
 		DependencyAutoUnblock: normalizeDependencyAutoUnblockConfig(DependencyAutoUnblockConfig{
 			Enabled:      cfg.Tracker.DependencyAutoUnblock.Enabled,
 			SourceStates: append([]string(nil), cfg.Tracker.DependencyAutoUnblock.SourceStates...),
@@ -246,6 +247,7 @@ func normalizeConfig(cfg Config) Config {
 	cfg.AutoPromote = normalizeAutoPromoteConfig(cfg.AutoPromote)
 	cfg.Plan = gate.EffectivePlan(cfg.Plan)
 	cfg.DependencySource = normalizeDependencySource(cfg.DependencySource)
+	cfg.StatusLabelPrefix = strings.ToLower(strings.TrimSpace(cfg.StatusLabelPrefix))
 	cfg.DependencyAutoUnblock = normalizeDependencyAutoUnblockConfig(cfg.DependencyAutoUnblock)
 	cfg.BlockedRecovery = normalizeBlockedRecoveryConfig(cfg.BlockedRecovery)
 	cfg.BlockerAutoPromote = normalizeBlockerAutoPromoteConfig(cfg.BlockerAutoPromote, cfg.ActiveStates, cfg.DependencyAutoUnblock)
@@ -265,6 +267,13 @@ func normalizeConfig(cfg Config) Config {
 	}
 
 	return cfg
+}
+
+func blockedCauseStatusLabelPrefix(cfg workflowconfig.Config) string {
+	if cfg.Tracker.GitHubStatusSource != workflowconfig.GitHubStatusSourceLabel {
+		return ""
+	}
+	return strings.ToLower(strings.TrimSpace(cfg.Tracker.StatusLabelPrefix))
 }
 
 func stopRunPriorityNames(value workflowconfig.StringOrMap) map[int]string {

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -93,6 +93,7 @@ type Config struct {
 	AutoPromote                   AutoPromoteConfig
 	Plan                          gate.PlanConfig
 	DependencySource              string
+	StatusLabelPrefix             string
 	DependencyAutoUnblock         DependencyAutoUnblockConfig
 	BlockedRecovery               BlockedRecoveryConfig
 	BlockerAutoPromote            BlockerAutoPromoteConfig

--- a/internal/orchestrator/ranking_test.go
+++ b/internal/orchestrator/ranking_test.go
@@ -356,6 +356,31 @@ func TestConfigFromWorkflowIncludesDispatchPriorityByState(t *testing.T) {
 	}
 }
 
+func TestConfigFromWorkflowIncludesBlockedCauseStatusLabelPrefix(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		source string
+		want   string
+	}{
+		{name: "label status source", source: workflowconfig.GitHubStatusSourceLabel, want: "workflow:"},
+		{name: "project status source", source: workflowconfig.GitHubStatusSourceProjectV2},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			workflow := workflowconfig.Default()
+			workflow.Tracker.GitHubStatusSource = tt.source
+			workflow.Tracker.StatusLabelPrefix = " Workflow: "
+			if got := ConfigFromWorkflow(workflow).StatusLabelPrefix; got != tt.want {
+				t.Fatalf("StatusLabelPrefix = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
 func rankingIssue(id string, state string, priority int, createdAt time.Time) connector.Issue {
 	issue := connector.NewIssue()
 	issue.ID = id

--- a/internal/orchestrator/workflow_metrics.go
+++ b/internal/orchestrator/workflow_metrics.go
@@ -56,17 +56,18 @@ type workflowLaneReworkBreakerMetadata struct {
 }
 
 type workflowLaneBlockedRecoveryMetadata struct {
-	Owner            string `json:"owner,omitempty"`
-	Cause            string `json:"cause,omitempty"`
-	Predicate        string `json:"predicate,omitempty"`
-	CauseFingerprint string `json:"cause_fingerprint,omitempty"`
-	TargetState      string `json:"target_state,omitempty"`
-	RunMode          string `json:"run_mode,omitempty"`
-	IntentResumable  bool   `json:"intent_resumable,omitempty"`
-	Resumable        bool   `json:"resumable,omitempty"`
-	Reachability     string `json:"reachability,omitempty"`
-	HoldReason       string `json:"hold_reason,omitempty"`
-	OperatorRemedy   string `json:"operator_remedy,omitempty"`
+	Owner                   string `json:"owner,omitempty"`
+	Cause                   string `json:"cause,omitempty"`
+	Predicate               string `json:"predicate,omitempty"`
+	CauseFingerprint        string `json:"cause_fingerprint,omitempty"`
+	CauseFingerprintVersion int    `json:"cause_fingerprint_version,omitempty"`
+	TargetState             string `json:"target_state,omitempty"`
+	RunMode                 string `json:"run_mode,omitempty"`
+	IntentResumable         bool   `json:"intent_resumable,omitempty"`
+	Resumable               bool   `json:"resumable,omitempty"`
+	Reachability            string `json:"reachability,omitempty"`
+	HoldReason              string `json:"hold_reason,omitempty"`
+	OperatorRemedy          string `json:"operator_remedy,omitempty"`
 }
 
 func (m workflowLaneBlockedRecoveryMetadata) intentResumable() bool {


### PR DESCRIPTION
## Summary

- hash a narrow blocked-recovery cause identity instead of attempt-mutated workspace and Workpad signals
- ignore configured status-label churn while preserving operator-controlled label, config, tooling, base, health, field, and PR inputs
- version the new fingerprint schema and fail closed for legacy persisted hashes so deployment cannot grant an unintended retry
- keep identical failures held in Blocked and surface the existing cause-unchanged human-attention remedy

Fixes #1782

## UI Surface Contract

- [x] N/A, or the linked issue explicitly authorizes any high-impact UI surface, layout, density, first-viewport, or responsive visibility tradeoff.
- [x] Persistent top-of-screen messaging is explicitly authorized by the issue, or this PR does not add it.
- [x] Visual changes to primary operator screens include screenshot or browser verification below. (No visual changes.)

## Test Plan

- [x] `go test ./internal/orchestrator -count=1`
- [x] table-driven regression coverage for workspace, Workpad, status-label, and legacy-fingerprint behavior
- [x] `make check` after rebasing onto current `origin/main`