### PR TITLE
fix(recovery): reconcile exact-head pull requests

### DIFF
--- a/internal/connector/connector.go
+++ b/internal/connector/connector.go
@@ -164,6 +164,10 @@ type PullRequestHydrator interface {
 	HydratePullRequest(context.Context, Issue) (Issue, error)
 }
 
+type PullRequestHeadLookup interface {
+	LookupPullRequestByHead(context.Context, string, string, string) (PullRequest, bool, error)
+}
+
 type PullRequestDiffFingerprintReader interface {
 	PullRequestDiffFingerprint(context.Context, Issue) (string, error)
 }

--- a/internal/connector/github/adapter_test.go
+++ b/internal/connector/github/adapter_test.go
@@ -4595,6 +4595,76 @@ func TestConnectorHydratePullRequestRefreshesCurrentStatus(t *testing.T) {
 	}
 }
 
+func TestConnectorLookupPullRequestByHeadUsesExactCurrentHead(t *testing.T) {
+	t.Parallel()
+
+	const (
+		branch  = "detent/acme_widgets_18"
+		headSHA = "current-head"
+		path    = "/repos/example/repo/pulls?direction=desc&head=example%3Adetent%2Facme_widgets_18&per_page=100&sort=updated&state=all"
+	)
+	tests := []struct {
+		name      string
+		body      string
+		wantFound bool
+		wantState string
+	}{
+		{
+			name:      "open exact head",
+			body:      `[{"node_id":"PR_42","number":42,"html_url":"https://github.com/example/repo/pull/42","state":"open","head":{"ref":"detent/acme_widgets_18","sha":"current-head"},"base":{"ref":"main","sha":"base-head"}}]`,
+			wantFound: true,
+			wantState: "OPEN",
+		},
+		{
+			name:      "merged exact head",
+			body:      `[{"node_id":"PR_42","number":42,"html_url":"https://github.com/example/repo/pull/42","state":"closed","merged_at":"2026-08-12T18:00:00Z","head":{"ref":"detent/acme_widgets_18","sha":"current-head"},"base":{"ref":"main","sha":"base-head"}}]`,
+			wantFound: true,
+			wantState: "MERGED",
+		},
+		{
+			name:      "closed unmerged exact head",
+			body:      `[{"node_id":"PR_42","number":42,"html_url":"https://github.com/example/repo/pull/42","state":"closed","head":{"ref":"detent/acme_widgets_18","sha":"current-head"},"base":{"ref":"main","sha":"base-head"}}]`,
+			wantFound: true,
+			wantState: "CLOSED",
+		},
+		{
+			name: "stale head does not match",
+			body: `[{"node_id":"PR_42","number":42,"html_url":"https://github.com/example/repo/pull/42","state":"open","head":{"ref":"detent/acme_widgets_18","sha":"stale-head"},"base":{"ref":"main","sha":"base-head"}}]`,
+		},
+		{
+			name: "no pull request",
+			body: `[]`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			server := newGraphQLTestServer(t, []graphqlTestResponse{{
+				method: http.MethodGet,
+				path:   path,
+				body:   tt.body,
+			}})
+			c := newGitHubTestConnector(t, server, Config{})
+
+			pullRequest, found, err := c.LookupPullRequestByHead(t.Context(), "example/repo", branch, headSHA)
+			if err != nil {
+				t.Fatalf("LookupPullRequestByHead() error = %v", err)
+			}
+			if found != tt.wantFound {
+				t.Fatalf("LookupPullRequestByHead() = %#v, found = %v, want %v", pullRequest, found, tt.wantFound)
+			}
+			if !tt.wantFound {
+				return
+			}
+			if pullRequest.Number != 42 || pullRequest.State != tt.wantState || pullRequest.BranchName != branch || pullRequest.HeadSHA != headSHA {
+				t.Fatalf("LookupPullRequestByHead() = %#v, want PR 42 state %s on exact head", pullRequest, tt.wantState)
+			}
+		})
+	}
+}
+
 func TestConnectorPullRequestDiffFingerprintIsContentStableAndCached(t *testing.T) {
 	t.Parallel()
 

--- a/internal/connector/github/pull_requests.go
+++ b/internal/connector/github/pull_requests.go
@@ -333,6 +333,35 @@ func (c *Connector) HydratePullRequest(ctx context.Context, issue connector.Issu
 	return issue, nil
 }
 
+func (c *Connector) LookupPullRequestByHead(
+	ctx context.Context,
+	repository string,
+	branch string,
+	headSHA string,
+) (connector.PullRequest, bool, error) {
+	repo, ok := pullRequestRepoFromName(repository)
+	branch = strings.TrimSpace(branch)
+	headSHA = strings.TrimSpace(headSHA)
+	if !ok || branch == "" || headSHA == "" {
+		return connector.PullRequest{}, false, errors.New("lookup github pull request by head: invalid repository, branch, or head SHA")
+	}
+
+	var response []restPullRequest
+	if err := c.client.REST(ctx, http.MethodGet, restPullRequestsByHeadPath(repo, branch), nil, &response); err != nil {
+		return connector.PullRequest{}, false, fmt.Errorf("lookup github pull request by head: %w", err)
+	}
+	for _, candidate := range response {
+		pullRequest := pullRequestNodeFromREST(candidate)
+		if strings.TrimSpace(pullRequest.HeadRefName) != branch || strings.TrimSpace(pullRequest.HeadSHA) != headSHA {
+			continue
+		}
+		issue := connector.Issue{}
+		attachPullRequestToIssue(&issue, repo, pullRequest)
+		return *issue.PullRequest, true, nil
+	}
+	return connector.PullRequest{}, false, nil
+}
+
 func (c *Connector) PullRequestDiffFingerprint(ctx context.Context, issue connector.Issue) (string, error) {
 	repo, number, ok := hydratedPullRequestRef(issue)
 	if !ok || issue.PullRequest == nil {

--- a/internal/connector/github/rest.go
+++ b/internal/connector/github/rest.go
@@ -65,6 +65,16 @@ func restPullRequestsPath(repo pullRequestRepo, page int) string {
 	return "/repos/" + url.PathEscape(repo.Owner) + "/" + url.PathEscape(repo.Name) + "/pulls?" + values.Encode()
 }
 
+func restPullRequestsByHeadPath(repo pullRequestRepo, branch string) string {
+	values := url.Values{}
+	values.Set("state", "all")
+	values.Set("head", repo.Owner+":"+strings.TrimSpace(branch))
+	values.Set("sort", "updated")
+	values.Set("direction", "desc")
+	values.Set("per_page", strconv.Itoa(pullRequestsPageSize))
+	return "/repos/" + url.PathEscape(repo.Owner) + "/" + url.PathEscape(repo.Name) + "/pulls?" + values.Encode()
+}
+
 func restPullRequestPath(repo pullRequestRepo, number int) string {
 	return "/repos/" + url.PathEscape(repo.Owner) + "/" + url.PathEscape(repo.Name) + "/pulls/" + strconv.Itoa(number)
 }

--- a/internal/connector/githublocal/githublocal.go
+++ b/internal/connector/githublocal/githublocal.go
@@ -54,6 +54,7 @@ type githubBackend interface {
 	connector.ProjectRemover
 	connector.PullRequestCommenter
 	connector.PullRequestCommentReader
+	connector.PullRequestHeadLookup
 	connector.PullRequestHydrator
 	connector.PullRequestMergeQueue
 	connector.PullRequestMerger
@@ -122,6 +123,7 @@ var _ connector.ProjectRemover = (*Connector)(nil)
 var _ connector.PullRequestCommenter = (*Connector)(nil)
 var _ connector.PullRequestCommentReader = (*Connector)(nil)
 var _ connector.PullRequestDiffFingerprintReader = (*Connector)(nil)
+var _ connector.PullRequestHeadLookup = (*Connector)(nil)
 var _ connector.PullRequestHydrator = (*Connector)(nil)
 var _ connector.PullRequestLabelReapplier = (*Connector)(nil)
 var _ connector.PullRequestMergeQueue = (*Connector)(nil)
@@ -563,6 +565,10 @@ func (c *Connector) EnqueuePullRequest(ctx context.Context, issue connector.Issu
 
 func (c *Connector) HydratePullRequest(ctx context.Context, issue connector.Issue) (connector.Issue, error) {
 	return c.github.HydratePullRequest(ctx, issue)
+}
+
+func (c *Connector) LookupPullRequestByHead(ctx context.Context, repository string, branch string, headSHA string) (connector.PullRequest, bool, error) {
+	return c.github.LookupPullRequestByHead(ctx, repository, branch, headSHA)
 }
 
 func (c *Connector) PullRequestDiffFingerprint(ctx context.Context, issue connector.Issue) (string, error) {

--- a/internal/connector/githublocal/githublocal_test.go
+++ b/internal/connector/githublocal/githublocal_test.go
@@ -782,6 +782,10 @@ func (b *recordingGitHubBackend) HydratePullRequest(context.Context, connector.I
 	panic("unexpected github HydratePullRequest")
 }
 
+func (b *recordingGitHubBackend) LookupPullRequestByHead(context.Context, string, string, string) (connector.PullRequest, bool, error) {
+	panic("unexpected github LookupPullRequestByHead")
+}
+
 func (b *recordingGitHubBackend) FetchIssueParents(context.Context, string) ([]connector.Issue, error) {
 	panic("unexpected github FetchIssueParents")
 }

--- a/internal/connector/memory/memory.go
+++ b/internal/connector/memory/memory.go
@@ -74,6 +74,7 @@ var _ connector.IssueReferenceResolver = (*Connector)(nil)
 var _ connector.ProjectRemover = (*Connector)(nil)
 var _ connector.PullRequestCommenter = (*Connector)(nil)
 var _ connector.PullRequestDiffFingerprintReader = (*Connector)(nil)
+var _ connector.PullRequestHeadLookup = (*Connector)(nil)
 var _ connector.PullRequestHydrator = (*Connector)(nil)
 var _ connector.PullRequestMerger = (*Connector)(nil)
 
@@ -387,6 +388,23 @@ func (c *Connector) HydratePullRequest(_ context.Context, issue connector.Issue)
 		}
 	}
 	return cloneIssue(issue), nil
+}
+
+func (c *Connector) LookupPullRequestByHead(_ context.Context, repository string, branch string, headSHA string) (connector.PullRequest, bool, error) {
+	repository = normalizeState(repository)
+	branch = strings.TrimSpace(branch)
+	headSHA = strings.TrimSpace(headSHA)
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	for _, issue := range c.issues {
+		if issue.PullRequest == nil || normalizeState(memoryPullRequestRepository(issue)) != repository ||
+			strings.TrimSpace(issue.PullRequest.BranchName) != branch || strings.TrimSpace(issue.PullRequest.HeadSHA) != headSHA {
+			continue
+		}
+		pullRequest := *issue.PullRequest
+		return pullRequest, true, nil
+	}
+	return connector.PullRequest{}, false, nil
 }
 
 func (c *Connector) PullRequestDiffFingerprint(ctx context.Context, issue connector.Issue) (string, error) {

--- a/internal/orchestrator/deliverable_recovery.go
+++ b/internal/orchestrator/deliverable_recovery.go
@@ -3,24 +3,167 @@ package orchestrator
 import (
 	"context"
 	"errors"
+	"fmt"
 	"log/slog"
+	"strconv"
 	"strings"
+	"time"
 
+	"github.com/digitaldrywood/detent/internal/connector"
 	runpkg "github.com/digitaldrywood/detent/internal/runner"
 	"github.com/digitaldrywood/detent/internal/telemetry"
 )
 
-const deliverableRecoveryNeedsHumanReason = "deliverable_recovery_needs_human_attention"
+const (
+	deliverableRecoveryNeedsHumanReason = "deliverable_recovery_needs_human_attention"
+	deliverableRecoveryLookupAttempts   = 3
+	deliverableRecoveryLookupBackoff    = 250 * time.Millisecond
+)
 
-func (o *Orchestrator) blockDeliverableRecoveryFailure(ctx context.Context, state *State, event runpkg.Completion, running Running) bool {
+type deliverableRecoveryLookupResult struct {
+	Branch         string
+	Repository     string
+	HeadSHA        string
+	HydrationState string
+	LookupResult   string
+	Attempts       int
+	PullRequest    *connector.PullRequest
+}
+
+func (r deliverableRecoveryLookupResult) reconciles() bool {
+	if r.PullRequest == nil {
+		return false
+	}
+	state := normalizePullRequestState(r.PullRequest.State)
+	return state == "open" || state == "merged"
+}
+
+func (o *Orchestrator) lookupDeliverableRecovery(
+	ctx context.Context,
+	running Running,
+	recoveryErr *runpkg.DeliverableRecoveryError,
+) deliverableRecoveryLookupResult {
+	result := deliverableRecoveryLookupResult{
+		Branch:         deliverableRecoveryBranch(recoveryErr, running),
+		Repository:     pullRequestRepository(running.Issue),
+		HeadSHA:        strings.TrimSpace(running.DiffStats.HeadSHA),
+		HydrationState: deliverableRecoveryHydrationState(running.Issue.PullRequest),
+	}
+	if result.Repository == "" {
+		result.LookupResult = "PR lookup unavailable: repository is unknown"
+		return result
+	}
+	if result.HeadSHA == "" {
+		result.LookupResult = "PR lookup unavailable: current workspace head SHA is unknown"
+		return result
+	}
+	lookup, ok := o.connector.(connector.PullRequestHeadLookup)
+	if !ok {
+		result.LookupResult = "PR lookup unavailable: connector does not support exact-head lookup"
+		return result
+	}
+
+	var lookupErr error
+	for attempt := 1; attempt <= deliverableRecoveryLookupAttempts; attempt++ {
+		result.Attempts = attempt
+		pullRequest, found, err := lookup.LookupPullRequestByHead(ctx, result.Repository, result.Branch, result.HeadSHA)
+		if err == nil {
+			if !found {
+				result.LookupResult = "no exact-head pull request"
+				return result
+			}
+			fresh := pullRequest
+			result.PullRequest = &fresh
+			if strings.TrimSpace(fresh.BranchName) != result.Branch || strings.TrimSpace(fresh.HeadSHA) != result.HeadSHA {
+				result.LookupResult = fmt.Sprintf(
+					"no exact-head pull request; lookup returned PR #%d branch %q head %q",
+					fresh.Number,
+					strings.TrimSpace(fresh.BranchName),
+					strings.TrimSpace(fresh.HeadSHA),
+				)
+				result.PullRequest = nil
+				return result
+			}
+			state := normalizePullRequestState(fresh.State)
+			switch state {
+			case "open", "merged":
+				result.LookupResult = fmt.Sprintf("exact-head pull request #%d is %s", fresh.Number, state)
+			case "closed":
+				result.LookupResult = fmt.Sprintf("exact-head pull request #%d is closed without merge", fresh.Number)
+			default:
+				result.LookupResult = fmt.Sprintf("exact-head pull request #%d has state %q", fresh.Number, strings.TrimSpace(fresh.State))
+			}
+			return result
+		}
+		lookupErr = err
+		if attempt == deliverableRecoveryLookupAttempts {
+			break
+		}
+		wait := o.deliverableRecoveryWait
+		if wait == nil {
+			wait = waitForDispatchBackoff
+		}
+		if !wait(ctx, deliverableRecoveryLookupBackoff*time.Duration(1<<(attempt-1))) {
+			break
+		}
+	}
+	result.LookupResult = "PR lookup unavailable after " + strconv.Itoa(result.Attempts) + " attempts"
+	if lookupErr != nil {
+		result.LookupResult += ": " + o.operatorText(lookupErr.Error())
+	}
+	return result
+}
+
+func deliverableRecoveryHydrationState(pullRequest *connector.PullRequest) string {
+	if pullRequest == nil {
+		return "none at dispatch"
+	}
+	return fmt.Sprintf(
+		"cached at dispatch: PR #%d state=%q branch=%q head=%q",
+		pullRequest.Number,
+		strings.TrimSpace(pullRequest.State),
+		strings.TrimSpace(pullRequest.BranchName),
+		strings.TrimSpace(pullRequest.HeadSHA),
+	)
+}
+
+func deliverableRecoveryIssue(running Running, lookup deliverableRecoveryLookupResult) connector.Issue {
+	issue := cloneIssue(running.Issue)
+	if lookup.PullRequest == nil {
+		return issue
+	}
+	pullRequest := *lookup.PullRequest
+	issue.PullRequest = &pullRequest
+	issue.PRRepository = lookup.Repository
+	number := pullRequest.Number
+	issue.PRNumber = &number
+	return issue
+}
+
+func (o *Orchestrator) blockDeliverableRecoveryFailure(
+	ctx context.Context,
+	state *State,
+	event runpkg.Completion,
+	running Running,
+	lookup deliverableRecoveryLookupResult,
+) bool {
 	var recoveryErr *runpkg.DeliverableRecoveryError
 	if state == nil || !errors.As(event.Err, &recoveryErr) || recoveryErr == nil {
 		return false
 	}
-	branch := deliverableRecoveryBranch(recoveryErr, running)
-	reason := deliverableRecoveryNeedsHumanReason + ": pushed branch " + branch + " has no recoverable pull request"
-	humanAction := "open or adopt a pull request manually for pushed branch " + branch + ", then move the issue to Rework"
+	branch := lookup.Branch
+	if branch == "" {
+		branch = deliverableRecoveryBranch(recoveryErr, running)
+		lookup.Branch = branch
+	}
+	reason, humanAction := deliverableRecoveryParkReason(lookup)
 	issue := cloneIssue(running.Issue)
+	if lookup.PullRequest != nil {
+		issue = deliverableRecoveryIssue(running, lookup)
+	} else if strings.HasPrefix(strings.TrimSpace(lookup.LookupResult), "no exact-head pull request") {
+		issue.PullRequest = nil
+		issue.PRNumber = nil
+	}
 	metadata := o.newBlockedRecoveryMetadata(
 		ctx,
 		issue,
@@ -48,7 +191,15 @@ func (o *Orchestrator) blockDeliverableRecoveryFailure(ctx context.Context, stat
 	blockedAt := event.CompletedAt.UTC()
 	issue.StageUpdatedAt = &blockedAt
 	if o.connector != nil {
-		comment := "Pull request delivery remains unrecoverable and needs human attention.\n\n- pushed branch: `" + branch + "`\n- failing command: `" + deliverableRecoveryCommand(recoveryErr) + "`\n- recovery: " + humanAction + "\n- error: " + o.operatorText(recoveryErr.Error())
+		comment := "Pull request delivery remains unrecoverable and needs human attention.\n\n" +
+			"- branch: `" + branch + "`\n" +
+			"- workspace head: `" + lookup.HeadSHA + "`\n" +
+			"- hydration state: " + lookup.HydrationState + "\n" +
+			"- lookup result: " + lookup.LookupResult + "\n" +
+			"- lookup attempts: " + strconv.Itoa(lookup.Attempts) + "\n" +
+			"- failing command: `" + deliverableRecoveryCommand(recoveryErr) + "`\n" +
+			"- recovery: " + humanAction + "\n" +
+			"- error: " + o.operatorText(recoveryErr.Error())
 		if err := o.connector.CreateComment(ctx, issue.ID, comment); err != nil && o.logger != nil {
 			o.logger.Warn("deliverable recovery block comment failed", "issue_id", issue.ID, "identifier", issue.Identifier, "error", err)
 		}
@@ -82,6 +233,21 @@ func (o *Orchestrator) blockDeliverableRecoveryFailure(ctx context.Context, stat
 		"error", recoveryErr,
 	)
 	return true
+}
+
+func deliverableRecoveryParkReason(lookup deliverableRecoveryLookupResult) (string, string) {
+	branch := strings.TrimSpace(lookup.Branch)
+	lookupResult := strings.TrimSpace(lookup.LookupResult)
+	base := deliverableRecoveryNeedsHumanReason + ": pushed branch " + branch + " has no recoverable pull request"
+	humanAction := "open or adopt a pull request manually for pushed branch " + branch + ", then move the issue to Rework"
+	if strings.HasPrefix(lookupResult, "PR lookup unavailable") {
+		base = deliverableRecoveryNeedsHumanReason + ": PR lookup unavailable for pushed branch " + branch
+		humanAction = "restore pull request lookup availability, then move the issue to Rework"
+	} else if lookup.PullRequest != nil && normalizePullRequestState(lookup.PullRequest.State) == "closed" {
+		base = deliverableRecoveryNeedsHumanReason + ": pushed branch " + branch + " has an exact-head pull request closed without merge"
+		humanAction = "reopen the exact-head pull request or open a replacement, then move the issue to Rework"
+	}
+	return base + " (hydration state: " + lookup.HydrationState + "; lookup result: " + lookupResult + ")", humanAction
 }
 
 func deliverableRecoveryBranch(recoveryErr *runpkg.DeliverableRecoveryError, running Running) string {

--- a/internal/orchestrator/deliverable_recovery.go
+++ b/internal/orchestrator/deliverable_recovery.go
@@ -63,39 +63,45 @@ func (o *Orchestrator) lookupDeliverableRecovery(
 		return result
 	}
 
-	var lookupErr error
+	var (
+		lookupErr error
+		notFound  bool
+	)
 	for attempt := 1; attempt <= deliverableRecoveryLookupAttempts; attempt++ {
 		result.Attempts = attempt
 		pullRequest, found, err := lookup.LookupPullRequestByHead(ctx, result.Repository, result.Branch, result.HeadSHA)
 		if err == nil {
+			lookupErr = nil
 			if !found {
-				result.LookupResult = "no exact-head pull request"
+				notFound = true
+			} else {
+				fresh := pullRequest
+				result.PullRequest = &fresh
+				if strings.TrimSpace(fresh.BranchName) != result.Branch || strings.TrimSpace(fresh.HeadSHA) != result.HeadSHA {
+					result.LookupResult = fmt.Sprintf(
+						"no exact-head pull request; lookup returned PR #%d branch %q head %q",
+						fresh.Number,
+						strings.TrimSpace(fresh.BranchName),
+						strings.TrimSpace(fresh.HeadSHA),
+					)
+					result.PullRequest = nil
+					return result
+				}
+				state := normalizePullRequestState(fresh.State)
+				switch state {
+				case "open", "merged":
+					result.LookupResult = fmt.Sprintf("exact-head pull request #%d is %s", fresh.Number, state)
+				case "closed":
+					result.LookupResult = fmt.Sprintf("exact-head pull request #%d is closed without merge", fresh.Number)
+				default:
+					result.LookupResult = fmt.Sprintf("exact-head pull request #%d has state %q", fresh.Number, strings.TrimSpace(fresh.State))
+				}
 				return result
 			}
-			fresh := pullRequest
-			result.PullRequest = &fresh
-			if strings.TrimSpace(fresh.BranchName) != result.Branch || strings.TrimSpace(fresh.HeadSHA) != result.HeadSHA {
-				result.LookupResult = fmt.Sprintf(
-					"no exact-head pull request; lookup returned PR #%d branch %q head %q",
-					fresh.Number,
-					strings.TrimSpace(fresh.BranchName),
-					strings.TrimSpace(fresh.HeadSHA),
-				)
-				result.PullRequest = nil
-				return result
-			}
-			state := normalizePullRequestState(fresh.State)
-			switch state {
-			case "open", "merged":
-				result.LookupResult = fmt.Sprintf("exact-head pull request #%d is %s", fresh.Number, state)
-			case "closed":
-				result.LookupResult = fmt.Sprintf("exact-head pull request #%d is closed without merge", fresh.Number)
-			default:
-				result.LookupResult = fmt.Sprintf("exact-head pull request #%d has state %q", fresh.Number, strings.TrimSpace(fresh.State))
-			}
-			return result
+		} else {
+			lookupErr = err
+			notFound = false
 		}
-		lookupErr = err
 		if attempt == deliverableRecoveryLookupAttempts {
 			break
 		}
@@ -104,8 +110,14 @@ func (o *Orchestrator) lookupDeliverableRecovery(
 			wait = waitForDispatchBackoff
 		}
 		if !wait(ctx, deliverableRecoveryLookupBackoff*time.Duration(1<<(attempt-1))) {
+			lookupErr = ctx.Err()
+			notFound = false
 			break
 		}
+	}
+	if notFound {
+		result.LookupResult = "no exact-head pull request after " + strconv.Itoa(result.Attempts) + " attempts"
+		return result
 	}
 	result.LookupResult = "PR lookup unavailable after " + strconv.Itoa(result.Attempts) + " attempts"
 	if lookupErr != nil {

--- a/internal/orchestrator/implement_progress.go
+++ b/internal/orchestrator/implement_progress.go
@@ -261,6 +261,18 @@ func (o *Orchestrator) evaluateImplementCompletionProgress(
 		o.warnImplementProgressHydration(issue, reason, nil)
 		return decision
 	}
+	if pullRequestMerged(issue.PullRequest) {
+		refreshed, workpadCurrent := o.refreshImplementCompletionIssue(ctx, issue)
+		decision.Issue = refreshed
+		decision.TrackerState = strings.TrimSpace(refreshed.State)
+		if workpadCurrent && implementProgressMergedCompletion(refreshed, running.DiffStats) {
+			decision.WorkpadStatus = workpad.StatusComplete
+			decision.CurrentSignature = autoPromoteReworkSignatureFromIssue(refreshed, staleMergedPullRequestSummaryFromIssue(refreshed))
+			decision.Reason = implementMergedCompletionReason
+			return decision
+		}
+		issue = refreshed
+	}
 	signature := autoPromoteReworkSignatureFromIssue(issue, AutoPromoteSummaryFromIssue(issue))
 	decision.CurrentSignature = signature
 	if !implementProgressSignatureUsable(signature) {

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -241,6 +241,7 @@ type Orchestrator struct {
 	newStalenessNotifier    func(staleness.DeliveryConfig) (staleness.Notifier, error)
 	mergeWorkerLimit        runDurationLimitFactory
 	mergeWorkerStartupTimer mergeWorkerStartupTimerFactory
+	deliverableRecoveryWait func(context.Context, time.Duration) bool
 	heartbeats              *heartbeatManager
 	hydrationSkipStreaks    map[string]int
 	hydrationWarned         bool

--- a/internal/orchestrator/run_completion.go
+++ b/internal/orchestrator/run_completion.go
@@ -142,6 +142,32 @@ func (o *Orchestrator) handleRunResult(ctx context.Context, state *State, event 
 	if o.handleModelPermitDeferred(ctx, state, event, running) {
 		return
 	}
+	deliverableLookup := deliverableRecoveryLookupResult{}
+	var deliverableRecoveryErr *runpkg.DeliverableRecoveryError
+	if errors.As(event.Err, &deliverableRecoveryErr) && deliverableRecoveryErr != nil {
+		if diffStatsPresent(event.Result.DiffStats) {
+			running.DiffStats = event.Result.DiffStats
+		}
+		deliverableLookup = o.lookupDeliverableRecovery(ctx, running, deliverableRecoveryErr)
+		if deliverableLookup.reconciles() {
+			running.Issue = deliverableRecoveryIssue(running, deliverableLookup)
+			event.Err = nil
+			event.Result.FinalState = FinalStateCompleted
+			event.Result.PullRequestUpdated = true
+			recordStateEvent(state, telemetry.ActivityEvent{
+				At:      event.CompletedAt,
+				Event:   "deliverable_recovery_reconciled",
+				Message: deliverableLookup.LookupResult + " for " + issueLabel(running.Issue),
+			})
+			telemetry.LogLifecycle(o.logger, slog.LevelInfo, telemetry.LifecycleWorkAttempt, "deliverable_recovery_reconciled", o.runningLifecycleCorrelation(running.Issue, running),
+				"workspace_branch", deliverableLookup.Branch,
+				"workspace_head_sha", deliverableLookup.HeadSHA,
+				"hydration_state", deliverableLookup.HydrationState,
+				"lookup_result", deliverableLookup.LookupResult,
+				"pull_request_number", deliverableLookup.PullRequest.Number,
+			)
+		}
+	}
 	if event.Err != nil {
 		o.releaseTerminalAttemptClaim(ctx, state, running.Issue, event.CompletedAt)
 	}
@@ -190,7 +216,7 @@ func (o *Orchestrator) handleRunResult(ctx context.Context, state *State, event 
 		o.deferBackendCapacityProbe(state, running, event.CompletedAt, event.Err)
 	}
 
-	if workspaceIssueTerminal(running.Issue, o.cfg.TerminalStates) {
+	if !deliverableLookup.reconciles() && workspaceIssueTerminal(running.Issue, o.cfg.TerminalStates) {
 		o.recordProjectAttemptOutcome(state, event.IssueID, event.CompletedAt, store.WorkAttemptTerminalSuccess, nil, "", "")
 		tokens := event.Result.Tokens
 		if tokens == (TokenTotals{}) {
@@ -247,7 +273,7 @@ func (o *Orchestrator) handleRunResult(ctx context.Context, state *State, event 
 		errorMessage := event.Err.Error()
 		phase := "failed"
 		statusMessage := "worker failed"
-		var deliverableRecoveryErr *runpkg.DeliverableRecoveryError
+		deliverableRecoveryErr = nil
 		if errors.As(event.Err, &deliverableRecoveryErr) && deliverableRecoveryErr != nil {
 			errorClass = deliverableRecoveryNeedsHumanReason
 			phase = "blocked"
@@ -266,7 +292,7 @@ func (o *Orchestrator) handleRunResult(ctx context.Context, state *State, event 
 		if attempt < 1 {
 			attempt = nextAttempt(running.Attempt)
 		}
-		if o.blockDeliverableRecoveryFailure(ctx, state, event, running) {
+		if o.blockDeliverableRecoveryFailure(ctx, state, event, running, deliverableLookup) {
 			return
 		}
 		if o.tripTokenCeilingCircuitBreaker(ctx, state, event, running, attempt) {

--- a/internal/orchestrator/terminal_attempt_retry_test.go
+++ b/internal/orchestrator/terminal_attempt_retry_test.go
@@ -127,15 +127,74 @@ func TestHandleRunResultRoutesTerminalRetryByWorkProduct(t *testing.T) {
 	}
 }
 
-func TestHandleRunResultParksUnrecoverableDeliverableWithBranch(t *testing.T) {
+func TestHandleRunResultReconcilesDeliverableRecoveryExactHead(t *testing.T) {
 	t.Parallel()
 
+	const (
+		branch  = "detent/acme_widgets_18"
+		headSHA = "current-head"
+	)
 	tests := []struct {
-		name   string
-		branch string
+		name             string
+		cached           *connector.PullRequest
+		lookup           *connector.PullRequest
+		lookupErrors     []error
+		wantBlocked      bool
+		wantReason       string
+		wantLookupCalls  int
+		wantMergedReason bool
 	}{
-		{name: "named pushed branch", branch: "detent/acme_widgets_18"},
-		{name: "fallback workspace branch", branch: "detent/acme_widgets_19"},
+		{
+			name: "open pull request on exact current head reconciles",
+			lookup: &connector.PullRequest{
+				Number: 18, BranchName: branch, State: "OPEN", HeadSHA: headSHA,
+			},
+			wantLookupCalls: 1,
+		},
+		{
+			name:            "no pull request parks",
+			wantBlocked:     true,
+			wantReason:      "no exact-head pull request",
+			wantLookupCalls: 1,
+		},
+		{
+			name: "merged pull request routes to merged deliverable reconciliation",
+			lookup: &connector.PullRequest{
+				Number: 18, BranchName: branch, State: "MERGED", HeadSHA: headSHA,
+				CIStatus: "success", CheckRunCount: 1,
+			},
+			wantLookupCalls:  1,
+			wantMergedReason: true,
+		},
+		{
+			name: "closed unmerged pull request parks accurately",
+			lookup: &connector.PullRequest{
+				Number: 18, BranchName: branch, State: "CLOSED", HeadSHA: headSHA,
+			},
+			wantBlocked:     true,
+			wantReason:      "closed without merge",
+			wantLookupCalls: 1,
+		},
+		{
+			name: "lookup unavailable retries then parks",
+			lookupErrors: []error{
+				errors.New("lookup unavailable 1"),
+				errors.New("lookup unavailable 2"),
+				errors.New("lookup unavailable 3"),
+			},
+			wantBlocked:     true,
+			wantReason:      "PR lookup unavailable",
+			wantLookupCalls: 3,
+		},
+		{
+			name: "stale cached hydration is not trusted",
+			cached: &connector.PullRequest{
+				Number: 18, BranchName: branch, State: "OPEN", HeadSHA: headSHA,
+			},
+			wantBlocked:     true,
+			wantReason:      "lookup result: no exact-head pull request",
+			wantLookupCalls: 1,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -143,44 +202,94 @@ func TestHandleRunResultParksUnrecoverableDeliverableWithBranch(t *testing.T) {
 
 			now := time.Date(2026, 8, 12, 18, 0, 0, 0, time.UTC)
 			issue := terminalRetryTestIssue(tt.name)
-			issue.BranchName = tt.branch
-			tracker := &terminalRetryConnector{issues: map[string]connector.Issue{issue.ID: cloneIssue(issue)}}
+			issue.BranchName = branch
+			issue.PRRepository = "acme/widgets"
+			issue.PullRequest = tt.cached
+			issue.Comments = []connector.IssueComment{{
+				Body: "## Codex Workpad\n\n```detent-status\nschema: 1\nstatus: complete\nblockers: []\nhuman_action: null\n```",
+			}}
+			tracker := &terminalRetryConnector{
+				issues:       map[string]connector.Issue{issue.ID: cloneIssue(issue)},
+				lookup:       tt.lookup,
+				lookupErrors: append([]error(nil), tt.lookupErrors...),
+			}
 			attempts := &terminalRetryWorkAttemptStore{}
 			cfg := normalizeConfig(Config{ActiveStates: []string{"Todo", "In Progress"}, TerminalStates: []string{"Done"}})
-			o := &Orchestrator{cfg: cfg, connector: tracker, workAttempts: attempts}
+			o := &Orchestrator{
+				cfg: cfg, connector: tracker, workAttempts: attempts,
+				deliverableRecoveryWait: func(context.Context, time.Duration) bool { return true },
+			}
 			state := newState(cfg)
 			state.Running[issue.ID] = Running{
 				Issue: issue, Attempt: 1, WorkAttemptID: 42, Mode: runpkg.RunModeImplement,
-				StartedAt: now.Add(-time.Minute), WorkProductPushed: true, WorkspacePath: "/work/" + tt.branch,
+				StartedAt: now.Add(-time.Minute), WorkProductPushed: true, WorkspacePath: "/work/" + branch,
+				DiffStats: DiffStats{Status: "clean", HeadSHA: headSHA},
 			}
 			state.Claimed[issue.ID] = Claimed{Issue: issue, ClaimedAt: now.Add(-time.Minute)}
 			commandErr := &runpkg.DeliverableCommandError{
-				Operation: "codex_apps/github.create_pull_request", Arguments: `{"head":"` + tt.branch + `"}`,
+				Operation: "codex_apps/github.create_pull_request", Arguments: `{"head":"` + branch + `"}`,
 				Status: "failed", Message: "HTTP 503: unavailable",
 			}
 
 			o.handleRunResult(t.Context(), &state, runpkg.Completion{
-				IssueID:     issue.ID,
-				Result:      runpkg.RunResult{FinalState: runpkg.FinalStateNeedsHumanAttention, PullRequestHeadPushed: true},
-				Err:         &runpkg.DeliverableRecoveryError{Branch: tt.branch, Err: commandErr},
+				IssueID: issue.ID,
+				Result: runpkg.RunResult{
+					FinalState: runpkg.FinalStateNeedsHumanAttention, PullRequestHeadPushed: true,
+					DiffStats: runpkg.DiffStats{Status: "clean", HeadSHA: headSHA},
+				},
+				Err:         &runpkg.DeliverableRecoveryError{Branch: branch, Err: commandErr},
 				CompletedAt: now,
 			})
 
-			if _, retrying := state.Retry[issue.ID]; retrying {
-				t.Fatalf("Retry[%q] present after unrecoverable PR delivery", issue.ID)
+			if tracker.lookupCalls != tt.wantLookupCalls {
+				t.Fatalf("lookup calls = %d, want %d", tracker.lookupCalls, tt.wantLookupCalls)
+			}
+			if tracker.lookupRepository != "acme/widgets" || tracker.lookupBranch != branch || tracker.lookupHeadSHA != headSHA {
+				t.Fatalf(
+					"lookup target = %q/%q@%q, want acme/widgets/%s@%s",
+					tracker.lookupRepository,
+					tracker.lookupBranch,
+					tracker.lookupHeadSHA,
+					branch,
+					headSHA,
+				)
 			}
 			blocked, ok := state.Blocked[issue.ID]
-			if !ok || blocked.Issue.State != blockedStatusState || !strings.Contains(blocked.Reason, tt.branch) || !strings.Contains(blocked.RecoveryReason, tt.branch) {
-				t.Fatalf("Blocked[%q] = %#v, want needs-human recovery naming branch %q", issue.ID, blocked, tt.branch)
+			if ok != tt.wantBlocked {
+				t.Fatalf("Blocked[%q] present = %v, want %v: %#v", issue.ID, ok, tt.wantBlocked, blocked)
 			}
-			if got := tracker.transitionStates(); !slices.Equal(got, []string{blockedStatusState}) {
-				t.Fatalf("state transitions = %v, want [%s]", got, blockedStatusState)
+			if tt.wantBlocked {
+				if !strings.Contains(blocked.Reason, branch) || !strings.Contains(blocked.Reason, tt.wantReason) {
+					t.Fatalf("Blocked[%q].Reason = %q, want branch and %q", issue.ID, blocked.Reason, tt.wantReason)
+				}
+				if len(tracker.comments) != 1 || !strings.Contains(tracker.comments[0], "hydration state:") ||
+					!strings.Contains(tracker.comments[0], "lookup result:") || !strings.Contains(tracker.comments[0], tt.wantReason) {
+					t.Fatalf("comments = %#v, want hydration and lookup diagnostics containing %q", tracker.comments, tt.wantReason)
+				}
+				if got := tracker.transitionStates(); !slices.Equal(got, []string{blockedStatusState}) {
+					t.Fatalf("state transitions = %v, want [%s]", got, blockedStatusState)
+				}
+				if tt.cached != nil && tt.lookup == nil && blocked.Issue.PullRequest != nil {
+					t.Fatalf("Blocked[%q].Issue.PullRequest = %#v, want stale hydration cleared", issue.ID, blocked.Issue.PullRequest)
+				}
+				if tt.lookup != nil && normalizePullRequestState(tt.lookup.State) == "closed" &&
+					(blocked.Issue.PullRequest == nil || normalizePullRequestState(blocked.Issue.PullRequest.State) != "closed") {
+					t.Fatalf("Blocked[%q].Issue.PullRequest = %#v, want fresh closed PR", issue.ID, blocked.Issue.PullRequest)
+				}
+				return
 			}
-			if len(tracker.comments) != 1 || !strings.Contains(tracker.comments[0], tt.branch) || !strings.Contains(tracker.comments[0], "needs human attention") {
-				t.Fatalf("comments = %#v, want needs-human message naming branch", tracker.comments)
+			if len(attempts.completions) != 1 || attempts.completions[0].TerminalState != store.WorkAttemptTerminalSuccess {
+				t.Fatalf("work attempt completions = %#v, want successful reconciliation", attempts.completions)
 			}
-			if len(attempts.completions) != 1 || attempts.completions[0].Phase != "blocked" || !strings.Contains(attempts.completions[0].StatusMessage, tt.branch) {
-				t.Fatalf("work attempt completions = %#v, want blocked phase naming branch", attempts.completions)
+			completed := state.Completed[issue.ID]
+			if completed.Issue.PullRequest == nil || completed.Issue.PullRequest.Number != 18 {
+				t.Fatalf("Completed[%q].Issue.PullRequest = %#v, want reconciled PR 18", issue.ID, completed.Issue.PullRequest)
+			}
+			if tt.wantMergedReason {
+				record := implementProgressRecordFromCompletion(t, attempts.completions[0])
+				if record.Reason != implementMergedCompletionReason {
+					t.Fatalf("completion reason = %q, want %q", record.Reason, implementMergedCompletionReason)
+				}
 			}
 		})
 	}
@@ -325,9 +434,15 @@ func terminalRetryTestIssueWithPullRequest(suffix string) connector.Issue {
 }
 
 type terminalRetryConnector struct {
-	issues      map[string]connector.Issue
-	transitions []string
-	comments    []string
+	issues           map[string]connector.Issue
+	transitions      []string
+	comments         []string
+	lookup           *connector.PullRequest
+	lookupErrors     []error
+	lookupCalls      int
+	lookupRepository string
+	lookupBranch     string
+	lookupHeadSHA    string
 }
 
 func (c *terminalRetryConnector) Name() string { return "terminal-retry" }
@@ -348,6 +463,37 @@ func (c *terminalRetryConnector) FetchIssueStatesByIDs(_ context.Context, ids []
 		}
 	}
 	return issues, nil
+}
+
+func (c *terminalRetryConnector) FetchIssueComments(_ context.Context, issue connector.Issue) ([]connector.IssueComment, error) {
+	return append([]connector.IssueComment(nil), c.issues[issue.ID].Comments...), nil
+}
+
+func (c *terminalRetryConnector) LookupPullRequestByHead(_ context.Context, repository string, branch string, headSHA string) (connector.PullRequest, bool, error) {
+	c.lookupCalls++
+	c.lookupRepository = repository
+	c.lookupBranch = branch
+	c.lookupHeadSHA = headSHA
+	if c.lookupCalls <= len(c.lookupErrors) {
+		return connector.PullRequest{}, false, c.lookupErrors[c.lookupCalls-1]
+	}
+	if c.lookup == nil {
+		return connector.PullRequest{}, false, nil
+	}
+	pullRequest := *c.lookup
+	return pullRequest, true, nil
+}
+
+func (c *terminalRetryConnector) HydratePullRequest(_ context.Context, issue connector.Issue) (connector.Issue, error) {
+	if c.lookup == nil {
+		return issue, nil
+	}
+	pullRequest := *c.lookup
+	issue.PullRequest = &pullRequest
+	issue.PRRepository = "acme/widgets"
+	number := pullRequest.Number
+	issue.PRNumber = &number
+	return issue, nil
 }
 
 func (c *terminalRetryConnector) CreateComment(_ context.Context, _ string, body string) error {

--- a/internal/orchestrator/terminal_attempt_retry_test.go
+++ b/internal/orchestrator/terminal_attempt_retry_test.go
@@ -139,6 +139,7 @@ func TestHandleRunResultReconcilesDeliverableRecoveryExactHead(t *testing.T) {
 		cached           *connector.PullRequest
 		lookup           *connector.PullRequest
 		lookupErrors     []error
+		lookupFoundAfter int
 		wantBlocked      bool
 		wantReason       string
 		wantLookupCalls  int
@@ -155,7 +156,15 @@ func TestHandleRunResultReconcilesDeliverableRecoveryExactHead(t *testing.T) {
 			name:            "no pull request parks",
 			wantBlocked:     true,
 			wantReason:      "no exact-head pull request",
-			wantLookupCalls: 1,
+			wantLookupCalls: 3,
+		},
+		{
+			name: "transient not found retries then reconciles",
+			lookup: &connector.PullRequest{
+				Number: 18, BranchName: branch, State: "OPEN", HeadSHA: headSHA,
+			},
+			lookupFoundAfter: 3,
+			wantLookupCalls:  3,
 		},
 		{
 			name: "merged pull request routes to merged deliverable reconciliation",
@@ -193,7 +202,7 @@ func TestHandleRunResultReconcilesDeliverableRecoveryExactHead(t *testing.T) {
 			},
 			wantBlocked:     true,
 			wantReason:      "lookup result: no exact-head pull request",
-			wantLookupCalls: 1,
+			wantLookupCalls: 3,
 		},
 	}
 	for _, tt := range tests {
@@ -209,9 +218,10 @@ func TestHandleRunResultReconcilesDeliverableRecoveryExactHead(t *testing.T) {
 				Body: "## Codex Workpad\n\n```detent-status\nschema: 1\nstatus: complete\nblockers: []\nhuman_action: null\n```",
 			}}
 			tracker := &terminalRetryConnector{
-				issues:       map[string]connector.Issue{issue.ID: cloneIssue(issue)},
-				lookup:       tt.lookup,
-				lookupErrors: append([]error(nil), tt.lookupErrors...),
+				issues:           map[string]connector.Issue{issue.ID: cloneIssue(issue)},
+				lookup:           tt.lookup,
+				lookupErrors:     append([]error(nil), tt.lookupErrors...),
+				lookupFoundAfter: tt.lookupFoundAfter,
 			}
 			attempts := &terminalRetryWorkAttemptStore{}
 			cfg := normalizeConfig(Config{ActiveStates: []string{"Todo", "In Progress"}, TerminalStates: []string{"Done"}})
@@ -440,6 +450,7 @@ type terminalRetryConnector struct {
 	lookup           *connector.PullRequest
 	lookupErrors     []error
 	lookupCalls      int
+	lookupFoundAfter int
 	lookupRepository string
 	lookupBranch     string
 	lookupHeadSHA    string
@@ -478,6 +489,9 @@ func (c *terminalRetryConnector) LookupPullRequestByHead(_ context.Context, repo
 		return connector.PullRequest{}, false, c.lookupErrors[c.lookupCalls-1]
 	}
 	if c.lookup == nil {
+		return connector.PullRequest{}, false, nil
+	}
+	if c.lookupFoundAfter > c.lookupCalls {
 		return connector.PullRequest{}, false, nil
 	}
 	pullRequest := *c.lookup

--- a/internal/runner/agent.go
+++ b/internal/runner/agent.go
@@ -1421,6 +1421,14 @@ func (r *Runner) Run(ctx context.Context, req RunRequest) (RunResult, error) {
 	if brakeDiff := sessionBrake.resultDiffStats(); brakeDiff != (DiffStats{}) {
 		result.DiffStats = brakeDiff
 	}
+	var exhaustedDeliverable *DeliverableRecoveryError
+	if mode == RunModeImplement && result.PullRequestHeadPushed && errors.As(turnErr, &exhaustedDeliverable) {
+		if recoveryState := r.workspaceRecoveryState(runWorkspace, ctx, info, workspaceIssue, "deliverable_recovery"); recoveryState != nil {
+			result.DiffStats = diffStatsFromWorkspace(recoveryState.DiffStat)
+			result.DiffStats.UnpushedCommits = recoveryState.UnpushedCommits
+			result.DiffStats.HeadSHA = strings.TrimSpace(recoveryState.HeadSHA)
+		}
+	}
 	commandFinishedAttrs := []any{
 		"workspace_path", info.Path,
 		"work_attempt_id", req.WorkAttemptID,

--- a/internal/runner/runner_test.go
+++ b/internal/runner/runner_test.go
@@ -674,7 +674,13 @@ func TestRunnerRunRecoversPushedPullRequestDeliverable(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			workspaceBackend := &fakeWorkspaceBackend{info: workspace.Info{Path: t.TempDir(), Branch: branch}}
+			workspaceBackend := &fakeWorkspaceBackend{
+				info: workspace.Info{Path: t.TempDir(), Branch: branch},
+				recoveryStates: []workspace.RecoveryState{
+					{HeadSHA: "dispatch-head"},
+					{HeadSHA: "current-head"},
+				},
+			}
 			backend := &deliverableRecoveryAgentBackend{turns: [][]AgentUpdate{
 				{
 					{Type: AgentUpdateToolStarted, ItemID: "push", Tool: "commandExecution", Delta: "git push -u origin HEAD"},
@@ -710,6 +716,9 @@ func TestRunnerRunRecoversPushedPullRequestDeliverable(t *testing.T) {
 				}
 				if recoveryErr.Branch != branch || !strings.Contains(runErr.Error(), branch) || result.FinalState != FinalStateNeedsHumanAttention {
 					t.Fatalf("recovery error/result = %#v/%#v, want branch %q and needs-human state", recoveryErr, result, branch)
+				}
+				if result.DiffStats.HeadSHA != "current-head" {
+					t.Fatalf("DiffStats.HeadSHA = %q, want fresh current head", result.DiffStats.HeadSHA)
 				}
 				for _, want := range []string{"codex_apps/github.create_pull_request", "status=failed", arguments, "HTTP 503: unavailable", `{"status":503,"message":"unavailable"}`} {
 					if !strings.Contains(runErr.Error(), want) {


### PR DESCRIPTION
## Summary

- perform a fresh exact-head pull request lookup before parking failed deliverable recovery
- reconcile matching open and merged pull requests through normal completion paths
- bound lookup retries and record branch, hydration, and lookup evidence for accurate parks
- refresh the runner's current workspace head before returning recovery failure evidence

Fixes #1788

## UI Surface Contract

- [x] N/A, or the linked issue explicitly authorizes any high-impact UI surface, layout, density, first-viewport, or responsive visibility tradeoff.
- [x] Persistent top-of-screen messaging is explicitly authorized by the issue, or this PR does not add it.
- [ ] Visual changes to primary operator screens include screenshot or browser verification below.

## Test Plan

- [x] `go test ./internal/runner -run '^TestRunnerRunRecoversPushedPullRequestDeliverable$' -count=1`
- [x] `go test ./internal/orchestrator -run '^TestHandleRunResultReconcilesDeliverableRecoveryExactHead$' -count=1`
- [x] `go test ./internal/runner ./internal/orchestrator ./internal/connector/... -count=1`
- [x] `make check` after rebasing onto current `origin/main`