### PR TITLE
fix(recovery): look up unlinked exact-head PRs

### DIFF
--- a/internal/orchestrator/blocked_cause_recovery.go
+++ b/internal/orchestrator/blocked_cause_recovery.go
@@ -378,7 +378,8 @@ func (o *Orchestrator) reconcileBlockedReadyPullRequest(
 	}
 	signals := o.blockedCauseSignals(ctx, issue, park.RunMode, park.TargetState, DiffStats{})
 	if !implementProgressLinkedPullRequest(issue) {
-		if strings.TrimSpace(issue.BranchName) == "" || strings.TrimSpace(signals.WorkspaceHeadSHA) == "" {
+		issue.BranchName = blockedReadyPullRequestBranch(state, issue)
+		if issue.BranchName == "" || strings.TrimSpace(signals.WorkspaceHeadSHA) == "" {
 			return false, false
 		}
 		lookedUp, outcome, err := o.lookupBlockedReadyPullRequest(ctx, issue, signals)
@@ -439,6 +440,20 @@ func (o *Orchestrator) reconcileBlockedReadyPullRequest(
 		Message: "reconciled " + issueLabel(issue) + " from Blocked to Merging with its ready pull request",
 	})
 	return true, true
+}
+
+func blockedReadyPullRequestBranch(state *State, issue connector.Issue) string {
+	if branch := strings.TrimSpace(issue.BranchName); branch != "" {
+		return branch
+	}
+	if state == nil {
+		return ""
+	}
+	blocked, ok := state.Blocked[strings.TrimSpace(issue.ID)]
+	if !ok {
+		return ""
+	}
+	return strings.TrimSpace(blocked.Issue.BranchName)
 }
 
 func (o *Orchestrator) lookupBlockedReadyPullRequest(

--- a/internal/orchestrator/blocked_cause_recovery.go
+++ b/internal/orchestrator/blocked_cause_recovery.go
@@ -5,6 +5,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"slices"
 	"strings"
@@ -18,15 +19,20 @@ import (
 )
 
 const (
-	blockedRecoveryOwnerOrchestrator           = "orchestrator"
-	blockedRecoveryOwnerHuman                  = "human"
-	blockedRecoveryOwnerOperator               = "operator"
-	blockedRecoveryPredicateFingerprintChange  = "fingerprint_changed"
-	blockedRecoveryPredicateOncePerFingerprint = "once_per_fingerprint"
-	blockedRecoveryPredicateManaged            = "managed"
-	blockedCauseFingerprintVersion             = 2
-	workflowActionCauseBlockedRecovery         = "cause_blocked_recovery"
-	workflowActionBlockedReadyPRReconciliation = "blocked_ready_pr_reconciliation"
+	blockedRecoveryOwnerOrchestrator               = "orchestrator"
+	blockedRecoveryOwnerHuman                      = "human"
+	blockedRecoveryOwnerOperator                   = "operator"
+	blockedRecoveryPredicateFingerprintChange      = "fingerprint_changed"
+	blockedRecoveryPredicateOncePerFingerprint     = "once_per_fingerprint"
+	blockedRecoveryPredicateManaged                = "managed"
+	blockedCauseFingerprintVersion                 = 2
+	workflowActionCauseBlockedRecovery             = "cause_blocked_recovery"
+	workflowActionBlockedReadyPRReconciliation     = "blocked_ready_pr_reconciliation"
+	blockedReadyPullRequestLookupAttempts          = 3
+	blockedReadyPullRequestLookupBackoff           = 250 * time.Millisecond
+	blockedReadyPullRequestLookupFoundReason       = "ready_pr_lookup_found"
+	blockedReadyPullRequestLookupNoneReason        = "ready_pr_lookup_none"
+	blockedReadyPullRequestLookupUnavailableReason = "ready_pr_lookup_unavailable"
 )
 
 type blockedCauseSignals struct {
@@ -258,8 +264,9 @@ func (o *Orchestrator) recoverCauseBlockedIssue(
 		return false
 	}
 	dependencyCfg := normalizeDependencyAutoUnblockConfig(o.cfg.DependencyAutoUnblock)
-	if reason := o.blockedCauseHoldReason(issue, state, nil, dependencyCfg); reason != "" {
-		o.recordBlockedRecoveryDecision(ctx, state, issue, "hold", reason, nil, "")
+	holdReason := o.blockedCauseHoldReason(issue, state, nil, dependencyCfg)
+	if holdReason != "" && holdReason != "invalid_workpad_signal" {
+		o.recordBlockedRecoveryDecision(ctx, state, issue, "hold", holdReason, nil, "")
 		return false
 	}
 	if o.currentBlockedOperatorStop(ctx, state, issue) {
@@ -270,13 +277,14 @@ func (o *Orchestrator) recoverCauseBlockedIssue(
 	withDependencies, workpadRefs := o.issueWithCurrentWorkpadDependencyRefs(ctx, withDependencies)
 	blockers := o.resolveDependencyBlockers(ctx, withDependencies)
 	workpadBlockers := dependencyBlockersMatchingRefs(blockers, workpadRefs)
-	if reason := o.blockedCauseHoldReason(issue, state, workpadBlockers, dependencyCfg); reason != "" {
+	holdReason = o.blockedCauseHoldReason(issue, state, workpadBlockers, dependencyCfg)
+	if holdReason != "" && holdReason != "invalid_workpad_signal" {
 		o.recordBlockedRecoveryDecision(
 			ctx,
 			state,
 			withDependencies,
 			"hold",
-			reason,
+			holdReason,
 			nil,
 			"",
 			dependencyBlockersNotReady(workpadBlockers, dependencyCfg, o.cfg.TerminalStates)...,
@@ -285,6 +293,15 @@ func (o *Orchestrator) recoverCauseBlockedIssue(
 	}
 	if len(withDependencies.BlockedBy) > 0 {
 		o.recordBlockedRecoveryDecision(ctx, state, withDependencies, "defer", "dependency_recovery", nil, "")
+		return false
+	}
+	if holdReason == "invalid_workpad_signal" {
+		if park, ok := o.currentBlockedRecoveryPark(ctx, state, issue); ok {
+			if handled, transitioned := o.reconcileBlockedReadyPullRequest(ctx, state, issue, park, now); handled {
+				return transitioned
+			}
+		}
+		o.recordBlockedRecoveryDecision(ctx, state, issue, "hold", holdReason, nil, "")
 		return false
 	}
 	if park, ok := o.latestReworkBreakerPark(ctx, issue); ok {
@@ -356,10 +373,31 @@ func (o *Orchestrator) reconcileBlockedReadyPullRequest(
 	park workflowLaneBlockedRecoveryMetadata,
 	now time.Time,
 ) (bool, bool) {
-	if !blockedReadyPullRequestRecoverableCause(park) || !implementProgressLinkedPullRequest(issue) {
+	if !blockedReadyPullRequestRecoverableCause(park) {
 		return false, false
 	}
 	signals := o.blockedCauseSignals(ctx, issue, park.RunMode, park.TargetState, DiffStats{})
+	if !implementProgressLinkedPullRequest(issue) {
+		if strings.TrimSpace(issue.BranchName) == "" || strings.TrimSpace(signals.WorkspaceHeadSHA) == "" {
+			return false, false
+		}
+		lookedUp, outcome, err := o.lookupBlockedReadyPullRequest(ctx, issue, signals)
+		switch outcome {
+		case blockedReadyPullRequestLookupFoundReason:
+			issue = lookedUp
+			signals = o.blockedCauseSignals(ctx, issue, park.RunMode, park.TargetState, DiffStats{})
+			o.recordBlockedRecoveryDecision(ctx, state, issue, "evaluate", outcome, &park, blockedCauseFingerprint(park.Cause, signals))
+		case blockedReadyPullRequestLookupNoneReason:
+			o.recordBlockedRecoveryDecision(ctx, state, issue, "hold", outcome, &park, blockedCauseFingerprint(park.Cause, signals))
+			return true, false
+		default:
+			o.recordBlockedRecoveryDecision(ctx, state, issue, "defer", blockedReadyPullRequestLookupUnavailableReason, &park, blockedCauseFingerprint(park.Cause, signals))
+			if err != nil && o.logger != nil {
+				o.logger.Warn("blocked ready pull request lookup unavailable", "issue_id", issue.ID, "identifier", issue.Identifier, "error", err)
+			}
+			return true, false
+		}
+	}
 	if reason := o.blockedReadyPullRequestDeferredReason(ctx, state, issue, signals, now); reason != "" {
 		o.recordBlockedRecoveryDecision(ctx, state, issue, "defer", reason, &park, blockedCauseFingerprint(park.Cause, signals))
 		return true, false
@@ -401,6 +439,76 @@ func (o *Orchestrator) reconcileBlockedReadyPullRequest(
 		Message: "reconciled " + issueLabel(issue) + " from Blocked to Merging with its ready pull request",
 	})
 	return true, true
+}
+
+func (o *Orchestrator) lookupBlockedReadyPullRequest(
+	ctx context.Context,
+	issue connector.Issue,
+	signals blockedCauseSignals,
+) (connector.Issue, string, error) {
+	repository := pullRequestRepository(issue)
+	branch := strings.TrimSpace(issue.BranchName)
+	headSHA := strings.TrimSpace(signals.WorkspaceHeadSHA)
+	if repository == "" || branch == "" || headSHA == "" {
+		return issue, blockedReadyPullRequestLookupUnavailableReason, errors.New(
+			"exact-head pull request lookup requires repository, branch, and workspace head",
+		)
+	}
+	lookup, ok := o.connector.(connector.PullRequestHeadLookup)
+	if !ok {
+		return issue, blockedReadyPullRequestLookupUnavailableReason, errors.New("connector does not support exact-head pull request lookup")
+	}
+
+	var lookupErr error
+	for attempt := 1; attempt <= blockedReadyPullRequestLookupAttempts; attempt++ {
+		pullRequest, found, err := lookup.LookupPullRequestByHead(ctx, repository, branch, headSHA)
+		if err == nil {
+			if !found || normalizePullRequestState(pullRequest.State) != "open" {
+				return issue, blockedReadyPullRequestLookupNoneReason, nil
+			}
+			if strings.TrimSpace(pullRequest.BranchName) != branch || strings.TrimSpace(pullRequest.HeadSHA) != headSHA {
+				return issue, blockedReadyPullRequestLookupUnavailableReason, fmt.Errorf(
+					"exact-head pull request lookup returned branch %q head %q",
+					strings.TrimSpace(pullRequest.BranchName),
+					strings.TrimSpace(pullRequest.HeadSHA),
+				)
+			}
+			candidate := cloneIssue(issue)
+			candidate.PRRepository = repository
+			candidate.PullRequest = &pullRequest
+			candidate.PRNumber = &pullRequest.Number
+			hydrator, ok := o.connector.(connector.PullRequestHydrator)
+			if !ok {
+				return issue, blockedReadyPullRequestLookupUnavailableReason, errors.New("connector does not support pull request hydration")
+			}
+			hydrated, err := hydrator.HydratePullRequest(ctx, candidate)
+			if err != nil {
+				return issue, blockedReadyPullRequestLookupUnavailableReason, fmt.Errorf("hydrate exact-head pull request: %w", err)
+			}
+			if hydrated.PullRequest == nil || hydrated.PullRequest.Number != pullRequest.Number ||
+				strings.TrimSpace(hydrated.PullRequest.BranchName) != branch || strings.TrimSpace(hydrated.PullRequest.HeadSHA) != headSHA {
+				return issue, blockedReadyPullRequestLookupUnavailableReason, errors.New("exact-head pull request hydration returned inconsistent pull request data")
+			}
+			return hydrated, blockedReadyPullRequestLookupFoundReason, nil
+		}
+		lookupErr = err
+		if attempt == blockedReadyPullRequestLookupAttempts {
+			break
+		}
+		wait := o.deliverableRecoveryWait
+		if wait == nil {
+			wait = waitForDispatchBackoff
+		}
+		if !wait(ctx, blockedReadyPullRequestLookupBackoff*time.Duration(1<<(attempt-1))) {
+			if ctxErr := ctx.Err(); ctxErr != nil {
+				lookupErr = ctxErr
+			} else {
+				lookupErr = errors.New("exact-head pull request lookup retry interrupted")
+			}
+			break
+		}
+	}
+	return issue, blockedReadyPullRequestLookupUnavailableReason, lookupErr
 }
 
 func blockedReadyPullRequestRecoverableCause(park workflowLaneBlockedRecoveryMetadata) bool {
@@ -659,6 +767,10 @@ func BlockedRecoveryOperatorRemedy(issue connector.Issue, reason string) string 
 		return "Retry the lane transition after restoring tracker write access."
 	case "managed_recovery":
 		return "Review the configured recovery owner and move the issue manually if that owner cannot recover it."
+	case blockedReadyPullRequestLookupNoneReason:
+		return "No PR found for the current workspace branch and head."
+	case blockedReadyPullRequestLookupUnavailableReason:
+		return "Retry exact-head pull request lookup after connector access recovers."
 	case "no_recovery_predicate":
 		return "Add a durable recovery predicate or move the issue to a lane that starts fresh work."
 	default:

--- a/internal/orchestrator/blocked_cause_recovery_test.go
+++ b/internal/orchestrator/blocked_cause_recovery_test.go
@@ -837,7 +837,6 @@ func TestRecoverBlockedReadyPullRequestExactHeadLookup(t *testing.T) {
 			t.Parallel()
 
 			issue := blockedReadyPullRequestIssue()
-			issue.BranchName = branch
 			if !tt.linked {
 				issue.PRNumber = nil
 				issue.PullRequest = nil
@@ -881,8 +880,10 @@ func TestRecoverBlockedReadyPullRequestExactHeadLookup(t *testing.T) {
 			}
 			state := newState(cfg)
 			parkedAt := time.Date(2026, 8, 14, 13, 15, 0, 0, time.UTC)
+			blockedIssue := cloneIssue(issue)
+			blockedIssue.BranchName = branch
 			state.Blocked[issue.ID] = Blocked{
-				Issue:     issue,
+				Issue:     blockedIssue,
 				Reason:    strandedUnpushedWorkReason,
 				BlockedAt: parkedAt,
 				Source:    BlockedSourceProjectStatus,

--- a/internal/orchestrator/blocked_cause_recovery_test.go
+++ b/internal/orchestrator/blocked_cause_recovery_test.go
@@ -778,6 +778,163 @@ func TestRecoverBlockedReadyPullRequestToMerging(t *testing.T) {
 	}
 }
 
+func TestRecoverBlockedReadyPullRequestExactHeadLookup(t *testing.T) {
+	t.Parallel()
+
+	const (
+		branch     = "detent/exact-head-recovery"
+		repository = "digitaldrywood/detent"
+	)
+	readyPullRequest := *blockedReadyPullRequestIssue().PullRequest
+	readyPullRequest.BranchName = branch
+	tests := []struct {
+		name              string
+		linked            bool
+		lookupPullRequest connector.PullRequest
+		lookupFound       bool
+		lookupErr         error
+		invalidWorkpad    bool
+		wantLookupCalls   int
+		wantHydrateCalls  int
+		wantWaitCalls     int
+		wantAction        string
+		wantReason        string
+		wantMerging       bool
+	}{
+		{
+			name:              "unlinked exact-head open pull request reconciles",
+			lookupPullRequest: readyPullRequest,
+			lookupFound:       true,
+			wantLookupCalls:   1,
+			wantHydrateCalls:  1,
+			wantMerging:       true,
+		},
+		{
+			name:            "unlinked with no pull request holds accurately",
+			invalidWorkpad:  true,
+			wantLookupCalls: 1,
+			wantAction:      "hold",
+			wantReason:      blockedReadyPullRequestLookupNoneReason,
+		},
+		{
+			name:            "lookup unavailable defers after bounded retries",
+			lookupErr:       connector.ErrResourceExhausted,
+			invalidWorkpad:  true,
+			wantLookupCalls: blockedReadyPullRequestLookupAttempts,
+			wantWaitCalls:   blockedReadyPullRequestLookupAttempts - 1,
+			wantAction:      "defer",
+			wantReason:      blockedReadyPullRequestLookupUnavailableReason,
+		},
+		{
+			name:        "linked pull request fast path remains unchanged",
+			linked:      true,
+			wantMerging: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			issue := blockedReadyPullRequestIssue()
+			issue.BranchName = branch
+			if !tt.linked {
+				issue.PRNumber = nil
+				issue.PullRequest = nil
+			}
+			if tt.invalidWorkpad {
+				issue.WorkpadSignal = &workpad.Signal{
+					Source: workpad.SourceStructured,
+					Status: workpad.StatusBlocked,
+					Invalid: &workpad.Invalid{
+						Message: "status must be in_progress, blocked, or complete",
+					},
+				}
+			}
+			tracker := &blockedReadyPullRequestLookupConnector{
+				dependencyAutoUnblockConnector: &dependencyAutoUnblockConnector{},
+				pullRequest:                    tt.lookupPullRequest,
+				found:                          tt.lookupFound,
+				err:                            tt.lookupErr,
+			}
+			cfg := normalizeConfig(Config{
+				MaxConcurrentAgents:  1,
+				ActiveStates:         []string{"Todo", "In Progress", "Rework", autoPromoteMergingState},
+				TerminalStates:       []string{"Done", "Cancelled"},
+				MergeFastPathEnabled: true,
+				AutoPromote: AutoPromoteConfig{
+					Enabled: true,
+					Gate:    gate.Config{Kind: gate.KindCommand, AutomatedReview: gate.AutomatedReviewOff},
+				},
+			})
+			var logs bytes.Buffer
+			waitCalls := 0
+			orch := &Orchestrator{
+				cfg:               cfg,
+				connector:         tracker,
+				logger:            slog.New(slog.NewTextHandler(&logs, nil)),
+				recoveryInspector: staticBlockedRecoveryInspector{snapshot: runpkg.BlockedRecoverySnapshot{HeadSHA: readyPullRequest.HeadSHA, WorkspacePresent: true, WorkspaceStatus: "present", Health: "ready"}},
+				deliverableRecoveryWait: func(context.Context, time.Duration) bool {
+					waitCalls++
+					return true
+				},
+			}
+			state := newState(cfg)
+			parkedAt := time.Date(2026, 8, 14, 13, 15, 0, 0, time.UTC)
+			state.Blocked[issue.ID] = Blocked{
+				Issue:     issue,
+				Reason:    strandedUnpushedWorkReason,
+				BlockedAt: parkedAt,
+				Source:    BlockedSourceProjectStatus,
+				Recovery: &workflowLaneBlockedRecoveryMetadata{
+					Owner:       blockedRecoveryOwnerOrchestrator,
+					Cause:       strandedUnpushedWorkReason,
+					Predicate:   blockedRecoveryPredicateOncePerFingerprint,
+					TargetState: autoPromoteReworkState,
+					RunMode:     RunModeImplement,
+				},
+			}
+
+			orch.recoverBlockedIssues(t.Context(), &state, []connector.Issue{issue}, parkedAt.Add(time.Minute))
+
+			if tracker.lookupCalls != tt.wantLookupCalls {
+				t.Fatalf("lookup calls = %d, want %d", tracker.lookupCalls, tt.wantLookupCalls)
+			}
+			if tracker.hydrateCalls != tt.wantHydrateCalls {
+				t.Fatalf("hydrate calls = %d, want %d", tracker.hydrateCalls, tt.wantHydrateCalls)
+			}
+			if waitCalls != tt.wantWaitCalls {
+				t.Fatalf("retry waits = %d, want %d", waitCalls, tt.wantWaitCalls)
+			}
+			if tracker.lookupCalls > 0 && (tracker.repository != repository || tracker.branch != branch || tracker.headSHA != readyPullRequest.HeadSHA) {
+				t.Fatalf("lookup = (%q, %q, %q), want (%q, %q, %q)", tracker.repository, tracker.branch, tracker.headSHA, repository, branch, readyPullRequest.HeadSHA)
+			}
+			if tracker.lookupCalls > 0 {
+				wantOutcome := tt.wantReason
+				if tt.lookupFound {
+					wantOutcome = blockedReadyPullRequestLookupFoundReason
+				}
+				if !strings.Contains(logs.String(), "reason="+wantOutcome) {
+					t.Fatalf("logs = %q, want lookup outcome %q", logs.String(), wantOutcome)
+				}
+			}
+			if tt.wantMerging {
+				if len(tracker.updates) != 1 || tracker.updates[0] != (dependencyAutoUnblockUpdate{issueID: issue.ID, state: autoPromoteMergingState}) {
+					t.Fatalf("updates = %#v, want one Merging transition", tracker.updates)
+				}
+				return
+			}
+			blocked := state.Blocked[issue.ID]
+			if blocked.RecoveryAction != tt.wantAction || blocked.RecoveryReason != tt.wantReason {
+				t.Fatalf("blocked recovery = %#v, want action %q reason %q", blocked, tt.wantAction, tt.wantReason)
+			}
+			if tt.wantReason == blockedReadyPullRequestLookupNoneReason && !strings.Contains(blocked.RecoveryRemedy, "No PR found") {
+				t.Fatalf("recovery remedy = %q, want accurate no-PR outcome", blocked.RecoveryRemedy)
+			}
+		})
+	}
+}
+
 func blockedReadyPullRequestIssue() connector.Issue {
 	prNumber := 1776
 	issue := dependencyAutoUnblockIssue("issue-ready-pr", blockedStatusState)
@@ -796,6 +953,31 @@ func blockedReadyPullRequestIssue() connector.Issue {
 		CheckRunCount:   1,
 	}
 	return issue
+}
+
+type blockedReadyPullRequestLookupConnector struct {
+	*dependencyAutoUnblockConnector
+	pullRequest  connector.PullRequest
+	found        bool
+	err          error
+	repository   string
+	branch       string
+	headSHA      string
+	lookupCalls  int
+	hydrateCalls int
+}
+
+func (c *blockedReadyPullRequestLookupConnector) LookupPullRequestByHead(_ context.Context, repository string, branch string, headSHA string) (connector.PullRequest, bool, error) {
+	c.lookupCalls++
+	c.repository = repository
+	c.branch = branch
+	c.headSHA = headSHA
+	return c.pullRequest, c.found, c.err
+}
+
+func (c *blockedReadyPullRequestLookupConnector) HydratePullRequest(_ context.Context, issue connector.Issue) (connector.Issue, error) {
+	c.hydrateCalls++
+	return issue, nil
 }
 
 func blockedCauseTestOrchestrator(tracker *dependencyAutoUnblockConnector) *Orchestrator {


### PR DESCRIPTION
## Summary

- perform a connector-level exact-head PR lookup when recoverable Blocked hydration has no linked PR
- hydrate found PRs before applying the existing merge-readiness checks
- record found, none, and unavailable lookup outcomes, with bounded retries for connector failures

Fixes #1790

## UI Surface Contract

- [x] N/A; this PR does not change UI surfaces.
- [x] This PR does not add persistent top-of-screen messaging.
- [x] N/A; this PR has no visual changes.

## Test Plan

- [x] `go test ./internal/orchestrator -run '^TestRecoverBlockedReadyPullRequest(ExactHeadLookup|ToMerging)$' -count=1`
- [x] `go test ./internal/orchestrator -count=1`
- [x] `make check`