### PR TITLE
fix(codex): allow workflow issue mutations

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -369,17 +369,33 @@ codex:
     - server: codex_apps
       tool: github.update_pull_request
       repository: digitaldrywood/detent
+    - server: codex_apps
+      tool: github.add_comment_to_issue
+      repository: digitaldrywood/detent
+    - server: codex_apps
+      tool: github.update_issue_comment
+      repository: digitaldrywood/detent
+    - server: codex_apps
+      tool: github.update_issue
+      repository: digitaldrywood/detent
 ```
 
 The allowlist is a narrow exception to `codex.approval_policy`, not a broader
 approval mode. With either `never` or `on-request`, Detent accepts an MCP
 elicitation only when it correlates to exactly one pending tool call on the
-same server, thread, and turn; the correlated tool is a supported pull-request
-deliverable mutation; and both its `repository_full_name` argument and the
-active work item's pull-request repository match the configured tuple. Missing
-or ambiguous correlation, other mutation tools, and repository mismatches are
-declined. Command, file-change, permission, and user-input requests retain
-their existing handling.
+same server, thread, and turn; the correlated tool is a supported workflow
+deliverable mutation; and both its repository argument and the active work
+item's pull-request repository match the configured tuple. Pull-request and
+issue updates use `repository_full_name`; issue comment creation and updates
+use `repo_full_name`. Missing or ambiguous correlation, other mutation tools
+including `github.delete_issue`, and repository mismatches are declined.
+Command, file-change, permission, and user-input requests retain their existing
+handling.
+
+Allowlisting `github.update_issue` permits its full exposed mutation surface:
+title, body, state, assignees, milestone, and labels may all be replaced. The
+allowlist correlates and constrains the repository, but does not constrain the
+other approved arguments.
 
 With `approval_policy: never` and an empty allowlist, non-browser MCP
 elicitations are declined exactly as before. `chrome-devtools` empty-form tool

--- a/docs/config.md
+++ b/docs/config.md
@@ -384,13 +384,15 @@ The allowlist is a narrow exception to `codex.approval_policy`, not a broader
 approval mode. With either `never` or `on-request`, Detent accepts an MCP
 elicitation only when it correlates to exactly one pending tool call on the
 same server, thread, and turn; the correlated tool is a supported workflow
-deliverable mutation; and both its repository argument and the active work
-item's pull-request repository match the configured tuple. Pull-request and
-issue updates use `repository_full_name`; issue comment creation and updates
-use `repo_full_name`. Missing or ambiguous correlation, other mutation tools
-including `github.delete_issue`, and repository mismatches are declined.
-Command, file-change, permission, and user-input requests retain their existing
-handling.
+deliverable mutation; and both its repository argument and the corresponding
+active work-item repository match the configured tuple. Pull-request mutations
+match the linked pull-request repository. Issue and Workpad mutations match the
+tracked issue repository, including when the linked pull request is in another
+repository. Pull-request and issue updates use `repository_full_name`; issue
+comment creation and updates use `repo_full_name`. Missing or ambiguous
+correlation, other mutation tools including `github.delete_issue`, and
+repository mismatches are declined. Command, file-change, permission, and
+user-input requests retain their existing handling.
 
 Allowlisting `github.update_issue` permits its full exposed mutation surface:
 title, body, state, assignees, milestone, and labels may all be replaced. The

--- a/internal/codex/appserver.go
+++ b/internal/codex/appserver.go
@@ -215,6 +215,7 @@ type MCPElicitationRule struct {
 type MCPElicitationPolicy struct {
 	DeliverableKind string
 	Repository      string
+	IssueRepository string
 	Allowlist       []MCPElicitationRule
 }
 
@@ -1260,6 +1261,7 @@ func newMCPElicitationState(policy MCPElicitationPolicy, onUpdate UpdateHandler)
 		policy: MCPElicitationPolicy{
 			DeliverableKind: strings.TrimSpace(policy.DeliverableKind),
 			Repository:      strings.TrimSpace(policy.Repository),
+			IssueRepository: strings.TrimSpace(policy.IssueRepository),
 			Allowlist:       append([]MCPElicitationRule(nil), policy.Allowlist...),
 		},
 		pending:  map[string]pendingMCPToolCall{},
@@ -1484,7 +1486,7 @@ func mcpElicitationResponse(params json.RawMessage, state *mcpElicitationState) 
 			decision.Reason = "tool_not_allowlisted"
 			return decline()
 		}
-		repositoryArgument, deliverableTool := deliverableMCPRepositoryArgument(call.Server, call.Tool)
+		repositoryArgument, expectedRepository, deliverableTool := deliverableMCPRepository(policy, call.Server, call.Tool)
 		if !deliverableTool || policy.DeliverableKind != "pull_request" {
 			decision.Reason = "non_deliverable_mutation"
 			return decline()
@@ -1495,8 +1497,8 @@ func mcpElicitationResponse(params json.RawMessage, state *mcpElicitationState) 
 			return decline()
 		}
 		decision.Repository = repository
-		if policy.Repository == "" || !strings.EqualFold(repository, policy.Repository) ||
-			!state.hasRepositoryRule(call.Server, call.Tool, policy.Repository) {
+		if expectedRepository == "" || !strings.EqualFold(repository, expectedRepository) ||
+			!state.hasRepositoryRule(call.Server, call.Tool, expectedRepository) {
 			decision.Reason = "repository_mismatch"
 			return decline()
 		}
@@ -1510,17 +1512,19 @@ func mcpElicitationResponse(params json.RawMessage, state *mcpElicitationState) 
 	return map[string]any{"action": "accept", "content": map[string]any{}}, decision
 }
 
-func deliverableMCPRepositoryArgument(server string, tool string) (string, bool) {
+func deliverableMCPRepository(policy MCPElicitationPolicy, server string, tool string) (string, string, bool) {
 	if server != "codex_apps" {
-		return "", false
+		return "", "", false
 	}
 	switch tool {
 	case "github.add_comment_to_issue", "github.update_issue_comment":
-		return "repo_full_name", true
-	case "github.create_pull_request", "github.update_issue", "github.update_pull_request":
-		return "repository_full_name", true
+		return "repo_full_name", policy.IssueRepository, true
+	case "github.update_issue":
+		return "repository_full_name", policy.IssueRepository, true
+	case "github.create_pull_request", "github.update_pull_request":
+		return "repository_full_name", policy.Repository, true
 	default:
-		return "", false
+		return "", "", false
 	}
 }
 

--- a/internal/codex/appserver.go
+++ b/internal/codex/appserver.go
@@ -1515,7 +1515,9 @@ func deliverableMCPRepositoryArgument(server string, tool string) (string, bool)
 		return "", false
 	}
 	switch tool {
-	case "github.create_pull_request", "github.update_pull_request":
+	case "github.add_comment_to_issue", "github.update_issue_comment":
+		return "repo_full_name", true
+	case "github.create_pull_request", "github.update_issue", "github.update_pull_request":
 		return "repository_full_name", true
 	default:
 		return "", false

--- a/internal/codex/appserver_test.go
+++ b/internal/codex/appserver_test.go
@@ -1478,7 +1478,8 @@ func TestMCPElicitationResponseAllowsWorkflowDeliverableMutations(t *testing.T) 
 
 			state := newMCPElicitationState(MCPElicitationPolicy{
 				DeliverableKind: "pull_request",
-				Repository:      "acme/widgets",
+				Repository:      "acme/delivery",
+				IssueRepository: "acme/widgets",
 				Allowlist: []MCPElicitationRule{{
 					Server: "codex_apps", Tool: tt.tool, Repository: "acme/widgets",
 				}},

--- a/internal/codex/appserver_test.go
+++ b/internal/codex/appserver_test.go
@@ -1386,6 +1386,128 @@ func TestMCPElicitationResponse(t *testing.T) {
 	}
 }
 
+func TestMCPElicitationResponseAllowsWorkflowDeliverableMutations(t *testing.T) {
+	t.Parallel()
+
+	const request = `{
+		"threadId":"thread-1","turnId":"turn-1","serverName":"codex_apps","mode":"form",
+		"requestedSchema":{"type":"object","properties":{}},"_meta":{"codex_approval_kind":"mcp_tool_call"}
+	}`
+	tests := []struct {
+		name           string
+		tool           string
+		arguments      string
+		wantAction     string
+		wantReason     string
+		wantRepository string
+	}{
+		{
+			name:           "add issue comment matching repository",
+			tool:           "github.add_comment_to_issue",
+			arguments:      `{"repo_full_name":"acme/widgets","pr_number":18,"comment":"workpad"}`,
+			wantAction:     "accept",
+			wantReason:     "allowlisted_deliverable_tool",
+			wantRepository: "acme/widgets",
+		},
+		{
+			name:           "update issue comment matching repository",
+			tool:           "github.update_issue_comment",
+			arguments:      `{"repo_full_name":"acme/widgets","comment_id":42,"comment":"updated workpad"}`,
+			wantAction:     "accept",
+			wantReason:     "allowlisted_deliverable_tool",
+			wantRepository: "acme/widgets",
+		},
+		{
+			name:           "update issue matching repository",
+			tool:           "github.update_issue",
+			arguments:      `{"repository_full_name":"acme/widgets","issue_number":18,"labels":["detent:in-progress"]}`,
+			wantAction:     "accept",
+			wantReason:     "allowlisted_deliverable_tool",
+			wantRepository: "acme/widgets",
+		},
+		{
+			name:           "add issue comment mismatched repository",
+			tool:           "github.add_comment_to_issue",
+			arguments:      `{"repo_full_name":"acme/other","pr_number":18,"comment":"workpad"}`,
+			wantAction:     "decline",
+			wantReason:     "repository_mismatch",
+			wantRepository: "acme/other",
+		},
+		{
+			name:           "update issue comment mismatched repository",
+			tool:           "github.update_issue_comment",
+			arguments:      `{"repo_full_name":"acme/other","comment_id":42,"comment":"updated workpad"}`,
+			wantAction:     "decline",
+			wantReason:     "repository_mismatch",
+			wantRepository: "acme/other",
+		},
+		{
+			name:           "update issue mismatched repository",
+			tool:           "github.update_issue",
+			arguments:      `{"repository_full_name":"acme/other","issue_number":18,"labels":["detent:in-progress"]}`,
+			wantAction:     "decline",
+			wantReason:     "repository_mismatch",
+			wantRepository: "acme/other",
+		},
+		{
+			name:       "add issue comment wrong repository argument",
+			tool:       "github.add_comment_to_issue",
+			arguments:  `{"repository_full_name":"acme/widgets","pr_number":18,"comment":"workpad"}`,
+			wantAction: "decline",
+			wantReason: "invalid_tool_arguments",
+		},
+		{
+			name:       "update issue comment wrong repository argument",
+			tool:       "github.update_issue_comment",
+			arguments:  `{"repository_full_name":"acme/widgets","comment_id":42,"comment":"updated workpad"}`,
+			wantAction: "decline",
+			wantReason: "invalid_tool_arguments",
+		},
+		{
+			name:       "update issue wrong repository argument",
+			tool:       "github.update_issue",
+			arguments:  `{"repo_full_name":"acme/widgets","issue_number":18,"labels":["detent:in-progress"]}`,
+			wantAction: "decline",
+			wantReason: "invalid_tool_arguments",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			state := newMCPElicitationState(MCPElicitationPolicy{
+				DeliverableKind: "pull_request",
+				Repository:      "acme/widgets",
+				Allowlist: []MCPElicitationRule{{
+					Server: "codex_apps", Tool: tt.tool, Repository: "acme/widgets",
+				}},
+			}, nil)
+			pending := `{"threadId":"thread-1","turnId":"turn-1","item":{"id":"item-1","type":"mcpToolCall","server":"codex_apps","tool":"` + tt.tool + `","arguments":` + tt.arguments + `}}`
+			if err := state.observe(notificationMessage(t, "item/started", pending)); err != nil {
+				t.Fatalf("observe() error = %v", err)
+			}
+
+			response, decision := mcpElicitationResponse(json.RawMessage(request), state)
+			if got := response["action"]; got != tt.wantAction {
+				t.Errorf("action = %v, want %q", got, tt.wantAction)
+			}
+			if decision.Action != tt.wantAction {
+				t.Errorf("decision action = %q, want %q", decision.Action, tt.wantAction)
+			}
+			if decision.Reason != tt.wantReason {
+				t.Errorf("decision reason = %q, want %q", decision.Reason, tt.wantReason)
+			}
+			if decision.Tool != tt.tool {
+				t.Errorf("decision tool = %q, want %q", decision.Tool, tt.tool)
+			}
+			if decision.Repository != tt.wantRepository {
+				t.Errorf("decision repository = %q, want %q", decision.Repository, tt.wantRepository)
+			}
+		})
+	}
+}
+
 func TestAppServerRunTurnRecordsDeclinedMCPElicitations(t *testing.T) {
 	t.Parallel()
 

--- a/internal/codex/backend.go
+++ b/internal/codex/backend.go
@@ -134,6 +134,7 @@ func mcpElicitationPolicy(allowlist []MCPElicitationRule, req runner.AgentTurnRe
 	return MCPElicitationPolicy{
 		DeliverableKind: strings.TrimSpace(req.DeliverableKind),
 		Repository:      strings.TrimSpace(req.DeliverableRepository),
+		IssueRepository: strings.TrimSpace(req.IssueRepository),
 		Allowlist:       append([]MCPElicitationRule(nil), allowlist...),
 	}
 }

--- a/internal/codex/backend_test.go
+++ b/internal/codex/backend_test.go
@@ -145,6 +145,7 @@ func TestMCPElicitationPolicyForTurn(t *testing.T) {
 			want: MCPElicitationPolicy{
 				DeliverableKind: "pull_request",
 				Repository:      "acme/widgets",
+				IssueRepository: "acme/issues",
 				Allowlist:       rules,
 			},
 		},
@@ -158,6 +159,7 @@ func TestMCPElicitationPolicyForTurn(t *testing.T) {
 			got := mcpElicitationPolicy(rules, runner.AgentTurnRequest{
 				DeliverableKind:       " pull_request ",
 				DeliverableRepository: " acme/widgets ",
+				IssueRepository:       " acme/issues ",
 			}, tt.restricted)
 			if !reflect.DeepEqual(got, tt.want) {
 				t.Fatalf("mcpElicitationPolicy() = %#v, want %#v", got, tt.want)

--- a/internal/runner/agent.go
+++ b/internal/runner/agent.go
@@ -534,6 +534,17 @@ func agentTurnDeliverable(cfg config.Config, issue connector.Issue, mode string)
 	return strings.TrimSpace(cfg.Deliverable.Kind), repository
 }
 
+func agentTurnIssueRepository(cfg config.Config, issue connector.Issue) string {
+	identifier := strings.TrimSpace(issue.Identifier)
+	if githubIssueNumber(identifier) != "" {
+		repository := strings.TrimSpace(identifier[:strings.LastIndex(identifier, "#")])
+		if repository != "" {
+			return repository
+		}
+	}
+	return strings.TrimSpace(cfg.Tracker.Repository)
+}
+
 func runRole(mode string, issue connector.Issue) string {
 	switch normalizeRunMode(mode) {
 	case RunModePlan:
@@ -1304,6 +1315,7 @@ func (r *Runner) Run(ctx context.Context, req RunRequest) (RunResult, error) {
 		ExtraWritableRoots:    extraWritableRoots,
 		DeliverableKind:       deliverableKind,
 		DeliverableRepository: deliverableRepository,
+		IssueRepository:       agentTurnIssueRepository(workflow.Config, req.Issue),
 		cacheStrategy:         workflow.Config.Workspace.CacheStrategy,
 		projectID:             r.projectID,
 		workerGitHub:          workerGitHub,

--- a/internal/runner/runner_test.go
+++ b/internal/runner/runner_test.go
@@ -32,6 +32,47 @@ import (
 	"github.com/digitaldrywood/detent/internal/workspace"
 )
 
+func TestAgentTurnIssueRepository(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		configured string
+		issue      connector.Issue
+		want       string
+	}{
+		{
+			name: "issue identifier differs from linked PR repository",
+			issue: connector.Issue{
+				Identifier:   " acme/issues#42 ",
+				PRRepository: "acme/delivery",
+			},
+			want: "acme/issues",
+		},
+		{
+			name:       "tracker repository fallback",
+			configured: " acme/issues ",
+			issue:      connector.Issue{Identifier: "ISSUE-42", PRRepository: "acme/delivery"},
+			want:       "acme/issues",
+		},
+		{
+			name:  "missing repository",
+			issue: connector.Issue{Identifier: "ISSUE-42", PRRepository: "acme/delivery"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			cfg := config.Config{Tracker: config.Tracker{Repository: tt.configured}}
+			if got := agentTurnIssueRepository(cfg, tt.issue); got != tt.want {
+				t.Fatalf("agentTurnIssueRepository() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestRunnerRunPreparesWorkspaceRunsCodexAndRecordsSession(t *testing.T) {
 	t.Parallel()
 
@@ -276,8 +317,10 @@ func TestRunnerRunPreparesWorkspaceRunsCodexAndRecordsSession(t *testing.T) {
 	if codexClient.request.Workspace != workspacePath {
 		t.Fatalf("codex workspace = %q, want %q", codexClient.request.Workspace, workspacePath)
 	}
-	if codexClient.request.DeliverableKind != config.DeliverablePullRequest || codexClient.request.DeliverableRepository != "digitaldrywood/detent" {
-		t.Fatalf("codex deliverable = %q/%q, want pull request for digitaldrywood/detent", codexClient.request.DeliverableKind, codexClient.request.DeliverableRepository)
+	if codexClient.request.DeliverableKind != config.DeliverablePullRequest ||
+		codexClient.request.DeliverableRepository != "digitaldrywood/detent" ||
+		codexClient.request.IssueRepository != "digitaldrywood/detent" {
+		t.Fatalf("codex repositories = deliverable %q/%q, issue %q", codexClient.request.DeliverableKind, codexClient.request.DeliverableRepository, codexClient.request.IssueRepository)
 	}
 	cacheRoot := sharedWorkerCacheRoot(workspacePath, "detent")
 	for name, want := range map[string]string{

--- a/internal/runner/types.go
+++ b/internal/runner/types.go
@@ -253,6 +253,7 @@ type AgentTurnRequest struct {
 	ExtraWritableRoots    []string
 	DeliverableKind       string
 	DeliverableRepository string
+	IssueRepository       string
 	Environment           procgroup.Environment
 	cacheStrategy         string
 	projectID             string


### PR DESCRIPTION
## Summary

- treat issue Workpad creation, Workpad updates, and issue updates as allowlist-eligible deliverable mutations
- correlate each supported GitHub tool through its actual repository argument without widening other mutations
- keep issue/Workpad mutations scoped to the tracked issue repository while PR mutations remain scoped to the linked PR repository
- document the full `github.update_issue` authority and cover matching, mismatched, wrong-key, and cross-repository behavior

Fixes #1794

## UI Surface Contract

- [x] N/A; this PR does not change a UI surface.
- [x] This PR does not add persistent top-of-screen messaging.
- [x] N/A; this PR has no visual changes.

## Test Plan

- [x] `go test ./internal/codex -run '^Test(MCPElicitationResponseAllowsWorkflowDeliverableMutations|MCPElicitationPolicyForTurn)$' -count=1`
- [x] `go test ./internal/runner -run '^(TestAgentTurnIssueRepository|TestRunnerRunPreparesWorkspaceRunsCodexAndRecordsSession)$' -count=1`
- [x] `go test ./internal/codex ./internal/runner -count=1`
- [x] `make check`