### PR TITLE
fix(ops): surface stale binary drift

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -295,6 +295,26 @@ install_release_or_go() {
 	install_go
 }
 
+report_service_restart_required() {
+	if command -v systemctl >/dev/null 2>&1 && systemctl --user is-active --quiet detent.service 2>/dev/null; then
+		printf '%s\n' "A running systemd user service was not restarted and is still using the previous Detent binary."
+		printf '%s\n' "Restart it to load this installation: systemctl --user restart detent.service"
+		return
+	fi
+	if command -v systemctl >/dev/null 2>&1 && systemctl is-active --quiet detent.service 2>/dev/null; then
+		printf '%s\n' "A running systemd service was not restarted and is still using the previous Detent binary."
+		printf '%s\n' "Restart it to load this installation: sudo systemctl restart detent.service"
+		return
+	fi
+	if command -v launchctl >/dev/null 2>&1 && command -v id >/dev/null 2>&1; then
+		launchd_target="gui/$(id -u)/com.digitaldrywood.detent"
+		if launchctl print "$launchd_target" >/dev/null 2>&1; then
+			printf '%s\n' "A running launchd service was not restarted and is still using the previous Detent binary."
+			printf 'Restart it to load this installation: launchctl kickstart -k %s\n' "$launchd_target"
+		fi
+	fi
+}
+
 install_dir="$(choose_install_dir)"
 target="$install_dir/detent"
 
@@ -357,6 +377,7 @@ install_binary
 
 cleanup_lock=false
 echo "Installed Detent at $target"
+report_service_restart_required
 case ":${PATH:-}:" in
 	*":$install_dir:"*) ;;
 	*) printf 'Add %s to PATH before running detent: export PATH="%s:$PATH"\n' "$install_dir" "$install_dir" ;;

--- a/install_test.go
+++ b/install_test.go
@@ -358,6 +358,55 @@ func TestInstallScriptReportsPathGuidanceWhenInstallDirIsMissingFromPath(t *test
 	}
 }
 
+func TestInstallScriptReportsActiveServiceRestartGuidance(t *testing.T) {
+	t.Parallel()
+
+	root, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("Getwd() error = %v", err)
+	}
+
+	tmp := t.TempDir()
+	source := filepath.Join(tmp, "source-detent")
+	if err := os.WriteFile(source, []byte("#!/usr/bin/env sh\nexit 0\n"), 0o755); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+	fakeBin := filepath.Join(tmp, "fakebin")
+	if err := os.MkdirAll(fakeBin, 0o755); err != nil {
+		t.Fatalf("MkdirAll(fakebin) error = %v", err)
+	}
+	fakeSystemctl := filepath.Join(fakeBin, "systemctl")
+	if err := os.WriteFile(fakeSystemctl, []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
+		t.Fatalf("WriteFile(systemctl) error = %v", err)
+	}
+
+	installDir := filepath.Join(tmp, "bin")
+	stateDir := filepath.Join(tmp, "state")
+	env := append(os.Environ(),
+		"HOME="+tmp,
+		"PATH="+fakeBin+string(os.PathListSeparator)+os.Getenv("PATH"),
+		"DETENT_INSTALL_SOURCE="+source,
+		"DETENT_INSTALL_DIR="+installDir,
+		"DETENT_STATE_DIR="+stateDir,
+		"DETENT_INSTALL_LOCK="+filepath.Join(stateDir, "install.lock"),
+		"DETENT_INSTALL_TEST_UNAME_S=Linux",
+		"DETENT_INSTALL_TEST_UNAME_M=x86_64",
+	)
+
+	result := runInstall(t, root, env)
+	if result.err != nil {
+		t.Fatalf("install error = %v\nstdout:\n%s\nstderr:\n%s", result.err, result.stdout, result.stderr)
+	}
+	for _, want := range []string{
+		"running systemd user service was not restarted",
+		"systemctl --user restart detent.service",
+	} {
+		if !strings.Contains(result.stdout, want) {
+			t.Fatalf("install stdout = %q, want containing %q", result.stdout, want)
+		}
+	}
+}
+
 func TestInstallScriptAbortsOnChecksumMismatch(t *testing.T) {
 	t.Parallel()
 

--- a/internal/buildinfo/drift.go
+++ b/internal/buildinfo/drift.go
@@ -1,0 +1,73 @@
+package buildinfo
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+)
+
+type Drift struct {
+	Comparable bool
+	Detected   bool
+}
+
+type BinaryRunner func(context.Context, string, ...string) (string, error)
+
+func DetectDrift(running Info, installed Info) Drift {
+	if IsZero(running) || IsZero(installed) {
+		return Drift{}
+	}
+	running = Normalize(running)
+	installed = Normalize(installed)
+	if !placeholderCommit(running.Commit) && !placeholderCommit(installed.Commit) {
+		return Drift{Comparable: true, Detected: !sameCommit(running.Commit, installed.Commit)}
+	}
+	if !placeholderVersion(running.Version) && !placeholderVersion(installed.Version) {
+		return Drift{Comparable: true, Detected: running.Version != installed.Version}
+	}
+	return Drift{}
+}
+
+func ReadBinary(ctx context.Context, path string, run BinaryRunner) (Info, error) {
+	path = strings.TrimSpace(path)
+	if path == "" {
+		return Info{}, errors.New("binary path is required")
+	}
+	if run == nil {
+		return Info{}, errors.New("binary runner is required")
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	output, err := run(ctx, path, "--format", "json", "version")
+	if err != nil {
+		return Info{}, fmt.Errorf("read installed Detent build: %w", err)
+	}
+	var payload struct {
+		Version string `json:"version"`
+		Commit  string `json:"commit"`
+		Date    string `json:"build_date"`
+	}
+	if err := json.Unmarshal([]byte(output), &payload); err != nil {
+		return Info{}, fmt.Errorf("decode installed Detent build: %w", err)
+	}
+	info := Info{Version: payload.Version, Commit: payload.Commit, Date: payload.Date}
+	if IsZero(info) {
+		return Info{}, errors.New("installed Detent binary did not report build metadata")
+	}
+	return Normalize(info), nil
+}
+
+func sameCommit(left string, right string) bool {
+	left = strings.ToLower(strings.TrimSpace(left))
+	right = strings.ToLower(strings.TrimSpace(right))
+	if left == right {
+		return true
+	}
+	if min(len(left), len(right)) < shortCommitWidth {
+		return false
+	}
+	return strings.HasPrefix(left, right) || strings.HasPrefix(right, left)
+}

--- a/internal/buildinfo/drift_test.go
+++ b/internal/buildinfo/drift_test.go
@@ -1,0 +1,128 @@
+package buildinfo
+
+import (
+	"context"
+	"errors"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func TestDetectDrift(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		running   Info
+		installed Info
+		want      Drift
+	}{
+		{
+			name:      "matching commit",
+			running:   Info{Version: "v1.2.2", Commit: "abcdef123456"},
+			installed: Info{Version: "v1.2.3", Commit: "abcdef123456"},
+			want:      Drift{Comparable: true},
+		},
+		{
+			name:      "matching short commit",
+			running:   Info{Version: "v1.2.3", Commit: "abcdef1"},
+			installed: Info{Version: "v1.2.3", Commit: "abcdef123456"},
+			want:      Drift{Comparable: true},
+		},
+		{
+			name:      "different commit",
+			running:   Info{Version: "v1.2.2", Commit: "abcdef123456"},
+			installed: Info{Version: "v1.2.3", Commit: "123456abcdef"},
+			want:      Drift{Comparable: true, Detected: true},
+		},
+		{
+			name:      "version fallback matches",
+			running:   Info{Version: "v1.2.3", Commit: "none"},
+			installed: Info{Version: "v1.2.3", Commit: "none"},
+			want:      Drift{Comparable: true},
+		},
+		{
+			name:      "version fallback differs",
+			running:   Info{Version: "v1.2.2", Commit: "none"},
+			installed: Info{Version: "v1.2.3", Commit: "none"},
+			want:      Drift{Comparable: true, Detected: true},
+		},
+		{
+			name:      "unknown builds",
+			running:   Info{Version: "dev", Commit: "none"},
+			installed: Info{Version: "dev", Commit: "none"},
+		},
+		{
+			name:      "missing running build",
+			running:   Info{},
+			installed: Info{Version: "v1.2.3", Commit: "abcdef123456"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			if got := DetectDrift(tt.running, tt.installed); got != tt.want {
+				t.Fatalf("DetectDrift() = %#v, want %#v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestReadBinary(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		path     string
+		output   string
+		runErr   error
+		want     Info
+		wantErr  string
+		wantPath string
+		wantArgs []string
+	}{
+		{
+			name:     "build metadata",
+			path:     " /opt/detent/bin/detent ",
+			output:   `{"version":"v1.2.3","commit":"abcdef123456","build_date":"2026-08-14T00:00:00Z"}`,
+			want:     Info{Version: "v1.2.3", Commit: "abcdef123456", Date: "2026-08-14T00:00:00Z"},
+			wantPath: "/opt/detent/bin/detent",
+			wantArgs: []string{"--format", "json", "version"},
+		},
+		{name: "runner failure", path: "/opt/detent", runErr: errors.New("permission denied"), wantErr: "read installed Detent build"},
+		{name: "invalid output", path: "/opt/detent", output: "not-json", wantErr: "decode installed Detent build"},
+		{name: "missing metadata", path: "/opt/detent", output: `{}`, wantErr: "did not report build metadata"},
+		{name: "missing path", wantErr: "binary path is required"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			var gotPath string
+			var gotArgs []string
+			got, err := ReadBinary(context.Background(), tt.path, func(_ context.Context, path string, args ...string) (string, error) {
+				gotPath = path
+				gotArgs = append([]string(nil), args...)
+				return tt.output, tt.runErr
+			})
+			if tt.wantErr != "" {
+				if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
+					t.Fatalf("ReadBinary() error = %v, want containing %q", err, tt.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("ReadBinary() error = %v", err)
+			}
+			if got != tt.want {
+				t.Fatalf("ReadBinary() = %#v, want %#v", got, tt.want)
+			}
+			if gotPath != tt.wantPath || !reflect.DeepEqual(gotArgs, tt.wantArgs) {
+				t.Fatalf("runner call = %q %#v, want %q %#v", gotPath, gotArgs, tt.wantPath, tt.wantArgs)
+			}
+		})
+	}
+}

--- a/internal/cli/boot.go
+++ b/internal/cli/boot.go
@@ -161,6 +161,8 @@ type startRunningDependencies struct {
 	boardSnapshotStore    boardsnapshot.Store
 	boardSnapshotInterval time.Duration
 	backgroundWaitStarted func()
+	buildDriftInterval    time.Duration
+	readInstalledBuild    installedBuildReader
 	managerDependencies   project.ManagerDependencies
 }
 
@@ -369,6 +371,13 @@ func startRunningWithDependencies(ctx context.Context, cfg BootConfig, deps star
 		}
 		resourceWorkers.Wait()
 	}()
+	readInstalledBuild := deps.readInstalledBuild
+	if readInstalledBuild == nil {
+		readInstalledBuild = readInstalledExecutableBuild
+	}
+	resourceWorkers.Go(func() {
+		runRuntimeBuildDriftMonitor(runCtx, cfg.Build, deps.buildDriftInterval, readInstalledBuild, logger)
+	})
 	resourceWorkers.Go(func() {
 		publishSnapshots(runCtx, manager.Registry(), globalDispatchGate, snapshotHub, snapshotSeq, cfg.Shutdown, runtimeStore, displayURL, defaultSnapshotInterval, time.Now, updateScheduler)
 	})

--- a/internal/cli/boot.go
+++ b/internal/cli/boot.go
@@ -373,7 +373,7 @@ func startRunningWithDependencies(ctx context.Context, cfg BootConfig, deps star
 	}()
 	readInstalledBuild := deps.readInstalledBuild
 	if readInstalledBuild == nil {
-		readInstalledBuild = readInstalledExecutableBuild
+		readInstalledBuild = newInstalledExecutableBuildReader(os.Executable, defaultCommandRunner)
 	}
 	resourceWorkers.Go(func() {
 		runRuntimeBuildDriftMonitor(runCtx, cfg.Build, deps.buildDriftInterval, readInstalledBuild, logger)

--- a/internal/cli/build_drift.go
+++ b/internal/cli/build_drift.go
@@ -3,7 +3,6 @@ package cli
 import (
 	"context"
 	"log/slog"
-	"os"
 	"strings"
 	"time"
 
@@ -81,14 +80,16 @@ func runRuntimeBuildDriftMonitor(
 	}
 }
 
-func readInstalledExecutableBuild(ctx context.Context) (buildinfo.Info, string, error) {
-	path, err := os.Executable()
-	if err != nil {
-		return buildinfo.Info{}, "", err
+func newInstalledExecutableBuildReader(executable func() (string, error), run buildinfo.BinaryRunner) installedBuildReader {
+	path, pathErr := executable()
+	path = strings.TrimSuffix(strings.TrimSpace(path), " (deleted)")
+	return func(ctx context.Context) (buildinfo.Info, string, error) {
+		if pathErr != nil {
+			return buildinfo.Info{}, path, pathErr
+		}
+		info, err := buildinfo.ReadBinary(ctx, path, run)
+		return info, path, err
 	}
-	path = strings.TrimSpace(path)
-	info, err := buildinfo.ReadBinary(ctx, path, defaultCommandRunner)
-	return info, path, err
 }
 
 func waitForBuildDriftCheck(ctx context.Context, interval time.Duration) bool {

--- a/internal/cli/build_drift.go
+++ b/internal/cli/build_drift.go
@@ -1,0 +1,103 @@
+package cli
+
+import (
+	"context"
+	"log/slog"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/digitaldrywood/detent/internal/buildinfo"
+)
+
+const (
+	defaultBuildDriftInterval = time.Minute
+	buildDriftReadTimeout     = 5 * time.Second
+)
+
+type installedBuildReader func(context.Context) (buildinfo.Info, string, error)
+
+func runRuntimeBuildDriftMonitor(
+	ctx context.Context,
+	runningBuild buildinfo.Info,
+	interval time.Duration,
+	read installedBuildReader,
+	logger *slog.Logger,
+) {
+	if buildinfo.IsZero(runningBuild) || read == nil {
+		return
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if interval <= 0 {
+		interval = defaultBuildDriftInterval
+	}
+	if logger == nil {
+		logger = slog.Default()
+	}
+	driftDetected := false
+	lastReadError := ""
+	for waitForBuildDriftCheck(ctx, interval) {
+		readCtx, cancel := context.WithTimeout(ctx, buildDriftReadTimeout)
+		installedBuild, path, err := read(readCtx)
+		cancel()
+		if err != nil {
+			if message := err.Error(); message != lastReadError && ctx.Err() == nil {
+				logger.Warn("check installed Detent build drift failed", "binary", path, "error", err)
+				lastReadError = message
+			}
+			continue
+		}
+		lastReadError = ""
+		drift := buildinfo.DetectDrift(runningBuild, installedBuild)
+		if !drift.Comparable {
+			continue
+		}
+		if drift.Detected {
+			if !driftDetected {
+				logger.Warn(
+					"running Detent build differs from installed binary; restart required",
+					"binary", path,
+					"running_version", runningBuild.Version,
+					"running_commit", buildinfo.ShortCommit(runningBuild.Commit),
+					"installed_version", installedBuild.Version,
+					"installed_commit", buildinfo.ShortCommit(installedBuild.Commit),
+					"remediation", "detent start --restart",
+				)
+			}
+			driftDetected = true
+			continue
+		}
+		if driftDetected {
+			logger.Info(
+				"running Detent build now matches installed binary",
+				"binary", path,
+				"version", runningBuild.Version,
+				"commit", buildinfo.ShortCommit(runningBuild.Commit),
+			)
+		}
+		driftDetected = false
+	}
+}
+
+func readInstalledExecutableBuild(ctx context.Context) (buildinfo.Info, string, error) {
+	path, err := os.Executable()
+	if err != nil {
+		return buildinfo.Info{}, "", err
+	}
+	path = strings.TrimSpace(path)
+	info, err := buildinfo.ReadBinary(ctx, path, defaultCommandRunner)
+	return info, path, err
+}
+
+func waitForBuildDriftCheck(ctx context.Context, interval time.Duration) bool {
+	timer := time.NewTimer(interval)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		return false
+	case <-timer.C:
+		return true
+	}
+}

--- a/internal/cli/build_drift_test.go
+++ b/internal/cli/build_drift_test.go
@@ -12,6 +12,34 @@ import (
 	"github.com/digitaldrywood/detent/internal/buildinfo"
 )
 
+func TestNewInstalledExecutableBuildReaderCapturesPath(t *testing.T) {
+	t.Parallel()
+
+	executableCalls := 0
+	var paths []string
+	read := newInstalledExecutableBuildReader(func() (string, error) {
+		executableCalls++
+		return "/opt/detent/bin/detent (deleted)", nil
+	}, func(_ context.Context, path string, _ ...string) (string, error) {
+		paths = append(paths, path)
+		return `{"version":"v1.2.3","commit":"abcdef123456","build_date":"2026-08-14T00:00:00Z"}`, nil
+	})
+
+	for range 2 {
+		if _, _, err := read(context.Background()); err != nil {
+			t.Fatalf("read() error = %v", err)
+		}
+	}
+	if executableCalls != 1 {
+		t.Fatalf("executable calls = %d, want 1", executableCalls)
+	}
+	for _, path := range paths {
+		if path != "/opt/detent/bin/detent" {
+			t.Fatalf("binary path = %q, want captured pathname without deleted suffix", path)
+		}
+	}
+}
+
 func TestRunRuntimeBuildDriftMonitor(t *testing.T) {
 	t.Parallel()
 

--- a/internal/cli/build_drift_test.go
+++ b/internal/cli/build_drift_test.go
@@ -1,0 +1,71 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"log/slog"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/digitaldrywood/detent/internal/buildinfo"
+)
+
+func TestRunRuntimeBuildDriftMonitor(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		installed  buildinfo.Info
+		readErr    error
+		wantLog    string
+		wantAbsent string
+	}{
+		{
+			name:       "matching build stays quiet",
+			installed:  buildinfo.Info{Version: "v1.2.3", Commit: "abcdef123456"},
+			wantAbsent: "restart required",
+		},
+		{
+			name:      "stale running build warns with remediation",
+			installed: buildinfo.Info{Version: "v1.2.4", Commit: "123456abcdef"},
+			wantLog:   "detent start --restart",
+		},
+		{
+			name:    "read failure is visible",
+			readErr: errors.New("permission denied"),
+			wantLog: "check installed Detent build drift failed",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			var output bytes.Buffer
+			logger := slog.New(slog.NewTextHandler(&output, nil))
+			ctx, cancel := context.WithCancel(context.Background())
+			calls := 0
+			read := func(context.Context) (buildinfo.Info, string, error) {
+				calls++
+				if calls > 1 {
+					cancel()
+				}
+				return tt.installed, "/opt/detent/bin/detent", tt.readErr
+			}
+			runRuntimeBuildDriftMonitor(ctx, buildinfo.Info{
+				Version: "v1.2.3",
+				Commit:  "abcdef123456",
+			}, time.Nanosecond, read, logger)
+
+			logs := output.String()
+			if tt.wantLog != "" && !strings.Contains(logs, tt.wantLog) {
+				t.Fatalf("logs = %q, want containing %q", logs, tt.wantLog)
+			}
+			if tt.wantAbsent != "" && strings.Contains(logs, tt.wantAbsent) {
+				t.Fatalf("logs = %q, want no %q", logs, tt.wantAbsent)
+			}
+		})
+	}
+}

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -501,7 +501,7 @@ func runDoctor(ctx context.Context, cfg doctorConfig, opts options, deps doctorD
 		doctorCheckJob{
 			Name: "Remote Detent service",
 			Run: func(jobCtx context.Context) []doctorCheck {
-				return checkDoctorDetentService(jobCtx, liveBoot, deps)
+				return checkDoctorDetentService(jobCtx, liveBoot, cfg.Build, deps)
 			},
 		},
 		doctorCheckJob{

--- a/internal/cli/doctor_environment.go
+++ b/internal/cli/doctor_environment.go
@@ -15,6 +15,7 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/digitaldrywood/detent/internal/buildinfo"
 	"github.com/digitaldrywood/detent/internal/codex"
 	workflowconfig "github.com/digitaldrywood/detent/internal/config"
 	globalconfig "github.com/digitaldrywood/detent/internal/config/global"
@@ -830,7 +831,7 @@ type doctorHealthResponse struct {
 	HealthNotificationFailures []healthnotify.Failure       `json:"health_notification_failures"`
 }
 
-func checkDoctorDetentService(ctx context.Context, cfg BootConfig, deps doctorDeps) []doctorCheck {
+func checkDoctorDetentService(ctx context.Context, cfg BootConfig, installedBuild buildinfo.Info, deps doctorDeps) []doctorCheck {
 	probe, err := probeDoctorHealth(ctx, cfg, deps)
 	version := strings.TrimSpace(probe.Health.Version)
 	commit := strings.TrimSpace(probe.Health.Commit)
@@ -845,7 +846,11 @@ func checkDoctorDetentService(ctx context.Context, cfg BootConfig, deps doctorDe
 			check.Detail += "; health check: " + err.Error()
 			check.Hint = "Review the running Detent service health, then rerun detent doctor."
 		}
-		return []doctorCheck{check}
+		checks := []doctorCheck{check}
+		if driftCheck, ok := checkDoctorBuildDrift(buildinfo.Info{Version: version, Commit: commit}, installedBuild); ok {
+			checks = append(checks, driftCheck)
+		}
+		return checks
 	}
 	if err != nil {
 		return nil
@@ -856,6 +861,26 @@ func checkDoctorDetentService(ctx context.Context, cfg BootConfig, deps doctorDe
 		Detail: fmt.Sprintf("remote service at %s did not report its complete build", probe.URL),
 		Hint:   "Upgrade the running Detent service, then rerun detent doctor.",
 	}}
+}
+
+func checkDoctorBuildDrift(runningBuild buildinfo.Info, installedBuild buildinfo.Info) (doctorCheck, bool) {
+	drift := buildinfo.DetectDrift(runningBuild, installedBuild)
+	if !drift.Comparable {
+		return doctorCheck{}, false
+	}
+	running := fmt.Sprintf("%s (%s)", strings.TrimSpace(runningBuild.Version), buildinfo.ShortCommit(runningBuild.Commit))
+	installed := fmt.Sprintf("%s (%s)", strings.TrimSpace(installedBuild.Version), buildinfo.ShortCommit(installedBuild.Commit))
+	check := doctorCheck{
+		Name:   "Detent build drift",
+		Status: doctorOK,
+		Detail: fmt.Sprintf("running service build %s matches installed executable build %s", running, installed),
+	}
+	if drift.Detected {
+		check.Status = doctorWarn
+		check.Detail = fmt.Sprintf("running service build %s differs from installed executable build %s", running, installed)
+		check.Hint = "Run `detent start --restart` to load the installed build, then rerun detent doctor."
+	}
+	return check, true
 }
 
 type doctorHealthEnvironment struct {

--- a/internal/cli/doctor_test.go
+++ b/internal/cli/doctor_test.go
@@ -4390,7 +4390,7 @@ func TestCheckDoctorDetentServiceReportsRemoteBuild(t *testing.T) {
 				t.Fatalf("Marshal() error = %v", err)
 			}
 			port := 4017
-			checks := checkDoctorDetentService(t.Context(), BootConfig{Host: "127.0.0.1", Port: &port}, doctorDeps{
+			checks := checkDoctorDetentService(t.Context(), BootConfig{Host: "127.0.0.1", Port: &port}, buildinfo.Info{}, doctorDeps{
 				httpDo: func(request *http.Request) (*http.Response, error) {
 					if request.URL.String() != "http://127.0.0.1:4017/health" {
 						t.Errorf("URL = %q, want configured health endpoint", request.URL)
@@ -4430,13 +4430,77 @@ func TestCheckDoctorDetentServiceSkipsAbsentService(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			checks := checkDoctorDetentService(t.Context(), BootConfig{}, doctorDeps{
+			checks := checkDoctorDetentService(t.Context(), BootConfig{}, buildinfo.Info{}, doctorDeps{
 				httpDo: func(*http.Request) (*http.Response, error) {
 					return nil, tt.err
 				},
 			})
 			if len(checks) != 0 {
 				t.Fatalf("checks = %#v, want absent service omitted", checks)
+			}
+		})
+	}
+}
+
+func TestCheckDoctorDetentServiceReportsBuildDrift(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		running    buildinfo.Info
+		installed  buildinfo.Info
+		wantStatus doctorStatus
+		wantDetail string
+		wantHint   string
+	}{
+		{
+			name:       "matching build",
+			running:    buildinfo.Info{Version: "v1.2.3", Commit: "abcdef123456"},
+			installed:  buildinfo.Info{Version: "v1.2.3", Commit: "abcdef123456"},
+			wantStatus: doctorOK,
+			wantDetail: "matches installed executable build",
+		},
+		{
+			name:       "stale running build",
+			running:    buildinfo.Info{Version: "v1.2.2", Commit: "123456abcdef"},
+			installed:  buildinfo.Info{Version: "v1.2.3", Commit: "abcdef123456"},
+			wantStatus: doctorWarn,
+			wantDetail: "differs from installed executable build",
+			wantHint:   "detent start --restart",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			payload, err := json.Marshal(map[string]any{
+				"status":  "ok",
+				"version": tt.running.Version,
+				"commit":  tt.running.Commit,
+				"mode":    "running",
+				"checks": map[string]string{
+					"hub": "configured", "store": "configured", "registry": "configured", "connector": "configured",
+				},
+			})
+			if err != nil {
+				t.Fatalf("Marshal() error = %v", err)
+			}
+			port := 4017
+			checks := checkDoctorDetentService(t.Context(), BootConfig{Host: "127.0.0.1", Port: &port}, tt.installed, doctorDeps{
+				httpDo: func(*http.Request) (*http.Response, error) {
+					return &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(bytes.NewReader(payload))}, nil
+				},
+			})
+			if len(checks) != 2 {
+				t.Fatalf("checks = %#v, want remote service and build drift checks", checks)
+			}
+			got := checks[1]
+			if got.Name != "Detent build drift" || got.Status != tt.wantStatus {
+				t.Fatalf("check = %#v, want status %s", got, tt.wantStatus)
+			}
+			if !strings.Contains(got.Detail, tt.wantDetail) || !strings.Contains(got.Hint, tt.wantHint) {
+				t.Fatalf("check = %#v, want detail %q and hint %q", got, tt.wantDetail, tt.wantHint)
 			}
 		})
 	}


### PR DESCRIPTION
## Summary

- compare the running service build with the installed executable in `detent doctor`
- monitor the on-disk executable once per minute and log a restart remediation when it drifts
- tell installers when an active systemd or launchd service was not restarted
- cover commit/version comparison, binary metadata reads, doctor output, runtime logging, and installer guidance

Fixes #1797

## UI Surface Contract

- [x] N/A; this PR changes doctor output, structured logs, and installer text without changing a browser UI.
- [x] This PR does not add persistent top-of-screen messaging.
- [x] No primary operator screen changed, so screenshot/browser verification is not applicable.

## Test Plan

- [x] `sh -n install.sh`
- [x] `go test ./internal/buildinfo ./internal/cli . -count=1`
- [x] `PATH="$TMPDIR/detent-1797-tools:$PATH" make check`
- [x] `tmp/detent --format json version`