### PR TITLE
feat(codex): sanction scoped issue creation

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -386,6 +386,9 @@ codex:
     - server: codex_apps
       tool: github.update_issue
       repository: digitaldrywood/detent
+    - server: codex_apps
+      tool: github.create_issue
+      repository: digitaldrywood/detent
 ```
 
 The allowlist is a narrow exception to `codex.approval_policy`, not a broader
@@ -396,11 +399,18 @@ deliverable mutation; and both its repository argument and the corresponding
 active work-item repository match the configured tuple. Pull-request mutations
 match the linked pull-request repository. Issue and Workpad mutations match the
 tracked issue repository, including when the linked pull request is in another
-repository. Pull-request and issue updates use `repository_full_name`; issue
-comment creation and updates use `repo_full_name`. Missing or ambiguous
-correlation, other mutation tools including `github.delete_issue`, and
-repository mismatches are declined. Command, file-change, permission, and
-user-input requests retain their existing handling.
+repository. Pull-request and issue creation and updates use
+`repository_full_name`; issue comment creation and updates use
+`repo_full_name`. Missing or ambiguous correlation, other mutation tools
+including `github.delete_issue`, and repository mismatches are declined.
+Command, file-change, permission, and user-input requests retain their existing
+handling.
+
+Allowlisting `github.create_issue` authorizes issue creation only on the
+workflow's own tracked repository. This supports workers filing scoped issues
+they discover while delivering the current work item; it does not authorize
+issue deletion, transfer, or creation in any other repository. Those mutations
+remain non-deliverable.
 
 Allowlisting `github.update_issue` permits its full exposed mutation surface:
 title, body, state, assignees, milestone, and labels may all be replaced. The

--- a/internal/codex/appserver.go
+++ b/internal/codex/appserver.go
@@ -1519,7 +1519,7 @@ func deliverableMCPRepository(policy MCPElicitationPolicy, server string, tool s
 	switch tool {
 	case "github.add_comment_to_issue", "github.update_issue_comment":
 		return "repo_full_name", policy.IssueRepository, true
-	case "github.update_issue":
+	case "github.create_issue", "github.update_issue":
 		return "repository_full_name", policy.IssueRepository, true
 	case "github.create_pull_request", "github.update_pull_request":
 		return "repository_full_name", policy.Repository, true

--- a/internal/codex/appserver_test.go
+++ b/internal/codex/appserver_test.go
@@ -1149,14 +1149,14 @@ func TestMCPElicitationResponse(t *testing.T) {
 				"requestedSchema":{"type":"object","properties":{}},
 				"_meta":{"codex_approval_kind":"mcp_tool_call"}
 			}`,
-			policy: MCPElicitationPolicy{DeliverableKind: "pull_request", Repository: "acme/widgets"},
+			policy: MCPElicitationPolicy{DeliverableKind: "pull_request", IssueRepository: "acme/widgets"},
 			pending: []string{`{
 				"threadId":"thread-1","turnId":"turn-1",
-				"item":{"id":"item-1","type":"mcpToolCall","server":"codex_apps","tool":"github.create_pull_request","arguments":{"repository_full_name":"acme/widgets"}}
+				"item":{"id":"item-1","type":"mcpToolCall","server":"codex_apps","tool":"github.create_issue","arguments":{"repository_full_name":"acme/widgets","title":"Follow-up"}}
 			}`},
 			wantAction: "decline",
 			wantReason: "unsupported_server",
-			wantTool:   "github.create_pull_request",
+			wantTool:   "github.create_issue",
 		},
 		{
 			name: "allowlisted deliverable tuple",
@@ -1402,6 +1402,14 @@ func TestMCPElicitationResponseAllowsWorkflowDeliverableMutations(t *testing.T) 
 		wantRepository string
 	}{
 		{
+			name:           "create issue matching repository",
+			tool:           "github.create_issue",
+			arguments:      `{"repository_full_name":"acme/widgets","title":"Follow-up"}`,
+			wantAction:     "accept",
+			wantReason:     "allowlisted_deliverable_tool",
+			wantRepository: "acme/widgets",
+		},
+		{
 			name:           "add issue comment matching repository",
 			tool:           "github.add_comment_to_issue",
 			arguments:      `{"repo_full_name":"acme/widgets","pr_number":18,"comment":"workpad"}`,
@@ -1426,6 +1434,14 @@ func TestMCPElicitationResponseAllowsWorkflowDeliverableMutations(t *testing.T) 
 			wantRepository: "acme/widgets",
 		},
 		{
+			name:           "create issue mismatched repository",
+			tool:           "github.create_issue",
+			arguments:      `{"repository_full_name":"acme/other","title":"Follow-up"}`,
+			wantAction:     "decline",
+			wantReason:     "repository_mismatch",
+			wantRepository: "acme/other",
+		},
+		{
 			name:           "add issue comment mismatched repository",
 			tool:           "github.add_comment_to_issue",
 			arguments:      `{"repo_full_name":"acme/other","pr_number":18,"comment":"workpad"}`,
@@ -1448,6 +1464,13 @@ func TestMCPElicitationResponseAllowsWorkflowDeliverableMutations(t *testing.T) 
 			wantAction:     "decline",
 			wantReason:     "repository_mismatch",
 			wantRepository: "acme/other",
+		},
+		{
+			name:       "create issue wrong repository argument",
+			tool:       "github.create_issue",
+			arguments:  `{"repo_full_name":"acme/widgets","title":"Follow-up"}`,
+			wantAction: "decline",
+			wantReason: "invalid_tool_arguments",
 		},
 		{
 			name:       "add issue comment wrong repository argument",


### PR DESCRIPTION
## Summary

- sanction allowlisted `github.create_issue` calls only when `repository_full_name` matches the active tracked issue repository
- retain non-deliverable classification for delete, transfer, and other mutations
- document the scoped self-filing path and add table-driven regression coverage

Fixes #1800

## UI Surface Contract

- [x] N/A; this PR does not change UI surfaces.
- [x] This PR does not add persistent top-of-screen messaging.
- [x] This PR has no visual changes.

## Test Plan

- [x] Focused `TestMCPElicitationResponse` tests
- [x] `make check`
