### PR TITLE
fix(recovery): report empty deliverables accurately

### DIFF
--- a/internal/orchestrator/deliverable_recovery.go
+++ b/internal/orchestrator/deliverable_recovery.go
@@ -16,18 +16,22 @@ import (
 
 const (
 	deliverableRecoveryNeedsHumanReason = "deliverable_recovery_needs_human_attention"
+	noCommitsToDeliverReason            = "no_commits_to_deliver"
 	deliverableRecoveryLookupAttempts   = 3
 	deliverableRecoveryLookupBackoff    = 250 * time.Millisecond
 )
 
 type deliverableRecoveryLookupResult struct {
-	Branch         string
-	Repository     string
-	HeadSHA        string
-	HydrationState string
-	LookupResult   string
-	Attempts       int
-	PullRequest    *connector.PullRequest
+	Branch               string
+	Repository           string
+	HeadSHA              string
+	HydrationState       string
+	LookupResult         string
+	Attempts             int
+	PullRequest          *connector.PullRequest
+	CommitsAhead         int
+	RemoteBranchExists   bool
+	DeliveryStateChecked bool
 }
 
 func (r deliverableRecoveryLookupResult) reconciles() bool {
@@ -44,10 +48,25 @@ func (o *Orchestrator) lookupDeliverableRecovery(
 	recoveryErr *runpkg.DeliverableRecoveryError,
 ) deliverableRecoveryLookupResult {
 	result := deliverableRecoveryLookupResult{
-		Branch:         deliverableRecoveryBranch(recoveryErr, running),
-		Repository:     pullRequestRepository(running.Issue),
-		HeadSHA:        strings.TrimSpace(running.DiffStats.HeadSHA),
-		HydrationState: deliverableRecoveryHydrationState(running.Issue.PullRequest),
+		Branch:               deliverableRecoveryBranch(recoveryErr, running),
+		Repository:           pullRequestRepository(running.Issue),
+		HeadSHA:              strings.TrimSpace(running.DiffStats.HeadSHA),
+		HydrationState:       deliverableRecoveryHydrationState(running.Issue.PullRequest),
+		CommitsAhead:         running.DiffStats.CommitsAhead,
+		RemoteBranchExists:   running.DiffStats.RemoteBranchExists,
+		DeliveryStateChecked: running.DiffStats.DeliveryStateChecked,
+	}
+	if !result.DeliveryStateChecked {
+		result.LookupResult = "PR lookup skipped: delivery state check unavailable"
+		return result
+	}
+	if result.CommitsAhead == 0 {
+		result.LookupResult = "PR lookup skipped: no local commits ahead"
+		return result
+	}
+	if !result.RemoteBranchExists {
+		result.LookupResult = "PR lookup skipped: remote branch is missing"
+		return result
 	}
 	if result.Repository == "" {
 		result.LookupResult = "PR lookup unavailable: repository is unknown"
@@ -204,8 +223,11 @@ func (o *Orchestrator) blockDeliverableRecoveryFailure(
 	issue.StageUpdatedAt = &blockedAt
 	if o.connector != nil {
 		comment := "Pull request delivery remains unrecoverable and needs human attention.\n\n" +
+			"- reason: `" + reason + "`\n" +
 			"- branch: `" + branch + "`\n" +
 			"- workspace head: `" + lookup.HeadSHA + "`\n" +
+			"- local commits ahead: " + deliverableRecoveryCommitsAheadText(lookup) + "\n" +
+			"- remote branch exists: " + deliverableRecoveryRemoteBranchText(lookup) + "\n" +
 			"- hydration state: " + lookup.HydrationState + "\n" +
 			"- lookup result: " + lookup.LookupResult + "\n" +
 			"- lookup attempts: " + strconv.Itoa(lookup.Attempts) + "\n" +
@@ -234,13 +256,17 @@ func (o *Orchestrator) blockDeliverableRecoveryFailure(
 		Source:         BlockedSourceProjectStatus,
 		Recovery:       metadata.BlockedRecovery,
 	}
+	reasonCode := deliverableRecoveryReasonCode(lookup)
 	recordStateEvent(state, telemetry.ActivityEvent{
 		At:      event.CompletedAt,
-		Event:   deliverableRecoveryNeedsHumanReason,
-		Message: "parked " + issueLabel(issue) + " with recoverable pushed branch " + branch,
+		Event:   reasonCode,
+		Message: "parked " + issueLabel(issue) + ": " + reason,
 	})
-	telemetry.LogLifecycle(o.logger, slog.LevelError, telemetry.LifecycleSafetyControl, deliverableRecoveryNeedsHumanReason, o.runningLifecycleCorrelation(issue, running),
+	telemetry.LogLifecycle(o.logger, slog.LevelError, telemetry.LifecycleSafetyControl, reasonCode, o.runningLifecycleCorrelation(issue, running),
 		"workspace_branch", branch,
+		"local_commits_ahead", lookup.CommitsAhead,
+		"remote_branch_exists", lookup.RemoteBranchExists,
+		"delivery_state_checked", lookup.DeliveryStateChecked,
 		"deliverable_command", deliverableRecoveryCommand(recoveryErr),
 		"error", recoveryErr,
 	)
@@ -252,7 +278,16 @@ func deliverableRecoveryParkReason(lookup deliverableRecoveryLookupResult) (stri
 	lookupResult := strings.TrimSpace(lookup.LookupResult)
 	base := deliverableRecoveryNeedsHumanReason + ": pushed branch " + branch + " has no recoverable pull request"
 	humanAction := "open or adopt a pull request manually for pushed branch " + branch + ", then move the issue to Rework"
-	if strings.HasPrefix(lookupResult, "PR lookup unavailable") {
+	if lookup.DeliveryStateChecked && lookup.CommitsAhead == 0 {
+		base = noCommitsToDeliverReason + ": branch " + branch + " has no local commits ahead"
+		humanAction = "return the issue to Todo when implementation work is ready to resume"
+	} else if lookup.DeliveryStateChecked && !lookup.RemoteBranchExists {
+		base = deliverableRecoveryNeedsHumanReason + ": remote branch is missing for branch " + branch
+		humanAction = "push the local branch, then move the issue to Rework"
+	} else if !lookup.DeliveryStateChecked {
+		base = deliverableRecoveryNeedsHumanReason + ": delivery state check unavailable for branch " + branch
+		humanAction = "restore workspace delivery inspection, then move the issue to Rework"
+	} else if strings.HasPrefix(lookupResult, "PR lookup unavailable") {
 		base = deliverableRecoveryNeedsHumanReason + ": PR lookup unavailable for pushed branch " + branch
 		humanAction = "restore pull request lookup availability, then move the issue to Rework"
 	} else if lookup.PullRequest != nil && normalizePullRequestState(lookup.PullRequest.State) == "closed" {
@@ -260,6 +295,27 @@ func deliverableRecoveryParkReason(lookup deliverableRecoveryLookupResult) (stri
 		humanAction = "reopen the exact-head pull request or open a replacement, then move the issue to Rework"
 	}
 	return base + " (hydration state: " + lookup.HydrationState + "; lookup result: " + lookupResult + ")", humanAction
+}
+
+func deliverableRecoveryReasonCode(lookup deliverableRecoveryLookupResult) string {
+	if lookup.DeliveryStateChecked && lookup.CommitsAhead == 0 {
+		return noCommitsToDeliverReason
+	}
+	return deliverableRecoveryNeedsHumanReason
+}
+
+func deliverableRecoveryCommitsAheadText(lookup deliverableRecoveryLookupResult) string {
+	if !lookup.DeliveryStateChecked {
+		return "unavailable"
+	}
+	return strconv.Itoa(lookup.CommitsAhead)
+}
+
+func deliverableRecoveryRemoteBranchText(lookup deliverableRecoveryLookupResult) string {
+	if !lookup.DeliveryStateChecked {
+		return "unavailable"
+	}
+	return strconv.FormatBool(lookup.RemoteBranchExists)
 }
 
 func deliverableRecoveryBranch(recoveryErr *runpkg.DeliverableRecoveryError, running Running) string {

--- a/internal/orchestrator/run_completion.go
+++ b/internal/orchestrator/run_completion.go
@@ -275,9 +275,9 @@ func (o *Orchestrator) handleRunResult(ctx context.Context, state *State, event 
 		statusMessage := "worker failed"
 		deliverableRecoveryErr = nil
 		if errors.As(event.Err, &deliverableRecoveryErr) && deliverableRecoveryErr != nil {
-			errorClass = deliverableRecoveryNeedsHumanReason
+			errorClass = deliverableRecoveryReasonCode(deliverableLookup)
 			phase = "blocked"
-			statusMessage = "pushed branch " + deliverableRecoveryBranch(deliverableRecoveryErr, running) + " needs human attention"
+			statusMessage = "branch " + deliverableRecoveryBranch(deliverableRecoveryErr, running) + " needs delivery recovery"
 		}
 		if spendProgress.Block && deliverableRecoveryErr == nil && !errors.Is(event.Err, runpkg.ErrSessionTokenCeilingExceeded) {
 			terminalState = store.WorkAttemptTerminalNoProgress

--- a/internal/orchestrator/state.go
+++ b/internal/orchestrator/state.go
@@ -920,6 +920,9 @@ func diffStatsPresent(diffStats DiffStats) bool {
 		diffStats.AddedLines != 0 ||
 		diffStats.RemovedLines != 0 ||
 		diffStats.UnpushedCommits != 0 ||
+		diffStats.CommitsAhead != 0 ||
+		diffStats.RemoteBranchExists ||
+		diffStats.DeliveryStateChecked ||
 		diffStats.HeadSHA != "" ||
 		diffStats.Fingerprint != "" ||
 		diffStats.Status != ""

--- a/internal/orchestrator/terminal_attempt_retry_test.go
+++ b/internal/orchestrator/terminal_attempt_retry_test.go
@@ -144,6 +144,9 @@ func TestHandleRunResultReconcilesDeliverableRecoveryExactHead(t *testing.T) {
 		wantReason       string
 		wantLookupCalls  int
 		wantMergedReason bool
+		wantReasonCode   string
+		commitsAhead     int
+		remoteBranch     bool
 	}{
 		{
 			name: "open pull request on exact current head reconciles",
@@ -151,12 +154,30 @@ func TestHandleRunResultReconcilesDeliverableRecoveryExactHead(t *testing.T) {
 				Number: 18, BranchName: branch, State: "OPEN", HeadSHA: headSHA,
 			},
 			wantLookupCalls: 1,
+			commitsAhead:    1,
+			remoteBranch:    true,
 		},
 		{
 			name:            "no pull request parks",
 			wantBlocked:     true,
 			wantReason:      "no exact-head pull request",
 			wantLookupCalls: 3,
+			commitsAhead:    1,
+			remoteBranch:    true,
+		},
+		{
+			name:            "zero commits ahead parks without pull request lookup",
+			wantBlocked:     true,
+			wantReason:      "no_commits_to_deliver",
+			wantReasonCode:  noCommitsToDeliverReason,
+			wantLookupCalls: 0,
+		},
+		{
+			name:            "deleted remote branch parks accurately",
+			wantBlocked:     true,
+			wantReason:      "remote branch is missing",
+			wantLookupCalls: 0,
+			commitsAhead:    1,
 		},
 		{
 			name: "transient not found retries then reconciles",
@@ -165,6 +186,8 @@ func TestHandleRunResultReconcilesDeliverableRecoveryExactHead(t *testing.T) {
 			},
 			lookupFoundAfter: 3,
 			wantLookupCalls:  3,
+			commitsAhead:     1,
+			remoteBranch:     true,
 		},
 		{
 			name: "merged pull request routes to merged deliverable reconciliation",
@@ -174,6 +197,8 @@ func TestHandleRunResultReconcilesDeliverableRecoveryExactHead(t *testing.T) {
 			},
 			wantLookupCalls:  1,
 			wantMergedReason: true,
+			commitsAhead:     1,
+			remoteBranch:     true,
 		},
 		{
 			name: "closed unmerged pull request parks accurately",
@@ -183,6 +208,8 @@ func TestHandleRunResultReconcilesDeliverableRecoveryExactHead(t *testing.T) {
 			wantBlocked:     true,
 			wantReason:      "closed without merge",
 			wantLookupCalls: 1,
+			commitsAhead:    1,
+			remoteBranch:    true,
 		},
 		{
 			name: "lookup unavailable retries then parks",
@@ -194,6 +221,8 @@ func TestHandleRunResultReconcilesDeliverableRecoveryExactHead(t *testing.T) {
 			wantBlocked:     true,
 			wantReason:      "PR lookup unavailable",
 			wantLookupCalls: 3,
+			commitsAhead:    1,
+			remoteBranch:    true,
 		},
 		{
 			name: "stale cached hydration is not trusted",
@@ -203,6 +232,8 @@ func TestHandleRunResultReconcilesDeliverableRecoveryExactHead(t *testing.T) {
 			wantBlocked:     true,
 			wantReason:      "lookup result: no exact-head pull request",
 			wantLookupCalls: 3,
+			commitsAhead:    1,
+			remoteBranch:    true,
 		},
 	}
 	for _, tt := range tests {
@@ -233,7 +264,10 @@ func TestHandleRunResultReconcilesDeliverableRecoveryExactHead(t *testing.T) {
 			state.Running[issue.ID] = Running{
 				Issue: issue, Attempt: 1, WorkAttemptID: 42, Mode: runpkg.RunModeImplement,
 				StartedAt: now.Add(-time.Minute), WorkProductPushed: true, WorkspacePath: "/work/" + branch,
-				DiffStats: DiffStats{Status: "clean", HeadSHA: headSHA},
+				DiffStats: DiffStats{
+					Status: "clean", HeadSHA: headSHA,
+					DeliveryStateChecked: true, CommitsAhead: tt.commitsAhead, RemoteBranchExists: tt.remoteBranch,
+				},
 			}
 			state.Claimed[issue.ID] = Claimed{Issue: issue, ClaimedAt: now.Add(-time.Minute)}
 			commandErr := &runpkg.DeliverableCommandError{
@@ -245,7 +279,10 @@ func TestHandleRunResultReconcilesDeliverableRecoveryExactHead(t *testing.T) {
 				IssueID: issue.ID,
 				Result: runpkg.RunResult{
 					FinalState: runpkg.FinalStateNeedsHumanAttention, PullRequestHeadPushed: true,
-					DiffStats: runpkg.DiffStats{Status: "clean", HeadSHA: headSHA},
+					DiffStats: runpkg.DiffStats{
+						Status: "clean", HeadSHA: headSHA,
+						DeliveryStateChecked: true, CommitsAhead: tt.commitsAhead, RemoteBranchExists: tt.remoteBranch,
+					},
 				},
 				Err:         &runpkg.DeliverableRecoveryError{Branch: branch, Err: commandErr},
 				CompletedAt: now,
@@ -254,7 +291,7 @@ func TestHandleRunResultReconcilesDeliverableRecoveryExactHead(t *testing.T) {
 			if tracker.lookupCalls != tt.wantLookupCalls {
 				t.Fatalf("lookup calls = %d, want %d", tracker.lookupCalls, tt.wantLookupCalls)
 			}
-			if tracker.lookupRepository != "acme/widgets" || tracker.lookupBranch != branch || tracker.lookupHeadSHA != headSHA {
+			if tt.wantLookupCalls > 0 && (tracker.lookupRepository != "acme/widgets" || tracker.lookupBranch != branch || tracker.lookupHeadSHA != headSHA) {
 				t.Fatalf(
 					"lookup target = %q/%q@%q, want acme/widgets/%s@%s",
 					tracker.lookupRepository,
@@ -269,12 +306,19 @@ func TestHandleRunResultReconcilesDeliverableRecoveryExactHead(t *testing.T) {
 				t.Fatalf("Blocked[%q] present = %v, want %v: %#v", issue.ID, ok, tt.wantBlocked, blocked)
 			}
 			if tt.wantBlocked {
+				wantReasonCode := tt.wantReasonCode
+				if wantReasonCode == "" {
+					wantReasonCode = deliverableRecoveryNeedsHumanReason
+				}
+				if len(attempts.completions) != 1 || attempts.completions[0].ErrorClass != wantReasonCode {
+					t.Fatalf("work attempt error class = %#v, want %q", attempts.completions, wantReasonCode)
+				}
 				if !strings.Contains(blocked.Reason, branch) || !strings.Contains(blocked.Reason, tt.wantReason) {
 					t.Fatalf("Blocked[%q].Reason = %q, want branch and %q", issue.ID, blocked.Reason, tt.wantReason)
 				}
-				if len(tracker.comments) != 1 || !strings.Contains(tracker.comments[0], "hydration state:") ||
-					!strings.Contains(tracker.comments[0], "lookup result:") || !strings.Contains(tracker.comments[0], tt.wantReason) {
-					t.Fatalf("comments = %#v, want hydration and lookup diagnostics containing %q", tracker.comments, tt.wantReason)
+				if len(tracker.comments) != 1 || !strings.Contains(tracker.comments[0], "local commits ahead: ") ||
+					!strings.Contains(tracker.comments[0], "remote branch exists: ") || !strings.Contains(tracker.comments[0], tt.wantReason) {
+					t.Fatalf("comments = %#v, want delivery diagnostics containing %q", tracker.comments, tt.wantReason)
 				}
 				if got := tracker.transitionStates(); !slices.Equal(got, []string{blockedStatusState}) {
 					t.Fatalf("state transitions = %v, want [%s]", got, blockedStatusState)

--- a/internal/runner/agent.go
+++ b/internal/runner/agent.go
@@ -1433,6 +1433,7 @@ func (r *Runner) Run(ctx context.Context, req RunRequest) (RunResult, error) {
 	if brakeDiff := sessionBrake.resultDiffStats(); brakeDiff != (DiffStats{}) {
 		result.DiffStats = brakeDiff
 	}
+	var deliverableState *workspace.DeliverableState
 	var exhaustedDeliverable *DeliverableRecoveryError
 	if mode == RunModeImplement && result.PullRequestHeadPushed && errors.As(turnErr, &exhaustedDeliverable) {
 		if recoveryState := r.workspaceRecoveryState(runWorkspace, ctx, info, workspaceIssue, "deliverable_recovery"); recoveryState != nil {
@@ -1440,6 +1441,8 @@ func (r *Runner) Run(ctx context.Context, req RunRequest) (RunResult, error) {
 			result.DiffStats.UnpushedCommits = recoveryState.UnpushedCommits
 			result.DiffStats.HeadSHA = strings.TrimSpace(recoveryState.HeadSHA)
 		}
+		deliverableState = r.workspaceDeliverableState(runWorkspace, ctx, info, workspaceIssue)
+		applyDeliverableState(&result.DiffStats, deliverableState)
 	}
 	commandFinishedAttrs := []any{
 		"workspace_path", info.Path,
@@ -1527,6 +1530,7 @@ func (r *Runner) Run(ctx context.Context, req RunRequest) (RunResult, error) {
 			result.DiffStats.HeadSHA = strings.TrimSpace(recoveryState.HeadSHA)
 		}
 	}
+	applyDeliverableState(&result.DiffStats, deliverableState)
 	finishedAt := r.now().UTC()
 	result.Tokens.RuntimeSeconds = runtimeSeconds(runStartedAt, finishedAt)
 	if err := r.finishSession(ctx, sessionID, sessionStarted, req.WorkAttemptID, req.Issue, startedAt, finishedAt, result, sessionModel, backendConfig.Kind, turns, turnResult, resumeState.DetentSessionID); err != nil {
@@ -1697,6 +1701,39 @@ func (r *Runner) workspaceRecoveryState(
 		slog.String("error", err.Error()),
 	)
 	return nil
+}
+
+func (r *Runner) workspaceDeliverableState(
+	backend workspace.Backend,
+	ctx context.Context,
+	info workspace.Info,
+	issue workspace.Issue,
+) *workspace.DeliverableState {
+	provider, ok := backend.(workspace.DeliverableStateProvider)
+	if !ok {
+		return nil
+	}
+	state, err := provider.DeliverableState(ctx, info, issue)
+	if err == nil {
+		return &state
+	}
+	r.logger.Warn(
+		"workspace deliverable state failed",
+		slog.String("issue_id", issue.ID),
+		slog.String("issue_identifier", issue.Identifier),
+		slog.String("workspace_path", info.Path),
+		slog.String("error", err.Error()),
+	)
+	return nil
+}
+
+func applyDeliverableState(diffStats *DiffStats, state *workspace.DeliverableState) {
+	if diffStats == nil || state == nil {
+		return
+	}
+	diffStats.CommitsAhead = state.CommitsAhead
+	diffStats.RemoteBranchExists = state.RemoteBranchExists
+	diffStats.DeliveryStateChecked = true
 }
 
 func (r *Runner) checkDispatchBudget(ctx context.Context, checker BudgetChecker, estimator DispatchEstimator, issue connector.Issue, model string, now time.Time) (RunResult, bool, error) {

--- a/internal/runner/runner_test.go
+++ b/internal/runner/runner_test.go
@@ -717,12 +717,15 @@ func TestRunnerRunRecoversPushedPullRequestDeliverable(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			workspaceBackend := &fakeWorkspaceBackend{
-				info: workspace.Info{Path: t.TempDir(), Branch: branch},
-				recoveryStates: []workspace.RecoveryState{
-					{HeadSHA: "dispatch-head"},
-					{HeadSHA: "current-head"},
+			workspaceBackend := &fakeDeliverableWorkspaceBackend{
+				fakeWorkspaceBackend: &fakeWorkspaceBackend{
+					info: workspace.Info{Path: t.TempDir(), Branch: branch},
+					recoveryStates: []workspace.RecoveryState{
+						{HeadSHA: "dispatch-head"},
+						{HeadSHA: "current-head"},
+					},
 				},
+				deliverableState: workspace.DeliverableState{CommitsAhead: 1, RemoteBranchExists: true},
 			}
 			backend := &deliverableRecoveryAgentBackend{turns: [][]AgentUpdate{
 				{
@@ -762,6 +765,9 @@ func TestRunnerRunRecoversPushedPullRequestDeliverable(t *testing.T) {
 				}
 				if result.DiffStats.HeadSHA != "current-head" {
 					t.Fatalf("DiffStats.HeadSHA = %q, want fresh current head", result.DiffStats.HeadSHA)
+				}
+				if !result.DiffStats.DeliveryStateChecked || result.DiffStats.CommitsAhead != 1 || !result.DiffStats.RemoteBranchExists {
+					t.Fatalf("DiffStats delivery state = %#v, want checked pushed commit", result.DiffStats)
 				}
 				for _, want := range []string{"codex_apps/github.create_pull_request", "status=failed", arguments, "HTTP 503: unavailable", `{"status":503,"message":"unavailable"}`} {
 					if !strings.Contains(runErr.Error(), want) {
@@ -4999,6 +5005,15 @@ type fakeWorkspaceBackend struct {
 	recoveryStates []workspace.RecoveryState
 	recoveryErr    error
 	recoveryCalls  int
+}
+
+type fakeDeliverableWorkspaceBackend struct {
+	*fakeWorkspaceBackend
+	deliverableState workspace.DeliverableState
+}
+
+func (b *fakeDeliverableWorkspaceBackend) DeliverableState(context.Context, workspace.Info, workspace.Issue) (workspace.DeliverableState, error) {
+	return b.deliverableState, nil
 }
 
 func (b *fakeWorkspaceBackend) RecoveryState(context.Context, workspace.Info, workspace.Issue) (workspace.RecoveryState, error) {

--- a/internal/runner/types.go
+++ b/internal/runner/types.go
@@ -567,13 +567,16 @@ type BudgetRefusal struct {
 }
 
 type DiffStats struct {
-	FilesChanged    int
-	AddedLines      int
-	RemovedLines    int
-	UnpushedCommits int
-	HeadSHA         string
-	Fingerprint     string
-	Status          string
+	FilesChanged         int
+	AddedLines           int
+	RemovedLines         int
+	UnpushedCommits      int
+	CommitsAhead         int
+	RemoteBranchExists   bool
+	DeliveryStateChecked bool
+	HeadSHA              string
+	Fingerprint          string
+	Status               string
 }
 
 type TokenTotals struct {

--- a/internal/workspace/diffstat.go
+++ b/internal/workspace/diffstat.go
@@ -79,6 +79,18 @@ func (l *LocalGit) RecoveryState(ctx context.Context, info Info, issue Issue) (R
 	}, nil
 }
 
+func (l *LocalGit) DeliverableState(ctx context.Context, info Info, issue Issue) (DeliverableState, error) {
+	normalized, err := l.normalizeInfo(info, issue)
+	if err != nil {
+		return DeliverableState{}, err
+	}
+	commitsAhead, remoteBranchExists, err := gitDeliveryState(ctx, normalized.Path, normalized.Branch, issue.BaseRef)
+	if err != nil {
+		return DeliverableState{}, err
+	}
+	return DeliverableState{CommitsAhead: commitsAhead, RemoteBranchExists: remoteBranchExists}, nil
+}
+
 func (l *LocalGit) Diff(ctx context.Context, info Info, issue Issue, maxBytes int) (Diff, error) {
 	normalized, err := l.normalizeInfo(info, issue)
 	if err != nil {
@@ -201,6 +213,37 @@ func gitUnpushedCommitCount(ctx context.Context, workspacePath string) (int, err
 		return 0, fmt.Errorf("parse unpushed commit count: %w", err)
 	}
 	return count, nil
+}
+
+func gitDeliveryState(ctx context.Context, workspacePath string, branch string, baseRef string) (int, bool, error) {
+	branch = strings.TrimSpace(branch)
+	if branch == "" {
+		return 0, false, errors.New("inspect delivery state: workspace branch is required")
+	}
+	base := strings.TrimSpace(baseRef)
+	if base == "" {
+		branch, head, err := remoteDefaultBranchHead(ctx, workspacePath, defaultGitRemote)
+		if err != nil {
+			return 0, false, fmt.Errorf("inspect delivery base: %w", err)
+		}
+		if _, err := runGitAt(ctx, workspacePath, "fetch", "--no-tags", defaultGitRemote, "refs/heads/"+branch); err != nil {
+			return 0, false, fmt.Errorf("fetch delivery base %s/%s: %w", defaultGitRemote, branch, err)
+		}
+		base = head
+	}
+	output, err := runGitAt(ctx, workspacePath, "rev-list", "--count", base+"..HEAD")
+	if err != nil {
+		return 0, false, fmt.Errorf("count local commits ahead: %w", err)
+	}
+	commitsAhead, err := strconv.Atoi(strings.TrimSpace(output))
+	if err != nil {
+		return 0, false, fmt.Errorf("parse local commits ahead: %w", err)
+	}
+	_, remoteBranchExists, err := remoteBranchHead(ctx, workspacePath, defaultGitRemote, branch)
+	if err != nil {
+		return 0, false, fmt.Errorf("inspect remote branch %s/%s: %w", defaultGitRemote, branch, err)
+	}
+	return commitsAhead, remoteBranchExists, nil
 }
 
 func gitRecoveryBaseFingerprint(ctx context.Context, workspacePath string, baseRef string) string {

--- a/internal/workspace/diffstat_test.go
+++ b/internal/workspace/diffstat_test.go
@@ -227,6 +227,75 @@ func TestLocalGitRecoveryStateDetectsStrandedWork(t *testing.T) {
 	}
 }
 
+func TestLocalGitDeliverableState(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name               string
+		push               bool
+		advanceRemoteBase  bool
+		deleteRemoteBranch bool
+		wantCommitsAhead   int
+		wantRemoteBranch   bool
+	}{
+		{name: "zero ahead without remote branch"},
+		{name: "pushed commit", push: true, wantCommitsAhead: 1, wantRemoteBranch: true},
+		{name: "pushed commit after remote base advances", push: true, advanceRemoteBase: true, wantCommitsAhead: 1, wantRemoteBranch: true},
+		{name: "pushed then deleted remote branch", push: true, deleteRemoteBranch: true, wantCommitsAhead: 1},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			source := initSourceRepo(t)
+			remote := initBareRemote(t)
+			runGit(t, source, "remote", "add", "origin", remote)
+			runGit(t, source, "push", "-u", "origin", "main")
+			backend, err := NewBackend(KindLocalGit, LocalGitOptions{
+				Root: filepath.Join(t.TempDir(), "workspaces"), SourceRoot: source, AutoBranch: true,
+			})
+			if err != nil {
+				t.Fatalf("NewBackend() error = %v", err)
+			}
+			provider := backend.(DeliverableStateProvider)
+			issue := Issue{Identifier: "DD-DELIVERABLE-" + tt.name}
+			info, err := backend.Create(t.Context(), issue)
+			if err != nil {
+				t.Fatalf("Create() error = %v", err)
+			}
+			if tt.push {
+				path := filepath.Join(info.Path, "delivered.txt")
+				if err := os.WriteFile(path, []byte("delivered\n"), 0o600); err != nil {
+					t.Fatalf("write delivered file: %v", err)
+				}
+				runGit(t, info.Path, "add", "delivered.txt")
+				runGit(t, info.Path, "commit", "-m", "test: add delivered work")
+				runGit(t, info.Path, "push", "-u", "origin", "HEAD:"+info.Branch)
+			}
+			if tt.advanceRemoteBase {
+				path := filepath.Join(source, "remote-base.txt")
+				if err := os.WriteFile(path, []byte("remote base\n"), 0o600); err != nil {
+					t.Fatalf("write remote base file: %v", err)
+				}
+				runGit(t, source, "add", "remote-base.txt")
+				runGit(t, source, "commit", "-m", "test: advance remote base")
+				runGit(t, source, "push", "origin", "main")
+			}
+			if tt.deleteRemoteBranch {
+				runGit(t, info.Path, "push", "origin", "--delete", info.Branch)
+			}
+
+			got, err := provider.DeliverableState(t.Context(), info, issue)
+			if err != nil {
+				t.Fatalf("DeliverableState() error = %v", err)
+			}
+			if got.CommitsAhead != tt.wantCommitsAhead || got.RemoteBranchExists != tt.wantRemoteBranch {
+				t.Fatalf("DeliverableState() = %+v, want commits ahead=%d remote branch=%t", got, tt.wantCommitsAhead, tt.wantRemoteBranch)
+			}
+		})
+	}
+}
+
 func TestLocalGitRecoveryStateDetectsAmendedCommit(t *testing.T) {
 	t.Parallel()
 

--- a/internal/workspace/merge.go
+++ b/internal/workspace/merge.go
@@ -122,6 +122,21 @@ func remoteDefaultBranch(ctx context.Context, workspacePath string, remote strin
 	return "", fmt.Errorf("remote %s HEAD is not a branch", remote)
 }
 
+func remoteDefaultBranchHead(ctx context.Context, workspacePath string, remote string) (string, string, error) {
+	branch, err := remoteDefaultBranch(ctx, workspacePath, remote)
+	if err != nil {
+		return "", "", err
+	}
+	head, exists, err := remoteBranchHead(ctx, workspacePath, remote, branch)
+	if err != nil {
+		return "", "", err
+	}
+	if !exists {
+		return "", "", fmt.Errorf("remote %s default branch %s is missing", remote, branch)
+	}
+	return branch, head, nil
+}
+
 func remoteBranchHead(ctx context.Context, workspacePath string, remote string, branch string) (string, bool, error) {
 	ref := "refs/heads/" + branch
 	output, err := runGitAt(ctx, workspacePath, "ls-remote", remote, ref)

--- a/internal/workspace/workspace.go
+++ b/internal/workspace/workspace.go
@@ -63,6 +63,10 @@ type RecoveryStateProvider interface {
 	RecoveryState(context.Context, Info, Issue) (RecoveryState, error)
 }
 
+type DeliverableStateProvider interface {
+	DeliverableState(context.Context, Info, Issue) (DeliverableState, error)
+}
+
 type IssueRecoveryStateProvider interface {
 	IssueRecoveryState(context.Context, Issue) (RecoveryState, error)
 }
@@ -73,6 +77,11 @@ type RecoveryState struct {
 	HeadSHA              string
 	WorkspaceFingerprint string
 	UnpushedCommits      int
+}
+
+type DeliverableState struct {
+	CommitsAhead       int
+	RemoteBranchExists bool
 }
 
 type MergePreparer interface {


### PR DESCRIPTION
## Summary

- inspect commits ahead and exact remote branch existence after exhausted pull request delivery
- park zero-ahead workspaces with `no_commits_to_deliver` before pull request lookup
- report missing remote branches accurately while preserving pushed-with-commits recovery

Fixes #1801

## UI Surface Contract

- [x] N/A, or the linked issue explicitly authorizes any high-impact UI surface, layout, density, first-viewport, or responsive visibility tradeoff.
- [x] Persistent top-of-screen messaging is explicitly authorized by the issue, or this PR does not add it.
- [x] Visual changes to primary operator screens include screenshot or browser verification below.

## Test Plan

- [x] `make check`
- [x] `go test ./internal/workspace ./internal/runner ./internal/orchestrator -count=1`
