### PR TITLE
feat(ops): add live tmux window status

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -41,6 +41,7 @@ Runtime settings resolve in this order: explicit flag, environment variable,
 | API token | | `DETENT_API_TOKEN` | `api_token` | open on loopback, fail closed on non-loopback |
 | Loopback peer read trust | | | `trust_loopback_peer_read` | `false` |
 | Private dashboard URL | | | `dashboard_access` | disabled |
+| tmux window status | | `$TMUX` detection | `ops.tmux_window_status` | enabled inside tmux |
 | Web port | `--port` | `PORT` | `port` | `4000` |
 | Instance name | | | `instance_name` | short hostname |
 | Health webhook | | | `notifications.health.webhook.url` | disabled |
@@ -53,6 +54,11 @@ Runtime settings resolve in this order: explicit flag, environment variable,
 The web host resolves from `--host`, then the first registered workflow's
 `server.host`, then the built-in `127.0.0.1` default. It is not a top-level
 `global.yaml` key.
+
+When Detent starts inside tmux, it renames the current window to a compact
+running, queued, and blocked count summary. It restores the original name on
+clean shutdown. Set `ops.tmux_window_status: false` to disable this behavior;
+Detent never invokes tmux when `$TMUX` is absent.
 
 Use `github_token: gh` in `global.yaml` to resolve the token from
 `gh auth token` at startup. Literal token values also work but should not be

--- a/docs/multi-project.md
+++ b/docs/multi-project.md
@@ -245,6 +245,7 @@ can include `--workflow-ref origin/main` during registration or add
 | `auth` | Restart required; persisted sessions remain valid until their configured expiry |
 | `global.startup` | Live reload |
 | `instance_name` | Live reload |
+| `ops.tmux_window_status` | Restart required |
 | `global.identity` | Live reload; project runtimes restart in-process and `/api/v1/state.instance.name` updates after the next telemetry snapshot |
 | `global.active_hours` | Live reload at the next dispatch decision; running agents drain when a window closes |
 | `global.max_concurrent_agents`, `global.scheduling`, `global.agent_pools`, `global.fair_share`, and project pool assignments | Live reload at the next dispatch decision; adding, removing, or lowering `burst_to` preserves active workers and drains to the new ceiling, and removed pools drain their active workers before retirement |

--- a/internal/cli/boot.go
+++ b/internal/cli/boot.go
@@ -39,6 +39,7 @@ import (
 	"github.com/digitaldrywood/detent/internal/scheduler"
 	"github.com/digitaldrywood/detent/internal/store"
 	"github.com/digitaldrywood/detent/internal/telemetry"
+	"github.com/digitaldrywood/detent/internal/tmuxstatus"
 	"github.com/digitaldrywood/detent/internal/tui"
 	"github.com/digitaldrywood/detent/internal/web"
 	"github.com/digitaldrywood/detent/internal/web/demofixtures"
@@ -327,6 +328,16 @@ func startRunningWithDependencies(ctx context.Context, cfg BootConfig, deps star
 
 	snapshotHub := hub.New[telemetry.Snapshot]()
 	snapshotSeq := &atomic.Uint64{}
+	var windowStatus *tmuxstatus.Status
+	if tmuxstatus.Enabled(os.Getenv("TMUX"), cfg.Global.Ops.TmuxWindowStatus) {
+		windowStatus, err = tmuxstatus.New(runCtx)
+		if err != nil {
+			logger.Warn("initialize tmux window status failed", "error", err)
+		}
+	}
+	if windowStatus != nil {
+		defer closeTmuxWindowStatus(windowStatus, logger)
+	}
 	healthNotifications, err := newHealthNotificationManager(cfg.Global, runtimeStore, logger)
 	if err != nil {
 		return err
@@ -378,6 +389,11 @@ func startRunningWithDependencies(ctx context.Context, cfg BootConfig, deps star
 	resourceWorkers.Go(func() {
 		runRuntimeBuildDriftMonitor(runCtx, cfg.Build, deps.buildDriftInterval, readInstalledBuild, logger)
 	})
+	if windowStatus != nil {
+		resourceWorkers.Go(func() {
+			runTmuxWindowStatus(runCtx, snapshotHub, windowStatus, defaultSnapshotInterval, logger)
+		})
+	}
 	resourceWorkers.Go(func() {
 		publishSnapshots(runCtx, manager.Registry(), globalDispatchGate, snapshotHub, snapshotSeq, cfg.Shutdown, runtimeStore, displayURL, defaultSnapshotInterval, time.Now, updateScheduler)
 	})

--- a/internal/cli/global_reload.go
+++ b/internal/cli/global_reload.go
@@ -284,6 +284,9 @@ func changedGlobalConfigFields(previous globalconfig.Config, next globalconfig.C
 	if !reflect.DeepEqual(previous.Auth, next.Auth) {
 		fields = append(fields, globalConfigChange{Field: "auth", RequiresRestart: true})
 	}
+	if !reflect.DeepEqual(previous.Ops, next.Ops) {
+		fields = append(fields, globalConfigChange{Field: "ops.tmux_window_status", RequiresRestart: true})
+	}
 	if !reflect.DeepEqual(previous.Projects, next.Projects) {
 		fields = append(fields, globalConfigChange{Field: "projects", Old: globalProjectIDs(previous.Projects), New: globalProjectIDs(next.Projects)})
 	}

--- a/internal/cli/global_reload_test.go
+++ b/internal/cli/global_reload_test.go
@@ -245,6 +245,10 @@ func TestChangedGlobalConfigFieldsReloadClassification(t *testing.T) {
 		{name: "notifications", field: "notifications", requiresRestart: true, mutate: func(cfg *globalconfig.Config) {
 			cfg.Notifications.Health.Webhook.URL = "https://alerts.example.test/detent"
 		}},
+		{name: "tmux window status", field: "ops.tmux_window_status", requiresRestart: true, mutate: func(cfg *globalconfig.Config) {
+			enabled := false
+			cfg.Ops.TmuxWindowStatus = &enabled
+		}},
 		{name: "projects", field: "projects", mutate: func(cfg *globalconfig.Config) { cfg.Projects = []globalconfig.Project{{ID: "bravo", Weight: 2}} }},
 		{name: "project pool", field: "projects", mutate: func(cfg *globalconfig.Config) { cfg.Projects[0].Pool = "video" }},
 		{name: "maximum concurrent agents", field: "global.max_concurrent_agents", mutate: func(cfg *globalconfig.Config) { cfg.Global.MaxConcurrentAgents = 4 }},

--- a/internal/cli/tmux_status.go
+++ b/internal/cli/tmux_status.go
@@ -1,0 +1,96 @@
+package cli
+
+import (
+	"context"
+	"log/slog"
+	"time"
+
+	"github.com/digitaldrywood/detent/internal/hub"
+	"github.com/digitaldrywood/detent/internal/telemetry"
+)
+
+const tmuxRestoreTimeout = 2 * time.Second
+
+type tmuxWindowStatus interface {
+	Update(context.Context, telemetry.Snapshot) error
+	Close(context.Context) error
+}
+
+func runTmuxWindowStatus(
+	ctx context.Context,
+	snapshots *hub.Hub[telemetry.Snapshot],
+	status tmuxWindowStatus,
+	interval time.Duration,
+	logger *slog.Logger,
+) {
+	if snapshots == nil || status == nil {
+		return
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if interval <= 0 {
+		interval = defaultSnapshotInterval
+	}
+	if logger == nil {
+		logger = slog.Default()
+	}
+
+	subscription, err := snapshots.Subscribe(ctx)
+	if err != nil {
+		if ctx.Err() == nil {
+			logger.Warn("subscribe tmux window status failed", "error", err)
+		}
+		return
+	}
+	defer subscription.Close()
+
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+	runTmuxWindowStatusUpdates(ctx, subscription.C(), ticker.C, status, logger)
+}
+
+func runTmuxWindowStatusUpdates(
+	ctx context.Context,
+	updates <-chan telemetry.Snapshot,
+	ticks <-chan time.Time,
+	status tmuxWindowStatus,
+	logger *slog.Logger,
+) {
+	var latest telemetry.Snapshot
+	pending := false
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case snapshot, ok := <-updates:
+			if !ok {
+				return
+			}
+			latest = snapshot
+			pending = true
+		case <-ticks:
+			if !pending {
+				continue
+			}
+			pending = false
+			if err := status.Update(ctx, latest); err != nil {
+				logger.Warn("update tmux window status failed", "error", err)
+			}
+		}
+	}
+}
+
+func closeTmuxWindowStatus(status tmuxWindowStatus, logger *slog.Logger) {
+	if status == nil {
+		return
+	}
+	if logger == nil {
+		logger = slog.Default()
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), tmuxRestoreTimeout)
+	defer cancel()
+	if err := status.Close(ctx); err != nil {
+		logger.Warn("restore tmux window name failed", "error", err)
+	}
+}

--- a/internal/cli/tmux_status_test.go
+++ b/internal/cli/tmux_status_test.go
@@ -1,0 +1,58 @@
+package cli
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"testing"
+	"time"
+
+	"github.com/digitaldrywood/detent/internal/telemetry"
+)
+
+func TestRunTmuxWindowStatusUpdatesCoalescesSnapshots(t *testing.T) {
+	t.Parallel()
+	ctx, cancel := context.WithCancel(context.Background())
+	updates := make(chan telemetry.Snapshot)
+	ticks := make(chan time.Time)
+	status := &recordingTmuxWindowStatus{updates: make(chan telemetry.Snapshot, 1)}
+	done := make(chan struct{})
+	go func() {
+		runTmuxWindowStatusUpdates(ctx, updates, ticks, status, slog.New(slog.NewTextHandler(io.Discard, nil)))
+		close(done)
+	}()
+
+	updates <- telemetry.Snapshot{Counts: telemetry.Counts{Running: 1}}
+	want := telemetry.Snapshot{Counts: telemetry.Counts{Running: 2, Queue: 3, Blocked: 4}}
+	updates <- want
+	select {
+	case got := <-status.updates:
+		t.Fatalf("Update() before tick = %#v", got)
+	default:
+	}
+	ticks <- time.Now()
+	if got := <-status.updates; got.Counts != want.Counts {
+		t.Fatalf("Update() counts = %#v, want %#v", got.Counts, want.Counts)
+	}
+	select {
+	case got := <-status.updates:
+		t.Fatalf("extra Update() = %#v", got)
+	default:
+	}
+
+	cancel()
+	<-done
+}
+
+type recordingTmuxWindowStatus struct {
+	updates chan telemetry.Snapshot
+}
+
+func (s *recordingTmuxWindowStatus) Update(_ context.Context, snapshot telemetry.Snapshot) error {
+	s.updates <- snapshot
+	return nil
+}
+
+func (*recordingTmuxWindowStatus) Close(context.Context) error {
+	return nil
+}

--- a/internal/config/global/config.go
+++ b/internal/config/global/config.go
@@ -73,6 +73,7 @@ type Config struct {
 	APIToken              string          `yaml:"api_token,omitempty"`
 	TrustLoopbackPeerRead bool            `yaml:"trust_loopback_peer_read,omitempty"`
 	DashboardAccess       DashboardAccess `yaml:"dashboard_access,omitempty"`
+	Ops                   Ops             `yaml:"ops,omitempty"`
 	Port                  *int            `yaml:"port,omitempty"`
 	InstanceName          string          `yaml:"instance_name,omitempty"`
 	Notifications         Notifications   `yaml:"notifications,omitempty"`
@@ -86,6 +87,14 @@ type DashboardAccess struct {
 	Mode       string `yaml:"mode,omitempty"`
 	Token      string `yaml:"token,omitempty"`
 	AllowWrite bool   `yaml:"allow_write,omitempty"`
+}
+
+type Ops struct {
+	TmuxWindowStatus *bool `yaml:"tmux_window_status,omitempty"`
+}
+
+func (o Ops) IsZero() bool {
+	return o.TmuxWindowStatus == nil
 }
 
 func (a DashboardAccess) IsZero() bool {
@@ -948,6 +957,7 @@ func validateRaw(attrs map[string]any, opts options) []string {
 		problems = append(problems, err.Error())
 	}
 	problems = append(problems, dashboardAccessRawErrors(attrs["dashboard_access"])...)
+	problems = append(problems, opsRawErrors(attrs["ops"])...)
 	problems = append(problems, optionalStringTypeError(attrs, "instance_name")...)
 	problems = append(problems, optionalSingleLineStringError(attrs, "instance_name")...)
 	problems = append(problems, notificationsRawErrors(attrs["notifications"])...)
@@ -1731,6 +1741,10 @@ func build(attrs map[string]any, path string, opts options) (Config, error) {
 	if err != nil {
 		return Config{}, buildValidationError(path, err)
 	}
+	ops, err := buildOps(attrs["ops"])
+	if err != nil {
+		return Config{}, buildValidationError(path, err)
+	}
 	instanceName, err := optionalString(attrs["instance_name"], "instance_name")
 	if err != nil {
 		return Config{}, buildValidationError(path, err)
@@ -1772,6 +1786,7 @@ func build(attrs map[string]any, path string, opts options) (Config, error) {
 		APIToken:              apiToken,
 		TrustLoopbackPeerRead: trustLoopbackPeerRead,
 		DashboardAccess:       dashboardAccess,
+		Ops:                   ops,
 		Port:                  port,
 		InstanceName:          instanceName,
 		Notifications:         notifications,
@@ -1780,6 +1795,38 @@ func build(attrs map[string]any, path string, opts options) (Config, error) {
 		Global:                settings,
 		Projects:              builtProjects,
 	}, nil
+}
+
+func opsRawErrors(value any) []string {
+	if value == nil {
+		return nil
+	}
+	attrs, ok := value.(map[string]any)
+	if !ok {
+		return []string{"ops: must be a mapping"}
+	}
+	if _, err := optionalBool(attrs["tmux_window_status"], "ops.tmux_window_status"); err != nil {
+		return []string{err.Error()}
+	}
+	return nil
+}
+
+func buildOps(value any) (Ops, error) {
+	if value == nil {
+		return Ops{}, nil
+	}
+	attrs, err := mapValue(value, "ops")
+	if err != nil {
+		return Ops{}, err
+	}
+	if _, configured := attrs["tmux_window_status"]; !configured {
+		return Ops{}, nil
+	}
+	enabled, err := optionalBool(attrs["tmux_window_status"], "ops.tmux_window_status")
+	if err != nil {
+		return Ops{}, err
+	}
+	return Ops{TmuxWindowStatus: &enabled}, nil
 }
 
 func dashboardAccessRawErrors(value any) []string {

--- a/internal/config/global/ops_test.go
+++ b/internal/config/global/ops_test.go
@@ -1,0 +1,70 @@
+package global
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestOpsConfigRoundTrip(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name    string
+		enabled bool
+	}{
+		{name: "enabled", enabled: true},
+		{name: "disabled", enabled: false},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			path := filepath.Join(t.TempDir(), "global.yaml")
+			cfg, err := DefaultAt(path)
+			if err != nil {
+				t.Fatalf("DefaultAt() error = %v", err)
+			}
+			cfg.Ops.TmuxWindowStatus = &test.enabled
+			if err := Write(path, cfg); err != nil {
+				t.Fatalf("Write() error = %v", err)
+			}
+
+			got, err := Read(path)
+			if err != nil {
+				t.Fatalf("Read() error = %v", err)
+			}
+			if got.Ops.TmuxWindowStatus == nil || *got.Ops.TmuxWindowStatus != test.enabled {
+				t.Fatalf("Ops.TmuxWindowStatus = %v, want %t", got.Ops.TmuxWindowStatus, test.enabled)
+			}
+		})
+	}
+}
+
+func TestOpsConfigValidation(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name   string
+		config string
+		want   string
+	}{
+		{name: "mapping", config: "ops: enabled", want: "ops: must be a mapping"},
+		{name: "boolean", config: "ops:\n  tmux_window_status: sometimes", want: "ops.tmux_window_status: must be a boolean"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			_, err := Parse([]byte(`apiVersion: detent/v1
+kind: GlobalConfig
+`+test.config+`
+global:
+  max_concurrent_agents: 8
+  scheduling: weighted
+projects: []
+`), test.name+".yaml")
+			if err == nil || !strings.Contains(err.Error(), test.want) {
+				t.Fatalf("Parse() error = %v, want containing %q", err, test.want)
+			}
+		})
+	}
+}

--- a/internal/telemetry/snapshot.go
+++ b/internal/telemetry/snapshot.go
@@ -445,6 +445,22 @@ type Counts struct {
 	Completed int `json:"completed"`
 }
 
+func (s Snapshot) EffectiveCounts() Counts {
+	return Counts{
+		Running:   countOrLength(s.Counts.Running, len(s.Running)),
+		Queue:     countOrLength(s.Counts.Queue, len(s.Queue)),
+		Blocked:   countOrLength(s.Counts.Blocked, len(s.Blocked)),
+		Completed: countOrLength(s.Counts.Completed, len(s.Completed)),
+	}
+}
+
+func countOrLength(count int, length int) int {
+	if count > 0 {
+		return count
+	}
+	return length
+}
+
 type TrackerDrift struct {
 	UntrackedOpen []Issue `json:"untracked_open,omitempty"`
 	OpenTerminal  []Issue `json:"open_terminal,omitempty"`

--- a/internal/telemetry/snapshot_test.go
+++ b/internal/telemetry/snapshot_test.go
@@ -366,6 +366,46 @@ func TestSnapshotJSONShape(t *testing.T) {
 	}
 }
 
+func TestSnapshotEffectiveCounts(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name     string
+		snapshot telemetry.Snapshot
+		want     telemetry.Counts
+	}{
+		{
+			name: "uses aggregate counts",
+			snapshot: telemetry.Snapshot{
+				Counts:    telemetry.Counts{Running: 7, Queue: 6, Blocked: 5, Completed: 4},
+				Running:   []telemetry.Running{{}},
+				Queue:     []telemetry.Queued{{}},
+				Blocked:   []telemetry.Blocked{{}},
+				Completed: []telemetry.Completed{{}},
+			},
+			want: telemetry.Counts{Running: 7, Queue: 6, Blocked: 5, Completed: 4},
+		},
+		{
+			name: "falls back to row lengths",
+			snapshot: telemetry.Snapshot{
+				Running:   []telemetry.Running{{}, {}},
+				Queue:     []telemetry.Queued{{}},
+				Blocked:   []telemetry.Blocked{{}, {}, {}},
+				Completed: []telemetry.Completed{{}, {}, {}, {}},
+			},
+			want: telemetry.Counts{Running: 2, Queue: 1, Blocked: 3, Completed: 4},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			if got := test.snapshot.EffectiveCounts(); got != test.want {
+				t.Fatalf("EffectiveCounts() = %#v, want %#v", got, test.want)
+			}
+		})
+	}
+}
+
 func TestSnapshotOmitsUnavailableRuntimeIdentityFields(t *testing.T) {
 	t.Parallel()
 

--- a/internal/tmuxstatus/status.go
+++ b/internal/tmuxstatus/status.go
@@ -1,0 +1,103 @@
+package tmuxstatus
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os/exec"
+	"strings"
+	"sync"
+
+	"github.com/digitaldrywood/detent/internal/telemetry"
+)
+
+type commandRunner interface {
+	Output(context.Context, ...string) (string, error)
+	Run(context.Context, ...string) error
+}
+
+type Status struct {
+	runner       commandRunner
+	target       string
+	originalName string
+	lastName     string
+	closeOnce    sync.Once
+	closeErr     error
+}
+
+func Enabled(tmux string, configured *bool) bool {
+	if strings.TrimSpace(tmux) == "" {
+		return false
+	}
+	return configured == nil || *configured
+}
+
+func New(ctx context.Context) (*Status, error) {
+	return newStatus(ctx, execCommandRunner{})
+}
+
+func newStatus(ctx context.Context, runner commandRunner) (*Status, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if runner == nil {
+		return nil, errors.New("tmux command runner is required")
+	}
+
+	current, err := runner.Output(ctx, "display-message", "-p", "#{window_id}\t#{window_name}")
+	if err != nil {
+		return nil, fmt.Errorf("read current tmux window: %w", err)
+	}
+	target, originalName, ok := strings.Cut(strings.TrimSuffix(current, "\n"), "\t")
+	if !ok || strings.TrimSpace(target) == "" {
+		return nil, errors.New("read current tmux window: unexpected response")
+	}
+
+	return &Status{
+		runner:       runner,
+		target:       strings.TrimSpace(target),
+		originalName: originalName,
+	}, nil
+}
+
+func Format(counts telemetry.Counts) string {
+	return fmt.Sprintf("detent %dr/%dq/%db", counts.Running, counts.Queue, counts.Blocked)
+}
+
+func (s *Status) Update(ctx context.Context, snapshot telemetry.Snapshot) error {
+	if s == nil {
+		return nil
+	}
+	name := Format(snapshot.EffectiveCounts())
+	if name == s.lastName {
+		return nil
+	}
+	if err := s.runner.Run(ctx, "rename-window", "-t", s.target, name); err != nil {
+		return fmt.Errorf("rename tmux window: %w", err)
+	}
+	s.lastName = name
+	return nil
+}
+
+func (s *Status) Close(ctx context.Context) error {
+	if s == nil {
+		return nil
+	}
+	s.closeOnce.Do(func() {
+		if err := s.runner.Run(ctx, "rename-window", "-t", s.target, s.originalName); err != nil {
+			s.closeErr = fmt.Errorf("restore tmux window name: %w", err)
+		}
+	})
+	return s.closeErr
+}
+
+type execCommandRunner struct{}
+
+func (execCommandRunner) Output(ctx context.Context, args ...string) (string, error) {
+	output, err := exec.CommandContext(ctx, "tmux", args...).Output() // #nosec G204 -- arguments are fixed tmux operations assembled within this package.
+	return string(output), err
+}
+
+func (execCommandRunner) Run(ctx context.Context, args ...string) error {
+	return exec.CommandContext(ctx, "tmux", args...).Run() // #nosec G204 -- arguments are fixed tmux operations assembled within this package.
+}

--- a/internal/tmuxstatus/status_test.go
+++ b/internal/tmuxstatus/status_test.go
@@ -1,0 +1,136 @@
+package tmuxstatus
+
+import (
+	"context"
+	"errors"
+	"reflect"
+	"testing"
+
+	"github.com/digitaldrywood/detent/internal/telemetry"
+)
+
+func TestEnabled(t *testing.T) {
+	t.Parallel()
+	trueValue := true
+	falseValue := false
+	tests := []struct {
+		name       string
+		tmux       string
+		configured *bool
+		want       bool
+	}{
+		{name: "outside tmux defaults off", want: false},
+		{name: "outside tmux explicit on stays off", configured: &trueValue, want: false},
+		{name: "inside tmux defaults on", tmux: "/tmp/tmux-501/default,1,0", want: true},
+		{name: "inside tmux explicit on", tmux: "/tmp/tmux-501/default,1,0", configured: &trueValue, want: true},
+		{name: "inside tmux explicit off", tmux: "/tmp/tmux-501/default,1,0", configured: &falseValue, want: false},
+		{name: "blank tmux is absent", tmux: "  ", want: false},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			if got := Enabled(test.tmux, test.configured); got != test.want {
+				t.Fatalf("Enabled() = %t, want %t", got, test.want)
+			}
+		})
+	}
+}
+
+func TestFormat(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name   string
+		counts telemetry.Counts
+		want   string
+	}{
+		{name: "idle", want: "detent 0r/0q/0b"},
+		{name: "active", counts: telemetry.Counts{Running: 2, Queue: 1, Blocked: 3}, want: "detent 2r/1q/3b"},
+		{name: "large counts stay compact", counts: telemetry.Counts{Running: 120, Queue: 45, Blocked: 8}, want: "detent 120r/45q/8b"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			if got := Format(test.counts); got != test.want {
+				t.Fatalf("Format() = %q, want %q", got, test.want)
+			}
+		})
+	}
+}
+
+func TestStatusLifecycle(t *testing.T) {
+	t.Parallel()
+	runner := &recordingRunner{output: "@7\tDetent:2\n"}
+	status, err := newStatus(context.Background(), runner)
+	if err != nil {
+		t.Fatalf("newStatus() error = %v", err)
+	}
+
+	snapshot := telemetry.Snapshot{
+		Running: []telemetry.Running{{}, {}},
+		Queue:   []telemetry.Queued{{}},
+		Blocked: []telemetry.Blocked{{}, {}, {}},
+	}
+	if err := status.Update(context.Background(), snapshot); err != nil {
+		t.Fatalf("Update() error = %v", err)
+	}
+	if err := status.Update(context.Background(), snapshot); err != nil {
+		t.Fatalf("duplicate Update() error = %v", err)
+	}
+	if err := status.Close(context.Background()); err != nil {
+		t.Fatalf("Close() error = %v", err)
+	}
+	if err := status.Close(context.Background()); err != nil {
+		t.Fatalf("duplicate Close() error = %v", err)
+	}
+
+	want := [][]string{
+		{"display-message", "-p", "#{window_id}\t#{window_name}"},
+		{"rename-window", "-t", "@7", "detent 2r/1q/3b"},
+		{"rename-window", "-t", "@7", "Detent:2"},
+	}
+	if !reflect.DeepEqual(runner.calls, want) {
+		t.Fatalf("commands = %#v, want %#v", runner.calls, want)
+	}
+}
+
+func TestStatusRetriesFailedRename(t *testing.T) {
+	t.Parallel()
+	runner := &recordingRunner{output: "@7\tDetent:2\n"}
+	status, err := newStatus(context.Background(), runner)
+	if err != nil {
+		t.Fatalf("newStatus() error = %v", err)
+	}
+
+	runner.err = errors.New("tmux unavailable")
+	snapshot := telemetry.Snapshot{Counts: telemetry.Counts{Running: 1}}
+	if err := status.Update(context.Background(), snapshot); err == nil {
+		t.Fatal("Update() error = nil, want rename failure")
+	}
+	runner.err = nil
+	if err := status.Update(context.Background(), snapshot); err != nil {
+		t.Fatalf("retry Update() error = %v", err)
+	}
+
+	wantRename := []string{"rename-window", "-t", "@7", "detent 1r/0q/0b"}
+	if len(runner.calls) != 3 || !reflect.DeepEqual(runner.calls[1], wantRename) || !reflect.DeepEqual(runner.calls[2], wantRename) {
+		t.Fatalf("commands = %#v, want two rename attempts %#v", runner.calls, wantRename)
+	}
+}
+
+type recordingRunner struct {
+	output string
+	err    error
+	calls  [][]string
+}
+
+func (r *recordingRunner) Output(_ context.Context, args ...string) (string, error) {
+	r.calls = append(r.calls, append([]string(nil), args...))
+	return r.output, r.err
+}
+
+func (r *recordingRunner) Run(_ context.Context, args ...string) error {
+	r.calls = append(r.calls, append([]string(nil), args...))
+	return r.err
+}

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -542,14 +542,6 @@ func compactSessionID(sessionID string) string {
 	return string(runes[:4]) + "..." + string(runes[len(runes)-6:])
 }
 
-func countOrLen(count int, length int) int {
-	if count > 0 {
-		return count
-	}
-
-	return length
-}
-
 func formatTimestamp(value time.Time) string {
 	if value.IsZero() {
 		return "n/a"

--- a/internal/tui/summary.go
+++ b/internal/tui/summary.go
@@ -19,15 +19,16 @@ func (m Model) ExitSummary() string {
 		now = time.Now
 	}
 	snapshot := m.snapshot
+	counts := snapshot.EffectiveCounts()
 	lines := []string{
 		"Detent exit summary",
 		"Timestamp: " + formatTimestamp(now()),
 		fmt.Sprintf(
 			"Counts: ● %d running | ◐ %d queued | ✗ %d blocked | ✓ %d completed",
-			countOrLen(snapshot.Counts.Running, len(snapshot.Running)),
-			countOrLen(snapshot.Counts.Queue, len(snapshot.Queue)),
-			countOrLen(snapshot.Counts.Blocked, len(snapshot.Blocked)),
-			countOrLen(snapshot.Counts.Completed, len(snapshot.Completed)),
+			counts.Running,
+			counts.Queue,
+			counts.Blocked,
+			counts.Completed,
 		),
 	}
 

--- a/internal/tui/view.go
+++ b/internal/tui/view.go
@@ -158,7 +158,8 @@ func (m Model) renderSnapshotDashboard(width int, height int) []string {
 		lines = append(lines, frameContent(line, width))
 	}
 
-	runningTotal := countOrLen(snapshot.Counts.Running, len(snapshot.Running))
+	counts := snapshot.EffectiveCounts()
+	runningTotal := counts.Running
 	if m.collapsed[runningSection] {
 		lines = append(lines, collapsedSectionLine("RUNNING", runningTotal, width, m.styles, m.focusedSection == runningSection))
 	} else {
@@ -170,7 +171,7 @@ func (m Model) renderSnapshotDashboard(width int, height int) []string {
 	sections := []dashboardSection{
 		{
 			label:       "QUEUE",
-			total:       countOrLen(snapshot.Counts.Queue, len(snapshot.Queue)),
+			total:       counts.Queue,
 			rows:        queueRows,
 			emptyLabel:  "No queued retries",
 			visibleRows: caps.queue,
@@ -181,7 +182,7 @@ func (m Model) renderSnapshotDashboard(width int, height int) []string {
 		},
 		{
 			label:       "BLOCKED",
-			total:       countOrLen(snapshot.Counts.Blocked, len(snapshot.Blocked)),
+			total:       counts.Blocked,
 			rows:        blockedRows,
 			emptyLabel:  "No blocked work",
 			visibleRows: caps.blocked,
@@ -192,7 +193,7 @@ func (m Model) renderSnapshotDashboard(width int, height int) []string {
 		},
 		{
 			label:       "COMPLETED",
-			total:       countOrLen(snapshot.Counts.Completed, len(snapshot.Completed)),
+			total:       counts.Completed,
 			rows:        completedRows,
 			emptyLabel:  "No completed work",
 			visibleRows: caps.completed,
@@ -232,13 +233,14 @@ func (m Model) snapshotHeader(snapshot telemetry.Snapshot) []string {
 	instance := formatOptionalInfo(formatInstance(snapshot.Instance), m.styles)
 	scope := formatOptionalInfo(formatAuthorizationScope(snapshot.Instance), m.styles)
 
-	counts := m.styles.ok.Render(fmt.Sprintf("● %d running", countOrLen(snapshot.Counts.Running, len(snapshot.Running)))) +
+	effectiveCounts := snapshot.EffectiveCounts()
+	counts := m.styles.ok.Render(fmt.Sprintf("● %d running", effectiveCounts.Running)) +
 		m.styles.muted.Render("   ") +
-		m.styles.warn.Render(fmt.Sprintf("◐ %d queued", countOrLen(snapshot.Counts.Queue, len(snapshot.Queue)))) +
+		m.styles.warn.Render(fmt.Sprintf("◐ %d queued", effectiveCounts.Queue)) +
 		m.styles.muted.Render("   ") +
-		m.styles.error.Render(fmt.Sprintf("✗ %d blocked", countOrLen(snapshot.Counts.Blocked, len(snapshot.Blocked)))) +
+		m.styles.error.Render(fmt.Sprintf("✗ %d blocked", effectiveCounts.Blocked)) +
 		m.styles.muted.Render("   ") +
-		m.styles.info.Render(fmt.Sprintf("✓ %d completed", countOrLen(snapshot.Counts.Completed, len(snapshot.Completed))))
+		m.styles.info.Render(fmt.Sprintf("✓ %d completed", effectiveCounts.Completed))
 
 	refresh := formatNextRefresh(snapshot.Refresh)
 	if refresh == "" {


### PR DESCRIPTION
## Summary

- add opt-out live tmux window status using the TUI telemetry counts
- coalesce rename attempts to the snapshot tick and restore the original targeted window name on shutdown
- document and validate ops.tmux_window_status

Fixes #1806

## UI Surface Contract

- [x] N/A; the linked issue explicitly authorizes the tmux window-name surface.
- [x] This PR does not add persistent top-of-screen messaging.
- [x] This PR does not change a primary operator screen, so browser screenshots are not applicable.

## Test Plan

- [x] make check
- [x] table-driven formatter and enablement matrix tests
- [x] deterministic coalescing and tmux command lifecycle tests