### PR TITLE
fix(merge): bound fallback agent to conflict resolution

### DIFF
--- a/config.reference.yaml
+++ b/config.reference.yaml
@@ -537,6 +537,8 @@
 #   merge_worker_startup_timeout_ms: 240000
 #   # agent.merge_worker_max_duration_ms | type: integer | default: 21600000 | required: No | validation: must be greater than 0
 #   merge_worker_max_duration_ms: 21600000
+#   # agent.merge_fallback_max_duration_ms | type: integer | default: 1200000 | required: No | validation: must be greater than 0
+#   merge_fallback_max_duration_ms: 1200000
 #   # agent.max_retry_backoff_ms | type: integer | default: 300000 | required: No | validation: must be greater than 0
 #   max_retry_backoff_ms: 300000
 #   # agent.overload_retry_delay_ms | type: integer | default: 45000 | required: No | validation: must be greater than 0

--- a/docs/config.md
+++ b/docs/config.md
@@ -515,6 +515,7 @@ only to resettable budget pacing and never clears a per-issue hard hold.
 | `agent.max_session_tokens` | `integer` | `0` | No | must be greater than or equal to 0 |
 | `agent.max_turn_duration_ms` | `integer` | `0` | No | must be greater than or equal to 0 |
 | `agent.max_turns` | `integer` | `20` | No | must be greater than 0 |
+| `agent.merge_fallback_max_duration_ms` | `integer` | `1200000` | No | must be greater than 0 |
 | `agent.merge_fast_path` | `object` | `see child fields` | No | None |
 | `agent.merge_fast_path.enabled` | `boolean` | `true` | No | None |
 | `agent.merge_fast_path.fairness_age_seconds` | `integer` | `7200` | No | must be greater than 0 |

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -73,6 +73,7 @@ const (
 	DefaultOverloadRetryDelayMS              = 45000
 	DefaultMergeWorkerStartupTimeoutMS       = 4 * 60 * 1000
 	DefaultMergeWorkerMaxDurationMS          = 6 * 60 * 60 * 1000
+	DefaultMergeFallbackMaxDurationMS        = 20 * 60 * 1000
 	DefaultMergeFairnessAgeSeconds           = 2 * 60 * 60
 	DefaultMaxSessionDurationMS              = 2 * 60 * 60 * 1000
 	DefaultNoProgressTimeoutMS               = 90 * 60 * 1000
@@ -299,6 +300,7 @@ type Agent struct {
 	NoProgressTimeoutMS          int                          `yaml:"no_progress_timeout_ms"`
 	MergeWorkerStartupTimeoutMS  int                          `yaml:"merge_worker_startup_timeout_ms"`
 	MergeWorkerMaxDurationMS     int                          `yaml:"merge_worker_max_duration_ms"`
+	MergeFallbackMaxDurationMS   int                          `yaml:"merge_fallback_max_duration_ms"`
 	MaxRetryBackoffMS            int                          `yaml:"max_retry_backoff_ms"`
 	OverloadRetryDelayMS         int                          `yaml:"overload_retry_delay_ms"`
 	NoProgressTokenLimit         int64                        `yaml:"no_progress_token_limit"`
@@ -1366,6 +1368,7 @@ func Default() Config {
 			NoProgressTimeoutMS:         DefaultNoProgressTimeoutMS,
 			MergeWorkerStartupTimeoutMS: DefaultMergeWorkerStartupTimeoutMS,
 			MergeWorkerMaxDurationMS:    DefaultMergeWorkerMaxDurationMS,
+			MergeFallbackMaxDurationMS:  DefaultMergeFallbackMaxDurationMS,
 			MaxRetryBackoffMS:           300000,
 			OverloadRetryDelayMS:        DefaultOverloadRetryDelayMS,
 			NoProgressTokenLimit:        DefaultNoProgressTokenLimit,
@@ -1695,6 +1698,9 @@ func (c *Config) normalize() {
 	}
 	if c.Agent.MergeWorkerMaxDurationMS == 0 {
 		c.Agent.MergeWorkerMaxDurationMS = DefaultMergeWorkerMaxDurationMS
+	}
+	if c.Agent.MergeFallbackMaxDurationMS == 0 {
+		c.Agent.MergeFallbackMaxDurationMS = DefaultMergeFallbackMaxDurationMS
 	}
 	if c.Agent.MergeFastPath.FairnessAgeSeconds == 0 {
 		c.Agent.MergeFastPath.FairnessAgeSeconds = DefaultMergeFairnessAgeSeconds
@@ -2115,6 +2121,7 @@ func (a *Agent) validate(prefix string, problems *[]string) {
 	}
 	validatePositive(prefix+".merge_worker_startup_timeout_ms", a.MergeWorkerStartupTimeoutMS, problems)
 	validatePositive(prefix+".merge_worker_max_duration_ms", a.MergeWorkerMaxDurationMS, problems)
+	validatePositive(prefix+".merge_fallback_max_duration_ms", a.MergeFallbackMaxDurationMS, problems)
 	validatePositive(prefix+".max_retry_backoff_ms", a.MaxRetryBackoffMS, problems)
 	validatePositive(prefix+".overload_retry_delay_ms", a.OverloadRetryDelayMS, problems)
 	if a.MaxSessionTokens < 0 {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -974,6 +974,7 @@ agent:
   no_progress_timeout_ms: 1800000
   merge_worker_startup_timeout_ms: 180000
   merge_worker_max_duration_ms: 7200000
+  merge_fallback_max_duration_ms: 1200000
   max_session_tokens: 10000000
   max_session_context_multiplier: 3.5
   max_session_token_override_label: Allow-Large-Session
@@ -1233,6 +1234,9 @@ Ticket prompt {{ issue.title }}
 	}
 	if cfg.Agent.MergeWorkerMaxDurationMS != 7200000 {
 		t.Fatalf("Agent.MergeWorkerMaxDurationMS = %d, want 7200000", cfg.Agent.MergeWorkerMaxDurationMS)
+	}
+	if cfg.Agent.MergeFallbackMaxDurationMS != 1200000 {
+		t.Fatalf("Agent.MergeFallbackMaxDurationMS = %d, want 1200000", cfg.Agent.MergeFallbackMaxDurationMS)
 	}
 	if cfg.Agent.MaxSessionTokens != 10000000 {
 		t.Fatalf("Agent.MaxSessionTokens = %d, want 10000000", cfg.Agent.MaxSessionTokens)
@@ -1616,6 +1620,9 @@ func TestParseWorkflowDefaults(t *testing.T) {
 	}
 	if cfg.Agent.MergeWorkerMaxDurationMS != DefaultMergeWorkerMaxDurationMS {
 		t.Fatalf("Agent.MergeWorkerMaxDurationMS = %d, want %d", cfg.Agent.MergeWorkerMaxDurationMS, DefaultMergeWorkerMaxDurationMS)
+	}
+	if cfg.Agent.MergeFallbackMaxDurationMS != DefaultMergeFallbackMaxDurationMS {
+		t.Fatalf("Agent.MergeFallbackMaxDurationMS = %d, want %d", cfg.Agent.MergeFallbackMaxDurationMS, DefaultMergeFallbackMaxDurationMS)
 	}
 	if cfg.Agent.MaxSessionDurationMS != DefaultMaxSessionDurationMS {
 		t.Fatalf("Agent.MaxSessionDurationMS = %d, want %d", cfg.Agent.MaxSessionDurationMS, DefaultMaxSessionDurationMS)
@@ -3462,6 +3469,7 @@ agent:
   no_progress_timeout_ms: -1
   merge_worker_startup_timeout_ms: -1
   merge_worker_max_duration_ms: -1
+  merge_fallback_max_duration_ms: -1
   max_session_tokens: -1
   max_session_context_multiplier: -0.5
   output_truncation:
@@ -3504,6 +3512,7 @@ Prompt
 				"agent.no_progress_timeout_ms must be greater than or equal to 0",
 				"agent.merge_worker_startup_timeout_ms must be greater than 0",
 				"agent.merge_worker_max_duration_ms must be greater than 0",
+				"agent.merge_fallback_max_duration_ms must be greater than 0",
 				"agent.max_session_tokens must be greater than or equal to 0",
 				"agent.max_session_context_multiplier must be greater than or equal to 0",
 				"agent.output_truncation.max_bytes must be greater than or equal to 0",

--- a/internal/orchestrator/merge_fallback.go
+++ b/internal/orchestrator/merge_fallback.go
@@ -1,0 +1,38 @@
+package orchestrator
+
+import (
+	"context"
+	"errors"
+	"strings"
+
+	runpkg "github.com/digitaldrywood/detent/internal/runner"
+)
+
+func (o *Orchestrator) handleMergeFallbackBudgetExceeded(
+	ctx context.Context,
+	state *State,
+	event runpkg.Completion,
+	running Running,
+) bool {
+	if !errors.Is(event.Err, runpkg.ErrMergeFallbackBudgetExceeded) {
+		return false
+	}
+	if o.completeLatestTerminalMergeWorkerResult(ctx, state, event, running) {
+		return true
+	}
+	findings := strings.TrimSpace(event.Result.MergeFallbackFindings)
+	if findings == "" {
+		findings = strings.TrimSpace(event.Result.Output)
+	}
+	o.reworkMergeWorkerResult(
+		ctx,
+		state,
+		event,
+		running,
+		running.Issue,
+		mergeFallbackBudgetExceededReason,
+		nil,
+		findings,
+	)
+	return true
+}

--- a/internal/orchestrator/merge_fallback_test.go
+++ b/internal/orchestrator/merge_fallback_test.go
@@ -1,0 +1,121 @@
+package orchestrator
+
+import (
+	"context"
+	"errors"
+	"io"
+	"log/slog"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/digitaldrywood/detent/internal/connector"
+	runpkg "github.com/digitaldrywood/detent/internal/runner"
+	"github.com/digitaldrywood/detent/internal/store"
+)
+
+func TestMergeFallbackRoutesBoundedOutcomesToRework(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name              string
+		result            runpkg.RunResult
+		runErr            error
+		wantReason        string
+		wantTerminalState store.WorkAttemptTerminalState
+	}{
+		{
+			name: "structured review finding",
+			result: runpkg.RunResult{
+				FinalState:            runpkg.FinalStateCompleted,
+				Output:                runpkg.RunOutputMergeFallbackRework,
+				MergeFallbackFindings: "Found an unrelated authorization defect and stopped.",
+			},
+			wantReason:        mergeFallbackRequiresReworkReason,
+			wantTerminalState: store.WorkAttemptTerminalSuccess,
+		},
+		{
+			name: "fallback budget exceeded",
+			result: runpkg.RunResult{
+				FinalState: runpkg.FinalStateMergeFallbackExceeded,
+				Output:     "Conflict resolved; validation still running.",
+			},
+			runErr:            errors.Join(runpkg.ErrMergeFallbackBudgetExceeded, context.DeadlineExceeded),
+			wantReason:        mergeFallbackBudgetExceededReason,
+			wantTerminalState: store.WorkAttemptTerminalTimedOut,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			now := time.Date(2026, 8, 15, 14, 0, 0, 0, time.UTC)
+			issue := connector.Issue{
+				ID:           "issue-1809-" + strings.ReplaceAll(tt.name, " ", "-"),
+				Identifier:   "digitaldrywood/detent#1809",
+				State:        "Merging",
+				PRRepository: "digitaldrywood/detent",
+				PullRequest: &connector.PullRequest{
+					Number:         1810,
+					URL:            "https://github.test/digitaldrywood/detent/pull/1810",
+					State:          "OPEN",
+					MergeableState: "dirty",
+					HeadSHA:        "conflicted-head",
+				},
+			}
+			tracker := &autoPromoteTickMergeConnector{
+				autoPromoteTickConnector: &autoPromoteTickConnector{stateIssues: []connector.Issue{issue}},
+			}
+			cfg := normalizeConfig(Config{
+				ActiveStates:   []string{"Rework", "Merging"},
+				ObservedStates: []string{"Merging"},
+				TerminalStates: []string{"Done", "Cancelled"},
+			})
+			attempts := &recordingWorkAttemptStore{}
+			orch := &Orchestrator{
+				cfg:          cfg,
+				connector:    tracker,
+				workAttempts: attempts,
+				logger:       slog.New(slog.NewTextHandler(io.Discard, nil)),
+			}
+			state := newState(cfg)
+			state.Running[issue.ID] = Running{
+				Issue:         cloneIssue(issue),
+				Attempt:       1,
+				WorkAttemptID: 1809,
+				StartedAt:     now.Add(-20 * time.Minute),
+				Mode:          runpkg.RunModeMerge,
+			}
+			state.Claimed[issue.ID] = Claimed{Issue: cloneIssue(issue), ClaimedAt: now.Add(-20 * time.Minute)}
+
+			orch.handleRunResult(t.Context(), &state, runpkg.Completion{
+				IssueID:     issue.ID,
+				CompletedAt: now,
+				Request:     runpkg.RunRequest{Mode: runpkg.RunModeMerge},
+				Result:      tt.result,
+				Err:         tt.runErr,
+			})
+
+			if len(tracker.updates) != 1 || tracker.updates[0].state != "Rework" {
+				t.Fatalf("state updates = %#v, want one Rework transition", tracker.updates)
+			}
+			if len(tracker.comments) != 1 || !strings.Contains(tracker.comments[0].body, tt.wantReason) {
+				t.Fatalf("comments = %#v, want reason %q", tracker.comments, tt.wantReason)
+			}
+			if !strings.Contains(tracker.comments[0].body, "authorization defect") &&
+				!strings.Contains(tracker.comments[0].body, "validation still running") {
+				t.Fatalf("comment = %q, want preserved merge-fallback findings", tracker.comments[0].body)
+			}
+			if len(attempts.completions) != 1 || attempts.completions[0].TerminalState != tt.wantTerminalState {
+				t.Fatalf("attempt completions = %#v, want terminal state %q", attempts.completions, tt.wantTerminalState)
+			}
+			if _, ok := state.Retry[issue.ID]; ok {
+				t.Fatalf("Retry[%q] present after Rework handoff", issue.ID)
+			}
+			if _, ok := state.Claimed[issue.ID]; ok {
+				t.Fatalf("Claimed[%q] present after Rework handoff", issue.ID)
+			}
+		})
+	}
+}

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -59,6 +59,8 @@ const (
 	mergeWorkerRetryExhaustedReason            = "merge_worker_retry_exhausted"
 	mergeWorkerCurrentHeadCIWaitExceededReason = "merge_worker_current_head_ci_wait_exceeded"
 	mergeWorkerDurationExceededReason          = "merge_worker_duration_exceeded"
+	mergeFallbackBudgetExceededReason          = "merge_fallback_budget_exceeded"
+	mergeFallbackRequiresReworkReason          = "merge_fallback_requires_rework"
 )
 
 var (

--- a/internal/orchestrator/run_completion.go
+++ b/internal/orchestrator/run_completion.go
@@ -194,6 +194,9 @@ func (o *Orchestrator) handleRunResult(ctx context.Context, state *State, event 
 	if o.handleMergeWorkerDurationExceeded(ctx, state, event, running) {
 		return
 	}
+	if o.handleMergeFallbackBudgetExceeded(ctx, state, event, running) {
+		return
+	}
 	if o.handleSessionBrake(ctx, state, event, running) {
 		return
 	}
@@ -1131,6 +1134,10 @@ func (o *Orchestrator) completeProgrammaticMergeWorkerResult(
 	if !mergeWorkerTurnSucceeded(event) {
 		return false
 	}
+	if strings.TrimSpace(event.Result.Output) == runpkg.RunOutputMergeFallbackRework {
+		o.reworkMergeWorkerResult(ctx, state, event, running, issue, mergeFallbackRequiresReworkReason, nil, event.Result.MergeFallbackFindings)
+		return true
+	}
 	hydrator, ok := o.connector.(connector.PullRequestHydrator)
 	if !ok {
 		return false
@@ -1176,7 +1183,7 @@ func (o *Orchestrator) completeProgrammaticMergeWorkerResult(
 				o.waitForMergeWorkerRequiredCheckPropagation(ctx, state, event, running, issue)
 				return true
 			}
-			o.reworkMergeWorkerResult(ctx, state, event, running, issue, mergeWorkerRequiredChecksMissingReason, missingChecks)
+			o.reworkMergeWorkerResult(ctx, state, event, running, issue, mergeWorkerRequiredChecksMissingReason, missingChecks, "")
 			return true
 		}
 		if mergeFastPathResult(event) && mergeWorkerMergeabilityPending(issue) {
@@ -1188,7 +1195,7 @@ func (o *Orchestrator) completeProgrammaticMergeWorkerResult(
 			return true
 		}
 		if mergeFastPathResult(event) {
-			o.reworkMergeWorkerResult(ctx, state, event, running, issue, mergeWorkerFastPathNotReadyReason, nil)
+			o.reworkMergeWorkerResult(ctx, state, event, running, issue, mergeWorkerFastPathNotReadyReason, nil, "")
 			return true
 		}
 		return false
@@ -1579,7 +1586,7 @@ func mergeFastPathResult(event runpkg.Completion) bool {
 		return false
 	}
 	switch strings.TrimSpace(event.Result.Output) {
-	case runpkg.RunOutputMergeFastPathClean, runpkg.RunOutputMergeFastPathCheckedHead:
+	case runpkg.RunOutputMergeFastPathClean, runpkg.RunOutputMergeFastPathCheckedHead, runpkg.RunOutputMergeFallbackResolved:
 		return true
 	default:
 		return false
@@ -1882,6 +1889,7 @@ func (o *Orchestrator) reworkMergeWorkerResult(
 	issue connector.Issue,
 	reason string,
 	missingChecks []string,
+	findings string,
 ) {
 	issueID := strings.TrimSpace(event.IssueID)
 	running.Issue = issue
@@ -1889,15 +1897,23 @@ func (o *Orchestrator) reworkMergeWorkerResult(
 		o.failProgrammaticMergeWorkerResult(ctx, state, event, running, "merge_worker_rework_failed", err)
 		return
 	}
-	if comment := mergeWorkerReworkComment(issue, reason, missingChecks); comment != "" {
+	if comment := mergeWorkerReworkComment(issue, reason, missingChecks, findings); comment != "" {
 		if err := o.connector.CreateComment(ctx, issueID, comment); err != nil && o.logger != nil {
 			o.logger.Warn("merge worker rework comment failed", "issue_id", issueID, "reason", reason, "error", err)
 		}
 	}
-	o.recordProjectAttemptOutcome(state, event.IssueID, event.CompletedAt, store.WorkAttemptTerminalSuccess, nil, "", "")
-	o.completeDurableWorkAttempt(ctx, state, running, event.CompletedAt, store.WorkAttemptTerminalSuccess, "", "", "rework", "merge worker routed current head to Rework")
-	o.logMergeWorkerFailure(issue, reason, nil)
-	o.recordMergeFailed(state, issue, event.CompletedAt, reason, nil)
+	terminalState := store.WorkAttemptTerminalSuccess
+	errorClass := ""
+	errorMessage := ""
+	if event.Err != nil {
+		terminalState = store.WorkAttemptTerminalTimedOut
+		errorClass = reason
+		errorMessage = event.Err.Error()
+	}
+	o.recordProjectAttemptOutcome(state, event.IssueID, event.CompletedAt, terminalState, event.Err, errorClass, errorMessage)
+	o.completeDurableWorkAttempt(ctx, state, running, event.CompletedAt, terminalState, errorClass, errorMessage, "rework", "merge worker routed current head to Rework")
+	o.logMergeWorkerFailure(issue, reason, event.Err)
+	o.recordMergeFailed(state, issue, event.CompletedAt, reason, event.Err)
 	if err := o.abandonClaim(ctx, issueID); err != nil && o.logger != nil {
 		o.logger.Warn("abandon merge worker rework claim failed", "issue_id", issueID, "error", err)
 	}
@@ -1913,7 +1929,7 @@ func (o *Orchestrator) reworkMergeWorkerResult(
 	})
 }
 
-func mergeWorkerReworkComment(issue connector.Issue, reason string, missingChecks []string) string {
+func mergeWorkerReworkComment(issue connector.Issue, reason string, missingChecks []string, findings string) string {
 	var b strings.Builder
 	b.WriteString("Merge worker routed this issue from Merging to Rework.")
 	b.WriteString("\n\n- reason: ")
@@ -1921,6 +1937,11 @@ func mergeWorkerReworkComment(issue connector.Issue, reason string, missingCheck
 	if len(missingChecks) > 0 {
 		b.WriteString("\n- missing_required_checks: ")
 		b.WriteString(strings.Join(missingChecks, ", "))
+	}
+	if findings = strings.TrimSpace(findings); findings != "" {
+		b.WriteString("\n\nMerge-fallback findings:\n\n```text\n")
+		b.WriteString(findings)
+		b.WriteString("\n```")
 	}
 	if issue.PullRequest != nil {
 		if url := strings.TrimSpace(issue.PullRequest.URL); url != "" {

--- a/internal/runner/agent.go
+++ b/internal/runner/agent.go
@@ -626,6 +626,53 @@ func mergePrecheckFromWorkspace(precheck workspace.MergePrepareResult) MergePrec
 	}
 }
 
+func mergeFallbackResult(output string) string {
+	trimmed := strings.TrimSpace(output)
+	resolvedMarker := "DETENT_MERGE_FALLBACK: resolved"
+	reworkMarker := "DETENT_MERGE_FALLBACK: rework"
+	if strings.Count(trimmed, resolvedMarker) == 1 &&
+		strings.Count(trimmed, reworkMarker) == 0 &&
+		strings.HasSuffix(trimmed, resolvedMarker) {
+		return RunOutputMergeFallbackResolved
+	}
+	return RunOutputMergeFallbackRework
+}
+
+func (r *Runner) verifyMergeFallback(
+	ctx context.Context,
+	backend workspace.Backend,
+	info workspace.Info,
+	issue workspace.Issue,
+	targetBranch string,
+	result RunResult,
+) (RunResult, error) {
+	result.MergeFallbackFindings = strings.TrimSpace(result.Output)
+	result.Output = mergeFallbackResult(result.Output)
+	if result.Output == RunOutputMergeFallbackRework {
+		return result, nil
+	}
+	preparer, ok := backend.(workspace.MergePreparer)
+	if !ok {
+		result.Output = RunOutputMergeFallbackRework
+		return result, nil
+	}
+	precheck, err := preparer.PrepareMerge(ctx, info, issue, workspace.MergePrepareOptions{TargetBranch: strings.TrimSpace(targetBranch)})
+	if err != nil {
+		if cause := context.Cause(ctx); errors.Is(cause, ErrMergeFallbackBudgetExceeded) {
+			err = errors.Join(cause, err)
+		}
+		return result, fmt.Errorf("verify merge fallback: %w", err)
+	}
+	converted := mergePrecheckFromWorkspace(precheck)
+	result.MergePrecheck = &converted
+	if precheck.Status != workspace.MergePrepareStatusClean {
+		result.Output = RunOutputMergeFallbackRework
+		return result, nil
+	}
+	result.PullRequestHeadPushed = result.PullRequestHeadPushed || precheck.HeadChanged
+	return result, nil
+}
+
 func cloneMergePrecheck(precheck *MergePrecheck) *MergePrecheck {
 	if precheck == nil {
 		return nil
@@ -815,6 +862,7 @@ func withAgentDurationLimit(ctx context.Context, duration time.Duration, limit e
 func durationLimitError(err error) bool {
 	return errors.Is(err, ErrTurnDurationExceeded) ||
 		errors.Is(err, ErrSessionDurationExceeded) ||
+		errors.Is(err, ErrMergeFallbackBudgetExceeded) ||
 		errors.Is(err, ErrSessionTurnLimitExceeded) ||
 		errors.Is(err, ErrSessionNoProgress)
 }
@@ -1256,10 +1304,19 @@ func (r *Runner) Run(ctx context.Context, req RunRequest) (RunResult, error) {
 	if err != nil {
 		return RunResult{}, err
 	}
+	sessionDuration := durationFromMillis(workflow.Config.Agent.MaxSessionDurationMS)
+	sessionLimitError := ErrSessionDurationExceeded
+	if mergeFallback {
+		sessionDuration = durationFromMillis(workflow.Config.Agent.MergeFallbackMaxDurationMS)
+		if sessionDuration <= 0 {
+			sessionDuration = durationFromMillis(config.DefaultMergeFallbackMaxDurationMS)
+		}
+		sessionLimitError = ErrMergeFallbackBudgetExceeded
+	}
 	sessionCtx, cancelSession := r.sessionLimit(
 		ctx,
-		durationFromMillis(workflow.Config.Agent.MaxSessionDurationMS),
-		ErrSessionDurationExceeded,
+		sessionDuration,
+		sessionLimitError,
 	)
 	defer cancelSession()
 	sessionCtx, cancelSessionBrake := context.WithCancelCause(sessionCtx)
@@ -1267,7 +1324,7 @@ func (r *Runner) Run(ctx context.Context, req RunRequest) (RunResult, error) {
 	sessionBrake := newSessionBrakeController(
 		sessionCtx,
 		runStartedAt,
-		durationFromMillis(workflow.Config.Agent.MaxSessionDurationMS),
+		sessionDuration,
 		workflow.Config.Agent.MaxTurns,
 		durationFromMillis(workflow.Config.Agent.NoProgressTimeoutMS),
 		cancelSessionBrake,
@@ -1319,6 +1376,9 @@ func (r *Runner) Run(ctx context.Context, req RunRequest) (RunResult, error) {
 		cacheStrategy:         workflow.Config.Workspace.CacheStrategy,
 		projectID:             r.projectID,
 		workerGitHub:          workerGitHub,
+	}
+	if mergeFallback && (turnRequest.MaxDuration <= 0 || sessionDuration < turnRequest.MaxDuration) {
+		turnRequest.MaxDuration = sessionDuration
 	}
 	if mode == RunModeRoutine {
 		turnRequest.ToolInstructions = routineToolInstructions
@@ -1429,6 +1489,16 @@ func (r *Runner) Run(ctx context.Context, req RunRequest) (RunResult, error) {
 	turnErr := execution.err
 	cleanupErr := execution.cleanupErr
 	result := execution.result
+	if mergeFallback && turnErr == nil {
+		targetBranch := ""
+		if req.Issue.PullRequest != nil {
+			targetBranch = req.Issue.PullRequest.BaseRef
+		}
+		result, turnErr = r.verifyMergeFallback(sessionCtx, runWorkspace, info, workspaceIssue, targetBranch, result)
+		if turnErr != nil {
+			result.FinalState = finalStateForTurnError(turnErr)
+		}
+	}
 	result.budgetProjection = budgetProjection
 	if brakeDiff := sessionBrake.resultDiffStats(); brakeDiff != (DiffStats{}) {
 		result.DiffStats = brakeDiff
@@ -2682,6 +2752,9 @@ func finalStateForTurnError(err error) string {
 	}
 	if errors.Is(err, ErrMergeWorkerDurationExceeded) {
 		return FinalStateMergeDurationExceeded
+	}
+	if errors.Is(err, ErrMergeFallbackBudgetExceeded) {
+		return FinalStateMergeFallbackExceeded
 	}
 	if errors.Is(err, ErrSessionTokenCeilingExceeded) {
 		return FinalStateTokenCeilingExceeded

--- a/internal/runner/duration_limit_test.go
+++ b/internal/runner/duration_limit_test.go
@@ -177,6 +177,113 @@ func TestRunnerSessionDurationSpansResumeFallback(t *testing.T) {
 	}
 }
 
+func TestRunnerMergeFallbackUsesDedicatedBudget(t *testing.T) {
+	t.Parallel()
+
+	durationLimit := &controlledDurationLimit{}
+	agentBackend := &durationBlockingAgentBackend{expireDuration: durationLimit.Expire}
+	workspaceBackend := &fakeMergeWorkspaceBackend{
+		fakeWorkspaceBackend: fakeWorkspaceBackend{info: workspace.Info{Path: t.TempDir(), Key: "issue-merge-fallback"}},
+		prepareResult:        workspace.MergePrepareResult{Status: workspace.MergePrepareStatusConflict},
+	}
+	runner, err := NewRunner(Dependencies{
+		Workflow: config.Workflow{Config: config.Config{Agent: config.Agent{
+			MaxSessionDurationMS:       int(time.Hour / time.Millisecond),
+			MergeFallbackMaxDurationMS: 25,
+		}}},
+		Workspace:    workspaceBackend,
+		AgentBackend: agentBackend,
+		sessionLimit: durationLimit.Context,
+		turnLimit: func(ctx context.Context, _ time.Duration, _ error) (context.Context, context.CancelFunc) {
+			return ctx, func() {}
+		},
+	})
+	if err != nil {
+		t.Fatalf("NewRunner() error = %v", err)
+	}
+
+	result, err := runner.Run(t.Context(), RunRequest{
+		Issue: connector.Issue{
+			ID:          "issue-merge-fallback",
+			Identifier:  "digitaldrywood/detent#1809",
+			BranchName:  "detent/fallback",
+			PullRequest: &connector.PullRequest{State: "open", BaseRef: "main"},
+		},
+		Mode: RunModeMerge,
+	})
+	if !errors.Is(err, ErrMergeFallbackBudgetExceeded) {
+		t.Fatalf("Run() error = %v, want ErrMergeFallbackBudgetExceeded", err)
+	}
+	if result.FinalState != FinalStateMergeFallbackExceeded {
+		t.Fatalf("FinalState = %q, want %q", result.FinalState, FinalStateMergeFallbackExceeded)
+	}
+	if result.Output != "workingworkingworking" {
+		t.Fatalf("Output = %q, want bounded partial findings", result.Output)
+	}
+	if durationLimit.duration != 25*time.Millisecond || !errors.Is(durationLimit.limit, ErrMergeFallbackBudgetExceeded) {
+		t.Fatalf("fallback limit = (%s, %v), want (25ms, ErrMergeFallbackBudgetExceeded)", durationLimit.duration, durationLimit.limit)
+	}
+	if agentBackend.request.MaxDuration != 25*time.Millisecond {
+		t.Fatalf("AgentTurnRequest.MaxDuration = %s, want 25ms", agentBackend.request.MaxDuration)
+	}
+	if workspaceBackend.prepareCalls != 1 {
+		t.Fatalf("PrepareMerge() calls = %d, want only the initial conflict precheck", workspaceBackend.prepareCalls)
+	}
+}
+
+func TestRunnerMergeFallbackBudgetExpiresDuringReverification(t *testing.T) {
+	t.Parallel()
+
+	durationLimit := &controlledDurationLimit{}
+	workspaceBackend := &fakeMergeWorkspaceBackend{
+		fakeWorkspaceBackend: fakeWorkspaceBackend{info: workspace.Info{Path: t.TempDir(), Key: "issue-merge-fallback-verify"}},
+		prepareFunc: func(ctx context.Context, call int) (workspace.MergePrepareResult, error) {
+			if call == 0 {
+				return workspace.MergePrepareResult{Status: workspace.MergePrepareStatusConflict}, nil
+			}
+			durationLimit.Expire()
+			<-ctx.Done()
+			return workspace.MergePrepareResult{}, ctx.Err()
+		},
+	}
+	runner, err := NewRunner(Dependencies{
+		Workflow: config.Workflow{Config: config.Config{Agent: config.Agent{
+			MergeFallbackMaxDurationMS: 25,
+		}}},
+		Workspace: workspaceBackend,
+		AgentBackend: &fakeCodexClient{updates: []AgentUpdate{{
+			Type:  AgentUpdateMessageDelta,
+			Delta: "Resolved the conflict.\nDETENT_MERGE_FALLBACK: resolved",
+		}}},
+		sessionLimit: durationLimit.Context,
+	})
+	if err != nil {
+		t.Fatalf("NewRunner() error = %v", err)
+	}
+
+	result, err := runner.Run(t.Context(), RunRequest{
+		Issue: connector.Issue{
+			ID:          "issue-merge-fallback-verify",
+			Identifier:  "digitaldrywood/detent#1809",
+			BranchName:  "detent/fallback",
+			PullRequest: &connector.PullRequest{State: "open", BaseRef: "main"},
+		},
+		Mode: RunModeMerge,
+	})
+	if !errors.Is(err, ErrMergeFallbackBudgetExceeded) {
+		t.Fatalf("Run() error = %v, want ErrMergeFallbackBudgetExceeded", err)
+	}
+	if result.FinalState != FinalStateMergeFallbackExceeded {
+		t.Fatalf("FinalState = %q, want %q", result.FinalState, FinalStateMergeFallbackExceeded)
+	}
+	if result.MergeFallbackFindings == "" {
+		t.Fatal("MergeFallbackFindings is empty")
+	}
+	if workspaceBackend.prepareCalls != 2 {
+		t.Fatalf("PrepareMerge() calls = %d, want initial precheck and re-verification", workspaceBackend.prepareCalls)
+	}
+}
+
 func TestRunAgentBackendTurnPreservesParentCancellation(t *testing.T) {
 	t.Parallel()
 

--- a/internal/runner/prompt.go
+++ b/internal/runner/prompt.go
@@ -238,12 +238,20 @@ func BuildMergeFallbackPrompt(workflow config.Workflow, issue connector.Issue, o
 		b.WriteString(strings.TrimSpace(issue.PullRequest.URL))
 		b.WriteString("\n")
 	}
-	b.WriteString("\nYour task is only to finish the merge-worker handoff:\n")
+	b.WriteString("\nComplete these phases in order. Detent checks your final status before it can continue.\n\n")
+	b.WriteString("### Phase 1: resolve the rebase\n\n")
 	b.WriteString("- Re-run the fetch/rebase onto the target branch if needed.\n")
-	b.WriteString("- Resolve merge conflicts or other rebase blockers without unrelated refactors.\n")
-	b.WriteString("- Run the focused merge gate when the branch is source-clean; run the full configured gate if you edit code, resolve conflicts, or validation state is stale.\n")
-	b.WriteString("- Push the branch with lease protection after a successful rebase; never use an unguarded force-push.\n")
-	b.WriteString("- Leave the issue in Merging with a concrete blocker if the merge cannot continue without human action.\n")
+	b.WriteString("- Resolve only merge conflicts or blockers required by the rebase.\n")
+	b.WriteString("- Do not perform general code review, investigate unrelated correctness findings, or make unrelated refactors.\n")
+	b.WriteString("- If you discover work beyond conflict resolution, record it in your final response and stop.\n\n")
+	b.WriteString("### Phase 2: re-verify the resolved head\n\n")
+	b.WriteString("- Start this phase only after the rebase is conflict-free and the workspace is source-clean.\n")
+	b.WriteString("- Run the focused merge gate when current validation remains valid; run the full configured gate if you edit code, resolve conflicts, or validation state is stale.\n")
+	b.WriteString("- Push with lease protection after the gate passes; never use an unguarded force-push.\n")
+	b.WriteString("- Do not merge the pull request or change the issue state. Detent re-checks the branch and performs the handoff.\n\n")
+	b.WriteString("End your final response with exactly one of these lines:\n")
+	b.WriteString("- `DETENT_MERGE_FALLBACK: resolved` only after both phases succeed.\n")
+	b.WriteString("- `DETENT_MERGE_FALLBACK: rework` when conflict resolution, verification, or an out-of-scope finding requires normal Rework.\n")
 
 	prompt := prependWorkspaceIsolationBlock(b.String(), workflow.Config, opts.WorkspacePath, opts.Branch)
 	var err error
@@ -260,10 +268,11 @@ func BuildMergeFallbackPrompt(workflow config.Workflow, issue connector.Issue, o
 	prompt = appendBlockedHandoffBlock(prompt)
 	prompt = appendGateBlock(prompt, workflow.Config)
 	prompt = appendAvailableSkills(prompt, AvailableSkillsBlock(opts.AvailableSkills))
-	if promptDeliverableKind(workflow.Config.Deliverable) != config.DeliverablePullRequest {
-		return prompt, nil
+	if promptDeliverableKind(workflow.Config.Deliverable) == config.DeliverablePullRequest {
+		prompt = appendClosingReferenceInstruction(prompt, issue)
 	}
-	return appendClosingReferenceInstruction(prompt, issue), nil
+	prompt = strings.TrimRight(prompt, " \t\r\n") + "\n\n## Merge-fallback enforcement\n\nBroader workflow instructions above do not authorize general review or unrelated fixes in this session. Detent accepts resolution only when your final response ends with `DETENT_MERGE_FALLBACK: resolved` and its deterministic recheck finds a clean head. Otherwise end with `DETENT_MERGE_FALLBACK: rework`."
+	return prompt, nil
 }
 
 func BuildValidatorPrompt(workflow config.Workflow, issue connector.Issue, opts ValidatorPromptOptions) string {

--- a/internal/runner/runner_test.go
+++ b/internal/runner/runner_test.go
@@ -2752,7 +2752,7 @@ func TestRunnerMergeModeConflictUsesFocusedPrompt(t *testing.T) {
 	}
 	runner, err := NewRunner(Dependencies{
 		Workflow: config.Workflow{
-			Config: config.Config{},
+			Config: config.Config{Agent: config.Agent{MergeFallbackMaxDurationMS: 20 * 60 * 1000}},
 			Prompt: "Full implement workflow playbook for {{ issue.identifier }}",
 		},
 		Workspace:    workspaceBackend,
@@ -2783,7 +2783,9 @@ func TestRunnerMergeModeConflictUsesFocusedPrompt(t *testing.T) {
 		"merge-worker fallback",
 		"Deterministic merge pre-check status: conflict",
 		"CONFLICT (content): Merge conflict in README.md",
-		"Re-run the fetch/rebase onto the target branch",
+		"Do not perform general code review",
+		"DETENT_MERGE_FALLBACK: resolved",
+		"DETENT_MERGE_FALLBACK: rework",
 		"https://github.com/digitaldrywood/detent/pull/900",
 	} {
 		if !strings.Contains(prompt, want) {
@@ -2792,6 +2794,113 @@ func TestRunnerMergeModeConflictUsesFocusedPrompt(t *testing.T) {
 	}
 	if strings.Contains(prompt, "Full implement workflow playbook") {
 		t.Fatalf("prompt included full workflow playbook:\n%s", prompt)
+	}
+	if codexClient.request.MaxDuration != 20*time.Minute {
+		t.Fatalf("merge fallback MaxDuration = %s, want 20m", codexClient.request.MaxDuration)
+	}
+	if !strings.HasSuffix(prompt, "Otherwise end with `DETENT_MERGE_FALLBACK: rework`.") {
+		t.Fatalf("prompt does not end with merge-fallback enforcement:\n%s", prompt)
+	}
+}
+
+func TestRunnerMergeFallbackOutcomes(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name             string
+		agentOutput      string
+		verification     workspace.MergePrepareResult
+		wantOutput       string
+		wantPrepareCalls int
+		wantHeadPushed   bool
+	}{
+		{
+			name:             "resolved conflict is deterministically reverified",
+			agentOutput:      "Resolved the README conflict and passed make check.\nDETENT_MERGE_FALLBACK: resolved",
+			verification:     workspace.MergePrepareResult{Status: workspace.MergePrepareStatusClean, HeadChanged: true},
+			wantOutput:       RunOutputMergeFallbackResolved,
+			wantPrepareCalls: 2,
+			wantHeadPushed:   true,
+		},
+		{
+			name:             "review finding exits to rework without investigation",
+			agentOutput:      "Found an unrelated authorization defect; no investigation performed.\nDETENT_MERGE_FALLBACK: rework",
+			wantOutput:       RunOutputMergeFallbackRework,
+			wantPrepareCalls: 1,
+		},
+		{
+			name:             "missing structured outcome exits to rework",
+			agentOutput:      "I completed another review pass.",
+			wantOutput:       RunOutputMergeFallbackRework,
+			wantPrepareCalls: 1,
+		},
+		{
+			name:             "ambiguous structured outcome exits to rework",
+			agentOutput:      "DETENT_MERGE_FALLBACK: rework\nDETENT_MERGE_FALLBACK: resolved",
+			wantOutput:       RunOutputMergeFallbackRework,
+			wantPrepareCalls: 1,
+		},
+		{
+			name:             "still-conflicted branch exits to rework",
+			agentOutput:      "Resolved the conflict.\nDETENT_MERGE_FALLBACK: resolved",
+			verification:     workspace.MergePrepareResult{Status: workspace.MergePrepareStatusConflict, Message: "README.md still conflicts"},
+			wantOutput:       RunOutputMergeFallbackRework,
+			wantPrepareCalls: 2,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			workspaceBackend := &fakeMergeWorkspaceBackend{
+				fakeWorkspaceBackend: fakeWorkspaceBackend{info: workspace.Info{Path: t.TempDir(), Branch: "detent/fallback"}},
+				prepareResults: []workspace.MergePrepareResult{
+					{Status: workspace.MergePrepareStatusConflict, Message: "README.md conflicts"},
+					tt.verification,
+				},
+			}
+			agentBackend := &fakeCodexClient{updates: []AgentUpdate{{Type: AgentUpdateMessageDelta, Delta: tt.agentOutput}}}
+			runner, err := NewRunner(Dependencies{
+				Workflow:     config.Workflow{Config: config.Config{Agent: config.Agent{MergeFallbackMaxDurationMS: 20 * 60 * 1000}}},
+				Workspace:    workspaceBackend,
+				AgentBackend: agentBackend,
+			})
+			if err != nil {
+				t.Fatalf("NewRunner() error = %v", err)
+			}
+
+			result, err := runner.Run(t.Context(), RunRequest{
+				Issue: connector.Issue{
+					ID:         "issue-fallback",
+					Identifier: "digitaldrywood/detent#1809",
+					BranchName: "detent/fallback",
+					PullRequest: &connector.PullRequest{
+						State:   "open",
+						BaseRef: "main",
+					},
+				},
+				Mode: RunModeMerge,
+			})
+			if err != nil {
+				t.Fatalf("Run() error = %v", err)
+			}
+			if result.Output != tt.wantOutput {
+				t.Fatalf("Run().Output = %q, want %q", result.Output, tt.wantOutput)
+			}
+			if result.MergeFallbackFindings != tt.agentOutput {
+				t.Fatalf("MergeFallbackFindings = %q, want agent output", result.MergeFallbackFindings)
+			}
+			if workspaceBackend.prepareCalls != tt.wantPrepareCalls {
+				t.Fatalf("PrepareMerge() calls = %d, want %d", workspaceBackend.prepareCalls, tt.wantPrepareCalls)
+			}
+			if result.PullRequestHeadPushed != tt.wantHeadPushed {
+				t.Fatalf("PullRequestHeadPushed = %t, want %t", result.PullRequestHeadPushed, tt.wantHeadPushed)
+			}
+			if workspaceBackend.prepareOptions.TargetBranch != "main" {
+				t.Fatalf("verification target branch = %q, want main", workspaceBackend.prepareOptions.TargetBranch)
+			}
+		})
 	}
 }
 
@@ -5077,19 +5186,34 @@ func (b *fakeWorkspaceBackend) DiffStat(context.Context, workspace.Info, workspa
 type fakeMergeWorkspaceBackend struct {
 	fakeWorkspaceBackend
 	prepareResult  workspace.MergePrepareResult
+	prepareResults []workspace.MergePrepareResult
 	prepareErr     error
+	prepareFunc    func(context.Context, int) (workspace.MergePrepareResult, error)
 	prepareCalled  bool
+	prepareCalls   int
 	prepareOptions workspace.MergePrepareOptions
 }
 
 func (b *fakeMergeWorkspaceBackend) PrepareMerge(
-	_ context.Context,
+	ctx context.Context,
 	_ workspace.Info,
 	_ workspace.Issue,
 	opts workspace.MergePrepareOptions,
 ) (workspace.MergePrepareResult, error) {
 	b.prepareCalled = true
 	b.prepareOptions = opts
+	call := b.prepareCalls
+	b.prepareCalls++
+	if b.prepareFunc != nil {
+		return b.prepareFunc(ctx, call)
+	}
+	if len(b.prepareResults) > 0 {
+		index := call
+		if index >= len(b.prepareResults) {
+			index = len(b.prepareResults) - 1
+		}
+		return b.prepareResults[index], b.prepareErr
+	}
 	return b.prepareResult, b.prepareErr
 }
 

--- a/internal/runner/supervisor.go
+++ b/internal/runner/supervisor.go
@@ -212,6 +212,7 @@ func cooperativeStopError(err error) bool {
 		errors.Is(err, ErrModelPermitUnavailable) ||
 		errors.Is(err, ErrMergeWorkerStartupTimeout) ||
 		errors.Is(err, ErrMergeWorkerDurationExceeded) ||
+		errors.Is(err, ErrMergeFallbackBudgetExceeded) ||
 		errors.Is(err, ErrSessionDurationExceeded) ||
 		errors.Is(err, ErrSessionTurnLimitExceeded) ||
 		errors.Is(err, ErrSessionNoProgress)

--- a/internal/runner/types.go
+++ b/internal/runner/types.go
@@ -26,6 +26,7 @@ const (
 	FinalStateMergeRevoked          = "merge_revoked"
 	FinalStateCIUnavailable         = "ci_unavailable"
 	FinalStateMergeDurationExceeded = "merge_duration_exceeded"
+	FinalStateMergeFallbackExceeded = "merge_fallback_budget_exceeded"
 	FinalStateNeedsHumanAttention   = "needs_human_attention"
 	TokenCeilingSourceAbsolute      = "max_session_tokens"
 	TokenCeilingSourceContextWindow = "max_session_context_multiplier"
@@ -38,6 +39,8 @@ const (
 	RunOutputMergeFastPathClean       = "merge_fast_path_clean"
 	RunOutputMergeFastPathCheckedHead = "merge_fast_path_checked_head"
 	RunOutputMergeFallbackDeferred    = "merge_fallback_deferred"
+	RunOutputMergeFallbackResolved    = "merge_fallback_resolved"
+	RunOutputMergeFallbackRework      = "merge_fallback_rework"
 )
 
 var (
@@ -49,6 +52,7 @@ var (
 	ErrCIUnavailable                = errors.New("CI unavailable")
 	ErrMergeWorkerStartupTimeout    = errors.New("merge worker startup timed out")
 	ErrMergeWorkerDurationExceeded  = errors.New("merge worker duration exceeded")
+	ErrMergeFallbackBudgetExceeded  = errors.New("merge fallback budget exceeded")
 	ErrModelPermitUnavailable       = errors.New("provider model permit unavailable")
 	ErrAgentTurnCleanup             = errors.New("agent turn cleanup failed")
 	ErrAgentResumeUnsupported       = errors.New("agent backend does not support resume verification")
@@ -510,6 +514,7 @@ type RunResult struct {
 	PullRequestHeadPushed   bool
 	CITriggerLabelReapplied bool
 	MergePrecheck           *MergePrecheck
+	MergeFallbackFindings   string
 	budgetProjection        *dispatchBudgetProjection
 }
 


### PR DESCRIPTION
## Summary

- scope merge-fallback agents to conflict resolution and ordered re-verification
- enforce a machine-checked resolved/rework outcome with a configurable 20-minute default budget
- route unresolved work or budget exhaustion to Rework with preserved findings
- leave checked clean heads on the existing no-agent fast path

Fixes #1809

## UI Surface Contract

- [x] N/A, or the linked issue explicitly authorizes any high-impact UI surface, layout, density, first-viewport, or responsive visibility tradeoff.
- [x] Persistent top-of-screen messaging is explicitly authorized by the issue, or this PR does not add it.
- [x] Visual changes to primary operator screens include screenshot or browser verification below. (N/A: no UI changes.)

## Test Plan

- [x] `make check`