### PR TITLE
fix(claude): classify session-limit output as backend capacity

### DIFF
--- a/internal/backendcapacity/capacity.go
+++ b/internal/backendcapacity/capacity.go
@@ -27,7 +27,7 @@ const (
 	ErrorTypeTransientOverload ErrorType = "transient_overload"
 )
 
-var retryAtPattern = regexp.MustCompile(`(?i)(?:try again|resets?)\s+at\s+([0-9]{1,2}:[0-9]{2}\s*(?:am|pm))`)
+var retryAtPattern = regexp.MustCompile(`(?i)(?:try again|resets?)\s+(?:at\s+)?([0-9]{1,2}:[0-9]{2}\s*(?:am|pm))(?:\s*\(([A-Za-z0-9._+-]+(?:/[A-Za-z0-9._+-]+)*)\))?`)
 var http5xxPattern = regexp.MustCompile(`(?i)(?:http(?:/[0-9.]+)?\s+|status(?:[\s_-]*code)?["']?\s*[:=]?\s*)(5[0-9]{2})\b`)
 
 type Scope struct {
@@ -219,17 +219,26 @@ func resetFromText(text string, now time.Time) *time.Time {
 		}
 	}
 	match := retryAtPattern.FindStringSubmatch(text)
-	if len(match) != 2 {
+	if len(match) != 3 {
 		return nil
 	}
 	location := now.Location()
-	parsed, err := time.ParseInLocation("3:04 PM", strings.ToUpper(strings.TrimSpace(match[1])), location)
+	if timezone := strings.TrimSpace(match[2]); timezone != "" {
+		var err error
+		location, err = time.LoadLocation(timezone)
+		if err != nil {
+			return nil
+		}
+	}
+	now = now.In(location)
+	clock := strings.ToUpper(strings.Join(strings.Fields(match[1]), ""))
+	parsed, err := time.ParseInLocation("3:04PM", clock, location)
 	if err != nil {
 		return nil
 	}
 	resetAt := time.Date(now.Year(), now.Month(), now.Day(), parsed.Hour(), parsed.Minute(), 0, 0, location)
 	if !resetAt.After(now) {
-		resetAt = resetAt.Add(24 * time.Hour)
+		resetAt = resetAt.AddDate(0, 0, 1)
 	}
 	resetAt = resetAt.UTC()
 	return &resetAt

--- a/internal/backendcapacity/capacity_test.go
+++ b/internal/backendcapacity/capacity_test.go
@@ -131,3 +131,54 @@ func TestClassifyUsageLimitCanRequireReset(t *testing.T) {
 		t.Fatalf("Classify() = %#v, %v, want reset-bearing usage limit", details, ok)
 	}
 }
+
+func TestResetFromText(t *testing.T) {
+	t.Parallel()
+
+	chicago, err := time.LoadLocation("America/Chicago")
+	if err != nil {
+		t.Fatalf("LoadLocation() error = %v", err)
+	}
+	tests := []struct {
+		name string
+		text string
+		now  time.Time
+		want time.Time
+	}{
+		{
+			name: "try again at local time",
+			text: "You've hit your limit. Try again at 9:39 PM",
+			now:  time.Date(2026, 8, 15, 15, 47, 49, 0, chicago),
+			want: time.Date(2026, 8, 16, 2, 39, 0, 0, time.UTC),
+		},
+		{
+			name: "resets at local time",
+			text: "resets at 4:10pm",
+			now:  time.Date(2026, 8, 15, 15, 47, 49, 0, chicago),
+			want: time.Date(2026, 8, 15, 21, 10, 0, 0, time.UTC),
+		},
+		{
+			name: "resets in explicit IANA timezone",
+			text: "resets 4:10pm (America/Chicago)",
+			now:  time.Date(2026, 8, 15, 20, 47, 49, 0, time.UTC),
+			want: time.Date(2026, 8, 15, 21, 10, 0, 0, time.UTC),
+		},
+		{
+			name: "resets in single-component IANA timezone",
+			text: "resets 4:10pm (UTC)",
+			now:  time.Date(2026, 8, 15, 15, 47, 49, 0, time.UTC),
+			want: time.Date(2026, 8, 15, 16, 10, 0, 0, time.UTC),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := resetFromText(tt.text, tt.now)
+			if got == nil || !got.Equal(tt.want) {
+				t.Fatalf("resetFromText() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/claudecode/capacity.go
+++ b/internal/claudecode/capacity.go
@@ -1,6 +1,7 @@
 package claudecode
 
 import (
+	"strings"
 	"time"
 
 	"github.com/digitaldrywood/detent/internal/backendcapacity"
@@ -61,7 +62,19 @@ func claudeCapacityResetAt(limits *telemetry.RateLimits) *time.Time {
 	if limits == nil {
 		return nil
 	}
-	for _, bucket := range []*telemetry.RateLimitBucket{limits.Primary, limits.Secondary} {
+	buckets := []*telemetry.RateLimitBucket{limits.Primary, limits.Secondary}
+	reachedType := strings.TrimSpace(limits.ReachedType)
+	if reachedType != "" && !strings.EqualFold(reachedType, "five_hour") {
+		buckets[0], buckets[1] = buckets[1], buckets[0]
+	}
+	for _, bucket := range buckets {
+		if bucket == nil || bucket.ResetAt == nil || bucket.Status != telemetry.RateLimitStatusExhausted {
+			continue
+		}
+		resetAt := bucket.ResetAt.UTC()
+		return &resetAt
+	}
+	for _, bucket := range buckets {
 		if bucket == nil || bucket.ResetAt == nil {
 			continue
 		}

--- a/internal/claudecode/capacity.go
+++ b/internal/claudecode/capacity.go
@@ -20,6 +20,7 @@ var claudeCapacityRules = backendcapacity.Rules{
 		"usage limit reached",
 		"rate limit reached",
 		"you've hit your limit",
+		"you've hit your session limit",
 		"quota exceeded",
 	},
 	RequireReset: true,

--- a/internal/claudecode/capacity_test.go
+++ b/internal/claudecode/capacity_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/digitaldrywood/detent/internal/backendcapacity"
+	"github.com/digitaldrywood/detent/internal/telemetry"
 )
 
 func TestAgentBackendClassifyCapacityError(t *testing.T) {
@@ -53,5 +54,56 @@ func TestClassifyCapacityErrorProductionSessionLimit(t *testing.T) {
 	want := time.Date(2026, 8, 15, 21, 10, 0, 0, time.UTC)
 	if details.Type != backendcapacity.ErrorTypeUsageLimit || details.ResetAt == nil || !details.ResetAt.Equal(want) {
 		t.Fatalf("ClassifyCapacityError() = %#v, want usage limit reset at %s", details, want)
+	}
+}
+
+func TestClaudeCapacityResetAtUsesReachedWindow(t *testing.T) {
+	t.Parallel()
+
+	primaryReset := time.Date(2026, 8, 15, 21, 10, 0, 0, time.UTC)
+	secondaryReset := time.Date(2026, 8, 22, 21, 10, 0, 0, time.UTC)
+	tests := []struct {
+		name            string
+		reachedType     string
+		primaryStatus   string
+		secondaryStatus string
+		want            time.Time
+	}{
+		{
+			name:            "five-hour window",
+			reachedType:     "five_hour",
+			primaryStatus:   telemetry.RateLimitStatusExhausted,
+			secondaryStatus: telemetry.RateLimitStatusUnknown,
+			want:            primaryReset,
+		},
+		{
+			name:            "weekly window",
+			reachedType:     "seven_day",
+			primaryStatus:   telemetry.RateLimitStatusUnknown,
+			secondaryStatus: telemetry.RateLimitStatusExhausted,
+			want:            secondaryReset,
+		},
+		{name: "missing reached type", want: primaryReset},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := claudeCapacityResetAt(&telemetry.RateLimits{
+				ReachedType: tt.reachedType,
+				Primary: &telemetry.RateLimitBucket{
+					Status:  tt.primaryStatus,
+					ResetAt: &primaryReset,
+				},
+				Secondary: &telemetry.RateLimitBucket{
+					Status:  tt.secondaryStatus,
+					ResetAt: &secondaryReset,
+				},
+			})
+			if got == nil || !got.Equal(tt.want) {
+				t.Fatalf("claudeCapacityResetAt() = %v, want %s", got, tt.want)
+			}
+		})
 	}
 }

--- a/internal/claudecode/capacity_test.go
+++ b/internal/claudecode/capacity_test.go
@@ -5,6 +5,8 @@ import (
 	"errors"
 	"testing"
 	"time"
+
+	"github.com/digitaldrywood/detent/internal/backendcapacity"
 )
 
 func TestAgentBackendClassifyCapacityError(t *testing.T) {
@@ -33,5 +35,23 @@ func TestAgentBackendClassifyCapacityError(t *testing.T) {
 				t.Fatalf("ClassifyCapacityError() ok = %v, want %v", ok, tt.want)
 			}
 		})
+	}
+}
+
+func TestClassifyCapacityErrorProductionSessionLimit(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 8, 15, 20, 47, 49, 0, time.UTC)
+	details, ok := ClassifyCapacityError(
+		errors.New("You've hit your session limit · resets 4:10pm (America/Chicago)"),
+		nil,
+		now,
+	)
+	if !ok {
+		t.Fatal("ClassifyCapacityError() ok = false, want true")
+	}
+	want := time.Date(2026, 8, 15, 21, 10, 0, 0, time.UTC)
+	if details.Type != backendcapacity.ErrorTypeUsageLimit || details.ResetAt == nil || !details.ResetAt.Equal(want) {
+		t.Fatalf("ClassifyCapacityError() = %#v, want usage limit reset at %s", details, want)
 	}
 }

--- a/internal/claudecode/stream.go
+++ b/internal/claudecode/stream.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/digitaldrywood/detent/internal/agentidentity"
 	"github.com/digitaldrywood/detent/internal/runner"
+	"github.com/digitaldrywood/detent/internal/telemetry"
 )
 
 type streamItem struct {
@@ -34,6 +35,14 @@ type claudeEvent struct {
 	Result       string         `json:"result"`
 	DurationMS   int64          `json:"duration_ms"`
 	TotalCostUSD float64        `json:"total_cost_usd"`
+	RateLimit    *rateLimitInfo `json:"rate_limit_info"`
+}
+
+type rateLimitInfo struct {
+	Status        string  `json:"status"`
+	ResetsAt      int64   `json:"resetsAt"`
+	RateLimitType string  `json:"rateLimitType"`
+	Utilization   float64 `json:"utilization"`
 }
 
 type claudeMessage struct {
@@ -143,6 +152,8 @@ func (s *turnState) apply(event claudeEvent, includePartialMessages bool, onUpda
 			return err
 		}
 		return s.applyStreamEvent(event, includePartialMessages, onUpdate)
+	case "rate_limit_event":
+		return s.applyRateLimit(event, onUpdate)
 	case "result":
 		if err := s.emitModelChange(previousModel, onUpdate); err != nil {
 			return err
@@ -151,6 +162,43 @@ func (s *turnState) apply(event claudeEvent, includePartialMessages bool, onUpda
 	default:
 		return nil
 	}
+}
+
+func (s *turnState) applyRateLimit(event claudeEvent, onUpdate runner.AgentUpdateHandler) error {
+	if event.RateLimit == nil {
+		return nil
+	}
+	info := event.RateLimit
+	bucket := &telemetry.RateLimitBucket{Status: strings.TrimSpace(info.Status)}
+	if strings.EqualFold(bucket.Status, "rejected") {
+		bucket.Status = telemetry.RateLimitStatusExhausted
+	}
+	if info.ResetsAt > 0 {
+		resetAt := time.Unix(info.ResetsAt, 0).UTC()
+		bucket.ResetAt = &resetAt
+	}
+	if info.Utilization > 0 {
+		bucket.Limit = 100
+		bucket.Used = min(max(int64(info.Utilization*100), 0), 100)
+		bucket.Remaining = 100 - bucket.Used
+	}
+	limitType := strings.TrimSpace(info.RateLimitType)
+	limits := &telemetry.RateLimits{LimitID: "claude", LimitName: "Claude"}
+	if strings.EqualFold(strings.TrimSpace(info.Status), "rejected") {
+		limits.ReachedType = limitType
+	}
+	if limitType == "" || strings.EqualFold(limitType, "five_hour") {
+		limits.Primary = bucket
+	} else {
+		limits.Secondary = bucket
+	}
+	return emitUpdate(onUpdate, runner.AgentUpdate{
+		Type:       runner.AgentUpdateRateLimits,
+		ThreadID:   s.sessionID,
+		TurnID:     s.sessionID,
+		Model:      s.model,
+		RateLimits: limits,
+	})
 }
 
 func (s *turnState) applyInit(event claudeEvent, onUpdate runner.AgentUpdateHandler) error {
@@ -337,7 +385,7 @@ func (s *turnState) applyResult(event claudeEvent, onUpdate runner.AgentUpdateHa
 	s.resultSubtype = event.Subtype
 	s.resultText = strings.TrimSpace(event.Result)
 	s.resultIsError = event.IsError
-	// Non-goals: --resume continuity, rate-limit telemetry, and total_cost_usd budget ingest.
+	// Non-goals: --resume continuity and total_cost_usd budget ingest.
 	if event.Usage != nil && !event.Usage.empty() {
 		s.usage = event.Usage.agentUsage()
 		return s.emitUsage(onUpdate)

--- a/internal/claudecode/stream_activity_test.go
+++ b/internal/claudecode/stream_activity_test.go
@@ -3,9 +3,35 @@ package claudecode
 import (
 	"encoding/json"
 	"testing"
+	"time"
 
 	"github.com/digitaldrywood/detent/internal/runner"
+	"github.com/digitaldrywood/detent/internal/telemetry"
 )
+
+func TestTurnStateEmitsStructuredRateLimit(t *testing.T) {
+	t.Parallel()
+
+	var event claudeEvent
+	if err := json.Unmarshal([]byte(`{"type":"rate_limit_event","rate_limit_info":{"status":"rejected","resetsAt":1786828200,"rateLimitType":"five_hour","overageStatus":"rejected","overageDisabledReason":"out_of_credits","isUsingOverage":false},"session_id":"session-capacity"}`), &event); err != nil {
+		t.Fatalf("Unmarshal() error = %v", err)
+	}
+	var updates []runner.AgentUpdate
+	if err := (&turnState{}).apply(event, false, func(update runner.AgentUpdate) error {
+		updates = append(updates, update)
+		return nil
+	}); err != nil {
+		t.Fatalf("apply() error = %v", err)
+	}
+	if len(updates) != 1 || updates[0].Type != runner.AgentUpdateRateLimits || updates[0].RateLimits == nil {
+		t.Fatalf("updates = %#v, want one rate limit update", updates)
+	}
+	limits := updates[0].RateLimits
+	wantReset := time.Unix(1786828200, 0).UTC()
+	if limits.ReachedType != "five_hour" || limits.Primary == nil || limits.Primary.Status != telemetry.RateLimitStatusExhausted || limits.Primary.ResetAt == nil || !limits.Primary.ResetAt.Equal(wantReset) {
+		t.Fatalf("RateLimits = %#v, want exhausted five-hour limit reset at %s", limits, wantReset)
+	}
+}
 
 func TestTurnStateEmitsToolContent(t *testing.T) {
 	t.Parallel()

--- a/internal/orchestrator/backend_capacity_test.go
+++ b/internal/orchestrator/backend_capacity_test.go
@@ -11,12 +11,55 @@ import (
 	"time"
 
 	"github.com/digitaldrywood/detent/internal/backendcapacity"
+	"github.com/digitaldrywood/detent/internal/claudecode"
 	"github.com/digitaldrywood/detent/internal/connector"
 	"github.com/digitaldrywood/detent/internal/gate"
 	runpkg "github.com/digitaldrywood/detent/internal/runner"
 	"github.com/digitaldrywood/detent/internal/store"
 	"github.com/digitaldrywood/detent/internal/telemetry"
 )
+
+func TestProductionClaudeSessionLimitRecordsOneCapacityOutage(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 8, 15, 20, 47, 49, 0, time.UTC)
+	scope := backendcapacity.Scope{BackendID: "claude-video", BackendKind: "claude_code", Provider: "anthropic"}
+	cfg := normalizeConfig(Config{
+		ActiveStates:   []string{"In Progress"},
+		TerminalStates: []string{"Done"},
+		FailureBreaker: FailureBreakerConfig{SameClassLimit: 5, Window: time.Hour, Cooldown: time.Hour},
+	})
+	orch := &Orchestrator{cfg: cfg}
+	state := newState(cfg)
+	message := "You've hit your session limit · resets 4:10pm (America/Chicago)"
+	issue := connector.Issue{ID: "issue-capacity", State: "In Progress"}
+
+	for attempt := 1; attempt <= 5; attempt++ {
+		state.Running[issue.ID] = Running{Issue: issue, Attempt: attempt, StartedAt: now.Add(-time.Minute)}
+		state.Claimed[issue.ID] = Claimed{Issue: issue, ClaimedAt: now.Add(-time.Minute)}
+		details, ok := claudecode.ClassifyCapacityError(errors.New(message), nil, now)
+		if !ok {
+			t.Fatalf("attempt %d did not classify production output as capacity", attempt)
+		}
+		capacityErr := backendcapacity.NewError(scope, details, errors.New(message))
+		orch.handleRunResult(t.Context(), &state, runpkg.Completion{
+			IssueID:     issue.ID,
+			Request:     runpkg.RunRequest{Issue: issue, Attempt: attempt},
+			Err:         capacityErr,
+			CompletedAt: now,
+		})
+	}
+
+	if len(state.BackendOutages) != 1 {
+		t.Fatalf("BackendOutages = %#v, want one scoped outage", state.BackendOutages)
+	}
+	if state.FailureBreaker.Active() || len(state.FailureBreaker.Failures) != 0 {
+		t.Fatalf("FailureBreaker = %#v, want no capacity strikes", state.FailureBreaker)
+	}
+	if len(state.InstantFailures) != 0 || len(state.RepeatedFailures) != 0 {
+		t.Fatalf("issue failure breakers = instant %#v repeated %#v, want no capacity strikes", state.InstantFailures, state.RepeatedFailures)
+	}
+}
 
 func TestBackendCapacityDispatchAllowsOneResetProbe(t *testing.T) {
 	t.Parallel()

--- a/internal/orchestrator/run_completion.go
+++ b/internal/orchestrator/run_completion.go
@@ -209,7 +209,7 @@ func (o *Orchestrator) handleRunResult(ctx context.Context, state *State, event 
 			o.handleTransientOverload(ctx, state, event, running, capacityErr)
 			return
 		}
-		o.recordProjectAttemptOutcome(state, event.IssueID, event.CompletedAt, store.WorkAttemptTerminalFailure, event.Err, "backend_capacity", errorString(event.Err))
+		o.recordProjectAttemptOutcome(state, event.IssueID, event.CompletedAt, store.WorkAttemptTerminalCapacity, event.Err, "backend_capacity", errorString(event.Err))
 		o.handleBackendCapacityError(ctx, state, event, running, capacityErr)
 		return
 	}


### PR DESCRIPTION
## Summary

- ingest Claude Code's structured `rate_limit_event` reset signal from `stream-json`
- classify the documented session-limit fallback and parse optional `at` plus explicit IANA timezones
- keep usage-capacity completions out of generic project and issue failure-breaker accounting

Fixes #1814

## UI Surface Contract

- [x] N/A; this PR does not change UI surfaces.
- [x] This PR does not add persistent top-of-screen messaging.
- [x] N/A; this PR has no visual changes.

## Test Plan

- [x] `go test ./internal/backendcapacity ./internal/claudecode ./internal/runner ./internal/orchestrator -count=1`
- [x] `make check` (repo-pinned golangci-lint v2.1.6; 79.0% total coverage)