### PR TITLE
fix(ops): tmux status renames its own window

### DIFF
--- a/internal/cli/boot.go
+++ b/internal/cli/boot.go
@@ -329,8 +329,9 @@ func startRunningWithDependencies(ctx context.Context, cfg BootConfig, deps star
 	snapshotHub := hub.New[telemetry.Snapshot]()
 	snapshotSeq := &atomic.Uint64{}
 	var windowStatus *tmuxstatus.Status
-	if tmuxstatus.Enabled(os.Getenv("TMUX"), cfg.Global.Ops.TmuxWindowStatus) {
-		windowStatus, err = tmuxstatus.New(runCtx)
+	tmuxPane := os.Getenv("TMUX_PANE")
+	if tmuxstatus.Enabled(os.Getenv("TMUX"), tmuxPane, cfg.Global.Ops.TmuxWindowStatus) {
+		windowStatus, err = tmuxstatus.New(runCtx, tmuxPane)
 		if err != nil {
 			logger.Warn("initialize tmux window status failed", "error", err)
 		}

--- a/internal/tmuxstatus/status.go
+++ b/internal/tmuxstatus/status.go
@@ -25,38 +25,38 @@ type Status struct {
 	closeErr     error
 }
 
-func Enabled(tmux string, configured *bool) bool {
-	if strings.TrimSpace(tmux) == "" {
+func Enabled(tmux, pane string, configured *bool) bool {
+	if strings.TrimSpace(tmux) == "" || strings.TrimSpace(pane) == "" {
 		return false
 	}
 	return configured == nil || *configured
 }
 
-func New(ctx context.Context) (*Status, error) {
-	return newStatus(ctx, execCommandRunner{})
+func New(ctx context.Context, pane string) (*Status, error) {
+	return newStatus(ctx, execCommandRunner{}, pane)
 }
 
-func newStatus(ctx context.Context, runner commandRunner) (*Status, error) {
+func newStatus(ctx context.Context, runner commandRunner, pane string) (*Status, error) {
 	if ctx == nil {
 		ctx = context.Background()
 	}
 	if runner == nil {
 		return nil, errors.New("tmux command runner is required")
 	}
+	target := strings.TrimSpace(pane)
+	if target == "" {
+		return nil, errors.New("tmux pane target is required")
+	}
 
-	current, err := runner.Output(ctx, "display-message", "-p", "#{window_id}\t#{window_name}")
+	current, err := runner.Output(ctx, "display-message", "-t", target, "-p", "#{window_name}")
 	if err != nil {
 		return nil, fmt.Errorf("read current tmux window: %w", err)
-	}
-	target, originalName, ok := strings.Cut(strings.TrimSuffix(current, "\n"), "\t")
-	if !ok || strings.TrimSpace(target) == "" {
-		return nil, errors.New("read current tmux window: unexpected response")
 	}
 
 	return &Status{
 		runner:       runner,
-		target:       strings.TrimSpace(target),
-		originalName: originalName,
+		target:       target,
+		originalName: strings.TrimSuffix(current, "\n"),
 	}, nil
 }
 

--- a/internal/tmuxstatus/status.go
+++ b/internal/tmuxstatus/status.go
@@ -48,15 +48,19 @@ func newStatus(ctx context.Context, runner commandRunner, pane string) (*Status,
 		return nil, errors.New("tmux pane target is required")
 	}
 
-	current, err := runner.Output(ctx, "display-message", "-t", target, "-p", "#{window_name}")
+	current, err := runner.Output(ctx, "display-message", "-t", target, "-p", "#{window_id}\t#{window_name}")
 	if err != nil {
 		return nil, fmt.Errorf("read current tmux window: %w", err)
+	}
+	windowID, originalName, ok := strings.Cut(strings.TrimSuffix(current, "\n"), "\t")
+	if !ok || strings.TrimSpace(windowID) == "" {
+		return nil, errors.New("read current tmux window: unexpected response")
 	}
 
 	return &Status{
 		runner:       runner,
-		target:       target,
-		originalName: strings.TrimSuffix(current, "\n"),
+		target:       strings.TrimSpace(windowID),
+		originalName: originalName,
 	}, nil
 }
 

--- a/internal/tmuxstatus/status_test.go
+++ b/internal/tmuxstatus/status_test.go
@@ -64,7 +64,7 @@ func TestFormat(t *testing.T) {
 
 func TestStatusLifecycle(t *testing.T) {
 	t.Parallel()
-	runner := &recordingRunner{output: "Detent:2\n"}
+	runner := &recordingRunner{output: "@7\tDetent:2\n"}
 	status, err := newStatus(context.Background(), runner, "%7")
 	if err != nil {
 		t.Fatalf("newStatus() error = %v", err)
@@ -89,9 +89,9 @@ func TestStatusLifecycle(t *testing.T) {
 	}
 
 	want := [][]string{
-		{"display-message", "-t", "%7", "-p", "#{window_name}"},
-		{"rename-window", "-t", "%7", "detent 2r/1q/3b"},
-		{"rename-window", "-t", "%7", "Detent:2"},
+		{"display-message", "-t", "%7", "-p", "#{window_id}\t#{window_name}"},
+		{"rename-window", "-t", "@7", "detent 2r/1q/3b"},
+		{"rename-window", "-t", "@7", "Detent:2"},
 	}
 	if !reflect.DeepEqual(runner.calls, want) {
 		t.Fatalf("commands = %#v, want %#v", runner.calls, want)
@@ -100,7 +100,7 @@ func TestStatusLifecycle(t *testing.T) {
 
 func TestStatusRetriesFailedRename(t *testing.T) {
 	t.Parallel()
-	runner := &recordingRunner{output: "Detent:2\n"}
+	runner := &recordingRunner{output: "@7\tDetent:2\n"}
 	status, err := newStatus(context.Background(), runner, "%7")
 	if err != nil {
 		t.Fatalf("newStatus() error = %v", err)
@@ -116,7 +116,7 @@ func TestStatusRetriesFailedRename(t *testing.T) {
 		t.Fatalf("retry Update() error = %v", err)
 	}
 
-	wantRename := []string{"rename-window", "-t", "%7", "detent 1r/0q/0b"}
+	wantRename := []string{"rename-window", "-t", "@7", "detent 1r/0q/0b"}
 	if len(runner.calls) != 3 || !reflect.DeepEqual(runner.calls[1], wantRename) || !reflect.DeepEqual(runner.calls[2], wantRename) {
 		t.Fatalf("commands = %#v, want two rename attempts %#v", runner.calls, wantRename)
 	}

--- a/internal/tmuxstatus/status_test.go
+++ b/internal/tmuxstatus/status_test.go
@@ -16,21 +16,24 @@ func TestEnabled(t *testing.T) {
 	tests := []struct {
 		name       string
 		tmux       string
+		pane       string
 		configured *bool
 		want       bool
 	}{
 		{name: "outside tmux defaults off", want: false},
-		{name: "outside tmux explicit on stays off", configured: &trueValue, want: false},
-		{name: "inside tmux defaults on", tmux: "/tmp/tmux-501/default,1,0", want: true},
-		{name: "inside tmux explicit on", tmux: "/tmp/tmux-501/default,1,0", configured: &trueValue, want: true},
-		{name: "inside tmux explicit off", tmux: "/tmp/tmux-501/default,1,0", configured: &falseValue, want: false},
-		{name: "blank tmux is absent", tmux: "  ", want: false},
+		{name: "outside tmux explicit on stays off", pane: "%7", configured: &trueValue, want: false},
+		{name: "inside tmux without pane stays off", tmux: "/tmp/tmux-501/default,1,0", want: false},
+		{name: "inside tmux defaults on", tmux: "/tmp/tmux-501/default,1,0", pane: "%7", want: true},
+		{name: "inside tmux explicit on", tmux: "/tmp/tmux-501/default,1,0", pane: "%7", configured: &trueValue, want: true},
+		{name: "inside tmux explicit off", tmux: "/tmp/tmux-501/default,1,0", pane: "%7", configured: &falseValue, want: false},
+		{name: "blank tmux is absent", tmux: "  ", pane: "%7", want: false},
+		{name: "blank pane is absent", tmux: "/tmp/tmux-501/default,1,0", pane: "  ", want: false},
 	}
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
-			if got := Enabled(test.tmux, test.configured); got != test.want {
+			if got := Enabled(test.tmux, test.pane, test.configured); got != test.want {
 				t.Fatalf("Enabled() = %t, want %t", got, test.want)
 			}
 		})
@@ -61,8 +64,8 @@ func TestFormat(t *testing.T) {
 
 func TestStatusLifecycle(t *testing.T) {
 	t.Parallel()
-	runner := &recordingRunner{output: "@7\tDetent:2\n"}
-	status, err := newStatus(context.Background(), runner)
+	runner := &recordingRunner{output: "Detent:2\n"}
+	status, err := newStatus(context.Background(), runner, "%7")
 	if err != nil {
 		t.Fatalf("newStatus() error = %v", err)
 	}
@@ -86,9 +89,9 @@ func TestStatusLifecycle(t *testing.T) {
 	}
 
 	want := [][]string{
-		{"display-message", "-p", "#{window_id}\t#{window_name}"},
-		{"rename-window", "-t", "@7", "detent 2r/1q/3b"},
-		{"rename-window", "-t", "@7", "Detent:2"},
+		{"display-message", "-t", "%7", "-p", "#{window_name}"},
+		{"rename-window", "-t", "%7", "detent 2r/1q/3b"},
+		{"rename-window", "-t", "%7", "Detent:2"},
 	}
 	if !reflect.DeepEqual(runner.calls, want) {
 		t.Fatalf("commands = %#v, want %#v", runner.calls, want)
@@ -97,8 +100,8 @@ func TestStatusLifecycle(t *testing.T) {
 
 func TestStatusRetriesFailedRename(t *testing.T) {
 	t.Parallel()
-	runner := &recordingRunner{output: "@7\tDetent:2\n"}
-	status, err := newStatus(context.Background(), runner)
+	runner := &recordingRunner{output: "Detent:2\n"}
+	status, err := newStatus(context.Background(), runner, "%7")
 	if err != nil {
 		t.Fatalf("newStatus() error = %v", err)
 	}
@@ -113,7 +116,7 @@ func TestStatusRetriesFailedRename(t *testing.T) {
 		t.Fatalf("retry Update() error = %v", err)
 	}
 
-	wantRename := []string{"rename-window", "-t", "@7", "detent 1r/0q/0b"}
+	wantRename := []string{"rename-window", "-t", "%7", "detent 1r/0q/0b"}
 	if len(runner.calls) != 3 || !reflect.DeepEqual(runner.calls[1], wantRename) || !reflect.DeepEqual(runner.calls[2], wantRename) {
 		t.Fatalf("commands = %#v, want two rename attempts %#v", runner.calls, wantRename)
 	}


### PR DESCRIPTION
## Summary

- require `TMUX_PANE` before enabling tmux window status
- target the caller pane when reading, renaming, and restoring the window name
- cover pane targeting and missing-pane behavior with table-driven tests

Fixes #1817

## UI Surface Contract

- [x] N/A; this PR does not change UI surfaces.
- [x] This PR does not add persistent top-of-screen messaging.
- [x] N/A; this PR has no visual changes.

## Test Plan

- [x] `go test ./internal/tmuxstatus ./internal/cli -count=1`
- [x] `PATH="$(go env GOBIN):$PATH" make check` (repo-pinned golangci-lint v2.1.6; 79.0% coverage)