### PR TITLE
perf(web): cache project state enrichment

### DIFF
--- a/docs/dashboard-api.md
+++ b/docs/dashboard-api.md
@@ -198,6 +198,11 @@ Useful endpoints:
 | `/api/v1/webhooks/github` | Accept signed GitHub webhook deliveries with `POST`. |
 | `/api/v1/<issue>` | JSON detail for a known board, pipeline, running, retrying, or blocked issue. |
 
+Project state scopes workflow metrics from the fleet snapshot enrichment cache
+instead of rerunning historical database reports for each request. The project
+diagnostics page is the opt-in detail path that loads project-specific runtime
+store evidence and history.
+
 The wildcard issue route accepts an issue ID, canonical identifier, issue URL,
 bare number, or `#number`. Add `?project=<id>` when a number or other reference
 exists in more than one project; an unscoped collision returns

--- a/internal/web/api.go
+++ b/internal/web/api.go
@@ -123,7 +123,7 @@ func (s *Server) apiProjectState(c echo.Context, projectID string) error {
 		return c.JSON(http.StatusOK, snapshotErrorResponse(now, "snapshot_unavailable", "Snapshot unavailable"))
 	}
 	snapshot = s.cachedEnrichedSnapshot(c.Request().Context(), snapshot)
-	projects := s.projectSmallMultiples(c.Request().Context(), snapshot)
+	projects := s.cachedProjectSmallMultiples(snapshot)
 	project, ok := s.dashboardProject(projectID, projects, snapshot)
 	if !ok {
 		return c.JSON(http.StatusNotFound, errorResponse("project_not_found", "Project not found"))
@@ -134,7 +134,6 @@ func (s *Server) apiProjectState(c echo.Context, projectID string) error {
 		URL:         project.URL,
 		Pool:        project.Pool,
 	})
-	scopedSnapshot.WorkflowMetrics = s.snapshotWorkflowMetrics(c.Request().Context(), scopedSnapshot)
 	scopedSnapshot = s.withManualRefresh(scopedSnapshot)
 
 	return c.JSON(http.StatusOK, stateResponse(scopedSnapshot, generatedAt(scopedSnapshot, now), s.instanceName(), s.build))

--- a/internal/web/api_benchmark_test.go
+++ b/internal/web/api_benchmark_test.go
@@ -1,0 +1,147 @@
+package web_test
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/digitaldrywood/detent/internal/hub"
+	"github.com/digitaldrywood/detent/internal/project"
+	"github.com/digitaldrywood/detent/internal/store"
+	"github.com/digitaldrywood/detent/internal/telemetry"
+	"github.com/digitaldrywood/detent/internal/web"
+)
+
+func BenchmarkProjectStateAPIWarmCache(b *testing.B) {
+	ctx := context.Background()
+	backend, err := store.Open(ctx, store.Config{
+		Backend: store.BackendSQLite,
+		Path:    filepath.Join(b.TempDir(), "detent.db"),
+	})
+	if err != nil {
+		b.Fatalf("store.Open() error = %v", err)
+	}
+	b.Cleanup(func() {
+		if err := backend.Close(); err != nil {
+			b.Fatalf("Close() error = %v", err)
+		}
+	})
+
+	now := time.Date(2026, 8, 15, 22, 16, 27, 0, time.UTC)
+	seedBenchmarkWorkflowEvents(b, backend, now)
+	snapshot := benchmarkProjectStateSnapshot(now)
+	snapshotHub := hub.New[telemetry.Snapshot]()
+	if err := snapshotHub.Publish(snapshot); err != nil {
+		b.Fatalf("Publish() error = %v", err)
+	}
+	server, err := web.NewServer(web.Config{}, web.Dependencies{
+		Hub:       snapshotHub,
+		Store:     backend,
+		Registry:  project.NewRegistry(),
+		Connector: connectorProbe{name: "memory"},
+	})
+	if err != nil {
+		b.Fatalf("NewServer() error = %v", err)
+	}
+
+	warm := httptest.NewRecorder()
+	server.Handler().ServeHTTP(warm, httptest.NewRequestWithContext(b.Context(), http.MethodGet, "/api/v1/projects/detent/state", nil))
+	if warm.Code != http.StatusOK {
+		b.Fatalf("warm status = %d, want %d; body = %s", warm.Code, http.StatusOK, warm.Body.String())
+	}
+	responseBytes := warm.Body.Len()
+	b.ResetTimer()
+	for b.Loop() {
+		recorder := httptest.NewRecorder()
+		server.Handler().ServeHTTP(recorder, httptest.NewRequestWithContext(b.Context(), http.MethodGet, "/api/v1/projects/detent/state", nil))
+		if recorder.Code != http.StatusOK {
+			b.Fatalf("status = %d, want %d; body = %s", recorder.Code, http.StatusOK, recorder.Body.String())
+		}
+	}
+	b.StopTimer()
+	b.ReportMetric(float64(responseBytes), "bytes/response")
+}
+
+func seedBenchmarkWorkflowEvents(b *testing.B, backend store.Store, now time.Time) {
+	b.Helper()
+	const laneEvents = 1670
+	const activeEvents = 870
+
+	for index := range laneEvents {
+		finishedAt := now.Add(-time.Duration(index%720) * time.Hour)
+		issueIndex := index % activeEvents
+		_, err := backend.RecordWorkflowPhaseEvent(b.Context(), store.WorkflowPhaseEvent{
+			ProjectID:       "detent",
+			IssueID:         "issue-" + strconv.Itoa(issueIndex),
+			Identifier:      "digitaldrywood/detent#" + strconv.Itoa(issueIndex+1),
+			PhaseType:       store.WorkflowPhaseTypeLane,
+			PhaseName:       "In Progress",
+			Status:          "completed",
+			StartedAt:       finishedAt.Add(-10 * time.Minute),
+			FinishedAt:      finishedAt,
+			DurationSeconds: 600,
+		})
+		if err != nil {
+			b.Fatalf("RecordWorkflowPhaseEvent(lane %d) error = %v", index, err)
+		}
+	}
+	for index := range activeEvents {
+		finishedAt := now.Add(-time.Duration(index%720) * time.Hour)
+		_, err := backend.RecordWorkflowPhaseEvent(b.Context(), store.WorkflowPhaseEvent{
+			ProjectID:       "detent",
+			IssueID:         "issue-" + strconv.Itoa(index),
+			Identifier:      "digitaldrywood/detent#" + strconv.Itoa(index+1),
+			PhaseType:       store.WorkflowPhaseTypeAgentSession,
+			PhaseName:       "agent_active",
+			Status:          "completed",
+			StartedAt:       finishedAt.Add(-8 * time.Minute),
+			FinishedAt:      finishedAt.Add(-5 * time.Minute),
+			DurationSeconds: 180,
+			Turns:           4,
+			TotalTokens:     12000,
+			EndpointFamily:  "codex",
+		})
+		if err != nil {
+			b.Fatalf("RecordWorkflowPhaseEvent(active %d) error = %v", index, err)
+		}
+	}
+}
+
+func benchmarkProjectStateSnapshot(now time.Time) telemetry.Snapshot {
+	const workAttempts = 600
+	snapshot := telemetry.Snapshot{
+		GeneratedAt: now,
+		Project:     telemetry.Project{ID: "detent", DisplayName: "Detent"},
+		Projects: []telemetry.ProjectSnapshot{{
+			Project: telemetry.Project{ID: "detent", DisplayName: "Detent"},
+		}},
+		WorkAttempts: make([]telemetry.WorkAttempt, 0, workAttempts),
+	}
+	for index := range workAttempts {
+		snapshot.WorkAttempts = append(snapshot.WorkAttempts, telemetry.WorkAttempt{
+			AttemptID:      int64(index + 1),
+			ProjectID:      "detent",
+			IssueID:        "issue-" + strconv.Itoa(index),
+			Identifier:     "digitaldrywood/detent#" + strconv.Itoa(index+1),
+			IssueURL:       "https://github.com/digitaldrywood/detent/issues/" + strconv.Itoa(index+1),
+			Repo:           "digitaldrywood/detent",
+			WorkerType:     "codex",
+			WorkerHost:     "corys-mac-studio",
+			Lane:           "In Progress",
+			AttemptNumber:  1,
+			Status:         "completed",
+			StartedAt:      now.Add(-time.Hour),
+			CompletedAt:    &now,
+			TerminalState:  "completed",
+			StatusMessage:  strings.Repeat("representative state payload ", 4),
+			CurrentCommand: "make check",
+			NextAction:     "awaiting promotion",
+		})
+	}
+	return snapshot
+}

--- a/internal/web/server_test.go
+++ b/internal/web/server_test.go
@@ -6668,6 +6668,50 @@ func TestProjectStateAPIScopesSnapshot(t *testing.T) {
 	}
 }
 
+func TestStateAPICachesEnrichmentQueries(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		path string
+	}{
+		{name: "fleet", path: "/api/v1/state"},
+		{name: "project", path: "/api/v1/projects/detent/state"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			backend := &enrichmentQueryCountingStore{}
+			deps := testDeps(t)
+			deps.Store = backend
+			mustSetWebProject(t, deps.Registry, "detent", false)
+			if err := deps.Hub.Publish(telemetry.Snapshot{
+				GeneratedAt: time.Date(2026, 8, 15, 22, 16, 27, 0, time.UTC),
+				Project:     telemetry.Project{ID: "detent", DisplayName: "Detent"},
+				Projects: []telemetry.ProjectSnapshot{{
+					Project: telemetry.Project{ID: "detent", DisplayName: "Detent"},
+				}},
+			}); err != nil {
+				t.Fatalf("Publish() error = %v", err)
+			}
+			server, err := web.NewServer(web.Config{}, deps)
+			if err != nil {
+				t.Fatalf("NewServer() error = %v", err)
+			}
+
+			requestJSON(t, server, http.MethodGet, tt.path, http.StatusOK)
+			requestJSON(t, server, http.MethodGet, tt.path, http.StatusOK)
+			if got := backend.workflowMetricsCalls.Load(); got != 6 {
+				t.Fatalf("WorkflowMetricsReport() calls = %d, want 6", got)
+			}
+			if got := backend.budgetCostCalls.Load(); got != 1 {
+				t.Fatalf("BudgetCostEvents() calls = %d, want 1", got)
+			}
+		})
+	}
+}
+
 func TestStateAPIIncludesGitHubGraphQLRateLimitStatus(t *testing.T) {
 	t.Parallel()
 
@@ -11915,6 +11959,23 @@ type renderBlockingStore struct {
 
 	release <-chan struct{}
 	calls   atomic.Int64
+}
+
+type enrichmentQueryCountingStore struct {
+	storeProbe
+
+	workflowMetricsCalls atomic.Int64
+	budgetCostCalls      atomic.Int64
+}
+
+func (s *enrichmentQueryCountingStore) WorkflowMetricsReport(context.Context, store.WorkflowMetricsQuery) (store.WorkflowMetricsReport, error) {
+	s.workflowMetricsCalls.Add(1)
+	return store.WorkflowMetricsReport{}, nil
+}
+
+func (s *enrichmentQueryCountingStore) BudgetCostEvents(context.Context, store.BudgetCostQuery) ([]store.BudgetCostEvent, error) {
+	s.budgetCostCalls.Add(1)
+	return nil, nil
 }
 
 func (s *renderBlockingStore) wait(ctx context.Context) error {


### PR DESCRIPTION
## Summary

- reuse cached fleet workflow enrichment for project-scoped state responses instead of rerunning six historical reports per request
- avoid project spend and budget override reads that were only used to locate the project and did not affect the serialized response
- add query-count regression coverage, a representative 481 KB endpoint benchmark, and cache-versus-lazy API documentation

The representative warm benchmark improves from 1.476s/op and 25.9 MB/op to 0.723ms/op and about 1.3 MB/op.

Fixes #1818

## UI Surface Contract

- [x] N/A, or the linked issue explicitly authorizes any high-impact UI surface, layout, density, first-viewport, or responsive visibility tradeoff.
- [x] Persistent top-of-screen messaging is explicitly authorized by the issue, or this PR does not add it.
- [x] Visual changes to primary operator screens include screenshot or browser verification below.

No visual behavior changes.

## Test Plan

- [x] `go test ./internal/web -count=1`
- [x] `go test ./internal/web -run '^$' -bench '^BenchmarkProjectStateAPIWarmCache$' -benchtime=5x -count=1 -benchmem`
- [x] `make check`
