### PR TITLE
fix(ops): count only current blocked rows

### DIFF
--- a/internal/telemetry/snapshot.go
+++ b/internal/telemetry/snapshot.go
@@ -473,7 +473,7 @@ func (s Snapshot) EffectiveCounts() Counts {
 	return Counts{
 		Running:   countOrLength(s.Counts.Running, len(s.Running)),
 		Queue:     countOrLength(s.Counts.Queue, len(s.Queue)),
-		Blocked:   countOrLength(s.Counts.Blocked, len(s.Blocked)),
+		Blocked:   len(s.Blocked),
 		Completed: countOrLength(s.Counts.Completed, len(s.Completed)),
 	}
 }

--- a/internal/telemetry/snapshot_test.go
+++ b/internal/telemetry/snapshot_test.go
@@ -374,7 +374,7 @@ func TestSnapshotEffectiveCounts(t *testing.T) {
 		want     telemetry.Counts
 	}{
 		{
-			name: "uses aggregate counts",
+			name: "uses aggregate counts except current blocked rows",
 			snapshot: telemetry.Snapshot{
 				Counts:    telemetry.Counts{Running: 7, Queue: 6, Blocked: 5, Completed: 4},
 				Running:   []telemetry.Running{{}},
@@ -382,7 +382,7 @@ func TestSnapshotEffectiveCounts(t *testing.T) {
 				Blocked:   []telemetry.Blocked{{}},
 				Completed: []telemetry.Completed{{}},
 			},
-			want: telemetry.Counts{Running: 7, Queue: 6, Blocked: 5, Completed: 4},
+			want: telemetry.Counts{Running: 7, Queue: 6, Blocked: 1, Completed: 4},
 		},
 		{
 			name: "falls back to row lengths",

--- a/internal/tmuxstatus/status_test.go
+++ b/internal/tmuxstatus/status_test.go
@@ -98,6 +98,49 @@ func TestStatusLifecycle(t *testing.T) {
 	}
 }
 
+func TestStatusUpdateUsesCurrentBlockedRows(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name     string
+		snapshot telemetry.Snapshot
+		want     string
+	}{
+		{
+			name: "ignores historical blocked count",
+			snapshot: telemetry.Snapshot{
+				Counts: telemetry.Counts{Running: 7, Blocked: 10},
+			},
+			want: "detent 7r/0q/0b",
+		},
+		{
+			name: "counts current blocked rows",
+			snapshot: telemetry.Snapshot{
+				Blocked: []telemetry.Blocked{{}, {}},
+			},
+			want: "detent 0r/0q/2b",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			runner := &recordingRunner{output: "@7\tDetent:2\n"}
+			status, err := newStatus(context.Background(), runner, "%7")
+			if err != nil {
+				t.Fatalf("newStatus() error = %v", err)
+			}
+
+			if err := status.Update(context.Background(), test.snapshot); err != nil {
+				t.Fatalf("Update() error = %v", err)
+			}
+
+			if got := runner.calls[1][3]; got != test.want {
+				t.Fatalf("window name = %q, want %q", got, test.want)
+			}
+		})
+	}
+}
+
 func TestStatusRetriesFailedRename(t *testing.T) {
 	t.Parallel()
 	runner := &recordingRunner{output: "@7\tDetent:2\n"}


### PR DESCRIPTION
## Summary

- derive effective blocked counts from current blocked rows instead of potentially stale aggregate records
- align tmux and TUI blocked counts with `/api/v1/*/state` current-state semantics
- cover historical `Blocked: 10` with no blocked lane and verify tmux renders `0b`

Root cause: `Snapshot.EffectiveCounts` preferred any nonzero aggregate blocked count even when the authoritative current blocked-row collection was empty.

Fixes #1822

## UI Surface Contract

- [x] N/A; this corrects an existing tmux status value and does not add a new UI surface or layout tradeoff.
- [x] This PR does not add persistent top-of-screen messaging.
- [x] No primary operator screen layout changed, so browser screenshots are not applicable.

## Test Plan

- [x] `go test ./internal/telemetry ./internal/tmuxstatus ./internal/tui ./internal/web -count=1`
- [x] `PATH="$(go env GOBIN):$PATH" make check` (golangci-lint v2.1.6; 79.0% coverage)