### PR TITLE
fix(recovery): rearm REST budget parks

### DIFF
--- a/internal/orchestrator/blocked_cause_recovery.go
+++ b/internal/orchestrator/blocked_cause_recovery.go
@@ -336,6 +336,9 @@ func (o *Orchestrator) recoverCauseBlockedIssue(
 		o.recordBlockedRecoveryDecision(ctx, state, issue, "hold", "human_recovery", &park, park.CauseFingerprint)
 		return false
 	}
+	if handled, transitioned := o.reconcileRepeatedFailureGitHubRESTBudgetPark(ctx, state, issue, park, now); handled {
+		return transitioned
+	}
 	if park.Predicate == blockedRecoveryPredicateManaged {
 		o.recordBlockedRecoveryDecision(ctx, state, issue, "hold", "managed_recovery", &park, park.CauseFingerprint)
 		return false
@@ -790,6 +793,10 @@ func BlockedRecoveryOperatorRemedy(issue connector.Issue, reason string) string 
 		return "Review the blocking cause, then move the issue to a lane that starts fresh work."
 	case "transition_failed":
 		return "Retry the lane transition after restoring tracker write access."
+	case githubRESTBudgetWaitingReason, githubRESTBudgetObservationPendingReason:
+		return "Detent will return the issue to its prior lane after the matching GitHub REST budget rises above the worker reserve."
+	case githubRESTBudgetRearmConsumedReason:
+		return "Wait for the next GitHub REST reset window, or move the issue manually after confirming capacity is stable."
 	case "managed_recovery":
 		return "Review the configured recovery owner and move the issue manually if that owner cannot recover it."
 	case blockedReadyPullRequestLookupNoneReason:

--- a/internal/orchestrator/blocked_cause_recovery_test.go
+++ b/internal/orchestrator/blocked_cause_recovery_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/digitaldrywood/detent/internal/gate"
 	runpkg "github.com/digitaldrywood/detent/internal/runner"
 	"github.com/digitaldrywood/detent/internal/store"
+	"github.com/digitaldrywood/detent/internal/telemetry"
 	"github.com/digitaldrywood/detent/internal/workpad"
 )
 
@@ -396,6 +397,298 @@ func TestCauseBlockedRecoveryPersistsAndBoundsFingerprintAttempts(t *testing.T) 
 			}
 		})
 	}
+}
+
+func TestRepeatedFailureParkRecoveryUsesRecordedRESTBudgetFailures(t *testing.T) {
+	t.Parallel()
+
+	parkedAt := time.Date(2026, 8, 15, 23, 50, 0, 0, time.UTC)
+	observedAt := parkedAt.Add(time.Hour)
+	resetAt := observedAt.Add(time.Hour)
+	budgetError := "run agent turn: worker github REST budget reached reserved headroom: remaining=940 reserve=1250 reset_at=2026-08-16T01:00:00Z"
+	tests := []struct {
+		name             string
+		errorMessage     string
+		remaining        int64
+		consumed         bool
+		wantTransition   bool
+		wantAction       string
+		wantReason       string
+		wantSurfaceParts []string
+	}{
+		{name: "budget recovers", errorMessage: budgetError, remaining: 4927, wantTransition: true},
+		{
+			name:             "budget remains exhausted",
+			errorMessage:     budgetError,
+			remaining:        940,
+			wantAction:       "defer",
+			wantReason:       githubRESTBudgetWaitingReason,
+			wantSurfaceParts: []string{"transient GitHub REST budget", "remaining=940/5000", "reserve=1250"},
+		},
+		{
+			name:         "non-transient failure stays parked",
+			errorMessage: "run agent turn: runner transport closed",
+			remaining:    4927,
+			wantAction:   "hold",
+			wantReason:   "cause_unchanged",
+		},
+		{
+			name:             "same exhaustion episode does not rearm twice",
+			errorMessage:     budgetError,
+			remaining:        4927,
+			consumed:         true,
+			wantAction:       "hold",
+			wantReason:       githubRESTBudgetRearmConsumedReason,
+			wantSurfaceParts: []string{"capacity recovered", "automatic re-arm already used", "remaining=4927/5000"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			issue := dependencyAutoUnblockIssue("issue-"+strings.ReplaceAll(tt.name, " ", "-"), blockedStatusState)
+			tracker := &dependencyAutoUnblockConnector{}
+			orch := blockedCauseTestOrchestrator(tracker)
+			metadata := orch.newBlockedRecoveryMetadata(
+				t.Context(),
+				issue,
+				RunModeImplement,
+				"repeated_failure_circuit_breaker",
+				blockedRecoveryPredicateFingerprintChange,
+				"Todo",
+				DiffStats{},
+			)
+			metrics := &autoPromoteWorkflowMetricsRecorder{}
+			if tt.consumed {
+				signature := githubRESTBudgetRecoverySignature(githubRESTBudgetEvidence{
+					Consumer:           telemetry.RESTConsumerSharedPool,
+					CredentialIdentity: "github-rest:worker",
+					ResetAt:            resetAt,
+				}, 1250)
+				consumedMetadata := workflowLaneMetadataWithActionSignature(workflowLaneMetadata{}, workflowActionGitHubRESTBudgetRecovery, signature)
+				if _, err := metrics.RecordWorkflowPhaseEvent(t.Context(), store.WorkflowPhaseEvent{
+					ProjectID:    defaultWorkflowMetricsProjectID,
+					IssueID:      issue.ID,
+					Identifier:   issue.Identifier,
+					IssueURL:     issue.URL,
+					PhaseType:    store.WorkflowPhaseTypeLane,
+					PhaseName:    "In Progress",
+					Reason:       workflowActionGitHubRESTBudgetRecovery,
+					Status:       "entered",
+					StartedAt:    parkedAt.Add(-time.Minute),
+					MetadataJSON: workflowLaneMetadataJSON(issue, consumedMetadata),
+				}); err != nil {
+					t.Fatalf("RecordWorkflowPhaseEvent() consumed recovery error = %v", err)
+				}
+			}
+			recordBlockedCausePark(t, metrics, issue, parkedAt, metadata)
+			attempts := &implementProgressAttemptStore{}
+			for attempt := repeatedFailureThreshold; attempt >= 1; attempt-- {
+				attempts.history = append(attempts.history, store.WorkAttempt{
+					ID:            int64(attempt),
+					ProjectID:     defaultWorkflowMetricsProjectID,
+					IssueID:       issue.ID,
+					Identifier:    issue.Identifier,
+					Lane:          "In Progress",
+					AttemptNumber: attempt,
+					Status:        store.WorkAttemptStatusTerminal,
+					TerminalState: store.WorkAttemptTerminalFailure,
+					ErrorClass:    workAttemptErrorRunner,
+					ErrorMessage:  tt.errorMessage,
+					CompletedAt:   parkedAt.Add(-time.Duration(repeatedFailureThreshold-attempt) * time.Minute),
+				})
+			}
+
+			orch.workflowMetrics = metrics
+			orch.workAttempts = attempts
+			state := newState(orch.cfg)
+			state.RateLimits = &telemetry.RateLimits{
+				GitHubREST: &telemetry.RateLimitBucket{
+					Remaining:  4999,
+					Limit:      5000,
+					ResetAt:    &resetAt,
+					ObservedAt: &observedAt,
+				},
+				GitHubRESTBudgets: []telemetry.RESTBudget{{
+					Consumer:            telemetry.RESTConsumerSharedPool,
+					CredentialIdentity:  "github-rest:worker",
+					EndpointFamily:      "shared credential pool",
+					Resource:            "core",
+					Remaining:           tt.remaining,
+					Limit:               5000,
+					MinRemainingReserve: 1250,
+					ResetAt:             &resetAt,
+					ObservedAt:          &observedAt,
+				}},
+			}
+			state.Blocked[issue.ID] = Blocked{
+				Issue:     issue,
+				Source:    BlockedSourceProjectStatus,
+				BlockedAt: parkedAt,
+				Recovery:  metadata.BlockedRecovery,
+			}
+
+			transitioned := orch.recoverBlockedIssues(t.Context(), &state, []connector.Issue{issue}, observedAt)
+
+			if tt.wantTransition {
+				if len(tracker.updates) != 1 || tracker.updates[0].state != "In Progress" {
+					t.Fatalf("updates = %#v, want recovery to prior lane In Progress", tracker.updates)
+				}
+				if _, ok := transitioned[issue.ID]; !ok {
+					t.Fatalf("transitioned[%q] missing", issue.ID)
+				}
+				return
+			}
+			if len(tracker.updates) != 0 {
+				t.Fatalf("updates = %#v, want park held", tracker.updates)
+			}
+			if _, ok := transitioned[issue.ID]; ok {
+				t.Fatalf("transitioned[%q] present for held park", issue.ID)
+			}
+			blocked := state.Blocked[issue.ID]
+			if blocked.RecoveryAction != tt.wantAction || blocked.RecoveryReason != tt.wantReason {
+				t.Fatalf("blocked recovery = %q/%q, want %q/%q", blocked.RecoveryAction, blocked.RecoveryReason, tt.wantAction, tt.wantReason)
+			}
+			for _, part := range tt.wantSurfaceParts {
+				if !strings.Contains(blocked.Reason, part) {
+					t.Fatalf("blocked reason = %q, want %q", blocked.Reason, part)
+				}
+			}
+		})
+	}
+}
+
+func TestRepeatedFailureRESTBudgetParkProbesAfterReset(t *testing.T) {
+	t.Parallel()
+
+	parkedAt := time.Date(2026, 8, 15, 23, 50, 0, 0, time.UTC)
+	exhaustedResetAt := parkedAt.Add(10 * time.Minute)
+	recoveryAt := exhaustedResetAt.Add(time.Minute)
+	nextResetAt := recoveryAt.Add(time.Hour)
+	oldObservedAt := parkedAt
+	newObservedAt := recoveryAt
+	budgetError := "run agent turn: worker github REST budget reached reserved headroom: consumer=worker credential_identity=github-rest:worker remaining=940 reserve=1250 reset_at=" + exhaustedResetAt.Format(time.RFC3339)
+	tests := []struct {
+		name           string
+		probeBudget    telemetry.RESTBudget
+		repetitions    int
+		wantTransition bool
+		wantProbeCalls int
+	}{
+		{
+			name: "matching worker credential recovers",
+			probeBudget: telemetry.RESTBudget{
+				Consumer:            telemetry.RESTConsumerWorker,
+				CredentialIdentity:  "github-rest:worker",
+				EndpointFamily:      "worker credential",
+				Resource:            "core",
+				Remaining:           4927,
+				Limit:               5000,
+				MinRemainingReserve: 1250,
+				ResetAt:             &nextResetAt,
+				ObservedAt:          &newObservedAt,
+			},
+			wantTransition: true,
+			wantProbeCalls: 1,
+		},
+		{
+			name: "different credential cannot recover park",
+			probeBudget: telemetry.RESTBudget{
+				Consumer:            telemetry.RESTConsumerWorker,
+				CredentialIdentity:  "github-rest:tracker",
+				EndpointFamily:      "worker credential",
+				Resource:            "core",
+				Remaining:           4927,
+				Limit:               5000,
+				MinRemainingReserve: 1250,
+				ResetAt:             &nextResetAt,
+				ObservedAt:          &newObservedAt,
+			},
+			repetitions:    2,
+			wantProbeCalls: 1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			issue := dependencyAutoUnblockIssue("issue-probe-"+strings.ReplaceAll(tt.name, " ", "-"), blockedStatusState)
+			tracker := &dependencyAutoUnblockConnector{}
+			orch := blockedCauseTestOrchestrator(tracker)
+			metrics := &autoPromoteWorkflowMetricsRecorder{}
+			metadata := orch.newBlockedRecoveryMetadata(
+				t.Context(),
+				issue,
+				RunModeImplement,
+				repeatedFailureCircuitBreakerCause,
+				blockedRecoveryPredicateGitHubRESTBudget,
+				"In Progress",
+				DiffStats{},
+			)
+			evidence, ok := githubRESTBudgetEvidenceFromMessage(budgetError)
+			if !ok {
+				t.Fatal("budget error did not parse")
+			}
+			evidence.TargetState = "In Progress"
+			applyGitHubRESTBudgetEvidence(metadata.BlockedRecovery, evidence)
+			recordBlockedCausePark(t, metrics, issue, parkedAt, metadata)
+			prober := &staticGitHubRESTBudgetProber{budget: tt.probeBudget}
+			orch.workflowMetrics = metrics
+			orch.githubRESTBudgetProber = prober
+
+			state := newState(orch.cfg)
+			state.RateLimits = &telemetry.RateLimits{
+				GitHubREST: &telemetry.RateLimitBucket{
+					Remaining:  4999,
+					Limit:      5000,
+					ResetAt:    &nextResetAt,
+					ObservedAt: &newObservedAt,
+				},
+				GitHubRESTBudgets: []telemetry.RESTBudget{{
+					Consumer:            telemetry.RESTConsumerWorker,
+					CredentialIdentity:  "github-rest:worker",
+					EndpointFamily:      "worker credential",
+					Resource:            "core",
+					Remaining:           940,
+					Limit:               5000,
+					MinRemainingReserve: 1250,
+					ResetAt:             &exhaustedResetAt,
+					ObservedAt:          &oldObservedAt,
+				}},
+			}
+			state.Blocked[issue.ID] = Blocked{
+				Issue:     issue,
+				Source:    BlockedSourceProjectStatus,
+				BlockedAt: parkedAt,
+				Recovery:  metadata.BlockedRecovery,
+			}
+
+			var transitioned map[string]struct{}
+			for range max(1, tt.repetitions) {
+				transitioned = orch.recoverBlockedIssues(t.Context(), &state, []connector.Issue{issue}, recoveryAt)
+			}
+
+			if prober.calls != tt.wantProbeCalls {
+				t.Fatalf("probe calls = %d, want %d", prober.calls, tt.wantProbeCalls)
+			}
+			_, didTransition := transitioned[issue.ID]
+			if didTransition != tt.wantTransition {
+				t.Fatalf("transitioned = %v, want %v", didTransition, tt.wantTransition)
+			}
+		})
+	}
+}
+
+type staticGitHubRESTBudgetProber struct {
+	budget telemetry.RESTBudget
+	calls  int
+}
+
+func (p *staticGitHubRESTBudgetProber) ProbeGitHubRESTBudget(context.Context, connector.Issue) (telemetry.RESTBudget, bool, error) {
+	p.calls++
+	return p.budget, true, nil
 }
 
 func TestBlockedCauseFingerprintTracksNormalizedLabels(t *testing.T) {

--- a/internal/orchestrator/github_rest_capacity.go
+++ b/internal/orchestrator/github_rest_capacity.go
@@ -2,11 +2,14 @@ package orchestrator
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"strconv"
 	"strings"
 	"time"
 
 	"github.com/digitaldrywood/detent/internal/backendcapacity"
+	"github.com/digitaldrywood/detent/internal/connector"
 	runpkg "github.com/digitaldrywood/detent/internal/runner"
 	"github.com/digitaldrywood/detent/internal/store"
 	"github.com/digitaldrywood/detent/internal/telemetry"
@@ -16,12 +19,31 @@ const (
 	githubRESTCapacityBackendID = "github-rest"
 	githubRESTCapacityKind      = "github_rest_rate_limit"
 	githubRESTCapacityError     = "github_rest_capacity"
+
+	blockedRecoveryPredicateGitHubRESTBudget = "github_rest_budget_recovered"
+	workflowActionGitHubRESTBudgetRecovery   = "github_rest_budget_recovery"
+	githubRESTBudgetWaitingReason            = "github_rest_budget_wait"
+	githubRESTBudgetObservationPendingReason = "github_rest_budget_observation_pending"
+	githubRESTBudgetRearmConsumedReason      = "github_rest_budget_rearm_consumed"
+	repeatedFailureCircuitBreakerCause       = "repeated_failure_circuit_breaker"
+	githubRESTBudgetProbeRetryInterval       = time.Minute
 )
 
 var githubRESTCapacityScope = backendcapacity.Scope{
 	BackendID:   githubRESTCapacityBackendID,
 	BackendKind: "tracker",
 	Provider:    "github",
+}
+
+type githubRESTBudgetEvidence struct {
+	Consumer           string
+	CredentialIdentity string
+	Remaining          int64
+	Limit              int64
+	Reserve            int64
+	ResetAt            time.Time
+	ObservedAt         time.Time
+	TargetState        string
 }
 
 func (o *Orchestrator) syncGitHubRESTCapacityOutage(state *State, now time.Time) {
@@ -150,4 +172,371 @@ func (o *Orchestrator) handleGitHubRESTCapacityCompletion(
 		Message: githubRESTCapacityStatusMessage(outage),
 	})
 	return true
+}
+
+func isGitHubRESTBudgetHeadroomError(err error) bool {
+	return err != nil && (errors.Is(err, runpkg.ErrWorkerGitHubRESTReserved) || isGitHubRESTBudgetHeadroomMessage(err.Error()))
+}
+
+func isGitHubRESTBudgetHeadroomMessage(message string) bool {
+	return strings.Contains(strings.ToLower(strings.TrimSpace(message)), "worker github rest budget reached reserved headroom")
+}
+
+func githubRESTBudgetEvidenceFromError(err error) (githubRESTBudgetEvidence, bool) {
+	if !isGitHubRESTBudgetHeadroomError(err) {
+		return githubRESTBudgetEvidence{}, false
+	}
+	return githubRESTBudgetEvidenceFromMessage(err.Error())
+}
+
+func githubRESTBudgetEvidenceFromMessage(message string) (githubRESTBudgetEvidence, bool) {
+	if !isGitHubRESTBudgetHeadroomMessage(message) {
+		return githubRESTBudgetEvidence{}, false
+	}
+	evidence := githubRESTBudgetEvidence{}
+	for _, field := range strings.Fields(message) {
+		key, value, ok := strings.Cut(strings.Trim(field, ",;"), "=")
+		if !ok {
+			continue
+		}
+		switch strings.ToLower(strings.TrimSpace(key)) {
+		case "consumer":
+			evidence.Consumer = strings.TrimSpace(value)
+		case "credential_identity":
+			evidence.CredentialIdentity = strings.TrimSpace(value)
+		case "remaining":
+			if parsed, err := strconv.ParseInt(strings.TrimSpace(value), 10, 64); err == nil {
+				evidence.Remaining = parsed
+			}
+		case "reserve":
+			if parsed, err := strconv.ParseInt(strings.TrimSpace(value), 10, 64); err == nil {
+				evidence.Reserve = parsed
+			}
+		case "reset_at":
+			if parsed, err := time.Parse(time.RFC3339, strings.TrimSpace(value)); err == nil {
+				evidence.ResetAt = parsed
+			}
+		}
+	}
+	return evidence, evidence.Reserve > 0
+}
+
+func (o *Orchestrator) githubRESTBudgetParkEvidence(state *State, err error, targetState string) (githubRESTBudgetEvidence, bool) {
+	evidence, ok := githubRESTBudgetEvidenceFromError(err)
+	if !ok {
+		return githubRESTBudgetEvidence{}, false
+	}
+	evidence.TargetState = o.repeatedFailureRecoveryTarget(targetState)
+	if current, currentOK := currentGitHubRESTBudget(state, evidence); currentOK {
+		evidence.Limit = current.Limit
+		if evidence.ResetAt.IsZero() {
+			evidence.ResetAt = current.ResetAt
+		}
+		evidence.ObservedAt = current.ObservedAt
+		evidence.CredentialIdentity = current.CredentialIdentity
+		if current.Consumer != "" {
+			evidence.Consumer = current.Consumer
+		}
+	}
+	return evidence, true
+}
+
+func applyGitHubRESTBudgetEvidence(metadata *workflowLaneBlockedRecoveryMetadata, evidence githubRESTBudgetEvidence) {
+	if metadata == nil {
+		return
+	}
+	metadata.ResourceKind = githubRESTCapacityKind
+	metadata.ResourceConsumer = strings.TrimSpace(evidence.Consumer)
+	metadata.ResourceCredential = strings.TrimSpace(evidence.CredentialIdentity)
+	metadata.ResourceRemaining = evidence.Remaining
+	metadata.ResourceLimit = evidence.Limit
+	metadata.ResourceReserve = evidence.Reserve
+	metadata.ResourceResetAt = githubRESTBudgetTimeValue(evidence.ResetAt)
+	metadata.ResourceObservedAt = githubRESTBudgetTimeValue(evidence.ObservedAt)
+}
+
+func githubRESTBudgetTimeValue(value time.Time) string {
+	if value.IsZero() {
+		return ""
+	}
+	return value.UTC().Format(time.RFC3339)
+}
+
+func githubRESTBudgetEvidenceFromMetadata(park workflowLaneBlockedRecoveryMetadata) (githubRESTBudgetEvidence, bool) {
+	if strings.TrimSpace(park.ResourceKind) != githubRESTCapacityKind || park.ResourceReserve <= 0 {
+		return githubRESTBudgetEvidence{}, false
+	}
+	resetAt := githubRESTBudgetMetadataTime(park.ResourceResetAt)
+	observedAt := githubRESTBudgetMetadataTime(park.ResourceObservedAt)
+	return githubRESTBudgetEvidence{
+		Consumer:           strings.TrimSpace(park.ResourceConsumer),
+		CredentialIdentity: strings.TrimSpace(park.ResourceCredential),
+		Remaining:          park.ResourceRemaining,
+		Limit:              park.ResourceLimit,
+		Reserve:            park.ResourceReserve,
+		ResetAt:            resetAt,
+		ObservedAt:         observedAt,
+		TargetState:        strings.TrimSpace(park.TargetState),
+	}, true
+}
+
+func githubRESTBudgetMetadataTime(value string) time.Time {
+	parsed, err := time.Parse(time.RFC3339, strings.TrimSpace(value))
+	if err != nil {
+		return time.Time{}
+	}
+	return parsed
+}
+
+func (o *Orchestrator) repeatedFailureGitHubRESTBudgetEvidence(
+	ctx context.Context,
+	issue connector.Issue,
+	park workflowLaneBlockedRecoveryMetadata,
+) (githubRESTBudgetEvidence, bool) {
+	if strings.TrimSpace(park.Cause) != repeatedFailureCircuitBreakerCause {
+		return githubRESTBudgetEvidence{}, false
+	}
+	if evidence, ok := githubRESTBudgetEvidenceFromMetadata(park); ok {
+		evidence.TargetState = o.repeatedFailureRecoveryTarget(evidence.TargetState)
+		return evidence, true
+	}
+	if o == nil || o.workAttempts == nil {
+		return githubRESTBudgetEvidence{}, false
+	}
+	attempts, err := o.workAttempts.ListRecentTerminalWorkAttempts(ctx, store.WorkAttemptHistoryQuery{
+		ProjectID:  strings.TrimSpace(o.cfg.Project.ID),
+		IssueID:    strings.TrimSpace(issue.ID),
+		Identifier: strings.TrimSpace(issue.Identifier),
+		IssueURL:   strings.TrimSpace(issue.URL),
+		Limit:      repeatedFailureThreshold,
+	})
+	if err != nil {
+		if o.logger != nil {
+			o.logger.Warn("repeated failure REST budget evidence unavailable", "issue_id", issue.ID, "identifier", issue.Identifier, "error", err)
+		}
+		return githubRESTBudgetEvidence{}, false
+	}
+	if len(attempts) < repeatedFailureThreshold {
+		return githubRESTBudgetEvidence{}, false
+	}
+	var evidence githubRESTBudgetEvidence
+	for index, attempt := range attempts[:repeatedFailureThreshold] {
+		candidate, ok := githubRESTBudgetEvidenceFromMessage(attempt.ErrorMessage)
+		if !ok {
+			return githubRESTBudgetEvidence{}, false
+		}
+		if index == 0 {
+			evidence = candidate
+			evidence.TargetState = o.repeatedFailureRecoveryTarget(attempt.Lane)
+		}
+	}
+	return evidence, true
+}
+
+func currentGitHubRESTBudget(state *State, match githubRESTBudgetEvidence) (githubRESTBudgetEvidence, bool) {
+	if state == nil || state.RateLimits == nil {
+		return githubRESTBudgetEvidence{}, false
+	}
+	var current githubRESTBudgetEvidence
+	for _, budget := range state.RateLimits.GitHubRESTBudgets {
+		if budget.Limit <= 0 || budget.ObservedAt == nil {
+			continue
+		}
+		consumer := strings.TrimSpace(budget.Consumer)
+		if consumer == "" {
+			consumer = telemetry.RESTConsumerOrchestrator
+		}
+		if match.CredentialIdentity != "" && strings.TrimSpace(budget.CredentialIdentity) != match.CredentialIdentity {
+			continue
+		}
+		if match.Consumer != "" && consumer != match.Consumer {
+			continue
+		}
+		if match.CredentialIdentity == "" && match.Consumer == "" {
+			if budget.MinRemainingReserve != match.Reserve || consumer == telemetry.RESTConsumerOrchestrator {
+				continue
+			}
+		}
+		if current.ObservedAt.IsZero() || budget.ObservedAt.After(current.ObservedAt) {
+			current = githubRESTBudgetEvidence{
+				Consumer:           consumer,
+				CredentialIdentity: strings.TrimSpace(budget.CredentialIdentity),
+				Remaining:          budget.Remaining,
+				Limit:              budget.Limit,
+				Reserve:            match.Reserve,
+				ObservedAt:         budget.ObservedAt.UTC(),
+			}
+			if budget.ResetAt != nil {
+				current.ResetAt = budget.ResetAt.UTC()
+			}
+		}
+	}
+	return current, current.Limit > 0
+}
+
+func (o *Orchestrator) probeGitHubRESTBudgetPark(
+	ctx context.Context,
+	state *State,
+	issue connector.Issue,
+	evidence githubRESTBudgetEvidence,
+	now time.Time,
+) {
+	if o == nil || o.githubRESTBudgetProber == nil || !evidence.ResetAt.IsZero() && evidence.ResetAt.After(now) {
+		return
+	}
+	key := strings.TrimSpace(evidence.Consumer) + "\x00" + strings.TrimSpace(evidence.CredentialIdentity)
+	if o.githubRESTBudgetProbes == nil {
+		o.githubRESTBudgetProbes = map[string]time.Time{}
+	}
+	if next := o.githubRESTBudgetProbes[key]; next.After(now) {
+		return
+	}
+	o.githubRESTBudgetProbes[key] = now.Add(githubRESTBudgetProbeRetryInterval)
+	budget, supported, err := o.githubRESTBudgetProber.ProbeGitHubRESTBudget(ctx, issue)
+	if err != nil {
+		if o.logger != nil {
+			o.logger.Warn("GitHub REST budget recovery probe failed", "issue_id", issue.ID, "identifier", issue.Identifier, "error", err)
+		}
+		return
+	}
+	if !supported || !gitHubRESTBudgetMatchesEvidence(budget, evidence) {
+		return
+	}
+	if state.RateLimits == nil {
+		state.RateLimits = &telemetry.RateLimits{}
+	}
+	state.RateLimits.GitHubRESTBudgets = mergeRESTBudgets(state.RateLimits.GitHubRESTBudgets, []telemetry.RESTBudget{budget})
+}
+
+func gitHubRESTBudgetMatchesEvidence(budget telemetry.RESTBudget, evidence githubRESTBudgetEvidence) bool {
+	consumer := strings.TrimSpace(budget.Consumer)
+	if consumer == "" {
+		consumer = telemetry.RESTConsumerOrchestrator
+	}
+	if evidence.Consumer != "" && consumer != evidence.Consumer {
+		return false
+	}
+	if evidence.CredentialIdentity != "" && strings.TrimSpace(budget.CredentialIdentity) != evidence.CredentialIdentity {
+		return false
+	}
+	return evidence.CredentialIdentity != "" || evidence.Consumer != "" || budget.MinRemainingReserve == evidence.Reserve
+}
+
+func (o *Orchestrator) repeatedFailureRecoveryTarget(candidate string) string {
+	candidate = strings.TrimSpace(candidate)
+	if candidate == "" || normalizeState(candidate) == normalizeState(blockedStatusState) || stateIn(candidate, o.cfg.TerminalStates) {
+		return "Todo"
+	}
+	return candidate
+}
+
+func (o *Orchestrator) reconcileRepeatedFailureGitHubRESTBudgetPark(
+	ctx context.Context,
+	state *State,
+	issue connector.Issue,
+	park workflowLaneBlockedRecoveryMetadata,
+	now time.Time,
+) (bool, bool) {
+	evidence, ok := o.repeatedFailureGitHubRESTBudgetEvidence(ctx, issue, park)
+	if !ok {
+		return false, false
+	}
+	park.Predicate = blockedRecoveryPredicateGitHubRESTBudget
+	park.TargetState = o.repeatedFailureRecoveryTarget(evidence.TargetState)
+	applyGitHubRESTBudgetEvidence(&park, evidence)
+	blockedAt := workflowLaneFallbackAt(issue)
+	if entry, exists := state.Blocked[strings.TrimSpace(issue.ID)]; exists && !entry.BlockedAt.IsZero() {
+		blockedAt = entry.BlockedAt
+	}
+	current, observed := currentGitHubRESTBudget(state, evidence)
+	if observed {
+		evidence.Consumer = current.Consumer
+		evidence.CredentialIdentity = current.CredentialIdentity
+		if evidence.ResetAt.IsZero() {
+			evidence.ResetAt = current.ResetAt
+		}
+		applyGitHubRESTBudgetEvidence(&park, evidence)
+	}
+	if !observed || current.ObservedAt.IsZero() || !current.ObservedAt.After(blockedAt) || current.ResetAt.IsZero() || !current.ResetAt.After(now) {
+		o.probeGitHubRESTBudgetPark(ctx, state, issue, evidence, now)
+		current, observed = currentGitHubRESTBudget(state, evidence)
+	}
+	if !observed || current.ObservedAt.IsZero() || !current.ObservedAt.After(blockedAt) || current.ResetAt.IsZero() || !current.ResetAt.After(now) {
+		o.recordBlockedRecoveryDecision(ctx, state, issue, "defer", githubRESTBudgetObservationPendingReason, &park, "")
+		o.setGitHubRESTBudgetParkSurface(state, issue.ID, githubRESTBudgetStatusMessage("waiting for a fresh observation", evidence))
+		return true, false
+	}
+	applyGitHubRESTBudgetEvidence(&park, current)
+	if current.Remaining <= evidence.Reserve {
+		o.recordBlockedRecoveryDecision(ctx, state, issue, "defer", githubRESTBudgetWaitingReason, &park, "")
+		o.setGitHubRESTBudgetParkSurface(state, issue.ID, githubRESTBudgetStatusMessage("waiting for capacity", current))
+		return true, false
+	}
+	signature := githubRESTBudgetRecoverySignature(current, evidence.Reserve)
+	if _, consumed := o.workflowTimelineActionSignature(ctx, issue, workflowActionGitHubRESTBudgetRecovery, signature); consumed {
+		o.recordBlockedRecoveryDecision(ctx, state, issue, "hold", githubRESTBudgetRearmConsumedReason, &park, signature)
+		o.setGitHubRESTBudgetParkSurface(state, issue.ID, githubRESTBudgetStatusMessage("capacity recovered; automatic re-arm already used for this reset window", current))
+		return true, false
+	}
+	targetState := o.repeatedFailureRecoveryTarget(evidence.TargetState)
+	metadata := workflowLaneMetadataWithActionSignature(workflowLaneMetadata{}, workflowActionGitHubRESTBudgetRecovery, signature)
+	if err := o.updateIssueStateByIDStrictWithMetadata(ctx, state, issue.ID, issue, targetState, now, workflowActionGitHubRESTBudgetRecovery, metadata); err != nil {
+		o.recordBlockedRecoveryDecision(ctx, state, issue, "defer", "transition_failed", &park, signature)
+		o.setGitHubRESTBudgetParkSurface(state, issue.ID, githubRESTBudgetStatusMessage("capacity recovered; lane transition failed", current))
+		return true, false
+	}
+	if o.connector != nil {
+		comment := fmt.Sprintf(
+			"GitHub REST capacity recovered. Detent moved %s from %s back to %s.\n\n- consumer: %s\n- credential_identity: %s\n- remaining: %d / %d\n- worker reserve: %d\n- reset_at: %s\n- exhaustion_episode: %s",
+			issueLabel(issue), strings.TrimSpace(issue.State), targetState,
+			strings.TrimSpace(current.Consumer), strings.TrimSpace(current.CredentialIdentity), current.Remaining, current.Limit, evidence.Reserve,
+			current.ResetAt.UTC().Format(time.RFC3339), signature,
+		)
+		if err := o.connector.CreateComment(ctx, issue.ID, comment); err != nil && o.logger != nil {
+			o.logger.Warn("GitHub REST budget recovery comment failed", "issue_id", issue.ID, "identifier", issue.Identifier, "error", err)
+		}
+	}
+	delete(state.Blocked, issue.ID)
+	o.logBlockedRecoveryDecision(issue, "transition", "github_rest_budget_recovered", &park, signature)
+	return true, true
+}
+
+func githubRESTBudgetRecoverySignature(current githubRESTBudgetEvidence, reserve int64) string {
+	return fmt.Sprintf(
+		"consumer=%s;credential_identity=%s;reset_at=%s;reserve=%d",
+		strings.TrimSpace(current.Consumer),
+		strings.TrimSpace(current.CredentialIdentity),
+		current.ResetAt.UTC().Format(time.RFC3339),
+		reserve,
+	)
+}
+
+func githubRESTBudgetStatusMessage(status string, budget githubRESTBudgetEvidence) string {
+	message := fmt.Sprintf("transient GitHub REST budget %s: remaining=%d", strings.TrimSpace(status), budget.Remaining)
+	if budget.Limit > 0 {
+		message += "/" + strconv.FormatInt(budget.Limit, 10)
+	}
+	message += " reserve=" + strconv.FormatInt(budget.Reserve, 10)
+	if budget.Consumer != "" {
+		message += " consumer=" + strings.TrimSpace(budget.Consumer)
+	}
+	if budget.CredentialIdentity != "" {
+		message += " credential_identity=" + strings.TrimSpace(budget.CredentialIdentity)
+	}
+	if !budget.ResetAt.IsZero() {
+		message += " reset_at=" + budget.ResetAt.UTC().Format(time.RFC3339)
+	}
+	return message
+}
+
+func (o *Orchestrator) setGitHubRESTBudgetParkSurface(state *State, issueID string, reason string) {
+	if state == nil {
+		return
+	}
+	entry, ok := state.Blocked[strings.TrimSpace(issueID)]
+	if !ok {
+		return
+	}
+	entry.Reason = strings.TrimSpace(reason)
+	state.Blocked[strings.TrimSpace(issueID)] = entry
 }

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -235,6 +235,8 @@ type Orchestrator struct {
 	recoveryInspector       runpkg.BlockedRecoveryInspector
 	dailyBudgetStatus       runpkg.DailyBudgetStatusProvider
 	issueBudgetStatus       runpkg.IssueBudgetStatusProvider
+	githubRESTBudgetProber  runpkg.GitHubRESTBudgetProber
+	githubRESTBudgetProbes  map[string]time.Time
 	now                     func() time.Time
 	retrospector            Retrospector
 	workerProcesses         WorkerProcessStore
@@ -380,6 +382,10 @@ func New(cfg Config, deps Dependencies) (*Orchestrator, error) {
 	if candidate, ok := runner.(runpkg.IssueBudgetStatusProvider); ok {
 		issueBudgetStatus = candidate
 	}
+	var githubRESTBudgetProber runpkg.GitHubRESTBudgetProber
+	if candidate, ok := runner.(runpkg.GitHubRESTBudgetProber); ok {
+		githubRESTBudgetProber = candidate
+	}
 
 	logger := deps.Logger
 	if logger == nil {
@@ -513,6 +519,8 @@ func New(cfg Config, deps Dependencies) (*Orchestrator, error) {
 		recoveryInspector:       blockedRecoveryInspector,
 		dailyBudgetStatus:       dailyBudgetStatus,
 		issueBudgetStatus:       issueBudgetStatus,
+		githubRESTBudgetProber:  githubRESTBudgetProber,
+		githubRESTBudgetProbes:  map[string]time.Time{},
 		now:                     now,
 		dispatchGateSamples:     map[dispatchGateSampleKey]time.Time{},
 		ciTriggerLabelHeads:     map[string]ciTriggerLabelHead{},

--- a/internal/orchestrator/repeated_failure_test.go
+++ b/internal/orchestrator/repeated_failure_test.go
@@ -21,6 +21,18 @@ type tokenCeilingRunner struct {
 	failureCount int64
 }
 
+type restBudgetHeadroomRunner struct {
+	calls atomic.Int64
+}
+
+func (r *restBudgetHeadroomRunner) Run(_ context.Context, _ orchestrator.RunRequest) (orchestrator.RunResult, error) {
+	n := r.calls.Add(1)
+	return orchestrator.RunResult{}, fmt.Errorf(
+		"run agent turn: worker github REST budget reached reserved headroom: consumer=shared_pool credential_identity=github-rest:worker remaining=%d reserve=1250 reset_at=2026-08-16T01:00:00Z",
+		950-n,
+	)
+}
+
 func (r *tokenCeilingRunner) Run(_ context.Context, _ orchestrator.RunRequest) (orchestrator.RunResult, error) {
 	n := r.calls.Add(1)
 	if r.failureCount > 0 && n > r.failureCount {
@@ -131,6 +143,67 @@ func TestRunRepeatedFailureCounterResetsOnSuccessfulCompletion(t *testing.T) {
 	}
 	if _, ok := state.RepeatedFailures[issue.ID]; ok {
 		t.Fatalf("RepeatedFailures[%q] present after successful completion", issue.ID)
+	}
+}
+
+func TestRunParksRESTBudgetFailuresAsTransientRecovery(t *testing.T) {
+	t.Parallel()
+
+	issue := testIssue("issue-rest-budget-park", "digitaldrywood/detent#1824", "Todo")
+	tracker := newFakeConnector(issue)
+	runner := &restBudgetHeadroomRunner{}
+	metrics := &workflowMetricsRecorder{}
+
+	orch, err := orchestrator.New(orchestrator.Config{
+		PollInterval:           time.Millisecond,
+		MaxConcurrentAgents:    1,
+		MaxRetryBackoff:        time.Millisecond,
+		FailureRetryBaseDelay:  time.Millisecond,
+		ActiveStates:           []string{"Todo", "In Progress"},
+		ObservedStates:         []string{"Blocked"},
+		TerminalStates:         []string{"Done", "Cancelled"},
+		ContinuationRetryDelay: time.Second,
+	}, orchestrator.Dependencies{
+		Connector:       tracker,
+		Runner:          runner,
+		WorkflowMetrics: metrics,
+	})
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	stop := runOrchestrator(t, orch)
+
+	var metadataJSON string
+	waitForState(t, orch, func(state orchestrator.State) bool {
+		for _, event := range metrics.snapshot() {
+			if event.PhaseName == "Blocked" && strings.Contains(event.MetadataJSON, `"predicate":"github_rest_budget_recovered"`) {
+				metadataJSON = event.MetadataJSON
+				return true
+			}
+		}
+		return false
+	})
+	stop()
+
+	for _, want := range []string{
+		`"cause":"repeated_failure_circuit_breaker"`,
+		`"target_state":"In Progress"`,
+		`"resource_kind":"github_rest_rate_limit"`,
+		`"resource_consumer":"shared_pool"`,
+		`"resource_credential":"github-rest:worker"`,
+		`"resource_remaining":945`,
+		`"resource_reserve":1250`,
+		`"resource_reset_at":"2026-08-16T01:00:00Z"`,
+	} {
+		if !strings.Contains(metadataJSON, want) {
+			t.Fatalf("workflow metadata = %q, want %q", metadataJSON, want)
+		}
+	}
+	comments := tracker.commentCalls()
+	if len(comments) != 1 ||
+		!strings.Contains(comments[0].body, "transient resource wait") ||
+		!strings.Contains(comments[0].body, "remaining=945 reserve=1250") {
+		t.Fatalf("comments = %#v, want transient REST-budget explanation", comments)
 	}
 }
 

--- a/internal/orchestrator/run_completion.go
+++ b/internal/orchestrator/run_completion.go
@@ -934,6 +934,9 @@ func (o *Orchestrator) recordRepeatedFailure(state *State, event runpkg.Completi
 		failure.FirstFailureAt = event.CompletedAt
 	}
 	failure.Count++
+	if isGitHubRESTBudgetHeadroomError(event.Err) {
+		failure.GitHubRESTBudgetFailures++
+	}
 	failure.Issue = cloneIssue(running.Issue)
 	failure.Error = o.operatorText(event.Err.Error())
 	failure.LastFailureAt = event.CompletedAt
@@ -951,15 +954,33 @@ func (o *Orchestrator) parkRepeatedFailure(
 ) {
 	targetState := o.instantFailureParkState()
 	issue := cloneIssue(running.Issue)
+	recoveryPredicate := blockedRecoveryPredicateFingerprintChange
+	recoveryTarget := "Todo"
+	budgetEvidence := githubRESTBudgetEvidence{}
+	budgetPark := failure.GitHubRESTBudgetFailures == failure.Count
+	if budgetPark {
+		var ok bool
+		budgetEvidence, ok = o.githubRESTBudgetParkEvidence(state, event.Err, issue.State)
+		budgetPark = ok
+		if budgetPark {
+			recoveryPredicate = blockedRecoveryPredicateGitHubRESTBudget
+			recoveryTarget = budgetEvidence.TargetState
+		}
+	}
 	metadata := o.newBlockedRecoveryMetadata(
 		ctx,
 		issue,
 		running.Mode,
-		"repeated_failure_circuit_breaker",
-		blockedRecoveryPredicateFingerprintChange,
-		"Todo",
+		repeatedFailureCircuitBreakerCause,
+		recoveryPredicate,
+		recoveryTarget,
 		running.DiffStats,
 	)
+	if budgetPark {
+		metadata.BlockedRecovery.TargetState = recoveryTarget
+		metadata.BlockedRecovery.IntentResumable = true
+		applyGitHubRESTBudgetEvidence(metadata.BlockedRecovery, budgetEvidence)
+	}
 	if targetState != "" {
 		if err := o.updateIssueStateByIDWithMetadata(ctx, state, issue.ID, issue, targetState, event.CompletedAt, "repeated_failure_circuit_breaker", metadata); err != nil {
 			if o.logger != nil {
@@ -976,7 +997,7 @@ func (o *Orchestrator) parkRepeatedFailure(
 		}
 	}
 	if o.connector != nil {
-		if err := o.connector.CreateComment(ctx, issue.ID, repeatedFailureComment(issue, event.Err, failure, attempt, targetState, o.cfg.OutputTruncationMaxBytes)); err != nil && o.logger != nil {
+		if err := o.connector.CreateComment(ctx, issue.ID, repeatedFailureComment(issue, event.Err, failure, attempt, targetState, o.cfg.OutputTruncationMaxBytes, budgetPark)); err != nil && o.logger != nil {
 			o.logger.Error("repeated failure circuit breaker comment failed", "issue_id", issue.ID, "identifier", issue.Identifier, "error", err)
 		}
 	}
@@ -992,15 +1013,24 @@ func (o *Orchestrator) parkRepeatedFailure(
 	if state.Blocked == nil {
 		state.Blocked = map[string]Blocked{}
 	}
-	state.Blocked[issue.ID] = Blocked{
+	blocked := Blocked{
 		Issue:          issue,
 		Reason:         repeatedFailureBlockedReasonPrefix + failure.Error,
-		RecoveryReason: blockedRecoveryPredicateFingerprintChange,
-		RecoveryTarget: "Todo",
+		RecoveryReason: recoveryPredicate,
+		RecoveryTarget: recoveryTarget,
 		BlockedAt:      event.CompletedAt,
 		Source:         BlockedSourceProjectStatus,
 		Recovery:       metadata.BlockedRecovery,
 	}
+	if budgetPark {
+		blocked.Reason = githubRESTBudgetStatusMessage("waiting for capacity", budgetEvidence)
+		blocked.RecoveryAction = "defer"
+		blocked.RecoveryReason = githubRESTBudgetWaitingReason
+		blocked.RecoveryRemedy = BlockedRecoveryOperatorRemedy(issue, githubRESTBudgetWaitingReason)
+		blocked.RecoveryReachability = blockedRecoveryReachability("defer")
+		blocked.RecoveryIntentResumable = true
+	}
+	state.Blocked[issue.ID] = blocked
 	recordStateEvent(state, telemetry.ActivityEvent{
 		At:      event.CompletedAt,
 		Event:   "worker_repeated_failure_circuit_breaker_tripped",
@@ -1017,11 +1047,19 @@ func (o *Orchestrator) parkRepeatedFailure(
 	}
 }
 
-func repeatedFailureComment(issue connector.Issue, err error, failure RepeatedFailure, attempt int, targetState string, maxBytes int) string {
+func repeatedFailureComment(issue connector.Issue, err error, failure RepeatedFailure, attempt int, targetState string, maxBytes int, budgetPark bool) string {
 	var b strings.Builder
-	b.WriteString("Detent stopped retrying this worker after ")
+	if budgetPark {
+		b.WriteString("Detent paused this worker after ")
+	} else {
+		b.WriteString("Detent stopped retrying this worker after ")
+	}
 	b.WriteString(strconv.Itoa(failure.Count))
-	b.WriteString(" consecutive failed attempts. Each attempt ran to failure and spent real agent time, so retrying without a change is waste.")
+	if budgetPark {
+		b.WriteString(" consecutive attempts reached the worker's GitHub REST reserve. This is a transient resource wait; Detent will re-evaluate it when the matching credential budget recovers.")
+	} else {
+		b.WriteString(" consecutive failed attempts. Each attempt ran to failure and spent real agent time, so retrying without a change is waste.")
+	}
 	if targetState = strings.TrimSpace(targetState); targetState != "" {
 		b.WriteString("\n\nIssue parked in `")
 		b.WriteString(targetState)
@@ -1036,7 +1074,11 @@ func repeatedFailureComment(issue connector.Issue, err error, failure RepeatedFa
 	b.WriteString("\n- last error:\n\n```text\n")
 	b.WriteString(runtimeoutput.Truncate(strings.TrimSpace(err.Error()), maxBytes).Value)
 	b.WriteString("\n```")
-	b.WriteString("\n\nFix the workflow or agent configuration causing every attempt to fail. Detent requeues the issue when the cause fingerprint changes.")
+	if budgetPark {
+		b.WriteString("\n\nDetent returns the issue to its prior lane once per GitHub REST exhaustion episode after remaining capacity rises above the recorded worker reserve.")
+	} else {
+		b.WriteString("\n\nFix the workflow or agent configuration causing every attempt to fail. Detent requeues the issue when the cause fingerprint changes.")
+	}
 	return b.String()
 }
 

--- a/internal/orchestrator/state.go
+++ b/internal/orchestrator/state.go
@@ -254,11 +254,12 @@ type InstantFailure struct {
 // counts and other attempt-specific details vary between otherwise identical
 // failures, and each retry of a long-running failure spends real money.
 type RepeatedFailure struct {
-	Issue          connector.Issue
-	Error          string
-	Count          int
-	FirstFailureAt time.Time
-	LastFailureAt  time.Time
+	Issue                    connector.Issue
+	Error                    string
+	Count                    int
+	GitHubRESTBudgetFailures int
+	FirstFailureAt           time.Time
+	LastFailureAt            time.Time
 }
 
 type ProjectFailureBreaker struct {

--- a/internal/orchestrator/workflow_metrics.go
+++ b/internal/orchestrator/workflow_metrics.go
@@ -68,6 +68,14 @@ type workflowLaneBlockedRecoveryMetadata struct {
 	Reachability            string `json:"reachability,omitempty"`
 	HoldReason              string `json:"hold_reason,omitempty"`
 	OperatorRemedy          string `json:"operator_remedy,omitempty"`
+	ResourceKind            string `json:"resource_kind,omitempty"`
+	ResourceConsumer        string `json:"resource_consumer,omitempty"`
+	ResourceCredential      string `json:"resource_credential,omitempty"`
+	ResourceRemaining       int64  `json:"resource_remaining,omitempty"`
+	ResourceLimit           int64  `json:"resource_limit,omitempty"`
+	ResourceReserve         int64  `json:"resource_reserve,omitempty"`
+	ResourceResetAt         string `json:"resource_reset_at,omitempty"`
+	ResourceObservedAt      string `json:"resource_observed_at,omitempty"`
 }
 
 func (m workflowLaneBlockedRecoveryMetadata) intentResumable() bool {

--- a/internal/runner/types.go
+++ b/internal/runner/types.go
@@ -147,6 +147,10 @@ type BlockedRecoveryInspector interface {
 	BlockedRecoverySnapshot(context.Context, RunRequest) BlockedRecoverySnapshot
 }
 
+type GitHubRESTBudgetProber interface {
+	ProbeGitHubRESTBudget(context.Context, connector.Issue) (telemetry.RESTBudget, bool, error)
+}
+
 type BlockedRecoverySnapshot struct {
 	ConfigFingerprint    string
 	ToolingFingerprint   string

--- a/internal/runner/worker_github.go
+++ b/internal/runner/worker_github.go
@@ -21,6 +21,7 @@ import (
 	"time"
 
 	"github.com/digitaldrywood/detent/internal/config"
+	"github.com/digitaldrywood/detent/internal/connector"
 	"github.com/digitaldrywood/detent/internal/telemetry"
 )
 
@@ -88,6 +89,22 @@ func (r *Runner) workerGitHubPolicy(ctx context.Context, cfg config.Config, issu
 		return workerGitHubPolicy{}, err
 	}
 	return policy.classifyCredential(ctx)
+}
+
+func (r *Runner) ProbeGitHubRESTBudget(ctx context.Context, issue connector.Issue) (telemetry.RESTBudget, bool, error) {
+	workflow, _, _, _ := r.runtimeSnapshot()
+	policy, err := r.workerGitHubPolicy(ctx, workflow.Config, issue.Identifier)
+	if err != nil {
+		return telemetry.RESTBudget{}, true, err
+	}
+	if !policy.Enabled {
+		return telemetry.RESTBudget{}, false, nil
+	}
+	budget, err := policy.probe(ctx)
+	if err != nil {
+		return telemetry.RESTBudget{}, true, err
+	}
+	return policy.restBudget(budget), true, nil
 }
 
 func workerGitHubPolicyName(policy workerGitHubPolicy) string {
@@ -568,11 +585,9 @@ func (p workerGitHubPolicy) probeContext(ctx context.Context) (context.Context, 
 
 func (p workerGitHubPolicy) observe(budget workerGitHubBudget, onUpdate AgentUpdateHandler) error {
 	consumer := telemetry.RESTConsumerWorker
-	endpointFamily := "worker credential"
 	usageAttribution := "worker"
 	if p.CredentialMode == workerGitHubCredentialShared {
 		consumer = telemetry.RESTConsumerSharedPool
-		endpointFamily = "shared credential pool"
 		usageAttribution = "indeterminate"
 	}
 	p.Logger.Info(
@@ -591,23 +606,31 @@ func (p workerGitHubPolicy) observe(budget workerGitHubBudget, onUpdate AgentUpd
 	if onUpdate == nil {
 		return nil
 	}
+	return onUpdate(AgentUpdate{
+		Type:       AgentUpdateRateLimits,
+		RateLimits: &telemetry.RateLimits{GitHubRESTBudgets: []telemetry.RESTBudget{p.restBudget(budget)}},
+	})
+}
+
+func (p workerGitHubPolicy) restBudget(budget workerGitHubBudget) telemetry.RESTBudget {
 	resetAt := budget.ResetAt
 	observedAt := budget.ObservedAt
-	return onUpdate(AgentUpdate{
-		Type: AgentUpdateRateLimits,
-		RateLimits: &telemetry.RateLimits{GitHubRESTBudgets: []telemetry.RESTBudget{{
-			Consumer:            consumer,
-			CredentialIdentity:  p.CredentialIdentity,
-			EndpointFamily:      endpointFamily,
-			Resource:            "core",
-			Remaining:           budget.Remaining,
-			Used:                budget.Used,
-			Limit:               budget.Limit,
-			MinRemainingReserve: p.MinRemaining,
-			ResetAt:             &resetAt,
-			ObservedAt:          &observedAt,
-		}}},
-	})
+	endpointFamily := "worker credential"
+	if p.CredentialMode == workerGitHubCredentialShared {
+		endpointFamily = "shared credential pool"
+	}
+	return telemetry.RESTBudget{
+		Consumer:            p.budgetConsumer(),
+		CredentialIdentity:  p.CredentialIdentity,
+		EndpointFamily:      endpointFamily,
+		Resource:            "core",
+		Remaining:           budget.Remaining,
+		Used:                budget.Used,
+		Limit:               budget.Limit,
+		MinRemainingReserve: p.MinRemaining,
+		ResetAt:             &resetAt,
+		ObservedAt:          &observedAt,
+	}
 }
 
 func (p workerGitHubPolicy) reserveError(budget workerGitHubBudget) error {
@@ -626,7 +649,15 @@ func (p workerGitHubPolicy) reserveError(budget workerGitHubBudget) error {
 		"limit", budget.Limit,
 		"reset_at", budget.ResetAt,
 	)
-	return fmt.Errorf("%w: remaining=%s reserve=%s reset_at=%s", ErrWorkerGitHubRESTReserved, strconv.FormatInt(budget.Remaining, 10), strconv.FormatInt(p.MinRemaining, 10), budget.ResetAt.Format(time.RFC3339))
+	return fmt.Errorf(
+		"%w: consumer=%s credential_identity=%s remaining=%s reserve=%s reset_at=%s",
+		ErrWorkerGitHubRESTReserved,
+		p.budgetConsumer(),
+		p.CredentialIdentity,
+		strconv.FormatInt(budget.Remaining, 10),
+		strconv.FormatInt(p.MinRemaining, 10),
+		budget.ResetAt.Format(time.RFC3339),
+	)
 }
 
 func (p workerGitHubPolicy) budgetConsumer() string {

--- a/internal/runner/worker_github_test.go
+++ b/internal/runner/worker_github_test.go
@@ -335,6 +335,11 @@ func TestWorkerGitHubGovernorStopsAtReserve(t *testing.T) {
 	if err := stop(); !errors.Is(err, ErrWorkerGitHubRESTReserved) {
 		t.Fatalf("stop governor error = %v, want ErrWorkerGitHubRESTReserved", err)
 	}
+	for _, want := range []string{"consumer=shared_pool", "credential_identity=github-rest:worker"} {
+		if !strings.Contains(context.Cause(governedCtx).Error(), want) {
+			t.Fatalf("context cause = %q, want containing %q", context.Cause(governedCtx), want)
+		}
+	}
 	for _, want := range []string{"remaining=1200", "worker_reserved_headroom=1250", "orchestrator_dispatch_floor=1000"} {
 		if !strings.Contains(logs.String(), want) {
 			t.Fatalf("logs = %q, want containing %q", logs.String(), want)


### PR DESCRIPTION
## Summary

- classify repeated-failure parks caused entirely by GitHub REST reserved-headroom errors as transient resource waits
- reuse fresh governor budget observations to restore the recorded prior lane after capacity rises above the worker reserve
- match recovery to the parked worker credential and independently probe that budget after its reset when no worker remains active
- persist one recovery action signature per REST reset window to prevent immediate re-exhaustion from thrashing
- expose remaining, limit, reserve, and reset state on the blocked surface, including legacy parks reconstructed from durable work attempts

The circuit breaker previously stored only the generic cause-fingerprint predicate. Because REST capacity was absent from that fingerprint, a park remained blocked after the shared pool recovered. The new recovery path records the resource evidence and prior lane while retaining the existing manual behavior for non-transient failures.

Fixes #1824

## UI Surface Contract

- [x] N/A; this changes the existing blocked-status reason and recovery metadata without adding or restructuring a primary operator screen.
- [x] This PR does not add persistent top-of-screen messaging.
- [x] No visual layout changed, so screenshot or browser verification is not applicable.

## Test Plan

- [x] `go test ./internal/orchestrator ./internal/runner -count=1`
- [x] `env -u DETENT_API_TOKEN go test -race ./internal/orchestrator ./internal/runner -count=1`
- [x] `go test ./internal/orchestrator -run '^TestRunParksRESTBudgetFailuresAsTransientRecovery$' -count=100`
- [x] `make check` on current head `9360e876`
- [x] Aggregate coverage 79.1%; configured package and exact-file coverage floors passed
- [x] Current-head CI run 31921025940 passed all 11 jobs
