### PR TITLE
fix(ops): log tmux status lifecycle

### DIFF
--- a/.detent/skills/verify-interactive-tmux-tui.md
+++ b/.detent/skills/verify-interactive-tmux-tui.md
@@ -1,0 +1,15 @@
+---
+name: verify-interactive-tmux-tui
+description: Reproduce and validate tmux behavior in Detent's real interactive TUI path without touching the live orchestrator.
+when_to_use: Use when tmux integration works in unit or headless tests but is reported broken while an operator runs Detent's interactive terminal dashboard.
+---
+
+# Verify the interactive TUI inside tmux
+
+- Build the target source into the Detent-provided temporary directory. For a release regression, export the exact tag there and build that source separately.
+- Generate an isolated memory-tracker runtime under the same temporary directory, then stop it and reuse its config with the root `detent --config ... --port 0` command so stdout remains a TTY and launches the terminal dashboard.
+- Start a private tmux server with its socket under the Detent temporary directory. If the absolute socket path exceeds the platform limit, change into that directory and use a relative `-S` socket name.
+- Create a target window and an untouched control window. Disable `automatic-rename` and `allow-rename` on both so an explicit rename persists and terminal escape sequences cannot confound the result.
+- Attach a real client to the target window before starting Detent. Launch Detent through `tmux send-keys`, then poll tmux window metadata for the expected name with a bounded deadline.
+- Record stable window IDs, pane IDs, names, active flags, and current commands. Assert that only the caller window changes, the control window remains untouched, and the displayed counts match the isolated board state.
+- Inspect the isolated runtime log for initialization and first-success records. Send the TUI its normal interrupt, verify the original target name is restored, and detach the private client. Never bind port 4000 or signal the live Detent process.

--- a/internal/cli/boot.go
+++ b/internal/cli/boot.go
@@ -331,7 +331,7 @@ func startRunningWithDependencies(ctx context.Context, cfg BootConfig, deps star
 	var windowStatus *tmuxstatus.Status
 	tmuxPane := os.Getenv("TMUX_PANE")
 	if tmuxstatus.Enabled(os.Getenv("TMUX"), tmuxPane, cfg.Global.Ops.TmuxWindowStatus) {
-		windowStatus, err = tmuxstatus.New(runCtx, tmuxPane)
+		windowStatus, err = tmuxstatus.New(runCtx, tmuxPane, logger)
 		if err != nil {
 			logger.Warn("initialize tmux window status failed", "error", err)
 		}

--- a/internal/tmuxstatus/status.go
+++ b/internal/tmuxstatus/status.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log/slog"
 	"os/exec"
 	"strings"
 	"sync"
@@ -21,6 +22,8 @@ type Status struct {
 	target       string
 	originalName string
 	lastName     string
+	logger       *slog.Logger
+	renameOnce   sync.Once
 	closeOnce    sync.Once
 	closeErr     error
 }
@@ -32,13 +35,16 @@ func Enabled(tmux, pane string, configured *bool) bool {
 	return configured == nil || *configured
 }
 
-func New(ctx context.Context, pane string) (*Status, error) {
-	return newStatus(ctx, execCommandRunner{}, pane)
+func New(ctx context.Context, pane string, logger *slog.Logger) (*Status, error) {
+	return newStatus(ctx, execCommandRunner{}, pane, logger)
 }
 
-func newStatus(ctx context.Context, runner commandRunner, pane string) (*Status, error) {
+func newStatus(ctx context.Context, runner commandRunner, pane string, logger *slog.Logger) (*Status, error) {
 	if ctx == nil {
 		ctx = context.Background()
+	}
+	if logger == nil {
+		logger = slog.Default()
 	}
 	if runner == nil {
 		return nil, errors.New("tmux command runner is required")
@@ -57,11 +63,14 @@ func newStatus(ctx context.Context, runner commandRunner, pane string) (*Status,
 		return nil, errors.New("read current tmux window: unexpected response")
 	}
 
-	return &Status{
+	status := &Status{
 		runner:       runner,
 		target:       strings.TrimSpace(windowID),
 		originalName: originalName,
-	}, nil
+		logger:       logger,
+	}
+	logger.Info("initialized tmux window status", "window_id", status.target, "original_name", status.originalName)
+	return status, nil
 }
 
 func Format(counts telemetry.Counts) string {
@@ -80,6 +89,9 @@ func (s *Status) Update(ctx context.Context, snapshot telemetry.Snapshot) error 
 		return fmt.Errorf("rename tmux window: %w", err)
 	}
 	s.lastName = name
+	s.renameOnce.Do(func() {
+		s.logger.Info("tmux window status renamed", "window_id", s.target, "name", name)
+	})
 	return nil
 }
 

--- a/internal/tmuxstatus/status_test.go
+++ b/internal/tmuxstatus/status_test.go
@@ -1,9 +1,13 @@
 package tmuxstatus
 
 import (
+	"bytes"
 	"context"
 	"errors"
+	"io"
+	"log/slog"
 	"reflect"
+	"strings"
 	"testing"
 
 	"github.com/digitaldrywood/detent/internal/telemetry"
@@ -65,7 +69,7 @@ func TestFormat(t *testing.T) {
 func TestStatusLifecycle(t *testing.T) {
 	t.Parallel()
 	runner := &recordingRunner{output: "@7\tDetent:2\n"}
-	status, err := newStatus(context.Background(), runner, "%7")
+	status, err := newStatus(context.Background(), runner, "%7", discardLogger())
 	if err != nil {
 		t.Fatalf("newStatus() error = %v", err)
 	}
@@ -125,7 +129,7 @@ func TestStatusUpdateUsesCurrentBlockedRows(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
 			runner := &recordingRunner{output: "@7\tDetent:2\n"}
-			status, err := newStatus(context.Background(), runner, "%7")
+			status, err := newStatus(context.Background(), runner, "%7", discardLogger())
 			if err != nil {
 				t.Fatalf("newStatus() error = %v", err)
 			}
@@ -144,7 +148,7 @@ func TestStatusUpdateUsesCurrentBlockedRows(t *testing.T) {
 func TestStatusRetriesFailedRename(t *testing.T) {
 	t.Parallel()
 	runner := &recordingRunner{output: "@7\tDetent:2\n"}
-	status, err := newStatus(context.Background(), runner, "%7")
+	status, err := newStatus(context.Background(), runner, "%7", discardLogger())
 	if err != nil {
 		t.Fatalf("newStatus() error = %v", err)
 	}
@@ -163,6 +167,77 @@ func TestStatusRetriesFailedRename(t *testing.T) {
 	if len(runner.calls) != 3 || !reflect.DeepEqual(runner.calls[1], wantRename) || !reflect.DeepEqual(runner.calls[2], wantRename) {
 		t.Fatalf("commands = %#v, want two rename attempts %#v", runner.calls, wantRename)
 	}
+}
+
+func TestStatusLogsLifecycle(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name          string
+		firstFails    bool
+		firstCounts   telemetry.Counts
+		secondCounts  telemetry.Counts
+		wantFirstName string
+	}{
+		{
+			name:          "logs first successful rename only",
+			firstCounts:   telemetry.Counts{Running: 1},
+			secondCounts:  telemetry.Counts{Running: 2},
+			wantFirstName: "detent 1r/0q/0b",
+		},
+		{
+			name:          "failed rename does not consume first success log",
+			firstFails:    true,
+			firstCounts:   telemetry.Counts{Running: 1},
+			secondCounts:  telemetry.Counts{Running: 2},
+			wantFirstName: "detent 2r/0q/0b",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			var logs bytes.Buffer
+			logger := slog.New(slog.NewTextHandler(&logs, nil))
+			runner := &recordingRunner{output: "@7\tDetent:2\n"}
+			status, err := newStatus(context.Background(), runner, "%7", logger)
+			if err != nil {
+				t.Fatalf("newStatus() error = %v", err)
+			}
+
+			if test.firstFails {
+				runner.err = errors.New("tmux unavailable")
+			}
+			firstErr := status.Update(context.Background(), telemetry.Snapshot{Counts: test.firstCounts})
+			if test.firstFails && firstErr == nil {
+				t.Fatal("first Update() error = nil, want rename failure")
+			}
+			if !test.firstFails && firstErr != nil {
+				t.Fatalf("first Update() error = %v", firstErr)
+			}
+			runner.err = nil
+			if err := status.Update(context.Background(), telemetry.Snapshot{Counts: test.secondCounts}); err != nil {
+				t.Fatalf("second Update() error = %v", err)
+			}
+
+			output := logs.String()
+			if got := strings.Count(output, "msg=\"initialized tmux window status\""); got != 1 {
+				t.Fatalf("initialization log count = %d, want 1; logs:\n%s", got, output)
+			}
+			if !strings.Contains(output, "window_id=@7 original_name=Detent:2") {
+				t.Fatalf("initialization log missing window metadata; logs:\n%s", output)
+			}
+			if got := strings.Count(output, "msg=\"tmux window status renamed\""); got != 1 {
+				t.Fatalf("rename log count = %d, want 1; logs:\n%s", got, output)
+			}
+			if !strings.Contains(output, "window_id=@7 name=\""+test.wantFirstName+"\"") {
+				t.Fatalf("rename log missing first successful name %q; logs:\n%s", test.wantFirstName, output)
+			}
+		})
+	}
+}
+
+func discardLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(io.Discard, nil))
 }
 
 type recordingRunner struct {


### PR DESCRIPTION
## Summary

- record the resolved tmux window ID and original name when status tracking initializes
- record the first successful status rename once, including the target and rendered counts
- preserve a reusable attached-TUI verification recipe for future tmux regressions

Fixes #1826

## UI Surface Contract

- [x] N/A; this PR adds runtime observability without changing UI surfaces.
- [x] This PR does not add persistent top-of-screen messaging.
- [x] N/A; this PR has no visual changes to primary operator screens.

## Test Plan

- [x] `go test ./internal/tmuxstatus ./internal/cli -count=1`
- [x] Attached isolated tmux TUI: caller window renamed within one tick, control window untouched, blocked count remained zero, lifecycle logs emitted, and original name restored on exit
- [x] `PATH="$(go env GOBIN):$PATH" make check` (golangci-lint v2.1.6; 79.0% coverage)
