### PR TITLE
perf(web): bound workflow flow query

### DIFF
--- a/db/queries/store.sql
+++ b/db/queries/store.sql
@@ -683,24 +683,8 @@ FROM workflow_phase_events AS event
 WHERE event.finished_at IS NOT NULL
   AND event.phase_type IN ('agent_session', 'local_check', 'ci')
   AND (sqlc.narg(project_id) IS NULL OR event.project_id = sqlc.narg(project_id))
-  AND EXISTS (
-    SELECT 1
-    FROM workflow_phase_events AS lane
-    WHERE lane.finished_at IS NOT NULL
-      AND lane.phase_type = 'lane'
-      AND (sqlc.narg(project_id) IS NULL OR lane.project_id = sqlc.narg(project_id))
-      AND (sqlc.narg(from_time) IS NULL OR lane.finished_at >= sqlc.narg(from_time))
-      AND (sqlc.narg(to_time) IS NULL OR lane.finished_at < sqlc.narg(to_time))
-      AND event.project_id = lane.project_id
-      AND event.started_at < lane.finished_at
-      AND event.finished_at > lane.started_at
-      AND (
-        (event.issue_id IS NOT NULL AND event.issue_id <> '' AND event.issue_id = lane.issue_id)
-        OR (event.identifier IS NOT NULL AND event.identifier <> '' AND event.identifier = lane.identifier)
-        OR (event.issue_url IS NOT NULL AND event.issue_url <> '' AND event.issue_url = lane.issue_url)
-        OR (event.pr_number IS NOT NULL AND event.pr_number = lane.pr_number)
-      )
-  )
+  AND (sqlc.narg(from_time) IS NULL OR event.finished_at > sqlc.narg(from_time))
+  AND (sqlc.narg(to_time) IS NULL OR event.started_at < sqlc.narg(to_time))
 ORDER BY event.project_id, event.phase_type, event.phase_name, event.finished_at, event.id;
 
 -- name: IssueWorkflowTimelineRows :many

--- a/internal/store/metrics.go
+++ b/internal/store/metrics.go
@@ -125,10 +125,22 @@ func (s *sqliteStore) WorkflowMetricsReport(ctx context.Context, query WorkflowM
 		}
 	}
 
+	flowFrom, flowTo, ok := workflowLaneFlowBounds(flowRows)
+	if !ok {
+		return workflowMetricsReport(metricRows, flowRows, query.From, query.To), nil
+	}
+	flowFromTime, err := optionalTimestamp("flow_from", flowFrom)
+	if err != nil {
+		return WorkflowMetricsReport{}, err
+	}
+	flowToTime, err := optionalTimestamp("flow_to", flowTo)
+	if err != nil {
+		return WorkflowMetricsReport{}, err
+	}
 	activeRows, err := s.queries.WorkflowPhaseFlowRows(ctx, sqlc.WorkflowPhaseFlowRowsParams{
 		ProjectID: nullString(query.ProjectID),
-		FromTime:  from,
-		ToTime:    to,
+		FromTime:  flowFromTime,
+		ToTime:    flowToTime,
 	})
 	if err != nil {
 		return WorkflowMetricsReport{}, fmt.Errorf("reading workflow flow metrics: %w", err)
@@ -214,6 +226,24 @@ type workflowLaneTrendAccumulator struct {
 	phaseName  string
 	buckets    []workflowLaneTrendBucket
 	totalCount int64
+}
+
+func workflowLaneFlowBounds(rows []workflowMetricRow) (time.Time, time.Time, bool) {
+	var from time.Time
+	var to time.Time
+	for _, row := range rows {
+		event := row.event
+		if event.PhaseType != WorkflowPhaseTypeLane || !workflowEventHasInterval(event) {
+			continue
+		}
+		if from.IsZero() || event.StartedAt.Before(from) {
+			from = event.StartedAt
+		}
+		if to.IsZero() || event.FinishedAt.After(to) {
+			to = event.FinishedAt
+		}
+	}
+	return from, to, !from.IsZero() && from.Before(to)
 }
 
 func workflowMetricRowsFromEvents(rows []sqlc.WorkflowPhaseEvent) ([]workflowMetricRow, error) {

--- a/internal/store/sqlc/store.sql.go
+++ b/internal/store/sqlc/store.sql.go
@@ -4672,24 +4672,8 @@ FROM workflow_phase_events AS event
 WHERE event.finished_at IS NOT NULL
   AND event.phase_type IN ('agent_session', 'local_check', 'ci')
   AND (?1 IS NULL OR event.project_id = ?1)
-  AND EXISTS (
-    SELECT 1
-    FROM workflow_phase_events AS lane
-    WHERE lane.finished_at IS NOT NULL
-      AND lane.phase_type = 'lane'
-      AND (?1 IS NULL OR lane.project_id = ?1)
-      AND (?2 IS NULL OR lane.finished_at >= ?2)
-      AND (?3 IS NULL OR lane.finished_at < ?3)
-      AND event.project_id = lane.project_id
-      AND event.started_at < lane.finished_at
-      AND event.finished_at > lane.started_at
-      AND (
-        (event.issue_id IS NOT NULL AND event.issue_id <> '' AND event.issue_id = lane.issue_id)
-        OR (event.identifier IS NOT NULL AND event.identifier <> '' AND event.identifier = lane.identifier)
-        OR (event.issue_url IS NOT NULL AND event.issue_url <> '' AND event.issue_url = lane.issue_url)
-        OR (event.pr_number IS NOT NULL AND event.pr_number = lane.pr_number)
-      )
-  )
+  AND (?2 IS NULL OR event.finished_at > ?2)
+  AND (?3 IS NULL OR event.started_at < ?3)
 ORDER BY event.project_id, event.phase_type, event.phase_name, event.finished_at, event.id
 `
 

--- a/internal/web/api_benchmark_test.go
+++ b/internal/web/api_benchmark_test.go
@@ -2,6 +2,8 @@ package web_test
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"path/filepath"
@@ -17,48 +19,25 @@ import (
 	"github.com/digitaldrywood/detent/internal/web"
 )
 
-func BenchmarkProjectStateAPIWarmCache(b *testing.B) {
-	ctx := context.Background()
-	backend, err := store.Open(ctx, store.Config{
-		Backend: store.BackendSQLite,
-		Path:    filepath.Join(b.TempDir(), "detent.db"),
-	})
-	if err != nil {
-		b.Fatalf("store.Open() error = %v", err)
-	}
-	b.Cleanup(func() {
-		if err := backend.Close(); err != nil {
-			b.Fatalf("Close() error = %v", err)
-		}
-	})
+const projectStatePerformanceDeadline = 2 * time.Second
 
-	now := time.Date(2026, 8, 15, 22, 16, 27, 0, time.UTC)
-	seedBenchmarkWorkflowEvents(b, backend, now)
-	snapshot := benchmarkProjectStateSnapshot(now)
-	snapshotHub := hub.New[telemetry.Snapshot]()
-	if err := snapshotHub.Publish(snapshot); err != nil {
-		b.Fatalf("Publish() error = %v", err)
-	}
-	server, err := web.NewServer(web.Config{}, web.Dependencies{
-		Hub:       snapshotHub,
-		Store:     backend,
-		Registry:  project.NewRegistry(),
-		Connector: connectorProbe{name: "memory"},
-	})
-	if err != nil {
-		b.Fatalf("NewServer() error = %v", err)
-	}
+func BenchmarkProjectStateAPIWarmStoreChangingSnapshot(b *testing.B) {
+	server, snapshotHub, snapshot := newProjectStatePerformanceServer(b, 5000, 2600)
 
-	warm := httptest.NewRecorder()
-	server.Handler().ServeHTTP(warm, httptest.NewRequestWithContext(b.Context(), http.MethodGet, "/api/v1/projects/detent/state", nil))
+	warm := projectStatePerformanceRequest(b.Context(), server, 0)
 	if warm.Code != http.StatusOK {
 		b.Fatalf("warm status = %d, want %d; body = %s", warm.Code, http.StatusOK, warm.Body.String())
 	}
 	responseBytes := warm.Body.Len()
 	b.ResetTimer()
+	index := 0
 	for b.Loop() {
-		recorder := httptest.NewRecorder()
-		server.Handler().ServeHTTP(recorder, httptest.NewRequestWithContext(b.Context(), http.MethodGet, "/api/v1/projects/detent/state", nil))
+		index++
+		snapshot.GeneratedAt = snapshot.GeneratedAt.Add(time.Second)
+		if err := snapshotHub.Publish(snapshot); err != nil {
+			b.Fatalf("Publish() error = %v", err)
+		}
+		recorder := projectStatePerformanceRequest(b.Context(), server, index)
 		if recorder.Code != http.StatusOK {
 			b.Fatalf("status = %d, want %d; body = %s", recorder.Code, http.StatusOK, recorder.Body.String())
 		}
@@ -67,15 +46,90 @@ func BenchmarkProjectStateAPIWarmCache(b *testing.B) {
 	b.ReportMetric(float64(responseBytes), "bytes/response")
 }
 
-func seedBenchmarkWorkflowEvents(b *testing.B, backend store.Store, now time.Time) {
-	b.Helper()
-	const laneEvents = 1670
-	const activeEvents = 870
+func TestProjectStateAPIRepresentativeDataCompletesBeforeDeadline(t *testing.T) {
+	server, snapshotHub, snapshot := newProjectStatePerformanceServer(t, 1000, 500)
+
+	warm := projectStatePerformanceRequest(t.Context(), server, 0)
+	if warm.Code != http.StatusOK {
+		t.Fatalf("warm status = %d, want %d; body = %s", warm.Code, http.StatusOK, warm.Body.String())
+	}
+	snapshot.GeneratedAt = snapshot.GeneratedAt.Add(time.Second)
+	if err := snapshotHub.Publish(snapshot); err != nil {
+		t.Fatalf("Publish() error = %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(t.Context(), projectStatePerformanceDeadline)
+	defer cancel()
+	recorder := projectStatePerformanceRequest(ctx, server, 1)
+	if errors.Is(ctx.Err(), context.DeadlineExceeded) {
+		t.Fatalf("project state request exceeded %s", projectStatePerformanceDeadline)
+	}
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d; body = %s", recorder.Code, http.StatusOK, recorder.Body.String())
+	}
+}
+
+func newProjectStatePerformanceServer(
+	tb testing.TB,
+	laneEvents int,
+	activeEvents int,
+) (*web.Server, *hub.Hub[telemetry.Snapshot], telemetry.Snapshot) {
+	tb.Helper()
+	ctx := context.Background()
+	backend, err := store.Open(ctx, store.Config{
+		Backend: store.BackendSQLite,
+		Path:    filepath.Join(tb.TempDir(), "detent.db"),
+	})
+	if err != nil {
+		tb.Fatalf("store.Open() error = %v", err)
+	}
+	tb.Cleanup(func() {
+		if err := backend.Close(); err != nil {
+			tb.Fatalf("Close() error = %v", err)
+		}
+	})
+
+	now := time.Date(2026, 8, 15, 22, 16, 27, 0, time.UTC)
+	seedProjectStatePerformanceEvents(tb, ctx, backend, now, laneEvents, activeEvents)
+	snapshot := benchmarkProjectStateSnapshot(now)
+	snapshotHub := hub.New[telemetry.Snapshot]()
+	if err := snapshotHub.Publish(snapshot); err != nil {
+		tb.Fatalf("Publish() error = %v", err)
+	}
+	server, err := web.NewServer(web.Config{}, web.Dependencies{
+		Hub:       snapshotHub,
+		Store:     backend,
+		Registry:  project.NewRegistry(),
+		Connector: connectorProbe{name: "memory"},
+	})
+	if err != nil {
+		tb.Fatalf("NewServer() error = %v", err)
+	}
+	return server, snapshotHub, snapshot
+}
+
+func projectStatePerformanceRequest(ctx context.Context, server *web.Server, index int) *httptest.ResponseRecorder {
+	recorder := httptest.NewRecorder()
+	request := httptest.NewRequestWithContext(ctx, http.MethodGet, "/api/v1/projects/detent/state", nil)
+	request.RemoteAddr = fmt.Sprintf("[2001:db8::%x]:1234", index+1)
+	server.Handler().ServeHTTP(recorder, request)
+	return recorder
+}
+
+func seedProjectStatePerformanceEvents(
+	tb testing.TB,
+	ctx context.Context,
+	backend store.Store,
+	now time.Time,
+	laneEvents int,
+	activeEvents int,
+) {
+	tb.Helper()
 
 	for index := range laneEvents {
 		finishedAt := now.Add(-time.Duration(index%720) * time.Hour)
 		issueIndex := index % activeEvents
-		_, err := backend.RecordWorkflowPhaseEvent(b.Context(), store.WorkflowPhaseEvent{
+		_, err := backend.RecordWorkflowPhaseEvent(ctx, store.WorkflowPhaseEvent{
 			ProjectID:       "detent",
 			IssueID:         "issue-" + strconv.Itoa(issueIndex),
 			Identifier:      "digitaldrywood/detent#" + strconv.Itoa(issueIndex+1),
@@ -87,12 +141,12 @@ func seedBenchmarkWorkflowEvents(b *testing.B, backend store.Store, now time.Tim
 			DurationSeconds: 600,
 		})
 		if err != nil {
-			b.Fatalf("RecordWorkflowPhaseEvent(lane %d) error = %v", index, err)
+			tb.Fatalf("RecordWorkflowPhaseEvent(lane %d) error = %v", index, err)
 		}
 	}
 	for index := range activeEvents {
 		finishedAt := now.Add(-time.Duration(index%720) * time.Hour)
-		_, err := backend.RecordWorkflowPhaseEvent(b.Context(), store.WorkflowPhaseEvent{
+		_, err := backend.RecordWorkflowPhaseEvent(ctx, store.WorkflowPhaseEvent{
 			ProjectID:       "detent",
 			IssueID:         "issue-" + strconv.Itoa(index),
 			Identifier:      "digitaldrywood/detent#" + strconv.Itoa(index+1),
@@ -107,13 +161,13 @@ func seedBenchmarkWorkflowEvents(b *testing.B, backend store.Store, now time.Tim
 			EndpointFamily:  "codex",
 		})
 		if err != nil {
-			b.Fatalf("RecordWorkflowPhaseEvent(active %d) error = %v", index, err)
+			tb.Fatalf("RecordWorkflowPhaseEvent(active %d) error = %v", index, err)
 		}
 	}
 }
 
 func benchmarkProjectStateSnapshot(now time.Time) telemetry.Snapshot {
-	const workAttempts = 600
+	const workAttempts = 300
 	snapshot := telemetry.Snapshot{
 		GeneratedAt: now,
 		Project:     telemetry.Project{ID: "detent", DisplayName: "Detent"},


### PR DESCRIPTION
## Summary

- bound workflow phase-flow SQL to the lane-event time range already loaded for the response
- preserve issue identity and interval-overlap filtering in Go while avoiding the correlated full-history scan
- add a changing-snapshot benchmark and a deterministic 2-second regression test

## Profile Summary

The representative fixture models the reported endpoint with 5,000 lane events, 2,600 active-state events, 300 attempts, and a 244,938-byte response. Each measured request republishes the snapshot with a new `GeneratedAt`, so it exercises the warm-store response path instead of returning a cached whole snapshot.

Before the change, one warm request took 13.636 seconds. CPU profiling attributed 11.47 seconds cumulative (91.2%) to workflow metrics and 11.14 seconds (88.6%) to `WorkflowPhaseFlowRows`. The correlated `EXISTS` query was executed for six workflow reports and repeatedly scanned history. Per-issue response hydration and N+1 store queries were eliminated as dominant causes; activity/history recomputation was confirmed.

After bounding the SQL candidate set by the loaded lane-event interval, six warm runs took 400–437 ms (about 32x faster) at the same payload size. The post-change profile reduced cumulative SQLite query time to about 0.54 seconds across the profiled benchmark. No cache layer was added.

Fixes #1827

## Test Plan

- `go test ./internal/store -run '^TestWorkflowMetrics' -count=1`
- `go test -race ./internal/web -run '^TestProjectStateAPIRepresentativeDataCompletesBeforeDeadline$' -count=10`
- `go test -race ./internal/store -run '^TestWorkflowMetrics' -count=10`
- `go test ./internal/web -run '^$' -bench '^BenchmarkProjectStateAPIWarmStoreChangingSnapshot$' -benchtime=6x -count=1 -benchmem`
- `make check`