### PR TITLE
fix(test): eliminate Windows Core timing flakes

### DIFF
--- a/internal/store/pool_contention_e2e_test.go
+++ b/internal/store/pool_contention_e2e_test.go
@@ -91,19 +91,26 @@ func TestPoolContentionTelemetryEndToEnd(t *testing.T) {
 		errCh <- orch.Run(runCtx)
 	}()
 
-	refusal := waitForSchedulerDecision(
-		t,
-		runtimeStore,
+	if _, err := orch.State(ctx); err != nil {
+		t.Fatalf("orchestrator State() error = %v", err)
+	}
+	decisions, err := runtimeStore.ListRecentSchedulerDecisions(
+		ctx,
+		store.SchedulerDecisionQuery{Limit: 100},
+	)
+	if err != nil {
+		t.Fatalf("ListRecentSchedulerDecisions() error = %v", err)
+	}
+	refusal, ok := schedulerDecisionWithReason(
+		decisions,
 		scheduler.DispatchGateReasonReservedForHigherPriorityProject,
 	)
+	if !ok {
+		t.Fatalf("scheduler decision %q not found; decisions = %#v", scheduler.DispatchGateReasonReservedForHigherPriorityProject, decisions)
+	}
 	cancel()
-	select {
-	case err := <-errCh:
-		if !errors.Is(err, context.Canceled) {
-			t.Fatalf("orchestrator Run() error = %v, want context canceled", err)
-		}
-	case <-time.After(5 * time.Second):
-		t.Fatal("timed out waiting for orchestrator to stop")
+	if err := <-errCh; !errors.Is(err, context.Canceled) {
+		t.Fatalf("orchestrator Run() error = %v, want context canceled", err)
 	}
 
 	if refusal.ProjectID != cloudProject.ID || refusal.IssueID != issue.ID {
@@ -184,38 +191,11 @@ func TestPoolContentionTelemetryEndToEnd(t *testing.T) {
 	}
 }
 
-func waitForSchedulerDecision(
-	t *testing.T,
-	runtimeStore store.Store,
-	reason string,
-) store.SchedulerDecision {
-	t.Helper()
-
-	timeout := time.NewTimer(time.Second)
-	defer timeout.Stop()
-	ticker := time.NewTicker(10 * time.Millisecond)
-	defer ticker.Stop()
-
-	var last []store.SchedulerDecision
-	for {
-		decisions, err := runtimeStore.ListRecentSchedulerDecisions(
-			t.Context(),
-			store.SchedulerDecisionQuery{Limit: 100},
-		)
-		if err != nil {
-			t.Fatalf("ListRecentSchedulerDecisions() error = %v", err)
-		}
-		last = decisions
-		for _, decision := range decisions {
-			if decision.Reason == reason {
-				return decision
-			}
-		}
-
-		select {
-		case <-timeout.C:
-			t.Fatalf("timed out waiting for scheduler decision %q; decisions = %#v", reason, last)
-		case <-ticker.C:
+func schedulerDecisionWithReason(decisions []store.SchedulerDecision, reason string) (store.SchedulerDecision, bool) {
+	for _, decision := range decisions {
+		if decision.Reason == reason {
+			return decision, true
 		}
 	}
+	return store.SchedulerDecision{}, false
 }

--- a/internal/store/pool_contention_e2e_test.go
+++ b/internal/store/pool_contention_e2e_test.go
@@ -21,6 +21,7 @@ import (
 func TestPoolContentionTelemetryEndToEnd(t *testing.T) {
 	t.Parallel()
 
+	const synchronizationWatchdog = 2 * time.Minute
 	ctx := t.Context()
 	dbPath := filepath.Join(t.TempDir(), "detent.db")
 	runtimeStore, err := store.Open(ctx, store.Config{
@@ -91,7 +92,9 @@ func TestPoolContentionTelemetryEndToEnd(t *testing.T) {
 		errCh <- orch.Run(runCtx)
 	}()
 
-	if _, err := orch.State(ctx); err != nil {
+	stateCtx, cancelState := context.WithTimeout(ctx, synchronizationWatchdog)
+	defer cancelState()
+	if _, err := orch.State(stateCtx); err != nil {
 		t.Fatalf("orchestrator State() error = %v", err)
 	}
 	decisions, err := runtimeStore.ListRecentSchedulerDecisions(
@@ -109,8 +112,13 @@ func TestPoolContentionTelemetryEndToEnd(t *testing.T) {
 		t.Fatalf("scheduler decision %q not found; decisions = %#v", scheduler.DispatchGateReasonReservedForHigherPriorityProject, decisions)
 	}
 	cancel()
-	if err := <-errCh; !errors.Is(err, context.Canceled) {
-		t.Fatalf("orchestrator Run() error = %v, want context canceled", err)
+	select {
+	case err := <-errCh:
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("orchestrator Run() error = %v, want context canceled", err)
+		}
+	case <-time.After(synchronizationWatchdog):
+		t.Fatal("orchestrator did not stop before synchronization watchdog")
 	}
 
 	if refusal.ProjectID != cloudProject.ID || refusal.IssueID != issue.ID {

--- a/internal/web/api_benchmark_norace_test.go
+++ b/internal/web/api_benchmark_norace_test.go
@@ -1,0 +1,5 @@
+//go:build !race
+
+package web_test
+
+const projectStatePerformanceDeadlineEnabled = true

--- a/internal/web/api_benchmark_race_test.go
+++ b/internal/web/api_benchmark_race_test.go
@@ -1,0 +1,5 @@
+//go:build race
+
+package web_test
+
+const projectStatePerformanceDeadlineEnabled = false

--- a/internal/web/api_benchmark_test.go
+++ b/internal/web/api_benchmark_test.go
@@ -58,10 +58,14 @@ func TestProjectStateAPIRepresentativeDataCompletesBeforeDeadline(t *testing.T) 
 		t.Fatalf("Publish() error = %v", err)
 	}
 
-	ctx, cancel := context.WithTimeout(t.Context(), projectStatePerformanceDeadline)
+	ctx := t.Context()
+	cancel := func() {}
+	if projectStatePerformanceDeadlineEnabled {
+		ctx, cancel = context.WithTimeout(ctx, projectStatePerformanceDeadline)
+	}
 	defer cancel()
 	recorder := projectStatePerformanceRequest(ctx, server, 1)
-	if errors.Is(ctx.Err(), context.DeadlineExceeded) {
+	if projectStatePerformanceDeadlineEnabled && errors.Is(ctx.Err(), context.DeadlineExceeded) {
 		t.Fatalf("project state request exceeded %s", projectStatePerformanceDeadline)
 	}
 	if recorder.Code != http.StatusOK {

--- a/internal/web/server_test.go
+++ b/internal/web/server_test.go
@@ -7504,40 +7504,22 @@ func TestBoardFirstPaintDoesNotWaitForSnapshotEnrichment(t *testing.T) {
 	go func() {
 		defer close(eventsDone)
 		rec := httptest.NewRecorder()
-		req := httptest.NewRequest(http.MethodGet, "/events?view=board", nil).WithContext(eventsCtx)
+		req := httptest.NewRequestWithContext(eventsCtx, http.MethodGet, "/events?view=board", nil)
 		server.Handler().ServeHTTP(rec, req)
 	}()
 
-	select {
-	case <-started:
-	case <-time.After(time.Second):
-		t.Fatal("snapshot enrichment did not start")
-	}
+	<-started
 
-	type response struct {
-		code int
-		body string
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/", nil)
+	server.Handler().ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d; body = %s", rec.Code, http.StatusOK, rec.Body.String())
 	}
-	responseReady := make(chan response, 1)
-	go func() {
-		rec := httptest.NewRecorder()
-		req := httptest.NewRequest(http.MethodGet, "/", nil)
-		server.Handler().ServeHTTP(rec, req)
-		responseReady <- response{code: rec.Code, body: rec.Body.String()}
-	}()
-
-	select {
-	case got := <-responseReady:
-		if got.code != http.StatusOK {
-			t.Fatalf("status = %d, want %d; body = %s", got.code, http.StatusOK, got.body)
+	for _, want := range []string{"Cached board issue", generatedAt.Format(time.RFC3339), `id="live-clock"`} {
+		if !strings.Contains(rec.Body.String(), want) {
+			t.Fatalf("body missing %q:\n%s", want, rec.Body.String())
 		}
-		for _, want := range []string{"Cached board issue", generatedAt.Format(time.RFC3339), `id="live-clock"`} {
-			if !strings.Contains(got.body, want) {
-				t.Fatalf("body missing %q:\n%s", want, got.body)
-			}
-		}
-	case <-time.After(500 * time.Millisecond):
-		t.Fatal("board first paint exceeded 500ms while snapshot enrichment was blocked")
 	}
 	if got := fetchCalls.Load(); got != 0 {
 		t.Fatalf("FetchCandidateIssues calls = %d, want 0", got)
@@ -7545,11 +7527,7 @@ func TestBoardFirstPaintDoesNotWaitForSnapshotEnrichment(t *testing.T) {
 
 	close(release)
 	cancelEvents()
-	select {
-	case <-eventsDone:
-	case <-time.After(time.Second):
-		t.Fatal("event stream did not stop")
-	}
+	<-eventsDone
 }
 
 func TestBoardPageNavigationUsesCurrentInMemorySnapshot(t *testing.T) {

--- a/internal/web/server_test.go
+++ b/internal/web/server_test.go
@@ -7457,6 +7457,7 @@ func TestDashboardReadsLatestSnapshotWithoutSubscribing(t *testing.T) {
 func TestBoardFirstPaintDoesNotWaitForSnapshotEnrichment(t *testing.T) {
 	t.Parallel()
 
+	const synchronizationWatchdog = 2 * time.Minute
 	started := make(chan struct{})
 	release := make(chan struct{})
 	var startedOnce sync.Once
@@ -7508,18 +7509,39 @@ func TestBoardFirstPaintDoesNotWaitForSnapshotEnrichment(t *testing.T) {
 		server.Handler().ServeHTTP(rec, req)
 	}()
 
-	<-started
-
-	rec := httptest.NewRecorder()
-	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/", nil)
-	server.Handler().ServeHTTP(rec, req)
-	if rec.Code != http.StatusOK {
-		t.Fatalf("status = %d, want %d; body = %s", rec.Code, http.StatusOK, rec.Body.String())
+	select {
+	case <-started:
+	case <-time.After(synchronizationWatchdog):
+		t.Fatal("snapshot enrichment did not start before synchronization watchdog")
 	}
-	for _, want := range []string{"Cached board issue", generatedAt.Format(time.RFC3339), `id="live-clock"`} {
-		if !strings.Contains(rec.Body.String(), want) {
-			t.Fatalf("body missing %q:\n%s", want, rec.Body.String())
+
+	type response struct {
+		code int
+		body string
+	}
+	responseReady := make(chan response, 1)
+	go func() {
+		rec := httptest.NewRecorder()
+		req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/", nil)
+		server.Handler().ServeHTTP(rec, req)
+		responseReady <- response{code: rec.Code, body: rec.Body.String()}
+	}()
+
+	select {
+	case got := <-responseReady:
+		if got.code != http.StatusOK {
+			t.Fatalf("status = %d, want %d; body = %s", got.code, http.StatusOK, got.body)
 		}
+		for _, want := range []string{"Cached board issue", generatedAt.Format(time.RFC3339), `id="live-clock"`} {
+			if !strings.Contains(got.body, want) {
+				t.Fatalf("body missing %q:\n%s", want, got.body)
+			}
+		}
+	case <-time.After(synchronizationWatchdog):
+		close(release)
+		cancelEvents()
+		<-responseReady
+		t.Fatal("board first paint waited for blocked enrichment until synchronization watchdog")
 	}
 	if got := fetchCalls.Load(); got != 0 {
 		t.Fatalf("FetchCandidateIssues calls = %d, want 0", got)
@@ -7527,7 +7549,11 @@ func TestBoardFirstPaintDoesNotWaitForSnapshotEnrichment(t *testing.T) {
 
 	close(release)
 	cancelEvents()
-	<-eventsDone
+	select {
+	case <-eventsDone:
+	case <-time.After(synchronizationWatchdog):
+		t.Fatal("event stream did not stop before synchronization watchdog")
+	}
 }
 
 func TestBoardPageNavigationUsesCurrentInMemorySnapshot(t *testing.T) {


### PR DESCRIPTION
## Summary

- prove first paint uses cached state while enrichment remains blocked without measuring renderer speed
- synchronize pool-contention telemetry on completion of the orchestrator initial tick instead of polling SQLite against a one-second deadline
- preserve the bounded workflow-flow query and normal-build project-state performance deadline from #1829
- keep race instrumentation focused on response correctness because hosted-runner race overhead is not a stable performance signal

Fixes #1830
Fixes #1834

## UI Surface Contract

- [x] N/A, or the linked issue explicitly authorizes any high-impact UI surface, layout, density, first-viewport, or responsive visibility tradeoff.
- [x] Persistent top-of-screen messaging is explicitly authorized by the issue, or this PR does not add it.
- [x] Visual changes to primary operator screens include screenshot or browser verification below. N/A: test-only change.

## Test Plan

- [x] `make check`
- [x] focused repetition: first-paint and normal-build #1829 performance tests 50x; pool-contention test 100x
- [x] race repetition: web 10x; store 20x; representative project-state response 5x
- [x] Windows amd64 cross-compilation for both affected test packages
- [x] current-head CI, including Windows Core and Ubuntu race