### PR TITLE
fix(ops): reassert tmux window status

### DIFF
--- a/internal/cli/tmux_status.go
+++ b/internal/cli/tmux_status.go
@@ -58,7 +58,7 @@ func runTmuxWindowStatusUpdates(
 	logger *slog.Logger,
 ) {
 	var latest telemetry.Snapshot
-	pending := false
+	initialized := false
 	for {
 		select {
 		case <-ctx.Done():
@@ -68,12 +68,11 @@ func runTmuxWindowStatusUpdates(
 				return
 			}
 			latest = snapshot
-			pending = true
+			initialized = true
 		case <-ticks:
-			if !pending {
+			if !initialized {
 				continue
 			}
-			pending = false
 			if err := status.Update(ctx, latest); err != nil {
 				logger.Warn("update tmux window status failed", "error", err)
 			}

--- a/internal/cli/tmux_status_test.go
+++ b/internal/cli/tmux_status_test.go
@@ -34,6 +34,15 @@ func TestRunTmuxWindowStatusUpdatesCoalescesSnapshots(t *testing.T) {
 	if got := <-status.updates; got.Counts != want.Counts {
 		t.Fatalf("Update() counts = %#v, want %#v", got.Counts, want.Counts)
 	}
+	ticks <- time.Now()
+	select {
+	case got := <-status.updates:
+		if got.Counts != want.Counts {
+			t.Fatalf("reasserted Update() counts = %#v, want %#v", got.Counts, want.Counts)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("Update() was not called on the next tick")
+	}
 	select {
 	case got := <-status.updates:
 		t.Fatalf("extra Update() = %#v", got)

--- a/internal/telemetry/workload.go
+++ b/internal/telemetry/workload.go
@@ -34,12 +34,15 @@ func boardWorkload(snapshot Snapshot, projectID string) BoardWorkloadCounts {
 		if !boardWorkloadProjectMatches(issue, snapshot.Project.ID, projectID) {
 			return
 		}
-		state := normalizedWorkloadState(issue.State)
+		boardState := normalizeBoardState(strings.ReplaceAll(issue.State, "_", " "))
+		state := normalizedWorkloadState(boardState)
 		if state == "" {
 			state = fallback
 		}
-		if state == "" && rank < 30 {
-			return
+		if state == "" {
+			if rank < 30 || !nonWorkloadBoardState(boardState) {
+				return
+			}
 		}
 		key := issueStateKey(issue)
 		if key == "" {
@@ -128,6 +131,14 @@ func normalizedWorkloadState(state string) string {
 		return "Blocked"
 	}
 	return ""
+}
+
+func nonWorkloadBoardState(state string) bool {
+	switch state {
+	case "Backlog", "Done":
+		return true
+	}
+	return false
 }
 
 func blockedRowDependencyWaiting(row Blocked) bool {

--- a/internal/telemetry/workload.go
+++ b/internal/telemetry/workload.go
@@ -38,7 +38,7 @@ func boardWorkload(snapshot Snapshot, projectID string) BoardWorkloadCounts {
 		if state == "" {
 			state = fallback
 		}
-		if state == "" {
+		if state == "" && rank < 30 {
 			return
 		}
 		key := issueStateKey(issue)

--- a/internal/telemetry/workload_test.go
+++ b/internal/telemetry/workload_test.go
@@ -46,6 +46,14 @@ func TestBoardWorkload(t *testing.T) {
 			want: BoardWorkloadCounts{Blocked: 1},
 		},
 		{
+			name: "tracker terminal state removes stale blocked runtime state",
+			snapshot: Snapshot{
+				BoardIssues: []Issue{{ID: "done", State: "Done"}},
+				Blocked:     []Blocked{{Issue: Issue{ID: "done", State: "Blocked"}}},
+			},
+			want: BoardWorkloadCounts{},
+		},
+		{
 			name: "runtime rows fill absent board details without double counting",
 			snapshot: Snapshot{
 				Project: Project{ID: "detent"},

--- a/internal/telemetry/workload_test.go
+++ b/internal/telemetry/workload_test.go
@@ -54,6 +54,18 @@ func TestBoardWorkload(t *testing.T) {
 			want: BoardWorkloadCounts{},
 		},
 		{
+			name: "custom tracker states preserve runtime workload state",
+			snapshot: Snapshot{
+				BoardIssues: []Issue{
+					{ID: "running", State: "Research"},
+					{ID: "queued", State: "Draft"},
+				},
+				Running: []Running{{Issue: Issue{ID: "running"}}},
+				Queue:   []Queued{{Issue: Issue{ID: "queued"}}},
+			},
+			want: BoardWorkloadCounts{Load: 2, Todo: 1, Active: 1},
+		},
+		{
 			name: "runtime rows fill absent board details without double counting",
 			snapshot: Snapshot{
 				Project: Project{ID: "detent"},

--- a/internal/tmuxstatus/status.go
+++ b/internal/tmuxstatus/status.go
@@ -81,9 +81,17 @@ func (s *Status) Update(ctx context.Context, snapshot telemetry.Snapshot) error 
 	if s == nil {
 		return nil
 	}
-	name := Format(snapshot.EffectiveCounts())
+	counts := snapshot.EffectiveCounts()
+	counts.Blocked = telemetry.BoardWorkload(snapshot).Blocked
+	name := Format(counts)
 	if name == s.lastName {
-		return nil
+		currentName, err := s.runner.Output(ctx, "display-message", "-t", s.target, "-p", "#{window_name}")
+		if err != nil {
+			return fmt.Errorf("read current tmux window name: %w", err)
+		}
+		if strings.TrimSuffix(currentName, "\n") == name {
+			return nil
+		}
 	}
 	if err := s.runner.Run(ctx, "rename-window", "-t", s.target, name); err != nil {
 		return fmt.Errorf("rename tmux window: %w", err)

--- a/internal/tmuxstatus/status_test.go
+++ b/internal/tmuxstatus/status_test.go
@@ -68,7 +68,7 @@ func TestFormat(t *testing.T) {
 
 func TestStatusLifecycle(t *testing.T) {
 	t.Parallel()
-	runner := &recordingRunner{output: "@7\tDetent:2\n"}
+	runner := &recordingRunner{output: "@7\tDetent:2\n", windowName: "Detent:2"}
 	status, err := newStatus(context.Background(), runner, "%7", discardLogger())
 	if err != nil {
 		t.Fatalf("newStatus() error = %v", err)
@@ -95,6 +95,7 @@ func TestStatusLifecycle(t *testing.T) {
 	want := [][]string{
 		{"display-message", "-t", "%7", "-p", "#{window_id}\t#{window_name}"},
 		{"rename-window", "-t", "@7", "detent 2r/1q/3b"},
+		{"display-message", "-t", "@7", "-p", "#{window_name}"},
 		{"rename-window", "-t", "@7", "Detent:2"},
 	}
 	if !reflect.DeepEqual(runner.calls, want) {
@@ -102,7 +103,29 @@ func TestStatusLifecycle(t *testing.T) {
 	}
 }
 
-func TestStatusUpdateUsesCurrentBlockedRows(t *testing.T) {
+func TestStatusCorrectsExternalRenameOnNextUpdate(t *testing.T) {
+	t.Parallel()
+	runner := &recordingRunner{output: "@7\tDetent:2\n", windowName: "Detent:2"}
+	status, err := newStatus(context.Background(), runner, "%7", discardLogger())
+	if err != nil {
+		t.Fatalf("newStatus() error = %v", err)
+	}
+
+	snapshot := telemetry.Snapshot{Counts: telemetry.Counts{Running: 2, Queue: 3}}
+	if err := status.Update(context.Background(), snapshot); err != nil {
+		t.Fatalf("first Update() error = %v", err)
+	}
+	runner.windowName = "external-rename"
+	if err := status.Update(context.Background(), snapshot); err != nil {
+		t.Fatalf("second Update() error = %v", err)
+	}
+
+	if got, want := runner.windowName, "detent 2r/3q/0b"; got != want {
+		t.Fatalf("window name = %q, want %q", got, want)
+	}
+}
+
+func TestStatusUpdateUsesCurrentBoardCounts(t *testing.T) {
 	t.Parallel()
 	tests := []struct {
 		name     string
@@ -110,18 +133,28 @@ func TestStatusUpdateUsesCurrentBlockedRows(t *testing.T) {
 		want     string
 	}{
 		{
-			name: "ignores historical blocked count",
+			name: "ignores aggregate blocked count",
 			snapshot: telemetry.Snapshot{
-				Counts: telemetry.Counts{Running: 7, Blocked: 10},
+				Counts: telemetry.Counts{Running: 7, Queue: 6, Blocked: 10},
 			},
-			want: "detent 7r/0q/0b",
+			want: "detent 7r/6q/0b",
 		},
 		{
-			name: "counts current blocked rows",
+			name: "current tracker rows override stale blocked runtime rows",
 			snapshot: telemetry.Snapshot{
-				Blocked: []telemetry.Blocked{{}, {}},
+				Counts: telemetry.Counts{Running: 2, Queue: 3, Blocked: 15},
+				BoardIssues: []telemetry.Issue{
+					{ID: "blocked-1", State: "Blocked"},
+					{ID: "blocked-2", State: "Blocked"},
+					{ID: "stale-1", State: "Done"},
+				},
+				Blocked: []telemetry.Blocked{
+					{Issue: telemetry.Issue{ID: "blocked-1", State: "Blocked"}},
+					{Issue: telemetry.Issue{ID: "blocked-2", State: "Blocked"}},
+					{Issue: telemetry.Issue{ID: "stale-1", State: "Blocked"}},
+				},
 			},
-			want: "detent 0r/0q/2b",
+			want: "detent 2r/3q/2b",
 		},
 	}
 
@@ -241,17 +274,24 @@ func discardLogger() *slog.Logger {
 }
 
 type recordingRunner struct {
-	output string
-	err    error
-	calls  [][]string
+	output     string
+	windowName string
+	err        error
+	calls      [][]string
 }
 
 func (r *recordingRunner) Output(_ context.Context, args ...string) (string, error) {
 	r.calls = append(r.calls, append([]string(nil), args...))
+	if len(args) == 5 && args[0] == "display-message" && args[4] == "#{window_name}" {
+		return r.windowName + "\n", r.err
+	}
 	return r.output, r.err
 }
 
 func (r *recordingRunner) Run(_ context.Context, args ...string) error {
 	r.calls = append(r.calls, append([]string(nil), args...))
+	if r.err == nil && len(args) == 4 && args[0] == "rename-window" {
+		r.windowName = args[3]
+	}
 	return r.err
 }


### PR DESCRIPTION
## Summary

- recheck the actual tmux window name on each throttled tick and repair external renames
- derive the tmux blocked count from current board state instead of stale runtime rows
- preserve original-name restore behavior and cover tick, count, and shutdown semantics

Fixes #1831

## UI Surface Contract

- [x] N/A, or the linked issue explicitly authorizes any high-impact UI surface, layout, density, first-viewport, or responsive visibility tradeoff.
- [x] Persistent top-of-screen messaging is explicitly authorized by the issue, or this PR does not add it.
- [x] Visual changes to primary operator screens include screenshot or browser verification below.

Private tmux verification used an isolated memory tracker and separate tmux socket. The target recovered from `external-probe` to `detent 0r/0q/2b` on the next tick, the control window remained unchanged, and shutdown restored `target-original`.

## Test Plan

- [x] `make check`
- [x] focused tests for CLI tick reassertion, board workload precedence, and tmux lifecycle
- [x] isolated interactive tmux TUI verification