### PR TITLE
fix(merge): scope missing-check streaks by head

### DIFF
--- a/internal/orchestrator/blocked_cause_recovery.go
+++ b/internal/orchestrator/blocked_cause_recovery.go
@@ -561,11 +561,8 @@ func (o *Orchestrator) blockedReadyPullRequestDeferredReason(
 	signals blockedCauseSignals,
 	now time.Time,
 ) string {
-	if !o.cfg.MergeFastPathEnabled {
-		return "merge_fast_path_disabled"
-	}
-	if !stateIn(autoPromoteMergingState, o.cfg.ActiveStates) {
-		return "merging_lane_inactive"
+	if reason := o.mergeLaneUnavailableReason(); reason != "" {
+		return reason
 	}
 	autoPromoteCfg := normalizeAutoPromoteConfig(o.cfg.AutoPromote)
 	if !autoPromoteCfg.Enabled {
@@ -593,6 +590,16 @@ func (o *Orchestrator) blockedReadyPullRequestDeferredReason(
 	}
 	if !o.reworkBreakerAutoPromoteGateReady(ctx, state, issue, autoPromoteCfg, now) {
 		return "pull_request_gate_not_ready"
+	}
+	return ""
+}
+
+func (o *Orchestrator) mergeLaneUnavailableReason() string {
+	if !o.cfg.MergeFastPathEnabled {
+		return "merge_fast_path_disabled"
+	}
+	if !stateIn(autoPromoteMergingState, o.cfg.ActiveStates) {
+		return "merging_lane_inactive"
 	}
 	return ""
 }

--- a/internal/orchestrator/blocked_cause_recovery.go
+++ b/internal/orchestrator/blocked_cause_recovery.go
@@ -329,6 +329,9 @@ func (o *Orchestrator) recoverCauseBlockedIssue(
 		}
 		return false
 	}
+	if handled, transitioned := o.reconcilePersistentlyMissingRequiredCheckPark(ctx, state, issue, park, now); handled {
+		return transitioned
+	}
 	if handled, transitioned := o.reconcileBlockedReadyPullRequest(ctx, state, issue, park, now); handled {
 		return transitioned
 	}

--- a/internal/orchestrator/merge_required_checks.go
+++ b/internal/orchestrator/merge_required_checks.go
@@ -84,6 +84,10 @@ func (o *Orchestrator) reconcilePersistentlyMissingRequiredCheckPark(
 		o.recordBlockedRecoveryDecision(ctx, state, issue, "hold", "required_checks_still_missing", &park, "")
 		return true, false
 	}
+	if reason := o.mergeLaneUnavailableReason(); reason != "" {
+		o.recordBlockedRecoveryDecision(ctx, state, issue, "defer", reason, &park, "")
+		return true, false
+	}
 	signature := fmt.Sprintf("cause=%s;pr=%d;head=%s", blockedCauseHash(park.Cause), pullRequestNumber(issue), strings.TrimSpace(issue.PullRequest.HeadSHA))
 	metadata := workflowLaneMetadataWithActionSignature(workflowLaneMetadata{}, workflowActionMergeRequiredCheckParkRecovery, signature)
 	if err := o.updateIssueStateByIDStrictWithMetadata(

--- a/internal/orchestrator/merge_required_checks.go
+++ b/internal/orchestrator/merge_required_checks.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
+	"fmt"
 	"sort"
 	"strconv"
 	"strings"
@@ -19,6 +20,7 @@ import (
 const (
 	mergeWorkerMissingRequiredCheckLimit            = 3
 	mergeWorkerPersistentMissingRequiredCheckReason = "merge_worker_required_checks_persistently_missing"
+	workflowActionMergeRequiredCheckParkRecovery    = "merge_required_check_park_recovery"
 )
 
 func (o *Orchestrator) evaluateMergeRequiredCheckStreaks(
@@ -44,6 +46,7 @@ func (o *Orchestrator) evaluateMergeRequiredCheckStreaks(
 		IssueID:                   issueID,
 		Repository:                pullRequestRepository(issue),
 		PRNumber:                  prNumber,
+		HeadSHA:                   strings.TrimSpace(issue.PullRequest.HeadSHA),
 		RequiredChecksFingerprint: mergeRequiredCheckConfigFingerprint(requiredChecks),
 		MissingChecks:             missingChecks,
 		EvaluatedAt:               evaluatedAt,
@@ -61,6 +64,63 @@ func (o *Orchestrator) evaluateMergeRequiredCheckStreaks(
 		return nil
 	}
 	return streaks
+}
+
+func (o *Orchestrator) reconcilePersistentlyMissingRequiredCheckPark(
+	ctx context.Context,
+	state *State,
+	issue connector.Issue,
+	park workflowLaneBlockedRecoveryMetadata,
+	now time.Time,
+) (bool, bool) {
+	if !strings.HasPrefix(strings.TrimSpace(park.Cause), mergeWorkerPersistentMissingRequiredCheckReason) {
+		return false, false
+	}
+	if issue.PullRequest == nil || pullRequestHydrationBlocksProgress(issue.PullRequest) || pullRequestNumber(issue) <= 0 || strings.TrimSpace(issue.PullRequest.HeadSHA) == "" {
+		o.recordBlockedRecoveryDecision(ctx, state, issue, "defer", "pull_request_hydration_unavailable", &park, "")
+		return true, false
+	}
+	if len(mergeWorkerMissingRequiredChecks(issue)) > 0 {
+		o.recordBlockedRecoveryDecision(ctx, state, issue, "hold", "required_checks_still_missing", &park, "")
+		return true, false
+	}
+	signature := fmt.Sprintf("cause=%s;pr=%d;head=%s", blockedCauseHash(park.Cause), pullRequestNumber(issue), strings.TrimSpace(issue.PullRequest.HeadSHA))
+	metadata := workflowLaneMetadataWithActionSignature(workflowLaneMetadata{}, workflowActionMergeRequiredCheckParkRecovery, signature)
+	if err := o.updateIssueStateByIDStrictWithMetadata(
+		ctx,
+		state,
+		issue.ID,
+		issue,
+		autoPromoteMergingState,
+		now,
+		workflowActionMergeRequiredCheckParkRecovery,
+		metadata,
+	); err != nil {
+		o.recordBlockedRecoveryDecision(ctx, state, issue, "defer", "required_check_recovery_transition_failed", &park, signature)
+		return true, false
+	}
+	if o.connector != nil {
+		body := fmt.Sprintf(
+			"Auto-released this issue from Blocked to Merging after the current pull request head published all required checks.\n\n- cause: %s\n- pull request: %s\n- head_sha: %s",
+			strings.TrimSpace(park.Cause),
+			strings.TrimSpace(issue.PullRequest.URL),
+			strings.TrimSpace(issue.PullRequest.HeadSHA),
+		)
+		if err := o.connector.CreateComment(ctx, issue.ID, body); err != nil && o.logger != nil {
+			o.logger.Warn("required check park recovery comment failed", "issue_id", issue.ID, "identifier", issue.Identifier, "error", err)
+		}
+	}
+	o.clearMergeRequiredCheckStreaks(ctx, issue)
+	delete(state.Blocked, issue.ID)
+	o.clearAutoPromotedIssueDispatchMemory(state, issue.ID)
+	promoted := promotedIssue(issue, autoPromoteMergingState, now)
+	o.recordMergeQueueEntered(state, promoted, now, workflowActionMergeRequiredCheckParkRecovery)
+	recordStateEvent(state, telemetry.ActivityEvent{
+		At:      now,
+		Event:   workflowActionMergeRequiredCheckParkRecovery,
+		Message: "auto-released " + issueLabel(issue) + " after required checks appeared on the current head",
+	})
+	return true, true
 }
 
 func mergeRequiredCheckConfigFingerprint(checkNames []string) string {

--- a/internal/orchestrator/merge_required_checks_test.go
+++ b/internal/orchestrator/merge_required_checks_test.go
@@ -117,9 +117,10 @@ func TestPersistentlyMissingRequiredCheckParkRecovery(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name        string
-		recovery    mergeRequiredCheckEvaluationStep
-		wantMerging bool
+		name         string
+		recovery     mergeRequiredCheckEvaluationStep
+		mutateConfig func(*Config)
+		wantMerging  bool
 	}{
 		{
 			name:        "check appears on current head",
@@ -129,6 +130,20 @@ func TestPersistentlyMissingRequiredCheckParkRecovery(t *testing.T) {
 		{
 			name:     "check remains missing on current head",
 			recovery: mergeRequiredCheckEvaluationStep{missing: true, headSHA: "head-a", requiredChecks: []string{"Test"}},
+		},
+		{
+			name:     "check appears while merge fast path is disabled",
+			recovery: mergeRequiredCheckEvaluationStep{headSHA: "head-b", requiredChecks: []string{"Test"}},
+			mutateConfig: func(cfg *Config) {
+				cfg.MergeFastPathEnabled = false
+			},
+		},
+		{
+			name:     "check appears while merging lane is inactive",
+			recovery: mergeRequiredCheckEvaluationStep{headSHA: "head-b", requiredChecks: []string{"Test"}},
+			mutateConfig: func(cfg *Config) {
+				cfg.ActiveStates = []string{"Todo", "In Progress", "Rework"}
+			},
 		},
 	}
 
@@ -141,6 +156,10 @@ func TestPersistentlyMissingRequiredCheckParkRecovery(t *testing.T) {
 			missing := mergeRequiredCheckEvaluationStep{missing: true, headSHA: "head-a", requiredChecks: []string{"Test"}}
 			for evaluation := range mergeWorkerMissingRequiredCheckLimit {
 				runMergeRequiredCheckEvaluation(t, orch, tracker, &state, missing, now.Add(time.Duration(evaluation)*time.Minute))
+			}
+			if tt.mutateConfig != nil {
+				tt.mutateConfig(&orch.cfg)
+				orch.cfg = normalizeConfig(orch.cfg)
 			}
 
 			issue := mergeRequiredCheckTestIssue(tt.recovery)
@@ -159,6 +178,8 @@ func TestPersistentlyMissingRequiredCheckParkRecovery(t *testing.T) {
 				if len(tracker.comments) == 0 || !strings.Contains(tracker.comments[len(tracker.comments)-1].body, "head-b") {
 					t.Fatalf("comments = %#v, want current-head recovery audit", tracker.comments)
 				}
+			} else if _, ok := state.Blocked[issue.ID]; !ok {
+				t.Fatalf("Blocked[%q] missing after deferred recovery", issue.ID)
 			}
 		})
 	}

--- a/internal/orchestrator/merge_required_checks_test.go
+++ b/internal/orchestrator/merge_required_checks_test.go
@@ -61,7 +61,6 @@ func TestMergeRequiredCheckStreakEscalation(t *testing.T) {
 				{missing: true, headSHA: "head-a", requiredChecks: []string{"Test"}},
 				{missing: true, headSHA: "head-b", requiredChecks: []string{"Test"}},
 			},
-			wantBlocked: true,
 		},
 		{
 			name: "auto-promote disabled",
@@ -109,6 +108,57 @@ func TestMergeRequiredCheckStreakEscalation(t *testing.T) {
 			}
 			if len(tracker.comments) == 0 || !strings.Contains(tracker.comments[len(tracker.comments)-1].body, "Test") {
 				t.Fatalf("comments = %#v, want persistent missing-check detail", tracker.comments)
+			}
+		})
+	}
+}
+
+func TestPersistentlyMissingRequiredCheckParkRecovery(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		recovery    mergeRequiredCheckEvaluationStep
+		wantMerging bool
+	}{
+		{
+			name:        "check appears on current head",
+			recovery:    mergeRequiredCheckEvaluationStep{headSHA: "head-b", requiredChecks: []string{"Test"}},
+			wantMerging: true,
+		},
+		{
+			name:     "check remains missing on current head",
+			recovery: mergeRequiredCheckEvaluationStep{missing: true, headSHA: "head-a", requiredChecks: []string{"Test"}},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			orch, tracker, state, closeStore := newMergeRequiredCheckTestOrchestrator(t, true)
+			defer closeStore()
+			now := time.Date(2026, 8, 7, 16, 0, 0, 0, time.UTC)
+			missing := mergeRequiredCheckEvaluationStep{missing: true, headSHA: "head-a", requiredChecks: []string{"Test"}}
+			for evaluation := range mergeWorkerMissingRequiredCheckLimit {
+				runMergeRequiredCheckEvaluation(t, orch, tracker, &state, missing, now.Add(time.Duration(evaluation)*time.Minute))
+			}
+
+			issue := mergeRequiredCheckTestIssue(tt.recovery)
+			issue.State = blockedStatusState
+			gotMerging := orch.recoverCauseBlockedIssue(t.Context(), &state, issue, now.Add(time.Hour))
+			if gotMerging != tt.wantMerging {
+				t.Fatalf("recoverCauseBlockedIssue() = %t, want %t", gotMerging, tt.wantMerging)
+			}
+			if tt.wantMerging {
+				if len(tracker.updates) == 0 || tracker.updates[len(tracker.updates)-1].state != autoPromoteMergingState {
+					t.Fatalf("updates = %#v, want final Merging transition", tracker.updates)
+				}
+				if _, ok := state.Blocked[issue.ID]; ok {
+					t.Fatalf("Blocked[%q] still present after required check appeared", issue.ID)
+				}
+				if len(tracker.comments) == 0 || !strings.Contains(tracker.comments[len(tracker.comments)-1].body, "head-b") {
+					t.Fatalf("comments = %#v, want current-head recovery audit", tracker.comments)
+				}
 			}
 		})
 	}

--- a/internal/store/merge_required_checks.go
+++ b/internal/store/merge_required_checks.go
@@ -12,6 +12,7 @@ import (
 type mergeRequiredCheckRow struct {
 	repository                string
 	prNumber                  int
+	headSHA                   string
 	checkName                 string
 	requiredChecksFingerprint string
 	consecutiveMissing        int
@@ -28,6 +29,10 @@ func (s *sqliteStore) EvaluateMergeRequiredChecks(ctx context.Context, evaluatio
 	}
 	if evaluation.PRNumber <= 0 {
 		return nil, errors.New("pr_number must be greater than zero")
+	}
+	headSHA := strings.TrimSpace(evaluation.HeadSHA)
+	if headSHA == "" {
+		return nil, errors.New("head_sha is required")
 	}
 	fingerprint := strings.TrimSpace(evaluation.RequiredChecksFingerprint)
 	if fingerprint == "" {
@@ -67,18 +72,20 @@ WHERE project_id = ? AND issue_id = ?`, projectID, issueID); err != nil {
 		if row, ok := previous[checkName]; ok &&
 			row.repository == repository &&
 			row.prNumber == evaluation.PRNumber &&
+			row.headSHA == headSHA &&
 			row.requiredChecksFingerprint == fingerprint {
 			count = row.consecutiveMissing + 1
 		}
 		if _, err := tx.ExecContext(ctx, `
 INSERT INTO merge_required_check_streaks (
-  project_id, issue_id, repository, pr_number, check_name,
+  project_id, issue_id, repository, pr_number, head_sha, check_name,
   required_checks_fingerprint, consecutive_missing, updated_at
-) VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
 			projectID,
 			issueID,
 			repository,
 			evaluation.PRNumber,
+			headSHA,
 			checkName,
 			fingerprint,
 			count,
@@ -118,7 +125,7 @@ WHERE project_id = ? AND issue_id = ?`, projectID, issueID); err != nil {
 
 func mergeRequiredCheckRows(ctx context.Context, tx *sql.Tx, projectID string, issueID string) (map[string]mergeRequiredCheckRow, error) {
 	rows, err := tx.QueryContext(ctx, `
-SELECT repository, pr_number, check_name, required_checks_fingerprint, consecutive_missing
+SELECT repository, pr_number, head_sha, check_name, required_checks_fingerprint, consecutive_missing
 FROM merge_required_check_streaks
 WHERE project_id = ? AND issue_id = ?`, projectID, issueID)
 	if err != nil {
@@ -132,6 +139,7 @@ WHERE project_id = ? AND issue_id = ?`, projectID, issueID)
 		if err := rows.Scan(
 			&row.repository,
 			&row.prNumber,
+			&row.headSHA,
 			&row.checkName,
 			&row.requiredChecksFingerprint,
 			&row.consecutiveMissing,

--- a/internal/store/merge_required_checks_test.go
+++ b/internal/store/merge_required_checks_test.go
@@ -48,6 +48,14 @@ func TestMergeRequiredCheckStreakLifecycle(t *testing.T) {
 			},
 		},
 		{
+			name: "head SHA change resets",
+			steps: []mergeRequiredCheckTestStep{
+				{headSHA: "head-a", missing: []string{"Test"}, want: map[string]int{"Test": 1}},
+				{headSHA: "head-a", missing: []string{"Test"}, want: map[string]int{"Test": 2}},
+				{headSHA: "head-b", missing: []string{"Test"}, want: map[string]int{"Test": 1}},
+			},
+		},
+		{
 			name: "terminal clear resets",
 			steps: []mergeRequiredCheckTestStep{
 				{missing: []string{"Test"}, want: map[string]int{"Test": 1}},
@@ -86,11 +94,16 @@ func TestMergeRequiredCheckStreakLifecycle(t *testing.T) {
 				if prNumber == 0 {
 					prNumber = 41
 				}
+				headSHA := step.headSHA
+				if headSHA == "" {
+					headSHA = "head-a"
+				}
 				streaks, err := backend.EvaluateMergeRequiredChecks(t.Context(), MergeRequiredCheckEvaluation{
 					ProjectID:                 "detent",
 					IssueID:                   "issue-1634",
 					Repository:                "digitaldrywood/detent",
 					PRNumber:                  prNumber,
+					HeadSHA:                   headSHA,
 					RequiredChecksFingerprint: fingerprint,
 					MissingChecks:             step.missing,
 					EvaluatedAt:               time.Date(2026, 8, 7, 15, index, 0, 0, time.UTC),
@@ -112,6 +125,7 @@ func TestMergeRequiredCheckStreakLifecycle(t *testing.T) {
 
 type mergeRequiredCheckTestStep struct {
 	prNumber    int
+	headSHA     string
 	fingerprint string
 	missing     []string
 	clear       bool
@@ -139,8 +153,9 @@ func TestMergeRequiredCheckStreakValidation(t *testing.T) {
 		{name: "project", evaluation: MergeRequiredCheckEvaluation{}, want: "project_id"},
 		{name: "issue", evaluation: MergeRequiredCheckEvaluation{ProjectID: "detent"}, want: "issue_id"},
 		{name: "pull request", evaluation: MergeRequiredCheckEvaluation{ProjectID: "detent", IssueID: "issue"}, want: "pr_number"},
-		{name: "fingerprint", evaluation: MergeRequiredCheckEvaluation{ProjectID: "detent", IssueID: "issue", PRNumber: 1}, want: "required_checks_fingerprint"},
-		{name: "timestamp", evaluation: MergeRequiredCheckEvaluation{ProjectID: "detent", IssueID: "issue", PRNumber: 1, RequiredChecksFingerprint: "config"}, want: "evaluated_at"},
+		{name: "head SHA", evaluation: MergeRequiredCheckEvaluation{ProjectID: "detent", IssueID: "issue", PRNumber: 1}, want: "head_sha"},
+		{name: "fingerprint", evaluation: MergeRequiredCheckEvaluation{ProjectID: "detent", IssueID: "issue", PRNumber: 1, HeadSHA: "head"}, want: "required_checks_fingerprint"},
+		{name: "timestamp", evaluation: MergeRequiredCheckEvaluation{ProjectID: "detent", IssueID: "issue", PRNumber: 1, HeadSHA: "head", RequiredChecksFingerprint: "config"}, want: "evaluated_at"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -149,6 +164,50 @@ func TestMergeRequiredCheckStreakValidation(t *testing.T) {
 				t.Fatalf("EvaluateMergeRequiredChecks() error = %v, want %q", err, tt.want)
 			}
 		})
+	}
+}
+
+func TestMergeRequiredCheckLegacyStreakDoesNotCarryToCurrentHead(t *testing.T) {
+	t.Parallel()
+
+	backend, err := Open(t.Context(), Config{Path: filepath.Join(t.TempDir(), "detent.db")})
+	if err != nil {
+		t.Fatalf("Open() error = %v", err)
+	}
+	t.Cleanup(func() {
+		if err := backend.Close(); err != nil {
+			t.Fatalf("Close() error = %v", err)
+		}
+	})
+	sqliteBackend, ok := backend.(*sqliteStore)
+	if !ok {
+		t.Fatalf("Open() backend = %T, want *sqliteStore", backend)
+	}
+	if _, err := sqliteBackend.db.ExecContext(t.Context(), `
+INSERT INTO merge_required_check_streaks (
+  project_id, issue_id, repository, pr_number, check_name,
+  required_checks_fingerprint, consecutive_missing, updated_at
+) VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+		"detent", "issue-1634", "digitaldrywood/detent", 41, "Test", "config", 2, "2026-08-07T16:00:00Z",
+	); err != nil {
+		t.Fatalf("seed legacy streak error = %v", err)
+	}
+
+	streaks, err := backend.EvaluateMergeRequiredChecks(t.Context(), MergeRequiredCheckEvaluation{
+		ProjectID:                 "detent",
+		IssueID:                   "issue-1634",
+		Repository:                "digitaldrywood/detent",
+		PRNumber:                  41,
+		HeadSHA:                   "head-a",
+		RequiredChecksFingerprint: "config",
+		MissingChecks:             []string{"Test"},
+		EvaluatedAt:               time.Date(2026, 8, 7, 16, 1, 0, 0, time.UTC),
+	})
+	if err != nil {
+		t.Fatalf("EvaluateMergeRequiredChecks() error = %v", err)
+	}
+	if len(streaks) != 1 || streaks[0].ConsecutiveMissing != 1 {
+		t.Fatalf("streaks = %#v, want fresh current-head count 1", streaks)
 	}
 }
 
@@ -165,6 +224,7 @@ func TestMergeRequiredCheckStreakPersistsAcrossStoreRestart(t *testing.T) {
 		IssueID:                   "issue-1634",
 		Repository:                "digitaldrywood/detent",
 		PRNumber:                  41,
+		HeadSHA:                   "head-a",
 		RequiredChecksFingerprint: "config",
 		MissingChecks:             []string{"Test"},
 		EvaluatedAt:               time.Date(2026, 8, 7, 16, 0, 0, 0, time.UTC),

--- a/internal/store/migrations/00037_scope_merge_required_check_streaks_by_head.sql
+++ b/internal/store/migrations/00037_scope_merge_required_check_streaks_by_head.sql
@@ -1,0 +1,7 @@
+-- +goose Up
+ALTER TABLE merge_required_check_streaks
+ADD COLUMN head_sha TEXT NOT NULL DEFAULT '';
+
+-- +goose Down
+ALTER TABLE merge_required_check_streaks
+DROP COLUMN head_sha;

--- a/internal/store/sqlc/models.go
+++ b/internal/store/sqlc/models.go
@@ -241,6 +241,7 @@ type MergeRequiredCheckStreak struct {
 	RequiredChecksFingerprint string `json:"required_checks_fingerprint"`
 	ConsecutiveMissing        int64  `json:"consecutive_missing"`
 	UpdatedAt                 string `json:"updated_at"`
+	HeadSha                   string `json:"head_sha"`
 }
 
 type ProjectDispatchStatus struct {

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -721,6 +721,7 @@ type MergeRequiredCheckEvaluation struct {
 	IssueID                   string
 	Repository                string
 	PRNumber                  int
+	HeadSHA                   string
 	RequiredChecksFingerprint string
 	MissingChecks             []string
 	EvaluatedAt               time.Time


### PR DESCRIPTION
## Summary

- persist the sampled PR head SHA with missing required-check streaks so a new head starts at one
- auto-release the persistent-missing-check park when fresh current-head hydration reports all required checks present
- cover head changes, legacy streak rows, same-head escalation, and current-head park recovery

Fixes #1835

## UI Surface Contract

- [x] N/A, or the linked issue explicitly authorizes any high-impact UI surface, layout, density, first-viewport, or responsive visibility tradeoff.
- [x] Persistent top-of-screen messaging is explicitly authorized by the issue, or this PR does not add it.
- [x] Visual changes to primary operator screens include screenshot or browser verification below. N/A: no UI changes.

## Test Plan

- [x] `make generate`
- [x] focused store and orchestrator tests
- [x] `make check`