### PR TITLE
feat(orchestrator): add typed blocker evidence

### DIFF
--- a/config.reference.yaml
+++ b/config.reference.yaml
@@ -222,6 +222,25 @@
 #         hydration_next_retry_at: null
 #         # tracker.issues[].pull_request.ci_status | type: string | default: none | required: No | validation: None
 #         ci_status: null
+#         # tracker.issues[].pull_request.checks | type: list<object> | default: [] | required: No | validation: None
+#         checks:
+#           -
+#             # tracker.issues[].pull_request.checks[].id | type: integer | default: 0 when configured | required: No | validation: None
+#             id: 0
+#             # tracker.issues[].pull_request.checks[].workflow_run_id | type: integer | default: 0 when configured | required: No | validation: None
+#             workflow_run_id: 0
+#             # tracker.issues[].pull_request.checks[].name | type: string | default: none | required: No | validation: None
+#             name: null
+#             # tracker.issues[].pull_request.checks[].status | type: string | default: none | required: No | validation: None
+#             status: null
+#             # tracker.issues[].pull_request.checks[].conclusion | type: string | default: none | required: No | validation: None
+#             conclusion: null
+#             # tracker.issues[].pull_request.checks[].details_url | type: string | default: none | required: No | validation: None
+#             details_url: null
+#             # tracker.issues[].pull_request.checks[].queue_seconds | type: integer | default: 0 when configured | required: No | validation: None
+#             queue_seconds: 0
+#             # tracker.issues[].pull_request.checks[].duration_seconds | type: integer | default: 0 when configured | required: No | validation: None
+#             duration_seconds: 0
 #         # tracker.issues[].pull_request.check_run_count | type: integer | default: 0 when configured | required: No | validation: None
 #         check_run_count: 0
 #         # tracker.issues[].pull_request.status_context_count | type: integer | default: 0 when configured | required: No | validation: None

--- a/docs/config.md
+++ b/docs/config.md
@@ -881,6 +881,15 @@ only to resettable budget pacing and never clears a per-issue hard hold.
 | `tracker.issues[].pull_request.base_sha` | `string` | `none` | No | None |
 | `tracker.issues[].pull_request.branch_name` | `string` | `none` | No | None |
 | `tracker.issues[].pull_request.check_run_count` | `integer` | `0 when configured` | No | None |
+| `tracker.issues[].pull_request.checks` | `list<object>` | `[]` | No | None |
+| `tracker.issues[].pull_request.checks[].conclusion` | `string` | `none` | No | None |
+| `tracker.issues[].pull_request.checks[].details_url` | `string` | `none` | No | None |
+| `tracker.issues[].pull_request.checks[].duration_seconds` | `integer` | `0 when configured` | No | None |
+| `tracker.issues[].pull_request.checks[].id` | `integer` | `0 when configured` | No | None |
+| `tracker.issues[].pull_request.checks[].name` | `string` | `none` | No | None |
+| `tracker.issues[].pull_request.checks[].queue_seconds` | `integer` | `0 when configured` | No | None |
+| `tracker.issues[].pull_request.checks[].status` | `string` | `none` | No | None |
+| `tracker.issues[].pull_request.checks[].workflow_run_id` | `integer` | `0 when configured` | No | None |
 | `tracker.issues[].pull_request.ci_duration_seconds` | `integer` | `0 when configured` | No | None |
 | `tracker.issues[].pull_request.ci_queue_seconds` | `integer` | `0 when configured` | No | None |
 | `tracker.issues[].pull_request.ci_status` | `string` | `none` | No | None |

--- a/docs/dependency-workflows.md
+++ b/docs/dependency-workflows.md
@@ -5,6 +5,32 @@
 Detent supports two dependency patterns. Use the one that matches how much of
 the wait should be visible on the board.
 
+Workpad blockers may declare live evidence directly. Each typed blocker names
+an `owner`, a `predicate`, and a `recheck_interval` or `expires_at`. Detent
+re-evaluates these records on every blocked-lane tick and clears the park when
+all predicates are false. The supported predicate types are `issue_state`,
+`pull_request_state`, `check_presence`, `budget_capacity`, and
+`config_fingerprint`.
+
+```detent-status
+schema: 1
+status: blocked
+blockers:
+  - ref: "owner/repo#123"
+    reason: "waiting for the dependency to close"
+    owner: orchestrator
+    predicate:
+      type: issue_state
+      states: [open]
+    recheck_interval: tick
+human_action: null
+```
+
+Free-text blocker entries remain valid for compatibility, but Detent marks
+them unverifiable, surfaces their owner and age, and never clears them
+automatically. An expired predicate that still holds is also unverifiable;
+orchestrator-owned unverifiable parks are escalated for operator attention.
+
 - **Keep the issue in `Todo`.** Add a machine-readable dependency line such as
   `Depends on: #123`, `Blocked by: owner/repo#123`, or
   `Depends on: https://github.com/owner/repo/issues/123`. Detent keeps the

--- a/internal/connector/github/adapter_test.go
+++ b/internal/connector/github/adapter_test.go
@@ -6182,6 +6182,24 @@ func newGitHubTestConnector(t *testing.T, server *graphqlTestServer, cfg Config)
 	return c
 }
 
+func TestPullRequestCheckInventoryRetainsSettledNames(t *testing.T) {
+	t.Parallel()
+
+	checks := pullRequestCheckInventory(
+		[]restCheckRun{{ID: 1, Name: "Test", Status: "completed", Conclusion: "success"}},
+		[]restCommitStatus{{Context: "Deploy", State: "pending"}, {Context: "test", State: "success"}},
+	)
+	if len(checks) != 2 {
+		t.Fatalf("checks = %#v, want check run and distinct status context", checks)
+	}
+	if checks[0].Name != "Test" || checks[0].Status != "completed" || checks[0].Conclusion != "success" {
+		t.Fatalf("check run = %#v", checks[0])
+	}
+	if checks[1].Name != "Deploy" || checks[1].Status != "pending" {
+		t.Fatalf("status context = %#v", checks[1])
+	}
+}
+
 type contextValueCaptureClient struct {
 	base   HTTPClient
 	key    any

--- a/internal/connector/github/adapter_test.go
+++ b/internal/connector/github/adapter_test.go
@@ -6200,6 +6200,25 @@ func TestPullRequestCheckInventoryRetainsSettledNames(t *testing.T) {
 	}
 }
 
+func TestPullRequestCheckInventoryRetainsIgnoredNames(t *testing.T) {
+	t.Parallel()
+
+	tests := []string{"cancelled", "canceled", "skipped"}
+	for _, conclusion := range tests {
+		t.Run(conclusion, func(t *testing.T) {
+			t.Parallel()
+
+			checks := pullRequestCheckInventory(
+				[]restCheckRun{{ID: 1, Name: "Optional", Status: "completed", Conclusion: conclusion}},
+				nil,
+			)
+			if len(checks) != 1 || checks[0].Name != "Optional" || checks[0].Conclusion != conclusion {
+				t.Fatalf("checks = %#v, want ignored check name retained", checks)
+			}
+		})
+	}
+}
+
 type contextValueCaptureClient struct {
 	base   HTTPClient
 	key    any

--- a/internal/connector/github/issue_text.go
+++ b/internal/connector/github/issue_text.go
@@ -146,6 +146,7 @@ func parseWorkpadSignal(issue githubIssueNode) *workpad.Signal {
 			continue
 		}
 		if signal, ok := workpad.SignalFromComment(body, comment.URL, repo); ok {
+			signal.RecordedAt = parseWorkpadRecordedAt(comment.CreatedAt, comment.UpdatedAt)
 			return signal
 		}
 		if reason := markdownSectionText(body, "Human Action Needed"); reason != "" {
@@ -153,6 +154,7 @@ func parseWorkpadSignal(issue githubIssueNode) *workpad.Signal {
 				Source:      workpad.SourceProseSection,
 				CommentURL:  strings.TrimSpace(comment.URL),
 				HumanAction: reason,
+				RecordedAt:  parseWorkpadRecordedAt(comment.CreatedAt, comment.UpdatedAt),
 			}
 		}
 		return nil
@@ -161,9 +163,17 @@ func parseWorkpadSignal(issue githubIssueNode) *workpad.Signal {
 		return &workpad.Signal{
 			Source:      workpad.SourceProseSection,
 			HumanAction: reason,
+			RecordedAt:  parseWorkpadRecordedAt(issue.CreatedAt, issue.UpdatedAt),
 		}
 	}
 	return nil
+}
+
+func parseWorkpadRecordedAt(createdAt *string, updatedAt *string) *time.Time {
+	if parsed := parseGitHubTime(updatedAt); parsed != nil {
+		return parsed
+	}
+	return parseGitHubTime(createdAt)
 }
 
 func workpadCommentBody(body string) bool {

--- a/internal/connector/github/pull_request_checks.go
+++ b/internal/connector/github/pull_request_checks.go
@@ -64,6 +64,7 @@ func (c *Connector) fetchPullRequestCI(ctx context.Context, repo pullRequestRepo
 	}
 	return pullRequestCI{
 		State:                 state,
+		Checks:                pullRequestCheckInventory(effectiveRuns, statuses),
 		CheckRunCount:         len(checkRuns),
 		StatusContextCount:    len(statuses),
 		CIQueueSeconds:        telemetry.QueueSeconds,
@@ -76,6 +77,44 @@ func (c *Connector) fetchPullRequestCI(ctx context.Context, repo pullRequestRepo
 		RequiredFailures:      requiredFailures,
 		TransientFailures:     transientFailures,
 	}, nil
+}
+
+func pullRequestCheckInventory(checkRuns []restCheckRun, statuses []restCommitStatus) []connector.PullRequestCheck {
+	checks := make([]connector.PullRequestCheck, 0, len(checkRuns)+len(statuses))
+	seen := map[string]struct{}{}
+	for _, checkRun := range checkRuns {
+		name := strings.TrimSpace(checkRun.Name)
+		key := strings.ToLower(name)
+		if key == "" {
+			continue
+		}
+		seen[key] = struct{}{}
+		checks = append(checks, connector.PullRequestCheck{
+			ID:            checkRun.ID,
+			WorkflowRunID: checkRunWorkflowRunID(checkRun),
+			Name:          name,
+			Status:        normalizedCheckRunStatus(checkRun),
+			Conclusion:    strings.ToLower(strings.TrimSpace(checkRun.Conclusion)),
+			DetailsURL:    firstNonBlank(checkRun.DetailsURL, checkRun.HTMLURL),
+		})
+	}
+	for _, status := range statuses {
+		name := strings.TrimSpace(status.Context)
+		key := strings.ToLower(name)
+		if key == "" {
+			continue
+		}
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		seen[key] = struct{}{}
+		checks = append(checks, connector.PullRequestCheck{
+			Name:       name,
+			Status:     strings.ToLower(strings.TrimSpace(status.State)),
+			Conclusion: strings.ToLower(strings.TrimSpace(status.State)),
+		})
+	}
+	return checks
 }
 
 func (c *Connector) transientCheckRunFailures(ctx context.Context, repo pullRequestRepo, checkRuns []restCheckRun) ([]connector.PullRequestCheck, error) {

--- a/internal/connector/github/pull_request_checks.go
+++ b/internal/connector/github/pull_request_checks.go
@@ -64,7 +64,7 @@ func (c *Connector) fetchPullRequestCI(ctx context.Context, repo pullRequestRepo
 	}
 	return pullRequestCI{
 		State:                 state,
-		Checks:                pullRequestCheckInventory(effectiveRuns, statuses),
+		Checks:                pullRequestCheckInventory(checkRuns, statuses),
 		CheckRunCount:         len(checkRuns),
 		StatusContextCount:    len(statuses),
 		CIQueueSeconds:        telemetry.QueueSeconds,
@@ -82,7 +82,8 @@ func (c *Connector) fetchPullRequestCI(ctx context.Context, repo pullRequestRepo
 func pullRequestCheckInventory(checkRuns []restCheckRun, statuses []restCommitStatus) []connector.PullRequestCheck {
 	checks := make([]connector.PullRequestCheck, 0, len(checkRuns)+len(statuses))
 	seen := map[string]struct{}{}
-	for _, checkRun := range checkRuns {
+	for _, group := range groupedCheckRuns(checkRuns) {
+		checkRun := latestCheckRun(group)
 		name := strings.TrimSpace(checkRun.Name)
 		key := strings.ToLower(name)
 		if key == "" {
@@ -591,12 +592,7 @@ func selectCheckRunContext(checkRuns []restCheckRun) checkRunContextResult {
 	if len(checkRuns) == 0 {
 		return checkRunContextResult{}
 	}
-	latest := checkRuns[0]
-	for _, checkRun := range checkRuns[1:] {
-		if restCheckRunAfter(checkRun, latest) {
-			latest = checkRun
-		}
-	}
+	latest := latestCheckRun(checkRuns)
 	status := normalizedCheckRunStatus(latest)
 	conclusion := strings.ToLower(strings.TrimSpace(latest.Conclusion))
 	if (status != "" && status != "completed") || conclusion == "" {
@@ -606,6 +602,19 @@ func selectCheckRunContext(checkRuns []restCheckRun) checkRunContextResult {
 		return checkRunContextResult{}
 	}
 	return checkRunContextResult{Run: latest, Settled: true}
+}
+
+func latestCheckRun(checkRuns []restCheckRun) restCheckRun {
+	if len(checkRuns) == 0 {
+		return restCheckRun{}
+	}
+	latest := checkRuns[0]
+	for _, checkRun := range checkRuns[1:] {
+		if restCheckRunAfter(checkRun, latest) {
+			latest = checkRun
+		}
+	}
+	return latest
 }
 
 func ignoredCheckRunConclusion(conclusion string) bool {

--- a/internal/connector/github/pull_requests.go
+++ b/internal/connector/github/pull_requests.go
@@ -847,6 +847,7 @@ func attachPullRequestToIssue(issue *connector.Issue, repo pullRequestRepo, pull
 		HydrationDegradedReason:      strings.TrimSpace(pullRequest.HydrationDegradedReason),
 		HydrationNextRetryAt:         cloneGitHubTime(pullRequest.HydrationNextRetryAt),
 		CIStatus:                     normalizePullRequestCIStatus(pullRequestCIState(pullRequest)),
+		Checks:                       append([]connector.PullRequestCheck(nil), pullRequest.CI.Checks...),
 		CheckRunCount:                pullRequest.CI.CheckRunCount,
 		StatusContextCount:           pullRequest.CI.StatusContextCount,
 		CIQueueSeconds:               pullRequest.CI.CIQueueSeconds,

--- a/internal/connector/github/pullrequestcache.go
+++ b/internal/connector/github/pullrequestcache.go
@@ -226,6 +226,7 @@ func clonePullRequestStatus(status pullRequestStatus) pullRequestStatus {
 func clonePullRequestCI(ci pullRequestCI) pullRequestCI {
 	return pullRequestCI{
 		State:                 ci.State,
+		Checks:                append([]connector.PullRequestCheck(nil), ci.Checks...),
 		CheckRunCount:         ci.CheckRunCount,
 		StatusContextCount:    ci.StatusContextCount,
 		CIQueueSeconds:        ci.CIQueueSeconds,

--- a/internal/connector/github/types.go
+++ b/internal/connector/github/types.go
@@ -329,6 +329,7 @@ type restCommitStatus struct {
 
 type pullRequestCI struct {
 	State                 string
+	Checks                []connector.PullRequestCheck
 	CheckRunCount         int
 	StatusContextCount    int
 	CIQueueSeconds        int64

--- a/internal/connector/issue.go
+++ b/internal/connector/issue.go
@@ -121,6 +121,7 @@ type PullRequest struct {
 	HydrationDegradedReason      string                      `json:"hydration_degraded_reason,omitempty" yaml:"hydration_degraded_reason,omitempty"`
 	HydrationNextRetryAt         *time.Time                  `json:"hydration_next_retry_at,omitempty" yaml:"hydration_next_retry_at,omitempty"`
 	CIStatus                     string                      `json:"ci_status,omitempty" yaml:"ci_status,omitempty"`
+	Checks                       []PullRequestCheck          `json:"checks,omitempty" yaml:"checks,omitempty"`
 	CheckRunCount                int                         `json:"check_run_count,omitempty" yaml:"check_run_count,omitempty"`
 	StatusContextCount           int                         `json:"status_context_count,omitempty" yaml:"status_context_count,omitempty"`
 	CIQueueSeconds               int64                       `json:"ci_queue_seconds,omitempty" yaml:"ci_queue_seconds,omitempty"`

--- a/internal/connector/memory/memory.go
+++ b/internal/connector/memory/memory.go
@@ -696,6 +696,13 @@ func cloneIssue(issue connector.Issue) connector.Issue {
 			submittedAt := *issue.PullRequest.LatestCodexReviewSubmittedAt
 			pullRequest.LatestCodexReviewSubmittedAt = &submittedAt
 		}
+		pullRequest.Checks = append([]connector.PullRequestCheck(nil), issue.PullRequest.Checks...)
+		pullRequest.SlowChecks = append([]connector.PullRequestCheck(nil), issue.PullRequest.SlowChecks...)
+		pullRequest.RunningChecks = append([]string(nil), issue.PullRequest.RunningChecks...)
+		pullRequest.UnstartedChecks = append([]connector.PullRequestCheck(nil), issue.PullRequest.UnstartedChecks...)
+		pullRequest.StaleSuccessfulChecks = append([]connector.PullRequestCheck(nil), issue.PullRequest.StaleSuccessfulChecks...)
+		pullRequest.RequiredCheckFailures = append([]connector.PullRequestCheck(nil), issue.PullRequest.RequiredCheckFailures...)
+		pullRequest.TransientFailedChecks = append([]connector.PullRequestCheck(nil), issue.PullRequest.TransientFailedChecks...)
 		pullRequest.CodexReviewFindings = append([]connector.PullRequestFinding(nil), issue.PullRequest.CodexReviewFindings...)
 		if issue.PullRequest.Labels != nil {
 			pullRequest.Labels = append([]string{}, issue.PullRequest.Labels...)

--- a/internal/orchestrator/autopromote.go
+++ b/internal/orchestrator/autopromote.go
@@ -572,9 +572,11 @@ func autoPromoteIssueWorkpadSignal(issue connector.Issue) (*workpad.Signal, bool
 			continue
 		}
 		if signal, ok := workpad.SignalFromComment(body, comment.URL, dependencyIssueRepo(issue.Identifier)); ok {
+			signal.RecordedAt = autoPromoteWorkpadRecordedAt(comment)
 			return signal, true
 		}
 		if signal := autoPromoteWorkpadProseSignalFromBody(body, comment.URL); signal != nil {
+			signal.RecordedAt = autoPromoteWorkpadRecordedAt(comment)
 			return signal, true
 		}
 		return nil, false
@@ -589,6 +591,18 @@ func autoPromoteIssueWorkpadSignal(issue connector.Issue) (*workpad.Signal, bool
 		}, true
 	}
 	return nil, false
+}
+
+func autoPromoteWorkpadRecordedAt(comment connector.IssueComment) *time.Time {
+	if comment.UpdatedAt != nil && !comment.UpdatedAt.IsZero() {
+		updatedAt := comment.UpdatedAt.UTC()
+		return &updatedAt
+	}
+	if comment.CreatedAt != nil && !comment.CreatedAt.IsZero() {
+		createdAt := comment.CreatedAt.UTC()
+		return &createdAt
+	}
+	return nil
 }
 
 func autoPromoteIsWorkpadComment(body string) bool {

--- a/internal/orchestrator/blocked_cause_recovery.go
+++ b/internal/orchestrator/blocked_cause_recovery.go
@@ -264,8 +264,7 @@ func (o *Orchestrator) recoverCauseBlockedIssue(
 		return false
 	}
 	withDependencies := o.issueWithDependencyRefs(issue)
-	workpadCurrent := o.workpadBlockersMatchCurrentBlockedEntry(ctx, issue)
-	withDependencies, workpadRefs := o.issueWithCurrentWorkpadDependencyRefs(ctx, withDependencies)
+	withDependencies, workpadRefs, workpadCurrent := o.issueWithCurrentWorkpadDependencyRefs(ctx, withDependencies)
 	blockers := o.resolveDependencyBlockers(ctx, withDependencies)
 	withDependencies.BlockedBy = dependencyResolvedBlockerRefs(blockers)
 	references := make(map[string]connector.Issue, len(blockers))
@@ -320,7 +319,7 @@ func (o *Orchestrator) recoverCauseBlockedIssue(
 		return false
 	}
 	workpadBlockers := dependencyBlockersMatchingRefs(blockers, workpadRefs)
-	holdReason := o.blockedCauseHoldReason(issue, state, workpadBlockers, dependencyCfg)
+	holdReason := o.blockedCauseHoldReason(issue, state, workpadBlockers, dependencyCfg, workpadCurrent)
 	if holdReason != "" && holdReason != "invalid_workpad_signal" {
 		o.recordBlockedRecoveryDecision(
 			ctx,
@@ -663,17 +662,16 @@ func (o *Orchestrator) blockedCauseHoldReason(
 	state *State,
 	workpadBlockers []dependencyBlocker,
 	dependencyCfg DependencyAutoUnblockConfig,
+	workpadCurrent bool,
 ) string {
 	if reason := BlockedRecoveryHumanHoldReason(issue, o.cfg.AutoPromote.OptoutLabel); reason != "" {
 		return reason
 	}
-	if issue.WorkpadSignal != nil {
-		if workpadHasRecordedNonDependencyBlocker(issue.WorkpadSignal) {
-			return "recorded_blocker"
-		}
-		if len(workpadBlockers) > 0 && !dependencyBlockersReady(workpadBlockers, dependencyCfg, o.cfg.TerminalStates) {
-			return "workpad_blocker"
-		}
+	if workpadCurrent && workpadHasRecordedNonDependencyBlocker(issue.WorkpadSignal) {
+		return "recorded_blocker"
+	}
+	if len(workpadBlockers) > 0 && !dependencyBlockersReady(workpadBlockers, dependencyCfg, o.cfg.TerminalStates) {
+		return "workpad_blocker"
 	}
 	if state != nil {
 		if blocked, ok := state.Blocked[strings.TrimSpace(issue.ID)]; ok && blocked.Source == BlockedSourceOperatorStop {

--- a/internal/orchestrator/blocked_cause_recovery.go
+++ b/internal/orchestrator/blocked_cause_recovery.go
@@ -167,18 +167,13 @@ func (o *Orchestrator) blockedCauseSignals(
 }
 
 func blockedCauseWorkpadSignal(signal *workpad.Signal) *workpad.Signal {
-	if signal == nil {
+	cloned := workpad.CloneSignal(signal)
+	if cloned == nil {
 		return nil
 	}
-	cloned := *signal
 	cloned.CommentURL = ""
-	cloned.Blockers = append([]workpad.Blocker(nil), signal.Blockers...)
-	cloned.Fields = blockedCauseFields(signal.Fields)
-	if signal.Invalid != nil {
-		invalid := *signal.Invalid
-		cloned.Invalid = &invalid
-	}
-	return &cloned
+	cloned.Fields = blockedCauseFields(cloned.Fields)
+	return cloned
 }
 
 func blockedCauseLabels(labels []string, statusLabelPrefix string) []string {
@@ -269,25 +264,63 @@ func (o *Orchestrator) recoverCauseBlockedIssue(
 		return false
 	}
 	withDependencies := o.issueWithDependencyRefs(issue)
+	workpadCurrent := o.workpadBlockersMatchCurrentBlockedEntry(ctx, issue)
 	withDependencies, workpadRefs := o.issueWithCurrentWorkpadDependencyRefs(ctx, withDependencies)
 	blockers := o.resolveDependencyBlockers(ctx, withDependencies)
 	withDependencies.BlockedBy = dependencyResolvedBlockerRefs(blockers)
-	workpadBlockers := dependencyBlockersMatchingRefs(blockers, workpadRefs)
-	holdReason := o.blockedCauseHoldReason(issue, state, workpadBlockers, dependencyCfg)
-	if holdReason != "" && holdReason != "invalid_workpad_signal" {
-		o.recordBlockedRecoveryDecision(
-			ctx,
-			state,
-			withDependencies,
-			"hold",
-			holdReason,
-			nil,
-			"",
-			dependencyBlockersNotReady(workpadBlockers, dependencyCfg, o.cfg.TerminalStates)...,
-		)
+	references := make(map[string]connector.Issue, len(blockers))
+	for _, blocker := range blockers {
+		if blocker.Resolved {
+			references[normalizedIssueIdentifier(blocker.Issue.Identifier)] = blocker.Issue
+		}
+	}
+	recorded := recordedBlockerEvaluation{}
+	if issue.WorkpadSignal == nil || len(issue.WorkpadSignal.Blockers) == 0 || workpadCurrent {
+		recorded = o.evaluateRecordedBlockers(ctx, state, issue, references, now)
+	}
+	if recorded.Found {
+		if recorded.Unverifiable {
+			reason := "unverifiable_blocker"
+			if issue.WorkpadSignal != nil {
+				switch {
+				case issue.WorkpadSignal.Invalid != nil:
+					if park, ok := o.currentBlockedRecoveryPark(ctx, state, issue); ok {
+						if handled, transitioned := o.reconcileBlockedReadyPullRequest(ctx, state, issue, park, now); handled {
+							return transitioned
+						}
+					}
+					reason = "invalid_workpad_signal"
+				case strings.TrimSpace(issue.WorkpadSignal.HumanAction) != "":
+					reason = "human_action"
+				}
+			}
+			o.recordBlockedRecoveryDecision(ctx, state, withDependencies, "hold", reason, nil, "")
+			setBlockedEvidence(state, issue.ID, recorded.Evidence)
+			return false
+		}
+		if recorded.Holds {
+			action := "defer"
+			if recorded.HumanOwned {
+				action = "hold"
+			}
+			o.recordBlockedRecoveryDecision(ctx, state, withDependencies, action, "recorded_blocker_holds", nil, "")
+			setBlockedEvidence(state, issue.ID, recorded.Evidence)
+			return false
+		}
+		if len(blockers) > 0 && !dependencyBlockersReady(blockers, dependencyCfg, o.cfg.TerminalStates) {
+			o.recordBlockedRecoveryDecision(ctx, state, withDependencies, "defer", "dependency_recovery", nil, "")
+			setBlockedEvidence(state, issue.ID, recorded.Evidence)
+			return false
+		}
+		if o.applyRecordedBlockerRecovery(ctx, state, withDependencies, blockers, recorded.Evidence, now) {
+			return true
+		}
+		o.recordBlockedRecoveryDecision(ctx, state, withDependencies, "hold", "transition_failed", nil, "")
+		setBlockedEvidence(state, issue.ID, recorded.Evidence)
 		return false
 	}
-	holdReason = o.blockedCauseHoldReason(issue, state, workpadBlockers, dependencyCfg)
+	workpadBlockers := dependencyBlockersMatchingRefs(blockers, workpadRefs)
+	holdReason := o.blockedCauseHoldReason(issue, state, workpadBlockers, dependencyCfg)
 	if holdReason != "" && holdReason != "invalid_workpad_signal" {
 		o.recordBlockedRecoveryDecision(
 			ctx,
@@ -635,6 +668,9 @@ func (o *Orchestrator) blockedCauseHoldReason(
 		return reason
 	}
 	if issue.WorkpadSignal != nil {
+		if workpadHasRecordedNonDependencyBlocker(issue.WorkpadSignal) {
+			return "recorded_blocker"
+		}
 		if len(workpadBlockers) > 0 && !dependencyBlockersReady(workpadBlockers, dependencyCfg, o.cfg.TerminalStates) {
 			return "workpad_blocker"
 		}
@@ -645,6 +681,18 @@ func (o *Orchestrator) blockedCauseHoldReason(
 		}
 	}
 	return ""
+}
+
+func workpadHasRecordedNonDependencyBlocker(signal *workpad.Signal) bool {
+	if signal == nil || signal.Invalid != nil || strings.TrimSpace(signal.Status) != workpad.StatusBlocked {
+		return false
+	}
+	for _, blocker := range signal.Blockers {
+		if blocker.Unverifiable || blocker.Predicate != nil && blocker.Predicate.Type != workpad.PredicateIssueState {
+			return true
+		}
+	}
+	return false
 }
 
 func BlockedRecoveryHumanHoldReason(issue connector.Issue, optoutLabel string) string {
@@ -753,6 +801,7 @@ func (o *Orchestrator) recordBlockedRecoveryDecision(
 	entry.RecoveryRemedy = BlockedRecoveryOperatorRemedy(issue, reason)
 	entry.RecoveryReachability = blockedRecoveryReachability(action)
 	entry.NeedsHumanAttention = strings.EqualFold(strings.TrimSpace(action), "hold")
+	entry.BlockerEvidence = nil
 	entry.RecoveryRoot = nil
 	if park != nil {
 		current := *park
@@ -794,6 +843,12 @@ func BlockedRecoveryOperatorRemedy(issue connector.Issue, reason string) string 
 			return strings.TrimSpace(issue.WorkpadSignal.HumanAction)
 		}
 		return "Complete the requested human action, then update the Workpad."
+	case "unverifiable_blocker":
+		return "Replace the free-text blocker with a typed predicate, or resolve it and update the Workpad."
+	case "recorded_blocker_holds":
+		return "Detent will re-check the recorded blocker predicate on the next tick."
+	case "recorded_blocker":
+		return "Detent is retaining the issue while its recorded blocker predicate is active."
 	case "workpad_blocker":
 		return "Resolve or remove the current Workpad blocker references."
 	case "operator_stop":

--- a/internal/orchestrator/blocker_evidence.go
+++ b/internal/orchestrator/blocker_evidence.go
@@ -1,0 +1,661 @@
+package orchestrator
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/digitaldrywood/detent/internal/backendcapacity"
+	"github.com/digitaldrywood/detent/internal/connector"
+	"github.com/digitaldrywood/detent/internal/telemetry"
+	"github.com/digitaldrywood/detent/internal/workpad"
+)
+
+const (
+	blockerEvidenceStatusHolds            = "holds"
+	blockerEvidenceStatusCleared          = "cleared"
+	blockerEvidenceStatusUnverifiable     = "unverifiable"
+	workflowActionRecordedBlockerRecovery = "recorded_blocker_recovery"
+)
+
+type blockerPredicateContext struct {
+	issue           connector.Issue
+	state           *State
+	now             time.Time
+	references      map[string]connector.Issue
+	hydrated        map[string]connector.Issue
+	hydrationErrors map[string]error
+}
+
+type blockerPredicateEvaluator func(context.Context, *Orchestrator, *blockerPredicateContext, workpad.Predicate) (string, string)
+
+var blockerPredicateRegistry = map[string]blockerPredicateEvaluator{
+	workpad.PredicateIssueState:        evaluateIssueStatePredicate,
+	workpad.PredicatePullRequestState:  evaluatePullRequestStatePredicate,
+	workpad.PredicateCheckPresence:     evaluateCheckPresencePredicate,
+	workpad.PredicateBudgetCapacity:    evaluateBudgetCapacityPredicate,
+	workpad.PredicateConfigFingerprint: evaluateConfigFingerprintPredicate,
+}
+
+type recordedBlockerEvaluation struct {
+	Evidence     []telemetry.BlockerEvidence
+	Found        bool
+	Holds        bool
+	Unverifiable bool
+	HumanOwned   bool
+}
+
+func (o *Orchestrator) evaluateRecordedBlockers(
+	ctx context.Context,
+	state *State,
+	issue connector.Issue,
+	resolvedReferences map[string]connector.Issue,
+	now time.Time,
+) recordedBlockerEvaluation {
+	signal := issue.WorkpadSignal
+	if signal == nil {
+		return recordedBlockerEvaluation{}
+	}
+	if signal.Source == workpad.SourceStructured && strings.TrimSpace(signal.Status) != workpad.StatusBlocked {
+		return recordedBlockerEvaluation{}
+	}
+	result := recordedBlockerEvaluation{}
+	recordedAt := recordedBlockerTime(state, issue, signal)
+	if signal.Invalid != nil {
+		result.Found = true
+		result.Unverifiable = true
+		result.HumanOwned = true
+		result.Evidence = append(result.Evidence, newBlockerEvidence(
+			"invalid",
+			workpad.BlockerOwnerHuman,
+			blockerEvidenceStatusUnverifiable,
+			"",
+			signal.Invalid.Message,
+			"the structured blocker could not be parsed",
+			recordedAt,
+			nil,
+			"",
+			now,
+		))
+		return result
+	}
+
+	predicateContext := &blockerPredicateContext{
+		issue:           issue,
+		state:           state,
+		now:             now,
+		references:      o.resolveBlockerPredicateReferences(ctx, issue, signal.Blockers, resolvedReferences),
+		hydrated:        map[string]connector.Issue{},
+		hydrationErrors: map[string]error{},
+	}
+	for _, blocker := range signal.Blockers {
+		if blocker.Predicate == nil && !blocker.Unverifiable {
+			continue
+		}
+		result.Found = true
+		evidence := o.evaluateRecordedBlocker(ctx, predicateContext, blocker, recordedAt)
+		result.Evidence = append(result.Evidence, evidence)
+		result.Holds = result.Holds || evidence.Status == blockerEvidenceStatusHolds
+		result.Unverifiable = result.Unverifiable || evidence.Unverifiable
+		result.HumanOwned = result.HumanOwned || evidence.Owner == workpad.BlockerOwnerHuman && evidence.Status != blockerEvidenceStatusCleared
+	}
+	if humanAction := strings.TrimSpace(signal.HumanAction); humanAction != "" {
+		result.Found = true
+		result.Unverifiable = true
+		result.HumanOwned = true
+		result.Evidence = append(result.Evidence, newBlockerEvidence(
+			"free_text",
+			workpad.BlockerOwnerHuman,
+			blockerEvidenceStatusUnverifiable,
+			"",
+			humanAction,
+			"human_action has no live predicate",
+			recordedAt,
+			nil,
+			"",
+			now,
+		))
+	}
+	return result
+}
+
+func (o *Orchestrator) evaluateRecordedBlocker(
+	ctx context.Context,
+	predicateContext *blockerPredicateContext,
+	blocker workpad.Blocker,
+	recordedAt *time.Time,
+) telemetry.BlockerEvidence {
+	owner := strings.TrimSpace(blocker.Owner)
+	if owner == "" {
+		owner = workpad.BlockerOwnerHuman
+		if blocker.Predicate != nil {
+			owner = workpad.BlockerOwnerOrchestrator
+		}
+	}
+	predicate := blocker.Predicate
+	if predicate == nil || blocker.Unverifiable {
+		return newBlockerEvidence(
+			"free_text",
+			owner,
+			blockerEvidenceStatusUnverifiable,
+			firstNonBlank(blocker.Identifier, blocker.Ref),
+			blocker.Reason,
+			"free-text blocker has no live predicate",
+			recordedAt,
+			blocker.ExpiresAt,
+			blocker.RecheckInterval,
+			predicateContext.now,
+		)
+	}
+	evaluator, ok := blockerPredicateRegistry[predicate.Type]
+	if !ok {
+		return newBlockerEvidence(
+			predicate.Type,
+			owner,
+			blockerEvidenceStatusUnverifiable,
+			blockerPredicateReference(*predicate),
+			blocker.Reason,
+			"predicate evaluator is not registered",
+			recordedAt,
+			blocker.ExpiresAt,
+			blocker.RecheckInterval,
+			predicateContext.now,
+		)
+	}
+	status, detail := evaluator(ctx, o, predicateContext, *predicate)
+	if status == blockerEvidenceStatusHolds && blocker.ExpiresAt != nil && !predicateContext.now.Before(*blocker.ExpiresAt) {
+		status = blockerEvidenceStatusUnverifiable
+		detail = "predicate expired while the blocking condition still held"
+	}
+	return newBlockerEvidence(
+		predicate.Type,
+		owner,
+		status,
+		blockerPredicateReference(*predicate),
+		blocker.Reason,
+		detail,
+		recordedAt,
+		blocker.ExpiresAt,
+		blocker.RecheckInterval,
+		predicateContext.now,
+	)
+}
+
+func newBlockerEvidence(
+	predicateType string,
+	owner string,
+	status string,
+	reference string,
+	reason string,
+	detail string,
+	recordedAt *time.Time,
+	expiresAt *time.Time,
+	recheckInterval string,
+	now time.Time,
+) telemetry.BlockerEvidence {
+	evidence := telemetry.BlockerEvidence{
+		Type:            strings.TrimSpace(predicateType),
+		Owner:           strings.TrimSpace(owner),
+		Status:          strings.TrimSpace(status),
+		Reference:       strings.TrimSpace(reference),
+		Reason:          strings.TrimSpace(reason),
+		Detail:          strings.TrimSpace(detail),
+		Unverifiable:    status == blockerEvidenceStatusUnverifiable,
+		RecheckInterval: strings.TrimSpace(recheckInterval),
+	}
+	if recordedAt != nil && !recordedAt.IsZero() {
+		value := recordedAt.UTC()
+		evidence.RecordedAt = &value
+		if now.After(value) {
+			evidence.AgeSeconds = int64(now.Sub(value) / time.Second)
+		}
+	}
+	if expiresAt != nil && !expiresAt.IsZero() {
+		value := expiresAt.UTC()
+		evidence.ExpiresAt = &value
+	}
+	return evidence
+}
+
+func recordedBlockerTime(state *State, issue connector.Issue, signal *workpad.Signal) *time.Time {
+	if signal != nil && signal.RecordedAt != nil && !signal.RecordedAt.IsZero() {
+		value := signal.RecordedAt.UTC()
+		return &value
+	}
+	if state != nil {
+		if blocked, ok := state.Blocked[strings.TrimSpace(issue.ID)]; ok && !blocked.BlockedAt.IsZero() {
+			value := blocked.BlockedAt.UTC()
+			return &value
+		}
+	}
+	for _, value := range []*time.Time{issue.StageUpdatedAt, issue.UpdatedAt, issue.CreatedAt} {
+		if value != nil && !value.IsZero() {
+			cloned := value.UTC()
+			return &cloned
+		}
+	}
+	return nil
+}
+
+func blockerPredicateReference(predicate workpad.Predicate) string {
+	return firstNonBlank(predicate.Identifier, predicate.Ref, predicate.Check, predicate.Resource, predicate.Scope, predicate.Fingerprint)
+}
+
+func (o *Orchestrator) resolveBlockerPredicateReferences(
+	ctx context.Context,
+	issue connector.Issue,
+	blockers []workpad.Blocker,
+	seed map[string]connector.Issue,
+) map[string]connector.Issue {
+	resolved := map[string]connector.Issue{}
+	for identifier, resolvedIssue := range seed {
+		resolved[normalizedIssueIdentifier(identifier)] = resolvedIssue
+	}
+	self := normalizedIssueIdentifier(issue.Identifier)
+	if self != "" {
+		resolved[self] = issue
+	}
+	refs := []connector.BlockedRef{}
+	seen := map[string]struct{}{}
+	for _, blocker := range blockers {
+		if blocker.Predicate == nil {
+			continue
+		}
+		predicate := blocker.Predicate
+		identifier := normalizedIssueIdentifier(predicate.Identifier)
+		if identifier == "" || identifier == self {
+			continue
+		}
+		if _, ok := resolved[identifier]; ok {
+			continue
+		}
+		if _, ok := seen[identifier]; ok {
+			continue
+		}
+		seen[identifier] = struct{}{}
+		refs = append(refs, connector.BlockedRef{Identifier: predicate.Identifier})
+	}
+	if len(refs) == 0 {
+		return resolved
+	}
+	for _, blocker := range o.resolveDependencyBlockers(ctx, connector.Issue{ID: issue.ID, Identifier: issue.Identifier, BlockedBy: refs}) {
+		if !blocker.Resolved {
+			continue
+		}
+		identifier := normalizedIssueIdentifier(blocker.Issue.Identifier)
+		if identifier != "" {
+			resolved[identifier] = blocker.Issue
+		}
+	}
+	return resolved
+}
+
+func blockerPredicateIssue(predicateContext *blockerPredicateContext, predicate workpad.Predicate) (connector.Issue, bool) {
+	identifier := normalizedIssueIdentifier(predicate.Identifier)
+	if identifier == "" || identifier == normalizedIssueIdentifier(predicateContext.issue.Identifier) {
+		return predicateContext.issue, true
+	}
+	issue, ok := predicateContext.references[identifier]
+	return issue, ok
+}
+
+func evaluateIssueStatePredicate(
+	_ context.Context,
+	o *Orchestrator,
+	predicateContext *blockerPredicateContext,
+	predicate workpad.Predicate,
+) (string, string) {
+	if normalizedIssueIdentifier(predicate.Identifier) == normalizedIssueIdentifier(predicateContext.issue.Identifier) {
+		return blockerEvidenceStatusUnverifiable, "issue_state predicate cannot reference the blocked issue itself"
+	}
+	issue, ok := blockerPredicateIssue(predicateContext, predicate)
+	if !ok {
+		return blockerEvidenceStatusUnverifiable, "referenced issue could not be resolved"
+	}
+	if len(predicate.States) == 0 {
+		cfg := normalizeDependencyAutoUnblockConfig(o.cfg.DependencyAutoUnblock)
+		blocker := dependencyBlocker{Issue: issue, Resolved: true, Ref: connector.BlockedRef{Identifier: issue.Identifier, State: issue.State}}
+		if dependencyBlockerReady(blocker, cfg, o.cfg.TerminalStates) {
+			return blockerEvidenceStatusCleared, "referenced issue is terminal or its linked pull request merged"
+		}
+		return blockerEvidenceStatusHolds, "referenced issue remains non-terminal"
+	}
+	if issueStateMatches(issue, predicate.States) {
+		return blockerEvidenceStatusHolds, "referenced issue state matches the blocking states"
+	}
+	return blockerEvidenceStatusCleared, "referenced issue state no longer matches the blocking states"
+}
+
+func issueStateMatches(issue connector.Issue, states []string) bool {
+	observed := map[string]struct{}{normalizeState(issue.State): {}}
+	if issue.Closed {
+		observed["closed"] = struct{}{}
+	} else {
+		observed["open"] = struct{}{}
+	}
+	for _, state := range states {
+		if _, ok := observed[normalizeState(state)]; ok {
+			return true
+		}
+	}
+	return false
+}
+
+func evaluatePullRequestStatePredicate(
+	ctx context.Context,
+	o *Orchestrator,
+	predicateContext *blockerPredicateContext,
+	predicate workpad.Predicate,
+) (string, string) {
+	issue, ok := blockerPredicateIssue(predicateContext, predicate)
+	if !ok {
+		return blockerEvidenceStatusUnverifiable, "referenced issue could not be resolved"
+	}
+	issue, err := o.hydrateBlockerPredicatePullRequest(ctx, predicateContext, issue)
+	if err != nil {
+		return blockerEvidenceStatusUnverifiable, "pull request state could not be refreshed"
+	}
+	state, verifiable := observedPullRequestState(issue)
+	if !verifiable {
+		return blockerEvidenceStatusUnverifiable, "pull request hydration is unavailable"
+	}
+	if tokenInList(state, predicate.States) {
+		return blockerEvidenceStatusHolds, "pull request state matches the blocking states"
+	}
+	return blockerEvidenceStatusCleared, "pull request state no longer matches the blocking states"
+}
+
+func observedPullRequestState(issue connector.Issue) (string, bool) {
+	if issue.PullRequest == nil {
+		return "missing", true
+	}
+	if pullRequestHydrationUnavailableReason(issue.PullRequest) != "" || pullRequestHydrationDegradedReason(issue.PullRequest) != "" {
+		return "", false
+	}
+	state := normalizePullRequestState(issue.PullRequest.State)
+	if state == "" {
+		return "", false
+	}
+	return state, true
+}
+
+func evaluateCheckPresencePredicate(
+	ctx context.Context,
+	o *Orchestrator,
+	predicateContext *blockerPredicateContext,
+	predicate workpad.Predicate,
+) (string, string) {
+	issue, ok := blockerPredicateIssue(predicateContext, predicate)
+	if !ok {
+		return blockerEvidenceStatusUnverifiable, "referenced issue could not be resolved"
+	}
+	issue, err := o.hydrateBlockerPredicatePullRequest(ctx, predicateContext, issue)
+	if err != nil {
+		return blockerEvidenceStatusUnverifiable, "pull request checks could not be refreshed"
+	}
+	if issue.PullRequest != nil && (pullRequestHydrationUnavailableReason(issue.PullRequest) != "" || pullRequestHydrationDegradedReason(issue.PullRequest) != "") {
+		return blockerEvidenceStatusUnverifiable, "pull request check hydration is unavailable"
+	}
+	present, verifiable := pullRequestCheckPresent(issue.PullRequest, predicate.Check)
+	if !verifiable {
+		return blockerEvidenceStatusUnverifiable, "pull request check inventory is unavailable"
+	}
+	wantPresent := predicate.Present != nil && *predicate.Present
+	if present == wantPresent {
+		return blockerEvidenceStatusHolds, fmt.Sprintf("check presence remains %t", present)
+	}
+	return blockerEvidenceStatusCleared, fmt.Sprintf("check presence changed to %t", present)
+}
+
+func (o *Orchestrator) hydrateBlockerPredicatePullRequest(
+	ctx context.Context,
+	predicateContext *blockerPredicateContext,
+	issue connector.Issue,
+) (connector.Issue, error) {
+	key := normalizedIssueIdentifier(issue.Identifier)
+	if hydrated, ok := predicateContext.hydrated[key]; ok {
+		return hydrated, nil
+	}
+	if err, ok := predicateContext.hydrationErrors[key]; ok {
+		return issue, err
+	}
+	if issue.PullRequest == nil && issue.PRNumber == nil {
+		predicateContext.hydrated[key] = issue
+		return issue, nil
+	}
+	hydrator, ok := o.connector.(connector.PullRequestHydrator)
+	if !ok {
+		err := errors.New("connector does not support pull request hydration")
+		predicateContext.hydrationErrors[key] = err
+		return issue, err
+	}
+	hydrated, err := hydrator.HydratePullRequest(ctx, issue)
+	if err != nil {
+		predicateContext.hydrationErrors[key] = err
+		return issue, err
+	}
+	predicateContext.hydrated[key] = hydrated
+	return hydrated, nil
+}
+
+func pullRequestCheckPresent(pullRequest *connector.PullRequest, checkName string) (bool, bool) {
+	if pullRequest == nil {
+		return false, true
+	}
+	checkName = strings.TrimSpace(checkName)
+	for _, check := range pullRequest.Checks {
+		if strings.EqualFold(strings.TrimSpace(check.Name), checkName) {
+			return true, true
+		}
+	}
+	if len(pullRequest.Checks) == 0 && (pullRequest.CheckRunCount > 0 || pullRequest.StatusContextCount > 0) {
+		return false, false
+	}
+	return false, true
+}
+
+func evaluateBudgetCapacityPredicate(
+	ctx context.Context,
+	o *Orchestrator,
+	predicateContext *blockerPredicateContext,
+	predicate workpad.Predicate,
+) (string, string) {
+	switch predicate.Scope {
+	case "daily", "daily_budget":
+		if o.dailyBudgetStatus == nil {
+			return blockerEvidenceStatusUnverifiable, "daily budget status provider is unavailable"
+		}
+		status, known, err := o.dailyBudgetStatus.DailyBudgetStatus(ctx, predicateContext.now)
+		if err != nil || !known {
+			return blockerEvidenceStatusUnverifiable, "daily budget status could not be refreshed"
+		}
+		return capacityConditionStatus(status.Active && status.MaxUSD > 0 && status.CurrentSpendUSD >= status.MaxUSD, predicate.Condition, "daily budget")
+	case "issue", "issue_budget":
+		if o.issueBudgetStatus == nil {
+			return blockerEvidenceStatusUnverifiable, "issue budget status provider is unavailable"
+		}
+		status, known, err := o.issueBudgetStatus.IssueBudgetStatus(ctx, predicateContext.issue)
+		if err != nil || !known {
+			return blockerEvidenceStatusUnverifiable, "issue budget status could not be refreshed"
+		}
+		return capacityConditionStatus(status.Active && status.MaxUSD > 0 && status.CurrentSpendUSD >= status.MaxUSD, predicate.Condition, "issue budget")
+	case "global", "global_capacity":
+		if predicateContext.state == nil || predicateContext.state.MaxConcurrentAgents <= 0 {
+			return blockerEvidenceStatusUnverifiable, "global capacity limit is unavailable"
+		}
+		exhausted := activeAgentClaims(predicateContext.state) >= predicateContext.state.MaxConcurrentAgents
+		return capacityConditionStatus(exhausted, predicate.Condition, "global capacity")
+	case "backend", "backend_capacity":
+		if predicateContext.state == nil {
+			return blockerEvidenceStatusUnverifiable, "backend capacity state is unavailable"
+		}
+		exhausted := backendCapacityOutageMatches(predicateContext.state.BackendOutages, predicate.Resource)
+		return capacityConditionStatus(exhausted, predicate.Condition, "backend capacity")
+	default:
+		return blockerEvidenceStatusUnverifiable, "budget or capacity scope is not registered"
+	}
+}
+
+func capacityConditionStatus(exhausted bool, condition string, label string) (string, string) {
+	condition = strings.ToLower(strings.TrimSpace(condition))
+	holds := exhausted
+	if condition == "available" {
+		holds = !exhausted
+	}
+	if holds {
+		return blockerEvidenceStatusHolds, label + " condition still holds"
+	}
+	return blockerEvidenceStatusCleared, label + " condition no longer holds"
+}
+
+func activeAgentClaims(state *State) int {
+	if state == nil {
+		return 0
+	}
+	active := map[string]struct{}{}
+	for issueID := range state.Running {
+		active[issueID] = struct{}{}
+	}
+	for issueID := range state.Claimed {
+		active[issueID] = struct{}{}
+	}
+	return len(active)
+}
+
+func backendCapacityOutageMatches(outages map[string]BackendOutage, resource string) bool {
+	resource = strings.ToLower(strings.TrimSpace(resource))
+	for _, outage := range outages {
+		scope := (backendcapacity.Scope{
+			BackendID:   outage.Scope.BackendID,
+			BackendKind: outage.Scope.BackendKind,
+			Provider:    outage.Scope.Provider,
+		}).Normalize()
+		if resource == "" || strings.EqualFold(scope.BackendID, resource) || strings.EqualFold(scope.BackendKind, resource) || strings.EqualFold(scope.Provider, resource) {
+			return true
+		}
+	}
+	return false
+}
+
+func evaluateConfigFingerprintPredicate(
+	ctx context.Context,
+	o *Orchestrator,
+	predicateContext *blockerPredicateContext,
+	predicate workpad.Predicate,
+) (string, string) {
+	signals := o.blockedCauseSignals(ctx, predicateContext.issue, RunModeImplement, predicateContext.issue.State, DiffStats{})
+	if strings.TrimSpace(signals.ConfigFingerprint) == "" {
+		return blockerEvidenceStatusUnverifiable, "live config fingerprint is unavailable"
+	}
+	if strings.TrimSpace(signals.ConfigFingerprint) == strings.TrimSpace(predicate.Fingerprint) {
+		return blockerEvidenceStatusHolds, "config fingerprint is unchanged"
+	}
+	return blockerEvidenceStatusCleared, "config fingerprint changed"
+}
+
+func tokenInList(value string, values []string) bool {
+	value = strings.ToLower(strings.TrimSpace(value))
+	for _, candidate := range values {
+		if value == strings.ToLower(strings.TrimSpace(candidate)) {
+			return true
+		}
+	}
+	return false
+}
+
+func setBlockedEvidence(state *State, issueID string, evidence []telemetry.BlockerEvidence) {
+	if state == nil {
+		return
+	}
+	issueID = strings.TrimSpace(issueID)
+	entry, ok := state.Blocked[issueID]
+	if !ok {
+		return
+	}
+	entry.BlockerEvidence = cloneBlockerEvidence(evidence)
+	state.Blocked[issueID] = entry
+}
+
+func (o *Orchestrator) applyRecordedBlockerRecovery(
+	ctx context.Context,
+	state *State,
+	issue connector.Issue,
+	dependencies []dependencyBlocker,
+	evidence []telemetry.BlockerEvidence,
+	now time.Time,
+) bool {
+	targetState := dependencyAutoUnblockTargetState(state, issue, normalizeDependencyAutoUnblockConfig(o.cfg.DependencyAutoUnblock).TargetState)
+	encoded, err := json.Marshal(evidence)
+	if err != nil {
+		if o.logger != nil {
+			o.logger.Warn("recorded blocker evidence encoding failed", "issue_id", issue.ID, "identifier", issue.Identifier, "error", err)
+		}
+		return false
+	}
+	signature := workpad.ContentHash(strings.TrimSpace(issue.Identifier) + "\n" + string(encoded))
+	metadata := workflowLaneMetadataWithActionSignature(workflowLaneMetadata{}, workflowActionRecordedBlockerRecovery, signature)
+	if err := o.updateIssueStateByIDStrictWithMetadata(
+		ctx,
+		state,
+		strings.TrimSpace(issue.ID),
+		issue,
+		targetState,
+		now,
+		workflowActionRecordedBlockerRecovery,
+		metadata,
+	); err != nil {
+		if o.logger != nil {
+			o.logger.Warn("recorded blocker recovery failed", "issue_id", issue.ID, "identifier", issue.Identifier, "target_state", targetState, "error", err)
+		}
+		return false
+	}
+	if o.connector != nil {
+		if err := o.connector.CreateComment(ctx, issue.ID, recordedBlockerRecoveryComment(issue, targetState, dependencies, evidence)); err != nil && o.logger != nil {
+			o.logger.Warn("recorded blocker recovery comment failed", "issue_id", issue.ID, "identifier", issue.Identifier, "error", err)
+		}
+	}
+	delete(state.Blocked, strings.TrimSpace(issue.ID))
+	recordStateEvent(state, telemetry.ActivityEvent{
+		At:      now,
+		Event:   workflowActionRecordedBlockerRecovery,
+		Message: "cleared recorded blockers for " + issueLabel(issue) + " and moved it to " + targetState,
+	})
+	return true
+}
+
+func recordedBlockerRecoveryComment(
+	issue connector.Issue,
+	targetState string,
+	dependencies []dependencyBlocker,
+	evidence []telemetry.BlockerEvidence,
+) string {
+	var b strings.Builder
+	b.WriteString("Recorded blocker predicates cleared. Moved ")
+	b.WriteString(issueLabel(issue))
+	b.WriteString(" from ")
+	b.WriteString(strings.TrimSpace(issue.State))
+	b.WriteString(" to ")
+	b.WriteString(strings.TrimSpace(targetState))
+	b.WriteString(".")
+	b.WriteString("\n\nCleared evidence:")
+	for _, item := range evidence {
+		b.WriteString("\n- ")
+		b.WriteString(strings.TrimSpace(item.Type))
+		if item.Reference != "" {
+			b.WriteString(" ")
+			b.WriteString(strings.TrimSpace(item.Reference))
+		}
+		b.WriteString(" (owner: ")
+		b.WriteString(strings.TrimSpace(item.Owner))
+		b.WriteString(")")
+	}
+	for _, dependency := range dependencies {
+		b.WriteString("\n- issue_state ")
+		b.WriteString(dependencyBlockerLabel(dependency))
+		b.WriteString(" (owner: orchestrator)")
+	}
+	return b.String()
+}

--- a/internal/orchestrator/blocker_evidence_test.go
+++ b/internal/orchestrator/blocker_evidence_test.go
@@ -301,6 +301,35 @@ func TestRecordedBlockerRecoveryClearsWithinTick(t *testing.T) {
 	}
 }
 
+func TestExplicitIssueStatePredicateDoesNotBecomeLegacyDependency(t *testing.T) {
+	now := time.Date(2026, 8, 16, 18, 0, 0, 0, time.UTC)
+	referenced := dependencyAutoUnblockIssue("issue-reference-open", "In Progress")
+	referenced.Identifier = "digitaldrywood/detent#42"
+	tracker := &dependencyAutoUnblockConnector{blockers: []connector.Issue{referenced}}
+	orch := blockedCauseTestOrchestrator(tracker)
+	issue := dependencyAutoUnblockIssue("issue-explicit-state", blockedStatusState)
+	issue.WorkpadSignal = &workpad.Signal{
+		Source: workpad.SourceStructured,
+		Status: workpad.StatusBlocked,
+		Blockers: []workpad.Blocker{typedTestBlocker(workpad.Predicate{
+			Type:       workpad.PredicateIssueState,
+			Identifier: referenced.Identifier,
+			States:     []string{"closed"},
+		})},
+	}
+	state := newState(orch.cfg)
+	state.Blocked[issue.ID] = Blocked{Issue: issue, BlockedAt: now.Add(-time.Hour), Source: BlockedSourceProjectStatus}
+
+	transitioned := orch.recoverBlockedIssues(t.Context(), &state, []connector.Issue{issue}, now)
+
+	if _, ok := transitioned[issue.ID]; !ok {
+		t.Fatalf("transitioned[%q] missing after explicit state stopped matching", issue.ID)
+	}
+	if len(tracker.updates) != 1 || tracker.updates[0].state != "Todo" {
+		t.Fatalf("updates = %#v, want Todo transition", tracker.updates)
+	}
+}
+
 func typedTestBlocker(predicate workpad.Predicate) workpad.Blocker {
 	return workpad.Blocker{
 		Owner:           workpad.BlockerOwnerOrchestrator,

--- a/internal/orchestrator/blocker_evidence_test.go
+++ b/internal/orchestrator/blocker_evidence_test.go
@@ -1,0 +1,330 @@
+package orchestrator
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/digitaldrywood/detent/internal/connector"
+	runpkg "github.com/digitaldrywood/detent/internal/runner"
+	"github.com/digitaldrywood/detent/internal/workpad"
+)
+
+func TestRecordedBlockerPredicateRegistry(t *testing.T) {
+	now := time.Date(2026, 8, 16, 18, 0, 0, 0, time.UTC)
+	present := true
+	absent := false
+	tests := []struct {
+		name             string
+		blocker          workpad.Blocker
+		prepare          func(*Orchestrator, *State, *connector.Issue, *blockerEvidenceTestConnector)
+		wantStatus       string
+		wantUnverifiable bool
+		wantOwner        string
+	}{
+		{
+			name: "issue state holds",
+			blocker: typedTestBlocker(workpad.Predicate{
+				Type:       workpad.PredicateIssueState,
+				Identifier: "digitaldrywood/detent#42",
+				States:     []string{"open"},
+			}),
+			prepare: func(_ *Orchestrator, _ *State, _ *connector.Issue, tracker *blockerEvidenceTestConnector) {
+				tracker.blockers = []connector.Issue{{Identifier: "digitaldrywood/detent#42", State: "In Progress"}}
+			},
+			wantStatus: blockerEvidenceStatusHolds,
+			wantOwner:  workpad.BlockerOwnerOrchestrator,
+		},
+		{
+			name: "issue state clears",
+			blocker: typedTestBlocker(workpad.Predicate{
+				Type:       workpad.PredicateIssueState,
+				Identifier: "digitaldrywood/detent#42",
+				States:     []string{"open"},
+			}),
+			prepare: func(_ *Orchestrator, _ *State, _ *connector.Issue, tracker *blockerEvidenceTestConnector) {
+				tracker.blockers = []connector.Issue{{Identifier: "digitaldrywood/detent#42", State: "Done", Closed: true}}
+			},
+			wantStatus: blockerEvidenceStatusCleared,
+			wantOwner:  workpad.BlockerOwnerOrchestrator,
+		},
+		{
+			name: "issue state rejects self reference",
+			blocker: typedTestBlocker(workpad.Predicate{
+				Type:       workpad.PredicateIssueState,
+				Identifier: "digitaldrywood/detent#evidence",
+				States:     []string{"open"},
+			}),
+			wantStatus:       blockerEvidenceStatusUnverifiable,
+			wantUnverifiable: true,
+			wantOwner:        workpad.BlockerOwnerOrchestrator,
+		},
+		{
+			name: "pull request state holds",
+			blocker: typedTestBlocker(workpad.Predicate{
+				Type:   workpad.PredicatePullRequestState,
+				States: []string{"open"},
+			}),
+			prepare: func(_ *Orchestrator, _ *State, issue *connector.Issue, _ *blockerEvidenceTestConnector) {
+				issue.PullRequest = &connector.PullRequest{Number: 42, State: "OPEN"}
+			},
+			wantStatus: blockerEvidenceStatusHolds,
+			wantOwner:  workpad.BlockerOwnerOrchestrator,
+		},
+		{
+			name: "pull request state clears",
+			blocker: typedTestBlocker(workpad.Predicate{
+				Type:   workpad.PredicatePullRequestState,
+				States: []string{"open"},
+			}),
+			prepare: func(_ *Orchestrator, _ *State, issue *connector.Issue, _ *blockerEvidenceTestConnector) {
+				issue.PullRequest = &connector.PullRequest{Number: 42, State: "MERGED"}
+			},
+			wantStatus: blockerEvidenceStatusCleared,
+			wantOwner:  workpad.BlockerOwnerOrchestrator,
+		},
+		{
+			name: "pull request state refresh clears stale state",
+			blocker: typedTestBlocker(workpad.Predicate{
+				Type:   workpad.PredicatePullRequestState,
+				States: []string{"open"},
+			}),
+			prepare: func(_ *Orchestrator, _ *State, issue *connector.Issue, tracker *blockerEvidenceTestConnector) {
+				issue.PullRequest = &connector.PullRequest{Number: 42, State: "OPEN"}
+				tracker.hydratedPullRequest = &connector.PullRequest{Number: 42, State: "MERGED"}
+			},
+			wantStatus: blockerEvidenceStatusCleared,
+			wantOwner:  workpad.BlockerOwnerOrchestrator,
+		},
+		{
+			name: "check absence holds",
+			blocker: typedTestBlocker(workpad.Predicate{
+				Type:    workpad.PredicateCheckPresence,
+				Check:   "Test",
+				Present: &absent,
+			}),
+			prepare: func(_ *Orchestrator, _ *State, issue *connector.Issue, _ *blockerEvidenceTestConnector) {
+				issue.PullRequest = &connector.PullRequest{Number: 42, State: "OPEN"}
+			},
+			wantStatus: blockerEvidenceStatusHolds,
+			wantOwner:  workpad.BlockerOwnerOrchestrator,
+		},
+		{
+			name: "check appearance clears",
+			blocker: typedTestBlocker(workpad.Predicate{
+				Type:    workpad.PredicateCheckPresence,
+				Check:   "Test",
+				Present: &absent,
+			}),
+			prepare: func(_ *Orchestrator, _ *State, issue *connector.Issue, _ *blockerEvidenceTestConnector) {
+				issue.PullRequest = &connector.PullRequest{Number: 42, State: "OPEN", Checks: []connector.PullRequestCheck{{Name: "Test"}}}
+			},
+			wantStatus: blockerEvidenceStatusCleared,
+			wantOwner:  workpad.BlockerOwnerOrchestrator,
+		},
+		{
+			name: "check presence condition holds",
+			blocker: typedTestBlocker(workpad.Predicate{
+				Type:    workpad.PredicateCheckPresence,
+				Check:   "Test",
+				Present: &present,
+			}),
+			prepare: func(_ *Orchestrator, _ *State, issue *connector.Issue, _ *blockerEvidenceTestConnector) {
+				issue.PullRequest = &connector.PullRequest{Number: 42, State: "OPEN", Checks: []connector.PullRequestCheck{{Name: "Test"}}}
+			},
+			wantStatus: blockerEvidenceStatusHolds,
+			wantOwner:  workpad.BlockerOwnerOrchestrator,
+		},
+		{
+			name: "budget exhaustion holds",
+			blocker: typedTestBlocker(workpad.Predicate{
+				Type:      workpad.PredicateBudgetCapacity,
+				Scope:     "daily_budget",
+				Condition: "exhausted",
+			}),
+			prepare: func(orch *Orchestrator, _ *State, _ *connector.Issue, _ *blockerEvidenceTestConnector) {
+				orch.dailyBudgetStatus = fakeDailyBudgetStatusProvider{status: DailyBudgetStatus{Active: true, CurrentSpendUSD: 10, MaxUSD: 10}}
+			},
+			wantStatus: blockerEvidenceStatusHolds,
+			wantOwner:  workpad.BlockerOwnerOrchestrator,
+		},
+		{
+			name: "budget recovery clears",
+			blocker: typedTestBlocker(workpad.Predicate{
+				Type:      workpad.PredicateBudgetCapacity,
+				Scope:     "daily_budget",
+				Condition: "exhausted",
+			}),
+			prepare: func(orch *Orchestrator, _ *State, _ *connector.Issue, _ *blockerEvidenceTestConnector) {
+				orch.dailyBudgetStatus = fakeDailyBudgetStatusProvider{status: DailyBudgetStatus{Active: true, CurrentSpendUSD: 4, MaxUSD: 10}}
+			},
+			wantStatus: blockerEvidenceStatusCleared,
+			wantOwner:  workpad.BlockerOwnerOrchestrator,
+		},
+		{
+			name: "config fingerprint holds",
+			blocker: typedTestBlocker(workpad.Predicate{
+				Type:        workpad.PredicateConfigFingerprint,
+				Fingerprint: "config-a",
+			}),
+			prepare: func(orch *Orchestrator, _ *State, _ *connector.Issue, _ *blockerEvidenceTestConnector) {
+				orch.recoveryInspector = staticBlockedRecoveryInspector{snapshot: blockedRecoverySnapshotWithConfig("config-a")}
+			},
+			wantStatus: blockerEvidenceStatusHolds,
+			wantOwner:  workpad.BlockerOwnerOrchestrator,
+		},
+		{
+			name: "config fingerprint change clears",
+			blocker: typedTestBlocker(workpad.Predicate{
+				Type:        workpad.PredicateConfigFingerprint,
+				Fingerprint: "config-a",
+			}),
+			prepare: func(orch *Orchestrator, _ *State, _ *connector.Issue, _ *blockerEvidenceTestConnector) {
+				orch.recoveryInspector = staticBlockedRecoveryInspector{snapshot: blockedRecoverySnapshotWithConfig("config-b")}
+			},
+			wantStatus: blockerEvidenceStatusCleared,
+			wantOwner:  workpad.BlockerOwnerOrchestrator,
+		},
+		{
+			name: "free text remains unverifiable",
+			blocker: workpad.Blocker{
+				Reason:       "waiting for an investigation",
+				Owner:        workpad.BlockerOwnerHuman,
+				Unverifiable: true,
+			},
+			wantStatus:       blockerEvidenceStatusUnverifiable,
+			wantUnverifiable: true,
+			wantOwner:        workpad.BlockerOwnerHuman,
+		},
+		{
+			name: "expired orchestrator predicate escalates",
+			blocker: func() workpad.Blocker {
+				blocker := typedTestBlocker(workpad.Predicate{Type: workpad.PredicateConfigFingerprint, Fingerprint: "config-a"})
+				expiresAt := now.Add(-time.Minute)
+				blocker.ExpiresAt = &expiresAt
+				return blocker
+			}(),
+			prepare: func(orch *Orchestrator, _ *State, _ *connector.Issue, _ *blockerEvidenceTestConnector) {
+				orch.recoveryInspector = staticBlockedRecoveryInspector{snapshot: blockedRecoverySnapshotWithConfig("config-a")}
+			},
+			wantStatus:       blockerEvidenceStatusUnverifiable,
+			wantUnverifiable: true,
+			wantOwner:        workpad.BlockerOwnerOrchestrator,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tracker := &blockerEvidenceTestConnector{dependencyAutoUnblockConnector: &dependencyAutoUnblockConnector{}}
+			orch := blockedCauseTestOrchestrator(tracker.dependencyAutoUnblockConnector)
+			orch.connector = tracker
+			state := newState(orch.cfg)
+			issue := dependencyAutoUnblockIssue("issue-evidence", blockedStatusState)
+			recordedAt := now.Add(-time.Hour)
+			issue.WorkpadSignal = &workpad.Signal{
+				Source:     workpad.SourceStructured,
+				Status:     workpad.StatusBlocked,
+				RecordedAt: &recordedAt,
+				Blockers:   []workpad.Blocker{tt.blocker},
+			}
+			if tt.prepare != nil {
+				tt.prepare(orch, &state, &issue, tracker)
+			}
+
+			got := orch.evaluateRecordedBlockers(t.Context(), &state, issue, nil, now)
+			if !got.Found || len(got.Evidence) != 1 {
+				t.Fatalf("evaluation = %#v, want one recorded blocker", got)
+			}
+			evidence := got.Evidence[0]
+			if evidence.Status != tt.wantStatus || evidence.Unverifiable != tt.wantUnverifiable || evidence.Owner != tt.wantOwner {
+				t.Fatalf("evidence = %#v", evidence)
+			}
+			if evidence.AgeSeconds != int64(time.Hour/time.Second) {
+				t.Fatalf("AgeSeconds = %d, want %d", evidence.AgeSeconds, int64(time.Hour/time.Second))
+			}
+		})
+	}
+}
+
+func TestRecordedBlockerRecoveryClearsWithinTick(t *testing.T) {
+	now := time.Date(2026, 8, 16, 18, 0, 0, 0, time.UTC)
+	tests := []struct {
+		name           string
+		fingerprint    string
+		wantTransition bool
+		wantStatus     string
+	}{
+		{name: "condition holds", fingerprint: "config-a", wantStatus: blockerEvidenceStatusHolds},
+		{name: "condition clears", fingerprint: "config-b", wantTransition: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tracker := &dependencyAutoUnblockConnector{}
+			orch := blockedCauseTestOrchestrator(tracker)
+			orch.recoveryInspector = staticBlockedRecoveryInspector{snapshot: blockedRecoverySnapshotWithConfig(tt.fingerprint)}
+			issue := dependencyAutoUnblockIssue("issue-tick-evidence", blockedStatusState)
+			issue.WorkpadSignal = &workpad.Signal{
+				Source: workpad.SourceStructured,
+				Status: workpad.StatusBlocked,
+				Blockers: []workpad.Blocker{typedTestBlocker(workpad.Predicate{
+					Type:        workpad.PredicateConfigFingerprint,
+					Fingerprint: "config-a",
+				})},
+			}
+			state := newState(orch.cfg)
+			state.Blocked[issue.ID] = Blocked{Issue: issue, BlockedAt: now.Add(-time.Hour), Source: BlockedSourceProjectStatus}
+
+			transitioned := orch.recoverBlockedIssues(t.Context(), &state, []connector.Issue{issue}, now)
+
+			_, didTransition := transitioned[issue.ID]
+			if didTransition != tt.wantTransition {
+				t.Fatalf("transitioned = %t, want %t", didTransition, tt.wantTransition)
+			}
+			if tt.wantTransition {
+				if len(tracker.updates) != 1 || tracker.updates[0].state != "Todo" {
+					t.Fatalf("updates = %#v, want Todo transition", tracker.updates)
+				}
+				if _, ok := state.Blocked[issue.ID]; ok {
+					t.Fatalf("Blocked[%q] remains after predicate cleared", issue.ID)
+				}
+				return
+			}
+			entry := state.Blocked[issue.ID]
+			if entry.RecoveryAction != "defer" || len(entry.BlockerEvidence) != 1 || entry.BlockerEvidence[0].Status != tt.wantStatus {
+				t.Fatalf("blocked entry = %#v", entry)
+			}
+			snapshot := state.Snapshot(now)
+			if len(snapshot.Blocked) != 1 || len(snapshot.Blocked[0].BlockerEvidence) != 1 || snapshot.Blocked[0].BlockerEvidence[0].Owner != workpad.BlockerOwnerOrchestrator {
+				t.Fatalf("snapshot blocker evidence = %#v", snapshot.Blocked)
+			}
+		})
+	}
+}
+
+func typedTestBlocker(predicate workpad.Predicate) workpad.Blocker {
+	return workpad.Blocker{
+		Owner:           workpad.BlockerOwnerOrchestrator,
+		Predicate:       &predicate,
+		RecheckInterval: "tick",
+	}
+}
+
+func blockedRecoverySnapshotWithConfig(fingerprint string) runpkg.BlockedRecoverySnapshot {
+	return runpkg.BlockedRecoverySnapshot{
+		ConfigFingerprint: fingerprint,
+		WorkspaceStatus:   "absent",
+		Health:            "ready",
+	}
+}
+
+type blockerEvidenceTestConnector struct {
+	*dependencyAutoUnblockConnector
+	hydratedPullRequest *connector.PullRequest
+}
+
+func (c *blockerEvidenceTestConnector) HydratePullRequest(_ context.Context, issue connector.Issue) (connector.Issue, error) {
+	if c.hydratedPullRequest != nil {
+		issue.PullRequest = c.hydratedPullRequest
+	}
+	return issue, nil
+}

--- a/internal/orchestrator/dependency_autounblock.go
+++ b/internal/orchestrator/dependency_autounblock.go
@@ -112,8 +112,8 @@ func (o *Orchestrator) autoUnblockDependencyIssues(
 		if !ok {
 			continue
 		}
-		hydrated, workpadRefs := o.issueWithCurrentWorkpadDependencyRefs(ctx, hydrated)
-		if reason := o.blockedCauseHoldReason(hydrated, state, nil, cfg); reason != "" {
+		hydrated, workpadRefs, workpadCurrent := o.issueWithCurrentWorkpadDependencyRefs(ctx, hydrated)
+		if reason := o.blockedCauseHoldReason(hydrated, state, nil, cfg, workpadCurrent); reason != "" {
 			o.logDependencyAutoUnblockDecision(hydrated, "hold", reason, nil, "")
 			continue
 		}
@@ -127,7 +127,7 @@ func (o *Orchestrator) autoUnblockDependencyIssues(
 		o.logDependencyProseOnly(hydrated)
 		blockers := o.resolveDependencyBlockers(ctx, hydrated)
 		workpadBlockers := dependencyBlockersMatchingRefs(blockers, workpadRefs)
-		if reason := o.blockedCauseHoldReason(hydrated, state, workpadBlockers, cfg); reason != "" {
+		if reason := o.blockedCauseHoldReason(hydrated, state, workpadBlockers, cfg, workpadCurrent); reason != "" {
 			o.logDependencyAutoUnblockDecision(hydrated, "hold", reason, blockers, "")
 			continue
 		}
@@ -382,15 +382,15 @@ func (o *Orchestrator) issueWithDependencyRefs(issue connector.Issue) connector.
 func (o *Orchestrator) issueWithCurrentWorkpadDependencyRefs(
 	ctx context.Context,
 	issue connector.Issue,
-) (connector.Issue, []connector.BlockedRef) {
+) (connector.Issue, []connector.BlockedRef, bool) {
 	if !o.workpadBlockersMatchCurrentBlockedEntry(ctx, issue) {
-		return issue, nil
+		return issue, nil, false
 	}
 	refs := workpadDependencyRefs(issue)
 	issue.BlockedBy = mergeDependencyBlockedRefs(issue.BlockedBy, refs)
 	issue.BlockedBy = dependencyBlockedRefsWithoutSelf(issue.BlockedBy, issue.Identifier)
 	refs = dependencyBlockedRefsWithoutSelf(refs, issue.Identifier)
-	return issue, refs
+	return issue, refs, true
 }
 
 func (o *Orchestrator) workpadBlockersMatchCurrentBlockedEntry(ctx context.Context, issue connector.Issue) bool {
@@ -461,8 +461,10 @@ func workpadDependencyRefs(issue connector.Issue) []connector.BlockedRef {
 	repo := dependencyIssueRepo(issue.Identifier)
 	refs := make([]connector.BlockedRef, 0, len(signal.Blockers))
 	for _, blocker := range signal.Blockers {
-		if blocker.Predicate != nil && blocker.Predicate.Type != workpad.PredicateIssueState {
-			continue
+		if blocker.Predicate != nil {
+			if blocker.Predicate.Type != workpad.PredicateIssueState || len(blocker.Predicate.States) > 0 {
+				continue
+			}
 		}
 		identifier := strings.TrimSpace(blocker.Identifier)
 		if identifier == "" && blocker.Predicate != nil {

--- a/internal/orchestrator/dependency_autounblock.go
+++ b/internal/orchestrator/dependency_autounblock.go
@@ -461,7 +461,13 @@ func workpadDependencyRefs(issue connector.Issue) []connector.BlockedRef {
 	repo := dependencyIssueRepo(issue.Identifier)
 	refs := make([]connector.BlockedRef, 0, len(signal.Blockers))
 	for _, blocker := range signal.Blockers {
+		if blocker.Predicate != nil && blocker.Predicate.Type != workpad.PredicateIssueState {
+			continue
+		}
 		identifier := strings.TrimSpace(blocker.Identifier)
+		if identifier == "" && blocker.Predicate != nil {
+			identifier = strings.TrimSpace(blocker.Predicate.Identifier)
+		}
 		if identifier == "" {
 			parsed, err := workpad.ParseRef(blocker.Ref, repo)
 			if err != nil {

--- a/internal/orchestrator/dependency_autounblock_test.go
+++ b/internal/orchestrator/dependency_autounblock_test.go
@@ -27,19 +27,20 @@ func TestTickRecoversCurrentWorkpadDependencyBlockers(t *testing.T) {
 	unresolved.Identifier = "digitaldrywood/ghostreel#35"
 
 	tests := []struct {
-		name                string
-		blockers            []connector.Issue
-		humanAction         string
-		invalid             *workpad.Invalid
-		labels              []string
-		stickyReason        string
-		nativeDuplicate     bool
-		workpadUpdatedAt    time.Time
-		previousLaneStarted time.Time
-		wantTransition      bool
-		wantHoldReason      string
-		wantUnresolved      string
-		wantWorkpadLookup   bool
+		name                  string
+		blockers              []connector.Issue
+		humanAction           string
+		invalid               *workpad.Invalid
+		labels                []string
+		stickyReason          string
+		nativeDuplicate       bool
+		recordedNonDependency bool
+		workpadUpdatedAt      time.Time
+		previousLaneStarted   time.Time
+		wantTransition        bool
+		wantHoldReason        string
+		wantUnresolved        string
+		wantWorkpadLookup     bool
 	}{
 		{
 			name:                "all refs resolved after no progress limit",
@@ -146,6 +147,13 @@ func TestTickRecoversCurrentWorkpadDependencyBlockers(t *testing.T) {
 			workpadUpdatedAt:    parkedAt.Add(-2 * time.Hour),
 			previousLaneStarted: parkedAt.Add(-time.Hour),
 		},
+		{
+			name:                  "stale non-dependency blocker from prior blocked entry",
+			recordedNonDependency: true,
+			stickyReason:          noProgressLimitReason,
+			workpadUpdatedAt:      parkedAt.Add(-2 * time.Hour),
+			previousLaneStarted:   parkedAt.Add(-time.Hour),
+		},
 	}
 
 	for _, tt := range tests {
@@ -168,6 +176,12 @@ func TestTickRecoversCurrentWorkpadDependencyBlockers(t *testing.T) {
 					Ref:        blocker.Identifier,
 					Identifier: blocker.Identifier,
 				})
+			}
+			if tt.recordedNonDependency {
+				waiting.WorkpadSignal.Blockers = append(waiting.WorkpadSignal.Blockers, typedTestBlocker(workpad.Predicate{
+					Type:        workpad.PredicateConfigFingerprint,
+					Fingerprint: "stale-config",
+				}))
 			}
 			if tt.nativeDuplicate {
 				waiting.BlockedBy = []connector.BlockedRef{{
@@ -227,6 +241,9 @@ func TestTickRecoversCurrentWorkpadDependencyBlockers(t *testing.T) {
 			}
 			if tt.name == "stale blocker list from prior blocked entry" && strings.Contains(logs.String(), "reason=workpad_blocker") {
 				t.Fatalf("stale Workpad blocker held current entry:\n%s", logs.String())
+			}
+			if tt.recordedNonDependency && strings.Contains(logs.String(), "reason=recorded_blocker") {
+				t.Fatalf("stale recorded blocker held current entry:\n%s", logs.String())
 			}
 		})
 	}

--- a/internal/orchestrator/snapshot.go
+++ b/internal/orchestrator/snapshot.go
@@ -710,6 +710,7 @@ func blockedSnapshots(blocked map[string]Blocked, claims map[string]Claimed, now
 			RecoveryReachability:    entry.RecoveryReachability,
 			RecoveryIntentResumable: entry.RecoveryIntentResumable,
 			NeedsHumanAttention:     entry.NeedsHumanAttention,
+			BlockerEvidence:         cloneBlockerEvidence(entry.BlockerEvidence),
 			RecoveryRoot:            entry.RecoveryRoot,
 			Attempt:                 entry.Attempt,
 			WorkAttemptID:           entry.WorkAttemptID,

--- a/internal/orchestrator/state.go
+++ b/internal/orchestrator/state.go
@@ -177,6 +177,7 @@ type Blocked struct {
 	RecoveryReachability    string
 	RecoveryIntentResumable bool
 	NeedsHumanAttention     bool
+	BlockerEvidence         []telemetry.BlockerEvidence
 	RecoveryRoot            *telemetry.BlockedRecoveryRoot
 	BlockedAt               time.Time
 	Source                  BlockedSource
@@ -444,6 +445,7 @@ func (s State) clone() State {
 	}
 	for id, blocked := range s.Blocked {
 		blocked.Issue = cloneIssue(blocked.Issue)
+		blocked.BlockerEvidence = cloneBlockerEvidence(blocked.BlockerEvidence)
 		cloned.Blocked[id] = blocked
 	}
 	for id, completed := range s.Completed {
@@ -480,6 +482,21 @@ func (s State) clone() State {
 	maps.Copy(cloned.ReapedWorkspaces, s.ReapedWorkspaces)
 	maps.Copy(cloned.planRework, s.planRework)
 
+	return cloned
+}
+
+func cloneBlockerEvidence(evidence []telemetry.BlockerEvidence) []telemetry.BlockerEvidence {
+	cloned := append([]telemetry.BlockerEvidence(nil), evidence...)
+	for index := range cloned {
+		if evidence[index].RecordedAt != nil {
+			recordedAt := *evidence[index].RecordedAt
+			cloned[index].RecordedAt = &recordedAt
+		}
+		if evidence[index].ExpiresAt != nil {
+			expiresAt := *evidence[index].ExpiresAt
+			cloned[index].ExpiresAt = &expiresAt
+		}
+	}
 	return cloned
 }
 
@@ -601,6 +618,7 @@ func cloneIssue(issue connector.Issue) connector.Issue {
 			nextRetryAt := *issue.PullRequest.HydrationNextRetryAt
 			pullRequest.HydrationNextRetryAt = &nextRetryAt
 		}
+		pullRequest.Checks = append([]connector.PullRequestCheck(nil), issue.PullRequest.Checks...)
 		pullRequest.SlowChecks = append([]connector.PullRequestCheck(nil), issue.PullRequest.SlowChecks...)
 		pullRequest.RunningChecks = append([]string(nil), issue.PullRequest.RunningChecks...)
 		pullRequest.UnstartedChecks = append([]connector.PullRequestCheck(nil), issue.PullRequest.UnstartedChecks...)

--- a/internal/orchestrator/tick.go
+++ b/internal/orchestrator/tick.go
@@ -781,6 +781,9 @@ func applyPullRequestHydrationBlock(target *connector.PullRequest, source connec
 	if strings.TrimSpace(target.CIStatus) == "" {
 		target.CIStatus = source.CIStatus
 	}
+	if len(target.Checks) == 0 {
+		target.Checks = append([]connector.PullRequestCheck(nil), source.Checks...)
+	}
 	if len(target.RequiredCheckFailures) == 0 {
 		target.RequiredCheckFailures = append([]connector.PullRequestCheck(nil), source.RequiredCheckFailures...)
 	}

--- a/internal/runner/prompt.go
+++ b/internal/runner/prompt.go
@@ -705,8 +705,16 @@ func appendBlockedHandoffBlock(prompt string) string {
 		"blockers:\n" +
 		"  - ref: \"owner/repo#123\"\n" +
 		"    reason: \"waiting for the dependency to merge\"\n" +
+		"    owner: orchestrator\n" +
+		"    predicate:\n" +
+		"      type: issue_state\n" +
+		"      states: [open]\n" +
+		"    recheck_interval: tick\n" +
 		"human_action: null\n" +
 		"```\n\n" +
+		"Every blocker should include a typed predicate, an owner (`orchestrator` or `human`), and either `recheck_interval` or `expires_at`. " +
+		"Supported predicate types are `issue_state`, `pull_request_state`, `check_presence`, `budget_capacity`, and `config_fingerprint`. " +
+		"A bare free-text blocker is accepted for compatibility but is surfaced as unverifiable with its owner and age, and Detent never auto-clears it.\n\n" +
 		"When `tracker.blocked_recovery` is enabled and the workflow intentionally parks agent-recoverable PR maintenance in a configured source lane, " +
 		"set `reason_code` to `merge_conflict`, `stale_base`, or `missing_current_head_ci` in the blocked status block. " +
 		"Do not set a recovery reason code for manual or human-only parking.\n\n" +

--- a/internal/runner/prompt_test.go
+++ b/internal/runner/prompt_test.go
@@ -273,8 +273,14 @@ func TestBuildPromptDocumentsWorkpadStatusContract(t *testing.T) {
 			"blockers:\n" +
 			"  - ref: \"owner/repo#123\"\n" +
 			"    reason: \"waiting for the dependency to merge\"\n" +
+			"    owner: orchestrator\n" +
+			"    predicate:\n" +
+			"      type: issue_state\n" +
+			"      states: [open]\n" +
+			"    recheck_interval: tick\n" +
 			"human_action: null\n" +
 			"```",
+		"A bare free-text blocker is accepted for compatibility but is surfaced as unverifiable with its owner and age",
 		"```detent-status\n" +
 			"schema: 1\n" +
 			"status: complete\n" +

--- a/internal/telemetry/snapshot.go
+++ b/internal/telemetry/snapshot.go
@@ -815,6 +815,7 @@ type Blocked struct {
 	RecoveryReachability    string               `json:"recovery_reachability,omitempty"`
 	RecoveryIntentResumable bool                 `json:"recovery_intent_resumable,omitempty"`
 	NeedsHumanAttention     bool                 `json:"needs_human_attention,omitempty"`
+	BlockerEvidence         []BlockerEvidence    `json:"blocker_evidence,omitempty"`
 	RecoveryRoot            *BlockedRecoveryRoot `json:"recovery_root,omitempty"`
 	BlockedAt               *time.Time           `json:"blocked_at,omitempty"`
 	LastEventAt             *time.Time           `json:"last_event_at,omitempty"`
@@ -827,6 +828,20 @@ type Blocked struct {
 	Priority                int                  `json:"priority,omitempty"`
 	PriorityName            string               `json:"priority_name,omitempty"`
 	StopReason              string               `json:"stop_reason,omitempty"`
+}
+
+type BlockerEvidence struct {
+	Type            string     `json:"type"`
+	Owner           string     `json:"owner"`
+	Status          string     `json:"status"`
+	Reference       string     `json:"reference,omitempty"`
+	Reason          string     `json:"reason,omitempty"`
+	Detail          string     `json:"detail,omitempty"`
+	Unverifiable    bool       `json:"unverifiable,omitempty"`
+	AgeSeconds      int64      `json:"age_seconds,omitempty"`
+	RecordedAt      *time.Time `json:"recorded_at,omitempty"`
+	ExpiresAt       *time.Time `json:"expires_at,omitempty"`
+	RecheckInterval string     `json:"recheck_interval,omitempty"`
 }
 
 type BlockedRecoveryRoot struct {

--- a/internal/web/api.go
+++ b/internal/web/api.go
@@ -707,6 +707,7 @@ func blockedEntries(entries []telemetry.Blocked) []blockedAPIResponse {
 			RecoveryReachability:    optionalString(entry.RecoveryReachability),
 			RecoveryIntentResumable: entry.RecoveryIntentResumable,
 			NeedsHumanAttention:     entry.NeedsHumanAttention,
+			BlockerEvidence:         append([]telemetry.BlockerEvidence(nil), entry.BlockerEvidence...),
 			BlockedBy:               append([]telemetry.BlockedRef{}, entry.BlockedBy...),
 			RecoveryRoot:            entry.RecoveryRoot,
 			WorkerHost:              optionalString(entry.WorkerHost),
@@ -804,6 +805,7 @@ func blockedIssueResponse(entry telemetry.Blocked) *blockedIssueAPIResponse {
 		RecoveryReachability:    optionalString(entry.RecoveryReachability),
 		RecoveryIntentResumable: entry.RecoveryIntentResumable,
 		NeedsHumanAttention:     entry.NeedsHumanAttention,
+		BlockerEvidence:         append([]telemetry.BlockerEvidence(nil), entry.BlockerEvidence...),
 		BlockedBy:               append([]telemetry.BlockedRef{}, entry.BlockedBy...),
 		RecoveryRoot:            entry.RecoveryRoot,
 		BlockedAt:               timestampStringPtr(entry.BlockedAt),
@@ -1547,6 +1549,7 @@ type blockedAPIResponse struct {
 	RecoveryReachability    *string                        `json:"recovery_reachability"`
 	RecoveryIntentResumable bool                           `json:"recovery_intent_resumable"`
 	NeedsHumanAttention     bool                           `json:"needs_human_attention"`
+	BlockerEvidence         []telemetry.BlockerEvidence    `json:"blocker_evidence,omitempty"`
 	BlockedBy               []telemetry.BlockedRef         `json:"blocked_by"`
 	RecoveryRoot            *telemetry.BlockedRecoveryRoot `json:"recovery_root"`
 	WorkerHost              *string                        `json:"worker_host"`
@@ -1814,6 +1817,7 @@ type blockedIssueAPIResponse struct {
 	RecoveryReachability    *string                        `json:"recovery_reachability"`
 	RecoveryIntentResumable bool                           `json:"recovery_intent_resumable"`
 	NeedsHumanAttention     bool                           `json:"needs_human_attention"`
+	BlockerEvidence         []telemetry.BlockerEvidence    `json:"blocker_evidence,omitempty"`
 	BlockedBy               []telemetry.BlockedRef         `json:"blocked_by"`
 	RecoveryRoot            *telemetry.BlockedRecoveryRoot `json:"recovery_root"`
 	BlockedAt               *string                        `json:"blocked_at"`

--- a/internal/web/api_issue_test.go
+++ b/internal/web/api_issue_test.go
@@ -114,7 +114,7 @@ func TestAPIIssueSurfacesWorkpadBlockerResolution(t *testing.T) {
 	}{
 		{name: "open ref is live", refs: []telemetry.BlockedRef{openRef}, wantJSON: []string{`"tracker_state":"open"`}},
 		{name: "closed ref is resolved", refs: []telemetry.BlockedRef{closedRef}, wantJSON: []string{`"tracker_state":"closed"`}},
-		{name: "mixed refs retain human hold", refs: []telemetry.BlockedRef{closedRef, openRef}, wantJSON: []string{`"tracker_state":"closed"`, `"tracker_state":"open"`, `"recovery_reason":"human_action"`, `"recovery_remedy":"approve the remaining deployment"`}},
+		{name: "mixed refs retain human hold", refs: []telemetry.BlockedRef{closedRef, openRef}, wantJSON: []string{`"tracker_state":"closed"`, `"tracker_state":"open"`, `"recovery_reason":"human_action"`, `"recovery_remedy":"approve the remaining deployment"`, `"type":"free_text"`, `"owner":"human"`, `"unverifiable":true`, `"age_seconds":3600`}},
 	}
 
 	for _, tt := range tests {
@@ -130,6 +130,13 @@ func TestAPIIssueSurfacesWorkpadBlockerResolution(t *testing.T) {
 				RecoveryReason:      "human_action",
 				RecoveryRemedy:      "approve the remaining deployment",
 				NeedsHumanAttention: true,
+				BlockerEvidence: []telemetry.BlockerEvidence{{
+					Type:         "free_text",
+					Owner:        "human",
+					Status:       "unverifiable",
+					Unverifiable: true,
+					AgeSeconds:   3600,
+				}},
 			}}}); err != nil {
 				t.Fatalf("Publish() error = %v", err)
 			}

--- a/internal/web/templates/board_data.go
+++ b/internal/web/templates/board_data.go
@@ -1017,6 +1017,9 @@ func boardMoreBlockedLabel(count int) string {
 
 func boardExceptionDetail(row telemetry.Blocked, now time.Time) string {
 	detail := boardBlockedDetail(row.Source, row.RecoveryAction, row.RecoveryReason, row.RecoveryRemedy, row.Error)
+	if evidence := boardBlockerEvidenceDetail(row, now); evidence != "" {
+		detail = strings.TrimSpace(detail + " · " + evidence)
+	}
 	if detail == "" && boardBlockedWaiting(row.Source, row.RecoveryAction, row.RecoveryReason, row.Error) {
 		if boardBlockedDependencyWaiting(row.Source, row.RecoveryReason, row.Error, row.BlockedBy) {
 			detail = "dependency not ready"
@@ -1031,6 +1034,25 @@ func boardExceptionDetail(row telemetry.Blocked, now time.Time) string {
 		detail += " · waiting " + prPipelineAge(*row.BlockedAt, now)
 	}
 	return detail
+}
+
+func boardBlockerEvidenceDetail(row telemetry.Blocked, now time.Time) string {
+	for _, evidence := range row.BlockerEvidence {
+		if !evidence.Unverifiable {
+			continue
+		}
+		parts := []string{"unverifiable " + strings.ReplaceAll(strings.TrimSpace(evidence.Type), "_", " ")}
+		if owner := strings.TrimSpace(evidence.Owner); owner != "" {
+			parts = append(parts, "owner "+owner)
+		}
+		if evidence.RecordedAt != nil && !now.IsZero() {
+			parts = append(parts, "age "+prPipelineAge(*evidence.RecordedAt, now))
+		} else if evidence.AgeSeconds > 0 {
+			parts = append(parts, "age "+formatDuration(float64(evidence.AgeSeconds)))
+		}
+		return strings.Join(parts, " · ")
+	}
+	return ""
 }
 
 func boardCardViewFromCard(data DashboardData, lane projectKanbanLane, card projectKanbanCard, terminal bool, scope string, fallbackProjectID string) boardCardView {

--- a/internal/web/templates/board_data_test.go
+++ b/internal/web/templates/board_data_test.go
@@ -1648,6 +1648,24 @@ func TestBoardExceptionsDistinguishHeldRecoveryFromDefer(t *testing.T) {
 	}
 }
 
+func TestBoardBlockerEvidenceDetailSurfacesUnverifiableAgeAndOwner(t *testing.T) {
+	t.Parallel()
+
+	recordedAt := time.Date(2026, 8, 16, 12, 0, 0, 0, time.UTC)
+	detail := boardBlockerEvidenceDetail(telemetry.Blocked{BlockerEvidence: []telemetry.BlockerEvidence{{
+		Type:         "free_text",
+		Owner:        "human",
+		Status:       "unverifiable",
+		Unverifiable: true,
+		RecordedAt:   &recordedAt,
+	}}}, recordedAt.Add(90*time.Minute))
+	for _, want := range []string{"unverifiable free text", "owner human", "age 1h 30m"} {
+		if !strings.Contains(detail, want) {
+			t.Fatalf("detail = %q, want containing %q", detail, want)
+		}
+	}
+}
+
 func TestBoardBlockedWaitingCardsUseWarningTreatment(t *testing.T) {
 	data := boardTestData()
 	blockedAt := data.Snapshot.GeneratedAt.Add(-15 * time.Minute)

--- a/internal/web/templates/dashboard_data.go
+++ b/internal/web/templates/dashboard_data.go
@@ -4781,6 +4781,7 @@ func blockedLastUpdateMeta(row telemetry.Blocked) string {
 }
 
 func blockedRecoverySummary(row telemetry.Blocked) string {
+	evidenceDetail := boardBlockerEvidenceDetail(row, time.Time{})
 	action := strings.ToLower(strings.TrimSpace(row.RecoveryAction))
 	reason := strings.ReplaceAll(strings.TrimSpace(row.RecoveryReason), "_", " ")
 	remedy := strings.TrimSpace(row.RecoveryRemedy)
@@ -4791,6 +4792,9 @@ func blockedRecoverySummary(row telemetry.Blocked) string {
 		}
 		if remedy != "" {
 			detail += ". " + remedy
+		}
+		if evidenceDetail != "" {
+			detail += ". " + evidenceDetail
 		}
 		return detail
 	}
@@ -4810,6 +4814,9 @@ func blockedRecoverySummary(row telemetry.Blocked) string {
 			if rootReason := strings.ReplaceAll(strings.TrimSpace(row.RecoveryRoot.Reason), "_", " "); rootReason != "" {
 				detail += " (" + rootReason + ")"
 			}
+		}
+		if evidenceDetail != "" {
+			detail += "; " + evidenceDetail
 		}
 		return detail
 	}

--- a/internal/workpad/workpad.go
+++ b/internal/workpad/workpad.go
@@ -9,6 +9,7 @@ import (
 	"regexp"
 	"sort"
 	"strings"
+	"time"
 
 	"gopkg.in/yaml.v3"
 )
@@ -22,6 +23,15 @@ const (
 	StatusInProgress = "in_progress"
 	StatusBlocked    = "blocked"
 	StatusComplete   = "complete"
+
+	BlockerOwnerOrchestrator = "orchestrator"
+	BlockerOwnerHuman        = "human"
+
+	PredicateIssueState        = "issue_state"
+	PredicatePullRequestState  = "pull_request_state"
+	PredicateCheckPresence     = "check_presence"
+	PredicateBudgetCapacity    = "budget_capacity"
+	PredicateConfigFingerprint = "config_fingerprint"
 )
 
 var refPattern = regexp.MustCompile(`^(?:([A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+))?#([1-9][0-9]*)$`)
@@ -33,14 +43,33 @@ type Signal struct {
 	ReasonCode  string            `json:"reason_code,omitempty" yaml:"reason_code,omitempty"`
 	Blockers    []Blocker         `json:"blockers,omitempty" yaml:"blockers,omitempty"`
 	HumanAction string            `json:"human_action,omitempty" yaml:"human_action,omitempty"`
+	RecordedAt  *time.Time        `json:"recorded_at,omitempty" yaml:"recorded_at,omitempty"`
 	Fields      map[string]string `json:"fields,omitempty" yaml:"fields,omitempty"`
 	Invalid     *Invalid          `json:"invalid,omitempty" yaml:"invalid,omitempty"`
 }
 
 type Blocker struct {
-	Ref        string `json:"ref,omitempty" yaml:"ref,omitempty"`
-	Identifier string `json:"identifier,omitempty" yaml:"identifier,omitempty"`
-	Reason     string `json:"reason,omitempty" yaml:"reason,omitempty"`
+	Ref             string     `json:"ref,omitempty" yaml:"ref,omitempty"`
+	Identifier      string     `json:"identifier,omitempty" yaml:"identifier,omitempty"`
+	Reason          string     `json:"reason,omitempty" yaml:"reason,omitempty"`
+	Owner           string     `json:"owner,omitempty" yaml:"owner,omitempty"`
+	Predicate       *Predicate `json:"predicate,omitempty" yaml:"predicate,omitempty"`
+	ExpiresAt       *time.Time `json:"expires_at,omitempty" yaml:"expires_at,omitempty"`
+	RecheckInterval string     `json:"recheck_interval,omitempty" yaml:"recheck_interval,omitempty"`
+	Unverifiable    bool       `json:"unverifiable,omitempty" yaml:"unverifiable,omitempty"`
+}
+
+type Predicate struct {
+	Type        string   `json:"type,omitempty" yaml:"type,omitempty"`
+	Ref         string   `json:"ref,omitempty" yaml:"ref,omitempty"`
+	Identifier  string   `json:"identifier,omitempty" yaml:"identifier,omitempty"`
+	States      []string `json:"states,omitempty" yaml:"states,omitempty"`
+	Check       string   `json:"check,omitempty" yaml:"check,omitempty"`
+	Present     *bool    `json:"present,omitempty" yaml:"present,omitempty"`
+	Scope       string   `json:"scope,omitempty" yaml:"scope,omitempty"`
+	Resource    string   `json:"resource,omitempty" yaml:"resource,omitempty"`
+	Condition   string   `json:"condition,omitempty" yaml:"condition,omitempty"`
+	Fingerprint string   `json:"fingerprint,omitempty" yaml:"fingerprint,omitempty"`
 }
 
 type Invalid struct {
@@ -59,8 +88,26 @@ type statusBlockYAML struct {
 }
 
 type blockerYAML struct {
-	Ref    string `yaml:"ref"`
-	Reason string `yaml:"reason"`
+	Ref             string         `yaml:"ref"`
+	Reason          string         `yaml:"reason"`
+	Owner           string         `yaml:"owner"`
+	Predicate       *predicateYAML `yaml:"predicate"`
+	ExpiresAt       string         `yaml:"expires_at"`
+	RecheckInterval string         `yaml:"recheck_interval"`
+}
+
+type predicateYAML struct {
+	Type        string   `yaml:"type"`
+	Kind        string   `yaml:"kind"`
+	Ref         string   `yaml:"ref"`
+	State       string   `yaml:"state"`
+	States      []string `yaml:"states"`
+	Check       string   `yaml:"check"`
+	Present     *bool    `yaml:"present"`
+	Scope       string   `yaml:"scope"`
+	Resource    string   `yaml:"resource"`
+	Condition   string   `yaml:"condition"`
+	Fingerprint string   `yaml:"fingerprint"`
 }
 
 func SignalFromComment(body string, commentURL string, repo string) (*Signal, bool) {
@@ -155,15 +202,53 @@ func ParseStatusBlock(content string, repo string) (*Signal, error) {
 	blockers := make([]Blocker, 0, len(raw.Blockers))
 	for index, blocker := range raw.Blockers {
 		ref := strings.TrimSpace(blocker.Ref)
-		identifier, err := ParseRef(ref, repo)
-		if err != nil {
-			problems = append(problems, fmt.Sprintf("blockers[%d].ref %q must be #N or owner/repo#N", index, ref))
-			continue
+		reason := strings.TrimSpace(blocker.Reason)
+		owner := normalizeToken(blocker.Owner)
+		predicate, predicateProblems := normalizePredicate(blocker.Predicate, ref, repo)
+		for _, problem := range predicateProblems {
+			problems = append(problems, fmt.Sprintf("blockers[%d].%s", index, problem))
+		}
+		identifier := ""
+		if ref != "" {
+			parsed, err := ParseRef(ref, repo)
+			if err != nil {
+				problems = append(problems, fmt.Sprintf("blockers[%d].ref %q must be #N or owner/repo#N", index, ref))
+			} else {
+				identifier = parsed
+			}
+		}
+		if predicate == nil && ref != "" {
+			predicate = &Predicate{Type: PredicateIssueState, Ref: ref, Identifier: identifier}
+		}
+		if owner == "" {
+			owner = BlockerOwnerHuman
+			if predicate != nil {
+				owner = BlockerOwnerOrchestrator
+			}
+		}
+		if owner != BlockerOwnerOrchestrator && owner != BlockerOwnerHuman {
+			problems = append(problems, fmt.Sprintf("blockers[%d].owner %q must be orchestrator or human", index, strings.TrimSpace(blocker.Owner)))
+		}
+		expiresAt, expiryProblem := parseExpiry(blocker.ExpiresAt)
+		if expiryProblem != "" {
+			problems = append(problems, fmt.Sprintf("blockers[%d].expires_at %s", index, expiryProblem))
+		}
+		recheckInterval, intervalProblem := parseRecheckInterval(blocker.RecheckInterval, predicate != nil)
+		if intervalProblem != "" {
+			problems = append(problems, fmt.Sprintf("blockers[%d].recheck_interval %s", index, intervalProblem))
+		}
+		if predicate == nil && reason == "" {
+			problems = append(problems, fmt.Sprintf("blockers[%d] requires a ref, predicate, or reason", index))
 		}
 		blockers = append(blockers, Blocker{
-			Ref:        ref,
-			Identifier: identifier,
-			Reason:     strings.TrimSpace(blocker.Reason),
+			Ref:             ref,
+			Identifier:      identifier,
+			Reason:          reason,
+			Owner:           owner,
+			Predicate:       predicate,
+			ExpiresAt:       expiresAt,
+			RecheckInterval: recheckInterval,
+			Unverifiable:    predicate == nil,
 		})
 	}
 	if raw.Status == StatusBlocked && len(blockers) == 0 && humanAction == "" && reasonCode == "" {
@@ -208,6 +293,176 @@ func ParseStatusBlock(content string, repo string) (*Signal, error) {
 	}, nil
 }
 
+func normalizePredicate(raw *predicateYAML, blockerRef string, repo string) (*Predicate, []string) {
+	if raw == nil {
+		return nil, nil
+	}
+	problems := []string{}
+	predicateType := normalizePredicateType(raw.Type)
+	kind := normalizePredicateType(raw.Kind)
+	if predicateType == "" {
+		predicateType = kind
+	} else if kind != "" && kind != predicateType {
+		problems = append(problems, "predicate type and kind must match")
+	}
+	ref := strings.TrimSpace(raw.Ref)
+	if ref == "" {
+		ref = strings.TrimSpace(blockerRef)
+	}
+	identifier := ""
+	if ref != "" {
+		parsed, err := ParseRef(ref, repo)
+		if err != nil {
+			problems = append(problems, fmt.Sprintf("predicate.ref %q must be #N or owner/repo#N", ref))
+		} else {
+			identifier = parsed
+		}
+	}
+	states := append([]string(nil), raw.States...)
+	if state := strings.TrimSpace(raw.State); state != "" {
+		states = append(states, state)
+	}
+	for index := range states {
+		states[index] = normalizeToken(states[index])
+	}
+	states = uniqueNonBlank(states)
+	predicate := &Predicate{
+		Type:        predicateType,
+		Ref:         ref,
+		Identifier:  identifier,
+		States:      states,
+		Check:       strings.TrimSpace(raw.Check),
+		Present:     cloneBool(raw.Present),
+		Scope:       normalizeToken(raw.Scope),
+		Resource:    strings.TrimSpace(raw.Resource),
+		Condition:   normalizeToken(raw.Condition),
+		Fingerprint: strings.TrimSpace(raw.Fingerprint),
+	}
+	switch predicate.Type {
+	case PredicateIssueState:
+		if predicate.Identifier == "" {
+			problems = append(problems, "predicate.ref is required for issue_state")
+		}
+	case PredicatePullRequestState:
+		if len(predicate.States) == 0 {
+			problems = append(problems, "predicate.state or predicate.states is required for pull_request_state")
+		}
+	case PredicateCheckPresence:
+		if predicate.Check == "" {
+			problems = append(problems, "predicate.check is required for check_presence")
+		}
+		if predicate.Present == nil {
+			problems = append(problems, "predicate.present is required for check_presence")
+		}
+	case PredicateBudgetCapacity:
+		switch predicate.Scope {
+		case "daily", "daily_budget":
+			predicate.Scope = "daily_budget"
+		case "issue", "issue_budget":
+			predicate.Scope = "issue_budget"
+		case "global", "global_capacity":
+			predicate.Scope = "global_capacity"
+		case "backend", "backend_capacity":
+			predicate.Scope = "backend_capacity"
+		default:
+			problems = append(problems, "predicate.scope must be daily_budget, issue_budget, global_capacity, or backend_capacity")
+		}
+		if predicate.Condition == "" {
+			predicate.Condition = "exhausted"
+		}
+		switch predicate.Condition {
+		case "exhausted", "full", "unavailable":
+			predicate.Condition = "exhausted"
+		case "available":
+		default:
+			problems = append(problems, "predicate.condition must be exhausted or available")
+		}
+	case PredicateConfigFingerprint:
+		if predicate.Fingerprint == "" {
+			problems = append(problems, "predicate.fingerprint is required for config_fingerprint")
+		}
+	default:
+		problems = append(problems, fmt.Sprintf("predicate.type %q must be issue_state, pull_request_state, check_presence, budget_capacity, or config_fingerprint", predicate.Type))
+	}
+	return predicate, problems
+}
+
+func normalizePredicateType(value string) string {
+	switch normalizeToken(value) {
+	case "issue_ref", "issue_ref_state":
+		return PredicateIssueState
+	case "pr_state":
+		return PredicatePullRequestState
+	case "check_present":
+		return PredicateCheckPresence
+	case "budget_condition", "capacity_condition":
+		return PredicateBudgetCapacity
+	case "config":
+		return PredicateConfigFingerprint
+	default:
+		return normalizeToken(value)
+	}
+}
+
+func parseExpiry(value string) (*time.Time, string) {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return nil, ""
+	}
+	parsed, err := time.Parse(time.RFC3339, value)
+	if err != nil {
+		return nil, "must be an RFC3339 timestamp"
+	}
+	parsed = parsed.UTC()
+	return &parsed, ""
+}
+
+func parseRecheckInterval(value string, typed bool) (string, string) {
+	value = strings.ToLower(strings.TrimSpace(value))
+	if value == "" && typed {
+		return "tick", ""
+	}
+	if value == "" || value == "tick" {
+		return value, ""
+	}
+	duration, err := time.ParseDuration(value)
+	if err != nil || duration <= 0 {
+		return "", "must be tick or a positive Go duration"
+	}
+	return duration.String(), ""
+}
+
+func normalizeToken(value string) string {
+	value = strings.ToLower(strings.TrimSpace(value))
+	value = strings.ReplaceAll(value, "-", "_")
+	return strings.Join(strings.Fields(value), "_")
+}
+
+func uniqueNonBlank(values []string) []string {
+	out := make([]string, 0, len(values))
+	seen := map[string]struct{}{}
+	for _, value := range values {
+		value = strings.TrimSpace(value)
+		if value == "" {
+			continue
+		}
+		if _, ok := seen[value]; ok {
+			continue
+		}
+		seen[value] = struct{}{}
+		out = append(out, value)
+	}
+	return out
+}
+
+func cloneBool(value *bool) *bool {
+	if value == nil {
+		return nil
+	}
+	cloned := *value
+	return &cloned
+}
+
 func ParseRef(ref string, repo string) (string, error) {
 	ref = strings.TrimSpace(ref)
 	matches := refPattern.FindStringSubmatch(ref)
@@ -240,7 +495,13 @@ func Reason(signal *Signal) string {
 		if ref == "" {
 			ref = strings.TrimSpace(blocker.Ref)
 		}
+		if ref == "" && blocker.Predicate != nil {
+			ref = blocker.Predicate.Type
+		}
 		if ref == "" {
+			if reason := strings.TrimSpace(blocker.Reason); reason != "" {
+				parts = append(parts, reason)
+			}
 			continue
 		}
 		if reason := strings.TrimSpace(blocker.Reason); reason != "" {
@@ -263,7 +524,24 @@ func CloneSignal(signal *Signal) *Signal {
 		return nil
 	}
 	cloned := *signal
-	cloned.Blockers = append([]Blocker(nil), signal.Blockers...)
+	cloned.Blockers = make([]Blocker, len(signal.Blockers))
+	for index, blocker := range signal.Blockers {
+		cloned.Blockers[index] = blocker
+		if blocker.Predicate != nil {
+			predicate := *blocker.Predicate
+			predicate.States = append([]string(nil), blocker.Predicate.States...)
+			predicate.Present = cloneBool(blocker.Predicate.Present)
+			cloned.Blockers[index].Predicate = &predicate
+		}
+		if blocker.ExpiresAt != nil {
+			expiresAt := *blocker.ExpiresAt
+			cloned.Blockers[index].ExpiresAt = &expiresAt
+		}
+	}
+	if signal.RecordedAt != nil {
+		recordedAt := *signal.RecordedAt
+		cloned.RecordedAt = &recordedAt
+	}
 	if signal.Fields != nil {
 		cloned.Fields = make(map[string]string, len(signal.Fields))
 		for name, value := range signal.Fields {

--- a/internal/workpad/workpad_test.go
+++ b/internal/workpad/workpad_test.go
@@ -4,6 +4,7 @@ import (
 	"reflect"
 	"strings"
 	"testing"
+	"time"
 )
 
 func TestSignalFromComment(t *testing.T) {
@@ -196,4 +197,131 @@ func TestParseRef(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestParseStatusBlockTypedBlockers(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name               string
+		blocker            string
+		wantType           string
+		wantOwner          string
+		wantIdentifier     string
+		wantState          string
+		wantCheck          string
+		wantScope          string
+		wantFingerprint    string
+		wantPresent        *bool
+		wantUnverifiable   bool
+		wantRecheck        string
+		wantExpiry         string
+		wantErrorSubstring string
+	}{
+		{
+			name:           "issue state",
+			blocker:        "ref: '#42'\n    reason: waiting for closure\n    owner: orchestrator\n    predicate:\n      type: issue_state\n      states: [open]\n    recheck_interval: 30s",
+			wantType:       PredicateIssueState,
+			wantOwner:      BlockerOwnerOrchestrator,
+			wantIdentifier: "digitaldrywood/detent#42",
+			wantState:      "open",
+			wantRecheck:    "30s",
+		},
+		{
+			name:        "pull request state",
+			blocker:     "owner: orchestrator\n    predicate:\n      kind: pull-request-state\n      state: open",
+			wantType:    PredicatePullRequestState,
+			wantOwner:   BlockerOwnerOrchestrator,
+			wantState:   "open",
+			wantRecheck: "tick",
+		},
+		{
+			name:        "check presence",
+			blocker:     "owner: orchestrator\n    predicate:\n      type: check_presence\n      check: Test\n      present: false",
+			wantType:    PredicateCheckPresence,
+			wantOwner:   BlockerOwnerOrchestrator,
+			wantCheck:   "Test",
+			wantPresent: boolPointer(false),
+			wantRecheck: "tick",
+		},
+		{
+			name:        "budget capacity",
+			blocker:     "owner: orchestrator\n    predicate:\n      type: budget_capacity\n      scope: daily-budget\n      condition: exhausted",
+			wantType:    PredicateBudgetCapacity,
+			wantOwner:   BlockerOwnerOrchestrator,
+			wantScope:   "daily_budget",
+			wantRecheck: "tick",
+		},
+		{
+			name:            "config fingerprint",
+			blocker:         "owner: orchestrator\n    predicate:\n      type: config_fingerprint\n      fingerprint: config-a\n    expires_at: '2026-08-17T12:00:00Z'",
+			wantType:        PredicateConfigFingerprint,
+			wantOwner:       BlockerOwnerOrchestrator,
+			wantFingerprint: "config-a",
+			wantRecheck:     "tick",
+			wantExpiry:      "2026-08-17T12:00:00Z",
+		},
+		{
+			name:             "free text accepted and flagged",
+			blocker:          "reason: waiting for somebody to investigate",
+			wantOwner:        BlockerOwnerHuman,
+			wantUnverifiable: true,
+		},
+		{
+			name:               "typed predicate validation",
+			blocker:            "owner: orchestrator\n    predicate:\n      type: check_presence\n      check: Test",
+			wantErrorSubstring: "predicate.present is required",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			content := "schema: 1\nstatus: blocked\nblockers:\n  - " + tt.blocker + "\nhuman_action: null"
+			signal, err := ParseStatusBlock(content, "digitaldrywood/detent")
+			if tt.wantErrorSubstring != "" {
+				if err == nil || !strings.Contains(err.Error(), tt.wantErrorSubstring) {
+					t.Fatalf("ParseStatusBlock() error = %v, want containing %q", err, tt.wantErrorSubstring)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("ParseStatusBlock() error = %v", err)
+			}
+			if len(signal.Blockers) != 1 {
+				t.Fatalf("Blockers = %#v, want one", signal.Blockers)
+			}
+			blocker := signal.Blockers[0]
+			if blocker.Owner != tt.wantOwner || blocker.Unverifiable != tt.wantUnverifiable || blocker.RecheckInterval != tt.wantRecheck {
+				t.Fatalf("blocker metadata = %#v", blocker)
+			}
+			if tt.wantExpiry != "" && (blocker.ExpiresAt == nil || blocker.ExpiresAt.Format(time.RFC3339) != tt.wantExpiry) {
+				t.Fatalf("ExpiresAt = %v, want %s", blocker.ExpiresAt, tt.wantExpiry)
+			}
+			if tt.wantType == "" {
+				if blocker.Predicate != nil {
+					t.Fatalf("Predicate = %#v, want nil", blocker.Predicate)
+				}
+				return
+			}
+			predicate := blocker.Predicate
+			if predicate == nil {
+				t.Fatal("Predicate = nil")
+			}
+			if predicate.Type != tt.wantType || predicate.Identifier != tt.wantIdentifier || predicate.Check != tt.wantCheck || predicate.Scope != tt.wantScope || predicate.Fingerprint != tt.wantFingerprint {
+				t.Fatalf("Predicate = %#v", predicate)
+			}
+			if tt.wantState != "" && (len(predicate.States) != 1 || predicate.States[0] != tt.wantState) {
+				t.Fatalf("States = %#v, want %q", predicate.States, tt.wantState)
+			}
+			if tt.wantPresent != nil && (predicate.Present == nil || *predicate.Present != *tt.wantPresent) {
+				t.Fatalf("Present = %v, want %t", predicate.Present, *tt.wantPresent)
+			}
+		})
+	}
+}
+
+func boolPointer(value bool) *bool {
+	return &value
 }


### PR DESCRIPTION
## Summary

- parse backward-compatible typed Workpad blockers with live predicates, ownership, expiry, and re-check metadata
- re-evaluate issue, pull request, check, budget/capacity, and config predicates on every blocked-lane tick, clearing resolved parks and escalating unverifiable evidence
- expose blocker evidence through telemetry, APIs, dashboard details, worker guidance, and dependency documentation
- retain the complete current pull-request check inventory so check-presence predicates remain machine-verifiable

Fixes #1837

## UI Surface Contract

- [x] The linked issue explicitly authorizes surfacing unverifiable blocker owner and age on the operator dashboard.
- [x] This PR does not add persistent top-of-screen messaging.
- [x] Verified the primary board in an isolated `dev-runtime --demo screenshots --port 0` session with Chrome DevTools at 1920×1080; the board rendered correctly with no runtime console errors. Chrome reported one existing form-field accessibility issue unrelated to this change.

## Test Plan

- [x] `go test ./internal/orchestrator ./internal/workpad ./internal/connector/... ./internal/runner ./internal/web/...`
- [x] `PATH="$TMPDIR/detent-1837-tools:$PATH" make check` using repository-pinned golangci-lint v2.1.6
- [x] race suite and configured coverage floors (79.0% aggregate)
- [x] isolated Chrome DevTools board smoke test