### PR TITLE
fix(admission): bound ProjectV2 candidates

### DIFF
--- a/internal/admission/manager.go
+++ b/internal/admission/manager.go
@@ -95,6 +95,7 @@ type Result struct {
 	ProjectID       string
 	CandidatesFound int
 	Candidates      int
+	ItemsRead       int
 	Proposals       []admissionmodel.Proposal
 	Skipped         map[string]int
 	Truncated       map[string]int
@@ -366,10 +367,11 @@ func (m *Manager) runOnce(ctx context.Context, settings Settings, scheduledFor t
 		runErr = errors.Join(runErr, release())
 	}()
 
-	candidates, readerTruncations, readerFiltered, err := readAdmissionCandidates(ctx, settings.Issues, settings.Config)
+	candidates, readerTruncations, itemsRead, readerFiltered, err := readAdmissionCandidates(ctx, settings.Issues, settings.Config)
 	if err != nil {
 		return result, fmt.Errorf("fetch backlog admission candidates: %w", err)
 	}
+	result.ItemsRead = itemsRead
 	if readerTruncations > 0 {
 		result.Truncated["candidate_reader"] += readerTruncations
 	}
@@ -464,7 +466,7 @@ func readAdmissionCandidates(
 	ctx context.Context,
 	issues IssueStore,
 	cfg config.BacklogAdmission,
-) ([]connector.Issue, int, map[string]int, error) {
+) ([]connector.Issue, int, int, map[string]int, error) {
 	requests := make([]connector.CandidateRequest, 0, 3)
 	if len(cfg.Sources.States) > 0 {
 		requests = append(requests, connector.CandidateRequest{
@@ -488,6 +490,7 @@ func readAdmissionCandidates(
 	candidates := []connector.Issue{}
 	seen := map[string]struct{}{}
 	truncations := 0
+	itemsRead := 0
 	filtered := map[string]int{}
 	for _, request := range requests {
 		request.Limit = limit
@@ -499,8 +502,9 @@ func readAdmissionCandidates(
 		}
 		result, err := issues.ReadCandidates(ctx, request)
 		if err != nil {
-			return nil, 0, nil, fmt.Errorf("read %s selector: %w", request.Selector, err)
+			return nil, 0, 0, nil, fmt.Errorf("read %s selector: %w", request.Selector, err)
 		}
+		itemsRead += result.ItemsRead
 		if result.Truncated {
 			truncations++
 		}
@@ -516,7 +520,7 @@ func readAdmissionCandidates(
 			candidates = append(candidates, issue)
 		}
 	}
-	return candidates, truncations, filtered, nil
+	return candidates, truncations, itemsRead, filtered, nil
 }
 
 func (m *Manager) reconcileOpenProposals(
@@ -1838,9 +1842,17 @@ func (m *Manager) runAndLog(ctx context.Context, scheduledFor time.Time) {
 		}
 		return
 	}
+	m.logScheduledCompletion(ctx, result)
+}
+
+func (m *Manager) logScheduledCompletion(ctx context.Context, result Result) {
 	telemetry.LogLifecycleMessageContext(ctx, m.logger, slog.LevelInfo, telemetry.LifecycleAdmission, "scheduled_backlog_admission_completed", "scheduled backlog admission completed", telemetry.LifecycleCorrelation{ProjectID: result.ProjectID},
+		"items_read", result.ItemsRead,
+		"candidates_found", result.CandidatesFound,
 		"candidates", result.Candidates,
 		"proposals", len(result.Proposals),
+		"truncated", len(result.Truncated) > 0,
+		"truncations", result.Truncated,
 		"deferred_reason", result.DeferredReason,
 	)
 }

--- a/internal/admission/manager_test.go
+++ b/internal/admission/manager_test.go
@@ -1,9 +1,11 @@
 package admission
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
+	"log/slog"
 	"path/filepath"
 	"reflect"
 	"strconv"
@@ -191,7 +193,9 @@ func TestManagerRecordsCandidateReaderTruncation(t *testing.T) {
 	if err != nil {
 		t.Fatalf("RunOnce() error = %v", err)
 	}
-	if result.Truncated["candidate_reader"] != 1 || result.CandidatesFound != connector.DefaultCandidatePageSize {
+	if result.Truncated["candidate_reader"] != 1 ||
+		result.CandidatesFound != connector.DefaultCandidatePageSize ||
+		result.ItemsRead != len(issues) {
 		t.Fatalf("result = %#v, want reader truncation at %d candidates", result, connector.DefaultCandidatePageSize)
 	}
 	if agent.calls != 0 {
@@ -203,6 +207,64 @@ func TestManagerRecordsCandidateReaderTruncation(t *testing.T) {
 	}
 	if record.Truncated["candidate_reader"] != 1 {
 		t.Fatalf("run ledger truncation = %#v, want candidate_reader=1", record.Truncated)
+	}
+}
+
+func TestManagerLogsScheduledAdmissionScan(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name           string
+		result         Result
+		wantTruncated  bool
+		wantTruncation int
+	}{
+		{
+			name: "exhausted scan",
+			result: Result{
+				ProjectID: "pyroapex",
+				ItemsRead: 425,
+				Truncated: map[string]int{},
+			},
+		},
+		{
+			name: "bounded scan",
+			result: Result{
+				ProjectID: "pyroapex",
+				ItemsRead: 100,
+				Truncated: map[string]int{"candidate_reader": 1},
+			},
+			wantTruncated:  true,
+			wantTruncation: 1,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			var output bytes.Buffer
+			manager := &Manager{logger: slog.New(slog.NewJSONHandler(&output, nil))}
+			manager.logScheduledCompletion(t.Context(), test.result)
+
+			var record struct {
+				Event           string         `json:"event"`
+				ItemsRead       int            `json:"items_read"`
+				CandidatesFound int            `json:"candidates_found"`
+				Truncated       bool           `json:"truncated"`
+				Truncations     map[string]int `json:"truncations"`
+			}
+			if err := json.Unmarshal(output.Bytes(), &record); err != nil {
+				t.Fatalf("decode log record: %v", err)
+			}
+			if record.Event != "scheduled_backlog_admission_completed" ||
+				record.ItemsRead != test.result.ItemsRead ||
+				record.CandidatesFound != test.result.CandidatesFound ||
+				record.Truncated != test.wantTruncated ||
+				record.Truncations["candidate_reader"] != test.wantTruncation {
+				t.Fatalf("log record = %#v", record)
+			}
+		})
 	}
 }
 
@@ -2382,7 +2444,7 @@ func TestReadAdmissionCandidatesPushesAuthorsOnlyToStates(t *testing.T) {
 	cfg.Sources.Labels = []string{"sentry"}
 	cfg.Authors.Allow = []string{"octocat"}
 
-	_, _, _, err := readAdmissionCandidates(context.Background(), tracker, cfg)
+	_, _, _, _, err := readAdmissionCandidates(context.Background(), tracker, cfg)
 	if err != nil {
 		t.Fatalf("readAdmissionCandidates() error = %v", err)
 	}

--- a/internal/connector/candidate.go
+++ b/internal/connector/candidate.go
@@ -138,6 +138,7 @@ func (r CandidateRequest) ProbeLimit() int {
 type CandidateResult struct {
 	Issues    []Issue        `json:"issues" yaml:"issues"`
 	PagesRead int            `json:"pages_read" yaml:"pages_read"`
+	ItemsRead int            `json:"items_read" yaml:"items_read"`
 	Truncated bool           `json:"truncated" yaml:"truncated"`
 	Filtered  map[string]int `json:"filtered,omitempty" yaml:"filtered,omitempty"`
 }
@@ -149,6 +150,7 @@ type CandidateReader interface {
 
 func NewCandidateResult(issues []Issue, request CandidateRequest, pagesRead int, incomplete bool) CandidateResult {
 	issues = append([]Issue(nil), issues...)
+	itemsRead := len(issues)
 	SortCandidateIssues(issues)
 	truncated := incomplete || len(issues) > request.Limit
 	if len(issues) > request.Limit {
@@ -157,6 +159,7 @@ func NewCandidateResult(issues []Issue, request CandidateRequest, pagesRead int,
 	return CandidateResult{
 		Issues:    issues,
 		PagesRead: pagesRead,
+		ItemsRead: itemsRead,
 		Truncated: truncated,
 		Filtered:  map[string]int{},
 	}

--- a/internal/connector/candidate_test.go
+++ b/internal/connector/candidate_test.go
@@ -209,8 +209,8 @@ func TestNewCandidateResultSortsBeforeApplyingLimit(t *testing.T) {
 	if !reflect.DeepEqual(ids, []string{"1", "2"}) {
 		t.Fatalf("candidate IDs = %#v, want [1 2]", ids)
 	}
-	if !got.Truncated || got.PagesRead != 2 {
-		t.Fatalf("result = %#v, want two pages and truncation", got)
+	if !got.Truncated || got.PagesRead != 2 || got.ItemsRead != 3 {
+		t.Fatalf("result = %#v, want three read items, two pages, and truncation", got)
 	}
 	if issues[0].ID != "3" {
 		t.Fatalf("NewCandidateResult mutated input = %#v", issues)

--- a/internal/connector/github/candidate.go
+++ b/internal/connector/github/candidate.go
@@ -24,6 +24,7 @@ func (c *Connector) ReadCandidates(ctx context.Context, request connector.Candid
 	var (
 		issues         []connector.Issue
 		pagesRead      int
+		itemsRead      int
 		incomplete     bool
 		authorRejected int
 		err            error
@@ -46,7 +47,7 @@ func (c *Connector) ReadCandidates(ctx context.Context, request connector.Candid
 		case c.usesIssueFieldStatus():
 			issues, pagesRead, incomplete, authorRejected, err = c.readIssueFieldCandidates(ctx, request)
 		default:
-			issues, pagesRead, incomplete, err = c.readProjectCandidates(ctx, request)
+			issues, pagesRead, itemsRead, incomplete, err = c.readProjectCandidates(ctx, request)
 		}
 	}
 	if err != nil {
@@ -54,6 +55,9 @@ func (c *Connector) ReadCandidates(ctx context.Context, request connector.Candid
 	}
 
 	result := connector.NewCandidateResult(issues, request, pagesRead, incomplete)
+	if itemsRead > 0 {
+		result.ItemsRead = itemsRead
+	}
 	if authorRejected > 0 {
 		result.Filtered["author"] = authorRejected
 	}
@@ -355,13 +359,13 @@ func (c *Connector) issueFieldAuthorRejections(
 func (c *Connector) readProjectCandidates(
 	ctx context.Context,
 	request connector.CandidateRequest,
-) ([]connector.Issue, int, bool, error) {
+) ([]connector.Issue, int, int, bool, error) {
 	if c.projectID == "" {
-		return nil, 0, false, ErrMissingProject
+		return nil, 0, 0, false, ErrMissingProject
 	}
 	wantedStates := normalizedStateSet(request.States)
 	if len(wantedStates) == 0 {
-		return []connector.Issue{}, 0, false, nil
+		return []connector.Issue{}, 0, 0, false, nil
 	}
 
 	scanLimit := request.ProbeLimit()
@@ -373,37 +377,30 @@ func (c *Connector) readProjectCandidates(
 	totalItems := 0
 	pagesRead := 0
 	for {
-		if itemsRead >= scanLimit {
-			c.defaultBlankProjectItemStatuses(ctx, blankStatusItemIDs)
-			return issues, pagesRead, true, nil
-		}
 		var response struct {
 			Node *struct {
 				Items projectItemsConnection `json:"items"`
 			} `json:"node"`
 		}
-		pageSize := min(request.EffectivePageSize(), projectItemsPageSize, scanLimit-itemsRead)
+		pageSize := min(request.EffectivePageSize(), projectItemsPageSize)
 		if err := c.client.GraphQLWithType(ctx, graphQLQueryCandidateIssues, observedStatusProjectItemsQuery, map[string]any{
 			"projectId": c.projectID,
 			"first":     pageSize,
 			"after":     after,
 		}, &response); err != nil {
-			return nil, 0, false, fmt.Errorf("fetch github project candidates: %w", err)
+			return nil, 0, 0, false, fmt.Errorf("fetch github project candidates: %w", err)
 		}
 		pagesRead++
 		if response.Node == nil {
-			return nil, 0, false, ErrProjectNotFound
+			return nil, 0, 0, false, ErrProjectNotFound
 		}
 		pageItems := response.Node.Items.Nodes
-		if remaining := scanLimit - itemsRead; len(pageItems) > remaining {
-			pageItems = pageItems[:remaining]
-		}
 		itemsRead += len(pageItems)
 		totalItems = max(totalItems, response.Node.Items.TotalCount)
 		for _, item := range pageItems {
 			issue, ok, blankStatusItemID, err := c.normalizeProjectItem(item)
 			if err != nil {
-				return nil, 0, false, err
+				return nil, 0, 0, false, err
 			}
 			if !ok {
 				continue
@@ -411,26 +408,26 @@ func (c *Connector) readProjectCandidates(
 			if blankStatusItemID != "" && repairBlankStatuses {
 				blankStatusItemIDs = append(blankStatusItemIDs, blankStatusItemID)
 			}
-			if _, ok := wantedStates[normalizeStateName(issue.State)]; ok {
+			if _, ok := wantedStates[normalizeStateName(issue.State)]; ok && len(issues) < scanLimit {
 				issues = append(issues, issue)
 			}
 		}
-		if len(pageItems) < len(response.Node.Items.Nodes) {
+		if len(issues) >= scanLimit {
 			c.defaultBlankProjectItemStatuses(ctx, blankStatusItemIDs)
-			return issues, pagesRead, true, nil
+			return issues, pagesRead, itemsRead, true, nil
 		}
 
 		if !response.Node.Items.PageInfo.HasNextPage {
 			c.defaultBlankProjectItemStatuses(ctx, blankStatusItemIDs)
-			return issues, pagesRead, totalItems > itemsRead, nil
+			return issues, pagesRead, itemsRead, totalItems > itemsRead, nil
 		}
-		if itemsRead >= scanLimit || pagesRead >= scanLimit {
+		if pagesRead >= projectCandidatePageLimit {
 			c.defaultBlankProjectItemStatuses(ctx, blankStatusItemIDs)
-			return issues, pagesRead, true, nil
+			return issues, pagesRead, itemsRead, true, nil
 		}
 		cursor := strings.TrimSpace(response.Node.Items.PageInfo.EndCursor)
 		if cursor == "" {
-			return nil, 0, false, ErrInvalidResponse
+			return nil, 0, 0, false, ErrInvalidResponse
 		}
 		after = &cursor
 	}

--- a/internal/connector/github/candidate_test.go
+++ b/internal/connector/github/candidate_test.go
@@ -67,13 +67,99 @@ func TestConnectorReadProjectCandidatesStopsAtBoundAndSorts(t *testing.T) {
 	}
 }
 
+func TestConnectorReadProjectCandidatesBoundsMatchingCandidates(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name          string
+		responses     []graphqlTestResponse
+		wantIDs       []string
+		wantItemsRead int
+		wantPagesRead int
+		wantTruncated bool
+	}{
+		{
+			name: "eligible candidate follows terminal prefix",
+			responses: []graphqlTestResponse{
+				{
+					body: projectItemsPageResponseWithTotal(3, true, "cursor-1", []string{
+						`{"id":"PVTI_1","content":{"__typename":"Issue","id":"I_1","number":1,"title":"Done first","state":"CLOSED","url":"https://github.com/digitaldrywood/detent/issues/1","repository":{"nameWithOwner":"digitaldrywood/detent"}},"statusValue":{"name":"Done"}}`,
+						`{"id":"PVTI_2","content":{"__typename":"Issue","id":"I_2","number":2,"title":"Done second","state":"CLOSED","url":"https://github.com/digitaldrywood/detent/issues/2","repository":{"nameWithOwner":"digitaldrywood/detent"}},"statusValue":{"name":"Done"}}`,
+					}),
+				},
+				{
+					body: projectItemsPageResponseWithTotal(3, false, "", []string{
+						`{"id":"PVTI_3","content":{"__typename":"Issue","id":"I_3","number":3,"title":"Backlog","state":"OPEN","url":"https://github.com/digitaldrywood/detent/issues/3","repository":{"nameWithOwner":"digitaldrywood/detent"}},"statusValue":{"name":"Backlog"}}`,
+					}),
+				},
+			},
+			wantIDs:       []string{"I_3"},
+			wantItemsRead: 3,
+			wantPagesRead: 2,
+		},
+		{
+			name: "probe limit counts only eligible candidates",
+			responses: []graphqlTestResponse{
+				{
+					body: projectItemsPageResponseWithTotal(4, true, "cursor-1", []string{
+						`{"id":"PVTI_1","content":{"__typename":"Issue","id":"I_1","number":1,"title":"Done","state":"CLOSED","url":"https://github.com/digitaldrywood/detent/issues/1","repository":{"nameWithOwner":"digitaldrywood/detent"}},"statusValue":{"name":"Done"}}`,
+						`{"id":"PVTI_2","content":{"__typename":"Issue","id":"I_2","number":2,"title":"First backlog","state":"OPEN","url":"https://github.com/digitaldrywood/detent/issues/2","repository":{"nameWithOwner":"digitaldrywood/detent"}},"statusValue":{"name":"Backlog"}}`,
+					}),
+				},
+				{
+					body: projectItemsPageResponseWithTotal(4, true, "cursor-2", []string{
+						`{"id":"PVTI_3","content":{"__typename":"Issue","id":"I_3","number":3,"title":"Second backlog","state":"OPEN","url":"https://github.com/digitaldrywood/detent/issues/3","repository":{"nameWithOwner":"digitaldrywood/detent"}},"statusValue":{"name":"Backlog"}}`,
+						`{"id":"PVTI_4","content":{"__typename":"Issue","id":"I_4","number":4,"title":"Third backlog","state":"OPEN","url":"https://github.com/digitaldrywood/detent/issues/4","repository":{"nameWithOwner":"digitaldrywood/detent"}},"statusValue":{"name":"Backlog"}}`,
+					}),
+				},
+			},
+			wantIDs:       []string{"I_2"},
+			wantItemsRead: 4,
+			wantPagesRead: 2,
+			wantTruncated: true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			server := newGraphQLTestServer(t, test.responses)
+			c := newGitHubTestConnector(t, server, Config{
+				ProjectSlug:    "PVT_1",
+				ObservedStates: []string{"Backlog"},
+				TerminalStates: []string{"Done"},
+			})
+
+			got, err := c.ReadCandidates(context.Background(), connector.CandidateRequest{
+				Selector: connector.CandidateSelectorStates,
+				States:   []string{"Backlog"},
+				Limit:    1,
+				PageSize: 2,
+			})
+			if err != nil {
+				t.Fatalf("ReadCandidates() error = %v", err)
+			}
+			if ids := githubIssueIDs(got.Issues); !reflect.DeepEqual(ids, test.wantIDs) {
+				t.Fatalf("candidate IDs = %#v, want %#v", ids, test.wantIDs)
+			}
+			if got.ItemsRead != test.wantItemsRead || got.PagesRead != test.wantPagesRead || got.Truncated != test.wantTruncated {
+				t.Fatalf("result = %#v, want items_read=%d pages_read=%d truncated=%t", got, test.wantItemsRead, test.wantPagesRead, test.wantTruncated)
+			}
+		})
+	}
+}
+
 func TestConnectorReadProjectCandidatesBoundsEmptyCursorPages(t *testing.T) {
 	t.Parallel()
 
-	server := newGraphQLTestServer(t, []graphqlTestResponse{
-		{body: projectItemsPageResponseWithTotal(3, true, "cursor-1", nil)},
-		{body: projectItemsPageResponseWithTotal(3, true, "cursor-2", nil)},
-	})
+	responses := make([]graphqlTestResponse, projectCandidatePageLimit)
+	for index := range responses {
+		responses[index] = graphqlTestResponse{
+			body: projectItemsPageResponseWithTotal(3, true, "cursor-"+strconv.Itoa(index+1), nil),
+		}
+	}
+	server := newGraphQLTestServer(t, responses)
 	c := newGitHubTestConnector(t, server, Config{ProjectSlug: "PVT_1"})
 
 	got, err := c.ReadCandidates(context.Background(), connector.CandidateRequest{
@@ -85,8 +171,8 @@ func TestConnectorReadProjectCandidatesBoundsEmptyCursorPages(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ReadCandidates() error = %v", err)
 	}
-	if len(got.Issues) != 0 || !got.Truncated || got.PagesRead != 2 {
-		t.Fatalf("result = %#v, want empty bounded truncation after two pages", got)
+	if len(got.Issues) != 0 || !got.Truncated || got.PagesRead != projectCandidatePageLimit {
+		t.Fatalf("result = %#v, want empty truncation at the independent page bound", got)
 	}
 }
 

--- a/internal/connector/github/types.go
+++ b/internal/connector/github/types.go
@@ -9,6 +9,7 @@ import (
 
 const (
 	projectItemsPageSize                      = 50
+	projectCandidatePageLimit                 = 100
 	projectItemsPerIssue                      = 100
 	projectItemFieldValuesPageSize            = 100
 	linkedIssuePageSize                       = 20

--- a/internal/connector/githublocal/githublocal.go
+++ b/internal/connector/githublocal/githublocal.go
@@ -309,7 +309,9 @@ func (c *Connector) ReadCandidates(ctx context.Context, request connector.Candid
 	if err != nil {
 		return connector.CandidateResult{}, err
 	}
-	return connector.NewCandidateResult(issues, request, result.PagesRead, result.Truncated), nil
+	hydrated := connector.NewCandidateResult(issues, request, result.PagesRead, result.Truncated)
+	hydrated.ItemsRead = result.ItemsRead
+	return hydrated, nil
 }
 
 func (c *Connector) FetchCandidateIssues(ctx context.Context) ([]connector.Issue, error) {


### PR DESCRIPTION
## Summary

- Continue ProjectV2 paging past non-candidate board items until the candidate probe is satisfied, the board is exhausted, or the independent page safety bound is reached.
- Propagate raw item scan counts and log completion truncation details so an exhausted scan is distinguishable from a bounded scan.
- Add regressions for terminal board prefixes, candidate-bound truncation, item counts, and scheduled completion telemetry.

Fixes #1845

## UI Surface Contract

- [x] N/A; this PR does not change UI surfaces.
- [x] This PR does not add persistent top-of-screen messaging.
- [x] N/A; this PR has no visual changes.

## Test Plan

- [x] `go test ./internal/connector/... ./internal/admission -count=1`
- [x] `PATH="$TMPDIR/go-bin:$PATH" make check` (repository-pinned golangci-lint v2.1.6)