### PR TITLE
fix(orchestrator): fence revoked workers

### DIFF
--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -79,11 +79,35 @@ The recommended GitHub Project board states are:
 
 Manual `Cancelled` means Detent should stop managing the work item, not that
 GitHub issues or pull requests are automatically closed. On the next poll that
-observes the cancelled terminal state, Detent cancels any running agent context,
-releases the global dispatch slot, clears configured claim lease state, records
-the run as completed with final state `Cancelled`, and asks the workspace
-backend to remove the Detent worktree, prune git worktrees, delete the generated
-`detent/` branch when safe, and reap workspace processes.
+observes the cancelled terminal state, Detent revokes the running worker lease,
+cancels its context, and terminates its persisted process group. The same
+revocation occurs when an item moves from any configured active state to any
+non-active state, including `Blocked` and review lanes. Detent first sends the
+graceful termination signal, waits 250 milliseconds by default, escalates to a
+forced kill, and waits another 250 milliseconds to verify exit. Process
+identity includes the recorded start time so a stale PID or process group is
+never signaled.
+
+Regular tracker polling observes a lane change within
+`max(polling.interval_ms, 2 minutes)`; a targeted refresh begins revocation as
+soon as that refresh is applied. These observation bounds are followed by the
+two bounded process-stop waits above. Stop request, result, escalation, and
+failure events are exposed in `/api/v1/state` telemetry.
+
+Worker completion is fenced by both the dispatch generation and durable work
+attempt ID. Detent also reads the current tracker lane before publishing normal
+completion state or artifact-gate fields. A stale generation, a revoked lease,
+or a non-active lane rejects the completion without changing the tracker. If
+the final tracker read fails, Detent fails closed and stops the worker. Moving
+the item back to an active state creates a fresh generation; output from the
+prior generation remains invalid.
+
+After the worker has exited, Detent releases the global dispatch slot, clears
+configured claim lease state, and records the work attempt as `lane_revoked`.
+For a terminal destination, it records the run as completed with that terminal
+state and asks the workspace backend to remove the Detent worktree, prune git
+worktrees, delete the generated `detent/` branch when safe, and reap workspace
+processes.
 
 Terminal cleanup is attempted on each poll for terminal states so a cancelled
 non-running issue can still clean up an existing Detent workspace without

--- a/internal/orchestrator/dispatch.go
+++ b/internal/orchestrator/dispatch.go
@@ -612,10 +612,12 @@ func (o *Orchestrator) dispatchIssueWithAdmission(
 			dispatchProgress = o.implementProgressDispatchArtifactSnapshot(runCtx, issue)
 		}
 	}
+	generation := o.workerGeneration.Add(1)
 	state.Running[issue.ID] = Running{
 		Issue:               issue,
 		Attempt:             attempt,
 		WorkAttemptID:       workAttemptID,
+		Generation:          generation,
 		Mode:                runMode,
 		DispatchSourceState: dispatchStartSourceState,
 		DispatchTargetState: dispatchStartTargetState,
@@ -646,6 +648,7 @@ func (o *Orchestrator) dispatchIssueWithAdmission(
 		Issue:               issue,
 		Attempt:             attempt,
 		WorkAttemptID:       workAttemptID,
+		Generation:          generation,
 		Mode:                runMode,
 		DispatchSourceState: dispatchSourceState,
 		DispatchTargetState: dispatchTargetState,

--- a/internal/orchestrator/dispatch_test.go
+++ b/internal/orchestrator/dispatch_test.go
@@ -2873,6 +2873,7 @@ func TestDispatchReadyIssuesLogsDebugDecisionAndWorkerLifecycle(t *testing.T) {
 	selected := dispatchTestIssue("issue-selected", "Todo")
 	selected.Fields = map[string]string{"Status": "Todo"}
 	selected.UpdatedAt = timePointer(now.Add(-2 * time.Minute))
+	orch.connector = hydratingDispatchConnector{issue: selected}
 
 	ctx := t.Context()
 	orch.dispatchReadyIssues(ctx, &state, []connector.Issue{running, selected}, now)

--- a/internal/orchestrator/lane_revocation.go
+++ b/internal/orchestrator/lane_revocation.go
@@ -1,0 +1,393 @@
+package orchestrator
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/digitaldrywood/detent/internal/connector"
+	"github.com/digitaldrywood/detent/internal/procgroup"
+	runpkg "github.com/digitaldrywood/detent/internal/runner"
+	"github.com/digitaldrywood/detent/internal/scheduler"
+	"github.com/digitaldrywood/detent/internal/store"
+	"github.com/digitaldrywood/detent/internal/telemetry"
+)
+
+const (
+	laneRevocationStateChanged               = "tracker_lane_changed"
+	laneRevocationCompletionFenceUnavailable = "completion_fence_unavailable"
+)
+
+type pendingLaneRevocation struct {
+	issue         connector.Issue
+	fromState     string
+	toState       string
+	reason        string
+	requestedAt   time.Time
+	generation    uint64
+	running       Running
+	completion    *runpkg.Completion
+	workerProcess procgroup.Identity
+	reapOutcome   procgroup.TerminationOutcome
+	reapDone      bool
+	reapErr       error
+}
+
+func (o *Orchestrator) beginLaneRevocation(
+	ctx context.Context,
+	state *State,
+	running Running,
+	refreshed connector.Issue,
+	now time.Time,
+	reason string,
+) {
+	issueID := strings.TrimSpace(running.Issue.ID)
+	if state == nil || issueID == "" {
+		return
+	}
+	if pending, ok := o.pendingLaneRevocations[issueID]; ok {
+		if !pending.reapDone {
+			o.reapPendingLaneRevocation(ctx, state, pending)
+		}
+		if pending.completion != nil && pending.reapDone {
+			o.finishLaneRevocation(ctx, state, pending)
+		}
+		return
+	}
+	if o.pendingLaneRevocations == nil {
+		o.pendingLaneRevocations = map[string]*pendingLaneRevocation{}
+	}
+	if now.IsZero() {
+		now = o.clockNow().UTC()
+	}
+	fromState := strings.TrimSpace(running.Issue.State)
+	running.Issue = mergeIssueTrackerFields(running.Issue, refreshed)
+	pending := &pendingLaneRevocation{
+		issue:       cloneIssue(running.Issue),
+		fromState:   fromState,
+		toState:     strings.TrimSpace(running.Issue.State),
+		reason:      strings.TrimSpace(reason),
+		requestedAt: now.UTC(),
+		generation:  running.Generation,
+		running:     running,
+	}
+	o.pendingLaneRevocations[issueID] = pending
+	state.Running[issueID] = running
+	delete(state.Retry, issueID)
+	delete(state.BudgetRefusals, issueID)
+	if running.stop != nil {
+		running.stop(runpkg.ErrLaneRevoked)
+	} else if running.cancel != nil {
+		running.cancel()
+	}
+	if o.logger != nil {
+		o.logger.Info(
+			"worker lane stop requested",
+			"project_id", strings.TrimSpace(o.cfg.Project.ID),
+			"issue_id", issueID,
+			"identifier", running.Issue.Identifier,
+			"generation", running.Generation,
+			"work_attempt_id", running.WorkAttemptID,
+			"from_state", fromState,
+			"to_state", running.Issue.State,
+			"reason", pending.reason,
+			"grace", o.workerReapGrace,
+		)
+	}
+	recordStateEvent(state, telemetry.ActivityEvent{
+		At:      pending.requestedAt,
+		Event:   "worker_lane_stop_requested",
+		Message: "stopping worker for " + issueLabel(running.Issue) + " after lane changed from " + fromState + " to " + running.Issue.State,
+	})
+	o.reapPendingLaneRevocation(ctx, state, pending)
+}
+
+func (o *Orchestrator) reapPendingLaneRevocation(ctx context.Context, state *State, pending *pendingLaneRevocation) {
+	if pending == nil || pending.reapDone {
+		return
+	}
+	outcome, identity, err := o.reapRunningWorker(ctx, pending.running, pending.workerProcess)
+	if identity.PID > 0 {
+		pending.workerProcess = identity
+	}
+	pending.reapOutcome = outcome
+	pending.reapDone = err == nil
+	pending.reapErr = err
+	at := o.clockNow().UTC()
+	if outcome == procgroup.TerminationOutcomeKilled {
+		recordStateEvent(state, telemetry.ActivityEvent{
+			At:      at,
+			Event:   "worker_lane_stop_escalated",
+			Message: "worker for " + issueLabel(pending.issue) + " exceeded the graceful stop bound and was killed",
+		})
+	}
+	if o.logger != nil {
+		attrs := []any{
+			"project_id", strings.TrimSpace(o.cfg.Project.ID),
+			"issue_id", pending.issue.ID,
+			"identifier", pending.issue.Identifier,
+			"generation", pending.generation,
+			"work_attempt_id", pending.running.WorkAttemptID,
+			"decision", string(outcome),
+			"pid", identity.PID,
+			"pgid", identity.GroupID,
+			"grace", o.workerReapGrace,
+		}
+		if err != nil {
+			attrs = append(attrs, "error", err)
+		}
+		o.logger.Info("worker lane stop result", attrs...)
+	}
+	event := "worker_lane_stop_result"
+	message := "worker stop for " + issueLabel(pending.issue) + " finished with " + string(outcome)
+	if err != nil {
+		event = "worker_lane_stop_failed"
+		message = "worker stop for " + issueLabel(pending.issue) + " failed: " + err.Error()
+	}
+	recordStateEvent(state, telemetry.ActivityEvent{At: at, Event: event, Message: message})
+}
+
+func (o *Orchestrator) handleLaneRevocationCompletion(
+	ctx context.Context,
+	state *State,
+	event runpkg.Completion,
+	running Running,
+) bool {
+	pending, ok := o.pendingLaneRevocations[event.IssueID]
+	if !ok {
+		return false
+	}
+	pending.running = running
+	pending.running.Issue = cloneIssue(pending.issue)
+	pending.completion = &event
+	if !pending.reapDone {
+		o.reapPendingLaneRevocation(ctx, state, pending)
+	}
+	if pending.reapDone {
+		o.finishLaneRevocation(ctx, state, pending)
+	}
+	return true
+}
+
+func (o *Orchestrator) finishLaneRevocation(ctx context.Context, state *State, pending *pendingLaneRevocation) {
+	if pending == nil || pending.completion == nil || !pending.reapDone {
+		return
+	}
+	event := *pending.completion
+	running := pending.running
+	running.Issue = cloneIssue(pending.issue)
+	completedAt := event.CompletedAt.UTC()
+	if completedAt.IsZero() {
+		completedAt = o.clockNow().UTC()
+	}
+	o.heartbeats.remove(event.IssueID)
+	o.releaseGlobalDispatchSlot(running.globalSlot)
+	running.globalSlot = scheduler.Slot{}
+	if !event.Result.RuntimeIdentity.IsZero() {
+		running.RuntimeIdentity = running.RuntimeIdentity.Merge(event.Result.RuntimeIdentity)
+	}
+	if diffStatsPresent(event.Result.DiffStats) {
+		running.DiffStats = event.Result.DiffStats
+		state.DiffStats[event.IssueID] = event.Result.DiffStats
+	}
+	tokens := event.Result.Tokens
+	if tokens == (TokenTotals{}) {
+		tokens = running.Tokens
+	}
+	state.TokenTotals = addTokenTotals(state.TokenTotals, tokens)
+	state.RateLimits = mergeRateLimits(state.RateLimits, event.Result.RateLimits)
+	o.recordProjectAttemptOutcome(
+		state,
+		event.IssueID,
+		completedAt,
+		store.WorkAttemptTerminalLaneRevoked,
+		runpkg.ErrLaneRevoked,
+		string(store.WorkAttemptTerminalLaneRevoked),
+		pending.reason,
+	)
+	o.completeDurableWorkAttemptWithMetadata(
+		ctx,
+		state,
+		running,
+		completedAt,
+		store.WorkAttemptTerminalLaneRevoked,
+		string(store.WorkAttemptTerminalLaneRevoked),
+		pending.reason,
+		"lane_revoked",
+		"worker stopped after leaving a worker-owned lane",
+		map[string]any{"lane_revocation": map[string]any{
+			"generation":   pending.generation,
+			"from_state":   pending.fromState,
+			"to_state":     pending.toState,
+			"reason":       pending.reason,
+			"requested_at": pending.requestedAt,
+			"reap_outcome": pending.reapOutcome,
+		}},
+	)
+	delete(o.pendingLaneRevocations, event.IssueID)
+	delete(state.Running, event.IssueID)
+	delete(state.Claimed, event.IssueID)
+	delete(state.Retry, event.IssueID)
+	delete(state.BudgetRefusals, event.IssueID)
+	delete(state.PriorAttempts, event.IssueID)
+	delete(state.InstantFailures, event.IssueID)
+	delete(state.RepeatedFailures, event.IssueID)
+	releaseDispatchRecoveryAdmission(state, event.IssueID)
+	releaseProjectFailureBreakerCanary(state, event.IssueID)
+	if err := o.abandonClaim(context.WithoutCancel(ctx), event.IssueID); err != nil && o.logger != nil {
+		o.logger.Warn("lane revocation claim release failed", "issue_id", event.IssueID, "error", err)
+	}
+	if workspaceIssueTerminal(running.Issue, o.cfg.TerminalStates) {
+		finalState := strings.TrimSpace(running.Issue.State)
+		if finalState == "" {
+			finalState = runpkg.FinalStateLaneRevoked
+		}
+		state.Completed[event.IssueID] = Completed{
+			Issue:           cloneIssue(running.Issue),
+			SessionID:       running.SessionID,
+			StartedAt:       running.StartedAt,
+			CompletedAt:     terminalCompletedAt(running.Issue, o.cfg.TerminalStates, completedAt),
+			FinalState:      finalState,
+			Tokens:          tokens,
+			RuntimeIdentity: running.RuntimeIdentity,
+		}
+		o.recordEfficiencyReceipt(ctx, running.Issue, completedAt)
+		o.reapWorkspace(ctx, state, running.Issue, workspaceReapReason(running.Issue, o.cfg.TerminalStates), completedAt)
+	}
+	if o.logger != nil {
+		o.logger.Info(
+			"worker lane revocation completed",
+			"project_id", strings.TrimSpace(o.cfg.Project.ID),
+			"issue_id", event.IssueID,
+			"identifier", running.Issue.Identifier,
+			"generation", pending.generation,
+			"work_attempt_id", running.WorkAttemptID,
+			"to_state", running.Issue.State,
+			"reap_outcome", pending.reapOutcome,
+		)
+	}
+}
+
+func (o *Orchestrator) reapRunningWorker(
+	ctx context.Context,
+	running Running,
+	identity procgroup.Identity,
+) (procgroup.TerminationOutcome, procgroup.Identity, error) {
+	found := identity.PID > 0
+	if !found {
+		var err error
+		identity, found, err = o.persistedWorkerProcess(ctx, running)
+		if err != nil {
+			return "", procgroup.Identity{}, fmt.Errorf("load persisted identity: %w", err)
+		}
+	}
+	if !found {
+		return procgroup.TerminationOutcomeAlreadyExited, procgroup.Identity{}, nil
+	}
+	reap := o.reapWorkerProcess
+	if reap == nil {
+		reap = procgroup.Terminate
+	}
+	outcome, err := reap(context.WithoutCancel(ctx), identity, o.workerReapGrace)
+	if err != nil {
+		return "", identity, err
+	}
+	if outcome == procgroup.TerminationOutcomeStaleIdentity {
+		return outcome, identity, nil
+	}
+	if o.workerProcesses != nil && running.DetentSessionID > 0 {
+		if err := o.workerProcesses.MarkSessionWorkerProcessReaped(context.WithoutCancel(ctx), running.DetentSessionID, store.WorkerProcessReap{
+			ReapedAt: o.clockNow().UTC(),
+			Outcome:  string(outcome),
+		}); err != nil {
+			return outcome, identity, fmt.Errorf("persist reap outcome: %w", err)
+		}
+	}
+	return outcome, identity, nil
+}
+
+func completionMatchesRunning(event runpkg.Completion, running Running) bool {
+	if event.Request.Generation > 0 && running.Generation > 0 && event.Request.Generation != running.Generation {
+		return false
+	}
+	if event.Request.WorkAttemptID > 0 && running.WorkAttemptID > 0 && event.Request.WorkAttemptID != running.WorkAttemptID {
+		return false
+	}
+	return true
+}
+
+func (o *Orchestrator) refreshCompletionLane(ctx context.Context, running Running) (connector.Issue, error) {
+	if o == nil || o.connector == nil {
+		return cloneIssue(running.Issue), nil
+	}
+	issues, err := o.connector.FetchIssueStatesByIDs(ctx, []string{running.Issue.ID})
+	if err != nil {
+		return connector.Issue{}, err
+	}
+	for _, issue := range issues {
+		if strings.TrimSpace(issue.ID) == strings.TrimSpace(running.Issue.ID) {
+			return mergeIssueTrackerFields(running.Issue, issue), nil
+		}
+	}
+	return connector.Issue{}, fmt.Errorf("issue %s was not returned by completion fence", issueLabel(running.Issue))
+}
+
+func (o *Orchestrator) rejectWorkerCompletion(
+	ctx context.Context,
+	state *State,
+	event runpkg.Completion,
+	running Running,
+	reason string,
+	err error,
+) {
+	at := event.CompletedAt.UTC()
+	if at.IsZero() {
+		at = o.clockNow().UTC()
+	}
+	message := "rejected stale completion for " + issueLabel(event.Request.Issue) + ": " + reason
+	if strings.TrimSpace(event.Request.Issue.ID) == "" {
+		message = "rejected stale completion for " + issueLabel(running.Issue) + ": " + reason
+	}
+	if err != nil {
+		message += ": " + err.Error()
+	}
+	recordStateEvent(state, telemetry.ActivityEvent{At: at, Event: "stale_worker_completion_rejected", Message: message})
+	if o.logger != nil {
+		o.logger.Warn(
+			"stale worker completion rejected",
+			"project_id", strings.TrimSpace(o.cfg.Project.ID),
+			"issue_id", event.IssueID,
+			"generation", event.Request.Generation,
+			"current_generation", running.Generation,
+			"work_attempt_id", event.Request.WorkAttemptID,
+			"current_work_attempt_id", running.WorkAttemptID,
+			"reason", reason,
+			"error", err,
+		)
+	}
+	if o.workflowMetrics != nil {
+		_, recordErr := o.workflowMetrics.RecordWorkflowPhaseEvent(context.WithoutCancel(ctx), store.WorkflowPhaseEvent{
+			ProjectID:  strings.TrimSpace(o.cfg.Project.ID),
+			SessionID:  running.DetentSessionID,
+			IssueID:    event.IssueID,
+			Identifier: running.Issue.Identifier,
+			PhaseType:  store.WorkflowPhaseTypeRecovery,
+			PhaseName:  "stale_completion_rejected",
+			Reason:     reason,
+			Status:     "rejected",
+			StartedAt:  at,
+			FinishedAt: at,
+			MetadataJSON: marshalWorkAttemptJSON(map[string]any{
+				"generation":              event.Request.Generation,
+				"current_generation":      running.Generation,
+				"work_attempt_id":         event.Request.WorkAttemptID,
+				"current_work_attempt_id": running.WorkAttemptID,
+				"error":                   errorString(err),
+			}),
+		})
+		if recordErr != nil && o.logger != nil {
+			o.logger.Warn("stale completion audit persistence failed", "issue_id", event.IssueID, "error", recordErr)
+		}
+	}
+}

--- a/internal/orchestrator/lane_revocation_test.go
+++ b/internal/orchestrator/lane_revocation_test.go
@@ -1,0 +1,459 @@
+package orchestrator
+
+import (
+	"context"
+	"errors"
+	"io"
+	"log/slog"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/digitaldrywood/detent/internal/connector"
+	"github.com/digitaldrywood/detent/internal/procgroup"
+	runpkg "github.com/digitaldrywood/detent/internal/runner"
+	"github.com/digitaldrywood/detent/internal/scheduler"
+	"github.com/digitaldrywood/detent/internal/store"
+	"github.com/digitaldrywood/detent/internal/telemetry"
+)
+
+func TestLaneRevocationPreservesTrackerDestination(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name          string
+		destination   string
+		wantCompleted bool
+	}{
+		{name: "blocked lane", destination: "Blocked"},
+		{name: "review lane", destination: "Review"},
+		{name: "terminal lane", destination: "Done", wantCompleted: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			now := time.Date(2026, 8, 16, 18, 35, 0, 0, time.UTC)
+			issue := laneRevocationIssue("issue-22", "digitaldrywood/video-studio#22", "Production")
+			parked := cloneIssue(issue)
+			parked.State = tt.destination
+			attempts := &recordingWorkAttemptStore{}
+			tracker := &runningStateConnector{issues: []connector.Issue{parked}}
+			cfg := normalizeConfig(Config{
+				Project:        scheduler.ProjectCandidate{ID: "video-studio"},
+				ActiveStates:   []string{"Todo", "Production", "Rework"},
+				ObservedStates: []string{"Blocked", "Review"},
+				TerminalStates: []string{"Done", "Cancelled"},
+			})
+			orch := &Orchestrator{
+				cfg:                    cfg,
+				connector:              tracker,
+				workAttempts:           attempts,
+				pendingLaneRevocations: map[string]*pendingLaneRevocation{},
+				logger:                 slog.New(slog.NewTextHandler(io.Discard, nil)),
+				now:                    func() time.Time { return now },
+			}
+			state := newState(cfg)
+			runCtx, stop := context.WithCancelCause(context.Background())
+			state.Running[issue.ID] = Running{
+				Issue:         issue,
+				Attempt:       2,
+				WorkAttemptID: 42,
+				Generation:    7,
+				StartedAt:     now.Add(-time.Hour),
+				stop:          stop,
+			}
+			state.Claimed[issue.ID] = Claimed{Issue: issue, ClaimedAt: now.Add(-time.Hour)}
+			state.Retry[issue.ID] = Retry{Issue: issue, Attempt: 3, DueAt: now.Add(time.Hour)}
+
+			orch.reconcileRunningIssues(t.Context(), &state, now)
+
+			if !errors.Is(context.Cause(runCtx), runpkg.ErrLaneRevoked) {
+				t.Fatalf("context cause = %v, want ErrLaneRevoked", context.Cause(runCtx))
+			}
+			orch.handleRunResult(t.Context(), &state, runpkg.Completion{
+				IssueID: issue.ID,
+				Request: runpkg.RunRequest{
+					Issue:         issue,
+					WorkAttemptID: 42,
+					Generation:    7,
+				},
+				CompletedAt: now.Add(time.Second),
+				Err:         runpkg.ErrLaneRevoked,
+				Result:      runpkg.RunResult{FinalState: runpkg.FinalStateLaneRevoked},
+			})
+
+			if _, ok := state.Running[issue.ID]; ok {
+				t.Fatalf("Running[%q] present after lane revocation", issue.ID)
+			}
+			if _, ok := state.Claimed[issue.ID]; ok {
+				t.Fatalf("Claimed[%q] present after lane revocation", issue.ID)
+			}
+			if _, ok := state.Retry[issue.ID]; ok {
+				t.Fatalf("Retry[%q] present after lane revocation", issue.ID)
+			}
+			_, completed := state.Completed[issue.ID]
+			if completed != tt.wantCompleted {
+				t.Fatalf("Completed[%q] present = %v, want %v", issue.ID, completed, tt.wantCompleted)
+			}
+			if len(attempts.completions) != 1 || attempts.completions[0].TerminalState != store.WorkAttemptTerminalLaneRevoked {
+				t.Fatalf("work attempt completions = %#v, want lane_revoked", attempts.completions)
+			}
+			if len(tracker.updates) != 0 || len(tracker.setFieldCalls) != 0 {
+				t.Fatalf("tracker writes = updates %#v fields %#v, want none", tracker.updates, tracker.setFieldCalls)
+			}
+			if tracker.issues[0].State != tt.destination {
+				t.Fatalf("tracker state = %q, want preserved %q", tracker.issues[0].State, tt.destination)
+			}
+		})
+	}
+}
+
+func TestLaneChangeFinishRaceRejectsArtifactCompletion(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 8, 16, 18, 35, 0, 0, time.UTC)
+	issue := laneRevocationIssue("issue-artifact-22", "digitaldrywood/video-studio#22", "Production")
+	issue.Deliverable = &connector.Deliverable{Kind: "artifact"}
+	issue.Fields = map[string]string{"render_status": "recut"}
+	parked := cloneIssue(issue)
+	parked.State = "Blocked"
+	workpad := "## Codex Workpad\n\n```detent-status\nschema: 1\nstatus: complete\nfields:\n  render_status: pending_review\nblockers: []\nhuman_action: null\n```"
+	tracker := &autoPromoteTickConnector{
+		stateIssues: []connector.Issue{parked},
+		issueComments: map[string][]connector.IssueComment{
+			issue.ID: {{Body: workpad}},
+		},
+	}
+	attempts := &recordingWorkAttemptStore{}
+	cfg := normalizeConfig(Config{
+		Project:        scheduler.ProjectCandidate{ID: "video-studio"},
+		ActiveStates:   []string{"Todo", "Production", "Rework"},
+		ObservedStates: []string{"Blocked", "Review"},
+		TerminalStates: []string{"Done", "Cancelled"},
+		AutoPromote: AutoPromoteConfig{
+			Enabled:     true,
+			SourceState: "Review",
+			Gate:        artifactCompletionTestGate(),
+		},
+	})
+	orch := &Orchestrator{
+		cfg:                    cfg,
+		connector:              tracker,
+		workAttempts:           attempts,
+		pendingLaneRevocations: map[string]*pendingLaneRevocation{},
+		logger:                 slog.New(slog.NewTextHandler(io.Discard, nil)),
+		now:                    func() time.Time { return now },
+	}
+	state := newState(cfg)
+	state.Running[issue.ID] = Running{
+		Issue:               issue,
+		Attempt:             1,
+		WorkAttemptID:       44,
+		Generation:          4,
+		DispatchWorkpadRead: true,
+		StartedAt:           now.Add(-time.Hour),
+	}
+
+	orch.handleRunResult(t.Context(), &state, runpkg.Completion{
+		IssueID: issue.ID,
+		Request: runpkg.RunRequest{
+			Issue:         issue,
+			WorkAttemptID: 44,
+			Generation:    4,
+		},
+		CompletedAt: now,
+		Result:      runpkg.RunResult{FinalState: runpkg.FinalStateCompleted},
+	})
+
+	if len(tracker.setFields) != 0 || len(tracker.updates) != 0 {
+		t.Fatalf("tracker writes = fields %#v updates %#v, want none", tracker.setFields, tracker.updates)
+	}
+	if got := tracker.stateIssues[0].Fields["render_status"]; got != "recut" {
+		t.Fatalf("render_status = %q, want recut", got)
+	}
+	if len(attempts.completions) != 1 || attempts.completions[0].TerminalState != store.WorkAttemptTerminalLaneRevoked {
+		t.Fatalf("work attempt completions = %#v, want lane_revoked", attempts.completions)
+	}
+	if !hasLaneRevocationEvent(state.RecentEvents, "stale_worker_completion_rejected") {
+		t.Fatalf("RecentEvents = %#v, want stale completion rejection", state.RecentEvents)
+	}
+}
+
+func TestStaleWorkerGenerationCannotCompleteFreshLease(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 8, 16, 18, 40, 0, 0, time.UTC)
+	issue := laneRevocationIssue("issue-generation", "digitaldrywood/video-studio#23", "Production")
+	metrics := &autoPromoteWorkflowMetricsRecorder{}
+	tracker := &runningStateConnector{issues: []connector.Issue{issue}}
+	cfg := normalizeConfig(Config{
+		Project:      scheduler.ProjectCandidate{ID: "video-studio"},
+		ActiveStates: []string{"Todo", "Production", "Rework"},
+	})
+	orch := &Orchestrator{
+		cfg:             cfg,
+		connector:       tracker,
+		workflowMetrics: metrics,
+		logger:          slog.New(slog.NewTextHandler(io.Discard, nil)),
+		now:             func() time.Time { return now },
+	}
+	state := newState(cfg)
+	state.Running[issue.ID] = Running{Issue: issue, WorkAttemptID: 202, Generation: 2}
+
+	orch.handleRunResult(t.Context(), &state, runpkg.Completion{
+		IssueID: issue.ID,
+		Request: runpkg.RunRequest{
+			Issue:         issue,
+			WorkAttemptID: 101,
+			Generation:    1,
+		},
+		CompletedAt: now,
+		Result:      runpkg.RunResult{FinalState: runpkg.FinalStateCompleted},
+	})
+
+	running, ok := state.Running[issue.ID]
+	if !ok || running.Generation != 2 || running.WorkAttemptID != 202 {
+		t.Fatalf("Running[%q] = %#v, want fresh generation 2 attempt 202", issue.ID, running)
+	}
+	if len(tracker.updates) != 0 || len(tracker.setFieldCalls) != 0 {
+		t.Fatalf("tracker writes = updates %#v fields %#v, want none", tracker.updates, tracker.setFieldCalls)
+	}
+	events := metrics.snapshot()
+	if len(events) != 1 || events[0].PhaseName != "stale_completion_rejected" || events[0].Status != "rejected" {
+		t.Fatalf("workflow events = %#v, want stale completion rejection audit", events)
+	}
+}
+
+func TestCompletionAfterLeaseCleanupRecordsRejection(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 8, 16, 18, 42, 0, 0, time.UTC)
+	issue := laneRevocationIssue("issue-cleaned-lease", "digitaldrywood/video-studio#23", "Production")
+	metrics := &autoPromoteWorkflowMetricsRecorder{}
+	cfg := normalizeConfig(Config{
+		Project:      scheduler.ProjectCandidate{ID: "video-studio"},
+		ActiveStates: []string{"Todo", "Production", "Rework"},
+	})
+	orch := &Orchestrator{
+		cfg:             cfg,
+		workflowMetrics: metrics,
+		logger:          slog.New(slog.NewTextHandler(io.Discard, nil)),
+		now:             func() time.Time { return now },
+	}
+	state := newState(cfg)
+
+	orch.handleRunResult(t.Context(), &state, runpkg.Completion{
+		IssueID: issue.ID,
+		Request: runpkg.RunRequest{
+			Issue:         issue,
+			WorkAttemptID: 101,
+			Generation:    1,
+		},
+		CompletedAt: now,
+	})
+
+	if !hasLaneRevocationEvent(state.RecentEvents, "stale_worker_completion_rejected") {
+		t.Fatalf("RecentEvents = %#v, want stale completion rejection", state.RecentEvents)
+	}
+	events := metrics.snapshot()
+	if len(events) != 1 || events[0].PhaseName != "stale_completion_rejected" || events[0].Status != "rejected" {
+		t.Fatalf("workflow events = %#v, want stale completion rejection audit", events)
+	}
+}
+
+func TestMovingBackToActiveLaneCreatesFreshGeneration(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 8, 16, 18, 45, 0, 0, time.UTC)
+	issue := laneRevocationIssue("issue-reentry", "digitaldrywood/video-studio#24", "Production")
+	tracker := &runningStateConnector{issues: []connector.Issue{issue}}
+	runner := newWorkerHostRunner()
+	cfg := normalizeConfig(Config{
+		Project:             scheduler.ProjectCandidate{ID: "video-studio"},
+		MaxConcurrentAgents: 1,
+		ActiveStates:        []string{"Todo", "Production", "Rework"},
+		ObservedStates:      []string{"Blocked"},
+		TerminalStates:      []string{"Done", "Cancelled"},
+	})
+	orch, err := New(cfg, Dependencies{Connector: tracker, Runner: runner, Now: func() time.Time { return now }})
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	state := newState(orch.cfg)
+	runCtx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	if !orch.dispatchIssue(runCtx, &state, issue, 1, now, "") {
+		t.Fatal("first dispatch = false, want true")
+	}
+	firstRequest := receiveWorkerHostRunRequest(t, runner.started)
+	parked := cloneIssue(issue)
+	parked.State = "Blocked"
+	tracker.issues = []connector.Issue{parked}
+	orch.reconcileRunningIssues(runCtx, &state, now.Add(time.Second))
+	firstCompletion := receiveLaneRevocationCompletion(t, orch.runResults)
+	orch.handleRunResult(runCtx, &state, firstCompletion)
+
+	tracker.issues = []connector.Issue{issue}
+	if !orch.dispatchIssue(runCtx, &state, issue, 2, now.Add(2*time.Second), "") {
+		t.Fatal("second dispatch = false, want true")
+	}
+	secondRequest := receiveWorkerHostRunRequest(t, runner.started)
+	if secondRequest.Generation <= firstRequest.Generation {
+		t.Fatalf("second generation = %d, want greater than first generation %d", secondRequest.Generation, firstRequest.Generation)
+	}
+
+	orch.handleRunResult(runCtx, &state, firstCompletion)
+	running, ok := state.Running[issue.ID]
+	if !ok || running.Generation != secondRequest.Generation {
+		t.Fatalf("Running[%q] = %#v, want fresh generation %d", issue.ID, running, secondRequest.Generation)
+	}
+	if !hasLaneRevocationEvent(state.RecentEvents, "stale_worker_completion_rejected") {
+		t.Fatalf("RecentEvents = %#v, want stale completion rejection", state.RecentEvents)
+	}
+
+	if running.stop != nil {
+		running.stop(runpkg.ErrLaneRevoked)
+	}
+	_ = receiveLaneRevocationCompletion(t, orch.runResults)
+}
+
+func TestLaneRevocationRecordsGraceTimeoutEscalation(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 8, 16, 18, 50, 0, 0, time.UTC)
+	issue := laneRevocationIssue("issue-escalation", "digitaldrywood/video-studio#25", "Production")
+	parked := cloneIssue(issue)
+	parked.State = "Blocked"
+	identity := procgroup.Identity{PID: 2501, GroupID: 2501, StartedAt: now.Add(-time.Hour)}
+	processes := &laneRevocationProcessStore{active: []store.WorkerProcess{{
+		SessionID: 55,
+		IssueID:   issue.ID,
+		WorkerProcessIdentity: store.WorkerProcessIdentity{
+			PID:       identity.PID,
+			GroupID:   identity.GroupID,
+			StartedAt: identity.StartedAt,
+		},
+	}}}
+	cfg := normalizeConfig(Config{ActiveStates: []string{"Production"}})
+	orch := &Orchestrator{
+		cfg:                    cfg,
+		connector:              &runningStateConnector{issues: []connector.Issue{parked}},
+		workerProcesses:        processes,
+		workerReapGrace:        20 * time.Millisecond,
+		pendingLaneRevocations: map[string]*pendingLaneRevocation{},
+		reapWorkerProcess: func(_ context.Context, got procgroup.Identity, grace time.Duration) (procgroup.TerminationOutcome, error) {
+			if got != identity || grace != 20*time.Millisecond {
+				t.Fatalf("reap arguments = %#v, %s, want %#v, 20ms", got, grace, identity)
+			}
+			return procgroup.TerminationOutcomeKilled, nil
+		},
+		logger: slog.New(slog.NewTextHandler(io.Discard, nil)),
+		now:    func() time.Time { return now },
+	}
+	state := newState(cfg)
+	state.Running[issue.ID] = Running{
+		Issue:           issue,
+		Generation:      5,
+		DetentSessionID: 55,
+		WorkerProcess:   identity,
+	}
+
+	orch.reconcileRunningIssues(t.Context(), &state, now)
+
+	for _, event := range []string{"worker_lane_stop_requested", "worker_lane_stop_escalated", "worker_lane_stop_result"} {
+		if !hasLaneRevocationEvent(state.RecentEvents, event) {
+			t.Fatalf("RecentEvents = %#v, want %s", state.RecentEvents, event)
+		}
+	}
+	if len(processes.reaped) != 1 || processes.reaped[0].Outcome != store.WorkerProcessOutcomeKilled {
+		t.Fatalf("process reap records = %#v, want killed_after_timeout", processes.reaped)
+	}
+}
+
+func TestReconcileRunningIssuesStopsVideoStudioIncidentWorkers(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 8, 16, 18, 35, 0, 0, time.UTC)
+	cfg := normalizeConfig(Config{ActiveStates: []string{"Production"}})
+	state := newState(cfg)
+	tracker := &runningStateConnector{}
+	orch := &Orchestrator{
+		cfg:                    cfg,
+		connector:              tracker,
+		pendingLaneRevocations: map[string]*pendingLaneRevocation{},
+		logger:                 slog.New(slog.NewTextHandler(io.Discard, nil)),
+		now:                    func() time.Time { return now },
+	}
+	contexts := make([]context.Context, 0, 6)
+	for number := 22; number <= 27; number++ {
+		id := "wi-video-studio-" + strconv.Itoa(number)
+		if number == 22 {
+			id = "wi-0c7d736611a111641bd57b97"
+		}
+		issue := laneRevocationIssue(id, "digitaldrywood/video-studio#"+strconv.Itoa(number), "Production")
+		parked := cloneIssue(issue)
+		parked.State = "Blocked"
+		tracker.issues = append(tracker.issues, parked)
+		runCtx, stop := context.WithCancelCause(context.Background())
+		contexts = append(contexts, runCtx)
+		state.Running[id] = Running{Issue: issue, Generation: uint64(number), stop: stop}
+	}
+
+	orch.reconcileRunningIssues(t.Context(), &state, now)
+
+	for index, runCtx := range contexts {
+		if !errors.Is(context.Cause(runCtx), runpkg.ErrLaneRevoked) {
+			t.Fatalf("worker #%d context cause = %v, want ErrLaneRevoked", index+22, context.Cause(runCtx))
+		}
+	}
+	if len(orch.pendingLaneRevocations) != 6 {
+		t.Fatalf("pending lane revocations = %d, want 6", len(orch.pendingLaneRevocations))
+	}
+}
+
+func laneRevocationIssue(id string, identifier string, state string) connector.Issue {
+	issue := connector.NewIssue()
+	issue.ID = id
+	issue.Identifier = identifier
+	issue.Title = "Lane revocation test"
+	issue.State = state
+	return issue
+}
+
+func receiveLaneRevocationCompletion(t *testing.T, completions <-chan runpkg.Completion) runpkg.Completion {
+	t.Helper()
+
+	select {
+	case completion := <-completions:
+		return completion
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for worker completion")
+		return runpkg.Completion{}
+	}
+}
+
+func hasLaneRevocationEvent(events []telemetry.ActivityEvent, name string) bool {
+	for _, event := range events {
+		if event.Event == name {
+			return true
+		}
+	}
+	return false
+}
+
+type laneRevocationProcessStore struct {
+	active []store.WorkerProcess
+	reaped []store.WorkerProcessReap
+}
+
+func (s *laneRevocationProcessStore) ListActiveWorkerProcesses(context.Context) ([]store.WorkerProcess, error) {
+	return append([]store.WorkerProcess(nil), s.active...), nil
+}
+
+func (s *laneRevocationProcessStore) MarkSessionWorkerProcessReaped(_ context.Context, _ int64, reap store.WorkerProcessReap) error {
+	s.reaped = append(s.reaped, reap)
+	return nil
+}

--- a/internal/orchestrator/merge_duration_test.go
+++ b/internal/orchestrator/merge_duration_test.go
@@ -232,9 +232,9 @@ func TestNormalDurationMergeIsUnaffected(t *testing.T) {
 	if completion.Err != nil {
 		t.Fatalf("completion error = %v, want nil", completion.Err)
 	}
-	running := state.Running[issue.ID]
-	running.Issue.State = "Done"
-	state.Running[issue.ID] = running
+	if err := tracker.UpdateIssueState(t.Context(), issue.ID, "Done"); err != nil {
+		t.Fatalf("UpdateIssueState(Done) error = %v", err)
+	}
 	orch.handleRunResult(t.Context(), &state, completion)
 
 	if _, ok := state.Blocked[issue.ID]; ok {

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -276,10 +276,12 @@ type Orchestrator struct {
 	validatorCapacityEvents chan validatorCapacityEvent
 	done                    chan struct{}
 	pendingStops            map[string]*pendingStopRun
+	pendingLaneRevocations  map[string]*pendingLaneRevocation
 	pendingMergeRevocations map[string]mergeRevocation
 	mergeRevocationComments map[string]*mergeRevocationCommentState
 	completedStops          map[string]StopRunResult
 	refreshSeq              atomic.Uint64
+	workerGeneration        atomic.Uint64
 }
 
 type validatorStageResult struct {
@@ -541,6 +543,7 @@ func New(cfg Config, deps Dependencies) (*Orchestrator, error) {
 		validatorCapacityEvents: make(chan validatorCapacityEvent, max(cfg.MaxConcurrentAgents, 1)),
 		done:                    make(chan struct{}),
 		pendingStops:            map[string]*pendingStopRun{},
+		pendingLaneRevocations:  map[string]*pendingLaneRevocation{},
 		pendingMergeRevocations: map[string]mergeRevocation{},
 		mergeRevocationComments: map[string]*mergeRevocationCommentState{},
 		completedStops:          map[string]StopRunResult{},

--- a/internal/orchestrator/orphan_recovery_test.go
+++ b/internal/orchestrator/orphan_recovery_test.go
@@ -167,6 +167,39 @@ func TestRecoverDurableWorkAttemptsDoesNotResumeExpiredClaim(t *testing.T) {
 	}
 }
 
+func TestRecoverDurableWorkAttemptsDoesNotResumeOutsideActiveLane(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 8, 16, 18, 35, 0, 0, time.UTC)
+	issue := orphanRecoveryIssue()
+	issue.State = "Blocked"
+	attempts := &orphanRecoveryAttemptStore{
+		orphans: []store.OrphanedAgentSession{orphanRecoverySession(now)},
+	}
+	orch, err := New(Config{
+		Project:                scheduler.ProjectCandidate{ID: "detent"},
+		ActiveStates:           []string{"Todo", "In Progress", "Merging"},
+		ObservedStates:         []string{"Blocked"},
+		ResumeOrphanedSessions: true,
+	}, Dependencies{
+		Connector:    hydratingDispatchConnector{issue: issue},
+		WorkAttempts: attempts,
+	})
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	state := newState(orch.cfg)
+
+	orch.recoverDurableWorkAttempts(context.Background(), &state, now)
+
+	if len(state.Retry) != 0 {
+		t.Fatalf("state.Retry = %#v, want no inactive-lane resume", state.Retry)
+	}
+	if len(attempts.marked) != 0 {
+		t.Fatalf("marked sessions = %#v, want inactive session left terminated", attempts.marked)
+	}
+}
+
 func orphanRecoverySession(now time.Time) store.OrphanedAgentSession {
 	return store.OrphanedAgentSession{
 		ResumeState: store.AgentResumeState{

--- a/internal/orchestrator/reaper.go
+++ b/internal/orchestrator/reaper.go
@@ -254,7 +254,11 @@ func (o *Orchestrator) completeRunningIssueFromWorkspaceCleanup(ctx context.Cont
 			slog.String("reason", workspaceReapReason(running.Issue, o.cfg.TerminalStates)),
 		)
 	}
-	o.completeTerminalRunning(ctx, state, issueID, running, terminalCompletedAt(running.Issue, o.cfg.TerminalStates, now), running.Tokens)
+	if running.Generation == 0 {
+		o.completeTerminalRunning(ctx, state, issueID, running, terminalCompletedAt(running.Issue, o.cfg.TerminalStates, now), running.Tokens)
+		return true
+	}
+	o.beginLaneRevocation(ctx, state, running, running.Issue, now, laneRevocationStateChanged)
 	return true
 }
 

--- a/internal/orchestrator/reconcile.go
+++ b/internal/orchestrator/reconcile.go
@@ -272,13 +272,35 @@ func (o *Orchestrator) reconcileRunningIssues(ctx context.Context, state *State,
 		}
 
 		running := state.Running[id]
-		mergeWorker := running.Mode == runpkg.RunModeMerge || mergeWorkerIssue(running.Issue)
-		running.Issue = o.hydrateRunningIssueComments(ctx, mergeIssueTrackerFields(running.Issue, issue))
-		if workspaceIssueTerminal(running.Issue, o.cfg.TerminalStates) {
-			o.completeTerminalRunning(ctx, state, id, running, terminalCompletedAt(running.Issue, o.cfg.TerminalStates, now), running.Tokens)
+		if pending, revoking := o.pendingLaneRevocations[id]; revoking {
+			if !pending.reapDone {
+				o.reapPendingLaneRevocation(ctx, state, pending)
+			}
+			if pending.completion != nil && pending.reapDone {
+				o.finishLaneRevocation(ctx, state, pending)
+			}
 			continue
 		}
-		if mergeWorker {
+		mergeWorker := running.Mode == runpkg.RunModeMerge || mergeWorkerIssue(running.Issue)
+		refreshedRunning := running
+		refreshedRunning.Issue = o.hydrateRunningIssueComments(ctx, mergeIssueTrackerFields(running.Issue, issue))
+		if mergeWorker && running.Generation == 0 {
+			var revoked bool
+			refreshedRunning, revoked = o.revokeRunningMergeIfIneligible(ctx, state, refreshedRunning, now)
+			if revoked {
+				continue
+			}
+		}
+		if !stateIn(refreshedRunning.Issue.State, o.cfg.ActiveStates) || workspaceIssueTerminal(refreshedRunning.Issue, o.cfg.TerminalStates) {
+			if running.Generation == 0 && workspaceIssueTerminal(refreshedRunning.Issue, o.cfg.TerminalStates) {
+				o.completeTerminalRunning(ctx, state, id, refreshedRunning, terminalCompletedAt(refreshedRunning.Issue, o.cfg.TerminalStates, now), refreshedRunning.Tokens)
+				continue
+			}
+			o.beginLaneRevocation(ctx, state, running, refreshedRunning.Issue, now, laneRevocationStateChanged)
+			continue
+		}
+		running = refreshedRunning
+		if mergeWorker && running.Generation > 0 {
 			var revoked bool
 			running, revoked = o.revokeRunningMergeIfIneligible(ctx, state, running, now)
 			if revoked {

--- a/internal/orchestrator/reconcile_test.go
+++ b/internal/orchestrator/reconcile_test.go
@@ -134,6 +134,40 @@ func TestTickReconcilesRunningIssueTrackerState(t *testing.T) {
 	}
 }
 
+func TestReconcileRunningIssuesStopsWorkerOutsideActiveLane(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 8, 16, 18, 35, 0, 0, time.UTC)
+	issue := connector.Issue{
+		ID:         "wi-0c7d736611a111641bd57b97",
+		Identifier: "digitaldrywood/video-studio#22",
+		State:      "Production",
+	}
+	parked := cloneIssue(issue)
+	parked.State = "Blocked"
+	runCtx, stop := context.WithCancelCause(context.Background())
+	state := newState(normalizeConfig(Config{
+		ActiveStates:   []string{"Todo", "Production", "Rework"},
+		ObservedStates: []string{"Blocked", "Review"},
+		TerminalStates: []string{"Done", "Cancelled"},
+	}))
+	state.Running[issue.ID] = Running{Issue: issue, stop: stop}
+	tracker := &runningStateConnector{issues: []connector.Issue{parked}}
+	orch := &Orchestrator{
+		cfg:       normalizeConfig(Config{ActiveStates: []string{"Todo", "Production", "Rework"}}),
+		connector: tracker,
+		logger:    slog.New(slog.NewTextHandler(io.Discard, nil)),
+	}
+
+	orch.reconcileRunningIssues(t.Context(), &state, now)
+
+	select {
+	case <-runCtx.Done():
+	default:
+		t.Fatal("worker context remains active after the item moved to Blocked")
+	}
+}
+
 func TestReconcileRunningIssuesRevokesIneligibleMerge(t *testing.T) {
 	t.Parallel()
 

--- a/internal/orchestrator/run_completion.go
+++ b/internal/orchestrator/run_completion.go
@@ -109,7 +109,38 @@ func (o *Orchestrator) handleRunUpdate(state *State, event runUpdate) {
 func (o *Orchestrator) handleRunResult(ctx context.Context, state *State, event runpkg.Completion) {
 	running, ok := state.Running[event.IssueID]
 	if !ok {
+		if event.Request.Generation > 0 || event.Request.WorkAttemptID > 0 {
+			o.rejectWorkerCompletion(ctx, state, event, Running{}, "worker lease is no longer active", nil)
+		}
 		return
+	}
+	if !completionMatchesRunning(event, running) {
+		o.rejectWorkerCompletion(ctx, state, event, running, "worker generation or work-attempt lease no longer owns the item", nil)
+		return
+	}
+	if o.handleLaneRevocationCompletion(ctx, state, event, running) {
+		return
+	}
+	if running.Generation > 0 {
+		refreshed, err := o.refreshCompletionLane(ctx, running)
+		if err != nil {
+			o.rejectWorkerCompletion(ctx, state, event, running, laneRevocationCompletionFenceUnavailable, err)
+			o.beginLaneRevocation(ctx, state, running, running.Issue, event.CompletedAt, laneRevocationCompletionFenceUnavailable)
+			o.handleLaneRevocationCompletion(ctx, state, event, running)
+			return
+		}
+		running.Issue = refreshed
+		state.Running[event.IssueID] = running
+		if claimed, found := state.Claimed[event.IssueID]; found {
+			claimed.Issue = cloneIssue(refreshed)
+			state.Claimed[event.IssueID] = claimed
+		}
+		if !stateIn(refreshed.State, o.cfg.ActiveStates) || workspaceIssueTerminal(refreshed, o.cfg.TerminalStates) {
+			o.rejectWorkerCompletion(ctx, state, event, running, "current tracker lane is not worker-owned", nil)
+			o.beginLaneRevocation(ctx, state, running, refreshed, event.CompletedAt, laneRevocationStateChanged)
+			o.handleLaneRevocationCompletion(ctx, state, event, running)
+			return
+		}
 	}
 	o.heartbeats.remove(event.IssueID)
 	if o.retrospector != nil {

--- a/internal/orchestrator/state.go
+++ b/internal/orchestrator/state.go
@@ -114,6 +114,7 @@ type Running struct {
 	Issue                 connector.Issue
 	Attempt               int
 	WorkAttemptID         int64
+	Generation            uint64
 	Mode                  string
 	DispatchSourceState   string
 	DispatchTargetState   string

--- a/internal/orchestrator/stop_run.go
+++ b/internal/orchestrator/stop_run.go
@@ -321,31 +321,12 @@ func (o *Orchestrator) completeOperatorStopCompletion(ctx context.Context, state
 }
 
 func (o *Orchestrator) reapOperatorStopWorker(ctx context.Context, running Running, identity procgroup.Identity) (procgroup.TerminationOutcome, procgroup.Identity, error) {
-	found := identity.PID > 0
-	if !found {
-		var err error
-		identity, found, err = o.persistedWorkerProcess(ctx, running)
-		if err != nil {
-			return "", procgroup.Identity{}, fmt.Errorf("%w: load persisted identity: %w", ErrStopRunWorkerProcess, err)
-		}
-	}
-	if !found {
-		return procgroup.TerminationOutcomeAlreadyExited, procgroup.Identity{}, nil
-	}
-	outcome, err := o.reapWorkerProcess(context.WithoutCancel(ctx), identity, o.workerReapGrace)
+	outcome, identity, err := o.reapRunningWorker(ctx, running, identity)
 	if err != nil {
 		return "", identity, fmt.Errorf("%w: %w", ErrStopRunWorkerProcess, err)
 	}
 	if outcome == procgroup.TerminationOutcomeStaleIdentity {
 		return outcome, identity, fmt.Errorf("%w: persisted PID, PGID, or start time is stale", ErrStopRunWorkerProcess)
-	}
-	if o.workerProcesses != nil && running.DetentSessionID > 0 {
-		if err := o.workerProcesses.MarkSessionWorkerProcessReaped(context.WithoutCancel(ctx), running.DetentSessionID, store.WorkerProcessReap{
-			ReapedAt: o.clockNow().UTC(),
-			Outcome:  string(outcome),
-		}); err != nil {
-			return outcome, identity, fmt.Errorf("%w: persist reap outcome: %w", ErrStopRunWorkerProcess, err)
-		}
 	}
 	return outcome, identity, nil
 }
@@ -362,7 +343,7 @@ func (o *Orchestrator) persistedWorkerProcess(ctx context.Context, running Runni
 			}
 		}
 		if running.WorkerProcess.PID > 0 {
-			return procgroup.Identity{}, false, fmt.Errorf("active worker identity for session %d was not persisted", running.DetentSessionID)
+			return running.WorkerProcess, true, nil
 		}
 		return procgroup.Identity{}, false, nil
 	}

--- a/internal/orchestrator/targeted_reconcile.go
+++ b/internal/orchestrator/targeted_reconcile.go
@@ -74,8 +74,13 @@ func (o *Orchestrator) applyTargetedReconcile(
 		clearBlockedStatusIssue(state, issue.ID)
 	}
 
-	if running, ok := state.Running[issue.ID]; ok && workspaceIssueTerminal(running.Issue, o.cfg.TerminalStates) {
-		o.completeTerminalRunning(ctx, state, issue.ID, running, terminalCompletedAt(running.Issue, o.cfg.TerminalStates, now), running.Tokens)
+	if running, ok := state.Running[issue.ID]; ok &&
+		(!stateIn(running.Issue.State, o.cfg.ActiveStates) || workspaceIssueTerminal(running.Issue, o.cfg.TerminalStates)) {
+		if running.Generation == 0 && workspaceIssueTerminal(running.Issue, o.cfg.TerminalStates) {
+			o.completeTerminalRunning(ctx, state, issue.ID, running, terminalCompletedAt(running.Issue, o.cfg.TerminalStates, now), running.Tokens)
+			return
+		}
+		o.beginLaneRevocation(ctx, state, running, running.Issue, now, laneRevocationStateChanged)
 	}
 }
 

--- a/internal/procgroup/identity.go
+++ b/internal/procgroup/identity.go
@@ -20,6 +20,7 @@ type TerminationOutcome string
 
 const (
 	TerminationOutcomeTerminated    TerminationOutcome = "terminated"
+	TerminationOutcomeKilled        TerminationOutcome = "killed_after_timeout"
 	TerminationOutcomeAlreadyExited TerminationOutcome = "already_exited"
 	TerminationOutcomeStaleIdentity TerminationOutcome = "stale_identity"
 )

--- a/internal/procgroup/process_group_unix.go
+++ b/internal/procgroup/process_group_unix.go
@@ -230,7 +230,7 @@ func Terminate(ctx context.Context, identity Identity, grace time.Duration) (Ter
 	if !waitForProcessTargetExit(context.Background(), identity.PID, groupID, grace) {
 		return "", fmt.Errorf("process group %d remained alive after SIGKILL", groupID)
 	}
-	return TerminationOutcomeTerminated, nil
+	return TerminationOutcomeKilled, nil
 }
 
 func inspectProcess(pid int) (Identity, error) {

--- a/internal/procgroup/process_group_unix_test.go
+++ b/internal/procgroup/process_group_unix_test.go
@@ -434,8 +434,8 @@ func TestTerminateEscalatesSurvivingProcessGroup(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Terminate() error = %v", err)
 	}
-	if outcome != TerminationOutcomeTerminated {
-		t.Fatalf("Terminate() outcome = %q, want %q", outcome, TerminationOutcomeTerminated)
+	if outcome != TerminationOutcomeKilled {
+		t.Fatalf("Terminate() outcome = %q, want %q", outcome, TerminationOutcomeKilled)
 	}
 	assertKilled(t, waitForExit(t, proc.Wait))
 	assertKilled(t, waitForExit(t, proc.WaitGroupMember))

--- a/internal/runner/agent.go
+++ b/internal/runner/agent.go
@@ -2747,6 +2747,9 @@ func finalStateForTurnError(err error) string {
 	if errors.Is(err, ErrMergeRevoked) {
 		return FinalStateMergeRevoked
 	}
+	if errors.Is(err, ErrLaneRevoked) {
+		return FinalStateLaneRevoked
+	}
 	if errors.Is(err, ErrCIUnavailable) {
 		return FinalStateCIUnavailable
 	}

--- a/internal/runner/supervisor.go
+++ b/internal/runner/supervisor.go
@@ -193,10 +193,14 @@ func (s *Supervisor) Run(ctx context.Context, request RunRequest) (completion Co
 	result, err := s.backend.Run(ctx, request)
 	if cause := context.Cause(ctx); errors.Is(cause, ErrMergeWorkerStartupTimeout) ||
 		errors.Is(cause, ErrMergeWorkerDurationExceeded) ||
-		errors.Is(cause, ErrCIUnavailable) {
+		errors.Is(cause, ErrCIUnavailable) ||
+		errors.Is(cause, ErrLaneRevoked) {
 		err = errors.Join(cause, err)
 		if errors.Is(cause, ErrMergeWorkerDurationExceeded) {
 			result.FinalState = FinalStateMergeDurationExceeded
+		}
+		if errors.Is(cause, ErrLaneRevoked) {
+			result.FinalState = FinalStateLaneRevoked
 		}
 	}
 	completion.CompletedAt = s.now()
@@ -208,6 +212,7 @@ func (s *Supervisor) Run(ctx context.Context, request RunRequest) (completion Co
 func cooperativeStopError(err error) bool {
 	return errors.Is(err, ErrOperatorStopped) ||
 		errors.Is(err, ErrMergeRevoked) ||
+		errors.Is(err, ErrLaneRevoked) ||
 		errors.Is(err, ErrCIUnavailable) ||
 		errors.Is(err, ErrModelPermitUnavailable) ||
 		errors.Is(err, ErrMergeWorkerStartupTimeout) ||

--- a/internal/runner/supervisor_test.go
+++ b/internal/runner/supervisor_test.go
@@ -138,6 +138,25 @@ func TestSupervisorDoesNotRetryMergeRevokedRun(t *testing.T) {
 	}
 }
 
+func TestSupervisorDoesNotRetryLaneRevokedRun(t *testing.T) {
+	t.Parallel()
+
+	supervisor, err := NewSupervisor(laneRevokedBackend{}, SupervisorConfig{})
+	if err != nil {
+		t.Fatalf("NewSupervisor() error = %v", err)
+	}
+	completion := supervisor.Run(t.Context(), RunRequest{Issue: connector.Issue{ID: "issue-1849"}, Attempt: 4})
+	if !errors.Is(completion.Err, ErrLaneRevoked) {
+		t.Fatalf("Err = %v, want ErrLaneRevoked", completion.Err)
+	}
+	if completion.Retryable || completion.RetryAttempt != 0 || completion.RetryDelay != 0 {
+		t.Fatalf("retry state = retryable %v attempt %d delay %s, want no retry", completion.Retryable, completion.RetryAttempt, completion.RetryDelay)
+	}
+	if got := finalStateForTurnError(ErrLaneRevoked); got != FinalStateLaneRevoked {
+		t.Fatalf("finalStateForTurnError() = %q, want %q", got, FinalStateLaneRevoked)
+	}
+}
+
 func TestMergeWorkerDurationExceededFinalState(t *testing.T) {
 	t.Parallel()
 
@@ -164,9 +183,12 @@ func TestSupervisorPropagatesCancellationCause(t *testing.T) {
 		name          string
 		cause         error
 		wantCI        bool
+		wantLane      bool
+		wantFinal     string
 		wantRetryable bool
 	}{
 		{name: "CI unavailable remains cooperative", cause: ErrCIUnavailable, wantCI: true},
+		{name: "lane revocation remains cooperative", cause: ErrLaneRevoked, wantLane: true, wantFinal: FinalStateLaneRevoked},
 		{name: "ordinary cancellation remains retryable", cause: context.Canceled, wantRetryable: true},
 	}
 
@@ -187,6 +209,12 @@ func TestSupervisorPropagatesCancellationCause(t *testing.T) {
 			})
 			if got := errors.Is(completion.Err, ErrCIUnavailable); got != tt.wantCI {
 				t.Fatalf("errors.Is(Err, ErrCIUnavailable) = %v, want %v; Err = %v", got, tt.wantCI, completion.Err)
+			}
+			if got := errors.Is(completion.Err, ErrLaneRevoked); got != tt.wantLane {
+				t.Fatalf("errors.Is(Err, ErrLaneRevoked) = %v, want %v; Err = %v", got, tt.wantLane, completion.Err)
+			}
+			if completion.Result.FinalState != tt.wantFinal {
+				t.Fatalf("FinalState = %q, want %q", completion.Result.FinalState, tt.wantFinal)
 			}
 			if completion.Retryable != tt.wantRetryable {
 				t.Fatalf("Retryable = %v, want %v", completion.Retryable, tt.wantRetryable)
@@ -525,6 +553,12 @@ type mergeRevokedBackend struct{}
 
 func (mergeRevokedBackend) Run(context.Context, RunRequest) (RunResult, error) {
 	return RunResult{FinalState: FinalStateMergeRevoked}, ErrMergeRevoked
+}
+
+type laneRevokedBackend struct{}
+
+func (laneRevokedBackend) Run(context.Context, RunRequest) (RunResult, error) {
+	return RunResult{FinalState: FinalStateLaneRevoked}, ErrLaneRevoked
 }
 
 type contextErrorBackend struct{}

--- a/internal/runner/types.go
+++ b/internal/runner/types.go
@@ -24,6 +24,7 @@ const (
 	FinalStateTokenCeilingExceeded  = "token_ceiling_exceeded"
 	FinalStateOperatorStopped       = "operator_stopped"
 	FinalStateMergeRevoked          = "merge_revoked"
+	FinalStateLaneRevoked           = "lane_revoked"
 	FinalStateCIUnavailable         = "ci_unavailable"
 	FinalStateMergeDurationExceeded = "merge_duration_exceeded"
 	FinalStateMergeFallbackExceeded = "merge_fallback_budget_exceeded"
@@ -49,6 +50,7 @@ var (
 	ErrSessionDurationExceeded      = errors.New("agent session duration exceeded")
 	ErrOperatorStopped              = errors.New("operator stopped run")
 	ErrMergeRevoked                 = errors.New("merge eligibility revoked")
+	ErrLaneRevoked                  = errors.New("worker-owned lane revoked")
 	ErrCIUnavailable                = errors.New("CI unavailable")
 	ErrMergeWorkerStartupTimeout    = errors.New("merge worker startup timed out")
 	ErrMergeWorkerDurationExceeded  = errors.New("merge worker duration exceeded")
@@ -412,6 +414,7 @@ type RunRequest struct {
 	Issue                     connector.Issue
 	Attempt                   int
 	WorkAttemptID             int64
+	Generation                uint64
 	Mode                      string
 	DispatchSourceState       string
 	DispatchTargetState       string

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -26,6 +26,7 @@ const (
 	OrphanRecoveryResumed             = "resumed"
 	OrphanRecoveryFresh               = "fresh"
 	WorkerProcessOutcomeTerminated    = "terminated"
+	WorkerProcessOutcomeKilled        = "killed_after_timeout"
 	WorkerProcessOutcomeAlreadyExited = "already_exited"
 	WorkerProcessOutcomeStaleIdentity = "stale_identity"
 )
@@ -323,6 +324,7 @@ const (
 	WorkAttemptTerminalCapacity        WorkAttemptTerminalState = "capacity"
 	WorkAttemptTerminalOperatorStopped WorkAttemptTerminalState = "operator_stopped"
 	WorkAttemptTerminalMergeRevoked    WorkAttemptTerminalState = "merge_revoked"
+	WorkAttemptTerminalLaneRevoked     WorkAttemptTerminalState = "lane_revoked"
 )
 
 type SchedulerDecisionResult string


### PR DESCRIPTION
## Summary

- Revoke and reap a worker with bounded process-group termination whenever its item leaves every configured worker-owned lane, while preserving the operator-selected destination.
- Fence completion writes by dispatch generation, durable work-attempt lease, and the current tracker lane; record rejected stale completion and stop escalation telemetry.
- Preserve restart recovery invariants, reproduce the six-worker video-studio incident, and document the default observation and drain bounds.

Fixes #1849

## UI Surface Contract

- [x] N/A; this PR does not change a UI surface, layout, density, first viewport, or responsive visibility.
- [x] This PR does not add persistent top-of-screen messaging.
- [x] N/A; there are no visual changes to primary operator screens.

## Test Plan

- [x] `make check`
- [x] `go test ./internal/orchestrator ./internal/runner ./internal/procgroup ./internal/store -count=1`
- [x] `go test -race ./internal/orchestrator ./internal/runner ./internal/procgroup -count=1`