### PR TITLE
fix(recovery): rearm invalid workpad parks

### DIFF
--- a/internal/orchestrator/blocked_cause_recovery.go
+++ b/internal/orchestrator/blocked_cause_recovery.go
@@ -283,12 +283,12 @@ func (o *Orchestrator) recoverCauseBlockedIssue(
 			if issue.WorkpadSignal != nil {
 				switch {
 				case issue.WorkpadSignal.Invalid != nil:
-					if park, ok := o.currentBlockedRecoveryPark(ctx, state, issue); ok {
-						if handled, transitioned := o.reconcileBlockedReadyPullRequest(ctx, state, issue, park, now); handled {
+					reason = BlockedRecoveryHumanHoldReason(issue, o.cfg.AutoPromote.OptoutLabel)
+					if reason == "invalid_workpad_signal" && len(withDependencies.BlockedBy) == 0 {
+						if handled, transitioned := o.reconcileInvalidWorkpadPark(ctx, state, issue, now); handled {
 							return transitioned
 						}
 					}
-					reason = "invalid_workpad_signal"
 				case strings.TrimSpace(issue.WorkpadSignal.HumanAction) != "":
 					reason = "human_action"
 				}
@@ -338,10 +338,8 @@ func (o *Orchestrator) recoverCauseBlockedIssue(
 		return false
 	}
 	if holdReason == "invalid_workpad_signal" {
-		if park, ok := o.currentBlockedRecoveryPark(ctx, state, issue); ok {
-			if handled, transitioned := o.reconcileBlockedReadyPullRequest(ctx, state, issue, park, now); handled {
-				return transitioned
-			}
+		if handled, transitioned := o.reconcileInvalidWorkpadPark(ctx, state, issue, now); handled {
+			return transitioned
 		}
 		o.recordBlockedRecoveryDecision(ctx, state, issue, "hold", holdReason, nil, "")
 		return false
@@ -350,10 +348,7 @@ func (o *Orchestrator) recoverCauseBlockedIssue(
 		o.recordBlockedRecoveryDecision(ctx, state, issue, "defer", "rework_breaker_recovery", nil, park.Signature)
 		return false
 	}
-	park, ok := o.currentBlockedRecoveryPark(ctx, state, issue)
-	if !ok {
-		park, ok = o.currentLegacyRepeatedFailureGitHubRESTBudgetPark(ctx, issue)
-	}
+	park, ok := o.currentBlockedRecoveryParkWithLegacyRESTBudget(ctx, state, issue)
 	if !ok {
 		recoveryCfg := normalizeBlockedRecoveryConfig(o.cfg.BlockedRecovery)
 		reasonCode, reasonFound := o.latestWorkflowLaneReason(ctx, issue, issue.State)
@@ -415,6 +410,25 @@ func (o *Orchestrator) recoverCauseBlockedIssue(
 	delete(state.Blocked, issue.ID)
 	o.logBlockedRecoveryDecision(issue, "transition", "recovery_predicate_satisfied", &park, currentFingerprint)
 	return true
+}
+
+func (o *Orchestrator) reconcileInvalidWorkpadPark(
+	ctx context.Context,
+	state *State,
+	issue connector.Issue,
+	now time.Time,
+) (bool, bool) {
+	park, ok := o.currentBlockedRecoveryParkWithLegacyRESTBudget(ctx, state, issue)
+	if !ok {
+		return false, false
+	}
+	if handled, transitioned := o.reconcileBlockedReadyPullRequest(ctx, state, issue, park, now); handled {
+		return true, transitioned
+	}
+	if !strings.EqualFold(strings.TrimSpace(park.Owner), blockedRecoveryOwnerOrchestrator) {
+		return false, false
+	}
+	return o.reconcileRepeatedFailureGitHubRESTBudgetPark(ctx, state, issue, park, now)
 }
 
 func (o *Orchestrator) reconcileBlockedReadyPullRequest(
@@ -695,9 +709,6 @@ func workpadHasRecordedNonDependencyBlocker(signal *workpad.Signal) bool {
 
 func BlockedRecoveryHumanHoldReason(issue connector.Issue, optoutLabel string) string {
 	if issue.WorkpadSignal != nil {
-		if issue.WorkpadSignal.Invalid != nil {
-			return "invalid_workpad_signal"
-		}
 		if strings.TrimSpace(issue.WorkpadSignal.HumanAction) != "" {
 			return "human_action"
 		}
@@ -708,6 +719,9 @@ func BlockedRecoveryHumanHoldReason(issue connector.Issue, optoutLabel string) s
 		if normalized == "requires-human-review" || configuredOptout != "" && normalized == configuredOptout {
 			return "human_action"
 		}
+	}
+	if issue.WorkpadSignal != nil && issue.WorkpadSignal.Invalid != nil {
+		return "invalid_workpad_signal"
 	}
 	return ""
 }
@@ -747,6 +761,18 @@ func (o *Orchestrator) currentBlockedRecoveryPark(
 		return workflowLaneBlockedRecoveryMetadata{}, false
 	}
 	return *entry.Metadata.BlockedRecovery, true
+}
+
+func (o *Orchestrator) currentBlockedRecoveryParkWithLegacyRESTBudget(
+	ctx context.Context,
+	state *State,
+	issue connector.Issue,
+) (workflowLaneBlockedRecoveryMetadata, bool) {
+	park, ok := o.currentBlockedRecoveryPark(ctx, state, issue)
+	if ok {
+		return park, true
+	}
+	return o.currentLegacyRepeatedFailureGitHubRESTBudgetPark(ctx, issue)
 }
 
 func blockedCauseRecoverySignature(cause string, fingerprint string) string {

--- a/internal/orchestrator/blocked_cause_recovery_test.go
+++ b/internal/orchestrator/blocked_cause_recovery_test.go
@@ -412,12 +412,14 @@ func TestRepeatedFailureParkRecoveryUsesRecordedRESTBudgetFailures(t *testing.T)
 		errorMessage     string
 		remaining        int64
 		consumed         bool
+		workpadStatus    string
 		wantTransition   bool
 		wantAction       string
 		wantReason       string
 		wantSurfaceParts []string
 	}{
 		{name: "budget recovers", errorMessage: budgetError, remaining: 4927, wantTransition: true},
+		{name: "current park recovers with invalid workpad", errorMessage: budgetError, remaining: 4927, workpadStatus: workpad.StatusBlocked, wantTransition: true},
 		{
 			name:             "budget remains exhausted",
 			errorMessage:     budgetError,
@@ -449,6 +451,13 @@ func TestRepeatedFailureParkRecoveryUsesRecordedRESTBudgetFailures(t *testing.T)
 			t.Parallel()
 
 			issue := dependencyAutoUnblockIssue("issue-"+strings.ReplaceAll(tt.name, " ", "-"), blockedStatusState)
+			if tt.workpadStatus != "" {
+				issue.WorkpadSignal = &workpad.Signal{
+					Source:  workpad.SourceStructured,
+					Status:  tt.workpadStatus,
+					Invalid: &workpad.Invalid{Message: "status must be in_progress, blocked, or complete"},
+				}
+			}
 			tracker := &dependencyAutoUnblockConnector{}
 			orch := blockedCauseTestOrchestrator(tracker)
 			metadata := orch.newBlockedRecoveryMetadata(
@@ -572,12 +581,56 @@ func TestRepeatedFailureLegacyRESTBudgetParkRecoversAfterTrackerTransitionDelay(
 		identifier       string
 		stageUpdateDelay time.Duration
 		remaining        int64
+		workpadStatus    string
+		humanAction      string
+		blockedBy        []connector.BlockedRef
+		resolvedBlockers []connector.Issue
+		parkOwner        string
+		blockedSource    BlockedSource
 		wantTransition   bool
+		wantReason       string
 	}{
-		{name: "corp 519 label update lag", identifier: "gopherguides/corp#519", stageUpdateDelay: 7 * time.Second, remaining: 1012, wantTransition: true},
+		{name: "corp 519 invalid blocked workpad", identifier: "gopherguides/corp#519", stageUpdateDelay: 7 * time.Second, remaining: 1012, workpadStatus: workpad.StatusBlocked, wantTransition: true},
 		{name: "corp 520 label update lag", identifier: "gopherguides/corp#520", stageUpdateDelay: 4 * time.Second, remaining: 945, wantTransition: true},
-		{name: "corp 521 label update lag", identifier: "gopherguides/corp#521", stageUpdateDelay: 5 * time.Second, remaining: 944, wantTransition: true},
+		{name: "corp 521 invalid in progress workpad", identifier: "gopherguides/corp#521", stageUpdateDelay: 5 * time.Second, remaining: 944, workpadStatus: workpad.StatusInProgress, wantTransition: true},
 		{name: "later manual reblock", identifier: "gopherguides/corp#522", stageUpdateDelay: 15 * time.Second, remaining: 944},
+		{
+			name:             "invalid workpad with human action",
+			identifier:       "gopherguides/corp#523",
+			stageUpdateDelay: 5 * time.Second,
+			remaining:        944,
+			workpadStatus:    workpad.StatusBlocked,
+			humanAction:      "confirm the recovery",
+			wantReason:       "human_action",
+		},
+		{
+			name:             "invalid workpad with unresolved dependency",
+			identifier:       "gopherguides/corp#524",
+			stageUpdateDelay: 5 * time.Second,
+			remaining:        944,
+			workpadStatus:    workpad.StatusBlocked,
+			blockedBy:        []connector.BlockedRef{{Identifier: "gopherguides/corp#500"}},
+			resolvedBlockers: []connector.Issue{{ID: "issue-500", Identifier: "gopherguides/corp#500", State: "In Progress"}},
+			wantReason:       "invalid_workpad_signal",
+		},
+		{
+			name:             "invalid workpad with operator stop",
+			identifier:       "gopherguides/corp#525",
+			stageUpdateDelay: 5 * time.Second,
+			remaining:        944,
+			workpadStatus:    workpad.StatusInProgress,
+			blockedSource:    BlockedSourceOperatorStop,
+			wantReason:       "operator_stop",
+		},
+		{
+			name:             "invalid workpad with human owned park",
+			identifier:       "gopherguides/corp#526",
+			stageUpdateDelay: 5 * time.Second,
+			remaining:        944,
+			workpadStatus:    workpad.StatusBlocked,
+			parkOwner:        blockedRecoveryOwnerHuman,
+			wantReason:       "invalid_workpad_signal",
+		},
 	}
 
 	for _, tt := range tests {
@@ -586,9 +639,18 @@ func TestRepeatedFailureLegacyRESTBudgetParkRecoversAfterTrackerTransitionDelay(
 
 			issue := dependencyAutoUnblockIssue("issue-"+strings.ReplaceAll(tt.name, " ", "-"), blockedStatusState)
 			issue.Identifier = tt.identifier
+			if tt.workpadStatus != "" {
+				issue.WorkpadSignal = &workpad.Signal{
+					Source:      workpad.SourceStructured,
+					Status:      tt.workpadStatus,
+					HumanAction: tt.humanAction,
+					Invalid:     &workpad.Invalid{Message: "status must be in_progress, blocked, or complete"},
+				}
+			}
+			issue.BlockedBy = tt.blockedBy
 			stageUpdatedAt := parkedAt.Add(tt.stageUpdateDelay)
 			issue.StageUpdatedAt = &stageUpdatedAt
-			tracker := &dependencyAutoUnblockConnector{}
+			tracker := &dependencyAutoUnblockConnector{blockers: tt.resolvedBlockers}
 			orch := blockedCauseTestOrchestrator(tracker)
 			orch.cfg.Project.ID = "gopher-corp"
 			metadata := orch.newBlockedRecoveryMetadata(
@@ -600,6 +662,9 @@ func TestRepeatedFailureLegacyRESTBudgetParkRecoversAfterTrackerTransitionDelay(
 				"Todo",
 				DiffStats{},
 			)
+			if tt.parkOwner != "" {
+				metadata.BlockedRecovery.Owner = tt.parkOwner
+			}
 			metrics := &autoPromoteWorkflowMetricsRecorder{}
 			recordBlockedCausePark(t, metrics, issue, parkedAt, metadata)
 			attempts := &implementProgressAttemptStore{}
@@ -635,9 +700,13 @@ func TestRepeatedFailureLegacyRESTBudgetParkRecoversAfterTrackerTransitionDelay(
 			}}
 			orch.githubRESTBudgetProber = prober
 			state := newState(orch.cfg)
+			blockedSource := tt.blockedSource
+			if blockedSource == "" {
+				blockedSource = BlockedSourceProjectStatus
+			}
 			state.Blocked[issue.ID] = Blocked{
 				Issue:     issue,
-				Source:    BlockedSourceProjectStatus,
+				Source:    blockedSource,
 				BlockedAt: recoveredAt,
 			}
 
@@ -658,6 +727,9 @@ func TestRepeatedFailureLegacyRESTBudgetParkRecoversAfterTrackerTransitionDelay(
 			}
 			if prober.calls != boolInt(tt.wantTransition) {
 				t.Fatalf("probe calls = %d, want %d", prober.calls, boolInt(tt.wantTransition))
+			}
+			if tt.wantReason != "" && state.Blocked[issue.ID].RecoveryReason != tt.wantReason {
+				t.Fatalf("recovery reason = %q, want %q", state.Blocked[issue.ID].RecoveryReason, tt.wantReason)
 			}
 			if tt.wantTransition {
 				query := attempts.queries[0]


### PR DESCRIPTION
## Summary

- reconcile current and legacy repeated-failure REST-budget parks before invalid-workpad holds
- preserve explicit human action, operator stops, human-owned parks, and dependency holds
- cover the corp#519/#521 production shapes plus current-park and negative safety cases

Fixes #1850

## UI Surface Contract

- [x] N/A, or the linked issue explicitly authorizes any high-impact UI surface, layout, density, first-viewport, or responsive visibility tradeoff.
- [x] Persistent top-of-screen messaging is explicitly authorized by the issue, or this PR does not add it.
- [x] Visual changes to primary operator screens include screenshot or browser verification below.

## Test Plan

- [x] `make check`