### PR TITLE
fix(health): detect frozen orchestrator ticks

### DIFF
--- a/docs/dashboard-api.md
+++ b/docs/dashboard-api.md
@@ -198,6 +198,15 @@ Useful endpoints:
 | `/api/v1/webhooks/github` | Accept signed GitHub webhook deliveries with `POST`. |
 | `/api/v1/<issue>` | JSON detail for a known board, pipeline, running, retrying, or blocked issue. |
 
+State responses calculate `snapshot_age_seconds` when the request is served,
+so counts remain attributable to their producer timestamp even if snapshot
+publication stops. Refresh objects include `next_refresh_overdue`; an explicit
+`ready` status becomes `degraded` once `next_refresh_at` is in the past.
+`/health` also reports `snapshot_generated_at`, `snapshot_age_seconds`, the
+current refresh object, and per-project `tick_liveness`. A tick loop that misses
+two effective polling intervals reports `needs_attention`, its last tick,
+overdue next refresh, missed interval count, and `frozen_at` timestamp.
+
 Project state scopes workflow metrics from the fleet snapshot enrichment cache
 instead of rerunning historical database reports for each request. The project
 diagnostics page is the opt-in detail path that loads project-specific runtime

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -282,6 +282,7 @@ type Orchestrator struct {
 	completedStops          map[string]StopRunResult
 	refreshSeq              atomic.Uint64
 	workerGeneration        atomic.Uint64
+	tickWatchdog            *tickWatchdog
 }
 
 type validatorStageResult struct {
@@ -547,6 +548,7 @@ func New(cfg Config, deps Dependencies) (*Orchestrator, error) {
 		pendingMergeRevocations: map[string]mergeRevocation{},
 		mergeRevocationComments: map[string]*mergeRevocationCommentState{},
 		completedStops:          map[string]StopRunResult{},
+		tickWatchdog:            newTickWatchdog(cfg.Project.ID, cfg.PollInterval, logger),
 	}
 	orchestrator.heartbeats = newHeartbeatManager(cfg, deps.Connector, deps.WorkAttempts, now, logger)
 	return orchestrator, nil
@@ -563,6 +565,16 @@ func (o *Orchestrator) Run(ctx context.Context) error {
 	}
 	defer close(o.done)
 	defer o.markGlobalProjectIdle()
+	watchdogCtx, stopWatchdog := context.WithCancel(ctx)
+	watchdogDone := make(chan struct{})
+	go func() {
+		defer close(watchdogDone)
+		o.tickWatchdog.Run(watchdogCtx)
+	}()
+	defer func() {
+		stopWatchdog()
+		<-watchdogDone
+	}()
 	heartbeatCtx, stopHeartbeats := context.WithCancel(ctx)
 	heartbeatsDone := make(chan struct{})
 	var heartbeatResults <-chan heartbeatResult
@@ -585,7 +597,10 @@ func (o *Orchestrator) Run(ctx context.Context) error {
 	defer o.validatorWG.Wait()
 	defer o.releaseRunningSlots(&state)
 	o.recoverDurableWorkAttempts(ctx, &state, time.Now())
-	o.tick(ctx, &state, time.Now())
+	initialTickAt := time.Now()
+	o.startTick(&state, initialTickAt)
+	o.tick(ctx, &state, initialTickAt)
+	o.finishTick(&state)
 	resetTicker(ticker, state.PollInterval)
 
 	for {
@@ -593,13 +608,19 @@ func (o *Orchestrator) Run(ctx context.Context) error {
 		case <-ctx.Done():
 			return ctx.Err()
 		case now := <-ticker.C:
+			o.startTick(&state, now)
 			o.tick(ctx, &state, now)
+			o.finishTick(&state)
 			resetTicker(ticker, state.PollInterval)
 		case request := <-o.refreshes:
+			o.startTick(&state, time.Now())
 			o.tickManual(ctx, &state, request)
+			o.finishTick(&state)
 			resetTicker(ticker, state.PollInterval)
 		case request := <-o.reconciles:
+			o.startTick(&state, time.Now())
 			o.reconcileTarget(ctx, &state, request)
+			o.finishTick(&state)
 			resetTicker(ticker, state.PollInterval)
 		case request := <-o.capacityClearRequests:
 			request.reply <- capacityClearReply{cleared: o.clearBackendCapacity(&state, request.scope, request.at)}
@@ -607,7 +628,9 @@ func (o *Orchestrator) Run(ctx context.Context) error {
 			result := o.requestProjectFailureBreakerCanary(&state, request.at)
 			request.reply <- result
 			if result.Requested {
+				o.startTick(&state, time.Now())
 				o.tick(ctx, &state, request.at)
+				o.finishTick(&state)
 				resetTicker(ticker, state.PollInterval)
 			}
 		case request := <-o.stopRequests:
@@ -634,11 +657,37 @@ func (o *Orchestrator) Run(ctx context.Context) error {
 			request.reply <- o.handleOperatorMove(&state, request.request, request.at)
 		case update := <-o.configUpdates:
 			o.applyRuntimeUpdate(&state, update.update, ticker)
+			o.finishTick(&state)
 			update.reply <- struct{}{}
 		case request := <-o.stateRequests:
 			request.reply <- state.clone()
 		}
 	}
+}
+
+func (o *Orchestrator) TickLiveness(now time.Time) telemetry.TickLiveness {
+	if o == nil || o.tickWatchdog == nil {
+		return telemetry.TickLiveness{Status: telemetry.TickLivenessStatusInitializing}
+	}
+	return o.tickWatchdog.Snapshot(now)
+}
+
+func (o *Orchestrator) startTick(state *State, at time.Time) {
+	if o == nil || o.tickWatchdog == nil || state == nil {
+		return
+	}
+	nextRefreshAt := time.Time{}
+	if state.PollInterval > 0 {
+		nextRefreshAt = at.Add(state.PollInterval)
+	}
+	o.tickWatchdog.Advance(at, nextRefreshAt, state.PollInterval)
+}
+
+func (o *Orchestrator) finishTick(state *State) {
+	if o == nil || o.tickWatchdog == nil || state == nil {
+		return
+	}
+	o.tickWatchdog.Schedule(state.NextRefreshAt, state.PollInterval)
 }
 
 func (o *Orchestrator) ClearBackendCapacity(ctx context.Context, scope string) ([]BackendOutage, error) {

--- a/internal/orchestrator/tick_watchdog.go
+++ b/internal/orchestrator/tick_watchdog.go
@@ -1,0 +1,187 @@
+package orchestrator
+
+import (
+	"context"
+	"log/slog"
+	"sync"
+	"time"
+
+	"github.com/digitaldrywood/detent/internal/telemetry"
+)
+
+const (
+	tickWatchdogIntervalCount = int64(2)
+	maxTickWatchdogCheckEvery = 30 * time.Second
+)
+
+type tickWatchdog struct {
+	mu            sync.RWMutex
+	projectID     string
+	status        telemetry.TickLivenessStatus
+	lastTickAt    time.Time
+	nextRefreshAt time.Time
+	interval      time.Duration
+	frozenAt      time.Time
+	logger        *slog.Logger
+}
+
+func newTickWatchdog(projectID string, interval time.Duration, logger *slog.Logger) *tickWatchdog {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	return &tickWatchdog{
+		projectID: projectID,
+		status:    telemetry.TickLivenessStatusInitializing,
+		interval:  interval,
+		logger:    logger,
+	}
+}
+
+func (w *tickWatchdog) Advance(at time.Time, nextRefreshAt time.Time, interval time.Duration) {
+	if w == nil || at.IsZero() {
+		return
+	}
+	at = at.UTC()
+	if nextRefreshAt.IsZero() && interval > 0 {
+		nextRefreshAt = at.Add(interval)
+	}
+	if !nextRefreshAt.IsZero() {
+		nextRefreshAt = nextRefreshAt.UTC()
+	}
+
+	w.mu.Lock()
+	recovered := w.status == telemetry.TickLivenessStatusNeedsAttention
+	w.lastTickAt = at
+	w.nextRefreshAt = nextRefreshAt
+	if interval > 0 {
+		w.interval = interval
+	}
+	w.frozenAt = time.Time{}
+	w.status = telemetry.TickLivenessStatusReady
+	w.mu.Unlock()
+
+	if recovered {
+		w.logger.Info("orchestrator tick loop recovered", "project_id", w.projectID, "last_tick_at", at)
+	}
+}
+
+func (w *tickWatchdog) Schedule(nextRefreshAt time.Time, interval time.Duration) {
+	if w == nil {
+		return
+	}
+	if !nextRefreshAt.IsZero() {
+		nextRefreshAt = nextRefreshAt.UTC()
+	}
+	w.mu.Lock()
+	w.nextRefreshAt = nextRefreshAt
+	if interval > 0 {
+		w.interval = interval
+	}
+	w.mu.Unlock()
+}
+
+func (w *tickWatchdog) Evaluate(now time.Time) telemetry.TickLiveness {
+	if w == nil {
+		return telemetry.TickLiveness{Status: telemetry.TickLivenessStatusInitializing}
+	}
+	now = now.UTC()
+	w.mu.Lock()
+	previous := w.status
+	missed := missedTickIntervals(w.lastTickAt, now, w.interval)
+	if !w.lastTickAt.IsZero() && missed >= tickWatchdogIntervalCount {
+		w.status = telemetry.TickLivenessStatusNeedsAttention
+		if w.frozenAt.IsZero() {
+			w.frozenAt = w.lastTickAt
+		}
+	}
+	liveness := w.livenessLocked(now)
+	w.mu.Unlock()
+
+	if previous != telemetry.TickLivenessStatusNeedsAttention && liveness.Status == telemetry.TickLivenessStatusNeedsAttention {
+		w.logger.Warn(
+			"orchestrator tick loop frozen",
+			"project_id", liveness.ProjectID,
+			"last_tick_at", liveness.LastTickAt,
+			"next_refresh_at", liveness.NextRefreshAt,
+			"missed_intervals", liveness.MissedIntervals,
+		)
+	}
+	return liveness
+}
+
+func (w *tickWatchdog) Snapshot(now time.Time) telemetry.TickLiveness {
+	if w == nil {
+		return telemetry.TickLiveness{Status: telemetry.TickLivenessStatusInitializing}
+	}
+	w.mu.RLock()
+	defer w.mu.RUnlock()
+	return w.livenessLocked(now.UTC())
+}
+
+func (w *tickWatchdog) Run(ctx context.Context) {
+	if w == nil {
+		return
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	ticker := time.NewTicker(w.checkEvery())
+	defer ticker.Stop()
+	w.run(ctx, ticker.C)
+}
+
+func (w *tickWatchdog) checkEvery() time.Duration {
+	w.mu.RLock()
+	defer w.mu.RUnlock()
+	return tickWatchdogCheckEvery(w.interval)
+}
+
+func (w *tickWatchdog) run(ctx context.Context, checks <-chan time.Time) {
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case now := <-checks:
+			w.Evaluate(now)
+		}
+	}
+}
+
+func (w *tickWatchdog) livenessLocked(now time.Time) telemetry.TickLiveness {
+	return telemetry.TickLiveness{
+		ProjectID:             w.projectID,
+		Status:                w.status,
+		LastTickAt:            watchdogTimePointer(w.lastTickAt),
+		NextRefreshAt:         watchdogTimePointer(w.nextRefreshAt),
+		NextRefreshOverdue:    !w.nextRefreshAt.IsZero() && !now.IsZero() && now.After(w.nextRefreshAt),
+		FrozenAt:              watchdogTimePointer(w.frozenAt),
+		MissedIntervals:       missedTickIntervals(w.lastTickAt, now, w.interval),
+		WatchdogIntervalCount: tickWatchdogIntervalCount,
+	}
+}
+
+func missedTickIntervals(lastTickAt time.Time, now time.Time, interval time.Duration) int64 {
+	if lastTickAt.IsZero() || now.IsZero() || interval <= 0 || now.Before(lastTickAt) {
+		return 0
+	}
+	return int64(now.Sub(lastTickAt) / interval)
+}
+
+func tickWatchdogCheckEvery(interval time.Duration) time.Duration {
+	checkEvery := interval / 2
+	if checkEvery <= 0 {
+		checkEvery = time.Millisecond
+	}
+	if checkEvery > maxTickWatchdogCheckEvery {
+		return maxTickWatchdogCheckEvery
+	}
+	return checkEvery
+}
+
+func watchdogTimePointer(value time.Time) *time.Time {
+	if value.IsZero() {
+		return nil
+	}
+	copy := value
+	return &copy
+}

--- a/internal/orchestrator/tick_watchdog_test.go
+++ b/internal/orchestrator/tick_watchdog_test.go
@@ -1,0 +1,120 @@
+package orchestrator
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/digitaldrywood/detent/internal/telemetry"
+)
+
+func TestTickWatchdogEvaluatesLoopLiveness(t *testing.T) {
+	t.Parallel()
+
+	lastTickAt := time.Date(2026, 8, 17, 1, 21, 52, 0, time.UTC)
+	interval := 8 * time.Minute
+	tests := []struct {
+		name         string
+		now          time.Time
+		advance      bool
+		wantStatus   telemetry.TickLivenessStatus
+		wantOverdue  bool
+		wantMissed   int64
+		wantFrozenAt time.Time
+	}{
+		{
+			name:       "loop has not started",
+			now:        lastTickAt,
+			wantStatus: telemetry.TickLivenessStatusInitializing,
+		},
+		{
+			name:       "healthy loop remains ready",
+			now:        lastTickAt.Add(interval),
+			advance:    true,
+			wantStatus: telemetry.TickLivenessStatusReady,
+			wantMissed: 1,
+		},
+		{
+			name:        "past due loop is visible before watchdog threshold",
+			now:         lastTickAt.Add(interval + time.Second),
+			advance:     true,
+			wantStatus:  telemetry.TickLivenessStatusReady,
+			wantOverdue: true,
+			wantMissed:  1,
+		},
+		{
+			name:         "frozen loop needs attention after two intervals",
+			now:          lastTickAt.Add(2 * interval),
+			advance:      true,
+			wantStatus:   telemetry.TickLivenessStatusNeedsAttention,
+			wantOverdue:  true,
+			wantMissed:   2,
+			wantFrozenAt: lastTickAt,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			watchdog := newTickWatchdog("detent", interval, nil)
+			if tt.advance {
+				watchdog.Advance(lastTickAt, lastTickAt.Add(interval), interval)
+			}
+			got := watchdog.Evaluate(tt.now)
+			if got.Status != tt.wantStatus {
+				t.Fatalf("Status = %q, want %q", got.Status, tt.wantStatus)
+			}
+			if got.NextRefreshOverdue != tt.wantOverdue {
+				t.Fatalf("NextRefreshOverdue = %v, want %v", got.NextRefreshOverdue, tt.wantOverdue)
+			}
+			if got.MissedIntervals != tt.wantMissed {
+				t.Fatalf("MissedIntervals = %d, want %d", got.MissedIntervals, tt.wantMissed)
+			}
+			switch {
+			case tt.wantFrozenAt.IsZero() && got.FrozenAt != nil:
+				t.Fatalf("FrozenAt = %v, want nil", got.FrozenAt)
+			case !tt.wantFrozenAt.IsZero() && (got.FrozenAt == nil || !got.FrozenAt.Equal(tt.wantFrozenAt)):
+				t.Fatalf("FrozenAt = %v, want %v", got.FrozenAt, tt.wantFrozenAt)
+			}
+		})
+	}
+}
+
+func TestTickWatchdogRunsOutsideTickLoop(t *testing.T) {
+	t.Parallel()
+
+	lastTickAt := time.Date(2026, 8, 17, 1, 21, 52, 0, time.UTC)
+	interval := 8 * time.Minute
+	watchdog := newTickWatchdog("detent", interval, nil)
+	watchdog.Advance(lastTickAt, lastTickAt.Add(interval), interval)
+	checks := make(chan time.Time)
+	ctx, cancel := context.WithCancel(t.Context())
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		watchdog.run(ctx, checks)
+	}()
+
+	checks <- lastTickAt.Add(2 * interval)
+	deadline := time.NewTimer(time.Second)
+	ticker := time.NewTicker(time.Millisecond)
+	defer deadline.Stop()
+	defer ticker.Stop()
+	for {
+		if got := watchdog.Snapshot(lastTickAt.Add(2 * interval)); got.Status == telemetry.TickLivenessStatusNeedsAttention {
+			break
+		}
+		select {
+		case <-deadline.C:
+			t.Fatal("watchdog did not mark frozen loop needs_attention")
+		case <-ticker.C:
+		}
+	}
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("watchdog did not stop after cancellation")
+	}
+}

--- a/internal/project/registry.go
+++ b/internal/project/registry.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	globalconfig "github.com/digitaldrywood/detent/internal/config/global"
+	"github.com/digitaldrywood/detent/internal/telemetry"
 )
 
 type HealthStatus string
@@ -171,6 +172,25 @@ func (r *Registry) Health() []Health {
 		health = append(health, pendingHealth(pending[id]))
 	}
 	return health
+}
+
+func (r *Registry) TickLiveness(now time.Time) []telemetry.TickLiveness {
+	if r == nil {
+		return nil
+	}
+	projects := r.List()
+	liveness := make([]telemetry.TickLiveness, 0, len(projects))
+	for _, trackedProject := range projects {
+		if trackedProject == nil {
+			continue
+		}
+		orchestrator := trackedProject.Orchestrator()
+		if orchestrator == nil {
+			continue
+		}
+		liveness = append(liveness, orchestrator.TickLiveness(now))
+	}
+	return liveness
 }
 
 func projectHealth(trackedProject *Project) Health {

--- a/internal/telemetry/snapshot.go
+++ b/internal/telemetry/snapshot.go
@@ -57,6 +57,25 @@ type Snapshot struct {
 	TokenTrend              []TokenTrendPoint   `json:"token_trend,omitempty"`
 }
 
+func (s Snapshot) AgeSeconds(now time.Time) int64 {
+	if s.GeneratedAt.IsZero() || now.IsZero() || now.Before(s.GeneratedAt) {
+		return 0
+	}
+	return int64(now.Sub(s.GeneratedAt) / time.Second)
+}
+
+func (s Snapshot) WithFreshness(now time.Time) Snapshot {
+	s.Refresh = s.Refresh.WithFreshness(now)
+	if len(s.Projects) == 0 {
+		return s
+	}
+	s.Projects = append([]ProjectSnapshot(nil), s.Projects...)
+	for index := range s.Projects {
+		s.Projects[index].Refresh = s.Projects[index].Refresh.WithFreshness(now)
+	}
+	return s
+}
+
 type CICondition struct {
 	ProjectID           string    `json:"project_id,omitempty"`
 	UnstartedCheckCount int       `json:"unstarted_check_count"`
@@ -328,6 +347,25 @@ const (
 	RefreshStatusDegraded     RefreshStatus = "degraded"
 )
 
+type TickLivenessStatus string
+
+const (
+	TickLivenessStatusInitializing   TickLivenessStatus = "initializing"
+	TickLivenessStatusReady          TickLivenessStatus = "ready"
+	TickLivenessStatusNeedsAttention TickLivenessStatus = "needs_attention"
+)
+
+type TickLiveness struct {
+	ProjectID             string             `json:"project_id,omitempty"`
+	Status                TickLivenessStatus `json:"status"`
+	LastTickAt            *time.Time         `json:"last_tick_at,omitempty"`
+	NextRefreshAt         *time.Time         `json:"next_refresh_at,omitempty"`
+	NextRefreshOverdue    bool               `json:"next_refresh_overdue"`
+	FrozenAt              *time.Time         `json:"frozen_at,omitempty"`
+	MissedIntervals       int64              `json:"missed_intervals"`
+	WatchdogIntervalCount int64              `json:"watchdog_interval_count"`
+}
+
 type RefreshAttemptStatus string
 
 const (
@@ -355,6 +393,7 @@ type Refresh struct {
 	Status              RefreshStatus   `json:"status,omitempty"`
 	LastRefreshAt       *time.Time      `json:"last_refresh_at,omitempty"`
 	NextRefreshAt       *time.Time      `json:"next_refresh_at,omitempty"`
+	NextRefreshOverdue  bool            `json:"next_refresh_overdue"`
 	LastError           string          `json:"last_error,omitempty"`
 	LastErrorAt         *time.Time      `json:"last_error_at,omitempty"`
 	Sources             []RefreshSource `json:"sources,omitempty"`
@@ -402,6 +441,9 @@ func (r Refresh) ReadinessStatus() RefreshStatus {
 	case RefreshStatusInitializing:
 		return RefreshStatusInitializing
 	case RefreshStatusReady:
+		if r.NextRefreshOverdue {
+			return RefreshStatusDegraded
+		}
 		return RefreshStatusReady
 	case RefreshStatusDegraded:
 		return RefreshStatusDegraded
@@ -413,6 +455,24 @@ func (r Refresh) ReadinessStatus() RefreshStatus {
 		return RefreshStatusReady
 	}
 	return RefreshStatusInitializing
+}
+
+func (r Refresh) WithFreshness(now time.Time) Refresh {
+	r.NextRefreshOverdue = r.NextRefreshAt != nil && !now.IsZero() && now.After(*r.NextRefreshAt)
+	if !refreshHasReadinessSignal(r) {
+		return r
+	}
+	r.Status = r.ReadinessStatus()
+	return r
+}
+
+func refreshHasReadinessSignal(r Refresh) bool {
+	return strings.TrimSpace(string(r.Status)) != "" ||
+		r.LastRefreshAt != nil ||
+		r.NextRefreshAt != nil ||
+		strings.TrimSpace(r.LastError) != "" ||
+		r.LastErrorAt != nil ||
+		len(r.Sources) > 0
 }
 
 func (r Refresh) Ready() bool {

--- a/internal/telemetry/snapshot_test.go
+++ b/internal/telemetry/snapshot_test.go
@@ -726,6 +726,83 @@ func TestRefreshReadinessStatus(t *testing.T) {
 	}
 }
 
+func TestRefreshReadinessStatusAt(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 8, 17, 1, 39, 0, 0, time.UTC)
+	lastRefreshAt := now.Add(-18 * time.Minute)
+	tests := []struct {
+		name          string
+		nextRefreshAt time.Time
+		wantStatus    telemetry.RefreshStatus
+		wantOverdue   bool
+	}{
+		{
+			name:          "healthy refresh remains ready",
+			nextRefreshAt: now.Add(time.Minute),
+			wantStatus:    telemetry.RefreshStatusReady,
+		},
+		{
+			name:          "past due refresh becomes degraded",
+			nextRefreshAt: now.Add(-9 * time.Minute),
+			wantStatus:    telemetry.RefreshStatusDegraded,
+			wantOverdue:   true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			refresh := (telemetry.Refresh{
+				Status:        telemetry.RefreshStatusReady,
+				LastRefreshAt: &lastRefreshAt,
+				NextRefreshAt: &tt.nextRefreshAt,
+			}).WithFreshness(now)
+			if got := refresh.ReadinessStatus(); got != tt.wantStatus {
+				t.Fatalf("ReadinessStatus() = %q, want %q", got, tt.wantStatus)
+			}
+			if refresh.NextRefreshOverdue != tt.wantOverdue {
+				t.Fatalf("NextRefreshOverdue = %v, want %v", refresh.NextRefreshOverdue, tt.wantOverdue)
+			}
+		})
+	}
+}
+
+func TestSnapshotWithFreshness(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 8, 17, 1, 39, 0, 0, time.UTC)
+	generatedAt := now.Add(-18 * time.Minute)
+	nextRefreshAt := now.Add(-9 * time.Minute)
+	snapshot := (telemetry.Snapshot{
+		GeneratedAt: generatedAt,
+		Refresh: telemetry.Refresh{
+			Status:        telemetry.RefreshStatusReady,
+			LastRefreshAt: &generatedAt,
+			NextRefreshAt: &nextRefreshAt,
+		},
+		Projects: []telemetry.ProjectSnapshot{{
+			Project: telemetry.Project{ID: "detent"},
+			Refresh: telemetry.Refresh{
+				Status:        telemetry.RefreshStatusReady,
+				LastRefreshAt: &generatedAt,
+				NextRefreshAt: &nextRefreshAt,
+			},
+		}},
+	}).WithFreshness(now)
+
+	if got := snapshot.AgeSeconds(now); got != int64((18*time.Minute)/time.Second) {
+		t.Fatalf("AgeSeconds() = %d, want 1080", got)
+	}
+	if snapshot.Refresh.ReadinessStatus() != telemetry.RefreshStatusDegraded || !snapshot.Refresh.NextRefreshOverdue {
+		t.Fatalf("Refresh = %#v, want overdue degraded refresh", snapshot.Refresh)
+	}
+	if snapshot.Projects[0].Refresh.ReadinessStatus() != telemetry.RefreshStatusDegraded || !snapshot.Projects[0].Refresh.NextRefreshOverdue {
+		t.Fatalf("Projects[0].Refresh = %#v, want overdue degraded refresh", snapshot.Projects[0].Refresh)
+	}
+}
+
 func TestRefreshReadinessJSON(t *testing.T) {
 	t.Parallel()
 

--- a/internal/web/api.go
+++ b/internal/web/api.go
@@ -69,9 +69,9 @@ func (s *Server) apiState(c echo.Context) error {
 			return c.JSON(http.StatusOK, snapshotErrorResponse(demoBaseTime, "snapshot_unavailable", "Snapshot unavailable"))
 		}
 		snapshot := demofixtures.SnapshotForScenario(scenario.ProjectID, scenario.Variant)
-		return c.JSON(http.StatusOK, stateResponse(snapshot, generatedAt(snapshot, demoBaseTime), s.instanceName(), s.build))
+		return c.JSON(http.StatusOK, stateResponse(snapshot, generatedAt(snapshot, demoBaseTime), demoBaseTime, s.instanceName(), s.build))
 	}
-	now := apiNow()
+	now := s.now()
 	snapshot, ok := s.hub.Latest()
 	if !ok {
 		return c.JSON(http.StatusOK, snapshotErrorResponse(now, "snapshot_unavailable", "Snapshot unavailable"))
@@ -81,7 +81,7 @@ func (s *Server) apiState(c echo.Context) error {
 		snapshot = s.withManualRefresh(snapshot)
 	}
 
-	return c.JSON(http.StatusOK, stateResponse(snapshot, generatedAt(snapshot, now), s.instanceName(), s.build))
+	return c.JSON(http.StatusOK, stateResponse(snapshot, generatedAt(snapshot, now), now, s.instanceName(), s.build))
 }
 
 func (s *Server) apiProject(c echo.Context) error {
@@ -115,9 +115,9 @@ func (s *Server) apiProjectState(c echo.Context, projectID string) error {
 			return c.JSON(http.StatusNotFound, errorResponse("project_not_found", "Project not found"))
 		}
 		scoped := projectScopedSnapshotForProject(snapshot, telemetry.Project{ID: project.ID, DisplayName: project.Name, URL: project.URL, Pool: project.Pool})
-		return c.JSON(http.StatusOK, stateResponse(scoped, generatedAt(scoped, demoBaseTime), s.instanceName(), s.build))
+		return c.JSON(http.StatusOK, stateResponse(scoped, generatedAt(scoped, demoBaseTime), demoBaseTime, s.instanceName(), s.build))
 	}
-	now := apiNow()
+	now := s.now()
 	snapshot, ok := s.hub.Latest()
 	if !ok {
 		return c.JSON(http.StatusOK, snapshotErrorResponse(now, "snapshot_unavailable", "Snapshot unavailable"))
@@ -136,7 +136,7 @@ func (s *Server) apiProjectState(c echo.Context, projectID string) error {
 	})
 	scopedSnapshot = s.withManualRefresh(scopedSnapshot)
 
-	return c.JSON(http.StatusOK, stateResponse(scopedSnapshot, generatedAt(scopedSnapshot, now), s.instanceName(), s.build))
+	return c.JSON(http.StatusOK, stateResponse(scopedSnapshot, generatedAt(scopedSnapshot, now), now, s.instanceName(), s.build))
 }
 
 func (s *Server) apiTimeSeries(c echo.Context) error {
@@ -457,9 +457,11 @@ func (s *Server) handleHTTPError(err error, c echo.Context) {
 	}
 }
 
-func stateResponse(snapshot telemetry.Snapshot, generatedAt time.Time, instanceName string, build buildinfo.Info) stateAPIResponse {
+func stateResponse(snapshot telemetry.Snapshot, generatedAt time.Time, observedAt time.Time, instanceName string, build buildinfo.Info) stateAPIResponse {
+	snapshot = snapshot.WithFreshness(observedAt)
 	return stateAPIResponse{
 		GeneratedAt:        generatedAt,
+		SnapshotAgeSeconds: snapshot.AgeSeconds(observedAt),
 		Status:             runtimeStatus(snapshot),
 		Shutdown:           shutdownResponse(snapshot.Shutdown),
 		Update:             snapshot.Update,
@@ -1411,6 +1413,7 @@ func snapshotErrorResponse(generatedAt time.Time, code string, message string) s
 
 type stateAPIResponse struct {
 	GeneratedAt        time.Time                    `json:"generated_at"`
+	SnapshotAgeSeconds int64                        `json:"snapshot_age_seconds"`
 	Status             string                       `json:"status"`
 	Shutdown           shutdownAPIResponse          `json:"shutdown"`
 	Update             telemetry.Update             `json:"update,omitzero"`

--- a/internal/web/openapi.yaml
+++ b/internal/web/openapi.yaml
@@ -1055,9 +1055,10 @@ components:
       enum: [available, live, last_known, expired, unavailable, corrupt]
     State:
       type: object
-      required: [generated_at, status, shutdown, instance, projects, stats, board]
+      required: [generated_at, snapshot_age_seconds, status, shutdown, instance, projects, stats, board]
       properties:
         generated_at: {type: string, format: date-time}
+        snapshot_age_seconds: {type: integer, format: int64, minimum: 0}
         status: {type: string, enum: [running, draining]}
         shutdown: {$ref: "#/components/schemas/GenericObject"}
         instance: {$ref: "#/components/schemas/GenericObject"}

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -62,6 +62,11 @@ type Dependencies struct {
 	Chat                chatpkg.Provider
 	IssueExplainer      IssueExplainer
 	HealthNotifications healthnotify.FailureReader
+	TickLiveness        TickLivenessSource
+}
+
+type TickLivenessSource interface {
+	TickLiveness(time.Time) []telemetry.TickLiveness
 }
 
 type Mode string
@@ -109,6 +114,7 @@ type Config struct {
 	RuntimeLogPath        string
 	ServerAddress         string
 	Demo                  DemoConfig
+	Now                   func() time.Time
 }
 
 type Server struct {
@@ -168,6 +174,8 @@ type Server struct {
 	chat                *chatpkg.Service
 	issueExplainer      IssueExplainer
 	healthNotifications healthnotify.FailureReader
+	tickLiveness        TickLivenessSource
+	now                 func() time.Time
 	operatorTools       *operatortool.Executor
 	mcpHTTP             *mcp.HTTPHandler
 }
@@ -220,6 +228,10 @@ func NewServer(cfg Config, deps Dependencies) (*Server, error) {
 	sessions := magicLinks
 	if oidcEnabled {
 		sessions = oidcSessions
+	}
+	tickLiveness := deps.TickLiveness
+	if tickLiveness == nil && deps.Registry != nil {
+		tickLiveness = deps.Registry
 	}
 
 	server := &Server{
@@ -277,6 +289,8 @@ func NewServer(cfg Config, deps Dependencies) (*Server, error) {
 		identityAllowlist:   identityAllowlist,
 		issueExplainer:      deps.IssueExplainer,
 		healthNotifications: deps.HealthNotifications,
+		tickLiveness:        tickLiveness,
+		now:                 cfg.now(),
 	}
 	if !magicLinksEnabled && !oidcEnabled {
 		server.sessions = nil
@@ -1040,20 +1054,20 @@ func (s *Server) sidebarProjectContext(selectedProjectID string, projects []temp
 func (s *Server) latestSnapshot(ctx context.Context) telemetry.Snapshot {
 	snapshot, ok := s.hub.Latest()
 	if !ok {
-		return s.withManualRefresh(s.enrichSnapshot(ctx, telemetry.Snapshot{}))
+		return s.withManualRefresh(s.enrichSnapshot(ctx, telemetry.Snapshot{})).WithFreshness(s.now())
 	}
-	return s.withManualRefresh(s.cachedEnrichedSnapshot(ctx, snapshot))
+	return s.withManualRefresh(s.cachedEnrichedSnapshot(ctx, snapshot)).WithFreshness(s.now())
 }
 
 func (s *Server) latestBoardSnapshot() (telemetry.Snapshot, bool) {
 	snapshot, ok := s.hub.Latest()
 	if !ok {
-		return s.withManualRefresh(telemetry.Snapshot{}), false
+		return s.withManualRefresh(telemetry.Snapshot{}).WithFreshness(s.now()), false
 	}
 	if enriched, ok := s.snapshots.get(snapshot); ok {
-		return s.withManualRefresh(enriched), true
+		return s.withManualRefresh(enriched).WithFreshness(s.now()), true
 	}
-	return s.withManualRefresh(snapshot), false
+	return s.withManualRefresh(snapshot).WithFreshness(s.now()), false
 }
 
 func (s *Server) health(c echo.Context) error {
@@ -1061,6 +1075,7 @@ func (s *Server) health(c echo.Context) error {
 		return err
 	}
 	status := "ok"
+	now := s.now().UTC()
 	sessionsRemaining := 0
 	updateStatus := telemetry.Update{}
 	backendOutages := []telemetry.BackendOutage{}
@@ -1071,8 +1086,15 @@ func (s *Server) health(c echo.Context) error {
 	dispatch := telemetry.DispatchStatus{}
 	dispatchStalls := []telemetry.DispatchStatus{}
 	notificationFailures := []healthnotify.Failure{}
+	refresh := telemetry.Refresh{}
+	snapshotGeneratedAt := time.Time{}
+	snapshotAgeSeconds := int64(0)
 	if s.hub != nil {
 		if snapshot, ok := s.hub.Latest(); ok {
+			snapshot = snapshot.WithFreshness(now)
+			snapshotGeneratedAt = snapshot.GeneratedAt
+			snapshotAgeSeconds = snapshot.AgeSeconds(now)
+			refresh = snapshot.Refresh
 			updateStatus = snapshot.Update
 			backendOutages = append(backendOutages, snapshot.BackendOutages...)
 			failureBreakers = append(failureBreakers, snapshot.FailureBreakers...)
@@ -1086,6 +1108,10 @@ func (s *Server) health(c echo.Context) error {
 				sessionsRemaining = snapshot.Shutdown.SessionsRemaining
 			}
 		}
+	}
+	tickLiveness := []telemetry.TickLiveness{}
+	if s.tickLiveness != nil {
+		tickLiveness = s.tickLiveness.TickLiveness(now)
 	}
 	if s.healthNotifications != nil {
 		failures, err := s.healthNotifications.Failures(c.Request().Context())
@@ -1106,13 +1132,13 @@ func (s *Server) health(c echo.Context) error {
 		checks["demo_clock"] = s.demo.clock
 	}
 	projectStatus, projectHealth := s.projectHealth()
-	projectHealth = applyNeedsAttentionToProjectHealth(projectHealth, dispatchStalls, ciUnavailable, failureBreakers, backendOutages)
+	projectHealth = applyNeedsAttentionToProjectHealth(projectHealth, dispatchStalls, ciUnavailable, failureBreakers, backendOutages, tickLiveness)
 	var budgets []healthBudget
 	var workflows []healthWorkflowSource
 	if status != "draining" {
 		budgets = s.enforcedBudgets()
 		workflows = s.workflowSources()
-		if len(ciUnavailable) > 0 || len(dispatchStalls) > 0 || len(failureBreakers) > 0 || len(backendOutages) > 0 {
+		if len(ciUnavailable) > 0 || len(dispatchStalls) > 0 || len(failureBreakers) > 0 || len(backendOutages) > 0 || tickLivenessNeedsAttention(tickLiveness) {
 			status = "needs_attention"
 		}
 	}
@@ -1138,11 +1164,15 @@ func (s *Server) health(c echo.Context) error {
 		DispatchStalls:       dispatchStalls,
 		NotificationFailures: notificationFailures,
 		Projects:             projectHealth,
+		Refresh:              refresh,
+		SnapshotGeneratedAt:  snapshotGeneratedAt,
+		SnapshotAgeSeconds:   snapshotAgeSeconds,
+		TickLiveness:         tickLiveness,
 	})
 }
 
-func applyNeedsAttentionToProjectHealth(projects []healthProject, stalls []telemetry.DispatchStatus, ciUnavailable []telemetry.CICondition, breakers []telemetry.FailureBreaker, outages []telemetry.BackendOutage) []healthProject {
-	needsAttention := make(map[string]struct{}, len(stalls)+len(ciUnavailable)+len(breakers)+len(outages))
+func applyNeedsAttentionToProjectHealth(projects []healthProject, stalls []telemetry.DispatchStatus, ciUnavailable []telemetry.CICondition, breakers []telemetry.FailureBreaker, outages []telemetry.BackendOutage, tickLiveness []telemetry.TickLiveness) []healthProject {
+	needsAttention := make(map[string]struct{}, len(stalls)+len(ciUnavailable)+len(breakers)+len(outages)+len(tickLiveness))
 	for _, stall := range stalls {
 		if projectID := strings.TrimSpace(stall.ProjectID); projectID != "" && stall.Stalled {
 			needsAttention[projectID] = struct{}{}
@@ -1163,12 +1193,26 @@ func applyNeedsAttentionToProjectHealth(projects []healthProject, stalls []telem
 			needsAttention[projectID] = struct{}{}
 		}
 	}
+	for _, liveness := range tickLiveness {
+		if projectID := strings.TrimSpace(liveness.ProjectID); projectID != "" && liveness.Status == telemetry.TickLivenessStatusNeedsAttention {
+			needsAttention[projectID] = struct{}{}
+		}
+	}
 	for index := range projects {
 		if _, ok := needsAttention[strings.TrimSpace(projects[index].ProjectID)]; ok {
 			projects[index].Status = "needs_human_attention"
 		}
 	}
 	return projects
+}
+
+func tickLivenessNeedsAttention(values []telemetry.TickLiveness) bool {
+	for _, value := range values {
+		if value.Status == telemetry.TickLivenessStatusNeedsAttention {
+			return true
+		}
+	}
+	return false
 }
 
 func (s *Server) projectHealth() (string, []healthProject) {
@@ -1179,7 +1223,7 @@ func (s *Server) projectHealth() (string, []healthProject) {
 	status := "ok"
 	projectHealth := s.registry.Health()
 	activeHoursByProject := make(map[string]telemetry.ActiveHours)
-	now := time.Now().UTC()
+	now := s.now().UTC()
 	for _, trackedProject := range s.registry.List() {
 		if trackedProject == nil {
 			continue
@@ -1282,6 +1326,13 @@ func (cfg Config) logger() *slog.Logger {
 		return cfg.Logger
 	}
 	return slog.Default()
+}
+
+func (cfg Config) now() func() time.Time {
+	if cfg.Now != nil {
+		return cfg.Now
+	}
+	return time.Now
 }
 
 func (cfg Config) mode() Mode {
@@ -1435,6 +1486,10 @@ type healthResponse struct {
 	DispatchStalls       []telemetry.DispatchStatus   `json:"dispatch_stalls,omitempty"`
 	NotificationFailures []healthnotify.Failure       `json:"health_notification_failures,omitempty"`
 	Projects             []healthProject              `json:"projects,omitempty"`
+	Refresh              telemetry.Refresh            `json:"refresh"`
+	SnapshotGeneratedAt  time.Time                    `json:"snapshot_generated_at,omitzero"`
+	SnapshotAgeSeconds   int64                        `json:"snapshot_age_seconds"`
+	TickLiveness         []telemetry.TickLiveness     `json:"tick_liveness"`
 }
 
 type healthEnvironment struct {

--- a/internal/web/server_test.go
+++ b/internal/web/server_test.go
@@ -6903,6 +6903,101 @@ func TestHealthReportsDispatchStallAsNeedsHumanAttention(t *testing.T) {
 	}
 }
 
+func TestHealthReportsTickLivenessAndSnapshotAge(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 8, 17, 1, 39, 0, 0, time.UTC)
+	tests := []struct {
+		name             string
+		generatedAt      time.Time
+		nextRefreshAt    time.Time
+		liveness         telemetry.TickLiveness
+		wantHealthStatus string
+		wantRefresh      telemetry.RefreshStatus
+		wantAgeSeconds   string
+	}{
+		{
+			name:          "healthy loop remains ready",
+			generatedAt:   now.Add(-time.Second),
+			nextRefreshAt: now.Add(time.Minute),
+			liveness: telemetry.TickLiveness{
+				ProjectID:     "detent",
+				Status:        telemetry.TickLivenessStatusReady,
+				LastTickAt:    new(now.Add(-time.Second)),
+				NextRefreshAt: new(now.Add(time.Minute)),
+			},
+			wantHealthStatus: "ok",
+			wantRefresh:      telemetry.RefreshStatusReady,
+			wantAgeSeconds:   "1",
+		},
+		{
+			name:          "frozen loop needs attention",
+			generatedAt:   now.Add(-18 * time.Minute),
+			nextRefreshAt: now.Add(-9 * time.Minute),
+			liveness: telemetry.TickLiveness{
+				ProjectID:             "detent",
+				Status:                telemetry.TickLivenessStatusNeedsAttention,
+				LastTickAt:            new(now.Add(-18 * time.Minute)),
+				NextRefreshAt:         new(now.Add(-9 * time.Minute)),
+				NextRefreshOverdue:    true,
+				FrozenAt:              new(now.Add(-18 * time.Minute)),
+				MissedIntervals:       2,
+				WatchdogIntervalCount: 2,
+			},
+			wantHealthStatus: "needs_attention",
+			wantRefresh:      telemetry.RefreshStatusDegraded,
+			wantAgeSeconds:   "1080",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			deps := testDeps(t)
+			deps.TickLiveness = tickLivenessProbe{values: []telemetry.TickLiveness{tt.liveness}}
+			if err := deps.Hub.Publish(telemetry.Snapshot{
+				GeneratedAt: tt.generatedAt,
+				Refresh: telemetry.Refresh{
+					Status:        telemetry.RefreshStatusReady,
+					LastRefreshAt: &tt.generatedAt,
+					NextRefreshAt: &tt.nextRefreshAt,
+				},
+				Counts: telemetry.Counts{Running: 1},
+			}); err != nil {
+				t.Fatalf("Publish() error = %v", err)
+			}
+			server, err := web.NewServer(web.Config{Now: func() time.Time { return now }}, deps)
+			if err != nil {
+				t.Fatalf("NewServer() error = %v", err)
+			}
+
+			health := requestJSON(t, server, http.MethodGet, "/health", http.StatusOK)
+			if health["status"] != tt.wantHealthStatus {
+				t.Fatalf("health status = %#v, want %q", health["status"], tt.wantHealthStatus)
+			}
+			if got := nestedString(t, health, "snapshot_age_seconds"); got != tt.wantAgeSeconds {
+				t.Fatalf("health snapshot_age_seconds = %s, want %s", got, tt.wantAgeSeconds)
+			}
+			if got := nestedString(t, health, "refresh", "status"); got != string(tt.wantRefresh) {
+				t.Fatalf("health refresh.status = %q, want %q", got, tt.wantRefresh)
+			}
+			liveness := health["tick_liveness"].([]any)
+			if len(liveness) != 1 || liveness[0].(map[string]any)["status"] != string(tt.liveness.Status) {
+				t.Fatalf("health tick_liveness = %#v", liveness)
+			}
+
+			state := requestJSON(t, server, http.MethodGet, "/api/v1/state", http.StatusOK)
+			if got := nestedString(t, state, "snapshot_age_seconds"); got != tt.wantAgeSeconds {
+				t.Fatalf("state snapshot_age_seconds = %s, want %s", got, tt.wantAgeSeconds)
+			}
+			if got := nestedString(t, state, "refresh", "status"); got != string(tt.wantRefresh) {
+				t.Fatalf("state refresh.status = %q, want %q", got, tt.wantRefresh)
+			}
+		})
+	}
+}
+
 func TestProjectStateAPIRendersConfiguredProjectWithoutTelemetryRows(t *testing.T) {
 	t.Parallel()
 
@@ -13031,6 +13126,14 @@ type refreshProbe struct {
 	response web.RefreshResponse
 	err      error
 	calls    int
+}
+
+type tickLivenessProbe struct {
+	values []telemetry.TickLiveness
+}
+
+func (p tickLivenessProbe) TickLiveness(time.Time) []telemetry.TickLiveness {
+	return append([]telemetry.TickLiveness(nil), p.values...)
 }
 
 type operatorMoveProbe struct {


### PR DESCRIPTION
## Summary

- run a per-project tick watchdog on an independent goroutine and timer
- expose tick liveness and snapshot age through health and state APIs
- degrade stale refresh readiness at request time so frozen snapshots cannot remain ready

Fixes #1855

## UI Surface Contract

- [x] N/A; this change does not alter high-impact UI layout, density, or responsive visibility.
- [x] This PR does not add persistent top-of-screen messaging.
- [x] N/A; the observable changes are health and JSON API fields, with HTTP regression coverage.

## Test Plan

- [x] `go test -race ./internal/orchestrator ./internal/telemetry ./internal/web -run Test(TickWatchdog|RefreshReadinessStatusAt|SnapshotWithFreshness|HealthReportsTickLivenessAndSnapshotAge) -count=1`
- [x] `make check`