### PR TITLE
fix(orchestrator): recover stranded active cards

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -259,7 +259,10 @@ release-readiness automation after merged work accumulates.
 
 `observability.stranded_active_threshold_seconds` controls when Health and
 `detent doctor` report an issue that remains in `In Progress` without a live
-worker while project capacity is available. The default is 600 seconds, which
+worker and when Detent recovers it automatically. Issues with an open pull
+request or recoverable workspace work move to `Rework`; issues confirmed to
+have no recovery artifacts move to `Todo`. Detent holds the issue in place
+when artifact evidence is unavailable. The default is 600 seconds, which
 tolerates normal gaps between a completed session and prompt re-dispatch.
 
 `hooks` run lifecycle commands around worktree creation, agent execution, and

--- a/internal/orchestrator/stranded_active.go
+++ b/internal/orchestrator/stranded_active.go
@@ -1,35 +1,30 @@
 package orchestrator
 
 import (
+	"context"
 	"sort"
 	"strings"
 	"time"
 
+	"github.com/digitaldrywood/detent/internal/connector"
+	runpkg "github.com/digitaldrywood/detent/internal/runner"
 	"github.com/digitaldrywood/detent/internal/store"
 	"github.com/digitaldrywood/detent/internal/telemetry"
 )
 
-const strandedActiveState = "in progress"
+const (
+	strandedActiveState          = "in progress"
+	strandedActiveRecoveryReason = "stranded_active_recovery"
+)
+
+type strandedActiveRecoveryDecision struct {
+	TargetState string
+	Evidence    string
+	HoldReason  string
+}
 
 func strandedActiveIssueSnapshots(state State, issues []telemetry.Issue, now time.Time) []telemetry.StrandedIssue {
-	if state.StrandedActiveThreshold <= 0 || state.PoolAvailable <= 0 || state.PoolDraining || now.IsZero() {
-		return nil
-	}
-	if len(state.Running) >= state.MaxConcurrentAgents {
-		return nil
-	}
-
-	stateLimit := state.MaxConcurrentAgents
-	if configured, ok := state.MaxAgentsByState[strandedActiveState]; ok {
-		stateLimit = configured
-	}
-	stateUsed := 0
-	for _, running := range state.Running {
-		if normalizeState(running.Issue.State) == strandedActiveState {
-			stateUsed++
-		}
-	}
-	if stateUsed >= stateLimit {
+	if state.StrandedActiveThreshold <= 0 || now.IsZero() {
 		return nil
 	}
 
@@ -64,6 +59,177 @@ func strandedActiveIssueSnapshots(state State, issues []telemetry.Issue, now tim
 		return strandedActiveTarget(diagnostics[i]) < strandedActiveTarget(diagnostics[j])
 	})
 	return diagnostics
+}
+
+func (o *Orchestrator) recoverStrandedActiveIssues(
+	ctx context.Context,
+	state *State,
+	issues []connector.Issue,
+	now time.Time,
+) map[string]struct{} {
+	if o == nil || state == nil || len(issues) == 0 {
+		return nil
+	}
+	diagnostics := strandedActiveIssueSnapshots(
+		*state,
+		issueSnapshots(issues, 0, 0, now, state.laneEntries),
+		now,
+	)
+	transitioned := make(map[string]struct{}, len(diagnostics))
+	for _, diagnostic := range diagnostics {
+		issue, ok := strandedActiveConnectorIssue(diagnostic, issues)
+		if !ok || strings.TrimSpace(issue.ID) == "" {
+			continue
+		}
+		decision := o.strandedActiveRecoveryDecision(ctx, issue)
+		if strings.TrimSpace(decision.TargetState) == "" {
+			if o.logger != nil {
+				o.logger.Debug(
+					"stranded active issue recovery held",
+					"issue_id", issue.ID,
+					"identifier", issue.Identifier,
+					"duration_seconds", diagnostic.DurationSeconds,
+					"reason", decision.HoldReason,
+				)
+			}
+			continue
+		}
+		if err := o.updateIssueStateByIDStrictWithMetadata(
+			ctx,
+			state,
+			issue.ID,
+			issue,
+			decision.TargetState,
+			now,
+			strandedActiveRecoveryReason,
+			workflowLaneMetadata{},
+		); err != nil {
+			if o.logger != nil {
+				o.logger.Warn(
+					"stranded active issue recovery failed",
+					"issue_id", issue.ID,
+					"identifier", issue.Identifier,
+					"duration_seconds", diagnostic.DurationSeconds,
+					"target_state", decision.TargetState,
+					"evidence", decision.Evidence,
+					"error", err,
+				)
+			}
+			continue
+		}
+		transitioned[issue.ID] = struct{}{}
+		recordStateEvent(state, telemetry.ActivityEvent{
+			At:      now,
+			Event:   "stranded_active_recovered",
+			Message: "recovered " + issueLabel(issue) + " to " + decision.TargetState + " after " + (time.Duration(diagnostic.DurationSeconds) * time.Second).String() + " without a live worker; evidence: " + decision.Evidence,
+		})
+		if o.logger != nil {
+			o.logger.Info(
+				"stranded active issue recovered",
+				"issue_id", issue.ID,
+				"identifier", issue.Identifier,
+				"duration_seconds", diagnostic.DurationSeconds,
+				"target_state", decision.TargetState,
+				"evidence", decision.Evidence,
+			)
+		}
+	}
+	if len(transitioned) == 0 {
+		return nil
+	}
+	return transitioned
+}
+
+func (o *Orchestrator) strandedActiveRecoveryDecision(ctx context.Context, issue connector.Issue) strandedActiveRecoveryDecision {
+	openPullRequest, pullRequestUncertain := strandedActivePullRequestEvidence(issue)
+	if openPullRequest {
+		return strandedActiveRecoveryDecision{TargetState: autoPromoteReworkState, Evidence: "open_pull_request"}
+	}
+
+	snapshot := runpkg.BlockedRecoverySnapshot{WorkspaceStatus: "unavailable"}
+	if o.recoveryInspector != nil {
+		snapshot = o.recoveryInspector.BlockedRecoverySnapshot(ctx, runpkg.RunRequest{
+			Issue:           issue,
+			Mode:            RunModeImplement,
+			SelectorContext: o.selectorContext(),
+		})
+	}
+	workspaceWork, workspaceReady := strandedActiveWorkspaceEvidence(snapshot)
+	if workspaceWork {
+		evidence := "recoverable_workspace"
+		if snapshot.UnpushedCommits > 0 {
+			evidence = "unpushed_work"
+		}
+		return strandedActiveRecoveryDecision{TargetState: autoPromoteReworkState, Evidence: evidence}
+	}
+	if pullRequestUncertain {
+		return strandedActiveRecoveryDecision{HoldReason: "pull_request_evidence_unavailable"}
+	}
+	if !workspaceReady {
+		return strandedActiveRecoveryDecision{HoldReason: "workspace_evidence_unavailable"}
+	}
+	return strandedActiveRecoveryDecision{TargetState: "Todo", Evidence: "no_recovery_artifacts"}
+}
+
+func strandedActivePullRequestEvidence(issue connector.Issue) (bool, bool) {
+	if issue.PullRequest != nil {
+		if pullRequestHydrationBlocksProgress(issue.PullRequest) {
+			return false, true
+		}
+		switch normalizePullRequestState(issue.PullRequest.State) {
+		case "open":
+			return true, false
+		case "closed", "merged":
+			return false, false
+		case "":
+			if issue.PullRequest.Number > 0 ||
+				strings.TrimSpace(issue.PullRequest.URL) != "" ||
+				strings.TrimSpace(issue.PullRequest.BranchName) != "" {
+				return false, true
+			}
+		default:
+			return false, true
+		}
+	}
+	return false, issue.PRNumber != nil && *issue.PRNumber > 0
+}
+
+func strandedActiveWorkspaceEvidence(snapshot runpkg.BlockedRecoverySnapshot) (bool, bool) {
+	status := strings.TrimSpace(snapshot.WorkspaceStatus)
+	if status == "missing" {
+		return false, true
+	}
+	if status != "present" || !snapshot.WorkspacePresent {
+		return false, false
+	}
+	if snapshot.UnpushedCommits > 0 || snapshot.WorkspaceFiles > 0 {
+		return true, true
+	}
+	head := strings.TrimSpace(snapshot.HeadSHA)
+	base := strings.TrimSpace(snapshot.BaseFingerprint)
+	if head != "" && base != "" {
+		return head != base, true
+	}
+	if head != "" || base != "" {
+		return false, false
+	}
+	return false, true
+}
+
+func strandedActiveConnectorIssue(diagnostic telemetry.StrandedIssue, issues []connector.Issue) (connector.Issue, bool) {
+	for _, issue := range issues {
+		if strandedActiveIdentityMatches(
+			diagnostic.IssueID,
+			diagnostic.Identifier,
+			diagnostic.IssueURL,
+			issue.ID,
+			issue.Identifier,
+			issue.URL,
+		) {
+			return issue, true
+		}
+	}
+	return connector.Issue{}, false
 }
 
 func strandedActiveIssueHasWorker(issue telemetry.Issue, running map[string]Running, attempts []telemetry.WorkAttempt, now time.Time) bool {

--- a/internal/orchestrator/stranded_active_test.go
+++ b/internal/orchestrator/stranded_active_test.go
@@ -1,10 +1,12 @@
 package orchestrator
 
 import (
+	"context"
 	"testing"
 	"time"
 
 	"github.com/digitaldrywood/detent/internal/connector"
+	runpkg "github.com/digitaldrywood/detent/internal/runner"
 	"github.com/digitaldrywood/detent/internal/telemetry"
 )
 
@@ -85,16 +87,22 @@ func TestStrandedActiveIssueSnapshots(t *testing.T) {
 			wantReason:   "priority reservation",
 		},
 		{
-			name:      "suppresses gap when pool has no capacity",
-			state:     withStrandedActivePoolAvailable(baseState, 0),
-			issue:     issue,
-			wantCount: 0,
+			name:         "reports gap when pool has no capacity",
+			state:        withStrandedActivePoolAvailable(baseState, 0),
+			issue:        issue,
+			wantCount:    1,
+			wantDuration: int64((30 * time.Minute) / time.Second),
+			wantSince:    laneEnteredAt,
+			wantReason:   "priority reservation",
 		},
 		{
-			name:      "suppresses gap when project state capacity is full",
-			state:     withStrandedActiveStateLimit(baseState, 1, Running{Issue: connector.Issue{ID: "other", State: "In Progress"}}),
-			issue:     issue,
-			wantCount: 0,
+			name:         "reports gap when project state capacity is full",
+			state:        withStrandedActiveStateLimit(baseState, 1, Running{Issue: connector.Issue{ID: "other", State: "In Progress"}}),
+			issue:        issue,
+			wantCount:    1,
+			wantDuration: int64((30 * time.Minute) / time.Second),
+			wantSince:    laneEnteredAt,
+			wantReason:   "priority reservation",
 		},
 		{
 			name:  "suppresses non-working state",
@@ -127,6 +135,155 @@ func TestStrandedActiveIssueSnapshots(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestRecoverStrandedActiveIssues(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 8, 17, 15, 0, 0, 0, time.UTC)
+	enteredAt := now.Add(-30 * time.Minute)
+	baseIssue := connector.Issue{
+		ID:             "issue-1860",
+		Identifier:     "digitaldrywood/detent#1860",
+		URL:            "https://github.com/digitaldrywood/detent/issues/1860",
+		Title:          "Recover stranded active cards",
+		State:          "In Progress",
+		StageUpdatedAt: &enteredAt,
+	}
+
+	tests := []struct {
+		name       string
+		mutate     func(*connector.Issue, *State)
+		workspace  runpkg.BlockedRecoverySnapshot
+		wantTarget string
+	}{
+		{
+			name:       "stranded with no artifacts recovers to Todo",
+			workspace:  runpkg.BlockedRecoverySnapshot{WorkspaceStatus: "missing"},
+			wantTarget: "Todo",
+		},
+		{
+			name: "stranded with open pull request routes to Rework",
+			mutate: func(issue *connector.Issue, _ *State) {
+				issue.PullRequest = &connector.PullRequest{Number: 1861, State: "OPEN"}
+			},
+			workspace:  runpkg.BlockedRecoverySnapshot{WorkspaceStatus: "missing"},
+			wantTarget: autoPromoteReworkState,
+		},
+		{
+			name: "stranded with unpushed work routes to Rework",
+			workspace: runpkg.BlockedRecoverySnapshot{
+				WorkspaceStatus:  "present",
+				WorkspacePresent: true,
+				HeadSHA:          "work-head",
+				BaseFingerprint:  "base-head",
+				UnpushedCommits:  1,
+			},
+			wantTarget: autoPromoteReworkState,
+		},
+		{
+			name: "stranded with dirty worktree routes to Rework",
+			workspace: runpkg.BlockedRecoverySnapshot{
+				WorkspaceStatus:  "present",
+				WorkspacePresent: true,
+				HeadSHA:          "base-head",
+				BaseFingerprint:  "base-head",
+				WorkspaceFiles:   2,
+			},
+			wantTarget: autoPromoteReworkState,
+		},
+		{
+			name: "stranded with pushed workspace commit routes to Rework",
+			workspace: runpkg.BlockedRecoverySnapshot{
+				WorkspaceStatus:  "present",
+				WorkspacePresent: true,
+				HeadSHA:          "pushed-head",
+				BaseFingerprint:  "base-head",
+			},
+			wantTarget: autoPromoteReworkState,
+		},
+		{
+			name: "stranded with clean base workspace recovers to Todo",
+			workspace: runpkg.BlockedRecoverySnapshot{
+				WorkspaceStatus:  "present",
+				WorkspacePresent: true,
+				HeadSHA:          "base-head",
+				BaseFingerprint:  "base-head",
+			},
+			wantTarget: "Todo",
+		},
+		{
+			name: "live worker is never disturbed",
+			mutate: func(issue *connector.Issue, state *State) {
+				state.Running[issue.ID] = Running{Issue: *issue}
+			},
+			workspace: runpkg.BlockedRecoverySnapshot{WorkspaceStatus: "missing"},
+		},
+		{
+			name:      "unavailable workspace evidence holds active lane",
+			workspace: runpkg.BlockedRecoverySnapshot{WorkspaceStatus: "unavailable"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			issue := cloneIssue(baseIssue)
+			state := State{
+				StrandedActiveThreshold: 10 * time.Minute,
+				Running:                 map[string]Running{},
+				BoardIssues:             []connector.Issue{issue},
+			}
+			if tt.mutate != nil {
+				tt.mutate(&issue, &state)
+				state.BoardIssues[0] = cloneIssue(issue)
+			}
+			tracker := &strandedActiveRecoveryConnector{}
+			orchestrator := &Orchestrator{
+				cfg:               Config{ActiveStates: []string{"Todo", "In Progress", autoPromoteReworkState}},
+				connector:         tracker,
+				recoveryInspector: strandedActiveRecoveryInspector{snapshot: tt.workspace},
+			}
+
+			transitioned := orchestrator.recoverStrandedActiveIssues(t.Context(), &state, []connector.Issue{issue}, now)
+			if tt.wantTarget == "" {
+				if len(transitioned) != 0 || len(tracker.updates) != 0 {
+					t.Fatalf("transitioned = %#v, updates = %#v, want no transition", transitioned, tracker.updates)
+				}
+				return
+			}
+			if _, ok := transitioned[issue.ID]; !ok {
+				t.Fatalf("transitioned = %#v, want %s", transitioned, issue.ID)
+			}
+			if len(tracker.updates) != 1 || tracker.updates[0].issueID != issue.ID || tracker.updates[0].state != tt.wantTarget {
+				t.Fatalf("updates = %#v, want %s -> %s", tracker.updates, issue.ID, tt.wantTarget)
+			}
+		})
+	}
+}
+
+type strandedActiveRecoveryUpdate struct {
+	issueID string
+	state   string
+}
+
+type strandedActiveRecoveryConnector struct {
+	connector.Connector
+	updates []strandedActiveRecoveryUpdate
+}
+
+func (c *strandedActiveRecoveryConnector) UpdateIssueState(_ context.Context, issueID string, state string) error {
+	c.updates = append(c.updates, strandedActiveRecoveryUpdate{issueID: issueID, state: state})
+	return nil
+}
+
+type strandedActiveRecoveryInspector struct {
+	snapshot runpkg.BlockedRecoverySnapshot
+}
+
+func (i strandedActiveRecoveryInspector) BlockedRecoverySnapshot(context.Context, runpkg.RunRequest) runpkg.BlockedRecoverySnapshot {
+	return i.snapshot
 }
 
 func withStrandedActiveAttempts(state State, attempts ...telemetry.WorkAttempt) State {

--- a/internal/orchestrator/tick.go
+++ b/internal/orchestrator/tick.go
@@ -210,6 +210,11 @@ func (o *Orchestrator) tickWithManual(ctx context.Context, state *State, now tim
 		fetched,
 		artifactWaitTransitions.transitioned,
 	)
+	fetched = filterReconciledTickIssues(
+		state,
+		fetched,
+		o.recoverStrandedActiveIssues(ctx, state, fetched.candidates, now),
+	)
 	timing.next("rate_limits")
 	restCycle := o.captureConnectorRESTRateLimits(state, now)
 	o.logRESTRateLimitCycle(restCycle)

--- a/internal/web/templates/board_data.go
+++ b/internal/web/templates/board_data.go
@@ -1115,6 +1115,11 @@ func boardCardViewFromCard(data DashboardData, lane projectKanbanLane, card proj
 		view.AgeFooterTitle = strings.TrimSpace(card.TimeInStageTitle)
 	}
 	view.ExtraKind, view.ExtraText, view.ExtraChip = boardCardExtra(card, view)
+	if stranded, ok := boardCardStrandedActiveIssue(data.Snapshot, card); ok {
+		view.ExtraKind = primitives.KindWarn
+		view.ExtraText = "Stranded " + boardCardStrandedAge(stranded.DurationSeconds) + " · no worker"
+		view.ExtraChip = true
+	}
 	view.BlockerSummary = card.BlockerSummary
 	view.ParkSummary, view.ParkDetail = boardCardParkSummary(card.ParkSummary)
 	view.ProgressSummary, view.ProgressDetail, view.ProgressKind = boardCardCompletionProgress(card.CompletionProgress)
@@ -1142,6 +1147,42 @@ func boardCardViewFromCard(data DashboardData, lane projectKanbanLane, card proj
 	view.MergeLaneKind = card.MergeLaneKind
 	view.CompactSignal = boardCardCompactSignal(view)
 	return view
+}
+
+func boardCardStrandedActiveIssue(snapshot telemetry.Snapshot, card projectKanbanCard) (telemetry.StrandedIssue, bool) {
+	for _, issue := range snapshot.StrandedActiveIssues {
+		if strings.TrimSpace(issue.ProjectID) != "" && strings.TrimSpace(card.ProjectID) != "" &&
+			!strings.EqualFold(strings.TrimSpace(issue.ProjectID), strings.TrimSpace(card.ProjectID)) {
+			continue
+		}
+		if strings.TrimSpace(issue.IssueID) != "" && strings.TrimSpace(card.IssueID) != "" &&
+			strings.TrimSpace(issue.IssueID) == strings.TrimSpace(card.IssueID) {
+			return issue, true
+		}
+		if strings.TrimSpace(issue.Identifier) != "" && strings.TrimSpace(card.Identifier) != "" &&
+			strings.EqualFold(strings.TrimSpace(issue.Identifier), strings.TrimSpace(card.Identifier)) {
+			return issue, true
+		}
+		if strings.TrimSpace(issue.IssueURL) != "" && strings.TrimSpace(card.URL) != "" &&
+			strings.TrimSpace(issue.IssueURL) == strings.TrimSpace(card.URL) {
+			return issue, true
+		}
+	}
+	return telemetry.StrandedIssue{}, false
+}
+
+func boardCardStrandedAge(seconds int64) string {
+	duration := time.Duration(seconds) * time.Second
+	switch {
+	case duration >= 24*time.Hour:
+		return strconv.FormatInt(int64(duration/(24*time.Hour)), 10) + "d"
+	case duration >= time.Hour:
+		return strconv.FormatInt(int64(duration/time.Hour), 10) + "h"
+	case duration >= time.Minute:
+		return strconv.FormatInt(int64(duration/time.Minute), 10) + "m"
+	default:
+		return strconv.FormatInt(max(seconds, 0), 10) + "s"
+	}
 }
 
 func boardCardParkSummary(summary telemetry.ParkSummary) (string, string) {

--- a/internal/web/templates/board_data_test.go
+++ b/internal/web/templates/board_data_test.go
@@ -564,6 +564,30 @@ func TestBoardCardExtraShowsWaitReasonAheadOfCI(t *testing.T) {
 	}
 }
 
+func TestBoardCardViewSurfacesStrandedDuration(t *testing.T) {
+	t.Parallel()
+
+	card := projectKanbanCard{
+		IssueID:     "issue-1860",
+		Identifier:  "digitaldrywood/detent#1860",
+		IssueNumber: "#1860",
+		ProjectID:   "detent",
+		Title:       "Recover stranded active cards",
+		Stage:       "In Progress",
+	}
+	data := DashboardData{Snapshot: telemetry.Snapshot{StrandedActiveIssues: []telemetry.StrandedIssue{{
+		ProjectID: "detent", IssueID: card.IssueID, Identifier: card.Identifier, DurationSeconds: 31 * 24 * 60 * 60,
+	}}}}
+
+	view := boardCardViewFromCard(data, projectKanbanLane{Title: "In Progress"}, card, false, "fleet", "")
+	if view.ExtraKind != primitives.KindWarn || view.ExtraText != "Stranded 31d · no worker" || !view.ExtraChip {
+		t.Fatalf("stranded card signal = %q, %q, %t", view.ExtraKind, view.ExtraText, view.ExtraChip)
+	}
+	if view.CompactSignal != view.ExtraText {
+		t.Fatalf("CompactSignal = %q, want %q", view.CompactSignal, view.ExtraText)
+	}
+}
+
 func TestBoardCardRendersMergeLaneProgress(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

- recover active-lane cards after the configured strand threshold using existing pull-request and workspace evidence
- route preserved work to Rework, artifact-free cards to Todo, and hold cards when evidence is unavailable
- surface a compact stranded age on board cards while retaining detailed duration in Health and doctor

Fixes #1860

## UI Surface Contract

- [x] Issue #1860 explicitly authorizes surfacing stranded duration on operator cards.
- [x] This PR adds no persistent top-of-screen messaging.
- [x] Chrome DevTools verification used an isolated Kanban demo on port 0 at 1440x1000; the narrow card kept `Stranded 63d` visible and exposed the full `Stranded 63d · no worker` label to accessibility and hover.

## Test Plan

- [x] `go test ./internal/orchestrator ./internal/web/templates -run '^(TestStrandedActiveIssueSnapshots|TestRecoverStrandedActiveIssues|TestBoardCardViewSurfacesStrandedDuration|TestHealthStrandedActiveRowsGroupByProject)$' -count=1`
- [x] `go test ./internal/orchestrator ./internal/web/... -count=1`
- [x] `make check` (race suite and 79.1% coverage)