### PR TITLE
fix(github): isolate missing check references

### DIFF
--- a/internal/connector/github/pull_requests.go
+++ b/internal/connector/github/pull_requests.go
@@ -1006,16 +1006,23 @@ func (c *Connector) populatePullRequestStatus(ctx context.Context, repo pullRequ
 	}
 
 	status := pullRequestStatus{}
+	checksUnavailable := false
 	if strings.TrimSpace(pullRequest.HeadSHA) != "" {
 		ci, err := c.fetchPullRequestCI(ctx, repo, pullRequest.HeadSHA)
 		if err != nil {
-			state := c.pullRequestHydrationStateForError(repo, err)
-			if c.applyCachedPullRequestStatusAfterThrottle(ctx, repo, pullRequest, state) {
-				return nil
+			if errors.Is(err, ErrNotFound) {
+				pullRequest.HydrationUnavailableReason = connector.PullRequestHydrationReasonChecksUnavailable
+				checksUnavailable = true
+			} else {
+				state := c.pullRequestHydrationStateForError(repo, err)
+				if c.applyCachedPullRequestStatusAfterThrottle(ctx, repo, pullRequest, state) {
+					return nil
+				}
+				return err
 			}
-			return err
+		} else {
+			status.ci = ci
 		}
-		status.ci = ci
 	}
 	reviews, err := c.fetchPullRequestReviews(ctx, repo, pullRequest.Number, pullRequest.HeadSHA)
 	if err != nil {
@@ -1026,7 +1033,7 @@ func (c *Connector) populatePullRequestStatus(ctx context.Context, repo pullRequ
 		return err
 	}
 	status.reviews = reviews
-	if c.pullRequests != nil {
+	if c.pullRequests != nil && !checksUnavailable {
 		c.pullRequests.Set(repo, pullRequest.Number, pullRequest.HeadSHA, status)
 		c.logPullRequestCache(ctx, repo, pullRequest, false, false, "stored")
 	}

--- a/internal/connector/github/pull_requests_concurrency_test.go
+++ b/internal/connector/github/pull_requests_concurrency_test.go
@@ -66,6 +66,84 @@ func TestConnectorHydratesLinkedPullRequestsConcurrently(t *testing.T) {
 	}
 }
 
+func TestConnectorKeepsHydratingCandidatesWhenChecksReferenceIsNotFound(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name         string
+		notFoundPath string
+	}{
+		{
+			name:         "check runs",
+			notFoundPath: "/commits/sha-1/check-runs",
+		},
+		{
+			name:         "commit statuses",
+			notFoundPath: "/commits/sha-1/statuses",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			var notFoundRequests atomic.Int64
+			var stalePullRequestReviews atomic.Bool
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				if strings.Contains(r.URL.Path, tt.notFoundPath) {
+					notFoundRequests.Add(1)
+					http.Error(w, "reference not found", http.StatusNotFound)
+					return
+				}
+				if strings.Contains(r.URL.Path, "/commits/sha-2/check-runs") {
+					_, _ = w.Write([]byte(`{"check_runs":[{"status":"completed","conclusion":"success"}]}`))
+					return
+				}
+				if pullRequestNumber, ok := pullRequestDetailNumber(r.URL.Path); ok {
+					_, _ = fmt.Fprintf(w, `{"number":%d,"html_url":"https://github.com/digitaldrywood/detent/pull/%d","state":"open","head":{"ref":"detent/issue-%d","sha":"sha-%d"}}`, pullRequestNumber, pullRequestNumber, pullRequestNumber, pullRequestNumber)
+					return
+				}
+				if strings.Contains(r.URL.Path, "/pulls/1/reviews") {
+					stalePullRequestReviews.Store(true)
+				}
+				writePullRequestStatusResponse(w, r.URL.Path)
+			}))
+			t.Cleanup(server.Close)
+
+			githubConnector, err := NewConnector(Config{
+				Endpoint:                   server.URL,
+				APIKey:                     "token",
+				HTTPClient:                 server.Client(),
+				RESTFanoutMaxRequests:      80,
+				DisableConditionalRequests: true,
+			})
+			if err != nil {
+				t.Fatalf("NewConnector() error = %v", err)
+			}
+
+			for cycle := 1; cycle <= 2; cycle++ {
+				issues := linkedPullRequestIssues(1, 2)
+				if err := githubConnector.attachPullRequests(context.Background(), issues); err != nil {
+					t.Fatalf("cycle %d attachPullRequests() error = %v", cycle, err)
+				}
+				if issues[0].PullRequest == nil || issues[0].PullRequest.HydrationUnavailableReason != connector.PullRequestHydrationReasonChecksUnavailable {
+					t.Fatalf("cycle %d stale PullRequest = %#v, want checks-unavailable hydration", cycle, issues[0].PullRequest)
+				}
+				if issues[1].PullRequest == nil || issues[1].PullRequest.Number != 2 || issues[1].PullRequest.CIStatus != "pass" {
+					t.Fatalf("cycle %d healthy PullRequest = %#v, want fully hydrated PR 2", cycle, issues[1].PullRequest)
+				}
+			}
+			if !stalePullRequestReviews.Load() {
+				t.Fatal("stale pull request reviews were not hydrated")
+			}
+			if got := notFoundRequests.Load(); got != 2 {
+				t.Fatalf("not-found request count = %d, want 2 so incomplete checks are not cached", got)
+			}
+		})
+	}
+}
+
 func TestConnectorFiniteFanoutCompletesPriorityHydrationBeforeConcurrentTail(t *testing.T) {
 	t.Parallel()
 

--- a/internal/connector/issue.go
+++ b/internal/connector/issue.go
@@ -149,6 +149,7 @@ const (
 	PullRequestHydrationReasonSecondaryThrottled  = "secondary_throttled"
 	PullRequestHydrationReasonPrimaryExhausted    = "primary_exhausted"
 	PullRequestHydrationReasonRESTBudgetReserved  = "rest_budget_reserved"
+	PullRequestHydrationReasonChecksUnavailable   = "checks_unavailable"
 	PullRequestHydrationReasonStaleCachedPullData = "stale_cached_pull_request"
 )
 

--- a/internal/web/templates/dashboard_data.go
+++ b/internal/web/templates/dashboard_data.go
@@ -4506,6 +4506,8 @@ func pullRequestHydrationWaitDetail(unavailableReason string, degradedReason str
 		detail = "PR hydration primary exhausted"
 	case "rest_budget_reserved":
 		detail = "PR hydration waiting for REST budget"
+	case "checks_unavailable":
+		detail = "PR checks unavailable: current head SHA not found"
 	}
 	if detail == "" && strings.TrimSpace(degradedReason) == "stale_cached_pull_request" {
 		detail = "PR hydration using stale cached data"

--- a/internal/web/templates/dashboard_data_test.go
+++ b/internal/web/templates/dashboard_data_test.go
@@ -3147,6 +3147,16 @@ func TestPRPipelineWaitDetailExplainsHumanReviewReasons(t *testing.T) {
 			},
 			want: "PR hydration using stale cached data",
 		},
+		{
+			name: "hydration explains missing current head checks",
+			issue: telemetry.Issue{
+				State: "Human Review",
+				PullRequest: &telemetry.PullRequest{
+					HydrationUnavailableReason: "checks_unavailable",
+				},
+			},
+			want: "PR checks unavailable: current head SHA not found",
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Summary

- Treat a check-runs or commit-status 404 as issue-local `checks_unavailable` hydration.
- Continue review and healthy-candidate hydration without caching incomplete CI data.
- Show the stale-head reason in the existing card Waits row.

Fixes #1863

## UI Surface Contract

- [x] N/A for high-impact layout or density; the issue explicitly requires a per-card diagnostic and this PR changes no markup or CSS.
- [x] This PR does not add persistent top-of-screen messaging.
- [ ] Browser tooling was not exposed in this worker. No markup or CSS changed; `TestPRPipelineWaitDetailExplainsHumanReviewReasons` verifies the card text mapping.

## Test Plan

- [x] `go test ./internal/connector/github -run "^TestConnectorKeepsHydratingCandidatesWhenChecksReferenceIsNotFound$" -count=1 -v`
- [x] `go test ./internal/connector/github -count=1`
- [x] `go test ./internal/web/templates -count=1`
- [x] `make check` (golangci-lint v2.1.6, total coverage 79.1%)