### PR TITLE
fix(health): degrade on refresh failures

### DIFF
--- a/config.reference.yaml
+++ b/config.reference.yaml
@@ -492,6 +492,8 @@
 #   interval_ms: 120000
 #   # polling.conditional | type: boolean | default: true | required: No | validation: None
 #   conditional: true
+#   # polling.refresh_failure_threshold | type: integer | default: 3 | required: No | validation: must be greater than 0
+#   refresh_failure_threshold: 3
 # # workspace | type: object | default: see child fields | required: No | validation: agent.lessons.path must be a relative path inside the workspace; agent.skills.path must be a relative path inside the workspace
 # workspace:
 #   # workspace.kind | type: string | default: "local_git" | required: No | validation: must be one of local_git, filesystem

--- a/docs/config.md
+++ b/docs/config.md
@@ -166,7 +166,10 @@ persona to GitHub, Linear, an embedded SQLite board, or the in-memory tracker.
 The tracker declares active, observed, and terminal workflow states; state maps,
 transition automation, admission, planning, stop behavior, and routing all
 refer back to those names. `polling` controls how often Detent refreshes the
-tracker when no event gives it a fresher signal.
+tracker when no event gives it a fresher signal. Its
+`refresh_failure_threshold` controls how many consecutive failures after a
+successful refresh promote project and fleet health to `needs_attention`; a
+project whose first refresh fails needs attention immediately.
 
 Choose exactly one GitHub status source: ProjectV2, the repository issue
 `Status` field, or repository labels. `dependency_auto_unblock`,
@@ -732,6 +735,7 @@ only to resettable budget pacing and never clears a per-issue hard hold.
 | `polling` | `object` | `see child fields` | No | None |
 | `polling.conditional` | `boolean` | `true` | No | None |
 | `polling.interval_ms` | `integer` | `120000` | No | must be at least 60000<br>must be greater than 0 |
+| `polling.refresh_failure_threshold` | `integer` | `3` | No | must be greater than 0 |
 | `release` | `object` | `see child fields` | No | None |
 | `release.enabled` | `boolean` | `false` | No | release.max_age_hours must be greater than 0 when release.enabled is true<br>release.min_merged_issues must be greater than 0 when release.enabled is true<br>release.require_green_ci must be true when release.enabled is true<br>requires tracker.kind github or github_local<br>tracker.repository must be owner/name when release.enabled is true |
 | `release.flaky_check_names` | `list<string>` | `[]` | No | must not be empty when release.rerun_flaky_once is true |

--- a/docs/dashboard-api.md
+++ b/docs/dashboard-api.md
@@ -205,7 +205,11 @@ publication stops. Refresh objects include `next_refresh_overdue`; an explicit
 `/health` also reports `snapshot_generated_at`, `snapshot_age_seconds`, the
 current refresh object, and per-project `tick_liveness`. A tick loop that misses
 two effective polling intervals reports `needs_attention`, its last tick,
-overdue next refresh, missed interval count, and `frozen_at` timestamp.
+overdue next refresh, missed interval count, and `frozen_at` timestamp. A loop
+that continues ticking while tracker refreshes fail reports separate
+`refresh_failures` entries with the project, reason, threshold, streak, and last
+error. A failed first refresh is reported immediately because dispatch has
+never observed the project.
 
 Project state scopes workflow metrics from the fleet snapshot enrichment cache
 instead of rerunning historical database reports for each request. The project

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -79,6 +79,7 @@ const (
 	DefaultNoProgressTimeoutMS               = 90 * 60 * 1000
 
 	DefaultPollingIntervalMS              = 120000
+	DefaultRefreshFailureThreshold        = 3
 	MinPollingIntervalMS                  = 60000
 	DefaultShutdownDrainTimeoutMS         = 75000
 	DefaultBoardSnapshotStaleAfterSeconds = 15 * 60
@@ -244,8 +245,9 @@ type Identity struct {
 }
 
 type Polling struct {
-	IntervalMS  int  `yaml:"interval_ms"`
-	Conditional bool `yaml:"conditional"`
+	IntervalMS              int  `yaml:"interval_ms"`
+	Conditional             bool `yaml:"conditional"`
+	RefreshFailureThreshold int  `yaml:"refresh_failure_threshold"`
 }
 
 type Claims struct {
@@ -1338,8 +1340,9 @@ func Default() Config {
 			AutoProvision: true,
 		},
 		Polling: Polling{
-			IntervalMS:  DefaultPollingIntervalMS,
-			Conditional: true,
+			IntervalMS:              DefaultPollingIntervalMS,
+			Conditional:             true,
+			RefreshFailureThreshold: DefaultRefreshFailureThreshold,
 		},
 		Workspace: Workspace{
 			Kind:                   WorkspaceLocalGit,
@@ -1501,6 +1504,7 @@ func (c *Config) Validate() error {
 	c.validateTracker(&problems)
 	problems = append(problems, c.Dependencies.Validate("dependencies")...)
 	validatePollingInterval(c.Polling.IntervalMS, &problems)
+	validatePositive("polling.refresh_failure_threshold", c.Polling.RefreshFailureThreshold, &problems)
 	c.Workspace.validate(&problems)
 	if c.Worker.MaxConcurrentAgentsPerHost != nil {
 		validatePositive("worker.max_concurrent_agents_per_host", *c.Worker.MaxConcurrentAgentsPerHost, &problems)

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -137,6 +137,31 @@ func TestWorkerGitHubPolicyConfiguration(t *testing.T) {
 	}
 }
 
+func TestRefreshFailureThresholdConfiguration(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		raw  string
+		want int
+	}{
+		{name: "default", raw: "---\ntracker:\n  kind: memory\n---\nPrompt\n", want: DefaultRefreshFailureThreshold},
+		{name: "override", raw: "---\ntracker:\n  kind: memory\npolling:\n  refresh_failure_threshold: 5\n---\nPrompt\n", want: 5},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			workflow, err := ParseWorkflow([]byte(tt.raw))
+			if err != nil {
+				t.Fatalf("ParseWorkflow() error = %v", err)
+			}
+			if got := workflow.Config.Polling.RefreshFailureThreshold; got != tt.want {
+				t.Fatalf("Polling.RefreshFailureThreshold = %d, want %d", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestWorkerGitHubDefaultReserveBrakesBeforeOrchestrator(t *testing.T) {
 	t.Parallel()
 

--- a/internal/healthnotify/manager.go
+++ b/internal/healthnotify/manager.go
@@ -62,6 +62,7 @@ type Event struct {
 	WaitReasons             []string                   `json:"wait_reasons,omitempty"`
 	FailureBreakers         []telemetry.FailureBreaker `json:"failure_breakers,omitempty"`
 	BackendOutages          []telemetry.BackendOutage  `json:"backend_outages,omitempty"`
+	RefreshFailures         []telemetry.RefreshFailure `json:"refresh_failures,omitempty"`
 	EnteredAt               time.Time                  `json:"entered_at"`
 	NeedsAttentionEnteredAt time.Time                  `json:"needs_attention_entered_at"`
 	ObservedAt              time.Time                  `json:"observed_at"`
@@ -103,6 +104,7 @@ type durableState struct {
 	WaitReasons             []string                   `json:"wait_reasons,omitempty"`
 	FailureBreakers         []telemetry.FailureBreaker `json:"failure_breakers,omitempty"`
 	BackendOutages          []telemetry.BackendOutage  `json:"backend_outages,omitempty"`
+	RefreshFailures         []telemetry.RefreshFailure `json:"refresh_failures,omitempty"`
 	Deliveries              []deliveryState            `json:"deliveries,omitempty"`
 }
 
@@ -113,6 +115,7 @@ type pendingState struct {
 	WaitReasons     []string                   `json:"wait_reasons,omitempty"`
 	FailureBreakers []telemetry.FailureBreaker `json:"failure_breakers,omitempty"`
 	BackendOutages  []telemetry.BackendOutage  `json:"backend_outages,omitempty"`
+	RefreshFailures []telemetry.RefreshFailure `json:"refresh_failures,omitempty"`
 	Since           time.Time                  `json:"since"`
 }
 
@@ -303,6 +306,7 @@ func (m *Manager) applyObservation(state *durableState, current observation, now
 			WaitReasons:     compactSorted(current.WaitReasons),
 			FailureBreakers: append([]telemetry.FailureBreaker(nil), current.FailureBreakers...),
 			BackendOutages:  append([]telemetry.BackendOutage(nil), current.BackendOutages...),
+			RefreshFailures: append([]telemetry.RefreshFailure(nil), current.RefreshFailures...),
 			Since:           now,
 		}
 		return true
@@ -310,13 +314,15 @@ func (m *Manager) applyObservation(state *durableState, current observation, now
 	causes := compactSorted(current.Causes)
 	waitReasons := compactSorted(current.WaitReasons)
 	if state.Pending.State != current.State || !slices.Equal(state.Pending.Causes, causes) || !slices.Equal(state.Pending.WaitReasons, waitReasons) ||
-		!reflect.DeepEqual(state.Pending.FailureBreakers, current.FailureBreakers) || !reflect.DeepEqual(state.Pending.BackendOutages, current.BackendOutages) {
+		!reflect.DeepEqual(state.Pending.FailureBreakers, current.FailureBreakers) || !reflect.DeepEqual(state.Pending.BackendOutages, current.BackendOutages) ||
+		!reflect.DeepEqual(state.Pending.RefreshFailures, current.RefreshFailures) {
 		changed = true
 		state.Pending.State = current.State
 		state.Pending.Causes = causes
 		state.Pending.WaitReasons = waitReasons
 		state.Pending.FailureBreakers = append([]telemetry.FailureBreaker(nil), current.FailureBreakers...)
 		state.Pending.BackendOutages = append([]telemetry.BackendOutage(nil), current.BackendOutages...)
+		state.Pending.RefreshFailures = append([]telemetry.RefreshFailure(nil), current.RefreshFailures...)
 	}
 	if now.Before(state.Pending.Since.Add(m.cfg.Debounce)) {
 		return changed
@@ -330,6 +336,7 @@ func (m *Manager) applyObservation(state *durableState, current observation, now
 		state.WaitReasons = append([]string(nil), pending.WaitReasons...)
 		state.FailureBreakers = append([]telemetry.FailureBreaker(nil), pending.FailureBreakers...)
 		state.BackendOutages = append([]telemetry.BackendOutage(nil), pending.BackendOutages...)
+		state.RefreshFailures = append([]telemetry.RefreshFailure(nil), pending.RefreshFailures...)
 		state.Deliveries = append(state.Deliveries, deliveryState{Event: m.event(state, TransitionEntry, pending.State, pending.Since, pending.Since, now)})
 		return true
 	}
@@ -339,6 +346,7 @@ func (m *Manager) applyObservation(state *durableState, current observation, now
 	state.WaitReasons = nil
 	state.FailureBreakers = nil
 	state.BackendOutages = nil
+	state.RefreshFailures = nil
 	return true
 }
 
@@ -358,6 +366,7 @@ func (m *Manager) event(state *durableState, transition string, enteredState str
 		WaitReasons:             append([]string(nil), state.WaitReasons...),
 		FailureBreakers:         append([]telemetry.FailureBreaker(nil), state.FailureBreakers...),
 		BackendOutages:          append([]telemetry.BackendOutage(nil), state.BackendOutages...),
+		RefreshFailures:         append([]telemetry.RefreshFailure(nil), state.RefreshFailures...),
 		EnteredAt:               enteredAt.UTC(),
 		NeedsAttentionEnteredAt: attentionEnteredAt.UTC(),
 		ObservedAt:              observedAt.UTC(),

--- a/internal/healthnotify/manager_test.go
+++ b/internal/healthnotify/manager_test.go
@@ -238,6 +238,59 @@ func TestManagerPairsOneRecoveryWithEachEntry(t *testing.T) {
 	}
 }
 
+func TestManagerNotifiesRefreshFailureAndRecovery(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 8, 17, 15, 0, 0, 0, time.UTC)
+	lastRefreshAt := now.Add(-time.Minute)
+	lastErrorAt := now.Add(-30 * time.Second)
+	failed := telemetry.Snapshot{Projects: []telemetry.ProjectSnapshot{{
+		Project: telemetry.Project{ID: "pyroapex"},
+		Refresh: telemetry.Refresh{
+			FailureThreshold: 3,
+			LastRefreshAt:    &lastRefreshAt,
+			LastError:        "candidate endpoint unavailable",
+			LastErrorAt:      &lastErrorAt,
+			Sources: []telemetry.RefreshSource{{
+				Name: telemetry.RefreshSourceCandidates, FailureStreak: 3, LastError: "candidate endpoint unavailable", LastErrorAt: &lastErrorAt,
+			}},
+		},
+	}}}
+	recoveredAt := now.Add(2 * time.Minute)
+	recovered := telemetry.Snapshot{Projects: []telemetry.ProjectSnapshot{{
+		Project: telemetry.Project{ID: "pyroapex"},
+		Refresh: telemetry.Refresh{
+			FailureThreshold: 3,
+			LastRefreshAt:    &recoveredAt,
+			Sources: []telemetry.RefreshSource{{
+				Name: telemetry.RefreshSourceCandidates, LastSuccessAt: &recoveredAt,
+			}},
+		},
+	}}}
+	stateStore := newMemoryStateStore()
+	sender := &recordingSender{}
+	manager := newTestManager(t, stateStore, sender, Config{Debounce: time.Minute})
+	health := readyHealth("pyroapex")
+
+	managerReconcile(t, manager, failed, health, now)
+	managerReconcile(t, manager, failed, health, now.Add(time.Minute))
+	managerReconcile(t, manager, recovered, health, now.Add(2*time.Minute))
+	managerReconcile(t, manager, recovered, health, now.Add(3*time.Minute))
+
+	events := sender.Events()
+	if len(events) != 4 {
+		t.Fatalf("events = %#v, want project and fleet entry plus recovery", events)
+	}
+	for _, event := range events {
+		if !slices.Equal(event.Causes, []string{CauseRefreshFailure}) {
+			t.Fatalf("event causes = %v, want refresh failure", event.Causes)
+		}
+		if len(event.RefreshFailures) != 1 || event.RefreshFailures[0].ProjectID != "pyroapex" || event.RefreshFailures[0].LastError != "candidate endpoint unavailable" {
+			t.Fatalf("event refresh failures = %#v", event.RefreshFailures)
+		}
+	}
+}
+
 func TestManagerFleetRecoveryWaitsForEveryProjectCause(t *testing.T) {
 	t.Parallel()
 	now := time.Date(2026, 8, 13, 18, 0, 0, 0, time.UTC)

--- a/internal/healthnotify/observations.go
+++ b/internal/healthnotify/observations.go
@@ -16,6 +16,7 @@ const (
 	CauseDispatchStall           = "dispatch_stall"
 	CauseProjectFailureBreaker   = "project_failure_breaker"
 	CauseBackendCapacity         = "backend_capacity"
+	CauseRefreshFailure          = "refresh_failure"
 	StateFleetNeedsAttention     = "needs_attention"
 	StateProjectNeedsAttention   = "needs_human_attention"
 	TransitionEntry              = "entry"
@@ -34,6 +35,7 @@ type observation struct {
 	WaitReasons     []string
 	FailureBreakers []telemetry.FailureBreaker
 	BackendOutages  []telemetry.BackendOutage
+	RefreshFailures []telemetry.RefreshFailure
 }
 
 func observations(snapshot telemetry.Snapshot, health []project.Health) []observation {
@@ -48,6 +50,7 @@ func observations(snapshot telemetry.Snapshot, health []project.Health) []observ
 	projectCauses := map[string]map[string][]string{}
 	projectBreakers := map[string][]telemetry.FailureBreaker{}
 	projectOutages := map[string][]telemetry.BackendOutage{}
+	projectRefreshFailures := map[string][]telemetry.RefreshFailure{}
 	fleetCauses := []string{}
 	fleetWaitReasons := []string{}
 	for _, stall := range snapshot.DispatchStalls {
@@ -101,6 +104,18 @@ func observations(snapshot telemetry.Snapshot, health []project.Health) []observ
 		projectOutages[projectID] = append(projectOutages[projectID], outage)
 		fleetCauses = append(fleetCauses, CauseBackendCapacity)
 	}
+	for _, failure := range snapshot.RefreshFailures() {
+		projectID := strings.TrimSpace(failure.ProjectID)
+		if projectID == "" {
+			continue
+		}
+		if projectCauses[projectID] == nil {
+			projectCauses[projectID] = map[string][]string{}
+		}
+		projectCauses[projectID][CauseRefreshFailure] = nil
+		projectRefreshFailures[projectID] = append(projectRefreshFailures[projectID], failure)
+		fleetCauses = append(fleetCauses, CauseRefreshFailure)
+	}
 
 	projectIDs := make([]string, 0, len(projectStatuses)+len(projectCauses))
 	seen := map[string]struct{}{}
@@ -115,19 +130,23 @@ func observations(snapshot telemetry.Snapshot, health []project.Health) []observ
 		projectIDs = append(projectIDs, projectID)
 	}
 	slices.Sort(projectIDs)
-	result := make([]observation, 0, len(projectIDs)*4+1)
+	result := make([]observation, 0, len(projectIDs)*5+1)
 	for _, projectID := range projectIDs {
 		recoveryState := strings.TrimSpace(projectStatuses[projectID])
 		if recoveryState == "" {
 			recoveryState = unknownProjectRecoveryStatus
 		}
-		for _, cause := range []string{CauseCIUnavailable, CauseDispatchStall, CauseProjectFailureBreaker, CauseBackendCapacity} {
+		for _, cause := range []string{CauseCIUnavailable, CauseDispatchStall, CauseProjectFailureBreaker, CauseBackendCapacity, CauseRefreshFailure} {
 			waitReasons, active := projectCauses[projectID][cause]
 			state := recoveryState
 			causes := []string(nil)
 			if active {
 				state = StateProjectNeedsAttention
 				causes = []string{cause}
+			}
+			refreshFailures := []telemetry.RefreshFailure(nil)
+			if cause == CauseRefreshFailure {
+				refreshFailures = append(refreshFailures, projectRefreshFailures[projectID]...)
 			}
 			result = append(result, observation{
 				Identity:        projectIdentity(projectID, cause),
@@ -139,6 +158,7 @@ func observations(snapshot telemetry.Snapshot, health []project.Health) []observ
 				WaitReasons:     compactSorted(waitReasons),
 				FailureBreakers: append([]telemetry.FailureBreaker(nil), projectBreakers[projectID]...),
 				BackendOutages:  append([]telemetry.BackendOutage(nil), projectOutages[projectID]...),
+				RefreshFailures: refreshFailures,
 			})
 		}
 	}
@@ -159,6 +179,7 @@ func observations(snapshot telemetry.Snapshot, health []project.Health) []observ
 		WaitReasons:     compactSorted(fleetWaitReasons),
 		FailureBreakers: append([]telemetry.FailureBreaker(nil), snapshot.FailureBreakers...),
 		BackendOutages:  append([]telemetry.BackendOutage(nil), snapshot.BackendOutages...),
+		RefreshFailures: append([]telemetry.RefreshFailure(nil), snapshot.RefreshFailures()...),
 	})
 	return result
 }

--- a/internal/orchestrator/config.go
+++ b/internal/orchestrator/config.go
@@ -23,6 +23,7 @@ func ConfigFromWorkflow(cfg workflowconfig.Config) Config {
 
 	return Config{
 		PollInterval:               durationFromMillis(cfg.Polling.IntervalMS),
+		RefreshFailureThreshold:    cfg.Polling.RefreshFailureThreshold,
 		MaxConcurrentAgents:        cfg.Agent.MaxConcurrentAgents,
 		MaxConcurrentAgentsByState: cloneStateLimits(cfg.Agent.MaxConcurrentAgentsByState),
 		DispatchPriorityByState:    append([]string(nil), cfg.Agent.DispatchPriorityByState...),
@@ -160,6 +161,9 @@ func normalizeConfig(cfg Config) Config {
 	}
 	if cfg.PollInterval <= 0 {
 		cfg.PollInterval = defaultPollInterval
+	}
+	if cfg.RefreshFailureThreshold <= 0 {
+		cfg.RefreshFailureThreshold = workflowconfig.DefaultRefreshFailureThreshold
 	}
 	if cfg.MaxConcurrentAgents <= 0 {
 		cfg.MaxConcurrentAgents = defaultMaxConcurrentAgents

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -70,6 +70,7 @@ var (
 
 type Config struct {
 	PollInterval                  time.Duration
+	RefreshFailureThreshold       int
 	MaxConcurrentAgents           int
 	MaxConcurrentAgentsByState    map[string]int
 	DispatchPriorityByState       []string
@@ -968,6 +969,7 @@ func (o *Orchestrator) applyRuntimeUpdate(state *State, update RuntimeUpdate, ti
 		OverloadRetryDelay:    cfg.OverloadRetryDelay,
 	})
 	state.PollInterval = cfg.PollInterval
+	state.RefreshFailureThreshold = cfg.RefreshFailureThreshold
 	state.MaxConcurrentAgents = cfg.MaxConcurrentAgents
 	state.StrandedActiveThreshold = cfg.StrandedActiveThreshold
 	state.DispatchStallThreshold = cfg.DispatchStallThreshold

--- a/internal/orchestrator/refresh_health_test.go
+++ b/internal/orchestrator/refresh_health_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 	"time"
 
+	workflowconfig "github.com/digitaldrywood/detent/internal/config"
 	"github.com/digitaldrywood/detent/internal/connector"
 	"github.com/digitaldrywood/detent/internal/telemetry"
 )
@@ -119,6 +120,19 @@ func TestMarkRefreshKeepsEffectiveIntervalForStaleness(t *testing.T) {
 				t.Fatalf("refreshStaleAfter() = %s, want %s", got, tt.wantStaleAfter)
 			}
 		})
+	}
+}
+
+func TestRefreshFailureThresholdFlowsFromWorkflow(t *testing.T) {
+	t.Parallel()
+
+	workflow := workflowconfig.Default()
+	workflow.Polling.RefreshFailureThreshold = 5
+	cfg := normalizeConfig(ConfigFromWorkflow(workflow))
+	state := newState(cfg)
+	snapshot := state.Snapshot(time.Date(2026, 8, 17, 15, 0, 0, 0, time.UTC))
+	if snapshot.Refresh.FailureThreshold != 5 {
+		t.Fatalf("Refresh.FailureThreshold = %d, want 5", snapshot.Refresh.FailureThreshold)
 	}
 }
 

--- a/internal/orchestrator/snapshot.go
+++ b/internal/orchestrator/snapshot.go
@@ -37,10 +37,14 @@ func (s State) Snapshot(now time.Time) telemetry.Snapshot {
 	}
 	staleAfter := refreshStaleAfter(s.PollInterval)
 	sources := refreshSourceSnapshots(s.RefreshSources)
+	failureThreshold := s.RefreshFailureThreshold
+	if failureThreshold <= 0 {
+		failureThreshold = refreshFailureDegradedThreshold
+	}
 	refresh := telemetry.Refresh{
 		PollIntervalSeconds: int64(s.PollInterval / time.Second),
 		StaleAfterSeconds:   int64(staleAfter / time.Second),
-		FailureThreshold:    refreshFailureDegradedThreshold,
+		FailureThreshold:    failureThreshold,
 		DataSeq:             s.DataSeq,
 		LastRefreshAt:       timePointer(s.LastRefreshAt),
 		NextRefreshAt:       timePointer(s.NextRefreshAt),

--- a/internal/orchestrator/state.go
+++ b/internal/orchestrator/state.go
@@ -26,6 +26,7 @@ import (
 
 type State struct {
 	PollInterval             time.Duration
+	RefreshFailureThreshold  int
 	MaxConcurrentAgents      int
 	MaxAgentsByState         map[string]int
 	PoolName                 string
@@ -307,6 +308,7 @@ type DependencyAutoUnblockRecord struct {
 func newState(cfg Config) State {
 	return State{
 		PollInterval:             cfg.PollInterval,
+		RefreshFailureThreshold:  cfg.RefreshFailureThreshold,
 		MaxConcurrentAgents:      cfg.MaxConcurrentAgents,
 		MaxAgentsByState:         cloneStateLimits(cfg.MaxConcurrentAgentsByState),
 		StrandedActiveThreshold:  cfg.StrandedActiveThreshold,
@@ -356,6 +358,7 @@ func newState(cfg Config) State {
 func (s State) clone() State {
 	cloned := State{
 		PollInterval:             s.PollInterval,
+		RefreshFailureThreshold:  s.RefreshFailureThreshold,
 		MaxConcurrentAgents:      s.MaxConcurrentAgents,
 		MaxAgentsByState:         cloneStateLimits(s.MaxAgentsByState),
 		PoolName:                 s.PoolName,

--- a/internal/telemetry/snapshot.go
+++ b/internal/telemetry/snapshot.go
@@ -400,6 +400,23 @@ type Refresh struct {
 	Manual              *RefreshAttempt `json:"manual,omitempty"`
 }
 
+type RefreshFailureReason string
+
+const (
+	RefreshFailureReasonConsecutiveFailures RefreshFailureReason = "consecutive_failures"
+	RefreshFailureReasonNeverRefreshed      RefreshFailureReason = "never_refreshed"
+)
+
+type RefreshFailure struct {
+	ProjectID        string               `json:"project_id"`
+	Reason           RefreshFailureReason `json:"reason"`
+	Source           RefreshSourceName    `json:"source,omitempty"`
+	FailureStreak    int                  `json:"failure_streak"`
+	FailureThreshold int                  `json:"failure_threshold"`
+	LastError        string               `json:"last_error"`
+	LastErrorAt      *time.Time           `json:"last_error_at,omitempty"`
+}
+
 type RefreshSource struct {
 	ProjectID     string            `json:"project_id,omitempty"`
 	Name          RefreshSourceName `json:"name"`
@@ -520,6 +537,92 @@ func (r Refresh) Stale(now time.Time) bool {
 		}
 	}
 	return false
+}
+
+func (s Snapshot) RefreshFailures() []RefreshFailure {
+	projects := s.Projects
+	if len(projects) == 0 && (strings.TrimSpace(s.Project.ID) != "" || refreshHasReadinessSignal(s.Refresh)) {
+		projects = []ProjectSnapshot{{Project: s.Project, Refresh: s.Refresh}}
+	}
+	failures := make([]RefreshFailure, 0, len(projects))
+	for _, project := range projects {
+		if failure, ok := project.Refresh.failure(strings.TrimSpace(project.Project.ID)); ok {
+			failures = append(failures, failure)
+		}
+	}
+	return failures
+}
+
+func (r Refresh) failure(projectID string) (RefreshFailure, bool) {
+	threshold := r.FailureThreshold
+	if threshold <= 0 {
+		threshold = 3
+	}
+	source := mostRelevantFailedRefreshSource(r.Sources, threshold, r.LastRefreshAt == nil)
+	lastError := strings.TrimSpace(r.LastError)
+	lastErrorAt := r.LastErrorAt
+	if lastError == "" {
+		lastError = strings.TrimSpace(source.LastError)
+	}
+	if lastErrorAt == nil {
+		lastErrorAt = source.LastErrorAt
+	}
+	if r.LastRefreshAt == nil && lastError != "" {
+		return RefreshFailure{
+			ProjectID:        projectID,
+			Reason:           RefreshFailureReasonNeverRefreshed,
+			Source:           source.Name,
+			FailureStreak:    source.FailureStreak,
+			FailureThreshold: threshold,
+			LastError:        lastError,
+			LastErrorAt:      copyTimePointer(lastErrorAt),
+		}, true
+	}
+	if source.FailureStreak < threshold {
+		return RefreshFailure{}, false
+	}
+	return RefreshFailure{
+		ProjectID:        projectID,
+		Reason:           RefreshFailureReasonConsecutiveFailures,
+		Source:           source.Name,
+		FailureStreak:    source.FailureStreak,
+		FailureThreshold: threshold,
+		LastError:        lastError,
+		LastErrorAt:      copyTimePointer(lastErrorAt),
+	}, true
+}
+
+func mostRelevantFailedRefreshSource(sources []RefreshSource, threshold int, neverRefreshed bool) RefreshSource {
+	var selected RefreshSource
+	for _, source := range sources {
+		eligible := source.FailureStreak >= threshold
+		if neverRefreshed {
+			eligible = source.FailureStreak > 0 || strings.TrimSpace(source.LastError) != ""
+		}
+		if !eligible {
+			continue
+		}
+		if selected.Name == "" || source.FailureStreak > selected.FailureStreak ||
+			(source.FailureStreak == selected.FailureStreak && refreshSourceErrorAt(source).After(refreshSourceErrorAt(selected))) {
+			selected = source
+		}
+	}
+	return selected
+}
+
+func refreshSourceErrorAt(source RefreshSource) time.Time {
+	if source.LastErrorAt == nil {
+		return time.Time{}
+	}
+	return source.LastErrorAt.UTC()
+}
+
+func copyTimePointer(value *time.Time) *time.Time {
+	if value == nil {
+		return nil
+	}
+	cloned := *value
+	return &cloned
 }
 
 type Counts struct {

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -1086,12 +1086,14 @@ func (s *Server) health(c echo.Context) error {
 	dispatch := telemetry.DispatchStatus{}
 	dispatchStalls := []telemetry.DispatchStatus{}
 	notificationFailures := []healthnotify.Failure{}
+	refreshFailures := []telemetry.RefreshFailure{}
 	refresh := telemetry.Refresh{}
 	snapshotGeneratedAt := time.Time{}
 	snapshotAgeSeconds := int64(0)
 	if s.hub != nil {
 		if snapshot, ok := s.hub.Latest(); ok {
 			snapshot = snapshot.WithFreshness(now)
+			refreshFailures = snapshot.RefreshFailures()
 			snapshotGeneratedAt = snapshot.GeneratedAt
 			snapshotAgeSeconds = snapshot.AgeSeconds(now)
 			refresh = snapshot.Refresh
@@ -1132,13 +1134,13 @@ func (s *Server) health(c echo.Context) error {
 		checks["demo_clock"] = s.demo.clock
 	}
 	projectStatus, projectHealth := s.projectHealth()
-	projectHealth = applyNeedsAttentionToProjectHealth(projectHealth, dispatchStalls, ciUnavailable, failureBreakers, backendOutages, tickLiveness)
+	projectHealth = applyNeedsAttentionToProjectHealth(projectHealth, dispatchStalls, ciUnavailable, failureBreakers, backendOutages, tickLiveness, refreshFailures)
 	var budgets []healthBudget
 	var workflows []healthWorkflowSource
 	if status != "draining" {
 		budgets = s.enforcedBudgets()
 		workflows = s.workflowSources()
-		if len(ciUnavailable) > 0 || len(dispatchStalls) > 0 || len(failureBreakers) > 0 || len(backendOutages) > 0 || tickLivenessNeedsAttention(tickLiveness) {
+		if len(ciUnavailable) > 0 || len(dispatchStalls) > 0 || len(failureBreakers) > 0 || len(backendOutages) > 0 || tickLivenessNeedsAttention(tickLiveness) || len(refreshFailures) > 0 {
 			status = "needs_attention"
 		}
 	}
@@ -1163,6 +1165,7 @@ func (s *Server) health(c echo.Context) error {
 		Dispatch:             dispatch,
 		DispatchStalls:       dispatchStalls,
 		NotificationFailures: notificationFailures,
+		RefreshFailures:      refreshFailures,
 		Projects:             projectHealth,
 		Refresh:              refresh,
 		SnapshotGeneratedAt:  snapshotGeneratedAt,
@@ -1171,8 +1174,9 @@ func (s *Server) health(c echo.Context) error {
 	})
 }
 
-func applyNeedsAttentionToProjectHealth(projects []healthProject, stalls []telemetry.DispatchStatus, ciUnavailable []telemetry.CICondition, breakers []telemetry.FailureBreaker, outages []telemetry.BackendOutage, tickLiveness []telemetry.TickLiveness) []healthProject {
+func applyNeedsAttentionToProjectHealth(projects []healthProject, stalls []telemetry.DispatchStatus, ciUnavailable []telemetry.CICondition, breakers []telemetry.FailureBreaker, outages []telemetry.BackendOutage, tickLiveness []telemetry.TickLiveness, refreshFailures []telemetry.RefreshFailure) []healthProject {
 	needsAttention := make(map[string]struct{}, len(stalls)+len(ciUnavailable)+len(breakers)+len(outages)+len(tickLiveness))
+	refreshByProject := make(map[string]telemetry.RefreshFailure, len(refreshFailures))
 	for _, stall := range stalls {
 		if projectID := strings.TrimSpace(stall.ProjectID); projectID != "" && stall.Stalled {
 			needsAttention[projectID] = struct{}{}
@@ -1198,9 +1202,22 @@ func applyNeedsAttentionToProjectHealth(projects []healthProject, stalls []telem
 			needsAttention[projectID] = struct{}{}
 		}
 	}
+	for _, failure := range refreshFailures {
+		if projectID := strings.TrimSpace(failure.ProjectID); projectID != "" {
+			needsAttention[projectID] = struct{}{}
+			refreshByProject[projectID] = failure
+		}
+	}
 	for index := range projects {
-		if _, ok := needsAttention[strings.TrimSpace(projects[index].ProjectID)]; ok {
+		projectID := strings.TrimSpace(projects[index].ProjectID)
+		if _, ok := needsAttention[projectID]; ok {
 			projects[index].Status = "needs_human_attention"
+		}
+		if failure, ok := refreshByProject[projectID]; ok {
+			projects[index].LastError = failure.LastError
+			if failure.LastErrorAt != nil {
+				projects[index].LastErrorAt = failure.LastErrorAt.UTC()
+			}
 		}
 	}
 	return projects
@@ -1485,6 +1502,7 @@ type healthResponse struct {
 	Dispatch             telemetry.DispatchStatus     `json:"dispatch"`
 	DispatchStalls       []telemetry.DispatchStatus   `json:"dispatch_stalls,omitempty"`
 	NotificationFailures []healthnotify.Failure       `json:"health_notification_failures,omitempty"`
+	RefreshFailures      []telemetry.RefreshFailure   `json:"refresh_failures,omitempty"`
 	Projects             []healthProject              `json:"projects,omitempty"`
 	Refresh              telemetry.Refresh            `json:"refresh"`
 	SnapshotGeneratedAt  time.Time                    `json:"snapshot_generated_at,omitzero"`

--- a/internal/web/server_test.go
+++ b/internal/web/server_test.go
@@ -7014,6 +7014,127 @@ func TestHealthReportsTickLivenessAndSnapshotAge(t *testing.T) {
 	}
 }
 
+func TestHealthReportsProjectRefreshFailures(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 8, 17, 14, 0, 0, 0, time.UTC)
+	lastRefreshAt := now.Add(-time.Minute)
+	lastErrorAt := now.Add(-30 * time.Second)
+	tests := []struct {
+		name             string
+		refresh          telemetry.Refresh
+		wantHealthStatus string
+		wantFailures     int
+	}{
+		{
+			name: "single transient failure remains healthy",
+			refresh: telemetry.Refresh{
+				Status:           telemetry.RefreshStatusDegraded,
+				FailureThreshold: 3,
+				LastRefreshAt:    &lastRefreshAt,
+				LastError:        "candidate endpoint unavailable",
+				LastErrorAt:      &lastErrorAt,
+				Sources: []telemetry.RefreshSource{{
+					Name: telemetry.RefreshSourceCandidates, FailureStreak: 1, LastError: "candidate endpoint unavailable", LastErrorAt: &lastErrorAt,
+				}},
+			},
+			wantHealthStatus: "ok",
+		},
+		{
+			name: "consecutive failures need attention",
+			refresh: telemetry.Refresh{
+				Status:           telemetry.RefreshStatusDegraded,
+				FailureThreshold: 3,
+				LastRefreshAt:    &lastRefreshAt,
+				LastError:        "candidate endpoint unavailable",
+				LastErrorAt:      &lastErrorAt,
+				Sources: []telemetry.RefreshSource{{
+					Name: telemetry.RefreshSourceCandidates, FailureStreak: 3, LastError: "candidate endpoint unavailable", LastErrorAt: &lastErrorAt,
+				}},
+			},
+			wantHealthStatus: "needs_attention",
+			wantFailures:     1,
+		},
+		{
+			name: "never refreshed failure needs attention immediately",
+			refresh: telemetry.Refresh{
+				Status:           telemetry.RefreshStatusDegraded,
+				FailureThreshold: 3,
+				LastError:        "Bad credentials",
+				LastErrorAt:      &lastErrorAt,
+				Sources: []telemetry.RefreshSource{{
+					Name: telemetry.RefreshSourceCandidates, FailureStreak: 1, LastError: "Bad credentials", LastErrorAt: &lastErrorAt,
+				}},
+			},
+			wantHealthStatus: "needs_attention",
+			wantFailures:     1,
+		},
+		{
+			name: "successful refresh clears attention",
+			refresh: telemetry.Refresh{
+				Status:           telemetry.RefreshStatusReady,
+				FailureThreshold: 3,
+				LastRefreshAt:    &lastRefreshAt,
+				Sources: []telemetry.RefreshSource{{
+					Name: telemetry.RefreshSourceCandidates, LastSuccessAt: &lastRefreshAt,
+				}},
+			},
+			wantHealthStatus: "ok",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			deps := testDeps(t)
+			mustSetWebProject(t, deps.Registry, "pyroapex", true)
+			deps.TickLiveness = tickLivenessProbe{values: []telemetry.TickLiveness{{
+				ProjectID: "pyroapex", Status: telemetry.TickLivenessStatusReady, LastTickAt: &now,
+			}}}
+			if err := deps.Hub.Publish(telemetry.Snapshot{
+				GeneratedAt: now,
+				Project:     telemetry.Project{ID: "pyroapex"},
+				Projects: []telemetry.ProjectSnapshot{{
+					Project: telemetry.Project{ID: "pyroapex"},
+					Refresh: tt.refresh,
+				}},
+				Refresh: tt.refresh,
+			}); err != nil {
+				t.Fatalf("Publish() error = %v", err)
+			}
+			server, err := web.NewServer(web.Config{Now: func() time.Time { return now }}, deps)
+			if err != nil {
+				t.Fatalf("NewServer() error = %v", err)
+			}
+
+			health := requestJSON(t, server, http.MethodGet, "/health", http.StatusOK)
+			if health["status"] != tt.wantHealthStatus {
+				t.Fatalf("health status = %#v, want %q", health["status"], tt.wantHealthStatus)
+			}
+			failures, _ := health["refresh_failures"].([]any)
+			if len(failures) != tt.wantFailures {
+				t.Fatalf("refresh_failures = %#v, want %d entries", health["refresh_failures"], tt.wantFailures)
+			}
+			if tt.wantFailures > 0 {
+				failure := failures[0].(map[string]any)
+				if failure["project_id"] != "pyroapex" || failure["last_error"] != tt.refresh.LastError {
+					t.Fatalf("refresh failure = %#v", failure)
+				}
+				projects := health["projects"].([]any)
+				project := projects[0].(map[string]any)
+				if project["status"] != "needs_human_attention" || project["last_error"] != tt.refresh.LastError {
+					t.Fatalf("project health = %#v", project)
+				}
+			}
+			liveness := health["tick_liveness"].([]any)
+			if len(liveness) != 1 || liveness[0].(map[string]any)["status"] != string(telemetry.TickLivenessStatusReady) {
+				t.Fatalf("tick_liveness = %#v, want advancing loop", liveness)
+			}
+		})
+	}
+}
+
 func TestProjectStateAPIRendersConfiguredProjectWithoutTelemetryRows(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

- Promote per-project tracker refresh failure streaks into fleet `needs_attention` health with project and last-error diagnostics.
- Treat a failed first refresh as immediately attention-worthy, add a configurable threshold, and notify on entry and recovery transitions.

Fixes #1864

## UI Surface Contract

- [x] N/A, or the linked issue explicitly authorizes any high-impact UI surface, layout, density, first-viewport, or responsive visibility tradeoff.
- [x] Persistent top-of-screen messaging is explicitly authorized by the issue, or this PR does not add it.
- [x] Visual changes to primary operator screens include screenshot or browser verification below.

## Test Plan

- [x] `make check`
- [x] Table-driven fleet health tests cover transient failure, threshold crossing, never-refreshed failure, and recovery.
- [x] Health notifier tests cover entry and recovery payloads.