### PR TITLE
feat(resilience): model tracker outages

### DIFF
--- a/internal/cli/runner.go
+++ b/internal/cli/runner.go
@@ -911,6 +911,7 @@ func mergeSnapshot(current, next telemetry.Snapshot) telemetry.Snapshot {
 	current.TrackerDrift.UntrackedOpen = append(current.TrackerDrift.UntrackedOpen, next.TrackerDrift.UntrackedOpen...)
 	current.TrackerDrift.OpenTerminal = append(current.TrackerDrift.OpenTerminal, next.TrackerDrift.OpenTerminal...)
 	current.Budget.Refusals = append(current.Budget.Refusals, next.Budget.Refusals...)
+	current.TrackerUnavailable = append(current.TrackerUnavailable, next.TrackerUnavailable...)
 	current.CIUnavailable = append(current.CIUnavailable, next.CIUnavailable...)
 	current.BackendOutages = append(current.BackendOutages, next.BackendOutages...)
 	current.FailureBreakers = append(current.FailureBreakers, next.FailureBreakers...)
@@ -1343,6 +1344,11 @@ func stampSnapshotProjectID(snapshot telemetry.Snapshot) telemetry.Snapshot {
 	for i := range snapshot.CIUnavailable {
 		if strings.TrimSpace(snapshot.CIUnavailable[i].ProjectID) == "" {
 			snapshot.CIUnavailable[i].ProjectID = projectID
+		}
+	}
+	for i := range snapshot.TrackerUnavailable {
+		if strings.TrimSpace(snapshot.TrackerUnavailable[i].ProjectID) == "" {
+			snapshot.TrackerUnavailable[i].ProjectID = projectID
 		}
 	}
 	for i := range snapshot.FailureBreakers {

--- a/internal/connector/availability.go
+++ b/internal/connector/availability.go
@@ -1,0 +1,93 @@
+package connector
+
+import (
+	"errors"
+	"strings"
+)
+
+const (
+	TrackerUnavailableCondition       = "tracker_unavailable"
+	TrackerAvailabilityClassServer    = "server"
+	TrackerAvailabilityClassTimeout   = "timeout"
+	TrackerAvailabilityClassTransport = "transport"
+)
+
+var ErrTrackerUnavailable = errors.New("tracker unavailable")
+
+type TrackerAvailabilityScope struct {
+	Connector          string `json:"connector"`
+	Endpoint           string `json:"endpoint"`
+	Operation          string `json:"operation"`
+	CredentialIdentity string `json:"credential_identity,omitempty"`
+}
+
+func (s TrackerAvailabilityScope) Normalize() TrackerAvailabilityScope {
+	s.Connector = strings.ToLower(strings.TrimSpace(s.Connector))
+	s.Endpoint = strings.TrimSpace(s.Endpoint)
+	s.Operation = strings.ToLower(strings.TrimSpace(s.Operation))
+	s.CredentialIdentity = strings.TrimSpace(s.CredentialIdentity)
+	return s
+}
+
+func (s TrackerAvailabilityScope) Key(class string) string {
+	s = s.Normalize()
+	return strings.Join([]string{
+		s.Connector,
+		s.Endpoint,
+		s.Operation,
+		strings.ToLower(strings.TrimSpace(class)),
+		s.CredentialIdentity,
+	}, "\x00")
+}
+
+type TrackerAvailabilityError struct {
+	Scope TrackerAvailabilityScope
+	Class string
+	Err   error
+}
+
+func NewTrackerAvailabilityError(scope TrackerAvailabilityScope, class string, err error) *TrackerAvailabilityError {
+	return &TrackerAvailabilityError{
+		Scope: scope.Normalize(),
+		Class: strings.ToLower(strings.TrimSpace(class)),
+		Err:   err,
+	}
+}
+
+func (e *TrackerAvailabilityError) Error() string {
+	if e == nil {
+		return ErrTrackerUnavailable.Error()
+	}
+	tracker := strings.TrimSpace(e.Scope.Connector)
+	if tracker == "" {
+		tracker = "configured"
+	}
+	message := "tracker " + tracker + " unavailable (" + TrackerUnavailableCondition
+	if class := strings.TrimSpace(e.Class); class != "" {
+		message += "/" + class
+	}
+	message += ")"
+	if e.Err != nil {
+		message += ": " + e.Err.Error()
+	}
+	return message
+}
+
+func (e *TrackerAvailabilityError) Unwrap() error {
+	if e == nil {
+		return nil
+	}
+	return e.Err
+}
+
+func (e *TrackerAvailabilityError) Is(target error) bool {
+	return target == ErrTrackerUnavailable
+}
+
+func AsTrackerAvailability(err error) (*TrackerAvailabilityError, bool) {
+	var availabilityErr *TrackerAvailabilityError
+	if !errors.As(err, &availabilityErr) || availabilityErr == nil {
+		return nil, false
+	}
+	return availabilityErr, true
+}

--- a/internal/connector/github/client.go
+++ b/internal/connector/github/client.go
@@ -164,6 +164,7 @@ func (c *Client) graphQLWithType(ctx context.Context, queryType string, query st
 	}
 
 	queryType = graphQLQueryType(queryType, query)
+	trackerRead := graphQLTrackerRead(queryType, query)
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.endpoint, &body)
 	if err != nil {
 		return fmt.Errorf("%w: %w", ErrInvalidEndpoint, err)
@@ -185,9 +186,9 @@ func (c *Client) graphQLWithType(ctx context.Context, queryType string, query st
 	resp, err := c.httpClient.Do(req)
 	if err != nil {
 		if ctxErr := ctx.Err(); ctxErr != nil {
-			return ctxErr
+			return c.trackerReadAvailabilityError(trackerRead, token, c.endpoint, queryType, ctxErr)
 		}
-		return fmt.Errorf("%w: %w", ErrTransient, err)
+		return c.trackerReadAvailabilityError(trackerRead, token, c.endpoint, queryType, fmt.Errorf("%w: %w", ErrTransient, err))
 	}
 	defer func() {
 		if err := drainAndClose(resp.Body); err != nil {
@@ -205,7 +206,7 @@ func (c *Client) graphQLWithType(ctx context.Context, queryType string, query st
 
 	raw, err := io.ReadAll(resp.Body)
 	if err != nil {
-		return fmt.Errorf("%w: read response: %w", ErrTransient, err)
+		return c.trackerReadAvailabilityError(trackerRead, token, c.endpoint, queryType, fmt.Errorf("%w: read response: %w", ErrTransient, err))
 	}
 	connector.ReportProgress(ctx)
 	receivedAt := time.Now()
@@ -217,7 +218,7 @@ func (c *Client) graphQLWithType(ctx context.Context, queryType string, query st
 			return c.graphQLWithType(ctx, queryType, query, variables, out, false)
 		}
 		c.recordGraphQLRateLimitFailure(err, headerRateLimit)
-		return err
+		return c.trackerReadStatusError(trackerRead, token, c.endpoint, queryType, resp.StatusCode, err)
 	}
 
 	var envelope struct {
@@ -298,13 +299,14 @@ func (c *Client) restProbeWithTokenRefresh(ctx context.Context, method string, p
 	}
 
 	family := restEndpointFamily(method, path)
+	trackerRead := restTrackerRead(method, family)
 	c.logRESTRequest(ctx, "github rest probe request", method, path, family, body != nil)
 	resp, err := c.httpClient.Do(req)
 	if err != nil {
 		if ctxErr := ctx.Err(); ctxErr != nil {
-			return restProbeResult{}, ctxErr
+			return restProbeResult{}, c.trackerReadAvailabilityError(trackerRead, token, c.restEndpoint, restRequestPurpose(method, path), ctxErr)
 		}
-		return restProbeResult{}, fmt.Errorf("%w: %w", ErrTransient, err)
+		return restProbeResult{}, c.trackerReadAvailabilityError(trackerRead, token, c.restEndpoint, restRequestPurpose(method, path), fmt.Errorf("%w: %w", ErrTransient, err))
 	}
 	defer func() {
 		if err := drainAndClose(resp.Body); err != nil {
@@ -314,7 +316,7 @@ func (c *Client) restProbeWithTokenRefresh(ctx context.Context, method string, p
 
 	raw, err := io.ReadAll(resp.Body)
 	if err != nil {
-		return restProbeResult{}, fmt.Errorf("%w: read response: %w", ErrTransient, err)
+		return restProbeResult{}, c.trackerReadAvailabilityError(trackerRead, token, c.restEndpoint, restRequestPurpose(method, path), fmt.Errorf("%w: read response: %w", ErrTransient, err))
 	}
 	connector.ReportProgress(ctx)
 	receivedAt := time.Now()
@@ -403,13 +405,14 @@ func (c *Client) restWithTokenRefresh(ctx context.Context, method string, path s
 	}
 
 	family := restEndpointFamily(method, path)
+	trackerRead := restTrackerRead(method, family)
 	c.logRESTRequest(ctx, "github rest request", method, path, family, body != nil)
 	resp, err := c.httpClient.Do(req)
 	if err != nil {
 		if ctxErr := ctx.Err(); ctxErr != nil {
-			return nil, ctxErr
+			return nil, c.trackerReadAvailabilityError(trackerRead, token, c.restEndpoint, restRequestPurpose(method, path), ctxErr)
 		}
-		return nil, fmt.Errorf("%w: %w", ErrTransient, err)
+		return nil, c.trackerReadAvailabilityError(trackerRead, token, c.restEndpoint, restRequestPurpose(method, path), fmt.Errorf("%w: %w", ErrTransient, err))
 	}
 	defer func() {
 		if err := drainAndClose(resp.Body); err != nil {
@@ -420,7 +423,7 @@ func (c *Client) restWithTokenRefresh(ctx context.Context, method string, path s
 	c.logRESTResponse(ctx, "github rest response", method, path, family, resp.StatusCode)
 	raw, err := io.ReadAll(resp.Body)
 	if err != nil {
-		return nil, fmt.Errorf("%w: read response: %w", ErrTransient, err)
+		return nil, c.trackerReadAvailabilityError(trackerRead, token, c.restEndpoint, restRequestPurpose(method, path), fmt.Errorf("%w: read response: %w", ErrTransient, err))
 	}
 	connector.ReportProgress(ctx)
 	receivedAt := time.Now()
@@ -448,7 +451,7 @@ func (c *Client) restWithTokenRefresh(ctx context.Context, method string, path s
 		if c.refreshAfterAuthFailure(ctx, err, allowTokenRefresh) {
 			return c.restWithTokenRefresh(ctx, method, path, body, out, false)
 		}
-		return nil, err
+		return nil, c.trackerReadStatusError(trackerRead, token, c.restEndpoint, restRequestPurpose(method, path), resp.StatusCode, err)
 	}
 	headers := resp.Header.Clone()
 	c.storeRESTConditionalEntry(method, path, headers, raw)
@@ -1526,6 +1529,58 @@ func graphQLQueryType(queryType string, query string) string {
 		}
 	}
 	return "graphql"
+}
+
+func graphQLTrackerRead(queryType string, query string) bool {
+	if strings.HasPrefix(strings.ToLower(strings.TrimSpace(query)), "mutation") {
+		return false
+	}
+	switch strings.ToLower(strings.TrimSpace(queryType)) {
+	case graphQLQueryMergeQueue, graphQLQueryEnqueuePR:
+		return false
+	default:
+		return true
+	}
+}
+
+func restTrackerRead(method string, family string) bool {
+	if strings.ToUpper(strings.TrimSpace(method)) != http.MethodGet {
+		return false
+	}
+	switch strings.TrimSpace(family) {
+	case "label issues", "repository issues", "issue reads", "issue comments", "issue dependencies", "issue field values", "search":
+		return true
+	default:
+		return false
+	}
+}
+
+func (c *Client) trackerReadAvailabilityError(trackerRead bool, token string, endpoint string, operation string, err error) error {
+	if !trackerRead || err == nil || errors.Is(err, context.Canceled) {
+		return err
+	}
+	class := connector.TrackerAvailabilityClassTransport
+	if errors.Is(err, context.DeadlineExceeded) {
+		class = connector.TrackerAvailabilityClassTimeout
+	}
+	return connector.NewTrackerAvailabilityError(connector.TrackerAvailabilityScope{
+		Connector:          connector.BackendGitHub.String(),
+		Endpoint:           endpoint,
+		Operation:          operation,
+		CredentialIdentity: c.restCredentialIdentity(token),
+	}, class, err)
+}
+
+func (c *Client) trackerReadStatusError(trackerRead bool, token string, endpoint string, operation string, status int, err error) error {
+	if !trackerRead || status < http.StatusInternalServerError {
+		return err
+	}
+	return connector.NewTrackerAvailabilityError(connector.TrackerAvailabilityScope{
+		Connector:          connector.BackendGitHub.String(),
+		Endpoint:           endpoint,
+		Operation:          operation,
+		CredentialIdentity: c.restCredentialIdentity(token),
+	}, connector.TrackerAvailabilityClassServer, err)
 }
 
 func sortedGraphQLQueryCosts(costs map[string]connector.GraphQLQueryCost) []connector.GraphQLQueryCost {

--- a/internal/connector/github/client_test.go
+++ b/internal/connector/github/client_test.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"io"
 	"log/slog"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"runtime"
@@ -82,6 +83,63 @@ func TestClientGraphQLSendsBearerRequest(t *testing.T) {
 	variables := payload["variables"].(map[string]any)
 	if variables["id"] != "PVT_1" {
 		t.Fatalf("variables.id = %v, want PVT_1", variables["id"])
+	}
+}
+
+func TestClientTrackerAvailabilityClassification(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name             string
+		queryType        string
+		query            string
+		status           int
+		transportErr     error
+		wantAvailability bool
+		wantClass        string
+	}{
+		{name: "server error", query: "query DetentCandidates { viewer { login } }", status: http.StatusServiceUnavailable, wantAvailability: true, wantClass: connector.TrackerAvailabilityClassServer},
+		{name: "timeout", query: "query DetentCandidates { viewer { login } }", transportErr: context.DeadlineExceeded, wantAvailability: true, wantClass: connector.TrackerAvailabilityClassTimeout},
+		{name: "dns", query: "query DetentCandidates { viewer { login } }", transportErr: &net.DNSError{Err: "no such host", Name: "api.github.test"}, wantAvailability: true, wantClass: connector.TrackerAvailabilityClassTransport},
+		{name: "transport", query: "query DetentCandidates { viewer { login } }", transportErr: errors.New("tls handshake failed"), wantAvailability: true, wantClass: connector.TrackerAvailabilityClassTransport},
+		{name: "tracker status pull request references", queryType: graphQLQueryPullRequests, query: "query DetentPullRequestReferences { viewer { login } }", status: http.StatusServiceUnavailable, wantAvailability: true, wantClass: connector.TrackerAvailabilityClassServer},
+		{name: "rate limit", query: "query DetentCandidates { viewer { login } }", status: http.StatusTooManyRequests},
+		{name: "forbidden", query: "query DetentCandidates { viewer { login } }", status: http.StatusForbidden},
+		{name: "not found", query: "query DetentCandidates { viewer { login } }", status: http.StatusNotFound},
+		{name: "mutation server error", query: "mutation DetentMove { updateIssue(input: {}) { id } }", status: http.StatusServiceUnavailable},
+		{name: "merge queue server error", queryType: graphQLQueryMergeQueue, query: "query DetentMergeQueue { viewer { login } }", status: http.StatusServiceUnavailable},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			client, err := NewClient(ClientConfig{
+				Endpoint:    "https://api.github.test/graphql",
+				TokenSource: StaticTokenSource("test-token"),
+				HTTPClient: staticHTTPClient{do: func(req *http.Request) (*http.Response, error) {
+					if tt.transportErr != nil {
+						return nil, tt.transportErr
+					}
+					return jsonResponse(req, tt.status, `{"message":"unavailable"}`, nil), nil
+				}},
+			})
+			if err != nil {
+				t.Fatalf("NewClient() error = %v", err)
+			}
+
+			queryType := tt.queryType
+			if queryType == "" {
+				queryType = graphQLQueryCandidateIssues
+			}
+			err = client.GraphQLWithType(context.Background(), queryType, tt.query, nil, nil)
+			availabilityErr, gotAvailability := connector.AsTrackerAvailability(err)
+			if gotAvailability != tt.wantAvailability {
+				t.Fatalf("tracker availability = %v, want %v; error = %v", gotAvailability, tt.wantAvailability, err)
+			}
+			if gotAvailability && availabilityErr.Class != tt.wantClass {
+				t.Fatalf("class = %q, want %q", availabilityErr.Class, tt.wantClass)
+			}
+		})
 	}
 }
 
@@ -485,6 +543,9 @@ func TestClientRESTLogsRateLimitFailuresByDefault(t *testing.T) {
 	if !errors.Is(err, ErrRateLimited) {
 		t.Fatalf("REST() error = %v, want %v", err, ErrRateLimited)
 	}
+	if _, ok := connector.AsTrackerAvailability(err); ok {
+		t.Fatalf("REST() error = %v, do not want tracker availability for 403", err)
+	}
 
 	logText := logs.String()
 	for _, fragment := range []string{
@@ -556,6 +617,10 @@ func TestClientRESTLogsUnexpectedFailuresByDefault(t *testing.T) {
 	err = client.REST(context.Background(), http.MethodGet, "/repos/digitaldrywood/detent/issues", nil, nil)
 	if !errors.Is(err, ErrTransient) {
 		t.Fatalf("REST() error = %v, want %v", err, ErrTransient)
+	}
+	availabilityErr, ok := connector.AsTrackerAvailability(err)
+	if !ok || availabilityErr.Class != connector.TrackerAvailabilityClassServer {
+		t.Fatalf("REST() availability = %#v, want server class", availabilityErr)
 	}
 
 	logText := logs.String()

--- a/internal/connector/linear/client.go
+++ b/internal/connector/linear/client.go
@@ -3,13 +3,17 @@ package linear
 import (
 	"bytes"
 	"context"
+	"crypto/sha256"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"log/slog"
 	"net/http"
 	"net/url"
 	"strings"
+
+	"github.com/digitaldrywood/detent/internal/connector"
 )
 
 const (
@@ -85,32 +89,38 @@ func (c *Client) GraphQL(ctx context.Context, query string, variables map[string
 	req.Header.Set("Authorization", c.apiKey)
 	req.Header.Set("Content-Type", "application/json")
 
-	c.logger.DebugContext(ctx, "linear graphql request", "operation", firstLine(query), "variables_present", len(variables) > 0)
+	operation := linearGraphQLOperation(query)
+	trackerRead := !strings.HasPrefix(strings.ToLower(strings.TrimSpace(query)), "mutation")
+	c.logger.DebugContext(ctx, "linear graphql request", "operation", operation, "variables_present", len(variables) > 0)
 
 	resp, err := c.httpClient.Do(req)
 	if err != nil {
 		if ctxErr := ctx.Err(); ctxErr != nil {
-			return ctxErr
+			return c.trackerReadAvailabilityError(trackerRead, operation, ctxErr)
 		}
-		return fmt.Errorf("%w: %w", ErrTransient, err)
+		return c.trackerReadAvailabilityError(trackerRead, operation, fmt.Errorf("%w: %w", ErrTransient, err))
 	}
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
 		raw, err := io.ReadAll(io.LimitReader(resp.Body, maxErrorBodyBytes+1))
 		if err != nil {
-			return fmt.Errorf("%w: read response: %w", ErrTransient, err)
+			return c.trackerReadAvailabilityError(trackerRead, operation, fmt.Errorf("%w: read response: %w", ErrTransient, err))
 		}
-		return &StatusError{
+		statusErr := &StatusError{
 			StatusCode: resp.StatusCode,
 			Body:       strings.TrimSpace(string(raw)),
 			Err:        ErrUnexpectedStatus,
 		}
+		if trackerRead && resp.StatusCode >= http.StatusInternalServerError {
+			return connector.NewTrackerAvailabilityError(c.trackerAvailabilityScope(operation), connector.TrackerAvailabilityClassServer, statusErr)
+		}
+		return statusErr
 	}
 
 	raw, err := io.ReadAll(resp.Body)
 	if err != nil {
-		return fmt.Errorf("%w: read response: %w", ErrTransient, err)
+		return c.trackerReadAvailabilityError(trackerRead, operation, fmt.Errorf("%w: read response: %w", ErrTransient, err))
 	}
 
 	var envelope struct {
@@ -134,6 +144,42 @@ func (c *Client) GraphQL(ctx context.Context, query string, variables map[string
 	}
 
 	return nil
+}
+
+func (c *Client) trackerReadAvailabilityError(trackerRead bool, operation string, err error) error {
+	if !trackerRead || err == nil || errors.Is(err, context.Canceled) {
+		return err
+	}
+	class := connector.TrackerAvailabilityClassTransport
+	if errors.Is(err, context.DeadlineExceeded) {
+		class = connector.TrackerAvailabilityClassTimeout
+	}
+	return connector.NewTrackerAvailabilityError(c.trackerAvailabilityScope(operation), class, err)
+}
+
+func (c *Client) trackerAvailabilityScope(operation string) connector.TrackerAvailabilityScope {
+	sum := sha256.Sum256([]byte(c.endpoint + "\x00" + c.apiKey))
+	return connector.TrackerAvailabilityScope{
+		Connector:          connector.BackendLinear.String(),
+		Endpoint:           c.endpoint,
+		Operation:          operation,
+		CredentialIdentity: fmt.Sprintf("linear:%x", sum[:6]),
+	}
+}
+
+func linearGraphQLOperation(query string) string {
+	line := firstLine(query)
+	parts := strings.Fields(line)
+	if len(parts) >= 2 {
+		name := strings.Trim(parts[1], "{}")
+		if index := strings.IndexByte(name, '('); index >= 0 {
+			name = name[:index]
+		}
+		if name != "" {
+			return name
+		}
+	}
+	return "graphql"
 }
 
 func validateEndpoint(endpoint string) error {

--- a/internal/connector/linear/client_test.go
+++ b/internal/connector/linear/client_test.go
@@ -1,0 +1,76 @@
+package linear
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/digitaldrywood/detent/internal/connector"
+)
+
+type trackerAvailabilityHTTPClient struct {
+	do func(*http.Request) (*http.Response, error)
+}
+
+func (c trackerAvailabilityHTTPClient) Do(request *http.Request) (*http.Response, error) {
+	return c.do(request)
+}
+
+func TestClientTrackerAvailabilityClassification(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name             string
+		query            string
+		status           int
+		transportErr     error
+		wantAvailability bool
+		wantClass        string
+	}{
+		{name: "server error", query: "query DetentIssues { issues { nodes { id } } }", status: http.StatusBadGateway, wantAvailability: true, wantClass: connector.TrackerAvailabilityClassServer},
+		{name: "timeout", query: "query DetentIssues { issues { nodes { id } } }", transportErr: context.DeadlineExceeded, wantAvailability: true, wantClass: connector.TrackerAvailabilityClassTimeout},
+		{name: "dns", query: "query DetentIssues { issues { nodes { id } } }", transportErr: &net.DNSError{Err: "no such host", Name: "api.linear.test"}, wantAvailability: true, wantClass: connector.TrackerAvailabilityClassTransport},
+		{name: "transport", query: "query DetentIssues { issues { nodes { id } } }", transportErr: errors.New("tls handshake failed"), wantAvailability: true, wantClass: connector.TrackerAvailabilityClassTransport},
+		{name: "rate limit", query: "query DetentIssues { issues { nodes { id } } }", status: http.StatusTooManyRequests},
+		{name: "forbidden", query: "query DetentIssues { issues { nodes { id } } }", status: http.StatusForbidden},
+		{name: "not found", query: "query DetentIssues { issues { nodes { id } } }", status: http.StatusNotFound},
+		{name: "mutation server error", query: "mutation DetentMove { issueUpdate(id: \"1\") { success } }", status: http.StatusServiceUnavailable},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			client, err := NewClient(ClientConfig{
+				Endpoint: "https://api.linear.test/graphql",
+				APIKey:   "test-key",
+				HTTPClient: trackerAvailabilityHTTPClient{do: func(request *http.Request) (*http.Response, error) {
+					if tt.transportErr != nil {
+						return nil, tt.transportErr
+					}
+					return &http.Response{
+						StatusCode: tt.status,
+						Body:       io.NopCloser(strings.NewReader(`{"message":"unavailable"}`)),
+						Header:     http.Header{},
+						Request:    request,
+					}, nil
+				}},
+			})
+			if err != nil {
+				t.Fatalf("NewClient() error = %v", err)
+			}
+
+			err = client.GraphQL(context.Background(), tt.query, nil, nil)
+			availabilityErr, gotAvailability := connector.AsTrackerAvailability(err)
+			if gotAvailability != tt.wantAvailability {
+				t.Fatalf("tracker availability = %v, want %v; error = %v", gotAvailability, tt.wantAvailability, err)
+			}
+			if gotAvailability && availabilityErr.Class != tt.wantClass {
+				t.Fatalf("class = %q, want %q", availabilityErr.Class, tt.wantClass)
+			}
+		})
+	}
+}

--- a/internal/healthnotify/manager.go
+++ b/internal/healthnotify/manager.go
@@ -48,24 +48,25 @@ type Dependencies struct {
 }
 
 type Event struct {
-	Schema                  int                        `json:"schema"`
-	Event                   string                     `json:"event"`
-	ID                      string                     `json:"id"`
-	Identity                string                     `json:"identity"`
-	Transition              string                     `json:"transition"`
-	Instance                string                     `json:"instance"`
-	Host                    string                     `json:"host"`
-	Scope                   string                     `json:"scope"`
-	ProjectID               string                     `json:"project_id,omitempty"`
-	State                   string                     `json:"state"`
-	Causes                  []string                   `json:"causes,omitempty"`
-	WaitReasons             []string                   `json:"wait_reasons,omitempty"`
-	FailureBreakers         []telemetry.FailureBreaker `json:"failure_breakers,omitempty"`
-	BackendOutages          []telemetry.BackendOutage  `json:"backend_outages,omitempty"`
-	RefreshFailures         []telemetry.RefreshFailure `json:"refresh_failures,omitempty"`
-	EnteredAt               time.Time                  `json:"entered_at"`
-	NeedsAttentionEnteredAt time.Time                  `json:"needs_attention_entered_at"`
-	ObservedAt              time.Time                  `json:"observed_at"`
+	Schema                  int                          `json:"schema"`
+	Event                   string                       `json:"event"`
+	ID                      string                       `json:"id"`
+	Identity                string                       `json:"identity"`
+	Transition              string                       `json:"transition"`
+	Instance                string                       `json:"instance"`
+	Host                    string                       `json:"host"`
+	Scope                   string                       `json:"scope"`
+	ProjectID               string                       `json:"project_id,omitempty"`
+	State                   string                       `json:"state"`
+	Causes                  []string                     `json:"causes,omitempty"`
+	WaitReasons             []string                     `json:"wait_reasons,omitempty"`
+	TrackerConditions       []telemetry.TrackerCondition `json:"tracker_unavailable,omitempty"`
+	FailureBreakers         []telemetry.FailureBreaker   `json:"failure_breakers,omitempty"`
+	BackendOutages          []telemetry.BackendOutage    `json:"backend_outages,omitempty"`
+	RefreshFailures         []telemetry.RefreshFailure   `json:"refresh_failures,omitempty"`
+	EnteredAt               time.Time                    `json:"entered_at"`
+	NeedsAttentionEnteredAt time.Time                    `json:"needs_attention_entered_at"`
+	ObservedAt              time.Time                    `json:"observed_at"`
 }
 
 type Failure struct {
@@ -93,30 +94,32 @@ type Manager struct {
 }
 
 type durableState struct {
-	Schema                  int                        `json:"schema"`
-	Identity                string                     `json:"identity"`
-	Scope                   string                     `json:"scope"`
-	ProjectID               string                     `json:"project_id,omitempty"`
-	StableActive            bool                       `json:"stable_active"`
-	Pending                 *pendingState              `json:"pending,omitempty"`
-	NeedsAttentionEnteredAt time.Time                  `json:"needs_attention_entered_at,omitzero"`
-	Causes                  []string                   `json:"causes,omitempty"`
-	WaitReasons             []string                   `json:"wait_reasons,omitempty"`
-	FailureBreakers         []telemetry.FailureBreaker `json:"failure_breakers,omitempty"`
-	BackendOutages          []telemetry.BackendOutage  `json:"backend_outages,omitempty"`
-	RefreshFailures         []telemetry.RefreshFailure `json:"refresh_failures,omitempty"`
-	Deliveries              []deliveryState            `json:"deliveries,omitempty"`
+	Schema                  int                          `json:"schema"`
+	Identity                string                       `json:"identity"`
+	Scope                   string                       `json:"scope"`
+	ProjectID               string                       `json:"project_id,omitempty"`
+	StableActive            bool                         `json:"stable_active"`
+	Pending                 *pendingState                `json:"pending,omitempty"`
+	NeedsAttentionEnteredAt time.Time                    `json:"needs_attention_entered_at,omitzero"`
+	Causes                  []string                     `json:"causes,omitempty"`
+	WaitReasons             []string                     `json:"wait_reasons,omitempty"`
+	TrackerConditions       []telemetry.TrackerCondition `json:"tracker_unavailable,omitempty"`
+	FailureBreakers         []telemetry.FailureBreaker   `json:"failure_breakers,omitempty"`
+	BackendOutages          []telemetry.BackendOutage    `json:"backend_outages,omitempty"`
+	RefreshFailures         []telemetry.RefreshFailure   `json:"refresh_failures,omitempty"`
+	Deliveries              []deliveryState              `json:"deliveries,omitempty"`
 }
 
 type pendingState struct {
-	Active          bool                       `json:"active"`
-	State           string                     `json:"state"`
-	Causes          []string                   `json:"causes,omitempty"`
-	WaitReasons     []string                   `json:"wait_reasons,omitempty"`
-	FailureBreakers []telemetry.FailureBreaker `json:"failure_breakers,omitempty"`
-	BackendOutages  []telemetry.BackendOutage  `json:"backend_outages,omitempty"`
-	RefreshFailures []telemetry.RefreshFailure `json:"refresh_failures,omitempty"`
-	Since           time.Time                  `json:"since"`
+	Active            bool                         `json:"active"`
+	State             string                       `json:"state"`
+	Causes            []string                     `json:"causes,omitempty"`
+	WaitReasons       []string                     `json:"wait_reasons,omitempty"`
+	TrackerConditions []telemetry.TrackerCondition `json:"tracker_unavailable,omitempty"`
+	FailureBreakers   []telemetry.FailureBreaker   `json:"failure_breakers,omitempty"`
+	BackendOutages    []telemetry.BackendOutage    `json:"backend_outages,omitempty"`
+	RefreshFailures   []telemetry.RefreshFailure   `json:"refresh_failures,omitempty"`
+	Since             time.Time                    `json:"since"`
 }
 
 type deliveryState struct {
@@ -300,26 +303,29 @@ func (m *Manager) applyObservation(state *durableState, current observation, now
 	}
 	if state.Pending == nil || state.Pending.Active != current.Active {
 		state.Pending = &pendingState{
-			Active:          current.Active,
-			State:           current.State,
-			Causes:          compactSorted(current.Causes),
-			WaitReasons:     compactSorted(current.WaitReasons),
-			FailureBreakers: append([]telemetry.FailureBreaker(nil), current.FailureBreakers...),
-			BackendOutages:  append([]telemetry.BackendOutage(nil), current.BackendOutages...),
-			RefreshFailures: append([]telemetry.RefreshFailure(nil), current.RefreshFailures...),
-			Since:           now,
+			Active:            current.Active,
+			State:             current.State,
+			Causes:            compactSorted(current.Causes),
+			WaitReasons:       compactSorted(current.WaitReasons),
+			TrackerConditions: append([]telemetry.TrackerCondition(nil), current.TrackerConditions...),
+			FailureBreakers:   append([]telemetry.FailureBreaker(nil), current.FailureBreakers...),
+			BackendOutages:    append([]telemetry.BackendOutage(nil), current.BackendOutages...),
+			RefreshFailures:   append([]telemetry.RefreshFailure(nil), current.RefreshFailures...),
+			Since:             now,
 		}
 		return true
 	}
 	causes := compactSorted(current.Causes)
 	waitReasons := compactSorted(current.WaitReasons)
 	if state.Pending.State != current.State || !slices.Equal(state.Pending.Causes, causes) || !slices.Equal(state.Pending.WaitReasons, waitReasons) ||
+		!reflect.DeepEqual(state.Pending.TrackerConditions, current.TrackerConditions) ||
 		!reflect.DeepEqual(state.Pending.FailureBreakers, current.FailureBreakers) || !reflect.DeepEqual(state.Pending.BackendOutages, current.BackendOutages) ||
 		!reflect.DeepEqual(state.Pending.RefreshFailures, current.RefreshFailures) {
 		changed = true
 		state.Pending.State = current.State
 		state.Pending.Causes = causes
 		state.Pending.WaitReasons = waitReasons
+		state.Pending.TrackerConditions = append([]telemetry.TrackerCondition(nil), current.TrackerConditions...)
 		state.Pending.FailureBreakers = append([]telemetry.FailureBreaker(nil), current.FailureBreakers...)
 		state.Pending.BackendOutages = append([]telemetry.BackendOutage(nil), current.BackendOutages...)
 		state.Pending.RefreshFailures = append([]telemetry.RefreshFailure(nil), current.RefreshFailures...)
@@ -334,6 +340,7 @@ func (m *Manager) applyObservation(state *durableState, current observation, now
 		state.NeedsAttentionEnteredAt = pending.Since
 		state.Causes = append([]string(nil), pending.Causes...)
 		state.WaitReasons = append([]string(nil), pending.WaitReasons...)
+		state.TrackerConditions = append([]telemetry.TrackerCondition(nil), pending.TrackerConditions...)
 		state.FailureBreakers = append([]telemetry.FailureBreaker(nil), pending.FailureBreakers...)
 		state.BackendOutages = append([]telemetry.BackendOutage(nil), pending.BackendOutages...)
 		state.RefreshFailures = append([]telemetry.RefreshFailure(nil), pending.RefreshFailures...)
@@ -344,6 +351,7 @@ func (m *Manager) applyObservation(state *durableState, current observation, now
 	state.NeedsAttentionEnteredAt = time.Time{}
 	state.Causes = nil
 	state.WaitReasons = nil
+	state.TrackerConditions = nil
 	state.FailureBreakers = nil
 	state.BackendOutages = nil
 	state.RefreshFailures = nil
@@ -364,6 +372,7 @@ func (m *Manager) event(state *durableState, transition string, enteredState str
 		State:                   strings.TrimSpace(enteredState),
 		Causes:                  append([]string(nil), state.Causes...),
 		WaitReasons:             append([]string(nil), state.WaitReasons...),
+		TrackerConditions:       append([]telemetry.TrackerCondition(nil), state.TrackerConditions...),
 		FailureBreakers:         append([]telemetry.FailureBreaker(nil), state.FailureBreakers...),
 		BackendOutages:          append([]telemetry.BackendOutage(nil), state.BackendOutages...),
 		RefreshFailures:         append([]telemetry.RefreshFailure(nil), state.RefreshFailures...),

--- a/internal/healthnotify/manager_test.go
+++ b/internal/healthnotify/manager_test.go
@@ -66,6 +66,7 @@ func TestManagerEntryPayloadsFireOncePerIdentity(t *testing.T) {
 		snapshot        telemetry.Snapshot
 		cause           string
 		wantWaitReasons []string
+		wantTracker     bool
 	}{
 		{
 			name: "dispatch payload carries wait reason",
@@ -74,6 +75,14 @@ func TestManagerEntryPayloadsFireOncePerIdentity(t *testing.T) {
 			}}},
 			cause:           CauseDispatchStall,
 			wantWaitReasons: []string{"github_rest_capacity_paused"},
+		},
+		{
+			name: "tracker payload carries scoped condition",
+			snapshot: telemetry.Snapshot{TrackerUnavailable: []telemetry.TrackerCondition{{
+				ProjectID: "detent", Connector: "github", ConnectorInstance: "detent:github", Operation: "observed_status", ErrorClass: "server",
+			}}},
+			cause:       CauseTrackerUnavailable,
+			wantTracker: true,
 		},
 		{
 			name:     "CI payload omits wait reason",
@@ -115,6 +124,9 @@ func TestManagerEntryPayloadsFireOncePerIdentity(t *testing.T) {
 				}
 				if !event.EnteredAt.Equal(now) || !event.NeedsAttentionEnteredAt.Equal(now) || event.ID == "" {
 					t.Fatalf("event timestamps/id = %#v", event)
+				}
+				if got := len(event.TrackerConditions) > 0; got != tt.wantTracker {
+					t.Fatalf("TrackerConditions = %#v, want present %v", event.TrackerConditions, tt.wantTracker)
 				}
 			}
 		})

--- a/internal/healthnotify/observations.go
+++ b/internal/healthnotify/observations.go
@@ -12,6 +12,7 @@ import (
 const (
 	ScopeFleet                   = "fleet"
 	ScopeProject                 = "project"
+	CauseTrackerUnavailable      = "tracker_unavailable"
 	CauseCIUnavailable           = "ci_unavailable"
 	CauseDispatchStall           = "dispatch_stall"
 	CauseProjectFailureBreaker   = "project_failure_breaker"
@@ -26,16 +27,17 @@ const (
 )
 
 type observation struct {
-	Identity        string
-	Scope           string
-	ProjectID       string
-	Active          bool
-	State           string
-	Causes          []string
-	WaitReasons     []string
-	FailureBreakers []telemetry.FailureBreaker
-	BackendOutages  []telemetry.BackendOutage
-	RefreshFailures []telemetry.RefreshFailure
+	Identity          string
+	Scope             string
+	ProjectID         string
+	Active            bool
+	State             string
+	Causes            []string
+	WaitReasons       []string
+	TrackerConditions []telemetry.TrackerCondition
+	FailureBreakers   []telemetry.FailureBreaker
+	BackendOutages    []telemetry.BackendOutage
+	RefreshFailures   []telemetry.RefreshFailure
 }
 
 func observations(snapshot telemetry.Snapshot, health []project.Health) []observation {
@@ -48,11 +50,24 @@ func observations(snapshot telemetry.Snapshot, health []project.Health) []observ
 		projectStatuses[projectID] = strings.TrimSpace(string(current.Status))
 	}
 	projectCauses := map[string]map[string][]string{}
+	projectTrackerConditions := map[string][]telemetry.TrackerCondition{}
 	projectBreakers := map[string][]telemetry.FailureBreaker{}
 	projectOutages := map[string][]telemetry.BackendOutage{}
 	projectRefreshFailures := map[string][]telemetry.RefreshFailure{}
 	fleetCauses := []string{}
 	fleetWaitReasons := []string{}
+	for _, condition := range snapshot.TrackerUnavailable {
+		projectID := strings.TrimSpace(condition.ProjectID)
+		if projectID == "" {
+			continue
+		}
+		if projectCauses[projectID] == nil {
+			projectCauses[projectID] = map[string][]string{}
+		}
+		projectCauses[projectID][CauseTrackerUnavailable] = nil
+		projectTrackerConditions[projectID] = append(projectTrackerConditions[projectID], condition)
+		fleetCauses = append(fleetCauses, CauseTrackerUnavailable)
+	}
 	for _, stall := range snapshot.DispatchStalls {
 		if !stall.Stalled {
 			continue
@@ -136,7 +151,7 @@ func observations(snapshot telemetry.Snapshot, health []project.Health) []observ
 		if recoveryState == "" {
 			recoveryState = unknownProjectRecoveryStatus
 		}
-		for _, cause := range []string{CauseCIUnavailable, CauseDispatchStall, CauseProjectFailureBreaker, CauseBackendCapacity, CauseRefreshFailure} {
+		for _, cause := range []string{CauseTrackerUnavailable, CauseCIUnavailable, CauseDispatchStall, CauseProjectFailureBreaker, CauseBackendCapacity, CauseRefreshFailure} {
 			waitReasons, active := projectCauses[projectID][cause]
 			state := recoveryState
 			causes := []string(nil)
@@ -149,16 +164,17 @@ func observations(snapshot telemetry.Snapshot, health []project.Health) []observ
 				refreshFailures = append(refreshFailures, projectRefreshFailures[projectID]...)
 			}
 			result = append(result, observation{
-				Identity:        projectIdentity(projectID, cause),
-				Scope:           ScopeProject,
-				ProjectID:       projectID,
-				Active:          active,
-				State:           state,
-				Causes:          causes,
-				WaitReasons:     compactSorted(waitReasons),
-				FailureBreakers: append([]telemetry.FailureBreaker(nil), projectBreakers[projectID]...),
-				BackendOutages:  append([]telemetry.BackendOutage(nil), projectOutages[projectID]...),
-				RefreshFailures: refreshFailures,
+				Identity:          projectIdentity(projectID, cause),
+				Scope:             ScopeProject,
+				ProjectID:         projectID,
+				Active:            active,
+				State:             state,
+				Causes:            causes,
+				WaitReasons:       compactSorted(waitReasons),
+				TrackerConditions: append([]telemetry.TrackerCondition(nil), projectTrackerConditions[projectID]...),
+				FailureBreakers:   append([]telemetry.FailureBreaker(nil), projectBreakers[projectID]...),
+				BackendOutages:    append([]telemetry.BackendOutage(nil), projectOutages[projectID]...),
+				RefreshFailures:   refreshFailures,
 			})
 		}
 	}
@@ -171,15 +187,16 @@ func observations(snapshot telemetry.Snapshot, health []project.Health) []observ
 		fleetState = StateFleetNeedsAttention
 	}
 	result = append(result, observation{
-		Identity:        fleetIdentity,
-		Scope:           ScopeFleet,
-		Active:          len(fleetCauses) > 0,
-		State:           fleetState,
-		Causes:          fleetCauses,
-		WaitReasons:     compactSorted(fleetWaitReasons),
-		FailureBreakers: append([]telemetry.FailureBreaker(nil), snapshot.FailureBreakers...),
-		BackendOutages:  append([]telemetry.BackendOutage(nil), snapshot.BackendOutages...),
-		RefreshFailures: append([]telemetry.RefreshFailure(nil), snapshot.RefreshFailures()...),
+		Identity:          fleetIdentity,
+		Scope:             ScopeFleet,
+		Active:            len(fleetCauses) > 0,
+		State:             fleetState,
+		Causes:            fleetCauses,
+		WaitReasons:       compactSorted(fleetWaitReasons),
+		TrackerConditions: append([]telemetry.TrackerCondition(nil), snapshot.TrackerUnavailable...),
+		FailureBreakers:   append([]telemetry.FailureBreaker(nil), snapshot.FailureBreakers...),
+		BackendOutages:    append([]telemetry.BackendOutage(nil), snapshot.BackendOutages...),
+		RefreshFailures:   append([]telemetry.RefreshFailure(nil), snapshot.RefreshFailures()...),
 	})
 	return result
 }

--- a/internal/operatortool/executor.go
+++ b/internal/operatortool/executor.go
@@ -116,6 +116,7 @@ func (e *Executor) fleetHealth(ctx context.Context, raw json.RawMessage) (Result
 		Refresh:            snapshot.Refresh,
 		Counts:             snapshot.Counts,
 		RateLimits:         boundedRateLimits(snapshot.RateLimits),
+		TrackerUnavailable: boundedClone(snapshot.TrackerUnavailable, MaxItemLimit),
 		BackendOutages:     boundedClone(snapshot.BackendOutages, MaxItemLimit),
 		FailureBreakers:    boundedClone(snapshot.FailureBreakers, MaxItemLimit),
 		DispatchRecoveries: boundedClone(snapshot.DispatchRecoveries, MaxItemLimit),
@@ -350,6 +351,7 @@ type FleetHealthResult struct {
 	Refresh            telemetry.Refresh            `json:"refresh"`
 	Counts             telemetry.Counts             `json:"counts"`
 	RateLimits         *telemetry.RateLimits        `json:"rate_limits"`
+	TrackerUnavailable []telemetry.TrackerCondition `json:"tracker_unavailable"`
 	BackendOutages     []telemetry.BackendOutage    `json:"backend_outages"`
 	FailureBreakers    []telemetry.FailureBreaker   `json:"failure_breakers"`
 	DispatchRecoveries []telemetry.DispatchRecovery `json:"dispatch_recoveries"`

--- a/internal/orchestrator/dispatch.go
+++ b/internal/orchestrator/dispatch.go
@@ -299,6 +299,7 @@ const (
 	dispatchIssueFailureStartStateTransition  = "start_state_transition_failed"
 	dispatchIssueFailureBackendCapacityPaused = "backend_capacity_paused"
 	dispatchIssueFailureGitHubRESTPaused      = "github_rest_capacity_paused"
+	dispatchIssueFailureTrackerUnavailable    = "tracker_unavailable"
 	dispatchIssueFailureCIUnavailable         = "ci_unavailable"
 	dispatchIssueFailureRecoveryRamp          = "dispatch_recovery_ramp"
 )
@@ -373,6 +374,9 @@ func (o *Orchestrator) dispatchIssueWithAdmission(
 	defer o.finishDispatchStart()
 	if state.Draining {
 		return dispatchIssueOutcome{reason: dispatchIssueFailureDraining}
+	}
+	if activeTrackerUnavailable(state) && (trackerDependentDispatch(issue) || trackerUnavailableRetry(state, issue.ID)) {
+		return dispatchIssueOutcome{reason: dispatchIssueFailureTrackerUnavailable}
 	}
 	if activeCIUnavailable(state) && (ciDependentDispatch(issue) || ciUnavailableRetry(state, issue.ID)) {
 		return dispatchIssueOutcome{reason: dispatchIssueFailureCIUnavailable}

--- a/internal/orchestrator/dispatch_planner.go
+++ b/internal/orchestrator/dispatch_planner.go
@@ -256,6 +256,9 @@ func (p dispatchPlanner) retryAction(
 	retry Retry,
 	now time.Time,
 ) (dispatchAction, bool, string) {
+	if activeTrackerUnavailable(state) && (trackerDependentDispatch(issue) || retry.TrackerUnavailable) {
+		return dispatchAction{}, false, dispatchSkipTrackerUnavailable
+	}
 	if activeCIUnavailable(state) && (ciDependentDispatch(issue) || retry.CIUnavailable) {
 		return dispatchAction{}, false, dispatchSkipCIUnavailable
 	}
@@ -573,6 +576,7 @@ const (
 	dispatchSkipDispatchBackoffCancelled  = "dispatch_backoff_cancelled"
 	dispatchSkipMergeFairnessReserved     = "merge_fairness_head_reserved"
 	dispatchSkipGitHubRESTCapacity        = "github_rest_capacity_paused"
+	dispatchSkipTrackerUnavailable        = "tracker_unavailable"
 	dispatchSkipCIUnavailable             = "ci_unavailable"
 	dispatchSkipProjectFailureBreaker     = projectFailureBreakerDispatchPaused
 	dispatchSkipRateWindowBackpressure    = "provider_rate_window_backpressure"
@@ -633,6 +637,9 @@ func (p dispatchPlanner) dispatchableIssueDecisionForModelRequirement(
 	}
 	if stateIn(issue.State, p.cfg.TerminalStates) {
 		return dispatchableDecision{reason: dispatchSkipTerminalState}
+	}
+	if activeTrackerUnavailable(state) && trackerDependentDispatch(issue) {
+		return dispatchableDecision{reason: dispatchSkipTrackerUnavailable}
 	}
 	if activeCIUnavailable(state) && ciDependentDispatch(issue) {
 		return dispatchableDecision{reason: dispatchSkipCIUnavailable}

--- a/internal/orchestrator/dispatch_recovery.go
+++ b/internal/orchestrator/dispatch_recovery.go
@@ -12,6 +12,7 @@ const (
 	dispatchRecoveryGitHubREST            = "github_rest"
 	dispatchRecoveryPullRequestHydration  = "pull_request_hydration"
 	dispatchRecoveryBackendCapacity       = "backend_capacity"
+	dispatchRecoveryTrackerUnavailable    = connector.TrackerUnavailableCondition
 	dispatchRecoveryProjectFailureBreaker = "project_failure_breaker"
 	dispatchRecoveryStatusWaiting         = "waiting"
 	dispatchRecoveryStatusRamping         = "ramping"

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -269,6 +269,7 @@ type Orchestrator struct {
 	refreshes               chan manualRefreshRequest
 	reconciles              chan targetedRefreshRequest
 	capacityClearRequests   chan capacityClearRequest
+	trackerClearRequests    chan trackerClearRequest
 	failureCanaryRequests   chan failureBreakerCanaryRequest
 	stopRequests            chan stopRunRequest
 	modelPermitRequests     chan modelPermitRequest
@@ -335,6 +336,15 @@ type capacityClearRequest struct {
 
 type capacityClearReply struct {
 	cleared []BackendOutage
+}
+
+type trackerClearRequest struct {
+	at    time.Time
+	reply chan trackerClearReply
+}
+
+type trackerClearReply struct {
+	cleared []TrackerCondition
 }
 
 type failureBreakerCanaryRequest struct {
@@ -537,6 +547,7 @@ func New(cfg Config, deps Dependencies) (*Orchestrator, error) {
 		refreshes:               make(chan manualRefreshRequest, 1),
 		reconciles:              make(chan targetedRefreshRequest, 128),
 		capacityClearRequests:   make(chan capacityClearRequest),
+		trackerClearRequests:    make(chan trackerClearRequest),
 		failureCanaryRequests:   make(chan failureBreakerCanaryRequest),
 		stopRequests:            make(chan stopRunRequest),
 		modelPermitRequests:     make(chan modelPermitRequest),
@@ -625,6 +636,8 @@ func (o *Orchestrator) Run(ctx context.Context) error {
 			resetTicker(ticker, state.PollInterval)
 		case request := <-o.capacityClearRequests:
 			request.reply <- capacityClearReply{cleared: o.clearBackendCapacity(&state, request.scope, request.at)}
+		case request := <-o.trackerClearRequests:
+			request.reply <- trackerClearReply{cleared: o.clearTrackerAvailability(&state, request.at)}
 		case request := <-o.failureCanaryRequests:
 			result := o.requestProjectFailureBreakerCanary(&state, request.at)
 			request.reply <- result
@@ -706,6 +719,31 @@ func (o *Orchestrator) ClearBackendCapacity(ctx context.Context, scope string) (
 	case <-o.done:
 		return nil, ErrStopped
 	case o.capacityClearRequests <- request:
+	}
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	case <-o.done:
+		return nil, ErrStopped
+	case reply := <-request.reply:
+		return reply.cleared, nil
+	}
+}
+
+func (o *Orchestrator) ClearTrackerAvailability(ctx context.Context) ([]TrackerCondition, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	request := trackerClearRequest{
+		at:    o.clockNow(),
+		reply: make(chan trackerClearReply, 1),
+	}
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	case <-o.done:
+		return nil, ErrStopped
+	case o.trackerClearRequests <- request:
 	}
 	select {
 	case <-ctx.Done():

--- a/internal/orchestrator/plan_review.go
+++ b/internal/orchestrator/plan_review.go
@@ -254,17 +254,19 @@ func planReviewTargetState(action gate.Action) string {
 	}
 }
 
-func (o *Orchestrator) hydratePlanIssueComments(ctx context.Context, fetched *tickFetchedIssues) bool {
+func (o *Orchestrator) hydratePlanIssueComments(ctx context.Context, fetched *tickFetchedIssues) error {
 	cfg := gate.EffectivePlan(o.cfg.Plan)
 	if !cfg.Enabled {
-		return true
+		return nil
 	}
 	reader, ok := o.connector.(connector.IssueCommentReader)
 	if !ok {
-		return true
+		return nil
 	}
-	return o.hydratePlanIssueCommentsFor(ctx, reader, fetched.status, cfg) &&
-		o.hydratePlanIssueCommentsFor(ctx, reader, fetched.candidates, cfg)
+	if err := o.hydratePlanIssueCommentsFor(ctx, reader, fetched.status, cfg); err != nil {
+		return err
+	}
+	return o.hydratePlanIssueCommentsFor(ctx, reader, fetched.candidates, cfg)
 }
 
 func (o *Orchestrator) hydratePlanIssueCommentsFor(
@@ -272,7 +274,7 @@ func (o *Orchestrator) hydratePlanIssueCommentsFor(
 	reader connector.IssueCommentReader,
 	issues []connector.Issue,
 	cfg gate.PlanConfig,
-) bool {
+) error {
 	for index := range issues {
 		if !planCommentHydrationCandidate(cfg, issues[index]) || len(issues[index].Comments) > 0 {
 			continue
@@ -282,11 +284,11 @@ func (o *Orchestrator) hydratePlanIssueCommentsFor(
 			if o.logger != nil {
 				o.logger.Warn("fetch plan issue comments failed", "issue_id", issues[index].ID, "identifier", issues[index].Identifier, "error", err)
 			}
-			return false
+			return err
 		}
 		issues[index].Comments = comments
 	}
-	return true
+	return nil
 }
 
 func planCommentHydrationCandidate(cfg gate.PlanConfig, issue connector.Issue) bool {

--- a/internal/orchestrator/refresh_health.go
+++ b/internal/orchestrator/refresh_health.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/digitaldrywood/detent/internal/connector"
 	"github.com/digitaldrywood/detent/internal/telemetry"
 )
 
@@ -29,6 +30,8 @@ func recordRefreshSourceSuccess(state *State, name telemetry.RefreshSourceName, 
 	source.FailureStreak = 0
 	source.LastError = ""
 	source.LastErrorAt = nil
+	source.Condition = ""
+	source.Connector = ""
 	state.RefreshSources[name] = source
 }
 
@@ -45,6 +48,13 @@ func recordRefreshSourceFailure(state *State, name telemetry.RefreshSourceName, 
 	source.FailureStreak++
 	if err != nil {
 		source.LastError = strings.TrimSpace(err.Error())
+		if availabilityErr, ok := connector.AsTrackerAvailability(err); ok {
+			source.Condition = connector.TrackerUnavailableCondition
+			source.Connector = availabilityErr.Scope.Connector
+		} else {
+			source.Condition = ""
+			source.Connector = ""
+		}
 	}
 	source.LastErrorAt = &at
 	state.RefreshSources[name] = source

--- a/internal/orchestrator/refresh_health_test.go
+++ b/internal/orchestrator/refresh_health_test.go
@@ -136,6 +136,36 @@ func TestRefreshFailureThresholdFlowsFromWorkflow(t *testing.T) {
 	}
 }
 
+func TestTrackerRefreshHealthAttributesAvailabilityCondition(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 8, 17, 17, 20, 0, 0, time.UTC)
+	cfg := normalizeConfig(Config{RefreshFailureThreshold: 3})
+	state := newState(cfg)
+	err := connector.NewTrackerAvailabilityError(connector.TrackerAvailabilityScope{
+		Connector:          "github",
+		Endpoint:           "https://api.github.test/graphql",
+		Operation:          "observed_status",
+		CredentialIdentity: "github-rest:test",
+	}, connector.TrackerAvailabilityClassServer, errors.New("status 503"))
+	for attempt := range 3 {
+		recordRefreshSourceFailure(&state, telemetry.RefreshSourceStatuses, err, now.Add(time.Duration(attempt)*time.Second))
+	}
+
+	snapshot := state.Snapshot(now.Add(3 * time.Second))
+	source, ok := snapshot.Refresh.Source(telemetry.RefreshSourceStatuses)
+	if !ok {
+		t.Fatalf("Refresh.Source(%q) missing", telemetry.RefreshSourceStatuses)
+	}
+	if source.Condition != connector.TrackerUnavailableCondition || source.Connector != "github" {
+		t.Fatalf("refresh source attribution = condition %q connector %q", source.Condition, source.Connector)
+	}
+	failures := snapshot.RefreshFailures()
+	if len(failures) != 1 || failures[0].Condition != connector.TrackerUnavailableCondition || failures[0].Connector != "github" {
+		t.Fatalf("RefreshFailures() = %#v, want tracker attribution", failures)
+	}
+}
+
 type refreshHealthConnector struct {
 	candidateErr error
 	driftErr     error

--- a/internal/orchestrator/run_completion.go
+++ b/internal/orchestrator/run_completion.go
@@ -124,22 +124,28 @@ func (o *Orchestrator) handleRunResult(ctx context.Context, state *State, event 
 	if running.Generation > 0 {
 		refreshed, err := o.refreshCompletionLane(ctx, running)
 		if err != nil {
-			o.rejectWorkerCompletion(ctx, state, event, running, laneRevocationCompletionFenceUnavailable, err)
-			o.beginLaneRevocation(ctx, state, running, running.Issue, event.CompletedAt, laneRevocationCompletionFenceUnavailable)
-			o.handleLaneRevocationCompletion(ctx, state, event, running)
-			return
-		}
-		running.Issue = refreshed
-		state.Running[event.IssueID] = running
-		if claimed, found := state.Claimed[event.IssueID]; found {
-			claimed.Issue = cloneIssue(refreshed)
-			state.Claimed[event.IssueID] = claimed
-		}
-		if !stateIn(refreshed.State, o.cfg.ActiveStates) || workspaceIssueTerminal(refreshed, o.cfg.TerminalStates) {
-			o.rejectWorkerCompletion(ctx, state, event, running, "current tracker lane is not worker-owned", nil)
-			o.beginLaneRevocation(ctx, state, running, refreshed, event.CompletedAt, laneRevocationStateChanged)
-			o.handleLaneRevocationCompletion(ctx, state, event, running)
-			return
+			availabilityErr, unavailable := connector.AsTrackerAvailability(err)
+			if unavailable && availabilityErr != nil {
+				event.Err = err
+			} else {
+				o.rejectWorkerCompletion(ctx, state, event, running, laneRevocationCompletionFenceUnavailable, err)
+				o.beginLaneRevocation(ctx, state, running, running.Issue, event.CompletedAt, laneRevocationCompletionFenceUnavailable)
+				o.handleLaneRevocationCompletion(ctx, state, event, running)
+				return
+			}
+		} else {
+			running.Issue = refreshed
+			state.Running[event.IssueID] = running
+			if claimed, found := state.Claimed[event.IssueID]; found {
+				claimed.Issue = cloneIssue(refreshed)
+				state.Claimed[event.IssueID] = claimed
+			}
+			if !stateIn(refreshed.State, o.cfg.ActiveStates) || workspaceIssueTerminal(refreshed, o.cfg.TerminalStates) {
+				o.rejectWorkerCompletion(ctx, state, event, running, "current tracker lane is not worker-owned", nil)
+				o.beginLaneRevocation(ctx, state, running, refreshed, event.CompletedAt, laneRevocationStateChanged)
+				o.handleLaneRevocationCompletion(ctx, state, event, running)
+				return
+			}
 		}
 	}
 	o.heartbeats.remove(event.IssueID)
@@ -214,6 +220,9 @@ func (o *Orchestrator) handleRunResult(ctx context.Context, state *State, event 
 	}
 	releaseDispatchRecoveryAdmission(state, event.IssueID)
 	if o.handleCIUnavailableCompletion(ctx, state, event, running) {
+		return
+	}
+	if o.handleTrackerUnavailableCompletion(ctx, state, event, running) {
 		return
 	}
 	if o.handleMergeRevocationCompletion(ctx, state, event, running) {

--- a/internal/orchestrator/snapshot.go
+++ b/internal/orchestrator/snapshot.go
@@ -110,6 +110,7 @@ func (s State) Snapshot(now time.Time) telemetry.Snapshot {
 		Blocked:                 blockedSnapshots(s.Blocked, s.Claimed, now, s.laneEntries),
 		Completed:               completedSnapshots(s.Completed, s.Claimed, now, s.laneEntries),
 		RateLimits:              cloneRateLimits(s.RateLimits),
+		TrackerUnavailable:      trackerUnavailableSnapshots(s.TrackerUnavailable),
 		CIUnavailable:           ciUnavailableSnapshots(s.CIUnavailable),
 		BackendOutages:          backendOutageSnapshots(s.BackendOutages),
 		FailureBreakers:         projectFailureBreakerSnapshots(s),
@@ -171,6 +172,13 @@ func ciUnavailableSnapshots(condition *CICondition) []telemetry.CICondition {
 		return nil
 	}
 	return []telemetry.CICondition{*condition}
+}
+
+func trackerUnavailableSnapshots(condition *TrackerCondition) []telemetry.TrackerCondition {
+	if condition == nil {
+		return nil
+	}
+	return []telemetry.TrackerCondition{*condition}
 }
 
 func applySnapshotLaneProvenance(snapshot *telemetry.Snapshot, laneProvenance map[string]provenance.Attribution) {

--- a/internal/orchestrator/state.go
+++ b/internal/orchestrator/state.go
@@ -86,6 +86,8 @@ type State struct {
 	FailureBreaker           ProjectFailureBreaker
 	DispatchRecoveries       map[string]DispatchRecovery
 	StalenessWarnings        map[string]StalenessWarning
+	TrackerUnavailable       *TrackerCondition
+	trackerEvidence          map[string]trackerAvailabilityEvidence
 	CIUnavailable            *CICondition
 	BackendOutages           map[string]BackendOutage
 	BackendRecoveries        map[string]BackendRecovery
@@ -222,17 +224,18 @@ type MergeTiming struct {
 }
 
 type Retry struct {
-	Issue         connector.Issue
-	Attempt       int
-	DueAt         time.Time
-	Error         string
-	WorkerHost    string
-	CapacityScope backendcapacity.Scope
-	RetryMode     runpkg.RetryMode
-	ResumeState   store.AgentResumeState
-	MergePrecheck *runpkg.MergePrecheck
-	CIUnavailable bool
-	Wait          RetryWait
+	Issue              connector.Issue
+	Attempt            int
+	DueAt              time.Time
+	Error              string
+	WorkerHost         string
+	CapacityScope      backendcapacity.Scope
+	RetryMode          runpkg.RetryMode
+	ResumeState        store.AgentResumeState
+	MergePrecheck      *runpkg.MergePrecheck
+	CIUnavailable      bool
+	TrackerUnavailable bool
+	Wait               RetryWait
 }
 
 type RetryWait struct {
@@ -344,6 +347,7 @@ func newState(cfg Config) State {
 		FailureBreaker:           newProjectFailureBreaker(cfg.FailureBreaker),
 		DispatchRecoveries:       map[string]DispatchRecovery{},
 		StalenessWarnings:        map[string]StalenessWarning{},
+		trackerEvidence:          map[string]trackerAvailabilityEvidence{},
 		BackendOutages:           map[string]BackendOutage{},
 		BackendRecoveries:        map[string]BackendRecovery{},
 		DiffStats:                map[string]DiffStats{},
@@ -418,6 +422,8 @@ func (s State) clone() State {
 		FailureBreaker:           cloneProjectFailureBreaker(s.FailureBreaker),
 		DispatchRecoveries:       cloneDispatchRecoveries(s.DispatchRecoveries),
 		StalenessWarnings:        maps.Clone(s.StalenessWarnings),
+		TrackerUnavailable:       cloneTrackerCondition(s.TrackerUnavailable),
+		trackerEvidence:          maps.Clone(s.trackerEvidence),
 		CIUnavailable:            cloneCICondition(s.CIUnavailable),
 		BackendOutages:           maps.Clone(s.BackendOutages),
 		BackendRecoveries:        maps.Clone(s.BackendRecoveries),

--- a/internal/orchestrator/tick.go
+++ b/internal/orchestrator/tick.go
@@ -2,7 +2,6 @@ package orchestrator
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"strings"
 	"time"
@@ -83,6 +82,9 @@ func (o *Orchestrator) tickWithManual(ctx context.Context, state *State, now tim
 	}
 	if pause := o.gitHubRESTPause(state, now); pause > 0 {
 		o.logger.Warn("github rest polling paused", "remaining", gitHubRESTRemaining(state), "pause", pause)
+		return
+	}
+	if o.trackerAvailabilityPaused(ctx, state, now) {
 		return
 	}
 
@@ -344,10 +346,12 @@ func (o *Orchestrator) fetchTickIssues(
 	if err != nil {
 		o.logger.Warn("fetch candidate issues failed", "error", err)
 		recordRefreshSourceFailure(state, telemetry.RefreshSourceCandidates, err, now)
+		o.observeTrackerReadFailure(state, telemetry.RefreshSourceCandidates, err, now)
 		markRefreshError(state, "fetch candidate issues failed: "+err.Error(), now)
 		return tickFetchedIssues{}, false
 	}
 	recordRefreshSourceSuccess(state, telemetry.RefreshSourceCandidates, now)
+	o.recordTrackerReadSuccess(state, telemetry.RefreshSourceCandidates, now)
 
 	fetched := tickFetchedIssues{
 		candidates: cloneIssues(candidateIssues),
@@ -373,12 +377,14 @@ func (o *Orchestrator) fetchTickIssues(
 		if probeErr != nil {
 			o.logger.Warn("fetch observed status probe failed", "error", probeErr)
 			recordRefreshSourceFailure(state, telemetry.RefreshSourceStatuses, probeErr, now)
+			o.observeTrackerReadFailure(state, telemetry.RefreshSourceStatuses, probeErr, now)
 			markRefreshError(state, "fetch observed status probe failed: "+probeErr.Error(), now)
 			return fetched, true
 		}
 		if !exists {
 			fetched.statusOK = true
 			recordRefreshSourceSuccess(state, telemetry.RefreshSourceStatuses, now)
+			o.recordTrackerReadSuccess(state, telemetry.RefreshSourceStatuses, now)
 			clearRefreshError(state)
 			return fetched, true
 		}
@@ -388,15 +394,18 @@ func (o *Orchestrator) fetchTickIssues(
 	if statusErr != nil {
 		o.logger.Warn("fetch observed status issues failed", "error", statusErr)
 		recordRefreshSourceFailure(state, telemetry.RefreshSourceStatuses, statusErr, now)
+		o.observeTrackerReadFailure(state, telemetry.RefreshSourceStatuses, statusErr, now)
 		markRefreshError(state, "fetch observed status issues failed: "+statusErr.Error(), now)
 		return fetched, true
 	}
 	recordRefreshSourceSuccess(state, telemetry.RefreshSourceStatuses, now)
+	o.recordTrackerReadSuccess(state, telemetry.RefreshSourceStatuses, now)
 	fetched.status = cloneIssues(statusIssues)
 	fetched.statusOK = true
-	if !o.hydratePlanIssueComments(ctx, &fetched) {
-		recordRefreshSourceFailure(state, telemetry.RefreshSourceStatuses, errors.New("fetch plan issue comments failed"), now)
-		markRefreshError(state, "fetch plan issue comments failed", now)
+	if err := o.hydratePlanIssueComments(ctx, &fetched); err != nil {
+		recordRefreshSourceFailure(state, telemetry.RefreshSourceStatuses, err, now)
+		o.observeTrackerReadFailure(state, telemetry.RefreshSourceStatuses, err, now)
+		markRefreshError(state, "fetch plan issue comments failed: "+err.Error(), now)
 		return tickFetchedIssues{}, false
 	}
 	clearRefreshError(state)
@@ -507,6 +516,7 @@ func (o *Orchestrator) refreshStatusDrift(
 	if err != nil {
 		o.logger.Warn("fetch tracker status drift failed", "error", err)
 		recordRefreshSourceFailure(state, telemetry.RefreshSourceDrift, err, now)
+		o.observeTrackerReadFailure(state, telemetry.RefreshSourceDrift, err, now)
 		recordStateEvent(state, telemetry.ActivityEvent{
 			At:      now,
 			Event:   "tracker_status_drift_failed",
@@ -515,6 +525,7 @@ func (o *Orchestrator) refreshStatusDrift(
 		return
 	}
 	recordRefreshSourceSuccess(state, telemetry.RefreshSourceDrift, now)
+	o.recordTrackerReadSuccess(state, telemetry.RefreshSourceDrift, now)
 	state.StatusDrift = cloneStatusDrift(drift)
 }
 

--- a/internal/orchestrator/tracker_availability.go
+++ b/internal/orchestrator/tracker_availability.go
@@ -1,0 +1,388 @@
+package orchestrator
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"strings"
+	"time"
+
+	"github.com/digitaldrywood/detent/internal/connector"
+	runpkg "github.com/digitaldrywood/detent/internal/runner"
+	"github.com/digitaldrywood/detent/internal/store"
+	"github.com/digitaldrywood/detent/internal/telemetry"
+)
+
+const (
+	trackerUnavailableMinimumObservations = 2
+	trackerUnavailableErrorClass          = connector.TrackerUnavailableCondition
+)
+
+type TrackerCondition = telemetry.TrackerCondition
+
+type trackerAvailabilityEvidence struct {
+	Scope        connector.TrackerAvailabilityScope
+	Source       telemetry.RefreshSourceName
+	Class        string
+	Count        int
+	FirstFailure time.Time
+	LastFailure  time.Time
+	LastError    string
+}
+
+func (o *Orchestrator) observeTrackerReadFailure(state *State, source telemetry.RefreshSourceName, err error, observedAt time.Time) bool {
+	availabilityErr, ok := connector.AsTrackerAvailability(err)
+	if !ok {
+		o.recordTrackerReachableFailure(state, source, observedAt)
+		return false
+	}
+	if state == nil {
+		return true
+	}
+	if observedAt.IsZero() {
+		observedAt = o.clockNow()
+	}
+	observedAt = observedAt.UTC()
+	if state.trackerEvidence == nil {
+		state.trackerEvidence = map[string]trackerAvailabilityEvidence{}
+	}
+	key := availabilityErr.Scope.Key(availabilityErr.Class)
+	evidence := state.trackerEvidence[key]
+	if evidence.Count == 0 {
+		evidence = trackerAvailabilityEvidence{
+			Scope:        availabilityErr.Scope.Normalize(),
+			Source:       source,
+			Class:        strings.TrimSpace(availabilityErr.Class),
+			FirstFailure: observedAt,
+		}
+	}
+	evidence.Count++
+	evidence.LastFailure = observedAt
+	evidence.LastError = strings.TrimSpace(err.Error())
+	state.trackerEvidence[key] = evidence
+
+	if state.TrackerUnavailable != nil {
+		conditionKey := connector.TrackerAvailabilityScope{
+			Connector:          state.TrackerUnavailable.Connector,
+			Endpoint:           state.TrackerUnavailable.Endpoint,
+			Operation:          state.TrackerUnavailable.Operation,
+			CredentialIdentity: state.TrackerUnavailable.CredentialIdentity,
+		}.Key(state.TrackerUnavailable.ErrorClass)
+		if key != conditionKey {
+			return true
+		}
+		condition := *state.TrackerUnavailable
+		condition.LastObservedAt = observedAt
+		condition.LastError = evidence.LastError
+		state.TrackerUnavailable = &condition
+		return true
+	}
+	if evidence.Count < trackerUnavailableMinimumObservations {
+		return true
+	}
+
+	condition := TrackerCondition{
+		ProjectID:          strings.TrimSpace(o.cfg.Project.ID),
+		Connector:          trackerConnectorName(o.connector, evidence.Scope.Connector),
+		ConnectorInstance:  trackerConnectorInstance(o.cfg.Project.ID, o.connector, evidence.Scope.Connector),
+		Endpoint:           evidence.Scope.Endpoint,
+		Operation:          evidence.Scope.Operation,
+		ErrorClass:         evidence.Class,
+		CredentialIdentity: evidence.Scope.CredentialIdentity,
+		RefreshSource:      evidence.Source,
+		DetectedAt:         evidence.FirstFailure,
+		LastObservedAt:     observedAt,
+		NextProbeAt:        observedAt.Add(backendCapacityProbeDelayForAttempt(0)),
+		LastError:          evidence.LastError,
+	}
+	state.TrackerUnavailable = &condition
+	recordStateEvent(state, telemetry.ActivityEvent{
+		At:      observedAt,
+		Event:   connector.TrackerUnavailableCondition,
+		Message: trackerUnavailableStatusMessage(condition),
+	})
+	if o.logger != nil {
+		telemetry.LogLifecycleMessage(o.logger, slog.LevelWarn, telemetry.LifecycleSafetyControl, connector.TrackerUnavailableCondition, "tracker unavailable", telemetry.LifecycleCorrelation{ProjectID: o.cfg.Project.ID},
+			"connector", condition.Connector,
+			"connector_instance", condition.ConnectorInstance,
+			"endpoint", condition.Endpoint,
+			"operation", condition.Operation,
+			"error_class", condition.ErrorClass,
+			"credential_identity", condition.CredentialIdentity,
+			"next_probe_at", condition.NextProbeAt,
+			"error", err,
+		)
+	}
+	return true
+}
+
+func trackerConnectorName(candidate connector.Connector, fallback string) string {
+	if candidate != nil {
+		if name := strings.TrimSpace(candidate.Name()); name != "" {
+			return name
+		}
+	}
+	return strings.TrimSpace(fallback)
+}
+
+func trackerConnectorInstance(projectID string, candidate connector.Connector, fallback string) string {
+	return strings.TrimSpace(projectID) + ":" + trackerConnectorName(candidate, fallback)
+}
+
+func (o *Orchestrator) recordTrackerReadSuccess(state *State, source telemetry.RefreshSourceName, observedAt time.Time) {
+	if state == nil {
+		return
+	}
+	clearTrackerAvailabilityEvidence(state, source)
+	if state.TrackerUnavailable == nil || (state.TrackerUnavailable.RefreshSource != "" && state.TrackerUnavailable.RefreshSource != source) {
+		return
+	}
+	o.completeTrackerAvailabilityRecovery(state, observedAt, "canary")
+}
+
+func (o *Orchestrator) recordTrackerReachableFailure(state *State, source telemetry.RefreshSourceName, observedAt time.Time) {
+	if state == nil {
+		return
+	}
+	clearTrackerAvailabilityEvidence(state, source)
+	if state.TrackerUnavailable == nil || (state.TrackerUnavailable.RefreshSource != "" && state.TrackerUnavailable.RefreshSource != source) {
+		return
+	}
+	o.completeTrackerAvailabilityRecovery(state, observedAt, "reachable_response")
+}
+
+func clearTrackerAvailabilityEvidence(state *State, source telemetry.RefreshSourceName) {
+	for key, evidence := range state.trackerEvidence {
+		if source == "" || evidence.Source == source {
+			delete(state.trackerEvidence, key)
+		}
+	}
+}
+
+func activeTrackerUnavailable(state *State) bool {
+	return state != nil && state.TrackerUnavailable != nil
+}
+
+func trackerDependentDispatch(issue connector.Issue) bool {
+	return strings.TrimSpace(issue.ID) != ""
+}
+
+func trackerUnavailableRetry(state *State, issueID string) bool {
+	if state == nil {
+		return false
+	}
+	return state.Retry[issueID].TrackerUnavailable
+}
+
+func (o *Orchestrator) trackerAvailabilityPaused(ctx context.Context, state *State, now time.Time) bool {
+	if state == nil || state.TrackerUnavailable == nil {
+		return false
+	}
+	condition := *state.TrackerUnavailable
+	if !condition.NextProbeAt.IsZero() && now.Before(condition.NextProbeAt) {
+		markRefreshError(state, trackerUnavailableStatusMessage(condition), now)
+		return true
+	}
+	return !o.probeTrackerAvailability(ctx, state, now)
+}
+
+func (o *Orchestrator) probeTrackerAvailability(ctx context.Context, state *State, now time.Time) bool {
+	if state == nil || state.TrackerUnavailable == nil {
+		return true
+	}
+	condition := *state.TrackerUnavailable
+	condition.ProbeAttempts++
+	condition.LastProbeAt = now.UTC()
+	condition.LastProbeResult = "in_progress"
+	condition.LastProbeDetail = "canary tracker read started"
+	condition.NextProbeAt = time.Time{}
+	state.TrackerUnavailable = &condition
+
+	var err error
+	switch condition.RefreshSource {
+	case telemetry.RefreshSourceDrift:
+		reader, ok := o.connector.(connector.StatusDriftReader)
+		if ok {
+			var drift connector.StatusDrift
+			drift, err = reader.FetchStatusDrift(ctx)
+			if err == nil {
+				state.StatusDrift = cloneStatusDrift(drift)
+			}
+		} else {
+			_, err = o.fetchCandidateIssuesForTick(ctx, state)
+		}
+	case telemetry.RefreshSourceStatuses:
+		states := o.observedStatusFetchStatesForTick(state)
+		if len(states) > 0 {
+			_, err = o.fetchObservedIssuesByStates(ctx, states)
+		} else {
+			_, err = o.fetchCandidateIssuesForTick(ctx, state)
+		}
+	default:
+		_, err = o.fetchCandidateIssuesForTick(ctx, state)
+	}
+	if err == nil {
+		recordRefreshSourceSuccess(state, trackerConditionRefreshSource(condition), now)
+		o.completeTrackerAvailabilityRecovery(state, now, "canary")
+		return true
+	}
+
+	source := trackerConditionRefreshSource(condition)
+	recordRefreshSourceFailure(state, source, err, now)
+	markRefreshError(state, "tracker canary failed: "+err.Error(), now)
+	availabilityErr, unavailable := connector.AsTrackerAvailability(err)
+	if !unavailable {
+		o.completeTrackerAvailabilityRecovery(state, now, "reachable_response")
+		return false
+	}
+	condition = *state.TrackerUnavailable
+	condition.LastObservedAt = now.UTC()
+	condition.LastProbeAt = now.UTC()
+	condition.LastProbeResult = "failed"
+	condition.LastProbeDetail = strings.TrimSpace(err.Error())
+	condition.LastError = strings.TrimSpace(err.Error())
+	condition.Endpoint = availabilityErr.Scope.Endpoint
+	condition.Operation = availabilityErr.Scope.Operation
+	condition.ErrorClass = availabilityErr.Class
+	condition.NextProbeAt = backendCapacityBoundedProbeAt(time.Time{}, now.Add(backendCapacityProbeDelayForAttempt(condition.ProbeAttempts)), now)
+	state.TrackerUnavailable = &condition
+	return false
+}
+
+func trackerConditionRefreshSource(condition TrackerCondition) telemetry.RefreshSourceName {
+	if condition.RefreshSource != "" {
+		return condition.RefreshSource
+	}
+	return telemetry.RefreshSourceCandidates
+}
+
+func (o *Orchestrator) completeTrackerAvailabilityRecovery(state *State, recoveredAt time.Time, source string) {
+	if state == nil || state.TrackerUnavailable == nil {
+		return
+	}
+	if recoveredAt.IsZero() {
+		recoveredAt = o.clockNow()
+	}
+	condition := *state.TrackerUnavailable
+	state.TrackerUnavailable = nil
+	clear(state.trackerEvidence)
+	releaseTrackerUnavailableRetries(state, recoveredAt)
+	o.activateDispatchRecovery(state, dispatchRecoveryTrackerUnavailable, trackerUnavailableStatusMessage(condition), recoveredAt, "")
+	recordStateEvent(state, telemetry.ActivityEvent{
+		At:      recoveredAt.UTC(),
+		Event:   "tracker_availability_recovered",
+		Message: "tracker " + condition.Connector + " recovered via " + source,
+	})
+	if o.logger != nil {
+		telemetry.LogLifecycleMessage(o.logger, slog.LevelInfo, telemetry.LifecycleSafetyControl, "tracker_availability_recovered", "tracker availability recovered", telemetry.LifecycleCorrelation{ProjectID: o.cfg.Project.ID},
+			"connector", condition.Connector,
+			"connector_instance", condition.ConnectorInstance,
+			"detected_at", condition.DetectedAt,
+			"recovered_at", recoveredAt,
+			"source", source,
+		)
+	}
+}
+
+func releaseTrackerUnavailableRetries(state *State, releasedAt time.Time) {
+	for issueID, retry := range state.Retry {
+		if !retry.TrackerUnavailable {
+			continue
+		}
+		retry.DueAt = releasedAt
+		retry.TrackerUnavailable = false
+		state.Retry[issueID] = retry
+	}
+}
+
+func (o *Orchestrator) handleTrackerUnavailableCompletion(ctx context.Context, state *State, event runpkg.Completion, running Running) bool {
+	availabilityErr, ok := connector.AsTrackerAvailability(event.Err)
+	if !ok || availabilityErr == nil {
+		return false
+	}
+	o.observeTrackerReadFailure(state, "", event.Err, event.CompletedAt)
+	message := strings.TrimSpace(event.Err.Error())
+	o.completeDurableWorkAttempt(
+		ctx,
+		state,
+		running,
+		event.CompletedAt,
+		store.WorkAttemptTerminalCapacity,
+		trackerUnavailableErrorClass,
+		message,
+		"waiting",
+		message,
+	)
+	if workspaceIssueTerminal(running.Issue, o.cfg.TerminalStates) {
+		o.releaseClaim(state, running.Issue.ID)
+		return true
+	}
+	dueAt := event.CompletedAt.Add(max(event.RetryDelay, o.cfg.PollInterval))
+	if state.TrackerUnavailable != nil && !state.TrackerUnavailable.NextProbeAt.IsZero() {
+		dueAt = state.TrackerUnavailable.NextProbeAt
+	}
+	if dueAt.Before(event.CompletedAt) {
+		dueAt = event.CompletedAt
+	}
+	if state.FailureBreaker.Active() && state.FailureBreaker.CanaryIssueID == running.Issue.ID {
+		o.deferProjectFailureBreakerCanary(state, running.Issue.ID, event.CompletedAt, dueAt.Sub(event.CompletedAt))
+	}
+	state.Retry[running.Issue.ID] = Retry{
+		Issue:              cloneIssue(running.Issue),
+		Attempt:            running.Attempt,
+		DueAt:              dueAt,
+		Error:              message,
+		WorkerHost:         running.WorkerHost,
+		TrackerUnavailable: true,
+	}
+	recordStateEvent(state, telemetry.ActivityEvent{
+		At:      event.CompletedAt.UTC(),
+		Event:   "tracker_unavailable_attempt_waiting",
+		Message: "waiting to retry " + issueLabel(running.Issue) + " without tripping a failure breaker",
+	})
+	return true
+}
+
+func trackerUnavailableStatusMessage(condition TrackerCondition) string {
+	tracker := strings.TrimSpace(condition.Connector)
+	if tracker == "" {
+		tracker = "configured"
+	}
+	message := fmt.Sprintf("tracker %s unavailable (%s/%s)", tracker, connector.TrackerUnavailableCondition, condition.ErrorClass)
+	if !condition.NextProbeAt.IsZero() {
+		message += "; next canary at " + condition.NextProbeAt.UTC().Format(time.RFC3339)
+	}
+	return message
+}
+
+func cloneTrackerCondition(condition *TrackerCondition) *TrackerCondition {
+	if condition == nil {
+		return nil
+	}
+	cloned := *condition
+	return &cloned
+}
+
+func (o *Orchestrator) clearTrackerAvailability(state *State, clearedAt time.Time) []TrackerCondition {
+	if state == nil || state.TrackerUnavailable == nil {
+		return nil
+	}
+	if clearedAt.IsZero() {
+		clearedAt = o.clockNow()
+	}
+	condition := *state.TrackerUnavailable
+	condition.LastProbeAt = clearedAt.UTC()
+	condition.LastProbeResult = "operator_cleared"
+	condition.LastProbeDetail = "operator cleared the recorded condition"
+	condition.NextProbeAt = time.Time{}
+	state.TrackerUnavailable = nil
+	clear(state.trackerEvidence)
+	releaseTrackerUnavailableRetries(state, clearedAt)
+	o.activateDispatchRecovery(state, dispatchRecoveryTrackerUnavailable, trackerUnavailableStatusMessage(condition), clearedAt, "")
+	recordStateEvent(state, telemetry.ActivityEvent{
+		At:      clearedAt.UTC(),
+		Event:   "tracker_availability_operator_cleared",
+		Message: "operator cleared tracker " + condition.Connector + " availability condition",
+	})
+	return []TrackerCondition{condition}
+}

--- a/internal/orchestrator/tracker_availability_test.go
+++ b/internal/orchestrator/tracker_availability_test.go
@@ -1,0 +1,236 @@
+package orchestrator
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/digitaldrywood/detent/internal/connector"
+	runpkg "github.com/digitaldrywood/detent/internal/runner"
+	"github.com/digitaldrywood/detent/internal/scheduler"
+	"github.com/digitaldrywood/detent/internal/telemetry"
+)
+
+func TestTrackerAvailabilityRequiresCorrelatedEvidence(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 8, 17, 17, 20, 0, 0, time.UTC)
+	tests := []struct {
+		name       string
+		errors     []error
+		wantActive bool
+	}{
+		{name: "single transient", errors: []error{trackerAvailabilityTestError("candidate_issues", connector.TrackerAvailabilityClassServer)}},
+		{name: "correlated server failures", errors: []error{trackerAvailabilityTestError("candidate_issues", connector.TrackerAvailabilityClassServer), trackerAvailabilityTestError("candidate_issues", connector.TrackerAvailabilityClassServer)}, wantActive: true},
+		{name: "correlated timeouts", errors: []error{trackerAvailabilityTestError("candidate_issues", connector.TrackerAvailabilityClassTimeout), trackerAvailabilityTestError("candidate_issues", connector.TrackerAvailabilityClassTimeout)}, wantActive: true},
+		{name: "correlated transport failures", errors: []error{trackerAvailabilityTestError("candidate_issues", connector.TrackerAvailabilityClassTransport), trackerAvailabilityTestError("candidate_issues", connector.TrackerAvailabilityClassTransport)}, wantActive: true},
+		{name: "different operations", errors: []error{trackerAvailabilityTestError("candidate_issues", connector.TrackerAvailabilityClassServer), trackerAvailabilityTestError("observed_status", connector.TrackerAvailabilityClassServer)}},
+		{name: "different credential identities", errors: []error{trackerAvailabilityTestErrorWithCredential("candidate_issues", connector.TrackerAvailabilityClassServer, "github-rest:first"), trackerAvailabilityTestErrorWithCredential("candidate_issues", connector.TrackerAvailabilityClassServer, "github-rest:second")}},
+		{name: "reachable authorization failures", errors: []error{errors.New("github status 403"), errors.New("github status 403")}},
+		{name: "tenant capacity failures", errors: []error{errors.New("github status 429"), errors.New("github status 429")}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			cfg := normalizeConfig(Config{Project: scheduler.ProjectCandidate{ID: "detent"}})
+			orch := Orchestrator{cfg: cfg, connector: &backendCapacityTestConnector{}}
+			state := newState(cfg)
+			for index, err := range tt.errors {
+				orch.observeTrackerReadFailure(&state, telemetry.RefreshSourceCandidates, err, now.Add(time.Duration(index)*time.Second))
+			}
+			if got := state.TrackerUnavailable != nil; got != tt.wantActive {
+				t.Fatalf("TrackerUnavailable active = %v, want %v; evidence = %#v", got, tt.wantActive, state.trackerEvidence)
+			}
+			if tt.wantActive {
+				if state.TrackerUnavailable.ConnectorInstance != "detent:backend-capacity-test" || state.TrackerUnavailable.NextProbeAt.IsZero() {
+					t.Fatalf("TrackerUnavailable = %#v, want scoped condition with probe", state.TrackerUnavailable)
+				}
+			}
+		})
+	}
+}
+
+func TestTrackerAvailabilityCanaryClearsAndResumesDispatch(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 8, 17, 17, 20, 0, 0, time.UTC)
+	cfg := normalizeConfig(Config{
+		Project:             scheduler.ProjectCandidate{ID: "detent"},
+		MaxConcurrentAgents: 2,
+		ActiveStates:        []string{"Todo", "In Progress"},
+		TerminalStates:      []string{"Done"},
+	})
+	issue := dispatchTestIssue("issue-tracker", "Todo")
+	connectorBackend := &backendCapacityTestConnector{}
+	orch := Orchestrator{cfg: cfg, connector: connectorBackend, now: func() time.Time { return now }}
+	state := newState(cfg)
+	condition := TrackerCondition{
+		ProjectID:         "detent",
+		Connector:         "fake",
+		ConnectorInstance: "detent:fake",
+		Endpoint:          "https://tracker.test/graphql",
+		Operation:         "candidate_issues",
+		ErrorClass:        connector.TrackerAvailabilityClassServer,
+		RefreshSource:     telemetry.RefreshSourceCandidates,
+		DetectedAt:        now.Add(-time.Minute),
+		LastObservedAt:    now.Add(-time.Minute),
+		NextProbeAt:       now,
+	}
+	state.TrackerUnavailable = &condition
+	state.Retry[issue.ID] = Retry{Issue: issue, Attempt: 2, DueAt: now, TrackerUnavailable: true}
+
+	decision := newDispatchPlanner(cfg).dispatchableIssueDecision(issue, &state, false, now, "")
+	if decision.dispatchable || decision.reason != dispatchSkipTrackerUnavailable {
+		t.Fatalf("dispatch during condition = %#v, want tracker wait", decision)
+	}
+	if !orch.probeTrackerAvailability(t.Context(), &state, now) {
+		t.Fatal("probeTrackerAvailability() = false, want successful canary")
+	}
+	if state.TrackerUnavailable != nil {
+		t.Fatalf("TrackerUnavailable = %#v, want cleared", state.TrackerUnavailable)
+	}
+	retry := state.Retry[issue.ID]
+	if retry.TrackerUnavailable || !retry.DueAt.Equal(now) {
+		t.Fatalf("Retry[%q] = %#v, want released", issue.ID, retry)
+	}
+	_, allowed, reason := newDispatchPlanner(cfg).retryAction(&state, issue, retry, now)
+	if !allowed || reason != "" {
+		t.Fatalf("retry after canary = allowed %v reason %q, want allowed", allowed, reason)
+	}
+}
+
+func TestTrackerUnavailableCompletionBypassesAllFailureBreakers(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 8, 17, 17, 20, 0, 0, time.UTC)
+	cfg := normalizeConfig(Config{
+		Project:             scheduler.ProjectCandidate{ID: "detent"},
+		PollInterval:        time.Minute,
+		ActiveStates:        []string{"In Progress"},
+		TerminalStates:      []string{"Done"},
+		MaxConcurrentAgents: 1,
+		FailureBreaker: FailureBreakerConfig{
+			SameClassLimit: 1,
+			Window:         time.Hour,
+			Cooldown:       time.Hour,
+		},
+	})
+	tracker := &backendCapacityTestConnector{}
+	orch := Orchestrator{cfg: cfg, connector: tracker, now: func() time.Time { return now }}
+	state := newState(cfg)
+	issue := dispatchTestIssue("issue-tracker-wait", "In Progress")
+	state.Running[issue.ID] = Running{Issue: issue, Attempt: 4, StartedAt: now.Add(-time.Minute)}
+	state.InstantFailures[issue.ID] = InstantFailure{Issue: issue, Count: instantFailureThreshold - 1}
+	state.RepeatedFailures[issue.ID] = RepeatedFailure{Issue: issue, Count: repeatedFailureThreshold - 1}
+	err := trackerAvailabilityTestError("candidate_issues", connector.TrackerAvailabilityClassServer)
+
+	orch.handleRunResult(context.Background(), &state, runpkg.Completion{
+		IssueID:      issue.ID,
+		Request:      runpkg.RunRequest{Issue: issue, Attempt: 4},
+		Err:          err,
+		CompletedAt:  now,
+		RetryAttempt: 5,
+		RetryDelay:   time.Minute,
+	})
+
+	if got := state.InstantFailures[issue.ID].Count; got != instantFailureThreshold-1 {
+		t.Fatalf("instant failure count = %d, want unchanged", got)
+	}
+	if got := state.RepeatedFailures[issue.ID].Count; got != repeatedFailureThreshold-1 {
+		t.Fatalf("repeated failure count = %d, want unchanged", got)
+	}
+	if state.FailureBreaker.Active() || len(state.FailureBreaker.Failures) != 0 {
+		t.Fatalf("FailureBreaker = %#v, want no tracker strike", state.FailureBreaker)
+	}
+	if _, blocked := state.Blocked[issue.ID]; blocked {
+		t.Fatalf("Blocked[%q] present after tracker wait", issue.ID)
+	}
+	retry, ok := state.Retry[issue.ID]
+	if !ok || retry.Attempt != 4 || !retry.TrackerUnavailable {
+		t.Fatalf("Retry[%q] = %#v, want same-attempt typed tracker wait", issue.ID, retry)
+	}
+	if len(tracker.updates) != 0 || len(tracker.comments) != 0 {
+		t.Fatalf("tracker mutations = states %#v comments %#v, want none", tracker.updates, tracker.comments)
+	}
+}
+
+func TestClearTrackerAvailabilityReleasesWaiters(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 8, 17, 17, 20, 0, 0, time.UTC)
+	cfg := normalizeConfig(Config{MaxConcurrentAgents: 1})
+	orch := Orchestrator{cfg: cfg, now: func() time.Time { return now }}
+	state := newState(cfg)
+	issue := connector.Issue{ID: "issue-clear", State: "Todo"}
+	state.TrackerUnavailable = &TrackerCondition{Connector: "github", DetectedAt: now.Add(-time.Hour)}
+	state.Retry[issue.ID] = Retry{Issue: issue, Attempt: 1, DueAt: now.Add(time.Hour), TrackerUnavailable: true}
+
+	cleared := orch.clearTrackerAvailability(&state, now)
+	if len(cleared) != 1 || state.TrackerUnavailable != nil {
+		t.Fatalf("clearTrackerAvailability() = %#v, state = %#v", cleared, state.TrackerUnavailable)
+	}
+	retry := state.Retry[issue.ID]
+	if retry.TrackerUnavailable || !retry.DueAt.Equal(now) {
+		t.Fatalf("Retry[%q] = %#v, want released", issue.ID, retry)
+	}
+}
+
+func TestTrackerUnavailableCompletionFenceBecomesTypedWait(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 8, 17, 17, 20, 0, 0, time.UTC)
+	cfg := normalizeConfig(Config{
+		Project:        scheduler.ProjectCandidate{ID: "detent"},
+		PollInterval:   time.Minute,
+		ActiveStates:   []string{"In Progress"},
+		TerminalStates: []string{"Done"},
+	})
+	err := trackerAvailabilityTestError("issue_lookup", connector.TrackerAvailabilityClassTimeout)
+	tracker := &trackerFenceAvailabilityConnector{err: err}
+	orch := Orchestrator{cfg: cfg, connector: tracker, now: func() time.Time { return now }}
+	state := newState(cfg)
+	issue := dispatchTestIssue("issue-completion-fence", "In Progress")
+	state.Running[issue.ID] = Running{Issue: issue, Attempt: 2, Generation: 7, StartedAt: now.Add(-time.Minute)}
+
+	orch.handleRunResult(t.Context(), &state, runpkg.Completion{
+		IssueID:     issue.ID,
+		Request:     runpkg.RunRequest{Issue: issue, Attempt: 2, Generation: 7},
+		Result:      runpkg.RunResult{FinalState: FinalStateCompleted},
+		CompletedAt: now,
+	})
+
+	if len(orch.pendingLaneRevocations) != 0 {
+		t.Fatalf("pending lane revocations = %#v, want none", orch.pendingLaneRevocations)
+	}
+	retry, ok := state.Retry[issue.ID]
+	if !ok || !retry.TrackerUnavailable || retry.Attempt != 2 {
+		t.Fatalf("Retry[%q] = %#v, want typed tracker wait", issue.ID, retry)
+	}
+	if _, blocked := state.Blocked[issue.ID]; blocked {
+		t.Fatalf("Blocked[%q] present after completion-fence outage", issue.ID)
+	}
+}
+
+type trackerFenceAvailabilityConnector struct {
+	backendCapacityTestConnector
+	err error
+}
+
+func (c *trackerFenceAvailabilityConnector) FetchIssueStatesByIDs(context.Context, []string) ([]connector.Issue, error) {
+	return nil, c.err
+}
+
+func trackerAvailabilityTestError(operation string, class string) error {
+	return trackerAvailabilityTestErrorWithCredential(operation, class, "github-rest:test")
+}
+
+func trackerAvailabilityTestErrorWithCredential(operation string, class string, credentialIdentity string) error {
+	return connector.NewTrackerAvailabilityError(connector.TrackerAvailabilityScope{
+		Connector:          "github",
+		Endpoint:           "https://api.github.test/graphql",
+		Operation:          operation,
+		CredentialIdentity: credentialIdentity,
+	}, class, errors.New("upstream unavailable"))
+}

--- a/internal/orchestrator/work_attempts.go
+++ b/internal/orchestrator/work_attempts.go
@@ -792,6 +792,9 @@ func (o *Orchestrator) capacitySnapshotJSON(state *State, issue connector.Issue)
 	if state != nil && state.CIUnavailable != nil {
 		snapshot["ci_unavailable"] = *state.CIUnavailable
 	}
+	if state != nil && state.TrackerUnavailable != nil {
+		snapshot["tracker_unavailable"] = *state.TrackerUnavailable
+	}
 	if state != nil && len(state.DispatchRecoveries) > 0 {
 		snapshot["dispatch_recoveries"] = dispatchRecoveriesCapacitySnapshot(state.DispatchRecoveries, pool.Name, pool.Capacity)
 	}

--- a/internal/store/capacity_constraints.go
+++ b/internal/store/capacity_constraints.go
@@ -13,13 +13,14 @@ import (
 type CapacityConstraintReason string
 
 const (
-	CapacityConstraintSampleInterval                          = 5 * time.Minute
-	CapacityConstraintPool           CapacityConstraintReason = "pool_waits"
-	CapacityConstraintProject        CapacityConstraintReason = "project_capacity_full"
-	CapacityConstraintLane           CapacityConstraintReason = "lane_capacity_full"
-	CapacityConstraintWorkerHost     CapacityConstraintReason = "worker_host_capacity_full"
-	CapacityConstraintRateWindow     CapacityConstraintReason = "provider_rate_window_backpressure"
-	CapacityConstraintCIUnavailable  CapacityConstraintReason = "ci_unavailable"
+	CapacityConstraintSampleInterval                              = 5 * time.Minute
+	CapacityConstraintPool               CapacityConstraintReason = "pool_waits"
+	CapacityConstraintProject            CapacityConstraintReason = "project_capacity_full"
+	CapacityConstraintLane               CapacityConstraintReason = "lane_capacity_full"
+	CapacityConstraintWorkerHost         CapacityConstraintReason = "worker_host_capacity_full"
+	CapacityConstraintRateWindow         CapacityConstraintReason = "provider_rate_window_backpressure"
+	CapacityConstraintTrackerUnavailable CapacityConstraintReason = "tracker_unavailable"
+	CapacityConstraintCIUnavailable      CapacityConstraintReason = "ci_unavailable"
 )
 
 type CapacityConstraintQuery struct {
@@ -53,7 +54,7 @@ func QueryCapacityConstraintWaits(
 SELECT project_id, COALESCE(lane, ''), wait_reason, decision_at, capacity_snapshot_json
 FROM scheduler_decisions
 WHERE result = ?
-  AND wait_reason IN (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+  AND wait_reason IN (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
   AND decision_at >= ?`,
 		string(SchedulerDecisionResultSkipped),
 		poolCapacityWaitReason,
@@ -65,6 +66,7 @@ WHERE result = ?
 		string(CapacityConstraintWorkerHost),
 		"worker_host_unavailable",
 		string(CapacityConstraintRateWindow),
+		string(CapacityConstraintTrackerUnavailable),
 		string(CapacityConstraintCIUnavailable),
 		"local_slot_unavailable",
 		since,
@@ -164,6 +166,8 @@ func capacityConstraintReason(waitReason string, globalAvailable *int) (Capacity
 		return CapacityConstraintWorkerHost, true
 	case string(CapacityConstraintRateWindow):
 		return CapacityConstraintRateWindow, true
+	case string(CapacityConstraintTrackerUnavailable):
+		return CapacityConstraintTrackerUnavailable, true
 	case string(CapacityConstraintCIUnavailable):
 		return CapacityConstraintCIUnavailable, true
 	default:

--- a/internal/store/capacity_constraints_test.go
+++ b/internal/store/capacity_constraints_test.go
@@ -68,6 +68,12 @@ func TestCapacityConstraintReason(t *testing.T) {
 			wantOK:     true,
 		},
 		{
+			name:       "tracker unavailable",
+			waitReason: "tracker_unavailable",
+			want:       CapacityConstraintTrackerUnavailable,
+			wantOK:     true,
+		},
+		{
 			name:       "CI unavailable",
 			waitReason: "ci_unavailable",
 			want:       CapacityConstraintCIUnavailable,

--- a/internal/telemetry/snapshot.go
+++ b/internal/telemetry/snapshot.go
@@ -41,6 +41,7 @@ type Snapshot struct {
 	Completed               []Completed         `json:"completed"`
 	Budget                  Budget              `json:"budget"`
 	RateLimits              *RateLimits         `json:"rate_limits"`
+	TrackerUnavailable      []TrackerCondition  `json:"tracker_unavailable,omitempty"`
 	CIUnavailable           []CICondition       `json:"ci_unavailable,omitempty"`
 	BackendOutages          []BackendOutage     `json:"backend_outages,omitempty"`
 	FailureBreakers         []FailureBreaker    `json:"failure_breakers,omitempty"`
@@ -84,6 +85,25 @@ type CICondition struct {
 	DetectedAt          time.Time `json:"detected_at"`
 	LastObservedAt      time.Time `json:"last_observed_at"`
 	ParkedAttemptCount  int       `json:"parked_attempt_count,omitempty"`
+}
+
+type TrackerCondition struct {
+	ProjectID          string            `json:"project_id,omitempty"`
+	Connector          string            `json:"connector"`
+	ConnectorInstance  string            `json:"connector_instance"`
+	Endpoint           string            `json:"endpoint,omitempty"`
+	Operation          string            `json:"operation,omitempty"`
+	ErrorClass         string            `json:"error_class"`
+	CredentialIdentity string            `json:"credential_identity,omitempty"`
+	RefreshSource      RefreshSourceName `json:"refresh_source,omitempty"`
+	DetectedAt         time.Time         `json:"detected_at"`
+	LastObservedAt     time.Time         `json:"last_observed_at"`
+	NextProbeAt        time.Time         `json:"next_probe_at,omitzero"`
+	LastProbeAt        time.Time         `json:"last_probe_at,omitzero"`
+	LastProbeResult    string            `json:"last_probe_result,omitempty"`
+	LastProbeDetail    string            `json:"last_probe_detail,omitempty"`
+	ProbeAttempts      int               `json:"probe_attempts,omitempty"`
+	LastError          string            `json:"last_error,omitempty"`
 }
 
 type AdmissionProposal struct {
@@ -415,6 +435,8 @@ type RefreshFailure struct {
 	FailureThreshold int                  `json:"failure_threshold"`
 	LastError        string               `json:"last_error"`
 	LastErrorAt      *time.Time           `json:"last_error_at,omitempty"`
+	Condition        string               `json:"condition,omitempty"`
+	Connector        string               `json:"connector,omitempty"`
 }
 
 type RefreshSource struct {
@@ -425,6 +447,8 @@ type RefreshSource struct {
 	FailureStreak int               `json:"failure_streak,omitempty"`
 	LastError     string            `json:"last_error,omitempty"`
 	LastErrorAt   *time.Time        `json:"last_error_at,omitempty"`
+	Condition     string            `json:"condition,omitempty"`
+	Connector     string            `json:"connector,omitempty"`
 }
 
 type RefreshAttempt struct {
@@ -576,6 +600,8 @@ func (r Refresh) failure(projectID string) (RefreshFailure, bool) {
 			FailureThreshold: threshold,
 			LastError:        lastError,
 			LastErrorAt:      copyTimePointer(lastErrorAt),
+			Condition:        source.Condition,
+			Connector:        source.Connector,
 		}, true
 	}
 	if source.FailureStreak < threshold {
@@ -589,6 +615,8 @@ func (r Refresh) failure(projectID string) (RefreshFailure, bool) {
 		FailureThreshold: threshold,
 		LastError:        lastError,
 		LastErrorAt:      copyTimePointer(lastErrorAt),
+		Condition:        source.Condition,
+		Connector:        source.Connector,
 	}, true
 }
 

--- a/internal/web/api.go
+++ b/internal/web/api.go
@@ -483,6 +483,7 @@ func stateResponse(snapshot telemetry.Snapshot, generatedAt time.Time, observedA
 		WorkflowMetrics:    snapshot.WorkflowMetrics,
 		RecentSessions:     recentSessionEntries(snapshot.Completed),
 		RateLimits:         snapshot.RateLimits,
+		TrackerUnavailable: append([]telemetry.TrackerCondition(nil), snapshot.TrackerUnavailable...),
 		CIUnavailable:      append([]telemetry.CICondition(nil), snapshot.CIUnavailable...),
 		BackendOutages:     append([]telemetry.BackendOutage(nil), snapshot.BackendOutages...),
 		FailureBreakers:    append([]telemetry.FailureBreaker(nil), snapshot.FailureBreakers...),
@@ -1435,6 +1436,7 @@ type stateAPIResponse struct {
 	WorkflowMetrics    telemetry.WorkflowMetrics    `json:"workflow_metrics"`
 	RecentSessions     []recentSessionAPIResponse   `json:"recent_sessions"`
 	RateLimits         *telemetry.RateLimits        `json:"rate_limits"`
+	TrackerUnavailable []telemetry.TrackerCondition `json:"tracker_unavailable,omitempty"`
 	CIUnavailable      []telemetry.CICondition      `json:"ci_unavailable,omitempty"`
 	BackendOutages     []telemetry.BackendOutage    `json:"backend_outages,omitempty"`
 	FailureBreakers    []telemetry.FailureBreaker   `json:"failure_breakers,omitempty"`

--- a/internal/web/openapi.yaml
+++ b/internal/web/openapi.yaml
@@ -547,6 +547,32 @@ paths:
               schema: {$ref: "#/components/schemas/Status"}
         "404": {$ref: "#/components/responses/Problem"}
         "503": {$ref: "#/components/responses/Unavailable"}
+  /api/v1/tracker/availability/clear:
+    post:
+      operationId: clearTrackerAvailability
+      summary: Clear recorded tracker-availability conditions
+      tags: [administration]
+      security:
+        - bearerAuth: []
+        - apiKeyAuth: []
+      x-detent-access: admin
+      x-detent-scope: admin
+      x-detent-echo-path: /api/v1/tracker/availability/clear
+      requestBody:
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              type: object
+              properties:
+                project_id: {type: string}
+      responses:
+        "200":
+          description: Tracker availability records cleared.
+          content:
+            application/json:
+              schema: {$ref: "#/components/schemas/Status"}
+        "404": {$ref: "#/components/responses/Problem"}
+        "503": {$ref: "#/components/responses/Unavailable"}
   /api/v1/failure-breaker/canary:
     post:
       operationId: requestFailureBreakerCanary

--- a/internal/web/project_scope.go
+++ b/internal/web/project_scope.go
@@ -71,6 +71,7 @@ func projectScopedSnapshotForProject(snapshot telemetry.Snapshot, selectedProjec
 	out.Queue = scopedQueue(snapshot.Queue, selectedProjectID, fallbackProjectID)
 	out.Blocked = scopedBlocked(snapshot.Blocked, selectedProjectID, fallbackProjectID)
 	out.Completed = scopedCompleted(snapshot.Completed, selectedProjectID, fallbackProjectID)
+	out.TrackerUnavailable = scopedTrackerUnavailable(snapshot.TrackerUnavailable, selectedProjectID, fallbackProjectID)
 	out.CIUnavailable = scopedCIUnavailable(snapshot.CIUnavailable, selectedProjectID, fallbackProjectID)
 	out.FailureBreakers = scopedFailureBreakers(snapshot.FailureBreakers, selectedProjectID, fallbackProjectID)
 	out.DispatchRecoveries = scopedDispatchRecoveries(snapshot.DispatchRecoveries, selectedProjectID, fallbackProjectID)
@@ -121,6 +122,20 @@ func scopedDispatchStatuses(statuses []telemetry.DispatchStatus, selectedProject
 
 func scopedCIUnavailable(conditions []telemetry.CICondition, selectedProjectID string, fallbackProjectID string) []telemetry.CICondition {
 	out := make([]telemetry.CICondition, 0, len(conditions))
+	for _, condition := range conditions {
+		projectID := strings.TrimSpace(condition.ProjectID)
+		if projectID == "" {
+			projectID = fallbackProjectID
+		}
+		if projectID == selectedProjectID {
+			out = append(out, condition)
+		}
+	}
+	return out
+}
+
+func scopedTrackerUnavailable(conditions []telemetry.TrackerCondition, selectedProjectID string, fallbackProjectID string) []telemetry.TrackerCondition {
+	out := make([]telemetry.TrackerCondition, 0, len(conditions))
 	for _, condition := range conditions {
 		projectID := strings.TrimSpace(condition.ProjectID)
 		if projectID == "" {

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -434,6 +434,7 @@ func (s *Server) registerRoutes() {
 	s.echo.POST("/api/v1/refresh", s.apiRefresh, apiDashboardMutateAuth, apiWriteScope)
 	s.echo.POST("/api/v1/update/apply", s.apiUpdateApply, apiDashboardMutateAuth, apiAdminScope)
 	s.echo.POST("/api/v1/capacity/clear", s.apiCapacityClear, apiDashboardMutateAuth, apiAdminScope)
+	s.echo.POST("/api/v1/tracker/availability/clear", s.apiTrackerAvailabilityClear, apiDashboardMutateAuth, apiAdminScope)
 	s.echo.POST("/api/v1/failure-breaker/canary", s.apiFailureBreakerCanary, apiDashboardMutateAuth, apiAdminScope)
 	s.echo.POST("/api/v1/webhooks/github", s.githubWebhook)
 	s.echo.POST("/api/v1/intake/:project_id/:source", s.intakeWebhook)
@@ -1080,6 +1081,7 @@ func (s *Server) health(c echo.Context) error {
 	updateStatus := telemetry.Update{}
 	backendOutages := []telemetry.BackendOutage{}
 	failureBreakers := []telemetry.FailureBreaker{}
+	trackerUnavailable := []telemetry.TrackerCondition{}
 	ciUnavailable := []telemetry.CICondition{}
 	stalenessWarnings := []telemetry.StalenessWarning{}
 	strandedActiveIssues := []telemetry.StrandedIssue{}
@@ -1100,6 +1102,7 @@ func (s *Server) health(c echo.Context) error {
 			updateStatus = snapshot.Update
 			backendOutages = append(backendOutages, snapshot.BackendOutages...)
 			failureBreakers = append(failureBreakers, snapshot.FailureBreakers...)
+			trackerUnavailable = append(trackerUnavailable, snapshot.TrackerUnavailable...)
 			ciUnavailable = append(ciUnavailable, snapshot.CIUnavailable...)
 			stalenessWarnings = append(stalenessWarnings, snapshot.StalenessWarnings...)
 			strandedActiveIssues = append(strandedActiveIssues, snapshot.StrandedActiveIssues...)
@@ -1134,13 +1137,13 @@ func (s *Server) health(c echo.Context) error {
 		checks["demo_clock"] = s.demo.clock
 	}
 	projectStatus, projectHealth := s.projectHealth()
-	projectHealth = applyNeedsAttentionToProjectHealth(projectHealth, dispatchStalls, ciUnavailable, failureBreakers, backendOutages, tickLiveness, refreshFailures)
+	projectHealth = applyNeedsAttentionToProjectHealth(projectHealth, dispatchStalls, trackerUnavailable, ciUnavailable, failureBreakers, backendOutages, tickLiveness, refreshFailures)
 	var budgets []healthBudget
 	var workflows []healthWorkflowSource
 	if status != "draining" {
 		budgets = s.enforcedBudgets()
 		workflows = s.workflowSources()
-		if len(ciUnavailable) > 0 || len(dispatchStalls) > 0 || len(failureBreakers) > 0 || len(backendOutages) > 0 || tickLivenessNeedsAttention(tickLiveness) || len(refreshFailures) > 0 {
+		if len(trackerUnavailable) > 0 || len(ciUnavailable) > 0 || len(dispatchStalls) > 0 || len(failureBreakers) > 0 || len(backendOutages) > 0 || tickLivenessNeedsAttention(tickLiveness) || len(refreshFailures) > 0 {
 			status = "needs_attention"
 		}
 	}
@@ -1157,6 +1160,7 @@ func (s *Server) health(c echo.Context) error {
 		Environment:          healthEnvironment{Path: os.Getenv("PATH")},
 		Budgets:              budgets,
 		Workflows:            workflows,
+		TrackerUnavailable:   trackerUnavailable,
 		CIUnavailable:        ciUnavailable,
 		BackendOutages:       backendOutages,
 		FailureBreakers:      failureBreakers,
@@ -1174,8 +1178,8 @@ func (s *Server) health(c echo.Context) error {
 	})
 }
 
-func applyNeedsAttentionToProjectHealth(projects []healthProject, stalls []telemetry.DispatchStatus, ciUnavailable []telemetry.CICondition, breakers []telemetry.FailureBreaker, outages []telemetry.BackendOutage, tickLiveness []telemetry.TickLiveness, refreshFailures []telemetry.RefreshFailure) []healthProject {
-	needsAttention := make(map[string]struct{}, len(stalls)+len(ciUnavailable)+len(breakers)+len(outages)+len(tickLiveness))
+func applyNeedsAttentionToProjectHealth(projects []healthProject, stalls []telemetry.DispatchStatus, trackerUnavailable []telemetry.TrackerCondition, ciUnavailable []telemetry.CICondition, breakers []telemetry.FailureBreaker, outages []telemetry.BackendOutage, tickLiveness []telemetry.TickLiveness, refreshFailures []telemetry.RefreshFailure) []healthProject {
+	needsAttention := make(map[string]struct{}, len(stalls)+len(trackerUnavailable)+len(ciUnavailable)+len(breakers)+len(outages)+len(tickLiveness))
 	refreshByProject := make(map[string]telemetry.RefreshFailure, len(refreshFailures))
 	for _, stall := range stalls {
 		if projectID := strings.TrimSpace(stall.ProjectID); projectID != "" && stall.Stalled {
@@ -1183,6 +1187,11 @@ func applyNeedsAttentionToProjectHealth(projects []healthProject, stalls []telem
 		}
 	}
 	for _, condition := range ciUnavailable {
+		if projectID := strings.TrimSpace(condition.ProjectID); projectID != "" {
+			needsAttention[projectID] = struct{}{}
+		}
+	}
+	for _, condition := range trackerUnavailable {
 		if projectID := strings.TrimSpace(condition.ProjectID); projectID != "" {
 			needsAttention[projectID] = struct{}{}
 		}
@@ -1494,6 +1503,7 @@ type healthResponse struct {
 	Environment          healthEnvironment            `json:"environment"`
 	Budgets              []healthBudget               `json:"budgets,omitempty"`
 	Workflows            []healthWorkflowSource       `json:"workflows,omitempty"`
+	TrackerUnavailable   []telemetry.TrackerCondition `json:"tracker_unavailable,omitempty"`
 	CIUnavailable        []telemetry.CICondition      `json:"ci_unavailable,omitempty"`
 	BackendOutages       []telemetry.BackendOutage    `json:"backend_outages,omitempty"`
 	FailureBreakers      []telemetry.FailureBreaker   `json:"failure_breakers,omitempty"`

--- a/internal/web/server_test.go
+++ b/internal/web/server_test.go
@@ -241,6 +241,22 @@ func TestCapacityClearEndpointIsIdempotentWithoutOutages(t *testing.T) {
 	}
 }
 
+func TestTrackerAvailabilityClearEndpointIsIdempotentWithoutConditions(t *testing.T) {
+	t.Parallel()
+
+	server, err := web.NewServer(web.Config{}, testDeps(t))
+	if err != nil {
+		t.Fatalf("NewServer() error = %v", err)
+	}
+	recorder := performForm(t, server.Handler(), http.MethodPost, "/api/v1/tracker/availability/clear", nil)
+	if recorder.Code != http.StatusNoContent {
+		t.Fatalf("status = %d, want %d; body = %s", recorder.Code, http.StatusNoContent, recorder.Body.String())
+	}
+	if recorder.Header().Get("HX-Trigger") != "trackerAvailabilityCleared" {
+		t.Fatalf("HX-Trigger = %q", recorder.Header().Get("HX-Trigger"))
+	}
+}
+
 func TestFailureBreakerCanaryEndpointIsIdempotentWithoutActiveBreakers(t *testing.T) {
 	t.Parallel()
 

--- a/internal/web/templates/board_data.go
+++ b/internal/web/templates/board_data.go
@@ -2,6 +2,7 @@ package templates
 
 import (
 	"encoding/json"
+	"net/url"
 	"sort"
 	"strconv"
 	"strings"
@@ -32,27 +33,29 @@ type boardView struct {
 type boardAlertKind string
 
 const (
-	boardAlertKindLastKnown             boardAlertKind = "board-last-known"
-	boardAlertKindFailureBreaker        boardAlertKind = "project-failure-breaker"
-	boardAlertKindDispatchStall         boardAlertKind = "dispatch-stall"
-	boardAlertKindCIUnavailable         boardAlertKind = "ci-unavailable"
-	boardAlertKindStaleness             boardAlertKind = "staleness-warning"
-	boardAlertKindTrackerStale          boardAlertKind = "board-stale-data"
-	boardAlertKindAdmissionProposal     boardAlertKind = "admission-proposal"
-	boardAlertKindBackendCapacity       boardAlertKind = "backend-capacity-outage"
-	boardAlertKindDispatchRecovery      boardAlertKind = "dispatch-recovery-status"
-	boardAlertKindUpdatePending         boardAlertKind = "update-pending"
-	boardAlertDetailLimit                              = 5
-	boardAlertSeverityUpdatePending                    = 100
-	boardAlertSeverityDispatchRecovery                 = 200
-	boardAlertSeverityBackendCapacity                  = 300
-	boardAlertSeverityAdmissionProposal                = 425
-	boardAlertSeverityTrackerStale                     = 400
-	boardAlertSeverityStaleness                        = 450
-	boardAlertSeverityFailureBreaker                   = 500
-	boardAlertSeverityCIUnavailable                    = 550
-	boardAlertSeverityDispatchStall                    = 575
-	boardAlertSeverityLastKnown                        = 600
+	boardAlertKindLastKnown              boardAlertKind = "board-last-known"
+	boardAlertKindFailureBreaker         boardAlertKind = "project-failure-breaker"
+	boardAlertKindDispatchStall          boardAlertKind = "dispatch-stall"
+	boardAlertKindTrackerUnavailable     boardAlertKind = "tracker-unavailable"
+	boardAlertKindCIUnavailable          boardAlertKind = "ci-unavailable"
+	boardAlertKindStaleness              boardAlertKind = "staleness-warning"
+	boardAlertKindTrackerStale           boardAlertKind = "board-stale-data"
+	boardAlertKindAdmissionProposal      boardAlertKind = "admission-proposal"
+	boardAlertKindBackendCapacity        boardAlertKind = "backend-capacity-outage"
+	boardAlertKindDispatchRecovery       boardAlertKind = "dispatch-recovery-status"
+	boardAlertKindUpdatePending          boardAlertKind = "update-pending"
+	boardAlertDetailLimit                               = 5
+	boardAlertSeverityUpdatePending                     = 100
+	boardAlertSeverityDispatchRecovery                  = 200
+	boardAlertSeverityBackendCapacity                   = 300
+	boardAlertSeverityAdmissionProposal                 = 425
+	boardAlertSeverityTrackerStale                      = 400
+	boardAlertSeverityStaleness                         = 450
+	boardAlertSeverityFailureBreaker                    = 500
+	boardAlertSeverityCIUnavailable                     = 550
+	boardAlertSeverityTrackerUnavailable                = 560
+	boardAlertSeverityDispatchStall                     = 575
+	boardAlertSeverityLastKnown                         = 600
 )
 
 type boardAlert struct {
@@ -85,7 +88,7 @@ type boardAlertAction struct {
 }
 
 func boardAlerts(snapshot telemetry.Snapshot) []boardAlert {
-	alerts := make([]boardAlert, 0, len(snapshot.StalenessWarnings)+7)
+	alerts := make([]boardAlert, 0, len(snapshot.StalenessWarnings)+8)
 	if alert, ok := boardLastKnownAlert(snapshot); ok {
 		alerts = append(alerts, alert)
 	}
@@ -93,6 +96,9 @@ func boardAlerts(snapshot telemetry.Snapshot) []boardAlert {
 		alerts = append(alerts, alert)
 	}
 	if alert, ok := boardCIUnavailableAlert(snapshot); ok {
+		alerts = append(alerts, alert)
+	}
+	if alert, ok := boardTrackerUnavailableAlert(snapshot); ok {
 		alerts = append(alerts, alert)
 	}
 	if alert, ok := boardDispatchStallAlert(snapshot); ok {
@@ -191,6 +197,66 @@ func boardCIUnavailableAlert(snapshot telemetry.Snapshot) (boardAlert, bool) {
 		Overflow:      overflow,
 		DeepLink:      "/health/ui",
 	}, true
+}
+
+func boardTrackerUnavailableAlert(snapshot telemetry.Snapshot) (boardAlert, bool) {
+	if len(snapshot.TrackerUnavailable) == 0 {
+		return boardAlert{}, false
+	}
+	rows := make([]boardAlertDetailRow, 0, len(snapshot.TrackerUnavailable))
+	for index, condition := range snapshot.TrackerUnavailable {
+		label := strings.TrimSpace(condition.ProjectID)
+		if label == "" {
+			label = strings.TrimSpace(condition.ConnectorInstance)
+		}
+		if label == "" {
+			label = "Tracker"
+		}
+		summary := strings.TrimSpace(condition.Connector) + " tracker · tracker_unavailable"
+		if strings.TrimSpace(condition.Connector) == "" {
+			summary = "Tracker · tracker_unavailable"
+		}
+		detail := strings.TrimSpace(condition.Operation) + " · " + strings.TrimSpace(condition.ErrorClass)
+		if !condition.NextProbeAt.IsZero() {
+			delay := condition.NextProbeAt.Sub(snapshot.GeneratedAt)
+			if delay < 0 {
+				delay = 0
+			}
+			detail += " · next canary in " + formatDuration(delay.Seconds())
+		}
+		rows = append(rows, boardAlertDetailRow{
+			ID:      "board-alert-tracker-unavailable-" + boardAlertRowSlug(label, index),
+			Label:   label,
+			Summary: summary,
+			Detail:  strings.Trim(detail, " ·"),
+		})
+	}
+	rows, overflow := capBoardAlertRows(rows)
+	alert := boardAlert{
+		ID:            "board-alert-tracker-unavailable",
+		Kind:          boardAlertKindTrackerUnavailable,
+		Severity:      boardAlertSeverityTrackerUnavailable,
+		Tone:          primitives.KindErr,
+		TerseSummary:  "Tracker unavailable (" + boardCountLabel(len(snapshot.TrackerUnavailable), "connector", "connectors") + ")",
+		DetailSummary: "Tracker-dependent dispatch is paused until a canary read succeeds.",
+		DetailRows:    rows,
+		Overflow:      overflow,
+		DeepLink:      "/health/ui",
+	}
+	if len(snapshot.TrackerUnavailable) == 1 {
+		projectID := strings.TrimSpace(snapshot.TrackerUnavailable[0].ProjectID)
+		path := "/api/v1/tracker/availability/clear"
+		if projectID != "" {
+			path += "?project_id=" + url.QueryEscape(projectID)
+		}
+		alert.Action = &boardAlertAction{
+			Label:   "Clear condition",
+			Path:    path,
+			Target:  "#board-alert-tracker-unavailable",
+			Confirm: "Clear the tracker availability condition and resume dispatch?",
+		}
+	}
+	return alert, true
 }
 
 func ciUnavailableConditionDetail(condition telemetry.CICondition) string {

--- a/internal/web/templates/board_data_test.go
+++ b/internal/web/templates/board_data_test.go
@@ -2477,6 +2477,35 @@ func TestBoardAlertsSurfaceCIUnavailableEvidence(t *testing.T) {
 	}
 }
 
+func TestBoardAlertsNameTrackerAvailabilityCondition(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 8, 17, 17, 20, 0, 0, time.UTC)
+	alerts := boardAlerts(telemetry.Snapshot{
+		GeneratedAt: now,
+		TrackerUnavailable: []telemetry.TrackerCondition{{
+			ProjectID:         "detent",
+			Connector:         "github",
+			ConnectorInstance: "detent:github",
+			Operation:         "observed_status",
+			ErrorClass:        "server",
+			NextProbeAt:       now.Add(30 * time.Second),
+		}},
+	})
+	if len(alerts) != 1 || alerts[0].Kind != boardAlertKindTrackerUnavailable || alerts[0].Tone != primitives.KindErr {
+		t.Fatalf("boardAlerts() = %#v, want tracker-unavailable error", alerts)
+	}
+	combined := alerts[0].TerseSummary + " " + alerts[0].DetailSummary + " " + alerts[0].DetailRows[0].Summary + " " + alerts[0].DetailRows[0].Detail
+	for _, want := range []string{"Tracker unavailable", "github tracker", "tracker_unavailable", "observed_status", "server", "next canary in 30s"} {
+		if !strings.Contains(combined, want) {
+			t.Fatalf("tracker alert = %q, want containing %q", combined, want)
+		}
+	}
+	if alerts[0].Action == nil || !strings.Contains(alerts[0].Action.Path, "project_id=detent") {
+		t.Fatalf("tracker alert action = %#v, want project-scoped clear", alerts[0].Action)
+	}
+}
+
 func TestBoardAlertsSurfaceDispatchStallAsNeedsAttention(t *testing.T) {
 	t.Parallel()
 

--- a/internal/web/templates/dashboard_data.go
+++ b/internal/web/templates/dashboard_data.go
@@ -7180,6 +7180,8 @@ func dispatchRecoveryDetailParts(recovery telemetry.DispatchRecovery, now time.T
 
 func dispatchRecoveryKindLabel(kind string) string {
 	switch strings.TrimSpace(kind) {
+	case "tracker_unavailable":
+		return "tracker availability"
 	case "github_rest":
 		return "GitHub REST capacity"
 	case "pull_request_hydration":

--- a/internal/web/templates/freshness_data.go
+++ b/internal/web/templates/freshness_data.go
@@ -144,6 +144,9 @@ func refreshStaleDetailRows(snapshot telemetry.Snapshot) []refreshStaleDetailRow
 			if source.FailureStreak > 0 {
 				detail += " · " + formatCount(source.FailureStreak) + " consecutive failures"
 			}
+			if condition := refreshSourceConditionDetail(source); condition != "" {
+				detail += " · " + condition
+			}
 			if lastError := strings.TrimSpace(source.LastError); lastError != "" {
 				detail += " · " + lastError
 			}
@@ -179,6 +182,9 @@ func refreshStaleHealthDetail(snapshot telemetry.Snapshot) string {
 		}
 		if source.FailureStreak > 0 {
 			part += " · " + formatCount(source.FailureStreak) + " consecutive failures"
+		}
+		if condition := refreshSourceConditionDetail(source); condition != "" {
+			part += " · " + condition
 		}
 		if lastError := strings.TrimSpace(source.LastError); lastError != "" {
 			part += " · " + lastError
@@ -320,6 +326,9 @@ func healthRefreshRows(snapshot telemetry.Snapshot) []healthRow {
 			if source.FailureStreak > 0 {
 				detail += " · " + formatCount(source.FailureStreak) + " consecutive failures"
 			}
+			if condition := refreshSourceConditionDetail(source); condition != "" {
+				detail += " · " + condition
+			}
 			if refreshSourceStale(snapshot.Refresh, source, snapshot.GeneratedAt) {
 				kind = primitives.KindWarn
 				if lastError := strings.TrimSpace(source.LastError); lastError != "" {
@@ -342,6 +351,20 @@ func healthRefreshRows(snapshot telemetry.Snapshot) []healthRow {
 		})
 	}
 	return rows
+}
+
+func refreshSourceConditionDetail(source telemetry.RefreshSource) string {
+	condition := strings.TrimSpace(source.Condition)
+	if condition == "" {
+		return ""
+	}
+	connectorName := strings.TrimSpace(source.Connector)
+	if connectorName == "" {
+		connectorName = "tracker"
+	} else {
+		connectorName += " tracker"
+	}
+	return connectorName + " · " + condition
 }
 
 func refreshHealthStatus(kind primitives.Kind) string {

--- a/internal/web/templates/health_data.go
+++ b/internal/web/templates/health_data.go
@@ -50,6 +50,12 @@ func healthViewFromDashboard(data DashboardData) healthView {
 		view.Detail = boardCountLabel(len(snapshot.DispatchStalls), "Project needs", "Projects need") + " human attention."
 		return view
 	}
+	if len(snapshot.TrackerUnavailable) > 0 {
+		view.Kind = primitives.KindErr
+		view.Verdict = "Tracker is unavailable."
+		view.Detail = trackerUnavailableHealthDetail(snapshot.TrackerUnavailable)
+		return view
+	}
 	if len(snapshot.CIUnavailable) > 0 {
 		view.Kind = primitives.KindErr
 		view.Verdict = "CI is unavailable."
@@ -222,6 +228,7 @@ func healthRows(snapshot telemetry.Snapshot) []healthRow {
 	for _, stall := range snapshot.DispatchStalls {
 		rows = append(rows, healthDispatchStallRow(stall))
 	}
+	rows = append(rows, healthTrackerUnavailableRows(snapshot.TrackerUnavailable)...)
 	rows = append(rows, healthCIUnavailableRows(snapshot.CIUnavailable)...)
 	for _, warning := range snapshot.StalenessWarnings {
 		rows = append(rows, healthStalenessRow(warning))
@@ -307,6 +314,44 @@ func healthCIUnavailableRows(conditions []telemetry.CICondition) []healthRow {
 		})
 	}
 	return rows
+}
+
+func healthTrackerUnavailableRows(conditions []telemetry.TrackerCondition) []healthRow {
+	rows := make([]healthRow, 0, len(conditions))
+	for index, condition := range conditions {
+		projectID := strings.TrimSpace(condition.ProjectID)
+		if projectID == "" {
+			projectID = "project"
+		}
+		connectorName := strings.TrimSpace(condition.Connector)
+		if connectorName == "" {
+			connectorName = "Tracker"
+		}
+		detail := "tracker_unavailable · " + strings.Trim(strings.TrimSpace(condition.Operation)+" · "+strings.TrimSpace(condition.ErrorClass), " ·")
+		rows = append(rows, healthRow{
+			ID:        "health-tracker-unavailable-" + boardAlertRowSlug(projectID, index),
+			Component: connectorName + " tracker · " + projectID,
+			Kind:      primitives.KindErr,
+			Status:    "Unavailable",
+			Detail:    detail,
+			Resets:    "on successful canary",
+			ResetAt:   condition.NextProbeAt,
+			DetailAt:  condition.LastObservedAt,
+		})
+	}
+	return rows
+}
+
+func trackerUnavailableHealthDetail(conditions []telemetry.TrackerCondition) string {
+	if len(conditions) == 1 {
+		condition := conditions[0]
+		connectorName := strings.TrimSpace(condition.Connector)
+		if connectorName == "" {
+			connectorName = "Configured"
+		}
+		return connectorName + " tracker reads are unavailable; tracker-dependent dispatch is paused."
+	}
+	return boardCountLabel(len(conditions), "tracker connector is", "tracker connectors are") + " unavailable; tracker-dependent dispatch is paused."
 }
 
 func ciUnavailableHealthDetail(conditions []telemetry.CICondition) string {

--- a/internal/web/templates/health_data_test.go
+++ b/internal/web/templates/health_data_test.go
@@ -35,6 +35,17 @@ func TestHealthViewVerdicts(t *testing.T) {
 			wantVerdict: "Waiting for the first health snapshot.",
 		},
 		{
+			name: "tracker unavailability requires attention",
+			snapshot: telemetry.Snapshot{
+				GeneratedAt: now,
+				TrackerUnavailable: []telemetry.TrackerCondition{{
+					ProjectID: "detent", Connector: "github", Operation: "observed_status", ErrorClass: "server", NextProbeAt: now.Add(time.Minute),
+				}},
+			},
+			wantKind:    primitives.KindErr,
+			wantVerdict: "Tracker is unavailable.",
+		},
+		{
 			name: "CI unavailability requires attention",
 			snapshot: telemetry.Snapshot{
 				GeneratedAt: now,

--- a/internal/web/templates/shell_data.go
+++ b/internal/web/templates/shell_data.go
@@ -138,6 +138,9 @@ func appShellActiveNav(data DashboardShellData) string {
 }
 
 func appShellHealthKind(data DashboardShellData) primitives.Kind {
+	if len(data.Snapshot.TrackerUnavailable) > 0 || len(data.Snapshot.CIUnavailable) > 0 {
+		return primitives.KindErr
+	}
 	switch gitHubAPIHealth(data.Snapshot).State {
 	case gitHubAPIHealthStateBackoff, gitHubAPIHealthStateExhausted:
 		return primitives.KindErr

--- a/internal/web/tracker_availability.go
+++ b/internal/web/tracker_availability.go
@@ -1,0 +1,54 @@
+package web
+
+import (
+	"errors"
+	"net/http"
+	"strings"
+
+	"github.com/labstack/echo/v4"
+
+	"github.com/digitaldrywood/detent/internal/orchestrator"
+	"github.com/digitaldrywood/detent/internal/project"
+)
+
+type trackerAvailabilityClearResponse struct {
+	Status  string `json:"status"`
+	Project string `json:"project,omitempty"`
+	Cleared int    `json:"cleared"`
+}
+
+func (s *Server) apiTrackerAvailabilityClear(c echo.Context) error {
+	projectID := strings.TrimSpace(c.FormValue("project_id"))
+	projects := s.registry.List()
+	if projectID != "" {
+		selected, ok := s.registry.Get(project.ID(projectID))
+		if !ok {
+			return c.JSON(http.StatusNotFound, errorResponse("project_not_found", "project not found"))
+		}
+		projects = []*project.Project{selected}
+	}
+
+	cleared := 0
+	for _, candidate := range projects {
+		conditions, err := candidate.Orchestrator().ClearTrackerAvailability(c.Request().Context())
+		if err != nil {
+			if errors.Is(err, orchestrator.ErrStopped) {
+				continue
+			}
+			s.logger.Warn("tracker availability clear failed", "project_id", candidate.ID(), "error", err)
+			return c.JSON(http.StatusServiceUnavailable, errorResponse("tracker_availability_clear_failed", "tracker availability condition clear failed"))
+		}
+		cleared += len(conditions)
+	}
+
+	s.logger.Info("tracker availability clear requested", "project_id", projectID, "cleared", cleared)
+	if c.Request().Header.Get("HX-Request") == "true" {
+		c.Response().Header().Set("HX-Trigger", "trackerAvailabilityCleared")
+		return c.NoContent(http.StatusNoContent)
+	}
+	return c.JSON(http.StatusOK, trackerAvailabilityClearResponse{
+		Status:  "cleared",
+		Project: projectID,
+		Cleared: cleared,
+	})
+}


### PR DESCRIPTION
## Summary

- classify tracker-read 5xx, timeout, DNS, and transport failures without conflating auth, tenant capacity, forge writes, or CI
- add connector-scoped tracker outage correlation, source canaries, automatic recovery, operator clear, and tracker-dependent dispatch holds
- route typed tracker waits before all failure breakers and expose attributed health, telemetry, notifications, and board/Health UI

Fixes #1868

## UI Surface Contract

- [x] N/A, or the linked issue explicitly authorizes any high-impact UI surface, layout, density, first-viewport, or responsive visibility tradeoff.
- [x] Persistent top-of-screen messaging is explicitly authorized by the issue, or this PR does not add it.
- [x] Visual changes to primary operator screens include screenshot or browser verification below.

Issue #1868 explicitly requires an attributed board banner. Verified Board and Health in the isolated screenshots dev runtime at 1440x1100/DPR 1 on an ephemeral port; no JavaScript errors were reported and the live port 4000 was untouched.

## Test Plan

- [x] `make check`
- [x] table-driven GitHub and Linear classification tests cover 5xx, timeout, DNS/transport, 429, 403, 404, tracker status PR-reference reads, and forge exclusions
- [x] orchestrator tests cover single-transient correlation, canary clear/resume, operator clear, dispatch hold/resume, completion-fence waits, and all three failure breakers

Local gate: golangci-lint v2.1.6, vet, NilAway, race suite, 79.0% overall coverage, and configured package/file coverage floors all passed.