### PR TITLE
fix(orchestrator): defer fenced completions

### DIFF
--- a/db/queries/store.sql
+++ b/db/queries/store.sql
@@ -859,6 +859,7 @@ WHERE completed_at IS NULL
   AND (sqlc.arg(filter_project_id) = '' OR project_id = sqlc.arg(filter_project_id))
   AND lease_expires_at IS NOT NULL
   AND lease_expires_at <= sqlc.arg(lease_expires_at)
+  AND lower(trim(COALESCE(phase, ''))) != 'completion_deferred'
 RETURNING *;
 
 -- name: ReclaimActiveWorkAttempts :many
@@ -873,6 +874,7 @@ SET status = ?,
     status_message = ?
 WHERE completed_at IS NULL
   AND project_id = ?
+  AND lower(trim(COALESCE(phase, ''))) != 'completion_deferred'
 RETURNING *;
 
 -- name: CreateSchedulerDecision :one

--- a/internal/orchestrator/completion_deferral.go
+++ b/internal/orchestrator/completion_deferral.go
@@ -1,0 +1,409 @@
+package orchestrator
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/digitaldrywood/detent/internal/connector"
+	runpkg "github.com/digitaldrywood/detent/internal/runner"
+	"github.com/digitaldrywood/detent/internal/runtimeoutput"
+	"github.com/digitaldrywood/detent/internal/store"
+	"github.com/digitaldrywood/detent/internal/telemetry"
+)
+
+const (
+	deferredCompletionSchema       = 1
+	deferredCompletionMetadataKey  = "deferred_completion"
+	deferredCompletionPhase        = "completion_deferred"
+	deferredCompletionStatus       = "completion waiting on tracker lane fence"
+	deferredCompletionNextAction   = "retry completion fence"
+	deferredCompletionInvalidClass = "completion_deferral_invalid"
+)
+
+type deferredCompletion struct {
+	Schema       int                            `json:"schema"`
+	Running      Running                        `json:"running"`
+	Request      deferredCompletionRequest      `json:"request"`
+	Result       runpkg.RunResult               `json:"result"`
+	Error        string                         `json:"error,omitempty"`
+	CompletedAt  time.Time                      `json:"completed_at"`
+	Retryable    bool                           `json:"retryable,omitempty"`
+	RetryAttempt int                            `json:"retry_attempt,omitempty"`
+	RetryDelay   time.Duration                  `json:"retry_delay,omitempty"`
+	DeferredAt   time.Time                      `json:"deferred_at"`
+	Availability deferredCompletionAvailability `json:"availability"`
+	Persisted    bool                           `json:"-"`
+}
+
+type deferredCompletionRequest struct {
+	ProjectID           string                 `json:"project_id,omitempty"`
+	Issue               connector.Issue        `json:"issue"`
+	Attempt             int                    `json:"attempt,omitempty"`
+	WorkAttemptID       int64                  `json:"work_attempt_id,omitempty"`
+	Generation          uint64                 `json:"generation,omitempty"`
+	Mode                string                 `json:"mode,omitempty"`
+	DispatchSourceState string                 `json:"dispatch_source_state,omitempty"`
+	DispatchTargetState string                 `json:"dispatch_target_state,omitempty"`
+	PriorAttempt        runpkg.PriorAttempt    `json:"prior_attempt,omitzero"`
+	StartedAt           time.Time              `json:"started_at,omitzero"`
+	WorkerHost          string                 `json:"worker_host,omitempty"`
+	RetryMode           runpkg.RetryMode       `json:"retry_mode,omitempty"`
+	ResumeState         store.AgentResumeState `json:"resume_state,omitzero"`
+	MergePrecheck       *runpkg.MergePrecheck  `json:"merge_precheck,omitempty"`
+}
+
+type deferredCompletionAvailability struct {
+	Scope   connector.TrackerAvailabilityScope `json:"scope"`
+	Class   string                             `json:"class,omitempty"`
+	Message string                             `json:"message"`
+}
+
+func newDeferredCompletion(event runpkg.Completion, running Running, availabilityErr *connector.TrackerAvailabilityError, deferredAt time.Time) deferredCompletion {
+	running.CompletionOwnershipReleased = true
+	record := deferredCompletion{
+		Schema:       deferredCompletionSchema,
+		Running:      running,
+		Request:      deferredCompletionRequestFromRun(event.Request),
+		Result:       event.Result,
+		Error:        errorString(event.Err),
+		CompletedAt:  event.CompletedAt,
+		Retryable:    event.Retryable,
+		RetryAttempt: event.RetryAttempt,
+		RetryDelay:   event.RetryDelay,
+		DeferredAt:   deferredAt,
+	}
+	if availabilityErr != nil {
+		record.Availability = deferredCompletionAvailability{
+			Scope:   availabilityErr.Scope.Normalize(),
+			Class:   strings.TrimSpace(availabilityErr.Class),
+			Message: strings.TrimSpace(availabilityErr.Error()),
+		}
+	}
+	return record
+}
+
+func deferredCompletionRequestFromRun(request runpkg.RunRequest) deferredCompletionRequest {
+	return deferredCompletionRequest{
+		ProjectID:           request.ProjectID,
+		Issue:               cloneIssue(request.Issue),
+		Attempt:             request.Attempt,
+		WorkAttemptID:       request.WorkAttemptID,
+		Generation:          request.Generation,
+		Mode:                request.Mode,
+		DispatchSourceState: request.DispatchSourceState,
+		DispatchTargetState: request.DispatchTargetState,
+		PriorAttempt:        request.PriorAttempt,
+		StartedAt:           request.StartedAt,
+		WorkerHost:          request.WorkerHost,
+		RetryMode:           request.RetryMode,
+		ResumeState:         request.ResumeState,
+		MergePrecheck:       cloneMergePrecheck(request.MergePrecheck),
+	}
+}
+
+func (r deferredCompletion) completion() runpkg.Completion {
+	event := runpkg.Completion{
+		IssueID: r.Running.Issue.ID,
+		Request: runpkg.RunRequest{
+			ProjectID:           r.Request.ProjectID,
+			Issue:               cloneIssue(r.Request.Issue),
+			Attempt:             r.Request.Attempt,
+			WorkAttemptID:       r.Request.WorkAttemptID,
+			Generation:          r.Request.Generation,
+			Mode:                r.Request.Mode,
+			DispatchSourceState: r.Request.DispatchSourceState,
+			DispatchTargetState: r.Request.DispatchTargetState,
+			PriorAttempt:        r.Request.PriorAttempt,
+			StartedAt:           r.Request.StartedAt,
+			WorkerHost:          r.Request.WorkerHost,
+			RetryMode:           r.Request.RetryMode,
+			ResumeState:         r.Request.ResumeState,
+			MergePrecheck:       cloneMergePrecheck(r.Request.MergePrecheck),
+		},
+		Result:       r.Result,
+		CompletedAt:  r.CompletedAt,
+		Retryable:    r.Retryable,
+		RetryAttempt: r.RetryAttempt,
+		RetryDelay:   r.RetryDelay,
+	}
+	if strings.TrimSpace(r.Error) != "" {
+		event.Err = errors.New(r.Error)
+	}
+	return event
+}
+
+func (o *Orchestrator) deferTrackerUnavailableCompletion(
+	ctx context.Context,
+	state *State,
+	event runpkg.Completion,
+	running Running,
+	availabilityErr *connector.TrackerAvailabilityError,
+) {
+	deferredAt := o.clockNow().UTC()
+	if deferredAt.IsZero() {
+		deferredAt = event.CompletedAt.UTC()
+	}
+	if deferredAt.IsZero() {
+		deferredAt = time.Now().UTC()
+	}
+	o.observeTrackerReadFailure(state, "", availabilityErr, deferredAt)
+	record := newDeferredCompletion(event, running, availabilityErr, deferredAt)
+	record.Persisted = o.persistDeferredCompletion(ctx, state, record)
+
+	if !running.CompletionOwnershipReleased {
+		o.releaseGlobalDispatchSlot(running.globalSlot)
+		o.logWorkerLifecycle(running.Issue, "worker_capacity_released",
+			telemetry.WorkAttemptIDKey, running.WorkAttemptID,
+			telemetry.DetentSessionIDKey, running.DetentSessionID,
+			telemetry.ProviderSessionIDKey, running.SessionID,
+			"attempt", running.Attempt,
+			"worker_host", strings.TrimSpace(running.WorkerHost),
+			"reason", deferredCompletionPhase,
+		)
+		if running.cancel != nil {
+			running.cancel()
+		}
+	}
+	o.heartbeats.remove(event.IssueID)
+	delete(state.Running, event.IssueID)
+	releaseDispatchRecoveryAdmission(state, event.IssueID)
+	if state.deferredCompletions == nil {
+		state.deferredCompletions = map[string]deferredCompletion{}
+	}
+	state.deferredCompletions[event.IssueID] = record
+	delay := max(event.RetryDelay, o.cfg.PollInterval)
+	if delay < 0 {
+		delay = 0
+	}
+	state.Retry[event.IssueID] = Retry{
+		Issue:              cloneIssue(running.Issue),
+		Attempt:            running.Attempt,
+		DueAt:              deferredAt.Add(delay),
+		Error:              deferredCompletionStatus,
+		WorkerHost:         running.WorkerHost,
+		TrackerUnavailable: true,
+		CompletionDeferred: true,
+	}
+	recordStateEvent(state, telemetry.ActivityEvent{
+		At:      deferredAt,
+		Event:   deferredCompletionPhase,
+		Message: "preserved completed result for " + issueLabel(running.Issue) + " while waiting on the tracker lane fence",
+	})
+	if !record.Persisted {
+		recordStateEvent(state, telemetry.ActivityEvent{
+			At:      deferredAt,
+			Event:   "completion_deferral_persist_failed",
+			Message: "retained completed result in memory for " + issueLabel(running.Issue) + " after durable persistence failed",
+		})
+	}
+}
+
+func (o *Orchestrator) persistDeferredCompletion(ctx context.Context, state *State, record deferredCompletion) bool {
+	if o == nil || o.workAttempts == nil || record.Running.WorkAttemptID <= 0 {
+		return true
+	}
+	metadata, err := deferredCompletionMetadataJSON(record)
+	if err != nil {
+		if o.logger != nil {
+			o.logger.Error("deferred completion serialization failed", "attempt_id", record.Running.WorkAttemptID, "issue_id", record.Running.Issue.ID, "error", err)
+		}
+		return false
+	}
+	heartbeat := store.WorkAttemptHeartbeat{
+		AttemptID:              record.Running.WorkAttemptID,
+		HeartbeatAt:            record.DeferredAt,
+		Phase:                  deferredCompletionPhase,
+		StatusMessage:          deferredCompletionStatus,
+		WaitReason:             connector.TrackerUnavailableCondition,
+		GitHubRateSnapshotJSON: o.githubRateSnapshotJSON(state),
+		CIState:                workAttemptCIState(record.Running.Issue),
+		CapacitySnapshotJSON:   o.capacitySnapshotJSON(state, record.Running.Issue),
+		WorkerMetadataJSON:     metadata,
+		MetricsJSON:            runningWorkAttemptMetricsJSON(record.Running),
+		NextAction:             deferredCompletionNextAction,
+		ErrorClass:             connector.TrackerUnavailableCondition,
+		ErrorMessage:           record.Availability.Message,
+		DetentSessionID:        record.Running.DetentSessionID,
+		ProviderSessionID:      record.Running.SessionID,
+		RuntimeIdentity:        record.Running.RuntimeIdentity,
+	}
+	if err := o.workAttempts.RecordWorkAttemptHeartbeat(ctx, heartbeat); err != nil {
+		if o.logger != nil {
+			o.logger.Error("deferred completion persistence failed", "attempt_id", record.Running.WorkAttemptID, "issue_id", record.Running.Issue.ID, "error", err)
+		}
+		return false
+	}
+	o.applyWorkAttemptHeartbeatSnapshot(state, record.Running.WorkAttemptID, heartbeat, nil)
+	return true
+}
+
+func deferredCompletionMetadataJSON(record deferredCompletion) (string, error) {
+	metadata := map[string]any{
+		"run_mode":                    strings.TrimSpace(record.Running.Mode),
+		"issue_title":                 strings.TrimSpace(record.Running.Issue.Title),
+		"work_product_pushed":         record.Running.WorkProductPushed,
+		deferredCompletionMetadataKey: record,
+	}
+	payload, err := json.Marshal(metadata)
+	if err != nil {
+		return "", fmt.Errorf("marshal deferred completion: %w", err)
+	}
+	return string(payload), nil
+}
+
+func decodeDeferredCompletion(attempt store.WorkAttempt) (deferredCompletion, error) {
+	var metadata struct {
+		DeferredCompletion json.RawMessage `json:"deferred_completion"`
+	}
+	if err := json.Unmarshal([]byte(attempt.WorkerMetadataJSON), &metadata); err != nil {
+		return deferredCompletion{}, fmt.Errorf("decode work attempt metadata: %w", err)
+	}
+	if len(metadata.DeferredCompletion) == 0 {
+		return deferredCompletion{}, errors.New("deferred completion metadata is missing")
+	}
+	var record deferredCompletion
+	if err := json.Unmarshal(metadata.DeferredCompletion, &record); err != nil {
+		return deferredCompletion{}, fmt.Errorf("decode deferred completion: %w", err)
+	}
+	if record.Schema != deferredCompletionSchema {
+		return deferredCompletion{}, fmt.Errorf("deferred completion schema = %d, want %d", record.Schema, deferredCompletionSchema)
+	}
+	if strings.TrimSpace(record.Running.Issue.ID) == "" {
+		return deferredCompletion{}, errors.New("deferred completion issue_id is required")
+	}
+	if record.Running.WorkAttemptID != attempt.ID {
+		return deferredCompletion{}, fmt.Errorf("deferred completion attempt_id = %d, want %d", record.Running.WorkAttemptID, attempt.ID)
+	}
+	record.Running.CompletionOwnershipReleased = true
+	record.Persisted = true
+	return record, nil
+}
+
+func (o *Orchestrator) recoverDeferredCompletions(ctx context.Context, state *State, attempts []store.WorkAttempt, now time.Time) {
+	for _, attempt := range attempts {
+		if strings.TrimSpace(attempt.Phase) != deferredCompletionPhase {
+			continue
+		}
+		record, err := decodeDeferredCompletion(attempt)
+		if err != nil {
+			o.invalidateDeferredCompletion(ctx, state, attempt, now, err)
+			continue
+		}
+		issueID := record.Running.Issue.ID
+		state.deferredCompletions[issueID] = record
+		dueAt := now
+		if candidate := record.DeferredAt.Add(o.cfg.PollInterval); candidate.After(dueAt) {
+			dueAt = candidate
+		}
+		state.Retry[issueID] = Retry{
+			Issue:              cloneIssue(record.Running.Issue),
+			Attempt:            record.Running.Attempt,
+			DueAt:              dueAt,
+			Error:              deferredCompletionStatus,
+			WorkerHost:         record.Running.WorkerHost,
+			TrackerUnavailable: true,
+			CompletionDeferred: true,
+		}
+		state.Claimed[issueID] = recoveredDeferredCompletionClaim(o, record.Running.Issue, now)
+		o.upsertWorkAttemptSnapshot(state, telemetryWorkAttempt(attempt, now))
+		recordStateEvent(state, telemetry.ActivityEvent{
+			At:      now,
+			Event:   "completion_deferral_recovered",
+			Message: "recovered tracker-fenced completion for " + issueLabel(record.Running.Issue),
+		})
+	}
+}
+
+func recoveredDeferredCompletionClaim(o *Orchestrator, issue connector.Issue, now time.Time) Claimed {
+	if o != nil && o.cfg.Claiming.Enabled {
+		if claim, ok := o.verifiedClaim(issue, o.claimOwner()); ok {
+			return claim
+		}
+	}
+	return Claimed{Issue: cloneIssue(issue), ClaimedAt: now}
+}
+
+func (o *Orchestrator) invalidateDeferredCompletion(ctx context.Context, state *State, attempt store.WorkAttempt, now time.Time, cause error) {
+	completion := store.WorkAttemptCompletion{
+		AttemptID:          attempt.ID,
+		CompletedAt:        now,
+		Status:             store.WorkAttemptStatusTerminal,
+		TerminalState:      store.WorkAttemptTerminalAbandoned,
+		ErrorClass:         deferredCompletionInvalidClass,
+		ErrorMessage:       cause.Error(),
+		Phase:              "recovered",
+		StatusMessage:      "invalid deferred completion was abandoned",
+		WorkerMetadataJSON: attempt.WorkerMetadataJSON,
+		MetricsJSON:        attempt.MetricsJSON,
+		NextAction:         "inspect work attempt",
+	}
+	if err := o.workAttempts.CompleteWorkAttempt(ctx, completion); err != nil {
+		if o.logger != nil {
+			o.logger.Error("invalid deferred completion abandonment failed", "attempt_id", attempt.ID, "issue_id", attempt.IssueID, "error", err)
+		}
+		return
+	}
+	if o.logger != nil {
+		o.logger.Error("invalid deferred completion abandoned", "attempt_id", attempt.ID, "issue_id", attempt.IssueID, "error", cause)
+	}
+	o.applyWorkAttemptCompletionSnapshot(state, Running{Issue: recoveryIssueFromStoreAttempt(attempt), WorkAttemptID: attempt.ID, Attempt: attempt.AttemptNumber, StartedAt: attempt.StartedAt}, completion)
+}
+
+func recoveryIssueFromStoreAttempt(attempt store.WorkAttempt) connector.Issue {
+	issue := connector.NewIssue()
+	issue.ID = attempt.IssueID
+	issue.Identifier = attempt.Identifier
+	issue.URL = attempt.IssueURL
+	issue.State = attempt.Lane
+	return issue
+}
+
+func (o *Orchestrator) retryDeferredCompletions(ctx context.Context, state *State, now time.Time) bool {
+	for _, issueID := range sortedKeys(state.deferredCompletions) {
+		retry := state.Retry[issueID]
+		if !retry.DueAt.IsZero() && now.Before(retry.DueAt) {
+			continue
+		}
+		record := state.deferredCompletions[issueID]
+		if !record.Persisted {
+			record.DeferredAt = now
+			if !o.persistDeferredCompletion(ctx, state, record) {
+				retry.DueAt = now.Add(o.cfg.PollInterval)
+				state.Retry[issueID] = retry
+				return false
+			}
+			record.Persisted = true
+			state.deferredCompletions[issueID] = record
+		}
+		delete(state.deferredCompletions, issueID)
+		delete(state.Retry, issueID)
+		state.Running[issueID] = record.Running
+		if _, ok := state.Claimed[issueID]; !ok {
+			state.Claimed[issueID] = recoveredDeferredCompletionClaim(o, record.Running.Issue, now)
+		}
+		o.handleRunResult(ctx, state, record.completion())
+		if _, deferred := state.deferredCompletions[issueID]; deferred {
+			return false
+		}
+	}
+	return true
+}
+
+func cloneDeferredCompletions(source map[string]deferredCompletion) map[string]deferredCompletion {
+	cloned := make(map[string]deferredCompletion, len(source))
+	for issueID, record := range source {
+		record.Running.Issue = cloneIssue(record.Running.Issue)
+		record.Running.LastMessageTruncation = runtimeoutput.CloneTruncation(record.Running.LastMessageTruncation)
+		record.Running.RecentEvents = cloneActivityEvents(record.Running.RecentEvents)
+		record.Running.StopPriorityOptions = append([]telemetry.StopRunPriorityOption(nil), record.Running.StopPriorityOptions...)
+		record.Request.Issue = cloneIssue(record.Request.Issue)
+		record.Request.MergePrecheck = cloneMergePrecheck(record.Request.MergePrecheck)
+		record.Result.RateLimits = cloneRateLimits(record.Result.RateLimits)
+		cloned[issueID] = record
+	}
+	return cloned
+}

--- a/internal/orchestrator/completion_deferral_test.go
+++ b/internal/orchestrator/completion_deferral_test.go
@@ -1,0 +1,370 @@
+package orchestrator
+
+import (
+	"context"
+	"errors"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/digitaldrywood/detent/internal/connector"
+	runpkg "github.com/digitaldrywood/detent/internal/runner"
+	"github.com/digitaldrywood/detent/internal/scheduler"
+	"github.com/digitaldrywood/detent/internal/store"
+	"github.com/digitaldrywood/detent/internal/telemetry"
+)
+
+func TestCompletionFenceDeferralOutcomes(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name             string
+		fenceErr         error
+		wantDeferred     bool
+		wantTerminal     store.WorkAttemptTerminalState
+		wantFetches      int
+		wantPreservedOut string
+	}{
+		{
+			name:             "503 defers and preserves result",
+			fenceErr:         completionDeferralAvailabilityError(),
+			wantDeferred:     true,
+			wantFetches:      1,
+			wantPreservedOut: "validated completion",
+		},
+		{
+			name:         "403 follows existing fence rejection",
+			fenceErr:     errors.New("github graphql returned status 403"),
+			wantTerminal: store.WorkAttemptTerminalLaneRevoked,
+			wantFetches:  1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			now := time.Date(2026, 8, 17, 19, 0, 0, 0, time.UTC)
+			issue := completionDeferralIssue("issue-fence", "In Progress")
+			tracker := &completionDeferralConnector{
+				backendCapacityTestConnector: backendCapacityTestConnector{},
+				issue:                        issue,
+				firstErr:                     tt.fenceErr,
+			}
+			runtimeStore := openCompletionDeferralStore(t, filepath.Join(t.TempDir(), "detent.db"))
+			cfg := completionDeferralConfig()
+			orch := Orchestrator{cfg: cfg, connector: tracker, workAttempts: runtimeStore, now: func() time.Time { return now }}
+			state := newState(cfg)
+			attemptID := startCompletionDeferralAttempt(t, runtimeStore, issue, now)
+			state.Running[issue.ID] = completionDeferralRunning(issue, attemptID, now)
+			state.Claimed[issue.ID] = Claimed{Issue: cloneIssue(issue), ClaimedAt: now.Add(-time.Minute)}
+
+			orch.handleRunResult(t.Context(), &state, completionDeferralEvent(issue, attemptID, now))
+
+			_, deferred := state.deferredCompletions[issue.ID]
+			if deferred != tt.wantDeferred {
+				t.Fatalf("deferred completion present = %v, want %v", deferred, tt.wantDeferred)
+			}
+			if got := tracker.fetchCount(); got != tt.wantFetches {
+				t.Fatalf("completion fence fetches = %d, want %d", got, tt.wantFetches)
+			}
+			receipt, err := runtimeStore.WorkAttempt(t.Context(), attemptID)
+			if err != nil {
+				t.Fatalf("WorkAttempt() error = %v", err)
+			}
+			if tt.wantDeferred {
+				if receipt.Status != store.WorkAttemptStatusActive || receipt.Phase != deferredCompletionPhase || receipt.WaitReason != connector.TrackerUnavailableCondition || receipt.NextAction != deferredCompletionNextAction {
+					t.Fatalf("deferred work attempt = %#v, want active tracker wait", receipt)
+				}
+				record := state.deferredCompletions[issue.ID]
+				if record.Result.Output != tt.wantPreservedOut || record.Result.Tokens.TotalTokens != 37 {
+					t.Fatalf("preserved result = %#v, want output %q and 37 tokens", record.Result, tt.wantPreservedOut)
+				}
+				snapshot := state.Snapshot(now)
+				if len(snapshot.Queue) != 1 || snapshot.Queue[0].QueueState != telemetry.QueueStateWaitingOnTracker {
+					t.Fatalf("snapshot queue = %#v, want waiting_on_tracker", snapshot.Queue)
+				}
+				if outcome := orch.dispatchIssueWithOutcome(t.Context(), &state, issue, 1, now, ""); outcome.dispatched || outcome.reason != dispatchSkipCompletionDeferred {
+					t.Fatalf("dispatch while completion deferred = %#v, want suppressed", outcome)
+				}
+				return
+			}
+			if receipt.TerminalState != tt.wantTerminal {
+				t.Fatalf("terminal state = %q, want %q", receipt.TerminalState, tt.wantTerminal)
+			}
+			if retry, ok := state.Retry[issue.ID]; ok && retry.CompletionDeferred {
+				t.Fatalf("Retry[%q] = %#v, want no completion deferral", issue.ID, retry)
+			}
+		})
+	}
+}
+
+func TestDeferredCompletionRestartAndRecovery(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name               string
+		recoveredState     string
+		retryCount         int
+		wantDeferred       bool
+		wantTerminal       store.WorkAttemptTerminalState
+		wantAcceptedTokens int64
+	}{
+		{
+			name:           "deferral survives restart",
+			recoveredState: "In Progress",
+			wantDeferred:   true,
+		},
+		{
+			name:               "retry after recovery accepts intact lane",
+			recoveredState:     "In Progress",
+			retryCount:         1,
+			wantTerminal:       store.WorkAttemptTerminalSuccess,
+			wantAcceptedTokens: 37,
+		},
+		{
+			name:               "retry after recovery honors lane revocation",
+			recoveredState:     "Todo",
+			retryCount:         1,
+			wantTerminal:       store.WorkAttemptTerminalLaneRevoked,
+			wantAcceptedTokens: 37,
+		},
+		{
+			name:               "completion cannot be accepted twice",
+			recoveredState:     "In Progress",
+			retryCount:         2,
+			wantTerminal:       store.WorkAttemptTerminalSuccess,
+			wantAcceptedTokens: 37,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			now := time.Date(2026, 8, 17, 19, 30, 0, 0, time.UTC)
+			dbPath := filepath.Join(t.TempDir(), "detent.db")
+			issue := completionDeferralIssue("issue-restart", "In Progress")
+			tracker := &completionDeferralConnector{
+				backendCapacityTestConnector: backendCapacityTestConnector{},
+				issue:                        issue,
+				firstErr:                     completionDeferralAvailabilityError(),
+			}
+			cfg := completionDeferralConfig()
+			initialStore := openCompletionDeferralStoreWithoutCleanup(t, dbPath)
+			attemptID := startCompletionDeferralAttempt(t, initialStore, issue, now)
+			initialOrch := Orchestrator{cfg: cfg, connector: tracker, workAttempts: initialStore, now: func() time.Time { return now }}
+			initialState := newState(cfg)
+			initialState.Running[issue.ID] = completionDeferralRunning(issue, attemptID, now)
+			initialState.Claimed[issue.ID] = Claimed{Issue: cloneIssue(issue), ClaimedAt: now.Add(-time.Minute)}
+			initialOrch.handleRunResult(t.Context(), &initialState, completionDeferralEvent(issue, attemptID, now))
+			if err := initialStore.Close(); err != nil {
+				t.Fatalf("Close(initial store) error = %v", err)
+			}
+
+			restartedStore := openCompletionDeferralStore(t, dbPath)
+			recoveredIssue := cloneIssue(issue)
+			recoveredIssue.State = tt.recoveredState
+			tracker.setIssue(recoveredIssue)
+			restartAt := now.Add(2 * time.Minute)
+			restartedOrch := Orchestrator{cfg: cfg, connector: tracker, workAttempts: restartedStore, now: func() time.Time { return restartAt }}
+			restartedState := newState(cfg)
+			restartedOrch.recoverDurableWorkAttempts(t.Context(), &restartedState, restartAt)
+
+			if _, ok := restartedState.deferredCompletions[issue.ID]; !ok {
+				t.Fatalf("deferred completion missing after restart: %#v", restartedState.deferredCompletions)
+			}
+			if retry, ok := restartedState.Retry[issue.ID]; !ok || !retry.CompletionDeferred {
+				t.Fatalf("Retry[%q] = %#v, want recovered completion deferral", issue.ID, retry)
+			}
+			if _, ok := restartedState.Claimed[issue.ID]; !ok {
+				t.Fatalf("Claimed[%q] missing after restart", issue.ID)
+			}
+			if outcome := restartedOrch.dispatchIssueWithOutcome(t.Context(), &restartedState, recoveredIssue, 1, restartAt, ""); outcome.dispatched || outcome.reason != dispatchSkipCompletionDeferred {
+				t.Fatalf("dispatch after restart = %#v, want suppressed", outcome)
+			}
+			if tt.retryCount > 1 {
+				fetchesBeforeDuplicate := tracker.fetchCount()
+				restartedOrch.handleRunResult(t.Context(), &restartedState, completionDeferralEvent(issue, attemptID, restartAt))
+				if tracker.fetchCount() != fetchesBeforeDuplicate {
+					t.Fatalf("duplicate delivery retried completion fence")
+				}
+				receipt, err := restartedStore.WorkAttempt(t.Context(), attemptID)
+				if err != nil {
+					t.Fatalf("WorkAttempt() after duplicate delivery error = %v", err)
+				}
+				if receipt.Status != store.WorkAttemptStatusActive || receipt.Phase != deferredCompletionPhase {
+					t.Fatalf("duplicate delivery changed deferred receipt = %#v", receipt)
+				}
+			}
+
+			fetchesAfterFirstRetry := 0
+			for retryIndex := range tt.retryCount {
+				if ok := restartedOrch.retryDeferredCompletions(t.Context(), &restartedState, restartAt); !ok {
+					t.Fatal("retryDeferredCompletions() = false, want completed fence decision")
+				}
+				if retryIndex == 0 {
+					fetchesAfterFirstRetry = tracker.fetchCount()
+				}
+			}
+			if tt.retryCount > 1 && tracker.fetchCount() != fetchesAfterFirstRetry {
+				t.Fatalf("completion fence fetches after duplicate retry = %d, want unchanged %d", tracker.fetchCount(), fetchesAfterFirstRetry)
+			}
+
+			receipt, err := restartedStore.WorkAttempt(t.Context(), attemptID)
+			if err != nil {
+				t.Fatalf("WorkAttempt() error = %v", err)
+			}
+			if tt.wantDeferred {
+				if receipt.Status != store.WorkAttemptStatusActive || receipt.Phase != deferredCompletionPhase {
+					t.Fatalf("restarted receipt = %#v, want active completion deferral", receipt)
+				}
+				return
+			}
+			if receipt.TerminalState != tt.wantTerminal {
+				t.Fatalf("terminal state = %q, want %q", receipt.TerminalState, tt.wantTerminal)
+			}
+			if _, ok := restartedState.deferredCompletions[issue.ID]; ok {
+				t.Fatalf("deferred completion remains after fence decision")
+			}
+			if restartedState.TokenTotals.TotalTokens != tt.wantAcceptedTokens {
+				t.Fatalf("accepted tokens = %d, want %d", restartedState.TokenTotals.TotalTokens, tt.wantAcceptedTokens)
+			}
+		})
+	}
+}
+
+type completionDeferralConnector struct {
+	backendCapacityTestConnector
+	mu       sync.Mutex
+	issue    connector.Issue
+	firstErr error
+	fetches  int
+}
+
+func (c *completionDeferralConnector) FetchIssueStatesByIDs(context.Context, []string) ([]connector.Issue, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.fetches++
+	if c.fetches == 1 && c.firstErr != nil {
+		return nil, c.firstErr
+	}
+	return []connector.Issue{cloneIssue(c.issue)}, nil
+}
+
+func (c *completionDeferralConnector) fetchCount() int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.fetches
+}
+
+func (c *completionDeferralConnector) setIssue(issue connector.Issue) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.issue = cloneIssue(issue)
+}
+
+func completionDeferralAvailabilityError() error {
+	return connector.NewTrackerAvailabilityError(connector.TrackerAvailabilityScope{
+		Connector:          "github",
+		Endpoint:           "https://api.github.test/graphql",
+		Operation:          "issue_lookup",
+		CredentialIdentity: "github-rest:test",
+	}, connector.TrackerAvailabilityClassServer, errors.New("upstream returned status 503"))
+}
+
+func completionDeferralConfig() Config {
+	return normalizeConfig(Config{
+		Project:                scheduler.ProjectCandidate{ID: "detent"},
+		PollInterval:           time.Minute,
+		ContinuationRetryDelay: time.Minute,
+		ActiveStates:           []string{"In Progress"},
+		TerminalStates:         []string{"Done"},
+		MaxConcurrentAgents:    1,
+		FailureRetryBaseDelay:  time.Minute,
+		MaxRetryBackoff:        time.Minute,
+		OverloadRetryDelay:     time.Minute,
+	})
+}
+
+func completionDeferralIssue(id string, state string) connector.Issue {
+	issue := connector.NewIssue()
+	issue.ID = id
+	issue.Identifier = "digitaldrywood/detent#1869"
+	issue.Title = "Defer completion fence"
+	issue.URL = "https://github.com/digitaldrywood/detent/issues/1869"
+	issue.State = state
+	return issue
+}
+
+func completionDeferralRunning(issue connector.Issue, attemptID int64, now time.Time) Running {
+	return Running{
+		Issue:         cloneIssue(issue),
+		Attempt:       2,
+		WorkAttemptID: attemptID,
+		Generation:    7,
+		Mode:          runpkg.RunModeImplement,
+		StartedAt:     now.Add(-time.Minute),
+		WorkerHost:    "worker-a",
+	}
+}
+
+func completionDeferralEvent(issue connector.Issue, attemptID int64, now time.Time) runpkg.Completion {
+	return runpkg.Completion{
+		IssueID: issue.ID,
+		Request: runpkg.RunRequest{
+			ProjectID:     "detent",
+			Issue:         cloneIssue(issue),
+			Attempt:       2,
+			WorkAttemptID: attemptID,
+			Generation:    7,
+			Mode:          runpkg.RunModeImplement,
+			StartedAt:     now.Add(-time.Minute),
+			WorkerHost:    "worker-a",
+		},
+		Result: runpkg.RunResult{
+			FinalState: runpkg.FinalStateCompleted,
+			Output:     "validated completion",
+			Tokens:     runpkg.TokenTotals{InputTokens: 25, OutputTokens: 12, TotalTokens: 37},
+			DiffStats:  runpkg.DiffStats{FilesChanged: 2, AddedLines: 8, RemovedLines: 3, Status: "clean"},
+		},
+		CompletedAt: now,
+	}
+}
+
+func startCompletionDeferralAttempt(t *testing.T, runtimeStore store.Store, issue connector.Issue, now time.Time) int64 {
+	t.Helper()
+	attemptID, err := runtimeStore.StartWorkAttempt(t.Context(), store.WorkAttemptStart{
+		ProjectID:      "detent",
+		IssueID:        issue.ID,
+		Identifier:     issue.Identifier,
+		IssueURL:       issue.URL,
+		WorkerType:     "implement",
+		WorkerHost:     "worker-a",
+		Lane:           issue.State,
+		AttemptNumber:  2,
+		StartedAt:      now.Add(-time.Minute),
+		LeaseExpiresAt: now.Add(time.Minute),
+	})
+	if err != nil {
+		t.Fatalf("StartWorkAttempt() error = %v", err)
+	}
+	return attemptID
+}
+
+func openCompletionDeferralStore(t *testing.T, path string) store.Store {
+	t.Helper()
+	runtimeStore := openCompletionDeferralStoreWithoutCleanup(t, path)
+	t.Cleanup(func() {
+		if err := runtimeStore.Close(); err != nil {
+			t.Fatalf("Close() error = %v", err)
+		}
+	})
+	return runtimeStore
+}
+
+func openCompletionDeferralStoreWithoutCleanup(t *testing.T, path string) store.Store {
+	t.Helper()
+	runtimeStore, err := store.Open(t.Context(), store.Config{Backend: store.BackendSQLite, Path: path})
+	if err != nil {
+		t.Fatalf("store.Open() error = %v", err)
+	}
+	return runtimeStore
+}

--- a/internal/orchestrator/dispatch.go
+++ b/internal/orchestrator/dispatch.go
@@ -375,6 +375,9 @@ func (o *Orchestrator) dispatchIssueWithAdmission(
 	if state.Draining {
 		return dispatchIssueOutcome{reason: dispatchIssueFailureDraining}
 	}
+	if _, deferred := state.deferredCompletions[issue.ID]; deferred {
+		return dispatchIssueOutcome{reason: dispatchSkipCompletionDeferred}
+	}
 	if activeTrackerUnavailable(state) && (trackerDependentDispatch(issue) || trackerUnavailableRetry(state, issue.ID)) {
 		return dispatchIssueOutcome{reason: dispatchIssueFailureTrackerUnavailable}
 	}

--- a/internal/orchestrator/dispatch_planner.go
+++ b/internal/orchestrator/dispatch_planner.go
@@ -259,6 +259,9 @@ func (p dispatchPlanner) retryAction(
 	if activeTrackerUnavailable(state) && (trackerDependentDispatch(issue) || retry.TrackerUnavailable) {
 		return dispatchAction{}, false, dispatchSkipTrackerUnavailable
 	}
+	if retry.CompletionDeferred {
+		return dispatchAction{}, false, dispatchSkipCompletionDeferred
+	}
 	if activeCIUnavailable(state) && (ciDependentDispatch(issue) || retry.CIUnavailable) {
 		return dispatchAction{}, false, dispatchSkipCIUnavailable
 	}
@@ -577,6 +580,7 @@ const (
 	dispatchSkipMergeFairnessReserved     = "merge_fairness_head_reserved"
 	dispatchSkipGitHubRESTCapacity        = "github_rest_capacity_paused"
 	dispatchSkipTrackerUnavailable        = "tracker_unavailable"
+	dispatchSkipCompletionDeferred        = "completion_deferred"
 	dispatchSkipCIUnavailable             = "ci_unavailable"
 	dispatchSkipProjectFailureBreaker     = projectFailureBreakerDispatchPaused
 	dispatchSkipRateWindowBackpressure    = "provider_rate_window_backpressure"
@@ -676,6 +680,9 @@ func (p dispatchPlanner) dispatchableIssueDecisionForModelRequirement(
 	}
 	if _, ok := state.Running[issue.ID]; ok {
 		return dispatchableDecision{reason: dispatchSkipAlreadyRunning}
+	}
+	if _, ok := state.deferredCompletions[issue.ID]; ok {
+		return dispatchableDecision{reason: dispatchSkipCompletionDeferred}
 	}
 	if _, ok := state.Retry[issue.ID]; ok {
 		return dispatchableDecision{reason: dispatchSkipRetryPending}

--- a/internal/orchestrator/run_completion.go
+++ b/internal/orchestrator/run_completion.go
@@ -126,7 +126,8 @@ func (o *Orchestrator) handleRunResult(ctx context.Context, state *State, event 
 		if err != nil {
 			availabilityErr, unavailable := connector.AsTrackerAvailability(err)
 			if unavailable && availabilityErr != nil {
-				event.Err = err
+				o.deferTrackerUnavailableCompletion(ctx, state, event, running, availabilityErr)
+				return
 			} else {
 				o.rejectWorkerCompletion(ctx, state, event, running, laneRevocationCompletionFenceUnavailable, err)
 				o.beginLaneRevocation(ctx, state, running, running.Issue, event.CompletedAt, laneRevocationCompletionFenceUnavailable)
@@ -155,25 +156,28 @@ func (o *Orchestrator) handleRunResult(ctx context.Context, state *State, event 
 	if o.handleOperatorStopCompletion(ctx, state, event, running) {
 		return
 	}
-	o.releaseGlobalDispatchSlot(running.globalSlot)
-	o.logWorkerLifecycle(running.Issue, "worker_capacity_released",
-		telemetry.WorkAttemptIDKey, running.WorkAttemptID,
-		telemetry.DetentSessionIDKey, running.DetentSessionID,
-		telemetry.ProviderSessionIDKey, running.SessionID,
-		"attempt", running.Attempt,
-		"worker_host", strings.TrimSpace(running.WorkerHost),
-		"reason", "run_completed",
-	)
+	if !running.CompletionOwnershipReleased {
+		o.releaseGlobalDispatchSlot(running.globalSlot)
+		o.logWorkerLifecycle(running.Issue, "worker_capacity_released",
+			telemetry.WorkAttemptIDKey, running.WorkAttemptID,
+			telemetry.DetentSessionIDKey, running.DetentSessionID,
+			telemetry.ProviderSessionIDKey, running.SessionID,
+			"attempt", running.Attempt,
+			"worker_host", strings.TrimSpace(running.WorkerHost),
+			"reason", "run_completed",
+		)
+		if running.cancel != nil {
+			running.cancel()
+		}
+	}
 	running.globalSlot = scheduler.Slot{}
+	running.CompletionOwnershipReleased = true
 	if !event.Result.RuntimeIdentity.IsZero() {
 		running.RuntimeIdentity = running.RuntimeIdentity.Merge(event.Result.RuntimeIdentity)
 	}
 	running.WorkProductPushed = running.WorkProductPushed || event.Result.PullRequestHeadPushed || event.Result.PullRequestUpdated
 	if event.Result.RateLimits != nil {
 		state.RateLimits = mergeRateLimits(state.RateLimits, event.Result.RateLimits)
-	}
-	if running.cancel != nil {
-		running.cancel()
 	}
 	delete(state.Running, event.IssueID)
 	if o.handleModelPermitDeferred(ctx, state, event, running) {

--- a/internal/orchestrator/snapshot.go
+++ b/internal/orchestrator/snapshot.go
@@ -695,6 +695,9 @@ func queueSnapshots(retry map[string]Retry, claims map[string]Claimed, mergeTimi
 			queued.WorkspaceCreateCount = entry.Wait.WorkspaceCreateCount
 			queued.WorkspaceDestroyCount = entry.Wait.WorkspaceDestroyCount
 		}
+		if entry.CompletionDeferred {
+			queued.QueueState = telemetry.QueueStateWaitingOnTracker
+		}
 		if !entry.DueAt.IsZero() {
 			dueAt := entry.DueAt
 			queued.DueAt = &dueAt

--- a/internal/orchestrator/state.go
+++ b/internal/orchestrator/state.go
@@ -88,6 +88,7 @@ type State struct {
 	StalenessWarnings        map[string]StalenessWarning
 	TrackerUnavailable       *TrackerCondition
 	trackerEvidence          map[string]trackerAvailabilityEvidence
+	deferredCompletions      map[string]deferredCompletion
 	CIUnavailable            *CICondition
 	BackendOutages           map[string]BackendOutage
 	BackendRecoveries        map[string]BackendRecovery
@@ -114,43 +115,44 @@ type StalenessWarning struct {
 }
 
 type Running struct {
-	Issue                 connector.Issue
-	Attempt               int
-	WorkAttemptID         int64
-	Generation            uint64
-	Mode                  string
-	DispatchSourceState   string
-	DispatchTargetState   string
-	DispatchWorkpadHash   string
-	DispatchWorkpadRead   bool
-	DispatchProgress      implementProgressArtifactSnapshot
-	StartedAt             time.Time
-	WorkerHost            string
-	ProcessIdentity       string
-	WorkerProcess         procgroup.Identity
-	WorkspacePath         string
-	SessionID             string
-	DetentSessionID       int64
-	RuntimeIdentity       agentidentity.Identity
-	TurnCount             int
-	LastEventAt           time.Time
-	LastEvent             string
-	LastMessage           string
-	LastMessageTruncation *runtimeoutput.Truncation
-	RecentEvents          []telemetry.ActivityEvent
-	DiffStats             DiffStats
-	WorkProductPushed     bool
-	Tokens                TokenTotals
-	CapacityScope         backendcapacity.Scope
-	CapacityProbe         bool
-	ModelPermitExempt     bool
-	CIStopRequested       bool
-	StopDestination       string
-	StopPriorityOptions   []telemetry.StopRunPriorityOption
-	globalSlot            scheduler.Slot
-	cancel                context.CancelFunc
-	stop                  context.CancelCauseFunc
-	done                  <-chan struct{}
+	Issue                       connector.Issue
+	Attempt                     int
+	WorkAttemptID               int64
+	Generation                  uint64
+	Mode                        string
+	DispatchSourceState         string
+	DispatchTargetState         string
+	DispatchWorkpadHash         string
+	DispatchWorkpadRead         bool
+	DispatchProgress            implementProgressArtifactSnapshot
+	StartedAt                   time.Time
+	WorkerHost                  string
+	ProcessIdentity             string
+	WorkerProcess               procgroup.Identity
+	WorkspacePath               string
+	SessionID                   string
+	DetentSessionID             int64
+	RuntimeIdentity             agentidentity.Identity
+	TurnCount                   int
+	LastEventAt                 time.Time
+	LastEvent                   string
+	LastMessage                 string
+	LastMessageTruncation       *runtimeoutput.Truncation
+	RecentEvents                []telemetry.ActivityEvent
+	DiffStats                   DiffStats
+	WorkProductPushed           bool
+	Tokens                      TokenTotals
+	CapacityScope               backendcapacity.Scope
+	CapacityProbe               bool
+	ModelPermitExempt           bool
+	CIStopRequested             bool
+	CompletionOwnershipReleased bool
+	StopDestination             string
+	StopPriorityOptions         []telemetry.StopRunPriorityOption
+	globalSlot                  scheduler.Slot
+	cancel                      context.CancelFunc
+	stop                        context.CancelCauseFunc
+	done                        <-chan struct{}
 }
 
 type Claimed struct {
@@ -235,6 +237,7 @@ type Retry struct {
 	MergePrecheck      *runpkg.MergePrecheck
 	CIUnavailable      bool
 	TrackerUnavailable bool
+	CompletionDeferred bool
 	Wait               RetryWait
 }
 
@@ -348,6 +351,7 @@ func newState(cfg Config) State {
 		DispatchRecoveries:       map[string]DispatchRecovery{},
 		StalenessWarnings:        map[string]StalenessWarning{},
 		trackerEvidence:          map[string]trackerAvailabilityEvidence{},
+		deferredCompletions:      map[string]deferredCompletion{},
 		BackendOutages:           map[string]BackendOutage{},
 		BackendRecoveries:        map[string]BackendRecovery{},
 		DiffStats:                map[string]DiffStats{},
@@ -424,6 +428,7 @@ func (s State) clone() State {
 		StalenessWarnings:        maps.Clone(s.StalenessWarnings),
 		TrackerUnavailable:       cloneTrackerCondition(s.TrackerUnavailable),
 		trackerEvidence:          maps.Clone(s.trackerEvidence),
+		deferredCompletions:      cloneDeferredCompletions(s.deferredCompletions),
 		CIUnavailable:            cloneCICondition(s.CIUnavailable),
 		BackendOutages:           maps.Clone(s.BackendOutages),
 		BackendRecoveries:        maps.Clone(s.BackendRecoveries),

--- a/internal/orchestrator/tick.go
+++ b/internal/orchestrator/tick.go
@@ -87,6 +87,9 @@ func (o *Orchestrator) tickWithManual(ctx context.Context, state *State, now tim
 	if o.trackerAvailabilityPaused(ctx, state, now) {
 		return
 	}
+	if !o.retryDeferredCompletions(ctx, state, now) {
+		return
+	}
 
 	reserve := o.githubBudgetReserveDecision(state, now)
 	if reserve.degraded {

--- a/internal/orchestrator/work_attempts.go
+++ b/internal/orchestrator/work_attempts.go
@@ -70,6 +70,14 @@ func (o *Orchestrator) recoverDurableWorkAttempts(ctx context.Context, state *St
 	for _, attempt := range reclaimed {
 		o.recordRecoveredWorkAttempt(state, attempt, now)
 	}
+	active, err := o.workAttempts.ListActiveWorkAttempts(ctx, store.WorkAttemptQuery{ProjectID: projectID})
+	if err != nil {
+		if o.logger != nil {
+			o.logger.Warn("deferred completion recovery lookup failed", "project_id", projectID, "error", err)
+		}
+	} else {
+		o.recoverDeferredCompletions(ctx, state, active, now)
+	}
 	o.recoverPendingWorkAttemptCapacityReleases(ctx, state, projectID, now)
 	recent, err := o.workAttempts.ListRecentTerminalWorkAttempts(ctx, store.WorkAttemptHistoryQuery{
 		ProjectID: projectID,

--- a/internal/store/sqlc/store.sql.go
+++ b/internal/store/sqlc/store.sql.go
@@ -3683,6 +3683,7 @@ SET status = ?,
     status_message = ?
 WHERE completed_at IS NULL
   AND project_id = ?
+  AND lower(trim(COALESCE(phase, ''))) != 'completion_deferred'
 RETURNING id, project_id, issue_id, identifier, issue_url, pr_number, repo, worker_type, worker_host, lane, attempt_number, status, started_at, lease_expires_at, heartbeat_at, completed_at, terminal_state, error_class, error_message, phase, status_message, current_step, total_steps, progress_percent, current_command, wait_reason, github_rate_snapshot_json, ci_state, capacity_snapshot_json, worker_metadata_json, metrics_json, next_action, detent_session_id, provider_session_id, runtime_identity_json
 `
 
@@ -3820,6 +3821,7 @@ WHERE completed_at IS NULL
   AND (?9 = '' OR project_id = ?9)
   AND lease_expires_at IS NOT NULL
   AND lease_expires_at <= ?10
+  AND lower(trim(COALESCE(phase, ''))) != 'completion_deferred'
 RETURNING id, project_id, issue_id, identifier, issue_url, pr_number, repo, worker_type, worker_host, lane, attempt_number, status, started_at, lease_expires_at, heartbeat_at, completed_at, terminal_state, error_class, error_message, phase, status_message, current_step, total_steps, progress_percent, current_command, wait_reason, github_rate_snapshot_json, ci_state, capacity_snapshot_json, worker_metadata_json, metrics_json, next_action, detent_session_id, provider_session_id, runtime_identity_json
 `
 

--- a/internal/telemetry/snapshot.go
+++ b/internal/telemetry/snapshot.go
@@ -978,8 +978,9 @@ type Queued struct {
 }
 
 const (
-	QueueStateRetrying    = "retrying"
-	QueueStateWaitingOnCI = "waiting_on_ci"
+	QueueStateRetrying         = "retrying"
+	QueueStateWaitingOnCI      = "waiting_on_ci"
+	QueueStateWaitingOnTracker = "waiting_on_tracker"
 )
 
 type BlockedSource string


### PR DESCRIPTION
## Summary

- preserve completed worker results when the tracker lane fence returns a typed availability failure
- recover deferred completions durably after restart and replay the existing completion or lane-revocation path after tracker recovery
- prevent redispatch and expose the deferred item as `waiting_on_tracker`

Fixes #1869

## UI Surface Contract

- [x] N/A, or the linked issue explicitly authorizes any high-impact UI surface, layout, density, first-viewport, or responsive visibility tradeoff.
- [x] Persistent top-of-screen messaging is explicitly authorized by the issue, or this PR does not add it.
- [x] Visual changes to primary operator screens include screenshot or browser verification below.

## Test Plan

- [x] `make check`
- [x] `go test ./internal/orchestrator -run 'TestCompletionFenceDeferralOutcomes|TestDeferredCompletionRestartAndRecovery' -count=1`
- [x] restart recovery, intact-lane acceptance, genuine lane revocation, duplicate completion exclusion, dispatch exclusion, and non-availability 403 behavior are table-tested