### PR TITLE
feat(health): corroborate tracker outages

### DIFF
--- a/config.reference.yaml
+++ b/config.reference.yaml
@@ -58,6 +58,8 @@
 #   github_webhook_secret: null
 #   # tracker.github_status_source | type: string | default: "project_v2" | required: No | validation: must be omitted when tracker.kind is github_local; Detent stores workflow status in tracker.local_sqlite
 #   github_status_source: "project_v2"
+#   # tracker.status_page_url | type: string | default: "https://linearstatus.com" for linear; "https://www.githubstatus.com" for github or github_local; unused otherwise | required: No | validation: must be an absolute http or https base URL without credentials, path, query, or fragment
+#   status_page_url: null
 #   # tracker.project_slug | type: string | default: none | required: Conditional | validation: is required for github project_v2; is required for linear
 #   project_slug: null
 #   # tracker.repository | type: string | default: none | required: Conditional | validation: is required for github_local; is required for intake sources; must be owner/name when release.enabled is true

--- a/docs/config.md
+++ b/docs/config.md
@@ -178,6 +178,16 @@ the first advances work whose dependencies cleared, the second revives
 agent-recoverable PR maintenance, and the third promotes blockers when they
 enter configured states.
 
+GitHub and Linear trackers also receive a default Statuspage base URL through
+`tracker.status_page_url`; set that key to override the provider endpoint.
+Detent follows redirects and polls the unauthenticated Statuspage summary and
+unresolved-incident feeds at a low-frequency baseline, increasing freshness
+only while a Detent-observed `tracker_unavailable` condition is active. These
+feeds decorate health output only: malformed, slow, or unreachable status
+pages never create a condition or influence dispatch and recovery. Statuspage
+incident webhooks are a possible future optimization, not part of the current
+polling integration.
+
 ### Workspace, deliverable, and worker placement
 
 `workspace` controls isolation, source and output roots, branch creation, cache
@@ -998,6 +1008,7 @@ only to resettable budget pacing and never clears a per-issue hard hold.
 | `tracker.state_map` | `string or mapping` | `{}` | No | state names must not be blank |
 | `tracker.status_field` | `string` | `"Status"` | No | None |
 | `tracker.status_label_prefix` | `string` | `"detent:"` | No | None |
+| `tracker.status_page_url` | `string` | `"https://linearstatus.com" for linear; "https://www.githubstatus.com" for github or github_local; unused otherwise` | No | must be an absolute http or https base URL without credentials, path, query, or fragment |
 | `tracker.terminal_states` | `list<string>` | `["Closed","Cancelled","Canceled","Duplicate","Done"]` | No | state names must be unique<br>state names must not be blank<br>tracker.active_states, tracker.observed_states, or tracker.terminal_states must include Blocked when agent.auto_promote.no_progress_limit is greater than 0 |
 | `tracker.write_probe_issue` | `string` | `none` | No | None |
 | `worker` | `object` | `see child fields` | No | None |

--- a/internal/cli/boot.go
+++ b/internal/cli/boot.go
@@ -37,6 +37,7 @@ import (
 	"github.com/digitaldrywood/detent/internal/procgroup"
 	"github.com/digitaldrywood/detent/internal/project"
 	"github.com/digitaldrywood/detent/internal/scheduler"
+	"github.com/digitaldrywood/detent/internal/statuspage"
 	"github.com/digitaldrywood/detent/internal/store"
 	"github.com/digitaldrywood/detent/internal/telemetry"
 	"github.com/digitaldrywood/detent/internal/tmuxstatus"
@@ -165,6 +166,7 @@ type startRunningDependencies struct {
 	buildDriftInterval    time.Duration
 	readInstalledBuild    installedBuildReader
 	managerDependencies   project.ManagerDependencies
+	providerStatusManager *statuspage.Manager
 }
 
 func startRunning(ctx context.Context, cfg BootConfig) error {
@@ -328,6 +330,10 @@ func startRunningWithDependencies(ctx context.Context, cfg BootConfig, deps star
 
 	snapshotHub := hub.New[telemetry.Snapshot]()
 	snapshotSeq := &atomic.Uint64{}
+	providerStatus := deps.providerStatusManager
+	if providerStatus == nil {
+		providerStatus = statuspage.NewManager(statuspage.ManagerConfig{}, statuspage.ManagerDependencies{Logger: logger})
+	}
 	var windowStatus *tmuxstatus.Status
 	tmuxPane := os.Getenv("TMUX_PANE")
 	if tmuxstatus.Enabled(os.Getenv("TMUX"), tmuxPane, cfg.Global.Ops.TmuxWindowStatus) {
@@ -396,7 +402,18 @@ func startRunningWithDependencies(ctx context.Context, cfg BootConfig, deps star
 		})
 	}
 	resourceWorkers.Go(func() {
-		publishSnapshots(runCtx, manager.Registry(), globalDispatchGate, snapshotHub, snapshotSeq, cfg.Shutdown, runtimeStore, displayURL, defaultSnapshotInterval, time.Now, updateScheduler)
+		providerStatus.Run(runCtx, func() []statuspage.Source {
+			return providerStatusSources(manager.Registry())
+		}, func() []telemetry.TrackerCondition {
+			snapshot, ok := snapshotHub.Latest()
+			if !ok {
+				return nil
+			}
+			return append([]telemetry.TrackerCondition(nil), snapshot.TrackerUnavailable...)
+		}, time.Now)
+	})
+	resourceWorkers.Go(func() {
+		publishSnapshots(runCtx, manager.Registry(), globalDispatchGate, snapshotHub, snapshotSeq, cfg.Shutdown, runtimeStore, displayURL, providerStatus, defaultSnapshotInterval, time.Now, updateScheduler)
 	})
 	if healthNotifications.Enabled() {
 		resourceWorkers.Go(func() {

--- a/internal/cli/runner.go
+++ b/internal/cli/runner.go
@@ -25,6 +25,7 @@ import (
 	runnerpkg "github.com/digitaldrywood/detent/internal/runner"
 	"github.com/digitaldrywood/detent/internal/scheduler"
 	commandshell "github.com/digitaldrywood/detent/internal/shell"
+	"github.com/digitaldrywood/detent/internal/statuspage"
 	"github.com/digitaldrywood/detent/internal/store"
 	"github.com/digitaldrywood/detent/internal/telemetry"
 	detentupdate "github.com/digitaldrywood/detent/internal/update"
@@ -48,6 +49,10 @@ type autoUpdateStatusSource interface {
 
 type agentPoolSnapshotSource interface {
 	PoolSnapshots() []scheduler.PoolSnapshot
+}
+
+type providerStatusEnricher interface {
+	Enrich(telemetry.Snapshot, []statuspage.Source) telemetry.Snapshot
 }
 
 // withRunnerFactory returns a project.Factory that constructs a
@@ -320,6 +325,7 @@ func publishSnapshots(
 	shutdown *ShutdownController,
 	lifetimeSource lifetimeTotalsSource,
 	dashboardURL string,
+	providerStatus providerStatusEnricher,
 	interval time.Duration,
 	now func() time.Time,
 	updateSources ...autoUpdateStatusSource,
@@ -342,7 +348,7 @@ func publishSnapshots(
 	defer ticker.Stop()
 
 	for {
-		if err := publishSnapshotOnce(ctx, registry, poolSource, snapshotHub, seq, shutdown, now(), trend, lifetimeSource, dashboardURL, updateSources...); err != nil {
+		if err := publishSnapshotOnce(ctx, registry, poolSource, snapshotHub, seq, shutdown, now(), trend, lifetimeSource, dashboardURL, providerStatus, updateSources...); err != nil {
 			slog.Default().Warn("publish telemetry snapshot failed", "error", err)
 		}
 		select {
@@ -549,6 +555,7 @@ func publishSnapshotOnce(
 	trend *tokenTrendRecorder,
 	lifetimeSource lifetimeTotalsSource,
 	dashboardURL string,
+	providerStatus providerStatusEnricher,
 	updateSources ...autoUpdateStatusSource,
 ) error {
 	merged := telemetry.Snapshot{GeneratedAt: now}
@@ -636,6 +643,9 @@ func publishSnapshotOnce(
 		})
 	}
 	merged = dedupeSnapshotIssues(merged)
+	if providerStatus != nil {
+		merged = providerStatus.Enrich(merged, providerStatusSources(registry))
+	}
 	merged.AgentPools = telemetryAgentPools(poolSource)
 	if trend != nil {
 		merged = trend.apply(merged)
@@ -653,6 +663,25 @@ func publishSnapshotOnce(
 		return fmt.Errorf("publish snapshot: %w", err)
 	}
 	return nil
+}
+
+func providerStatusSources(registry *project.Registry) []statuspage.Source {
+	if registry == nil {
+		return nil
+	}
+	projects := registry.List()
+	sources := make([]statuspage.Source, 0, len(projects))
+	for _, trackedProject := range projects {
+		if trackedProject == nil {
+			continue
+		}
+		tracker := trackedProject.Workflow().Config.Tracker
+		if strings.TrimSpace(tracker.StatusPageURL) == "" {
+			continue
+		}
+		sources = append(sources, statuspage.SourceForTracker(string(trackedProject.ID()), tracker.Kind, tracker.StatusPageURL))
+	}
+	return sources
 }
 
 func telemetryUpdateStatus(sources []autoUpdateStatusSource) telemetry.Update {

--- a/internal/cli/runner_test.go
+++ b/internal/cli/runner_test.go
@@ -603,6 +603,7 @@ func TestPublishSnapshotsPublishesToHub(t *testing.T) {
 			nil,
 			nil,
 			"http://localhost:4101",
+			nil,
 			5*time.Millisecond,
 			func() time.Time { return now },
 		)
@@ -661,7 +662,7 @@ func TestPublishSnapshotOnceAssignsMonotonicSeq(t *testing.T) {
 	now := time.Date(2026, 7, 8, 12, 0, 0, 0, time.UTC)
 
 	for index := range 3 {
-		if err := publishSnapshotOnce(context.Background(), registry, nil, snapshotHub, &seq, nil, now.Add(time.Duration(index)*time.Second), nil, nil, "http://localhost:4101"); err != nil {
+		if err := publishSnapshotOnce(context.Background(), registry, nil, snapshotHub, &seq, nil, now.Add(time.Duration(index)*time.Second), nil, nil, "http://localhost:4101", nil); err != nil {
 			t.Fatalf("publishSnapshotOnce(%d) error = %v", index, err)
 		}
 		snapshot, ok := snapshotHub.Latest()
@@ -702,7 +703,7 @@ func TestPublishSnapshotOncePreservesLastKnownSnapshotUntilHydration(t *testing.
 		t.Fatalf("Publish(cached) error = %v", err)
 	}
 	var seq atomic.Uint64
-	if err := publishSnapshotOnce(context.Background(), registry, nil, snapshotHub, &seq, nil, cached.GeneratedAt.Add(time.Minute), nil, nil, ""); err != nil {
+	if err := publishSnapshotOnce(context.Background(), registry, nil, snapshotHub, &seq, nil, cached.GeneratedAt.Add(time.Minute), nil, nil, "", nil); err != nil {
 		t.Fatalf("publishSnapshotOnce() error = %v", err)
 	}
 
@@ -739,7 +740,7 @@ func TestPublishSnapshotOnceExpiresLastKnownSnapshotDuringHydration(t *testing.T
 		t.Fatalf("Publish(cached) error = %v", err)
 	}
 	var seq atomic.Uint64
-	if err := publishSnapshotOnce(context.Background(), registry, nil, snapshotHub, &seq, nil, expiresAt, nil, nil, ""); err != nil {
+	if err := publishSnapshotOnce(context.Background(), registry, nil, snapshotHub, &seq, nil, expiresAt, nil, nil, "", nil); err != nil {
 		t.Fatalf("publishSnapshotOnce() error = %v", err)
 	}
 
@@ -825,7 +826,7 @@ func TestPublishSnapshotOncePreservesProjectDataSeq(t *testing.T) {
 	snapshotHub := hub.New[telemetry.Snapshot]()
 	var seq atomic.Uint64
 	now := time.Date(2026, 7, 8, 12, 15, 0, 0, time.UTC)
-	if err := publishSnapshotOnce(context.Background(), registry, nil, snapshotHub, &seq, nil, now, nil, nil, "http://localhost:4101"); err != nil {
+	if err := publishSnapshotOnce(context.Background(), registry, nil, snapshotHub, &seq, nil, now, nil, nil, "http://localhost:4101", nil); err != nil {
 		t.Fatalf("publishSnapshotOnce() error = %v", err)
 	}
 
@@ -871,7 +872,7 @@ func TestPublishSnapshotOnceDoesNotLetPausedProjectsHoldFleetReadiness(t *testin
 	snapshotHub := hub.New[telemetry.Snapshot]()
 	now := time.Date(2026, 6, 22, 14, 0, 0, 0, time.UTC)
 	var seq atomic.Uint64
-	if err := publishSnapshotOnce(context.Background(), registry, nil, snapshotHub, &seq, nil, now, nil, nil, "http://localhost:4101"); err != nil {
+	if err := publishSnapshotOnce(context.Background(), registry, nil, snapshotHub, &seq, nil, now, nil, nil, "http://localhost:4101", nil); err != nil {
 		t.Fatalf("publishSnapshotOnce() error = %v", err)
 	}
 
@@ -932,7 +933,7 @@ func TestPublishSnapshotOnceSurfacesProjectStartupError(t *testing.T) {
 	snapshotHub := hub.New[telemetry.Snapshot]()
 	now := time.Date(2026, 6, 23, 14, 0, 0, 0, time.UTC)
 	var seq atomic.Uint64
-	if err := publishSnapshotOnce(context.Background(), registry, nil, snapshotHub, &seq, nil, now, nil, nil, "http://localhost:4101"); err != nil {
+	if err := publishSnapshotOnce(context.Background(), registry, nil, snapshotHub, &seq, nil, now, nil, nil, "http://localhost:4101", nil); err != nil {
 		t.Fatalf("publishSnapshotOnce() error = %v", err)
 	}
 
@@ -982,6 +983,7 @@ func TestPublishSnapshotOnceSurfacesPendingConnectorRetry(t *testing.T) {
 		nil,
 		nil,
 		"http://localhost:4101",
+		nil,
 	); err != nil {
 		t.Fatalf("publishSnapshotOnce() error = %v", err)
 	}
@@ -1043,7 +1045,7 @@ func TestPublishSnapshotOncePausedProjectSuppressesStartupError(t *testing.T) {
 	snapshotHub := hub.New[telemetry.Snapshot]()
 	now := time.Date(2026, 6, 23, 14, 30, 0, 0, time.UTC)
 	var seq atomic.Uint64
-	if err := publishSnapshotOnce(context.Background(), registry, nil, snapshotHub, &seq, nil, now, nil, nil, "http://localhost:4101"); err != nil {
+	if err := publishSnapshotOnce(context.Background(), registry, nil, snapshotHub, &seq, nil, now, nil, nil, "http://localhost:4101", nil); err != nil {
 		t.Fatalf("publishSnapshotOnce() error = %v", err)
 	}
 
@@ -1213,7 +1215,7 @@ func TestPublishSnapshotOncePreservesPipeline(t *testing.T) {
 
 	snapshotHub := hub.New[telemetry.Snapshot]()
 	var seq atomic.Uint64
-	if err := publishSnapshotOnce(context.Background(), registry, nil, snapshotHub, &seq, nil, now, nil, nil, "http://localhost:4101"); err != nil {
+	if err := publishSnapshotOnce(context.Background(), registry, nil, snapshotHub, &seq, nil, now, nil, nil, "http://localhost:4101", nil); err != nil {
 		t.Fatalf("publishSnapshotOnce() error = %v", err)
 	}
 

--- a/internal/cli/shutdown_test.go
+++ b/internal/cli/shutdown_test.go
@@ -1197,7 +1197,7 @@ func TestPublishShutdownSnapshotSharesSnapshotSeq(t *testing.T) {
 		t.Fatal("shutdown snapshot Draining = false, want true")
 	}
 
-	if err := publishSnapshotOnce(context.Background(), registry, nil, snapshotHub, &seq, controller, now.Add(time.Second), nil, nil, ""); err != nil {
+	if err := publishSnapshotOnce(context.Background(), registry, nil, snapshotHub, &seq, controller, now.Add(time.Second), nil, nil, "", nil); err != nil {
 		t.Fatalf("publishSnapshotOnce() error = %v", err)
 	}
 	nextSnapshot, ok := snapshotHub.Latest()

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -55,8 +55,10 @@ const (
 	DependencySourceMerged              = "merged"
 	DependencySourceNativeOnly          = "native_only"
 
-	defaultLinearEndpoint = "https://api.linear.app/graphql"
-	defaultGitHubEndpoint = "https://api.github.com/graphql"
+	defaultLinearEndpoint      = "https://api.linear.app/graphql"
+	defaultGitHubEndpoint      = "https://api.github.com/graphql"
+	defaultGitHubStatusPageURL = "https://www.githubstatus.com"
+	defaultLinearStatusPageURL = "https://linearstatus.com"
 
 	DefaultAgentBackendID                    = "codex"
 	AgentBackendCodex                        = "codex"
@@ -183,6 +185,7 @@ type Tracker struct {
 	GitHubAppInstallationID     string                `yaml:"github_app_installation_id"`
 	GitHubWebhookSecret         string                `yaml:"github_webhook_secret,omitempty"`
 	GitHubStatusSource          string                `yaml:"github_status_source"`
+	StatusPageURL               string                `yaml:"status_page_url,omitempty"`
 	ProjectSlug                 string                `yaml:"project_slug"`
 	Repository                  string                `yaml:"repository"`
 	StatusField                 string                `yaml:"status_field"`
@@ -1668,6 +1671,7 @@ func (c *Config) normalize() {
 		c.Tracker.Endpoint = defaultGitHubEndpoint
 	}
 	c.Tracker.GitHubStatusSource = normalizeGitHubStatusSource(c.Tracker.GitHubStatusSource)
+	c.Tracker.StatusPageURL = normalizeStatusPageURL(c.Tracker.Kind, c.Tracker.StatusPageURL)
 	c.Tracker.GitHubWebhookSecret = strings.TrimSpace(c.Tracker.GitHubWebhookSecret)
 	c.Tracker.Repository = strings.TrimSpace(c.Tracker.Repository)
 	c.Tracker.StatusField = strings.TrimSpace(c.Tracker.StatusField)
@@ -1806,8 +1810,34 @@ func (c *Config) validateTracker(problems *[]string) {
 	validatePositive("tracker.github_rest_min_remaining_reserve", c.Tracker.GitHubRESTMinReserve, problems)
 	validateNonNegative("tracker.github_rest_fanout_max_requests", c.Tracker.GitHubRESTFanoutMaxRequests, problems)
 	validatePositive("tracker.github_unstarted_check_threshold_seconds", c.Tracker.GitHubUnstartedSeconds, problems)
+	validateStatusPageURL(c.Tracker.StatusPageURL, problems)
 	*problems = append(*problems, c.Tracker.Claims.Validate("tracker.claims")...)
 	*problems = append(*problems, c.Tracker.Authorization.Validate("tracker.authorization")...)
+}
+
+func normalizeStatusPageURL(kind string, value string) string {
+	value = strings.TrimRight(strings.TrimSpace(value), "/")
+	if value != "" {
+		return value
+	}
+	switch kind {
+	case TrackerGitHub, TrackerGitHubLocal:
+		return defaultGitHubStatusPageURL
+	case TrackerLinear:
+		return defaultLinearStatusPageURL
+	default:
+		return ""
+	}
+}
+
+func validateStatusPageURL(value string, problems *[]string) {
+	if value == "" {
+		return
+	}
+	parsed, err := url.Parse(value)
+	if err != nil || parsed == nil || (parsed.Scheme != "http" && parsed.Scheme != "https") || parsed.Host == "" || parsed.User != nil || (parsed.Path != "" && parsed.Path != "/") || parsed.RawQuery != "" || parsed.Fragment != "" {
+		*problems = append(*problems, "tracker.status_page_url must be an absolute http or https base URL without credentials, path, query, or fragment")
+	}
 }
 
 func (c *Config) validateAgentInstructions(problems *[]string) {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -3109,6 +3109,63 @@ Prompt
 	}
 }
 
+func TestTrackerStatusPageDefaultsAndOverride(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		kind       string
+		configured string
+		want       string
+	}{
+		{name: "github default", kind: TrackerGitHub, want: defaultGitHubStatusPageURL},
+		{name: "github local default", kind: TrackerGitHubLocal, want: defaultGitHubStatusPageURL},
+		{name: "linear default", kind: TrackerLinear, want: defaultLinearStatusPageURL},
+		{name: "unknown connector has no source", kind: TrackerMemory},
+		{name: "configured source overrides default", kind: TrackerGitHub, configured: "https://status.example.com/", want: "https://status.example.com"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			cfg := Default()
+			cfg.Tracker.Kind = tt.kind
+			cfg.Tracker.StatusPageURL = tt.configured
+			cfg.normalize()
+			if cfg.Tracker.StatusPageURL != tt.want {
+				t.Fatalf("Tracker.StatusPageURL = %q, want %q", cfg.Tracker.StatusPageURL, tt.want)
+			}
+		})
+	}
+}
+
+func TestValidateStatusPageURL(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		value string
+		want  bool
+	}{
+		{name: "empty optional", want: false},
+		{name: "https", value: "https://status.example.com", want: false},
+		{name: "http", value: "http://127.0.0.1:8080", want: false},
+		{name: "relative", value: "/status", want: true},
+		{name: "credentials", value: "https://user@example.com", want: true},
+		{name: "path", value: "https://status.example.com/status", want: true},
+		{name: "query", value: "https://status.example.com?tenant=one", want: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			var problems []string
+			validateStatusPageURL(tt.value, &problems)
+			if got := len(problems) > 0; got != tt.want {
+				t.Fatalf("validateStatusPageURL(%q) problems = %v, want error %t", tt.value, problems, tt.want)
+			}
+		})
+	}
+}
+
 func TestParseWorkflowGitHubLocalRejectsGitHubStatusSource(t *testing.T) {
 	t.Parallel()
 

--- a/internal/config/configdoc/configdoc.go
+++ b/internal/config/configdoc/configdoc.go
@@ -346,6 +346,9 @@ func fieldDefault(defaultConfig config.Config, node *schemaNode) (string, string
 	if node.path == "tracker.endpoint" {
 		return trackerEndpointDefault()
 	}
+	if node.path == "tracker.status_page_url" {
+		return trackerStatusPageURLDefault()
+	}
 	if node.path == "codex.shell" || node.path == "hooks.shell" {
 		return "platform default shell", "null"
 	}
@@ -382,6 +385,23 @@ func fieldDefault(defaultConfig config.Config, node *schemaNode) (string, string
 		description += " when configured"
 	}
 	return description, literal
+}
+
+func trackerStatusPageURLDefault() (string, string) {
+	statusURLFor := func(kind string) string {
+		cfg := config.Default()
+		cfg.Tracker.Kind = kind
+		cfg, err := normalized(cfg)
+		if err != nil {
+			return ""
+		}
+		return cfg.Tracker.StatusPageURL
+	}
+	return fmt.Sprintf(
+		"%s for linear; %s for github or github_local; unused otherwise",
+		strconv.Quote(statusURLFor(config.TrackerLinear)),
+		strconv.Quote(statusURLFor(config.TrackerGitHub)),
+	), "null"
 }
 
 func trackerEndpointDefault() (string, string) {

--- a/internal/statuspage/client.go
+++ b/internal/statuspage/client.go
@@ -1,0 +1,314 @@
+package statuspage
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+)
+
+const (
+	defaultRequestTimeout = 5 * time.Second
+	maxResponseBytes      = 2 << 20
+)
+
+type HTTPDoer interface {
+	Do(*http.Request) (*http.Response, error)
+}
+
+type ClientConfig struct {
+	HTTPClient HTTPDoer
+	UserAgent  string
+}
+
+type Client struct {
+	httpClient HTTPDoer
+	userAgent  string
+}
+
+type Report struct {
+	Page       pagePayload
+	Status     statusPayload
+	Components []componentPayload
+	Incidents  []incidentPayload
+}
+
+func NewClient(cfg ClientConfig) *Client {
+	httpClient := cfg.HTTPClient
+	if httpClient == nil {
+		httpClient = &http.Client{Timeout: defaultRequestTimeout}
+	}
+	userAgent := strings.TrimSpace(cfg.UserAgent)
+	if userAgent == "" {
+		userAgent = "detent-provider-status"
+	}
+	return &Client{httpClient: httpClient, userAgent: userAgent}
+}
+
+func (c *Client) Fetch(ctx context.Context, source Source) (Report, error) {
+	source, ok := source.normalize()
+	if !ok {
+		return Report{}, errors.New("invalid status page source")
+	}
+	var summary summaryPayload
+	if err := c.fetch(ctx, source.BaseURL+"/api/v2/summary.json", &summary); err != nil {
+		return Report{}, fmt.Errorf("fetch summary: %w", err)
+	}
+	if err := validateSummary(summary); err != nil {
+		return Report{}, fmt.Errorf("validate summary: %w", err)
+	}
+
+	var unresolved unresolvedPayload
+	if err := c.fetch(ctx, source.BaseURL+"/api/v2/incidents/unresolved.json", &unresolved); err != nil {
+		return Report{}, fmt.Errorf("fetch unresolved incidents: %w", err)
+	}
+	if err := validateUnresolved(unresolved); err != nil {
+		return Report{}, fmt.Errorf("validate unresolved incidents: %w", err)
+	}
+	if summary.Page.ID != unresolved.Page.ID {
+		return Report{}, errors.New("status page feeds identify different pages")
+	}
+	return Report{
+		Page:       summary.Page,
+		Status:     summary.Status,
+		Components: append([]componentPayload(nil), summary.Components...),
+		Incidents:  append([]incidentPayload(nil), unresolved.Incidents...),
+	}, nil
+}
+
+func (c *Client) fetch(ctx context.Context, endpoint string, target any) error {
+	request, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
+	if err != nil {
+		return err
+	}
+	request.Header.Set("Accept", "application/json")
+	request.Header.Set("User-Agent", c.userAgent)
+	response, err := c.httpClient.Do(request)
+	if err != nil {
+		return err
+	}
+	defer response.Body.Close()
+	if response.StatusCode != http.StatusOK {
+		return fmt.Errorf("status %d", response.StatusCode)
+	}
+	body, err := io.ReadAll(io.LimitReader(response.Body, maxResponseBytes+1))
+	if err != nil {
+		return err
+	}
+	if len(body) > maxResponseBytes {
+		return errors.New("payload exceeds size limit")
+	}
+	decoder := json.NewDecoder(bytes.NewReader(body))
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(target); err != nil {
+		return fmt.Errorf("decode JSON: %w", err)
+	}
+	var trailing json.RawMessage
+	if err := decoder.Decode(&trailing); !errors.Is(err, io.EOF) {
+		if err == nil {
+			return errors.New("decode JSON: trailing value")
+		}
+		return fmt.Errorf("decode JSON trailer: %w", err)
+	}
+	return nil
+}
+
+type summaryPayload struct {
+	Page                  pagePayload        `json:"page"`
+	Components            []componentPayload `json:"components"`
+	Incidents             []incidentPayload  `json:"incidents"`
+	ScheduledMaintenances []incidentPayload  `json:"scheduled_maintenances"`
+	Status                statusPayload      `json:"status"`
+}
+
+type unresolvedPayload struct {
+	Page      pagePayload       `json:"page"`
+	Incidents []incidentPayload `json:"incidents"`
+}
+
+type pagePayload struct {
+	ID        string    `json:"id"`
+	Name      string    `json:"name"`
+	URL       string    `json:"url"`
+	TimeZone  string    `json:"time_zone"`
+	UpdatedAt time.Time `json:"updated_at"`
+}
+
+type statusPayload struct {
+	Indicator   string `json:"indicator"`
+	Description string `json:"description"`
+}
+
+type componentPayload struct {
+	ID                 string    `json:"id"`
+	Name               string    `json:"name"`
+	Status             string    `json:"status"`
+	CreatedAt          time.Time `json:"created_at"`
+	UpdatedAt          time.Time `json:"updated_at"`
+	Position           int       `json:"position"`
+	Description        *string   `json:"description"`
+	Showcase           bool      `json:"showcase"`
+	StartDate          *string   `json:"start_date"`
+	GroupID            *string   `json:"group_id"`
+	PageID             string    `json:"page_id"`
+	Group              bool      `json:"group"`
+	OnlyShowIfDegraded bool      `json:"only_show_if_degraded"`
+}
+
+type incidentPayload struct {
+	ID                string                  `json:"id"`
+	Name              string                  `json:"name"`
+	Status            string                  `json:"status"`
+	CreatedAt         time.Time               `json:"created_at"`
+	UpdatedAt         time.Time               `json:"updated_at"`
+	MonitoringAt      *time.Time              `json:"monitoring_at"`
+	ResolvedAt        *time.Time              `json:"resolved_at"`
+	Impact            string                  `json:"impact"`
+	Shortlink         string                  `json:"shortlink"`
+	StartedAt         time.Time               `json:"started_at"`
+	PageID            string                  `json:"page_id"`
+	IncidentUpdates   []incidentUpdatePayload `json:"incident_updates"`
+	Components        []componentPayload      `json:"components"`
+	ReminderIntervals json.RawMessage         `json:"reminder_intervals"`
+	ScheduledFor      *time.Time              `json:"scheduled_for"`
+	ScheduledUntil    *time.Time              `json:"scheduled_until"`
+}
+
+type incidentUpdatePayload struct {
+	ID                   string                     `json:"id"`
+	Status               string                     `json:"status"`
+	Body                 string                     `json:"body"`
+	IncidentID           string                     `json:"incident_id"`
+	CreatedAt            time.Time                  `json:"created_at"`
+	UpdatedAt            time.Time                  `json:"updated_at"`
+	DisplayAt            time.Time                  `json:"display_at"`
+	AffectedComponents   []affectedComponentPayload `json:"affected_components"`
+	DeliverNotifications bool                       `json:"deliver_notifications"`
+	CustomTweet          *string                    `json:"custom_tweet"`
+	TweetID              *string                    `json:"tweet_id"`
+}
+
+type affectedComponentPayload struct {
+	Code      string `json:"code"`
+	Name      string `json:"name"`
+	OldStatus string `json:"old_status"`
+	NewStatus string `json:"new_status"`
+}
+
+func validateSummary(summary summaryPayload) error {
+	if err := validatePage(summary.Page); err != nil {
+		return err
+	}
+	if !validStatusIndicator(summary.Status.Indicator) || strings.TrimSpace(summary.Status.Description) == "" {
+		return errors.New("summary status is invalid")
+	}
+	for _, component := range summary.Components {
+		if err := validateComponent(component, summary.Page.ID); err != nil {
+			return err
+		}
+	}
+	for _, incident := range append(append([]incidentPayload(nil), summary.Incidents...), summary.ScheduledMaintenances...) {
+		if err := validateIncident(incident, summary.Page.ID, false); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func validateUnresolved(unresolved unresolvedPayload) error {
+	if err := validatePage(unresolved.Page); err != nil {
+		return err
+	}
+	for _, incident := range unresolved.Incidents {
+		if err := validateIncident(incident, unresolved.Page.ID, true); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func validatePage(page pagePayload) error {
+	if strings.TrimSpace(page.ID) == "" || strings.TrimSpace(page.Name) == "" || strings.TrimSpace(page.TimeZone) == "" || page.UpdatedAt.IsZero() || !validHTTPURL(page.URL) {
+		return errors.New("page metadata is invalid")
+	}
+	return nil
+}
+
+func validateComponent(component componentPayload, pageID string) error {
+	if strings.TrimSpace(component.ID) == "" || strings.TrimSpace(component.Name) == "" || component.PageID != pageID || component.CreatedAt.IsZero() || component.UpdatedAt.IsZero() || !validComponentStatus(component.Status) {
+		return fmt.Errorf("component %q is invalid", component.Name)
+	}
+	return nil
+}
+
+func validateIncident(incident incidentPayload, pageID string, unresolved bool) error {
+	if strings.TrimSpace(incident.ID) == "" || strings.TrimSpace(incident.Name) == "" || incident.PageID != pageID || incident.CreatedAt.IsZero() || incident.UpdatedAt.IsZero() || incident.StartedAt.IsZero() || !validIncidentStatus(incident.Status) || !validImpact(incident.Impact) || !validHTTPURL(incident.Shortlink) {
+		return fmt.Errorf("incident %q is invalid", incident.Name)
+	}
+	if unresolved && (incident.Status == "resolved" || incident.Status == "completed") {
+		return fmt.Errorf("incident %q is resolved in unresolved feed", incident.Name)
+	}
+	for _, component := range incident.Components {
+		if err := validateComponent(component, pageID); err != nil {
+			return err
+		}
+	}
+	for _, update := range incident.IncidentUpdates {
+		if strings.TrimSpace(update.ID) == "" || update.IncidentID != incident.ID || strings.TrimSpace(update.Status) == "" || update.CreatedAt.IsZero() || update.UpdatedAt.IsZero() || update.DisplayAt.IsZero() {
+			return fmt.Errorf("incident %q update is invalid", incident.Name)
+		}
+		for _, component := range update.AffectedComponents {
+			if strings.TrimSpace(component.Code) == "" || strings.TrimSpace(component.Name) == "" || !validComponentStatus(component.OldStatus) || !validComponentStatus(component.NewStatus) {
+				return fmt.Errorf("incident %q affected component is invalid", incident.Name)
+			}
+		}
+	}
+	return nil
+}
+
+func validHTTPURL(value string) bool {
+	parsed, err := url.Parse(strings.TrimSpace(value))
+	return err == nil && parsed != nil && (parsed.Scheme == "http" || parsed.Scheme == "https") && parsed.Host != ""
+}
+
+func validStatusIndicator(value string) bool {
+	switch strings.TrimSpace(value) {
+	case "none", "minor", "major", "critical", "maintenance":
+		return true
+	default:
+		return false
+	}
+}
+
+func validComponentStatus(value string) bool {
+	switch strings.TrimSpace(value) {
+	case "operational", "degraded_performance", "partial_outage", "major_outage", "under_maintenance":
+		return true
+	default:
+		return false
+	}
+}
+
+func validIncidentStatus(value string) bool {
+	switch strings.TrimSpace(value) {
+	case "investigating", "identified", "monitoring", "resolved", "scheduled", "in_progress", "verifying", "completed":
+		return true
+	default:
+		return false
+	}
+}
+
+func validImpact(value string) bool {
+	switch strings.TrimSpace(value) {
+	case "none", "minor", "major", "critical", "maintenance":
+		return true
+	default:
+		return false
+	}
+}

--- a/internal/statuspage/manager.go
+++ b/internal/statuspage/manager.go
@@ -1,0 +1,328 @@
+package statuspage
+
+import (
+	"context"
+	"log/slog"
+	"slices"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/digitaldrywood/detent/internal/telemetry"
+)
+
+const (
+	defaultBaselineInterval = 30 * time.Minute
+	defaultActiveInterval   = time.Minute
+	defaultScanInterval     = 15 * time.Second
+)
+
+type Fetcher interface {
+	Fetch(context.Context, Source) (Report, error)
+}
+
+type ManagerConfig struct {
+	BaselineInterval time.Duration
+	ActiveInterval   time.Duration
+	ScanInterval     time.Duration
+}
+
+type ManagerDependencies struct {
+	Fetcher Fetcher
+	Logger  *slog.Logger
+}
+
+type cacheEntry struct {
+	Report      Report
+	AttemptedAt time.Time
+	Failed      bool
+}
+
+type Manager struct {
+	config  ManagerConfig
+	fetcher Fetcher
+	logger  *slog.Logger
+	pollMu  sync.Mutex
+	cacheMu sync.RWMutex
+	cache   map[string]cacheEntry
+}
+
+func NewManager(cfg ManagerConfig, deps ManagerDependencies) *Manager {
+	if cfg.BaselineInterval <= 0 {
+		cfg.BaselineInterval = defaultBaselineInterval
+	}
+	if cfg.ActiveInterval <= 0 {
+		cfg.ActiveInterval = defaultActiveInterval
+	}
+	if cfg.ScanInterval <= 0 {
+		cfg.ScanInterval = defaultScanInterval
+	}
+	if deps.Fetcher == nil {
+		deps.Fetcher = NewClient(ClientConfig{})
+	}
+	if deps.Logger == nil {
+		deps.Logger = slog.Default()
+	}
+	return &Manager{
+		config:  cfg,
+		fetcher: deps.Fetcher,
+		logger:  deps.Logger,
+		cache:   map[string]cacheEntry{},
+	}
+}
+
+func (m *Manager) Run(ctx context.Context, sources func() []Source, conditions func() []telemetry.TrackerCondition, now func() time.Time) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if sources == nil {
+		return
+	}
+	if conditions == nil {
+		conditions = func() []telemetry.TrackerCondition { return nil }
+	}
+	if now == nil {
+		now = time.Now
+	}
+	ticker := time.NewTicker(m.config.ScanInterval)
+	defer ticker.Stop()
+	for {
+		m.Poll(ctx, sources(), conditions(), now())
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+		}
+	}
+}
+
+func (m *Manager) Poll(ctx context.Context, sources []Source, conditions []telemetry.TrackerCondition, now time.Time) {
+	if m == nil {
+		return
+	}
+	m.pollMu.Lock()
+	defer m.pollMu.Unlock()
+	if now.IsZero() {
+		now = time.Now()
+	}
+	now = now.UTC()
+	normalized := normalizeSources(sources)
+	unique := uniqueSources(normalized)
+	active := activeSourceURLs(normalized, conditions)
+	for _, source := range unique {
+		interval := m.config.BaselineInterval
+		if _, ok := active[source.BaseURL]; ok {
+			interval = m.config.ActiveInterval
+		}
+		entry, ok := m.cached(source.BaseURL)
+		if ok && now.Sub(entry.AttemptedAt) < interval {
+			continue
+		}
+		report, err := m.fetcher.Fetch(ctx, source)
+		m.cacheMu.Lock()
+		m.cache[source.BaseURL] = cacheEntry{Report: report, AttemptedAt: now, Failed: err != nil}
+		m.cacheMu.Unlock()
+		if err != nil && ctx.Err() == nil {
+			m.logger.Warn("provider status poll failed", "provider", source.Provider, "source_url", source.BaseURL, "error", err)
+		}
+	}
+}
+
+func (m *Manager) Enrich(snapshot telemetry.Snapshot, sources []Source) telemetry.Snapshot {
+	if m == nil || len(snapshot.TrackerUnavailable) == 0 {
+		return snapshot
+	}
+	normalized := normalizeSources(sources)
+	snapshot.TrackerUnavailable = append([]telemetry.TrackerCondition(nil), snapshot.TrackerUnavailable...)
+	for index := range snapshot.TrackerUnavailable {
+		condition := &snapshot.TrackerUnavailable[index]
+		source, ok := sourceForCondition(normalized, *condition)
+		if !ok {
+			continue
+		}
+		status := telemetry.ProviderStatus{
+			Provider:  source.Provider,
+			SourceURL: source.BaseURL,
+			State:     telemetry.ProviderStatusPending,
+		}
+		entry, ok := m.cached(source.BaseURL)
+		if !ok {
+			condition.ProviderStatus = &status
+			continue
+		}
+		status.CheckedAt = entry.AttemptedAt
+		if entry.Failed {
+			status.State = telemetry.ProviderStatusUnavailable
+			condition.ProviderStatus = &status
+			continue
+		}
+		incident, ok := corroboratingIncident(entry.Report, source)
+		if !ok {
+			status.State = telemetry.ProviderStatusNoMatch
+			condition.ProviderStatus = &status
+			continue
+		}
+		status.State = telemetry.ProviderStatusCorroborated
+		status.Incident = &incident
+		condition.ProviderStatus = &status
+	}
+	return snapshot
+}
+
+func (m *Manager) cached(baseURL string) (cacheEntry, bool) {
+	m.cacheMu.RLock()
+	defer m.cacheMu.RUnlock()
+	entry, ok := m.cache[baseURL]
+	return entry, ok
+}
+
+func uniqueSources(sources []Source) []Source {
+	byURL := map[string]Source{}
+	order := make([]string, 0, len(sources))
+	for _, source := range sources {
+		normalized, ok := source.normalize()
+		if !ok {
+			continue
+		}
+		if existing, found := byURL[normalized.BaseURL]; found {
+			existing.RelevantComponents = append(existing.RelevantComponents, normalized.RelevantComponents...)
+			existing, _ = existing.normalize()
+			byURL[normalized.BaseURL] = existing
+			continue
+		}
+		byURL[normalized.BaseURL] = normalized
+		order = append(order, normalized.BaseURL)
+	}
+	result := make([]Source, 0, len(order))
+	for _, baseURL := range order {
+		result = append(result, byURL[baseURL])
+	}
+	return result
+}
+
+func normalizeSources(sources []Source) []Source {
+	result := make([]Source, 0, len(sources))
+	for _, source := range sources {
+		if normalized, ok := source.normalize(); ok {
+			result = append(result, normalized)
+		}
+	}
+	return result
+}
+
+func activeSourceURLs(sources []Source, conditions []telemetry.TrackerCondition) map[string]struct{} {
+	active := map[string]struct{}{}
+	for _, condition := range conditions {
+		if source, ok := sourceForCondition(sources, condition); ok {
+			active[source.BaseURL] = struct{}{}
+		}
+	}
+	return active
+}
+
+func sourceForCondition(sources []Source, condition telemetry.TrackerCondition) (Source, bool) {
+	projectID := strings.TrimSpace(condition.ProjectID)
+	connector := strings.ToLower(strings.TrimSpace(condition.Connector))
+	for _, source := range sources {
+		if projectID != "" && source.ProjectID == projectID {
+			return source, true
+		}
+	}
+	for _, source := range sources {
+		if connector != "" && source.Connector == connector {
+			return source, true
+		}
+	}
+	return Source{}, false
+}
+
+func corroboratingIncident(report Report, source Source) (telemetry.ProviderIncident, bool) {
+	relevant := make(map[string]struct{}, len(source.RelevantComponents))
+	for _, component := range source.RelevantComponents {
+		relevant[strings.ToLower(strings.TrimSpace(component))] = struct{}{}
+	}
+	var selected incidentPayload
+	var selectedComponents []string
+	for _, incident := range report.Incidents {
+		components := matchingComponents(incident, report.Components, relevant)
+		if len(relevant) > 0 && len(components) == 0 {
+			continue
+		}
+		if selected.ID == "" || incidentImpactRank(incident.Impact) > incidentImpactRank(selected.Impact) || (incident.Impact == selected.Impact && incident.UpdatedAt.After(selected.UpdatedAt)) {
+			selected = incident
+			selectedComponents = components
+		}
+	}
+	if selected.ID == "" {
+		return telemetry.ProviderIncident{}, false
+	}
+	return telemetry.ProviderIncident{
+		Name:       selected.Name,
+		URL:        selected.Shortlink,
+		Status:     operatorIncidentStatus(selected.Status),
+		Impact:     selected.Impact,
+		Components: selectedComponents,
+		UpdatedAt:  selected.UpdatedAt,
+	}, true
+}
+
+func matchingComponents(incident incidentPayload, summary []componentPayload, relevant map[string]struct{}) []string {
+	names := make([]string, 0, len(incident.Components))
+	appendName := func(name string) {
+		name = strings.TrimSpace(name)
+		if name == "" || slices.Contains(names, name) {
+			return
+		}
+		if len(relevant) > 0 {
+			if _, ok := relevant[strings.ToLower(name)]; !ok {
+				return
+			}
+		}
+		names = append(names, name)
+	}
+	for _, component := range incident.Components {
+		appendName(component.Name)
+	}
+	for _, update := range incident.IncidentUpdates {
+		for _, component := range update.AffectedComponents {
+			appendName(component.Name)
+		}
+	}
+	if len(names) > 0 || len(incident.Components) > 0 {
+		return names
+	}
+	for _, component := range summary {
+		if component.Status != "operational" {
+			appendName(component.Name)
+		}
+	}
+	return names
+}
+
+func incidentImpactRank(impact string) int {
+	switch strings.TrimSpace(impact) {
+	case "critical":
+		return 4
+	case "major":
+		return 3
+	case "minor":
+		return 2
+	case "maintenance":
+		return 1
+	default:
+		return 0
+	}
+}
+
+func operatorIncidentStatus(status string) string {
+	switch strings.TrimSpace(status) {
+	case "identified":
+		return "mitigating"
+	case "in_progress":
+		return "in progress"
+	default:
+		return strings.ReplaceAll(strings.TrimSpace(status), "_", " ")
+	}
+}
+
+var _ Fetcher = (*Client)(nil)

--- a/internal/statuspage/source.go
+++ b/internal/statuspage/source.go
@@ -1,0 +1,61 @@
+package statuspage
+
+import (
+	"net/url"
+	"strings"
+)
+
+type Source struct {
+	ProjectID          string
+	Connector          string
+	Provider           string
+	BaseURL            string
+	RelevantComponents []string
+}
+
+func SourceForTracker(projectID string, connector string, baseURL string) Source {
+	connector = strings.ToLower(strings.TrimSpace(connector))
+	source := Source{
+		ProjectID: strings.TrimSpace(projectID),
+		Connector: connector,
+		BaseURL:   strings.TrimRight(strings.TrimSpace(baseURL), "/"),
+	}
+	switch connector {
+	case "github", "github_local":
+		source.Provider = "GitHub"
+		source.RelevantComponents = []string{"API Requests", "Issues", "Pull Requests", "Git Operations", "Webhooks", "Actions"}
+	case "linear":
+		source.Provider = "Linear"
+		source.RelevantComponents = []string{"EU Region – Linear API", "US Region – Linear API"}
+	default:
+		source.Provider = strings.TrimSpace(connector)
+	}
+	return source
+}
+
+func (s Source) normalize() (Source, bool) {
+	s.ProjectID = strings.TrimSpace(s.ProjectID)
+	s.Connector = strings.ToLower(strings.TrimSpace(s.Connector))
+	s.Provider = strings.TrimSpace(s.Provider)
+	s.BaseURL = strings.TrimRight(strings.TrimSpace(s.BaseURL), "/")
+	parsed, err := url.Parse(s.BaseURL)
+	if err != nil || parsed == nil || (parsed.Scheme != "http" && parsed.Scheme != "https") || parsed.Host == "" {
+		return Source{}, false
+	}
+	components := make([]string, 0, len(s.RelevantComponents))
+	seen := map[string]struct{}{}
+	for _, component := range s.RelevantComponents {
+		component = strings.TrimSpace(component)
+		key := strings.ToLower(component)
+		if key == "" {
+			continue
+		}
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		seen[key] = struct{}{}
+		components = append(components, component)
+	}
+	s.RelevantComponents = components
+	return s, true
+}

--- a/internal/statuspage/statuspage_test.go
+++ b/internal/statuspage/statuspage_test.go
@@ -1,0 +1,378 @@
+package statuspage
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/digitaldrywood/detent/internal/telemetry"
+)
+
+func TestClientFetchStrictStatuspageFeeds(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name         string
+		mutate       func(map[string]any, map[string]any)
+		redirect     bool
+		wantErr      string
+		wantIncident string
+	}{
+		{name: "valid feeds", wantIncident: "GitHub service disruption"},
+		{name: "redirects followed", redirect: true, wantIncident: "GitHub service disruption"},
+		{
+			name: "unknown field rejected",
+			mutate: func(summary map[string]any, _ map[string]any) {
+				summary["unexpected"] = true
+			},
+			wantErr: "unknown field",
+		},
+		{
+			name: "wrong field type rejected",
+			mutate: func(_ map[string]any, unresolved map[string]any) {
+				unresolved["incidents"] = "open"
+			},
+			wantErr: "cannot unmarshal",
+		},
+		{
+			name: "missing required metadata rejected",
+			mutate: func(summary map[string]any, _ map[string]any) {
+				summary["page"].(map[string]any)["id"] = ""
+			},
+			wantErr: "page metadata is invalid",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			summary, unresolved := statuspagePayloads(t, "identified", []string{"API Requests", "Issues"}, true)
+			if tt.mutate != nil {
+				tt.mutate(summary, unresolved)
+			}
+			target := newStatuspageServer(t, summary, unresolved, nil)
+			baseURL := target.URL
+			if tt.redirect {
+				redirect := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					http.Redirect(w, r, target.URL+r.URL.Path, http.StatusMovedPermanently)
+				}))
+				t.Cleanup(redirect.Close)
+				baseURL = redirect.URL
+			}
+			report, err := NewClient(ClientConfig{}).Fetch(context.Background(), SourceForTracker("detent", "github", baseURL))
+			if tt.wantErr != "" {
+				if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
+					t.Fatalf("Fetch() error = %v, want containing %q", err, tt.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("Fetch() error = %v", err)
+			}
+			if len(report.Incidents) != 1 || report.Incidents[0].Name != tt.wantIncident {
+				t.Fatalf("Fetch().Incidents = %#v, want %q", report.Incidents, tt.wantIncident)
+			}
+		})
+	}
+}
+
+func TestManagerCorroboratesWithoutControllingCondition(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 8, 17, 17, 20, 0, 0, time.UTC)
+	tests := []struct {
+		name               string
+		incidentStatus     string
+		incidentComponents []string
+		componentsHealthy  bool
+		fetchErr           error
+		malformed          bool
+		projectCount       int
+		wantState          string
+		wantStatus         string
+		wantComponents     []string
+		wantRequests       int
+	}{
+		{
+			name:               "incident names links and mitigation",
+			incidentStatus:     "identified",
+			incidentComponents: []string{"API Requests", "Issues"},
+			componentsHealthy:  true,
+			projectCount:       1,
+			wantState:          telemetry.ProviderStatusCorroborated,
+			wantStatus:         "mitigating",
+			wantComponents:     []string{"API Requests", "Issues"},
+			wantRequests:       2,
+		},
+		{
+			name:               "operational summary still trusts open incident",
+			incidentStatus:     "investigating",
+			incidentComponents: []string{"API Requests"},
+			componentsHealthy:  true,
+			projectCount:       1,
+			wantState:          telemetry.ProviderStatusCorroborated,
+			wantStatus:         "investigating",
+			wantComponents:     []string{"API Requests"},
+			wantRequests:       2,
+		},
+		{
+			name:               "unrelated incident does not match",
+			incidentStatus:     "investigating",
+			incidentComponents: []string{"Pages"},
+			componentsHealthy:  true,
+			projectCount:       1,
+			wantState:          telemetry.ProviderStatusNoMatch,
+			wantRequests:       2,
+		},
+		{
+			name:         "unreachable page is non fatal",
+			fetchErr:     errors.New("network unavailable"),
+			projectCount: 1,
+			wantState:    telemetry.ProviderStatusUnavailable,
+		},
+		{
+			name:               "malformed payload is non fatal",
+			incidentStatus:     "identified",
+			incidentComponents: []string{"API Requests"},
+			malformed:          true,
+			projectCount:       1,
+			wantState:          telemetry.ProviderStatusUnavailable,
+			wantRequests:       1,
+		},
+		{
+			name:               "shared provider is polled once per endpoint",
+			incidentStatus:     "identified",
+			incidentComponents: []string{"API Requests", "Issues"},
+			componentsHealthy:  true,
+			projectCount:       3,
+			wantState:          telemetry.ProviderStatusCorroborated,
+			wantStatus:         "mitigating",
+			wantComponents:     []string{"API Requests", "Issues"},
+			wantRequests:       2,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			var fetcher Fetcher
+			var counts requestCounts
+			baseURL := "https://status.example.com"
+			if tt.fetchErr != nil {
+				fetcher = errorFetcher{err: tt.fetchErr}
+			} else {
+				summary, unresolved := statuspagePayloads(t, tt.incidentStatus, tt.incidentComponents, tt.componentsHealthy)
+				if tt.malformed {
+					summary["unexpected"] = true
+				}
+				server := newStatuspageServer(t, summary, unresolved, &counts)
+				baseURL = server.URL
+				fetcher = NewClient(ClientConfig{})
+			}
+			manager := NewManager(ManagerConfig{}, ManagerDependencies{
+				Fetcher: fetcher,
+				Logger:  slog.New(slog.NewTextHandler(io.Discard, nil)),
+			})
+			sources := make([]Source, 0, tt.projectCount)
+			conditions := make([]telemetry.TrackerCondition, 0, tt.projectCount)
+			for index := range tt.projectCount {
+				projectID := "project-" + string(rune('a'+index))
+				sources = append(sources, SourceForTracker(projectID, "github", baseURL))
+				conditions = append(conditions, telemetry.TrackerCondition{
+					ProjectID:  projectID,
+					Connector:  "github",
+					ErrorClass: "server",
+				})
+			}
+			manager.Poll(context.Background(), sources, conditions, now)
+			snapshot := manager.Enrich(telemetry.Snapshot{TrackerUnavailable: append([]telemetry.TrackerCondition(nil), conditions...)}, sources)
+			if len(snapshot.TrackerUnavailable) != tt.projectCount {
+				t.Fatalf("Enrich() conditions = %d, want %d", len(snapshot.TrackerUnavailable), tt.projectCount)
+			}
+			for _, condition := range snapshot.TrackerUnavailable {
+				if condition.ProviderStatus == nil || condition.ProviderStatus.State != tt.wantState {
+					t.Fatalf("Enrich().ProviderStatus = %#v, want state %q", condition.ProviderStatus, tt.wantState)
+				}
+				if condition.ErrorClass != "server" {
+					t.Fatalf("Enrich() changed Detent condition: %#v", condition)
+				}
+				if tt.wantStatus == "" {
+					if condition.ProviderStatus.Incident != nil {
+						t.Fatalf("Enrich().Incident = %#v, want nil", condition.ProviderStatus.Incident)
+					}
+					continue
+				}
+				incident := condition.ProviderStatus.Incident
+				if incident == nil || incident.Name != "GitHub service disruption" || incident.URL != "https://stspg.io/example" || incident.Status != tt.wantStatus || !equalStrings(incident.Components, tt.wantComponents) {
+					t.Fatalf("Enrich().Incident = %#v", incident)
+				}
+			}
+			if got := counts.total(); got != tt.wantRequests {
+				t.Fatalf("provider requests = %d, want %d", got, tt.wantRequests)
+			}
+		})
+	}
+}
+
+func TestManagerPollingIntervals(t *testing.T) {
+	t.Parallel()
+
+	summary, unresolved := statuspagePayloads(t, "identified", []string{"API Requests"}, true)
+	var counts requestCounts
+	server := newStatuspageServer(t, summary, unresolved, &counts)
+	manager := NewManager(ManagerConfig{
+		BaselineInterval: 30 * time.Minute,
+		ActiveInterval:   time.Minute,
+	}, ManagerDependencies{
+		Fetcher: NewClient(ClientConfig{}),
+		Logger:  slog.New(slog.NewTextHandler(io.Discard, nil)),
+	})
+	source := SourceForTracker("detent", "github", server.URL)
+	condition := telemetry.TrackerCondition{ProjectID: "detent", Connector: "github"}
+	start := time.Date(2026, 8, 17, 17, 20, 0, 0, time.UTC)
+	tests := []struct {
+		name       string
+		at         time.Time
+		conditions []telemetry.TrackerCondition
+		want       int
+	}{
+		{name: "initial baseline", at: start, want: 2},
+		{name: "steady state stays quiet", at: start.Add(2 * time.Minute), want: 2},
+		{name: "active condition refreshes stale baseline", at: start.Add(2 * time.Minute), conditions: []telemetry.TrackerCondition{condition}, want: 4},
+		{name: "active condition remains rate limited", at: start.Add(2*time.Minute + 30*time.Second), conditions: []telemetry.TrackerCondition{condition}, want: 4},
+		{name: "active interval refreshes", at: start.Add(3 * time.Minute), conditions: []telemetry.TrackerCondition{condition}, want: 6},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			manager.Poll(context.Background(), []Source{source}, tt.conditions, tt.at)
+			if got := counts.total(); got != tt.want {
+				t.Fatalf("requests after Poll() = %d, want %d", got, tt.want)
+			}
+		})
+	}
+}
+
+type errorFetcher struct {
+	err error
+}
+
+func (f errorFetcher) Fetch(context.Context, Source) (Report, error) {
+	return Report{}, f.err
+}
+
+type requestCounts struct {
+	mu         sync.Mutex
+	summary    int
+	unresolved int
+}
+
+func (c *requestCounts) add(path string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	switch path {
+	case "/api/v2/summary.json":
+		c.summary++
+	case "/api/v2/incidents/unresolved.json":
+		c.unresolved++
+	}
+}
+
+func (c *requestCounts) total() int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.summary + c.unresolved
+}
+
+func newStatuspageServer(t *testing.T, summary map[string]any, unresolved map[string]any, counts *requestCounts) *httptest.Server {
+	t.Helper()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if counts != nil {
+			counts.add(r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/api/v2/summary.json":
+			_ = json.NewEncoder(w).Encode(summary)
+		case "/api/v2/incidents/unresolved.json":
+			_ = json.NewEncoder(w).Encode(unresolved)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(server.Close)
+	return server
+}
+
+func statuspagePayloads(t *testing.T, incidentStatus string, incidentComponents []string, componentsHealthy bool) (map[string]any, map[string]any) {
+	t.Helper()
+	now := time.Date(2026, 8, 17, 16, 59, 38, 0, time.UTC).Format(time.RFC3339)
+	page := map[string]any{
+		"id": "page-id", "name": "GitHub", "url": "https://www.githubstatus.com", "time_zone": "Etc/UTC", "updated_at": now,
+	}
+	componentNames := []string{"API Requests", "Issues", "Pages"}
+	components := make([]any, 0, len(componentNames))
+	byName := map[string]map[string]any{}
+	for index, name := range componentNames {
+		status := "operational"
+		if !componentsHealthy && name == "API Requests" {
+			status = "major_outage"
+		}
+		component := map[string]any{
+			"id": "component-" + string(rune('a'+index)), "name": name, "status": status,
+			"created_at": now, "updated_at": now, "position": index + 1, "description": nil,
+			"showcase": true, "start_date": nil, "group_id": nil, "page_id": "page-id", "group": false,
+			"only_show_if_degraded": false,
+		}
+		components = append(components, component)
+		byName[name] = component
+	}
+	incidentComponentPayloads := make([]any, 0, len(incidentComponents))
+	affected := make([]any, 0, len(incidentComponents))
+	for _, name := range incidentComponents {
+		component, ok := byName[name]
+		if !ok {
+			component = map[string]any{
+				"id": "component-extra", "name": name, "status": "operational", "created_at": now, "updated_at": now,
+				"position": 99, "description": nil, "showcase": true, "start_date": nil, "group_id": nil,
+				"page_id": "page-id", "group": false, "only_show_if_degraded": false,
+			}
+		}
+		incidentComponentPayloads = append(incidentComponentPayloads, component)
+		affected = append(affected, map[string]any{"code": component["id"], "name": name, "old_status": "operational", "new_status": "degraded_performance"})
+	}
+	incident := map[string]any{
+		"id": "incident-id", "name": "GitHub service disruption", "status": incidentStatus,
+		"created_at": now, "updated_at": now, "monitoring_at": nil, "resolved_at": nil, "impact": "critical",
+		"shortlink": "https://stspg.io/example", "started_at": now, "page_id": "page-id", "reminder_intervals": nil,
+		"incident_updates": []any{map[string]any{
+			"id": "update-id", "status": incidentStatus, "body": "Mitigation is underway", "incident_id": "incident-id",
+			"created_at": now, "updated_at": now, "display_at": now, "affected_components": affected,
+			"deliver_notifications": true, "custom_tweet": nil, "tweet_id": nil,
+		}},
+		"components": incidentComponentPayloads,
+	}
+	summary := map[string]any{
+		"page": page, "components": components, "incidents": []any{incident}, "scheduled_maintenances": []any{},
+		"status": map[string]any{"indicator": "critical", "description": "Major Service Outage"},
+	}
+	unresolved := map[string]any{"page": page, "incidents": []any{incident}}
+	return summary, unresolved
+}
+
+func equalStrings(got []string, want []string) bool {
+	if len(got) != len(want) {
+		return false
+	}
+	for index := range got {
+		if got[index] != want[index] {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/telemetry/snapshot.go
+++ b/internal/telemetry/snapshot.go
@@ -104,6 +104,31 @@ type TrackerCondition struct {
 	LastProbeDetail    string            `json:"last_probe_detail,omitempty"`
 	ProbeAttempts      int               `json:"probe_attempts,omitempty"`
 	LastError          string            `json:"last_error,omitempty"`
+	ProviderStatus     *ProviderStatus   `json:"provider_status,omitempty"`
+}
+
+const (
+	ProviderStatusPending      = "pending"
+	ProviderStatusCorroborated = "corroborated"
+	ProviderStatusNoMatch      = "no_matching_incident"
+	ProviderStatusUnavailable  = "unavailable"
+)
+
+type ProviderStatus struct {
+	Provider  string            `json:"provider"`
+	SourceURL string            `json:"source_url"`
+	State     string            `json:"state"`
+	CheckedAt time.Time         `json:"checked_at,omitzero"`
+	Incident  *ProviderIncident `json:"incident,omitempty"`
+}
+
+type ProviderIncident struct {
+	Name       string    `json:"name"`
+	URL        string    `json:"url"`
+	Status     string    `json:"status"`
+	Impact     string    `json:"impact,omitempty"`
+	Components []string  `json:"components,omitempty"`
+	UpdatedAt  time.Time `json:"updated_at"`
 }
 
 type AdmissionProposal struct {

--- a/internal/web/templates/board_data.go
+++ b/internal/web/templates/board_data.go
@@ -205,12 +205,12 @@ func boardTrackerUnavailableAlert(snapshot telemetry.Snapshot) (boardAlert, bool
 	}
 	rows := make([]boardAlertDetailRow, 0, len(snapshot.TrackerUnavailable))
 	for index, condition := range snapshot.TrackerUnavailable {
-		label := strings.TrimSpace(condition.ProjectID)
-		if label == "" {
-			label = strings.TrimSpace(condition.ConnectorInstance)
+		projectLabel := strings.TrimSpace(condition.ProjectID)
+		if projectLabel == "" {
+			projectLabel = strings.TrimSpace(condition.ConnectorInstance)
 		}
-		if label == "" {
-			label = "Tracker"
+		if projectLabel == "" {
+			projectLabel = "Tracker"
 		}
 		summary := strings.TrimSpace(condition.Connector) + " tracker · tracker_unavailable"
 		if strings.TrimSpace(condition.Connector) == "" {
@@ -224,9 +224,23 @@ func boardTrackerUnavailableAlert(snapshot telemetry.Snapshot) (boardAlert, bool
 			}
 			detail += " · next canary in " + formatDuration(delay.Seconds())
 		}
+		label := projectLabel
+		link := ""
+		if providerSummary, providerLink := trackerProviderStatusSummary(condition); providerSummary != "" {
+			summary = providerSummary
+			if providerLink != "" {
+				label = providerSummary
+				link = providerLink
+				summary = projectLabel
+			}
+			if condition.ProviderStatus != nil && condition.ProviderStatus.Incident != nil {
+				detail = condition.ProviderStatus.Incident.Name + " · " + detail
+			}
+		}
 		rows = append(rows, boardAlertDetailRow{
-			ID:      "board-alert-tracker-unavailable-" + boardAlertRowSlug(label, index),
+			ID:      "board-alert-tracker-unavailable-" + boardAlertRowSlug(projectLabel, index),
 			Label:   label,
+			Link:    link,
 			Summary: summary,
 			Detail:  strings.Trim(detail, " ·"),
 		})

--- a/internal/web/templates/board_data_test.go
+++ b/internal/web/templates/board_data_test.go
@@ -2506,6 +2506,54 @@ func TestBoardAlertsNameTrackerAvailabilityCondition(t *testing.T) {
 	}
 }
 
+func TestBoardAlertsCorroborateTrackerIncident(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		status      telemetry.ProviderStatus
+		wantSummary string
+		wantLink    string
+	}{
+		{
+			name: "incident names components and links shortlink",
+			status: telemetry.ProviderStatus{
+				Provider: "GitHub",
+				State:    telemetry.ProviderStatusCorroborated,
+				Incident: &telemetry.ProviderIncident{
+					Name:       "GitHub service disruption",
+					URL:        "https://stspg.io/example",
+					Status:     "mitigating",
+					Components: []string{"API Requests", "Issues"},
+				},
+			},
+			wantSummary: "GitHub incident affecting API Requests and Issues — mitigating",
+			wantLink:    "https://stspg.io/example",
+		},
+		{
+			name:        "missing incident is explicit corroboration information",
+			status:      telemetry.ProviderStatus{Provider: "GitHub", State: telemetry.ProviderStatusNoMatch},
+			wantSummary: "no matching provider incident",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			alerts := boardAlerts(telemetry.Snapshot{TrackerUnavailable: []telemetry.TrackerCondition{{
+				ProjectID: "detent", Connector: "github", Operation: "observed_status", ErrorClass: "server", ProviderStatus: &tt.status,
+			}}})
+			if len(alerts) != 1 || len(alerts[0].DetailRows) != 1 {
+				t.Fatalf("boardAlerts() = %#v, want one tracker alert row", alerts)
+			}
+			row := alerts[0].DetailRows[0]
+			combined := row.Label + " " + row.Summary + " " + row.Detail
+			if !strings.Contains(combined, tt.wantSummary) || row.Link != tt.wantLink {
+				t.Fatalf("tracker provider row = %#v, want summary %q and link %q", row, tt.wantSummary, tt.wantLink)
+			}
+		})
+	}
+}
+
 func TestBoardAlertsSurfaceDispatchStallAsNeedsAttention(t *testing.T) {
 	t.Parallel()
 

--- a/internal/web/templates/dashboard_test.go
+++ b/internal/web/templates/dashboard_test.go
@@ -276,6 +276,37 @@ func TestHealthPageRendersOneClientLocalCapacityNotice(t *testing.T) {
 	}
 }
 
+func TestHealthPageRendersTrackerProviderIncidentLink(t *testing.T) {
+	t.Parallel()
+
+	html := renderHealthPageV2(t, templates.DashboardData{Snapshot: telemetry.Snapshot{
+		GeneratedAt: time.Date(2026, 8, 17, 17, 20, 0, 0, time.UTC),
+		TrackerUnavailable: []telemetry.TrackerCondition{{
+			ProjectID: "detent",
+			Connector: "github",
+			ProviderStatus: &telemetry.ProviderStatus{
+				Provider: "GitHub",
+				State:    telemetry.ProviderStatusCorroborated,
+				Incident: &telemetry.ProviderIncident{
+					Name:       "GitHub service disruption",
+					URL:        "https://stspg.io/example",
+					Status:     "mitigating",
+					Components: []string{"API Requests", "Issues"},
+				},
+			},
+		}},
+	}})
+	for _, want := range []string{
+		`href="https://stspg.io/example"`,
+		"GitHub incident affecting API Requests and Issues — mitigating",
+		"GitHub service disruption",
+	} {
+		if !strings.Contains(html, want) {
+			t.Fatalf("health page missing %q:\n%s", want, html)
+		}
+	}
+}
+
 func TestProjectDiagnosticsPageRendersWorkflowDiagnosticPromptCopyControls(t *testing.T) {
 	t.Parallel()
 

--- a/internal/web/templates/health.templ
+++ b/internal/web/templates/health.templ
@@ -68,7 +68,11 @@ templ HealthSnapshotV2(data DashboardData) {
 					{ row.Status }
 				</span>
 				<span class="min-w-0 break-words text-xs text-sec">
-					{ row.Detail }
+					if row.Link != "" {
+						<a class="font-medium text-accent hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent" href={ templ.SafeURL(row.Link) }>{ row.Detail }</a>
+					} else {
+						{ row.Detail }
+					}
 					if !row.DetailAt.IsZero() {
 						{ " " }
 						@LocalTime(row.DetailAt, LocalTimeOptions{Relative: true})

--- a/internal/web/templates/health_data.go
+++ b/internal/web/templates/health_data.go
@@ -28,6 +28,7 @@ type healthRow struct {
 	Kind      primitives.Kind
 	Status    string
 	Detail    string
+	Link      string
 	Quota     string
 	QuotaPct  int
 	QuotaWarn bool
@@ -328,12 +329,21 @@ func healthTrackerUnavailableRows(conditions []telemetry.TrackerCondition) []hea
 			connectorName = "Tracker"
 		}
 		detail := "tracker_unavailable · " + strings.Trim(strings.TrimSpace(condition.Operation)+" · "+strings.TrimSpace(condition.ErrorClass), " ·")
+		link := ""
+		if providerSummary, providerLink := trackerProviderStatusSummary(condition); providerSummary != "" {
+			detail = providerSummary
+			link = providerLink
+			if condition.ProviderStatus != nil && condition.ProviderStatus.Incident != nil {
+				detail += " · " + condition.ProviderStatus.Incident.Name
+			}
+		}
 		rows = append(rows, healthRow{
 			ID:        "health-tracker-unavailable-" + boardAlertRowSlug(projectID, index),
 			Component: connectorName + " tracker · " + projectID,
 			Kind:      primitives.KindErr,
 			Status:    "Unavailable",
 			Detail:    detail,
+			Link:      link,
 			Resets:    "on successful canary",
 			ResetAt:   condition.NextProbeAt,
 			DetailAt:  condition.LastObservedAt,
@@ -345,6 +355,9 @@ func healthTrackerUnavailableRows(conditions []telemetry.TrackerCondition) []hea
 func trackerUnavailableHealthDetail(conditions []telemetry.TrackerCondition) string {
 	if len(conditions) == 1 {
 		condition := conditions[0]
+		if providerSummary, _ := trackerProviderStatusSummary(condition); providerSummary != "" {
+			return providerSummary + "; tracker-dependent dispatch is paused."
+		}
 		connectorName := strings.TrimSpace(condition.Connector)
 		if connectorName == "" {
 			connectorName = "Configured"
@@ -352,6 +365,58 @@ func trackerUnavailableHealthDetail(conditions []telemetry.TrackerCondition) str
 		return connectorName + " tracker reads are unavailable; tracker-dependent dispatch is paused."
 	}
 	return boardCountLabel(len(conditions), "tracker connector is", "tracker connectors are") + " unavailable; tracker-dependent dispatch is paused."
+}
+
+func trackerProviderStatusSummary(condition telemetry.TrackerCondition) (string, string) {
+	status := condition.ProviderStatus
+	if status == nil {
+		return "", ""
+	}
+	switch status.State {
+	case telemetry.ProviderStatusCorroborated:
+		if status.Incident == nil {
+			return "provider status corroborated the outage", ""
+		}
+		provider := strings.TrimSpace(status.Provider)
+		if provider == "" {
+			provider = "Provider"
+		}
+		summary := provider + " incident"
+		if len(status.Incident.Components) > 0 {
+			summary += " affecting " + healthNaturalList(status.Incident.Components)
+		}
+		if phase := strings.TrimSpace(status.Incident.Status); phase != "" {
+			summary += " — " + phase
+		}
+		return summary, strings.TrimSpace(status.Incident.URL)
+	case telemetry.ProviderStatusNoMatch:
+		return "no matching provider incident", ""
+	case telemetry.ProviderStatusUnavailable:
+		return "provider status unavailable", ""
+	case telemetry.ProviderStatusPending:
+		return "provider status check pending", ""
+	default:
+		return "", ""
+	}
+}
+
+func healthNaturalList(values []string) string {
+	clean := make([]string, 0, len(values))
+	for _, value := range values {
+		if value = strings.TrimSpace(value); value != "" {
+			clean = append(clean, value)
+		}
+	}
+	switch len(clean) {
+	case 0:
+		return ""
+	case 1:
+		return clean[0]
+	case 2:
+		return clean[0] + " and " + clean[1]
+	default:
+		return strings.Join(clean[:len(clean)-1], ", ") + ", and " + clean[len(clean)-1]
+	}
 }
 
 func ciUnavailableHealthDetail(conditions []telemetry.CICondition) string {

--- a/internal/web/templates/health_data_test.go
+++ b/internal/web/templates/health_data_test.go
@@ -132,6 +132,48 @@ func TestHealthViewVerdicts(t *testing.T) {
 	}
 }
 
+func TestHealthTrackerProviderStatus(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		status     telemetry.ProviderStatus
+		wantDetail string
+		wantLink   string
+	}{
+		{
+			name: "corroborating incident",
+			status: telemetry.ProviderStatus{
+				Provider: "GitHub",
+				State:    telemetry.ProviderStatusCorroborated,
+				Incident: &telemetry.ProviderIncident{
+					Name:       "GitHub service disruption",
+					URL:        "https://stspg.io/example",
+					Status:     "mitigating",
+					Components: []string{"API Requests", "Issues"},
+				},
+			},
+			wantDetail: "GitHub incident affecting API Requests and Issues — mitigating",
+			wantLink:   "https://stspg.io/example",
+		},
+		{name: "no incident", status: telemetry.ProviderStatus{Provider: "GitHub", State: telemetry.ProviderStatusNoMatch}, wantDetail: "no matching provider incident"},
+		{name: "unreachable provider", status: telemetry.ProviderStatus{Provider: "GitHub", State: telemetry.ProviderStatusUnavailable}, wantDetail: "provider status unavailable"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			condition := telemetry.TrackerCondition{ProjectID: "detent", Connector: "github", ErrorClass: "server", ProviderStatus: &tt.status}
+			rows := healthTrackerUnavailableRows([]telemetry.TrackerCondition{condition})
+			if len(rows) != 1 || !strings.Contains(rows[0].Detail, tt.wantDetail) || rows[0].Link != tt.wantLink {
+				t.Fatalf("healthTrackerUnavailableRows() = %#v, want detail %q and link %q", rows, tt.wantDetail, tt.wantLink)
+			}
+			if detail := trackerUnavailableHealthDetail([]telemetry.TrackerCondition{condition}); !strings.Contains(detail, tt.wantDetail) {
+				t.Fatalf("trackerUnavailableHealthDetail() = %q, want containing %q", detail, tt.wantDetail)
+			}
+		})
+	}
+}
+
 func TestHealthDispatchStallRows(t *testing.T) {
 	t.Parallel()
 

--- a/internal/web/templates/health_templ.go
+++ b/internal/web/templates/health_templ.go
@@ -326,26 +326,59 @@ func HealthSnapshotV2(data DashboardData) templ.Component {
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			var templ_7745c5c3_Var19 string
-			templ_7745c5c3_Var19, templ_7745c5c3_Err = templ.JoinStringErrs(row.Detail)
-			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/health.templ`, Line: 71, Col: 17}
-			}
-			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var19))
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 20, " ")
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
-			if !row.DetailAt.IsZero() {
-				var templ_7745c5c3_Var20 string
-				templ_7745c5c3_Var20, templ_7745c5c3_Err = templ.JoinStringErrs(" ")
+			if row.Link != "" {
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 20, "<a class=\"font-medium text-accent hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent\" href=\"")
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/health.templ`, Line: 73, Col: 11}
+					return templ_7745c5c3_Err
+				}
+				var templ_7745c5c3_Var19 templ.SafeURL
+				templ_7745c5c3_Var19, templ_7745c5c3_Err = templ.JoinURLErrs(templ.SafeURL(row.Link))
+				if templ_7745c5c3_Err != nil {
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/health.templ`, Line: 72, Col: 161}
+				}
+				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var19))
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 21, "\">")
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+				var templ_7745c5c3_Var20 string
+				templ_7745c5c3_Var20, templ_7745c5c3_Err = templ.JoinStringErrs(row.Detail)
+				if templ_7745c5c3_Err != nil {
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/health.templ`, Line: 72, Col: 176}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var20))
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 22, "</a> ")
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+			} else {
+				var templ_7745c5c3_Var21 string
+				templ_7745c5c3_Var21, templ_7745c5c3_Err = templ.JoinStringErrs(row.Detail)
+				if templ_7745c5c3_Err != nil {
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/health.templ`, Line: 74, Col: 18}
+				}
+				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var21))
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 23, " ")
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+			}
+			if !row.DetailAt.IsZero() {
+				var templ_7745c5c3_Var22 string
+				templ_7745c5c3_Var22, templ_7745c5c3_Err = templ.JoinStringErrs(" ")
+				if templ_7745c5c3_Err != nil {
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/health.templ`, Line: 77, Col: 11}
+				}
+				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var22))
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
@@ -354,70 +387,70 @@ func HealthSnapshotV2(data DashboardData) templ.Component {
 					return templ_7745c5c3_Err
 				}
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 21, "</span> ")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 24, "</span> ")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			if row.Quota != "" {
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 22, "<span class=\"flex items-center gap-2.5\"><span class=\"whitespace-nowrap font-mono text-xs text-sec tabular-nums\">")
-				if templ_7745c5c3_Err != nil {
-					return templ_7745c5c3_Err
-				}
-				var templ_7745c5c3_Var21 string
-				templ_7745c5c3_Var21, templ_7745c5c3_Err = templ.JoinStringErrs(row.Quota)
-				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/health.templ`, Line: 79, Col: 89}
-				}
-				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var21))
-				if templ_7745c5c3_Err != nil {
-					return templ_7745c5c3_Err
-				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 23, "</span> <span class=\"h-1 min-w-0 flex-1 overflow-hidden rounded-xs bg-line\">")
-				if templ_7745c5c3_Err != nil {
-					return templ_7745c5c3_Err
-				}
-				var templ_7745c5c3_Var22 = []any{"block " + healthQuotaBarKindClass(row.Kind, row.QuotaWarn)}
-				templ_7745c5c3_Err = templ.RenderCSSItems(ctx, templ_7745c5c3_Buffer, templ_7745c5c3_Var22...)
-				if templ_7745c5c3_Err != nil {
-					return templ_7745c5c3_Err
-				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 24, "<span class=\"")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 25, "<span class=\"flex items-center gap-2.5\"><span class=\"whitespace-nowrap font-mono text-xs text-sec tabular-nums\">")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
 				var templ_7745c5c3_Var23 string
-				templ_7745c5c3_Var23, templ_7745c5c3_Err = templ.JoinStringErrs(templ.CSSClasses(templ_7745c5c3_Var22).String())
+				templ_7745c5c3_Var23, templ_7745c5c3_Err = templ.JoinStringErrs(row.Quota)
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/health.templ`, Line: 1, Col: 0}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/health.templ`, Line: 83, Col: 89}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var23))
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 25, "\" style=\"")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 26, "</span> <span class=\"h-1 min-w-0 flex-1 overflow-hidden rounded-xs bg-line\">")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				var templ_7745c5c3_Var24 string
-				templ_7745c5c3_Var24, templ_7745c5c3_Err = templruntime.SanitizeStyleAttributeValues(fleetProgressStyle(row.QuotaPct))
-				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/health.templ`, Line: 81, Col: 123}
-				}
-				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var24))
+				var templ_7745c5c3_Var24 = []any{"block " + healthQuotaBarKindClass(row.Kind, row.QuotaWarn)}
+				templ_7745c5c3_Err = templ.RenderCSSItems(ctx, templ_7745c5c3_Buffer, templ_7745c5c3_Var24...)
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 26, "\"></span></span></span> ")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 27, "<span class=\"")
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+				var templ_7745c5c3_Var25 string
+				templ_7745c5c3_Var25, templ_7745c5c3_Err = templ.JoinStringErrs(templ.CSSClasses(templ_7745c5c3_Var24).String())
+				if templ_7745c5c3_Err != nil {
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/health.templ`, Line: 1, Col: 0}
+				}
+				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var25))
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 28, "\" style=\"")
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+				var templ_7745c5c3_Var26 string
+				templ_7745c5c3_Var26, templ_7745c5c3_Err = templruntime.SanitizeStyleAttributeValues(fleetProgressStyle(row.QuotaPct))
+				if templ_7745c5c3_Err != nil {
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/health.templ`, Line: 85, Col: 123}
+				}
+				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var26))
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 29, "\"></span></span></span> ")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
 			} else {
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 27, "<span class=\"text-xs text-dim\">—</span> ")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 30, "<span class=\"text-xs text-dim\">—</span> ")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 28, "<span class=\"text-right font-mono text-xs text-sec tabular-nums\">")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 31, "<span class=\"text-right font-mono text-xs text-sec tabular-nums\">")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -427,35 +460,35 @@ func HealthSnapshotV2(data DashboardData) templ.Component {
 					return templ_7745c5c3_Err
 				}
 			} else {
-				var templ_7745c5c3_Var25 string
-				templ_7745c5c3_Var25, templ_7745c5c3_Err = templ.JoinStringErrs(row.Resets)
+				var templ_7745c5c3_Var27 string
+				templ_7745c5c3_Var27, templ_7745c5c3_Err = templ.JoinStringErrs(row.Resets)
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/health.templ`, Line: 91, Col: 18}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/health.templ`, Line: 95, Col: 18}
 				}
-				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var25))
+				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var27))
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 29, "</span></div>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 32, "</span></div>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 30, "</div></div></section><p class=\"flex-none text-2xs text-dim\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 33, "</div></div></section><p class=\"flex-none text-2xs text-dim\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		var templ_7745c5c3_Var26 string
-		templ_7745c5c3_Var26, templ_7745c5c3_Err = templ.JoinStringErrs(view.Footnote)
+		var templ_7745c5c3_Var28 string
+		templ_7745c5c3_Var28, templ_7745c5c3_Err = templ.JoinStringErrs(view.Footnote)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/health.templ`, Line: 99, Col: 55}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/health.templ`, Line: 103, Col: 55}
 		}
-		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var26))
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var28))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 31, "</p>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 34, "</p>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}


### PR DESCRIPTION
## Summary

- add strict, unauthenticated Statuspage summary and unresolved-incident polling with cached provider-level deduplication
- keep provider data telemetry-only while enriching tracker outage health and board surfaces with incident names, components, phases, and shortlinks
- add GitHub and Linear defaults, a per-tracker override, generated config documentation, and table-driven regression coverage

Fixes #1870

## UI Surface Contract

- [x] N/A, or the linked issue explicitly authorizes any high-impact UI surface, layout, density, first-viewport, or responsive visibility tradeoff.
- [x] Persistent top-of-screen messaging is explicitly authorized by the issue, or this PR does not add it.
- [x] Visual changes to primary operator screens include screenshot or browser verification below.

The worker did not expose `mcp__chrome-devtools__navigate_page`. Rendered-template tests verify the Health incident phrase and shortlink, board data tests verify the corresponding banner row, and the current-head CI Browser Visual gate passed its full browser visual suite.

## Test Plan

- [x] `PATH="$PWD/.detent/tmp/go-bin:$PATH" make check` (project-pinned golangci-lint v2.1.6; 79.0% coverage)
- [x] `go test ./internal/statuspage ./internal/config ./internal/config/configdoc ./internal/telemetry ./internal/web/templates ./internal/cli`
- [x] live schema probe against GitHub Statuspage summary and unresolved-incident feeds
- [x] current-head CI run 32058823680 (all 11 jobs passed, including Browser Visual)