### PR TITLE
feat(resilience): model forge write outages

### DIFF
--- a/.detent/skills/isolated-go-ui-snapshot-preview.md
+++ b/.detent/skills/isolated-go-ui-snapshot-preview.md
@@ -1,0 +1,14 @@
+---
+name: isolated-go-ui-snapshot-preview
+description: Browser-verify a Go-rendered Detent UI state without modifying the live dogfood process or committing preview fixtures.
+when_to_use: Use when a UI condition needs a seeded telemetry snapshot that the running instance cannot safely reproduce.
+---
+
+# Isolated Go UI snapshot preview
+
+1. Put a temporary package test and Go overlay JSON under the Detent-provided temporary directory. Map a virtual `_test.go` path inside the target package to the temporary test file so the worktree stays unchanged.
+2. In the test, construct the real server dependencies, publish the required telemetry snapshot, and serve the real handler with `httptest.NewServer`. Print the random-port URL and wait for a temporary completion marker with a bounded deadline.
+3. Run only the overlay test in a managed terminal session. Open the printed URL with the worktree-aware Chrome DevTools MCP; never bind to or mutate the live port-4000 process.
+4. Inspect a semantic page snapshot before taking a viewport screenshot. Exercise expandable alerts and related health pages so both terse and detailed copy are verified.
+5. Close the Chrome page before creating the completion marker. Open SSE connections otherwise keep `httptest.Server.Close` blocked.
+6. Wait on the original test session and require a passing exit. Let Detent remove the temporary overlay, test, marker, and browser context after the worker exits.

--- a/internal/cli/runner.go
+++ b/internal/cli/runner.go
@@ -941,6 +941,7 @@ func mergeSnapshot(current, next telemetry.Snapshot) telemetry.Snapshot {
 	current.TrackerDrift.OpenTerminal = append(current.TrackerDrift.OpenTerminal, next.TrackerDrift.OpenTerminal...)
 	current.Budget.Refusals = append(current.Budget.Refusals, next.Budget.Refusals...)
 	current.TrackerUnavailable = append(current.TrackerUnavailable, next.TrackerUnavailable...)
+	current.ForgeUnavailable = append(current.ForgeUnavailable, next.ForgeUnavailable...)
 	current.CIUnavailable = append(current.CIUnavailable, next.CIUnavailable...)
 	current.BackendOutages = append(current.BackendOutages, next.BackendOutages...)
 	current.FailureBreakers = append(current.FailureBreakers, next.FailureBreakers...)
@@ -1378,6 +1379,11 @@ func stampSnapshotProjectID(snapshot telemetry.Snapshot) telemetry.Snapshot {
 	for i := range snapshot.TrackerUnavailable {
 		if strings.TrimSpace(snapshot.TrackerUnavailable[i].ProjectID) == "" {
 			snapshot.TrackerUnavailable[i].ProjectID = projectID
+		}
+	}
+	for i := range snapshot.ForgeUnavailable {
+		if strings.TrimSpace(snapshot.ForgeUnavailable[i].ProjectID) == "" {
+			snapshot.ForgeUnavailable[i].ProjectID = projectID
 		}
 	}
 	for i := range snapshot.FailureBreakers {

--- a/internal/forgeavailability/availability.go
+++ b/internal/forgeavailability/availability.go
@@ -1,0 +1,214 @@
+package forgeavailability
+
+import (
+	"errors"
+	"net/url"
+	"regexp"
+	"strings"
+)
+
+const (
+	Condition      = "forge_unavailable"
+	ClassServer    = "server"
+	ClassTimeout   = "timeout"
+	ClassTransport = "transport"
+)
+
+var (
+	ErrUnavailable = errors.New("forge unavailable")
+	httpStatusRE   = regexp.MustCompile(`(?i)(?:http(?:/\d(?:\.\d)?)?|status)[^0-9]{0,16}([1-5][0-9]{2})`)
+	urlHostRE      = regexp.MustCompile(`(?i)\b(?:https?|ssh|git)://([^/@\s]+@)?([^/:\s]+)`)
+	scpHostRE      = regexp.MustCompile(`(?i)\b(?:[^@\s]+@)([a-z0-9][a-z0-9.-]*):`)
+)
+
+type Scope struct {
+	Host      string `json:"host"`
+	Operation string `json:"operation"`
+}
+
+func (s Scope) Normalize() Scope {
+	s.Host = NormalizeHost(s.Host)
+	s.Operation = strings.ToLower(strings.TrimSpace(s.Operation))
+	return s
+}
+
+func (s Scope) Key() string {
+	return s.Normalize().Host
+}
+
+type Error struct {
+	Scope Scope
+	Class string
+	Err   error
+}
+
+func NewError(scope Scope, class string, err error) *Error {
+	return &Error{
+		Scope: scope.Normalize(),
+		Class: strings.ToLower(strings.TrimSpace(class)),
+		Err:   err,
+	}
+}
+
+func (e *Error) Error() string {
+	if e == nil {
+		return ErrUnavailable.Error()
+	}
+	host := e.Scope.Host
+	if host == "" {
+		host = "configured"
+	}
+	message := "forge " + host + " unavailable (" + Condition
+	if e.Class != "" {
+		message += "/" + e.Class
+	}
+	message += ")"
+	if e.Err != nil {
+		message += ": " + e.Err.Error()
+	}
+	return message
+}
+
+func (e *Error) Unwrap() error {
+	if e == nil {
+		return nil
+	}
+	return e.Err
+}
+
+func (e *Error) Is(target error) bool {
+	return target == ErrUnavailable
+}
+
+func As(err error) (*Error, bool) {
+	var availabilityErr *Error
+	if !errors.As(err, &availabilityErr) || availabilityErr == nil {
+		return nil, false
+	}
+	return availabilityErr, true
+}
+
+func Classify(operation string, detail string) (string, bool) {
+	operation = strings.ToLower(strings.TrimSpace(operation))
+	detail = strings.ToLower(strings.TrimSpace(detail))
+	if !WriteOperation(operation) || detail == "" {
+		return "", false
+	}
+	for _, excluded := range []string{
+		"http 401", "http 403", "http 429", "status 401", "status 403", "status 429",
+		"non-fast-forward", "protected branch", "pre-receive hook declined", "hook declined",
+		"remote rejected", "[rejected]", "permission denied (publickey)", "authentication failed",
+		"repository not found",
+	} {
+		if strings.Contains(detail, excluded) {
+			return "", false
+		}
+	}
+	for _, match := range httpStatusRE.FindAllStringSubmatch(detail, -1) {
+		if len(match) == 2 && strings.HasPrefix(match[1], "5") {
+			return ClassServer, true
+		}
+		if len(match) == 2 && (match[1] == "401" || match[1] == "403" || match[1] == "429") {
+			return "", false
+		}
+	}
+	for _, timeout := range []string{
+		"context deadline exceeded", "operation timed out", "operation timeout", "i/o timeout",
+		"connection timed out", "connection timeout", "tls handshake timeout", "timeout awaiting response",
+	} {
+		if strings.Contains(detail, timeout) {
+			return ClassTimeout, true
+		}
+	}
+	for _, transport := range []string{
+		"could not resolve host", "temporary failure in name resolution", "name or service not known",
+		"no such host", "network is unreachable", "connection refused", "connection reset by peer",
+		"failed to connect", "tls handshake", "ssl connect error", "certificate verify failed",
+		"remote end hung up unexpectedly", "unexpected disconnect", "early eof",
+		"kex_exchange_identification: connection closed", "connection closed by remote host",
+	} {
+		if strings.Contains(detail, transport) {
+			return ClassTransport, true
+		}
+	}
+	return "", false
+}
+
+func ProvesReachability(operation string, detail string) bool {
+	if !WriteOperation(operation) {
+		return false
+	}
+	detail = strings.ToLower(strings.TrimSpace(detail))
+	for _, match := range httpStatusRE.FindAllStringSubmatch(detail, -1) {
+		if len(match) == 2 && !strings.HasPrefix(match[1], "5") {
+			return true
+		}
+	}
+	for _, evidence := range []string{
+		"non-fast-forward", "protected branch", "pre-receive hook declined", "hook declined",
+		"remote rejected", "[rejected]", "permission denied (publickey)", "authentication failed",
+		"repository not found",
+	} {
+		if strings.Contains(detail, evidence) {
+			return true
+		}
+	}
+	return false
+}
+
+func WriteOperation(operation string) bool {
+	operation = strings.ToLower(strings.TrimSpace(operation))
+	if strings.Contains(operation, "ci-trigger-label") {
+		return false
+	}
+	if strings.Contains(operation, "git push") || strings.Contains(operation, "git fetch") || strings.HasPrefix(operation, "push") {
+		return true
+	}
+	if strings.Contains(operation, "create_pull_request") || strings.Contains(operation, "update_pull_request") || strings.Contains(operation, "edit_pull_request") {
+		return true
+	}
+	for _, command := range []string{"gh pr create", "gh pr edit", "gh pr ready"} {
+		if strings.Contains(operation, command) {
+			return true
+		}
+	}
+	return strings.Contains(operation, "gh api") && strings.Contains(operation, "/pulls")
+}
+
+func HostFromText(value string) string {
+	if match := urlHostRE.FindStringSubmatch(value); len(match) == 3 {
+		return NormalizeHost(match[2])
+	}
+	if match := scpHostRE.FindStringSubmatch(value); len(match) == 2 {
+		return NormalizeHost(match[1])
+	}
+	return ""
+}
+
+func HostFromEndpoint(endpoint string) string {
+	endpoint = strings.TrimSpace(endpoint)
+	if endpoint == "" {
+		return ""
+	}
+	parsed, err := url.Parse(endpoint)
+	if err != nil || parsed.Hostname() == "" {
+		return NormalizeHost(endpoint)
+	}
+	host := NormalizeHost(parsed.Hostname())
+	if host == "api.github.com" {
+		return "github.com"
+	}
+	return host
+}
+
+func NormalizeHost(host string) string {
+	host = strings.ToLower(strings.TrimSpace(host))
+	host = strings.TrimSuffix(host, ".")
+	if strings.Contains(host, "://") {
+		return HostFromEndpoint(host)
+	}
+	if parsed, err := url.Parse("//" + host); err == nil && parsed.Hostname() != "" {
+		host = strings.ToLower(parsed.Hostname())
+	}
+	return host
+}

--- a/internal/forgeavailability/availability_test.go
+++ b/internal/forgeavailability/availability_test.go
@@ -1,0 +1,89 @@
+package forgeavailability
+
+import "testing"
+
+func TestClassify(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		operation string
+		detail    string
+		wantClass string
+		want      bool
+	}{
+		{name: "git HTTP 503", operation: "git push", detail: "fatal: unable to access repository: HTTP 503", wantClass: ClassServer, want: true},
+		{name: "git timeout", operation: "git push", detail: "ssh: connect to host github.com port 22: Operation timed out", wantClass: ClassTimeout, want: true},
+		{name: "git DNS", operation: "git push", detail: "ssh: Could not resolve hostname github.com: no such host\nfatal: Could not read from remote repository.", wantClass: ClassTransport, want: true},
+		{name: "git fetch server error", operation: "git fetch", detail: "remote: HTTP 503 Service Unavailable", wantClass: ClassServer, want: true},
+		{name: "pull request server error", operation: "codex_apps/github.create_pull_request", detail: `{"status":502,"message":"unavailable"}`, wantClass: ClassServer, want: true},
+		{name: "non fast forward", operation: "git push", detail: "[rejected] main -> main (non-fast-forward)"},
+		{name: "protected branch", operation: "git push", detail: "remote: protected branch hook declined"},
+		{name: "forbidden", operation: "git push", detail: "HTTP 403: forbidden"},
+		{name: "credential capacity", operation: "gh pr create", detail: "HTTP 429: too many requests"},
+		{name: "lookup is not a write", operation: "codex_apps/github.search_issues", detail: "HTTP 503"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			gotClass, got := Classify(tt.operation, tt.detail)
+			if got != tt.want || gotClass != tt.wantClass {
+				t.Fatalf("Classify() = %q, %v, want %q, %v", gotClass, got, tt.wantClass, tt.want)
+			}
+		})
+	}
+}
+
+func TestProvesReachability(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		operation string
+		detail    string
+		want      bool
+	}{
+		{name: "non fast forward", operation: "git push", detail: "[rejected] feature -> feature (non-fast-forward)", want: true},
+		{name: "forbidden", operation: "git push", detail: "HTTP 403: forbidden", want: true},
+		{name: "rate limited", operation: "gh pr create", detail: "HTTP 429: too many requests", want: true},
+		{name: "server unavailable", operation: "git push", detail: "HTTP 503: unavailable"},
+		{name: "transport failure", operation: "git push", detail: "Could not resolve host: github.com"},
+		{name: "ambiguous failure", operation: "git push", detail: "command exited with status 1"},
+		{name: "read response", operation: "search issues", detail: "HTTP 403: forbidden"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := ProvesReachability(tt.operation, tt.detail); got != tt.want {
+				t.Fatalf("ProvesReachability() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestHostNormalization(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		value string
+		call  func(string) string
+		want  string
+	}{
+		{name: "GitHub API endpoint", value: "https://api.github.com/graphql", call: HostFromEndpoint, want: "github.com"},
+		{name: "enterprise endpoint", value: "https://forge.example.com/api/graphql", call: HostFromEndpoint, want: "forge.example.com"},
+		{name: "HTTPS remote", value: "fatal: unable to access https://github.com/acme/widgets.git", call: HostFromText, want: "github.com"},
+		{name: "SSH remote", value: "git@forge.example.com:acme/widgets.git", call: HostFromText, want: "forge.example.com"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := tt.call(tt.value); got != tt.want {
+				t.Fatalf("host = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/healthnotify/manager.go
+++ b/internal/healthnotify/manager.go
@@ -61,6 +61,7 @@ type Event struct {
 	Causes                  []string                     `json:"causes,omitempty"`
 	WaitReasons             []string                     `json:"wait_reasons,omitempty"`
 	TrackerConditions       []telemetry.TrackerCondition `json:"tracker_unavailable,omitempty"`
+	ForgeConditions         []telemetry.ForgeCondition   `json:"forge_unavailable,omitempty"`
 	FailureBreakers         []telemetry.FailureBreaker   `json:"failure_breakers,omitempty"`
 	BackendOutages          []telemetry.BackendOutage    `json:"backend_outages,omitempty"`
 	RefreshFailures         []telemetry.RefreshFailure   `json:"refresh_failures,omitempty"`
@@ -104,6 +105,7 @@ type durableState struct {
 	Causes                  []string                     `json:"causes,omitempty"`
 	WaitReasons             []string                     `json:"wait_reasons,omitempty"`
 	TrackerConditions       []telemetry.TrackerCondition `json:"tracker_unavailable,omitempty"`
+	ForgeConditions         []telemetry.ForgeCondition   `json:"forge_unavailable,omitempty"`
 	FailureBreakers         []telemetry.FailureBreaker   `json:"failure_breakers,omitempty"`
 	BackendOutages          []telemetry.BackendOutage    `json:"backend_outages,omitempty"`
 	RefreshFailures         []telemetry.RefreshFailure   `json:"refresh_failures,omitempty"`
@@ -116,6 +118,7 @@ type pendingState struct {
 	Causes            []string                     `json:"causes,omitempty"`
 	WaitReasons       []string                     `json:"wait_reasons,omitempty"`
 	TrackerConditions []telemetry.TrackerCondition `json:"tracker_unavailable,omitempty"`
+	ForgeConditions   []telemetry.ForgeCondition   `json:"forge_unavailable,omitempty"`
 	FailureBreakers   []telemetry.FailureBreaker   `json:"failure_breakers,omitempty"`
 	BackendOutages    []telemetry.BackendOutage    `json:"backend_outages,omitempty"`
 	RefreshFailures   []telemetry.RefreshFailure   `json:"refresh_failures,omitempty"`
@@ -308,6 +311,7 @@ func (m *Manager) applyObservation(state *durableState, current observation, now
 			Causes:            compactSorted(current.Causes),
 			WaitReasons:       compactSorted(current.WaitReasons),
 			TrackerConditions: append([]telemetry.TrackerCondition(nil), current.TrackerConditions...),
+			ForgeConditions:   append([]telemetry.ForgeCondition(nil), current.ForgeConditions...),
 			FailureBreakers:   append([]telemetry.FailureBreaker(nil), current.FailureBreakers...),
 			BackendOutages:    append([]telemetry.BackendOutage(nil), current.BackendOutages...),
 			RefreshFailures:   append([]telemetry.RefreshFailure(nil), current.RefreshFailures...),
@@ -319,6 +323,7 @@ func (m *Manager) applyObservation(state *durableState, current observation, now
 	waitReasons := compactSorted(current.WaitReasons)
 	if state.Pending.State != current.State || !slices.Equal(state.Pending.Causes, causes) || !slices.Equal(state.Pending.WaitReasons, waitReasons) ||
 		!reflect.DeepEqual(state.Pending.TrackerConditions, current.TrackerConditions) ||
+		!reflect.DeepEqual(state.Pending.ForgeConditions, current.ForgeConditions) ||
 		!reflect.DeepEqual(state.Pending.FailureBreakers, current.FailureBreakers) || !reflect.DeepEqual(state.Pending.BackendOutages, current.BackendOutages) ||
 		!reflect.DeepEqual(state.Pending.RefreshFailures, current.RefreshFailures) {
 		changed = true
@@ -326,6 +331,7 @@ func (m *Manager) applyObservation(state *durableState, current observation, now
 		state.Pending.Causes = causes
 		state.Pending.WaitReasons = waitReasons
 		state.Pending.TrackerConditions = append([]telemetry.TrackerCondition(nil), current.TrackerConditions...)
+		state.Pending.ForgeConditions = append([]telemetry.ForgeCondition(nil), current.ForgeConditions...)
 		state.Pending.FailureBreakers = append([]telemetry.FailureBreaker(nil), current.FailureBreakers...)
 		state.Pending.BackendOutages = append([]telemetry.BackendOutage(nil), current.BackendOutages...)
 		state.Pending.RefreshFailures = append([]telemetry.RefreshFailure(nil), current.RefreshFailures...)
@@ -341,6 +347,7 @@ func (m *Manager) applyObservation(state *durableState, current observation, now
 		state.Causes = append([]string(nil), pending.Causes...)
 		state.WaitReasons = append([]string(nil), pending.WaitReasons...)
 		state.TrackerConditions = append([]telemetry.TrackerCondition(nil), pending.TrackerConditions...)
+		state.ForgeConditions = append([]telemetry.ForgeCondition(nil), pending.ForgeConditions...)
 		state.FailureBreakers = append([]telemetry.FailureBreaker(nil), pending.FailureBreakers...)
 		state.BackendOutages = append([]telemetry.BackendOutage(nil), pending.BackendOutages...)
 		state.RefreshFailures = append([]telemetry.RefreshFailure(nil), pending.RefreshFailures...)
@@ -352,6 +359,7 @@ func (m *Manager) applyObservation(state *durableState, current observation, now
 	state.Causes = nil
 	state.WaitReasons = nil
 	state.TrackerConditions = nil
+	state.ForgeConditions = nil
 	state.FailureBreakers = nil
 	state.BackendOutages = nil
 	state.RefreshFailures = nil
@@ -373,6 +381,7 @@ func (m *Manager) event(state *durableState, transition string, enteredState str
 		Causes:                  append([]string(nil), state.Causes...),
 		WaitReasons:             append([]string(nil), state.WaitReasons...),
 		TrackerConditions:       append([]telemetry.TrackerCondition(nil), state.TrackerConditions...),
+		ForgeConditions:         append([]telemetry.ForgeCondition(nil), state.ForgeConditions...),
 		FailureBreakers:         append([]telemetry.FailureBreaker(nil), state.FailureBreakers...),
 		BackendOutages:          append([]telemetry.BackendOutage(nil), state.BackendOutages...),
 		RefreshFailures:         append([]telemetry.RefreshFailure(nil), state.RefreshFailures...),

--- a/internal/healthnotify/manager_test.go
+++ b/internal/healthnotify/manager_test.go
@@ -67,6 +67,7 @@ func TestManagerEntryPayloadsFireOncePerIdentity(t *testing.T) {
 		cause           string
 		wantWaitReasons []string
 		wantTracker     bool
+		wantForge       bool
 	}{
 		{
 			name: "dispatch payload carries wait reason",
@@ -83,6 +84,14 @@ func TestManagerEntryPayloadsFireOncePerIdentity(t *testing.T) {
 			}}},
 			cause:       CauseTrackerUnavailable,
 			wantTracker: true,
+		},
+		{
+			name: "forge payload carries scoped condition",
+			snapshot: telemetry.Snapshot{ForgeUnavailable: []telemetry.ForgeCondition{{
+				ProjectID: "detent", Host: "github.com", Operation: "git push", ErrorClass: "server",
+			}}},
+			cause:     CauseForgeUnavailable,
+			wantForge: true,
 		},
 		{
 			name:     "CI payload omits wait reason",
@@ -127,6 +136,9 @@ func TestManagerEntryPayloadsFireOncePerIdentity(t *testing.T) {
 				}
 				if got := len(event.TrackerConditions) > 0; got != tt.wantTracker {
 					t.Fatalf("TrackerConditions = %#v, want present %v", event.TrackerConditions, tt.wantTracker)
+				}
+				if got := len(event.ForgeConditions) > 0; got != tt.wantForge {
+					t.Fatalf("ForgeConditions = %#v, want present %v", event.ForgeConditions, tt.wantForge)
 				}
 			}
 		})

--- a/internal/healthnotify/observations.go
+++ b/internal/healthnotify/observations.go
@@ -13,6 +13,7 @@ const (
 	ScopeFleet                   = "fleet"
 	ScopeProject                 = "project"
 	CauseTrackerUnavailable      = "tracker_unavailable"
+	CauseForgeUnavailable        = "forge_unavailable"
 	CauseCIUnavailable           = "ci_unavailable"
 	CauseDispatchStall           = "dispatch_stall"
 	CauseProjectFailureBreaker   = "project_failure_breaker"
@@ -35,6 +36,7 @@ type observation struct {
 	Causes            []string
 	WaitReasons       []string
 	TrackerConditions []telemetry.TrackerCondition
+	ForgeConditions   []telemetry.ForgeCondition
 	FailureBreakers   []telemetry.FailureBreaker
 	BackendOutages    []telemetry.BackendOutage
 	RefreshFailures   []telemetry.RefreshFailure
@@ -51,6 +53,7 @@ func observations(snapshot telemetry.Snapshot, health []project.Health) []observ
 	}
 	projectCauses := map[string]map[string][]string{}
 	projectTrackerConditions := map[string][]telemetry.TrackerCondition{}
+	projectForgeConditions := map[string][]telemetry.ForgeCondition{}
 	projectBreakers := map[string][]telemetry.FailureBreaker{}
 	projectOutages := map[string][]telemetry.BackendOutage{}
 	projectRefreshFailures := map[string][]telemetry.RefreshFailure{}
@@ -67,6 +70,18 @@ func observations(snapshot telemetry.Snapshot, health []project.Health) []observ
 		projectCauses[projectID][CauseTrackerUnavailable] = nil
 		projectTrackerConditions[projectID] = append(projectTrackerConditions[projectID], condition)
 		fleetCauses = append(fleetCauses, CauseTrackerUnavailable)
+	}
+	for _, condition := range snapshot.ForgeUnavailable {
+		projectID := strings.TrimSpace(condition.ProjectID)
+		if projectID == "" {
+			continue
+		}
+		if projectCauses[projectID] == nil {
+			projectCauses[projectID] = map[string][]string{}
+		}
+		projectCauses[projectID][CauseForgeUnavailable] = nil
+		projectForgeConditions[projectID] = append(projectForgeConditions[projectID], condition)
+		fleetCauses = append(fleetCauses, CauseForgeUnavailable)
 	}
 	for _, stall := range snapshot.DispatchStalls {
 		if !stall.Stalled {
@@ -151,7 +166,7 @@ func observations(snapshot telemetry.Snapshot, health []project.Health) []observ
 		if recoveryState == "" {
 			recoveryState = unknownProjectRecoveryStatus
 		}
-		for _, cause := range []string{CauseTrackerUnavailable, CauseCIUnavailable, CauseDispatchStall, CauseProjectFailureBreaker, CauseBackendCapacity, CauseRefreshFailure} {
+		for _, cause := range []string{CauseTrackerUnavailable, CauseForgeUnavailable, CauseCIUnavailable, CauseDispatchStall, CauseProjectFailureBreaker, CauseBackendCapacity, CauseRefreshFailure} {
 			waitReasons, active := projectCauses[projectID][cause]
 			state := recoveryState
 			causes := []string(nil)
@@ -172,6 +187,7 @@ func observations(snapshot telemetry.Snapshot, health []project.Health) []observ
 				Causes:            causes,
 				WaitReasons:       compactSorted(waitReasons),
 				TrackerConditions: append([]telemetry.TrackerCondition(nil), projectTrackerConditions[projectID]...),
+				ForgeConditions:   append([]telemetry.ForgeCondition(nil), projectForgeConditions[projectID]...),
 				FailureBreakers:   append([]telemetry.FailureBreaker(nil), projectBreakers[projectID]...),
 				BackendOutages:    append([]telemetry.BackendOutage(nil), projectOutages[projectID]...),
 				RefreshFailures:   refreshFailures,
@@ -194,6 +210,7 @@ func observations(snapshot telemetry.Snapshot, health []project.Health) []observ
 		Causes:            fleetCauses,
 		WaitReasons:       compactSorted(fleetWaitReasons),
 		TrackerConditions: append([]telemetry.TrackerCondition(nil), snapshot.TrackerUnavailable...),
+		ForgeConditions:   append([]telemetry.ForgeCondition(nil), snapshot.ForgeUnavailable...),
 		FailureBreakers:   append([]telemetry.FailureBreaker(nil), snapshot.FailureBreakers...),
 		BackendOutages:    append([]telemetry.BackendOutage(nil), snapshot.BackendOutages...),
 		RefreshFailures:   append([]telemetry.RefreshFailure(nil), snapshot.RefreshFailures()...),

--- a/internal/operatortool/executor.go
+++ b/internal/operatortool/executor.go
@@ -117,6 +117,7 @@ func (e *Executor) fleetHealth(ctx context.Context, raw json.RawMessage) (Result
 		Counts:             snapshot.Counts,
 		RateLimits:         boundedRateLimits(snapshot.RateLimits),
 		TrackerUnavailable: boundedClone(snapshot.TrackerUnavailable, MaxItemLimit),
+		ForgeUnavailable:   boundedClone(snapshot.ForgeUnavailable, MaxItemLimit),
 		BackendOutages:     boundedClone(snapshot.BackendOutages, MaxItemLimit),
 		FailureBreakers:    boundedClone(snapshot.FailureBreakers, MaxItemLimit),
 		DispatchRecoveries: boundedClone(snapshot.DispatchRecoveries, MaxItemLimit),
@@ -352,6 +353,7 @@ type FleetHealthResult struct {
 	Counts             telemetry.Counts             `json:"counts"`
 	RateLimits         *telemetry.RateLimits        `json:"rate_limits"`
 	TrackerUnavailable []telemetry.TrackerCondition `json:"tracker_unavailable"`
+	ForgeUnavailable   []telemetry.ForgeCondition   `json:"forge_unavailable"`
 	BackendOutages     []telemetry.BackendOutage    `json:"backend_outages"`
 	FailureBreakers    []telemetry.FailureBreaker   `json:"failure_breakers"`
 	DispatchRecoveries []telemetry.DispatchRecovery `json:"dispatch_recoveries"`

--- a/internal/orchestrator/config.go
+++ b/internal/orchestrator/config.go
@@ -8,6 +8,7 @@ import (
 	workflowconfig "github.com/digitaldrywood/detent/internal/config"
 	"github.com/digitaldrywood/detent/internal/connector"
 	"github.com/digitaldrywood/detent/internal/efficiency"
+	"github.com/digitaldrywood/detent/internal/forgeavailability"
 	"github.com/digitaldrywood/detent/internal/gate"
 	"github.com/digitaldrywood/detent/internal/selector"
 	"github.com/digitaldrywood/detent/internal/staleness"
@@ -112,6 +113,7 @@ func ConfigFromWorkflow(cfg workflowconfig.Config) Config {
 		GitHubGraphQLWarnRemaining:    int64(cfg.Tracker.GitHubGraphQLWarnRemaining),
 		GitHubGraphQLMinReserve:       int64(cfg.Tracker.GitHubGraphQLMinReserve),
 		GitHubRESTMinReserve:          int64(cfg.Tracker.GitHubRESTMinReserve),
+		ForgeHost:                     forgeavailability.HostFromEndpoint(cfg.Tracker.Endpoint),
 		OutputTruncationMaxBytes:      cfg.Agent.OutputTruncation.MaxBytes,
 		Lessons: LessonCaptureConfig{
 			Path:       cfg.Agent.Lessons.Path,
@@ -155,6 +157,7 @@ func stalenessConfigFromWorkflow(cfg workflowconfig.StalenessObservability, term
 }
 
 func normalizeConfig(cfg Config) Config {
+	cfg.ForgeHost = forgeavailability.NormalizeHost(cfg.ForgeHost)
 	cfg.BillingMode = strings.ToLower(strings.TrimSpace(cfg.BillingMode))
 	if cfg.BillingMode == "" {
 		cfg.BillingMode = workflowconfig.BillingModeSubscription

--- a/internal/orchestrator/dispatch.go
+++ b/internal/orchestrator/dispatch.go
@@ -165,11 +165,15 @@ func (o *Orchestrator) dispatchReadyIssues(ctx context.Context, state *State, is
 			return !mergeWorkerIssue(issue) || lastDispatchFailure != dispatchIssueFailureGlobalSlotUnavailable
 		},
 		retryDispatchFailed: func(issue connector.Issue, retry Retry) {
+			releaseForgeAvailabilityProbe(state, issue.ID, "deferred", dispatchFailureRetryReason(lastDispatchFailure), now)
 			planner.scheduleRetry(state, issue, retry.Attempt, now, dispatchFailureRetryReason(lastDispatchFailure), false, retry.WorkerHost)
 			rescheduled := state.Retry[issue.ID]
 			rescheduled.RetryMode = retry.RetryMode
 			rescheduled.ResumeState = retry.ResumeState
 			rescheduled.MergePrecheck = cloneMergePrecheck(retry.MergePrecheck)
+			rescheduled.ForgeUnavailable = retry.ForgeUnavailable
+			rescheduled.ForgeHost = retry.ForgeHost
+			rescheduled.ForgeRetry = cloneForgeRetry(retry.ForgeRetry)
 			state.Retry[issue.ID] = rescheduled
 		},
 		pollRetryWait: func(issue connector.Issue, retry Retry) (Retry, bool, string) {
@@ -300,6 +304,7 @@ const (
 	dispatchIssueFailureBackendCapacityPaused = "backend_capacity_paused"
 	dispatchIssueFailureGitHubRESTPaused      = "github_rest_capacity_paused"
 	dispatchIssueFailureTrackerUnavailable    = "tracker_unavailable"
+	dispatchIssueFailureForgeUnavailable      = "forge_unavailable"
 	dispatchIssueFailureCIUnavailable         = "ci_unavailable"
 	dispatchIssueFailureRecoveryRamp          = "dispatch_recovery_ramp"
 )
@@ -378,11 +383,19 @@ func (o *Orchestrator) dispatchIssueWithAdmission(
 	if _, deferred := state.deferredCompletions[issue.ID]; deferred {
 		return dispatchIssueOutcome{reason: dispatchSkipCompletionDeferred}
 	}
+	queuedRetry, retryQueued := state.Retry[issue.ID]
+	if retryState != nil {
+		queuedRetry = *retryState
+		retryQueued = true
+	}
 	if activeTrackerUnavailable(state) && (trackerDependentDispatch(issue) || trackerUnavailableRetry(state, issue.ID)) {
 		return dispatchIssueOutcome{reason: dispatchIssueFailureTrackerUnavailable}
 	}
 	if activeCIUnavailable(state) && (ciDependentDispatch(issue) || ciUnavailableRetry(state, issue.ID)) {
 		return dispatchIssueOutcome{reason: dispatchIssueFailureCIUnavailable}
+	}
+	if forgeAvailabilityBlocks(state, issue, queuedRetry, o.cfg.ForgeHost, now) {
+		return dispatchIssueOutcome{reason: dispatchIssueFailureForgeUnavailable}
 	}
 	if _, paused := activeGitHubRESTCapacityOutage(state, now); paused {
 		return dispatchIssueOutcome{reason: dispatchIssueFailureGitHubRESTPaused}
@@ -392,11 +405,6 @@ func (o *Orchestrator) dispatchIssueWithAdmission(
 	}
 	if reason := dispatchRecoveryBlockReason(state, now); reason != "" {
 		return dispatchIssueOutcome{reason: reason}
-	}
-	queuedRetry, retryQueued := state.Retry[issue.ID]
-	if retryState != nil {
-		queuedRetry = *retryState
-		retryQueued = true
 	}
 	runMode := o.dispatchMode(ctx, state, issue)
 	capacityRequest := runpkg.RunRequest{Issue: issue, Mode: runMode, SelectorContext: o.selectorContext()}
@@ -635,6 +643,7 @@ func (o *Orchestrator) dispatchIssueWithAdmission(
 		WorkerHost:          workerHost,
 		CapacityScope:       capacityScope,
 		CapacityProbe:       capacityProbeKey != "",
+		ForgeProbeHost:      reservedForgeProbeHost(state, issue.ID),
 		ModelPermitExempt:   !modelPermitRequired,
 		StopDestination:     o.cfg.StopRunTargetState,
 		StopPriorityOptions: stopRunPriorityOptions(o.cfg.StopRunPriorityNames),
@@ -668,6 +677,7 @@ func (o *Orchestrator) dispatchIssueWithAdmission(
 		OnOverrideRejected:  o.agentOverrideRejectionHandler(runCtx, issue),
 		ProgressProbe:       o.sessionProgressProbe(issue),
 		MergePrecheck:       cloneMergePrecheck(queuedRetry.MergePrecheck),
+		ForgeRetry:          cloneForgeRetry(queuedRetry.ForgeRetry),
 	}
 	if !modelPermitRequired {
 		request.AcquireModelPermit = o.modelPermitAcquirer(issue.ID)

--- a/internal/orchestrator/dispatch_planner.go
+++ b/internal/orchestrator/dispatch_planner.go
@@ -265,6 +265,9 @@ func (p dispatchPlanner) retryAction(
 	if activeCIUnavailable(state) && (ciDependentDispatch(issue) || retry.CIUnavailable) {
 		return dispatchAction{}, false, dispatchSkipCIUnavailable
 	}
+	if forgeAvailabilityBlocks(state, issue, retry, p.cfg.ForgeHost, now) {
+		return dispatchAction{}, false, dispatchSkipForgeUnavailable
+	}
 	if outage, paused := activeGitHubRESTCapacityOutage(state, now); paused {
 		if retry.DueAt.Before(outage.ResumeAt) {
 			retry.DueAt = outage.ResumeAt
@@ -274,6 +277,15 @@ func (p dispatchPlanner) retryAction(
 	}
 	if reason := dispatchRecoveryBlockReason(state, now); reason != "" {
 		return dispatchAction{}, false, reason
+	}
+	forgeProbeReserved := false
+	if retry.ForgeUnavailable {
+		if _, active := forgeCondition(state, retry.ForgeHost); active {
+			_, forgeProbeReserved = reserveForgeAvailabilityProbe(state, issue.ID, retry, now)
+			if !forgeProbeReserved {
+				return dispatchAction{}, false, dispatchSkipForgeUnavailable
+			}
+		}
 	}
 	delete(state.Retry, retry.Issue.ID)
 
@@ -287,6 +299,9 @@ func (p dispatchPlanner) retryAction(
 		modelPermitRequired,
 	)
 	if !decision.dispatchable {
+		if forgeProbeReserved {
+			releaseForgeAvailabilityProbe(state, issue.ID, "deferred", decision.reason, now)
+		}
 		if decision.reason == dispatchSkipProjectFailureBreaker {
 			if retry.DueAt.Before(state.FailureBreaker.ResumeAt) {
 				retry.DueAt = state.FailureBreaker.ResumeAt
@@ -317,6 +332,9 @@ func (p dispatchPlanner) retryAction(
 
 	action, ok := p.newDispatchAction(state, issue, retry.Attempt, retry.WorkerHost, true, modelPermitRequired, &retry)
 	if !ok {
+		if forgeProbeReserved {
+			releaseForgeAvailabilityProbe(state, issue.ID, "deferred", dispatchSkipWorkerHostUnavailable, now)
+		}
 		return dispatchAction{}, false, dispatchSkipWorkerHostUnavailable
 	}
 	return action, true, ""
@@ -581,6 +599,7 @@ const (
 	dispatchSkipGitHubRESTCapacity        = "github_rest_capacity_paused"
 	dispatchSkipTrackerUnavailable        = "tracker_unavailable"
 	dispatchSkipCompletionDeferred        = "completion_deferred"
+	dispatchSkipForgeUnavailable          = "forge_unavailable"
 	dispatchSkipCIUnavailable             = "ci_unavailable"
 	dispatchSkipProjectFailureBreaker     = projectFailureBreakerDispatchPaused
 	dispatchSkipRateWindowBackpressure    = "provider_rate_window_backpressure"
@@ -644,6 +663,9 @@ func (p dispatchPlanner) dispatchableIssueDecisionForModelRequirement(
 	}
 	if activeTrackerUnavailable(state) && trackerDependentDispatch(issue) {
 		return dispatchableDecision{reason: dispatchSkipTrackerUnavailable}
+	}
+	if forgeAvailabilityBlocks(state, issue, Retry{}, p.cfg.ForgeHost, now) {
+		return dispatchableDecision{reason: dispatchSkipForgeUnavailable}
 	}
 	if activeCIUnavailable(state) && ciDependentDispatch(issue) {
 		return dispatchableDecision{reason: dispatchSkipCIUnavailable}

--- a/internal/orchestrator/dispatch_recovery.go
+++ b/internal/orchestrator/dispatch_recovery.go
@@ -13,6 +13,7 @@ const (
 	dispatchRecoveryPullRequestHydration  = "pull_request_hydration"
 	dispatchRecoveryBackendCapacity       = "backend_capacity"
 	dispatchRecoveryTrackerUnavailable    = connector.TrackerUnavailableCondition
+	dispatchRecoveryForgeUnavailable      = "forge_unavailable"
 	dispatchRecoveryProjectFailureBreaker = "project_failure_breaker"
 	dispatchRecoveryStatusWaiting         = "waiting"
 	dispatchRecoveryStatusRamping         = "ramping"

--- a/internal/orchestrator/forge_availability.go
+++ b/internal/orchestrator/forge_availability.go
@@ -1,0 +1,543 @@
+package orchestrator
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log/slog"
+	"strings"
+	"time"
+
+	"github.com/digitaldrywood/detent/internal/connector"
+	"github.com/digitaldrywood/detent/internal/forgeavailability"
+	runpkg "github.com/digitaldrywood/detent/internal/runner"
+	"github.com/digitaldrywood/detent/internal/store"
+	"github.com/digitaldrywood/detent/internal/telemetry"
+)
+
+const forgeUnavailableErrorClass = forgeavailability.Condition
+
+type ForgeCondition = telemetry.ForgeCondition
+
+type forgeWaitMetadata struct {
+	Host              string    `json:"host"`
+	Operation         string    `json:"operation"`
+	Branch            string    `json:"branch,omitempty"`
+	WorkProductPushed bool      `json:"work_product_pushed,omitempty"`
+	ErrorClass        string    `json:"error_class"`
+	DetectedAt        time.Time `json:"detected_at"`
+	NextProbeAt       time.Time `json:"next_probe_at"`
+}
+
+func (o *Orchestrator) registerForgeUnavailable(state *State, availabilityErr *forgeavailability.Error, running Running, observedAt time.Time) ForgeCondition {
+	if state == nil || availabilityErr == nil {
+		return ForgeCondition{}
+	}
+	if observedAt.IsZero() {
+		observedAt = o.clockNow()
+	}
+	observedAt = observedAt.UTC()
+	if state.ForgeUnavailable == nil {
+		state.ForgeUnavailable = map[string]ForgeCondition{}
+	}
+	scope := availabilityErr.Scope.Normalize()
+	if scope.Host == "" {
+		scope.Host = forgeavailability.NormalizeHost(o.cfg.ForgeHost)
+	}
+	key := scope.Key()
+	condition, exists := state.ForgeUnavailable[key]
+	if !exists {
+		condition = ForgeCondition{
+			ProjectID:  strings.TrimSpace(o.cfg.Project.ID),
+			Host:       scope.Host,
+			DetectedAt: observedAt,
+		}
+	}
+	condition.Operation = scope.Operation
+	condition.ErrorClass = strings.TrimSpace(availabilityErr.Class)
+	condition.LastObservedAt = observedAt
+	condition.LastError = strings.TrimSpace(availabilityErr.Error())
+	if condition.ProbeIssueID == running.Issue.ID {
+		condition.ProbeIssueID = ""
+		condition.LastProbeAt = observedAt
+		condition.LastProbeResult = "failed"
+		condition.LastProbeDetail = condition.LastError
+	}
+	condition.NextProbeAt = backendCapacityBoundedProbeAt(
+		time.Time{},
+		observedAt.Add(backendCapacityProbeDelayForAttempt(condition.ProbeAttempts)),
+		observedAt,
+	)
+	state.ForgeUnavailable[key] = condition
+	if !exists {
+		recordStateEvent(state, telemetry.ActivityEvent{At: observedAt, Event: forgeavailability.Condition, Message: forgeUnavailableStatusMessage(condition)})
+		telemetry.LogLifecycleMessage(o.logger, slog.LevelWarn, telemetry.LifecycleSafetyControl, forgeavailability.Condition, "forge unavailable", o.runningLifecycleCorrelation(running.Issue, running),
+			"forge_host", condition.Host,
+			"operation", condition.Operation,
+			"error_class", condition.ErrorClass,
+			"next_probe_at", condition.NextProbeAt,
+			"error", availabilityErr,
+		)
+	}
+	return condition
+}
+
+func forgeCondition(state *State, host string) (ForgeCondition, bool) {
+	if state == nil || len(state.ForgeUnavailable) == 0 {
+		return ForgeCondition{}, false
+	}
+	host = forgeavailability.NormalizeHost(host)
+	if host != "" {
+		condition, ok := state.ForgeUnavailable[host]
+		return condition, ok
+	}
+	if len(state.ForgeUnavailable) != 1 {
+		return ForgeCondition{}, false
+	}
+	for _, condition := range state.ForgeUnavailable {
+		return condition, true
+	}
+	return ForgeCondition{}, false
+}
+
+func forgeHostForIssue(issue connector.Issue, fallback string) string {
+	pullRequestURL := ""
+	if issue.PullRequest != nil {
+		pullRequestURL = issue.PullRequest.URL
+	}
+	for _, value := range []string{
+		pullRequestURL,
+		issue.PRRepository,
+		issue.URL,
+	} {
+		if host := forgeavailability.HostFromText(value); host != "" {
+			return host
+		}
+	}
+	return forgeavailability.NormalizeHost(fallback)
+}
+
+func forgeAvailabilityBlocks(state *State, issue connector.Issue, retry Retry, fallbackHost string, now time.Time) bool {
+	host := retry.ForgeHost
+	if host == "" {
+		host = forgeHostForIssue(issue, fallbackHost)
+	}
+	condition, active := forgeCondition(state, host)
+	if !active {
+		return false
+	}
+	if condition.ProbeIssueID == issue.ID {
+		return false
+	}
+	if retry.ForgeUnavailable && condition.ProbeIssueID == "" && !now.Before(condition.NextProbeAt) {
+		return false
+	}
+	return retry.ForgeUnavailable || mergeWorkerIssue(issue)
+}
+
+func reserveForgeAvailabilityProbe(state *State, issueID string, retry Retry, now time.Time) (string, bool) {
+	if state == nil || !retry.ForgeUnavailable {
+		return "", false
+	}
+	condition, active := forgeCondition(state, retry.ForgeHost)
+	if !active || condition.ProbeIssueID != "" || now.Before(condition.NextProbeAt) {
+		return "", false
+	}
+	condition.ProbeIssueID = issueID
+	condition.ProbeAttempts++
+	condition.LastProbeAt = now.UTC()
+	condition.LastProbeResult = "in_progress"
+	condition.LastProbeDetail = "forge write canary started"
+	condition.NextProbeAt = time.Time{}
+	state.ForgeUnavailable[forgeavailability.NormalizeHost(condition.Host)] = condition
+	return condition.Host, true
+}
+
+func releaseForgeAvailabilityProbe(state *State, issueID string, result string, detail string, now time.Time) {
+	if state == nil {
+		return
+	}
+	for key, condition := range state.ForgeUnavailable {
+		if condition.ProbeIssueID != issueID {
+			continue
+		}
+		condition.ProbeIssueID = ""
+		condition.LastProbeAt = now.UTC()
+		condition.LastProbeResult = strings.TrimSpace(result)
+		condition.LastProbeDetail = strings.TrimSpace(detail)
+		if condition.NextProbeAt.IsZero() {
+			condition.NextProbeAt = now.Add(backendCapacityProbeDelayForAttempt(condition.ProbeAttempts)).UTC()
+		}
+		state.ForgeUnavailable[key] = condition
+	}
+}
+
+func reservedForgeProbeHost(state *State, issueID string) string {
+	if state == nil {
+		return ""
+	}
+	for _, condition := range state.ForgeUnavailable {
+		if condition.ProbeIssueID == issueID {
+			return condition.Host
+		}
+	}
+	return ""
+}
+
+func (o *Orchestrator) handleForgeUnavailableCompletion(ctx context.Context, state *State, event runpkg.Completion, running Running) bool {
+	availabilityErr, unavailable := forgeavailability.As(event.Err)
+	if !unavailable || availabilityErr == nil {
+		return false
+	}
+	condition := o.registerForgeUnavailable(state, availabilityErr, running, event.CompletedAt)
+	forgeRetry := forgeRetryFromCompletion(event, running, condition)
+	o.releaseTerminalAttemptClaim(ctx, state, running.Issue, event.CompletedAt)
+	message := strings.TrimSpace(availabilityErr.Error())
+	o.completeDurableWorkAttemptWithMetadata(
+		ctx,
+		state,
+		running,
+		event.CompletedAt,
+		store.WorkAttemptTerminalCapacity,
+		forgeUnavailableErrorClass,
+		message,
+		"waiting",
+		message,
+		map[string]any{"forge_wait": forgeWaitMetadata{
+			Host:              condition.Host,
+			Operation:         forgeRetry.Operation,
+			Branch:            forgeRetry.Branch,
+			WorkProductPushed: forgeRetry.WorkProductPushed,
+			ErrorClass:        condition.ErrorClass,
+			DetectedAt:        condition.DetectedAt,
+			NextProbeAt:       condition.NextProbeAt,
+		}},
+	)
+	if workspaceIssueTerminal(running.Issue, o.cfg.TerminalStates) {
+		return true
+	}
+	if state.FailureBreaker.Active() && state.FailureBreaker.CanaryIssueID == running.Issue.ID {
+		o.deferProjectFailureBreakerCanary(state, running.Issue.ID, event.CompletedAt, condition.NextProbeAt.Sub(event.CompletedAt))
+	}
+	state.Retry[running.Issue.ID] = Retry{
+		Issue:            cloneIssue(running.Issue),
+		Attempt:          running.Attempt,
+		DueAt:            condition.NextProbeAt,
+		Error:            message,
+		WorkerHost:       running.WorkerHost,
+		ForgeUnavailable: true,
+		ForgeHost:        condition.Host,
+		ForgeRetry:       forgeRetry,
+	}
+	recordStateEvent(state, telemetry.ActivityEvent{
+		At:      event.CompletedAt.UTC(),
+		Event:   "forge_unavailable_attempt_waiting",
+		Message: "waiting to retry the forge write for " + issueLabel(running.Issue) + " without tripping a failure breaker",
+	})
+	return true
+}
+
+func (o *Orchestrator) recoverForgeAvailabilityWaits(ctx context.Context, state *State, attempts []store.WorkAttempt, now time.Time) {
+	if state == nil || len(attempts) == 0 {
+		return
+	}
+	latest := latestStoreTerminalAttemptsByIssue(attempts)
+	waits := make(map[string]forgeWaitMetadata, len(latest))
+	issueIDs := make([]string, 0, len(latest))
+	for issueID, attempt := range latest {
+		metadata, ok := forgeWaitMetadataFromAttempt(attempt)
+		if !ok {
+			continue
+		}
+		waits[issueID] = metadata
+		issueIDs = append(issueIDs, issueID)
+	}
+	if len(waits) == 0 {
+		return
+	}
+	issuesByID, validated := o.validateForgeWaitIssues(ctx, issueIDs)
+	for issueID, metadata := range waits {
+		attempt := latest[issueID]
+		issue := forgeWaitIssueFromAttempt(attempt)
+		if validated {
+			var ok bool
+			issue, ok = issuesByID[issueID]
+			if !ok || !stateIn(issue.State, o.cfg.ActiveStates) || workspaceIssueTerminal(issue, o.cfg.TerminalStates) {
+				continue
+			}
+		}
+		o.restoreForgeAvailabilityWait(state, issue, attempt, metadata, now)
+	}
+}
+
+func latestStoreTerminalAttemptsByIssue(attempts []store.WorkAttempt) map[string]store.WorkAttempt {
+	latest := make(map[string]store.WorkAttempt)
+	for _, attempt := range attempts {
+		if attempt.Status != store.WorkAttemptStatusTerminal {
+			continue
+		}
+		issueID := strings.TrimSpace(attempt.IssueID)
+		if issueID == "" {
+			continue
+		}
+		current, ok := latest[issueID]
+		if ok && (attempt.CompletedAt.Before(current.CompletedAt) || attempt.CompletedAt.Equal(current.CompletedAt) && attempt.ID <= current.ID) {
+			continue
+		}
+		latest[issueID] = attempt
+	}
+	return latest
+}
+
+func forgeWaitMetadataFromAttempt(attempt store.WorkAttempt) (forgeWaitMetadata, bool) {
+	if attempt.TerminalState != store.WorkAttemptTerminalCapacity || strings.TrimSpace(attempt.ErrorClass) != forgeUnavailableErrorClass {
+		return forgeWaitMetadata{}, false
+	}
+	var metadata struct {
+		ForgeWait forgeWaitMetadata `json:"forge_wait"`
+	}
+	if json.Unmarshal([]byte(attempt.WorkerMetadataJSON), &metadata) != nil {
+		return forgeWaitMetadata{}, false
+	}
+	metadata.ForgeWait.Host = forgeavailability.NormalizeHost(metadata.ForgeWait.Host)
+	metadata.ForgeWait.Operation = strings.TrimSpace(metadata.ForgeWait.Operation)
+	metadata.ForgeWait.Branch = strings.TrimSpace(metadata.ForgeWait.Branch)
+	metadata.ForgeWait.ErrorClass = strings.TrimSpace(metadata.ForgeWait.ErrorClass)
+	if metadata.ForgeWait.Host == "" || !forgeavailability.WriteOperation(metadata.ForgeWait.Operation) || !validForgeAvailabilityClass(metadata.ForgeWait.ErrorClass) {
+		return forgeWaitMetadata{}, false
+	}
+	return metadata.ForgeWait, true
+}
+
+func validForgeAvailabilityClass(class string) bool {
+	switch strings.TrimSpace(class) {
+	case forgeavailability.ClassServer, forgeavailability.ClassTimeout, forgeavailability.ClassTransport:
+		return true
+	default:
+		return false
+	}
+}
+
+func (o *Orchestrator) validateForgeWaitIssues(ctx context.Context, issueIDs []string) (map[string]connector.Issue, bool) {
+	if o == nil || o.connector == nil || len(issueIDs) == 0 {
+		return nil, false
+	}
+	issues, err := o.connector.FetchIssueStatesByIDs(ctx, issueIDs)
+	if err != nil {
+		if o.logger != nil {
+			o.logger.Warn("forge wait issue validation failed; preserving durable waits", "issue_ids", issueIDs, "error", err)
+		}
+		return nil, false
+	}
+	byID := make(map[string]connector.Issue, len(issues))
+	for _, issue := range issues {
+		if issueID := strings.TrimSpace(issue.ID); issueID != "" {
+			byID[issueID] = issue
+		}
+	}
+	return byID, true
+}
+
+func forgeWaitIssueFromAttempt(attempt store.WorkAttempt) connector.Issue {
+	issue := connector.NewIssue()
+	issue.ID = strings.TrimSpace(attempt.IssueID)
+	issue.Identifier = strings.TrimSpace(attempt.Identifier)
+	issue.URL = strings.TrimSpace(attempt.IssueURL)
+	issue.State = strings.TrimSpace(attempt.Lane)
+	issue.PRRepository = strings.TrimSpace(attempt.Repo)
+	if attempt.PRNumber != nil && *attempt.PRNumber > 0 {
+		number := int(*attempt.PRNumber)
+		issue.PRNumber = &number
+	}
+	return issue
+}
+
+func (o *Orchestrator) restoreForgeAvailabilityWait(state *State, issue connector.Issue, attempt store.WorkAttempt, metadata forgeWaitMetadata, now time.Time) {
+	detectedAt := metadata.DetectedAt
+	if detectedAt.IsZero() {
+		detectedAt = attempt.CompletedAt
+	}
+	nextProbeAt := metadata.NextProbeAt
+	if nextProbeAt.IsZero() || nextProbeAt.Before(now) {
+		nextProbeAt = now
+	}
+	host := forgeavailability.NormalizeHost(metadata.Host)
+	condition, exists := state.ForgeUnavailable[host]
+	if !exists {
+		condition = ForgeCondition{ProjectID: strings.TrimSpace(o.cfg.Project.ID), Host: host, DetectedAt: detectedAt.UTC()}
+	}
+	if condition.DetectedAt.IsZero() || detectedAt.Before(condition.DetectedAt) {
+		condition.DetectedAt = detectedAt.UTC()
+	}
+	condition.Operation = metadata.Operation
+	condition.ErrorClass = metadata.ErrorClass
+	condition.LastObservedAt = attempt.CompletedAt.UTC()
+	condition.LastError = strings.TrimSpace(attempt.ErrorMessage)
+	if condition.NextProbeAt.IsZero() || nextProbeAt.Before(condition.NextProbeAt) {
+		condition.NextProbeAt = nextProbeAt.UTC()
+	}
+	state.ForgeUnavailable[host] = condition
+	state.Retry[issue.ID] = Retry{
+		Issue:            cloneIssue(issue),
+		Attempt:          attempt.AttemptNumber,
+		DueAt:            nextProbeAt.UTC(),
+		Error:            strings.TrimSpace(attempt.ErrorMessage),
+		WorkerHost:       strings.TrimSpace(attempt.WorkerHost),
+		ForgeUnavailable: true,
+		ForgeHost:        host,
+		ForgeRetry: &runpkg.ForgeRetry{
+			Host:              host,
+			Operation:         metadata.Operation,
+			Branch:            metadata.Branch,
+			WorkProductPushed: metadata.WorkProductPushed,
+		},
+	}
+	recordStateEvent(state, telemetry.ActivityEvent{At: now.UTC(), Event: "forge_unavailable_wait_restored", Message: "restored durable forge wait for " + issueLabel(issue)})
+}
+
+func forgeRetryFromCompletion(event runpkg.Completion, running Running, condition ForgeCondition) *runpkg.ForgeRetry {
+	retry := &runpkg.ForgeRetry{
+		Host:              condition.Host,
+		Operation:         condition.Operation,
+		Branch:            strings.TrimSpace(event.Result.WorkspaceBranch),
+		WorkProductPushed: running.WorkProductPushed || event.Result.PullRequestHeadPushed || event.Result.PullRequestUpdated,
+	}
+	if retry.Branch == "" {
+		retry.Branch = strings.TrimSpace(running.Issue.BranchName)
+	}
+	var deliverableErr *runpkg.DeliverableCommandError
+	if errors.As(event.Err, &deliverableErr) && deliverableErr != nil {
+		retry.Arguments = strings.TrimSpace(deliverableErr.Arguments)
+		if operation := strings.TrimSpace(deliverableErr.Operation); operation != "" {
+			retry.Operation = operation
+		}
+	}
+	var recoveryErr *runpkg.DeliverableRecoveryError
+	if errors.As(event.Err, &recoveryErr) && recoveryErr != nil && strings.TrimSpace(recoveryErr.Branch) != "" {
+		retry.Branch = strings.TrimSpace(recoveryErr.Branch)
+	}
+	return retry
+}
+
+func (o *Orchestrator) finishForgeAvailabilityProbe(state *State, event runpkg.Completion, running Running) {
+	if state == nil || strings.TrimSpace(running.ForgeProbeHost) == "" {
+		return
+	}
+	if event.Result.ForgeWriteCompleted || forgeWriteReachedRemote(event.Err) {
+		o.completeForgeAvailabilityRecovery(state, running.ForgeProbeHost, event.CompletedAt, "canary")
+		return
+	}
+	releaseForgeAvailabilityProbe(state, running.Issue.ID, "inconclusive", errorString(event.Err), event.CompletedAt)
+}
+
+func forgeWriteReachedRemote(err error) bool {
+	var deliverableErr *runpkg.DeliverableCommandError
+	if !errors.As(err, &deliverableErr) || deliverableErr == nil {
+		return false
+	}
+	operation := deliverableErr.Operation
+	if deliverableErr.OperationClass == "push" {
+		operation = "git push"
+	}
+	return forgeavailability.ProvesReachability(operation, deliverableErr.Error())
+}
+
+func (o *Orchestrator) completeForgeAvailabilityRecovery(state *State, host string, recoveredAt time.Time, source string) {
+	if state == nil {
+		return
+	}
+	host = forgeavailability.NormalizeHost(host)
+	condition, ok := state.ForgeUnavailable[host]
+	if !ok {
+		return
+	}
+	if recoveredAt.IsZero() {
+		recoveredAt = o.clockNow()
+	}
+	delete(state.ForgeUnavailable, host)
+	releaseForgeUnavailableRetries(state, host, recoveredAt)
+	o.activateDispatchRecovery(state, dispatchRecoveryForgeUnavailable, forgeUnavailableStatusMessage(condition), recoveredAt, "")
+	recordStateEvent(state, telemetry.ActivityEvent{
+		At:      recoveredAt.UTC(),
+		Event:   "forge_availability_recovered",
+		Message: "forge " + condition.Host + " recovered via " + source,
+	})
+	telemetry.LogLifecycleMessage(o.logger, slog.LevelInfo, telemetry.LifecycleSafetyControl, "forge_availability_recovered", "forge availability recovered", telemetry.LifecycleCorrelation{ProjectID: o.cfg.Project.ID},
+		"forge_host", condition.Host,
+		"detected_at", condition.DetectedAt,
+		"recovered_at", recoveredAt,
+		"source", source,
+	)
+}
+
+func releaseForgeUnavailableRetries(state *State, host string, releasedAt time.Time) {
+	for issueID, retry := range state.Retry {
+		if !retry.ForgeUnavailable || forgeavailability.NormalizeHost(retry.ForgeHost) != host {
+			continue
+		}
+		retry.DueAt = releasedAt
+		retry.ForgeUnavailable = false
+		state.Retry[issueID] = retry
+	}
+}
+
+func forgeUnavailableStatusMessage(condition ForgeCondition) string {
+	host := strings.TrimSpace(condition.Host)
+	if host == "" {
+		host = "configured"
+	}
+	message := fmt.Sprintf("forge %s unavailable (%s/%s)", host, forgeavailability.Condition, condition.ErrorClass)
+	if !condition.NextProbeAt.IsZero() {
+		message += "; next write canary at " + condition.NextProbeAt.UTC().Format(time.RFC3339)
+	}
+	return message
+}
+
+func (o *Orchestrator) clearForgeAvailability(state *State, host string, clearedAt time.Time) []ForgeCondition {
+	if state == nil || len(state.ForgeUnavailable) == 0 {
+		return nil
+	}
+	if clearedAt.IsZero() {
+		clearedAt = o.clockNow()
+	}
+	host = forgeavailability.NormalizeHost(host)
+	cleared := make([]ForgeCondition, 0, len(state.ForgeUnavailable))
+	for _, key := range sortedKeys(state.ForgeUnavailable) {
+		condition := state.ForgeUnavailable[key]
+		if host != "" && forgeavailability.NormalizeHost(condition.Host) != host {
+			continue
+		}
+		condition.LastProbeAt = clearedAt.UTC()
+		condition.LastProbeResult = "operator_cleared"
+		condition.LastProbeDetail = "operator cleared the recorded condition"
+		condition.NextProbeAt = time.Time{}
+		delete(state.ForgeUnavailable, key)
+		releaseForgeUnavailableRetries(state, forgeavailability.NormalizeHost(condition.Host), clearedAt)
+		o.activateDispatchRecovery(state, dispatchRecoveryForgeUnavailable, forgeUnavailableStatusMessage(condition), clearedAt, "")
+		cleared = append(cleared, condition)
+	}
+	return cleared
+}
+
+func (o *Orchestrator) ClearForgeAvailability(ctx context.Context, host string) ([]ForgeCondition, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	request := forgeClearRequest{host: forgeavailability.NormalizeHost(host), at: o.clockNow(), reply: make(chan forgeClearReply, 1)}
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	case <-o.done:
+		return nil, ErrStopped
+	case o.forgeClearRequests <- request:
+	}
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	case <-o.done:
+		return nil, ErrStopped
+	case reply := <-request.reply:
+		return reply.cleared, nil
+	}
+}

--- a/internal/orchestrator/forge_availability_test.go
+++ b/internal/orchestrator/forge_availability_test.go
@@ -1,0 +1,378 @@
+package orchestrator
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/digitaldrywood/detent/internal/connector"
+	"github.com/digitaldrywood/detent/internal/forgeavailability"
+	runpkg "github.com/digitaldrywood/detent/internal/runner"
+	"github.com/digitaldrywood/detent/internal/scheduler"
+	"github.com/digitaldrywood/detent/internal/store"
+)
+
+func TestForgeUnavailableCompletionBypassesAllFailureBreakers(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 8, 17, 18, 0, 0, 0, time.UTC)
+	cfg := normalizeConfig(Config{
+		Project:             scheduler.ProjectCandidate{ID: "detent"},
+		ForgeHost:           "github.com",
+		PollInterval:        time.Minute,
+		ActiveStates:        []string{"In Progress"},
+		TerminalStates:      []string{"Done"},
+		MaxConcurrentAgents: 1,
+		FailureBreaker: FailureBreakerConfig{
+			SameClassLimit: 1,
+			Window:         time.Hour,
+			Cooldown:       time.Hour,
+		},
+	})
+	tracker := &backendCapacityTestConnector{}
+	attempts := &recordingWorkAttemptStore{}
+	orch := Orchestrator{cfg: cfg, connector: tracker, workAttempts: attempts, now: func() time.Time { return now }}
+	state := newState(cfg)
+	issue := dispatchTestIssue("issue-forge-wait", "In Progress")
+	issue.URL = "https://github.com/digitaldrywood/detent/issues/1871"
+	state.Running[issue.ID] = Running{Issue: issue, Attempt: 4, WorkAttemptID: 42, StartedAt: now.Add(-time.Minute)}
+	state.InstantFailures[issue.ID] = InstantFailure{Issue: issue, Count: instantFailureThreshold - 1}
+	state.RepeatedFailures[issue.ID] = RepeatedFailure{Issue: issue, Count: repeatedFailureThreshold - 1}
+	state.FailureBreaker.Failures["existing"] = []ProjectFailure{{IssueID: "other", At: now.Add(-time.Minute)}}
+	deliverableErr := &runpkg.DeliverableCommandError{
+		OperationClass: "pull_request",
+		Operation:      "codex_apps/github.create_pull_request",
+		Arguments:      `{"head":"detent/1871"}`,
+		Status:         "failed",
+		Message:        "HTTP 503: unavailable",
+	}
+	err := forgeavailability.NewError(
+		forgeavailability.Scope{Host: "github.com", Operation: deliverableErr.Operation},
+		forgeavailability.ClassServer,
+		deliverableErr,
+	)
+
+	orch.handleRunResult(context.Background(), &state, runpkg.Completion{
+		IssueID:      issue.ID,
+		Request:      runpkg.RunRequest{Issue: issue, Attempt: 4},
+		Result:       runpkg.RunResult{PullRequestHeadPushed: true, WorkspaceBranch: "detent/1871"},
+		Err:          err,
+		CompletedAt:  now,
+		RetryAttempt: 5,
+		RetryDelay:   time.Minute,
+	})
+
+	if got := state.InstantFailures[issue.ID].Count; got != instantFailureThreshold-1 {
+		t.Fatalf("instant failure count = %d, want unchanged", got)
+	}
+	if got := state.RepeatedFailures[issue.ID].Count; got != repeatedFailureThreshold-1 {
+		t.Fatalf("repeated failure count = %d, want unchanged", got)
+	}
+	if got := len(state.FailureBreaker.Failures["existing"]); got != 1 || state.FailureBreaker.Active() {
+		t.Fatalf("FailureBreaker = %#v, want existing evidence unchanged and inactive", state.FailureBreaker)
+	}
+	if _, blocked := state.Blocked[issue.ID]; blocked {
+		t.Fatalf("Blocked[%q] present after forge wait", issue.ID)
+	}
+	retry, ok := state.Retry[issue.ID]
+	if !ok || retry.Attempt != 4 || !retry.ForgeUnavailable || retry.ForgeRetry == nil {
+		t.Fatalf("Retry[%q] = %#v, want same-attempt typed forge wait", issue.ID, retry)
+	}
+	if !retry.ForgeRetry.WorkProductPushed || retry.ForgeRetry.Branch != "detent/1871" {
+		t.Fatalf("ForgeRetry = %#v, want pushed branch preserved", retry.ForgeRetry)
+	}
+	if len(tracker.updates) != 0 || len(tracker.comments) != 0 {
+		t.Fatalf("tracker mutations = states %#v comments %#v, want none", tracker.updates, tracker.comments)
+	}
+	if len(attempts.completions) != 1 || attempts.completions[0].TerminalState != store.WorkAttemptTerminalCapacity {
+		t.Fatalf("work attempt completions = %#v, want durable capacity wait", attempts.completions)
+	}
+	var persisted struct {
+		ForgeWait forgeWaitMetadata `json:"forge_wait"`
+	}
+	if err := json.Unmarshal([]byte(attempts.completions[0].WorkerMetadataJSON), &persisted); err != nil {
+		t.Fatalf("decode forge wait metadata: %v", err)
+	}
+	if persisted.ForgeWait.Host != "github.com" || persisted.ForgeWait.Branch != "detent/1871" || !persisted.ForgeWait.WorkProductPushed {
+		t.Fatalf("persisted forge wait = %#v, want scoped pushed branch", persisted.ForgeWait)
+	}
+}
+
+func TestRecoverDurableForgeAvailabilityWait(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 8, 17, 18, 0, 0, 0, time.UTC)
+	waiting := dispatchTestIssue("durable-forge-wait", "In Progress")
+	waiting.URL = "https://github.com/digitaldrywood/detent/issues/1871"
+	completed := dispatchTestIssue("completed-after-wait", "In Progress")
+	metadata := func(branch string) string {
+		return marshalWorkAttemptJSON(map[string]any{
+			"forge_wait": forgeWaitMetadata{
+				Host:              "github.com",
+				Operation:         "git push",
+				Branch:            branch,
+				WorkProductPushed: false,
+				ErrorClass:        forgeavailability.ClassTransport,
+				DetectedAt:        now.Add(-2 * time.Minute),
+				NextProbeAt:       now.Add(time.Minute),
+			},
+		})
+	}
+	attempts := &recordingWorkAttemptStore{recent: []store.WorkAttempt{
+		{
+			ID: 3, ProjectID: "detent", IssueID: waiting.ID, Identifier: waiting.Identifier, IssueURL: waiting.URL,
+			WorkerHost: "worker-a", Lane: waiting.State, AttemptNumber: 4, Status: store.WorkAttemptStatusTerminal,
+			CompletedAt: now.Add(-time.Minute), TerminalState: store.WorkAttemptTerminalCapacity, ErrorClass: forgeUnavailableErrorClass,
+			ErrorMessage: "forge github.com unavailable", WorkerMetadataJSON: metadata("detent/1871"),
+		},
+		{
+			ID: 2, ProjectID: "detent", IssueID: completed.ID, Identifier: completed.Identifier,
+			Lane: completed.State, AttemptNumber: 2, Status: store.WorkAttemptStatusTerminal,
+			CompletedAt: now.Add(-30 * time.Second), TerminalState: store.WorkAttemptTerminalSuccess, WorkerMetadataJSON: `{}`,
+		},
+		{
+			ID: 1, ProjectID: "detent", IssueID: completed.ID, Identifier: completed.Identifier,
+			Lane: completed.State, AttemptNumber: 1, Status: store.WorkAttemptStatusTerminal,
+			CompletedAt: now.Add(-2 * time.Minute), TerminalState: store.WorkAttemptTerminalCapacity, ErrorClass: forgeUnavailableErrorClass,
+			WorkerMetadataJSON: metadata("detent/old"),
+		},
+	}}
+	connectorBackend := &forgeWaitRecoveryConnector{issues: []connector.Issue{waiting, completed}}
+	cfg := normalizeConfig(Config{
+		Project:             scheduler.ProjectCandidate{ID: "detent"},
+		ForgeHost:           "github.com",
+		ActiveStates:        []string{"Todo", "In Progress"},
+		TerminalStates:      []string{"Done"},
+		MaxConcurrentAgents: 1,
+	})
+	orch := Orchestrator{cfg: cfg, connector: connectorBackend, workAttempts: attempts, now: func() time.Time { return now }}
+	state := newState(cfg)
+
+	orch.recoverDurableWorkAttempts(context.Background(), &state, now)
+
+	condition, ok := state.ForgeUnavailable["github.com"]
+	if !ok || !condition.NextProbeAt.Equal(now.Add(time.Minute)) {
+		t.Fatalf("ForgeUnavailable = %#v, want restored host condition", state.ForgeUnavailable)
+	}
+	retry, ok := state.Retry[waiting.ID]
+	if !ok || !retry.ForgeUnavailable || retry.Attempt != 4 || retry.ForgeRetry == nil || retry.ForgeRetry.Branch != "detent/1871" {
+		t.Fatalf("Retry[%q] = %#v, want restored same-attempt write canary", waiting.ID, retry)
+	}
+	if _, ok := state.Retry[completed.ID]; ok {
+		t.Fatalf("Retry[%q] restored despite newer successful attempt", completed.ID)
+	}
+	if terminalAttemptRetryableFailure(telemetryWorkAttempt(attempts.recent[0], now)) {
+		t.Fatal("durable forge wait treated as a generic terminal retry")
+	}
+}
+
+func TestForgeWaitMetadataRequiresStructuredAvailabilityEvidence(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 8, 17, 18, 0, 0, 0, time.UTC)
+	valid := forgeWaitMetadata{
+		Host: "github.com", Operation: "git push", ErrorClass: forgeavailability.ClassServer,
+		DetectedAt: now.Add(-time.Minute), NextProbeAt: now,
+	}
+	tests := []struct {
+		name    string
+		attempt store.WorkAttempt
+		want    bool
+	}{
+		{name: "valid", attempt: forgeWaitAttempt(valid), want: true},
+		{name: "malformed JSON", attempt: store.WorkAttempt{Status: store.WorkAttemptStatusTerminal, TerminalState: store.WorkAttemptTerminalCapacity, ErrorClass: forgeUnavailableErrorClass, WorkerMetadataJSON: `{`}},
+		{name: "missing host", attempt: forgeWaitAttempt(forgeWaitMetadata{Operation: "git push", ErrorClass: forgeavailability.ClassServer})},
+		{name: "tracker read operation", attempt: forgeWaitAttempt(forgeWaitMetadata{Host: "github.com", Operation: "search issues", ErrorClass: forgeavailability.ClassServer})},
+		{name: "unknown class", attempt: forgeWaitAttempt(forgeWaitMetadata{Host: "github.com", Operation: "git push", ErrorClass: "auth"})},
+		{name: "ordinary failure", attempt: store.WorkAttempt{Status: store.WorkAttemptStatusTerminal, TerminalState: store.WorkAttemptTerminalFailure, ErrorClass: forgeUnavailableErrorClass, WorkerMetadataJSON: marshalWorkAttemptJSON(map[string]any{"forge_wait": valid})}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			_, got := forgeWaitMetadataFromAttempt(tt.attempt)
+			if got != tt.want {
+				t.Fatalf("forgeWaitMetadataFromAttempt() valid = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestRecoverForgeWaitPreservesDeferralWhenTrackerValidationFails(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 8, 17, 18, 0, 0, 0, time.UTC)
+	issue := dispatchTestIssue("tracker-validation-failed", "In Progress")
+	attempt := forgeWaitAttempt(forgeWaitMetadata{
+		Host: "github.com", Operation: "git push", Branch: "detent/1871",
+		ErrorClass: forgeavailability.ClassServer, DetectedAt: now.Add(-time.Minute), NextProbeAt: now,
+	})
+	attempt.ID = 1
+	attempt.IssueID = issue.ID
+	attempt.Identifier = issue.Identifier
+	attempt.Lane = issue.State
+	attempt.AttemptNumber = 3
+	attempt.CompletedAt = now.Add(-time.Minute)
+	cfg := normalizeConfig(Config{
+		Project: scheduler.ProjectCandidate{ID: "detent"}, ActiveStates: []string{"In Progress"}, TerminalStates: []string{"Done"}, MaxConcurrentAgents: 1,
+	})
+	orch := Orchestrator{cfg: cfg, connector: &forgeWaitRecoveryConnector{err: errors.New("tracker unavailable")}}
+	state := newState(cfg)
+
+	orch.recoverForgeAvailabilityWaits(context.Background(), &state, []store.WorkAttempt{attempt}, now)
+
+	if _, ok := state.ForgeUnavailable["github.com"]; !ok {
+		t.Fatal("forge condition not restored after tracker validation failure")
+	}
+	if retry, ok := state.Retry[issue.ID]; !ok || !retry.ForgeUnavailable {
+		t.Fatalf("Retry[%q] = %#v, want continued durable deferral", issue.ID, retry)
+	}
+}
+
+func forgeWaitAttempt(metadata forgeWaitMetadata) store.WorkAttempt {
+	return store.WorkAttempt{
+		Status: store.WorkAttemptStatusTerminal, TerminalState: store.WorkAttemptTerminalCapacity,
+		ErrorClass: forgeUnavailableErrorClass, WorkerMetadataJSON: marshalWorkAttemptJSON(map[string]any{"forge_wait": metadata}),
+	}
+}
+
+func TestForgeAvailabilityDispatchIsScopedToNextWriteAndHost(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 8, 17, 18, 0, 0, 0, time.UTC)
+	cfg := normalizeConfig(Config{
+		Project:             scheduler.ProjectCandidate{ID: "detent"},
+		ForgeHost:           "github.com",
+		ActiveStates:        []string{"In Progress", "Merging"},
+		TerminalStates:      []string{"Done"},
+		MaxConcurrentAgents: 2,
+	})
+	state := newState(cfg)
+	state.ForgeUnavailable["github.com"] = ForgeCondition{Host: "github.com", NextProbeAt: now.Add(time.Minute)}
+	planner := newDispatchPlanner(cfg)
+
+	implementation := dispatchTestIssue("implementation", "In Progress")
+	implementation.URL = "https://github.com/digitaldrywood/detent/issues/1871"
+	if decision := planner.dispatchableIssueDecision(implementation, &state, false, now, ""); !decision.dispatchable {
+		t.Fatalf("implementation decision = %#v, want non-write work to proceed", decision)
+	}
+
+	merge := dispatchTestIssueWithPullRequest("merge", "Merging", "OPEN")
+	if decision := planner.dispatchableIssueDecision(merge, &state, false, now, ""); decision.dispatchable || decision.reason != dispatchSkipForgeUnavailable {
+		t.Fatalf("merge decision = %#v, want forge wait", decision)
+	}
+
+	otherHostRetry := Retry{
+		Issue:            implementation,
+		Attempt:          2,
+		DueAt:            now,
+		ForgeUnavailable: true,
+		ForgeHost:        "gitlab.example.com",
+	}
+	state.Retry[implementation.ID] = otherHostRetry
+	if _, allowed, reason := planner.retryAction(&state, implementation, otherHostRetry, now); !allowed || reason != "" {
+		t.Fatalf("other-host retry = allowed %v reason %q, want independent host", allowed, reason)
+	}
+}
+
+func TestForgeAvailabilityProbeClearsOnlyForgeCondition(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 8, 17, 18, 0, 0, 0, time.UTC)
+	cfg := normalizeConfig(Config{Project: scheduler.ProjectCandidate{ID: "detent"}, ForgeHost: "github.com", MaxConcurrentAgents: 1})
+	orch := Orchestrator{cfg: cfg, now: func() time.Time { return now }}
+	state := newState(cfg)
+	issue := dispatchTestIssue("forge-probe", "In Progress")
+	state.TrackerUnavailable = &TrackerCondition{Connector: "github", DetectedAt: now.Add(-time.Minute)}
+	state.ForgeUnavailable["github.com"] = ForgeCondition{
+		Host:         "github.com",
+		ProbeIssueID: issue.ID,
+		DetectedAt:   now.Add(-time.Minute),
+	}
+	state.Retry[issue.ID] = Retry{Issue: issue, DueAt: now.Add(time.Hour), ForgeUnavailable: true, ForgeHost: "github.com"}
+
+	orch.finishForgeAvailabilityProbe(&state, runpkg.Completion{
+		IssueID:     issue.ID,
+		Result:      runpkg.RunResult{ForgeWriteCompleted: true},
+		CompletedAt: now,
+	}, Running{Issue: issue, ForgeProbeHost: "github.com"})
+
+	if len(state.ForgeUnavailable) != 0 {
+		t.Fatalf("ForgeUnavailable = %#v, want cleared", state.ForgeUnavailable)
+	}
+	if state.TrackerUnavailable == nil {
+		t.Fatal("TrackerUnavailable cleared with independent forge condition")
+	}
+	retry := state.Retry[issue.ID]
+	if retry.ForgeUnavailable || !retry.DueAt.Equal(now) {
+		t.Fatalf("Retry[%q] = %#v, want released", issue.ID, retry)
+	}
+}
+
+func TestRejectedPushRemainsWorkFailure(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 8, 17, 18, 0, 0, 0, time.UTC)
+	cfg := normalizeConfig(Config{
+		Project:             scheduler.ProjectCandidate{ID: "detent"},
+		ForgeHost:           "github.com",
+		ActiveStates:        []string{"In Progress"},
+		TerminalStates:      []string{"Done"},
+		MaxConcurrentAgents: 1,
+	})
+	orch := Orchestrator{cfg: cfg, connector: &backendCapacityTestConnector{}, now: func() time.Time { return now }}
+	state := newState(cfg)
+	issue := dispatchTestIssue("rejected-push", "In Progress")
+	issue.URL = "https://github.com/digitaldrywood/detent/issues/1871"
+	state.Running[issue.ID] = Running{Issue: issue, Attempt: 1, StartedAt: now.Add(-time.Second)}
+	err := &runpkg.DeliverableCommandError{
+		OperationClass: "push",
+		Operation:      "git push",
+		Status:         "failed",
+		Message:        "[rejected] feature -> feature (non-fast-forward)",
+	}
+
+	orch.handleRunResult(context.Background(), &state, runpkg.Completion{
+		IssueID:      issue.ID,
+		Request:      runpkg.RunRequest{Issue: issue, Attempt: 1},
+		Result:       runpkg.RunResult{TurnStarted: true},
+		Err:          err,
+		CompletedAt:  now,
+		RetryAttempt: 2,
+		RetryDelay:   time.Minute,
+	})
+
+	if len(state.ForgeUnavailable) != 0 {
+		t.Fatalf("ForgeUnavailable = %#v, want no outage for rejected push", state.ForgeUnavailable)
+	}
+	if retry := state.Retry[issue.ID]; retry.ForgeUnavailable {
+		t.Fatalf("Retry[%q] = %#v, want ordinary work failure", issue.ID, retry)
+	}
+	if state.RepeatedFailures[issue.ID].Count != 1 || state.InstantFailures[issue.ID].Count != 1 {
+		t.Fatalf("failure counts = repeated %#v instant %#v, want one real strike", state.RepeatedFailures, state.InstantFailures)
+	}
+}
+
+func TestForgeWriteRejectionClearsProbeButStillReturnsFailure(t *testing.T) {
+	t.Parallel()
+
+	err := &runpkg.DeliverableCommandError{OperationClass: "push", Operation: "git push", Message: "HTTP 403: forbidden"}
+	if !forgeWriteReachedRemote(err) {
+		t.Fatal("forgeWriteReachedRemote() = false, want reachable rejection to clear a canary")
+	}
+	if _, unavailable := forgeavailability.As(err); unavailable || errors.Is(err, forgeavailability.ErrUnavailable) {
+		t.Fatalf("error = %v, want ordinary failure", err)
+	}
+}
+
+type forgeWaitRecoveryConnector struct {
+	backendCapacityTestConnector
+	issues []connector.Issue
+	err    error
+}
+
+func (c *forgeWaitRecoveryConnector) FetchIssueStatesByIDs(context.Context, []string) ([]connector.Issue, error) {
+	return append([]connector.Issue(nil), c.issues...), c.err
+}

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -116,6 +116,7 @@ type Config struct {
 	GitHubGraphQLWarnRemaining    int64
 	GitHubGraphQLMinReserve       int64
 	GitHubRESTMinReserve          int64
+	ForgeHost                     string
 	OutputTruncationMaxBytes      int
 	EfficiencyThresholds          efficiency.Thresholds
 	Lessons                       LessonCaptureConfig
@@ -270,6 +271,7 @@ type Orchestrator struct {
 	reconciles              chan targetedRefreshRequest
 	capacityClearRequests   chan capacityClearRequest
 	trackerClearRequests    chan trackerClearRequest
+	forgeClearRequests      chan forgeClearRequest
 	failureCanaryRequests   chan failureBreakerCanaryRequest
 	stopRequests            chan stopRunRequest
 	modelPermitRequests     chan modelPermitRequest
@@ -345,6 +347,16 @@ type trackerClearRequest struct {
 
 type trackerClearReply struct {
 	cleared []TrackerCondition
+}
+
+type forgeClearRequest struct {
+	host  string
+	at    time.Time
+	reply chan forgeClearReply
+}
+
+type forgeClearReply struct {
+	cleared []ForgeCondition
 }
 
 type failureBreakerCanaryRequest struct {
@@ -548,6 +560,7 @@ func New(cfg Config, deps Dependencies) (*Orchestrator, error) {
 		reconciles:              make(chan targetedRefreshRequest, 128),
 		capacityClearRequests:   make(chan capacityClearRequest),
 		trackerClearRequests:    make(chan trackerClearRequest),
+		forgeClearRequests:      make(chan forgeClearRequest),
 		failureCanaryRequests:   make(chan failureBreakerCanaryRequest),
 		stopRequests:            make(chan stopRunRequest),
 		modelPermitRequests:     make(chan modelPermitRequest),
@@ -638,6 +651,8 @@ func (o *Orchestrator) Run(ctx context.Context) error {
 			request.reply <- capacityClearReply{cleared: o.clearBackendCapacity(&state, request.scope, request.at)}
 		case request := <-o.trackerClearRequests:
 			request.reply <- trackerClearReply{cleared: o.clearTrackerAvailability(&state, request.at)}
+		case request := <-o.forgeClearRequests:
+			request.reply <- forgeClearReply{cleared: o.clearForgeAvailability(&state, request.host, request.at)}
 		case request := <-o.failureCanaryRequests:
 			result := o.requestProjectFailureBreakerCanary(&state, request.at)
 			request.reply <- result

--- a/internal/orchestrator/run_completion.go
+++ b/internal/orchestrator/run_completion.go
@@ -183,6 +183,10 @@ func (o *Orchestrator) handleRunResult(ctx context.Context, state *State, event 
 	if o.handleModelPermitDeferred(ctx, state, event, running) {
 		return
 	}
+	if o.handleForgeUnavailableCompletion(ctx, state, event, running) {
+		return
+	}
+	o.finishForgeAvailabilityProbe(state, event, running)
 	deliverableLookup := deliverableRecoveryLookupResult{}
 	var deliverableRecoveryErr *runpkg.DeliverableRecoveryError
 	if errors.As(event.Err, &deliverableRecoveryErr) && deliverableRecoveryErr != nil {

--- a/internal/orchestrator/shadow.go
+++ b/internal/orchestrator/shadow.go
@@ -72,6 +72,9 @@ func (s *State) ensureInitialized(cfg Config) {
 	if s.Retry == nil {
 		s.Retry = map[string]Retry{}
 	}
+	if s.ForgeUnavailable == nil {
+		s.ForgeUnavailable = map[string]ForgeCondition{}
+	}
 	if s.DependencyAutoUnblocks == nil {
 		s.DependencyAutoUnblocks = map[string]DependencyAutoUnblockRecord{}
 	}

--- a/internal/orchestrator/snapshot.go
+++ b/internal/orchestrator/snapshot.go
@@ -111,6 +111,7 @@ func (s State) Snapshot(now time.Time) telemetry.Snapshot {
 		Completed:               completedSnapshots(s.Completed, s.Claimed, now, s.laneEntries),
 		RateLimits:              cloneRateLimits(s.RateLimits),
 		TrackerUnavailable:      trackerUnavailableSnapshots(s.TrackerUnavailable),
+		ForgeUnavailable:        forgeUnavailableSnapshots(s.ForgeUnavailable),
 		CIUnavailable:           ciUnavailableSnapshots(s.CIUnavailable),
 		BackendOutages:          backendOutageSnapshots(s.BackendOutages),
 		FailureBreakers:         projectFailureBreakerSnapshots(s),
@@ -179,6 +180,14 @@ func trackerUnavailableSnapshots(condition *TrackerCondition) []telemetry.Tracke
 		return nil
 	}
 	return []telemetry.TrackerCondition{*condition}
+}
+
+func forgeUnavailableSnapshots(conditions map[string]ForgeCondition) []telemetry.ForgeCondition {
+	result := make([]telemetry.ForgeCondition, 0, len(conditions))
+	for _, key := range sortedKeys(conditions) {
+		result = append(result, conditions[key])
+	}
+	return result
 }
 
 func applySnapshotLaneProvenance(snapshot *telemetry.Snapshot, laneProvenance map[string]provenance.Attribution) {

--- a/internal/orchestrator/state.go
+++ b/internal/orchestrator/state.go
@@ -89,6 +89,7 @@ type State struct {
 	TrackerUnavailable       *TrackerCondition
 	trackerEvidence          map[string]trackerAvailabilityEvidence
 	deferredCompletions      map[string]deferredCompletion
+	ForgeUnavailable         map[string]ForgeCondition
 	CIUnavailable            *CICondition
 	BackendOutages           map[string]BackendOutage
 	BackendRecoveries        map[string]BackendRecovery
@@ -144,6 +145,7 @@ type Running struct {
 	Tokens                      TokenTotals
 	CapacityScope               backendcapacity.Scope
 	CapacityProbe               bool
+	ForgeProbeHost              string
 	ModelPermitExempt           bool
 	CIStopRequested             bool
 	CompletionOwnershipReleased bool
@@ -238,6 +240,9 @@ type Retry struct {
 	CIUnavailable      bool
 	TrackerUnavailable bool
 	CompletionDeferred bool
+	ForgeUnavailable   bool
+	ForgeHost          string
+	ForgeRetry         *runpkg.ForgeRetry
 	Wait               RetryWait
 }
 
@@ -352,6 +357,7 @@ func newState(cfg Config) State {
 		StalenessWarnings:        map[string]StalenessWarning{},
 		trackerEvidence:          map[string]trackerAvailabilityEvidence{},
 		deferredCompletions:      map[string]deferredCompletion{},
+		ForgeUnavailable:         map[string]ForgeCondition{},
 		BackendOutages:           map[string]BackendOutage{},
 		BackendRecoveries:        map[string]BackendRecovery{},
 		DiffStats:                map[string]DiffStats{},
@@ -429,6 +435,7 @@ func (s State) clone() State {
 		TrackerUnavailable:       cloneTrackerCondition(s.TrackerUnavailable),
 		trackerEvidence:          maps.Clone(s.trackerEvidence),
 		deferredCompletions:      cloneDeferredCompletions(s.deferredCompletions),
+		ForgeUnavailable:         maps.Clone(s.ForgeUnavailable),
 		CIUnavailable:            cloneCICondition(s.CIUnavailable),
 		BackendOutages:           maps.Clone(s.BackendOutages),
 		BackendRecoveries:        maps.Clone(s.BackendRecoveries),
@@ -470,6 +477,7 @@ func (s State) clone() State {
 	for id, retry := range s.Retry {
 		retry.Issue = cloneIssue(retry.Issue)
 		retry.MergePrecheck = cloneMergePrecheck(retry.MergePrecheck)
+		retry.ForgeRetry = cloneForgeRetry(retry.ForgeRetry)
 		retry.Wait.PendingChecks = append([]string(nil), retry.Wait.PendingChecks...)
 		cloned.Retry[id] = retry
 	}
@@ -520,6 +528,14 @@ func cloneMergePrecheck(precheck *runpkg.MergePrecheck) *runpkg.MergePrecheck {
 		return nil
 	}
 	cloned := *precheck
+	return &cloned
+}
+
+func cloneForgeRetry(retry *runpkg.ForgeRetry) *runpkg.ForgeRetry {
+	if retry == nil {
+		return nil
+	}
+	cloned := *retry
 	return &cloned
 }
 

--- a/internal/orchestrator/terminal_attempt_retry.go
+++ b/internal/orchestrator/terminal_attempt_retry.go
@@ -181,6 +181,9 @@ func workAttemptCompletedAfter(left telemetry.WorkAttempt, right telemetry.WorkA
 }
 
 func terminalAttemptRetryableFailure(attempt telemetry.WorkAttempt) bool {
+	if strings.TrimSpace(attempt.ErrorClass) == forgeUnavailableErrorClass {
+		return false
+	}
 	return terminalAttemptStateRetryDemotable(store.WorkAttemptTerminalState(strings.ToLower(strings.TrimSpace(attempt.TerminalState))))
 }
 

--- a/internal/orchestrator/work_attempts.go
+++ b/internal/orchestrator/work_attempts.go
@@ -91,6 +91,7 @@ func (o *Orchestrator) recoverDurableWorkAttempts(ctx context.Context, state *St
 		for index := len(recent) - 1; index >= 0; index-- {
 			o.upsertWorkAttemptSnapshot(state, telemetryWorkAttempt(recent[index], now))
 		}
+		o.recoverForgeAvailabilityWaits(ctx, state, recent, now)
 	}
 	decisions, err := o.workAttempts.ListRecentSchedulerDecisions(ctx, store.SchedulerDecisionQuery{
 		ProjectID: projectID,
@@ -802,6 +803,9 @@ func (o *Orchestrator) capacitySnapshotJSON(state *State, issue connector.Issue)
 	}
 	if state != nil && state.TrackerUnavailable != nil {
 		snapshot["tracker_unavailable"] = *state.TrackerUnavailable
+	}
+	if state != nil && len(state.ForgeUnavailable) > 0 {
+		snapshot["forge_unavailable"] = forgeUnavailableSnapshots(state.ForgeUnavailable)
 	}
 	if state != nil && len(state.DispatchRecoveries) > 0 {
 		snapshot["dispatch_recoveries"] = dispatchRecoveriesCapacitySnapshot(state.DispatchRecoveries, pool.Name, pool.Capacity)

--- a/internal/runner/agent.go
+++ b/internal/runner/agent.go
@@ -20,6 +20,7 @@ import (
 	"github.com/digitaldrywood/detent/internal/budget"
 	"github.com/digitaldrywood/detent/internal/config"
 	"github.com/digitaldrywood/detent/internal/connector"
+	"github.com/digitaldrywood/detent/internal/forgeavailability"
 	"github.com/digitaldrywood/detent/internal/gate"
 	"github.com/digitaldrywood/detent/internal/lessons"
 	"github.com/digitaldrywood/detent/internal/notes"
@@ -603,6 +604,7 @@ func (r *Runner) prepareMergeFastPath(
 			Output:                RunOutputMergeFastPathClean,
 			DiffStats:             diffStatsFromWorkspace(precheck.DiffStat),
 			PullRequestHeadPushed: precheck.HeadChanged,
+			ForgeWriteCompleted:   true,
 		}, precheck, true, nil
 	case workspace.MergePrepareStatusConflict, workspace.MergePrepareStatusDirty:
 		r.logWorkerEvent(req.Issue, "worker_merge_fast_path_fallback",
@@ -952,6 +954,7 @@ func (r *Runner) runAgentTurn(
 	result.PullRequestUpdated = progress.pullRequestUpdated()
 	result.PullRequestHeadPushed = progress.pullRequestHeadPushed()
 	result.CITriggerLabelReapplied = progress.ciTriggerLabelReapplied()
+	result.ForgeWriteCompleted = progress.forgeWriteCompleted()
 	if turnErr == nil {
 		if deliverableErr := progress.deliverableError(); deliverableErr != nil {
 			turnErr = deliverableErr
@@ -1084,6 +1087,7 @@ func (r *Runner) Run(ctx context.Context, req RunRequest) (RunResult, error) {
 		ctx = context.Background()
 	}
 	workflow, agentRuntime, budgetChecker, dispatchEstimator := r.runtimeSnapshot()
+	forgeHost := forgeavailability.HostFromEndpoint(workflow.Config.Tracker.Endpoint)
 	mode := normalizeRunMode(req.Mode)
 	if mode == RunModeMerge && mergeFastPathCheckedHead(req.Issue) {
 		r.logWorkerEvent(req.Issue, "worker_merge_fast_path_checked_head",
@@ -1112,7 +1116,7 @@ func (r *Runner) Run(ctx context.Context, req RunRequest) (RunResult, error) {
 	}
 	info, err := runWorkspace.Create(ctx, workspaceIssue)
 	if err != nil {
-		return RunResult{}, fmt.Errorf("create workspace: %w", err)
+		return RunResult{}, classifyForgeOperationError(fmt.Errorf("create workspace: %w", err), "git fetch", forgeHost)
 	}
 	r.logWorkerEvent(req.Issue, "worker_workspace_created",
 		telemetry.WorkAttemptIDKey, req.WorkAttemptID,
@@ -1143,7 +1147,11 @@ func (r *Runner) Run(ctx context.Context, req RunRequest) (RunResult, error) {
 		} else {
 			precheckResult, precheck, handled, err := r.prepareMergeFastPath(ctx, req, info, workspaceIssue)
 			if err != nil {
-				return RunResult{}, err
+				operation := "git fetch"
+				if strings.Contains(strings.ToLower(err.Error()), "git push") {
+					operation = "git push"
+				}
+				return RunResult{}, classifyForgeOperationError(err, operation, forgeHost)
 			}
 			mergePrecheck = mergePrecheckFromWorkspace(precheck)
 			if handled {
@@ -1195,6 +1203,12 @@ func (r *Runner) Run(ctx context.Context, req RunRequest) (RunResult, error) {
 	}
 	if err != nil {
 		return RunResult{}, fmt.Errorf("build prompt: %w", err)
+	}
+	if req.ForgeRetry != nil && !strings.Contains(strings.ToLower(req.ForgeRetry.Operation), "git fetch") {
+		prompt = forgeRetryPrompt(*req.ForgeRetry, req.Issue)
+		if strings.TrimSpace(req.ForgeRetry.Branch) != "" && req.Issue.PullRequest == nil {
+			req.deliverableRecoveryBranch = strings.TrimSpace(req.ForgeRetry.Branch)
+		}
 	}
 	role := runRole(req.Mode, req.Issue)
 	routeRole := agentRuntime.effectiveRunRole(role)
@@ -1350,7 +1364,7 @@ func (r *Runner) Run(ctx context.Context, req RunRequest) (RunResult, error) {
 	commandStartedAttrs = append(commandStartedAttrs, runtimeIdentityLogAttrs(runtimeIdentity)...)
 	r.logWorkerEvent(req.Issue, "worker_command_started", commandStartedAttrs...)
 	turnPrompt := prompt
-	if orphanRecovery && !agentResumeStateEmpty(resumeState) {
+	if req.ForgeRetry == nil && orphanRecovery && !agentResumeStateEmpty(resumeState) {
 		turnPrompt = orphanResumePrompt
 	}
 	var extraWritableRoots []string
@@ -1421,6 +1435,12 @@ func (r *Runner) Run(ctx context.Context, req RunRequest) (RunResult, error) {
 			execution.err = classifyAgentCapacityError(backend, selection, backendConfig, execution.result.RuntimeIdentity, execution.err, execution.result.RateLimits, runStartedAt)
 		}
 	}
+	if req.ForgeRetry != nil && strings.Contains(strings.ToLower(req.ForgeRetry.Operation), "git fetch") {
+		execution.result.ForgeWriteCompleted = true
+	}
+	if req.ForgeRetry != nil && req.ForgeRetry.WorkProductPushed {
+		execution.result.PullRequestHeadPushed = true
+	}
 	turns := int64(max(execution.turnCount, 1))
 	if deliverableErr, ok := recoverablePullRequestDeliverable(execution); ok {
 		branch := strings.TrimSpace(info.Branch)
@@ -1489,6 +1509,7 @@ func (r *Runner) Run(ctx context.Context, req RunRequest) (RunResult, error) {
 	turnErr := execution.err
 	cleanupErr := execution.cleanupErr
 	result := execution.result
+	result.WorkspaceBranch = strings.TrimSpace(info.Branch)
 	if mergeFallback && turnErr == nil {
 		targetBranch := ""
 		if req.Issue.PullRequest != nil {
@@ -1499,6 +1520,7 @@ func (r *Runner) Run(ctx context.Context, req RunRequest) (RunResult, error) {
 			result.FinalState = finalStateForTurnError(turnErr)
 		}
 	}
+	turnErr = classifyForgeDeliverableError(turnErr, forgeHost, result.PullRequestHeadPushed)
 	result.budgetProjection = budgetProjection
 	if brakeDiff := sessionBrake.resultDiffStats(); brakeDiff != (DiffStats{}) {
 		result.DiffStats = brakeDiff
@@ -1588,7 +1610,7 @@ func (r *Runner) Run(ctx context.Context, req RunRequest) (RunResult, error) {
 		finishedAt := r.now().UTC()
 		result.Tokens.RuntimeSeconds = runtimeSeconds(runStartedAt, finishedAt)
 		return result, errors.Join(
-			fmt.Errorf("workspace diff stat: %w", err),
+			classifyForgeOperationError(fmt.Errorf("workspace diff stat: %w", err), "git fetch", forgeHost),
 			r.finishSession(ctx, sessionID, sessionStarted, req.WorkAttemptID, req.Issue, startedAt, finishedAt, result, sessionModel, backendConfig.Kind, turns, turnResult, resumeState.DetentSessionID),
 		)
 	}
@@ -1614,6 +1636,52 @@ func recoverablePullRequestDeliverable(execution agentTurnExecution) (*Deliverab
 		return nil, false
 	}
 	return pullRequestDeliverableFailure(execution.err)
+}
+
+func classifyForgeDeliverableError(err error, fallbackHost string, workProductPushed bool) error {
+	if err == nil {
+		return nil
+	}
+	if availabilityErr, ok := forgeavailability.As(err); ok && availabilityErr != nil {
+		return err
+	}
+	errorsFound, _ := deliverableCommandErrors(err)
+	for _, deliverableErr := range errorsFound {
+		if deliverableErr == nil {
+			continue
+		}
+		if workProductPushed && strings.Contains(strings.ToLower(deliverableErr.Arguments), "ci-trigger-label") {
+			continue
+		}
+		operation := strings.TrimSpace(deliverableErr.Operation)
+		if deliverableErr.OperationClass == "push" && !strings.Contains(strings.ToLower(operation), "git push") {
+			operation = "git push"
+		}
+		class, unavailable := forgeavailability.Classify(operation, deliverableErr.Error())
+		if !unavailable {
+			continue
+		}
+		host := forgeavailability.HostFromText(deliverableErr.Arguments + " " + deliverableErr.Error())
+		if host == "" {
+			host = fallbackHost
+		}
+		return forgeavailability.NewError(forgeavailability.Scope{Host: host, Operation: operation}, class, err)
+	}
+	return err
+}
+
+func classifyForgeOperationError(err error, operation string, host string) error {
+	if err == nil {
+		return nil
+	}
+	class, unavailable := forgeavailability.Classify(operation, err.Error())
+	if !unavailable {
+		return err
+	}
+	if observedHost := forgeavailability.HostFromText(err.Error()); observedHost != "" {
+		host = observedHost
+	}
+	return forgeavailability.NewError(forgeavailability.Scope{Host: host, Operation: operation}, class, err)
 }
 
 func pullRequestDeliverableFailure(err error) (*DeliverableCommandError, bool) {
@@ -1691,6 +1759,38 @@ func deliverableRecoveryPrompt(branch string, repository string, deliverableErr 
 	return prompt.String()
 }
 
+func forgeRetryPrompt(retry ForgeRetry, issue connector.Issue) string {
+	branch := strings.TrimSpace(retry.Branch)
+	operation := strings.TrimSpace(retry.Operation)
+	if operation == "" {
+		operation = "the failed forge write"
+	}
+	var prompt strings.Builder
+	prompt.WriteString("The prior attempt completed its implementation work but the forge was unavailable. Retry only the deliverable write; do not edit files, change commits, rerun implementation, or perform unrelated work.\n\n")
+	if retry.WorkProductPushed {
+		prompt.WriteString("The branch is already pushed. Preserve it and recover the pull request create or update for branch `")
+		prompt.WriteString(branch)
+		prompt.WriteString("`.")
+	} else {
+		prompt.WriteString("Retry `")
+		prompt.WriteString(operation)
+		prompt.WriteString("` for branch `")
+		prompt.WriteString(branch)
+		prompt.WriteString("`. After the push succeeds, create or update the required pull request if one is not already open.")
+	}
+	if repository := strings.TrimSpace(issue.PRRepository); repository != "" {
+		prompt.WriteString(" Use repository `")
+		prompt.WriteString(repository)
+		prompt.WriteString("`.")
+	}
+	if arguments := strings.TrimSpace(retry.Arguments); arguments != "" {
+		prompt.WriteString("\n\nThe failed operation used these arguments:\n\n")
+		prompt.WriteString(arguments)
+	}
+	prompt.WriteString("\n\nComplete the existing Detent Workpad and handoff protocol after delivery succeeds.")
+	return prompt.String()
+}
+
 func mergeAgentTurnExecutions(initial agentTurnExecution, recovery agentTurnExecution) agentTurnExecution {
 	result := recovery.result
 	result.Output = joinAgentOutputs(initial.result.Output, recovery.result.Output)
@@ -1702,6 +1802,7 @@ func mergeAgentTurnExecutions(initial agentTurnExecution, recovery agentTurnExec
 	result.PullRequestUpdated = initial.result.PullRequestUpdated || recovery.result.PullRequestUpdated
 	result.PullRequestHeadPushed = initial.result.PullRequestHeadPushed || recovery.result.PullRequestHeadPushed
 	result.CITriggerLabelReapplied = initial.result.CITriggerLabelReapplied || recovery.result.CITriggerLabelReapplied
+	result.ForgeWriteCompleted = initial.result.ForgeWriteCompleted || recovery.result.ForgeWriteCompleted
 	if result.DiffStats == (DiffStats{}) {
 		result.DiffStats = initial.result.DiffStats
 	}
@@ -3056,6 +3157,7 @@ func (p *agentRunProgress) recordDeliverableToolCompletion(update AgentUpdate) {
 		case "push":
 			delete(p.deliverableFailures, "push")
 			p.deliverableSuccesses["push"] = true
+			p.deliverableSuccesses["forge_write"] = true
 			if gitPushChanged(update, invocation.command) {
 				p.successfulPushes++
 				p.ciTriggerLabelValid = false
@@ -3070,6 +3172,7 @@ func (p *agentRunProgress) recordDeliverableToolCompletion(update AgentUpdate) {
 			delete(p.deliverableFailures, "ci_trigger_label")
 			p.deliverableSuccesses["push"] = true
 			p.deliverableSuccesses["ci_trigger_label"] = true
+			p.deliverableSuccesses["forge_write"] = true
 			if gitPushChanged(update, invocation.command) {
 				p.successfulPushes++
 			}
@@ -3078,6 +3181,7 @@ func (p *agentRunProgress) recordDeliverableToolCompletion(update AgentUpdate) {
 		case "pull_request":
 			delete(p.deliverableFailures, "pull_request")
 			p.deliverableSuccesses["pull_request"] = true
+			p.deliverableSuccesses["forge_write"] = true
 		case "pull_request_lookup":
 			if pullRequestLookupAdopts(update, p.deliverableRecoveryBranch) {
 				delete(p.deliverableFailures, "pull_request")
@@ -3131,6 +3235,10 @@ func (p *agentRunProgress) pullRequestHeadPushed() bool {
 
 func (p *agentRunProgress) ciTriggerLabelReapplied() bool {
 	return p.successfulPushes > 0 && p.ciTriggerLabelValid && p.ciTriggerPushSequence == p.successfulPushes
+}
+
+func (p *agentRunProgress) forgeWriteCompleted() bool {
+	return p.deliverableSuccesses["forge_write"]
 }
 
 func (p *agentRunProgress) deliverableError() error {

--- a/internal/runner/forge_availability_test.go
+++ b/internal/runner/forge_availability_test.go
@@ -1,0 +1,53 @@
+package runner
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/digitaldrywood/detent/internal/forgeavailability"
+)
+
+func TestClassifyForgeDeliverableError(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		operation string
+		message   string
+		wantClass string
+		wantTyped bool
+	}{
+		{name: "git 503", operation: "git push", message: "HTTP 503: unavailable", wantClass: forgeavailability.ClassServer, wantTyped: true},
+		{name: "git timeout", operation: "git push", message: "operation timed out", wantClass: forgeavailability.ClassTimeout, wantTyped: true},
+		{name: "git DNS", operation: "git push", message: "Could not resolve host: github.com", wantClass: forgeavailability.ClassTransport, wantTyped: true},
+		{name: "pull request 502", operation: "codex_apps/github.create_pull_request", message: "HTTP 502: bad gateway", wantClass: forgeavailability.ClassServer, wantTyped: true},
+		{name: "non fast forward", operation: "git push", message: "[rejected] feature -> feature (non-fast-forward)"},
+		{name: "forbidden", operation: "git push", message: "HTTP 403: forbidden"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			deliverableErr := &DeliverableCommandError{
+				OperationClass: "push",
+				Operation:      tt.operation,
+				Status:         "failed",
+				Message:        tt.message,
+			}
+			got := classifyForgeDeliverableError(deliverableErr, "github.com", false)
+			availabilityErr, typed := forgeavailability.As(got)
+			if typed != tt.wantTyped {
+				t.Fatalf("typed = %v, want %v; error = %v", typed, tt.wantTyped, got)
+			}
+			if !tt.wantTyped {
+				if !errors.Is(got, deliverableErr) {
+					t.Fatalf("error = %v, want original deliverable failure", got)
+				}
+				return
+			}
+			if availabilityErr.Class != tt.wantClass || availabilityErr.Scope.Host != "github.com" {
+				t.Fatalf("forge error = %#v, want class %q on github.com", availabilityErr, tt.wantClass)
+			}
+		})
+	}
+}

--- a/internal/runner/types.go
+++ b/internal/runner/types.go
@@ -434,9 +434,18 @@ type RunRequest struct {
 	AgentToolHandler          AgentToolHandler
 	AcquireModelPermit        ModelPermitAcquirer
 	MergePrecheck             *MergePrecheck
+	ForgeRetry                *ForgeRetry
 	sessionBrake              *sessionBrakeController
 	deliverableRecoveryBranch string
 	sessionTurnOffset         int
+}
+
+type ForgeRetry struct {
+	Host              string
+	Operation         string
+	Arguments         string
+	Branch            string
+	WorkProductPushed bool
 }
 
 type SessionProgressProbe func(context.Context) (string, error)
@@ -520,6 +529,8 @@ type RunResult struct {
 	PullRequestUpdated      bool
 	PullRequestHeadPushed   bool
 	CITriggerLabelReapplied bool
+	ForgeWriteCompleted     bool
+	WorkspaceBranch         string
 	MergePrecheck           *MergePrecheck
 	MergeFallbackFindings   string
 	budgetProjection        *dispatchBudgetProjection

--- a/internal/store/capacity_constraints.go
+++ b/internal/store/capacity_constraints.go
@@ -20,6 +20,7 @@ const (
 	CapacityConstraintWorkerHost         CapacityConstraintReason = "worker_host_capacity_full"
 	CapacityConstraintRateWindow         CapacityConstraintReason = "provider_rate_window_backpressure"
 	CapacityConstraintTrackerUnavailable CapacityConstraintReason = "tracker_unavailable"
+	CapacityConstraintForgeUnavailable   CapacityConstraintReason = "forge_unavailable"
 	CapacityConstraintCIUnavailable      CapacityConstraintReason = "ci_unavailable"
 )
 
@@ -54,7 +55,7 @@ func QueryCapacityConstraintWaits(
 SELECT project_id, COALESCE(lane, ''), wait_reason, decision_at, capacity_snapshot_json
 FROM scheduler_decisions
 WHERE result = ?
-  AND wait_reason IN (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+  AND wait_reason IN (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
   AND decision_at >= ?`,
 		string(SchedulerDecisionResultSkipped),
 		poolCapacityWaitReason,
@@ -67,6 +68,7 @@ WHERE result = ?
 		"worker_host_unavailable",
 		string(CapacityConstraintRateWindow),
 		string(CapacityConstraintTrackerUnavailable),
+		string(CapacityConstraintForgeUnavailable),
 		string(CapacityConstraintCIUnavailable),
 		"local_slot_unavailable",
 		since,
@@ -168,6 +170,8 @@ func capacityConstraintReason(waitReason string, globalAvailable *int) (Capacity
 		return CapacityConstraintRateWindow, true
 	case string(CapacityConstraintTrackerUnavailable):
 		return CapacityConstraintTrackerUnavailable, true
+	case string(CapacityConstraintForgeUnavailable):
+		return CapacityConstraintForgeUnavailable, true
 	case string(CapacityConstraintCIUnavailable):
 		return CapacityConstraintCIUnavailable, true
 	default:

--- a/internal/store/capacity_constraints_test.go
+++ b/internal/store/capacity_constraints_test.go
@@ -74,6 +74,12 @@ func TestCapacityConstraintReason(t *testing.T) {
 			wantOK:     true,
 		},
 		{
+			name:       "forge unavailable",
+			waitReason: "forge_unavailable",
+			want:       CapacityConstraintForgeUnavailable,
+			wantOK:     true,
+		},
+		{
 			name:       "CI unavailable",
 			waitReason: "ci_unavailable",
 			want:       CapacityConstraintCIUnavailable,

--- a/internal/telemetry/snapshot.go
+++ b/internal/telemetry/snapshot.go
@@ -42,6 +42,7 @@ type Snapshot struct {
 	Budget                  Budget              `json:"budget"`
 	RateLimits              *RateLimits         `json:"rate_limits"`
 	TrackerUnavailable      []TrackerCondition  `json:"tracker_unavailable,omitempty"`
+	ForgeUnavailable        []ForgeCondition    `json:"forge_unavailable,omitempty"`
 	CIUnavailable           []CICondition       `json:"ci_unavailable,omitempty"`
 	BackendOutages          []BackendOutage     `json:"backend_outages,omitempty"`
 	FailureBreakers         []FailureBreaker    `json:"failure_breakers,omitempty"`
@@ -129,6 +130,22 @@ type ProviderIncident struct {
 	Impact     string    `json:"impact,omitempty"`
 	Components []string  `json:"components,omitempty"`
 	UpdatedAt  time.Time `json:"updated_at"`
+}
+
+type ForgeCondition struct {
+	ProjectID       string    `json:"project_id,omitempty"`
+	Host            string    `json:"host"`
+	Operation       string    `json:"operation,omitempty"`
+	ErrorClass      string    `json:"error_class"`
+	DetectedAt      time.Time `json:"detected_at"`
+	LastObservedAt  time.Time `json:"last_observed_at"`
+	NextProbeAt     time.Time `json:"next_probe_at,omitzero"`
+	LastProbeAt     time.Time `json:"last_probe_at,omitzero"`
+	LastProbeResult string    `json:"last_probe_result,omitempty"`
+	LastProbeDetail string    `json:"last_probe_detail,omitempty"`
+	ProbeAttempts   int       `json:"probe_attempts,omitempty"`
+	ProbeIssueID    string    `json:"probe_issue_id,omitempty"`
+	LastError       string    `json:"last_error,omitempty"`
 }
 
 type AdmissionProposal struct {

--- a/internal/web/api.go
+++ b/internal/web/api.go
@@ -484,6 +484,7 @@ func stateResponse(snapshot telemetry.Snapshot, generatedAt time.Time, observedA
 		RecentSessions:     recentSessionEntries(snapshot.Completed),
 		RateLimits:         snapshot.RateLimits,
 		TrackerUnavailable: append([]telemetry.TrackerCondition(nil), snapshot.TrackerUnavailable...),
+		ForgeUnavailable:   append([]telemetry.ForgeCondition(nil), snapshot.ForgeUnavailable...),
 		CIUnavailable:      append([]telemetry.CICondition(nil), snapshot.CIUnavailable...),
 		BackendOutages:     append([]telemetry.BackendOutage(nil), snapshot.BackendOutages...),
 		FailureBreakers:    append([]telemetry.FailureBreaker(nil), snapshot.FailureBreakers...),
@@ -1437,6 +1438,7 @@ type stateAPIResponse struct {
 	RecentSessions     []recentSessionAPIResponse   `json:"recent_sessions"`
 	RateLimits         *telemetry.RateLimits        `json:"rate_limits"`
 	TrackerUnavailable []telemetry.TrackerCondition `json:"tracker_unavailable,omitempty"`
+	ForgeUnavailable   []telemetry.ForgeCondition   `json:"forge_unavailable,omitempty"`
 	CIUnavailable      []telemetry.CICondition      `json:"ci_unavailable,omitempty"`
 	BackendOutages     []telemetry.BackendOutage    `json:"backend_outages,omitempty"`
 	FailureBreakers    []telemetry.FailureBreaker   `json:"failure_breakers,omitempty"`

--- a/internal/web/forge_availability.go
+++ b/internal/web/forge_availability.go
@@ -1,0 +1,57 @@
+package web
+
+import (
+	"errors"
+	"net/http"
+	"strings"
+
+	"github.com/labstack/echo/v4"
+
+	"github.com/digitaldrywood/detent/internal/orchestrator"
+	"github.com/digitaldrywood/detent/internal/project"
+)
+
+type forgeAvailabilityClearResponse struct {
+	Status  string `json:"status"`
+	Project string `json:"project,omitempty"`
+	Host    string `json:"host,omitempty"`
+	Cleared int    `json:"cleared"`
+}
+
+func (s *Server) apiForgeAvailabilityClear(c echo.Context) error {
+	projectID := strings.TrimSpace(c.FormValue("project_id"))
+	host := strings.TrimSpace(c.FormValue("host"))
+	projects := s.registry.List()
+	if projectID != "" {
+		selected, ok := s.registry.Get(project.ID(projectID))
+		if !ok {
+			return c.JSON(http.StatusNotFound, errorResponse("project_not_found", "project not found"))
+		}
+		projects = []*project.Project{selected}
+	}
+
+	cleared := 0
+	for _, candidate := range projects {
+		conditions, err := candidate.Orchestrator().ClearForgeAvailability(c.Request().Context(), host)
+		if err != nil {
+			if errors.Is(err, orchestrator.ErrStopped) {
+				continue
+			}
+			s.logger.Warn("forge availability clear failed", "project_id", candidate.ID(), "host", host, "error", err)
+			return c.JSON(http.StatusServiceUnavailable, errorResponse("forge_availability_clear_failed", "forge availability condition clear failed"))
+		}
+		cleared += len(conditions)
+	}
+
+	s.logger.Info("forge availability clear requested", "project_id", projectID, "host", host, "cleared", cleared)
+	if c.Request().Header.Get("HX-Request") == "true" {
+		c.Response().Header().Set("HX-Trigger", "forgeAvailabilityCleared")
+		return c.NoContent(http.StatusNoContent)
+	}
+	return c.JSON(http.StatusOK, forgeAvailabilityClearResponse{
+		Status:  "cleared",
+		Project: projectID,
+		Host:    host,
+		Cleared: cleared,
+	})
+}

--- a/internal/web/openapi.yaml
+++ b/internal/web/openapi.yaml
@@ -573,6 +573,33 @@ paths:
               schema: {$ref: "#/components/schemas/Status"}
         "404": {$ref: "#/components/responses/Problem"}
         "503": {$ref: "#/components/responses/Unavailable"}
+  /api/v1/forge/availability/clear:
+    post:
+      operationId: clearForgeAvailability
+      summary: Clear recorded forge-write availability conditions
+      tags: [administration]
+      security:
+        - bearerAuth: []
+        - apiKeyAuth: []
+      x-detent-access: admin
+      x-detent-scope: admin
+      x-detent-echo-path: /api/v1/forge/availability/clear
+      requestBody:
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              type: object
+              properties:
+                project_id: {type: string}
+                host: {type: string}
+      responses:
+        "200":
+          description: Forge availability records cleared.
+          content:
+            application/json:
+              schema: {$ref: "#/components/schemas/Status"}
+        "404": {$ref: "#/components/responses/Problem"}
+        "503": {$ref: "#/components/responses/Unavailable"}
   /api/v1/failure-breaker/canary:
     post:
       operationId: requestFailureBreakerCanary

--- a/internal/web/project_scope.go
+++ b/internal/web/project_scope.go
@@ -72,6 +72,7 @@ func projectScopedSnapshotForProject(snapshot telemetry.Snapshot, selectedProjec
 	out.Blocked = scopedBlocked(snapshot.Blocked, selectedProjectID, fallbackProjectID)
 	out.Completed = scopedCompleted(snapshot.Completed, selectedProjectID, fallbackProjectID)
 	out.TrackerUnavailable = scopedTrackerUnavailable(snapshot.TrackerUnavailable, selectedProjectID, fallbackProjectID)
+	out.ForgeUnavailable = scopedForgeUnavailable(snapshot.ForgeUnavailable, selectedProjectID, fallbackProjectID)
 	out.CIUnavailable = scopedCIUnavailable(snapshot.CIUnavailable, selectedProjectID, fallbackProjectID)
 	out.FailureBreakers = scopedFailureBreakers(snapshot.FailureBreakers, selectedProjectID, fallbackProjectID)
 	out.DispatchRecoveries = scopedDispatchRecoveries(snapshot.DispatchRecoveries, selectedProjectID, fallbackProjectID)
@@ -136,6 +137,20 @@ func scopedCIUnavailable(conditions []telemetry.CICondition, selectedProjectID s
 
 func scopedTrackerUnavailable(conditions []telemetry.TrackerCondition, selectedProjectID string, fallbackProjectID string) []telemetry.TrackerCondition {
 	out := make([]telemetry.TrackerCondition, 0, len(conditions))
+	for _, condition := range conditions {
+		projectID := strings.TrimSpace(condition.ProjectID)
+		if projectID == "" {
+			projectID = fallbackProjectID
+		}
+		if projectID == selectedProjectID {
+			out = append(out, condition)
+		}
+	}
+	return out
+}
+
+func scopedForgeUnavailable(conditions []telemetry.ForgeCondition, selectedProjectID string, fallbackProjectID string) []telemetry.ForgeCondition {
+	out := make([]telemetry.ForgeCondition, 0, len(conditions))
 	for _, condition := range conditions {
 		projectID := strings.TrimSpace(condition.ProjectID)
 		if projectID == "" {

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -435,6 +435,7 @@ func (s *Server) registerRoutes() {
 	s.echo.POST("/api/v1/update/apply", s.apiUpdateApply, apiDashboardMutateAuth, apiAdminScope)
 	s.echo.POST("/api/v1/capacity/clear", s.apiCapacityClear, apiDashboardMutateAuth, apiAdminScope)
 	s.echo.POST("/api/v1/tracker/availability/clear", s.apiTrackerAvailabilityClear, apiDashboardMutateAuth, apiAdminScope)
+	s.echo.POST("/api/v1/forge/availability/clear", s.apiForgeAvailabilityClear, apiDashboardMutateAuth, apiAdminScope)
 	s.echo.POST("/api/v1/failure-breaker/canary", s.apiFailureBreakerCanary, apiDashboardMutateAuth, apiAdminScope)
 	s.echo.POST("/api/v1/webhooks/github", s.githubWebhook)
 	s.echo.POST("/api/v1/intake/:project_id/:source", s.intakeWebhook)
@@ -1082,6 +1083,7 @@ func (s *Server) health(c echo.Context) error {
 	backendOutages := []telemetry.BackendOutage{}
 	failureBreakers := []telemetry.FailureBreaker{}
 	trackerUnavailable := []telemetry.TrackerCondition{}
+	forgeUnavailable := []telemetry.ForgeCondition{}
 	ciUnavailable := []telemetry.CICondition{}
 	stalenessWarnings := []telemetry.StalenessWarning{}
 	strandedActiveIssues := []telemetry.StrandedIssue{}
@@ -1103,6 +1105,7 @@ func (s *Server) health(c echo.Context) error {
 			backendOutages = append(backendOutages, snapshot.BackendOutages...)
 			failureBreakers = append(failureBreakers, snapshot.FailureBreakers...)
 			trackerUnavailable = append(trackerUnavailable, snapshot.TrackerUnavailable...)
+			forgeUnavailable = append(forgeUnavailable, snapshot.ForgeUnavailable...)
 			ciUnavailable = append(ciUnavailable, snapshot.CIUnavailable...)
 			stalenessWarnings = append(stalenessWarnings, snapshot.StalenessWarnings...)
 			strandedActiveIssues = append(strandedActiveIssues, snapshot.StrandedActiveIssues...)
@@ -1137,13 +1140,13 @@ func (s *Server) health(c echo.Context) error {
 		checks["demo_clock"] = s.demo.clock
 	}
 	projectStatus, projectHealth := s.projectHealth()
-	projectHealth = applyNeedsAttentionToProjectHealth(projectHealth, dispatchStalls, trackerUnavailable, ciUnavailable, failureBreakers, backendOutages, tickLiveness, refreshFailures)
+	projectHealth = applyNeedsAttentionToProjectHealth(projectHealth, dispatchStalls, trackerUnavailable, forgeUnavailable, ciUnavailable, failureBreakers, backendOutages, tickLiveness, refreshFailures)
 	var budgets []healthBudget
 	var workflows []healthWorkflowSource
 	if status != "draining" {
 		budgets = s.enforcedBudgets()
 		workflows = s.workflowSources()
-		if len(trackerUnavailable) > 0 || len(ciUnavailable) > 0 || len(dispatchStalls) > 0 || len(failureBreakers) > 0 || len(backendOutages) > 0 || tickLivenessNeedsAttention(tickLiveness) || len(refreshFailures) > 0 {
+		if len(trackerUnavailable) > 0 || len(forgeUnavailable) > 0 || len(ciUnavailable) > 0 || len(dispatchStalls) > 0 || len(failureBreakers) > 0 || len(backendOutages) > 0 || tickLivenessNeedsAttention(tickLiveness) || len(refreshFailures) > 0 {
 			status = "needs_attention"
 		}
 	}
@@ -1161,6 +1164,7 @@ func (s *Server) health(c echo.Context) error {
 		Budgets:              budgets,
 		Workflows:            workflows,
 		TrackerUnavailable:   trackerUnavailable,
+		ForgeUnavailable:     forgeUnavailable,
 		CIUnavailable:        ciUnavailable,
 		BackendOutages:       backendOutages,
 		FailureBreakers:      failureBreakers,
@@ -1178,8 +1182,8 @@ func (s *Server) health(c echo.Context) error {
 	})
 }
 
-func applyNeedsAttentionToProjectHealth(projects []healthProject, stalls []telemetry.DispatchStatus, trackerUnavailable []telemetry.TrackerCondition, ciUnavailable []telemetry.CICondition, breakers []telemetry.FailureBreaker, outages []telemetry.BackendOutage, tickLiveness []telemetry.TickLiveness, refreshFailures []telemetry.RefreshFailure) []healthProject {
-	needsAttention := make(map[string]struct{}, len(stalls)+len(trackerUnavailable)+len(ciUnavailable)+len(breakers)+len(outages)+len(tickLiveness))
+func applyNeedsAttentionToProjectHealth(projects []healthProject, stalls []telemetry.DispatchStatus, trackerUnavailable []telemetry.TrackerCondition, forgeUnavailable []telemetry.ForgeCondition, ciUnavailable []telemetry.CICondition, breakers []telemetry.FailureBreaker, outages []telemetry.BackendOutage, tickLiveness []telemetry.TickLiveness, refreshFailures []telemetry.RefreshFailure) []healthProject {
+	needsAttention := make(map[string]struct{}, len(stalls)+len(trackerUnavailable)+len(forgeUnavailable)+len(ciUnavailable)+len(breakers)+len(outages)+len(tickLiveness))
 	refreshByProject := make(map[string]telemetry.RefreshFailure, len(refreshFailures))
 	for _, stall := range stalls {
 		if projectID := strings.TrimSpace(stall.ProjectID); projectID != "" && stall.Stalled {
@@ -1192,6 +1196,11 @@ func applyNeedsAttentionToProjectHealth(projects []healthProject, stalls []telem
 		}
 	}
 	for _, condition := range trackerUnavailable {
+		if projectID := strings.TrimSpace(condition.ProjectID); projectID != "" {
+			needsAttention[projectID] = struct{}{}
+		}
+	}
+	for _, condition := range forgeUnavailable {
 		if projectID := strings.TrimSpace(condition.ProjectID); projectID != "" {
 			needsAttention[projectID] = struct{}{}
 		}
@@ -1504,6 +1513,7 @@ type healthResponse struct {
 	Budgets              []healthBudget               `json:"budgets,omitempty"`
 	Workflows            []healthWorkflowSource       `json:"workflows,omitempty"`
 	TrackerUnavailable   []telemetry.TrackerCondition `json:"tracker_unavailable,omitempty"`
+	ForgeUnavailable     []telemetry.ForgeCondition   `json:"forge_unavailable,omitempty"`
 	CIUnavailable        []telemetry.CICondition      `json:"ci_unavailable,omitempty"`
 	BackendOutages       []telemetry.BackendOutage    `json:"backend_outages,omitempty"`
 	FailureBreakers      []telemetry.FailureBreaker   `json:"failure_breakers,omitempty"`

--- a/internal/web/server_test.go
+++ b/internal/web/server_test.go
@@ -257,6 +257,22 @@ func TestTrackerAvailabilityClearEndpointIsIdempotentWithoutConditions(t *testin
 	}
 }
 
+func TestForgeAvailabilityClearEndpointIsIdempotentWithoutConditions(t *testing.T) {
+	t.Parallel()
+
+	server, err := web.NewServer(web.Config{}, testDeps(t))
+	if err != nil {
+		t.Fatalf("NewServer() error = %v", err)
+	}
+	recorder := performForm(t, server.Handler(), http.MethodPost, "/api/v1/forge/availability/clear", nil)
+	if recorder.Code != http.StatusNoContent {
+		t.Fatalf("status = %d, want %d; body = %s", recorder.Code, http.StatusNoContent, recorder.Body.String())
+	}
+	if recorder.Header().Get("HX-Trigger") != "forgeAvailabilityCleared" {
+		t.Fatalf("HX-Trigger = %q", recorder.Header().Get("HX-Trigger"))
+	}
+}
+
 func TestFailureBreakerCanaryEndpointIsIdempotentWithoutActiveBreakers(t *testing.T) {
 	t.Parallel()
 

--- a/internal/web/templates/board_data.go
+++ b/internal/web/templates/board_data.go
@@ -37,6 +37,7 @@ const (
 	boardAlertKindFailureBreaker         boardAlertKind = "project-failure-breaker"
 	boardAlertKindDispatchStall          boardAlertKind = "dispatch-stall"
 	boardAlertKindTrackerUnavailable     boardAlertKind = "tracker-unavailable"
+	boardAlertKindForgeUnavailable       boardAlertKind = "forge-unavailable"
 	boardAlertKindCIUnavailable          boardAlertKind = "ci-unavailable"
 	boardAlertKindStaleness              boardAlertKind = "staleness-warning"
 	boardAlertKindTrackerStale           boardAlertKind = "board-stale-data"
@@ -54,6 +55,7 @@ const (
 	boardAlertSeverityFailureBreaker                    = 500
 	boardAlertSeverityCIUnavailable                     = 550
 	boardAlertSeverityTrackerUnavailable                = 560
+	boardAlertSeverityForgeUnavailable                  = 565
 	boardAlertSeverityDispatchStall                     = 575
 	boardAlertSeverityLastKnown                         = 600
 )
@@ -99,6 +101,9 @@ func boardAlerts(snapshot telemetry.Snapshot) []boardAlert {
 		alerts = append(alerts, alert)
 	}
 	if alert, ok := boardTrackerUnavailableAlert(snapshot); ok {
+		alerts = append(alerts, alert)
+	}
+	if alert, ok := boardForgeUnavailableAlert(snapshot); ok {
 		alerts = append(alerts, alert)
 	}
 	if alert, ok := boardDispatchStallAlert(snapshot); ok {
@@ -268,6 +273,73 @@ func boardTrackerUnavailableAlert(snapshot telemetry.Snapshot) (boardAlert, bool
 			Path:    path,
 			Target:  "#board-alert-tracker-unavailable",
 			Confirm: "Clear the tracker availability condition and resume dispatch?",
+		}
+	}
+	return alert, true
+}
+
+func boardForgeUnavailableAlert(snapshot telemetry.Snapshot) (boardAlert, bool) {
+	if len(snapshot.ForgeUnavailable) == 0 {
+		return boardAlert{}, false
+	}
+	rows := make([]boardAlertDetailRow, 0, len(snapshot.ForgeUnavailable))
+	for index, condition := range snapshot.ForgeUnavailable {
+		label := strings.TrimSpace(condition.ProjectID)
+		if label == "" {
+			label = strings.TrimSpace(condition.Host)
+		}
+		if label == "" {
+			label = "Forge"
+		}
+		host := strings.TrimSpace(condition.Host)
+		if host == "" {
+			host = "Configured"
+		}
+		detail := strings.Trim(strings.TrimSpace(condition.Operation)+" · "+strings.TrimSpace(condition.ErrorClass), " ·")
+		if !condition.NextProbeAt.IsZero() {
+			delay := condition.NextProbeAt.Sub(snapshot.GeneratedAt)
+			if delay < 0 {
+				delay = 0
+			}
+			detail += " · next write canary in " + formatDuration(delay.Seconds())
+		}
+		rows = append(rows, boardAlertDetailRow{
+			ID:      "board-alert-forge-unavailable-" + boardAlertRowSlug(label, index),
+			Label:   label,
+			Summary: host + " forge · forge_unavailable",
+			Detail:  strings.Trim(detail, " ·"),
+		})
+	}
+	rows, overflow := capBoardAlertRows(rows)
+	alert := boardAlert{
+		ID:            "board-alert-forge-unavailable",
+		Kind:          boardAlertKindForgeUnavailable,
+		Severity:      boardAlertSeverityForgeUnavailable,
+		Tone:          primitives.KindErr,
+		TerseSummary:  "Forge writes unavailable (" + boardCountLabel(len(snapshot.ForgeUnavailable), "host", "hosts") + ")",
+		DetailSummary: "Push and pull-request delivery are paused until a write canary succeeds; other work can proceed.",
+		DetailRows:    rows,
+		Overflow:      overflow,
+		DeepLink:      "/health/ui",
+	}
+	if len(snapshot.ForgeUnavailable) == 1 {
+		condition := snapshot.ForgeUnavailable[0]
+		query := url.Values{}
+		if projectID := strings.TrimSpace(condition.ProjectID); projectID != "" {
+			query.Set("project_id", projectID)
+		}
+		if host := strings.TrimSpace(condition.Host); host != "" {
+			query.Set("host", host)
+		}
+		path := "/api/v1/forge/availability/clear"
+		if encoded := query.Encode(); encoded != "" {
+			path += "?" + encoded
+		}
+		alert.Action = &boardAlertAction{
+			Label:   "Clear condition",
+			Path:    path,
+			Target:  "#board-alert-forge-unavailable",
+			Confirm: "Clear the forge availability condition and allow write delivery to resume?",
 		}
 	}
 	return alert, true

--- a/internal/web/templates/board_data_test.go
+++ b/internal/web/templates/board_data_test.go
@@ -2554,6 +2554,37 @@ func TestBoardAlertsCorroborateTrackerIncident(t *testing.T) {
 	}
 }
 
+func TestBoardAlertsNameForgeWriteConditionDistinctly(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 8, 17, 18, 0, 0, 0, time.UTC)
+	alerts := boardAlerts(telemetry.Snapshot{
+		GeneratedAt: now,
+		ForgeUnavailable: []telemetry.ForgeCondition{{
+			ProjectID:   "detent",
+			Host:        "github.com",
+			Operation:   "git push",
+			ErrorClass:  "transport",
+			NextProbeAt: now.Add(30 * time.Second),
+		}},
+	})
+	if len(alerts) != 1 || alerts[0].Kind != boardAlertKindForgeUnavailable || alerts[0].Tone != primitives.KindErr {
+		t.Fatalf("boardAlerts() = %#v, want forge-unavailable error", alerts)
+	}
+	combined := alerts[0].TerseSummary + " " + alerts[0].DetailSummary + " " + alerts[0].DetailRows[0].Summary + " " + alerts[0].DetailRows[0].Detail
+	for _, want := range []string{"Forge writes unavailable", "github.com forge", "forge_unavailable", "git push", "transport", "next write canary in 30s"} {
+		if !strings.Contains(combined, want) {
+			t.Fatalf("forge alert = %q, want containing %q", combined, want)
+		}
+	}
+	if strings.Contains(combined, "Tracker unavailable") || strings.Contains(combined, "tracker reads") {
+		t.Fatalf("forge alert = %q, want no tracker-read label", combined)
+	}
+	if alerts[0].Action == nil || !strings.Contains(alerts[0].Action.Path, "host=github.com") || !strings.Contains(alerts[0].Action.Path, "project_id=detent") {
+		t.Fatalf("forge alert action = %#v, want host- and project-scoped clear", alerts[0].Action)
+	}
+}
+
 func TestBoardAlertsSurfaceDispatchStallAsNeedsAttention(t *testing.T) {
 	t.Parallel()
 

--- a/internal/web/templates/dashboard_data.go
+++ b/internal/web/templates/dashboard_data.go
@@ -7182,6 +7182,8 @@ func dispatchRecoveryKindLabel(kind string) string {
 	switch strings.TrimSpace(kind) {
 	case "tracker_unavailable":
 		return "tracker availability"
+	case "forge_unavailable":
+		return "forge write availability"
 	case "github_rest":
 		return "GitHub REST capacity"
 	case "pull_request_hydration":

--- a/internal/web/templates/health_data.go
+++ b/internal/web/templates/health_data.go
@@ -57,6 +57,12 @@ func healthViewFromDashboard(data DashboardData) healthView {
 		view.Detail = trackerUnavailableHealthDetail(snapshot.TrackerUnavailable)
 		return view
 	}
+	if len(snapshot.ForgeUnavailable) > 0 {
+		view.Kind = primitives.KindErr
+		view.Verdict = "Forge writes are unavailable."
+		view.Detail = forgeUnavailableHealthDetail(snapshot.ForgeUnavailable)
+		return view
+	}
 	if len(snapshot.CIUnavailable) > 0 {
 		view.Kind = primitives.KindErr
 		view.Verdict = "CI is unavailable."
@@ -230,6 +236,7 @@ func healthRows(snapshot telemetry.Snapshot) []healthRow {
 		rows = append(rows, healthDispatchStallRow(stall))
 	}
 	rows = append(rows, healthTrackerUnavailableRows(snapshot.TrackerUnavailable)...)
+	rows = append(rows, healthForgeUnavailableRows(snapshot.ForgeUnavailable)...)
 	rows = append(rows, healthCIUnavailableRows(snapshot.CIUnavailable)...)
 	for _, warning := range snapshot.StalenessWarnings {
 		rows = append(rows, healthStalenessRow(warning))
@@ -352,6 +359,32 @@ func healthTrackerUnavailableRows(conditions []telemetry.TrackerCondition) []hea
 	return rows
 }
 
+func healthForgeUnavailableRows(conditions []telemetry.ForgeCondition) []healthRow {
+	rows := make([]healthRow, 0, len(conditions))
+	for index, condition := range conditions {
+		projectID := strings.TrimSpace(condition.ProjectID)
+		if projectID == "" {
+			projectID = "project"
+		}
+		host := strings.TrimSpace(condition.Host)
+		if host == "" {
+			host = "configured forge"
+		}
+		detail := "forge_unavailable · " + strings.Trim(strings.TrimSpace(condition.Operation)+" · "+strings.TrimSpace(condition.ErrorClass), " ·")
+		rows = append(rows, healthRow{
+			ID:        "health-forge-unavailable-" + boardAlertRowSlug(projectID+"-"+host, index),
+			Component: "Forge writes · " + host + " · " + projectID,
+			Kind:      primitives.KindErr,
+			Status:    "Unavailable",
+			Detail:    detail,
+			Resets:    "on successful write canary",
+			ResetAt:   condition.NextProbeAt,
+			DetailAt:  condition.LastObservedAt,
+		})
+	}
+	return rows
+}
+
 func trackerUnavailableHealthDetail(conditions []telemetry.TrackerCondition) string {
 	if len(conditions) == 1 {
 		condition := conditions[0]
@@ -417,6 +450,17 @@ func healthNaturalList(values []string) string {
 	default:
 		return strings.Join(clean[:len(clean)-1], ", ") + ", and " + clean[len(clean)-1]
 	}
+}
+
+func forgeUnavailableHealthDetail(conditions []telemetry.ForgeCondition) string {
+	if len(conditions) == 1 {
+		host := strings.TrimSpace(conditions[0].Host)
+		if host == "" {
+			host = "The configured forge"
+		}
+		return host + " cannot accept push or pull-request writes; write-dependent dispatch is paused."
+	}
+	return boardCountLabel(len(conditions), "forge host cannot", "forge hosts cannot") + " accept writes; write-dependent dispatch is paused."
 }
 
 func ciUnavailableHealthDetail(conditions []telemetry.CICondition) string {

--- a/internal/web/templates/health_data_test.go
+++ b/internal/web/templates/health_data_test.go
@@ -57,6 +57,17 @@ func TestHealthViewVerdicts(t *testing.T) {
 			wantVerdict: "CI is unavailable.",
 		},
 		{
+			name: "forge write unavailability requires attention",
+			snapshot: telemetry.Snapshot{
+				GeneratedAt: now,
+				ForgeUnavailable: []telemetry.ForgeCondition{{
+					ProjectID: "detent", Host: "github.com", Operation: "git push", ErrorClass: "server", NextProbeAt: now.Add(time.Minute),
+				}},
+			},
+			wantKind:    primitives.KindErr,
+			wantVerdict: "Forge writes are unavailable.",
+		},
+		{
 			name: "dispatch stall requires attention",
 			snapshot: telemetry.Snapshot{
 				GeneratedAt: now,

--- a/internal/web/templates/shell_data.go
+++ b/internal/web/templates/shell_data.go
@@ -138,7 +138,7 @@ func appShellActiveNav(data DashboardShellData) string {
 }
 
 func appShellHealthKind(data DashboardShellData) primitives.Kind {
-	if len(data.Snapshot.TrackerUnavailable) > 0 || len(data.Snapshot.CIUnavailable) > 0 {
+	if len(data.Snapshot.TrackerUnavailable) > 0 || len(data.Snapshot.ForgeUnavailable) > 0 || len(data.Snapshot.CIUnavailable) > 0 {
 		return primitives.KindErr
 	}
 	switch gitHubAPIHealth(data.Snapshot).State {


### PR DESCRIPTION
## Summary

- model forge transport and pull-request write availability as a host-scoped `forge_unavailable` condition
- preserve completed and pushed work in durable same-attempt waits that bypass all failure breakers
- hold only write-dependent dispatch, recover through a single write canary, and expose a distinct health/banner surface
- classify availability failures separately from authentication, rate capacity, and rejected pushes

Fixes #1871

## UI Surface Contract

- [x] #1871 explicitly authorizes the forge-unavailable banner and health surface.
- [x] Persistent top-of-screen messaging is explicitly required by #1871.
- [x] Visual changes to primary operator screens include isolated browser verification below.

## Test Plan

- [x] `go test ./internal/forgeavailability ./internal/runner ./internal/orchestrator ./internal/store ./internal/healthnotify ./internal/operatortool ./internal/web ./internal/web/templates`
- [x] `make check` after rebase onto current `origin/main` (race, lint, vet, NilAway, 78.9% coverage, package/file floors)
- [x] Isolated random-port browser verification of the expanded forge banner and distinct health verdict/detail/row