### PR TITLE
fix(dispatch): explain selector declines

### DIFF
--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -71,6 +71,7 @@ type doctorCheck struct {
 	HealthNotificationFailures []healthnotify.Failure                     `json:"health_notification_failures,omitempty"`
 	UntrackedIssues            []doctorStatusDriftIssueDiagnostic         `json:"untracked_issues,omitempty"`
 	OpenTerminalIssues         []doctorStatusDriftIssueDiagnostic         `json:"open_terminal_issues,omitempty"`
+	AuthorizationAttention     []doctorAuthorizationAttentionDiagnostic   `json:"authorization_attention,omitempty"`
 	OwnershipAttention         []doctorOwnershipAttentionDiagnostic       `json:"ownership_attention,omitempty"`
 	ParkReviews                []doctorParkReviewDiagnostic               `json:"park_reviews,omitempty"`
 	ProjectDefinition          *doctorProjectDefinitionDiagnostic         `json:"project_definition,omitempty"`

--- a/internal/cli/doctor_ownership.go
+++ b/internal/cli/doctor_ownership.go
@@ -19,6 +19,134 @@ type doctorOwnershipAttentionDiagnostic struct {
 	Remedy          string `json:"remedy"`
 }
 
+type doctorAuthorizationAttentionDiagnostic struct {
+	IssueID         string        `json:"issue_id,omitempty"`
+	IssueIdentifier string        `json:"issue_identifier,omitempty"`
+	IssueURL        string        `json:"issue_url,omitempty"`
+	State           string        `json:"state,omitempty"`
+	Rule            selector.Rule `json:"rule"`
+	Value           string        `json:"value,omitempty"`
+	Detail          string        `json:"detail"`
+}
+
+func checkDoctorAuthorizationEligibility(
+	ctx context.Context,
+	projectID string,
+	project globalconfig.Project,
+	cfg workflowconfig.Config,
+	deps doctorDeps,
+) doctorCheck {
+	name := "Project " + projectID + " authorization eligibility"
+	if problems := doctorAuthorizationProblems(project.Authorization, cfg.Tracker.Authorization); len(problems) > 0 {
+		return doctorCheck{
+			Name:   name,
+			Status: doctorFail,
+			Detail: "authorization selector is invalid: " + strings.Join(problems, "; "),
+			Hint:   "Fix the authorization selector configuration, then rerun detent doctor.",
+		}
+	}
+	authorization := doctorAuthorizationSelector(project.Authorization, cfg.Tracker.Authorization)
+	if !authorization.Configured() {
+		return doctorCheck{Name: name, Status: doctorOK, Detail: "authorization selector is empty; all issues are allowed"}
+	}
+	if deps.autoPromoteConnector == nil {
+		deps.autoPromoteConnector = defaultDoctorAutoPromoteConnector
+	}
+	projectConnector, err := deps.autoPromoteConnector(cfg)
+	if err != nil {
+		return doctorCheck{Name: name, Status: doctorWarn, Detail: fmt.Sprintf("authorization eligibility could not be checked: %v", err), Hint: "Fix tracker credentials and rerun detent doctor."}
+	}
+	if projectConnector == nil {
+		return doctorCheck{Name: name, Status: doctorWarn, Detail: "authorization eligibility could not be checked: connector is nil", Hint: "Fix tracker configuration and rerun detent doctor."}
+	}
+	states := doctorRequiredGitHubStatusStates(cfg)
+	issues, fetchErr := projectConnector.FetchIssuesByStates(ctx, states)
+	closeErr := closeDoctorAutoPromoteConnector(projectConnector)
+	if fetchErr != nil {
+		return doctorCheck{Name: name, Status: doctorWarn, Detail: fmt.Sprintf("lane-labeled issues could not be checked for authorization eligibility: %v", fetchErr), Hint: "Fix tracker connectivity and rerun detent doctor."}
+	}
+	if closeErr != nil {
+		return doctorCheck{Name: name, Status: doctorWarn, Detail: fmt.Sprintf("authorization diagnostic connector could not be closed: %v", closeErr), Hint: "Rerun detent doctor and check local network resources."}
+	}
+
+	identity := cfg.Identity
+	identity.Normalize()
+	selectorContext := selector.Context{InstanceLogin: identity.GitHubLogin, Persona: identity.Name}
+	diagnostics := make([]doctorAuthorizationAttentionDiagnostic, 0)
+	for _, issue := range issues {
+		if issue.Closed || !doctorIssueHasLaneLabel(issue, cfg.Tracker.StatusLabelPrefix) {
+			continue
+		}
+		decision := selector.Decide(issue, authorization, selectorContext)
+		if decision.Matched {
+			continue
+		}
+		diagnostics = append(diagnostics, doctorAuthorizationAttentionDiagnostic{
+			IssueID:         strings.TrimSpace(issue.ID),
+			IssueIdentifier: strings.TrimSpace(issue.Identifier),
+			IssueURL:        strings.TrimSpace(issue.URL),
+			State:           strings.TrimSpace(issue.State),
+			Rule:            decision.Rule,
+			Value:           decision.Value,
+			Detail:          decision.Detail,
+		})
+	}
+	if len(diagnostics) == 0 {
+		return doctorCheck{Name: name, Status: doctorOK, Detail: "all open lane-labeled issues match the authorization selector"}
+	}
+	summaries := make([]string, 0, len(diagnostics))
+	for _, diagnostic := range diagnostics {
+		identifier := diagnostic.IssueIdentifier
+		if identifier == "" {
+			identifier = diagnostic.IssueID
+		}
+		summaries = append(summaries, identifier+": "+diagnostic.Detail)
+	}
+	return doctorCheck{
+		Name:                   name,
+		Status:                 doctorWarn,
+		Detail:                 fmt.Sprintf("%d open lane-labeled issue(s) cannot dispatch: %s", len(diagnostics), strings.Join(summaries, "; ")),
+		Hint:                   "Correct each issue label or author to match the authorization selector, or update the selector intentionally.",
+		AuthorizationAttention: diagnostics,
+	}
+}
+
+func doctorAuthorizationProblems(projectSelector selector.Selector, workflowSelector selector.Selector) []string {
+	problems := projectSelector.Validate("global.authorization")
+	return append(problems, workflowSelector.Validate("tracker.authorization")...)
+}
+
+func doctorAuthorizationSelector(selectors ...selector.Selector) selector.Selector {
+	configured := make([]selector.Selector, 0, len(selectors))
+	for _, candidate := range selectors {
+		if candidate.Configured() {
+			configured = append(configured, candidate)
+		}
+	}
+	switch len(configured) {
+	case 0:
+		return selector.Selector{}
+	case 1:
+		return configured[0]
+	default:
+		return selector.Selector{And: configured}
+	}
+}
+
+func doctorIssueHasLaneLabel(issue connector.Issue, prefix string) bool {
+	prefix = strings.ToLower(strings.TrimSpace(prefix))
+	if prefix == "" {
+		return false
+	}
+	for _, label := range issue.Labels {
+		label = strings.ToLower(strings.TrimSpace(label))
+		if strings.HasPrefix(label, prefix) && strings.TrimSpace(strings.TrimPrefix(label, prefix)) != "" {
+			return true
+		}
+	}
+	return false
+}
+
 func checkDoctorOwnershipEligibility(
 	ctx context.Context,
 	projectID string,

--- a/internal/cli/doctor_ownership_test.go
+++ b/internal/cli/doctor_ownership_test.go
@@ -61,3 +61,90 @@ func TestDoctorOwnershipEligibility(t *testing.T) {
 		})
 	}
 }
+
+func TestDoctorAuthorizationEligibilityReportsLaneLabeledMismatch(t *testing.T) {
+	t.Parallel()
+
+	cfg := workflowconfig.Default()
+	cfg.Tracker.StatusLabelPrefix = "detent:"
+	cfg.Tracker.ActiveStates = []string{"Todo"}
+	cfg.Tracker.ObservedStates = []string{"Blocked"}
+	cfg.Tracker.TerminalStates = []string{"Done"}
+	issues := []connector.Issue{
+		{ID: "issue-532", Identifier: "gopherguides/corp#532", State: "Todo", Labels: []string{"detent:todo"}},
+		{ID: "issue-authorized", Identifier: "gopherguides/corp#533", State: "Todo", Labels: []string{"detent:todo", "detent"}},
+		{ID: "issue-untracked", Identifier: "gopherguides/corp#534", State: "Todo"},
+		{ID: "issue-closed", Identifier: "gopherguides/corp#535", State: "Done", Closed: true, Labels: []string{"detent:done"}},
+	}
+	tracker := &doctorAuthorizationConnector{issues: issues}
+	check := checkDoctorAuthorizationEligibility(t.Context(), "corp", globalconfig.Project{
+		Authorization: selector.Selector{Labels: selector.Labels{Include: []string{"detent"}}},
+	}, cfg, doctorDeps{
+		autoPromoteConnector: func(workflowconfig.Config) (doctorAutoPromoteConnector, error) {
+			return tracker, nil
+		},
+	})
+
+	if check.Status != doctorWarn || len(check.AuthorizationAttention) != 1 {
+		t.Fatalf("check = %#v, want one authorization warning", check)
+	}
+	diagnostic := check.AuthorizationAttention[0]
+	if diagnostic.IssueIdentifier != "gopherguides/corp#532" || diagnostic.Rule != selector.RuleLabelInclude || diagnostic.Value != "detent" {
+		t.Fatalf("authorization diagnostic = %#v", diagnostic)
+	}
+	for _, want := range []string{"gopherguides/corp#532", "missing required label `detent`"} {
+		if !strings.Contains(check.Detail, want) {
+			t.Fatalf("check detail = %q, want containing %q", check.Detail, want)
+		}
+	}
+	wantStates := []string{"Blocked", "Done", "Todo"}
+	if len(tracker.states) != len(wantStates) {
+		t.Fatalf("states = %#v, want %#v", tracker.states, wantStates)
+	}
+	for index := range wantStates {
+		if tracker.states[index] != wantStates[index] {
+			t.Fatalf("states = %#v, want %#v", tracker.states, wantStates)
+		}
+	}
+}
+
+func TestDoctorAuthorizationEligibilityDistinguishesConfiguration(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		project    globalconfig.Project
+		wantStatus doctorStatus
+		wantDetail string
+	}{
+		{name: "empty selector allows all", wantStatus: doctorOK, wantDetail: "authorization selector is empty; all issues are allowed"},
+		{
+			name: "malformed selector fails",
+			project: globalconfig.Project{Authorization: selector.Selector{
+				Labels: selector.Labels{Include: []string{""}},
+			}},
+			wantStatus: doctorFail,
+			wantDetail: "authorization selector is invalid: global.authorization.labels.include[0] must not be blank",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			check := checkDoctorAuthorizationEligibility(t.Context(), "corp", tt.project, workflowconfig.Default(), doctorDeps{})
+			if check.Status != tt.wantStatus || check.Detail != tt.wantDetail {
+				t.Fatalf("check = %#v, want status %s detail %q", check, tt.wantStatus, tt.wantDetail)
+			}
+		})
+	}
+}
+
+type doctorAuthorizationConnector struct {
+	issues []connector.Issue
+	states []string
+}
+
+func (c *doctorAuthorizationConnector) FetchIssuesByStates(_ context.Context, states []string) ([]connector.Issue, error) {
+	c.states = append([]string(nil), states...)
+	return append([]connector.Issue(nil), c.issues...), nil
+}

--- a/internal/cli/doctor_project.go
+++ b/internal/cli/doctor_project.go
@@ -357,6 +357,8 @@ func checkDoctorProjectWithProgress(
 	if doctorTrackerUsesGitHubReads(workflow.Config.Tracker.Kind) {
 		setDoctorCurrentCheck("Project " + id + " issue agent models")
 		checks = append(checks, checkDoctorIssueAgentModels(ctx, id, project, workflow.Config, deps))
+		setDoctorCurrentCheck("Project " + id + " authorization eligibility")
+		checks = append(checks, checkDoctorAuthorizationEligibility(ctx, id, project, workflow.Config, deps))
 		setDoctorCurrentCheck("Project " + id + " ownership eligibility")
 		checks = append(checks, checkDoctorOwnershipEligibility(ctx, id, project, workflow.Config, deps))
 		setDoctorCurrentCheck("Project " + id + " configured labels")

--- a/internal/orchestrator/diagnostics.go
+++ b/internal/orchestrator/diagnostics.go
@@ -64,6 +64,7 @@ func (o *Orchestrator) logDispatchPlanDecision(ctx context.Context, state *State
 	attrs := o.schedulerDecisionAttrs(state, now, decision.Issue,
 		"result", result,
 		"skip_reason", reason,
+		"skip_detail", strings.TrimSpace(decision.SkipDetail),
 		"selection_reason", strings.TrimSpace(decision.SelectionReason),
 		"queue_position", decision.QueuePosition,
 		"retry", decision.Retry,
@@ -71,6 +72,12 @@ func (o *Orchestrator) logDispatchPlanDecision(ctx context.Context, state *State
 		"worker_host", strings.TrimSpace(decision.WorkerHost),
 		"unblocker_count", decision.UnblockerCount,
 	)
+	if decision.AuthorizationDecision != nil {
+		attrs = append(attrs,
+			"authorization_rule", decision.AuthorizationDecision.Rule,
+			"authorization_value", decision.AuthorizationDecision.Value,
+		)
+	}
 	telemetry.LogLifecycle(o.logger, slog.LevelDebug, telemetry.LifecycleDispatch, "scheduler_dispatch_decision", o.issueLifecycleCorrelation(decision.Issue), attrs...)
 }
 

--- a/internal/orchestrator/dispatch_planner.go
+++ b/internal/orchestrator/dispatch_planner.go
@@ -40,15 +40,17 @@ type dispatchAction struct {
 }
 
 type dispatchPlanDecision struct {
-	Issue           connector.Issue
-	QueuePosition   int
-	Attempt         int
-	WorkerHost      string
-	Retry           bool
-	Selected        bool
-	SkipReason      string
-	SelectionReason string
-	UnblockerCount  int
+	Issue                 connector.Issue
+	QueuePosition         int
+	Attempt               int
+	WorkerHost            string
+	Retry                 bool
+	Selected              bool
+	SkipReason            string
+	SkipDetail            string
+	AuthorizationDecision *selector.Decision
+	SelectionReason       string
+	UnblockerCount        int
 }
 
 func newDispatchPlanner(cfg Config) dispatchPlanner {
@@ -231,6 +233,11 @@ func clearBlockedUnblockerCounts(issues []connector.Issue, blocked map[string]Bl
 }
 
 func (p dispatchPlanner) logDecision(hooks dispatchPlanHooks, decision dispatchPlanDecision) {
+	if decision.SkipReason == dispatchSkipAuthorizationSelector && decision.AuthorizationDecision == nil {
+		authorization := p.authorizationDecision(decision.Issue)
+		decision.AuthorizationDecision = &authorization
+		decision.SkipDetail = authorization.Detail
+	}
 	decision.UnblockerCount = decision.Issue.UnblockerCount
 	if hooks.decision != nil {
 		hooks.decision(decision)
@@ -568,8 +575,10 @@ func (p dispatchPlanner) dispatchableIssue(
 }
 
 type dispatchableDecision struct {
-	dispatchable bool
-	reason       string
+	dispatchable  bool
+	reason        string
+	detail        string
+	authorization *selector.Decision
 }
 
 const (
@@ -581,7 +590,7 @@ const (
 	dispatchSkipArtifactGateWaitStatus    = "artifact_gate_wait_status"
 	dispatchSkipMergedPullRequest         = "merged_pull_request_reconciliation_pending"
 	dispatchSkipDuplicatePullRequest      = "duplicate_pull_request_work"
-	dispatchSkipUnauthorized              = "unauthorized"
+	dispatchSkipAuthorizationSelector     = "authorization_selector_declined"
 	dispatchSkipOwnershipAssigneeRequired = "ownership_assignee_required"
 	dispatchSkipBlockedByDependency       = "blocked_by_dependency"
 	dispatchSkipAlreadyRunning            = "already_running"
@@ -691,8 +700,12 @@ func (p dispatchPlanner) dispatchableIssueDecisionForModelRequirement(
 	if duplicatePullRequestWork(issue) {
 		return dispatchableDecision{reason: dispatchSkipDuplicatePullRequest}
 	}
-	if !p.authorized(issue) {
-		return dispatchableDecision{reason: dispatchSkipUnauthorized}
+	if authorization := p.authorizationDecision(issue); !authorization.Matched {
+		return dispatchableDecision{
+			reason:        dispatchSkipAuthorizationSelector,
+			detail:        authorization.Detail,
+			authorization: &authorization,
+		}
 	}
 	if p.needsAssignee(issue) {
 		return dispatchableDecision{reason: dispatchSkipOwnershipAssigneeRequired}
@@ -792,6 +805,10 @@ func (p dispatchPlanner) authorized(issue connector.Issue) bool {
 		return true
 	}
 	return selector.Match(issue, p.cfg.Authorization, p.cfg.SelectorContext)
+}
+
+func (p dispatchPlanner) authorizationDecision(issue connector.Issue) selector.Decision {
+	return selector.Decide(issue, p.cfg.Authorization, p.cfg.SelectorContext)
 }
 
 func (p dispatchPlanner) needsAssignee(issue connector.Issue) bool {

--- a/internal/orchestrator/dispatch_status.go
+++ b/internal/orchestrator/dispatch_status.go
@@ -97,7 +97,7 @@ func projectDispatchStatusFromCycle(
 				}
 			}
 		} else {
-			waitReason = schedulerDecisionWaitReason(decision.SkipReason)
+			waitReason = dispatchPlanDecisionWaitReason(decision)
 			if decision.SkipReason == dispatchSkipProjectFailureBreaker {
 				status.EligibleCandidateCount++
 			}
@@ -130,6 +130,13 @@ func projectDispatchStatusFromCycle(
 		status.AllSkippedSince = &now
 	}
 	return status
+}
+
+func dispatchPlanDecisionWaitReason(decision dispatchPlanDecision) string {
+	if detail := strings.TrimSpace(decision.SkipDetail); detail != "" {
+		return detail
+	}
+	return schedulerDecisionWaitReason(decision.SkipReason)
 }
 
 func dispatchStatusExcludesCandidate(decision dispatchPlanDecision) bool {

--- a/internal/orchestrator/dispatch_test.go
+++ b/internal/orchestrator/dispatch_test.go
@@ -1288,6 +1288,81 @@ func TestDispatchableFiltersUnauthorizedCandidates(t *testing.T) {
 	}
 }
 
+func TestDispatchableAuthorizationDecisionCarriesSelectorDetail(t *testing.T) {
+	t.Parallel()
+
+	cfg := normalizeConfig(Config{
+		MaxConcurrentAgents: 1,
+		ActiveStates:        []string{"Todo"},
+		TerminalStates:      []string{"Done"},
+		Authorization: selector.Selector{
+			Labels: selector.Labels{Include: []string{"detent"}},
+		},
+	})
+	issue := dispatchTestIssue("issue-selector-declined", "Todo")
+	issue.Labels = []string{"detent:todo"}
+
+	state := newState(cfg)
+	decision := newDispatchPlanner(cfg).dispatchableIssueDecision(issue, &state, false, time.Now(), "")
+	if decision.dispatchable || decision.reason != dispatchSkipAuthorizationSelector {
+		t.Fatalf("dispatchableIssueDecision() = %#v, want authorization selector decline", decision)
+	}
+	if decision.authorization == nil || decision.authorization.Rule != selector.RuleLabelInclude || decision.authorization.Value != "detent" {
+		t.Fatalf("authorization decision = %#v, want missing include label detail", decision.authorization)
+	}
+	if decision.detail != "issue does not match authorization selector: missing required label `detent`" {
+		t.Fatalf("decision detail = %q", decision.detail)
+	}
+}
+
+func TestAuthorizationSelectorDetailReachesDispatchTelemetry(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 8, 17, 20, 0, 0, 0, time.UTC)
+	cfg := normalizeConfig(Config{
+		MaxConcurrentAgents:    1,
+		ActiveStates:           []string{"Todo"},
+		TerminalStates:         []string{"Done"},
+		DispatchStallThreshold: time.Hour,
+		Authorization: selector.Selector{
+			Labels: selector.Labels{Include: []string{"detent"}},
+		},
+	})
+	cfg.Project.ID = "corp"
+	issue := dispatchTestIssue("issue-532", "Todo")
+	issue.Labels = []string{"detent:todo"}
+	attempts := &recordingWorkAttemptStore{}
+	orch := &Orchestrator{cfg: cfg, workAttempts: attempts}
+	state := newState(cfg)
+	decisions := make([]dispatchPlanDecision, 0, 1)
+
+	newDispatchPlanner(cfg).plan(&state, []connector.Issue{issue}, now, dispatchPlanHooks{
+		decision: func(decision dispatchPlanDecision) {
+			decisions = append(decisions, decision)
+			orch.logDispatchPlanDecision(t.Context(), &state, now, decision)
+		},
+	})
+
+	if len(decisions) != 1 || len(attempts.decisions) != 1 {
+		t.Fatalf("plan decisions = %#v, persisted = %#v", decisions, attempts.decisions)
+	}
+	const wantDetail = "issue does not match authorization selector: missing required label `detent`"
+	persisted := attempts.decisions[0]
+	if persisted.Reason != dispatchSkipAuthorizationSelector || persisted.WaitReason != wantDetail {
+		t.Fatalf("persisted decision = %#v", persisted)
+	}
+	for _, want := range []string{`"rule":"label_include"`, `"value":"detent"`, `"detail":"` + wantDetail + `"`} {
+		if !strings.Contains(persisted.MetadataJSON, want) {
+			t.Fatalf("metadata = %q, want containing %q", persisted.MetadataJSON, want)
+		}
+	}
+	status := projectDispatchStatusFromCycle(store.ProjectDispatchStatus{}, "corp", []connector.Issue{issue}, decisions, nil, now)
+	snapshot := dispatchStatusSnapshot(status, cfg.DispatchStallThreshold, now.Add(2*time.Hour))
+	if snapshot.WaitReason != wantDetail {
+		t.Fatalf("dispatch payload wait_reason = %q, want %q", snapshot.WaitReason, wantDetail)
+	}
+}
+
 func TestDispatchPlanOwnershipEligibility(t *testing.T) {
 	t.Parallel()
 

--- a/internal/orchestrator/staleness.go
+++ b/internal/orchestrator/staleness.go
@@ -184,6 +184,7 @@ func stalenessDecisions(decisions []telemetry.SchedulerDecision, issues map[stri
 			Merged:       pullRequestMerged(issue.PullRequest),
 			Result:       strings.TrimSpace(decision.Result),
 			Reason:       strings.TrimSpace(decision.Reason),
+			Detail:       strings.TrimSpace(decision.WaitReason),
 			At:           decision.DecisionAt.UTC(),
 		})
 	}

--- a/internal/orchestrator/work_attempts.go
+++ b/internal/orchestrator/work_attempts.go
@@ -509,6 +509,14 @@ func (o *Orchestrator) recordSchedulerDecision(ctx context.Context, state *State
 	if reason == "" {
 		reason = result
 	}
+	waitReason := schedulerDecisionWaitReason(reason)
+	metadata := map[string]any{}
+	if detail := strings.TrimSpace(decision.SkipDetail); detail != "" {
+		waitReason = detail
+	}
+	if authorization := decision.AuthorizationDecision; authorization != nil {
+		metadata["authorization_decision"] = authorization
+	}
 	record := store.SchedulerDecision{
 		ProjectID:              strings.TrimSpace(o.cfg.Project.ID),
 		IssueID:                strings.TrimSpace(decision.Issue.ID),
@@ -525,9 +533,12 @@ func (o *Orchestrator) recordSchedulerDecision(ctx context.Context, state *State
 		AttemptNumber:          decision.Attempt,
 		WorkerHost:             strings.TrimSpace(decision.WorkerHost),
 		DecisionAt:             now,
-		WaitReason:             schedulerDecisionWaitReason(reason),
+		WaitReason:             waitReason,
 		CapacitySnapshotJSON:   o.capacitySnapshotJSON(state, decision.Issue),
 		GitHubRateSnapshotJSON: o.githubRateSnapshotJSON(state),
+	}
+	if len(metadata) > 0 {
+		record.MetadataJSON = marshalWorkAttemptJSON(metadata)
 	}
 	snapshot := telemetrySchedulerDecision(record)
 	if o.workAttempts != nil {

--- a/internal/selector/match.go
+++ b/internal/selector/match.go
@@ -16,6 +16,26 @@ type Context struct {
 	Persona       string
 }
 
+type Rule string
+
+const (
+	RuleConfiguration Rule = "configuration"
+	RuleAssignee      Rule = "assignee"
+	RuleAuthor        Rule = "author"
+	RuleLabelInclude  Rule = "label_include"
+	RuleLabelExclude  Rule = "label_exclude"
+	RuleField         Rule = "field"
+	RulePriority      Rule = "priority"
+	RuleAlternative   Rule = "alternative"
+)
+
+type Decision struct {
+	Matched bool   `json:"matched"`
+	Rule    Rule   `json:"rule,omitempty"`
+	Value   string `json:"value,omitempty"`
+	Detail  string `json:"detail"`
+}
+
 type Selector struct {
 	AssigneeIn []string      `yaml:"assignee_in,omitempty"`
 	AuthorIn   []string      `yaml:"author_in,omitempty"`
@@ -253,6 +273,165 @@ func Match(issue connector.Issue, selector Selector, ctx Context) bool {
 		return false
 	}
 	return true
+}
+
+func Decide(issue connector.Issue, selector Selector, ctx Context) Decision {
+	if problems := selector.Validate("authorization"); len(problems) > 0 {
+		problem := problems[0]
+		return Decision{
+			Rule:   RuleConfiguration,
+			Value:  selectorProblemField(problem),
+			Detail: "authorization selector is invalid: " + problem,
+		}
+	}
+	if !selector.Configured() {
+		return Decision{
+			Matched: true,
+			Rule:    RuleConfiguration,
+			Detail:  "authorization selector is empty; all issues are allowed",
+		}
+	}
+	return decideConfigured(issue, selector, ctx)
+}
+
+func decideConfigured(issue connector.Issue, selector Selector, ctx Context) Decision {
+	if !matchIdentityList(issueAssignees(issue), selector.AssigneeIn, ctx) {
+		assignees := nonBlankStrings(issueAssignees(issue))
+		value := strings.Join(assignees, ", ")
+		detail := "issue does not match authorization selector: issue is unassigned; assignee allowlist is " + codeList(describeSelectorValues(selector.AssigneeIn, ctx))
+		if value != "" {
+			detail = "issue does not match authorization selector: assignee " + codeList(assignees) + " is not in allowlist " + codeList(describeSelectorValues(selector.AssigneeIn, ctx))
+		}
+		return Decision{Rule: RuleAssignee, Value: value, Detail: detail}
+	}
+	if !matchIdentityList([]string{issue.AuthorID}, selector.AuthorIn, ctx) {
+		author := strings.TrimSpace(issue.AuthorID)
+		detail := "issue does not match authorization selector: issue has no author; author allowlist is " + codeList(describeSelectorValues(selector.AuthorIn, ctx))
+		if author != "" {
+			detail = "issue does not match authorization selector: author `" + author + "` is not in allowlist " + codeList(describeSelectorValues(selector.AuthorIn, ctx))
+		}
+		return Decision{Rule: RuleAuthor, Value: author, Detail: detail}
+	}
+	if decision, matched := decideLabels(issue.Labels, selector.Labels); !matched {
+		return decision
+	}
+	if decision, matched := decideFields(issue.Fields, selector.Fields, ctx); !matched {
+		return decision
+	}
+	if !matchPriority(issue.Priority, selector.PriorityIn) {
+		value := ""
+		if issue.Priority != nil {
+			value = strconv.Itoa(*issue.Priority)
+		}
+		detail := "issue does not match authorization selector: issue has no priority; priority allowlist is " + integerCodeList(selector.PriorityIn)
+		if value != "" {
+			detail = "issue does not match authorization selector: priority `" + value + "` is not in allowlist " + integerCodeList(selector.PriorityIn)
+		}
+		return Decision{Rule: RulePriority, Value: value, Detail: detail}
+	}
+	for _, child := range selector.And {
+		decision := decideConfiguredOrEmpty(issue, child, ctx)
+		if !decision.Matched {
+			return decision
+		}
+	}
+	if len(selector.Or) > 0 {
+		details := make([]string, 0, len(selector.Or))
+		for _, child := range selector.Or {
+			decision := decideConfiguredOrEmpty(issue, child, ctx)
+			if decision.Matched {
+				return Decision{Matched: true, Detail: "issue matches authorization selector"}
+			}
+			details = append(details, strings.TrimPrefix(decision.Detail, "issue does not match authorization selector: "))
+		}
+		return Decision{
+			Rule:   RuleAlternative,
+			Detail: "issue does not match authorization selector: no alternative matched (" + strings.Join(details, "; ") + ")",
+		}
+	}
+	return Decision{Matched: true, Detail: "issue matches authorization selector"}
+}
+
+func decideConfiguredOrEmpty(issue connector.Issue, selector Selector, ctx Context) Decision {
+	if !selector.Configured() {
+		return Decision{Matched: true, Rule: RuleConfiguration, Detail: "authorization selector is empty; all issues are allowed"}
+	}
+	return decideConfigured(issue, selector, ctx)
+}
+
+func decideLabels(issueLabels []string, labels Labels) (Decision, bool) {
+	present := make(map[string]struct{}, len(issueLabels))
+	for _, label := range issueLabels {
+		if normalized := normalizeLabel(label); normalized != "" {
+			present[normalized] = struct{}{}
+		}
+	}
+	for _, label := range labels.Include {
+		label = strings.TrimSpace(label)
+		if _, ok := present[normalizeLabel(label)]; !ok {
+			return Decision{
+				Rule:   RuleLabelInclude,
+				Value:  label,
+				Detail: "issue does not match authorization selector: missing required label `" + label + "`",
+			}, false
+		}
+	}
+	for _, label := range labels.Exclude {
+		label = strings.TrimSpace(label)
+		if _, ok := present[normalizeLabel(label)]; ok {
+			return Decision{
+				Rule:   RuleLabelExclude,
+				Value:  label,
+				Detail: "issue does not match authorization selector: excluded label `" + label + "` is present",
+			}, false
+		}
+	}
+	return Decision{Matched: true}, true
+}
+
+func decideFields(fields map[string]string, rules []FieldEquals, ctx Context) (Decision, bool) {
+	for _, rule := range rules {
+		name := strings.TrimSpace(rule.Name)
+		value, ok := fieldValue(fields, name)
+		if !ok {
+			return Decision{
+				Rule:   RuleField,
+				Value:  name,
+				Detail: "issue does not match authorization selector: required field `" + name + "` is missing",
+			}, false
+		}
+		if !matchFieldValue(value, rule.Value, ctx) {
+			return Decision{
+				Rule:   RuleField,
+				Value:  value,
+				Detail: "issue does not match authorization selector: field `" + name + "` value `" + strings.TrimSpace(value) + "` does not equal `" + describeSelectorValue(rule.Value, ctx) + "`",
+			}, false
+		}
+	}
+	return Decision{Matched: true}, true
+}
+
+func selectorProblemField(problem string) string {
+	field, _, _ := strings.Cut(strings.TrimSpace(problem), " ")
+	return strings.TrimSuffix(field, ":")
+}
+
+func codeList(values []string) string {
+	formatted := make([]string, 0, len(values))
+	for _, value := range values {
+		if value = strings.TrimSpace(value); value != "" {
+			formatted = append(formatted, "`"+value+"`")
+		}
+	}
+	return strings.Join(formatted, ", ")
+}
+
+func integerCodeList(values []int) string {
+	formatted := make([]string, 0, len(values))
+	for _, value := range values {
+		formatted = append(formatted, "`"+strconv.Itoa(value)+"`")
+	}
+	return strings.Join(formatted, ", ")
 }
 
 func matchPriority(priority *int, allowed []int) bool {

--- a/internal/selector/match_test.go
+++ b/internal/selector/match_test.go
@@ -235,6 +235,69 @@ func TestMatch(t *testing.T) {
 	}
 }
 
+func TestDecideExplainsAuthorizationOutcome(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		issue       connector.Issue
+		selector    Selector
+		wantMatched bool
+		wantRule    Rule
+		wantValue   string
+		wantDetail  string
+	}{
+		{
+			name:       "missing include label",
+			issue:      connector.Issue{Labels: []string{"detent:todo"}},
+			selector:   Selector{Labels: Labels{Include: []string{"detent"}}},
+			wantRule:   RuleLabelInclude,
+			wantValue:  "detent",
+			wantDetail: "issue does not match authorization selector: missing required label `detent`",
+		},
+		{
+			name:       "present exclude label",
+			issue:      connector.Issue{Labels: []string{"detent", "manual"}},
+			selector:   Selector{Labels: Labels{Exclude: []string{"manual"}}},
+			wantRule:   RuleLabelExclude,
+			wantValue:  "manual",
+			wantDetail: "issue does not match authorization selector: excluded label `manual` is present",
+		},
+		{
+			name:       "author not allowlisted",
+			issue:      connector.Issue{AuthorID: "bob"},
+			selector:   Selector{AuthorIn: []string{"alice"}},
+			wantRule:   RuleAuthor,
+			wantValue:  "bob",
+			wantDetail: "issue does not match authorization selector: author `bob` is not in allowlist `alice`",
+		},
+		{
+			name:        "empty selector",
+			wantMatched: true,
+			wantRule:    RuleConfiguration,
+			wantDetail:  "authorization selector is empty; all issues are allowed",
+		},
+		{
+			name:       "malformed selector",
+			selector:   Selector{Labels: Labels{Include: []string{""}}},
+			wantRule:   RuleConfiguration,
+			wantValue:  "authorization.labels.include[0]",
+			wantDetail: "authorization selector is invalid: authorization.labels.include[0] must not be blank",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := Decide(tt.issue, tt.selector, Context{})
+			if got.Matched != tt.wantMatched || got.Rule != tt.wantRule || got.Value != tt.wantValue || got.Detail != tt.wantDetail {
+				t.Fatalf("Decide() = %#v, want matched=%t rule=%q value=%q detail=%q", got, tt.wantMatched, tt.wantRule, tt.wantValue, tt.wantDetail)
+			}
+		})
+	}
+}
+
 func TestDescribe(t *testing.T) {
 	t.Parallel()
 

--- a/internal/staleness/staleness.go
+++ b/internal/staleness/staleness.go
@@ -67,6 +67,7 @@ type Decision struct {
 	Merged       bool
 	Result       string
 	Reason       string
+	Detail       string
 	At           time.Time
 }
 
@@ -265,6 +266,10 @@ func repeatedDecisionWarnings(cfg Config, input Input, now time.Time) []Warning 
 		if current.count < cfg.RepeatedDecisionCount {
 			continue
 		}
+		detail := "the same scheduler decision has recurred beyond its configured threshold"
+		if decisionDetail := strings.TrimSpace(current.decision.Detail); decisionDetail != "" && decisionDetail != strings.TrimSpace(current.decision.Reason) {
+			detail = decisionDetail
+		}
 		warnings = append(warnings, Warning{
 			ID:               warningID(KindRepeatedDecision + "\x00" + key),
 			ProjectID:        strings.TrimSpace(input.ProjectID),
@@ -273,7 +278,7 @@ func repeatedDecisionWarnings(cfg Config, input Input, now time.Time) []Warning 
 			Identifier:       strings.TrimSpace(current.decision.Identifier),
 			IssueURL:         strings.TrimSpace(current.decision.IssueURL),
 			Reason:           strings.TrimSpace(current.decision.Reason),
-			Detail:           "the same scheduler decision has recurred beyond its configured threshold",
+			Detail:           detail,
 			Since:            current.first,
 			AgeSeconds:       int64(now.Sub(current.first) / time.Second),
 			ThresholdSeconds: int64(cfg.RepeatedDecisionWindow / time.Second),

--- a/internal/staleness/staleness_test.go
+++ b/internal/staleness/staleness_test.go
@@ -222,6 +222,26 @@ func TestEvaluateRepeatedDecisions(t *testing.T) {
 	}
 }
 
+func TestEvaluateRepeatedDecisionRendersAuthorizationDetail(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 8, 17, 20, 0, 0, 0, time.UTC)
+	const detail = "issue does not match authorization selector: missing required label `detent`"
+	decisions := repeatedDecisions(now.Add(-time.Hour), 3, 20*time.Minute, "authorization_selector_declined", "Todo")
+	for index := range decisions {
+		decisions[index].Detail = detail
+	}
+	warnings := Evaluate(Config{
+		Enabled:                true,
+		RepeatedDecisionCount:  3,
+		RepeatedDecisionWindow: 24 * time.Hour,
+	}, Input{ProjectID: "corp", Decisions: decisions}, now)
+
+	if len(warnings) != 1 || warnings[0].Reason != "authorization_selector_declined" || warnings[0].Detail != detail {
+		t.Fatalf("warnings = %#v, want actionable authorization detail", warnings)
+	}
+}
+
 func TestEvaluateProviderRateWindowPacing(t *testing.T) {
 	t.Parallel()
 	now := time.Date(2026, 8, 7, 15, 0, 0, 0, time.UTC)

--- a/internal/web/board_card_test.go
+++ b/internal/web/board_card_test.go
@@ -64,6 +64,38 @@ func TestAPIBoardCardRendersLiveActivityAndVerboseUsage(t *testing.T) {
 	}
 }
 
+func TestAPIBoardCardRendersAuthorizationSelectorDetail(t *testing.T) {
+	t.Parallel()
+
+	const detail = "issue does not match authorization selector: missing required label `detent`"
+	at := time.Date(2026, 8, 17, 20, 0, 0, 0, time.UTC)
+	issue := telemetry.Issue{ID: "issue-532", Identifier: "gopherguides/corp#532", ProjectID: "corp", Title: "Hand-filed issue", State: "Todo"}
+	deps := testDeps(t)
+	if err := deps.Hub.Publish(telemetry.Snapshot{
+		GeneratedAt: at,
+		BoardIssues: []telemetry.Issue{issue},
+		SchedulerDecisions: []telemetry.SchedulerDecision{{
+			ID: 1, ProjectID: "corp", IssueID: issue.ID, Identifier: issue.Identifier, Result: "skipped", Reason: "authorization_selector_declined", WaitReason: detail, DecisionAt: at,
+		}},
+	}); err != nil {
+		t.Fatalf("Publish() error = %v", err)
+	}
+	server, err := web.NewServer(web.Config{StaticDir: t.TempDir()}, deps)
+	if err != nil {
+		t.Fatalf("NewServer() error = %v", err)
+	}
+
+	body := requestHTML(t, server.Handler(), http.MethodGet, "/api/v1/board/activity?project=corp&issue=issue-532", http.StatusOK)
+	for _, want := range []string{"Dispatch skipped", detail} {
+		if !strings.Contains(body, want) {
+			t.Fatalf("board activity missing %q:\n%s", want, body)
+		}
+	}
+	if strings.Contains(body, ">unauthorized<") {
+		t.Fatalf("board activity presents selector decline as credential failure:\n%s", body)
+	}
+}
+
 func TestBoardLiveSessionPageRendersActiveSessionFullWidth(t *testing.T) {
 	t.Parallel()
 

--- a/internal/web/templates/board_data_test.go
+++ b/internal/web/templates/board_data_test.go
@@ -2588,11 +2588,12 @@ func TestBoardAlertsNameForgeWriteConditionDistinctly(t *testing.T) {
 func TestBoardAlertsSurfaceDispatchStallAsNeedsAttention(t *testing.T) {
 	t.Parallel()
 
+	const authorizationDetail = "issue does not match authorization selector: missing required label `detent`"
 	secondsSinceLastSelected := int64(14_400)
 	alerts := boardAlerts(telemetry.Snapshot{DispatchStalls: []telemetry.DispatchStatus{{
 		ProjectID:                "detent",
 		CandidateCount:           8,
-		WaitReason:               "github_rest_capacity",
+		WaitReason:               authorizationDetail,
 		SecondsSinceLastSelected: &secondsSinceLastSelected,
 		StallDurationSeconds:     10_800,
 		Stalled:                  true,
@@ -2602,7 +2603,7 @@ func TestBoardAlertsSurfaceDispatchStallAsNeedsAttention(t *testing.T) {
 		t.Fatalf("boardAlerts() = %#v, want one dispatch-stall error", alerts)
 	}
 	combined := alerts[0].TerseSummary + " " + alerts[0].DetailSummary + " " + alerts[0].DetailRows[0].Summary + " " + alerts[0].DetailRows[0].Detail
-	for _, want := range []string{"Dispatch stalled", "human attention", "8 candidates", "3h", "github_rest_capacity"} {
+	for _, want := range []string{"Dispatch stalled", "human attention", "8 candidates", "3h", authorizationDetail} {
 		if !strings.Contains(combined, want) {
 			t.Fatalf("dispatch alert = %q, want containing %q", combined, want)
 		}


### PR DESCRIPTION
## Summary

- Return structured authorization selector decisions that name the failed rule and concrete label, author, assignee, field, or priority value.
- Persist actionable selector detail through dispatch status and repeated-decision warnings so board activity and stall alerts explain the operator fix.
- Teach `detent doctor` to report open lane-labeled issues that fail the combined project and workflow authorization selector.

Fixes #1876

## UI Surface Contract

- [x] N/A, or the linked issue explicitly authorizes any high-impact UI surface, layout, density, first-viewport, or responsive visibility tradeoff.
- [x] Persistent top-of-screen messaging is explicitly authorized by the issue, or this PR does not add it.
- [x] Visual changes to primary operator screens include screenshot or browser verification below.

This changes diagnostic text within existing board activity and stall-alert surfaces; it does not add or reshape UI. Server-rendered board regression tests verify the actionable text in both surfaces.

## Test Plan

- [x] `make check`
- [x] Table-driven selector cases cover missing include label, present exclude label, author allowlist miss, empty selector, and malformed selector.
- [x] Dispatch persistence/payload, staleness warning, doctor, board activity, and stall-alert rendering regressions pass.