### PR TITLE
fix(doctor): bound workflow lint query

### DIFF
--- a/internal/cli/doctor_workflow_lint.go
+++ b/internal/cli/doctor_workflow_lint.go
@@ -731,54 +731,54 @@ func checkDoctorWorkflowRuntimeLint(ctx context.Context, projectID string, workf
 	return checks
 }
 
-func doctorWaitStatusIncidents(ctx context.Context, db doctorTelemetryStore, projectID string, cfg workflowconfig.Config, now time.Time) ([]doctorWaitStatusIncident, error) {
-	rows, err := db.QueryContext(ctx, `
-WITH project_decisions AS (
+const doctorWaitStatusIncidentsQuery = `
+WITH issue_summaries AS (
   SELECT
-    id,
     COALESCE(NULLIF(identifier, ''), NULLIF(issue_id, ''), NULLIF(issue_url, ''), 'unassigned') AS issue_key,
-    COALESCE(lane, '') AS lane,
-    COALESCE(result, '') AS result,
-    COALESCE(reason, '') AS reason,
-    COALESCE(attempt_number, 0) AS attempt_number,
-    decision_at
+    MAX(id) AS latest_id,
+    MAX(CASE
+      WHEN COALESCE(result, '') != 'skipped'
+        OR COALESCE(reason, '') != 'artifact_gate_wait_status'
+        OR COALESCE(attempt_number, 0) != 0
+      THEN id
+      ELSE 0
+    END) AS reset_id
   FROM scheduler_decisions
   WHERE project_id = ?
     AND decision_at >= ?
-), ranked AS (
-  SELECT
-    id,
-    issue_key,
-    lane,
-    result,
-    reason,
-    attempt_number,
-    decision_at,
-    ROW_NUMBER() OVER (PARTITION BY issue_key ORDER BY id DESC) AS latest_rank,
-    MAX(CASE WHEN result != 'skipped' OR reason != 'artifact_gate_wait_status' OR attempt_number != 0 THEN id ELSE 0 END)
-      OVER (PARTITION BY issue_key) AS reset_id
-  FROM project_decisions
+  GROUP BY issue_key
 ), active_issues AS (
-  SELECT issue_key, lane, reset_id
-  FROM ranked
-  WHERE latest_rank = 1
-    AND result = 'skipped'
-    AND reason = 'artifact_gate_wait_status'
-    AND attempt_number = 0
+  SELECT
+    summaries.issue_key,
+    COALESCE(latest.lane, '') AS lane,
+    summaries.reset_id
+  FROM issue_summaries AS summaries
+  JOIN scheduler_decisions AS latest ON latest.id = summaries.latest_id
+  WHERE COALESCE(latest.result, '') = 'skipped'
+    AND COALESCE(latest.reason, '') = 'artifact_gate_wait_status'
+    AND COALESCE(latest.attempt_number, 0) = 0
 )
 SELECT
   active_issues.issue_key,
   active_issues.lane,
-  MIN(ranked.decision_at),
-  MAX(ranked.decision_at),
+  MIN(streak.decision_at),
+  MAX(streak.decision_at),
   COUNT(*)
 FROM active_issues
-JOIN ranked ON ranked.issue_key = active_issues.issue_key
-WHERE ranked.id > active_issues.reset_id
-  AND ranked.result = 'skipped'
-  AND ranked.reason = 'artifact_gate_wait_status'
-  AND ranked.attempt_number = 0
-GROUP BY active_issues.issue_key, active_issues.lane`, strings.TrimSpace(projectID), now.Add(-doctorWorkflowWaitStatusWindow).UTC().Format(time.RFC3339Nano))
+JOIN scheduler_decisions AS streak
+  ON COALESCE(NULLIF(streak.identifier, ''), NULLIF(streak.issue_id, ''), NULLIF(streak.issue_url, ''), 'unassigned') = active_issues.issue_key
+  AND streak.id > active_issues.reset_id
+WHERE streak.project_id = ?
+  AND streak.decision_at >= ?
+  AND COALESCE(streak.result, '') = 'skipped'
+  AND COALESCE(streak.reason, '') = 'artifact_gate_wait_status'
+  AND COALESCE(streak.attempt_number, 0) = 0
+GROUP BY active_issues.issue_key, active_issues.lane`
+
+func doctorWaitStatusIncidents(ctx context.Context, db doctorTelemetryStore, projectID string, cfg workflowconfig.Config, now time.Time) ([]doctorWaitStatusIncident, error) {
+	projectID = strings.TrimSpace(projectID)
+	cutoff := now.Add(-doctorWorkflowWaitStatusWindow).UTC().Format(time.RFC3339Nano)
+	rows, err := db.QueryContext(ctx, doctorWaitStatusIncidentsQuery, projectID, cutoff, projectID, cutoff)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/cli/doctor_workflow_lint_test.go
+++ b/internal/cli/doctor_workflow_lint_test.go
@@ -641,6 +641,143 @@ func TestCheckDoctorWorkflowRuntimeLintFindsWaitDeadlockAndCeilingDeaths(t *test
 	}
 }
 
+func TestDoctorWaitStatusIncidentsPreservesContinuousWaitSemantics(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 8, 18, 14, 0, 0, 0, time.UTC)
+	type decision struct {
+		project string
+		lane    string
+		result  string
+		reason  string
+		attempt int
+		at      time.Time
+	}
+	tests := []struct {
+		name      string
+		decisions []decision
+		wantLane  string
+		wantFirst time.Time
+		wantCount int64
+	}{
+		{
+			name: "continuous wait follows latest lane",
+			decisions: []decision{
+				{project: "alpha", lane: "Todo", result: "skipped", reason: "artifact_gate_wait_status", at: now.Add(-20 * time.Minute)},
+				{project: "alpha", lane: "In Progress", result: "skipped", reason: "artifact_gate_wait_status", at: now.Add(-time.Minute)},
+			},
+			wantLane:  "In Progress",
+			wantFirst: now.Add(-20 * time.Minute),
+			wantCount: 2,
+		},
+		{
+			name: "latest non-wait decision clears incident",
+			decisions: []decision{
+				{project: "alpha", lane: "Todo", result: "skipped", reason: "artifact_gate_wait_status", at: now.Add(-20 * time.Minute)},
+				{project: "alpha", lane: "In Progress", result: "selected", attempt: 1, at: now.Add(-time.Minute)},
+			},
+		},
+		{
+			name: "reset excludes earlier skips",
+			decisions: []decision{
+				{project: "alpha", lane: "Todo", result: "skipped", reason: "artifact_gate_wait_status", at: now.Add(-23 * time.Minute)},
+				{project: "alpha", lane: "In Progress", result: "selected", attempt: 1, at: now.Add(-22 * time.Minute)},
+				{project: "alpha", lane: "Todo", result: "skipped", reason: "artifact_gate_wait_status", at: now.Add(-20 * time.Minute)},
+				{project: "alpha", lane: "Todo", result: "skipped", reason: "artifact_gate_wait_status", at: now.Add(-time.Minute)},
+			},
+			wantLane:  "Todo",
+			wantFirst: now.Add(-20 * time.Minute),
+			wantCount: 2,
+		},
+		{
+			name: "other project decisions are isolated",
+			decisions: []decision{
+				{project: "alpha", lane: "Todo", result: "skipped", reason: "artifact_gate_wait_status", at: now.Add(-20 * time.Minute)},
+				{project: "alpha", lane: "Todo", result: "skipped", reason: "artifact_gate_wait_status", at: now.Add(-time.Minute)},
+				{project: "beta", lane: "In Progress", result: "selected", attempt: 1, at: now},
+			},
+			wantLane:  "Todo",
+			wantFirst: now.Add(-20 * time.Minute),
+			wantCount: 2,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			db := openDoctorWorkflowLintDB(t)
+			for _, decision := range tt.decisions {
+				if _, err := db.Exec(`INSERT INTO scheduler_decisions (project_id, identifier, lane, result, reason, attempt_number, decision_at) VALUES (?, ?, ?, ?, ?, ?, ?)`,
+					decision.project, "digitaldrywood/detent#1878", decision.lane, decision.result, decision.reason, decision.attempt, decision.at.Format(time.RFC3339Nano)); err != nil {
+					t.Fatalf("insert scheduler decision: %v", err)
+				}
+			}
+
+			cfg := workflowconfig.Default()
+			cfg.Tracker.ActiveStates = []string{"Todo", "In Progress"}
+			cfg.Polling.IntervalMS = 60_000
+			incidents, err := doctorWaitStatusIncidents(context.Background(), db, "alpha", cfg, now)
+			if err != nil {
+				t.Fatalf("doctorWaitStatusIncidents() error = %v", err)
+			}
+			if tt.wantCount == 0 {
+				if len(incidents) != 0 {
+					t.Fatalf("incidents = %#v, want none", incidents)
+				}
+				return
+			}
+			if len(incidents) != 1 {
+				t.Fatalf("incidents = %#v, want one", incidents)
+			}
+			incident := incidents[0]
+			if incident.Lane != tt.wantLane || !incident.FirstSkipAt.Equal(tt.wantFirst) || incident.SkipCount != tt.wantCount {
+				t.Fatalf("incident = %#v, want lane %q first %s count %d", incident, tt.wantLane, tt.wantFirst, tt.wantCount)
+			}
+		})
+	}
+}
+
+func TestDoctorWaitStatusIncidentsQueryUsesBoundedPlan(t *testing.T) {
+	t.Parallel()
+
+	db := openDoctorWorkflowLintDB(t)
+	if _, err := db.Exec(`CREATE INDEX scheduler_decisions_project_at_idx ON scheduler_decisions(project_id, decision_at DESC, id DESC)`); err != nil {
+		t.Fatalf("create scheduler decision index: %v", err)
+	}
+	cutoff := time.Date(2026, 8, 17, 14, 0, 0, 0, time.UTC).Format(time.RFC3339Nano)
+	rows, err := db.QueryContext(t.Context(), "EXPLAIN QUERY PLAN "+doctorWaitStatusIncidentsQuery, "alpha", cutoff, "alpha", cutoff)
+	if err != nil {
+		t.Fatalf("EXPLAIN QUERY PLAN error = %v", err)
+	}
+	defer rows.Close()
+
+	details := make([]string, 0)
+	for rows.Next() {
+		var id int
+		var parent int
+		var unused int
+		var detail string
+		if err := rows.Scan(&id, &parent, &unused, &detail); err != nil {
+			t.Fatalf("scan query plan: %v", err)
+		}
+		details = append(details, detail)
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatalf("read query plan: %v", err)
+	}
+	plan := strings.Join(details, "\n")
+	if strings.Count(plan, "USING INDEX scheduler_decisions_project_at_idx") < 2 {
+		t.Fatalf("query plan = %q, want two indexed project/time scans", plan)
+	}
+	if !strings.Contains(plan, "USING INTEGER PRIMARY KEY") {
+		t.Fatalf("query plan = %q, want latest-decision primary-key lookup", plan)
+	}
+	if strings.Contains(plan, "MATERIALIZE ranked") || strings.Contains(plan, "TEMP B-TREE FOR ORDER BY") {
+		t.Fatalf("query plan = %q, want no full-history window materialization", plan)
+	}
+}
+
 func TestCheckDoctorWorkflowRuntimeLintCleanHistoryIsQuiet(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

- replace the workflow wait-status window/self-join query with indexed latest/reset aggregation
- preserve continuous streak, lane, reset, and project-isolation semantics
- add table-driven semantic coverage and a bounded query-plan regression

Fixes #1878

## UI Surface Contract

- [x] N/A; this change has no UI surface impact.
- [x] This PR does not add persistent top-of-screen messaging.
- [x] N/A; this PR has no visual changes.

## Test Plan

- [x] `make check`
- [x] focused workflow-lint tests
- [x] focused workflow-lint race tests
- [x] isolated 900,000-row query-plan benchmark (30.60s before, 2.14s after)