### PR TITLE
feat(dispatch): configure rate-window pacing

### DIFF
--- a/config.annotated.yaml
+++ b/config.annotated.yaml
@@ -46,6 +46,12 @@ worker:
 # Bound fleet concurrency globally and serialize only the merge lane.
 agent:
   max_concurrent_agents: 4
+  # The project may override global subscription-provider pacing. Missing or
+  # stale provider buckets fail open to max_concurrent_agents.
+  rate_window_pacing:
+    mode: proportional
+    floor_percent: 20
+    stale_after_seconds: 900
   max_concurrent_agents_by_state:
     Merging: 1
   auto_promote:

--- a/config.reference.yaml
+++ b/config.reference.yaml
@@ -548,6 +548,14 @@
 # agent:
 #   # agent.max_concurrent_agents | type: integer | default: 10 | required: No | validation: must be greater than 0
 #   max_concurrent_agents: 10
+#   # agent.rate_window_pacing | type: object | default: see child fields | required: No | validation: None
+#   rate_window_pacing:
+#     # agent.rate_window_pacing.mode | type: string | default: "proportional" | required: No | validation: must be one of proportional, off, floor
+#     mode: "proportional"
+#     # agent.rate_window_pacing.floor_percent | type: number | default: 20 | required: No | validation: must be greater than 0 and less than or equal to 100
+#     floor_percent: 20
+#     # agent.rate_window_pacing.stale_after_seconds | type: integer | default: 900 | required: No | validation: must be greater than 0
+#     stale_after_seconds: 900
 #   # agent.max_turns | type: integer | default: 20 | required: No | validation: must be greater than 0
 #   max_turns: 20
 #   # agent.max_turn_duration_ms | type: integer | default: 0 | required: No | validation: must be greater than or equal to 0

--- a/docs/config.md
+++ b/docs/config.md
@@ -544,6 +544,10 @@ only to resettable budget pacing and never clears a per-issue hard hold.
 | `agent.output_truncation.max_bytes` | `integer` | `0` | No | must be greater than or equal to 0 |
 | `agent.overload_retry_delay_ms` | `integer` | `45000` | No | must be greater than 0 |
 | `agent.prioritize_unblockers` | `boolean` | `true` | No | None |
+| `agent.rate_window_pacing` | `object` | `see child fields` | No | None |
+| `agent.rate_window_pacing.floor_percent` | `number` | `20` | No | must be greater than 0 and less than or equal to 100 |
+| `agent.rate_window_pacing.mode` | `string` | `"proportional"` | No | must be one of proportional, off, floor |
+| `agent.rate_window_pacing.stale_after_seconds` | `integer` | `900` | No | must be greater than 0 |
 | `agent.resume_orphaned_sessions` | `boolean` | `true` | No | None |
 | `agent.shutdown` | `object` | `see child fields` | No | None |
 | `agent.shutdown.drain_timeout_ms` | `integer` | `75000` | No | must be greater than or equal to 0 |

--- a/docs/dashboard-api.md
+++ b/docs/dashboard-api.md
@@ -86,6 +86,16 @@ primary or secondary provider rate-window percentage. An omitted mode defaults
 to `subscription`, so USD controls are inert unless metered billing is declared
 explicitly.
 
+Subscription pacing is configured globally with `global.rate_window_pacing`
+and overridden per project with `agent.rate_window_pacing`. The default
+`proportional` mode preserves the existing percentage scaling. `off` disables
+scaling, and `floor` keeps full concurrency until remaining capacity falls
+below `floor_percent`. Missing buckets, buckets without an observation
+timestamp, and buckets older than `stale_after_seconds` fail open to
+`agent.max_concurrent_agents`. Both `/health` and board-state responses expose
+the resolved mode, bucket freshness, observed remaining percentage, and
+effective permit ceiling at `dispatch.rate_window_pacing`.
+
 `agent.no_progress_token_limit` defaults to `25000000` tokens and is enforced
 in both billing modes. Detent sums persisted `total_tokens` for the issue across
 attempts after its latest accepted lane or PR advancement. Reaching the limit

--- a/docs/examples/multi-project/global.yaml
+++ b/docs/examples/multi-project/global.yaml
@@ -20,6 +20,11 @@ global:
   # Bound total subprocess pressure on this host. Per-project caps below split
   # these five slots between the two repositories.
   max_concurrent_agents: 5
+  # Preserve full width until a fresh provider bucket falls below 20%.
+  rate_window_pacing:
+    mode: floor
+    floor_percent: 20
+    stale_after_seconds: 900
   scheduling: weighted
   fair_share:
     half_life: 1h

--- a/docs/multi-project.md
+++ b/docs/multi-project.md
@@ -27,6 +27,10 @@ update:
   auto_apply_enabled: false
 global:
   max_concurrent_agents: 8
+  rate_window_pacing:
+    mode: proportional
+    floor_percent: 20
+    stale_after_seconds: 900
   scheduling: weighted
   active_hours:
     timezone: America/Chicago
@@ -104,11 +108,37 @@ largest observed constraint across pool capacity, the project's
 `agent.max_concurrent_agents`, lane-specific
 `agent.max_concurrent_agents_by_state`, worker-host capacity, and subscription
 provider rate-window backpressure. Each finding names the matching lever.
-Rate-window backpressure recommends no configuration change because raising a
-configured cap cannot increase the effective provider-paced limit.
+Rate-window backpressure points to `global.rate_window_pacing` and the
+per-project `agent.rate_window_pacing` override. Raising a concurrency cap does
+not increase the effective provider-paced limit.
 Because pool refusals are sampled, all constraint reasons are normalized to
 one observation per five-minute interval before doctor selects the binding
 constraint. Telemetry from a project's previous pool assignment is ignored.
+
+`global.rate_window_pacing` controls subscription-provider pacing for every
+project unless that project's `agent.rate_window_pacing` explicitly overrides
+it. `mode: proportional` is the default and scales concurrency by the lowest
+fresh primary or secondary remaining percentage. `mode: off` never scales, so
+`agent.max_concurrent_agents` remains the project cap and
+`provider_rate_window_backpressure` cannot be a dispatch wait reason. `mode:
+floor` preserves full width while the remaining percentage is at or above
+`floor_percent`, then uses proportional scaling below that threshold.
+
+Provider buckets older than `stale_after_seconds` (default `900`), buckets
+without an observation timestamp, and snapshots with no primary or secondary
+bucket fail open to configured concurrency. The board state and `/health`
+report the effective mode, bucket status, observation time and remaining
+percentage, permit ceiling, and whether scaling is active under
+`dispatch.rate_window_pacing`. Turning pacing off or failing open shifts the
+risk to exhausting the provider window completely.
+
+A project override belongs in its `detent.yaml`:
+
+```yaml
+agent:
+  rate_window_pacing:
+    mode: off
+```
 
 A pool-bound project in a single-class pool is told to raise that pool's
 capacity, never to split it. For an elastic pool this names `burst_to`, the
@@ -248,6 +278,7 @@ can include `--workflow-ref origin/main` during registration or add
 | `ops.tmux_window_status` | Restart required |
 | `global.identity` | Live reload; project runtimes restart in-process and `/api/v1/state.instance.name` updates after the next telemetry snapshot |
 | `global.active_hours` | Live reload at the next dispatch decision; running agents drain when a window closes |
+| `global.rate_window_pacing` and `agent.rate_window_pacing` | Live reload at the next dispatch decision without interrupting running agents; the project value wins when explicitly set |
 | `global.max_concurrent_agents`, `global.scheduling`, `global.agent_pools`, `global.fair_share`, and project pool assignments | Live reload at the next dispatch decision; adding, removing, or lowering `burst_to` preserves active workers and drains to the new ceiling, and removed pools drain their active workers before retirement |
 | `log_level` | Live reload |
 | `port`, `env`, `log_max_size_bytes`, `log_max_backups` | Restart required |

--- a/internal/claudecode/stream.go
+++ b/internal/claudecode/stream.go
@@ -169,7 +169,8 @@ func (s *turnState) applyRateLimit(event claudeEvent, onUpdate runner.AgentUpdat
 		return nil
 	}
 	info := event.RateLimit
-	bucket := &telemetry.RateLimitBucket{Status: strings.TrimSpace(info.Status)}
+	observedAt := time.Now().UTC()
+	bucket := &telemetry.RateLimitBucket{Status: strings.TrimSpace(info.Status), ObservedAt: &observedAt}
 	if strings.EqualFold(bucket.Status, "rejected") {
 		bucket.Status = telemetry.RateLimitStatusExhausted
 	}

--- a/internal/claudecode/stream_activity_test.go
+++ b/internal/claudecode/stream_activity_test.go
@@ -31,6 +31,9 @@ func TestTurnStateEmitsStructuredRateLimit(t *testing.T) {
 	if limits.ReachedType != "five_hour" || limits.Primary == nil || limits.Primary.Status != telemetry.RateLimitStatusExhausted || limits.Primary.ResetAt == nil || !limits.Primary.ResetAt.Equal(wantReset) {
 		t.Fatalf("RateLimits = %#v, want exhausted five-hour limit reset at %s", limits, wantReset)
 	}
+	if limits.Primary.ObservedAt == nil {
+		t.Fatalf("Primary.ObservedAt = nil, want observation timestamp")
+	}
 }
 
 func TestTurnStateEmitsToolContent(t *testing.T) {

--- a/internal/cli/doctor_agent_pools.go
+++ b/internal/cli/doctor_agent_pools.go
@@ -397,7 +397,10 @@ func doctorCapacityRecommendation(
 			projectID,
 		), ""
 	case store.CapacityConstraintRateWindow:
-		return "provider rate-window backpressure is binding; no config change is recommended because raising a cap will not help.", ""
+		return fmt.Sprintf(
+			"provider rate-window backpressure is binding.\nset project %q agent.rate_window_pacing.mode to off or floor, or adjust global.rate_window_pacing.",
+			projectID,
+		), ""
 	default:
 		return "", ""
 	}

--- a/internal/cli/doctor_agent_pools_test.go
+++ b/internal/cli/doctor_agent_pools_test.go
@@ -111,14 +111,14 @@ func TestDoctorCapacityConstraintBindingRecommendations(t *testing.T) {
 			want:       []string{`raise project "video" worker.max_concurrent_agents_per_host`},
 		},
 		{
-			name:     "rate window recommends no config change",
+			name:     "rate window recommends pacing configuration",
 			cfg:      doctorAgentPoolsTestConfig([]globalconfig.Project{{ID: "video"}}),
 			projects: []doctorWorkloadProject{doctorCapacityTestProject("video", "default", workload.ClassCloudOnly, 5)},
 			waits: []store.CapacityConstraintWait{
 				{ProjectID: "video", WorkloadClass: "cloud-only", Pool: "default", Reason: store.CapacityConstraintRateWindow, WaitCount: 6},
 			},
 			wantStatus: doctorWarn,
-			want:       []string{"provider rate-window backpressure is binding", "no config change is recommended"},
+			want:       []string{"provider rate-window backpressure is binding", `set project "video" agent.rate_window_pacing.mode to off or floor`, "global.rate_window_pacing"},
 			notWant:    []string{"raise ", "split "},
 		},
 		{

--- a/internal/cli/global_reload.go
+++ b/internal/cli/global_reload.go
@@ -302,6 +302,9 @@ func changedGlobalSettings(previous globalconfig.Settings, next globalconfig.Set
 	if previous.Scheduling != next.Scheduling {
 		fields = append(fields, globalConfigChange{Field: "global.scheduling", Old: previous.Scheduling, New: next.Scheduling})
 	}
+	if previous.RateWindowPacing != next.RateWindowPacing {
+		fields = append(fields, globalConfigChange{Field: "global.rate_window_pacing", Old: previous.RateWindowPacing, New: next.RateWindowPacing})
+	}
 	if !reflect.DeepEqual(previous.AgentPools, next.AgentPools) {
 		fields = append(fields, globalConfigChange{Field: "global.agent_pools", Old: previous.AgentPools, New: next.AgentPools})
 	}

--- a/internal/cli/runner.go
+++ b/internal/cli/runner.go
@@ -1466,6 +1466,7 @@ func mergeFleetDispatchStatus(current telemetry.DispatchStatus, next telemetry.D
 		SkippedCount:        current.SkippedCount + next.SkippedCount,
 		Stalled:             current.Stalled || next.Stalled,
 		NeedsHumanAttention: current.NeedsHumanAttention || next.NeedsHumanAttention,
+		RateWindowPacing:    mergeFleetRateWindowPacing(current.RateWindowPacing, next.RateWindowPacing),
 	}
 	merged.LastSelectedAt = latestTime(current.LastSelectedAt, next.LastSelectedAt)
 	merged.ObservedAt = current.ObservedAt
@@ -1483,6 +1484,44 @@ func mergeFleetDispatchStatus(current telemetry.DispatchStatus, next telemetry.D
 		merged.WaitReason = next.WaitReason
 	} else if current.Stalled {
 		merged.WaitReason = current.WaitReason
+	}
+	return merged
+}
+
+func mergeFleetRateWindowPacing(current telemetry.RateWindowPacing, next telemetry.RateWindowPacing) telemetry.RateWindowPacing {
+	if strings.TrimSpace(current.Mode) == "" {
+		return next
+	}
+	if strings.TrimSpace(next.Mode) == "" {
+		return current
+	}
+	merged := telemetry.RateWindowPacing{
+		Mode:              current.Mode,
+		FloorPercent:      current.FloorPercent,
+		StaleAfterSeconds: current.StaleAfterSeconds,
+		Applicable:        current.Applicable || next.Applicable,
+		BucketStatus:      current.BucketStatus,
+		PermitCeiling:     current.PermitCeiling + next.PermitCeiling,
+		ScalingApplied:    current.ScalingApplied || next.ScalingApplied,
+	}
+	if current.Mode != next.Mode {
+		merged.Mode = "mixed"
+	}
+	if current.FloorPercent != next.FloorPercent {
+		merged.FloorPercent = 0
+	}
+	if current.StaleAfterSeconds != next.StaleAfterSeconds {
+		merged.StaleAfterSeconds = 0
+	}
+	if current.BucketStatus != next.BucketStatus {
+		merged.BucketStatus = "mixed"
+	}
+	merged.ObservedRemainingPercent = current.ObservedRemainingPercent
+	merged.ObservedAt = current.ObservedAt
+	if next.ObservedRemainingPercent != nil && (merged.ObservedRemainingPercent == nil || *next.ObservedRemainingPercent < *merged.ObservedRemainingPercent) {
+		remaining := *next.ObservedRemainingPercent
+		merged.ObservedRemainingPercent = &remaining
+		merged.ObservedAt = next.ObservedAt
 	}
 	return merged
 }

--- a/internal/codex/backend.go
+++ b/internal/codex/backend.go
@@ -263,6 +263,12 @@ func rateLimitsFromCodex(snapshot *RateLimitSnapshot) *telemetry.RateLimits {
 		Secondary:   rateLimitBucketFromCodex(snapshot.Secondary),
 		Credits:     creditsBucketFromCodex(snapshot.Credits),
 	}
+	observedAt := time.Now().UTC()
+	for _, bucket := range []*telemetry.RateLimitBucket{limits.Primary, limits.Secondary} {
+		if bucket != nil {
+			bucket.ObservedAt = &observedAt
+		}
+	}
 	if strings.TrimSpace(snapshot.RateLimitReachedType) != "" {
 		bucket := limits.Primary
 		if strings.Contains(strings.ToLower(snapshot.RateLimitReachedType), "secondary") {

--- a/internal/codex/capacity_test.go
+++ b/internal/codex/capacity_test.go
@@ -257,4 +257,7 @@ func TestRateLimitsFromCodexPreservesReachedType(t *testing.T) {
 	if limits.Primary == nil || limits.Primary.Status != telemetry.RateLimitStatusExhausted {
 		t.Fatalf("Primary = %#v, want exhausted", limits.Primary)
 	}
+	if limits.Primary.ObservedAt == nil {
+		t.Fatalf("Primary.ObservedAt = nil, want observation timestamp")
+	}
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -299,6 +299,7 @@ type Worker struct {
 
 type Agent struct {
 	MaxConcurrentAgents          int                          `yaml:"max_concurrent_agents"`
+	RateWindowPacing             RateWindowPacing             `yaml:"rate_window_pacing"`
 	MaxTurns                     int                          `yaml:"max_turns"`
 	MaxTurnDurationMS            int                          `yaml:"max_turn_duration_ms"`
 	MaxSessionDurationMS         int                          `yaml:"max_session_duration_ms"`
@@ -1369,6 +1370,7 @@ func Default() Config {
 		},
 		Agent: Agent{
 			MaxConcurrentAgents:         10,
+			RateWindowPacing:            DefaultRateWindowPacing(),
 			MaxTurns:                    20,
 			MaxSessionDurationMS:        DefaultMaxSessionDurationMS,
 			NoProgressTimeoutMS:         DefaultNoProgressTimeoutMS,
@@ -1701,6 +1703,7 @@ func (c *Config) normalize() {
 	}
 
 	c.Agent.MaxConcurrentAgentsByState = normalizeStateLimits(c.Agent.MaxConcurrentAgentsByState)
+	c.Agent.RateWindowPacing = c.Agent.RateWindowPacing.Normalized()
 	if c.Agent.MergeWorkerStartupTimeoutMS == 0 {
 		c.Agent.MergeWorkerStartupTimeoutMS = DefaultMergeWorkerStartupTimeoutMS
 	}
@@ -2143,6 +2146,7 @@ func normalizeDeliverableKind(kind string) string {
 
 func (a *Agent) validate(prefix string, problems *[]string) {
 	validatePositive(prefix+".max_concurrent_agents", a.MaxConcurrentAgents, problems)
+	*problems = append(*problems, a.RateWindowPacing.Validate(prefix+".rate_window_pacing")...)
 	validatePositive(prefix+".max_turns", a.MaxTurns, problems)
 	if a.MaxTurnDurationMS < 0 {
 		*problems = append(*problems, prefix+".max_turn_duration_ms must be greater than or equal to 0")

--- a/internal/config/global/config.go
+++ b/internal/config/global/config.go
@@ -119,14 +119,15 @@ func (u Update) NormalizedCheckIntervalHours() int {
 }
 
 type Settings struct {
-	MaxConcurrentAgents int                 `yaml:"max_concurrent_agents"`
-	Scheduling          string              `yaml:"scheduling"`
-	AgentPools          []AgentPool         `yaml:"agent_pools,omitempty"`
-	ActiveHours         *activehours.Config `yaml:"active_hours,omitempty"`
-	Identity            Identity            `yaml:"identity,omitempty"`
-	Knowledge           Knowledge           `yaml:"knowledge,omitempty"`
-	FairShare           map[string]any      `yaml:"fair_share,omitempty"`
-	Startup             map[string]any      `yaml:"startup,omitempty"`
+	MaxConcurrentAgents int                             `yaml:"max_concurrent_agents"`
+	RateWindowPacing    workflowconfig.RateWindowPacing `yaml:"rate_window_pacing"`
+	Scheduling          string                          `yaml:"scheduling"`
+	AgentPools          []AgentPool                     `yaml:"agent_pools,omitempty"`
+	ActiveHours         *activehours.Config             `yaml:"active_hours,omitempty"`
+	Identity            Identity                        `yaml:"identity,omitempty"`
+	Knowledge           Knowledge                       `yaml:"knowledge,omitempty"`
+	FairShare           map[string]any                  `yaml:"fair_share,omitempty"`
+	Startup             map[string]any                  `yaml:"startup,omitempty"`
 }
 
 type AgentPool struct {
@@ -137,29 +138,30 @@ type AgentPool struct {
 }
 
 type Project struct {
-	ID                       string              `yaml:"id"`
-	Pool                     string              `yaml:"pool,omitempty"`
-	Workflow                 string              `yaml:"workflow"`
-	WorkflowRef              string              `yaml:"workflow_ref,omitempty"`
-	Workdir                  string              `yaml:"workdir"`
-	Color                    string              `yaml:"color,omitempty"`
-	Knowledge                Knowledge           `yaml:"knowledge,omitempty"`
-	Weight                   int                 `yaml:"weight"`
-	Priority                 int                 `yaml:"priority"`
-	Paused                   bool                `yaml:"paused,omitempty"`
-	PausedReason             string              `yaml:"paused_reason,omitempty"`
-	PausedAt                 string              `yaml:"paused_at,omitempty"`
-	PausedUntilIssue         string              `yaml:"paused_until_issue,omitempty"`
-	PausedUntil              string              `yaml:"paused_until,omitempty"`
-	ActiveHours              *activehours.Config `yaml:"active_hours,omitempty"`
-	ActiveHoursOverrideUntil string              `yaml:"active_hours_override_until,omitempty"`
-	CredentialRef            string              `yaml:"credential_ref,omitempty"`
-	Authorization            selector.Selector   `yaml:"authorization,omitempty"`
-	Intake                   intakeconfig.Config `yaml:"intake,omitempty"`
-	Identity                 Identity            `yaml:"-"`
-	GlobalKnowledge          Knowledge           `yaml:"-"`
-	GlobalActiveHours        *activehours.Config `yaml:"-"`
-	IntakeConfigured         bool                `yaml:"-"`
+	ID                       string                          `yaml:"id"`
+	Pool                     string                          `yaml:"pool,omitempty"`
+	Workflow                 string                          `yaml:"workflow"`
+	WorkflowRef              string                          `yaml:"workflow_ref,omitempty"`
+	Workdir                  string                          `yaml:"workdir"`
+	Color                    string                          `yaml:"color,omitempty"`
+	Knowledge                Knowledge                       `yaml:"knowledge,omitempty"`
+	Weight                   int                             `yaml:"weight"`
+	Priority                 int                             `yaml:"priority"`
+	Paused                   bool                            `yaml:"paused,omitempty"`
+	PausedReason             string                          `yaml:"paused_reason,omitempty"`
+	PausedAt                 string                          `yaml:"paused_at,omitempty"`
+	PausedUntilIssue         string                          `yaml:"paused_until_issue,omitempty"`
+	PausedUntil              string                          `yaml:"paused_until,omitempty"`
+	ActiveHours              *activehours.Config             `yaml:"active_hours,omitempty"`
+	ActiveHoursOverrideUntil string                          `yaml:"active_hours_override_until,omitempty"`
+	CredentialRef            string                          `yaml:"credential_ref,omitempty"`
+	Authorization            selector.Selector               `yaml:"authorization,omitempty"`
+	Intake                   intakeconfig.Config             `yaml:"intake,omitempty"`
+	Identity                 Identity                        `yaml:"-"`
+	GlobalKnowledge          Knowledge                       `yaml:"-"`
+	GlobalActiveHours        *activehours.Config             `yaml:"-"`
+	GlobalRateWindowPacing   workflowconfig.RateWindowPacing `yaml:"-"`
+	IntakeConfigured         bool                            `yaml:"-"`
 }
 
 type Identity = workflowconfig.Identity
@@ -660,6 +662,7 @@ func (c Config) Validate(opts ...Option) error {
 	if c.Global.MaxConcurrentAgents <= 0 {
 		problems = append(problems, "global.max_concurrent_agents: must be a positive integer")
 	}
+	problems = append(problems, c.Global.RateWindowPacing.Validate("global.rate_window_pacing")...)
 	if !validSchedulingMode(c.Global.Scheduling) {
 		problems = append(problems, "global.scheduling: must be one of "+strings.Join(schedulingModes, ", "))
 	}
@@ -929,6 +932,7 @@ func defaultConfig(path string) Config {
 func defaultSettings() Settings {
 	return Settings{
 		MaxConcurrentAgents: 8,
+		RateWindowPacing:    workflowconfig.DefaultRateWindowPacing(),
 		Scheduling:          SchedulingWeighted,
 		FairShare: map[string]any{
 			"half_life": "1h",
@@ -1038,6 +1042,7 @@ func globalErrors(value any) []string {
 	var problems []string
 	problems = append(problems, prefixErrors(requiredErrors(global, []string{"max_concurrent_agents", "scheduling"}), "global")...)
 	problems = append(problems, positiveIntegerError(global["max_concurrent_agents"], "global.max_concurrent_agents")...)
+	problems = append(problems, rateWindowPacingErrors(global["rate_window_pacing"], "global.rate_window_pacing")...)
 	problems = append(problems, schedulingErrors(global["scheduling"], "global.scheduling")...)
 	problems = append(problems, agentPoolsErrors(global["agent_pools"])...)
 	problems = append(problems, activeHoursErrors(global["active_hours"], "global.active_hours")...)
@@ -1063,6 +1068,20 @@ func schedulingErrors(value any, field string) []string {
 		return nil
 	}
 	return []string{field + ": must be one of " + strings.Join(schedulingModes, ", ")}
+}
+
+func rateWindowPacingErrors(value any, field string) []string {
+	if value == nil {
+		return nil
+	}
+	if _, ok := value.(map[string]any); !ok {
+		return []string{field + ": must be a mapping"}
+	}
+	var pacing workflowconfig.RateWindowPacing
+	if err := decodeYAMLValue(value, &pacing); err != nil {
+		return []string{field + ": " + err.Error()}
+	}
+	return pacing.Validate(field)
 }
 
 func validSchedulingMode(mode string) bool {
@@ -1936,8 +1955,16 @@ func buildSettings(attrs map[string]any, opts options) (Settings, error) {
 		}
 		activeHours = &parsed
 	}
+	rateWindowPacing := settings.RateWindowPacing
+	if attrs["rate_window_pacing"] != nil {
+		if err := decodeYAMLValue(attrs["rate_window_pacing"], &rateWindowPacing); err != nil {
+			return Settings{}, fmt.Errorf("global.rate_window_pacing: %w", err)
+		}
+		rateWindowPacing = rateWindowPacing.Normalized()
+	}
 
 	settings.MaxConcurrentAgents = maxConcurrentAgents
+	settings.RateWindowPacing = rateWindowPacing
 	settings.Scheduling = scheduling
 	settings.AgentPools = agentPools
 	settings.ActiveHours = activeHours

--- a/internal/config/global/config_test.go
+++ b/internal/config/global/config_test.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"testing"
 
+	workflowconfig "github.com/digitaldrywood/detent/internal/config"
 	"github.com/digitaldrywood/detent/internal/selector"
 )
 
@@ -550,6 +551,7 @@ func TestWriteRoundTripsConfig(t *testing.T) {
 		Port:                  &port,
 		Global: Settings{
 			MaxConcurrentAgents: 3,
+			RateWindowPacing:    workflowconfig.DefaultRateWindowPacing(),
 			Scheduling:          SchedulingStrict,
 			AgentPools: []AgentPool{
 				{Name: "code", MaxConcurrentAgents: 5},

--- a/internal/config/global/rate_window_pacing_test.go
+++ b/internal/config/global/rate_window_pacing_test.go
@@ -1,0 +1,48 @@
+package global
+
+import (
+	"strings"
+	"testing"
+
+	workflowconfig "github.com/digitaldrywood/detent/internal/config"
+)
+
+func TestBuildGlobalRateWindowPacing(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		value     any
+		want      workflowconfig.RateWindowPacing
+		wantError string
+	}{
+		{name: "default", want: workflowconfig.DefaultRateWindowPacing()},
+		{name: "off", value: map[string]any{"mode": "off"}, want: workflowconfig.RateWindowPacing{Mode: workflowconfig.RateWindowPacingOff}.Normalized()},
+		{name: "floor", value: map[string]any{"mode": "floor", "floor_percent": 30, "stale_after_seconds": 600}, want: workflowconfig.RateWindowPacing{Mode: workflowconfig.RateWindowPacingFloor, FloorPercent: 30, StaleAfterSeconds: 600}},
+		{name: "invalid", value: map[string]any{"mode": "burst"}, wantError: "mode must be one of proportional, off, floor"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			attrs := map[string]any{"max_concurrent_agents": 8, "scheduling": SchedulingWeighted}
+			if tt.value != nil {
+				attrs["rate_window_pacing"] = tt.value
+			}
+			if problems := rateWindowPacingErrors(tt.value, "global.rate_window_pacing"); len(problems) > 0 {
+				if tt.wantError == "" || !strings.Contains(strings.Join(problems, "; "), tt.wantError) {
+					t.Fatalf("rateWindowPacingErrors() = %v", problems)
+				}
+				return
+			}
+			settings, err := buildSettings(attrs, defaultOptions())
+			if err != nil {
+				t.Fatalf("buildSettings() error = %v", err)
+			}
+			if settings.RateWindowPacing != tt.want {
+				t.Fatalf("RateWindowPacing = %#v, want %#v", settings.RateWindowPacing, tt.want)
+			}
+		})
+	}
+}

--- a/internal/config/rate_window_pacing.go
+++ b/internal/config/rate_window_pacing.go
@@ -1,0 +1,71 @@
+package config
+
+import (
+	"strings"
+)
+
+const (
+	RateWindowPacingProportional = "proportional"
+	RateWindowPacingOff          = "off"
+	RateWindowPacingFloor        = "floor"
+
+	DefaultRateWindowPacingFloorPercent      = 20
+	DefaultRateWindowPacingStaleAfterSeconds = 15 * 60
+)
+
+type RateWindowPacing struct {
+	Mode              string  `yaml:"mode"`
+	FloorPercent      float64 `yaml:"floor_percent"`
+	StaleAfterSeconds int     `yaml:"stale_after_seconds"`
+}
+
+func DefaultRateWindowPacing() RateWindowPacing {
+	return RateWindowPacing{
+		Mode:              RateWindowPacingProportional,
+		FloorPercent:      DefaultRateWindowPacingFloorPercent,
+		StaleAfterSeconds: DefaultRateWindowPacingStaleAfterSeconds,
+	}
+}
+
+func (p RateWindowPacing) Normalized() RateWindowPacing {
+	p.Mode = strings.ToLower(strings.TrimSpace(p.Mode))
+	if p.Mode == "" {
+		p.Mode = RateWindowPacingProportional
+	}
+	if p.FloorPercent == 0 {
+		p.FloorPercent = DefaultRateWindowPacingFloorPercent
+	}
+	if p.StaleAfterSeconds == 0 {
+		p.StaleAfterSeconds = DefaultRateWindowPacingStaleAfterSeconds
+	}
+	return p
+}
+
+func (p RateWindowPacing) Validate(prefix string) []string {
+	p = p.Normalized()
+	var problems []string
+	switch p.Mode {
+	case RateWindowPacingProportional, RateWindowPacingOff, RateWindowPacingFloor:
+	default:
+		problems = append(problems, prefix+".mode must be one of proportional, off, floor")
+	}
+	if p.FloorPercent <= 0 || p.FloorPercent > 100 {
+		problems = append(problems, prefix+".floor_percent must be greater than 0 and less than or equal to 100")
+	}
+	if p.StaleAfterSeconds <= 0 {
+		problems = append(problems, prefix+".stale_after_seconds must be greater than 0")
+	}
+	return problems
+}
+
+func (c Config) RateWindowPacingConfigured() bool {
+	for path := range c.configuredFields {
+		if strings.HasPrefix(path, "agent.rate_window_pacing.") {
+			return true
+		}
+	}
+	if c.configuredFields != nil {
+		return false
+	}
+	return c.Agent.RateWindowPacing.Normalized() != DefaultRateWindowPacing()
+}

--- a/internal/config/rate_window_pacing_test.go
+++ b/internal/config/rate_window_pacing_test.go
@@ -1,0 +1,67 @@
+package config
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestRateWindowPacingConfiguration(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name           string
+		yaml           string
+		want           RateWindowPacing
+		wantConfigured bool
+		wantError      string
+	}{
+		{
+			name: "default proportional",
+			yaml: "",
+			want: DefaultRateWindowPacing(),
+		},
+		{
+			name:           "off",
+			yaml:           "agent:\n  rate_window_pacing:\n    mode: off\n",
+			want:           RateWindowPacing{Mode: RateWindowPacingOff, FloorPercent: DefaultRateWindowPacingFloorPercent, StaleAfterSeconds: DefaultRateWindowPacingStaleAfterSeconds},
+			wantConfigured: true,
+		},
+		{
+			name:           "floor",
+			yaml:           "agent:\n  rate_window_pacing:\n    mode: floor\n    floor_percent: 35\n    stale_after_seconds: 600\n",
+			want:           RateWindowPacing{Mode: RateWindowPacingFloor, FloorPercent: 35, StaleAfterSeconds: 600},
+			wantConfigured: true,
+		},
+		{
+			name:      "invalid mode",
+			yaml:      "agent:\n  rate_window_pacing:\n    mode: burst\n",
+			wantError: "agent.rate_window_pacing.mode must be one of proportional, off, floor",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			workflow, err := ParseWorkflow([]byte("---\ntracker:\n  kind: memory\n" + tt.yaml + "---\n"))
+			if err == nil {
+				err = workflow.Config.Validate()
+			}
+			if tt.wantError != "" {
+				if err == nil || !strings.Contains(err.Error(), tt.wantError) {
+					t.Fatalf("ParseWorkflow() error = %v, want containing %q", err, tt.wantError)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("ParseWorkflow() error = %v", err)
+			}
+			if got := workflow.Config.Agent.RateWindowPacing; got != tt.want {
+				t.Fatalf("RateWindowPacing = %#v, want %#v", got, tt.want)
+			}
+			if got := workflow.Config.RateWindowPacingConfigured(); got != tt.wantConfigured {
+				t.Fatalf("RateWindowPacingConfigured() = %t, want %t", got, tt.wantConfigured)
+			}
+		})
+	}
+}

--- a/internal/orchestrator/config.go
+++ b/internal/orchestrator/config.go
@@ -44,6 +44,7 @@ func ConfigFromWorkflow(cfg workflowconfig.Config) Config {
 		NoProgressTokenLimit:       cfg.Agent.NoProgressTokenLimit,
 		NoProgressSpendLimitUSD:    cfg.Agent.NoProgressSpendLimitUSD,
 		BillingMode:                cfg.Budget.EffectiveBillingMode(),
+		RateWindowPacing:           cfg.Agent.RateWindowPacing.Normalized(),
 		FailureBreaker: FailureBreakerConfig{
 			SameClassLimit: cfg.Agent.FailureBreaker.SameClassLimit,
 			Window:         durationFromSeconds(cfg.Agent.FailureBreaker.WindowSeconds),
@@ -159,6 +160,7 @@ func stalenessConfigFromWorkflow(cfg workflowconfig.StalenessObservability, term
 func normalizeConfig(cfg Config) Config {
 	cfg.ForgeHost = forgeavailability.NormalizeHost(cfg.ForgeHost)
 	cfg.BillingMode = strings.ToLower(strings.TrimSpace(cfg.BillingMode))
+	cfg.RateWindowPacing = cfg.RateWindowPacing.Normalized()
 	if cfg.BillingMode == "" {
 		cfg.BillingMode = workflowconfig.BillingModeSubscription
 	}

--- a/internal/orchestrator/dispatch_planner.go
+++ b/internal/orchestrator/dispatch_planner.go
@@ -17,6 +17,7 @@ import (
 
 type dispatchPlanner struct {
 	cfg Config
+	now time.Time
 }
 
 type dispatchPlanHooks struct {
@@ -63,6 +64,7 @@ func (p dispatchPlanner) plan(
 	now time.Time,
 	hooks dispatchPlanHooks,
 ) DispatchPlan {
+	p.now = now
 	state.ensureInitialized(p.cfg)
 	p.trackOwnershipAttentionCandidates(state, candidates, now)
 
@@ -661,6 +663,7 @@ func (p dispatchPlanner) dispatchableIssueDecisionForModelRequirement(
 	preferredWorkerHost string,
 	modelPermitRequired bool,
 ) dispatchableDecision {
+	p.now = now
 	if !validCandidate(issue) {
 		return dispatchableDecision{reason: dispatchSkipInvalidCandidate}
 	}
@@ -905,19 +908,29 @@ func (p dispatchPlanner) providerModelPermitSlots(state *State) int {
 	if state == nil {
 		return 0
 	}
-	limit := state.MaxConcurrentAgents
-	if p.cfg.subscriptionBilling() {
-		if remaining, ok := providerRateWindowRemainingPercent(state); ok {
-			limit = int(math.Ceil(float64(limit) * remaining / 100))
-			limit = max(1, limit)
-		}
-	}
-	available := limit - modelPermitsUsed(state)
+	evaluation := evaluateProviderRateWindowPacing(
+		p.cfg.BillingMode,
+		p.cfg.RateWindowPacing,
+		state.MaxConcurrentAgents,
+		state.RateLimits,
+		p.now,
+	)
+	available := evaluation.permitCeiling - modelPermitsUsed(state)
 	return max(0, available)
 }
 
 func (p dispatchPlanner) rateWindowBackpressureActive(state *State) bool {
-	return p.cfg.subscriptionBilling() && p.hardAvailableSlots(state) > 0 && p.providerModelPermitSlots(state) == 0
+	if state == nil {
+		return false
+	}
+	evaluation := evaluateProviderRateWindowPacing(
+		p.cfg.BillingMode,
+		p.cfg.RateWindowPacing,
+		state.MaxConcurrentAgents,
+		state.RateLimits,
+		p.now,
+	)
+	return evaluation.scalingApplied && p.hardAvailableSlots(state) > 0 && p.providerModelPermitSlots(state) == 0
 }
 
 func (p dispatchPlanner) modelPermitRequiredAtDispatch(issue connector.Issue) bool {
@@ -941,21 +954,87 @@ func modelPermitsUsed(state *State) int {
 	return used
 }
 
-func providerRateWindowRemainingPercent(state *State) (float64, bool) {
-	if state == nil || state.RateLimits == nil {
-		return 0, false
+type providerRateWindowPacingEvaluation struct {
+	mode                     string
+	floorPercent             float64
+	staleAfter               time.Duration
+	applicable               bool
+	bucketStatus             string
+	observedRemainingPercent *float64
+	observedAt               *time.Time
+	permitCeiling            int
+	scalingApplied           bool
+}
+
+func evaluateProviderRateWindowPacing(
+	billingMode string,
+	pacing workflowconfig.RateWindowPacing,
+	maxConcurrent int,
+	limits *telemetry.RateLimits,
+	now time.Time,
+) providerRateWindowPacingEvaluation {
+	pacing = pacing.Normalized()
+	evaluation := providerRateWindowPacingEvaluation{
+		mode:          pacing.Mode,
+		floorPercent:  pacing.FloorPercent,
+		staleAfter:    time.Duration(pacing.StaleAfterSeconds) * time.Second,
+		permitCeiling: max(0, maxConcurrent),
 	}
-	remaining := 100.0
+	remaining, observedAt, status := providerRateWindowObservation(limits, now, evaluation.staleAfter)
+	evaluation.bucketStatus = status
+	evaluation.observedRemainingPercent = remaining
+	evaluation.observedAt = observedAt
+	evaluation.applicable = !strings.EqualFold(strings.TrimSpace(billingMode), workflowconfig.BillingModeMetered) && pacing.Mode != workflowconfig.RateWindowPacingOff
+	if !evaluation.applicable || status != telemetry.RateWindowBucketFresh || remaining == nil || maxConcurrent <= 0 {
+		return evaluation
+	}
+	if pacing.Mode == workflowconfig.RateWindowPacingFloor && *remaining >= pacing.FloorPercent {
+		return evaluation
+	}
+	evaluation.permitCeiling = max(1, int(math.Ceil(float64(maxConcurrent)*(*remaining)/100)))
+	evaluation.scalingApplied = evaluation.permitCeiling < maxConcurrent
+	return evaluation
+}
+
+func providerRateWindowObservation(
+	limits *telemetry.RateLimits,
+	now time.Time,
+	staleAfter time.Duration,
+) (*float64, *time.Time, string) {
+	if limits == nil {
+		return nil, nil, telemetry.RateWindowBucketMissing
+	}
+	var freshRemaining *float64
+	var freshObservedAt *time.Time
+	var staleRemaining *float64
+	var staleObservedAt *time.Time
 	seen := false
-	for _, bucket := range []*telemetry.RateLimitBucket{state.RateLimits.Primary, state.RateLimits.Secondary} {
+	for _, bucket := range []*telemetry.RateLimitBucket{limits.Primary, limits.Secondary} {
 		if bucket == nil || bucket.Limit <= 0 {
 			continue
 		}
-		percent := float64(bucket.Remaining) / float64(bucket.Limit) * 100
-		remaining = min(remaining, max(0, min(100, percent)))
 		seen = true
+		percent := float64(bucket.Remaining) / float64(bucket.Limit) * 100
+		percent = max(0, min(100, percent))
+		if bucket.ObservedAt == nil || bucket.ObservedAt.IsZero() || !now.IsZero() && now.Sub(*bucket.ObservedAt) > staleAfter {
+			if staleRemaining == nil || percent < *staleRemaining {
+				staleRemaining = &percent
+				staleObservedAt = cloneTimePointer(bucket.ObservedAt)
+			}
+			continue
+		}
+		if freshRemaining == nil || percent < *freshRemaining {
+			freshRemaining = &percent
+			freshObservedAt = cloneTimePointer(bucket.ObservedAt)
+		}
 	}
-	return remaining, seen
+	if freshRemaining != nil {
+		return freshRemaining, freshObservedAt, telemetry.RateWindowBucketFresh
+	}
+	if seen {
+		return staleRemaining, staleObservedAt, telemetry.RateWindowBucketStale
+	}
+	return nil, nil, telemetry.RateWindowBucketMissing
 }
 
 func (p dispatchPlanner) stateSlotsAvailable(issue connector.Issue, state *State) bool {

--- a/internal/orchestrator/dispatch_test.go
+++ b/internal/orchestrator/dispatch_test.go
@@ -405,14 +405,19 @@ func TestPlanDispatchSubscriptionRateWindowBackpressure(t *testing.T) {
 	tests := []struct {
 		name        string
 		billingMode string
+		pacing      workflowconfig.RateWindowPacing
 		limits      *telemetry.RateLimits
 		want        int
 	}{
 		{name: "metered ignores provider window", billingMode: workflowconfig.BillingModeMetered, limits: providerRateLimits(20, 100), want: 10},
 		{name: "subscription scales to primary remaining", billingMode: workflowconfig.BillingModeSubscription, limits: providerRateLimits(50, 100), want: 5},
-		{name: "subscription uses lower secondary remaining", billingMode: workflowconfig.BillingModeSubscription, limits: &telemetry.RateLimits{Primary: &telemetry.RateLimitBucket{Remaining: 80, Limit: 100}, Secondary: &telemetry.RateLimitBucket{Remaining: 30, Limit: 100}}, want: 3},
+		{name: "subscription uses lower secondary remaining", billingMode: workflowconfig.BillingModeSubscription, limits: providerPrimarySecondaryRateLimits(80, 30), want: 3},
 		{name: "subscription preserves one soft slot at exhaustion", billingMode: workflowconfig.BillingModeSubscription, limits: providerRateLimits(0, 100), want: 1},
 		{name: "subscription without snapshot uses configured capacity", billingMode: workflowconfig.BillingModeSubscription, want: 10},
+		{name: "off ignores provider window", billingMode: workflowconfig.BillingModeSubscription, pacing: workflowconfig.RateWindowPacing{Mode: workflowconfig.RateWindowPacingOff}, limits: providerRateLimits(10, 100), want: 10},
+		{name: "floor preserves capacity above threshold", billingMode: workflowconfig.BillingModeSubscription, pacing: workflowconfig.RateWindowPacing{Mode: workflowconfig.RateWindowPacingFloor, FloorPercent: 25}, limits: providerRateLimits(30, 100), want: 10},
+		{name: "floor scales below threshold", billingMode: workflowconfig.BillingModeSubscription, pacing: workflowconfig.RateWindowPacing{Mode: workflowconfig.RateWindowPacingFloor, FloorPercent: 25}, limits: providerRateLimits(20, 100), want: 2},
+		{name: "stale snapshot uses configured capacity", billingMode: workflowconfig.BillingModeSubscription, limits: staleProviderRateLimits(10, 100), want: 10},
 	}
 
 	for _, tt := range tests {
@@ -421,6 +426,7 @@ func TestPlanDispatchSubscriptionRateWindowBackpressure(t *testing.T) {
 
 			cfg := normalizeConfig(Config{
 				BillingMode:         tt.billingMode,
+				RateWindowPacing:    tt.pacing,
 				MaxConcurrentAgents: 10,
 				ActiveStates:        []string{"Todo"},
 				TerminalStates:      []string{"Done"},
@@ -441,7 +447,21 @@ func TestPlanDispatchSubscriptionRateWindowBackpressure(t *testing.T) {
 }
 
 func providerRateLimits(remaining, limit int64) *telemetry.RateLimits {
-	return &telemetry.RateLimits{Primary: &telemetry.RateLimitBucket{Remaining: remaining, Limit: limit}}
+	observedAt := time.Date(2100, 1, 1, 0, 0, 0, 0, time.UTC)
+	return &telemetry.RateLimits{Primary: &telemetry.RateLimitBucket{Remaining: remaining, Limit: limit, ObservedAt: &observedAt}}
+}
+
+func staleProviderRateLimits(remaining, limit int64) *telemetry.RateLimits {
+	observedAt := time.Date(2000, 1, 1, 0, 0, 0, 0, time.UTC)
+	return &telemetry.RateLimits{Primary: &telemetry.RateLimitBucket{Remaining: remaining, Limit: limit, ObservedAt: &observedAt}}
+}
+
+func providerPrimarySecondaryRateLimits(primary, secondary int64) *telemetry.RateLimits {
+	observedAt := time.Date(2100, 1, 1, 0, 0, 0, 0, time.UTC)
+	return &telemetry.RateLimits{
+		Primary:   &telemetry.RateLimitBucket{Remaining: primary, Limit: 100, ObservedAt: &observedAt},
+		Secondary: &telemetry.RateLimitBucket{Remaining: secondary, Limit: 100, ObservedAt: &observedAt},
+	}
 }
 
 func TestSubscriptionPrunesLegacyUSDBudgetRefusals(t *testing.T) {
@@ -1974,9 +1994,7 @@ func TestDispatchableIssueDecisionCapacityReason(t *testing.T) {
 				BillingMode:         workflowconfig.BillingModeSubscription,
 			},
 			state: func(state *State) {
-				state.RateLimits = &telemetry.RateLimits{
-					Primary: &telemetry.RateLimitBucket{Remaining: 50, Limit: 100},
-				}
+				state.RateLimits = providerRateLimits(50, 100)
 				for index := range 5 {
 					running := dispatchTestIssue(fmt.Sprintf("running-%d", index), "Todo")
 					state.Running[running.ID] = Running{Issue: running}

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/digitaldrywood/detent/internal/activity"
+	workflowconfig "github.com/digitaldrywood/detent/internal/config"
 	"github.com/digitaldrywood/detent/internal/connector"
 	"github.com/digitaldrywood/detent/internal/efficiency"
 	"github.com/digitaldrywood/detent/internal/gate"
@@ -90,6 +91,7 @@ type Config struct {
 	NoProgressTokenLimit          int64
 	NoProgressSpendLimitUSD       float64
 	BillingMode                   string
+	RateWindowPacing              workflowconfig.RateWindowPacing
 	FailureBreaker                FailureBreakerConfig
 	Project                       scheduler.ProjectCandidate
 	Claiming                      ClaimingConfig
@@ -1024,6 +1026,8 @@ func (o *Orchestrator) applyRuntimeUpdate(state *State, update RuntimeUpdate, ti
 	state.PollInterval = cfg.PollInterval
 	state.RefreshFailureThreshold = cfg.RefreshFailureThreshold
 	state.MaxConcurrentAgents = cfg.MaxConcurrentAgents
+	state.BillingMode = cfg.BillingMode
+	state.RateWindowPacing = cfg.RateWindowPacing
 	state.StrandedActiveThreshold = cfg.StrandedActiveThreshold
 	state.DispatchStallThreshold = cfg.DispatchStallThreshold
 	state.AutoPromoteQuietDuration = cfg.AutoPromote.QuietDuration

--- a/internal/orchestrator/provider_window_admission.go
+++ b/internal/orchestrator/provider_window_admission.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"time"
 
 	runpkg "github.com/digitaldrywood/detent/internal/runner"
 )
@@ -50,7 +51,12 @@ func (o *Orchestrator) handleModelPermitRequest(state *State, issueID string) er
 	if !running.ModelPermitExempt {
 		return nil
 	}
-	if o.dispatchPlanner().providerModelPermitSlots(state) == 0 {
+	planner := o.dispatchPlanner()
+	planner.now = time.Now()
+	if o.now != nil {
+		planner.now = o.now()
+	}
+	if planner.providerModelPermitSlots(state) == 0 {
 		return runpkg.ErrModelPermitUnavailable
 	}
 	running.ModelPermitExempt = false

--- a/internal/orchestrator/provider_window_admission_test.go
+++ b/internal/orchestrator/provider_window_admission_test.go
@@ -209,6 +209,19 @@ func TestProviderWindowScaledCap(t *testing.T) {
 	}
 }
 
+func TestProviderWindowPacingOffNeverBackpressures(t *testing.T) {
+	t.Parallel()
+
+	cfg := providerWindowTestConfig()
+	cfg.RateWindowPacing = workflowconfig.RateWindowPacing{Mode: workflowconfig.RateWindowPacingOff}.Normalized()
+	state := providerWindowState(cfg, 1)
+	issue := dispatchTestIssue("candidate", "Todo")
+	decision := newDispatchPlanner(cfg).dispatchableIssueDecision(issue, &state, false, time.Now(), "")
+	if !decision.dispatchable || decision.reason == dispatchSkipRateWindowBackpressure {
+		t.Fatalf("dispatchable decision = %#v, want dispatchable without provider backpressure", decision)
+	}
+}
+
 func TestModelPermitDeferralReleasesHardCapacityAndPreservesPrecheck(t *testing.T) {
 	t.Parallel()
 

--- a/internal/orchestrator/rate_window_pacing_snapshot_test.go
+++ b/internal/orchestrator/rate_window_pacing_snapshot_test.go
@@ -1,0 +1,61 @@
+package orchestrator
+
+import (
+	"testing"
+	"time"
+
+	workflowconfig "github.com/digitaldrywood/detent/internal/config"
+	"github.com/digitaldrywood/detent/internal/telemetry"
+)
+
+func TestRateWindowPacingSnapshot(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 8, 18, 12, 0, 0, 0, time.UTC)
+	freshAt := now.Add(-time.Minute)
+	staleAt := now.Add(-16 * time.Minute)
+	tests := []struct {
+		name             string
+		pacing           workflowconfig.RateWindowPacing
+		limits           *telemetry.RateLimits
+		wantStatus       string
+		wantCeiling      int
+		wantApplicable   bool
+		wantScaling      bool
+		wantRemaining    float64
+		wantHasRemaining bool
+	}{
+		{name: "missing fails open", wantStatus: telemetry.RateWindowBucketMissing, wantCeiling: 10, wantApplicable: true},
+		{name: "stale fails open", limits: pacingRateLimits(10, &staleAt), wantStatus: telemetry.RateWindowBucketStale, wantCeiling: 10, wantApplicable: true, wantRemaining: 10, wantHasRemaining: true},
+		{name: "proportional scales fresh", limits: pacingRateLimits(10, &freshAt), wantStatus: telemetry.RateWindowBucketFresh, wantCeiling: 1, wantApplicable: true, wantScaling: true, wantRemaining: 10, wantHasRemaining: true},
+		{name: "off reports but does not scale", pacing: workflowconfig.RateWindowPacing{Mode: workflowconfig.RateWindowPacingOff}, limits: pacingRateLimits(10, &freshAt), wantStatus: telemetry.RateWindowBucketFresh, wantCeiling: 10, wantRemaining: 10, wantHasRemaining: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			cfg := normalizeConfig(Config{
+				BillingMode:         workflowconfig.BillingModeSubscription,
+				RateWindowPacing:    tt.pacing,
+				MaxConcurrentAgents: 10,
+			})
+			state := newState(cfg)
+			state.RateLimits = tt.limits
+			got := state.Snapshot(now).Dispatch.RateWindowPacing
+			if got.BucketStatus != tt.wantStatus || got.PermitCeiling != tt.wantCeiling || got.Applicable != tt.wantApplicable || got.ScalingApplied != tt.wantScaling {
+				t.Fatalf("RateWindowPacing = %#v", got)
+			}
+			if (got.ObservedRemainingPercent != nil) != tt.wantHasRemaining {
+				t.Fatalf("ObservedRemainingPercent = %v, want presence %t", got.ObservedRemainingPercent, tt.wantHasRemaining)
+			}
+			if tt.wantHasRemaining && *got.ObservedRemainingPercent != tt.wantRemaining {
+				t.Fatalf("ObservedRemainingPercent = %v, want %.0f", *got.ObservedRemainingPercent, tt.wantRemaining)
+			}
+		})
+	}
+}
+
+func pacingRateLimits(remaining int64, observedAt *time.Time) *telemetry.RateLimits {
+	return &telemetry.RateLimits{Primary: &telemetry.RateLimitBucket{Remaining: remaining, Limit: 100, ObservedAt: observedAt}}
+}

--- a/internal/orchestrator/shadow.go
+++ b/internal/orchestrator/shadow.go
@@ -4,6 +4,7 @@ import (
 	"sort"
 	"time"
 
+	workflowconfig "github.com/digitaldrywood/detent/internal/config"
 	"github.com/digitaldrywood/detent/internal/connector"
 )
 
@@ -53,6 +54,16 @@ func (s *State) ensureInitialized(cfg Config) {
 	}
 	if s.MaxConcurrentAgents <= 0 {
 		s.MaxConcurrentAgents = cfg.MaxConcurrentAgents
+	}
+	if s.BillingMode == "" {
+		s.BillingMode = cfg.BillingMode
+	}
+	if s.RateWindowPacing.Mode == "" {
+		s.RateWindowPacing = cfg.RateWindowPacing
+	}
+	s.RateWindowPacing = s.RateWindowPacing.Normalized()
+	if s.BillingMode == "" {
+		s.BillingMode = workflowconfig.BillingModeSubscription
 	}
 	if s.Running == nil {
 		s.Running = map[string]Running{}

--- a/internal/orchestrator/snapshot.go
+++ b/internal/orchestrator/snapshot.go
@@ -124,6 +124,7 @@ func (s State) Snapshot(now time.Time) telemetry.Snapshot {
 			Refusals: budgetRefusalSnapshots(s.BudgetRefusals),
 		},
 	}
+	snapshot.Dispatch.RateWindowPacing = rateWindowPacingSnapshot(s, now)
 	if snapshot.Dispatch.Stalled {
 		snapshot.DispatchStalls = []telemetry.DispatchStatus{snapshot.Dispatch}
 	}
@@ -135,6 +136,27 @@ func (s State) Snapshot(now time.Time) telemetry.Snapshot {
 	}
 	applySnapshotLaneProvenance(&snapshot, s.laneProvenance)
 	return snapshot
+}
+
+func rateWindowPacingSnapshot(state State, now time.Time) telemetry.RateWindowPacing {
+	evaluation := evaluateProviderRateWindowPacing(
+		state.BillingMode,
+		state.RateWindowPacing,
+		state.MaxConcurrentAgents,
+		state.RateLimits,
+		now,
+	)
+	return telemetry.RateWindowPacing{
+		Mode:                     evaluation.mode,
+		FloorPercent:             evaluation.floorPercent,
+		StaleAfterSeconds:        int64(evaluation.staleAfter / time.Second),
+		Applicable:               evaluation.applicable,
+		BucketStatus:             evaluation.bucketStatus,
+		ObservedRemainingPercent: evaluation.observedRemainingPercent,
+		ObservedAt:               evaluation.observedAt,
+		PermitCeiling:            evaluation.permitCeiling,
+		ScalingApplied:           evaluation.scalingApplied,
+	}
 }
 
 func dispatchStatusSnapshot(status store.ProjectDispatchStatus, threshold time.Duration, now time.Time) telemetry.DispatchStatus {

--- a/internal/orchestrator/state.go
+++ b/internal/orchestrator/state.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/digitaldrywood/detent/internal/agentidentity"
 	"github.com/digitaldrywood/detent/internal/backendcapacity"
+	workflowconfig "github.com/digitaldrywood/detent/internal/config"
 	"github.com/digitaldrywood/detent/internal/connector"
 	"github.com/digitaldrywood/detent/internal/gate"
 	"github.com/digitaldrywood/detent/internal/procgroup"
@@ -28,6 +29,8 @@ type State struct {
 	PollInterval             time.Duration
 	RefreshFailureThreshold  int
 	MaxConcurrentAgents      int
+	BillingMode              string
+	RateWindowPacing         workflowconfig.RateWindowPacing
 	MaxAgentsByState         map[string]int
 	PoolName                 string
 	PoolCapacity             int
@@ -321,6 +324,8 @@ func newState(cfg Config) State {
 		PollInterval:             cfg.PollInterval,
 		RefreshFailureThreshold:  cfg.RefreshFailureThreshold,
 		MaxConcurrentAgents:      cfg.MaxConcurrentAgents,
+		BillingMode:              cfg.BillingMode,
+		RateWindowPacing:         cfg.RateWindowPacing,
 		MaxAgentsByState:         cloneStateLimits(cfg.MaxConcurrentAgentsByState),
 		StrandedActiveThreshold:  cfg.StrandedActiveThreshold,
 		DispatchStallThreshold:   cfg.DispatchStallThreshold,
@@ -374,6 +379,8 @@ func (s State) clone() State {
 		PollInterval:             s.PollInterval,
 		RefreshFailureThreshold:  s.RefreshFailureThreshold,
 		MaxConcurrentAgents:      s.MaxConcurrentAgents,
+		BillingMode:              s.BillingMode,
+		RateWindowPacing:         s.RateWindowPacing,
 		MaxAgentsByState:         cloneStateLimits(s.MaxAgentsByState),
 		PoolName:                 s.PoolName,
 		PoolCapacity:             s.PoolCapacity,

--- a/internal/project/manager.go
+++ b/internal/project/manager.go
@@ -120,6 +120,7 @@ func ManagerConfigFromGlobal(cfg globalconfig.Config) ManagerConfig {
 	projects := append([]globalconfig.Project(nil), cfg.Projects...)
 	for index := range projects {
 		projects[index].GlobalKnowledge = cfg.Global.Knowledge
+		projects[index].GlobalRateWindowPacing = cfg.Global.RateWindowPacing
 		if cfg.Global.ActiveHours != nil {
 			activeHours := cfg.Global.ActiveHours.Normalize()
 			projects[index].GlobalActiveHours = &activeHours
@@ -334,7 +335,7 @@ func (m *Manager) Reconcile(ctx context.Context, cfg ManagerConfig) (ReconcileRe
 	result := ReconcileResult{}
 	seen := make(map[ID]struct{}, len(m.cfg.Projects))
 	pending := map[ID]struct{}{}
-	activeHoursChanges := map[ID]*Project{}
+	liveConfigChanges := map[ID]*Project{}
 	for _, current := range m.registry.List() {
 		id := current.ID()
 		seen[id] = struct{}{}
@@ -347,9 +348,9 @@ func (m *Manager) Reconcile(ctx context.Context, cfg ManagerConfig) (ReconcileRe
 			result.Unchanged = append(result.Unchanged, id)
 			continue
 		}
-		if !runtimeCredentialChanged && sameProjectConfigExceptActiveHours(current.Config(), next) {
+		if !runtimeCredentialChanged && sameProjectConfigExceptLiveFields(current.Config(), next) {
 			result.Changed = append(result.Changed, id)
-			activeHoursChanges[id] = current
+			liveConfigChanges[id] = current
 			continue
 		}
 		result.Changed = append(result.Changed, id)
@@ -383,7 +384,7 @@ func (m *Manager) Reconcile(ctx context.Context, cfg ManagerConfig) (ReconcileRe
 	prepared := make(map[ID]*Project, len(result.Added)+len(result.Changed))
 	handled := map[ID]struct{}{}
 	for _, id := range result.Changed {
-		if _, ok := activeHoursChanges[id]; ok {
+		if _, ok := liveConfigChanges[id]; ok {
 			continue
 		}
 		_, preparedProject, err := m.createProjectLocked(desired[id])
@@ -414,13 +415,13 @@ func (m *Manager) Reconcile(ctx context.Context, cfg ManagerConfig) (ReconcileRe
 	stopped := make([]rollbackProject, 0, len(result.Removed)+len(result.Changed))
 	started := make([]startedProject, 0, len(prepared))
 	added := map[ID]struct{}{}
-	updatedActiveHours := make([]rollbackActiveHours, 0, len(activeHoursChanges))
+	updatedLiveConfigs := make([]rollbackActiveHours, 0, len(liveConfigChanges))
 	rollback := func() error {
 		cleanupErr := m.stopUncommittedStartedProjects(ctx, started)
 		cleanupErr = errors.Join(cleanupErr, closePreparedProjects(ctx, prepared))
-		for i := len(updatedActiveHours) - 1; i >= 0; i-- {
-			item := updatedActiveHours[i]
-			cleanupErr = errors.Join(cleanupErr, item.project.updateActiveHours(ctx, item.config))
+		for i := len(updatedLiveConfigs) - 1; i >= 0; i-- {
+			item := updatedLiveConfigs[i]
+			cleanupErr = errors.Join(cleanupErr, item.project.updateLiveConfig(ctx, item.config))
 		}
 		for id := range added {
 			m.registry.Delete(id)
@@ -473,12 +474,12 @@ func (m *Manager) Reconcile(ctx context.Context, cfg ManagerConfig) (ReconcileRe
 		if _, ok := handled[id]; ok {
 			continue
 		}
-		if current, ok := activeHoursChanges[id]; ok {
+		if current, ok := liveConfigChanges[id]; ok {
 			previousConfig := current.Config()
-			if err := current.updateActiveHours(ctx, desired[id]); err != nil {
+			if err := current.updateLiveConfig(ctx, desired[id]); err != nil {
 				return result, errors.Join(err, rollback())
 			}
-			updatedActiveHours = append(updatedActiveHours, rollbackActiveHours{
+			updatedLiveConfigs = append(updatedLiveConfigs, rollbackActiveHours{
 				project: current,
 				config:  previousConfig,
 			})
@@ -1314,12 +1315,13 @@ func sameProjectConfig(left globalconfig.Project, right globalconfig.Project) bo
 	return reflect.DeepEqual(normalizeManagerProjectConfig(left), normalizeManagerProjectConfig(right))
 }
 
-func sameProjectConfigExceptActiveHours(left globalconfig.Project, right globalconfig.Project) bool {
+func sameProjectConfigExceptLiveFields(left globalconfig.Project, right globalconfig.Project) bool {
 	left = normalizeManagerProjectConfig(left)
 	right = normalizeManagerProjectConfig(right)
 	left.ActiveHours = right.ActiveHours
 	left.GlobalActiveHours = right.GlobalActiveHours
 	left.ActiveHoursOverrideUntil = right.ActiveHoursOverrideUntil
+	left.GlobalRateWindowPacing = right.GlobalRateWindowPacing
 	return reflect.DeepEqual(left, right)
 }
 

--- a/internal/project/project.go
+++ b/internal/project/project.go
@@ -420,7 +420,7 @@ func (p *Project) DispatchCandidate() scheduler.ProjectCandidate {
 	return p.orchConfig.Project
 }
 
-func (p *Project) updateActiveHours(ctx context.Context, cfg globalconfig.Project) error {
+func (p *Project) updateLiveConfig(ctx context.Context, cfg globalconfig.Project) error {
 	if ctx == nil {
 		ctx = context.Background()
 	}
@@ -430,6 +430,7 @@ func (p *Project) updateActiveHours(ctx context.Context, cfg globalconfig.Projec
 	p.mu.Lock()
 	workflow := p.workflow
 	workflow.Config.ActiveHours = EffectiveActiveHours(cfg, p.workflowActiveHours)
+	workflow.Config.Agent.RateWindowPacing = effectiveRateWindowPacing(cfg, workflow.Config)
 	runtimeConfig := projectOrchestratorConfig(cfg, workflow.Config)
 	projectOrchestrator := p.orchestrator
 	running := p.done != nil
@@ -438,7 +439,7 @@ func (p *Project) updateActiveHours(ctx context.Context, cfg globalconfig.Projec
 
 	if projectOrchestrator != nil && running {
 		if err := projectOrchestrator.UpdateConfig(ctx, runtimeConfig); err != nil {
-			return fmt.Errorf("update project active hours: %w", err)
+			return fmt.Errorf("update project live config: %w", err)
 		}
 	}
 	if projectAdmission != nil {
@@ -1497,6 +1498,7 @@ func workflowConfigWithProjectIdentity(
 	project globalconfig.Project,
 	workflow workflowconfig.Config,
 ) workflowconfig.Config {
+	workflow.Agent.RateWindowPacing = effectiveRateWindowPacing(project, workflow)
 	if project.IntakeConfigured {
 		workflow.Intake = project.Intake
 		workflow.Intake.Normalize()
@@ -1519,6 +1521,13 @@ func workflowConfigWithProjectIdentity(
 	identity.Normalize()
 	workflow.Identity = identity
 	return workflow
+}
+
+func effectiveRateWindowPacing(project globalconfig.Project, workflow workflowconfig.Config) workflowconfig.RateWindowPacing {
+	if workflow.RateWindowPacingConfigured() {
+		return workflow.Agent.RateWindowPacing.Normalized()
+	}
+	return project.GlobalRateWindowPacing.Normalized()
 }
 
 func intakeRoot(project globalconfig.Project, workflow workflowconfig.Config) string {

--- a/internal/project/rate_window_pacing_reload_test.go
+++ b/internal/project/rate_window_pacing_reload_test.go
@@ -1,0 +1,66 @@
+package project_test
+
+import (
+	"context"
+	"reflect"
+	"testing"
+
+	workflowconfig "github.com/digitaldrywood/detent/internal/config"
+	globalconfig "github.com/digitaldrywood/detent/internal/config/global"
+	"github.com/digitaldrywood/detent/internal/project"
+)
+
+func TestManagerReconcileHotAppliesGlobalRateWindowPacing(t *testing.T) {
+	t.Parallel()
+
+	initialPacing := workflowconfig.DefaultRateWindowPacing()
+	initial := globalconfig.Project{ID: "alpha", Weight: 1, GlobalRateWindowPacing: initialPacing}
+	created := 0
+	manager, err := project.NewManager(project.ManagerConfig{Projects: []globalconfig.Project{initial}}, project.ManagerDependencies{
+		ProjectFactory: func(cfg globalconfig.Project) (*project.Project, error) {
+			created++
+			workflow := workflowConfig("memory")
+			return project.New(project.Config{Project: cfg, Workflow: workflowconfig.Workflow{Config: workflow}}, project.Dependencies{Runner: blockingRunner{}})
+		},
+	})
+	if err != nil {
+		t.Fatalf("NewManager() error = %v", err)
+	}
+	if err := manager.Start(context.Background()); err != nil {
+		t.Fatalf("Start() error = %v", err)
+	}
+	t.Cleanup(func() {
+		for _, item := range manager.Registry().List() {
+			if err := item.Close(); err != nil {
+				t.Errorf("Close(%s) error = %v", item.ID(), err)
+			}
+		}
+	})
+
+	before, ok := manager.Registry().Get("alpha")
+	if !ok {
+		t.Fatal("project alpha missing before reconcile")
+	}
+	off := workflowconfig.RateWindowPacing{Mode: workflowconfig.RateWindowPacingOff}.Normalized()
+	result, err := manager.Reconcile(context.Background(), project.ManagerConfig{Projects: []globalconfig.Project{{ID: "alpha", Weight: 1, GlobalRateWindowPacing: off}}})
+	if err != nil {
+		t.Fatalf("Reconcile() error = %v", err)
+	}
+	if want := (project.ReconcileResult{Changed: []project.ID{"alpha"}}); !reflect.DeepEqual(result, want) {
+		t.Fatalf("Reconcile() = %#v, want %#v", result, want)
+	}
+	after, ok := manager.Registry().Get("alpha")
+	if !ok {
+		t.Fatal("project alpha missing after reconcile")
+	}
+	if before != after || created != 1 {
+		t.Fatalf("project restarted: before=%p after=%p created=%d", before, after, created)
+	}
+	state, err := after.Orchestrator().State(context.Background())
+	if err != nil {
+		t.Fatalf("State() error = %v", err)
+	}
+	if got := state.RateWindowPacing.Mode; got != workflowconfig.RateWindowPacingOff {
+		t.Fatalf("State().RateWindowPacing.Mode = %q, want off", got)
+	}
+}

--- a/internal/project/rate_window_pacing_test.go
+++ b/internal/project/rate_window_pacing_test.go
@@ -1,0 +1,37 @@
+package project
+
+import (
+	"testing"
+
+	workflowconfig "github.com/digitaldrywood/detent/internal/config"
+	globalconfig "github.com/digitaldrywood/detent/internal/config/global"
+)
+
+func TestEffectiveRateWindowPacingProjectOverride(t *testing.T) {
+	t.Parallel()
+
+	global := workflowconfig.RateWindowPacing{Mode: workflowconfig.RateWindowPacingOff}.Normalized()
+	tests := []struct {
+		name string
+		yaml string
+		want string
+	}{
+		{name: "global applies when project omits setting", yaml: "", want: workflowconfig.RateWindowPacingOff},
+		{name: "project override wins", yaml: "agent:\n  rate_window_pacing:\n    mode: proportional\n", want: workflowconfig.RateWindowPacingProportional},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			workflow, err := workflowconfig.ParseWorkflow([]byte("---\ntracker:\n  kind: memory\n" + tt.yaml + "---\n"))
+			if err != nil {
+				t.Fatalf("ParseWorkflow() error = %v", err)
+			}
+			project := globalconfig.Project{GlobalRateWindowPacing: global}
+			if got := effectiveRateWindowPacing(project, workflow.Config).Mode; got != tt.want {
+				t.Fatalf("effective mode = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/telemetry/snapshot.go
+++ b/internal/telemetry/snapshot.go
@@ -347,20 +347,39 @@ type ProjectSnapshot struct {
 }
 
 type DispatchStatus struct {
-	ProjectID                string     `json:"project_id,omitempty"`
-	CandidateCount           int        `json:"candidate_count"`
-	EligibleCandidateCount   int        `json:"eligible_candidate_count"`
-	SelectedCount            int        `json:"selected_count"`
-	SkippedCount             int        `json:"skipped_count"`
-	WaitReason               string     `json:"wait_reason,omitempty"`
-	AllSkippedSince          *time.Time `json:"all_skipped_since,omitempty"`
-	LastSelectedAt           *time.Time `json:"last_selected_at,omitempty"`
-	SecondsSinceLastSelected *int64     `json:"seconds_since_last_selected,omitempty"`
-	StallDurationSeconds     int64      `json:"stall_duration_seconds,omitempty"`
-	StallThresholdSeconds    int64      `json:"stall_threshold_seconds,omitempty"`
-	ObservedAt               time.Time  `json:"observed_at,omitzero"`
-	Stalled                  bool       `json:"stalled"`
-	NeedsHumanAttention      bool       `json:"needs_human_attention"`
+	ProjectID                string           `json:"project_id,omitempty"`
+	CandidateCount           int              `json:"candidate_count"`
+	EligibleCandidateCount   int              `json:"eligible_candidate_count"`
+	SelectedCount            int              `json:"selected_count"`
+	SkippedCount             int              `json:"skipped_count"`
+	WaitReason               string           `json:"wait_reason,omitempty"`
+	AllSkippedSince          *time.Time       `json:"all_skipped_since,omitempty"`
+	LastSelectedAt           *time.Time       `json:"last_selected_at,omitempty"`
+	SecondsSinceLastSelected *int64           `json:"seconds_since_last_selected,omitempty"`
+	StallDurationSeconds     int64            `json:"stall_duration_seconds,omitempty"`
+	StallThresholdSeconds    int64            `json:"stall_threshold_seconds,omitempty"`
+	ObservedAt               time.Time        `json:"observed_at,omitzero"`
+	Stalled                  bool             `json:"stalled"`
+	NeedsHumanAttention      bool             `json:"needs_human_attention"`
+	RateWindowPacing         RateWindowPacing `json:"rate_window_pacing"`
+}
+
+const (
+	RateWindowBucketFresh   = "fresh"
+	RateWindowBucketMissing = "missing"
+	RateWindowBucketStale   = "stale"
+)
+
+type RateWindowPacing struct {
+	Mode                     string     `json:"mode"`
+	FloorPercent             float64    `json:"floor_percent"`
+	StaleAfterSeconds        int64      `json:"stale_after_seconds"`
+	Applicable               bool       `json:"applicable"`
+	BucketStatus             string     `json:"bucket_status"`
+	ObservedRemainingPercent *float64   `json:"observed_remaining_percent,omitempty"`
+	ObservedAt               *time.Time `json:"observed_at,omitempty"`
+	PermitCeiling            int        `json:"permit_ceiling"`
+	ScalingApplied           bool       `json:"scaling_applied"`
 }
 
 type Release struct {

--- a/internal/web/server_test.go
+++ b/internal/web/server_test.go
@@ -6923,6 +6923,7 @@ func TestHealthReportsDispatchStallAsNeedsHumanAttention(t *testing.T) {
 	lastSelectedAt := now.Add(-4 * time.Hour)
 	stall := telemetry.DispatchStatus{
 		ProjectID: "detent", CandidateCount: 8, SkippedCount: 8, WaitReason: "github_rest_capacity", LastSelectedAt: &lastSelectedAt, StallDurationSeconds: 10_800, Stalled: true, NeedsHumanAttention: true,
+		RateWindowPacing: telemetry.RateWindowPacing{Mode: "floor", FloorPercent: 25, StaleAfterSeconds: 900, Applicable: true, BucketStatus: telemetry.RateWindowBucketFresh, PermitCeiling: 2, ScalingApplied: true},
 	}
 	if err := deps.Hub.Publish(telemetry.Snapshot{GeneratedAt: now, Dispatch: stall, DispatchStalls: []telemetry.DispatchStatus{stall}}); err != nil {
 		t.Fatalf("Publish() error = %v", err)
@@ -6944,10 +6945,16 @@ func TestHealthReportsDispatchStallAsNeedsHumanAttention(t *testing.T) {
 	if len(stalls) != 1 || nestedString(t, stalls[0].(map[string]any), "candidate_count") != "8" {
 		t.Fatalf("health dispatch_stalls = %#v", stalls)
 	}
+	if got := nestedString(t, health, "dispatch", "rate_window_pacing", "mode"); got != "floor" {
+		t.Fatalf("health dispatch pacing mode = %q, want floor", got)
+	}
 
 	state := requestJSON(t, server, http.MethodGet, "/api/v1/state", http.StatusOK)
 	if nestedString(t, state, "dispatch", "last_selected_at") != lastSelectedAt.Format(time.RFC3339) {
 		t.Fatalf("state dispatch = %#v, want last_selected_at %s", state["dispatch"], lastSelectedAt)
+	}
+	if got := nestedString(t, state, "dispatch", "rate_window_pacing", "permit_ceiling"); got != "2" {
+		t.Fatalf("state dispatch pacing ceiling = %q, want 2", got)
 	}
 }
 


### PR DESCRIPTION
## Summary

- add global and per-project provider rate-window pacing with proportional, off, and floor modes
- fail open on missing or stale provider observations and hot-reload pacing without restarting project runtimes
- expose the active pacing regime in health and board-state telemetry, with generated docs and regression coverage

Fixes #1883

## UI Surface Contract

- [x] N/A, or the linked issue explicitly authorizes any high-impact UI surface, layout, density, first-viewport, or responsive visibility tradeoff.
- [x] Persistent top-of-screen messaging is explicitly authorized by the issue, or this PR does not add it.
- [x] Visual changes to primary operator screens include screenshot or browser verification below.

No visual UI changes; observability is exposed through existing health and board-state JSON surfaces.

## Test Plan

- [x] `make check`
- [x] `go test ./internal/config ./internal/config/global ./internal/project ./internal/orchestrator ./internal/cli ./internal/codex ./internal/claudecode ./internal/web`
