### PR TITLE
fix(runner): reap orphaned agent processes

### DIFF
--- a/db/queries/store.sql
+++ b/db/queries/store.sql
@@ -135,7 +135,8 @@ SET worker_pid = sqlc.arg(worker_pid),
     worker_pgid = sqlc.arg(worker_pgid),
     worker_started_at = sqlc.arg(worker_started_at),
     worker_reaped_at = NULL,
-    worker_reap_outcome = NULL
+    worker_reap_outcome = NULL,
+    worker_reap_reason = NULL
 WHERE id = sqlc.arg(id);
 
 -- name: ListActiveWorkerProcesses :many
@@ -146,17 +147,19 @@ SELECT
   CAST(COALESCE(issue_url, '') AS TEXT) AS issue_url,
   CAST(worker_pid AS INTEGER) AS worker_pid,
   CAST(COALESCE(worker_pgid, 0) AS INTEGER) AS worker_pgid,
-  CAST(worker_started_at AS TEXT) AS worker_started_at
+  CAST(worker_started_at AS TEXT) AS worker_started_at,
+  CAST(COALESCE(final_state, '') AS TEXT) AS final_state,
+  CAST(COALESCE(completed_at, '') AS TEXT) AS completed_at
 FROM codex_sessions
-WHERE completed_at IS NULL
-  AND worker_reaped_at IS NULL
-  AND COALESCE(worker_pid, 0) > 0
+WHERE worker_reaped_at IS NULL
+  AND worker_pid > 0
 ORDER BY started_at, id;
 
 -- name: MarkCodexSessionWorkerProcessReaped :execrows
 UPDATE codex_sessions
 SET worker_reaped_at = sqlc.arg(worker_reaped_at),
-    worker_reap_outcome = sqlc.arg(worker_reap_outcome)
+    worker_reap_outcome = sqlc.arg(worker_reap_outcome),
+    worker_reap_reason = sqlc.arg(worker_reap_reason)
 WHERE id = sqlc.arg(id);
 
 -- name: UpdateCodexSessionResumeState :execrows

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -142,6 +142,7 @@ Structured command objects:
 | `detent state [--project detent]` | A bounded projection of the public state response, plus `truncation`; internal `board_issues` are excluded. |
 | `detent skill install --target codex --dry-run` | The complete skill install result, including bundle/build stamps, target intent and status, every planned filesystem action, and any rollback actions. |
 | `detent doctor` | `{"checks":[{"name":"Config resolution","status":"OK","detail":"...","hint":"..."}],"summary":{"ok":8,"warn":0,"fail":0},"result":"PASS"}` |
+| `detent fix worker-processes --dry-run` / `--yes` | The orphaned process groups reported by the live service, including session identity, PID, PGID, RSS, and the reap outcome when applied. |
 
 ### Project refresh proposals
 

--- a/docs/dashboard-api.md
+++ b/docs/dashboard-api.md
@@ -213,7 +213,11 @@ so counts remain attributable to their producer timestamp even if snapshot
 publication stops. Refresh objects include `next_refresh_overdue`; an explicit
 `ready` status becomes `degraded` once `next_refresh_at` is in the past.
 `/health` also reports `snapshot_generated_at`, `snapshot_age_seconds`, the
-current refresh object, and per-project `tick_liveness`. A tick loop that misses
+current refresh object, per-project `tick_liveness`, and
+`orphaned_agent_processes` with process and session counts, total RSS, age, and
+recorded session identity. Orphaned agent processes make health report
+`needs_attention`; `detent doctor` lists them and recommends
+`detent fix worker-processes --yes` for a confirmed reap. A tick loop that misses
 two effective polling intervals reports `needs_attention`, its last tick,
 overdue next refresh, missed interval count, and `frozen_at` timestamp. A loop
 that continues ticking while tracker refreshes fail reports separate

--- a/internal/claudecode/process.go
+++ b/internal/claudecode/process.go
@@ -57,7 +57,7 @@ func (b *AgentBackend) RunTurn(
 	cmd.Stdout = stdoutWriter
 	cmd.Stderr = stderrWriter
 
-	procgroup.Configure(cmd)
+	procgroup.Configure(ctx, cmd)
 	if err := cmd.Start(); err != nil {
 		return runner.AgentTurnResult{}, errors.Join(
 			fmt.Errorf("start claude command: %w", err),

--- a/internal/cli/boot.go
+++ b/internal/cli/boot.go
@@ -462,6 +462,7 @@ func startRunningWithDependencies(ctx context.Context, cfg BootConfig, deps star
 		Chat:                chatProvider,
 		IssueExplainer:      newIssueExplainer(snapshotHub, runtimeStore),
 		HealthNotifications: healthNotifications,
+		WorkerProcesses:     runtimeStore,
 	})
 	if err != nil {
 		return err

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -73,6 +73,7 @@ type doctorCheck struct {
 	OpenTerminalIssues         []doctorStatusDriftIssueDiagnostic         `json:"open_terminal_issues,omitempty"`
 	AuthorizationAttention     []doctorAuthorizationAttentionDiagnostic   `json:"authorization_attention,omitempty"`
 	OwnershipAttention         []doctorOwnershipAttentionDiagnostic       `json:"ownership_attention,omitempty"`
+	OrphanedAgentProcesses     *telemetry.OrphanedAgentProcesses          `json:"orphaned_agent_processes,omitempty"`
 	ParkReviews                []doctorParkReviewDiagnostic               `json:"park_reviews,omitempty"`
 	ProjectDefinition          *doctorProjectDefinitionDiagnostic         `json:"project_definition,omitempty"`
 	Capabilities               *doctorCapabilityReport                    `json:"capabilities,omitempty"`

--- a/internal/cli/doctor_environment.go
+++ b/internal/cli/doctor_environment.go
@@ -816,19 +816,20 @@ type doctorHealthProbe struct {
 }
 
 type doctorHealthResponse struct {
-	Status                     string                       `json:"status"`
-	Version                    string                       `json:"version"`
-	Commit                     string                       `json:"commit"`
-	Mode                       string                       `json:"mode"`
-	Checks                     map[string]string            `json:"checks"`
-	Environment                doctorHealthEnvironment      `json:"environment"`
-	Budgets                    []doctorHealthBudget         `json:"budgets"`
-	Workflows                  []doctorHealthWorkflow       `json:"workflows"`
-	StalenessWarnings          []telemetry.StalenessWarning `json:"staleness_warnings"`
-	StrandedIssues             []telemetry.StrandedIssue    `json:"stranded_active_issues"`
-	Dispatch                   telemetry.DispatchStatus     `json:"dispatch"`
-	DispatchStalls             []telemetry.DispatchStatus   `json:"dispatch_stalls"`
-	HealthNotificationFailures []healthnotify.Failure       `json:"health_notification_failures"`
+	Status                     string                           `json:"status"`
+	Version                    string                           `json:"version"`
+	Commit                     string                           `json:"commit"`
+	Mode                       string                           `json:"mode"`
+	Checks                     map[string]string                `json:"checks"`
+	Environment                doctorHealthEnvironment          `json:"environment"`
+	Budgets                    []doctorHealthBudget             `json:"budgets"`
+	Workflows                  []doctorHealthWorkflow           `json:"workflows"`
+	StalenessWarnings          []telemetry.StalenessWarning     `json:"staleness_warnings"`
+	StrandedIssues             []telemetry.StrandedIssue        `json:"stranded_active_issues"`
+	Dispatch                   telemetry.DispatchStatus         `json:"dispatch"`
+	DispatchStalls             []telemetry.DispatchStatus       `json:"dispatch_stalls"`
+	HealthNotificationFailures []healthnotify.Failure           `json:"health_notification_failures"`
+	OrphanedAgentProcesses     telemetry.OrphanedAgentProcesses `json:"orphaned_agent_processes"`
 }
 
 func checkDoctorDetentService(ctx context.Context, cfg BootConfig, installedBuild buildinfo.Info, deps doctorDeps) []doctorCheck {
@@ -847,6 +848,9 @@ func checkDoctorDetentService(ctx context.Context, cfg BootConfig, installedBuil
 			check.Hint = "Review the running Detent service health, then rerun detent doctor."
 		}
 		checks := []doctorCheck{check}
+		if probe.Health.OrphanedAgentProcesses.Count > 0 {
+			checks = append(checks, checkDoctorOrphanedAgentProcesses(probe.Health.OrphanedAgentProcesses))
+		}
 		if driftCheck, ok := checkDoctorBuildDrift(buildinfo.Info{Version: version, Commit: commit}, installedBuild); ok {
 			checks = append(checks, driftCheck)
 		}
@@ -855,12 +859,61 @@ func checkDoctorDetentService(ctx context.Context, cfg BootConfig, installedBuil
 	if err != nil {
 		return nil
 	}
-	return []doctorCheck{{
+	checks := []doctorCheck{{
 		Name:   "Remote Detent service",
 		Status: doctorWarn,
 		Detail: fmt.Sprintf("remote service at %s did not report its complete build", probe.URL),
 		Hint:   "Upgrade the running Detent service, then rerun detent doctor.",
 	}}
+	if probe.Health.OrphanedAgentProcesses.Count > 0 {
+		checks = append(checks, checkDoctorOrphanedAgentProcesses(probe.Health.OrphanedAgentProcesses))
+	}
+	return checks
+}
+
+func checkDoctorOrphanedAgentProcesses(summary telemetry.OrphanedAgentProcesses) doctorCheck {
+	check := doctorCheck{
+		Name:                   "Orphaned agent processes",
+		Status:                 doctorOK,
+		Detail:                 "no agent processes exist without a corresponding live session",
+		OrphanedAgentProcesses: &summary,
+	}
+	if summary.Count == 0 {
+		return check
+	}
+	details := make([]string, 0, len(summary.Processes))
+	for _, process := range summary.Processes {
+		identity := strings.TrimSpace(process.Identifier)
+		if identity == "" {
+			identity = fmt.Sprintf("session %d", process.SessionID)
+		}
+		details = append(details, fmt.Sprintf(
+			"%s pid=%d age=%s rss=%s",
+			identity,
+			process.PID,
+			(time.Duration(process.AgeSeconds)*time.Second).Round(time.Second),
+			formatWorkerProcessBytes(process.RSSBytes),
+		))
+	}
+	check.Status = doctorWarn
+	check.Detail = fmt.Sprintf(
+		"%d orphaned agent process(es) across %d session(s) hold %s RSS: %s",
+		summary.Count,
+		summary.SessionCount,
+		formatWorkerProcessBytes(summary.TotalRSSBytes),
+		strings.Join(details, "; "),
+	)
+	check.Hint = "Run `detent fix worker-processes --yes` to terminate the listed process groups gracefully, then force any survivors."
+	return check
+}
+
+func formatWorkerProcessBytes(value int64) string {
+	const mebibyte = int64(1024 * 1024)
+	const gibibyte = int64(1024 * 1024 * 1024)
+	if value >= gibibyte {
+		return fmt.Sprintf("%.1f GiB", float64(value)/float64(gibibyte))
+	}
+	return fmt.Sprintf("%.1f MiB", float64(value)/float64(mebibyte))
 }
 
 func checkDoctorBuildDrift(runningBuild buildinfo.Info, installedBuild buildinfo.Info) (doctorCheck, bool) {

--- a/internal/cli/doctor_worker_processes_test.go
+++ b/internal/cli/doctor_worker_processes_test.go
@@ -1,0 +1,108 @@
+package cli
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/digitaldrywood/detent/internal/procgroup"
+	"github.com/digitaldrywood/detent/internal/store"
+	"github.com/digitaldrywood/detent/internal/telemetry"
+)
+
+func TestCheckDoctorOrphanedAgentProcesses(t *testing.T) {
+	t.Parallel()
+
+	startedAt := time.Date(2026, 8, 18, 12, 0, 0, 0, time.UTC)
+	tests := []struct {
+		name       string
+		summary    telemetry.OrphanedAgentProcesses
+		wantStatus doctorStatus
+		wantDetail []string
+	}{
+		{
+			name:       "healthy",
+			wantStatus: doctorOK,
+			wantDetail: []string{"no agent processes"},
+		},
+		{
+			name: "orphan reports age and memory",
+			summary: telemetry.OrphanedAgentProcesses{
+				Count:         2,
+				SessionCount:  1,
+				TotalRSSBytes: 512 * 1024 * 1024,
+				Processes: []telemetry.OrphanedAgentProcess{{
+					SessionID:  1885,
+					Identifier: "digitaldrywood/detent#1885",
+					PID:        4242,
+					StartedAt:  startedAt,
+					AgeSeconds: 2 * 60 * 60,
+					RSSBytes:   512 * 1024 * 1024,
+				}},
+			},
+			wantStatus: doctorWarn,
+			wantDetail: []string{"2 orphaned", "digitaldrywood/detent#1885", "pid=4242", "age=2h0m0s", "rss=512.0 MiB"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			check := checkDoctorOrphanedAgentProcesses(tt.summary)
+			if check.Status != tt.wantStatus {
+				t.Fatalf("status = %q, want %q", check.Status, tt.wantStatus)
+			}
+			for _, want := range tt.wantDetail {
+				if !strings.Contains(check.Detail, want) {
+					t.Fatalf("detail = %q, want %q", check.Detail, want)
+				}
+			}
+			if tt.summary.Count > 0 && !strings.Contains(check.Hint, "fix worker-processes --yes") {
+				t.Fatalf("hint = %q, want reap command", check.Hint)
+			}
+		})
+	}
+}
+
+func TestApplyWorkerProcessesFixRecordsReapCause(t *testing.T) {
+	t.Parallel()
+
+	startedAt := time.Date(2026, 8, 18, 12, 0, 0, 0, time.UTC)
+	reapedAt := startedAt.Add(time.Hour)
+	processStore := &workerProcessesFixTestStore{}
+	result := workerProcessesFixResult{Processes: []workerProcessFixOutcome{{SessionID: 1885, PID: 4242, GroupID: 4242, StartedAt: startedAt}}}
+	var gotIdentity procgroup.Identity
+	err := applyWorkerProcessesFix(
+		context.Background(),
+		processStore,
+		&result,
+		func(_ context.Context, identity procgroup.Identity, _ time.Duration) (procgroup.TerminationOutcome, error) {
+			gotIdentity = identity
+			return procgroup.TerminationOutcomeKilled, nil
+		},
+		func() time.Time { return reapedAt },
+	)
+	if err != nil {
+		t.Fatalf("applyWorkerProcessesFix() error = %v", err)
+	}
+	if gotIdentity != (procgroup.Identity{PID: 4242, GroupID: 4242, StartedAt: startedAt}) {
+		t.Fatalf("reaped identity = %#v", gotIdentity)
+	}
+	if len(processStore.reaps) != 1 || processStore.reaps[0].Reason != "doctor_reap" || processStore.reaps[0].Outcome != store.WorkerProcessOutcomeKilled || !processStore.reaps[0].ReapedAt.Equal(reapedAt) {
+		t.Fatalf("reap records = %#v", processStore.reaps)
+	}
+}
+
+type workerProcessesFixTestStore struct {
+	reaps []store.WorkerProcessReap
+}
+
+func (s *workerProcessesFixTestStore) MarkSessionWorkerProcessReaped(_ context.Context, _ int64, reap store.WorkerProcessReap) error {
+	s.reaps = append(s.reaps, reap)
+	return nil
+}
+
+func (*workerProcessesFixTestStore) Close() error {
+	return nil
+}

--- a/internal/cli/fix.go
+++ b/internal/cli/fix.go
@@ -38,6 +38,7 @@ func newFixCommand(configPath *string, opts options) *cobra.Command {
 	cmd.AddCommand(
 		newWorkflowLayoutFixCommand(configPath, opts),
 		newAgentPoolsFixCommand(configPath, opts),
+		newWorkerProcessesFixCommand(configPath, opts),
 	)
 	return cmd
 }

--- a/internal/cli/fix_worker_processes.go
+++ b/internal/cli/fix_worker_processes.go
@@ -1,0 +1,202 @@
+package cli
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"strings"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	globalconfig "github.com/digitaldrywood/detent/internal/config/global"
+	"github.com/digitaldrywood/detent/internal/procgroup"
+	"github.com/digitaldrywood/detent/internal/store"
+	"github.com/digitaldrywood/detent/internal/telemetry"
+)
+
+type workerProcessesFixResult struct {
+	Processes []workerProcessFixOutcome `json:"processes"`
+	DryRun    bool                      `json:"dry_run"`
+	Applied   bool                      `json:"applied"`
+	Cancelled bool                      `json:"cancelled"`
+	Noop      bool                      `json:"noop"`
+}
+
+type workerProcessFixOutcome struct {
+	SessionID  int64     `json:"session_id"`
+	Identifier string    `json:"identifier,omitempty"`
+	PID        int       `json:"pid"`
+	GroupID    int       `json:"pgid,omitempty"`
+	StartedAt  time.Time `json:"started_at"`
+	RSSBytes   int64     `json:"rss_bytes"`
+	Outcome    string    `json:"outcome,omitempty"`
+}
+
+type workerProcessFixStore interface {
+	MarkSessionWorkerProcessReaped(context.Context, int64, store.WorkerProcessReap) error
+	Close() error
+}
+
+func newWorkerProcessesFixCommand(configPath *string, opts options) *cobra.Command {
+	var dryRun bool
+	var confirmed bool
+	cmd := &cobra.Command{
+		Use:     "worker-processes",
+		Short:   "Reap agent processes without live Detent sessions",
+		Example: "detent fix worker-processes --dry-run\n  detent fix worker-processes --yes",
+		Args:    NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			if dryRun && confirmed {
+				return WrapValidation(errors.New("--dry-run and --yes cannot be used together"))
+			}
+			resolution, err := resolveConfigPathResolution(derefString(configPath), opts)
+			if err != nil {
+				return err
+			}
+			read := opts.read
+			if read == nil {
+				read = func(path string) (globalconfig.Config, error) {
+					return globalconfig.Read(path)
+				}
+			}
+			global, err := read(resolution.Path)
+			if err != nil {
+				return err
+			}
+			global.Path = resolution.Path
+			probe, err := probeDoctorHealth(cmd.Context(), doctorLiveBoot(BootConfig{}, &global), doctorDeps{httpDo: opts.httpDo}.withDefaults())
+			if err != nil && probe.Health.Mode == "" {
+				return fmt.Errorf("inspect live Detent worker processes at %s: %w", probe.URL, err)
+			}
+			result := newWorkerProcessesFixResult(probe.Health.OrphanedAgentProcesses)
+			result.DryRun = dryRun
+			result.Noop = len(result.Processes) == 0
+			out, err := OutputForCommand(cmd)
+			if err != nil {
+				return err
+			}
+			if dryRun || result.Noop {
+				return out.Write(func(writer io.Writer) error {
+					return writeWorkerProcessesFixResult(writer, result)
+				}, result)
+			}
+			if !confirmed {
+				if !out.IsJSON() {
+					if err := writeWorkerProcessesFixResult(cmd.OutOrStdout(), result); err != nil {
+						return err
+					}
+				}
+				ok, err := confirmFix(cmd, "Reap these orphaned agent process groups?", "worker process reap")
+				if err != nil {
+					return err
+				}
+				if !ok {
+					result.Cancelled = true
+					if out.IsJSON() {
+						return out.Write(nil, result)
+					}
+					_, err := fmt.Fprintln(cmd.OutOrStdout(), "Worker process reap cancelled; no processes were signaled.")
+					return err
+				}
+			}
+			processStore, err := store.Open(cmd.Context(), store.Config{Backend: store.BackendSQLite, Path: runtimeStorePath(BootConfig{Global: global})})
+			if err != nil {
+				return err
+			}
+			applyErr := applyWorkerProcessesFix(cmd.Context(), processStore, &result, procgroup.Terminate, time.Now)
+			closeErr := processStore.Close()
+			if err := errors.Join(applyErr, closeErr); err != nil {
+				return err
+			}
+			result.Applied = true
+			return out.Write(func(writer io.Writer) error {
+				return writeWorkerProcessesFixResult(writer, result)
+			}, result)
+		},
+	}
+	cmd.Flags().BoolVar(&dryRun, "dry-run", false, "show orphaned agent processes without signaling them")
+	cmd.Flags().BoolVar(&confirmed, "yes", false, "reap orphaned agent processes without an interactive confirmation")
+	return cmd
+}
+
+func newWorkerProcessesFixResult(summary telemetry.OrphanedAgentProcesses) workerProcessesFixResult {
+	result := workerProcessesFixResult{Processes: make([]workerProcessFixOutcome, 0, len(summary.Processes))}
+	for _, process := range summary.Processes {
+		result.Processes = append(result.Processes, workerProcessFixOutcome{
+			SessionID:  process.SessionID,
+			Identifier: process.Identifier,
+			PID:        process.PID,
+			GroupID:    process.GroupID,
+			StartedAt:  process.StartedAt,
+			RSSBytes:   process.RSSBytes,
+		})
+	}
+	return result
+}
+
+func applyWorkerProcessesFix(
+	ctx context.Context,
+	processStore workerProcessFixStore,
+	result *workerProcessesFixResult,
+	reap workerProcessReapFunc,
+	now func() time.Time,
+) error {
+	if result == nil || len(result.Processes) == 0 {
+		return nil
+	}
+	if reap == nil {
+		reap = procgroup.Terminate
+	}
+	if now == nil {
+		now = time.Now
+	}
+	for index := range result.Processes {
+		process := &result.Processes[index]
+		outcome, err := reap(ctx, procgroup.Identity{PID: process.PID, GroupID: process.GroupID, StartedAt: process.StartedAt}, procgroup.DefaultTerminationGrace)
+		if err != nil {
+			return fmt.Errorf("reap worker process %d: %w", process.PID, err)
+		}
+		process.Outcome = string(outcome)
+		if err := processStore.MarkSessionWorkerProcessReaped(ctx, process.SessionID, store.WorkerProcessReap{
+			ReapedAt: now().UTC(),
+			Outcome:  process.Outcome,
+			Reason:   "doctor_reap",
+		}); err != nil {
+			return fmt.Errorf("record worker process %d reap: %w", process.PID, err)
+		}
+	}
+	return nil
+}
+
+func writeWorkerProcessesFixResult(out io.Writer, result workerProcessesFixResult) error {
+	if len(result.Processes) == 0 {
+		_, err := fmt.Fprintln(out, "No orphaned agent processes found.")
+		return err
+	}
+	for _, process := range result.Processes {
+		identity := strings.TrimSpace(process.Identifier)
+		if identity == "" {
+			identity = fmt.Sprintf("session %d", process.SessionID)
+		}
+		line := fmt.Sprintf("%s pid=%d pgid=%d rss=%s", identity, process.PID, process.GroupID, formatWorkerProcessBytes(process.RSSBytes))
+		if process.Outcome != "" {
+			line += " outcome=" + process.Outcome
+		}
+		if _, err := fmt.Fprintln(out, line); err != nil {
+			return err
+		}
+	}
+	switch {
+	case result.DryRun:
+		_, err := fmt.Fprintln(out, "Dry run; no processes were signaled.")
+		return err
+	case result.Applied:
+		_, err := fmt.Fprintln(out, "Orphaned agent processes reaped.")
+		return err
+	default:
+		_, err := fmt.Fprintln(out, "Reaping requires confirmation.")
+		return err
+	}
+}

--- a/internal/cli/worker_processes.go
+++ b/internal/cli/worker_processes.go
@@ -74,6 +74,7 @@ func reapWorkerProcesses(
 		if err := processStore.MarkSessionWorkerProcessReaped(ctx, process.SessionID, store.WorkerProcessReap{
 			ReapedAt: now().UTC(),
 			Outcome:  string(outcome),
+			Reason:   strings.TrimSpace(reason),
 		}); err != nil {
 			result = errors.Join(result, err)
 		}

--- a/internal/cli/worker_processes_test.go
+++ b/internal/cli/worker_processes_test.go
@@ -67,6 +67,9 @@ func TestReapWorkerProcessesAtStartup(t *testing.T) {
 		if !reaped.reap.ReapedAt.Equal(reapedAt) {
 			t.Fatalf("reaped at = %s, want %s", reaped.reap.ReapedAt, reapedAt)
 		}
+		if reaped.reap.Reason != "startup" {
+			t.Fatalf("reap reason = %q, want startup", reaped.reap.Reason)
+		}
 	}
 	for _, want := range []string{
 		"reason=startup",

--- a/internal/codex/transport.go
+++ b/internal/codex/transport.go
@@ -116,7 +116,7 @@ func (f *LocalTransportFactory) NewTransport(ctx context.Context) (Transport, er
 	cmd.Stdout = stdoutWriter
 	cmd.Stderr = stderrWriter
 
-	procgroup.Configure(cmd)
+	procgroup.Configure(ctx, cmd)
 	if err := cmd.Start(); err != nil {
 		return nil, errors.Join(
 			fmt.Errorf("start command: %w", err),

--- a/internal/orchestrator/heartbeat_test.go
+++ b/internal/orchestrator/heartbeat_test.go
@@ -322,7 +322,7 @@ func startHeartbeatWorkerProcess(t *testing.T) procgroup.Identity {
 	t.Helper()
 	cmd := exec.CommandContext(context.Background(), os.Args[0], "-test.run=^TestHeartbeatWorkerProcessHelper$")
 	cmd.Env = append(os.Environ(), "DETENT_HEARTBEAT_PROCESS_HELPER=1")
-	procgroup.Configure(cmd)
+	procgroup.Configure(t.Context(), cmd)
 	if err := cmd.Start(); err != nil {
 		t.Fatalf("Start() error = %v", err)
 	}

--- a/internal/orchestrator/lane_revocation.go
+++ b/internal/orchestrator/lane_revocation.go
@@ -115,7 +115,7 @@ func (o *Orchestrator) reapPendingLaneRevocation(ctx context.Context, state *Sta
 	if pending == nil || pending.reapDone {
 		return
 	}
-	outcome, identity, err := o.reapRunningWorker(ctx, pending.running, pending.workerProcess)
+	outcome, identity, err := o.reapRunningWorker(ctx, pending.running, pending.workerProcess, "lane_revoked")
 	if identity.PID > 0 {
 		pending.workerProcess = identity
 	}
@@ -398,6 +398,7 @@ func (o *Orchestrator) reapRunningWorker(
 	ctx context.Context,
 	running Running,
 	identity procgroup.Identity,
+	reason string,
 ) (procgroup.TerminationOutcome, procgroup.Identity, error) {
 	found := identity.PID > 0
 	if !found {
@@ -425,6 +426,7 @@ func (o *Orchestrator) reapRunningWorker(
 		if err := o.workerProcesses.MarkSessionWorkerProcessReaped(context.WithoutCancel(ctx), running.DetentSessionID, store.WorkerProcessReap{
 			ReapedAt: o.clockNow().UTC(),
 			Outcome:  string(outcome),
+			Reason:   strings.TrimSpace(reason),
 		}); err != nil {
 			return outcome, identity, fmt.Errorf("persist reap outcome: %w", err)
 		}

--- a/internal/orchestrator/stop_run.go
+++ b/internal/orchestrator/stop_run.go
@@ -321,7 +321,7 @@ func (o *Orchestrator) completeOperatorStopCompletion(ctx context.Context, state
 }
 
 func (o *Orchestrator) reapOperatorStopWorker(ctx context.Context, running Running, identity procgroup.Identity) (procgroup.TerminationOutcome, procgroup.Identity, error) {
-	outcome, identity, err := o.reapRunningWorker(ctx, running, identity)
+	outcome, identity, err := o.reapRunningWorker(ctx, running, identity, "operator_stopped")
 	if err != nil {
 		return "", identity, fmt.Errorf("%w: %w", ErrStopRunWorkerProcess, err)
 	}

--- a/internal/orchestrator/stop_run_process_unix_test.go
+++ b/internal/orchestrator/stop_run_process_unix_test.go
@@ -102,7 +102,7 @@ func TestStopRunReapsDescendantThatSurvivesParentCancellation(t *testing.T) {
 
 func TestStopRunRefusesStalePersistedProcessIdentity(t *testing.T) {
 	cmd := exec.CommandContext(context.Background(), "sleep", "30")
-	procgroup.Configure(cmd)
+	procgroup.Configure(t.Context(), cmd)
 	if err := cmd.Start(); err != nil {
 		t.Fatalf("Start() error = %v", err)
 	}
@@ -285,7 +285,7 @@ type operatorStopDescendantRunner struct {
 func (r *operatorStopDescendantRunner) Run(ctx context.Context, request orchestrator.RunRequest) (orchestrator.RunResult, error) {
 	script := "sleep 30 >/dev/null 2>&1 & printf '%s\\n' \"$!\" > " + operatorStopShellQuote(r.pidPath) + "; wait"
 	cmd := exec.CommandContext(context.Background(), "sh", "-c", script)
-	procgroup.Configure(cmd)
+	procgroup.Configure(ctx, cmd)
 	if err := cmd.Start(); err != nil {
 		return orchestrator.RunResult{}, err
 	}

--- a/internal/procgroup/identity.go
+++ b/internal/procgroup/identity.go
@@ -22,6 +22,14 @@ type Identity struct {
 
 type TerminationOutcome string
 
+type Observation struct {
+	Identity
+	Alive        bool
+	Stale        bool
+	ProcessCount int
+	RSSBytes     int64
+}
+
 const (
 	TerminationOutcomeTerminated    TerminationOutcome = "terminated"
 	TerminationOutcomeKilled        TerminationOutcome = "killed_after_timeout"
@@ -52,6 +60,13 @@ func Alive(identity Identity) (bool, error) {
 
 func RSS(ctx context.Context, identity Identity) (uint64, error) {
 	return processGroupRSS(ctx, identity)
+}
+
+func Observe(identities []Identity) ([]Observation, error) {
+	if len(identities) == 0 {
+		return []Observation{}, nil
+	}
+	return observeProcesses(identities)
 }
 
 func sameIdentity(current Identity, recorded Identity) bool {

--- a/internal/procgroup/process_group_other.go
+++ b/internal/procgroup/process_group_other.go
@@ -10,7 +10,7 @@ import (
 	"time"
 )
 
-func Configure(cmd *exec.Cmd) {
+func Configure(_ context.Context, cmd *exec.Cmd) {
 	cmd.Cancel = func() error {
 		return TerminateTree(cmd, 0)
 	}
@@ -40,6 +40,22 @@ func inspectProcess(pid int) (Identity, error) {
 		return Identity{}, ErrProcessNotRunning
 	}
 	return Identity{PID: pid, StartedAt: time.Now().UTC()}, nil
+}
+
+func observeProcesses(identities []Identity) ([]Observation, error) {
+	observations := make([]Observation, 0, len(identities))
+	for _, identity := range identities {
+		alive, err := Alive(identity)
+		if err != nil {
+			return nil, err
+		}
+		count := 0
+		if alive {
+			count = 1
+		}
+		observations = append(observations, Observation{Identity: identity, Alive: alive, ProcessCount: count})
+	}
+	return observations, nil
 }
 
 func Terminate(_ context.Context, identity Identity, _ time.Duration) (TerminationOutcome, error) {

--- a/internal/procgroup/process_group_unix.go
+++ b/internal/procgroup/process_group_unix.go
@@ -18,13 +18,22 @@ import (
 
 const workerNiceDelta = 5
 
-func Configure(cmd *exec.Cmd) {
+func Configure(ctx context.Context, cmd *exec.Cmd) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
 	if cmd.SysProcAttr == nil {
 		cmd.SysProcAttr = &syscall.SysProcAttr{}
 	}
 	cmd.SysProcAttr.Setpgid = true
+	terminationCtx := context.WithoutCancel(ctx)
 	cmd.Cancel = func() error {
-		return TerminateTree(cmd, GroupID(cmd))
+		identity, err := Inspect(cmd)
+		if err != nil {
+			return TerminateTree(cmd, GroupID(cmd))
+		}
+		_, err = Terminate(terminationCtx, identity, DefaultTerminationGrace)
+		return err
 	}
 }
 
@@ -267,6 +276,80 @@ func inspectProcess(pid int) (Identity, error) {
 		return Identity{}, fmt.Errorf("inspect process %d start time: %w", pid, err)
 	}
 	return Identity{PID: pid, GroupID: groupID, StartedAt: startedAt.UTC()}, nil
+}
+
+type observedProcess struct {
+	identity Identity
+	rssBytes int64
+	zombie   bool
+}
+
+func observeProcesses(identities []Identity) ([]Observation, error) {
+	path, err := exec.LookPath("ps")
+	if err != nil {
+		return nil, fmt.Errorf("locate ps: %w", err)
+	}
+	cmd := &exec.Cmd{
+		Path: path,
+		Args: []string{"ps", "-axo", "pid=,pgid=,rss=,stat=,lstart="},
+		Env:  append(os.Environ(), "LC_ALL=C"),
+	}
+	output, err := cmd.Output()
+	if err != nil {
+		return nil, fmt.Errorf("inspect worker processes: %w", err)
+	}
+
+	byPID := make(map[int]observedProcess)
+	byGroup := make(map[int][]observedProcess)
+	for line := range strings.Lines(string(output)) {
+		fields := strings.Fields(line)
+		if len(fields) != 9 {
+			continue
+		}
+		pid, pidErr := strconv.Atoi(fields[0])
+		groupID, groupErr := strconv.Atoi(fields[1])
+		rssKB, rssErr := strconv.ParseInt(fields[2], 10, 64)
+		startedAt, startedErr := time.ParseInLocation("Mon Jan 2 15:04:05 2006", strings.Join(fields[4:], " "), time.Local)
+		if pidErr != nil || groupErr != nil || rssErr != nil || startedErr != nil {
+			continue
+		}
+		process := observedProcess{
+			identity: Identity{PID: pid, GroupID: groupID, StartedAt: startedAt.UTC()},
+			rssBytes: max(rssKB, 0) * 1024,
+			zombie:   strings.HasPrefix(fields[3], "Z"),
+		}
+		byPID[pid] = process
+		byGroup[groupID] = append(byGroup[groupID], process)
+	}
+
+	observations := make([]Observation, 0, len(identities))
+	for _, identity := range identities {
+		observation := Observation{Identity: identity}
+		if identity.PID <= 0 || identity.StartedAt.IsZero() {
+			observations = append(observations, observation)
+			continue
+		}
+		leader, leaderFound := byPID[identity.PID]
+		if leaderFound && !sameIdentity(leader.identity, identity) {
+			observation.Stale = true
+			observations = append(observations, observation)
+			continue
+		}
+		groupID := identity.GroupID
+		if groupID <= 0 {
+			groupID = identity.PID
+		}
+		for _, process := range byGroup[groupID] {
+			if process.zombie {
+				continue
+			}
+			observation.ProcessCount++
+			observation.RSSBytes += process.rssBytes
+		}
+		observation.Alive = observation.ProcessCount > 0
+		observations = append(observations, observation)
+	}
+	return observations, nil
 }
 
 func signalProcessTarget(pid int, groupID int, signal syscall.Signal) error {

--- a/internal/procgroup/process_group_unix_test.go
+++ b/internal/procgroup/process_group_unix_test.go
@@ -37,7 +37,7 @@ func TestConfigure(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			Configure(tt.cmd)
+			Configure(t.Context(), tt.cmd)
 
 			if tt.cmd.SysProcAttr == nil {
 				t.Fatal("SysProcAttr is nil, want configured attributes")
@@ -127,7 +127,7 @@ func TestDeprioritize(t *testing.T) {
 
 func TestDeprioritizeExitedProcess(t *testing.T) {
 	cmd := exec.CommandContext(context.Background(), "true")
-	Configure(cmd)
+	Configure(t.Context(), cmd)
 	if err := cmd.Run(); err != nil {
 		t.Fatalf("Run() error = %v", err)
 	}
@@ -161,6 +161,42 @@ func TestAliveRejectsStaleProcessIdentity(t *testing.T) {
 			}
 			if got != tt.want {
 				t.Fatalf("Alive() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestObserveMeasuresMatchingProcessGroupAndRejectsStaleIdentity(t *testing.T) {
+	proc := startSleepGroup(t)
+	identity, err := Inspect(proc.cmd)
+	if err != nil {
+		t.Fatalf("Inspect() error = %v", err)
+	}
+	tests := []struct {
+		name      string
+		identity  Identity
+		wantAlive bool
+		wantStale bool
+	}{
+		{name: "matching process group", identity: identity, wantAlive: true},
+		{name: "stale process identity", identity: Identity{PID: identity.PID, GroupID: identity.GroupID, StartedAt: identity.StartedAt.Add(time.Second)}, wantStale: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			observations, err := Observe([]Identity{tt.identity})
+			if err != nil {
+				t.Fatalf("Observe() error = %v", err)
+			}
+			if len(observations) != 1 {
+				t.Fatalf("Observe() len = %d, want 1", len(observations))
+			}
+			got := observations[0]
+			if got.Alive != tt.wantAlive || got.Stale != tt.wantStale {
+				t.Fatalf("Observe() = %#v, want alive=%t stale=%t", got, tt.wantAlive, tt.wantStale)
+			}
+			if tt.wantAlive && (got.ProcessCount < 2 || got.RSSBytes <= 0) {
+				t.Fatalf("Observe() = %#v, want group count and RSS", got)
 			}
 		})
 	}
@@ -271,7 +307,7 @@ func TestCleanupWaitsForOrphanedGroupMembers(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			cmd := exec.CommandContext(context.Background(), "sh", "-c", tt.command)
-			Configure(cmd)
+			Configure(t.Context(), cmd)
 			if err := cmd.Start(); err != nil {
 				t.Fatalf("Start() error = %v", err)
 			}
@@ -298,7 +334,7 @@ func TestCleanupWaitsForOrphanedGroupMembers(t *testing.T) {
 
 func TestCleanupTreatsZombieOnlyGroupAsExited(t *testing.T) {
 	cmd := exec.CommandContext(context.Background(), "sleep", "30")
-	Configure(cmd)
+	Configure(t.Context(), cmd)
 	if err := cmd.Start(); err != nil {
 		t.Fatalf("Start() error = %v", err)
 	}
@@ -454,7 +490,7 @@ func startSleep(t *testing.T) *startedProcess {
 	t.Helper()
 
 	cmd := exec.CommandContext(context.Background(), "sleep", "30")
-	Configure(cmd)
+	Configure(t.Context(), cmd)
 	if err := cmd.Start(); err != nil {
 		t.Fatalf("Start() error = %v, want nil", err)
 	}
@@ -518,7 +554,7 @@ func startIgnoringTerminationGroup(t *testing.T) *startedProcess {
 	memberReady := readyDir + "/member.ready"
 	cmd := exec.CommandContext(context.Background(), "sh", "-c", "trap '' TERM; : > \"$READY_PATH\"; exec sleep 30")
 	cmd.Env = append(os.Environ(), "READY_PATH="+leaderReady)
-	Configure(cmd)
+	Configure(t.Context(), cmd)
 	if err := cmd.Start(); err != nil {
 		t.Fatalf("Start() error = %v", err)
 	}
@@ -573,7 +609,7 @@ func startExitedCommand(t *testing.T) (*exec.Cmd, int) {
 	t.Helper()
 
 	cmd := exec.CommandContext(context.Background(), "true")
-	Configure(cmd)
+	Configure(t.Context(), cmd)
 	if err := cmd.Start(); err != nil {
 		t.Fatalf("Start() error = %v, want nil", err)
 	}

--- a/internal/procgroup/process_group_windows.go
+++ b/internal/procgroup/process_group_windows.go
@@ -12,7 +12,7 @@ import (
 	"golang.org/x/sys/windows"
 )
 
-func Configure(cmd *exec.Cmd) {
+func Configure(_ context.Context, cmd *exec.Cmd) {
 	cmd.Cancel = func() error {
 		return TerminateTree(cmd, 0)
 	}
@@ -59,6 +59,22 @@ func inspectProcess(pid int) (Identity, error) {
 		return Identity{}, fmt.Errorf("inspect process %d start time: %w", pid, err)
 	}
 	return Identity{PID: pid, StartedAt: startedAt}, nil
+}
+
+func observeProcesses(identities []Identity) ([]Observation, error) {
+	observations := make([]Observation, 0, len(identities))
+	for _, identity := range identities {
+		alive, err := Alive(identity)
+		if err != nil {
+			return nil, err
+		}
+		count := 0
+		if alive {
+			count = 1
+		}
+		observations = append(observations, Observation{Identity: identity, Alive: alive, ProcessCount: count})
+	}
+	return observations, nil
 }
 
 func Terminate(_ context.Context, identity Identity, grace time.Duration) (TerminationOutcome, error) {

--- a/internal/procgroup/process_group_windows_test.go
+++ b/internal/procgroup/process_group_windows_test.go
@@ -13,7 +13,7 @@ import (
 func TestWindowsInspectAndTerminate(t *testing.T) {
 	cmd := exec.CommandContext(context.Background(), os.Args[0], "-test.run=^TestWindowsProcessHelper$")
 	cmd.Env = append(os.Environ(), "DETENT_WINDOWS_PROCESS_HELPER=1")
-	Configure(cmd)
+	Configure(t.Context(), cmd)
 	if err := cmd.Start(); err != nil {
 		t.Fatalf("Start() error = %v", err)
 	}

--- a/internal/runner/agent.go
+++ b/internal/runner/agent.go
@@ -66,6 +66,13 @@ type sessionWorkerProcessStore interface {
 	UpdateSessionWorkerProcess(context.Context, int64, store.WorkerProcessIdentity) error
 }
 
+type sessionWorkerProcessReaper interface {
+	ListActiveWorkerProcesses(context.Context) ([]store.WorkerProcess, error)
+	MarkSessionWorkerProcessReaped(context.Context, int64, store.WorkerProcessReap) error
+}
+
+type workerProcessReapFunc func(context.Context, procgroup.Identity, time.Duration) (procgroup.TerminationOutcome, error)
+
 type sessionResumeStore interface {
 	UpdateSessionResumeState(context.Context, int64, store.SessionResumeState) error
 }
@@ -114,6 +121,8 @@ type Dependencies struct {
 	MaxAgentRSSBytes    uint64
 	RSSPollInterval     time.Duration
 	ProcessRSS          func(context.Context, procgroup.Identity) (uint64, error)
+	WorkerReapGrace     time.Duration
+	ReapWorkerProcess   workerProcessReapFunc
 	sessionLimit        durationLimitContextFactory
 	turnLimit           durationLimitContextFactory
 	progressTicker      sessionProgressTickerFactory
@@ -140,6 +149,8 @@ type Runner struct {
 	maxAgentRSSBytes    uint64
 	rssPollInterval     time.Duration
 	processRSS          func(context.Context, procgroup.Identity) (uint64, error)
+	workerReapGrace     time.Duration
+	reapWorkerProcess   workerProcessReapFunc
 	sessionLimit        durationLimitContextFactory
 	turnLimit           durationLimitContextFactory
 	progressTicker      sessionProgressTickerFactory
@@ -165,6 +176,12 @@ func NewRunner(deps Dependencies) (*Runner, error) {
 	}
 	if deps.ProcessRSS == nil {
 		deps.ProcessRSS = procgroup.RSS
+	}
+	if deps.WorkerReapGrace <= 0 {
+		deps.WorkerReapGrace = procgroup.DefaultTerminationGrace
+	}
+	if deps.ReapWorkerProcess == nil {
+		deps.ReapWorkerProcess = procgroup.Terminate
 	}
 	if deps.sessionLimit == nil {
 		deps.sessionLimit = withAgentDurationLimit
@@ -223,6 +240,8 @@ func NewRunner(deps Dependencies) (*Runner, error) {
 		maxAgentRSSBytes:    deps.MaxAgentRSSBytes,
 		rssPollInterval:     deps.RSSPollInterval,
 		processRSS:          deps.ProcessRSS,
+		workerReapGrace:     deps.WorkerReapGrace,
+		reapWorkerProcess:   deps.ReapWorkerProcess,
 		sessionLimit:        deps.sessionLimit,
 		turnLimit:           deps.turnLimit,
 		progressTicker:      deps.progressTicker,
@@ -1037,8 +1056,21 @@ func (r *Runner) runAgentTurn(
 		}
 		return nil
 	}, r.turnLimit)
+	processReapErr := r.reapSessionWorkerProcess(
+		ctx,
+		detentSessionID,
+		runRequest.Issue,
+		workerProcessReapReason(ctx, turnErr),
+	)
+	if processReapErr != nil {
+		turnErr = errors.Join(turnErr, fmt.Errorf("%w: %w", ErrWorkerProcessReap, processReapErr))
+	}
 	if cause := context.Cause(ctx); cooperativeStopError(cause) || durationLimitError(cause) {
-		turnErr = cause
+		if processReapErr != nil {
+			turnErr = errors.Join(cause, fmt.Errorf("%w: %w", ErrWorkerProcessReap, processReapErr))
+		} else {
+			turnErr = cause
+		}
 	}
 	var memoryErr *SessionMemoryCeilingError
 	if errors.As(turnErr, &memoryErr) {
@@ -1506,7 +1538,7 @@ func (r *Runner) Run(ctx context.Context, req RunRequest) (RunResult, error) {
 	if execution.err != nil {
 		execution.err = classifyAgentCapacityError(backend, selection, backendConfig, execution.result.RuntimeIdentity, execution.err, execution.result.RateLimits, runStartedAt)
 	}
-	if execution.err != nil && !IsCapacityError(execution.err) && !durationLimitError(execution.err) && !agentResumeEmpty(turnRequest.Resume) && !execution.turnStarted {
+	if execution.err != nil && !IsCapacityError(execution.err) && !durationLimitError(execution.err) && !errors.Is(execution.err, ErrWorkerProcessReap) && !agentResumeEmpty(turnRequest.Resume) && !execution.turnStarted {
 		r.logWorkerEvent(req.Issue, "worker_resume_failed_fallback",
 			telemetry.WorkAttemptIDKey, req.WorkAttemptID,
 			telemetry.DetentSessionIDKey, sessionID,
@@ -2242,8 +2274,21 @@ func (r *Runner) Validate(ctx context.Context, req ValidatorRequest) (gate.Valid
 		}
 		return nil
 	}, r.turnLimit)
+	processReapErr := r.reapSessionWorkerProcess(
+		sessionCtx,
+		sessionID,
+		req.Issue,
+		workerProcessReapReason(sessionCtx, turnErr),
+	)
+	if processReapErr != nil {
+		turnErr = errors.Join(turnErr, fmt.Errorf("%w: %w", ErrWorkerProcessReap, processReapErr))
+	}
 	if cause := context.Cause(sessionCtx); cooperativeStopError(cause) || durationLimitError(cause) {
-		turnErr = cause
+		if processReapErr != nil {
+			turnErr = errors.Join(cause, fmt.Errorf("%w: %w", ErrWorkerProcessReap, processReapErr))
+		} else {
+			turnErr = cause
+		}
 	}
 	turnErr = sessionBrake.wrapTurnLimit(ctx, turnErr)
 	turnErr = sessionBrake.wrapDuration(ctx, turnErr, durationFromMillis(workflow.Config.Agent.MaxSessionDurationMS))
@@ -2602,6 +2647,65 @@ func (r *Runner) persistSessionWorkerProcess(ctx context.Context, sessionID int6
 		return fmt.Errorf("update agent session worker process: %w", err)
 	}
 	return nil
+}
+
+func (r *Runner) reapSessionWorkerProcess(ctx context.Context, sessionID int64, issue connector.Issue, reason string) error {
+	if sessionID <= 0 {
+		return nil
+	}
+	processStore, ok := r.store.(sessionWorkerProcessReaper)
+	if !ok {
+		return nil
+	}
+	processes, err := processStore.ListActiveWorkerProcesses(context.WithoutCancel(ctx))
+	if err != nil {
+		return fmt.Errorf("list agent session worker processes: %w", err)
+	}
+	for _, process := range processes {
+		if process.SessionID != sessionID {
+			continue
+		}
+		identity := procgroup.Identity{PID: process.PID, GroupID: process.GroupID, StartedAt: process.StartedAt}
+		outcome, reapErr := r.reapWorkerProcess(context.WithoutCancel(ctx), identity, r.workerReapGrace)
+		attrs := []any{
+			telemetry.DetentSessionIDKey, sessionID,
+			"pid", process.PID,
+			"pgid", process.GroupID,
+			"reason", strings.TrimSpace(reason),
+			"decision", string(outcome),
+		}
+		if reapErr != nil {
+			attrs = append(attrs, "error", reapErr)
+			r.logWorkerEventLevel(slog.LevelInfo, issue, "worker_process_reap_decision", attrs...)
+			return fmt.Errorf("reap agent session worker process: %w", reapErr)
+		}
+		r.logWorkerEventLevel(slog.LevelInfo, issue, "worker_process_reap_decision", attrs...)
+		if err := processStore.MarkSessionWorkerProcessReaped(context.WithoutCancel(ctx), sessionID, store.WorkerProcessReap{
+			ReapedAt: r.now().UTC(),
+			Outcome:  string(outcome),
+			Reason:   strings.TrimSpace(reason),
+		}); err != nil {
+			return fmt.Errorf("record agent session worker process reap: %w", err)
+		}
+	}
+	return nil
+}
+
+func workerProcessReapReason(ctx context.Context, turnErr error) string {
+	cause := context.Cause(ctx)
+	combined := errors.Join(cause, turnErr)
+	switch {
+	case errors.Is(combined, ErrSessionDurationExceeded), errors.Is(combined, ErrMergeFallbackBudgetExceeded):
+		return "maximum_session_lifetime_exceeded"
+	case errors.Is(combined, ErrTurnDurationExceeded):
+		return "maximum_turn_lifetime_exceeded"
+	case errors.Is(combined, context.Canceled):
+		return "session_cancelled"
+	case turnErr != nil:
+		return "turn_failed"
+	default:
+		return "turn_completed"
+	}
 }
 
 func (r *Runner) updateSessionResumeState(ctx context.Context, sessionID int64, resumedFromSessionID int64, orphanRecoveryOutcome string, fallbackReason string) error {

--- a/internal/runner/duration_limit_test.go
+++ b/internal/runner/duration_limit_test.go
@@ -110,6 +110,107 @@ func TestRunnerEnforcesConfiguredDurationLimits(t *testing.T) {
 	}
 }
 
+func TestRunnerSessionLifetimeReapsWorkerAndRecordsCause(t *testing.T) {
+	t.Parallel()
+
+	startedAt := time.Date(2026, 8, 18, 14, 0, 0, 0, time.UTC)
+	identity := procgroup.Identity{PID: 1885, GroupID: 1885, StartedAt: startedAt}
+	durationLimit := &controlledDurationLimit{}
+	processStore := &durationReapSessionStore{
+		fakeSessionStore: &fakeSessionStore{sessionID: 1885},
+		process: store.WorkerProcess{
+			SessionID: 1885,
+			WorkerProcessIdentity: store.WorkerProcessIdentity{
+				PID:       identity.PID,
+				GroupID:   identity.GroupID,
+				StartedAt: identity.StartedAt,
+			},
+		},
+	}
+	backend := &durationWorkerAgentBackend{identity: identity, expireSession: durationLimit.Expire}
+	var reaped procgroup.Identity
+	runner, err := NewRunner(Dependencies{
+		Workflow:     config.Workflow{Config: config.Config{Agent: config.Agent{MaxSessionDurationMS: 25}}, Prompt: "Work"},
+		Workspace:    &fakeWorkspaceBackend{info: workspace.Info{Path: t.TempDir(), Key: "issue-session-lifetime"}},
+		AgentBackend: backend,
+		Store:        processStore,
+		sessionLimit: durationLimit.Context,
+		ReapWorkerProcess: func(_ context.Context, got procgroup.Identity, _ time.Duration) (procgroup.TerminationOutcome, error) {
+			reaped = got
+			return procgroup.TerminationOutcomeKilled, nil
+		},
+	})
+	if err != nil {
+		t.Fatalf("NewRunner() error = %v", err)
+	}
+
+	_, err = runner.Run(context.Background(), RunRequest{Issue: connector.Issue{ID: "issue-session-lifetime", Identifier: "digitaldrywood/detent#1885"}})
+	if !errors.Is(err, ErrSessionDurationExceeded) {
+		t.Fatalf("Run() error = %v, want ErrSessionDurationExceeded", err)
+	}
+	if reaped != identity {
+		t.Fatalf("reaped identity = %#v, want %#v", reaped, identity)
+	}
+	if len(processStore.reaps) != 1 {
+		t.Fatalf("reap records = %#v, want one", processStore.reaps)
+	}
+	if got := processStore.reaps[0]; got.Outcome != store.WorkerProcessOutcomeKilled || got.Reason != "maximum_session_lifetime_exceeded" {
+		t.Fatalf("reap record = %#v, want killed maximum session lifetime", got)
+	}
+	if processStore.finished.FinalState != FinalStateSessionDurationExceeded {
+		t.Fatalf("final state = %q, want %q", processStore.finished.FinalState, FinalStateSessionDurationExceeded)
+	}
+}
+
+func TestRunnerReapsWorkerAfterTerminalTurn(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		turnErr    error
+		wantReason string
+	}{
+		{name: "completed", wantReason: "turn_completed"},
+		{name: "failed", turnErr: errors.New("provider failed"), wantReason: "turn_failed"},
+		{name: "cancelled", turnErr: context.Canceled, wantReason: "session_cancelled"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			startedAt := time.Date(2026, 8, 18, 14, 0, 0, 0, time.UTC)
+			identity := procgroup.Identity{PID: 1885, GroupID: 1885, StartedAt: startedAt}
+			processStore := &durationReapSessionStore{
+				fakeSessionStore: &fakeSessionStore{sessionID: 1885},
+				process: store.WorkerProcess{SessionID: 1885, WorkerProcessIdentity: store.WorkerProcessIdentity{
+					PID: identity.PID, GroupID: identity.GroupID, StartedAt: identity.StartedAt,
+				}},
+			}
+			runner, err := NewRunner(Dependencies{
+				Workflow:     config.Workflow{Prompt: "Work"},
+				Workspace:    &fakeWorkspaceBackend{info: workspace.Info{Path: t.TempDir(), Key: "issue-terminal-worker"}},
+				AgentBackend: terminalWorkerAgentBackend{identity: identity, err: tt.turnErr},
+				Store:        processStore,
+				ReapWorkerProcess: func(context.Context, procgroup.Identity, time.Duration) (procgroup.TerminationOutcome, error) {
+					return procgroup.TerminationOutcomeAlreadyExited, nil
+				},
+			})
+			if err != nil {
+				t.Fatalf("NewRunner() error = %v", err)
+			}
+			_, runErr := runner.Run(context.Background(), RunRequest{Issue: connector.Issue{ID: "issue-terminal-worker", Identifier: "digitaldrywood/detent#1885"}})
+			if tt.turnErr == nil && runErr != nil {
+				t.Fatalf("Run() error = %v", runErr)
+			}
+			if tt.turnErr != nil && !errors.Is(runErr, tt.turnErr) {
+				t.Fatalf("Run() error = %v, want %v", runErr, tt.turnErr)
+			}
+			if len(processStore.reaps) != 1 || processStore.reaps[0].Reason != tt.wantReason || processStore.reaps[0].Outcome != store.WorkerProcessOutcomeAlreadyExited {
+				t.Fatalf("reap records = %#v, want reason %q", processStore.reaps, tt.wantReason)
+			}
+		})
+	}
+}
+
 func TestRunnerSessionDurationSpansResumeFallback(t *testing.T) {
 	t.Parallel()
 
@@ -461,6 +562,32 @@ type durationBlockingAgentBackend struct {
 	expireDuration func()
 }
 
+type durationWorkerAgentBackend struct {
+	identity      procgroup.Identity
+	expireSession func()
+}
+
+type terminalWorkerAgentBackend struct {
+	identity procgroup.Identity
+	err      error
+}
+
+func (b terminalWorkerAgentBackend) RunTurn(_ context.Context, _ AgentTurnRequest, onUpdate AgentUpdateHandler) (AgentTurnResult, error) {
+	if err := onUpdate(AgentUpdate{Type: AgentUpdateProcessStarted, WorkerProcess: b.identity}); err != nil {
+		return AgentTurnResult{}, err
+	}
+	return AgentTurnResult{ThreadID: "thread-1885", TurnID: "turn-1885", SessionID: "session-1885"}, b.err
+}
+
+func (b *durationWorkerAgentBackend) RunTurn(ctx context.Context, _ AgentTurnRequest, onUpdate AgentUpdateHandler) (AgentTurnResult, error) {
+	if err := onUpdate(AgentUpdate{Type: AgentUpdateProcessStarted, WorkerProcess: b.identity}); err != nil {
+		return AgentTurnResult{}, err
+	}
+	b.expireSession()
+	<-ctx.Done()
+	return AgentTurnResult{}, ctx.Err()
+}
+
 func (b *durationBlockingAgentBackend) RunTurn(ctx context.Context, request AgentTurnRequest, onUpdate AgentUpdateHandler) (AgentTurnResult, error) {
 	b.request = request
 	b.recordDeadline(ctx)
@@ -565,6 +692,23 @@ type durationBlockingSessionStore struct {
 	*fakeSessionStore
 	hasDeadline   bool
 	expireSession func()
+}
+
+type durationReapSessionStore struct {
+	*fakeSessionStore
+	process store.WorkerProcess
+	reaps   []store.WorkerProcessReap
+}
+
+func (s *durationReapSessionStore) ListActiveWorkerProcesses(context.Context) ([]store.WorkerProcess, error) {
+	return []store.WorkerProcess{s.process}, nil
+}
+
+func (s *durationReapSessionStore) MarkSessionWorkerProcessReaped(_ context.Context, sessionID int64, reap store.WorkerProcessReap) error {
+	if sessionID == s.process.SessionID {
+		s.reaps = append(s.reaps, reap)
+	}
+	return nil
 }
 
 func (s *durationBlockingSessionStore) UpdateSessionWorkerProcess(ctx context.Context, _ int64, _ store.WorkerProcessIdentity) error {

--- a/internal/runner/types.go
+++ b/internal/runner/types.go
@@ -59,6 +59,7 @@ var (
 	ErrMergeFallbackBudgetExceeded  = errors.New("merge fallback budget exceeded")
 	ErrModelPermitUnavailable       = errors.New("provider model permit unavailable")
 	ErrAgentTurnCleanup             = errors.New("agent turn cleanup failed")
+	ErrWorkerProcessReap            = errors.New("worker process reap failed")
 	ErrAgentResumeUnsupported       = errors.New("agent backend does not support resume verification")
 	ErrDeliverableRecoveryExhausted = errors.New("deliverable recovery exhausted")
 )

--- a/internal/store/migrations/00038_add_worker_reap_reason.sql
+++ b/internal/store/migrations/00038_add_worker_reap_reason.sql
@@ -1,0 +1,9 @@
+-- +goose Up
+ALTER TABLE codex_sessions ADD COLUMN worker_reap_reason TEXT;
+CREATE INDEX idx_codex_sessions_unreaped_worker_processes
+ON codex_sessions(worker_reaped_at, worker_pid)
+WHERE worker_reaped_at IS NULL AND worker_pid > 0;
+
+-- +goose Down
+DROP INDEX idx_codex_sessions_unreaped_worker_processes;
+ALTER TABLE codex_sessions DROP COLUMN worker_reap_reason;

--- a/internal/store/sqlc/models.go
+++ b/internal/store/sqlc/models.go
@@ -160,6 +160,7 @@ type CodexSession struct {
 	WorkerReapedAt               sql.NullString `json:"worker_reaped_at"`
 	WorkerReapOutcome            sql.NullString `json:"worker_reap_outcome"`
 	ProjectID                    sql.NullString `json:"project_id"`
+	WorkerReapReason             sql.NullString `json:"worker_reap_reason"`
 }
 
 type DetentRun struct {

--- a/internal/store/sqlc/store.sql.go
+++ b/internal/store/sqlc/store.sql.go
@@ -449,7 +449,7 @@ INSERT INTO codex_sessions (
   orphan_recovery_outcome,
   orphan_recovery_fallback_reason
 ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-RETURNING id, run_id, issue_id, identifier, issue_url, started_at, completed_at, turns, input_tokens, output_tokens, total_tokens, runtime_seconds, final_state, model, cached_input_tokens, reasoning_output_tokens, model_context_window, requested_model, agent_backend_id, agent_backend_kind, agent_role, provider_thread_id, provider_session_id, resumed_from_session_id, work_attempt_id, agent_route, provider, provider_provenance, requested_model_provenance, model_provenance, reasoning_effort, reasoning_effort_provenance, service_tier, service_tier_provenance, identity_observed_at, orphan_recovery_outcome, skill_draft_proposed, orphan_recovery_fallback_reason, worker_pid, worker_pgid, worker_started_at, worker_reaped_at, worker_reap_outcome, project_id
+RETURNING id, run_id, issue_id, identifier, issue_url, started_at, completed_at, turns, input_tokens, output_tokens, total_tokens, runtime_seconds, final_state, model, cached_input_tokens, reasoning_output_tokens, model_context_window, requested_model, agent_backend_id, agent_backend_kind, agent_role, provider_thread_id, provider_session_id, resumed_from_session_id, work_attempt_id, agent_route, provider, provider_provenance, requested_model_provenance, model_provenance, reasoning_effort, reasoning_effort_provenance, service_tier, service_tier_provenance, identity_observed_at, orphan_recovery_outcome, skill_draft_proposed, orphan_recovery_fallback_reason, worker_pid, worker_pgid, worker_started_at, worker_reaped_at, worker_reap_outcome, project_id, worker_reap_reason
 `
 
 type CreateCodexSessionParams struct {
@@ -578,6 +578,7 @@ func (q *Queries) CreateCodexSession(ctx context.Context, arg CreateCodexSession
 		&i.WorkerReapedAt,
 		&i.WorkerReapOutcome,
 		&i.ProjectID,
+		&i.WorkerReapReason,
 	)
 	return i, err
 }
@@ -1568,7 +1569,7 @@ func (q *Queries) GetAPIKeyByHash(ctx context.Context, keyHash string) (ApiKey, 
 }
 
 const getCodexSession = `-- name: GetCodexSession :one
-SELECT id, run_id, issue_id, identifier, issue_url, started_at, completed_at, turns, input_tokens, output_tokens, total_tokens, runtime_seconds, final_state, model, cached_input_tokens, reasoning_output_tokens, model_context_window, requested_model, agent_backend_id, agent_backend_kind, agent_role, provider_thread_id, provider_session_id, resumed_from_session_id, work_attempt_id, agent_route, provider, provider_provenance, requested_model_provenance, model_provenance, reasoning_effort, reasoning_effort_provenance, service_tier, service_tier_provenance, identity_observed_at, orphan_recovery_outcome, skill_draft_proposed, orphan_recovery_fallback_reason, worker_pid, worker_pgid, worker_started_at, worker_reaped_at, worker_reap_outcome, project_id
+SELECT id, run_id, issue_id, identifier, issue_url, started_at, completed_at, turns, input_tokens, output_tokens, total_tokens, runtime_seconds, final_state, model, cached_input_tokens, reasoning_output_tokens, model_context_window, requested_model, agent_backend_id, agent_backend_kind, agent_role, provider_thread_id, provider_session_id, resumed_from_session_id, work_attempt_id, agent_route, provider, provider_provenance, requested_model_provenance, model_provenance, reasoning_effort, reasoning_effort_provenance, service_tier, service_tier_provenance, identity_observed_at, orphan_recovery_outcome, skill_draft_proposed, orphan_recovery_fallback_reason, worker_pid, worker_pgid, worker_started_at, worker_reaped_at, worker_reap_outcome, project_id, worker_reap_reason
 FROM codex_sessions
 WHERE id = ?
 `
@@ -1621,6 +1622,7 @@ func (q *Queries) GetCodexSession(ctx context.Context, id int64) (CodexSession, 
 		&i.WorkerReapedAt,
 		&i.WorkerReapOutcome,
 		&i.ProjectID,
+		&i.WorkerReapReason,
 	)
 	return i, err
 }
@@ -2464,11 +2466,12 @@ SELECT
   CAST(COALESCE(issue_url, '') AS TEXT) AS issue_url,
   CAST(worker_pid AS INTEGER) AS worker_pid,
   CAST(COALESCE(worker_pgid, 0) AS INTEGER) AS worker_pgid,
-  CAST(worker_started_at AS TEXT) AS worker_started_at
+  CAST(worker_started_at AS TEXT) AS worker_started_at,
+  CAST(COALESCE(final_state, '') AS TEXT) AS final_state,
+  CAST(COALESCE(completed_at, '') AS TEXT) AS completed_at
 FROM codex_sessions
-WHERE completed_at IS NULL
-  AND worker_reaped_at IS NULL
-  AND COALESCE(worker_pid, 0) > 0
+WHERE worker_reaped_at IS NULL
+  AND worker_pid > 0
 ORDER BY started_at, id
 `
 
@@ -2480,6 +2483,8 @@ type ListActiveWorkerProcessesRow struct {
 	WorkerPid       int64  `json:"worker_pid"`
 	WorkerPgid      int64  `json:"worker_pgid"`
 	WorkerStartedAt string `json:"worker_started_at"`
+	FinalState      string `json:"final_state"`
+	CompletedAt     string `json:"completed_at"`
 }
 
 func (q *Queries) ListActiveWorkerProcesses(ctx context.Context) ([]ListActiveWorkerProcessesRow, error) {
@@ -2499,6 +2504,8 @@ func (q *Queries) ListActiveWorkerProcesses(ctx context.Context) ([]ListActiveWo
 			&i.WorkerPid,
 			&i.WorkerPgid,
 			&i.WorkerStartedAt,
+			&i.FinalState,
+			&i.CompletedAt,
 		); err != nil {
 			return nil, err
 		}
@@ -3157,7 +3164,7 @@ func (q *Queries) ListPendingWorkAttemptCapacityReleases(ctx context.Context, pr
 }
 
 const listRecentCodexSessions = `-- name: ListRecentCodexSessions :many
-SELECT id, run_id, issue_id, identifier, issue_url, started_at, completed_at, turns, input_tokens, output_tokens, total_tokens, runtime_seconds, final_state, model, cached_input_tokens, reasoning_output_tokens, model_context_window, requested_model, agent_backend_id, agent_backend_kind, agent_role, provider_thread_id, provider_session_id, resumed_from_session_id, work_attempt_id, agent_route, provider, provider_provenance, requested_model_provenance, model_provenance, reasoning_effort, reasoning_effort_provenance, service_tier, service_tier_provenance, identity_observed_at, orphan_recovery_outcome, skill_draft_proposed, orphan_recovery_fallback_reason, worker_pid, worker_pgid, worker_started_at, worker_reaped_at, worker_reap_outcome, project_id
+SELECT id, run_id, issue_id, identifier, issue_url, started_at, completed_at, turns, input_tokens, output_tokens, total_tokens, runtime_seconds, final_state, model, cached_input_tokens, reasoning_output_tokens, model_context_window, requested_model, agent_backend_id, agent_backend_kind, agent_role, provider_thread_id, provider_session_id, resumed_from_session_id, work_attempt_id, agent_route, provider, provider_provenance, requested_model_provenance, model_provenance, reasoning_effort, reasoning_effort_provenance, service_tier, service_tier_provenance, identity_observed_at, orphan_recovery_outcome, skill_draft_proposed, orphan_recovery_fallback_reason, worker_pid, worker_pgid, worker_started_at, worker_reaped_at, worker_reap_outcome, project_id, worker_reap_reason
 FROM codex_sessions
 ORDER BY completed_at DESC, id DESC
 LIMIT ?
@@ -3217,6 +3224,7 @@ func (q *Queries) ListRecentCodexSessions(ctx context.Context, limit int64) ([]C
 			&i.WorkerReapedAt,
 			&i.WorkerReapOutcome,
 			&i.ProjectID,
+			&i.WorkerReapReason,
 		); err != nil {
 			return nil, err
 		}
@@ -3462,18 +3470,25 @@ func (q *Queries) MarkCodexSessionOrphaned(ctx context.Context, arg MarkCodexSes
 const markCodexSessionWorkerProcessReaped = `-- name: MarkCodexSessionWorkerProcessReaped :execrows
 UPDATE codex_sessions
 SET worker_reaped_at = ?1,
-    worker_reap_outcome = ?2
-WHERE id = ?3
+    worker_reap_outcome = ?2,
+    worker_reap_reason = ?3
+WHERE id = ?4
 `
 
 type MarkCodexSessionWorkerProcessReapedParams struct {
 	WorkerReapedAt    sql.NullString `json:"worker_reaped_at"`
 	WorkerReapOutcome sql.NullString `json:"worker_reap_outcome"`
+	WorkerReapReason  sql.NullString `json:"worker_reap_reason"`
 	ID                int64          `json:"id"`
 }
 
 func (q *Queries) MarkCodexSessionWorkerProcessReaped(ctx context.Context, arg MarkCodexSessionWorkerProcessReapedParams) (int64, error) {
-	result, err := q.db.ExecContext(ctx, markCodexSessionWorkerProcessReaped, arg.WorkerReapedAt, arg.WorkerReapOutcome, arg.ID)
+	result, err := q.db.ExecContext(ctx, markCodexSessionWorkerProcessReaped,
+		arg.WorkerReapedAt,
+		arg.WorkerReapOutcome,
+		arg.WorkerReapReason,
+		arg.ID,
+	)
 	if err != nil {
 		return 0, err
 	}
@@ -4053,7 +4068,8 @@ SET worker_pid = ?1,
     worker_pgid = ?2,
     worker_started_at = ?3,
     worker_reaped_at = NULL,
-    worker_reap_outcome = NULL
+    worker_reap_outcome = NULL,
+    worker_reap_reason = NULL
 WHERE id = ?4
 `
 

--- a/internal/store/sqlite.go
+++ b/internal/store/sqlite.go
@@ -294,11 +294,20 @@ func (s *sqliteStore) ListActiveWorkerProcesses(ctx context.Context) ([]WorkerPr
 		if err != nil {
 			return nil, err
 		}
+		var completedAt time.Time
+		if strings.TrimSpace(row.CompletedAt) != "" {
+			completedAt, err = parseTimestamp("completed_at", row.CompletedAt)
+			if err != nil {
+				return nil, err
+			}
+		}
 		processes = append(processes, WorkerProcess{
-			SessionID:  row.SessionID,
-			IssueID:    strings.TrimSpace(row.IssueID),
-			Identifier: strings.TrimSpace(row.Identifier),
-			IssueURL:   strings.TrimSpace(row.IssueURL),
+			SessionID:   row.SessionID,
+			IssueID:     strings.TrimSpace(row.IssueID),
+			Identifier:  strings.TrimSpace(row.Identifier),
+			IssueURL:    strings.TrimSpace(row.IssueURL),
+			FinalState:  strings.TrimSpace(row.FinalState),
+			CompletedAt: completedAt,
 			WorkerProcessIdentity: WorkerProcessIdentity{
 				PID:       int(row.WorkerPid),
 				GroupID:   int(row.WorkerPgid),
@@ -320,6 +329,7 @@ func (s *sqliteStore) MarkSessionWorkerProcessReaped(ctx context.Context, sessio
 	rows, err := s.queries.MarkCodexSessionWorkerProcessReaped(ctx, sqlc.MarkCodexSessionWorkerProcessReapedParams{
 		WorkerReapedAt:    sql.NullString{String: reapedAt, Valid: true},
 		WorkerReapOutcome: nullString(reap.Outcome),
+		WorkerReapReason:  nullString(reap.Reason),
 		ID:                sessionID,
 	})
 	if err != nil {

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -407,16 +407,19 @@ type WorkerProcessIdentity struct {
 }
 
 type WorkerProcess struct {
-	SessionID  int64
-	IssueID    string
-	Identifier string
-	IssueURL   string
+	SessionID   int64
+	IssueID     string
+	Identifier  string
+	IssueURL    string
+	FinalState  string
+	CompletedAt time.Time
 	WorkerProcessIdentity
 }
 
 type WorkerProcessReap struct {
 	ReapedAt time.Time
 	Outcome  string
+	Reason   string
 }
 
 type SessionResumeState struct {

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -1574,11 +1574,25 @@ func TestActiveWorkerProcessesAreJournaledAndReaped(t *testing.T) {
 	if got := active[0]; got.SessionID != sessionID || got.Identifier != "digitaldrywood/detent#1214" || got.PID != 4242 || got.GroupID != 4242 || !got.StartedAt.Equal(processStartedAt) {
 		t.Fatalf("active worker process = %#v", got)
 	}
+	if err := backend.FinishSession(ctx, sessionID, SessionFinish{
+		CompletedAt: startedAt.Add(90 * time.Second),
+		FinalState:  "completed",
+	}); err != nil {
+		t.Fatalf("FinishSession() error = %v", err)
+	}
+	active, err = backend.ListActiveWorkerProcesses(ctx)
+	if err != nil {
+		t.Fatalf("ListActiveWorkerProcesses() after terminal session error = %v", err)
+	}
+	if len(active) != 1 {
+		t.Fatalf("ListActiveWorkerProcesses() after terminal session len = %d, want unreaped process retained", len(active))
+	}
 
 	reapedAt := startedAt.Add(2 * time.Second)
 	if err := backend.MarkSessionWorkerProcessReaped(ctx, sessionID, WorkerProcessReap{
 		ReapedAt: reapedAt,
 		Outcome:  WorkerProcessOutcomeTerminated,
+		Reason:   "terminal_completed",
 	}); err != nil {
 		t.Fatalf("MarkSessionWorkerProcessReaped() error = %v", err)
 	}
@@ -1588,6 +1602,13 @@ func TestActiveWorkerProcessesAreJournaledAndReaped(t *testing.T) {
 	}
 	if len(active) != 0 {
 		t.Fatalf("ListActiveWorkerProcesses() after reap len = %d, want 0", len(active))
+	}
+	session, err := backend.Queries().GetCodexSession(ctx, sessionID)
+	if err != nil {
+		t.Fatalf("GetCodexSession() error = %v", err)
+	}
+	if session.WorkerReapOutcome.String != WorkerProcessOutcomeTerminated || session.WorkerReapReason.String != "terminal_completed" {
+		t.Fatalf("persisted reap = outcome %q reason %q", session.WorkerReapOutcome.String, session.WorkerReapReason.String)
 	}
 }
 

--- a/internal/telemetry/snapshot.go
+++ b/internal/telemetry/snapshot.go
@@ -78,6 +78,26 @@ type PressureAverages struct {
 	Total  uint64  `json:"total"`
 }
 
+type OrphanedAgentProcesses struct {
+	Count         int                    `json:"count"`
+	SessionCount  int                    `json:"session_count"`
+	TotalRSSBytes int64                  `json:"total_rss_bytes"`
+	Processes     []OrphanedAgentProcess `json:"processes,omitempty"`
+}
+
+type OrphanedAgentProcess struct {
+	SessionID    int64     `json:"session_id"`
+	IssueID      string    `json:"issue_id,omitempty"`
+	Identifier   string    `json:"identifier,omitempty"`
+	PID          int       `json:"pid"`
+	GroupID      int       `json:"pgid,omitempty"`
+	StartedAt    time.Time `json:"started_at"`
+	AgeSeconds   int64     `json:"age_seconds"`
+	RSSBytes     int64     `json:"rss_bytes"`
+	ProcessCount int       `json:"process_count"`
+	FinalState   string    `json:"final_state,omitempty"`
+}
+
 func (s Snapshot) AgeSeconds(now time.Time) int64 {
 	if s.GeneratedAt.IsZero() || now.IsZero() || now.Before(s.GeneratedAt) {
 		return 0

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -33,6 +33,7 @@ import (
 	"github.com/digitaldrywood/detent/internal/mcp"
 	"github.com/digitaldrywood/detent/internal/operatortool"
 	"github.com/digitaldrywood/detent/internal/pause"
+	"github.com/digitaldrywood/detent/internal/procgroup"
 	"github.com/digitaldrywood/detent/internal/project"
 	"github.com/digitaldrywood/detent/internal/store"
 	"github.com/digitaldrywood/detent/internal/telemetry"
@@ -64,6 +65,12 @@ type Dependencies struct {
 	IssueExplainer      IssueExplainer
 	HealthNotifications healthnotify.FailureReader
 	TickLiveness        TickLivenessSource
+	WorkerProcesses     WorkerProcessStore
+	ObserveProcesses    func([]procgroup.Identity) ([]procgroup.Observation, error)
+}
+
+type WorkerProcessStore interface {
+	ListActiveWorkerProcesses(context.Context) ([]store.WorkerProcess, error)
 }
 
 type TickLivenessSource interface {
@@ -176,6 +183,8 @@ type Server struct {
 	issueExplainer      IssueExplainer
 	healthNotifications healthnotify.FailureReader
 	tickLiveness        TickLivenessSource
+	workerProcesses     WorkerProcessStore
+	observeProcesses    func([]procgroup.Identity) ([]procgroup.Observation, error)
 	now                 func() time.Time
 	operatorTools       *operatortool.Executor
 	mcpHTTP             *mcp.HTTPHandler
@@ -234,6 +243,10 @@ func NewServer(cfg Config, deps Dependencies) (*Server, error) {
 	if tickLiveness == nil && deps.Registry != nil {
 		tickLiveness = deps.Registry
 	}
+	observeProcesses := deps.ObserveProcesses
+	if observeProcesses == nil {
+		observeProcesses = procgroup.Observe
+	}
 
 	server := &Server{
 		echo:                e,
@@ -291,6 +304,8 @@ func NewServer(cfg Config, deps Dependencies) (*Server, error) {
 		issueExplainer:      deps.IssueExplainer,
 		healthNotifications: deps.HealthNotifications,
 		tickLiveness:        tickLiveness,
+		workerProcesses:     deps.WorkerProcesses,
+		observeProcesses:    observeProcesses,
 		now:                 cfg.now(),
 	}
 	if !magicLinksEnabled && !oidcEnabled {
@@ -1099,11 +1114,13 @@ func (s *Server) health(c echo.Context) error {
 	refresh := telemetry.Refresh{}
 	memoryPressure := telemetry.MemoryPressure{}
 	agentMemory := []healthAgentMemory{}
+	latestSnapshot := telemetry.Snapshot{}
 	snapshotGeneratedAt := time.Time{}
 	snapshotAgeSeconds := int64(0)
 	if s.hub != nil {
 		if snapshot, ok := s.hub.Latest(); ok {
 			snapshot = snapshot.WithFreshness(now)
+			latestSnapshot = snapshot
 			refreshFailures = snapshot.RefreshFailures()
 			snapshotGeneratedAt = snapshot.GeneratedAt
 			snapshotAgeSeconds = snapshot.AgeSeconds(now)
@@ -1152,6 +1169,13 @@ func (s *Server) health(c echo.Context) error {
 		"registry":  configuredStatus(s.registry),
 		"connector": configuredStatus(s.connector),
 	}
+	orphanedProcesses, orphanErr := s.orphanedAgentProcesses(c.Request().Context(), latestSnapshot, now)
+	if orphanErr != nil {
+		checks["worker_processes"] = "unavailable: " + orphanErr.Error()
+		s.logger.Warn("inspect orphaned agent processes failed", "error", orphanErr)
+	} else {
+		checks["worker_processes"] = configuredStatus(s.workerProcesses)
+	}
 	if s.demo != nil {
 		checks["demo"] = DemoModeScreenshots
 		checks["demo_clock"] = s.demo.clock
@@ -1163,7 +1187,7 @@ func (s *Server) health(c echo.Context) error {
 	if status != "draining" {
 		budgets = s.enforcedBudgets()
 		workflows = s.workflowSources()
-		if len(trackerUnavailable) > 0 || len(forgeUnavailable) > 0 || len(ciUnavailable) > 0 || len(dispatchStalls) > 0 || len(failureBreakers) > 0 || len(backendOutages) > 0 || tickLivenessNeedsAttention(tickLiveness) || len(refreshFailures) > 0 || memoryPressure.DispatchHeld {
+		if len(trackerUnavailable) > 0 || len(forgeUnavailable) > 0 || len(ciUnavailable) > 0 || len(dispatchStalls) > 0 || len(failureBreakers) > 0 || len(backendOutages) > 0 || tickLivenessNeedsAttention(tickLiveness) || len(refreshFailures) > 0 || memoryPressure.DispatchHeld || orphanedProcesses.Count > 0 {
 			status = "needs_attention"
 		}
 		if pauseExitNeedsAttention(projectHealth) {
@@ -1171,37 +1195,102 @@ func (s *Server) health(c echo.Context) error {
 		}
 	}
 	return c.JSON(http.StatusOK, healthResponse{
-		Status:               status,
-		Version:              s.build.Version,
-		Commit:               s.build.Commit,
-		ProjectStatus:        projectStatus,
-		Mode:                 string(s.mode),
-		Connector:            s.connectorName(),
-		SessionsRemaining:    sessionsRemaining,
-		Update:               updateStatus,
-		Checks:               checks,
-		Environment:          healthEnvironment{Path: os.Getenv("PATH")},
-		Budgets:              budgets,
-		Workflows:            workflows,
-		TrackerUnavailable:   trackerUnavailable,
-		ForgeUnavailable:     forgeUnavailable,
-		CIUnavailable:        ciUnavailable,
-		BackendOutages:       backendOutages,
-		FailureBreakers:      failureBreakers,
-		StalenessWarnings:    stalenessWarnings,
-		StrandedIssues:       strandedActiveIssues,
-		Dispatch:             dispatch,
-		DispatchStalls:       dispatchStalls,
-		NotificationFailures: notificationFailures,
-		RefreshFailures:      refreshFailures,
-		Projects:             projectHealth,
-		Refresh:              refresh,
-		MemoryPressure:       memoryPressure,
-		AgentMemory:          agentMemory,
-		SnapshotGeneratedAt:  snapshotGeneratedAt,
-		SnapshotAgeSeconds:   snapshotAgeSeconds,
-		TickLiveness:         tickLiveness,
+		Status:                 status,
+		Version:                s.build.Version,
+		Commit:                 s.build.Commit,
+		ProjectStatus:          projectStatus,
+		Mode:                   string(s.mode),
+		Connector:              s.connectorName(),
+		SessionsRemaining:      sessionsRemaining,
+		Update:                 updateStatus,
+		Checks:                 checks,
+		Environment:            healthEnvironment{Path: os.Getenv("PATH")},
+		Budgets:                budgets,
+		Workflows:              workflows,
+		TrackerUnavailable:     trackerUnavailable,
+		ForgeUnavailable:       forgeUnavailable,
+		CIUnavailable:          ciUnavailable,
+		BackendOutages:         backendOutages,
+		FailureBreakers:        failureBreakers,
+		StalenessWarnings:      stalenessWarnings,
+		StrandedIssues:         strandedActiveIssues,
+		Dispatch:               dispatch,
+		DispatchStalls:         dispatchStalls,
+		NotificationFailures:   notificationFailures,
+		RefreshFailures:        refreshFailures,
+		Projects:               projectHealth,
+		Refresh:                refresh,
+		MemoryPressure:         memoryPressure,
+		AgentMemory:            agentMemory,
+		SnapshotGeneratedAt:    snapshotGeneratedAt,
+		SnapshotAgeSeconds:     snapshotAgeSeconds,
+		TickLiveness:           tickLiveness,
+		OrphanedAgentProcesses: orphanedProcesses,
 	})
+}
+
+func (s *Server) orphanedAgentProcesses(ctx context.Context, snapshot telemetry.Snapshot, now time.Time) (telemetry.OrphanedAgentProcesses, error) {
+	summary := telemetry.OrphanedAgentProcesses{Processes: []telemetry.OrphanedAgentProcess{}}
+	if s.workerProcesses == nil || s.observeProcesses == nil {
+		return summary, nil
+	}
+	processes, err := s.workerProcesses.ListActiveWorkerProcesses(ctx)
+	if err != nil {
+		return summary, fmt.Errorf("list worker process registry: %w", err)
+	}
+	liveSessions := make(map[int64]struct{}, len(snapshot.Running))
+	for _, running := range snapshot.Running {
+		if running.DetentSessionID > 0 {
+			liveSessions[running.DetentSessionID] = struct{}{}
+		}
+	}
+	candidates := make([]store.WorkerProcess, 0, len(processes))
+	identities := make([]procgroup.Identity, 0, len(processes))
+	for _, process := range processes {
+		if process.CompletedAt.IsZero() {
+			if _, live := liveSessions[process.SessionID]; live {
+				continue
+			}
+			if snapshot.GeneratedAt.IsZero() || snapshot.GeneratedAt.Before(process.StartedAt) {
+				continue
+			}
+		}
+		candidates = append(candidates, process)
+		identities = append(identities, procgroup.Identity{PID: process.PID, GroupID: process.GroupID, StartedAt: process.StartedAt})
+	}
+	observations, err := s.observeProcesses(identities)
+	if err != nil {
+		return summary, fmt.Errorf("observe worker process registry: %w", err)
+	}
+	if len(observations) != len(candidates) {
+		return summary, fmt.Errorf("observe worker process registry: got %d observations for %d processes", len(observations), len(candidates))
+	}
+	for index, observation := range observations {
+		if !observation.Alive || observation.Stale {
+			continue
+		}
+		process := candidates[index]
+		ageSeconds := int64(0)
+		if now.After(process.StartedAt) {
+			ageSeconds = int64(now.Sub(process.StartedAt) / time.Second)
+		}
+		summary.Count += observation.ProcessCount
+		summary.SessionCount++
+		summary.TotalRSSBytes += observation.RSSBytes
+		summary.Processes = append(summary.Processes, telemetry.OrphanedAgentProcess{
+			SessionID:    process.SessionID,
+			IssueID:      process.IssueID,
+			Identifier:   process.Identifier,
+			PID:          process.PID,
+			GroupID:      process.GroupID,
+			StartedAt:    process.StartedAt,
+			AgeSeconds:   ageSeconds,
+			RSSBytes:     observation.RSSBytes,
+			ProcessCount: observation.ProcessCount,
+			FinalState:   process.FinalState,
+		})
+	}
+	return summary, nil
 }
 
 func applyNeedsAttentionToProjectHealth(projects []healthProject, stalls []telemetry.DispatchStatus, trackerUnavailable []telemetry.TrackerCondition, forgeUnavailable []telemetry.ForgeCondition, ciUnavailable []telemetry.CICondition, breakers []telemetry.FailureBreaker, outages []telemetry.BackendOutage, tickLiveness []telemetry.TickLiveness, refreshFailures []telemetry.RefreshFailure) []healthProject {
@@ -1534,36 +1623,37 @@ func (s *Server) connectorName() string {
 }
 
 type healthResponse struct {
-	Status               string                       `json:"status"`
-	Version              string                       `json:"version"`
-	Commit               string                       `json:"commit"`
-	ProjectStatus        string                       `json:"project_status"`
-	Mode                 string                       `json:"mode"`
-	Connector            string                       `json:"connector"`
-	SessionsRemaining    int                          `json:"sessions_remaining,omitempty"`
-	Update               telemetry.Update             `json:"update,omitzero"`
-	Checks               map[string]string            `json:"checks"`
-	Environment          healthEnvironment            `json:"environment"`
-	Budgets              []healthBudget               `json:"budgets,omitempty"`
-	Workflows            []healthWorkflowSource       `json:"workflows,omitempty"`
-	TrackerUnavailable   []telemetry.TrackerCondition `json:"tracker_unavailable,omitempty"`
-	ForgeUnavailable     []telemetry.ForgeCondition   `json:"forge_unavailable,omitempty"`
-	CIUnavailable        []telemetry.CICondition      `json:"ci_unavailable,omitempty"`
-	BackendOutages       []telemetry.BackendOutage    `json:"backend_outages,omitempty"`
-	FailureBreakers      []telemetry.FailureBreaker   `json:"failure_breakers,omitempty"`
-	StalenessWarnings    []telemetry.StalenessWarning `json:"staleness_warnings,omitempty"`
-	StrandedIssues       []telemetry.StrandedIssue    `json:"stranded_active_issues,omitempty"`
-	Dispatch             telemetry.DispatchStatus     `json:"dispatch"`
-	DispatchStalls       []telemetry.DispatchStatus   `json:"dispatch_stalls,omitempty"`
-	NotificationFailures []healthnotify.Failure       `json:"health_notification_failures,omitempty"`
-	RefreshFailures      []telemetry.RefreshFailure   `json:"refresh_failures,omitempty"`
-	Projects             []healthProject              `json:"projects,omitempty"`
-	Refresh              telemetry.Refresh            `json:"refresh"`
-	MemoryPressure       telemetry.MemoryPressure     `json:"memory_pressure"`
-	AgentMemory          []healthAgentMemory          `json:"agent_memory"`
-	SnapshotGeneratedAt  time.Time                    `json:"snapshot_generated_at,omitzero"`
-	SnapshotAgeSeconds   int64                        `json:"snapshot_age_seconds"`
-	TickLiveness         []telemetry.TickLiveness     `json:"tick_liveness"`
+	Status                 string                           `json:"status"`
+	Version                string                           `json:"version"`
+	Commit                 string                           `json:"commit"`
+	ProjectStatus          string                           `json:"project_status"`
+	Mode                   string                           `json:"mode"`
+	Connector              string                           `json:"connector"`
+	SessionsRemaining      int                              `json:"sessions_remaining,omitempty"`
+	Update                 telemetry.Update                 `json:"update,omitzero"`
+	Checks                 map[string]string                `json:"checks"`
+	Environment            healthEnvironment                `json:"environment"`
+	Budgets                []healthBudget                   `json:"budgets,omitempty"`
+	Workflows              []healthWorkflowSource           `json:"workflows,omitempty"`
+	TrackerUnavailable     []telemetry.TrackerCondition     `json:"tracker_unavailable,omitempty"`
+	ForgeUnavailable       []telemetry.ForgeCondition       `json:"forge_unavailable,omitempty"`
+	CIUnavailable          []telemetry.CICondition          `json:"ci_unavailable,omitempty"`
+	BackendOutages         []telemetry.BackendOutage        `json:"backend_outages,omitempty"`
+	FailureBreakers        []telemetry.FailureBreaker       `json:"failure_breakers,omitempty"`
+	StalenessWarnings      []telemetry.StalenessWarning     `json:"staleness_warnings,omitempty"`
+	StrandedIssues         []telemetry.StrandedIssue        `json:"stranded_active_issues,omitempty"`
+	Dispatch               telemetry.DispatchStatus         `json:"dispatch"`
+	DispatchStalls         []telemetry.DispatchStatus       `json:"dispatch_stalls,omitempty"`
+	NotificationFailures   []healthnotify.Failure           `json:"health_notification_failures,omitempty"`
+	RefreshFailures        []telemetry.RefreshFailure       `json:"refresh_failures,omitempty"`
+	Projects               []healthProject                  `json:"projects,omitempty"`
+	Refresh                telemetry.Refresh                `json:"refresh"`
+	MemoryPressure         telemetry.MemoryPressure         `json:"memory_pressure"`
+	AgentMemory            []healthAgentMemory              `json:"agent_memory"`
+	SnapshotGeneratedAt    time.Time                        `json:"snapshot_generated_at,omitzero"`
+	SnapshotAgeSeconds     int64                            `json:"snapshot_age_seconds"`
+	TickLiveness           []telemetry.TickLiveness         `json:"tick_liveness"`
+	OrphanedAgentProcesses telemetry.OrphanedAgentProcesses `json:"orphaned_agent_processes"`
 }
 
 type healthAgentMemory struct {

--- a/internal/web/server_test.go
+++ b/internal/web/server_test.go
@@ -41,6 +41,7 @@ import (
 	"github.com/digitaldrywood/detent/internal/hub"
 	"github.com/digitaldrywood/detent/internal/orchestrator"
 	"github.com/digitaldrywood/detent/internal/pause"
+	"github.com/digitaldrywood/detent/internal/procgroup"
 	"github.com/digitaldrywood/detent/internal/project"
 	"github.com/digitaldrywood/detent/internal/provenance"
 	"github.com/digitaldrywood/detent/internal/selector"
@@ -7059,6 +7060,85 @@ func TestHealthReportsDispatchStallAsNeedsHumanAttention(t *testing.T) {
 	}
 	if got := nestedString(t, state, "dispatch", "rate_window_pacing", "permit_ceiling"); got != "2" {
 		t.Fatalf("state dispatch pacing ceiling = %q, want 2", got)
+	}
+}
+
+func TestHealthReportsOnlyWorkerProcessesWithoutLiveSessions(t *testing.T) {
+	now := time.Date(2026, 8, 18, 15, 0, 0, 0, time.UTC)
+	tests := []struct {
+		name                 string
+		terminal             bool
+		live                 bool
+		snapshotBeforeWorker bool
+		wantCount            string
+		wantStatus           string
+	}{
+		{name: "terminal session is orphaned", terminal: true, wantCount: "2", wantStatus: "needs_attention"},
+		{name: "live tracked session is excluded", live: true, wantCount: "0", wantStatus: "ok"},
+		{name: "new session awaits fresh snapshot", snapshotBeforeWorker: true, wantCount: "0", wantStatus: "ok"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			deps := testDeps(t)
+			deps.Store = openWebTestStore(t)
+			deps.WorkerProcesses = deps.Store
+			startedAt := now.Add(-2 * time.Hour)
+			sessionID, err := deps.Store.StartSession(t.Context(), store.SessionStart{
+				IssueID:    "issue-1885",
+				Identifier: "digitaldrywood/detent#1885",
+				StartedAt:  startedAt,
+			})
+			if err != nil {
+				t.Fatalf("StartSession() error = %v", err)
+			}
+			if err := deps.Store.UpdateSessionWorkerProcess(t.Context(), sessionID, store.WorkerProcessIdentity{PID: 1885, GroupID: 1885, StartedAt: startedAt}); err != nil {
+				t.Fatalf("UpdateSessionWorkerProcess() error = %v", err)
+			}
+			if tt.terminal {
+				if err := deps.Store.FinishSession(t.Context(), sessionID, store.SessionFinish{CompletedAt: now.Add(-time.Hour), FinalState: "completed"}); err != nil {
+					t.Fatalf("FinishSession() error = %v", err)
+				}
+			}
+			observedIdentities := 0
+			deps.ObserveProcesses = func(identities []procgroup.Identity) ([]procgroup.Observation, error) {
+				observedIdentities = len(identities)
+				observations := make([]procgroup.Observation, 0, len(identities))
+				for _, identity := range identities {
+					observations = append(observations, procgroup.Observation{Identity: identity, Alive: true, ProcessCount: 2, RSSBytes: 256 * 1024 * 1024})
+				}
+				return observations, nil
+			}
+			snapshot := telemetry.Snapshot{GeneratedAt: now}
+			if tt.snapshotBeforeWorker {
+				snapshot.GeneratedAt = startedAt.Add(-time.Second)
+			}
+			if tt.live {
+				snapshot.Running = []telemetry.Running{{DetentSessionID: sessionID}}
+			}
+			if err := deps.Hub.Publish(snapshot); err != nil {
+				t.Fatalf("Publish() error = %v", err)
+			}
+			server, err := web.NewServer(web.Config{Now: func() time.Time { return now }}, deps)
+			if err != nil {
+				t.Fatalf("NewServer() error = %v", err)
+			}
+
+			health := requestJSON(t, server, http.MethodGet, "/health", http.StatusOK)
+			if got := nestedString(t, health, "orphaned_agent_processes", "count"); got != tt.wantCount {
+				t.Fatalf("orphaned process count = %s, want %s", got, tt.wantCount)
+			}
+			if health["status"] != tt.wantStatus {
+				t.Fatalf("health status = %#v, want %q", health["status"], tt.wantStatus)
+			}
+			wantObserved := 1
+			if tt.live || tt.snapshotBeforeWorker {
+				wantObserved = 0
+			}
+			if observedIdentities != wantObserved {
+				t.Fatalf("observed identities = %d, want %d", observedIdentities, wantObserved)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## Summary

- reap every recorded worker process after completed, failed, cancelled, or duration-limited turns and persist the lifecycle reason
- recover unreaped terminal and prior-lifetime process groups at startup with validated TERM-to-KILL escalation
- expose orphan process count, RSS, age, and identity through health and doctor, with a confirmation-gated repair command

Fixes #1885

## UI Surface Contract

- [x] N/A, or the linked issue explicitly authorizes any high-impact UI surface, layout, density, first-viewport, or responsive visibility tradeoff.
- [x] Persistent top-of-screen messaging is explicitly authorized by the issue, or this PR does not add it.
- [x] Visual changes to primary operator screens include screenshot or browser verification below.

No visual UI changes.

## Test Plan

- [x] `make generate`
- [x] focused lifecycle matrix across store, procgroup, runner, web, CLI, and orchestrator
- [x] `make check` with the CI-pinned golangci-lint v2.1.6; race tests and 78.8% coverage passed