### PR TITLE
fix(gate): complete operational no-PR work

### DIFF
--- a/internal/orchestrator/autopromote.go
+++ b/internal/orchestrator/autopromote.go
@@ -55,6 +55,7 @@ type AutoPromoteAction string
 
 const (
 	AutoPromoteActionPromote     AutoPromoteAction = "promote"
+	AutoPromoteActionComplete    AutoPromoteAction = "complete"
 	AutoPromoteActionRework      AutoPromoteAction = "rework"
 	AutoPromoteActionAwaitReview AutoPromoteAction = "await_review"
 	AutoPromoteActionSkip        AutoPromoteAction = "skip"
@@ -68,6 +69,7 @@ const (
 	AutoPromoteReasonOptoutLabel                     AutoPromoteReason = "optout_label"
 	AutoPromoteReasonLabelNotAllowed                 AutoPromoteReason = "label_not_allowed"
 	AutoPromoteReasonMissingPullRequest              AutoPromoteReason = "missing_pull_request"
+	AutoPromoteReasonOperationalCompletion           AutoPromoteReason = "operational_completion"
 	AutoPromoteReasonPullRequestMerged               AutoPromoteReason = "pull_request_merged"
 	AutoPromoteReasonDraftPullRequest                AutoPromoteReason = "draft_pull_request"
 	AutoPromoteReasonMergeRevocationLimit            AutoPromoteReason = "merge_revocation_limit"
@@ -107,6 +109,7 @@ type AutoPromoteDecision struct {
 	WorkpadStatusInvalidContent  string
 	WorkpadBlockerVerifications  []AutoPromoteWorkpadBlockerVerification
 	WorkpadProseFallbackDisabled bool
+	OperationalEvidence          string
 }
 
 type AutoPromoteWorkpadBlockerVerification struct {
@@ -145,6 +148,12 @@ func EvaluateAutoPromote(
 		autoPromoteApplyWorkpadDecisionFields(&decision, workpad)
 		return decision
 	}
+	if completion, ok := operationalCompletionFromIssue(issue); ok {
+		decision := autoPromoteDecision(AutoPromoteActionComplete, AutoPromoteReasonOperationalCompletion)
+		decision.OperationalEvidence = completion.evidence
+		autoPromoteApplyWorkpadDecisionFields(&decision, workpad)
+		return decision
+	}
 	if gateRequiresPullRequest(cfg.Gate) {
 		if issue.PullRequest != nil &&
 			normalizePullRequestState(issue.PullRequest.State) == "open" &&
@@ -176,6 +185,31 @@ func EvaluateAutoPromote(
 	decision.Findings = autoPromoteFindingsFromGate(gateDecision.Findings)
 	autoPromoteApplyWorkpadDecisionFields(&decision, workpad)
 	return decision
+}
+
+type operationalCompletion struct {
+	evidence   string
+	workpadURL string
+	recordedAt *time.Time
+}
+
+func operationalCompletionFromIssue(issue connector.Issue) (operationalCompletion, bool) {
+	if issue.PullRequest != nil || workAttemptPRNumber(issue) != nil {
+		return operationalCompletion{}, false
+	}
+	signal, ok := autoPromoteIssueWorkpadSignal(issue)
+	if !ok {
+		return operationalCompletion{}, false
+	}
+	evidence, ok := workpad.OperationalCompletion(signal)
+	if !ok {
+		return operationalCompletion{}, false
+	}
+	return operationalCompletion{
+		evidence:   evidence,
+		workpadURL: strings.TrimSpace(signal.CommentURL),
+		recordedAt: signal.RecordedAt,
+	}, true
 }
 
 func autoPromoteHumanReviewRequired(issue connector.Issue, cfg AutoPromoteConfig, gateCfg gate.Config) bool {

--- a/internal/orchestrator/autopromote_test.go
+++ b/internal/orchestrator/autopromote_test.go
@@ -694,6 +694,80 @@ func TestEvaluateAutoPromote(t *testing.T) {
 	}
 }
 
+func TestEvaluateAutoPromoteOperationalCompletion(t *testing.T) {
+	t.Parallel()
+
+	cfg := AutoPromoteConfig{
+		Enabled:        true,
+		TerminalStates: []string{"Done", "Cancelled"},
+		Gate:           gate.Config{Kind: gate.KindCommand},
+	}
+	tests := []struct {
+		name         string
+		body         string
+		pullRequest  *connector.PullRequest
+		wantAction   AutoPromoteAction
+		wantReason   AutoPromoteReason
+		wantEvidence string
+	}{
+		{
+			name:         "declared operational completion",
+			body:         operationalCompletionWorkpadBody("Runner service is healthy and accepting jobs."),
+			wantAction:   AutoPromoteActionComplete,
+			wantReason:   AutoPromoteReasonOperationalCompletion,
+			wantEvidence: "Runner service is healthy and accepting jobs.",
+		},
+		{
+			name:       "ordinary no diff completion",
+			body:       "## Codex Workpad\n\n```detent-status\nschema: 1\nstatus: complete\nblockers: []\nhuman_action: null\n```",
+			wantAction: AutoPromoteActionSkip,
+			wantReason: AutoPromoteReasonMissingPullRequest,
+		},
+		{
+			name:       "operational declaration without evidence",
+			body:       "## Codex Workpad\n\n```detent-status\nschema: 1\nstatus: complete\nfields:\n  completion_kind: operational\nblockers: []\nhuman_action: null\n```",
+			wantAction: AutoPromoteActionSkip,
+			wantReason: AutoPromoteReasonMissingPullRequest,
+		},
+		{
+			name:        "operational declaration with pull request placeholder",
+			body:        operationalCompletionWorkpadBody("Runner service is healthy and accepting jobs."),
+			pullRequest: &connector.PullRequest{HydrationUnavailableReason: "rate_limited"},
+			wantAction:  AutoPromoteActionSkip,
+			wantReason:  AutoPromoteReasonPullRequestHydrationUnavailable,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			issue := autoPromoteTestIssue("issue-operational-completion", nil)
+			issue.PullRequest = tt.pullRequest
+			issue.Comments = []connector.IssueComment{{
+				Body: tt.body,
+				URL:  "https://github.test/comment/operational-completion",
+			}}
+			got := EvaluateAutoPromote(issue, AutoPromoteSummary{
+				PullRequestHydrationUnavailableReason: pullRequestHydrationUnavailableReason(tt.pullRequest),
+			}, cfg, time.Now())
+
+			if got.Action != tt.wantAction {
+				t.Fatalf("Action = %q, want %q", got.Action, tt.wantAction)
+			}
+			if got.Reason != tt.wantReason {
+				t.Fatalf("Reason = %q, want %q", got.Reason, tt.wantReason)
+			}
+			if got.OperationalEvidence != tt.wantEvidence {
+				t.Fatalf("OperationalEvidence = %q, want %q", got.OperationalEvidence, tt.wantEvidence)
+			}
+			if tt.wantAction == AutoPromoteActionComplete && got.WorkpadCommentURL != "https://github.test/comment/operational-completion" {
+				t.Fatalf("WorkpadCommentURL = %q", got.WorkpadCommentURL)
+			}
+		})
+	}
+}
+
 func TestArtifactStatusFromIssue(t *testing.T) {
 	t.Parallel()
 

--- a/internal/orchestrator/autopromote_tick.go
+++ b/internal/orchestrator/autopromote_tick.go
@@ -44,8 +44,10 @@ type autoPromoteTickResult struct {
 }
 
 type staleMergingPullRequestDecision struct {
-	targetState string
-	reason      string
+	targetState         string
+	reason              string
+	operationalEvidence string
+	workpadURL          string
 }
 
 type mergeBaseRefreshDecision struct {
@@ -97,12 +99,14 @@ func (o *Orchestrator) autoPromoteHumanReviewIssues(
 		if issueID == "" {
 			continue
 		}
-		if handled, transitioned := o.parkRepeatedMergeRevocations(ctx, state, issue, now); handled {
-			if transitioned {
-				result.transitioned[issueID] = struct{}{}
-				o.clearAutoPromotedIssueDispatchMemory(state, issueID)
+		if _, operational := operationalCompletionFromIssue(issue); !operational {
+			if handled, transitioned := o.parkRepeatedMergeRevocations(ctx, state, issue, now); handled {
+				if transitioned {
+					result.transitioned[issueID] = struct{}{}
+					o.clearAutoPromotedIssueDispatchMemory(state, issueID)
+				}
+				continue
 			}
-			continue
 		}
 
 		summary := AutoPromoteSummaryFromIssue(issue)
@@ -254,9 +258,7 @@ func (o *Orchestrator) restoreDurableGateWaitCompletions(
 		return
 	}
 	autoCfg := normalizeAutoPromoteConfig(o.cfg.AutoPromote)
-	if !autoPromoteDurableGateWaitTrackingEnabled(autoCfg) {
-		return
-	}
+	gateWaitTracking := autoPromoteDurableGateWaitTrackingEnabled(autoCfg)
 	if state.Completed == nil {
 		state.Completed = map[string]Completed{}
 	}
@@ -268,14 +270,24 @@ func (o *Orchestrator) restoreDurableGateWaitCompletions(
 		if _, ok := state.Completed[issueID]; ok {
 			continue
 		}
-		if !autoPromoteDurableGateWaitTrackedIssue(issue, o.cfg, autoCfg) {
+		completion, operational := operationalCompletionFromIssue(issue)
+		var (
+			attempt store.WorkAttempt
+			ok      bool
+			err     error
+		)
+		switch {
+		case operational:
+			attempt, ok, err = o.latestSuccessfulOperationalCompletionAttempt(ctx, issue, completion)
+		case gateWaitTracking && autoPromoteDurableGateWaitTrackedIssue(issue, o.cfg, autoCfg):
+			attempt, ok, err = o.latestSuccessfulGateWaitAttempt(ctx, issue)
+		default:
 			continue
 		}
-		attempt, ok, err := o.latestSuccessfulGateWaitAttempt(ctx, issue)
 		if err != nil {
 			if o.logger != nil {
 				o.logger.Warn(
-					"restore durable gate-wait completion failed",
+					"restore durable completion failed",
 					"issue_id", issueID,
 					"identifier", issue.Identifier,
 					"error", err,
@@ -297,18 +309,7 @@ func (o *Orchestrator) latestSuccessfulGateWaitAttempt(
 	if o == nil || o.workAttempts == nil {
 		return store.WorkAttempt{}, false, nil
 	}
-	limit := normalizeAutoPromoteConfig(o.cfg.AutoPromote).NoProgressLimit + 1
-	if limit < 20 {
-		limit = 20
-	}
-	attempts, err := o.workAttempts.ListRecentTerminalWorkAttempts(ctx, store.WorkAttemptHistoryQuery{
-		ProjectID:  strings.TrimSpace(o.cfg.Project.ID),
-		IssueID:    strings.TrimSpace(issue.ID),
-		Identifier: strings.TrimSpace(issue.Identifier),
-		IssueURL:   strings.TrimSpace(issue.URL),
-		WorkerType: "agent",
-		Limit:      limit,
-	})
+	attempts, err := o.recentAgentTerminalAttempts(ctx, issue)
 	if err != nil {
 		return store.WorkAttempt{}, false, err
 	}
@@ -322,6 +323,60 @@ func (o *Orchestrator) latestSuccessfulGateWaitAttempt(
 		return attempt, true, nil
 	}
 	return store.WorkAttempt{}, false, nil
+}
+
+func (o *Orchestrator) latestSuccessfulOperationalCompletionAttempt(
+	ctx context.Context,
+	issue connector.Issue,
+	completion operationalCompletion,
+) (store.WorkAttempt, bool, error) {
+	if completion.recordedAt == nil || completion.recordedAt.IsZero() {
+		return store.WorkAttempt{}, false, nil
+	}
+	attempts, err := o.recentAgentTerminalAttempts(ctx, issue)
+	if err != nil {
+		return store.WorkAttempt{}, false, err
+	}
+	for _, attempt := range attempts {
+		if attempt.TerminalState != store.WorkAttemptTerminalSuccess || attempt.CompletedAt.Before(*completion.recordedAt) {
+			continue
+		}
+		record, ok := implementProgressRecordFromAttempt(attempt)
+		if !ok || strings.TrimSpace(record.Outcome) != string(store.WorkAttemptTerminalSuccess) {
+			continue
+		}
+		if strings.TrimSpace(record.WorkpadStatus) != workpad.StatusComplete ||
+			!slices.Contains(record.ProgressKinds, "audit_artifact") {
+			continue
+		}
+		return attempt, true, nil
+	}
+	return store.WorkAttempt{}, false, nil
+}
+
+func (o *Orchestrator) recentAgentTerminalAttempts(
+	ctx context.Context,
+	issue connector.Issue,
+) ([]store.WorkAttempt, error) {
+	if o == nil || o.workAttempts == nil {
+		return nil, nil
+	}
+	limit := normalizeAutoPromoteConfig(o.cfg.AutoPromote).NoProgressLimit + 1
+	if limit < 20 {
+		limit = 20
+	}
+	attempts, err := o.workAttempts.ListRecentTerminalWorkAttempts(ctx, store.WorkAttemptHistoryQuery{
+		ProjectID:  strings.TrimSpace(o.cfg.Project.ID),
+		IssueID:    strings.TrimSpace(issue.ID),
+		Identifier: strings.TrimSpace(issue.Identifier),
+		IssueURL:   strings.TrimSpace(issue.URL),
+		WorkerType: "agent",
+		Limit:      limit,
+	})
+	if err != nil {
+		return nil, err
+	}
+	return attempts, nil
 }
 
 func gateWaitAttemptMatchesPullRequest(attempt store.WorkAttempt, issue connector.Issue) bool {
@@ -740,6 +795,27 @@ func (o *Orchestrator) reconcileStaleMergingPullRequestIssues(
 			continue
 		}
 		decision := staleMergingPullRequestDecisionForIssue(issue, o.cfg)
+		if decision.reason == string(AutoPromoteReasonOperationalCompletion) {
+			completion, _ := operationalCompletionFromIssue(issue)
+			_, completed, err := o.latestSuccessfulOperationalCompletionAttempt(ctx, issue, completion)
+			if err != nil {
+				if o.logger != nil {
+					o.logger.Warn(
+						"stale operational completion reconciliation failed",
+						"issue_id", issueID,
+						"identifier", issue.Identifier,
+						"error", err,
+					)
+				}
+				consumedRepositories = consumeMergeWorkerRepository(consumedRepositories, repository)
+				continue
+			}
+			if !completed {
+				o.logStaleMergingPullRequestDeferred(issue, decision)
+				consumedRepositories = consumeMergeWorkerRepository(consumedRepositories, repository)
+				continue
+			}
+		}
 		if decision.reason == string(AutoPromoteReasonCINotGreen) &&
 			o.retryTransientPullRequestChecks(ctx, state, issue, now, decision.reason) {
 			consumedRepositories = consumeMergeWorkerRepository(consumedRepositories, repository)
@@ -771,6 +847,14 @@ func staleMergingPullRequestDecisionForIssue(issue connector.Issue, cfg Config) 
 	}
 	if closedCompletedIssueNeedsStatusReconciliation(issue, cfg.TerminalStates) {
 		return staleMergingPullRequestDecision{targetState: doneStateName(cfg.TerminalStates), reason: "issue_closed_completed"}
+	}
+	if completion, ok := operationalCompletionFromIssue(issue); ok {
+		return staleMergingPullRequestDecision{
+			targetState:         doneStateName(cfg.TerminalStates),
+			reason:              string(AutoPromoteReasonOperationalCompletion),
+			operationalEvidence: completion.evidence,
+			workpadURL:          completion.workpadURL,
+		}
 	}
 	if _, revoked := mergeApprovalLabelRevoked(issue, cfg); revoked {
 		return staleMergingPullRequestDecision{
@@ -848,10 +932,12 @@ func (o *Orchestrator) applyStaleMergingPullRequestDecision(
 	}
 
 	o.logStaleMergingPullRequestDecision(issue, decision)
-	if normalizeState(decision.targetState) == normalizeState(doneStateName(o.cfg.TerminalStates)) {
-		o.recordMergeCompleted(state, issue, now, decision.targetState)
-	} else {
-		o.recordMergeFailed(state, issue, now, decision.reason, nil)
+	if decision.reason != string(AutoPromoteReasonOperationalCompletion) {
+		if normalizeState(decision.targetState) == normalizeState(doneStateName(o.cfg.TerminalStates)) {
+			o.recordMergeCompleted(state, issue, now, decision.targetState)
+		} else {
+			o.recordMergeFailed(state, issue, now, decision.reason, nil)
+		}
 	}
 	recordStateEvent(state, telemetry.ActivityEvent{
 		At:      now,
@@ -868,6 +954,14 @@ func staleMergingPullRequestComment(issue connector.Issue, decision staleMerging
 	b.WriteString(".")
 	b.WriteString("\n\n- reason: ")
 	b.WriteString(decision.reason)
+	if evidence := strings.TrimSpace(decision.operationalEvidence); evidence != "" {
+		b.WriteString("\n- operational_evidence: ")
+		b.WriteString(evidence)
+	}
+	if url := strings.TrimSpace(decision.workpadURL); url != "" {
+		b.WriteString("\n- workpad_comment: ")
+		b.WriteString(url)
+	}
 	if issue.PullRequest != nil {
 		if url := strings.TrimSpace(issue.PullRequest.URL); url != "" {
 			b.WriteString("\n- pull request: ")
@@ -893,6 +987,12 @@ func (o *Orchestrator) logStaleMergingPullRequestDecision(issue connector.Issue,
 		"reason", decision.reason,
 		"target_state", decision.targetState,
 	)
+	if evidence := strings.TrimSpace(decision.operationalEvidence); evidence != "" {
+		attrs = append(attrs, "operational_evidence", evidence)
+	}
+	if url := strings.TrimSpace(decision.workpadURL); url != "" {
+		attrs = append(attrs, "workpad_comment_url", url)
+	}
 	o.logger.Info("stale_merging_pr_reconciled", attrs...)
 }
 
@@ -2589,6 +2689,8 @@ func autoPromoteCheckFailed(check connector.PullRequestCheck) bool {
 func autoPromoteTargetState(action AutoPromoteAction, cfg AutoPromoteConfig) string {
 	cfg = normalizeAutoPromoteConfig(cfg)
 	switch action {
+	case AutoPromoteActionComplete:
+		return doneStateName(cfg.TerminalStates)
 	case AutoPromoteActionPromote:
 		return cfg.PassState
 	case AutoPromoteActionRework:
@@ -2953,6 +3055,9 @@ func (o *Orchestrator) logAutoPromoteDecision(issue connector.Issue, decision Au
 }
 
 func appendAutoPromoteWorkpadAttrs(attrs []any, decision AutoPromoteDecision) []any {
+	if evidence := strings.TrimSpace(decision.OperationalEvidence); evidence != "" {
+		attrs = append(attrs, "operational_evidence", evidence)
+	}
 	if url := strings.TrimSpace(decision.WorkpadCommentURL); url != "" {
 		attrs = append(attrs, "workpad_comment_url", url)
 	}
@@ -3008,6 +3113,12 @@ func autoPromoteComment(
 		return ""
 	}
 	switch {
+	case decision.Action == AutoPromoteActionComplete:
+		b.WriteString("Completed this issue operationally from ")
+		b.WriteString(sourceState)
+		b.WriteString(" to ")
+		b.WriteString(targetState)
+		b.WriteString(" without a pull request.")
 	case decision.Action == AutoPromoteActionPromote:
 		b.WriteString("Auto-promoted this issue from ")
 		b.WriteString(sourceState)
@@ -3056,6 +3167,10 @@ func autoPromoteComment(
 	if failedChecks := strings.Join(summary.FailedChecks, ", "); failedChecks != "" {
 		b.WriteString("\n- failed_checks: ")
 		b.WriteString(failedChecks)
+	}
+	if evidence := strings.TrimSpace(decision.OperationalEvidence); evidence != "" {
+		b.WriteString("\n- operational_evidence: ")
+		b.WriteString(evidence)
 	}
 	appendAutoPromoteWorkpadCommentFields(&b, decision)
 

--- a/internal/orchestrator/autopromote_tick_test.go
+++ b/internal/orchestrator/autopromote_tick_test.go
@@ -19,6 +19,7 @@ import (
 	runpkg "github.com/digitaldrywood/detent/internal/runner"
 	"github.com/digitaldrywood/detent/internal/scheduler"
 	"github.com/digitaldrywood/detent/internal/store"
+	"github.com/digitaldrywood/detent/internal/workpad"
 )
 
 func TestTickAutoPromoteHumanReviewIssues(t *testing.T) {
@@ -3730,6 +3731,255 @@ func TestTickReconcilesStaleMergingPullRequestStates(t *testing.T) {
 	}
 	if running := state.Running[conflicting.ID]; running.cancel != nil {
 		running.cancel()
+	}
+}
+
+func TestStaleMergingOperationalCompletionReconcilesDone(t *testing.T) {
+	t.Parallel()
+
+	cfg := normalizeConfig(Config{
+		ActiveStates:   []string{"Todo", "In Progress", "Rework", "Merging"},
+		TerminalStates: []string{"Done", "Cancelled"},
+	})
+	tests := []struct {
+		name       string
+		body       string
+		wantState  string
+		wantReason string
+	}{
+		{
+			name:       "declared operational completion",
+			body:       operationalCompletionWorkpadBody("Runner service is healthy and accepting jobs."),
+			wantState:  "Done",
+			wantReason: string(AutoPromoteReasonOperationalCompletion),
+		},
+		{
+			name:       "ordinary no diff completion",
+			body:       "## Codex Workpad\n\n```detent-status\nschema: 1\nstatus: complete\nblockers: []\nhuman_action: null\n```",
+			wantState:  "Human Review",
+			wantReason: string(AutoPromoteReasonMissingPullRequest),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			issue := autoPromoteTickIssue("issue-operational-merging", []string{"bug"}, nil)
+			issue.State = "Merging"
+			issue.Comments = []connector.IssueComment{{
+				Body: tt.body,
+				URL:  "https://github.test/comment/operational-merging",
+			}}
+			decision := staleMergingPullRequestDecisionForIssue(issue, cfg)
+			if decision.targetState != tt.wantState || decision.reason != tt.wantReason {
+				t.Fatalf("decision = %#v, want state %q reason %q", decision, tt.wantState, tt.wantReason)
+			}
+			if tt.wantReason != string(AutoPromoteReasonOperationalCompletion) {
+				return
+			}
+			comment := staleMergingPullRequestComment(issue, decision)
+			if strings.Contains(comment, string(AutoPromoteReasonMissingPullRequest)) {
+				t.Fatalf("comment %q contains missing_pull_request", comment)
+			}
+			for _, fragment := range []string{
+				"operational_evidence: Runner service is healthy and accepting jobs.",
+				"workpad_comment: https://github.test/comment/operational-merging",
+			} {
+				if !strings.Contains(comment, fragment) {
+					t.Fatalf("comment %q missing fragment %q", comment, fragment)
+				}
+			}
+		})
+	}
+}
+
+func TestAutoPromoteOperationalCompletionAfterRuntimeStateLoss(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 8, 18, 18, 30, 0, 0, time.UTC)
+	workpadRecordedAt := now.Add(-2 * time.Minute)
+	successfulAttempt := store.WorkAttempt{
+		ID:            1,
+		StartedAt:     now.Add(-time.Minute),
+		CompletedAt:   now.Add(-30 * time.Second),
+		TerminalState: store.WorkAttemptTerminalSuccess,
+		WorkerMetadataJSON: marshalWorkAttemptJSON(map[string]any{
+			"run_mode": runpkg.RunModeImplement,
+			implementProgressMetadataKey: implementProgressRecord{
+				Outcome:            string(store.WorkAttemptTerminalSuccess),
+				Reason:             implementProgressReasonNonDiff,
+				WorkspaceDiffStats: implementProgressDiffStats{Status: "clean"},
+				WorkpadStatus:      workpad.StatusComplete,
+				ProgressKinds:      []string{"audit_artifact"},
+			},
+		}),
+	}
+	tests := []struct {
+		name        string
+		attempts    []store.WorkAttempt
+		wantRestore bool
+	}{
+		{name: "successful attempt after declaration", attempts: []store.WorkAttempt{successfulAttempt}, wantRestore: true},
+		{name: "no terminal attempt"},
+		{
+			name: "attempt before declaration",
+			attempts: []store.WorkAttempt{func() store.WorkAttempt {
+				attempt := successfulAttempt
+				attempt.CompletedAt = workpadRecordedAt.Add(-time.Second)
+				return attempt
+			}()},
+		},
+		{
+			name: "attempt without audit artifact",
+			attempts: []store.WorkAttempt{func() store.WorkAttempt {
+				attempt := successfulAttempt
+				attempt.WorkerMetadataJSON = marshalWorkAttemptJSON(map[string]any{
+					"run_mode": runpkg.RunModeImplement,
+					implementProgressMetadataKey: implementProgressRecord{
+						Outcome:       string(store.WorkAttemptTerminalSuccess),
+						Reason:        implementProgressReasonNonDiff,
+						WorkpadStatus: workpad.StatusComplete,
+					},
+				})
+				return attempt
+			}()},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			issue := autoPromoteTickIssue("issue-operational-restart", []string{"bug"}, nil)
+			issue.State = "In Progress"
+			issue.Comments = []connector.IssueComment{{
+				Body:      operationalCompletionWorkpadBody("Runner service is healthy and accepting jobs."),
+				URL:       "https://github.test/comment/operational-restart",
+				CreatedAt: &workpadRecordedAt,
+			}}
+			tracker := &autoPromoteTickConnector{stateIssues: []connector.Issue{issue}}
+			attempts := &recordingWorkAttemptStore{history: tt.attempts}
+			cfg := normalizeConfig(Config{
+				AutoPromote: AutoPromoteConfig{
+					Enabled: true,
+					Gate:    gate.Config{Kind: gate.KindCommand},
+				},
+				ActiveStates:   []string{"Todo", "In Progress", "Rework", "Merging"},
+				TerminalStates: []string{"Done", "Cancelled"},
+			})
+			orch := &Orchestrator{cfg: cfg, connector: tracker, workAttempts: attempts}
+			state := newState(cfg)
+
+			orch.restoreDurableGateWaitCompletions(t.Context(), &state, []connector.Issue{issue})
+			_, restored := state.Completed[issue.ID]
+			if restored != tt.wantRestore {
+				t.Fatalf("state.Completed[%q] present = %v, want %v", issue.ID, restored, tt.wantRestore)
+			}
+
+			result := orch.autoPromoteHumanReviewIssues(t.Context(), &state, []connector.Issue{issue}, now)
+			_, transitioned := result.transitioned[issue.ID]
+			if transitioned != tt.wantRestore {
+				t.Fatalf("transitioned[%q] present = %v, want %v", issue.ID, transitioned, tt.wantRestore)
+			}
+			wantUpdates := []autoPromoteTickUpdate(nil)
+			if tt.wantRestore {
+				wantUpdates = []autoPromoteTickUpdate{{issueID: issue.ID, state: "Done"}}
+			}
+			if got, want := tracker.updates, wantUpdates; !reflect.DeepEqual(got, want) {
+				t.Fatalf("updates = %#v, want %#v", got, want)
+			}
+			if len(result.dispatchCandidates) != 0 {
+				t.Fatalf("dispatchCandidates = %#v, want none", result.dispatchCandidates)
+			}
+			if tt.wantRestore {
+				if len(tracker.comments) != 1 || strings.Contains(tracker.comments[0].body, string(AutoPromoteReasonMissingPullRequest)) {
+					t.Fatalf("comments = %#v, want one operational audit comment", tracker.comments)
+				}
+				if !strings.Contains(tracker.comments[0].body, "reason: operational_completion") {
+					t.Fatalf("comment = %q, want operational completion reason", tracker.comments[0].body)
+				}
+			} else if len(tracker.comments) != 0 {
+				t.Fatalf("comments = %#v, want none", tracker.comments)
+			}
+			if len(attempts.historyQueries) != 1 {
+				t.Fatalf("history queries = %d, want 1", len(attempts.historyQueries))
+			}
+		})
+	}
+}
+
+func TestReconcileStaleMergingOperationalCompletionWaitsForDurableAttempt(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 8, 18, 19, 0, 0, 0, time.UTC)
+	workpadRecordedAt := now.Add(-2 * time.Minute)
+	completedAttempt := store.WorkAttempt{
+		CompletedAt:   now.Add(-time.Minute),
+		TerminalState: store.WorkAttemptTerminalSuccess,
+		WorkerMetadataJSON: marshalWorkAttemptJSON(map[string]any{
+			"run_mode": runpkg.RunModeImplement,
+			implementProgressMetadataKey: implementProgressRecord{
+				Outcome:       string(store.WorkAttemptTerminalSuccess),
+				Reason:        implementProgressReasonNonDiff,
+				WorkpadStatus: workpad.StatusComplete,
+				ProgressKinds: []string{"audit_artifact"},
+			},
+		}),
+	}
+	tests := []struct {
+		name     string
+		attempts []store.WorkAttempt
+		wantDone bool
+	}{
+		{name: "waits without terminal attempt"},
+		{name: "completes after terminal attempt", attempts: []store.WorkAttempt{completedAttempt}, wantDone: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			issue := autoPromoteTickIssue("issue-operational-stale-merging", []string{"bug"}, nil)
+			issue.State = "Merging"
+			issue.Comments = []connector.IssueComment{{
+				Body:      operationalCompletionWorkpadBody("Runner service is healthy and accepting jobs."),
+				URL:       "https://github.test/comment/operational-stale-merging",
+				CreatedAt: &workpadRecordedAt,
+			}}
+			tracker := &autoPromoteTickConnector{stateIssues: []connector.Issue{issue}}
+			cfg := normalizeConfig(Config{
+				AutoPromote:    AutoPromoteConfig{Enabled: true, Gate: gate.Config{Kind: gate.KindCommand}},
+				ActiveStates:   []string{"Todo", "In Progress", "Rework", "Merging"},
+				TerminalStates: []string{"Done", "Cancelled"},
+			})
+			orch := &Orchestrator{
+				cfg:          cfg,
+				connector:    tracker,
+				workAttempts: &recordingWorkAttemptStore{history: tt.attempts},
+				logger:       slog.New(slog.NewTextHandler(io.Discard, nil)),
+			}
+			state := newState(cfg)
+
+			transitioned := orch.reconcileStaleMergingPullRequestIssues(t.Context(), &state, []connector.Issue{issue}, now)
+
+			_, done := transitioned[issue.ID]
+			if done != tt.wantDone {
+				t.Fatalf("transitioned[%q] present = %v, want %v", issue.ID, done, tt.wantDone)
+			}
+			wantUpdates := []autoPromoteTickUpdate(nil)
+			if tt.wantDone {
+				wantUpdates = []autoPromoteTickUpdate{{issueID: issue.ID, state: "Done"}}
+			}
+			if !reflect.DeepEqual(tracker.updates, wantUpdates) {
+				t.Fatalf("updates = %#v, want %#v", tracker.updates, wantUpdates)
+			}
+			for _, comment := range tracker.comments {
+				if strings.Contains(comment.body, string(AutoPromoteReasonMissingPullRequest)) {
+					t.Fatalf("comment = %q, must not report missing_pull_request", comment.body)
+				}
+			}
+		})
 	}
 }
 

--- a/internal/orchestrator/completion_transition.go
+++ b/internal/orchestrator/completion_transition.go
@@ -276,7 +276,8 @@ func completedActiveReviewTargetState(
 	case normalizeState(reviewState), normalizeState(autoPromoteMergingState):
 		return ""
 	case normalizeState(autoPromoteReworkState):
-		if gate.Effective(cfg.Gate).Kind != gate.KindArtifact {
+		_, operational := operationalCompletionFromIssue(issue)
+		if !operational && gate.Effective(cfg.Gate).Kind != gate.KindArtifact {
 			return ""
 		}
 	}
@@ -293,6 +294,9 @@ func completedActiveReviewTargetState(
 }
 
 func completedActiveShouldEnterReview(issue connector.Issue, cfg AutoPromoteConfig) bool {
+	if _, ok := operationalCompletionFromIssue(issue); ok {
+		return true
+	}
 	if autoPromoteHumanReviewRequired(issue, cfg, cfg.Gate) {
 		return true
 	}
@@ -335,6 +339,9 @@ func completedActiveFinalStateReviewEligible(finalState string, reviewState stri
 }
 
 func completedActiveIssueReadyForReview(issue connector.Issue, requirePullRequest bool) bool {
+	if _, ok := operationalCompletionFromIssue(issue); ok {
+		return true
+	}
 	if !requirePullRequest {
 		return true
 	}

--- a/internal/orchestrator/completion_transition_test.go
+++ b/internal/orchestrator/completion_transition_test.go
@@ -71,6 +71,22 @@ func TestCompletedActiveReviewTargetState(t *testing.T) {
 			finalState: FinalStateCompleted,
 		},
 		{
+			name: "operational rework completion advances to review",
+			issue: func() connector.Issue {
+				issue := completionTransitionIssue("Rework", "")
+				issue.Comments = []connector.IssueComment{{
+					Body: operationalCompletionWorkpadBody("Runner service is healthy and accepting jobs."),
+				}}
+				return issue
+			}(),
+			finalState: FinalStateCompleted,
+			cfg: AutoPromoteConfig{
+				Enabled: true,
+				Gate:    gate.Config{Kind: gate.KindCommand},
+			},
+			want: autoPromoteSourceState,
+		},
+		{
 			name:       "artifact rework completed without pull request advances to configured review",
 			issue:      completionTransitionIssue("Rework", ""),
 			finalState: FinalStateCompleted,
@@ -366,6 +382,61 @@ func TestTransitionCompletedActiveIssuesLeavesAutoPromoteIssueActive(t *testing.
 	}
 	if len(state.RecentEvents) != 0 {
 		t.Fatalf("RecentEvents = %#v, want none", state.RecentEvents)
+	}
+}
+
+func TestTransitionCompletedActiveIssuesCompletesOperationalWorkWithoutPullRequest(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 8, 18, 18, 0, 0, 0, time.UTC)
+	issue := completionTransitionIssue("In Progress", "")
+	issue.Comments = []connector.IssueComment{{
+		Body: operationalCompletionWorkpadBody("Runner service is healthy and accepting jobs."),
+		URL:  "https://github.test/comment/operational-completion",
+	}}
+	tracker := &autoPromoteTickConnector{stateIssues: []connector.Issue{issue}}
+	cfg := normalizeConfig(Config{
+		AutoPromote: AutoPromoteConfig{
+			Enabled: true,
+			Gate:    gate.Config{Kind: gate.KindCommand},
+		},
+		ActiveStates:   []string{"Todo", "In Progress", "Rework", "Merging"},
+		TerminalStates: []string{"Done", "Cancelled"},
+	})
+	orch := &Orchestrator{cfg: cfg, connector: tracker}
+	state := newState(cfg)
+	state.Completed[issue.ID] = Completed{
+		Issue:       issue,
+		CompletedAt: now.Add(-time.Minute),
+		FinalState:  FinalStateCompleted,
+	}
+
+	result := orch.transitionCompletedActiveIssuesToReview(t.Context(), &state, []connector.Issue{issue}, now)
+
+	if _, ok := result.transitioned[issue.ID]; !ok {
+		t.Fatalf("transitioned[%q] missing", issue.ID)
+	}
+	if got, want := tracker.updates, []autoPromoteTickUpdate{{issueID: issue.ID, state: "Done"}}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("updates = %#v, want %#v", got, want)
+	}
+	if got := state.Completed[issue.ID].Issue.State; got != "Done" {
+		t.Fatalf("Completed issue state = %q, want Done", got)
+	}
+	if len(result.dispatchCandidates) != 0 {
+		t.Fatalf("dispatchCandidates = %#v, want none", result.dispatchCandidates)
+	}
+	if len(tracker.comments) != 1 {
+		t.Fatalf("comments = %#v, want one audit comment", tracker.comments)
+	}
+	for _, fragment := range []string{
+		"Completed this issue operationally",
+		"reason: operational_completion",
+		"operational_evidence: Runner service is healthy and accepting jobs.",
+		"workpad_comment: https://github.test/comment/operational-completion",
+	} {
+		if !strings.Contains(tracker.comments[0].body, fragment) {
+			t.Fatalf("comment %q missing fragment %q", tracker.comments[0].body, fragment)
+		}
 	}
 }
 
@@ -723,6 +794,18 @@ func completionTransitionIssue(state string, pullRequestState string) connector.
 		issue.PullRequest = &connector.PullRequest{State: pullRequestState}
 	}
 	return issue
+}
+
+func operationalCompletionWorkpadBody(evidence string) string {
+	return "## Codex Workpad\n\n```detent-status\n" +
+		"schema: 1\n" +
+		"status: complete\n" +
+		"fields:\n" +
+		"  completion_kind: operational\n" +
+		"  completion_evidence: \"" + evidence + "\"\n" +
+		"blockers: []\n" +
+		"human_action: null\n" +
+		"```"
 }
 
 func artifactCompletionTransitionIssue(state string, status string) connector.Issue {

--- a/internal/orchestrator/merge_revocation.go
+++ b/internal/orchestrator/merge_revocation.go
@@ -101,6 +101,9 @@ func mergeRevocationForIssue(issue connector.Issue, cfg Config, checkPullRequest
 			reason: mergeRevocationStateChanged,
 		}, true
 	}
+	if _, ok := operationalCompletionFromIssue(issue); ok {
+		return mergeRevocation{}, false
+	}
 	if _, revoked := mergeApprovalLabelRevoked(issue, cfg); revoked {
 		return mergeRevocation{
 			issue:       cloneIssue(issue),

--- a/internal/orchestrator/merge_revocation_test.go
+++ b/internal/orchestrator/merge_revocation_test.go
@@ -203,6 +203,47 @@ func TestDraftMergeRevocationUsesConfiguredSourceState(t *testing.T) {
 	}
 }
 
+func TestMergeRevocationDoesNotReportMissingPullRequestForOperationalCompletion(t *testing.T) {
+	t.Parallel()
+
+	cfg := normalizeConfig(Config{AutoPromote: AutoPromoteConfig{SourceState: "Human Review"}})
+	tests := []struct {
+		name        string
+		body        string
+		wantRevoked bool
+		wantReason  string
+	}{
+		{
+			name: "declared operational completion",
+			body: operationalCompletionWorkpadBody("Runner service is healthy and accepting jobs."),
+		},
+		{
+			name:        "ordinary no diff completion",
+			body:        "## Codex Workpad\n\n```detent-status\nschema: 1\nstatus: complete\nblockers: []\nhuman_action: null\n```",
+			wantRevoked: true,
+			wantReason:  mergeRevocationMissingPullRequest,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			issue := connector.Issue{
+				ID:    "issue-operational-merge",
+				State: "Merging",
+				Comments: []connector.IssueComment{{
+					Body: tt.body,
+				}},
+			}
+			revocation, revoked := mergeRevocationForIssue(issue, cfg, true)
+			if revoked != tt.wantRevoked || revocation.reason != tt.wantReason {
+				t.Fatalf("mergeRevocationForIssue() = %#v, %t; want revoked %t reason %q", revocation, revoked, tt.wantRevoked, tt.wantReason)
+			}
+		})
+	}
+}
+
 func TestMergeRevocationCommentsDeduplicateReasonAndHeadSHA(t *testing.T) {
 	t.Parallel()
 

--- a/internal/runner/prompt.go
+++ b/internal/runner/prompt.go
@@ -725,6 +725,18 @@ func appendBlockedHandoffBlock(prompt string) string {
 		"blockers: []\n" +
 		"human_action: null\n" +
 		"```\n\n" +
+		"Operational work completed outside the repository with no diff and no pull request may instead declare:\n\n" +
+		"```detent-status\n" +
+		"schema: 1\n" +
+		"status: complete\n" +
+		"fields:\n" +
+		"  completion_kind: operational\n" +
+		"  completion_evidence: \"what changed on the host and how it was verified\"\n" +
+		"blockers: []\n" +
+		"human_action: null\n" +
+		"```\n\n" +
+		"Use the operational declaration only when the completed work intentionally has no repository change or pull request. " +
+		"An ordinary no-diff completion continues through the configured pull-request gate.\n\n" +
 		"Narrative Workpad sentences are never read as blockers. Legacy fallback during the deprecation window: keep a machine-readable issue-body line such as `Blocked by: #123` or `Depends on: owner/repo#123` only when native dependencies are unavailable and the project has not migrated."
 }
 

--- a/internal/runner/prompt_test.go
+++ b/internal/runner/prompt_test.go
@@ -287,6 +287,9 @@ func TestBuildPromptDocumentsWorkpadStatusContract(t *testing.T) {
 			"blockers: []\n" +
 			"human_action: null\n" +
 			"```",
+		"Operational work completed outside the repository with no diff and no pull request may instead declare:",
+		"completion_kind: operational",
+		"completion_evidence: \"what changed on the host and how it was verified\"",
 	} {
 		if !strings.Contains(prompt, want) {
 			t.Fatalf("prompt missing %q:\n%s", want, prompt)

--- a/internal/workpad/workpad.go
+++ b/internal/workpad/workpad.go
@@ -24,6 +24,10 @@ const (
 	StatusBlocked    = "blocked"
 	StatusComplete   = "complete"
 
+	FieldCompletionKind     = "completion_kind"
+	FieldCompletionEvidence = "completion_evidence"
+	CompletionOperational   = "operational"
+
 	BlockerOwnerOrchestrator = "orchestrator"
 	BlockerOwnerHuman        = "human"
 
@@ -511,6 +515,19 @@ func Reason(signal *Signal) string {
 		parts = append(parts, ref)
 	}
 	return strings.Join(parts, "; ")
+}
+
+func OperationalCompletion(signal *Signal) (string, bool) {
+	if signal == nil || signal.Invalid != nil || signal.Source != SourceStructured ||
+		strings.TrimSpace(signal.Status) != StatusComplete ||
+		strings.TrimSpace(signal.HumanAction) != "" || len(signal.Blockers) > 0 {
+		return "", false
+	}
+	if normalizeToken(signal.Fields[FieldCompletionKind]) != CompletionOperational {
+		return "", false
+	}
+	evidence := strings.TrimSpace(signal.Fields[FieldCompletionEvidence])
+	return evidence, evidence != ""
 }
 
 func normalizeReasonCode(reasonCode string) string {

--- a/internal/workpad/workpad_test.go
+++ b/internal/workpad/workpad_test.go
@@ -166,6 +166,83 @@ func TestSignalFromComment(t *testing.T) {
 	}
 }
 
+func TestOperationalCompletion(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name         string
+		signal       *Signal
+		wantEvidence string
+		want         bool
+	}{
+		{
+			name: "structured complete declaration",
+			signal: &Signal{
+				Source: SourceStructured,
+				Status: StatusComplete,
+				Fields: map[string]string{
+					"completion_kind":     "operational",
+					"completion_evidence": "Runner service is healthy and accepting jobs.",
+				},
+			},
+			wantEvidence: "Runner service is healthy and accepting jobs.",
+			want:         true,
+		},
+		{
+			name: "missing evidence",
+			signal: &Signal{
+				Source: SourceStructured,
+				Status: StatusComplete,
+				Fields: map[string]string{"completion_kind": "operational"},
+			},
+		},
+		{
+			name: "ordinary completion",
+			signal: &Signal{
+				Source: SourceStructured,
+				Status: StatusComplete,
+			},
+		},
+		{
+			name: "blocked declaration",
+			signal: &Signal{
+				Source: SourceStructured,
+				Status: StatusBlocked,
+				Fields: map[string]string{
+					"completion_kind":     "operational",
+					"completion_evidence": "Runner service is healthy.",
+				},
+			},
+		},
+		{
+			name: "completion with blocker",
+			signal: &Signal{
+				Source:   SourceStructured,
+				Status:   StatusComplete,
+				Blockers: []Blocker{{Reason: "waiting for verification"}},
+				Fields: map[string]string{
+					"completion_kind":     "operational",
+					"completion_evidence": "Runner service is healthy.",
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			gotEvidence, got := OperationalCompletion(tt.signal)
+			if got != tt.want {
+				t.Fatalf("OperationalCompletion() ok = %t, want %t", got, tt.want)
+			}
+			if gotEvidence != tt.wantEvidence {
+				t.Fatalf("OperationalCompletion() evidence = %q, want %q", gotEvidence, tt.wantEvidence)
+			}
+		})
+	}
+}
+
 func TestParseRef(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

- accept an explicit, evidenced operational completion declaration from a structured Workpad
- route legitimate no-PR operational work directly to Done with an audit comment
- retain the existing `missing_pull_request` gate for ordinary no-diff work and require durable attempt evidence across restarts

Fixes #1884

## UI Surface Contract

- [x] N/A; this PR has no UI changes.
- [x] This PR does not add persistent top-of-screen messaging.
- [x] N/A; this PR has no visual changes.

## Test Plan

- [x] `make check`