### PR TITLE
fix(orchestrator): stop repeated dispatch loops

### DIFF
--- a/.detent/skills/diagnose-dispatch-loops.md
+++ b/.detent/skills/diagnose-dispatch-loops.md
@@ -1,0 +1,16 @@
+---
+name: diagnose-dispatch-loops
+description: Diagnose and stop Detent issues that repeatedly dispatch in one lane despite successful or mixed terminal outcomes.
+when_to_use: Use when one issue runs repeatedly without lane, diff, commit, or pull-request advancement, especially when attempt numbers reset or other circuit breakers do not fire.
+---
+
+# Diagnose dispatch loops
+
+1. Reproduce the recorded terminal-attempt sequence before testing a suspected narrative cause.
+2. Trace what `attempt_number` represents. Treat a reset retry series separately from durable same-issue, same-lane dispatch history.
+3. Build the progress fingerprint from the lane, workspace diff, workspace head, and pull-request identity and movement. Do not treat Workpad or audit-only changes as product progress.
+4. Count consecutive durable terminal completions regardless of success or failure. Reset only on a changed progress fingerprint or lane advancement, and fail open when required evidence is unavailable.
+5. Require at least two dispatches so one legitimately slow run cannot trip the loop brake.
+6. Park with a distinct loop cause and make that cause sticky against automatic recovery paths that would immediately recreate the loop. Preserve explicit recovery when new deliverable evidence appears.
+7. Surface the repeated issue in health before the trip threshold, including the issue, lane, count, limit, and latest completion time.
+8. Test successful and failed repetition, each reset signal, single-run behavior, the distinct park cause, default activation without spend configuration, and recovery interactions.

--- a/internal/cli/runner.go
+++ b/internal/cli/runner.go
@@ -948,6 +948,7 @@ func mergeSnapshot(current, next telemetry.Snapshot) telemetry.Snapshot {
 	current.CIUnavailable = append(current.CIUnavailable, next.CIUnavailable...)
 	current.BackendOutages = append(current.BackendOutages, next.BackendOutages...)
 	current.FailureBreakers = append(current.FailureBreakers, next.FailureBreakers...)
+	current.DispatchLoops = append(current.DispatchLoops, next.DispatchLoops...)
 	current.DispatchRecoveries = append(current.DispatchRecoveries, next.DispatchRecoveries...)
 	current.StalenessWarnings = append(current.StalenessWarnings, next.StalenessWarnings...)
 	current.StrandedActiveIssues = append(current.StrandedActiveIssues, next.StrandedActiveIssues...)
@@ -1395,6 +1396,11 @@ func stampSnapshotProjectID(snapshot telemetry.Snapshot) telemetry.Snapshot {
 	for i := range snapshot.FailureBreakers {
 		if strings.TrimSpace(snapshot.FailureBreakers[i].ProjectID) == "" {
 			snapshot.FailureBreakers[i].ProjectID = projectID
+		}
+	}
+	for i := range snapshot.DispatchLoops {
+		if strings.TrimSpace(snapshot.DispatchLoops[i].ProjectID) == "" {
+			snapshot.DispatchLoops[i].ProjectID = projectID
 		}
 	}
 	for i := range snapshot.DispatchRecoveries {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -657,6 +657,9 @@ func TestNoProgressSpendLimitConfiguration(t *testing.T) {
 			if workflow.Config.Agent.NoProgressSpendLimitUSD != tt.want {
 				t.Fatalf("NoProgressSpendLimitUSD = %g, want %g", workflow.Config.Agent.NoProgressSpendLimitUSD, tt.want)
 			}
+			if workflow.Config.Agent.AutoPromote.NoProgressLimit != DefaultNoProgressLimit {
+				t.Fatalf("AutoPromote.NoProgressLimit = %d, want %d", workflow.Config.Agent.AutoPromote.NoProgressLimit, DefaultNoProgressLimit)
+			}
 		})
 	}
 }

--- a/internal/orchestrator/blocked_cause_recovery.go
+++ b/internal/orchestrator/blocked_cause_recovery.go
@@ -603,7 +603,7 @@ func blockedReadyPullRequestRecoverableCause(park workflowLaneBlockedRecoveryMet
 	if owner != blockedRecoveryOwnerOrchestrator || strings.TrimSpace(park.RunMode) != RunModeImplement {
 		return false
 	}
-	return cause == strandedUnpushedWorkReason || cause == noProgressLimitReason || cause == repeatedFailureCircuitBreakerCause
+	return cause == strandedUnpushedWorkReason || cause == noProgressLimitReason || cause == dispatchLoopDetectedReason || cause == repeatedFailureCircuitBreakerCause
 }
 
 func (o *Orchestrator) blockedReadyPullRequestDeferredReason(

--- a/internal/orchestrator/blocked_cause_recovery_test.go
+++ b/internal/orchestrator/blocked_cause_recovery_test.go
@@ -1049,6 +1049,7 @@ func TestRecoverBlockedReadyPullRequestToMerging(t *testing.T) {
 		wantMerging  bool
 	}{
 		{name: "recoverable stranded work with ready pull request", cause: strandedUnpushedWorkReason, owner: blockedRecoveryOwnerOrchestrator, snapshot: baseSnapshot, wantMerging: true},
+		{name: "recoverable dispatch loop with ready pull request", cause: dispatchLoopDetectedReason, owner: blockedRecoveryOwnerOrchestrator, snapshot: baseSnapshot, wantMerging: true},
 		{
 			name:  "invalid workpad repeated failure with ready linked pull request",
 			cause: repeatedFailureCircuitBreakerCause,

--- a/internal/orchestrator/dependency_autounblock.go
+++ b/internal/orchestrator/dependency_autounblock.go
@@ -1076,7 +1076,7 @@ func stickyBlockReason(reason string) bool {
 		return true
 	}
 	switch reason {
-	case "rework_limit", string(AutoPromoteReasonMergeRevocationLimit), "no_progress_limit", "workpad_blocked_unactioned", "circuit_breaker", "token_ceiling_circuit_breaker", artifactGateConvergenceReason:
+	case "rework_limit", string(AutoPromoteReasonMergeRevocationLimit), noProgressLimitReason, dispatchLoopDetectedReason, "workpad_blocked_unactioned", "circuit_breaker", "token_ceiling_circuit_breaker", artifactGateConvergenceReason:
 		return true
 	default:
 		return false

--- a/internal/orchestrator/dispatch_loop.go
+++ b/internal/orchestrator/dispatch_loop.go
@@ -1,0 +1,211 @@
+package orchestrator
+
+import (
+	"context"
+	"fmt"
+	"slices"
+	"strings"
+
+	"github.com/digitaldrywood/detent/internal/store"
+)
+
+const dispatchLoopDetectedReason = "dispatch_loop_detected"
+
+const dispatchLoopMinimumDispatches = 2
+
+func dispatchLoopBlockMessage(decision implementCompletionProgressDecision) string {
+	return fmt.Sprintf(
+		"loop detected after %d dispatches without lane, diff, commit, or pull request advancement",
+		decision.ConsecutiveNoProgress,
+	)
+}
+
+type dispatchLoopFingerprint struct {
+	Lane            string
+	PRNumber        int64
+	PRHeadSHA       string
+	FailedChecks    []string
+	FilesChanged    int
+	AddedLines      int
+	RemovedLines    int
+	UnpushedCommits int
+	WorkspaceHead   string
+	DiffFingerprint string
+	DiffStatus      string
+}
+
+func (o *Orchestrator) evaluateDispatchLoopProgress(
+	ctx context.Context,
+	running Running,
+	decision implementCompletionProgressDecision,
+) implementCompletionProgressDecision {
+	if decision.NoProgressLimit <= 0 || dispatchLoopPreservesSpecificDecision(decision) {
+		return decision
+	}
+
+	dispatchLane := normalizeState(firstNonBlank(running.DispatchSourceState, running.Issue.State))
+	currentLane := normalizeState(firstNonBlank(decision.TrackerState, decision.Issue.State))
+	decision.TrackerState = strings.TrimSpace(firstNonBlank(decision.TrackerState, decision.Issue.State))
+	if dispatchLane == "" || currentLane == "" || dispatchLane != currentLane {
+		return resetDispatchLoopDecision(decision)
+	}
+
+	attempts, err := o.recentImplementCompletionAttempts(ctx, decision.Issue, running)
+	if err != nil {
+		if decision.Warning == "" {
+			decision.Warning = err.Error()
+		}
+		return decision
+	}
+
+	current := dispatchLoopFingerprintFromDecision(decision, currentLane)
+	previous, found := latestDispatchLoopFingerprint(attempts, currentLane)
+	if dispatchLoopCurrentAdvanced(decision, current, previous, found) {
+		return resetDispatchLoopDecision(decision)
+	}
+
+	decision.ConsecutiveNoProgress = 1 + consecutiveDispatchLoopAttempts(attempts, current)
+	if decision.BlockReason == noProgressLimitReason {
+		decision.Block = false
+		decision.BlockReason = ""
+	}
+	if decision.ConsecutiveNoProgress < dispatchLoopMinimumDispatches || decision.ConsecutiveNoProgress < decision.NoProgressLimit {
+		return decision
+	}
+
+	decision.Outcome = store.WorkAttemptTerminalNoProgress
+	decision.Reason = dispatchLoopDetectedReason
+	decision.BlockReason = dispatchLoopDetectedReason
+	decision.Block = true
+	decision.DependencyDeferral = false
+	return decision
+}
+
+func dispatchLoopPreservesSpecificDecision(decision implementCompletionProgressDecision) bool {
+	switch strings.TrimSpace(decision.Reason) {
+	case strandedUnpushedWorkReason, workpadBlockedUnactionedReason:
+		return true
+	default:
+		return decision.Block && decision.BlockReason != "" && decision.BlockReason != noProgressLimitReason
+	}
+}
+
+func resetDispatchLoopDecision(decision implementCompletionProgressDecision) implementCompletionProgressDecision {
+	decision.ConsecutiveNoProgress = 0
+	if decision.BlockReason == noProgressLimitReason {
+		decision.Block = false
+		decision.BlockReason = ""
+	}
+	return decision
+}
+
+func dispatchLoopCurrentAdvanced(
+	decision implementCompletionProgressDecision,
+	current dispatchLoopFingerprint,
+	previous dispatchLoopFingerprint,
+	found bool,
+) bool {
+	switch strings.TrimSpace(decision.Reason) {
+	case "pull_request_created_or_updated", implementMergedCompletionReason:
+		return true
+	case "pull_request_hydrator_unavailable", "pull_request_hydration_failed", "pull_request_hydration_unavailable",
+		"attempt_history_lookup_failed", "workspace_diffstat_unavailable", "workspace_diffstat_unavailable_without_pull_request",
+		"workspace_diff_fingerprint_unavailable_without_pull_request", workspaceHeadUnavailableReason,
+		pullRequestHeadUnavailableReason, unpushedRemoteTruthUnavailable:
+		return true
+	}
+	if found {
+		return !dispatchLoopFingerprintEqual(previous, current)
+	}
+	return !implementProgressDiffStatsClean(decision.WorkspaceDiffStats) && diffStatsPresent(decision.WorkspaceDiffStats)
+}
+
+func latestDispatchLoopFingerprint(attempts []store.WorkAttempt, currentLane string) (dispatchLoopFingerprint, bool) {
+	for _, attempt := range attempts {
+		record, ok := implementProgressRecordFromAnyAttempt(attempt)
+		if !ok {
+			continue
+		}
+		return dispatchLoopFingerprintFromRecord(attempt, record, currentLane), true
+	}
+	return dispatchLoopFingerprint{}, false
+}
+
+func consecutiveDispatchLoopAttempts(attempts []store.WorkAttempt, current dispatchLoopFingerprint) int {
+	count := 0
+	for _, attempt := range attempts {
+		record, ok := implementProgressRecordFromAnyAttempt(attempt)
+		if !ok {
+			return count
+		}
+		fingerprint := dispatchLoopFingerprintFromRecord(attempt, record, current.Lane)
+		if !dispatchLoopFingerprintEqual(fingerprint, current) || dispatchLoopRecordAdvanced(record) {
+			return count
+		}
+		count++
+	}
+	return count
+}
+
+func dispatchLoopRecordAdvanced(record implementProgressRecord) bool {
+	if record.ConsecutiveNoProgress > 0 {
+		return false
+	}
+	for _, kind := range record.ProgressKinds {
+		switch strings.TrimSpace(kind) {
+		case "tracker_state_transition", "pull_request", "workspace_diff":
+			return true
+		}
+	}
+	switch strings.TrimSpace(record.Reason) {
+	case "pull_request_created_or_updated", "signature_changed", implementMergedCompletionReason:
+		return true
+	default:
+		return false
+	}
+}
+
+func dispatchLoopFingerprintFromDecision(decision implementCompletionProgressDecision, lane string) dispatchLoopFingerprint {
+	diff := implementProgressDiffStatsFromDiffStats(decision.WorkspaceDiffStats)
+	return dispatchLoopFingerprintFromValues(lane, decision.CurrentSignature, diff)
+}
+
+func dispatchLoopFingerprintFromRecord(attempt store.WorkAttempt, record implementProgressRecord, fallbackLane string) dispatchLoopFingerprint {
+	lane := normalizeState(firstNonBlank(record.TrackerState, attempt.Lane, fallbackLane))
+	return dispatchLoopFingerprintFromValues(lane, record.CurrentSignature.signature(), record.WorkspaceDiffStats)
+}
+
+func dispatchLoopFingerprintFromValues(lane string, signature autoPromoteReworkSignature, diff implementProgressDiffStats) dispatchLoopFingerprint {
+	diffStatus := strings.TrimSpace(diff.Status)
+	if diffStatus == "" && diff.FilesChanged == 0 && diff.AddedLines == 0 && diff.RemovedLines == 0 &&
+		diff.UnpushedCommits == 0 && strings.TrimSpace(diff.HeadSHA) == "" && strings.TrimSpace(diff.Fingerprint) == "" {
+		diffStatus = "clean"
+	}
+	return dispatchLoopFingerprint{
+		Lane:            normalizeState(lane),
+		PRNumber:        signature.PRNumber,
+		PRHeadSHA:       strings.TrimSpace(signature.HeadSHA),
+		FailedChecks:    autoPromoteCanonicalChecks(signature.FailedChecks),
+		FilesChanged:    diff.FilesChanged,
+		AddedLines:      diff.AddedLines,
+		RemovedLines:    diff.RemovedLines,
+		UnpushedCommits: diff.UnpushedCommits,
+		WorkspaceHead:   strings.TrimSpace(diff.HeadSHA),
+		DiffFingerprint: strings.TrimSpace(diff.Fingerprint),
+		DiffStatus:      diffStatus,
+	}
+}
+
+func dispatchLoopFingerprintEqual(left dispatchLoopFingerprint, right dispatchLoopFingerprint) bool {
+	return left.Lane == right.Lane &&
+		left.PRNumber == right.PRNumber &&
+		left.PRHeadSHA == right.PRHeadSHA &&
+		slices.Equal(left.FailedChecks, right.FailedChecks) &&
+		left.FilesChanged == right.FilesChanged &&
+		left.AddedLines == right.AddedLines &&
+		left.RemovedLines == right.RemovedLines &&
+		left.UnpushedCommits == right.UnpushedCommits &&
+		left.WorkspaceHead == right.WorkspaceHead &&
+		left.DiffFingerprint == right.DiffFingerprint &&
+		left.DiffStatus == right.DiffStatus
+}

--- a/internal/orchestrator/dispatch_loop_test.go
+++ b/internal/orchestrator/dispatch_loop_test.go
@@ -1,0 +1,243 @@
+package orchestrator
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/digitaldrywood/detent/internal/connector"
+	runpkg "github.com/digitaldrywood/detent/internal/runner"
+	"github.com/digitaldrywood/detent/internal/scheduler"
+	"github.com/digitaldrywood/detent/internal/store"
+)
+
+func TestEvaluateDispatchLoopProgress(t *testing.T) {
+	t.Parallel()
+
+	clean := implementProgressDiffStats{Status: "clean"}
+	dirty := implementProgressDiffStats{FilesChanged: 1, AddedLines: 4, Fingerprint: "same-diff", Status: "changed"}
+	signature := autoPromoteReworkSignature{PRNumber: 42, HeadSHA: "same-head"}
+	tests := []struct {
+		name            string
+		history         []store.WorkAttempt
+		running         Running
+		decision        implementCompletionProgressDecision
+		wantCount       int
+		wantBlock       bool
+		wantReason      string
+		wantBlockReason string
+		limit           int
+	}{
+		{
+			name: "successful terminal states count",
+			history: []store.WorkAttempt{
+				dispatchLoopHistoryAttempt(2, store.WorkAttemptTerminalSuccess, autoPromoteReworkSignature{}, clean, nil, 2),
+				dispatchLoopHistoryAttempt(1, store.WorkAttemptTerminalSuccess, autoPromoteReworkSignature{}, clean, nil, 1),
+			},
+			running:         dispatchLoopRunning("Rework", DiffStats{Status: "clean"}),
+			decision:        dispatchLoopDecision("Rework", store.WorkAttemptTerminalSuccess, autoPromoteReworkSignature{}, DiffStats{Status: "clean"}),
+			wantCount:       3,
+			wantBlock:       true,
+			wantReason:      dispatchLoopDetectedReason,
+			wantBlockReason: dispatchLoopDetectedReason,
+		},
+		{
+			name: "failure terminal states count",
+			history: []store.WorkAttempt{
+				dispatchLoopHistoryAttempt(2, store.WorkAttemptTerminalFailure, autoPromoteReworkSignature{}, clean, nil, 2),
+				dispatchLoopHistoryAttempt(1, store.WorkAttemptTerminalFailure, autoPromoteReworkSignature{}, clean, nil, 1),
+			},
+			running:         dispatchLoopRunning("Rework", DiffStats{Status: "clean"}),
+			decision:        dispatchLoopDecision("Rework", store.WorkAttemptTerminalFailure, autoPromoteReworkSignature{}, DiffStats{Status: "clean"}),
+			wantCount:       3,
+			wantBlock:       true,
+			wantReason:      dispatchLoopDetectedReason,
+			wantBlockReason: dispatchLoopDetectedReason,
+		},
+		{
+			name:       "single completed run does not trip even with limit one",
+			running:    dispatchLoopRunning("Rework", DiffStats{Status: "clean"}),
+			decision:   dispatchLoopDecision("Rework", store.WorkAttemptTerminalSuccess, autoPromoteReworkSignature{}, DiffStats{Status: "clean"}),
+			wantCount:  1,
+			wantReason: implementDependencyDeferralReason,
+			limit:      1,
+		},
+		{
+			name: "diff advancement resets",
+			history: []store.WorkAttempt{
+				dispatchLoopHistoryAttempt(2, store.WorkAttemptTerminalSuccess, autoPromoteReworkSignature{}, dirty, nil, 2),
+				dispatchLoopHistoryAttempt(1, store.WorkAttemptTerminalSuccess, autoPromoteReworkSignature{}, dirty, nil, 1),
+			},
+			running:    dispatchLoopRunning("Rework", DiffStats{FilesChanged: 2, AddedLines: 8, Fingerprint: "new-diff", Status: "changed"}),
+			decision:   dispatchLoopDecision("Rework", store.WorkAttemptTerminalSuccess, autoPromoteReworkSignature{}, DiffStats{FilesChanged: 2, AddedLines: 8, Fingerprint: "new-diff", Status: "changed"}),
+			wantReason: implementDependencyDeferralReason,
+		},
+		{
+			name: "commit advancement resets",
+			history: []store.WorkAttempt{
+				dispatchLoopHistoryAttempt(2, store.WorkAttemptTerminalSuccess, autoPromoteReworkSignature{}, implementProgressDiffStats{HeadSHA: "old-head", Status: "clean"}, nil, 2),
+				dispatchLoopHistoryAttempt(1, store.WorkAttemptTerminalSuccess, autoPromoteReworkSignature{}, implementProgressDiffStats{HeadSHA: "old-head", Status: "clean"}, nil, 1),
+			},
+			running:    dispatchLoopRunning("Rework", DiffStats{HeadSHA: "new-head", Status: "clean"}),
+			decision:   dispatchLoopDecision("Rework", store.WorkAttemptTerminalSuccess, autoPromoteReworkSignature{}, DiffStats{HeadSHA: "new-head", Status: "clean"}),
+			wantReason: implementDependencyDeferralReason,
+		},
+		{
+			name: "pull request advancement resets",
+			history: []store.WorkAttempt{
+				dispatchLoopHistoryAttempt(2, store.WorkAttemptTerminalSuccess, signature, clean, nil, 2),
+				dispatchLoopHistoryAttempt(1, store.WorkAttemptTerminalSuccess, signature, clean, nil, 1),
+			},
+			running:    dispatchLoopRunning("Rework", DiffStats{Status: "clean"}),
+			decision:   dispatchLoopDecision("Rework", store.WorkAttemptTerminalSuccess, autoPromoteReworkSignature{PRNumber: 42, HeadSHA: "new-head"}, DiffStats{Status: "clean"}),
+			wantReason: implementDependencyDeferralReason,
+		},
+		{
+			name: "lane advancement resets",
+			history: []store.WorkAttempt{
+				dispatchLoopHistoryAttempt(2, store.WorkAttemptTerminalSuccess, autoPromoteReworkSignature{}, clean, nil, 2),
+				dispatchLoopHistoryAttempt(1, store.WorkAttemptTerminalSuccess, autoPromoteReworkSignature{}, clean, nil, 1),
+			},
+			running:    dispatchLoopRunning("Rework", DiffStats{Status: "clean"}),
+			decision:   dispatchLoopDecision("In Progress", store.WorkAttemptTerminalSuccess, autoPromoteReworkSignature{}, DiffStats{Status: "clean"}),
+			wantReason: implementDependencyDeferralReason,
+		},
+		{
+			name: "workpad-only changes do not reset",
+			history: []store.WorkAttempt{
+				dispatchLoopHistoryAttempt(2, store.WorkAttemptTerminalSuccess, autoPromoteReworkSignature{}, clean, []string{"audit_artifact"}, 2),
+				dispatchLoopHistoryAttempt(1, store.WorkAttemptTerminalSuccess, autoPromoteReworkSignature{}, clean, []string{"workpad_predicate"}, 1),
+			},
+			running:         dispatchLoopRunning("Rework", DiffStats{Status: "clean"}),
+			decision:        dispatchLoopDecision("Rework", store.WorkAttemptTerminalSuccess, autoPromoteReworkSignature{}, DiffStats{Status: "clean"}),
+			wantCount:       3,
+			wantBlock:       true,
+			wantReason:      dispatchLoopDetectedReason,
+			wantBlockReason: dispatchLoopDetectedReason,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if tt.limit > 0 {
+				tt.decision.NoProgressLimit = tt.limit
+			}
+			orch := &Orchestrator{
+				cfg: Config{
+					Project:                 scheduler.ProjectCandidate{ID: "detent"},
+					NoProgressSpendLimitUSD: 0,
+				},
+				workAttempts: &implementProgressAttemptStore{history: tt.history},
+			}
+
+			got := orch.evaluateDispatchLoopProgress(t.Context(), tt.running, tt.decision)
+
+			if got.ConsecutiveNoProgress != tt.wantCount || got.Block != tt.wantBlock || got.Reason != tt.wantReason || got.BlockReason != tt.wantBlockReason {
+				t.Fatalf("evaluateDispatchLoopProgress() = count %d block %v reason %q block reason %q, want %d %v %q %q", got.ConsecutiveNoProgress, got.Block, got.Reason, got.BlockReason, tt.wantCount, tt.wantBlock, tt.wantReason, tt.wantBlockReason)
+			}
+		})
+	}
+}
+
+func TestHandleRunResultTripsDispatchLoopAfterFailures(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 8, 18, 15, 0, 0, 0, time.UTC)
+	issue := implementProgressIssueWithoutPR()
+	issue.State = "Rework"
+	history := []store.WorkAttempt{
+		dispatchLoopHistoryAttempt(2, store.WorkAttemptTerminalFailure, autoPromoteReworkSignature{}, implementProgressDiffStats{Status: "clean"}, nil, 2),
+		dispatchLoopHistoryAttempt(1, store.WorkAttemptTerminalFailure, autoPromoteReworkSignature{}, implementProgressDiffStats{Status: "clean"}, nil, 1),
+	}
+	tracker := &implementProgressConnector{refreshed: issue}
+	attempts := &implementProgressAttemptStore{history: history}
+	cfg := normalizeConfig(Config{
+		Project:        scheduler.ProjectCandidate{ID: "detent"},
+		AutoPromote:    AutoPromoteConfig{NoProgressLimit: 3},
+		ActiveStates:   []string{"Rework"},
+		ObservedStates: []string{"Blocked"},
+		TerminalStates: []string{"Done"},
+	})
+	orch := &Orchestrator{cfg: cfg, connector: tracker, workAttempts: attempts}
+	state := newState(cfg)
+	state.Running[issue.ID] = Running{
+		Issue:               issue,
+		Attempt:             1,
+		WorkAttemptID:       42,
+		Mode:                runpkg.RunModeImplement,
+		DispatchSourceState: "Rework",
+		StartedAt:           now.Add(-time.Minute),
+		DiffStats:           DiffStats{Status: "clean"},
+	}
+	state.Claimed[issue.ID] = Claimed{Issue: issue, ClaimedAt: now.Add(-time.Minute)}
+
+	orch.handleRunResult(t.Context(), &state, runpkg.Completion{
+		IssueID:     issue.ID,
+		CompletedAt: now,
+		Request:     runpkg.RunRequest{Mode: runpkg.RunModeImplement},
+		Result:      runpkg.RunResult{FinalState: runpkg.FinalStateFailed, DiffStats: DiffStats{Status: "clean"}},
+		Err:         errors.New("worker failed without progress"),
+	})
+
+	if len(attempts.completions) != 1 || attempts.completions[0].TerminalState != store.WorkAttemptTerminalNoProgress || attempts.completions[0].ErrorClass != dispatchLoopDetectedReason {
+		t.Fatalf("completions = %#v, want dispatch-loop no-progress terminal", attempts.completions)
+	}
+	if blocked, ok := state.Blocked[issue.ID]; !ok || blocked.Reason != dispatchLoopDetectedReason {
+		t.Fatalf("Blocked[%q] = %#v, %v", issue.ID, blocked, ok)
+	}
+	if len(tracker.comments) != 1 || tracker.comments[0].body == "" {
+		t.Fatalf("comments = %#v, want loop-specific park comment", tracker.comments)
+	}
+}
+
+func dispatchLoopRunning(lane string, diff DiffStats) Running {
+	issue := connector.Issue{ID: "issue-loop", Identifier: "digitaldrywood/detent#1886", State: lane}
+	return Running{Issue: issue, DispatchSourceState: lane, DiffStats: diff, Mode: runpkg.RunModeImplement}
+}
+
+func dispatchLoopDecision(lane string, outcome store.WorkAttemptTerminalState, signature autoPromoteReworkSignature, diff DiffStats) implementCompletionProgressDecision {
+	issue := connector.Issue{ID: "issue-loop", Identifier: "digitaldrywood/detent#1886", State: lane}
+	return implementCompletionProgressDecision{
+		Issue:              issue,
+		Outcome:            outcome,
+		Reason:             implementDependencyDeferralReason,
+		CurrentSignature:   signature,
+		WorkspaceDiffStats: diff,
+		TrackerState:       lane,
+		NoProgressLimit:    3,
+	}
+}
+
+func dispatchLoopHistoryAttempt(
+	id int64,
+	terminal store.WorkAttemptTerminalState,
+	signature autoPromoteReworkSignature,
+	diff implementProgressDiffStats,
+	progressKinds []string,
+	count int,
+) store.WorkAttempt {
+	return store.WorkAttempt{
+		ID:            id,
+		ProjectID:     "detent",
+		IssueID:       "issue-loop",
+		Identifier:    "digitaldrywood/detent#1886",
+		WorkerType:    "agent",
+		Lane:          "Rework",
+		Status:        store.WorkAttemptStatusTerminal,
+		TerminalState: terminal,
+		CompletedAt:   time.Date(2026, 8, 18, 14, int(id), 0, 0, time.UTC),
+		WorkerMetadataJSON: marshalWorkAttemptJSON(map[string]any{
+			implementProgressMetadataKey: implementProgressRecord{
+				Outcome:               string(terminal),
+				Reason:                implementDependencyDeferralReason,
+				CurrentSignature:      implementProgressSignatureRecordFromSignature(signature),
+				WorkspaceDiffStats:    diff,
+				TrackerState:          "Rework",
+				ConsecutiveNoProgress: count,
+				NoProgressLimit:       3,
+				ProgressKinds:         progressKinds,
+			},
+		}),
+	}
+}

--- a/internal/orchestrator/implement_progress.go
+++ b/internal/orchestrator/implement_progress.go
@@ -702,6 +702,10 @@ func implementProgressRecordFromAttempt(attempt store.WorkAttempt) (implementPro
 		attempt.TerminalState != store.WorkAttemptTerminalNoProgress {
 		return implementProgressRecord{}, false
 	}
+	return implementProgressRecordFromAnyAttempt(attempt)
+}
+
+func implementProgressRecordFromAnyAttempt(attempt store.WorkAttempt) (implementProgressRecord, bool) {
 	var root struct {
 		CompletionProgress implementProgressRecord `json:"completion_progress"`
 	}
@@ -955,12 +959,16 @@ func (o *Orchestrator) blockImplementProgress(
 		Source:         BlockedSourceProjectStatus,
 		Recovery:       metadata.BlockedRecovery,
 	}
+	eventName := "implement_worker_no_progress_limit"
+	if blockReason == dispatchLoopDetectedReason {
+		eventName = "implement_worker_dispatch_loop_detected"
+	}
 	recordStateEvent(state, telemetry.ActivityEvent{
 		At:      blockedAt,
-		Event:   "implement_worker_no_progress_limit",
+		Event:   eventName,
 		Message: "parked " + issueLabel(issue) + " after implement progress breaker " + blockReason,
 	})
-	telemetry.LogLifecycle(o.logger, slog.LevelError, telemetry.LifecycleSafetyControl, "implement_worker_no_progress_limit", o.runningLifecycleCorrelation(issue, running),
+	telemetry.LogLifecycle(o.logger, slog.LevelError, telemetry.LifecycleSafetyControl, eventName, o.runningLifecycleCorrelation(issue, running),
 		"block_reason", blockReason,
 		"consecutive_no_progress", decision.ConsecutiveNoProgress,
 		"no_progress_limit", decision.NoProgressLimit,
@@ -997,7 +1005,11 @@ func implementProgressRecoveryReason(decision implementCompletionProgressDecisio
 
 func implementProgressBlockComment(issue connector.Issue, decision implementCompletionProgressDecision) string {
 	var b strings.Builder
-	if decision.WorkspaceDiffStats.UnpushedCommits > 0 {
+	if strings.TrimSpace(decision.BlockReason) == dispatchLoopDetectedReason {
+		b.WriteString("Routed this issue to Blocked: loop detected after ")
+		b.WriteString(strconv.Itoa(decision.ConsecutiveNoProgress))
+		b.WriteString(" dispatches without lane, diff, commit, or pull request advancement.")
+	} else if decision.WorkspaceDiffStats.UnpushedCommits > 0 {
 		b.WriteString("Routed this issue to Blocked because the implement worker completed repeatedly with work produced but stranded unpushed in the workspace.")
 	} else {
 		b.WriteString("Routed this issue to Blocked because the implement worker completed repeatedly without deliverable progress.")

--- a/internal/orchestrator/implement_progress_test.go
+++ b/internal/orchestrator/implement_progress_test.go
@@ -39,6 +39,7 @@ func TestHandleRunResultClassifiesImplementWorkerProgress(t *testing.T) {
 		diffStats          DiffStats
 		noProgressLimit    int
 		wantTerminal       store.WorkAttemptTerminalState
+		wantErrorClass     string
 		wantReason         string
 		wantPreviousHead   string
 		wantCurrentHead    string
@@ -47,6 +48,7 @@ func TestHandleRunResultClassifiesImplementWorkerProgress(t *testing.T) {
 		wantComment        string
 		wantRetry          bool
 		wantLogContains    string
+		wantEvent          string
 		wantFailedAdded    []string
 		wantFailedRemoved  []string
 		wantConsecutive    int
@@ -73,6 +75,7 @@ func TestHandleRunResultClassifiesImplementWorkerProgress(t *testing.T) {
 			wantReason:      "first_completed_attempt",
 			wantCurrentHead: "same-head",
 			wantHydrations:  1,
+			wantConsecutive: 1,
 			wantRetry:       true,
 		},
 		{
@@ -99,6 +102,7 @@ func TestHandleRunResultClassifiesImplementWorkerProgress(t *testing.T) {
 			wantReason:      "first_completed_attempt",
 			wantCurrentHead: "same-head",
 			wantHydrations:  1,
+			wantConsecutive: 1,
 			wantRetry:       true,
 		},
 		{
@@ -125,7 +129,7 @@ func TestHandleRunResultClassifiesImplementWorkerProgress(t *testing.T) {
 			noProgressLimit:  3,
 			wantTerminal:     store.WorkAttemptTerminalNoProgress,
 			wantReason:       "unchanged_signature_clean_diff",
-			wantConsecutive:  1,
+			wantConsecutive:  2,
 			wantPreviousHead: "same-head",
 			wantCurrentHead:  "same-head",
 			wantHydrations:   1,
@@ -189,14 +193,14 @@ func TestHandleRunResultClassifiesImplementWorkerProgress(t *testing.T) {
 			diffStats:        DiffStats{Status: "clean"},
 			noProgressLimit:  3,
 			wantTerminal:     store.WorkAttemptTerminalNoProgress,
-			wantReason:       "unchanged_signature_clean_diff",
+			wantReason:       dispatchLoopDetectedReason,
 			wantConsecutive:  3,
 			wantPreviousHead: "same-head",
 			wantCurrentHead:  "same-head",
 			wantHydrations:   1,
 			wantBlocked:      true,
-			wantBlockReason:  noProgressLimitReason,
-			wantComment:      "no_progress_limit",
+			wantBlockReason:  dispatchLoopDetectedReason,
+			wantComment:      "loop detected after 3 dispatches",
 		},
 		{
 			name:               "new pull request creation avoids false no progress",
@@ -219,7 +223,19 @@ func TestHandleRunResultClassifiesImplementWorkerProgress(t *testing.T) {
 			wantRetry:       true,
 		},
 		{
-			name:         "third clean dependency wait defers without tripping limit",
+			name:              "first dependency deferral releases claim without tripping loop",
+			runningIssue:      implementProgressIssueWithoutPR(),
+			diffStats:         DiffStats{Status: "clean"},
+			noProgressLimit:   3,
+			wantTerminal:      store.WorkAttemptTerminalSuccess,
+			wantReason:        implementDependencyDeferralReason,
+			workpadBlockerRef: "digitaldrywood/detent#134",
+			resolvedBlockers:  []connector.Issue{{ID: "blocker-134", Identifier: "digitaldrywood/detent#134", State: "Todo"}},
+			wantConsecutive:   1,
+			wantProgressKinds: nil,
+		},
+		{
+			name:         "third same lane dependency deferral trips dispatch loop",
 			runningIssue: implementProgressIssueWithoutPR(),
 			history: []store.WorkAttempt{
 				implementProgressDependencyDeferralHistoryAttempt(2, "digitaldrywood/detent#134", "Todo"),
@@ -227,14 +243,16 @@ func TestHandleRunResultClassifiesImplementWorkerProgress(t *testing.T) {
 			},
 			diffStats:         DiffStats{Status: "clean"},
 			noProgressLimit:   3,
-			wantTerminal:      store.WorkAttemptTerminalSuccess,
-			wantReason:        "dependency_deferral",
+			wantTerminal:      store.WorkAttemptTerminalNoProgress,
+			wantErrorClass:    dispatchLoopDetectedReason,
+			wantReason:        "dispatch_loop_detected",
 			workpadBlockerRef: "digitaldrywood/detent#134",
 			resolvedBlockers:  []connector.Issue{{ID: "blocker-134", Identifier: "digitaldrywood/detent#134", State: "Todo"}},
-			wantLogContains:   "",
-			wantConsecutive:   0,
-			wantBlocked:       false,
-			wantRetry:         false,
+			wantConsecutive:   3,
+			wantBlocked:       true,
+			wantBlockReason:   "dispatch_loop_detected",
+			wantComment:       "loop detected after 3 dispatches without lane, diff, commit, or pull request advancement",
+			wantEvent:         "implement_worker_dispatch_loop_detected",
 		},
 		{
 			name:              "dependency deferral persistence failure retains claim",
@@ -248,6 +266,7 @@ func TestHandleRunResultClassifiesImplementWorkerProgress(t *testing.T) {
 			completionErr:     errors.New("attempt store unavailable"),
 			wantClaimed:       true,
 			wantLogContains:   "complete work attempt failed",
+			wantConsecutive:   1,
 		},
 		{
 			name:              "malformed blocker ref counts as no progress",
@@ -297,10 +316,10 @@ func TestHandleRunResultClassifiesImplementWorkerProgress(t *testing.T) {
 			diffStats:       DiffStats{Status: "clean"},
 			noProgressLimit: 3,
 			wantTerminal:    store.WorkAttemptTerminalNoProgress,
-			wantReason:      "completed_clean_diff_without_pull_request",
+			wantReason:      dispatchLoopDetectedReason,
 			wantConsecutive: 3,
 			wantBlocked:     true,
-			wantBlockReason: noProgressLimitReason,
+			wantBlockReason: dispatchLoopDetectedReason,
 			wantComment:     "consecutive_no_progress_attempts: 3",
 		},
 		{
@@ -313,14 +332,14 @@ func TestHandleRunResultClassifiesImplementWorkerProgress(t *testing.T) {
 			diffStats:       DiffStats{FilesChanged: 9, AddedLines: 120, RemovedLines: 30, Fingerprint: "same-diff", Status: "changed"},
 			noProgressLimit: 3,
 			wantTerminal:    store.WorkAttemptTerminalNoProgress,
-			wantReason:      "unchanged_workspace_diff_without_pull_request",
+			wantReason:      dispatchLoopDetectedReason,
 			wantConsecutive: 3,
 			wantBlocked:     true,
-			wantBlockReason: noProgressLimitReason,
+			wantBlockReason: dispatchLoopDetectedReason,
 			wantComment:     "consecutive_no_progress_attempts: 3",
 		},
 		{
-			name:         "audit field resets streak despite identical non-empty diff",
+			name:         "audit field does not reset identical non-empty diff loop",
 			runningIssue: implementProgressIssueWithoutPR(),
 			history: []store.WorkAttempt{
 				implementProgressNoPRHistoryAttempt(2, DiffStats{FilesChanged: 9, AddedLines: 120, RemovedLines: 30, Fingerprint: "same-diff", Status: "changed"}, "", ""),
@@ -328,10 +347,13 @@ func TestHandleRunResultClassifiesImplementWorkerProgress(t *testing.T) {
 			},
 			diffStats:          DiffStats{FilesChanged: 9, AddedLines: 120, RemovedLines: 30, Fingerprint: "same-diff", Status: "changed"},
 			noProgressLimit:    3,
-			wantTerminal:       store.WorkAttemptTerminalSuccess,
-			wantReason:         implementProgressReasonNonDiff,
+			wantTerminal:       store.WorkAttemptTerminalNoProgress,
+			wantReason:         dispatchLoopDetectedReason,
 			wantProgressKinds:  []string{"audit_artifact"},
-			wantRetry:          true,
+			wantConsecutive:    3,
+			wantBlocked:        true,
+			wantBlockReason:    dispatchLoopDetectedReason,
+			wantComment:        "loop detected after 3 dispatches",
 			runningWorkpadBody: implementProgressStructuredWorkpad("in_progress", "", nil),
 			currentWorkpadBody: implementProgressStructuredWorkpad("in_progress", "", map[string]string{"duplicate_active_email_groups": "23"}),
 		},
@@ -363,7 +385,7 @@ func TestHandleRunResultClassifiesImplementWorkerProgress(t *testing.T) {
 			wantRetry:         true,
 		},
 		{
-			name:               "verifiable non-diff audit field resets no-progress streak",
+			name:               "verifiable non-diff audit field remains in no-progress streak",
 			runningIssue:       implementProgressIssueWithoutPR(),
 			history:            []store.WorkAttempt{implementProgressLegacyNoPRHistoryAttempt(1)},
 			diffStats:          DiffStats{Status: "clean"},
@@ -371,6 +393,7 @@ func TestHandleRunResultClassifiesImplementWorkerProgress(t *testing.T) {
 			wantTerminal:       store.WorkAttemptTerminalSuccess,
 			wantReason:         "verifiable_non_diff_progress",
 			wantProgressKinds:  []string{"audit_artifact"},
+			wantConsecutive:    2,
 			wantRetry:          true,
 			runningWorkpadBody: implementProgressStructuredWorkpad("in_progress", "", nil),
 			currentWorkpadBody: implementProgressStructuredWorkpad("in_progress", "", map[string]string{"duplicate_active_email_groups": "23"}),
@@ -417,7 +440,7 @@ func TestHandleRunResultClassifiesImplementWorkerProgress(t *testing.T) {
 			workpadBlockerRef:  "digitaldrywood/detent#134",
 		},
 		{
-			name:         "changing blocked human action does not trip",
+			name:         "changing blocked human action does not hide dispatch loop",
 			runningIssue: implementProgressIssueWithoutPR(),
 			history: []store.WorkAttempt{
 				implementProgressNoPRHistoryAttempt(2, DiffStats{FilesChanged: 2, AddedLines: 2, Fingerprint: "same-diff", Status: "changed"}, "Choose the old review path.", "In Progress"),
@@ -425,9 +448,12 @@ func TestHandleRunResultClassifiesImplementWorkerProgress(t *testing.T) {
 			},
 			diffStats:          DiffStats{FilesChanged: 2, AddedLines: 2, Fingerprint: "same-diff", Status: "changed"},
 			noProgressLimit:    3,
-			wantTerminal:       store.WorkAttemptTerminalSuccess,
-			wantReason:         "workspace_diff_present_without_pull_request",
-			wantRetry:          true,
+			wantTerminal:       store.WorkAttemptTerminalNoProgress,
+			wantReason:         dispatchLoopDetectedReason,
+			wantConsecutive:    3,
+			wantBlocked:        true,
+			wantBlockReason:    dispatchLoopDetectedReason,
+			wantComment:        "loop detected after 3 dispatches",
 			workpadHumanAction: "Choose the new review path.",
 		},
 		{
@@ -562,6 +588,9 @@ func TestHandleRunResultClassifiesImplementWorkerProgress(t *testing.T) {
 			if completion.TerminalState != tt.wantTerminal {
 				t.Fatalf("TerminalState = %q, want %q", completion.TerminalState, tt.wantTerminal)
 			}
+			if tt.wantErrorClass != "" && completion.ErrorClass != tt.wantErrorClass {
+				t.Fatalf("ErrorClass = %q, want %q", completion.ErrorClass, tt.wantErrorClass)
+			}
 			record := implementProgressRecordFromCompletion(t, completion)
 			if record.Reason != tt.wantReason {
 				t.Fatalf("metadata reason = %q, want %q", record.Reason, tt.wantReason)
@@ -614,6 +643,15 @@ func TestHandleRunResultClassifiesImplementWorkerProgress(t *testing.T) {
 			}
 			if tt.wantLogContains != "" && !strings.Contains(logs.String(), tt.wantLogContains) {
 				t.Fatalf("logs did not contain %q:\n%s", tt.wantLogContains, logs.String())
+			}
+			if tt.wantEvent != "" {
+				found := false
+				for _, event := range state.RecentEvents {
+					found = found || event.Event == tt.wantEvent
+				}
+				if !found {
+					t.Fatalf("RecentEvents = %#v, want %q", state.RecentEvents, tt.wantEvent)
+				}
 			}
 		})
 	}
@@ -1146,6 +1184,7 @@ func TestStickyBlockReasonIncludesCircuitBreakers(t *testing.T) {
 
 	for _, reason := range []string{
 		noProgressLimitReason,
+		dispatchLoopDetectedReason,
 		workpadBlockedUnactionedReason,
 		"token_ceiling_circuit_breaker",
 		tokenCeilingBlockedReasonPrefix + "observed 16100000 tokens above the 16000000 max_session_tokens ceiling",

--- a/internal/orchestrator/run_completion.go
+++ b/internal/orchestrator/run_completion.go
@@ -311,6 +311,17 @@ func (o *Orchestrator) handleRunResult(ctx context.Context, state *State, event 
 			pushEvidenceRefreshed = warning == ""
 			o.scheduleCITriggerLabel(ctx, running.Issue, gate.Effective(o.cfg.AutoPromote.Gate).RequiredStatusChecks, running.Attempt, true, warning != "")
 		}
+		progress := implementCompletionProgressDecision{}
+		progressMetadata := map[string]any{}
+		if !mergeWorkerIssue(running.Issue) && strings.TrimSpace(event.Request.Mode) != runpkg.RunModePlan && strings.TrimSpace(running.Mode) != runpkg.RunModePlan {
+			if diffStatsPresent(event.Result.DiffStats) {
+				running.DiffStats = event.Result.DiffStats
+			}
+			progress = o.evaluateImplementCompletionProgress(ctx, running, event.Result.FinalState, event.Result.PullRequestUpdated)
+			progress = o.evaluateDispatchLoopProgress(ctx, running, progress)
+			running.Issue = progress.Issue
+			progressMetadata = implementCompletionProgressMetadata(progress)
+		}
 		spendProgress := spendProgressDecision{}
 		if !mergeWorkerIssue(running.Issue) {
 			evidenceWarning := ""
@@ -335,7 +346,13 @@ func (o *Orchestrator) handleRunResult(ctx context.Context, state *State, event 
 			phase = "blocked"
 			statusMessage = "branch " + deliverableRecoveryBranch(deliverableRecoveryErr, running) + " needs delivery recovery"
 		}
-		if spendProgress.Block && deliverableRecoveryErr == nil && !errors.Is(event.Err, runpkg.ErrSessionTokenCeilingExceeded) {
+		if progress.Block && progress.BlockReason == dispatchLoopDetectedReason && deliverableRecoveryErr == nil && !errors.Is(event.Err, runpkg.ErrSessionTokenCeilingExceeded) {
+			terminalState = store.WorkAttemptTerminalNoProgress
+			errorClass = dispatchLoopDetectedReason
+			errorMessage = dispatchLoopBlockMessage(progress)
+			phase = "no_progress"
+			statusMessage = "dispatch loop circuit breaker tripped"
+		} else if spendProgress.Block && deliverableRecoveryErr == nil && !errors.Is(event.Err, runpkg.ErrSessionTokenCeilingExceeded) {
 			terminalState = store.WorkAttemptTerminalNoProgress
 			errorClass = spendProgressReason
 			errorMessage = spendProgressBlockMessage(spendProgress)
@@ -343,7 +360,10 @@ func (o *Orchestrator) handleRunResult(ctx context.Context, state *State, event 
 			statusMessage = "no-progress circuit breaker tripped"
 		}
 		o.recordProjectAttemptOutcome(state, event.IssueID, event.CompletedAt, terminalState, event.Err, errorClass, errorMessage)
-		o.completeDurableWorkAttemptWithMetadata(ctx, state, running, event.CompletedAt, terminalState, errorClass, errorMessage, phase, statusMessage, spendProgressMetadata(spendProgress))
+		o.completeDurableWorkAttemptWithMetadata(ctx, state, running, event.CompletedAt, terminalState, errorClass, errorMessage, phase, statusMessage, mergeWorkAttemptMetadata(
+			progressMetadata,
+			spendProgressMetadata(spendProgress),
+		))
 		attempt := event.RetryAttempt
 		if attempt < 1 {
 			attempt = nextAttempt(running.Attempt)
@@ -352,6 +372,9 @@ func (o *Orchestrator) handleRunResult(ctx context.Context, state *State, event 
 			return
 		}
 		if o.tripTokenCeilingCircuitBreaker(ctx, state, event, running, attempt) {
+			return
+		}
+		if progress.Block && progress.BlockReason == dispatchLoopDetectedReason && o.blockImplementProgress(ctx, state, running, progress, event.CompletedAt) {
 			return
 		}
 		if spendProgress.Block && o.blockSpendProgress(ctx, state, running, spendProgress, event.CompletedAt) {
@@ -457,6 +480,7 @@ func (o *Orchestrator) handleRunResult(ctx context.Context, state *State, event 
 		running.Issue = o.applyArtifactGateCompletionFields(ctx, running.Issue, running.DispatchWorkpadHash, running.DispatchWorkpadRead)
 	}
 	progress := o.evaluateImplementCompletionProgress(ctx, running, finalState, event.Result.PullRequestUpdated)
+	progress = o.evaluateDispatchLoopProgress(ctx, running, progress)
 	running.Issue = progress.Issue
 	if event.Result.PullRequestHeadPushed && !event.Result.CITriggerLabelReapplied {
 		forceReapply := false
@@ -491,6 +515,11 @@ func (o *Orchestrator) handleRunResult(ctx context.Context, state *State, event 
 		terminalState = store.WorkAttemptTerminalNoProgress
 		phase = "no_progress"
 		statusMessage = "worker completed without PR progress"
+		if progress.BlockReason == dispatchLoopDetectedReason {
+			errorClass = dispatchLoopDetectedReason
+			errorMessage = dispatchLoopBlockMessage(progress)
+			statusMessage = "dispatch loop circuit breaker tripped"
+		}
 	}
 	if spendProgress.Block {
 		terminalState = store.WorkAttemptTerminalNoProgress

--- a/internal/orchestrator/snapshot.go
+++ b/internal/orchestrator/snapshot.go
@@ -82,6 +82,7 @@ func (s State) Snapshot(now time.Time) telemetry.Snapshot {
 	boardIssueSnapshots := issueSnapshots(boardIssues, s.AutoPromoteQuietDuration, s.PollInterval, now, s.laneEntries)
 	applyIssueRuntimeIdentities(boardIssueSnapshots, s.Running, s.WorkAttempts)
 	applyIssueCompletionProgress(boardIssueSnapshots, s.WorkAttempts)
+	dispatchLoops := dispatchLoopSnapshots(boardIssueSnapshots, s.WorkAttempts)
 	s.applyGatePendingSnapshots(boardIssueSnapshots, boardIssues)
 	s.applyAutoPromoteDecisionSnapshots(boardIssueSnapshots, boardIssues, now)
 	s.applyArtifactGateWaitDispatchSnapshots(boardIssueSnapshots, boardIssues)
@@ -116,6 +117,7 @@ func (s State) Snapshot(now time.Time) telemetry.Snapshot {
 		BackendOutages:          backendOutageSnapshots(s.BackendOutages),
 		FailureBreakers:         projectFailureBreakerSnapshots(s),
 		MemoryPressure:          s.MemoryPressure,
+		DispatchLoops:           dispatchLoops,
 		DispatchRecoveries:      dispatchRecoverySnapshots(s.DispatchRecoveries, s.PoolName, poolCapacity),
 		StalenessWarnings:       stalenessWarningSnapshots(s.StalenessWarnings),
 		StrandedActiveIssues:    strandedActiveIssues,
@@ -839,7 +841,7 @@ func applyIssueCompletionProgress(issues []telemetry.Issue, attempts []telemetry
 		if latest == nil {
 			continue
 		}
-		record, ok := implementProgressRecordFromAttempt(store.WorkAttempt{
+		record, ok := implementProgressRecordFromAnyAttempt(store.WorkAttempt{
 			TerminalState:      store.WorkAttemptTerminalState(strings.TrimSpace(latest.TerminalState)),
 			WorkerMetadataJSON: latest.WorkerMetadataJSON,
 		})
@@ -854,6 +856,44 @@ func applyIssueCompletionProgress(issues []telemetry.Issue, attempts []telemetry
 			NoProgressLimit:       record.NoProgressLimit,
 		}
 	}
+}
+
+func dispatchLoopSnapshots(issues []telemetry.Issue, attempts []telemetry.WorkAttempt) []telemetry.DispatchLoop {
+	var loops []telemetry.DispatchLoop
+	for _, issue := range issues {
+		progress := issue.CompletionProgress
+		if progress.NoProgressLimit <= 0 || progress.ConsecutiveNoProgress < 2 {
+			continue
+		}
+		var latest *telemetry.WorkAttempt
+		for attemptIndex := range attempts {
+			attempt := &attempts[attemptIndex]
+			if !strings.EqualFold(strings.TrimSpace(attempt.Status), string(store.WorkAttemptStatusTerminal)) ||
+				!snapshotIssueMatches(issue, attempt.IssueID, attempt.Identifier, attempt.IssueURL) {
+				continue
+			}
+			if latest == nil || workAttemptCompletedAfter(*attempt, *latest) {
+				latest = attempt
+			}
+		}
+		var lastCompletedAt *time.Time
+		if latest != nil {
+			lastCompletedAt = cloneTimePointer(latest.CompletedAt)
+		}
+		loops = append(loops, telemetry.DispatchLoop{
+			ProjectID:             issue.ProjectID,
+			IssueID:               issue.ID,
+			Identifier:            issue.Identifier,
+			IssueURL:              issue.URL,
+			Title:                 issue.Title,
+			Lane:                  issue.State,
+			ConsecutiveDispatches: progress.ConsecutiveNoProgress,
+			DispatchLimit:         progress.NoProgressLimit,
+			Tripped:               progress.ConsecutiveNoProgress >= progress.NoProgressLimit,
+			LastCompletedAt:       lastCompletedAt,
+		})
+	}
+	return loops
 }
 
 func snapshotIssueMatches(issue telemetry.Issue, issueID string, identifier string, issueURL string) bool {

--- a/internal/orchestrator/snapshot_test.go
+++ b/internal/orchestrator/snapshot_test.go
@@ -93,6 +93,51 @@ func TestStateSnapshotCarriesLatestCompletionProgress(t *testing.T) {
 	}
 }
 
+func TestStateSnapshotSurfacesActiveDispatchLoops(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 8, 18, 16, 0, 0, 0, time.UTC)
+	tests := []struct {
+		name      string
+		count     int
+		wantLoops int
+		wantTrip  bool
+	}{
+		{name: "single slow run is not an active loop", count: 1},
+		{name: "repetition is surfaced before trip", count: 2, wantLoops: 1},
+		{name: "tripped loop remains visible", count: 3, wantLoops: 1, wantTrip: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			state := newState(normalizeConfig(Config{}))
+			state.BoardIssues = []connector.Issue{{ID: "issue-1886", Identifier: "digitaldrywood/detent#1886", Title: "Stop dispatch loops", State: "Rework"}}
+			state.WorkAttempts = []telemetry.WorkAttempt{{
+				AttemptID:          int64(tt.count),
+				IssueID:            "issue-1886",
+				Identifier:         "digitaldrywood/detent#1886",
+				Status:             string(store.WorkAttemptStatusTerminal),
+				TerminalState:      string(store.WorkAttemptTerminalSuccess),
+				CompletedAt:        timePointer(now),
+				WorkerMetadataJSON: marshalWorkAttemptJSON(map[string]any{implementProgressMetadataKey: implementProgressRecord{Outcome: "success", Reason: implementDependencyDeferralReason, TrackerState: "Rework", ConsecutiveNoProgress: tt.count, NoProgressLimit: 3}}),
+			}}
+
+			loops := state.Snapshot(now).DispatchLoops
+			if len(loops) != tt.wantLoops {
+				t.Fatalf("DispatchLoops = %#v, want %d", loops, tt.wantLoops)
+			}
+			if tt.wantLoops == 0 {
+				return
+			}
+			loop := loops[0]
+			if loop.Identifier != "digitaldrywood/detent#1886" || loop.Lane != "Rework" || loop.ConsecutiveDispatches != tt.count || loop.DispatchLimit != 3 || loop.Tripped != tt.wantTrip || loop.LastCompletedAt == nil || !loop.LastCompletedAt.Equal(now) {
+				t.Fatalf("DispatchLoops[0] = %#v", loop)
+			}
+		})
+	}
+}
+
 func TestStateSnapshotCarriesOperatorStopRecovery(t *testing.T) {
 	t.Parallel()
 

--- a/internal/telemetry/snapshot.go
+++ b/internal/telemetry/snapshot.go
@@ -46,6 +46,7 @@ type Snapshot struct {
 	CIUnavailable           []CICondition       `json:"ci_unavailable,omitempty"`
 	BackendOutages          []BackendOutage     `json:"backend_outages,omitempty"`
 	FailureBreakers         []FailureBreaker    `json:"failure_breakers,omitempty"`
+	DispatchLoops           []DispatchLoop      `json:"dispatch_loops,omitempty"`
 	DispatchRecoveries      []DispatchRecovery  `json:"dispatch_recoveries,omitempty"`
 	StalenessWarnings       []StalenessWarning  `json:"staleness_warnings,omitempty"`
 	StrandedActiveIssues    []StrandedIssue     `json:"stranded_active_issues,omitempty"`
@@ -231,6 +232,19 @@ type FailureBreakerItem struct {
 	RecoveryAction          string `json:"recovery_action,omitempty"`
 	RecoveryReason          string `json:"recovery_reason,omitempty"`
 	RecoveryIntentResumable bool   `json:"recovery_intent_resumable,omitempty"`
+}
+
+type DispatchLoop struct {
+	ProjectID             string     `json:"project_id,omitempty"`
+	IssueID               string     `json:"issue_id,omitempty"`
+	Identifier            string     `json:"identifier,omitempty"`
+	IssueURL              string     `json:"issue_url,omitempty"`
+	Title                 string     `json:"title,omitempty"`
+	Lane                  string     `json:"lane,omitempty"`
+	ConsecutiveDispatches int        `json:"consecutive_dispatches"`
+	DispatchLimit         int        `json:"dispatch_limit"`
+	Tripped               bool       `json:"tripped"`
+	LastCompletedAt       *time.Time `json:"last_completed_at,omitempty"`
 }
 
 type DispatchRecovery struct {

--- a/internal/web/api.go
+++ b/internal/web/api.go
@@ -489,6 +489,7 @@ func stateResponse(snapshot telemetry.Snapshot, generatedAt time.Time, observedA
 		CIUnavailable:      append([]telemetry.CICondition(nil), snapshot.CIUnavailable...),
 		BackendOutages:     append([]telemetry.BackendOutage(nil), snapshot.BackendOutages...),
 		FailureBreakers:    append([]telemetry.FailureBreaker(nil), snapshot.FailureBreakers...),
+		DispatchLoops:      append([]telemetry.DispatchLoop(nil), snapshot.DispatchLoops...),
 		DispatchRecoveries: append([]telemetry.DispatchRecovery(nil), snapshot.DispatchRecoveries...),
 		Dispatch:           snapshot.Dispatch,
 		DispatchStalls:     append([]telemetry.DispatchStatus(nil), snapshot.DispatchStalls...),
@@ -1447,6 +1448,7 @@ type stateAPIResponse struct {
 	CIUnavailable      []telemetry.CICondition      `json:"ci_unavailable,omitempty"`
 	BackendOutages     []telemetry.BackendOutage    `json:"backend_outages,omitempty"`
 	FailureBreakers    []telemetry.FailureBreaker   `json:"failure_breakers,omitempty"`
+	DispatchLoops      []telemetry.DispatchLoop     `json:"dispatch_loops,omitempty"`
 	DispatchRecoveries []telemetry.DispatchRecovery `json:"dispatch_recoveries,omitempty"`
 	Dispatch           telemetry.DispatchStatus     `json:"dispatch"`
 	DispatchStalls     []telemetry.DispatchStatus   `json:"dispatch_stalls,omitempty"`

--- a/internal/web/project_scope.go
+++ b/internal/web/project_scope.go
@@ -75,6 +75,7 @@ func projectScopedSnapshotForProject(snapshot telemetry.Snapshot, selectedProjec
 	out.ForgeUnavailable = scopedForgeUnavailable(snapshot.ForgeUnavailable, selectedProjectID, fallbackProjectID)
 	out.CIUnavailable = scopedCIUnavailable(snapshot.CIUnavailable, selectedProjectID, fallbackProjectID)
 	out.FailureBreakers = scopedFailureBreakers(snapshot.FailureBreakers, selectedProjectID, fallbackProjectID)
+	out.DispatchLoops = scopedDispatchLoops(snapshot.DispatchLoops, selectedProjectID, fallbackProjectID)
 	out.DispatchRecoveries = scopedDispatchRecoveries(snapshot.DispatchRecoveries, selectedProjectID, fallbackProjectID)
 	out.DispatchStalls = scopedDispatchStatuses(snapshot.DispatchStalls, selectedProjectID, fallbackProjectID)
 	out.StalenessWarnings = scopedStalenessWarnings(snapshot.StalenessWarnings, selectedProjectID, fallbackProjectID)
@@ -239,6 +240,20 @@ func scopedFailureBreakers(breakers []telemetry.FailureBreaker, selectedProjectI
 		}
 		if projectID == selectedProjectID {
 			out = append(out, breaker)
+		}
+	}
+	return out
+}
+
+func scopedDispatchLoops(loops []telemetry.DispatchLoop, selectedProjectID string, fallbackProjectID string) []telemetry.DispatchLoop {
+	out := make([]telemetry.DispatchLoop, 0, len(loops))
+	for _, loop := range loops {
+		projectID := strings.TrimSpace(loop.ProjectID)
+		if projectID == "" {
+			projectID = fallbackProjectID
+		}
+		if projectID == selectedProjectID {
+			out = append(out, loop)
 		}
 	}
 	return out

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -1102,6 +1102,7 @@ func (s *Server) health(c echo.Context) error {
 	updateStatus := telemetry.Update{}
 	backendOutages := []telemetry.BackendOutage{}
 	failureBreakers := []telemetry.FailureBreaker{}
+	dispatchLoops := []telemetry.DispatchLoop{}
 	trackerUnavailable := []telemetry.TrackerCondition{}
 	forgeUnavailable := []telemetry.ForgeCondition{}
 	ciUnavailable := []telemetry.CICondition{}
@@ -1138,6 +1139,7 @@ func (s *Server) health(c echo.Context) error {
 			updateStatus = snapshot.Update
 			backendOutages = append(backendOutages, snapshot.BackendOutages...)
 			failureBreakers = append(failureBreakers, snapshot.FailureBreakers...)
+			dispatchLoops = append(dispatchLoops, snapshot.DispatchLoops...)
 			trackerUnavailable = append(trackerUnavailable, snapshot.TrackerUnavailable...)
 			forgeUnavailable = append(forgeUnavailable, snapshot.ForgeUnavailable...)
 			ciUnavailable = append(ciUnavailable, snapshot.CIUnavailable...)
@@ -1181,13 +1183,13 @@ func (s *Server) health(c echo.Context) error {
 		checks["demo_clock"] = s.demo.clock
 	}
 	projectStatus, projectHealth := s.projectHealth()
-	projectHealth = applyNeedsAttentionToProjectHealth(projectHealth, dispatchStalls, trackerUnavailable, forgeUnavailable, ciUnavailable, failureBreakers, backendOutages, tickLiveness, refreshFailures)
+	projectHealth = applyNeedsAttentionToProjectHealth(projectHealth, dispatchStalls, trackerUnavailable, forgeUnavailable, ciUnavailable, failureBreakers, dispatchLoops, backendOutages, tickLiveness, refreshFailures)
 	var budgets []healthBudget
 	var workflows []healthWorkflowSource
 	if status != "draining" {
 		budgets = s.enforcedBudgets()
 		workflows = s.workflowSources()
-		if len(trackerUnavailable) > 0 || len(forgeUnavailable) > 0 || len(ciUnavailable) > 0 || len(dispatchStalls) > 0 || len(failureBreakers) > 0 || len(backendOutages) > 0 || tickLivenessNeedsAttention(tickLiveness) || len(refreshFailures) > 0 || memoryPressure.DispatchHeld || orphanedProcesses.Count > 0 {
+		if len(trackerUnavailable) > 0 || len(forgeUnavailable) > 0 || len(ciUnavailable) > 0 || len(dispatchStalls) > 0 || len(failureBreakers) > 0 || len(dispatchLoops) > 0 || len(backendOutages) > 0 || tickLivenessNeedsAttention(tickLiveness) || len(refreshFailures) > 0 || memoryPressure.DispatchHeld || orphanedProcesses.Count > 0 {
 			status = "needs_attention"
 		}
 		if pauseExitNeedsAttention(projectHealth) {
@@ -1212,6 +1214,7 @@ func (s *Server) health(c echo.Context) error {
 		CIUnavailable:          ciUnavailable,
 		BackendOutages:         backendOutages,
 		FailureBreakers:        failureBreakers,
+		DispatchLoops:          dispatchLoops,
 		StalenessWarnings:      stalenessWarnings,
 		StrandedIssues:         strandedActiveIssues,
 		Dispatch:               dispatch,
@@ -1293,8 +1296,8 @@ func (s *Server) orphanedAgentProcesses(ctx context.Context, snapshot telemetry.
 	return summary, nil
 }
 
-func applyNeedsAttentionToProjectHealth(projects []healthProject, stalls []telemetry.DispatchStatus, trackerUnavailable []telemetry.TrackerCondition, forgeUnavailable []telemetry.ForgeCondition, ciUnavailable []telemetry.CICondition, breakers []telemetry.FailureBreaker, outages []telemetry.BackendOutage, tickLiveness []telemetry.TickLiveness, refreshFailures []telemetry.RefreshFailure) []healthProject {
-	needsAttention := make(map[string]struct{}, len(stalls)+len(trackerUnavailable)+len(forgeUnavailable)+len(ciUnavailable)+len(breakers)+len(outages)+len(tickLiveness))
+func applyNeedsAttentionToProjectHealth(projects []healthProject, stalls []telemetry.DispatchStatus, trackerUnavailable []telemetry.TrackerCondition, forgeUnavailable []telemetry.ForgeCondition, ciUnavailable []telemetry.CICondition, breakers []telemetry.FailureBreaker, loops []telemetry.DispatchLoop, outages []telemetry.BackendOutage, tickLiveness []telemetry.TickLiveness, refreshFailures []telemetry.RefreshFailure) []healthProject {
+	needsAttention := make(map[string]struct{}, len(stalls)+len(trackerUnavailable)+len(forgeUnavailable)+len(ciUnavailable)+len(breakers)+len(loops)+len(outages)+len(tickLiveness))
 	refreshByProject := make(map[string]telemetry.RefreshFailure, len(refreshFailures))
 	for _, stall := range stalls {
 		if projectID := strings.TrimSpace(stall.ProjectID); projectID != "" && stall.Stalled {
@@ -1318,6 +1321,11 @@ func applyNeedsAttentionToProjectHealth(projects []healthProject, stalls []telem
 	}
 	for _, breaker := range breakers {
 		if projectID := strings.TrimSpace(breaker.ProjectID); projectID != "" {
+			needsAttention[projectID] = struct{}{}
+		}
+	}
+	for _, loop := range loops {
+		if projectID := strings.TrimSpace(loop.ProjectID); projectID != "" {
 			needsAttention[projectID] = struct{}{}
 		}
 	}
@@ -1640,6 +1648,7 @@ type healthResponse struct {
 	CIUnavailable          []telemetry.CICondition          `json:"ci_unavailable,omitempty"`
 	BackendOutages         []telemetry.BackendOutage        `json:"backend_outages,omitempty"`
 	FailureBreakers        []telemetry.FailureBreaker       `json:"failure_breakers,omitempty"`
+	DispatchLoops          []telemetry.DispatchLoop         `json:"dispatch_loops,omitempty"`
 	StalenessWarnings      []telemetry.StalenessWarning     `json:"staleness_warnings,omitempty"`
 	StrandedIssues         []telemetry.StrandedIssue        `json:"stranded_active_issues,omitempty"`
 	Dispatch               telemetry.DispatchStatus         `json:"dispatch"`

--- a/internal/web/server_test.go
+++ b/internal/web/server_test.go
@@ -7503,6 +7503,42 @@ func TestHealthReportsStrandedActiveIssues(t *testing.T) {
 	}
 }
 
+func TestHealthReportsActiveDispatchLoops(t *testing.T) {
+	t.Parallel()
+
+	deps := testDeps(t)
+	mustSetWebProject(t, deps.Registry, "detent", false)
+	completedAt := time.Date(2026, 8, 18, 16, 0, 0, 0, time.UTC)
+	if err := deps.Hub.Publish(telemetry.Snapshot{
+		DispatchLoops: []telemetry.DispatchLoop{{
+			ProjectID: "detent", Identifier: "digitaldrywood/pyroapex#1850", Lane: "Rework", ConsecutiveDispatches: 2, DispatchLimit: 3, LastCompletedAt: &completedAt,
+		}},
+	}); err != nil {
+		t.Fatalf("Publish() error = %v", err)
+	}
+	server, err := web.NewServer(web.Config{}, deps)
+	if err != nil {
+		t.Fatalf("NewServer() error = %v", err)
+	}
+
+	payload := requestJSON(t, server, http.MethodGet, "/health", http.StatusOK)
+	if payload["status"] != "needs_attention" {
+		t.Fatalf("status = %#v, want needs_attention", payload["status"])
+	}
+	loops, ok := payload["dispatch_loops"].([]any)
+	if !ok || len(loops) != 1 {
+		t.Fatalf("dispatch_loops = %#v, want one loop", payload["dispatch_loops"])
+	}
+	loop := loops[0].(map[string]any)
+	if loop["identifier"] != "digitaldrywood/pyroapex#1850" || loop["lane"] != "Rework" || loop["consecutive_dispatches"] != float64(2) || loop["dispatch_limit"] != float64(3) || loop["tripped"] != false {
+		t.Fatalf("dispatch_loops[0] = %#v", loop)
+	}
+	projects := payload["projects"].([]any)
+	if len(projects) != 1 || projects[0].(map[string]any)["status"] != "needs_human_attention" {
+		t.Fatalf("projects = %#v, want detent needs_human_attention", projects)
+	}
+}
+
 func TestHealthDistinguishesProcessHealthFromProjectConnectorDegradation(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

- count same-issue, same-lane dispatches across successful and failed terminal states using lane, diff, commit, and pull-request evidence
- park repeated no-progress work with the distinct `dispatch_loop_detected` cause and prevent dependency recovery from immediately recreating the loop
- surface active loops in health and state telemetry before the brake trips, independently of spend configuration

Fixes #1886

## UI Surface Contract

- [x] N/A, or the linked issue explicitly authorizes any high-impact UI surface, layout, density, first-viewport, or responsive visibility tradeoff.
- [x] Persistent top-of-screen messaging is explicitly authorized by the issue, or this PR does not add it.
- [x] Visual changes to primary operator screens include screenshot or browser verification below.

No visual UI surfaces changed; health and state JSON gained structured `dispatch_loops` evidence.

## Test Plan

- [x] `make check`
- [x] `go test ./internal/orchestrator -run ^FuzzSafetyCriticalOrchestratorBoundaries -count=1`
- [x] `go test ./internal/orchestrator -run ^ -fuzz ^FuzzSafetyCriticalOrchestratorBoundaries -fuzztime=10s`
- [x] `implement_progress.go` exact-file coverage: 90.5%