### PR TITLE
fix(pause): fail closed at dispatch gate

### DIFF
--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -15,8 +15,10 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/digitaldrywood/detent/internal/buildinfo"
+	workflowconfig "github.com/digitaldrywood/detent/internal/config"
 	globalconfig "github.com/digitaldrywood/detent/internal/config/global"
 	"github.com/digitaldrywood/detent/internal/orchestrator"
+	"github.com/digitaldrywood/detent/internal/pause"
 	"github.com/digitaldrywood/detent/internal/project"
 )
 
@@ -847,6 +849,8 @@ func validateProjectFlags(cfg globalconfig.Project) error {
 
 type projectEdit func(*globalconfig.Project) error
 
+type projectValidation func(context.Context, globalconfig.Config, int) error
+
 func newPauseProjectCommand(configPath *string, opts options) *cobra.Command {
 	var reason string
 	var untilIssue string
@@ -874,6 +878,8 @@ func newPauseProjectCommand(configPath *string, opts options) *cobra.Command {
 				project.PausedUntilIssue = untilIssue
 				project.PausedUntil = until
 				return nil
+			}, func(ctx context.Context, cfg globalconfig.Config, index int) error {
+				return validatePauseIssueReference(ctx, cfg, index)
 			})
 			if err != nil {
 				return err
@@ -1069,7 +1075,15 @@ func newPromoteCommand(configPath *string, opts options) *cobra.Command {
 	return cmd
 }
 
-func updateProject(ctx context.Context, configPath string, opts options, operation Operation, id string, edit projectEdit) (globalconfig.Project, error) {
+func updateProject(
+	ctx context.Context,
+	configPath string,
+	opts options,
+	operation Operation,
+	id string,
+	edit projectEdit,
+	validations ...projectValidation,
+) (globalconfig.Project, error) {
 	path, err := resolveConfigPath(configPath, opts)
 	if err != nil {
 		return globalconfig.Project{}, err
@@ -1087,6 +1101,14 @@ func updateProject(ctx context.Context, configPath string, opts options, operati
 	if err := edit(&cfg.Projects[index]); err != nil {
 		return globalconfig.Project{}, err
 	}
+	for _, validate := range validations {
+		if validate == nil {
+			continue
+		}
+		if err := validate(ctx, cfg, index); err != nil {
+			return globalconfig.Project{}, err
+		}
+	}
 	if err := opts.write(path, cfg); err != nil {
 		return globalconfig.Project{}, err
 	}
@@ -1099,6 +1121,66 @@ func updateProject(ctx context.Context, configPath string, opts options, operati
 		return globalconfig.Project{}, err
 	}
 	return cfg.Projects[index], nil
+}
+
+func validatePauseIssueReference(ctx context.Context, cfg globalconfig.Config, projectIndex int) error {
+	project := cfg.Projects[projectIndex]
+	reference := strings.TrimSpace(project.PausedUntilIssue)
+	if reference == "" {
+		return nil
+	}
+
+	deps := runtimeDeps{}.withDefaults()
+	trackers := make([]pause.Tracker, 0, len(cfg.Projects))
+	trackerKinds := make(map[string]string, len(cfg.Projects))
+	for _, candidate := range cfg.Projects {
+		workflow, err := loadRuntimeProjectWorkflow(ctx, candidate, deps)
+		if err != nil {
+			if strings.EqualFold(strings.TrimSpace(candidate.ID), strings.TrimSpace(project.ID)) {
+				return pauseIssueValidationError(project.ID, reference, fmt.Errorf("load project workflow: %w", err))
+			}
+			continue
+		}
+		projectID := strings.TrimSpace(candidate.ID)
+		trackers = append(trackers, pause.Tracker{
+			ProjectID:  projectID,
+			Kind:       workflow.Config.Tracker.Kind,
+			Repository: workflow.Config.Tracker.Repository,
+		})
+		trackerKinds[strings.ToLower(projectID)] = workflow.Config.Tracker.Kind
+	}
+
+	resolution, err := pause.ResolveReference(project.ID, reference, trackers)
+	if err != nil {
+		return pauseIssueValidationError(project.ID, reference, err)
+	}
+	kind := trackerKinds[strings.ToLower(strings.TrimSpace(resolution.ProjectID))]
+	if !pauseTrackerSupportsIssueReferences(kind) {
+		return pauseIssueValidationError(
+			project.ID,
+			reference,
+			fmt.Errorf("resolver project %s tracker kind %s cannot resolve issue references", resolution.ProjectID, kind),
+		)
+	}
+	return nil
+}
+
+func pauseTrackerSupportsIssueReferences(kind string) bool {
+	switch strings.ToLower(strings.TrimSpace(kind)) {
+	case workflowconfig.TrackerGitHub, workflowconfig.TrackerGitHubLocal, workflowconfig.TrackerLocalSQLite, workflowconfig.TrackerMemory:
+		return true
+	default:
+		return false
+	}
+}
+
+func pauseIssueValidationError(projectID string, reference string, err error) error {
+	return WrapValidation(fmt.Errorf(
+		"cannot pause project %q with --until-issue %q: %w",
+		strings.TrimSpace(projectID),
+		strings.TrimSpace(reference),
+		err,
+	))
 }
 
 func newRemoveProjectCommand(configPath *string, opts options) *cobra.Command {

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -1650,6 +1650,92 @@ func TestPauseCommandExitConditionFlags(t *testing.T) {
 	}
 }
 
+func TestPauseCommandValidatesIssueReference(t *testing.T) {
+	t.Parallel()
+
+	localWorkflow := `---
+tracker:
+  kind: local_sqlite
+  local_sqlite:
+    path: .detent/work-items.db
+    project_id: video
+---
+Prompt
+`
+	githubWorkflow := `---
+tracker:
+  kind: github
+  repository: digitaldrywood/video-studio
+---
+Prompt
+`
+	tests := []struct {
+		name       string
+		withGitHub bool
+		wantError  string
+		wantPaused bool
+	}{
+		{
+			name:      "rejects cross repository issue without resolver",
+			wantError: "no configured project tracker can resolve GitHub pause exit issue digitaldrywood/video-studio#155",
+		},
+		{
+			name:       "accepts cross repository issue with configured resolver",
+			withGitHub: true,
+			wantPaused: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			local := createProjectFilesWithWorkflow(t, localWorkflow)
+			projects := []globalconfig.Project{{
+				ID:       "video",
+				Workflow: local.workflowPath,
+				Workdir:  local.workdirPath,
+				Weight:   1,
+			}}
+			if tt.withGitHub {
+				github := createProjectFilesWithWorkflow(t, githubWorkflow)
+				projects = append(projects, globalconfig.Project{
+					ID:       "video-studio",
+					Workflow: github.workflowPath,
+					Workdir:  github.workdirPath,
+					Weight:   1,
+				})
+			}
+			configPath := filepath.Join(local.root, "global.yaml")
+			writeGlobalConfig(t, configPath, projects)
+
+			cmd := cli.NewRootCommand(context.Background())
+			cmd.SetOut(&bytes.Buffer{})
+			cmd.SetErr(&bytes.Buffer{})
+			cmd.SetArgs([]string{
+				"--config", configPath,
+				"pause", "video",
+				"--reason", "release hold",
+				"--until-issue", "digitaldrywood/video-studio#155",
+			})
+			err := cmd.Execute()
+			if tt.wantError != "" {
+				if err == nil || !strings.Contains(err.Error(), tt.wantError) {
+					t.Fatalf("Execute() error = %v, want containing %q", err, tt.wantError)
+				}
+			} else if err != nil {
+				t.Fatalf("Execute() error = %v", err)
+			}
+
+			assertProject(t, configPath, "video", func(project globalconfig.Project) {
+				if project.Paused != tt.wantPaused {
+					t.Fatalf("Paused = %t, want %t", project.Paused, tt.wantPaused)
+				}
+			})
+		})
+	}
+}
+
 func TestPauseCommandRejectsInvalidFlags(t *testing.T) {
 	t.Parallel()
 

--- a/internal/cli/pause_monitor.go
+++ b/internal/cli/pause_monitor.go
@@ -78,7 +78,7 @@ func checkPauseExitConditions(ctx context.Context, deps pauseMonitorDeps) {
 			resolution, resolveErr := pause.ResolveReference(configuredProject.ID, configuredProject.PausedUntilIssue, trackers)
 			if resolveErr != nil {
 				recordPauseEvaluationFailure(deps, configuredProject, "", now, resolveErr)
-				deps.logger.Warn(
+				deps.logger.Error(
 					"check project pause exit condition failed",
 					"project_id", configuredProject.ID,
 					"pause_exit_issue", configuredProject.PausedUntilIssue,
@@ -96,7 +96,7 @@ func checkPauseExitConditions(ctx context.Context, deps pauseMonitorDeps) {
 		result, err := pause.Evaluate(ctx, configuredProject, now, trackerRepository, resolver)
 		if err != nil {
 			recordPauseEvaluationFailure(deps, configuredProject, resolverProjectID, now, err)
-			deps.logger.Warn(
+			deps.logger.Error(
 				"check project pause exit condition failed",
 				"project_id", configuredProject.ID,
 				"pause_exit_issue", configuredProject.PausedUntilIssue,

--- a/internal/cli/pause_monitor_test.go
+++ b/internal/cli/pause_monitor_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/digitaldrywood/detent/internal/connector"
 	"github.com/digitaldrywood/detent/internal/connector/memory"
 	"github.com/digitaldrywood/detent/internal/pause"
+	"github.com/digitaldrywood/detent/internal/scheduler"
 )
 
 func TestCheckPauseExitConditionsAutoUnpausesEligibleProjects(t *testing.T) {
@@ -243,6 +244,7 @@ func TestCheckPauseExitConditionsRecordsEvaluationHealth(t *testing.T) {
 			current := clonePauseMonitorConfig(cfg)
 			projectConnector := memory.New(memory.Config{Issues: tt.issues})
 			statuses := map[string]pause.ExitStatus{}
+			var logs bytes.Buffer
 			deps := pauseMonitorDeps{
 				read: func() (globalconfig.Config, error) {
 					return clonePauseMonitorConfig(current), nil
@@ -267,7 +269,7 @@ func TestCheckPauseExitConditionsRecordsEvaluationHealth(t *testing.T) {
 					delete(statuses, projectID)
 				},
 				now:    func() time.Time { return time.Date(2026, 8, 18, 12, 0, 0, 0, time.UTC) },
-				logger: slog.New(slog.NewTextHandler(&bytes.Buffer{}, nil)),
+				logger: slog.New(slog.NewTextHandler(&logs, nil)),
 			}
 			for range tt.ticks {
 				checkPauseExitConditions(context.Background(), deps)
@@ -285,6 +287,112 @@ func TestCheckPauseExitConditionsRecordsEvaluationHealth(t *testing.T) {
 			}
 			if tt.wantError != "" && !strings.Contains(status.LastError, tt.wantError) {
 				t.Fatalf("pause status error = %q, want substring %q", status.LastError, tt.wantError)
+			}
+			if tt.wantError != "" {
+				for _, want := range []string{
+					"level=ERROR",
+					"pause_exit_issue=digitaldrywood/detent#1499",
+					tt.wantError,
+				} {
+					if !strings.Contains(logs.String(), want) {
+						t.Fatalf("pause evaluation log missing %q:\n%s", want, logs.String())
+					}
+				}
+				if !current.Projects[0].Paused {
+					t.Fatal("project automatically unpaused after exit evaluation failure")
+				}
+			}
+		})
+	}
+}
+
+func TestPauseExitEvaluationFailureKeepsDispatchPaused(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name         string
+		trackerKind  string
+		wantLogError string
+	}{
+		{
+			name:         "reference cannot be routed",
+			trackerKind:  "local_sqlite",
+			wantLogError: "no configured project tracker can resolve GitHub pause exit issue",
+		},
+		{
+			name:         "routed issue cannot be evaluated",
+			trackerKind:  "memory",
+			wantLogError: "pause exit issue digitaldrywood/video-studio#155 was not found",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			const reference = "digitaldrywood/video-studio#155"
+			cfg := globalconfig.Config{Projects: []globalconfig.Project{{
+				ID:               "video",
+				Paused:           true,
+				PausedUntilIssue: reference,
+			}}}
+			gate, err := scheduler.NewPoolRegistry([]scheduler.PoolConfig{{
+				Name: scheduler.DefaultPoolName,
+				Scheduler: scheduler.Config{
+					Kind:     "round_robin",
+					Capacity: 1,
+				},
+			}}, []scheduler.ProjectCandidate{{
+				ID:     "video",
+				Weight: 1,
+				Paused: true,
+			}})
+			if err != nil {
+				t.Fatalf("NewPoolRegistry() error = %v", err)
+			}
+			var logs bytes.Buffer
+			wrote := false
+			unpaused := false
+
+			checkPauseExitConditions(t.Context(), pauseMonitorDeps{
+				read: func() (globalconfig.Config, error) {
+					return clonePauseMonitorConfig(cfg), nil
+				},
+				write: func(globalconfig.Config) error {
+					wrote = true
+					return nil
+				},
+				unpause: func(context.Context, string) error {
+					unpaused = true
+					return nil
+				},
+				connectorFor: func(string) connector.Connector {
+					return memory.New(memory.Config{})
+				},
+				trackerKindFor: func(string) string { return tt.trackerKind },
+				logger:         slog.New(slog.NewTextHandler(&logs, nil)),
+			})
+
+			staleCandidate := scheduler.ProjectCandidate{ID: "video", Weight: 1}
+			_, acquired, decision, err := gate.TryAcquireWithDecision(
+				t.Context(),
+				staleCandidate,
+				scheduler.SlotRequest{State: "Todo"},
+				time.Now(),
+			)
+			if err != nil {
+				t.Fatalf("TryAcquireWithDecision() error = %v", err)
+			}
+			if acquired || decision.Reason != scheduler.DispatchGateReasonPaused {
+				t.Fatalf("TryAcquireWithDecision() acquired = %t decision = %#v, want dispatch pause", acquired, decision)
+			}
+			if wrote || unpaused {
+				t.Fatalf("pause exit failure wrote = %t unpaused = %t, want both false", wrote, unpaused)
+			}
+			for _, want := range []string{"level=ERROR", "pause_exit_issue=" + reference, tt.wantLogError} {
+				if !strings.Contains(logs.String(), want) {
+					t.Fatalf("pause evaluation log missing %q:\n%s", want, logs.String())
+				}
 			}
 		})
 	}

--- a/internal/scheduler/global.go
+++ b/internal/scheduler/global.go
@@ -403,12 +403,20 @@ func priorityRank(priority int) int {
 }
 
 func normalizeProjectCandidates(projects []ProjectCandidate) []ProjectCandidate {
+	configured := normalizeConfiguredProjectCandidates(projects)
+	candidates := make([]ProjectCandidate, 0, len(configured))
+	for _, project := range configured {
+		if !project.Paused {
+			candidates = append(candidates, project)
+		}
+	}
+	return candidates
+}
+
+func normalizeConfiguredProjectCandidates(projects []ProjectCandidate) []ProjectCandidate {
 	candidates := make([]ProjectCandidate, 0, len(projects))
 	seen := make(map[string]struct{}, len(projects))
 	for _, project := range projects {
-		if project.Paused {
-			continue
-		}
 		project.ID = normalizeProjectID(project.ID)
 		if project.ID == "" {
 			continue

--- a/internal/scheduler/global_gate.go
+++ b/internal/scheduler/global_gate.go
@@ -89,6 +89,7 @@ type GlobalDispatchGate struct {
 	running        map[uint64]runningProjectSlot
 	selected       map[string]selectedProjectSlot
 	projects       map[string]ProjectCandidate
+	pausedProjects map[string]struct{}
 	projectCycles  map[string]projectCycleState
 	dispatchPauses int
 }
@@ -99,13 +100,14 @@ func NewGlobalDispatchGate(global GlobalScheduler, projects ...ProjectCandidate)
 
 func newGlobalDispatchGate(poolName string, global GlobalScheduler, projects ...ProjectCandidate) *GlobalDispatchGate {
 	gate := &GlobalDispatchGate{
-		poolName:      normalizePoolName(poolName),
-		global:        global,
-		ready:         map[string]readyProjectSlot{},
-		running:       map[uint64]runningProjectSlot{},
-		selected:      map[string]selectedProjectSlot{},
-		projects:      map[string]ProjectCandidate{},
-		projectCycles: map[string]projectCycleState{},
+		poolName:       normalizePoolName(poolName),
+		global:         global,
+		ready:          map[string]readyProjectSlot{},
+		running:        map[uint64]runningProjectSlot{},
+		selected:       map[string]selectedProjectSlot{},
+		projects:       map[string]ProjectCandidate{},
+		pausedProjects: map[string]struct{}{},
+		projectCycles:  map[string]projectCycleState{},
 	}
 	gate.SetProjects(projects)
 	return gate
@@ -156,12 +158,20 @@ func (g *GlobalDispatchGate) SetProjects(projects []ProjectCandidate) {
 		return
 	}
 
-	normalized := normalizeProjectCandidates(projects)
+	configured := normalizeConfiguredProjectCandidates(projects)
 	g.mu.Lock()
 	defer g.mu.Unlock()
 
-	next := make(map[string]ProjectCandidate, len(normalized))
-	for _, project := range normalized {
+	next := make(map[string]ProjectCandidate, len(configured))
+	paused := make(map[string]struct{})
+	for _, project := range configured {
+		if project.Paused {
+			paused[project.ID] = struct{}{}
+			delete(g.ready, project.ID)
+			delete(g.selected, project.ID)
+			delete(g.projectCycles, project.ID)
+			continue
+		}
 		next[project.ID] = project
 	}
 	for projectID := range g.projects {
@@ -178,6 +188,7 @@ func (g *GlobalDispatchGate) SetProjects(projects []ProjectCandidate) {
 		}
 	}
 	g.projects = next
+	g.pausedProjects = paused
 }
 
 func (g *GlobalDispatchGate) PauseDispatch() func() {
@@ -231,6 +242,12 @@ func (g *GlobalDispatchGate) BeginProjectCycle(project ProjectCandidate) {
 
 	g.mu.Lock()
 	defer g.mu.Unlock()
+	if _, paused := g.pausedProjects[project.ID]; paused {
+		delete(g.ready, project.ID)
+		delete(g.selected, project.ID)
+		g.projectCycles[project.ID] = projectCycleState{idle: true}
+		return
+	}
 
 	g.projects[project.ID] = project
 	delete(g.ready, project.ID)
@@ -268,6 +285,12 @@ func (g *GlobalDispatchGate) MarkReady(project ProjectCandidate) {
 
 	g.mu.Lock()
 	defer g.mu.Unlock()
+	if _, paused := g.pausedProjects[project.ID]; paused {
+		delete(g.ready, project.ID)
+		delete(g.selected, project.ID)
+		g.projectCycles[project.ID] = projectCycleState{idle: true}
+		return
+	}
 
 	g.projects[project.ID] = project
 	ready := g.ready[project.ID]
@@ -338,6 +361,12 @@ func (g *GlobalDispatchGate) TryAcquireWithDecision(
 	case <-ctx.Done():
 		return Slot{}, false, DispatchGateDecision{}, ctx.Err()
 	default:
+	}
+	if _, paused := g.pausedProjects[project.ID]; paused {
+		delete(g.ready, project.ID)
+		delete(g.selected, project.ID)
+		g.projectCycles[project.ID] = projectCycleState{idle: true}
+		return Slot{}, false, g.decisionLocked(project.ID, req, DispatchGateReasonPaused), nil
 	}
 
 	g.projects[project.ID] = project

--- a/internal/scheduler/global_gate_test.go
+++ b/internal/scheduler/global_gate_test.go
@@ -152,6 +152,74 @@ func TestGlobalDispatchGateManualPauseIsStrongerThanOpenWindow(t *testing.T) {
 	}
 }
 
+func TestGlobalDispatchGateConfiguredPauseRejectsStaleCandidate(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		configure func(*scheduler.GlobalDispatchGate, scheduler.ProjectCandidate)
+	}{
+		{
+			name: "initial configuration",
+			configure: func(gate *scheduler.GlobalDispatchGate, project scheduler.ProjectCandidate) {
+				gate.SetProjects([]scheduler.ProjectCandidate{project})
+			},
+		},
+		{
+			name: "runtime reconfiguration",
+			configure: func(gate *scheduler.GlobalDispatchGate, project scheduler.ProjectCandidate) {
+				project.Paused = false
+				gate.SetProjects([]scheduler.ProjectCandidate{project})
+				project.Paused = true
+				gate.SetProjects([]scheduler.ProjectCandidate{project})
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			project := scheduler.ProjectCandidate{ID: "paused", Weight: 1, Priority: 0, Paused: true}
+			gate := scheduler.NewGlobalDispatchGate(scheduler.NewStrictPriority(scheduler.Config{Capacity: 1}))
+			tt.configure(gate, project)
+
+			project.Paused = false
+			gate.BeginProjectCycle(project)
+			gate.MarkReady(project)
+			active := scheduler.ProjectCandidate{ID: "active", Weight: 1, Priority: 2}
+			slot, ok, decision, err := gate.TryAcquireWithDecision(
+				t.Context(),
+				active,
+				scheduler.SlotRequest{State: "Todo"},
+				time.Now(),
+			)
+			if err != nil {
+				t.Fatalf("active TryAcquireWithDecision() error = %v", err)
+			}
+			if !ok || decision.Reason != scheduler.DispatchGateReasonGranted {
+				t.Fatalf("active TryAcquireWithDecision() ok = %t decision = %#v, want grant", ok, decision)
+			}
+			if err := gate.Release(slot); err != nil {
+				t.Fatalf("Release() error = %v", err)
+			}
+
+			_, ok, decision, err = gate.TryAcquireWithDecision(
+				t.Context(),
+				project,
+				scheduler.SlotRequest{State: "Todo"},
+				time.Now(),
+			)
+			if err != nil {
+				t.Fatalf("TryAcquireWithDecision() error = %v", err)
+			}
+			if ok || decision.Reason != scheduler.DispatchGateReasonPaused {
+				t.Fatalf("TryAcquireWithDecision() ok = %t decision = %#v, want configured pause", ok, decision)
+			}
+		})
+	}
+}
+
 func TestGlobalDispatchGateUsesConfiguredProjectSelection(t *testing.T) {
 	t.Parallel()
 

--- a/internal/scheduler/pool_registry.go
+++ b/internal/scheduler/pool_registry.go
@@ -357,7 +357,7 @@ func (r *PoolRegistry) Release(slot Slot) error {
 }
 
 func (r *PoolRegistry) setProjectsLocked(projects []ProjectCandidate) {
-	normalized := normalizeProjectCandidates(projects)
+	normalized := normalizeConfiguredProjectCandidates(projects)
 	projectPools := make(map[string]string, len(normalized))
 	grouped := make(map[string][]ProjectCandidate, len(r.active))
 	for _, project := range normalized {


### PR DESCRIPTION
## Summary

- retain configured project pauses at the dispatch gate so stale orchestrator candidates cannot acquire or reserve slots
- validate `pause --until-issue` against compatible configured trackers before writing global config
- log pause exit evaluation failures at ERROR with the unresolved reference and preserve the pause

Fixes #1892

## UI Surface Contract

- [x] N/A, or the linked issue explicitly authorizes any high-impact UI surface, layout, density, first-viewport, or responsive visibility tradeoff.
- [x] Persistent top-of-screen messaging is explicitly authorized by the issue, or this PR does not add it.
- [x] Visual changes to primary operator screens include screenshot or browser verification below. N/A: no UI changes in this PR.

## Test Plan

- [x] `make check`
- [x] `go test ./internal/orchestrator -run '^$' -fuzz=. -fuzztime=30s`
- [x] regression covers exit-check error followed by a stale dispatch-slot request
