### PR TITLE
fix(health): distinguish refresh pacing

### DIFF
--- a/.detent/skills/deterministic-htmx-lifecycle-testing.md
+++ b/.detent/skills/deterministic-htmx-lifecycle-testing.md
@@ -1,0 +1,14 @@
+---
+name: deterministic-htmx-lifecycle-testing
+description: Stabilize HTMX browser tests that dispatch synthetic lifecycle events without racing the framework's own DOM swaps.
+when_to_use: Use when a focused HTMX test passes but a serial browser suite exposes duplicate nodes, settling classes, or assertions that race a synthetic lifecycle event.
+---
+
+# Test HTMX lifecycle behavior deterministically
+
+- Reproduce the failure in the full serial file and inspect the transient DOM before changing waits.
+- Trace both application listeners and HTMX's default handling for the dispatched lifecycle event. A synthetic event can exercise framework mutation as well as application behavior.
+- Remove impossible target and payload combinations. Test only event shapes the server and HTMX extension can produce in normal operation.
+- Preserve the behavior contract with realistic same-state and changed-state cases instead of asserting before an unintended swap wins a race.
+- Wait on observable completion conditions such as the intended element, settled DOM, or application state. Do not use sleeps or assertions that depend on catching a transient frame.
+- Run the focused case, the complete serial file with retries disabled, and the repository's full browser and validation gates.

--- a/docs/dashboard-api.md
+++ b/docs/dashboard-api.md
@@ -211,7 +211,13 @@ Useful endpoints:
 State responses calculate `snapshot_age_seconds` when the request is served,
 so counts remain attributable to their producer timestamp even if snapshot
 publication stops. Refresh objects include `next_refresh_overdue`; an explicit
-`ready` status becomes `degraded` once `next_refresh_at` is in the past.
+`ready` status becomes `behind` once `next_refresh_at` is in the past. `behind`
+is a pacing state and keeps successful tracker data operational. The refresh
+object reports `behind_by_seconds`, each project reports
+`last_duration_seconds`, and the fleet reports `observed_sweep_seconds`.
+`stale_after_seconds` expands with the observed multi-project sweep and includes
+headroom. A refresh becomes `degraded` only after that window is exceeded or a
+refresh source reaches its failure threshold.
 `/health` also reports `snapshot_generated_at`, `snapshot_age_seconds`, the
 current refresh object, per-project `tick_liveness`, and
 `orphaned_agent_processes` with process and session counts, total RSS, age, and

--- a/internal/boardsnapshot/store.go
+++ b/internal/boardsnapshot/store.go
@@ -150,7 +150,7 @@ func Eligible(snapshot telemetry.Snapshot) bool {
 		return true
 	}
 	status := snapshot.Refresh.ReadinessStatus()
-	if status == telemetry.RefreshStatusReady {
+	if status == telemetry.RefreshStatusReady || status == telemetry.RefreshStatusBehind {
 		return true
 	}
 	return status == telemetry.RefreshStatusDegraded && carriesTrackerData(snapshot)
@@ -178,7 +178,7 @@ func carriesTrackerData(snapshot telemetry.Snapshot) bool {
 	}
 	for _, project := range snapshot.Projects {
 		if project.Refresh.LastRefreshAt != nil ||
-			project.Refresh.ReadinessStatus() == telemetry.RefreshStatusReady ||
+			project.Refresh.Ready() ||
 			project.Counts != (telemetry.Counts{}) {
 			return true
 		}

--- a/internal/boardsnapshot/store_test.go
+++ b/internal/boardsnapshot/store_test.go
@@ -105,6 +105,7 @@ func TestEligible(t *testing.T) {
 		want     bool
 	}{
 		{name: "ready", snapshot: telemetry.Snapshot{GeneratedAt: now, Refresh: telemetry.Refresh{Status: telemetry.RefreshStatusReady}}, want: true},
+		{name: "loop behind", snapshot: telemetry.Snapshot{GeneratedAt: now, Refresh: telemetry.Refresh{Status: telemetry.RefreshStatusBehind}}, want: true},
 		{name: "live snapshot without refresh signal", snapshot: telemetry.Snapshot{GeneratedAt: now, Projects: []telemetry.ProjectSnapshot{{Project: telemetry.Project{ID: "paused"}}}}, want: true},
 		{name: "degraded with prior data", snapshot: telemetry.Snapshot{GeneratedAt: now, Refresh: telemetry.Refresh{Status: telemetry.RefreshStatusDegraded}, BoardIssues: []telemetry.Issue{{ID: "issue"}}}, want: true},
 		{name: "initializing", snapshot: telemetry.Snapshot{GeneratedAt: now, Refresh: telemetry.Refresh{Status: telemetry.RefreshStatusInitializing}}},

--- a/internal/cli/runner.go
+++ b/internal/cli/runner.go
@@ -1594,6 +1594,11 @@ func mergeRefresh(current, next telemetry.Refresh) telemetry.Refresh {
 	if next.DataSeq > current.DataSeq {
 		current.DataSeq = next.DataSeq
 	}
+	current.ObservedSweepSeconds += next.LastDurationSeconds
+	if next.BehindBySeconds > current.BehindBySeconds {
+		current.BehindBySeconds = next.BehindBySeconds
+	}
+	current.StalenessWindowExceeded = current.StalenessWindowExceeded || next.StalenessWindowExceeded
 	current.LastRefreshAt = latestTime(current.LastRefreshAt, next.LastRefreshAt)
 	current.NextRefreshAt = earliestTime(current.NextRefreshAt, next.NextRefreshAt)
 	if strings.TrimSpace(next.LastError) != "" {
@@ -1616,6 +1621,8 @@ func mergeRefresh(current, next telemetry.Refresh) telemetry.Refresh {
 		current.Status = telemetry.RefreshStatusDegraded
 	case current.ReadinessStatus() == telemetry.RefreshStatusInitializing || next.ReadinessStatus() == telemetry.RefreshStatusInitializing:
 		current.Status = telemetry.RefreshStatusInitializing
+	case current.ReadinessStatus() == telemetry.RefreshStatusBehind || next.ReadinessStatus() == telemetry.RefreshStatusBehind:
+		current.Status = telemetry.RefreshStatusBehind
 	case currentHadSignal || nextHadSignal:
 		current.Status = telemetry.RefreshStatusReady
 	default:

--- a/internal/orchestrator/data_seq_test.go
+++ b/internal/orchestrator/data_seq_test.go
@@ -96,8 +96,15 @@ func TestTickDataSeqChangesOnlyAfterSuccessfulRefresh(t *testing.T) {
 			if snapshot := state.Snapshot(now); snapshot.Refresh.DataSeq != state.DataSeq {
 				t.Fatalf("Snapshot().Refresh.DataSeq = %d, want %d", snapshot.Refresh.DataSeq, state.DataSeq)
 			}
-			if cloned := state.clone(); cloned.DataSeq != state.DataSeq {
+			cloned := state.clone()
+			if snapshot := cloned.Snapshot(now); snapshot.Refresh.LastDurationSeconds != durationSecondsCeil(state.LastRefreshDuration) {
+				t.Fatalf("clone().Snapshot().Refresh.LastDurationSeconds = %d, want measured duration %d", snapshot.Refresh.LastDurationSeconds, durationSecondsCeil(state.LastRefreshDuration))
+			}
+			if cloned.DataSeq != state.DataSeq {
 				t.Fatalf("clone().DataSeq = %d, want %d", cloned.DataSeq, state.DataSeq)
+			}
+			if cloned.LastRefreshDuration != state.LastRefreshDuration {
+				t.Fatalf("clone().LastRefreshDuration = %s, want %s", cloned.LastRefreshDuration, state.LastRefreshDuration)
 			}
 		})
 	}

--- a/internal/orchestrator/refresh_timing.go
+++ b/internal/orchestrator/refresh_timing.go
@@ -39,17 +39,21 @@ func (t *refreshTiming) next(phase string) {
 	t.phaseStarted = now
 }
 
-func (t *refreshTiming) log(ctx context.Context, completed bool, state *State) {
-	if t == nil || t.logger == nil {
-		return
+func (t *refreshTiming) log(ctx context.Context, completed bool, state *State) time.Duration {
+	if t == nil {
+		return 0
 	}
 	now := time.Now()
 	t.finishPhase(now)
+	duration := now.Sub(t.startedAt)
+	if t.logger == nil {
+		return duration
+	}
 	attrs := []any{
 		"project_id", t.projectID,
 		"manual", t.manual,
 		"completed", completed,
-		"total_duration", now.Sub(t.startedAt),
+		"total_duration", duration,
 	}
 	if state != nil {
 		attrs = append(attrs,
@@ -59,6 +63,7 @@ func (t *refreshTiming) log(ctx context.Context, completed bool, state *State) {
 	}
 	attrs = append(attrs, t.phases...)
 	t.logger.InfoContext(ctx, "project refresh timing", attrs...)
+	return duration
 }
 
 func refreshTimingStatus(state *State) string {

--- a/internal/orchestrator/snapshot.go
+++ b/internal/orchestrator/snapshot.go
@@ -45,6 +45,7 @@ func (s State) Snapshot(now time.Time) telemetry.Snapshot {
 	refresh := telemetry.Refresh{
 		PollIntervalSeconds: int64(s.PollInterval / time.Second),
 		StaleAfterSeconds:   int64(staleAfter / time.Second),
+		LastDurationSeconds: durationSecondsCeil(s.LastRefreshDuration),
 		FailureThreshold:    failureThreshold,
 		DataSeq:             s.DataSeq,
 		LastRefreshAt:       timePointer(s.LastRefreshAt),
@@ -161,6 +162,13 @@ func rateWindowPacingSnapshot(state State, now time.Time) telemetry.RateWindowPa
 		PermitCeiling:            evaluation.permitCeiling,
 		ScalingApplied:           evaluation.scalingApplied,
 	}
+}
+
+func durationSecondsCeil(duration time.Duration) int64 {
+	if duration <= 0 {
+		return 0
+	}
+	return int64((duration + time.Second - 1) / time.Second)
 }
 
 func dispatchStatusSnapshot(status store.ProjectDispatchStatus, threshold time.Duration, now time.Time) telemetry.DispatchStatus {

--- a/internal/orchestrator/state.go
+++ b/internal/orchestrator/state.go
@@ -52,6 +52,7 @@ type State struct {
 	DrainStartedAt           time.Time
 	DataSeq                  uint64
 	LastRefreshAt            time.Time
+	LastRefreshDuration      time.Duration
 	NextRefreshAt            time.Time
 	LastRefreshError         string
 	LastRefreshErrorAt       time.Time
@@ -409,6 +410,7 @@ func (s State) clone() State {
 		DrainStartedAt:           s.DrainStartedAt,
 		DataSeq:                  s.DataSeq,
 		LastRefreshAt:            s.LastRefreshAt,
+		LastRefreshDuration:      s.LastRefreshDuration,
 		NextRefreshAt:            s.NextRefreshAt,
 		LastRefreshError:         s.LastRefreshError,
 		LastRefreshErrorAt:       s.LastRefreshErrorAt,

--- a/internal/orchestrator/tick.go
+++ b/internal/orchestrator/tick.go
@@ -56,7 +56,7 @@ func (o *Orchestrator) tickWithManual(ctx context.Context, state *State, now tim
 	completed := false
 	timing := newRefreshTiming(o.logger, o.cfg.Project.ID, manual != nil)
 	defer func() {
-		timing.log(ctx, completed, state)
+		state.LastRefreshDuration = timing.log(ctx, completed, state)
 	}()
 	state.tickTransitions = &issueStateSnapshotTransitions{}
 	defer func() {

--- a/internal/telemetry/snapshot.go
+++ b/internal/telemetry/snapshot.go
@@ -107,15 +107,78 @@ func (s Snapshot) AgeSeconds(now time.Time) int64 {
 }
 
 func (s Snapshot) WithFreshness(now time.Time) Snapshot {
-	s.Refresh = s.Refresh.WithFreshness(now)
 	if len(s.Projects) == 0 {
+		s.Refresh = s.Refresh.WithFreshness(now)
 		return s
 	}
 	s.Projects = append([]ProjectSnapshot(nil), s.Projects...)
+	staleAfterSeconds, observedSweepSeconds := refreshFleetStaleAfter(s.Refresh, s.Projects)
+	if staleAfterSeconds > s.Refresh.StaleAfterSeconds {
+		s.Refresh.StaleAfterSeconds = staleAfterSeconds
+	}
+	s.Refresh.ObservedSweepSeconds = observedSweepSeconds
+	s.Refresh = s.Refresh.WithFreshness(now)
 	for index := range s.Projects {
+		if !refreshHasReadinessSignal(s.Projects[index].Refresh) {
+			continue
+		}
+		if staleAfterSeconds > s.Projects[index].Refresh.StaleAfterSeconds {
+			s.Projects[index].Refresh.StaleAfterSeconds = staleAfterSeconds
+		}
 		s.Projects[index].Refresh = s.Projects[index].Refresh.WithFreshness(now)
+		projectRefresh := s.Projects[index].Refresh
+		switch projectRefresh.ReadinessStatus() {
+		case RefreshStatusDegraded:
+			s.Refresh.Status = RefreshStatusDegraded
+			s.Refresh.StalenessWindowExceeded = s.Refresh.StalenessWindowExceeded || projectRefresh.StalenessWindowExceeded
+			if strings.TrimSpace(s.Refresh.LastError) == "" || projectRefresh.StalenessWindowExceeded {
+				s.Refresh.LastError = projectRefresh.LastError
+				s.Refresh.LastErrorAt = copyTimePointer(projectRefresh.LastErrorAt)
+			}
+		case RefreshStatusInitializing:
+			if s.Refresh.ReadinessStatus() != RefreshStatusDegraded {
+				s.Refresh.Status = RefreshStatusInitializing
+			}
+		case RefreshStatusBehind:
+			if s.Refresh.ReadinessStatus() == RefreshStatusReady {
+				s.Refresh.Status = RefreshStatusBehind
+			}
+		}
 	}
 	return s
+}
+
+func refreshFleetStaleAfter(fleet Refresh, projects []ProjectSnapshot) (int64, int64) {
+	staleAfterSeconds := fleet.StaleAfterSeconds
+	var observedDurationSeconds int64
+	var activeProjectCount int64
+	var knownDurationCount int64
+	for _, project := range projects {
+		refresh := project.Refresh
+		if !refreshHasReadinessSignal(refresh) {
+			continue
+		}
+		activeProjectCount++
+		if refresh.StaleAfterSeconds > staleAfterSeconds {
+			staleAfterSeconds = refresh.StaleAfterSeconds
+		}
+		if refresh.LastDurationSeconds > 0 {
+			observedDurationSeconds += refresh.LastDurationSeconds
+			knownDurationCount++
+		}
+	}
+	if activeProjectCount < 2 || knownDurationCount == 0 {
+		return staleAfterSeconds, observedDurationSeconds
+	}
+	unknownDurationCount := activeProjectCount - knownDurationCount
+	if unknownDurationCount > 0 {
+		observedDurationSeconds += ((observedDurationSeconds + knownDurationCount - 1) / knownDurationCount) * unknownDurationCount
+	}
+	adaptiveStaleAfterSeconds := refreshSweepHeadroomMultiplier * observedDurationSeconds
+	if adaptiveStaleAfterSeconds > staleAfterSeconds {
+		staleAfterSeconds = adaptiveStaleAfterSeconds
+	}
+	return staleAfterSeconds, observedDurationSeconds
 }
 
 type CICondition struct {
@@ -475,9 +538,12 @@ func (h AuthHealth) IsZero() bool {
 
 type RefreshStatus string
 
+const refreshSweepHeadroomMultiplier = 2
+
 const (
 	RefreshStatusInitializing RefreshStatus = "initializing"
 	RefreshStatusReady        RefreshStatus = "ready"
+	RefreshStatusBehind       RefreshStatus = "behind"
 	RefreshStatusDegraded     RefreshStatus = "degraded"
 )
 
@@ -520,18 +586,22 @@ const (
 )
 
 type Refresh struct {
-	PollIntervalSeconds int64           `json:"poll_interval_seconds,omitempty"`
-	StaleAfterSeconds   int64           `json:"stale_after_seconds,omitempty"`
-	FailureThreshold    int             `json:"failure_threshold,omitempty"`
-	DataSeq             uint64          `json:"data_seq,omitempty"`
-	Status              RefreshStatus   `json:"status,omitempty"`
-	LastRefreshAt       *time.Time      `json:"last_refresh_at,omitempty"`
-	NextRefreshAt       *time.Time      `json:"next_refresh_at,omitempty"`
-	NextRefreshOverdue  bool            `json:"next_refresh_overdue"`
-	LastError           string          `json:"last_error,omitempty"`
-	LastErrorAt         *time.Time      `json:"last_error_at,omitempty"`
-	Sources             []RefreshSource `json:"sources,omitempty"`
-	Manual              *RefreshAttempt `json:"manual,omitempty"`
+	PollIntervalSeconds     int64           `json:"poll_interval_seconds,omitempty"`
+	StaleAfterSeconds       int64           `json:"stale_after_seconds,omitempty"`
+	LastDurationSeconds     int64           `json:"last_duration_seconds,omitempty"`
+	ObservedSweepSeconds    int64           `json:"observed_sweep_seconds,omitempty"`
+	BehindBySeconds         int64           `json:"behind_by_seconds,omitempty"`
+	FailureThreshold        int             `json:"failure_threshold,omitempty"`
+	DataSeq                 uint64          `json:"data_seq,omitempty"`
+	Status                  RefreshStatus   `json:"status,omitempty"`
+	LastRefreshAt           *time.Time      `json:"last_refresh_at,omitempty"`
+	NextRefreshAt           *time.Time      `json:"next_refresh_at,omitempty"`
+	NextRefreshOverdue      bool            `json:"next_refresh_overdue"`
+	StalenessWindowExceeded bool            `json:"staleness_window_exceeded,omitempty"`
+	LastError               string          `json:"last_error,omitempty"`
+	LastErrorAt             *time.Time      `json:"last_error_at,omitempty"`
+	Sources                 []RefreshSource `json:"sources,omitempty"`
+	Manual                  *RefreshAttempt `json:"manual,omitempty"`
 }
 
 type RefreshFailureReason string
@@ -539,6 +609,7 @@ type RefreshFailureReason string
 const (
 	RefreshFailureReasonConsecutiveFailures RefreshFailureReason = "consecutive_failures"
 	RefreshFailureReasonNeverRefreshed      RefreshFailureReason = "never_refreshed"
+	RefreshFailureReasonStale               RefreshFailureReason = "stale"
 )
 
 type RefreshFailure struct {
@@ -592,21 +663,26 @@ func (a RefreshAttempt) IsZero() bool {
 }
 
 func (r Refresh) ReadinessStatus() RefreshStatus {
+	if strings.TrimSpace(r.LastError) != "" || r.LastErrorAt != nil {
+		return RefreshStatusDegraded
+	}
 	switch RefreshStatus(strings.TrimSpace(string(r.Status))) {
 	case RefreshStatusInitializing:
 		return RefreshStatusInitializing
 	case RefreshStatusReady:
 		if r.NextRefreshOverdue {
-			return RefreshStatusDegraded
+			return RefreshStatusBehind
 		}
 		return RefreshStatusReady
+	case RefreshStatusBehind:
+		return RefreshStatusBehind
 	case RefreshStatusDegraded:
 		return RefreshStatusDegraded
 	}
-	if strings.TrimSpace(r.LastError) != "" || r.LastErrorAt != nil {
-		return RefreshStatusDegraded
-	}
 	if r.LastRefreshAt != nil {
+		if r.NextRefreshOverdue {
+			return RefreshStatusBehind
+		}
 		return RefreshStatusReady
 	}
 	return RefreshStatusInitializing
@@ -614,11 +690,71 @@ func (r Refresh) ReadinessStatus() RefreshStatus {
 
 func (r Refresh) WithFreshness(now time.Time) Refresh {
 	r.NextRefreshOverdue = r.NextRefreshAt != nil && !now.IsZero() && now.After(*r.NextRefreshAt)
+	r.BehindBySeconds = 0
+	if r.NextRefreshOverdue {
+		r.BehindBySeconds = int64(now.Sub(*r.NextRefreshAt) / time.Second)
+	}
 	if !refreshHasReadinessSignal(r) {
 		return r
 	}
-	r.Status = r.ReadinessStatus()
+	readinessStatus := r.ReadinessStatus()
+	wasStalenessWindowExceeded := r.StalenessWindowExceeded
+	if readinessStatus == RefreshStatusDegraded && !wasStalenessWindowExceeded {
+		r.Status = RefreshStatusDegraded
+		return r
+	}
+	r.StalenessWindowExceeded = false
+	if deadline, ok := r.stalenessDeadline(); ok && now.After(deadline) {
+		r.Status = RefreshStatusDegraded
+		r.StalenessWindowExceeded = true
+		r.LastErrorAt = copyTimePointer(&deadline)
+		if r.LastRefreshAt == nil {
+			r.LastError = "refresh has never completed within the expected sweep window"
+		} else {
+			r.LastError = "refresh has not succeeded within the expected sweep window"
+		}
+		return r
+	}
+	if wasStalenessWindowExceeded {
+		r.LastError = ""
+		r.LastErrorAt = nil
+		if r.LastRefreshAt == nil {
+			readinessStatus = RefreshStatusInitializing
+		} else {
+			readinessStatus = RefreshStatusReady
+		}
+	}
+	if r.NextRefreshOverdue {
+		r.Status = RefreshStatusBehind
+		return r
+	}
+	if r.LastRefreshAt == nil {
+		r.Status = readinessStatus
+		return r
+	}
+	r.Status = RefreshStatusReady
 	return r
+}
+
+func (r Refresh) stalenessDeadline() (time.Time, bool) {
+	staleAfter := time.Duration(r.StaleAfterSeconds) * time.Second
+	if staleAfter <= 0 {
+		return time.Time{}, false
+	}
+	oldest := r.LastRefreshAt
+	for index := range r.Sources {
+		successAt := r.Sources[index].LastSuccessAt
+		if successAt != nil && (oldest == nil || successAt.Before(*oldest)) {
+			oldest = successAt
+		}
+	}
+	if oldest != nil {
+		return oldest.Add(staleAfter), true
+	}
+	if r.NextRefreshAt != nil {
+		return r.NextRefreshAt.Add(staleAfter), true
+	}
+	return time.Time{}, false
 }
 
 func refreshHasReadinessSignal(r Refresh) bool {
@@ -631,7 +767,8 @@ func refreshHasReadinessSignal(r Refresh) bool {
 }
 
 func (r Refresh) Ready() bool {
-	return r.ReadinessStatus() == RefreshStatusReady
+	status := r.ReadinessStatus()
+	return status == RefreshStatusReady || status == RefreshStatusBehind
 }
 
 func (r Refresh) Initializing() bool {
@@ -640,6 +777,10 @@ func (r Refresh) Initializing() bool {
 
 func (r Refresh) Degraded() bool {
 	return r.ReadinessStatus() == RefreshStatusDegraded
+}
+
+func (r Refresh) Behind() bool {
+	return r.ReadinessStatus() == RefreshStatusBehind
 }
 
 func (r Refresh) Source(name RefreshSourceName) (RefreshSource, bool) {
@@ -709,6 +850,19 @@ func (r Refresh) failure(projectID string) (RefreshFailure, bool) {
 		return RefreshFailure{
 			ProjectID:        projectID,
 			Reason:           RefreshFailureReasonNeverRefreshed,
+			Source:           source.Name,
+			FailureStreak:    source.FailureStreak,
+			FailureThreshold: threshold,
+			LastError:        lastError,
+			LastErrorAt:      copyTimePointer(lastErrorAt),
+			Condition:        source.Condition,
+			Connector:        source.Connector,
+		}, true
+	}
+	if r.StalenessWindowExceeded {
+		return RefreshFailure{
+			ProjectID:        projectID,
+			Reason:           RefreshFailureReasonStale,
 			Source:           source.Name,
 			FailureStreak:    source.FailureStreak,
 			FailureThreshold: threshold,

--- a/internal/telemetry/snapshot_test.go
+++ b/internal/telemetry/snapshot_test.go
@@ -2,6 +2,7 @@ package telemetry_test
 
 import (
 	"encoding/json"
+	"fmt"
 	"reflect"
 	"testing"
 	"time"
@@ -698,6 +699,14 @@ func TestRefreshReadinessStatus(t *testing.T) {
 			want: telemetry.RefreshStatusDegraded,
 		},
 		{
+			name: "loop behind remains operational",
+			value: telemetry.Refresh{
+				Status: telemetry.RefreshStatusBehind,
+			},
+			want:  telemetry.RefreshStatusBehind,
+			ready: true,
+		},
+		{
 			name: "legacy loaded snapshot infers ready",
 			value: telemetry.Refresh{
 				LastRefreshAt: &now,
@@ -730,6 +739,10 @@ func TestRefreshReadinessStatusAt(t *testing.T) {
 	t.Parallel()
 
 	now := time.Date(2026, 8, 17, 1, 39, 0, 0, time.UTC)
+	legacyReady := (telemetry.Refresh{Status: telemetry.RefreshStatusReady}).WithFreshness(now)
+	if got := legacyReady.ReadinessStatus(); got != telemetry.RefreshStatusReady {
+		t.Fatalf("legacy ReadinessStatus() = %q, want %q", got, telemetry.RefreshStatusReady)
+	}
 	lastRefreshAt := now.Add(-18 * time.Minute)
 	tests := []struct {
 		name          string
@@ -743,9 +756,9 @@ func TestRefreshReadinessStatusAt(t *testing.T) {
 			wantStatus:    telemetry.RefreshStatusReady,
 		},
 		{
-			name:          "past due refresh becomes degraded",
+			name:          "past due refresh reports loop behind",
 			nextRefreshAt: now.Add(-9 * time.Minute),
-			wantStatus:    telemetry.RefreshStatusDegraded,
+			wantStatus:    telemetry.RefreshStatusBehind,
 			wantOverdue:   true,
 		},
 	}
@@ -795,11 +808,230 @@ func TestSnapshotWithFreshness(t *testing.T) {
 	if got := snapshot.AgeSeconds(now); got != int64((18*time.Minute)/time.Second) {
 		t.Fatalf("AgeSeconds() = %d, want 1080", got)
 	}
-	if snapshot.Refresh.ReadinessStatus() != telemetry.RefreshStatusDegraded || !snapshot.Refresh.NextRefreshOverdue {
-		t.Fatalf("Refresh = %#v, want overdue degraded refresh", snapshot.Refresh)
+	if snapshot.Refresh.ReadinessStatus() != telemetry.RefreshStatusBehind || !snapshot.Refresh.NextRefreshOverdue {
+		t.Fatalf("Refresh = %#v, want overdue behind refresh", snapshot.Refresh)
 	}
-	if snapshot.Projects[0].Refresh.ReadinessStatus() != telemetry.RefreshStatusDegraded || !snapshot.Projects[0].Refresh.NextRefreshOverdue {
-		t.Fatalf("Projects[0].Refresh = %#v, want overdue degraded refresh", snapshot.Projects[0].Refresh)
+	if snapshot.Projects[0].Refresh.ReadinessStatus() != telemetry.RefreshStatusBehind || !snapshot.Projects[0].Refresh.NextRefreshOverdue {
+		t.Fatalf("Projects[0].Refresh = %#v, want overdue behind refresh", snapshot.Projects[0].Refresh)
+	}
+}
+
+func TestSnapshotRefreshSweepHealth(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 8, 18, 13, 0, 0, 0, time.UTC)
+	healthyLastRefreshAt := now.Add(-90 * time.Second)
+	healthyNextRefreshAt := now.Add(-30 * time.Second)
+	neverNextRefreshAt := now.Add(-7 * time.Minute)
+	failureAt := now.Add(-time.Second)
+	tests := []struct {
+		name              string
+		projectCount      int
+		lastDuration      int64
+		mutate            func(int, *telemetry.Refresh)
+		wantStatus        telemetry.RefreshStatus
+		wantStaleAfter    int64
+		wantFailureReason telemetry.RefreshFailureReason
+	}{
+		{
+			name:           "healthy one-project host reports pacing only",
+			projectCount:   1,
+			lastDuration:   16,
+			wantStatus:     telemetry.RefreshStatusBehind,
+			wantStaleAfter: 120,
+		},
+		{
+			name:           "healthy ten-project host expands sweep window",
+			projectCount:   10,
+			lastDuration:   16,
+			wantStatus:     telemetry.RefreshStatusBehind,
+			wantStaleAfter: 320,
+		},
+		{
+			name:           "five-project threshold follows observed sweep",
+			projectCount:   5,
+			lastDuration:   20,
+			wantStatus:     telemetry.RefreshStatusBehind,
+			wantStaleAfter: 200,
+		},
+		{
+			name:              "failing source remains degraded",
+			projectCount:      10,
+			lastDuration:      16,
+			wantStatus:        telemetry.RefreshStatusDegraded,
+			wantStaleAfter:    320,
+			wantFailureReason: telemetry.RefreshFailureReasonConsecutiveFailures,
+			mutate: func(index int, refresh *telemetry.Refresh) {
+				if index != 0 {
+					return
+				}
+				refresh.Status = telemetry.RefreshStatusDegraded
+				refresh.LastError = "candidate endpoint unavailable"
+				refresh.LastErrorAt = &failureAt
+				refresh.FailureThreshold = 3
+				refresh.Sources = []telemetry.RefreshSource{{
+					Name:          telemetry.RefreshSourceCandidates,
+					LastSuccessAt: &healthyLastRefreshAt,
+					FailureStreak: 3,
+					LastError:     "candidate endpoint unavailable",
+					LastErrorAt:   &failureAt,
+				}}
+			},
+		},
+		{
+			name:              "never-refreshed project exceeds ten-project sweep window",
+			projectCount:      10,
+			lastDuration:      16,
+			wantStatus:        telemetry.RefreshStatusDegraded,
+			wantStaleAfter:    320,
+			wantFailureReason: telemetry.RefreshFailureReasonNeverRefreshed,
+			mutate: func(index int, refresh *telemetry.Refresh) {
+				if index != 0 {
+					return
+				}
+				refresh.Status = telemetry.RefreshStatusInitializing
+				refresh.LastRefreshAt = nil
+				refresh.NextRefreshAt = &neverNextRefreshAt
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			projects := make([]telemetry.ProjectSnapshot, tt.projectCount)
+			for index := range projects {
+				refresh := telemetry.Refresh{
+					PollIntervalSeconds: 60,
+					StaleAfterSeconds:   120,
+					LastDurationSeconds: tt.lastDuration,
+					FailureThreshold:    3,
+					Status:              telemetry.RefreshStatusReady,
+					LastRefreshAt:       &healthyLastRefreshAt,
+					NextRefreshAt:       &healthyNextRefreshAt,
+				}
+				if tt.mutate != nil {
+					tt.mutate(index, &refresh)
+				}
+				projects[index] = telemetry.ProjectSnapshot{
+					Project: telemetry.Project{ID: fmt.Sprintf("project-%d", index)},
+					Refresh: refresh,
+				}
+			}
+			snapshot := (telemetry.Snapshot{
+				GeneratedAt: now,
+				Refresh:     projects[0].Refresh,
+				Projects:    projects,
+			}).WithFreshness(now)
+
+			if got := snapshot.Refresh.ReadinessStatus(); got != tt.wantStatus {
+				t.Fatalf("Refresh status = %q, want %q; refresh = %#v", got, tt.wantStatus, snapshot.Refresh)
+			}
+			if snapshot.Refresh.StaleAfterSeconds != tt.wantStaleAfter {
+				t.Fatalf("StaleAfterSeconds = %d, want %d", snapshot.Refresh.StaleAfterSeconds, tt.wantStaleAfter)
+			}
+			failures := snapshot.RefreshFailures()
+			if tt.wantFailureReason == "" {
+				if len(failures) != 0 {
+					t.Fatalf("RefreshFailures() = %#v, want none", failures)
+				}
+				return
+			}
+			if len(failures) != 1 || failures[0].Reason != tt.wantFailureReason {
+				t.Fatalf("RefreshFailures() = %#v, want one %q failure", failures, tt.wantFailureReason)
+			}
+		})
+	}
+}
+
+func TestSnapshotWithFreshnessDistinguishesRefreshPacingFromFailure(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 8, 18, 12, 0, 0, 0, time.UTC)
+	lastRefreshAt := now.Add(-90 * time.Second)
+	nextRefreshAt := now.Add(-30 * time.Second)
+	tests := []struct {
+		name         string
+		projectCount int
+	}{
+		{name: "one project", projectCount: 1},
+		{name: "ten projects", projectCount: 10},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			projects := make([]telemetry.ProjectSnapshot, tt.projectCount)
+			for index := range projects {
+				projects[index] = telemetry.ProjectSnapshot{
+					Project: telemetry.Project{ID: fmt.Sprintf("project-%d", index)},
+					Refresh: telemetry.Refresh{
+						PollIntervalSeconds: 60,
+						StaleAfterSeconds:   120,
+						Status:              telemetry.RefreshStatusReady,
+						LastRefreshAt:       &lastRefreshAt,
+						NextRefreshAt:       &nextRefreshAt,
+					},
+				}
+			}
+			snapshot := (telemetry.Snapshot{
+				GeneratedAt: now,
+				Refresh:     projects[0].Refresh,
+				Projects:    projects,
+			}).WithFreshness(now)
+
+			if got := snapshot.Refresh.ReadinessStatus(); got != telemetry.RefreshStatus("behind") {
+				t.Fatalf("Refresh status = %q, want behind", got)
+			}
+			if !snapshot.Refresh.NextRefreshOverdue {
+				t.Fatal("NextRefreshOverdue = false, want true")
+			}
+			if snapshot.Refresh.LastError != "" || snapshot.Refresh.LastErrorAt != nil {
+				t.Fatalf("refresh error = %q at %v, want none", snapshot.Refresh.LastError, snapshot.Refresh.LastErrorAt)
+			}
+		})
+	}
+}
+
+func TestSnapshotFreshnessRecoversWhenObservedSweepExpandsWindow(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 8, 18, 12, 0, 0, 0, time.UTC)
+	lastRefreshAt := now.Add(-150 * time.Second)
+	nextRefreshAt := now.Add(-90 * time.Second)
+	refresh := telemetry.Refresh{
+		PollIntervalSeconds: 60,
+		StaleAfterSeconds:   120,
+		LastDurationSeconds: 16,
+		Status:              telemetry.RefreshStatusReady,
+		LastRefreshAt:       &lastRefreshAt,
+		NextRefreshAt:       &nextRefreshAt,
+	}
+	snapshot := (telemetry.Snapshot{
+		GeneratedAt: now,
+		Refresh:     refresh,
+		Projects: []telemetry.ProjectSnapshot{{
+			Project: telemetry.Project{ID: "project-0"},
+			Refresh: refresh,
+		}},
+	}).WithFreshness(now)
+	if !snapshot.Refresh.StalenessWindowExceeded {
+		t.Fatal("StalenessWindowExceeded = false, want true before sweep history is available")
+	}
+	for index := 1; index < 10; index++ {
+		snapshot.Projects = append(snapshot.Projects, telemetry.ProjectSnapshot{
+			Project: telemetry.Project{ID: fmt.Sprintf("project-%d", index)},
+			Refresh: refresh,
+		})
+	}
+	snapshot = snapshot.WithFreshness(now)
+	if got := snapshot.Refresh.ReadinessStatus(); got != telemetry.RefreshStatusBehind {
+		t.Fatalf("Refresh status = %q, want %q", got, telemetry.RefreshStatusBehind)
+	}
+	if snapshot.Refresh.StalenessWindowExceeded || snapshot.Refresh.LastError != "" || snapshot.Refresh.LastErrorAt != nil {
+		t.Fatalf("Refresh = %#v, want recovered pacing state without error", snapshot.Refresh)
 	}
 }
 

--- a/internal/web/server_test.go
+++ b/internal/web/server_test.go
@@ -7184,7 +7184,7 @@ func TestHealthReportsTickLivenessAndSnapshotAge(t *testing.T) {
 				WatchdogIntervalCount: 2,
 			},
 			wantHealthStatus: "needs_attention",
-			wantRefresh:      telemetry.RefreshStatusDegraded,
+			wantRefresh:      telemetry.RefreshStatusBehind,
 			wantAgeSeconds:   "1080",
 		},
 	}
@@ -7291,6 +7291,22 @@ func TestHealthReportsProjectRefreshFailures(t *testing.T) {
 			},
 			wantHealthStatus: "needs_attention",
 			wantFailures:     1,
+		},
+		{
+			name: "loop behind remains healthy",
+			refresh: telemetry.Refresh{
+				Status:               telemetry.RefreshStatusBehind,
+				FailureThreshold:     3,
+				LastRefreshAt:        &lastRefreshAt,
+				NextRefreshAt:        &lastErrorAt,
+				NextRefreshOverdue:   true,
+				BehindBySeconds:      30,
+				ObservedSweepSeconds: 160,
+				Sources: []telemetry.RefreshSource{{
+					Name: telemetry.RefreshSourceCandidates, LastSuccessAt: &lastRefreshAt,
+				}},
+			},
+			wantHealthStatus: "ok",
 		},
 		{
 			name: "successful refresh clears attention",
@@ -8962,8 +8978,10 @@ func TestServerEventsStreamsHealthSnapshotForHealthNav(t *testing.T) {
 
 	now := time.Date(2026, 6, 25, 14, 30, 0, 0, time.UTC)
 	backoffUntil := now.Add(5 * time.Minute)
+	lastRefreshAt := now.Add(-90 * time.Second)
+	nextRefreshAt := now.Add(-30 * time.Second)
 	deps := testDeps(t)
-	server, err := web.NewServer(web.Config{SSETickInterval: time.Hour}, deps)
+	server, err := web.NewServer(web.Config{SSETickInterval: time.Hour, Now: func() time.Time { return now }}, deps)
 	if err != nil {
 		t.Fatalf("NewServer() error = %v", err)
 	}
@@ -8975,6 +8993,13 @@ func TestServerEventsStreamsHealthSnapshotForHealthNav(t *testing.T) {
 
 	if err := deps.Hub.Publish(telemetry.Snapshot{
 		GeneratedAt: now,
+		Refresh: telemetry.Refresh{
+			PollIntervalSeconds: 60,
+			StaleAfterSeconds:   120,
+			Status:              telemetry.RefreshStatusReady,
+			LastRefreshAt:       &lastRefreshAt,
+			NextRefreshAt:       &nextRefreshAt,
+		},
 		RateLimits: &telemetry.RateLimits{
 			GitHubREST:    &telemetry.RateLimitBucket{Remaining: 4878, Used: 122, Limit: 5000},
 			GitHubGraphQL: &telemetry.RateLimitBucket{Remaining: 4880, Used: 120, Limit: 5000},
@@ -9001,6 +9026,7 @@ func TestServerEventsStreamsHealthSnapshotForHealthNav(t *testing.T) {
 		`id="health-github-graphql"`,
 		"122 / 5,000",
 		"120 / 5,000",
+		"Loop behind",
 	} {
 		if !strings.Contains(snapshotEvent.data, want) {
 			t.Fatalf("health snapshot event missing %q:\n%s", want, snapshotEvent.data)

--- a/internal/web/sse.go
+++ b/internal/web/sse.go
@@ -143,7 +143,7 @@ func (s *Server) events(c echo.Context) error {
 			if !ok {
 				return nil
 			}
-			snapshot = s.withManualRefresh(s.cachedEnrichedSnapshot(ctx, snapshot))
+			snapshot = s.withManualRefresh(s.cachedEnrichedSnapshot(ctx, snapshot)).WithFreshness(s.now())
 			data := s.dashboardData(ctx, snapshot)
 			if selectedProjectID != "" {
 				if scopedData, ok := s.projectDashboardData(ctx, selectedProjectID, snapshot); ok {

--- a/internal/web/templates/dashboard_data.go
+++ b/internal/web/templates/dashboard_data.go
@@ -1675,7 +1675,8 @@ func snapshotReady(snapshot telemetry.Snapshot) bool {
 	if snapshot.LastKnown {
 		return false
 	}
-	return snapshotReadinessStatus(snapshot) == telemetry.RefreshStatusReady
+	status := snapshotReadinessStatus(snapshot)
+	return status == telemetry.RefreshStatusReady || status == telemetry.RefreshStatusBehind
 }
 
 func snapshotInitializing(snapshot telemetry.Snapshot) bool {
@@ -1730,7 +1731,7 @@ func snapshotHasPriorTrackerSnapshot(snapshot telemetry.Snapshot) bool {
 
 func projectSnapshotHasPriorTrackerData(project telemetry.ProjectSnapshot) bool {
 	return project.Refresh.LastRefreshAt != nil ||
-		project.Refresh.Status == telemetry.RefreshStatusReady ||
+		project.Refresh.Ready() ||
 		project.Counts != (telemetry.Counts{})
 }
 

--- a/internal/web/templates/freshness_data.go
+++ b/internal/web/templates/freshness_data.go
@@ -13,6 +13,9 @@ func refreshFreshnessKind(snapshot telemetry.Snapshot) primitives.Kind {
 	if snapshot.Refresh.Stale(snapshot.GeneratedAt) {
 		return primitives.KindWarn
 	}
+	if snapshot.Refresh.Behind() {
+		return primitives.KindNeutral
+	}
 	if len(snapshot.Refresh.Sources) > 0 {
 		if refreshOldestSuccess(snapshot.Refresh.Sources).IsZero() {
 			return primitives.KindNeutral
@@ -29,6 +32,9 @@ func refreshFreshnessKind(snapshot telemetry.Snapshot) primitives.Kind {
 }
 
 func refreshFreshnessLabel(snapshot telemetry.Snapshot) string {
+	if snapshot.Refresh.Behind() {
+		return "Loop behind"
+	}
 	switch refreshFreshnessKind(snapshot) {
 	case primitives.KindWarn:
 		return "Data stale"
@@ -294,11 +300,15 @@ func healthRefreshRows(snapshot telemetry.Snapshot) []healthRow {
 	}
 	if len(groups) == 0 && snapshotHasRefreshSignal(snapshot.Refresh) {
 		kind := refreshFreshnessKind(snapshot)
+		status := refreshHealthStatus(kind)
+		if snapshot.Refresh.Behind() {
+			status = "Behind"
+		}
 		return []healthRow{{
 			ID:        "health-tracker",
 			Component: "Tracker freshness",
 			Kind:      kind,
-			Status:    refreshHealthStatus(kind),
+			Status:    status,
 			Detail:    refreshFreshnessSummary(snapshot),
 			Resets:    "—",
 		}}
@@ -315,6 +325,11 @@ func healthRefreshRows(snapshot telemetry.Snapshot) []healthRow {
 			return refreshSourceOrder(sources[i].Name) < refreshSourceOrder(sources[j].Name)
 		})
 		kind := primitives.KindOK
+		status := "Current"
+		if snapshot.Refresh.Behind() {
+			kind = primitives.KindNeutral
+			status = "Behind"
+		}
 		details := make([]string, 0, len(sources))
 		for _, source := range sources {
 			detail := refreshSourceDisplayName(source.Name)
@@ -337,6 +352,9 @@ func healthRefreshRows(snapshot telemetry.Snapshot) []healthRow {
 			}
 			details = append(details, detail)
 		}
+		if kind == primitives.KindWarn {
+			status = refreshHealthStatus(kind)
+		}
 		component := "Tracker freshness"
 		if projectID != "" {
 			component += " · " + projectID
@@ -345,7 +363,7 @@ func healthRefreshRows(snapshot telemetry.Snapshot) []healthRow {
 			ID:        "health-tracker-" + boardCardSlug(projectID),
 			Component: component,
 			Kind:      kind,
-			Status:    refreshHealthStatus(kind),
+			Status:    status,
 			Detail:    strings.Join(details, " · "),
 			Resets:    "—",
 		})

--- a/internal/web/templates/health_data.go
+++ b/internal/web/templates/health_data.go
@@ -128,6 +128,12 @@ func healthViewFromDashboard(data DashboardData) healthView {
 		view.Detail = "Review the affected issues before the proposals expire."
 		return view
 	}
+	if snapshot.Refresh.Behind() {
+		view.Kind = primitives.KindNeutral
+		view.Verdict = "Refresh loop is behind."
+		view.Detail = "The latest tracker refresh succeeded; the loop is pacing behind its target cadence."
+		return view
+	}
 	switch api.State {
 	case gitHubAPIHealthStateHealthy, gitHubAPIHealthStateAtRest:
 		view.Kind = primitives.KindOK

--- a/internal/web/templates/health_data_test.go
+++ b/internal/web/templates/health_data_test.go
@@ -35,6 +35,20 @@ func TestHealthViewVerdicts(t *testing.T) {
 			wantVerdict: "Waiting for the first health snapshot.",
 		},
 		{
+			name: "refresh pacing is distinct from failure",
+			snapshot: telemetry.Snapshot{
+				GeneratedAt: now,
+				Refresh: telemetry.Refresh{
+					Status:               telemetry.RefreshStatusBehind,
+					NextRefreshOverdue:   true,
+					BehindBySeconds:      30,
+					ObservedSweepSeconds: 160,
+				},
+			},
+			wantKind:    primitives.KindNeutral,
+			wantVerdict: "Refresh loop is behind.",
+		},
+		{
 			name: "tracker unavailability requires attention",
 			snapshot: telemetry.Snapshot{
 				GeneratedAt: now,

--- a/tests/visual/layout.spec.js
+++ b/tests/visual/layout.spec.js
@@ -1600,13 +1600,14 @@ test("project kanban move is immediate and survives a stale snapshot", async ({
     });
     await page.locator("#board-lanes").waitFor({ state: "visible" });
 
-    const staleSnapshot = await page
-      .locator("#snapshot")
-      .evaluate((snapshot) => snapshot.innerHTML);
     const card = page.locator(
       '[data-kanban-card][data-kanban-current-state="Backlog"]',
       { hasText: "Kanban demo backlog intake" },
     );
+    await expect(card).toBeVisible();
+    const staleSnapshot = await page
+      .locator("#snapshot")
+      .evaluate((snapshot) => snapshot.innerHTML);
     const sourceLane = page.locator('[data-kanban-drop-state="Backlog"]');
     const targetLane = page.locator('[data-kanban-drop-state="Todo"]');
 
@@ -1934,10 +1935,6 @@ test("dashboard prompts reload only when the serving build changes", async ({
 
   const notice = page.locator("[data-detent-build-update]");
   const footer = page.locator("#detent-build-version");
-  await dispatchBuildVersion(page, "v98.0.0", "#live-clock");
-  await expect(notice).toBeHidden();
-  await expect(footer).toHaveText(servedVersion);
-
   await dispatchBuildVersion(page, servedVersion);
   await expect(notice).toBeHidden();
   await expect(footer).toHaveText(servedVersion);
@@ -1951,28 +1948,23 @@ test("dashboard prompts reload only when the serving build changes", async ({
   );
 });
 
-async function dispatchBuildVersion(
-  page,
-  version,
-  targetSelector = "#detent-build-version",
-) {
-  await page.evaluate(({ liveVersion, selector }) => {
-    const target = document.querySelector(selector);
+async function dispatchBuildVersion(page, version) {
+  await page.evaluate((liveVersion) => {
     const footer = document.getElementById("detent-build-version");
-    if (!target || !footer) {
+    if (!footer) {
       throw new Error("Build version SSE elements not found");
     }
     const incoming = footer.cloneNode(true);
     incoming.textContent = liveVersion;
     incoming.setAttribute("title", liveVersion);
     incoming.setAttribute("data-detent-build-version", liveVersion);
-    target.dispatchEvent(
+    footer.dispatchEvent(
       new CustomEvent("htmx:sseBeforeMessage", {
         bubbles: true,
         detail: { elt: footer, data: incoming.outerHTML },
       }),
     );
-  }, { liveVersion: version, selector: targetSelector });
+  }, version);
 }
 
 test("reports page renders KPI figures and charts", async ({


### PR DESCRIPTION
## Summary

- report overdue successful refreshes as a non-actionable `behind` pacing state
- adapt the staleness deadline to measured multi-project sweep duration while preserving failure and never-refreshed degradation
- expose pacing telemetry and keep behind snapshots operational across the API, SSE, board cache, and Health UI

Fixes #1890

## UI Surface Contract

- [x] The linked issue explicitly authorizes the Health status distinction; this PR does not change layout, density, first-viewport, or responsive visibility.
- [x] This PR does not add persistent top-of-screen messaging.
- [x] Browser verification used an isolated random-port snapshot preview: Health rendered `Refresh loop is behind`, `Behind`, and `Loop behind` after SSE refresh, while `/health` remained HTTP 200 with no refresh failures.

## Test Plan

- [x] `make check`
- [x] focused affected-package tests for telemetry, orchestrator, board snapshots, Health API/SSE, and Health presentation
- [x] isolated browser verification on a disposable server without touching the live port-4000 process