### PR TITLE
test(web): stabilize MCP rate-limit test

### DIFF
--- a/internal/web/auth.go
+++ b/internal/web/auth.go
@@ -605,7 +605,7 @@ func (s *Server) applyAPIKeyRateLimit(c echo.Context, credential apikey.Credenti
 	if key == "" {
 		key = apikey.StaticKeyID
 	}
-	allowed, remaining := s.keyLimiter.Allow(key, time.Now())
+	allowed, remaining := s.keyLimiter.Allow(key, s.now())
 	s.setRateLimitHeaders(c, s.keyLimiter.Limit(), remaining)
 	if allowed {
 		return nil

--- a/internal/web/auth_sse_test.go
+++ b/internal/web/auth_sse_test.go
@@ -76,6 +76,7 @@ func TestLoopbackPeerReadTrustPreservesRateLimits(t *testing.T) {
 				globalConfigSource: func() globalconfig.Config { return cfg },
 				lookupEnv:          func(string) string { return "" },
 				serverAddr:         "0.0.0.0:0",
+				now:                time.Now,
 			}
 			tt.configure(server)
 			t.Cleanup(func() {

--- a/internal/web/mcp_http_test.go
+++ b/internal/web/mcp_http_test.go
@@ -108,7 +108,7 @@ func TestRemoteMCPBypassesDashboardAuthenticationGates(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
 
-			server, _ := newRemoteMCPTestServerWithConfig(t, nil, test.config)
+			server, _ := newRemoteMCPTestServerWithConfig(t, nil, test.config, nil)
 			token, _ := createRemoteMCPKey(t, server, "Global read", []string{"read"}, nil)
 			authorized := performJSON(t, server.Handler(), http.MethodPost, "/mcp", mcpInitializeRequest, map[string]string{
 				"Authorization": "Bearer " + token,
@@ -148,7 +148,8 @@ func TestRemoteMCPBearerTokenIsNotLoggedOrEchoed(t *testing.T) {
 func TestRemoteMCPUsesExistingRateLimits(t *testing.T) {
 	t.Parallel()
 
-	server, _ := newRemoteMCPTestServer(t, nil)
+	now := time.Date(2026, time.January, 1, 0, 0, 0, 0, time.UTC)
+	server, _ := newRemoteMCPTestServerWithConfig(t, nil, globalconfig.Config{}, func() time.Time { return now })
 	token, _ := createRemoteMCPKey(t, server, "Rate limited read", []string{"read"}, nil)
 	var limited bool
 	for range 40 {
@@ -195,10 +196,10 @@ func TestRemoteMCPUsesWebServerShutdown(t *testing.T) {
 
 func newRemoteMCPTestServer(t *testing.T, logger *slog.Logger) (*web.Server, store.Store) {
 	t.Helper()
-	return newRemoteMCPTestServerWithConfig(t, logger, globalconfig.Config{})
+	return newRemoteMCPTestServerWithConfig(t, logger, globalconfig.Config{}, nil)
 }
 
-func newRemoteMCPTestServerWithConfig(t *testing.T, logger *slog.Logger, config globalconfig.Config) (*web.Server, store.Store) {
+func newRemoteMCPTestServerWithConfig(t *testing.T, logger *slog.Logger, config globalconfig.Config, now func() time.Time) (*web.Server, store.Store) {
 	t.Helper()
 	backend := openWebTestStore(t)
 	deps := testDeps(t)
@@ -209,6 +210,7 @@ func newRemoteMCPTestServerWithConfig(t *testing.T, logger *slog.Logger, config 
 		Logger:        logger,
 		ServerAddress: "127.0.0.1:0",
 		GlobalConfig:  config,
+		Now:           now,
 	}, deps)
 	if err != nil {
 		t.Fatalf("NewServer() error = %v", err)


### PR DESCRIPTION
## Summary

- route API-key limiter decisions through the existing injected server clock
- freeze the MCP test clock so request throughput cannot refill the production limiter
- preserve remote MCP 429 header coverage and production rate-limit defaults

Fixes #1897

## UI Surface Contract

- [x] N/A, or the linked issue explicitly authorizes any high-impact UI surface, layout, density, first-viewport, or responsive visibility tradeoff.
- [x] Persistent top-of-screen messaging is explicitly authorized by the issue, or this PR does not add it.
- [x] Visual changes to primary operator screens include screenshot or browser verification below.

No UI changes.

## Test Plan

- [x] `go test -race ./internal/web -count=10`
- [x] focused post-rebase race repetition (`-count=10`)
- [x] `make check`