### PR TITLE
fix(runner): enforce agent memory ceilings

### DIFF
--- a/docs/ONBOARDING.md
+++ b/docs/ONBOARDING.md
@@ -2934,6 +2934,24 @@ awk 'NF {last=$0} END {exit last == "MUTATION_CONFIRMED=true" ? 0 : 1}' "$ONBOAR
    final backstop. Reject worker launch wrappers that double-fork or move the
    worker into another cgroup.
 
+   On a shared Linux host, install a `detent.service` drop-in with host-specific
+   `MemoryHigh` and `MemoryMax` values. Size them for Detent's aggregate worker
+   footprint while preserving memory for unrelated workloads, and keep
+   `MemoryMax` above `MemoryHigh`. As a starting point on a 32 GiB host partly
+   reserved for other work:
+
+   ```ini
+   [Service]
+   MemoryHigh=24G
+   MemoryMax=28G
+   ```
+
+   Use `systemctl --user edit detent.service`, reload systemd, and restart only
+   during an approved maintenance window. Confirm the effective limits with
+   `systemctl --user show detent.service -p MemoryHigh -p MemoryMax`. The cgroup
+   limits are defense in depth for the whole service; Detent's per-agent RSS
+   ceiling and memory-pressure admission control remain the primary controls.
+
    When the project defines `hooks.after_create` or other bootstrap hooks,
    dry-run that hook or the equivalent repo bootstrap script from an isolated
    throwaway worktree with the same service PATH before moving an issue to

--- a/docs/dependency-workflows.md
+++ b/docs/dependency-workflows.md
@@ -89,3 +89,22 @@ service cgroup, so its persisted worker registry can terminate stale process
 groups on shutdown or startup while systemd remains the final cleanup backstop.
 Do not wrap worker commands in launchers that double-fork or explicitly move
 children into another cgroup.
+
+On shared Linux hosts, add `MemoryHigh` and `MemoryMax` to `detent.service` as
+defense in depth. Size both for the aggregate orchestrator and worker footprint,
+leave capacity for unrelated workloads, and keep `MemoryMax` above
+`MemoryHigh`. For example, a 32 GiB host reserved partly for other work could
+use this user-service drop-in as a starting point:
+
+```ini
+[Service]
+MemoryHigh=24G
+MemoryMax=28G
+```
+
+Create the drop-in with `systemctl --user edit detent.service`, then run
+`systemctl --user daemon-reload` and restart the service during an approved
+maintenance window. Verify the effective values with
+`systemctl --user show detent.service -p MemoryHigh -p MemoryMax`. These cgroup
+limits protect the host if Detent's per-agent RSS ceiling fails; they do not
+replace the per-agent ceiling or memory-pressure admission control.

--- a/internal/cli/boot.go
+++ b/internal/cli/boot.go
@@ -36,6 +36,7 @@ import (
 	"github.com/digitaldrywood/detent/internal/orchestrator"
 	"github.com/digitaldrywood/detent/internal/procgroup"
 	"github.com/digitaldrywood/detent/internal/project"
+	runnerpkg "github.com/digitaldrywood/detent/internal/runner"
 	"github.com/digitaldrywood/detent/internal/scheduler"
 	"github.com/digitaldrywood/detent/internal/statuspage"
 	"github.com/digitaldrywood/detent/internal/store"
@@ -277,10 +278,17 @@ func startRunningWithDependencies(ctx context.Context, cfg BootConfig, deps star
 	runtimeGitHubToken := newRuntimeGitHubTokenState(runtimeGlobalGitHubToken(cfg.Runtime.GitHubToken))
 	globalConfigState := newGlobalConfigState(cfg.Global)
 	refreshGitHubToken := runtimeGitHubTokenRefresher(globalConfigState, runtimeGitHubToken)
+	managerConfig := managerConfigWithRuntimeGitHubToken(cfg.Global, runtimeGitHubToken.get())
+	dispatchPacer := runnerpkg.NewStartupDispatchPacer(runnerpkg.StartupDispatchPacerConfig{
+		MaxStartsPerSecond: managerConfig.Startup.MaxSpawnPerSecond,
+		Jitter:             managerConfig.Startup.Jitter,
+		RampStarts:         startupDispatchRampStarts(globalDispatchGate),
+	})
 	projectFactory := withRunnerFactory(project.Dependencies{
 		Events:             events,
 		Logger:             logger,
 		GlobalDispatchGate: globalDispatchGate,
+		DispatchPacer:      dispatchPacer,
 		WorkflowMetrics:    runtimeStore,
 		Efficiency:         runtimeStore,
 		WorkAttempts:       runtimeStore,
@@ -300,10 +308,7 @@ func startRunningWithDependencies(ctx context.Context, cfg BootConfig, deps star
 	managerDependencies.ProjectFactory = projectFactory
 	managerDependencies.Events = events
 	managerDependencies.Logger = logger
-	manager, err := project.NewManager(
-		managerConfigWithRuntimeGitHubToken(cfg.Global, runtimeGitHubToken.get()),
-		managerDependencies,
-	)
+	manager, err := project.NewManager(managerConfig, managerDependencies)
 	if err != nil {
 		return err
 	}
@@ -1315,6 +1320,21 @@ func buildGlobalDispatchPools(
 		return nil, fmt.Errorf("create agent pools: %w", err)
 	}
 	return registry, nil
+}
+
+func startupDispatchRampStarts(registry *scheduler.PoolRegistry) int {
+	if registry == nil {
+		return 1
+	}
+	total := 0
+	for _, pool := range registry.PoolSnapshots() {
+		capacity := pool.BurstTo
+		if capacity <= 0 {
+			capacity = pool.Capacity
+		}
+		total += capacity
+	}
+	return max(total, 1)
 }
 
 func globalPoolConfigs(

--- a/internal/cli/runner.go
+++ b/internal/cli/runner.go
@@ -86,7 +86,7 @@ func withRunnerFactory(
 		run := deps.Runner
 		if run == nil {
 			var err error
-			run, err = buildRunner(workflow, cfg.ID, cfg.Workdir, sessionStore, deps.Logger)
+			run, err = buildRunner(workflow, cfg.ID, cfg.Workdir, cfg.EffectiveMemory(), sessionStore, deps.Logger)
 			if err != nil {
 				return nil, fmt.Errorf("build project runner %s: %w", cfg.ID, err)
 			}
@@ -111,6 +111,7 @@ func buildRunner(
 	workflow workflowconfig.Workflow,
 	projectID string,
 	projectWorkdir string,
+	memory globalconfig.Memory,
 	sessionStore runnerpkg.SessionStore,
 	logger *slog.Logger,
 ) (orchestrator.Runner, error) {
@@ -139,6 +140,8 @@ func buildRunner(
 		Store:               sessionStore,
 		Pricing:             pricing,
 		BudgetGuardBuilder:  budgetGuardBuilder,
+		MaxAgentRSSBytes:    uint64(memory.MaxAgentRSSBytes),
+		RSSPollInterval:     time.Duration(memory.PollIntervalMS) * time.Millisecond,
 		Logger:              logger,
 	})
 	if err != nil {
@@ -962,6 +965,9 @@ func mergeSnapshot(current, next telemetry.Snapshot) telemetry.Snapshot {
 	current.Tokens.RuntimeSeconds += next.Tokens.RuntimeSeconds
 
 	current.RateLimits = mergeFleetRateLimits(current.RateLimits, next.RateLimits)
+	if current.MemoryPressure.ObservedAt.IsZero() || next.MemoryPressure.ObservedAt.After(current.MemoryPressure.ObservedAt) {
+		current.MemoryPressure = next.MemoryPressure
+	}
 	return current
 }
 

--- a/internal/cli/runner_test.go
+++ b/internal/cli/runner_test.go
@@ -160,7 +160,7 @@ func TestBuildRunnerReturnsRunner(t *testing.T) {
 	cfg.Tracker.Kind = workflowconfig.TrackerMemory
 	cfg.Workspace.Root = t.TempDir()
 
-	run, err := buildRunner(workflowconfig.Workflow{Config: cfg}, "alpha", "", nil, nil)
+	run, err := buildRunner(workflowconfig.Workflow{Config: cfg}, "alpha", "", globalconfig.Memory{}, nil, nil)
 	if err != nil {
 		t.Fatalf("buildRunner() error = %v", err)
 	}
@@ -228,7 +228,7 @@ Prompt {{ issue.identifier }}
 		t.Fatalf("Validate() error = %v", err)
 	}
 
-	run, err := buildRunner(workflow, "detent", source, sessionStore, nil)
+	run, err := buildRunner(workflow, "detent", source, globalconfig.Memory{}, sessionStore, nil)
 	if err != nil {
 		t.Fatalf("buildRunner() error = %v", err)
 	}
@@ -320,7 +320,7 @@ func TestBuildRunnerUsesTopLevelPricingPath(t *testing.T) {
 	cfg.Workspace.Root = t.TempDir()
 	cfg.Budget.PricingPath = filepath.Join(t.TempDir(), "missing-models.yaml")
 
-	_, err := buildRunner(workflowconfig.Workflow{Config: cfg}, "alpha", "", nil, nil)
+	_, err := buildRunner(workflowconfig.Workflow{Config: cfg}, "alpha", "", globalconfig.Memory{}, nil, nil)
 	if err == nil {
 		t.Fatal("buildRunner() error = nil, want pricing load error")
 	}

--- a/internal/config/global/config.go
+++ b/internal/config/global/config.go
@@ -25,12 +25,15 @@ const (
 	Kind                            = "GlobalConfig"
 	DefaultUpdateCheckIntervalHours = 6
 
-	SchedulingWeighted              = "weighted"
-	SchedulingStrict                = "strict"
-	SchedulingRoundRobin            = "round_robin"
-	SchedulingFairShare             = "fair_share"
-	DefaultAgentPoolName            = "default"
-	DashboardAccessModePrivateToken = "private_token"
+	SchedulingWeighted                            = "weighted"
+	SchedulingStrict                              = "strict"
+	SchedulingRoundRobin                          = "round_robin"
+	SchedulingFairShare                           = "fair_share"
+	DefaultAgentPoolName                          = "default"
+	DashboardAccessModePrivateToken               = "private_token"
+	DefaultMaxAgentRSSBytes                 int64 = 8 * 1024 * 1024 * 1024
+	DefaultMemoryPressureSomeAvg60Threshold       = 10.0
+	DefaultMemoryPollIntervalMS                   = 1000
 
 	configFileMode = 0o600
 )
@@ -128,6 +131,30 @@ type Settings struct {
 	Knowledge           Knowledge                       `yaml:"knowledge,omitempty"`
 	FairShare           map[string]any                  `yaml:"fair_share,omitempty"`
 	Startup             map[string]any                  `yaml:"startup,omitempty"`
+	Memory              Memory                          `yaml:"memory,omitempty"`
+}
+
+type Memory struct {
+	MaxAgentRSSBytes           int64   `yaml:"max_agent_rss_bytes"`
+	PressureSomeAvg60Threshold float64 `yaml:"pressure_some_avg60_threshold"`
+	PollIntervalMS             int     `yaml:"poll_interval_ms"`
+}
+
+type ProjectMemory struct {
+	MaxAgentRSSBytes *int64 `yaml:"max_agent_rss_bytes,omitempty"`
+}
+
+func (m Memory) Normalized() Memory {
+	if m.MaxAgentRSSBytes <= 0 {
+		m.MaxAgentRSSBytes = DefaultMaxAgentRSSBytes
+	}
+	if m.PressureSomeAvg60Threshold <= 0 {
+		m.PressureSomeAvg60Threshold = DefaultMemoryPressureSomeAvg60Threshold
+	}
+	if m.PollIntervalMS <= 0 {
+		m.PollIntervalMS = DefaultMemoryPollIntervalMS
+	}
+	return m
 }
 
 type AgentPool struct {
@@ -157,11 +184,21 @@ type Project struct {
 	CredentialRef            string                          `yaml:"credential_ref,omitempty"`
 	Authorization            selector.Selector               `yaml:"authorization,omitempty"`
 	Intake                   intakeconfig.Config             `yaml:"intake,omitempty"`
+	Memory                   ProjectMemory                   `yaml:"memory,omitempty"`
 	Identity                 Identity                        `yaml:"-"`
 	GlobalKnowledge          Knowledge                       `yaml:"-"`
 	GlobalActiveHours        *activehours.Config             `yaml:"-"`
 	GlobalRateWindowPacing   workflowconfig.RateWindowPacing `yaml:"-"`
+	GlobalMemory             Memory                          `yaml:"-"`
 	IntakeConfigured         bool                            `yaml:"-"`
+}
+
+func (p Project) EffectiveMemory() Memory {
+	memory := p.GlobalMemory.Normalized()
+	if p.Memory.MaxAgentRSSBytes != nil {
+		memory.MaxAgentRSSBytes = *p.Memory.MaxAgentRSSBytes
+	}
+	return memory
 }
 
 type Identity = workflowconfig.Identity
@@ -314,6 +351,7 @@ func Write(path string, cfg Config, opts ...Option) error {
 	}
 
 	cfg.Path = expandedPath
+	cfg.Global.Memory = cfg.Global.Memory.Normalized()
 	if err := cfg.Validate(opts...); err != nil {
 		return err
 	}
@@ -672,6 +710,7 @@ func (c Config) Validate(opts ...Option) error {
 	}
 	problems = append(problems, c.Global.Identity.Validate("global.identity")...)
 	problems = append(problems, startupErrors(c.Global.Startup, "global.startup")...)
+	problems = append(problems, memoryProblems(c.Global.Memory, "global.memory")...)
 
 	if c.Projects == nil {
 		problems = append(problems, "projects: is required")
@@ -711,6 +750,9 @@ func (c Config) Validate(opts ...Option) error {
 			}
 		}
 		problems = append(problems, project.Authorization.Validate(prefix+".authorization")...)
+		if project.Memory.MaxAgentRSSBytes != nil && *project.Memory.MaxAgentRSSBytes <= 0 {
+			problems = append(problems, prefix+".memory.max_agent_rss_bytes: must be a positive integer")
+		}
 	}
 	problems = append(problems, duplicateProjectIDErrorsFromProjects(c.Projects)...)
 	problems = append(problems, projectAgentPoolProblems(c.Global.AgentPools, c.Projects)...)
@@ -941,6 +983,11 @@ func defaultSettings() Settings {
 			"jitter_seconds":       10,
 			"max_spawn_per_second": 2,
 		},
+		Memory: Memory{
+			MaxAgentRSSBytes:           DefaultMaxAgentRSSBytes,
+			PressureSomeAvg60Threshold: DefaultMemoryPressureSomeAvg60Threshold,
+			PollIntervalMS:             DefaultMemoryPollIntervalMS,
+		},
 	}
 }
 
@@ -1051,6 +1098,7 @@ func globalErrors(value any) []string {
 	problems = append(problems, knowledgeErrors(global["knowledge"], "global.knowledge")...)
 	problems = append(problems, optionalMapErrors(global, "fair_share")...)
 	problems = append(problems, optionalMapErrors(global, "startup")...)
+	problems = append(problems, memoryErrors(global["memory"], "global.memory", false)...)
 
 	if startup, ok := global["startup"].(map[string]any); ok {
 		problems = append(problems, startupErrors(startup, "global.startup")...)
@@ -1224,6 +1272,44 @@ func startupErrors(startup map[string]any, prefix string) []string {
 	return problems
 }
 
+func memoryErrors(value any, prefix string, projectOverride bool) []string {
+	if value == nil {
+		return nil
+	}
+	memory, ok := value.(map[string]any)
+	if !ok {
+		return []string{prefix + ": must be a mapping"}
+	}
+	var problems []string
+	if value, ok := memory["max_agent_rss_bytes"]; ok && !positiveInteger(value) {
+		problems = append(problems, prefix+".max_agent_rss_bytes: must be a positive integer")
+	}
+	if projectOverride {
+		return problems
+	}
+	if value, ok := memory["pressure_some_avg60_threshold"]; ok && !positiveNumber(value) {
+		problems = append(problems, prefix+".pressure_some_avg60_threshold: must be a positive number")
+	}
+	if value, ok := memory["poll_interval_ms"]; ok && !positiveInteger(value) {
+		problems = append(problems, prefix+".poll_interval_ms: must be a positive integer")
+	}
+	return problems
+}
+
+func memoryProblems(memory Memory, prefix string) []string {
+	var problems []string
+	if memory.MaxAgentRSSBytes <= 0 {
+		problems = append(problems, prefix+".max_agent_rss_bytes: must be a positive integer")
+	}
+	if memory.PressureSomeAvg60Threshold <= 0 {
+		problems = append(problems, prefix+".pressure_some_avg60_threshold: must be a positive number")
+	}
+	if memory.PollIntervalMS <= 0 {
+		problems = append(problems, prefix+".poll_interval_ms: must be a positive integer")
+	}
+	return problems
+}
+
 func projectsErrors(value any, opts options) []string {
 	if value == nil {
 		return nil
@@ -1272,6 +1358,7 @@ func projectErrors(value any, index int, opts options) []string {
 	problems = append(problems, credentialRefErrors(project, prefix)...)
 	problems = append(problems, authorizationErrors(project["authorization"], prefix+".authorization")...)
 	problems = append(problems, intakeErrors(project["intake"], prefix+".intake")...)
+	problems = append(problems, memoryErrors(project["memory"], prefix+".memory", true)...)
 
 	return problems
 }
@@ -1508,6 +1595,17 @@ func integerError(value any, field string) []string {
 func positiveInteger(value any) bool {
 	number, ok := value.(int)
 	return ok && number > 0
+}
+
+func positiveNumber(value any) bool {
+	switch number := value.(type) {
+	case int:
+		return number > 0
+	case float64:
+		return number > 0
+	default:
+		return false
+	}
 }
 
 func nonNegativeInteger(value any) bool {
@@ -1962,6 +2060,12 @@ func buildSettings(attrs map[string]any, opts options) (Settings, error) {
 		}
 		rateWindowPacing = rateWindowPacing.Normalized()
 	}
+	memory := settings.Memory
+	if attrs["memory"] != nil {
+		if err := decodeYAMLValue(attrs["memory"], &memory); err != nil {
+			return Settings{}, fmt.Errorf("global.memory: %w", err)
+		}
+	}
 
 	settings.MaxConcurrentAgents = maxConcurrentAgents
 	settings.RateWindowPacing = rateWindowPacing
@@ -1972,6 +2076,7 @@ func buildSettings(attrs map[string]any, opts options) (Settings, error) {
 	settings.Knowledge = knowledge
 	settings.FairShare = fairShare
 	settings.Startup = startup
+	settings.Memory = memory
 	return settings, nil
 }
 
@@ -2122,6 +2227,12 @@ func buildProjects(projects []any, opts options) ([]Project, error) {
 		if err != nil {
 			return nil, err
 		}
+		var memory ProjectMemory
+		if project["memory"] != nil {
+			if err := decodeYAMLValue(project["memory"], &memory); err != nil {
+				return nil, fmt.Errorf("%s.memory: %w", prefix, err)
+			}
+		}
 
 		out = append(out, Project{
 			ID:                       strings.TrimSpace(id),
@@ -2143,6 +2254,7 @@ func buildProjects(projects []any, opts options) ([]Project, error) {
 			CredentialRef:            credentialRef,
 			Authorization:            authorization,
 			Intake:                   projectIntake,
+			Memory:                   memory,
 			IntakeConfigured:         intakeConfigured,
 		})
 	}

--- a/internal/config/global/config_test.go
+++ b/internal/config/global/config_test.go
@@ -230,11 +230,57 @@ func TestDefaultConfig(t *testing.T) {
 	if got := cfg.Global.Startup["max_spawn_per_second"]; got != 2 {
 		t.Fatalf("Global.Startup[max_spawn_per_second] = %v, want 2", got)
 	}
+	if cfg.Global.Memory.MaxAgentRSSBytes != DefaultMaxAgentRSSBytes ||
+		cfg.Global.Memory.PressureSomeAvg60Threshold != DefaultMemoryPressureSomeAvg60Threshold ||
+		cfg.Global.Memory.PollIntervalMS != DefaultMemoryPollIntervalMS {
+		t.Fatalf("Global.Memory = %#v, want defaults", cfg.Global.Memory)
+	}
 	if cfg.Global.Identity.Configured() {
 		t.Fatalf("Global.Identity = %#v, want omitted default", cfg.Global.Identity)
 	}
 	if len(cfg.Projects) != 0 {
 		t.Fatalf("Projects = %#v, want empty", cfg.Projects)
+	}
+}
+
+func TestReadMemorySettingsAndProjectOverride(t *testing.T) {
+	t.Parallel()
+
+	paths := createProjectFiles(t)
+	configPath := filepath.Join(paths.root, "global.yaml")
+	writeFile(t, configPath, `apiVersion: detent/v1
+kind: GlobalConfig
+global:
+  max_concurrent_agents: 8
+  scheduling: weighted
+  memory:
+    max_agent_rss_bytes: 4294967296
+    pressure_some_avg60_threshold: 12.5
+    poll_interval_ms: 250
+projects:
+  - id: detent
+    workflow: `+paths.workflow+`
+    workdir: `+paths.workdir+`
+    weight: 5
+    priority: 50
+    memory:
+      max_agent_rss_bytes: 2147483648
+`)
+
+	cfg, err := Read(configPath, WithHome(paths.home))
+	if err != nil {
+		t.Fatalf("Read() error = %v", err)
+	}
+	wantGlobal := Memory{MaxAgentRSSBytes: 4294967296, PressureSomeAvg60Threshold: 12.5, PollIntervalMS: 250}
+	if cfg.Global.Memory != wantGlobal {
+		t.Fatalf("Global.Memory = %#v, want %#v", cfg.Global.Memory, wantGlobal)
+	}
+	project := cfg.Projects[0]
+	project.GlobalMemory = cfg.Global.Memory
+	wantProject := wantGlobal
+	wantProject.MaxAgentRSSBytes = 2147483648
+	if got := project.EffectiveMemory(); got != wantProject {
+		t.Fatalf("EffectiveMemory() = %#v, want %#v", got, wantProject)
 	}
 }
 
@@ -559,6 +605,7 @@ func TestWriteRoundTripsConfig(t *testing.T) {
 			},
 			FairShare: map[string]any{"half_life": "30m"},
 			Startup:   map[string]any{"jitter_seconds": 0, "max_spawn_per_second": 1},
+			Memory:    defaultSettings().Memory,
 			Identity: Identity{
 				Name:          "release-captain",
 				GitHubLogin:   "detent-bot",
@@ -1400,6 +1447,33 @@ projects: []
 `,
 			want: []string{
 				"instance_name: must be a single line",
+			},
+		},
+		{
+			name: "invalid memory settings",
+			raw: `apiVersion: detent/v1
+kind: GlobalConfig
+global:
+  max_concurrent_agents: 8
+  scheduling: weighted
+  memory:
+    max_agent_rss_bytes: 0
+    pressure_some_avg60_threshold: -1
+    poll_interval_ms: fast
+projects:
+  - id: detent
+    workflow: ` + paths.workflow + `
+    workdir: ` + paths.workdir + `
+    weight: 5
+    priority: 50
+    memory:
+      max_agent_rss_bytes: -1
+`,
+			want: []string{
+				"global.memory.max_agent_rss_bytes: must be a positive integer",
+				"global.memory.pressure_some_avg60_threshold: must be a positive number",
+				"global.memory.poll_interval_ms: must be a positive integer",
+				"projects[0].memory.max_agent_rss_bytes: must be a positive integer",
 			},
 		},
 		{

--- a/internal/hostmemory/pressure.go
+++ b/internal/hostmemory/pressure.go
@@ -1,0 +1,88 @@
+package hostmemory
+
+import (
+	"errors"
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+)
+
+var ErrUnsupported = errors.New("host memory pressure is unsupported on this platform")
+
+type Sample struct {
+	Some       Pressure
+	Full       Pressure
+	ObservedAt time.Time
+}
+
+type Pressure struct {
+	Avg10  float64
+	Avg60  float64
+	Avg300 float64
+	Total  uint64
+}
+
+func Parse(value string) (Sample, error) {
+	var sample Sample
+	seen := map[string]bool{}
+	for line := range strings.Lines(value) {
+		fields := strings.Fields(line)
+		if len(fields) == 0 {
+			continue
+		}
+		kind := fields[0]
+		if kind != "some" && kind != "full" {
+			continue
+		}
+		pressure, err := parsePressureFields(fields[1:])
+		if err != nil {
+			return Sample{}, fmt.Errorf("parse memory pressure %s: %w", kind, err)
+		}
+		if kind == "some" {
+			sample.Some = pressure
+		} else {
+			sample.Full = pressure
+		}
+		seen[kind] = true
+	}
+	if !seen["some"] {
+		return Sample{}, errors.New("parse memory pressure: some row is missing")
+	}
+	return sample, nil
+}
+
+func parsePressureFields(fields []string) (Pressure, error) {
+	values := make(map[string]string, len(fields))
+	for _, field := range fields {
+		key, value, ok := strings.Cut(field, "=")
+		if ok {
+			values[key] = value
+		}
+	}
+	avg10, err := parseFloat(values, "avg10")
+	if err != nil {
+		return Pressure{}, err
+	}
+	avg60, err := parseFloat(values, "avg60")
+	if err != nil {
+		return Pressure{}, err
+	}
+	avg300, err := parseFloat(values, "avg300")
+	if err != nil {
+		return Pressure{}, err
+	}
+	total, err := strconv.ParseUint(values["total"], 10, 64)
+	if err != nil {
+		return Pressure{}, fmt.Errorf("total: %w", err)
+	}
+	return Pressure{Avg10: avg10, Avg60: avg60, Avg300: avg300, Total: total}, nil
+}
+
+func parseFloat(values map[string]string, key string) (float64, error) {
+	value, err := strconv.ParseFloat(values[key], 64)
+	if err != nil {
+		return 0, fmt.Errorf("%s: %w", key, err)
+	}
+	return value, nil
+}

--- a/internal/hostmemory/pressure_test.go
+++ b/internal/hostmemory/pressure_test.go
@@ -1,0 +1,44 @@
+package hostmemory
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestParse(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name      string
+		input     string
+		wantAvg60 float64
+		wantTotal uint64
+		wantError string
+	}{
+		{
+			name:      "linux pressure sample",
+			input:     "some avg10=1.25 avg60=10.50 avg300=3.00 total=1234\nfull avg10=0.00 avg60=0.25 avg300=0.10 total=42\n",
+			wantAvg60: 10.5,
+			wantTotal: 42,
+		},
+		{name: "missing some", input: "full avg10=0 avg60=0 avg300=0 total=0\n", wantError: "some row is missing"},
+		{name: "malformed average", input: "some avg10=0 avg60=nope avg300=0 total=0\n", wantError: "avg60"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := Parse(test.input)
+			if test.wantError != "" {
+				if err == nil || !strings.Contains(err.Error(), test.wantError) {
+					t.Fatalf("Parse() error = %v, want containing %q", err, test.wantError)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("Parse() error = %v", err)
+			}
+			if got.Some.Avg60 != test.wantAvg60 || got.Full.Total != test.wantTotal {
+				t.Fatalf("Parse() = %#v, want some.avg60=%v full.total=%d", got, test.wantAvg60, test.wantTotal)
+			}
+		})
+	}
+}

--- a/internal/hostmemory/read_linux.go
+++ b/internal/hostmemory/read_linux.go
@@ -1,0 +1,27 @@
+//go:build linux
+
+package hostmemory
+
+import (
+	"context"
+	"os"
+	"time"
+)
+
+func Read(ctx context.Context) (Sample, error) {
+	select {
+	case <-ctx.Done():
+		return Sample{}, ctx.Err()
+	default:
+	}
+	data, err := os.ReadFile("/proc/pressure/memory")
+	if err != nil {
+		return Sample{}, err
+	}
+	sample, err := Parse(string(data))
+	if err != nil {
+		return Sample{}, err
+	}
+	sample.ObservedAt = time.Now().UTC()
+	return sample, nil
+}

--- a/internal/hostmemory/read_other.go
+++ b/internal/hostmemory/read_other.go
@@ -1,0 +1,9 @@
+//go:build !linux
+
+package hostmemory
+
+import "context"
+
+func Read(context.Context) (Sample, error) {
+	return Sample{}, ErrUnsupported
+}

--- a/internal/orchestrator/dispatch.go
+++ b/internal/orchestrator/dispatch.go
@@ -306,6 +306,7 @@ const (
 	dispatchIssueFailureTrackerUnavailable    = "tracker_unavailable"
 	dispatchIssueFailureForgeUnavailable      = "forge_unavailable"
 	dispatchIssueFailureCIUnavailable         = "ci_unavailable"
+	dispatchIssueFailureMemoryPressure        = "memory_pressure_high"
 	dispatchIssueFailureRecoveryRamp          = "dispatch_recovery_ramp"
 )
 
@@ -402,6 +403,9 @@ func (o *Orchestrator) dispatchIssueWithAdmission(
 	}
 	if !projectFailureBreakerAllowsDispatch(state, now) {
 		return dispatchIssueOutcome{reason: projectFailureBreakerDispatchPaused}
+	}
+	if state.MemoryPressure.DispatchHeld {
+		return dispatchIssueOutcome{reason: dispatchIssueFailureMemoryPressure}
 	}
 	if reason := dispatchRecoveryBlockReason(state, now); reason != "" {
 		return dispatchIssueOutcome{reason: reason}

--- a/internal/orchestrator/memory_pressure.go
+++ b/internal/orchestrator/memory_pressure.go
@@ -1,0 +1,52 @@
+package orchestrator
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"github.com/digitaldrywood/detent/internal/hostmemory"
+	"github.com/digitaldrywood/detent/internal/telemetry"
+)
+
+func (o *Orchestrator) observeMemoryPressure(ctx context.Context, state *State, now time.Time) {
+	if o == nil || state == nil || o.readMemoryPressure == nil || o.cfg.MemoryPressureSomeAvg60Max <= 0 {
+		return
+	}
+	if now.IsZero() {
+		now = o.clockNow()
+	}
+	pollInterval := o.cfg.MemoryPressurePollInterval
+	if pollInterval > 0 && !state.MemoryPressure.ObservedAt.IsZero() && now.Sub(state.MemoryPressure.ObservedAt) < pollInterval {
+		return
+	}
+	pressure := telemetry.MemoryPressure{
+		SomeAvg60Max: o.cfg.MemoryPressureSomeAvg60Max,
+		ObservedAt:   now.UTC(),
+	}
+	sample, err := o.readMemoryPressure(ctx)
+	if err != nil {
+		if !errors.Is(err, hostmemory.ErrUnsupported) {
+			pressure.LastError = err.Error()
+		}
+		state.MemoryPressure = pressure
+		return
+	}
+	if !sample.ObservedAt.IsZero() {
+		pressure.ObservedAt = sample.ObservedAt.UTC()
+	}
+	pressure.Supported = true
+	pressure.Some = pressureAverages(sample.Some)
+	pressure.Full = pressureAverages(sample.Full)
+	pressure.DispatchHeld = sample.Some.Avg60 > pressure.SomeAvg60Max
+	state.MemoryPressure = pressure
+}
+
+func pressureAverages(pressure hostmemory.Pressure) telemetry.PressureAverages {
+	return telemetry.PressureAverages{
+		Avg10:  pressure.Avg10,
+		Avg60:  pressure.Avg60,
+		Avg300: pressure.Avg300,
+		Total:  pressure.Total,
+	}
+}

--- a/internal/orchestrator/memory_pressure_test.go
+++ b/internal/orchestrator/memory_pressure_test.go
@@ -1,0 +1,90 @@
+package orchestrator
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/digitaldrywood/detent/internal/connector"
+	"github.com/digitaldrywood/detent/internal/hostmemory"
+)
+
+func TestObserveMemoryPressureControlsAdmission(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name          string
+		avg60         float64
+		readErr       error
+		wantSupported bool
+		wantHeld      bool
+	}{
+		{name: "below threshold admits", avg60: 9.99, wantSupported: true},
+		{name: "at threshold admits", avg60: 10, wantSupported: true},
+		{name: "above threshold holds", avg60: 10.01, wantSupported: true, wantHeld: true},
+		{name: "unsupported platform admits", readErr: hostmemory.ErrUnsupported},
+		{name: "read failure admits", readErr: errors.New("pressure unavailable")},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			now := time.Date(2026, 8, 18, 17, 0, 0, 0, time.UTC)
+			orch := &Orchestrator{
+				cfg: Config{MemoryPressureSomeAvg60Max: 10, MemoryPressurePollInterval: time.Second},
+				readMemoryPressure: func(context.Context) (hostmemory.Sample, error) {
+					return hostmemory.Sample{Some: hostmemory.Pressure{Avg60: tt.avg60}, ObservedAt: now}, tt.readErr
+				},
+				now: func() time.Time { return now },
+			}
+			state := newState(normalizeConfig(orch.cfg))
+			orch.observeMemoryPressure(t.Context(), &state, now)
+			if state.MemoryPressure.Supported != tt.wantSupported || state.MemoryPressure.DispatchHeld != tt.wantHeld {
+				t.Fatalf("MemoryPressure = %#v, want supported %v held %v", state.MemoryPressure, tt.wantSupported, tt.wantHeld)
+			}
+			if tt.wantSupported && state.MemoryPressure.Some.Avg60 != tt.avg60 {
+				t.Fatalf("Some.Avg60 = %v, want %v", state.MemoryPressure.Some.Avg60, tt.avg60)
+			}
+		})
+	}
+}
+
+func TestObserveMemoryPressureResumesAfterPressureFalls(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 8, 18, 17, 0, 0, 0, time.UTC)
+	avg60 := 11.0
+	orch := &Orchestrator{
+		cfg: Config{MemoryPressureSomeAvg60Max: 10, MemoryPressurePollInterval: time.Second},
+		readMemoryPressure: func(context.Context) (hostmemory.Sample, error) {
+			return hostmemory.Sample{Some: hostmemory.Pressure{Avg60: avg60}}, nil
+		},
+		now: func() time.Time { return now },
+	}
+	state := newState(normalizeConfig(orch.cfg))
+	orch.observeMemoryPressure(t.Context(), &state, now)
+	if !state.MemoryPressure.DispatchHeld {
+		t.Fatal("DispatchHeld = false above threshold")
+	}
+	outcome := orch.dispatchIssueWithAdmission(
+		t.Context(),
+		&state,
+		connector.Issue{ID: "issue-1899"},
+		0,
+		now,
+		"",
+		false,
+		nil,
+	)
+	if outcome.dispatched || outcome.reason != dispatchIssueFailureMemoryPressure {
+		t.Fatalf("dispatch outcome = %#v, want memory pressure hold", outcome)
+	}
+	avg60 = 9
+	now = now.Add(time.Second)
+	orch.observeMemoryPressure(t.Context(), &state, now)
+	if state.MemoryPressure.DispatchHeld {
+		t.Fatal("DispatchHeld = true after pressure fell below threshold")
+	}
+}

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -14,6 +14,7 @@ import (
 	"github.com/digitaldrywood/detent/internal/connector"
 	"github.com/digitaldrywood/detent/internal/efficiency"
 	"github.com/digitaldrywood/detent/internal/gate"
+	"github.com/digitaldrywood/detent/internal/hostmemory"
 	"github.com/digitaldrywood/detent/internal/procgroup"
 	releasepkg "github.com/digitaldrywood/detent/internal/release"
 	runpkg "github.com/digitaldrywood/detent/internal/runner"
@@ -126,6 +127,8 @@ type Config struct {
 	StalenessDelivery             staleness.DeliveryConfig
 	StrandedActiveThreshold       time.Duration
 	DispatchStallThreshold        time.Duration
+	MemoryPressureSomeAvg60Max    float64
+	MemoryPressurePollInterval    time.Duration
 }
 
 type LessonCaptureConfig struct {
@@ -169,6 +172,8 @@ type Dependencies struct {
 	Activity             *activity.Broker
 	Release              releasepkg.Coordinator
 	GlobalDispatchGate   scheduler.ProjectDispatchGate
+	DispatchPacer        runpkg.DispatchPacer
+	ReadMemoryPressure   func(context.Context) (hostmemory.Sample, error)
 	Now                  func() time.Time
 	Logger               *slog.Logger
 	Retrospector         Retrospector
@@ -225,6 +230,7 @@ type Orchestrator struct {
 	reaper                  WorkspaceReaper
 	logger                  *slog.Logger
 	globalDispatchGate      scheduler.ProjectDispatchGate
+	readMemoryPressure      func(context.Context) (hostmemory.Sample, error)
 	validatorMu             sync.Mutex
 	validatorWG             sync.WaitGroup
 	validatorRuns           map[string]struct{}
@@ -500,6 +506,10 @@ func New(cfg Config, deps Dependencies) (*Orchestrator, error) {
 	if newStalenessNotifier == nil {
 		newStalenessNotifier = staleness.NewNotifier
 	}
+	readMemoryPressure := deps.ReadMemoryPressure
+	if readMemoryPressure == nil {
+		readMemoryPressure = hostmemory.Read
+	}
 
 	supervisor, err := runpkg.NewSupervisor(runner, runpkg.SupervisorConfig{
 		MaxRetryBackoff:       cfg.MaxRetryBackoff,
@@ -507,6 +517,7 @@ func New(cfg Config, deps Dependencies) (*Orchestrator, error) {
 		OverloadRetryDelay:    cfg.OverloadRetryDelay,
 		Now:                   now,
 		Logger:                logger,
+		DispatchPacer:         deps.DispatchPacer,
 	})
 	if err != nil {
 		return nil, err
@@ -529,6 +540,7 @@ func New(cfg Config, deps Dependencies) (*Orchestrator, error) {
 		reaper:                  reaper,
 		logger:                  logger,
 		globalDispatchGate:      deps.GlobalDispatchGate,
+		readMemoryPressure:      readMemoryPressure,
 		validatorRuns:           map[string]struct{}{},
 		validatorResults:        map[string]validatorStageResult{},
 		validatorFailures:       map[string]validatorStageFailure{},
@@ -1030,6 +1042,7 @@ func (o *Orchestrator) applyRuntimeUpdate(state *State, update RuntimeUpdate, ti
 	state.RateWindowPacing = cfg.RateWindowPacing
 	state.StrandedActiveThreshold = cfg.StrandedActiveThreshold
 	state.DispatchStallThreshold = cfg.DispatchStallThreshold
+	state.MemoryPressure.SomeAvg60Max = cfg.MemoryPressureSomeAvg60Max
 	state.AutoPromoteQuietDuration = cfg.AutoPromote.QuietDuration
 	state.AutoPromote = cloneAutoPromoteConfig(cfg.AutoPromote)
 	state.ActiveStates = append([]string(nil), cfg.ActiveStates...)

--- a/internal/orchestrator/run_completion.go
+++ b/internal/orchestrator/run_completion.go
@@ -75,6 +75,11 @@ func (o *Orchestrator) handleRunUpdate(state *State, event runUpdate) {
 	if diffStatsPresent(event.usage.DiffStats) {
 		running.DiffStats = event.usage.DiffStats
 	}
+	if !event.usage.RSSObservedAt.IsZero() {
+		running.RSSBytes = event.usage.RSSBytes
+		running.RSSCeilingBytes = event.usage.RSSCeilingBytes
+		running.RSSObservedAt = event.usage.RSSObservedAt
+	}
 	running.Tokens = event.usage.Tokens
 	state.Running[event.issueID] = running
 	o.trackRunningHeartbeat(state, running, state.Claimed[event.issueID], o.clockNow())

--- a/internal/orchestrator/session_brake.go
+++ b/internal/orchestrator/session_brake.go
@@ -70,6 +70,8 @@ func (o *Orchestrator) handleSessionBrake(
 			"elapsed", brake.Elapsed,
 			"turns", brake.Turns,
 			"tokens", brake.Tokens,
+			"rss_bytes", brake.RSSBytes,
+			"rss_ceiling_bytes", brake.RSSCeilingBytes,
 			"target_state", targetState,
 			"resumable", resumable,
 		)
@@ -78,7 +80,11 @@ func (o *Orchestrator) handleSessionBrake(
 	terminalState := store.WorkAttemptTerminalTimedOut
 	phase := "timed_out"
 	statusMessage := "agent session exceeded its configured catastrophe bound"
-	if errors.Is(brake, runpkg.ErrSessionNoProgress) {
+	if errors.Is(brake, runpkg.ErrSessionMemoryCeilingExceeded) {
+		terminalState = store.WorkAttemptTerminalMemoryCeiling
+		phase = runpkg.FinalStateMemoryCeilingExceeded
+		statusMessage = "agent session stopped after exceeding its memory ceiling"
+	} else if errors.Is(brake, runpkg.ErrSessionNoProgress) {
 		terminalState = store.WorkAttemptTerminalNoProgress
 		phase = "no_progress"
 		statusMessage = "agent session stopped after no work-product progress"
@@ -227,6 +233,8 @@ func sessionBrakeMetadata(brake *runpkg.SessionBrakeError, targetState string, r
 			"elapsed_seconds":     brake.Elapsed.Seconds(),
 			"turns":               brake.Turns,
 			"tokens":              brake.Tokens,
+			"rss_bytes":           brake.RSSBytes,
+			"rss_ceiling_bytes":   brake.RSSCeilingBytes,
 			"configured_duration": brake.Limit.String(),
 			"configured_turns":    brake.MaxTurns,
 			"last_progress_at":    brake.LastProgressAt.UTC().Format(time.RFC3339Nano),
@@ -249,6 +257,12 @@ func sessionBrakeComment(brake *runpkg.SessionBrakeError, targetState string, re
 	body.WriteString(strconv.Itoa(brake.Turns))
 	body.WriteString("\n- tokens: ")
 	body.WriteString(strconv.FormatInt(brake.Tokens, 10))
+	if brake.RSSCeilingBytes > 0 {
+		body.WriteString("\n- rss_bytes: ")
+		body.WriteString(strconv.FormatUint(brake.RSSBytes, 10))
+		body.WriteString("\n- rss_ceiling_bytes: ")
+		body.WriteString(strconv.FormatUint(brake.RSSCeilingBytes, 10))
+	}
 	body.WriteString("\n- resumable: ")
 	body.WriteString(strconv.FormatBool(resumable))
 	body.WriteString("\n- parked_state: ")

--- a/internal/orchestrator/session_brake_test.go
+++ b/internal/orchestrator/session_brake_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/digitaldrywood/detent/internal/connector/memory"
 	runpkg "github.com/digitaldrywood/detent/internal/runner"
 	"github.com/digitaldrywood/detent/internal/scheduler"
+	"github.com/digitaldrywood/detent/internal/store"
 )
 
 func TestSessionBrakeReleasesSlotRecordsCauseAndParks(t *testing.T) {
@@ -26,11 +27,13 @@ func TestSessionBrakeReleasesSlotRecordsCauseAndParks(t *testing.T) {
 		reworkState  string
 		wantState    string
 		finalState   string
+		wantTerminal store.WorkAttemptTerminalState
 	}{
 		{
-			name:       "no work product returns to todo",
-			wantState:  "Todo",
-			finalState: runpkg.FinalStateSessionDurationExceeded,
+			name:         "no work product returns to todo",
+			wantState:    "Todo",
+			finalState:   runpkg.FinalStateSessionDurationExceeded,
+			wantTerminal: store.WorkAttemptTerminalTimedOut,
 		},
 		{
 			name:      "workspace progress moves to rework",
@@ -42,8 +45,9 @@ func TestSessionBrakeReleasesSlotRecordsCauseAndParks(t *testing.T) {
 				Fingerprint:     "workspace-progress",
 				Status:          "changed",
 			},
-			wantState:  "Rework",
-			finalState: runpkg.FinalStateNoProgress,
+			wantState:    "Rework",
+			finalState:   runpkg.FinalStateNoProgress,
+			wantTerminal: store.WorkAttemptTerminalNoProgress,
 		},
 		{
 			name:         "workspace progress uses configured rework state",
@@ -52,6 +56,7 @@ func TestSessionBrakeReleasesSlotRecordsCauseAndParks(t *testing.T) {
 			reworkState:  "Production Rework",
 			wantState:    "production rework",
 			finalState:   runpkg.FinalStateNoProgress,
+			wantTerminal: store.WorkAttemptTerminalNoProgress,
 		},
 		{
 			name:         "workspace progress falls back to todo when rework is inactive",
@@ -59,6 +64,13 @@ func TestSessionBrakeReleasesSlotRecordsCauseAndParks(t *testing.T) {
 			activeStates: []string{"Todo", "In Progress"},
 			wantState:    "Todo",
 			finalState:   runpkg.FinalStateNoProgress,
+			wantTerminal: store.WorkAttemptTerminalNoProgress,
+		},
+		{
+			name:         "memory ceiling returns to todo without breaker strike",
+			wantState:    "Todo",
+			finalState:   runpkg.FinalStateMemoryCeilingExceeded,
+			wantTerminal: store.WorkAttemptTerminalMemoryCeiling,
 		},
 	}
 
@@ -93,8 +105,14 @@ func TestSessionBrakeReleasesSlotRecordsCauseAndParks(t *testing.T) {
 				LastProgressAt:   startedAt.Add(45 * time.Minute),
 				Resumable:        tt.resumable,
 			}
-			if tt.finalState == runpkg.FinalStateNoProgress {
+			switch tt.finalState {
+			case runpkg.FinalStateNoProgress:
 				brake.Reason = runpkg.SessionBrakeReasonNoProgress
+			case runpkg.FinalStateMemoryCeilingExceeded:
+				brake.Reason = runpkg.SessionBrakeReasonMemory
+				brake.RSSBytes = 9 << 30
+				brake.RSSCeilingBytes = 8 << 30
+				brake.CauseFingerprint = "memory-ceiling-1572"
 			}
 			runner := sessionBrakeCompletionRunner{
 				result: RunResult{
@@ -143,6 +161,10 @@ func TestSessionBrakeReleasesSlotRecordsCauseAndParks(t *testing.T) {
 				logger:             slog.New(slog.NewTextHandler(&logs, nil)),
 			}
 			state := newState(cfg)
+			if tt.finalState == runpkg.FinalStateMemoryCeilingExceeded {
+				state.InstantFailures[issue.ID] = InstantFailure{Count: instantFailureThreshold - 1}
+				state.RepeatedFailures[issue.ID] = RepeatedFailure{Count: repeatedFailureThreshold - 1}
+			}
 
 			if !orch.dispatchIssue(t.Context(), &state, issue, 1, startedAt, "") {
 				t.Fatal("dispatchIssue() = false, want true")
@@ -186,6 +208,9 @@ func TestSessionBrakeReleasesSlotRecordsCauseAndParks(t *testing.T) {
 			if len(attempts.completions) != 1 {
 				t.Fatalf("work attempt completions = %#v, want one", attempts.completions)
 			}
+			if attempts.completions[0].TerminalState != tt.wantTerminal {
+				t.Fatalf("terminal state = %q, want %q", attempts.completions[0].TerminalState, tt.wantTerminal)
+			}
 			var metadata map[string]any
 			if err := json.Unmarshal([]byte(attempts.completions[0].WorkerMetadataJSON), &metadata); err != nil {
 				t.Fatalf("unmarshal work attempt metadata: %v", err)
@@ -193,6 +218,20 @@ func TestSessionBrakeReleasesSlotRecordsCauseAndParks(t *testing.T) {
 			sessionBrake, ok := metadata[sessionBrakeMetadataKey].(map[string]any)
 			if !ok || sessionBrake["cause_fingerprint"] != brake.CauseFingerprint {
 				t.Fatalf("session brake metadata = %#v, want cause fingerprint", metadata)
+			}
+			if tt.finalState == runpkg.FinalStateMemoryCeilingExceeded {
+				if sessionBrake["rss_bytes"] != float64(brake.RSSBytes) || sessionBrake["rss_ceiling_bytes"] != float64(brake.RSSCeilingBytes) {
+					t.Fatalf("session brake metadata = %#v, want RSS evidence", sessionBrake)
+				}
+				if _, ok := state.InstantFailures[issue.ID]; ok {
+					t.Fatalf("InstantFailures[%q] present after memory ceiling", issue.ID)
+				}
+				if _, ok := state.RepeatedFailures[issue.ID]; ok {
+					t.Fatalf("RepeatedFailures[%q] present after memory ceiling", issue.ID)
+				}
+				if state.FailureBreaker.Count != 0 || len(state.FailureBreaker.Failures) != 0 {
+					t.Fatalf("FailureBreaker = %#v, want no memory ceiling strike", state.FailureBreaker)
+				}
 			}
 
 			var stateUpdated bool

--- a/internal/orchestrator/snapshot.go
+++ b/internal/orchestrator/snapshot.go
@@ -115,6 +115,7 @@ func (s State) Snapshot(now time.Time) telemetry.Snapshot {
 		CIUnavailable:           ciUnavailableSnapshots(s.CIUnavailable),
 		BackendOutages:          backendOutageSnapshots(s.BackendOutages),
 		FailureBreakers:         projectFailureBreakerSnapshots(s),
+		MemoryPressure:          s.MemoryPressure,
 		DispatchRecoveries:      dispatchRecoverySnapshots(s.DispatchRecoveries, s.PoolName, poolCapacity),
 		StalenessWarnings:       stalenessWarningSnapshots(s.StalenessWarnings),
 		StrandedActiveIssues:    strandedActiveIssues,
@@ -697,6 +698,9 @@ func runningSnapshots(running map[string]Running, claims map[string]Claimed, mer
 			DiffFiles:             entry.DiffStats.FilesChanged,
 			DiffStatus:            entry.DiffStats.Status,
 			Tokens:                tokensFromTokenTotals(entry.Tokens),
+			RSSBytes:              entry.RSSBytes,
+			RSSCeilingBytes:       entry.RSSCeilingBytes,
+			RSSObservedAt:         entry.RSSObservedAt,
 		})
 		out[len(out)-1].RuntimeIdentity = entry.RuntimeIdentity
 	}

--- a/internal/orchestrator/state.go
+++ b/internal/orchestrator/state.go
@@ -38,6 +38,7 @@ type State struct {
 	PoolDraining             bool
 	StrandedActiveThreshold  time.Duration
 	DispatchStallThreshold   time.Duration
+	MemoryPressure           telemetry.MemoryPressure
 	AutoPromoteQuietDuration time.Duration
 	AutoPromote              AutoPromoteConfig
 	ActiveStates             []string
@@ -146,6 +147,9 @@ type Running struct {
 	DiffStats                   DiffStats
 	WorkProductPushed           bool
 	Tokens                      TokenTotals
+	RSSBytes                    uint64
+	RSSCeilingBytes             uint64
+	RSSObservedAt               time.Time
 	CapacityScope               backendcapacity.Scope
 	CapacityProbe               bool
 	ForgeProbeHost              string
@@ -321,14 +325,17 @@ type DependencyAutoUnblockRecord struct {
 
 func newState(cfg Config) State {
 	return State{
-		PollInterval:             cfg.PollInterval,
-		RefreshFailureThreshold:  cfg.RefreshFailureThreshold,
-		MaxConcurrentAgents:      cfg.MaxConcurrentAgents,
-		BillingMode:              cfg.BillingMode,
-		RateWindowPacing:         cfg.RateWindowPacing,
-		MaxAgentsByState:         cloneStateLimits(cfg.MaxConcurrentAgentsByState),
-		StrandedActiveThreshold:  cfg.StrandedActiveThreshold,
-		DispatchStallThreshold:   cfg.DispatchStallThreshold,
+		PollInterval:            cfg.PollInterval,
+		RefreshFailureThreshold: cfg.RefreshFailureThreshold,
+		MaxConcurrentAgents:     cfg.MaxConcurrentAgents,
+		BillingMode:             cfg.BillingMode,
+		RateWindowPacing:        cfg.RateWindowPacing,
+		MaxAgentsByState:        cloneStateLimits(cfg.MaxConcurrentAgentsByState),
+		StrandedActiveThreshold: cfg.StrandedActiveThreshold,
+		DispatchStallThreshold:  cfg.DispatchStallThreshold,
+		MemoryPressure: telemetry.MemoryPressure{
+			SomeAvg60Max: cfg.MemoryPressureSomeAvg60Max,
+		},
 		AutoPromoteQuietDuration: cfg.AutoPromote.QuietDuration,
 		AutoPromote:              cloneAutoPromoteConfig(cfg.AutoPromote),
 		ActiveStates:             append([]string(nil), cfg.ActiveStates...),
@@ -388,6 +395,7 @@ func (s State) clone() State {
 		PoolDraining:             s.PoolDraining,
 		StrandedActiveThreshold:  s.StrandedActiveThreshold,
 		DispatchStallThreshold:   s.DispatchStallThreshold,
+		MemoryPressure:           s.MemoryPressure,
 		AutoPromoteQuietDuration: s.AutoPromoteQuietDuration,
 		AutoPromote:              cloneAutoPromoteConfig(s.AutoPromote),
 		ActiveStates:             append([]string(nil), s.ActiveStates...),

--- a/internal/orchestrator/tick.go
+++ b/internal/orchestrator/tick.go
@@ -68,6 +68,7 @@ func (o *Orchestrator) tickWithManual(ctx context.Context, state *State, now tim
 	restRateLimitsCaptured := false
 	previous := captureTickPreviousState(state)
 	o.markRefresh(state, now)
+	o.observeMemoryPressure(ctx, state, now)
 	defer func() {
 		o.finishRefresh(state, now, !restRateLimitsCaptured)
 		if manual != nil {

--- a/internal/procgroup/identity.go
+++ b/internal/procgroup/identity.go
@@ -1,6 +1,7 @@
 package procgroup
 
 import (
+	"context"
 	"errors"
 	"os/exec"
 	"time"
@@ -8,7 +9,10 @@ import (
 
 const DefaultTerminationGrace = 250 * time.Millisecond
 
-var ErrProcessNotRunning = errors.New("process is not running")
+var (
+	ErrProcessNotRunning = errors.New("process is not running")
+	ErrRSSUnsupported    = errors.New("process RSS inspection is unsupported on this platform")
+)
 
 type Identity struct {
 	PID       int
@@ -44,6 +48,10 @@ func Alive(identity Identity) (bool, error) {
 		return false, err
 	}
 	return sameIdentity(current, identity), nil
+}
+
+func RSS(ctx context.Context, identity Identity) (uint64, error) {
+	return processGroupRSS(ctx, identity)
 }
 
 func sameIdentity(current Identity, recorded Identity) bool {

--- a/internal/procgroup/rss_other.go
+++ b/internal/procgroup/rss_other.go
@@ -1,0 +1,9 @@
+//go:build !unix
+
+package procgroup
+
+import "context"
+
+func processGroupRSS(context.Context, Identity) (uint64, error) {
+	return 0, ErrRSSUnsupported
+}

--- a/internal/procgroup/rss_unix.go
+++ b/internal/procgroup/rss_unix.go
@@ -1,0 +1,48 @@
+//go:build unix
+
+package procgroup
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+)
+
+func processGroupRSS(ctx context.Context, identity Identity) (uint64, error) {
+	alive, err := Alive(identity)
+	if err != nil {
+		return 0, err
+	}
+	if !alive {
+		return 0, ErrProcessNotRunning
+	}
+	cmd := exec.CommandContext(ctx, "ps", "-axo", "pgid=,rss=")
+	cmd.Env = append(os.Environ(), "LC_ALL=C")
+	output, err := cmd.Output()
+	if err != nil {
+		return 0, fmt.Errorf("inspect process group RSS: %w", err)
+	}
+	return parseProcessGroupRSS(string(output), identity.GroupID)
+}
+
+func parseProcessGroupRSS(output string, groupID int) (uint64, error) {
+	if groupID <= 0 {
+		return 0, ErrProcessNotRunning
+	}
+	var totalKiB uint64
+	for line := range strings.Lines(output) {
+		fields := strings.Fields(line)
+		if len(fields) != 2 || fields[0] != strconv.Itoa(groupID) {
+			continue
+		}
+		rssKiB, err := strconv.ParseUint(fields[1], 10, 64)
+		if err != nil {
+			return 0, fmt.Errorf("parse process group %d RSS %q: %w", groupID, fields[1], err)
+		}
+		totalKiB += rssKiB
+	}
+	return totalKiB * 1024, nil
+}

--- a/internal/procgroup/rss_unix_test.go
+++ b/internal/procgroup/rss_unix_test.go
@@ -1,0 +1,30 @@
+//go:build unix
+
+package procgroup
+
+import "testing"
+
+func TestParseProcessGroupRSS(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name    string
+		output  string
+		groupID int
+		want    uint64
+	}{
+		{name: "sums group members", output: " 10 512\n 20 1024\n 10 256\n", groupID: 10, want: 768 * 1024},
+		{name: "missing group", output: " 20 1024\n", groupID: 10, want: 0},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := parseProcessGroupRSS(test.output, test.groupID)
+			if err != nil {
+				t.Fatalf("parseProcessGroupRSS() error = %v", err)
+			}
+			if got != test.want {
+				t.Fatalf("parseProcessGroupRSS() = %d, want %d", got, test.want)
+			}
+		})
+	}
+}

--- a/internal/project/manager.go
+++ b/internal/project/manager.go
@@ -122,6 +122,7 @@ func ManagerConfigFromGlobal(cfg globalconfig.Config) ManagerConfig {
 	for index := range projects {
 		projects[index].GlobalKnowledge = cfg.Global.Knowledge
 		projects[index].GlobalRateWindowPacing = cfg.Global.RateWindowPacing
+		projects[index].GlobalMemory = cfg.Global.Memory
 		if cfg.Global.ActiveHours != nil {
 			activeHours := cfg.Global.ActiveHours.Normalize()
 			projects[index].GlobalActiveHours = &activeHours

--- a/internal/project/project.go
+++ b/internal/project/project.go
@@ -28,6 +28,7 @@ import (
 	releasepkg "github.com/digitaldrywood/detent/internal/release"
 	"github.com/digitaldrywood/detent/internal/retro"
 	"github.com/digitaldrywood/detent/internal/routine"
+	runpkg "github.com/digitaldrywood/detent/internal/runner"
 	"github.com/digitaldrywood/detent/internal/scheduler"
 	"github.com/digitaldrywood/detent/internal/selector"
 	"github.com/digitaldrywood/detent/internal/store"
@@ -115,6 +116,7 @@ type Dependencies struct {
 	Runner                    orchestrator.Runner
 	Scheduler                 scheduler.Scheduler
 	GlobalDispatchGate        scheduler.ProjectDispatchGate
+	DispatchPacer             runpkg.DispatchPacer
 	WorkflowMetrics           orchestrator.WorkflowMetricsRecorder
 	Efficiency                efficiency.Recorder
 	LifecycleExporter         efficiency.LifecycleExporter
@@ -318,6 +320,7 @@ func New(cfg Config, deps Dependencies) (*Project, error) {
 		Connector:          projectConnector,
 		Runner:             deps.Runner,
 		GlobalDispatchGate: deps.GlobalDispatchGate,
+		DispatchPacer:      deps.DispatchPacer,
 		WorkflowMetrics:    deps.WorkflowMetrics,
 		Efficiency:         deps.Efficiency,
 		LifecycleExporter:  lifecycleExporter,
@@ -1471,6 +1474,9 @@ func buildReleaseCoordinator(cfg workflowconfig.Config, projectConnector connect
 func projectOrchestratorConfig(project globalconfig.Project, workflow workflowconfig.Config) orchestrator.Config {
 	workflow = workflowConfigWithProjectIdentity(project, workflow)
 	cfg := orchestrator.ConfigFromWorkflow(workflow)
+	memory := project.EffectiveMemory()
+	cfg.MemoryPressureSomeAvg60Max = memory.PressureSomeAvg60Threshold
+	cfg.MemoryPressurePollInterval = time.Duration(memory.PollIntervalMS) * time.Millisecond
 	overrideUntil := activehours.ParsePersistedOverride(project.ActiveHoursOverrideUntil)
 	cfg.Project = scheduler.ProjectCandidate{
 		ID:                       project.ID,

--- a/internal/runner/agent.go
+++ b/internal/runner/agent.go
@@ -111,6 +111,9 @@ type Dependencies struct {
 	Now                 func() time.Time
 	Logger              *slog.Logger
 	AfterRunTimeout     time.Duration
+	MaxAgentRSSBytes    uint64
+	RSSPollInterval     time.Duration
+	ProcessRSS          func(context.Context, procgroup.Identity) (uint64, error)
 	sessionLimit        durationLimitContextFactory
 	turnLimit           durationLimitContextFactory
 	progressTicker      sessionProgressTickerFactory
@@ -134,6 +137,9 @@ type Runner struct {
 	now                 func() time.Time
 	logger              *slog.Logger
 	afterRunTimeout     time.Duration
+	maxAgentRSSBytes    uint64
+	rssPollInterval     time.Duration
+	processRSS          func(context.Context, procgroup.Identity) (uint64, error)
 	sessionLimit        durationLimitContextFactory
 	turnLimit           durationLimitContextFactory
 	progressTicker      sessionProgressTickerFactory
@@ -153,6 +159,12 @@ func NewRunner(deps Dependencies) (*Runner, error) {
 	}
 	if deps.AfterRunTimeout <= 0 {
 		deps.AfterRunTimeout = defaultAfterRunTimeout
+	}
+	if deps.RSSPollInterval <= 0 {
+		deps.RSSPollInterval = time.Second
+	}
+	if deps.ProcessRSS == nil {
+		deps.ProcessRSS = procgroup.RSS
 	}
 	if deps.sessionLimit == nil {
 		deps.sessionLimit = withAgentDurationLimit
@@ -208,6 +220,9 @@ func NewRunner(deps Dependencies) (*Runner, error) {
 		now:                 deps.Now,
 		logger:              deps.Logger,
 		afterRunTimeout:     deps.AfterRunTimeout,
+		maxAgentRSSBytes:    deps.MaxAgentRSSBytes,
+		rssPollInterval:     deps.RSSPollInterval,
+		processRSS:          deps.ProcessRSS,
 		sessionLimit:        deps.sessionLimit,
 		turnLimit:           deps.turnLimit,
 		progressTicker:      deps.progressTicker,
@@ -780,20 +795,62 @@ func runAgentBackendTurnWithToolsUsingLimit(
 		turnLimit = withAgentDurationLimit
 	}
 	run := func(ctx context.Context, request AgentTurnRequest) (AgentTurnResult, error) {
-		turnCtx, cancel := turnLimit(
+		limitCtx, cancelLimit := turnLimit(
 			ctx,
 			request.MaxDuration,
 			ErrTurnDurationExceeded,
 		)
-		defer cancel()
+		defer cancelLimit()
+		turnCtx, cancelTurn := context.WithCancelCause(limitCtx)
+		defer cancelTurn(nil)
 
 		var boundedUpdateHandler AgentUpdateHandler
 		var updateMu sync.Mutex
-		if onUpdate != nil {
+		var memoryGovernor sync.Once
+		var memoryGovernorWG sync.WaitGroup
+		if onUpdate != nil || request.MaxRSSBytes > 0 {
 			boundedUpdateHandler = func(update AgentUpdate) error {
 				updateMu.Lock()
 				defer updateMu.Unlock()
-				return onUpdate(turnCtx, update)
+				if onUpdate != nil {
+					if err := onUpdate(turnCtx, update); err != nil {
+						return err
+					}
+				}
+				if update.Type != AgentUpdateProcessStarted || request.MaxRSSBytes == 0 || update.WorkerProcess.PID <= 0 {
+					return nil
+				}
+				if err := observeAgentRSS(turnCtx, request, update.WorkerProcess, onUpdate); err != nil {
+					cancelTurn(err)
+					return err
+				}
+				memoryGovernor.Do(func() {
+					memoryGovernorWG.Add(1)
+					go func() {
+						defer memoryGovernorWG.Done()
+						interval := request.RSSPollInterval
+						if interval <= 0 {
+							interval = time.Second
+						}
+						ticker := time.NewTicker(interval)
+						defer ticker.Stop()
+						for {
+							select {
+							case <-turnCtx.Done():
+								return
+							case <-ticker.C:
+								updateMu.Lock()
+								err := observeAgentRSS(turnCtx, request, update.WorkerProcess, onUpdate)
+								updateMu.Unlock()
+								if err != nil {
+									cancelTurn(err)
+									return
+								}
+							}
+						}
+					}()
+				})
+				return nil
 			}
 		}
 		governedCtx, stopGovernor, err := startWorkerGitHubGovernor(turnCtx, request.workerGitHub, boundedUpdateHandler)
@@ -811,7 +868,12 @@ func runAgentBackendTurnWithToolsUsingLimit(
 		} else {
 			result, runErr = backend.RunTurn(governedCtx, request, boundedUpdateHandler)
 		}
+		cancelTurn(nil)
+		memoryGovernorWG.Wait()
 		runErr = errors.Join(runErr, stopGovernor())
+		if cause := context.Cause(turnCtx); errors.Is(cause, ErrSessionMemoryCeilingExceeded) {
+			return result, errors.Join(cause, runErr)
+		}
 		if cause := context.Cause(turnCtx); errors.Is(cause, ErrTurnDurationExceeded) {
 			return result, errors.Join(cause, runErr)
 		}
@@ -846,6 +908,35 @@ func runAgentBackendTurnWithToolsUsingLimit(
 		cleanupErr = fmt.Errorf("cleanup worker scratch: %w", cleanupErr)
 	}
 	return result, runErr, cleanupErr
+}
+
+func observeAgentRSS(
+	ctx context.Context,
+	request AgentTurnRequest,
+	identity procgroup.Identity,
+	onUpdate agentContextUpdateHandler,
+) error {
+	if request.MaxRSSBytes == 0 || request.processRSS == nil {
+		return nil
+	}
+	rssBytes, err := request.processRSS(ctx, identity)
+	if err != nil {
+		return nil
+	}
+	if onUpdate != nil {
+		if err := onUpdate(ctx, AgentUpdate{
+			Type:            AgentUpdateResourceUsage,
+			WorkerProcess:   identity,
+			RSSBytes:        rssBytes,
+			RSSCeilingBytes: request.MaxRSSBytes,
+		}); err != nil {
+			return err
+		}
+	}
+	if rssBytes <= request.MaxRSSBytes {
+		return nil
+	}
+	return &SessionMemoryCeilingError{RSSBytes: rssBytes, CeilingBytes: request.MaxRSSBytes}
 }
 
 func withAgentDurationLimit(ctx context.Context, duration time.Duration, limit error) (context.Context, context.CancelFunc) {
@@ -948,6 +1039,12 @@ func (r *Runner) runAgentTurn(
 	}, r.turnLimit)
 	if cause := context.Cause(ctx); cooperativeStopError(cause) || durationLimitError(cause) {
 		turnErr = cause
+	}
+	var memoryErr *SessionMemoryCeilingError
+	if errors.As(turnErr, &memoryErr) {
+		if brake := runRequest.sessionBrake.memoryCeiling(memoryErr, r.now()); brake != nil {
+			turnErr = brake
+		}
 	}
 	result.Output = progress.outputText()
 	result.SkillDraftProposed = skillDraftProposed(result.Output)
@@ -1387,9 +1484,12 @@ func (r *Runner) Run(ctx context.Context, req RunRequest) (RunResult, error) {
 		DeliverableKind:       deliverableKind,
 		DeliverableRepository: deliverableRepository,
 		IssueRepository:       agentTurnIssueRepository(workflow.Config, req.Issue),
+		MaxRSSBytes:           r.maxAgentRSSBytes,
+		RSSPollInterval:       r.rssPollInterval,
 		cacheStrategy:         workflow.Config.Workspace.CacheStrategy,
 		projectID:             r.projectID,
 		workerGitHub:          workerGitHub,
+		processRSS:            r.processRSS,
 	}
 	if mergeFallback && (turnRequest.MaxDuration <= 0 || sessionDuration < turnRequest.MaxDuration) {
 		turnRequest.MaxDuration = sessionDuration
@@ -2093,9 +2193,12 @@ func (r *Runner) Validate(ctx context.Context, req ValidatorRequest) (gate.Valid
 		TurnTimeout:        durationFromMillis(validator.TurnTimeoutMS),
 		MaxDuration:        durationFromMillis(workflow.Config.Agent.MaxTurnDurationMS),
 		ExtraWritableRoots: extraWritableRootsForWorkspace(sessionCtx, info.Path, r.logger),
+		MaxRSSBytes:        r.maxAgentRSSBytes,
+		RSSPollInterval:    r.rssPollInterval,
 		cacheStrategy:      workflow.Config.Workspace.CacheStrategy,
 		projectID:          r.projectID,
 		workerGitHub:       workerGitHub,
+		processRSS:         r.processRSS,
 	}, nil, nil, func(updateCtx context.Context, update AgentUpdate) error {
 		eventAt := r.now()
 		if update.Type == AgentUpdateTokenUsage {
@@ -2863,6 +2966,9 @@ func finalStateForTurnError(err error) string {
 	if errors.Is(err, ErrSessionTokenCeilingExceeded) {
 		return FinalStateTokenCeilingExceeded
 	}
+	if errors.Is(err, ErrSessionMemoryCeilingExceeded) {
+		return FinalStateMemoryCeilingExceeded
+	}
 	if errors.Is(err, ErrSessionDurationExceeded) {
 		return FinalStateSessionDurationExceeded
 	}
@@ -2998,6 +3104,9 @@ type agentRunProgress struct {
 	sessionID                 string
 	processIdentity           string
 	workerProcess             procgroup.Identity
+	rssBytes                  uint64
+	rssCeilingBytes           uint64
+	rssObservedAt             time.Time
 	turnIDs                   map[string]struct{}
 	messages                  map[string]*runtimeoutput.Buffer
 	messageOrder              []string
@@ -3047,6 +3156,12 @@ func (p *agentRunProgress) apply(update AgentUpdate, eventAt time.Time) {
 	}
 	if update.WorkerProcess.PID > 0 && !update.WorkerProcess.StartedAt.IsZero() {
 		p.workerProcess = update.WorkerProcess
+	}
+	if update.Type == AgentUpdateResourceUsage {
+		p.rssBytes = update.RSSBytes
+		p.rssCeilingBytes = update.RSSCeilingBytes
+		p.rssObservedAt = eventAt.UTC()
+		return
 	}
 	if update.TurnID != "" {
 		p.turnIDs[update.TurnID] = struct{}{}
@@ -3692,6 +3807,9 @@ func (r *Runner) publishRunUpdate(
 		WorkProductPushed:     progress.pullRequestHeadPushed() || progress.pullRequestUpdated(),
 		Tokens:                result.Tokens,
 		RateLimits:            result.RateLimits,
+		RSSBytes:              progress.rssBytes,
+		RSSCeilingBytes:       progress.rssCeilingBytes,
+		RSSObservedAt:         progress.rssObservedAt,
 	}
 	if req.Admission == nil {
 		diffStats, ok := r.liveDiffStats(ctx, info, issue, progress, eventAt)
@@ -4149,6 +4267,8 @@ func workerRunOutcome(err error, finalState string) string {
 		return "timed_out"
 	case errors.Is(err, ErrSessionTokenCeilingExceeded):
 		return FinalStateTokenCeilingExceeded
+	case errors.Is(err, ErrSessionMemoryCeilingExceeded):
+		return FinalStateMemoryCeilingExceeded
 	case err != nil:
 		return "failed"
 	case strings.EqualFold(strings.TrimSpace(finalState), FinalStateCompleted), strings.TrimSpace(finalState) == "":

--- a/internal/runner/dispatch_pacer.go
+++ b/internal/runner/dispatch_pacer.go
@@ -1,0 +1,103 @@
+package runner
+
+import (
+	"context"
+	"crypto/rand"
+	"math/big"
+	"sync"
+	"time"
+)
+
+type DispatchPacer interface {
+	Wait(context.Context) error
+}
+
+type StartupDispatchPacerConfig struct {
+	MaxStartsPerSecond int
+	Jitter             time.Duration
+	RampStarts         int
+	Sleep              func(context.Context, time.Duration) error
+	RandomJitter       func(time.Duration) time.Duration
+}
+
+type StartupDispatchPacer struct {
+	mu                 sync.Mutex
+	maxStartsPerSecond int
+	jitter             time.Duration
+	rampStarts         int
+	started            int
+	sleep              func(context.Context, time.Duration) error
+	randomJitter       func(time.Duration) time.Duration
+}
+
+func NewStartupDispatchPacer(cfg StartupDispatchPacerConfig) *StartupDispatchPacer {
+	if cfg.RampStarts < 1 {
+		cfg.RampStarts = 1
+	}
+	if cfg.Sleep == nil {
+		cfg.Sleep = sleepDispatchPacer
+	}
+	if cfg.RandomJitter == nil {
+		cfg.RandomJitter = randomDispatchJitter
+	}
+	return &StartupDispatchPacer{
+		maxStartsPerSecond: cfg.MaxStartsPerSecond,
+		jitter:             cfg.Jitter,
+		rampStarts:         cfg.RampStarts,
+		sleep:              cfg.Sleep,
+		randomJitter:       cfg.RandomJitter,
+	}
+}
+
+func (p *StartupDispatchPacer) Wait(ctx context.Context) error {
+	if p == nil {
+		return nil
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if p.started >= p.rampStarts {
+		return nil
+	}
+	if p.started > 0 {
+		delay := time.Duration(0)
+		if p.maxStartsPerSecond > 0 {
+			delay = time.Second / time.Duration(p.maxStartsPerSecond)
+		}
+		if p.jitter > 0 {
+			delay += p.randomJitter(p.jitter)
+		}
+		if err := p.sleep(ctx, delay); err != nil {
+			return err
+		}
+	}
+	p.started++
+	return nil
+}
+
+func sleepDispatchPacer(ctx context.Context, delay time.Duration) error {
+	if delay <= 0 {
+		return nil
+	}
+	timer := time.NewTimer(delay)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		return context.Cause(ctx)
+	case <-timer.C:
+		return nil
+	}
+}
+
+func randomDispatchJitter(maximum time.Duration) time.Duration {
+	if maximum <= 0 {
+		return 0
+	}
+	value, err := rand.Int(rand.Reader, big.NewInt(int64(maximum)))
+	if err != nil {
+		return 0
+	}
+	return time.Duration(value.Int64())
+}

--- a/internal/runner/dispatch_pacer_test.go
+++ b/internal/runner/dispatch_pacer_test.go
@@ -1,0 +1,111 @@
+package runner
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+func TestStartupDispatchPacerRampsInitialStarts(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		config     StartupDispatchPacerConfig
+		waits      int
+		wantDelays []time.Duration
+	}{
+		{
+			name: "spaces the configured startup width",
+			config: StartupDispatchPacerConfig{
+				MaxStartsPerSecond: 2,
+				Jitter:             100 * time.Millisecond,
+				RampStarts:         4,
+			},
+			waits:      6,
+			wantDelays: []time.Duration{525 * time.Millisecond, 525 * time.Millisecond, 525 * time.Millisecond},
+		},
+		{
+			name: "single startup slot needs no delay",
+			config: StartupDispatchPacerConfig{
+				MaxStartsPerSecond: 1,
+				Jitter:             time.Second,
+				RampStarts:         1,
+			},
+			waits: 3,
+		},
+		{
+			name: "rate alone spaces starts",
+			config: StartupDispatchPacerConfig{
+				MaxStartsPerSecond: 4,
+				RampStarts:         3,
+			},
+			waits:      3,
+			wantDelays: []time.Duration{250 * time.Millisecond, 250 * time.Millisecond},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			var delays []time.Duration
+			tt.config.Sleep = func(_ context.Context, delay time.Duration) error {
+				delays = append(delays, delay)
+				return nil
+			}
+			tt.config.RandomJitter = func(time.Duration) time.Duration { return 25 * time.Millisecond }
+			pacer := NewStartupDispatchPacer(tt.config)
+			for range tt.waits {
+				if err := pacer.Wait(t.Context()); err != nil {
+					t.Fatalf("Wait() error = %v", err)
+				}
+			}
+			if len(delays) != len(tt.wantDelays) {
+				t.Fatalf("delays = %v, want %v", delays, tt.wantDelays)
+			}
+			for index := range delays {
+				if delays[index] != tt.wantDelays[index] {
+					t.Fatalf("delays = %v, want %v", delays, tt.wantDelays)
+				}
+			}
+		})
+	}
+}
+
+func TestSupervisorPacesNormalDispatchBeforeRunningWorker(t *testing.T) {
+	t.Parallel()
+
+	var order []string
+	supervisor, err := NewSupervisor(orderRecordingBackend{order: &order}, SupervisorConfig{
+		DispatchPacer: orderRecordingPacer{order: &order},
+	})
+	if err != nil {
+		t.Fatalf("NewSupervisor() error = %v", err)
+	}
+	completion := supervisor.Run(t.Context(), RunRequest{})
+	if completion.Err != nil {
+		t.Fatalf("Run() error = %v", completion.Err)
+	}
+	if len(order) != 2 || order[0] != "pace" || order[1] != "run" {
+		t.Fatalf("order = %v, want [pace run]", order)
+	}
+}
+
+type orderRecordingPacer struct {
+	order *[]string
+}
+
+func (p orderRecordingPacer) Wait(context.Context) error {
+	*p.order = append(*p.order, "pace")
+	return nil
+}
+
+type orderRecordingBackend struct {
+	order *[]string
+}
+
+func (b orderRecordingBackend) Run(context.Context, RunRequest) (RunResult, error) {
+	*b.order = append(*b.order, "run")
+	return RunResult{}, nil
+}

--- a/internal/runner/memory_limit_test.go
+++ b/internal/runner/memory_limit_test.go
@@ -1,0 +1,94 @@
+package runner
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/digitaldrywood/detent/internal/procgroup"
+)
+
+func TestObserveAgentRSS(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		rssBytes   uint64
+		readErr    error
+		wantBreach bool
+		wantUpdate bool
+	}{
+		{name: "below ceiling", rssBytes: 511, wantUpdate: true},
+		{name: "at ceiling", rssBytes: 512, wantUpdate: true},
+		{name: "above ceiling", rssBytes: 513, wantBreach: true, wantUpdate: true},
+		{name: "read failure is fail open", readErr: errors.New("rss unavailable")},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			var updates []AgentUpdate
+			request := AgentTurnRequest{
+				MaxRSSBytes: 512,
+				processRSS: func(context.Context, procgroup.Identity) (uint64, error) {
+					return tt.rssBytes, tt.readErr
+				},
+			}
+			err := observeAgentRSS(t.Context(), request, procgroup.Identity{PID: 1899}, func(_ context.Context, update AgentUpdate) error {
+				updates = append(updates, update)
+				return nil
+			})
+			if got := errors.Is(err, ErrSessionMemoryCeilingExceeded); got != tt.wantBreach {
+				t.Fatalf("observeAgentRSS() error = %v, breach = %v, want %v", err, got, tt.wantBreach)
+			}
+			if got := len(updates) == 1; got != tt.wantUpdate {
+				t.Fatalf("updates = %#v, present = %v, want %v", updates, got, tt.wantUpdate)
+			}
+			if tt.wantUpdate && (updates[0].RSSBytes != tt.rssBytes || updates[0].RSSCeilingBytes != 512) {
+				t.Fatalf("resource update = %#v, want RSS %d and ceiling 512", updates[0], tt.rssBytes)
+			}
+		})
+	}
+}
+
+func TestRunAgentBackendTurnStopsOnInitialMemoryBreach(t *testing.T) {
+	t.Parallel()
+
+	backend := processStartingAgentBackend{identity: procgroup.Identity{PID: 1899}}
+	_, err, cleanupErr := runAgentBackendTurnWithToolsUsingLimit(
+		t.Context(),
+		backend,
+		AgentTurnRequest{
+			MaxRSSBytes: 512,
+			processRSS: func(context.Context, procgroup.Identity) (uint64, error) {
+				return 513, nil
+			},
+		},
+		nil,
+		nil,
+		nil,
+		nil,
+	)
+	if !errors.Is(err, ErrSessionMemoryCeilingExceeded) {
+		t.Fatalf("runAgentBackendTurnWithToolsUsingLimit() error = %v, want memory ceiling", err)
+	}
+	var memoryErr *SessionMemoryCeilingError
+	if !errors.As(err, &memoryErr) || memoryErr.RSSBytes != 513 || memoryErr.CeilingBytes != 512 {
+		t.Fatalf("memory error = %#v, want RSS 513 and ceiling 512", memoryErr)
+	}
+	if cleanupErr != nil {
+		t.Fatalf("cleanup error = %v, want nil", cleanupErr)
+	}
+}
+
+type processStartingAgentBackend struct {
+	identity procgroup.Identity
+}
+
+func (b processStartingAgentBackend) RunTurn(_ context.Context, _ AgentTurnRequest, onUpdate AgentUpdateHandler) (AgentTurnResult, error) {
+	if onUpdate == nil {
+		return AgentTurnResult{}, nil
+	}
+	return AgentTurnResult{}, onUpdate(AgentUpdate{Type: AgentUpdateProcessStarted, WorkerProcess: b.identity})
+}

--- a/internal/runner/session_brake.go
+++ b/internal/runner/session_brake.go
@@ -24,6 +24,7 @@ const (
 	SessionBrakeReasonDuration   = "session_duration_exceeded"
 	SessionBrakeReasonTurnLimit  = "session_turn_limit_exceeded"
 	SessionBrakeReasonNoProgress = "session_no_progress"
+	SessionBrakeReasonMemory     = FinalStateMemoryCeilingExceeded
 )
 
 var (
@@ -39,6 +40,8 @@ type SessionBrakeError struct {
 	Elapsed           time.Duration
 	Turns             int
 	Tokens            int64
+	RSSBytes          uint64
+	RSSCeilingBytes   uint64
 	LastProgressAt    time.Time
 	WorkspaceProgress string
 	WorkpadProgress   string
@@ -85,6 +88,8 @@ func (e *SessionBrakeError) Is(target error) bool {
 		return e.Reason == SessionBrakeReasonTurnLimit
 	case ErrSessionNoProgress:
 		return e.Reason == SessionBrakeReasonNoProgress
+	case ErrSessionMemoryCeilingExceeded:
+		return e.Reason == SessionBrakeReasonMemory
 	default:
 		return errors.Is(e.cause, target)
 	}
@@ -383,6 +388,19 @@ func (c *sessionBrakeController) newErrorLocked(reason string, cause error, limi
 	return brake
 }
 
+func (c *sessionBrakeController) memoryCeiling(err *SessionMemoryCeilingError, at time.Time) *SessionBrakeError {
+	if c == nil || err == nil {
+		return nil
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	brake := c.newErrorLocked(SessionBrakeReasonMemory, err, 0, at)
+	brake.RSSBytes = err.RSSBytes
+	brake.RSSCeilingBytes = err.CeilingBytes
+	brake.CauseFingerprint = sessionBrakeFingerprint(brake)
+	return brake
+}
+
 func (c *sessionBrakeController) resultDiffStats() DiffStats {
 	if c == nil {
 		return DiffStats{}
@@ -434,6 +452,7 @@ func sessionBrakeFingerprint(brake *SessionBrakeError) string {
 		strings.TrimSpace(brake.Reason),
 		brake.Limit.String(),
 		strconv.Itoa(brake.MaxTurns),
+		strconv.FormatUint(brake.RSSCeilingBytes, 10),
 		strings.TrimSpace(brake.WorkspaceProgress),
 		strings.TrimSpace(brake.WorkpadProgress),
 		strconv.Itoa(brake.FilesChanged),

--- a/internal/runner/supervisor.go
+++ b/internal/runner/supervisor.go
@@ -27,6 +27,7 @@ type SupervisorConfig struct {
 	OverloadRetryDelay    time.Duration
 	Now                   func() time.Time
 	Logger                *slog.Logger
+	DispatchPacer         DispatchPacer
 }
 
 type Supervisor struct {
@@ -37,6 +38,7 @@ type Supervisor struct {
 	overloadRetryDelay    time.Duration
 	now                   func() time.Time
 	logger                *slog.Logger
+	dispatchPacer         DispatchPacer
 }
 
 type Completion struct {
@@ -77,6 +79,7 @@ func NewSupervisor(backend Backend, cfg SupervisorConfig) (*Supervisor, error) {
 		overloadRetryDelay:    cfg.OverloadRetryDelay,
 		now:                   cfg.Now,
 		logger:                cfg.Logger,
+		dispatchPacer:         cfg.DispatchPacer,
 	}, nil
 }
 
@@ -189,6 +192,16 @@ func (s *Supervisor) Run(ctx context.Context, request RunRequest) (completion Co
 			WorkAttemptID:   request.WorkAttemptID,
 		}, attrs...)
 	}()
+	if s.dispatchPacer != nil {
+		if err := s.dispatchPacer.Wait(ctx); err != nil {
+			if cause := context.Cause(ctx); cause != nil {
+				err = cause
+			}
+			completion.CompletedAt = s.now()
+			completion.Err = err
+			return completion
+		}
+	}
 
 	result, err := s.backend.Run(ctx, request)
 	if cause := context.Cause(ctx); errors.Is(cause, ErrMergeWorkerStartupTimeout) ||
@@ -219,6 +232,7 @@ func cooperativeStopError(err error) bool {
 		errors.Is(err, ErrMergeWorkerDurationExceeded) ||
 		errors.Is(err, ErrMergeFallbackBudgetExceeded) ||
 		errors.Is(err, ErrSessionDurationExceeded) ||
+		errors.Is(err, ErrSessionMemoryCeilingExceeded) ||
 		errors.Is(err, ErrSessionTurnLimitExceeded) ||
 		errors.Is(err, ErrSessionNoProgress)
 }

--- a/internal/runner/types.go
+++ b/internal/runner/types.go
@@ -22,6 +22,7 @@ const (
 	FinalStateCompleted             = "completed"
 	FinalStateFailed                = "failed"
 	FinalStateTokenCeilingExceeded  = "token_ceiling_exceeded"
+	FinalStateMemoryCeilingExceeded = "memory_ceiling_exceeded"
 	FinalStateOperatorStopped       = "operator_stopped"
 	FinalStateMergeRevoked          = "merge_revoked"
 	FinalStateLaneRevoked           = "lane_revoked"
@@ -46,6 +47,7 @@ const (
 
 var (
 	ErrSessionTokenCeilingExceeded  = errors.New("session token ceiling exceeded")
+	ErrSessionMemoryCeilingExceeded = errors.New("session memory ceiling exceeded")
 	ErrTurnDurationExceeded         = errors.New("agent turn duration exceeded")
 	ErrSessionDurationExceeded      = errors.New("agent session duration exceeded")
 	ErrOperatorStopped              = errors.New("operator stopped run")
@@ -265,9 +267,12 @@ type AgentTurnRequest struct {
 	DeliverableRepository string
 	IssueRepository       string
 	Environment           procgroup.Environment
+	MaxRSSBytes           uint64
+	RSSPollInterval       time.Duration
 	cacheStrategy         string
 	projectID             string
 	workerGitHub          workerGitHubPolicy
+	processRSS            func(context.Context, procgroup.Identity) (uint64, error)
 }
 
 type AgentResume struct {
@@ -328,6 +333,7 @@ const (
 	AgentUpdateToolOutput       AgentUpdateType = "tool_output"
 	AgentUpdateToolCompleted    AgentUpdateType = "tool_completed"
 	AgentUpdateMCPElicitation   AgentUpdateType = "mcp_elicitation"
+	AgentUpdateResourceUsage    AgentUpdateType = "resource_usage"
 )
 
 type AgentUpdate struct {
@@ -348,6 +354,8 @@ type AgentUpdate struct {
 	BackendErrorMessage string
 	Tokens              AgentTokenUsage
 	RateLimits          *telemetry.RateLimits
+	RSSBytes            uint64
+	RSSCeilingBytes     uint64
 }
 
 type AgentTokenUsage struct {
@@ -375,6 +383,22 @@ type SessionTokenCeilingError struct {
 	Source             string
 	ModelContextWindow int64
 	ContextMultiplier  float64
+}
+
+type SessionMemoryCeilingError struct {
+	RSSBytes     uint64
+	CeilingBytes uint64
+}
+
+func (e *SessionMemoryCeilingError) Error() string {
+	if e == nil {
+		return ErrSessionMemoryCeilingExceeded.Error()
+	}
+	return fmt.Sprintf("%s: rss_bytes=%d ceiling_bytes=%d", ErrSessionMemoryCeilingExceeded, e.RSSBytes, e.CeilingBytes)
+}
+
+func (e *SessionMemoryCeilingError) Unwrap() error {
+	return ErrSessionMemoryCeilingExceeded
 }
 
 func (e *SessionTokenCeilingError) Error() string {
@@ -575,6 +599,9 @@ type UsageUpdate struct {
 	Tokens                TokenTotals
 	DiffStats             DiffStats
 	RateLimits            *telemetry.RateLimits
+	RSSBytes              uint64
+	RSSCeilingBytes       uint64
+	RSSObservedAt         time.Time
 }
 
 type BudgetRefusal struct {

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -325,6 +325,7 @@ const (
 	WorkAttemptTerminalSuperseded      WorkAttemptTerminalState = "superseded"
 	WorkAttemptTerminalAbandoned       WorkAttemptTerminalState = "abandoned"
 	WorkAttemptTerminalNoProgress      WorkAttemptTerminalState = "no_progress"
+	WorkAttemptTerminalMemoryCeiling   WorkAttemptTerminalState = "memory_ceiling_exceeded"
 	WorkAttemptTerminalCapacity        WorkAttemptTerminalState = "capacity"
 	WorkAttemptTerminalOperatorStopped WorkAttemptTerminalState = "operator_stopped"
 	WorkAttemptTerminalMergeRevoked    WorkAttemptTerminalState = "merge_revoked"

--- a/internal/telemetry/snapshot.go
+++ b/internal/telemetry/snapshot.go
@@ -55,9 +55,27 @@ type Snapshot struct {
 	Throughput              TokenThroughput     `json:"throughput"`
 	Concurrency             ConcurrencyHistory  `json:"concurrency"`
 	LifetimeTotals          LifetimeTotals      `json:"lifetime_totals"`
+	MemoryPressure          MemoryPressure      `json:"memory_pressure"`
 	CycleTime               CycleTimeReport     `json:"cycle_time"`
 	WorkflowMetrics         WorkflowMetrics     `json:"workflow_metrics"`
 	TokenTrend              []TokenTrendPoint   `json:"token_trend,omitempty"`
+}
+
+type MemoryPressure struct {
+	Supported    bool             `json:"supported"`
+	Some         PressureAverages `json:"some"`
+	Full         PressureAverages `json:"full"`
+	SomeAvg60Max float64          `json:"some_avg60_max"`
+	DispatchHeld bool             `json:"dispatch_held"`
+	ObservedAt   time.Time        `json:"observed_at,omitzero"`
+	LastError    string           `json:"last_error,omitempty"`
+}
+
+type PressureAverages struct {
+	Avg10  float64 `json:"avg10"`
+	Avg60  float64 `json:"avg60"`
+	Avg300 float64 `json:"avg300"`
+	Total  uint64  `json:"total"`
 }
 
 func (s Snapshot) AgeSeconds(now time.Time) int64 {
@@ -956,6 +974,9 @@ type Running struct {
 	DiffFiles             int                       `json:"diff_files"`
 	DiffStatus            string                    `json:"diff_status,omitempty"`
 	Tokens                Tokens                    `json:"tokens"`
+	RSSBytes              uint64                    `json:"rss_bytes"`
+	RSSCeilingBytes       uint64                    `json:"rss_ceiling_bytes"`
+	RSSObservedAt         time.Time                 `json:"rss_observed_at,omitzero"`
 }
 
 type StopRunPriorityOption struct {

--- a/internal/web/api.go
+++ b/internal/web/api.go
@@ -480,6 +480,7 @@ func stateResponse(snapshot telemetry.Snapshot, generatedAt time.Time, observedA
 		TokenTotals:        totalsResponse(snapshot.Tokens),
 		Throughput:         throughputResponse(snapshot.Throughput),
 		LifetimeTotals:     lifetimeTotalsResponseFromTelemetry(snapshot.LifetimeTotals),
+		MemoryPressure:     snapshot.MemoryPressure,
 		WorkflowMetrics:    snapshot.WorkflowMetrics,
 		RecentSessions:     recentSessionEntries(snapshot.Completed),
 		RateLimits:         snapshot.RateLimits,
@@ -658,6 +659,9 @@ func runningEntries(entries []telemetry.Running) []runningAPIResponse {
 			DiffFiles:             entry.DiffFiles,
 			DiffStatus:            diffStatus(entry.DiffStatus),
 			Tokens:                tokenCountsResponse(entry.Tokens),
+			RSSBytes:              entry.RSSBytes,
+			RSSCeilingBytes:       entry.RSSCeilingBytes,
+			RSSObservedAt:         timestampString(entry.RSSObservedAt),
 		})
 	}
 	return payload
@@ -1434,6 +1438,7 @@ type stateAPIResponse struct {
 	TokenTotals        tokenTotalsAPIResponse       `json:"codex_totals"`
 	Throughput         throughputAPIResponse        `json:"throughput"`
 	LifetimeTotals     lifetimeTotalsResponse       `json:"lifetime_totals"`
+	MemoryPressure     telemetry.MemoryPressure     `json:"memory_pressure"`
 	WorkflowMetrics    telemetry.WorkflowMetrics    `json:"workflow_metrics"`
 	RecentSessions     []recentSessionAPIResponse   `json:"recent_sessions"`
 	RateLimits         *telemetry.RateLimits        `json:"rate_limits"`
@@ -1515,6 +1520,9 @@ type runningAPIResponse struct {
 	DiffFiles             int                       `json:"diff_files"`
 	DiffStatus            string                    `json:"diff_status"`
 	Tokens                tokenCountsAPIResponse    `json:"tokens"`
+	RSSBytes              uint64                    `json:"rss_bytes"`
+	RSSCeilingBytes       uint64                    `json:"rss_ceiling_bytes"`
+	RSSObservedAt         *string                   `json:"rss_observed_at"`
 }
 
 type retryAPIResponse struct {

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -1097,6 +1097,8 @@ func (s *Server) health(c echo.Context) error {
 	notificationFailures := []healthnotify.Failure{}
 	refreshFailures := []telemetry.RefreshFailure{}
 	refresh := telemetry.Refresh{}
+	memoryPressure := telemetry.MemoryPressure{}
+	agentMemory := []healthAgentMemory{}
 	snapshotGeneratedAt := time.Time{}
 	snapshotAgeSeconds := int64(0)
 	if s.hub != nil {
@@ -1106,6 +1108,16 @@ func (s *Server) health(c echo.Context) error {
 			snapshotGeneratedAt = snapshot.GeneratedAt
 			snapshotAgeSeconds = snapshot.AgeSeconds(now)
 			refresh = snapshot.Refresh
+			memoryPressure = snapshot.MemoryPressure
+			for _, running := range snapshot.Running {
+				agentMemory = append(agentMemory, healthAgentMemory{
+					ProjectID:       running.ProjectID,
+					IssueIdentifier: running.Identifier,
+					RSSBytes:        running.RSSBytes,
+					RSSCeilingBytes: running.RSSCeilingBytes,
+					ObservedAt:      running.RSSObservedAt,
+				})
+			}
 			updateStatus = snapshot.Update
 			backendOutages = append(backendOutages, snapshot.BackendOutages...)
 			failureBreakers = append(failureBreakers, snapshot.FailureBreakers...)
@@ -1151,7 +1163,7 @@ func (s *Server) health(c echo.Context) error {
 	if status != "draining" {
 		budgets = s.enforcedBudgets()
 		workflows = s.workflowSources()
-		if len(trackerUnavailable) > 0 || len(forgeUnavailable) > 0 || len(ciUnavailable) > 0 || len(dispatchStalls) > 0 || len(failureBreakers) > 0 || len(backendOutages) > 0 || tickLivenessNeedsAttention(tickLiveness) || len(refreshFailures) > 0 {
+		if len(trackerUnavailable) > 0 || len(forgeUnavailable) > 0 || len(ciUnavailable) > 0 || len(dispatchStalls) > 0 || len(failureBreakers) > 0 || len(backendOutages) > 0 || tickLivenessNeedsAttention(tickLiveness) || len(refreshFailures) > 0 || memoryPressure.DispatchHeld {
 			status = "needs_attention"
 		}
 		if pauseExitNeedsAttention(projectHealth) {
@@ -1184,6 +1196,8 @@ func (s *Server) health(c echo.Context) error {
 		RefreshFailures:      refreshFailures,
 		Projects:             projectHealth,
 		Refresh:              refresh,
+		MemoryPressure:       memoryPressure,
+		AgentMemory:          agentMemory,
 		SnapshotGeneratedAt:  snapshotGeneratedAt,
 		SnapshotAgeSeconds:   snapshotAgeSeconds,
 		TickLiveness:         tickLiveness,
@@ -1545,9 +1559,19 @@ type healthResponse struct {
 	RefreshFailures      []telemetry.RefreshFailure   `json:"refresh_failures,omitempty"`
 	Projects             []healthProject              `json:"projects,omitempty"`
 	Refresh              telemetry.Refresh            `json:"refresh"`
+	MemoryPressure       telemetry.MemoryPressure     `json:"memory_pressure"`
+	AgentMemory          []healthAgentMemory          `json:"agent_memory"`
 	SnapshotGeneratedAt  time.Time                    `json:"snapshot_generated_at,omitzero"`
 	SnapshotAgeSeconds   int64                        `json:"snapshot_age_seconds"`
 	TickLiveness         []telemetry.TickLiveness     `json:"tick_liveness"`
+}
+
+type healthAgentMemory struct {
+	ProjectID       string    `json:"project_id,omitempty"`
+	IssueIdentifier string    `json:"issue_identifier,omitempty"`
+	RSSBytes        uint64    `json:"rss_bytes"`
+	RSSCeilingBytes uint64    `json:"rss_ceiling_bytes"`
+	ObservedAt      time.Time `json:"observed_at,omitzero"`
 }
 
 type healthEnvironment struct {

--- a/internal/web/server_test.go
+++ b/internal/web/server_test.go
@@ -6856,6 +6856,59 @@ func TestStateAPIIncludesProjectFailureBreakerEvidence(t *testing.T) {
 	}
 }
 
+func TestHealthAndStateReportMemoryPressureAndAgentRSS(t *testing.T) {
+	t.Parallel()
+
+	deps := testDeps(t)
+	now := time.Date(2026, 8, 18, 17, 0, 0, 0, time.UTC)
+	observedAt := now.Add(-time.Second)
+	if err := deps.Hub.Publish(telemetry.Snapshot{
+		GeneratedAt: now,
+		MemoryPressure: telemetry.MemoryPressure{
+			Supported:    true,
+			Some:         telemetry.PressureAverages{Avg60: 12.5},
+			SomeAvg60Max: 10,
+			DispatchHeld: true,
+			ObservedAt:   observedAt,
+		},
+		Running: []telemetry.Running{{
+			Issue:           telemetry.Issue{ProjectID: "detent", Identifier: "digitaldrywood/detent#1899"},
+			RSSBytes:        7 << 30,
+			RSSCeilingBytes: 8 << 30,
+			RSSObservedAt:   observedAt,
+		}},
+	}); err != nil {
+		t.Fatalf("Publish() error = %v", err)
+	}
+
+	server, err := web.NewServer(web.Config{}, deps)
+	if err != nil {
+		t.Fatalf("NewServer() error = %v", err)
+	}
+
+	health := requestJSON(t, server, http.MethodGet, "/health", http.StatusOK)
+	if health["status"] != "needs_attention" {
+		t.Fatalf("health status = %#v, want needs_attention", health["status"])
+	}
+	pressure := health["memory_pressure"].(map[string]any)
+	if pressure["dispatch_held"] != true || pressure["some"].(map[string]any)["avg60"] != 12.5 {
+		t.Fatalf("health memory_pressure = %#v", pressure)
+	}
+	agents := health["agent_memory"].([]any)
+	if len(agents) != 1 || agents[0].(map[string]any)["rss_bytes"] != float64(7<<30) || agents[0].(map[string]any)["rss_ceiling_bytes"] != float64(8<<30) {
+		t.Fatalf("health agent_memory = %#v", agents)
+	}
+
+	state := requestJSON(t, server, http.MethodGet, "/api/v1/state", http.StatusOK)
+	if state["memory_pressure"].(map[string]any)["dispatch_held"] != true {
+		t.Fatalf("state memory_pressure = %#v", state["memory_pressure"])
+	}
+	running := state["running"].([]any)
+	if len(running) != 1 || running[0].(map[string]any)["rss_bytes"] != float64(7<<30) {
+		t.Fatalf("state running = %#v", running)
+	}
+}
+
 func TestHealthReportsCICondition(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

- enforce a configurable per-agent process-tree RSS ceiling with a project override and a distinct breaker-safe terminal outcome
- hold dispatch under Linux host memory pressure, publish pressure and active-agent RSS health data, and pace normal worker starts after restart
- document systemd service memory limits as defense in depth for shared hosts

Fixes #1899

## UI Surface Contract

- [x] N/A, or the linked issue explicitly authorizes any high-impact UI surface, layout, density, first-viewport, or responsive visibility tradeoff.
- [x] Persistent top-of-screen messaging is explicitly authorized by the issue, or this PR does not add it.
- [x] Visual changes to primary operator screens include screenshot or browser verification below.

No visual operator-screen changes; the observable additions are JSON health and state fields.

## Test Plan

- [x] `make check`
- [x] table-driven RSS ceiling, breaker exclusion, PSI admission/resume, startup pacing, and health telemetry regressions
