### PR TITLE
fix(orchestrator): protect live rework

### DIFF
--- a/internal/orchestrator/autopromote_tick.go
+++ b/internal/orchestrator/autopromote_tick.go
@@ -384,6 +384,14 @@ func gateWaitAttemptMatchesPullRequest(attempt store.WorkAttempt, issue connecto
 	if !ok || strings.TrimSpace(record.Outcome) != string(store.WorkAttemptTerminalSuccess) {
 		return false
 	}
+	if issue.PullRequest == nil {
+		return false
+	}
+	currentHeadSHA := strings.TrimSpace(issue.PullRequest.HeadSHA)
+	attemptHeadSHA := strings.TrimSpace(record.CurrentSignature.HeadSHA)
+	if currentHeadSHA == "" || attemptHeadSHA == "" || attemptHeadSHA != currentHeadSHA {
+		return false
+	}
 	prNumber := int64(pullRequestNumber(issue))
 	if prNumber <= 0 {
 		return false

--- a/internal/orchestrator/autopromote_tick_test.go
+++ b/internal/orchestrator/autopromote_tick_test.go
@@ -716,6 +716,7 @@ func TestTickAutoPromoteRecoversActiveIssueAfterRestart(t *testing.T) {
 		Number:                 144,
 		URL:                    "https://github.test/digitaldrywood/detent/pull/144",
 		State:                  "OPEN",
+		HeadSHA:                "restart-head",
 		CIStatus:               "pending",
 		CodexReviewState:       "COMMENTED",
 		CodexReviewSubmittedAt: &oldReview,
@@ -804,6 +805,7 @@ func TestTickAutoPromoteRecoversOptionalReviewDeadlineAfterRestart(t *testing.T)
 		Number:         1297,
 		URL:            "https://github.test/digitaldrywood/detent/pull/1297",
 		State:          "OPEN",
+		HeadSHA:        "optional-head",
 		MergeableState: "clean",
 		CIStatus:       "success",
 	})
@@ -867,10 +869,12 @@ func TestLatestSuccessfulGateWaitAttemptRequiresCurrentImplementationEvidence(t 
 	currentPR := int64(144)
 	otherPR := int64(143)
 	currentSignature := autoPromoteReworkSignature{PRNumber: currentPR, HeadSHA: "current-head"}
+	staleSignature := autoPromoteReworkSignature{PRNumber: currentPR, HeadSHA: "stale-head"}
 	otherSignature := autoPromoteReworkSignature{PRNumber: otherPR, HeadSHA: "other-head"}
 	issue := autoPromoteTickIssue("issue-gate-wait-evidence", []string{"bug"}, &connector.PullRequest{
-		Number: 144,
-		State:  "OPEN",
+		Number:  144,
+		State:   "OPEN",
+		HeadSHA: "current-head",
 	})
 	issue.State = "In Progress"
 
@@ -905,39 +909,57 @@ func TestLatestSuccessfulGateWaitAttemptRequiresCurrentImplementationEvidence(t 
 			}},
 		},
 		{
-			name: "accepts current PR from attempt",
+			name: "ignores current PR without head evidence",
 			attempts: []store.WorkAttempt{{
 				ID:                 4,
 				PRNumber:           &currentPR,
 				TerminalState:      store.WorkAttemptTerminalSuccess,
 				WorkerMetadataJSON: implementProgressMetadataJSON(autoPromoteReworkSignature{}, store.WorkAttemptTerminalSuccess),
 			}},
-			wantID: 4,
+		},
+		{
+			name: "ignores success for an older current PR head",
+			attempts: []store.WorkAttempt{{
+				ID:                 5,
+				PRNumber:           &currentPR,
+				TerminalState:      store.WorkAttemptTerminalSuccess,
+				WorkerMetadataJSON: implementProgressMetadataJSON(staleSignature, store.WorkAttemptTerminalSuccess),
+			}},
+		},
+		{
+			name: "accepts current PR and head from combined evidence",
+			attempts: []store.WorkAttempt{{
+				ID:                 6,
+				PRNumber:           &currentPR,
+				TerminalState:      store.WorkAttemptTerminalSuccess,
+				WorkerMetadataJSON: implementProgressMetadataJSON(autoPromoteReworkSignature{HeadSHA: "current-head"}, store.WorkAttemptTerminalSuccess),
+			}},
+			wantID: 6,
 		},
 		{
 			name: "accepts current PR from completion record",
 			attempts: []store.WorkAttempt{{
-				ID:                 5,
+				ID:                 7,
 				TerminalState:      store.WorkAttemptTerminalSuccess,
 				WorkerMetadataJSON: implementProgressMetadataJSON(currentSignature, store.WorkAttemptTerminalSuccess),
 			}},
-			wantID: 5,
+			wantID: 7,
 		},
 		{
 			name: "skips newer unrelated success for older current completion",
 			attempts: []store.WorkAttempt{
 				{
-					ID:                 6,
+					ID:                 9,
 					TerminalState:      store.WorkAttemptTerminalSuccess,
 					WorkerMetadataJSON: marshalWorkAttemptJSON(map[string]any{"run_mode": runpkg.RunModePlan}),
 				},
 				{
-					ID:                 5,
+					ID:                 8,
 					TerminalState:      store.WorkAttemptTerminalSuccess,
 					WorkerMetadataJSON: implementProgressMetadataJSON(currentSignature, store.WorkAttemptTerminalSuccess),
 				},
 			},
-			wantID: 5,
+			wantID: 8,
 		},
 	}
 

--- a/internal/orchestrator/completion_transition.go
+++ b/internal/orchestrator/completion_transition.go
@@ -27,6 +27,9 @@ func (o *Orchestrator) transitionCompletedActiveIssuesToReview(
 		if issueID == "" {
 			continue
 		}
+		if _, running := state.Running[issueID]; running {
+			continue
+		}
 		completed, ok := state.Completed[issueID]
 		if !ok {
 			continue

--- a/internal/orchestrator/completion_transition_test.go
+++ b/internal/orchestrator/completion_transition_test.go
@@ -673,6 +673,62 @@ func TestTransitionCompletedActiveIssuesKeepsHumanReviewWhenRequired(t *testing.
 	}
 }
 
+func TestTransitionCompletedActiveIssuesRespectsRunningWorker(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 8, 18, 19, 10, 0, 0, time.UTC)
+	tests := []struct {
+		name           string
+		running        bool
+		wantTransition bool
+	}{
+		{name: "completed issue without running worker transitions", wantTransition: true},
+		{name: "completed issue with running worker stays active", running: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			issue := completionTransitionIssue("In Progress", "OPEN")
+			tracker := &autoPromoteTickConnector{stateIssues: []connector.Issue{issue}}
+			cfg := normalizeConfig(Config{
+				AutoPromote:    AutoPromoteConfig{Gate: gate.Config{Kind: gate.KindHumanReview}},
+				ActiveStates:   []string{"Todo", "In Progress", "Rework", "Merging"},
+				TerminalStates: []string{"Done", "Cancelled"},
+			})
+			orch := &Orchestrator{cfg: cfg, connector: tracker}
+			state := newState(cfg)
+			state.Completed[issue.ID] = Completed{
+				Issue:       issue,
+				CompletedAt: now.Add(-time.Minute),
+				FinalState:  FinalStateCompleted,
+			}
+			if tt.running {
+				state.Running[issue.ID] = Running{Issue: issue, StartedAt: now.Add(-30 * time.Second)}
+			}
+
+			result := orch.transitionCompletedActiveIssuesToReview(t.Context(), &state, []connector.Issue{issue}, now)
+
+			_, transitioned := result.transitioned[issue.ID]
+			if transitioned != tt.wantTransition {
+				t.Fatalf("transitioned[%q] present = %v, want %v", issue.ID, transitioned, tt.wantTransition)
+			}
+			if got := len(tracker.updates); got != boolInt(tt.wantTransition) {
+				t.Fatalf("tracker updates = %d, want %d", got, boolInt(tt.wantTransition))
+			}
+			if tt.running {
+				if _, ok := state.Running[issue.ID]; !ok {
+					t.Fatalf("Running[%q] missing after blocked transition", issue.ID)
+				}
+				if got := state.Completed[issue.ID].Issue.State; got != "In Progress" {
+					t.Fatalf("Completed issue state = %q, want In Progress", got)
+				}
+			}
+		})
+	}
+}
+
 func TestTransitionCompletedActiveIssuesAutomatedReviewTimeoutModes(t *testing.T) {
 	t.Parallel()
 

--- a/internal/orchestrator/lane_revocation.go
+++ b/internal/orchestrator/lane_revocation.go
@@ -3,11 +3,13 @@ package orchestrator
 import (
 	"context"
 	"fmt"
+	"strconv"
 	"strings"
 	"time"
 
 	"github.com/digitaldrywood/detent/internal/connector"
 	"github.com/digitaldrywood/detent/internal/procgroup"
+	"github.com/digitaldrywood/detent/internal/provenance"
 	runpkg "github.com/digitaldrywood/detent/internal/runner"
 	"github.com/digitaldrywood/detent/internal/scheduler"
 	"github.com/digitaldrywood/detent/internal/store"
@@ -16,6 +18,8 @@ import (
 
 const (
 	laneRevocationStateChanged               = "tracker_lane_changed"
+	laneRevocationDetentStateChanged         = "detent_tracker_lane_changed"
+	laneRevocationDetentErrorClass           = "detent_lane_revoked"
 	laneRevocationCompletionFenceUnavailable = "completion_fence_unavailable"
 )
 
@@ -24,6 +28,7 @@ type pendingLaneRevocation struct {
 	fromState     string
 	toState       string
 	reason        string
+	origin        provenance.Origin
 	requestedAt   time.Time
 	generation    uint64
 	running       Running
@@ -63,11 +68,14 @@ func (o *Orchestrator) beginLaneRevocation(
 	}
 	fromState := strings.TrimSpace(running.Issue.State)
 	running.Issue = mergeIssueTrackerFields(running.Issue, refreshed)
+	attribution := laneRevocationAttribution(state, running.Issue)
+	reason = laneRevocationReason(reason, attribution)
 	pending := &pendingLaneRevocation{
 		issue:       cloneIssue(running.Issue),
 		fromState:   fromState,
 		toState:     strings.TrimSpace(running.Issue.State),
 		reason:      strings.TrimSpace(reason),
+		origin:      attribution.Origin,
 		requestedAt: now.UTC(),
 		generation:  running.Generation,
 		running:     running,
@@ -195,6 +203,9 @@ func (o *Orchestrator) finishLaneRevocation(ctx context.Context, state *State, p
 	if tokens == (TokenTotals{}) {
 		tokens = running.Tokens
 	}
+	running.Tokens = tokens
+	workDiscarded := laneRevocationDiscardedWork(event, running, tokens)
+	errorClass := laneRevocationErrorClass(pending.reason)
 	state.TokenTotals = addTokenTotals(state.TokenTotals, tokens)
 	state.RateLimits = mergeRateLimits(state.RateLimits, event.Result.RateLimits)
 	o.recordProjectAttemptOutcome(
@@ -203,7 +214,7 @@ func (o *Orchestrator) finishLaneRevocation(ctx context.Context, state *State, p
 		completedAt,
 		store.WorkAttemptTerminalLaneRevoked,
 		runpkg.ErrLaneRevoked,
-		string(store.WorkAttemptTerminalLaneRevoked),
+		errorClass,
 		pending.reason,
 	)
 	o.completeDurableWorkAttemptWithMetadata(
@@ -212,19 +223,29 @@ func (o *Orchestrator) finishLaneRevocation(ctx context.Context, state *State, p
 		running,
 		completedAt,
 		store.WorkAttemptTerminalLaneRevoked,
-		string(store.WorkAttemptTerminalLaneRevoked),
+		errorClass,
 		pending.reason,
 		"lane_revoked",
 		"worker stopped after leaving a worker-owned lane",
 		map[string]any{"lane_revocation": map[string]any{
-			"generation":   pending.generation,
-			"from_state":   pending.fromState,
-			"to_state":     pending.toState,
-			"reason":       pending.reason,
-			"requested_at": pending.requestedAt,
-			"reap_outcome": pending.reapOutcome,
+			"generation":      pending.generation,
+			"from_state":      pending.fromState,
+			"to_state":        pending.toState,
+			"reason":          pending.reason,
+			"origin":          pending.origin,
+			"requested_at":    pending.requestedAt,
+			"reap_outcome":    pending.reapOutcome,
+			"work_discarded":  workDiscarded,
+			"output_tokens":   tokens.OutputTokens,
+			"total_tokens":    tokens.TotalTokens,
+			"runtime_seconds": tokens.RuntimeSeconds,
+			"turns":           running.TurnCount,
+			"files_changed":   running.DiffStats.FilesChanged,
 		}},
 	)
+	if workDiscarded {
+		o.reportLaneRevocationDiscardedWork(ctx, state, pending, event, running, tokens)
+	}
 	delete(o.pendingLaneRevocations, event.IssueID)
 	delete(state.Running, event.IssueID)
 	delete(state.Claimed, event.IssueID)
@@ -267,6 +288,110 @@ func (o *Orchestrator) finishLaneRevocation(ctx context.Context, state *State, p
 			"reap_outcome", pending.reapOutcome,
 		)
 	}
+}
+
+func laneRevocationAttribution(state *State, issue connector.Issue) provenance.Attribution {
+	if state != nil {
+		if attribution, ok := state.laneProvenance[workflowLaneEntryKey(issue)]; ok {
+			return provenance.Prepare(attribution)
+		}
+	}
+	return provenance.AttributionFromSource(provenance.SourceTrackerObservation, provenance.Actor{})
+}
+
+func laneRevocationReason(reason string, attribution provenance.Attribution) string {
+	reason = strings.TrimSpace(reason)
+	if reason == laneRevocationStateChanged && provenance.NormalizeOrigin(attribution.Origin) == provenance.OriginDetent {
+		return laneRevocationDetentStateChanged
+	}
+	return reason
+}
+
+func laneRevocationErrorClass(reason string) string {
+	if strings.TrimSpace(reason) == laneRevocationDetentStateChanged {
+		return laneRevocationDetentErrorClass
+	}
+	return string(store.WorkAttemptTerminalLaneRevoked)
+}
+
+func laneRevocationDiscardedWork(event runpkg.Completion, running Running, tokens TokenTotals) bool {
+	return event.Result.TurnStarted ||
+		running.TurnCount > 0 ||
+		strings.TrimSpace(event.Result.Output) != "" ||
+		strings.TrimSpace(running.LastMessage) != "" ||
+		tokens.OutputTokens > 0 ||
+		tokens.TotalTokens > 0 ||
+		diffStatsPresent(event.Result.DiffStats) ||
+		diffStatsPresent(running.DiffStats) ||
+		running.WorkProductPushed
+}
+
+func (o *Orchestrator) reportLaneRevocationDiscardedWork(
+	ctx context.Context,
+	state *State,
+	pending *pendingLaneRevocation,
+	event runpkg.Completion,
+	running Running,
+	tokens TokenTotals,
+) {
+	at := event.CompletedAt.UTC()
+	if at.IsZero() {
+		at = o.clockNow().UTC()
+	}
+	origin := string(provenance.NormalizeOrigin(pending.origin))
+	recordStateEvent(state, telemetry.ActivityEvent{
+		At:      at,
+		Event:   "worker_lane_output_discarded",
+		Message: "worker output for " + issueLabel(running.Issue) + " was discarded after a " + origin + " lane change from " + pending.fromState + " to " + pending.toState,
+	})
+	if o.connector == nil {
+		return
+	}
+	body := laneRevocationDiscardedWorkComment(pending, event, running, tokens)
+	if err := o.connector.CreateComment(context.WithoutCancel(ctx), running.Issue.ID, body); err != nil {
+		recordStateEvent(state, telemetry.ActivityEvent{
+			At:      at,
+			Event:   "worker_lane_output_discard_notice_failed",
+			Message: "failed to report discarded worker output for " + issueLabel(running.Issue) + ": " + err.Error(),
+		})
+		if o.logger != nil {
+			o.logger.Warn("discarded worker output comment failed", "issue_id", running.Issue.ID, "identifier", running.Issue.Identifier, "error", err)
+		}
+	}
+}
+
+func laneRevocationDiscardedWorkComment(
+	pending *pendingLaneRevocation,
+	event runpkg.Completion,
+	running Running,
+	tokens TokenTotals,
+) string {
+	var b strings.Builder
+	b.WriteString("Detent stopped this worker after the tracker moved the issue out of a worker-owned lane. The session produced work that was not accepted by the completion fence.")
+	b.WriteString("\n\n- reason: worker_lane_revocation_output_discarded")
+	b.WriteString("\n- revocation_reason: ")
+	b.WriteString(pending.reason)
+	b.WriteString("\n- lane_change_origin: ")
+	b.WriteString(string(provenance.NormalizeOrigin(pending.origin)))
+	b.WriteString("\n- from_state: ")
+	b.WriteString(pending.fromState)
+	b.WriteString("\n- to_state: ")
+	b.WriteString(pending.toState)
+	b.WriteString("\n- attempt: ")
+	b.WriteString(strconv.Itoa(running.Attempt))
+	b.WriteString("\n- output_tokens: ")
+	b.WriteString(strconv.FormatInt(tokens.OutputTokens, 10))
+	b.WriteString("\n- total_tokens: ")
+	b.WriteString(strconv.FormatInt(tokens.TotalTokens, 10))
+	b.WriteString("\n- runtime_seconds: ")
+	b.WriteString(strconv.FormatFloat(tokens.RuntimeSeconds, 'f', -1, 64))
+	b.WriteString("\n- files_changed: ")
+	b.WriteString(strconv.Itoa(running.DiffStats.FilesChanged))
+	if finalState := strings.TrimSpace(event.Result.FinalState); finalState != "" {
+		b.WriteString("\n- final_state: ")
+		b.WriteString(finalState)
+	}
+	return b.String()
 }
 
 func (o *Orchestrator) reapRunningWorker(

--- a/internal/orchestrator/lane_revocation_test.go
+++ b/internal/orchestrator/lane_revocation_test.go
@@ -2,15 +2,18 @@ package orchestrator
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"io"
 	"log/slog"
 	"strconv"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/digitaldrywood/detent/internal/connector"
 	"github.com/digitaldrywood/detent/internal/procgroup"
+	"github.com/digitaldrywood/detent/internal/provenance"
 	runpkg "github.com/digitaldrywood/detent/internal/runner"
 	"github.com/digitaldrywood/detent/internal/scheduler"
 	"github.com/digitaldrywood/detent/internal/store"
@@ -105,6 +108,139 @@ func TestLaneRevocationPreservesTrackerDestination(t *testing.T) {
 			}
 			if tracker.issues[0].State != tt.destination {
 				t.Fatalf("tracker state = %q, want preserved %q", tracker.issues[0].State, tt.destination)
+			}
+		})
+	}
+}
+
+func TestLaneRevocationRecordsOriginAndDiscardedWork(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 8, 18, 19, 20, 0, 0, time.UTC)
+	tests := []struct {
+		name           string
+		origin         provenance.Attribution
+		detentAuthored bool
+		wantReason     string
+		wantErrorClass string
+		wantOrigin     provenance.Origin
+	}{
+		{
+			name:           "operator move keeps tracker revocation",
+			origin:         provenance.AttributionFromSource(provenance.SourceHumanSession, provenance.Actor{Login: "operator", Kind: "User"}),
+			wantReason:     laneRevocationStateChanged,
+			wantErrorClass: string(store.WorkAttemptTerminalLaneRevoked),
+			wantOrigin:     provenance.OriginHuman,
+		},
+		{
+			name:           "Detent move has distinct revocation",
+			detentAuthored: true,
+			wantReason:     "detent_tracker_lane_changed",
+			wantErrorClass: laneRevocationDetentErrorClass,
+			wantOrigin:     provenance.OriginDetent,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			issue := laneRevocationIssue("issue-origin", "digitaldrywood/detent#1903", "Rework")
+			parked := cloneIssue(issue)
+			parked.State = "Human Review"
+			tracker := &autoPromoteTickConnector{stateIssues: []connector.Issue{parked}}
+			attempts := &recordingWorkAttemptStore{}
+			cfg := normalizeConfig(Config{
+				Project:        scheduler.ProjectCandidate{ID: "detent"},
+				ActiveStates:   []string{"Todo", "In Progress", "Rework", "Merging"},
+				ObservedStates: []string{"Human Review"},
+				TerminalStates: []string{"Done", "Cancelled"},
+			})
+			orch := &Orchestrator{
+				cfg:                    cfg,
+				connector:              tracker,
+				workAttempts:           attempts,
+				pendingLaneRevocations: map[string]*pendingLaneRevocation{},
+				logger:                 slog.New(slog.NewTextHandler(io.Discard, nil)),
+				now:                    func() time.Time { return now },
+			}
+			state := newState(cfg)
+			runCtx, stop := context.WithCancelCause(context.Background())
+			state.Running[issue.ID] = Running{
+				Issue:         issue,
+				Attempt:       3,
+				WorkAttemptID: 1903,
+				Generation:    9,
+				StartedAt:     now.Add(-397 * time.Second),
+				Tokens: runpkg.TokenTotals{
+					OutputTokens:   13_422,
+					TotalTokens:    42_000,
+					RuntimeSeconds: 397,
+				},
+				stop: stop,
+			}
+			if tt.detentAuthored {
+				if err := orch.updateIssueStateByID(t.Context(), &state, issue.ID, issue, parked.State, now.Add(-time.Minute), "completed_active_review_transition"); err != nil {
+					t.Fatalf("record Detent lane transition: %v", err)
+				}
+			} else {
+				state.laneProvenance[workflowLaneEntryKey(parked)] = tt.origin
+			}
+
+			orch.reconcileRunningIssues(t.Context(), &state, now)
+
+			if !errors.Is(context.Cause(runCtx), runpkg.ErrLaneRevoked) {
+				t.Fatalf("context cause = %v, want ErrLaneRevoked", context.Cause(runCtx))
+			}
+			pending := orch.pendingLaneRevocations[issue.ID]
+			if pending == nil || pending.reason != tt.wantReason {
+				t.Fatalf("pending revocation = %#v, want reason %q", pending, tt.wantReason)
+			}
+			orch.handleRunResult(t.Context(), &state, runpkg.Completion{
+				IssueID: issue.ID,
+				Request: runpkg.RunRequest{Issue: issue, WorkAttemptID: 1903, Generation: 9},
+				Result: runpkg.RunResult{
+					FinalState:  runpkg.FinalStateLaneRevoked,
+					Output:      "completed rework summary",
+					TurnStarted: true,
+				},
+				CompletedAt: now.Add(time.Second),
+				Err:         runpkg.ErrLaneRevoked,
+			})
+
+			if len(attempts.completions) != 1 {
+				t.Fatalf("work attempt completions = %#v, want one", attempts.completions)
+			}
+			completion := attempts.completions[0]
+			if completion.ErrorClass != tt.wantErrorClass {
+				t.Fatalf("error class = %q, want %q", completion.ErrorClass, tt.wantErrorClass)
+			}
+			if completion.ErrorMessage != tt.wantReason {
+				t.Fatalf("error message = %q, want %q", completion.ErrorMessage, tt.wantReason)
+			}
+			var metadata struct {
+				LaneRevocation struct {
+					Origin        provenance.Origin `json:"origin"`
+					WorkDiscarded bool              `json:"work_discarded"`
+					OutputTokens  int64             `json:"output_tokens"`
+				} `json:"lane_revocation"`
+			}
+			if err := json.Unmarshal([]byte(completion.WorkerMetadataJSON), &metadata); err != nil {
+				t.Fatalf("decode worker metadata: %v", err)
+			}
+			if metadata.LaneRevocation.Origin != tt.wantOrigin || !metadata.LaneRevocation.WorkDiscarded || metadata.LaneRevocation.OutputTokens != 13_422 {
+				t.Fatalf("lane revocation metadata = %#v, want origin %q and discarded output", metadata.LaneRevocation, tt.wantOrigin)
+			}
+			if len(tracker.comments) != 1 {
+				t.Fatalf("comments = %#v, want discarded-work notice", tracker.comments)
+			}
+			for _, fragment := range []string{tt.wantReason, "output_tokens: 13422", "runtime_seconds: 397"} {
+				if !strings.Contains(tracker.comments[0].body, fragment) {
+					t.Fatalf("comment %q missing %q", tracker.comments[0].body, fragment)
+				}
+			}
+			if !hasLaneRevocationEvent(state.RecentEvents, "worker_lane_output_discarded") {
+				t.Fatalf("RecentEvents = %#v, want discarded output event", state.RecentEvents)
 			}
 		})
 	}

--- a/internal/orchestrator/workflow_metrics.go
+++ b/internal/orchestrator/workflow_metrics.go
@@ -169,6 +169,7 @@ func (o *Orchestrator) updateIssueStateByIDWithMetadataMode(
 		o.clearMergeRequiredCheckStreaks(ctx, terminalIssue)
 	}
 	updateIssueStateSnapshots(state, issueID, issue, targetState, at)
+	recordIssueStateMutationProvenance(state, issueID, issue, targetState, at, reason, metadata)
 	if strings.TrimSpace(issue.ID) == "" {
 		issue.ID = issueID
 	}
@@ -297,9 +298,7 @@ func (o *Orchestrator) recordLaneTransition(
 	if reason == "" {
 		reason = "state_transition"
 	}
-	if metadata.Provenance.Origin == "" {
-		metadata.Provenance.Origin = workflowOriginForReason(reason)
-	}
+	metadata.Provenance = workflowLaneMutationAttribution(reason, metadata)
 	if err := workflowmetrics.RecordLaneTransition(ctx, o.workflowMetrics, workflowmetrics.LaneTransition{
 		ProjectID:    o.workflowMetricsProjectID(),
 		Issue:        issue,
@@ -310,6 +309,47 @@ func (o *Orchestrator) recordLaneTransition(
 	}); err != nil && o.logger != nil {
 		o.logger.Warn("record lane transition metric failed", "issue_id", issue.ID, "identifier", issue.Identifier, "from_state", sourceState, "target_state", targetState, "error", err)
 	}
+}
+
+func recordIssueStateMutationProvenance(
+	state *State,
+	issueID string,
+	issue connector.Issue,
+	targetState string,
+	at time.Time,
+	reason string,
+	metadata workflowLaneMetadata,
+) {
+	if state == nil || normalizeState(issue.State) == normalizeState(targetState) {
+		return
+	}
+	transitioned := cloneIssue(issue)
+	if strings.TrimSpace(transitioned.ID) == "" {
+		transitioned.ID = strings.TrimSpace(issueID)
+	}
+	transitioned.State = strings.TrimSpace(targetState)
+	laneKey := workflowLaneEntryKey(transitioned)
+	if laneKey == "" {
+		return
+	}
+	if state.laneProvenance == nil {
+		state.laneProvenance = map[string]provenance.Attribution{}
+	}
+	state.laneProvenance[laneKey] = workflowLaneMutationAttribution(reason, metadata)
+	if !at.IsZero() {
+		if state.laneEntries == nil {
+			state.laneEntries = map[string]time.Time{}
+		}
+		state.laneEntries[laneKey] = at.UTC()
+	}
+}
+
+func workflowLaneMutationAttribution(reason string, metadata workflowLaneMetadata) provenance.Attribution {
+	attribution := metadata.Provenance
+	if attribution.Origin == "" {
+		attribution.Origin = workflowOriginForReason(reason)
+	}
+	return provenance.Prepare(attribution)
 }
 
 func (o *Orchestrator) recordWorkflowReviewAction(


### PR DESCRIPTION
## Summary

- require durable successful completion evidence to match both the current pull request number and head SHA
- prevent completion processing from moving an issue while a worker remains live
- distinguish Detent-authored lane revocations and surface discarded worker output through durable metadata, health telemetry, and an issue comment

Fixes #1903

## UI Surface Contract

- [x] N/A; this change does not alter a UI surface.
- [x] This change does not add persistent top-of-screen messaging.
- [x] This change does not alter primary operator screen layout or visuals.

## Test Plan

- [x] `go test ./internal/orchestrator -run 'TestLatestSuccessfulGateWaitAttemptRequiresCurrentImplementationEvidence|TestTransitionCompletedActiveIssuesRespectsRunningWorker|TestLaneRevocationRecordsOriginAndDiscardedWork' -count=1`
- [x] `go test ./internal/orchestrator -count=1`
- [x] `make check` with repository-pinned golangci-lint v2.1.6
