### PR TITLE
fix(orchestrator): filter unauthorized rows

### DIFF
--- a/internal/orchestrator/snapshot.go
+++ b/internal/orchestrator/snapshot.go
@@ -31,6 +31,7 @@ const (
 // for publishing to the web dashboard. Slices are sorted by issue id so the
 // output is deterministic.
 func (s State) Snapshot(now time.Time) telemetry.Snapshot {
+	s = s.authorizedSnapshotRuntime()
 	poolCapacity := s.PoolCapacity
 	if poolCapacity <= 0 {
 		poolCapacity = s.MaxConcurrentAgents
@@ -570,8 +571,115 @@ func authorizedSnapshotIssues(issues []connector.Issue, authorization selector.S
 	}
 	out := make([]connector.Issue, 0, len(issues))
 	for _, issue := range issues {
-		if selector.Match(issue, authorization, ctx) {
+		if snapshotIssueAuthorized(issue, authorization, ctx) {
 			out = append(out, issue)
+		}
+	}
+	return out
+}
+
+func snapshotIssueAuthorized(issue connector.Issue, authorization selector.Selector, ctx selector.Context) bool {
+	return !authorization.Configured() || selector.Match(issue, authorization, ctx)
+}
+
+type snapshotRuntimeAuthorizer struct {
+	authorization selector.Selector
+	ctx           selector.Context
+	byID          map[string]connector.Issue
+	byIdentifier  map[string]connector.Issue
+	byURL         map[string]connector.Issue
+}
+
+func newSnapshotRuntimeAuthorizer(state State) snapshotRuntimeAuthorizer {
+	authorizer := snapshotRuntimeAuthorizer{
+		authorization: state.Authorization,
+		ctx:           state.SelectorContext,
+		byID:          map[string]connector.Issue{},
+		byIdentifier:  map[string]connector.Issue{},
+		byURL:         map[string]connector.Issue{},
+	}
+	for _, issue := range state.BoardIssues {
+		authorizer.add(issue)
+	}
+	for _, issue := range state.Pipeline {
+		authorizer.add(issue)
+	}
+	for _, id := range sortedKeys(state.Retry) {
+		authorizer.add(state.Retry[id].Issue)
+	}
+	for _, id := range sortedKeys(state.Running) {
+		authorizer.add(state.Running[id].Issue)
+	}
+	for _, id := range sortedKeys(state.Blocked) {
+		authorizer.add(state.Blocked[id].Issue)
+	}
+	for _, id := range sortedKeys(state.Completed) {
+		authorizer.add(state.Completed[id].Issue)
+	}
+	return authorizer
+}
+
+func (a snapshotRuntimeAuthorizer) add(issue connector.Issue) {
+	if id := strings.TrimSpace(issue.ID); id != "" {
+		if _, exists := a.byID[id]; !exists {
+			a.byID[id] = issue
+		}
+	}
+	if identifier := strings.TrimSpace(issue.Identifier); identifier != "" {
+		if _, exists := a.byIdentifier[identifier]; !exists {
+			a.byIdentifier[identifier] = issue
+		}
+	}
+	if issueURL := strings.TrimSpace(issue.URL); issueURL != "" {
+		if _, exists := a.byURL[issueURL]; !exists {
+			a.byURL[issueURL] = issue
+		}
+	}
+}
+
+func (a snapshotRuntimeAuthorizer) authorized(issue connector.Issue) bool {
+	if !a.authorization.Configured() {
+		return true
+	}
+	if current, ok := a.byID[strings.TrimSpace(issue.ID)]; ok {
+		issue = current
+	} else if current, ok := a.byIdentifier[strings.TrimSpace(issue.Identifier)]; ok {
+		issue = current
+	} else if current, ok := a.byURL[strings.TrimSpace(issue.URL)]; ok {
+		issue = current
+	}
+	return snapshotIssueAuthorized(issue, a.authorization, a.ctx)
+}
+
+func (s State) authorizedSnapshotRuntime() State {
+	if !s.Authorization.Configured() {
+		return s
+	}
+	authorizer := newSnapshotRuntimeAuthorizer(s)
+	s.Retry = authorizedRuntimeEntries(s.Retry, authorizer, func(entry Retry) connector.Issue { return entry.Issue })
+	s.Running = authorizedRuntimeEntries(s.Running, authorizer, func(entry Running) connector.Issue { return entry.Issue })
+	s.Blocked = authorizedRuntimeEntries(s.Blocked, authorizer, func(entry Blocked) connector.Issue { return entry.Issue })
+	s.Completed = authorizedRuntimeEntries(s.Completed, authorizer, func(entry Completed) connector.Issue { return entry.Issue })
+	s.WorkAttempts = authorizedSnapshotWorkAttempts(s.WorkAttempts, authorizer)
+	return s
+}
+
+func authorizedRuntimeEntries[T any](entries map[string]T, authorizer snapshotRuntimeAuthorizer, issue func(T) connector.Issue) map[string]T {
+	out := make(map[string]T, len(entries))
+	for id, entry := range entries {
+		if authorizer.authorized(issue(entry)) {
+			out[id] = entry
+		}
+	}
+	return out
+}
+
+func authorizedSnapshotWorkAttempts(attempts []telemetry.WorkAttempt, authorizer snapshotRuntimeAuthorizer) []telemetry.WorkAttempt {
+	out := make([]telemetry.WorkAttempt, 0, len(attempts))
+	for _, attempt := range attempts {
+		issue := connector.Issue{ID: attempt.IssueID, Identifier: attempt.Identifier, URL: attempt.IssueURL}
+		if authorizer.authorized(issue) {
+			out = append(out, attempt)
 		}
 	}
 	return out

--- a/internal/orchestrator/snapshot_test.go
+++ b/internal/orchestrator/snapshot_test.go
@@ -828,6 +828,90 @@ func TestStateSnapshotFiltersIssueListsByAuthorization(t *testing.T) {
 	}
 }
 
+func TestStateSnapshotFiltersRuntimeRowsUsingCurrentAuthorization(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 8, 18, 16, 0, 0, 0, time.UTC)
+	issue := func(id, state string, authorized bool) connector.Issue {
+		labels := []string{"bug"}
+		if authorized {
+			labels = append(labels, "detent:cory")
+		}
+		return connector.Issue{ID: id, Identifier: "getparable/parable#" + id, State: state, Labels: labels}
+	}
+	state := newState(normalizeConfig(Config{
+		Authorization: selector.Selector{Labels: selector.Labels{Include: []string{"detent:cory"}}},
+	}))
+	state.BoardIssues = []connector.Issue{
+		issue("authorized-queue", "Todo", true),
+		issue("unauthorized-running", "In Progress", false),
+	}
+	state.Retry["authorized-queue"] = Retry{Issue: issue("authorized-queue", "Todo", false), Attempt: 2}
+	state.Retry["unauthorized-queue"] = Retry{Issue: issue("unauthorized-queue", "Todo", false), Attempt: 2}
+	state.Running["authorized-running"] = Running{Issue: issue("authorized-running", "In Progress", true), Attempt: 1, StartedAt: now.Add(-time.Hour)}
+	state.Running["unauthorized-running"] = Running{Issue: issue("unauthorized-running", "In Progress", true), Attempt: 1, StartedAt: now.Add(-time.Hour)}
+	state.Blocked["authorized-blocked"] = Blocked{Issue: issue("authorized-blocked", "Blocked", true), Attempt: 1, BlockedAt: now.Add(-time.Hour)}
+	state.Blocked["unauthorized-blocked"] = Blocked{Issue: issue("unauthorized-blocked", "Blocked", false), Attempt: 1, BlockedAt: now.Add(-time.Hour)}
+	state.Blocked["authorized-dependency-wait"] = Blocked{
+		Issue:     issue("authorized-dependency-wait", "Todo", true),
+		Reason:    "waiting for getparable/parable#2230 Open",
+		Source:    BlockedSourceDependency,
+		BlockedAt: now.Add(-time.Hour),
+	}
+	state.Blocked["unauthorized-dependency-wait"] = Blocked{
+		Issue:     issue("unauthorized-dependency-wait", "Todo", false),
+		Reason:    "waiting for getparable/parable#2230 Open",
+		Source:    BlockedSourceDependency,
+		BlockedAt: now.Add(-time.Hour),
+	}
+	state.Completed["authorized-completed"] = Completed{Issue: issue("authorized-completed", "Done", true), CompletedAt: now.Add(-time.Hour)}
+	state.Completed["unauthorized-completed"] = Completed{Issue: issue("unauthorized-completed", "Done", false), CompletedAt: now.Add(-time.Hour)}
+	state.WorkAttempts = []telemetry.WorkAttempt{
+		{AttemptID: 1, IssueID: "authorized-completed", Identifier: "getparable/parable#authorized-completed", Status: string(store.WorkAttemptStatusTerminal), CompletedAt: timePointer(now.Add(-time.Hour))},
+		{AttemptID: 2, IssueID: "unauthorized-completed", Identifier: "getparable/parable#unauthorized-completed", Status: string(store.WorkAttemptStatusTerminal), CompletedAt: timePointer(now.Add(-time.Hour))},
+	}
+
+	snapshot := state.Snapshot(now)
+	tests := []struct {
+		name string
+		got  []telemetry.Issue
+		want []string
+	}{
+		{name: "queue", got: queuedTelemetryIssues(snapshot.Queue), want: []string{"authorized-queue"}},
+		{name: "running", got: runningTelemetryIssues(snapshot.Running), want: []string{"authorized-running"}},
+		{name: "blocked", got: blockedTelemetryIssues(snapshot.Blocked), want: []string{"authorized-blocked", "authorized-dependency-wait"}},
+		{name: "completed", got: completedTelemetryIssues(snapshot.Completed), want: []string{"authorized-completed"}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := telemetryIssueIDs(tt.got); !slices.Equal(got, tt.want) {
+				t.Fatalf("runtime issue ids = %#v, want %#v", got, tt.want)
+			}
+		})
+	}
+
+	wantCounts := telemetry.Counts{Running: 1, Queue: 1, Blocked: 2, Completed: 1}
+	if snapshot.Counts != wantCounts {
+		t.Fatalf("Counts = %#v, want %#v", snapshot.Counts, wantCounts)
+	}
+	if len(snapshot.WorkAttempts) != 1 || snapshot.WorkAttempts[0].IssueID != "authorized-completed" {
+		t.Fatalf("WorkAttempts = %#v, want only authorized-completed", snapshot.WorkAttempts)
+	}
+	wantLaneCounts := []telemetry.BoardStateCount{
+		{State: "Todo", Count: 2},
+		{State: "In Progress", Count: 1},
+		{State: "Blocked", Count: 1},
+	}
+	if got := telemetry.BoardStateCounts(snapshot); !reflect.DeepEqual(got, wantLaneCounts) {
+		t.Fatalf("BoardStateCounts() = %#v, want %#v", got, wantLaneCounts)
+	}
+	wantWorkload := telemetry.BoardWorkloadCounts{Load: 3, Todo: 1, Active: 1, Waiting: 1, Blocked: 1}
+	if got := telemetry.BoardWorkload(snapshot); got != wantWorkload {
+		t.Fatalf("BoardWorkload() = %#v, want %#v", got, wantWorkload)
+	}
+}
+
 func TestStateSnapshotCarriesIssueComments(t *testing.T) {
 	t.Parallel()
 
@@ -1533,4 +1617,36 @@ func telemetryIssueIDs(issues []telemetry.Issue) []string {
 		out = append(out, issue.ID)
 	}
 	return out
+}
+
+func queuedTelemetryIssues(rows []telemetry.Queued) []telemetry.Issue {
+	issues := make([]telemetry.Issue, 0, len(rows))
+	for _, row := range rows {
+		issues = append(issues, row.Issue)
+	}
+	return issues
+}
+
+func runningTelemetryIssues(rows []telemetry.Running) []telemetry.Issue {
+	issues := make([]telemetry.Issue, 0, len(rows))
+	for _, row := range rows {
+		issues = append(issues, row.Issue)
+	}
+	return issues
+}
+
+func blockedTelemetryIssues(rows []telemetry.Blocked) []telemetry.Issue {
+	issues := make([]telemetry.Issue, 0, len(rows))
+	for _, row := range rows {
+		issues = append(issues, row.Issue)
+	}
+	return issues
+}
+
+func completedTelemetryIssues(rows []telemetry.Completed) []telemetry.Issue {
+	issues := make([]telemetry.Issue, 0, len(rows))
+	for _, row := range rows {
+		issues = append(issues, row.Issue)
+	}
+	return issues
 }


### PR DESCRIPTION
## Summary

- Apply the effective current authorization selector before runtime issue collections reach snapshot consumers.
- Prefer current tracker attributes over stale runtime copies and filter work attempts so recent completions cannot recreate unauthorized cards.
- Cover Queue, Running, Blocked, Completed, dependency-wait fallback, lane counts, workload figures, and current-versus-stale label behavior.

Fixes #1905

## UI Surface Contract

- [x] N/A, or the linked issue explicitly authorizes any high-impact UI surface, layout, density, first-viewport, or responsive visibility tradeoff.
- [x] Persistent top-of-screen messaging is explicitly authorized by the issue, or this PR does not add it.
- [x] Visual changes to primary operator screens include screenshot or browser verification below.

Browser verification used an isolated real-handler snapshot server on a random port. Project and fleet Kanban each showed only the authorized #1905 card with 0 ready, 0 waiting, and 0 blocked; unauthorized #2245 was absent in compact and cozy density.

## Test Plan

- [x] `go test ./internal/orchestrator -count=1`
- [x] `make check` (CI-pinned golangci-lint v2.1.6; race suite; 78.9% total coverage; package/file floors)
- [x] Isolated overlay browser test for project and fleet Kanban at compact and cozy density