### PR TITLE
fix(workspace): repair quarantined worktree metadata

### DIFF
--- a/internal/orchestrator/run_completion.go
+++ b/internal/orchestrator/run_completion.go
@@ -296,6 +296,10 @@ func (o *Orchestrator) handleRunResult(ctx context.Context, state *State, event 
 		o.completeTerminalRunning(context.Background(), state, event.IssueID, running, terminalCompletedAt(running.Issue, o.cfg.TerminalStates, event.CompletedAt), tokens)
 		return
 	}
+	if errors.Is(event.Err, runpkg.ErrWorkspacePreparation) {
+		o.handleWorkspacePreparationFailure(ctx, state, event, running)
+		return
+	}
 
 	if event.Err != nil {
 		o.logWorkerLifecycle(running.Issue, "worker_"+workerOutcome(event.Err, event.Result.FinalState),
@@ -620,6 +624,39 @@ func (o *Orchestrator) handleRunResult(ctx context.Context, state *State, event 
 		return
 	}
 	o.scheduleContinuationRetry(ctx, state, running.Issue, 1, event.CompletedAt, "", running.WorkerHost)
+}
+
+func (o *Orchestrator) handleWorkspacePreparationFailure(
+	ctx context.Context,
+	state *State,
+	event runpkg.Completion,
+	running Running,
+) {
+	errorMessage := event.Err.Error()
+	o.logWorkerLifecycle(running.Issue, "worker_workspace_preparation_failed",
+		telemetry.WorkAttemptIDKey, running.WorkAttemptID,
+		"attempt", running.Attempt,
+		"worker_host", strings.TrimSpace(running.WorkerHost),
+		"error", event.Err,
+	)
+	o.recordProjectAttemptOutcome(state, event.IssueID, event.CompletedAt, store.WorkAttemptTerminalFailure, event.Err, workAttemptErrorWorkspace, errorMessage)
+	o.completeDurableWorkAttempt(ctx, state, running, event.CompletedAt, store.WorkAttemptTerminalFailure, workAttemptErrorWorkspace, errorMessage, "workspace_repair", "workspace preparation failed")
+	delete(state.InstantFailures, event.IssueID)
+	delete(state.RepeatedFailures, event.IssueID)
+	attempt := event.RetryAttempt
+	if attempt < 1 {
+		attempt = nextAttempt(running.Attempt)
+	}
+	delay := event.RetryDelay
+	if delay <= 0 {
+		delay = o.retryDelay(attempt, false)
+	}
+	o.scheduleRetryAfter(state, running.Issue, attempt, event.CompletedAt, delay, errorMessage, running.WorkerHost)
+	recordStateEvent(state, telemetry.ActivityEvent{
+		At:      event.CompletedAt,
+		Event:   "workspace_repair_retry_scheduled",
+		Message: "scheduled workspace repair retry for " + issueLabel(running.Issue),
+	})
 }
 
 func (o *Orchestrator) completeRedundantGateWaitRun(

--- a/internal/orchestrator/runner.go
+++ b/internal/orchestrator/runner.go
@@ -6,6 +6,8 @@ import (
 
 const FinalStateCompleted = runner.FinalStateCompleted
 
+var ErrWorkspacePreparation = runner.ErrWorkspacePreparation
+
 const RunModeImplement = runner.RunModeImplement
 
 const RunModePlan = runner.RunModePlan

--- a/internal/orchestrator/work_attempts.go
+++ b/internal/orchestrator/work_attempts.go
@@ -22,6 +22,7 @@ const (
 	maxRecentWorkAttemptSnapshots   = 50
 	maxRecentSchedulerDecisions     = 500
 	workAttemptErrorRunner          = "runner_error"
+	workAttemptErrorWorkspace       = "workspace_preparation"
 	workAttemptErrorStartTransition = "start_state_transition_failed"
 	workAttemptErrorMergeIncomplete = "merge_worker_terminal_state_missing"
 	workAttemptErrorMergeDuration   = "merge_worker_duration_exceeded"

--- a/internal/orchestrator/workspace_preparation_test.go
+++ b/internal/orchestrator/workspace_preparation_test.go
@@ -1,0 +1,86 @@
+package orchestrator
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/digitaldrywood/detent/internal/connector"
+	runpkg "github.com/digitaldrywood/detent/internal/runner"
+)
+
+func TestWorkspacePreparationFailuresDoNotTripWorkFailureBreakers(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		err  error
+	}{
+		{
+			name: "dangling gitdir",
+			err:  fmt.Errorf("%w: create workspace: dangling gitdir", runpkg.ErrWorkspacePreparation),
+		},
+		{
+			name: "stale clean recovery",
+			err:  fmt.Errorf("%w: create workspace: recover stale clean workspace", runpkg.ErrWorkspacePreparation),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			cfg := normalizeConfig(Config{
+				ActiveStates:   []string{"In Progress"},
+				ObservedStates: []string{"Blocked"},
+				TerminalStates: []string{"Done"},
+				FailureBreaker: FailureBreakerConfig{
+					SameClassLimit: repeatedFailureThreshold,
+					Window:         time.Hour,
+					Cooldown:       time.Hour,
+				},
+			})
+			orch := &Orchestrator{cfg: cfg}
+			state := newState(cfg)
+			issue := connector.Issue{ID: "issue-workspace", Identifier: "digitaldrywood/detent#1907", State: "In Progress"}
+			base := time.Date(2026, 8, 18, 20, 0, 0, 0, time.UTC)
+
+			for attempt := 1; attempt <= repeatedFailureThreshold; attempt++ {
+				completedAt := base.Add(time.Duration(attempt) * time.Minute)
+				running := Running{
+					Issue:     issue,
+					Mode:      runpkg.RunModePlan,
+					Attempt:   attempt,
+					StartedAt: completedAt.Add(-time.Minute),
+				}
+				state.Running[issue.ID] = running
+				orch.handleRunResult(t.Context(), &state, runpkg.Completion{
+					IssueID:      issue.ID,
+					Request:      runpkg.RunRequest{Mode: runpkg.RunModePlan},
+					Err:          tt.err,
+					CompletedAt:  completedAt,
+					RetryAttempt: attempt + 1,
+					RetryDelay:   time.Second,
+				})
+			}
+
+			if _, blocked := state.Blocked[issue.ID]; blocked {
+				t.Fatalf("Blocked[%q] present after workspace preparation failures", issue.ID)
+			}
+			if _, ok := state.Retry[issue.ID]; !ok {
+				t.Fatalf("Retry[%q] missing after workspace preparation failure", issue.ID)
+			}
+			if _, ok := state.InstantFailures[issue.ID]; ok {
+				t.Fatalf("InstantFailures[%q] present after workspace preparation failure", issue.ID)
+			}
+			if _, ok := state.RepeatedFailures[issue.ID]; ok {
+				t.Fatalf("RepeatedFailures[%q] present after workspace preparation failure", issue.ID)
+			}
+			if state.FailureBreaker.Class != workAttemptErrorWorkspace {
+				t.Fatalf("FailureBreaker.Class = %q, want %q", state.FailureBreaker.Class, workAttemptErrorWorkspace)
+			}
+			if event, ok := recentStateEvent(state, "workspace_repair_retry_scheduled"); !ok || event.Message == "" {
+				t.Fatalf("RecentEvents = %#v, want workspace repair retry event", state.RecentEvents)
+			}
+		})
+	}
+}

--- a/internal/runner/agent.go
+++ b/internal/runner/agent.go
@@ -1245,7 +1245,8 @@ func (r *Runner) Run(ctx context.Context, req RunRequest) (RunResult, error) {
 	}
 	info, err := runWorkspace.Create(ctx, workspaceIssue)
 	if err != nil {
-		return RunResult{}, classifyForgeOperationError(fmt.Errorf("create workspace: %w", err), "git fetch", forgeHost)
+		classifiedErr := classifyForgeOperationError(fmt.Errorf("create workspace: %w", err), "git fetch", forgeHost)
+		return RunResult{}, fmt.Errorf("%w: %w", ErrWorkspacePreparation, classifiedErr)
 	}
 	r.logWorkerEvent(req.Issue, "worker_workspace_created",
 		telemetry.WorkAttemptIDKey, req.WorkAttemptID,

--- a/internal/runner/runner_test.go
+++ b/internal/runner/runner_test.go
@@ -2720,6 +2720,9 @@ func TestRunnerPublishesWorkspaceCreateStartedBeforeCreate(t *testing.T) {
 	if !errors.Is(err, createErr) {
 		t.Fatalf("Run() error = %v, want %v", err, createErr)
 	}
+	if !errors.Is(err, ErrWorkspacePreparation) {
+		t.Fatalf("Run() error = %v, want ErrWorkspacePreparation", err)
+	}
 	if update.LastEvent != "workspace_create_started" || !update.LastEventAt.Equal(now) {
 		t.Fatalf("workspace progress update = %#v, want start event at %v", update, now)
 	}

--- a/internal/runner/types.go
+++ b/internal/runner/types.go
@@ -60,6 +60,7 @@ var (
 	ErrModelPermitUnavailable       = errors.New("provider model permit unavailable")
 	ErrAgentTurnCleanup             = errors.New("agent turn cleanup failed")
 	ErrWorkerProcessReap            = errors.New("worker process reap failed")
+	ErrWorkspacePreparation         = errors.New("workspace preparation failed")
 	ErrAgentResumeUnsupported       = errors.New("agent backend does not support resume verification")
 	ErrDeliverableRecoveryExhausted = errors.New("deliverable recovery exhausted")
 )

--- a/internal/workspace/workspace.go
+++ b/internal/workspace/workspace.go
@@ -567,6 +567,9 @@ func (l *LocalGit) branchName(issue Issue, key string) string {
 }
 
 func (l *LocalGit) ensureWorktree(ctx context.Context, path string, branch string) (bool, error) {
+	if _, err := l.runGit(ctx, "worktree", "prune"); err != nil {
+		return false, fmt.Errorf("prune stale worktree registrations during preparation: %w", withCommandOutput(err))
+	}
 	exists, isDir, err := pathExists(path)
 	if err != nil {
 		return false, err
@@ -584,6 +587,10 @@ func (l *LocalGit) ensureWorktree(ctx context.Context, path string, branch strin
 				if err := l.recoverStaleSourceWorktree(ctx, path, current, branch); err != nil {
 					return false, err
 				}
+				exists = false
+			} else if removed, err := l.removeDanglingSourceWorktree(ctx, path); err != nil {
+				return false, err
+			} else if removed {
 				exists = false
 			} else if l.isGitWorkspace(ctx, path) {
 				return false, fmt.Errorf("workspace path is a git worktree not managed by source: %s", path)
@@ -790,13 +797,32 @@ func (l *LocalGit) unreferencedDetachedHead(ctx context.Context, path string, cu
 
 func (l *LocalGit) removeCleanWorktree(ctx context.Context, path string) error {
 	_, err := l.runGit(ctx, "worktree", "remove", path)
-	if err != nil {
-		return fmt.Errorf("remove stale clean worktree: %w", err)
+	if err == nil {
+		return nil
 	}
+	removeErr := fmt.Errorf("remove stale clean worktree: %w", err)
+	if cleanupErr := removeWorkspacePath(l.root, path); cleanupErr != nil {
+		return errors.Join(removeErr, fmt.Errorf("remove partially recovered workspace: %w", cleanupErr))
+	}
+	if _, pruneErr := l.runGit(ctx, "worktree", "prune"); pruneErr != nil {
+		return errors.Join(removeErr, fmt.Errorf("prune partially recovered workspace registration: %w", withCommandOutput(pruneErr)))
+	}
+	l.logger.Warn("removed partially recovered clean workspace", slog.String("path", path), slog.Any("git_remove_error", err))
 	return nil
 }
 
 func (l *LocalGit) quarantineWorktree(ctx context.Context, path string) (string, error) {
+	metadata, err := inspectGitMetadata(ctx, path)
+	if err != nil {
+		return "", fmt.Errorf("inspect stale worktree before quarantine: %w", err)
+	}
+	sourceCommon, err := gitCommonDir(ctx, l.sourceRoot)
+	if err != nil {
+		return "", fmt.Errorf("inspect source before quarantine: %w", err)
+	}
+	if metadata.commonDir != sourceCommon {
+		return "", fmt.Errorf("refusing to quarantine worktree not managed by source: %s", path)
+	}
 	quarantinePath, err := l.nextQuarantinePath(path)
 	if err != nil {
 		return "", err
@@ -807,7 +833,158 @@ func (l *LocalGit) quarantineWorktree(ctx context.Context, path string) (string,
 	if _, err := l.runGit(ctx, "worktree", "move", path, quarantinePath); err != nil {
 		return "", fmt.Errorf("move stale worktree to quarantine: %w", err)
 	}
+	if err := relocateWorktreeAdmin(metadata, quarantinePath); err != nil {
+		if _, rollbackErr := l.runGit(ctx, "worktree", "move", quarantinePath, path); rollbackErr != nil {
+			return "", errors.Join(fmt.Errorf("release quarantined worktree admin name: %w", err), fmt.Errorf("restore stale worktree path: %w", rollbackErr))
+		}
+		return "", fmt.Errorf("release quarantined worktree admin name: %w", err)
+	}
 	return quarantinePath, nil
+}
+
+func (l *LocalGit) removeDanglingSourceWorktree(ctx context.Context, path string) (bool, error) {
+	gitDir, ok, err := readLinkedWorktreeGitDir(path)
+	if err != nil || !ok {
+		return false, err
+	}
+	sourceCommon, err := gitCommonDir(ctx, l.sourceRoot)
+	if err != nil {
+		return false, fmt.Errorf("inspect source for dangling workspace: %w", err)
+	}
+	adminRoot := filepath.Join(sourceCommon, "worktrees")
+	if filepath.Dir(gitDir) != adminRoot {
+		return false, nil
+	}
+	exists, _, err := pathExists(gitDir)
+	if err != nil {
+		return false, fmt.Errorf("inspect linked worktree admin directory: %w", err)
+	}
+	if exists {
+		return false, nil
+	}
+	if err := removeWorkspacePath(l.root, path); err != nil {
+		return false, fmt.Errorf("remove workspace with dangling gitdir: %w", err)
+	}
+	l.logger.Warn("removed workspace with dangling gitdir", slog.String("path", path), slog.String("git_dir", gitDir))
+	return true, nil
+}
+
+func relocateWorktreeAdmin(metadata gitMetadata, workspacePath string) error {
+	adminRoot := filepath.Join(metadata.commonDir, "worktrees")
+	if filepath.Dir(metadata.gitDir) != adminRoot {
+		return fmt.Errorf("worktree admin directory %s is not directly under %s", metadata.gitDir, adminRoot)
+	}
+	info, err := os.Lstat(metadata.gitDir)
+	if err != nil {
+		return fmt.Errorf("inspect worktree admin directory: %w", err)
+	}
+	if !info.IsDir() {
+		return fmt.Errorf("worktree admin path is not a directory: %s", metadata.gitDir)
+	}
+
+	newGitDir, err := nextWorktreeAdminPath(adminRoot, filepath.Base(workspacePath))
+	if err != nil {
+		return err
+	}
+	gitFilePath := filepath.Join(workspacePath, ".git")
+	linkedGitDir, ok, err := readLinkedWorktreeGitDir(workspacePath)
+	if err != nil {
+		return err
+	}
+	if !ok || linkedGitDir != metadata.gitDir {
+		return fmt.Errorf("worktree gitdir pointer changed during quarantine: got %s, want %s", linkedGitDir, metadata.gitDir)
+	}
+	if err := os.Rename(metadata.gitDir, newGitDir); err != nil {
+		return fmt.Errorf("rename worktree admin directory: %w", err)
+	}
+	if err := writeLinkedWorktreeGitDir(gitFilePath, newGitDir); err != nil {
+		if rollbackErr := os.Rename(newGitDir, metadata.gitDir); rollbackErr != nil {
+			return errors.Join(err, fmt.Errorf("restore worktree admin directory: %w", rollbackErr))
+		}
+		return err
+	}
+	return nil
+}
+
+func nextWorktreeAdminPath(adminRoot string, workspaceBase string) (string, error) {
+	base := SafeKey(workspaceBase)
+	for i := range 100 {
+		name := base
+		if i > 0 {
+			name += strconv.Itoa(i)
+		}
+		candidate := filepath.Join(adminRoot, name)
+		exists, _, err := pathExists(candidate)
+		if err != nil {
+			return "", err
+		}
+		if !exists {
+			return candidate, nil
+		}
+	}
+	return "", errors.New("exhausted worktree admin path attempts")
+}
+
+func readLinkedWorktreeGitDir(workspacePath string) (string, bool, error) {
+	path := filepath.Join(workspacePath, ".git")
+	info, err := os.Lstat(path)
+	if errors.Is(err, fs.ErrNotExist) {
+		return "", false, nil
+	}
+	if err != nil {
+		return "", false, fmt.Errorf("inspect linked worktree gitdir: %w", err)
+	}
+	if !info.Mode().IsRegular() {
+		return "", false, nil
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return "", false, fmt.Errorf("read linked worktree gitdir: %w", err)
+	}
+	value, ok := strings.CutPrefix(strings.TrimSpace(string(data)), "gitdir: ")
+	if !ok || strings.TrimSpace(value) == "" {
+		return "", false, nil
+	}
+	gitDir := strings.TrimSpace(value)
+	if !filepath.IsAbs(gitDir) {
+		gitDir = filepath.Join(workspacePath, gitDir)
+	}
+	return filepath.Clean(gitDir), true, nil
+}
+
+func writeLinkedWorktreeGitDir(path string, gitDir string) (err error) {
+	info, err := os.Stat(path)
+	if err != nil {
+		return fmt.Errorf("inspect linked worktree gitdir file: %w", err)
+	}
+	temp, err := os.CreateTemp(filepath.Dir(path), ".git.detent-*")
+	if err != nil {
+		return fmt.Errorf("create linked worktree gitdir file: %w", err)
+	}
+	tempPath := temp.Name()
+	closed := false
+	defer func() {
+		if !closed {
+			err = errors.Join(err, temp.Close())
+		}
+		if cleanupErr := os.Remove(tempPath); cleanupErr != nil && !errors.Is(cleanupErr, fs.ErrNotExist) {
+			err = errors.Join(err, cleanupErr)
+		}
+	}()
+	if err := temp.Chmod(info.Mode().Perm()); err != nil {
+		return fmt.Errorf("set linked worktree gitdir file mode: %w", err)
+	}
+	if _, err := fmt.Fprintf(temp, "gitdir: %s\n", gitDir); err != nil {
+		return fmt.Errorf("write linked worktree gitdir file: %w", err)
+	}
+	if err := temp.Close(); err != nil {
+		return fmt.Errorf("close linked worktree gitdir file: %w", err)
+	}
+	closed = true
+	if err := os.Rename(tempPath, path); err != nil {
+		return fmt.Errorf("replace linked worktree gitdir file: %w", err)
+	}
+	return nil
 }
 
 func (l *LocalGit) nextQuarantinePath(path string) (string, error) {

--- a/internal/workspace/workspace_test.go
+++ b/internal/workspace/workspace_test.go
@@ -1443,6 +1443,136 @@ func TestLocalGitCreateQuarantinesCleanDetachedUnreferencedCommit(t *testing.T) 
 	}
 }
 
+func TestLocalGitCreateRepairsWorkspacePreparationFailures(t *testing.T) {
+	skipWindows(t)
+
+	tests := []struct {
+		name string
+		run  func(*testing.T)
+	}{
+		{
+			name: "quarantine releases canonical admin name",
+			run: func(t *testing.T) {
+				source := initSourceRepo(t)
+				root := filepath.Join(t.TempDir(), "workspaces")
+				backend, err := NewLocalGit(LocalGitOptions{Root: root, SourceRoot: source, AutoBranch: true})
+				if err != nil {
+					t.Fatalf("NewLocalGit() error = %v", err)
+				}
+
+				issue := Issue{Identifier: "DD-ADMIN-NAME"}
+				first, err := backend.Create(t.Context(), issue)
+				if err != nil {
+					t.Fatalf("first Create() error = %v", err)
+				}
+				runGit(t, first.Path, "switch", "--detach", "HEAD")
+				if err := os.WriteFile(filepath.Join(first.Path, "local-progress.txt"), []byte("keep\n"), 0o600); err != nil {
+					t.Fatalf("write local progress: %v", err)
+				}
+
+				second, err := backend.Create(t.Context(), issue)
+				if err != nil {
+					t.Fatalf("second Create() error = %v", err)
+				}
+				entries, err := os.ReadDir(filepath.Join(root, ".detent", "quarantine"))
+				if err != nil || len(entries) != 1 {
+					t.Fatalf("quarantine entries = %d, error = %v, want one", len(entries), err)
+				}
+				quarantinedPath := filepath.Join(root, ".detent", "quarantine", entries[0].Name())
+				if got, want := filepath.Base(linkedWorktreeGitDir(t, second.Path)), filepath.Base(second.Path); got != want {
+					t.Fatalf("replacement admin name = %q, want %q", got, want)
+				}
+				if got, want := filepath.Base(linkedWorktreeGitDir(t, quarantinedPath)), filepath.Base(quarantinedPath); got != want {
+					t.Fatalf("quarantine admin name = %q, want %q", got, want)
+				}
+			},
+		},
+		{
+			name: "dangling gitdir is recreated",
+			run: func(t *testing.T) {
+				source := initSourceRepo(t)
+				root := filepath.Join(t.TempDir(), "workspaces")
+				backend, err := NewLocalGit(LocalGitOptions{Root: root, SourceRoot: source, AutoBranch: true})
+				if err != nil {
+					t.Fatalf("NewLocalGit() error = %v", err)
+				}
+
+				issue := Issue{Identifier: "DD-DANGLING-GITDIR"}
+				first, err := backend.Create(t.Context(), issue)
+				if err != nil {
+					t.Fatalf("first Create() error = %v", err)
+				}
+				adminDir := linkedWorktreeGitDir(t, first.Path)
+				orphanedAdminDir := adminDir + "-orphaned"
+				if err := os.Rename(adminDir, orphanedAdminDir); err != nil {
+					t.Fatalf("orphan admin directory: %v", err)
+				}
+
+				second, err := backend.Create(t.Context(), issue)
+				if err != nil {
+					t.Fatalf("second Create() error = %v", err)
+				}
+				if !second.Created {
+					t.Fatal("second Create() Created = false, want true")
+				}
+				if got, want := filepath.Base(linkedWorktreeGitDir(t, second.Path)), filepath.Base(second.Path); got != want {
+					t.Fatalf("replacement admin name = %q, want %q", got, want)
+				}
+				if _, err := os.Stat(orphanedAdminDir); !errors.Is(err, os.ErrNotExist) {
+					t.Fatalf("orphaned admin directory stat error = %v, want absent", err)
+				}
+			},
+		},
+		{
+			name: "failed clean removal leaves recreatable path",
+			run: func(t *testing.T) {
+				source := initSourceRepo(t)
+				root := filepath.Join(t.TempDir(), "workspaces")
+				backend, err := NewLocalGit(LocalGitOptions{Root: root, SourceRoot: source, AutoBranch: true})
+				if err != nil {
+					t.Fatalf("NewLocalGit() error = %v", err)
+				}
+
+				issue := Issue{Identifier: "DD-PARTIAL-REMOVE"}
+				first, err := backend.Create(t.Context(), issue)
+				if err != nil {
+					t.Fatalf("first Create() error = %v", err)
+				}
+				runGit(t, first.Path, "branch", "detent/other-partial-remove", "HEAD")
+				runGit(t, first.Path, "switch", "detent/other-partial-remove")
+				lockedDir := filepath.Join(first.Path, "locked")
+				if err := os.MkdirAll(lockedDir, 0o700); err != nil {
+					t.Fatalf("create locked directory: %v", err)
+				}
+				if err := os.WriteFile(filepath.Join(lockedDir, "tracked.txt"), []byte("tracked\n"), 0o600); err != nil {
+					t.Fatalf("write tracked file: %v", err)
+				}
+				runGit(t, first.Path, "add", "locked/tracked.txt")
+				runGit(t, first.Path, "commit", "-m", "add locked file")
+				if err := os.Chmod(lockedDir, 0o500); err != nil {
+					t.Fatalf("make tracked directory read-only: %v", err)
+				}
+				t.Cleanup(func() { restoreWritableTree(t, first.Path) })
+
+				second, err := backend.Create(t.Context(), issue)
+				if err != nil {
+					t.Fatalf("second Create() error = %v", err)
+				}
+				if !second.Created {
+					t.Fatal("second Create() Created = false, want true")
+				}
+				if _, err := os.Stat(filepath.Join(second.Path, "locked")); !errors.Is(err, os.ErrNotExist) {
+					t.Fatalf("stale locked directory stat error = %v, want absent", err)
+				}
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, tt.run)
+	}
+}
+
 func TestLocalGitBeforeAndAfterRunHooks(t *testing.T) {
 	t.Parallel()
 	skipWindows(t)


### PR DESCRIPTION
## Summary

- relocate quarantined worktree admin metadata so replacement workspaces reclaim the canonical name
- prune and recreate managed dangling gitdir targets, with cleanup fallback after partial stale-worktree removal
- classify pre-agent workspace preparation failures separately from agent work failures and retry workspace repair without issue breaker strikes

Fixes #1907

## UI Surface Contract

- [x] N/A, or the linked issue explicitly authorizes any high-impact UI surface, layout, density, first-viewport, or responsive visibility tradeoff.
- [x] Persistent top-of-screen messaging is explicitly authorized by the issue, or this PR does not add it.
- [x] Visual changes to primary operator screens include screenshot or browser verification below.

No UI changes.

## Test Plan

- [x] `make check`
- [x] `go test ./internal/workspace -count=1`
- [x] `go test ./internal/runner -count=1`
- [x] `go test ./internal/orchestrator -run WorkspacePreparation\\|RepeatedFailure\\|ProjectAttemptFailureClass -count=1`