### PR TITLE
fix(orchestrator): accept owned completion

### DIFF
--- a/internal/orchestrator/completion_handshake.go
+++ b/internal/orchestrator/completion_handshake.go
@@ -1,0 +1,112 @@
+package orchestrator
+
+import (
+	"context"
+	"strings"
+	"time"
+
+	"github.com/digitaldrywood/detent/internal/connector"
+	"github.com/digitaldrywood/detent/internal/provenance"
+	"github.com/digitaldrywood/detent/internal/telemetry"
+	"github.com/digitaldrywood/detent/internal/workpad"
+)
+
+func (o *Orchestrator) acceptCurrentAttemptCompletionLane(
+	ctx context.Context,
+	state *State,
+	running Running,
+	refreshed connector.Issue,
+	now time.Time,
+) (Running, bool) {
+	targetState := normalizeAutoPromoteConfig(o.cfg.AutoPromote).SourceState
+	if normalizeState(refreshed.State) != normalizeState(targetState) {
+		return running, false
+	}
+	if running.CompletionLane != "" {
+		if normalizeState(running.CompletionLane) != normalizeState(refreshed.State) {
+			return running, false
+		}
+		running.Issue = mergeIssueTrackerFields(running.Issue, refreshed)
+		return running, true
+	}
+
+	hydrated := cloneIssue(refreshed)
+	if reader, ok := o.connector.(connector.IssueCommentReader); ok {
+		comments, err := reader.FetchIssueComments(ctx, hydrated)
+		if err != nil {
+			if o.logger != nil {
+				o.logger.Warn("completion handshake comment refresh failed", "issue_id", hydrated.ID, "identifier", hydrated.Identifier, "error", err)
+			}
+			return running, false
+		}
+		hydrated.Comments = comments
+	}
+	signal, ok := autoPromoteIssueWorkpadSignal(hydrated)
+	if !ok || !workpad.CurrentAttemptCompletion(signal, running.WorkAttemptID, running.Generation) {
+		return running, false
+	}
+	if signal.RecordedAt != nil && !running.StartedAt.IsZero() && signal.RecordedAt.Before(running.StartedAt) {
+		return running, false
+	}
+	if now.IsZero() {
+		now = o.clockNow().UTC()
+	}
+	running.Issue = mergeIssueTrackerFields(running.Issue, hydrated)
+	running.CompletionLane = strings.TrimSpace(hydrated.State)
+	running.CompletionWorkpadURL = strings.TrimSpace(signal.CommentURL)
+	running.CompletionAcceptedAt = now.UTC()
+	if state != nil {
+		if state.laneProvenance == nil {
+			state.laneProvenance = make(map[string]provenance.Attribution)
+		}
+		state.laneProvenance[workflowLaneEntryKey(running.Issue)] = provenance.AttributionFromSource(provenance.SourceDetentAgentSession, provenance.Actor{})
+		state.Running[running.Issue.ID] = running
+		if claimed, found := state.Claimed[running.Issue.ID]; found {
+			claimed.Issue = cloneIssue(running.Issue)
+			state.Claimed[running.Issue.ID] = claimed
+		}
+		recordStateEvent(state, telemetry.ActivityEvent{
+			At:      running.CompletionAcceptedAt,
+			Event:   "agent_completion_lane_accepted",
+			Message: "accepted the current attempt completion handshake for " + issueLabel(running.Issue) + " in " + running.CompletionLane,
+		})
+	}
+	if o.logger != nil {
+		o.logger.Info(
+			"agent completion lane accepted",
+			"project_id", strings.TrimSpace(o.cfg.Project.ID),
+			"issue_id", running.Issue.ID,
+			"identifier", running.Issue.Identifier,
+			"generation", running.Generation,
+			"work_attempt_id", running.WorkAttemptID,
+			"completion_lane", running.CompletionLane,
+			"workpad_url", running.CompletionWorkpadURL,
+		)
+	}
+	return running, true
+}
+
+func (o *Orchestrator) finishAcceptedCompletionLaneRun(
+	ctx context.Context,
+	state *State,
+	running Running,
+	completedAt time.Time,
+) {
+	issueID := strings.TrimSpace(running.Issue.ID)
+	if completed, ok := state.Completed[issueID]; ok {
+		completed.Issue = cloneIssue(running.Issue)
+		state.Completed[issueID] = completed
+	}
+	if err := o.abandonClaim(ctx, issueID); err != nil && o.logger != nil {
+		o.logger.Warn("accepted completion lane claim release failed", "issue_id", issueID, "error", err)
+	}
+	delete(state.Claimed, issueID)
+	delete(state.Retry, issueID)
+	delete(state.BudgetRefusals, issueID)
+	delete(state.PriorAttempts, issueID)
+	recordStateEvent(state, telemetry.ActivityEvent{
+		At:      completedAt,
+		Event:   "agent_completion_lane_finished",
+		Message: "finished accepted current-attempt completion for " + issueLabel(running.Issue) + " in " + running.CompletionLane,
+	})
+}

--- a/internal/orchestrator/completion_transition.go
+++ b/internal/orchestrator/completion_transition.go
@@ -278,11 +278,6 @@ func completedActiveReviewTargetState(
 	switch normalizeState(issue.State) {
 	case normalizeState(reviewState), normalizeState(autoPromoteMergingState):
 		return ""
-	case normalizeState(autoPromoteReworkState):
-		_, operational := operationalCompletionFromIssue(issue)
-		if !operational && gate.Effective(cfg.Gate).Kind != gate.KindArtifact {
-			return ""
-		}
 	}
 	if !completedActiveIssueReadyForReview(issue, gateRequiresPullRequest(cfg.Gate)) {
 		return ""

--- a/internal/orchestrator/completion_transition_test.go
+++ b/internal/orchestrator/completion_transition_test.go
@@ -66,9 +66,10 @@ func TestCompletedActiveReviewTargetState(t *testing.T) {
 			want: "Review",
 		},
 		{
-			name:       "rework completed with open pull request waits for dispatch",
+			name:       "rework completed with open pull request advances to human review",
 			issue:      completionTransitionIssue("Rework", "OPEN"),
 			finalState: FinalStateCompleted,
+			want:       autoPromoteSourceState,
 		},
 		{
 			name: "operational rework completion advances to review",

--- a/internal/orchestrator/implement_progress_test.go
+++ b/internal/orchestrator/implement_progress_test.go
@@ -45,6 +45,7 @@ func TestHandleRunResultClassifiesImplementWorkerProgress(t *testing.T) {
 		wantCurrentHead    string
 		wantHydrations     int
 		wantBlocked        bool
+		wantReview         bool
 		wantComment        string
 		wantRetry          bool
 		wantLogContains    string
@@ -76,7 +77,7 @@ func TestHandleRunResultClassifiesImplementWorkerProgress(t *testing.T) {
 			wantCurrentHead: "same-head",
 			wantHydrations:  1,
 			wantConsecutive: 1,
-			wantRetry:       true,
+			wantReview:      true,
 		},
 		{
 			name:             "new head SHA succeeds",
@@ -90,7 +91,7 @@ func TestHandleRunResultClassifiesImplementWorkerProgress(t *testing.T) {
 			wantPreviousHead: "same-head",
 			wantCurrentHead:  "new-head",
 			wantHydrations:   1,
-			wantRetry:        true,
+			wantReview:       true,
 		},
 		{
 			name:            "stale remote ref with pushed pull request head is not stranded",
@@ -103,7 +104,7 @@ func TestHandleRunResultClassifiesImplementWorkerProgress(t *testing.T) {
 			wantCurrentHead: "same-head",
 			wantHydrations:  1,
 			wantConsecutive: 1,
-			wantRetry:       true,
+			wantReview:      true,
 		},
 		{
 			name:             "new pull request head with newer unpushed commit remains stranded",
@@ -180,7 +181,7 @@ func TestHandleRunResultClassifiesImplementWorkerProgress(t *testing.T) {
 			wantReason:      "workspace_head_unavailable_for_unpushed_check",
 			wantCurrentHead: "same-head",
 			wantHydrations:  1,
-			wantRetry:       true,
+			wantReview:      true,
 		},
 		{
 			name:          "limit trip blocks with comment",
@@ -482,7 +483,7 @@ func TestHandleRunResultClassifiesImplementWorkerProgress(t *testing.T) {
 			wantTerminal:    store.WorkAttemptTerminalSuccess,
 			wantReason:      "pull_request_hydration_failed",
 			wantHydrations:  1,
-			wantRetry:       true,
+			wantReview:      true,
 			wantLogContains: "implement worker progress check failed open",
 		},
 		{
@@ -495,7 +496,7 @@ func TestHandleRunResultClassifiesImplementWorkerProgress(t *testing.T) {
 			wantTerminal:    store.WorkAttemptTerminalSuccess,
 			wantReason:      "pull_request_hydration_unavailable",
 			wantHydrations:  1,
-			wantRetry:       true,
+			wantReview:      true,
 			wantLogContains: "implement worker progress check failed open",
 		},
 		{
@@ -510,7 +511,7 @@ func TestHandleRunResultClassifiesImplementWorkerProgress(t *testing.T) {
 			wantPreviousHead:  "same-head",
 			wantCurrentHead:   "new-head",
 			wantHydrations:    1,
-			wantRetry:         true,
+			wantReview:        true,
 			wantFailedAdded:   []string{"Lint"},
 			wantFailedRemoved: []string{},
 		},
@@ -634,6 +635,13 @@ func TestHandleRunResultClassifiesImplementWorkerProgress(t *testing.T) {
 				}
 				if _, ok := state.Retry[tt.runningIssue.ID]; ok {
 					t.Fatalf("Retry[%q] present after block", tt.runningIssue.ID)
+				}
+			} else if tt.wantReview {
+				if len(tracker.updates) != 1 || tracker.updates[0].state != autoPromoteSourceState {
+					t.Fatalf("updates = %#v, want one Human Review update", tracker.updates)
+				}
+				if _, ok := state.Retry[tt.runningIssue.ID]; ok {
+					t.Fatalf("Retry[%q] present after review transition", tt.runningIssue.ID)
 				}
 			} else if _, ok := state.Retry[tt.runningIssue.ID]; ok != tt.wantRetry {
 				t.Fatalf("retry present = %v, want %v", ok, tt.wantRetry)

--- a/internal/orchestrator/lane_revocation_test.go
+++ b/internal/orchestrator/lane_revocation_test.go
@@ -113,6 +113,141 @@ func TestLaneRevocationPreservesTrackerDestination(t *testing.T) {
 	}
 }
 
+func TestCompletionLaneHandshakeClassifiesCurrentAttempt(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 8, 18, 21, 10, 53, 0, time.UTC)
+	tests := []struct {
+		name                string
+		handshakeAttempt    int64
+		handshakeGeneration uint64
+		reconcileFirst      bool
+		wantTerminal        store.WorkAttemptTerminalState
+		wantRevoked         bool
+	}{
+		{
+			name:                "agent lane write before delivery completion",
+			handshakeAttempt:    3295,
+			handshakeGeneration: 7,
+			reconcileFirst:      true,
+			wantTerminal:        store.WorkAttemptTerminalSuccess,
+		},
+		{
+			name:                "delivery completion observes agent lane write",
+			handshakeAttempt:    3295,
+			handshakeGeneration: 7,
+			wantTerminal:        store.WorkAttemptTerminalSuccess,
+		},
+		{
+			name:           "operator move to completion lane",
+			reconcileFirst: true,
+			wantTerminal:   store.WorkAttemptTerminalLaneRevoked,
+			wantRevoked:    true,
+		},
+		{
+			name:                "agent that no longer holds attempt",
+			handshakeAttempt:    3238,
+			handshakeGeneration: 6,
+			reconcileFirst:      true,
+			wantTerminal:        store.WorkAttemptTerminalLaneRevoked,
+			wantRevoked:         true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			issue := laneRevocationIssue("issue-completion-handshake", "gopherguides/corp#72", "Rework")
+			issue.PullRequest = &connector.PullRequest{Number: 189, State: "OPEN", HeadSHA: "d130765c"}
+			parked := cloneIssue(issue)
+			parked.State = "Human Review"
+			tracker := &autoPromoteTickConnector{stateIssues: []connector.Issue{parked}}
+			if tt.handshakeAttempt > 0 {
+				recordedAt := now.Add(-time.Minute)
+				tracker.issueComments = map[string][]connector.IssueComment{
+					issue.ID: {{
+						Body:      completionHandshakeWorkpadBody(tt.handshakeAttempt, tt.handshakeGeneration),
+						URL:       "https://github.test/workpad",
+						UpdatedAt: &recordedAt,
+					}},
+				}
+			}
+			attempts := &recordingWorkAttemptStore{}
+			cfg := normalizeConfig(Config{
+				Project:        scheduler.ProjectCandidate{ID: "corp"},
+				ActiveStates:   []string{"Todo", "In Progress", "Rework", "Merging"},
+				ObservedStates: []string{"Human Review"},
+				TerminalStates: []string{"Done", "Cancelled"},
+			})
+			orch := &Orchestrator{
+				cfg:                    cfg,
+				connector:              tracker,
+				workAttempts:           attempts,
+				pendingLaneRevocations: map[string]*pendingLaneRevocation{},
+				logger:                 slog.New(slog.NewTextHandler(io.Discard, nil)),
+				now:                    func() time.Time { return now },
+			}
+			state := newState(cfg)
+			runCtx, stop := context.WithCancelCause(context.Background())
+			state.Running[issue.ID] = Running{
+				Issue:         issue,
+				Attempt:       3,
+				WorkAttemptID: 3295,
+				Generation:    7,
+				StartedAt:     now.Add(-20 * time.Minute),
+				stop:          stop,
+			}
+			state.Claimed[issue.ID] = Claimed{Issue: issue, ClaimedAt: now.Add(-20 * time.Minute)}
+
+			if tt.reconcileFirst {
+				orch.reconcileRunningIssues(t.Context(), &state, now)
+			}
+			if got := errors.Is(context.Cause(runCtx), runpkg.ErrLaneRevoked); got != tt.wantRevoked {
+				t.Fatalf("worker revoked = %v, want %v; cause = %v", got, tt.wantRevoked, context.Cause(runCtx))
+			}
+
+			completion := runpkg.Completion{
+				IssueID:     issue.ID,
+				Request:     runpkg.RunRequest{Issue: issue, WorkAttemptID: 3295, Generation: 7},
+				CompletedAt: now.Add(time.Second),
+				Result: runpkg.RunResult{
+					FinalState:            runpkg.FinalStateCompleted,
+					PullRequestUpdated:    !tt.wantRevoked,
+					PullRequestHeadPushed: !tt.wantRevoked,
+					TurnStarted:           true,
+				},
+			}
+			if tt.wantRevoked {
+				completion.Err = runpkg.ErrLaneRevoked
+				completion.Result.FinalState = runpkg.FinalStateLaneRevoked
+			}
+			orch.handleRunResult(t.Context(), &state, completion)
+
+			if len(attempts.completions) != 1 || attempts.completions[0].TerminalState != tt.wantTerminal {
+				t.Fatalf("work attempt completions = %#v, want %q", attempts.completions, tt.wantTerminal)
+			}
+			if tt.wantTerminal == store.WorkAttemptTerminalSuccess {
+				if attempts.completions[0].ErrorClass != "" || attempts.completions[0].ErrorMessage != "" {
+					t.Fatalf("successful completion error = %q/%q", attempts.completions[0].ErrorClass, attempts.completions[0].ErrorMessage)
+				}
+				if _, ok := state.Claimed[issue.ID]; ok {
+					t.Fatalf("Claimed[%q] present after accepted completion", issue.ID)
+				}
+				if got := state.Completed[issue.ID].Issue.State; got != "Human Review" {
+					t.Fatalf("completed issue state = %q, want Human Review", got)
+				}
+				attribution := state.laneProvenance[workflowLaneEntryKey(parked)]
+				if provenance.NormalizeOrigin(attribution.Origin) != provenance.OriginAgent {
+					t.Fatalf("lane provenance = %#v, want agent", attribution)
+				}
+			} else if _, ok := orch.pendingLaneRevocations[issue.ID]; ok {
+				t.Fatalf("pending lane revocation retained after completion")
+			}
+		})
+	}
+}
+
 func TestLaneRevocationRecordsOriginAndDiscardedWork(t *testing.T) {
 	t.Parallel()
 
@@ -557,6 +692,13 @@ func laneRevocationIssue(id string, identifier string, state string) connector.I
 	issue.Title = "Lane revocation test"
 	issue.State = state
 	return issue
+}
+
+func completionHandshakeWorkpadBody(workAttemptID int64, generation uint64) string {
+	return "## Codex Workpad\n\n```detent-status\nschema: 1\nstatus: complete\nfields:\n" +
+		"  completion_work_attempt_id: \"" + strconv.FormatInt(workAttemptID, 10) + "\"\n" +
+		"  completion_generation: \"" + strconv.FormatUint(generation, 10) + "\"\n" +
+		"blockers: []\nhuman_action: null\n```"
 }
 
 func receiveLaneRevocationCompletion(t *testing.T, completions <-chan runpkg.Completion) runpkg.Completion {

--- a/internal/orchestrator/reconcile.go
+++ b/internal/orchestrator/reconcile.go
@@ -292,6 +292,10 @@ func (o *Orchestrator) reconcileRunningIssues(ctx context.Context, state *State,
 			}
 		}
 		if !stateIn(refreshedRunning.Issue.State, o.cfg.ActiveStates) || workspaceIssueTerminal(refreshedRunning.Issue, o.cfg.TerminalStates) {
+			if accepted, ok := o.acceptCurrentAttemptCompletionLane(ctx, state, running, refreshedRunning.Issue, now); ok {
+				state.Running[id] = accepted
+				continue
+			}
 			if running.Generation == 0 && workspaceIssueTerminal(refreshedRunning.Issue, o.cfg.TerminalStates) {
 				o.completeTerminalRunning(ctx, state, id, refreshedRunning, terminalCompletedAt(refreshedRunning.Issue, o.cfg.TerminalStates, now), refreshedRunning.Tokens)
 				continue

--- a/internal/orchestrator/run_completion.go
+++ b/internal/orchestrator/run_completion.go
@@ -147,10 +147,14 @@ func (o *Orchestrator) handleRunResult(ctx context.Context, state *State, event 
 				state.Claimed[event.IssueID] = claimed
 			}
 			if !stateIn(refreshed.State, o.cfg.ActiveStates) || workspaceIssueTerminal(refreshed, o.cfg.TerminalStates) {
-				o.rejectWorkerCompletion(ctx, state, event, running, "current tracker lane is not worker-owned", nil)
-				o.beginLaneRevocation(ctx, state, running, refreshed, event.CompletedAt, laneRevocationStateChanged)
-				o.handleLaneRevocationCompletion(ctx, state, event, running)
-				return
+				if accepted, ok := o.acceptCurrentAttemptCompletionLane(ctx, state, running, refreshed, event.CompletedAt); ok {
+					running = accepted
+				} else {
+					o.rejectWorkerCompletion(ctx, state, event, running, "current tracker lane is not worker-owned", nil)
+					o.beginLaneRevocation(ctx, state, running, refreshed, event.CompletedAt, laneRevocationStateChanged)
+					o.handleLaneRevocationCompletion(ctx, state, event, running)
+					return
+				}
 			}
 		}
 	}
@@ -595,6 +599,16 @@ func (o *Orchestrator) handleRunResult(ctx context.Context, state *State, event 
 			})
 		}
 		return
+	}
+	if running.CompletionLane != "" {
+		o.finishAcceptedCompletionLaneRun(ctx, state, running, event.CompletedAt)
+		return
+	}
+	if terminalState == store.WorkAttemptTerminalSuccess {
+		transition := o.transitionCompletedActiveIssuesToReview(ctx, state, []connector.Issue{running.Issue}, event.CompletedAt)
+		if _, transitioned := transition.transitioned[event.IssueID]; transitioned {
+			return
+		}
 	}
 	if event.Result.BudgetRefusal != nil && !o.cfg.subscriptionBilling() && event.Result.BudgetRefusal.Code == string(budget.ReasonPerIssueMaxUSD) {
 		if err := o.abandonClaim(ctx, event.IssueID); err != nil && o.logger != nil {

--- a/internal/orchestrator/state.go
+++ b/internal/orchestrator/state.go
@@ -157,6 +157,9 @@ type Running struct {
 	ModelPermitExempt           bool
 	CIStopRequested             bool
 	CompletionOwnershipReleased bool
+	CompletionLane              string
+	CompletionWorkpadURL        string
+	CompletionAcceptedAt        time.Time
 	StopDestination             string
 	StopPriorityOptions         []telemetry.StopRunPriorityOption
 	globalSlot                  scheduler.Slot

--- a/internal/orchestrator/targeted_reconcile.go
+++ b/internal/orchestrator/targeted_reconcile.go
@@ -76,6 +76,10 @@ func (o *Orchestrator) applyTargetedReconcile(
 
 	if running, ok := state.Running[issue.ID]; ok &&
 		(!stateIn(running.Issue.State, o.cfg.ActiveStates) || workspaceIssueTerminal(running.Issue, o.cfg.TerminalStates)) {
+		if accepted, acceptedCompletion := o.acceptCurrentAttemptCompletionLane(ctx, state, running, running.Issue, now); acceptedCompletion {
+			state.Running[issue.ID] = accepted
+			return
+		}
 		if running.Generation == 0 && workspaceIssueTerminal(running.Issue, o.cfg.TerminalStates) {
 			o.completeTerminalRunning(ctx, state, issue.ID, running, terminalCompletedAt(running.Issue, o.cfg.TerminalStates, now), running.Tokens)
 			return

--- a/internal/retro/detector.go
+++ b/internal/retro/detector.go
@@ -572,7 +572,7 @@ func phaseTime(event PhaseEvent) time.Time {
 
 func successful(state string) bool {
 	switch strings.ToLower(strings.TrimSpace(state)) {
-	case "success", "completed", "complete", "done", "merged":
+	case "success", "completed", "complete", "done", "merged", "delivered":
 		return true
 	default:
 		return false

--- a/internal/retro/detector_test.go
+++ b/internal/retro/detector_test.go
@@ -6,6 +6,27 @@ import (
 	"time"
 )
 
+func TestSuccessfulTerminalState(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		state string
+		want  bool
+	}{
+		{state: "success", want: true},
+		{state: "delivered", want: true},
+		{state: "lane_revoked"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.state, func(t *testing.T) {
+			t.Parallel()
+			if got := successful(tt.state); got != tt.want {
+				t.Fatalf("successful(%q) = %t, want %t", tt.state, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestDetectReplaysEfficiencyIncidents(t *testing.T) {
 	t.Parallel()
 

--- a/internal/runner/agent.go
+++ b/internal/runner/agent.go
@@ -1310,6 +1310,8 @@ func (r *Runner) Run(ctx context.Context, req RunRequest) (RunResult, error) {
 	}
 	promptOptions := PromptOptions{
 		Attempt:              &attempt,
+		WorkAttemptID:        req.WorkAttemptID,
+		Generation:           req.Generation,
 		PlanOnly:             mode == RunModePlan,
 		MergeFallback:        mergeFallback,
 		MergePrecheckStatus:  mergePrecheck.Status,

--- a/internal/runner/prompt.go
+++ b/internal/runner/prompt.go
@@ -48,6 +48,8 @@ const (
 
 type PromptOptions struct {
 	Attempt              *int
+	WorkAttemptID        int64
+	Generation           uint64
 	PlanOnly             bool
 	MergeFallback        bool
 	MergePrecheckStatus  string
@@ -113,7 +115,7 @@ func BuildPrompt(workflow config.Workflow, issue connector.Issue, opts PromptOpt
 	rendered = appendWorkflowInstructionsBlock(rendered, workflow.Config.Agent, issue, opts)
 	rendered = appendMergeMethodBlock(rendered, workflow.Config.Deliverable)
 	rendered = appendDeliverableBlock(rendered, workflow.Config, issue, opts.WorkspacePath)
-	rendered = appendBlockedHandoffBlock(rendered)
+	rendered = appendBlockedHandoffBlock(rendered, opts)
 	rendered = appendGateBlock(rendered, workflow.Config)
 	rendered = appendAvailableSkills(rendered, AvailableSkillsBlock(opts.AvailableSkills))
 	if promptDeliverableKind(workflow.Config.Deliverable) != config.DeliverablePullRequest {
@@ -265,7 +267,7 @@ func BuildMergeFallbackPrompt(workflow config.Workflow, issue connector.Issue, o
 	}
 	prompt = appendWorkflowInstructionsBlock(prompt, workflow.Config.Agent, issue, opts)
 	prompt = appendMergeMethodBlock(prompt, workflow.Config.Deliverable)
-	prompt = appendBlockedHandoffBlock(prompt)
+	prompt = appendBlockedHandoffBlock(prompt, opts)
 	prompt = appendGateBlock(prompt, workflow.Config)
 	prompt = appendAvailableSkills(prompt, AvailableSkillsBlock(opts.AvailableSkills))
 	if promptDeliverableKind(workflow.Config.Deliverable) == config.DeliverablePullRequest {
@@ -686,7 +688,15 @@ func githubTrackerHostname(tracker config.Tracker) string {
 	return parsed.Host
 }
 
-func appendBlockedHandoffBlock(prompt string) string {
+func appendBlockedHandoffBlock(prompt string, opts PromptOptions) string {
+	completionFields := ""
+	completionOwnership := "Detent owns the completion-lane transition after it accepts the attempt. Do not move the issue to a review or terminal lane yourself; leave the issue in its worker-owned lane and update the Workpad instead."
+	if opts.WorkAttemptID > 0 && opts.Generation > 0 {
+		completionFields = "fields:\n" +
+			"  completion_work_attempt_id: \"" + strconv.FormatInt(opts.WorkAttemptID, 10) + "\"\n" +
+			"  completion_generation: \"" + strconv.FormatUint(opts.Generation, 10) + "\"\n"
+		completionOwnership += " If project workflow instructions still require a completion-lane move, write the exact attempt fields shown below before making that move; Detent accepts only a handshake matching the current lease."
+	}
 	return strings.TrimRight(prompt, " \t\r\n") + "\n\n## Blocked handoff\n\n" +
 		"When writing a Workpad `detent-status` block, `status` must be exactly one of `in_progress`, `blocked`, or `complete`; no other value is valid. " +
 		"The block signals the current work state only. The project's configured flow decides any later review, gate-wait, or merge lane placement.\n\n" +
@@ -718,10 +728,12 @@ func appendBlockedHandoffBlock(prompt string) string {
 		"When `tracker.blocked_recovery` is enabled and the workflow intentionally parks agent-recoverable PR maintenance in a configured source lane, " +
 		"set `reason_code` to `merge_conflict`, `stale_base`, or `missing_current_head_ci` in the blocked status block. " +
 		"Do not set a recovery reason code for manual or human-only parking.\n\n" +
+		completionOwnership + "\n\n" +
 		"On successful completion, declare completion with the same structured block:\n\n" +
 		"```detent-status\n" +
 		"schema: 1\n" +
 		"status: complete\n" +
+		completionFields +
 		"blockers: []\n" +
 		"human_action: null\n" +
 		"```\n\n" +

--- a/internal/runner/prompt_test.go
+++ b/internal/runner/prompt_test.go
@@ -301,6 +301,28 @@ func TestBuildPromptDocumentsWorkpadStatusContract(t *testing.T) {
 	}
 }
 
+func TestBuildPromptBindsCompletionToCurrentAttempt(t *testing.T) {
+	t.Parallel()
+
+	prompt, err := BuildPrompt(config.Workflow{Prompt: "Base prompt"}, connector.Issue{
+		Identifier: "digitaldrywood/detent#1906",
+		Title:      "Fence completion",
+	}, PromptOptions{WorkAttemptID: 3295, Generation: 7})
+	if err != nil {
+		t.Fatalf("BuildPrompt() error = %v", err)
+	}
+	for _, want := range []string{
+		"Detent owns the completion-lane transition after it accepts the attempt.",
+		"completion_work_attempt_id: \"3295\"",
+		"completion_generation: \"7\"",
+		"accepts only a handshake matching the current lease",
+	} {
+		if !strings.Contains(prompt, want) {
+			t.Fatalf("prompt missing %q:\n%s", want, prompt)
+		}
+	}
+}
+
 func TestBuildPromptSkillCreationInstructionsAreConfigurable(t *testing.T) {
 	t.Parallel()
 

--- a/internal/store/migrations/00039_flag_delivered_lane_revocations.sql
+++ b/internal/store/migrations/00039_flag_delivered_lane_revocations.sql
@@ -1,0 +1,59 @@
+-- +goose Up
+UPDATE work_attempts
+SET terminal_state = 'delivered',
+    error_class = NULL,
+    error_message = NULL,
+    phase = 'completed',
+    status_message = 'delivery completed before lane revocation',
+    worker_metadata_json = json_set(
+      CASE WHEN json_valid(worker_metadata_json) THEN worker_metadata_json ELSE '{}' END,
+      '$.historical_lane_revocation',
+      json_object(
+        'classification', 'delivered_before_revocation',
+        'original_terminal_state', terminal_state,
+        'original_error_class', COALESCE(error_class, ''),
+        'original_error_message', COALESCE(error_message, ''),
+        'original_phase', COALESCE(phase, ''),
+        'original_status_message', COALESCE(status_message, '')
+      )
+    )
+WHERE lower(trim(COALESCE(terminal_state, ''))) = 'lane_revoked'
+  AND lower(trim(COALESCE(error_message, ''))) IN ('tracker_lane_changed', 'detent_tracker_lane_changed')
+  AND json_extract(
+    CASE WHEN json_valid(worker_metadata_json) THEN worker_metadata_json ELSE '{}' END,
+    '$.work_product_pushed'
+  ) = 1;
+
+UPDATE codex_sessions
+SET final_state = 'delivered'
+WHERE lower(trim(COALESCE(final_state, ''))) = 'lane_revoked'
+  AND EXISTS (
+    SELECT 1
+    FROM work_attempts
+    WHERE work_attempts.id = codex_sessions.work_attempt_id
+      AND lower(trim(COALESCE(work_attempts.terminal_state, ''))) = 'delivered'
+      AND json_extract(work_attempts.worker_metadata_json, '$.historical_lane_revocation.classification') = 'delivered_before_revocation'
+  );
+
+-- +goose Down
+UPDATE codex_sessions
+SET final_state = 'lane_revoked'
+WHERE lower(trim(COALESCE(final_state, ''))) = 'delivered'
+  AND EXISTS (
+    SELECT 1
+    FROM work_attempts
+    WHERE work_attempts.id = codex_sessions.work_attempt_id
+      AND lower(trim(COALESCE(work_attempts.terminal_state, ''))) = 'delivered'
+      AND json_extract(work_attempts.worker_metadata_json, '$.historical_lane_revocation.classification') = 'delivered_before_revocation'
+  );
+
+UPDATE work_attempts
+SET terminal_state = json_extract(worker_metadata_json, '$.historical_lane_revocation.original_terminal_state'),
+    error_class = NULLIF(json_extract(worker_metadata_json, '$.historical_lane_revocation.original_error_class'), ''),
+    error_message = NULLIF(json_extract(worker_metadata_json, '$.historical_lane_revocation.original_error_message'), ''),
+    phase = NULLIF(json_extract(worker_metadata_json, '$.historical_lane_revocation.original_phase'), ''),
+    status_message = NULLIF(json_extract(worker_metadata_json, '$.historical_lane_revocation.original_status_message'), ''),
+    worker_metadata_json = json_remove(worker_metadata_json, '$.historical_lane_revocation')
+WHERE lower(trim(COALESCE(terminal_state, ''))) = 'delivered'
+  AND json_extract(worker_metadata_json, '$.historical_lane_revocation.classification') = 'delivered_before_revocation'
+  AND json_extract(worker_metadata_json, '$.historical_lane_revocation.original_terminal_state') = 'lane_revoked';

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -330,6 +330,7 @@ const (
 	WorkAttemptTerminalOperatorStopped WorkAttemptTerminalState = "operator_stopped"
 	WorkAttemptTerminalMergeRevoked    WorkAttemptTerminalState = "merge_revoked"
 	WorkAttemptTerminalLaneRevoked     WorkAttemptTerminalState = "lane_revoked"
+	WorkAttemptTerminalDelivered       WorkAttemptTerminalState = "delivered"
 )
 
 type SchedulerDecisionResult string

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -135,6 +135,100 @@ func TestCostPerOutcomeIndexesMigrationUpDown(t *testing.T) {
 	}
 }
 
+func TestDeliveredLaneRevocationMigrationUpDown(t *testing.T) {
+	ctx := t.Context()
+	db, err := sql.Open("sqlite", filepath.Join(t.TempDir(), "detent.db"))
+	if err != nil {
+		t.Fatalf("sql.Open() error = %v", err)
+	}
+	db.SetMaxOpenConns(1)
+	t.Cleanup(func() {
+		if err := db.Close(); err != nil {
+			t.Fatalf("db.Close() error = %v", err)
+		}
+	})
+	if err := configureSQLite(ctx, db, 0); err != nil {
+		t.Fatalf("configureSQLite() error = %v", err)
+	}
+
+	migrationMu.Lock()
+	defer migrationMu.Unlock()
+	goose.SetBaseFS(migrationsFS)
+	defer goose.SetBaseFS(nil)
+	if err := goose.SetDialect("sqlite3"); err != nil {
+		t.Fatalf("goose.SetDialect() error = %v", err)
+	}
+	if err := goose.UpToContext(ctx, db, "migrations", 38); err != nil {
+		t.Fatalf("goose.UpToContext(38) error = %v", err)
+	}
+
+	if _, err := db.ExecContext(ctx, `
+INSERT INTO work_attempts (
+  id, project_id, worker_type, status, started_at, completed_at,
+  terminal_state, error_class, error_message, phase, status_message, worker_metadata_json
+) VALUES
+  (3295, 'corp', 'implementation', 'terminal', '2026-08-18T20:49:37Z', '2026-08-18T21:10:53Z',
+   'lane_revoked', 'lane_revoked', 'tracker_lane_changed', 'lane_revoked', 'worker stopped after leaving a worker-owned lane',
+   '{"work_product_pushed":true,"lane_revocation":{"work_discarded":true}}'),
+  (3238, 'corp', 'implementation', 'terminal', '2026-08-18T15:59:18Z', '2026-08-18T16:06:21Z',
+   'lane_revoked', 'lane_revoked', 'tracker_lane_changed', 'lane_revoked', 'worker stopped after leaving a worker-owned lane',
+   '{"work_product_pushed":false,"lane_revocation":{"work_discarded":true}}'),
+  (3300, 'corp', 'implementation', 'terminal', '2026-08-18T22:00:00Z', '2026-08-18T22:10:00Z',
+   'lane_revoked', 'lane_revoked', 'operator_hold', 'lane_revoked', 'operator stopped the worker',
+   '{"work_product_pushed":true}');
+`); err != nil {
+		t.Fatalf("seed lane revocations error = %v", err)
+	}
+	if _, err := db.ExecContext(ctx, `
+INSERT INTO codex_sessions (id, work_attempt_id, identifier, started_at, completed_at, final_state) VALUES
+  (3337, 3295, 'gopherguides/corp#72', '2026-08-18T20:49:37Z', '2026-08-18T21:10:53Z', 'lane_revoked'),
+  (3338, 3238, 'gopherguides/corp#72', '2026-08-18T15:59:18Z', '2026-08-18T16:06:21Z', 'lane_revoked');
+`); err != nil {
+		t.Fatalf("seed lane revocation sessions error = %v", err)
+	}
+
+	if err := goose.UpToContext(ctx, db, "migrations", 39); err != nil {
+		t.Fatalf("goose.UpToContext(39) error = %v", err)
+	}
+	if got := queryString(t, db, "SELECT terminal_state FROM work_attempts WHERE id = 3295"); got != "delivered" {
+		t.Fatalf("delivered terminal state = %q, want delivered", got)
+	}
+	if got := queryString(t, db, "SELECT COALESCE(error_class, '') FROM work_attempts WHERE id = 3295"); got != "" {
+		t.Fatalf("delivered error class = %q, want empty", got)
+	}
+	if got := queryString(t, db, "SELECT json_extract(worker_metadata_json, '$.historical_lane_revocation.classification') FROM work_attempts WHERE id = 3295"); got != "delivered_before_revocation" {
+		t.Fatalf("historical classification = %q, want delivered_before_revocation", got)
+	}
+	if got := queryString(t, db, "SELECT terminal_state FROM work_attempts WHERE id = 3238"); got != "lane_revoked" {
+		t.Fatalf("undelivered attempt terminal state = %q, want lane_revoked", got)
+	}
+	if got := queryString(t, db, "SELECT terminal_state FROM work_attempts WHERE id = 3300"); got != "lane_revoked" {
+		t.Fatalf("operator revocation terminal state = %q, want lane_revoked", got)
+	}
+	if got := queryString(t, db, "SELECT final_state FROM codex_sessions WHERE id = 3337"); got != "delivered" {
+		t.Fatalf("delivered session final state = %q, want delivered", got)
+	}
+	if got := queryString(t, db, "SELECT final_state FROM codex_sessions WHERE id = 3338"); got != "lane_revoked" {
+		t.Fatalf("undelivered session final state = %q, want lane_revoked", got)
+	}
+
+	if err := goose.DownToContext(ctx, db, "migrations", 38); err != nil {
+		t.Fatalf("goose.DownToContext(38) error = %v", err)
+	}
+	if got := queryString(t, db, "SELECT terminal_state FROM work_attempts WHERE id = 3295"); got != "lane_revoked" {
+		t.Fatalf("restored terminal state = %q, want lane_revoked", got)
+	}
+	if got := queryString(t, db, "SELECT error_message FROM work_attempts WHERE id = 3295"); got != "tracker_lane_changed" {
+		t.Fatalf("restored error message = %q, want tracker_lane_changed", got)
+	}
+	if got := queryString(t, db, "SELECT final_state FROM codex_sessions WHERE id = 3337"); got != "lane_revoked" {
+		t.Fatalf("restored session final state = %q, want lane_revoked", got)
+	}
+	if got := queryInt(t, db, "SELECT COUNT(*) FROM work_attempts WHERE json_extract(worker_metadata_json, '$.historical_lane_revocation.classification') IS NOT NULL"); got != 0 {
+		t.Fatalf("historical classifications after down = %d, want 0", got)
+	}
+}
+
 func TestCachedTokenTelemetryMigrationUpDown(t *testing.T) {
 	ctx := context.Background()
 	dbPath := filepath.Join(t.TempDir(), "detent.db")

--- a/internal/web/templates/analytics_data.go
+++ b/internal/web/templates/analytics_data.go
@@ -102,7 +102,7 @@ func analyticsAttemptDecision(attempt telemetry.WorkAttempt) (primitives.Kind, s
 		return primitives.KindErr, "failed"
 	}
 	switch strings.ToLower(strings.TrimSpace(attempt.TerminalState)) {
-	case "done", "completed", "merged", "success":
+	case "done", "completed", "merged", "success", "delivered":
 		return primitives.KindOK, "completed"
 	case "cancelled", "canceled":
 		return primitives.KindNeutral, "cancelled"

--- a/internal/web/templates/analytics_data_test.go
+++ b/internal/web/templates/analytics_data_test.go
@@ -69,6 +69,7 @@ func TestAnalyticsAttemptDecisions(t *testing.T) {
 		{name: "stale wins", attempt: telemetry.WorkAttempt{Status: "running", Stale: true}, wantKind: primitives.KindWarn, wantText: "stale"},
 		{name: "error is failed", attempt: telemetry.WorkAttempt{ErrorMessage: "boom"}, wantKind: primitives.KindErr, wantText: "failed"},
 		{name: "terminal done completed", attempt: telemetry.WorkAttempt{TerminalState: "Done"}, wantKind: primitives.KindOK, wantText: "completed"},
+		{name: "historical delivery completed", attempt: telemetry.WorkAttempt{TerminalState: "delivered"}, wantKind: primitives.KindOK, wantText: "completed"},
 		{name: "running dispatched", attempt: telemetry.WorkAttempt{Status: "running"}, wantKind: primitives.KindOK, wantText: "dispatched"},
 		{name: "skipped stays neutral", attempt: telemetry.WorkAttempt{Status: "skipped"}, wantKind: primitives.KindNeutral, wantText: "skipped"},
 	}

--- a/internal/web/templates/dashboard_data.go
+++ b/internal/web/templates/dashboard_data.go
@@ -8802,7 +8802,7 @@ func workAttemptStatusClass(row telemetry.WorkAttempt) string {
 		return base + "bg-err/15 text-err"
 	}
 	switch strings.TrimSpace(row.TerminalState) {
-	case "success":
+	case "success", "delivered":
 		return base + "bg-ok/15 text-ok"
 	case "failure", "timed_out", "abandoned", "cancelled":
 		return base + "bg-err/15 text-err"

--- a/internal/web/templates/dashboard_data_test.go
+++ b/internal/web/templates/dashboard_data_test.go
@@ -12,6 +12,15 @@ import (
 	"github.com/digitaldrywood/detent/internal/web/ui/primitives"
 )
 
+func TestWorkAttemptStatusClassTreatsDeliveredAsSuccessful(t *testing.T) {
+	t.Parallel()
+
+	got := workAttemptStatusClass(telemetry.WorkAttempt{TerminalState: "delivered"})
+	if !strings.Contains(got, "bg-ok/15") {
+		t.Fatalf("workAttemptStatusClass(delivered) = %q, want success class", got)
+	}
+}
+
 func TestThroughputRateFormatsRollingTokenTPS(t *testing.T) {
 	t.Parallel()
 

--- a/internal/workpad/workpad.go
+++ b/internal/workpad/workpad.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"regexp"
 	"sort"
+	"strconv"
 	"strings"
 	"time"
 
@@ -24,9 +25,11 @@ const (
 	StatusBlocked    = "blocked"
 	StatusComplete   = "complete"
 
-	FieldCompletionKind     = "completion_kind"
-	FieldCompletionEvidence = "completion_evidence"
-	CompletionOperational   = "operational"
+	FieldCompletionKind       = "completion_kind"
+	FieldCompletionEvidence   = "completion_evidence"
+	FieldCompletionAttempt    = "completion_work_attempt_id"
+	FieldCompletionGeneration = "completion_generation"
+	CompletionOperational     = "operational"
 
 	BlockerOwnerOrchestrator = "orchestrator"
 	BlockerOwnerHuman        = "human"
@@ -528,6 +531,17 @@ func OperationalCompletion(signal *Signal) (string, bool) {
 	}
 	evidence := strings.TrimSpace(signal.Fields[FieldCompletionEvidence])
 	return evidence, evidence != ""
+}
+
+func CurrentAttemptCompletion(signal *Signal, workAttemptID int64, generation uint64) bool {
+	if signal == nil || signal.Invalid != nil || signal.Source != SourceStructured ||
+		strings.TrimSpace(signal.Status) != StatusComplete ||
+		strings.TrimSpace(signal.HumanAction) != "" || len(signal.Blockers) > 0 ||
+		workAttemptID <= 0 || generation == 0 {
+		return false
+	}
+	return strings.TrimSpace(signal.Fields[FieldCompletionAttempt]) == strconv.FormatInt(workAttemptID, 10) &&
+		strings.TrimSpace(signal.Fields[FieldCompletionGeneration]) == strconv.FormatUint(generation, 10)
 }
 
 func normalizeReasonCode(reasonCode string) string {

--- a/internal/workpad/workpad_test.go
+++ b/internal/workpad/workpad_test.go
@@ -166,6 +166,78 @@ func TestSignalFromComment(t *testing.T) {
 	}
 }
 
+func TestCurrentAttemptCompletion(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		signal     *Signal
+		attemptID  int64
+		generation uint64
+		want       bool
+	}{
+		{
+			name: "current structured completion",
+			signal: &Signal{
+				Source: SourceStructured,
+				Status: StatusComplete,
+				Fields: map[string]string{
+					FieldCompletionAttempt:    "3295",
+					FieldCompletionGeneration: "7",
+				},
+			},
+			attemptID:  3295,
+			generation: 7,
+			want:       true,
+		},
+		{
+			name: "stale attempt",
+			signal: &Signal{
+				Source: SourceStructured,
+				Status: StatusComplete,
+				Fields: map[string]string{
+					FieldCompletionAttempt:    "3238",
+					FieldCompletionGeneration: "6",
+				},
+			},
+			attemptID:  3295,
+			generation: 7,
+		},
+		{
+			name: "operator move without handshake",
+			signal: &Signal{
+				Source: SourceStructured,
+				Status: StatusComplete,
+			},
+			attemptID:  3295,
+			generation: 7,
+		},
+		{
+			name: "blocked completion is not accepted",
+			signal: &Signal{
+				Source:   SourceStructured,
+				Status:   StatusComplete,
+				Blockers: []Blocker{{Reason: "waiting"}},
+				Fields: map[string]string{
+					FieldCompletionAttempt:    "3295",
+					FieldCompletionGeneration: "7",
+				},
+			},
+			attemptID:  3295,
+			generation: 7,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := CurrentAttemptCompletion(tt.signal, tt.attemptID, tt.generation); got != tt.want {
+				t.Fatalf("CurrentAttemptCompletion() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestOperationalCompletion(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

- bind completion signals to the active work-attempt ID and generation before accepting an agent-authored completion-lane move
- let authenticated completion survive reconciliation until delivery finishes, while preserving operator and stale-agent revocation behavior
- transition successful Rework attempts under Detent ownership and classify historically pushed lane revocations as delivered with reversible audit metadata

Fixes #1906

## UI Surface Contract

- [x] N/A; this PR does not change UI layout, density, first-viewport behavior, or responsive visibility.
- [x] This PR does not add persistent top-of-screen messaging.
- [x] This PR has no visual changes to primary operator screens; browser verification is not applicable.

## Test Plan

- [x] `make check`
- [x] table-driven current-attempt, operator-move, stale-attempt, and lane-ordering regressions
- [x] migration up/down coverage for work attempts and linked sessions