### PR TITLE
fix(board): surface current blocked cause

### DIFF
--- a/internal/orchestrator/blocked_cause_recovery.go
+++ b/internal/orchestrator/blocked_cause_recovery.go
@@ -307,7 +307,16 @@ func (o *Orchestrator) recoverCauseBlockedIssue(
 			return false
 		}
 		if len(blockers) > 0 && !dependencyBlockersReady(blockers, dependencyCfg, o.cfg.TerminalStates) {
-			o.recordBlockedRecoveryDecision(ctx, state, withDependencies, "defer", "dependency_recovery", nil, "")
+			o.recordBlockedRecoveryDecision(
+				ctx,
+				state,
+				withDependencies,
+				"defer",
+				"dependency_recovery",
+				nil,
+				"",
+				dependencyBlockersNotReady(blockers, dependencyCfg, o.cfg.TerminalStates)...,
+			)
 			setBlockedEvidence(state, issue.ID, recorded.Evidence)
 			return false
 		}
@@ -333,8 +342,9 @@ func (o *Orchestrator) recoverCauseBlockedIssue(
 		)
 		return false
 	}
-	if len(withDependencies.BlockedBy) > 0 {
-		o.recordBlockedRecoveryDecision(ctx, state, withDependencies, "defer", "dependency_recovery", nil, "")
+	unresolvedBlockers := dependencyBlockersNotReady(blockers, dependencyCfg, o.cfg.TerminalStates)
+	if len(unresolvedBlockers) > 0 {
+		o.recordBlockedRecoveryDecision(ctx, state, withDependencies, "defer", "dependency_recovery", nil, "", unresolvedBlockers...)
 		return false
 	}
 	if holdReason == "invalid_workpad_signal" {
@@ -366,7 +376,11 @@ func (o *Orchestrator) recoverCauseBlockedIssue(
 		return transitioned
 	}
 	if park.Owner == blockedRecoveryOwnerHuman || park.Owner == blockedRecoveryOwnerOperator {
-		o.recordBlockedRecoveryDecision(ctx, state, issue, "hold", "human_recovery", &park, park.CauseFingerprint)
+		reason := strings.TrimSpace(park.HoldReason)
+		if reason == "" {
+			reason = "human_recovery"
+		}
+		o.recordBlockedRecoveryDecision(ctx, state, issue, "hold", reason, &park, park.CauseFingerprint)
 		return false
 	}
 	if handled, transitioned := o.reconcileRepeatedFailureGitHubRESTBudgetPark(ctx, state, issue, park, now); handled {
@@ -818,6 +832,7 @@ func (o *Orchestrator) recordBlockedRecoveryDecision(
 		return
 	}
 	entry.Issue = cloneIssue(issue)
+	providedPark := park != nil
 	if park == nil {
 		if current, found := o.currentBlockedRecoveryPark(ctx, state, issue); found {
 			park = &current
@@ -832,6 +847,14 @@ func (o *Orchestrator) recordBlockedRecoveryDecision(
 	entry.RecoveryRoot = nil
 	if park != nil {
 		current := *park
+		if providedPark {
+			if cause := strings.TrimSpace(current.Cause); cause != "" {
+				entry.Reason = cause
+			}
+			if remedy := strings.TrimSpace(current.OperatorRemedy); remedy != "" {
+				entry.RecoveryRemedy = remedy
+			}
+		}
 		current.IntentResumable = current.intentResumable()
 		current.Resumable = false
 		current.Reachability = entry.RecoveryReachability
@@ -844,7 +867,22 @@ func (o *Orchestrator) recordBlockedRecoveryDecision(
 		entry.Recovery = nil
 		entry.RecoveryIntentResumable = strings.EqualFold(strings.TrimSpace(action), "defer")
 	}
+	if strings.EqualFold(strings.TrimSpace(reason), "dependency_recovery") && len(unresolvedWorkpadBlockers) > 0 {
+		entry.Reason = blockedDependencyWaitingReason(unresolvedWorkpadBlockers)
+	}
 	state.Blocked[issue.ID] = entry
+}
+
+func blockedDependencyWaitingReason(blockers []dependencyBlocker) string {
+	parts := make([]string, 0, len(blockers))
+	for _, blocker := range blockers {
+		part := dependencyBlockerLabel(blocker)
+		if state := dependencyBlockerState(blocker); state != "" {
+			part += " (" + state + ")"
+		}
+		parts = append(parts, part)
+	}
+	return "waiting on " + strings.Join(parts, ", ")
 }
 
 func blockedRecoveryReachability(action string) string {

--- a/internal/orchestrator/blocked_cause_recovery_test.go
+++ b/internal/orchestrator/blocked_cause_recovery_test.go
@@ -556,6 +556,7 @@ func TestRepeatedFailureParkRecoveryUsesRecordedRESTBudgetFailures(t *testing.T)
 			if _, ok := transitioned[issue.ID]; ok {
 				t.Fatalf("transitioned[%q] present for held park", issue.ID)
 			}
+			orch.trackBlockedStatusIssues(&state, []connector.Issue{issue}, observedAt.Add(time.Minute))
 			blocked := state.Blocked[issue.ID]
 			if blocked.RecoveryAction != tt.wantAction || blocked.RecoveryReason != tt.wantReason {
 				t.Fatalf("blocked recovery = %q/%q, want %q/%q", blocked.RecoveryAction, blocked.RecoveryReason, tt.wantAction, tt.wantReason)
@@ -566,6 +567,91 @@ func TestRepeatedFailureParkRecoveryUsesRecordedRESTBudgetFailures(t *testing.T)
 				}
 			}
 		})
+	}
+}
+
+func TestBlockedCauseRecoveryUsesCurrentCauseAfterDependencyResolution(t *testing.T) {
+	t.Parallel()
+
+	parkedAt := time.Date(2026, 8, 18, 21, 47, 10, 0, time.UTC)
+	issue := dependencyAutoUnblockIssue("issue-current-blocked-cause", blockedStatusState)
+	issue.BlockedBy = []connector.BlockedRef{{
+		Identifier:   "gopherguides/corp#72",
+		State:        "Done",
+		TrackerState: connector.BlockedRefTrackerStateClosed,
+		Source:       connector.BlockedRefSourceNative,
+	}}
+	blocker := dependencyAutoUnblockIssue("issue-resolved-blocker", "Done")
+	blocker.Identifier = "gopherguides/corp#72"
+	blocker.Closed = true
+	cause := "no_commits_to_deliver: branch detent/gopher-corp-example has no local commits ahead"
+	remedy := "return the issue to Todo when implementation work is ready to resume"
+	metadata := workflowLaneMetadata{BlockedRecovery: &workflowLaneBlockedRecoveryMetadata{
+		Owner:          blockedRecoveryOwnerHuman,
+		Cause:          cause,
+		Predicate:      blockedRecoveryPredicateManaged,
+		TargetState:    autoPromoteReworkState,
+		RunMode:        RunModeImplement,
+		HoldReason:     noCommitsToDeliverReason,
+		OperatorRemedy: remedy,
+	}}
+	metrics := &autoPromoteWorkflowMetricsRecorder{}
+	recordBlockedCausePark(t, metrics, issue, parkedAt, metadata)
+	tracker := &dependencyAutoUnblockConnector{blockers: []connector.Issue{blocker}}
+	orch := blockedCauseTestOrchestrator(tracker)
+	orch.workflowMetrics = metrics
+	state := newState(orch.cfg)
+	state.Blocked[issue.ID] = Blocked{
+		Issue:          issue,
+		Reason:         blockedReasonProjectStatus,
+		RecoveryReason: string(BlockedRecoveryReasonDependencyBlocker),
+		BlockedAt:      parkedAt,
+		Source:         BlockedSourceProjectStatus,
+	}
+
+	orch.recoverBlockedIssues(t.Context(), &state, []connector.Issue{issue}, parkedAt.Add(time.Minute))
+	orch.trackBlockedStatusIssues(&state, []connector.Issue{issue}, parkedAt.Add(2*time.Minute))
+
+	blocked := state.Blocked[issue.ID]
+	if blocked.RecoveryAction != "hold" || blocked.RecoveryReason != noCommitsToDeliverReason {
+		t.Fatalf("blocked recovery = %q/%q, want hold/%s", blocked.RecoveryAction, blocked.RecoveryReason, noCommitsToDeliverReason)
+	}
+	if blocked.Reason != cause {
+		t.Fatalf("blocked reason = %q, want current cause %q", blocked.Reason, cause)
+	}
+	if blocked.RecoveryRemedy != remedy || !blocked.NeedsHumanAttention {
+		t.Fatalf("blocked recovery remedy = %q, needs human = %t", blocked.RecoveryRemedy, blocked.NeedsHumanAttention)
+	}
+}
+
+func TestBlockedCauseRecoveryNamesUnresolvedDependency(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 8, 18, 22, 0, 0, 0, time.UTC)
+	issue := dependencyAutoUnblockIssue("issue-unresolved-blocker", blockedStatusState)
+	issue.BlockedBy = []connector.BlockedRef{{Identifier: "gopherguides/corp#526", State: "In Progress", Source: connector.BlockedRefSourceNative}}
+	blocker := dependencyAutoUnblockIssue("issue-live-blocker", "In Progress")
+	blocker.Identifier = "gopherguides/corp#526"
+	tracker := &dependencyAutoUnblockConnector{blockers: []connector.Issue{blocker}}
+	orch := blockedCauseTestOrchestrator(tracker)
+	state := newState(orch.cfg)
+	state.Blocked[issue.ID] = Blocked{
+		Issue:          issue,
+		Reason:         blockedReasonProjectStatus,
+		RecoveryReason: string(BlockedRecoveryReasonDependencyBlocker),
+		BlockedAt:      now,
+		Source:         BlockedSourceProjectStatus,
+	}
+
+	orch.recoverBlockedIssues(t.Context(), &state, []connector.Issue{issue}, now)
+	orch.trackBlockedStatusIssues(&state, []connector.Issue{issue}, now.Add(time.Minute))
+
+	blocked := state.Blocked[issue.ID]
+	if blocked.RecoveryAction != "defer" || blocked.RecoveryReason != "dependency_recovery" {
+		t.Fatalf("blocked recovery = %q/%q, want defer/dependency_recovery", blocked.RecoveryAction, blocked.RecoveryReason)
+	}
+	if want := "waiting on gopherguides/corp#526 (In Progress)"; blocked.Reason != want {
+		t.Fatalf("blocked reason = %q, want %q", blocked.Reason, want)
 	}
 }
 

--- a/internal/orchestrator/deliverable_recovery.go
+++ b/internal/orchestrator/deliverable_recovery.go
@@ -205,6 +205,9 @@ func (o *Orchestrator) blockDeliverableRecoveryFailure(
 		running.DiffStats,
 	)
 	metadata.BlockedRecovery.Owner = blockedRecoveryOwnerHuman
+	reasonCode := deliverableRecoveryReasonCode(lookup)
+	metadata.BlockedRecovery.HoldReason = reasonCode
+	metadata.BlockedRecovery.OperatorRemedy = humanAction
 	if err := o.updateIssueStateByIDWithMetadata(ctx, state, issue.ID, issue, blockedStatusState, event.CompletedAt, reason, metadata); err != nil {
 		if o.logger != nil {
 			o.logger.Warn(
@@ -248,15 +251,18 @@ func (o *Orchestrator) blockDeliverableRecoveryFailure(
 		state.Blocked = map[string]Blocked{}
 	}
 	state.Blocked[issue.ID] = Blocked{
-		Issue:          issue,
-		Reason:         reason,
-		RecoveryReason: humanAction,
-		RecoveryTarget: autoPromoteReworkState,
-		BlockedAt:      event.CompletedAt,
-		Source:         BlockedSourceProjectStatus,
-		Recovery:       metadata.BlockedRecovery,
+		Issue:                issue,
+		Reason:               reason,
+		RecoveryAction:       "hold",
+		RecoveryReason:       reasonCode,
+		RecoveryRemedy:       humanAction,
+		RecoveryTarget:       autoPromoteReworkState,
+		RecoveryReachability: blockedRecoveryReachability("hold"),
+		NeedsHumanAttention:  true,
+		BlockedAt:            event.CompletedAt,
+		Source:               BlockedSourceProjectStatus,
+		Recovery:             metadata.BlockedRecovery,
 	}
-	reasonCode := deliverableRecoveryReasonCode(lookup)
 	recordStateEvent(state, telemetry.ActivityEvent{
 		At:      event.CompletedAt,
 		Event:   reasonCode,

--- a/internal/orchestrator/reconcile.go
+++ b/internal/orchestrator/reconcile.go
@@ -525,17 +525,8 @@ func clearBlockedStatusIssue(state *State, issueID string) {
 }
 
 func (o *Orchestrator) setBlockedStatusIssue(state *State, issue connector.Issue, now time.Time) {
-	if existing, ok := state.Blocked[issue.ID]; ok &&
-		existing.Source == BlockedSourceProjectStatus &&
-		(strings.HasPrefix(existing.Reason, instantFailureBlockedReasonPrefix) ||
-			strings.HasPrefix(existing.Reason, repeatedFailureBlockedReasonPrefix) ||
-			strings.HasPrefix(existing.Reason, tokenCeilingBlockedReasonPrefix) ||
-			strings.HasPrefix(existing.Reason, artifactGateConvergenceBlockedReasonPrefix) ||
-			strings.HasPrefix(existing.Reason, mergeWorkerRetryExhaustedReason) ||
-			strings.HasPrefix(existing.Reason, mergeWorkerPersistentMissingRequiredCheckReason) ||
-			strings.HasPrefix(existing.Reason, mergeWorkerDurationExceededReason)) &&
-		strings.TrimSpace(issue.BlockerReason) == "" {
-		existing.Issue = cloneIssue(issue)
+	if existing, ok := state.Blocked[issue.ID]; ok && existing.Source == BlockedSourceProjectStatus {
+		existing.Issue = mergeIssueTrackerFields(existing.Issue, issue)
 		state.Blocked[issue.ID] = existing
 		return
 	}

--- a/internal/web/templates/board_data.go
+++ b/internal/web/templates/board_data.go
@@ -1593,7 +1593,10 @@ func boardCardMatchesIssue(issue telemetry.Issue, card projectKanbanCard) bool {
 
 func boardCardBlockedWaitingText(card projectKanbanCard) string {
 	if len(card.Blockers) > 0 {
-		return "waiting - " + card.Blockers[0]
+		return "waiting on " + card.Blockers[0]
+	}
+	if len(card.ClearedBlockers) > 0 && boardBlockedDependencyWaiting(card.BlockedSource, card.BlockedRecoveryReason, card.BlockedReason, nil) {
+		return "waiting - project status"
 	}
 	if detail := boardBlockedDetail(card.BlockedSource, card.BlockedRecoveryAction, card.BlockedRecoveryReason, card.BlockedRecoveryRemedy, card.BlockedReason); detail != "" {
 		return "waiting - " + detail

--- a/internal/web/templates/board_data_test.go
+++ b/internal/web/templates/board_data_test.go
@@ -1816,12 +1816,84 @@ func TestBoardBlockedWaitingCardsUseWarningTreatment(t *testing.T) {
 	if card.ExtraKind != primitives.KindWarn || !card.ExtraChip {
 		t.Fatalf("card extra = %q chip %t, want warn chip; card = %+v", card.ExtraKind, card.ExtraChip, card)
 	}
-	if !strings.Contains(card.ExtraText, "waiting - digitaldrywood/detent#170 In Progress") {
+	if !strings.Contains(card.ExtraText, "waiting on digitaldrywood/detent#170 (In Progress)") {
 		t.Fatalf("card extra text = %q", card.ExtraText)
 	}
 	cardClass := boardCardClass(card)
 	if !strings.Contains(cardClass, "border-warn/45") || strings.Contains(cardClass, "border-err/45") {
 		t.Fatalf("card class = %q, want warning border without error border", cardClass)
+	}
+}
+
+func TestBoardBlockedCauseBadge(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		card     projectKanbanCard
+		wantKind primitives.Kind
+		wantText string
+	}{
+		{
+			name: "unresolved dependency names ref and state",
+			card: projectKanbanCard{
+				BlockedSource:         telemetry.BlockedSourceProjectStatus,
+				BlockedReason:         "waiting on gopherguides/corp#526 (In Progress)",
+				BlockedRecoveryAction: "defer",
+				BlockedRecoveryReason: "dependency_recovery",
+				Blockers:              []string{"gopherguides/corp#526 (In Progress)"},
+			},
+			wantKind: primitives.KindWarn,
+			wantText: "waiting on gopherguides/corp#526 (In Progress)",
+		},
+		{
+			name: "satisfied refs cannot claim dependency wait",
+			card: projectKanbanCard{
+				BlockedSource:         telemetry.BlockedSourceProjectStatus,
+				BlockedReason:         "blocked by project status",
+				BlockedRecoveryReason: "dependency_blocker",
+				ClearedBlockers:       []string{"gopherguides/corp#526 (Done)"},
+			},
+			wantKind: primitives.KindWarn,
+			wantText: "waiting - project status",
+		},
+		{
+			name: "transient resource wait stays passive",
+			card: projectKanbanCard{
+				BlockedSource:         telemetry.BlockedSourceProjectStatus,
+				BlockedReason:         "transient GitHub REST budget waiting for capacity: remaining=940/5000 reserve=1250",
+				BlockedRecoveryAction: "defer",
+				BlockedRecoveryReason: "github_rest_budget_wait",
+			},
+			wantKind: primitives.KindWarn,
+			wantText: "waiting - transient GitHub REST budget waiting for capacity: remaining=940/5000 reserve=1250",
+		},
+		{
+			name: "human delivery failure needs review",
+			card: projectKanbanCard{
+				BlockedSource:         telemetry.BlockedSourceProjectStatus,
+				BlockedReason:         "no_commits_to_deliver: branch detent/gopher-corp-example has no local commits ahead",
+				BlockedRecoveryAction: "hold",
+				BlockedRecoveryReason: "no_commits_to_deliver",
+				BlockedRecoveryRemedy: "return the issue to Todo when implementation work is ready to resume",
+			},
+			wantKind: primitives.KindErr,
+			wantText: "needs review - no commits to deliver — return the issue to Todo when implementation work is ready to resume",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			kind, text, chip := boardCardExtra(tt.card, boardCardView{})
+			if kind != tt.wantKind || text != tt.wantText || !chip {
+				t.Fatalf("boardCardExtra() = %q, %q, %t, want %q, %q, true", kind, text, chip, tt.wantKind, tt.wantText)
+			}
+			if strings.Contains(text, "dependency not ready") {
+				t.Fatalf("boardCardExtra() exposed unnamed dependency: %q", text)
+			}
+		})
 	}
 }
 

--- a/internal/web/templates/dashboard_data.go
+++ b/internal/web/templates/dashboard_data.go
@@ -3230,7 +3230,7 @@ func projectKanbanBlockerLabels(refs []telemetry.BlockedRef, terminalStates map[
 				label += " (" + trackerState + ")"
 			}
 		} else if state := strings.TrimSpace(ref.State); state != "" {
-			label += " " + state
+			label += " (" + state + ")"
 		}
 		if projectKanbanBlockedRefCleared(ref, terminalStates) {
 			cleared = append(cleared, label)

--- a/internal/web/templates/dashboard_data_test.go
+++ b/internal/web/templates/dashboard_data_test.go
@@ -1833,8 +1833,8 @@ func TestProjectKanbanBoardGroupsSnapshotRowsByConfiguredStates(t *testing.T) {
 		{Lane: "Backlog", IssueNumber: "#10", Title: "Backlog issue", TimeInStage: "7m 0s", Metadata: "No linked PR"},
 		{Lane: "Todo", IssueNumber: "#11", Title: "Todo issue", TimeInStage: "6m 0s", Metadata: "No linked PR"},
 		{Lane: "In Progress", IssueNumber: "#13", Title: "Running issue", TimeInStage: "5m 0s", Labels: "bug", Assignees: "bob", Metadata: "No linked PR"},
-		{Lane: "Blocked", IssueNumber: "#14", Title: "Blocked issue", TimeInStage: "4m 0s", Blockers: "digitaldrywood/detent#401 In Progress", Metadata: "No linked PR"},
-		{Lane: "Human Review", IssueNumber: "#12", Title: "Review lane PR", URL: "https://github.com/digitaldrywood/detent/issues/12", CIStatus: "pass", CodexReviewState: "clean", TimeInStage: "3m 0s", WaitDetail: "waiting for auto-promote", Labels: "enhancement, stage:s6", Assignees: "alice", ClearedBlockers: "digitaldrywood/detent#10 Done", Metadata: "PR #142"},
+		{Lane: "Blocked", IssueNumber: "#14", Title: "Blocked issue", TimeInStage: "4m 0s", Blockers: "digitaldrywood/detent#401 (In Progress)", Metadata: "No linked PR"},
+		{Lane: "Human Review", IssueNumber: "#12", Title: "Review lane PR", URL: "https://github.com/digitaldrywood/detent/issues/12", CIStatus: "pass", CodexReviewState: "clean", TimeInStage: "3m 0s", WaitDetail: "waiting for auto-promote", Labels: "enhancement, stage:s6", Assignees: "alice", ClearedBlockers: "digitaldrywood/detent#10 (Done)", Metadata: "PR #142"},
 		{Lane: "Done", IssueNumber: "#15", Title: "Done lane PR", URL: "https://github.com/digitaldrywood/detent/issues/15", CIStatus: "pass", CodexReviewState: "clean", TimeInStage: "2m 0s", Metadata: "PR #145"},
 	}
 	if len(got) != len(want) {
@@ -2318,7 +2318,7 @@ func TestProjectKanbanCardForIssueOnlyKeepsActiveBlockers(t *testing.T) {
 			blockedBy: []telemetry.BlockedRef{
 				{Identifier: "digitaldrywood/detent#429", State: "Done"},
 			},
-			wantCleared: []string{"digitaldrywood/detent#429 Done"},
+			wantCleared: []string{"digitaldrywood/detent#429 (Done)"},
 		},
 		{
 			name:  "non-terminal dependency stays active",
@@ -2326,7 +2326,7 @@ func TestProjectKanbanCardForIssueOnlyKeepsActiveBlockers(t *testing.T) {
 			blockedBy: []telemetry.BlockedRef{
 				{Identifier: "digitaldrywood/detent#430", State: "In Progress"},
 			},
-			wantBlockers: []string{"digitaldrywood/detent#430 In Progress"},
+			wantBlockers: []string{"digitaldrywood/detent#430 (In Progress)"},
 		},
 		{
 			name:  "unresolved dependency stays active",
@@ -2402,7 +2402,7 @@ func TestProjectKanbanCardForIssueUsesProjectTerminalStates(t *testing.T) {
 	if len(card.Blockers) != 0 {
 		t.Fatalf("Blockers = %#v, want none for project terminal state", card.Blockers)
 	}
-	if got, want := strings.Join(card.ClearedBlockers, ", "), "digitaldrywood/custom#429 Released"; got != want {
+	if got, want := strings.Join(card.ClearedBlockers, ", "), "digitaldrywood/custom#429 (Released)"; got != want {
 		t.Fatalf("ClearedBlockers = %q, want %q", got, want)
 	}
 }


### PR DESCRIPTION
## Summary

- Keep the latest durable blocked cause authoritative after dependency refs resolve and tracker status refreshes.
- Name active dependency waits with the unresolved issue and state while retaining satisfied refs only as resolved context.
- Distinguish transient GitHub REST capacity waits from `no_commits_to_deliver` failures that need human action.

Fixes #1912

## UI Surface Contract

- [x] N/A, or the linked issue explicitly authorizes any high-impact UI surface, layout, density, first-viewport, or responsive visibility tradeoff.
- [x] Persistent top-of-screen messaging is explicitly authorized by the issue, or this PR does not add it.
- [x] Visual changes to primary operator screens include screenshot or browser verification below.

Browser verification used an isolated random-port server with the real board handler. It confirmed resolved refs do not produce a dependency-wait badge, active refs render as `waiting on <issue> (<state>)`, REST budget waits remain warnings, and `no_commits_to_deliver` renders as a needs-review error with its remediation.

## Test Plan

- [x] `PATH="$TMPDIR/bin:$PATH" make check` using the CI-pinned golangci-lint v2.1.6 (race suite, 78.9% coverage, package/file floors)
- [x] `go test ./internal/orchestrator ./internal/web/templates`
- [x] Isolated Chrome DevTools verification of the four blocked-card states and the human-action detail sheet