### PR TITLE
fix(orchestrator): refresh blocked causes

### DIFF
--- a/internal/orchestrator/backend_capacity.go
+++ b/internal/orchestrator/backend_capacity.go
@@ -734,7 +734,7 @@ func (o *Orchestrator) backendCapacityBlockedRecoveryTarget(
 	if !recoveredAt.IsZero() && (recoveredAt.Before(entry.Event.StartedAt) || recoveredAt.Before(commentAt)) {
 		return "", "backend capacity recovery predates the current Blocked entry evidence"
 	}
-	if len(issue.BlockedBy) > 0 {
+	if blockedRefsUnresolved(issue.BlockedBy, o.cfg.TerminalStates) {
 		return "", "current issue has independent dependency blockers"
 	}
 	if signal, found := autoPromoteIssueWorkpadSignal(issue); found && signal != nil && signal.Source == workpad.SourceStructured {

--- a/internal/orchestrator/blocked_cause_recovery.go
+++ b/internal/orchestrator/blocked_cause_recovery.go
@@ -284,7 +284,7 @@ func (o *Orchestrator) recoverCauseBlockedIssue(
 				switch {
 				case issue.WorkpadSignal.Invalid != nil:
 					reason = BlockedRecoveryHumanHoldReason(issue, o.cfg.AutoPromote.OptoutLabel)
-					if reason == "invalid_workpad_signal" && len(withDependencies.BlockedBy) == 0 {
+					if reason == "invalid_workpad_signal" && len(dependencyBlockersNotReady(blockers, dependencyCfg, o.cfg.TerminalStates)) == 0 {
 						if handled, transitioned := o.reconcileInvalidWorkpadPark(ctx, state, issue, now); handled {
 							return transitioned
 						}
@@ -827,16 +827,36 @@ func (o *Orchestrator) recordBlockedRecoveryDecision(
 	if state == nil || strings.TrimSpace(issue.ID) == "" {
 		return
 	}
-	entry, ok := state.Blocked[issue.ID]
-	if !ok {
-		return
-	}
-	entry.Issue = cloneIssue(issue)
 	providedPark := park != nil
 	if park == nil {
 		if current, found := o.currentBlockedRecoveryPark(ctx, state, issue); found {
 			park = &current
 		}
+	}
+	entry, ok := state.Blocked[issue.ID]
+	if !ok {
+		if !blockedRecoveryDecisionShouldMaterialize(reason) {
+			return
+		}
+		blockedAt := time.Time{}
+		if issue.StageUpdatedAt != nil {
+			blockedAt = issue.StageUpdatedAt.UTC()
+		}
+		o.setBlockedStatusIssue(state, issue, blockedAt)
+		entry, ok = state.Blocked[issue.ID]
+		if !ok {
+			return
+		}
+	}
+	previousRecoveryReason := strings.TrimSpace(entry.RecoveryReason)
+	entry.Issue = cloneIssue(issue)
+	if trackerReason := strings.TrimSpace(issue.BlockerReason); trackerReason != "" {
+		entry.Reason = trackerReason
+	} else if strings.EqualFold(previousRecoveryReason, string(BlockedRecoveryReasonDependencyBlocker)) ||
+		strings.EqualFold(previousRecoveryReason, "dependency_recovery") ||
+		strings.EqualFold(strings.TrimSpace(entry.Reason), "blocked by project status") ||
+		strings.HasPrefix(strings.ToLower(strings.TrimSpace(entry.Reason)), "waiting on ") {
+		entry.Reason = ""
 	}
 	entry.RecoveryAction = strings.TrimSpace(action)
 	entry.RecoveryReason = strings.TrimSpace(reason)
@@ -871,6 +891,19 @@ func (o *Orchestrator) recordBlockedRecoveryDecision(
 		entry.Reason = blockedDependencyWaitingReason(unresolvedWorkpadBlockers)
 	}
 	state.Blocked[issue.ID] = entry
+}
+
+func blockedRecoveryDecisionShouldMaterialize(reason string) bool {
+	reason = strings.ToLower(strings.TrimSpace(reason))
+	if strings.Contains(reason, "already_consumed") {
+		return false
+	}
+	switch reason {
+	case "no_recovery_predicate", "pr_maintenance_recovery", "rework_breaker_recovery":
+		return false
+	default:
+		return true
+	}
 }
 
 func blockedDependencyWaitingReason(blockers []dependencyBlocker) string {

--- a/internal/orchestrator/blocked_cause_recovery_test.go
+++ b/internal/orchestrator/blocked_cause_recovery_test.go
@@ -573,54 +573,68 @@ func TestRepeatedFailureParkRecoveryUsesRecordedRESTBudgetFailures(t *testing.T)
 func TestBlockedCauseRecoveryUsesCurrentCauseAfterDependencyResolution(t *testing.T) {
 	t.Parallel()
 
-	parkedAt := time.Date(2026, 8, 18, 21, 47, 10, 0, time.UTC)
-	issue := dependencyAutoUnblockIssue("issue-current-blocked-cause", blockedStatusState)
-	issue.BlockedBy = []connector.BlockedRef{{
-		Identifier:   "gopherguides/corp#72",
-		State:        "Done",
-		TrackerState: connector.BlockedRefTrackerStateClosed,
-		Source:       connector.BlockedRefSourceNative,
-	}}
-	blocker := dependencyAutoUnblockIssue("issue-resolved-blocker", "Done")
-	blocker.Identifier = "gopherguides/corp#72"
-	blocker.Closed = true
-	cause := "no_commits_to_deliver: branch detent/gopher-corp-example has no local commits ahead"
-	remedy := "return the issue to Todo when implementation work is ready to resume"
-	metadata := workflowLaneMetadata{BlockedRecovery: &workflowLaneBlockedRecoveryMetadata{
-		Owner:          blockedRecoveryOwnerHuman,
-		Cause:          cause,
-		Predicate:      blockedRecoveryPredicateManaged,
-		TargetState:    autoPromoteReworkState,
-		RunMode:        RunModeImplement,
-		HoldReason:     noCommitsToDeliverReason,
-		OperatorRemedy: remedy,
-	}}
-	metrics := &autoPromoteWorkflowMetricsRecorder{}
-	recordBlockedCausePark(t, metrics, issue, parkedAt, metadata)
-	tracker := &dependencyAutoUnblockConnector{blockers: []connector.Issue{blocker}}
-	orch := blockedCauseTestOrchestrator(tracker)
-	orch.workflowMetrics = metrics
-	state := newState(orch.cfg)
-	state.Blocked[issue.ID] = Blocked{
-		Issue:          issue,
-		Reason:         blockedReasonProjectStatus,
-		RecoveryReason: string(BlockedRecoveryReasonDependencyBlocker),
-		BlockedAt:      parkedAt,
-		Source:         BlockedSourceProjectStatus,
-	}
+	for _, tt := range []struct {
+		name      string
+		seedStale bool
+	}{
+		{name: "first observation"},
+		{name: "supersedes stale dependency classification", seedStale: true},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 
-	orch.recoverBlockedIssues(t.Context(), &state, []connector.Issue{issue}, parkedAt.Add(time.Minute))
-	orch.trackBlockedStatusIssues(&state, []connector.Issue{issue}, parkedAt.Add(2*time.Minute))
+			parkedAt := time.Date(2026, 8, 18, 21, 47, 10, 0, time.UTC)
+			issue := dependencyAutoUnblockIssue("issue-current-blocked-cause-"+strings.ReplaceAll(tt.name, " ", "-"), blockedStatusState)
+			issue.BlockedBy = []connector.BlockedRef{{
+				Identifier:   "gopherguides/corp#72",
+				State:        "Done",
+				TrackerState: connector.BlockedRefTrackerStateClosed,
+				Source:       connector.BlockedRefSourceNative,
+			}}
+			blocker := dependencyAutoUnblockIssue("issue-resolved-blocker", "Done")
+			blocker.Identifier = "gopherguides/corp#72"
+			blocker.Closed = true
+			cause := "no_commits_to_deliver: branch detent/gopher-corp-example has no local commits ahead"
+			remedy := "return the issue to Todo when implementation work is ready to resume"
+			metadata := workflowLaneMetadata{BlockedRecovery: &workflowLaneBlockedRecoveryMetadata{
+				Owner:          blockedRecoveryOwnerHuman,
+				Cause:          cause,
+				Predicate:      blockedRecoveryPredicateManaged,
+				TargetState:    autoPromoteReworkState,
+				RunMode:        RunModeImplement,
+				HoldReason:     noCommitsToDeliverReason,
+				OperatorRemedy: remedy,
+			}}
+			metrics := &autoPromoteWorkflowMetricsRecorder{}
+			recordBlockedCausePark(t, metrics, issue, parkedAt, metadata)
+			tracker := &dependencyAutoUnblockConnector{blockers: []connector.Issue{blocker}}
+			orch := blockedCauseTestOrchestrator(tracker)
+			orch.workflowMetrics = metrics
+			state := newState(orch.cfg)
+			if tt.seedStale {
+				state.Blocked[issue.ID] = Blocked{
+					Issue:          issue,
+					Reason:         "blocked by project status",
+					RecoveryReason: string(BlockedRecoveryReasonDependencyBlocker),
+					BlockedAt:      parkedAt,
+					Source:         BlockedSourceProjectStatus,
+				}
+			}
 
-	blocked := state.Blocked[issue.ID]
-	if blocked.RecoveryAction != "hold" || blocked.RecoveryReason != noCommitsToDeliverReason {
-		t.Fatalf("blocked recovery = %q/%q, want hold/%s", blocked.RecoveryAction, blocked.RecoveryReason, noCommitsToDeliverReason)
-	}
-	if blocked.Reason != cause {
-		t.Fatalf("blocked reason = %q, want current cause %q", blocked.Reason, cause)
-	}
-	if blocked.RecoveryRemedy != remedy || !blocked.NeedsHumanAttention {
-		t.Fatalf("blocked recovery remedy = %q, needs human = %t", blocked.RecoveryRemedy, blocked.NeedsHumanAttention)
+			orch.recoverBlockedIssues(t.Context(), &state, []connector.Issue{issue}, parkedAt.Add(time.Minute))
+			orch.trackBlockedStatusIssues(&state, []connector.Issue{issue}, parkedAt.Add(2*time.Minute))
+
+			blocked := state.Blocked[issue.ID]
+			if blocked.RecoveryAction != "hold" || blocked.RecoveryReason != noCommitsToDeliverReason {
+				t.Fatalf("blocked recovery = %q/%q, want hold/%s", blocked.RecoveryAction, blocked.RecoveryReason, noCommitsToDeliverReason)
+			}
+			if blocked.Reason != cause {
+				t.Fatalf("blocked reason = %q, want current cause %q", blocked.Reason, cause)
+			}
+			if blocked.RecoveryRemedy != remedy || !blocked.NeedsHumanAttention {
+				t.Fatalf("blocked recovery remedy = %q, needs human = %t", blocked.RecoveryRemedy, blocked.NeedsHumanAttention)
+			}
+		})
 	}
 }
 
@@ -635,13 +649,6 @@ func TestBlockedCauseRecoveryNamesUnresolvedDependency(t *testing.T) {
 	tracker := &dependencyAutoUnblockConnector{blockers: []connector.Issue{blocker}}
 	orch := blockedCauseTestOrchestrator(tracker)
 	state := newState(orch.cfg)
-	state.Blocked[issue.ID] = Blocked{
-		Issue:          issue,
-		Reason:         blockedReasonProjectStatus,
-		RecoveryReason: string(BlockedRecoveryReasonDependencyBlocker),
-		BlockedAt:      now,
-		Source:         BlockedSourceProjectStatus,
-	}
 
 	orch.recoverBlockedIssues(t.Context(), &state, []connector.Issue{issue}, now)
 	orch.trackBlockedStatusIssues(&state, []connector.Issue{issue}, now.Add(time.Minute))

--- a/internal/orchestrator/blocked_recovery.go
+++ b/internal/orchestrator/blocked_recovery.go
@@ -69,7 +69,7 @@ func EvaluateBlockedRecovery(issue connector.Issue) BlockedRecoveryDecision {
 		Enabled:      true,
 		SourceStates: []string{blockedStatusState},
 		TargetState:  autoPromoteReworkState,
-	}))
+	}), []string{"Done", "Cancelled", "Canceled", "Closed"})
 }
 
 func EvaluateBlockedRecoveryWithConfig(issue connector.Issue, cfg BlockedRecoveryConfig) BlockedRecoveryDecision {
@@ -80,7 +80,7 @@ func EvaluateBlockedRecoveryWithConfig(issue connector.Issue, cfg BlockedRecover
 	return decision
 }
 
-func evaluateBlockedRecovery(issue connector.Issue, cfg BlockedRecoveryConfig) BlockedRecoveryDecision {
+func evaluateBlockedRecovery(issue connector.Issue, cfg BlockedRecoveryConfig, terminalStates []string) BlockedRecoveryDecision {
 	issue = issueWithTextDependencyRefs(issue)
 	cfg = normalizeBlockedRecoveryConfig(cfg)
 	if !stateIn(issue.State, cfg.SourceStates) {
@@ -89,7 +89,7 @@ func evaluateBlockedRecovery(issue connector.Issue, cfg BlockedRecoveryConfig) B
 	if blockedRecoveryHumanOnly(issue) {
 		return blockedRecoveryDecision(BlockedRecoveryActionNone, BlockedRecoveryReasonHumanBlocker, "blocked reason requires a human")
 	}
-	if len(issue.BlockedBy) > 0 {
+	if blockedRefsUnresolved(issue.BlockedBy, terminalStates) {
 		return blockedRecoveryDecision(BlockedRecoveryActionNone, BlockedRecoveryReasonDependencyBlocker, "dependency blockers must clear first")
 	}
 	if issue.PullRequest == nil {
@@ -195,7 +195,7 @@ func (o *Orchestrator) recoverBlockedIssues(
 		}
 		if park, ok := o.latestReworkBreakerPark(ctx, issue); normalizeState(issue.State) == normalizeState(blockedStatusState) && autoPromoteCfg.Enabled && ok {
 			if reworkBreakerAutoUnparkConsumed(park.Timeline, park.Signature) ||
-				!reworkBreakerAutoUnparkReady(issue, park) ||
+				!reworkBreakerAutoUnparkReady(issue, park, o.cfg.TerminalStates) ||
 				!o.reworkBreakerAutoPromoteGateReady(ctx, state, issue, autoPromoteCfg, now) {
 				continue
 			}
@@ -215,7 +215,7 @@ func (o *Orchestrator) recoverBlockedIssues(
 		if !ok || !blockedRecoveryReasonAllowed(recoveryCfg, reasonCode) {
 			continue
 		}
-		decision := evaluateBlockedRecovery(issue, recoveryCfg)
+		decision := evaluateBlockedRecovery(issue, recoveryCfg, o.cfg.TerminalStates)
 		if decision.Action != BlockedRecoveryActionRework {
 			continue
 		}
@@ -351,7 +351,7 @@ func evaluateStructuredBlockedRecovery(
 	if !blockedRecoveryReasonAllowed(cfg, reasonCode) {
 		return BlockedRecoveryDecision{}, "", false
 	}
-	decision := evaluateBlockedRecovery(issue, cfg)
+	decision := evaluateBlockedRecovery(issue, cfg, []string{"Done", "Cancelled", "Canceled", "Closed"})
 	if decision.Action != BlockedRecoveryActionRework ||
 		!blockedRecoveryConditionMatches(reasonCode, decision.Reason) {
 		return BlockedRecoveryDecision{}, "", false
@@ -476,8 +476,8 @@ func reworkBreakerPullRequestMetadataEqual(left, right *workflowLanePullRequestM
 		strings.TrimSpace(left.HeadSHA) != "" && strings.TrimSpace(left.HeadSHA) == strings.TrimSpace(right.HeadSHA)
 }
 
-func reworkBreakerAutoUnparkReady(issue connector.Issue, park reworkBreakerPark) bool {
-	if normalizeState(issue.State) != normalizeState(blockedStatusState) || issue.Closed || reworkBreakerIssueHeld(issue) {
+func reworkBreakerAutoUnparkReady(issue connector.Issue, park reworkBreakerPark, terminalStates []string) bool {
+	if normalizeState(issue.State) != normalizeState(blockedStatusState) || issue.Closed || reworkBreakerIssueHeld(issue, terminalStates) {
 		return false
 	}
 	if issue.StageUpdatedAt != nil && issue.StageUpdatedAt.After(park.Event.StartedAt.Add(reworkBreakerStageUpdateSkew)) {
@@ -498,13 +498,28 @@ func reworkBreakerAutoUnparkReady(issue connector.Issue, park reworkBreakerPark)
 		len(autoPromoteFindingsFromPullRequest(pr)) == 0
 }
 
-func reworkBreakerIssueHeld(issue connector.Issue) bool {
+func reworkBreakerIssueHeld(issue connector.Issue, terminalStates []string) bool {
 	issue = issueWithTextDependencyRefs(issue)
-	if len(issue.BlockedBy) > 0 || strings.TrimSpace(issue.BlockerReason) != "" || blockedRecoveryHumanOnly(issue) {
+	if blockedRefsUnresolved(issue.BlockedBy, terminalStates) || strings.TrimSpace(issue.BlockerReason) != "" || blockedRecoveryHumanOnly(issue) {
 		return true
 	}
 	signal := issue.WorkpadSignal
 	return signal != nil && (signal.Invalid != nil || strings.TrimSpace(signal.HumanAction) != "" || len(signal.Blockers) > 0 || strings.EqualFold(strings.TrimSpace(signal.Status), "blocked"))
+}
+
+func blockedRefsUnresolved(refs []connector.BlockedRef, terminalStates []string) bool {
+	for _, ref := range refs {
+		switch strings.ToLower(strings.TrimSpace(ref.TrackerState)) {
+		case connector.BlockedRefTrackerStateClosed:
+			continue
+		case connector.BlockedRefTrackerStateOpen:
+			return true
+		}
+		if !stateIn(ref.State, terminalStates) {
+			return true
+		}
+	}
+	return false
 }
 
 func reworkBreakerCIGreen(pr *connector.PullRequest) bool {
@@ -830,6 +845,7 @@ func blockedRecoveryHumanOnly(issue connector.Issue) bool {
 		"human approval",
 		"explicit human approval",
 		"requires human",
+		"needs human",
 		"requires-human-review",
 		"human review",
 		"product direction",

--- a/internal/orchestrator/blocked_recovery_test.go
+++ b/internal/orchestrator/blocked_recovery_test.go
@@ -13,6 +13,132 @@ import (
 	"github.com/digitaldrywood/detent/internal/workpad"
 )
 
+func TestEvaluateBlockedRecoveryUsesOnlyUnresolvedDependencies(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name           string
+		ref            connector.BlockedRef
+		terminalStates []string
+		want           BlockedRecoveryReason
+	}{
+		{
+			name: "closed tracker ref is resolved",
+			ref: connector.BlockedRef{
+				Identifier:   "digitaldrywood/detent#1900",
+				State:        "In Progress",
+				TrackerState: connector.BlockedRefTrackerStateClosed,
+			},
+			want: BlockedRecoveryReasonNoRecoverableSignal,
+		},
+		{
+			name: "terminal workflow state is resolved",
+			ref: connector.BlockedRef{
+				Identifier: "digitaldrywood/detent#1901",
+				State:      "Released",
+			},
+			terminalStates: []string{"Released"},
+			want:           BlockedRecoveryReasonNoRecoverableSignal,
+		},
+		{
+			name: "open tracker ref remains unresolved",
+			ref: connector.BlockedRef{
+				Identifier:   "digitaldrywood/detent#1902",
+				State:        "Done",
+				TrackerState: connector.BlockedRefTrackerStateOpen,
+			},
+			want: BlockedRecoveryReasonDependencyBlocker,
+		},
+		{
+			name: "active workflow state remains unresolved",
+			ref: connector.BlockedRef{
+				Identifier: "digitaldrywood/detent#1903",
+				State:      "In Progress",
+			},
+			want: BlockedRecoveryReasonDependencyBlocker,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			issue := connector.Issue{
+				State:     blockedStatusState,
+				BlockedBy: []connector.BlockedRef{tt.ref},
+				PullRequest: &connector.PullRequest{
+					State:          "open",
+					MergeableState: "clean",
+					CIStatus:       "success",
+				},
+			}
+			terminalStates := tt.terminalStates
+			if len(terminalStates) == 0 {
+				terminalStates = []string{"Done", "Cancelled", "Canceled", "Closed"}
+			}
+			terminalStates = normalizedStates(terminalStates)
+			got := evaluateBlockedRecovery(issue, normalizeBlockedRecoveryConfig(BlockedRecoveryConfig{
+				Enabled:      true,
+				SourceStates: []string{blockedStatusState},
+			}), terminalStates)
+
+			if got.Reason != tt.want {
+				t.Fatalf("recovery reason = %q, want %q", got.Reason, tt.want)
+			}
+		})
+	}
+}
+
+func TestSetBlockedStatusIssueStoresSpecificCurrentCause(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		cause      string
+		wantReason BlockedRecoveryReason
+	}{
+		{
+			name:       "resolved dependency has no generic error",
+			wantReason: BlockedRecoveryReasonMissingPullRequest,
+		},
+		{
+			name:       "human attention cause stays actionable",
+			cause:      "pull request delivery needs human attention",
+			wantReason: BlockedRecoveryReasonHumanBlocker,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			cfg := normalizeConfig(Config{TerminalStates: []string{"Done"}})
+			orch := &Orchestrator{cfg: cfg}
+			state := newState(cfg)
+			issue := connector.Issue{
+				ID:            "issue-" + strings.ReplaceAll(tt.name, " ", "-"),
+				State:         blockedStatusState,
+				BlockerReason: tt.cause,
+				BlockedBy: []connector.BlockedRef{{
+					Identifier:   "digitaldrywood/detent#1900",
+					State:        "Done",
+					TrackerState: connector.BlockedRefTrackerStateClosed,
+				}},
+			}
+
+			orch.setBlockedStatusIssue(&state, issue, time.Date(2026, 8, 18, 22, 30, 0, 0, time.UTC))
+
+			blocked := state.Blocked[issue.ID]
+			if blocked.Reason != tt.cause || blocked.RecoveryReason != string(tt.wantReason) {
+				t.Fatalf("stored cause = %q/%q, want %q/%q", blocked.Reason, blocked.RecoveryReason, tt.cause, tt.wantReason)
+			}
+			if blocked.Reason == "blocked by project status" {
+				t.Fatalf("stored generic project-status error: %#v", blocked)
+			}
+		})
+	}
+}
+
 func TestRecoverBlockedIssuesSkipsPersistedStickyBlockedIssue(t *testing.T) {
 	t.Parallel()
 

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -56,7 +56,6 @@ const (
 	maxRecentEvents                            = 50
 	blockedStatusState                         = "Blocked"
 	blockedReasonDependency                    = "blocked by non-terminal dependency"
-	blockedReasonProjectStatus                 = "blocked by project status"
 	mergeWorkerTerminalStateMissing            = "merge worker completed without reaching a terminal issue or pull request state"
 	mergeWorkerRetryExhaustedReason            = "merge_worker_retry_exhausted"
 	mergeWorkerCurrentHeadCIWaitExceededReason = "merge_worker_current_head_ci_wait_exceeded"

--- a/internal/orchestrator/reconcile.go
+++ b/internal/orchestrator/reconcile.go
@@ -544,7 +544,11 @@ func (o *Orchestrator) setBlockedStatusIssue(state *State, issue connector.Issue
 		state.Blocked[issue.ID] = existing
 		return
 	}
-	recovery := EvaluateBlockedRecovery(issue)
+	recovery := evaluateBlockedRecovery(issue, normalizeBlockedRecoveryConfig(BlockedRecoveryConfig{
+		Enabled:      true,
+		SourceStates: []string{blockedStatusState},
+		TargetState:  autoPromoteReworkState,
+	}), o.cfg.TerminalStates)
 	state.Blocked[issue.ID] = Blocked{
 		Issue:          cloneIssue(issue),
 		Reason:         blockedStatusReason(issue),
@@ -561,9 +565,5 @@ func blockedFromDependency(blocked Blocked) bool {
 }
 
 func blockedStatusReason(issue connector.Issue) string {
-	reason := strings.TrimSpace(issue.BlockerReason)
-	if reason != "" {
-		return reason
-	}
-	return blockedReasonProjectStatus
+	return strings.TrimSpace(issue.BlockerReason)
 }

--- a/internal/orchestrator/staleness.go
+++ b/internal/orchestrator/staleness.go
@@ -126,7 +126,7 @@ func (o *Orchestrator) stalenessItem(issue connector.Issue, state *State) stalen
 	if enteredAt.IsZero() {
 		enteredAt = workflowLaneFallbackAt(issue)
 	}
-	hasRecovery := len(issue.BlockedBy) > 0
+	hasRecovery := blockedRefsUnresolved(issue.BlockedBy, o.cfg.TerminalStates)
 	if blocked, ok := state.Blocked[strings.TrimSpace(issue.ID)]; ok {
 		hasRecovery = hasRecovery || blocked.Recovery != nil || strings.TrimSpace(blocked.RecoveryReason) != ""
 	}

--- a/internal/telemetry/workload.go
+++ b/internal/telemetry/workload.go
@@ -158,9 +158,22 @@ func BlockedRowDependencyWaiting(row Blocked) bool {
 	if strings.EqualFold(strings.TrimSpace(row.State), "Blocked") {
 		return false
 	}
-	if row.Source == BlockedSourceDependency || strings.EqualFold(strings.TrimSpace(row.RecoveryReason), "dependency_blocker") {
+	hasUnresolvedRef := false
+	for _, ref := range row.BlockedBy {
+		trackerState := strings.ToLower(strings.TrimSpace(ref.TrackerState))
+		if trackerState == "closed" {
+			continue
+		}
+		state := normalizeBoardState(strings.ReplaceAll(ref.State, "_", " "))
+		if trackerState != "open" && (state == "Done" || state == "Cancelled" || state == "Canceled" || state == "Closed") {
+			continue
+		}
+		hasUnresolvedRef = true
+		break
+	}
+	if row.Source == BlockedSourceDependency && (hasUnresolvedRef || len(row.BlockedBy) == 0) {
 		return true
 	}
 	reason := strings.ToLower(strings.TrimSpace(row.Error))
-	return reason == "blocked by non-terminal dependency" || strings.HasPrefix(reason, "depends on ") || len(row.BlockedBy) > 0
+	return reason == "blocked by non-terminal dependency" || strings.HasPrefix(reason, "depends on ") || hasUnresolvedRef
 }

--- a/internal/telemetry/workload_test.go
+++ b/internal/telemetry/workload_test.go
@@ -46,6 +46,26 @@ func TestBoardWorkload(t *testing.T) {
 			want: BoardWorkloadCounts{Blocked: 1},
 		},
 		{
+			name: "resolved refs clear stale dependency classification",
+			snapshot: Snapshot{
+				BoardIssues: []Issue{{ID: "resolved", State: "Todo"}},
+				Blocked: []Blocked{{
+					Issue: Issue{
+						ID:    "resolved",
+						State: "Todo",
+						BlockedBy: []BlockedRef{{
+							Identifier:   "digitaldrywood/detent#1900",
+							State:        "Done",
+							TrackerState: "closed",
+						}},
+					},
+					Source:         BlockedSourceProjectStatus,
+					RecoveryReason: "dependency_blocker",
+				}},
+			},
+			want: BoardWorkloadCounts{Blocked: 1},
+		},
+		{
 			name: "runtime block wins over stale ready tracker state",
 			snapshot: Snapshot{
 				BoardIssues: []Issue{{ID: "blocked", State: "Todo"}},

--- a/internal/web/templates/board_data.go
+++ b/internal/web/templates/board_data.go
@@ -1326,7 +1326,9 @@ func boardCardViewFromCard(data DashboardData, lane projectKanbanLane, card proj
 	view.ProgressSummary, view.ProgressDetail, view.ProgressKind = boardCardCompletionProgress(card.CompletionProgress)
 	view.OriginDetail = boardCardOriginDetail(card.Origin, card.OriginActor)
 	view.AuthorDetail = boardCardAuthorDetail(card.AuthorID, card.OriginActor)
-	view.Activity = boardCardActivity(data.Snapshot, card)
+	if card.BlockedReason == "" && card.BlockedRecoveryAction == "" && card.BlockedRecoveryReason == "" {
+		view.Activity = boardCardActivity(data.Snapshot, card)
+	}
 	view.PRStatus, view.PRStatusClass = boardCardPRStatus(card)
 	if view.Running {
 		view.RuntimeBadge = true
@@ -1709,7 +1711,10 @@ func boardBlockedLegacyWaitingReason(reason string) bool {
 
 func boardBlockedDetail(source telemetry.BlockedSource, recoveryAction string, recoveryReason string, recoveryRemedy string, reason string) string {
 	if strings.EqualFold(strings.TrimSpace(recoveryAction), "hold") {
-		detail := strings.ReplaceAll(strings.TrimSpace(recoveryReason), "_", " ")
+		detail := strings.TrimSpace(reason)
+		if detail == "" {
+			detail = strings.ReplaceAll(strings.TrimSpace(recoveryReason), "_", " ")
+		}
 		if detail == "" {
 			detail = "blocked recovery held"
 		}

--- a/internal/web/templates/board_data_test.go
+++ b/internal/web/templates/board_data_test.go
@@ -1896,7 +1896,7 @@ func TestBoardBlockedCauseBadge(t *testing.T) {
 				BlockedRecoveryRemedy: "return the issue to Todo when implementation work is ready to resume",
 			},
 			wantKind: primitives.KindErr,
-			wantText: "needs review - no commits to deliver — return the issue to Todo when implementation work is ready to resume",
+			wantText: "needs review - no_commits_to_deliver: branch detent/gopher-corp-example has no local commits ahead — return the issue to Todo when implementation work is ready to resume",
 		},
 	}
 
@@ -1910,6 +1910,70 @@ func TestBoardBlockedCauseBadge(t *testing.T) {
 			}
 			if strings.Contains(text, "dependency not ready") {
 				t.Fatalf("boardCardExtra() exposed unnamed dependency: %q", text)
+			}
+		})
+	}
+}
+
+func TestBoardBlockedCardCauseUsesStoredRecoveryState(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		action    string
+		reason    string
+		cause     string
+		wantKind  primitives.Kind
+		wantClass string
+	}{
+		{
+			name:      "transient wait",
+			action:    "defer",
+			reason:    "github_rest_budget_wait",
+			cause:     "transient GitHub REST budget waiting for capacity",
+			wantKind:  primitives.KindWarn,
+			wantClass: "border-warn/45",
+		},
+		{
+			name:      "human attention",
+			action:    "hold",
+			reason:    "no_commits_to_deliver",
+			cause:     "no_commits_to_deliver: current branch has no commits ahead",
+			wantKind:  primitives.KindErr,
+			wantClass: "border-err/45",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			card := projectKanbanCard{
+				IssueID:               "issue-1915",
+				Identifier:            "digitaldrywood/detent#1915",
+				IssueNumber:           "#1915",
+				ProjectID:             "detent",
+				Title:                 tt.name,
+				Stage:                 "Blocked",
+				BlockedSource:         telemetry.BlockedSourceProjectStatus,
+				BlockedReason:         tt.cause,
+				BlockedRecoveryAction: tt.action,
+				BlockedRecoveryReason: tt.reason,
+				Comments: []telemetry.IssueComment{{
+					Body: "activity feed supplied a different blocked cause",
+				}},
+			}
+			view := boardCardViewFromCard(DashboardData{}, projectKanbanLane{Title: "Blocked"}, card, false, "fleet", "detent")
+
+			if view.ExtraKind != tt.wantKind || !strings.Contains(view.ExtraText, tt.cause) {
+				t.Fatalf("blocked cause = %q/%q, want %q containing %q", view.ExtraKind, view.ExtraText, tt.wantKind, tt.cause)
+			}
+			if view.Activity != "" {
+				t.Fatalf("Activity = %q, want stored blocked cause to be authoritative", view.Activity)
+			}
+			html := renderBoardComponent(t, boardCardView2(view))
+			if !strings.Contains(html, tt.wantClass) || strings.Contains(html, "activity feed supplied") {
+				t.Fatalf("blocked card did not use stored cause treatment:\n%s", html)
 			}
 		})
 	}
@@ -2016,7 +2080,7 @@ func TestBoardCardSurfacesWorkpadBlockerResolution(t *testing.T) {
 			}}
 
 			html := renderBoardComponent(t, BoardSnapshot(data))
-			for _, want := range append(tt.wantRefs, "needs review - human action — approve the remaining deployment") {
+			for _, want := range append(tt.wantRefs, "needs review - the workflow emits Test (Go 1.26.5) — approve the remaining deployment") {
 				if !strings.Contains(html, want) {
 					t.Fatalf("board card missing %q:\n%s", want, html)
 				}


### PR DESCRIPTION
## Summary

- replace stale dependency classifications with the current recorded blocked cause at the source
- treat only unresolved dependency refs as recovery blockers across orchestrator and telemetry consumers
- render transient waits, human-attention holds, and genuine dependency waits from the same stored recovery state

Fixes #1915

## UI Surface Contract

- [x] The linked issue explicitly authorizes the blocked-card treatment change.
- [x] This PR does not add persistent top-of-screen messaging.
- [x] Visual changes to the primary operator board were browser verified below.

Browser verification used an isolated `httptest` server and published telemetry snapshot. The board rendered the transient GitHub capacity wait with warning treatment, the human-attention delivery failure with error treatment and `needs review`, and the genuine dependency as `waiting on gopherguides/corp#612 (In Progress)`. A deliberately mismatched activity cause was absent from the cards and remained available in the detail sheet.

## Test Plan

- [x] `go test ./internal/orchestrator ./internal/telemetry ./internal/web/templates ./internal/cli -count=1`
- [x] isolated browser preview with transient, human-attention, and dependency cards
- [x] `PATH="$TMPDIR/bin:$PATH" make check` using repository-pinned golangci-lint v2.1.6
