### PR TITLE
fix(workspace): skip Git metadata warning for filesystem workspaces

### DIFF
--- a/internal/runner/agent.go
+++ b/internal/runner/agent.go
@@ -597,7 +597,10 @@ func runRole(mode string, issue connector.Issue) string {
 	}
 }
 
-func extraWritableRootsForWorkspace(ctx context.Context, workspacePath string, logger *slog.Logger) []string {
+func extraWritableRootsForWorkspace(ctx context.Context, workspaceKind string, workspacePath string, logger *slog.Logger) []string {
+	if workspaceKind == config.WorkspaceFilesystem {
+		return nil
+	}
 	roots, err := workspace.GitMetadataWritableRoots(ctx, workspacePath)
 	if err != nil {
 		if logger != nil {
@@ -1501,7 +1504,7 @@ func (r *Runner) Run(ctx context.Context, req RunRequest) (RunResult, error) {
 	}
 	var extraWritableRoots []string
 	if req.Admission == nil {
-		extraWritableRoots = extraWritableRootsForWorkspace(sessionCtx, info.Path, r.logger)
+		extraWritableRoots = extraWritableRootsForWorkspace(sessionCtx, workflow.Config.Workspace.Kind, info.Path, r.logger)
 	}
 	deliverableKind, deliverableRepository := agentTurnDeliverable(workflow.Config, req.Issue, mode)
 	turnRequest := AgentTurnRequest{
@@ -2227,7 +2230,7 @@ func (r *Runner) Validate(ctx context.Context, req ValidatorRequest) (gate.Valid
 		MaxTurns:           workflow.Config.Agent.MaxTurns,
 		TurnTimeout:        durationFromMillis(validator.TurnTimeoutMS),
 		MaxDuration:        durationFromMillis(workflow.Config.Agent.MaxTurnDurationMS),
-		ExtraWritableRoots: extraWritableRootsForWorkspace(sessionCtx, info.Path, r.logger),
+		ExtraWritableRoots: extraWritableRootsForWorkspace(sessionCtx, workflow.Config.Workspace.Kind, info.Path, r.logger),
 		MaxRSSBytes:        r.maxAgentRSSBytes,
 		RSSPollInterval:    r.rssPollInterval,
 		cacheStrategy:      workflow.Config.Workspace.CacheStrategy,

--- a/internal/runner/runner_test.go
+++ b/internal/runner/runner_test.go
@@ -3071,6 +3071,68 @@ func TestRunnerRunAddsGitMetadataExtraRootsForManagedWorkspace(t *testing.T) {
 	}
 }
 
+func TestRunnerRunReportsGitMetadataFailuresByWorkspaceKind(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		kind        string
+		wantWarning bool
+	}{
+		{
+			name: "filesystem skips git metadata probe",
+			kind: config.WorkspaceFilesystem,
+		},
+		{
+			name:        "local git reports metadata failure",
+			kind:        config.WorkspaceLocalGit,
+			wantWarning: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			workspacePath := t.TempDir()
+			var logs bytes.Buffer
+			agentBackend := &fakeCodexClient{}
+			runner, err := NewRunner(Dependencies{
+				Workflow: config.Workflow{Config: config.Config{
+					Workspace: config.Workspace{Kind: tt.kind},
+				}},
+				Workspace: &fakeWorkspaceBackend{
+					info: workspace.Info{Path: workspacePath, Key: "issue-1867"},
+				},
+				AgentBackend: agentBackend,
+				Logger:       slog.New(slog.NewTextHandler(&logs, nil)),
+			})
+			if err != nil {
+				t.Fatalf("NewRunner() error = %v", err)
+			}
+
+			_, err = runner.Run(context.Background(), RunRequest{
+				Issue: connector.Issue{
+					ID:         "issue-1867",
+					Identifier: "digitaldrywood/detent#1867",
+					Title:      "Workspace metadata diagnostics",
+				},
+			})
+			if err != nil {
+				t.Fatalf("Run() error = %v", err)
+			}
+
+			if len(agentBackend.request.ExtraWritableRoots) != 0 {
+				t.Fatalf("ExtraWritableRoots = %#v, want none", agentBackend.request.ExtraWritableRoots)
+			}
+			gotWarning := strings.Contains(logs.String(), "workspace git metadata writable roots unavailable")
+			if gotWarning != tt.wantWarning {
+				t.Fatalf("git metadata warning = %t, want %t; logs:\n%s", gotWarning, tt.wantWarning, logs.String())
+			}
+		})
+	}
+}
+
 func TestRunnerRunLogsLifecycleWithoutPromptOrMessageBody(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

- skip Git metadata writable-root discovery for configured filesystem workspaces
- preserve metadata failure warnings for Git-backed workspaces
- cover filesystem and local Git warning behavior with table-driven regression tests

Fixes #1867

## UI Surface Contract

- [x] N/A, or the linked issue explicitly authorizes any high-impact UI surface, layout, density, first-viewport, or responsive visibility tradeoff.
- [x] Persistent top-of-screen messaging is explicitly authorized by the issue, or this PR does not add it.
- [x] Visual changes to primary operator screens include screenshot or browser verification below. N/A: no UI changes.

## Test Plan

- [x] `make check`
- [x] `go test ./internal/runner -run '^(TestRunnerRunReportsGitMetadataFailuresByWorkspaceKind|TestRunnerRunAddsGitMetadataExtraRootsForManagedWorkspace)$' -count=1 -v`