### PR TITLE
fix(tracker): reconcile terminal closure

### DIFF
--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -71,6 +71,7 @@ type doctorCheck struct {
 	HealthNotificationFailures []healthnotify.Failure                     `json:"health_notification_failures,omitempty"`
 	UntrackedIssues            []doctorStatusDriftIssueDiagnostic         `json:"untracked_issues,omitempty"`
 	OpenTerminalIssues         []doctorStatusDriftIssueDiagnostic         `json:"open_terminal_issues,omitempty"`
+	ClosedActiveIssues         []doctorStatusDriftIssueDiagnostic         `json:"closed_active_issues,omitempty"`
 	AuthorizationAttention     []doctorAuthorizationAttentionDiagnostic   `json:"authorization_attention,omitempty"`
 	OwnershipAttention         []doctorOwnershipAttentionDiagnostic       `json:"ownership_attention,omitempty"`
 	OrphanedAgentProcesses     *telemetry.OrphanedAgentProcesses          `json:"orphaned_agent_processes,omitempty"`

--- a/internal/cli/doctor_autopromote.go
+++ b/internal/cli/doctor_autopromote.go
@@ -494,11 +494,12 @@ func checkDoctorLabelStatusDriftLive(
 
 	untracked := doctorStatusDriftDiagnostics(drift.UntrackedOpen)
 	openTerminal := doctorStatusDriftDiagnostics(drift.OpenTerminal)
-	if len(untracked) == 0 && len(openTerminal) == 0 {
+	closedActive := doctorStatusDriftDiagnostics(drift.ClosedActive)
+	if len(untracked) == 0 && len(openTerminal) == 0 && len(closedActive) == 0 {
 		return doctorCheck{
 			Name:   name,
 			Status: doctorOK,
-			Detail: "sampled open repository issues; 0 untracked open issues and 0 open terminal issues",
+			Detail: "sampled repository issues; 0 untracked open issues, 0 open terminal issues, and 0 closed active issues",
 		}
 	}
 
@@ -513,13 +514,18 @@ func checkDoctorLabelStatusDriftLive(
 	if len(openTerminal) > 0 {
 		detail += ": " + doctorStatusDriftIssueSummaries(openTerminal)
 	}
+	detail += fmt.Sprintf("; %d closed issue(s) with active status label", len(closedActive))
+	if len(closedActive) > 0 {
+		detail += ": " + doctorStatusDriftIssueSummaries(closedActive)
+	}
 	return doctorCheck{
 		Name:               name,
 		Status:             doctorWarn,
 		Detail:             detail,
-		Hint:               "Apply exactly one configured status label such as detent:backlog or detent:todo to untracked open issues; close or relabel open terminal-labeled issues.",
+		Hint:               "Apply exactly one configured status label to untracked open issues; close landed terminal-labeled issues, report terminal issues without landed work, and move closed active-labeled issues to a terminal lane.",
 		UntrackedIssues:    untracked,
 		OpenTerminalIssues: openTerminal,
+		ClosedActiveIssues: closedActive,
 	}
 }
 

--- a/internal/cli/doctor_test.go
+++ b/internal/cli/doctor_test.go
@@ -3201,6 +3201,15 @@ func TestCheckDoctorLabelStatusDriftReportsUntrackedAndTerminalIssues(t *testing
 				URL:        "https://github.com/digitaldrywood/detent/issues/583",
 				Labels:     []string{"detent:done"},
 			}},
+			ClosedActive: []connector.Issue{{
+				ID:         "I_584",
+				Identifier: "digitaldrywood/detent#584",
+				Title:      "Closed but active",
+				State:      "In Progress",
+				Closed:     true,
+				URL:        "https://github.com/digitaldrywood/detent/issues/584",
+				Labels:     []string{"detent:in-progress"},
+			}},
 		},
 	}
 
@@ -3220,6 +3229,9 @@ func TestCheckDoctorLabelStatusDriftReportsUntrackedAndTerminalIssues(t *testing
 		"1 open issue(s) with terminal status label",
 		"digitaldrywood/detent#583",
 		"https://github.com/digitaldrywood/detent/issues/583",
+		"1 closed issue(s) with active status label",
+		"digitaldrywood/detent#584",
+		"https://github.com/digitaldrywood/detent/issues/584",
 	} {
 		if !strings.Contains(got.Detail, want) {
 			t.Fatalf("Detail = %q, want containing %q", got.Detail, want)
@@ -3230,6 +3242,9 @@ func TestCheckDoctorLabelStatusDriftReportsUntrackedAndTerminalIssues(t *testing
 	}
 	if len(got.OpenTerminalIssues) != 1 || got.OpenTerminalIssues[0].State != "Done" {
 		t.Fatalf("OpenTerminalIssues = %#v, want Done diagnostic", got.OpenTerminalIssues)
+	}
+	if len(got.ClosedActiveIssues) != 1 || got.ClosedActiveIssues[0].State != "In Progress" {
+		t.Fatalf("ClosedActiveIssues = %#v, want In Progress diagnostic", got.ClosedActiveIssues)
 	}
 }
 

--- a/internal/cli/runner.go
+++ b/internal/cli/runner.go
@@ -958,6 +958,7 @@ func mergeSnapshot(current, next telemetry.Snapshot) telemetry.Snapshot {
 	current.Pipeline = append(current.Pipeline, next.Pipeline...)
 	current.TrackerDrift.UntrackedOpen = append(current.TrackerDrift.UntrackedOpen, next.TrackerDrift.UntrackedOpen...)
 	current.TrackerDrift.OpenTerminal = append(current.TrackerDrift.OpenTerminal, next.TrackerDrift.OpenTerminal...)
+	current.TrackerDrift.ClosedActive = append(current.TrackerDrift.ClosedActive, next.TrackerDrift.ClosedActive...)
 	current.Budget.Refusals = append(current.Budget.Refusals, next.Budget.Refusals...)
 	current.TrackerUnavailable = append(current.TrackerUnavailable, next.TrackerUnavailable...)
 	current.ForgeUnavailable = append(current.ForgeUnavailable, next.ForgeUnavailable...)
@@ -1358,6 +1359,9 @@ func stampSnapshotProjectID(snapshot telemetry.Snapshot) telemetry.Snapshot {
 	}
 	for i := range snapshot.TrackerDrift.OpenTerminal {
 		snapshot.TrackerDrift.OpenTerminal[i] = stampIssueProjectID(snapshot.TrackerDrift.OpenTerminal[i], projectID)
+	}
+	for i := range snapshot.TrackerDrift.ClosedActive {
+		snapshot.TrackerDrift.ClosedActive[i] = stampIssueProjectID(snapshot.TrackerDrift.ClosedActive[i], projectID)
 	}
 	for i := range snapshot.Running {
 		snapshot.Running[i].Issue = stampIssueProjectID(snapshot.Running[i].Issue, projectID)

--- a/internal/connector/connector.go
+++ b/internal/connector/connector.go
@@ -304,4 +304,5 @@ type IssueChildrenResolver interface {
 type StatusDrift struct {
 	UntrackedOpen []Issue `json:"untracked_open,omitempty" yaml:"untracked_open,omitempty"`
 	OpenTerminal  []Issue `json:"open_terminal,omitempty" yaml:"open_terminal,omitempty"`
+	ClosedActive  []Issue `json:"closed_active,omitempty" yaml:"closed_active,omitempty"`
 }

--- a/internal/connector/factory/factory_test.go
+++ b/internal/connector/factory/factory_test.go
@@ -240,13 +240,23 @@ func TestFactoryGitHubConnectorUsesConfiguredLogger(t *testing.T) {
 	})
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path != "/repos/digitaldrywood/detent/issues" {
-			t.Fatalf("path = %s, want repository issues path", r.URL.Path)
-		}
-		if got := r.URL.Query().Get("state"); got != "open" {
-			t.Fatalf("state query = %q, want open", got)
+		switch r.URL.Path {
+		case "/repos/digitaldrywood/detent/issues":
+			if got := r.URL.Query().Get("state"); got != "open" {
+				t.Fatalf("state query = %q, want open", got)
+			}
+		case "/search/issues":
+			if !strings.Contains(r.URL.Query().Get("q"), "is:closed") {
+				t.Fatalf("search query = %q, want closed issue search", r.URL.Query().Get("q"))
+			}
+		default:
+			t.Fatalf("path = %s, want repository issues or search path", r.URL.Path)
 		}
 		w.Header().Set("Content-Type", "application/json")
+		if r.URL.Path == "/search/issues" {
+			_, _ = w.Write([]byte(`{"total_count":0,"items":[]}`))
+			return
+		}
 		_, _ = w.Write([]byte(`[]`))
 	}))
 	t.Cleanup(server.Close)

--- a/internal/connector/github/pull_requests.go
+++ b/internal/connector/github/pull_requests.go
@@ -1119,6 +1119,7 @@ func (c *Connector) fetchPullRequestReviews(ctx context.Context, repo pullReques
 type pullRequestReference struct {
 	Number     int
 	Repository string
+	State      string
 	UpdatedAt  *time.Time
 }
 
@@ -1160,10 +1161,27 @@ func firstPullRequestReference(pullRequests nodeConnection[pullRequest]) (pullRe
 	return fallback, fallbackOK
 }
 
+func mergedPullRequestReference(pullRequests nodeConnection[pullRequest]) (pullRequestReference, bool) {
+	var merged pullRequestReference
+	mergedOK := false
+	for _, pullRequest := range pullRequests.Nodes {
+		if pullRequest.Number <= 0 || normalizeStateName(pullRequest.State) != "merged" {
+			continue
+		}
+		ref := pullRequestReferenceFromNode(pullRequest)
+		if !mergedOK || pullRequestReferenceAfter(ref, merged) {
+			merged = ref
+			mergedOK = true
+		}
+	}
+	return merged, mergedOK
+}
+
 func pullRequestReferenceFromNode(pullRequest pullRequest) pullRequestReference {
 	return pullRequestReference{
 		Number:     pullRequest.Number,
 		Repository: strings.TrimSpace(pullRequest.Repository.NameWithOwner),
+		State:      strings.ToUpper(strings.TrimSpace(pullRequest.State)),
 		UpdatedAt:  parseGitHubTime(pullRequest.UpdatedAt),
 	}
 }

--- a/internal/connector/github/statuslabel.go
+++ b/internal/connector/github/statuslabel.go
@@ -127,6 +127,10 @@ func (c *Connector) fetchLabelIssuesByStates(ctx context.Context, stateNames []s
 }
 
 func (c *Connector) attachLabelIssuePullRequestReferences(ctx context.Context, issues []connector.Issue) error {
+	return c.attachLabelIssuePullRequestReferencesWithState(ctx, issues, false)
+}
+
+func (c *Connector) attachLabelIssuePullRequestReferencesWithState(ctx context.Context, issues []connector.Issue, includeState bool) error {
 	indexesByID := make(map[string][]int, len(issues))
 	ids := make([]string, 0, len(issues))
 	for index, issue := range issues {
@@ -195,6 +199,11 @@ func (c *Connector) attachLabelIssuePullRequestReferences(ctx context.Context, i
 				return nil
 			}
 			ref, ok := firstPullRequestReference(pullRequests)
+			if includeState {
+				if merged, mergedOK := mergedPullRequestReference(pullRequests); mergedOK {
+					ref, ok = merged, true
+				}
+			}
 			if !ok {
 				continue
 			}
@@ -202,6 +211,9 @@ func (c *Connector) attachLabelIssuePullRequestReferences(ctx context.Context, i
 				number := ref.Number
 				issues[index].PRNumber = &number
 				issues[index].PRRepository = ref.Repository
+				if includeState {
+					issues[index].PullRequest = &connector.PullRequest{Number: ref.Number, State: ref.State}
+				}
 				if issues[index].PRRepository == "" {
 					issues[index].PRRepository = pullRequestRepoName(c.repository)
 				}
@@ -254,7 +266,67 @@ func (c *Connector) FetchStatusDrift(ctx context.Context) (connector.StatusDrift
 	drift, _, _, err := c.readLabelStatusDrift(ctx, labelStatusDriftReadOptions{
 		PageSize: repositoryIssuesPageSize,
 	})
-	return drift, err
+	if err != nil {
+		return connector.StatusDrift{}, err
+	}
+	drift.ClosedActive, err = c.readClosedActiveLabelIssues(ctx)
+	if err != nil {
+		return connector.StatusDrift{}, err
+	}
+	if err := c.attachLabelIssuePullRequestReferencesWithState(ctx, drift.OpenTerminal, true); err != nil {
+		return connector.StatusDrift{}, fmt.Errorf("hydrate open terminal issue pull requests: %w", err)
+	}
+	return drift, nil
+}
+
+func (c *Connector) readClosedActiveLabelIssues(ctx context.Context) ([]connector.Issue, error) {
+	if !c.usesLabelStatus() || len(c.activeStates) == 0 {
+		return nil, nil
+	}
+	labels := make([]string, 0, len(c.activeStates))
+	active := make(map[string]struct{}, len(c.activeStates))
+	for _, state := range c.activeStates {
+		label := c.statusLabelForState(state)
+		if label == "" {
+			continue
+		}
+		labels = append(labels, label)
+		active[normalizeStateName(state)] = struct{}{}
+	}
+	if len(labels) == 0 {
+		return nil, nil
+	}
+
+	issues := []connector.Issue{}
+	itemsRead := 0
+	for page := 1; ; page++ {
+		var response restIssueSearchResponse
+		path := restClosedActiveIssuesSearchPagePath(c.repository, labels, page, repositoryIssuesPageSize)
+		if err := c.client.REST(ctx, http.MethodGet, path, nil, &response); err != nil {
+			return nil, fmt.Errorf("fetch github closed active issue drift: %w", err)
+		}
+		itemsRead += len(response.Items)
+		for _, item := range response.Items {
+			if item.PullRequest != nil || !githubIssueClosed(item.State) {
+				continue
+			}
+			ref := issueRef{Owner: c.repository.Owner, Name: c.repository.Name, Number: item.Number}
+			node := githubIssueNodeFromREST(ref, item)
+			resolution := c.labelStatusResolutionFromLabels(node.Labels)
+			if resolution.conflicted() || resolution.Status == "" {
+				continue
+			}
+			state := c.githubToDetentState(resolution.Status)
+			if _, ok := active[normalizeStateName(state)]; !ok {
+				continue
+			}
+			c.cacheIssueRef(node)
+			issues = append(issues, c.buildLabelIssue(node, resolution.Status))
+		}
+		if len(response.Items) < repositoryIssuesPageSize || itemsRead >= response.TotalCount {
+			return issues, nil
+		}
+	}
 }
 
 func (c *Connector) readLabelStatusDrift(
@@ -787,6 +859,29 @@ func restRepositoryOpenIssuesPagePath(repo pullRequestRepo, page int, pageSize i
 	values.Set("per_page", strconv.Itoa(pageSize))
 	values.Set("page", strconv.Itoa(page))
 	return "/repos/" + url.PathEscape(repo.Owner) + "/" + url.PathEscape(repo.Name) + "/issues?" + values.Encode()
+}
+
+func restClosedActiveIssuesSearchPagePath(repo pullRequestRepo, labels []string, page int, pageSize int) string {
+	terms := make([]string, 0, len(labels))
+	for _, label := range labels {
+		label = strings.TrimSpace(label)
+		if label != "" {
+			terms = append(terms, `label:"`+strings.ReplaceAll(label, `"`, `\"`)+`"`)
+		}
+	}
+	query := "repo:" + pullRequestRepoName(repo) + " is:issue is:closed"
+	if len(terms) == 1 {
+		query += " " + terms[0]
+	} else if len(terms) > 1 {
+		query += " (" + strings.Join(terms, " OR ") + ")"
+	}
+	values := url.Values{}
+	values.Set("q", query)
+	values.Set("sort", "created")
+	values.Set("order", "asc")
+	values.Set("per_page", strconv.Itoa(pageSize))
+	values.Set("page", strconv.Itoa(page))
+	return "/search/issues?" + values.Encode()
 }
 
 func restIssueLabelsPath(ref issueRef) string {

--- a/internal/connector/github/statuslabel_test.go
+++ b/internal/connector/github/statuslabel_test.go
@@ -169,7 +169,7 @@ func TestConnectorFetchCandidateIssuesWithFilterIgnoresStatusLabels(t *testing.T
 	}
 }
 
-func TestConnectorFetchStatusDriftReportsUntrackedAndOpenTerminalIssues(t *testing.T) {
+func TestConnectorFetchStatusDriftReportsTrackerStateMismatches(t *testing.T) {
 	t.Parallel()
 
 	server := newGraphQLTestServer(t, []graphqlTestResponse{
@@ -177,6 +177,14 @@ func TestConnectorFetchStatusDriftReportsUntrackedAndOpenTerminalIssues(t *testi
 			method: http.MethodGet,
 			path:   "/repos/digitaldrywood/detent/issues?page=1&per_page=100&state=open",
 			body:   `[{"node_id":"I_771","number":771,"title":"Untracked issue","body":"","state":"open","html_url":"https://github.com/digitaldrywood/detent/issues/771","assignees":[],"labels":[{"name":"bug"}]},{"node_id":"I_770","number":770,"title":"Normal backlog","body":"","state":"open","html_url":"https://github.com/digitaldrywood/detent/issues/770","assignees":[],"labels":[{"name":"detent:backlog"}]},{"node_id":"I_583","number":583,"title":"Done but open","body":"","state":"open","html_url":"https://github.com/digitaldrywood/detent/issues/583","assignees":[],"labels":[{"name":"detent:done"},{"name":"bug"}]},{"node_id":"PR_12","number":12,"title":"Pull request","body":"","state":"open","html_url":"https://github.com/digitaldrywood/detent/pull/12","assignees":[],"labels":[],"pull_request":{}}]`,
+		},
+		{
+			method: http.MethodGet,
+			path:   "/search/issues?order=asc&page=1&per_page=100&q=repo%3Adigitaldrywood%2Fdetent+is%3Aissue+is%3Aclosed+label%3A%22detent%3Atodo%22&sort=created",
+			body:   `{"total_count":1,"items":[{"node_id":"I_584","number":584,"title":"Closed but active","body":"","state":"closed","state_reason":"completed","html_url":"https://github.com/digitaldrywood/detent/issues/584","assignees":[],"labels":[{"name":"detent:todo"}]}]}`,
+		},
+		{
+			body: `{"data":{"nodes":[{"__typename":"Issue","id":"I_583","closedByPullRequestsReferences":{"nodes":[{"number":582,"url":"https://github.com/digitaldrywood/detent/pull/582","state":"MERGED","updatedAt":"2026-08-18T12:00:00Z","repository":{"nameWithOwner":"digitaldrywood/detent"}},{"number":585,"url":"https://github.com/digitaldrywood/detent/pull/585","state":"OPEN","updatedAt":"2026-08-19T12:00:00Z","repository":{"nameWithOwner":"digitaldrywood/detent"}}]}}]}}`,
 		},
 	})
 	c := newGitHubTestConnector(t, server, Config{
@@ -203,8 +211,14 @@ func TestConnectorFetchStatusDriftReportsUntrackedAndOpenTerminalIssues(t *testi
 	if got.OpenTerminal[0].Identifier != "digitaldrywood/detent#583" || got.OpenTerminal[0].State != "Done" {
 		t.Fatalf("OpenTerminal[0] = %#v, want open terminal #583 Done", got.OpenTerminal[0])
 	}
-	if len(server.requests()) != 1 {
-		t.Fatalf("request count = %d, want one open issue scan", len(server.requests()))
+	if got.OpenTerminal[0].PullRequest == nil || got.OpenTerminal[0].PullRequest.Number != 582 || got.OpenTerminal[0].PullRequest.State != "MERGED" {
+		t.Fatalf("OpenTerminal[0].PullRequest = %#v, want merged linked pull request", got.OpenTerminal[0].PullRequest)
+	}
+	if len(got.ClosedActive) != 1 || got.ClosedActive[0].Identifier != "digitaldrywood/detent#584" || got.ClosedActive[0].State != "Todo" {
+		t.Fatalf("ClosedActive = %#v, want closed active #584 Todo", got.ClosedActive)
+	}
+	if len(server.requests()) != 3 {
+		t.Fatalf("request count = %d, want open scan, closed active scan, and merged PR hydration", len(server.requests()))
 	}
 }
 
@@ -230,11 +244,18 @@ func TestConnectorRESTBackoffsAreIsolatedAcrossTestClients(t *testing.T) {
 	rateLimited.client.restEndpoint = sharedEndpoint
 	rateLimited.client.httpClient = routeGitHubTestRequests(t, rateLimitedServer)
 
-	ordinaryServer := newGraphQLTestServer(t, []graphqlTestResponse{{
-		method: http.MethodGet,
-		path:   "/repos/digitaldrywood/detent/issues?page=1&per_page=100&state=open",
-		body:   `[]`,
-	}})
+	ordinaryServer := newGraphQLTestServer(t, []graphqlTestResponse{
+		{
+			method: http.MethodGet,
+			path:   "/repos/digitaldrywood/detent/issues?page=1&per_page=100&state=open",
+			body:   `[]`,
+		},
+		{
+			method: http.MethodGet,
+			path:   "/search/issues?order=asc&page=1&per_page=100&q=repo%3Adigitaldrywood%2Fdetent+is%3Aissue+is%3Aclosed+%28label%3A%22detent%3Atodo%22+OR+label%3A%22detent%3Ain-progress%22%29&sort=created",
+			body:   `{"total_count":0,"items":[]}`,
+		},
+	})
 	ordinary := newGitHubTestConnector(t, ordinaryServer, config)
 	ordinary.client.restEndpoint = sharedEndpoint
 	ordinary.client.httpClient = routeGitHubTestRequests(t, ordinaryServer)
@@ -277,8 +298,8 @@ func TestConnectorRESTBackoffsAreIsolatedAcrossTestClients(t *testing.T) {
 	if errs["ordinary"] != nil {
 		t.Fatalf("ordinary FetchStatusDrift() error = %v, want nil", errs["ordinary"])
 	}
-	if len(ordinaryServer.requests()) != 1 {
-		t.Fatalf("ordinary server request count = %d, want 1", len(ordinaryServer.requests()))
+	if len(ordinaryServer.requests()) != 2 {
+		t.Fatalf("ordinary server request count = %d, want 2", len(ordinaryServer.requests()))
 	}
 }
 

--- a/internal/orchestrator/orchestrator_test.go
+++ b/internal/orchestrator/orchestrator_test.go
@@ -2917,6 +2917,7 @@ func (c *statusDriftConnector) FetchStatusDrift(context.Context) (connector.Stat
 	return connector.StatusDrift{
 		UntrackedOpen: cloneIssues(c.drift.UntrackedOpen),
 		OpenTerminal:  cloneIssues(c.drift.OpenTerminal),
+		ClosedActive:  cloneIssues(c.drift.ClosedActive),
 	}, c.err
 }
 

--- a/internal/orchestrator/reconcile.go
+++ b/internal/orchestrator/reconcile.go
@@ -208,6 +208,20 @@ func closedReasonCompleted(reason string) bool {
 	return reason == "completed"
 }
 
+func (o *Orchestrator) closeLandedTerminalIssue(ctx context.Context, issue connector.Issue) (bool, error) {
+	if issue.Closed || !pullRequestMerged(issue.PullRequest) {
+		return false, nil
+	}
+	closer, ok := o.connector.(connector.IssueCloser)
+	if !ok {
+		return false, nil
+	}
+	if err := closer.CloseIssue(ctx, issue.ID); err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
 func filterReconciledIssues(issues []connector.Issue, reconciled map[string]struct{}) []connector.Issue {
 	if len(reconciled) == 0 || len(issues) == 0 {
 		return issues

--- a/internal/orchestrator/snapshot.go
+++ b/internal/orchestrator/snapshot.go
@@ -254,6 +254,9 @@ func applySnapshotLaneProvenance(snapshot *telemetry.Snapshot, laneProvenance ma
 	for index := range snapshot.TrackerDrift.OpenTerminal {
 		apply(&snapshot.TrackerDrift.OpenTerminal[index])
 	}
+	for index := range snapshot.TrackerDrift.ClosedActive {
+		apply(&snapshot.TrackerDrift.ClosedActive[index])
+	}
 	for index := range snapshot.Running {
 		apply(&snapshot.Running[index].Issue)
 	}
@@ -700,6 +703,7 @@ func authorizedStatusDrift(drift connector.StatusDrift, authorization selector.S
 	return connector.StatusDrift{
 		UntrackedOpen: authorizedSnapshotIssues(drift.UntrackedOpen, authorization, ctx),
 		OpenTerminal:  authorizedSnapshotIssues(drift.OpenTerminal, authorization, ctx),
+		ClosedActive:  authorizedSnapshotIssues(drift.ClosedActive, authorization, ctx),
 	}
 }
 
@@ -713,6 +717,7 @@ func statusDriftSnapshot(
 	return telemetry.TrackerDrift{
 		UntrackedOpen: issueSnapshots(drift.UntrackedOpen, quietDuration, pollInterval, now, laneEntries),
 		OpenTerminal:  issueSnapshots(drift.OpenTerminal, quietDuration, pollInterval, now, laneEntries),
+		ClosedActive:  issueSnapshots(drift.ClosedActive, quietDuration, pollInterval, now, laneEntries),
 	}
 }
 

--- a/internal/orchestrator/state.go
+++ b/internal/orchestrator/state.go
@@ -644,6 +644,7 @@ func cloneStatusDrift(drift connector.StatusDrift) connector.StatusDrift {
 	return connector.StatusDrift{
 		UntrackedOpen: cloneIssues(drift.UntrackedOpen),
 		OpenTerminal:  cloneIssues(drift.OpenTerminal),
+		ClosedActive:  cloneIssues(drift.ClosedActive),
 	}
 }
 

--- a/internal/orchestrator/status_reconciliation_test.go
+++ b/internal/orchestrator/status_reconciliation_test.go
@@ -93,6 +93,87 @@ func TestReconcileClosedCompletedIssueStatusesLeavesOtherIssuesUnchanged(t *test
 	}
 }
 
+func TestTerminalIssueClosure(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		issue       connector.Issue
+		transitions []string
+		wantCloses  int
+	}{
+		{
+			name:        "first terminal entry closes landed work",
+			issue:       statusReconcileLandedIssue("issue-first-entry", "Merging", false),
+			transitions: []string{"Done"},
+			wantCloses:  1,
+		},
+		{
+			name:        "done rework done closes reopened issue",
+			issue:       statusReconcileLandedIssue("issue-round-trip", "Done", true),
+			transitions: []string{"Rework", "Done"},
+			wantCloses:  1,
+		},
+		{
+			name:        "already closed terminal issue is not closed again",
+			issue:       statusReconcileLandedIssue("issue-closed", "Done", true),
+			transitions: []string{"Done"},
+		},
+		{
+			name:        "terminal issue without landed work remains open",
+			issue:       statusReconcileIssue("issue-no-work", "Merging", false, ""),
+			transitions: []string{"Done"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			tracker := &statusReconcileConnector{}
+			orch := newStatusReconcileOrchestrator(tracker)
+			state := newState(orch.cfg)
+			issue := cloneIssue(tt.issue)
+			for _, target := range tt.transitions {
+				if normalizeState(issue.State) == normalizeState("Done") && normalizeState(target) == normalizeState("Rework") {
+					issue.Closed = false
+					issue.ClosedReason = ""
+				}
+				if err := orch.updateIssueState(context.Background(), &state, issue, target, time.Now(), "test"); err != nil {
+					t.Fatalf("updateIssueState(%q) error = %v", target, err)
+				}
+				issue.State = target
+			}
+
+			if got := len(tracker.closes); got != tt.wantCloses {
+				t.Fatalf("CloseIssue() calls = %d, want %d: %#v", got, tt.wantCloses, tracker.closes)
+			}
+		})
+	}
+}
+
+func TestRefreshStatusDriftReconcilesOnlyLandedOpenTerminalIssues(t *testing.T) {
+	t.Parallel()
+
+	landed := statusReconcileLandedIssue("issue-stranded", "Done", false)
+	unlanded := statusReconcileIssue("issue-no-landed-work", "Done", false, "")
+	alreadyClosed := statusReconcileLandedIssue("issue-already-closed", "Done", true)
+	tracker := &statusReconcileConnector{
+		drift: connector.StatusDrift{OpenTerminal: []connector.Issue{landed, unlanded, alreadyClosed}},
+	}
+	orch := newStatusReconcileOrchestrator(tracker)
+	state := newState(orch.cfg)
+
+	orch.refreshStatusDrift(context.Background(), &state, time.Now(), githubBudgetReserveDecision{})
+
+	if len(tracker.closes) != 1 || tracker.closes[0] != landed.ID {
+		t.Fatalf("closes = %#v, want only %q", tracker.closes, landed.ID)
+	}
+	if len(state.StatusDrift.OpenTerminal) != 1 || state.StatusDrift.OpenTerminal[0].ID != unlanded.ID {
+		t.Fatalf("StatusDrift.OpenTerminal = %#v, want unlanded issue reported", state.StatusDrift.OpenTerminal)
+	}
+}
+
 func TestTickReconcilesClosedCompletedIssueStatusesFromExistingPolls(t *testing.T) {
 	t.Parallel()
 
@@ -219,6 +300,12 @@ func statusReconcileIssue(id string, state string, closed bool, closedReason str
 	return issue
 }
 
+func statusReconcileLandedIssue(id string, state string, closed bool) connector.Issue {
+	issue := statusReconcileIssue(id, state, closed, "completed")
+	issue.PullRequest = &connector.PullRequest{Number: 1, State: "MERGED"}
+	return issue
+}
+
 type statusUpdate struct {
 	issueID string
 	state   string
@@ -229,6 +316,8 @@ type statusReconcileConnector struct {
 	stateIssues    []connector.Issue
 	updates        []statusUpdate
 	comments       []string
+	closes         []string
+	drift          connector.StatusDrift
 	fetchByStates  [][]string
 	fetchByIDCount int
 }
@@ -254,6 +343,15 @@ func (c *statusReconcileConnector) FetchIssueStatesByIDs(context.Context, []stri
 func (c *statusReconcileConnector) CreateComment(_ context.Context, _ string, body string) error {
 	c.comments = append(c.comments, body)
 	return nil
+}
+
+func (c *statusReconcileConnector) CloseIssue(_ context.Context, issueID string) error {
+	c.closes = append(c.closes, issueID)
+	return nil
+}
+
+func (c *statusReconcileConnector) FetchStatusDrift(context.Context) (connector.StatusDrift, error) {
+	return cloneStatusDrift(c.drift), nil
 }
 
 func (c *statusReconcileConnector) UpdateIssueState(_ context.Context, issueID string, state string) error {

--- a/internal/orchestrator/tick.go
+++ b/internal/orchestrator/tick.go
@@ -583,9 +583,41 @@ func (o *Orchestrator) refreshStatusDrift(
 		})
 		return
 	}
+	drift.OpenTerminal = o.reconcileOpenTerminalIssueDrift(ctx, state, drift.OpenTerminal, now)
 	recordRefreshSourceSuccess(state, telemetry.RefreshSourceDrift, now)
 	o.recordTrackerReadSuccess(state, telemetry.RefreshSourceDrift, now)
 	state.StatusDrift = cloneStatusDrift(drift)
+}
+
+func (o *Orchestrator) reconcileOpenTerminalIssueDrift(
+	ctx context.Context,
+	state *State,
+	issues []connector.Issue,
+	now time.Time,
+) []connector.Issue {
+	remaining := make([]connector.Issue, 0, len(issues))
+	for _, issue := range issues {
+		if issue.Closed {
+			continue
+		}
+		closed, err := o.closeLandedTerminalIssue(ctx, issue)
+		if err != nil {
+			o.logger.Warn("reconcile open terminal issue failed", "issue_id", issue.ID, "identifier", issue.Identifier, "error", err)
+			remaining = append(remaining, issue)
+			continue
+		}
+		if !closed {
+			remaining = append(remaining, issue)
+			continue
+		}
+		o.logger.Info("reconciled open terminal issue", "issue_id", issue.ID, "identifier", issue.Identifier)
+		recordStateEvent(state, telemetry.ActivityEvent{
+			At:      now,
+			Event:   "open_terminal_issue_reconciled",
+			Message: "closed " + issueLabel(issue) + " after confirming its linked pull request is merged",
+		})
+	}
+	return remaining
 }
 
 func (o *Orchestrator) candidateFetchStatesForTick(state *State) []string {

--- a/internal/orchestrator/workflow_metrics.go
+++ b/internal/orchestrator/workflow_metrics.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"strings"
 	"time"
 
@@ -165,6 +166,15 @@ func (o *Orchestrator) updateIssueStateByIDWithMetadataMode(
 		terminalIssue := cloneIssue(issue)
 		if strings.TrimSpace(terminalIssue.ID) == "" {
 			terminalIssue.ID = issueID
+		}
+		terminalIssue.State = targetState
+		closed, err := o.closeLandedTerminalIssue(ctx, terminalIssue)
+		if err != nil {
+			return fmt.Errorf("close terminal issue %s: %w", issueID, err)
+		}
+		if closed {
+			issue.Closed = true
+			issue.ClosedReason = "completed"
 		}
 		o.clearMergeRequiredCheckStreaks(ctx, terminalIssue)
 	}
@@ -531,6 +541,7 @@ func stateLaneEntryIssues(state *State) []connector.Issue {
 	}
 	issues = append(issues, state.StatusDrift.UntrackedOpen...)
 	issues = append(issues, state.StatusDrift.OpenTerminal...)
+	issues = append(issues, state.StatusDrift.ClosedActive...)
 	return issues
 }
 

--- a/internal/telemetry/snapshot.go
+++ b/internal/telemetry/snapshot.go
@@ -953,10 +953,11 @@ func countOrLength(count int, length int) int {
 type TrackerDrift struct {
 	UntrackedOpen []Issue `json:"untracked_open,omitempty"`
 	OpenTerminal  []Issue `json:"open_terminal,omitempty"`
+	ClosedActive  []Issue `json:"closed_active,omitempty"`
 }
 
 func (d TrackerDrift) IsZero() bool {
-	return len(d.UntrackedOpen) == 0 && len(d.OpenTerminal) == 0
+	return len(d.UntrackedOpen) == 0 && len(d.OpenTerminal) == 0 && len(d.ClosedActive) == 0
 }
 
 type Issue struct {

--- a/internal/web/kanban.go
+++ b/internal/web/kanban.go
@@ -197,6 +197,9 @@ func (s *Server) apiKanbanMove(c echo.Context) error {
 			if err := setter.SetIssueField(c.Request().Context(), req.issueID, target.kanban.IssueStateFieldID, kanbanstate.MappedState(target.workflow, req.targetState)); err != nil {
 				return err
 			}
+			if err := closeLandedKanbanTerminalIssue(c.Request().Context(), target, snapshotIssue, req.issueID, req.targetState); err != nil {
+				return err
+			}
 			s.recordKanbanLaneTransition(
 				c.Request().Context(),
 				req.projectID,
@@ -212,6 +215,9 @@ func (s *Server) apiKanbanMove(c echo.Context) error {
 			return nil
 		}
 		if err := target.connector.UpdateIssueState(c.Request().Context(), req.issueID, req.targetState); err != nil {
+			return err
+		}
+		if err := closeLandedKanbanTerminalIssue(c.Request().Context(), target, snapshotIssue, req.issueID, req.targetState); err != nil {
 			return err
 		}
 		s.recordKanbanLaneTransition(
@@ -292,6 +298,30 @@ func (s *Server) apiKanbanMove(c echo.Context) error {
 		"runtime_block_cleared", runtimeMove.BlockedCleared,
 	)
 	return s.kanbanMoveSuccess(c, req, "Moved card to "+req.targetState+".")
+}
+
+func closeLandedKanbanTerminalIssue(
+	ctx context.Context,
+	target kanbanActionTarget,
+	issue telemetry.Issue,
+	issueID string,
+	targetState string,
+) error {
+	terminal := false
+	for _, state := range target.workflow.Tracker.TerminalStates {
+		if kanbanstate.NormalizeState(state) == kanbanstate.NormalizeState(targetState) {
+			terminal = true
+			break
+		}
+	}
+	if !terminal || issue.PullRequest == nil || !strings.EqualFold(strings.TrimSpace(issue.PullRequest.State), "merged") {
+		return nil
+	}
+	closer, ok := target.connector.(connector.IssueCloser)
+	if !ok {
+		return nil
+	}
+	return closer.CloseIssue(ctx, issueID)
 }
 
 func (s *Server) kanbanMoveSuccess(c echo.Context, req kanbanMoveRequest, message string) error {

--- a/internal/web/server_test.go
+++ b/internal/web/server_test.go
@@ -20,6 +20,7 @@ import (
 	"path/filepath"
 	"reflect"
 	"regexp"
+	"slices"
 	"strconv"
 	"strings"
 	"sync"
@@ -2514,6 +2515,71 @@ func TestKanbanMoveRoutesProjectV2AndIssueFieldUpdates(t *testing.T) {
 			}
 			if got := actionConnector.issueFieldUpdates(); !equalIssueFieldUpdates(got, tt.wantField) {
 				t.Fatalf("issue field updates = %#v, want %#v", got, tt.wantField)
+			}
+		})
+	}
+}
+
+func TestKanbanMoveClosesOnlyLandedTerminalIssues(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name              string
+		issueStateFieldID int
+		pullRequestState  string
+		wantCloses        []string
+	}{
+		{name: "project status landed work", pullRequestState: "MERGED", wantCloses: []string{"I_kw1"}},
+		{name: "issue field landed work", issueStateFieldID: 123, pullRequestState: "MERGED", wantCloses: []string{"I_kw1"}},
+		{name: "terminal without landed work", pullRequestState: "OPEN"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			deps := testDeps(t)
+			actionConnector := &kanbanActionConnector{name: "github"}
+			mustSetKanbanProject(t, deps.Registry, "detent", workflowconfig.Kanban{
+				Mode:              workflowconfig.KanbanModeIntegration,
+				IssueStateFieldID: tt.issueStateFieldID,
+				AllowedTransitions: map[string][]string{
+					"Merging": {"Done"},
+				},
+			}, actionConnector)
+			if err := deps.Hub.Publish(telemetry.Snapshot{
+				GeneratedAt: time.Date(2026, 8, 18, 12, 0, 0, 0, time.UTC),
+				Project:     telemetry.Project{ID: "detent"},
+				Pipeline: []telemetry.Issue{{
+					ID:         "I_kw1",
+					Identifier: "digitaldrywood/detent#1",
+					ProjectID:  "detent",
+					Title:      "Terminal card",
+					State:      "Merging",
+					PullRequest: &telemetry.PullRequest{
+						Number: 1,
+						State:  tt.pullRequestState,
+					},
+				}},
+			}); err != nil {
+				t.Fatalf("Publish() error = %v", err)
+			}
+			server, err := web.NewServer(web.Config{}, deps)
+			if err != nil {
+				t.Fatalf("NewServer() error = %v", err)
+			}
+
+			rec := performForm(t, server.Handler(), http.MethodPost, "/api/v1/kanban/move", url.Values{
+				"project_id":    {"detent"},
+				"issue_id":      {"I_kw1"},
+				"current_state": {"Merging"},
+				"target_state":  {"Done"},
+			})
+			if rec.Code != http.StatusOK {
+				t.Fatalf("status = %d, want %d; body = %s", rec.Code, http.StatusOK, rec.Body.String())
+			}
+			if got := actionConnector.issueCloses(); !slices.Equal(got, tt.wantCloses) {
+				t.Fatalf("CloseIssue() calls = %#v, want %#v", got, tt.wantCloses)
 			}
 		})
 	}
@@ -12817,6 +12883,7 @@ type kanbanActionConnector struct {
 	fields         []kanbanIssueFieldUpdate
 	fieldClears    []kanbanIssueFieldUpdate
 	removes        []kanbanRemoval
+	closes         []string
 	commentLog     []kanbanComment
 	commentEdits   []kanbanCommentEdit
 	commentDeletes []kanbanCommentDelete
@@ -12939,6 +13006,14 @@ func (c *kanbanActionConnector) UpdateIssueState(_ context.Context, issueID stri
 	return err
 }
 
+func (c *kanbanActionConnector) CloseIssue(_ context.Context, issueID string) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	c.closes = append(c.closes, issueID)
+	return nil
+}
+
 func (c *kanbanActionConnector) SetAssignee(context.Context, string, string) error {
 	return connector.ErrNotImplemented
 }
@@ -13005,6 +13080,13 @@ func (c *kanbanActionConnector) removals() []kanbanRemoval {
 	defer c.mu.Unlock()
 
 	return append([]kanbanRemoval(nil), c.removes...)
+}
+
+func (c *kanbanActionConnector) issueCloses() []string {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	return append([]string(nil), c.closes...)
 }
 
 func (c *kanbanActionConnector) comments() []kanbanComment {


### PR DESCRIPTION
## Summary

- Reapply tracker issue closure whenever landed work reaches a configured terminal lane, including after Done → Rework → Done round trips.
- Reconcile stranded open terminal issues only when a linked pull request is confirmed merged; leave unlanded terminal issues surfaced for operators.
- Report the inverse closed-active lane mismatch through runtime drift and `detent doctor`.

Fixes #1917

## UI Surface Contract

- [x] N/A; this change does not modify UI surface, layout, density, first-viewport, or responsive visibility.
- [x] This PR does not add persistent top-of-screen messaging.
- [x] N/A; this PR has no visual changes to primary operator screens.

## Test Plan

- [x] `make check`
- [x] Table-driven terminal transition and reconciliation regressions
- [x] Connector, doctor, and Kanban focused tests