### PR TITLE
fix(orchestrator): enforce cumulative spend progress

### DIFF
--- a/internal/orchestrator/run_completion.go
+++ b/internal/orchestrator/run_completion.go
@@ -336,8 +336,7 @@ func (o *Orchestrator) handleRunResult(ctx context.Context, state *State, event 
 			if !pushEvidenceRefreshed && (implementProgressLinkedPullRequest(running.Issue) || event.Result.PullRequestUpdated) {
 				running.Issue, evidenceWarning = o.refreshSpendProgressIssue(ctx, running.Issue)
 			}
-			accepted, acceptedReason := dispatchAcceptedStateChange(running)
-			spendProgress = o.evaluateSpendProgress(ctx, running, event.CompletedAt, accepted, acceptedReason)
+			spendProgress = o.evaluateSpendProgress(ctx, running, event.CompletedAt, false, "")
 			if evidenceWarning != "" {
 				spendProgress.Warning = evidenceWarning
 				spendProgress.Block = false

--- a/internal/orchestrator/safety_fuzz_test.go
+++ b/internal/orchestrator/safety_fuzz_test.go
@@ -27,7 +27,7 @@ func FuzzSafetyCriticalOrchestratorBoundaries(f *testing.F) {
 	f.Add(0, 0, 0, "", "clean", int64(1), " head ", "lint,test", int64(1), "head", "test,lint", int64(60), int64(0), true, int64(0), int64(1), int64(2), true, uint8(0))
 	f.Add(1, 2, 3, "fingerprint", "dirty", int64(1), "head-a", "test", int64(2), "head-b", "lint", int64(-60), int64(0), true, int64(10), int64(-10), int64(0), false, uint8(1))
 	f.Add(0, 0, 0, "clean", "dirty", int64(1), "same-head", "fail", int64(1), "same-head", "pass", int64(0), int64(0), false, int64(0), int64(0), int64(0), false, uint8(2))
-	f.Add(0, 0, 0, "", "", int64(0), "", "", int64(0), "", "", int64(0), int64(0), false, int64(0), int64(0), int64(0), false, uint8(3))
+	f.Add(0, 0, 0, "", "", int64(0), "", "", int64(0), "", "", int64(0), int64(0), false, int64(0), int64(10), int64(0), false, uint8(3))
 
 	f.Fuzz(func(
 		t *testing.T,
@@ -162,9 +162,6 @@ func FuzzSafetyCriticalOrchestratorBoundaries(f *testing.F) {
 			})
 		}
 		wantBaseline := createdAt
-		if stageUpdatedAt.After(wantBaseline) {
-			wantBaseline = stageUpdatedAt
-		}
 		if accepted && acceptedAt.After(wantBaseline) {
 			wantBaseline = acceptedAt
 		}

--- a/internal/orchestrator/spend_progress.go
+++ b/internal/orchestrator/spend_progress.go
@@ -282,10 +282,8 @@ func (o *Orchestrator) refreshSpendProgressIssue(ctx context.Context, issue conn
 
 func spendProgressBaseline(issue connector.Issue, attempts []store.WorkAttempt) time.Time {
 	baseline := time.Time{}
-	for _, candidate := range []*time.Time{issue.CreatedAt, issue.StageUpdatedAt} {
-		if candidate != nil && candidate.After(baseline) {
-			baseline = candidate.UTC()
-		}
+	if issue.CreatedAt != nil {
+		baseline = issue.CreatedAt.UTC()
 	}
 	for _, attempt := range attempts {
 		if !spendProgressAttemptAccepted(attempt) || !attempt.CompletedAt.After(baseline) {
@@ -375,25 +373,13 @@ func mergeWorkAttemptMetadata(groups ...map[string]any) map[string]any {
 	return merged
 }
 
-func implementAcceptedStateChange(running Running, decision implementCompletionProgressDecision) (bool, string) {
-	if accepted, reason := dispatchAcceptedStateChange(running); accepted {
-		return true, reason
-	}
+func implementAcceptedStateChange(_ Running, decision implementCompletionProgressDecision) (bool, string) {
 	switch strings.TrimSpace(decision.Reason) {
 	case "pull_request_created_or_updated", "signature_changed", implementMergedCompletionReason:
 		return true, decision.Reason
 	default:
 		return false, ""
 	}
-}
-
-func dispatchAcceptedStateChange(running Running) (bool, string) {
-	source := strings.TrimSpace(running.DispatchSourceState)
-	target := strings.TrimSpace(running.DispatchTargetState)
-	if source != "" && target != "" && !strings.EqualFold(source, target) {
-		return true, "lane_transition"
-	}
-	return false, ""
 }
 
 func (o *Orchestrator) blockSpendProgress(

--- a/internal/orchestrator/spend_progress_test.go
+++ b/internal/orchestrator/spend_progress_test.go
@@ -207,6 +207,40 @@ func TestEvaluateSpendProgress(t *testing.T) {
 	}
 }
 
+func TestSpendProgressBaselineIgnoresLaneTransitions(t *testing.T) {
+	t.Parallel()
+
+	createdAt := time.Date(2026, 7, 11, 11, 0, 0, 0, time.UTC)
+	stageUpdatedAt := createdAt.Add(30 * time.Minute)
+	acceptedAt := createdAt.Add(45 * time.Minute)
+	tests := []struct {
+		name     string
+		attempts []store.WorkAttempt
+		want     time.Time
+	}{
+		{name: "lane transition only", want: createdAt},
+		{
+			name: "accepted work product progress",
+			attempts: []store.WorkAttempt{{
+				CompletedAt: acceptedAt,
+				WorkerMetadataJSON: marshalWorkAttemptJSON(map[string]any{
+					spendProgressMetadataKey: spendProgressRecord{AcceptedStateChange: true},
+				}),
+			}},
+			want: acceptedAt,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			issue := connector.Issue{CreatedAt: &createdAt, StageUpdatedAt: &stageUpdatedAt}
+			if got := spendProgressBaseline(issue, tt.attempts); !got.Equal(tt.want) {
+				t.Fatalf("spendProgressBaseline() = %s, want %s", got, tt.want)
+			}
+		})
+	}
+}
+
 func spendProgressIssueWithPR(headSHA string, mergeableState string, ciStatus string) connector.Issue {
 	number := 214
 	return connector.Issue{
@@ -346,43 +380,34 @@ type connectorOnly struct {
 	connector.Connector
 }
 
-func TestDispatchAcceptedStateChange(t *testing.T) {
+func TestImplementAcceptedStateChangeRequiresWorkProductProgress(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name    string
-		running Running
-		want    bool
+		name       string
+		running    Running
+		decision   implementCompletionProgressDecision
+		want       bool
+		wantReason string
 	}{
-		{name: "lane transition", running: Running{DispatchSourceState: "Todo", DispatchTargetState: "In Progress"}, want: true},
-		{name: "same lane", running: Running{DispatchSourceState: "Rework", DispatchTargetState: "Rework"}},
-		{name: "missing transition", running: Running{}},
+		{name: "retry lane transition", running: Running{DispatchSourceState: "Todo", DispatchTargetState: "In Progress"}},
+		{name: "rework lane transition", running: Running{DispatchSourceState: "Rework", DispatchTargetState: "In Progress"}},
+		{name: "park lane transition", running: Running{DispatchSourceState: "In Progress", DispatchTargetState: "Blocked"}},
+		{name: "pull request update", decision: implementCompletionProgressDecision{Reason: "pull_request_created_or_updated"}, want: true, wantReason: "pull_request_created_or_updated"},
+		{name: "signature change", decision: implementCompletionProgressDecision{Reason: "signature_changed"}, want: true, wantReason: "signature_changed"},
+		{name: "merged completion", decision: implementCompletionProgressDecision{Reason: implementMergedCompletionReason}, want: true, wantReason: implementMergedCompletionReason},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			got, reason := dispatchAcceptedStateChange(tt.running)
+			got, reason := implementAcceptedStateChange(tt.running, tt.decision)
 			if got != tt.want {
 				t.Fatalf("accepted = %t, want %t", got, tt.want)
 			}
-			if got && reason != "lane_transition" {
-				t.Fatalf("reason = %q, want lane_transition", reason)
-			}
-			if !got && reason != "" {
-				t.Fatalf("reason = %q, want empty", reason)
+			if reason != tt.wantReason {
+				t.Fatalf("reason = %q, want %q", reason, tt.wantReason)
 			}
 		})
-	}
-}
-
-func TestImplementAcceptedStateChangeAcceptsMergedCompletion(t *testing.T) {
-	t.Parallel()
-
-	accepted, reason := implementAcceptedStateChange(Running{}, implementCompletionProgressDecision{
-		Reason: implementMergedCompletionReason,
-	})
-	if !accepted || reason != implementMergedCompletionReason {
-		t.Fatalf("implementAcceptedStateChange() = %t, %q, want true, %q", accepted, reason, implementMergedCompletionReason)
 	}
 }
 
@@ -393,6 +418,8 @@ func TestHandleRunResultTripsTokenProgressBreakerOnSubscription(t *testing.T) {
 	createdAt := base.Add(-30 * time.Minute)
 	issue := implementProgressIssueWithoutPR()
 	issue.CreatedAt = &createdAt
+	stageUpdatedAt := base.Add(-5 * time.Minute)
+	issue.StageUpdatedAt = &stageUpdatedAt
 	tracker := &implementProgressConnector{}
 	attempts := &implementProgressAttemptStore{}
 	cfg := normalizeConfig(Config{
@@ -419,12 +446,14 @@ func TestHandleRunResultTripsTokenProgressBreakerOnSubscription(t *testing.T) {
 	}
 	state := newState(cfg)
 	running := Running{
-		Issue:         issue,
-		Attempt:       5,
-		WorkAttemptID: 42,
-		Mode:          runpkg.RunModeImplement,
-		StartedAt:     base.Add(-2 * time.Minute),
-		DiffStats:     DiffStats{FilesChanged: 2, AddedLines: 10, RemovedLines: 3, Status: "dirty"},
+		Issue:               issue,
+		Attempt:             5,
+		WorkAttemptID:       42,
+		Mode:                runpkg.RunModeImplement,
+		StartedAt:           base.Add(-2 * time.Minute),
+		DiffStats:           DiffStats{FilesChanged: 2, AddedLines: 10, RemovedLines: 3, Status: "dirty"},
+		DispatchSourceState: "Rework",
+		DispatchTargetState: "In Progress",
 	}
 	state.Running[issue.ID] = running
 	state.Claimed[issue.ID] = Claimed{Issue: issue, ClaimedAt: running.StartedAt}
@@ -505,11 +534,13 @@ func TestHandleRunResultAcceptsPRAdvanceBeforeWorkerError(t *testing.T) {
 	}
 	state := newState(cfg)
 	running := Running{
-		Issue:         runningIssue,
-		Attempt:       2,
-		WorkAttemptID: 42,
-		Mode:          runpkg.RunModeImplement,
-		StartedAt:     base.Add(-5 * time.Minute),
+		Issue:               runningIssue,
+		Attempt:             2,
+		WorkAttemptID:       42,
+		Mode:                runpkg.RunModeImplement,
+		StartedAt:           base.Add(-5 * time.Minute),
+		DispatchSourceState: "Rework",
+		DispatchTargetState: "In Progress",
 	}
 	state.Running[runningIssue.ID] = running
 	state.Claimed[runningIssue.ID] = Claimed{Issue: runningIssue, ClaimedAt: running.StartedAt}


### PR DESCRIPTION
## Summary

- stop treating dispatch lane transitions as accepted spend progress
- anchor no-progress spend to issue creation and durable work-product progress instead of lane timestamps
- cover retry, rework, park, failure, token-limit, and safety-fuzz boundaries

Fixes #1925

## UI Surface Contract

- [x] N/A; this PR has no UI changes.
- [x] This PR does not add persistent top-of-screen messaging.
- [x] N/A; no operator screen changed.

## Test Plan

- [x] `make check`
- [x] `go test ./internal/orchestrator -run "^$" -fuzz=FuzzSafetyCriticalOrchestratorBoundaries -fuzztime=30s`
- [x] exact-file coverage for `internal/orchestrator/spend_progress.go`: 91.33% (required 90%)