### PR TITLE
fix(orchestrator): make breaker parks sticky

### DIFF
--- a/config.reference.yaml
+++ b/config.reference.yaml
@@ -102,6 +102,8 @@
 #     target_state: "Rework"
 #     # tracker.blocked_recovery.reason_codes | type: list<string> | default: ["merge_conflict","stale_base","missing_current_head_ci"] | required: No | validation: must contain only merge_conflict, stale_base, missing_current_head_ci; must not be empty when tracker.blocked_recovery.enabled is true
 #     reason_codes: ["merge_conflict","stale_base","missing_current_head_ci"]
+#     # tracker.blocked_recovery.breaker_cooldown_seconds | type: integer | default: 86400 | required: No | validation: must be greater than or equal to 0
+#     breaker_cooldown_seconds: 86400
 #   # tracker.blocker_auto_promote | type: object | default: see child fields | required: No | validation: None
 #   blocker_auto_promote:
 #     # tracker.blocker_auto_promote.enabled | type: boolean | default: false | required: Conditional | validation: tracker.blocker_auto_promote.target_state is required when tracker.blocker_auto_promote.enabled is true

--- a/docs/config.md
+++ b/docs/config.md
@@ -805,6 +805,7 @@ only to resettable budget pacing and never clears a per-issue hard hold.
 | `tracker.authorization.priority_in` | `list<integer>` | `[]` | No | values must be integers 1 through 4 |
 | `tracker.auto_provision` | `boolean` | `true` | No | None |
 | `tracker.blocked_recovery` | `object` | `see child fields` | No | None |
+| `tracker.blocked_recovery.breaker_cooldown_seconds` | `integer` | `86400` | No | must be greater than or equal to 0 |
 | `tracker.blocked_recovery.enabled` | `boolean` | `false` | Conditional | tracker.active_states must include tracker.blocked_recovery.target_state when tracker.blocked_recovery.enabled is true<br>tracker.blocked_recovery.reason_codes must not be empty when tracker.blocked_recovery.enabled is true<br>tracker.blocked_recovery.source_states must not be empty when tracker.blocked_recovery.enabled is true<br>tracker.blocked_recovery.target_state is required when tracker.blocked_recovery.enabled is true |
 | `tracker.blocked_recovery.reason_codes` | `list<string>` | `["merge_conflict","stale_base","missing_current_head_ci"]` | No | must contain only merge_conflict, stale_base, missing_current_head_ci<br>must not be empty when tracker.blocked_recovery.enabled is true |
 | `tracker.blocked_recovery.source_states` | `list<string>` | `["blocked"]` | No | must not be empty when tracker.blocked_recovery.enabled is true<br>state names must be unique<br>state names must not be blank |

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -222,10 +222,11 @@ type DependencyAutoUnblock struct {
 }
 
 type BlockedRecovery struct {
-	Enabled      bool     `yaml:"enabled"`
-	SourceStates []string `yaml:"source_states"`
-	TargetState  string   `yaml:"target_state"`
-	ReasonCodes  []string `yaml:"reason_codes"`
+	Enabled                bool     `yaml:"enabled"`
+	SourceStates           []string `yaml:"source_states"`
+	TargetState            string   `yaml:"target_state"`
+	ReasonCodes            []string `yaml:"reason_codes"`
+	BreakerCooldownSeconds int      `yaml:"breaker_cooldown_seconds"`
 }
 
 type Dependencies struct {
@@ -1039,16 +1040,23 @@ func (b *BlockedRecovery) Normalize() {
 	}
 	b.SourceStates = normalizeStateList(b.SourceStates)
 	b.TargetState = strings.TrimSpace(b.TargetState)
+	if b.BreakerCooldownSeconds == 0 {
+		b.BreakerCooldownSeconds = 24 * 60 * 60
+	}
 	for index := range b.ReasonCodes {
 		b.ReasonCodes[index] = normalizeBlockedRecoveryReasonCode(b.ReasonCodes[index])
 	}
 }
 
 func (b BlockedRecovery) Validate(prefix string) []string {
+	breakerCooldownSeconds := b.BreakerCooldownSeconds
 	b.ReasonCodes = slices.Clone(b.ReasonCodes)
 	b.Normalize()
 
 	var problems []string
+	if breakerCooldownSeconds < 0 {
+		problems = append(problems, prefix+".breaker_cooldown_seconds must be greater than or equal to 0")
+	}
 	validateStateList(prefix+".source_states", b.SourceStates, &problems)
 	if b.Enabled {
 		if len(b.SourceStates) == 0 {
@@ -1333,9 +1341,10 @@ func Default() Config {
 				Readiness:    DependencyReadinessTerminalOrMerged,
 			},
 			BlockedRecovery: BlockedRecovery{
-				SourceStates: []string{"Blocked"},
-				TargetState:  "Rework",
-				ReasonCodes:  []string{"merge_conflict", "stale_base", "missing_current_head_ci"},
+				SourceStates:           []string{"Blocked"},
+				TargetState:            "Rework",
+				ReasonCodes:            []string{"merge_conflict", "stale_base", "missing_current_head_ci"},
+				BreakerCooldownSeconds: 24 * 60 * 60,
 			},
 			BlockerAutoPromote: BlockerAutoPromote{
 				BlockerStates: []string{"Backlog", "Blocked", "Human Review"},

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -962,6 +962,7 @@ tracker:
     readiness: terminal_or_merged
   blocked_recovery:
     enabled: true
+    breaker_cooldown_seconds: 43200
     source_states:
       - Blocked
     target_state: Rework
@@ -1232,6 +1233,9 @@ Ticket prompt {{ issue.title }}
 	}
 	if got := cfg.Tracker.BlockedRecovery.ReasonCodes; !reflect.DeepEqual(got, []string{"merge_conflict", "stale_base", "missing_current_head_ci"}) {
 		t.Fatalf("Tracker.BlockedRecovery.ReasonCodes = %#v, want canonical reason codes", got)
+	}
+	if cfg.Tracker.BlockedRecovery.BreakerCooldownSeconds != 43200 {
+		t.Fatalf("Tracker.BlockedRecovery.BreakerCooldownSeconds = %d, want 43200", cfg.Tracker.BlockedRecovery.BreakerCooldownSeconds)
 	}
 	if !cfg.Tracker.BlockerAutoPromote.Enabled {
 		t.Fatal("Tracker.BlockerAutoPromote.Enabled = false, want true")
@@ -1588,6 +1592,9 @@ func TestParseWorkflowDefaults(t *testing.T) {
 	}
 	if got := cfg.Tracker.BlockedRecovery.ReasonCodes; !reflect.DeepEqual(got, []string{"merge_conflict", "stale_base", "missing_current_head_ci"}) {
 		t.Fatalf("Tracker.BlockedRecovery.ReasonCodes = %#v, want default allowlist", got)
+	}
+	if cfg.Tracker.BlockedRecovery.BreakerCooldownSeconds != 86400 {
+		t.Fatalf("Tracker.BlockedRecovery.BreakerCooldownSeconds = %d, want 86400", cfg.Tracker.BlockedRecovery.BreakerCooldownSeconds)
 	}
 	if cfg.Tracker.BlockerAutoPromote.Enabled {
 		t.Fatal("Tracker.BlockerAutoPromote.Enabled = true, want disabled by default")
@@ -3722,6 +3729,7 @@ tracker:
     - Rework
   blocked_recovery:
     enabled: true
+    breaker_cooldown_seconds: -1
     source_states: [""]
     target_state: ""
     reason_codes:
@@ -3732,6 +3740,7 @@ tracker:
 Prompt
 `,
 			want: []string{
+				"tracker.blocked_recovery.breaker_cooldown_seconds must be greater than or equal to 0",
 				"tracker.blocked_recovery.source_states state names must not be blank",
 				"tracker.blocked_recovery.target_state is required when tracker.blocked_recovery.enabled is true",
 				"tracker.blocked_recovery.reason_codes must contain only merge_conflict, stale_base, missing_current_head_ci",

--- a/internal/orchestrator/blocked_cause_recovery.go
+++ b/internal/orchestrator/blocked_cause_recovery.go
@@ -25,7 +25,8 @@ const (
 	blockedRecoveryPredicateFingerprintChange      = "fingerprint_changed"
 	blockedRecoveryPredicateOncePerFingerprint     = "once_per_fingerprint"
 	blockedRecoveryPredicateManaged                = "managed"
-	blockedCauseFingerprintVersion                 = 2
+	blockedCauseFingerprintVersion                 = 3
+	blockedCauseLegacyBreakerFingerprintVersion    = 2
 	workflowActionCauseBlockedRecovery             = "cause_blocked_recovery"
 	workflowActionBlockedReadyPRReconciliation     = "blocked_ready_pr_reconciliation"
 	blockedReadyPullRequestLookupAttempts          = 3
@@ -210,7 +211,6 @@ func blockedCauseFingerprint(cause string, signals blockedCauseSignals) string {
 		Cause:              strings.TrimSpace(cause),
 		ConfigFingerprint:  signals.ConfigFingerprint,
 		ToolingFingerprint: signals.ToolingFingerprint,
-		BaseFingerprint:    signals.BaseFingerprint,
 		Health:             signals.Health,
 		Description:        signals.Description,
 		ModelOverride:      signals.ModelOverride,
@@ -221,11 +221,28 @@ func blockedCauseFingerprint(cause string, signals blockedCauseSignals) string {
 		PRBaseSHA:          signals.PRBaseSHA,
 		PRDiffFingerprint:  signals.PRDiffFingerprint,
 	}
+	if !breakerParkCause(cause) {
+		identity.BaseFingerprint = signals.BaseFingerprint
+	}
 	data, err := json.Marshal(identity)
 	if err != nil {
 		return blockedCauseHash(err.Error())
 	}
 	return blockedCauseHash(string(data))
+}
+
+func breakerParkCause(cause string) bool {
+	cause = strings.ToLower(strings.TrimSpace(cause))
+	if strings.HasPrefix(cause, tokenCeilingBlockedReasonPrefix) ||
+		strings.HasPrefix(cause, repeatedFailureBlockedReasonPrefix) {
+		return true
+	}
+	switch cause {
+	case dispatchLoopDetectedReason, noProgressLimitReason, spendProgressReason, repeatedFailureCircuitBreakerCause, "token_ceiling_circuit_breaker":
+		return true
+	default:
+		return false
+	}
 }
 
 func blockedCauseHash(value string) string {
@@ -263,6 +280,7 @@ func (o *Orchestrator) recoverCauseBlockedIssue(
 		o.recordBlockedRecoveryDecision(ctx, state, issue, "hold", "operator_stop", nil, "")
 		return false
 	}
+	_, currentParkFound := o.currentBlockedRecoveryPark(ctx, state, issue)
 	withDependencies := o.issueWithDependencyRefs(issue)
 	withDependencies, workpadRefs, workpadCurrent := o.issueWithCurrentWorkpadDependencyRefs(ctx, withDependencies)
 	blockers := o.resolveDependencyBlockers(ctx, withDependencies)
@@ -320,12 +338,15 @@ func (o *Orchestrator) recoverCauseBlockedIssue(
 			setBlockedEvidence(state, issue.ID, recorded.Evidence)
 			return false
 		}
-		if o.applyRecordedBlockerRecovery(ctx, state, withDependencies, blockers, recorded.Evidence, now) {
-			return true
+		if !currentParkFound {
+			if o.applyRecordedBlockerRecovery(ctx, state, withDependencies, blockers, recorded.Evidence, now) {
+				return true
+			}
+			o.recordBlockedRecoveryDecision(ctx, state, withDependencies, "hold", "transition_failed", nil, "")
+			setBlockedEvidence(state, issue.ID, recorded.Evidence)
+			return false
 		}
-		o.recordBlockedRecoveryDecision(ctx, state, withDependencies, "hold", "transition_failed", nil, "")
 		setBlockedEvidence(state, issue.ID, recorded.Evidence)
-		return false
 	}
 	workpadBlockers := dependencyBlockersMatchingRefs(blockers, workpadRefs)
 	holdReason := o.blockedCauseHoldReason(issue, state, workpadBlockers, dependencyCfg, workpadCurrent)
@@ -395,9 +416,23 @@ func (o *Orchestrator) recoverCauseBlockedIssue(
 		o.recordBlockedRecoveryDecision(ctx, state, issue, "hold", "no_recovery_predicate", &park, park.CauseFingerprint)
 		return false
 	}
-	if park.CauseFingerprintVersion != blockedCauseFingerprintVersion {
+	breakerPark := breakerParkCause(park.Cause)
+	if park.CauseFingerprintVersion != blockedCauseFingerprintVersion &&
+		(!breakerPark || park.CauseFingerprintVersion != blockedCauseLegacyBreakerFingerprintVersion) {
 		o.recordBlockedRecoveryDecision(ctx, state, issue, "hold", "legacy_cause_fingerprint", &park, park.CauseFingerprint)
 		return false
+	}
+	if breakerPark {
+		parkedAt, found := o.currentBlockedRecoveryParkedAt(ctx, state, issue)
+		if !found {
+			o.recordBlockedRecoveryDecision(ctx, state, issue, "hold", "breaker_cooldown_unavailable", &park, park.CauseFingerprint)
+			return false
+		}
+		cooldown := normalizeBlockedRecoveryConfig(o.cfg.BlockedRecovery).BreakerCooldown
+		if now.Before(parkedAt.Add(cooldown)) {
+			o.recordBlockedRecoveryDecision(ctx, state, issue, "defer", "breaker_cooldown_active", &park, park.CauseFingerprint)
+			return false
+		}
 	}
 	signals := o.blockedCauseSignals(ctx, issue, park.RunMode, park.TargetState, DiffStats{})
 	currentFingerprint := blockedCauseFingerprint(park.Cause, signals)
@@ -780,6 +815,34 @@ func (o *Orchestrator) currentBlockedRecoveryPark(
 	return *entry.Metadata.BlockedRecovery, true
 }
 
+func (o *Orchestrator) currentBlockedRecoveryParkedAt(
+	ctx context.Context,
+	state *State,
+	issue connector.Issue,
+) (time.Time, bool) {
+	issueID := strings.TrimSpace(issue.ID)
+	if state != nil && issueID != "" {
+		if blocked, ok := state.Blocked[issueID]; ok &&
+			blocked.Recovery != nil &&
+			blockedEntryMatchesCurrent(issue, blocked.BlockedAt) &&
+			!blocked.BlockedAt.IsZero() {
+			return blocked.BlockedAt.UTC(), true
+		}
+	}
+	entry, ok := o.latestWorkflowLaneEntry(ctx, issue)
+	if ok &&
+		normalizeState(entry.Event.PhaseName) == normalizeState(blockedStatusState) &&
+		blockedEntryMatchesCurrent(issue, entry.Event.StartedAt) &&
+		entry.Metadata.BlockedRecovery != nil &&
+		!entry.Event.StartedAt.IsZero() {
+		return entry.Event.StartedAt.UTC(), true
+	}
+	if issue.StageUpdatedAt != nil && !issue.StageUpdatedAt.IsZero() {
+		return issue.StageUpdatedAt.UTC(), true
+	}
+	return time.Time{}, false
+}
+
 func (o *Orchestrator) currentBlockedRecoveryParkWithLegacyRESTBudget(
 	ctx context.Context,
 	state *State,
@@ -957,6 +1020,10 @@ func BlockedRecoveryOperatorRemedy(issue connector.Issue, reason string) string 
 		return "Change the blocking cause, or move the issue to a lane that starts fresh work."
 	case "legacy_cause_fingerprint":
 		return "Review the blocking cause, then move the issue to a lane that starts fresh work."
+	case "breaker_cooldown_active":
+		return "Detent will re-evaluate this circuit-breaker park after its cooldown expires."
+	case "breaker_cooldown_unavailable":
+		return "Restore the recorded Blocked transition time or move the issue to a lane that starts fresh work."
 	case "transition_failed":
 		return "Retry the lane transition after restoring tracker write access."
 	case githubRESTBudgetWaitingReason, githubRESTBudgetObservationPendingReason:

--- a/internal/orchestrator/blocked_cause_recovery_test.go
+++ b/internal/orchestrator/blocked_cause_recovery_test.go
@@ -231,6 +231,7 @@ func TestCauseBlockedRecoveryPersistsAndBoundsFingerprintAttempts(t *testing.T) 
 
 	tests := []struct {
 		name                  string
+		cause                 string
 		predicate             string
 		parked                runpkg.BlockedRecoverySnapshot
 		current               runpkg.BlockedRecoverySnapshot
@@ -291,6 +292,7 @@ func TestCauseBlockedRecoveryPersistsAndBoundsFingerprintAttempts(t *testing.T) 
 		},
 		{
 			name:      "stranded workspace once per unchanged fingerprint",
+			cause:     strandedUnpushedWorkReason,
 			predicate: blockedRecoveryPredicateOncePerFingerprint,
 			parked: runpkg.BlockedRecoverySnapshot{
 				ConfigFingerprint:    "config-same",
@@ -326,11 +328,15 @@ func TestCauseBlockedRecoveryPersistsAndBoundsFingerprintAttempts(t *testing.T) 
 			parkOrch.workflowMetrics = metrics
 			parkOrch.recoveryInspector = staticBlockedRecoveryInspector{snapshot: tt.parked}
 			parkedAt := time.Date(2026, 7, 29, 18, 30, 0, 0, time.UTC)
+			cause := tt.cause
+			if cause == "" {
+				cause = noProgressLimitReason
+			}
 			metadata := parkOrch.newBlockedRecoveryMetadata(
 				t.Context(),
 				issue,
 				RunModeImplement,
-				noProgressLimitReason,
+				cause,
 				tt.predicate,
 				"Todo",
 				DiffStats{},
@@ -355,12 +361,26 @@ func TestCauseBlockedRecoveryPersistsAndBoundsFingerprintAttempts(t *testing.T) 
 				BlockedAt: parkedAt,
 				Recovery:  metadata.BlockedRecovery,
 			}
-			currentFingerprint := blockedCauseFingerprint(noProgressLimitReason, orch.blockedCauseSignals(t.Context(), currentIssue, RunModeImplement, metadata.BlockedRecovery.TargetState, DiffStats{}))
+			currentFingerprint := blockedCauseFingerprint(cause, orch.blockedCauseSignals(t.Context(), currentIssue, RunModeImplement, metadata.BlockedRecovery.TargetState, DiffStats{}))
 			if tt.wantStableFingerprint && currentFingerprint != metadata.BlockedRecovery.CauseFingerprint {
 				t.Fatalf("current fingerprint = %q, parked fingerprint = %q", currentFingerprint, metadata.BlockedRecovery.CauseFingerprint)
 			}
 
-			transitioned := orch.recoverBlockedIssues(t.Context(), &state, []connector.Issue{currentIssue}, parkedAt.Add(time.Minute))
+			recoveryAt := parkedAt.Add(time.Minute)
+			if breakerParkCause(cause) {
+				if tt.wantTransition {
+					orch.recoverBlockedIssues(t.Context(), &state, []connector.Issue{currentIssue}, parkedAt.Add(defaultBreakerParkCooldown-time.Nanosecond))
+					if len(tracker.updates) != 0 {
+						t.Fatalf("updates before cooldown = %#v, want breaker held", tracker.updates)
+					}
+					blocked := state.Blocked[issue.ID]
+					if blocked.RecoveryAction != "defer" || blocked.RecoveryReason != "breaker_cooldown_active" || blocked.NeedsHumanAttention {
+						t.Fatalf("pre-cooldown recovery = %#v, want machine-deferred cooldown", blocked)
+					}
+				}
+				recoveryAt = parkedAt.Add(defaultBreakerParkCooldown)
+			}
+			transitioned := orch.recoverBlockedIssues(t.Context(), &state, []connector.Issue{currentIssue}, recoveryAt)
 
 			if tt.wantTransition {
 				if len(tracker.updates) != 1 || tracker.updates[0].state != tt.wantTarget {
@@ -369,7 +389,7 @@ func TestCauseBlockedRecoveryPersistsAndBoundsFingerprintAttempts(t *testing.T) 
 				if _, ok := transitioned[issue.ID]; !ok {
 					t.Fatalf("transitioned[%q] missing", issue.ID)
 				}
-				assertWorkflowActionSignature(t, metrics, issue, workflowActionCauseBlockedRecovery, blockedCauseRecoverySignature(noProgressLimitReason, currentFingerprint))
+				assertWorkflowActionSignature(t, metrics, issue, workflowActionCauseBlockedRecovery, blockedCauseRecoverySignature(cause, currentFingerprint))
 
 				if tt.predicate == blockedRecoveryPredicateOncePerFingerprint {
 					recordBlockedCausePark(t, metrics, issue, parkedAt.Add(2*time.Minute), metadata)
@@ -400,6 +420,48 @@ func TestCauseBlockedRecoveryPersistsAndBoundsFingerprintAttempts(t *testing.T) 
 	}
 }
 
+func TestCauseBlockedRecoveryCooldownSurvivesRestart(t *testing.T) {
+	t.Parallel()
+
+	parkedAt := time.Date(2026, 8, 19, 4, 0, 0, 0, time.UTC)
+	issue := dependencyAutoUnblockIssue("issue-restarted-breaker-cooldown", blockedStatusState)
+	metrics := &autoPromoteWorkflowMetricsRecorder{}
+	parkOrch := blockedCauseTestOrchestrator(&dependencyAutoUnblockConnector{})
+	parkOrch.workflowMetrics = metrics
+	parkOrch.recoveryInspector = staticBlockedRecoveryInspector{snapshot: runpkg.BlockedRecoverySnapshot{
+		ConfigFingerprint: "config-before",
+		Health:            "ready",
+	}}
+	metadata := parkOrch.newBlockedRecoveryMetadata(
+		t.Context(),
+		issue,
+		RunModeImplement,
+		dispatchLoopDetectedReason,
+		blockedRecoveryPredicateFingerprintChange,
+		"Todo",
+		DiffStats{},
+	)
+	recordBlockedCausePark(t, metrics, issue, parkedAt, metadata)
+
+	tracker := &dependencyAutoUnblockConnector{}
+	restarted := blockedCauseTestOrchestrator(tracker)
+	restarted.workflowMetrics = metrics
+	restarted.recoveryInspector = staticBlockedRecoveryInspector{snapshot: runpkg.BlockedRecoverySnapshot{
+		ConfigFingerprint: "config-after",
+		Health:            "ready",
+	}}
+	state := newState(restarted.cfg)
+
+	restarted.recoverBlockedIssues(t.Context(), &state, []connector.Issue{issue}, parkedAt.Add(defaultBreakerParkCooldown-time.Nanosecond))
+	if len(tracker.updates) != 0 {
+		t.Fatalf("pre-cooldown restart updates = %#v, want park held", tracker.updates)
+	}
+	restarted.recoverBlockedIssues(t.Context(), &state, []connector.Issue{issue}, parkedAt.Add(defaultBreakerParkCooldown))
+	if len(tracker.updates) != 1 || tracker.updates[0].state != "Todo" {
+		t.Fatalf("post-cooldown restart updates = %#v, want Todo", tracker.updates)
+	}
+}
+
 func TestRepeatedFailureParkRecoveryUsesRecordedRESTBudgetFailures(t *testing.T) {
 	t.Parallel()
 
@@ -417,6 +479,7 @@ func TestRepeatedFailureParkRecoveryUsesRecordedRESTBudgetFailures(t *testing.T)
 		wantAction       string
 		wantReason       string
 		wantSurfaceParts []string
+		recoveryAfter    time.Duration
 	}{
 		{name: "budget recovers", errorMessage: budgetError, remaining: 4927, wantTransition: true},
 		{name: "current park recovers with invalid workpad", errorMessage: budgetError, remaining: 4927, workpadStatus: workpad.StatusBlocked, wantTransition: true},
@@ -429,11 +492,12 @@ func TestRepeatedFailureParkRecoveryUsesRecordedRESTBudgetFailures(t *testing.T)
 			wantSurfaceParts: []string{"transient GitHub REST budget", "remaining=940/5000", "reserve=1250"},
 		},
 		{
-			name:         "non-transient failure stays parked",
-			errorMessage: "run agent turn: runner transport closed",
-			remaining:    4927,
-			wantAction:   "hold",
-			wantReason:   "cause_unchanged",
+			name:          "non-transient failure stays parked",
+			errorMessage:  "run agent turn: runner transport closed",
+			remaining:     4927,
+			wantAction:    "hold",
+			wantReason:    "cause_unchanged",
+			recoveryAfter: defaultBreakerParkCooldown,
 		},
 		{
 			name:             "same exhaustion episode does not rearm twice",
@@ -539,7 +603,11 @@ func TestRepeatedFailureParkRecoveryUsesRecordedRESTBudgetFailures(t *testing.T)
 				Recovery:  metadata.BlockedRecovery,
 			}
 
-			transitioned := orch.recoverBlockedIssues(t.Context(), &state, []connector.Issue{issue}, observedAt)
+			recoveryAt := observedAt
+			if tt.recoveryAfter > 0 {
+				recoveryAt = parkedAt.Add(tt.recoveryAfter)
+			}
+			transitioned := orch.recoverBlockedIssues(t.Context(), &state, []connector.Issue{issue}, recoveryAt)
 
 			if tt.wantTransition {
 				if len(tracker.updates) != 1 || tracker.updates[0].state != "In Progress" {
@@ -610,6 +678,12 @@ func TestBlockedCauseRecoveryUsesCurrentCauseAfterDependencyResolution(t *testin
 			tracker := &dependencyAutoUnblockConnector{blockers: []connector.Issue{blocker}}
 			orch := blockedCauseTestOrchestrator(tracker)
 			orch.workflowMetrics = metrics
+			orch.cfg.DependencyAutoUnblock = normalizeDependencyAutoUnblockConfig(DependencyAutoUnblockConfig{
+				Enabled:      true,
+				SourceStates: []string{blockedStatusState},
+				TargetState:  "Todo",
+				Readiness:    DependencyReadinessTerminalOrMerged,
+			})
 			state := newState(orch.cfg)
 			if tt.seedStale {
 				state.Blocked[issue.ID] = Blocked{
@@ -619,6 +693,13 @@ func TestBlockedCauseRecoveryUsesCurrentCauseAfterDependencyResolution(t *testin
 					BlockedAt:      parkedAt,
 					Source:         BlockedSourceProjectStatus,
 				}
+			}
+
+			if transitioned := orch.autoUnblockDependencyIssues(t.Context(), &state, []connector.Issue{issue}, parkedAt.Add(time.Minute)); len(transitioned) != 0 {
+				t.Fatalf("dependency auto-unblock transitioned cause-owned park: %#v", transitioned)
+			}
+			if len(tracker.updates) != 0 {
+				t.Fatalf("dependency auto-unblock updates = %#v, want cause-owned park held", tracker.updates)
 			}
 
 			orch.recoverBlockedIssues(t.Context(), &state, []connector.Issue{issue}, parkedAt.Add(time.Minute))
@@ -984,6 +1065,29 @@ func TestBlockedCauseFingerprintTracksNormalizedLabels(t *testing.T) {
 	}
 }
 
+func TestBlockedCauseFingerprintIgnoresUnrelatedBaseForBreakerParks(t *testing.T) {
+	t.Parallel()
+
+	parked := blockedCauseSignals{ConfigFingerprint: "config-same", BaseFingerprint: "base-before", Health: "ready"}
+	current := parked
+	current.BaseFingerprint = "base-after-unrelated-merge"
+
+	for _, cause := range []string{
+		noProgressLimitReason,
+		dispatchLoopDetectedReason,
+		spendProgressReason,
+		repeatedFailureCircuitBreakerCause,
+		"token_ceiling_circuit_breaker",
+	} {
+		if blockedCauseFingerprint(cause, parked) != blockedCauseFingerprint(cause, current) {
+			t.Fatalf("breaker cause %q changed after unrelated base movement", cause)
+		}
+	}
+	if blockedCauseFingerprint(strandedUnpushedWorkReason, parked) == blockedCauseFingerprint(strandedUnpushedWorkReason, current) {
+		t.Fatal("non-breaker recovery fingerprint ignored base movement")
+	}
+}
+
 func TestBlockedCauseFingerprintIgnoresAttemptMutatedSignals(t *testing.T) {
 	t.Parallel()
 
@@ -1113,7 +1217,7 @@ func TestBlockedRecoveryMetadataSeparatesIntentFromReachability(t *testing.T) {
 	if !strings.Contains(raw, `"intent_resumable":true`) {
 		t.Fatalf("metadata = %s", raw)
 	}
-	if !strings.Contains(raw, `"cause_fingerprint_version":2`) {
+	if !strings.Contains(raw, `"cause_fingerprint_version":3`) {
 		t.Fatalf("metadata = %s", raw)
 	}
 	if strings.Contains(raw, `"resumable":true`) {

--- a/internal/orchestrator/blocked_recovery.go
+++ b/internal/orchestrator/blocked_recovery.go
@@ -14,6 +14,8 @@ import (
 
 const reworkBreakerStageUpdateSkew = time.Second
 
+const defaultBreakerParkCooldown = 24 * time.Hour
+
 const (
 	blockedRecoveryReasonMergeConflict        = "merge_conflict"
 	blockedRecoveryReasonStaleBase            = "stale_base"
@@ -21,10 +23,11 @@ const (
 )
 
 type BlockedRecoveryConfig struct {
-	Enabled      bool
-	SourceStates []string
-	TargetState  string
-	ReasonCodes  []string
+	Enabled         bool
+	SourceStates    []string
+	TargetState     string
+	ReasonCodes     []string
+	BreakerCooldown time.Duration
 }
 
 type BlockedRecoveryAction string
@@ -143,6 +146,9 @@ func normalizeBlockedRecoveryConfig(cfg BlockedRecoveryConfig) BlockedRecoveryCo
 		blockedRecoveryReasonStaleBase,
 		blockedRecoveryReasonMissingCurrentHeadCI,
 	}))
+	if cfg.BreakerCooldown <= 0 {
+		cfg.BreakerCooldown = defaultBreakerParkCooldown
+	}
 	return cfg
 }
 

--- a/internal/orchestrator/config.go
+++ b/internal/orchestrator/config.go
@@ -89,10 +89,11 @@ func ConfigFromWorkflow(cfg workflowconfig.Config) Config {
 			Readiness:    cfg.Tracker.DependencyAutoUnblock.Readiness,
 		}),
 		BlockedRecovery: normalizeBlockedRecoveryConfig(BlockedRecoveryConfig{
-			Enabled:      cfg.Tracker.BlockedRecovery.Enabled,
-			SourceStates: append([]string(nil), cfg.Tracker.BlockedRecovery.SourceStates...),
-			TargetState:  cfg.Tracker.BlockedRecovery.TargetState,
-			ReasonCodes:  append([]string(nil), cfg.Tracker.BlockedRecovery.ReasonCodes...),
+			Enabled:         cfg.Tracker.BlockedRecovery.Enabled,
+			SourceStates:    append([]string(nil), cfg.Tracker.BlockedRecovery.SourceStates...),
+			TargetState:     cfg.Tracker.BlockedRecovery.TargetState,
+			ReasonCodes:     append([]string(nil), cfg.Tracker.BlockedRecovery.ReasonCodes...),
+			BreakerCooldown: durationFromSeconds(cfg.Tracker.BlockedRecovery.BreakerCooldownSeconds),
 		}),
 		BlockerAutoPromote: BlockerAutoPromoteConfig{
 			Enabled:       cfg.Tracker.BlockerAutoPromote.Enabled,

--- a/internal/orchestrator/dependency_autounblock.go
+++ b/internal/orchestrator/dependency_autounblock.go
@@ -121,6 +121,14 @@ func (o *Orchestrator) autoUnblockDependencyIssues(
 			o.logDependencyAutoUnblockDecision(hydrated, "hold", "operator_stop", nil, "")
 			continue
 		}
+		if park, ok := o.currentBlockedRecoveryPark(ctx, state, hydrated); ok && strings.TrimSpace(park.Cause) != "" {
+			o.logDependencyAutoUnblockDecision(hydrated, "hold", "blocked_cause_recovery", nil, "")
+			continue
+		}
+		if stickyReason := o.issueStickyBlockReason(ctx, state, hydrated); stickyReason != "" {
+			o.logDependencyAutoUnblockDecision(hydrated, "hold", stickyReason, nil, "")
+			continue
+		}
 		if len(hydrated.BlockedBy) == 0 {
 			continue
 		}
@@ -129,10 +137,6 @@ func (o *Orchestrator) autoUnblockDependencyIssues(
 		workpadBlockers := dependencyBlockersMatchingRefs(blockers, workpadRefs)
 		if reason := o.blockedCauseHoldReason(hydrated, state, workpadBlockers, cfg, workpadCurrent); reason != "" {
 			o.logDependencyAutoUnblockDecision(hydrated, "hold", reason, blockers, "")
-			continue
-		}
-		if stickyReason := o.issueStickyBlockReason(ctx, state, hydrated); stickyReason != "" &&
-			(!dependencyBlockersReady(workpadBlockers, cfg, o.cfg.TerminalStates) || !workpadBlockerStickyOverrideAllowed(stickyReason)) {
 			continue
 		}
 		if !dependencyBlockersReady(blockers, cfg, o.cfg.TerminalStates) {
@@ -1071,20 +1075,17 @@ func blockedEntryMatchesCurrent(issue connector.Issue, enteredAt time.Time) bool
 func stickyBlockReason(reason string) bool {
 	reason = strings.ToLower(strings.TrimSpace(reason))
 	if strings.HasPrefix(reason, tokenCeilingBlockedReasonPrefix) ||
+		strings.HasPrefix(reason, repeatedFailureBlockedReasonPrefix) ||
 		strings.HasPrefix(reason, artifactGateConvergenceBlockedReasonPrefix) ||
 		strings.HasPrefix(reason, mergeWorkerRetryExhaustedReason) {
 		return true
 	}
 	switch reason {
-	case "rework_limit", string(AutoPromoteReasonMergeRevocationLimit), noProgressLimitReason, dispatchLoopDetectedReason, "workpad_blocked_unactioned", "circuit_breaker", "token_ceiling_circuit_breaker", artifactGateConvergenceReason:
+	case "rework_limit", string(AutoPromoteReasonMergeRevocationLimit), noProgressLimitReason, dispatchLoopDetectedReason, spendProgressReason, repeatedFailureCircuitBreakerCause, "workpad_blocked_unactioned", "circuit_breaker", "token_ceiling_circuit_breaker", artifactGateConvergenceReason:
 		return true
 	default:
 		return false
 	}
-}
-
-func workpadBlockerStickyOverrideAllowed(reason string) bool {
-	return strings.EqualFold(strings.TrimSpace(reason), noProgressLimitReason)
 }
 
 func (o *Orchestrator) dependencyAutoUnblockAlreadyConsumed(

--- a/internal/orchestrator/dependency_autounblock_test.go
+++ b/internal/orchestrator/dependency_autounblock_test.go
@@ -48,7 +48,6 @@ func TestTickRecoversCurrentWorkpadDependencyBlockers(t *testing.T) {
 			stickyReason:        noProgressLimitReason,
 			workpadUpdatedAt:    parkedAt.Add(-time.Minute),
 			previousLaneStarted: parkedAt.Add(-time.Hour),
-			wantTransition:      true,
 			wantWorkpadLookup:   true,
 		},
 		{
@@ -58,7 +57,22 @@ func TestTickRecoversCurrentWorkpadDependencyBlockers(t *testing.T) {
 			nativeDuplicate:     true,
 			workpadUpdatedAt:    parkedAt.Add(-time.Minute),
 			previousLaneStarted: parkedAt.Add(-time.Hour),
-			wantTransition:      true,
+			wantWorkpadLookup:   true,
+		},
+		{
+			name:                "resolved refs after spend breaker",
+			blockers:            []connector.Issue{resolved},
+			stickyReason:        spendProgressReason,
+			workpadUpdatedAt:    parkedAt.Add(-time.Minute),
+			previousLaneStarted: parkedAt.Add(-time.Hour),
+			wantWorkpadLookup:   true,
+		},
+		{
+			name:                "resolved refs after repeated failure breaker",
+			blockers:            []connector.Issue{resolved},
+			stickyReason:        repeatedFailureCircuitBreakerCause,
+			workpadUpdatedAt:    parkedAt.Add(-time.Minute),
+			previousLaneStarted: parkedAt.Add(-time.Hour),
 			wantWorkpadLookup:   true,
 		},
 		{

--- a/internal/orchestrator/dispatch_loop.go
+++ b/internal/orchestrator/dispatch_loop.go
@@ -197,8 +197,7 @@ func dispatchLoopFingerprintFromValues(lane string, signature autoPromoteReworkS
 }
 
 func dispatchLoopFingerprintEqual(left dispatchLoopFingerprint, right dispatchLoopFingerprint) bool {
-	return left.Lane == right.Lane &&
-		left.PRNumber == right.PRNumber &&
+	return left.PRNumber == right.PRNumber &&
 		left.PRHeadSHA == right.PRHeadSHA &&
 		slices.Equal(left.FailedChecks, right.FailedChecks) &&
 		left.FilesChanged == right.FilesChanged &&

--- a/internal/orchestrator/dispatch_loop_test.go
+++ b/internal/orchestrator/dispatch_loop_test.go
@@ -103,6 +103,19 @@ func TestEvaluateDispatchLoopProgress(t *testing.T) {
 			wantReason: implementDependencyDeferralReason,
 		},
 		{
+			name: "breaker park and release lane residency preserves count",
+			history: []store.WorkAttempt{
+				dispatchLoopHistoryAttemptInLane(2, store.WorkAttemptTerminalSuccess, autoPromoteReworkSignature{}, clean, nil, 2, "In Progress"),
+				dispatchLoopHistoryAttemptInLane(1, store.WorkAttemptTerminalSuccess, autoPromoteReworkSignature{}, clean, nil, 1, "In Progress"),
+			},
+			running:         dispatchLoopRunning("Rework", DiffStats{Status: "clean"}),
+			decision:        dispatchLoopDecision("Rework", store.WorkAttemptTerminalSuccess, autoPromoteReworkSignature{}, DiffStats{Status: "clean"}),
+			wantCount:       3,
+			wantBlock:       true,
+			wantReason:      dispatchLoopDetectedReason,
+			wantBlockReason: dispatchLoopDetectedReason,
+		},
+		{
 			name: "workpad-only changes do not reset",
 			history: []store.WorkAttempt{
 				dispatchLoopHistoryAttempt(2, store.WorkAttemptTerminalSuccess, autoPromoteReworkSignature{}, clean, []string{"audit_artifact"}, 2),
@@ -217,13 +230,25 @@ func dispatchLoopHistoryAttempt(
 	progressKinds []string,
 	count int,
 ) store.WorkAttempt {
+	return dispatchLoopHistoryAttemptInLane(id, terminal, signature, diff, progressKinds, count, "Rework")
+}
+
+func dispatchLoopHistoryAttemptInLane(
+	id int64,
+	terminal store.WorkAttemptTerminalState,
+	signature autoPromoteReworkSignature,
+	diff implementProgressDiffStats,
+	progressKinds []string,
+	count int,
+	lane string,
+) store.WorkAttempt {
 	return store.WorkAttempt{
 		ID:            id,
 		ProjectID:     "detent",
 		IssueID:       "issue-loop",
 		Identifier:    "digitaldrywood/detent#1886",
 		WorkerType:    "agent",
-		Lane:          "Rework",
+		Lane:          lane,
 		Status:        store.WorkAttemptStatusTerminal,
 		TerminalState: terminal,
 		CompletedAt:   time.Date(2026, 8, 18, 14, int(id), 0, 0, time.UTC),
@@ -233,7 +258,7 @@ func dispatchLoopHistoryAttempt(
 				Reason:                implementDependencyDeferralReason,
 				CurrentSignature:      implementProgressSignatureRecordFromSignature(signature),
 				WorkspaceDiffStats:    diff,
-				TrackerState:          "Rework",
+				TrackerState:          lane,
 				ConsecutiveNoProgress: count,
 				NoProgressLimit:       3,
 				ProgressKinds:         progressKinds,

--- a/internal/orchestrator/dispatch_test.go
+++ b/internal/orchestrator/dispatch_test.go
@@ -262,10 +262,11 @@ func TestConfigFromWorkflowIncludesDispatchControls(t *testing.T) {
 	cfg.Tracker.Claims.TTLSeconds = 300
 	cfg.Tracker.Claims.HeartbeatSeconds = 45
 	cfg.Tracker.BlockedRecovery = workflowconfig.BlockedRecovery{
-		Enabled:      true,
-		SourceStates: []string{"Blocked", "Parked"},
-		TargetState:  "Repair",
-		ReasonCodes:  []string{"merge_conflict", "stale_base"},
+		Enabled:                true,
+		SourceStates:           []string{"Blocked", "Parked"},
+		TargetState:            "Repair",
+		ReasonCodes:            []string{"merge_conflict", "stale_base"},
+		BreakerCooldownSeconds: 12 * 60 * 60,
 	}
 	cfg.Tracker.PriorityMap = workflowconfig.StringOrMap{IsMap: true, Map: map[string]any{"Critical": 1, "Normal": 3, "No priority": nil}}
 	staggerSeconds := 20
@@ -311,7 +312,8 @@ func TestConfigFromWorkflowIncludesDispatchControls(t *testing.T) {
 	if !got.BlockedRecovery.Enabled ||
 		!slices.Equal(got.BlockedRecovery.SourceStates, []string{"blocked", "parked"}) ||
 		got.BlockedRecovery.TargetState != "Repair" ||
-		!slices.Equal(got.BlockedRecovery.ReasonCodes, []string{"merge_conflict", "stale_base"}) {
+		!slices.Equal(got.BlockedRecovery.ReasonCodes, []string{"merge_conflict", "stale_base"}) ||
+		got.BlockedRecovery.BreakerCooldown != 12*time.Hour {
 		t.Fatalf("BlockedRecovery = %#v, want configured recovery policy", got.BlockedRecovery)
 	}
 	if got.WorkspaceCleanupIdleTTL != 2*time.Hour {


### PR DESCRIPTION
## Summary

- keep breaker-owned Blocked parks out of dependency and recorded-blocker auto-recovery
- require a configurable 24-hour cooldown plus issue-specific cause-fingerprint change before generic breaker recovery
- preserve dispatch-loop counts across Blocked lane residency and cover cooldown restart behavior

Fixes #1924

## UI Surface Contract

- [x] N/A; this PR has no UI changes.
- [x] This PR does not add persistent top-of-screen messaging.
- [x] N/A; this PR has no visual changes to operator screens.

## Test Plan

- [x] `make check`
- [x] Focused orchestrator recovery and dispatch-loop regression tests
- [x] Config generation and validation tests