### PR TITLE
fix(local): dedupe JSON field warnings

### DIFF
--- a/internal/connector/local/local.go
+++ b/internal/connector/local/local.go
@@ -1,6 +1,7 @@
 package local
 
 import (
+	"bytes"
 	"context"
 	"database/sql"
 	"encoding/json"
@@ -10,6 +11,7 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -1067,11 +1069,15 @@ where project_id = ?`
 	defer rows.Close()
 
 	issues := []connector.Issue{}
+	warningSummaries := map[fieldHydrationWarningKey]*fieldHydrationWarningSummary{}
 	for rows.Next() {
-		issue, err := c.scanIssue(rows)
+		issue, warnings, err := c.scanIssue(rows)
 		if err != nil {
 			closeErr := rows.Close()
 			return nil, errors.Join(err, closeErr)
+		}
+		for _, warning := range warnings {
+			addFieldHydrationWarning(warningSummaries, c.projectID, issue.ID, warning)
 		}
 		issues = append(issues, issue)
 	}
@@ -1082,6 +1088,7 @@ where project_id = ?`
 	if err := rows.Close(); err != nil {
 		return nil, err
 	}
+	c.logFieldHydrationWarnings(warningSummaries)
 	for i := range issues {
 		comments, err := c.FetchIssueComments(ctx, issues[i])
 		if err != nil {
@@ -1216,7 +1223,7 @@ type issueScanner interface {
 	Scan(dest ...any) error
 }
 
-func (c *Connector) scanIssue(scanner issueScanner) (connector.Issue, error) {
+func (c *Connector) scanIssue(scanner issueScanner) (connector.Issue, []fieldHydrationWarning, error) {
 	var issue connector.Issue
 	var projectID string
 	var priority sql.NullInt64
@@ -1237,7 +1244,7 @@ func (c *Connector) scanIssue(scanner issueScanner) (connector.Issue, error) {
 		&githubNodeID, &githubRepositoryID, &githubIssueNumber, &githubUpstreamState, &githubOrphaned,
 	)
 	if err != nil {
-		return connector.Issue{}, err
+		return connector.Issue{}, nil, err
 	}
 	if priority.Valid {
 		value := int(priority.Int64)
@@ -1255,15 +1262,6 @@ func (c *Connector) scanIssue(scanner issueScanner) (connector.Issue, error) {
 		)
 	} else {
 		issue.Fields = fields
-		for _, warning := range warnings {
-			c.logger.Warn("local sqlite work item field has non-string JSON value",
-				"project_id", projectID,
-				"issue_id", issue.ID,
-				"field", warning.field,
-				"json_type", warning.jsonType,
-				"action", warning.action,
-			)
-		}
 	}
 	issue.Metadata = unmarshalStringMap(metadataJSON)
 	applyGitHubIdentityMetadata(&issue, githubIdentity{
@@ -1281,7 +1279,7 @@ func (c *Connector) scanIssue(scanner issueScanner) (connector.Issue, error) {
 	if deliverableHasContent(deliverable) {
 		issue.Deliverable = &deliverable
 	}
-	return issue, nil
+	return issue, warnings, nil
 }
 
 func deliverableHasContent(deliverable connector.Deliverable) bool {
@@ -1539,6 +1537,68 @@ type fieldHydrationWarning struct {
 	action   string
 }
 
+type fieldHydrationWarningKey struct {
+	projectID string
+	field     string
+}
+
+type fieldHydrationWarningSummary struct {
+	key         fieldHydrationWarningKey
+	issueID     string
+	jsonType    string
+	action      string
+	repeatCount int
+}
+
+func addFieldHydrationWarning(
+	summaries map[fieldHydrationWarningKey]*fieldHydrationWarningSummary,
+	projectID string,
+	issueID string,
+	warning fieldHydrationWarning,
+) {
+	key := fieldHydrationWarningKey{projectID: projectID, field: warning.field}
+	summary := summaries[key]
+	if summary == nil {
+		summaries[key] = &fieldHydrationWarningSummary{
+			key:      key,
+			issueID:  issueID,
+			jsonType: warning.jsonType,
+			action:   warning.action,
+		}
+		return
+	}
+	summary.repeatCount++
+	if summary.jsonType != warning.jsonType {
+		summary.jsonType = "mixed"
+	}
+	if summary.action != warning.action {
+		summary.action = "mixed"
+	}
+}
+
+func (c *Connector) logFieldHydrationWarnings(summaries map[fieldHydrationWarningKey]*fieldHydrationWarningSummary) {
+	ordered := make([]*fieldHydrationWarningSummary, 0, len(summaries))
+	for _, summary := range summaries {
+		ordered = append(ordered, summary)
+	}
+	sort.Slice(ordered, func(i, j int) bool {
+		if ordered[i].key.projectID != ordered[j].key.projectID {
+			return ordered[i].key.projectID < ordered[j].key.projectID
+		}
+		return ordered[i].key.field < ordered[j].key.field
+	})
+	for _, summary := range ordered {
+		c.logger.Warn("local sqlite work item field has non-string JSON value",
+			"project_id", summary.key.projectID,
+			"issue_id", summary.issueID,
+			"field", summary.key.field,
+			"json_type", summary.jsonType,
+			"action", summary.action,
+			"repeat_count", summary.repeatCount,
+		)
+	}
+}
+
 func unmarshalIssueFields(raw string) (map[string]string, []fieldHydrationWarning, error) {
 	var encoded map[string]json.RawMessage
 	if err := json.Unmarshal([]byte(strings.TrimSpace(raw)), &encoded); err != nil {
@@ -1549,15 +1609,11 @@ func unmarshalIssueFields(raw string) (map[string]string, []fieldHydrationWarnin
 	warnings := make([]fieldHydrationWarning, 0)
 	for field, encodedValue := range encoded {
 		value, jsonType, ok := issueFieldString(encodedValue)
-		if jsonType != "string" {
-			action := "skipped"
-			if ok {
-				action = "stringified"
-			}
+		if !ok {
 			warnings = append(warnings, fieldHydrationWarning{
 				field:    field,
 				jsonType: jsonType,
-				action:   action,
+				action:   "skipped",
 			})
 		}
 		if ok {
@@ -1589,7 +1645,11 @@ func issueFieldString(raw json.RawMessage) (string, string, bool) {
 	case 'n':
 		return "null", "null", true
 	case '[':
-		return "", "array", false
+		var compact bytes.Buffer
+		if err := json.Compact(&compact, raw); err != nil {
+			return "", "invalid", false
+		}
+		return compact.String(), "array", true
 	case '{':
 		return "", "object", false
 	default:

--- a/internal/connector/local/local_test.go
+++ b/internal/connector/local/local_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"database/sql"
 	"errors"
+	"fmt"
 	"log/slog"
 	"path/filepath"
 	"strconv"
@@ -121,16 +122,19 @@ func TestConnectorFetchesMixedTypeWorkItemFields(t *testing.T) {
 	t.Parallel()
 
 	ctx := t.Context()
-	issue := connector.NewIssue()
-	issue.ID = "mock-1"
-	issue.Identifier = "video/mock-1"
-	issue.State = "Review"
+	issues := make([]connector.Issue, 2)
+	for index := range issues {
+		issues[index] = connector.NewIssue()
+		issues[index].ID = fmt.Sprintf("mock-%d", index+1)
+		issues[index].Identifier = "video/" + issues[index].ID
+		issues[index].State = "Review"
+	}
 	var logs bytes.Buffer
 
 	store, err := New(Config{
 		Path:      filepath.Join(t.TempDir(), "mixed-fields.db"),
 		ProjectID: "video",
-		Issues:    []connector.Issue{issue},
+		Issues:    issues,
 		Logger: slog.New(slog.NewTextHandler(&logs, &slog.HandlerOptions{
 			Level: slog.LevelWarn,
 		})),
@@ -144,54 +148,93 @@ func TestConnectorFetchesMixedTypeWorkItemFields(t *testing.T) {
 		}
 	})
 
-	const fieldsJSON = `{"gate":"mock","slug":"demo","render_status":"recut","review_round":6,"approved":true,"quality":null,"nested":{"stage":1},"cuts":[1,2]}`
+	const fieldsJSON = `{"gate":"mock","slug":"demo","render_status":"recut","review_round":6,"review_addressed_feedback":["@ 1:23 — fix it"],"approved":true,"quality":null,"nested":{"stage":1}}`
 	if _, err := store.db.ExecContext(ctx, `
-update detent_work_items set fields_json = ? where project_id = ? and id = ?`,
-		fieldsJSON, "video", issue.ID); err != nil {
+update detent_work_items set fields_json = ? where project_id = ?`, fieldsJSON, "video"); err != nil {
 		t.Fatalf("update fields_json error = %v", err)
 	}
 
-	issues, err := store.FetchIssuesByStates(ctx, []string{"Review"})
+	gotIssues, err := store.FetchIssuesByStates(ctx, []string{"Review"})
 	if err != nil {
 		t.Fatalf("FetchIssuesByStates() error = %v", err)
 	}
-	if len(issues) != 1 {
-		t.Fatalf("FetchIssuesByStates() len = %d, want 1", len(issues))
+	if len(gotIssues) != len(issues) {
+		t.Fatalf("FetchIssuesByStates() len = %d, want %d", len(gotIssues), len(issues))
 	}
 	want := map[string]string{
-		"gate":          "mock",
-		"slug":          "demo",
-		"render_status": "recut",
-		"review_round":  "6",
-		"approved":      "true",
-		"quality":       "null",
+		"gate":                      "mock",
+		"slug":                      "demo",
+		"render_status":             "recut",
+		"review_round":              "6",
+		"review_addressed_feedback": `["@ 1:23 — fix it"]`,
+		"approved":                  "true",
+		"quality":                   "null",
 	}
-	if len(issues[0].Fields) != len(want) {
-		t.Fatalf("Fields = %#v, want %#v", issues[0].Fields, want)
-	}
-	for field, value := range want {
-		if issues[0].Fields[field] != value {
-			t.Errorf("Fields[%q] = %q, want %q", field, issues[0].Fields[field], value)
+	for _, issue := range gotIssues {
+		if len(issue.Fields) != len(want) {
+			t.Fatalf("Fields = %#v, want %#v", issue.Fields, want)
+		}
+		for field, value := range want {
+			if issue.Fields[field] != value {
+				t.Errorf("Fields[%q] = %q, want %q", field, issue.Fields[field], value)
+			}
+		}
+		if value, ok := issue.Fields["nested"]; ok {
+			t.Errorf("Fields[%q] = %q, want field omitted", "nested", value)
 		}
 	}
-	for _, field := range []string{"nested", "cuts"} {
-		if value, ok := issues[0].Fields[field]; ok {
-			t.Errorf("Fields[%q] = %q, want field omitted", field, value)
-		}
+	if count := strings.Count(logs.String(), "local sqlite work item field has non-string JSON value"); count != 1 {
+		t.Fatalf("field warning count = %d, want 1:\n%s", count, logs.String())
 	}
-	if count := strings.Count(logs.String(), "local sqlite work item field has non-string JSON value"); count != 5 {
-		t.Fatalf("field warning count = %d, want 5:\n%s", count, logs.String())
-	}
-	for _, warning := range []string{
-		"field=review_round json_type=number action=stringified",
-		"field=approved json_type=boolean action=stringified",
-		"field=quality json_type=null action=stringified",
-		"field=nested json_type=object action=skipped",
-		"field=cuts json_type=array action=skipped",
+	for _, wantLog := range []string{
+		"project_id=video",
+		"field=nested",
+		"json_type=object",
+		"action=skipped",
+		"repeat_count=1",
 	} {
-		if !strings.Contains(logs.String(), warning) {
-			t.Errorf("logs missing %q:\n%s", warning, logs.String())
+		if !strings.Contains(logs.String(), wantLog) {
+			t.Errorf("logs missing %q:\n%s", wantLog, logs.String())
 		}
+	}
+	for _, field := range []string{"review_round", "review_addressed_feedback"} {
+		if strings.Contains(logs.String(), "field="+field) {
+			t.Errorf("logs contain accepted field %q:\n%s", field, logs.String())
+		}
+	}
+}
+
+func TestUnmarshalIssueFields(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name         string
+		raw          string
+		wantValue    string
+		wantWarnings int
+	}{
+		{name: "string", raw: `{"field":"value"}`, wantValue: "value"},
+		{name: "number", raw: `{"field":6}`, wantValue: "6"},
+		{name: "boolean", raw: `{"field":true}`, wantValue: "true"},
+		{name: "null", raw: `{"field":null}`, wantValue: "null"},
+		{name: "array", raw: `{"field":["one","two"]}`, wantValue: `["one","two"]`},
+		{name: "object", raw: `{"field":{"nested":true}}`, wantWarnings: 1},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			fields, warnings, err := unmarshalIssueFields(tt.raw)
+			if err != nil {
+				t.Fatalf("unmarshalIssueFields() error = %v", err)
+			}
+			if fields["field"] != tt.wantValue {
+				t.Errorf("unmarshalIssueFields() field = %q, want %q", fields["field"], tt.wantValue)
+			}
+			if len(warnings) != tt.wantWarnings {
+				t.Errorf("unmarshalIssueFields() warnings = %#v, want %d", warnings, tt.wantWarnings)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## Summary

- hydrate numeric, boolean, null, and list-shaped local SQLite work-item fields without warning
- aggregate unsupported field warnings by project and field per fetch with a repeat counter
- cover the Video Studio review-field contract and repeated-warning behavior

Fixes #1931

## UI Surface Contract

- [x] N/A; this PR does not change a UI surface, layout, density, first viewport, or responsive visibility.
- [x] This PR does not add persistent top-of-screen messaging.
- [x] N/A; this PR has no visual changes to operator screens.

## Test Plan

- [x] `go test ./internal/connector/local -count=1`
- [x] `go test ./internal/orchestrator -run "TestLocalSQLiteArtifactReworkUsesConfiguredStatusField|TestLocalSQLiteArtifactLifecycleEndToEnd" -count=1`
- [x] `PATH="$TMPDIR/bin:$PATH" GOTOOLCHAIN=go1.26.6 GOLANGCI_LINT_CACHE="$TMPDIR/golangci-cache" make check` with CI-pinned golangci-lint v2.1.6
