### PR TITLE
fix(orchestrator): bound retry repair loops

### DIFF
--- a/internal/orchestrator/backend_capacity.go
+++ b/internal/orchestrator/backend_capacity.go
@@ -60,7 +60,7 @@ func (o *Orchestrator) handleBackendCapacityError(
 ) {
 	running = o.restoreBackendCapacityIssueState(ctx, state, running, event.CompletedAt)
 	outage := o.registerBackendOutage(state, capacityErr, event.CompletedAt, running.CapacityProbe)
-	o.completeDurableWorkAttempt(
+	attemptCompleted := o.completeDurableWorkAttemptWithMetadata(
 		ctx,
 		state,
 		running,
@@ -70,12 +70,27 @@ func (o *Orchestrator) handleBackendCapacityError(
 		event.Err.Error(),
 		"waiting",
 		backendCapacityStatusMessage(outage),
+		nil,
 	)
 	if workspaceIssueTerminal(running.Issue, o.cfg.TerminalStates) {
 		o.releaseClaim(state, running.Issue.ID)
 		return
 	}
-	running.Issue, _ = o.demoteTerminalAttemptRetry(ctx, state, running.Issue, running.WorkProductPushed, event.CompletedAt)
+	var parked bool
+	running.Issue, _, parked = o.demoteTerminalAttemptRetry(
+		ctx,
+		state,
+		running.Issue,
+		running.WorkProductPushed,
+		terminalAttemptRetryLimitCause,
+		attemptCompleted,
+		running.Mode,
+		running.DiffStats,
+		event.CompletedAt,
+	)
+	if parked {
+		return
+	}
 	o.scheduleBackendCapacityRetry(state, running, outage)
 	recordStateEvent(state, telemetry.ActivityEvent{
 		At:      event.CompletedAt,

--- a/internal/orchestrator/blocked_cause_recovery.go
+++ b/internal/orchestrator/blocked_cause_recovery.go
@@ -238,7 +238,13 @@ func breakerParkCause(cause string) bool {
 		return true
 	}
 	switch cause {
-	case dispatchLoopDetectedReason, noProgressLimitReason, spendProgressReason, repeatedFailureCircuitBreakerCause, "token_ceiling_circuit_breaker":
+	case dispatchLoopDetectedReason,
+		noProgressLimitReason,
+		spendProgressReason,
+		repeatedFailureCircuitBreakerCause,
+		"token_ceiling_circuit_breaker",
+		terminalAttemptRetryLimitCause,
+		workspacePreparationRetryLimitCause:
 		return true
 	default:
 		return false
@@ -652,7 +658,11 @@ func blockedReadyPullRequestRecoverableCause(park workflowLaneBlockedRecoveryMet
 	if owner != blockedRecoveryOwnerOrchestrator || strings.TrimSpace(park.RunMode) != RunModeImplement {
 		return false
 	}
-	return cause == strandedUnpushedWorkReason || cause == noProgressLimitReason || cause == dispatchLoopDetectedReason || cause == repeatedFailureCircuitBreakerCause
+	return cause == strandedUnpushedWorkReason ||
+		cause == noProgressLimitReason ||
+		cause == dispatchLoopDetectedReason ||
+		cause == repeatedFailureCircuitBreakerCause ||
+		cause == terminalAttemptRetryLimitCause
 }
 
 func (o *Orchestrator) blockedReadyPullRequestDeferredReason(

--- a/internal/orchestrator/blocked_cause_recovery_test.go
+++ b/internal/orchestrator/blocked_cause_recovery_test.go
@@ -462,6 +462,16 @@ func TestCauseBlockedRecoveryCooldownSurvivesRestart(t *testing.T) {
 	}
 }
 
+func TestBreakerParkCauseIncludesRetryCycleLimits(t *testing.T) {
+	t.Parallel()
+
+	for _, cause := range []string{terminalAttemptRetryLimitCause, workspacePreparationRetryLimitCause} {
+		if !breakerParkCause(cause) {
+			t.Fatalf("breakerParkCause(%q) = false, want true", cause)
+		}
+	}
+}
+
 func TestRepeatedFailureParkRecoveryUsesRecordedRESTBudgetFailures(t *testing.T) {
 	t.Parallel()
 

--- a/internal/orchestrator/dependency_autounblock.go
+++ b/internal/orchestrator/dependency_autounblock.go
@@ -1081,7 +1081,18 @@ func stickyBlockReason(reason string) bool {
 		return true
 	}
 	switch reason {
-	case "rework_limit", string(AutoPromoteReasonMergeRevocationLimit), noProgressLimitReason, dispatchLoopDetectedReason, spendProgressReason, repeatedFailureCircuitBreakerCause, "workpad_blocked_unactioned", "circuit_breaker", "token_ceiling_circuit_breaker", artifactGateConvergenceReason:
+	case "rework_limit",
+		string(AutoPromoteReasonMergeRevocationLimit),
+		noProgressLimitReason,
+		dispatchLoopDetectedReason,
+		spendProgressReason,
+		repeatedFailureCircuitBreakerCause,
+		"workpad_blocked_unactioned",
+		"circuit_breaker",
+		"token_ceiling_circuit_breaker",
+		artifactGateConvergenceReason,
+		terminalAttemptRetryLimitCause,
+		workspacePreparationRetryLimitCause:
 		return true
 	default:
 		return false

--- a/internal/orchestrator/github_rest_capacity.go
+++ b/internal/orchestrator/github_rest_capacity.go
@@ -150,7 +150,7 @@ func (o *Orchestrator) handleGitHubRESTCapacityCompletion(
 	if event.Err != nil {
 		errorMessage = event.Err.Error()
 	}
-	o.completeDurableWorkAttempt(
+	attemptCompleted := o.completeDurableWorkAttemptWithMetadata(
 		ctx,
 		state,
 		running,
@@ -160,12 +160,27 @@ func (o *Orchestrator) handleGitHubRESTCapacityCompletion(
 		errorMessage,
 		"waiting",
 		githubRESTCapacityStatusMessage(outage),
+		nil,
 	)
 	if workspaceIssueTerminal(running.Issue, o.cfg.TerminalStates) {
 		o.releaseClaim(state, running.Issue.ID)
 		return true
 	}
-	running.Issue, _ = o.demoteTerminalAttemptRetry(ctx, state, running.Issue, running.WorkProductPushed, event.CompletedAt)
+	var parked bool
+	running.Issue, _, parked = o.demoteTerminalAttemptRetry(
+		ctx,
+		state,
+		running.Issue,
+		running.WorkProductPushed,
+		terminalAttemptRetryLimitCause,
+		attemptCompleted,
+		running.Mode,
+		running.DiffStats,
+		event.CompletedAt,
+	)
+	if parked {
+		return true
+	}
 	o.scheduleBackendCapacityRetry(state, running, outage)
 	recordStateEvent(state, telemetry.ActivityEvent{
 		At:      event.CompletedAt,

--- a/internal/orchestrator/implement_progress_test.go
+++ b/internal/orchestrator/implement_progress_test.go
@@ -1193,6 +1193,8 @@ func TestStickyBlockReasonIncludesCircuitBreakers(t *testing.T) {
 	for _, reason := range []string{
 		noProgressLimitReason,
 		dispatchLoopDetectedReason,
+		terminalAttemptRetryLimitCause,
+		workspacePreparationRetryLimitCause,
 		workpadBlockedUnactionedReason,
 		"token_ceiling_circuit_breaker",
 		tokenCeilingBlockedReasonPrefix + "observed 16100000 tokens above the 16000000 max_session_tokens ceiling",

--- a/internal/orchestrator/run_completion.go
+++ b/internal/orchestrator/run_completion.go
@@ -367,7 +367,7 @@ func (o *Orchestrator) handleRunResult(ctx context.Context, state *State, event 
 			statusMessage = "no-progress circuit breaker tripped"
 		}
 		o.recordProjectAttemptOutcome(state, event.IssueID, event.CompletedAt, terminalState, event.Err, errorClass, errorMessage)
-		o.completeDurableWorkAttemptWithMetadata(ctx, state, running, event.CompletedAt, terminalState, errorClass, errorMessage, phase, statusMessage, mergeWorkAttemptMetadata(
+		attemptCompleted := o.completeDurableWorkAttemptWithMetadata(ctx, state, running, event.CompletedAt, terminalState, errorClass, errorMessage, phase, statusMessage, mergeWorkAttemptMetadata(
 			progressMetadata,
 			spendProgressMetadata(spendProgress),
 		))
@@ -403,7 +403,21 @@ func (o *Orchestrator) handleRunResult(ctx context.Context, state *State, event 
 			return
 		}
 		if terminalAttemptStateRetryDemotable(terminalState) {
-			running.Issue, _ = o.demoteTerminalAttemptRetry(ctx, state, running.Issue, running.WorkProductPushed, event.CompletedAt)
+			var parked bool
+			running.Issue, _, parked = o.demoteTerminalAttemptRetry(
+				ctx,
+				state,
+				running.Issue,
+				running.WorkProductPushed,
+				terminalAttemptRetryLimitCause,
+				attemptCompleted,
+				running.Mode,
+				running.DiffStats,
+				event.CompletedAt,
+			)
+			if parked {
+				return
+			}
 		}
 		delay := event.RetryDelay
 		if delay <= 0 {
@@ -639,9 +653,38 @@ func (o *Orchestrator) handleWorkspacePreparationFailure(
 		"error", event.Err,
 	)
 	o.recordProjectAttemptOutcome(state, event.IssueID, event.CompletedAt, store.WorkAttemptTerminalFailure, event.Err, workAttemptErrorWorkspace, errorMessage)
-	o.completeDurableWorkAttempt(ctx, state, running, event.CompletedAt, store.WorkAttemptTerminalFailure, workAttemptErrorWorkspace, errorMessage, "workspace_repair", "workspace preparation failed")
-	delete(state.InstantFailures, event.IssueID)
-	delete(state.RepeatedFailures, event.IssueID)
+	attemptCompleted := o.completeDurableWorkAttemptWithMetadata(
+		ctx,
+		state,
+		running,
+		event.CompletedAt,
+		store.WorkAttemptTerminalFailure,
+		workAttemptErrorWorkspace,
+		errorMessage,
+		"workspace_repair",
+		"workspace preparation failed",
+		nil,
+	)
+	if attemptCompleted {
+		count, known := o.consecutiveRetryCycleCount(ctx, state, running.Issue, workspacePreparationRetryLimitCause, event.CompletedAt)
+		switch {
+		case !known:
+			o.recordRetryCycleHistoryUnavailable(state, running.Issue, workspacePreparationRetryLimitCause, event.CompletedAt)
+		case count >= consecutiveRetryCycleLimit:
+			if _, parked := o.parkRetryCycleLimit(
+				ctx,
+				state,
+				running.Issue,
+				running.Mode,
+				running.DiffStats,
+				workspacePreparationRetryLimitCause,
+				count,
+				event.CompletedAt,
+			); parked {
+				return
+			}
+		}
+	}
 	attempt := event.RetryAttempt
 	if attempt < 1 {
 		attempt = nextAttempt(running.Attempt)

--- a/internal/orchestrator/terminal_attempt_retry.go
+++ b/internal/orchestrator/terminal_attempt_retry.go
@@ -3,6 +3,9 @@ package orchestrator
 import (
 	"context"
 	"encoding/json"
+	"fmt"
+	"log/slog"
+	"sort"
 	"strings"
 	"time"
 
@@ -11,25 +14,50 @@ import (
 	"github.com/digitaldrywood/detent/internal/telemetry"
 )
 
-const terminalAttemptWithoutWorkProductReason = "terminal_attempt_without_work_product"
+const (
+	terminalAttemptWithoutWorkProductReason     = "terminal_attempt_without_work_product"
+	terminalAttemptRetryLimitCause              = "terminal_attempt_retry_limit"
+	workspacePreparationRetryLimitCause         = "workspace_preparation_retry_limit"
+	consecutiveRetryCycleLimit                  = 3
+	terminalAttemptRetryLimitEvent              = "terminal_attempt_retry_limit_reached"
+	workspacePreparationRetryLimitEvent         = "workspace_preparation_retry_limit_reached"
+	terminalAttemptRetryHistoryUnavailableEvent = "terminal_attempt_retry_history_unavailable"
+	workspaceRetryHistoryUnavailableEvent       = "workspace_preparation_retry_history_unavailable"
+)
 
 func (o *Orchestrator) demoteTerminalAttemptRetry(
 	ctx context.Context,
 	state *State,
 	issue connector.Issue,
 	workProductPushed bool,
+	retryCause string,
+	durable bool,
+	runMode string,
+	diffStats DiffStats,
 	at time.Time,
-) (connector.Issue, bool) {
+) (connector.Issue, bool, bool) {
 	if o == nil || o.connector == nil ||
 		normalizeState(issue.State) != normalizeState(planImplementationState) ||
 		terminalAttemptHasWorkProduct(issue, workProductPushed) ||
 		pullRequestHydrationBlocksProgress(issue.PullRequest) ||
 		o.terminalAttemptClaimBlocksDemotion(ctx, issue, at) {
-		return issue, false
+		return issue, false, false
+	}
+	if durable {
+		count, known := o.consecutiveRetryCycleCount(ctx, state, issue, retryCause, at)
+		switch {
+		case !known:
+			o.recordRetryCycleHistoryUnavailable(state, issue, retryCause, at)
+		case count >= consecutiveRetryCycleLimit:
+			parked, ok := o.parkRetryCycleLimit(ctx, state, issue, runMode, diffStats, retryCause, count, at)
+			if ok {
+				return parked, true, true
+			}
+		}
 	}
 	targetState := terminalAttemptTodoState(o.cfg.ActiveStates)
 	if targetState == "" {
-		return issue, false
+		return issue, false, false
 	}
 	if err := o.updateIssueState(ctx, state, issue, targetState, at, terminalAttemptWithoutWorkProductReason); err != nil {
 		if o.logger != nil {
@@ -47,7 +75,7 @@ func (o *Orchestrator) demoteTerminalAttemptRetry(
 			Event:   "terminal_attempt_retry_demotion_failed",
 			Message: "failed to move " + issueLabel(issue) + " to " + targetState + " after a terminal attempt without pushed work",
 		})
-		return issue, false
+		return issue, false, false
 	}
 
 	fromState := issue.State
@@ -75,7 +103,221 @@ func (o *Orchestrator) demoteTerminalAttemptRetry(
 			"reason", terminalAttemptWithoutWorkProductReason,
 		)
 	}
+	return issue, true, false
+}
+
+func (o *Orchestrator) consecutiveRetryCycleCount(
+	ctx context.Context,
+	state *State,
+	issue connector.Issue,
+	cause string,
+	at time.Time,
+) (int, bool) {
+	attempts, ok := o.recentIssueTerminalAttempts(ctx, state, issue, consecutiveRetryCycleLimit, at)
+	if !ok {
+		return 0, false
+	}
+	count := 0
+	for _, attempt := range attempts {
+		if !retryCycleAttemptMatches(attempt, cause) {
+			break
+		}
+		count++
+	}
+	return count, true
+}
+
+func (o *Orchestrator) recentIssueTerminalAttempts(
+	ctx context.Context,
+	state *State,
+	issue connector.Issue,
+	limit int,
+	at time.Time,
+) ([]telemetry.WorkAttempt, bool) {
+	byID := make(map[int64]telemetry.WorkAttempt)
+	withoutID := make([]telemetry.WorkAttempt, 0)
+	add := func(attempt telemetry.WorkAttempt) {
+		if !workAttemptMatchesIssue(attempt, issue) ||
+			!strings.EqualFold(strings.TrimSpace(attempt.Status), string(store.WorkAttemptStatusTerminal)) {
+			return
+		}
+		if attempt.AttemptID > 0 {
+			byID[attempt.AttemptID] = attempt
+			return
+		}
+		withoutID = append(withoutID, attempt)
+	}
+	if state != nil {
+		for _, attempt := range state.WorkAttempts {
+			add(attempt)
+		}
+	}
+	if o != nil && o.workAttempts != nil {
+		stored, err := o.workAttempts.ListRecentTerminalWorkAttempts(ctx, store.WorkAttemptHistoryQuery{
+			ProjectID:  strings.TrimSpace(o.cfg.Project.ID),
+			IssueID:    strings.TrimSpace(issue.ID),
+			Identifier: strings.TrimSpace(issue.Identifier),
+			IssueURL:   strings.TrimSpace(issue.URL),
+			Limit:      limit,
+		})
+		if err != nil {
+			if o.logger != nil {
+				o.logger.Warn("retry cycle work attempt history lookup failed", "issue_id", issue.ID, "identifier", issue.Identifier, "error", err)
+			}
+			return nil, false
+		}
+		for _, attempt := range stored {
+			add(telemetryWorkAttempt(attempt, at))
+		}
+	}
+	attempts := make([]telemetry.WorkAttempt, 0, len(byID)+len(withoutID))
+	for _, attempt := range byID {
+		attempts = append(attempts, attempt)
+	}
+	attempts = append(attempts, withoutID...)
+	sort.Slice(attempts, func(left, right int) bool {
+		return workAttemptCompletedAfter(attempts[left], attempts[right])
+	})
+	if limit > 0 && len(attempts) > limit {
+		attempts = attempts[:limit]
+	}
+	return attempts, true
+}
+
+func workAttemptMatchesIssue(attempt telemetry.WorkAttempt, issue connector.Issue) bool {
+	if issueID := strings.TrimSpace(issue.ID); issueID != "" && strings.TrimSpace(attempt.IssueID) == issueID {
+		return true
+	}
+	if identifier := strings.TrimSpace(issue.Identifier); identifier != "" && strings.TrimSpace(attempt.Identifier) == identifier {
+		return true
+	}
+	issueURL := strings.TrimSpace(issue.URL)
+	return issueURL != "" && strings.TrimSpace(attempt.IssueURL) == issueURL
+}
+
+func retryCycleAttemptMatches(attempt telemetry.WorkAttempt, cause string) bool {
+	switch strings.TrimSpace(cause) {
+	case workspacePreparationRetryLimitCause:
+		return strings.TrimSpace(attempt.ErrorClass) == workAttemptErrorWorkspace &&
+			strings.EqualFold(strings.TrimSpace(attempt.TerminalState), string(store.WorkAttemptTerminalFailure))
+	case terminalAttemptRetryLimitCause:
+		return strings.TrimSpace(attempt.ErrorClass) != workAttemptErrorWorkspace &&
+			terminalAttemptRetryableFailure(attempt) &&
+			!workAttemptHasPushedProduct(attempt)
+	default:
+		return false
+	}
+}
+
+func retryCycleCauseForAttempt(attempt telemetry.WorkAttempt) string {
+	if strings.TrimSpace(attempt.ErrorClass) == workAttemptErrorWorkspace {
+		return workspacePreparationRetryLimitCause
+	}
+	return terminalAttemptRetryLimitCause
+}
+
+func (o *Orchestrator) parkRetryCycleLimit(
+	ctx context.Context,
+	state *State,
+	issue connector.Issue,
+	runMode string,
+	diffStats DiffStats,
+	cause string,
+	count int,
+	at time.Time,
+) (connector.Issue, bool) {
+	if o == nil || o.connector == nil || state == nil {
+		return issue, false
+	}
+	targetState := blockedStatusState
+	metadata := o.newBlockedRecoveryMetadata(
+		ctx,
+		issue,
+		runMode,
+		cause,
+		blockedRecoveryPredicateFingerprintChange,
+		"Todo",
+		diffStats,
+	)
+	if err := o.updateIssueStateByIDWithMetadata(ctx, state, issue.ID, issue, targetState, at, cause, metadata); err != nil {
+		if o.logger != nil {
+			o.logger.Error("retry cycle limit state transition failed", "issue_id", issue.ID, "identifier", issue.Identifier, "cause", cause, "target_state", targetState, "error", err)
+		}
+		return issue, false
+	}
+	issue.State = targetState
+	if err := o.abandonClaim(ctx, issue.ID); err != nil && o.logger != nil {
+		o.logger.Warn("retry cycle limit claim release failed", "issue_id", issue.ID, "identifier", issue.Identifier, "cause", cause, "error", err)
+	}
+	delete(state.Claimed, issue.ID)
+	delete(state.Retry, issue.ID)
+	delete(state.BudgetRefusals, issue.ID)
+	delete(state.PriorAttempts, issue.ID)
+	if state.Blocked == nil {
+		state.Blocked = map[string]Blocked{}
+	}
+	state.Blocked[issue.ID] = Blocked{
+		Issue:          cloneIssue(issue),
+		Reason:         cause,
+		RecoveryReason: blockedRecoveryPredicateFingerprintChange,
+		RecoveryTarget: metadata.BlockedRecovery.TargetState,
+		BlockedAt:      at,
+		Source:         BlockedSourceProjectStatus,
+		Recovery:       metadata.BlockedRecovery,
+	}
+	if o.connector != nil {
+		comment := fmt.Sprintf(
+			"Detent stopped retrying %s after %d consecutive %s attempts. The issue is parked in `%s` until its recovery fingerprint changes.",
+			issueLabel(issue),
+			count,
+			retryCycleDescription(cause),
+			targetState,
+		)
+		if err := o.connector.CreateComment(ctx, issue.ID, comment); err != nil && o.logger != nil {
+			o.logger.Warn("retry cycle limit comment failed", "issue_id", issue.ID, "identifier", issue.Identifier, "cause", cause, "error", err)
+		}
+	}
+	event := retryCycleLimitEvent(cause)
+	recordStateEvent(state, telemetry.ActivityEvent{
+		At:      at,
+		Event:   event,
+		Message: fmt.Sprintf("parked %s after %d consecutive %s attempts", issueLabel(issue), count, retryCycleDescription(cause)),
+	})
+	if o.logger != nil {
+		telemetry.LogLifecycleMessage(o.logger, slog.LevelError, telemetry.LifecycleSafetyControl, event, "retry cycle limit reached", o.issueLifecycleCorrelation(issue),
+			"cause", cause,
+			"consecutive_attempts", count,
+			"limit", consecutiveRetryCycleLimit,
+			"target_state", targetState,
+		)
+	}
 	return issue, true
+}
+
+func retryCycleDescription(cause string) string {
+	if strings.TrimSpace(cause) == workspacePreparationRetryLimitCause {
+		return "workspace-preparation"
+	}
+	return "terminal-without-work-product"
+}
+
+func retryCycleLimitEvent(cause string) string {
+	if strings.TrimSpace(cause) == workspacePreparationRetryLimitCause {
+		return workspacePreparationRetryLimitEvent
+	}
+	return terminalAttemptRetryLimitEvent
+}
+
+func (o *Orchestrator) recordRetryCycleHistoryUnavailable(state *State, issue connector.Issue, cause string, at time.Time) {
+	event := terminalAttemptRetryHistoryUnavailableEvent
+	if strings.TrimSpace(cause) == workspacePreparationRetryLimitCause {
+		event = workspaceRetryHistoryUnavailableEvent
+	}
+	recordStateEvent(state, telemetry.ActivityEvent{
+		At:      at,
+		Event:   event,
+		Message: "continued retrying " + issueLabel(issue) + " because durable retry history was unavailable",
+	})
 }
 
 func (o *Orchestrator) releaseTerminalAttemptClaim(ctx context.Context, state *State, issue connector.Issue, at time.Time) {
@@ -123,11 +365,15 @@ func (o *Orchestrator) reconcileTerminalAttemptRetryStates(
 		if !ok || !terminalAttemptRetryableFailure(attempt) {
 			continue
 		}
-		updated, changed := o.demoteTerminalAttemptRetry(
+		updated, changed, _ := o.demoteTerminalAttemptRetry(
 			ctx,
 			state,
 			issue,
 			workAttemptHasPushedProduct(attempt),
+			retryCycleCauseForAttempt(attempt),
+			true,
+			workAttemptRunMode(attempt),
+			DiffStats{},
 			now,
 		)
 		if changed {
@@ -135,6 +381,16 @@ func (o *Orchestrator) reconcileTerminalAttemptRetryStates(
 		}
 	}
 	return transitions
+}
+
+func workAttemptRunMode(attempt telemetry.WorkAttempt) string {
+	var metadata struct {
+		RunMode string `json:"run_mode"`
+	}
+	if json.Unmarshal([]byte(attempt.WorkerMetadataJSON), &metadata) == nil && strings.TrimSpace(metadata.RunMode) != "" {
+		return strings.TrimSpace(metadata.RunMode)
+	}
+	return RunModeImplement
 }
 
 func (o *Orchestrator) terminalAttemptClaimBlocksDemotion(ctx context.Context, issue connector.Issue, now time.Time) bool {

--- a/internal/orchestrator/terminal_attempt_retry_test.go
+++ b/internal/orchestrator/terminal_attempt_retry_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/digitaldrywood/detent/internal/backendcapacity"
 	"github.com/digitaldrywood/detent/internal/connector"
 	runpkg "github.com/digitaldrywood/detent/internal/runner"
+	"github.com/digitaldrywood/detent/internal/scheduler"
 	"github.com/digitaldrywood/detent/internal/store"
 	"github.com/digitaldrywood/detent/internal/telemetry"
 )
@@ -124,6 +125,68 @@ func TestHandleRunResultRoutesTerminalRetryByWorkProduct(t *testing.T) {
 				t.Fatalf("persisted work_product_pushed = %v, want %v", got, tt.result.PullRequestHeadPushed)
 			}
 		})
+	}
+}
+
+func TestHandleRunResultParksTerminalRetryAtDurableLimit(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 8, 20, 13, 0, 0, 0, time.UTC)
+	issue := terminalRetryTestIssue("runtime-limit")
+	tracker := &terminalRetryConnector{issues: map[string]connector.Issue{issue.ID: cloneIssue(issue)}}
+	attempts := &terminalRetryWorkAttemptStore{}
+	cfg := normalizeConfig(Config{
+		ActiveStates:          []string{"Todo", "In Progress"},
+		ObservedStates:        []string{"Blocked"},
+		TerminalStates:        []string{"Done"},
+		MaxRetryBackoff:       time.Minute,
+		FailureRetryBaseDelay: time.Second,
+	})
+	o := &Orchestrator{cfg: cfg, connector: tracker, workAttempts: attempts}
+	state := newState(cfg)
+
+	for attempt := 1; attempt <= consecutiveRetryCycleLimit; attempt++ {
+		completedAt := now.Add(time.Duration(attempt) * time.Minute)
+		issue.State = planImplementationState
+		tracker.issues[issue.ID] = cloneIssue(issue)
+		state.Running[issue.ID] = Running{
+			Issue:         cloneIssue(issue),
+			Attempt:       attempt,
+			WorkAttemptID: int64(attempt),
+			Mode:          runpkg.RunModePlan,
+			StartedAt:     completedAt.Add(-time.Minute),
+		}
+		state.Claimed[issue.ID] = Claimed{Issue: cloneIssue(issue), ClaimedAt: completedAt.Add(-time.Minute)}
+		o.upsertWorkAttemptSnapshot(&state, telemetry.WorkAttempt{
+			AttemptID: int64(attempt), IssueID: issue.ID, Identifier: issue.Identifier,
+			Status: string(store.WorkAttemptStatusActive), StartedAt: completedAt.Add(-time.Minute),
+		})
+
+		o.handleRunResult(t.Context(), &state, runpkg.Completion{
+			IssueID:      issue.ID,
+			Request:      runpkg.RunRequest{Mode: runpkg.RunModePlan},
+			Err:          errors.New("runner failed before producing work"),
+			CompletedAt:  completedAt,
+			RetryAttempt: attempt + 1,
+			RetryDelay:   time.Second,
+		})
+
+		if attempt < consecutiveRetryCycleLimit {
+			if retry, ok := state.Retry[issue.ID]; !ok || retry.Issue.State != "Todo" {
+				t.Fatalf("attempt %d Retry[%q] = %#v, want Todo retry", attempt, issue.ID, retry)
+			}
+		}
+	}
+
+	blocked, ok := state.Blocked[issue.ID]
+	if !ok || blocked.Reason != terminalAttemptRetryLimitCause || blocked.Recovery == nil {
+		t.Fatalf("Blocked[%q] = %#v, want terminal retry limit park", issue.ID, blocked)
+	}
+	if _, ok := state.Retry[issue.ID]; ok {
+		t.Fatalf("Retry[%q] present after durable terminal retry limit", issue.ID)
+	}
+	if len(attempts.completions) != consecutiveRetryCycleLimit {
+		t.Fatalf("work attempt completions = %d, want %d", len(attempts.completions), consecutiveRetryCycleLimit)
 	}
 }
 
@@ -394,6 +457,242 @@ func TestReconcileTerminalAttemptRetryStatesDemotesRecoveredEmptyAttempt(t *test
 	}
 }
 
+func TestReconcileTerminalAttemptRetryStatesBoundsDurableFailures(t *testing.T) {
+	t.Parallel()
+
+	const retryLimit = 3
+	now := time.Date(2026, 8, 20, 14, 0, 0, 0, time.UTC)
+	tests := []struct {
+		name         string
+		attempts     []telemetry.WorkAttempt
+		wantState    string
+		wantBlocked  bool
+		wantRecovery string
+	}{
+		{
+			name:      "below limit returns to todo",
+			attempts:  terminalRetryFailureAttempts("issue-below-limit", now, retryLimit-1),
+			wantState: "Todo",
+		},
+		{
+			name:         "limit parks in blocked",
+			attempts:     terminalRetryFailureAttempts("issue-at-limit", now, retryLimit),
+			wantState:    "Blocked",
+			wantBlocked:  true,
+			wantRecovery: "fingerprint_changed",
+		},
+		{
+			name: "successful completion resets the sequence",
+			attempts: []telemetry.WorkAttempt{
+				{
+					AttemptID: 3, IssueID: "issue-success-reset", Status: string(store.WorkAttemptStatusTerminal),
+					TerminalState: string(store.WorkAttemptTerminalFailure), CompletedAt: timePointer(now),
+				},
+				{
+					AttemptID: 2, IssueID: "issue-success-reset", Status: string(store.WorkAttemptStatusTerminal),
+					TerminalState: string(store.WorkAttemptTerminalSuccess), CompletedAt: timePointer(now.Add(-time.Minute)),
+				},
+				{
+					AttemptID: 1, IssueID: "issue-success-reset", Status: string(store.WorkAttemptStatusTerminal),
+					TerminalState: string(store.WorkAttemptTerminalFailure), CompletedAt: timePointer(now.Add(-2 * time.Minute)),
+				},
+			},
+			wantState: "Todo",
+		},
+		{
+			name: "pushed work resets the sequence",
+			attempts: []telemetry.WorkAttempt{
+				{
+					AttemptID: 3, IssueID: "issue-push-reset", Status: string(store.WorkAttemptStatusTerminal),
+					TerminalState: string(store.WorkAttemptTerminalFailure), CompletedAt: timePointer(now),
+				},
+				{
+					AttemptID: 2, IssueID: "issue-push-reset", Status: string(store.WorkAttemptStatusTerminal),
+					TerminalState: string(store.WorkAttemptTerminalFailure), CompletedAt: timePointer(now.Add(-time.Minute)),
+					WorkerMetadataJSON: `{"work_product_pushed":true}`,
+				},
+				{
+					AttemptID: 1, IssueID: "issue-push-reset", Status: string(store.WorkAttemptStatusTerminal),
+					TerminalState: string(store.WorkAttemptTerminalFailure), CompletedAt: timePointer(now.Add(-2 * time.Minute)),
+				},
+			},
+			wantState: "Todo",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			issueID := tt.attempts[0].IssueID
+			issue := terminalRetryTestIssue(strings.TrimPrefix(issueID, "issue-"))
+			issue.ID = issueID
+			tracker := &terminalRetryConnector{issues: map[string]connector.Issue{issue.ID: cloneIssue(issue)}}
+			cfg := normalizeConfig(Config{
+				ActiveStates:   []string{"Todo", "In Progress"},
+				ObservedStates: []string{"Blocked"},
+				TerminalStates: []string{"Done"},
+			})
+			o := &Orchestrator{cfg: cfg, connector: tracker}
+			state := newState(cfg)
+			state.WorkAttempts = append([]telemetry.WorkAttempt(nil), tt.attempts...)
+
+			transitions := o.reconcileTerminalAttemptRetryStates(t.Context(), &state, []connector.Issue{issue}, now)
+
+			if len(transitions) != 1 || transitions[0].State != tt.wantState {
+				t.Fatalf("transitions = %#v, want one transition to %s", transitions, tt.wantState)
+			}
+			if got := tracker.transitionStates(); !slices.Equal(got, []string{tt.wantState}) {
+				t.Fatalf("state transitions = %v, want [%s]", got, tt.wantState)
+			}
+			blocked, ok := state.Blocked[issue.ID]
+			if ok != tt.wantBlocked {
+				t.Fatalf("Blocked[%q] present = %v, want %v: %#v", issue.ID, ok, tt.wantBlocked, blocked)
+			}
+			if tt.wantBlocked && (blocked.RecoveryReason != tt.wantRecovery || blocked.Recovery == nil) {
+				t.Fatalf("Blocked[%q] = %#v, want durable fingerprint recovery", issue.ID, blocked)
+			}
+		})
+	}
+}
+
+func TestReconcileTerminalAttemptRetryStatesUsesDurableIssueHistory(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 8, 20, 15, 0, 0, 0, time.UTC)
+	tests := []struct {
+		name        string
+		errorClass  string
+		historyErr  error
+		wantState   string
+		wantBlocked bool
+		wantReason  string
+		wantEvent   string
+	}{
+		{name: "persisted terminal history reaches limit", errorClass: workAttemptErrorRunner, wantState: "Blocked", wantBlocked: true, wantReason: terminalAttemptRetryLimitCause},
+		{name: "persisted workspace history reaches limit", errorClass: workAttemptErrorWorkspace, wantState: "Blocked", wantBlocked: true, wantReason: workspacePreparationRetryLimitCause},
+		{name: "history lookup failure fails open", errorClass: workAttemptErrorRunner, historyErr: errors.New("history unavailable"), wantState: "Todo", wantEvent: terminalAttemptRetryHistoryUnavailableEvent},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			issue := terminalRetryTestIssue("durable-history")
+			tracker := &terminalRetryConnector{issues: map[string]connector.Issue{issue.ID: cloneIssue(issue)}}
+			attempts := &terminalRetryWorkAttemptStore{historyErr: tt.historyErr}
+			for attempt := 3; attempt >= 1; attempt-- {
+				attempts.history = append(attempts.history, store.WorkAttempt{
+					ID:            int64(attempt),
+					IssueID:       issue.ID,
+					Identifier:    issue.Identifier,
+					Status:        store.WorkAttemptStatusTerminal,
+					TerminalState: store.WorkAttemptTerminalFailure,
+					ErrorClass:    tt.errorClass,
+					CompletedAt:   now.Add(-time.Duration(3-attempt) * time.Minute),
+				})
+			}
+			cfg := normalizeConfig(Config{
+				Project:        scheduler.ProjectCandidate{ID: "detent"},
+				ActiveStates:   []string{"Todo", "In Progress"},
+				ObservedStates: []string{"Blocked"},
+				TerminalStates: []string{"Done"},
+			})
+			o := &Orchestrator{cfg: cfg, connector: tracker, workAttempts: attempts}
+			state := newState(cfg)
+			state.WorkAttempts = terminalRetryFailureAttempts(issue.ID, now, 1)
+			state.WorkAttempts[0].ErrorClass = tt.errorClass
+
+			transitions := o.reconcileTerminalAttemptRetryStates(t.Context(), &state, []connector.Issue{issue}, now)
+
+			if len(transitions) != 1 || transitions[0].State != tt.wantState {
+				t.Fatalf("transitions = %#v, want one transition to %s", transitions, tt.wantState)
+			}
+			blocked, ok := state.Blocked[issue.ID]
+			if ok != tt.wantBlocked {
+				t.Fatalf("Blocked[%q] present = %v, want %v", issue.ID, ok, tt.wantBlocked)
+			}
+			if tt.wantBlocked && blocked.Reason != tt.wantReason {
+				t.Fatalf("Blocked[%q].Reason = %q, want %q", issue.ID, blocked.Reason, tt.wantReason)
+			}
+			if len(attempts.historyQueries) != 1 {
+				t.Fatalf("history queries = %#v, want one", attempts.historyQueries)
+			}
+			query := attempts.historyQueries[0]
+			if query.ProjectID != "detent" || query.IssueID != issue.ID || query.Identifier != issue.Identifier || query.Limit != consecutiveRetryCycleLimit {
+				t.Fatalf("history query = %#v, want durable issue identity and limit", query)
+			}
+			if tt.wantEvent != "" {
+				if event, ok := recentStateEvent(state, tt.wantEvent); !ok || event.Message == "" {
+					t.Fatalf("RecentEvents = %#v, want %s", state.RecentEvents, tt.wantEvent)
+				}
+			}
+		})
+	}
+}
+
+func TestRetryCycleAttemptMatches(t *testing.T) {
+	t.Parallel()
+
+	base := telemetry.WorkAttempt{
+		Status:        string(store.WorkAttemptStatusTerminal),
+		TerminalState: string(store.WorkAttemptTerminalFailure),
+		ErrorClass:    workAttemptErrorRunner,
+	}
+	tests := []struct {
+		name         string
+		mutate       func(*telemetry.WorkAttempt)
+		cause        string
+		wantMatching bool
+	}{
+		{name: "failure", cause: terminalAttemptRetryLimitCause, wantMatching: true},
+		{name: "timed out", cause: terminalAttemptRetryLimitCause, wantMatching: true, mutate: func(attempt *telemetry.WorkAttempt) {
+			attempt.TerminalState = string(store.WorkAttemptTerminalTimedOut)
+		}},
+		{name: "abandoned", cause: terminalAttemptRetryLimitCause, wantMatching: true, mutate: func(attempt *telemetry.WorkAttempt) {
+			attempt.TerminalState = string(store.WorkAttemptTerminalAbandoned)
+		}},
+		{name: "capacity", cause: terminalAttemptRetryLimitCause, wantMatching: true, mutate: func(attempt *telemetry.WorkAttempt) {
+			attempt.TerminalState = string(store.WorkAttemptTerminalCapacity)
+		}},
+		{name: "success resets terminal", cause: terminalAttemptRetryLimitCause, mutate: func(attempt *telemetry.WorkAttempt) { attempt.TerminalState = string(store.WorkAttemptTerminalSuccess) }},
+		{name: "pushed work resets terminal", cause: terminalAttemptRetryLimitCause, mutate: func(attempt *telemetry.WorkAttempt) { attempt.WorkerMetadataJSON = `{"work_product_pushed":true}` }},
+		{name: "forge outage resets terminal", cause: terminalAttemptRetryLimitCause, mutate: func(attempt *telemetry.WorkAttempt) { attempt.ErrorClass = forgeUnavailableErrorClass }},
+		{name: "workspace is separate from terminal", cause: terminalAttemptRetryLimitCause, mutate: func(attempt *telemetry.WorkAttempt) { attempt.ErrorClass = workAttemptErrorWorkspace }},
+		{name: "workspace failure", cause: workspacePreparationRetryLimitCause, wantMatching: true, mutate: func(attempt *telemetry.WorkAttempt) { attempt.ErrorClass = workAttemptErrorWorkspace }},
+		{name: "runner failure resets workspace", cause: workspacePreparationRetryLimitCause},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			attempt := base
+			if tt.mutate != nil {
+				tt.mutate(&attempt)
+			}
+			if got := retryCycleAttemptMatches(attempt, tt.cause); got != tt.wantMatching {
+				t.Fatalf("retryCycleAttemptMatches() = %v, want %v for %#v", got, tt.wantMatching, attempt)
+			}
+		})
+	}
+}
+
+func terminalRetryFailureAttempts(issueID string, now time.Time, count int) []telemetry.WorkAttempt {
+	attempts := make([]telemetry.WorkAttempt, 0, count)
+	for index := range count {
+		attemptID := int64(count - index)
+		attempts = append(attempts, telemetry.WorkAttempt{
+			AttemptID:     attemptID,
+			IssueID:       issueID,
+			Status:        string(store.WorkAttemptStatusTerminal),
+			TerminalState: string(store.WorkAttemptTerminalFailure),
+			ErrorClass:    "runner_error",
+			CompletedAt:   timePointer(now.Add(-time.Duration(index) * time.Minute)),
+		})
+	}
+	return attempts
+}
+
 func TestReconcileTerminalAttemptRetryStatesRespectsLiveForeignClaim(t *testing.T) {
 	t.Parallel()
 
@@ -576,7 +875,10 @@ func (c *terminalRetryConnector) transitionStates() []string {
 }
 
 type terminalRetryWorkAttemptStore struct {
-	completions []store.WorkAttemptCompletion
+	completions    []store.WorkAttemptCompletion
+	history        []store.WorkAttempt
+	historyErr     error
+	historyQueries []store.WorkAttemptHistoryQuery
 }
 
 func (s *terminalRetryWorkAttemptStore) StartWorkAttempt(context.Context, store.WorkAttemptStart) (int64, error) {
@@ -608,8 +910,9 @@ func (s *terminalRetryWorkAttemptStore) ListActiveWorkAttempts(context.Context, 
 	return nil, nil
 }
 
-func (s *terminalRetryWorkAttemptStore) ListRecentTerminalWorkAttempts(context.Context, store.WorkAttemptHistoryQuery) ([]store.WorkAttempt, error) {
-	return nil, nil
+func (s *terminalRetryWorkAttemptStore) ListRecentTerminalWorkAttempts(_ context.Context, query store.WorkAttemptHistoryQuery) ([]store.WorkAttempt, error) {
+	s.historyQueries = append(s.historyQueries, query)
+	return append([]store.WorkAttempt(nil), s.history...), s.historyErr
 }
 
 func (s *terminalRetryWorkAttemptStore) RecordSchedulerDecision(context.Context, store.SchedulerDecision) (int64, error) {

--- a/internal/orchestrator/transient_overload.go
+++ b/internal/orchestrator/transient_overload.go
@@ -55,7 +55,7 @@ func (o *Orchestrator) handleTransientOverload(
 	} else {
 		o.deferProjectFailureBreakerCanary(state, event.IssueID, event.CompletedAt, delay)
 	}
-	o.completeDurableWorkAttempt(
+	attemptCompleted := o.completeDurableWorkAttemptWithMetadata(
 		ctx,
 		state,
 		running,
@@ -65,6 +65,7 @@ func (o *Orchestrator) handleTransientOverload(
 		event.Err.Error(),
 		"waiting",
 		statusMessage,
+		nil,
 	)
 	if workspaceIssueTerminal(running.Issue, o.cfg.TerminalStates) {
 		o.releaseClaim(state, running.Issue.ID)
@@ -77,7 +78,21 @@ func (o *Orchestrator) handleTransientOverload(
 	if attempt < 1 {
 		attempt = 1
 	}
-	running.Issue, _ = o.demoteTerminalAttemptRetry(ctx, state, running.Issue, running.WorkProductPushed, event.CompletedAt)
+	var parked bool
+	running.Issue, _, parked = o.demoteTerminalAttemptRetry(
+		ctx,
+		state,
+		running.Issue,
+		running.WorkProductPushed,
+		terminalAttemptRetryLimitCause,
+		attemptCompleted,
+		running.Mode,
+		running.DiffStats,
+		event.CompletedAt,
+	)
+	if parked {
+		return
+	}
 	o.scheduleRetryAfter(
 		state,
 		running.Issue,

--- a/internal/orchestrator/workspace_preparation_test.go
+++ b/internal/orchestrator/workspace_preparation_test.go
@@ -2,16 +2,20 @@ package orchestrator
 
 import (
 	"fmt"
+	"slices"
 	"testing"
 	"time"
 
 	"github.com/digitaldrywood/detent/internal/connector"
 	runpkg "github.com/digitaldrywood/detent/internal/runner"
+	"github.com/digitaldrywood/detent/internal/store"
+	"github.com/digitaldrywood/detent/internal/telemetry"
 )
 
-func TestWorkspacePreparationFailuresDoNotTripWorkFailureBreakers(t *testing.T) {
+func TestWorkspacePreparationRetriesAreBoundedAndPreserveFailureBreakers(t *testing.T) {
 	t.Parallel()
 
+	const retryLimit = 3
 	tests := []struct {
 		name string
 		err  error
@@ -29,8 +33,11 @@ func TestWorkspacePreparationFailuresDoNotTripWorkFailureBreakers(t *testing.T) 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
+			issue := connector.Issue{ID: "issue-workspace", Identifier: "digitaldrywood/detent#1907", State: "In Progress"}
+			tracker := &terminalRetryConnector{issues: map[string]connector.Issue{issue.ID: cloneIssue(issue)}}
+			attempts := &terminalRetryWorkAttemptStore{}
 			cfg := normalizeConfig(Config{
-				ActiveStates:   []string{"In Progress"},
+				ActiveStates:   []string{"Todo", "In Progress"},
 				ObservedStates: []string{"Blocked"},
 				TerminalStates: []string{"Done"},
 				FailureBreaker: FailureBreakerConfig{
@@ -39,20 +46,26 @@ func TestWorkspacePreparationFailuresDoNotTripWorkFailureBreakers(t *testing.T) 
 					Cooldown:       time.Hour,
 				},
 			})
-			orch := &Orchestrator{cfg: cfg}
+			orch := &Orchestrator{cfg: cfg, connector: tracker, workAttempts: attempts}
 			state := newState(cfg)
-			issue := connector.Issue{ID: "issue-workspace", Identifier: "digitaldrywood/detent#1907", State: "In Progress"}
+			state.InstantFailures[issue.ID] = InstantFailure{Issue: issue, Count: 2}
+			state.RepeatedFailures[issue.ID] = RepeatedFailure{Issue: issue, Count: 2}
 			base := time.Date(2026, 8, 18, 20, 0, 0, 0, time.UTC)
 
-			for attempt := 1; attempt <= repeatedFailureThreshold; attempt++ {
+			for attempt := 1; attempt <= retryLimit; attempt++ {
 				completedAt := base.Add(time.Duration(attempt) * time.Minute)
 				running := Running{
-					Issue:     issue,
-					Mode:      runpkg.RunModePlan,
-					Attempt:   attempt,
-					StartedAt: completedAt.Add(-time.Minute),
+					Issue:         issue,
+					Mode:          runpkg.RunModePlan,
+					Attempt:       attempt,
+					WorkAttemptID: int64(attempt),
+					StartedAt:     completedAt.Add(-time.Minute),
 				}
 				state.Running[issue.ID] = running
+				orch.upsertWorkAttemptSnapshot(&state, telemetry.WorkAttempt{
+					AttemptID: int64(attempt), IssueID: issue.ID, Identifier: issue.Identifier,
+					Status: string(store.WorkAttemptStatusActive), StartedAt: running.StartedAt,
+				})
 				orch.handleRunResult(t.Context(), &state, runpkg.Completion{
 					IssueID:      issue.ID,
 					Request:      runpkg.RunRequest{Mode: runpkg.RunModePlan},
@@ -61,25 +74,35 @@ func TestWorkspacePreparationFailuresDoNotTripWorkFailureBreakers(t *testing.T) 
 					RetryAttempt: attempt + 1,
 					RetryDelay:   time.Second,
 				})
+
+				if state.InstantFailures[issue.ID].Count != 2 || state.RepeatedFailures[issue.ID].Count != 2 {
+					t.Fatalf("attempt %d failure breakers = instant %#v repeated %#v, want preserved counts", attempt, state.InstantFailures[issue.ID], state.RepeatedFailures[issue.ID])
+				}
+				if attempt < retryLimit {
+					if _, blocked := state.Blocked[issue.ID]; blocked {
+						t.Fatalf("Blocked[%q] present at attempt %d below limit", issue.ID, attempt)
+					}
+					if _, ok := state.Retry[issue.ID]; !ok {
+						t.Fatalf("Retry[%q] missing at attempt %d below limit", issue.ID, attempt)
+					}
+				}
 			}
 
-			if _, blocked := state.Blocked[issue.ID]; blocked {
-				t.Fatalf("Blocked[%q] present after workspace preparation failures", issue.ID)
+			blocked, ok := state.Blocked[issue.ID]
+			if !ok || blocked.Reason != workspacePreparationRetryLimitCause || blocked.Recovery == nil || blocked.RecoveryReason != blockedRecoveryPredicateFingerprintChange {
+				t.Fatalf("Blocked[%q] = %#v, want durable fingerprint-recovery park", issue.ID, blocked)
 			}
-			if _, ok := state.Retry[issue.ID]; !ok {
-				t.Fatalf("Retry[%q] missing after workspace preparation failure", issue.ID)
+			if _, ok := state.Retry[issue.ID]; ok {
+				t.Fatalf("Retry[%q] present after workspace preparation retry limit", issue.ID)
 			}
-			if _, ok := state.InstantFailures[issue.ID]; ok {
-				t.Fatalf("InstantFailures[%q] present after workspace preparation failure", issue.ID)
+			if got := tracker.transitionStates(); !slices.Equal(got, []string{"Blocked"}) {
+				t.Fatalf("state transitions = %v, want [Blocked]", got)
 			}
-			if _, ok := state.RepeatedFailures[issue.ID]; ok {
-				t.Fatalf("RepeatedFailures[%q] present after workspace preparation failure", issue.ID)
+			if failures := state.FailureBreaker.Failures[workAttemptErrorWorkspace]; len(failures) != retryLimit {
+				t.Fatalf("FailureBreaker.Failures[%q] = %#v, want %d preserved failures", workAttemptErrorWorkspace, failures, retryLimit)
 			}
-			if state.FailureBreaker.Class != workAttemptErrorWorkspace {
-				t.Fatalf("FailureBreaker.Class = %q, want %q", state.FailureBreaker.Class, workAttemptErrorWorkspace)
-			}
-			if event, ok := recentStateEvent(state, "workspace_repair_retry_scheduled"); !ok || event.Message == "" {
-				t.Fatalf("RecentEvents = %#v, want workspace repair retry event", state.RecentEvents)
+			if event, ok := recentStateEvent(state, workspacePreparationRetryLimitEvent); !ok || event.Message == "" {
+				t.Fatalf("RecentEvents = %#v, want workspace preparation limit event", state.RecentEvents)
 			}
 		})
 	}

--- a/internal/workspace/workspace.go
+++ b/internal/workspace/workspace.go
@@ -32,6 +32,8 @@ const defaultHookTimeout = time.Minute
 const workspaceCommandWaitDelay = time.Second
 const hookOutputTailBytes = 16 * 1024
 const workerScratchRelativePath = ".detent/tmp"
+const quarantineTimestampFormat = "20060102T150405.000000000Z"
+const quarantineAccumulationWarningThreshold = 5
 
 var (
 	ErrHookFailed         = errors.New("workspace hook failed")
@@ -751,15 +753,34 @@ func (l *LocalGit) recoverStaleSourceWorktree(ctx context.Context, path string, 
 			}
 			return fmt.Errorf("workspace path is on branch %q, want %q and %s; preserve it by moving or cleaning %s: %w", currentBranch, expectedBranch, reason, path, err)
 		}
+		quarantineCount, countErr := l.quarantineWorkspaceCount(path)
+		if countErr != nil {
+			l.logger.Warn(
+				"workspace quarantine count failed",
+				slog.String("path", path),
+				slog.String("quarantine_path", quarantinePath),
+				slog.Any("error", countErr),
+			)
+		}
 		l.logger.Warn(
 			"quarantined stale workspace",
 			slog.String("path", path),
 			slog.String("quarantine_path", quarantinePath),
+			slog.Int("quarantine_count", quarantineCount),
 			slog.String("current_branch", currentBranch),
 			slog.String("expected_branch", expectedBranch),
 			slog.Bool("dirty", dirty),
 			slog.Bool("unreferenced_detached_head", unreferencedDetachedHead),
 		)
+		if quarantineCount > quarantineAccumulationWarningThreshold {
+			l.logger.Error(
+				"workspace quarantine accumulation exceeded threshold",
+				slog.String("path", path),
+				slog.String("quarantine_path", quarantinePath),
+				slog.Int("quarantine_count", quarantineCount),
+				slog.Int("threshold", quarantineAccumulationWarningThreshold),
+			)
+		}
 		return nil
 	}
 
@@ -990,7 +1011,7 @@ func writeLinkedWorktreeGitDir(path string, gitDir string) (err error) {
 func (l *LocalGit) nextQuarantinePath(path string) (string, error) {
 	parent := filepath.Join(l.root, ".detent", "quarantine")
 	base := SafeKey(filepath.Base(path))
-	stamp := time.Now().UTC().Format("20060102T150405.000000000Z")
+	stamp := time.Now().UTC().Format(quarantineTimestampFormat)
 	for i := range 100 {
 		name := base + "-" + stamp
 		if i > 0 {
@@ -1009,6 +1030,46 @@ func (l *LocalGit) nextQuarantinePath(path string) (string, error) {
 		}
 	}
 	return "", errors.New("exhausted quarantine workspace path attempts")
+}
+
+func (l *LocalGit) quarantineWorkspaceCount(path string) (int, error) {
+	parent := filepath.Join(l.root, ".detent", "quarantine")
+	entries, err := os.ReadDir(parent)
+	if errors.Is(err, fs.ErrNotExist) {
+		return 0, nil
+	}
+	if err != nil {
+		return 0, fmt.Errorf("read quarantine directory: %w", err)
+	}
+	base := SafeKey(filepath.Base(path))
+	count := 0
+	for _, entry := range entries {
+		if entry.IsDir() && quarantineEntryMatchesWorkspace(base, entry.Name()) {
+			count++
+		}
+	}
+	return count, nil
+}
+
+func quarantineEntryMatchesWorkspace(base string, name string) bool {
+	suffix, ok := strings.CutPrefix(name, base+"-")
+	if !ok {
+		return false
+	}
+	stampEnd := strings.IndexByte(suffix, 'Z')
+	if stampEnd < 0 {
+		return false
+	}
+	stampEnd++
+	if _, err := time.Parse(quarantineTimestampFormat, suffix[:stampEnd]); err != nil {
+		return false
+	}
+	collision := suffix[stampEnd:]
+	if collision == "" {
+		return true
+	}
+	value, err := strconv.Atoi(strings.TrimPrefix(collision, "-"))
+	return err == nil && strings.HasPrefix(collision, "-") && value > 0
 }
 
 func (l *LocalGit) branchExists(ctx context.Context, branch string) (bool, error) {

--- a/internal/workspace/workspace_test.go
+++ b/internal/workspace/workspace_test.go
@@ -1573,6 +1573,42 @@ func TestLocalGitCreateRepairsWorkspacePreparationFailures(t *testing.T) {
 	}
 }
 
+func TestLocalGitQuarantineWorkspaceCount(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	parent := filepath.Join(root, ".detent", "quarantine")
+	if err := os.MkdirAll(parent, 0o700); err != nil {
+		t.Fatalf("create quarantine directory: %v", err)
+	}
+	base := "detent-acme_widgets_42"
+	stamp := "20260820T140000.000000000Z"
+	for _, name := range []string{
+		base + "-" + stamp,
+		base + "-" + stamp + "-1",
+		base + "-" + stamp + "-2",
+		base + "-malformed",
+		base + "-other-" + stamp,
+		base + "0-" + stamp,
+	} {
+		if err := os.MkdirAll(filepath.Join(parent, name), 0o700); err != nil {
+			t.Fatalf("create quarantine entry %q: %v", name, err)
+		}
+	}
+	if err := os.WriteFile(filepath.Join(parent, base+"-20260820T150000.000000000Z"), []byte("not a directory"), 0o600); err != nil {
+		t.Fatalf("create quarantine file: %v", err)
+	}
+	backend := &LocalGit{root: root}
+
+	got, err := backend.quarantineWorkspaceCount(filepath.Join(root, base))
+	if err != nil {
+		t.Fatalf("quarantineWorkspaceCount() error = %v", err)
+	}
+	if got != 3 {
+		t.Fatalf("quarantineWorkspaceCount() = %d, want 3", got)
+	}
+}
+
 func TestLocalGitBeforeAndAfterRunHooks(t *testing.T) {
 	t.Parallel()
 	skipWindows(t)


### PR DESCRIPTION
## Summary

- bound terminal-without-work-product and workspace-preparation retry cycles at three durable consecutive attempts
- park exhausted retries with sticky breaker recovery metadata while preserving failure-breaker evidence
- report excessive per-workspace quarantine accumulation without deleting preserved work

Fixes #1927

## UI Surface Contract

- [x] N/A, or the linked issue explicitly authorizes any high-impact UI surface, layout, density, first-viewport, or responsive visibility tradeoff.
- [x] Persistent top-of-screen messaging is explicitly authorized by the issue, or this PR does not add it.
- [x] Visual changes to primary operator screens include screenshot or browser verification below.

## Test Plan

- [x] `go test ./internal/orchestrator ./internal/workspace -count=1`
- [x] `go test ./internal/orchestrator -run '^$' -fuzz=FuzzSafetyCriticalOrchestratorBoundaries -fuzztime=30s`
- [x] `make check`
