### PR TITLE
fix(orchestrator): gate GitHub REST headroom

### DIFF
--- a/internal/orchestrator/github_rest_capacity.go
+++ b/internal/orchestrator/github_rest_capacity.go
@@ -2,6 +2,7 @@ package orchestrator
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"strconv"
@@ -47,6 +48,17 @@ type githubRESTBudgetEvidence struct {
 	TargetState        string
 }
 
+type githubRESTWaitMetadata struct {
+	Consumer           string    `json:"consumer"`
+	CredentialIdentity string    `json:"credential_identity"`
+	Remaining          int64     `json:"remaining"`
+	Limit              int64     `json:"limit,omitempty"`
+	Reserve            int64     `json:"reserve"`
+	ResetAt            time.Time `json:"reset_at"`
+	ObservedAt         time.Time `json:"observed_at,omitzero"`
+	RetryAt            time.Time `json:"retry_at"`
+}
+
 func (o *Orchestrator) syncGitHubRESTCapacityOutage(state *State, now time.Time) {
 	if state == nil {
 		return
@@ -55,11 +67,11 @@ func (o *Orchestrator) syncGitHubRESTCapacityOutage(state *State, now time.Time)
 		now = o.clockNow()
 	}
 	key, existing, exists := githubRESTCapacityOutage(state.BackendOutages)
-	bucket := gitHubRESTBucketFromState(state)
-	if bucket == nil {
+	evidence, exceeded, observed := gitHubRESTCapacityObservation(state, o.cfg.GitHubRESTMinReserve, now)
+	if !observed {
 		return
 	}
-	if !gitHubRESTCapacityExceeded(bucket, o.cfg.GitHubRESTMinReserve, now) {
+	if !exceeded {
 		if exists {
 			delete(state.BackendOutages, key)
 			o.activateDispatchRecovery(
@@ -77,6 +89,70 @@ func (o *Orchestrator) syncGitHubRESTCapacityOutage(state *State, now time.Time)
 		}
 		return
 	}
+	o.setGitHubRESTCapacityOutage(state, evidence, now)
+}
+
+func gitHubRESTCapacityObservation(state *State, floor int64, now time.Time) (githubRESTBudgetEvidence, bool, bool) {
+	if state == nil || state.RateLimits == nil {
+		return githubRESTBudgetEvidence{}, false, false
+	}
+	selected := githubRESTBudgetEvidence{}
+	exceeded := false
+	observed := false
+	if bucket := state.RateLimits.GitHubREST; bucket != nil && bucket.Limit > 0 {
+		observed = true
+		if gitHubRESTCapacityExceeded(bucket, floor, now) {
+			candidate := githubRESTBudgetEvidence{
+				Consumer:  telemetry.RESTConsumerOrchestrator,
+				Remaining: bucket.Remaining,
+				Limit:     bucket.Limit,
+				Reserve:   floor,
+				ResetAt:   bucket.ResetAt.UTC(),
+			}
+			if bucket.ObservedAt != nil {
+				candidate.ObservedAt = bucket.ObservedAt.UTC()
+			}
+			selected = candidate
+			exceeded = true
+		}
+	}
+	for _, budget := range state.RateLimits.GitHubRESTBudgets {
+		consumer := strings.TrimSpace(budget.Consumer)
+		if consumer != telemetry.RESTConsumerWorker && consumer != telemetry.RESTConsumerSharedPool ||
+			budget.MinRemainingReserve <= 0 || budget.ResetAt == nil {
+			continue
+		}
+		observed = true
+		if !budget.ResetAt.After(now) || budget.Remaining > budget.MinRemainingReserve {
+			continue
+		}
+		candidate := githubRESTBudgetEvidence{
+			Consumer:           consumer,
+			CredentialIdentity: strings.TrimSpace(budget.CredentialIdentity),
+			Remaining:          budget.Remaining,
+			Limit:              budget.Limit,
+			Reserve:            budget.MinRemainingReserve,
+			ResetAt:            budget.ResetAt.UTC(),
+		}
+		if budget.ObservedAt != nil {
+			candidate.ObservedAt = budget.ObservedAt.UTC()
+		}
+		if !exceeded || candidate.ResetAt.After(selected.ResetAt) {
+			selected = candidate
+		}
+		exceeded = true
+	}
+	return selected, exceeded, observed
+}
+
+func (o *Orchestrator) setGitHubRESTCapacityOutage(state *State, evidence githubRESTBudgetEvidence, now time.Time) BackendOutage {
+	if state == nil {
+		return BackendOutage{}
+	}
+	if now.IsZero() {
+		now = o.clockNow()
+	}
+	_, existing, exists := githubRESTCapacityOutage(state.BackendOutages)
 
 	if state.BackendOutages == nil {
 		state.BackendOutages = map[string]BackendOutage{}
@@ -85,15 +161,23 @@ func (o *Orchestrator) syncGitHubRESTCapacityOutage(state *State, now time.Time)
 	if exists && !existing.DetectedAt.IsZero() {
 		detectedAt = existing.DetectedAt
 	}
-	resetAt := bucket.ResetAt.UTC()
+	resetAt := evidence.ResetAt.UTC()
+	resumeAt := resetAt
+	if !resumeAt.After(now) {
+		resumeAt = now.Add(backendCapacityResetJitter)
+	}
+	lastObservedAt := now
+	if !evidence.ObservedAt.IsZero() {
+		lastObservedAt = evidence.ObservedAt.UTC()
+	}
 	outage := BackendOutage{
 		Scope:          githubRESTCapacityScope,
 		Kind:           githubRESTCapacityKind,
-		Reason:         fmt.Sprintf("GitHub REST remaining %d is at or below dispatch floor %d", bucket.Remaining, o.cfg.GitHubRESTMinReserve),
+		Reason:         githubRESTCapacityReason(evidence),
 		DetectedAt:     detectedAt,
-		LastObservedAt: now,
+		LastObservedAt: lastObservedAt,
 		ResetAt:        resetAt,
-		ResumeAt:       resetAt,
+		ResumeAt:       resumeAt,
 	}
 	state.BackendOutages[githubRESTCapacityScope.Key()] = outage
 	o.markDispatchRecoveryWait(state, dispatchRecoveryGitHubREST, outage.Reason, outage.ResumeAt, now)
@@ -104,6 +188,19 @@ func (o *Orchestrator) syncGitHubRESTCapacityOutage(state *State, now time.Time)
 			Message: githubRESTCapacityStatusMessage(outage),
 		})
 	}
+	return outage
+}
+
+func githubRESTCapacityReason(evidence githubRESTBudgetEvidence) string {
+	consumer := strings.TrimSpace(evidence.Consumer)
+	if consumer == "" || consumer == telemetry.RESTConsumerOrchestrator {
+		return fmt.Sprintf("GitHub REST remaining %d is at or below dispatch floor %d", evidence.Remaining, evidence.Reserve)
+	}
+	reason := fmt.Sprintf("GitHub REST %s remaining %d is at or below reserved headroom %d", consumer, evidence.Remaining, evidence.Reserve)
+	if credential := strings.TrimSpace(evidence.CredentialIdentity); credential != "" {
+		reason += " for credential " + credential
+	}
+	return reason
 }
 
 func gitHubRESTCapacityExceeded(bucket *telemetry.RateLimitBucket, floor int64, now time.Time) bool {
@@ -141,14 +238,49 @@ func (o *Orchestrator) handleGitHubRESTCapacityCompletion(
 	event runpkg.Completion,
 	running Running,
 ) bool {
-	outage, ok := activeGitHubRESTCapacityOutage(state, event.CompletedAt)
-	if !ok {
+	evidence, headroom := githubRESTBudgetEvidenceFromError(event.Err)
+	outage, active := activeGitHubRESTCapacityOutage(state, event.CompletedAt)
+	if headroom {
+		if current, ok := currentGitHubRESTBudget(state, evidence); ok {
+			evidence.Limit = current.Limit
+			evidence.ObservedAt = current.ObservedAt
+			if evidence.ResetAt.IsZero() {
+				evidence.ResetAt = current.ResetAt
+			}
+			if evidence.Consumer == "" {
+				evidence.Consumer = current.Consumer
+			}
+			if evidence.CredentialIdentity == "" {
+				evidence.CredentialIdentity = current.CredentialIdentity
+			}
+		}
+		if evidence.ObservedAt.IsZero() {
+			evidence.ObservedAt = event.CompletedAt.UTC()
+		}
+		recordGitHubRESTBudgetEvidence(state, evidence)
+		outage = o.setGitHubRESTCapacityOutage(state, evidence, event.CompletedAt)
+	} else if !active {
 		return false
 	}
 	running = o.restoreBackendCapacityIssueState(ctx, state, running, event.CompletedAt)
 	errorMessage := githubRESTCapacityStatusMessage(outage)
 	if event.Err != nil {
 		errorMessage = event.Err.Error()
+	}
+	metadata := map[string]any(nil)
+	retryAt := time.Time{}
+	if headroom {
+		retryAt = backendCapacityResumeAt(evidence.ResetAt, event.CompletedAt)
+		metadata = map[string]any{"github_rest_wait": githubRESTWaitMetadata{
+			Consumer:           evidence.Consumer,
+			CredentialIdentity: evidence.CredentialIdentity,
+			Remaining:          evidence.Remaining,
+			Limit:              evidence.Limit,
+			Reserve:            evidence.Reserve,
+			ResetAt:            evidence.ResetAt,
+			ObservedAt:         evidence.ObservedAt,
+			RetryAt:            retryAt,
+		}}
 	}
 	attemptCompleted := o.completeDurableWorkAttemptWithMetadata(
 		ctx,
@@ -160,7 +292,7 @@ func (o *Orchestrator) handleGitHubRESTCapacityCompletion(
 		errorMessage,
 		"waiting",
 		githubRESTCapacityStatusMessage(outage),
-		nil,
+		metadata,
 	)
 	if workspaceIssueTerminal(running.Issue, o.cfg.TerminalStates) {
 		o.releaseClaim(state, running.Issue.ID)
@@ -181,13 +313,181 @@ func (o *Orchestrator) handleGitHubRESTCapacityCompletion(
 	if parked {
 		return true
 	}
-	o.scheduleBackendCapacityRetry(state, running, outage)
+	if headroom {
+		o.deferProjectFailureBreakerCanary(state, event.IssueID, event.CompletedAt, retryAt.Sub(event.CompletedAt))
+		o.scheduleGitHubRESTCapacityRetry(state, running, outage, retryAt)
+	} else {
+		o.scheduleBackendCapacityRetry(state, running, outage)
+	}
 	recordStateEvent(state, telemetry.ActivityEvent{
 		At:      event.CompletedAt,
 		Event:   "github_rest_capacity_completion_deferred",
 		Message: githubRESTCapacityStatusMessage(outage),
 	})
 	return true
+}
+
+func recordGitHubRESTBudgetEvidence(state *State, evidence githubRESTBudgetEvidence) {
+	if state == nil || evidence.Reserve <= 0 || evidence.ResetAt.IsZero() {
+		return
+	}
+	if state.RateLimits == nil {
+		state.RateLimits = &telemetry.RateLimits{}
+	}
+	consumer := strings.TrimSpace(evidence.Consumer)
+	if consumer == "" {
+		consumer = telemetry.RESTConsumerWorker
+	}
+	endpointFamily := "worker credential"
+	if consumer == telemetry.RESTConsumerSharedPool {
+		endpointFamily = "shared credential pool"
+	}
+	resetAt := evidence.ResetAt.UTC()
+	observedAt := evidence.ObservedAt.UTC()
+	used := int64(0)
+	if evidence.Limit > evidence.Remaining {
+		used = evidence.Limit - evidence.Remaining
+	}
+	state.RateLimits.GitHubRESTBudgets = mergeRESTBudgets(state.RateLimits.GitHubRESTBudgets, []telemetry.RESTBudget{{
+		Consumer:            consumer,
+		CredentialIdentity:  strings.TrimSpace(evidence.CredentialIdentity),
+		EndpointFamily:      endpointFamily,
+		Resource:            "core",
+		Remaining:           evidence.Remaining,
+		Used:                used,
+		Limit:               evidence.Limit,
+		MinRemainingReserve: evidence.Reserve,
+		ResetAt:             &resetAt,
+		ObservedAt:          &observedAt,
+	}})
+}
+
+func (o *Orchestrator) scheduleGitHubRESTCapacityRetry(state *State, running Running, outage BackendOutage, retryAt time.Time) {
+	issue := cloneIssue(running.Issue)
+	state.Retry[issue.ID] = Retry{
+		Issue:         issue,
+		Attempt:       running.Attempt,
+		DueAt:         retryAt,
+		Error:         githubRESTCapacityStatusMessage(outage),
+		WorkerHost:    running.WorkerHost,
+		CapacityScope: outage.Scope,
+	}
+}
+
+func (o *Orchestrator) recoverGitHubRESTCapacityWaits(ctx context.Context, state *State, attempts []store.WorkAttempt, now time.Time) {
+	if state == nil || len(attempts) == 0 {
+		return
+	}
+	latest := latestStoreTerminalAttemptsByIssue(attempts)
+	waits := make(map[string]githubRESTWaitMetadata, len(latest))
+	issueIDs := make([]string, 0, len(latest))
+	for issueID, attempt := range latest {
+		metadata, ok := githubRESTWaitMetadataFromAttempt(attempt)
+		if !ok {
+			continue
+		}
+		waits[issueID] = metadata
+		issueIDs = append(issueIDs, issueID)
+	}
+	if len(waits) == 0 {
+		return
+	}
+	issuesByID, validated := o.validateGitHubRESTWaitIssues(ctx, issueIDs)
+	for issueID, metadata := range waits {
+		attempt := latest[issueID]
+		issue := githubRESTWaitIssueFromAttempt(attempt)
+		if validated {
+			var ok bool
+			issue, ok = issuesByID[issueID]
+			if !ok || !stateIn(issue.State, o.cfg.ActiveStates) || workspaceIssueTerminal(issue, o.cfg.TerminalStates) {
+				continue
+			}
+		}
+		o.restoreGitHubRESTCapacityWait(state, issue, attempt, metadata, now)
+	}
+	o.syncGitHubRESTCapacityOutage(state, now)
+}
+
+func githubRESTWaitMetadataFromAttempt(attempt store.WorkAttempt) (githubRESTWaitMetadata, bool) {
+	if attempt.TerminalState != store.WorkAttemptTerminalCapacity || strings.TrimSpace(attempt.ErrorClass) != githubRESTCapacityError {
+		return githubRESTWaitMetadata{}, false
+	}
+	var metadata struct {
+		GitHubRESTWait githubRESTWaitMetadata `json:"github_rest_wait"`
+	}
+	if json.Unmarshal([]byte(attempt.WorkerMetadataJSON), &metadata) != nil {
+		return githubRESTWaitMetadata{}, false
+	}
+	wait := metadata.GitHubRESTWait
+	wait.Consumer = strings.TrimSpace(wait.Consumer)
+	wait.CredentialIdentity = strings.TrimSpace(wait.CredentialIdentity)
+	if wait.Consumer != telemetry.RESTConsumerWorker && wait.Consumer != telemetry.RESTConsumerSharedPool ||
+		wait.CredentialIdentity == "" || wait.Reserve <= 0 || wait.ResetAt.IsZero() || wait.RetryAt.IsZero() || wait.RetryAt.Before(wait.ResetAt) {
+		return githubRESTWaitMetadata{}, false
+	}
+	return wait, true
+}
+
+func (o *Orchestrator) validateGitHubRESTWaitIssues(ctx context.Context, issueIDs []string) (map[string]connector.Issue, bool) {
+	if o == nil || o.connector == nil || len(issueIDs) == 0 {
+		return nil, false
+	}
+	issues, err := o.connector.FetchIssueStatesByIDs(ctx, issueIDs)
+	if err != nil {
+		if o.logger != nil {
+			o.logger.Warn("GitHub REST wait issue validation failed; preserving durable waits", "issue_ids", issueIDs, "error", err)
+		}
+		return nil, false
+	}
+	byID := make(map[string]connector.Issue, len(issues))
+	for _, issue := range issues {
+		if issueID := strings.TrimSpace(issue.ID); issueID != "" {
+			byID[issueID] = issue
+		}
+	}
+	return byID, true
+}
+
+func githubRESTWaitIssueFromAttempt(attempt store.WorkAttempt) connector.Issue {
+	issue := connector.NewIssue()
+	issue.ID = strings.TrimSpace(attempt.IssueID)
+	issue.Identifier = strings.TrimSpace(attempt.Identifier)
+	issue.URL = strings.TrimSpace(attempt.IssueURL)
+	issue.State = strings.TrimSpace(attempt.Lane)
+	issue.PRRepository = strings.TrimSpace(attempt.Repo)
+	if attempt.PRNumber != nil && *attempt.PRNumber > 0 {
+		number := int(*attempt.PRNumber)
+		issue.PRNumber = &number
+	}
+	return issue
+}
+
+func (o *Orchestrator) restoreGitHubRESTCapacityWait(state *State, issue connector.Issue, attempt store.WorkAttempt, metadata githubRESTWaitMetadata, now time.Time) {
+	observedAt := metadata.ObservedAt
+	if observedAt.IsZero() {
+		observedAt = attempt.CompletedAt
+	}
+	recordGitHubRESTBudgetEvidence(state, githubRESTBudgetEvidence{
+		Consumer:           metadata.Consumer,
+		CredentialIdentity: metadata.CredentialIdentity,
+		Remaining:          metadata.Remaining,
+		Limit:              metadata.Limit,
+		Reserve:            metadata.Reserve,
+		ResetAt:            metadata.ResetAt,
+		ObservedAt:         observedAt,
+	})
+	retryAt := metadata.RetryAt
+	if retryAt.Before(now) {
+		retryAt = now
+	}
+	state.Retry[issue.ID] = Retry{
+		Issue:         cloneIssue(issue),
+		Attempt:       attempt.AttemptNumber,
+		DueAt:         retryAt.UTC(),
+		Error:         strings.TrimSpace(attempt.ErrorMessage),
+		WorkerHost:    strings.TrimSpace(attempt.WorkerHost),
+		CapacityScope: githubRESTCapacityScope,
+	}
 }
 
 func isGitHubRESTBudgetHeadroomError(err error) bool {

--- a/internal/orchestrator/rate_limit_test.go
+++ b/internal/orchestrator/rate_limit_test.go
@@ -566,6 +566,235 @@ func TestGitHubRESTCapacityOutagePausesDispatchAndResumesAtReset(t *testing.T) {
 	}
 }
 
+func TestWorkerGitHubRESTReservePausesDispatchAboveTrackerFloor(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 8, 15, 23, 21, 0, 0, time.UTC)
+	resetAt := now.Add(39 * time.Minute)
+	issue := connector.Issue{
+		ID:               "issue-1929-dispatch",
+		Identifier:       "gopher-corp#521",
+		Title:            "Protect worker REST headroom",
+		State:            "In Progress",
+		URL:              "https://github.test/gopher-corp/issues/521",
+		AssignedToWorker: true,
+	}
+	cfg := normalizeConfig(Config{
+		Project:              scheduler.ProjectCandidate{ID: "gopher-corp"},
+		MaxConcurrentAgents:  1,
+		ActiveStates:         []string{"Todo", "In Progress"},
+		TerminalStates:       []string{"Done", "Cancelled"},
+		GitHubRESTMinReserve: 1000,
+	})
+	state := newState(cfg)
+	state.RateLimits = &telemetry.RateLimits{
+		GitHubREST: &telemetry.RateLimitBucket{
+			Limit: 5000, Used: 3991, Remaining: 1009, ResetAt: &resetAt, ObservedAt: timePointer(now),
+		},
+		GitHubRESTBudgets: []telemetry.RESTBudget{{
+			Consumer: telemetry.RESTConsumerSharedPool, CredentialIdentity: "github-rest:worker",
+			EndpointFamily: "shared credential pool", Resource: "core", Limit: 5000, Used: 3991,
+			Remaining: 1009, MinRemainingReserve: 1250, ResetAt: &resetAt, ObservedAt: timePointer(now),
+		}},
+	}
+	orch := newRateLimitTestOrchestrator(cfg, &rateLimitConnector{})
+	orch.syncGitHubRESTCapacityOutage(&state, now)
+
+	dispatches := 0
+	var decision dispatchPlanDecision
+	orch.dispatchPlanner().plan(&state, []connector.Issue{issue}, now, dispatchPlanHooks{
+		dispatch: func(dispatchAction) bool {
+			dispatches++
+			return true
+		},
+		decision: func(candidate dispatchPlanDecision) {
+			decision = candidate
+		},
+	})
+
+	if dispatches != 0 {
+		t.Fatalf("dispatches = %d, want 0 below worker reserve", dispatches)
+	}
+	if decision.SkipReason != dispatchSkipGitHubRESTCapacity {
+		t.Fatalf("SkipReason = %q, want %q", decision.SkipReason, dispatchSkipGitHubRESTCapacity)
+	}
+	outage, ok := activeGitHubRESTCapacityOutage(&state, now)
+	if !ok || !outage.ResumeAt.Equal(resetAt) || !strings.Contains(outage.Reason, "1250") {
+		t.Fatalf("GitHub REST outage = %#v, want worker reserve wait until %s", outage, resetAt)
+	}
+}
+
+func TestWorkerGitHubRESTHeadroomCompletionDefersWithoutBreakerStrike(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 8, 15, 23, 22, 25, 0, time.UTC)
+	resetAt := time.Date(2026, 8, 16, 0, 0, 0, 0, time.UTC)
+	issue := implementProgressIssueWithoutPR()
+	issue.ID = "issue-1929-completion"
+	issue.Identifier = "gopher-corp#521"
+	cfg := normalizeConfig(Config{
+		Project:             scheduler.ProjectCandidate{ID: "gopher-corp"},
+		MaxConcurrentAgents: 1,
+		ActiveStates:        []string{"Todo", "In Progress"},
+		TerminalStates:      []string{"Done", "Cancelled"},
+	})
+	attempts := &implementProgressAttemptStore{}
+	orch := &Orchestrator{
+		cfg:          cfg,
+		connector:    &implementProgressConnector{},
+		workAttempts: attempts,
+		logger:       slog.New(slog.NewTextHandler(io.Discard, nil)),
+	}
+	state := newState(cfg)
+	state.Running[issue.ID] = Running{
+		Issue: issue, Attempt: 4, WorkAttemptID: 42, Mode: runpkg.RunModeImplement,
+		StartedAt: now.Add(-42 * time.Second), DiffStats: DiffStats{Status: "clean"},
+	}
+	state.Claimed[issue.ID] = Claimed{Issue: issue, ClaimedAt: now.Add(-42 * time.Second)}
+	state.InstantFailures[issue.ID] = InstantFailure{Issue: issue, Count: instantFailureThreshold - 1}
+	state.RepeatedFailures[issue.ID] = RepeatedFailure{Issue: issue, Count: repeatedFailureThreshold - 1}
+	state.FailureBreaker.Failures["existing"] = []ProjectFailure{{IssueID: "other", At: now.Add(-time.Minute)}}
+	headroomErr := errors.New("run agent turn: worker github REST budget reached reserved headroom: consumer=shared_pool credential_identity=github-rest:worker remaining=1009 reserve=1250 reset_at=2026-08-16T00:00:00Z")
+	workerBudget := telemetry.RESTBudget{
+		Consumer: telemetry.RESTConsumerSharedPool, CredentialIdentity: "github-rest:worker",
+		EndpointFamily: "shared credential pool", Resource: "core", Limit: 5000, Used: 3991,
+		Remaining: 1009, MinRemainingReserve: 1250, ResetAt: &resetAt, ObservedAt: timePointer(now),
+	}
+
+	orch.handleRunResult(context.Background(), &state, runpkg.Completion{
+		IssueID: issue.ID, CompletedAt: now, RetryAttempt: 5, RetryDelay: 5 * time.Minute,
+		Request: runpkg.RunRequest{Issue: issue, Attempt: 4, Mode: runpkg.RunModeImplement},
+		Result: runpkg.RunResult{
+			FinalState: runpkg.FinalStateFailed,
+			DiffStats:  DiffStats{Status: "clean"},
+			RateLimits: &telemetry.RateLimits{GitHubRESTBudgets: []telemetry.RESTBudget{workerBudget}},
+		},
+		Err: headroomErr,
+	})
+
+	if len(attempts.completions) != 1 || attempts.completions[0].TerminalState != store.WorkAttemptTerminalCapacity {
+		t.Fatalf("completions = %#v, want one capacity terminal", attempts.completions)
+	}
+	if attempts.completions[0].ErrorClass != githubRESTCapacityError || !strings.Contains(attempts.completions[0].WorkerMetadataJSON, `"github_rest_wait"`) {
+		t.Fatalf("completion = %#v, want durable GitHub REST wait metadata", attempts.completions[0])
+	}
+	retry, ok := state.Retry[issue.ID]
+	wantRetryAt := resetAt.Add(backendCapacityResetJitter)
+	if !ok || retry.Attempt != 4 || !retry.DueAt.Equal(wantRetryAt) {
+		t.Fatalf("Retry[%q] = %#v, want same-attempt retry at %s", issue.ID, retry, wantRetryAt)
+	}
+	if got := state.InstantFailures[issue.ID].Count; got != instantFailureThreshold-1 {
+		t.Fatalf("instant failure count = %d, want unchanged", got)
+	}
+	if got := state.RepeatedFailures[issue.ID].Count; got != repeatedFailureThreshold-1 {
+		t.Fatalf("repeated failure count = %d, want unchanged", got)
+	}
+	if got := len(state.FailureBreaker.Failures["existing"]); got != 1 || state.FailureBreaker.Active() {
+		t.Fatalf("FailureBreaker = %#v, want existing evidence unchanged and inactive", state.FailureBreaker)
+	}
+	if _, blocked := state.Blocked[issue.ID]; blocked {
+		t.Fatalf("Blocked[%q] present after capacity deferral", issue.ID)
+	}
+}
+
+func TestRecoverDurableWorkerGitHubRESTWait(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 8, 15, 23, 30, 0, 0, time.UTC)
+	resetAt := time.Date(2026, 8, 16, 0, 0, 0, 0, time.UTC)
+	retryAt := resetAt.Add(backendCapacityResetJitter)
+	issue := connector.Issue{ID: "issue-1929-restart", Identifier: "gopher-corp#521", State: "In Progress"}
+	metadata := `{"github_rest_wait":{"consumer":"shared_pool","credential_identity":"github-rest:worker","remaining":1009,"limit":5000,"reserve":1250,"reset_at":"` + resetAt.Format(time.RFC3339) + `","retry_at":"` + retryAt.Format(time.RFC3339) + `"}}`
+	attempts := &recordingWorkAttemptStore{recent: []store.WorkAttempt{{
+		ID: 1929, ProjectID: "gopher-corp", IssueID: issue.ID, Identifier: issue.Identifier,
+		Lane: issue.State, AttemptNumber: 4, Status: store.WorkAttemptStatusTerminal,
+		CompletedAt: now.Add(-time.Minute), TerminalState: store.WorkAttemptTerminalCapacity,
+		ErrorClass: githubRESTCapacityError, ErrorMessage: "worker GitHub REST reserve reached",
+		WorkerMetadataJSON: metadata,
+	}}}
+	cfg := normalizeConfig(Config{
+		Project: scheduler.ProjectCandidate{ID: "gopher-corp"}, ActiveStates: []string{"Todo", "In Progress"},
+		TerminalStates: []string{"Done"}, MaxConcurrentAgents: 1,
+	})
+	orch := &Orchestrator{
+		cfg: cfg, connector: &rateLimitConnector{issuesByID: []connector.Issue{issue}},
+		workAttempts: attempts, logger: slog.New(slog.NewTextHandler(io.Discard, nil)),
+	}
+	state := newState(cfg)
+
+	orch.recoverDurableWorkAttempts(context.Background(), &state, now)
+
+	retry, ok := state.Retry[issue.ID]
+	if !ok || retry.Attempt != 4 || !retry.DueAt.Equal(retryAt) || !retry.CapacityScope.Matches(githubRESTCapacityScope) {
+		t.Fatalf("Retry[%q] = %#v, want restored REST capacity wait", issue.ID, retry)
+	}
+	if outage, ok := activeGitHubRESTCapacityOutage(&state, now); !ok || !outage.ResumeAt.Equal(resetAt) {
+		t.Fatalf("BackendOutages = %#v, want restored REST outage until %s", state.BackendOutages, resetAt)
+	}
+	if terminalAttemptRetryableFailure(telemetryWorkAttempt(attempts.recent[0], now)) {
+		t.Fatal("durable GitHub REST wait treated as a generic terminal retry")
+	}
+}
+
+func TestGitHubRESTWaitMetadataFromAttempt(t *testing.T) {
+	t.Parallel()
+
+	resetAt := time.Date(2026, 8, 16, 0, 0, 0, 0, time.UTC)
+	retryAt := resetAt.Add(backendCapacityResetJitter)
+	validMetadata := `{"github_rest_wait":{"consumer":"shared_pool","credential_identity":"github-rest:worker","remaining":1009,"limit":5000,"reserve":1250,"reset_at":"` + resetAt.Format(time.RFC3339) + `","retry_at":"` + retryAt.Format(time.RFC3339) + `"}}`
+	tests := []struct {
+		name     string
+		attempt  store.WorkAttempt
+		wantWait bool
+	}{
+		{
+			name: "capacity wait",
+			attempt: store.WorkAttempt{
+				TerminalState: store.WorkAttemptTerminalCapacity,
+				ErrorClass:    githubRESTCapacityError, WorkerMetadataJSON: validMetadata,
+			},
+			wantWait: true,
+		},
+		{
+			name: "generic failure",
+			attempt: store.WorkAttempt{
+				TerminalState: store.WorkAttemptTerminalFailure,
+				ErrorClass:    githubRESTCapacityError, WorkerMetadataJSON: validMetadata,
+			},
+		},
+		{
+			name: "missing credential",
+			attempt: store.WorkAttempt{
+				TerminalState:      store.WorkAttemptTerminalCapacity,
+				ErrorClass:         githubRESTCapacityError,
+				WorkerMetadataJSON: `{"github_rest_wait":{"consumer":"worker","reserve":1250,"reset_at":"` + resetAt.Format(time.RFC3339) + `","retry_at":"` + retryAt.Format(time.RFC3339) + `"}}`,
+			},
+		},
+		{
+			name: "retry before reset",
+			attempt: store.WorkAttempt{
+				TerminalState:      store.WorkAttemptTerminalCapacity,
+				ErrorClass:         githubRESTCapacityError,
+				WorkerMetadataJSON: `{"github_rest_wait":{"consumer":"worker","credential_identity":"github-rest:worker","reserve":1250,"reset_at":"` + resetAt.Format(time.RFC3339) + `","retry_at":"` + resetAt.Add(-time.Second).Format(time.RFC3339) + `"}}`,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			wait, ok := githubRESTWaitMetadataFromAttempt(tt.attempt)
+			if ok != tt.wantWait {
+				t.Fatalf("githubRESTWaitMetadataFromAttempt() ok = %v, want %v", ok, tt.wantWait)
+			}
+			if ok && (!wait.ResetAt.Equal(resetAt) || !wait.RetryAt.Equal(retryAt)) {
+				t.Fatalf("githubRESTWaitMetadataFromAttempt() = %#v, want reset %s retry %s", wait, resetAt, retryAt)
+			}
+		})
+	}
+}
+
 func TestTickDetectsGitHubRESTExhaustionBeforeDispatch(t *testing.T) {
 	t.Parallel()
 

--- a/internal/orchestrator/repeated_failure_test.go
+++ b/internal/orchestrator/repeated_failure_test.go
@@ -22,14 +22,15 @@ type tokenCeilingRunner struct {
 }
 
 type restBudgetHeadroomRunner struct {
-	calls atomic.Int64
+	calls   atomic.Int64
+	resetAt time.Time
 }
 
 func (r *restBudgetHeadroomRunner) Run(_ context.Context, _ orchestrator.RunRequest) (orchestrator.RunResult, error) {
 	n := r.calls.Add(1)
 	return orchestrator.RunResult{}, fmt.Errorf(
-		"run agent turn: worker github REST budget reached reserved headroom: consumer=shared_pool credential_identity=github-rest:worker remaining=%d reserve=1250 reset_at=2026-08-16T01:00:00Z",
-		950-n,
+		"run agent turn: worker github REST budget reached reserved headroom: consumer=shared_pool credential_identity=github-rest:worker remaining=%d reserve=1250 reset_at=%s",
+		950-n, r.resetAt.Format(time.RFC3339),
 	)
 }
 
@@ -146,12 +147,13 @@ func TestRunRepeatedFailureCounterResetsOnSuccessfulCompletion(t *testing.T) {
 	}
 }
 
-func TestRunParksRESTBudgetFailuresAsTransientRecovery(t *testing.T) {
+func TestRunDefersRESTBudgetFailureAsCapacityWithoutBreaker(t *testing.T) {
 	t.Parallel()
 
 	issue := testIssue("issue-rest-budget-park", "digitaldrywood/detent#1824", "Todo")
 	tracker := newFakeConnector(issue)
-	runner := &restBudgetHeadroomRunner{}
+	resetAt := time.Now().UTC().Add(time.Hour).Truncate(time.Second)
+	runner := &restBudgetHeadroomRunner{resetAt: resetAt}
 	metrics := &workflowMetricsRecorder{}
 
 	orch, err := orchestrator.New(orchestrator.Config{
@@ -172,38 +174,35 @@ func TestRunParksRESTBudgetFailuresAsTransientRecovery(t *testing.T) {
 		t.Fatalf("New() error = %v", err)
 	}
 	stop := runOrchestrator(t, orch)
-
-	var metadataJSON string
-	waitForState(t, orch, func(state orchestrator.State) bool {
-		for _, event := range metrics.snapshot() {
-			if event.PhaseName == "Blocked" && strings.Contains(event.MetadataJSON, `"predicate":"github_rest_budget_recovered"`) {
-				metadataJSON = event.MetadataJSON
-				return true
-			}
-		}
-		return false
+	state := waitForState(t, orch, func(state orchestrator.State) bool {
+		_, ok := state.Retry[issue.ID]
+		return ok
 	})
 	stop()
 
-	for _, want := range []string{
-		`"cause":"repeated_failure_circuit_breaker"`,
-		`"target_state":"In Progress"`,
-		`"resource_kind":"github_rest_rate_limit"`,
-		`"resource_consumer":"shared_pool"`,
-		`"resource_credential":"github-rest:worker"`,
-		`"resource_remaining":945`,
-		`"resource_reserve":1250`,
-		`"resource_reset_at":"2026-08-16T01:00:00Z"`,
-	} {
-		if !strings.Contains(metadataJSON, want) {
-			t.Fatalf("workflow metadata = %q, want %q", metadataJSON, want)
+	retry := state.Retry[issue.ID]
+	if want := resetAt.Add(5 * time.Second); !retry.DueAt.Equal(want) {
+		t.Fatalf("retry DueAt = %s, want %s", retry.DueAt, want)
+	}
+	if got := runner.calls.Load(); got != 1 {
+		t.Fatalf("runner calls = %d, want 1 before reset", got)
+	}
+	if _, ok := state.Blocked[issue.ID]; ok {
+		t.Fatalf("Blocked[%q] present after capacity deferral", issue.ID)
+	}
+	if _, ok := state.RepeatedFailures[issue.ID]; ok {
+		t.Fatalf("RepeatedFailures[%q] present after capacity deferral", issue.ID)
+	}
+	if state.FailureBreaker.Active() {
+		t.Fatalf("FailureBreaker = %#v, want inactive", state.FailureBreaker)
+	}
+	for _, event := range metrics.snapshot() {
+		if event.PhaseName == "Blocked" {
+			t.Fatalf("workflow event = %#v, want no breaker transition", event)
 		}
 	}
-	comments := tracker.commentCalls()
-	if len(comments) != 1 ||
-		!strings.Contains(comments[0].body, "transient resource wait") ||
-		!strings.Contains(comments[0].body, "remaining=945 reserve=1250") {
-		t.Fatalf("comments = %#v, want transient REST-budget explanation", comments)
+	if comments := tracker.commentCalls(); len(comments) != 0 {
+		t.Fatalf("comments = %#v, want no breaker explanation", comments)
 	}
 }
 

--- a/internal/orchestrator/run_completion.go
+++ b/internal/orchestrator/run_completion.go
@@ -228,7 +228,7 @@ func (o *Orchestrator) handleRunResult(ctx context.Context, state *State, event 
 	if event.Err == nil || event.Result.TurnStarted {
 		o.recordProjectFailureBreakerProgress(state, event.IssueID, event.CompletedAt)
 		o.advanceDispatchRecovery(state, event.IssueID, event.CompletedAt)
-	} else {
+	} else if !isGitHubRESTBudgetHeadroomError(event.Err) {
 		delay := event.RetryDelay
 		if delay <= 0 {
 			delay = o.cfg.OverloadRetryDelay
@@ -258,7 +258,7 @@ func (o *Orchestrator) handleRunResult(ctx context.Context, state *State, event 
 		return
 	}
 	if o.handleGitHubRESTCapacityCompletion(ctx, state, event, running) {
-		o.recordProjectAttemptOutcome(state, event.IssueID, event.CompletedAt, store.WorkAttemptTerminalFailure, event.Err, "github_rest_capacity", errorString(event.Err))
+		o.recordProjectAttemptOutcome(state, event.IssueID, event.CompletedAt, store.WorkAttemptTerminalCapacity, event.Err, githubRESTCapacityError, errorString(event.Err))
 		return
 	}
 	if capacityErr, ok := backendcapacity.As(event.Err); ok {

--- a/internal/orchestrator/terminal_attempt_retry.go
+++ b/internal/orchestrator/terminal_attempt_retry.go
@@ -437,7 +437,7 @@ func workAttemptCompletedAfter(left telemetry.WorkAttempt, right telemetry.WorkA
 }
 
 func terminalAttemptRetryableFailure(attempt telemetry.WorkAttempt) bool {
-	if strings.TrimSpace(attempt.ErrorClass) == forgeUnavailableErrorClass {
+	if strings.TrimSpace(attempt.ErrorClass) == forgeUnavailableErrorClass || strings.TrimSpace(attempt.ErrorClass) == githubRESTCapacityError {
 		return false
 	}
 	return terminalAttemptStateRetryDemotable(store.WorkAttemptTerminalState(strings.ToLower(strings.TrimSpace(attempt.TerminalState))))

--- a/internal/orchestrator/terminal_attempt_retry.go
+++ b/internal/orchestrator/terminal_attempt_retry.go
@@ -437,8 +437,19 @@ func workAttemptCompletedAfter(left telemetry.WorkAttempt, right telemetry.WorkA
 }
 
 func terminalAttemptRetryableFailure(attempt telemetry.WorkAttempt) bool {
-	if strings.TrimSpace(attempt.ErrorClass) == forgeUnavailableErrorClass || strings.TrimSpace(attempt.ErrorClass) == githubRESTCapacityError {
+	errorClass := strings.TrimSpace(attempt.ErrorClass)
+	if errorClass == forgeUnavailableErrorClass {
 		return false
+	}
+	if errorClass == githubRESTCapacityError {
+		_, durable := githubRESTWaitMetadataFromAttempt(store.WorkAttempt{
+			TerminalState:      store.WorkAttemptTerminalState(strings.ToLower(strings.TrimSpace(attempt.TerminalState))),
+			ErrorClass:         errorClass,
+			WorkerMetadataJSON: attempt.WorkerMetadataJSON,
+		})
+		if durable {
+			return false
+		}
 	}
 	return terminalAttemptStateRetryDemotable(store.WorkAttemptTerminalState(strings.ToLower(strings.TrimSpace(attempt.TerminalState))))
 }

--- a/internal/orchestrator/terminal_attempt_retry_test.go
+++ b/internal/orchestrator/terminal_attempt_retry_test.go
@@ -693,6 +693,60 @@ func terminalRetryFailureAttempts(issueID string, now time.Time, count int) []te
 	return attempts
 }
 
+func TestReconcileTerminalAttemptRetryStatesHandlesGitHubRESTCapacityCompatibility(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 8, 20, 10, 0, 0, 0, time.UTC)
+	resetAt := now.Add(time.Hour)
+	retryAt := resetAt.Add(backendCapacityResetJitter)
+	durableMetadata := `{"github_rest_wait":{"consumer":"shared_pool","credential_identity":"github-rest:worker","remaining":1009,"limit":5000,"reserve":1250,"reset_at":"` + resetAt.Format(time.RFC3339) + `","retry_at":"` + retryAt.Format(time.RFC3339) + `"}}`
+	tests := []struct {
+		name         string
+		metadata     string
+		wantState    string
+		wantDemotion bool
+	}{
+		{name: "legacy metadata-less attempt", wantState: "Todo", wantDemotion: true},
+		{name: "durable wait metadata", metadata: durableMetadata, wantState: "In Progress"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			issue := terminalRetryTestIssue(strings.ReplaceAll(tt.name, " ", "-"))
+			tracker := &terminalRetryConnector{issues: map[string]connector.Issue{issue.ID: cloneIssue(issue)}}
+			cfg := normalizeConfig(Config{ActiveStates: []string{"Todo", "In Progress"}, TerminalStates: []string{"Done"}})
+			o := &Orchestrator{cfg: cfg, connector: tracker}
+			state := newState(cfg)
+			state.WorkAttempts = []telemetry.WorkAttempt{{
+				AttemptID:          1,
+				IssueID:            issue.ID,
+				Identifier:         issue.Identifier,
+				Status:             string(store.WorkAttemptStatusTerminal),
+				TerminalState:      string(store.WorkAttemptTerminalCapacity),
+				ErrorClass:         githubRESTCapacityError,
+				CompletedAt:        timePointer(now.Add(-time.Minute)),
+				WorkerMetadataJSON: tt.metadata,
+			}}
+
+			transitions := o.reconcileTerminalAttemptRetryStates(t.Context(), &state, []connector.Issue{issue}, now)
+
+			if got := len(transitions) == 1; got != tt.wantDemotion {
+				t.Fatalf("demoted = %v, want %v: %#v", got, tt.wantDemotion, transitions)
+			}
+			if tt.wantDemotion && transitions[0].State != tt.wantState {
+				t.Fatalf("transition state = %q, want %q", transitions[0].State, tt.wantState)
+			}
+			if got := tracker.transitionStates(); tt.wantDemotion && !slices.Equal(got, []string{tt.wantState}) {
+				t.Fatalf("state transitions = %v, want [%s]", got, tt.wantState)
+			} else if !tt.wantDemotion && len(got) != 0 {
+				t.Fatalf("state transitions = %v, want none", got)
+			}
+		})
+	}
+}
+
 func TestReconcileTerminalAttemptRetryStatesRespectsLiveForeignClaim(t *testing.T) {
 	t.Parallel()
 

--- a/internal/orchestrator/work_attempts.go
+++ b/internal/orchestrator/work_attempts.go
@@ -93,6 +93,7 @@ func (o *Orchestrator) recoverDurableWorkAttempts(ctx context.Context, state *St
 			o.upsertWorkAttemptSnapshot(state, telemetryWorkAttempt(recent[index], now))
 		}
 		o.recoverForgeAvailabilityWaits(ctx, state, recent, now)
+		o.recoverGitHubRESTCapacityWaits(ctx, state, recent, now)
 	}
 	decisions, err := o.workAttempts.ListRecentSchedulerDecisions(ctx, store.SchedulerDecisionQuery{
 		ProjectID: projectID,

--- a/internal/runner/capacity.go
+++ b/internal/runner/capacity.go
@@ -142,7 +142,7 @@ func configuredCapacityScope(selection RouteSelection, backend config.AgentBacke
 
 func IsCapacityError(err error) bool {
 	var capacityErr *backendcapacity.Error
-	return errors.As(err, &capacityErr)
+	return errors.Is(err, ErrWorkerGitHubRESTReserved) || errors.As(err, &capacityErr)
 }
 
 func IsTransientOverload(err error) bool {

--- a/internal/runner/supervisor_test.go
+++ b/internal/runner/supervisor_test.go
@@ -3,6 +3,7 @@ package runner
 import (
 	"context"
 	"errors"
+	"fmt"
 	"log/slog"
 	"strings"
 	"sync"
@@ -99,6 +100,35 @@ func TestSupervisorDoesNotAdvanceRetryForCapacityError(t *testing.T) {
 	if completion.Retryable || completion.RetryAttempt != 0 || completion.RetryDelay != 0 {
 		t.Fatalf("retry state = retryable %v attempt %d delay %s, want unchanged", completion.Retryable, completion.RetryAttempt, completion.RetryDelay)
 	}
+}
+
+func TestSupervisorDoesNotApplyGenericBackoffToGitHubRESTHeadroom(t *testing.T) {
+	t.Parallel()
+
+	supervisor, err := NewSupervisor(gitHubRESTHeadroomBackend{}, SupervisorConfig{
+		FailureRetryBaseDelay: 10 * time.Second,
+		MaxRetryBackoff:       5 * time.Minute,
+	})
+	if err != nil {
+		t.Fatalf("NewSupervisor() error = %v", err)
+	}
+
+	completion := supervisor.Run(t.Context(), RunRequest{
+		Issue:   connector.Issue{ID: "issue-1929"},
+		Attempt: 4,
+	})
+	if !errors.Is(completion.Err, ErrWorkerGitHubRESTReserved) || !IsCapacityError(completion.Err) {
+		t.Fatalf("Err = %v, want GitHub REST capacity error", completion.Err)
+	}
+	if completion.Retryable || completion.RetryAttempt != 0 || completion.RetryDelay != 0 {
+		t.Fatalf("retry state = retryable %v attempt %d delay %s, want reset-aware orchestration", completion.Retryable, completion.RetryAttempt, completion.RetryDelay)
+	}
+}
+
+type gitHubRESTHeadroomBackend struct{}
+
+func (gitHubRESTHeadroomBackend) Run(context.Context, RunRequest) (RunResult, error) {
+	return RunResult{}, fmt.Errorf("%w: remaining=1009 reserve=1250 reset_at=2026-08-16T00:00:00Z", ErrWorkerGitHubRESTReserved)
 }
 
 func TestSupervisorDoesNotRetryOperatorStoppedRun(t *testing.T) {


### PR DESCRIPTION
## Summary

- Gate worker dispatch when the tracked GitHub REST worker or shared-pool budget reaches its configured reserve, even while the tracker floor still has headroom.
- Treat worker headroom exits as durable capacity waits that retry at reset plus jitter without advancing generic retry backoff or failure breakers.
- Restore typed GitHub REST waits across orchestrator restarts while preserving same-attempt retry semantics.

Fixes #1929

## UI Surface Contract

- [x] N/A; this PR does not change a UI surface, layout, density, first viewport, or responsive visibility.
- [x] This PR does not add persistent top-of-screen messaging.
- [x] N/A; this PR contains no visual changes to primary operator screens.

## Test Plan

- [x] `make check`