### PR TITLE
fix(orchestrator): retain yieldless failures

### DIFF
--- a/internal/codex/appserver.go
+++ b/internal/codex/appserver.go
@@ -148,6 +148,13 @@ func (e *TurnFailedError) BackendErrorMessage() string {
 	return strings.TrimSpace(e.Message)
 }
 
+func (e *TurnFailedError) BackendErrorStatus() string {
+	if e == nil {
+		return ""
+	}
+	return strings.TrimSpace(e.Status)
+}
+
 type AppServer struct {
 	transportFactory TransportFactory
 	clientInfo       ClientInfo
@@ -1882,6 +1889,14 @@ func updateFromMessage(msg Message) (Update, bool, error) {
 			status = turnCompletedTopLevelStatus(params.Status, params.Error, params.Type)
 		}
 		errorBody, errorMessage := turnCompletedBackendError(params.Error, params.Turn.Error, params.Message, params.Turn.Message, msg.Params)
+		if status != "" && !strings.EqualFold(status, "completed") && errorBody == "" && errorMessage == "" {
+			errorBody = turnCompletedMissingErrorBody(status)
+			if strings.EqualFold(status, "interrupted") {
+				errorMessage = "codex reported an interrupted turn without error detail"
+			} else {
+				errorMessage = "codex reported turn status " + strconv.Quote(status) + " without error detail"
+			}
+		}
 		return Update{
 			Type:                UpdateTurnCompleted,
 			Method:              msg.Method,
@@ -2023,7 +2038,7 @@ func turnCompletedBackendError(
 		message := firstNonBlank(errorMessageFromJSON(params), errorMessageFromJSON(topLevelError), errorMessageFromJSON(turnError), topLevelMessage, turnMessage)
 		return body, message
 	}
-	body := compactJSON(firstRawJSON(topLevelError, turnError))
+	body := compactNonNullJSON(firstRawJSON(topLevelError, turnError))
 	message := firstNonBlank(errorMessageFromJSON(topLevelError), errorMessageFromJSON(turnError), topLevelMessage, turnMessage)
 	if body != "" {
 		if message != "" {
@@ -2035,6 +2050,20 @@ func turnCompletedBackendError(
 		return compactJSON(params), message
 	}
 	return "", ""
+}
+
+func turnCompletedMissingErrorBody(status string) string {
+	body, err := json.Marshal(struct {
+		Status string `json:"status"`
+		Detail string `json:"detail"`
+	}{
+		Status: strings.TrimSpace(status),
+		Detail: "backend supplied no error",
+	})
+	if err != nil {
+		return ""
+	}
+	return string(body)
 }
 
 func firstRawJSON(values ...json.RawMessage) json.RawMessage {

--- a/internal/codex/appserver_test.go
+++ b/internal/codex/appserver_test.go
@@ -1764,6 +1764,45 @@ func TestAppServerRunTurnReportsTurnErrorBody(t *testing.T) {
 	}
 }
 
+func TestAppServerRunTurnReportsInterruptedTurnWithoutNullDetail(t *testing.T) {
+	t.Parallel()
+
+	transport := newFakeAppServerTransport([]Message{
+		responseMessage(t, 1, `{"userAgent":"codex-cli/0.142.5"}`),
+		responseMessage(t, 2, `{"thread":{"id":"thread-1","model":"gpt-5-codex"}}`),
+		responseMessage(t, 3, `{"turn":{"id":"turn-1"}}`),
+		notificationMessage(t, "turn/completed", `{"threadId":"thread-1","turn":{"id":"turn-1","status":"interrupted","error":null}}`),
+	})
+	server, err := NewAppServer(staticTransportFactory{transport: transport},
+		WithReadTimeout(time.Second),
+		WithTurnTimeout(time.Second),
+	)
+	if err != nil {
+		t.Fatalf("NewAppServer() error = %v", err)
+	}
+
+	_, err = server.RunTurn(context.Background(), RunTurnRequest{
+		Workspace: "/tmp/detent-workspace",
+		Prompt:    "Ship issue #1928",
+	}, nil)
+	if !errors.Is(err, ErrTurnFailed) {
+		t.Fatalf("RunTurn() error = %v, want ErrTurnFailed", err)
+	}
+	var turnErr *TurnFailedError
+	if !errors.As(err, &turnErr) {
+		t.Fatalf("RunTurn() error = %T, want TurnFailedError", err)
+	}
+	if got := turnErr.BackendErrorBody(); got != `{"status":"interrupted","detail":"backend supplied no error"}` {
+		t.Fatalf("BackendErrorBody = %q", got)
+	}
+	if got := turnErr.BackendErrorMessage(); got != "codex reported an interrupted turn without error detail" {
+		t.Fatalf("BackendErrorMessage = %q", got)
+	}
+	if strings.HasSuffix(err.Error(), ": null") {
+		t.Fatalf("RunTurn() error = %q, want actionable interruption detail", err)
+	}
+}
+
 type staticTransportFactory struct {
 	transport Transport
 }

--- a/internal/orchestrator/dispatch_loop.go
+++ b/internal/orchestrator/dispatch_loop.go
@@ -106,7 +106,9 @@ func dispatchLoopCurrentAdvanced(
 	found bool,
 ) bool {
 	switch strings.TrimSpace(decision.Reason) {
-	case "pull_request_created_or_updated", implementMergedCompletionReason:
+	case "pull_request_created_or_updated":
+		return implementProgressSignatureUsable(decision.CurrentSignature)
+	case implementMergedCompletionReason:
 		return true
 	case "pull_request_hydrator_unavailable", "pull_request_hydration_failed", "pull_request_hydration_unavailable",
 		"attempt_history_lookup_failed", "workspace_diffstat_unavailable", "workspace_diffstat_unavailable_without_pull_request",
@@ -153,12 +155,18 @@ func dispatchLoopRecordAdvanced(record implementProgressRecord) bool {
 	}
 	for _, kind := range record.ProgressKinds {
 		switch strings.TrimSpace(kind) {
-		case "tracker_state_transition", "pull_request", "workspace_diff":
+		case "tracker_state_transition", "workspace_diff":
 			return true
+		case "pull_request":
+			if implementProgressSignatureUsable(record.CurrentSignature.signature()) {
+				return true
+			}
 		}
 	}
 	switch strings.TrimSpace(record.Reason) {
-	case "pull_request_created_or_updated", "signature_changed", implementMergedCompletionReason:
+	case "pull_request_created_or_updated":
+		return implementProgressSignatureUsable(record.CurrentSignature.signature())
+	case "signature_changed", implementMergedCompletionReason:
 		return true
 	default:
 		return false

--- a/internal/orchestrator/dispatch_loop_test.go
+++ b/internal/orchestrator/dispatch_loop_test.go
@@ -55,6 +55,24 @@ func TestEvaluateDispatchLoopProgress(t *testing.T) {
 			wantBlockReason: dispatchLoopDetectedReason,
 		},
 		{
+			name: "unverified pull request updates count",
+			history: []store.WorkAttempt{
+				dispatchLoopReportedPRUpdateAttempt(2),
+				dispatchLoopReportedPRUpdateAttempt(1),
+			},
+			running: dispatchLoopRunning("In Progress", DiffStats{Status: "clean"}),
+			decision: func() implementCompletionProgressDecision {
+				decision := dispatchLoopDecision("In Progress", store.WorkAttemptTerminalSuccess, autoPromoteReworkSignature{}, DiffStats{Status: "clean"})
+				decision.Reason = "pull_request_created_or_updated"
+				decision.ProgressKinds = []string{"pull_request"}
+				return decision
+			}(),
+			wantCount:       3,
+			wantBlock:       true,
+			wantReason:      dispatchLoopDetectedReason,
+			wantBlockReason: dispatchLoopDetectedReason,
+		},
+		{
 			name:       "single completed run does not trip even with limit one",
 			running:    dispatchLoopRunning("Rework", DiffStats{Status: "clean"}),
 			decision:   dispatchLoopDecision("Rework", store.WorkAttemptTerminalSuccess, autoPromoteReworkSignature{}, DiffStats{Status: "clean"}),
@@ -262,6 +280,28 @@ func dispatchLoopHistoryAttemptInLane(
 				ConsecutiveNoProgress: count,
 				NoProgressLimit:       3,
 				ProgressKinds:         progressKinds,
+			},
+		}),
+	}
+}
+
+func dispatchLoopReportedPRUpdateAttempt(id int64) store.WorkAttempt {
+	return store.WorkAttempt{
+		ID:            id,
+		ProjectID:     "detent",
+		IssueID:       "issue-loop",
+		Identifier:    "digitaldrywood/detent#1886",
+		WorkerType:    "agent",
+		Lane:          "In Progress",
+		Status:        store.WorkAttemptStatusTerminal,
+		TerminalState: store.WorkAttemptTerminalSuccess,
+		CompletedAt:   time.Date(2026, 8, 18, 14, int(id), 0, 0, time.UTC),
+		WorkerMetadataJSON: marshalWorkAttemptJSON(map[string]any{
+			implementProgressMetadataKey: implementProgressRecord{
+				Outcome:            string(store.WorkAttemptTerminalSuccess),
+				Reason:             "pull_request_created_or_updated",
+				WorkspaceDiffStats: implementProgressDiffStats{Status: "clean"},
+				ProgressKinds:      []string{"pull_request"},
 			},
 		}),
 	}

--- a/internal/orchestrator/implement_progress_test.go
+++ b/internal/orchestrator/implement_progress_test.go
@@ -204,13 +204,14 @@ func TestHandleRunResultClassifiesImplementWorkerProgress(t *testing.T) {
 			wantComment:      "loop detected after 3 dispatches",
 		},
 		{
-			name:               "new pull request creation avoids false no progress",
+			name:               "unverified pull request update counts as no progress",
 			runningIssue:       implementProgressIssueWithoutPR(),
 			diffStats:          DiffStats{Status: "clean"},
 			noProgressLimit:    3,
 			pullRequestUpdated: true,
 			wantTerminal:       store.WorkAttemptTerminalSuccess,
 			wantReason:         "pull_request_created_or_updated",
+			wantConsecutive:    1,
 			wantRetry:          true,
 		},
 		{
@@ -663,6 +664,110 @@ func TestHandleRunResultClassifiesImplementWorkerProgress(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestHandleRunResultResetsFailureBreakersOnlyForDurableWorkProduct(t *testing.T) {
+	t.Parallel()
+
+	base := time.Date(2026, 8, 20, 12, 0, 0, 0, time.UTC)
+	tests := []struct {
+		name      string
+		issue     connector.Issue
+		hydrated  connector.Issue
+		wantReset bool
+	}{
+		{
+			name:  "yieldless completion preserves failures",
+			issue: implementProgressIssueWithoutPR(),
+		},
+		{
+			name:      "linked pull request clears failures",
+			issue:     implementProgressIssue("head", "Test"),
+			hydrated:  implementProgressIssue("head", "Test"),
+			wantReset: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			tracker := &implementProgressConnector{refreshed: tt.issue, hydrated: tt.hydrated}
+			attempts := &implementProgressAttemptStore{}
+			cfg := normalizeConfig(Config{
+				Project:                scheduler.ProjectCandidate{ID: "detent"},
+				AutoPromote:            AutoPromoteConfig{NoProgressLimit: 3},
+				ActiveStates:           []string{"Todo", "In Progress", "Rework", "Merging"},
+				ObservedStates:         []string{"Human Review", "Blocked"},
+				TerminalStates:         []string{"Done", "Cancelled"},
+				ContinuationRetryDelay: time.Minute,
+			})
+			orch := &Orchestrator{cfg: cfg, connector: tracker, workAttempts: attempts}
+			state := newState(cfg)
+			state.Running[tt.issue.ID] = Running{
+				Issue:         tt.issue,
+				Attempt:       3,
+				WorkAttemptID: 42,
+				Mode:          runpkg.RunModeImplement,
+				StartedAt:     base.Add(-time.Minute),
+				DiffStats:     DiffStats{Status: "clean"},
+			}
+			state.Claimed[tt.issue.ID] = Claimed{Issue: tt.issue, ClaimedAt: base.Add(-time.Minute)}
+			state.InstantFailures[tt.issue.ID] = InstantFailure{Issue: tt.issue, Count: 2}
+			state.RepeatedFailures[tt.issue.ID] = RepeatedFailure{Issue: tt.issue, Count: 2}
+
+			orch.handleRunResult(t.Context(), &state, runpkg.Completion{
+				IssueID:     tt.issue.ID,
+				CompletedAt: base,
+				Request:     runpkg.RunRequest{Mode: runpkg.RunModeImplement},
+				Result:      runpkg.RunResult{FinalState: FinalStateCompleted, DiffStats: DiffStats{Status: "clean"}},
+			})
+
+			_, instantPresent := state.InstantFailures[tt.issue.ID]
+			_, repeatedPresent := state.RepeatedFailures[tt.issue.ID]
+			if tt.wantReset && (instantPresent || repeatedPresent) {
+				t.Fatalf("failure breakers remain after durable work product: instant=%t repeated=%t", instantPresent, repeatedPresent)
+			}
+			if !tt.wantReset && (!instantPresent || !repeatedPresent) {
+				t.Fatalf("failure breakers cleared after yieldless completion: instant=%t repeated=%t", instantPresent, repeatedPresent)
+			}
+		})
+	}
+}
+
+func TestRunnerWorkAttemptErrorClass(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		err  error
+		want string
+	}{
+		{name: "generic runner failure", err: errors.New("runner failed"), want: workAttemptErrorRunner},
+		{name: "interrupted backend turn", err: backendStatusTestError{status: "interrupted"}, want: workAttemptErrorInterrupted},
+		{name: "failed backend turn", err: backendStatusTestError{status: "failed"}, want: workAttemptErrorRunner},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := runnerWorkAttemptErrorClass(tt.err); got != tt.want {
+				t.Fatalf("runnerWorkAttemptErrorClass() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+type backendStatusTestError struct {
+	status string
+}
+
+func (e backendStatusTestError) Error() string {
+	return "backend turn " + e.status
+}
+
+func (e backendStatusTestError) BackendErrorStatus() string {
+	return e.status
 }
 
 func TestHandleRunResultAcceptsMergedNoDiffCompletion(t *testing.T) {

--- a/internal/orchestrator/implement_progress_test.go
+++ b/internal/orchestrator/implement_progress_test.go
@@ -671,10 +671,12 @@ func TestHandleRunResultResetsFailureBreakersOnlyForDurableWorkProduct(t *testin
 
 	base := time.Date(2026, 8, 20, 12, 0, 0, 0, time.UTC)
 	tests := []struct {
-		name      string
-		issue     connector.Issue
-		hydrated  connector.Issue
-		wantReset bool
+		name           string
+		issue          connector.Issue
+		hydrated       connector.Issue
+		refreshedState string
+		completionLane string
+		wantReset      bool
 	}{
 		{
 			name:  "yieldless completion preserves failures",
@@ -686,13 +688,29 @@ func TestHandleRunResultResetsFailureBreakersOnlyForDurableWorkProduct(t *testin
 			hydrated:  implementProgressIssue("head", "Test"),
 			wantReset: true,
 		},
+		{
+			name:           "current attempt completion lane clears failures",
+			issue:          implementProgressIssueWithoutPR(),
+			completionLane: "Human Review",
+			wantReset:      true,
+		},
+		{
+			name:           "tracker state transition clears failures",
+			issue:          implementProgressIssueWithoutPR(),
+			refreshedState: "Rework",
+			wantReset:      true,
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			tracker := &implementProgressConnector{refreshed: tt.issue, hydrated: tt.hydrated}
+			refreshed := cloneIssue(tt.issue)
+			if tt.refreshedState != "" {
+				refreshed.State = tt.refreshedState
+			}
+			tracker := &implementProgressConnector{refreshed: refreshed, hydrated: tt.hydrated}
 			attempts := &implementProgressAttemptStore{}
 			cfg := normalizeConfig(Config{
 				Project:                scheduler.ProjectCandidate{ID: "detent"},
@@ -705,12 +723,14 @@ func TestHandleRunResultResetsFailureBreakersOnlyForDurableWorkProduct(t *testin
 			orch := &Orchestrator{cfg: cfg, connector: tracker, workAttempts: attempts}
 			state := newState(cfg)
 			state.Running[tt.issue.ID] = Running{
-				Issue:         tt.issue,
-				Attempt:       3,
-				WorkAttemptID: 42,
-				Mode:          runpkg.RunModeImplement,
-				StartedAt:     base.Add(-time.Minute),
-				DiffStats:     DiffStats{Status: "clean"},
+				Issue:            tt.issue,
+				Attempt:          3,
+				WorkAttemptID:    42,
+				Mode:             runpkg.RunModeImplement,
+				StartedAt:        base.Add(-time.Minute),
+				DiffStats:        DiffStats{Status: "clean"},
+				DispatchProgress: implementProgressArtifactSnapshotFromIssue(tt.issue, true),
+				CompletionLane:   tt.completionLane,
 			}
 			state.Claimed[tt.issue.ID] = Claimed{Issue: tt.issue, ClaimedAt: base.Add(-time.Minute)}
 			state.InstantFailures[tt.issue.ID] = InstantFailure{Issue: tt.issue, Count: 2}

--- a/internal/orchestrator/repeated_failure_test.go
+++ b/internal/orchestrator/repeated_failure_test.go
@@ -108,7 +108,7 @@ func TestRunParksIssueAfterRepeatedCostlyWorkerFailures(t *testing.T) {
 	}
 }
 
-func TestRunRepeatedFailureCounterResetsOnSuccessfulCompletion(t *testing.T) {
+func TestRunRepeatedFailureCounterSurvivesYieldlessCompletion(t *testing.T) {
 	t.Parallel()
 
 	issue := testIssue("issue-repeated-fail-reset", "digitaldrywood/detent#980", "Todo")
@@ -142,8 +142,8 @@ func TestRunRepeatedFailureCounterResetsOnSuccessfulCompletion(t *testing.T) {
 	if _, ok := state.Blocked[issue.ID]; ok {
 		t.Fatalf("Blocked[%q] present after successful completion", issue.ID)
 	}
-	if _, ok := state.RepeatedFailures[issue.ID]; ok {
-		t.Fatalf("RepeatedFailures[%q] present after successful completion", issue.ID)
+	if got := state.RepeatedFailures[issue.ID].Count; got != 4 {
+		t.Fatalf("RepeatedFailures[%q].Count = %d, want 4 after yieldless completion", issue.ID, got)
 	}
 }
 

--- a/internal/orchestrator/run_completion.go
+++ b/internal/orchestrator/run_completion.go
@@ -343,7 +343,7 @@ func (o *Orchestrator) handleRunResult(ctx context.Context, state *State, event 
 			}
 		}
 		terminalState := terminalStateForRun(event.Err, event.Result.FinalState)
-		errorClass := workAttemptErrorRunner
+		errorClass := runnerWorkAttemptErrorClass(event.Err)
 		errorMessage := event.Err.Error()
 		phase := "failed"
 		statusMessage := "worker failed"
@@ -435,11 +435,9 @@ func (o *Orchestrator) handleRunResult(ctx context.Context, state *State, event 
 		return
 	}
 
-	// Every path below is a completion without a worker error: reset both
-	// failure circuit breakers here so plan and merge-worker completions do
-	// not carry stale counts into the next attempt cycle.
-	delete(state.InstantFailures, event.IssueID)
-	delete(state.RepeatedFailures, event.IssueID)
+	if mergeWorkerIssue(running.Issue) || implementProgressLinkedPullRequest(running.Issue) {
+		resetWorkerFailureBreakers(state, event.IssueID)
+	}
 
 	if event.Request.Mode == runpkg.RunModePlan {
 		o.logWorkerLifecycle(running.Issue, "worker_"+workerOutcome(event.Err, event.Result.FinalState),
@@ -786,6 +784,11 @@ func (o *Orchestrator) commentBudgetRefusal(ctx context.Context, issueID string,
 			"error", err,
 		)
 	}
+}
+
+func resetWorkerFailureBreakers(state *State, issueID string) {
+	delete(state.InstantFailures, issueID)
+	delete(state.RepeatedFailures, issueID)
 }
 
 func (o *Orchestrator) tripInstantFailureCircuitBreaker(
@@ -2371,6 +2374,7 @@ func (o *Orchestrator) completePlanRunning(
 	}
 	o.recordProjectAttemptOutcome(state, event.IssueID, event.CompletedAt, store.WorkAttemptTerminalSuccess, nil, "", "")
 	o.completeDurableWorkAttempt(ctx, state, running, event.CompletedAt, store.WorkAttemptTerminalSuccess, "", "", "completed", "plan review created")
+	resetWorkerFailureBreakers(state, issueID)
 	if err := o.abandonClaim(ctx, issueID); err != nil && o.logger != nil {
 		o.logger.Warn("abandon completed plan claim failed", "issue_id", issueID, "error", err)
 	}

--- a/internal/orchestrator/run_completion.go
+++ b/internal/orchestrator/run_completion.go
@@ -435,7 +435,7 @@ func (o *Orchestrator) handleRunResult(ctx context.Context, state *State, event 
 		return
 	}
 
-	if mergeWorkerIssue(running.Issue) || implementProgressLinkedPullRequest(running.Issue) {
+	if mergeWorkerIssue(running.Issue) {
 		resetWorkerFailureBreakers(state, event.IssueID)
 	}
 
@@ -501,6 +501,9 @@ func (o *Orchestrator) handleRunResult(ctx context.Context, state *State, event 
 	progress := o.evaluateImplementCompletionProgress(ctx, running, finalState, event.Result.PullRequestUpdated)
 	progress = o.evaluateDispatchLoopProgress(ctx, running, progress)
 	running.Issue = progress.Issue
+	if terminalState == store.WorkAttemptTerminalSuccess && implementCompletionHasDurableProgress(running, progress) {
+		resetWorkerFailureBreakers(state, event.IssueID)
+	}
 	if event.Result.PullRequestHeadPushed && !event.Result.CITriggerLabelReapplied {
 		forceReapply := false
 		if pullRequestRepository(running.Issue) == "" || pullRequestNumber(running.Issue) <= 0 || running.Issue.PullRequest == nil || strings.TrimSpace(progress.CurrentSignature.HeadSHA) == "" {
@@ -789,6 +792,18 @@ func (o *Orchestrator) commentBudgetRefusal(ctx context.Context, issueID string,
 func resetWorkerFailureBreakers(state *State, issueID string) {
 	delete(state.InstantFailures, issueID)
 	delete(state.RepeatedFailures, issueID)
+}
+
+func implementCompletionHasDurableProgress(running Running, decision implementCompletionProgressDecision) bool {
+	if strings.TrimSpace(running.CompletionLane) != "" || implementProgressLinkedPullRequest(decision.Issue) {
+		return true
+	}
+	for _, kind := range decision.ProgressKinds {
+		if strings.TrimSpace(kind) == "tracker_state_transition" {
+			return true
+		}
+	}
+	return false
 }
 
 func (o *Orchestrator) tripInstantFailureCircuitBreaker(

--- a/internal/orchestrator/work_attempts.go
+++ b/internal/orchestrator/work_attempts.go
@@ -22,6 +22,7 @@ const (
 	maxRecentWorkAttemptSnapshots   = 50
 	maxRecentSchedulerDecisions     = 500
 	workAttemptErrorRunner          = "runner_error"
+	workAttemptErrorInterrupted     = "runner_interrupted"
 	workAttemptErrorWorkspace       = "workspace_preparation"
 	workAttemptErrorStartTransition = "start_state_transition_failed"
 	workAttemptErrorMergeIncomplete = "merge_worker_terminal_state_missing"
@@ -1040,6 +1041,16 @@ func terminalStateForRun(err error, finalState string) store.WorkAttemptTerminal
 	default:
 		return store.WorkAttemptTerminalFailure
 	}
+}
+
+func runnerWorkAttemptErrorClass(err error) string {
+	var statusCarrier interface {
+		BackendErrorStatus() string
+	}
+	if errors.As(err, &statusCarrier) && strings.EqualFold(strings.TrimSpace(statusCarrier.BackendErrorStatus()), "interrupted") {
+		return workAttemptErrorInterrupted
+	}
+	return workAttemptErrorRunner
 }
 
 func rateLimitsFromState(state *State) *telemetry.RateLimits {


### PR DESCRIPTION
## Summary

- Count terminal completions with unverified PR-update signals as dispatch-loop no-progress.
- Preserve per-issue failure counters across clean, yieldless completions while retaining resets for durable plan, merge, and linked-PR work products.
- Attribute Codex `status: interrupted` terminal events as `runner_interrupted` and replace null backend detail with a stable diagnostic.

Fixes #1928

## UI Surface Contract

- [x] N/A; this PR has no UI changes.
- [x] This PR does not add persistent top-of-screen messaging.
- [x] This PR has no visual changes to primary operator screens.

## Test Plan

- [x] `make check`
- [x] `go test ./internal/orchestrator ./internal/codex -count=1`