### PR TITLE
perf(runner): resume safe rework threads

### DIFF
--- a/config.reference.yaml
+++ b/config.reference.yaml
@@ -596,8 +596,8 @@
 #   max_session_token_override_label: null
 #   # agent.max_session_token_override_field | type: string | default: none | required: No | validation: None
 #   max_session_token_override_field: null
-#   # agent.experimental_thread_resume | type: boolean | default: false | required: No | validation: None
-#   experimental_thread_resume: false
+#   # agent.experimental_thread_resume | type: boolean | default: true | required: No | validation: None
+#   experimental_thread_resume: true
 #   # agent.resume_orphaned_sessions | type: boolean | default: true | required: No | validation: None
 #   resume_orphaned_sessions: true
 #   # agent.effort | type: object | default: see child fields | required: No | validation: None

--- a/db/queries/store.sql
+++ b/db/queries/store.sql
@@ -210,29 +210,48 @@ WHERE id = sqlc.arg(id)
 
 -- name: GetLatestCompletedAgentResumeState :one
 SELECT
-  id,
-  CAST(COALESCE(provider_thread_id, '') AS TEXT) AS provider_thread_id,
-  CAST(COALESCE(provider_session_id, '') AS TEXT) AS provider_session_id,
-  CAST(COALESCE(requested_model, '') AS TEXT) AS requested_model,
-  CAST(COALESCE(model, '') AS TEXT) AS model,
-  CAST(COALESCE(agent_backend_id, '') AS TEXT) AS agent_backend_id,
-  CAST(COALESCE(agent_backend_kind, '') AS TEXT) AS agent_backend_kind,
-  CAST(COALESCE(agent_role, '') AS TEXT) AS agent_role,
-  CAST(completed_at AS TEXT) AS completed_at
-FROM codex_sessions
-WHERE completed_at IS NOT NULL
-  AND lower(trim(COALESCE(final_state, ''))) = 'completed'
-  AND (COALESCE(provider_thread_id, '') != '' OR COALESCE(provider_session_id, '') != '')
-  AND COALESCE(agent_backend_id, '') = sqlc.arg(agent_backend_id)
-  AND COALESCE(agent_backend_kind, '') = sqlc.arg(agent_backend_kind)
-  AND COALESCE(agent_role, '') = sqlc.arg(agent_role)
-  AND COALESCE(NULLIF(requested_model, ''), COALESCE(model, '')) = sqlc.arg(requested_model)
+  s.id,
+  CAST(COALESCE(s.provider_thread_id, '') AS TEXT) AS provider_thread_id,
+  CAST(COALESCE(s.provider_session_id, '') AS TEXT) AS provider_session_id,
+  CAST(COALESCE(s.requested_model, '') AS TEXT) AS requested_model,
+  CAST(COALESCE(s.model, '') AS TEXT) AS model,
+  CAST(COALESCE(s.agent_backend_id, '') AS TEXT) AS agent_backend_id,
+  CAST(COALESCE(s.agent_backend_kind, '') AS TEXT) AS agent_backend_kind,
+  CAST(COALESCE(s.agent_role, '') AS TEXT) AS agent_role,
+  CAST(s.completed_at AS TEXT) AS completed_at
+FROM codex_sessions AS s
+JOIN work_attempts AS w ON w.id = s.work_attempt_id
+WHERE s.completed_at IS NOT NULL
+  AND w.completed_at IS NOT NULL
+  AND lower(trim(COALESCE(s.final_state, ''))) = 'completed'
+  AND (COALESCE(s.provider_thread_id, '') != '' OR COALESCE(s.provider_session_id, '') != '')
+  AND COALESCE(s.project_id, '') = sqlc.arg(project_id)
+  AND COALESCE(
+    CASE WHEN json_valid(w.worker_metadata_json)
+      THEN CAST(json_extract(w.worker_metadata_json, '$.pr_number') AS INTEGER)
+      ELSE NULL
+    END,
+    w.pr_number,
+    0
+  ) = CAST(sqlc.arg(pr_number) AS INTEGER)
+  AND CASE WHEN json_valid(w.worker_metadata_json)
+    THEN CAST(COALESCE(json_extract(w.worker_metadata_json, '$.pr_head_sha'), '') AS TEXT)
+    ELSE ''
+  END = sqlc.arg(pr_head_sha)
+  AND CASE WHEN json_valid(w.worker_metadata_json)
+    THEN CAST(COALESCE(json_extract(w.worker_metadata_json, '$.pr_base_sha'), '') AS TEXT)
+    ELSE ''
+  END = sqlc.arg(pr_base_sha)
+  AND COALESCE(s.agent_backend_id, '') = sqlc.arg(agent_backend_id)
+  AND COALESCE(s.agent_backend_kind, '') = sqlc.arg(agent_backend_kind)
+  AND COALESCE(s.agent_role, '') = sqlc.arg(agent_role)
+  AND COALESCE(NULLIF(s.requested_model, ''), COALESCE(s.model, '')) = sqlc.arg(requested_model)
   AND (
-    (sqlc.arg(issue_id) != '' AND COALESCE(issue_id, '') = sqlc.arg(issue_id))
-    OR (sqlc.arg(identifier) != '' AND COALESCE(identifier, '') = sqlc.arg(identifier))
-    OR (sqlc.arg(issue_url) != '' AND COALESCE(issue_url, '') = sqlc.arg(issue_url))
+    (sqlc.arg(issue_id) != '' AND COALESCE(s.issue_id, '') = sqlc.arg(issue_id))
+    OR (sqlc.arg(identifier) != '' AND COALESCE(s.identifier, '') = sqlc.arg(identifier))
+    OR (sqlc.arg(issue_url) != '' AND COALESCE(s.issue_url, '') = sqlc.arg(issue_url))
   )
-ORDER BY completed_at DESC, id DESC
+ORDER BY s.completed_at DESC, s.id DESC
 LIMIT 1;
 
 -- name: GetLatestIssueAgentResumeState :one

--- a/docs/config.md
+++ b/docs/config.md
@@ -500,7 +500,7 @@ only to resettable budget pacing and never clears a per-issue hard hold.
 | `agent.effort.code` | `string` | `none` | No | must be one of low, medium, high, xhigh, max, ultracode |
 | `agent.effort.merge` | `string` | `none` | No | must be one of low, medium, high, xhigh, max, ultracode |
 | `agent.effort.rework` | `string` | `none` | No | must be one of low, medium, high, xhigh, max, ultracode |
-| `agent.experimental_thread_resume` | `boolean` | `false` | No | None |
+| `agent.experimental_thread_resume` | `boolean` | `true` | No | None |
 | `agent.failure_breaker` | `object` | `see child fields` | No | None |
 | `agent.failure_breaker.cooldown_seconds` | `integer` | `3600` | No | must be greater than 0 |
 | `agent.failure_breaker.same_class_limit` | `integer` | `5` | No | must be greater than 0 |

--- a/docs/thread-resume-spike.md
+++ b/docs/thread-resume-spike.md
@@ -4,7 +4,7 @@ Issue: digitaldrywood/detent#859
 
 ## Recommendation
 
-Adapt the prototype behind `agent.experimental_thread_resume`, then enable it only after dogfood Detent is running the #852 cache telemetry migration. The backend resume surfaces are present and can be wired safely with fresh fallback semantics, but the cache-read delta cannot be verified from the live dogfood store available during this spike.
+Enable the prototype for rework redispatches only when the prior completed session and current issue share the same project, pull request number, head SHA, base SHA, backend, model, and role. Keep fresh fallback semantics for missing or expired provider state. The #852 cache telemetry migration is now part of the store, so `agent.experimental_thread_resume` defaults to enabled while remaining an operator opt-out.
 
 ## Backend Support
 
@@ -17,13 +17,14 @@ Claude Code `2.1.199` exposes `-r, --resume [value]` for print-mode sessions. Th
 Neither verified CLI surface publishes a durable TTL in the command help or generated schema. Codex describes `thread/resume` as loading a thread from disk by `threadId` or rejoining a running thread; Claude describes resuming by session ID. Treat stored provider IDs as opportunistic local cache keys:
 
 - Resume only from Detent sessions that completed successfully.
+- Resume automatically only for implement workers dispatched from the configured Rework state with an unchanged pull request head and base.
 - Force fresh dispatch when the requested model, backend ID, backend kind, or agent role changes.
 - Fall back to a fresh thread only when the resume attempt fails before a new turn starts.
 - Keep per-issue handoff notes as the durable cross-machine fallback, because provider thread/session IDs can expire, be pruned, or be unavailable on another host.
 
 ## Prototype Shape
 
-The migration adds resume metadata to `codex_sessions`: requested model, backend identity, agent role, provider thread/session IDs, and the Detent session ID used as a resume source. The runner looks up the newest completed matching code session only when `agent.experimental_thread_resume` is true, passes an `AgentResume` field into the backend request, and clears the source state before retrying fresh if the resumed attempt fails before a turn starts.
+The migration adds resume metadata to `codex_sessions`: requested model, backend identity, agent role, provider thread/session IDs, and the Detent session ID used as a resume source. Completed work attempts persist their current pull request head and base SHAs. On a Rework redispatch, the runner looks up the newest completed session whose issue, project, pull request fingerprint, backend, requested model, and role all match, passes an `AgentResume` field into the backend request, and clears the source state before retrying fresh if the resumed attempt fails before a turn starts.
 
 With the flag off, Detent does not look up resume state and does not pass resume arguments to either backend. The schema is still extended so the feature can be enabled without another storage change.
 
@@ -38,6 +39,8 @@ The issue body records the prior Prometheus audit estimate of a 50-80% input red
 3. the same issue resumed with the flag enabled, and
 4. cache-read fraction compared from #852's usage report columns.
 
+Successful selection remains measurable through `codex_sessions.resumed_from_session_id`; cached-input share and per-issue lifetime tokens remain available from the same session rows.
+
 ## Validation
 
 The prototype is covered by focused tests for:
@@ -47,4 +50,5 @@ The prototype is covered by focused tests for:
 - Flag-off runner behavior avoiding resume lookup and backend resume args.
 - Resume handshake failure falling back to a fresh backend attempt.
 - Resumed turn failure not retrying after the turn has started.
-- Store lookup selecting only completed code sessions matching issue identity, backend identity, and requested model.
+- Automatic lookup restricted to Rework redispatches with complete current pull request identity.
+- Store lookup selecting only completed sessions matching project, issue, pull request head and base, backend identity, role, and requested model.

--- a/internal/cli/doctor_test.go
+++ b/internal/cli/doctor_test.go
@@ -3274,7 +3274,7 @@ func TestDoctorWorkflowDetailSurfacesIdentityAndAuthorization(t *testing.T) {
 		"worker-model=provider-default",
 		"session-guard=max_turns=20, max_turn_duration_ms=disabled, max_session_duration_ms=7200000, no_progress_timeout_ms=5400000, merge_worker_max_duration_ms=21600000, max_session_tokens=disabled, max_session_context_multiplier=disabled",
 		"billing-mode=metered",
-		"orphan-recovery=resume_orphaned_sessions=true, experimental_thread_resume=false",
+		"orphan-recovery=resume_orphaned_sessions=true, experimental_thread_resume=true",
 		"prioritize-unblockers=true",
 		"authorization selectors from global.yaml and WORKFLOW.md",
 	} {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1400,6 +1400,7 @@ func Default() Config {
 				WindowSeconds:   DefaultFailureBreakerWindowSeconds,
 				CooldownSeconds: DefaultFailureBreakerCooldownSeconds,
 			},
+			ExperimentalThreadResume:   true,
 			ResumeOrphanedSessions:     true,
 			Shutdown:                   Shutdown{DrainTimeoutMS: DefaultShutdownDrainTimeoutMS},
 			MaxConcurrentAgentsByState: map[string]int{},

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1677,8 +1677,8 @@ func TestParseWorkflowDefaults(t *testing.T) {
 	if cfg.Agent.MergeFastPath.FairnessAgeSeconds != DefaultMergeFairnessAgeSeconds {
 		t.Fatalf("Agent.MergeFastPath.FairnessAgeSeconds = %d, want %d", cfg.Agent.MergeFastPath.FairnessAgeSeconds, DefaultMergeFairnessAgeSeconds)
 	}
-	if cfg.Agent.ExperimentalThreadResume {
-		t.Fatal("Agent.ExperimentalThreadResume = true, want disabled default")
+	if !cfg.Agent.ExperimentalThreadResume {
+		t.Fatal("Agent.ExperimentalThreadResume = false, want enabled default")
 	}
 	if !cfg.Agent.ResumeOrphanedSessions {
 		t.Fatal("Agent.ResumeOrphanedSessions = false, want enabled default")

--- a/internal/orchestrator/dispatch_test.go
+++ b/internal/orchestrator/dispatch_test.go
@@ -3,6 +3,7 @@ package orchestrator
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"log/slog"
@@ -25,6 +26,44 @@ import (
 	"github.com/digitaldrywood/detent/internal/store"
 	"github.com/digitaldrywood/detent/internal/telemetry"
 )
+
+func TestRunningWorkAttemptMetadataJSONPersistsPullRequestFingerprint(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		request  *connector.PullRequest
+		wantPR   int64
+		wantHead string
+		wantBase string
+	}{
+		{name: "current pull request", request: &connector.PullRequest{Number: 42, HeadSHA: " head-current ", BaseSHA: " base-current "}, wantPR: 42, wantHead: "head-current", wantBase: "base-current"},
+		{name: "no pull request"},
+		{name: "missing base", request: &connector.PullRequest{HeadSHA: "head-current"}, wantHead: "head-current"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			encoded := runningWorkAttemptMetadataJSON(
+				Running{Issue: connector.Issue{PullRequest: tt.request}},
+				map[string]any{"pr_number": 99, "pr_head_sha": "untrusted-head", "pr_base_sha": "untrusted-base"},
+			)
+			var metadata struct {
+				PRNumber  int64  `json:"pr_number"`
+				PRHeadSHA string `json:"pr_head_sha"`
+				PRBaseSHA string `json:"pr_base_sha"`
+			}
+			if err := json.Unmarshal([]byte(encoded), &metadata); err != nil {
+				t.Fatalf("json.Unmarshal() error = %v", err)
+			}
+			if metadata.PRNumber != tt.wantPR || metadata.PRHeadSHA != tt.wantHead || metadata.PRBaseSHA != tt.wantBase {
+				t.Fatalf("pull request fingerprint = %#v, want PR %d head %q base %q", metadata, tt.wantPR, tt.wantHead, tt.wantBase)
+			}
+		})
+	}
+}
 
 func TestHandleRunUpdatePersistsRuntimeIdentityHeartbeat(t *testing.T) {
 	t.Parallel()

--- a/internal/orchestrator/work_attempts.go
+++ b/internal/orchestrator/work_attempts.go
@@ -994,10 +994,21 @@ func runningWorkAttemptMetadataJSON(running Running, metadata map[string]any) st
 	}
 	for key, value := range metadata {
 		key = strings.TrimSpace(key)
-		if key == "" {
+		if key == "" || key == "pr_number" || key == "pr_head_sha" || key == "pr_base_sha" {
 			continue
 		}
 		out[key] = value
+	}
+	if pullRequest := running.Issue.PullRequest; pullRequest != nil {
+		if number := workAttemptPRNumber(running.Issue); number != nil {
+			out["pr_number"] = *number
+		}
+		if headSHA := strings.TrimSpace(pullRequest.HeadSHA); headSHA != "" {
+			out["pr_head_sha"] = headSHA
+		}
+		if baseSHA := strings.TrimSpace(pullRequest.BaseSHA); baseSHA != "" {
+			out["pr_base_sha"] = baseSHA
+		}
 	}
 	return marshalWorkAttemptJSON(out)
 }

--- a/internal/runner/agent.go
+++ b/internal/runner/agent.go
@@ -1115,51 +1115,92 @@ func (r *Runner) runAgentTurn(
 func (r *Runner) agentResumeState(
 	ctx context.Context,
 	cfg config.Agent,
-	issue connector.Issue,
+	req RunRequest,
 	model string,
 	backendID string,
 	backendKind string,
 	agentRole string,
 ) store.AgentResumeState {
-	if !cfg.ExperimentalThreadResume {
-		return store.AgentResumeState{}
-	}
-	model = strings.TrimSpace(model)
-	backendID = strings.TrimSpace(backendID)
-	backendKind = strings.TrimSpace(backendKind)
-	agentRole = strings.TrimSpace(agentRole)
-	if model == "" || backendID == "" || backendKind == "" || agentRole == "" {
+	lookup, ok := automaticAgentResumeLookup(r.projectID, cfg, req, model, backendID, backendKind, agentRole)
+	if !ok {
 		return store.AgentResumeState{}
 	}
 	resumeStore, ok := r.store.(store.AgentResumeStore)
 	if !ok {
 		return store.AgentResumeState{}
 	}
-	state, err := resumeStore.LatestCompletedAgentResumeState(ctx, store.AgentResumeLookup{
-		IssueID:          issue.ID,
-		Identifier:       issue.Identifier,
-		IssueURL:         issue.URL,
-		RequestedModel:   model,
-		AgentBackendID:   backendID,
-		AgentBackendKind: backendKind,
-		AgentRole:        agentRole,
-	})
+	state, err := resumeStore.LatestCompletedAgentResumeState(ctx, lookup)
 	if err != nil {
 		if !errors.Is(err, store.ErrNotFound) {
 			r.logger.Warn(
 				"agent resume state lookup failed",
-				slog.String("issue_id", issue.ID),
-				slog.String("issue_identifier", issue.Identifier),
-				slog.String("model", model),
-				slog.String("backend_id", backendID),
-				slog.String("backend_kind", backendKind),
-				slog.String("agent_role", agentRole),
+				slog.String("issue_id", req.Issue.ID),
+				slog.String("issue_identifier", req.Issue.Identifier),
+				slog.String("model", lookup.RequestedModel),
+				slog.String("backend_id", lookup.AgentBackendID),
+				slog.String("backend_kind", lookup.AgentBackendKind),
+				slog.String("agent_role", lookup.AgentRole),
 				slog.Any("error", err),
 			)
 		}
 		return store.AgentResumeState{}
 	}
+	r.logWorkerEvent(req.Issue, "worker_thread_resume_selected",
+		telemetry.WorkAttemptIDKey, req.WorkAttemptID,
+		"resumed_from_session_id", state.DetentSessionID,
+		"pr_number", lookup.PRNumber,
+		"pr_head_sha", lookup.PRHeadSHA,
+		"pr_base_sha", lookup.PRBaseSHA,
+	)
 	return state
+}
+
+func automaticAgentResumeLookup(
+	projectID string,
+	cfg config.Agent,
+	req RunRequest,
+	model string,
+	backendID string,
+	backendKind string,
+	agentRole string,
+) (store.AgentResumeLookup, bool) {
+	if !cfg.ExperimentalThreadResume || normalizeRunMode(req.Mode) != RunModeImplement {
+		return store.AgentResumeLookup{}, false
+	}
+	reworkState := strings.TrimSpace(cfg.AutoPromote.ReworkState)
+	if reworkState == "" {
+		reworkState = "Rework"
+	}
+	dispatchSourceState := strings.TrimSpace(req.DispatchSourceState)
+	if dispatchSourceState == "" {
+		dispatchSourceState = strings.TrimSpace(req.Issue.State)
+	}
+	if !strings.EqualFold(dispatchSourceState, reworkState) || req.Issue.PullRequest == nil {
+		return store.AgentResumeLookup{}, false
+	}
+	prNumber := int64(req.Issue.PullRequest.Number)
+	if req.Issue.PRNumber != nil && *req.Issue.PRNumber > 0 {
+		prNumber = int64(*req.Issue.PRNumber)
+	}
+	lookup := store.AgentResumeLookup{
+		ProjectID:        strings.TrimSpace(projectID),
+		IssueID:          strings.TrimSpace(req.Issue.ID),
+		Identifier:       strings.TrimSpace(req.Issue.Identifier),
+		IssueURL:         strings.TrimSpace(req.Issue.URL),
+		PRNumber:         prNumber,
+		PRHeadSHA:        strings.TrimSpace(req.Issue.PullRequest.HeadSHA),
+		PRBaseSHA:        strings.TrimSpace(req.Issue.PullRequest.BaseSHA),
+		RequestedModel:   strings.TrimSpace(model),
+		AgentBackendID:   strings.TrimSpace(backendID),
+		AgentBackendKind: strings.TrimSpace(backendKind),
+		AgentRole:        strings.TrimSpace(agentRole),
+	}
+	if lookup.ProjectID == "" || lookup.PRNumber <= 0 || lookup.PRHeadSHA == "" || lookup.PRBaseSHA == "" ||
+		lookup.RequestedModel == "" || lookup.AgentBackendID == "" || lookup.AgentBackendKind == "" || lookup.AgentRole == "" ||
+		(lookup.IssueID == "" && lookup.Identifier == "" && lookup.IssueURL == "") {
+		return store.AgentResumeLookup{}, false
+	}
+	return lookup, true
 }
 
 func (r *Runner) runRequestResumeState(
@@ -1180,7 +1221,7 @@ func (r *Runner) runRequestResumeState(
 		}
 		return req.ResumeState, nil
 	default:
-		return r.agentResumeState(ctx, cfg, req.Issue, model, backendID, backendKind, agentRole), nil
+		return r.agentResumeState(ctx, cfg, req, model, backendID, backendKind, agentRole), nil
 	}
 }
 

--- a/internal/runner/duration_limit_test.go
+++ b/internal/runner/duration_limit_test.go
@@ -254,9 +254,11 @@ func TestRunnerSessionDurationSpansResumeFallback(t *testing.T) {
 
 	_, err = runner.Run(context.Background(), RunRequest{
 		Issue: connector.Issue{
-			ID:         "issue-duration-resume",
-			Identifier: "digitaldrywood/detent#1496",
+			ID:          "issue-duration-resume",
+			Identifier:  "digitaldrywood/detent#1496",
+			PullRequest: &connector.PullRequest{Number: 42, HeadSHA: "head-current", BaseSHA: "base-current"},
 		},
+		DispatchSourceState: "Rework",
 	})
 	if !errors.Is(err, ErrSessionDurationExceeded) {
 		t.Fatalf("Run() error = %v, want ErrSessionDurationExceeded", err)

--- a/internal/runner/runner_test.go
+++ b/internal/runner/runner_test.go
@@ -1368,6 +1368,117 @@ func TestRunnerRunLeavesThreadResumeDisabledByDefault(t *testing.T) {
 	}
 }
 
+func TestRunnerRunRestrictsAutomaticThreadResumeToCurrentPRRework(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name                string
+		mode                string
+		dispatchSourceState string
+		pullRequest         *connector.PullRequest
+		wantLookups         int
+	}{
+		{
+			name:                "current pull request rework",
+			mode:                RunModeImplement,
+			dispatchSourceState: "Rework",
+			pullRequest:         &connector.PullRequest{Number: 42, HeadSHA: "head-current", BaseSHA: "base-current"},
+			wantLookups:         1,
+		},
+		{
+			name:                "todo dispatch",
+			mode:                RunModeImplement,
+			dispatchSourceState: "Todo",
+			pullRequest:         &connector.PullRequest{Number: 42, HeadSHA: "head-current", BaseSHA: "base-current"},
+		},
+		{
+			name:                "merge dispatch",
+			mode:                RunModeMerge,
+			dispatchSourceState: "Merging",
+			pullRequest:         &connector.PullRequest{Number: 42, HeadSHA: "head-current", BaseSHA: "base-current"},
+		},
+		{
+			name:                "rework without pull request",
+			mode:                RunModeImplement,
+			dispatchSourceState: "Rework",
+		},
+		{
+			name:                "rework without head",
+			mode:                RunModeImplement,
+			dispatchSourceState: "Rework",
+			pullRequest:         &connector.PullRequest{Number: 42, BaseSHA: "base-current"},
+		},
+		{
+			name:                "rework without base",
+			mode:                RunModeImplement,
+			dispatchSourceState: "Rework",
+			pullRequest:         &connector.PullRequest{Number: 42, HeadSHA: "head-current"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			startedAt := time.Date(2026, 8, 20, 12, 0, 0, 0, time.UTC)
+			workspaceBackend := &fakeWorkspaceBackend{
+				info: workspace.Info{Path: t.TempDir(), Key: "issue-1930", Branch: "detent/issue-1930"},
+			}
+			agentBackend := &fakeCodexClient{
+				result: AgentTurnResult{ThreadID: "thread-current", TurnID: "turn-2", SessionID: "session-current"},
+			}
+			sessionStore := &fakeSessionStore{
+				sessionID: 1930,
+				resumeState: store.AgentResumeState{
+					DetentSessionID:   1929,
+					ProviderThreadID:  "thread-prior",
+					ProviderSessionID: "session-prior",
+				},
+			}
+			runner, err := NewRunner(Dependencies{
+				ProjectID: "detent",
+				Workflow: config.Workflow{
+					Config: config.Config{Agent: config.Agent{ExperimentalThreadResume: true}},
+					Prompt: "Work",
+				},
+				Workspace:    workspaceBackend,
+				AgentBackend: agentBackend,
+				Store:        sessionStore,
+				Now:          newFakeClock(startedAt, startedAt.Add(time.Second)).Now,
+			})
+			if err != nil {
+				t.Fatalf("NewRunner() error = %v", err)
+			}
+
+			_, err = runner.Run(t.Context(), RunRequest{
+				Issue: connector.Issue{
+					ID:            "issue-1930",
+					Identifier:    "digitaldrywood/detent#1930",
+					Title:         "Resume current PR rework",
+					State:         "In Progress",
+					PullRequest:   tt.pullRequest,
+					ModelOverride: "gpt-5-codex",
+				},
+				Mode:                tt.mode,
+				DispatchSourceState: tt.dispatchSourceState,
+				StartedAt:           startedAt,
+			})
+			if err != nil {
+				t.Fatalf("Run() error = %v", err)
+			}
+			if sessionStore.resumeLookups != tt.wantLookups {
+				t.Fatalf("resume lookups = %d, want %d", sessionStore.resumeLookups, tt.wantLookups)
+			}
+			if tt.wantLookups == 1 {
+				lookup := sessionStore.resumeLookup
+				if lookup.ProjectID != "detent" || lookup.PRNumber != 42 || lookup.PRHeadSHA != "head-current" || lookup.PRBaseSHA != "base-current" {
+					t.Fatalf("resume lookup = %#v, want current pull request fingerprint", lookup)
+				}
+			}
+		})
+	}
+}
+
 func TestRunnerRunRoutineRequestsReadOnlyBackendTurn(t *testing.T) {
 	t.Parallel()
 
@@ -2037,8 +2148,10 @@ func TestRunnerRunFallsBackFreshWhenResumeFails(t *testing.T) {
 			Identifier:    "digitaldrywood/detent#859",
 			Title:         "Thread resume spike",
 			ModelOverride: "gpt-5-codex",
+			PullRequest:   &connector.PullRequest{Number: 42, HeadSHA: "head-current", BaseSHA: "base-current"},
 		},
-		StartedAt: startedAt,
+		DispatchSourceState: "Rework",
+		StartedAt:           startedAt,
 	})
 	if err != nil {
 		t.Fatalf("Run() error = %v, want fresh fallback success", err)
@@ -2108,8 +2221,10 @@ func TestRunnerRunDoesNotFallbackFreshForCapacityError(t *testing.T) {
 			Identifier:    "digitaldrywood/detent#1142",
 			Title:         "Capacity outage",
 			ModelOverride: "gpt-5-codex",
+			PullRequest:   &connector.PullRequest{Number: 42, HeadSHA: "head-current", BaseSHA: "base-current"},
 		},
-		StartedAt: startedAt,
+		DispatchSourceState: "Rework",
+		StartedAt:           startedAt,
 	})
 	if !IsCapacityError(err) {
 		t.Fatalf("Run() error = %v, want capacity error", err)
@@ -2158,8 +2273,10 @@ func TestRunnerRunDoesNotFallbackAfterResumedTurnStarts(t *testing.T) {
 			Identifier:    "digitaldrywood/detent#859",
 			Title:         "Thread resume spike",
 			ModelOverride: "gpt-5-codex",
+			PullRequest:   &connector.PullRequest{Number: 42, HeadSHA: "head-current", BaseSHA: "base-current"},
 		},
-		StartedAt: startedAt,
+		DispatchSourceState: "Rework",
+		StartedAt:           startedAt,
 	})
 	if err == nil {
 		t.Fatal("Run() error = nil, want resumed turn failure")
@@ -3793,7 +3910,7 @@ func TestRunnerRunRoutesPerStageRoles(t *testing.T) {
 	}
 }
 
-func TestRunnerRunThreadResumeUsesDerivedRoleKey(t *testing.T) {
+func TestRunnerRunDoesNotResumeMergeRole(t *testing.T) {
 	t.Parallel()
 
 	workspaceBackend := &fakeWorkspaceBackend{
@@ -3853,8 +3970,8 @@ func TestRunnerRunThreadResumeUsesDerivedRoleKey(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Run() error = %v", err)
 	}
-	if sessionStore.resumeLookup.AgentRole != RoleMerge {
-		t.Fatalf("resume lookup role = %q, want %q", sessionStore.resumeLookup.AgentRole, RoleMerge)
+	if sessionStore.resumeLookups != 0 {
+		t.Fatalf("resume lookups = %d, want none for merge", sessionStore.resumeLookups)
 	}
 	if !agentResumeEmpty(agentBackend.request.Resume) {
 		t.Fatalf("AgentTurnRequest.Resume = %#v, want no implement resume state for merge", agentBackend.request.Resume)

--- a/internal/store/sqlc/store.sql.go
+++ b/internal/store/sqlc/store.sql.go
@@ -1653,33 +1653,56 @@ func (q *Queries) GetDetentRun(ctx context.Context, id int64) (DetentRun, error)
 
 const getLatestCompletedAgentResumeState = `-- name: GetLatestCompletedAgentResumeState :one
 SELECT
-  id,
-  CAST(COALESCE(provider_thread_id, '') AS TEXT) AS provider_thread_id,
-  CAST(COALESCE(provider_session_id, '') AS TEXT) AS provider_session_id,
-  CAST(COALESCE(requested_model, '') AS TEXT) AS requested_model,
-  CAST(COALESCE(model, '') AS TEXT) AS model,
-  CAST(COALESCE(agent_backend_id, '') AS TEXT) AS agent_backend_id,
-  CAST(COALESCE(agent_backend_kind, '') AS TEXT) AS agent_backend_kind,
-  CAST(COALESCE(agent_role, '') AS TEXT) AS agent_role,
-  CAST(completed_at AS TEXT) AS completed_at
-FROM codex_sessions
-WHERE completed_at IS NOT NULL
-  AND lower(trim(COALESCE(final_state, ''))) = 'completed'
-  AND (COALESCE(provider_thread_id, '') != '' OR COALESCE(provider_session_id, '') != '')
-  AND COALESCE(agent_backend_id, '') = ?1
-  AND COALESCE(agent_backend_kind, '') = ?2
-  AND COALESCE(agent_role, '') = ?3
-  AND COALESCE(NULLIF(requested_model, ''), COALESCE(model, '')) = ?4
+  s.id,
+  CAST(COALESCE(s.provider_thread_id, '') AS TEXT) AS provider_thread_id,
+  CAST(COALESCE(s.provider_session_id, '') AS TEXT) AS provider_session_id,
+  CAST(COALESCE(s.requested_model, '') AS TEXT) AS requested_model,
+  CAST(COALESCE(s.model, '') AS TEXT) AS model,
+  CAST(COALESCE(s.agent_backend_id, '') AS TEXT) AS agent_backend_id,
+  CAST(COALESCE(s.agent_backend_kind, '') AS TEXT) AS agent_backend_kind,
+  CAST(COALESCE(s.agent_role, '') AS TEXT) AS agent_role,
+  CAST(s.completed_at AS TEXT) AS completed_at
+FROM codex_sessions AS s
+JOIN work_attempts AS w ON w.id = s.work_attempt_id
+WHERE s.completed_at IS NOT NULL
+  AND w.completed_at IS NOT NULL
+  AND lower(trim(COALESCE(s.final_state, ''))) = 'completed'
+  AND (COALESCE(s.provider_thread_id, '') != '' OR COALESCE(s.provider_session_id, '') != '')
+  AND COALESCE(s.project_id, '') = ?1
+  AND COALESCE(
+    CASE WHEN json_valid(w.worker_metadata_json)
+      THEN CAST(json_extract(w.worker_metadata_json, '$.pr_number') AS INTEGER)
+      ELSE NULL
+    END,
+    w.pr_number,
+    0
+  ) = CAST(?2 AS INTEGER)
+  AND CASE WHEN json_valid(w.worker_metadata_json)
+    THEN CAST(COALESCE(json_extract(w.worker_metadata_json, '$.pr_head_sha'), '') AS TEXT)
+    ELSE ''
+  END = ?3
+  AND CASE WHEN json_valid(w.worker_metadata_json)
+    THEN CAST(COALESCE(json_extract(w.worker_metadata_json, '$.pr_base_sha'), '') AS TEXT)
+    ELSE ''
+  END = ?4
+  AND COALESCE(s.agent_backend_id, '') = ?5
+  AND COALESCE(s.agent_backend_kind, '') = ?6
+  AND COALESCE(s.agent_role, '') = ?7
+  AND COALESCE(NULLIF(s.requested_model, ''), COALESCE(s.model, '')) = ?8
   AND (
-    (?5 != '' AND COALESCE(issue_id, '') = ?5)
-    OR (?6 != '' AND COALESCE(identifier, '') = ?6)
-    OR (?7 != '' AND COALESCE(issue_url, '') = ?7)
+    (?9 != '' AND COALESCE(s.issue_id, '') = ?9)
+    OR (?10 != '' AND COALESCE(s.identifier, '') = ?10)
+    OR (?11 != '' AND COALESCE(s.issue_url, '') = ?11)
   )
-ORDER BY completed_at DESC, id DESC
+ORDER BY s.completed_at DESC, s.id DESC
 LIMIT 1
 `
 
 type GetLatestCompletedAgentResumeStateParams struct {
+	ProjectID        sql.NullString `json:"project_id"`
+	PrNumber         int64          `json:"pr_number"`
+	PrHeadSha        string         `json:"pr_head_sha"`
+	PrBaseSha        string         `json:"pr_base_sha"`
 	AgentBackendID   sql.NullString `json:"agent_backend_id"`
 	AgentBackendKind sql.NullString `json:"agent_backend_kind"`
 	AgentRole        sql.NullString `json:"agent_role"`
@@ -1703,6 +1726,10 @@ type GetLatestCompletedAgentResumeStateRow struct {
 
 func (q *Queries) GetLatestCompletedAgentResumeState(ctx context.Context, arg GetLatestCompletedAgentResumeStateParams) (GetLatestCompletedAgentResumeStateRow, error) {
 	row := q.db.QueryRowContext(ctx, getLatestCompletedAgentResumeState,
+		arg.ProjectID,
+		arg.PrNumber,
+		arg.PrHeadSha,
+		arg.PrBaseSha,
 		arg.AgentBackendID,
 		arg.AgentBackendKind,
 		arg.AgentRole,

--- a/internal/store/sqlite.go
+++ b/internal/store/sqlite.go
@@ -420,6 +420,9 @@ func (s *sqliteStore) FinishSession(ctx context.Context, sessionID int64, attrs 
 
 func (s *sqliteStore) LatestCompletedAgentResumeState(ctx context.Context, attrs AgentResumeLookup) (AgentResumeState, error) {
 	attrs = normalizeAgentResumeLookup(attrs)
+	if attrs.ProjectID == "" || attrs.PRNumber <= 0 || attrs.PRHeadSHA == "" || attrs.PRBaseSHA == "" {
+		return AgentResumeState{}, ErrNotFound
+	}
 	if attrs.RequestedModel == "" || attrs.AgentBackendID == "" || attrs.AgentBackendKind == "" || attrs.AgentRole == "" {
 		return AgentResumeState{}, ErrNotFound
 	}
@@ -428,6 +431,10 @@ func (s *sqliteStore) LatestCompletedAgentResumeState(ctx context.Context, attrs
 	}
 
 	row, err := s.queries.GetLatestCompletedAgentResumeState(ctx, sqlc.GetLatestCompletedAgentResumeStateParams{
+		ProjectID:        nullString(attrs.ProjectID),
+		PrNumber:         attrs.PRNumber,
+		PrHeadSha:        attrs.PRHeadSHA,
+		PrBaseSha:        attrs.PRBaseSHA,
 		AgentBackendID:   nullString(attrs.AgentBackendID),
 		AgentBackendKind: nullString(attrs.AgentBackendKind),
 		AgentRole:        nullString(attrs.AgentRole),
@@ -559,9 +566,13 @@ func (s *sqliteStore) MarkAgentSessionOrphaned(ctx context.Context, sessionID in
 
 func normalizeAgentResumeLookup(attrs AgentResumeLookup) AgentResumeLookup {
 	return AgentResumeLookup{
+		ProjectID:        strings.TrimSpace(attrs.ProjectID),
 		IssueID:          strings.TrimSpace(attrs.IssueID),
 		Identifier:       strings.TrimSpace(attrs.Identifier),
 		IssueURL:         strings.TrimSpace(attrs.IssueURL),
+		PRNumber:         attrs.PRNumber,
+		PRHeadSHA:        strings.TrimSpace(attrs.PRHeadSHA),
+		PRBaseSHA:        strings.TrimSpace(attrs.PRBaseSHA),
 		RequestedModel:   strings.TrimSpace(attrs.RequestedModel),
 		AgentBackendID:   strings.TrimSpace(attrs.AgentBackendID),
 		AgentBackendKind: strings.TrimSpace(attrs.AgentBackendKind),

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -449,9 +449,13 @@ type SessionFinish struct {
 }
 
 type AgentResumeLookup struct {
+	ProjectID        string
 	IssueID          string
 	Identifier       string
 	IssueURL         string
+	PRNumber         int64
+	PRHeadSHA        string
+	PRBaseSHA        string
 	RequestedModel   string
 	AgentBackendID   string
 	AgentBackendKind string

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -1407,7 +1407,24 @@ func TestLatestCompletedAgentResumeStateMatchesIssueBackendAndModel(t *testing.T
 		t.Fatalf("FinishSession(first) error = %v", err)
 	}
 
+	resumeMetadata := `{"pr_number":42,"pr_head_sha":"head-current","pr_base_sha":"base-current"}`
+	resumeAttemptID, err := backend.StartWorkAttempt(ctx, WorkAttemptStart{
+		ProjectID:          "detent",
+		IssueID:            "issue-859",
+		Identifier:         "digitaldrywood/detent#859",
+		IssueURL:           "https://github.com/digitaldrywood/detent/issues/859",
+		Repo:               "digitaldrywood/detent",
+		WorkerType:         "agent",
+		Lane:               "Todo",
+		AttemptNumber:      2,
+		StartedAt:          startedAt.Add(4 * time.Minute),
+		WorkerMetadataJSON: resumeMetadata,
+	})
+	if err != nil {
+		t.Fatalf("StartWorkAttempt(resume candidate) error = %v", err)
+	}
 	secondID, err := backend.StartSession(ctx, SessionStart{
+		WorkAttemptID:    resumeAttemptID,
 		ProjectID:        "detent",
 		IssueID:          "issue-859",
 		Identifier:       "digitaldrywood/detent#859",
@@ -1431,6 +1448,15 @@ func TestLatestCompletedAgentResumeStateMatchesIssueBackendAndModel(t *testing.T
 		ResumedFromSessionID: firstID,
 	}); err != nil {
 		t.Fatalf("FinishSession(second) error = %v", err)
+	}
+	if err := backend.CompleteWorkAttempt(ctx, WorkAttemptCompletion{
+		AttemptID:          resumeAttemptID,
+		CompletedAt:        startedAt.Add(6 * time.Minute),
+		Status:             WorkAttemptStatusTerminal,
+		TerminalState:      WorkAttemptTerminalSuccess,
+		WorkerMetadataJSON: resumeMetadata,
+	}); err != nil {
+		t.Fatalf("CompleteWorkAttempt(resume candidate) error = %v", err)
 	}
 
 	validatorID, err := backend.StartSession(ctx, SessionStart{
@@ -1459,9 +1485,13 @@ func TestLatestCompletedAgentResumeStateMatchesIssueBackendAndModel(t *testing.T
 	}
 
 	got, err := backend.LatestCompletedAgentResumeState(ctx, AgentResumeLookup{
+		ProjectID:        "detent",
 		IssueID:          "issue-859",
 		Identifier:       "digitaldrywood/detent#859",
 		IssueURL:         "https://github.com/digitaldrywood/detent/issues/859",
+		PRNumber:         42,
+		PRHeadSHA:        "head-current",
+		PRBaseSHA:        "base-current",
 		RequestedModel:   "gpt-5-codex",
 		AgentBackendID:   "codex",
 		AgentBackendKind: "codex",
@@ -1488,7 +1518,11 @@ func TestLatestCompletedAgentResumeStateMatchesIssueBackendAndModel(t *testing.T
 	}
 
 	_, err = backend.LatestCompletedAgentResumeState(ctx, AgentResumeLookup{
+		ProjectID:        "detent",
 		IssueID:          "issue-859",
+		PRNumber:         42,
+		PRHeadSHA:        "head-current",
+		PRBaseSHA:        "base-current",
 		RequestedModel:   "gpt-5-codex-mini",
 		AgentBackendID:   "codex",
 		AgentBackendKind: "codex",
@@ -1499,7 +1533,11 @@ func TestLatestCompletedAgentResumeStateMatchesIssueBackendAndModel(t *testing.T
 	}
 
 	_, err = backend.LatestCompletedAgentResumeState(ctx, AgentResumeLookup{
+		ProjectID:        "detent",
 		IssueID:          "issue-859",
+		PRNumber:         42,
+		PRHeadSHA:        "head-current",
+		PRBaseSHA:        "base-current",
 		RequestedModel:   "gpt-5-codex",
 		AgentBackendID:   "codex",
 		AgentBackendKind: "codex",
@@ -1507,6 +1545,34 @@ func TestLatestCompletedAgentResumeStateMatchesIssueBackendAndModel(t *testing.T
 	})
 	if !errors.Is(err, ErrNotFound) {
 		t.Fatalf("LatestCompletedAgentResumeState(role mismatch) error = %v, want ErrNotFound", err)
+	}
+
+	for _, tt := range []struct {
+		name    string
+		project string
+		headSHA string
+		baseSHA string
+	}{
+		{name: "project mismatch", project: "other", headSHA: "head-current", baseSHA: "base-current"},
+		{name: "head mismatch", project: "detent", headSHA: "head-stale", baseSHA: "base-current"},
+		{name: "base mismatch", project: "detent", headSHA: "head-current", baseSHA: "base-moved"},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := backend.LatestCompletedAgentResumeState(ctx, AgentResumeLookup{
+				ProjectID:        tt.project,
+				IssueID:          "issue-859",
+				PRNumber:         42,
+				PRHeadSHA:        tt.headSHA,
+				PRBaseSHA:        tt.baseSHA,
+				RequestedModel:   "gpt-5-codex",
+				AgentBackendID:   "codex",
+				AgentBackendKind: "codex",
+				AgentRole:        "code",
+			})
+			if !errors.Is(err, ErrNotFound) {
+				t.Fatalf("LatestCompletedAgentResumeState() error = %v, want ErrNotFound", err)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## Summary

- Enable automatic provider-thread resume for implement workers redispatched from the configured Rework state.
- Require exact project, issue, PR number, head/base SHA, backend, model, and role identity before resuming.
- Persist the trusted PR fingerprint with completed work attempts and retain fresh-session fallback before a resumed turn starts.
- Enable the experimental resume flag by default as an operator opt-out and update generated references.

Fixes #1930

## UI Surface Contract

- [x] N/A, or the linked issue explicitly authorizes any high-impact UI surface, layout, density, first-viewport, or responsive visibility tradeoff.
- [x] Persistent top-of-screen messaging is explicitly authorized by the issue, or this PR does not add it.
- [x] Visual changes to primary operator screens include screenshot or browser verification below. No UI changes.

## Test Plan

- [x] `PATH="$PWD/.detent/tmp/go-bin:$PATH" GOTOOLCHAIN=go1.26.6 make check` (78.9% aggregate coverage)
