### PR TITLE
fix(capacity): pause subscription exhaustion

### DIFF
--- a/internal/backendcapacity/capacity.go
+++ b/internal/backendcapacity/capacity.go
@@ -28,6 +28,7 @@ const (
 )
 
 var retryAtPattern = regexp.MustCompile(`(?i)(?:try again|resets?)\s+(?:at\s+)?([0-9]{1,2}:[0-9]{2}\s*(?:am|pm))(?:\s*\(([A-Za-z0-9._+-]+(?:/[A-Za-z0-9._+-]+)*)\))?`)
+var retryDatePattern = regexp.MustCompile(`(?i)(?:try again|resets?)\s+(?:at\s+)?([A-Za-z]{3,9})\s+([0-9]{1,2})(?:st|nd|rd|th)?,?\s+([0-9]{4})\s+([0-9]{1,2}:[0-9]{2}\s*(?:am|pm))(?:\s*\(([A-Za-z0-9._+-]+(?:/[A-Za-z0-9._+-]+)*)\))?`)
 var http5xxPattern = regexp.MustCompile(`(?i)(?:http(?:/[0-9.]+)?\s+|status(?:[\s_-]*code)?["']?\s*[:=]?\s*)(5[0-9]{2})\b`)
 
 type Scope struct {
@@ -218,6 +219,9 @@ func resetFromText(text string, now time.Time) *time.Time {
 			return resetAt
 		}
 	}
+	if resetAt := resetFromDatedText(text, now); resetAt != nil {
+		return resetAt
+	}
 	match := retryAtPattern.FindStringSubmatch(text)
 	if len(match) != 3 {
 		return nil
@@ -239,6 +243,38 @@ func resetFromText(text string, now time.Time) *time.Time {
 	resetAt := time.Date(now.Year(), now.Month(), now.Day(), parsed.Hour(), parsed.Minute(), 0, 0, location)
 	if !resetAt.After(now) {
 		resetAt = resetAt.AddDate(0, 0, 1)
+	}
+	resetAt = resetAt.UTC()
+	return &resetAt
+}
+
+func resetFromDatedText(text string, now time.Time) *time.Time {
+	match := retryDatePattern.FindStringSubmatch(text)
+	if len(match) != 6 {
+		return nil
+	}
+	location := now.Location()
+	if timezone := strings.TrimSpace(match[5]); timezone != "" {
+		var err error
+		location, err = time.LoadLocation(timezone)
+		if err != nil {
+			return nil
+		}
+	}
+	month := strings.ToLower(strings.TrimSpace(match[1]))
+	if month == "" {
+		return nil
+	}
+	month = strings.ToUpper(month[:1]) + month[1:]
+	value := strings.Join([]string{
+		month,
+		strings.TrimSpace(match[2]) + ",",
+		strings.TrimSpace(match[3]),
+		strings.ToUpper(strings.Join(strings.Fields(match[4]), "")),
+	}, " ")
+	resetAt, err := time.ParseInLocation("Jan 2, 2006 3:04PM", value, location)
+	if err != nil {
+		return nil
 	}
 	resetAt = resetAt.UTC()
 	return &resetAt

--- a/internal/backendcapacity/capacity_test.go
+++ b/internal/backendcapacity/capacity_test.go
@@ -169,6 +169,12 @@ func TestResetFromText(t *testing.T) {
 			now:  time.Date(2026, 8, 15, 15, 47, 49, 0, time.UTC),
 			want: time.Date(2026, 8, 15, 16, 10, 0, 0, time.UTC),
 		},
+		{
+			name: "subscription reset with date",
+			text: "You've hit your usage limit. Visit https://chatgpt.com/codex/settings/usage to purchase more credits or try again at Aug 20th, 2026 10:27 AM.",
+			now:  time.Date(2026, 8, 19, 11, 28, 34, 0, chicago),
+			want: time.Date(2026, 8, 20, 15, 27, 0, 0, time.UTC),
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/claudecode/capacity.go
+++ b/internal/claudecode/capacity.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/digitaldrywood/detent/internal/backendcapacity"
+	"github.com/digitaldrywood/detent/internal/runner"
 	"github.com/digitaldrywood/detent/internal/telemetry"
 )
 
@@ -55,7 +56,47 @@ func ClassifyCapacityError(err error, limits *telemetry.RateLimits, now time.Tim
 	if details, ok := backendcapacity.ClassifyTransientOverload(err.Error(), claudeOverloadRules); ok {
 		return details, true
 	}
-	return backendcapacity.Classify(err.Error(), claudeCapacityResetAt(limits), now, claudeCapacityRules)
+	details, ok := backendcapacity.Classify(err.Error(), claudeCapacityResetAt(limits), now, claudeCapacityRules)
+	if ok && strings.Contains(strings.ToLower(err.Error()), "session limit") {
+		details.Reason = "subscription window exhausted"
+	}
+	return details, ok
+}
+
+func (b *AgentBackend) CapacityStatus(limits *telemetry.RateLimits) (runner.CapacityStatus, bool) {
+	if b == nil {
+		return runner.CapacityStatus{}, false
+	}
+	return CapacityStatus(limits)
+}
+
+func CapacityStatus(limits *telemetry.RateLimits) (runner.CapacityStatus, bool) {
+	if limits == nil {
+		return runner.CapacityStatus{}, false
+	}
+	resetAt := claudeCapacityResetAt(limits)
+	exhausted := strings.TrimSpace(limits.ReachedType) != ""
+	if !exhausted {
+		for _, bucket := range []*telemetry.RateLimitBucket{limits.Primary, limits.Secondary} {
+			if bucket != nil && bucket.Status == telemetry.RateLimitStatusExhausted {
+				exhausted = true
+				break
+			}
+		}
+	}
+	if !exhausted {
+		return runner.CapacityStatus{}, false
+	}
+	return runner.CapacityStatus{
+		Exhausted: true,
+		Detail:    "live provider status reports an exhausted subscription window",
+		Details: backendcapacity.Details{
+			Type:    backendcapacity.ErrorTypeUsageLimit,
+			Kind:    "subscription_window_exhausted",
+			Reason:  "subscription window exhausted",
+			ResetAt: resetAt,
+		},
+	}, true
 }
 
 func claudeCapacityResetAt(limits *telemetry.RateLimits) *time.Time {

--- a/internal/claudecode/capacity_test.go
+++ b/internal/claudecode/capacity_test.go
@@ -107,3 +107,20 @@ func TestClaudeCapacityResetAtUsesReachedWindow(t *testing.T) {
 		})
 	}
 }
+
+func TestCapacityStatusClassifiesRejectedSubscriptionWindow(t *testing.T) {
+	t.Parallel()
+
+	resetAt := time.Date(2026, 8, 15, 21, 10, 0, 0, time.UTC)
+	limits := &telemetry.RateLimits{
+		ReachedType: "five_hour",
+		Primary: &telemetry.RateLimitBucket{
+			Status:  telemetry.RateLimitStatusExhausted,
+			ResetAt: &resetAt,
+		},
+	}
+	status, ok := CapacityStatus(limits)
+	if !ok || !status.Exhausted || status.Available || status.Details.ResetAt == nil || !status.Details.ResetAt.Equal(resetAt) {
+		t.Fatalf("CapacityStatus() = %#v, %v, want exhausted subscription reset at %s", status, ok, resetAt)
+	}
+}

--- a/internal/codex/capacity.go
+++ b/internal/codex/capacity.go
@@ -85,7 +85,17 @@ func ClassifyCapacityError(err error, limits *telemetry.RateLimits, now time.Tim
 	if details, ok := backendcapacity.ClassifyTransientOverload(text, codexOverloadRules); ok {
 		return details, true
 	}
-	return backendcapacity.Classify(text, codexCapacityResetAt(limits), now, codexCapacityRules)
+	details, ok := backendcapacity.Classify(text, codexCapacityResetAt(limits), now, codexCapacityRules)
+	if ok && codexSubscriptionLimitText(text) {
+		details.Reason = "subscription window exhausted"
+	}
+	return details, ok
+}
+
+func codexSubscriptionLimitText(text string) bool {
+	text = strings.ToLower(strings.TrimSpace(text))
+	return strings.Contains(text, "chatgpt.com/codex/settings/usage") ||
+		strings.Contains(text, "purchase more credits or try again at")
 }
 
 func codexStartupOperation(text string) bool {
@@ -113,7 +123,7 @@ func CapacityStatus(limits *telemetry.RateLimits) (runner.CapacityStatus, bool) 
 		return runner.CapacityStatus{}, false
 	}
 	if strings.TrimSpace(limits.ReachedType) != "" {
-		return runner.CapacityStatus{Detail: "live provider status still reports an exhausted window"}, true
+		return codexExhaustedCapacityStatus(limits, "live provider status still reports an exhausted subscription window"), true
 	}
 	minimumRemaining := int64(101)
 	found := false
@@ -124,7 +134,10 @@ func CapacityStatus(limits *telemetry.RateLimits) (runner.CapacityStatus, bool) 
 		found = true
 		remaining := bucket.Remaining * 100 / bucket.Limit
 		minimumRemaining = min(minimumRemaining, remaining)
-		if bucket.Status == telemetry.RateLimitStatusExhausted || remaining < codexCapacityAvailableThresholdPercent {
+		if bucket.Status == telemetry.RateLimitStatusExhausted {
+			return codexExhaustedCapacityStatus(limits, fmt.Sprintf("live provider status reports an exhausted subscription window with %d%% capacity remaining", remaining)), true
+		}
+		if remaining < codexCapacityAvailableThresholdPercent {
 			return runner.CapacityStatus{Detail: fmt.Sprintf("live provider status reports %d%% capacity remaining", remaining)}, true
 		}
 	}
@@ -135,6 +148,19 @@ func CapacityStatus(limits *telemetry.RateLimits) (runner.CapacityStatus, bool) 
 		Available: true,
 		Detail:    fmt.Sprintf("live provider status reports %d%% capacity remaining", minimumRemaining),
 	}, true
+}
+
+func codexExhaustedCapacityStatus(limits *telemetry.RateLimits, detail string) runner.CapacityStatus {
+	return runner.CapacityStatus{
+		Exhausted: true,
+		Detail:    detail,
+		Details: backendcapacity.Details{
+			Type:    backendcapacity.ErrorTypeUsageLimit,
+			Kind:    "subscription_window_exhausted",
+			Reason:  "subscription window exhausted",
+			ResetAt: codexCapacityResetAt(limits),
+		},
+	}
 }
 
 func codexCapacityErrorText(err error) string {

--- a/internal/codex/capacity_test.go
+++ b/internal/codex/capacity_test.go
@@ -36,6 +36,15 @@ func TestAgentBackendClassifyCapacityError(t *testing.T) {
 			wantType: backendcapacity.ErrorTypeUsageLimit,
 		},
 		{
+			name: "recorded subscription exhaustion payload",
+			err: &TurnFailedError{
+				Status: "failed",
+				Body:   `{"message":"You've hit your usage limit. Visit https://chatgpt.com/codex/settings/usage to purchase more credits or try again at Aug 20th, 2026 10:27 AM.","codexErrorInfo":"usageLimitExceeded","additionalDetails":null}`,
+			},
+			want:     true,
+			wantType: backendcapacity.ErrorTypeUsageLimit,
+		},
+		{
 			name: "google resource exhausted without reset",
 			err:  &TurnFailedError{Status: "failed", Body: `{"error":{"status":"RESOURCE_EXHAUSTED"}}`},
 		},
@@ -171,6 +180,7 @@ func TestCapacityStatus(t *testing.T) {
 		limits        *telemetry.RateLimits
 		wantReported  bool
 		wantAvailable bool
+		wantExhausted bool
 	}{
 		{name: "missing status"},
 		{
@@ -196,7 +206,8 @@ func TestCapacityStatus(t *testing.T) {
 				ReachedType: "primary",
 				Primary:     &telemetry.RateLimitBucket{Limit: 100, Remaining: 20},
 			},
-			wantReported: true,
+			wantReported:  true,
+			wantExhausted: true,
 		},
 	}
 
@@ -205,8 +216,8 @@ func TestCapacityStatus(t *testing.T) {
 			t.Parallel()
 
 			status, reported := CapacityStatus(tt.limits)
-			if reported != tt.wantReported || status.Available != tt.wantAvailable {
-				t.Fatalf("CapacityStatus() = %#v, %v, want available %v reported %v", status, reported, tt.wantAvailable, tt.wantReported)
+			if reported != tt.wantReported || status.Available != tt.wantAvailable || status.Exhausted != tt.wantExhausted {
+				t.Fatalf("CapacityStatus() = %#v, %v, want available %v exhausted %v reported %v", status, reported, tt.wantAvailable, tt.wantExhausted, tt.wantReported)
 			}
 		})
 	}

--- a/internal/orchestrator/backend_capacity.go
+++ b/internal/orchestrator/backend_capacity.go
@@ -195,12 +195,16 @@ func backendCapacityStatusMessage(outage BackendOutage) string {
 	if backend == "" {
 		backend = "agent backend"
 	}
+	reason := strings.TrimSpace(outage.Reason)
 	message := "backend " + backend + " at usage limit"
+	if reason != "" {
+		message = "backend " + backend + ": " + reason
+	}
 	if !outage.ResumeAt.IsZero() {
-		message += " — provider-recorded resume at " + outage.ResumeAt.UTC().Format(time.RFC3339)
+		message += ", resumes ~" + outage.ResumeAt.UTC().Format("2006-01-02 15:04 UTC")
 	}
 	if !outage.NextProbeAt.IsZero() {
-		message += "; next probe at " + outage.NextProbeAt.UTC().Format(time.RFC3339)
+		message += "; next probe ~" + outage.NextProbeAt.UTC().Format("2006-01-02 15:04 UTC")
 	}
 	return message
 }
@@ -428,16 +432,65 @@ func (o *Orchestrator) recoverBackendCapacityFromStatus(
 	if o.capacityStatus == nil || rateLimits == nil || !running.CapacityScope.Hosted() {
 		return
 	}
-	key, outage, ok := matchingBackendOutage(state.BackendOutages, running.CapacityScope)
-	if !ok {
-		return
-	}
 	status, ok := o.capacityStatus.BackendCapacityStatus(running.CapacityScope, rateLimits)
 	if !ok {
 		return
 	}
 	if observedAt.IsZero() {
 		observedAt = o.clockNow()
+	}
+	key, outage, active := matchingBackendOutage(state.BackendOutages, running.CapacityScope)
+	if status.Exhausted {
+		wasActive := active
+		details := status.Details
+		if details.Type == "" {
+			details.Type = backendcapacity.ErrorTypeUsageLimit
+		}
+		if strings.TrimSpace(details.Kind) == "" {
+			details.Kind = "subscription_window_exhausted"
+		}
+		if strings.TrimSpace(details.Reason) == "" {
+			details.Reason = "subscription window exhausted"
+		}
+		detail := strings.TrimSpace(status.Detail)
+		if detail == "" {
+			detail = details.Reason
+		}
+		capacityErr, classified := backendcapacity.As(backendcapacity.NewError(
+			running.CapacityScope,
+			details,
+			errors.New(detail),
+		))
+		if !classified {
+			return
+		}
+		o.registerBackendOutage(state, capacityErr, observedAt, running.CapacityProbe)
+		key, outage, active = matchingBackendOutage(state.BackendOutages, running.CapacityScope)
+		if !active {
+			return
+		}
+		outage.LastProbeAt = observedAt
+		outage.LastProbeResult = "status_exhausted"
+		outage.LastProbeDetail = strings.TrimSpace(status.Detail)
+		state.BackendOutages[key] = outage
+		if !wasActive {
+			recordStateEvent(state, telemetry.ActivityEvent{
+				At:      observedAt,
+				Event:   "backend_capacity_paused",
+				Message: backendCapacityStatusMessage(outage),
+			})
+			telemetry.LogLifecycleMessage(o.logger, slog.LevelWarn, telemetry.LifecycleSafetyControl, "backend_capacity_paused", "backend capacity paused from provider status", o.runningLifecycleCorrelation(running.Issue, running),
+				"backend_id", outage.Scope.BackendID,
+				"backend_kind", outage.Scope.BackendKind,
+				"provider", outage.Scope.Provider,
+				"reset_at", outage.ResetAt,
+				"resume_at", outage.ResumeAt,
+			)
+		}
+		return
+	}
+	if !active {
+		return
 	}
 	outage.LastProbeAt = observedAt
 	outage.LastProbeDetail = strings.TrimSpace(status.Detail)
@@ -640,6 +693,33 @@ func (o *Orchestrator) recoverBackendCapacityBlockedIssues(
 	for _, issue := range issuesInStates(issues, []string{blockedStatusState}) {
 		capacityErr, capacityComment, hydratedIssue, ok := o.classifyBlockedCapacityIssue(ctx, state, issue, now)
 		if !ok {
+			request := runpkg.RunRequest{
+				Issue:           hydratedIssue,
+				Mode:            runpkg.RunModeImplement,
+				SelectorContext: o.selectorContext(),
+			}
+			scope, scoped := o.backendCapacityScope(request)
+			if !scoped {
+				continue
+			}
+			if _, _, active := matchingBackendOutage(state.BackendOutages, scope); active {
+				continue
+			}
+			recoveryKey, recovery, recovered := matchingBackendRecovery(state.BackendRecoveries, scope)
+			if !recovered {
+				continue
+			}
+			targetState, suppression := o.backendCapacityBreakerRecoveryTarget(ctx, hydratedIssue, recovery)
+			if suppression != "" {
+				recovery = o.recordBackendCapacityBlockedRecoverySuppressed(state, hydratedIssue, recovery, suppression, now)
+				state.BackendRecoveries[recoveryKey] = recovery
+				continue
+			}
+			if !o.applyBackendCapacityBlockedRecovery(ctx, state, hydratedIssue, targetState, recovery.Outage, recovery, now) {
+				continue
+			}
+			transitioned[hydratedIssue.ID] = struct{}{}
+			consumedRecoveries[recoveryKey] = struct{}{}
 			continue
 		}
 		key, outage, active := matchingBackendOutage(state.BackendOutages, capacityErr.Scope)
@@ -679,6 +759,133 @@ func (o *Orchestrator) recoverBackendCapacityBlockedIssues(
 		return nil
 	}
 	return transitioned
+}
+
+func (o *Orchestrator) backendCapacityBreakerRecoveryTarget(
+	ctx context.Context,
+	issue connector.Issue,
+	recovery BackendRecovery,
+) (string, string) {
+	entry, ok := o.latestWorkflowLaneEntry(ctx, issue)
+	if !ok {
+		return "", "current Blocked-entry provenance is unavailable"
+	}
+	if normalizeState(entry.Event.PhaseName) != normalizeState(blockedStatusState) ||
+		!blockedEntryMatchesCurrent(issue, entry.Event.StartedAt) {
+		return "", "latest durable lane entry is not the current Blocked entry"
+	}
+	reason := strings.TrimSpace(entry.Event.Reason)
+	switch reason {
+	case "token_ceiling_circuit_breaker", artifactGateConvergenceReason:
+	default:
+		return "", "current Blocked entry has independent cause " + reason
+	}
+	if recovery.Outage.DetectedAt.IsZero() || recovery.RecoveredAt.IsZero() {
+		return "", "backend capacity outage window is incomplete"
+	}
+	if entry.Event.StartedAt.Before(recovery.Outage.DetectedAt.Add(-reworkBreakerStageUpdateSkew)) ||
+		entry.Event.StartedAt.After(recovery.RecoveredAt) {
+		return "", "breaker park falls outside the backend capacity outage window"
+	}
+	if ok, evidenceReason := o.backendCapacityBreakerEvidenceWithinOutage(ctx, issue, reason, recovery); !ok {
+		return "", evidenceReason
+	}
+	if independentReason := o.backendCapacityIndependentBlockerReason(issue); independentReason != "" {
+		return "", independentReason
+	}
+	targetState := strings.TrimSpace(entry.Event.PreviousPhaseName)
+	if targetState == "" || normalizeState(targetState) == normalizeState(blockedStatusState) || stateIn(targetState, o.cfg.TerminalStates) {
+		return "", "current Blocked entry has no recoverable captured source lane"
+	}
+	return targetState, ""
+}
+
+func (o *Orchestrator) backendCapacityBreakerEvidenceWithinOutage(
+	ctx context.Context,
+	issue connector.Issue,
+	reason string,
+	recovery BackendRecovery,
+) (bool, string) {
+	if o.workAttempts == nil {
+		return false, "breaker attempt history is unavailable"
+	}
+	limit := 1
+	if reason == artifactGateConvergenceReason {
+		limit = artifactGateConvergenceLimit + 1
+	}
+	attempts, err := o.workAttempts.ListRecentTerminalWorkAttempts(ctx, store.WorkAttemptHistoryQuery{
+		ProjectID:  strings.TrimSpace(o.cfg.Project.ID),
+		IssueID:    strings.TrimSpace(issue.ID),
+		Identifier: strings.TrimSpace(issue.Identifier),
+		IssueURL:   strings.TrimSpace(issue.URL),
+		WorkerType: workAttemptWorkerType(issue, runpkg.RunModeImplement),
+		Limit:      limit,
+	})
+	if err != nil {
+		return false, "breaker attempt history lookup failed"
+	}
+	if reason == "token_ceiling_circuit_breaker" {
+		if len(attempts) == 0 || !backendCapacityTokenCeilingAttempt(attempts[0]) {
+			return false, "latest breaker attempt is not a token-ceiling failure"
+		}
+		if !backendCapacityEvidenceInWindow(attempts[0].CompletedAt, recovery) {
+			return false, "token-ceiling evidence falls outside the backend capacity outage window"
+		}
+		return true, ""
+	}
+	if len(attempts) == 0 {
+		return false, "artifact-gate convergence history is unavailable"
+	}
+	latest, ok := artifactGateConvergenceRecordFromAttempt(attempts[0])
+	if !ok || !latest.Tripped || latest.Limit <= 0 || latest.ConsecutiveUnchanged < latest.Limit || len(attempts) < latest.Limit {
+		return false, "artifact-gate convergence evidence is incomplete"
+	}
+	for index := range latest.Limit {
+		attempt := attempts[index]
+		record, found := artifactGateConvergenceRecordFromAttempt(attempt)
+		if !found || !record.Unchanged ||
+			!strings.EqualFold(strings.TrimSpace(record.StatusField), strings.TrimSpace(latest.StatusField)) ||
+			!strings.EqualFold(strings.TrimSpace(record.DispatchStatus), strings.TrimSpace(latest.DispatchStatus)) ||
+			!strings.EqualFold(strings.TrimSpace(record.CompletionStatus), strings.TrimSpace(latest.CompletionStatus)) {
+			return false, "artifact-gate convergence evidence is incomplete"
+		}
+		if !backendCapacityEvidenceInWindow(attempt.CompletedAt, recovery) {
+			return false, "artifact-gate convergence evidence falls outside the backend capacity outage window"
+		}
+	}
+	return true, ""
+}
+
+func backendCapacityTokenCeilingAttempt(attempt store.WorkAttempt) bool {
+	text := strings.ToLower(strings.TrimSpace(attempt.ErrorClass + "\n" + attempt.ErrorMessage))
+	return strings.Contains(text, "token_ceiling") || strings.Contains(text, "session token ceiling exceeded")
+}
+
+func backendCapacityEvidenceInWindow(at time.Time, recovery BackendRecovery) bool {
+	return !at.IsZero() &&
+		!at.Before(recovery.Outage.DetectedAt.Add(-reworkBreakerStageUpdateSkew)) &&
+		!at.After(recovery.RecoveredAt)
+}
+
+func (o *Orchestrator) backendCapacityIndependentBlockerReason(issue connector.Issue) string {
+	if blockedRefsUnresolved(issue.BlockedBy, o.cfg.TerminalStates) {
+		return "current issue has independent dependency blockers"
+	}
+	if signal, found := autoPromoteIssueWorkpadSignal(issue); found && signal != nil && signal.Source == workpad.SourceStructured {
+		if signal.Invalid != nil {
+			return "current structured Workpad blocker status is invalid"
+		}
+		if strings.TrimSpace(signal.HumanAction) != "" {
+			return "current structured Workpad declares a human action"
+		}
+		if len(signal.Blockers) > 0 {
+			return "current structured Workpad declares independent typed blockers"
+		}
+		if strings.TrimSpace(signal.Status) == workpad.StatusBlocked {
+			return "current structured Workpad declares an independent blocked reason"
+		}
+	}
+	return ""
 }
 
 func (o *Orchestrator) classifyBlockedCapacityIssue(
@@ -749,22 +956,8 @@ func (o *Orchestrator) backendCapacityBlockedRecoveryTarget(
 	if !recoveredAt.IsZero() && (recoveredAt.Before(entry.Event.StartedAt) || recoveredAt.Before(commentAt)) {
 		return "", "backend capacity recovery predates the current Blocked entry evidence"
 	}
-	if blockedRefsUnresolved(issue.BlockedBy, o.cfg.TerminalStates) {
-		return "", "current issue has independent dependency blockers"
-	}
-	if signal, found := autoPromoteIssueWorkpadSignal(issue); found && signal != nil && signal.Source == workpad.SourceStructured {
-		if signal.Invalid != nil {
-			return "", "current structured Workpad blocker status is invalid"
-		}
-		if strings.TrimSpace(signal.HumanAction) != "" {
-			return "", "current structured Workpad declares a human action"
-		}
-		if len(signal.Blockers) > 0 {
-			return "", "current structured Workpad declares independent typed blockers"
-		}
-		if strings.TrimSpace(signal.Status) == workpad.StatusBlocked {
-			return "", "current structured Workpad declares an independent blocked reason"
-		}
+	if independentReason := o.backendCapacityIndependentBlockerReason(issue); independentReason != "" {
+		return "", independentReason
 	}
 	targetState := strings.TrimSpace(entry.Event.PreviousPhaseName)
 	if targetState == "" || normalizeState(targetState) == normalizeState(blockedStatusState) || stateIn(targetState, o.cfg.TerminalStates) {

--- a/internal/orchestrator/backend_capacity.go
+++ b/internal/orchestrator/backend_capacity.go
@@ -828,6 +828,9 @@ func (o *Orchestrator) backendCapacityBreakerEvidenceWithinOutage(
 		if len(attempts) == 0 || !backendCapacityTokenCeilingAttempt(attempts[0]) {
 			return false, "latest breaker attempt is not a token-ceiling failure"
 		}
+		if !backendCapacityAttemptMatchesScope(attempts[0], recovery.Outage.Scope) {
+			return false, "token-ceiling evidence belongs to a different backend capacity scope"
+		}
 		if !backendCapacityEvidenceInWindow(attempts[0].CompletedAt, recovery) {
 			return false, "token-ceiling evidence falls outside the backend capacity outage window"
 		}
@@ -849,6 +852,9 @@ func (o *Orchestrator) backendCapacityBreakerEvidenceWithinOutage(
 			!strings.EqualFold(strings.TrimSpace(record.CompletionStatus), strings.TrimSpace(latest.CompletionStatus)) {
 			return false, "artifact-gate convergence evidence is incomplete"
 		}
+		if !backendCapacityAttemptMatchesScope(attempt, recovery.Outage.Scope) {
+			return false, "artifact-gate convergence evidence belongs to a different backend capacity scope"
+		}
 		if !backendCapacityEvidenceInWindow(attempt.CompletedAt, recovery) {
 			return false, "artifact-gate convergence evidence falls outside the backend capacity outage window"
 		}
@@ -865,6 +871,18 @@ func backendCapacityEvidenceInWindow(at time.Time, recovery BackendRecovery) boo
 	return !at.IsZero() &&
 		!at.Before(recovery.Outage.DetectedAt.Add(-reworkBreakerStageUpdateSkew)) &&
 		!at.After(recovery.RecoveredAt)
+}
+
+func backendCapacityAttemptMatchesScope(attempt store.WorkAttempt, scope backendcapacity.Scope) bool {
+	identity := attempt.RuntimeIdentity.Normalize()
+	scope = scope.Normalize()
+	if identity.BackendID == "" || identity.BackendKind == "" ||
+		!strings.EqualFold(identity.BackendID, scope.BackendID) ||
+		!strings.EqualFold(identity.BackendKind, scope.BackendKind) {
+		return false
+	}
+	return scope.Provider == "" ||
+		(identity.Provider.Known() && strings.EqualFold(identity.Provider.Value, scope.Provider))
 }
 
 func (o *Orchestrator) backendCapacityIndependentBlockerReason(issue connector.Issue) string {

--- a/internal/orchestrator/backend_capacity_test.go
+++ b/internal/orchestrator/backend_capacity_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/digitaldrywood/detent/internal/connector"
 	"github.com/digitaldrywood/detent/internal/gate"
 	runpkg "github.com/digitaldrywood/detent/internal/runner"
+	"github.com/digitaldrywood/detent/internal/scheduler"
 	"github.com/digitaldrywood/detent/internal/store"
 	"github.com/digitaldrywood/detent/internal/telemetry"
 	"github.com/digitaldrywood/detent/internal/workpad"
@@ -59,6 +60,121 @@ func TestProductionClaudeSessionLimitRecordsOneCapacityOutage(t *testing.T) {
 	}
 	if len(state.InstantFailures) != 0 || len(state.RepeatedFailures) != 0 {
 		t.Fatalf("issue failure breakers = instant %#v repeated %#v, want no capacity strikes", state.InstantFailures, state.RepeatedFailures)
+	}
+}
+
+func TestSubscriptionStatusArmsOutageBeforeCompletion(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 8, 19, 16, 30, 43, 0, time.UTC)
+	resetAt := time.Date(2026, 8, 20, 15, 27, 0, 0, time.UTC)
+	scope := backendcapacity.Scope{BackendID: "codex", BackendKind: "codex", Provider: "openai"}
+	controller := backendCapacityTestController{
+		scope: scope,
+		status: runpkg.CapacityStatus{
+			Exhausted: true,
+			Detail:    "live provider status reports an exhausted subscription window",
+			Details: backendcapacity.Details{
+				Type:    backendcapacity.ErrorTypeUsageLimit,
+				Kind:    "subscription_window_exhausted",
+				Reason:  "subscription window exhausted",
+				ResetAt: &resetAt,
+			},
+		},
+		hasStatus: true,
+	}
+	orch := &Orchestrator{capacityController: controller, capacityStatus: controller, now: func() time.Time { return now }}
+	state := newState(normalizeConfig(Config{}))
+	issue := connector.Issue{ID: "issue-live-exhaustion", State: "In Progress"}
+	state.Running[issue.ID] = Running{Issue: issue, CapacityScope: scope, StartedAt: now.Add(-time.Minute)}
+
+	orch.handleRunUpdate(&state, runUpdate{
+		issueID: issue.ID,
+		usage: runpkg.UsageUpdate{
+			LastEventAt: now,
+			RateLimits: &telemetry.RateLimits{
+				ReachedType: "primary",
+				Primary: &telemetry.RateLimitBucket{
+					Status:  telemetry.RateLimitStatusExhausted,
+					ResetAt: &resetAt,
+				},
+			},
+		},
+	})
+
+	outage, ok := state.BackendOutages[scope.Key()]
+	if !ok || outage.Kind != "subscription_window_exhausted" || outage.Reason != "subscription window exhausted" || !outage.ResetAt.Equal(resetAt) {
+		t.Fatalf("BackendOutages = %#v, want named subscription outage reset at %s", state.BackendOutages, resetAt)
+	}
+	if _, _, paused := orch.backendCapacityDispatch(&state, runpkg.RunRequest{Issue: connector.Issue{ID: "issue-next"}}, now); !paused {
+		t.Fatal("backendCapacityDispatch() paused = false after rejected subscription status")
+	}
+	message := backendCapacityStatusMessage(outage)
+	if !strings.Contains(message, "backend codex: subscription window exhausted") || !strings.Contains(message, "resumes ~2026-08-20 15:27 UTC") {
+		t.Fatalf("backendCapacityStatusMessage() = %q", message)
+	}
+
+	orch.capacityStatus = backendCapacityTestController{
+		scope:     scope,
+		status:    runpkg.CapacityStatus{Exhausted: true},
+		hasStatus: true,
+	}
+	orch.recoverBackendCapacityFromStatus(&state, state.Running[issue.ID], &telemetry.RateLimits{}, now.Add(time.Minute))
+	outage = state.BackendOutages[scope.Key()]
+	if outage.Kind != "subscription_window_exhausted" || outage.Reason != "subscription window exhausted" {
+		t.Fatalf("defaulted BackendOutage = %#v, want named subscription outage", outage)
+	}
+}
+
+func TestSlippedSubscriptionAttemptsFinishAsCapacityBeforeSessionBrakes(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 8, 19, 20, 0, 0, 0, time.UTC)
+	resetAt := now.Add(12 * time.Hour)
+	scope := backendcapacity.Scope{BackendID: "claude-video", BackendKind: "claude_code", Provider: "anthropic"}
+	attempts := &recordingWorkAttemptStore{}
+	cfg := normalizeConfig(Config{ActiveStates: []string{"In Progress", "Rework"}, TerminalStates: []string{"Done"}})
+	orch := &Orchestrator{cfg: cfg, workAttempts: attempts}
+	state := newState(cfg)
+	issue := connector.Issue{ID: "issue-slipped-capacity", State: "In Progress"}
+	state.Running[issue.ID] = Running{
+		Issue:         issue,
+		Attempt:       3,
+		WorkAttemptID: 42,
+		CapacityScope: scope,
+		StartedAt:     now.Add(-5 * time.Minute),
+	}
+	state.Claimed[issue.ID] = Claimed{Issue: issue, ClaimedAt: now.Add(-5 * time.Minute)}
+	ceilingErr := &runpkg.SessionTokenCeilingError{
+		TotalTokens:   16_100_000,
+		CeilingTokens: 16_000_000,
+		Source:        runpkg.TokenCeilingSourceAbsolute,
+	}
+
+	orch.handleRunResult(t.Context(), &state, runpkg.Completion{
+		IssueID: issue.ID,
+		Request: runpkg.RunRequest{Issue: issue, Attempt: 3, Mode: runpkg.RunModeImplement},
+		Result: runpkg.RunResult{
+			FinalState: runpkg.FinalStateTokenCeilingExceeded,
+			Tokens:     TokenTotals{TotalTokens: 16_100_000},
+		},
+		Err: backendcapacity.NewError(scope, backendcapacity.Details{
+			Type:    backendcapacity.ErrorTypeUsageLimit,
+			Kind:    "subscription_window_exhausted",
+			Reason:  "subscription window exhausted",
+			ResetAt: &resetAt,
+		}, ceilingErr),
+		CompletedAt: now,
+	})
+
+	if len(attempts.completions) != 1 || attempts.completions[0].TerminalState != store.WorkAttemptTerminalCapacity || attempts.completions[0].ErrorClass != backendcapacity.ErrorClass {
+		t.Fatalf("work attempt completions = %#v, want backend capacity", attempts.completions)
+	}
+	if len(state.Blocked) != 0 || len(state.InstantFailures) != 0 || len(state.RepeatedFailures) != 0 || state.FailureBreaker.Active() {
+		t.Fatalf("outage-era brakes = blocked %#v instant %#v repeated %#v project %#v", state.Blocked, state.InstantFailures, state.RepeatedFailures, state.FailureBreaker)
+	}
+	if retry, ok := state.Retry[issue.ID]; !ok || !retry.CapacityScope.Matches(scope) || retry.Attempt != 3 {
+		t.Fatalf("Retry[%q] = %#v, want same-attempt capacity wait", issue.ID, retry)
 	}
 }
 
@@ -739,9 +855,10 @@ func TestBackendCapacityHelperBoundaries(t *testing.T) {
 	}
 	outage := BackendOutage{
 		Scope:    backendcapacity.Scope{BackendKind: "codex"},
+		Reason:   "subscription window exhausted",
 		ResumeAt: now,
 	}
-	if got := backendCapacityStatusMessage(outage); !strings.Contains(got, "backend codex") || !strings.Contains(got, now.Format(time.RFC3339)) {
+	if got := backendCapacityStatusMessage(outage); !strings.Contains(got, "backend codex: subscription window exhausted") || !strings.Contains(got, "resumes ~2026-07-10 01:55 UTC") {
 		t.Fatalf("backendCapacityStatusMessage() = %q", got)
 	}
 
@@ -1196,6 +1313,218 @@ func TestRecoverBackendCapacityBlockedIssues(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+func TestRecoverBackendCapacityOutageEraBreakerParks(t *testing.T) {
+	t.Parallel()
+
+	parkedAt := time.Date(2026, 8, 19, 22, 0, 0, 0, time.UTC)
+	detectedAt := parkedAt.Add(-3 * time.Minute)
+	recoveredAt := parkedAt.Add(5 * time.Minute)
+	scope := backendcapacity.Scope{BackendID: "claude-video", BackendKind: "claude_code", Provider: "anthropic"}
+	artifactAttempt := func(completedAt time.Time, consecutive int, tripped bool) store.WorkAttempt {
+		return store.WorkAttempt{
+			Status:        store.WorkAttemptStatusTerminal,
+			TerminalState: store.WorkAttemptTerminalSuccess,
+			CompletedAt:   completedAt,
+			WorkerMetadataJSON: marshalWorkAttemptJSON(map[string]any{
+				artifactGateConvergenceMetadataKey: artifactGateConvergenceRecord{
+					StatusField:          "Artifact Status",
+					DispatchStatus:       "Pending",
+					CompletionStatus:     "Pending",
+					Unchanged:            true,
+					ConsecutiveUnchanged: consecutive,
+					Limit:                artifactGateConvergenceLimit,
+					Tripped:              tripped,
+				},
+			}),
+		}
+	}
+	mismatchedArtifact := artifactAttempt(parkedAt.Add(-time.Minute), 2, false)
+	mismatchedArtifact.WorkerMetadataJSON = marshalWorkAttemptJSON(map[string]any{
+		artifactGateConvergenceMetadataKey: artifactGateConvergenceRecord{
+			StatusField:          "Artifact Status",
+			DispatchStatus:       "Pending",
+			CompletionStatus:     "Changed",
+			Unchanged:            true,
+			ConsecutiveUnchanged: 2,
+			Limit:                artifactGateConvergenceLimit,
+		},
+	})
+	tests := []struct {
+		name            string
+		reason          string
+		attempts        []store.WorkAttempt
+		historyErr      error
+		wantTransition  bool
+		wantSuppression string
+	}{
+		{
+			name:   "token ceiling evidence entirely inside outage",
+			reason: "token_ceiling_circuit_breaker",
+			attempts: []store.WorkAttempt{{
+				Status:        store.WorkAttemptStatusTerminal,
+				TerminalState: store.WorkAttemptTerminalFailure,
+				ErrorClass:    "runner_error",
+				ErrorMessage:  "session token ceiling exceeded: total_tokens=16100000 ceiling_tokens=16000000",
+				CompletedAt:   parkedAt,
+			}},
+			wantTransition: true,
+		},
+		{
+			name:   "token ceiling evidence outside outage stays parked",
+			reason: "token_ceiling_circuit_breaker",
+			attempts: []store.WorkAttempt{{
+				ErrorMessage: "session token ceiling exceeded",
+				CompletedAt:  detectedAt.Add(-time.Minute),
+			}},
+			wantSuppression: "falls outside",
+		},
+		{
+			name:   "non token ceiling evidence stays parked",
+			reason: "token_ceiling_circuit_breaker",
+			attempts: []store.WorkAttempt{{
+				ErrorMessage: "ordinary runner failure",
+				CompletedAt:  parkedAt,
+			}},
+			wantSuppression: "not a token-ceiling",
+		},
+		{
+			name:   "artifact convergence evidence entirely inside outage",
+			reason: artifactGateConvergenceReason,
+			attempts: []store.WorkAttempt{
+				artifactAttempt(parkedAt, 3, true),
+				artifactAttempt(parkedAt.Add(-time.Minute), 2, false),
+				artifactAttempt(parkedAt.Add(-2*time.Minute), 1, false),
+			},
+			wantTransition: true,
+		},
+		{
+			name:   "artifact convergence with pre-outage evidence stays parked",
+			reason: artifactGateConvergenceReason,
+			attempts: []store.WorkAttempt{
+				artifactAttempt(parkedAt, 3, true),
+				artifactAttempt(parkedAt.Add(-time.Minute), 2, false),
+				artifactAttempt(detectedAt.Add(-time.Minute), 1, false),
+			},
+			wantSuppression: "falls outside",
+		},
+		{
+			name:            "artifact convergence without history stays parked",
+			reason:          artifactGateConvergenceReason,
+			wantSuppression: "history is unavailable",
+		},
+		{
+			name:            "artifact convergence incomplete history stays parked",
+			reason:          artifactGateConvergenceReason,
+			attempts:        []store.WorkAttempt{artifactAttempt(parkedAt, 3, true)},
+			wantSuppression: "evidence is incomplete",
+		},
+		{
+			name:   "artifact convergence mismatched history stays parked",
+			reason: artifactGateConvergenceReason,
+			attempts: []store.WorkAttempt{
+				artifactAttempt(parkedAt, 3, true),
+				mismatchedArtifact,
+				artifactAttempt(parkedAt.Add(-2*time.Minute), 1, false),
+			},
+			wantSuppression: "evidence is incomplete",
+		},
+		{
+			name:            "attempt history lookup failure stays parked",
+			reason:          artifactGateConvergenceReason,
+			historyErr:      errors.New("history unavailable"),
+			wantSuppression: "lookup failed",
+		},
+		{
+			name:            "independent breaker stays parked",
+			reason:          "operator_hold",
+			wantSuppression: "independent cause",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			stageUpdatedAt := parkedAt
+			issue := connector.Issue{
+				ID:             "issue-" + strings.ReplaceAll(tt.name, " ", "-"),
+				Identifier:     "digitaldrywood/video#99",
+				State:          blockedStatusState,
+				StageUpdatedAt: &stageUpdatedAt,
+				Comments:       []connector.IssueComment{{Body: "ordinary operator note"}},
+				WorkpadSignal: &workpad.Signal{
+					Source: workpad.SourceStructured,
+					Status: workpad.StatusInProgress,
+				},
+			}
+			tracker := &backendCapacityTestConnector{}
+			metrics := &autoPromoteWorkflowMetricsRecorder{}
+			attemptStore := &recordingWorkAttemptStore{history: tt.attempts, historyErr: tt.historyErr}
+			orch := &Orchestrator{
+				cfg:                normalizeConfig(Config{Project: scheduler.ProjectCandidate{ID: "video"}, ActiveStates: []string{"In Progress", "Rework"}, TerminalStates: []string{"Done"}}),
+				connector:          tracker,
+				capacityController: backendCapacityTestController{scope: scope},
+				workflowMetrics:    metrics,
+				workAttempts:       attemptStore,
+			}
+			if _, err := metrics.RecordWorkflowPhaseEvent(t.Context(), store.WorkflowPhaseEvent{
+				ProjectID:         "video",
+				IssueID:           issue.ID,
+				Identifier:        issue.Identifier,
+				PhaseType:         store.WorkflowPhaseTypeLane,
+				PhaseName:         blockedStatusState,
+				PreviousPhaseName: "In Progress",
+				Reason:            tt.reason,
+				Status:            "entered",
+				StartedAt:         parkedAt,
+			}); err != nil {
+				t.Fatalf("RecordWorkflowPhaseEvent() error = %v", err)
+			}
+			state := newState(orch.cfg)
+			state.Blocked[issue.ID] = Blocked{Issue: issue, BlockedAt: parkedAt, Source: BlockedSourceProjectStatus}
+			state.BackendRecoveries[scope.Key()] = BackendRecovery{
+				Outage: BackendOutage{
+					Scope:      scope,
+					DetectedAt: detectedAt,
+					Reason:     "subscription window exhausted",
+				},
+				RecoveredAt: recoveredAt,
+			}
+
+			transitioned := orch.recoverBackendCapacityBlockedIssues(t.Context(), &state, []connector.Issue{issue}, recoveredAt)
+			if tt.wantTransition {
+				if _, ok := transitioned[issue.ID]; !ok || len(tracker.updates) != 1 || tracker.updates[0].state != "In Progress" {
+					t.Fatalf("recovery = transitioned %#v updates %#v, want In Progress", transitioned, tracker.updates)
+				}
+				if _, blocked := state.Blocked[issue.ID]; blocked {
+					t.Fatalf("Blocked[%q] remains after outage-era breaker recovery", issue.ID)
+				}
+				return
+			}
+			if len(transitioned) != 0 || len(tracker.updates) != 0 {
+				t.Fatalf("recovery = transitioned %#v updates %#v, want sticky park", transitioned, tracker.updates)
+			}
+			recovery := state.BackendRecoveries[scope.Key()]
+			if got := recovery.SuppressedIssues[issue.ID]; !strings.Contains(got, tt.wantSuppression) {
+				t.Fatalf("suppression = %q, want %q", got, tt.wantSuppression)
+			}
+		})
+	}
+}
+
+func TestBackendCapacityBreakerRecoveryRequiresDurableProvenance(t *testing.T) {
+	t.Parallel()
+
+	orch := &Orchestrator{}
+	issue := connector.Issue{ID: "issue-no-history", State: blockedStatusState}
+	if _, reason := orch.backendCapacityBreakerRecoveryTarget(t.Context(), issue, BackendRecovery{}); !strings.Contains(reason, "provenance is unavailable") {
+		t.Fatalf("recovery target suppression = %q, want missing provenance", reason)
+	}
+	if ok, reason := orch.backendCapacityBreakerEvidenceWithinOutage(t.Context(), issue, "token_ceiling_circuit_breaker", BackendRecovery{}); ok || !strings.Contains(reason, "history is unavailable") {
+		t.Fatalf("recovery evidence = (%v, %q), want missing history", ok, reason)
 	}
 }
 

--- a/internal/orchestrator/backend_capacity_test.go
+++ b/internal/orchestrator/backend_capacity_test.go
@@ -1323,8 +1323,16 @@ func TestRecoverBackendCapacityOutageEraBreakerParks(t *testing.T) {
 	detectedAt := parkedAt.Add(-3 * time.Minute)
 	recoveredAt := parkedAt.Add(5 * time.Minute)
 	scope := backendcapacity.Scope{BackendID: "claude-video", BackendKind: "claude_code", Provider: "anthropic"}
+	otherScope := backendcapacity.Scope{BackendID: "codex", BackendKind: "codex", Provider: "openai"}
+	otherProviderScope := backendcapacity.Scope{BackendID: scope.BackendID, BackendKind: scope.BackendKind, Provider: "openai"}
+	withScope := func(attempt store.WorkAttempt, attemptScope backendcapacity.Scope) store.WorkAttempt {
+		attempt.RuntimeIdentity.BackendID = attemptScope.BackendID
+		attempt.RuntimeIdentity.BackendKind = attemptScope.BackendKind
+		attempt.RuntimeIdentity.Provider.Value = attemptScope.Provider
+		return attempt
+	}
 	artifactAttempt := func(completedAt time.Time, consecutive int, tripped bool) store.WorkAttempt {
-		return store.WorkAttempt{
+		return withScope(store.WorkAttempt{
 			Status:        store.WorkAttemptStatusTerminal,
 			TerminalState: store.WorkAttemptTerminalSuccess,
 			CompletedAt:   completedAt,
@@ -1339,7 +1347,7 @@ func TestRecoverBackendCapacityOutageEraBreakerParks(t *testing.T) {
 					Tripped:              tripped,
 				},
 			}),
-		}
+		}, scope)
 	}
 	mismatchedArtifact := artifactAttempt(parkedAt.Add(-time.Minute), 2, false)
 	mismatchedArtifact.WorkerMetadataJSON = marshalWorkAttemptJSON(map[string]any{
@@ -1363,31 +1371,58 @@ func TestRecoverBackendCapacityOutageEraBreakerParks(t *testing.T) {
 		{
 			name:   "token ceiling evidence entirely inside outage",
 			reason: "token_ceiling_circuit_breaker",
-			attempts: []store.WorkAttempt{{
+			attempts: []store.WorkAttempt{withScope(store.WorkAttempt{
 				Status:        store.WorkAttemptStatusTerminal,
 				TerminalState: store.WorkAttemptTerminalFailure,
 				ErrorClass:    "runner_error",
 				ErrorMessage:  "session token ceiling exceeded: total_tokens=16100000 ceiling_tokens=16000000",
 				CompletedAt:   parkedAt,
-			}},
+			}, scope)},
 			wantTransition: true,
 		},
 		{
 			name:   "token ceiling evidence outside outage stays parked",
 			reason: "token_ceiling_circuit_breaker",
-			attempts: []store.WorkAttempt{{
+			attempts: []store.WorkAttempt{withScope(store.WorkAttempt{
 				ErrorMessage: "session token ceiling exceeded",
 				CompletedAt:  detectedAt.Add(-time.Minute),
-			}},
+			}, scope)},
 			wantSuppression: "falls outside",
+		},
+		{
+			name:   "token ceiling evidence from another backend stays parked",
+			reason: "token_ceiling_circuit_breaker",
+			attempts: []store.WorkAttempt{withScope(store.WorkAttempt{
+				ErrorMessage: "session token ceiling exceeded",
+				CompletedAt:  parkedAt,
+			}, otherScope)},
+			wantSuppression: "different backend capacity scope",
+		},
+		{
+			name:   "token ceiling evidence from another provider stays parked",
+			reason: "token_ceiling_circuit_breaker",
+			attempts: []store.WorkAttempt{withScope(store.WorkAttempt{
+				ErrorMessage: "session token ceiling exceeded",
+				CompletedAt:  parkedAt,
+			}, otherProviderScope)},
+			wantSuppression: "different backend capacity scope",
+		},
+		{
+			name:   "token ceiling evidence without runtime identity stays parked",
+			reason: "token_ceiling_circuit_breaker",
+			attempts: []store.WorkAttempt{{
+				ErrorMessage: "session token ceiling exceeded",
+				CompletedAt:  parkedAt,
+			}},
+			wantSuppression: "different backend capacity scope",
 		},
 		{
 			name:   "non token ceiling evidence stays parked",
 			reason: "token_ceiling_circuit_breaker",
-			attempts: []store.WorkAttempt{{
+			attempts: []store.WorkAttempt{withScope(store.WorkAttempt{
 				ErrorMessage: "ordinary runner failure",
 				CompletedAt:  parkedAt,
-			}},
+			}, scope)},
 			wantSuppression: "not a token-ceiling",
 		},
 		{
@@ -1409,6 +1444,26 @@ func TestRecoverBackendCapacityOutageEraBreakerParks(t *testing.T) {
 				artifactAttempt(detectedAt.Add(-time.Minute), 1, false),
 			},
 			wantSuppression: "falls outside",
+		},
+		{
+			name:   "artifact convergence from another backend stays parked",
+			reason: artifactGateConvergenceReason,
+			attempts: []store.WorkAttempt{
+				withScope(artifactAttempt(parkedAt, 3, true), otherScope),
+				artifactAttempt(parkedAt.Add(-time.Minute), 2, false),
+				artifactAttempt(parkedAt.Add(-2*time.Minute), 1, false),
+			},
+			wantSuppression: "different backend capacity scope",
+		},
+		{
+			name:   "artifact convergence with older evidence from another backend stays parked",
+			reason: artifactGateConvergenceReason,
+			attempts: []store.WorkAttempt{
+				artifactAttempt(parkedAt, 3, true),
+				withScope(artifactAttempt(parkedAt.Add(-time.Minute), 2, false), otherScope),
+				artifactAttempt(parkedAt.Add(-2*time.Minute), 1, false),
+			},
+			wantSuppression: "different backend capacity scope",
 		},
 		{
 			name:            "artifact convergence without history stays parked",

--- a/internal/orchestrator/run_completion.go
+++ b/internal/orchestrator/run_completion.go
@@ -254,13 +254,6 @@ func (o *Orchestrator) handleRunResult(ctx context.Context, state *State, event 
 	if o.handleMergeFallbackBudgetExceeded(ctx, state, event, running) {
 		return
 	}
-	if o.handleSessionBrake(ctx, state, event, running) {
-		return
-	}
-	if o.handleGitHubRESTCapacityCompletion(ctx, state, event, running) {
-		o.recordProjectAttemptOutcome(state, event.IssueID, event.CompletedAt, store.WorkAttemptTerminalCapacity, event.Err, githubRESTCapacityError, errorString(event.Err))
-		return
-	}
 	if capacityErr, ok := backendcapacity.As(event.Err); ok {
 		if capacityErr.Details.Type == backendcapacity.ErrorTypeTransientOverload {
 			o.handleTransientOverload(ctx, state, event, running, capacityErr)
@@ -268,6 +261,13 @@ func (o *Orchestrator) handleRunResult(ctx context.Context, state *State, event 
 		}
 		o.recordProjectAttemptOutcome(state, event.IssueID, event.CompletedAt, store.WorkAttemptTerminalCapacity, event.Err, "backend_capacity", errorString(event.Err))
 		o.handleBackendCapacityError(ctx, state, event, running, capacityErr)
+		return
+	}
+	if o.handleSessionBrake(ctx, state, event, running) {
+		return
+	}
+	if o.handleGitHubRESTCapacityCompletion(ctx, state, event, running) {
+		o.recordProjectAttemptOutcome(state, event.IssueID, event.CompletedAt, store.WorkAttemptTerminalCapacity, event.Err, githubRESTCapacityError, errorString(event.Err))
 		return
 	}
 	if event.Err == nil || event.Result.TurnStarted {

--- a/internal/runner/agent.go
+++ b/internal/runner/agent.go
@@ -1582,9 +1582,7 @@ func (r *Runner) Run(ctx context.Context, req RunRequest) (RunResult, error) {
 	execution := r.runAgentTurn(sessionCtx, backend, turnRequest, req, info, workspaceIssue, workflow.Config.Agent, workflow.Config.Gate.CITriggerLabel, runStartedAt, sessionID, runtimeIdentity)
 	execution.err = sessionBrake.wrapTurnLimit(ctx, execution.err)
 	execution.err = sessionBrake.wrapDuration(ctx, execution.err, durationFromMillis(workflow.Config.Agent.MaxSessionDurationMS))
-	if execution.err != nil {
-		execution.err = classifyAgentCapacityError(backend, selection, backendConfig, execution.result.RuntimeIdentity, execution.err, execution.result.RateLimits, runStartedAt)
-	}
+	execution.err = classifyAgentCapacityError(backend, selection, backendConfig, execution.result.RuntimeIdentity, execution.err, execution.result.RateLimits, runStartedAt)
 	if execution.err != nil && !IsCapacityError(execution.err) && !durationLimitError(execution.err) && !errors.Is(execution.err, ErrWorkerProcessReap) && !agentResumeEmpty(turnRequest.Resume) && !execution.turnStarted {
 		r.logWorkerEvent(req.Issue, "worker_resume_failed_fallback",
 			telemetry.WorkAttemptIDKey, req.WorkAttemptID,
@@ -1610,9 +1608,7 @@ func (r *Runner) Run(ctx context.Context, req RunRequest) (RunResult, error) {
 		execution = r.runAgentTurn(sessionCtx, backend, turnRequest, req, info, workspaceIssue, workflow.Config.Agent, workflow.Config.Gate.CITriggerLabel, runStartedAt, sessionID, runtimeIdentity)
 		execution.err = sessionBrake.wrapTurnLimit(ctx, execution.err)
 		execution.err = sessionBrake.wrapDuration(ctx, execution.err, durationFromMillis(workflow.Config.Agent.MaxSessionDurationMS))
-		if execution.err != nil {
-			execution.err = classifyAgentCapacityError(backend, selection, backendConfig, execution.result.RuntimeIdentity, execution.err, execution.result.RateLimits, runStartedAt)
-		}
+		execution.err = classifyAgentCapacityError(backend, selection, backendConfig, execution.result.RuntimeIdentity, execution.err, execution.result.RateLimits, runStartedAt)
 	}
 	if req.ForgeRetry != nil && strings.Contains(strings.ToLower(req.ForgeRetry.Operation), "git fetch") {
 		execution.result.ForgeWriteCompleted = true
@@ -1644,9 +1640,7 @@ func (r *Runner) Run(ctx context.Context, req RunRequest) (RunResult, error) {
 		recovery := r.runAgentTurn(sessionCtx, backend, recoveryRequest, recoveryRunRequest, info, workspaceIssue, workflow.Config.Agent, workflow.Config.Gate.CITriggerLabel, runStartedAt, sessionID, execution.result.RuntimeIdentity)
 		recovery.err = sessionBrake.wrapTurnLimit(ctx, recovery.err)
 		recovery.err = sessionBrake.wrapDuration(ctx, recovery.err, durationFromMillis(workflow.Config.Agent.MaxSessionDurationMS))
-		if recovery.err != nil {
-			recovery.err = classifyAgentCapacityError(backend, selection, backendConfig, recovery.result.RuntimeIdentity, recovery.err, recovery.result.RateLimits, runStartedAt)
-		}
+		recovery.err = classifyAgentCapacityError(backend, selection, backendConfig, recovery.result.RuntimeIdentity, recovery.err, recovery.result.RateLimits, runStartedAt)
 		initialErr := execution.err
 		execution = mergeAgentTurnExecutions(execution, recovery)
 		turns = int64(max(execution.turnCount, 1))
@@ -2344,9 +2338,7 @@ func (r *Runner) Validate(ctx context.Context, req ValidatorRequest) (gate.Valid
 		runResult.DiffStats = brakeDiff
 	}
 	turnErr = errors.Join(turnErr, scratchCleanupErr)
-	if turnErr != nil {
-		turnErr = classifyAgentCapacityError(backend, selection, backendConfig, runResult.RuntimeIdentity, turnErr, runResult.RateLimits, runStartedAt)
-	}
+	turnErr = classifyAgentCapacityError(backend, selection, backendConfig, runResult.RuntimeIdentity, turnErr, runResult.RateLimits, runStartedAt)
 	checkFinishedAttrs := []any{
 		"workspace_path", info.Path,
 		"detent_session_id", sessionID,

--- a/internal/runner/capacity.go
+++ b/internal/runner/capacity.go
@@ -21,7 +21,9 @@ type AgentCapacityStatusProvider interface {
 
 type CapacityStatus struct {
 	Available bool
+	Exhausted bool
 	Detail    string
+	Details   backendcapacity.Details
 }
 
 type CapacityController interface {
@@ -107,22 +109,55 @@ func classifyAgentCapacityError(
 	rateLimits *telemetry.RateLimits,
 	now time.Time,
 ) error {
-	if err == nil {
-		return nil
-	}
-	classifier, ok := backend.(AgentCapacityClassifier)
-	if !ok {
+	var capacityErr *backendcapacity.Error
+	if errors.As(err, &capacityErr) {
 		return err
+	}
+	if err != nil {
+		if classifier, ok := backend.(AgentCapacityClassifier); ok {
+			scope := configuredCapacityScope(selection, backendConfig, identity)
+			if scope.Hosted() {
+				if details, classified := classifier.ClassifyCapacityError(err, rateLimits, now); classified {
+					return backendcapacity.NewError(scope, details, err)
+				}
+			}
+		}
 	}
 	scope := configuredCapacityScope(selection, backendConfig, identity)
 	if !scope.Hosted() {
 		return err
 	}
-	details, ok := classifier.ClassifyCapacityError(err, rateLimits, now)
+	provider, ok := backend.(AgentCapacityStatusProvider)
 	if !ok {
 		return err
 	}
+	status, reported := provider.CapacityStatus(rateLimits)
+	if !reported || !status.Exhausted {
+		return err
+	}
+	details := status.Details
+	if details.Type == "" {
+		details.Type = backendcapacity.ErrorTypeUsageLimit
+	}
+	if strings.TrimSpace(details.Kind) == "" {
+		details.Kind = "subscription_window_exhausted"
+	}
+	if strings.TrimSpace(details.Reason) == "" {
+		details.Reason = "subscription window exhausted"
+	}
+	if err == nil {
+		err = errors.New(firstNonBlankCapacityDetail(status.Detail, details.Reason))
+	}
 	return backendcapacity.NewError(scope, details, err)
+}
+
+func firstNonBlankCapacityDetail(values ...string) string {
+	for _, value := range values {
+		if value = strings.TrimSpace(value); value != "" {
+			return value
+		}
+	}
+	return "subscription window exhausted"
 }
 
 func configuredCapacityScope(selection RouteSelection, backend config.AgentBackend, identity agentidentity.Identity) backendcapacity.Scope {

--- a/internal/runner/capacity_test.go
+++ b/internal/runner/capacity_test.go
@@ -44,6 +44,81 @@ func TestClassifyAgentCapacityErrorSkipsLocalProviders(t *testing.T) {
 	}
 }
 
+func TestClassifyAgentCapacityErrorUsesExhaustedProviderStatus(t *testing.T) {
+	t.Parallel()
+
+	resetAt := time.Date(2026, 8, 20, 15, 27, 0, 0, time.UTC)
+	tests := []struct {
+		name       string
+		runErr     error
+		status     CapacityStatus
+		wantErr    bool
+		wantReason string
+	}{
+		{
+			name: "clean completion with exhausted subscription window",
+			status: CapacityStatus{
+				Exhausted: true,
+				Detail:    "live provider status reports an exhausted subscription window",
+				Details: backendcapacity.Details{
+					Type:    backendcapacity.ErrorTypeUsageLimit,
+					Kind:    "subscription_window_exhausted",
+					Reason:  "subscription window exhausted",
+					ResetAt: &resetAt,
+				},
+			},
+			wantErr:    true,
+			wantReason: "subscription window exhausted",
+		},
+		{
+			name:   "missing result with exhausted subscription window",
+			runErr: errors.New("agent result event missing"),
+			status: CapacityStatus{
+				Exhausted: true,
+				Details: backendcapacity.Details{
+					ResetAt: &resetAt,
+				},
+			},
+			wantErr:    true,
+			wantReason: "subscription window exhausted",
+		},
+		{
+			name:   "ordinary failure without exact exhaustion",
+			runErr: errors.New("agent result event missing"),
+			status: CapacityStatus{Detail: "live provider status reports 4% capacity remaining"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := classifyAgentCapacityError(
+				capacityStatusBackend{status: tt.status},
+				RouteSelection{BackendID: "codex"},
+				config.AgentBackend{ID: "codex", Kind: config.AgentBackendCodex, Provider: "openai"},
+				agentidentity.Identity{},
+				tt.runErr,
+				&telemetry.RateLimits{},
+				time.Now(),
+			)
+			capacityErr, ok := backendcapacity.As(got)
+			if ok != tt.wantErr {
+				t.Fatalf("backendcapacity.As() ok = %v, want %v; error = %v", ok, tt.wantErr, got)
+			}
+			if !tt.wantErr {
+				if !errors.Is(got, tt.runErr) {
+					t.Fatalf("error = %v, want original %v", got, tt.runErr)
+				}
+				return
+			}
+			if capacityErr.Details.Reason != tt.wantReason || capacityErr.Details.ResetAt == nil || !capacityErr.Details.ResetAt.Equal(resetAt) {
+				t.Fatalf("capacity error = %#v, want reason %q reset %s", capacityErr, tt.wantReason, resetAt)
+			}
+		})
+	}
+}
+
 type capacityClassifierBackend struct{}
 
 func (capacityClassifierBackend) RunTurn(context.Context, AgentTurnRequest, AgentUpdateHandler) (AgentTurnResult, error) {
@@ -52,4 +127,16 @@ func (capacityClassifierBackend) RunTurn(context.Context, AgentTurnRequest, Agen
 
 func (capacityClassifierBackend) ClassifyCapacityError(error, *telemetry.RateLimits, time.Time) (backendcapacity.Details, bool) {
 	return backendcapacity.Details{Kind: "usageLimitExceeded", Reason: "provider usage limit reached"}, true
+}
+
+type capacityStatusBackend struct {
+	status CapacityStatus
+}
+
+func (capacityStatusBackend) RunTurn(context.Context, AgentTurnRequest, AgentUpdateHandler) (AgentTurnResult, error) {
+	return AgentTurnResult{}, nil
+}
+
+func (b capacityStatusBackend) CapacityStatus(*telemetry.RateLimits) (CapacityStatus, bool) {
+	return b.status, true
 }

--- a/internal/web/templates/dashboard_data.go
+++ b/internal/web/templates/dashboard_data.go
@@ -7104,6 +7104,9 @@ func backendCapacityOutageTitle(outage telemetry.BackendOutage) string {
 	if strings.TrimSpace(outage.Kind) == "github_rest_rate_limit" {
 		return "GitHub REST dispatch paused"
 	}
+	if strings.EqualFold(strings.TrimSpace(outage.Reason), "subscription window exhausted") {
+		return "Backend " + backendCapacityBackendID(outage) + ": subscription window exhausted"
+	}
 	return "Backend " + backendCapacityBackendID(outage) + " at usage limit"
 }
 
@@ -7507,6 +7510,9 @@ func backendCapacityOutageDetailParts(outage telemetry.BackendOutage, now time.T
 	}
 	provider := strings.TrimSpace(outage.Provider)
 	detail := "Dispatch is paused"
+	if reason := strings.TrimSpace(outage.Reason); reason != "" && !strings.EqualFold(reason, "provider usage limit reached") {
+		detail = reason + ". " + detail
+	}
 	if provider != "" {
 		detail += " for " + provider
 	}

--- a/internal/web/templates/health_data.go
+++ b/internal/web/templates/health_data.go
@@ -838,11 +838,15 @@ func healthReleaseRow(release telemetry.Release) healthRow {
 
 func healthBackendOutageRow(outage telemetry.BackendOutage, now time.Time) healthRow {
 	detail, resumeAt, _ := backendCapacityOutageDetailParts(outage, now)
+	status := "Usage limit"
+	if strings.EqualFold(strings.TrimSpace(outage.Reason), "subscription window exhausted") {
+		status = "Subscription exhausted"
+	}
 	return healthRow{
 		ID:        "health-backend-" + boardCardSlug(outage.BackendID),
 		Component: "Backend " + outage.BackendID,
 		Kind:      primitives.KindWarn,
-		Status:    "Usage limit",
+		Status:    status,
 		Detail:    detail,
 		DetailAt:  resumeAt,
 		Resets:    "—",

--- a/internal/web/templates/health_data_test.go
+++ b/internal/web/templates/health_data_test.go
@@ -106,6 +106,20 @@ func TestHealthViewVerdicts(t *testing.T) {
 			wantVerdict: "Backend codex at usage limit.",
 		},
 		{
+			name: "subscription outage names condition",
+			snapshot: telemetry.Snapshot{
+				GeneratedAt: now,
+				BackendOutages: []telemetry.BackendOutage{{
+					BackendID: "codex",
+					Provider:  "openai",
+					Reason:    "subscription window exhausted",
+					ResumeAt:  now.Add(44 * time.Minute),
+				}},
+			},
+			wantKind:    primitives.KindWarn,
+			wantVerdict: "Backend codex: subscription window exhausted.",
+		},
+		{
 			name: "failure breaker warns",
 			snapshot: telemetry.Snapshot{
 				GeneratedAt: now,
@@ -401,6 +415,25 @@ func TestHealthRowsIncludeBackendCapacityOutage(t *testing.T) {
 	})
 	row := rows[len(rows)-1]
 	if row.Component != "Backend codex" || row.Status != "Usage limit" || !row.ResetAt.Equal(now.Add(44*time.Minute)) {
+		t.Fatalf("backend outage row = %+v", row)
+	}
+}
+
+func TestHealthRowsNameSubscriptionExhaustion(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 8, 19, 22, 0, 0, 0, time.UTC)
+	rows := healthRows(telemetry.Snapshot{
+		GeneratedAt: now,
+		BackendOutages: []telemetry.BackendOutage{{
+			BackendID: "codex",
+			Provider:  "openai",
+			Reason:    "subscription window exhausted",
+			ResumeAt:  now.Add(44 * time.Minute),
+		}},
+	})
+	row := rows[len(rows)-1]
+	if row.Status != "Subscription exhausted" || !strings.Contains(row.Detail, "subscription window exhausted") {
 		t.Fatalf("backend outage row = %+v", row)
 	}
 }


### PR DESCRIPTION
## Summary

- Detect Codex and Claude subscription exhaustion from provider errors and live status, pause backend dispatch, and terminal-state slipped attempts as capacity before other brakes.
- Resume through the existing canary machinery and re-evaluate only breaker parks whose durable evidence falls wholly within the outage window.
- Name subscription exhaustion plus resume and probe timing in Board and Health surfaces.

Fixes #1935

## UI Surface Contract

- [x] N/A, or the linked issue explicitly authorizes any high-impact UI surface, layout, density, first-viewport, or responsive visibility tradeoff.
- [x] Persistent top-of-screen messaging is explicitly authorized by the issue, or this PR does not add it.
- [x] Visual changes to primary operator screens include screenshot or browser verification below.
  - Browser-verified the expandable Board alert and Health detail/status rows with an isolated seeded snapshot on an ephemeral `httptest` server; the live Detent process was untouched.

## Test Plan

- [x] `make check`
- [x] Focused provider, runner, orchestrator, and template tests.
- [x] `backend_capacity.go` exact-file coverage: 90.787% (473/521).
- [x] `go test ./internal/orchestrator -run '^.
- [x] Isolated Chrome DevTools verification of terse and expanded Board copy plus Health reset/probe messaging.
 -fuzz=FuzzSafetyCriticalOrchestratorBoundaries -fuzztime=30s` (1,322,908 executions).
- [x] Isolated Chrome DevTools verification of terse and expanded Board copy plus Health reset/probe messaging.