### PR TITLE
fix(workspace): preserve invalid worktree state

### DIFF
--- a/.detent/skills/git-command-postcondition-fault-injection.md
+++ b/.detent/skills/git-command-postcondition-fault-injection.md
@@ -1,0 +1,14 @@
+---
+name: git-command-postcondition-fault-injection
+description: Reproduce Git command failures and impossible-looking successful postconditions without replacing ordinary Git behavior.
+when_to_use: Use when a Git subprocess intermittently leaves partial state or reports success while a required repository or worktree invariant is false.
+---
+
+# Inject Git postcondition faults
+
+- Resolve the absolute real `git` executable before changing `PATH`, then place a same-named wrapper first on `PATH` for one isolated test. Delegate every command except the exact argument sequence under test to the real executable.
+- For a partial-failure case, create only the filesystem evidence Git could leave behind, emit a distinctive stderr marker, and exit nonzero. Assert that the caller preserves the original error and handles the surviving state safely.
+- For a false-success case, run the real command first and require its zero exit status, then mutate only the resulting fixture into the recorded bad postcondition before returning zero. This tests the caller's invariant instead of inventing a narrative root cause.
+- Keep source, target, wrapper, markers, and logs under test-owned or Detent-provided temporary directories. Quote every embedded path and restore `PATH` through the test framework's scoped environment support.
+- Assert temporal behavior as well as the final error: downstream hooks must not run, diagnostics must report observed and expected state, forensic files must survive, and pre-existing foreign repositories must remain untouched.
+- Run the regression repeatedly and with the race detector, then remove any production fix that depends on the wrapper itself. The wrapper is fault injection, not a command abstraction to ship.

--- a/internal/workspace/workspace.go
+++ b/internal/workspace/workspace.go
@@ -40,6 +40,7 @@ var (
 	ErrMissingWorkspace   = errors.New("workspace missing")
 	ErrUnsafePath         = errors.New("unsafe workspace path")
 	ErrUnsupportedBackend = errors.New("unsupported workspace backend")
+	ErrWorktreeInvariant  = errors.New("workspace worktree invariant failed")
 )
 
 var unsafeKeyPattern = regexp.MustCompile(`[^A-Za-z0-9._-]`)
@@ -242,6 +243,18 @@ type workspaceRemovalError struct {
 	err         error
 }
 
+type worktreeCreationError struct {
+	err error
+}
+
+func (e *worktreeCreationError) Error() string {
+	return e.err.Error()
+}
+
+func (e *worktreeCreationError) Unwrap() error {
+	return e.err
+}
+
 func (e *workspaceRemovalError) Error() string {
 	return fmt.Sprintf("remove workspace path %q: %v; remediation: %s", e.path, e.err, e.remediation)
 }
@@ -404,19 +417,26 @@ func (l *LocalGit) Create(ctx context.Context, issue Issue) (Info, error) {
 
 	created, err := l.createWorktree(ctx, info.Path, info.Branch)
 	if err != nil {
+		var creationErr *worktreeCreationError
+		if errors.As(err, &creationErr) {
+			err = l.preserveFailedWorkspace(ctx, info.Path, err)
+		}
 		return Info{}, err
 	}
 	info.Created = created
 	if err := ensureGitInfoExcludes(ctx, info.Path, detentHandoffDiffExcludes); err != nil {
+		if created {
+			err = l.preserveFailedWorkspace(ctx, info.Path, err)
+		}
 		return Info{}, err
 	}
 
 	if created {
+		if err := l.validateCreatedWorktree(ctx, info.Path); err != nil {
+			return Info{}, l.preserveFailedWorkspace(ctx, info.Path, err)
+		}
 		if err := l.runHook(ctx, "after_create", l.hooks.AfterCreate, info, issue); err != nil {
-			if cleanupErr := l.removePath(ctx, info.Path); cleanupErr != nil {
-				l.logger.Warn("failed to clean workspace after after_create hook error", slog.String("path", info.Path), slog.Any("error", cleanupErr))
-			}
-			return Info{}, err
+			return Info{}, l.preserveFailedWorkspace(ctx, info.Path, err)
 		}
 	}
 
@@ -618,7 +638,7 @@ func (l *LocalGit) ensureWorktree(ctx context.Context, path string, branch strin
 
 	if l.autoBranch {
 		if err := l.addBranchedWorktree(ctx, path, branch); err != nil {
-			return false, err
+			return false, &worktreeCreationError{err: err}
 		}
 		return true, nil
 	}
@@ -627,7 +647,62 @@ func (l *LocalGit) ensureWorktree(ctx context.Context, path string, branch strin
 		_, addErr := l.runGit(ctx, "worktree", "add", "--detach", path, "HEAD")
 		return addErr
 	})
-	return err == nil, err
+	if err != nil {
+		return false, &worktreeCreationError{err: err}
+	}
+	return true, nil
+}
+
+func (l *LocalGit) validateCreatedWorktree(ctx context.Context, path string) error {
+	sourceCommon, sourceErr := gitCommonDir(ctx, l.sourceRoot)
+	workspaceCommon, workspaceErr := gitCommonDirWithinRoot(ctx, path)
+	registered, registrationErr := l.sourceWorktreeRegistered(ctx, path)
+	if sourceErr == nil && workspaceErr == nil && registrationErr == nil && workspaceCommon == sourceCommon && registered {
+		return nil
+	}
+
+	sourceObservation := fmt.Sprintf("%q", sourceCommon)
+	if sourceErr != nil {
+		sourceObservation = fmt.Sprintf("unavailable (%v)", sourceErr)
+	}
+	workspaceObservation := fmt.Sprintf("%q", workspaceCommon)
+	if workspaceErr != nil {
+		workspaceObservation = fmt.Sprintf("unavailable (%v)", workspaceErr)
+	}
+	registrationObservation := strconv.FormatBool(registered)
+	if registrationErr != nil {
+		registrationObservation = fmt.Sprintf("unavailable (%v)", registrationErr)
+	}
+	return fmt.Errorf(
+		"%w: path %q; workspace common dir: %s; source common dir: %s; registered with source: %s",
+		ErrWorktreeInvariant,
+		path,
+		workspaceObservation,
+		sourceObservation,
+		registrationObservation,
+	)
+}
+
+func (l *LocalGit) sourceWorktreeRegistered(ctx context.Context, path string) (bool, error) {
+	output, err := l.runGit(ctx, "worktree", "list", "--porcelain", "-z")
+	if err != nil {
+		return false, withCommandOutput(err)
+	}
+	want, err := canonicalExistingPath(path)
+	if err != nil {
+		return false, fmt.Errorf("resolve workspace registration path: %w", err)
+	}
+	for _, field := range strings.Split(output, "\x00") {
+		listed, ok := strings.CutPrefix(field, "worktree ")
+		if !ok {
+			continue
+		}
+		listed, err = canonicalExistingPath(listed)
+		if err == nil && listed == want {
+			return true, nil
+		}
+	}
+	return false, nil
 }
 
 func (l *LocalGit) addBranchedWorktree(ctx context.Context, path string, branch string) error {
@@ -861,6 +936,87 @@ func (l *LocalGit) quarantineWorktree(ctx context.Context, path string) (string,
 		return "", fmt.Errorf("release quarantined worktree admin name: %w", err)
 	}
 	return quarantinePath, nil
+}
+
+func (l *LocalGit) preserveFailedWorkspace(ctx context.Context, path string, cause error) error {
+	quarantinePath, preserved, err := l.quarantineFailedWorkspace(ctx, path)
+	if err != nil {
+		l.logger.Warn(
+			"failed to quarantine workspace failure state",
+			slog.String("path", path),
+			slog.Any("cause", cause),
+			slog.Any("error", err),
+		)
+		return errors.Join(cause, fmt.Errorf("quarantine failed workspace %q: %w", path, err))
+	}
+	if !preserved {
+		return cause
+	}
+
+	quarantineCount, countErr := l.quarantineWorkspaceCount(path)
+	if countErr != nil {
+		l.logger.Warn(
+			"workspace quarantine count failed",
+			slog.String("path", path),
+			slog.String("quarantine_path", quarantinePath),
+			slog.Any("error", countErr),
+		)
+	}
+	l.logger.Warn(
+		"quarantined failed workspace",
+		slog.String("path", path),
+		slog.String("quarantine_path", quarantinePath),
+		slog.Int("quarantine_count", quarantineCount),
+		slog.Any("cause", cause),
+	)
+	if quarantineCount > quarantineAccumulationWarningThreshold {
+		l.logger.Error(
+			"workspace quarantine accumulation exceeded threshold",
+			slog.String("path", path),
+			slog.String("quarantine_path", quarantinePath),
+			slog.Int("quarantine_count", quarantineCount),
+			slog.Int("threshold", quarantineAccumulationWarningThreshold),
+		)
+	}
+	return fmt.Errorf("%w; workspace quarantined at %q", cause, quarantinePath)
+}
+
+func (l *LocalGit) quarantineFailedWorkspace(ctx context.Context, path string) (string, bool, error) {
+	exists, isDir, err := pathExists(path)
+	if err != nil || !exists {
+		return "", false, err
+	}
+	if isDir && l.isSourceWorktree(ctx, path) {
+		quarantinePath, err := l.quarantineWorktree(ctx, path)
+		if err != nil {
+			return "", false, err
+		}
+		if _, err := runGitAt(ctx, quarantinePath, "checkout", "--detach", "HEAD"); err != nil {
+			l.logger.Warn(
+				"failed to detach quarantined workspace",
+				slog.String("path", path),
+				slog.String("quarantine_path", quarantinePath),
+				slog.Any("error", withCommandOutput(err)),
+			)
+		}
+		return quarantinePath, true, nil
+	}
+
+	path, err = validateWorkspacePath(l.root, path)
+	if err != nil {
+		return "", false, err
+	}
+	quarantinePath, err := l.nextQuarantinePath(path)
+	if err != nil {
+		return "", false, err
+	}
+	if err := os.MkdirAll(filepath.Dir(quarantinePath), 0o700); err != nil {
+		return "", false, fmt.Errorf("create quarantine parent: %w", err)
+	}
+	if err := os.Rename(path, quarantinePath); err != nil {
+		return "", false, fmt.Errorf("move failed workspace to quarantine: %w", err)
+	}
+	return quarantinePath, true, nil
 }
 
 func (l *LocalGit) removeDanglingSourceWorktree(ctx context.Context, path string) (bool, error) {

--- a/internal/workspace/workspace.go
+++ b/internal/workspace/workspace.go
@@ -29,6 +29,7 @@ const (
 )
 
 const defaultHookTimeout = time.Minute
+const failedWorkspacePreservationTimeout = time.Minute
 const workspaceCommandWaitDelay = time.Second
 const hookOutputTailBytes = 16 * 1024
 const workerScratchRelativePath = ".detent/tmp"
@@ -939,14 +940,22 @@ func (l *LocalGit) quarantineWorktree(ctx context.Context, path string) (string,
 }
 
 func (l *LocalGit) preserveFailedWorkspace(ctx context.Context, path string, cause error) error {
-	quarantinePath, preserved, err := l.quarantineFailedWorkspace(ctx, path)
+	preservationCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), failedWorkspacePreservationTimeout)
+	defer cancel()
+
+	quarantinePath, preserved, err := l.quarantineFailedWorkspace(preservationCtx, path)
 	if err != nil {
 		l.logger.Warn(
 			"failed to quarantine workspace failure state",
 			slog.String("path", path),
+			slog.String("quarantine_path", quarantinePath),
+			slog.Bool("preserved", preserved),
 			slog.Any("cause", cause),
 			slog.Any("error", err),
 		)
+		if preserved {
+			return errors.Join(cause, fmt.Errorf("workspace quarantined at %q but failed to release its branch: %w", quarantinePath, err))
+		}
 		return errors.Join(cause, fmt.Errorf("quarantine failed workspace %q: %w", path, err))
 	}
 	if !preserved {
@@ -986,18 +995,20 @@ func (l *LocalGit) quarantineFailedWorkspace(ctx context.Context, path string) (
 	if err != nil || !exists {
 		return "", false, err
 	}
-	if isDir && l.isSourceWorktree(ctx, path) {
+	linkedWorktree := false
+	if isDir {
+		_, linkedWorktree, err = readLinkedWorktreeGitDir(path)
+		if err != nil {
+			return "", false, fmt.Errorf("inspect failed workspace linkage: %w", err)
+		}
+	}
+	if isDir && linkedWorktree {
 		quarantinePath, err := l.quarantineWorktree(ctx, path)
 		if err != nil {
 			return "", false, err
 		}
-		if _, err := runGitAt(ctx, quarantinePath, "checkout", "--detach", "HEAD"); err != nil {
-			l.logger.Warn(
-				"failed to detach quarantined workspace",
-				slog.String("path", path),
-				slog.String("quarantine_path", quarantinePath),
-				slog.Any("error", withCommandOutput(err)),
-			)
+		if err := detachWorktreeHead(ctx, quarantinePath); err != nil {
+			return quarantinePath, true, err
 		}
 		return quarantinePath, true, nil
 	}
@@ -1017,6 +1028,21 @@ func (l *LocalGit) quarantineFailedWorkspace(ctx context.Context, path string) (
 		return "", false, fmt.Errorf("move failed workspace to quarantine: %w", err)
 	}
 	return quarantinePath, true, nil
+}
+
+func detachWorktreeHead(ctx context.Context, path string) error {
+	output, err := runGitAt(ctx, path, "rev-parse", "--verify", "HEAD")
+	if err != nil {
+		return fmt.Errorf("resolve quarantined worktree HEAD: %w", withCommandOutput(err))
+	}
+	head := strings.TrimSpace(output)
+	if head == "" {
+		return errors.New("resolve quarantined worktree HEAD: empty revision")
+	}
+	if _, err := runGitAt(ctx, path, "update-ref", "--no-deref", "HEAD", head); err != nil {
+		return fmt.Errorf("detach quarantined worktree HEAD: %w", withCommandOutput(err))
+	}
+	return nil
 }
 
 func (l *LocalGit) removeDanglingSourceWorktree(ctx context.Context, path string) (bool, error) {

--- a/internal/workspace/workspace_test.go
+++ b/internal/workspace/workspace_test.go
@@ -1727,6 +1727,124 @@ func TestLocalGitHookFailureSurfaces(t *testing.T) {
 	if _, statErr := os.Stat(filepath.Join(root, "DD-FAIL")); !errors.Is(statErr, os.ErrNotExist) {
 		t.Fatalf("failed after_create workspace exists, stat error = %v", statErr)
 	}
+	quarantinedPath := singleQuarantinedWorkspace(t, root)
+	if got := readFile(t, filepath.Join(quarantinedPath, "README.md")); got != "source repo\n" {
+		t.Fatalf("quarantined README.md = %q, want source repo", got)
+	}
+	if got := strings.TrimSpace(runGit(t, quarantinedPath, "branch", "--show-current")); got != "" {
+		t.Fatalf("quarantined worktree branch = %q, want detached HEAD", got)
+	}
+	if got := runGit(t, source, "worktree", "list", "--porcelain"); !strings.Contains(got, quarantinedPath) {
+		t.Fatalf("git worktree list does not contain quarantined path:\n%s", got)
+	}
+
+	retryBackend, retryErr := NewLocalGit(LocalGitOptions{Root: root, SourceRoot: source, AutoBranch: true})
+	if retryErr != nil {
+		t.Fatalf("NewLocalGit() retry error = %v", retryErr)
+	}
+	retried, retryErr := retryBackend.Create(context.Background(), Issue{Identifier: "DD-FAIL"})
+	if retryErr != nil {
+		t.Fatalf("retry Create() error = %v", retryErr)
+	}
+	if !retried.Created {
+		t.Fatal("retry Create() Created = false, want true")
+	}
+}
+
+func TestLocalGitCreateQuarantinesFailedCreationState(t *testing.T) {
+	skipWindows(t)
+
+	tests := []struct {
+		name           string
+		mode           string
+		identifier     string
+		wantError      []string
+		wantStandalone bool
+	}{
+		{
+			name:       "partial worktree add failure",
+			mode:       "partial_failure",
+			identifier: "DD-PARTIAL-CREATE",
+			wantError: []string{
+				"synthetic worktree add failure",
+				"workspace quarantined at",
+			},
+		},
+		{
+			name:       "successful add yields standalone repository",
+			mode:       "standalone_after_add",
+			identifier: "DD-STANDALONE",
+			wantError: []string{
+				"workspace worktree invariant failed",
+				"registered with source: false",
+				"workspace quarantined at",
+			},
+			wantStandalone: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			source := initSourceRepo(t)
+			root := filepath.Join(t.TempDir(), "workspaces")
+			target := filepath.Join(root, tt.identifier)
+			tracePath := filepath.Join(t.TempDir(), "after-create.trace")
+			installGitCreationWrapper(t, tt.mode, source, target)
+
+			backend, err := NewLocalGit(LocalGitOptions{
+				Root:       root,
+				SourceRoot: source,
+				AutoBranch: true,
+				Hooks: Hooks{
+					AfterCreate: "printf 'ran\\n' > " + shellQuote(tracePath),
+					Timeout:     time.Second,
+				},
+			})
+			if err != nil {
+				t.Fatalf("NewLocalGit() error = %v", err)
+			}
+
+			_, err = backend.Create(context.Background(), Issue{Identifier: tt.identifier})
+			if err == nil {
+				t.Fatal("Create() error = nil, want creation failure")
+			}
+			if tt.wantStandalone && !errors.Is(err, ErrWorktreeInvariant) {
+				t.Errorf("Create() error = %v, want ErrWorktreeInvariant", err)
+			}
+			for _, want := range tt.wantError {
+				if !strings.Contains(err.Error(), want) {
+					t.Errorf("Create() error = %q, want %q", err, want)
+				}
+			}
+			if tt.wantStandalone {
+				for _, want := range []string{filepath.Join(target, ".git"), filepath.Join(source, ".git")} {
+					if !strings.Contains(err.Error(), want) {
+						t.Errorf("Create() error = %q, want common dir %q", err, want)
+					}
+				}
+			}
+			if _, statErr := os.Stat(tracePath); !errors.Is(statErr, os.ErrNotExist) {
+				t.Fatalf("after_create hook ran, stat error = %v", statErr)
+			}
+			if _, statErr := os.Stat(target); !errors.Is(statErr, os.ErrNotExist) {
+				t.Fatalf("failed workspace remains at original path, stat error = %v", statErr)
+			}
+
+			quarantinedPath := singleQuarantinedWorkspace(t, root)
+			if got := readFile(t, filepath.Join(quarantinedPath, "forensics.txt")); got != tt.mode+"\n" {
+				t.Fatalf("quarantined forensics.txt = %q, want %q", got, tt.mode)
+			}
+			gitInfo, statErr := os.Stat(filepath.Join(quarantinedPath, ".git"))
+			switch {
+			case tt.wantStandalone && statErr != nil:
+				t.Fatalf("stat quarantined .git: %v", statErr)
+			case tt.wantStandalone && !gitInfo.IsDir():
+				t.Fatalf("quarantined .git mode = %v, want directory", gitInfo.Mode())
+			case !tt.wantStandalone && !errors.Is(statErr, os.ErrNotExist):
+				t.Fatalf("partial quarantine .git stat error = %v, want absent", statErr)
+			}
+		})
+	}
 }
 
 func TestHookErrorErrorIncludesBoundedOutputTail(t *testing.T) {
@@ -2199,6 +2317,58 @@ func runCommand(t *testing.T, dir string, name string, args ...string) string {
 		t.Fatalf("%s %s failed: %v\n%s", name, strings.Join(args, " "), err, output)
 	}
 	return string(output)
+}
+
+func installGitCreationWrapper(t *testing.T, mode string, source string, target string) {
+	t.Helper()
+
+	realGit, err := exec.LookPath("git")
+	if err != nil {
+		t.Fatalf("locate git: %v", err)
+	}
+	wrapperDir := t.TempDir()
+	wrapperPath := filepath.Join(wrapperDir, "git")
+	var action string
+	switch mode {
+	case "partial_failure":
+		action = "mkdir -p " + shellQuote(target) + "\n" +
+			"printf 'partial_failure\\n' > " + shellQuote(filepath.Join(target, "forensics.txt")) + "\n" +
+			"printf 'synthetic worktree add failure\\n' >&2\n" +
+			"exit 23"
+	case "standalone_after_add":
+		action = shellQuote(realGit) + " \"$@\"\n" +
+			"status=$?\n" +
+			"if [ \"$status\" -ne 0 ]; then exit \"$status\"; fi\n" +
+			shellQuote(realGit) + " -C " + shellQuote(source) + " worktree remove --force " + shellQuote(target) + "\n" +
+			shellQuote(realGit) + " clone --quiet " + shellQuote(source) + " " + shellQuote(target) + "\n" +
+			"printf 'standalone_after_add\\n' > " + shellQuote(filepath.Join(target, "forensics.txt")) + "\n" +
+			"exit 0"
+	default:
+		t.Fatalf("unknown git wrapper mode %q", mode)
+	}
+	script := "#!/bin/sh\n" +
+		"if [ \"$1\" = \"-C\" ] && [ \"$3\" = \"worktree\" ] && [ \"$4\" = \"add\" ]; then\n" +
+		action + "\n" +
+		"fi\n" +
+		"exec " + shellQuote(realGit) + " \"$@\"\n"
+	if err := os.WriteFile(wrapperPath, []byte(script), 0o700); err != nil {
+		t.Fatalf("write git wrapper: %v", err)
+	}
+	t.Setenv("PATH", wrapperDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+}
+
+func singleQuarantinedWorkspace(t *testing.T, root string) string {
+	t.Helper()
+
+	parent := filepath.Join(root, ".detent", "quarantine")
+	entries, err := os.ReadDir(parent)
+	if err != nil {
+		t.Fatalf("read quarantine directory: %v", err)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("quarantine entries = %d, want 1", len(entries))
+	}
+	return filepath.Join(parent, entries[0].Name())
 }
 
 func readFile(t *testing.T, path string) string {

--- a/internal/workspace/workspace_test.go
+++ b/internal/workspace/workspace_test.go
@@ -1751,6 +1751,139 @@ func TestLocalGitHookFailureSurfaces(t *testing.T) {
 	}
 }
 
+func TestLocalGitPreserveFailedWorkspaceReleasesBranch(t *testing.T) {
+	skipWindows(t)
+
+	tests := []struct {
+		name       string
+		identifier string
+		ctx        func() context.Context
+		prepare    func(*testing.T, string, string)
+		wantStatus string
+	}{
+		{
+			name:       "canceled creation context",
+			identifier: "DD-CANCELED-PRESERVE",
+			ctx: func() context.Context {
+				ctx, cancel := context.WithCancel(context.Background())
+				cancel()
+				return ctx
+			},
+		},
+		{
+			name:       "unmerged index",
+			identifier: "DD-UNMERGED-PRESERVE",
+			ctx:        context.Background,
+			prepare: func(t *testing.T, source string, workspace string) {
+				t.Helper()
+				if err := os.WriteFile(filepath.Join(workspace, "README.md"), []byte("workspace\n"), 0o600); err != nil {
+					t.Fatalf("write workspace README.md: %v", err)
+				}
+				runGit(t, workspace, "add", "README.md")
+				runGit(t, workspace, "commit", "-m", "workspace change")
+				if err := os.WriteFile(filepath.Join(source, "README.md"), []byte("source\n"), 0o600); err != nil {
+					t.Fatalf("write source README.md: %v", err)
+				}
+				runGit(t, source, "add", "README.md")
+				runGit(t, source, "commit", "-m", "source change")
+
+				cmd := exec.Command("git", "-C", workspace, "merge", "main")
+				output, err := cmd.CombinedOutput()
+				if err == nil {
+					t.Fatalf("git merge succeeded, want conflict:\n%s", output)
+				}
+			},
+			wantStatus: "UU README.md",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			source := initSourceRepo(t)
+			root := filepath.Join(t.TempDir(), "workspaces")
+			backend, err := NewLocalGit(LocalGitOptions{Root: root, SourceRoot: source, AutoBranch: true})
+			if err != nil {
+				t.Fatalf("NewLocalGit() error = %v", err)
+			}
+			info, err := backend.Create(context.Background(), Issue{Identifier: tt.identifier})
+			if err != nil {
+				t.Fatalf("Create() error = %v", err)
+			}
+			if tt.prepare != nil {
+				tt.prepare(t, source, info.Path)
+			}
+
+			cause := errors.New("synthetic workspace failure")
+			err = backend.preserveFailedWorkspace(tt.ctx(), info.Path, cause)
+			if !errors.Is(err, cause) {
+				t.Fatalf("preserveFailedWorkspace() error = %v, want cause", err)
+			}
+			if _, statErr := os.Stat(info.Path); !errors.Is(statErr, os.ErrNotExist) {
+				t.Fatalf("failed workspace remains at original path, stat error = %v", statErr)
+			}
+
+			quarantinedPath := singleQuarantinedWorkspace(t, root)
+			if got := runGit(t, source, "worktree", "list", "--porcelain"); !strings.Contains(got, quarantinedPath) || strings.Contains(got, info.Path+"\n") {
+				t.Fatalf("git worktree list does not register only quarantined path:\n%s", got)
+			}
+			if got := strings.TrimSpace(runGit(t, quarantinedPath, "branch", "--show-current")); got != "" {
+				t.Fatalf("quarantined worktree branch = %q, want detached HEAD", got)
+			}
+			if tt.wantStatus != "" {
+				if got := runGit(t, quarantinedPath, "status", "--porcelain"); !strings.Contains(got, tt.wantStatus) {
+					t.Fatalf("quarantined worktree status = %q, want %q", got, tt.wantStatus)
+				}
+			}
+
+			retried, retryErr := backend.Create(context.Background(), Issue{Identifier: tt.identifier})
+			if retryErr != nil {
+				t.Fatalf("retry Create() error = %v", retryErr)
+			}
+			if !retried.Created {
+				t.Fatal("retry Create() Created = false, want true")
+			}
+		})
+	}
+}
+
+func TestLocalGitPreserveFailedWorkspaceSurfacesBranchReleaseFailure(t *testing.T) {
+	skipWindows(t)
+
+	source := initSourceRepo(t)
+	root := filepath.Join(t.TempDir(), "workspaces")
+	backend, err := NewLocalGit(LocalGitOptions{Root: root, SourceRoot: source, AutoBranch: true})
+	if err != nil {
+		t.Fatalf("NewLocalGit() error = %v", err)
+	}
+	info, err := backend.Create(context.Background(), Issue{Identifier: "DD-DETACH-FAILURE"})
+	if err != nil {
+		t.Fatalf("Create() error = %v", err)
+	}
+	installGitUpdateRefFailureWrapper(t)
+
+	cause := errors.New("synthetic workspace failure")
+	err = backend.preserveFailedWorkspace(context.Background(), info.Path, cause)
+	if !errors.Is(err, cause) {
+		t.Fatalf("preserveFailedWorkspace() error = %v, want cause", err)
+	}
+	for _, want := range []string{"workspace quarantined at", "failed to release its branch", "synthetic update-ref failure"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("preserveFailedWorkspace() error = %q, want %q", err, want)
+		}
+	}
+	if _, statErr := os.Stat(info.Path); !errors.Is(statErr, os.ErrNotExist) {
+		t.Fatalf("failed workspace remains at original path, stat error = %v", statErr)
+	}
+
+	quarantinedPath := singleQuarantinedWorkspace(t, root)
+	if !strings.Contains(err.Error(), quarantinedPath) {
+		t.Fatalf("preserveFailedWorkspace() error = %q, want quarantine path %q", err, quarantinedPath)
+	}
+	if got := strings.TrimSpace(runGit(t, quarantinedPath, "branch", "--show-current")); got != info.Branch {
+		t.Fatalf("quarantined worktree branch = %q, want %q after release failure", got, info.Branch)
+	}
+}
+
 func TestLocalGitCreateQuarantinesFailedCreationState(t *testing.T) {
 	skipWindows(t)
 
@@ -2349,6 +2482,27 @@ func installGitCreationWrapper(t *testing.T, mode string, source string, target 
 	script := "#!/bin/sh\n" +
 		"if [ \"$1\" = \"-C\" ] && [ \"$3\" = \"worktree\" ] && [ \"$4\" = \"add\" ]; then\n" +
 		action + "\n" +
+		"fi\n" +
+		"exec " + shellQuote(realGit) + " \"$@\"\n"
+	if err := os.WriteFile(wrapperPath, []byte(script), 0o700); err != nil {
+		t.Fatalf("write git wrapper: %v", err)
+	}
+	t.Setenv("PATH", wrapperDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+}
+
+func installGitUpdateRefFailureWrapper(t *testing.T) {
+	t.Helper()
+
+	realGit, err := exec.LookPath("git")
+	if err != nil {
+		t.Fatalf("locate git: %v", err)
+	}
+	wrapperDir := t.TempDir()
+	wrapperPath := filepath.Join(wrapperDir, "git")
+	script := "#!/bin/sh\n" +
+		"if [ \"$1\" = \"-C\" ] && [ \"$3\" = \"update-ref\" ] && [ \"$4\" = \"--no-deref\" ] && [ \"$5\" = \"HEAD\" ]; then\n" +
+		"printf 'synthetic update-ref failure\\n' >&2\n" +
+		"exit 29\n" +
 		"fi\n" +
 		"exec " + shellQuote(realGit) + " \"$@\"\n"
 	if err := os.WriteFile(wrapperPath, []byte(script), 0o700); err != nil {


### PR DESCRIPTION
## Summary

- Verify each newly created local Git workspace resolves to the source repository common directory and appears in its exact worktree registration before running `after_create`.
- Quarantine partial creation state, metadata setup failures, invariant failures, and hook failures using a bounded preservation context that remains live after creation cancellation.
- Release valid quarantined worktrees with ref-only HEAD detachment so unmerged indexes remain intact and bounded retries can reuse their branches; surface any release failure with the retained path.
- Cover false-success, partial-failure, canceled-context, unmerged-index, and branch-release-error postconditions with isolated standard-library regressions and document the reusable fault-injection method.

Fixes #1936

## UI Surface Contract

- [x] N/A, or the linked issue explicitly authorizes any high-impact UI surface, layout, density, first-viewport, or responsive visibility tradeoff.
- [x] Persistent top-of-screen messaging is explicitly authorized by the issue, or this PR does not add it.
- [x] Visual changes to primary operator screens include screenshot or browser verification below.

## Test Plan

- [x] Focused workspace quarantine and branch-release regressions under the race detector for 10 consecutive runs.
- [x] `make check` with Go 1.26.6 and golangci-lint v2.1.6 (78.9% coverage).
- [x] Current-head CI run 32400603179 passed all checks.
