### PR TITLE
fix(update): bound automatic apply deferral

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -50,6 +50,13 @@ Runtime settings resolve in this order: explicit flag, environment variable,
 | Automatic update checks | | | `update.auto_check_enabled` | `false` |
 | Update check interval | | | `update.check_interval_hours` | `6` |
 | Automatic update apply when idle | | | `update.auto_apply_enabled` | `false` |
+| Maximum automatic update deferral | | | `update.max_deferral_hours` | `6` |
+
+Automatic apply waits for an idle runtime until `update.max_deferral_hours`
+elapses, then pauses new dispatches and lets in-flight attempts finish within
+their configured session ceilings before applying and restarting. Add
+`[detent-critical]` to a GitHub release body to bypass the idle wait and start
+that drain immediately.
 
 The web host resolves from `--host`, then the first registered workflow's
 `server.host`, then the built-in `127.0.0.1` default. It is not a top-level

--- a/internal/cli/boot.go
+++ b/internal/cli/boot.go
@@ -354,9 +354,16 @@ func startRunningWithDependencies(ctx context.Context, cfg BootConfig, deps star
 	if err != nil {
 		return err
 	}
-	updateScheduler, err := newRuntimeUpdateScheduler(cfg, logger, func(ctx context.Context) (func(), bool) {
-		return runtimeUpdateIdleReservation(ctx, manager.Registry(), globalDispatchGate)
-	})
+	updateScheduler, err := newRuntimeUpdateScheduler(
+		cfg,
+		logger,
+		func(ctx context.Context) (func(), bool) {
+			return runtimeUpdateIdleReservation(ctx, manager.Registry(), globalDispatchGate)
+		},
+		func(ctx context.Context) (func(), error) {
+			return runtimeUpdateDrainReservation(ctx, manager.Registry(), globalDispatchGate)
+		},
+	)
 	if err != nil {
 		return err
 	}

--- a/internal/cli/runner.go
+++ b/internal/cli/runner.go
@@ -717,6 +717,9 @@ func telemetryUpdateStatus(sources []autoUpdateStatusSource) telemetry.Update {
 		LastAppliedVersion: status.LastAppliedVersion,
 		NextCheckAt:        status.NextCheckAt,
 		AvailableVersion:   status.AvailableVersion,
+		PendingSince:       status.PendingSince,
+		MaxDeferralHours:   int(status.MaxDeferral / time.Hour),
+		Critical:           status.Critical,
 		LastError:          status.LastError,
 	}
 }

--- a/internal/cli/runner_test.go
+++ b/internal/cli/runner_test.go
@@ -36,6 +36,7 @@ func TestTelemetryUpdateStatus(t *testing.T) {
 	t.Parallel()
 
 	lastCheck := time.Date(2026, 7, 11, 15, 0, 0, 0, time.UTC)
+	pendingSince := lastCheck.Add(-4 * time.Hour)
 	got := telemetryUpdateStatus([]autoUpdateStatusSource{autoUpdateStatusStub{status: detentupdate.AutoStatus{
 		Enabled:            true,
 		AutoApplyEnabled:   true,
@@ -43,8 +44,11 @@ func TestTelemetryUpdateStatus(t *testing.T) {
 		State:              "scheduled",
 		LastCheckAt:        &lastCheck,
 		LastAppliedVersion: "1.2.4",
+		PendingSince:       &pendingSince,
+		MaxDeferral:        6 * time.Hour,
+		Critical:           true,
 	}}})
-	if !got.Enabled || !got.AutoApplyEnabled || got.CheckIntervalHours != 12 || got.LastAppliedVersion != "1.2.4" || got.LastCheckAt == nil {
+	if !got.Enabled || !got.AutoApplyEnabled || got.CheckIntervalHours != 12 || got.LastAppliedVersion != "1.2.4" || got.LastCheckAt == nil || got.PendingSince == nil || got.MaxDeferralHours != 6 || !got.Critical {
 		t.Fatalf("telemetryUpdateStatus() = %#v", got)
 	}
 }

--- a/internal/cli/update_runtime.go
+++ b/internal/cli/update_runtime.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"os"
@@ -10,9 +11,14 @@ import (
 	"sync"
 	"time"
 
+	workflowconfig "github.com/digitaldrywood/detent/internal/config"
 	"github.com/digitaldrywood/detent/internal/project"
 	detentupdate "github.com/digitaldrywood/detent/internal/update"
 )
+
+const runtimeUpdateDrainPollInterval = 500 * time.Millisecond
+
+var ErrRuntimeUpdateDrainTimeout = errors.New("automatic update runtime drain timed out")
 
 type RestartRequest struct {
 	mu     sync.RWMutex
@@ -41,13 +47,20 @@ func (r *RestartRequest) set(binary string) {
 	r.binary = strings.TrimSpace(binary)
 }
 
-func newRuntimeUpdateScheduler(cfg BootConfig, logger *slog.Logger, reserveIdle func(context.Context) (func(), bool)) (*detentupdate.Scheduler, error) {
+func newRuntimeUpdateScheduler(
+	cfg BootConfig,
+	logger *slog.Logger,
+	reserveIdle func(context.Context) (func(), bool),
+	reserveDrain func(context.Context) (func(), error),
+) (*detentupdate.Scheduler, error) {
 	interval := time.Duration(cfg.Global.Update.NormalizedCheckIntervalHours()) * time.Hour
 	schedulerConfig := detentupdate.SchedulerConfig{
 		Enabled:          cfg.Global.Update.AutoCheckEnabled,
 		AutoApplyEnabled: cfg.Global.Update.AutoApplyEnabled,
 		CheckInterval:    interval,
+		MaxDeferral:      time.Duration(cfg.Global.Update.NormalizedMaxDeferralHours()) * time.Hour,
 		ReserveIdle:      reserveIdle,
+		ReserveDrain:     reserveDrain,
 		Logger:           logger,
 		StatePath:        runtimeUpdateStatePath(cfg),
 	}
@@ -125,6 +138,108 @@ func runtimeUpdateIdleReservation(ctx context.Context, registry *project.Registr
 		return nil, false
 	}
 	return release, true
+}
+
+func runtimeUpdateDrainReservation(ctx context.Context, registry *project.Registry, gate dispatchPauser) (func(), error) {
+	if gate == nil {
+		return nil, errors.New("runtime dispatch pauser is unavailable")
+	}
+	release := gate.PauseDispatch()
+	err := waitForRuntimeUpdateIdle(
+		ctx,
+		func(waitCtx context.Context) bool { return runtimeUpdateIdle(waitCtx, registry) },
+		runtimeUpdateDrainTimeout(registry),
+		time.Now,
+		waitForRuntimeUpdateDrain,
+	)
+	if err != nil {
+		release()
+		return nil, err
+	}
+	return release, nil
+}
+
+func waitForRuntimeUpdateIdle(
+	ctx context.Context,
+	idle func(context.Context) bool,
+	timeout time.Duration,
+	now func() time.Time,
+	wait func(context.Context, time.Duration) bool,
+) error {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if idle == nil {
+		return errors.New("runtime idle check is unavailable")
+	}
+	if timeout <= 0 {
+		return fmt.Errorf("%w: invalid ceiling %s", ErrRuntimeUpdateDrainTimeout, timeout)
+	}
+	if now == nil {
+		now = time.Now
+	}
+	if wait == nil {
+		wait = waitForRuntimeUpdateDrain
+	}
+	deadline := now().Add(timeout)
+	for !idle(ctx) {
+		remaining := deadline.Sub(now())
+		if remaining <= 0 {
+			return fmt.Errorf("%w after %s", ErrRuntimeUpdateDrainTimeout, timeout)
+		}
+		if !wait(ctx, min(runtimeUpdateDrainPollInterval, remaining)) {
+			if err := ctx.Err(); err != nil {
+				return err
+			}
+			return fmt.Errorf("%w after %s", ErrRuntimeUpdateDrainTimeout, timeout)
+		}
+	}
+	return nil
+}
+
+func waitForRuntimeUpdateDrain(ctx context.Context, delay time.Duration) bool {
+	timer := time.NewTimer(delay)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		return false
+	case <-timer.C:
+		return true
+	}
+}
+
+func runtimeUpdateDrainTimeout(registry *project.Registry) time.Duration {
+	defaultTimeout := max(
+		time.Duration(workflowconfig.DefaultMaxSessionDurationMS)*time.Millisecond,
+		time.Duration(workflowconfig.DefaultMergeWorkerMaxDurationMS)*time.Millisecond,
+		time.Duration(workflowconfig.DefaultMergeFallbackMaxDurationMS)*time.Millisecond,
+	)
+	if registry == nil {
+		return defaultTimeout
+	}
+	timeout := time.Duration(0)
+	for _, trackedProject := range registry.List() {
+		agent := trackedProject.Workflow().Config.Agent
+		ceilings := []struct {
+			configured int
+			fallback   int
+		}{
+			{configured: agent.MaxSessionDurationMS, fallback: workflowconfig.DefaultMaxSessionDurationMS},
+			{configured: agent.MergeWorkerMaxDurationMS, fallback: workflowconfig.DefaultMergeWorkerMaxDurationMS},
+			{configured: agent.MergeFallbackMaxDurationMS, fallback: workflowconfig.DefaultMergeFallbackMaxDurationMS},
+		}
+		for _, ceiling := range ceilings {
+			configured := ceiling.configured
+			if configured <= 0 {
+				configured = ceiling.fallback
+			}
+			timeout = max(timeout, time.Duration(configured)*time.Millisecond)
+		}
+	}
+	if timeout == 0 {
+		return defaultTimeout
+	}
+	return timeout
 }
 
 func requestUpdateRestart(controller *ShutdownController, restart *RestartRequest, binary string) bool {

--- a/internal/cli/update_runtime_test.go
+++ b/internal/cli/update_runtime_test.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"context"
+	"errors"
 	"sync"
 	"testing"
 	"time"
@@ -118,6 +119,47 @@ func TestRequestUpdateRestartUsesShutdownDrainState(t *testing.T) {
 				if tt.wantDrainEvent {
 					t.Fatal("shutdown request missing, want drain")
 				}
+			}
+		})
+	}
+}
+
+func TestWaitForRuntimeUpdateIdleHonorsCeiling(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		idleAfter time.Duration
+		wantWait  time.Duration
+		wantErr   error
+	}{
+		{name: "in-flight attempts finish before ceiling", idleAfter: time.Second, wantWait: time.Second},
+		{name: "in-flight attempts consume full ceiling", idleAfter: 4 * time.Second, wantWait: 3 * time.Second, wantErr: ErrRuntimeUpdateDrainTimeout},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			startedAt := time.Date(2026, 8, 20, 10, 0, 0, 0, time.UTC)
+			now := startedAt
+			waited := time.Duration(0)
+			err := waitForRuntimeUpdateIdle(
+				context.Background(),
+				func(context.Context) bool { return now.Sub(startedAt) >= tt.idleAfter },
+				3*time.Second,
+				func() time.Time { return now },
+				func(_ context.Context, delay time.Duration) bool {
+					now = now.Add(delay)
+					waited += delay
+					return true
+				},
+			)
+			if !errors.Is(err, tt.wantErr) {
+				t.Fatalf("waitForRuntimeUpdateIdle() error = %v, want %v", err, tt.wantErr)
+			}
+			if waited != tt.wantWait {
+				t.Fatalf("waited = %s, want %s", waited, tt.wantWait)
 			}
 		})
 	}

--- a/internal/config/global/config.go
+++ b/internal/config/global/config.go
@@ -24,6 +24,7 @@ const (
 	APIVersion                      = "detent/v1"
 	Kind                            = "GlobalConfig"
 	DefaultUpdateCheckIntervalHours = 6
+	DefaultUpdateMaxDeferralHours   = 6
 
 	SchedulingWeighted                            = "weighted"
 	SchedulingStrict                              = "strict"
@@ -108,10 +109,11 @@ type Update struct {
 	AutoCheckEnabled   bool `yaml:"auto_check_enabled,omitempty"`
 	CheckIntervalHours int  `yaml:"check_interval_hours,omitempty"`
 	AutoApplyEnabled   bool `yaml:"auto_apply_enabled,omitempty"`
+	MaxDeferralHours   int  `yaml:"max_deferral_hours,omitempty"`
 }
 
 func (u Update) IsZero() bool {
-	return !u.AutoCheckEnabled && u.CheckIntervalHours == 0 && !u.AutoApplyEnabled
+	return !u.AutoCheckEnabled && u.CheckIntervalHours == 0 && !u.AutoApplyEnabled && u.MaxDeferralHours == 0
 }
 
 func (u Update) NormalizedCheckIntervalHours() int {
@@ -119,6 +121,13 @@ func (u Update) NormalizedCheckIntervalHours() int {
 		return u.CheckIntervalHours
 	}
 	return DefaultUpdateCheckIntervalHours
+}
+
+func (u Update) NormalizedMaxDeferralHours() int {
+	if u.MaxDeferralHours > 0 {
+		return u.MaxDeferralHours
+	}
+	return DefaultUpdateMaxDeferralHours
 }
 
 type Settings struct {
@@ -695,6 +704,9 @@ func (c Config) Validate(opts ...Option) error {
 	if c.Update.CheckIntervalHours < 0 {
 		problems = append(problems, "update.check_interval_hours: must be a positive integer")
 	}
+	if c.Update.MaxDeferralHours < 0 {
+		problems = append(problems, "update.max_deferral_hours: must be a positive integer")
+	}
 	problems = append(problems, c.Auth.validate("auth")...)
 
 	if c.Global.MaxConcurrentAgents <= 0 {
@@ -1039,6 +1051,9 @@ func updateErrors(value any) []string {
 	}
 	if interval, ok := update["check_interval_hours"]; ok && !positiveInteger(interval) {
 		problems = append(problems, "update.check_interval_hours: must be a positive integer")
+	}
+	if interval, ok := update["max_deferral_hours"]; ok && !positiveInteger(interval) {
+		problems = append(problems, "update.max_deferral_hours: must be a positive integer")
 	}
 	return problems
 }

--- a/internal/config/global/config_test.go
+++ b/internal/config/global/config_test.go
@@ -302,6 +302,7 @@ update:
   auto_check_enabled: true
   check_interval_hours: 12
   auto_apply_enabled: true
+  max_deferral_hours: 4
 global:
   max_concurrent_agents: 8
   scheduling: weighted
@@ -347,8 +348,8 @@ projects:
 	if cfg.InstanceName != "buildbox" {
 		t.Fatalf("InstanceName = %q, want buildbox", cfg.InstanceName)
 	}
-	if !cfg.Update.AutoCheckEnabled || !cfg.Update.AutoApplyEnabled || cfg.Update.NormalizedCheckIntervalHours() != 12 {
-		t.Fatalf("Update = %#v, want enabled 12-hour auto-apply", cfg.Update)
+	if !cfg.Update.AutoCheckEnabled || !cfg.Update.AutoApplyEnabled || cfg.Update.NormalizedCheckIntervalHours() != 12 || cfg.Update.NormalizedMaxDeferralHours() != 4 {
+		t.Fatalf("Update = %#v, want enabled 12-hour auto-apply with 4-hour deferral", cfg.Update)
 	}
 	if cfg.Projects[0].WorkflowRef != "origin/main" {
 		t.Fatalf("Project.WorkflowRef = %q, want origin/main", cfg.Projects[0].WorkflowRef)
@@ -456,6 +457,7 @@ func TestReadValidatesUpdateSettings(t *testing.T) {
 		{name: "mapping", update: "disabled", want: "update: must be a mapping"},
 		{name: "enabled boolean", update: "\n  auto_check_enabled: yes-please", want: "update.auto_check_enabled: must be a boolean"},
 		{name: "positive interval", update: "\n  check_interval_hours: 0", want: "update.check_interval_hours: must be a positive integer"},
+		{name: "positive max deferral", update: "\n  max_deferral_hours: 0", want: "update.max_deferral_hours: must be a positive integer"},
 	}
 
 	for _, tt := range tests {
@@ -489,6 +491,9 @@ func TestUpdateUsesSixHourDefaultInterval(t *testing.T) {
 
 	if got := (Update{}).NormalizedCheckIntervalHours(); got != 6 {
 		t.Fatalf("NormalizedCheckIntervalHours() = %d, want 6", got)
+	}
+	if got := (Update{}).NormalizedMaxDeferralHours(); got != 6 {
+		t.Fatalf("NormalizedMaxDeferralHours() = %d, want 6", got)
 	}
 }
 

--- a/internal/telemetry/snapshot.go
+++ b/internal/telemetry/snapshot.go
@@ -2,6 +2,7 @@ package telemetry
 
 import (
 	"encoding/json"
+	"fmt"
 	"strings"
 	"time"
 
@@ -353,11 +354,32 @@ type Update struct {
 	LastAppliedVersion string     `json:"last_applied_version,omitempty"`
 	NextCheckAt        *time.Time `json:"next_check_at,omitempty"`
 	AvailableVersion   string     `json:"available_version,omitempty"`
+	PendingSince       *time.Time `json:"pending_since,omitempty"`
+	MaxDeferralHours   int        `json:"max_deferral_hours,omitempty"`
+	Critical           bool       `json:"critical,omitempty"`
 	LastError          string     `json:"last_error,omitempty"`
 }
 
 func (u Update) IsZero() bool {
-	return !u.Enabled && !u.AutoApplyEnabled && u.CheckIntervalHours == 0 && u.State == "" && u.LastCheckAt == nil && u.LastAppliedVersion == "" && u.NextCheckAt == nil && u.AvailableVersion == "" && u.LastError == ""
+	return !u.Enabled && !u.AutoApplyEnabled && u.CheckIntervalHours == 0 && u.State == "" && u.LastCheckAt == nil && u.LastAppliedVersion == "" && u.NextCheckAt == nil && u.AvailableVersion == "" && u.PendingSince == nil && u.MaxDeferralHours == 0 && !u.Critical && u.LastError == ""
+}
+
+func (u Update) DisplayState(now time.Time) string {
+	if strings.TrimSpace(u.State) != "pending_idle" || u.PendingSince == nil || u.MaxDeferralHours <= 0 {
+		return u.State
+	}
+	age := now.Sub(*u.PendingSince)
+	if age < 0 {
+		age = 0
+	}
+	return fmt.Sprintf("pending_idle (%s, max %dh)", compactUpdateDuration(age), u.MaxDeferralHours)
+}
+
+func compactUpdateDuration(duration time.Duration) string {
+	if duration < time.Hour {
+		return fmt.Sprintf("%dm", max(0, int(duration/time.Minute)))
+	}
+	return fmt.Sprintf("%dh", int(duration/time.Hour))
 }
 
 type Shutdown struct {

--- a/internal/update/scheduler.go
+++ b/internal/update/scheduler.go
@@ -17,6 +17,8 @@ const defaultJitterFraction = 10
 
 const defaultIdlePollInterval = 5 * time.Second
 
+const defaultMaxDeferral = 6 * time.Hour
+
 var ErrNoPendingUpdate = errors.New("no Detent update is pending")
 
 type Updater interface {
@@ -28,11 +30,14 @@ type AutoStatus struct {
 	Enabled            bool
 	AutoApplyEnabled   bool
 	CheckInterval      time.Duration
+	MaxDeferral        time.Duration
 	State              string
 	LastCheckAt        *time.Time
 	LastAppliedVersion string
 	NextCheckAt        *time.Time
 	AvailableVersion   string
+	PendingSince       *time.Time
+	Critical           bool
 	LastError          string
 }
 
@@ -41,10 +46,12 @@ type SchedulerConfig struct {
 	AutoApplyEnabled   bool
 	CheckInterval      time.Duration
 	IdlePollInterval   time.Duration
+	MaxDeferral        time.Duration
 	LastAppliedVersion string
 	StatePath          string
 	Updater            Updater
 	ReserveIdle        func(context.Context) (func(), bool)
+	ReserveDrain       func(context.Context) (func(), error)
 	RequestRestart     func(string) bool
 	Logger             *slog.Logger
 	Now                func() time.Time
@@ -69,6 +76,12 @@ func NewScheduler(cfg SchedulerConfig) (*Scheduler, error) {
 	if cfg.Enabled && cfg.AutoApplyEnabled && cfg.ReserveIdle == nil {
 		return nil, errors.New("runtime idle reservation is required when automatic update apply is enabled")
 	}
+	if cfg.MaxDeferral < 0 {
+		return nil, errors.New("update maximum deferral must not be negative")
+	}
+	if cfg.Enabled && cfg.AutoApplyEnabled && cfg.ReserveDrain == nil {
+		return nil, errors.New("runtime drain reservation is required when automatic update apply is enabled")
+	}
 	if cfg.Logger == nil {
 		cfg.Logger = slog.Default()
 	}
@@ -83,6 +96,9 @@ func NewScheduler(cfg SchedulerConfig) (*Scheduler, error) {
 	}
 	if cfg.IdlePollInterval <= 0 {
 		cfg.IdlePollInterval = defaultIdlePollInterval
+	}
+	if cfg.AutoApplyEnabled && cfg.MaxDeferral == 0 {
+		cfg.MaxDeferral = defaultMaxDeferral
 	}
 	loadedLastCheckAt, lastCheckFound, err := loadSchedulerState(cfg.StatePath)
 	if err != nil {
@@ -102,6 +118,7 @@ func NewScheduler(cfg SchedulerConfig) (*Scheduler, error) {
 			Enabled:            cfg.Enabled,
 			AutoApplyEnabled:   cfg.AutoApplyEnabled,
 			CheckInterval:      cfg.CheckInterval,
+			MaxDeferral:        cfg.MaxDeferral,
 			State:              state,
 			LastCheckAt:        lastCheckAt,
 			LastAppliedVersion: strings.TrimSpace(cfg.LastAppliedVersion),
@@ -117,25 +134,30 @@ func (s *Scheduler) Run(ctx context.Context) {
 		ctx = context.Background()
 	}
 	for {
-		if s.pendingIdle() {
-			if !s.cfg.Wait(ctx, min(s.cfg.IdlePollInterval, s.cfg.CheckInterval)) {
-				return
-			}
-			if _, err := s.applyWhenIdle(ctx); err != nil && ctx.Err() == nil {
-				s.cfg.Logger.Warn("automatic update apply failed", "error", err)
-			}
-			continue
+		checkDelay, next := s.nextCheck()
+		pendingDelay, pending := s.nextPendingAction()
+		delay := checkDelay
+		if pending && pendingDelay < delay {
+			delay = pendingDelay
 		}
-		delay, next := s.nextCheck()
 		s.updateStatus(func(status *AutoStatus) {
-			status.State = "scheduled"
+			if !pending {
+				status.State = "scheduled"
+			}
 			status.NextCheckAt = &next
 		})
 		if delay > 0 && !s.cfg.Wait(ctx, delay) {
 			return
 		}
-		if _, err := s.CheckNow(ctx); err != nil && ctx.Err() == nil {
-			s.cfg.Logger.Warn("automatic update check failed", "error", err)
+		if checkDelay <= delay {
+			if _, err := s.CheckNow(ctx); err != nil && ctx.Err() == nil {
+				s.cfg.Logger.Warn("automatic update check failed", "error", err)
+			}
+		}
+		if pending && pendingDelay <= delay && s.pendingIdle() {
+			if _, err := s.applyWhenIdle(ctx); err != nil && ctx.Err() == nil {
+				s.cfg.Logger.Warn("automatic update apply failed", "error", err)
+			}
 		}
 	}
 }
@@ -166,7 +188,7 @@ func (s *Scheduler) CheckNow(ctx context.Context) (Status, error) {
 			})
 			return checked, fmt.Errorf("check for Detent update: %w", err)
 		}
-		persistErr := s.recordFailure(checkedAt, err)
+		persistErr := s.recordCheckFailure(checkedAt, err)
 		return checked, fmt.Errorf("check for Detent update: %w", errors.Join(err, persistErr))
 	}
 	if !checked.UpdateAvailable {
@@ -174,6 +196,7 @@ func (s *Scheduler) CheckNow(ctx context.Context) (Status, error) {
 			status.State = "up_to_date"
 			status.LastCheckAt = &checkedAt
 			status.AvailableVersion = ""
+			clearPending(status)
 		})
 		persistErr := s.persistLastCheck(checkedAt)
 		s.cfg.Logger.Info("automatic update check completed", "current_version", checked.CurrentVersion, "update_available", false)
@@ -184,18 +207,30 @@ func (s *Scheduler) CheckNow(ctx context.Context) (Status, error) {
 		status.State = "available"
 		status.LastCheckAt = &checkedAt
 		status.AvailableVersion = checked.LatestVersion
+		status.Critical = checked.Critical
 	})
 	persistErr := s.persistLastCheck(checkedAt)
 	s.cfg.Logger.Info("Detent update available", "current_version", checked.CurrentVersion, "latest_version", checked.LatestVersion, "auto_apply_enabled", s.cfg.AutoApplyEnabled)
 	if !s.cfg.AutoApplyEnabled {
+		s.updateStatus(clearPending)
 		return checked, persistErr
 	}
 	if checked.InstallSource != InstallSourceRelease {
 		s.updateStatus(func(status *AutoStatus) {
 			status.State = "available_manual_apply"
+			clearPending(status)
 		})
 		s.cfg.Logger.Warn("automatic update apply skipped for non-release install", "install_source", checked.InstallSource, "latest_version", checked.LatestVersion)
 		return checked, persistErr
+	}
+	if checked.Critical {
+		s.updateStatus(func(status *AutoStatus) {
+			status.State = "pending_idle"
+			setPendingSince(status, checkedAt)
+		})
+		s.cfg.Logger.Warn("critical Detent update bypassing idle wait", "version", checked.LatestVersion)
+		applied, applyErr := s.drainAndApplyLocked(ctx)
+		return applied, errors.Join(persistErr, applyErr)
 	}
 	releaseIdle, idle := s.cfg.ReserveIdle(ctx)
 	if !idle {
@@ -204,6 +239,7 @@ func (s *Scheduler) CheckNow(ctx context.Context) (Status, error) {
 		}
 		s.updateStatus(func(status *AutoStatus) {
 			status.State = "pending_idle"
+			setPendingSince(status, checkedAt)
 		})
 		s.cfg.Logger.Info("automatic update apply deferred until runtime is idle", "version", checked.LatestVersion)
 		return checked, persistErr
@@ -234,6 +270,9 @@ func (s *Scheduler) applyWhenIdle(ctx context.Context) (Status, error) {
 	if !s.pendingIdle() {
 		return Status{}, nil
 	}
+	if s.deferralExpired() {
+		return s.drainAndApplyLocked(ctx)
+	}
 	releaseIdle, idle := s.cfg.ReserveIdle(ctx)
 	if !idle {
 		if releaseIdle != nil {
@@ -242,6 +281,22 @@ func (s *Scheduler) applyWhenIdle(ctx context.Context) (Status, error) {
 		return Status{}, nil
 	}
 	return s.applyLocked(ctx, releaseIdle)
+}
+
+func (s *Scheduler) drainAndApplyLocked(ctx context.Context) (Status, error) {
+	s.updateStatus(func(status *AutoStatus) {
+		status.State = "draining"
+		status.LastError = ""
+	})
+	releaseDrain, err := s.cfg.ReserveDrain(ctx)
+	if err != nil {
+		s.updateStatus(func(status *AutoStatus) {
+			status.State = "pending_idle"
+			status.LastError = err.Error()
+		})
+		return Status{}, fmt.Errorf("drain runtime for automatic update: %w", err)
+	}
+	return s.applyLocked(ctx, releaseDrain)
 }
 
 func (s *Scheduler) applyLocked(ctx context.Context, releaseIdle func()) (Status, error) {
@@ -269,6 +324,7 @@ func (s *Scheduler) applyLocked(ctx context.Context, releaseIdle func()) (Status
 		s.updateStatus(func(status *AutoStatus) {
 			status.State = "available"
 			status.LastError = strings.TrimSpace(applied.Message)
+			clearPending(status)
 		})
 		return applied, nil
 	}
@@ -278,6 +334,7 @@ func (s *Scheduler) applyLocked(ctx context.Context, releaseIdle func()) (Status
 		status.LastAppliedVersion = applied.LatestVersion
 		status.AvailableVersion = ""
 		status.LastError = ""
+		clearPending(status)
 	})
 	restartRequested := s.cfg.RequestRestart != nil && s.cfg.RequestRestart(applied.Binary)
 	if !restartRequested {
@@ -301,6 +358,29 @@ func (s *Scheduler) pendingIdle() bool {
 	return s.status.State == "pending_idle" && strings.TrimSpace(s.status.AvailableVersion) != ""
 }
 
+func (s *Scheduler) nextPendingAction() (time.Duration, bool) {
+	status := s.Status()
+	if status.State != "pending_idle" || strings.TrimSpace(status.AvailableVersion) == "" {
+		return 0, false
+	}
+	if status.PendingSince == nil || status.MaxDeferral <= 0 {
+		return s.cfg.IdlePollInterval, true
+	}
+	remaining := status.PendingSince.Add(status.MaxDeferral).Sub(s.cfg.Now())
+	if remaining <= 0 {
+		return 0, true
+	}
+	return min(s.cfg.IdlePollInterval, remaining), true
+}
+
+func (s *Scheduler) deferralExpired() bool {
+	status := s.Status()
+	return status.State == "pending_idle" &&
+		status.PendingSince != nil &&
+		status.MaxDeferral > 0 &&
+		!s.cfg.Now().Before(status.PendingSince.Add(status.MaxDeferral))
+}
+
 func (s *Scheduler) Status() AutoStatus {
 	if s == nil {
 		return AutoStatus{}
@@ -313,6 +393,25 @@ func (s *Scheduler) Status() AutoStatus {
 func (s *Scheduler) recordFailure(checkedAt time.Time, err error) error {
 	s.updateStatus(func(status *AutoStatus) {
 		status.State = "failed"
+		status.LastCheckAt = &checkedAt
+		status.LastError = err.Error()
+	})
+	persistErr := s.persistLastCheck(checkedAt)
+	if persistErr != nil {
+		s.updateStatus(func(status *AutoStatus) {
+			status.LastError = errors.Join(err, persistErr).Error()
+		})
+	}
+	return persistErr
+}
+
+func (s *Scheduler) recordCheckFailure(checkedAt time.Time, err error) error {
+	s.updateStatus(func(status *AutoStatus) {
+		if status.PendingSince != nil && strings.TrimSpace(status.AvailableVersion) != "" {
+			status.State = "pending_idle"
+		} else {
+			status.State = "failed"
+		}
 		status.LastCheckAt = &checkedAt
 		status.LastError = err.Error()
 	})
@@ -375,7 +474,22 @@ func cloneAutoStatus(status AutoStatus) AutoStatus {
 		nextCheckAt := *status.NextCheckAt
 		status.NextCheckAt = &nextCheckAt
 	}
+	if status.PendingSince != nil {
+		pendingSince := *status.PendingSince
+		status.PendingSince = &pendingSince
+	}
 	return status
+}
+
+func setPendingSince(status *AutoStatus, pendingSince time.Time) {
+	if status.PendingSince == nil {
+		status.PendingSince = &pendingSince
+	}
+}
+
+func clearPending(status *AutoStatus) {
+	status.PendingSince = nil
+	status.Critical = false
 }
 
 func jitteredDelay(interval time.Duration) time.Duration {

--- a/internal/update/scheduler.go
+++ b/internal/update/scheduler.go
@@ -100,17 +100,26 @@ func NewScheduler(cfg SchedulerConfig) (*Scheduler, error) {
 	if cfg.AutoApplyEnabled && cfg.MaxDeferral == 0 {
 		cfg.MaxDeferral = defaultMaxDeferral
 	}
-	loadedLastCheckAt, lastCheckFound, err := loadSchedulerState(cfg.StatePath)
+	loadedState, stateFound, err := loadSchedulerState(cfg.StatePath)
 	if err != nil {
 		cfg.Logger.Warn("load automatic update state failed", "path", cfg.StatePath, "error", err)
 	}
 	var lastCheckAt *time.Time
-	if lastCheckFound {
-		lastCheckAt = &loadedLastCheckAt
+	if stateFound {
+		lastCheckAt = &loadedState.LastCheckAt
 	}
 	state := "disabled"
 	if cfg.Enabled {
 		state = "scheduled"
+	}
+	var pendingSince *time.Time
+	availableVersion := ""
+	critical := false
+	if cfg.Enabled && cfg.AutoApplyEnabled && stateFound && loadedState.PendingSince != nil {
+		state = "pending_idle"
+		pendingSince = loadedState.PendingSince
+		availableVersion = loadedState.AvailableVersion
+		critical = loadedState.Critical
 	}
 	return &Scheduler{
 		cfg: cfg,
@@ -122,6 +131,9 @@ func NewScheduler(cfg SchedulerConfig) (*Scheduler, error) {
 			State:              state,
 			LastCheckAt:        lastCheckAt,
 			LastAppliedVersion: strings.TrimSpace(cfg.LastAppliedVersion),
+			AvailableVersion:   availableVersion,
+			PendingSince:       pendingSince,
+			Critical:           critical,
 		},
 	}, nil
 }
@@ -209,11 +221,10 @@ func (s *Scheduler) CheckNow(ctx context.Context) (Status, error) {
 		status.AvailableVersion = checked.LatestVersion
 		status.Critical = checked.Critical
 	})
-	persistErr := s.persistLastCheck(checkedAt)
 	s.cfg.Logger.Info("Detent update available", "current_version", checked.CurrentVersion, "latest_version", checked.LatestVersion, "auto_apply_enabled", s.cfg.AutoApplyEnabled)
 	if !s.cfg.AutoApplyEnabled {
 		s.updateStatus(clearPending)
-		return checked, persistErr
+		return checked, s.persistLastCheck(checkedAt)
 	}
 	if checked.InstallSource != InstallSourceRelease {
 		s.updateStatus(func(status *AutoStatus) {
@@ -221,13 +232,14 @@ func (s *Scheduler) CheckNow(ctx context.Context) (Status, error) {
 			clearPending(status)
 		})
 		s.cfg.Logger.Warn("automatic update apply skipped for non-release install", "install_source", checked.InstallSource, "latest_version", checked.LatestVersion)
-		return checked, persistErr
+		return checked, s.persistLastCheck(checkedAt)
 	}
 	if checked.Critical {
 		s.updateStatus(func(status *AutoStatus) {
 			status.State = "pending_idle"
 			setPendingSince(status, checkedAt)
 		})
+		persistErr := s.persistLastCheck(checkedAt)
 		s.cfg.Logger.Warn("critical Detent update bypassing idle wait", "version", checked.LatestVersion)
 		applied, applyErr := s.drainAndApplyLocked(ctx)
 		return applied, errors.Join(persistErr, applyErr)
@@ -241,12 +253,12 @@ func (s *Scheduler) CheckNow(ctx context.Context) (Status, error) {
 			status.State = "pending_idle"
 			setPendingSince(status, checkedAt)
 		})
+		persistErr := s.persistLastCheck(checkedAt)
 		s.cfg.Logger.Info("automatic update apply deferred until runtime is idle", "version", checked.LatestVersion)
 		return checked, persistErr
 	}
 
-	applied, applyErr := s.applyLocked(ctx, releaseIdle)
-	return applied, errors.Join(persistErr, applyErr)
+	return s.applyLocked(ctx, releaseIdle)
 }
 
 func (s *Scheduler) ApplyPending(ctx context.Context) (Status, error) {
@@ -270,7 +282,7 @@ func (s *Scheduler) applyWhenIdle(ctx context.Context) (Status, error) {
 	if !s.pendingIdle() {
 		return Status{}, nil
 	}
-	if s.deferralExpired() {
+	if s.Status().Critical || s.deferralExpired() {
 		return s.drainAndApplyLocked(ctx)
 	}
 	releaseIdle, idle := s.cfg.ReserveIdle(ctx)
@@ -326,7 +338,7 @@ func (s *Scheduler) applyLocked(ctx context.Context, releaseIdle func()) (Status
 			status.LastError = strings.TrimSpace(applied.Message)
 			clearPending(status)
 		})
-		return applied, nil
+		return applied, s.persistCurrentState()
 	}
 
 	s.updateStatus(func(status *AutoStatus) {
@@ -336,20 +348,21 @@ func (s *Scheduler) applyLocked(ctx context.Context, releaseIdle func()) (Status
 		status.LastError = ""
 		clearPending(status)
 	})
+	persistErr := s.persistCurrentState()
 	restartRequested := s.cfg.RequestRestart != nil && s.cfg.RequestRestart(applied.Binary)
 	if !restartRequested {
 		s.updateStatus(func(status *AutoStatus) {
 			status.State = "applied_restart_deferred"
 		})
 		s.cfg.Logger.Warn("Detent update applied; restart deferred because shutdown is already in progress or restart is unavailable", "version", applied.LatestVersion)
-		return applied, nil
+		return applied, persistErr
 	}
 	s.updateStatus(func(status *AutoStatus) {
 		status.State = "restart_requested"
 	})
 	keepIdleReserved = true
 	s.cfg.Logger.Info("Detent update applied; graceful restart requested", "version", applied.LatestVersion)
-	return applied, nil
+	return applied, persistErr
 }
 
 func (s *Scheduler) pendingIdle() bool {
@@ -425,7 +438,15 @@ func (s *Scheduler) recordCheckFailure(checkedAt time.Time, err error) error {
 }
 
 func (s *Scheduler) persistLastCheck(checkedAt time.Time) error {
-	if err := saveSchedulerState(s.cfg.StatePath, checkedAt); err != nil {
+	status := s.Status()
+	state := schedulerState{LastCheckAt: checkedAt}
+	if status.State == "pending_idle" && status.PendingSince != nil && strings.TrimSpace(status.AvailableVersion) != "" {
+		pendingSince := *status.PendingSince
+		state.AvailableVersion = status.AvailableVersion
+		state.PendingSince = &pendingSince
+		state.Critical = status.Critical
+	}
+	if err := saveSchedulerState(s.cfg.StatePath, state); err != nil {
 		wrapped := fmt.Errorf("persist automatic update state: %w", err)
 		s.updateStatus(func(status *AutoStatus) {
 			status.LastError = wrapped.Error()
@@ -433,6 +454,14 @@ func (s *Scheduler) persistLastCheck(checkedAt time.Time) error {
 		return wrapped
 	}
 	return nil
+}
+
+func (s *Scheduler) persistCurrentState() error {
+	status := s.Status()
+	if status.LastCheckAt == nil {
+		return nil
+	}
+	return s.persistLastCheck(*status.LastCheckAt)
 }
 
 func (s *Scheduler) nextCheck() (time.Duration, time.Time) {

--- a/internal/update/scheduler_state.go
+++ b/internal/update/scheduler_state.go
@@ -13,47 +13,72 @@ import (
 const schedulerStateSchema = 1
 
 type schedulerState struct {
-	Schema      int       `json:"schema"`
-	LastCheckAt time.Time `json:"last_check_at"`
+	Schema           int        `json:"schema"`
+	LastCheckAt      time.Time  `json:"last_check_at"`
+	AvailableVersion string     `json:"available_version,omitempty"`
+	PendingSince     *time.Time `json:"pending_since,omitempty"`
+	Critical         bool       `json:"critical,omitempty"`
 }
 
-func loadSchedulerState(path string) (time.Time, bool, error) {
+func loadSchedulerState(path string) (schedulerState, bool, error) {
 	path = strings.TrimSpace(path)
 	if path == "" {
-		return time.Time{}, false, nil
+		return schedulerState{}, false, nil
 	}
 	raw, err := os.ReadFile(path)
 	if errors.Is(err, os.ErrNotExist) {
-		return time.Time{}, false, nil
+		return schedulerState{}, false, nil
 	}
 	if err != nil {
-		return time.Time{}, false, fmt.Errorf("read scheduler state: %w", err)
+		return schedulerState{}, false, fmt.Errorf("read scheduler state: %w", err)
 	}
 	var state schedulerState
 	if err := json.Unmarshal(raw, &state); err != nil {
-		return time.Time{}, false, fmt.Errorf("decode scheduler state: %w", err)
+		return schedulerState{}, false, fmt.Errorf("decode scheduler state: %w", err)
 	}
 	if state.Schema != schedulerStateSchema {
-		return time.Time{}, false, fmt.Errorf("decode scheduler state: unsupported schema %d", state.Schema)
+		return schedulerState{}, false, fmt.Errorf("decode scheduler state: unsupported schema %d", state.Schema)
 	}
 	if state.LastCheckAt.IsZero() {
-		return time.Time{}, false, errors.New("decode scheduler state: last check timestamp is required")
+		return schedulerState{}, false, errors.New("decode scheduler state: last check timestamp is required")
 	}
-	return state.LastCheckAt, true, nil
+	state.AvailableVersion = strings.TrimSpace(state.AvailableVersion)
+	if state.PendingSince != nil {
+		if state.PendingSince.IsZero() || state.AvailableVersion == "" {
+			return schedulerState{}, false, errors.New("decode scheduler state: pending update requires timestamp and version")
+		}
+		pendingSince := state.PendingSince.UTC()
+		state.PendingSince = &pendingSince
+	} else {
+		state.AvailableVersion = ""
+		state.Critical = false
+	}
+	state.LastCheckAt = state.LastCheckAt.UTC()
+	return state, true, nil
 }
 
-func saveSchedulerState(path string, lastCheckAt time.Time) (saveErr error) {
+func saveSchedulerState(path string, state schedulerState) (saveErr error) {
 	path = strings.TrimSpace(path)
 	if path == "" {
 		return nil
 	}
-	if lastCheckAt.IsZero() {
+	if state.LastCheckAt.IsZero() {
 		return errors.New("save scheduler state: last check timestamp is required")
 	}
-	raw, err := json.Marshal(schedulerState{
-		Schema:      schedulerStateSchema,
-		LastCheckAt: lastCheckAt.UTC(),
-	})
+	state.Schema = schedulerStateSchema
+	state.LastCheckAt = state.LastCheckAt.UTC()
+	state.AvailableVersion = strings.TrimSpace(state.AvailableVersion)
+	if state.PendingSince != nil {
+		if state.PendingSince.IsZero() || state.AvailableVersion == "" {
+			return errors.New("save scheduler state: pending update requires timestamp and version")
+		}
+		pendingSince := state.PendingSince.UTC()
+		state.PendingSince = &pendingSince
+	} else {
+		state.AvailableVersion = ""
+		state.Critical = false
+	}
+	raw, err := json.Marshal(state)
 	if err != nil {
 		return fmt.Errorf("encode scheduler state: %w", err)
 	}

--- a/internal/update/scheduler_test.go
+++ b/internal/update/scheduler_test.go
@@ -139,6 +139,7 @@ func TestSchedulerAutoApplyBehavior(t *testing.T) {
 				ReserveIdle: func(context.Context) (func(), bool) {
 					return func() { releaseCalls++ }, true
 				},
+				ReserveDrain: schedulerDrainReservation,
 				RequestRestart: func(binary string) bool {
 					restartCalls++
 					if binary != "/opt/detent/bin/detent" {
@@ -204,6 +205,7 @@ func TestSchedulerDefersAutoApplyUntilIdle(t *testing.T) {
 			reservationHeld = true
 			return func() { reservationHeld = false }, true
 		},
+		ReserveDrain: schedulerDrainReservation,
 		RequestRestart: func(string) bool {
 			if !reservationHeld {
 				t.Error("idle reservation released before restart request")
@@ -248,6 +250,97 @@ func TestSchedulerDefersAutoApplyUntilIdle(t *testing.T) {
 	}
 }
 
+func TestSchedulerDrainPolicy(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name              string
+		critical          bool
+		advance           time.Duration
+		wantPendingBefore bool
+		wantIdleCalls     int
+	}{
+		{name: "busy runtime force drains at cap", advance: 2 * time.Hour, wantPendingBefore: true, wantIdleCalls: 1},
+		{name: "critical release drains immediately", critical: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			now := time.Date(2026, 8, 20, 10, 0, 0, 0, time.UTC)
+			updater := &schedulerUpdaterStub{
+				checkStatus: Status{
+					CurrentVersion:  "1.2.3",
+					LatestVersion:   "1.2.4",
+					UpdateAvailable: true,
+					InstallSource:   InstallSourceRelease,
+					Action:          ActionAvailable,
+					Critical:        tt.critical,
+				},
+				applyStatus: Status{
+					LatestVersion: "1.2.4",
+					Action:        ActionUpdated,
+					Binary:        "/opt/detent/bin/detent",
+				},
+			}
+			idleCalls := 0
+			drainCalls := 0
+			drainReserved := false
+			scheduler, err := NewScheduler(SchedulerConfig{
+				Enabled:          true,
+				AutoApplyEnabled: true,
+				CheckInterval:    time.Hour,
+				MaxDeferral:      2 * time.Hour,
+				Updater:          updater,
+				Now:              func() time.Time { return now },
+				ReserveIdle: func(context.Context) (func(), bool) {
+					idleCalls++
+					return nil, false
+				},
+				ReserveDrain: func(context.Context) (func(), error) {
+					drainCalls++
+					drainReserved = true
+					return func() { drainReserved = false }, nil
+				},
+				RequestRestart: func(string) bool {
+					if !drainReserved {
+						t.Error("restart requested before runtime drain reservation")
+					}
+					return true
+				},
+			})
+			if err != nil {
+				t.Fatalf("NewScheduler() error = %v", err)
+			}
+
+			if _, err := scheduler.CheckNow(context.Background()); err != nil {
+				t.Fatalf("CheckNow() error = %v", err)
+			}
+			if tt.wantPendingBefore {
+				status := scheduler.Status()
+				if status.State != "pending_idle" || status.PendingSince == nil || !status.PendingSince.Equal(now) {
+					t.Fatalf("Status() before cap = %#v, want pending since %s", status, now)
+				}
+				now = now.Add(tt.advance)
+				if _, err := scheduler.applyWhenIdle(context.Background()); err != nil {
+					t.Fatalf("applyWhenIdle() error = %v", err)
+				}
+			}
+
+			if idleCalls != tt.wantIdleCalls || drainCalls != 1 || updater.applyCalls != 1 {
+				t.Fatalf("calls: Idle=%d Drain=%d Apply=%d, want %d/1/1", idleCalls, drainCalls, updater.applyCalls, tt.wantIdleCalls)
+			}
+			if got := scheduler.Status(); got.State != "restart_requested" || got.PendingSince != nil || got.Critical {
+				t.Fatalf("Status() = %#v, want cleared restart request", got)
+			}
+			if !drainReserved {
+				t.Fatal("drain reservation released before restart owns dispatch")
+			}
+		})
+	}
+}
+
 func TestSchedulerApplyPendingBypassesIdleWait(t *testing.T) {
 	t.Parallel()
 
@@ -273,6 +366,7 @@ func TestSchedulerApplyPendingBypassesIdleWait(t *testing.T) {
 		ReserveIdle: func(context.Context) (func(), bool) {
 			return nil, false
 		},
+		ReserveDrain:   schedulerDrainReservation,
 		RequestRestart: func(string) bool { return true },
 	})
 	if err != nil {
@@ -315,6 +409,7 @@ func TestSchedulerReleasesIdleReservationWhenApplyFails(t *testing.T) {
 		ReserveIdle: func(context.Context) (func(), bool) {
 			return func() { releaseCalls++ }, true
 		},
+		ReserveDrain: schedulerDrainReservation,
 	})
 	if err != nil {
 		t.Fatalf("NewScheduler() error = %v", err)
@@ -339,6 +434,23 @@ func TestSchedulerAutoApplyRequiresIdleReservation(t *testing.T) {
 	})
 	if err == nil || !strings.Contains(err.Error(), "idle reservation") {
 		t.Fatalf("NewScheduler() error = %v, want idle reservation requirement", err)
+	}
+}
+
+func TestSchedulerAutoApplyRequiresDrainReservation(t *testing.T) {
+	t.Parallel()
+
+	_, err := NewScheduler(SchedulerConfig{
+		Enabled:          true,
+		AutoApplyEnabled: true,
+		CheckInterval:    time.Hour,
+		Updater:          &schedulerUpdaterStub{},
+		ReserveIdle: func(context.Context) (func(), bool) {
+			return nil, false
+		},
+	})
+	if err == nil || !strings.Contains(err.Error(), "drain reservation") {
+		t.Fatalf("NewScheduler() error = %v, want drain reservation requirement", err)
 	}
 }
 
@@ -367,6 +479,7 @@ func TestSchedulerRunPollsPendingUpdateUntilIdle(t *testing.T) {
 		ReserveIdle: func(context.Context) (func(), bool) {
 			return func() {}, idle
 		},
+		ReserveDrain:   schedulerDrainReservation,
 		RequestRestart: func(string) bool { return true },
 		NextDelay:      func(interval time.Duration) time.Duration { return interval },
 		Now: func() time.Time {
@@ -396,6 +509,53 @@ func TestSchedulerRunPollsPendingUpdateUntilIdle(t *testing.T) {
 	}
 	if len(delays) != 3 || delays[0] != time.Hour || delays[1] != 2*time.Second || delays[2] != time.Hour {
 		t.Fatalf("wait delays = %v, want [1h 2s 1h]", delays)
+	}
+}
+
+func TestSchedulerRunChecksOnIntervalWhilePendingIdle(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	now := time.Date(2026, 8, 20, 10, 0, 0, 0, time.UTC)
+	updater := &schedulerUpdaterStub{
+		checkStatus: Status{
+			CurrentVersion:  "1.2.3",
+			LatestVersion:   "1.2.4",
+			UpdateAvailable: true,
+			Action:          ActionAvailable,
+			InstallSource:   InstallSourceRelease,
+		},
+	}
+	waits := 0
+	scheduler, err := NewScheduler(SchedulerConfig{
+		Enabled:          true,
+		AutoApplyEnabled: true,
+		CheckInterval:    time.Hour,
+		IdlePollInterval: 30 * time.Minute,
+		Updater:          updater,
+		ReserveIdle: func(context.Context) (func(), bool) {
+			return nil, false
+		},
+		ReserveDrain: schedulerDrainReservation,
+		Now:          func() time.Time { return now },
+		NextDelay:    func(interval time.Duration) time.Duration { return interval },
+		Wait: func(_ context.Context, delay time.Duration) bool {
+			now = now.Add(delay)
+			waits++
+			if waits == 4 {
+				cancel()
+				return false
+			}
+			return true
+		},
+	})
+	if err != nil {
+		t.Fatalf("NewScheduler() error = %v", err)
+	}
+
+	scheduler.Run(ctx)
+	if updater.checkCalls != 2 {
+		t.Fatalf("Check() calls = %d, want 2 while runtime remains busy", updater.checkCalls)
 	}
 }
 
@@ -754,4 +914,8 @@ func (s *schedulerUpdaterStub) Apply(context.Context, ApplyOptions) (Status, err
 	defer s.mu.Unlock()
 	s.applyCalls++
 	return s.applyStatus, s.applyErr
+}
+
+func schedulerDrainReservation(context.Context) (func(), error) {
+	return func() {}, nil
 }

--- a/internal/update/scheduler_test.go
+++ b/internal/update/scheduler_test.go
@@ -695,6 +695,102 @@ func TestSchedulerRestartAfterIntervalChecksBeforeWaiting(t *testing.T) {
 	}
 }
 
+func TestSchedulerRestartPreservesPendingDeferral(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name             string
+		critical         bool
+		initialDrainFail bool
+		restartAdvance   time.Duration
+		wantIdleCalls    int
+	}{
+		{name: "busy runtime keeps original deadline", restartAdvance: 2 * time.Hour},
+		{name: "critical release retries drain immediately", critical: true, initialDrainFail: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			statePath := filepath.Join(t.TempDir(), "update-state.json")
+			pendingSince := time.Date(2026, 8, 20, 10, 0, 0, 0, time.UTC)
+			now := pendingSince
+			initialUpdater := &schedulerUpdaterStub{checkStatus: Status{
+				CurrentVersion:  "1.2.3",
+				LatestVersion:   "1.2.4",
+				UpdateAvailable: true,
+				InstallSource:   InstallSourceRelease,
+				Critical:        tt.critical,
+			}}
+			initial, err := NewScheduler(SchedulerConfig{
+				Enabled:          true,
+				AutoApplyEnabled: true,
+				CheckInterval:    time.Hour,
+				MaxDeferral:      2 * time.Hour,
+				StatePath:        statePath,
+				Updater:          initialUpdater,
+				Now:              func() time.Time { return now },
+				ReserveIdle:      func(context.Context) (func(), bool) { return nil, false },
+				ReserveDrain: func(context.Context) (func(), error) {
+					if tt.initialDrainFail {
+						return nil, errors.New("drain unavailable")
+					}
+					return schedulerDrainReservation(context.Background())
+				},
+			})
+			if err != nil {
+				t.Fatalf("NewScheduler() initial error = %v", err)
+			}
+			_, checkErr := initial.CheckNow(context.Background())
+			if tt.initialDrainFail && checkErr == nil {
+				t.Fatal("CheckNow() error = nil, want initial drain failure")
+			}
+			if !tt.initialDrainFail && checkErr != nil {
+				t.Fatalf("CheckNow() error = %v", checkErr)
+			}
+
+			now = pendingSince.Add(tt.restartAdvance)
+			idleCalls := 0
+			drainCalls := 0
+			updater := &schedulerUpdaterStub{applyStatus: Status{
+				LatestVersion: "1.2.4",
+				Action:        ActionUpdated,
+			}}
+			restarted, err := NewScheduler(SchedulerConfig{
+				Enabled:          true,
+				AutoApplyEnabled: true,
+				CheckInterval:    time.Hour,
+				MaxDeferral:      2 * time.Hour,
+				StatePath:        statePath,
+				Updater:          updater,
+				Now:              func() time.Time { return now },
+				ReserveIdle: func(context.Context) (func(), bool) {
+					idleCalls++
+					return nil, false
+				},
+				ReserveDrain: func(context.Context) (func(), error) {
+					drainCalls++
+					return func() {}, nil
+				},
+			})
+			if err != nil {
+				t.Fatalf("NewScheduler() restart error = %v", err)
+			}
+			status := restarted.Status()
+			if status.State != "pending_idle" || status.AvailableVersion != "1.2.4" || status.PendingSince == nil || !status.PendingSince.Equal(pendingSince) || status.Critical != tt.critical {
+				t.Fatalf("Status() = %#v, want restored pending release", status)
+			}
+			if _, err := restarted.applyWhenIdle(context.Background()); err != nil {
+				t.Fatalf("applyWhenIdle() error = %v", err)
+			}
+			if idleCalls != tt.wantIdleCalls || drainCalls != 1 || updater.applyCalls != 1 {
+				t.Fatalf("calls: Idle=%d Drain=%d Apply=%d, want %d/1/1", idleCalls, drainCalls, updater.applyCalls, tt.wantIdleCalls)
+			}
+		})
+	}
+}
+
 func TestSchedulerRepeatedRapidRestartsCannotStarveCheck(t *testing.T) {
 	t.Parallel()
 

--- a/internal/update/update.go
+++ b/internal/update/update.go
@@ -80,6 +80,7 @@ type Asset struct {
 
 type Release struct {
 	TagName    string  `json:"tag_name"`
+	Body       string  `json:"body"`
 	Draft      bool    `json:"draft"`
 	Prerelease bool    `json:"prerelease"`
 	Assets     []Asset `json:"assets"`
@@ -341,6 +342,7 @@ type Status struct {
 	Command         string        `json:"command,omitempty"`
 	Binary          string        `json:"binary,omitempty"`
 	Asset           string        `json:"asset,omitempty"`
+	Critical        bool          `json:"critical,omitempty"`
 }
 
 func NewService(cfg Config) *Service {
@@ -622,6 +624,7 @@ func (s *Service) plan(ctx context.Context) (Status, Release, error) {
 
 	status.LatestTag = release.TagName
 	status.LatestVersion = displayVersion(release.TagName)
+	status.Critical = releaseCritical(release)
 	cmp, err := CompareVersions(release.TagName, s.cfg.CurrentVersion)
 	if err != nil {
 		status.Action = ActionRefused
@@ -637,6 +640,10 @@ func (s *Service) plan(ctx context.Context) (Status, Release, error) {
 		status.Message = fmt.Sprintf("Detent %s is up to date.", status.CurrentVersion)
 	}
 	return status, release, nil
+}
+
+func releaseCritical(release Release) bool {
+	return strings.Contains(strings.ToLower(release.Body), "[detent-critical]")
 }
 
 func SelectLatestRelease(current string, releases []Release) (Release, bool, error) {

--- a/internal/update/update_test.go
+++ b/internal/update/update_test.go
@@ -676,6 +676,43 @@ func TestServiceRejectsBadChecksumSignatureBeforeReplacement(t *testing.T) {
 	}
 }
 
+func TestServiceCheckReportsCriticalReleaseMarker(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		body     string
+		critical bool
+	}{
+		{name: "ordinary release", body: "Routine fixes"},
+		{name: "critical release", body: "Burn brake release\n\n[DETENT-CRITICAL]", critical: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			service := NewService(Config{
+				CurrentVersion: "1.2.3",
+				ExecutablePath: "/opt/detent/bin/detent",
+				GOOS:           "linux",
+				GOARCH:         "amd64",
+				Client: staticReleaseClient{releases: []Release{{
+					TagName: "v1.2.4",
+					Body:    tt.body,
+				}}},
+			})
+			status, err := service.Check(context.Background())
+			if err != nil {
+				t.Fatalf("Check() error = %v", err)
+			}
+			if status.Critical != tt.critical {
+				t.Fatalf("Check().Critical = %t, want %t", status.Critical, tt.critical)
+			}
+		})
+	}
+}
+
 func TestServiceGoInstallYesRunsCommandAndReportsVersion(t *testing.T) {
 	t.Parallel()
 

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -1196,6 +1196,7 @@ func (s *Server) health(c echo.Context) error {
 			status = "needs_attention"
 		}
 	}
+	updateStatus.State = updateStatus.DisplayState(now)
 	return c.JSON(http.StatusOK, healthResponse{
 		Status:                 status,
 		Version:                s.build.Version,

--- a/internal/web/server_test.go
+++ b/internal/web/server_test.go
@@ -7783,6 +7783,38 @@ func TestHealthReportsRunningBuildDistinctFromAppliedUpdate(t *testing.T) {
 	}
 }
 
+func TestHealthReportsUpdateDeferralAge(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 8, 20, 14, 0, 0, 0, time.UTC)
+	pendingSince := now.Add(-4 * time.Hour)
+	deps := testDeps(t)
+	if err := deps.Hub.Publish(telemetry.Snapshot{
+		GeneratedAt: now,
+		Update: telemetry.Update{
+			Enabled:          true,
+			AutoApplyEnabled: true,
+			State:            "pending_idle",
+			PendingSince:     &pendingSince,
+			MaxDeferralHours: 6,
+		},
+	}); err != nil {
+		t.Fatalf("Publish() error = %v", err)
+	}
+	server, err := web.NewServer(web.Config{Now: func() time.Time { return now }}, deps)
+	if err != nil {
+		t.Fatalf("NewServer() error = %v", err)
+	}
+	payload := requestJSON(t, server, http.MethodGet, "/health", http.StatusOK)
+	update, ok := payload["update"].(map[string]any)
+	if !ok {
+		t.Fatalf("update payload = %#v, want object", payload["update"])
+	}
+	if update["state"] != "pending_idle (4h, max 6h)" {
+		t.Fatalf("update state = %#v, want deferral age", update["state"])
+	}
+}
+
 func TestHealthReportsEnvironmentPath(t *testing.T) {
 	t.Parallel()
 

--- a/internal/web/templates/health_data.go
+++ b/internal/web/templates/health_data.go
@@ -280,7 +280,7 @@ func healthRows(snapshot telemetry.Snapshot) []healthRow {
 	}
 	rows = append(rows, healthRefreshRows(snapshot)...)
 	rows = append(rows, healthAdmissionProposalRows(snapshot.AdmissionProposals, snapshot.GeneratedAt)...)
-	rows = append(rows, healthSchedulerRow(snapshot), healthUpdateRow(snapshot.Update), healthBackoffRow(snapshot))
+	rows = append(rows, healthSchedulerRow(snapshot), healthUpdateRowAt(snapshot.Update, snapshot.GeneratedAt), healthBackoffRow(snapshot))
 	for _, release := range healthReleases(snapshot) {
 		rows = append(rows, healthReleaseRow(release))
 	}
@@ -736,6 +736,10 @@ func doctorStyleStalenessTarget(warning telemetry.StalenessWarning) string {
 }
 
 func healthUpdateRow(update telemetry.Update) healthRow {
+	return healthUpdateRowAt(update, time.Now())
+}
+
+func healthUpdateRowAt(update telemetry.Update, now time.Time) healthRow {
 	row := healthRow{
 		ID:        "health-update",
 		Component: "Detent update",
@@ -751,7 +755,7 @@ func healthUpdateRow(update telemetry.Update) healthRow {
 		return row
 	}
 	row.Kind = primitives.KindOK
-	row.Status = strings.ReplaceAll(strings.TrimSpace(update.State), "_", " ")
+	row.Status = strings.ReplaceAll(strings.TrimSpace(update.DisplayState(now)), "_", " ")
 	if row.Status == "" || row.Status == "scheduled" {
 		row.Status = "Scheduled"
 	}

--- a/internal/web/templates/health_data_test.go
+++ b/internal/web/templates/health_data_test.go
@@ -665,6 +665,38 @@ func TestHealthUpdateRowShowsRuntimeStatus(t *testing.T) {
 	}
 }
 
+func TestHealthUpdateRowShowsDeferralAge(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		age  time.Duration
+		want string
+	}{
+		{name: "hours", age: 4 * time.Hour, want: "pending idle (4h, max 6h)"},
+		{name: "minutes", age: 30 * time.Minute, want: "pending idle (30m, max 6h)"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			now := time.Date(2026, 8, 20, 14, 0, 0, 0, time.UTC)
+			pendingSince := now.Add(-tt.age)
+			row := healthUpdateRowAt(telemetry.Update{
+				Enabled:          true,
+				AutoApplyEnabled: true,
+				State:            "pending_idle",
+				PendingSince:     &pendingSince,
+				MaxDeferralHours: 6,
+			}, now)
+			if row.Status != tt.want {
+				t.Fatalf("healthUpdateRowAt().Status = %q, want %q", row.Status, tt.want)
+			}
+		})
+	}
+}
+
 func TestHealthExhaustedRowDetailNotHealthy(t *testing.T) {
 	snapshot := telemetry.Snapshot{
 		GeneratedAt: time.Date(2026, 7, 4, 16, 0, 0, 0, time.UTC),


### PR DESCRIPTION
## Summary

- keep release checks interval-driven while automatic apply waits for idle
- force a bounded dispatch drain after the configurable deferral cap, with critical-release bypass
- expose pending age and cap in health output and document the six-hour default

Fixes #1947

## UI Surface Contract

- [x] Issue #1947 explicitly authorizes the health status change; no layout, density, or responsive tradeoff is introduced.
- [x] This PR adds no persistent top-of-screen message.
- [x] Isolated Chrome DevTools verification against the real `/health/ui` rendered `pending idle (4h, max 6h)` cleanly; the related `/health` JSON was also inspected.

## Test Plan

- [x] `PATH="$GOBIN:$PATH" GOTOOLCHAIN=go1.26.6 make check`
- [x] Focused table-driven scheduler, drain, configuration, and health tests
- [x] Isolated browser verification on a random-port `httptest.Server`
