### PR TITLE
fix(orchestrator): clarify loop park evidence

### DIFF
--- a/internal/orchestrator/implement_progress.go
+++ b/internal/orchestrator/implement_progress.go
@@ -1062,24 +1062,28 @@ func implementProgressBlockComment(issue connector.Issue, decision implementComp
 		b.WriteString("\n- failed_checks_removed: ")
 		b.WriteString(removed)
 	}
-	b.WriteString("\n- workspace_diffstat: ")
-	if diffStatsPresent(decision.WorkspaceDiffStats) {
-		b.WriteString(strconv.Itoa(decision.WorkspaceDiffStats.FilesChanged))
-		b.WriteString(" files, +")
-		b.WriteString(strconv.Itoa(decision.WorkspaceDiffStats.AddedLines))
-		b.WriteString("/-")
-		b.WriteString(strconv.Itoa(decision.WorkspaceDiffStats.RemovedLines))
-		if status := strings.TrimSpace(decision.WorkspaceDiffStats.Status); status != "" {
-			b.WriteString(" (")
-			b.WriteString(status)
-			b.WriteString(")")
-		}
+	if blockReason == dispatchLoopDetectedReason {
+		appendDispatchLoopWorkspaceEvidence(&b, decision)
 	} else {
-		b.WriteString("unavailable")
-	}
-	if decision.WorkspaceDiffStats.UnpushedCommits > 0 {
-		b.WriteString("\n- unpushed_commits: ")
-		b.WriteString(strconv.Itoa(decision.WorkspaceDiffStats.UnpushedCommits))
+		b.WriteString("\n- workspace_diffstat: ")
+		if diffStatsPresent(decision.WorkspaceDiffStats) {
+			b.WriteString(strconv.Itoa(decision.WorkspaceDiffStats.FilesChanged))
+			b.WriteString(" files, +")
+			b.WriteString(strconv.Itoa(decision.WorkspaceDiffStats.AddedLines))
+			b.WriteString("/-")
+			b.WriteString(strconv.Itoa(decision.WorkspaceDiffStats.RemovedLines))
+			if status := strings.TrimSpace(decision.WorkspaceDiffStats.Status); status != "" {
+				b.WriteString(" (")
+				b.WriteString(status)
+				b.WriteString(")")
+			}
+		} else {
+			b.WriteString("unavailable")
+		}
+		if decision.WorkspaceDiffStats.UnpushedCommits > 0 {
+			b.WriteString("\n- unpushed_commits: ")
+			b.WriteString(strconv.Itoa(decision.WorkspaceDiffStats.UnpushedCommits))
+		}
 	}
 	if humanAction := strings.TrimSpace(decision.HumanAction); humanAction != "" {
 		b.WriteString("\n\nHuman action requested by the Workpad:\n\n")
@@ -1090,4 +1094,47 @@ func implementProgressBlockComment(issue connector.Issue, decision implementComp
 		}
 	}
 	return b.String()
+}
+
+func appendDispatchLoopWorkspaceEvidence(b *strings.Builder, decision implementCompletionProgressDecision) {
+	diffStats := decision.WorkspaceDiffStats
+	b.WriteString("\n- evidence: workspace unchanged across ")
+	b.WriteString(strconv.Itoa(decision.ConsecutiveNoProgress))
+	b.WriteString(" attempts")
+	if headSHA := strings.TrimSpace(diffStats.HeadSHA); headSHA != "" {
+		b.WriteString(" — head `")
+		b.WriteString(headSHA)
+		b.WriteString("`")
+		if fingerprint := strings.TrimSpace(diffStats.Fingerprint); fingerprint != "" {
+			b.WriteString(" and diff fingerprint `")
+			b.WriteString(fingerprint)
+			b.WriteString("`")
+		}
+	} else if fingerprint := strings.TrimSpace(diffStats.Fingerprint); fingerprint != "" {
+		b.WriteString(" — diff fingerprint `")
+		b.WriteString(fingerprint)
+		b.WriteString("`")
+	}
+	b.WriteString(" identical since attempt 1")
+
+	if diffStats.FilesChanged == 0 && diffStats.AddedLines == 0 && diffStats.RemovedLines == 0 && diffStats.UnpushedCommits == 0 {
+		return
+	}
+	b.WriteString("\n- carried stale work: carrying ")
+	b.WriteString(strconv.Itoa(diffStats.FilesChanged))
+	b.WriteString(" changed file")
+	if diffStats.FilesChanged != 1 {
+		b.WriteString("s")
+	}
+	b.WriteString(" (+")
+	b.WriteString(strconv.Itoa(diffStats.AddedLines))
+	b.WriteString("/-")
+	b.WriteString(strconv.Itoa(diffStats.RemovedLines))
+	b.WriteString("), ")
+	b.WriteString(strconv.Itoa(diffStats.UnpushedCommits))
+	b.WriteString(" unpushed commit")
+	if diffStats.UnpushedCommits != 1 {
+		b.WriteString("s")
+	}
+	b.WriteString(", unchanged since attempt 1")
 }

--- a/internal/orchestrator/implement_progress.go
+++ b/internal/orchestrator/implement_progress.go
@@ -1098,6 +1098,10 @@ func implementProgressBlockComment(issue connector.Issue, decision implementComp
 
 func appendDispatchLoopWorkspaceEvidence(b *strings.Builder, decision implementCompletionProgressDecision) {
 	diffStats := decision.WorkspaceDiffStats
+	if !diffStatsPresent(diffStats) {
+		b.WriteString("\n- workspace evidence: unavailable")
+		return
+	}
 	b.WriteString("\n- evidence: workspace unchanged across ")
 	b.WriteString(strconv.Itoa(decision.ConsecutiveNoProgress))
 	b.WriteString(" attempts")

--- a/internal/orchestrator/implement_progress_test.go
+++ b/internal/orchestrator/implement_progress_test.go
@@ -1457,30 +1457,77 @@ func TestImplementProgressMergedCompletionQualification(t *testing.T) {
 	}
 }
 
-func TestImplementProgressBlockCommentIncludesBoundaryEvidence(t *testing.T) {
+func TestImplementProgressBlockComment(t *testing.T) {
 	t.Parallel()
 
-	decision := implementCompletionProgressDecision{
-		BlockReason:            workpadBlockedUnactionedReason,
-		NoProgressLimit:        3,
-		ConsecutiveNoProgress:  2,
-		ConsecutiveHumanAction: 3,
-		HumanAction:            "Approve release\nConfirm rollback",
-		CurrentSignature:       autoPromoteReworkSignature{PRNumber: 42, HeadSHA: "head", FailedChecks: []string{"test"}},
-		PreviousSignature:      autoPromoteReworkSignature{HeadSHA: "previous"},
-		FailedChecksAdded:      []string{"test"},
-		FailedChecksRemoved:    []string{"lint"},
-		WorkspaceDiffStats:     DiffStats{Status: "clean"},
+	tests := []struct {
+		name         string
+		decision     implementCompletionProgressDecision
+		wantContains []string
+		wantAbsent   []string
+	}{
+		{
+			name: "boundary evidence",
+			decision: implementCompletionProgressDecision{
+				BlockReason:            workpadBlockedUnactionedReason,
+				NoProgressLimit:        3,
+				ConsecutiveNoProgress:  2,
+				ConsecutiveHumanAction: 3,
+				HumanAction:            "Approve release\nConfirm rollback",
+				CurrentSignature:       autoPromoteReworkSignature{PRNumber: 42, HeadSHA: "head", FailedChecks: []string{"test"}},
+				PreviousSignature:      autoPromoteReworkSignature{HeadSHA: "previous"},
+				FailedChecksAdded:      []string{"test"},
+				FailedChecksRemoved:    []string{"lint"},
+				WorkspaceDiffStats:     DiffStats{Status: "clean"},
+			},
+			wantContains: []string{"workpad_blocked_unactioned", "pull/42", "head", "previous", "failed_checks_added", "0 files", "> Approve release", "> Confirm rollback"},
+		},
+		{
+			name: "dispatch loop stale carry",
+			decision: implementCompletionProgressDecision{
+				BlockReason:           dispatchLoopDetectedReason,
+				NoProgressLimit:       3,
+				ConsecutiveNoProgress: 3,
+				WorkspaceDiffStats: DiffStats{
+					FilesChanged:    1,
+					AddedLines:      1,
+					RemovedLines:    1,
+					UnpushedCommits: 2,
+					HeadSHA:         "workspace-head",
+					Fingerprint:     "diff-fingerprint",
+					Status:          "changed",
+				},
+			},
+			wantContains: []string{
+				"workspace unchanged across 3 attempts",
+				"head `workspace-head`",
+				"diff fingerprint `diff-fingerprint`",
+				"identical since attempt 1",
+				"carrying 1 changed file (+1/-1), 2 unpushed commits, unchanged since attempt 1",
+			},
+			wantAbsent: []string{"workspace_diffstat", "(changed)"},
+		},
 	}
 	issue := connector.Issue{PullRequest: &connector.PullRequest{URL: "https://github.test/pull/42"}}
-	comment := implementProgressBlockComment(issue, decision)
-	for _, want := range []string{"workpad_blocked_unactioned", "pull/42", "head", "previous", "failed_checks_added", "0 files", "> Approve release", "> Confirm rollback"} {
-		if !strings.Contains(comment, want) {
-			t.Fatalf("comment missing %q:\n%s", want, comment)
-		}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			comment := implementProgressBlockComment(issue, tt.decision)
+			for _, want := range tt.wantContains {
+				if !strings.Contains(comment, want) {
+					t.Fatalf("comment missing %q:\n%s", want, comment)
+				}
+			}
+			for _, unwanted := range tt.wantAbsent {
+				if strings.Contains(comment, unwanted) {
+					t.Fatalf("comment contains misleading evidence %q:\n%s", unwanted, comment)
+				}
+			}
+		})
 	}
-	if got := implementProgressRecoveryReason(decision); got != decision.HumanAction {
-		t.Fatalf("implementProgressRecoveryReason() = %q, want %q", got, decision.HumanAction)
+	if got := implementProgressRecoveryReason(tests[0].decision); got != tests[0].decision.HumanAction {
+		t.Fatalf("implementProgressRecoveryReason() = %q, want %q", got, tests[0].decision.HumanAction)
 	}
 }
 

--- a/internal/orchestrator/implement_progress_test.go
+++ b/internal/orchestrator/implement_progress_test.go
@@ -1507,6 +1507,16 @@ func TestImplementProgressBlockComment(t *testing.T) {
 			},
 			wantAbsent: []string{"workspace_diffstat", "(changed)"},
 		},
+		{
+			name: "dispatch loop unavailable workspace evidence",
+			decision: implementCompletionProgressDecision{
+				BlockReason:           dispatchLoopDetectedReason,
+				NoProgressLimit:       3,
+				ConsecutiveNoProgress: 3,
+			},
+			wantContains: []string{"workspace evidence: unavailable"},
+			wantAbsent:   []string{"workspace unchanged", "identical since"},
+		},
 	}
 	issue := connector.Issue{PullRequest: &connector.PullRequest{URL: "https://github.test/pull/42"}}
 	for _, tt := range tests {


### PR DESCRIPTION
## Summary

- explain loop parks using the unchanged workspace head and diff fingerprint
- label nonzero diff and unpushed counts as carried stale work
- add table-driven regression coverage for stale-carry park comments

Fixes #1953

## UI Surface Contract

- [x] N/A, or the linked issue explicitly authorizes any high-impact UI surface, layout, density, first-viewport, or responsive visibility tradeoff.
- [x] Persistent top-of-screen messaging is explicitly authorized by the issue, or this PR does not add it.
- [x] Visual changes to primary operator screens include screenshot or browser verification below. N/A: issue-comment text only.

## Test Plan

- [x] `go test ./internal/orchestrator -run "^TestImplementProgressBlockComment$" -count=1`
- [x] `go test ./internal/orchestrator -count=1`
- [x] `go test ./internal/orchestrator -run "^$" -fuzz=FuzzSafetyCriticalOrchestratorBoundaries -fuzztime=30s`
- [x] `GOTOOLCHAIN=go1.26.6 PATH="$TMPDIR/bin:$PATH" make check`