### PR TITLE
fix(recovery): rebaseline legacy parks

### DIFF
--- a/internal/orchestrator/autopromote_tick_test.go
+++ b/internal/orchestrator/autopromote_tick_test.go
@@ -6054,8 +6054,24 @@ func (r *autoPromoteWorkflowMetricsRecorder) RecordWorkflowPhaseEvent(_ context.
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
+	if event.ID <= 0 {
+		event.ID = int64(len(r.events) + 1)
+	}
 	r.events = append(r.events, event)
-	return int64(len(r.events)), nil
+	return event.ID, nil
+}
+
+func (r *autoPromoteWorkflowMetricsRecorder) UpdateWorkflowPhaseEventMetadata(_ context.Context, eventID int64, metadataJSON string) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	for index := range r.events {
+		if r.events[index].ID == eventID {
+			r.events[index].MetadataJSON = metadataJSON
+			return nil
+		}
+	}
+	return store.ErrNotFound
 }
 
 func (r *autoPromoteWorkflowMetricsRecorder) IssueWorkflowTimeline(_ context.Context, identity store.IssueIdentity) (store.WorkflowTimeline, error) {

--- a/internal/orchestrator/blocked_cause_recovery.go
+++ b/internal/orchestrator/blocked_cause_recovery.go
@@ -26,7 +26,6 @@ const (
 	blockedRecoveryPredicateOncePerFingerprint     = "once_per_fingerprint"
 	blockedRecoveryPredicateManaged                = "managed"
 	blockedCauseFingerprintVersion                 = 3
-	blockedCauseLegacyBreakerFingerprintVersion    = 2
 	workflowActionCauseBlockedRecovery             = "cause_blocked_recovery"
 	workflowActionBlockedReadyPRReconciliation     = "blocked_ready_pr_reconciliation"
 	blockedReadyPullRequestLookupAttempts          = 3
@@ -423,10 +422,17 @@ func (o *Orchestrator) recoverCauseBlockedIssue(
 		return false
 	}
 	breakerPark := breakerParkCause(park.Cause)
-	if park.CauseFingerprintVersion != blockedCauseFingerprintVersion &&
-		(!breakerPark || park.CauseFingerprintVersion != blockedCauseLegacyBreakerFingerprintVersion) {
-		o.recordBlockedRecoveryDecision(ctx, state, issue, "hold", "legacy_cause_fingerprint", &park, park.CauseFingerprint)
-		return false
+	signals := blockedCauseSignals{}
+	currentFingerprint := ""
+	if park.CauseFingerprintVersion != blockedCauseFingerprintVersion {
+		signals = o.blockedCauseSignals(ctx, issue, park.RunMode, park.TargetState, DiffStats{})
+		currentFingerprint = blockedCauseFingerprint(park.Cause, signals)
+		rebased, ok := o.rebaselineLegacyBlockedRecoveryPark(ctx, state, issue, park, signals, currentFingerprint)
+		if !ok {
+			o.recordBlockedRecoveryDecision(ctx, state, issue, "hold", "legacy_cause_fingerprint", &park, park.CauseFingerprint)
+			return false
+		}
+		park = rebased
 	}
 	if breakerPark {
 		parkedAt, found := o.currentBlockedRecoveryParkedAt(ctx, state, issue)
@@ -440,8 +446,10 @@ func (o *Orchestrator) recoverCauseBlockedIssue(
 			return false
 		}
 	}
-	signals := o.blockedCauseSignals(ctx, issue, park.RunMode, park.TargetState, DiffStats{})
-	currentFingerprint := blockedCauseFingerprint(park.Cause, signals)
+	if currentFingerprint == "" {
+		signals = o.blockedCauseSignals(ctx, issue, park.RunMode, park.TargetState, DiffStats{})
+		currentFingerprint = blockedCauseFingerprint(park.Cause, signals)
+	}
 	if park.Predicate == blockedRecoveryPredicateFingerprintChange && currentFingerprint == park.CauseFingerprint {
 		o.recordBlockedRecoveryDecision(ctx, state, issue, "hold", "cause_unchanged", &park, currentFingerprint)
 		return false
@@ -465,6 +473,71 @@ func (o *Orchestrator) recoverCauseBlockedIssue(
 	delete(state.Blocked, issue.ID)
 	o.logBlockedRecoveryDecision(issue, "transition", "recovery_predicate_satisfied", &park, currentFingerprint)
 	return true
+}
+
+func (o *Orchestrator) rebaselineLegacyBlockedRecoveryPark(
+	ctx context.Context,
+	state *State,
+	issue connector.Issue,
+	park workflowLaneBlockedRecoveryMetadata,
+	signals blockedCauseSignals,
+	fingerprint string,
+) (workflowLaneBlockedRecoveryMetadata, bool) {
+	if o == nil || o.workflowMetrics == nil || strings.TrimSpace(park.Cause) == "" || strings.TrimSpace(fingerprint) == "" {
+		return park, false
+	}
+	updater, ok := o.workflowMetrics.(WorkflowMetricsMetadataUpdater)
+	if !ok {
+		return park, false
+	}
+	entry, ok := o.latestWorkflowLaneEntry(ctx, issue)
+	if !ok ||
+		entry.Event.ID <= 0 ||
+		normalizeState(entry.Event.PhaseName) != normalizeState(blockedStatusState) ||
+		!blockedEntryMatchesCurrent(issue, entry.Event.StartedAt) ||
+		entry.Metadata.BlockedRecovery == nil ||
+		!sameBlockedRecoveryPark(*entry.Metadata.BlockedRecovery, park) {
+		return park, false
+	}
+
+	rebased := park
+	rebased.Cause = strings.TrimSpace(rebased.Cause)
+	rebased.CauseFingerprint = strings.TrimSpace(fingerprint)
+	rebased.CauseFingerprintVersion = blockedCauseFingerprintVersion
+	rebased.TargetState = blockedCauseTargetState(issue, signals, rebased.TargetState)
+	rebased.RunMode = strings.TrimSpace(rebased.RunMode)
+	rebased.IntentResumable = blockedCauseResumable(issue, signals)
+	rebased.Resumable = false
+	rebased.Reachability = ""
+	rebased.HoldReason = ""
+	rebased.OperatorRemedy = ""
+
+	metadata := entry.Metadata
+	metadata.BlockedRecovery = &rebased
+	if err := updater.UpdateWorkflowPhaseEventMetadata(ctx, entry.Event.ID, workflowLaneMetadataJSON(issue, metadata)); err != nil {
+		if o.logger != nil {
+			o.logger.Warn("legacy blocked recovery fingerprint rebaseline failed", "issue_id", issue.ID, "identifier", issue.Identifier, "error", err)
+		}
+		return park, false
+	}
+	if state != nil {
+		if blocked, found := state.Blocked[strings.TrimSpace(issue.ID)]; found {
+			blocked.Recovery = &rebased
+			state.Blocked[strings.TrimSpace(issue.ID)] = blocked
+		}
+	}
+	if o.logger != nil {
+		o.logger.Info("legacy blocked recovery fingerprint rebaselined", "issue_id", issue.ID, "identifier", issue.Identifier, "cause", rebased.Cause, "fingerprint_version", blockedCauseFingerprintVersion)
+	}
+	return rebased, true
+}
+
+func sameBlockedRecoveryPark(left workflowLaneBlockedRecoveryMetadata, right workflowLaneBlockedRecoveryMetadata) bool {
+	return strings.EqualFold(strings.TrimSpace(left.Owner), strings.TrimSpace(right.Owner)) &&
+		strings.TrimSpace(left.Cause) == strings.TrimSpace(right.Cause) &&
+		strings.TrimSpace(left.Predicate) == strings.TrimSpace(right.Predicate) &&
+		strings.TrimSpace(left.CauseFingerprint) == strings.TrimSpace(right.CauseFingerprint) &&
+		left.CauseFingerprintVersion == right.CauseFingerprintVersion
 }
 
 func (o *Orchestrator) reconcileInvalidWorkpadPark(
@@ -1029,7 +1102,7 @@ func BlockedRecoveryOperatorRemedy(issue connector.Issue, reason string) string 
 	case "fingerprint_already_consumed":
 		return "Change the blocking cause, or move the issue to a lane that starts fresh work."
 	case "legacy_cause_fingerprint":
-		return "Review the blocking cause, then move the issue to a lane that starts fresh work."
+		return "Park predates the current recovery schema; move the issue to Todo or Rework to re-evaluate it."
 	case "breaker_cooldown_active":
 		return "Detent will re-evaluate this circuit-breaker park after its cooldown expires."
 	case "breaker_cooldown_unavailable":

--- a/internal/orchestrator/blocked_cause_recovery_test.go
+++ b/internal/orchestrator/blocked_cause_recovery_test.go
@@ -1154,15 +1154,26 @@ func TestBlockedCauseFingerprintIgnoresAttemptMutatedSignals(t *testing.T) {
 	}
 }
 
-func TestCauseBlockedRecoveryHoldsLegacyFingerprint(t *testing.T) {
+func TestCauseBlockedRecoveryRebaselinesLegacyFingerprint(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name      string
-		predicate string
+		name           string
+		cause          string
+		predicate      string
+		wantTransition bool
 	}{
-		{name: "fingerprint change", predicate: blockedRecoveryPredicateFingerprintChange},
-		{name: "once per fingerprint", predicate: blockedRecoveryPredicateOncePerFingerprint},
+		{
+			name:      "fingerprint change resumes after a later cause change",
+			cause:     noProgressLimitReason,
+			predicate: blockedRecoveryPredicateFingerprintChange,
+		},
+		{
+			name:           "once per fingerprint resumes immediately",
+			cause:          strandedUnpushedWorkReason,
+			predicate:      blockedRecoveryPredicateOncePerFingerprint,
+			wantTransition: true,
+		},
 	}
 
 	for _, tt := range tests {
@@ -1172,7 +1183,7 @@ func TestCauseBlockedRecoveryHoldsLegacyFingerprint(t *testing.T) {
 			metrics := &autoPromoteWorkflowMetricsRecorder{}
 			parkOrch := blockedCauseTestOrchestrator(&dependencyAutoUnblockConnector{})
 			parkOrch.recoveryInspector = staticBlockedRecoveryInspector{snapshot: runpkg.BlockedRecoverySnapshot{ConfigFingerprint: "config-old", Health: "ready"}}
-			metadata := parkOrch.newBlockedRecoveryMetadata(t.Context(), issue, RunModeImplement, noProgressLimitReason, tt.predicate, "Todo", DiffStats{})
+			metadata := parkOrch.newBlockedRecoveryMetadata(t.Context(), issue, RunModeImplement, tt.cause, tt.predicate, "Todo", DiffStats{})
 			metadata.BlockedRecovery.CauseFingerprint = "legacy-fingerprint"
 			metadata.BlockedRecovery.CauseFingerprintVersion = 0
 			parkedAt := time.Date(2026, 8, 13, 18, 0, 0, 0, time.UTC)
@@ -1190,17 +1201,180 @@ func TestCauseBlockedRecoveryHoldsLegacyFingerprint(t *testing.T) {
 				Recovery:  metadata.BlockedRecovery,
 			}
 
-			transitioned := orch.recoverBlockedIssues(t.Context(), &state, []connector.Issue{issue}, parkedAt.Add(time.Minute))
+			recoveryAt := parkedAt.Add(defaultBreakerParkCooldown)
+			transitioned := orch.recoverBlockedIssues(t.Context(), &state, []connector.Issue{issue}, recoveryAt)
 
-			if len(tracker.updates) != 0 || len(transitioned) != 0 {
-				t.Fatalf("updates = %#v, transitioned = %#v, want legacy fingerprint held", tracker.updates, transitioned)
+			wantUpdates := 0
+			if tt.wantTransition {
+				wantUpdates = 1
+			}
+			if got := len(tracker.updates); got != wantUpdates {
+				t.Fatalf("updates = %#v, want transition %t", tracker.updates, tt.wantTransition)
+			}
+			if _, ok := transitioned[issue.ID]; ok != tt.wantTransition {
+				t.Fatalf("transitioned[%q] present = %t, want %t", issue.ID, ok, tt.wantTransition)
+			}
+			currentFingerprint := blockedCauseFingerprint(tt.cause, orch.blockedCauseSignals(t.Context(), issue, RunModeImplement, metadata.BlockedRecovery.TargetState, DiffStats{}))
+			if !workflowTimelineHasCurrentFingerprint(t, metrics, issue, currentFingerprint) {
+				t.Fatalf("workflow timeline does not contain current fingerprint %q", currentFingerprint)
+			}
+			if got := blockedLaneEntryCount(metrics.snapshot(), issue.ID); got != 1 {
+				t.Fatalf("Blocked lane entries = %d, want legacy park updated in place", got)
+			}
+			if tt.wantTransition {
+				return
 			}
 			blocked := state.Blocked[issue.ID]
-			if blocked.RecoveryAction != "hold" || blocked.RecoveryReason != "legacy_cause_fingerprint" || !blocked.NeedsHumanAttention {
-				t.Fatalf("blocked recovery = %#v, want visible legacy-fingerprint hold", blocked)
+			if blocked.RecoveryAction != "hold" || blocked.RecoveryReason != "cause_unchanged" || !blocked.NeedsHumanAttention || blocked.Recovery == nil {
+				t.Fatalf("blocked recovery = %#v, want current-schema cause hold", blocked)
+			}
+			if blocked.Recovery.CauseFingerprintVersion != blockedCauseFingerprintVersion || blocked.Recovery.CauseFingerprint != currentFingerprint {
+				t.Fatalf("recovery metadata = %#v, want version %d fingerprint %q", blocked.Recovery, blockedCauseFingerprintVersion, currentFingerprint)
+			}
+
+			restartedTracker := &dependencyAutoUnblockConnector{}
+			restarted := blockedCauseTestOrchestrator(restartedTracker)
+			restarted.workflowMetrics = metrics
+			restarted.recoveryInspector = staticBlockedRecoveryInspector{snapshot: runpkg.BlockedRecoverySnapshot{ConfigFingerprint: "config-newer", Health: "ready"}}
+			restartedState := newState(restarted.cfg)
+			restarted.recoverBlockedIssues(t.Context(), &restartedState, []connector.Issue{issue}, recoveryAt.Add(time.Minute))
+			if len(restartedTracker.updates) != 1 || restartedTracker.updates[0].state != "Todo" {
+				t.Fatalf("restart updates = %#v, want Todo after current-schema cause change", restartedTracker.updates)
 			}
 		})
 	}
+}
+
+func TestCauseBlockedRecoveryLegacyFingerprintUnsafeRemedy(t *testing.T) {
+	t.Parallel()
+
+	issue := dependencyAutoUnblockIssue("issue-legacy-unsafe", blockedStatusState)
+	parkedAt := time.Date(2026, 8, 13, 18, 0, 0, 0, time.UTC)
+	legacy := &workflowLaneBlockedRecoveryMetadata{
+		Owner:                   blockedRecoveryOwnerOrchestrator,
+		Cause:                   noProgressLimitReason,
+		Predicate:               blockedRecoveryPredicateFingerprintChange,
+		CauseFingerprint:        "legacy-fingerprint",
+		CauseFingerprintVersion: 0,
+		TargetState:             "Todo",
+		RunMode:                 RunModeImplement,
+	}
+	orch := blockedCauseTestOrchestrator(&dependencyAutoUnblockConnector{})
+	orch.recoveryInspector = staticBlockedRecoveryInspector{snapshot: runpkg.BlockedRecoverySnapshot{ConfigFingerprint: "config-new", Health: "ready"}}
+	state := newState(orch.cfg)
+	state.Blocked[issue.ID] = Blocked{Issue: issue, Source: BlockedSourceProjectStatus, BlockedAt: parkedAt, Recovery: legacy}
+
+	orch.recoverBlockedIssues(t.Context(), &state, []connector.Issue{issue}, parkedAt.Add(defaultBreakerParkCooldown))
+
+	blocked := state.Blocked[issue.ID]
+	if blocked.RecoveryAction != "hold" || blocked.RecoveryReason != "legacy_cause_fingerprint" || !blocked.NeedsHumanAttention {
+		t.Fatalf("blocked recovery = %#v, want unsafe legacy hold", blocked)
+	}
+	wantRemedy := "Park predates the current recovery schema; move the issue to Todo or Rework to re-evaluate it."
+	if blocked.RecoveryRemedy != wantRemedy {
+		t.Fatalf("recovery remedy = %q, want %q", blocked.RecoveryRemedy, wantRemedy)
+	}
+}
+
+func TestCauseBlockedRecoveryUpgradeSweepRebaselinesLegacyBacklog(t *testing.T) {
+	t.Parallel()
+
+	projects := []struct {
+		name  string
+		count int
+	}{
+		{name: "digitaldrywood-video", count: 6},
+		{name: "ghostreel", count: 2},
+		{name: "creswoodcornersarmory", count: 1},
+	}
+	metrics := &autoPromoteWorkflowMetricsRecorder{}
+	issues := make([]connector.Issue, 0, 9)
+	state := newState(blockedCauseTestOrchestrator(&dependencyAutoUnblockConnector{}).cfg)
+	parkedAt := time.Date(2026, 8, 13, 18, 0, 0, 0, time.UTC)
+	for _, project := range projects {
+		for index := range project.count {
+			issue := dependencyAutoUnblockIssue(fmt.Sprintf("%s-legacy-%d", project.name, index+1), blockedStatusState)
+			metadata := workflowLaneMetadata{BlockedRecovery: &workflowLaneBlockedRecoveryMetadata{
+				Owner:                   blockedRecoveryOwnerOrchestrator,
+				Cause:                   noProgressLimitReason,
+				Predicate:               blockedRecoveryPredicateFingerprintChange,
+				CauseFingerprint:        "legacy-fingerprint",
+				CauseFingerprintVersion: index % blockedCauseFingerprintVersion,
+				TargetState:             "Todo",
+				RunMode:                 RunModeImplement,
+			}}
+			recordBlockedCausePark(t, metrics, issue, parkedAt, metadata)
+			state.Blocked[issue.ID] = Blocked{Issue: issue, Source: BlockedSourceProjectStatus, BlockedAt: parkedAt, Recovery: metadata.BlockedRecovery}
+			issues = append(issues, issue)
+		}
+	}
+
+	orch := blockedCauseTestOrchestrator(&dependencyAutoUnblockConnector{})
+	orch.workflowMetrics = metrics
+	orch.recoveryInspector = staticBlockedRecoveryInspector{snapshot: runpkg.BlockedRecoverySnapshot{ConfigFingerprint: "config-current", Health: "ready"}}
+	orch.recoverBlockedIssues(t.Context(), &state, issues, parkedAt.Add(time.Minute))
+
+	if len(state.Blocked) != 9 {
+		t.Fatalf("blocked backlog size = %d, want 9 live parks", len(state.Blocked))
+	}
+	for _, issue := range issues {
+		blocked := state.Blocked[issue.ID]
+		if blocked.RecoveryReason == "legacy_cause_fingerprint" || blocked.Recovery == nil || blocked.Recovery.CauseFingerprintVersion != blockedCauseFingerprintVersion {
+			t.Fatalf("Blocked[%q] = %#v, want current-schema recovery", issue.ID, blocked)
+		}
+	}
+	eventCount := len(metrics.snapshot())
+	if eventCount != len(issues) {
+		t.Fatalf("workflow events after upgrade sweep = %d, want %d parks updated in place", eventCount, len(issues))
+	}
+	restarted := blockedCauseTestOrchestrator(&dependencyAutoUnblockConnector{})
+	restarted.workflowMetrics = metrics
+	restarted.recoveryInspector = orch.recoveryInspector
+	restartedState := newState(restarted.cfg)
+	restarted.recoverBlockedIssues(t.Context(), &restartedState, issues, parkedAt.Add(2*time.Minute))
+	if got := len(metrics.snapshot()); got != eventCount {
+		t.Fatalf("workflow events after restart = %d, want one-pass count %d", got, eventCount)
+	}
+	for _, issue := range issues {
+		blocked := restartedState.Blocked[issue.ID]
+		if blocked.RecoveryReason == "legacy_cause_fingerprint" || blocked.Recovery == nil || blocked.Recovery.CauseFingerprintVersion != blockedCauseFingerprintVersion {
+			t.Fatalf("restarted Blocked[%q] = %#v, want durable current-schema recovery", issue.ID, blocked)
+		}
+	}
+}
+
+func blockedLaneEntryCount(events []store.WorkflowPhaseEvent, issueID string) int {
+	count := 0
+	for _, event := range events {
+		if event.IssueID == issueID && event.PhaseType == store.WorkflowPhaseTypeLane &&
+			normalizeState(event.PhaseName) == normalizeState(blockedStatusState) &&
+			strings.EqualFold(strings.TrimSpace(event.Status), "entered") {
+			count++
+		}
+	}
+	return count
+}
+
+func workflowTimelineHasCurrentFingerprint(
+	t *testing.T,
+	metrics *autoPromoteWorkflowMetricsRecorder,
+	issue connector.Issue,
+	fingerprint string,
+) bool {
+	t.Helper()
+	timeline, err := metrics.IssueWorkflowTimeline(t.Context(), store.IssueIdentity{ProjectID: defaultWorkflowMetricsProjectID, IssueID: issue.ID})
+	if err != nil {
+		t.Fatalf("IssueWorkflowTimeline() error = %v", err)
+	}
+	for _, event := range timeline.Events {
+		metadata, ok := workflowLaneMetadataFromJSON(event.MetadataJSON)
+		if ok && metadata.BlockedRecovery != nil &&
+			metadata.BlockedRecovery.CauseFingerprintVersion == blockedCauseFingerprintVersion &&
+			metadata.BlockedRecovery.CauseFingerprint == fingerprint {
+			return true
+		}
+	}
+	return false
 }
 
 func TestBlockedRecoveryMetadataSeparatesIntentFromReachability(t *testing.T) {

--- a/internal/orchestrator/workflow_metrics.go
+++ b/internal/orchestrator/workflow_metrics.go
@@ -31,6 +31,10 @@ type WorkflowMetricsTimelineReader interface {
 	IssueWorkflowTimeline(context.Context, store.IssueIdentity) (store.WorkflowTimeline, error)
 }
 
+type WorkflowMetricsMetadataUpdater interface {
+	UpdateWorkflowPhaseEventMetadata(context.Context, int64, string) error
+}
+
 type workflowLaneMetadata struct {
 	PullRequest           *workflowLanePullRequestMetadata           `json:"pull_request,omitempty"`
 	DependencyAutoUnblock *workflowLaneDependencyAutoUnblockMetadata `json:"dependency_auto_unblock,omitempty"`

--- a/internal/store/metrics.go
+++ b/internal/store/metrics.go
@@ -79,6 +79,31 @@ func (s *sqliteStore) RecordWorkflowPhaseEvent(ctx context.Context, attrs Workfl
 	return event.ID, nil
 }
 
+func (s *sqliteStore) UpdateWorkflowPhaseEventMetadata(ctx context.Context, eventID int64, metadataJSON string) error {
+	if eventID <= 0 {
+		return errors.New("workflow phase event id is required")
+	}
+	metadataJSON = strings.TrimSpace(metadataJSON)
+	if metadataJSON == "" {
+		metadataJSON = "{}"
+	}
+	result, err := s.db.ExecContext(ctx, `
+UPDATE workflow_phase_events
+SET metadata_json = ?
+WHERE id = ?`, metadataJSON, eventID)
+	if err != nil {
+		return fmt.Errorf("updating workflow phase event metadata: %w", err)
+	}
+	updated, err := result.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("reading updated workflow phase event count: %w", err)
+	}
+	if updated == 0 {
+		return ErrNotFound
+	}
+	return nil
+}
+
 func (s *sqliteStore) ProvenanceAttributionTrustBoundary(ctx context.Context) (time.Time, error) {
 	value, err := s.queries.ProvenanceAttributionTrustBoundary(ctx)
 	if err != nil {

--- a/internal/store/park_summary_test.go
+++ b/internal/store/park_summary_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"path/filepath"
 	"reflect"
+	"strings"
 	"testing"
 	"time"
 )
@@ -69,6 +70,46 @@ func TestParkDefinition(t *testing.T) {
 				t.Fatalf("Causes = %#v, want one %q", summary.Causes, tt.wantCause)
 			}
 		})
+	}
+}
+
+func TestWorkflowPhaseMetadataUpdatePreservesParkCount(t *testing.T) {
+	t.Parallel()
+
+	db := openParkTestStore(t, filepath.Join(t.TempDir(), "detent.db"))
+	at := time.Date(2026, 8, 12, 17, 34, 57, 0, time.UTC)
+	eventID, err := db.RecordWorkflowPhaseEvent(t.Context(), WorkflowPhaseEvent{
+		ProjectID:    "detent",
+		IssueID:      "issue-6",
+		Identifier:   "digitaldrywood/detent.build#6",
+		IssueURL:     "https://github.com/digitaldrywood/detent.build/issues/6",
+		PhaseType:    WorkflowPhaseTypeLane,
+		PhaseName:    "Blocked",
+		Reason:       "no_progress_limit",
+		Status:       "entered",
+		StartedAt:    at,
+		MetadataJSON: `{"blocked_recovery":{"owner":"orchestrator","cause":"no_progress_limit","cause_fingerprint":"legacy"}}`,
+	})
+	if err != nil {
+		t.Fatalf("RecordWorkflowPhaseEvent() error = %v", err)
+	}
+	if err := db.UpdateWorkflowPhaseEventMetadata(t.Context(), eventID, `{"blocked_recovery":{"owner":"orchestrator","cause":"no_progress_limit","cause_fingerprint":"current","cause_fingerprint_version":2}}`); err != nil {
+		t.Fatalf("UpdateWorkflowPhaseEventMetadata() error = %v", err)
+	}
+
+	summary, err := db.IssueParkSummary(t.Context(), parkTestIdentity())
+	if err != nil {
+		t.Fatalf("IssueParkSummary() error = %v", err)
+	}
+	if summary.ParkCount != 1 || len(summary.Causes) != 1 || summary.Causes[0].Count != 1 {
+		t.Fatalf("park summary = %#v, want one migrated park", summary)
+	}
+	timeline, err := db.IssueWorkflowTimeline(t.Context(), parkTestIdentity())
+	if err != nil {
+		t.Fatalf("IssueWorkflowTimeline() error = %v", err)
+	}
+	if len(timeline.Events) != 1 || !strings.Contains(timeline.Events[0].MetadataJSON, `"cause_fingerprint":"current"`) {
+		t.Fatalf("workflow timeline = %#v, want one event with current metadata", timeline.Events)
 	}
 }
 


### PR DESCRIPTION
## Summary

- Re-baseline legacy recovery parks onto the current fingerprint schema without resetting their Blocked age or breaker cooldown.
- Continue ordinary fingerprint reconciliation after migration and retain an explicit Todo/Rework remedy when durable re-baselining is unsafe.
- Cover both recovery predicates, restart durability, migration idempotence, and the recorded nine-item backlog distribution.

Fixes #1955

## UI Surface Contract

- [x] N/A, or the linked issue explicitly authorizes any high-impact UI surface, layout, density, first-viewport, or responsive visibility tradeoff.
- [x] Persistent top-of-screen messaging is explicitly authorized by the issue, or this PR does not add it.
- [x] Visual changes to primary operator screens include screenshot or browser verification below.

No visual surface changed; the existing recovery badge/remedy data now reports the explicit legacy-schema operator action only when migration cannot be persisted safely.

## Test Plan

- [x] `make check`
- [x] Focused legacy recovery regression tests
- [x] Full orchestrator package tests
