### PR TITLE
fix(config): resolve admission effort source

### DIFF
--- a/config.reference.yaml
+++ b/config.reference.yaml
@@ -1147,6 +1147,8 @@
 #   criteria_section: null
 #   # backlog_admission.require_effort | type: boolean | default: false | required: No | validation: None
 #   require_effort: false
+#   # backlog_admission.effort_file | type: string | default: "WORKFLOW.md" | required: No | validation: must be WORKFLOW.md or AGENTS.md
+#   effort_file: "WORKFLOW.md"
 #   # backlog_admission.effort_section | type: string | default: none | required: Conditional | validation: is required when require_effort is true
 #   effort_section: null
 #   # backlog_admission.exclude_labels | type: list<string> | default: [] | required: No | validation: None

--- a/docs/ONBOARDING.md
+++ b/docs/ONBOARDING.md
@@ -1224,8 +1224,13 @@ probes.
    Gates`, and sets `criteria_section` to the exact heading. It writes no
    admission heading or dangling `criteria_section` key when admission is off.
    It always creates or appends the operator-approved four-tier rubric in
-   `AGENTS.md`, without replacing existing content, and leaves `model` unset.
-   The four admission run ceilings are always written explicitly.
+   `AGENTS.md`, replacing an incomplete matching section while preserving
+   complete existing guidance and unrelated content, and leaves `model` unset.
+   When admission is enabled, it also sets
+   `require_effort: true`, `effort_file: AGENTS.md`, and `effort_section` to
+   that exact generated heading. The builder resolves both named sections from
+   their configured files before it writes any proposal. The four admission
+   run ceilings are always written explicitly.
 
 7. **Kanban interaction.** Ask this only for Custom/advanced. If the operator
    wants to override a selected profile's `KANBAN_MODE`, switch to
@@ -2889,6 +2894,12 @@ awk 'NF {last=$0} END {exit last == "MUTATION_CONFIRMED=true" ? 0 : 1}' "$ONBOAR
      rg -Fx "## $CRITERIA_SECTION" <source-root>/WORKFLOW.md
      rg -n '^### (Alignment|Readiness|Size|Safety Gates)$' \
        <source-root>/WORKFLOW.md
+     rg -q '^[[:space:]]*require_effort:[[:space:]]*true$' \
+       <source-root>/detent.yaml
+     rg -q '^[[:space:]]*effort_file:[[:space:]]*AGENTS.md$' \
+       <source-root>/detent.yaml
+     rg -q '^[[:space:]]*effort_section:[[:space:]]*Issue effort selection$' \
+       <source-root>/detent.yaml
    else
      ! rg -q '^[[:space:]]*criteria_section:' <source-root>/detent.yaml
    fi
@@ -3485,7 +3496,7 @@ the card instead of auto-resolving it.
 | Backlog admission ceilings | `BACKLOG_ADMISSION_MAX_CANDIDATES_PER_RUN`, `BACKLOG_ADMISSION_MAX_PROPOSALS_PER_RUN`, `BACKLOG_ADMISSION_MAX_OPEN_PROPOSALS`, and `BACKLOG_ADMISSION_PROPOSAL_EXPIRY_DAYS` map to the same-named lower-case `backlog_admission` keys. |
 | Backlog auto-admission | `BACKLOG_ADMISSION_AUTO_ADMIT` and `BACKLOG_ADMISSION_AUTO_ADMIT_MIN_CONFIDENCE` map to `backlog_admission.auto_admit` and `auto_admit_min_confidence`; `BACKLOG_ADMISSION_AUTHORS_ALLOW_ASSOCIATION` maps to the trusted `backlog_admission.authors.allow_association` scopes. |
 | Admission criteria prose | `ADMISSION_ALIGNMENT_CRITERIA`, `ADMISSION_READINESS_CRITERIA`, `ADMISSION_SIZE_CRITERIA`, and `ADMISSION_SAFETY_GATES` generate the matching `WORKFLOW.md` subsections when admission is enabled. |
-| Issue effort rubric | `EFFORT_MEDIUM_CRITERIA`, `EFFORT_HIGH_CRITERIA`, `EFFORT_XHIGH_CRITERIA`, and `EFFORT_MAX_CRITERIA` generate the four-tier `detent-agent` rubric in `AGENTS.md`; `model` remains unset. |
+| Issue effort rubric | `EFFORT_MEDIUM_CRITERIA`, `EFFORT_HIGH_CRITERIA`, `EFFORT_XHIGH_CRITERIA`, and `EFFORT_MAX_CRITERIA` generate the four-tier `detent-agent` rubric in `AGENTS.md`; enabled admission points `effort_file` and `effort_section` at that rubric, and `model` remains unset. |
 | Scheduled repository routine | `ROUTINES_ENABLED`, `ROUTINE_NAME`, `ROUTINE_SCHEDULE`, and `ROUTINE_PROMPT` control the generated `routines` entry. |
 | Built-in stale-TODO intake | `STALE_TODOS_ENABLED` and `STALE_TODOS_SCHEDULE` control the generated scheduled `intake.sources` scanner. |
 | Prompt body | The complete Markdown content of prose-only `WORKFLOW.md`. |

--- a/docs/admission.md
+++ b/docs/admission.md
@@ -25,12 +25,17 @@ not proposed again.
 
 `require_effort` is off by default, preserving admission behavior for existing
 projects. When enabled, `effort_section` must identify a separate project-owned
-rubric in the shared `WORKFLOW.md`. Effort names are taken from bold or
-code-formatted list items in that section rather than from a built-in Detent
-rubric. The read-only admission agent recommends one listed effort and explains
-why. If the issue has no `detent-agent` block, Detent appends the recommendation
-before moving it to the target state. Existing blocks remain authoritative and
-are never modified. A missing or invalid recommendation prevents admission.
+rubric in `effort_file`. The file defaults to `WORKFLOW.md`; set it to
+`AGENTS.md` when the repository keeps effort-selection guidance with its agent
+instructions. Both files are read from the same project-definition directory
+or configured git ref, and only these two explicit sources are accepted. A
+section found in the other file fails validation with a correction hint rather
+than silently selecting it. Effort names are taken from bold or code-formatted
+list items in that section rather than from a built-in Detent rubric. The
+read-only admission agent recommends one listed effort and explains why. If the
+issue has no `detent-agent` block, Detent appends the recommendation before
+moving it to the target state. Existing blocks remain authoritative and are
+never modified. A missing or invalid recommendation prevents admission.
 
 `auto_admit` is off by default. When enabled, Detent admits proposals whose
 confidence is at least `auto_admit_min_confidence`, after revalidating the source

--- a/docs/config.md
+++ b/docs/config.md
@@ -634,6 +634,7 @@ only to resettable budget pacing and never clears a per-issue hard hold.
 | `backlog_admission.auto_admit_by_label` | `mapping<string, boolean>` | `{}` | No | None |
 | `backlog_admission.auto_admit_min_confidence` | `number` | `0.9` | No | None |
 | `backlog_admission.criteria_section` | `string` | `none` | Conditional | is required |
+| `backlog_admission.effort_file` | `string` | `"WORKFLOW.md"` | No | must be WORKFLOW.md or AGENTS.md |
 | `backlog_admission.effort_section` | `string` | `none` | Conditional | is required when require_effort is true |
 | `backlog_admission.enabled` | `boolean` | `false` | No | None |
 | `backlog_admission.exclude_labels` | `list<string>` | `[]` | No | None |

--- a/docs/scheduled-routines.md
+++ b/docs/scheduled-routines.md
@@ -169,6 +169,7 @@ backlog_admission:
   target_state: Todo
   criteria_section: "Admission criteria"
   require_effort: false
+  effort_file: WORKFLOW.md
   effort_section: "Issue effort selection"
   exclude_labels: []
   authors:

--- a/docs/workflow-overlays.md
+++ b/docs/workflow-overlays.md
@@ -17,6 +17,12 @@ reconciliation covers missed filesystem events. `detent doctor` reports an
 active overlay, lists its structured override keys, and warns if Git tracks the
 local file.
 
+If a changed definition cannot be loaded or validated, Detent keeps the last
+good workflow active and marks the project degraded in `/health`. The workflow
+source entry records `last_reload_error` and `reload_failed_at`, and
+`detent doctor` reports that the project is pinned to its last-good revision.
+A later successful reload clears the degraded state.
+
 For example:
 
 ```yaml

--- a/internal/cli/doctor_environment.go
+++ b/internal/cli/doctor_environment.go
@@ -941,13 +941,15 @@ type doctorHealthEnvironment struct {
 }
 
 type doctorHealthWorkflow struct {
-	ProjectID  string    `json:"project_id"`
-	Path       string    `json:"path"`
-	SourceHash string    `json:"source_hash"`
-	Revision   string    `json:"revision"`
-	Layout     string    `json:"layout"`
-	ModifiedAt time.Time `json:"modified_at"`
-	LoadedAt   time.Time `json:"loaded_at"`
+	ProjectID       string    `json:"project_id"`
+	Path            string    `json:"path"`
+	SourceHash      string    `json:"source_hash"`
+	Revision        string    `json:"revision"`
+	Layout          string    `json:"layout"`
+	ModifiedAt      time.Time `json:"modified_at"`
+	LoadedAt        time.Time `json:"loaded_at"`
+	LastReloadError string    `json:"last_reload_error"`
+	ReloadFailedAt  time.Time `json:"reload_failed_at"`
 }
 
 type doctorHealthBudget struct {

--- a/internal/cli/doctor_project.go
+++ b/internal/cli/doctor_project.go
@@ -83,6 +83,21 @@ func checkDoctorWorkflowDrift(ctx context.Context, cfg globalconfig.Config, boot
 			})
 			continue
 		}
+		if runtimeWorkflow.LastReloadError != "" {
+			checks = append(checks, doctorCheck{
+				Name:   name,
+				Status: doctorFail,
+				Detail: fmt.Sprintf(
+					"project %s is running its last-good workflow loaded at %s because reload failed at %s: %s",
+					id,
+					doctorWorkflowTimestamp(runtimeWorkflow.LoadedAt),
+					doctorWorkflowTimestamp(runtimeWorkflow.ReloadFailedAt),
+					runtimeWorkflow.LastReloadError,
+				),
+				Hint: "Fix the configured project-definition source; Detent will clear the degraded status after a successful reload.",
+			})
+			continue
+		}
 
 		diskWorkflow, loadErr := loadDoctorProjectWorkflow(ctx, configuredProject, deps)
 		if loadErr != nil {

--- a/internal/cli/doctor_test.go
+++ b/internal/cli/doctor_test.go
@@ -5171,6 +5171,61 @@ func TestCheckDoctorWorkflowDriftReportsStaleLiveConfig(t *testing.T) {
 	}
 }
 
+func TestCheckDoctorWorkflowDriftReportsLastGoodReloadFailure(t *testing.T) {
+	t.Parallel()
+
+	loadedAt := time.Date(2026, 8, 20, 15, 0, 0, 0, time.UTC)
+	failedAt := loadedAt.Add(5 * time.Minute)
+	tests := []struct {
+		name      string
+		reloadErr string
+		want      string
+	}{
+		{name: "watch reload validation", reloadErr: "workflow reload validation failed: effort section missing", want: "workflow reload validation failed"},
+		{name: "reconcile load", reloadErr: "workflow reconcile failed: invalid detent.yaml", want: "workflow reconcile failed"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			payload, err := json.Marshal(map[string]any{
+				"status": "ok",
+				"mode":   "running",
+				"checks": map[string]string{
+					"hub": "configured", "store": "configured", "registry": "configured", "connector": "configured",
+				},
+				"workflows": []map[string]any{{
+					"project_id":        "detent",
+					"path":              "WORKFLOW.md",
+					"source_hash":       "last-good-hash",
+					"loaded_at":         loadedAt,
+					"last_reload_error": tt.reloadErr,
+					"reload_failed_at":  failedAt,
+				}},
+			})
+			if err != nil {
+				t.Fatalf("Marshal() error = %v", err)
+			}
+			port := 4001
+			checks := checkDoctorWorkflowDrift(context.Background(), globalconfig.Config{
+				Projects: []globalconfig.Project{{ID: "detent", Workflow: "WORKFLOW.md"}},
+			}, BootConfig{Host: "127.0.0.1", Port: &port}, doctorDeps{
+				httpDo: func(*http.Request) (*http.Response, error) {
+					return &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(bytes.NewReader(payload))}, nil
+				},
+			})
+
+			if len(checks) != 1 || checks[0].Status != doctorFail {
+				t.Fatalf("checks = %#v, want one failure", checks)
+			}
+			for _, want := range []string{"running its last-good workflow", "loaded at 2026-08-20T15:00:00Z", "reload failed at 2026-08-20T15:05:00Z", tt.want} {
+				if !strings.Contains(checks[0].Detail, want) {
+					t.Fatalf("Detail = %q, want containing %q", checks[0].Detail, want)
+				}
+			}
+		})
+	}
+}
+
 func TestCheckDoctorWorkflowDriftDefersPausedProject(t *testing.T) {
 	t.Parallel()
 

--- a/internal/cli/onboarding_workflow_builder.go
+++ b/internal/cli/onboarding_workflow_builder.go
@@ -186,6 +186,9 @@ func buildOnboardingWorkflow(ctx context.Context, cfg onboardingBuildWorkflowCon
 		ConfigPath:   projectConfigPath,
 		Config:       []byte(projectConfig),
 		HasConfig:    true,
+		AgentsPath:   agentsPath,
+		Agents:       []byte(agents),
+		HasAgents:    true,
 	}); err != nil {
 		return onboardingBuildWorkflowResult{}, fmt.Errorf("parse generated project definition: %w", err)
 	}
@@ -803,7 +806,9 @@ func applyOnboardingWorkflowAdmissionDecisions(root *yaml.Node, answers onboardi
 	decisions.set(root, "backlog_admission.sources.states", []string{sourceState}, sourceProvenance, sourceWhy)
 	decisions.set(root, "backlog_admission.target_state", targetState, targetProvenance, targetWhy)
 	decisions.set(root, "backlog_admission.criteria_section", criteriaSection, criteriaProvenance, criteriaWhy)
-	decisions.set(root, "backlog_admission.require_effort", false, "preset", "effort rubric generation is handled separately")
+	decisions.set(root, "backlog_admission.require_effort", true, "preset", "admitted issues require an explicit project-owned effort recommendation")
+	decisions.set(root, "backlog_admission.effort_file", workflowconfig.BacklogAdmissionEffortFileAgents, "preset", "onboarding writes the project effort rubric to AGENTS.md")
+	decisions.set(root, "backlog_admission.effort_section", onboardingEffortRubricHeading, "preset", "generated project-owned effort rubric heading")
 	decisions.set(root, "backlog_admission.max_candidates_per_run", maxCandidates, maxCandidatesProvenance, maxCandidatesWhy)
 	decisions.set(root, "backlog_admission.max_proposals_per_run", maxProposals, maxProposalsProvenance, maxProposalsWhy)
 	decisions.set(root, "backlog_admission.max_open_proposals", maxOpenProposals, maxOpenProposalsProvenance, maxOpenProposalsWhy)
@@ -1126,6 +1131,10 @@ func renderOnboardingAgentGuidance(existing string, answers onboardingAnswers) (
 	rubric := markdownLines(lines...)
 	if strings.TrimSpace(existing) == "" {
 		return rubric, nil
+	}
+	heading := "## " + onboardingEffortRubricHeading
+	if _, found := onboardingMarkdownSection(existing, heading); found {
+		return replaceProjectRefreshMarkdownSection(existing, heading, rubric), nil
 	}
 	return strings.TrimRight(existing, "\n") + "\n\n" + rubric, nil
 }

--- a/internal/cli/onboarding_workflow_builder.go
+++ b/internal/cli/onboarding_workflow_builder.go
@@ -161,7 +161,15 @@ func buildOnboardingWorkflow(ctx context.Context, cfg onboardingBuildWorkflowCon
 	if err != nil {
 		return onboardingBuildWorkflowResult{}, err
 	}
-	agentsPath := filepath.Join(sourceRoot, "AGENTS.md")
+	outputPath := strings.TrimSpace(cfg.OutputPath)
+	if outputPath == "" {
+		outputPath = filepath.Join(sourceRoot, defaultWorkflowFile)
+	}
+	if !filepath.IsAbs(outputPath) {
+		outputPath = filepath.Join(sourceRoot, outputPath)
+	}
+	outputPath = filepath.Clean(outputPath)
+	agentsPath := filepath.Join(filepath.Dir(outputPath), "AGENTS.md")
 	existingAgents, err := readOnboardingAgentsFile(agentsPath)
 	if err != nil {
 		return onboardingBuildWorkflowResult{}, err
@@ -171,14 +179,6 @@ func buildOnboardingWorkflow(ctx context.Context, cfg onboardingBuildWorkflowCon
 		return onboardingBuildWorkflowResult{}, err
 	}
 
-	outputPath := strings.TrimSpace(cfg.OutputPath)
-	if outputPath == "" {
-		outputPath = filepath.Join(sourceRoot, defaultWorkflowFile)
-	}
-	if !filepath.IsAbs(outputPath) {
-		outputPath = filepath.Join(sourceRoot, outputPath)
-	}
-	outputPath = filepath.Clean(outputPath)
 	projectConfigPath := workflowconfig.DefinitionPath(outputPath)
 	if _, err := workflowconfig.ParseProjectDefinition(workflowconfig.ProjectDefinitionSources{
 		WorkflowPath: outputPath,

--- a/internal/cli/onboarding_workflow_builder_test.go
+++ b/internal/cli/onboarding_workflow_builder_test.go
@@ -597,12 +597,22 @@ func TestBuildOnboardingWorkflowWritesEffortRubric(t *testing.T) {
 
 	tests := []struct {
 		name             string
+		outputDir        string
+		rootAgents       string
+		intakeProfile    string
 		existing         string
 		wantHeadingCount int
 		wantUnchanged    bool
 	}{
 		{name: "creates AGENTS.md when absent", wantHeadingCount: 1},
 		{name: "appends to existing AGENTS.md", existing: "# Repository agent guidance\n\nPreserve this project-owned content.\n", wantHeadingCount: 1},
+		{
+			name:             "writes AGENTS.md beside nested workflow",
+			outputDir:        "config",
+			rootAgents:       "# Root agent guidance\n\nPreserve this root-owned content.\n",
+			intakeProfile:    "assisted_intake",
+			wantHeadingCount: 1,
+		},
 		{
 			name:             "replaces matching heading that lacks guidance",
 			existing:         "# Repository agent guidance\n\n## Issue effort selection\n\nRecord estimates here.\n",
@@ -638,14 +648,24 @@ func TestBuildOnboardingWorkflowWritesEffortRubric(t *testing.T) {
 			t.Parallel()
 
 			root := initOnboardingWorkflowBuilderGitRepository(t, "https://github.com/acme/api.git")
-			agentsPath := filepath.Join(root, "AGENTS.md")
+			if tt.rootAgents != "" {
+				writeOnboardingWorkflowBuilderFile(t, filepath.Join(root, "AGENTS.md"), tt.rootAgents)
+			}
+			outputDir := filepath.Join(root, tt.outputDir)
+			outputPath := filepath.Join(outputDir, defaultWorkflowFile)
+			agentsPath := filepath.Join(outputDir, "AGENTS.md")
 			if tt.existing != "" {
 				writeOnboardingWorkflowBuilderFile(t, agentsPath, tt.existing)
 			}
-			answersPath := writeOnboardingWorkflowBuilderAnswers(t, onboardingWorkflowBuilderVariantAnswers(root, "github_local", "review_gate", "INTAKE_PROFILE=manual_intake"))
+			intakeProfile := tt.intakeProfile
+			if intakeProfile == "" {
+				intakeProfile = "manual_intake"
+			}
+			answersPath := writeOnboardingWorkflowBuilderAnswers(t, onboardingWorkflowBuilderVariantAnswers(root, "github_local", "review_gate", "INTAKE_PROFILE="+intakeProfile))
 
 			result, err := buildOnboardingWorkflow(context.Background(), onboardingBuildWorkflowConfig{
 				AnswersPath: answersPath,
+				OutputPath:  outputPath,
 				Write:       true,
 			})
 			if err != nil {
@@ -664,6 +684,18 @@ func TestBuildOnboardingWorkflowWritesEffortRubric(t *testing.T) {
 			}
 			if tt.existing != "" && !strings.HasPrefix(got, "# Repository agent guidance") {
 				t.Fatalf("AGENTS.md did not preserve existing content:\n%s", got)
+			}
+			if tt.rootAgents != "" {
+				rootAgents, err := os.ReadFile(filepath.Join(root, "AGENTS.md"))
+				if err != nil {
+					t.Fatalf("ReadFile(root AGENTS.md) error = %v", err)
+				}
+				if string(rootAgents) != tt.rootAgents {
+					t.Fatalf("root AGENTS.md changed:\n%s", rootAgents)
+				}
+			}
+			if _, err := workflowconfig.LoadWorkflow(outputPath); err != nil {
+				t.Fatalf("LoadWorkflow(%s) error = %v", outputPath, err)
 			}
 			if count := strings.Count(got, "## Issue effort selection"); count != tt.wantHeadingCount {
 				t.Fatalf("effort heading count = %d, want %d:\n%s", count, tt.wantHeadingCount, got)

--- a/internal/cli/onboarding_workflow_builder_test.go
+++ b/internal/cli/onboarding_workflow_builder_test.go
@@ -580,8 +580,14 @@ func TestBuildOnboardingWorkflowRendersIntakeProfiles(t *testing.T) {
 			if workflow.Config.BacklogAdmission.CriteriaSection != onboardingAdmissionCriteriaHeading {
 				t.Fatalf("CriteriaSection = %q, want exact generated heading %q", workflow.Config.BacklogAdmission.CriteriaSection, onboardingAdmissionCriteriaHeading)
 			}
+			if !workflow.Config.BacklogAdmission.RequireEffort ||
+				workflow.Config.BacklogAdmission.EffortFile != workflowconfig.BacklogAdmissionEffortFileAgents ||
+				workflow.Config.BacklogAdmission.EffortSection != onboardingEffortRubricHeading {
+				t.Fatalf("BacklogAdmission effort source = %#v, want AGENTS.md rubric", workflow.Config.BacklogAdmission)
+			}
 			assertOnboardingWorkflowDecision(t, result.Decisions, "backlog_admission.enabled", "answer")
 			assertOnboardingWorkflowDecision(t, result.Decisions, "backlog_admission.max_candidates_per_run", "answer")
+			assertOnboardingWorkflowDecision(t, result.Decisions, "backlog_admission.effort_file", "preset")
 		})
 	}
 }
@@ -598,9 +604,9 @@ func TestBuildOnboardingWorkflowWritesEffortRubric(t *testing.T) {
 		{name: "creates AGENTS.md when absent", wantHeadingCount: 1},
 		{name: "appends to existing AGENTS.md", existing: "# Repository agent guidance\n\nPreserve this project-owned content.\n", wantHeadingCount: 1},
 		{
-			name:             "appends when matching heading lacks guidance",
+			name:             "replaces matching heading that lacks guidance",
 			existing:         "# Repository agent guidance\n\n## Issue effort selection\n\nRecord estimates here.\n",
-			wantHeadingCount: 2,
+			wantHeadingCount: 1,
 		},
 		{
 			name: "preserves complete existing guidance",
@@ -656,7 +662,7 @@ func TestBuildOnboardingWorkflowWritesEffortRubric(t *testing.T) {
 			if tt.wantUnchanged && got != tt.existing {
 				t.Fatalf("AGENTS.md changed complete existing guidance:\n%s", got)
 			}
-			if tt.existing != "" && !strings.HasPrefix(got, strings.TrimRight(tt.existing, "\n")) {
+			if tt.existing != "" && !strings.HasPrefix(got, "# Repository agent guidance") {
 				t.Fatalf("AGENTS.md did not preserve existing content:\n%s", got)
 			}
 			if count := strings.Count(got, "## Issue effort selection"); count != tt.wantHeadingCount {
@@ -853,6 +859,9 @@ func parseOnboardingBuildWorkflowResult(result onboardingBuildWorkflowResult) (w
 		ConfigPath:   result.ConfigPath,
 		Config:       []byte(result.Config),
 		HasConfig:    true,
+		AgentsPath:   result.AgentsPath,
+		Agents:       []byte(result.Agents),
+		HasAgents:    true,
 	})
 }
 

--- a/internal/cli/refresh_project.go
+++ b/internal/cli/refresh_project.go
@@ -288,7 +288,7 @@ func planProjectRefresh(ctx context.Context, cfg projectRefreshConfig) (projectR
 	if err != nil {
 		return projectRefreshPlan{}, err
 	}
-	if err := validateProjectRefreshCandidate(workflowPath, []byte(refreshedWorkflow), configPath, refreshedConfig); err != nil {
+	if err := validateProjectRefreshCandidate(workflowPath, []byte(refreshedWorkflow), configPath, refreshedConfig, agentsPath, []byte(refreshedAgents)); err != nil {
 		return projectRefreshPlan{}, err
 	}
 
@@ -691,7 +691,9 @@ func refreshProjectWorkflow(existing string, generated string, cfg workflowconfi
 	if projectRefreshYAMLTextSectionRequired(cfg.BacklogAdmission.Enabled, cfg.BacklogAdmission.CriteriaSection) {
 		refreshed = appendProjectRefreshMarkdownSection(refreshed, generated, cfg.BacklogAdmission.CriteriaSection)
 	}
-	if cfg.BacklogAdmission.RequireEffort && strings.TrimSpace(cfg.BacklogAdmission.EffortSection) != "" {
+	if cfg.BacklogAdmission.RequireEffort &&
+		cfg.BacklogAdmission.EffortFile != workflowconfig.BacklogAdmissionEffortFileAgents &&
+		strings.TrimSpace(cfg.BacklogAdmission.EffortSection) != "" {
 		section := strings.TrimSpace(cfg.BacklogAdmission.EffortSection)
 		if _, found := onboardingMarkdownSection(refreshed, "## "+section); !found {
 			refreshed = strings.TrimRight(refreshed, "\n") + "\n\n" + projectRefreshEffortSection(section)
@@ -787,13 +789,16 @@ func projectRefreshEffortSection(section string) string {
 	)
 }
 
-func validateProjectRefreshCandidate(workflowPath string, workflow []byte, configPath string, config []byte) error {
+func validateProjectRefreshCandidate(workflowPath string, workflow []byte, configPath string, config []byte, agentsPath string, agents []byte) error {
 	sources := workflowconfig.ProjectDefinitionSources{
 		WorkflowPath: workflowPath,
 		Workflow:     workflow,
 		ConfigPath:   configPath,
 		Config:       config,
 		HasConfig:    true,
+		AgentsPath:   agentsPath,
+		Agents:       agents,
+		HasAgents:    true,
 	}
 	localWorkflowPath := workflowconfig.LocalWorkflowPath(workflowPath)
 	localWorkflow, _, localWorkflowExists, err := readOptionalProjectRefreshFile(localWorkflowPath)

--- a/internal/config/admission.go
+++ b/internal/config/admission.go
@@ -20,6 +20,8 @@ const (
 	DefaultBacklogAdmissionMaxOpenProposals       = 10
 	DefaultBacklogAdmissionProposalExpiryDays     = 7
 	DefaultBacklogAdmissionAutoAdmitMinConfidence = 0.9
+	BacklogAdmissionEffortFileWorkflow            = "WORKFLOW.md"
+	BacklogAdmissionEffortFileAgents              = "AGENTS.md"
 )
 
 var (
@@ -35,6 +37,7 @@ type BacklogAdmission struct {
 	TargetState            string                  `yaml:"target_state"`
 	CriteriaSection        string                  `yaml:"criteria_section"`
 	RequireEffort          bool                    `yaml:"require_effort"`
+	EffortFile             string                  `yaml:"effort_file,omitempty"`
 	EffortSection          string                  `yaml:"effort_section,omitempty"`
 	ExcludeLabels          []string                `yaml:"exclude_labels,omitempty"`
 	Authors                BacklogAdmissionAuthors `yaml:"authors,omitempty"`
@@ -91,6 +94,7 @@ func (a *BacklogAdmission) Normalize() {
 	a.Sources.Labels = normalizeAdmissionSourceLabels(a.Sources.Labels)
 	a.TargetState = strings.TrimSpace(a.TargetState)
 	a.CriteriaSection = strings.TrimSpace(a.CriteriaSection)
+	a.EffortFile = normalizeAdmissionEffortFile(a.EffortFile)
 	a.EffortSection = strings.TrimSpace(a.EffortSection)
 	a.ExcludeLabels = normalizeLabels(a.ExcludeLabels)
 	a.AutoAdmitByLabel = normalizeAdmissionLabelPolicies(a.AutoAdmitByLabel)
@@ -135,6 +139,9 @@ func (a BacklogAdmission) Validate(prefix string, states []string, tracker Track
 	}
 	if a.RequireEffort && a.EffortSection == "" {
 		problems = append(problems, prefix+".effort_section is required when require_effort is true")
+	}
+	if a.EffortFile != BacklogAdmissionEffortFileWorkflow && a.EffortFile != BacklogAdmissionEffortFileAgents {
+		problems = append(problems, prefix+".effort_file must be WORKFLOW.md or AGENTS.md")
 	}
 	validatePositive(prefix+".max_candidates_per_run", a.MaxCandidatesPerRun, &problems)
 	validatePositive(prefix+".max_proposals_per_run", a.MaxProposalsPerRun, &problems)
@@ -328,7 +335,7 @@ func ResolveAdmissionCriteria(prompt string, section string) (AdmissionCriteria,
 	if section == "" {
 		return AdmissionCriteria{}, errors.New("backlog admission criteria section is required")
 	}
-	match, text, err := resolveAdmissionSection(prompt, section, "criteria")
+	match, text, err := resolveAdmissionSection(prompt, section, "criteria", BacklogAdmissionEffortFileWorkflow)
 	if err != nil {
 		return AdmissionCriteria{}, err
 	}
@@ -343,11 +350,43 @@ func ResolveAdmissionCriteria(prompt string, section string) (AdmissionCriteria,
 }
 
 func ResolveAdmissionEffortRubric(prompt string, section string) (AdmissionEffortRubric, error) {
+	return resolveAdmissionEffortRubric(prompt, section, BacklogAdmissionEffortFileWorkflow)
+}
+
+func ResolveWorkflowAdmissionEffortRubric(workflow Workflow) (AdmissionEffortRubric, error) {
+	file := normalizeAdmissionEffortFile(workflow.Config.BacklogAdmission.EffortFile)
+	prompt := workflow.SharedPrompt
+	alternatePrompt := workflow.AgentsPrompt
+	alternateFile := BacklogAdmissionEffortFileAgents
+	switch file {
+	case BacklogAdmissionEffortFileWorkflow:
+	case BacklogAdmissionEffortFileAgents:
+		prompt = workflow.AgentsPrompt
+		alternatePrompt = workflow.SharedPrompt
+		alternateFile = BacklogAdmissionEffortFileWorkflow
+	default:
+		return AdmissionEffortRubric{}, fmt.Errorf("backlog admission effort file %q must be WORKFLOW.md or AGENTS.md", file)
+	}
+
+	rubric, err := resolveAdmissionEffortRubric(prompt, workflow.Config.BacklogAdmission.EffortSection, file)
+	if err == nil || !admissionHeadingExists(alternatePrompt, workflow.Config.BacklogAdmission.EffortSection) {
+		return rubric, err
+	}
+	return AdmissionEffortRubric{}, fmt.Errorf(
+		"%w; section %q exists in %s instead; set backlog_admission.effort_file to %s or move the section",
+		err,
+		strings.TrimSpace(workflow.Config.BacklogAdmission.EffortSection),
+		alternateFile,
+		alternateFile,
+	)
+}
+
+func resolveAdmissionEffortRubric(prompt string, section string, source string) (AdmissionEffortRubric, error) {
 	section = strings.TrimSpace(section)
 	if section == "" {
 		return AdmissionEffortRubric{}, errors.New("backlog admission effort section is required")
 	}
-	match, text, err := resolveAdmissionSection(prompt, section, "effort")
+	match, text, err := resolveAdmissionSection(prompt, section, "effort", source)
 	if err != nil {
 		return AdmissionEffortRubric{}, err
 	}
@@ -361,7 +400,7 @@ func ResolveAdmissionEffortRubric(prompt string, section string) (AdmissionEffor
 	return AdmissionEffortRubric{Section: match.Title, Text: text, Efforts: efforts}, nil
 }
 
-func resolveAdmissionSection(prompt string, section string, kind string) (markdownHeading, string, error) {
+func resolveAdmissionSection(prompt string, section string, kind string, source string) (markdownHeading, string, error) {
 	headings := markdownHeadings(prompt)
 	matches := make([]markdownHeading, 0, 1)
 	for _, heading := range headings {
@@ -370,10 +409,10 @@ func resolveAdmissionSection(prompt string, section string, kind string) (markdo
 		}
 	}
 	if len(matches) == 0 {
-		return markdownHeading{}, "", fmt.Errorf("backlog admission %s section %q was not found in shared WORKFLOW.md", kind, section)
+		return markdownHeading{}, "", fmt.Errorf("backlog admission %s section %q was not found in %s", kind, section, source)
 	}
 	if len(matches) > 1 {
-		return markdownHeading{}, "", fmt.Errorf("backlog admission %s section %q is duplicated in shared WORKFLOW.md", kind, section)
+		return markdownHeading{}, "", fmt.Errorf("backlog admission %s section %q is duplicated in %s", kind, section, source)
 	}
 	match := matches[0]
 	end := len(prompt)
@@ -386,7 +425,7 @@ func resolveAdmissionSection(prompt string, section string, kind string) (markdo
 	}
 	text := strings.TrimSpace(prompt[match.End:end])
 	if text == "" {
-		return markdownHeading{}, "", fmt.Errorf("backlog admission %s section %q is empty in shared WORKFLOW.md", kind, section)
+		return markdownHeading{}, "", fmt.Errorf("backlog admission %s section %q is empty in %s", kind, section, source)
 	}
 	return match, text, nil
 }
@@ -401,8 +440,29 @@ func ValidateWorkflowAdmission(workflow Workflow) error {
 	if !workflow.Config.BacklogAdmission.RequireEffort {
 		return nil
 	}
-	_, err := ResolveAdmissionEffortRubric(workflow.SharedPrompt, workflow.Config.BacklogAdmission.EffortSection)
+	_, err := ResolveWorkflowAdmissionEffortRubric(workflow)
 	return err
+}
+
+func normalizeAdmissionEffortFile(file string) string {
+	switch strings.ToLower(strings.TrimSpace(file)) {
+	case "", "workflow.md":
+		return BacklogAdmissionEffortFileWorkflow
+	case "agents.md":
+		return BacklogAdmissionEffortFileAgents
+	default:
+		return strings.TrimSpace(file)
+	}
+}
+
+func admissionHeadingExists(prompt string, section string) bool {
+	section = strings.TrimSpace(section)
+	for _, heading := range markdownHeadings(prompt) {
+		if strings.EqualFold(strings.TrimSpace(heading.Title), section) {
+			return true
+		}
+	}
+	return false
 }
 
 type markdownHeading struct {

--- a/internal/config/admission_test.go
+++ b/internal/config/admission_test.go
@@ -26,6 +26,7 @@ backlog_admission:
   target_state: Todo
   criteria_section: Admission criteria
   require_effort: true
+  effort_file: WORKFLOW.md
   effort_section: Issue effort selection
   exclude_labels: [Skip, skip]
   authors:
@@ -64,7 +65,7 @@ backlog_admission:
 		got.MaxCandidatesPerRun != 20 || got.MaxProposalsPerRun != 2 ||
 		got.MaxOpenProposals != 8 || got.ProposalExpiryDays != 5 ||
 		!got.AutoAdmit || got.AutoAdmitMinConfidence != 0.95 || got.Sources.Untracked ||
-		!got.RequireEffort || got.EffortSection != "Issue effort selection" {
+		!got.RequireEffort || got.EffortFile != BacklogAdmissionEffortFileWorkflow || got.EffortSection != "Issue effort selection" {
 		t.Fatalf("BacklogAdmission = %#v", got)
 	}
 	if len(got.AutoAdmitByLabel) != 2 || !got.AutoAdmitByLabel["defect"] || got.AutoAdmitByLabel["requires-human-review"] {
@@ -131,6 +132,11 @@ func TestBacklogAdmissionValidate(t *testing.T) {
 		{name: "missing effort section", tracker: Tracker{Kind: TrackerGitHub}, mutate: func(cfg *BacklogAdmission) {
 			cfg.RequireEffort = true
 		}, want: "effort_section is required"},
+		{name: "invalid effort file", tracker: Tracker{Kind: TrackerGitHub}, mutate: func(cfg *BacklogAdmission) {
+			cfg.RequireEffort = true
+			cfg.EffortFile = "README.md"
+			cfg.EffortSection = "Effort"
+		}, want: "effort_file must be WORKFLOW.md or AGENTS.md"},
 		{name: "zero candidate cap", tracker: Tracker{Kind: TrackerGitHub}, mutate: func(cfg *BacklogAdmission) { cfg.MaxCandidatesPerRun = 0 }, want: "max_candidates_per_run must be greater than 0"},
 		{name: "negative proposal cap", tracker: Tracker{Kind: TrackerGitHub}, mutate: func(cfg *BacklogAdmission) { cfg.MaxProposalsPerRun = -1 }, want: "max_proposals_per_run must be greater than 0"},
 		{name: "zero open cap", tracker: Tracker{Kind: TrackerGitHub}, mutate: func(cfg *BacklogAdmission) { cfg.MaxOpenProposals = 0 }, want: "max_open_proposals must be greater than 0"},
@@ -578,6 +584,134 @@ func TestResolveAdmissionEffortRubric(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+func TestProjectDefinitionResolvesAdmissionEffortFromConfiguredFile(t *testing.T) {
+	t.Parallel()
+
+	config := []byte(`schema: 1
+tracker:
+  kind: memory
+backlog_admission:
+  enabled: true
+  sources:
+    states: [Backlog]
+  target_state: Todo
+  criteria_section: Admission Criteria
+  require_effort: true
+  effort_file: AGENTS.md
+  effort_section: Issue Effort Selection
+`)
+	workflowPrompt := []byte("## Admission Criteria\n\n- **Alignment** — ready.\n")
+	agentsPrompt := []byte("## Issue Effort Selection\n\n- `medium` — small.\n- `high` — standard.\n")
+
+	workflow, err := ParseProjectDefinition(ProjectDefinitionSources{
+		WorkflowPath: "WORKFLOW.md",
+		Workflow:     workflowPrompt,
+		ConfigPath:   "detent.yaml",
+		Config:       config,
+		HasConfig:    true,
+		AgentsPath:   "AGENTS.md",
+		Agents:       agentsPrompt,
+		HasAgents:    true,
+	})
+	if err != nil {
+		t.Fatalf("ParseProjectDefinition() error = %v", err)
+	}
+	rubric, err := ResolveWorkflowAdmissionEffortRubric(workflow)
+	if err != nil {
+		t.Fatalf("ResolveWorkflowAdmissionEffortRubric() error = %v", err)
+	}
+	if rubric.Section != "Issue Effort Selection" || len(rubric.Efforts) != 2 || rubric.Efforts[0] != "medium" || rubric.Efforts[1] != "high" {
+		t.Fatalf("rubric = %#v, want AGENTS.md efforts", rubric)
+	}
+}
+
+func TestProjectDefinitionReportsAdmissionEffortInDifferentFile(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		effortFile string
+		workflow   string
+		agents     string
+		want       string
+	}{
+		{
+			name:       "configured agents but section is in workflow",
+			effortFile: BacklogAdmissionEffortFileAgents,
+			workflow:   "## Admission Criteria\n\n- **Alignment** — ready.\n\n## Issue Effort Selection\n\n- `high` — standard.\n",
+			agents:     "# Agent guidance\n",
+			want:       "exists in WORKFLOW.md instead; set backlog_admission.effort_file to WORKFLOW.md",
+		},
+		{
+			name:       "configured workflow but section is in agents",
+			effortFile: BacklogAdmissionEffortFileWorkflow,
+			workflow:   "## Admission Criteria\n\n- **Alignment** — ready.\n",
+			agents:     "## Issue Effort Selection\n\n- `high` — standard.\n",
+			want:       "exists in AGENTS.md instead; set backlog_admission.effort_file to AGENTS.md",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			config := []byte("schema: 1\ntracker:\n  kind: memory\nbacklog_admission:\n  enabled: true\n  sources:\n    states: [Backlog]\n  target_state: Todo\n  criteria_section: Admission Criteria\n  require_effort: true\n  effort_file: " + tt.effortFile + "\n  effort_section: Issue Effort Selection\n")
+			_, err := ParseProjectDefinition(ProjectDefinitionSources{
+				WorkflowPath: "WORKFLOW.md",
+				Workflow:     []byte(tt.workflow),
+				ConfigPath:   "detent.yaml",
+				Config:       config,
+				HasConfig:    true,
+				AgentsPath:   "AGENTS.md",
+				Agents:       []byte(tt.agents),
+				HasAgents:    true,
+			})
+			if err == nil || !strings.Contains(err.Error(), tt.want) {
+				t.Fatalf("ParseProjectDefinition() error = %v, want %q", err, tt.want)
+			}
+		})
+	}
+}
+
+func TestProjectDefinitionHashesConfiguredAdmissionEffortFile(t *testing.T) {
+	t.Parallel()
+
+	parse := func(t *testing.T, effortFile string, agents string) Workflow {
+		t.Helper()
+		workflowPrompt := "## Admission Criteria\n\n- **Alignment** — ready.\n"
+		if effortFile == BacklogAdmissionEffortFileWorkflow {
+			workflowPrompt += "\n## Issue Effort Selection\n\n- `high` — standard.\n"
+		}
+		config := []byte("schema: 1\ntracker:\n  kind: memory\nbacklog_admission:\n  enabled: true\n  sources:\n    states: [Backlog]\n  target_state: Todo\n  criteria_section: Admission Criteria\n  require_effort: true\n  effort_file: " + effortFile + "\n  effort_section: Issue Effort Selection\n")
+		workflow, err := ParseProjectDefinition(ProjectDefinitionSources{
+			WorkflowPath: "WORKFLOW.md",
+			Workflow:     []byte(workflowPrompt),
+			ConfigPath:   "detent.yaml",
+			Config:       config,
+			HasConfig:    true,
+			AgentsPath:   "AGENTS.md",
+			Agents:       []byte(agents),
+			HasAgents:    true,
+		})
+		if err != nil {
+			t.Fatalf("ParseProjectDefinition() error = %v", err)
+		}
+		return workflow
+	}
+
+	agentsA := "## Issue Effort Selection\n\n- `high` — standard.\n"
+	agentsB := "## Issue Effort Selection\n\n- `high` — cross-cutting.\n"
+	fromAgentsA := parse(t, BacklogAdmissionEffortFileAgents, agentsA)
+	fromAgentsB := parse(t, BacklogAdmissionEffortFileAgents, agentsB)
+	if fromAgentsA.SourceHash == fromAgentsB.SourceHash {
+		t.Fatal("AGENTS.md-backed source hash did not change with the configured rubric")
+	}
+	fromWorkflowA := parse(t, BacklogAdmissionEffortFileWorkflow, agentsA)
+	fromWorkflowB := parse(t, BacklogAdmissionEffortFileWorkflow, agentsB)
+	if fromWorkflowA.SourceHash != fromWorkflowB.SourceHash {
+		t.Fatal("WORKFLOW.md-backed source hash changed for unrelated AGENTS.md guidance")
 	}
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -134,6 +134,7 @@ type Workflow struct {
 	Config       Config
 	Prompt       string
 	SharedPrompt string
+	AgentsPrompt string
 	SourceHash   string
 	Overlay      WorkflowOverlay
 	Definition   ProjectDefinition
@@ -1502,6 +1503,7 @@ func Default() Config {
 		Budget: budget,
 		BacklogAdmission: BacklogAdmission{
 			Schedule:               DefaultBacklogAdmissionSchedule,
+			EffortFile:             BacklogAdmissionEffortFileWorkflow,
 			MaxCandidatesPerRun:    DefaultBacklogAdmissionMaxCandidatesPerRun,
 			MaxProposalsPerRun:     DefaultBacklogAdmissionMaxProposalsPerRun,
 			MaxOpenProposals:       DefaultBacklogAdmissionMaxOpenProposals,

--- a/internal/config/project_definition.go
+++ b/internal/config/project_definition.go
@@ -50,6 +50,9 @@ type ProjectDefinitionSources struct {
 	LocalConfigPath   string
 	LocalConfig       []byte
 	HasLocalConfig    bool
+	AgentsPath        string
+	Agents            []byte
+	HasAgents         bool
 }
 
 type ProjectDefinitionError struct {
@@ -112,6 +115,10 @@ func readProjectDefinitionSources(path string) (ProjectDefinitionSources, error)
 	if sources.LocalConfig, sources.HasLocalConfig, err = readOptionalDefinitionFile(sources.LocalConfigPath); err != nil {
 		return ProjectDefinitionSources{}, projectDefinitionReadError(path, "read local project config", err)
 	}
+	sources.AgentsPath = filepath.Join(filepath.Dir(path), BacklogAdmissionEffortFileAgents)
+	if sources.Agents, sources.HasAgents, err = readOptionalDefinitionFile(sources.AgentsPath); err != nil {
+		return ProjectDefinitionSources{}, projectDefinitionReadError(path, "read agent guidance", err)
+	}
 	return sources, nil
 }
 
@@ -145,6 +152,7 @@ func ParseProjectDefinition(sources ProjectDefinitionSources) (Workflow, error) 
 		if parseErr != nil {
 			return Workflow{}, definitionError(definition, parseErr)
 		}
+		workflow = attachProjectDefinitionAgents(workflow, sources)
 		workflow.Definition = definition
 		workflow.Definition.Revision = workflow.SourceHash
 		if validationErr := ValidateWorkflowAdmission(workflow); validationErr != nil {
@@ -156,6 +164,7 @@ func ParseProjectDefinition(sources ProjectDefinitionSources) (Workflow, error) 
 		if parseErr != nil {
 			return Workflow{}, definitionError(definition, parseErr)
 		}
+		workflow = attachProjectDefinitionAgents(workflow, sources)
 		workflow.Definition = definition
 		workflow.Definition.Revision = workflow.SourceHash
 		if validationErr := ValidateWorkflowAdmission(workflow); validationErr != nil {
@@ -380,7 +389,7 @@ func parseSplitProjectDefinition(
 	if sources.HasLocalWorkflow {
 		prompt = mergeWorkflowPrompts(sharedPrompt, normalizeProjectDefinitionPrompt(local.prompt))
 	}
-	hash := projectDefinitionHash(sources)
+	hash := projectDefinitionHash(sources, false)
 	workflow := Workflow{
 		Config:       cfg,
 		Prompt:       prompt,
@@ -481,7 +490,23 @@ func mixedProjectDefinitionError(
 	return errors.New("mixed project definition has ambiguous authority: " + strings.Join(conflicts, "; "))
 }
 
-func projectDefinitionHash(sources ProjectDefinitionSources) string {
+func attachProjectDefinitionAgents(workflow Workflow, sources ProjectDefinitionSources) Workflow {
+	admission := workflow.Config.BacklogAdmission
+	admission.Normalize()
+	if !admission.RequireEffort {
+		return workflow
+	}
+	if sources.HasAgents && (admission.EffortFile == BacklogAdmissionEffortFileAgents ||
+		!admissionHeadingExists(workflow.SharedPrompt, admission.EffortSection)) {
+		workflow.AgentsPrompt = string(normalizeProjectDefinitionPrompt(sources.Agents))
+	}
+	if admission.EffortFile == BacklogAdmissionEffortFileAgents {
+		workflow.SourceHash = projectDefinitionHash(sources, true)
+	}
+	return workflow
+}
+
+func projectDefinitionHash(sources ProjectDefinitionSources, includeAgents bool) string {
 	hash := sha256.New()
 	for _, source := range []struct {
 		name    string
@@ -492,6 +517,7 @@ func projectDefinitionHash(sources ProjectDefinitionSources) string {
 		{name: "detent.yaml", raw: sources.Config, present: sources.HasConfig},
 		{name: "WORKFLOW.local.md", raw: sources.LocalWorkflow, present: sources.HasLocalWorkflow},
 		{name: "detent.local.yaml", raw: sources.LocalConfig, present: sources.HasLocalConfig},
+		{name: BacklogAdmissionEffortFileAgents, raw: sources.Agents, present: includeAgents && sources.HasAgents},
 	} {
 		if !source.present {
 			continue

--- a/internal/config/watcher/watcher.go
+++ b/internal/config/watcher/watcher.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"log/slog"
+	"path/filepath"
 	"time"
 
 	workflowconfig "github.com/digitaldrywood/detent/internal/config"
@@ -71,6 +72,7 @@ func New(path string, opts ...Option) (*Watcher, error) {
 			workflowconfig.DefinitionPath(path),
 			workflowconfig.LocalWorkflowPath(path),
 			workflowconfig.LocalDefinitionPath(path),
+			filepath.Join(filepath.Dir(path), workflowconfig.BacklogAdmissionEffortFileAgents),
 		),
 	}, cfg.fileOptions...)...)
 	if err != nil {

--- a/internal/project/project.go
+++ b/internal/project/project.go
@@ -85,6 +85,8 @@ type WorkflowSourceStatus struct {
 	LastWatchEventAt time.Time
 	LastReconcileAt  time.Time
 	WatcherArmed     bool
+	LastReloadError  string
+	ReloadFailedAt   time.Time
 }
 
 type Config struct {
@@ -270,10 +272,7 @@ func New(cfg Config, deps Dependencies) (*Project, error) {
 			return nil, errors.Join(fmt.Errorf("create project backlog admission: %w", err), closeConnector(retroProductConnector))
 		}
 		if workflow.Config.BacklogAdmission.RequireEffort {
-			admissionEffortRubric, err = workflowconfig.ResolveAdmissionEffortRubric(
-				workflow.SharedPrompt,
-				workflow.Config.BacklogAdmission.EffortSection,
-			)
+			admissionEffortRubric, err = workflowconfig.ResolveWorkflowAdmissionEffortRubric(workflow)
 			if err != nil {
 				return nil, errors.Join(fmt.Errorf("create project backlog admission: %w", err), closeConnector(retroProductConnector))
 			}
@@ -1232,11 +1231,12 @@ func (p *Project) reconcileWorkflow(ctx context.Context) error {
 	p.mu.Unlock()
 	if err != nil {
 		if ctx.Err() == nil {
-			p.logger.Warn("workflow reconcile failed", "project_id", p.id, "path", workflowSourceDisplayPath(projectConfig), "error", err)
+			return p.workflowReloadError("workflow reconcile failed", workflowSourceDisplayPath(projectConfig), err)
 		}
 		return fmt.Errorf("load workflow: %w", err)
 	}
 	if workflow.SourceHash == "" || workflow.SourceHash == loadedHash {
+		p.clearWorkflowReloadError()
 		return nil
 	}
 
@@ -1289,10 +1289,7 @@ func (p *Project) handleWorkflowUpdate(ctx context.Context, update configwatcher
 		}
 		admissionCriteria = resolvedCriteria
 		if workflow.Config.BacklogAdmission.RequireEffort {
-			resolvedRubric, rubricErr := workflowconfig.ResolveAdmissionEffortRubric(
-				workflow.SharedPrompt,
-				workflow.Config.BacklogAdmission.EffortSection,
-			)
+			resolvedRubric, rubricErr := workflowconfig.ResolveWorkflowAdmissionEffortRubric(workflow)
 			if rubricErr != nil {
 				return p.workflowReloadError("workflow reload backlog admission effort rubric failed", update.Path, rubricErr)
 			}
@@ -1418,6 +1415,8 @@ func (p *Project) handleWorkflowUpdate(ctx context.Context, update configwatcher
 	} else {
 		p.workflowSource.LoadedAt = update.At.UTC()
 	}
+	p.workflowSource.LastReloadError = ""
+	p.workflowSource.ReloadFailedAt = time.Time{}
 	p.connector = projectConnector
 	p.retroProduct = retroProductConnector
 	retainRetroProduct = true
@@ -1447,7 +1446,19 @@ func (p *Project) handleWorkflowUpdate(ctx context.Context, update configwatcher
 
 func (p *Project) workflowReloadError(message, path string, err error) error {
 	p.logger.Warn(message, "project_id", p.id, "path", path, "error", err)
-	return fmt.Errorf("%s: %w", message, err)
+	reloadErr := fmt.Errorf("%s: %w", message, err)
+	p.mu.Lock()
+	p.workflowSource.LastReloadError = reloadErr.Error()
+	p.workflowSource.ReloadFailedAt = time.Now().UTC()
+	p.mu.Unlock()
+	return reloadErr
+}
+
+func (p *Project) clearWorkflowReloadError() {
+	p.mu.Lock()
+	p.workflowSource.LastReloadError = ""
+	p.workflowSource.ReloadFailedAt = time.Time{}
+	p.mu.Unlock()
 }
 
 type releaseCoordinatorBuild struct {

--- a/internal/project/project_test.go
+++ b/internal/project/project_test.go
@@ -921,6 +921,29 @@ func TestProjectHotReloadAppliesRuntimeGitHubTokenBeforeValidation(t *testing.T)
 	if got.Workflow().Prompt != "reloaded\n" {
 		t.Fatalf("Workflow().Prompt after invalid reload = %q, want last valid workflow", got.Workflow().Prompt)
 	}
+	sourceStatus := got.WorkflowSourceStatus()
+	if !strings.Contains(sourceStatus.LastReloadError, "workflow reload failed") || sourceStatus.ReloadFailedAt.IsZero() {
+		t.Fatalf("WorkflowSourceStatus() = %#v, want persistent reload failure", sourceStatus)
+	}
+	registry := project.NewRegistry()
+	if err := registry.Set(got); err != nil {
+		t.Fatalf("Registry.Set() error = %v", err)
+	}
+	health := registry.Health()
+	if len(health) != 1 || health[0].Status != project.HealthStatusDegraded || !strings.Contains(health[0].LastError, "workflow reload failed") {
+		t.Fatalf("Registry.Health() = %#v, want degraded last-good project", health)
+	}
+
+	writeProjectGitHubWorkflow(t, workflowPath, 60000, "recovered")
+	waitForWorkflowPrompt(t, got, "recovered\n")
+	_ = receiveConnectorConfig(t, connectorConfigs)
+	if recovered := got.WorkflowSourceStatus(); recovered.LastReloadError != "" || !recovered.ReloadFailedAt.IsZero() {
+		t.Fatalf("WorkflowSourceStatus() after recovery = %#v, want cleared reload failure", recovered)
+	}
+	health = registry.Health()
+	if len(health) != 1 || health[0].Status != project.HealthStatusReady || health[0].LastError != "" {
+		t.Fatalf("Registry.Health() after recovery = %#v, want ready project", health)
+	}
 }
 
 func TestProjectStartRunsProvisionerWhenAutoProvisionEnabled(t *testing.T) {

--- a/internal/project/registry.go
+++ b/internal/project/registry.go
@@ -251,6 +251,14 @@ func projectHealth(trackedProject *Project) Health {
 		status = HealthStatusReady
 	}
 	runtimeErr := trackedProject.RuntimeError()
+	workflowSource := trackedProject.WorkflowSourceStatus()
+	if workflowSource.LastReloadError != "" && status != HealthStatusPaused {
+		status = HealthStatusDegraded
+		if runtimeErr.Message == "" {
+			runtimeErr.Message = workflowSource.LastReloadError
+			runtimeErr.At = workflowSource.ReloadFailedAt
+		}
+	}
 	if status == HealthStatusInitializing && runtimeErr.Message != "" {
 		status = HealthStatusDegraded
 	}

--- a/internal/project/workflow_source.go
+++ b/internal/project/workflow_source.go
@@ -88,6 +88,7 @@ func workflowFileModifiedAt(cfg globalconfig.Project) time.Time {
 		workflowconfig.DefinitionPath(path),
 		workflowconfig.LocalWorkflowPath(path),
 		workflowconfig.LocalDefinitionPath(path),
+		filepath.Join(filepath.Dir(path), workflowconfig.BacklogAdmissionEffortFileAgents),
 	} {
 		info, err := os.Stat(candidate)
 		if err == nil && info.ModTime().After(modified) {
@@ -190,6 +191,11 @@ func (s workflowGitRefSource) load(ctx context.Context) (workflowconfig.Workflow
 	if err != nil {
 		return workflowconfig.Workflow{}, revision, err
 	}
+	agentsPath := path.Join(path.Dir(s.path), workflowconfig.BacklogAdmissionEffortFileAgents)
+	agentsRaw, hasAgents, err := s.loadOptionalRefFile(ctx, revision, agentsPath)
+	if err != nil {
+		return workflowconfig.Workflow{}, revision, err
+	}
 	localWorkflowPath := s.localPath()
 	localRaw, hasLocalWorkflow, err := readOptionalWorkflowSourceFile(localWorkflowPath)
 	if err != nil {
@@ -212,6 +218,9 @@ func (s workflowGitRefSource) load(ctx context.Context) (workflowconfig.Workflow
 		LocalConfigPath:   localConfigPath,
 		LocalConfig:       localConfigRaw,
 		HasLocalConfig:    hasLocalConfig,
+		AgentsPath:        revision + ":" + agentsPath,
+		Agents:            agentsRaw,
+		HasAgents:         hasAgents,
 	})
 	if err != nil {
 		return workflowconfig.Workflow{}, revision, err

--- a/internal/project/workflow_source_test.go
+++ b/internal/project/workflow_source_test.go
@@ -119,6 +119,58 @@ func TestLoadWorkflowUsesSplitDefinitionFromConfiguredGitRef(t *testing.T) {
 	}
 }
 
+func TestLoadWorkflowUsesAdmissionEffortGuidanceFromConfiguredGitRef(t *testing.T) {
+	t.Parallel()
+
+	repo := initWorkflowSourceRepo(t)
+	workflowPrompt := "## Admission Criteria\n\n- **Alignment** — ready.\n"
+	config := `schema: 1
+tracker:
+  kind: memory
+backlog_admission:
+  enabled: true
+  sources:
+    states: [Backlog]
+  target_state: Todo
+  criteria_section: Admission Criteria
+  require_effort: true
+  effort_file: AGENTS.md
+  effort_section: Issue Effort Selection
+`
+	agents := "## Issue Effort Selection\n\n- `medium` — small.\n- `high` — standard.\n"
+	for fileName, content := range map[string]string{
+		"WORKFLOW.md": workflowPrompt,
+		"detent.yaml": config,
+		"AGENTS.md":   agents,
+	} {
+		if err := os.WriteFile(filepath.Join(repo, fileName), []byte(content), 0o644); err != nil {
+			t.Fatalf("WriteFile(%s) error = %v", fileName, err)
+		}
+	}
+	runWorkflowSourceGit(t, repo, "add", "WORKFLOW.md", "detent.yaml", "AGENTS.md")
+	runWorkflowSourceGit(t, repo, "commit", "-m", "configure admission effort source")
+	updateWorkflowSourceRef(t, repo, "origin/main", "HEAD")
+	if err := os.WriteFile(filepath.Join(repo, "AGENTS.md"), []byte("working tree guidance\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile(AGENTS.md) error = %v", err)
+	}
+
+	workflow, err := LoadWorkflow(globalconfig.Project{
+		Workflow:    "WORKFLOW.md",
+		WorkflowRef: "origin/main",
+		Workdir:     repo,
+	})
+	if err != nil {
+		t.Fatalf("LoadWorkflow() error = %v", err)
+	}
+	rubric, err := workflowconfig.ResolveWorkflowAdmissionEffortRubric(workflow)
+	if err != nil {
+		t.Fatalf("ResolveWorkflowAdmissionEffortRubric() error = %v", err)
+	}
+	if len(rubric.Efforts) != 2 || rubric.Efforts[0] != "medium" || strings.Contains(workflow.AgentsPrompt, "working tree guidance") {
+		t.Fatalf("rubric = %#v agents prompt = %q, want configured-ref AGENTS.md", rubric, workflow.AgentsPrompt)
+	}
+}
+
 func TestLoadWorkflowUsesLocalOverlayWithConfiguredGitRef(t *testing.T) {
 	t.Parallel()
 

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -1443,6 +1443,8 @@ func (s *Server) workflowSources() []healthWorkflowSource {
 			LastWatchEventAt: status.LastWatchEventAt,
 			LastReconcileAt:  status.LastReconcileAt,
 			WatcherArmed:     status.WatcherArmed,
+			LastReloadError:  status.LastReloadError,
+			ReloadFailedAt:   status.ReloadFailedAt,
 		})
 	}
 	return sources
@@ -1701,6 +1703,8 @@ type healthWorkflowSource struct {
 	LastWatchEventAt time.Time `json:"last_watch_event_at,omitzero"`
 	LastReconcileAt  time.Time `json:"last_reconcile_at,omitzero"`
 	WatcherArmed     bool      `json:"watcher_armed"`
+	LastReloadError  string    `json:"last_reload_error,omitempty"`
+	ReloadFailedAt   time.Time `json:"reload_failed_at,omitzero"`
 }
 
 type healthBudget struct {

--- a/internal/web/server_test.go
+++ b/internal/web/server_test.go
@@ -34,6 +34,7 @@ import (
 	"github.com/digitaldrywood/detent/internal/buildinfo"
 	workflowconfig "github.com/digitaldrywood/detent/internal/config"
 	globalconfig "github.com/digitaldrywood/detent/internal/config/global"
+	configwatcher "github.com/digitaldrywood/detent/internal/config/watcher"
 	"github.com/digitaldrywood/detent/internal/connector"
 	"github.com/digitaldrywood/detent/internal/connector/local"
 	"github.com/digitaldrywood/detent/internal/efficiency"
@@ -7668,6 +7669,72 @@ func TestHealthDistinguishesProcessHealthFromProjectConnectorDegradation(t *test
 	}
 }
 
+func TestHealthReportsProjectPinnedToLastGoodWorkflow(t *testing.T) {
+	updates := make(chan configwatcher.Update, 1)
+	workflowCfg := workflowconfig.Default()
+	workflowCfg.Tracker.Kind = workflowconfig.TrackerMemory
+	trackedProject, err := project.New(project.Config{
+		Project: globalconfig.Project{ID: "detent", Workflow: "WORKFLOW.md"},
+		Workflow: workflowconfig.Workflow{
+			Config:     workflowCfg,
+			Prompt:     "last-good",
+			SourceHash: "last-good-hash",
+		},
+	}, project.Dependencies{
+		Connector: connectorProbe{name: "memory"},
+		Runner:    orchestrator.FakeRunner{},
+		WorkflowWatcherFactory: func(string) (project.WorkflowWatcher, error) {
+			return healthWorkflowWatcher{updates: updates}, nil
+		},
+	})
+	if err != nil {
+		t.Fatalf("project.New() error = %v", err)
+	}
+	if err := trackedProject.Start(context.Background()); err != nil {
+		t.Fatalf("Project.Start() error = %v", err)
+	}
+	t.Cleanup(func() {
+		if err := trackedProject.Stop(context.Background()); err != nil && !errors.Is(err, project.ErrNotRunning) {
+			t.Fatalf("Project.Stop() error = %v", err)
+		}
+	})
+	deadline := time.Now().Add(time.Second)
+	for !trackedProject.WorkflowSourceStatus().WatcherArmed {
+		if time.Now().After(deadline) {
+			t.Fatal("workflow watcher did not arm")
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	updates <- configwatcher.Update{Path: "WORKFLOW.md", Err: errors.New("effort section missing"), At: time.Now()}
+	for trackedProject.WorkflowSourceStatus().LastReloadError == "" {
+		if time.Now().After(deadline) {
+			t.Fatal("workflow reload failure was not recorded")
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	deps := testDeps(t)
+	if err := deps.Registry.Set(trackedProject); err != nil {
+		t.Fatalf("Registry.Set() error = %v", err)
+	}
+	server, err := web.NewServer(web.Config{}, deps)
+	if err != nil {
+		t.Fatalf("NewServer() error = %v", err)
+	}
+	payload := requestJSON(t, server, http.MethodGet, "/health", http.StatusOK)
+	if payload["project_status"] != "degraded" {
+		t.Fatalf("project_status = %#v, want degraded", payload["project_status"])
+	}
+	projects := payload["projects"].([]any)
+	if len(projects) != 1 || projects[0].(map[string]any)["status"] != "degraded" || !strings.Contains(projects[0].(map[string]any)["last_error"].(string), "workflow reload failed") {
+		t.Fatalf("projects = %#v, want degraded reload failure", projects)
+	}
+	workflows := payload["workflows"].([]any)
+	if len(workflows) != 1 || !strings.Contains(workflows[0].(map[string]any)["last_reload_error"].(string), "effort section missing") || workflows[0].(map[string]any)["reload_failed_at"] == nil {
+		t.Fatalf("workflows = %#v, want persisted reload failure", workflows)
+	}
+}
+
 func TestHealthRespondsDuringDrainWithoutSupplementalProjectReads(t *testing.T) {
 	t.Parallel()
 
@@ -11961,6 +12028,14 @@ type healthBudgetRunner struct {
 type blockingHealthBudgetRunner struct {
 	blocked chan<- struct{}
 	release <-chan struct{}
+}
+
+type healthWorkflowWatcher struct {
+	updates <-chan configwatcher.Update
+}
+
+func (w healthWorkflowWatcher) Watch(context.Context) (<-chan configwatcher.Update, error) {
+	return w.updates, nil
 }
 
 func (blockingHealthBudgetRunner) Run(context.Context, orchestrator.RunRequest) (orchestrator.RunResult, error) {


### PR DESCRIPTION
## Summary

- add an explicit `AGENTS.md` effort-rubric source while preserving `WORKFLOW.md` as the compatibility default
- validate generated onboarding admission sections through the same parser used by runtime reload before writing files
- expose last-good workflow reload failures as degraded project health and a failing doctor diagnostic until recovery

Fixes #1952

## UI Surface Contract

- [x] N/A, or the linked issue explicitly authorizes any high-impact UI surface, layout, density, first-viewport, or responsive visibility tradeoff.
- [x] Persistent top-of-screen messaging is explicitly authorized by the issue, or this PR does not add it.
- [x] Visual changes to primary operator screens include screenshot or browser verification below.

## Test Plan

- [x] `make check`
