### PR TITLE
fix(cli): resolve configured dashboard address

### DIFF
--- a/internal/cli/capacity.go
+++ b/internal/cli/capacity.go
@@ -10,6 +10,8 @@ import (
 	"strings"
 
 	"github.com/spf13/cobra"
+
+	globalconfig "github.com/digitaldrywood/detent/internal/config/global"
 )
 
 type capacityClearResult struct {
@@ -17,6 +19,24 @@ type capacityClearResult struct {
 	Project string `json:"project,omitempty"`
 	Scope   string `json:"scope,omitempty"`
 	Cleared int    `json:"cleared"`
+}
+
+type dashboardAddress struct {
+	Value      string
+	HostSource string
+	PortSource string
+}
+
+const dashboardAddressSourceServiceFlag = "service flag"
+
+func (a dashboardAddress) String() string {
+	if a.Value == "" {
+		return ""
+	}
+	if a.HostSource == a.PortSource {
+		return fmt.Sprintf("%s (from %s)", a.Value, a.HostSource)
+	}
+	return fmt.Sprintf("%s (host from %s, port from %s)", a.Value, a.HostSource, a.PortSource)
 }
 
 func newCapacityCommand(configPath *string, host *string, port *int, opts options) *cobra.Command {
@@ -67,7 +87,7 @@ func runCapacityClear(
 	scope string,
 	opts options,
 ) (capacityClearResult, error) {
-	boot, err := resolveDashboardBoot(ctx, configPath, host, port, portSet, opts)
+	boot, address, err := resolveDashboardBoot(ctx, configPath, host, port, portSet, opts)
 	if err != nil {
 		return capacityClearResult{}, err
 	}
@@ -88,7 +108,7 @@ func runCapacityClear(
 	}
 	response, err := opts.httpDo(request)
 	if err != nil {
-		return capacityClearResult{}, fmt.Errorf("clear capacity outage: %w", err)
+		return capacityClearResult{}, fmt.Errorf("clear capacity outage via %s: %w", address, err)
 	}
 	defer response.Body.Close()
 	if response.StatusCode < http.StatusOK || response.StatusCode >= http.StatusMultipleChoices {
@@ -122,14 +142,14 @@ func resolveDashboardBoot(
 	port int,
 	portSet bool,
 	opts options,
-) (BootConfig, error) {
+) (BootConfig, dashboardAddress, error) {
 	resolution, err := resolveConfigPathResolution(configPath, opts)
 	if err != nil {
-		return BootConfig{}, err
+		return BootConfig{}, dashboardAddress{}, err
 	}
 	cfg, err := opts.read(resolution.Path)
 	if err != nil {
-		return BootConfig{}, err
+		return BootConfig{}, dashboardAddress{}, err
 	}
 	portSetting, err := resolveRuntimePort(ctx, runtimeInput{
 		Config:     &cfg,
@@ -140,14 +160,74 @@ func resolveDashboardBoot(
 		},
 	}, runtimeDepsFromOptions(opts))
 	if err != nil {
-		return BootConfig{}, err
+		return BootConfig{}, dashboardAddress{}, err
+	}
+	hostSetting := resolveDashboardHost(ctx, host, firstGlobalProject(cfg))
+	if hostSetting.Source != runtimeSourceFlag || portSetting.Source != runtimeSourceFlag {
+		serviceArguments := runningServiceArguments(ctx, resolution.Path, opts)
+		if hostSetting.Source != runtimeSourceFlag {
+			if serviceHost, ok := serviceStringFlag(serviceArguments, "--host"); ok {
+				hostSetting = RuntimeValue{Value: serviceHost, Source: dashboardAddressSourceServiceFlag}
+			}
+		}
+		if portSetting.Source != runtimeSourceFlag {
+			if servicePort, ok := serviceIntFlag(serviceArguments, "--port"); ok {
+				portSetting = RuntimeIntValue{Value: servicePort, Source: dashboardAddressSourceServiceFlag}
+			}
+		}
 	}
 	resolvedPort := portSetting.Value
-	return BootConfig{
+	boot := BootConfig{
 		Mode:           BootModeRunning,
 		Global:         cfg,
 		ConfigPathRule: resolution.Rule,
-		Host:           bootHost(ctx, host, firstGlobalProject(cfg)),
+		Host:           hostSetting.Value,
 		Port:           &resolvedPort,
+	}
+	return boot, dashboardAddress{
+		Value:      dashboardServerAddr(boot),
+		HostSource: dashboardAddressSource(hostSetting.Source),
+		PortSource: dashboardAddressSource(portSetting.Source),
 	}, nil
+}
+
+func resolveDashboardHost(ctx context.Context, host string, project globalconfig.Project) RuntimeValue {
+	if host = strings.TrimSpace(host); host != "" {
+		return RuntimeValue{Value: host, Source: runtimeSourceFlag}
+	}
+	if host = bootHost(ctx, "", project); host != "" {
+		return RuntimeValue{Value: host, Source: runtimeSourceConfig}
+	}
+	return RuntimeValue{Value: defaultWebHost, Source: runtimeSourceDefault}
+}
+
+func dashboardAddressSource(source string) string {
+	if source == runtimeSourceWorkflow {
+		return runtimeSourceConfig
+	}
+	return sourceDetail(source)
+}
+
+func serviceStringFlag(arguments []string, name string) (string, bool) {
+	var value string
+	var found bool
+	for index, argument := range arguments {
+		if argument == name && index+1 < len(arguments) {
+			value = strings.TrimSpace(arguments[index+1])
+			found = value != ""
+		}
+		if raw, ok := strings.CutPrefix(argument, name+"="); ok {
+			value = strings.TrimSpace(raw)
+			found = value != ""
+		}
+	}
+	return value, found
+}
+
+func serviceIntFlag(arguments []string, name string) (int, bool) {
+	raw, ok := serviceStringFlag(arguments, name)
+	if !ok {
+		return 0, false
+	}
+	return validServicePort(raw)
 }

--- a/internal/cli/capacity_test.go
+++ b/internal/cli/capacity_test.go
@@ -1,14 +1,20 @@
 package cli
 
 import (
+	"context"
 	"encoding/json"
+	"errors"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"path/filepath"
 	"strconv"
+	"strings"
 	"testing"
 
 	globalconfig "github.com/digitaldrywood/detent/internal/config/global"
+	servicepkg "github.com/digitaldrywood/detent/internal/service"
 )
 
 func TestRunCapacityClear(t *testing.T) {
@@ -82,4 +88,144 @@ func TestDashboardServerAddrNormalizesWildcardHosts(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestResolveDashboardBootAddressPrecedence(t *testing.T) {
+	configuredHost := "100.109.187.102"
+	configuredPort := 4101
+	root := t.TempDir()
+	workflowPath := filepath.Join(root, "WORKFLOW.md")
+	writeBootHostWorkflow(t, workflowPath, configuredHost)
+	configured := globalconfig.Config{
+		Port: &configuredPort,
+		Projects: []globalconfig.Project{{
+			ID:       "detent",
+			Workflow: workflowPath,
+			Workdir:  root,
+		}},
+	}
+
+	tests := []struct {
+		name      string
+		config    globalconfig.Config
+		host      string
+		port      int
+		portSet   bool
+		service   bool
+		wantValue string
+		wantText  string
+	}{
+		{
+			name:      "configured address",
+			config:    configured,
+			port:      -1,
+			wantValue: "100.109.187.102:4101",
+			wantText:  "100.109.187.102:4101 (from config)",
+		},
+		{
+			name:      "flags override config",
+			config:    configured,
+			host:      "127.0.0.8",
+			port:      4202,
+			portSet:   true,
+			wantValue: "127.0.0.8:4202",
+			wantText:  "127.0.0.8:4202 (from flag)",
+		},
+		{
+			name:      "running service flags override config",
+			config:    configured,
+			port:      -1,
+			service:   true,
+			wantValue: "100.111.222.33:4303",
+			wantText:  "100.111.222.33:4303 (from service flag)",
+		},
+		{
+			name:      "defaults",
+			port:      -1,
+			wantValue: "127.0.0.1:4000",
+			wantText:  "127.0.0.1:4000 (from default)",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			opts := dashboardAddressOptions(tt.config)
+			if tt.service {
+				opts.service = serviceFactoryFor(&serviceRunnerStub{status: servicepkg.Status{
+					ServiceManager: servicepkg.ManagerSystemd,
+					ServiceScope:   "system",
+					Service:        "detent.service",
+					State:          servicepkg.StateRunning,
+				}})
+				opts.runCommand = func(context.Context, string, ...string) (string, error) {
+					return "[Service]\nExecStart=/usr/bin/detent --config /config/global.yaml --host 127.0.0.1 --port 4000\n# override.conf\nExecStart=\nExecStart=/usr/bin/detent --config /config/global.yaml --host 100.111.222.33 --port=4303\n", nil
+				}
+			}
+			_, address, err := resolveDashboardBoot(t.Context(), "/config/global.yaml", tt.host, tt.port, tt.portSet, opts)
+			if err != nil {
+				t.Fatalf("resolveDashboardBoot() error = %v", err)
+			}
+			if address.Value != tt.wantValue || address.String() != tt.wantText {
+				t.Fatalf("address = %#v, text = %q", address, address.String())
+			}
+		})
+	}
+}
+
+func TestRunCapacityClearUsesConfiguredAddress(t *testing.T) {
+	configuredPort := 4101
+	root := t.TempDir()
+	workflowPath := filepath.Join(root, "WORKFLOW.md")
+	writeBootHostWorkflow(t, workflowPath, "100.109.187.102")
+	opts := dashboardAddressOptions(globalconfig.Config{
+		Port: &configuredPort,
+		Projects: []globalconfig.Project{{
+			ID:       "detent",
+			Workflow: workflowPath,
+			Workdir:  root,
+		}},
+	})
+	opts.httpDo = func(request *http.Request) (*http.Response, error) {
+		if got := request.URL.Host; got != "100.109.187.102:4101" {
+			t.Fatalf("request host = %q", got)
+		}
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Header:     make(http.Header),
+			Body:       io.NopCloser(strings.NewReader(`{"status":"cleared","cleared":1}`)),
+		}, nil
+	}
+
+	result, err := runCapacityClear(t.Context(), "/config/global.yaml", "", -1, false, "", "codex", opts)
+	if err != nil {
+		t.Fatalf("runCapacityClear() error = %v", err)
+	}
+	if result.Cleared != 1 {
+		t.Fatalf("result = %#v", result)
+	}
+}
+
+func TestRunCapacityClearConnectionErrorIncludesAddressSource(t *testing.T) {
+	opts := dashboardAddressOptions(globalconfig.Config{})
+	opts.httpDo = func(*http.Request) (*http.Response, error) {
+		return nil, errors.New("connection refused")
+	}
+
+	_, err := runCapacityClear(t.Context(), "/config/global.yaml", "127.0.0.8", 4202, true, "", "codex", opts)
+	if err == nil || !strings.Contains(err.Error(), "127.0.0.8:4202 (from flag)") {
+		t.Fatalf("runCapacityClear() error = %v", err)
+	}
+}
+
+func dashboardAddressOptions(cfg globalconfig.Config) options {
+	opts := defaultOptions()
+	opts.resolvePath = func(string) (globalconfig.PathResolution, error) {
+		return globalconfig.PathResolution{Path: "/config/global.yaml", Rule: globalconfig.PathRuleFlag}, nil
+	}
+	opts.read = func(string) (globalconfig.Config, error) {
+		return cfg, nil
+	}
+	opts.lookupEnv = func(string) string { return "" }
+	opts.service = serviceFactoryFor(&serviceRunnerStub{status: servicepkg.Status{State: servicepkg.StateStopped}})
+	return opts
 }

--- a/internal/cli/dashboard_client.go
+++ b/internal/cli/dashboard_client.go
@@ -30,6 +30,7 @@ type dashboardHTTPClient interface {
 
 type DashboardReadClient struct {
 	baseURL    *url.URL
+	address    dashboardAddress
 	credential string
 	http       dashboardHTTPClient
 	timeout    time.Duration
@@ -61,6 +62,7 @@ func (e *DashboardResponseError) Error() string {
 type DashboardTransportError struct {
 	Timeout bool
 	Err     error
+	Address dashboardAddress
 }
 
 type DashboardState struct {
@@ -84,7 +86,13 @@ func (e *DashboardTransportError) Error() string {
 		return ""
 	}
 	if e.Timeout {
+		if detail := e.Address.String(); detail != "" {
+			return "dashboard API request to " + detail + " timed out"
+		}
 		return "dashboard API request timed out"
+	}
+	if detail := e.Address.String(); detail != "" {
+		return "dashboard API at " + detail + " is unreachable"
 	}
 	return "dashboard API is unreachable"
 }
@@ -104,7 +112,7 @@ func newDashboardReadClient(
 	portSet bool,
 	opts options,
 ) (*DashboardReadClient, error) {
-	boot, err := resolveDashboardBoot(ctx, configPath, host, port, portSet, opts)
+	boot, address, err := resolveDashboardBoot(ctx, configPath, host, port, portSet, opts)
 	if err != nil {
 		return nil, err
 	}
@@ -121,6 +129,7 @@ func newDashboardReadClient(
 	}
 	return &DashboardReadClient{
 		baseURL:    baseURL,
+		address:    address,
 		credential: credential,
 		http:       dashboardHTTPClientFunc(opts.httpDo),
 		timeout:    dashboardReadTimeout,
@@ -254,6 +263,7 @@ func (c *DashboardReadClient) requestJSON(ctx context.Context, method string, re
 		return 0, &DashboardTransportError{
 			Timeout: errors.Is(requestContext.Err(), context.DeadlineExceeded),
 			Err:     err,
+			Address: c.address,
 		}
 	}
 	defer response.Body.Close()
@@ -372,6 +382,7 @@ func (c *DashboardReadClient) Execute(ctx context.Context, call operatortool.Cal
 		return operatortool.Result{}, &DashboardTransportError{
 			Timeout: errors.Is(requestContext.Err(), context.DeadlineExceeded),
 			Err:     err,
+			Address: c.address,
 		}
 	}
 	defer response.Body.Close()

--- a/internal/cli/dashboard_client_test.go
+++ b/internal/cli/dashboard_client_test.go
@@ -363,6 +363,48 @@ func TestClassifyDashboardReadProblems(t *testing.T) {
 	}
 }
 
+func TestClassifyDashboardReadTransportIncludesAddressSource(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		timeout bool
+		err     error
+		want    string
+	}{
+		{
+			name: "unreachable",
+			err:  errors.New("connection refused"),
+			want: "dashboard API at 100.109.187.102:4101 (host from config, port from default) is unreachable",
+		},
+		{
+			name:    "timeout",
+			timeout: true,
+			err:     context.DeadlineExceeded,
+			want:    "dashboard API request to 100.109.187.102:4101 (host from config, port from default) timed out",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			err := &DashboardTransportError{
+				Timeout: tt.timeout,
+				Err:     tt.err,
+				Address: dashboardAddress{
+					Value:      "100.109.187.102:4101",
+					HostSource: runtimeSourceConfig,
+					PortSource: runtimeSourceDefault,
+				},
+			}
+			problem := ProblemForError(classifyDashboardReadError(err))
+			if problem.Detail != tt.want {
+				t.Fatalf("problem detail = %q, want %q", problem.Detail, tt.want)
+			}
+		})
+	}
+}
+
 func dashboardClientForServer(t *testing.T, server *httptest.Server, credential string) *DashboardReadClient {
 	t.Helper()
 	parsed, err := url.Parse(server.URL)

--- a/internal/cli/issue.go
+++ b/internal/cli/issue.go
@@ -66,15 +66,15 @@ func classifyDashboardReadError(err error) error {
 	if err == nil || errors.Is(err, context.Canceled) {
 		return err
 	}
-	if errors.Is(err, context.DeadlineExceeded) {
-		return NewClassifiedError(ErrDashboardTimeout, errorCodeDashboardTimeout, "dashboard API request timed out", "Confirm Detent is responsive, or retry the command.", nil)
-	}
 	var transport *DashboardTransportError
 	if errors.As(err, &transport) {
 		if transport.Timeout {
-			return NewClassifiedError(ErrDashboardTimeout, errorCodeDashboardTimeout, "dashboard API request timed out", "Confirm Detent is responsive, or retry the command.", nil)
+			return NewClassifiedError(ErrDashboardTimeout, errorCodeDashboardTimeout, transport.Error(), "Confirm Detent is responsive, or retry the command.", nil)
 		}
-		return NewClassifiedError(ErrDashboardUnreachable, errorCodeDashboardUnreachable, "dashboard service is stopped or unreachable", "Start Detent or verify the configured host and port.", nil)
+		return NewClassifiedError(ErrDashboardUnreachable, errorCodeDashboardUnreachable, transport.Error(), "Start Detent or verify the configured host and port.", nil)
+	}
+	if errors.Is(err, context.DeadlineExceeded) {
+		return NewClassifiedError(ErrDashboardTimeout, errorCodeDashboardTimeout, "dashboard API request timed out", "Confirm Detent is responsive, or retry the command.", nil)
 	}
 	var response *DashboardResponseError
 	if !errors.As(err, &response) {

--- a/internal/cli/service.go
+++ b/internal/cli/service.go
@@ -239,19 +239,83 @@ func installedServicePort(manager servicepkg.ManagerName, path string) (int, boo
 	return 0, false
 }
 
+func runningServiceArguments(ctx context.Context, configPath string, opts options) []string {
+	factory := opts.service
+	if factory == nil {
+		factory = defaultServiceFactory
+	}
+	runCommand := opts.runCommand
+	if runCommand == nil {
+		runCommand = defaultCommandRunner
+	}
+	runner, err := factory(servicepkg.Config{
+		GOOS:       runtime.GOOS,
+		ConfigPath: configPath,
+		LockPath:   filepath.Join(filepath.Dir(configPath), "detent.db.lock"),
+		RunCommand: servicepkg.CommandRunner(runCommand),
+	})
+	if err != nil {
+		return nil
+	}
+	status, err := runner.Status(ctx)
+	if err != nil || !status.Running() {
+		return nil
+	}
+	switch status.ServiceManager {
+	case servicepkg.ManagerSystemd:
+		arguments := []string{"cat", status.Service}
+		if status.ServiceScope == "user" {
+			arguments = append([]string{"--user"}, arguments...)
+		}
+		if content, runErr := runCommand(ctx, "systemctl", arguments...); runErr == nil {
+			if parsed := systemdDefinitionArguments([]byte(content)); len(parsed) > 0 {
+				return serviceArgumentsForConfig(parsed, configPath)
+			}
+		}
+	case servicepkg.ManagerLaunchd:
+		if content, readErr := os.ReadFile(status.DefinitionPath); readErr == nil {
+			return serviceArgumentsForConfig(launchdDefinitionArguments(content), configPath)
+		}
+	}
+	if content, readErr := os.ReadFile(status.DefinitionPath); readErr == nil {
+		return serviceArgumentsForConfig(systemdDefinitionArguments(content), configPath)
+	}
+	return nil
+}
+
+func serviceArgumentsForConfig(arguments []string, configPath string) []string {
+	serviceConfig, ok := serviceStringFlag(arguments, "--config")
+	if !ok {
+		return nil
+	}
+	serviceConfig, serviceErr := filepath.Abs(serviceConfig)
+	configPath, configErr := filepath.Abs(configPath)
+	if serviceErr != nil || configErr != nil || filepath.Clean(serviceConfig) != filepath.Clean(configPath) {
+		return nil
+	}
+	return arguments
+}
+
 func validServicePort(raw string) (int, bool) {
 	port, err := strconv.Atoi(strings.TrimSpace(raw))
 	return port, err == nil && port >= 0
 }
 
 func systemdDefinitionArguments(content []byte) []string {
+	var arguments []string
 	for line := range strings.SplitSeq(string(content), "\n") {
 		value, ok := strings.CutPrefix(strings.TrimSpace(line), "ExecStart=")
-		if ok {
-			return splitDefinitionArguments(value)
+		if !ok {
+			continue
+		}
+		if parsed := splitDefinitionArguments(value); len(parsed) > 0 {
+			for index := range parsed {
+				parsed[index] = strings.ReplaceAll(parsed[index], "%%", "%")
+			}
+			arguments = parsed
 		}
 	}
-	return nil
+	return arguments
 }
 
 func splitDefinitionArguments(value string) []string {

--- a/internal/cli/service_test.go
+++ b/internal/cli/service_test.go
@@ -229,6 +229,17 @@ func TestStoppedManagedServiceUsesNonzeroExitCode(t *testing.T) {
 	}
 }
 
+func TestSystemdDefinitionArgumentsDecodesLiteralPercents(t *testing.T) {
+	t.Parallel()
+
+	content := []byte(`ExecStart="/opt/detent%%worker" --config "/config/tenant%%2/global.yaml" --host "fe80::1%%eth0"`)
+	want := []string{"/opt/detent%worker", "--config", "/config/tenant%2/global.yaml", "--host", "fe80::1%eth0"}
+
+	if got := systemdDefinitionArguments(content); !reflect.DeepEqual(got, want) {
+		t.Fatalf("systemdDefinitionArguments() = %#v, want %#v", got, want)
+	}
+}
+
 func TestServiceCommandResolvesConfigAndRuntime(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

- resolve API-backed CLI dashboard addresses from matching running service flags before workflow/global configuration and defaults
- preserve explicit host and port flag precedence
- include the attempted address and independent host/port sources in transport failures

Fixes #1959

## UI Surface Contract

- [x] N/A, or the linked issue explicitly authorizes any high-impact UI surface, layout, density, first-viewport, or responsive visibility tradeoff.
- [x] Persistent top-of-screen messaging is explicitly authorized by the issue, or this PR does not add it.
- [x] Visual changes to primary operator screens include screenshot or browser verification below.

No UI changes.

## Test Plan

- [x] `make check`
- [x] `go test ./internal/cli -count=1`