### PR TITLE
fix(capacity): probe on codex auth change

### DIFF
--- a/.detent/skills/resilient-file-watch-reconciliation.md
+++ b/.detent/skills/resilient-file-watch-reconciliation.md
@@ -1,0 +1,16 @@
+---
+name: resilient-file-watch-reconciliation
+description: Keep file-triggered runtime reconciliation reliable when parent directories appear late or filesystem events are missed.
+when_to_use: Use when a long-running Detent watcher must react to atomic replacement, credentials or config paths may not exist at startup, or focused watcher tests become flaky under concurrent race suites.
+---
+
+# Resilient file-watch reconciliation
+
+- Attach the initial filesystem watch synchronously before reporting readiness so an immediate write cannot race watcher startup.
+- If the watched directory is absent, retain ownership of the target and retry attachment on a bounded interval instead of dropping it.
+- Capture a comparable file stamp before returning from successful initial setup. Include modification time, size, and mode when content does not need to be read.
+- Keep filesystem events as the fast path, but reconcile the stamp periodically. OS watcher delivery can miss an atomic rename under load.
+- Route event-driven and periodic observations through the same stamp comparison so one replacement produces one notification.
+- When attachment succeeds after retries, compare the current stamp with the last observation and notify if the file appeared or changed while detached.
+- Stop retry timers, poll timers, and watcher goroutines on context cancellation, and expose a completion channel so the owner can wait for shutdown.
+- Inject short retry and poll intervals in tests. Cover initial replacement, an absent parent followed by file creation, duplicate suppression, cancellation, and a race-enabled repetition.

--- a/internal/cli/backend_credentials.go
+++ b/internal/cli/backend_credentials.go
@@ -1,0 +1,405 @@
+package cli
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/digitaldrywood/detent/internal/backendcapacity"
+	workflowconfig "github.com/digitaldrywood/detent/internal/config"
+	configwatcher "github.com/digitaldrywood/detent/internal/config/watcher"
+	"github.com/digitaldrywood/detent/internal/hub"
+	"github.com/digitaldrywood/detent/internal/orchestrator"
+	"github.com/digitaldrywood/detent/internal/project"
+)
+
+var codexHomeAssignmentPattern = regexp.MustCompile(`(?:^|[[:space:];])CODEX_HOME=(?:"([^"]*)"|'([^']*)'|([^[:space:];|&]+))`)
+
+const backendCredentialWatchRetryDelay = 5 * time.Second
+
+type backendCredentialTarget struct {
+	projectID project.ID
+	scope     backendcapacity.Scope
+}
+
+type backendCredentialWatch struct {
+	path    string
+	targets []backendCredentialTarget
+}
+
+type credentialFileStamp struct {
+	modified int64
+	size     int64
+	mode     uint32
+}
+
+type backendCredentialWatchSet struct {
+	cancel context.CancelFunc
+	done   <-chan struct{}
+}
+
+func startBackendCredentialWatchers(
+	ctx context.Context,
+	registry *project.Registry,
+	events *hub.Hub[project.Event],
+	logger *slog.Logger,
+) <-chan struct{} {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if logger == nil {
+		logger = slog.Default()
+	}
+	var eventUpdates <-chan project.Event
+	var subscription *hub.Subscription[project.Event]
+	if events != nil {
+		var err error
+		subscription, err = events.Subscribe(ctx)
+		if err != nil {
+			logger.Warn("subscribe backend credential watcher to project events failed", "error", err)
+		} else {
+			eventUpdates = subscription.C()
+		}
+	}
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		if subscription != nil {
+			defer subscription.Close()
+		}
+		watchers := startBackendCredentialWatchSet(ctx, registry, logger)
+		defer watchers.stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case event, ok := <-eventUpdates:
+				if !ok {
+					eventUpdates = nil
+					continue
+				}
+				switch event.Kind {
+				case project.EventStarted, project.EventStopped, project.EventWorkflowReloaded:
+					watchers.stop()
+					watchers = startBackendCredentialWatchSet(ctx, registry, logger)
+				}
+			}
+		}
+	}()
+	return done
+}
+
+func startBackendCredentialWatchSet(ctx context.Context, registry *project.Registry, logger *slog.Logger) backendCredentialWatchSet {
+	watchCtx, cancel := context.WithCancel(ctx)
+	done := make(chan struct{})
+	watches := configuredBackendCredentialWatches(registry, logger)
+	var workers sync.WaitGroup
+	for _, watch := range watches {
+		watch := watch
+		watchDone, err := startBackendCredentialFileWatcher(watchCtx, watch.path, func(ctx context.Context) {
+			notifyBackendCredentialTargets(ctx, registry, watch.targets, logger)
+		}, logger)
+		if err != nil {
+			logger.Warn("watch backend credential file failed", "path", watch.path, "error", err)
+			continue
+		}
+		workers.Go(func() {
+			<-watchDone
+		})
+	}
+	go func() {
+		workers.Wait()
+		close(done)
+	}()
+	return backendCredentialWatchSet{cancel: cancel, done: done}
+}
+
+func (w backendCredentialWatchSet) stop() {
+	if w.cancel != nil {
+		w.cancel()
+	}
+	if w.done != nil {
+		<-w.done
+	}
+}
+
+func configuredBackendCredentialWatches(registry *project.Registry, logger *slog.Logger) []backendCredentialWatch {
+	if registry == nil {
+		return nil
+	}
+	byPath := map[string][]backendCredentialTarget{}
+	seen := map[string]struct{}{}
+	for _, trackedProject := range registry.List() {
+		if trackedProject == nil || trackedProject.Orchestrator() == nil {
+			continue
+		}
+		for _, backend := range trackedProject.Workflow().Config.AgentBackendConfigs() {
+			if backend.Kind != workflowconfig.AgentBackendCodex {
+				continue
+			}
+			path, err := codexCredentialPath(backend.Command, os.LookupEnv, os.UserHomeDir)
+			if err != nil {
+				logger.Warn("resolve codex credential path failed", "project_id", trackedProject.ID(), "backend_id", backend.ID, "error", err)
+				continue
+			}
+			provider := strings.TrimSpace(backend.Provider)
+			if provider == "" {
+				provider = strings.TrimSpace(backend.CodexOptions().ModelProvider)
+			}
+			target := backendCredentialTarget{
+				projectID: trackedProject.ID(),
+				scope: backendcapacity.Scope{
+					BackendID:   backend.ID,
+					BackendKind: backend.Kind,
+					Provider:    provider,
+				}.Normalize(),
+			}
+			key := path + "\x00" + string(target.projectID) + "\x00" + target.scope.Key()
+			if _, ok := seen[key]; ok {
+				continue
+			}
+			seen[key] = struct{}{}
+			byPath[path] = append(byPath[path], target)
+		}
+	}
+	paths := make([]string, 0, len(byPath))
+	for path := range byPath {
+		paths = append(paths, path)
+	}
+	sort.Strings(paths)
+	watches := make([]backendCredentialWatch, 0, len(paths))
+	for _, path := range paths {
+		watches = append(watches, backendCredentialWatch{path: path, targets: byPath[path]})
+	}
+	return watches
+}
+
+func codexCredentialPath(
+	command string,
+	lookupEnv func(string) (string, bool),
+	userHomeDir func() (string, error),
+) (string, error) {
+	if lookupEnv == nil {
+		lookupEnv = os.LookupEnv
+	}
+	if userHomeDir == nil {
+		userHomeDir = os.UserHomeDir
+	}
+	root := codexHomeFromCommand(command)
+	if root == "" {
+		root, _ = lookupEnv("CODEX_HOME")
+	}
+	root = os.Expand(root, func(name string) string {
+		value, _ := lookupEnv(name)
+		return value
+	})
+	root = strings.TrimSpace(root)
+	if root == "" {
+		home, err := userHomeDir()
+		if err != nil {
+			return "", fmt.Errorf("resolve home directory: %w", err)
+		}
+		root = filepath.Join(home, ".codex")
+	} else if root == "~" || strings.HasPrefix(root, "~/") {
+		home, err := userHomeDir()
+		if err != nil {
+			return "", fmt.Errorf("expand codex home: %w", err)
+		}
+		root = filepath.Join(home, strings.TrimPrefix(strings.TrimPrefix(root, "~"), "/"))
+	}
+	absolute, err := filepath.Abs(root)
+	if err != nil {
+		return "", fmt.Errorf("resolve codex home: %w", err)
+	}
+	return filepath.Join(filepath.Clean(absolute), "auth.json"), nil
+}
+
+func codexHomeFromCommand(command string) string {
+	match := codexHomeAssignmentPattern.FindStringSubmatch(command)
+	if len(match) == 0 {
+		return ""
+	}
+	for _, value := range match[1:] {
+		if strings.TrimSpace(value) != "" {
+			return strings.TrimSpace(value)
+		}
+	}
+	return ""
+}
+
+func startBackendCredentialFileWatcher(
+	ctx context.Context,
+	path string,
+	notify func(context.Context),
+	logger *slog.Logger,
+) (<-chan struct{}, error) {
+	return startBackendCredentialFileWatcherWithRetry(ctx, path, notify, logger, backendCredentialWatchRetryDelay)
+}
+
+func startBackendCredentialFileWatcherWithRetry(
+	ctx context.Context,
+	path string,
+	notify func(context.Context),
+	logger *slog.Logger,
+	retryDelay time.Duration,
+) (<-chan struct{}, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if logger == nil {
+		logger = slog.Default()
+	}
+	if retryDelay <= 0 {
+		retryDelay = backendCredentialWatchRetryDelay
+	}
+	watcher, err := configwatcher.NewFile(path, readCredentialFileStamp, configwatcher.WithFileLogger(logger))
+	if err != nil {
+		return nil, err
+	}
+	updates, watchErr := watcher.Watch(ctx)
+	var initialStamp *credentialFileStamp
+	if watchErr == nil {
+		stamp, stampErr := readCredentialFileStamp(path)
+		if stampErr == nil {
+			initialStamp = &stamp
+		} else if !errors.Is(stampErr, os.ErrNotExist) {
+			logger.Warn("read backend credential file metadata failed", "path", path, "error", stampErr)
+		}
+	}
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		lastStamp := initialStamp
+		retrying := watchErr != nil
+		loggedWatchFailure := false
+		for {
+			if watchErr != nil {
+				if !loggedWatchFailure {
+					logger.Warn("watch backend credential file failed; retrying", "path", path, "retry_delay", retryDelay, "error", watchErr)
+				}
+				loggedWatchFailure = true
+				retrying = true
+				if !waitForBackendCredentialWatchRetry(ctx, retryDelay) {
+					return
+				}
+				updates, watchErr = watcher.Watch(ctx)
+				continue
+			}
+
+			if stamp, stampErr := readCredentialFileStamp(path); stampErr == nil {
+				if backendCredentialStampChanged(&lastStamp, stamp) && notify != nil {
+					notify(ctx)
+				}
+			} else if !errors.Is(stampErr, os.ErrNotExist) {
+				logger.Warn("read backend credential file metadata failed", "path", path, "error", stampErr)
+			}
+			if retrying {
+				logger.Info("backend credential file watcher attached", "path", path)
+			}
+			loggedWatchFailure = false
+
+			if !monitorBackendCredentialFile(ctx, path, updates, notify, logger, retryDelay, &lastStamp) {
+				return
+			}
+			retrying = true
+			if !waitForBackendCredentialWatchRetry(ctx, retryDelay) {
+				return
+			}
+			updates, watchErr = watcher.Watch(ctx)
+		}
+	}()
+	return done, nil
+}
+
+func monitorBackendCredentialFile(
+	ctx context.Context,
+	path string,
+	updates <-chan configwatcher.FileUpdate[credentialFileStamp],
+	notify func(context.Context),
+	logger *slog.Logger,
+	pollInterval time.Duration,
+	lastStamp **credentialFileStamp,
+) bool {
+	poll := time.NewTicker(pollInterval)
+	defer poll.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return false
+		case update, ok := <-updates:
+			if !ok {
+				return true
+			}
+			if update.Err != nil {
+				logger.Warn("reload backend credential file metadata failed", "path", update.Path, "error", update.Err)
+				continue
+			}
+			if backendCredentialStampChanged(lastStamp, update.Value) && notify != nil {
+				notify(ctx)
+			}
+		case <-poll.C:
+			stamp, err := readCredentialFileStamp(path)
+			if err == nil && backendCredentialStampChanged(lastStamp, stamp) && notify != nil {
+				notify(ctx)
+			}
+		}
+	}
+}
+
+func backendCredentialStampChanged(last **credentialFileStamp, current credentialFileStamp) bool {
+	if *last != nil && **last == current {
+		return false
+	}
+	stamp := current
+	*last = &stamp
+	return true
+}
+
+func waitForBackendCredentialWatchRetry(ctx context.Context, delay time.Duration) bool {
+	timer := time.NewTimer(delay)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		return false
+	case <-timer.C:
+		return true
+	}
+}
+
+func readCredentialFileStamp(path string) (credentialFileStamp, error) {
+	info, err := os.Stat(path)
+	if err != nil {
+		return credentialFileStamp{}, err
+	}
+	return credentialFileStamp{
+		modified: info.ModTime().UnixNano(),
+		size:     info.Size(),
+		mode:     uint32(info.Mode()),
+	}, nil
+}
+
+func notifyBackendCredentialTargets(ctx context.Context, registry *project.Registry, targets []backendCredentialTarget, logger *slog.Logger) {
+	for _, target := range targets {
+		trackedProject, ok := registry.Get(target.projectID)
+		if !ok || trackedProject == nil || trackedProject.Orchestrator() == nil {
+			continue
+		}
+		scheduled, err := trackedProject.Orchestrator().BackendCredentialChanged(ctx, target.scope)
+		if err != nil {
+			if ctx.Err() == nil && !errors.Is(err, orchestrator.ErrStopped) {
+				logger.Warn("notify backend credential change failed", "project_id", target.projectID, "backend_id", target.scope.BackendID, "error", err)
+			}
+			continue
+		}
+		logger.Info("backend credential file changed", "project_id", target.projectID, "backend_id", target.scope.BackendID, "capacity_probe_scheduled", scheduled)
+	}
+}

--- a/internal/cli/backend_credentials_test.go
+++ b/internal/cli/backend_credentials_test.go
@@ -1,0 +1,157 @@
+package cli
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestCodexCredentialPath(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		command  string
+		env      map[string]string
+		home     string
+		wantRoot string
+	}{
+		{
+			name:     "command assignment overrides inherited home",
+			command:  "env CODEX_HOME=/opt/detent/codex-high codex app-server",
+			env:      map[string]string{"CODEX_HOME": "/var/lib/codex"},
+			home:     "/home/operator",
+			wantRoot: "/opt/detent/codex-high",
+		},
+		{
+			name:     "quoted command assignment expands environment",
+			command:  `CODEX_HOME="$HOME/codex profile" codex app-server`,
+			env:      map[string]string{"HOME": "/home/operator"},
+			home:     "/home/operator",
+			wantRoot: "/home/operator/codex profile",
+		},
+		{
+			name:     "inherited codex home",
+			command:  "codex app-server",
+			env:      map[string]string{"CODEX_HOME": "/var/lib/codex"},
+			home:     "/home/operator",
+			wantRoot: "/var/lib/codex",
+		},
+		{
+			name:     "default user home",
+			command:  "codex app-server",
+			home:     "/home/operator",
+			wantRoot: "/home/operator/.codex",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			lookup := func(name string) (string, bool) {
+				value, ok := tt.env[name]
+				return value, ok
+			}
+			got, err := codexCredentialPath(tt.command, lookup, func() (string, error) {
+				return tt.home, nil
+			})
+			if err != nil {
+				t.Fatalf("codexCredentialPath() error = %v", err)
+			}
+			wantRoot, err := filepath.Abs(filepath.FromSlash(tt.wantRoot))
+			if err != nil {
+				t.Fatalf("resolve expected credential root: %v", err)
+			}
+			want := filepath.Join(wantRoot, "auth.json")
+			if got != want {
+				t.Fatalf("codexCredentialPath() = %q, want %q", got, want)
+			}
+		})
+	}
+}
+
+func TestBackendCredentialFileWatcherNotifiesOnReplacement(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "auth.json")
+	if err := os.WriteFile(path, []byte("first account"), 0o600); err != nil {
+		t.Fatalf("write initial auth file: %v", err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	notified := make(chan struct{}, 2)
+	done, err := startBackendCredentialFileWatcherWithRetry(ctx, path, func(context.Context) {
+		notified <- struct{}{}
+	}, nil, 10*time.Millisecond)
+	if err != nil {
+		t.Fatalf("startBackendCredentialFileWatcher() error = %v", err)
+	}
+
+	replacement := filepath.Join(dir, "auth.json.replacement")
+	if err := os.WriteFile(replacement, []byte("replacement account"), 0o600); err != nil {
+		t.Fatalf("write replacement auth file: %v", err)
+	}
+	if err := os.Rename(replacement, path); err != nil {
+		t.Fatalf("replace auth file: %v", err)
+	}
+
+	select {
+	case <-notified:
+	case <-time.After(5 * time.Second):
+		t.Fatal("credential replacement did not trigger watcher notification")
+	}
+	select {
+	case <-notified:
+		t.Fatal("one credential replacement triggered duplicate notifications")
+	case <-time.After(500 * time.Millisecond):
+	}
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("credential watcher did not stop after cancellation")
+	}
+}
+
+func TestBackendCredentialFileWatcherRetriesMissingDirectory(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join(t.TempDir(), "missing", "codex", "auth.json")
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	notified := make(chan struct{}, 1)
+	done, err := startBackendCredentialFileWatcherWithRetry(ctx, path, func(context.Context) {
+		notified <- struct{}{}
+	}, nil, 10*time.Millisecond)
+	if err != nil {
+		t.Fatalf("startBackendCredentialFileWatcher() error = %v", err)
+	}
+
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("create credential directory: %v", err)
+	}
+	if err := os.WriteFile(path, []byte("new account"), 0o600); err != nil {
+		t.Fatalf("create credential file: %v", err)
+	}
+
+	select {
+	case <-notified:
+	case <-time.After(5 * time.Second):
+		t.Fatal("credential creation after missing directory did not trigger watcher notification")
+	}
+	select {
+	case <-notified:
+		t.Fatal("credential creation after missing directory triggered duplicate notifications")
+	case <-time.After(100 * time.Millisecond):
+	}
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("credential watcher did not stop after cancellation")
+	}
+}

--- a/internal/cli/boot.go
+++ b/internal/cli/boot.go
@@ -491,6 +491,10 @@ func startRunningWithDependencies(ctx context.Context, cfg BootConfig, deps star
 		}
 		go updateScheduler.Run(ctx)
 		globalWatcherDone := startGlobalConfigWatcher(ctx, cfg.Global, manager, logger, runtimeGitHubToken, applyRuntimeConfig, onGlobalReload)
+		credentialWatcherDone := startBackendCredentialWatchers(ctx, manager.Registry(), events, logger)
+		resourceWorkers.Go(func() {
+			<-credentialWatcherDone
+		})
 		select {
 		case globalWatcherStarted <- globalWatcherDone:
 		default:

--- a/internal/orchestrator/backend_credentials.go
+++ b/internal/orchestrator/backend_credentials.go
@@ -1,0 +1,80 @@
+package orchestrator
+
+import (
+	"context"
+	"log/slog"
+	"strings"
+	"time"
+
+	"github.com/digitaldrywood/detent/internal/backendcapacity"
+	"github.com/digitaldrywood/detent/internal/telemetry"
+)
+
+type backendCredentialChangeRequest struct {
+	scope backendcapacity.Scope
+	at    time.Time
+	reply chan bool
+}
+
+func (o *Orchestrator) BackendCredentialChanged(ctx context.Context, scope backendcapacity.Scope) (bool, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	request := backendCredentialChangeRequest{
+		scope: scope.Normalize(),
+		at:    o.clockNow(),
+		reply: make(chan bool, 1),
+	}
+	select {
+	case <-ctx.Done():
+		return false, ctx.Err()
+	case <-o.done:
+		return false, ErrStopped
+	case o.credentialChanges <- request:
+	}
+	select {
+	case <-ctx.Done():
+		return false, ctx.Err()
+	case <-o.done:
+		return false, ErrStopped
+	case scheduled := <-request.reply:
+		return scheduled, nil
+	}
+}
+
+func (o *Orchestrator) scheduleBackendCredentialProbe(state *State, scope backendcapacity.Scope, changedAt time.Time) bool {
+	if state == nil {
+		return false
+	}
+	key, outage, ok := matchingBackendOutage(state.BackendOutages, scope)
+	if !ok || strings.TrimSpace(outage.ProbeIssueID) != "" {
+		return false
+	}
+	if changedAt.IsZero() {
+		changedAt = o.clockNow()
+	}
+	outage.NextProbeAt = changedAt
+	outage.ProbeAttempts = 0
+	state.BackendOutages[key] = outage
+	for issueID, retry := range state.Retry {
+		if !retry.CapacityScope.Matches(outage.Scope) {
+			continue
+		}
+		retry.DueAt = changedAt
+		state.Retry[issueID] = retry
+	}
+	recordStateEvent(state, telemetry.ActivityEvent{
+		At:      changedAt,
+		Event:   "backend_capacity_credential_changed",
+		Message: "backend " + outage.Scope.BackendID + " credentials changed; capacity probe scheduled",
+	})
+	if o.logger != nil {
+		telemetry.LogLifecycleMessage(o.logger, slog.LevelInfo, telemetry.LifecycleSafetyControl, "backend_capacity_credential_changed", "backend credentials changed during capacity outage", telemetry.LifecycleCorrelation{ProjectID: o.cfg.Project.ID},
+			"backend_id", outage.Scope.BackendID,
+			"backend_kind", outage.Scope.BackendKind,
+			"provider", outage.Scope.Provider,
+			"probe_at", changedAt,
+		)
+	}
+	return true
+}

--- a/internal/orchestrator/backend_credentials_test.go
+++ b/internal/orchestrator/backend_credentials_test.go
@@ -1,0 +1,110 @@
+package orchestrator
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/digitaldrywood/detent/internal/backendcapacity"
+	"github.com/digitaldrywood/detent/internal/connector"
+	runpkg "github.com/digitaldrywood/detent/internal/runner"
+)
+
+func TestScheduleBackendCredentialProbe(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 8, 22, 14, 9, 51, 0, time.UTC)
+	codexScope := backendcapacity.Scope{BackendID: "codex", BackendKind: "codex", Provider: "openai"}
+	claudeScope := backendcapacity.Scope{BackendID: "claude", BackendKind: "claude_code", Provider: "anthropic"}
+	tests := []struct {
+		name         string
+		outage       BackendOutage
+		changedScope backendcapacity.Scope
+		want         bool
+	}{
+		{
+			name:         "matching idle outage schedules prompt probe",
+			outage:       BackendOutage{Scope: codexScope, NextProbeAt: now.Add(52 * time.Minute), ProbeAttempts: 7},
+			changedScope: codexScope,
+			want:         true,
+		},
+		{
+			name:         "different backend leaves outage unchanged",
+			outage:       BackendOutage{Scope: codexScope, NextProbeAt: now.Add(52 * time.Minute), ProbeAttempts: 7},
+			changedScope: claudeScope,
+		},
+		{
+			name:         "probe already in progress is not duplicated",
+			outage:       BackendOutage{Scope: codexScope, ProbeIssueID: "issue-probe", ProbeAttempts: 7},
+			changedScope: codexScope,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			cfg := normalizeConfig(Config{})
+			orch := &Orchestrator{cfg: cfg, now: func() time.Time { return now }}
+			state := newState(cfg)
+			state.BackendOutages[tt.outage.Scope.Key()] = tt.outage
+			state.Retry["issue-codex"] = Retry{
+				Issue:         connector.Issue{ID: "issue-codex"},
+				DueAt:         now.Add(52 * time.Minute),
+				CapacityScope: codexScope,
+			}
+
+			if got := orch.scheduleBackendCredentialProbe(&state, tt.changedScope, now); got != tt.want {
+				t.Fatalf("scheduleBackendCredentialProbe() = %t, want %t", got, tt.want)
+			}
+			outage := state.BackendOutages[tt.outage.Scope.Key()]
+			if !tt.want {
+				if outage != tt.outage {
+					t.Fatalf("outage = %#v, want unchanged %#v", outage, tt.outage)
+				}
+				return
+			}
+			if !outage.NextProbeAt.Equal(now) || outage.ProbeAttempts != 0 {
+				t.Fatalf("outage = %#v, want immediate probe with reset attempts", outage)
+			}
+			if retry := state.Retry["issue-codex"]; !retry.DueAt.Equal(now) {
+				t.Fatalf("retry due = %s, want %s", retry.DueAt, now)
+			}
+			if !stateEventExists(state, "backend_capacity_credential_changed") {
+				t.Fatalf("events = %#v, want credential change event", state.RecentEvents)
+			}
+		})
+	}
+}
+
+func TestCredentialTriggeredProbeFailureReentersNormalBackoff(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 8, 22, 14, 9, 51, 0, time.UTC)
+	scope := backendcapacity.Scope{BackendID: "codex", BackendKind: "codex", Provider: "openai"}
+	cfg := normalizeConfig(Config{})
+	orch := &Orchestrator{cfg: cfg, now: func() time.Time { return now }}
+	state := newState(cfg)
+	state.BackendOutages[scope.Key()] = BackendOutage{
+		Scope:         scope,
+		NextProbeAt:   now.Add(52 * time.Minute),
+		ProbeAttempts: 7,
+	}
+
+	if !orch.scheduleBackendCredentialProbe(&state, scope, now) {
+		t.Fatal("credential change did not schedule a probe")
+	}
+	orch.markBackendCapacityProbe(&state, scope.Key(), "issue-probe", now)
+	orch.deferBackendCapacityProbe(&state, Running{CapacityScope: scope, CapacityProbe: true}, now.Add(time.Minute), errors.New("workspace setup failed"))
+
+	outage := state.BackendOutages[scope.Key()]
+	wantNextProbe := now.Add(time.Minute).Add(backendCapacityProbeDelayForAttempt(1))
+	if outage.ProbeAttempts != 1 || outage.ProbeIssueID != "" || !outage.NextProbeAt.Equal(wantNextProbe) {
+		t.Fatalf("outage = %#v, want ordinary first-failure backoff until %s", outage, wantNextProbe)
+	}
+	request := backendCapacityTestController{scope: scope}
+	orch.capacityController = request
+	if _, _, paused := orch.backendCapacityDispatch(&state, runpkg.RunRequest{Issue: connector.Issue{ID: "issue-next"}}, wantNextProbe.Add(-time.Second)); !paused {
+		t.Fatal("dispatch admitted another probe before normal backoff elapsed")
+	}
+}

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -285,6 +285,7 @@ type Orchestrator struct {
 	refreshes               chan manualRefreshRequest
 	reconciles              chan targetedRefreshRequest
 	capacityClearRequests   chan capacityClearRequest
+	credentialChanges       chan backendCredentialChangeRequest
 	trackerClearRequests    chan trackerClearRequest
 	forgeClearRequests      chan forgeClearRequest
 	failureCanaryRequests   chan failureBreakerCanaryRequest
@@ -601,6 +602,7 @@ func New(cfg Config, deps Dependencies) (*Orchestrator, error) {
 		refreshes:               make(chan manualRefreshRequest, 1),
 		reconciles:              make(chan targetedRefreshRequest, 128),
 		capacityClearRequests:   make(chan capacityClearRequest),
+		credentialChanges:       make(chan backendCredentialChangeRequest),
 		trackerClearRequests:    make(chan trackerClearRequest),
 		forgeClearRequests:      make(chan forgeClearRequest),
 		failureCanaryRequests:   make(chan failureBreakerCanaryRequest),
@@ -695,6 +697,15 @@ func (o *Orchestrator) Run(ctx context.Context) error {
 			resetTicker(ticker, state.PollInterval)
 		case request := <-o.capacityClearRequests:
 			request.reply <- capacityClearReply{cleared: o.clearBackendCapacity(&state, request.scope, request.at)}
+		case request := <-o.credentialChanges:
+			scheduled := o.scheduleBackendCredentialProbe(&state, request.scope, request.at)
+			request.reply <- scheduled
+			if scheduled {
+				o.startTick(&state, request.at)
+				o.tick(ctx, &state, request.at)
+				o.finishTick(&state)
+				resetTicker(ticker, state.PollInterval)
+			}
 		case request := <-o.trackerClearRequests:
 			request.reply <- trackerClearReply{cleared: o.clearTrackerAvailability(&state, request.at)}
 		case request := <-o.forgeClearRequests:


### PR DESCRIPTION
## Summary

- watch each configured Codex backend auth file, including dedicated CODEX_HOME profiles
- retain and retry watches when credential directories do not exist at startup, with metadata reconciliation for missed atomic-replacement events
- reset matching capacity-outage probe pacing and run one immediate scheduler tick after credential replacement
- preserve normal failed-canary backoff and cover scheduler plus file-watch wiring

Fixes #1958

## UI Surface Contract

- [x] N/A; this PR does not change a UI surface.
- [x] This PR does not add persistent top-of-screen messaging.
- [x] N/A; this PR has no visual changes.

## Test Plan

- [x] `go test ./internal/cli ./internal/orchestrator -count=1`
- [x] `go test -race ./internal/cli -run "^TestBackendCredentialFileWatcher" -count=10`
- [x] `go test ./internal/orchestrator -run "^$" -fuzz=. -fuzztime=30s`
- [x] `GOTOOLCHAIN=go1.26.6 make check` with CI-pinned golangci-lint v2.1.6