### PR TITLE
fix(workspace): defer held branches

### DIFF
--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -258,6 +258,7 @@ type doctorDeps struct {
 	openSQLite           func(context.Context, string) (doctorStore, error)
 	openSQLiteReadOnly   func(context.Context, string) (doctorTelemetryStore, error)
 	gitWorkTree          func(context.Context, string) error
+	gitWorktrees         func(context.Context, string) ([]doctorGitWorktree, error)
 	gitRemoteURL         func(context.Context, string) (string, error)
 	gitTracked           func(context.Context, string) (bool, error)
 	workflowSourcePolicy doctorWorkflowSourcePolicyFunc
@@ -1170,6 +1171,9 @@ func (d doctorDeps) withDefaults() doctorDeps {
 	if d.gitWorkTree == nil {
 		d.gitWorkTree = defaults.gitWorkTree
 	}
+	if d.gitWorktrees == nil {
+		d.gitWorktrees = defaults.gitWorktrees
+	}
 	if d.gitRemoteURL == nil {
 		d.gitRemoteURL = defaults.gitRemoteURL
 	}
@@ -1223,6 +1227,7 @@ func defaultDoctorDeps() doctorDeps {
 		openSQLite:           openDoctorSQLite,
 		openSQLiteReadOnly:   openDoctorSQLiteReadOnly,
 		gitWorkTree:          defaultGitWorkTree,
+		gitWorktrees:         defaultDoctorGitWorktrees,
 		gitRemoteURL:         defaultGitRemoteURL,
 		gitTracked:           defaultGitTracked,
 		workflowSourcePolicy: defaultDoctorWorkflowSourcePolicy,

--- a/internal/cli/doctor_project.go
+++ b/internal/cli/doctor_project.go
@@ -462,6 +462,10 @@ func checkDoctorProjectWithProgress(
 		Status: doctorOK,
 		Detail: expandedSourceRoot + " is a git worktree",
 	})
+	if deps.gitWorktrees != nil {
+		setDoctorCurrentCheck("Project " + id + " external branch worktrees")
+		checks = append(checks, checkDoctorExternalBranchWorktrees(ctx, id, expandedSourceRoot, workflow.Config.Workspace.Root, deps))
+	}
 	setDoctorCurrentCheck("Project " + id + " issue effort guidance")
 	checks = append(checks, checkDoctorIssueEffortGuidance(id, expandedSourceRoot))
 	setDoctorCurrentCheck("Project " + id + " skills")

--- a/internal/cli/doctor_test.go
+++ b/internal/cli/doctor_test.go
@@ -4083,6 +4083,9 @@ func TestCheckDoctorProjectBuildsGitHubReadinessInventory(t *testing.T) {
 		gitWorkTree: func(context.Context, string) error {
 			return nil
 		},
+		gitWorktrees: func(context.Context, string) ([]doctorGitWorktree, error) {
+			return nil, nil
+		},
 		gitRemoteURL: func(context.Context, string) (string, error) {
 			return "git@github.com:digitaldrywood/detent.git", nil
 		},
@@ -6603,6 +6606,9 @@ func successfulDoctorDeps() doctorDeps {
 		},
 		gitWorkTree: func(context.Context, string) error {
 			return nil
+		},
+		gitWorktrees: func(context.Context, string) ([]doctorGitWorktree, error) {
+			return nil, nil
 		},
 		workflowSourcePolicy: func(_ context.Context, projectID string, _ globalconfig.Project, _ string, _ string) doctorCheck {
 			return doctorCheck{

--- a/internal/cli/doctor_worktrees.go
+++ b/internal/cli/doctor_worktrees.go
@@ -1,0 +1,147 @@
+package cli
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os/exec"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+type doctorGitWorktree struct {
+	Path   string
+	Branch string
+}
+
+func checkDoctorExternalBranchWorktrees(
+	ctx context.Context,
+	projectID string,
+	sourceRoot string,
+	workspaceRoot string,
+	deps doctorDeps,
+) doctorCheck {
+	name := "Project " + projectID + " external branch worktrees"
+	if deps.gitWorktrees == nil {
+		return doctorCheck{Name: name, Status: doctorOK, Detail: "skipped because the worktree inspector is unavailable"}
+	}
+	resolvedRoot, err := expandDoctorWorkspacePath(workspaceRoot)
+	if err != nil || strings.TrimSpace(workspaceRoot) == "" {
+		if err == nil {
+			err = errors.New("workspace.root is not configured")
+		}
+		return doctorCheck{
+			Name:   name,
+			Status: doctorWarn,
+			Detail: fmt.Sprintf("cannot inspect external branch worktrees: %v", err),
+			Hint:   "Set workspace.root to the directory Detent owns, then rerun detent doctor.",
+		}
+	}
+	worktrees, err := deps.gitWorktrees(ctx, sourceRoot)
+	if err != nil {
+		return doctorCheck{
+			Name:   name,
+			Status: doctorWarn,
+			Detail: fmt.Sprintf("cannot list worktrees registered with %s: %v", sourceRoot, err),
+			Hint:   "Verify the source repository, then rerun detent doctor.",
+		}
+	}
+	sourceRoot = doctorCanonicalPath(sourceRoot)
+	resolvedRoot = doctorCanonicalPath(resolvedRoot)
+	external := make([]doctorGitWorktree, 0)
+	for _, worktree := range worktrees {
+		worktree.Path = doctorCanonicalPath(worktree.Path)
+		worktree.Branch = strings.TrimSpace(worktree.Branch)
+		if worktree.Branch == "" || worktree.Path == "" || worktree.Path == sourceRoot || doctorPathWithin(resolvedRoot, worktree.Path) {
+			continue
+		}
+		external = append(external, worktree)
+	}
+	sort.Slice(external, func(left, right int) bool {
+		if external[left].Branch == external[right].Branch {
+			return external[left].Path < external[right].Path
+		}
+		return external[left].Branch < external[right].Branch
+	})
+	if len(external) == 0 {
+		return doctorCheck{
+			Name:   name,
+			Status: doctorOK,
+			Detail: "all branch worktrees are the configured source checkout or within workspace.root " + resolvedRoot,
+		}
+	}
+	details := make([]string, 0, len(external))
+	for _, worktree := range external {
+		details = append(details, worktree.Branch+" at "+worktree.Path)
+	}
+	summary := fmt.Sprintf("%d branches are held", len(external))
+	if len(external) == 1 {
+		summary = "1 branch is held"
+	}
+	return doctorCheck{
+		Name:   name,
+		Status: doctorWarn,
+		Detail: fmt.Sprintf("%s by worktrees outside workspace.root %s: %s", summary, resolvedRoot, strings.Join(details, "; ")),
+		Hint:   "Active PR review checkouts are safe to keep and Detent will resume when their branches are released. For genuinely dead entries, verify each path before running git worktree remove <path>, then run git worktree prune.",
+	}
+}
+
+func defaultDoctorGitWorktrees(ctx context.Context, sourceRoot string) ([]doctorGitWorktree, error) {
+	commandCtx, cancel := context.WithTimeout(ctx, doctorCommandTimeout)
+	defer cancel()
+	cmd := exec.CommandContext(commandCtx, "git", "-C", sourceRoot, "worktree", "list", "--porcelain", "-z") // #nosec G204 -- doctor runs a fixed read-only git command against the configured source root.
+	output, err := cmd.CombinedOutput()
+	if commandCtx.Err() != nil {
+		return nil, commandCtx.Err()
+	}
+	if err != nil {
+		if detail := strings.TrimSpace(string(output)); detail != "" {
+			return nil, fmt.Errorf("%w: %s", err, detail)
+		}
+		return nil, err
+	}
+	return parseDoctorGitWorktrees(string(output)), nil
+}
+
+func parseDoctorGitWorktrees(output string) []doctorGitWorktree {
+	worktrees := make([]doctorGitWorktree, 0)
+	current := doctorGitWorktree{}
+	flush := func() {
+		if strings.TrimSpace(current.Path) != "" {
+			worktrees = append(worktrees, current)
+		}
+		current = doctorGitWorktree{}
+	}
+	for _, field := range strings.Split(output, "\x00") {
+		switch {
+		case strings.HasPrefix(field, "worktree "):
+			flush()
+			current.Path = strings.TrimSpace(strings.TrimPrefix(field, "worktree "))
+		case strings.HasPrefix(field, "branch "):
+			branch := strings.TrimSpace(strings.TrimPrefix(field, "branch "))
+			current.Branch = strings.TrimPrefix(branch, "refs/heads/")
+		}
+	}
+	flush()
+	return worktrees
+}
+
+func doctorCanonicalPath(path string) string {
+	path = filepath.Clean(strings.TrimSpace(path))
+	if canonical, err := filepath.EvalSymlinks(path); err == nil {
+		path = canonical
+	}
+	if absolute, err := filepath.Abs(path); err == nil {
+		path = absolute
+	}
+	return filepath.Clean(path)
+}
+
+func doctorPathWithin(root string, path string) bool {
+	relative, err := filepath.Rel(root, path)
+	if err != nil {
+		return false
+	}
+	return relative == "." || relative != ".." && !strings.HasPrefix(relative, ".."+string(filepath.Separator)) && !filepath.IsAbs(relative)
+}

--- a/internal/cli/doctor_worktrees_test.go
+++ b/internal/cli/doctor_worktrees_test.go
@@ -1,0 +1,97 @@
+package cli
+
+import (
+	"context"
+	"errors"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestCheckDoctorExternalBranchWorktrees(t *testing.T) {
+	t.Parallel()
+
+	base := t.TempDir()
+	source := filepath.Join(base, "source")
+	root := filepath.Join(base, "managed")
+	external := filepath.Join(base, "review-pr-1917")
+	tests := []struct {
+		name       string
+		worktrees  []doctorGitWorktree
+		listErr    error
+		wantStatus doctorStatus
+		wantDetail []string
+		wantHint   string
+	}{
+		{
+			name: "source managed and detached worktrees are healthy",
+			worktrees: []doctorGitWorktree{
+				{Path: source, Branch: "main"},
+				{Path: filepath.Join(root, "issue-1"), Branch: "detent/issue-1"},
+				{Path: external},
+			},
+			wantStatus: doctorOK,
+			wantDetail: []string{"all branch worktrees", root},
+		},
+		{
+			name: "external review checkout warns with holder",
+			worktrees: []doctorGitWorktree{
+				{Path: source, Branch: "main"},
+				{Path: external, Branch: "detent/issue-1838"},
+			},
+			wantStatus: doctorWarn,
+			wantDetail: []string{"1 branch is held", "detent/issue-1838", external},
+			wantHint:   "Active PR review checkouts are safe to keep",
+		},
+		{
+			name:       "git listing failure warns",
+			listErr:    errors.New("corrupt worktree registry"),
+			wantStatus: doctorWarn,
+			wantDetail: []string{"cannot list worktrees", "corrupt worktree registry"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			check := checkDoctorExternalBranchWorktrees(t.Context(), "pyroapex", source, root, doctorDeps{
+				gitWorktrees: func(context.Context, string) ([]doctorGitWorktree, error) {
+					return append([]doctorGitWorktree(nil), tt.worktrees...), tt.listErr
+				},
+			})
+			if check.Status != tt.wantStatus {
+				t.Fatalf("Status = %s, want %s: %#v", check.Status, tt.wantStatus, check)
+			}
+			for _, want := range tt.wantDetail {
+				if !strings.Contains(check.Detail, want) {
+					t.Fatalf("Detail = %q, want containing %q", check.Detail, want)
+				}
+			}
+			if tt.wantHint != "" && !strings.Contains(check.Hint, tt.wantHint) {
+				t.Fatalf("Hint = %q, want containing %q", check.Hint, tt.wantHint)
+			}
+		})
+	}
+}
+
+func TestParseDoctorGitWorktrees(t *testing.T) {
+	t.Parallel()
+
+	output := "worktree /repo\x00HEAD abc\x00branch refs/heads/main\x00\x00" +
+		"worktree /managed/issue\x00HEAD def\x00branch refs/heads/detent/issue\x00\x00" +
+		"worktree /review/detached\x00HEAD 123\x00detached\x00\x00"
+	got := parseDoctorGitWorktrees(output)
+	want := []doctorGitWorktree{
+		{Path: "/repo", Branch: "main"},
+		{Path: "/managed/issue", Branch: "detent/issue"},
+		{Path: "/review/detached"},
+	}
+	if len(got) != len(want) {
+		t.Fatalf("worktrees = %#v, want %#v", got, want)
+	}
+	for index := range want {
+		if got[index] != want[index] {
+			t.Fatalf("worktrees[%d] = %#v, want %#v", index, got[index], want[index])
+		}
+	}
+}

--- a/internal/orchestrator/dispatch.go
+++ b/internal/orchestrator/dispatch.go
@@ -175,9 +175,14 @@ func (o *Orchestrator) dispatchReadyIssues(ctx context.Context, state *State, is
 			rescheduled.ForgeUnavailable = retry.ForgeUnavailable
 			rescheduled.ForgeHost = retry.ForgeHost
 			rescheduled.ForgeRetry = cloneForgeRetry(retry.ForgeRetry)
+			rescheduled.Wait = retry.Wait
+			rescheduled.Wait.PendingChecks = append([]string(nil), retry.Wait.PendingChecks...)
 			state.Retry[issue.ID] = rescheduled
 		},
 		pollRetryWait: func(issue connector.Issue, retry Retry) (Retry, bool, string) {
+			if retry.Wait.Kind == retryWaitWorkspaceBranchHeld {
+				return o.pollWorkspaceBranchHold(ctx, state, issue, retry, now)
+			}
 			return o.pollMergeWorkerCurrentHeadCI(ctx, state, issue, retry, now)
 		},
 		preserveMissingDueRetry: func(retry Retry) bool {

--- a/internal/orchestrator/dispatch_planner.go
+++ b/internal/orchestrator/dispatch_planner.go
@@ -107,7 +107,7 @@ func (p dispatchPlanner) plan(
 			continue
 		}
 		if retry, ok := dueRetries[issue.ID]; ok {
-			if retry.Wait.Kind == retryWaitCurrentHeadCI {
+			if retry.Wait.Kind == retryWaitCurrentHeadCI || retry.Wait.Kind == retryWaitWorkspaceBranchHeld {
 				var handled bool
 				reason := ""
 				if hooks.pollRetryWait != nil {
@@ -616,6 +616,7 @@ const (
 	dispatchSkipProjectFailureBreaker     = projectFailureBreakerDispatchPaused
 	dispatchSkipRateWindowBackpressure    = "provider_rate_window_backpressure"
 	dispatchSkipCurrentHeadCIWait         = "current_head_ci_wait"
+	dispatchSkipWorkspaceBranchHeld       = "workspace_branch_held"
 )
 
 func (p dispatchPlanner) previewCurrentHeadCIWait(

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -250,6 +250,7 @@ type Orchestrator struct {
 	capacityStatus          runpkg.CapacityStatusController
 	validatorCapacity       runpkg.ValidatorCapacityController
 	recoveryInspector       runpkg.BlockedRecoveryInspector
+	workspaceHoldInspector  runpkg.WorkspaceBranchHoldInspector
 	dailyBudgetStatus       runpkg.DailyBudgetStatusProvider
 	issueBudgetStatus       runpkg.IssueBudgetStatusProvider
 	githubRESTBudgetProber  runpkg.GitHubRESTBudgetProber
@@ -420,6 +421,10 @@ func New(cfg Config, deps Dependencies) (*Orchestrator, error) {
 	if candidate, ok := runner.(runpkg.BlockedRecoveryInspector); ok {
 		blockedRecoveryInspector = candidate
 	}
+	var workspaceHoldInspector runpkg.WorkspaceBranchHoldInspector
+	if candidate, ok := runner.(runpkg.WorkspaceBranchHoldInspector); ok {
+		workspaceHoldInspector = candidate
+	}
 	var capacityStatus runpkg.CapacityStatusController
 	if candidate, ok := runner.(runpkg.CapacityStatusController); ok {
 		capacityStatus = candidate
@@ -586,6 +591,7 @@ func New(cfg Config, deps Dependencies) (*Orchestrator, error) {
 		capacityStatus:          capacityStatus,
 		validatorCapacity:       validatorCapacity,
 		recoveryInspector:       blockedRecoveryInspector,
+		workspaceHoldInspector:  workspaceHoldInspector,
 		dailyBudgetStatus:       dailyBudgetStatus,
 		issueBudgetStatus:       issueBudgetStatus,
 		githubRESTBudgetProber:  githubRESTBudgetProber,

--- a/internal/orchestrator/run_completion.go
+++ b/internal/orchestrator/run_completion.go
@@ -193,6 +193,9 @@ func (o *Orchestrator) handleRunResult(ctx context.Context, state *State, event 
 	if o.handleModelPermitDeferred(ctx, state, event, running) {
 		return
 	}
+	if o.handleWorkspaceBranchHoldCompletion(ctx, state, event, running) {
+		return
+	}
 	if o.handleForgeUnavailableCompletion(ctx, state, event, running) {
 		return
 	}

--- a/internal/orchestrator/state.go
+++ b/internal/orchestrator/state.go
@@ -264,6 +264,9 @@ type RetryWait struct {
 	StartedAt             time.Time
 	PollCount             int
 	PendingChecks         []string
+	WorkspaceBranch       string
+	WorkspaceHolderPath   string
+	WorkspacePRNumber     int
 	WorkspaceCreateCount  int
 	WorkspaceDestroyCount int
 }

--- a/internal/orchestrator/terminal_attempt_retry.go
+++ b/internal/orchestrator/terminal_attempt_retry.go
@@ -438,7 +438,7 @@ func workAttemptCompletedAfter(left telemetry.WorkAttempt, right telemetry.WorkA
 
 func terminalAttemptRetryableFailure(attempt telemetry.WorkAttempt) bool {
 	errorClass := strings.TrimSpace(attempt.ErrorClass)
-	if errorClass == forgeUnavailableErrorClass {
+	if errorClass == forgeUnavailableErrorClass || errorClass == workspaceBranchHoldErrorClass {
 		return false
 	}
 	if errorClass == githubRESTCapacityError {

--- a/internal/orchestrator/work_attempts.go
+++ b/internal/orchestrator/work_attempts.go
@@ -93,6 +93,7 @@ func (o *Orchestrator) recoverDurableWorkAttempts(ctx context.Context, state *St
 		for index := len(recent) - 1; index >= 0; index-- {
 			o.upsertWorkAttemptSnapshot(state, telemetryWorkAttempt(recent[index], now))
 		}
+		o.recoverWorkspaceBranchHolds(ctx, state, recent, now)
 		o.recoverForgeAvailabilityWaits(ctx, state, recent, now)
 		o.recoverGitHubRESTCapacityWaits(ctx, state, recent, now)
 	}

--- a/internal/orchestrator/workspace_branch_hold.go
+++ b/internal/orchestrator/workspace_branch_hold.go
@@ -1,0 +1,257 @@
+package orchestrator
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"strings"
+	"time"
+
+	"github.com/digitaldrywood/detent/internal/connector"
+	runpkg "github.com/digitaldrywood/detent/internal/runner"
+	"github.com/digitaldrywood/detent/internal/store"
+	"github.com/digitaldrywood/detent/internal/telemetry"
+)
+
+const (
+	workspaceBranchHoldSchema     = 1
+	workspaceBranchHoldErrorClass = "workspace_branch_held"
+	retryWaitWorkspaceBranchHeld  = "workspace_branch_held"
+)
+
+type workspaceBranchHoldMetadata struct {
+	Schema       int       `json:"schema"`
+	Branch       string    `json:"branch"`
+	WorktreePath string    `json:"worktree_path"`
+	PRNumber     int       `json:"pr_number,omitempty"`
+	DetectedAt   time.Time `json:"detected_at"`
+	NextProbeAt  time.Time `json:"next_probe_at"`
+}
+
+func (o *Orchestrator) handleWorkspaceBranchHoldCompletion(
+	ctx context.Context,
+	state *State,
+	event runpkg.Completion,
+	running Running,
+) bool {
+	var heldErr *runpkg.WorkspaceBranchHeldError
+	if !errors.As(event.Err, &heldErr) || heldErr == nil {
+		return false
+	}
+	detectedAt := event.CompletedAt.UTC()
+	delay := max(event.RetryDelay, o.cfg.PollInterval)
+	if delay <= 0 {
+		delay = defaultOverloadRetryDelay
+	}
+	nextProbeAt := detectedAt.Add(delay)
+	message := heldErr.Error()
+	o.releaseTerminalAttemptClaim(ctx, state, running.Issue, event.CompletedAt)
+	o.completeDurableWorkAttemptWithMetadata(
+		ctx,
+		state,
+		running,
+		event.CompletedAt,
+		store.WorkAttemptTerminalCapacity,
+		workspaceBranchHoldErrorClass,
+		message,
+		"waiting",
+		message,
+		map[string]any{"workspace_branch_hold": workspaceBranchHoldMetadata{
+			Schema:       workspaceBranchHoldSchema,
+			Branch:       strings.TrimSpace(heldErr.Branch),
+			WorktreePath: strings.TrimSpace(heldErr.WorktreePath),
+			PRNumber:     heldErr.PRNumber,
+			DetectedAt:   detectedAt,
+			NextProbeAt:  nextProbeAt,
+		}},
+	)
+	if workspaceIssueTerminal(running.Issue, o.cfg.TerminalStates) {
+		return true
+	}
+	if state.FailureBreaker.Active() && state.FailureBreaker.CanaryIssueID == running.Issue.ID {
+		o.deferProjectFailureBreakerCanary(state, running.Issue.ID, event.CompletedAt, delay)
+	}
+	state.Retry[running.Issue.ID] = Retry{
+		Issue:      cloneIssue(running.Issue),
+		Attempt:    running.Attempt,
+		DueAt:      nextProbeAt,
+		Error:      message,
+		WorkerHost: running.WorkerHost,
+		Wait: RetryWait{
+			Kind:                retryWaitWorkspaceBranchHeld,
+			StartedAt:           detectedAt,
+			WorkspaceBranch:     strings.TrimSpace(heldErr.Branch),
+			WorkspaceHolderPath: strings.TrimSpace(heldErr.WorktreePath),
+			WorkspacePRNumber:   heldErr.PRNumber,
+		},
+	}
+	recordStateEvent(state, telemetry.ActivityEvent{
+		At:      detectedAt,
+		Event:   "workspace_branch_hold_waiting",
+		Message: message,
+	})
+	return true
+}
+
+func (o *Orchestrator) pollWorkspaceBranchHold(
+	ctx context.Context,
+	state *State,
+	issue connector.Issue,
+	retry Retry,
+	now time.Time,
+) (Retry, bool, string) {
+	if retry.Wait.Kind != retryWaitWorkspaceBranchHeld {
+		return retry, false, ""
+	}
+	if o.workspaceHoldInspector == nil {
+		return retry, false, ""
+	}
+	probeIssue := cloneIssue(issue)
+	if strings.TrimSpace(probeIssue.BranchName) == "" {
+		probeIssue.BranchName = strings.TrimSpace(retry.Wait.WorkspaceBranch)
+	}
+	if probeIssue.PRNumber == nil && retry.Wait.WorkspacePRNumber > 0 {
+		number := retry.Wait.WorkspacePRNumber
+		probeIssue.PRNumber = &number
+	}
+	hold, err := o.workspaceHoldInspector.InspectWorkspaceBranchHold(ctx, probeIssue)
+	retry.Issue = cloneIssue(issue)
+	retry.Wait.PollCount++
+	delay := o.cfg.PollInterval
+	if delay <= 0 {
+		delay = defaultOverloadRetryDelay
+	}
+	retry.DueAt = now.Add(delay)
+	if err != nil {
+		retry.Error = workspaceBranchHoldMessage(retry.Wait) + "; hold check failed: " + err.Error()
+		state.Retry[issue.ID] = retry
+		return retry, true, dispatchSkipWorkspaceBranchHeld
+	}
+	if hold.Held {
+		if branch := strings.TrimSpace(hold.Branch); branch != "" {
+			retry.Wait.WorkspaceBranch = branch
+		}
+		if path := strings.TrimSpace(hold.WorktreePath); path != "" {
+			retry.Wait.WorkspaceHolderPath = path
+		}
+		if hold.PRNumber > 0 {
+			retry.Wait.WorkspacePRNumber = hold.PRNumber
+		}
+		retry.Error = workspaceBranchHoldMessage(retry.Wait)
+		state.Retry[issue.ID] = retry
+		return retry, true, dispatchSkipWorkspaceBranchHeld
+	}
+
+	retry.Error = ""
+	retry.Wait = RetryWait{}
+	state.Retry[issue.ID] = retry
+	recordStateEvent(state, telemetry.ActivityEvent{
+		At:      now.UTC(),
+		Event:   "workspace_branch_hold_released",
+		Message: "branch hold released for " + issueLabel(issue) + "; dispatch will resume",
+	})
+	return retry, false, ""
+}
+
+func workspaceBranchHoldMessage(wait RetryWait) string {
+	return (&runpkg.WorkspaceBranchHeldError{
+		Branch:       strings.TrimSpace(wait.WorkspaceBranch),
+		WorktreePath: strings.TrimSpace(wait.WorkspaceHolderPath),
+		PRNumber:     wait.WorkspacePRNumber,
+	}).Error()
+}
+
+func workspaceBranchHoldMetadataFromAttempt(attempt store.WorkAttempt) (workspaceBranchHoldMetadata, bool) {
+	if attempt.Status != store.WorkAttemptStatusTerminal ||
+		attempt.TerminalState != store.WorkAttemptTerminalCapacity ||
+		strings.TrimSpace(attempt.ErrorClass) != workspaceBranchHoldErrorClass {
+		return workspaceBranchHoldMetadata{}, false
+	}
+	var metadata struct {
+		WorkspaceBranchHold workspaceBranchHoldMetadata `json:"workspace_branch_hold"`
+	}
+	if json.Unmarshal([]byte(attempt.WorkerMetadataJSON), &metadata) != nil {
+		return workspaceBranchHoldMetadata{}, false
+	}
+	hold := metadata.WorkspaceBranchHold
+	hold.Branch = strings.TrimSpace(hold.Branch)
+	hold.WorktreePath = strings.TrimSpace(hold.WorktreePath)
+	if hold.Schema != workspaceBranchHoldSchema || hold.Branch == "" || hold.WorktreePath == "" || hold.DetectedAt.IsZero() {
+		return workspaceBranchHoldMetadata{}, false
+	}
+	return hold, true
+}
+
+func (o *Orchestrator) recoverWorkspaceBranchHolds(ctx context.Context, state *State, attempts []store.WorkAttempt, now time.Time) {
+	if state == nil || len(attempts) == 0 {
+		return
+	}
+	latest := latestStoreTerminalAttemptsByIssue(attempts)
+	waits := make(map[string]workspaceBranchHoldMetadata)
+	issueIDs := make([]string, 0, len(latest))
+	for issueID, attempt := range latest {
+		metadata, ok := workspaceBranchHoldMetadataFromAttempt(attempt)
+		if !ok {
+			continue
+		}
+		waits[issueID] = metadata
+		issueIDs = append(issueIDs, issueID)
+	}
+	if len(waits) == 0 {
+		return
+	}
+	issuesByID, validated := o.validateWorkspaceHoldIssues(ctx, issueIDs)
+	for issueID, metadata := range waits {
+		attempt := latest[issueID]
+		issue := forgeWaitIssueFromAttempt(attempt)
+		if validated {
+			var ok bool
+			issue, ok = issuesByID[issueID]
+			if !ok || !stateIn(issue.State, o.cfg.ActiveStates) || workspaceIssueTerminal(issue, o.cfg.TerminalStates) {
+				continue
+			}
+		}
+		if strings.TrimSpace(issue.BranchName) == "" {
+			issue.BranchName = metadata.Branch
+		}
+		nextProbeAt := metadata.NextProbeAt
+		if nextProbeAt.IsZero() || nextProbeAt.Before(now) {
+			nextProbeAt = now
+		}
+		state.Retry[issueID] = Retry{
+			Issue:      cloneIssue(issue),
+			Attempt:    attempt.AttemptNumber,
+			DueAt:      nextProbeAt.UTC(),
+			Error:      strings.TrimSpace(attempt.ErrorMessage),
+			WorkerHost: strings.TrimSpace(attempt.WorkerHost),
+			Wait: RetryWait{
+				Kind:                retryWaitWorkspaceBranchHeld,
+				StartedAt:           metadata.DetectedAt,
+				WorkspaceBranch:     metadata.Branch,
+				WorkspaceHolderPath: metadata.WorktreePath,
+				WorkspacePRNumber:   metadata.PRNumber,
+			},
+		}
+		recordStateEvent(state, telemetry.ActivityEvent{At: now.UTC(), Event: "workspace_branch_hold_restored", Message: "restored durable branch hold for " + issueLabel(issue)})
+	}
+}
+
+func (o *Orchestrator) validateWorkspaceHoldIssues(ctx context.Context, issueIDs []string) (map[string]connector.Issue, bool) {
+	if o == nil || o.connector == nil || len(issueIDs) == 0 {
+		return nil, false
+	}
+	issues, err := o.connector.FetchIssueStatesByIDs(ctx, issueIDs)
+	if err != nil {
+		if o.logger != nil {
+			o.logger.Warn("workspace branch hold issue validation failed; preserving durable waits", "issue_ids", issueIDs, "error", err)
+		}
+		return nil, false
+	}
+	byID := make(map[string]connector.Issue, len(issues))
+	for _, issue := range issues {
+		if issueID := strings.TrimSpace(issue.ID); issueID != "" {
+			byID[issueID] = issue
+		}
+	}
+	return byID, true
+}

--- a/internal/orchestrator/workspace_branch_hold_test.go
+++ b/internal/orchestrator/workspace_branch_hold_test.go
@@ -1,0 +1,250 @@
+package orchestrator
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/digitaldrywood/detent/internal/connector"
+	runpkg "github.com/digitaldrywood/detent/internal/runner"
+	"github.com/digitaldrywood/detent/internal/scheduler"
+	"github.com/digitaldrywood/detent/internal/store"
+)
+
+func TestWorkspaceBranchHoldCompletionIsNotWorkFailure(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 8, 24, 14, 0, 0, 0, time.UTC)
+	issue := dispatchTestIssue("issue-held", "In Progress")
+	issue.BranchName = "detent/issue-held"
+	prNumber := 1917
+	issue.PRNumber = &prNumber
+	attempts := &terminalRetryWorkAttemptStore{}
+	cfg := normalizeConfig(Config{
+		Project:             scheduler.ProjectCandidate{ID: "detent"},
+		PollInterval:        time.Minute,
+		ActiveStates:        []string{"In Progress"},
+		TerminalStates:      []string{"Done"},
+		MaxConcurrentAgents: 1,
+		FailureBreaker: FailureBreakerConfig{
+			SameClassLimit: 1,
+			Window:         time.Hour,
+			Cooldown:       time.Hour,
+		},
+	})
+	orch := Orchestrator{cfg: cfg, connector: &terminalRetryConnector{}, workAttempts: attempts, now: func() time.Time { return now }}
+	state := newState(cfg)
+	state.InstantFailures[issue.ID] = InstantFailure{Issue: issue, Count: 2}
+	state.RepeatedFailures[issue.ID] = RepeatedFailure{Issue: issue, Count: 2}
+	state.FailureBreaker.Failures["existing"] = []ProjectFailure{{IssueID: "other", At: now.Add(-time.Minute)}}
+	state.Running[issue.ID] = Running{Issue: issue, Attempt: 4, WorkAttemptID: 42, StartedAt: now.Add(-time.Minute)}
+
+	orch.handleRunResult(t.Context(), &state, runpkg.Completion{
+		IssueID: issue.ID,
+		Request: runpkg.RunRequest{Issue: issue, Attempt: 4},
+		Err: &runpkg.WorkspaceBranchHeldError{
+			Branch:       issue.BranchName,
+			WorktreePath: "/review/pyroapex-pr-1917",
+			PRNumber:     prNumber,
+		},
+		CompletedAt:  now,
+		RetryAttempt: 4,
+		RetryDelay:   time.Minute,
+	})
+
+	if got := state.InstantFailures[issue.ID].Count; got != 2 {
+		t.Fatalf("instant failure count = %d, want unchanged", got)
+	}
+	if got := state.RepeatedFailures[issue.ID].Count; got != 2 {
+		t.Fatalf("repeated failure count = %d, want unchanged", got)
+	}
+	if got := len(state.FailureBreaker.Failures["existing"]); got != 1 || state.FailureBreaker.Active() {
+		t.Fatalf("FailureBreaker = %#v, want existing evidence unchanged and inactive", state.FailureBreaker)
+	}
+	if _, blocked := state.Blocked[issue.ID]; blocked {
+		t.Fatalf("Blocked[%q] present after branch hold", issue.ID)
+	}
+	retry, ok := state.Retry[issue.ID]
+	if !ok || retry.Attempt != 4 || retry.Wait.Kind != retryWaitWorkspaceBranchHeld {
+		t.Fatalf("Retry[%q] = %#v, want same-attempt workspace hold", issue.ID, retry)
+	}
+	wantMessage := "branch held by worktree at \"/review/pyroapex-pr-1917\" (PR #1917 checkout) — will resume when released"
+	if retry.Error != wantMessage {
+		t.Fatalf("Retry error = %q, want %q", retry.Error, wantMessage)
+	}
+	if len(attempts.completions) != 1 || attempts.completions[0].TerminalState != store.WorkAttemptTerminalCapacity || attempts.completions[0].ErrorClass != workspaceBranchHoldErrorClass {
+		t.Fatalf("work attempt completions = %#v, want durable capacity hold", attempts.completions)
+	}
+	var metadata struct {
+		WorkspaceBranchHold workspaceBranchHoldMetadata `json:"workspace_branch_hold"`
+	}
+	if err := json.Unmarshal([]byte(attempts.completions[0].WorkerMetadataJSON), &metadata); err != nil {
+		t.Fatalf("decode workspace hold metadata: %v", err)
+	}
+	if metadata.WorkspaceBranchHold.Branch != issue.BranchName || metadata.WorkspaceBranchHold.WorktreePath != "/review/pyroapex-pr-1917" {
+		t.Fatalf("workspace hold metadata = %#v", metadata.WorkspaceBranchHold)
+	}
+	if terminalAttemptRetryableFailure(telemetryWorkAttempt(store.WorkAttempt{
+		Status:        store.WorkAttemptStatusTerminal,
+		TerminalState: store.WorkAttemptTerminalCapacity,
+		ErrorClass:    workspaceBranchHoldErrorClass,
+	}, now)) {
+		t.Fatal("workspace branch hold treated as terminal work failure")
+	}
+}
+
+func TestWorkspaceBranchHoldIsDistinctFromPreparationFailure(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 8, 24, 14, 0, 0, 0, time.UTC)
+	issue := dispatchTestIssue("issue-workspace-errors", "In Progress")
+	tests := []struct {
+		name           string
+		err            error
+		wantErrorClass string
+		wantTerminal   store.WorkAttemptTerminalState
+		wantWait       string
+	}{
+		{
+			name:           "branch held",
+			err:            &runpkg.WorkspaceBranchHeldError{Branch: "detent/held", WorktreePath: "/review/pr"},
+			wantErrorClass: workspaceBranchHoldErrorClass,
+			wantTerminal:   store.WorkAttemptTerminalCapacity,
+			wantWait:       retryWaitWorkspaceBranchHeld,
+		},
+		{
+			name:           "genuine creation failure",
+			err:            errors.Join(runpkg.ErrWorkspacePreparation, errors.New("invalid gitdir")),
+			wantErrorClass: workAttemptErrorWorkspace,
+			wantTerminal:   store.WorkAttemptTerminalFailure,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			attempts := &terminalRetryWorkAttemptStore{}
+			cfg := normalizeConfig(Config{ActiveStates: []string{"In Progress"}, TerminalStates: []string{"Done"}, PollInterval: time.Minute})
+			orch := Orchestrator{cfg: cfg, connector: &terminalRetryConnector{}, workAttempts: attempts}
+			state := newState(cfg)
+			state.Running[issue.ID] = Running{Issue: issue, Attempt: 1, WorkAttemptID: 1, StartedAt: now.Add(-time.Minute)}
+			orch.handleRunResult(t.Context(), &state, runpkg.Completion{IssueID: issue.ID, Err: tt.err, CompletedAt: now, RetryDelay: time.Minute})
+			if len(attempts.completions) != 1 || attempts.completions[0].ErrorClass != tt.wantErrorClass || attempts.completions[0].TerminalState != tt.wantTerminal {
+				t.Fatalf("completion = %#v", attempts.completions)
+			}
+			if retry := state.Retry[issue.ID]; retry.Wait.Kind != tt.wantWait {
+				t.Fatalf("Retry wait = %q, want %q", retry.Wait.Kind, tt.wantWait)
+			}
+		})
+	}
+}
+
+func TestWorkspaceBranchHoldPollAutoResumesOnRelease(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 8, 24, 14, 0, 0, 0, time.UTC)
+	issue := dispatchTestIssue("issue-auto-resume", "In Progress")
+	issue.BranchName = "detent/issue-auto-resume"
+	inspector := &workspaceHoldInspectorStub{results: []runpkg.WorkspaceBranchHold{
+		{Branch: issue.BranchName, WorktreePath: "/review/pr", PRNumber: 1917, Held: true},
+		{Branch: issue.BranchName, Held: false},
+	}}
+	cfg := normalizeConfig(Config{ActiveStates: []string{"In Progress"}, TerminalStates: []string{"Done"}, MaxConcurrentAgents: 1, PollInterval: time.Minute})
+	orch := Orchestrator{cfg: cfg, workspaceHoldInspector: inspector}
+	state := newState(cfg)
+	state.Retry[issue.ID] = Retry{
+		Issue:   issue,
+		Attempt: 3,
+		DueAt:   now,
+		Wait: RetryWait{
+			Kind:                retryWaitWorkspaceBranchHeld,
+			StartedAt:           now.Add(-time.Minute),
+			WorkspaceBranch:     issue.BranchName,
+			WorkspaceHolderPath: "/review/pr",
+			WorkspacePRNumber:   1917,
+		},
+	}
+	dispatches := 0
+	hooks := dispatchPlanHooks{
+		pollRetryWait: func(candidate connector.Issue, retry Retry) (Retry, bool, string) {
+			return orch.pollWorkspaceBranchHold(t.Context(), &state, candidate, retry, now)
+		},
+		dispatch: func(dispatchAction) bool {
+			dispatches++
+			return true
+		},
+	}
+
+	newDispatchPlanner(cfg).plan(&state, []connector.Issue{issue}, now, hooks)
+	if dispatches != 0 || inspector.calls != 1 {
+		t.Fatalf("held poll dispatches=%d calls=%d, want 0 and 1", dispatches, inspector.calls)
+	}
+	retry := state.Retry[issue.ID]
+	if retry.Wait.PollCount != 1 || !retry.DueAt.Equal(now.Add(time.Minute)) {
+		t.Fatalf("held retry = %#v", retry)
+	}
+
+	now = retry.DueAt
+	hooks.pollRetryWait = func(candidate connector.Issue, retry Retry) (Retry, bool, string) {
+		return orch.pollWorkspaceBranchHold(t.Context(), &state, candidate, retry, now)
+	}
+	newDispatchPlanner(cfg).plan(&state, []connector.Issue{issue}, now, hooks)
+	if dispatches != 1 || inspector.calls != 2 {
+		t.Fatalf("released poll dispatches=%d calls=%d, want 1 and 2", dispatches, inspector.calls)
+	}
+	if _, waiting := state.Retry[issue.ID]; waiting {
+		t.Fatalf("Retry[%q] remains after release", issue.ID)
+	}
+}
+
+func TestRecoverWorkspaceBranchHoldUsesLatestAttempt(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 8, 24, 14, 0, 0, 0, time.UTC)
+	waiting := dispatchTestIssue("issue-restored", "In Progress")
+	waiting.BranchName = "detent/issue-restored"
+	completed := dispatchTestIssue("issue-completed", "In Progress")
+	metadata := func(branch string) string {
+		return marshalWorkAttemptJSON(map[string]any{"workspace_branch_hold": workspaceBranchHoldMetadata{
+			Schema: workspaceBranchHoldSchema, Branch: branch, WorktreePath: "/review/pr", PRNumber: 1917,
+			DetectedAt: now.Add(-2 * time.Minute), NextProbeAt: now.Add(time.Minute),
+		}})
+	}
+	attempts := []store.WorkAttempt{
+		{ID: 3, IssueID: waiting.ID, Identifier: waiting.Identifier, Lane: waiting.State, AttemptNumber: 4, Status: store.WorkAttemptStatusTerminal, CompletedAt: now.Add(-time.Minute), TerminalState: store.WorkAttemptTerminalCapacity, ErrorClass: workspaceBranchHoldErrorClass, ErrorMessage: "held", WorkerMetadataJSON: metadata(waiting.BranchName)},
+		{ID: 2, IssueID: completed.ID, Identifier: completed.Identifier, Lane: completed.State, AttemptNumber: 2, Status: store.WorkAttemptStatusTerminal, CompletedAt: now.Add(-30 * time.Second), TerminalState: store.WorkAttemptTerminalSuccess, WorkerMetadataJSON: `{}`},
+		{ID: 1, IssueID: completed.ID, Identifier: completed.Identifier, Lane: completed.State, AttemptNumber: 1, Status: store.WorkAttemptStatusTerminal, CompletedAt: now.Add(-2 * time.Minute), TerminalState: store.WorkAttemptTerminalCapacity, ErrorClass: workspaceBranchHoldErrorClass, WorkerMetadataJSON: metadata("detent/old")},
+	}
+	cfg := normalizeConfig(Config{ActiveStates: []string{"In Progress"}, TerminalStates: []string{"Done"}, MaxConcurrentAgents: 1})
+	orch := Orchestrator{cfg: cfg, connector: &forgeWaitRecoveryConnector{issues: []connector.Issue{waiting, completed}}}
+	state := newState(cfg)
+
+	orch.recoverWorkspaceBranchHolds(t.Context(), &state, attempts, now)
+
+	if retry, ok := state.Retry[waiting.ID]; !ok || retry.Attempt != 4 || retry.Wait.WorkspaceBranch != waiting.BranchName || retry.Wait.WorkspaceHolderPath != "/review/pr" {
+		t.Fatalf("Retry[%q] = %#v, want restored hold", waiting.ID, retry)
+	}
+	if _, ok := state.Retry[completed.ID]; ok {
+		t.Fatalf("Retry[%q] restored despite newer success", completed.ID)
+	}
+}
+
+type workspaceHoldInspectorStub struct {
+	results []runpkg.WorkspaceBranchHold
+	errs    []error
+	calls   int
+}
+
+func (s *workspaceHoldInspectorStub) InspectWorkspaceBranchHold(context.Context, connector.Issue) (runpkg.WorkspaceBranchHold, error) {
+	index := s.calls
+	s.calls++
+	var result runpkg.WorkspaceBranchHold
+	if index < len(s.results) {
+		result = s.results[index]
+	}
+	if index < len(s.errs) {
+		return result, s.errs[index]
+	}
+	return result, nil
+}

--- a/internal/runner/agent.go
+++ b/internal/runner/agent.go
@@ -1289,6 +1289,9 @@ func (r *Runner) Run(ctx context.Context, req RunRequest) (RunResult, error) {
 	}
 	info, err := runWorkspace.Create(ctx, workspaceIssue)
 	if err != nil {
+		if heldErr, held := workspaceBranchHeldError(err, req.Issue); held {
+			return RunResult{}, heldErr
+		}
 		classifiedErr := classifyForgeOperationError(fmt.Errorf("create workspace: %w", err), "git fetch", forgeHost)
 		return RunResult{}, fmt.Errorf("%w: %w", ErrWorkspacePreparation, classifiedErr)
 	}
@@ -4412,6 +4415,8 @@ func workerRunOutcome(err error, finalState string) string {
 		return FinalStateTokenCeilingExceeded
 	case errors.Is(err, ErrSessionMemoryCeilingExceeded):
 		return FinalStateMemoryCeilingExceeded
+	case errors.Is(err, ErrWorkspaceBranchHeld):
+		return "deferred"
 	case err != nil:
 		return "failed"
 	case strings.EqualFold(strings.TrimSpace(finalState), FinalStateCompleted), strings.TrimSpace(finalState) == "":

--- a/internal/runner/runner_test.go
+++ b/internal/runner/runner_test.go
@@ -2850,6 +2850,45 @@ func TestRunnerPublishesWorkspaceCreateStartedBeforeCreate(t *testing.T) {
 	}
 }
 
+func TestRunnerClassifiesWorkspaceBranchHold(t *testing.T) {
+	t.Parallel()
+
+	workspaceBackend := &fakeWorkspaceBackend{createErr: &workspace.BranchHeldError{
+		Branch: "detent/issue-1965",
+		Path:   "/review/PR-1917",
+	}}
+	runner, err := NewRunner(Dependencies{
+		Workflow:     config.Workflow{Config: config.Config{}},
+		Workspace:    workspaceBackend,
+		AgentBackend: &fakeCodexClient{},
+	})
+	if err != nil {
+		t.Fatalf("NewRunner() error = %v", err)
+	}
+
+	prNumber := 1917
+	_, err = runner.Run(t.Context(), RunRequest{Issue: connector.Issue{
+		ID:         "issue-held",
+		Identifier: "digitaldrywood/pyroapex#1838",
+		BranchName: "detent/issue-1965",
+		PRNumber:   &prNumber,
+	}})
+	var heldErr *WorkspaceBranchHeldError
+	if !errors.As(err, &heldErr) {
+		t.Fatalf("Run() error = %v, want WorkspaceBranchHeldError", err)
+	}
+	if errors.Is(err, ErrWorkspacePreparation) {
+		t.Fatalf("Run() error = %v, must be distinct from ErrWorkspacePreparation", err)
+	}
+	if heldErr.Branch != "detent/issue-1965" || heldErr.WorktreePath != "/review/PR-1917" || heldErr.PRNumber != prNumber {
+		t.Fatalf("WorkspaceBranchHeldError = %#v", heldErr)
+	}
+	want := "branch held by worktree at \"/review/PR-1917\" (PR #1917 checkout) — will resume when released"
+	if err.Error() != want {
+		t.Fatalf("Run() error = %q, want %q", err, want)
+	}
+}
+
 func TestRunnerMergeModeConflictUsesFocusedPrompt(t *testing.T) {
 	t.Parallel()
 

--- a/internal/runner/supervisor.go
+++ b/internal/runner/supervisor.go
@@ -157,7 +157,7 @@ func (s *Supervisor) Run(ctx context.Context, request RunRequest) (completion Co
 				slog.Any("panic", recovered),
 			)
 		}
-		if IsTransientOverload(completion.Err) {
+		if IsTransientOverload(completion.Err) || errors.Is(completion.Err, ErrWorkspaceBranchHeld) {
 			completion.Retryable = true
 			completion.RetryAttempt = request.Attempt
 			completion.RetryDelay = s.OverloadRetryDelay()
@@ -181,6 +181,9 @@ func (s *Supervisor) Run(ctx context.Context, request RunRequest) (completion Co
 		level := slog.LevelDebug
 		if IsTransientOverload(completion.Err) {
 			attrs = append(attrs, "reason", "transient_overload")
+			level = slog.LevelInfo
+		} else if errors.Is(completion.Err, ErrWorkspaceBranchHeld) {
+			attrs = append(attrs, "reason", "workspace_branch_held")
 			level = slog.LevelInfo
 		} else if completion.Err != nil {
 			level = slog.LevelWarn

--- a/internal/runner/supervisor_test.go
+++ b/internal/runner/supervisor_test.go
@@ -102,6 +102,23 @@ func TestSupervisorDoesNotAdvanceRetryForCapacityError(t *testing.T) {
 	}
 }
 
+func TestSupervisorRetriesWorkspaceBranchHoldWithoutAdvancingAttempt(t *testing.T) {
+	t.Parallel()
+
+	supervisor, err := NewSupervisor(workspaceBranchHeldBackend{}, SupervisorConfig{OverloadRetryDelay: 45 * time.Second})
+	if err != nil {
+		t.Fatalf("NewSupervisor() error = %v", err)
+	}
+
+	completion := supervisor.Run(t.Context(), RunRequest{Issue: connector.Issue{ID: "issue-held"}, Attempt: 7})
+	if !errors.Is(completion.Err, ErrWorkspaceBranchHeld) {
+		t.Fatalf("Err = %v, want ErrWorkspaceBranchHeld", completion.Err)
+	}
+	if !completion.Retryable || completion.RetryAttempt != 7 || completion.RetryDelay != 45*time.Second {
+		t.Fatalf("retry state = retryable %v attempt %d delay %s, want same attempt after 45s", completion.Retryable, completion.RetryAttempt, completion.RetryDelay)
+	}
+}
+
 func TestSupervisorDoesNotApplyGenericBackoffToGitHubRESTHeadroom(t *testing.T) {
 	t.Parallel()
 
@@ -571,6 +588,12 @@ type errorBackend struct{}
 
 func (errorBackend) Run(context.Context, RunRequest) (RunResult, error) {
 	return RunResult{}, errors.New("runner failed")
+}
+
+type workspaceBranchHeldBackend struct{}
+
+func (workspaceBranchHeldBackend) Run(context.Context, RunRequest) (RunResult, error) {
+	return RunResult{}, &WorkspaceBranchHeldError{Branch: "detent/held", WorktreePath: "/review/pr"}
 }
 
 type operatorStoppedBackend struct{}

--- a/internal/runner/types.go
+++ b/internal/runner/types.go
@@ -61,9 +61,42 @@ var (
 	ErrAgentTurnCleanup             = errors.New("agent turn cleanup failed")
 	ErrWorkerProcessReap            = errors.New("worker process reap failed")
 	ErrWorkspacePreparation         = errors.New("workspace preparation failed")
+	ErrWorkspaceBranchHeld          = errors.New("workspace branch held by worktree")
 	ErrAgentResumeUnsupported       = errors.New("agent backend does not support resume verification")
 	ErrDeliverableRecoveryExhausted = errors.New("deliverable recovery exhausted")
 )
+
+type WorkspaceBranchHeldError struct {
+	Branch       string
+	WorktreePath string
+	PRNumber     int
+}
+
+func (e *WorkspaceBranchHeldError) Error() string {
+	if e == nil {
+		return ErrWorkspaceBranchHeld.Error()
+	}
+	detail := fmt.Sprintf("branch held by worktree at %q", strings.TrimSpace(e.WorktreePath))
+	if e.PRNumber > 0 {
+		detail += fmt.Sprintf(" (PR #%d checkout)", e.PRNumber)
+	}
+	return detail + " — will resume when released"
+}
+
+func (e *WorkspaceBranchHeldError) Unwrap() error {
+	return ErrWorkspaceBranchHeld
+}
+
+type WorkspaceBranchHold struct {
+	Branch       string
+	WorktreePath string
+	PRNumber     int
+	Held         bool
+}
+
+type WorkspaceBranchHoldInspector interface {
+	InspectWorkspaceBranchHold(context.Context, connector.Issue) (WorkspaceBranchHold, error)
+}
 
 type DeliverableCommandError struct {
 	OperationClass string

--- a/internal/runner/workspace_hold.go
+++ b/internal/runner/workspace_hold.go
@@ -1,0 +1,39 @@
+package runner
+
+import (
+	"context"
+	"errors"
+	"strings"
+
+	"github.com/digitaldrywood/detent/internal/connector"
+	"github.com/digitaldrywood/detent/internal/workspace"
+)
+
+func (r *Runner) InspectWorkspaceBranchHold(ctx context.Context, issue connector.Issue) (WorkspaceBranchHold, error) {
+	provider, ok := r.workspace.(workspace.BranchHoldProvider)
+	if !ok {
+		return WorkspaceBranchHold{}, nil
+	}
+	hold, held, err := provider.BranchHold(ctx, workspaceIssue(r.projectID, issue))
+	if err != nil {
+		return WorkspaceBranchHold{}, err
+	}
+	return WorkspaceBranchHold{
+		Branch:       strings.TrimSpace(hold.Branch),
+		WorktreePath: strings.TrimSpace(hold.Path),
+		PRNumber:     ciTriggerPullRequestNumber(issue),
+		Held:         held,
+	}, nil
+}
+
+func workspaceBranchHeldError(err error, issue connector.Issue) (*WorkspaceBranchHeldError, bool) {
+	var heldErr *workspace.BranchHeldError
+	if !errors.As(err, &heldErr) || heldErr == nil {
+		return nil, false
+	}
+	return &WorkspaceBranchHeldError{
+		Branch:       strings.TrimSpace(heldErr.Branch),
+		WorktreePath: strings.TrimSpace(heldErr.Path),
+		PRNumber:     ciTriggerPullRequestNumber(issue),
+	}, true
+}

--- a/internal/workspace/workspace.go
+++ b/internal/workspace/workspace.go
@@ -71,6 +71,15 @@ type DeliverableStateProvider interface {
 	DeliverableState(context.Context, Info, Issue) (DeliverableState, error)
 }
 
+type BranchHoldProvider interface {
+	BranchHold(context.Context, Issue) (BranchHold, bool, error)
+}
+
+type BranchHold struct {
+	Branch string
+	Path   string
+}
+
 type IssueRecoveryStateProvider interface {
 	IssueRecoveryState(context.Context, Issue) (RecoveryState, error)
 }
@@ -246,6 +255,18 @@ type workspaceRemovalError struct {
 
 type worktreeCreationError struct {
 	err error
+}
+
+type BranchHeldError struct {
+	Branch string
+	Path   string
+}
+
+func (e *BranchHeldError) Error() string {
+	if e == nil {
+		return "branch held by another worktree"
+	}
+	return fmt.Sprintf("branch %q is held by worktree at %q", e.Branch, e.Path)
 }
 
 func (e *worktreeCreationError) Error() string {
@@ -545,6 +566,26 @@ func (l *LocalGit) IssueRecoveryState(ctx context.Context, issue Issue) (Recover
 	return l.RecoveryState(ctx, info, issue)
 }
 
+func (l *LocalGit) BranchHold(ctx context.Context, issue Issue) (BranchHold, bool, error) {
+	info, err := l.infoForIssue(issue)
+	if err != nil {
+		return BranchHold{}, false, err
+	}
+	if strings.TrimSpace(info.Branch) == "" {
+		return BranchHold{}, false, nil
+	}
+	release, err := l.acquireSourceOperation(ctx)
+	if err != nil {
+		return BranchHold{}, false, err
+	}
+	defer release()
+	holder, held, err := l.branchWorktreePath(ctx, info.Branch, info.Path)
+	if err != nil || !held {
+		return BranchHold{}, held, err
+	}
+	return BranchHold{Branch: info.Branch, Path: holder}, true, nil
+}
+
 func (l *LocalGit) normalizeInfo(info Info, issue Issue) (Info, error) {
 	key := info.Key
 	if key == "" {
@@ -713,6 +754,11 @@ func (l *LocalGit) addBranchedWorktree(ctx context.Context, path string, branch 
 			return err
 		}
 		if exists {
+			if holder, held, holdErr := l.branchWorktreePath(ctx, branch, path); holdErr != nil {
+				return holdErr
+			} else if held {
+				return &BranchHeldError{Branch: branch, Path: holder}
+			}
 			_, err = l.runGit(ctx, "worktree", "add", path, branch)
 			return err
 		}
@@ -724,6 +770,27 @@ func (l *LocalGit) addBranchedWorktree(ctx context.Context, path string, branch 
 		_, err = l.runGit(ctx, "worktree", "add", "-b", branch, path, baseRef)
 		return err
 	})
+}
+
+func (l *LocalGit) branchWorktreePath(ctx context.Context, branch string, targetPath string) (string, bool, error) {
+	output, err := l.runGit(ctx, "worktree", "list", "--porcelain", "-z")
+	if err != nil {
+		return "", false, withCommandOutput(err)
+	}
+	wantRef := "refs/heads/" + strings.TrimSpace(branch)
+	targetPath = filepath.Clean(targetPath)
+	var worktreePath string
+	for _, field := range strings.Split(output, "\x00") {
+		switch {
+		case strings.HasPrefix(field, "worktree "):
+			worktreePath = filepath.Clean(strings.TrimPrefix(field, "worktree "))
+		case strings.HasPrefix(field, "branch "):
+			if strings.TrimSpace(strings.TrimPrefix(field, "branch ")) == wantRef && worktreePath != targetPath {
+				return worktreePath, true, nil
+			}
+		}
+	}
+	return "", false, nil
 }
 
 func (l *LocalGit) addWorktreeWithPrune(ctx context.Context, add func() error) error {

--- a/internal/workspace/workspace_test.go
+++ b/internal/workspace/workspace_test.go
@@ -398,7 +398,7 @@ func TestLocalGitCreatePrunesMissingRegisteredWorktree(t *testing.T) {
 	}
 }
 
-func TestLocalGitCreateIncludesWorktreeAddStderr(t *testing.T) {
+func TestLocalGitCreateClassifiesOccupiedBranch(t *testing.T) {
 	t.Parallel()
 
 	source := initSourceRepo(t)
@@ -418,16 +418,12 @@ func TestLocalGitCreateIncludesWorktreeAddStderr(t *testing.T) {
 	if err == nil {
 		t.Fatal("Create() error = nil, want occupied branch error")
 	}
-	var commandErr *CommandError
-	if !errors.As(err, &commandErr) {
-		t.Fatalf("Create() error = %T, want *CommandError", err)
+	var heldErr *BranchHeldError
+	if !errors.As(err, &heldErr) {
+		t.Fatalf("Create() error = %T, want *BranchHeldError", err)
 	}
-	output := strings.TrimSpace(commandErr.Output)
-	if output == "" {
-		t.Fatal("CommandError.Output is empty, want git stderr")
-	}
-	if !strings.Contains(err.Error(), output) {
-		t.Fatalf("Create() error = %q, want git stderr %q", err, output)
+	if heldErr.Branch != "detent/dd-conflict" || heldErr.Path != occupiedPath {
+		t.Fatalf("BranchHeldError = %#v, want branch detent/dd-conflict at %q", heldErr, occupiedPath)
 	}
 }
 
@@ -1975,6 +1971,63 @@ func TestLocalGitCreateQuarantinesFailedCreationState(t *testing.T) {
 				t.Fatalf("quarantined .git mode = %v, want directory", gitInfo.Mode())
 			case !tt.wantStandalone && !errors.Is(statErr, os.ErrNotExist):
 				t.Fatalf("partial quarantine .git stat error = %v, want absent", statErr)
+			}
+		})
+	}
+}
+
+func TestLocalGitBranchHeldByWorktree(t *testing.T) {
+	skipWindows(t)
+
+	tests := []struct {
+		name               string
+		releaseBeforeRetry bool
+		wantCreated        bool
+	}{
+		{name: "held branch is classified"},
+		{name: "released branch creates workspace", releaseBeforeRetry: true, wantCreated: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			source := initSourceRepo(t)
+			root := filepath.Join(t.TempDir(), "workspaces")
+			holder := filepath.Join(t.TempDir(), "review-pr")
+			branch := "detent/reviewer-held"
+			runGit(t, source, "worktree", "add", "-b", branch, holder)
+
+			backend, err := NewLocalGit(LocalGitOptions{Root: root, SourceRoot: source, AutoBranch: true})
+			if err != nil {
+				t.Fatalf("NewLocalGit() error = %v", err)
+			}
+			issue := Issue{Identifier: "DD-HELD", BranchName: branch}
+
+			_, err = backend.Create(t.Context(), issue)
+			var heldErr *BranchHeldError
+			if !errors.As(err, &heldErr) {
+				t.Fatalf("Create() error = %v, want BranchHeldError", err)
+			}
+			if heldErr.Branch != branch || heldErr.Path != holder {
+				t.Fatalf("BranchHeldError = %#v, want branch %q path %q", heldErr, branch, holder)
+			}
+			hold, held, err := backend.BranchHold(t.Context(), issue)
+			if err != nil || !held || hold.Branch != branch || hold.Path != holder {
+				t.Fatalf("BranchHold() = %#v, %v, %v", hold, held, err)
+			}
+
+			if !tt.releaseBeforeRetry {
+				return
+			}
+			runGit(t, source, "worktree", "remove", holder)
+			if hold, held, err = backend.BranchHold(t.Context(), issue); err != nil || held {
+				t.Fatalf("BranchHold() after release = %#v, %v, %v", hold, held, err)
+			}
+			info, err := backend.Create(t.Context(), issue)
+			if err != nil {
+				t.Fatalf("Create() after release error = %v", err)
+			}
+			if info.Created != tt.wantCreated || info.Branch != branch {
+				t.Fatalf("Create() after release = %#v, want Created=%v branch=%q", info, tt.wantCreated, branch)
 			}
 		})
 	}

--- a/internal/workspace/workspace_test.go
+++ b/internal/workspace/workspace_test.go
@@ -422,9 +422,10 @@ func TestLocalGitCreateClassifiesOccupiedBranch(t *testing.T) {
 	if !errors.As(err, &heldErr) {
 		t.Fatalf("Create() error = %T, want *BranchHeldError", err)
 	}
-	if heldErr.Branch != "detent/dd-conflict" || heldErr.Path != occupiedPath {
-		t.Fatalf("BranchHeldError = %#v, want branch detent/dd-conflict at %q", heldErr, occupiedPath)
+	if heldErr.Branch != "detent/dd-conflict" {
+		t.Fatalf("BranchHeldError branch = %q, want detent/dd-conflict", heldErr.Branch)
 	}
+	requireSameFile(t, heldErr.Path, occupiedPath)
 }
 
 func TestRunWorktreeAddWithPrune(t *testing.T) {
@@ -2007,13 +2008,15 @@ func TestLocalGitBranchHeldByWorktree(t *testing.T) {
 			if !errors.As(err, &heldErr) {
 				t.Fatalf("Create() error = %v, want BranchHeldError", err)
 			}
-			if heldErr.Branch != branch || heldErr.Path != holder {
-				t.Fatalf("BranchHeldError = %#v, want branch %q path %q", heldErr, branch, holder)
+			if heldErr.Branch != branch {
+				t.Fatalf("BranchHeldError branch = %q, want %q", heldErr.Branch, branch)
 			}
+			requireSameFile(t, heldErr.Path, holder)
 			hold, held, err := backend.BranchHold(t.Context(), issue)
-			if err != nil || !held || hold.Branch != branch || hold.Path != holder {
+			if err != nil || !held || hold.Branch != branch {
 				t.Fatalf("BranchHold() = %#v, %v, %v", hold, held, err)
 			}
+			requireSameFile(t, hold.Path, holder)
 
 			if !tt.releaseBeforeRetry {
 				return
@@ -2030,6 +2033,21 @@ func TestLocalGitBranchHeldByWorktree(t *testing.T) {
 				t.Fatalf("Create() after release = %#v, want Created=%v branch=%q", info, tt.wantCreated, branch)
 			}
 		})
+	}
+}
+
+func requireSameFile(t *testing.T, got string, want string) {
+	t.Helper()
+	gotInfo, err := os.Stat(got)
+	if err != nil {
+		t.Fatalf("stat %q: %v", got, err)
+	}
+	wantInfo, err := os.Stat(want)
+	if err != nil {
+		t.Fatalf("stat %q: %v", want, err)
+	}
+	if !os.SameFile(gotInfo, wantInfo) {
+		t.Fatalf("path %q does not identify %q", got, want)
 	}
 }
 


### PR DESCRIPTION
## Summary

- classify branches owned by another worktree as durable external holds instead of workspace failures
- preserve the current attempt and failure counters while polling for automatic resume
- report external branch worktrees through `detent doctor` with holder paths and cleanup guidance
- keep the single-writer branch model instead of using a detached or alternate-branch fallback that could race a reviewer

Fixes #1965

## Test Plan

- `go test ./internal/workspace ./internal/runner ./internal/orchestrator ./internal/cli -count=1`
- `PATH="$TMPDIR/go126-bin:$PATH" GOTOOLCHAIN=go1.26.6 make check`