### PR TITLE
fix(board): reconcile staleness dismissals

### DIFF
--- a/internal/cli/boot.go
+++ b/internal/cli/boot.go
@@ -38,6 +38,7 @@ import (
 	"github.com/digitaldrywood/detent/internal/project"
 	runnerpkg "github.com/digitaldrywood/detent/internal/runner"
 	"github.com/digitaldrywood/detent/internal/scheduler"
+	"github.com/digitaldrywood/detent/internal/staleness"
 	"github.com/digitaldrywood/detent/internal/statuspage"
 	"github.com/digitaldrywood/detent/internal/store"
 	"github.com/digitaldrywood/detent/internal/telemetry"
@@ -279,6 +280,15 @@ func startRunningWithDependencies(ctx context.Context, cfg BootConfig, deps star
 	globalConfigState := newGlobalConfigState(cfg.Global)
 	refreshGitHubToken := runtimeGitHubTokenRefresher(globalConfigState, runtimeGitHubToken)
 	managerConfig := managerConfigWithRuntimeGitHubToken(cfg.Global, runtimeGitHubToken.get())
+	snapshotHub := hub.New[telemetry.Snapshot]()
+	projectIDs := make([]string, 0, len(cfg.Global.Projects))
+	for _, projectConfig := range cfg.Global.Projects {
+		projectIDs = append(projectIDs, projectConfig.ID)
+	}
+	stalenessAcknowledgements, err := staleness.NewAcknowledgements(runCtx, runtimeStore, snapshotHub, projectIDs)
+	if err != nil {
+		return err
+	}
 	dispatchPacer := runnerpkg.NewStartupDispatchPacer(runnerpkg.StartupDispatchPacerConfig{
 		MaxStartsPerSecond: managerConfig.Startup.MaxSpawnPerSecond,
 		Jitter:             managerConfig.Startup.Jitter,
@@ -295,7 +305,7 @@ func startRunningWithDependencies(ctx context.Context, cfg BootConfig, deps star
 		ProgressSpend:      runtimeStore,
 		AgentResume:        runtimeStore,
 		ValidatorMemo:      runtimeStore,
-		StalenessWarnings:  runtimeStore,
+		StalenessWarnings:  stalenessAcknowledgements,
 		RetroStore:         runtimeStore,
 		RoutineStore:       runtimeStore,
 		AdmissionStore:     runtimeStore,
@@ -334,7 +344,6 @@ func startRunningWithDependencies(ctx context.Context, cfg BootConfig, deps star
 		}
 	}()
 
-	snapshotHub := hub.New[telemetry.Snapshot]()
 	snapshotSeq := &atomic.Uint64{}
 	providerStatus := deps.providerStatusManager
 	if providerStatus == nil {
@@ -387,10 +396,10 @@ func startRunningWithDependencies(ctx context.Context, cfg BootConfig, deps star
 		logger.Warn("load board snapshot failed", "error", loadErr)
 	}
 	if cached {
-		if err := snapshotHub.Publish(cachedSnapshot); err != nil {
+		if err := stalenessAcknowledgements.Publish(cachedSnapshot); err != nil {
 			return fmt.Errorf("publish cached board snapshot: %w", err)
 		}
-	} else if err := publishStartupSnapshotOnce(runCtx, cfg.Global, snapshotHub, runtimeStore, displayURL, time.Now(), updateScheduler); err != nil {
+	} else if err := publishStartupSnapshotOnce(runCtx, cfg.Global, stalenessAcknowledgements, runtimeStore, displayURL, time.Now(), updateScheduler); err != nil {
 		return err
 	}
 	chatProvider := buildChatProvider(manager.Registry(), logger)
@@ -426,7 +435,7 @@ func startRunningWithDependencies(ctx context.Context, cfg BootConfig, deps star
 		}, time.Now)
 	})
 	resourceWorkers.Go(func() {
-		publishSnapshots(runCtx, manager.Registry(), globalDispatchGate, snapshotHub, snapshotSeq, cfg.Shutdown, runtimeStore, displayURL, providerStatus, defaultSnapshotInterval, time.Now, updateScheduler)
+		publishSnapshots(runCtx, manager.Registry(), globalDispatchGate, stalenessAcknowledgements, snapshotSeq, cfg.Shutdown, runtimeStore, displayURL, providerStatus, defaultSnapshotInterval, time.Now, updateScheduler)
 	})
 	if healthNotifications.Enabled() {
 		resourceWorkers.Go(func() {
@@ -471,6 +480,7 @@ func startRunningWithDependencies(ctx context.Context, cfg BootConfig, deps star
 		IssueExplainer:      newIssueExplainer(snapshotHub, runtimeStore),
 		HealthNotifications: healthNotifications,
 		WorkerProcesses:     runtimeStore,
+		StalenessWarnings:   stalenessAcknowledgements,
 	})
 	if err != nil {
 		return err

--- a/internal/cli/runner.go
+++ b/internal/cli/runner.go
@@ -55,6 +55,11 @@ type providerStatusEnricher interface {
 	Enrich(telemetry.Snapshot, []statuspage.Source) telemetry.Snapshot
 }
 
+type telemetrySnapshotPublisher interface {
+	Publish(telemetry.Snapshot) error
+	Latest() (telemetry.Snapshot, bool)
+}
+
 // withRunnerFactory returns a project.Factory that constructs a
 // per-project agent Runner from the project's own workflow (so each project's
 // codex command and workspace root are honored), injects it into the project's
@@ -323,7 +328,7 @@ func publishSnapshots(
 	ctx context.Context,
 	registry *project.Registry,
 	poolSource agentPoolSnapshotSource,
-	snapshotHub *hub.Hub[telemetry.Snapshot],
+	snapshotPublisher telemetrySnapshotPublisher,
 	seq *atomic.Uint64,
 	shutdown *ShutdownController,
 	lifetimeSource lifetimeTotalsSource,
@@ -333,7 +338,7 @@ func publishSnapshots(
 	now func() time.Time,
 	updateSources ...autoUpdateStatusSource,
 ) {
-	if registry == nil || snapshotHub == nil {
+	if registry == nil || snapshotPublisher == nil {
 		return
 	}
 	if interval <= 0 {
@@ -351,7 +356,7 @@ func publishSnapshots(
 	defer ticker.Stop()
 
 	for {
-		if err := publishSnapshotOnce(ctx, registry, poolSource, snapshotHub, seq, shutdown, now(), trend, lifetimeSource, dashboardURL, providerStatus, updateSources...); err != nil {
+		if err := publishSnapshotOnce(ctx, registry, poolSource, snapshotPublisher, seq, shutdown, now(), trend, lifetimeSource, dashboardURL, providerStatus, updateSources...); err != nil {
 			slog.Default().Warn("publish telemetry snapshot failed", "error", err)
 		}
 		select {
@@ -476,17 +481,17 @@ func persistBoardSnapshots(
 func publishStartupSnapshotOnce(
 	ctx context.Context,
 	cfg globalconfig.Config,
-	snapshotHub *hub.Hub[telemetry.Snapshot],
+	snapshotPublisher telemetrySnapshotPublisher,
 	lifetimeSource lifetimeTotalsSource,
 	dashboardURL string,
 	now time.Time,
 	updateSources ...autoUpdateStatusSource,
 ) error {
-	if snapshotHub == nil {
+	if snapshotPublisher == nil {
 		return nil
 	}
 	snapshot := startupSnapshot(ctx, cfg, lifetimeSource, dashboardURL, now, updateSources...)
-	if err := snapshotHub.Publish(snapshot); err != nil {
+	if err := snapshotPublisher.Publish(snapshot); err != nil {
 		return fmt.Errorf("publish startup snapshot: %w", err)
 	}
 	return nil
@@ -557,7 +562,7 @@ func publishSnapshotOnce(
 	ctx context.Context,
 	registry *project.Registry,
 	poolSource agentPoolSnapshotSource,
-	snapshotHub *hub.Hub[telemetry.Snapshot],
+	snapshotPublisher telemetrySnapshotPublisher,
 	seq *atomic.Uint64,
 	shutdown *ShutdownController,
 	now time.Time,
@@ -675,10 +680,10 @@ func publishSnapshotOnce(
 	}
 	merged.Seq = seq.Add(1)
 	summarizeSnapshotSections(&merged)
-	if current, ok := snapshotHub.Latest(); ok {
+	if current, ok := snapshotPublisher.Latest(); ok {
 		merged = composeLastKnownTrackerState(current, merged, now)
 	}
-	if err := snapshotHub.Publish(merged); err != nil {
+	if err := snapshotPublisher.Publish(merged); err != nil {
 		return fmt.Errorf("publish snapshot: %w", err)
 	}
 	return nil

--- a/internal/orchestrator/staleness.go
+++ b/internal/orchestrator/staleness.go
@@ -20,6 +20,7 @@ const (
 	stalenessDeliveryRetryBase = 5 * time.Minute
 	stalenessDeliveryRetryMax  = time.Hour
 	stalenessDeliveriesPerTick = 1
+	stalenessStateRetention    = 30 * 24 * time.Hour
 )
 
 func (o *Orchestrator) refreshStalenessWarnings(ctx context.Context, state *State, candidates []connector.Issue, now time.Time) {
@@ -27,6 +28,7 @@ func (o *Orchestrator) refreshStalenessWarnings(ctx context.Context, state *Stat
 		return
 	}
 	if !o.cfg.Staleness.Enabled {
+		o.stalenessWarningStates(ctx, state, nil, now)
 		state.StalenessWarnings = map[string]StalenessWarning{}
 		return
 	}
@@ -39,7 +41,7 @@ func (o *Orchestrator) refreshStalenessWarnings(ctx context.Context, state *Stat
 		Decisions:    stalenessDecisions(state.SchedulerDecisions, stalenessDecisionIssueIndex(state, candidates), state.laneEntries),
 	}, now)
 	evaluated = operatorFacingStalenessWarnings(evaluated, state)
-	persisted := o.stalenessWarningStates(ctx, state)
+	persisted := o.stalenessWarningStates(ctx, state, evaluated, now)
 	previous := state.StalenessWarnings
 	next := make(map[string]StalenessWarning, len(evaluated))
 	for _, warning := range evaluated {
@@ -111,17 +113,34 @@ func operatorFacingStalenessWarnings(warnings []staleness.Warning, state *State)
 	return out
 }
 
-func (o *Orchestrator) stalenessWarningStates(ctx context.Context, state *State) map[string]store.StalenessWarningState {
+func (o *Orchestrator) stalenessWarningStates(
+	ctx context.Context,
+	state *State,
+	evaluated []staleness.Warning,
+	now time.Time,
+) map[string]store.StalenessWarningState {
 	if state.stalenessReminders == nil {
 		state.stalenessReminders = map[string]time.Time{}
 	}
 	persisted := make(map[string]store.StalenessWarningState)
 	projectID := strings.TrimSpace(o.cfg.Project.ID)
 	if o.stalenessWarningStore != nil {
-		states, err := o.stalenessWarningStore.ListStalenessWarningStates(ctx, projectID)
+		activeWarningIDs := make([]string, 0, len(evaluated))
+		for _, warning := range evaluated {
+			if warningID := strings.TrimSpace(warning.ID); warningID != "" {
+				activeWarningIDs = append(activeWarningIDs, warningID)
+			}
+		}
+		states, err := o.stalenessWarningStore.ReconcileStalenessWarningStates(
+			ctx,
+			projectID,
+			activeWarningIDs,
+			now,
+			now.Add(-stalenessStateRetention),
+		)
 		if err != nil {
 			if o.logger != nil {
-				o.logger.Error("list staleness warning states", "project_id", projectID, "error", err)
+				o.logger.Error("reconcile staleness warning states", "project_id", projectID, "error", err)
 			}
 		} else {
 			for _, warningState := range states {

--- a/internal/staleness/acknowledgements.go
+++ b/internal/staleness/acknowledgements.go
@@ -1,0 +1,274 @@
+package staleness
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/digitaldrywood/detent/internal/hub"
+	"github.com/digitaldrywood/detent/internal/store"
+	"github.com/digitaldrywood/detent/internal/telemetry"
+)
+
+var ErrWarningNotActive = errors.New("staleness warning is not active")
+
+type WarningAcknowledgementResult struct {
+	WarningIDs        []string
+	SnapshotPublished bool
+}
+
+type warningIdentity struct {
+	projectID string
+	warningID string
+}
+
+type Acknowledgements struct {
+	mu           sync.Mutex
+	store        store.StalenessWarningStore
+	hub          *hub.Hub[telemetry.Snapshot]
+	acknowledged map[warningIdentity]struct{}
+	active       map[warningIdentity]struct{}
+	latestRaw    telemetry.Snapshot
+	hasLatestRaw bool
+}
+
+func NewAcknowledgements(
+	ctx context.Context,
+	stateStore store.StalenessWarningStore,
+	snapshotHub *hub.Hub[telemetry.Snapshot],
+	projectIDs []string,
+) (*Acknowledgements, error) {
+	if stateStore == nil {
+		return nil, errors.New("staleness acknowledgements require store")
+	}
+	if snapshotHub == nil {
+		return nil, errors.New("staleness acknowledgements require snapshot hub")
+	}
+	acknowledgements := &Acknowledgements{
+		store:        stateStore,
+		hub:          snapshotHub,
+		acknowledged: make(map[warningIdentity]struct{}),
+		active:       make(map[warningIdentity]struct{}),
+	}
+	seenProjects := make(map[string]struct{}, len(projectIDs))
+	for _, projectID := range projectIDs {
+		projectID = strings.TrimSpace(projectID)
+		if projectID == "" {
+			continue
+		}
+		if _, exists := seenProjects[projectID]; exists {
+			continue
+		}
+		seenProjects[projectID] = struct{}{}
+		states, err := stateStore.ListStalenessWarningStates(ctx, projectID)
+		if err != nil {
+			return nil, fmt.Errorf("load staleness warning acknowledgements for project %q: %w", projectID, err)
+		}
+		acknowledgements.replaceProjectAcknowledgements(projectID, states)
+	}
+	if latest, ok := snapshotHub.Latest(); ok {
+		acknowledgements.latestRaw = cloneSnapshotWarnings(latest)
+		acknowledgements.hasLatestRaw = true
+		acknowledgements.active = activeWarningIdentities(latest)
+	}
+	return acknowledgements, nil
+}
+
+func (a *Acknowledgements) Publish(snapshot telemetry.Snapshot) error {
+	if a == nil {
+		return errors.New("staleness acknowledgements are unavailable")
+	}
+	a.mu.Lock()
+	defer a.mu.Unlock()
+
+	a.latestRaw = cloneSnapshotWarnings(snapshot)
+	a.hasLatestRaw = true
+	a.active = activeWarningIdentities(snapshot)
+	return a.hub.Publish(a.effectiveSnapshot(snapshot))
+}
+
+func (a *Acknowledgements) Latest() (telemetry.Snapshot, bool) {
+	if a == nil || a.hub == nil {
+		return telemetry.Snapshot{}, false
+	}
+	return a.hub.Latest()
+}
+
+func (a *Acknowledgements) AcknowledgeActive(
+	ctx context.Context,
+	projectID string,
+	warningIDs []string,
+	at time.Time,
+) (WarningAcknowledgementResult, error) {
+	if a == nil {
+		return WarningAcknowledgementResult{}, errors.New("staleness acknowledgements are unavailable")
+	}
+	projectID = strings.TrimSpace(projectID)
+	warningIDs, err := normalizeWarningIDs(warningIDs)
+	if err != nil {
+		return WarningAcknowledgementResult{}, err
+	}
+	if projectID == "" {
+		return WarningAcknowledgementResult{}, store.ErrProjectRequired
+	}
+	a.mu.Lock()
+	defer a.mu.Unlock()
+
+	for _, warningID := range warningIDs {
+		identity := warningIdentity{projectID: projectID, warningID: warningID}
+		_, active := a.active[identity]
+		_, alreadyAcknowledged := a.acknowledged[identity]
+		if !active && !alreadyAcknowledged {
+			return WarningAcknowledgementResult{}, fmt.Errorf("%w: project %q warning %q", ErrWarningNotActive, projectID, warningID)
+		}
+	}
+	return a.acknowledgeLocked(ctx, projectID, warningIDs, at)
+}
+
+func (a *Acknowledgements) ListStalenessWarningStates(ctx context.Context, projectID string) ([]store.StalenessWarningState, error) {
+	return a.store.ListStalenessWarningStates(ctx, projectID)
+}
+
+func (a *Acknowledgements) RecordStalenessWarningReminder(ctx context.Context, projectID string, warningID string, at time.Time) error {
+	return a.store.RecordStalenessWarningReminder(ctx, projectID, warningID, at)
+}
+
+func (a *Acknowledgements) AcknowledgeStalenessWarning(ctx context.Context, projectID string, warningID string, at time.Time) error {
+	return a.AcknowledgeStalenessWarnings(ctx, projectID, []string{warningID}, at)
+}
+
+func (a *Acknowledgements) AcknowledgeStalenessWarnings(ctx context.Context, projectID string, warningIDs []string, at time.Time) error {
+	if a == nil {
+		return errors.New("staleness acknowledgements are unavailable")
+	}
+	projectID = strings.TrimSpace(projectID)
+	warningIDs, err := normalizeWarningIDs(warningIDs)
+	if err != nil {
+		return err
+	}
+	if projectID == "" {
+		return store.ErrProjectRequired
+	}
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	_, err = a.acknowledgeLocked(ctx, projectID, warningIDs, at)
+	return err
+}
+
+func (a *Acknowledgements) ReconcileStalenessWarningStates(
+	ctx context.Context,
+	projectID string,
+	activeWarningIDs []string,
+	observedAt time.Time,
+	inactiveBefore time.Time,
+) ([]store.StalenessWarningState, error) {
+	if a == nil {
+		return nil, errors.New("staleness acknowledgements are unavailable")
+	}
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	states, err := a.store.ReconcileStalenessWarningStates(ctx, projectID, activeWarningIDs, observedAt, inactiveBefore)
+	if err != nil {
+		return nil, err
+	}
+	a.replaceProjectAcknowledgements(projectID, states)
+	return states, nil
+}
+
+func (a *Acknowledgements) acknowledgeLocked(
+	ctx context.Context,
+	projectID string,
+	warningIDs []string,
+	at time.Time,
+) (WarningAcknowledgementResult, error) {
+	if err := a.store.AcknowledgeStalenessWarnings(ctx, projectID, warningIDs, at); err != nil {
+		return WarningAcknowledgementResult{}, err
+	}
+	for _, warningID := range warningIDs {
+		a.acknowledged[warningIdentity{projectID: projectID, warningID: warningID}] = struct{}{}
+	}
+	result := WarningAcknowledgementResult{WarningIDs: append([]string(nil), warningIDs...)}
+	if !a.hasLatestRaw {
+		return result, nil
+	}
+	if err := a.hub.Publish(a.effectiveSnapshot(a.latestRaw)); err != nil {
+		return result, fmt.Errorf("publish acknowledged staleness warnings: %w", err)
+	}
+	result.SnapshotPublished = true
+	return result, nil
+}
+
+func (a *Acknowledgements) replaceProjectAcknowledgements(projectID string, states []store.StalenessWarningState) {
+	projectID = strings.TrimSpace(projectID)
+	for identity := range a.acknowledged {
+		if identity.projectID == projectID {
+			delete(a.acknowledged, identity)
+		}
+	}
+	for _, state := range states {
+		warningID := strings.TrimSpace(state.WarningID)
+		if state.AcknowledgedAt == nil || warningID == "" {
+			continue
+		}
+		a.acknowledged[warningIdentity{projectID: projectID, warningID: warningID}] = struct{}{}
+	}
+}
+
+func (a *Acknowledgements) effectiveSnapshot(snapshot telemetry.Snapshot) telemetry.Snapshot {
+	filtered := make([]telemetry.StalenessWarning, 0, len(snapshot.StalenessWarnings))
+	for _, warning := range snapshot.StalenessWarnings {
+		identity := warningIdentity{
+			projectID: strings.TrimSpace(warning.ProjectID),
+			warningID: strings.TrimSpace(warning.ID),
+		}
+		if _, acknowledged := a.acknowledged[identity]; acknowledged {
+			continue
+		}
+		filtered = append(filtered, warning)
+	}
+	snapshot.StalenessWarnings = filtered
+	return snapshot
+}
+
+func activeWarningIdentities(snapshot telemetry.Snapshot) map[warningIdentity]struct{} {
+	active := make(map[warningIdentity]struct{}, len(snapshot.StalenessWarnings))
+	for _, warning := range snapshot.StalenessWarnings {
+		identity := warningIdentity{
+			projectID: strings.TrimSpace(warning.ProjectID),
+			warningID: strings.TrimSpace(warning.ID),
+		}
+		if identity.projectID == "" || identity.warningID == "" {
+			continue
+		}
+		active[identity] = struct{}{}
+	}
+	return active
+}
+
+func cloneSnapshotWarnings(snapshot telemetry.Snapshot) telemetry.Snapshot {
+	snapshot.StalenessWarnings = append([]telemetry.StalenessWarning(nil), snapshot.StalenessWarnings...)
+	return snapshot
+}
+
+func normalizeWarningIDs(warningIDs []string) ([]string, error) {
+	if len(warningIDs) == 0 {
+		return nil, errors.New("warning_ids are required")
+	}
+	seen := make(map[string]struct{}, len(warningIDs))
+	normalized := make([]string, 0, len(warningIDs))
+	for _, warningID := range warningIDs {
+		warningID = strings.TrimSpace(warningID)
+		if warningID == "" {
+			return nil, errors.New("warning_id is required")
+		}
+		if _, exists := seen[warningID]; exists {
+			continue
+		}
+		seen[warningID] = struct{}{}
+		normalized = append(normalized, warningID)
+	}
+	return normalized, nil
+}

--- a/internal/staleness/acknowledgements_test.go
+++ b/internal/staleness/acknowledgements_test.go
@@ -1,0 +1,134 @@
+package staleness_test
+
+import (
+	"errors"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/digitaldrywood/detent/internal/hub"
+	"github.com/digitaldrywood/detent/internal/staleness"
+	"github.com/digitaldrywood/detent/internal/store"
+	"github.com/digitaldrywood/detent/internal/telemetry"
+)
+
+func TestAcknowledgementsProjectsPersistedAndLiveState(t *testing.T) {
+	t.Parallel()
+	backend, err := store.Open(t.Context(), store.Config{Path: filepath.Join(t.TempDir(), "detent.db")})
+	if err != nil {
+		t.Fatalf("store.Open() error = %v", err)
+	}
+	t.Cleanup(func() { _ = backend.Close() })
+	now := time.Date(2026, 8, 24, 12, 0, 0, 0, time.UTC)
+	if err := backend.AcknowledgeStalenessWarning(t.Context(), "detent", "warning-1", now.Add(-time.Hour)); err != nil {
+		t.Fatalf("AcknowledgeStalenessWarning() error = %v", err)
+	}
+	snapshots := hub.New[telemetry.Snapshot]()
+	acknowledgements, err := staleness.NewAcknowledgements(t.Context(), backend, snapshots, []string{"detent", "other"})
+	if err != nil {
+		t.Fatalf("NewAcknowledgements() error = %v", err)
+	}
+	raw := telemetry.Snapshot{StalenessWarnings: []telemetry.StalenessWarning{
+		{ID: "warning-1", ProjectID: "detent"},
+		{ID: "warning-2", ProjectID: "detent"},
+		{ID: "warning-1", ProjectID: "other"},
+	}}
+	if err := acknowledgements.Publish(raw); err != nil {
+		t.Fatalf("Publish() error = %v", err)
+	}
+	assertWarningIdentities(t, snapshots, []string{"detent/warning-2", "other/warning-1"})
+
+	result, err := acknowledgements.AcknowledgeActive(t.Context(), "detent", []string{"warning-2"}, now)
+	if err != nil {
+		t.Fatalf("AcknowledgeActive() error = %v", err)
+	}
+	if !result.SnapshotPublished {
+		t.Fatal("AcknowledgeActive() did not publish the effective snapshot")
+	}
+	assertWarningIdentities(t, snapshots, []string{"other/warning-1"})
+	if err := acknowledgements.Publish(raw); err != nil {
+		t.Fatalf("Publish(unchanged raw snapshot) error = %v", err)
+	}
+	assertWarningIdentities(t, snapshots, []string{"other/warning-1"})
+
+	for _, tt := range []struct {
+		name      string
+		projectID string
+		warningID string
+	}{
+		{name: "unknown warning", projectID: "detent", warningID: "unknown"},
+		{name: "wrong project", projectID: "other", warningID: "warning-2"},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := acknowledgements.AcknowledgeActive(t.Context(), tt.projectID, []string{tt.warningID}, now)
+			if !errors.Is(err, staleness.ErrWarningNotActive) {
+				t.Fatalf("AcknowledgeActive() error = %v, want ErrWarningNotActive", err)
+			}
+		})
+	}
+}
+
+func TestAcknowledgementsReleaseExpiredRecurringEpisode(t *testing.T) {
+	t.Parallel()
+	backend, err := store.Open(t.Context(), store.Config{Path: filepath.Join(t.TempDir(), "detent.db")})
+	if err != nil {
+		t.Fatalf("store.Open() error = %v", err)
+	}
+	t.Cleanup(func() { _ = backend.Close() })
+	now := time.Date(2026, 8, 24, 12, 0, 0, 0, time.UTC)
+	if err := backend.AcknowledgeStalenessWarning(t.Context(), "detent", "warning-1", now.Add(-31*24*time.Hour)); err != nil {
+		t.Fatalf("AcknowledgeStalenessWarning() error = %v", err)
+	}
+	snapshots := hub.New[telemetry.Snapshot]()
+	acknowledgements, err := staleness.NewAcknowledgements(t.Context(), backend, snapshots, []string{"detent"})
+	if err != nil {
+		t.Fatalf("NewAcknowledgements() error = %v", err)
+	}
+	raw := telemetry.Snapshot{StalenessWarnings: []telemetry.StalenessWarning{{ID: "warning-1", ProjectID: "detent"}}}
+	if err := acknowledgements.Publish(raw); err != nil {
+		t.Fatalf("Publish(before reconciliation) error = %v", err)
+	}
+	assertWarningIdentities(t, snapshots, nil)
+	if _, err := acknowledgements.ReconcileStalenessWarningStates(
+		t.Context(),
+		"detent",
+		nil,
+		now,
+		now.Add(-30*24*time.Hour),
+	); err != nil {
+		t.Fatalf("ReconcileStalenessWarningStates(absent) error = %v", err)
+	}
+	if _, err := acknowledgements.ReconcileStalenessWarningStates(
+		t.Context(),
+		"detent",
+		[]string{"warning-1"},
+		now.Add(time.Minute),
+		now.Add(-30*24*time.Hour+time.Minute),
+	); err != nil {
+		t.Fatalf("ReconcileStalenessWarningStates(recurred) error = %v", err)
+	}
+	if err := acknowledgements.Publish(raw); err != nil {
+		t.Fatalf("Publish(after reconciliation) error = %v", err)
+	}
+	assertWarningIdentities(t, snapshots, []string{"detent/warning-1"})
+}
+
+func assertWarningIdentities(t *testing.T, snapshots *hub.Hub[telemetry.Snapshot], want []string) {
+	t.Helper()
+	snapshot, ok := snapshots.Latest()
+	if !ok {
+		t.Fatal("snapshot hub has no latest snapshot")
+	}
+	got := make([]string, 0, len(snapshot.StalenessWarnings))
+	for _, warning := range snapshot.StalenessWarnings {
+		got = append(got, warning.ProjectID+"/"+warning.ID)
+	}
+	if len(got) != len(want) {
+		t.Fatalf("warning identities = %v, want %v", got, want)
+	}
+	for index := range want {
+		if got[index] != want[index] {
+			t.Fatalf("warning identities = %v, want %v", got, want)
+		}
+	}
+}

--- a/internal/store/migrations/00042_add_staleness_warning_last_seen.sql
+++ b/internal/store/migrations/00042_add_staleness_warning_last_seen.sql
@@ -1,0 +1,9 @@
+-- +goose Up
+ALTER TABLE staleness_warning_states ADD COLUMN last_seen_at TEXT;
+
+UPDATE staleness_warning_states
+SET last_seen_at = COALESCE(acknowledged_at, reminded_at)
+WHERE last_seen_at IS NULL;
+
+-- +goose Down
+ALTER TABLE staleness_warning_states DROP COLUMN last_seen_at;

--- a/internal/store/sqlc/models.go
+++ b/internal/store/sqlc/models.go
@@ -330,6 +330,7 @@ type StalenessWarningState struct {
 	WarningID      string         `json:"warning_id"`
 	RemindedAt     sql.NullString `json:"reminded_at"`
 	AcknowledgedAt sql.NullString `json:"acknowledged_at"`
+	LastSeenAt     sql.NullString `json:"last_seen_at"`
 }
 
 type UsageEvent struct {

--- a/internal/store/staleness_warning.go
+++ b/internal/store/staleness_warning.go
@@ -155,6 +155,12 @@ func (s *sqliteStore) ReconcileStalenessWarningStates(
 		return nil, fmt.Errorf("begin staleness warning reconciliation: %w", err)
 	}
 	defer func() { _ = tx.Rollback() }()
+	if _, err := tx.ExecContext(ctx, `
+DELETE FROM staleness_warning_states
+WHERE project_id = ?
+  AND (last_seen_at IS NULL OR last_seen_at < ?)`, projectID, inactiveTimestamp); err != nil {
+		return nil, fmt.Errorf("prune inactive staleness warning states: %w", err)
+	}
 	for _, warningID := range activeWarningIDs {
 		if _, err := tx.ExecContext(ctx, `
 UPDATE staleness_warning_states
@@ -162,12 +168,6 @@ SET last_seen_at = ?
 WHERE project_id = ? AND warning_id = ?`, observedTimestamp, projectID, warningID); err != nil {
 			return nil, fmt.Errorf("mark staleness warning %q observed: %w", warningID, err)
 		}
-	}
-	if _, err := tx.ExecContext(ctx, `
-DELETE FROM staleness_warning_states
-WHERE project_id = ?
-  AND (last_seen_at IS NULL OR last_seen_at < ?)`, projectID, inactiveTimestamp); err != nil {
-		return nil, fmt.Errorf("prune inactive staleness warning states: %w", err)
 	}
 	states, err := listStalenessWarningStates(ctx, tx, projectID)
 	if err != nil {

--- a/internal/store/staleness_warning.go
+++ b/internal/store/staleness_warning.go
@@ -14,8 +14,16 @@ func (s *sqliteStore) ListStalenessWarningStates(ctx context.Context, projectID 
 	if projectID == "" {
 		return nil, ErrProjectRequired
 	}
-	rows, err := s.db.QueryContext(ctx, `
-SELECT warning_id, reminded_at, acknowledged_at
+	return listStalenessWarningStates(ctx, s.db, projectID)
+}
+
+type stalenessWarningStateQuerier interface {
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+}
+
+func listStalenessWarningStates(ctx context.Context, querier stalenessWarningStateQuerier, projectID string) ([]StalenessWarningState, error) {
+	rows, err := querier.QueryContext(ctx, `
+SELECT warning_id, reminded_at, acknowledged_at, last_seen_at
 FROM staleness_warning_states
 WHERE project_id = ?`, projectID)
 	if err != nil {
@@ -27,7 +35,8 @@ WHERE project_id = ?`, projectID)
 		var warningID string
 		var remindedAt sql.NullString
 		var acknowledgedAt sql.NullString
-		if err := rows.Scan(&warningID, &remindedAt, &acknowledgedAt); err != nil {
+		var lastSeenAt sql.NullString
+		if err := rows.Scan(&warningID, &remindedAt, &acknowledgedAt, &lastSeenAt); err != nil {
 			return nil, fmt.Errorf("scan staleness warning state: %w", err)
 		}
 		state := StalenessWarningState{ProjectID: projectID, WarningID: warningID}
@@ -44,6 +53,13 @@ WHERE project_id = ?`, projectID)
 				return nil, err
 			}
 			state.AcknowledgedAt = &parsed
+		}
+		if lastSeenAt.Valid {
+			parsed, err := parseTimestamp("last_seen_at", lastSeenAt.String)
+			if err != nil {
+				return nil, err
+			}
+			state.LastSeenAt = &parsed
 		}
 		states = append(states, state)
 	}
@@ -63,16 +79,26 @@ func (s *sqliteStore) RecordStalenessWarningReminder(ctx context.Context, projec
 		return err
 	}
 	if _, err := s.db.ExecContext(ctx, `
-INSERT INTO staleness_warning_states (project_id, warning_id, reminded_at)
-VALUES (?, ?, ?)
-ON CONFLICT(project_id, warning_id) DO UPDATE SET reminded_at = excluded.reminded_at`, projectID, warningID, timestamp); err != nil {
+INSERT INTO staleness_warning_states (project_id, warning_id, reminded_at, last_seen_at)
+VALUES (?, ?, ?, ?)
+ON CONFLICT(project_id, warning_id) DO UPDATE SET
+  reminded_at = excluded.reminded_at,
+  last_seen_at = excluded.last_seen_at`, projectID, warningID, timestamp, timestamp); err != nil {
 		return fmt.Errorf("record staleness warning reminder: %w", err)
 	}
 	return nil
 }
 
 func (s *sqliteStore) AcknowledgeStalenessWarning(ctx context.Context, projectID string, warningID string, at time.Time) error {
-	projectID, warningID, err := validatedStalenessWarningIdentity(projectID, warningID)
+	return s.AcknowledgeStalenessWarnings(ctx, projectID, []string{warningID}, at)
+}
+
+func (s *sqliteStore) AcknowledgeStalenessWarnings(ctx context.Context, projectID string, warningIDs []string, at time.Time) error {
+	projectID = strings.TrimSpace(projectID)
+	if projectID == "" {
+		return ErrProjectRequired
+	}
+	warningIDs, err := validatedStalenessWarningIDs(warningIDs)
 	if err != nil {
 		return err
 	}
@@ -80,13 +106,77 @@ func (s *sqliteStore) AcknowledgeStalenessWarning(ctx context.Context, projectID
 	if err != nil {
 		return err
 	}
-	if _, err := s.db.ExecContext(ctx, `
-INSERT INTO staleness_warning_states (project_id, warning_id, acknowledged_at)
-VALUES (?, ?, ?)
-ON CONFLICT(project_id, warning_id) DO UPDATE SET acknowledged_at = excluded.acknowledged_at`, projectID, warningID, timestamp); err != nil {
-		return fmt.Errorf("acknowledge staleness warning: %w", err)
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("begin staleness warning acknowledgement: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+	for _, warningID := range warningIDs {
+		if _, err := tx.ExecContext(ctx, `
+INSERT INTO staleness_warning_states (project_id, warning_id, acknowledged_at, last_seen_at)
+VALUES (?, ?, ?, ?)
+ON CONFLICT(project_id, warning_id) DO UPDATE SET
+  acknowledged_at = COALESCE(staleness_warning_states.acknowledged_at, excluded.acknowledged_at),
+  last_seen_at = excluded.last_seen_at`, projectID, warningID, timestamp, timestamp); err != nil {
+			return fmt.Errorf("acknowledge staleness warning %q: %w", warningID, err)
+		}
+	}
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("commit staleness warning acknowledgement: %w", err)
 	}
 	return nil
+}
+
+func (s *sqliteStore) ReconcileStalenessWarningStates(
+	ctx context.Context,
+	projectID string,
+	activeWarningIDs []string,
+	observedAt time.Time,
+	inactiveBefore time.Time,
+) ([]StalenessWarningState, error) {
+	projectID = strings.TrimSpace(projectID)
+	if projectID == "" {
+		return nil, ErrProjectRequired
+	}
+	activeWarningIDs, err := normalizedStalenessWarningIDs(activeWarningIDs)
+	if err != nil {
+		return nil, err
+	}
+	observedTimestamp, err := requiredTimestamp("last_seen_at", observedAt)
+	if err != nil {
+		return nil, err
+	}
+	inactiveTimestamp, err := requiredTimestamp("inactive_before", inactiveBefore)
+	if err != nil {
+		return nil, err
+	}
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return nil, fmt.Errorf("begin staleness warning reconciliation: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+	for _, warningID := range activeWarningIDs {
+		if _, err := tx.ExecContext(ctx, `
+UPDATE staleness_warning_states
+SET last_seen_at = ?
+WHERE project_id = ? AND warning_id = ?`, observedTimestamp, projectID, warningID); err != nil {
+			return nil, fmt.Errorf("mark staleness warning %q observed: %w", warningID, err)
+		}
+	}
+	if _, err := tx.ExecContext(ctx, `
+DELETE FROM staleness_warning_states
+WHERE project_id = ?
+  AND (last_seen_at IS NULL OR last_seen_at < ?)`, projectID, inactiveTimestamp); err != nil {
+		return nil, fmt.Errorf("prune inactive staleness warning states: %w", err)
+	}
+	states, err := listStalenessWarningStates(ctx, tx, projectID)
+	if err != nil {
+		return nil, err
+	}
+	if err := tx.Commit(); err != nil {
+		return nil, fmt.Errorf("commit staleness warning reconciliation: %w", err)
+	}
+	return states, nil
 }
 
 func validatedStalenessWarningIdentity(projectID string, warningID string) (string, string, error) {
@@ -99,4 +189,28 @@ func validatedStalenessWarningIdentity(projectID string, warningID string) (stri
 		return "", "", errors.New("warning_id is required")
 	}
 	return projectID, warningID, nil
+}
+
+func validatedStalenessWarningIDs(warningIDs []string) ([]string, error) {
+	if len(warningIDs) == 0 {
+		return nil, errors.New("warning_ids are required")
+	}
+	return normalizedStalenessWarningIDs(warningIDs)
+}
+
+func normalizedStalenessWarningIDs(warningIDs []string) ([]string, error) {
+	seen := make(map[string]struct{}, len(warningIDs))
+	normalized := make([]string, 0, len(warningIDs))
+	for _, warningID := range warningIDs {
+		warningID = strings.TrimSpace(warningID)
+		if warningID == "" {
+			return nil, errors.New("warning_id is required")
+		}
+		if _, exists := seen[warningID]; exists {
+			continue
+		}
+		seen[warningID] = struct{}{}
+		normalized = append(normalized, warningID)
+	}
+	return normalized, nil
 }

--- a/internal/store/staleness_warning_test.go
+++ b/internal/store/staleness_warning_test.go
@@ -58,7 +58,8 @@ func TestReconcileStalenessWarningStatesRetainsOnlyLiveEpisodes(t *testing.T) {
 		wantLastSeen   time.Time
 	}{
 		{name: "recently inactive survives transient absence", acknowledgedAt: now.Add(-time.Hour), wantState: true, wantLastSeen: now.Add(-time.Hour)},
-		{name: "continuously active refreshes last seen", acknowledgedAt: inactiveBefore.Add(-time.Second), active: []string{"warning-1"}, wantState: true, wantLastSeen: now},
+		{name: "recently active refreshes last seen", acknowledgedAt: inactiveBefore.Add(time.Second), active: []string{"warning-1"}, wantState: true, wantLastSeen: now},
+		{name: "expired active acknowledgement cannot be revived", acknowledgedAt: inactiveBefore.Add(-time.Second), active: []string{"warning-1"}, wantState: false},
 		{name: "stale inactive is pruned", acknowledgedAt: inactiveBefore.Add(-time.Second)},
 		{name: "stale recurring episode resurfaces", acknowledgedAt: inactiveBefore.Add(-time.Second), recur: true},
 	}

--- a/internal/store/staleness_warning_test.go
+++ b/internal/store/staleness_warning_test.go
@@ -35,10 +35,63 @@ func TestStalenessWarningStatePersistsAcrossReopen(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ListStalenessWarningStates() error = %v", err)
 	}
-	if len(states) != 1 || states[0].RemindedAt == nil || states[0].AcknowledgedAt == nil {
+	if len(states) != 1 || states[0].RemindedAt == nil || states[0].AcknowledgedAt == nil || states[0].LastSeenAt == nil {
 		t.Fatalf("states = %#v, want persisted reminder and acknowledgement", states)
 	}
 	if !states[0].RemindedAt.Equal(remindedAt) || !states[0].AcknowledgedAt.Equal(acknowledgedAt) {
 		t.Fatalf("state timestamps = %#v, want %v and %v", states[0], remindedAt, acknowledgedAt)
+	}
+	if !states[0].LastSeenAt.Equal(acknowledgedAt) {
+		t.Fatalf("last seen = %v, want acknowledgement time %v", states[0].LastSeenAt, acknowledgedAt)
+	}
+}
+
+func TestReconcileStalenessWarningStatesRetainsOnlyLiveEpisodes(t *testing.T) {
+	now := time.Date(2026, 8, 24, 12, 0, 0, 0, time.UTC)
+	inactiveBefore := now.Add(-30 * 24 * time.Hour)
+	tests := []struct {
+		name           string
+		acknowledgedAt time.Time
+		active         []string
+		recur          bool
+		wantState      bool
+		wantLastSeen   time.Time
+	}{
+		{name: "recently inactive survives transient absence", acknowledgedAt: now.Add(-time.Hour), wantState: true, wantLastSeen: now.Add(-time.Hour)},
+		{name: "continuously active refreshes last seen", acknowledgedAt: inactiveBefore.Add(-time.Second), active: []string{"warning-1"}, wantState: true, wantLastSeen: now},
+		{name: "stale inactive is pruned", acknowledgedAt: inactiveBefore.Add(-time.Second)},
+		{name: "stale recurring episode resurfaces", acknowledgedAt: inactiveBefore.Add(-time.Second), recur: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			backend, err := Open(t.Context(), Config{Path: filepath.Join(t.TempDir(), "detent.db")})
+			if err != nil {
+				t.Fatalf("Open() error = %v", err)
+			}
+			t.Cleanup(func() { _ = backend.Close() })
+			if err := backend.AcknowledgeStalenessWarning(t.Context(), "detent", "warning-1", tt.acknowledgedAt); err != nil {
+				t.Fatalf("AcknowledgeStalenessWarning() error = %v", err)
+			}
+			states, err := backend.ReconcileStalenessWarningStates(t.Context(), "detent", tt.active, now, inactiveBefore)
+			if err != nil {
+				t.Fatalf("ReconcileStalenessWarningStates() error = %v", err)
+			}
+			if tt.recur {
+				states, err = backend.ReconcileStalenessWarningStates(t.Context(), "detent", []string{"warning-1"}, now.Add(time.Minute), inactiveBefore.Add(time.Minute))
+				if err != nil {
+					t.Fatalf("ReconcileStalenessWarningStates(recurred) error = %v", err)
+				}
+			}
+			if got := len(states) == 1; got != tt.wantState {
+				t.Fatalf("state present = %t, want %t; states = %#v", got, tt.wantState, states)
+			}
+			if !tt.wantState {
+				return
+			}
+			if states[0].LastSeenAt == nil || !states[0].LastSeenAt.Equal(tt.wantLastSeen) {
+				t.Fatalf("LastSeenAt = %v, want %v", states[0].LastSeenAt, tt.wantLastSeen)
+			}
+		})
 	}
 }

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -179,6 +179,8 @@ type StalenessWarningStore interface {
 	ListStalenessWarningStates(context.Context, string) ([]StalenessWarningState, error)
 	RecordStalenessWarningReminder(context.Context, string, string, time.Time) error
 	AcknowledgeStalenessWarning(context.Context, string, string, time.Time) error
+	AcknowledgeStalenessWarnings(context.Context, string, []string, time.Time) error
+	ReconcileStalenessWarningStates(context.Context, string, []string, time.Time, time.Time) ([]StalenessWarningState, error)
 }
 
 type WorkAttemptCapacityReleaseStore interface {
@@ -843,6 +845,7 @@ type StalenessWarningState struct {
 	WarningID      string
 	RemindedAt     *time.Time
 	AcknowledgedAt *time.Time
+	LastSeenAt     *time.Time
 }
 
 type IssueSchedulerDecisionQuery struct {

--- a/internal/web/openapi.yaml
+++ b/internal/web/openapi.yaml
@@ -262,6 +262,44 @@ paths:
         "404": {$ref: "#/components/responses/Problem"}
         "409": {$ref: "#/components/responses/Problem"}
         "503": {$ref: "#/components/responses/Unavailable"}
+  /api/v1/projects/{project_id}/staleness-warnings/acknowledge:
+    parameters:
+      - $ref: "#/components/parameters/ProjectID"
+    post:
+      operationId: acknowledgeStalenessWarnings
+      summary: Dismiss an explicit set of active staleness warning conditions
+      description: Acknowledges only the warning IDs supplied by the caller in one transactional operation.
+      tags: [projects, operations]
+      security:
+        - bearerAuth: []
+        - apiKeyAuth: []
+      x-detent-access: project-scoped
+      x-detent-scope: write
+      x-detent-project-parameter: project_id
+      x-detent-echo-path: /api/v1/projects/:project_id/staleness-warnings/acknowledge
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [warning_ids]
+              properties:
+                warning_ids:
+                  type: array
+                  minItems: 1
+                  items: {type: string, minLength: 1}
+      responses:
+        "200":
+          description: The explicit warning conditions were acknowledged.
+          content:
+            application/json:
+              schema: {$ref: "#/components/schemas/GenericObject"}
+        "400": {$ref: "#/components/responses/Problem"}
+        "401": {$ref: "#/components/responses/Problem"}
+        "403": {$ref: "#/components/responses/Problem"}
+        "404": {$ref: "#/components/responses/Problem"}
+        "503": {$ref: "#/components/responses/Unavailable"}
   /api/v1/projects/{project_id}/staleness-warnings/{warning_id}/acknowledge:
     parameters:
       - $ref: "#/components/parameters/ProjectID"
@@ -289,6 +327,7 @@ paths:
         "400": {$ref: "#/components/responses/Problem"}
         "401": {$ref: "#/components/responses/Problem"}
         "403": {$ref: "#/components/responses/Problem"}
+        "404": {$ref: "#/components/responses/Problem"}
         "503": {$ref: "#/components/responses/Unavailable"}
   /api/v1/projects/{project_id}/timeseries:
     parameters:

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -35,6 +35,7 @@ import (
 	"github.com/digitaldrywood/detent/internal/pause"
 	"github.com/digitaldrywood/detent/internal/procgroup"
 	"github.com/digitaldrywood/detent/internal/project"
+	"github.com/digitaldrywood/detent/internal/staleness"
 	"github.com/digitaldrywood/detent/internal/store"
 	"github.com/digitaldrywood/detent/internal/telemetry"
 	"github.com/digitaldrywood/detent/internal/web/templates"
@@ -66,6 +67,7 @@ type Dependencies struct {
 	HealthNotifications healthnotify.FailureReader
 	TickLiveness        TickLivenessSource
 	WorkerProcesses     WorkerProcessStore
+	StalenessWarnings   *staleness.Acknowledgements
 	ObserveProcesses    func([]procgroup.Identity) ([]procgroup.Observation, error)
 }
 
@@ -184,6 +186,7 @@ type Server struct {
 	healthNotifications healthnotify.FailureReader
 	tickLiveness        TickLivenessSource
 	workerProcesses     WorkerProcessStore
+	stalenessWarnings   *staleness.Acknowledgements
 	observeProcesses    func([]procgroup.Identity) ([]procgroup.Observation, error)
 	now                 func() time.Time
 	operatorTools       *operatortool.Executor
@@ -305,6 +308,7 @@ func NewServer(cfg Config, deps Dependencies) (*Server, error) {
 		healthNotifications: deps.HealthNotifications,
 		tickLiveness:        tickLiveness,
 		workerProcesses:     deps.WorkerProcesses,
+		stalenessWarnings:   deps.StalenessWarnings,
 		observeProcesses:    observeProcesses,
 		now:                 cfg.now(),
 	}
@@ -438,6 +442,7 @@ func (s *Server) registerRoutes() {
 	s.echo.GET("/api/v1/projects/:project_id/work-attempts/:attempt_id", s.apiWorkAttemptReceipt, apiDashboardReadAuth, apiReadScope)
 	s.echo.GET("/api/v1/projects/:project_id/issues/explanation", s.apiIssueExplanation, apiReadAuth, apiReadScope)
 	s.echo.POST("/api/v1/projects/:project_id/issues/explanation", s.apiIssueParkAcknowledgement, apiMutateAuth, apiProjectWriteScope)
+	s.echo.POST("/api/v1/projects/:project_id/staleness-warnings/acknowledge", s.apiStalenessWarningsAcknowledgement, apiDashboardMutateAuth, apiProjectWriteScope)
 	s.echo.POST("/api/v1/projects/:project_id/staleness-warnings/:warning_id/acknowledge", s.apiStalenessWarningAcknowledgement, apiDashboardMutateAuth, apiProjectWriteScope)
 	s.echo.POST("/api/v1/projects/:project_id/work-attempts/:attempt_id/recovery", s.apiWorkAttemptRecovery, apiDashboardMutateAuth, apiProjectWriteScope)
 	s.echo.GET("/api/v1/projects/:project_id/runs/:attempt/stop", s.apiStopRunDialog, apiDashboardReadAuth, apiReadScope)

--- a/internal/web/staleness_warning.go
+++ b/internal/web/staleness_warning.go
@@ -1,12 +1,15 @@
 package web
 
 import (
+	"errors"
 	"log/slog"
 	"net/http"
 	"strings"
 	"time"
 
 	"github.com/labstack/echo/v4"
+
+	"github.com/digitaldrywood/detent/internal/staleness"
 )
 
 func (s *Server) apiStalenessWarningAcknowledgement(c echo.Context) error {
@@ -15,20 +18,78 @@ func (s *Server) apiStalenessWarningAcknowledgement(c echo.Context) error {
 	if projectID == "" || warningID == "" {
 		return c.JSON(http.StatusBadRequest, errorResponse("bad_request", "project_id and warning_id are required"))
 	}
+	return s.acknowledgeStalenessWarnings(c, projectID, []string{warningID}, false)
+}
+
+func (s *Server) apiStalenessWarningsAcknowledgement(c echo.Context) error {
+	projectID := strings.TrimSpace(c.Param("project_id"))
+	if projectID == "" {
+		return c.JSON(http.StatusBadRequest, errorResponse("bad_request", "project_id is required"))
+	}
+	var warningIDs []string
+	if strings.HasPrefix(strings.ToLower(strings.TrimSpace(c.Request().Header.Get(echo.HeaderContentType))), echo.MIMEApplicationJSON) {
+		var request struct {
+			WarningIDs []string `json:"warning_ids"`
+		}
+		if err := c.Bind(&request); err != nil {
+			return c.JSON(http.StatusBadRequest, errorResponse("bad_request", "Request body must contain warning_ids"))
+		}
+		warningIDs = request.WarningIDs
+	} else {
+		form, err := c.FormParams()
+		if err != nil {
+			return c.JSON(http.StatusBadRequest, errorResponse("bad_request", "Request form must contain warning_id values"))
+		}
+		warningIDs = form["warning_id"]
+	}
+	return s.acknowledgeStalenessWarnings(c, projectID, warningIDs, true)
+}
+
+func (s *Server) acknowledgeStalenessWarnings(c echo.Context, projectID string, warningIDs []string, bulk bool) error {
+	if len(warningIDs) == 0 {
+		return c.JSON(http.StatusBadRequest, errorResponse("bad_request", "warning_ids are required"))
+	}
+	for _, warningID := range warningIDs {
+		if strings.TrimSpace(warningID) == "" {
+			return c.JSON(http.StatusBadRequest, errorResponse("bad_request", "warning_ids must not contain empty values"))
+		}
+	}
 	acknowledgedAt := time.Now().UTC()
 	if s.now != nil {
 		acknowledgedAt = s.now().UTC()
 	}
-	if err := s.store.AcknowledgeStalenessWarning(c.Request().Context(), projectID, warningID, acknowledgedAt); err != nil {
+	if s.stalenessWarnings == nil {
+		return c.JSON(http.StatusServiceUnavailable, errorResponse("runtime_unavailable", "Staleness warning acknowledgements are unavailable"))
+	}
+	result, err := s.stalenessWarnings.AcknowledgeActive(c.Request().Context(), projectID, warningIDs, acknowledgedAt)
+	if errors.Is(err, staleness.ErrWarningNotActive) {
+		return c.JSON(http.StatusNotFound, errorResponse("not_found", "Staleness warning is not active for this project"))
+	}
+	if err != nil {
 		s.logger.Error("staleness warning acknowledgement failed", slog.Any("error", err))
 		return c.JSON(http.StatusServiceUnavailable, errorResponse("runtime_unavailable", "Staleness warning acknowledgement store is unavailable"))
 	}
+	s.logger.Info(
+		"staleness warnings acknowledged",
+		slog.String("project_id", projectID),
+		slog.Int("warning_count", len(result.WarningIDs)),
+		slog.String("reason", "operator_dismiss"),
+		slog.Bool("effective_snapshot_updated", result.SnapshotPublished),
+	)
 	if c.Request().Header.Get("HX-Request") == "true" {
 		return c.HTML(http.StatusOK, "")
 	}
+	if bulk {
+		return c.JSON(http.StatusOK, map[string]any{
+			"project_id":         projectID,
+			"warning_ids":        result.WarningIDs,
+			"acknowledged_at":    acknowledgedAt,
+			"snapshot_published": result.SnapshotPublished,
+		})
+	}
 	return c.JSON(http.StatusOK, map[string]any{
 		"project_id":      projectID,
-		"warning_id":      warningID,
+		"warning_id":      result.WarningIDs[0],
 		"acknowledged_at": acknowledgedAt,
 	})
 }

--- a/internal/web/staleness_warning_test.go
+++ b/internal/web/staleness_warning_test.go
@@ -4,15 +4,18 @@ import (
 	"encoding/json"
 	"net/http"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
 	globalconfig "github.com/digitaldrywood/detent/internal/config/global"
+	"github.com/digitaldrywood/detent/internal/staleness"
 	"github.com/digitaldrywood/detent/internal/store"
+	"github.com/digitaldrywood/detent/internal/telemetry"
 	"github.com/digitaldrywood/detent/internal/web"
 )
 
-func TestStalenessWarningAcknowledgementAPI(t *testing.T) {
+func TestStalenessWarningAcknowledgementSurvivesNextSSESnapshot(t *testing.T) {
 	t.Parallel()
 	backend, err := store.Open(t.Context(), store.Config{Path: filepath.Join(t.TempDir(), "detent.db")})
 	if err != nil {
@@ -20,15 +23,44 @@ func TestStalenessWarningAcknowledgementAPI(t *testing.T) {
 	}
 	t.Cleanup(func() { _ = backend.Close() })
 	now := time.Date(2026, 8, 20, 16, 0, 0, 0, time.UTC)
+	raw := telemetry.Snapshot{
+		Seq:         1,
+		GeneratedAt: now,
+		Project:     telemetry.Project{ID: "detent", DisplayName: "Detent"},
+		StalenessWarnings: []telemetry.StalenessWarning{
+			{ID: "warning-1", ProjectID: "detent", Kind: "lane_aging", Identifier: "detent#1", Detail: "first warning"},
+			{ID: "warning-2", ProjectID: "detent", Kind: "repeated_decision", Identifier: "detent#2", Detail: "second warning"},
+		},
+	}
 	deps := testDeps(t)
 	deps.Store = backend
+	acknowledgements, err := staleness.NewAcknowledgements(t.Context(), backend, deps.Hub, []string{"detent"})
+	if err != nil {
+		t.Fatalf("NewAcknowledgements() error = %v", err)
+	}
+	deps.StalenessWarnings = acknowledgements
+	if err := acknowledgements.Publish(raw); err != nil {
+		t.Fatalf("Publish(initial) error = %v", err)
+	}
 	server, err := web.NewServer(web.Config{
-		GlobalConfig: globalconfig.Config{APIToken: "detent_test_token"},
-		Now:          func() time.Time { return now },
+		GlobalConfig:        globalconfig.Config{APIToken: "detent_test_token"},
+		Now:                 func() time.Time { return now },
+		SSETickInterval:     time.Hour,
+		SSEFragmentInterval: time.Millisecond,
 	}, deps)
 	if err != nil {
 		t.Fatalf("NewServer() error = %v", err)
 	}
+	addr := startWebServer(t, server)
+	conn, body, reader := openRawEventStream(t, addr, "/events?view=board")
+	defer conn.Close()
+	defer body.Close()
+
+	initial := readRawSSEEventNamed(t, conn, reader, "snapshot")
+	if !strings.Contains(initial.data, "detent#1") || !strings.Contains(initial.data, `data-board-alert-count="2"`) {
+		t.Fatalf("initial SSE snapshot missing both warnings:\n%s", initial.data)
+	}
+
 	path := "/api/v1/projects/detent/staleness-warnings/warning-1/acknowledge"
 	recorder := performJSON(t, server.Handler(), http.MethodPost, path, "", map[string]string{"Authorization": "Bearer detent_test_token"})
 	if recorder.Code != http.StatusOK {
@@ -44,19 +76,115 @@ func TestStalenessWarningAcknowledgementAPI(t *testing.T) {
 	if response.WarningID != "warning-1" || !response.AcknowledgedAt.Equal(now) {
 		t.Fatalf("response = %#v, want warning-1 at %v", response, now)
 	}
+
+	afterDismiss := readRawSSEEventNamed(t, conn, reader, "snapshot")
+	assertFilteredStalenessSnapshot(t, afterDismiss.data)
+
+	raw.Seq = 2
+	raw.GeneratedAt = now.Add(time.Second)
+	raw.StalenessWarnings[1].AgeSeconds = 1
+	if err := acknowledgements.Publish(raw); err != nil {
+		t.Fatalf("Publish(unchanged orchestrator state) error = %v", err)
+	}
+	afterNextTick := readRawSSEEventNamed(t, conn, reader, "snapshot")
+	assertFilteredStalenessSnapshot(t, afterNextTick.data)
+
+	state := performJSON(t, server.Handler(), http.MethodGet, "/api/v1/state", "", map[string]string{"Authorization": "Bearer detent_test_token"})
+	if state.Code != http.StatusOK {
+		t.Fatalf("state status = %d, want %d; body = %s", state.Code, http.StatusOK, state.Body.String())
+	}
+	if strings.Contains(state.Body.String(), `"id":"warning-1"`) || !strings.Contains(state.Body.String(), `"id":"warning-2"`) {
+		t.Fatalf("state API did not use effective snapshot: %s", state.Body.String())
+	}
+
+	unknown := performJSON(t, server.Handler(), http.MethodPost, "/api/v1/projects/detent/staleness-warnings/unknown/acknowledge", "", map[string]string{"Authorization": "Bearer detent_test_token"})
+	if unknown.Code != http.StatusNotFound {
+		t.Fatalf("unknown warning status = %d, want %d; body = %s", unknown.Code, http.StatusNotFound, unknown.Body.String())
+	}
+}
+
+func TestBulkStalenessWarningAcknowledgementUsesExplicitTransactionalIDs(t *testing.T) {
+	t.Parallel()
+	backend, err := store.Open(t.Context(), store.Config{Path: filepath.Join(t.TempDir(), "detent.db")})
+	if err != nil {
+		t.Fatalf("store.Open() error = %v", err)
+	}
+	t.Cleanup(func() { _ = backend.Close() })
+	now := time.Date(2026, 8, 20, 17, 0, 0, 0, time.UTC)
+	deps := testDeps(t)
+	deps.Store = backend
+	acknowledgements, err := staleness.NewAcknowledgements(t.Context(), backend, deps.Hub, []string{"detent"})
+	if err != nil {
+		t.Fatalf("NewAcknowledgements() error = %v", err)
+	}
+	deps.StalenessWarnings = acknowledgements
+	if err := acknowledgements.Publish(telemetry.Snapshot{
+		GeneratedAt: now,
+		StalenessWarnings: []telemetry.StalenessWarning{
+			{ID: "warning-1", ProjectID: "detent"},
+			{ID: "warning-2", ProjectID: "detent"},
+			{ID: "warning-after-render", ProjectID: "detent"},
+		},
+	}); err != nil {
+		t.Fatalf("Publish() error = %v", err)
+	}
+	server, err := web.NewServer(web.Config{
+		GlobalConfig: globalconfig.Config{APIToken: "detent_test_token"},
+		Now:          func() time.Time { return now },
+	}, deps)
+	if err != nil {
+		t.Fatalf("NewServer() error = %v", err)
+	}
+
+	path := "/api/v1/projects/detent/staleness-warnings/acknowledge"
+	headers := map[string]string{"Authorization": "Bearer detent_test_token"}
+	requestBody := `{"warning_ids":["warning-1","warning-2"]}`
+	for attempt := range 2 {
+		recorder := performJSON(t, server.Handler(), http.MethodPost, path, requestBody, headers)
+		if recorder.Code != http.StatusOK {
+			t.Fatalf("attempt %d status = %d, want %d; body = %s", attempt+1, recorder.Code, http.StatusOK, recorder.Body.String())
+		}
+	}
+	latest, ok := deps.Hub.Latest()
+	if !ok || len(latest.StalenessWarnings) != 1 || latest.StalenessWarnings[0].ID != "warning-after-render" {
+		t.Fatalf("effective warnings = %#v, want only warning-after-render", latest.StalenessWarnings)
+	}
 	states, err := backend.ListStalenessWarningStates(t.Context(), "detent")
 	if err != nil {
 		t.Fatalf("ListStalenessWarningStates() error = %v", err)
 	}
-	if len(states) != 1 || states[0].AcknowledgedAt == nil || !states[0].AcknowledgedAt.Equal(now) {
-		t.Fatalf("persisted states = %#v, want acknowledgement", states)
+	if len(states) != 2 {
+		t.Fatalf("persisted states = %#v, want exactly two explicit acknowledgements", states)
 	}
 
-	htmx := performJSON(t, server.Handler(), http.MethodPost, "/api/v1/projects/detent/staleness-warnings/warning-2/acknowledge", "", map[string]string{
-		"Authorization": "Bearer detent_test_token",
-		"HX-Request":    "true",
-	})
-	if htmx.Code != http.StatusOK || htmx.Body.Len() != 0 {
-		t.Fatalf("HTMX response = %d %q, want empty 200", htmx.Code, htmx.Body.String())
+	invalid := performJSON(t, server.Handler(), http.MethodPost, path, `{"warning_ids":["warning-after-render","unknown"]}`, headers)
+	if invalid.Code != http.StatusNotFound {
+		t.Fatalf("mixed invalid status = %d, want %d; body = %s", invalid.Code, http.StatusNotFound, invalid.Body.String())
+	}
+	states, err = backend.ListStalenessWarningStates(t.Context(), "detent")
+	if err != nil {
+		t.Fatalf("ListStalenessWarningStates() after invalid request error = %v", err)
+	}
+	if len(states) != 2 {
+		t.Fatalf("mixed invalid request persisted partial acknowledgement: %#v", states)
+	}
+
+	empty := performJSON(t, server.Handler(), http.MethodPost, path, `{"warning_ids":["warning-after-render",""]}`, headers)
+	if empty.Code != http.StatusBadRequest {
+		t.Fatalf("empty warning ID status = %d, want %d; body = %s", empty.Code, http.StatusBadRequest, empty.Body.String())
+	}
+}
+
+func assertFilteredStalenessSnapshot(t *testing.T, snapshot string) {
+	t.Helper()
+	for _, want := range []string{`data-board-alert-count="1"`, ">1 warning<", "detent#2"} {
+		if !strings.Contains(snapshot, want) {
+			t.Fatalf("filtered snapshot missing %q:\n%s", want, snapshot)
+		}
+	}
+	for _, forbidden := range []string{"detent#1", "first warning"} {
+		if strings.Contains(snapshot, forbidden) {
+			t.Fatalf("filtered snapshot restored %q:\n%s", forbidden, snapshot)
+		}
 	}
 }

--- a/internal/web/templates/board.templ
+++ b/internal/web/templates/board.templ
@@ -118,6 +118,7 @@ templ boardAlertsBar(alerts []boardAlert) {
 			role="alert"
 			aria-live="polite"
 			data-board-alert-count={ strconv.Itoa(len(alerts)) }
+			data-board-alert-tone={ string(alerts[0].Tone) }
 			if boardAlertKindActive(alerts, boardAlertKindLastKnown) {
 				data-board-snapshot-stale="true"
 			}
@@ -134,10 +135,12 @@ templ boardAlertsBar(alerts []boardAlert) {
 				aria-controls="board-alerts-overlay"
 				aria-label={ boardAlertButtonLabel(alerts) }
 			>
-				@boardAlertGlyph(alerts[0], "size-3.5 shrink-0")
+				<span class="contents" data-board-alert-lead-glyph>
+					@boardAlertGlyph(alerts[0], "size-3.5 shrink-0")
+				</span>
 				<span class="shrink-0 font-medium" data-board-alert-count-label>{ boardCountLabel(len(alerts), "warning", "warnings") }</span>
 				<span class="hidden shrink-0 text-current/60 md:inline" aria-hidden="true">·</span>
-				<span class="hidden min-w-0 flex-1 truncate text-text md:inline">{ alerts[0].TerseSummary }</span>
+				<span class="hidden min-w-0 flex-1 truncate text-text md:inline" data-board-alert-lead-summary>{ alerts[0].TerseSummary }</span>
 				if len(alerts) > 1 {
 					<span class="shrink-0 font-medium" data-board-alert-overflow>{ "+" + strconv.Itoa(len(alerts)-1) }</span>
 				}
@@ -156,7 +159,9 @@ templ boardAlertsOverlayContents(alerts []boardAlert) {
 	{{ dismissals := boardStalenessDismissals(alerts) }}
 	<div class="divide-y divide-line" data-board-alerts-overlay-content>
 		<header class="sticky top-0 z-10 flex h-10 items-center gap-2 border-b border-line bg-page px-3 text-sm">
-			@boardAlertGlyph(alerts[0], "size-4 shrink-0")
+			<span class="contents" data-board-alert-lead-glyph>
+				@boardAlertGlyph(alerts[0], "size-4 shrink-0")
+			</span>
 			<p class="min-w-0 flex-1 truncate font-medium text-text" data-board-alert-count-label>{ boardCountLabel(len(alerts), "warning", "warnings") }</p>
 			for _, dismissal := range dismissals {
 				<form
@@ -190,11 +195,16 @@ templ boardAlertsOverlayContents(alerts []boardAlert) {
 					id={ alert.ID }
 					class="grid min-w-0 gap-2 px-4 py-3"
 					data-board-alert={ string(alert.Kind) }
+					data-board-alert-summary={ alert.TerseSummary }
+					data-board-alert-tone={ string(alert.Tone) }
 					if alert.StalenessWarningID != "" {
 						data-staleness-warning-id={ alert.StalenessWarningID }
 						data-staleness-project-id={ alert.StalenessProjectID }
 					}
 				>
+					<template data-board-alert-glyph-template>
+						@boardAlertGlyph(alert, "size-3.5 shrink-0")
+					</template>
 					<div class="flex min-w-0 items-start gap-3">
 						<div class="min-w-0 flex-1">
 							<p class="font-medium text-text">{ alert.TerseSummary }</p>
@@ -453,6 +463,42 @@ templ boardAlertScript() {
 				});
 			}
 
+			function syncLeadAlertRoot(root, lead, glyphTemplate) {
+				if (!root || typeof root.querySelectorAll !== "function") return;
+				root.querySelectorAll("[data-board-alert-lead-glyph]").forEach(function (glyph) {
+					glyph.replaceChildren(glyphTemplate.content.cloneNode(true));
+				});
+				root.querySelectorAll("[data-board-alert-lead-summary]").forEach(function (summary) {
+					summary.textContent = lead.dataset.boardAlertSummary || "";
+				});
+			}
+
+			function syncLeadAlert(bar, roots, lead, count) {
+				var glyphTemplate = lead.querySelector("template[data-board-alert-glyph-template]");
+				if (!(glyphTemplate instanceof HTMLTemplateElement)) return;
+				roots.forEach(function (root) {
+					syncLeadAlertRoot(root, lead, glyphTemplate);
+				});
+				var tones = {
+					err: ["border-err/40", "bg-err/10", "text-err"],
+					info: ["border-info/40", "bg-info/10", "text-info"],
+					warn: ["border-warn/40", "bg-warn/10", "text-warn"],
+				};
+				Object.values(tones).flat().forEach(function (className) {
+					bar.classList.remove(className);
+				});
+				var tone = lead.dataset.boardAlertTone || "warn";
+				(tones[tone] || tones.warn).forEach(function (className) {
+					bar.classList.add(className);
+				});
+				bar.dataset.boardAlertTone = tone;
+				var toggle = alertsToggle();
+				if (toggle) {
+					var countLabel = count + (count === 1 ? " board warning" : " board warnings");
+					toggle.setAttribute("aria-label", countLabel + ". Highest severity: " + (lead.dataset.boardAlertSummary || "") + ". Expand details.");
+				}
+			}
+
 			function settleStalenessDismissal(form) {
 				var projectID = form.dataset.stalenessProjectId || "";
 				var warningIDs = dismissedWarningIDs(form);
@@ -475,13 +521,17 @@ templ boardAlertScript() {
 				syncAlertCountRoot(bar, count);
 				syncAlertCountRoot(host, count);
 				if (template instanceof HTMLTemplateElement) syncAlertCountRoot(template.content, count);
+				var lead = countRoot.querySelector("[data-board-alert]");
+				if (lead) {
+					var leadRoots = [bar, host];
+					if (template instanceof HTMLTemplateElement) leadRoots.push(template.content);
+					syncLeadAlert(bar, leadRoots, lead, count);
+				}
 				var overflow = bar.querySelector("[data-board-alert-overflow]");
 				if (overflow) {
 					overflow.textContent = "+" + Math.max(0, count - 1);
 					overflow.hidden = count <= 1;
 				}
-				var toggle = alertsToggle();
-				if (toggle) toggle.setAttribute("aria-label", (toggle.getAttribute("aria-label") || "").replace(/^\d+ board warnings?/, count + (count === 1 ? " board warning" : " board warnings")));
 			}
 
 			document.addEventListener("click", function (event) {

--- a/internal/web/templates/board.templ
+++ b/internal/web/templates/board.templ
@@ -1,6 +1,7 @@
 package templates
 
 import (
+	"net/url"
 	"strconv"
 
 	"github.com/digitaldrywood/detent/internal/web/ui/components/icon"
@@ -134,11 +135,11 @@ templ boardAlertsBar(alerts []boardAlert) {
 				aria-label={ boardAlertButtonLabel(alerts) }
 			>
 				@boardAlertGlyph(alerts[0], "size-3.5 shrink-0")
-				<span class="shrink-0 font-medium">{ boardCountLabel(len(alerts), "warning", "warnings") }</span>
+				<span class="shrink-0 font-medium" data-board-alert-count-label>{ boardCountLabel(len(alerts), "warning", "warnings") }</span>
 				<span class="hidden shrink-0 text-current/60 md:inline" aria-hidden="true">·</span>
 				<span class="hidden min-w-0 flex-1 truncate text-text md:inline">{ alerts[0].TerseSummary }</span>
 				if len(alerts) > 1 {
-					<span class="shrink-0 font-medium">{ "+" + strconv.Itoa(len(alerts)-1) }</span>
+					<span class="shrink-0 font-medium" data-board-alert-overflow>{ "+" + strconv.Itoa(len(alerts)-1) }</span>
 				}
 				<span class="shrink-0 transition-transform duration-150 data-[open=true]:rotate-180" data-board-alerts-chevron data-open="false" aria-hidden="true">
 					@icon.ChevronDown(icon.Props{Class: "size-3.5"})
@@ -152,10 +153,27 @@ templ boardAlertsBar(alerts []boardAlert) {
 }
 
 templ boardAlertsOverlayContents(alerts []boardAlert) {
+	{{ dismissals := boardStalenessDismissals(alerts) }}
 	<div class="divide-y divide-line" data-board-alerts-overlay-content>
 		<header class="sticky top-0 z-10 flex h-10 items-center gap-2 border-b border-line bg-page px-3 text-sm">
 			@boardAlertGlyph(alerts[0], "size-4 shrink-0")
-			<p class="min-w-0 flex-1 truncate font-medium text-text">{ boardCountLabel(len(alerts), "warning", "warnings") }</p>
+			<p class="min-w-0 flex-1 truncate font-medium text-text" data-board-alert-count-label>{ boardCountLabel(len(alerts), "warning", "warnings") }</p>
+			for _, dismissal := range dismissals {
+				<form
+					class="shrink-0"
+					hx-post={ "/api/v1/projects/" + url.PathEscape(dismissal.ProjectID) + "/staleness-warnings/acknowledge" }
+					hx-swap="none"
+					hx-confirm={ "Dismiss " + strconv.Itoa(len(dismissal.WarningIDs)) + " staleness warnings?" }
+					data-staleness-dismiss-form
+					data-staleness-dismiss-bulk
+					data-staleness-project-id={ dismissal.ProjectID }
+				>
+					for _, warningID := range dismissal.WarningIDs {
+						<input type="hidden" name="warning_id" value={ warningID }/>
+					}
+					<button type="submit" class="inline-flex shrink-0 items-center rounded-chip px-2 py-1 text-xs font-medium text-sec hover:bg-elev hover:text-text focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent" data-staleness-dismiss-label>{ boardStalenessDismissalLabel(dismissal, len(dismissals)) }</button>
+				</form>
+			}
 			<button
 				type="button"
 				class="inline-flex shrink-0 items-center gap-1 rounded-chip px-2 py-1 text-xs font-medium text-sec hover:bg-elev hover:text-text focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent"
@@ -168,7 +186,15 @@ templ boardAlertsOverlayContents(alerts []boardAlert) {
 		</header>
 		<div class="grid divide-y divide-line">
 			for _, alert := range alerts {
-				<section id={ alert.ID } class="grid min-w-0 gap-2 px-4 py-3" data-board-alert={ string(alert.Kind) }>
+				<section
+					id={ alert.ID }
+					class="grid min-w-0 gap-2 px-4 py-3"
+					data-board-alert={ string(alert.Kind) }
+					if alert.StalenessWarningID != "" {
+						data-staleness-warning-id={ alert.StalenessWarningID }
+						data-staleness-project-id={ alert.StalenessProjectID }
+					}
+				>
 					<div class="flex min-w-0 items-start gap-3">
 						<div class="min-w-0 flex-1">
 							<p class="font-medium text-text">{ alert.TerseSummary }</p>
@@ -216,6 +242,11 @@ templ boardAlertsOverlayContents(alerts []boardAlert) {
 							hx-target={ alert.Action.Target }
 							hx-swap={ boardAlertActionSwap(alert.Action) }
 							hx-confirm={ alert.Action.Confirm }
+							if alert.StalenessWarningID != "" {
+								data-staleness-dismiss-form
+								data-staleness-warning-id={ alert.StalenessWarningID }
+								data-staleness-project-id={ alert.StalenessProjectID }
+							}
 						>
 							<input type="hidden" name="confirm" value="true"/>
 							<button type="submit" class="inline-flex min-h-8 items-center justify-center rounded-card border border-current/40 bg-surface px-3 py-1.5 text-xs font-medium text-text hover:bg-current/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-current/50">{ alert.Action.Label }</button>
@@ -373,6 +404,86 @@ templ boardAlertScript() {
 				return target.id === "snapshot" || Boolean(target.closest("#snapshot"));
 			}
 
+			function dismissedWarningIDs(form) {
+				var ids = [];
+				var directID = form.dataset.stalenessWarningId || "";
+				if (directID) ids.push(directID);
+				form.querySelectorAll("input[name='warning_id']").forEach(function (input) {
+					if (input.value && !ids.includes(input.value)) ids.push(input.value);
+				});
+				return ids;
+			}
+
+			function removeDismissedWarnings(root, projectID, warningIDs) {
+				if (!root || typeof root.querySelectorAll !== "function") return;
+				root.querySelectorAll("[data-board-alert='staleness-warning'][data-staleness-warning-id]").forEach(function (warning) {
+					if (warning.dataset.stalenessProjectId !== projectID) return;
+					if (warningIDs.includes(warning.dataset.stalenessWarningId || "")) warning.remove();
+				});
+			}
+
+			function syncBulkDismissals(root) {
+				if (!root || typeof root.querySelectorAll !== "function") return;
+				root.querySelectorAll("[data-staleness-dismiss-bulk]").forEach(function (form) {
+					var projectID = form.dataset.stalenessProjectId || "";
+					var active = [];
+					root.querySelectorAll("[data-board-alert='staleness-warning'][data-staleness-warning-id]").forEach(function (warning) {
+						if (warning.dataset.stalenessProjectId === projectID) active.push(warning.dataset.stalenessWarningId || "");
+					});
+					form.querySelectorAll("input[name='warning_id']").forEach(function (input) {
+						if (!active.includes(input.value)) input.remove();
+					});
+					if (active.length === 0) {
+						form.remove();
+						return;
+					}
+					var label = form.querySelector("[data-staleness-dismiss-label]");
+					if (label) label.textContent = label.textContent.replace(/\(\d+\)$/, "(" + active.length + ")");
+				});
+			}
+
+			function warningCountLabel(count) {
+				return count + (count === 1 ? " warning" : " warnings");
+			}
+
+			function syncAlertCountRoot(root, count) {
+				if (!root || typeof root.querySelectorAll !== "function") return;
+				root.querySelectorAll("[data-board-alert-count-label]").forEach(function (label) {
+					label.textContent = warningCountLabel(count);
+				});
+			}
+
+			function settleStalenessDismissal(form) {
+				var projectID = form.dataset.stalenessProjectId || "";
+				var warningIDs = dismissedWarningIDs(form);
+				if (!projectID || warningIDs.length === 0) return;
+				var host = overlayHost();
+				var template = overlayTemplate();
+				removeDismissedWarnings(host, projectID, warningIDs);
+				if (template instanceof HTMLTemplateElement) removeDismissedWarnings(template.content, projectID, warningIDs);
+				syncBulkDismissals(host);
+				if (template instanceof HTMLTemplateElement) syncBulkDismissals(template.content);
+				var countRoot = template instanceof HTMLTemplateElement ? template.content : host;
+				var count = countRoot && typeof countRoot.querySelectorAll === "function" ? countRoot.querySelectorAll("[data-board-alert]").length : 0;
+				var bar = alertsBar();
+				if (!bar || count === 0) {
+					if (bar) bar.remove();
+					closeOverlay(false);
+					return;
+				}
+				bar.dataset.boardAlertCount = String(count);
+				syncAlertCountRoot(bar, count);
+				syncAlertCountRoot(host, count);
+				if (template instanceof HTMLTemplateElement) syncAlertCountRoot(template.content, count);
+				var overflow = bar.querySelector("[data-board-alert-overflow]");
+				if (overflow) {
+					overflow.textContent = "+" + Math.max(0, count - 1);
+					overflow.hidden = count <= 1;
+				}
+				var toggle = alertsToggle();
+				if (toggle) toggle.setAttribute("aria-label", (toggle.getAttribute("aria-label") || "").replace(/^\d+ board warnings?/, count + (count === 1 ? " board warning" : " board warnings")));
+			}
+
 			document.addEventListener("click", function (event) {
 				var target = event.target instanceof Element ? event.target : null;
 				if (!target) return;
@@ -394,6 +505,16 @@ templ boardAlertScript() {
 
 			document.addEventListener("htmx:afterSettle", function (event) {
 				if (settledSnapshot(event)) syncOverlayAfterMorph();
+			});
+
+			document.addEventListener("htmx:beforeSwap", function (event) {
+				var requestElement = event.detail && event.detail.requestConfig && event.detail.requestConfig.elt;
+				var form = requestElement instanceof Element ? requestElement.closest("[data-staleness-dismiss-form]") : null;
+				if (!(form instanceof HTMLFormElement)) return;
+				var status = event.detail.xhr ? event.detail.xhr.status : 0;
+				if (status < 200 || status >= 300) return;
+				event.detail.shouldSwap = false;
+				settleStalenessDismissal(form);
 			});
 
 			window.addEventListener("resize", requestOverlayPosition);

--- a/internal/web/templates/board_data.go
+++ b/internal/web/templates/board_data.go
@@ -62,17 +62,19 @@ const (
 )
 
 type boardAlert struct {
-	ID            string
-	Kind          boardAlertKind
-	Severity      int
-	Tone          primitives.Kind
-	TerseSummary  string
-	DetailSummary string
-	DetailRows    []boardAlertDetailRow
-	Overflow      int
-	DeepLink      string
-	DeepLinkLabel string
-	Action        *boardAlertAction
+	ID                 string
+	Kind               boardAlertKind
+	Severity           int
+	Tone               primitives.Kind
+	TerseSummary       string
+	DetailSummary      string
+	DetailRows         []boardAlertDetailRow
+	Overflow           int
+	DeepLink           string
+	DeepLinkLabel      string
+	StalenessProjectID string
+	StalenessWarningID string
+	Action             *boardAlertAction
 }
 
 type boardAlertDetailRow struct {
@@ -89,6 +91,11 @@ type boardAlertAction struct {
 	Target  string
 	Swap    string
 	Confirm string
+}
+
+type boardStalenessDismissal struct {
+	ProjectID  string
+	WarningIDs []string
 }
 
 func boardAlerts(snapshot telemetry.Snapshot) []boardAlert {
@@ -429,18 +436,48 @@ func boardStalenessAlerts(warnings []telemetry.StalenessWarning) []boardAlert {
 			}
 		}
 		alerts = append(alerts, boardAlert{
-			ID:            alertID,
-			Kind:          boardAlertKindStaleness,
-			Severity:      boardAlertSeverityStaleness,
-			Tone:          primitives.KindWarn,
-			TerseSummary:  summary,
-			DetailSummary: detail,
-			DeepLink:      strings.TrimSpace(warning.IssueURL),
-			DeepLinkLabel: "Open",
-			Action:        action,
+			ID:                 alertID,
+			Kind:               boardAlertKindStaleness,
+			Severity:           boardAlertSeverityStaleness,
+			Tone:               primitives.KindWarn,
+			TerseSummary:       summary,
+			DetailSummary:      detail,
+			DeepLink:           strings.TrimSpace(warning.IssueURL),
+			DeepLinkLabel:      "Open",
+			StalenessProjectID: strings.TrimSpace(warning.ProjectID),
+			StalenessWarningID: strings.TrimSpace(warning.ID),
+			Action:             action,
 		})
 	}
 	return alerts
+}
+
+func boardStalenessDismissals(alerts []boardAlert) []boardStalenessDismissal {
+	indices := make(map[string]int)
+	dismissals := make([]boardStalenessDismissal, 0)
+	for _, alert := range alerts {
+		projectID := strings.TrimSpace(alert.StalenessProjectID)
+		warningID := strings.TrimSpace(alert.StalenessWarningID)
+		if alert.Kind != boardAlertKindStaleness || projectID == "" || warningID == "" {
+			continue
+		}
+		index, exists := indices[projectID]
+		if !exists {
+			index = len(dismissals)
+			indices[projectID] = index
+			dismissals = append(dismissals, boardStalenessDismissal{ProjectID: projectID})
+		}
+		dismissals[index].WarningIDs = append(dismissals[index].WarningIDs, warningID)
+	}
+	return dismissals
+}
+
+func boardStalenessDismissalLabel(dismissal boardStalenessDismissal, projectCount int) string {
+	count := len(dismissal.WarningIDs)
+	if projectCount > 1 {
+		return "Dismiss " + dismissal.ProjectID + " staleness warnings (" + strconv.Itoa(count) + ")"
+	}
+	return "Dismiss all staleness warnings (" + strconv.Itoa(count) + ")"
 }
 
 func boardLastKnownAlert(snapshot telemetry.Snapshot) (boardAlert, bool) {

--- a/internal/web/templates/board_data_test.go
+++ b/internal/web/templates/board_data_test.go
@@ -2680,8 +2680,11 @@ func TestBoardAlertCountIncludesOnlyActionableConditions(t *testing.T) {
 	for _, want := range []string{
 		`data-board-alert-count="1"`,
 		`hx-post="/api/v1/projects/detent/staleness-warnings/warning-actionable/acknowledge"`,
+		`hx-post="/api/v1/projects/detent/staleness-warnings/acknowledge"`,
 		`hx-swap="outerHTML"`,
+		`data-staleness-warning-id="warning-actionable"`,
 		">Dismiss<",
+		">Dismiss all staleness warnings (1)<",
 	} {
 		if !strings.Contains(html, want) {
 			t.Fatalf("board alert missing %q:\n%s", want, html)

--- a/internal/web/templates/board_templ.go
+++ b/internal/web/templates/board_templ.go
@@ -509,36 +509,49 @@ func boardAlertsBar(alerts []boardAlert) templ.Component {
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 37, "\"")
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
-			if boardAlertKindActive(alerts, boardAlertKindLastKnown) {
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 38, " data-board-snapshot-stale=\"true\"")
-				if templ_7745c5c3_Err != nil {
-					return templ_7745c5c3_Err
-				}
-			}
-			if boardAlertKindActive(alerts, boardAlertKindTrackerStale) {
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 39, " data-board-data-stale=\"true\"")
-				if templ_7745c5c3_Err != nil {
-					return templ_7745c5c3_Err
-				}
-			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 40, "><button id=\"board-alerts-toggle\" type=\"button\" class=\"flex h-5 min-w-0 max-w-full items-center gap-1.5 px-2 text-left text-xs focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-current\" data-board-alerts-toggle aria-expanded=\"false\" aria-controls=\"board-alerts-overlay\" aria-label=\"")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 37, "\" data-board-alert-tone=\"")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var22 string
-			templ_7745c5c3_Var22, templ_7745c5c3_Err = templ.JoinStringErrs(boardAlertButtonLabel(alerts))
+			templ_7745c5c3_Var22, templ_7745c5c3_Err = templ.JoinStringErrs(string(alerts[0].Tone))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 135, Col: 46}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 121, Col: 49}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var22))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 41, "\">")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 38, "\"")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			if boardAlertKindActive(alerts, boardAlertKindLastKnown) {
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 39, " data-board-snapshot-stale=\"true\"")
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+			}
+			if boardAlertKindActive(alerts, boardAlertKindTrackerStale) {
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 40, " data-board-data-stale=\"true\"")
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 41, "><button id=\"board-alerts-toggle\" type=\"button\" class=\"flex h-5 min-w-0 max-w-full items-center gap-1.5 px-2 text-left text-xs focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-current\" data-board-alerts-toggle aria-expanded=\"false\" aria-controls=\"board-alerts-overlay\" aria-label=\"")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			var templ_7745c5c3_Var23 string
+			templ_7745c5c3_Var23, templ_7745c5c3_Err = templ.JoinStringErrs(boardAlertButtonLabel(alerts))
+			if templ_7745c5c3_Err != nil {
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 136, Col: 46}
+			}
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var23))
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 42, "\"><span class=\"contents\" data-board-alert-lead-glyph>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -546,56 +559,56 @@ func boardAlertsBar(alerts []boardAlert) templ.Component {
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 42, "<span class=\"shrink-0 font-medium\" data-board-alert-count-label>")
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
-			var templ_7745c5c3_Var23 string
-			templ_7745c5c3_Var23, templ_7745c5c3_Err = templ.JoinStringErrs(boardCountLabel(len(alerts), "warning", "warnings"))
-			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 138, Col: 121}
-			}
-			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var23))
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 43, "</span> <span class=\"hidden shrink-0 text-current/60 md:inline\" aria-hidden=\"true\">·</span> <span class=\"hidden min-w-0 flex-1 truncate text-text md:inline\">")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 43, "</span> <span class=\"shrink-0 font-medium\" data-board-alert-count-label>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var24 string
-			templ_7745c5c3_Var24, templ_7745c5c3_Err = templ.JoinStringErrs(alerts[0].TerseSummary)
+			templ_7745c5c3_Var24, templ_7745c5c3_Err = templ.JoinStringErrs(boardCountLabel(len(alerts), "warning", "warnings"))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 140, Col: 93}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 141, Col: 121}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var24))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 44, "</span> ")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 44, "</span> <span class=\"hidden shrink-0 text-current/60 md:inline\" aria-hidden=\"true\">·</span> <span class=\"hidden min-w-0 flex-1 truncate text-text md:inline\" data-board-alert-lead-summary>")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			var templ_7745c5c3_Var25 string
+			templ_7745c5c3_Var25, templ_7745c5c3_Err = templ.JoinStringErrs(alerts[0].TerseSummary)
+			if templ_7745c5c3_Err != nil {
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 143, Col: 123}
+			}
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var25))
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 45, "</span> ")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			if len(alerts) > 1 {
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 45, "<span class=\"shrink-0 font-medium\" data-board-alert-overflow>")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 46, "<span class=\"shrink-0 font-medium\" data-board-alert-overflow>")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				var templ_7745c5c3_Var25 string
-				templ_7745c5c3_Var25, templ_7745c5c3_Err = templ.JoinStringErrs("+" + strconv.Itoa(len(alerts)-1))
+				var templ_7745c5c3_Var26 string
+				templ_7745c5c3_Var26, templ_7745c5c3_Err = templ.JoinStringErrs("+" + strconv.Itoa(len(alerts)-1))
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 142, Col: 101}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 145, Col: 101}
 				}
-				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var25))
+				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var26))
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 46, "</span> ")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 47, "</span> ")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 47, "<span class=\"shrink-0 transition-transform duration-150 data-[open=true]:rotate-180\" data-board-alerts-chevron data-open=\"false\" aria-hidden=\"true\">")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 48, "<span class=\"shrink-0 transition-transform duration-150 data-[open=true]:rotate-180\" data-board-alerts-chevron data-open=\"false\" aria-hidden=\"true\">")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -603,7 +616,7 @@ func boardAlertsBar(alerts []boardAlert) templ.Component {
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 48, "</span></button><template data-board-alerts-overlay-template>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 49, "</span></button><template data-board-alerts-overlay-template>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -611,7 +624,7 @@ func boardAlertsBar(alerts []boardAlert) templ.Component {
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 49, "</template></section>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 50, "</template></section>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -636,13 +649,13 @@ func boardAlertsOverlayContents(alerts []boardAlert) templ.Component {
 			}()
 		}
 		ctx = templ.InitializeContext(ctx)
-		templ_7745c5c3_Var26 := templ.GetChildren(ctx)
-		if templ_7745c5c3_Var26 == nil {
-			templ_7745c5c3_Var26 = templ.NopComponent
+		templ_7745c5c3_Var27 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var27 == nil {
+			templ_7745c5c3_Var27 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
 		dismissals := boardStalenessDismissals(alerts)
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 50, "<div class=\"divide-y divide-line\" data-board-alerts-overlay-content><header class=\"sticky top-0 z-10 flex h-10 items-center gap-2 border-b border-line bg-page px-3 text-sm\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 51, "<div class=\"divide-y divide-line\" data-board-alerts-overlay-content><header class=\"sticky top-0 z-10 flex h-10 items-center gap-2 border-b border-line bg-page px-3 text-sm\"><span class=\"contents\" data-board-alert-lead-glyph>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -650,105 +663,105 @@ func boardAlertsOverlayContents(alerts []boardAlert) templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 51, "<p class=\"min-w-0 flex-1 truncate font-medium text-text\" data-board-alert-count-label>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 52, "</span><p class=\"min-w-0 flex-1 truncate font-medium text-text\" data-board-alert-count-label>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		var templ_7745c5c3_Var27 string
-		templ_7745c5c3_Var27, templ_7745c5c3_Err = templ.JoinStringErrs(boardCountLabel(len(alerts), "warning", "warnings"))
+		var templ_7745c5c3_Var28 string
+		templ_7745c5c3_Var28, templ_7745c5c3_Err = templ.JoinStringErrs(boardCountLabel(len(alerts), "warning", "warnings"))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 160, Col: 142}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 165, Col: 142}
 		}
-		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var27))
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var28))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 52, "</p>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 53, "</p>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		for _, dismissal := range dismissals {
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 53, "<form class=\"shrink-0\" hx-post=\"")
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
-			var templ_7745c5c3_Var28 string
-			templ_7745c5c3_Var28, templ_7745c5c3_Err = templ.JoinStringErrs("/api/v1/projects/" + url.PathEscape(dismissal.ProjectID) + "/staleness-warnings/acknowledge")
-			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 164, Col: 108}
-			}
-			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var28))
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 54, "\" hx-swap=\"none\" hx-confirm=\"")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 54, "<form class=\"shrink-0\" hx-post=\"")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var29 string
-			templ_7745c5c3_Var29, templ_7745c5c3_Err = templ.JoinStringErrs("Dismiss " + strconv.Itoa(len(dismissal.WarningIDs)) + " staleness warnings?")
+			templ_7745c5c3_Var29, templ_7745c5c3_Err = templ.JoinStringErrs("/api/v1/projects/" + url.PathEscape(dismissal.ProjectID) + "/staleness-warnings/acknowledge")
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 166, Col: 95}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 169, Col: 108}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var29))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 55, "\" data-staleness-dismiss-form data-staleness-dismiss-bulk data-staleness-project-id=\"")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 55, "\" hx-swap=\"none\" hx-confirm=\"")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var30 string
-			templ_7745c5c3_Var30, templ_7745c5c3_Err = templ.JoinStringErrs(dismissal.ProjectID)
+			templ_7745c5c3_Var30, templ_7745c5c3_Err = templ.JoinStringErrs("Dismiss " + strconv.Itoa(len(dismissal.WarningIDs)) + " staleness warnings?")
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 169, Col: 52}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 171, Col: 95}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var30))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 56, "\">")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 56, "\" data-staleness-dismiss-form data-staleness-dismiss-bulk data-staleness-project-id=\"")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			var templ_7745c5c3_Var31 string
+			templ_7745c5c3_Var31, templ_7745c5c3_Err = templ.JoinStringErrs(dismissal.ProjectID)
+			if templ_7745c5c3_Err != nil {
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 174, Col: 52}
+			}
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var31))
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 57, "\">")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			for _, warningID := range dismissal.WarningIDs {
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 57, "<input type=\"hidden\" name=\"warning_id\" value=\"")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 58, "<input type=\"hidden\" name=\"warning_id\" value=\"")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				var templ_7745c5c3_Var31 string
-				templ_7745c5c3_Var31, templ_7745c5c3_Err = templ.JoinStringErrs(warningID)
+				var templ_7745c5c3_Var32 string
+				templ_7745c5c3_Var32, templ_7745c5c3_Err = templ.JoinStringErrs(warningID)
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 172, Col: 62}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 177, Col: 62}
 				}
-				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var31))
+				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var32))
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 58, "\"> ")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 59, "\"> ")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 59, "<button type=\"submit\" class=\"inline-flex shrink-0 items-center rounded-chip px-2 py-1 text-xs font-medium text-sec hover:bg-elev hover:text-text focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent\" data-staleness-dismiss-label>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 60, "<button type=\"submit\" class=\"inline-flex shrink-0 items-center rounded-chip px-2 py-1 text-xs font-medium text-sec hover:bg-elev hover:text-text focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent\" data-staleness-dismiss-label>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			var templ_7745c5c3_Var32 string
-			templ_7745c5c3_Var32, templ_7745c5c3_Err = templ.JoinStringErrs(boardStalenessDismissalLabel(dismissal, len(dismissals)))
+			var templ_7745c5c3_Var33 string
+			templ_7745c5c3_Var33, templ_7745c5c3_Err = templ.JoinStringErrs(boardStalenessDismissalLabel(dismissal, len(dismissals)))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 174, Col: 312}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 179, Col: 312}
 			}
-			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var32))
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var33))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 60, "</button></form>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 61, "</button></form>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 61, "<button type=\"button\" class=\"inline-flex shrink-0 items-center gap-1 rounded-chip px-2 py-1 text-xs font-medium text-sec hover:bg-elev hover:text-text focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent\" data-board-alerts-close aria-label=\"Collapse board alerts\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 62, "<button type=\"button\" class=\"inline-flex shrink-0 items-center gap-1 rounded-chip px-2 py-1 text-xs font-medium text-sec hover:bg-elev hover:text-text focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent\" data-board-alerts-close aria-label=\"Collapse board alerts\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -756,404 +769,438 @@ func boardAlertsOverlayContents(alerts []boardAlert) templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 62, "Close</button></header><div class=\"grid divide-y divide-line\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 63, "Close</button></header><div class=\"grid divide-y divide-line\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		for _, alert := range alerts {
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 63, "<section id=\"")
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
-			var templ_7745c5c3_Var33 string
-			templ_7745c5c3_Var33, templ_7745c5c3_Err = templ.JoinStringErrs(alert.ID)
-			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 190, Col: 18}
-			}
-			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var33))
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 64, "\" class=\"grid min-w-0 gap-2 px-4 py-3\" data-board-alert=\"")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 64, "<section id=\"")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var34 string
-			templ_7745c5c3_Var34, templ_7745c5c3_Err = templ.JoinStringErrs(string(alert.Kind))
+			templ_7745c5c3_Var34, templ_7745c5c3_Err = templ.JoinStringErrs(alert.ID)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 192, Col: 42}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 195, Col: 18}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var34))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 65, "\"")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 65, "\" class=\"grid min-w-0 gap-2 px-4 py-3\" data-board-alert=\"")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			if alert.StalenessWarningID != "" {
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 66, " data-staleness-warning-id=\"")
-				if templ_7745c5c3_Err != nil {
-					return templ_7745c5c3_Err
-				}
-				var templ_7745c5c3_Var35 string
-				templ_7745c5c3_Var35, templ_7745c5c3_Err = templ.JoinStringErrs(alert.StalenessWarningID)
-				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 194, Col: 58}
-				}
-				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var35))
-				if templ_7745c5c3_Err != nil {
-					return templ_7745c5c3_Err
-				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 67, "\" data-staleness-project-id=\"")
-				if templ_7745c5c3_Err != nil {
-					return templ_7745c5c3_Err
-				}
-				var templ_7745c5c3_Var36 string
-				templ_7745c5c3_Var36, templ_7745c5c3_Err = templ.JoinStringErrs(alert.StalenessProjectID)
-				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 195, Col: 58}
-				}
-				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var36))
-				if templ_7745c5c3_Err != nil {
-					return templ_7745c5c3_Err
-				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 68, "\"")
-				if templ_7745c5c3_Err != nil {
-					return templ_7745c5c3_Err
-				}
+			var templ_7745c5c3_Var35 string
+			templ_7745c5c3_Var35, templ_7745c5c3_Err = templ.JoinStringErrs(string(alert.Kind))
+			if templ_7745c5c3_Err != nil {
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 197, Col: 42}
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 69, "><div class=\"flex min-w-0 items-start gap-3\"><div class=\"min-w-0 flex-1\"><p class=\"font-medium text-text\">")
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var35))
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 66, "\" data-board-alert-summary=\"")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			var templ_7745c5c3_Var36 string
+			templ_7745c5c3_Var36, templ_7745c5c3_Err = templ.JoinStringErrs(alert.TerseSummary)
+			if templ_7745c5c3_Err != nil {
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 198, Col: 50}
+			}
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var36))
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 67, "\" data-board-alert-tone=\"")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var37 string
-			templ_7745c5c3_Var37, templ_7745c5c3_Err = templ.JoinStringErrs(alert.TerseSummary)
+			templ_7745c5c3_Var37, templ_7745c5c3_Err = templ.JoinStringErrs(string(alert.Tone))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 200, Col: 60}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 199, Col: 47}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var37))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 70, "</p>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 68, "\"")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			if alert.DetailSummary != "" {
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 71, "<p class=\"mt-0.5 text-xs text-sec\">")
+			if alert.StalenessWarningID != "" {
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 69, " data-staleness-warning-id=\"")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
 				var templ_7745c5c3_Var38 string
-				templ_7745c5c3_Var38, templ_7745c5c3_Err = templ.JoinStringErrs(alert.DetailSummary)
+				templ_7745c5c3_Var38, templ_7745c5c3_Err = templ.JoinStringErrs(alert.StalenessWarningID)
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 202, Col: 64}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 201, Col: 58}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var38))
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 72, "</p>")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 70, "\" data-staleness-project-id=\"")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 73, "</div>")
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
-			if alert.DeepLink != "" {
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 74, "<a class=\"shrink-0 text-xs font-medium text-accent hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent\" href=\"")
+				var templ_7745c5c3_Var39 string
+				templ_7745c5c3_Var39, templ_7745c5c3_Err = templ.JoinStringErrs(alert.StalenessProjectID)
 				if templ_7745c5c3_Err != nil {
-					return templ_7745c5c3_Err
-				}
-				var templ_7745c5c3_Var39 templ.SafeURL
-				templ_7745c5c3_Var39, templ_7745c5c3_Err = templ.JoinURLErrs(templ.SafeURL(alert.DeepLink))
-				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 206, Col: 185}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 202, Col: 58}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var39))
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 75, "\">")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 71, "\"")
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 72, "><template data-board-alert-glyph-template>")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = boardAlertGlyph(alert, "size-3.5 shrink-0").Render(ctx, templ_7745c5c3_Buffer)
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 73, "</template><div class=\"flex min-w-0 items-start gap-3\"><div class=\"min-w-0 flex-1\"><p class=\"font-medium text-text\">")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			var templ_7745c5c3_Var40 string
+			templ_7745c5c3_Var40, templ_7745c5c3_Err = templ.JoinStringErrs(alert.TerseSummary)
+			if templ_7745c5c3_Err != nil {
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 210, Col: 60}
+			}
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var40))
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 74, "</p>")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			if alert.DetailSummary != "" {
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 75, "<p class=\"mt-0.5 text-xs text-sec\">")
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+				var templ_7745c5c3_Var41 string
+				templ_7745c5c3_Var41, templ_7745c5c3_Err = templ.JoinStringErrs(alert.DetailSummary)
+				if templ_7745c5c3_Err != nil {
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 212, Col: 64}
+				}
+				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var41))
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 76, "</p>")
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 77, "</div>")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			if alert.DeepLink != "" {
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 78, "<a class=\"shrink-0 text-xs font-medium text-accent hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent\" href=\"")
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+				var templ_7745c5c3_Var42 templ.SafeURL
+				templ_7745c5c3_Var42, templ_7745c5c3_Err = templ.JoinURLErrs(templ.SafeURL(alert.DeepLink))
+				if templ_7745c5c3_Err != nil {
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 216, Col: 185}
+				}
+				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var42))
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 79, "\">")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
 				if alert.DeepLinkLabel != "" {
-					var templ_7745c5c3_Var40 string
-					templ_7745c5c3_Var40, templ_7745c5c3_Err = templ.JoinStringErrs(alert.DeepLinkLabel)
+					var templ_7745c5c3_Var43 string
+					templ_7745c5c3_Var43, templ_7745c5c3_Err = templ.JoinStringErrs(alert.DeepLinkLabel)
 					if templ_7745c5c3_Err != nil {
-						return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 208, Col: 30}
+						return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 218, Col: 30}
 					}
-					_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var40))
+					_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var43))
 					if templ_7745c5c3_Err != nil {
 						return templ_7745c5c3_Err
 					}
 				} else if alert.Overflow > 0 {
-					var templ_7745c5c3_Var41 string
-					templ_7745c5c3_Var41, templ_7745c5c3_Err = templ.JoinStringErrs("+" + strconv.Itoa(alert.Overflow) + " more · Health")
+					var templ_7745c5c3_Var44 string
+					templ_7745c5c3_Var44, templ_7745c5c3_Err = templ.JoinStringErrs("+" + strconv.Itoa(alert.Overflow) + " more · Health")
 					if templ_7745c5c3_Err != nil {
-						return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 210, Col: 65}
+						return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 220, Col: 65}
 					}
-					_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var41))
+					_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var44))
 					if templ_7745c5c3_Err != nil {
 						return templ_7745c5c3_Err
 					}
 				} else {
-					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 76, "Health")
+					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 80, "Health")
 					if templ_7745c5c3_Err != nil {
 						return templ_7745c5c3_Err
 					}
 				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 77, "</a>")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 81, "</a>")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 78, "</div>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 82, "</div>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			if len(alert.DetailRows) > 0 {
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 79, "<div class=\"grid gap-2 pl-3\">")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 83, "<div class=\"grid gap-2 pl-3\">")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
 				for _, row := range alert.DetailRows {
-					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 80, "<div id=\"")
+					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 84, "<div id=\"")
 					if templ_7745c5c3_Err != nil {
 						return templ_7745c5c3_Err
 					}
-					var templ_7745c5c3_Var42 string
-					templ_7745c5c3_Var42, templ_7745c5c3_Err = templ.JoinStringErrs(row.ID)
+					var templ_7745c5c3_Var45 string
+					templ_7745c5c3_Var45, templ_7745c5c3_Err = templ.JoinStringErrs(row.ID)
 					if templ_7745c5c3_Err != nil {
-						return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 220, Col: 24}
+						return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 230, Col: 24}
 					}
-					_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var42))
+					_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var45))
 					if templ_7745c5c3_Err != nil {
 						return templ_7745c5c3_Err
 					}
-					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 81, "\" class=\"min-w-0 border-l border-line pl-3 text-xs\"><p class=\"flex min-w-0 flex-wrap items-baseline gap-x-2 text-text\">")
+					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 85, "\" class=\"min-w-0 border-l border-line pl-3 text-xs\"><p class=\"flex min-w-0 flex-wrap items-baseline gap-x-2 text-text\">")
 					if templ_7745c5c3_Err != nil {
 						return templ_7745c5c3_Err
 					}
 					if row.Link != "" {
-						templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 82, "<a class=\"font-mono font-medium text-accent hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent\" href=\"")
+						templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 86, "<a class=\"font-mono font-medium text-accent hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent\" href=\"")
 						if templ_7745c5c3_Err != nil {
 							return templ_7745c5c3_Err
 						}
-						var templ_7745c5c3_Var43 templ.SafeURL
-						templ_7745c5c3_Var43, templ_7745c5c3_Err = templ.JoinURLErrs(templ.SafeURL(row.Link))
+						var templ_7745c5c3_Var46 templ.SafeURL
+						templ_7745c5c3_Var46, templ_7745c5c3_Err = templ.JoinURLErrs(templ.SafeURL(row.Link))
 						if templ_7745c5c3_Err != nil {
-							return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 223, Col: 176}
-						}
-						_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var43))
-						if templ_7745c5c3_Err != nil {
-							return templ_7745c5c3_Err
-						}
-						templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 83, "\">")
-						if templ_7745c5c3_Err != nil {
-							return templ_7745c5c3_Err
-						}
-						var templ_7745c5c3_Var44 string
-						templ_7745c5c3_Var44, templ_7745c5c3_Err = templ.JoinStringErrs(row.Label)
-						if templ_7745c5c3_Err != nil {
-							return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 223, Col: 190}
-						}
-						_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var44))
-						if templ_7745c5c3_Err != nil {
-							return templ_7745c5c3_Err
-						}
-						templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 84, "</a> ")
-						if templ_7745c5c3_Err != nil {
-							return templ_7745c5c3_Err
-						}
-					} else {
-						templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 85, "<span class=\"font-mono font-medium\">")
-						if templ_7745c5c3_Err != nil {
-							return templ_7745c5c3_Err
-						}
-						var templ_7745c5c3_Var45 string
-						templ_7745c5c3_Var45, templ_7745c5c3_Err = templ.JoinStringErrs(row.Label)
-						if templ_7745c5c3_Err != nil {
-							return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 225, Col: 58}
-						}
-						_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var45))
-						if templ_7745c5c3_Err != nil {
-							return templ_7745c5c3_Err
-						}
-						templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 86, "</span> ")
-						if templ_7745c5c3_Err != nil {
-							return templ_7745c5c3_Err
-						}
-					}
-					if row.Summary != "" {
-						templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 87, "<span class=\"text-sec\">")
-						if templ_7745c5c3_Err != nil {
-							return templ_7745c5c3_Err
-						}
-						var templ_7745c5c3_Var46 string
-						templ_7745c5c3_Var46, templ_7745c5c3_Err = templ.JoinStringErrs(row.Summary)
-						if templ_7745c5c3_Err != nil {
-							return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 228, Col: 47}
+							return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 233, Col: 176}
 						}
 						_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var46))
 						if templ_7745c5c3_Err != nil {
 							return templ_7745c5c3_Err
 						}
-						templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 88, "</span>")
-						if templ_7745c5c3_Err != nil {
-							return templ_7745c5c3_Err
-						}
-					}
-					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 89, "</p>")
-					if templ_7745c5c3_Err != nil {
-						return templ_7745c5c3_Err
-					}
-					if row.Detail != "" {
-						templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 90, "<p class=\"mt-0.5 break-words text-sec\">")
+						templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 87, "\">")
 						if templ_7745c5c3_Err != nil {
 							return templ_7745c5c3_Err
 						}
 						var templ_7745c5c3_Var47 string
-						templ_7745c5c3_Var47, templ_7745c5c3_Err = templ.JoinStringErrs(row.Detail)
+						templ_7745c5c3_Var47, templ_7745c5c3_Err = templ.JoinStringErrs(row.Label)
 						if templ_7745c5c3_Err != nil {
-							return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 232, Col: 61}
+							return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 233, Col: 190}
 						}
 						_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var47))
 						if templ_7745c5c3_Err != nil {
 							return templ_7745c5c3_Err
 						}
-						templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 91, "</p>")
+						templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 88, "</a> ")
+						if templ_7745c5c3_Err != nil {
+							return templ_7745c5c3_Err
+						}
+					} else {
+						templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 89, "<span class=\"font-mono font-medium\">")
+						if templ_7745c5c3_Err != nil {
+							return templ_7745c5c3_Err
+						}
+						var templ_7745c5c3_Var48 string
+						templ_7745c5c3_Var48, templ_7745c5c3_Err = templ.JoinStringErrs(row.Label)
+						if templ_7745c5c3_Err != nil {
+							return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 235, Col: 58}
+						}
+						_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var48))
+						if templ_7745c5c3_Err != nil {
+							return templ_7745c5c3_Err
+						}
+						templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 90, "</span> ")
 						if templ_7745c5c3_Err != nil {
 							return templ_7745c5c3_Err
 						}
 					}
-					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 92, "</div>")
+					if row.Summary != "" {
+						templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 91, "<span class=\"text-sec\">")
+						if templ_7745c5c3_Err != nil {
+							return templ_7745c5c3_Err
+						}
+						var templ_7745c5c3_Var49 string
+						templ_7745c5c3_Var49, templ_7745c5c3_Err = templ.JoinStringErrs(row.Summary)
+						if templ_7745c5c3_Err != nil {
+							return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 238, Col: 47}
+						}
+						_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var49))
+						if templ_7745c5c3_Err != nil {
+							return templ_7745c5c3_Err
+						}
+						templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 92, "</span>")
+						if templ_7745c5c3_Err != nil {
+							return templ_7745c5c3_Err
+						}
+					}
+					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 93, "</p>")
+					if templ_7745c5c3_Err != nil {
+						return templ_7745c5c3_Err
+					}
+					if row.Detail != "" {
+						templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 94, "<p class=\"mt-0.5 break-words text-sec\">")
+						if templ_7745c5c3_Err != nil {
+							return templ_7745c5c3_Err
+						}
+						var templ_7745c5c3_Var50 string
+						templ_7745c5c3_Var50, templ_7745c5c3_Err = templ.JoinStringErrs(row.Detail)
+						if templ_7745c5c3_Err != nil {
+							return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 242, Col: 61}
+						}
+						_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var50))
+						if templ_7745c5c3_Err != nil {
+							return templ_7745c5c3_Err
+						}
+						templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 95, "</p>")
+						if templ_7745c5c3_Err != nil {
+							return templ_7745c5c3_Err
+						}
+					}
+					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 96, "</div>")
 					if templ_7745c5c3_Err != nil {
 						return templ_7745c5c3_Err
 					}
 				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 93, "</div>")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 97, "</div>")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
 			}
 			if alert.Action != nil {
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 94, "<form class=\"pl-3\" hx-post=\"")
-				if templ_7745c5c3_Err != nil {
-					return templ_7745c5c3_Err
-				}
-				var templ_7745c5c3_Var48 string
-				templ_7745c5c3_Var48, templ_7745c5c3_Err = templ.JoinStringErrs(alert.Action.Path)
-				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 241, Col: 34}
-				}
-				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var48))
-				if templ_7745c5c3_Err != nil {
-					return templ_7745c5c3_Err
-				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 95, "\" hx-target=\"")
-				if templ_7745c5c3_Err != nil {
-					return templ_7745c5c3_Err
-				}
-				var templ_7745c5c3_Var49 string
-				templ_7745c5c3_Var49, templ_7745c5c3_Err = templ.JoinStringErrs(alert.Action.Target)
-				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 242, Col: 38}
-				}
-				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var49))
-				if templ_7745c5c3_Err != nil {
-					return templ_7745c5c3_Err
-				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 96, "\" hx-swap=\"")
-				if templ_7745c5c3_Err != nil {
-					return templ_7745c5c3_Err
-				}
-				var templ_7745c5c3_Var50 string
-				templ_7745c5c3_Var50, templ_7745c5c3_Err = templ.JoinStringErrs(boardAlertActionSwap(alert.Action))
-				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 243, Col: 51}
-				}
-				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var50))
-				if templ_7745c5c3_Err != nil {
-					return templ_7745c5c3_Err
-				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 97, "\" hx-confirm=\"")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 98, "<form class=\"pl-3\" hx-post=\"")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
 				var templ_7745c5c3_Var51 string
-				templ_7745c5c3_Var51, templ_7745c5c3_Err = templ.JoinStringErrs(alert.Action.Confirm)
+				templ_7745c5c3_Var51, templ_7745c5c3_Err = templ.JoinStringErrs(alert.Action.Path)
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 244, Col: 40}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 251, Col: 34}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var51))
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 98, "\"")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 99, "\" hx-target=\"")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				if alert.StalenessWarningID != "" {
-					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 99, " data-staleness-dismiss-form data-staleness-warning-id=\"")
-					if templ_7745c5c3_Err != nil {
-						return templ_7745c5c3_Err
-					}
-					var templ_7745c5c3_Var52 string
-					templ_7745c5c3_Var52, templ_7745c5c3_Err = templ.JoinStringErrs(alert.StalenessWarningID)
-					if templ_7745c5c3_Err != nil {
-						return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 247, Col: 60}
-					}
-					_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var52))
-					if templ_7745c5c3_Err != nil {
-						return templ_7745c5c3_Err
-					}
-					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 100, "\" data-staleness-project-id=\"")
-					if templ_7745c5c3_Err != nil {
-						return templ_7745c5c3_Err
-					}
-					var templ_7745c5c3_Var53 string
-					templ_7745c5c3_Var53, templ_7745c5c3_Err = templ.JoinStringErrs(alert.StalenessProjectID)
-					if templ_7745c5c3_Err != nil {
-						return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 248, Col: 60}
-					}
-					_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var53))
-					if templ_7745c5c3_Err != nil {
-						return templ_7745c5c3_Err
-					}
-					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 101, "\"")
-					if templ_7745c5c3_Err != nil {
-						return templ_7745c5c3_Err
-					}
+				var templ_7745c5c3_Var52 string
+				templ_7745c5c3_Var52, templ_7745c5c3_Err = templ.JoinStringErrs(alert.Action.Target)
+				if templ_7745c5c3_Err != nil {
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 252, Col: 38}
 				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 102, "><input type=\"hidden\" name=\"confirm\" value=\"true\"> <button type=\"submit\" class=\"inline-flex min-h-8 items-center justify-center rounded-card border border-current/40 bg-surface px-3 py-1.5 text-xs font-medium text-text hover:bg-current/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-current/50\">")
+				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var52))
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 100, "\" hx-swap=\"")
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+				var templ_7745c5c3_Var53 string
+				templ_7745c5c3_Var53, templ_7745c5c3_Err = templ.JoinStringErrs(boardAlertActionSwap(alert.Action))
+				if templ_7745c5c3_Err != nil {
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 253, Col: 51}
+				}
+				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var53))
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 101, "\" hx-confirm=\"")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
 				var templ_7745c5c3_Var54 string
-				templ_7745c5c3_Var54, templ_7745c5c3_Err = templ.JoinStringErrs(alert.Action.Label)
+				templ_7745c5c3_Var54, templ_7745c5c3_Err = templ.JoinStringErrs(alert.Action.Confirm)
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 252, Col: 294}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 254, Col: 40}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var54))
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 103, "</button></form>")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 102, "\"")
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+				if alert.StalenessWarningID != "" {
+					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 103, " data-staleness-dismiss-form data-staleness-warning-id=\"")
+					if templ_7745c5c3_Err != nil {
+						return templ_7745c5c3_Err
+					}
+					var templ_7745c5c3_Var55 string
+					templ_7745c5c3_Var55, templ_7745c5c3_Err = templ.JoinStringErrs(alert.StalenessWarningID)
+					if templ_7745c5c3_Err != nil {
+						return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 257, Col: 60}
+					}
+					_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var55))
+					if templ_7745c5c3_Err != nil {
+						return templ_7745c5c3_Err
+					}
+					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 104, "\" data-staleness-project-id=\"")
+					if templ_7745c5c3_Err != nil {
+						return templ_7745c5c3_Err
+					}
+					var templ_7745c5c3_Var56 string
+					templ_7745c5c3_Var56, templ_7745c5c3_Err = templ.JoinStringErrs(alert.StalenessProjectID)
+					if templ_7745c5c3_Err != nil {
+						return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 258, Col: 60}
+					}
+					_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var56))
+					if templ_7745c5c3_Err != nil {
+						return templ_7745c5c3_Err
+					}
+					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 105, "\"")
+					if templ_7745c5c3_Err != nil {
+						return templ_7745c5c3_Err
+					}
+				}
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 106, "><input type=\"hidden\" name=\"confirm\" value=\"true\"> <button type=\"submit\" class=\"inline-flex min-h-8 items-center justify-center rounded-card border border-current/40 bg-surface px-3 py-1.5 text-xs font-medium text-text hover:bg-current/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-current/50\">")
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+				var templ_7745c5c3_Var57 string
+				templ_7745c5c3_Var57, templ_7745c5c3_Err = templ.JoinStringErrs(alert.Action.Label)
+				if templ_7745c5c3_Err != nil {
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 262, Col: 294}
+				}
+				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var57))
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 107, "</button></form>")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 104, "</section>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 108, "</section>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 105, "</div></div>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 109, "</div></div>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -1184,9 +1231,9 @@ func boardAlertGlyph(alert boardAlert, class string) templ.Component {
 			}()
 		}
 		ctx = templ.InitializeContext(ctx)
-		templ_7745c5c3_Var55 := templ.GetChildren(ctx)
-		if templ_7745c5c3_Var55 == nil {
-			templ_7745c5c3_Var55 = templ.NopComponent
+		templ_7745c5c3_Var58 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var58 == nil {
+			templ_7745c5c3_Var58 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
 		if alert.Tone == primitives.KindErr {
@@ -1225,12 +1272,12 @@ func boardAlertsOverlayHost() templ.Component {
 			}()
 		}
 		ctx = templ.InitializeContext(ctx)
-		templ_7745c5c3_Var56 := templ.GetChildren(ctx)
-		if templ_7745c5c3_Var56 == nil {
-			templ_7745c5c3_Var56 = templ.NopComponent
+		templ_7745c5c3_Var59 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var59 == nil {
+			templ_7745c5c3_Var59 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 106, "<div id=\"board-alerts-overlay\" class=\"fixed z-40 hidden max-h-[40vh] overflow-y-auto rounded-card border border-line bg-page shadow-lg\" data-board-alerts-overlay-host aria-hidden=\"true\" hidden></div>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 110, "<div id=\"board-alerts-overlay\" class=\"fixed z-40 hidden max-h-[40vh] overflow-y-auto rounded-card border border-line bg-page shadow-lg\" data-board-alerts-overlay-host aria-hidden=\"true\" hidden></div>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -1254,12 +1301,12 @@ func boardAlertScript() templ.Component {
 			}()
 		}
 		ctx = templ.InitializeContext(ctx)
-		templ_7745c5c3_Var57 := templ.GetChildren(ctx)
-		if templ_7745c5c3_Var57 == nil {
-			templ_7745c5c3_Var57 = templ.NopComponent
+		templ_7745c5c3_Var60 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var60 == nil {
+			templ_7745c5c3_Var60 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 107, "<script>\n\t\t(function () {\n\t\t\tvar open = false;\n\t\t\tvar positionFrame = 0;\n\n\t\t\tfunction alertsBar() {\n\t\t\t\treturn document.getElementById(\"board-alerts\");\n\t\t\t}\n\n\t\t\tfunction alertsToggle() {\n\t\t\t\treturn document.querySelector(\"[data-board-alerts-toggle]\");\n\t\t\t}\n\n\t\t\tfunction overlayHost() {\n\t\t\t\treturn document.querySelector(\"[data-board-alerts-overlay-host]\");\n\t\t\t}\n\n\t\t\tfunction overlayTemplate() {\n\t\t\t\tvar bar = alertsBar();\n\t\t\t\treturn bar ? bar.querySelector(\"template[data-board-alerts-overlay-template]\") : null;\n\t\t\t}\n\n\t\t\tfunction setToggleState(expanded) {\n\t\t\t\tvar toggle = alertsToggle();\n\t\t\t\tif (!toggle) return;\n\t\t\t\ttoggle.setAttribute(\"aria-expanded\", expanded ? \"true\" : \"false\");\n\t\t\t\tvar chevron = toggle.querySelector(\"[data-board-alerts-chevron]\");\n\t\t\t\tif (chevron) chevron.setAttribute(\"data-open\", expanded ? \"true\" : \"false\");\n\t\t\t}\n\n\t\t\tfunction renderOverlay() {\n\t\t\t\tvar host = overlayHost();\n\t\t\t\tvar template = overlayTemplate();\n\t\t\t\tif (!host || !(template instanceof HTMLTemplateElement)) return false;\n\t\t\t\thost.replaceChildren(template.content.cloneNode(true));\n\t\t\t\tif (window.htmx) window.htmx.process(host);\n\t\t\t\treturn true;\n\t\t\t}\n\n\t\t\tfunction positionOverlay() {\n\t\t\t\tpositionFrame = 0;\n\t\t\t\tif (!open) return;\n\t\t\t\tvar bar = alertsBar();\n\t\t\t\tvar host = overlayHost();\n\t\t\t\tif (!bar || !host) return;\n\t\t\t\tvar rect = bar.getBoundingClientRect();\n\t\t\t\tvar margin = 8;\n\t\t\t\tvar width = Math.min(640, Math.max(0, window.innerWidth - margin * 2));\n\t\t\t\tvar left = Math.min(Math.max(margin, rect.left), Math.max(margin, window.innerWidth - width - margin));\n\t\t\t\thost.style.left = Math.round(left) + \"px\";\n\t\t\t\thost.style.top = Math.round(rect.bottom + 4) + \"px\";\n\t\t\t\thost.style.width = Math.round(width) + \"px\";\n\t\t\t}\n\n\t\t\tfunction requestOverlayPosition() {\n\t\t\t\tif (positionFrame) return;\n\t\t\t\tpositionFrame = requestAnimationFrame(positionOverlay);\n\t\t\t}\n\n\t\t\tfunction closeOverlay(restoreFocus) {\n\t\t\t\topen = false;\n\t\t\t\tvar host = overlayHost();\n\t\t\t\tif (host) {\n\t\t\t\t\thost.hidden = true;\n\t\t\t\t\thost.classList.add(\"hidden\");\n\t\t\t\t\thost.setAttribute(\"aria-hidden\", \"true\");\n\t\t\t\t}\n\t\t\t\tsetToggleState(false);\n\t\t\t\tif (restoreFocus) {\n\t\t\t\t\tvar toggle = alertsToggle();\n\t\t\t\t\tif (toggle) toggle.focus();\n\t\t\t\t}\n\t\t\t}\n\n\t\t\tfunction openOverlay() {\n\t\t\t\tif (!renderOverlay()) return;\n\t\t\t\topen = true;\n\t\t\t\tvar host = overlayHost();\n\t\t\t\tif (!host) return;\n\t\t\t\thost.hidden = false;\n\t\t\t\thost.classList.remove(\"hidden\");\n\t\t\t\thost.setAttribute(\"aria-hidden\", \"false\");\n\t\t\t\tsetToggleState(true);\n\t\t\t\tpositionOverlay();\n\t\t\t}\n\n\t\t\tfunction syncOverlayAfterMorph() {\n\t\t\t\tif (!open) {\n\t\t\t\t\tsetToggleState(false);\n\t\t\t\t\treturn;\n\t\t\t\t}\n\t\t\t\tif (!alertsBar()) {\n\t\t\t\t\tcloseOverlay(false);\n\t\t\t\t\treturn;\n\t\t\t\t}\n\t\t\t\tvar host = overlayHost();\n\t\t\t\tvar scrollTop = host ? host.scrollTop : 0;\n\t\t\t\tif (!renderOverlay()) {\n\t\t\t\t\tcloseOverlay(false);\n\t\t\t\t\treturn;\n\t\t\t\t}\n\t\t\t\thost = overlayHost();\n\t\t\t\tif (!host) return;\n\t\t\t\thost.hidden = false;\n\t\t\t\thost.classList.remove(\"hidden\");\n\t\t\t\thost.setAttribute(\"aria-hidden\", \"false\");\n\t\t\t\thost.scrollTop = scrollTop;\n\t\t\t\tsetToggleState(true);\n\t\t\t\tpositionOverlay();\n\t\t\t}\n\n\t\t\tfunction settledSnapshot(event) {\n\t\t\t\tvar detailTarget = event.detail && event.detail.target;\n\t\t\t\tvar target = detailTarget instanceof Element ? detailTarget : event.target;\n\t\t\t\tif (!(target instanceof Element)) return false;\n\t\t\t\treturn target.id === \"snapshot\" || Boolean(target.closest(\"#snapshot\"));\n\t\t\t}\n\n\t\t\tfunction dismissedWarningIDs(form) {\n\t\t\t\tvar ids = [];\n\t\t\t\tvar directID = form.dataset.stalenessWarningId || \"\";\n\t\t\t\tif (directID) ids.push(directID);\n\t\t\t\tform.querySelectorAll(\"input[name='warning_id']\").forEach(function (input) {\n\t\t\t\t\tif (input.value && !ids.includes(input.value)) ids.push(input.value);\n\t\t\t\t});\n\t\t\t\treturn ids;\n\t\t\t}\n\n\t\t\tfunction removeDismissedWarnings(root, projectID, warningIDs) {\n\t\t\t\tif (!root || typeof root.querySelectorAll !== \"function\") return;\n\t\t\t\troot.querySelectorAll(\"[data-board-alert='staleness-warning'][data-staleness-warning-id]\").forEach(function (warning) {\n\t\t\t\t\tif (warning.dataset.stalenessProjectId !== projectID) return;\n\t\t\t\t\tif (warningIDs.includes(warning.dataset.stalenessWarningId || \"\")) warning.remove();\n\t\t\t\t});\n\t\t\t}\n\n\t\t\tfunction syncBulkDismissals(root) {\n\t\t\t\tif (!root || typeof root.querySelectorAll !== \"function\") return;\n\t\t\t\troot.querySelectorAll(\"[data-staleness-dismiss-bulk]\").forEach(function (form) {\n\t\t\t\t\tvar projectID = form.dataset.stalenessProjectId || \"\";\n\t\t\t\t\tvar active = [];\n\t\t\t\t\troot.querySelectorAll(\"[data-board-alert='staleness-warning'][data-staleness-warning-id]\").forEach(function (warning) {\n\t\t\t\t\t\tif (warning.dataset.stalenessProjectId === projectID) active.push(warning.dataset.stalenessWarningId || \"\");\n\t\t\t\t\t});\n\t\t\t\t\tform.querySelectorAll(\"input[name='warning_id']\").forEach(function (input) {\n\t\t\t\t\t\tif (!active.includes(input.value)) input.remove();\n\t\t\t\t\t});\n\t\t\t\t\tif (active.length === 0) {\n\t\t\t\t\t\tform.remove();\n\t\t\t\t\t\treturn;\n\t\t\t\t\t}\n\t\t\t\t\tvar label = form.querySelector(\"[data-staleness-dismiss-label]\");\n\t\t\t\t\tif (label) label.textContent = label.textContent.replace(/\\(\\d+\\)$/, \"(\" + active.length + \")\");\n\t\t\t\t});\n\t\t\t}\n\n\t\t\tfunction warningCountLabel(count) {\n\t\t\t\treturn count + (count === 1 ? \" warning\" : \" warnings\");\n\t\t\t}\n\n\t\t\tfunction syncAlertCountRoot(root, count) {\n\t\t\t\tif (!root || typeof root.querySelectorAll !== \"function\") return;\n\t\t\t\troot.querySelectorAll(\"[data-board-alert-count-label]\").forEach(function (label) {\n\t\t\t\t\tlabel.textContent = warningCountLabel(count);\n\t\t\t\t});\n\t\t\t}\n\n\t\t\tfunction settleStalenessDismissal(form) {\n\t\t\t\tvar projectID = form.dataset.stalenessProjectId || \"\";\n\t\t\t\tvar warningIDs = dismissedWarningIDs(form);\n\t\t\t\tif (!projectID || warningIDs.length === 0) return;\n\t\t\t\tvar host = overlayHost();\n\t\t\t\tvar template = overlayTemplate();\n\t\t\t\tremoveDismissedWarnings(host, projectID, warningIDs);\n\t\t\t\tif (template instanceof HTMLTemplateElement) removeDismissedWarnings(template.content, projectID, warningIDs);\n\t\t\t\tsyncBulkDismissals(host);\n\t\t\t\tif (template instanceof HTMLTemplateElement) syncBulkDismissals(template.content);\n\t\t\t\tvar countRoot = template instanceof HTMLTemplateElement ? template.content : host;\n\t\t\t\tvar count = countRoot && typeof countRoot.querySelectorAll === \"function\" ? countRoot.querySelectorAll(\"[data-board-alert]\").length : 0;\n\t\t\t\tvar bar = alertsBar();\n\t\t\t\tif (!bar || count === 0) {\n\t\t\t\t\tif (bar) bar.remove();\n\t\t\t\t\tcloseOverlay(false);\n\t\t\t\t\treturn;\n\t\t\t\t}\n\t\t\t\tbar.dataset.boardAlertCount = String(count);\n\t\t\t\tsyncAlertCountRoot(bar, count);\n\t\t\t\tsyncAlertCountRoot(host, count);\n\t\t\t\tif (template instanceof HTMLTemplateElement) syncAlertCountRoot(template.content, count);\n\t\t\t\tvar overflow = bar.querySelector(\"[data-board-alert-overflow]\");\n\t\t\t\tif (overflow) {\n\t\t\t\t\toverflow.textContent = \"+\" + Math.max(0, count - 1);\n\t\t\t\t\toverflow.hidden = count <= 1;\n\t\t\t\t}\n\t\t\t\tvar toggle = alertsToggle();\n\t\t\t\tif (toggle) toggle.setAttribute(\"aria-label\", (toggle.getAttribute(\"aria-label\") || \"\").replace(/^\\d+ board warnings?/, count + (count === 1 ? \" board warning\" : \" board warnings\")));\n\t\t\t}\n\n\t\t\tdocument.addEventListener(\"click\", function (event) {\n\t\t\t\tvar target = event.target instanceof Element ? event.target : null;\n\t\t\t\tif (!target) return;\n\t\t\t\tif (target.closest(\"[data-board-alerts-close]\")) {\n\t\t\t\t\tcloseOverlay(true);\n\t\t\t\t\treturn;\n\t\t\t\t}\n\t\t\t\tif (!target.closest(\"[data-board-alerts-toggle]\")) return;\n\t\t\t\tif (open) {\n\t\t\t\t\tcloseOverlay(false);\n\t\t\t\t} else {\n\t\t\t\t\topenOverlay();\n\t\t\t\t}\n\t\t\t});\n\n\t\t\tdocument.addEventListener(\"keydown\", function (event) {\n\t\t\t\tif (event.key === \"Escape\" && open) closeOverlay(true);\n\t\t\t});\n\n\t\t\tdocument.addEventListener(\"htmx:afterSettle\", function (event) {\n\t\t\t\tif (settledSnapshot(event)) syncOverlayAfterMorph();\n\t\t\t});\n\n\t\t\tdocument.addEventListener(\"htmx:beforeSwap\", function (event) {\n\t\t\t\tvar requestElement = event.detail && event.detail.requestConfig && event.detail.requestConfig.elt;\n\t\t\t\tvar form = requestElement instanceof Element ? requestElement.closest(\"[data-staleness-dismiss-form]\") : null;\n\t\t\t\tif (!(form instanceof HTMLFormElement)) return;\n\t\t\t\tvar status = event.detail.xhr ? event.detail.xhr.status : 0;\n\t\t\t\tif (status < 200 || status >= 300) return;\n\t\t\t\tevent.detail.shouldSwap = false;\n\t\t\t\tsettleStalenessDismissal(form);\n\t\t\t});\n\n\t\t\twindow.addEventListener(\"resize\", requestOverlayPosition);\n\t\t})();\n\t</script>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 111, "<script>\n\t\t(function () {\n\t\t\tvar open = false;\n\t\t\tvar positionFrame = 0;\n\n\t\t\tfunction alertsBar() {\n\t\t\t\treturn document.getElementById(\"board-alerts\");\n\t\t\t}\n\n\t\t\tfunction alertsToggle() {\n\t\t\t\treturn document.querySelector(\"[data-board-alerts-toggle]\");\n\t\t\t}\n\n\t\t\tfunction overlayHost() {\n\t\t\t\treturn document.querySelector(\"[data-board-alerts-overlay-host]\");\n\t\t\t}\n\n\t\t\tfunction overlayTemplate() {\n\t\t\t\tvar bar = alertsBar();\n\t\t\t\treturn bar ? bar.querySelector(\"template[data-board-alerts-overlay-template]\") : null;\n\t\t\t}\n\n\t\t\tfunction setToggleState(expanded) {\n\t\t\t\tvar toggle = alertsToggle();\n\t\t\t\tif (!toggle) return;\n\t\t\t\ttoggle.setAttribute(\"aria-expanded\", expanded ? \"true\" : \"false\");\n\t\t\t\tvar chevron = toggle.querySelector(\"[data-board-alerts-chevron]\");\n\t\t\t\tif (chevron) chevron.setAttribute(\"data-open\", expanded ? \"true\" : \"false\");\n\t\t\t}\n\n\t\t\tfunction renderOverlay() {\n\t\t\t\tvar host = overlayHost();\n\t\t\t\tvar template = overlayTemplate();\n\t\t\t\tif (!host || !(template instanceof HTMLTemplateElement)) return false;\n\t\t\t\thost.replaceChildren(template.content.cloneNode(true));\n\t\t\t\tif (window.htmx) window.htmx.process(host);\n\t\t\t\treturn true;\n\t\t\t}\n\n\t\t\tfunction positionOverlay() {\n\t\t\t\tpositionFrame = 0;\n\t\t\t\tif (!open) return;\n\t\t\t\tvar bar = alertsBar();\n\t\t\t\tvar host = overlayHost();\n\t\t\t\tif (!bar || !host) return;\n\t\t\t\tvar rect = bar.getBoundingClientRect();\n\t\t\t\tvar margin = 8;\n\t\t\t\tvar width = Math.min(640, Math.max(0, window.innerWidth - margin * 2));\n\t\t\t\tvar left = Math.min(Math.max(margin, rect.left), Math.max(margin, window.innerWidth - width - margin));\n\t\t\t\thost.style.left = Math.round(left) + \"px\";\n\t\t\t\thost.style.top = Math.round(rect.bottom + 4) + \"px\";\n\t\t\t\thost.style.width = Math.round(width) + \"px\";\n\t\t\t}\n\n\t\t\tfunction requestOverlayPosition() {\n\t\t\t\tif (positionFrame) return;\n\t\t\t\tpositionFrame = requestAnimationFrame(positionOverlay);\n\t\t\t}\n\n\t\t\tfunction closeOverlay(restoreFocus) {\n\t\t\t\topen = false;\n\t\t\t\tvar host = overlayHost();\n\t\t\t\tif (host) {\n\t\t\t\t\thost.hidden = true;\n\t\t\t\t\thost.classList.add(\"hidden\");\n\t\t\t\t\thost.setAttribute(\"aria-hidden\", \"true\");\n\t\t\t\t}\n\t\t\t\tsetToggleState(false);\n\t\t\t\tif (restoreFocus) {\n\t\t\t\t\tvar toggle = alertsToggle();\n\t\t\t\t\tif (toggle) toggle.focus();\n\t\t\t\t}\n\t\t\t}\n\n\t\t\tfunction openOverlay() {\n\t\t\t\tif (!renderOverlay()) return;\n\t\t\t\topen = true;\n\t\t\t\tvar host = overlayHost();\n\t\t\t\tif (!host) return;\n\t\t\t\thost.hidden = false;\n\t\t\t\thost.classList.remove(\"hidden\");\n\t\t\t\thost.setAttribute(\"aria-hidden\", \"false\");\n\t\t\t\tsetToggleState(true);\n\t\t\t\tpositionOverlay();\n\t\t\t}\n\n\t\t\tfunction syncOverlayAfterMorph() {\n\t\t\t\tif (!open) {\n\t\t\t\t\tsetToggleState(false);\n\t\t\t\t\treturn;\n\t\t\t\t}\n\t\t\t\tif (!alertsBar()) {\n\t\t\t\t\tcloseOverlay(false);\n\t\t\t\t\treturn;\n\t\t\t\t}\n\t\t\t\tvar host = overlayHost();\n\t\t\t\tvar scrollTop = host ? host.scrollTop : 0;\n\t\t\t\tif (!renderOverlay()) {\n\t\t\t\t\tcloseOverlay(false);\n\t\t\t\t\treturn;\n\t\t\t\t}\n\t\t\t\thost = overlayHost();\n\t\t\t\tif (!host) return;\n\t\t\t\thost.hidden = false;\n\t\t\t\thost.classList.remove(\"hidden\");\n\t\t\t\thost.setAttribute(\"aria-hidden\", \"false\");\n\t\t\t\thost.scrollTop = scrollTop;\n\t\t\t\tsetToggleState(true);\n\t\t\t\tpositionOverlay();\n\t\t\t}\n\n\t\t\tfunction settledSnapshot(event) {\n\t\t\t\tvar detailTarget = event.detail && event.detail.target;\n\t\t\t\tvar target = detailTarget instanceof Element ? detailTarget : event.target;\n\t\t\t\tif (!(target instanceof Element)) return false;\n\t\t\t\treturn target.id === \"snapshot\" || Boolean(target.closest(\"#snapshot\"));\n\t\t\t}\n\n\t\t\tfunction dismissedWarningIDs(form) {\n\t\t\t\tvar ids = [];\n\t\t\t\tvar directID = form.dataset.stalenessWarningId || \"\";\n\t\t\t\tif (directID) ids.push(directID);\n\t\t\t\tform.querySelectorAll(\"input[name='warning_id']\").forEach(function (input) {\n\t\t\t\t\tif (input.value && !ids.includes(input.value)) ids.push(input.value);\n\t\t\t\t});\n\t\t\t\treturn ids;\n\t\t\t}\n\n\t\t\tfunction removeDismissedWarnings(root, projectID, warningIDs) {\n\t\t\t\tif (!root || typeof root.querySelectorAll !== \"function\") return;\n\t\t\t\troot.querySelectorAll(\"[data-board-alert='staleness-warning'][data-staleness-warning-id]\").forEach(function (warning) {\n\t\t\t\t\tif (warning.dataset.stalenessProjectId !== projectID) return;\n\t\t\t\t\tif (warningIDs.includes(warning.dataset.stalenessWarningId || \"\")) warning.remove();\n\t\t\t\t});\n\t\t\t}\n\n\t\t\tfunction syncBulkDismissals(root) {\n\t\t\t\tif (!root || typeof root.querySelectorAll !== \"function\") return;\n\t\t\t\troot.querySelectorAll(\"[data-staleness-dismiss-bulk]\").forEach(function (form) {\n\t\t\t\t\tvar projectID = form.dataset.stalenessProjectId || \"\";\n\t\t\t\t\tvar active = [];\n\t\t\t\t\troot.querySelectorAll(\"[data-board-alert='staleness-warning'][data-staleness-warning-id]\").forEach(function (warning) {\n\t\t\t\t\t\tif (warning.dataset.stalenessProjectId === projectID) active.push(warning.dataset.stalenessWarningId || \"\");\n\t\t\t\t\t});\n\t\t\t\t\tform.querySelectorAll(\"input[name='warning_id']\").forEach(function (input) {\n\t\t\t\t\t\tif (!active.includes(input.value)) input.remove();\n\t\t\t\t\t});\n\t\t\t\t\tif (active.length === 0) {\n\t\t\t\t\t\tform.remove();\n\t\t\t\t\t\treturn;\n\t\t\t\t\t}\n\t\t\t\t\tvar label = form.querySelector(\"[data-staleness-dismiss-label]\");\n\t\t\t\t\tif (label) label.textContent = label.textContent.replace(/\\(\\d+\\)$/, \"(\" + active.length + \")\");\n\t\t\t\t});\n\t\t\t}\n\n\t\t\tfunction warningCountLabel(count) {\n\t\t\t\treturn count + (count === 1 ? \" warning\" : \" warnings\");\n\t\t\t}\n\n\t\t\tfunction syncAlertCountRoot(root, count) {\n\t\t\t\tif (!root || typeof root.querySelectorAll !== \"function\") return;\n\t\t\t\troot.querySelectorAll(\"[data-board-alert-count-label]\").forEach(function (label) {\n\t\t\t\t\tlabel.textContent = warningCountLabel(count);\n\t\t\t\t});\n\t\t\t}\n\n\t\t\tfunction syncLeadAlertRoot(root, lead, glyphTemplate) {\n\t\t\t\tif (!root || typeof root.querySelectorAll !== \"function\") return;\n\t\t\t\troot.querySelectorAll(\"[data-board-alert-lead-glyph]\").forEach(function (glyph) {\n\t\t\t\t\tglyph.replaceChildren(glyphTemplate.content.cloneNode(true));\n\t\t\t\t});\n\t\t\t\troot.querySelectorAll(\"[data-board-alert-lead-summary]\").forEach(function (summary) {\n\t\t\t\t\tsummary.textContent = lead.dataset.boardAlertSummary || \"\";\n\t\t\t\t});\n\t\t\t}\n\n\t\t\tfunction syncLeadAlert(bar, roots, lead, count) {\n\t\t\t\tvar glyphTemplate = lead.querySelector(\"template[data-board-alert-glyph-template]\");\n\t\t\t\tif (!(glyphTemplate instanceof HTMLTemplateElement)) return;\n\t\t\t\troots.forEach(function (root) {\n\t\t\t\t\tsyncLeadAlertRoot(root, lead, glyphTemplate);\n\t\t\t\t});\n\t\t\t\tvar tones = {\n\t\t\t\t\terr: [\"border-err/40\", \"bg-err/10\", \"text-err\"],\n\t\t\t\t\tinfo: [\"border-info/40\", \"bg-info/10\", \"text-info\"],\n\t\t\t\t\twarn: [\"border-warn/40\", \"bg-warn/10\", \"text-warn\"],\n\t\t\t\t};\n\t\t\t\tObject.values(tones).flat().forEach(function (className) {\n\t\t\t\t\tbar.classList.remove(className);\n\t\t\t\t});\n\t\t\t\tvar tone = lead.dataset.boardAlertTone || \"warn\";\n\t\t\t\t(tones[tone] || tones.warn).forEach(function (className) {\n\t\t\t\t\tbar.classList.add(className);\n\t\t\t\t});\n\t\t\t\tbar.dataset.boardAlertTone = tone;\n\t\t\t\tvar toggle = alertsToggle();\n\t\t\t\tif (toggle) {\n\t\t\t\t\tvar countLabel = count + (count === 1 ? \" board warning\" : \" board warnings\");\n\t\t\t\t\ttoggle.setAttribute(\"aria-label\", countLabel + \". Highest severity: \" + (lead.dataset.boardAlertSummary || \"\") + \". Expand details.\");\n\t\t\t\t}\n\t\t\t}\n\n\t\t\tfunction settleStalenessDismissal(form) {\n\t\t\t\tvar projectID = form.dataset.stalenessProjectId || \"\";\n\t\t\t\tvar warningIDs = dismissedWarningIDs(form);\n\t\t\t\tif (!projectID || warningIDs.length === 0) return;\n\t\t\t\tvar host = overlayHost();\n\t\t\t\tvar template = overlayTemplate();\n\t\t\t\tremoveDismissedWarnings(host, projectID, warningIDs);\n\t\t\t\tif (template instanceof HTMLTemplateElement) removeDismissedWarnings(template.content, projectID, warningIDs);\n\t\t\t\tsyncBulkDismissals(host);\n\t\t\t\tif (template instanceof HTMLTemplateElement) syncBulkDismissals(template.content);\n\t\t\t\tvar countRoot = template instanceof HTMLTemplateElement ? template.content : host;\n\t\t\t\tvar count = countRoot && typeof countRoot.querySelectorAll === \"function\" ? countRoot.querySelectorAll(\"[data-board-alert]\").length : 0;\n\t\t\t\tvar bar = alertsBar();\n\t\t\t\tif (!bar || count === 0) {\n\t\t\t\t\tif (bar) bar.remove();\n\t\t\t\t\tcloseOverlay(false);\n\t\t\t\t\treturn;\n\t\t\t\t}\n\t\t\t\tbar.dataset.boardAlertCount = String(count);\n\t\t\t\tsyncAlertCountRoot(bar, count);\n\t\t\t\tsyncAlertCountRoot(host, count);\n\t\t\t\tif (template instanceof HTMLTemplateElement) syncAlertCountRoot(template.content, count);\n\t\t\t\tvar lead = countRoot.querySelector(\"[data-board-alert]\");\n\t\t\t\tif (lead) {\n\t\t\t\t\tvar leadRoots = [bar, host];\n\t\t\t\t\tif (template instanceof HTMLTemplateElement) leadRoots.push(template.content);\n\t\t\t\t\tsyncLeadAlert(bar, leadRoots, lead, count);\n\t\t\t\t}\n\t\t\t\tvar overflow = bar.querySelector(\"[data-board-alert-overflow]\");\n\t\t\t\tif (overflow) {\n\t\t\t\t\toverflow.textContent = \"+\" + Math.max(0, count - 1);\n\t\t\t\t\toverflow.hidden = count <= 1;\n\t\t\t\t}\n\t\t\t}\n\n\t\t\tdocument.addEventListener(\"click\", function (event) {\n\t\t\t\tvar target = event.target instanceof Element ? event.target : null;\n\t\t\t\tif (!target) return;\n\t\t\t\tif (target.closest(\"[data-board-alerts-close]\")) {\n\t\t\t\t\tcloseOverlay(true);\n\t\t\t\t\treturn;\n\t\t\t\t}\n\t\t\t\tif (!target.closest(\"[data-board-alerts-toggle]\")) return;\n\t\t\t\tif (open) {\n\t\t\t\t\tcloseOverlay(false);\n\t\t\t\t} else {\n\t\t\t\t\topenOverlay();\n\t\t\t\t}\n\t\t\t});\n\n\t\t\tdocument.addEventListener(\"keydown\", function (event) {\n\t\t\t\tif (event.key === \"Escape\" && open) closeOverlay(true);\n\t\t\t});\n\n\t\t\tdocument.addEventListener(\"htmx:afterSettle\", function (event) {\n\t\t\t\tif (settledSnapshot(event)) syncOverlayAfterMorph();\n\t\t\t});\n\n\t\t\tdocument.addEventListener(\"htmx:beforeSwap\", function (event) {\n\t\t\t\tvar requestElement = event.detail && event.detail.requestConfig && event.detail.requestConfig.elt;\n\t\t\t\tvar form = requestElement instanceof Element ? requestElement.closest(\"[data-staleness-dismiss-form]\") : null;\n\t\t\t\tif (!(form instanceof HTMLFormElement)) return;\n\t\t\t\tvar status = event.detail.xhr ? event.detail.xhr.status : 0;\n\t\t\t\tif (status < 200 || status >= 300) return;\n\t\t\t\tevent.detail.shouldSwap = false;\n\t\t\t\tsettleStalenessDismissal(form);\n\t\t\t});\n\n\t\t\twindow.addEventListener(\"resize\", requestOverlayPosition);\n\t\t})();\n\t</script>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -1283,139 +1330,139 @@ func boardLaneView2(lane boardLaneView) templ.Component {
 			}()
 		}
 		ctx = templ.InitializeContext(ctx)
-		templ_7745c5c3_Var58 := templ.GetChildren(ctx)
-		if templ_7745c5c3_Var58 == nil {
-			templ_7745c5c3_Var58 = templ.NopComponent
+		templ_7745c5c3_Var61 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var61 == nil {
+			templ_7745c5c3_Var61 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 108, "<section id=\"")
-		if templ_7745c5c3_Err != nil {
-			return templ_7745c5c3_Err
-		}
-		var templ_7745c5c3_Var59 string
-		templ_7745c5c3_Var59, templ_7745c5c3_Err = templ.JoinStringErrs(lane.DomID)
-		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 527, Col: 17}
-		}
-		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var59))
-		if templ_7745c5c3_Err != nil {
-			return templ_7745c5c3_Err
-		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 109, "\" class=\"flex w-full flex-none snap-start flex-col overflow-hidden rounded-card border border-line bg-surface data-[kanban-drop-allowed=false]:border-err/45 data-[kanban-drop-allowed=false]:opacity-70 data-[kanban-drop-allowed=false]:ring-2 data-[kanban-drop-allowed=false]:ring-inset data-[kanban-drop-allowed=false]:ring-err/20 data-[kanban-drop-allowed=true]:border-accent data-[kanban-drop-allowed=true]:ring-2 data-[kanban-drop-allowed=true]:ring-inset data-[kanban-drop-allowed=true]:ring-accent/30 data-[kanban-drop-source=true]:border-dashed data-[kanban-drop-source=true]:border-accent/50 data-[kanban-drop-source=true]:ring-2 data-[kanban-drop-source=true]:ring-inset data-[kanban-drop-source=true]:ring-accent/20 data-[lane-hidden=true]:hidden md:min-w-44 md:max-w-80 md:flex-1 md:snap-none md:data-[kanban-drop-allowed=false]:ring-0 md:data-[kanban-drop-allowed=true]:ring-0 md:data-[kanban-drop-source=true]:ring-0\" data-board-lane=\"")
-		if templ_7745c5c3_Err != nil {
-			return templ_7745c5c3_Err
-		}
-		var templ_7745c5c3_Var60 string
-		templ_7745c5c3_Var60, templ_7745c5c3_Err = templ.JoinStringErrs(lane.LaneID)
-		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 529, Col: 31}
-		}
-		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var60))
-		if templ_7745c5c3_Err != nil {
-			return templ_7745c5c3_Err
-		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 110, "\" data-board-lane-title=\"")
-		if templ_7745c5c3_Err != nil {
-			return templ_7745c5c3_Err
-		}
-		var templ_7745c5c3_Var61 string
-		templ_7745c5c3_Var61, templ_7745c5c3_Err = templ.JoinStringErrs(lane.Title)
-		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 530, Col: 36}
-		}
-		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var61))
-		if templ_7745c5c3_Err != nil {
-			return templ_7745c5c3_Err
-		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 111, "\" data-board-lane-default=\"")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 112, "<section id=\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		var templ_7745c5c3_Var62 string
-		templ_7745c5c3_Var62, templ_7745c5c3_Err = templ.JoinStringErrs(boardBoolAttr(lane.DefaultVisible))
+		templ_7745c5c3_Var62, templ_7745c5c3_Err = templ.JoinStringErrs(lane.DomID)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 531, Col: 62}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 577, Col: 17}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var62))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 112, "\" data-board-lane-card-count=\"")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 113, "\" class=\"flex w-full flex-none snap-start flex-col overflow-hidden rounded-card border border-line bg-surface data-[kanban-drop-allowed=false]:border-err/45 data-[kanban-drop-allowed=false]:opacity-70 data-[kanban-drop-allowed=false]:ring-2 data-[kanban-drop-allowed=false]:ring-inset data-[kanban-drop-allowed=false]:ring-err/20 data-[kanban-drop-allowed=true]:border-accent data-[kanban-drop-allowed=true]:ring-2 data-[kanban-drop-allowed=true]:ring-inset data-[kanban-drop-allowed=true]:ring-accent/30 data-[kanban-drop-source=true]:border-dashed data-[kanban-drop-source=true]:border-accent/50 data-[kanban-drop-source=true]:ring-2 data-[kanban-drop-source=true]:ring-inset data-[kanban-drop-source=true]:ring-accent/20 data-[lane-hidden=true]:hidden md:min-w-44 md:max-w-80 md:flex-1 md:snap-none md:data-[kanban-drop-allowed=false]:ring-0 md:data-[kanban-drop-allowed=true]:ring-0 md:data-[kanban-drop-source=true]:ring-0\" data-board-lane=\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		var templ_7745c5c3_Var63 string
-		templ_7745c5c3_Var63, templ_7745c5c3_Err = templ.JoinStringErrs(strconv.Itoa(lane.CardCount))
+		templ_7745c5c3_Var63, templ_7745c5c3_Err = templ.JoinStringErrs(lane.LaneID)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 532, Col: 59}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 579, Col: 31}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var63))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 113, "\" data-board-lane-visibility-state=\"")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 114, "\" data-board-lane-title=\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		var templ_7745c5c3_Var64 string
-		templ_7745c5c3_Var64, templ_7745c5c3_Err = templ.JoinStringErrs(string(boardLaneVisibilityAuto))
+		templ_7745c5c3_Var64, templ_7745c5c3_Err = templ.JoinStringErrs(lane.Title)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 533, Col: 68}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 580, Col: 36}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var64))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 114, "\" data-board-lane-pinned=\"false\" data-lane-hidden=\"")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 115, "\" data-board-lane-default=\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		var templ_7745c5c3_Var65 string
-		templ_7745c5c3_Var65, templ_7745c5c3_Err = templ.JoinStringErrs(boardBoolAttr(!lane.DefaultVisible))
+		templ_7745c5c3_Var65, templ_7745c5c3_Err = templ.JoinStringErrs(boardBoolAttr(lane.DefaultVisible))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 535, Col: 56}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 581, Col: 62}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var65))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 115, "\"")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 116, "\" data-board-lane-card-count=\"")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		var templ_7745c5c3_Var66 string
+		templ_7745c5c3_Var66, templ_7745c5c3_Err = templ.JoinStringErrs(strconv.Itoa(lane.CardCount))
+		if templ_7745c5c3_Err != nil {
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 582, Col: 59}
+		}
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var66))
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 117, "\" data-board-lane-visibility-state=\"")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		var templ_7745c5c3_Var67 string
+		templ_7745c5c3_Var67, templ_7745c5c3_Err = templ.JoinStringErrs(string(boardLaneVisibilityAuto))
+		if templ_7745c5c3_Err != nil {
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 583, Col: 68}
+		}
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var67))
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 118, "\" data-board-lane-pinned=\"false\" data-lane-hidden=\"")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		var templ_7745c5c3_Var68 string
+		templ_7745c5c3_Var68, templ_7745c5c3_Err = templ.JoinStringErrs(boardBoolAttr(!lane.DefaultVisible))
+		if templ_7745c5c3_Err != nil {
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 585, Col: 56}
+		}
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var68))
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 119, "\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		if lane.DropState != "" {
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 116, " data-kanban-drop-state=\"")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 120, " data-kanban-drop-state=\"")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			var templ_7745c5c3_Var66 string
-			templ_7745c5c3_Var66, templ_7745c5c3_Err = templ.JoinStringErrs(lane.DropState)
+			var templ_7745c5c3_Var69 string
+			templ_7745c5c3_Var69, templ_7745c5c3_Err = templ.JoinStringErrs(lane.DropState)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 537, Col: 42}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 587, Col: 42}
 			}
-			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var66))
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 117, "\" data-kanban-drop-key=\"")
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var69))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			var templ_7745c5c3_Var67 string
-			templ_7745c5c3_Var67, templ_7745c5c3_Err = templ.JoinStringErrs(lane.DropKey)
-			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 538, Col: 38}
-			}
-			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var67))
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 121, "\" data-kanban-drop-key=\"")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 118, "\"")
+			var templ_7745c5c3_Var70 string
+			templ_7745c5c3_Var70, templ_7745c5c3_Err = templ.JoinStringErrs(lane.DropKey)
+			if templ_7745c5c3_Err != nil {
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 588, Col: 38}
+			}
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var70))
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 122, "\"")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 119, "><header class=\"flex flex-none items-center gap-1.5 border-b border-line px-3 py-2\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 123, "><header class=\"flex flex-none items-center gap-1.5 border-b border-line px-3 py-2\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -1425,51 +1472,51 @@ func boardLaneView2(lane boardLaneView) templ.Component {
 				return templ_7745c5c3_Err
 			}
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 120, "<h2 class=\"text-xs font-semibold text-text\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 124, "<h2 class=\"text-xs font-semibold text-text\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		var templ_7745c5c3_Var68 string
-		templ_7745c5c3_Var68, templ_7745c5c3_Err = templ.JoinStringErrs(lane.Title)
+		var templ_7745c5c3_Var71 string
+		templ_7745c5c3_Var71, templ_7745c5c3_Err = templ.JoinStringErrs(lane.Title)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 545, Col: 59}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 595, Col: 59}
 		}
-		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var68))
-		if templ_7745c5c3_Err != nil {
-			return templ_7745c5c3_Err
-		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 121, "</h2><span class=\"font-mono text-2xs font-medium text-sec tabular-nums\">")
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var71))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		var templ_7745c5c3_Var69 string
-		templ_7745c5c3_Var69, templ_7745c5c3_Err = templ.JoinStringErrs(lane.Count)
-		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 546, Col: 82}
-		}
-		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var69))
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 125, "</h2><span class=\"font-mono text-2xs font-medium text-sec tabular-nums\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 122, "</span></header><div class=\"dt-lane-scroll flex min-h-0 flex-1 flex-col gap-2 overflow-y-auto overflow-x-hidden p-2\" data-preserve-scroll=\"")
+		var templ_7745c5c3_Var72 string
+		templ_7745c5c3_Var72, templ_7745c5c3_Err = templ.JoinStringErrs(lane.Count)
+		if templ_7745c5c3_Err != nil {
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 596, Col: 82}
+		}
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var72))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		var templ_7745c5c3_Var70 string
-		templ_7745c5c3_Var70, templ_7745c5c3_Err = templ.JoinStringErrs(lane.DomID + "-scroll")
-		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 548, Col: 148}
-		}
-		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var70))
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 126, "</span></header><div class=\"dt-lane-scroll flex min-h-0 flex-1 flex-col gap-2 overflow-y-auto overflow-x-hidden p-2\" data-preserve-scroll=\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 123, "\" data-kanban-card-container>")
+		var templ_7745c5c3_Var73 string
+		templ_7745c5c3_Var73, templ_7745c5c3_Err = templ.JoinStringErrs(lane.DomID + "-scroll")
+		if templ_7745c5c3_Err != nil {
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 598, Col: 148}
+		}
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var73))
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 127, "\" data-kanban-card-container>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		if len(lane.Cards) == 0 {
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 124, "<div class=\"contents\" data-kanban-empty-line>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 128, "<div class=\"contents\" data-kanban-empty-line>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -1477,7 +1524,7 @@ func boardLaneView2(lane boardLaneView) templ.Component {
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 125, "</div>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 129, "</div>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -1488,7 +1535,7 @@ func boardLaneView2(lane boardLaneView) templ.Component {
 				return templ_7745c5c3_Err
 			}
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 126, "</div></section>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 130, "</div></section>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -1512,43 +1559,43 @@ func boardCardView2(card boardCardView) templ.Component {
 			}()
 		}
 		ctx = templ.InitializeContext(ctx)
-		templ_7745c5c3_Var71 := templ.GetChildren(ctx)
-		if templ_7745c5c3_Var71 == nil {
-			templ_7745c5c3_Var71 = templ.NopComponent
+		templ_7745c5c3_Var74 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var74 == nil {
+			templ_7745c5c3_Var74 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		var templ_7745c5c3_Var72 = []any{boardCardClass(card) + boardCardInteractionClass(card)}
-		templ_7745c5c3_Err = templ.RenderCSSItems(ctx, templ_7745c5c3_Buffer, templ_7745c5c3_Var72...)
+		var templ_7745c5c3_Var75 = []any{boardCardClass(card) + boardCardInteractionClass(card)}
+		templ_7745c5c3_Err = templ.RenderCSSItems(ctx, templ_7745c5c3_Buffer, templ_7745c5c3_Var75...)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 127, "<article id=\"")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 131, "<article id=\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		var templ_7745c5c3_Var73 string
-		templ_7745c5c3_Var73, templ_7745c5c3_Err = templ.JoinStringErrs(card.DomID)
+		var templ_7745c5c3_Var76 string
+		templ_7745c5c3_Var76, templ_7745c5c3_Err = templ.JoinStringErrs(card.DomID)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 563, Col: 17}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 613, Col: 17}
 		}
-		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var73))
-		if templ_7745c5c3_Err != nil {
-			return templ_7745c5c3_Err
-		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 128, "\" class=\"")
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var76))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		var templ_7745c5c3_Var74 string
-		templ_7745c5c3_Var74, templ_7745c5c3_Err = templ.JoinStringErrs(templ.CSSClasses(templ_7745c5c3_Var72).String())
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 132, "\" class=\"")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		var templ_7745c5c3_Var77 string
+		templ_7745c5c3_Var77, templ_7745c5c3_Err = templ.JoinStringErrs(templ.CSSClasses(templ_7745c5c3_Var75).String())
 		if templ_7745c5c3_Err != nil {
 			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 1, Col: 0}
 		}
-		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var74))
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var77))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 129, "\" role=\"button\" tabindex=\"0\"")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 133, "\" role=\"button\" tabindex=\"0\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -1556,122 +1603,84 @@ func boardCardView2(card boardCardView) templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 130, " data-detail-sheet-project=\"")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 134, " data-detail-sheet-project=\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		var templ_7745c5c3_Var75 string
-		templ_7745c5c3_Var75, templ_7745c5c3_Err = templ.JoinStringErrs(card.Project)
+		var templ_7745c5c3_Var78 string
+		templ_7745c5c3_Var78, templ_7745c5c3_Err = templ.JoinStringErrs(card.Project)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 568, Col: 42}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 618, Col: 42}
 		}
-		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var75))
-		if templ_7745c5c3_Err != nil {
-			return templ_7745c5c3_Err
-		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 131, "\" data-detail-sheet-reference=\"")
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var78))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		var templ_7745c5c3_Var76 string
-		templ_7745c5c3_Var76, templ_7745c5c3_Err = templ.JoinStringErrs(card.Number)
-		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 569, Col: 43}
-		}
-		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var76))
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 135, "\" data-detail-sheet-reference=\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 132, "\"")
+		var templ_7745c5c3_Var79 string
+		templ_7745c5c3_Var79, templ_7745c5c3_Err = templ.JoinStringErrs(card.Number)
+		if templ_7745c5c3_Err != nil {
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 619, Col: 43}
+		}
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var79))
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 136, "\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		if card.MoveDisabledText != "" {
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 133, " title=\"")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 137, " title=\"")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			var templ_7745c5c3_Var77 string
-			templ_7745c5c3_Var77, templ_7745c5c3_Err = templ.JoinStringErrs(card.MoveDisabledText)
+			var templ_7745c5c3_Var80 string
+			templ_7745c5c3_Var80, templ_7745c5c3_Err = templ.JoinStringErrs(card.MoveDisabledText)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 571, Col: 32}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 621, Col: 32}
 			}
-			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var77))
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var80))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 134, "\"")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 138, "\"")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 		}
 		if card.DragDrop {
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 135, " data-kanban-card data-kanban-current-state=\"")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 139, " data-kanban-card data-kanban-current-state=\"")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			var templ_7745c5c3_Var78 string
-			templ_7745c5c3_Var78, templ_7745c5c3_Err = templ.JoinStringErrs(card.CurrentState)
+			var templ_7745c5c3_Var81 string
+			templ_7745c5c3_Var81, templ_7745c5c3_Err = templ.JoinStringErrs(card.CurrentState)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 575, Col: 48}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 625, Col: 48}
 			}
-			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var78))
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var81))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 136, "\"")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 140, "\"")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			if card.DataSeq > 0 {
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 137, " data-kanban-data-seq=\"")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 141, " data-kanban-data-seq=\"")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				var templ_7745c5c3_Var79 string
-				templ_7745c5c3_Var79, templ_7745c5c3_Err = templ.JoinStringErrs(strconv.FormatUint(card.DataSeq, 10))
+				var templ_7745c5c3_Var82 string
+				templ_7745c5c3_Var82, templ_7745c5c3_Err = templ.JoinStringErrs(strconv.FormatUint(card.DataSeq, 10))
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 577, Col: 63}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 627, Col: 63}
 				}
-				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var79))
-				if templ_7745c5c3_Err != nil {
-					return templ_7745c5c3_Err
-				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 138, "\"")
-				if templ_7745c5c3_Err != nil {
-					return templ_7745c5c3_Err
-				}
-			}
-			if card.IssueID != "" {
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 139, " data-kanban-issue-id=\"")
-				if templ_7745c5c3_Err != nil {
-					return templ_7745c5c3_Err
-				}
-				var templ_7745c5c3_Var80 string
-				templ_7745c5c3_Var80, templ_7745c5c3_Err = templ.JoinStringErrs(card.IssueID)
-				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 580, Col: 39}
-				}
-				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var80))
-				if templ_7745c5c3_Err != nil {
-					return templ_7745c5c3_Err
-				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 140, "\"")
-				if templ_7745c5c3_Err != nil {
-					return templ_7745c5c3_Err
-				}
-			}
-			if card.CanDrag {
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 141, " data-kanban-action=\"move\" data-kanban-allowed-targets=\"")
-				if templ_7745c5c3_Err != nil {
-					return templ_7745c5c3_Err
-				}
-				var templ_7745c5c3_Var81 string
-				templ_7745c5c3_Var81, templ_7745c5c3_Err = templ.JoinStringErrs(card.AllowedTargets)
-				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 584, Col: 53}
-				}
-				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var81))
+				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var82))
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
@@ -1680,31 +1689,69 @@ func boardCardView2(card boardCardView) templ.Component {
 					return templ_7745c5c3_Err
 				}
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 143, " else")
+			if card.IssueID != "" {
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 143, " data-kanban-issue-id=\"")
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+				var templ_7745c5c3_Var83 string
+				templ_7745c5c3_Var83, templ_7745c5c3_Err = templ.JoinStringErrs(card.IssueID)
+				if templ_7745c5c3_Err != nil {
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 630, Col: 39}
+				}
+				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var83))
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 144, "\"")
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+			}
+			if card.CanDrag {
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 145, " data-kanban-action=\"move\" data-kanban-allowed-targets=\"")
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+				var templ_7745c5c3_Var84 string
+				templ_7745c5c3_Var84, templ_7745c5c3_Err = templ.JoinStringErrs(card.AllowedTargets)
+				if templ_7745c5c3_Err != nil {
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 634, Col: 53}
+				}
+				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var84))
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 146, "\"")
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 147, " else")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			if card.MoveDisabledText != "" {
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 144, " data-kanban-move-disabled=\"true\" data-kanban-move-disabled-reason=\"")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 148, " data-kanban-move-disabled=\"true\" data-kanban-move-disabled-reason=\"")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				var templ_7745c5c3_Var82 string
-				templ_7745c5c3_Var82, templ_7745c5c3_Err = templ.JoinStringErrs(card.MoveDisabledText)
+				var templ_7745c5c3_Var85 string
+				templ_7745c5c3_Var85, templ_7745c5c3_Err = templ.JoinStringErrs(card.MoveDisabledText)
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 589, Col: 60}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 639, Col: 60}
 				}
-				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var82))
+				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var85))
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 145, "\"")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 149, "\"")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
 			}
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 146, "><div class=\"flex min-w-0 items-center gap-0.5 font-mono text-2xs font-medium text-sec\" data-board-card-content=\"cozy\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 150, "><div class=\"flex min-w-0 items-center gap-0.5 font-mono text-2xs font-medium text-sec\" data-board-card-content=\"cozy\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -1718,247 +1765,134 @@ func boardCardView2(card boardCardView) templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 147, "<span class=\"min-w-0 truncate\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 151, "<span class=\"min-w-0 truncate\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		var templ_7745c5c3_Var83 string
-		templ_7745c5c3_Var83, templ_7745c5c3_Err = templ.JoinStringErrs(card.Project)
+		var templ_7745c5c3_Var86 string
+		templ_7745c5c3_Var86, templ_7745c5c3_Err = templ.JoinStringErrs(card.Project)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 598, Col: 48}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 648, Col: 48}
 		}
-		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var83))
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var86))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 148, "</span> ")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 152, "</span> ")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		if card.PriorityBadge != "" {
-			var templ_7745c5c3_Var84 = []any{boardPriorityBadgeClass(card)}
-			templ_7745c5c3_Err = templ.RenderCSSItems(ctx, templ_7745c5c3_Buffer, templ_7745c5c3_Var84...)
+			var templ_7745c5c3_Var87 = []any{boardPriorityBadgeClass(card)}
+			templ_7745c5c3_Err = templ.RenderCSSItems(ctx, templ_7745c5c3_Buffer, templ_7745c5c3_Var87...)
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 149, "<span id=\"")
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
-			var templ_7745c5c3_Var85 string
-			templ_7745c5c3_Var85, templ_7745c5c3_Err = templ.JoinStringErrs(card.DomID + "-priority")
-			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 601, Col: 34}
-			}
-			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var85))
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 150, "\" class=\"")
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
-			var templ_7745c5c3_Var86 string
-			templ_7745c5c3_Var86, templ_7745c5c3_Err = templ.JoinStringErrs(templ.CSSClasses(templ_7745c5c3_Var84).String())
-			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 1, Col: 0}
-			}
-			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var86))
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 151, "\" tabindex=\"0\" role=\"img\" aria-label=\"")
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
-			var templ_7745c5c3_Var87 string
-			templ_7745c5c3_Var87, templ_7745c5c3_Err = templ.JoinStringErrs("Priority: " + card.PriorityBadge)
-			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 605, Col: 51}
-			}
-			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var87))
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 152, "\" data-board-priority data-board-priority-top=\"")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 153, "<span id=\"")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var88 string
-			templ_7745c5c3_Var88, templ_7745c5c3_Err = templ.JoinStringErrs(boardBoolAttr(card.PriorityTop))
+			templ_7745c5c3_Var88, templ_7745c5c3_Err = templ.JoinStringErrs(card.DomID + "-priority")
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 607, Col: 62}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 651, Col: 34}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var88))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 153, "\" data-help-trigger data-help-scope=\"dispatch-priority\" data-help-term=\"")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 154, "\" class=\"")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var89 string
-			templ_7745c5c3_Var89, templ_7745c5c3_Err = templ.JoinStringErrs(card.DomID + "-priority")
+			templ_7745c5c3_Var89, templ_7745c5c3_Err = templ.JoinStringErrs(templ.CSSClasses(templ_7745c5c3_Var87).String())
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 610, Col: 46}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 1, Col: 0}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var89))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 154, "\" data-help-title=\"")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 155, "\" tabindex=\"0\" role=\"img\" aria-label=\"")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var90 string
-			templ_7745c5c3_Var90, templ_7745c5c3_Err = templ.JoinStringErrs(card.PriorityTitle)
+			templ_7745c5c3_Var90, templ_7745c5c3_Err = templ.JoinStringErrs("Priority: " + card.PriorityBadge)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 611, Col: 41}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 655, Col: 51}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var90))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 155, "\" data-help-description=\"")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 156, "\" data-board-priority data-board-priority-top=\"")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var91 string
-			templ_7745c5c3_Var91, templ_7745c5c3_Err = templ.JoinStringErrs(card.PriorityDetail)
+			templ_7745c5c3_Var91, templ_7745c5c3_Err = templ.JoinStringErrs(boardBoolAttr(card.PriorityTop))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 612, Col: 48}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 657, Col: 62}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var91))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 156, "\" onclick=\"event.stopPropagation()\"><span class=\"min-w-0 truncate\">")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 157, "\" data-help-trigger data-help-scope=\"dispatch-priority\" data-help-term=\"")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var92 string
-			templ_7745c5c3_Var92, templ_7745c5c3_Err = templ.JoinStringErrs(card.PriorityBadge)
+			templ_7745c5c3_Var92, templ_7745c5c3_Err = templ.JoinStringErrs(card.DomID + "-priority")
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 614, Col: 56}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 660, Col: 46}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var92))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 157, "</span></span> ")
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
-		}
-		if card.MetaRight != "" {
-			templ_7745c5c3_Err = primitives.TrackerReferenceLinkIsolated(card.MetaRight, card.PRURL, "ml-auto flex-none whitespace-nowrap tabular-nums").Render(ctx, templ_7745c5c3_Buffer)
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
-		} else if card.MoveDisabledText != "" {
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 158, "<span class=\"ml-auto flex-none rounded-chip border border-line px-1.5 py-0.5 text-2xs text-dim\" title=\"")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 158, "\" data-help-title=\"")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var93 string
-			templ_7745c5c3_Var93, templ_7745c5c3_Err = templ.JoinStringErrs(card.MoveDisabledText)
+			templ_7745c5c3_Var93, templ_7745c5c3_Err = templ.JoinStringErrs(card.PriorityTitle)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 619, Col: 129}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 661, Col: 41}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var93))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 159, "\" data-kanban-move-disabled-label>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 159, "\" data-help-description=\"")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var94 string
-			templ_7745c5c3_Var94, templ_7745c5c3_Err = templ.JoinStringErrs(card.MoveDisabledLabel)
+			templ_7745c5c3_Var94, templ_7745c5c3_Err = templ.JoinStringErrs(card.PriorityDetail)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 619, Col: 188}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 662, Col: 48}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var94))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 160, "</span>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 160, "\" onclick=\"event.stopPropagation()\"><span class=\"min-w-0 truncate\">")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-		} else if card.Done {
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 161, "<span class=\"ml-auto text-ok\" role=\"img\" aria-label=\"done\">✓</span>")
+			var templ_7745c5c3_Var95 string
+			templ_7745c5c3_Var95, templ_7745c5c3_Err = templ.JoinStringErrs(card.PriorityBadge)
+			if templ_7745c5c3_Err != nil {
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 664, Col: 56}
+			}
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var95))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 162, "</div>")
-		if templ_7745c5c3_Err != nil {
-			return templ_7745c5c3_Err
-		}
-		var templ_7745c5c3_Var95 = []any{boardCardTitleClass(card)}
-		templ_7745c5c3_Err = templ.RenderCSSItems(ctx, templ_7745c5c3_Buffer, templ_7745c5c3_Var95...)
-		if templ_7745c5c3_Err != nil {
-			return templ_7745c5c3_Err
-		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 163, "<div class=\"")
-		if templ_7745c5c3_Err != nil {
-			return templ_7745c5c3_Err
-		}
-		var templ_7745c5c3_Var96 string
-		templ_7745c5c3_Var96, templ_7745c5c3_Err = templ.JoinStringErrs(templ.CSSClasses(templ_7745c5c3_Var95).String())
-		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 1, Col: 0}
-		}
-		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var96))
-		if templ_7745c5c3_Err != nil {
-			return templ_7745c5c3_Err
-		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 164, "\" data-board-card-title>")
-		if templ_7745c5c3_Err != nil {
-			return templ_7745c5c3_Err
-		}
-		var templ_7745c5c3_Var97 string
-		templ_7745c5c3_Var97, templ_7745c5c3_Err = templ.JoinStringErrs(card.Title)
-		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 624, Col: 77}
-		}
-		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var97))
-		if templ_7745c5c3_Err != nil {
-			return templ_7745c5c3_Err
-		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 165, "</div><div class=\"min-w-0 items-center gap-1.5 font-mono text-2xs text-sec\" data-board-card-content=\"compact\"><span class=\"flex-none font-medium text-text\" data-board-card-state>")
-		if templ_7745c5c3_Err != nil {
-			return templ_7745c5c3_Err
-		}
-		var templ_7745c5c3_Var98 string
-		templ_7745c5c3_Var98, templ_7745c5c3_Err = templ.JoinStringErrs(card.State)
-		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 626, Col: 83}
-		}
-		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var98))
-		if templ_7745c5c3_Err != nil {
-			return templ_7745c5c3_Err
-		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 166, "</span> ")
-		if templ_7745c5c3_Err != nil {
-			return templ_7745c5c3_Err
-		}
-		if card.CompactSignal != "" {
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 167, "<span aria-hidden=\"true\">·</span> <span class=\"min-w-0 truncate\">")
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
-			var templ_7745c5c3_Var99 string
-			templ_7745c5c3_Var99, templ_7745c5c3_Err = templ.JoinStringErrs(card.CompactSignal)
-			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 629, Col: 55}
-			}
-			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var99))
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 168, "</span> ")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 161, "</span></span> ")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -1969,52 +1903,129 @@ func boardCardView2(card boardCardView) templ.Component {
 				return templ_7745c5c3_Err
 			}
 		} else if card.MoveDisabledText != "" {
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 169, "<span class=\"ml-auto flex-none rounded-chip border border-line px-1.5 py-0.5 text-2xs text-dim\" title=\"")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 162, "<span class=\"ml-auto flex-none rounded-chip border border-line px-1.5 py-0.5 text-2xs text-dim\" title=\"")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			var templ_7745c5c3_Var100 string
-			templ_7745c5c3_Var100, templ_7745c5c3_Err = templ.JoinStringErrs(card.MoveDisabledText)
+			var templ_7745c5c3_Var96 string
+			templ_7745c5c3_Var96, templ_7745c5c3_Err = templ.JoinStringErrs(card.MoveDisabledText)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 634, Col: 129}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 669, Col: 129}
 			}
-			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var100))
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 170, "\" data-kanban-move-disabled-label>")
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var96))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			var templ_7745c5c3_Var101 string
-			templ_7745c5c3_Var101, templ_7745c5c3_Err = templ.JoinStringErrs(card.MoveDisabledLabel)
-			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 634, Col: 188}
-			}
-			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var101))
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 163, "\" data-kanban-move-disabled-label>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 171, "</span>")
+			var templ_7745c5c3_Var97 string
+			templ_7745c5c3_Var97, templ_7745c5c3_Err = templ.JoinStringErrs(card.MoveDisabledLabel)
+			if templ_7745c5c3_Err != nil {
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 669, Col: 188}
+			}
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var97))
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 164, "</span>")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+		} else if card.Done {
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 165, "<span class=\"ml-auto text-ok\" role=\"img\" aria-label=\"done\">✓</span>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 172, "</div>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 166, "</div>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		if card.MetaRight != "" && card.MoveDisabledText != "" {
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 173, "<div class=\"flex\" data-board-card-expanded><span class=\"flex-none rounded-chip border border-line px-1.5 py-0.5 text-2xs text-dim\" title=\"")
+		var templ_7745c5c3_Var98 = []any{boardCardTitleClass(card)}
+		templ_7745c5c3_Err = templ.RenderCSSItems(ctx, templ_7745c5c3_Buffer, templ_7745c5c3_Var98...)
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 167, "<div class=\"")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		var templ_7745c5c3_Var99 string
+		templ_7745c5c3_Var99, templ_7745c5c3_Err = templ.JoinStringErrs(templ.CSSClasses(templ_7745c5c3_Var98).String())
+		if templ_7745c5c3_Err != nil {
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 1, Col: 0}
+		}
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var99))
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 168, "\" data-board-card-title>")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		var templ_7745c5c3_Var100 string
+		templ_7745c5c3_Var100, templ_7745c5c3_Err = templ.JoinStringErrs(card.Title)
+		if templ_7745c5c3_Err != nil {
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 674, Col: 77}
+		}
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var100))
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 169, "</div><div class=\"min-w-0 items-center gap-1.5 font-mono text-2xs text-sec\" data-board-card-content=\"compact\"><span class=\"flex-none font-medium text-text\" data-board-card-state>")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		var templ_7745c5c3_Var101 string
+		templ_7745c5c3_Var101, templ_7745c5c3_Err = templ.JoinStringErrs(card.State)
+		if templ_7745c5c3_Err != nil {
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 676, Col: 83}
+		}
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var101))
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 170, "</span> ")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		if card.CompactSignal != "" {
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 171, "<span aria-hidden=\"true\">·</span> <span class=\"min-w-0 truncate\">")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var102 string
-			templ_7745c5c3_Var102, templ_7745c5c3_Err = templ.JoinStringErrs(card.MoveDisabledText)
+			templ_7745c5c3_Var102, templ_7745c5c3_Err = templ.JoinStringErrs(card.CompactSignal)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 639, Col: 121}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 679, Col: 55}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var102))
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 172, "</span> ")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+		}
+		if card.MetaRight != "" {
+			templ_7745c5c3_Err = primitives.TrackerReferenceLinkIsolated(card.MetaRight, card.PRURL, "ml-auto flex-none whitespace-nowrap tabular-nums").Render(ctx, templ_7745c5c3_Buffer)
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+		} else if card.MoveDisabledText != "" {
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 173, "<span class=\"ml-auto flex-none rounded-chip border border-line px-1.5 py-0.5 text-2xs text-dim\" title=\"")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			var templ_7745c5c3_Var103 string
+			templ_7745c5c3_Var103, templ_7745c5c3_Err = templ.JoinStringErrs(card.MoveDisabledText)
+			if templ_7745c5c3_Err != nil {
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 684, Col: 129}
+			}
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var103))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -2022,16 +2033,52 @@ func boardCardView2(card boardCardView) templ.Component {
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			var templ_7745c5c3_Var103 string
-			templ_7745c5c3_Var103, templ_7745c5c3_Err = templ.JoinStringErrs(card.MoveDisabledLabel)
+			var templ_7745c5c3_Var104 string
+			templ_7745c5c3_Var104, templ_7745c5c3_Err = templ.JoinStringErrs(card.MoveDisabledLabel)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 639, Col: 180}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 684, Col: 188}
 			}
-			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var103))
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var104))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 175, "</span></div>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 175, "</span>")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 176, "</div>")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		if card.MetaRight != "" && card.MoveDisabledText != "" {
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 177, "<div class=\"flex\" data-board-card-expanded><span class=\"flex-none rounded-chip border border-line px-1.5 py-0.5 text-2xs text-dim\" title=\"")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			var templ_7745c5c3_Var105 string
+			templ_7745c5c3_Var105, templ_7745c5c3_Err = templ.JoinStringErrs(card.MoveDisabledText)
+			if templ_7745c5c3_Err != nil {
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 689, Col: 121}
+			}
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var105))
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 178, "\" data-kanban-move-disabled-label>")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			var templ_7745c5c3_Var106 string
+			templ_7745c5c3_Var106, templ_7745c5c3_Err = templ.JoinStringErrs(card.MoveDisabledLabel)
+			if templ_7745c5c3_Err != nil {
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 689, Col: 180}
+			}
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var106))
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 179, "</span></div>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -2043,38 +2090,38 @@ func boardCardView2(card boardCardView) templ.Component {
 			}
 		}
 		if card.MergeLaneStatus != "" {
-			var templ_7745c5c3_Var104 = []any{"flex items-center gap-1.5 text-2xs " + boardExtraTextClass(card.MergeLaneKind)}
-			templ_7745c5c3_Err = templ.RenderCSSItems(ctx, templ_7745c5c3_Buffer, templ_7745c5c3_Var104...)
+			var templ_7745c5c3_Var107 = []any{"flex items-center gap-1.5 text-2xs " + boardExtraTextClass(card.MergeLaneKind)}
+			templ_7745c5c3_Err = templ.RenderCSSItems(ctx, templ_7745c5c3_Buffer, templ_7745c5c3_Var107...)
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 176, "<div class=\"")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 180, "<div class=\"")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			var templ_7745c5c3_Var105 string
-			templ_7745c5c3_Var105, templ_7745c5c3_Err = templ.JoinStringErrs(templ.CSSClasses(templ_7745c5c3_Var104).String())
+			var templ_7745c5c3_Var108 string
+			templ_7745c5c3_Var108, templ_7745c5c3_Err = templ.JoinStringErrs(templ.CSSClasses(templ_7745c5c3_Var107).String())
 			if templ_7745c5c3_Err != nil {
 				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 1, Col: 0}
 			}
-			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var105))
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var108))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 177, "\" data-board-card-merge-lane data-board-card-expanded title=\"")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 181, "\" data-board-card-merge-lane data-board-card-expanded title=\"")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			var templ_7745c5c3_Var106 string
-			templ_7745c5c3_Var106, templ_7745c5c3_Err = templ.JoinStringErrs(card.MergeLaneDetail)
+			var templ_7745c5c3_Var109 string
+			templ_7745c5c3_Var109, templ_7745c5c3_Err = templ.JoinStringErrs(card.MergeLaneDetail)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 646, Col: 178}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 696, Col: 178}
 			}
-			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var106))
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var109))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 178, "\">")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 182, "\">")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -2082,39 +2129,39 @@ func boardCardView2(card boardCardView) templ.Component {
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 179, "<span class=\"font-medium\">")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 183, "<span class=\"font-medium\">")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			var templ_7745c5c3_Var107 string
-			templ_7745c5c3_Var107, templ_7745c5c3_Err = templ.JoinStringErrs(card.MergeLaneStatus)
+			var templ_7745c5c3_Var110 string
+			templ_7745c5c3_Var110, templ_7745c5c3_Err = templ.JoinStringErrs(card.MergeLaneStatus)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 648, Col: 52}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 698, Col: 52}
 			}
-			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var107))
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 180, "</span> <span class=\"min-w-0 truncate font-mono\">")
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var110))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			var templ_7745c5c3_Var108 string
-			templ_7745c5c3_Var108, templ_7745c5c3_Err = templ.JoinStringErrs(card.MergeLaneDetail)
-			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 649, Col: 67}
-			}
-			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var108))
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 184, "</span> <span class=\"min-w-0 truncate font-mono\">")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 181, "</span></div>")
+			var templ_7745c5c3_Var111 string
+			templ_7745c5c3_Var111, templ_7745c5c3_Err = templ.JoinStringErrs(card.MergeLaneDetail)
+			if templ_7745c5c3_Err != nil {
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 699, Col: 67}
+			}
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var111))
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 185, "</span></div>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 		}
 		if card.OriginDetail != "" {
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 182, "<div class=\"flex items-center gap-1.5 text-2xs text-info\" data-board-card-origin data-board-card-expanded>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 186, "<div class=\"flex items-center gap-1.5 text-2xs text-info\" data-board-card-origin data-board-card-expanded>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -2122,27 +2169,27 @@ func boardCardView2(card boardCardView) templ.Component {
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 183, "<span class=\"min-w-0 truncate font-mono\">")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 187, "<span class=\"min-w-0 truncate font-mono\">")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			var templ_7745c5c3_Var109 string
-			templ_7745c5c3_Var109, templ_7745c5c3_Err = templ.JoinStringErrs(card.OriginDetail)
+			var templ_7745c5c3_Var112 string
+			templ_7745c5c3_Var112, templ_7745c5c3_Err = templ.JoinStringErrs(card.OriginDetail)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 655, Col: 64}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 705, Col: 64}
 			}
-			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var109))
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var112))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 184, "</span></div>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 188, "</span></div>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 		}
 		if card.ExtraText != "" && (!card.RuntimeBadge || card.ExtraText != "agent working") {
 			if card.ExtraChip {
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 185, "<div class=\"flex\" data-board-card-expanded>")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 189, "<div class=\"flex\" data-board-card-expanded>")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
@@ -2150,30 +2197,30 @@ func boardCardView2(card boardCardView) templ.Component {
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 186, "</div>")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 190, "</div>")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
 			} else {
-				var templ_7745c5c3_Var110 = []any{"flex items-center gap-1.5 text-2xs " + boardExtraTextClass(card.ExtraKind)}
-				templ_7745c5c3_Err = templ.RenderCSSItems(ctx, templ_7745c5c3_Buffer, templ_7745c5c3_Var110...)
+				var templ_7745c5c3_Var113 = []any{"flex items-center gap-1.5 text-2xs " + boardExtraTextClass(card.ExtraKind)}
+				templ_7745c5c3_Err = templ.RenderCSSItems(ctx, templ_7745c5c3_Buffer, templ_7745c5c3_Var113...)
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 187, "<div class=\"")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 191, "<div class=\"")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				var templ_7745c5c3_Var111 string
-				templ_7745c5c3_Var111, templ_7745c5c3_Err = templ.JoinStringErrs(templ.CSSClasses(templ_7745c5c3_Var110).String())
+				var templ_7745c5c3_Var114 string
+				templ_7745c5c3_Var114, templ_7745c5c3_Err = templ.JoinStringErrs(templ.CSSClasses(templ_7745c5c3_Var113).String())
 				if templ_7745c5c3_Err != nil {
 					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 1, Col: 0}
 				}
-				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var111))
+				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var114))
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 188, "\" data-board-card-expanded>")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 192, "\" data-board-card-expanded>")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
@@ -2181,144 +2228,144 @@ func boardCardView2(card boardCardView) templ.Component {
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				var templ_7745c5c3_Var112 string
-				templ_7745c5c3_Var112, templ_7745c5c3_Err = templ.JoinStringErrs(card.ExtraText)
+				var templ_7745c5c3_Var115 string
+				templ_7745c5c3_Var115, templ_7745c5c3_Err = templ.JoinStringErrs(card.ExtraText)
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 666, Col: 21}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 716, Col: 21}
 				}
-				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var112))
+				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var115))
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 189, "</div>")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 193, "</div>")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
 			}
 		}
 		if card.BlockerSummary != "" {
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 190, "<div class=\"min-w-0 text-2xs text-sec\" data-board-card-blockers data-board-card-expanded><span class=\"text-dim\">Blocker refs</span> ")
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
-			var templ_7745c5c3_Var113 string
-			templ_7745c5c3_Var113, templ_7745c5c3_Err = templ.JoinStringErrs(card.BlockerSummary)
-			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 672, Col: 68}
-			}
-			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var113))
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 191, "</div>")
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
-		}
-		if card.ParkSummary != "" {
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 192, "<div id=\"")
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
-			var templ_7745c5c3_Var114 string
-			templ_7745c5c3_Var114, templ_7745c5c3_Err = templ.JoinStringErrs(card.DomID + "-park-summary")
-			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 677, Col: 37}
-			}
-			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var114))
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 193, "\" class=\"min-w-0 truncate font-mono text-2xs text-sec\" tabindex=\"0\" role=\"img\" aria-label=\"")
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
-			var templ_7745c5c3_Var115 string
-			templ_7745c5c3_Var115, templ_7745c5c3_Err = templ.JoinStringErrs("Park history: " + card.ParkDetail)
-			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 681, Col: 51}
-			}
-			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var115))
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 194, "\" data-board-card-park-summary data-board-card-expanded data-help-trigger data-help-scope=\"park-history\" data-help-term=\"")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 194, "<div class=\"min-w-0 text-2xs text-sec\" data-board-card-blockers data-board-card-expanded><span class=\"text-dim\">Blocker refs</span> ")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var116 string
-			templ_7745c5c3_Var116, templ_7745c5c3_Err = templ.JoinStringErrs(card.DomID + "-park-summary")
+			templ_7745c5c3_Var116, templ_7745c5c3_Err = templ.JoinStringErrs(card.BlockerSummary)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 686, Col: 49}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 722, Col: 68}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var116))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 195, "\" data-help-title=\"Park history\" data-help-description=\"")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 195, "</div>")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+		}
+		if card.ParkSummary != "" {
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 196, "<div id=\"")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var117 string
-			templ_7745c5c3_Var117, templ_7745c5c3_Err = templ.JoinStringErrs(card.ParkDetail)
+			templ_7745c5c3_Var117, templ_7745c5c3_Err = templ.JoinStringErrs(card.DomID + "-park-summary")
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 688, Col: 43}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 727, Col: 37}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var117))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 196, "\">")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 197, "\" class=\"min-w-0 truncate font-mono text-2xs text-sec\" tabindex=\"0\" role=\"img\" aria-label=\"")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var118 string
-			templ_7745c5c3_Var118, templ_7745c5c3_Err = templ.JoinStringErrs(card.ParkSummary)
+			templ_7745c5c3_Var118, templ_7745c5c3_Err = templ.JoinStringErrs("Park history: " + card.ParkDetail)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 689, Col: 22}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 731, Col: 51}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var118))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 197, "</div>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 198, "\" data-board-card-park-summary data-board-card-expanded data-help-trigger data-help-scope=\"park-history\" data-help-term=\"")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-		}
-		if card.ProgressSummary != "" {
-			var templ_7745c5c3_Var119 = []any{"flex items-center gap-1.5 text-2xs " + boardExtraTextClass(card.ProgressKind)}
-			templ_7745c5c3_Err = templ.RenderCSSItems(ctx, templ_7745c5c3_Buffer, templ_7745c5c3_Var119...)
+			var templ_7745c5c3_Var119 string
+			templ_7745c5c3_Var119, templ_7745c5c3_Err = templ.JoinStringErrs(card.DomID + "-park-summary")
+			if templ_7745c5c3_Err != nil {
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 736, Col: 49}
+			}
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var119))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 198, "<div class=\"")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 199, "\" data-help-title=\"Park history\" data-help-description=\"")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var120 string
-			templ_7745c5c3_Var120, templ_7745c5c3_Err = templ.JoinStringErrs(templ.CSSClasses(templ_7745c5c3_Var119).String())
+			templ_7745c5c3_Var120, templ_7745c5c3_Err = templ.JoinStringErrs(card.ParkDetail)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 1, Col: 0}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 738, Col: 43}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var120))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 199, "\" title=\"")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 200, "\">")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var121 string
-			templ_7745c5c3_Var121, templ_7745c5c3_Err = templ.JoinStringErrs(card.ProgressDetail)
+			templ_7745c5c3_Var121, templ_7745c5c3_Err = templ.JoinStringErrs(card.ParkSummary)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 692, Col: 124}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 739, Col: 22}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var121))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 200, "\" data-board-card-progress data-board-card-expanded>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 201, "</div>")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+		}
+		if card.ProgressSummary != "" {
+			var templ_7745c5c3_Var122 = []any{"flex items-center gap-1.5 text-2xs " + boardExtraTextClass(card.ProgressKind)}
+			templ_7745c5c3_Err = templ.RenderCSSItems(ctx, templ_7745c5c3_Buffer, templ_7745c5c3_Var122...)
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 202, "<div class=\"")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			var templ_7745c5c3_Var123 string
+			templ_7745c5c3_Var123, templ_7745c5c3_Err = templ.JoinStringErrs(templ.CSSClasses(templ_7745c5c3_Var122).String())
+			if templ_7745c5c3_Err != nil {
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 1, Col: 0}
+			}
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var123))
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 203, "\" title=\"")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			var templ_7745c5c3_Var124 string
+			templ_7745c5c3_Var124, templ_7745c5c3_Err = templ.JoinStringErrs(card.ProgressDetail)
+			if templ_7745c5c3_Err != nil {
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 742, Col: 124}
+			}
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var124))
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 204, "\" data-board-card-progress data-board-card-expanded>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -2326,185 +2373,185 @@ func boardCardView2(card boardCardView) templ.Component {
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 201, "<span class=\"min-w-0 truncate font-mono\">")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 205, "<span class=\"min-w-0 truncate font-mono\">")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			var templ_7745c5c3_Var122 string
-			templ_7745c5c3_Var122, templ_7745c5c3_Err = templ.JoinStringErrs(card.ProgressSummary)
+			var templ_7745c5c3_Var125 string
+			templ_7745c5c3_Var125, templ_7745c5c3_Err = templ.JoinStringErrs(card.ProgressSummary)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 694, Col: 67}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 744, Col: 67}
 			}
-			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var122))
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var125))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 202, "</span></div>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 206, "</span></div>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 		}
 		if card.AgeFooter != "" {
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 203, "<div class=\"mt-0.5 flex items-center justify-between gap-2 border-t border-line/70 pt-1.5 font-mono text-2xs text-sec\" title=\"")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 207, "<div class=\"mt-0.5 flex items-center justify-between gap-2 border-t border-line/70 pt-1.5 font-mono text-2xs text-sec\" title=\"")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			var templ_7745c5c3_Var123 string
-			templ_7745c5c3_Var123, templ_7745c5c3_Err = templ.JoinStringErrs(card.AgeFooterTitle)
+			var templ_7745c5c3_Var126 string
+			templ_7745c5c3_Var126, templ_7745c5c3_Err = templ.JoinStringErrs(card.AgeFooterTitle)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 698, Col: 149}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 748, Col: 149}
 			}
-			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var123))
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 204, "\" data-board-card-age-footer data-board-card-expanded><span class=\"min-w-0 truncate\">In lane</span> <span class=\"flex-none whitespace-nowrap tabular-nums\">")
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var126))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			var templ_7745c5c3_Var124 string
-			templ_7745c5c3_Var124, templ_7745c5c3_Err = templ.JoinStringErrs(card.AgeFooter)
-			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 700, Col: 75}
-			}
-			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var124))
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 208, "\" data-board-card-age-footer data-board-card-expanded><span class=\"min-w-0 truncate\">In lane</span> <span class=\"flex-none whitespace-nowrap tabular-nums\">")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 205, "</span></div>")
+			var templ_7745c5c3_Var127 string
+			templ_7745c5c3_Var127, templ_7745c5c3_Err = templ.JoinStringErrs(card.AgeFooter)
+			if templ_7745c5c3_Err != nil {
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 750, Col: 75}
+			}
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var127))
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 209, "</span></div>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 		}
 		if card.AuthorDetail != "" || len(card.Labels) > 0 || card.Effort != "" || card.Activity != "" || card.PRStatus != "" {
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 206, "<div class=\"gap-1.5 border-t border-line/70 pt-1.5 text-2xs text-sec\" data-board-card-content=\"comfy\">")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 210, "<div class=\"gap-1.5 border-t border-line/70 pt-1.5 text-2xs text-sec\" data-board-card-content=\"comfy\">")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			if card.AuthorDetail != "" {
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 207, "<div class=\"flex min-w-0 items-center gap-1.5\" data-board-card-author><span class=\"flex-none text-dim\">Filed by</span> <span class=\"min-w-0 truncate font-mono text-text\">")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 211, "<div class=\"flex min-w-0 items-center gap-1.5\" data-board-card-author><span class=\"flex-none text-dim\">Filed by</span> <span class=\"min-w-0 truncate font-mono text-text\">")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				var templ_7745c5c3_Var125 string
-				templ_7745c5c3_Var125, templ_7745c5c3_Err = templ.JoinStringErrs(card.AuthorDetail)
+				var templ_7745c5c3_Var128 string
+				templ_7745c5c3_Var128, templ_7745c5c3_Err = templ.JoinStringErrs(card.AuthorDetail)
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 708, Col: 76}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 758, Col: 76}
 				}
-				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var125))
+				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var128))
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 208, "</span></div>")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 212, "</span></div>")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
 			}
 			if len(card.Labels) > 0 {
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 209, "<div class=\"flex min-w-0 flex-wrap gap-1\" data-board-card-labels>")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 213, "<div class=\"flex min-w-0 flex-wrap gap-1\" data-board-card-labels>")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
 				for _, label := range card.Labels {
-					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 210, "<span class=\"max-w-full truncate rounded-chip bg-surface px-1.5 py-0.5\">")
+					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 214, "<span class=\"max-w-full truncate rounded-chip bg-surface px-1.5 py-0.5\">")
 					if templ_7745c5c3_Err != nil {
 						return templ_7745c5c3_Err
 					}
-					var templ_7745c5c3_Var126 string
-					templ_7745c5c3_Var126, templ_7745c5c3_Err = templ.JoinStringErrs(label)
+					var templ_7745c5c3_Var129 string
+					templ_7745c5c3_Var129, templ_7745c5c3_Err = templ.JoinStringErrs(label)
 					if templ_7745c5c3_Err != nil {
-						return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 714, Col: 86}
+						return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 764, Col: 86}
 					}
-					_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var126))
-					if templ_7745c5c3_Err != nil {
-						return templ_7745c5c3_Err
-					}
-					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 211, "</span>")
+					_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var129))
 					if templ_7745c5c3_Err != nil {
 						return templ_7745c5c3_Err
 					}
-				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 212, "</div>")
-				if templ_7745c5c3_Err != nil {
-					return templ_7745c5c3_Err
-				}
-			}
-			if card.Effort != "" {
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 213, "<div class=\"flex min-w-0 items-center gap-1.5\" data-board-card-effort><span class=\"text-dim\">Effort</span> <span class=\"truncate font-mono text-text\">")
-				if templ_7745c5c3_Err != nil {
-					return templ_7745c5c3_Err
-				}
-				var templ_7745c5c3_Var127 string
-				templ_7745c5c3_Var127, templ_7745c5c3_Err = templ.JoinStringErrs(card.Effort)
-				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 721, Col: 62}
-				}
-				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var127))
-				if templ_7745c5c3_Err != nil {
-					return templ_7745c5c3_Err
-				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 214, "</span></div>")
-				if templ_7745c5c3_Err != nil {
-					return templ_7745c5c3_Err
-				}
-			}
-			if card.Activity != "" {
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 215, "<div class=\"line-clamp-2 min-w-0\" data-board-card-activity><span class=\"text-dim\">Activity</span> ")
-				if templ_7745c5c3_Err != nil {
-					return templ_7745c5c3_Err
-				}
-				var templ_7745c5c3_Var128 string
-				templ_7745c5c3_Var128, templ_7745c5c3_Err = templ.JoinStringErrs(card.Activity)
-				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 725, Col: 118}
-				}
-				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var128))
-				if templ_7745c5c3_Err != nil {
-					return templ_7745c5c3_Err
+					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 215, "</span>")
+					if templ_7745c5c3_Err != nil {
+						return templ_7745c5c3_Err
+					}
 				}
 				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 216, "</div>")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
 			}
-			if card.PRStatus != "" {
-				var templ_7745c5c3_Var129 = []any{"w-fit rounded-chip border px-1.5 py-0.5 font-mono " + card.PRStatusClass}
-				templ_7745c5c3_Err = templ.RenderCSSItems(ctx, templ_7745c5c3_Buffer, templ_7745c5c3_Var129...)
-				if templ_7745c5c3_Err != nil {
-					return templ_7745c5c3_Err
-				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 217, "<div class=\"")
+			if card.Effort != "" {
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 217, "<div class=\"flex min-w-0 items-center gap-1.5\" data-board-card-effort><span class=\"text-dim\">Effort</span> <span class=\"truncate font-mono text-text\">")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
 				var templ_7745c5c3_Var130 string
-				templ_7745c5c3_Var130, templ_7745c5c3_Err = templ.JoinStringErrs(templ.CSSClasses(templ_7745c5c3_Var129).String())
+				templ_7745c5c3_Var130, templ_7745c5c3_Err = templ.JoinStringErrs(card.Effort)
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 1, Col: 0}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 771, Col: 62}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var130))
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 218, "\" data-board-card-pr-status>")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 218, "</span></div>")
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+			}
+			if card.Activity != "" {
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 219, "<div class=\"line-clamp-2 min-w-0\" data-board-card-activity><span class=\"text-dim\">Activity</span> ")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
 				var templ_7745c5c3_Var131 string
-				templ_7745c5c3_Var131, templ_7745c5c3_Err = templ.JoinStringErrs(card.PRStatus)
+				templ_7745c5c3_Var131, templ_7745c5c3_Err = templ.JoinStringErrs(card.Activity)
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 728, Col: 135}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 775, Col: 118}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var131))
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 219, "</div>")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 220, "</div>")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 220, "</div>")
+			if card.PRStatus != "" {
+				var templ_7745c5c3_Var132 = []any{"w-fit rounded-chip border px-1.5 py-0.5 font-mono " + card.PRStatusClass}
+				templ_7745c5c3_Err = templ.RenderCSSItems(ctx, templ_7745c5c3_Buffer, templ_7745c5c3_Var132...)
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 221, "<div class=\"")
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+				var templ_7745c5c3_Var133 string
+				templ_7745c5c3_Var133, templ_7745c5c3_Err = templ.JoinStringErrs(templ.CSSClasses(templ_7745c5c3_Var132).String())
+				if templ_7745c5c3_Err != nil {
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 1, Col: 0}
+				}
+				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var133))
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 222, "\" data-board-card-pr-status>")
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+				var templ_7745c5c3_Var134 string
+				templ_7745c5c3_Var134, templ_7745c5c3_Err = templ.JoinStringErrs(card.PRStatus)
+				if templ_7745c5c3_Err != nil {
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 778, Col: 135}
+				}
+				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var134))
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 223, "</div>")
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 224, "</div>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -2515,7 +2562,7 @@ func boardCardView2(card boardCardView) templ.Component {
 				return templ_7745c5c3_Err
 			}
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 221, "</article>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 225, "</article>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -2539,74 +2586,74 @@ func boardRuntimeBadge(card boardCardView) templ.Component {
 			}()
 		}
 		ctx = templ.InitializeContext(ctx)
-		templ_7745c5c3_Var132 := templ.GetChildren(ctx)
-		if templ_7745c5c3_Var132 == nil {
-			templ_7745c5c3_Var132 = templ.NopComponent
+		templ_7745c5c3_Var135 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var135 == nil {
+			templ_7745c5c3_Var135 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 222, "<div id=\"")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 226, "<div id=\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		var templ_7745c5c3_Var133 string
-		templ_7745c5c3_Var133, templ_7745c5c3_Err = templ.JoinStringErrs(card.DomID + "-runtime-badge")
+		var templ_7745c5c3_Var136 string
+		templ_7745c5c3_Var136, templ_7745c5c3_Err = templ.JoinStringErrs(card.DomID + "-runtime-badge")
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 740, Col: 36}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 790, Col: 36}
 		}
-		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var133))
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var136))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 223, "\" class=\"flex min-w-0 items-center gap-1.5 text-2xs text-ok\" data-board-runtime-badge data-board-card-expanded")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 227, "\" class=\"flex min-w-0 items-center gap-1.5 text-2xs text-ok\" data-board-runtime-badge data-board-card-expanded")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		if card.RuntimeSummary != "" {
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 224, " tabindex=\"0\" role=\"img\" aria-label=\"")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 228, " tabindex=\"0\" role=\"img\" aria-label=\"")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			var templ_7745c5c3_Var134 string
-			templ_7745c5c3_Var134, templ_7745c5c3_Err = templ.JoinStringErrs("Agent runtime: " + card.RuntimeSummary)
+			var templ_7745c5c3_Var137 string
+			templ_7745c5c3_Var137, templ_7745c5c3_Err = templ.JoinStringErrs("Agent runtime: " + card.RuntimeSummary)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 747, Col: 55}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 797, Col: 55}
 			}
-			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var134))
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 225, "\" data-help-trigger data-help-scope=\"runtime-identity\" data-help-term=\"")
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var137))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			var templ_7745c5c3_Var135 string
-			templ_7745c5c3_Var135, templ_7745c5c3_Err = templ.JoinStringErrs(card.DomID + "-runtime-identity")
-			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 750, Col: 52}
-			}
-			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var135))
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 229, "\" data-help-trigger data-help-scope=\"runtime-identity\" data-help-term=\"")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 226, "\" data-help-title=\"Agent runtime\" data-help-description=\"")
+			var templ_7745c5c3_Var138 string
+			templ_7745c5c3_Var138, templ_7745c5c3_Err = templ.JoinStringErrs(card.DomID + "-runtime-identity")
+			if templ_7745c5c3_Err != nil {
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 800, Col: 52}
+			}
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var138))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			var templ_7745c5c3_Var136 string
-			templ_7745c5c3_Var136, templ_7745c5c3_Err = templ.JoinStringErrs(card.RuntimeDetail)
-			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 752, Col: 45}
-			}
-			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var136))
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 230, "\" data-help-title=\"Agent runtime\" data-help-description=\"")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 227, "\" onclick=\"event.stopPropagation()\"")
+			var templ_7745c5c3_Var139 string
+			templ_7745c5c3_Var139, templ_7745c5c3_Err = templ.JoinStringErrs(card.RuntimeDetail)
+			if templ_7745c5c3_Err != nil {
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 802, Col: 45}
+			}
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var139))
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 231, "\" onclick=\"event.stopPropagation()\"")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 228, ">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 232, ">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -2614,33 +2661,33 @@ func boardRuntimeBadge(card boardCardView) templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 229, "<span class=\"min-w-0 truncate font-mono\"><span class=\"runtime-badge-cozy\" data-runtime-density=\"cozy\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 233, "<span class=\"min-w-0 truncate font-mono\"><span class=\"runtime-badge-cozy\" data-runtime-density=\"cozy\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		var templ_7745c5c3_Var137 string
-		templ_7745c5c3_Var137, templ_7745c5c3_Err = templ.JoinStringErrs(card.RuntimeCozyText)
+		var templ_7745c5c3_Var140 string
+		templ_7745c5c3_Var140, templ_7745c5c3_Err = templ.JoinStringErrs(card.RuntimeCozyText)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 758, Col: 86}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 808, Col: 86}
 		}
-		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var137))
-		if templ_7745c5c3_Err != nil {
-			return templ_7745c5c3_Err
-		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 230, "</span> <span class=\"runtime-badge-comfy\" data-runtime-density=\"comfy\">")
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var140))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		var templ_7745c5c3_Var138 string
-		templ_7745c5c3_Var138, templ_7745c5c3_Err = templ.JoinStringErrs(card.RuntimeComfyText)
-		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 759, Col: 89}
-		}
-		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var138))
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 234, "</span> <span class=\"runtime-badge-comfy\" data-runtime-density=\"comfy\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 231, "</span></span></div>")
+		var templ_7745c5c3_Var141 string
+		templ_7745c5c3_Var141, templ_7745c5c3_Err = templ.JoinStringErrs(card.RuntimeComfyText)
+		if templ_7745c5c3_Err != nil {
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 809, Col: 89}
+		}
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var141))
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 235, "</span></span></div>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -2664,87 +2711,87 @@ func boardKanbanDragMoveForm(card boardCardView) templ.Component {
 			}()
 		}
 		ctx = templ.InitializeContext(ctx)
-		templ_7745c5c3_Var139 := templ.GetChildren(ctx)
-		if templ_7745c5c3_Var139 == nil {
-			templ_7745c5c3_Var139 = templ.NopComponent
+		templ_7745c5c3_Var142 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var142 == nil {
+			templ_7745c5c3_Var142 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 232, "<form class=\"hidden\" hx-post=\"/api/v1/kanban/move\" hx-target=\"#snapshot\" hx-swap=\"morph:innerHTML\" data-kanban-drag-move-form><input type=\"hidden\" name=\"kanban_drag\" value=\"true\"> <input type=\"hidden\" name=\"kanban_board\" value=\"")
-		if templ_7745c5c3_Err != nil {
-			return templ_7745c5c3_Err
-		}
-		var templ_7745c5c3_Var140 string
-		templ_7745c5c3_Var140, templ_7745c5c3_Err = templ.JoinStringErrs(card.Scope)
-		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 767, Col: 61}
-		}
-		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var140))
-		if templ_7745c5c3_Err != nil {
-			return templ_7745c5c3_Err
-		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 233, "\"> <input type=\"hidden\" name=\"project_id\" value=\"")
-		if templ_7745c5c3_Err != nil {
-			return templ_7745c5c3_Err
-		}
-		var templ_7745c5c3_Var141 string
-		templ_7745c5c3_Var141, templ_7745c5c3_Err = templ.JoinStringErrs(card.MoveProject)
-		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 768, Col: 65}
-		}
-		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var141))
-		if templ_7745c5c3_Err != nil {
-			return templ_7745c5c3_Err
-		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 234, "\"> <input type=\"hidden\" name=\"issue_id\" value=\"")
-		if templ_7745c5c3_Err != nil {
-			return templ_7745c5c3_Err
-		}
-		var templ_7745c5c3_Var142 string
-		templ_7745c5c3_Var142, templ_7745c5c3_Err = templ.JoinStringErrs(card.IssueID)
-		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 769, Col: 59}
-		}
-		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var142))
-		if templ_7745c5c3_Err != nil {
-			return templ_7745c5c3_Err
-		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 235, "\"> <input type=\"hidden\" name=\"current_state\" value=\"")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 236, "<form class=\"hidden\" hx-post=\"/api/v1/kanban/move\" hx-target=\"#snapshot\" hx-swap=\"morph:innerHTML\" data-kanban-drag-move-form><input type=\"hidden\" name=\"kanban_drag\" value=\"true\"> <input type=\"hidden\" name=\"kanban_board\" value=\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		var templ_7745c5c3_Var143 string
-		templ_7745c5c3_Var143, templ_7745c5c3_Err = templ.JoinStringErrs(card.CurrentState)
+		templ_7745c5c3_Var143, templ_7745c5c3_Err = templ.JoinStringErrs(card.Scope)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 770, Col: 69}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 817, Col: 61}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var143))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 236, "\"> <input type=\"hidden\" name=\"target_state\" value=\"\" data-kanban-drag-target-state> ")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 237, "\"> <input type=\"hidden\" name=\"project_id\" value=\"")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		var templ_7745c5c3_Var144 string
+		templ_7745c5c3_Var144, templ_7745c5c3_Err = templ.JoinStringErrs(card.MoveProject)
+		if templ_7745c5c3_Err != nil {
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 818, Col: 65}
+		}
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var144))
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 238, "\"> <input type=\"hidden\" name=\"issue_id\" value=\"")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		var templ_7745c5c3_Var145 string
+		templ_7745c5c3_Var145, templ_7745c5c3_Err = templ.JoinStringErrs(card.IssueID)
+		if templ_7745c5c3_Err != nil {
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 819, Col: 59}
+		}
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var145))
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 239, "\"> <input type=\"hidden\" name=\"current_state\" value=\"")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		var templ_7745c5c3_Var146 string
+		templ_7745c5c3_Var146, templ_7745c5c3_Err = templ.JoinStringErrs(card.CurrentState)
+		if templ_7745c5c3_Err != nil {
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 820, Col: 69}
+		}
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var146))
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 240, "\"> <input type=\"hidden\" name=\"target_state\" value=\"\" data-kanban-drag-target-state> ")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		if card.PRNumber != "" {
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 237, "<input type=\"hidden\" name=\"pr_number\" value=\"")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 241, "<input type=\"hidden\" name=\"pr_number\" value=\"")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			var templ_7745c5c3_Var144 string
-			templ_7745c5c3_Var144, templ_7745c5c3_Err = templ.JoinStringErrs(card.PRNumber)
+			var templ_7745c5c3_Var147 string
+			templ_7745c5c3_Var147, templ_7745c5c3_Err = templ.JoinStringErrs(card.PRNumber)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 773, Col: 62}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 823, Col: 62}
 			}
-			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var144))
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var147))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 238, "\">")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 242, "\">")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 239, "</form>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 243, "</form>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -2771,74 +2818,74 @@ func boardLanePicker(view boardView) templ.Component {
 			}()
 		}
 		ctx = templ.InitializeContext(ctx)
-		templ_7745c5c3_Var145 := templ.GetChildren(ctx)
-		if templ_7745c5c3_Var145 == nil {
-			templ_7745c5c3_Var145 = templ.NopComponent
+		templ_7745c5c3_Var148 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var148 == nil {
+			templ_7745c5c3_Var148 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 240, "<details id=\"board-lane-picker\" class=\"relative col-span-3 justify-self-start md:col-span-1\" data-board-lane-picker data-preserve-details=\"board-lane-picker\"><summary class=\"flex min-h-11 cursor-pointer list-none items-center gap-1.5 rounded-chip border border-line px-2.5 py-1 text-2xs text-sec hover:text-text [&::-webkit-details-marker]:hidden md:min-h-0\">Lanes <span data-board-lane-count class=\"tabular-nums\">")
-		if templ_7745c5c3_Err != nil {
-			return templ_7745c5c3_Err
-		}
-		var templ_7745c5c3_Var146 string
-		templ_7745c5c3_Var146, templ_7745c5c3_Err = templ.JoinStringErrs(boardLaneCountLabel(view))
-		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 784, Col: 85}
-		}
-		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var146))
-		if templ_7745c5c3_Err != nil {
-			return templ_7745c5c3_Err
-		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 241, "</span> <span class=\"rounded-chip bg-warn/15 px-1.5 py-0.5 font-mono text-warn\" data-board-hidden-card-count title=\"")
-		if templ_7745c5c3_Err != nil {
-			return templ_7745c5c3_Err
-		}
-		var templ_7745c5c3_Var147 string
-		templ_7745c5c3_Var147, templ_7745c5c3_Err = templ.JoinStringErrs(boardLaneHiddenCardSummary(view))
-		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 788, Col: 44}
-		}
-		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var147))
-		if templ_7745c5c3_Err != nil {
-			return templ_7745c5c3_Err
-		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 242, "\" aria-label=\"")
-		if templ_7745c5c3_Err != nil {
-			return templ_7745c5c3_Err
-		}
-		var templ_7745c5c3_Var148 string
-		templ_7745c5c3_Var148, templ_7745c5c3_Err = templ.JoinStringErrs(boardLaneHiddenCardSummary(view))
-		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 789, Col: 49}
-		}
-		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var148))
-		if templ_7745c5c3_Err != nil {
-			return templ_7745c5c3_Err
-		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 243, "\"")
-		if templ_7745c5c3_Err != nil {
-			return templ_7745c5c3_Err
-		}
-		if view.HiddenCards == 0 {
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 244, " hidden")
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
-		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 245, ">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 244, "<details id=\"board-lane-picker\" class=\"relative col-span-3 justify-self-start md:col-span-1\" data-board-lane-picker data-preserve-details=\"board-lane-picker\"><summary class=\"flex min-h-11 cursor-pointer list-none items-center gap-1.5 rounded-chip border border-line px-2.5 py-1 text-2xs text-sec hover:text-text [&::-webkit-details-marker]:hidden md:min-h-0\">Lanes <span data-board-lane-count class=\"tabular-nums\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		var templ_7745c5c3_Var149 string
-		templ_7745c5c3_Var149, templ_7745c5c3_Err = templ.JoinStringErrs(boardLaneHiddenCardBadgeLabel(view))
+		templ_7745c5c3_Var149, templ_7745c5c3_Err = templ.JoinStringErrs(boardLaneCountLabel(view))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 791, Col: 41}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 834, Col: 85}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var149))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 246, "</span>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 245, "</span> <span class=\"rounded-chip bg-warn/15 px-1.5 py-0.5 font-mono text-warn\" data-board-hidden-card-count title=\"")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		var templ_7745c5c3_Var150 string
+		templ_7745c5c3_Var150, templ_7745c5c3_Err = templ.JoinStringErrs(boardLaneHiddenCardSummary(view))
+		if templ_7745c5c3_Err != nil {
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 838, Col: 44}
+		}
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var150))
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 246, "\" aria-label=\"")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		var templ_7745c5c3_Var151 string
+		templ_7745c5c3_Var151, templ_7745c5c3_Err = templ.JoinStringErrs(boardLaneHiddenCardSummary(view))
+		if templ_7745c5c3_Err != nil {
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 839, Col: 49}
+		}
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var151))
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 247, "\"")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		if view.HiddenCards == 0 {
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 248, " hidden")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 249, ">")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		var templ_7745c5c3_Var152 string
+		templ_7745c5c3_Var152, templ_7745c5c3_Err = templ.JoinStringErrs(boardLaneHiddenCardBadgeLabel(view))
+		if templ_7745c5c3_Err != nil {
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 841, Col: 41}
+		}
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var152))
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 250, "</span>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -2846,7 +2893,7 @@ func boardLanePicker(view boardView) templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 247, "</summary><div class=\"absolute left-0 top-full z-40 mt-1 flex max-h-[calc(100vh-10rem)] w-[calc(100vw-2.5rem)] flex-col gap-1 overflow-y-auto rounded-card border border-line bg-elev p-1.5 md:left-auto md:right-0 md:max-h-none md:w-80 md:overflow-visible\"><div class=\"flex items-center justify-between gap-2 border-b border-line px-1 pb-1.5\"><span class=\"text-2xs font-medium uppercase text-sec\">Visibility</span> <button type=\"button\" class=\"inline-flex min-h-11 items-center gap-1.5 rounded-chip border border-line px-2 text-2xs font-medium text-sec hover:border-accent hover:text-accent disabled:pointer-events-none disabled:opacity-40 md:min-h-7\" data-board-lane-reset-all aria-label=\"Reset all lanes to Auto\" title=\"Reset all lanes to Auto\" disabled aria-disabled=\"true\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 251, "</summary><div class=\"absolute left-0 top-full z-40 mt-1 flex max-h-[calc(100vh-10rem)] w-[calc(100vw-2.5rem)] flex-col gap-1 overflow-y-auto rounded-card border border-line bg-elev p-1.5 md:left-auto md:right-0 md:max-h-none md:w-80 md:overflow-visible\"><div class=\"flex items-center justify-between gap-2 border-b border-line px-1 pb-1.5\"><span class=\"text-2xs font-medium uppercase text-sec\">Visibility</span> <button type=\"button\" class=\"inline-flex min-h-11 items-center gap-1.5 rounded-chip border border-line px-2 text-2xs font-medium text-sec hover:border-accent hover:text-accent disabled:pointer-events-none disabled:opacity-40 md:min-h-7\" data-board-lane-reset-all aria-label=\"Reset all lanes to Auto\" title=\"Reset all lanes to Auto\" disabled aria-disabled=\"true\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -2854,264 +2901,264 @@ func boardLanePicker(view boardView) templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 248, "<span>Reset all</span></button></div>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 252, "<span>Reset all</span></button></div>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		for _, lane := range view.Lanes {
-			var templ_7745c5c3_Var150 = []any{boardLaneVisibilityRowClass(lane)}
-			templ_7745c5c3_Err = templ.RenderCSSItems(ctx, templ_7745c5c3_Buffer, templ_7745c5c3_Var150...)
+			var templ_7745c5c3_Var153 = []any{boardLaneVisibilityRowClass(lane)}
+			templ_7745c5c3_Err = templ.RenderCSSItems(ctx, templ_7745c5c3_Buffer, templ_7745c5c3_Var153...)
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 249, "<div class=\"")
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
-			var templ_7745c5c3_Var151 string
-			templ_7745c5c3_Var151, templ_7745c5c3_Err = templ.JoinStringErrs(templ.CSSClasses(templ_7745c5c3_Var150).String())
-			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 1, Col: 0}
-			}
-			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var151))
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 250, "\" data-board-lane-row=\"")
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
-			var templ_7745c5c3_Var152 string
-			templ_7745c5c3_Var152, templ_7745c5c3_Err = templ.JoinStringErrs(lane.LaneID)
-			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 811, Col: 86}
-			}
-			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var152))
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 251, "\" data-board-lane-card-count=\"")
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
-			var templ_7745c5c3_Var153 string
-			templ_7745c5c3_Var153, templ_7745c5c3_Err = templ.JoinStringErrs(strconv.Itoa(lane.CardCount))
-			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 811, Col: 146}
-			}
-			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var153))
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 252, "\" data-board-lane-hidden-populated=\"")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 253, "<div class=\"")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var154 string
-			templ_7745c5c3_Var154, templ_7745c5c3_Err = templ.JoinStringErrs(boardBoolAttr(boardLaneHiddenPopulated(lane)))
+			templ_7745c5c3_Var154, templ_7745c5c3_Err = templ.JoinStringErrs(templ.CSSClasses(templ_7745c5c3_Var153).String())
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 811, Col: 229}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 1, Col: 0}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var154))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 253, "\"><div class=\"flex min-w-0 items-center gap-2\"><span class=\"min-w-0 flex-1 truncate font-medium\">")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 254, "\" data-board-lane-row=\"")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var155 string
-			templ_7745c5c3_Var155, templ_7745c5c3_Err = templ.JoinStringErrs(lane.Title)
+			templ_7745c5c3_Var155, templ_7745c5c3_Err = templ.JoinStringErrs(lane.LaneID)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 813, Col: 68}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 861, Col: 86}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var155))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 254, "</span> <span class=\"rounded-chip bg-surface px-1.5 py-0.5 font-mono text-2xs text-sec tabular-nums\">")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 255, "\" data-board-lane-card-count=\"")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var156 string
-			templ_7745c5c3_Var156, templ_7745c5c3_Err = templ.JoinStringErrs(lane.Count)
+			templ_7745c5c3_Var156, templ_7745c5c3_Err = templ.JoinStringErrs(strconv.Itoa(lane.CardCount))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 814, Col: 111}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 861, Col: 146}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var156))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 255, "</span></div><div class=\"grid grid-cols-[minmax(0,1fr)_auto_auto] items-center gap-1.5\"><span class=\"min-w-0 truncate text-2xs text-sec\" title=\"")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 256, "\" data-board-lane-hidden-populated=\"")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var157 string
-			templ_7745c5c3_Var157, templ_7745c5c3_Err = templ.JoinStringErrs(boardLaneVisibilityStatusTitle(lane))
+			templ_7745c5c3_Var157, templ_7745c5c3_Err = templ.JoinStringErrs(boardBoolAttr(boardLaneHiddenPopulated(lane)))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 817, Col: 99}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 861, Col: 229}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var157))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 256, "\" data-board-lane-visibility-status>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 257, "\"><div class=\"flex min-w-0 items-center gap-2\"><span class=\"min-w-0 flex-1 truncate font-medium\">")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var158 string
-			templ_7745c5c3_Var158, templ_7745c5c3_Err = templ.JoinStringErrs(boardLaneVisibilityStatusLabel(lane))
+			templ_7745c5c3_Var158, templ_7745c5c3_Err = templ.JoinStringErrs(lane.Title)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 817, Col: 174}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 863, Col: 68}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var158))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 257, "</span> <select class=\"h-11 rounded-chip border border-line bg-surface px-2 text-2xs text-text outline-none focus:border-accent md:h-7\" data-board-lane-visibility=\"")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 258, "</span> <span class=\"rounded-chip bg-surface px-1.5 py-0.5 font-mono text-2xs text-sec tabular-nums\">")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var159 string
-			templ_7745c5c3_Var159, templ_7745c5c3_Err = templ.JoinStringErrs(lane.LaneID)
+			templ_7745c5c3_Var159, templ_7745c5c3_Err = templ.JoinStringErrs(lane.Count)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 820, Col: 47}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 864, Col: 111}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var159))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 258, "\" data-board-lane-visibility-state=\"")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 259, "</span></div><div class=\"grid grid-cols-[minmax(0,1fr)_auto_auto] items-center gap-1.5\"><span class=\"min-w-0 truncate text-2xs text-sec\" title=\"")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var160 string
-			templ_7745c5c3_Var160, templ_7745c5c3_Err = templ.JoinStringErrs(string(boardLaneVisibilityAuto))
+			templ_7745c5c3_Var160, templ_7745c5c3_Err = templ.JoinStringErrs(boardLaneVisibilityStatusTitle(lane))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 821, Col: 73}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 867, Col: 99}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var160))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 259, "\" data-board-lane-visibility-effective=\"")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 260, "\" data-board-lane-visibility-status>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var161 string
-			templ_7745c5c3_Var161, templ_7745c5c3_Err = templ.JoinStringErrs(boardBoolAttr(lane.DefaultVisible))
+			templ_7745c5c3_Var161, templ_7745c5c3_Err = templ.JoinStringErrs(boardLaneVisibilityStatusLabel(lane))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 822, Col: 80}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 867, Col: 174}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var161))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 260, "\" aria-label=\"")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 261, "</span> <select class=\"h-11 rounded-chip border border-line bg-surface px-2 text-2xs text-text outline-none focus:border-accent md:h-7\" data-board-lane-visibility=\"")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var162 string
-			templ_7745c5c3_Var162, templ_7745c5c3_Err = templ.JoinStringErrs("Visibility for " + lane.Title + " lane")
+			templ_7745c5c3_Var162, templ_7745c5c3_Err = templ.JoinStringErrs(lane.LaneID)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 823, Col: 60}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 870, Col: 47}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var162))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 261, "\" title=\"")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 262, "\" data-board-lane-visibility-state=\"")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var163 string
-			templ_7745c5c3_Var163, templ_7745c5c3_Err = templ.JoinStringErrs(boardLaneVisibilityStatusTitle(lane))
+			templ_7745c5c3_Var163, templ_7745c5c3_Err = templ.JoinStringErrs(string(boardLaneVisibilityAuto))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 824, Col: 51}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 871, Col: 73}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var163))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 262, "\"><option value=\"")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 263, "\" data-board-lane-visibility-effective=\"")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var164 string
-			templ_7745c5c3_Var164, templ_7745c5c3_Err = templ.JoinStringErrs(string(boardLaneVisibilityAuto))
+			templ_7745c5c3_Var164, templ_7745c5c3_Err = templ.JoinStringErrs(boardBoolAttr(lane.DefaultVisible))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 826, Col: 54}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 872, Col: 80}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var164))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 263, "\" selected>Auto</option> <option value=\"")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 264, "\" aria-label=\"")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var165 string
-			templ_7745c5c3_Var165, templ_7745c5c3_Err = templ.JoinStringErrs(string(boardLaneVisibilityShow))
+			templ_7745c5c3_Var165, templ_7745c5c3_Err = templ.JoinStringErrs("Visibility for " + lane.Title + " lane")
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 827, Col: 54}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 873, Col: 60}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var165))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 264, "\">Show</option> <option value=\"")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 265, "\" title=\"")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var166 string
-			templ_7745c5c3_Var166, templ_7745c5c3_Err = templ.JoinStringErrs(string(boardLaneVisibilityHide))
+			templ_7745c5c3_Var166, templ_7745c5c3_Err = templ.JoinStringErrs(boardLaneVisibilityStatusTitle(lane))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 828, Col: 54}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 874, Col: 51}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var166))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 265, "\">Hide</option></select> <button type=\"button\" class=\"inline-flex size-11 items-center justify-center rounded-chip border border-line text-sec hover:border-accent hover:text-accent disabled:pointer-events-none disabled:opacity-40 md:size-7\" data-board-lane-reset=\"")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 266, "\"><option value=\"")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var167 string
-			templ_7745c5c3_Var167, templ_7745c5c3_Err = templ.JoinStringErrs(lane.LaneID)
+			templ_7745c5c3_Var167, templ_7745c5c3_Err = templ.JoinStringErrs(string(boardLaneVisibilityAuto))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 833, Col: 42}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 876, Col: 54}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var167))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 266, "\" value=\"")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 267, "\" selected>Auto</option> <option value=\"")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var168 string
-			templ_7745c5c3_Var168, templ_7745c5c3_Err = templ.JoinStringErrs(lane.LaneID)
+			templ_7745c5c3_Var168, templ_7745c5c3_Err = templ.JoinStringErrs(string(boardLaneVisibilityShow))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 834, Col: 26}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 877, Col: 54}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var168))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 267, "\" aria-label=\"")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 268, "\">Show</option> <option value=\"")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var169 string
-			templ_7745c5c3_Var169, templ_7745c5c3_Err = templ.JoinStringErrs("Reset " + lane.Title + " lane to Auto")
+			templ_7745c5c3_Var169, templ_7745c5c3_Err = templ.JoinStringErrs(string(boardLaneVisibilityHide))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 835, Col: 59}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 878, Col: 54}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var169))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 268, "\" title=\"Reset lane to Auto\" disabled aria-disabled=\"true\">")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 269, "\">Hide</option></select> <button type=\"button\" class=\"inline-flex size-11 items-center justify-center rounded-chip border border-line text-sec hover:border-accent hover:text-accent disabled:pointer-events-none disabled:opacity-40 md:size-7\" data-board-lane-reset=\"")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			var templ_7745c5c3_Var170 string
+			templ_7745c5c3_Var170, templ_7745c5c3_Err = templ.JoinStringErrs(lane.LaneID)
+			if templ_7745c5c3_Err != nil {
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 883, Col: 42}
+			}
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var170))
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 270, "\" value=\"")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			var templ_7745c5c3_Var171 string
+			templ_7745c5c3_Var171, templ_7745c5c3_Err = templ.JoinStringErrs(lane.LaneID)
+			if templ_7745c5c3_Err != nil {
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 884, Col: 26}
+			}
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var171))
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 271, "\" aria-label=\"")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			var templ_7745c5c3_Var172 string
+			templ_7745c5c3_Var172, templ_7745c5c3_Err = templ.JoinStringErrs("Reset " + lane.Title + " lane to Auto")
+			if templ_7745c5c3_Err != nil {
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 885, Col: 59}
+			}
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var172))
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 272, "\" title=\"Reset lane to Auto\" disabled aria-disabled=\"true\">")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -3119,12 +3166,12 @@ func boardLanePicker(view boardView) templ.Component {
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 269, "</button></div></div>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 273, "</button></div></div>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 270, "</div></details>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 274, "</div></details>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -3148,12 +3195,12 @@ func boardLaneScript() templ.Component {
 			}()
 		}
 		ctx = templ.InitializeContext(ctx)
-		templ_7745c5c3_Var170 := templ.GetChildren(ctx)
-		if templ_7745c5c3_Var170 == nil {
-			templ_7745c5c3_Var170 = templ.NopComponent
+		templ_7745c5c3_Var173 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var173 == nil {
+			templ_7745c5c3_Var173 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 271, "<script>\n\t\t(function () {\n\t\t\tvar storagePrefix = \"detent.ui.board.lanes.v2.\";\n\t\t\tvar legacyStoragePrefix = \"detent.ui.board.lanes.\";\n\t\t\tvar storageVersion = 1;\n\t\t\tvar stateAuto = \"auto\";\n\t\t\tvar stateShow = \"show\";\n\t\t\tvar stateHide = \"hide\";\n\t\t\tvar pickerOpen = false;\n\t\t\tvar activeLaneID = \"\";\n\t\t\tvar lanePositionFrame = 0;\n\n\t\t\tfunction visibilityStorage() {\n\t\t\t\ttry {\n\t\t\t\t\treturn window.localStorage;\n\t\t\t\t} catch (err) {\n\t\t\t\t\treturn null;\n\t\t\t\t}\n\t\t\t}\n\t\t\tfunction storageKey(root) {\n\t\t\t\treturn storagePrefix + (root.getAttribute(\"data-board-key\") || \"fleet\");\n\t\t\t}\n\t\t\tfunction legacyStorageKey(root) {\n\t\t\t\treturn legacyStoragePrefix + (root.getAttribute(\"data-board-key\") || \"fleet\");\n\t\t\t}\n\t\t\tfunction emptyPrefs() {\n\t\t\t\treturn { show: new Set(), hide: new Set() };\n\t\t\t}\n\t\t\tfunction laneIDSet(ids) {\n\t\t\t\tvar out = new Set();\n\t\t\t\tif (!Array.isArray(ids)) return out;\n\t\t\t\tids.forEach(function (id) {\n\t\t\t\t\tif (typeof id === \"string\" && id.trim() !== \"\") out.add(id);\n\t\t\t\t});\n\t\t\t\treturn out;\n\t\t\t}\n\t\t\tfunction normalizedPrefs(showIDs, hideIDs) {\n\t\t\t\tvar prefs = emptyPrefs();\n\t\t\t\tlaneIDSet(showIDs).forEach(function (id) {\n\t\t\t\t\tprefs.show.add(id);\n\t\t\t\t});\n\t\t\t\tlaneIDSet(hideIDs).forEach(function (id) {\n\t\t\t\t\tif (!prefs.show.has(id)) prefs.hide.add(id);\n\t\t\t\t});\n\t\t\t\treturn prefs;\n\t\t\t}\n\t\t\tfunction discardLegacyPrefs(root, store) {\n\t\t\t\tvar legacy = legacyStorageKey(root);\n\t\t\t\ttry {\n\t\t\t\t\tif (legacy !== storageKey(root)) store.removeItem(legacy);\n\t\t\t\t} catch (err) {}\n\t\t\t}\n\t\t\tfunction readPrefs(root) {\n\t\t\t\tvar store = visibilityStorage();\n\t\t\t\tif (!store) return emptyPrefs();\n\t\t\t\tdiscardLegacyPrefs(root, store);\n\t\t\t\tvar raw = \"\";\n\t\t\t\ttry {\n\t\t\t\t\traw = store.getItem(storageKey(root));\n\t\t\t\t} catch (err) {\n\t\t\t\t\treturn emptyPrefs();\n\t\t\t\t}\n\t\t\t\tif (!raw) return emptyPrefs();\n\t\t\t\ttry {\n\t\t\t\t\tvar parsed = JSON.parse(raw);\n\t\t\t\t\tif (!parsed || parsed.v !== storageVersion) {\n\t\t\t\t\t\ttry {\n\t\t\t\t\t\t\tstore.removeItem(storageKey(root));\n\t\t\t\t\t\t} catch (err) {}\n\t\t\t\t\t\treturn emptyPrefs();\n\t\t\t\t\t}\n\t\t\t\t\treturn normalizedPrefs(parsed.show, parsed.hide);\n\t\t\t\t} catch (err) {\n\t\t\t\t\ttry {\n\t\t\t\t\t\tstore.removeItem(storageKey(root));\n\t\t\t\t\t} catch (err) {}\n\t\t\t\t\treturn emptyPrefs();\n\t\t\t\t}\n\t\t\t}\n\t\t\tfunction writePrefs(root, prefs) {\n\t\t\t\tvar store = visibilityStorage();\n\t\t\t\tif (!store) return;\n\t\t\t\tvar show = Array.from(prefs.show).filter(Boolean).sort();\n\t\t\t\tvar hide = Array.from(prefs.hide).filter(function (id) {\n\t\t\t\t\treturn Boolean(id) && !prefs.show.has(id);\n\t\t\t\t}).sort();\n\t\t\t\tif (show.length === 0 && hide.length === 0) {\n\t\t\t\t\ttry {\n\t\t\t\t\t\tstore.removeItem(storageKey(root));\n\t\t\t\t\t} catch (err) {}\n\t\t\t\t\treturn;\n\t\t\t\t}\n\t\t\t\ttry {\n\t\t\t\t\tstore.setItem(storageKey(root), JSON.stringify({ v: storageVersion, show: show, hide: hide }));\n\t\t\t\t} catch (err) {}\n\t\t\t}\n\t\t\tfunction prefsHaveOverrides(prefs) {\n\t\t\t\treturn prefs.show.size > 0 || prefs.hide.size > 0;\n\t\t\t}\n\t\t\tfunction queryRoot(scope) {\n\t\t\t\tif (scope && typeof scope.querySelector === \"function\" && typeof scope.querySelectorAll === \"function\") return scope;\n\t\t\t\treturn document;\n\t\t\t}\n\t\t\tfunction boardLanesRoot(scope) {\n\t\t\t\tif (scope instanceof Element && scope.matches(\"[data-board-lanes]\")) return scope;\n\t\t\t\tif (scope && typeof scope.querySelector === \"function\") return scope.querySelector(\"[data-board-lanes]\");\n\t\t\t\treturn null;\n\t\t\t}\n\t\t\tfunction findByData(scope, attr, value) {\n\t\t\t\tvar root = queryRoot(scope);\n\t\t\t\tvar nodes = root.querySelectorAll(\"[\" + attr + \"]\");\n\t\t\t\tfor (var i = 0; i < nodes.length; i += 1) {\n\t\t\t\t\tif (nodes[i].getAttribute(attr) === value) return nodes[i];\n\t\t\t\t}\n\t\t\t\treturn null;\n\t\t\t}\n\t\t\tfunction laneID(lane) {\n\t\t\t\treturn lane.getAttribute(\"data-board-lane\") || \"\";\n\t\t\t}\n\t\t\tfunction laneDefaultVisible(lane) {\n\t\t\t\treturn lane.getAttribute(\"data-board-lane-default\") === \"true\";\n\t\t\t}\n\t\t\tfunction laneCardCount(lane) {\n\t\t\t\tvar parsed = Number.parseInt(lane.getAttribute(\"data-board-lane-card-count\") || \"0\", 10);\n\t\t\t\tif (!Number.isFinite(parsed) || parsed < 0) return 0;\n\t\t\t\treturn parsed;\n\t\t\t}\n\t\t\tfunction laneTitle(lane) {\n\t\t\t\treturn lane.getAttribute(\"data-board-lane-title\") || \"lane\";\n\t\t\t}\n\t\t\tfunction visibleBoardLanes(root) {\n\t\t\t\treturn Array.from(root.querySelectorAll(\"[data-board-lane]\")).filter(function (lane) {\n\t\t\t\t\treturn lane.getAttribute(\"data-lane-hidden\") !== \"true\";\n\t\t\t\t});\n\t\t\t}\n\t\t\tfunction lanePositionIndex(root, lanes, preferredID) {\n\t\t\t\tif (lanes.length === 0) return -1;\n\t\t\t\tif (preferredID) {\n\t\t\t\t\tvar preferred = lanes.findIndex(function (lane) {\n\t\t\t\t\t\treturn laneID(lane) === preferredID;\n\t\t\t\t\t});\n\t\t\t\t\tif (preferred >= 0) return preferred;\n\t\t\t\t}\n\t\t\t\tif (!root.isConnected) return 0;\n\t\t\t\tvar rootRect = root.getBoundingClientRect();\n\t\t\t\tvar center = rootRect.left + root.clientWidth / 2;\n\t\t\t\tvar nearest = 0;\n\t\t\t\tvar nearestDistance = Number.POSITIVE_INFINITY;\n\t\t\t\tlanes.forEach(function (lane, index) {\n\t\t\t\t\tvar rect = lane.getBoundingClientRect();\n\t\t\t\t\tvar distance = Math.abs(rect.left + rect.width / 2 - center);\n\t\t\t\t\tif (distance < nearestDistance) {\n\t\t\t\t\t\tnearest = index;\n\t\t\t\t\t\tnearestDistance = distance;\n\t\t\t\t\t}\n\t\t\t\t});\n\t\t\t\treturn nearest;\n\t\t\t}\n\t\t\tfunction updateLanePosition(scope, root, preferredID) {\n\t\t\t\tvar lanes = visibleBoardLanes(root);\n\t\t\t\tvar index = lanePositionIndex(root, lanes, preferredID);\n\t\t\t\tvar current = index < 0 ? 0 : index + 1;\n\t\t\t\tvar position = queryRoot(scope).querySelector(\"[data-board-lane-position]\");\n\t\t\t\tif (position) {\n\t\t\t\t\tvar currentNode = position.querySelector(\"[data-board-lane-position-current]\");\n\t\t\t\t\tvar totalNode = position.querySelector(\"[data-board-lane-position-total]\");\n\t\t\t\t\tif (currentNode) currentNode.textContent = String(current);\n\t\t\t\t\tif (totalNode) totalNode.textContent = String(lanes.length);\n\t\t\t\t\tposition.setAttribute(\"aria-label\", \"Lane \" + current + \" of \" + lanes.length);\n\t\t\t\t}\n\t\t\t\tif (root.isConnected && index >= 0) activeLaneID = laneID(lanes[index]);\n\t\t\t}\n\t\t\tfunction scheduleLanePosition(root) {\n\t\t\t\tif (!root || !root.isConnected) return;\n\t\t\t\twindow.cancelAnimationFrame(lanePositionFrame);\n\t\t\t\tlanePositionFrame = window.requestAnimationFrame(function () {\n\t\t\t\t\tupdateLanePosition(document, root, \"\");\n\t\t\t\t});\n\t\t\t}\n\t\t\tfunction formatNumber(value) {\n\t\t\t\treturn new Intl.NumberFormat(\"en-US\").format(value);\n\t\t\t}\n\t\t\tfunction cardCountLabel(count, singular, plural) {\n\t\t\t\treturn formatNumber(count) + \" \" + (count === 1 ? singular : plural);\n\t\t\t}\n\t\t\tfunction laneOverrideState(lane, prefs) {\n\t\t\t\tvar id = laneID(lane);\n\t\t\t\tif (prefs.show.has(id)) return stateShow;\n\t\t\t\tif (prefs.hide.has(id)) return stateHide;\n\t\t\t\treturn stateAuto;\n\t\t\t}\n\t\t\tfunction laneVisible(lane, state) {\n\t\t\t\tif (state === stateShow) return true;\n\t\t\t\tif (state === stateHide) return false;\n\t\t\t\treturn laneDefaultVisible(lane);\n\t\t\t}\n\t\t\tfunction stateLabel(lane, state, visible) {\n\t\t\t\tvar label = \"\";\n\t\t\t\tif (state === stateShow) {\n\t\t\t\t\tlabel = \"Always shown\";\n\t\t\t\t} else if (state === stateHide) {\n\t\t\t\t\tlabel = \"Always hidden\";\n\t\t\t\t} else {\n\t\t\t\t\tlabel = visible ? \"Auto shown\" : \"Auto hidden\";\n\t\t\t\t}\n\t\t\t\tif (!visible && laneCardCount(lane) > 0) {\n\t\t\t\t\treturn label + \" - \" + cardCountLabel(laneCardCount(lane), \"hidden card\", \"hidden cards\");\n\t\t\t\t}\n\t\t\t\treturn label;\n\t\t\t}\n\t\t\tfunction stateTitle(lane, state, visible) {\n\t\t\t\tvar title = \"\";\n\t\t\t\tif (state === stateShow) {\n\t\t\t\t\ttitle = \"Always show is saved for this lane.\";\n\t\t\t\t} else if (state === stateHide) {\n\t\t\t\t\ttitle = \"Always hide is saved for this lane.\";\n\t\t\t\t} else {\n\t\t\t\t\ttitle = \"Auto follows the board default.\";\n\t\t\t\t}\n\t\t\t\tif (!visible && laneCardCount(lane) > 0) {\n\t\t\t\t\treturn title + \" \" + cardCountLabel(laneCardCount(lane), \"card is\", \"cards are\") + \" hidden while this lane is off.\";\n\t\t\t\t}\n\t\t\t\treturn title;\n\t\t\t}\n\t\t\tfunction hiddenLaneSummary(lanes) {\n\t\t\t\tif (lanes.length === 0) return \"All populated lanes are visible.\";\n\t\t\t\tif (lanes.length === 1) {\n\t\t\t\t\tvar lane = lanes[0];\n\t\t\t\t\treturn cardCountLabel(lane.count, \"hidden card\", \"hidden cards\") + \" in \" + lane.title + \".\";\n\t\t\t\t}\n\t\t\t\tvar total = lanes.reduce(function (sum, lane) {\n\t\t\t\t\treturn sum + lane.count;\n\t\t\t\t}, 0);\n\t\t\t\tvar labels = lanes.map(function (lane) {\n\t\t\t\t\treturn lane.title + \" (\" + formatNumber(lane.count) + \")\";\n\t\t\t\t}).join(\", \");\n\t\t\t\treturn cardCountLabel(total, \"hidden card\", \"hidden cards\") + \" across \" + cardCountLabel(lanes.length, \"lane\", \"lanes\") + \": \" + labels + \".\";\n\t\t\t}\n\t\t\tfunction setResetDisabled(button, disabled) {\n\t\t\t\tif (!(button instanceof HTMLButtonElement)) return;\n\t\t\t\tbutton.disabled = disabled;\n\t\t\t\tbutton.setAttribute(\"aria-disabled\", disabled ? \"true\" : \"false\");\n\t\t\t}\n\t\t\tfunction updateLaneControls(scope, lane, state, visible) {\n\t\t\t\tvar id = laneID(lane);\n\t\t\t\tvar row = findByData(scope, \"data-board-lane-row\", id);\n\t\t\t\tvar hiddenPopulated = !visible && laneCardCount(lane) > 0;\n\t\t\t\tif (row instanceof HTMLElement) {\n\t\t\t\t\trow.dataset.boardLaneVisibilityState = state;\n\t\t\t\t\trow.dataset.boardLaneVisibilityEffective = visible ? \"visible\" : \"hidden\";\n\t\t\t\t\trow.dataset.boardLaneHiddenPopulated = hiddenPopulated ? \"true\" : \"false\";\n\t\t\t\t\trow.classList.toggle(\"border-warn/45\", hiddenPopulated);\n\t\t\t\t\trow.classList.toggle(\"bg-warn/10\", hiddenPopulated);\n\t\t\t\t\trow.classList.toggle(\"border-transparent\", !hiddenPopulated);\n\t\t\t\t\tvar status = row.querySelector(\"[data-board-lane-visibility-status]\");\n\t\t\t\t\tif (status) {\n\t\t\t\t\t\tstatus.textContent = stateLabel(lane, state, visible);\n\t\t\t\t\t\tstatus.setAttribute(\"title\", stateTitle(lane, state, visible));\n\t\t\t\t\t}\n\t\t\t\t}\n\t\t\t\tvar select = findByData(scope, \"data-board-lane-visibility\", id);\n\t\t\t\tif (select instanceof HTMLSelectElement) {\n\t\t\t\t\tselect.value = state;\n\t\t\t\t\tselect.dataset.boardLaneVisibilityState = state;\n\t\t\t\t\tselect.dataset.boardLaneVisibilityEffective = visible ? \"visible\" : \"hidden\";\n\t\t\t\t\tselect.setAttribute(\"title\", stateTitle(lane, state, visible));\n\t\t\t\t}\n\t\t\t\tsetResetDisabled(findByData(scope, \"data-board-lane-reset\", id), state === stateAuto);\n\t\t\t}\n\t\t\tfunction updateHiddenCardBadge(scope, hiddenCards, hiddenLanes) {\n\t\t\t\tvar root = queryRoot(scope);\n\t\t\t\tvar badge = root.querySelector(\"[data-board-hidden-card-count]\");\n\t\t\t\tif (!badge) return;\n\t\t\t\tvar summary = hiddenLaneSummary(hiddenLanes);\n\t\t\t\tbadge.hidden = hiddenCards === 0;\n\t\t\t\tbadge.textContent = hiddenCards > 0 ? formatNumber(hiddenCards) + \" hidden\" : \"\";\n\t\t\t\tbadge.setAttribute(\"title\", summary);\n\t\t\t\tbadge.setAttribute(\"aria-label\", summary);\n\t\t\t}\n\t\t\tfunction updateResetAll(scope, prefs) {\n\t\t\t\tqueryRoot(scope).querySelectorAll(\"[data-board-lane-reset-all]\").forEach(function (button) {\n\t\t\t\t\tsetResetDisabled(button, !prefsHaveOverrides(prefs));\n\t\t\t\t});\n\t\t\t}\n\t\t\tfunction applyTo(scope) {\n\t\t\t\tvar root = boardLanesRoot(scope);\n\t\t\t\tif (!root) return false;\n\t\t\t\tvar prefs = readPrefs(root);\n\t\t\t\tvar total = 0;\n\t\t\t\tvar visible = 0;\n\t\t\t\tvar hiddenCards = 0;\n\t\t\t\tvar hiddenLanes = [];\n\t\t\t\troot.querySelectorAll(\"[data-board-lane]\").forEach(function (lane) {\n\t\t\t\t\ttotal += 1;\n\t\t\t\t\tvar state = laneOverrideState(lane, prefs);\n\t\t\t\t\tvar show = laneVisible(lane, state);\n\t\t\t\t\tvar cards = laneCardCount(lane);\n\t\t\t\t\tlane.setAttribute(\"data-lane-hidden\", show ? \"false\" : \"true\");\n\t\t\t\t\tlane.setAttribute(\"data-board-lane-visibility-state\", state);\n\t\t\t\t\tlane.setAttribute(\"data-board-lane-pinned\", state === stateAuto ? \"false\" : \"true\");\n\t\t\t\t\tif (show) {\n\t\t\t\t\t\tvisible += 1;\n\t\t\t\t\t} else if (cards > 0) {\n\t\t\t\t\t\thiddenCards += cards;\n\t\t\t\t\t\thiddenLanes.push({ title: laneTitle(lane), count: cards });\n\t\t\t\t\t}\n\t\t\t\t\tupdateLaneControls(scope, lane, state, show);\n\t\t\t\t});\n\t\t\t\tvar count = queryRoot(scope).querySelector(\"[data-board-lane-count]\");\n\t\t\t\tif (count) count.textContent = visible + \"/\" + total;\n\t\t\t\tupdateHiddenCardBadge(scope, hiddenCards, hiddenLanes);\n\t\t\t\tupdateResetAll(scope, prefs);\n\t\t\t\tvar picker = queryRoot(scope).querySelector(\"[data-board-lane-picker]\");\n\t\t\t\tif (picker && pickerOpen) picker.setAttribute(\"open\", \"\");\n\t\t\t\tupdateLanePosition(scope, root, activeLaneID);\n\t\t\t\tif (root.isConnected) scheduleLanePosition(root);\n\t\t\t\tif (typeof window.__detentBoardKanbanDragAdjustSnapshot === \"function\") {\n\t\t\t\t\twindow.__detentBoardKanbanDragAdjustSnapshot(scope);\n\t\t\t\t}\n\t\t\t\treturn true;\n\t\t\t}\n\t\t\tfunction apply() {\n\t\t\t\tapplyTo(document);\n\t\t\t}\n\t\t\tfunction adjustedBoardHTML(html) {\n\t\t\t\tif (typeof html !== \"string\" || html.indexOf(\"data-board-lanes\") < 0) return \"\";\n\t\t\t\tvar template = document.createElement(\"template\");\n\t\t\t\ttemplate.innerHTML = html;\n\t\t\t\tif (!applyTo(template.content)) return \"\";\n\t\t\t\treturn template.innerHTML;\n\t\t\t}\n\t\t\tfunction snapshotSwapTarget(event) {\n\t\t\t\tvar target = event.detail && event.detail.target;\n\t\t\t\tif (!(target instanceof Element)) target = event.target;\n\t\t\t\tif (!(target instanceof Element)) return false;\n\t\t\t\treturn target.id === \"snapshot\" || Boolean(target.closest(\"#snapshot\"));\n\t\t\t}\n\t\t\tfunction applyBeforeSwap(event) {\n\t\t\t\tvar detail = event.detail || {};\n\t\t\t\tif (!snapshotSwapTarget(event) || typeof detail.serverResponse !== \"string\") return;\n\t\t\t\tvar adjusted = adjustedBoardHTML(detail.serverResponse);\n\t\t\t\tif (!adjusted) return;\n\t\t\t\tdetail.serverResponse = adjusted;\n\t\t\t}\n\t\t\tfunction applyBeforeSSEMessage(event) {\n\t\t\t\tvar detail = event.detail || {};\n\t\t\t\tvar target = detail.elt;\n\t\t\t\tif (!(target instanceof Element)) target = event.target;\n\t\t\t\tif (!(target instanceof Element) || target.id !== \"snapshot\") return;\n\t\t\t\tif (!window.htmx || typeof window.htmx.swap !== \"function\") return;\n\t\t\t\tvar adjusted = adjustedBoardHTML(detail.data);\n\t\t\t\tif (!adjusted) return;\n\t\t\t\tevent.preventDefault();\n\t\t\t\twindow.htmx.swap(target, adjusted, { swapStyle: target.getAttribute(\"hx-swap\") || \"innerHTML\" }, { contextElement: target });\n\t\t\t}\n\t\t\tfunction setLaneState(root, id, state) {\n\t\t\t\tvar prefs = readPrefs(root);\n\t\t\t\tprefs.show.delete(id);\n\t\t\t\tprefs.hide.delete(id);\n\t\t\t\tif (state === stateShow) prefs.show.add(id);\n\t\t\t\tif (state === stateHide) prefs.hide.add(id);\n\t\t\t\twritePrefs(root, prefs);\n\t\t\t\tapply();\n\t\t\t}\n\t\t\tdocument.addEventListener(\"change\", function (event) {\n\t\t\t\tvar target = event.target instanceof Element ? event.target : null;\n\t\t\t\tvar select = target ? target.closest(\"[data-board-lane-visibility]\") : null;\n\t\t\t\tif (!(select instanceof HTMLSelectElement)) return;\n\t\t\t\tvar root = document.querySelector(\"[data-board-lanes]\");\n\t\t\t\tif (!root) return;\n\t\t\t\tvar state = select.value;\n\t\t\t\tif (state !== stateShow && state !== stateHide) state = stateAuto;\n\t\t\t\tsetLaneState(root, select.getAttribute(\"data-board-lane-visibility\") || \"\", state);\n\t\t\t});\n\t\t\tdocument.addEventListener(\"toggle\", function (event) {\n\t\t\t\tvar picker = event.target;\n\t\t\t\tif (picker instanceof Element && picker.hasAttribute(\"data-board-lane-picker\")) {\n\t\t\t\t\tpickerOpen = picker.open;\n\t\t\t\t}\n\t\t\t}, true);\n\t\t\tdocument.addEventListener(\"click\", function (event) {\n\t\t\t\tvar target = event.target instanceof Element ? event.target : null;\n\t\t\t\tvar root = document.querySelector(\"[data-board-lanes]\");\n\t\t\t\tvar reset = target ? target.closest(\"[data-board-lane-reset]\") : null;\n\t\t\t\tif (reset instanceof HTMLButtonElement && root) {\n\t\t\t\t\tevent.preventDefault();\n\t\t\t\t\tsetLaneState(root, reset.value || reset.getAttribute(\"data-board-lane-reset\") || \"\", stateAuto);\n\t\t\t\t\treturn;\n\t\t\t\t}\n\t\t\t\tvar resetAll = target ? target.closest(\"[data-board-lane-reset-all]\") : null;\n\t\t\t\tif (resetAll instanceof HTMLButtonElement && root) {\n\t\t\t\t\tevent.preventDefault();\n\t\t\t\t\twritePrefs(root, emptyPrefs());\n\t\t\t\t\tapply();\n\t\t\t\t\treturn;\n\t\t\t\t}\n\t\t\t\tvar picker = document.querySelector(\"[data-board-lane-picker]\");\n\t\t\t\tif (picker && picker.open && !picker.contains(event.target)) {\n\t\t\t\t\tpicker.removeAttribute(\"open\");\n\t\t\t\t\tpickerOpen = false;\n\t\t\t\t}\n\t\t\t});\n\t\t\tdocument.addEventListener(\"keydown\", function (event) {\n\t\t\t\tif (event.key !== \"Escape\") return;\n\t\t\t\tvar picker = document.querySelector(\"[data-board-lane-picker]\");\n\t\t\t\tif (picker && picker.open) {\n\t\t\t\t\tpicker.removeAttribute(\"open\");\n\t\t\t\t\tpickerOpen = false;\n\t\t\t\t}\n\t\t\t});\n\t\t\tdocument.addEventListener(\"htmx:beforeSwap\", applyBeforeSwap);\n\t\t\tdocument.addEventListener(\"htmx:sseBeforeMessage\", applyBeforeSSEMessage);\n\t\t\tdocument.addEventListener(\"htmx:afterSettle\", apply);\n\t\t\tdocument.addEventListener(\"DOMContentLoaded\", apply);\n\t\t\tdocument.addEventListener(\"scroll\", function (event) {\n\t\t\t\tvar root = event.target instanceof Element && event.target.matches(\"[data-board-lanes]\") ? event.target : null;\n\t\t\t\tif (root) scheduleLanePosition(root);\n\t\t\t}, true);\n\t\t\twindow.addEventListener(\"resize\", function () {\n\t\t\t\tscheduleLanePosition(document.querySelector(\"[data-board-lanes]\"));\n\t\t\t});\n\t\t\twindow.addEventListener(\"storage\", function (event) {\n\t\t\t\tif (event.key && event.key.indexOf(storagePrefix) === 0) apply();\n\t\t\t});\n\t\t\tapply();\n\t\t})();\n\t</script>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 275, "<script>\n\t\t(function () {\n\t\t\tvar storagePrefix = \"detent.ui.board.lanes.v2.\";\n\t\t\tvar legacyStoragePrefix = \"detent.ui.board.lanes.\";\n\t\t\tvar storageVersion = 1;\n\t\t\tvar stateAuto = \"auto\";\n\t\t\tvar stateShow = \"show\";\n\t\t\tvar stateHide = \"hide\";\n\t\t\tvar pickerOpen = false;\n\t\t\tvar activeLaneID = \"\";\n\t\t\tvar lanePositionFrame = 0;\n\n\t\t\tfunction visibilityStorage() {\n\t\t\t\ttry {\n\t\t\t\t\treturn window.localStorage;\n\t\t\t\t} catch (err) {\n\t\t\t\t\treturn null;\n\t\t\t\t}\n\t\t\t}\n\t\t\tfunction storageKey(root) {\n\t\t\t\treturn storagePrefix + (root.getAttribute(\"data-board-key\") || \"fleet\");\n\t\t\t}\n\t\t\tfunction legacyStorageKey(root) {\n\t\t\t\treturn legacyStoragePrefix + (root.getAttribute(\"data-board-key\") || \"fleet\");\n\t\t\t}\n\t\t\tfunction emptyPrefs() {\n\t\t\t\treturn { show: new Set(), hide: new Set() };\n\t\t\t}\n\t\t\tfunction laneIDSet(ids) {\n\t\t\t\tvar out = new Set();\n\t\t\t\tif (!Array.isArray(ids)) return out;\n\t\t\t\tids.forEach(function (id) {\n\t\t\t\t\tif (typeof id === \"string\" && id.trim() !== \"\") out.add(id);\n\t\t\t\t});\n\t\t\t\treturn out;\n\t\t\t}\n\t\t\tfunction normalizedPrefs(showIDs, hideIDs) {\n\t\t\t\tvar prefs = emptyPrefs();\n\t\t\t\tlaneIDSet(showIDs).forEach(function (id) {\n\t\t\t\t\tprefs.show.add(id);\n\t\t\t\t});\n\t\t\t\tlaneIDSet(hideIDs).forEach(function (id) {\n\t\t\t\t\tif (!prefs.show.has(id)) prefs.hide.add(id);\n\t\t\t\t});\n\t\t\t\treturn prefs;\n\t\t\t}\n\t\t\tfunction discardLegacyPrefs(root, store) {\n\t\t\t\tvar legacy = legacyStorageKey(root);\n\t\t\t\ttry {\n\t\t\t\t\tif (legacy !== storageKey(root)) store.removeItem(legacy);\n\t\t\t\t} catch (err) {}\n\t\t\t}\n\t\t\tfunction readPrefs(root) {\n\t\t\t\tvar store = visibilityStorage();\n\t\t\t\tif (!store) return emptyPrefs();\n\t\t\t\tdiscardLegacyPrefs(root, store);\n\t\t\t\tvar raw = \"\";\n\t\t\t\ttry {\n\t\t\t\t\traw = store.getItem(storageKey(root));\n\t\t\t\t} catch (err) {\n\t\t\t\t\treturn emptyPrefs();\n\t\t\t\t}\n\t\t\t\tif (!raw) return emptyPrefs();\n\t\t\t\ttry {\n\t\t\t\t\tvar parsed = JSON.parse(raw);\n\t\t\t\t\tif (!parsed || parsed.v !== storageVersion) {\n\t\t\t\t\t\ttry {\n\t\t\t\t\t\t\tstore.removeItem(storageKey(root));\n\t\t\t\t\t\t} catch (err) {}\n\t\t\t\t\t\treturn emptyPrefs();\n\t\t\t\t\t}\n\t\t\t\t\treturn normalizedPrefs(parsed.show, parsed.hide);\n\t\t\t\t} catch (err) {\n\t\t\t\t\ttry {\n\t\t\t\t\t\tstore.removeItem(storageKey(root));\n\t\t\t\t\t} catch (err) {}\n\t\t\t\t\treturn emptyPrefs();\n\t\t\t\t}\n\t\t\t}\n\t\t\tfunction writePrefs(root, prefs) {\n\t\t\t\tvar store = visibilityStorage();\n\t\t\t\tif (!store) return;\n\t\t\t\tvar show = Array.from(prefs.show).filter(Boolean).sort();\n\t\t\t\tvar hide = Array.from(prefs.hide).filter(function (id) {\n\t\t\t\t\treturn Boolean(id) && !prefs.show.has(id);\n\t\t\t\t}).sort();\n\t\t\t\tif (show.length === 0 && hide.length === 0) {\n\t\t\t\t\ttry {\n\t\t\t\t\t\tstore.removeItem(storageKey(root));\n\t\t\t\t\t} catch (err) {}\n\t\t\t\t\treturn;\n\t\t\t\t}\n\t\t\t\ttry {\n\t\t\t\t\tstore.setItem(storageKey(root), JSON.stringify({ v: storageVersion, show: show, hide: hide }));\n\t\t\t\t} catch (err) {}\n\t\t\t}\n\t\t\tfunction prefsHaveOverrides(prefs) {\n\t\t\t\treturn prefs.show.size > 0 || prefs.hide.size > 0;\n\t\t\t}\n\t\t\tfunction queryRoot(scope) {\n\t\t\t\tif (scope && typeof scope.querySelector === \"function\" && typeof scope.querySelectorAll === \"function\") return scope;\n\t\t\t\treturn document;\n\t\t\t}\n\t\t\tfunction boardLanesRoot(scope) {\n\t\t\t\tif (scope instanceof Element && scope.matches(\"[data-board-lanes]\")) return scope;\n\t\t\t\tif (scope && typeof scope.querySelector === \"function\") return scope.querySelector(\"[data-board-lanes]\");\n\t\t\t\treturn null;\n\t\t\t}\n\t\t\tfunction findByData(scope, attr, value) {\n\t\t\t\tvar root = queryRoot(scope);\n\t\t\t\tvar nodes = root.querySelectorAll(\"[\" + attr + \"]\");\n\t\t\t\tfor (var i = 0; i < nodes.length; i += 1) {\n\t\t\t\t\tif (nodes[i].getAttribute(attr) === value) return nodes[i];\n\t\t\t\t}\n\t\t\t\treturn null;\n\t\t\t}\n\t\t\tfunction laneID(lane) {\n\t\t\t\treturn lane.getAttribute(\"data-board-lane\") || \"\";\n\t\t\t}\n\t\t\tfunction laneDefaultVisible(lane) {\n\t\t\t\treturn lane.getAttribute(\"data-board-lane-default\") === \"true\";\n\t\t\t}\n\t\t\tfunction laneCardCount(lane) {\n\t\t\t\tvar parsed = Number.parseInt(lane.getAttribute(\"data-board-lane-card-count\") || \"0\", 10);\n\t\t\t\tif (!Number.isFinite(parsed) || parsed < 0) return 0;\n\t\t\t\treturn parsed;\n\t\t\t}\n\t\t\tfunction laneTitle(lane) {\n\t\t\t\treturn lane.getAttribute(\"data-board-lane-title\") || \"lane\";\n\t\t\t}\n\t\t\tfunction visibleBoardLanes(root) {\n\t\t\t\treturn Array.from(root.querySelectorAll(\"[data-board-lane]\")).filter(function (lane) {\n\t\t\t\t\treturn lane.getAttribute(\"data-lane-hidden\") !== \"true\";\n\t\t\t\t});\n\t\t\t}\n\t\t\tfunction lanePositionIndex(root, lanes, preferredID) {\n\t\t\t\tif (lanes.length === 0) return -1;\n\t\t\t\tif (preferredID) {\n\t\t\t\t\tvar preferred = lanes.findIndex(function (lane) {\n\t\t\t\t\t\treturn laneID(lane) === preferredID;\n\t\t\t\t\t});\n\t\t\t\t\tif (preferred >= 0) return preferred;\n\t\t\t\t}\n\t\t\t\tif (!root.isConnected) return 0;\n\t\t\t\tvar rootRect = root.getBoundingClientRect();\n\t\t\t\tvar center = rootRect.left + root.clientWidth / 2;\n\t\t\t\tvar nearest = 0;\n\t\t\t\tvar nearestDistance = Number.POSITIVE_INFINITY;\n\t\t\t\tlanes.forEach(function (lane, index) {\n\t\t\t\t\tvar rect = lane.getBoundingClientRect();\n\t\t\t\t\tvar distance = Math.abs(rect.left + rect.width / 2 - center);\n\t\t\t\t\tif (distance < nearestDistance) {\n\t\t\t\t\t\tnearest = index;\n\t\t\t\t\t\tnearestDistance = distance;\n\t\t\t\t\t}\n\t\t\t\t});\n\t\t\t\treturn nearest;\n\t\t\t}\n\t\t\tfunction updateLanePosition(scope, root, preferredID) {\n\t\t\t\tvar lanes = visibleBoardLanes(root);\n\t\t\t\tvar index = lanePositionIndex(root, lanes, preferredID);\n\t\t\t\tvar current = index < 0 ? 0 : index + 1;\n\t\t\t\tvar position = queryRoot(scope).querySelector(\"[data-board-lane-position]\");\n\t\t\t\tif (position) {\n\t\t\t\t\tvar currentNode = position.querySelector(\"[data-board-lane-position-current]\");\n\t\t\t\t\tvar totalNode = position.querySelector(\"[data-board-lane-position-total]\");\n\t\t\t\t\tif (currentNode) currentNode.textContent = String(current);\n\t\t\t\t\tif (totalNode) totalNode.textContent = String(lanes.length);\n\t\t\t\t\tposition.setAttribute(\"aria-label\", \"Lane \" + current + \" of \" + lanes.length);\n\t\t\t\t}\n\t\t\t\tif (root.isConnected && index >= 0) activeLaneID = laneID(lanes[index]);\n\t\t\t}\n\t\t\tfunction scheduleLanePosition(root) {\n\t\t\t\tif (!root || !root.isConnected) return;\n\t\t\t\twindow.cancelAnimationFrame(lanePositionFrame);\n\t\t\t\tlanePositionFrame = window.requestAnimationFrame(function () {\n\t\t\t\t\tupdateLanePosition(document, root, \"\");\n\t\t\t\t});\n\t\t\t}\n\t\t\tfunction formatNumber(value) {\n\t\t\t\treturn new Intl.NumberFormat(\"en-US\").format(value);\n\t\t\t}\n\t\t\tfunction cardCountLabel(count, singular, plural) {\n\t\t\t\treturn formatNumber(count) + \" \" + (count === 1 ? singular : plural);\n\t\t\t}\n\t\t\tfunction laneOverrideState(lane, prefs) {\n\t\t\t\tvar id = laneID(lane);\n\t\t\t\tif (prefs.show.has(id)) return stateShow;\n\t\t\t\tif (prefs.hide.has(id)) return stateHide;\n\t\t\t\treturn stateAuto;\n\t\t\t}\n\t\t\tfunction laneVisible(lane, state) {\n\t\t\t\tif (state === stateShow) return true;\n\t\t\t\tif (state === stateHide) return false;\n\t\t\t\treturn laneDefaultVisible(lane);\n\t\t\t}\n\t\t\tfunction stateLabel(lane, state, visible) {\n\t\t\t\tvar label = \"\";\n\t\t\t\tif (state === stateShow) {\n\t\t\t\t\tlabel = \"Always shown\";\n\t\t\t\t} else if (state === stateHide) {\n\t\t\t\t\tlabel = \"Always hidden\";\n\t\t\t\t} else {\n\t\t\t\t\tlabel = visible ? \"Auto shown\" : \"Auto hidden\";\n\t\t\t\t}\n\t\t\t\tif (!visible && laneCardCount(lane) > 0) {\n\t\t\t\t\treturn label + \" - \" + cardCountLabel(laneCardCount(lane), \"hidden card\", \"hidden cards\");\n\t\t\t\t}\n\t\t\t\treturn label;\n\t\t\t}\n\t\t\tfunction stateTitle(lane, state, visible) {\n\t\t\t\tvar title = \"\";\n\t\t\t\tif (state === stateShow) {\n\t\t\t\t\ttitle = \"Always show is saved for this lane.\";\n\t\t\t\t} else if (state === stateHide) {\n\t\t\t\t\ttitle = \"Always hide is saved for this lane.\";\n\t\t\t\t} else {\n\t\t\t\t\ttitle = \"Auto follows the board default.\";\n\t\t\t\t}\n\t\t\t\tif (!visible && laneCardCount(lane) > 0) {\n\t\t\t\t\treturn title + \" \" + cardCountLabel(laneCardCount(lane), \"card is\", \"cards are\") + \" hidden while this lane is off.\";\n\t\t\t\t}\n\t\t\t\treturn title;\n\t\t\t}\n\t\t\tfunction hiddenLaneSummary(lanes) {\n\t\t\t\tif (lanes.length === 0) return \"All populated lanes are visible.\";\n\t\t\t\tif (lanes.length === 1) {\n\t\t\t\t\tvar lane = lanes[0];\n\t\t\t\t\treturn cardCountLabel(lane.count, \"hidden card\", \"hidden cards\") + \" in \" + lane.title + \".\";\n\t\t\t\t}\n\t\t\t\tvar total = lanes.reduce(function (sum, lane) {\n\t\t\t\t\treturn sum + lane.count;\n\t\t\t\t}, 0);\n\t\t\t\tvar labels = lanes.map(function (lane) {\n\t\t\t\t\treturn lane.title + \" (\" + formatNumber(lane.count) + \")\";\n\t\t\t\t}).join(\", \");\n\t\t\t\treturn cardCountLabel(total, \"hidden card\", \"hidden cards\") + \" across \" + cardCountLabel(lanes.length, \"lane\", \"lanes\") + \": \" + labels + \".\";\n\t\t\t}\n\t\t\tfunction setResetDisabled(button, disabled) {\n\t\t\t\tif (!(button instanceof HTMLButtonElement)) return;\n\t\t\t\tbutton.disabled = disabled;\n\t\t\t\tbutton.setAttribute(\"aria-disabled\", disabled ? \"true\" : \"false\");\n\t\t\t}\n\t\t\tfunction updateLaneControls(scope, lane, state, visible) {\n\t\t\t\tvar id = laneID(lane);\n\t\t\t\tvar row = findByData(scope, \"data-board-lane-row\", id);\n\t\t\t\tvar hiddenPopulated = !visible && laneCardCount(lane) > 0;\n\t\t\t\tif (row instanceof HTMLElement) {\n\t\t\t\t\trow.dataset.boardLaneVisibilityState = state;\n\t\t\t\t\trow.dataset.boardLaneVisibilityEffective = visible ? \"visible\" : \"hidden\";\n\t\t\t\t\trow.dataset.boardLaneHiddenPopulated = hiddenPopulated ? \"true\" : \"false\";\n\t\t\t\t\trow.classList.toggle(\"border-warn/45\", hiddenPopulated);\n\t\t\t\t\trow.classList.toggle(\"bg-warn/10\", hiddenPopulated);\n\t\t\t\t\trow.classList.toggle(\"border-transparent\", !hiddenPopulated);\n\t\t\t\t\tvar status = row.querySelector(\"[data-board-lane-visibility-status]\");\n\t\t\t\t\tif (status) {\n\t\t\t\t\t\tstatus.textContent = stateLabel(lane, state, visible);\n\t\t\t\t\t\tstatus.setAttribute(\"title\", stateTitle(lane, state, visible));\n\t\t\t\t\t}\n\t\t\t\t}\n\t\t\t\tvar select = findByData(scope, \"data-board-lane-visibility\", id);\n\t\t\t\tif (select instanceof HTMLSelectElement) {\n\t\t\t\t\tselect.value = state;\n\t\t\t\t\tselect.dataset.boardLaneVisibilityState = state;\n\t\t\t\t\tselect.dataset.boardLaneVisibilityEffective = visible ? \"visible\" : \"hidden\";\n\t\t\t\t\tselect.setAttribute(\"title\", stateTitle(lane, state, visible));\n\t\t\t\t}\n\t\t\t\tsetResetDisabled(findByData(scope, \"data-board-lane-reset\", id), state === stateAuto);\n\t\t\t}\n\t\t\tfunction updateHiddenCardBadge(scope, hiddenCards, hiddenLanes) {\n\t\t\t\tvar root = queryRoot(scope);\n\t\t\t\tvar badge = root.querySelector(\"[data-board-hidden-card-count]\");\n\t\t\t\tif (!badge) return;\n\t\t\t\tvar summary = hiddenLaneSummary(hiddenLanes);\n\t\t\t\tbadge.hidden = hiddenCards === 0;\n\t\t\t\tbadge.textContent = hiddenCards > 0 ? formatNumber(hiddenCards) + \" hidden\" : \"\";\n\t\t\t\tbadge.setAttribute(\"title\", summary);\n\t\t\t\tbadge.setAttribute(\"aria-label\", summary);\n\t\t\t}\n\t\t\tfunction updateResetAll(scope, prefs) {\n\t\t\t\tqueryRoot(scope).querySelectorAll(\"[data-board-lane-reset-all]\").forEach(function (button) {\n\t\t\t\t\tsetResetDisabled(button, !prefsHaveOverrides(prefs));\n\t\t\t\t});\n\t\t\t}\n\t\t\tfunction applyTo(scope) {\n\t\t\t\tvar root = boardLanesRoot(scope);\n\t\t\t\tif (!root) return false;\n\t\t\t\tvar prefs = readPrefs(root);\n\t\t\t\tvar total = 0;\n\t\t\t\tvar visible = 0;\n\t\t\t\tvar hiddenCards = 0;\n\t\t\t\tvar hiddenLanes = [];\n\t\t\t\troot.querySelectorAll(\"[data-board-lane]\").forEach(function (lane) {\n\t\t\t\t\ttotal += 1;\n\t\t\t\t\tvar state = laneOverrideState(lane, prefs);\n\t\t\t\t\tvar show = laneVisible(lane, state);\n\t\t\t\t\tvar cards = laneCardCount(lane);\n\t\t\t\t\tlane.setAttribute(\"data-lane-hidden\", show ? \"false\" : \"true\");\n\t\t\t\t\tlane.setAttribute(\"data-board-lane-visibility-state\", state);\n\t\t\t\t\tlane.setAttribute(\"data-board-lane-pinned\", state === stateAuto ? \"false\" : \"true\");\n\t\t\t\t\tif (show) {\n\t\t\t\t\t\tvisible += 1;\n\t\t\t\t\t} else if (cards > 0) {\n\t\t\t\t\t\thiddenCards += cards;\n\t\t\t\t\t\thiddenLanes.push({ title: laneTitle(lane), count: cards });\n\t\t\t\t\t}\n\t\t\t\t\tupdateLaneControls(scope, lane, state, show);\n\t\t\t\t});\n\t\t\t\tvar count = queryRoot(scope).querySelector(\"[data-board-lane-count]\");\n\t\t\t\tif (count) count.textContent = visible + \"/\" + total;\n\t\t\t\tupdateHiddenCardBadge(scope, hiddenCards, hiddenLanes);\n\t\t\t\tupdateResetAll(scope, prefs);\n\t\t\t\tvar picker = queryRoot(scope).querySelector(\"[data-board-lane-picker]\");\n\t\t\t\tif (picker && pickerOpen) picker.setAttribute(\"open\", \"\");\n\t\t\t\tupdateLanePosition(scope, root, activeLaneID);\n\t\t\t\tif (root.isConnected) scheduleLanePosition(root);\n\t\t\t\tif (typeof window.__detentBoardKanbanDragAdjustSnapshot === \"function\") {\n\t\t\t\t\twindow.__detentBoardKanbanDragAdjustSnapshot(scope);\n\t\t\t\t}\n\t\t\t\treturn true;\n\t\t\t}\n\t\t\tfunction apply() {\n\t\t\t\tapplyTo(document);\n\t\t\t}\n\t\t\tfunction adjustedBoardHTML(html) {\n\t\t\t\tif (typeof html !== \"string\" || html.indexOf(\"data-board-lanes\") < 0) return \"\";\n\t\t\t\tvar template = document.createElement(\"template\");\n\t\t\t\ttemplate.innerHTML = html;\n\t\t\t\tif (!applyTo(template.content)) return \"\";\n\t\t\t\treturn template.innerHTML;\n\t\t\t}\n\t\t\tfunction snapshotSwapTarget(event) {\n\t\t\t\tvar target = event.detail && event.detail.target;\n\t\t\t\tif (!(target instanceof Element)) target = event.target;\n\t\t\t\tif (!(target instanceof Element)) return false;\n\t\t\t\treturn target.id === \"snapshot\" || Boolean(target.closest(\"#snapshot\"));\n\t\t\t}\n\t\t\tfunction applyBeforeSwap(event) {\n\t\t\t\tvar detail = event.detail || {};\n\t\t\t\tif (!snapshotSwapTarget(event) || typeof detail.serverResponse !== \"string\") return;\n\t\t\t\tvar adjusted = adjustedBoardHTML(detail.serverResponse);\n\t\t\t\tif (!adjusted) return;\n\t\t\t\tdetail.serverResponse = adjusted;\n\t\t\t}\n\t\t\tfunction applyBeforeSSEMessage(event) {\n\t\t\t\tvar detail = event.detail || {};\n\t\t\t\tvar target = detail.elt;\n\t\t\t\tif (!(target instanceof Element)) target = event.target;\n\t\t\t\tif (!(target instanceof Element) || target.id !== \"snapshot\") return;\n\t\t\t\tif (!window.htmx || typeof window.htmx.swap !== \"function\") return;\n\t\t\t\tvar adjusted = adjustedBoardHTML(detail.data);\n\t\t\t\tif (!adjusted) return;\n\t\t\t\tevent.preventDefault();\n\t\t\t\twindow.htmx.swap(target, adjusted, { swapStyle: target.getAttribute(\"hx-swap\") || \"innerHTML\" }, { contextElement: target });\n\t\t\t}\n\t\t\tfunction setLaneState(root, id, state) {\n\t\t\t\tvar prefs = readPrefs(root);\n\t\t\t\tprefs.show.delete(id);\n\t\t\t\tprefs.hide.delete(id);\n\t\t\t\tif (state === stateShow) prefs.show.add(id);\n\t\t\t\tif (state === stateHide) prefs.hide.add(id);\n\t\t\t\twritePrefs(root, prefs);\n\t\t\t\tapply();\n\t\t\t}\n\t\t\tdocument.addEventListener(\"change\", function (event) {\n\t\t\t\tvar target = event.target instanceof Element ? event.target : null;\n\t\t\t\tvar select = target ? target.closest(\"[data-board-lane-visibility]\") : null;\n\t\t\t\tif (!(select instanceof HTMLSelectElement)) return;\n\t\t\t\tvar root = document.querySelector(\"[data-board-lanes]\");\n\t\t\t\tif (!root) return;\n\t\t\t\tvar state = select.value;\n\t\t\t\tif (state !== stateShow && state !== stateHide) state = stateAuto;\n\t\t\t\tsetLaneState(root, select.getAttribute(\"data-board-lane-visibility\") || \"\", state);\n\t\t\t});\n\t\t\tdocument.addEventListener(\"toggle\", function (event) {\n\t\t\t\tvar picker = event.target;\n\t\t\t\tif (picker instanceof Element && picker.hasAttribute(\"data-board-lane-picker\")) {\n\t\t\t\t\tpickerOpen = picker.open;\n\t\t\t\t}\n\t\t\t}, true);\n\t\t\tdocument.addEventListener(\"click\", function (event) {\n\t\t\t\tvar target = event.target instanceof Element ? event.target : null;\n\t\t\t\tvar root = document.querySelector(\"[data-board-lanes]\");\n\t\t\t\tvar reset = target ? target.closest(\"[data-board-lane-reset]\") : null;\n\t\t\t\tif (reset instanceof HTMLButtonElement && root) {\n\t\t\t\t\tevent.preventDefault();\n\t\t\t\t\tsetLaneState(root, reset.value || reset.getAttribute(\"data-board-lane-reset\") || \"\", stateAuto);\n\t\t\t\t\treturn;\n\t\t\t\t}\n\t\t\t\tvar resetAll = target ? target.closest(\"[data-board-lane-reset-all]\") : null;\n\t\t\t\tif (resetAll instanceof HTMLButtonElement && root) {\n\t\t\t\t\tevent.preventDefault();\n\t\t\t\t\twritePrefs(root, emptyPrefs());\n\t\t\t\t\tapply();\n\t\t\t\t\treturn;\n\t\t\t\t}\n\t\t\t\tvar picker = document.querySelector(\"[data-board-lane-picker]\");\n\t\t\t\tif (picker && picker.open && !picker.contains(event.target)) {\n\t\t\t\t\tpicker.removeAttribute(\"open\");\n\t\t\t\t\tpickerOpen = false;\n\t\t\t\t}\n\t\t\t});\n\t\t\tdocument.addEventListener(\"keydown\", function (event) {\n\t\t\t\tif (event.key !== \"Escape\") return;\n\t\t\t\tvar picker = document.querySelector(\"[data-board-lane-picker]\");\n\t\t\t\tif (picker && picker.open) {\n\t\t\t\t\tpicker.removeAttribute(\"open\");\n\t\t\t\t\tpickerOpen = false;\n\t\t\t\t}\n\t\t\t});\n\t\t\tdocument.addEventListener(\"htmx:beforeSwap\", applyBeforeSwap);\n\t\t\tdocument.addEventListener(\"htmx:sseBeforeMessage\", applyBeforeSSEMessage);\n\t\t\tdocument.addEventListener(\"htmx:afterSettle\", apply);\n\t\t\tdocument.addEventListener(\"DOMContentLoaded\", apply);\n\t\t\tdocument.addEventListener(\"scroll\", function (event) {\n\t\t\t\tvar root = event.target instanceof Element && event.target.matches(\"[data-board-lanes]\") ? event.target : null;\n\t\t\t\tif (root) scheduleLanePosition(root);\n\t\t\t}, true);\n\t\t\twindow.addEventListener(\"resize\", function () {\n\t\t\t\tscheduleLanePosition(document.querySelector(\"[data-board-lanes]\"));\n\t\t\t});\n\t\t\twindow.addEventListener(\"storage\", function (event) {\n\t\t\t\tif (event.key && event.key.indexOf(storagePrefix) === 0) apply();\n\t\t\t});\n\t\t\tapply();\n\t\t})();\n\t</script>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -3184,12 +3231,12 @@ func boardKanbanDragScript() templ.Component {
 			}()
 		}
 		ctx = templ.InitializeContext(ctx)
-		templ_7745c5c3_Var171 := templ.GetChildren(ctx)
-		if templ_7745c5c3_Var171 == nil {
-			templ_7745c5c3_Var171 = templ.NopComponent
+		templ_7745c5c3_Var174 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var174 == nil {
+			templ_7745c5c3_Var174 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 272, "<script>\n\t\t(function () {\n\t\t\tif (window.__detentBoardKanbanDragHandlersRegistered) return;\n\t\t\twindow.__detentBoardKanbanDragHandlersRegistered = true;\n\t\t\tvar DRAG_THRESHOLD_PX = 6;\n\t\t\tvar TOUCH_MOVE_TOLERANCE_PX = 10;\n\t\t\tvar TOUCH_LONG_PRESS_MS = 450;\n\t\t\tvar TOUCH_EDGE_ZONE_PX = 56;\n\t\t\tvar TOUCH_EDGE_ADVANCE_MS = 500;\n\t\t\t// Real mouse clicks travel a few pixels between press and release,\n\t\t\t// so distance alone cannot separate a click from a drag. A short\n\t\t\t// gesture released back over the source lane is a click: finish the\n\t\t\t// drag without swallowing the click so the detail sheet still opens.\n\t\t\tvar CLICK_GESTURE_MS = 250;\n\t\t\tvar draggedIssueID = \"\";\n\t\t\tvar draggedAllowedTargetKeys = [];\n\t\t\tvar pending = null;\n\t\t\tvar active = null;\n\t\t\tvar recentTouchStart = null;\n\t\t\tfunction connectionAllowsMoves() {\n\t\t\t\treturn document.documentElement.getAttribute(\"data-detent-connection\") === \"connected\";\n\t\t\t}\n\t\t\tfunction clearPending() {\n\t\t\t\tif (pending && pending.longPressTimer) window.clearTimeout(pending.longPressTimer);\n\t\t\t\tpending = null;\n\t\t\t\trecentTouchStart = null;\n\t\t\t}\n\t\t\tfunction touchWithIdentifier(touches, identifier) {\n\t\t\t\tif (!touches || identifier === null || identifier === undefined) return null;\n\t\t\t\tfor (var index = 0; index < touches.length; index += 1) {\n\t\t\t\t\tif (touches[index].identifier === identifier) return touches[index];\n\t\t\t\t}\n\t\t\t\treturn null;\n\t\t\t}\n\t\t\tfunction recentTouchIdentifier(card, event) {\n\t\t\t\tif (event.pointerType !== \"touch\" || !recentTouchStart) return null;\n\t\t\t\tif (Date.now() - recentTouchStart.startedAt >= 100) return null;\n\t\t\t\tif (!(recentTouchStart.target instanceof Node) || !card.contains(recentTouchStart.target)) return null;\n\t\t\t\treturn recentTouchStart.identifier;\n\t\t\t}\n\t\t\tfunction feedback(message, kind) {\n\t\t\t\tvar target = document.getElementById(\"board-feedback\");\n\t\t\t\tif (!target) return;\n\t\t\t\tvar text = String(message || \"\").trim();\n\t\t\t\ttarget.className = \"flex flex-none items-center gap-2 px-5 pt-3.5 text-xs \" + (kind === \"error\" ? \"text-err\" : \"text-sec\");\n\t\t\t\ttarget.textContent = text;\n\t\t\t\ttarget.hidden = text === \"\";\n\t\t\t}\n\t\t\tfunction queryRoot(scope) {\n\t\t\t\tif (scope && typeof scope.querySelector === \"function\" && typeof scope.querySelectorAll === \"function\") return scope;\n\t\t\t\treturn document;\n\t\t\t}\n\t\t\tfunction draggedCard(scope) {\n\t\t\t\tif (!draggedIssueID || !window.CSS || typeof CSS.escape !== \"function\") return null;\n\t\t\t\treturn queryRoot(scope).querySelector(\"[data-kanban-card][data-kanban-issue-id='\" + CSS.escape(draggedIssueID) + \"']\");\n\t\t\t}\n\t\t\tfunction cardByIssueID(scope, issueID) {\n\t\t\t\tvar cards = queryRoot(scope).querySelectorAll(\"[data-kanban-card][data-kanban-issue-id]\");\n\t\t\t\tfor (var index = 0; index < cards.length; index += 1) {\n\t\t\t\t\tif (cards[index].dataset.kanbanIssueId === issueID) return cards[index];\n\t\t\t\t}\n\t\t\t\treturn null;\n\t\t\t}\n\t\t\tfunction laneByState(scope, state) {\n\t\t\t\tvar lanes = queryRoot(scope).querySelectorAll(\"[data-kanban-drop-state]\");\n\t\t\t\tfor (var index = 0; index < lanes.length; index += 1) {\n\t\t\t\t\tif (lanes[index].dataset.kanbanDropState === state) return lanes[index];\n\t\t\t\t}\n\t\t\t\treturn null;\n\t\t\t}\n\t\t\tfunction cardContainer(lane) {\n\t\t\t\treturn lane instanceof HTMLElement ? lane.querySelector(\"[data-kanban-card-container]\") : null;\n\t\t\t}\n\t\t\tfunction updateEmptyLine(container) {\n\t\t\t\tif (!(container instanceof HTMLElement)) return;\n\t\t\t\tvar emptyLine = container.querySelector(\"[data-kanban-empty-line]\");\n\t\t\t\tif (emptyLine instanceof HTMLElement) emptyLine.hidden = Boolean(container.querySelector(\"[data-kanban-card]\"));\n\t\t\t}\n\t\t\tfunction placeCardInLane(card, state, scope) {\n\t\t\t\tvar lane = laneByState(scope, state);\n\t\t\t\tvar container = cardContainer(lane);\n\t\t\t\tif (!(card instanceof HTMLElement) || !(lane instanceof HTMLElement) || !(container instanceof HTMLElement)) return null;\n\t\t\t\tvar previousContainer = card.parentElement;\n\t\t\t\tcontainer.appendChild(card);\n\t\t\t\tlane.dataset.laneHidden = \"false\";\n\t\t\t\tupdateEmptyLine(previousContainer);\n\t\t\t\tupdateEmptyLine(container);\n\t\t\t\treturn lane;\n\t\t\t}\n\t\t\tfunction copyPendingMove(source, target) {\n\t\t\t\t[\n\t\t\t\t\t\"kanbanPendingMove\",\n\t\t\t\t\t\"kanbanPendingOrigin\",\n\t\t\t\t\t\"kanbanPendingSeq\",\n\t\t\t\t\t\"kanbanPendingTargetWasHidden\"\n\t\t\t\t].forEach(function (key) {\n\t\t\t\t\tif (source.dataset[key] === undefined) {\n\t\t\t\t\t\tdelete target.dataset[key];\n\t\t\t\t\t} else {\n\t\t\t\t\t\ttarget.dataset[key] = source.dataset[key];\n\t\t\t\t\t}\n\t\t\t\t});\n\t\t\t}\n\t\t\tfunction clearPendingMove(card) {\n\t\t\t\tif (!(card instanceof HTMLElement)) return;\n\t\t\t\tdelete card.dataset.kanbanPendingMove;\n\t\t\t\tdelete card.dataset.kanbanPendingOrigin;\n\t\t\t\tdelete card.dataset.kanbanPendingSeq;\n\t\t\t\tdelete card.dataset.kanbanPendingTargetWasHidden;\n\t\t\t}\n\t\t\tfunction pendingMoveSuperseded(liveCard, serverCard) {\n\t\t\t\tvar targetState = liveCard.dataset.kanbanPendingMove || \"\";\n\t\t\t\tif ((serverCard.dataset.kanbanCurrentState || \"\") === targetState) return true;\n\t\t\t\tvar pendingSeq = Number.parseInt(liveCard.dataset.kanbanPendingSeq || \"\", 10);\n\t\t\t\tvar serverSeq = Number.parseInt(serverCard.dataset.kanbanDataSeq || \"\", 10);\n\t\t\t\treturn Number.isFinite(pendingSeq) && Number.isFinite(serverSeq) && serverSeq > pendingSeq;\n\t\t\t}\n\t\t\tfunction applyPendingMoveState(scope) {\n\t\t\t\tvar root = queryRoot(scope);\n\t\t\t\tvar applied = false;\n\t\t\t\tdocument.querySelectorAll(\"#snapshot [data-kanban-card][data-kanban-pending-move]\").forEach(function (liveCard) {\n\t\t\t\t\tif (!(liveCard instanceof HTMLElement)) return;\n\t\t\t\t\tvar issueID = liveCard.dataset.kanbanIssueId || \"\";\n\t\t\t\t\tvar serverCard = cardByIssueID(root, issueID);\n\t\t\t\t\tif (!(serverCard instanceof HTMLElement)) return;\n\t\t\t\t\tif (pendingMoveSuperseded(liveCard, serverCard)) {\n\t\t\t\t\t\tif (serverCard === liveCard) clearPendingMove(serverCard);\n\t\t\t\t\t\treturn;\n\t\t\t\t\t}\n\t\t\t\t\tcopyPendingMove(liveCard, serverCard);\n\t\t\t\t\tif (placeCardInLane(serverCard, liveCard.dataset.kanbanPendingMove || \"\", root)) applied = true;\n\t\t\t\t});\n\t\t\t\treturn applied;\n\t\t\t}\n\t\t\tfunction targetKeysFromValue(value) {\n\t\t\t\treturn String(value || \"\").split(/\\s+/).filter(Boolean);\n\t\t\t}\n\t\t\tfunction allowedTargetKeys(card) {\n\t\t\t\tif (card instanceof HTMLElement) {\n\t\t\t\t\tvar keys = targetKeysFromValue(card.dataset.kanbanAllowedTargets || \"\");\n\t\t\t\t\tif (keys.length > 0) return keys;\n\t\t\t\t}\n\t\t\t\treturn draggedAllowedTargetKeys.slice();\n\t\t\t}\n\t\t\tfunction laneAllowed(card, lane) {\n\t\t\t\tif (!(lane instanceof HTMLElement)) return false;\n\t\t\t\tvar key = lane.dataset.kanbanDropKey || \"\";\n\t\t\t\treturn key !== \"\" && allowedTargetKeys(card).includes(key);\n\t\t\t}\n\t\t\tfunction setDropTargetState(card, scope) {\n\t\t\t\tvar sourceLane = card instanceof HTMLElement ? card.closest(\"[data-kanban-drop-state]\") : null;\n\t\t\t\tqueryRoot(scope).querySelectorAll(\"[data-kanban-drop-state]\").forEach(function (lane) {\n\t\t\t\t\tif (!(lane instanceof HTMLElement)) return;\n\t\t\t\t\tif (lane.dataset.kanbanDropWasHidden === undefined) {\n\t\t\t\t\t\tlane.dataset.kanbanDropWasHidden = lane.dataset.laneHidden || \"false\";\n\t\t\t\t\t}\n\t\t\t\t\tlane.dataset.laneHidden = \"false\";\n\t\t\t\t\tif (lane === sourceLane) {\n\t\t\t\t\t\t// The origin lane is not a transition target, but styling\n\t\t\t\t\t\t// it blocked reads as an error; mark it as the source so\n\t\t\t\t\t\t// the operator can see where the card came from.\n\t\t\t\t\t\tlane.dataset.kanbanDropSource = \"true\";\n\t\t\t\t\t\tdelete lane.dataset.kanbanDropAllowed;\n\t\t\t\t\t\tlane.removeAttribute(\"aria-disabled\");\n\t\t\t\t\t\treturn;\n\t\t\t\t\t}\n\t\t\t\t\tdelete lane.dataset.kanbanDropSource;\n\t\t\t\t\tvar allowed = laneAllowed(card, lane);\n\t\t\t\t\tlane.dataset.kanbanDropAllowed = allowed ? \"true\" : \"false\";\n\t\t\t\t\tlane.setAttribute(\"aria-disabled\", allowed ? \"false\" : \"true\");\n\t\t\t\t});\n\t\t\t}\n\t\t\tfunction applyActiveDragState(scope) {\n\t\t\t\tif (!draggedIssueID || draggedAllowedTargetKeys.length === 0) return false;\n\t\t\t\tvar root = queryRoot(scope);\n\t\t\t\tvar card = draggedCard(root);\n\t\t\t\tif (card instanceof HTMLElement) card.dataset.kanbanDragging = \"true\";\n\t\t\t\tsetDropTargetState(card, root);\n\t\t\t\tapplyTouchDragStyles(card, root);\n\t\t\t\treturn true;\n\t\t\t}\n\t\t\tfunction applyDragState(scope) {\n\t\t\t\tvar pendingApplied = applyPendingMoveState(scope);\n\t\t\t\treturn applyActiveDragState(scope) || pendingApplied;\n\t\t\t}\n\t\t\twindow.__detentBoardKanbanDragAdjustSnapshot = applyDragState;\n\t\t\tfunction clearDropTargetState() {\n\t\t\t\tdocument.querySelectorAll(\"[data-kanban-drop-state]\").forEach(function (lane) {\n\t\t\t\t\tif (!(lane instanceof HTMLElement)) return;\n\t\t\t\t\tif (lane.dataset.kanbanDropWasHidden !== undefined) {\n\t\t\t\t\t\tlane.dataset.laneHidden = lane.dataset.kanbanDropWasHidden;\n\t\t\t\t\t\tdelete lane.dataset.kanbanDropWasHidden;\n\t\t\t\t\t}\n\t\t\t\t\tdelete lane.dataset.kanbanDropAllowed;\n\t\t\t\t\tdelete lane.dataset.kanbanDropSource;\n\t\t\t\t\tlane.removeAttribute(\"aria-disabled\");\n\t\t\t\t});\n\t\t\t\tdocument.querySelectorAll(\"[data-kanban-card][data-kanban-dragging='true']\").forEach(function (card) {\n\t\t\t\t\tif (card instanceof HTMLElement) delete card.dataset.kanbanDragging;\n\t\t\t\t});\n\t\t\t}\n\t\t\tfunction responseMessage(response) {\n\t\t\t\tif (!response) return \"\";\n\t\t\t\tvar doc = new DOMParser().parseFromString(response, \"text/html\");\n\t\t\t\treturn (doc.body.textContent || \"\").trim();\n\t\t\t}\n\t\t\tfunction buildGhost(card, rect) {\n\t\t\t\tvar ghost = card.cloneNode(true);\n\t\t\t\tghost.removeAttribute(\"id\");\n\t\t\t\tghost.querySelectorAll(\"[id]\").forEach(function (node) {\n\t\t\t\t\tnode.removeAttribute(\"id\");\n\t\t\t\t});\n\t\t\t\tvar form = ghost.querySelector(\"[data-kanban-drag-move-form]\");\n\t\t\t\tif (form) form.remove();\n\t\t\t\tdelete ghost.dataset.kanbanDragging;\n\t\t\t\tvar origin = document.createElement(\"div\");\n\t\t\t\torigin.className = \"mb-1.5 flex items-center gap-1.5 border-b border-line pb-1.5 font-mono text-2xs font-medium text-accent\";\n\t\t\t\torigin.textContent = \"From \" + (card.dataset.kanbanCurrentState || \"current lane\");\n\t\t\t\tghost.insertBefore(origin, ghost.firstChild);\n\t\t\t\tghost.setAttribute(\"aria-hidden\", \"true\");\n\t\t\t\tghost.style.position = \"fixed\";\n\t\t\t\tghost.style.left = \"0\";\n\t\t\t\tghost.style.top = \"0\";\n\t\t\t\tghost.style.margin = \"0\";\n\t\t\t\tghost.style.width = rect.width + \"px\";\n\t\t\t\tghost.style.height = rect.height + \"px\";\n\t\t\t\tghost.style.pointerEvents = \"none\";\n\t\t\t\tghost.style.zIndex = \"1000\";\n\t\t\t\tghost.style.opacity = \"0.9\";\n\t\t\t\tghost.style.boxShadow = \"0 12px 32px rgba(0, 0, 0, 0.35)\";\n\t\t\t\tghost.style.willChange = \"transform\";\n\t\t\t\tdocument.body.appendChild(ghost);\n\t\t\t\treturn ghost;\n\t\t\t}\n\t\t\tfunction moveGhost(ghost, x, y, offsetX, offsetY) {\n\t\t\t\tghost.style.transform = \"translate(\" + Math.round(x - offsetX) + \"px, \" + Math.round(y - offsetY) + \"px)\";\n\t\t\t}\n\t\t\tfunction laneFromPoint(x, y) {\n\t\t\t\tvar hit = document.elementFromPoint(x, y);\n\t\t\t\treturn hit instanceof Element ? hit.closest(\"[data-kanban-drop-state]\") : null;\n\t\t\t}\n\t\t\tfunction applyTouchStyle(element, styles) {\n\t\t\t\tif (!active || active.pointerType !== \"touch\" || !(element instanceof HTMLElement) || !element.isConnected) return;\n\t\t\t\tif (!active.touchStyles.has(element)) {\n\t\t\t\t\tvar original = {};\n\t\t\t\t\tObject.keys(styles).forEach(function (property) {\n\t\t\t\t\t\toriginal[property] = element.style[property];\n\t\t\t\t\t});\n\t\t\t\t\tactive.touchStyles.set(element, original);\n\t\t\t\t}\n\t\t\t\tObject.keys(styles).forEach(function (property) {\n\t\t\t\t\telement.style[property] = styles[property];\n\t\t\t\t});\n\t\t\t}\n\t\t\tfunction applyTouchDragStyles(card, scope) {\n\t\t\t\tif (!active || active.pointerType !== \"touch\") return;\n\t\t\t\tvar root = queryRoot(scope);\n\t\t\t\tvar lanes = root.querySelector(\"[data-board-lanes]\");\n\t\t\t\tapplyTouchStyle(lanes, { touchAction: \"none\", scrollSnapType: \"none\" });\n\t\t\t\tapplyTouchStyle(card, {\n\t\t\t\t\ttouchAction: \"none\",\n\t\t\t\t\toutline: \"2px solid var(--color-accent)\",\n\t\t\t\t\toutlineOffset: \"2px\"\n\t\t\t\t});\n\t\t\t}\n\t\t\tfunction restoreTouchDragStyles() {\n\t\t\t\tif (!active || !active.touchStyles) return;\n\t\t\t\tactive.touchStyles.forEach(function (styles, element) {\n\t\t\t\t\tObject.keys(styles).forEach(function (property) {\n\t\t\t\t\t\telement.style[property] = styles[property];\n\t\t\t\t\t});\n\t\t\t\t});\n\t\t\t\tactive.touchStyles.clear();\n\t\t\t}\n\t\t\t// Native drags auto-scrolled the lane strip at the viewport edges;\n\t\t\t// pointer drags must do it themselves. Scrolls only while the\n\t\t\t// pointer moves, which is enough to reach off-screen lanes.\n\t\t\tfunction autoScrollLanes(x) {\n\t\t\t\tvar lanes = document.getElementById(\"board-lanes\");\n\t\t\t\tif (!lanes) return;\n\t\t\t\tvar rect = lanes.getBoundingClientRect();\n\t\t\t\tif (x < rect.left + 48) {\n\t\t\t\t\tlanes.scrollLeft -= 16;\n\t\t\t\t} else if (x > rect.right - 48) {\n\t\t\t\t\tlanes.scrollLeft += 16;\n\t\t\t\t}\n\t\t\t}\n\t\t\tfunction visibleDropLanes(lanes) {\n\t\t\t\treturn Array.from(lanes.querySelectorAll(\"[data-kanban-drop-state]\")).filter(function (lane) {\n\t\t\t\t\treturn lane instanceof HTMLElement && lane.dataset.laneHidden !== \"true\";\n\t\t\t\t});\n\t\t\t}\n\t\t\tfunction closestLaneIndex(lanes, laneNodes) {\n\t\t\t\tvar center = lanes.getBoundingClientRect().left + lanes.clientWidth / 2;\n\t\t\t\tvar closest = 0;\n\t\t\t\tvar distance = Infinity;\n\t\t\t\tlaneNodes.forEach(function (lane, index) {\n\t\t\t\t\tvar rect = lane.getBoundingClientRect();\n\t\t\t\t\tvar candidate = Math.abs(rect.left + rect.width / 2 - center);\n\t\t\t\t\tif (candidate < distance) {\n\t\t\t\t\t\tdistance = candidate;\n\t\t\t\t\t\tclosest = index;\n\t\t\t\t\t}\n\t\t\t\t});\n\t\t\t\treturn closest;\n\t\t\t}\n\t\t\tfunction advanceTouchLane(direction) {\n\t\t\t\tif (!active || active.pointerType !== \"touch\" || active.edgeDirection !== direction) return;\n\t\t\t\tactive.edgeTimer = null;\n\t\t\t\tvar lanes = document.getElementById(\"board-lanes\");\n\t\t\t\tif (!lanes) return;\n\t\t\t\tvar laneNodes = visibleDropLanes(lanes);\n\t\t\t\tif (laneNodes.length === 0) return;\n\t\t\t\tvar current = closestLaneIndex(lanes, laneNodes);\n\t\t\t\tvar target = Math.max(0, Math.min(laneNodes.length - 1, current + direction));\n\t\t\t\tif (target !== current) {\n\t\t\t\t\tlaneNodes[target].scrollIntoView({ behavior: \"smooth\", block: \"nearest\", inline: \"start\" });\n\t\t\t\t}\n\t\t\t\tif (active && active.edgeDirection === direction && target !== current) {\n\t\t\t\t\tactive.edgeTimer = window.setTimeout(function () {\n\t\t\t\t\t\tadvanceTouchLane(direction);\n\t\t\t\t\t}, TOUCH_EDGE_ADVANCE_MS);\n\t\t\t\t}\n\t\t\t}\n\t\t\tfunction updateTouchEdgeAdvance(x) {\n\t\t\t\tif (!active || active.pointerType !== \"touch\") return;\n\t\t\t\tvar lanes = document.getElementById(\"board-lanes\");\n\t\t\t\tif (!lanes) return;\n\t\t\t\tvar rect = lanes.getBoundingClientRect();\n\t\t\t\tvar direction = x < rect.left + TOUCH_EDGE_ZONE_PX ? -1 : (x > rect.right - TOUCH_EDGE_ZONE_PX ? 1 : 0);\n\t\t\t\tif (direction === active.edgeDirection) return;\n\t\t\t\tif (active.edgeTimer) window.clearTimeout(active.edgeTimer);\n\t\t\t\tactive.edgeDirection = direction;\n\t\t\t\tactive.edgeTimer = direction === 0 ? null : window.setTimeout(function () {\n\t\t\t\t\tadvanceTouchLane(direction);\n\t\t\t\t}, TOUCH_EDGE_ADVANCE_MS);\n\t\t\t}\n\t\t\tfunction stopTouchEdgeAdvance() {\n\t\t\t\tif (!active) return;\n\t\t\t\tif (active.edgeTimer) window.clearTimeout(active.edgeTimer);\n\t\t\t\tactive.edgeTimer = null;\n\t\t\t\tactive.edgeDirection = 0;\n\t\t\t}\n\t\t\tfunction suppressNextClick() {\n\t\t\t\tvar until = Date.now() + 400;\n\t\t\t\tdocument.addEventListener(\"click\", function suppress(event) {\n\t\t\t\t\tdocument.removeEventListener(\"click\", suppress, true);\n\t\t\t\t\tif (Date.now() > until) return;\n\t\t\t\t\tevent.preventDefault();\n\t\t\t\t\tevent.stopImmediatePropagation();\n\t\t\t\t}, true);\n\t\t\t}\n\t\t\tfunction beginDrag(event) {\n\t\t\t\tvar press = pending;\n\t\t\t\tif (!press) return;\n\t\t\t\tif (press.longPressTimer) window.clearTimeout(press.longPressTimer);\n\t\t\t\tdraggedIssueID = press.issueID;\n\t\t\t\tdraggedAllowedTargetKeys = press.targets;\n\t\t\t\tvar card = draggedCard(document) || press.card;\n\t\t\t\tactive = {\n\t\t\t\t\tpointerId: press.pointerId,\n\t\t\t\t\tpointerType: press.pointerType,\n\t\t\t\t\ttouchIdentifier: press.touchIdentifier,\n\t\t\t\t\toffsetX: press.startX - press.rect.left,\n\t\t\t\t\toffsetY: press.startY - press.rect.top,\n\t\t\t\t\tghost: buildGhost(card, press.rect),\n\t\t\t\t\tlastLaneBlocked: false,\n\t\t\t\t\tstartedAt: press.startedAt,\n\t\t\t\t\tcaptureElement: press.card,\n\t\t\t\t\ttouchStyles: new Map(),\n\t\t\t\t\tedgeDirection: 0,\n\t\t\t\t\tedgeTimer: null\n\t\t\t\t};\n\t\t\t\tpending = null;\n\t\t\t\trecentTouchStart = null;\n\t\t\t\tif (active.pointerType === \"touch\" && typeof active.captureElement.setPointerCapture === \"function\") {\n\t\t\t\t\ttry {\n\t\t\t\t\t\tactive.captureElement.setPointerCapture(active.pointerId);\n\t\t\t\t\t} catch (_) {}\n\t\t\t\t}\n\t\t\t\tcard.dataset.kanbanDragging = \"true\";\n\t\t\t\tsetDropTargetState(card, document);\n\t\t\t\tapplyTouchDragStyles(card, document);\n\t\t\t\tfeedback(\"Moving \" + (card.dataset.kanbanCurrentState || \"card\") + \".\");\n\t\t\t\tmoveGhost(active.ghost, event.clientX, event.clientY, active.offsetX, active.offsetY);\n\t\t\t}\n\t\t\tfunction finishDrag(keepClick) {\n\t\t\t\tif (active) {\n\t\t\t\t\tstopTouchEdgeAdvance();\n\t\t\t\t\trestoreTouchDragStyles();\n\t\t\t\t\tif (active.ghost) active.ghost.remove();\n\t\t\t\t\tif (active.captureElement && typeof active.captureElement.releasePointerCapture === \"function\") {\n\t\t\t\t\t\ttry {\n\t\t\t\t\t\t\tif (active.captureElement.hasPointerCapture(active.pointerId)) active.captureElement.releasePointerCapture(active.pointerId);\n\t\t\t\t\t\t} catch (_) {}\n\t\t\t\t\t}\n\t\t\t\t}\n\t\t\t\tclearPending();\n\t\t\t\tactive = null;\n\t\t\t\tdraggedIssueID = \"\";\n\t\t\t\tdraggedAllowedTargetKeys = [];\n\t\t\t\tclearDropTargetState();\n\t\t\t\t// A drag ends with the pointer still over a card, so the release\n\t\t\t\t// also fires a click; swallow it or the detail sheet opens.\n\t\t\t\tif (!keepClick) suppressNextClick();\n\t\t\t}\n\t\t\tfunction cancelDrag(keepClick) {\n\t\t\t\tif (!active) {\n\t\t\t\t\tclearPending();\n\t\t\t\t\treturn;\n\t\t\t\t}\n\t\t\t\tfinishDrag(keepClick);\n\t\t\t\tfeedback(\"Move cancelled.\", \"error\");\n\t\t\t}\n\t\t\tfunction rollbackPendingMove(card) {\n\t\t\t\tif (!(card instanceof HTMLElement) || !card.dataset.kanbanPendingMove) return;\n\t\t\t\tvar targetLane = card.closest(\"[data-kanban-drop-state]\");\n\t\t\t\tvar targetWasHidden = card.dataset.kanbanPendingTargetWasHidden === \"true\";\n\t\t\t\tvar originState = card.dataset.kanbanPendingOrigin || \"\";\n\t\t\t\tclearPendingMove(card);\n\t\t\t\tplaceCardInLane(card, originState, document);\n\t\t\t\tif (targetLane instanceof HTMLElement) {\n\t\t\t\t\ttargetLane.dataset.laneHidden = targetWasHidden ? \"true\" : \"false\";\n\t\t\t\t\tupdateEmptyLine(cardContainer(targetLane));\n\t\t\t\t}\n\t\t\t}\n\t\t\tfunction moveDragTo(x, y) {\n\t\t\t\tif (!active) return;\n\t\t\t\tmoveGhost(active.ghost, x, y, active.offsetX, active.offsetY);\n\t\t\t\tif (active.pointerType === \"touch\") {\n\t\t\t\t\tupdateTouchEdgeAdvance(x);\n\t\t\t\t} else {\n\t\t\t\t\tautoScrollLanes(x);\n\t\t\t\t}\n\t\t\t\tvar lane = laneFromPoint(x, y);\n\t\t\t\tvar card = draggedCard(document);\n\t\t\t\tvar blocked = lane instanceof HTMLElement && lane.dataset.kanbanDropSource !== \"true\" && !laneAllowed(card, lane);\n\t\t\t\tif (blocked && !active.lastLaneBlocked) {\n\t\t\t\t\tfeedback(\"Move blocked by transition policy.\", \"error\");\n\t\t\t\t} else if (!blocked && active.lastLaneBlocked) {\n\t\t\t\t\tfeedback(\"Moving \" + ((card && card.dataset.kanbanCurrentState) || \"card\") + \".\");\n\t\t\t\t}\n\t\t\t\tactive.lastLaneBlocked = blocked;\n\t\t\t}\n\t\t\tdocument.addEventListener(\"pointerdown\", function (event) {\n\t\t\t\tif (active || event.button !== 0 || event.isPrimary === false) return;\n\t\t\t\tvar pressedElement = event.target instanceof Element ? event.target : null;\n\t\t\t\tvar pressedCard = pressedElement ? pressedElement.closest(\"[data-kanban-card]\") : null;\n\t\t\t\tif (pressedCard && !connectionAllowsMoves()) {\n\t\t\t\t\tif (pressedElement.closest(\"a, button, input, select, textarea, summary, label, [data-help-trigger]\")) return;\n\t\t\t\t\tfeedback(\"Moves are disabled while the board reconnects. Reload if the connection does not recover.\", \"error\");\n\t\t\t\t\treturn;\n\t\t\t\t}\n\t\t\t\tif (pressedCard && pressedCard.dataset.kanbanMoveDisabled === \"true\") {\n\t\t\t\t\tif (pressedElement.closest(\"a, button, input, select, textarea, summary, label, [data-help-trigger]\")) return;\n\t\t\t\t\tfeedback(pressedCard.dataset.kanbanMoveDisabledReason || \"This card cannot be moved.\", \"error\");\n\t\t\t\t\treturn;\n\t\t\t\t}\n\t\t\t\tvar card = pressedCard && pressedCard.dataset.kanbanAction === \"move\" ? pressedCard : null;\n\t\t\t\tif (!card) return;\n\t\t\t\tif (card.dataset.kanbanPendingMove) return;\n\t\t\t\tvar issueID = card.dataset.kanbanIssueId || \"\";\n\t\t\t\tif (!issueID) return;\n\t\t\t\tpending = {\n\t\t\t\t\tpointerId: event.pointerId,\n\t\t\t\t\tpointerType: event.pointerType,\n\t\t\t\t\ttouchIdentifier: recentTouchIdentifier(card, event),\n\t\t\t\t\tcard: card,\n\t\t\t\t\tissueID: issueID,\n\t\t\t\t\ttargets: targetKeysFromValue(card.dataset.kanbanAllowedTargets || \"\"),\n\t\t\t\t\trect: card.getBoundingClientRect(),\n\t\t\t\t\tstartX: event.clientX,\n\t\t\t\t\tstartY: event.clientY,\n\t\t\t\t\tlastX: event.clientX,\n\t\t\t\t\tlastY: event.clientY,\n\t\t\t\t\tstartedAt: Date.now(),\n\t\t\t\t\tlongPressTimer: null\n\t\t\t\t};\n\t\t\t\tif (event.pointerType === \"touch\") {\n\t\t\t\t\tvar pointerId = event.pointerId;\n\t\t\t\t\tpending.longPressTimer = window.setTimeout(function () {\n\t\t\t\t\t\tif (!pending || pending.pointerId !== pointerId) return;\n\t\t\t\t\t\tbeginDrag({ clientX: pending.lastX, clientY: pending.lastY });\n\t\t\t\t\t}, TOUCH_LONG_PRESS_MS);\n\t\t\t\t}\n\t\t\t});\n\t\t\tdocument.addEventListener(\"touchstart\", function (event) {\n\t\t\t\tif (active || !event.changedTouches || event.changedTouches.length === 0) return;\n\t\t\t\tvar touch = event.changedTouches[0];\n\t\t\t\trecentTouchStart = {\n\t\t\t\t\tidentifier: touch.identifier,\n\t\t\t\t\ttarget: event.target,\n\t\t\t\t\tstartedAt: Date.now()\n\t\t\t\t};\n\t\t\t\tif (pending && pending.pointerType === \"touch\" && event.target instanceof Node && pending.card.contains(event.target)) {\n\t\t\t\t\tpending.touchIdentifier = touch.identifier;\n\t\t\t\t}\n\t\t\t});\n\t\t\tdocument.addEventListener(\"pointermove\", function (event) {\n\t\t\t\tif (pending && event.pointerId === pending.pointerId) {\n\t\t\t\t\tif (pending.pointerType === \"touch\") {\n\t\t\t\t\t\tif (Math.hypot(event.clientX - pending.startX, event.clientY - pending.startY) >= TOUCH_MOVE_TOLERANCE_PX) {\n\t\t\t\t\t\t\tclearPending();\n\t\t\t\t\t\t\treturn;\n\t\t\t\t\t\t}\n\t\t\t\t\t\tpending.lastX = event.clientX;\n\t\t\t\t\t\tpending.lastY = event.clientY;\n\t\t\t\t\t\treturn;\n\t\t\t\t\t}\n\t\t\t\t\t// A missed pointerup (released outside the window) must not\n\t\t\t\t\t// leave a stale press that turns a later hover into a drag.\n\t\t\t\t\tif (event.buttons === 0) {\n\t\t\t\t\t\tclearPending();\n\t\t\t\t\t\treturn;\n\t\t\t\t\t}\n\t\t\t\t\tif (Math.hypot(event.clientX - pending.startX, event.clientY - pending.startY) < DRAG_THRESHOLD_PX) return;\n\t\t\t\t\tbeginDrag(event);\n\t\t\t\t\treturn;\n\t\t\t\t}\n\t\t\t\tif (!active || event.pointerId !== active.pointerId) return;\n\t\t\t\tif (active.pointerType !== \"touch\" && event.buttons === 0) {\n\t\t\t\t\t// The release happened outside the window, so no click is\n\t\t\t\t\t// coming — cancelling must not arm the click suppressor or\n\t\t\t\t\t// it would eat the next real click after recovery.\n\t\t\t\t\tcancelDrag(true);\n\t\t\t\t\treturn;\n\t\t\t\t}\n\t\t\t\tevent.preventDefault();\n\t\t\t\tmoveDragTo(event.clientX, event.clientY);\n\t\t\t}, { passive: false });\n\t\t\tfunction dropAt(x, y) {\n\t\t\t\tif (!active) return;\n\t\t\t\tif (!connectionAllowsMoves()) {\n\t\t\t\t\tcancelDrag();\n\t\t\t\t\tfeedback(\"Move cancelled because the board connection was lost.\", \"error\");\n\t\t\t\t\treturn;\n\t\t\t\t}\n\t\t\t\tvar lane = laneFromPoint(x, y);\n\t\t\t\tvar card = draggedCard(document);\n\t\t\t\tif (!(lane instanceof HTMLElement)) {\n\t\t\t\t\tcancelDrag();\n\t\t\t\t\treturn;\n\t\t\t\t}\n\t\t\t\tif (lane.dataset.kanbanDropSource === \"true\") {\n\t\t\t\t\tif (Date.now() - active.startedAt < CLICK_GESTURE_MS) {\n\t\t\t\t\t\tfinishDrag(true);\n\t\t\t\t\t\tfeedback(\"\");\n\t\t\t\t\t\treturn;\n\t\t\t\t\t}\n\t\t\t\t\tcancelDrag();\n\t\t\t\t\treturn;\n\t\t\t\t}\n\t\t\t\tif (!laneAllowed(card, lane)) {\n\t\t\t\t\tfinishDrag();\n\t\t\t\t\tfeedback(\"Move blocked by transition policy.\", \"error\");\n\t\t\t\t\treturn;\n\t\t\t\t}\n\t\t\t\tvar form = card ? card.querySelector(\"[data-kanban-drag-move-form]\") : null;\n\t\t\t\tvar targetState = form ? form.querySelector(\"[data-kanban-drag-target-state]\") : null;\n\t\t\t\tif (!(form instanceof HTMLFormElement) || !(targetState instanceof HTMLInputElement)) {\n\t\t\t\t\tcancelDrag();\n\t\t\t\t\treturn;\n\t\t\t\t}\n\t\t\t\ttargetState.value = lane.dataset.kanbanDropState || \"\";\n\t\t\t\tcard.dataset.kanbanPendingMove = targetState.value;\n\t\t\t\tcard.dataset.kanbanPendingOrigin = card.dataset.kanbanCurrentState || \"\";\n\t\t\t\tif (card.dataset.kanbanDataSeq) card.dataset.kanbanPendingSeq = card.dataset.kanbanDataSeq;\n\t\t\t\tcard.dataset.kanbanPendingTargetWasHidden = lane.dataset.kanbanDropWasHidden || lane.dataset.laneHidden || \"false\";\n\t\t\t\tplaceCardInLane(card, targetState.value, document);\n\t\t\t\tfinishDrag();\n\t\t\t\tplaceCardInLane(card, targetState.value, document);\n\t\t\t\tform.requestSubmit();\n\t\t\t}\n\t\t\tdocument.addEventListener(\"pointerup\", function (event) {\n\t\t\t\tif (pending && event.pointerId === pending.pointerId) {\n\t\t\t\t\tclearPending();\n\t\t\t\t\treturn;\n\t\t\t\t}\n\t\t\t\tif (!active || event.pointerId !== active.pointerId) return;\n\t\t\t\tdropAt(event.clientX, event.clientY);\n\t\t\t});\n\t\t\tdocument.addEventListener(\"pointercancel\", function (event) {\n\t\t\t\tif (pending && event.pointerId === pending.pointerId) {\n\t\t\t\t\tclearPending();\n\t\t\t\t\treturn;\n\t\t\t\t}\n\t\t\t\tif (active && event.pointerId === active.pointerId && active.pointerType !== \"touch\") cancelDrag();\n\t\t\t});\n\t\t\tdocument.addEventListener(\"touchmove\", function (event) {\n\t\t\t\tif (!active || active.pointerType !== \"touch\") return;\n\t\t\t\tevent.preventDefault();\n\t\t\t\tvar touch = touchWithIdentifier(event.touches, active.touchIdentifier);\n\t\t\t\tif (!touch && active.touchIdentifier === null && event.touches && event.touches.length === 1) touch = event.touches[0];\n\t\t\t\tif (touch) moveDragTo(touch.clientX, touch.clientY);\n\t\t\t}, { passive: false });\n\t\t\tdocument.addEventListener(\"touchend\", function (event) {\n\t\t\t\tif (pending && pending.pointerType === \"touch\") {\n\t\t\t\t\tvar pendingTouch = touchWithIdentifier(event.changedTouches, pending.touchIdentifier);\n\t\t\t\t\tif (!pendingTouch && !(pending.touchIdentifier === null && event.touches && event.touches.length === 0)) return;\n\t\t\t\t\tclearPending();\n\t\t\t\t\treturn;\n\t\t\t\t}\n\t\t\t\tif (!active || active.pointerType !== \"touch\") return;\n\t\t\t\tvar touch = touchWithIdentifier(event.changedTouches, active.touchIdentifier);\n\t\t\t\tif (!touch && active.touchIdentifier === null && event.touches && event.touches.length === 0) touch = event.changedTouches && event.changedTouches[0];\n\t\t\t\tif (touch) dropAt(touch.clientX, touch.clientY);\n\t\t\t});\n\t\t\tdocument.addEventListener(\"touchcancel\", function (event) {\n\t\t\t\tif (pending && pending.pointerType === \"touch\") {\n\t\t\t\t\tvar pendingTouch = touchWithIdentifier(event.changedTouches, pending.touchIdentifier);\n\t\t\t\t\tif (!pendingTouch && !(pending.touchIdentifier === null && event.touches && event.touches.length === 0)) return;\n\t\t\t\t\tclearPending();\n\t\t\t\t\treturn;\n\t\t\t\t}\n\t\t\t\tif (!active || active.pointerType !== \"touch\") return;\n\t\t\t\tvar touch = touchWithIdentifier(event.changedTouches, active.touchIdentifier);\n\t\t\t\tif (touch || (active.touchIdentifier === null && event.touches && event.touches.length === 0)) cancelDrag();\n\t\t\t});\n\t\t\tdocument.addEventListener(\"contextmenu\", function (event) {\n\t\t\t\tvar touchPress = pending && pending.pointerType === \"touch\";\n\t\t\t\tvar touchDrag = active && active.pointerType === \"touch\";\n\t\t\t\tif ((touchPress || touchDrag) && event.target instanceof Element && event.target.closest(\"[data-kanban-card]\")) {\n\t\t\t\t\tevent.preventDefault();\n\t\t\t\t}\n\t\t\t});\n\t\t\tdocument.addEventListener(\"keydown\", function (event) {\n\t\t\t\tif (event.key === \"Escape\" && active) cancelDrag();\n\t\t\t});\n\t\t\tdocument.addEventListener(\"detent:connectionChange\", function (event) {\n\t\t\t\tif (!event.detail || event.detail.state === \"connected\") return;\n\t\t\t\tif (active) cancelDrag();\n\t\t\t\telse clearPending();\n\t\t\t});\n\t\t\twindow.addEventListener(\"blur\", function () {\n\t\t\t\tif (active) cancelDrag();\n\t\t\t});\n\t\t\t// Native HTML5 drags stay disabled inside cards (links, images):\n\t\t\t// they would start a compositor drag session that steals the pointer.\n\t\t\tdocument.addEventListener(\"dragstart\", function (event) {\n\t\t\t\tif (event.target instanceof Element && event.target.closest(\"[data-kanban-card]\")) {\n\t\t\t\t\tevent.preventDefault();\n\t\t\t\t}\n\t\t\t});\n\t\t\tdocument.addEventListener(\"htmx:afterSettle\", function () {\n\t\t\t\tapplyDragState(document);\n\t\t\t});\n\t\t\tfunction handleMoveError(event) {\n\t\t\t\tvar form = event.detail && event.detail.elt;\n\t\t\t\tif (!(form instanceof HTMLFormElement) || !form.matches(\"[data-kanban-drag-move-form]\")) return;\n\t\t\t\tvar issueIDInput = form.querySelector(\"input[name='issue_id']\");\n\t\t\t\tvar issueID = issueIDInput instanceof HTMLInputElement ? issueIDInput.value : \"\";\n\t\t\t\tvar card = form.closest(\"[data-kanban-card][data-kanban-pending-move]\");\n\t\t\t\tif (!(card instanceof HTMLElement) || !card.isConnected) card = cardByIssueID(document, issueID);\n\t\t\t\trollbackPendingMove(card);\n\t\t\t\tvar response = event.detail.xhr ? event.detail.xhr.responseText : \"\";\n\t\t\t\tfeedback(responseMessage(response) || \"Move failed.\", \"error\");\n\t\t\t}\n\t\t\tdocument.body.addEventListener(\"htmx:responseError\", handleMoveError);\n\t\t\tdocument.body.addEventListener(\"htmx:sendError\", handleMoveError);\n\t\t\tdocument.body.addEventListener(\"htmx:timeout\", handleMoveError);\n\t\t})();\n\t</script>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 276, "<script>\n\t\t(function () {\n\t\t\tif (window.__detentBoardKanbanDragHandlersRegistered) return;\n\t\t\twindow.__detentBoardKanbanDragHandlersRegistered = true;\n\t\t\tvar DRAG_THRESHOLD_PX = 6;\n\t\t\tvar TOUCH_MOVE_TOLERANCE_PX = 10;\n\t\t\tvar TOUCH_LONG_PRESS_MS = 450;\n\t\t\tvar TOUCH_EDGE_ZONE_PX = 56;\n\t\t\tvar TOUCH_EDGE_ADVANCE_MS = 500;\n\t\t\t// Real mouse clicks travel a few pixels between press and release,\n\t\t\t// so distance alone cannot separate a click from a drag. A short\n\t\t\t// gesture released back over the source lane is a click: finish the\n\t\t\t// drag without swallowing the click so the detail sheet still opens.\n\t\t\tvar CLICK_GESTURE_MS = 250;\n\t\t\tvar draggedIssueID = \"\";\n\t\t\tvar draggedAllowedTargetKeys = [];\n\t\t\tvar pending = null;\n\t\t\tvar active = null;\n\t\t\tvar recentTouchStart = null;\n\t\t\tfunction connectionAllowsMoves() {\n\t\t\t\treturn document.documentElement.getAttribute(\"data-detent-connection\") === \"connected\";\n\t\t\t}\n\t\t\tfunction clearPending() {\n\t\t\t\tif (pending && pending.longPressTimer) window.clearTimeout(pending.longPressTimer);\n\t\t\t\tpending = null;\n\t\t\t\trecentTouchStart = null;\n\t\t\t}\n\t\t\tfunction touchWithIdentifier(touches, identifier) {\n\t\t\t\tif (!touches || identifier === null || identifier === undefined) return null;\n\t\t\t\tfor (var index = 0; index < touches.length; index += 1) {\n\t\t\t\t\tif (touches[index].identifier === identifier) return touches[index];\n\t\t\t\t}\n\t\t\t\treturn null;\n\t\t\t}\n\t\t\tfunction recentTouchIdentifier(card, event) {\n\t\t\t\tif (event.pointerType !== \"touch\" || !recentTouchStart) return null;\n\t\t\t\tif (Date.now() - recentTouchStart.startedAt >= 100) return null;\n\t\t\t\tif (!(recentTouchStart.target instanceof Node) || !card.contains(recentTouchStart.target)) return null;\n\t\t\t\treturn recentTouchStart.identifier;\n\t\t\t}\n\t\t\tfunction feedback(message, kind) {\n\t\t\t\tvar target = document.getElementById(\"board-feedback\");\n\t\t\t\tif (!target) return;\n\t\t\t\tvar text = String(message || \"\").trim();\n\t\t\t\ttarget.className = \"flex flex-none items-center gap-2 px-5 pt-3.5 text-xs \" + (kind === \"error\" ? \"text-err\" : \"text-sec\");\n\t\t\t\ttarget.textContent = text;\n\t\t\t\ttarget.hidden = text === \"\";\n\t\t\t}\n\t\t\tfunction queryRoot(scope) {\n\t\t\t\tif (scope && typeof scope.querySelector === \"function\" && typeof scope.querySelectorAll === \"function\") return scope;\n\t\t\t\treturn document;\n\t\t\t}\n\t\t\tfunction draggedCard(scope) {\n\t\t\t\tif (!draggedIssueID || !window.CSS || typeof CSS.escape !== \"function\") return null;\n\t\t\t\treturn queryRoot(scope).querySelector(\"[data-kanban-card][data-kanban-issue-id='\" + CSS.escape(draggedIssueID) + \"']\");\n\t\t\t}\n\t\t\tfunction cardByIssueID(scope, issueID) {\n\t\t\t\tvar cards = queryRoot(scope).querySelectorAll(\"[data-kanban-card][data-kanban-issue-id]\");\n\t\t\t\tfor (var index = 0; index < cards.length; index += 1) {\n\t\t\t\t\tif (cards[index].dataset.kanbanIssueId === issueID) return cards[index];\n\t\t\t\t}\n\t\t\t\treturn null;\n\t\t\t}\n\t\t\tfunction laneByState(scope, state) {\n\t\t\t\tvar lanes = queryRoot(scope).querySelectorAll(\"[data-kanban-drop-state]\");\n\t\t\t\tfor (var index = 0; index < lanes.length; index += 1) {\n\t\t\t\t\tif (lanes[index].dataset.kanbanDropState === state) return lanes[index];\n\t\t\t\t}\n\t\t\t\treturn null;\n\t\t\t}\n\t\t\tfunction cardContainer(lane) {\n\t\t\t\treturn lane instanceof HTMLElement ? lane.querySelector(\"[data-kanban-card-container]\") : null;\n\t\t\t}\n\t\t\tfunction updateEmptyLine(container) {\n\t\t\t\tif (!(container instanceof HTMLElement)) return;\n\t\t\t\tvar emptyLine = container.querySelector(\"[data-kanban-empty-line]\");\n\t\t\t\tif (emptyLine instanceof HTMLElement) emptyLine.hidden = Boolean(container.querySelector(\"[data-kanban-card]\"));\n\t\t\t}\n\t\t\tfunction placeCardInLane(card, state, scope) {\n\t\t\t\tvar lane = laneByState(scope, state);\n\t\t\t\tvar container = cardContainer(lane);\n\t\t\t\tif (!(card instanceof HTMLElement) || !(lane instanceof HTMLElement) || !(container instanceof HTMLElement)) return null;\n\t\t\t\tvar previousContainer = card.parentElement;\n\t\t\t\tcontainer.appendChild(card);\n\t\t\t\tlane.dataset.laneHidden = \"false\";\n\t\t\t\tupdateEmptyLine(previousContainer);\n\t\t\t\tupdateEmptyLine(container);\n\t\t\t\treturn lane;\n\t\t\t}\n\t\t\tfunction copyPendingMove(source, target) {\n\t\t\t\t[\n\t\t\t\t\t\"kanbanPendingMove\",\n\t\t\t\t\t\"kanbanPendingOrigin\",\n\t\t\t\t\t\"kanbanPendingSeq\",\n\t\t\t\t\t\"kanbanPendingTargetWasHidden\"\n\t\t\t\t].forEach(function (key) {\n\t\t\t\t\tif (source.dataset[key] === undefined) {\n\t\t\t\t\t\tdelete target.dataset[key];\n\t\t\t\t\t} else {\n\t\t\t\t\t\ttarget.dataset[key] = source.dataset[key];\n\t\t\t\t\t}\n\t\t\t\t});\n\t\t\t}\n\t\t\tfunction clearPendingMove(card) {\n\t\t\t\tif (!(card instanceof HTMLElement)) return;\n\t\t\t\tdelete card.dataset.kanbanPendingMove;\n\t\t\t\tdelete card.dataset.kanbanPendingOrigin;\n\t\t\t\tdelete card.dataset.kanbanPendingSeq;\n\t\t\t\tdelete card.dataset.kanbanPendingTargetWasHidden;\n\t\t\t}\n\t\t\tfunction pendingMoveSuperseded(liveCard, serverCard) {\n\t\t\t\tvar targetState = liveCard.dataset.kanbanPendingMove || \"\";\n\t\t\t\tif ((serverCard.dataset.kanbanCurrentState || \"\") === targetState) return true;\n\t\t\t\tvar pendingSeq = Number.parseInt(liveCard.dataset.kanbanPendingSeq || \"\", 10);\n\t\t\t\tvar serverSeq = Number.parseInt(serverCard.dataset.kanbanDataSeq || \"\", 10);\n\t\t\t\treturn Number.isFinite(pendingSeq) && Number.isFinite(serverSeq) && serverSeq > pendingSeq;\n\t\t\t}\n\t\t\tfunction applyPendingMoveState(scope) {\n\t\t\t\tvar root = queryRoot(scope);\n\t\t\t\tvar applied = false;\n\t\t\t\tdocument.querySelectorAll(\"#snapshot [data-kanban-card][data-kanban-pending-move]\").forEach(function (liveCard) {\n\t\t\t\t\tif (!(liveCard instanceof HTMLElement)) return;\n\t\t\t\t\tvar issueID = liveCard.dataset.kanbanIssueId || \"\";\n\t\t\t\t\tvar serverCard = cardByIssueID(root, issueID);\n\t\t\t\t\tif (!(serverCard instanceof HTMLElement)) return;\n\t\t\t\t\tif (pendingMoveSuperseded(liveCard, serverCard)) {\n\t\t\t\t\t\tif (serverCard === liveCard) clearPendingMove(serverCard);\n\t\t\t\t\t\treturn;\n\t\t\t\t\t}\n\t\t\t\t\tcopyPendingMove(liveCard, serverCard);\n\t\t\t\t\tif (placeCardInLane(serverCard, liveCard.dataset.kanbanPendingMove || \"\", root)) applied = true;\n\t\t\t\t});\n\t\t\t\treturn applied;\n\t\t\t}\n\t\t\tfunction targetKeysFromValue(value) {\n\t\t\t\treturn String(value || \"\").split(/\\s+/).filter(Boolean);\n\t\t\t}\n\t\t\tfunction allowedTargetKeys(card) {\n\t\t\t\tif (card instanceof HTMLElement) {\n\t\t\t\t\tvar keys = targetKeysFromValue(card.dataset.kanbanAllowedTargets || \"\");\n\t\t\t\t\tif (keys.length > 0) return keys;\n\t\t\t\t}\n\t\t\t\treturn draggedAllowedTargetKeys.slice();\n\t\t\t}\n\t\t\tfunction laneAllowed(card, lane) {\n\t\t\t\tif (!(lane instanceof HTMLElement)) return false;\n\t\t\t\tvar key = lane.dataset.kanbanDropKey || \"\";\n\t\t\t\treturn key !== \"\" && allowedTargetKeys(card).includes(key);\n\t\t\t}\n\t\t\tfunction setDropTargetState(card, scope) {\n\t\t\t\tvar sourceLane = card instanceof HTMLElement ? card.closest(\"[data-kanban-drop-state]\") : null;\n\t\t\t\tqueryRoot(scope).querySelectorAll(\"[data-kanban-drop-state]\").forEach(function (lane) {\n\t\t\t\t\tif (!(lane instanceof HTMLElement)) return;\n\t\t\t\t\tif (lane.dataset.kanbanDropWasHidden === undefined) {\n\t\t\t\t\t\tlane.dataset.kanbanDropWasHidden = lane.dataset.laneHidden || \"false\";\n\t\t\t\t\t}\n\t\t\t\t\tlane.dataset.laneHidden = \"false\";\n\t\t\t\t\tif (lane === sourceLane) {\n\t\t\t\t\t\t// The origin lane is not a transition target, but styling\n\t\t\t\t\t\t// it blocked reads as an error; mark it as the source so\n\t\t\t\t\t\t// the operator can see where the card came from.\n\t\t\t\t\t\tlane.dataset.kanbanDropSource = \"true\";\n\t\t\t\t\t\tdelete lane.dataset.kanbanDropAllowed;\n\t\t\t\t\t\tlane.removeAttribute(\"aria-disabled\");\n\t\t\t\t\t\treturn;\n\t\t\t\t\t}\n\t\t\t\t\tdelete lane.dataset.kanbanDropSource;\n\t\t\t\t\tvar allowed = laneAllowed(card, lane);\n\t\t\t\t\tlane.dataset.kanbanDropAllowed = allowed ? \"true\" : \"false\";\n\t\t\t\t\tlane.setAttribute(\"aria-disabled\", allowed ? \"false\" : \"true\");\n\t\t\t\t});\n\t\t\t}\n\t\t\tfunction applyActiveDragState(scope) {\n\t\t\t\tif (!draggedIssueID || draggedAllowedTargetKeys.length === 0) return false;\n\t\t\t\tvar root = queryRoot(scope);\n\t\t\t\tvar card = draggedCard(root);\n\t\t\t\tif (card instanceof HTMLElement) card.dataset.kanbanDragging = \"true\";\n\t\t\t\tsetDropTargetState(card, root);\n\t\t\t\tapplyTouchDragStyles(card, root);\n\t\t\t\treturn true;\n\t\t\t}\n\t\t\tfunction applyDragState(scope) {\n\t\t\t\tvar pendingApplied = applyPendingMoveState(scope);\n\t\t\t\treturn applyActiveDragState(scope) || pendingApplied;\n\t\t\t}\n\t\t\twindow.__detentBoardKanbanDragAdjustSnapshot = applyDragState;\n\t\t\tfunction clearDropTargetState() {\n\t\t\t\tdocument.querySelectorAll(\"[data-kanban-drop-state]\").forEach(function (lane) {\n\t\t\t\t\tif (!(lane instanceof HTMLElement)) return;\n\t\t\t\t\tif (lane.dataset.kanbanDropWasHidden !== undefined) {\n\t\t\t\t\t\tlane.dataset.laneHidden = lane.dataset.kanbanDropWasHidden;\n\t\t\t\t\t\tdelete lane.dataset.kanbanDropWasHidden;\n\t\t\t\t\t}\n\t\t\t\t\tdelete lane.dataset.kanbanDropAllowed;\n\t\t\t\t\tdelete lane.dataset.kanbanDropSource;\n\t\t\t\t\tlane.removeAttribute(\"aria-disabled\");\n\t\t\t\t});\n\t\t\t\tdocument.querySelectorAll(\"[data-kanban-card][data-kanban-dragging='true']\").forEach(function (card) {\n\t\t\t\t\tif (card instanceof HTMLElement) delete card.dataset.kanbanDragging;\n\t\t\t\t});\n\t\t\t}\n\t\t\tfunction responseMessage(response) {\n\t\t\t\tif (!response) return \"\";\n\t\t\t\tvar doc = new DOMParser().parseFromString(response, \"text/html\");\n\t\t\t\treturn (doc.body.textContent || \"\").trim();\n\t\t\t}\n\t\t\tfunction buildGhost(card, rect) {\n\t\t\t\tvar ghost = card.cloneNode(true);\n\t\t\t\tghost.removeAttribute(\"id\");\n\t\t\t\tghost.querySelectorAll(\"[id]\").forEach(function (node) {\n\t\t\t\t\tnode.removeAttribute(\"id\");\n\t\t\t\t});\n\t\t\t\tvar form = ghost.querySelector(\"[data-kanban-drag-move-form]\");\n\t\t\t\tif (form) form.remove();\n\t\t\t\tdelete ghost.dataset.kanbanDragging;\n\t\t\t\tvar origin = document.createElement(\"div\");\n\t\t\t\torigin.className = \"mb-1.5 flex items-center gap-1.5 border-b border-line pb-1.5 font-mono text-2xs font-medium text-accent\";\n\t\t\t\torigin.textContent = \"From \" + (card.dataset.kanbanCurrentState || \"current lane\");\n\t\t\t\tghost.insertBefore(origin, ghost.firstChild);\n\t\t\t\tghost.setAttribute(\"aria-hidden\", \"true\");\n\t\t\t\tghost.style.position = \"fixed\";\n\t\t\t\tghost.style.left = \"0\";\n\t\t\t\tghost.style.top = \"0\";\n\t\t\t\tghost.style.margin = \"0\";\n\t\t\t\tghost.style.width = rect.width + \"px\";\n\t\t\t\tghost.style.height = rect.height + \"px\";\n\t\t\t\tghost.style.pointerEvents = \"none\";\n\t\t\t\tghost.style.zIndex = \"1000\";\n\t\t\t\tghost.style.opacity = \"0.9\";\n\t\t\t\tghost.style.boxShadow = \"0 12px 32px rgba(0, 0, 0, 0.35)\";\n\t\t\t\tghost.style.willChange = \"transform\";\n\t\t\t\tdocument.body.appendChild(ghost);\n\t\t\t\treturn ghost;\n\t\t\t}\n\t\t\tfunction moveGhost(ghost, x, y, offsetX, offsetY) {\n\t\t\t\tghost.style.transform = \"translate(\" + Math.round(x - offsetX) + \"px, \" + Math.round(y - offsetY) + \"px)\";\n\t\t\t}\n\t\t\tfunction laneFromPoint(x, y) {\n\t\t\t\tvar hit = document.elementFromPoint(x, y);\n\t\t\t\treturn hit instanceof Element ? hit.closest(\"[data-kanban-drop-state]\") : null;\n\t\t\t}\n\t\t\tfunction applyTouchStyle(element, styles) {\n\t\t\t\tif (!active || active.pointerType !== \"touch\" || !(element instanceof HTMLElement) || !element.isConnected) return;\n\t\t\t\tif (!active.touchStyles.has(element)) {\n\t\t\t\t\tvar original = {};\n\t\t\t\t\tObject.keys(styles).forEach(function (property) {\n\t\t\t\t\t\toriginal[property] = element.style[property];\n\t\t\t\t\t});\n\t\t\t\t\tactive.touchStyles.set(element, original);\n\t\t\t\t}\n\t\t\t\tObject.keys(styles).forEach(function (property) {\n\t\t\t\t\telement.style[property] = styles[property];\n\t\t\t\t});\n\t\t\t}\n\t\t\tfunction applyTouchDragStyles(card, scope) {\n\t\t\t\tif (!active || active.pointerType !== \"touch\") return;\n\t\t\t\tvar root = queryRoot(scope);\n\t\t\t\tvar lanes = root.querySelector(\"[data-board-lanes]\");\n\t\t\t\tapplyTouchStyle(lanes, { touchAction: \"none\", scrollSnapType: \"none\" });\n\t\t\t\tapplyTouchStyle(card, {\n\t\t\t\t\ttouchAction: \"none\",\n\t\t\t\t\toutline: \"2px solid var(--color-accent)\",\n\t\t\t\t\toutlineOffset: \"2px\"\n\t\t\t\t});\n\t\t\t}\n\t\t\tfunction restoreTouchDragStyles() {\n\t\t\t\tif (!active || !active.touchStyles) return;\n\t\t\t\tactive.touchStyles.forEach(function (styles, element) {\n\t\t\t\t\tObject.keys(styles).forEach(function (property) {\n\t\t\t\t\t\telement.style[property] = styles[property];\n\t\t\t\t\t});\n\t\t\t\t});\n\t\t\t\tactive.touchStyles.clear();\n\t\t\t}\n\t\t\t// Native drags auto-scrolled the lane strip at the viewport edges;\n\t\t\t// pointer drags must do it themselves. Scrolls only while the\n\t\t\t// pointer moves, which is enough to reach off-screen lanes.\n\t\t\tfunction autoScrollLanes(x) {\n\t\t\t\tvar lanes = document.getElementById(\"board-lanes\");\n\t\t\t\tif (!lanes) return;\n\t\t\t\tvar rect = lanes.getBoundingClientRect();\n\t\t\t\tif (x < rect.left + 48) {\n\t\t\t\t\tlanes.scrollLeft -= 16;\n\t\t\t\t} else if (x > rect.right - 48) {\n\t\t\t\t\tlanes.scrollLeft += 16;\n\t\t\t\t}\n\t\t\t}\n\t\t\tfunction visibleDropLanes(lanes) {\n\t\t\t\treturn Array.from(lanes.querySelectorAll(\"[data-kanban-drop-state]\")).filter(function (lane) {\n\t\t\t\t\treturn lane instanceof HTMLElement && lane.dataset.laneHidden !== \"true\";\n\t\t\t\t});\n\t\t\t}\n\t\t\tfunction closestLaneIndex(lanes, laneNodes) {\n\t\t\t\tvar center = lanes.getBoundingClientRect().left + lanes.clientWidth / 2;\n\t\t\t\tvar closest = 0;\n\t\t\t\tvar distance = Infinity;\n\t\t\t\tlaneNodes.forEach(function (lane, index) {\n\t\t\t\t\tvar rect = lane.getBoundingClientRect();\n\t\t\t\t\tvar candidate = Math.abs(rect.left + rect.width / 2 - center);\n\t\t\t\t\tif (candidate < distance) {\n\t\t\t\t\t\tdistance = candidate;\n\t\t\t\t\t\tclosest = index;\n\t\t\t\t\t}\n\t\t\t\t});\n\t\t\t\treturn closest;\n\t\t\t}\n\t\t\tfunction advanceTouchLane(direction) {\n\t\t\t\tif (!active || active.pointerType !== \"touch\" || active.edgeDirection !== direction) return;\n\t\t\t\tactive.edgeTimer = null;\n\t\t\t\tvar lanes = document.getElementById(\"board-lanes\");\n\t\t\t\tif (!lanes) return;\n\t\t\t\tvar laneNodes = visibleDropLanes(lanes);\n\t\t\t\tif (laneNodes.length === 0) return;\n\t\t\t\tvar current = closestLaneIndex(lanes, laneNodes);\n\t\t\t\tvar target = Math.max(0, Math.min(laneNodes.length - 1, current + direction));\n\t\t\t\tif (target !== current) {\n\t\t\t\t\tlaneNodes[target].scrollIntoView({ behavior: \"smooth\", block: \"nearest\", inline: \"start\" });\n\t\t\t\t}\n\t\t\t\tif (active && active.edgeDirection === direction && target !== current) {\n\t\t\t\t\tactive.edgeTimer = window.setTimeout(function () {\n\t\t\t\t\t\tadvanceTouchLane(direction);\n\t\t\t\t\t}, TOUCH_EDGE_ADVANCE_MS);\n\t\t\t\t}\n\t\t\t}\n\t\t\tfunction updateTouchEdgeAdvance(x) {\n\t\t\t\tif (!active || active.pointerType !== \"touch\") return;\n\t\t\t\tvar lanes = document.getElementById(\"board-lanes\");\n\t\t\t\tif (!lanes) return;\n\t\t\t\tvar rect = lanes.getBoundingClientRect();\n\t\t\t\tvar direction = x < rect.left + TOUCH_EDGE_ZONE_PX ? -1 : (x > rect.right - TOUCH_EDGE_ZONE_PX ? 1 : 0);\n\t\t\t\tif (direction === active.edgeDirection) return;\n\t\t\t\tif (active.edgeTimer) window.clearTimeout(active.edgeTimer);\n\t\t\t\tactive.edgeDirection = direction;\n\t\t\t\tactive.edgeTimer = direction === 0 ? null : window.setTimeout(function () {\n\t\t\t\t\tadvanceTouchLane(direction);\n\t\t\t\t}, TOUCH_EDGE_ADVANCE_MS);\n\t\t\t}\n\t\t\tfunction stopTouchEdgeAdvance() {\n\t\t\t\tif (!active) return;\n\t\t\t\tif (active.edgeTimer) window.clearTimeout(active.edgeTimer);\n\t\t\t\tactive.edgeTimer = null;\n\t\t\t\tactive.edgeDirection = 0;\n\t\t\t}\n\t\t\tfunction suppressNextClick() {\n\t\t\t\tvar until = Date.now() + 400;\n\t\t\t\tdocument.addEventListener(\"click\", function suppress(event) {\n\t\t\t\t\tdocument.removeEventListener(\"click\", suppress, true);\n\t\t\t\t\tif (Date.now() > until) return;\n\t\t\t\t\tevent.preventDefault();\n\t\t\t\t\tevent.stopImmediatePropagation();\n\t\t\t\t}, true);\n\t\t\t}\n\t\t\tfunction beginDrag(event) {\n\t\t\t\tvar press = pending;\n\t\t\t\tif (!press) return;\n\t\t\t\tif (press.longPressTimer) window.clearTimeout(press.longPressTimer);\n\t\t\t\tdraggedIssueID = press.issueID;\n\t\t\t\tdraggedAllowedTargetKeys = press.targets;\n\t\t\t\tvar card = draggedCard(document) || press.card;\n\t\t\t\tactive = {\n\t\t\t\t\tpointerId: press.pointerId,\n\t\t\t\t\tpointerType: press.pointerType,\n\t\t\t\t\ttouchIdentifier: press.touchIdentifier,\n\t\t\t\t\toffsetX: press.startX - press.rect.left,\n\t\t\t\t\toffsetY: press.startY - press.rect.top,\n\t\t\t\t\tghost: buildGhost(card, press.rect),\n\t\t\t\t\tlastLaneBlocked: false,\n\t\t\t\t\tstartedAt: press.startedAt,\n\t\t\t\t\tcaptureElement: press.card,\n\t\t\t\t\ttouchStyles: new Map(),\n\t\t\t\t\tedgeDirection: 0,\n\t\t\t\t\tedgeTimer: null\n\t\t\t\t};\n\t\t\t\tpending = null;\n\t\t\t\trecentTouchStart = null;\n\t\t\t\tif (active.pointerType === \"touch\" && typeof active.captureElement.setPointerCapture === \"function\") {\n\t\t\t\t\ttry {\n\t\t\t\t\t\tactive.captureElement.setPointerCapture(active.pointerId);\n\t\t\t\t\t} catch (_) {}\n\t\t\t\t}\n\t\t\t\tcard.dataset.kanbanDragging = \"true\";\n\t\t\t\tsetDropTargetState(card, document);\n\t\t\t\tapplyTouchDragStyles(card, document);\n\t\t\t\tfeedback(\"Moving \" + (card.dataset.kanbanCurrentState || \"card\") + \".\");\n\t\t\t\tmoveGhost(active.ghost, event.clientX, event.clientY, active.offsetX, active.offsetY);\n\t\t\t}\n\t\t\tfunction finishDrag(keepClick) {\n\t\t\t\tif (active) {\n\t\t\t\t\tstopTouchEdgeAdvance();\n\t\t\t\t\trestoreTouchDragStyles();\n\t\t\t\t\tif (active.ghost) active.ghost.remove();\n\t\t\t\t\tif (active.captureElement && typeof active.captureElement.releasePointerCapture === \"function\") {\n\t\t\t\t\t\ttry {\n\t\t\t\t\t\t\tif (active.captureElement.hasPointerCapture(active.pointerId)) active.captureElement.releasePointerCapture(active.pointerId);\n\t\t\t\t\t\t} catch (_) {}\n\t\t\t\t\t}\n\t\t\t\t}\n\t\t\t\tclearPending();\n\t\t\t\tactive = null;\n\t\t\t\tdraggedIssueID = \"\";\n\t\t\t\tdraggedAllowedTargetKeys = [];\n\t\t\t\tclearDropTargetState();\n\t\t\t\t// A drag ends with the pointer still over a card, so the release\n\t\t\t\t// also fires a click; swallow it or the detail sheet opens.\n\t\t\t\tif (!keepClick) suppressNextClick();\n\t\t\t}\n\t\t\tfunction cancelDrag(keepClick) {\n\t\t\t\tif (!active) {\n\t\t\t\t\tclearPending();\n\t\t\t\t\treturn;\n\t\t\t\t}\n\t\t\t\tfinishDrag(keepClick);\n\t\t\t\tfeedback(\"Move cancelled.\", \"error\");\n\t\t\t}\n\t\t\tfunction rollbackPendingMove(card) {\n\t\t\t\tif (!(card instanceof HTMLElement) || !card.dataset.kanbanPendingMove) return;\n\t\t\t\tvar targetLane = card.closest(\"[data-kanban-drop-state]\");\n\t\t\t\tvar targetWasHidden = card.dataset.kanbanPendingTargetWasHidden === \"true\";\n\t\t\t\tvar originState = card.dataset.kanbanPendingOrigin || \"\";\n\t\t\t\tclearPendingMove(card);\n\t\t\t\tplaceCardInLane(card, originState, document);\n\t\t\t\tif (targetLane instanceof HTMLElement) {\n\t\t\t\t\ttargetLane.dataset.laneHidden = targetWasHidden ? \"true\" : \"false\";\n\t\t\t\t\tupdateEmptyLine(cardContainer(targetLane));\n\t\t\t\t}\n\t\t\t}\n\t\t\tfunction moveDragTo(x, y) {\n\t\t\t\tif (!active) return;\n\t\t\t\tmoveGhost(active.ghost, x, y, active.offsetX, active.offsetY);\n\t\t\t\tif (active.pointerType === \"touch\") {\n\t\t\t\t\tupdateTouchEdgeAdvance(x);\n\t\t\t\t} else {\n\t\t\t\t\tautoScrollLanes(x);\n\t\t\t\t}\n\t\t\t\tvar lane = laneFromPoint(x, y);\n\t\t\t\tvar card = draggedCard(document);\n\t\t\t\tvar blocked = lane instanceof HTMLElement && lane.dataset.kanbanDropSource !== \"true\" && !laneAllowed(card, lane);\n\t\t\t\tif (blocked && !active.lastLaneBlocked) {\n\t\t\t\t\tfeedback(\"Move blocked by transition policy.\", \"error\");\n\t\t\t\t} else if (!blocked && active.lastLaneBlocked) {\n\t\t\t\t\tfeedback(\"Moving \" + ((card && card.dataset.kanbanCurrentState) || \"card\") + \".\");\n\t\t\t\t}\n\t\t\t\tactive.lastLaneBlocked = blocked;\n\t\t\t}\n\t\t\tdocument.addEventListener(\"pointerdown\", function (event) {\n\t\t\t\tif (active || event.button !== 0 || event.isPrimary === false) return;\n\t\t\t\tvar pressedElement = event.target instanceof Element ? event.target : null;\n\t\t\t\tvar pressedCard = pressedElement ? pressedElement.closest(\"[data-kanban-card]\") : null;\n\t\t\t\tif (pressedCard && !connectionAllowsMoves()) {\n\t\t\t\t\tif (pressedElement.closest(\"a, button, input, select, textarea, summary, label, [data-help-trigger]\")) return;\n\t\t\t\t\tfeedback(\"Moves are disabled while the board reconnects. Reload if the connection does not recover.\", \"error\");\n\t\t\t\t\treturn;\n\t\t\t\t}\n\t\t\t\tif (pressedCard && pressedCard.dataset.kanbanMoveDisabled === \"true\") {\n\t\t\t\t\tif (pressedElement.closest(\"a, button, input, select, textarea, summary, label, [data-help-trigger]\")) return;\n\t\t\t\t\tfeedback(pressedCard.dataset.kanbanMoveDisabledReason || \"This card cannot be moved.\", \"error\");\n\t\t\t\t\treturn;\n\t\t\t\t}\n\t\t\t\tvar card = pressedCard && pressedCard.dataset.kanbanAction === \"move\" ? pressedCard : null;\n\t\t\t\tif (!card) return;\n\t\t\t\tif (card.dataset.kanbanPendingMove) return;\n\t\t\t\tvar issueID = card.dataset.kanbanIssueId || \"\";\n\t\t\t\tif (!issueID) return;\n\t\t\t\tpending = {\n\t\t\t\t\tpointerId: event.pointerId,\n\t\t\t\t\tpointerType: event.pointerType,\n\t\t\t\t\ttouchIdentifier: recentTouchIdentifier(card, event),\n\t\t\t\t\tcard: card,\n\t\t\t\t\tissueID: issueID,\n\t\t\t\t\ttargets: targetKeysFromValue(card.dataset.kanbanAllowedTargets || \"\"),\n\t\t\t\t\trect: card.getBoundingClientRect(),\n\t\t\t\t\tstartX: event.clientX,\n\t\t\t\t\tstartY: event.clientY,\n\t\t\t\t\tlastX: event.clientX,\n\t\t\t\t\tlastY: event.clientY,\n\t\t\t\t\tstartedAt: Date.now(),\n\t\t\t\t\tlongPressTimer: null\n\t\t\t\t};\n\t\t\t\tif (event.pointerType === \"touch\") {\n\t\t\t\t\tvar pointerId = event.pointerId;\n\t\t\t\t\tpending.longPressTimer = window.setTimeout(function () {\n\t\t\t\t\t\tif (!pending || pending.pointerId !== pointerId) return;\n\t\t\t\t\t\tbeginDrag({ clientX: pending.lastX, clientY: pending.lastY });\n\t\t\t\t\t}, TOUCH_LONG_PRESS_MS);\n\t\t\t\t}\n\t\t\t});\n\t\t\tdocument.addEventListener(\"touchstart\", function (event) {\n\t\t\t\tif (active || !event.changedTouches || event.changedTouches.length === 0) return;\n\t\t\t\tvar touch = event.changedTouches[0];\n\t\t\t\trecentTouchStart = {\n\t\t\t\t\tidentifier: touch.identifier,\n\t\t\t\t\ttarget: event.target,\n\t\t\t\t\tstartedAt: Date.now()\n\t\t\t\t};\n\t\t\t\tif (pending && pending.pointerType === \"touch\" && event.target instanceof Node && pending.card.contains(event.target)) {\n\t\t\t\t\tpending.touchIdentifier = touch.identifier;\n\t\t\t\t}\n\t\t\t});\n\t\t\tdocument.addEventListener(\"pointermove\", function (event) {\n\t\t\t\tif (pending && event.pointerId === pending.pointerId) {\n\t\t\t\t\tif (pending.pointerType === \"touch\") {\n\t\t\t\t\t\tif (Math.hypot(event.clientX - pending.startX, event.clientY - pending.startY) >= TOUCH_MOVE_TOLERANCE_PX) {\n\t\t\t\t\t\t\tclearPending();\n\t\t\t\t\t\t\treturn;\n\t\t\t\t\t\t}\n\t\t\t\t\t\tpending.lastX = event.clientX;\n\t\t\t\t\t\tpending.lastY = event.clientY;\n\t\t\t\t\t\treturn;\n\t\t\t\t\t}\n\t\t\t\t\t// A missed pointerup (released outside the window) must not\n\t\t\t\t\t// leave a stale press that turns a later hover into a drag.\n\t\t\t\t\tif (event.buttons === 0) {\n\t\t\t\t\t\tclearPending();\n\t\t\t\t\t\treturn;\n\t\t\t\t\t}\n\t\t\t\t\tif (Math.hypot(event.clientX - pending.startX, event.clientY - pending.startY) < DRAG_THRESHOLD_PX) return;\n\t\t\t\t\tbeginDrag(event);\n\t\t\t\t\treturn;\n\t\t\t\t}\n\t\t\t\tif (!active || event.pointerId !== active.pointerId) return;\n\t\t\t\tif (active.pointerType !== \"touch\" && event.buttons === 0) {\n\t\t\t\t\t// The release happened outside the window, so no click is\n\t\t\t\t\t// coming — cancelling must not arm the click suppressor or\n\t\t\t\t\t// it would eat the next real click after recovery.\n\t\t\t\t\tcancelDrag(true);\n\t\t\t\t\treturn;\n\t\t\t\t}\n\t\t\t\tevent.preventDefault();\n\t\t\t\tmoveDragTo(event.clientX, event.clientY);\n\t\t\t}, { passive: false });\n\t\t\tfunction dropAt(x, y) {\n\t\t\t\tif (!active) return;\n\t\t\t\tif (!connectionAllowsMoves()) {\n\t\t\t\t\tcancelDrag();\n\t\t\t\t\tfeedback(\"Move cancelled because the board connection was lost.\", \"error\");\n\t\t\t\t\treturn;\n\t\t\t\t}\n\t\t\t\tvar lane = laneFromPoint(x, y);\n\t\t\t\tvar card = draggedCard(document);\n\t\t\t\tif (!(lane instanceof HTMLElement)) {\n\t\t\t\t\tcancelDrag();\n\t\t\t\t\treturn;\n\t\t\t\t}\n\t\t\t\tif (lane.dataset.kanbanDropSource === \"true\") {\n\t\t\t\t\tif (Date.now() - active.startedAt < CLICK_GESTURE_MS) {\n\t\t\t\t\t\tfinishDrag(true);\n\t\t\t\t\t\tfeedback(\"\");\n\t\t\t\t\t\treturn;\n\t\t\t\t\t}\n\t\t\t\t\tcancelDrag();\n\t\t\t\t\treturn;\n\t\t\t\t}\n\t\t\t\tif (!laneAllowed(card, lane)) {\n\t\t\t\t\tfinishDrag();\n\t\t\t\t\tfeedback(\"Move blocked by transition policy.\", \"error\");\n\t\t\t\t\treturn;\n\t\t\t\t}\n\t\t\t\tvar form = card ? card.querySelector(\"[data-kanban-drag-move-form]\") : null;\n\t\t\t\tvar targetState = form ? form.querySelector(\"[data-kanban-drag-target-state]\") : null;\n\t\t\t\tif (!(form instanceof HTMLFormElement) || !(targetState instanceof HTMLInputElement)) {\n\t\t\t\t\tcancelDrag();\n\t\t\t\t\treturn;\n\t\t\t\t}\n\t\t\t\ttargetState.value = lane.dataset.kanbanDropState || \"\";\n\t\t\t\tcard.dataset.kanbanPendingMove = targetState.value;\n\t\t\t\tcard.dataset.kanbanPendingOrigin = card.dataset.kanbanCurrentState || \"\";\n\t\t\t\tif (card.dataset.kanbanDataSeq) card.dataset.kanbanPendingSeq = card.dataset.kanbanDataSeq;\n\t\t\t\tcard.dataset.kanbanPendingTargetWasHidden = lane.dataset.kanbanDropWasHidden || lane.dataset.laneHidden || \"false\";\n\t\t\t\tplaceCardInLane(card, targetState.value, document);\n\t\t\t\tfinishDrag();\n\t\t\t\tplaceCardInLane(card, targetState.value, document);\n\t\t\t\tform.requestSubmit();\n\t\t\t}\n\t\t\tdocument.addEventListener(\"pointerup\", function (event) {\n\t\t\t\tif (pending && event.pointerId === pending.pointerId) {\n\t\t\t\t\tclearPending();\n\t\t\t\t\treturn;\n\t\t\t\t}\n\t\t\t\tif (!active || event.pointerId !== active.pointerId) return;\n\t\t\t\tdropAt(event.clientX, event.clientY);\n\t\t\t});\n\t\t\tdocument.addEventListener(\"pointercancel\", function (event) {\n\t\t\t\tif (pending && event.pointerId === pending.pointerId) {\n\t\t\t\t\tclearPending();\n\t\t\t\t\treturn;\n\t\t\t\t}\n\t\t\t\tif (active && event.pointerId === active.pointerId && active.pointerType !== \"touch\") cancelDrag();\n\t\t\t});\n\t\t\tdocument.addEventListener(\"touchmove\", function (event) {\n\t\t\t\tif (!active || active.pointerType !== \"touch\") return;\n\t\t\t\tevent.preventDefault();\n\t\t\t\tvar touch = touchWithIdentifier(event.touches, active.touchIdentifier);\n\t\t\t\tif (!touch && active.touchIdentifier === null && event.touches && event.touches.length === 1) touch = event.touches[0];\n\t\t\t\tif (touch) moveDragTo(touch.clientX, touch.clientY);\n\t\t\t}, { passive: false });\n\t\t\tdocument.addEventListener(\"touchend\", function (event) {\n\t\t\t\tif (pending && pending.pointerType === \"touch\") {\n\t\t\t\t\tvar pendingTouch = touchWithIdentifier(event.changedTouches, pending.touchIdentifier);\n\t\t\t\t\tif (!pendingTouch && !(pending.touchIdentifier === null && event.touches && event.touches.length === 0)) return;\n\t\t\t\t\tclearPending();\n\t\t\t\t\treturn;\n\t\t\t\t}\n\t\t\t\tif (!active || active.pointerType !== \"touch\") return;\n\t\t\t\tvar touch = touchWithIdentifier(event.changedTouches, active.touchIdentifier);\n\t\t\t\tif (!touch && active.touchIdentifier === null && event.touches && event.touches.length === 0) touch = event.changedTouches && event.changedTouches[0];\n\t\t\t\tif (touch) dropAt(touch.clientX, touch.clientY);\n\t\t\t});\n\t\t\tdocument.addEventListener(\"touchcancel\", function (event) {\n\t\t\t\tif (pending && pending.pointerType === \"touch\") {\n\t\t\t\t\tvar pendingTouch = touchWithIdentifier(event.changedTouches, pending.touchIdentifier);\n\t\t\t\t\tif (!pendingTouch && !(pending.touchIdentifier === null && event.touches && event.touches.length === 0)) return;\n\t\t\t\t\tclearPending();\n\t\t\t\t\treturn;\n\t\t\t\t}\n\t\t\t\tif (!active || active.pointerType !== \"touch\") return;\n\t\t\t\tvar touch = touchWithIdentifier(event.changedTouches, active.touchIdentifier);\n\t\t\t\tif (touch || (active.touchIdentifier === null && event.touches && event.touches.length === 0)) cancelDrag();\n\t\t\t});\n\t\t\tdocument.addEventListener(\"contextmenu\", function (event) {\n\t\t\t\tvar touchPress = pending && pending.pointerType === \"touch\";\n\t\t\t\tvar touchDrag = active && active.pointerType === \"touch\";\n\t\t\t\tif ((touchPress || touchDrag) && event.target instanceof Element && event.target.closest(\"[data-kanban-card]\")) {\n\t\t\t\t\tevent.preventDefault();\n\t\t\t\t}\n\t\t\t});\n\t\t\tdocument.addEventListener(\"keydown\", function (event) {\n\t\t\t\tif (event.key === \"Escape\" && active) cancelDrag();\n\t\t\t});\n\t\t\tdocument.addEventListener(\"detent:connectionChange\", function (event) {\n\t\t\t\tif (!event.detail || event.detail.state === \"connected\") return;\n\t\t\t\tif (active) cancelDrag();\n\t\t\t\telse clearPending();\n\t\t\t});\n\t\t\twindow.addEventListener(\"blur\", function () {\n\t\t\t\tif (active) cancelDrag();\n\t\t\t});\n\t\t\t// Native HTML5 drags stay disabled inside cards (links, images):\n\t\t\t// they would start a compositor drag session that steals the pointer.\n\t\t\tdocument.addEventListener(\"dragstart\", function (event) {\n\t\t\t\tif (event.target instanceof Element && event.target.closest(\"[data-kanban-card]\")) {\n\t\t\t\t\tevent.preventDefault();\n\t\t\t\t}\n\t\t\t});\n\t\t\tdocument.addEventListener(\"htmx:afterSettle\", function () {\n\t\t\t\tapplyDragState(document);\n\t\t\t});\n\t\t\tfunction handleMoveError(event) {\n\t\t\t\tvar form = event.detail && event.detail.elt;\n\t\t\t\tif (!(form instanceof HTMLFormElement) || !form.matches(\"[data-kanban-drag-move-form]\")) return;\n\t\t\t\tvar issueIDInput = form.querySelector(\"input[name='issue_id']\");\n\t\t\t\tvar issueID = issueIDInput instanceof HTMLInputElement ? issueIDInput.value : \"\";\n\t\t\t\tvar card = form.closest(\"[data-kanban-card][data-kanban-pending-move]\");\n\t\t\t\tif (!(card instanceof HTMLElement) || !card.isConnected) card = cardByIssueID(document, issueID);\n\t\t\t\trollbackPendingMove(card);\n\t\t\t\tvar response = event.detail.xhr ? event.detail.xhr.responseText : \"\";\n\t\t\t\tfeedback(responseMessage(response) || \"Move failed.\", \"error\");\n\t\t\t}\n\t\t\tdocument.body.addEventListener(\"htmx:responseError\", handleMoveError);\n\t\t\tdocument.body.addEventListener(\"htmx:sendError\", handleMoveError);\n\t\t\tdocument.body.addEventListener(\"htmx:timeout\", handleMoveError);\n\t\t})();\n\t</script>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -3215,61 +3262,61 @@ func boardScopeSelect(data DashboardData) templ.Component {
 			}()
 		}
 		ctx = templ.InitializeContext(ctx)
-		templ_7745c5c3_Var172 := templ.GetChildren(ctx)
-		if templ_7745c5c3_Var172 == nil {
-			templ_7745c5c3_Var172 = templ.NopComponent
+		templ_7745c5c3_Var175 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var175 == nil {
+			templ_7745c5c3_Var175 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 273, "<details class=\"group/scope relative min-w-0\"><summary class=\"flex min-w-0 cursor-pointer list-none items-center gap-1.5 rounded-card border border-line px-2.5 py-1 text-xs text-sec hover:text-text [&::-webkit-details-marker]:hidden\"><span class=\"min-w-0 truncate\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 277, "<details class=\"group/scope relative min-w-0\"><summary class=\"flex min-w-0 cursor-pointer list-none items-center gap-1.5 rounded-card border border-line px-2.5 py-1 text-xs text-sec hover:text-text [&::-webkit-details-marker]:hidden\"><span class=\"min-w-0 truncate\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		var templ_7745c5c3_Var173 string
-		templ_7745c5c3_Var173, templ_7745c5c3_Err = templ.JoinStringErrs(boardScopeLabel(data))
+		var templ_7745c5c3_Var176 string
+		templ_7745c5c3_Var176, templ_7745c5c3_Err = templ.JoinStringErrs(boardScopeLabel(data))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 1956, Col: 57}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 2006, Col: 57}
 		}
-		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var173))
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var176))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 274, "</span> <span aria-hidden=\"true\">▾</span></summary><div class=\"absolute left-0 top-full z-40 mt-1 flex w-52 flex-col gap-0.5 rounded-card border border-line bg-elev p-1.5\"><a href=\"/\" class=\"rounded-chip px-2 py-1 text-xs text-text hover:bg-surface\">All projects</a> ")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 278, "</span> <span aria-hidden=\"true\">▾</span></summary><div class=\"absolute left-0 top-full z-40 mt-1 flex w-52 flex-col gap-0.5 rounded-card border border-line bg-elev p-1.5\"><a href=\"/\" class=\"rounded-chip px-2 py-1 text-xs text-text hover:bg-surface\">All projects</a> ")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		for _, project := range appShellProjects(DashboardShellDataFromDashboard(data)) {
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 275, "<a href=\"")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 279, "<a href=\"")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			var templ_7745c5c3_Var174 templ.SafeURL
-			templ_7745c5c3_Var174, templ_7745c5c3_Err = templ.JoinURLErrs(templ.SafeURL(project.Href))
+			var templ_7745c5c3_Var177 templ.SafeURL
+			templ_7745c5c3_Var177, templ_7745c5c3_Err = templ.JoinURLErrs(templ.SafeURL(project.Href))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 1962, Col: 41}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 2012, Col: 41}
 			}
-			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var174))
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 276, "\" class=\"truncate rounded-chip px-2 py-1 text-xs text-text hover:bg-surface\">")
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var177))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			var templ_7745c5c3_Var175 string
-			templ_7745c5c3_Var175, templ_7745c5c3_Err = templ.JoinStringErrs(project.Name)
-			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 1962, Col: 133}
-			}
-			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var175))
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 280, "\" class=\"truncate rounded-chip px-2 py-1 text-xs text-text hover:bg-surface\">")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 277, "</a>")
+			var templ_7745c5c3_Var178 string
+			templ_7745c5c3_Var178, templ_7745c5c3_Err = templ.JoinStringErrs(project.Name)
+			if templ_7745c5c3_Err != nil {
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 2012, Col: 133}
+			}
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var178))
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 281, "</a>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 278, "</div></details>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 282, "</div></details>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}

--- a/internal/web/templates/board_templ.go
+++ b/internal/web/templates/board_templ.go
@@ -9,6 +9,7 @@ import "github.com/a-h/templ"
 import templruntime "github.com/a-h/templ/runtime"
 
 import (
+	"net/url"
 	"strconv"
 
 	"github.com/digitaldrywood/detent/internal/web/ui/components/icon"
@@ -268,7 +269,7 @@ func boardSnapshotBody(data DashboardData, alerts []boardAlert) templ.Component 
 			var templ_7745c5c3_Var7 string
 			templ_7745c5c3_Var7, templ_7745c5c3_Err = templ.JoinStringErrs(boardFeedbackGlyph(data.Kanban.FeedbackKind))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 73, Col: 74}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 74, Col: 74}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var7))
 			if templ_7745c5c3_Err != nil {
@@ -281,7 +282,7 @@ func boardSnapshotBody(data DashboardData, alerts []boardAlert) templ.Component 
 			var templ_7745c5c3_Var8 string
 			templ_7745c5c3_Var8, templ_7745c5c3_Err = templ.JoinStringErrs(data.Kanban.Feedback)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 74, Col: 25}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 75, Col: 25}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var8))
 			if templ_7745c5c3_Err != nil {
@@ -335,7 +336,7 @@ func boardSnapshotBody(data DashboardData, alerts []boardAlert) templ.Component 
 				var templ_7745c5c3_Var12 string
 				templ_7745c5c3_Var12, templ_7745c5c3_Err = templ.JoinStringErrs(refreshFreshnessSummary(data.Snapshot))
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 82, Col: 191}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 83, Col: 191}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var12))
 				if templ_7745c5c3_Err != nil {
@@ -383,7 +384,7 @@ func boardSnapshotBody(data DashboardData, alerts []boardAlert) templ.Component 
 		var templ_7745c5c3_Var13 string
 		templ_7745c5c3_Var13, templ_7745c5c3_Err = templ.JoinStringErrs("Lane 1 of " + formatCount(view.Visible))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 95, Col: 55}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 96, Col: 55}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var13))
 		if templ_7745c5c3_Err != nil {
@@ -396,7 +397,7 @@ func boardSnapshotBody(data DashboardData, alerts []boardAlert) templ.Component 
 		var templ_7745c5c3_Var14 string
 		templ_7745c5c3_Var14, templ_7745c5c3_Err = templ.JoinStringErrs(formatCount(view.Visible))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 97, Col: 139}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 98, Col: 139}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var14))
 		if templ_7745c5c3_Err != nil {
@@ -431,7 +432,7 @@ func boardSnapshotBody(data DashboardData, alerts []boardAlert) templ.Component 
 		var templ_7745c5c3_Var17 string
 		templ_7745c5c3_Var17, templ_7745c5c3_Err = templ.JoinStringErrs(view.Key)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 103, Col: 27}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 104, Col: 27}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var17))
 		if templ_7745c5c3_Err != nil {
@@ -502,7 +503,7 @@ func boardAlertsBar(alerts []boardAlert) templ.Component {
 			var templ_7745c5c3_Var21 string
 			templ_7745c5c3_Var21, templ_7745c5c3_Err = templ.JoinStringErrs(strconv.Itoa(len(alerts)))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 119, Col: 53}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 120, Col: 53}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var21))
 			if templ_7745c5c3_Err != nil {
@@ -531,7 +532,7 @@ func boardAlertsBar(alerts []boardAlert) templ.Component {
 			var templ_7745c5c3_Var22 string
 			templ_7745c5c3_Var22, templ_7745c5c3_Err = templ.JoinStringErrs(boardAlertButtonLabel(alerts))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 134, Col: 46}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 135, Col: 46}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var22))
 			if templ_7745c5c3_Err != nil {
@@ -545,14 +546,14 @@ func boardAlertsBar(alerts []boardAlert) templ.Component {
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 42, "<span class=\"shrink-0 font-medium\">")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 42, "<span class=\"shrink-0 font-medium\" data-board-alert-count-label>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var23 string
 			templ_7745c5c3_Var23, templ_7745c5c3_Err = templ.JoinStringErrs(boardCountLabel(len(alerts), "warning", "warnings"))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 137, Col: 92}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 138, Col: 121}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var23))
 			if templ_7745c5c3_Err != nil {
@@ -565,7 +566,7 @@ func boardAlertsBar(alerts []boardAlert) templ.Component {
 			var templ_7745c5c3_Var24 string
 			templ_7745c5c3_Var24, templ_7745c5c3_Err = templ.JoinStringErrs(alerts[0].TerseSummary)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 139, Col: 93}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 140, Col: 93}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var24))
 			if templ_7745c5c3_Err != nil {
@@ -576,14 +577,14 @@ func boardAlertsBar(alerts []boardAlert) templ.Component {
 				return templ_7745c5c3_Err
 			}
 			if len(alerts) > 1 {
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 45, "<span class=\"shrink-0 font-medium\">")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 45, "<span class=\"shrink-0 font-medium\" data-board-alert-overflow>")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
 				var templ_7745c5c3_Var25 string
 				templ_7745c5c3_Var25, templ_7745c5c3_Err = templ.JoinStringErrs("+" + strconv.Itoa(len(alerts)-1))
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 141, Col: 75}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 142, Col: 101}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var25))
 				if templ_7745c5c3_Err != nil {
@@ -640,6 +641,7 @@ func boardAlertsOverlayContents(alerts []boardAlert) templ.Component {
 			templ_7745c5c3_Var26 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
+		dismissals := boardStalenessDismissals(alerts)
 		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 50, "<div class=\"divide-y divide-line\" data-board-alerts-overlay-content><header class=\"sticky top-0 z-10 flex h-10 items-center gap-2 border-b border-line bg-page px-3 text-sm\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
@@ -648,20 +650,105 @@ func boardAlertsOverlayContents(alerts []boardAlert) templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 51, "<p class=\"min-w-0 flex-1 truncate font-medium text-text\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 51, "<p class=\"min-w-0 flex-1 truncate font-medium text-text\" data-board-alert-count-label>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		var templ_7745c5c3_Var27 string
 		templ_7745c5c3_Var27, templ_7745c5c3_Err = templ.JoinStringErrs(boardCountLabel(len(alerts), "warning", "warnings"))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 158, Col: 113}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 160, Col: 142}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var27))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 52, "</p><button type=\"button\" class=\"inline-flex shrink-0 items-center gap-1 rounded-chip px-2 py-1 text-xs font-medium text-sec hover:bg-elev hover:text-text focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent\" data-board-alerts-close aria-label=\"Collapse board alerts\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 52, "</p>")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		for _, dismissal := range dismissals {
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 53, "<form class=\"shrink-0\" hx-post=\"")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			var templ_7745c5c3_Var28 string
+			templ_7745c5c3_Var28, templ_7745c5c3_Err = templ.JoinStringErrs("/api/v1/projects/" + url.PathEscape(dismissal.ProjectID) + "/staleness-warnings/acknowledge")
+			if templ_7745c5c3_Err != nil {
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 164, Col: 108}
+			}
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var28))
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 54, "\" hx-swap=\"none\" hx-confirm=\"")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			var templ_7745c5c3_Var29 string
+			templ_7745c5c3_Var29, templ_7745c5c3_Err = templ.JoinStringErrs("Dismiss " + strconv.Itoa(len(dismissal.WarningIDs)) + " staleness warnings?")
+			if templ_7745c5c3_Err != nil {
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 166, Col: 95}
+			}
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var29))
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 55, "\" data-staleness-dismiss-form data-staleness-dismiss-bulk data-staleness-project-id=\"")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			var templ_7745c5c3_Var30 string
+			templ_7745c5c3_Var30, templ_7745c5c3_Err = templ.JoinStringErrs(dismissal.ProjectID)
+			if templ_7745c5c3_Err != nil {
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 169, Col: 52}
+			}
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var30))
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 56, "\">")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			for _, warningID := range dismissal.WarningIDs {
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 57, "<input type=\"hidden\" name=\"warning_id\" value=\"")
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+				var templ_7745c5c3_Var31 string
+				templ_7745c5c3_Var31, templ_7745c5c3_Err = templ.JoinStringErrs(warningID)
+				if templ_7745c5c3_Err != nil {
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 172, Col: 62}
+				}
+				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var31))
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 58, "\"> ")
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 59, "<button type=\"submit\" class=\"inline-flex shrink-0 items-center rounded-chip px-2 py-1 text-xs font-medium text-sec hover:bg-elev hover:text-text focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent\" data-staleness-dismiss-label>")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			var templ_7745c5c3_Var32 string
+			templ_7745c5c3_Var32, templ_7745c5c3_Err = templ.JoinStringErrs(boardStalenessDismissalLabel(dismissal, len(dismissals)))
+			if templ_7745c5c3_Err != nil {
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 174, Col: 312}
+			}
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var32))
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 60, "</button></form>")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 61, "<button type=\"button\" class=\"inline-flex shrink-0 items-center gap-1 rounded-chip px-2 py-1 text-xs font-medium text-sec hover:bg-elev hover:text-text focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent\" data-board-alerts-close aria-label=\"Collapse board alerts\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -669,332 +756,404 @@ func boardAlertsOverlayContents(alerts []boardAlert) templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 53, "Close</button></header><div class=\"grid divide-y divide-line\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 62, "Close</button></header><div class=\"grid divide-y divide-line\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		for _, alert := range alerts {
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 54, "<section id=\"")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 63, "<section id=\"")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			var templ_7745c5c3_Var28 string
-			templ_7745c5c3_Var28, templ_7745c5c3_Err = templ.JoinStringErrs(alert.ID)
+			var templ_7745c5c3_Var33 string
+			templ_7745c5c3_Var33, templ_7745c5c3_Err = templ.JoinStringErrs(alert.ID)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 171, Col: 26}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 190, Col: 18}
 			}
-			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var28))
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 55, "\" class=\"grid min-w-0 gap-2 px-4 py-3\" data-board-alert=\"")
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var33))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			var templ_7745c5c3_Var29 string
-			templ_7745c5c3_Var29, templ_7745c5c3_Err = templ.JoinStringErrs(string(alert.Kind))
-			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 171, Col: 103}
-			}
-			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var29))
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 64, "\" class=\"grid min-w-0 gap-2 px-4 py-3\" data-board-alert=\"")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 56, "\"><div class=\"flex min-w-0 items-start gap-3\"><div class=\"min-w-0 flex-1\"><p class=\"font-medium text-text\">")
+			var templ_7745c5c3_Var34 string
+			templ_7745c5c3_Var34, templ_7745c5c3_Err = templ.JoinStringErrs(string(alert.Kind))
+			if templ_7745c5c3_Err != nil {
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 192, Col: 42}
+			}
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var34))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			var templ_7745c5c3_Var30 string
-			templ_7745c5c3_Var30, templ_7745c5c3_Err = templ.JoinStringErrs(alert.TerseSummary)
-			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 174, Col: 60}
-			}
-			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var30))
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 65, "\"")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 57, "</p>")
+			if alert.StalenessWarningID != "" {
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 66, " data-staleness-warning-id=\"")
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+				var templ_7745c5c3_Var35 string
+				templ_7745c5c3_Var35, templ_7745c5c3_Err = templ.JoinStringErrs(alert.StalenessWarningID)
+				if templ_7745c5c3_Err != nil {
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 194, Col: 58}
+				}
+				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var35))
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 67, "\" data-staleness-project-id=\"")
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+				var templ_7745c5c3_Var36 string
+				templ_7745c5c3_Var36, templ_7745c5c3_Err = templ.JoinStringErrs(alert.StalenessProjectID)
+				if templ_7745c5c3_Err != nil {
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 195, Col: 58}
+				}
+				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var36))
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 68, "\"")
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 69, "><div class=\"flex min-w-0 items-start gap-3\"><div class=\"min-w-0 flex-1\"><p class=\"font-medium text-text\">")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			var templ_7745c5c3_Var37 string
+			templ_7745c5c3_Var37, templ_7745c5c3_Err = templ.JoinStringErrs(alert.TerseSummary)
+			if templ_7745c5c3_Err != nil {
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 200, Col: 60}
+			}
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var37))
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 70, "</p>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			if alert.DetailSummary != "" {
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 58, "<p class=\"mt-0.5 text-xs text-sec\">")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 71, "<p class=\"mt-0.5 text-xs text-sec\">")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				var templ_7745c5c3_Var31 string
-				templ_7745c5c3_Var31, templ_7745c5c3_Err = templ.JoinStringErrs(alert.DetailSummary)
+				var templ_7745c5c3_Var38 string
+				templ_7745c5c3_Var38, templ_7745c5c3_Err = templ.JoinStringErrs(alert.DetailSummary)
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 176, Col: 64}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 202, Col: 64}
 				}
-				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var31))
+				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var38))
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 59, "</p>")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 72, "</p>")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 60, "</div>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 73, "</div>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			if alert.DeepLink != "" {
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 61, "<a class=\"shrink-0 text-xs font-medium text-accent hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent\" href=\"")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 74, "<a class=\"shrink-0 text-xs font-medium text-accent hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent\" href=\"")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				var templ_7745c5c3_Var32 templ.SafeURL
-				templ_7745c5c3_Var32, templ_7745c5c3_Err = templ.JoinURLErrs(templ.SafeURL(alert.DeepLink))
+				var templ_7745c5c3_Var39 templ.SafeURL
+				templ_7745c5c3_Var39, templ_7745c5c3_Err = templ.JoinURLErrs(templ.SafeURL(alert.DeepLink))
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 180, Col: 185}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 206, Col: 185}
 				}
-				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var32))
+				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var39))
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 62, "\">")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 75, "\">")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
 				if alert.DeepLinkLabel != "" {
-					var templ_7745c5c3_Var33 string
-					templ_7745c5c3_Var33, templ_7745c5c3_Err = templ.JoinStringErrs(alert.DeepLinkLabel)
+					var templ_7745c5c3_Var40 string
+					templ_7745c5c3_Var40, templ_7745c5c3_Err = templ.JoinStringErrs(alert.DeepLinkLabel)
 					if templ_7745c5c3_Err != nil {
-						return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 182, Col: 30}
+						return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 208, Col: 30}
 					}
-					_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var33))
+					_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var40))
 					if templ_7745c5c3_Err != nil {
 						return templ_7745c5c3_Err
 					}
 				} else if alert.Overflow > 0 {
-					var templ_7745c5c3_Var34 string
-					templ_7745c5c3_Var34, templ_7745c5c3_Err = templ.JoinStringErrs("+" + strconv.Itoa(alert.Overflow) + " more · Health")
+					var templ_7745c5c3_Var41 string
+					templ_7745c5c3_Var41, templ_7745c5c3_Err = templ.JoinStringErrs("+" + strconv.Itoa(alert.Overflow) + " more · Health")
 					if templ_7745c5c3_Err != nil {
-						return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 184, Col: 65}
+						return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 210, Col: 65}
 					}
-					_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var34))
+					_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var41))
 					if templ_7745c5c3_Err != nil {
 						return templ_7745c5c3_Err
 					}
 				} else {
-					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 63, "Health")
+					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 76, "Health")
 					if templ_7745c5c3_Err != nil {
 						return templ_7745c5c3_Err
 					}
 				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 64, "</a>")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 77, "</a>")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 65, "</div>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 78, "</div>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			if len(alert.DetailRows) > 0 {
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 66, "<div class=\"grid gap-2 pl-3\">")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 79, "<div class=\"grid gap-2 pl-3\">")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
 				for _, row := range alert.DetailRows {
-					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 67, "<div id=\"")
+					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 80, "<div id=\"")
 					if templ_7745c5c3_Err != nil {
 						return templ_7745c5c3_Err
 					}
-					var templ_7745c5c3_Var35 string
-					templ_7745c5c3_Var35, templ_7745c5c3_Err = templ.JoinStringErrs(row.ID)
+					var templ_7745c5c3_Var42 string
+					templ_7745c5c3_Var42, templ_7745c5c3_Err = templ.JoinStringErrs(row.ID)
 					if templ_7745c5c3_Err != nil {
-						return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 194, Col: 24}
+						return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 220, Col: 24}
 					}
-					_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var35))
+					_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var42))
 					if templ_7745c5c3_Err != nil {
 						return templ_7745c5c3_Err
 					}
-					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 68, "\" class=\"min-w-0 border-l border-line pl-3 text-xs\"><p class=\"flex min-w-0 flex-wrap items-baseline gap-x-2 text-text\">")
+					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 81, "\" class=\"min-w-0 border-l border-line pl-3 text-xs\"><p class=\"flex min-w-0 flex-wrap items-baseline gap-x-2 text-text\">")
 					if templ_7745c5c3_Err != nil {
 						return templ_7745c5c3_Err
 					}
 					if row.Link != "" {
-						templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 69, "<a class=\"font-mono font-medium text-accent hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent\" href=\"")
+						templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 82, "<a class=\"font-mono font-medium text-accent hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent\" href=\"")
 						if templ_7745c5c3_Err != nil {
 							return templ_7745c5c3_Err
 						}
-						var templ_7745c5c3_Var36 templ.SafeURL
-						templ_7745c5c3_Var36, templ_7745c5c3_Err = templ.JoinURLErrs(templ.SafeURL(row.Link))
+						var templ_7745c5c3_Var43 templ.SafeURL
+						templ_7745c5c3_Var43, templ_7745c5c3_Err = templ.JoinURLErrs(templ.SafeURL(row.Link))
 						if templ_7745c5c3_Err != nil {
-							return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 197, Col: 176}
+							return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 223, Col: 176}
 						}
-						_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var36))
-						if templ_7745c5c3_Err != nil {
-							return templ_7745c5c3_Err
-						}
-						templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 70, "\">")
+						_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var43))
 						if templ_7745c5c3_Err != nil {
 							return templ_7745c5c3_Err
 						}
-						var templ_7745c5c3_Var37 string
-						templ_7745c5c3_Var37, templ_7745c5c3_Err = templ.JoinStringErrs(row.Label)
-						if templ_7745c5c3_Err != nil {
-							return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 197, Col: 190}
-						}
-						_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var37))
+						templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 83, "\">")
 						if templ_7745c5c3_Err != nil {
 							return templ_7745c5c3_Err
 						}
-						templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 71, "</a> ")
+						var templ_7745c5c3_Var44 string
+						templ_7745c5c3_Var44, templ_7745c5c3_Err = templ.JoinStringErrs(row.Label)
+						if templ_7745c5c3_Err != nil {
+							return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 223, Col: 190}
+						}
+						_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var44))
+						if templ_7745c5c3_Err != nil {
+							return templ_7745c5c3_Err
+						}
+						templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 84, "</a> ")
 						if templ_7745c5c3_Err != nil {
 							return templ_7745c5c3_Err
 						}
 					} else {
-						templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 72, "<span class=\"font-mono font-medium\">")
+						templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 85, "<span class=\"font-mono font-medium\">")
 						if templ_7745c5c3_Err != nil {
 							return templ_7745c5c3_Err
 						}
-						var templ_7745c5c3_Var38 string
-						templ_7745c5c3_Var38, templ_7745c5c3_Err = templ.JoinStringErrs(row.Label)
+						var templ_7745c5c3_Var45 string
+						templ_7745c5c3_Var45, templ_7745c5c3_Err = templ.JoinStringErrs(row.Label)
 						if templ_7745c5c3_Err != nil {
-							return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 199, Col: 58}
+							return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 225, Col: 58}
 						}
-						_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var38))
+						_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var45))
 						if templ_7745c5c3_Err != nil {
 							return templ_7745c5c3_Err
 						}
-						templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 73, "</span> ")
+						templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 86, "</span> ")
 						if templ_7745c5c3_Err != nil {
 							return templ_7745c5c3_Err
 						}
 					}
 					if row.Summary != "" {
-						templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 74, "<span class=\"text-sec\">")
+						templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 87, "<span class=\"text-sec\">")
 						if templ_7745c5c3_Err != nil {
 							return templ_7745c5c3_Err
 						}
-						var templ_7745c5c3_Var39 string
-						templ_7745c5c3_Var39, templ_7745c5c3_Err = templ.JoinStringErrs(row.Summary)
+						var templ_7745c5c3_Var46 string
+						templ_7745c5c3_Var46, templ_7745c5c3_Err = templ.JoinStringErrs(row.Summary)
 						if templ_7745c5c3_Err != nil {
-							return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 202, Col: 47}
+							return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 228, Col: 47}
 						}
-						_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var39))
+						_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var46))
 						if templ_7745c5c3_Err != nil {
 							return templ_7745c5c3_Err
 						}
-						templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 75, "</span>")
+						templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 88, "</span>")
 						if templ_7745c5c3_Err != nil {
 							return templ_7745c5c3_Err
 						}
 					}
-					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 76, "</p>")
+					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 89, "</p>")
 					if templ_7745c5c3_Err != nil {
 						return templ_7745c5c3_Err
 					}
 					if row.Detail != "" {
-						templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 77, "<p class=\"mt-0.5 break-words text-sec\">")
+						templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 90, "<p class=\"mt-0.5 break-words text-sec\">")
 						if templ_7745c5c3_Err != nil {
 							return templ_7745c5c3_Err
 						}
-						var templ_7745c5c3_Var40 string
-						templ_7745c5c3_Var40, templ_7745c5c3_Err = templ.JoinStringErrs(row.Detail)
+						var templ_7745c5c3_Var47 string
+						templ_7745c5c3_Var47, templ_7745c5c3_Err = templ.JoinStringErrs(row.Detail)
 						if templ_7745c5c3_Err != nil {
-							return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 206, Col: 61}
+							return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 232, Col: 61}
 						}
-						_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var40))
+						_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var47))
 						if templ_7745c5c3_Err != nil {
 							return templ_7745c5c3_Err
 						}
-						templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 78, "</p>")
+						templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 91, "</p>")
 						if templ_7745c5c3_Err != nil {
 							return templ_7745c5c3_Err
 						}
 					}
-					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 79, "</div>")
+					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 92, "</div>")
 					if templ_7745c5c3_Err != nil {
 						return templ_7745c5c3_Err
 					}
 				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 80, "</div>")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 93, "</div>")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
 			}
 			if alert.Action != nil {
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 81, "<form class=\"pl-3\" hx-post=\"")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 94, "<form class=\"pl-3\" hx-post=\"")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				var templ_7745c5c3_Var41 string
-				templ_7745c5c3_Var41, templ_7745c5c3_Err = templ.JoinStringErrs(alert.Action.Path)
+				var templ_7745c5c3_Var48 string
+				templ_7745c5c3_Var48, templ_7745c5c3_Err = templ.JoinStringErrs(alert.Action.Path)
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 215, Col: 34}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 241, Col: 34}
 				}
-				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var41))
-				if templ_7745c5c3_Err != nil {
-					return templ_7745c5c3_Err
-				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 82, "\" hx-target=\"")
+				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var48))
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				var templ_7745c5c3_Var42 string
-				templ_7745c5c3_Var42, templ_7745c5c3_Err = templ.JoinStringErrs(alert.Action.Target)
-				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 216, Col: 38}
-				}
-				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var42))
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 95, "\" hx-target=\"")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 83, "\" hx-swap=\"")
+				var templ_7745c5c3_Var49 string
+				templ_7745c5c3_Var49, templ_7745c5c3_Err = templ.JoinStringErrs(alert.Action.Target)
+				if templ_7745c5c3_Err != nil {
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 242, Col: 38}
+				}
+				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var49))
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				var templ_7745c5c3_Var43 string
-				templ_7745c5c3_Var43, templ_7745c5c3_Err = templ.JoinStringErrs(boardAlertActionSwap(alert.Action))
-				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 217, Col: 51}
-				}
-				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var43))
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 96, "\" hx-swap=\"")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 84, "\" hx-confirm=\"")
+				var templ_7745c5c3_Var50 string
+				templ_7745c5c3_Var50, templ_7745c5c3_Err = templ.JoinStringErrs(boardAlertActionSwap(alert.Action))
+				if templ_7745c5c3_Err != nil {
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 243, Col: 51}
+				}
+				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var50))
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				var templ_7745c5c3_Var44 string
-				templ_7745c5c3_Var44, templ_7745c5c3_Err = templ.JoinStringErrs(alert.Action.Confirm)
-				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 218, Col: 40}
-				}
-				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var44))
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 97, "\" hx-confirm=\"")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 85, "\"><input type=\"hidden\" name=\"confirm\" value=\"true\"> <button type=\"submit\" class=\"inline-flex min-h-8 items-center justify-center rounded-card border border-current/40 bg-surface px-3 py-1.5 text-xs font-medium text-text hover:bg-current/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-current/50\">")
+				var templ_7745c5c3_Var51 string
+				templ_7745c5c3_Var51, templ_7745c5c3_Err = templ.JoinStringErrs(alert.Action.Confirm)
+				if templ_7745c5c3_Err != nil {
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 244, Col: 40}
+				}
+				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var51))
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				var templ_7745c5c3_Var45 string
-				templ_7745c5c3_Var45, templ_7745c5c3_Err = templ.JoinStringErrs(alert.Action.Label)
-				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 221, Col: 294}
-				}
-				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var45))
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 98, "\"")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 86, "</button></form>")
+				if alert.StalenessWarningID != "" {
+					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 99, " data-staleness-dismiss-form data-staleness-warning-id=\"")
+					if templ_7745c5c3_Err != nil {
+						return templ_7745c5c3_Err
+					}
+					var templ_7745c5c3_Var52 string
+					templ_7745c5c3_Var52, templ_7745c5c3_Err = templ.JoinStringErrs(alert.StalenessWarningID)
+					if templ_7745c5c3_Err != nil {
+						return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 247, Col: 60}
+					}
+					_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var52))
+					if templ_7745c5c3_Err != nil {
+						return templ_7745c5c3_Err
+					}
+					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 100, "\" data-staleness-project-id=\"")
+					if templ_7745c5c3_Err != nil {
+						return templ_7745c5c3_Err
+					}
+					var templ_7745c5c3_Var53 string
+					templ_7745c5c3_Var53, templ_7745c5c3_Err = templ.JoinStringErrs(alert.StalenessProjectID)
+					if templ_7745c5c3_Err != nil {
+						return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 248, Col: 60}
+					}
+					_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var53))
+					if templ_7745c5c3_Err != nil {
+						return templ_7745c5c3_Err
+					}
+					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 101, "\"")
+					if templ_7745c5c3_Err != nil {
+						return templ_7745c5c3_Err
+					}
+				}
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 102, "><input type=\"hidden\" name=\"confirm\" value=\"true\"> <button type=\"submit\" class=\"inline-flex min-h-8 items-center justify-center rounded-card border border-current/40 bg-surface px-3 py-1.5 text-xs font-medium text-text hover:bg-current/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-current/50\">")
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+				var templ_7745c5c3_Var54 string
+				templ_7745c5c3_Var54, templ_7745c5c3_Err = templ.JoinStringErrs(alert.Action.Label)
+				if templ_7745c5c3_Err != nil {
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 252, Col: 294}
+				}
+				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var54))
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 103, "</button></form>")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 87, "</section>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 104, "</section>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 88, "</div></div>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 105, "</div></div>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -1025,9 +1184,9 @@ func boardAlertGlyph(alert boardAlert, class string) templ.Component {
 			}()
 		}
 		ctx = templ.InitializeContext(ctx)
-		templ_7745c5c3_Var46 := templ.GetChildren(ctx)
-		if templ_7745c5c3_Var46 == nil {
-			templ_7745c5c3_Var46 = templ.NopComponent
+		templ_7745c5c3_Var55 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var55 == nil {
+			templ_7745c5c3_Var55 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
 		if alert.Tone == primitives.KindErr {
@@ -1066,12 +1225,12 @@ func boardAlertsOverlayHost() templ.Component {
 			}()
 		}
 		ctx = templ.InitializeContext(ctx)
-		templ_7745c5c3_Var47 := templ.GetChildren(ctx)
-		if templ_7745c5c3_Var47 == nil {
-			templ_7745c5c3_Var47 = templ.NopComponent
+		templ_7745c5c3_Var56 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var56 == nil {
+			templ_7745c5c3_Var56 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 89, "<div id=\"board-alerts-overlay\" class=\"fixed z-40 hidden max-h-[40vh] overflow-y-auto rounded-card border border-line bg-page shadow-lg\" data-board-alerts-overlay-host aria-hidden=\"true\" hidden></div>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 106, "<div id=\"board-alerts-overlay\" class=\"fixed z-40 hidden max-h-[40vh] overflow-y-auto rounded-card border border-line bg-page shadow-lg\" data-board-alerts-overlay-host aria-hidden=\"true\" hidden></div>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -1095,12 +1254,12 @@ func boardAlertScript() templ.Component {
 			}()
 		}
 		ctx = templ.InitializeContext(ctx)
-		templ_7745c5c3_Var48 := templ.GetChildren(ctx)
-		if templ_7745c5c3_Var48 == nil {
-			templ_7745c5c3_Var48 = templ.NopComponent
+		templ_7745c5c3_Var57 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var57 == nil {
+			templ_7745c5c3_Var57 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 90, "<script>\n\t\t(function () {\n\t\t\tvar open = false;\n\t\t\tvar positionFrame = 0;\n\n\t\t\tfunction alertsBar() {\n\t\t\t\treturn document.getElementById(\"board-alerts\");\n\t\t\t}\n\n\t\t\tfunction alertsToggle() {\n\t\t\t\treturn document.querySelector(\"[data-board-alerts-toggle]\");\n\t\t\t}\n\n\t\t\tfunction overlayHost() {\n\t\t\t\treturn document.querySelector(\"[data-board-alerts-overlay-host]\");\n\t\t\t}\n\n\t\t\tfunction overlayTemplate() {\n\t\t\t\tvar bar = alertsBar();\n\t\t\t\treturn bar ? bar.querySelector(\"template[data-board-alerts-overlay-template]\") : null;\n\t\t\t}\n\n\t\t\tfunction setToggleState(expanded) {\n\t\t\t\tvar toggle = alertsToggle();\n\t\t\t\tif (!toggle) return;\n\t\t\t\ttoggle.setAttribute(\"aria-expanded\", expanded ? \"true\" : \"false\");\n\t\t\t\tvar chevron = toggle.querySelector(\"[data-board-alerts-chevron]\");\n\t\t\t\tif (chevron) chevron.setAttribute(\"data-open\", expanded ? \"true\" : \"false\");\n\t\t\t}\n\n\t\t\tfunction renderOverlay() {\n\t\t\t\tvar host = overlayHost();\n\t\t\t\tvar template = overlayTemplate();\n\t\t\t\tif (!host || !(template instanceof HTMLTemplateElement)) return false;\n\t\t\t\thost.replaceChildren(template.content.cloneNode(true));\n\t\t\t\tif (window.htmx) window.htmx.process(host);\n\t\t\t\treturn true;\n\t\t\t}\n\n\t\t\tfunction positionOverlay() {\n\t\t\t\tpositionFrame = 0;\n\t\t\t\tif (!open) return;\n\t\t\t\tvar bar = alertsBar();\n\t\t\t\tvar host = overlayHost();\n\t\t\t\tif (!bar || !host) return;\n\t\t\t\tvar rect = bar.getBoundingClientRect();\n\t\t\t\tvar margin = 8;\n\t\t\t\tvar width = Math.min(640, Math.max(0, window.innerWidth - margin * 2));\n\t\t\t\tvar left = Math.min(Math.max(margin, rect.left), Math.max(margin, window.innerWidth - width - margin));\n\t\t\t\thost.style.left = Math.round(left) + \"px\";\n\t\t\t\thost.style.top = Math.round(rect.bottom + 4) + \"px\";\n\t\t\t\thost.style.width = Math.round(width) + \"px\";\n\t\t\t}\n\n\t\t\tfunction requestOverlayPosition() {\n\t\t\t\tif (positionFrame) return;\n\t\t\t\tpositionFrame = requestAnimationFrame(positionOverlay);\n\t\t\t}\n\n\t\t\tfunction closeOverlay(restoreFocus) {\n\t\t\t\topen = false;\n\t\t\t\tvar host = overlayHost();\n\t\t\t\tif (host) {\n\t\t\t\t\thost.hidden = true;\n\t\t\t\t\thost.classList.add(\"hidden\");\n\t\t\t\t\thost.setAttribute(\"aria-hidden\", \"true\");\n\t\t\t\t}\n\t\t\t\tsetToggleState(false);\n\t\t\t\tif (restoreFocus) {\n\t\t\t\t\tvar toggle = alertsToggle();\n\t\t\t\t\tif (toggle) toggle.focus();\n\t\t\t\t}\n\t\t\t}\n\n\t\t\tfunction openOverlay() {\n\t\t\t\tif (!renderOverlay()) return;\n\t\t\t\topen = true;\n\t\t\t\tvar host = overlayHost();\n\t\t\t\tif (!host) return;\n\t\t\t\thost.hidden = false;\n\t\t\t\thost.classList.remove(\"hidden\");\n\t\t\t\thost.setAttribute(\"aria-hidden\", \"false\");\n\t\t\t\tsetToggleState(true);\n\t\t\t\tpositionOverlay();\n\t\t\t}\n\n\t\t\tfunction syncOverlayAfterMorph() {\n\t\t\t\tif (!open) {\n\t\t\t\t\tsetToggleState(false);\n\t\t\t\t\treturn;\n\t\t\t\t}\n\t\t\t\tif (!alertsBar()) {\n\t\t\t\t\tcloseOverlay(false);\n\t\t\t\t\treturn;\n\t\t\t\t}\n\t\t\t\tvar host = overlayHost();\n\t\t\t\tvar scrollTop = host ? host.scrollTop : 0;\n\t\t\t\tif (!renderOverlay()) {\n\t\t\t\t\tcloseOverlay(false);\n\t\t\t\t\treturn;\n\t\t\t\t}\n\t\t\t\thost = overlayHost();\n\t\t\t\tif (!host) return;\n\t\t\t\thost.hidden = false;\n\t\t\t\thost.classList.remove(\"hidden\");\n\t\t\t\thost.setAttribute(\"aria-hidden\", \"false\");\n\t\t\t\thost.scrollTop = scrollTop;\n\t\t\t\tsetToggleState(true);\n\t\t\t\tpositionOverlay();\n\t\t\t}\n\n\t\t\tfunction settledSnapshot(event) {\n\t\t\t\tvar detailTarget = event.detail && event.detail.target;\n\t\t\t\tvar target = detailTarget instanceof Element ? detailTarget : event.target;\n\t\t\t\tif (!(target instanceof Element)) return false;\n\t\t\t\treturn target.id === \"snapshot\" || Boolean(target.closest(\"#snapshot\"));\n\t\t\t}\n\n\t\t\tdocument.addEventListener(\"click\", function (event) {\n\t\t\t\tvar target = event.target instanceof Element ? event.target : null;\n\t\t\t\tif (!target) return;\n\t\t\t\tif (target.closest(\"[data-board-alerts-close]\")) {\n\t\t\t\t\tcloseOverlay(true);\n\t\t\t\t\treturn;\n\t\t\t\t}\n\t\t\t\tif (!target.closest(\"[data-board-alerts-toggle]\")) return;\n\t\t\t\tif (open) {\n\t\t\t\t\tcloseOverlay(false);\n\t\t\t\t} else {\n\t\t\t\t\topenOverlay();\n\t\t\t\t}\n\t\t\t});\n\n\t\t\tdocument.addEventListener(\"keydown\", function (event) {\n\t\t\t\tif (event.key === \"Escape\" && open) closeOverlay(true);\n\t\t\t});\n\n\t\t\tdocument.addEventListener(\"htmx:afterSettle\", function (event) {\n\t\t\t\tif (settledSnapshot(event)) syncOverlayAfterMorph();\n\t\t\t});\n\n\t\t\twindow.addEventListener(\"resize\", requestOverlayPosition);\n\t\t})();\n\t</script>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 107, "<script>\n\t\t(function () {\n\t\t\tvar open = false;\n\t\t\tvar positionFrame = 0;\n\n\t\t\tfunction alertsBar() {\n\t\t\t\treturn document.getElementById(\"board-alerts\");\n\t\t\t}\n\n\t\t\tfunction alertsToggle() {\n\t\t\t\treturn document.querySelector(\"[data-board-alerts-toggle]\");\n\t\t\t}\n\n\t\t\tfunction overlayHost() {\n\t\t\t\treturn document.querySelector(\"[data-board-alerts-overlay-host]\");\n\t\t\t}\n\n\t\t\tfunction overlayTemplate() {\n\t\t\t\tvar bar = alertsBar();\n\t\t\t\treturn bar ? bar.querySelector(\"template[data-board-alerts-overlay-template]\") : null;\n\t\t\t}\n\n\t\t\tfunction setToggleState(expanded) {\n\t\t\t\tvar toggle = alertsToggle();\n\t\t\t\tif (!toggle) return;\n\t\t\t\ttoggle.setAttribute(\"aria-expanded\", expanded ? \"true\" : \"false\");\n\t\t\t\tvar chevron = toggle.querySelector(\"[data-board-alerts-chevron]\");\n\t\t\t\tif (chevron) chevron.setAttribute(\"data-open\", expanded ? \"true\" : \"false\");\n\t\t\t}\n\n\t\t\tfunction renderOverlay() {\n\t\t\t\tvar host = overlayHost();\n\t\t\t\tvar template = overlayTemplate();\n\t\t\t\tif (!host || !(template instanceof HTMLTemplateElement)) return false;\n\t\t\t\thost.replaceChildren(template.content.cloneNode(true));\n\t\t\t\tif (window.htmx) window.htmx.process(host);\n\t\t\t\treturn true;\n\t\t\t}\n\n\t\t\tfunction positionOverlay() {\n\t\t\t\tpositionFrame = 0;\n\t\t\t\tif (!open) return;\n\t\t\t\tvar bar = alertsBar();\n\t\t\t\tvar host = overlayHost();\n\t\t\t\tif (!bar || !host) return;\n\t\t\t\tvar rect = bar.getBoundingClientRect();\n\t\t\t\tvar margin = 8;\n\t\t\t\tvar width = Math.min(640, Math.max(0, window.innerWidth - margin * 2));\n\t\t\t\tvar left = Math.min(Math.max(margin, rect.left), Math.max(margin, window.innerWidth - width - margin));\n\t\t\t\thost.style.left = Math.round(left) + \"px\";\n\t\t\t\thost.style.top = Math.round(rect.bottom + 4) + \"px\";\n\t\t\t\thost.style.width = Math.round(width) + \"px\";\n\t\t\t}\n\n\t\t\tfunction requestOverlayPosition() {\n\t\t\t\tif (positionFrame) return;\n\t\t\t\tpositionFrame = requestAnimationFrame(positionOverlay);\n\t\t\t}\n\n\t\t\tfunction closeOverlay(restoreFocus) {\n\t\t\t\topen = false;\n\t\t\t\tvar host = overlayHost();\n\t\t\t\tif (host) {\n\t\t\t\t\thost.hidden = true;\n\t\t\t\t\thost.classList.add(\"hidden\");\n\t\t\t\t\thost.setAttribute(\"aria-hidden\", \"true\");\n\t\t\t\t}\n\t\t\t\tsetToggleState(false);\n\t\t\t\tif (restoreFocus) {\n\t\t\t\t\tvar toggle = alertsToggle();\n\t\t\t\t\tif (toggle) toggle.focus();\n\t\t\t\t}\n\t\t\t}\n\n\t\t\tfunction openOverlay() {\n\t\t\t\tif (!renderOverlay()) return;\n\t\t\t\topen = true;\n\t\t\t\tvar host = overlayHost();\n\t\t\t\tif (!host) return;\n\t\t\t\thost.hidden = false;\n\t\t\t\thost.classList.remove(\"hidden\");\n\t\t\t\thost.setAttribute(\"aria-hidden\", \"false\");\n\t\t\t\tsetToggleState(true);\n\t\t\t\tpositionOverlay();\n\t\t\t}\n\n\t\t\tfunction syncOverlayAfterMorph() {\n\t\t\t\tif (!open) {\n\t\t\t\t\tsetToggleState(false);\n\t\t\t\t\treturn;\n\t\t\t\t}\n\t\t\t\tif (!alertsBar()) {\n\t\t\t\t\tcloseOverlay(false);\n\t\t\t\t\treturn;\n\t\t\t\t}\n\t\t\t\tvar host = overlayHost();\n\t\t\t\tvar scrollTop = host ? host.scrollTop : 0;\n\t\t\t\tif (!renderOverlay()) {\n\t\t\t\t\tcloseOverlay(false);\n\t\t\t\t\treturn;\n\t\t\t\t}\n\t\t\t\thost = overlayHost();\n\t\t\t\tif (!host) return;\n\t\t\t\thost.hidden = false;\n\t\t\t\thost.classList.remove(\"hidden\");\n\t\t\t\thost.setAttribute(\"aria-hidden\", \"false\");\n\t\t\t\thost.scrollTop = scrollTop;\n\t\t\t\tsetToggleState(true);\n\t\t\t\tpositionOverlay();\n\t\t\t}\n\n\t\t\tfunction settledSnapshot(event) {\n\t\t\t\tvar detailTarget = event.detail && event.detail.target;\n\t\t\t\tvar target = detailTarget instanceof Element ? detailTarget : event.target;\n\t\t\t\tif (!(target instanceof Element)) return false;\n\t\t\t\treturn target.id === \"snapshot\" || Boolean(target.closest(\"#snapshot\"));\n\t\t\t}\n\n\t\t\tfunction dismissedWarningIDs(form) {\n\t\t\t\tvar ids = [];\n\t\t\t\tvar directID = form.dataset.stalenessWarningId || \"\";\n\t\t\t\tif (directID) ids.push(directID);\n\t\t\t\tform.querySelectorAll(\"input[name='warning_id']\").forEach(function (input) {\n\t\t\t\t\tif (input.value && !ids.includes(input.value)) ids.push(input.value);\n\t\t\t\t});\n\t\t\t\treturn ids;\n\t\t\t}\n\n\t\t\tfunction removeDismissedWarnings(root, projectID, warningIDs) {\n\t\t\t\tif (!root || typeof root.querySelectorAll !== \"function\") return;\n\t\t\t\troot.querySelectorAll(\"[data-board-alert='staleness-warning'][data-staleness-warning-id]\").forEach(function (warning) {\n\t\t\t\t\tif (warning.dataset.stalenessProjectId !== projectID) return;\n\t\t\t\t\tif (warningIDs.includes(warning.dataset.stalenessWarningId || \"\")) warning.remove();\n\t\t\t\t});\n\t\t\t}\n\n\t\t\tfunction syncBulkDismissals(root) {\n\t\t\t\tif (!root || typeof root.querySelectorAll !== \"function\") return;\n\t\t\t\troot.querySelectorAll(\"[data-staleness-dismiss-bulk]\").forEach(function (form) {\n\t\t\t\t\tvar projectID = form.dataset.stalenessProjectId || \"\";\n\t\t\t\t\tvar active = [];\n\t\t\t\t\troot.querySelectorAll(\"[data-board-alert='staleness-warning'][data-staleness-warning-id]\").forEach(function (warning) {\n\t\t\t\t\t\tif (warning.dataset.stalenessProjectId === projectID) active.push(warning.dataset.stalenessWarningId || \"\");\n\t\t\t\t\t});\n\t\t\t\t\tform.querySelectorAll(\"input[name='warning_id']\").forEach(function (input) {\n\t\t\t\t\t\tif (!active.includes(input.value)) input.remove();\n\t\t\t\t\t});\n\t\t\t\t\tif (active.length === 0) {\n\t\t\t\t\t\tform.remove();\n\t\t\t\t\t\treturn;\n\t\t\t\t\t}\n\t\t\t\t\tvar label = form.querySelector(\"[data-staleness-dismiss-label]\");\n\t\t\t\t\tif (label) label.textContent = label.textContent.replace(/\\(\\d+\\)$/, \"(\" + active.length + \")\");\n\t\t\t\t});\n\t\t\t}\n\n\t\t\tfunction warningCountLabel(count) {\n\t\t\t\treturn count + (count === 1 ? \" warning\" : \" warnings\");\n\t\t\t}\n\n\t\t\tfunction syncAlertCountRoot(root, count) {\n\t\t\t\tif (!root || typeof root.querySelectorAll !== \"function\") return;\n\t\t\t\troot.querySelectorAll(\"[data-board-alert-count-label]\").forEach(function (label) {\n\t\t\t\t\tlabel.textContent = warningCountLabel(count);\n\t\t\t\t});\n\t\t\t}\n\n\t\t\tfunction settleStalenessDismissal(form) {\n\t\t\t\tvar projectID = form.dataset.stalenessProjectId || \"\";\n\t\t\t\tvar warningIDs = dismissedWarningIDs(form);\n\t\t\t\tif (!projectID || warningIDs.length === 0) return;\n\t\t\t\tvar host = overlayHost();\n\t\t\t\tvar template = overlayTemplate();\n\t\t\t\tremoveDismissedWarnings(host, projectID, warningIDs);\n\t\t\t\tif (template instanceof HTMLTemplateElement) removeDismissedWarnings(template.content, projectID, warningIDs);\n\t\t\t\tsyncBulkDismissals(host);\n\t\t\t\tif (template instanceof HTMLTemplateElement) syncBulkDismissals(template.content);\n\t\t\t\tvar countRoot = template instanceof HTMLTemplateElement ? template.content : host;\n\t\t\t\tvar count = countRoot && typeof countRoot.querySelectorAll === \"function\" ? countRoot.querySelectorAll(\"[data-board-alert]\").length : 0;\n\t\t\t\tvar bar = alertsBar();\n\t\t\t\tif (!bar || count === 0) {\n\t\t\t\t\tif (bar) bar.remove();\n\t\t\t\t\tcloseOverlay(false);\n\t\t\t\t\treturn;\n\t\t\t\t}\n\t\t\t\tbar.dataset.boardAlertCount = String(count);\n\t\t\t\tsyncAlertCountRoot(bar, count);\n\t\t\t\tsyncAlertCountRoot(host, count);\n\t\t\t\tif (template instanceof HTMLTemplateElement) syncAlertCountRoot(template.content, count);\n\t\t\t\tvar overflow = bar.querySelector(\"[data-board-alert-overflow]\");\n\t\t\t\tif (overflow) {\n\t\t\t\t\toverflow.textContent = \"+\" + Math.max(0, count - 1);\n\t\t\t\t\toverflow.hidden = count <= 1;\n\t\t\t\t}\n\t\t\t\tvar toggle = alertsToggle();\n\t\t\t\tif (toggle) toggle.setAttribute(\"aria-label\", (toggle.getAttribute(\"aria-label\") || \"\").replace(/^\\d+ board warnings?/, count + (count === 1 ? \" board warning\" : \" board warnings\")));\n\t\t\t}\n\n\t\t\tdocument.addEventListener(\"click\", function (event) {\n\t\t\t\tvar target = event.target instanceof Element ? event.target : null;\n\t\t\t\tif (!target) return;\n\t\t\t\tif (target.closest(\"[data-board-alerts-close]\")) {\n\t\t\t\t\tcloseOverlay(true);\n\t\t\t\t\treturn;\n\t\t\t\t}\n\t\t\t\tif (!target.closest(\"[data-board-alerts-toggle]\")) return;\n\t\t\t\tif (open) {\n\t\t\t\t\tcloseOverlay(false);\n\t\t\t\t} else {\n\t\t\t\t\topenOverlay();\n\t\t\t\t}\n\t\t\t});\n\n\t\t\tdocument.addEventListener(\"keydown\", function (event) {\n\t\t\t\tif (event.key === \"Escape\" && open) closeOverlay(true);\n\t\t\t});\n\n\t\t\tdocument.addEventListener(\"htmx:afterSettle\", function (event) {\n\t\t\t\tif (settledSnapshot(event)) syncOverlayAfterMorph();\n\t\t\t});\n\n\t\t\tdocument.addEventListener(\"htmx:beforeSwap\", function (event) {\n\t\t\t\tvar requestElement = event.detail && event.detail.requestConfig && event.detail.requestConfig.elt;\n\t\t\t\tvar form = requestElement instanceof Element ? requestElement.closest(\"[data-staleness-dismiss-form]\") : null;\n\t\t\t\tif (!(form instanceof HTMLFormElement)) return;\n\t\t\t\tvar status = event.detail.xhr ? event.detail.xhr.status : 0;\n\t\t\t\tif (status < 200 || status >= 300) return;\n\t\t\t\tevent.detail.shouldSwap = false;\n\t\t\t\tsettleStalenessDismissal(form);\n\t\t\t});\n\n\t\t\twindow.addEventListener(\"resize\", requestOverlayPosition);\n\t\t})();\n\t</script>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -1124,139 +1283,139 @@ func boardLaneView2(lane boardLaneView) templ.Component {
 			}()
 		}
 		ctx = templ.InitializeContext(ctx)
-		templ_7745c5c3_Var49 := templ.GetChildren(ctx)
-		if templ_7745c5c3_Var49 == nil {
-			templ_7745c5c3_Var49 = templ.NopComponent
+		templ_7745c5c3_Var58 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var58 == nil {
+			templ_7745c5c3_Var58 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 91, "<section id=\"")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 108, "<section id=\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		var templ_7745c5c3_Var50 string
-		templ_7745c5c3_Var50, templ_7745c5c3_Err = templ.JoinStringErrs(lane.DomID)
+		var templ_7745c5c3_Var59 string
+		templ_7745c5c3_Var59, templ_7745c5c3_Err = templ.JoinStringErrs(lane.DomID)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 406, Col: 17}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 527, Col: 17}
 		}
-		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var50))
-		if templ_7745c5c3_Err != nil {
-			return templ_7745c5c3_Err
-		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 92, "\" class=\"flex w-full flex-none snap-start flex-col overflow-hidden rounded-card border border-line bg-surface data-[kanban-drop-allowed=false]:border-err/45 data-[kanban-drop-allowed=false]:opacity-70 data-[kanban-drop-allowed=false]:ring-2 data-[kanban-drop-allowed=false]:ring-inset data-[kanban-drop-allowed=false]:ring-err/20 data-[kanban-drop-allowed=true]:border-accent data-[kanban-drop-allowed=true]:ring-2 data-[kanban-drop-allowed=true]:ring-inset data-[kanban-drop-allowed=true]:ring-accent/30 data-[kanban-drop-source=true]:border-dashed data-[kanban-drop-source=true]:border-accent/50 data-[kanban-drop-source=true]:ring-2 data-[kanban-drop-source=true]:ring-inset data-[kanban-drop-source=true]:ring-accent/20 data-[lane-hidden=true]:hidden md:min-w-44 md:max-w-80 md:flex-1 md:snap-none md:data-[kanban-drop-allowed=false]:ring-0 md:data-[kanban-drop-allowed=true]:ring-0 md:data-[kanban-drop-source=true]:ring-0\" data-board-lane=\"")
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var59))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		var templ_7745c5c3_Var51 string
-		templ_7745c5c3_Var51, templ_7745c5c3_Err = templ.JoinStringErrs(lane.LaneID)
-		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 408, Col: 31}
-		}
-		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var51))
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 109, "\" class=\"flex w-full flex-none snap-start flex-col overflow-hidden rounded-card border border-line bg-surface data-[kanban-drop-allowed=false]:border-err/45 data-[kanban-drop-allowed=false]:opacity-70 data-[kanban-drop-allowed=false]:ring-2 data-[kanban-drop-allowed=false]:ring-inset data-[kanban-drop-allowed=false]:ring-err/20 data-[kanban-drop-allowed=true]:border-accent data-[kanban-drop-allowed=true]:ring-2 data-[kanban-drop-allowed=true]:ring-inset data-[kanban-drop-allowed=true]:ring-accent/30 data-[kanban-drop-source=true]:border-dashed data-[kanban-drop-source=true]:border-accent/50 data-[kanban-drop-source=true]:ring-2 data-[kanban-drop-source=true]:ring-inset data-[kanban-drop-source=true]:ring-accent/20 data-[lane-hidden=true]:hidden md:min-w-44 md:max-w-80 md:flex-1 md:snap-none md:data-[kanban-drop-allowed=false]:ring-0 md:data-[kanban-drop-allowed=true]:ring-0 md:data-[kanban-drop-source=true]:ring-0\" data-board-lane=\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 93, "\" data-board-lane-title=\"")
+		var templ_7745c5c3_Var60 string
+		templ_7745c5c3_Var60, templ_7745c5c3_Err = templ.JoinStringErrs(lane.LaneID)
+		if templ_7745c5c3_Err != nil {
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 529, Col: 31}
+		}
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var60))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		var templ_7745c5c3_Var52 string
-		templ_7745c5c3_Var52, templ_7745c5c3_Err = templ.JoinStringErrs(lane.Title)
-		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 409, Col: 36}
-		}
-		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var52))
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 110, "\" data-board-lane-title=\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 94, "\" data-board-lane-default=\"")
+		var templ_7745c5c3_Var61 string
+		templ_7745c5c3_Var61, templ_7745c5c3_Err = templ.JoinStringErrs(lane.Title)
+		if templ_7745c5c3_Err != nil {
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 530, Col: 36}
+		}
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var61))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		var templ_7745c5c3_Var53 string
-		templ_7745c5c3_Var53, templ_7745c5c3_Err = templ.JoinStringErrs(boardBoolAttr(lane.DefaultVisible))
-		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 410, Col: 62}
-		}
-		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var53))
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 111, "\" data-board-lane-default=\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 95, "\" data-board-lane-card-count=\"")
+		var templ_7745c5c3_Var62 string
+		templ_7745c5c3_Var62, templ_7745c5c3_Err = templ.JoinStringErrs(boardBoolAttr(lane.DefaultVisible))
+		if templ_7745c5c3_Err != nil {
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 531, Col: 62}
+		}
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var62))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		var templ_7745c5c3_Var54 string
-		templ_7745c5c3_Var54, templ_7745c5c3_Err = templ.JoinStringErrs(strconv.Itoa(lane.CardCount))
-		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 411, Col: 59}
-		}
-		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var54))
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 112, "\" data-board-lane-card-count=\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 96, "\" data-board-lane-visibility-state=\"")
+		var templ_7745c5c3_Var63 string
+		templ_7745c5c3_Var63, templ_7745c5c3_Err = templ.JoinStringErrs(strconv.Itoa(lane.CardCount))
+		if templ_7745c5c3_Err != nil {
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 532, Col: 59}
+		}
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var63))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		var templ_7745c5c3_Var55 string
-		templ_7745c5c3_Var55, templ_7745c5c3_Err = templ.JoinStringErrs(string(boardLaneVisibilityAuto))
-		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 412, Col: 68}
-		}
-		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var55))
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 113, "\" data-board-lane-visibility-state=\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 97, "\" data-board-lane-pinned=\"false\" data-lane-hidden=\"")
+		var templ_7745c5c3_Var64 string
+		templ_7745c5c3_Var64, templ_7745c5c3_Err = templ.JoinStringErrs(string(boardLaneVisibilityAuto))
+		if templ_7745c5c3_Err != nil {
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 533, Col: 68}
+		}
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var64))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		var templ_7745c5c3_Var56 string
-		templ_7745c5c3_Var56, templ_7745c5c3_Err = templ.JoinStringErrs(boardBoolAttr(!lane.DefaultVisible))
-		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 414, Col: 56}
-		}
-		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var56))
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 114, "\" data-board-lane-pinned=\"false\" data-lane-hidden=\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 98, "\"")
+		var templ_7745c5c3_Var65 string
+		templ_7745c5c3_Var65, templ_7745c5c3_Err = templ.JoinStringErrs(boardBoolAttr(!lane.DefaultVisible))
+		if templ_7745c5c3_Err != nil {
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 535, Col: 56}
+		}
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var65))
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 115, "\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		if lane.DropState != "" {
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 99, " data-kanban-drop-state=\"")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 116, " data-kanban-drop-state=\"")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			var templ_7745c5c3_Var57 string
-			templ_7745c5c3_Var57, templ_7745c5c3_Err = templ.JoinStringErrs(lane.DropState)
+			var templ_7745c5c3_Var66 string
+			templ_7745c5c3_Var66, templ_7745c5c3_Err = templ.JoinStringErrs(lane.DropState)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 416, Col: 42}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 537, Col: 42}
 			}
-			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var57))
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 100, "\" data-kanban-drop-key=\"")
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var66))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			var templ_7745c5c3_Var58 string
-			templ_7745c5c3_Var58, templ_7745c5c3_Err = templ.JoinStringErrs(lane.DropKey)
-			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 417, Col: 38}
-			}
-			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var58))
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 117, "\" data-kanban-drop-key=\"")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 101, "\"")
+			var templ_7745c5c3_Var67 string
+			templ_7745c5c3_Var67, templ_7745c5c3_Err = templ.JoinStringErrs(lane.DropKey)
+			if templ_7745c5c3_Err != nil {
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 538, Col: 38}
+			}
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var67))
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 118, "\"")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 102, "><header class=\"flex flex-none items-center gap-1.5 border-b border-line px-3 py-2\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 119, "><header class=\"flex flex-none items-center gap-1.5 border-b border-line px-3 py-2\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -1266,51 +1425,51 @@ func boardLaneView2(lane boardLaneView) templ.Component {
 				return templ_7745c5c3_Err
 			}
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 103, "<h2 class=\"text-xs font-semibold text-text\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 120, "<h2 class=\"text-xs font-semibold text-text\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		var templ_7745c5c3_Var59 string
-		templ_7745c5c3_Var59, templ_7745c5c3_Err = templ.JoinStringErrs(lane.Title)
+		var templ_7745c5c3_Var68 string
+		templ_7745c5c3_Var68, templ_7745c5c3_Err = templ.JoinStringErrs(lane.Title)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 424, Col: 59}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 545, Col: 59}
 		}
-		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var59))
-		if templ_7745c5c3_Err != nil {
-			return templ_7745c5c3_Err
-		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 104, "</h2><span class=\"font-mono text-2xs font-medium text-sec tabular-nums\">")
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var68))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		var templ_7745c5c3_Var60 string
-		templ_7745c5c3_Var60, templ_7745c5c3_Err = templ.JoinStringErrs(lane.Count)
-		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 425, Col: 82}
-		}
-		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var60))
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 121, "</h2><span class=\"font-mono text-2xs font-medium text-sec tabular-nums\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 105, "</span></header><div class=\"dt-lane-scroll flex min-h-0 flex-1 flex-col gap-2 overflow-y-auto overflow-x-hidden p-2\" data-preserve-scroll=\"")
+		var templ_7745c5c3_Var69 string
+		templ_7745c5c3_Var69, templ_7745c5c3_Err = templ.JoinStringErrs(lane.Count)
+		if templ_7745c5c3_Err != nil {
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 546, Col: 82}
+		}
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var69))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		var templ_7745c5c3_Var61 string
-		templ_7745c5c3_Var61, templ_7745c5c3_Err = templ.JoinStringErrs(lane.DomID + "-scroll")
-		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 427, Col: 148}
-		}
-		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var61))
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 122, "</span></header><div class=\"dt-lane-scroll flex min-h-0 flex-1 flex-col gap-2 overflow-y-auto overflow-x-hidden p-2\" data-preserve-scroll=\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 106, "\" data-kanban-card-container>")
+		var templ_7745c5c3_Var70 string
+		templ_7745c5c3_Var70, templ_7745c5c3_Err = templ.JoinStringErrs(lane.DomID + "-scroll")
+		if templ_7745c5c3_Err != nil {
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 548, Col: 148}
+		}
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var70))
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 123, "\" data-kanban-card-container>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		if len(lane.Cards) == 0 {
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 107, "<div class=\"contents\" data-kanban-empty-line>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 124, "<div class=\"contents\" data-kanban-empty-line>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -1318,7 +1477,7 @@ func boardLaneView2(lane boardLaneView) templ.Component {
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 108, "</div>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 125, "</div>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -1329,7 +1488,7 @@ func boardLaneView2(lane boardLaneView) templ.Component {
 				return templ_7745c5c3_Err
 			}
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 109, "</div></section>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 126, "</div></section>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -1353,43 +1512,43 @@ func boardCardView2(card boardCardView) templ.Component {
 			}()
 		}
 		ctx = templ.InitializeContext(ctx)
-		templ_7745c5c3_Var62 := templ.GetChildren(ctx)
-		if templ_7745c5c3_Var62 == nil {
-			templ_7745c5c3_Var62 = templ.NopComponent
+		templ_7745c5c3_Var71 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var71 == nil {
+			templ_7745c5c3_Var71 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		var templ_7745c5c3_Var63 = []any{boardCardClass(card) + boardCardInteractionClass(card)}
-		templ_7745c5c3_Err = templ.RenderCSSItems(ctx, templ_7745c5c3_Buffer, templ_7745c5c3_Var63...)
+		var templ_7745c5c3_Var72 = []any{boardCardClass(card) + boardCardInteractionClass(card)}
+		templ_7745c5c3_Err = templ.RenderCSSItems(ctx, templ_7745c5c3_Buffer, templ_7745c5c3_Var72...)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 110, "<article id=\"")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 127, "<article id=\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		var templ_7745c5c3_Var64 string
-		templ_7745c5c3_Var64, templ_7745c5c3_Err = templ.JoinStringErrs(card.DomID)
+		var templ_7745c5c3_Var73 string
+		templ_7745c5c3_Var73, templ_7745c5c3_Err = templ.JoinStringErrs(card.DomID)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 442, Col: 17}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 563, Col: 17}
 		}
-		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var64))
-		if templ_7745c5c3_Err != nil {
-			return templ_7745c5c3_Err
-		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 111, "\" class=\"")
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var73))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		var templ_7745c5c3_Var65 string
-		templ_7745c5c3_Var65, templ_7745c5c3_Err = templ.JoinStringErrs(templ.CSSClasses(templ_7745c5c3_Var63).String())
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 128, "\" class=\"")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		var templ_7745c5c3_Var74 string
+		templ_7745c5c3_Var74, templ_7745c5c3_Err = templ.JoinStringErrs(templ.CSSClasses(templ_7745c5c3_Var72).String())
 		if templ_7745c5c3_Err != nil {
 			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 1, Col: 0}
 		}
-		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var65))
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var74))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 112, "\" role=\"button\" tabindex=\"0\"")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 129, "\" role=\"button\" tabindex=\"0\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -1397,155 +1556,155 @@ func boardCardView2(card boardCardView) templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 113, " data-detail-sheet-project=\"")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 130, " data-detail-sheet-project=\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		var templ_7745c5c3_Var66 string
-		templ_7745c5c3_Var66, templ_7745c5c3_Err = templ.JoinStringErrs(card.Project)
+		var templ_7745c5c3_Var75 string
+		templ_7745c5c3_Var75, templ_7745c5c3_Err = templ.JoinStringErrs(card.Project)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 447, Col: 42}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 568, Col: 42}
 		}
-		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var66))
-		if templ_7745c5c3_Err != nil {
-			return templ_7745c5c3_Err
-		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 114, "\" data-detail-sheet-reference=\"")
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var75))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		var templ_7745c5c3_Var67 string
-		templ_7745c5c3_Var67, templ_7745c5c3_Err = templ.JoinStringErrs(card.Number)
-		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 448, Col: 43}
-		}
-		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var67))
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 131, "\" data-detail-sheet-reference=\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 115, "\"")
+		var templ_7745c5c3_Var76 string
+		templ_7745c5c3_Var76, templ_7745c5c3_Err = templ.JoinStringErrs(card.Number)
+		if templ_7745c5c3_Err != nil {
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 569, Col: 43}
+		}
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var76))
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 132, "\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		if card.MoveDisabledText != "" {
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 116, " title=\"")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 133, " title=\"")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			var templ_7745c5c3_Var68 string
-			templ_7745c5c3_Var68, templ_7745c5c3_Err = templ.JoinStringErrs(card.MoveDisabledText)
+			var templ_7745c5c3_Var77 string
+			templ_7745c5c3_Var77, templ_7745c5c3_Err = templ.JoinStringErrs(card.MoveDisabledText)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 450, Col: 32}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 571, Col: 32}
 			}
-			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var68))
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var77))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 117, "\"")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 134, "\"")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 		}
 		if card.DragDrop {
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 118, " data-kanban-card data-kanban-current-state=\"")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 135, " data-kanban-card data-kanban-current-state=\"")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			var templ_7745c5c3_Var69 string
-			templ_7745c5c3_Var69, templ_7745c5c3_Err = templ.JoinStringErrs(card.CurrentState)
+			var templ_7745c5c3_Var78 string
+			templ_7745c5c3_Var78, templ_7745c5c3_Err = templ.JoinStringErrs(card.CurrentState)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 454, Col: 48}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 575, Col: 48}
 			}
-			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var69))
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var78))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 119, "\"")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 136, "\"")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			if card.DataSeq > 0 {
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 120, " data-kanban-data-seq=\"")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 137, " data-kanban-data-seq=\"")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				var templ_7745c5c3_Var70 string
-				templ_7745c5c3_Var70, templ_7745c5c3_Err = templ.JoinStringErrs(strconv.FormatUint(card.DataSeq, 10))
+				var templ_7745c5c3_Var79 string
+				templ_7745c5c3_Var79, templ_7745c5c3_Err = templ.JoinStringErrs(strconv.FormatUint(card.DataSeq, 10))
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 456, Col: 63}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 577, Col: 63}
 				}
-				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var70))
+				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var79))
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 121, "\"")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 138, "\"")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
 			}
 			if card.IssueID != "" {
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 122, " data-kanban-issue-id=\"")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 139, " data-kanban-issue-id=\"")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				var templ_7745c5c3_Var71 string
-				templ_7745c5c3_Var71, templ_7745c5c3_Err = templ.JoinStringErrs(card.IssueID)
+				var templ_7745c5c3_Var80 string
+				templ_7745c5c3_Var80, templ_7745c5c3_Err = templ.JoinStringErrs(card.IssueID)
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 459, Col: 39}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 580, Col: 39}
 				}
-				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var71))
+				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var80))
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 123, "\"")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 140, "\"")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
 			}
 			if card.CanDrag {
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 124, " data-kanban-action=\"move\" data-kanban-allowed-targets=\"")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 141, " data-kanban-action=\"move\" data-kanban-allowed-targets=\"")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				var templ_7745c5c3_Var72 string
-				templ_7745c5c3_Var72, templ_7745c5c3_Err = templ.JoinStringErrs(card.AllowedTargets)
+				var templ_7745c5c3_Var81 string
+				templ_7745c5c3_Var81, templ_7745c5c3_Err = templ.JoinStringErrs(card.AllowedTargets)
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 463, Col: 53}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 584, Col: 53}
 				}
-				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var72))
+				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var81))
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 125, "\"")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 142, "\"")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 126, " else")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 143, " else")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			if card.MoveDisabledText != "" {
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 127, " data-kanban-move-disabled=\"true\" data-kanban-move-disabled-reason=\"")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 144, " data-kanban-move-disabled=\"true\" data-kanban-move-disabled-reason=\"")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				var templ_7745c5c3_Var73 string
-				templ_7745c5c3_Var73, templ_7745c5c3_Err = templ.JoinStringErrs(card.MoveDisabledText)
+				var templ_7745c5c3_Var82 string
+				templ_7745c5c3_Var82, templ_7745c5c3_Err = templ.JoinStringErrs(card.MoveDisabledText)
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 468, Col: 60}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 589, Col: 60}
 				}
-				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var73))
+				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var82))
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 128, "\"")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 145, "\"")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
 			}
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 129, "><div class=\"flex min-w-0 items-center gap-0.5 font-mono text-2xs font-medium text-sec\" data-board-card-content=\"cozy\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 146, "><div class=\"flex min-w-0 items-center gap-0.5 font-mono text-2xs font-medium text-sec\" data-board-card-content=\"cozy\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -1559,247 +1718,134 @@ func boardCardView2(card boardCardView) templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 130, "<span class=\"min-w-0 truncate\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 147, "<span class=\"min-w-0 truncate\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		var templ_7745c5c3_Var74 string
-		templ_7745c5c3_Var74, templ_7745c5c3_Err = templ.JoinStringErrs(card.Project)
+		var templ_7745c5c3_Var83 string
+		templ_7745c5c3_Var83, templ_7745c5c3_Err = templ.JoinStringErrs(card.Project)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 477, Col: 48}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 598, Col: 48}
 		}
-		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var74))
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var83))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 131, "</span> ")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 148, "</span> ")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		if card.PriorityBadge != "" {
-			var templ_7745c5c3_Var75 = []any{boardPriorityBadgeClass(card)}
-			templ_7745c5c3_Err = templ.RenderCSSItems(ctx, templ_7745c5c3_Buffer, templ_7745c5c3_Var75...)
+			var templ_7745c5c3_Var84 = []any{boardPriorityBadgeClass(card)}
+			templ_7745c5c3_Err = templ.RenderCSSItems(ctx, templ_7745c5c3_Buffer, templ_7745c5c3_Var84...)
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 132, "<span id=\"")
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
-			var templ_7745c5c3_Var76 string
-			templ_7745c5c3_Var76, templ_7745c5c3_Err = templ.JoinStringErrs(card.DomID + "-priority")
-			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 480, Col: 34}
-			}
-			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var76))
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 133, "\" class=\"")
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
-			var templ_7745c5c3_Var77 string
-			templ_7745c5c3_Var77, templ_7745c5c3_Err = templ.JoinStringErrs(templ.CSSClasses(templ_7745c5c3_Var75).String())
-			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 1, Col: 0}
-			}
-			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var77))
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 134, "\" tabindex=\"0\" role=\"img\" aria-label=\"")
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
-			var templ_7745c5c3_Var78 string
-			templ_7745c5c3_Var78, templ_7745c5c3_Err = templ.JoinStringErrs("Priority: " + card.PriorityBadge)
-			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 484, Col: 51}
-			}
-			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var78))
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 135, "\" data-board-priority data-board-priority-top=\"")
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
-			var templ_7745c5c3_Var79 string
-			templ_7745c5c3_Var79, templ_7745c5c3_Err = templ.JoinStringErrs(boardBoolAttr(card.PriorityTop))
-			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 486, Col: 62}
-			}
-			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var79))
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 136, "\" data-help-trigger data-help-scope=\"dispatch-priority\" data-help-term=\"")
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
-			var templ_7745c5c3_Var80 string
-			templ_7745c5c3_Var80, templ_7745c5c3_Err = templ.JoinStringErrs(card.DomID + "-priority")
-			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 489, Col: 46}
-			}
-			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var80))
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 137, "\" data-help-title=\"")
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
-			var templ_7745c5c3_Var81 string
-			templ_7745c5c3_Var81, templ_7745c5c3_Err = templ.JoinStringErrs(card.PriorityTitle)
-			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 490, Col: 41}
-			}
-			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var81))
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 138, "\" data-help-description=\"")
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
-			var templ_7745c5c3_Var82 string
-			templ_7745c5c3_Var82, templ_7745c5c3_Err = templ.JoinStringErrs(card.PriorityDetail)
-			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 491, Col: 48}
-			}
-			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var82))
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 139, "\" onclick=\"event.stopPropagation()\"><span class=\"min-w-0 truncate\">")
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
-			var templ_7745c5c3_Var83 string
-			templ_7745c5c3_Var83, templ_7745c5c3_Err = templ.JoinStringErrs(card.PriorityBadge)
-			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 493, Col: 56}
-			}
-			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var83))
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 140, "</span></span> ")
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
-		}
-		if card.MetaRight != "" {
-			templ_7745c5c3_Err = primitives.TrackerReferenceLinkIsolated(card.MetaRight, card.PRURL, "ml-auto flex-none whitespace-nowrap tabular-nums").Render(ctx, templ_7745c5c3_Buffer)
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
-		} else if card.MoveDisabledText != "" {
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 141, "<span class=\"ml-auto flex-none rounded-chip border border-line px-1.5 py-0.5 text-2xs text-dim\" title=\"")
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
-			var templ_7745c5c3_Var84 string
-			templ_7745c5c3_Var84, templ_7745c5c3_Err = templ.JoinStringErrs(card.MoveDisabledText)
-			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 498, Col: 129}
-			}
-			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var84))
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 142, "\" data-kanban-move-disabled-label>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 149, "<span id=\"")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var85 string
-			templ_7745c5c3_Var85, templ_7745c5c3_Err = templ.JoinStringErrs(card.MoveDisabledLabel)
+			templ_7745c5c3_Var85, templ_7745c5c3_Err = templ.JoinStringErrs(card.DomID + "-priority")
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 498, Col: 188}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 601, Col: 34}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var85))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 143, "</span>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 150, "\" class=\"")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-		} else if card.Done {
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 144, "<span class=\"ml-auto text-ok\" role=\"img\" aria-label=\"done\">✓</span>")
+			var templ_7745c5c3_Var86 string
+			templ_7745c5c3_Var86, templ_7745c5c3_Err = templ.JoinStringErrs(templ.CSSClasses(templ_7745c5c3_Var84).String())
+			if templ_7745c5c3_Err != nil {
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 1, Col: 0}
+			}
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var86))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 145, "</div>")
-		if templ_7745c5c3_Err != nil {
-			return templ_7745c5c3_Err
-		}
-		var templ_7745c5c3_Var86 = []any{boardCardTitleClass(card)}
-		templ_7745c5c3_Err = templ.RenderCSSItems(ctx, templ_7745c5c3_Buffer, templ_7745c5c3_Var86...)
-		if templ_7745c5c3_Err != nil {
-			return templ_7745c5c3_Err
-		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 146, "<div class=\"")
-		if templ_7745c5c3_Err != nil {
-			return templ_7745c5c3_Err
-		}
-		var templ_7745c5c3_Var87 string
-		templ_7745c5c3_Var87, templ_7745c5c3_Err = templ.JoinStringErrs(templ.CSSClasses(templ_7745c5c3_Var86).String())
-		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 1, Col: 0}
-		}
-		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var87))
-		if templ_7745c5c3_Err != nil {
-			return templ_7745c5c3_Err
-		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 147, "\" data-board-card-title>")
-		if templ_7745c5c3_Err != nil {
-			return templ_7745c5c3_Err
-		}
-		var templ_7745c5c3_Var88 string
-		templ_7745c5c3_Var88, templ_7745c5c3_Err = templ.JoinStringErrs(card.Title)
-		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 503, Col: 77}
-		}
-		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var88))
-		if templ_7745c5c3_Err != nil {
-			return templ_7745c5c3_Err
-		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 148, "</div><div class=\"min-w-0 items-center gap-1.5 font-mono text-2xs text-sec\" data-board-card-content=\"compact\"><span class=\"flex-none font-medium text-text\" data-board-card-state>")
-		if templ_7745c5c3_Err != nil {
-			return templ_7745c5c3_Err
-		}
-		var templ_7745c5c3_Var89 string
-		templ_7745c5c3_Var89, templ_7745c5c3_Err = templ.JoinStringErrs(card.State)
-		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 505, Col: 83}
-		}
-		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var89))
-		if templ_7745c5c3_Err != nil {
-			return templ_7745c5c3_Err
-		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 149, "</span> ")
-		if templ_7745c5c3_Err != nil {
-			return templ_7745c5c3_Err
-		}
-		if card.CompactSignal != "" {
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 150, "<span aria-hidden=\"true\">·</span> <span class=\"min-w-0 truncate\">")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 151, "\" tabindex=\"0\" role=\"img\" aria-label=\"")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			var templ_7745c5c3_Var87 string
+			templ_7745c5c3_Var87, templ_7745c5c3_Err = templ.JoinStringErrs("Priority: " + card.PriorityBadge)
+			if templ_7745c5c3_Err != nil {
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 605, Col: 51}
+			}
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var87))
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 152, "\" data-board-priority data-board-priority-top=\"")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			var templ_7745c5c3_Var88 string
+			templ_7745c5c3_Var88, templ_7745c5c3_Err = templ.JoinStringErrs(boardBoolAttr(card.PriorityTop))
+			if templ_7745c5c3_Err != nil {
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 607, Col: 62}
+			}
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var88))
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 153, "\" data-help-trigger data-help-scope=\"dispatch-priority\" data-help-term=\"")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			var templ_7745c5c3_Var89 string
+			templ_7745c5c3_Var89, templ_7745c5c3_Err = templ.JoinStringErrs(card.DomID + "-priority")
+			if templ_7745c5c3_Err != nil {
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 610, Col: 46}
+			}
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var89))
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 154, "\" data-help-title=\"")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var90 string
-			templ_7745c5c3_Var90, templ_7745c5c3_Err = templ.JoinStringErrs(card.CompactSignal)
+			templ_7745c5c3_Var90, templ_7745c5c3_Err = templ.JoinStringErrs(card.PriorityTitle)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 508, Col: 55}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 611, Col: 41}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var90))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 151, "</span> ")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 155, "\" data-help-description=\"")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			var templ_7745c5c3_Var91 string
+			templ_7745c5c3_Var91, templ_7745c5c3_Err = templ.JoinStringErrs(card.PriorityDetail)
+			if templ_7745c5c3_Err != nil {
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 612, Col: 48}
+			}
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var91))
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 156, "\" onclick=\"event.stopPropagation()\"><span class=\"min-w-0 truncate\">")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			var templ_7745c5c3_Var92 string
+			templ_7745c5c3_Var92, templ_7745c5c3_Err = templ.JoinStringErrs(card.PriorityBadge)
+			if templ_7745c5c3_Err != nil {
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 614, Col: 56}
+			}
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var92))
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 157, "</span></span> ")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -1810,69 +1856,182 @@ func boardCardView2(card boardCardView) templ.Component {
 				return templ_7745c5c3_Err
 			}
 		} else if card.MoveDisabledText != "" {
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 152, "<span class=\"ml-auto flex-none rounded-chip border border-line px-1.5 py-0.5 text-2xs text-dim\" title=\"")
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
-			var templ_7745c5c3_Var91 string
-			templ_7745c5c3_Var91, templ_7745c5c3_Err = templ.JoinStringErrs(card.MoveDisabledText)
-			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 513, Col: 129}
-			}
-			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var91))
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 153, "\" data-kanban-move-disabled-label>")
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
-			var templ_7745c5c3_Var92 string
-			templ_7745c5c3_Var92, templ_7745c5c3_Err = templ.JoinStringErrs(card.MoveDisabledLabel)
-			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 513, Col: 188}
-			}
-			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var92))
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 154, "</span>")
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
-		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 155, "</div>")
-		if templ_7745c5c3_Err != nil {
-			return templ_7745c5c3_Err
-		}
-		if card.MetaRight != "" && card.MoveDisabledText != "" {
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 156, "<div class=\"flex\" data-board-card-expanded><span class=\"flex-none rounded-chip border border-line px-1.5 py-0.5 text-2xs text-dim\" title=\"")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 158, "<span class=\"ml-auto flex-none rounded-chip border border-line px-1.5 py-0.5 text-2xs text-dim\" title=\"")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var93 string
 			templ_7745c5c3_Var93, templ_7745c5c3_Err = templ.JoinStringErrs(card.MoveDisabledText)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 518, Col: 121}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 619, Col: 129}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var93))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 157, "\" data-kanban-move-disabled-label>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 159, "\" data-kanban-move-disabled-label>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var94 string
 			templ_7745c5c3_Var94, templ_7745c5c3_Err = templ.JoinStringErrs(card.MoveDisabledLabel)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 518, Col: 180}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 619, Col: 188}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var94))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 158, "</span></div>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 160, "</span>")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+		} else if card.Done {
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 161, "<span class=\"ml-auto text-ok\" role=\"img\" aria-label=\"done\">✓</span>")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 162, "</div>")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		var templ_7745c5c3_Var95 = []any{boardCardTitleClass(card)}
+		templ_7745c5c3_Err = templ.RenderCSSItems(ctx, templ_7745c5c3_Buffer, templ_7745c5c3_Var95...)
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 163, "<div class=\"")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		var templ_7745c5c3_Var96 string
+		templ_7745c5c3_Var96, templ_7745c5c3_Err = templ.JoinStringErrs(templ.CSSClasses(templ_7745c5c3_Var95).String())
+		if templ_7745c5c3_Err != nil {
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 1, Col: 0}
+		}
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var96))
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 164, "\" data-board-card-title>")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		var templ_7745c5c3_Var97 string
+		templ_7745c5c3_Var97, templ_7745c5c3_Err = templ.JoinStringErrs(card.Title)
+		if templ_7745c5c3_Err != nil {
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 624, Col: 77}
+		}
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var97))
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 165, "</div><div class=\"min-w-0 items-center gap-1.5 font-mono text-2xs text-sec\" data-board-card-content=\"compact\"><span class=\"flex-none font-medium text-text\" data-board-card-state>")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		var templ_7745c5c3_Var98 string
+		templ_7745c5c3_Var98, templ_7745c5c3_Err = templ.JoinStringErrs(card.State)
+		if templ_7745c5c3_Err != nil {
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 626, Col: 83}
+		}
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var98))
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 166, "</span> ")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		if card.CompactSignal != "" {
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 167, "<span aria-hidden=\"true\">·</span> <span class=\"min-w-0 truncate\">")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			var templ_7745c5c3_Var99 string
+			templ_7745c5c3_Var99, templ_7745c5c3_Err = templ.JoinStringErrs(card.CompactSignal)
+			if templ_7745c5c3_Err != nil {
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 629, Col: 55}
+			}
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var99))
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 168, "</span> ")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+		}
+		if card.MetaRight != "" {
+			templ_7745c5c3_Err = primitives.TrackerReferenceLinkIsolated(card.MetaRight, card.PRURL, "ml-auto flex-none whitespace-nowrap tabular-nums").Render(ctx, templ_7745c5c3_Buffer)
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+		} else if card.MoveDisabledText != "" {
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 169, "<span class=\"ml-auto flex-none rounded-chip border border-line px-1.5 py-0.5 text-2xs text-dim\" title=\"")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			var templ_7745c5c3_Var100 string
+			templ_7745c5c3_Var100, templ_7745c5c3_Err = templ.JoinStringErrs(card.MoveDisabledText)
+			if templ_7745c5c3_Err != nil {
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 634, Col: 129}
+			}
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var100))
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 170, "\" data-kanban-move-disabled-label>")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			var templ_7745c5c3_Var101 string
+			templ_7745c5c3_Var101, templ_7745c5c3_Err = templ.JoinStringErrs(card.MoveDisabledLabel)
+			if templ_7745c5c3_Err != nil {
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 634, Col: 188}
+			}
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var101))
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 171, "</span>")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 172, "</div>")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		if card.MetaRight != "" && card.MoveDisabledText != "" {
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 173, "<div class=\"flex\" data-board-card-expanded><span class=\"flex-none rounded-chip border border-line px-1.5 py-0.5 text-2xs text-dim\" title=\"")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			var templ_7745c5c3_Var102 string
+			templ_7745c5c3_Var102, templ_7745c5c3_Err = templ.JoinStringErrs(card.MoveDisabledText)
+			if templ_7745c5c3_Err != nil {
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 639, Col: 121}
+			}
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var102))
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 174, "\" data-kanban-move-disabled-label>")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			var templ_7745c5c3_Var103 string
+			templ_7745c5c3_Var103, templ_7745c5c3_Err = templ.JoinStringErrs(card.MoveDisabledLabel)
+			if templ_7745c5c3_Err != nil {
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 639, Col: 180}
+			}
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var103))
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 175, "</span></div>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -1884,38 +2043,38 @@ func boardCardView2(card boardCardView) templ.Component {
 			}
 		}
 		if card.MergeLaneStatus != "" {
-			var templ_7745c5c3_Var95 = []any{"flex items-center gap-1.5 text-2xs " + boardExtraTextClass(card.MergeLaneKind)}
-			templ_7745c5c3_Err = templ.RenderCSSItems(ctx, templ_7745c5c3_Buffer, templ_7745c5c3_Var95...)
+			var templ_7745c5c3_Var104 = []any{"flex items-center gap-1.5 text-2xs " + boardExtraTextClass(card.MergeLaneKind)}
+			templ_7745c5c3_Err = templ.RenderCSSItems(ctx, templ_7745c5c3_Buffer, templ_7745c5c3_Var104...)
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 159, "<div class=\"")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 176, "<div class=\"")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			var templ_7745c5c3_Var96 string
-			templ_7745c5c3_Var96, templ_7745c5c3_Err = templ.JoinStringErrs(templ.CSSClasses(templ_7745c5c3_Var95).String())
+			var templ_7745c5c3_Var105 string
+			templ_7745c5c3_Var105, templ_7745c5c3_Err = templ.JoinStringErrs(templ.CSSClasses(templ_7745c5c3_Var104).String())
 			if templ_7745c5c3_Err != nil {
 				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 1, Col: 0}
 			}
-			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var96))
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var105))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 160, "\" data-board-card-merge-lane data-board-card-expanded title=\"")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 177, "\" data-board-card-merge-lane data-board-card-expanded title=\"")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			var templ_7745c5c3_Var97 string
-			templ_7745c5c3_Var97, templ_7745c5c3_Err = templ.JoinStringErrs(card.MergeLaneDetail)
+			var templ_7745c5c3_Var106 string
+			templ_7745c5c3_Var106, templ_7745c5c3_Err = templ.JoinStringErrs(card.MergeLaneDetail)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 525, Col: 178}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 646, Col: 178}
 			}
-			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var97))
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var106))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 161, "\">")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 178, "\">")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -1923,39 +2082,39 @@ func boardCardView2(card boardCardView) templ.Component {
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 162, "<span class=\"font-medium\">")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 179, "<span class=\"font-medium\">")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			var templ_7745c5c3_Var98 string
-			templ_7745c5c3_Var98, templ_7745c5c3_Err = templ.JoinStringErrs(card.MergeLaneStatus)
+			var templ_7745c5c3_Var107 string
+			templ_7745c5c3_Var107, templ_7745c5c3_Err = templ.JoinStringErrs(card.MergeLaneStatus)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 527, Col: 52}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 648, Col: 52}
 			}
-			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var98))
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 163, "</span> <span class=\"min-w-0 truncate font-mono\">")
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var107))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			var templ_7745c5c3_Var99 string
-			templ_7745c5c3_Var99, templ_7745c5c3_Err = templ.JoinStringErrs(card.MergeLaneDetail)
-			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 528, Col: 67}
-			}
-			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var99))
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 180, "</span> <span class=\"min-w-0 truncate font-mono\">")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 164, "</span></div>")
+			var templ_7745c5c3_Var108 string
+			templ_7745c5c3_Var108, templ_7745c5c3_Err = templ.JoinStringErrs(card.MergeLaneDetail)
+			if templ_7745c5c3_Err != nil {
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 649, Col: 67}
+			}
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var108))
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 181, "</span></div>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 		}
 		if card.OriginDetail != "" {
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 165, "<div class=\"flex items-center gap-1.5 text-2xs text-info\" data-board-card-origin data-board-card-expanded>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 182, "<div class=\"flex items-center gap-1.5 text-2xs text-info\" data-board-card-origin data-board-card-expanded>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -1963,27 +2122,27 @@ func boardCardView2(card boardCardView) templ.Component {
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 166, "<span class=\"min-w-0 truncate font-mono\">")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 183, "<span class=\"min-w-0 truncate font-mono\">")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			var templ_7745c5c3_Var100 string
-			templ_7745c5c3_Var100, templ_7745c5c3_Err = templ.JoinStringErrs(card.OriginDetail)
+			var templ_7745c5c3_Var109 string
+			templ_7745c5c3_Var109, templ_7745c5c3_Err = templ.JoinStringErrs(card.OriginDetail)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 534, Col: 64}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 655, Col: 64}
 			}
-			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var100))
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var109))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 167, "</span></div>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 184, "</span></div>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 		}
 		if card.ExtraText != "" && (!card.RuntimeBadge || card.ExtraText != "agent working") {
 			if card.ExtraChip {
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 168, "<div class=\"flex\" data-board-card-expanded>")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 185, "<div class=\"flex\" data-board-card-expanded>")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
@@ -1991,30 +2150,30 @@ func boardCardView2(card boardCardView) templ.Component {
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 169, "</div>")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 186, "</div>")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
 			} else {
-				var templ_7745c5c3_Var101 = []any{"flex items-center gap-1.5 text-2xs " + boardExtraTextClass(card.ExtraKind)}
-				templ_7745c5c3_Err = templ.RenderCSSItems(ctx, templ_7745c5c3_Buffer, templ_7745c5c3_Var101...)
+				var templ_7745c5c3_Var110 = []any{"flex items-center gap-1.5 text-2xs " + boardExtraTextClass(card.ExtraKind)}
+				templ_7745c5c3_Err = templ.RenderCSSItems(ctx, templ_7745c5c3_Buffer, templ_7745c5c3_Var110...)
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 170, "<div class=\"")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 187, "<div class=\"")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				var templ_7745c5c3_Var102 string
-				templ_7745c5c3_Var102, templ_7745c5c3_Err = templ.JoinStringErrs(templ.CSSClasses(templ_7745c5c3_Var101).String())
+				var templ_7745c5c3_Var111 string
+				templ_7745c5c3_Var111, templ_7745c5c3_Err = templ.JoinStringErrs(templ.CSSClasses(templ_7745c5c3_Var110).String())
 				if templ_7745c5c3_Err != nil {
 					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 1, Col: 0}
 				}
-				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var102))
+				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var111))
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 171, "\" data-board-card-expanded>")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 188, "\" data-board-card-expanded>")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
@@ -2022,144 +2181,144 @@ func boardCardView2(card boardCardView) templ.Component {
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				var templ_7745c5c3_Var103 string
-				templ_7745c5c3_Var103, templ_7745c5c3_Err = templ.JoinStringErrs(card.ExtraText)
+				var templ_7745c5c3_Var112 string
+				templ_7745c5c3_Var112, templ_7745c5c3_Err = templ.JoinStringErrs(card.ExtraText)
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 545, Col: 21}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 666, Col: 21}
 				}
-				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var103))
+				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var112))
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 172, "</div>")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 189, "</div>")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
 			}
 		}
 		if card.BlockerSummary != "" {
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 173, "<div class=\"min-w-0 text-2xs text-sec\" data-board-card-blockers data-board-card-expanded><span class=\"text-dim\">Blocker refs</span> ")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 190, "<div class=\"min-w-0 text-2xs text-sec\" data-board-card-blockers data-board-card-expanded><span class=\"text-dim\">Blocker refs</span> ")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			var templ_7745c5c3_Var104 string
-			templ_7745c5c3_Var104, templ_7745c5c3_Err = templ.JoinStringErrs(card.BlockerSummary)
+			var templ_7745c5c3_Var113 string
+			templ_7745c5c3_Var113, templ_7745c5c3_Err = templ.JoinStringErrs(card.BlockerSummary)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 551, Col: 68}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 672, Col: 68}
 			}
-			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var104))
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var113))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 174, "</div>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 191, "</div>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 		}
 		if card.ParkSummary != "" {
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 175, "<div id=\"")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 192, "<div id=\"")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			var templ_7745c5c3_Var105 string
-			templ_7745c5c3_Var105, templ_7745c5c3_Err = templ.JoinStringErrs(card.DomID + "-park-summary")
+			var templ_7745c5c3_Var114 string
+			templ_7745c5c3_Var114, templ_7745c5c3_Err = templ.JoinStringErrs(card.DomID + "-park-summary")
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 556, Col: 37}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 677, Col: 37}
 			}
-			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var105))
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 176, "\" class=\"min-w-0 truncate font-mono text-2xs text-sec\" tabindex=\"0\" role=\"img\" aria-label=\"")
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var114))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			var templ_7745c5c3_Var106 string
-			templ_7745c5c3_Var106, templ_7745c5c3_Err = templ.JoinStringErrs("Park history: " + card.ParkDetail)
-			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 560, Col: 51}
-			}
-			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var106))
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 193, "\" class=\"min-w-0 truncate font-mono text-2xs text-sec\" tabindex=\"0\" role=\"img\" aria-label=\"")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 177, "\" data-board-card-park-summary data-board-card-expanded data-help-trigger data-help-scope=\"park-history\" data-help-term=\"")
+			var templ_7745c5c3_Var115 string
+			templ_7745c5c3_Var115, templ_7745c5c3_Err = templ.JoinStringErrs("Park history: " + card.ParkDetail)
+			if templ_7745c5c3_Err != nil {
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 681, Col: 51}
+			}
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var115))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			var templ_7745c5c3_Var107 string
-			templ_7745c5c3_Var107, templ_7745c5c3_Err = templ.JoinStringErrs(card.DomID + "-park-summary")
-			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 565, Col: 49}
-			}
-			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var107))
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 194, "\" data-board-card-park-summary data-board-card-expanded data-help-trigger data-help-scope=\"park-history\" data-help-term=\"")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 178, "\" data-help-title=\"Park history\" data-help-description=\"")
+			var templ_7745c5c3_Var116 string
+			templ_7745c5c3_Var116, templ_7745c5c3_Err = templ.JoinStringErrs(card.DomID + "-park-summary")
+			if templ_7745c5c3_Err != nil {
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 686, Col: 49}
+			}
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var116))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			var templ_7745c5c3_Var108 string
-			templ_7745c5c3_Var108, templ_7745c5c3_Err = templ.JoinStringErrs(card.ParkDetail)
-			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 567, Col: 43}
-			}
-			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var108))
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 195, "\" data-help-title=\"Park history\" data-help-description=\"")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 179, "\">")
+			var templ_7745c5c3_Var117 string
+			templ_7745c5c3_Var117, templ_7745c5c3_Err = templ.JoinStringErrs(card.ParkDetail)
+			if templ_7745c5c3_Err != nil {
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 688, Col: 43}
+			}
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var117))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			var templ_7745c5c3_Var109 string
-			templ_7745c5c3_Var109, templ_7745c5c3_Err = templ.JoinStringErrs(card.ParkSummary)
-			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 568, Col: 22}
-			}
-			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var109))
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 196, "\">")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 180, "</div>")
+			var templ_7745c5c3_Var118 string
+			templ_7745c5c3_Var118, templ_7745c5c3_Err = templ.JoinStringErrs(card.ParkSummary)
+			if templ_7745c5c3_Err != nil {
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 689, Col: 22}
+			}
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var118))
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 197, "</div>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 		}
 		if card.ProgressSummary != "" {
-			var templ_7745c5c3_Var110 = []any{"flex items-center gap-1.5 text-2xs " + boardExtraTextClass(card.ProgressKind)}
-			templ_7745c5c3_Err = templ.RenderCSSItems(ctx, templ_7745c5c3_Buffer, templ_7745c5c3_Var110...)
+			var templ_7745c5c3_Var119 = []any{"flex items-center gap-1.5 text-2xs " + boardExtraTextClass(card.ProgressKind)}
+			templ_7745c5c3_Err = templ.RenderCSSItems(ctx, templ_7745c5c3_Buffer, templ_7745c5c3_Var119...)
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 181, "<div class=\"")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 198, "<div class=\"")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			var templ_7745c5c3_Var111 string
-			templ_7745c5c3_Var111, templ_7745c5c3_Err = templ.JoinStringErrs(templ.CSSClasses(templ_7745c5c3_Var110).String())
+			var templ_7745c5c3_Var120 string
+			templ_7745c5c3_Var120, templ_7745c5c3_Err = templ.JoinStringErrs(templ.CSSClasses(templ_7745c5c3_Var119).String())
 			if templ_7745c5c3_Err != nil {
 				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 1, Col: 0}
 			}
-			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var111))
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var120))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 182, "\" title=\"")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 199, "\" title=\"")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			var templ_7745c5c3_Var112 string
-			templ_7745c5c3_Var112, templ_7745c5c3_Err = templ.JoinStringErrs(card.ProgressDetail)
+			var templ_7745c5c3_Var121 string
+			templ_7745c5c3_Var121, templ_7745c5c3_Err = templ.JoinStringErrs(card.ProgressDetail)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 571, Col: 124}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 692, Col: 124}
 			}
-			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var112))
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var121))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 183, "\" data-board-card-progress data-board-card-expanded>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 200, "\" data-board-card-progress data-board-card-expanded>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -2167,185 +2326,185 @@ func boardCardView2(card boardCardView) templ.Component {
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 184, "<span class=\"min-w-0 truncate font-mono\">")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 201, "<span class=\"min-w-0 truncate font-mono\">")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			var templ_7745c5c3_Var113 string
-			templ_7745c5c3_Var113, templ_7745c5c3_Err = templ.JoinStringErrs(card.ProgressSummary)
+			var templ_7745c5c3_Var122 string
+			templ_7745c5c3_Var122, templ_7745c5c3_Err = templ.JoinStringErrs(card.ProgressSummary)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 573, Col: 67}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 694, Col: 67}
 			}
-			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var113))
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var122))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 185, "</span></div>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 202, "</span></div>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 		}
 		if card.AgeFooter != "" {
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 186, "<div class=\"mt-0.5 flex items-center justify-between gap-2 border-t border-line/70 pt-1.5 font-mono text-2xs text-sec\" title=\"")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 203, "<div class=\"mt-0.5 flex items-center justify-between gap-2 border-t border-line/70 pt-1.5 font-mono text-2xs text-sec\" title=\"")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			var templ_7745c5c3_Var114 string
-			templ_7745c5c3_Var114, templ_7745c5c3_Err = templ.JoinStringErrs(card.AgeFooterTitle)
+			var templ_7745c5c3_Var123 string
+			templ_7745c5c3_Var123, templ_7745c5c3_Err = templ.JoinStringErrs(card.AgeFooterTitle)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 577, Col: 149}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 698, Col: 149}
 			}
-			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var114))
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 187, "\" data-board-card-age-footer data-board-card-expanded><span class=\"min-w-0 truncate\">In lane</span> <span class=\"flex-none whitespace-nowrap tabular-nums\">")
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var123))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			var templ_7745c5c3_Var115 string
-			templ_7745c5c3_Var115, templ_7745c5c3_Err = templ.JoinStringErrs(card.AgeFooter)
-			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 579, Col: 75}
-			}
-			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var115))
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 204, "\" data-board-card-age-footer data-board-card-expanded><span class=\"min-w-0 truncate\">In lane</span> <span class=\"flex-none whitespace-nowrap tabular-nums\">")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 188, "</span></div>")
+			var templ_7745c5c3_Var124 string
+			templ_7745c5c3_Var124, templ_7745c5c3_Err = templ.JoinStringErrs(card.AgeFooter)
+			if templ_7745c5c3_Err != nil {
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 700, Col: 75}
+			}
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var124))
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 205, "</span></div>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 		}
 		if card.AuthorDetail != "" || len(card.Labels) > 0 || card.Effort != "" || card.Activity != "" || card.PRStatus != "" {
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 189, "<div class=\"gap-1.5 border-t border-line/70 pt-1.5 text-2xs text-sec\" data-board-card-content=\"comfy\">")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 206, "<div class=\"gap-1.5 border-t border-line/70 pt-1.5 text-2xs text-sec\" data-board-card-content=\"comfy\">")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			if card.AuthorDetail != "" {
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 190, "<div class=\"flex min-w-0 items-center gap-1.5\" data-board-card-author><span class=\"flex-none text-dim\">Filed by</span> <span class=\"min-w-0 truncate font-mono text-text\">")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 207, "<div class=\"flex min-w-0 items-center gap-1.5\" data-board-card-author><span class=\"flex-none text-dim\">Filed by</span> <span class=\"min-w-0 truncate font-mono text-text\">")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				var templ_7745c5c3_Var116 string
-				templ_7745c5c3_Var116, templ_7745c5c3_Err = templ.JoinStringErrs(card.AuthorDetail)
+				var templ_7745c5c3_Var125 string
+				templ_7745c5c3_Var125, templ_7745c5c3_Err = templ.JoinStringErrs(card.AuthorDetail)
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 587, Col: 76}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 708, Col: 76}
 				}
-				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var116))
+				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var125))
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 191, "</span></div>")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 208, "</span></div>")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
 			}
 			if len(card.Labels) > 0 {
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 192, "<div class=\"flex min-w-0 flex-wrap gap-1\" data-board-card-labels>")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 209, "<div class=\"flex min-w-0 flex-wrap gap-1\" data-board-card-labels>")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
 				for _, label := range card.Labels {
-					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 193, "<span class=\"max-w-full truncate rounded-chip bg-surface px-1.5 py-0.5\">")
+					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 210, "<span class=\"max-w-full truncate rounded-chip bg-surface px-1.5 py-0.5\">")
 					if templ_7745c5c3_Err != nil {
 						return templ_7745c5c3_Err
 					}
-					var templ_7745c5c3_Var117 string
-					templ_7745c5c3_Var117, templ_7745c5c3_Err = templ.JoinStringErrs(label)
+					var templ_7745c5c3_Var126 string
+					templ_7745c5c3_Var126, templ_7745c5c3_Err = templ.JoinStringErrs(label)
 					if templ_7745c5c3_Err != nil {
-						return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 593, Col: 86}
+						return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 714, Col: 86}
 					}
-					_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var117))
+					_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var126))
 					if templ_7745c5c3_Err != nil {
 						return templ_7745c5c3_Err
 					}
-					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 194, "</span>")
+					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 211, "</span>")
 					if templ_7745c5c3_Err != nil {
 						return templ_7745c5c3_Err
 					}
 				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 195, "</div>")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 212, "</div>")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
 			}
 			if card.Effort != "" {
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 196, "<div class=\"flex min-w-0 items-center gap-1.5\" data-board-card-effort><span class=\"text-dim\">Effort</span> <span class=\"truncate font-mono text-text\">")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 213, "<div class=\"flex min-w-0 items-center gap-1.5\" data-board-card-effort><span class=\"text-dim\">Effort</span> <span class=\"truncate font-mono text-text\">")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				var templ_7745c5c3_Var118 string
-				templ_7745c5c3_Var118, templ_7745c5c3_Err = templ.JoinStringErrs(card.Effort)
+				var templ_7745c5c3_Var127 string
+				templ_7745c5c3_Var127, templ_7745c5c3_Err = templ.JoinStringErrs(card.Effort)
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 600, Col: 62}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 721, Col: 62}
 				}
-				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var118))
+				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var127))
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 197, "</span></div>")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 214, "</span></div>")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
 			}
 			if card.Activity != "" {
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 198, "<div class=\"line-clamp-2 min-w-0\" data-board-card-activity><span class=\"text-dim\">Activity</span> ")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 215, "<div class=\"line-clamp-2 min-w-0\" data-board-card-activity><span class=\"text-dim\">Activity</span> ")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				var templ_7745c5c3_Var119 string
-				templ_7745c5c3_Var119, templ_7745c5c3_Err = templ.JoinStringErrs(card.Activity)
+				var templ_7745c5c3_Var128 string
+				templ_7745c5c3_Var128, templ_7745c5c3_Err = templ.JoinStringErrs(card.Activity)
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 604, Col: 118}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 725, Col: 118}
 				}
-				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var119))
+				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var128))
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 199, "</div>")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 216, "</div>")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
 			}
 			if card.PRStatus != "" {
-				var templ_7745c5c3_Var120 = []any{"w-fit rounded-chip border px-1.5 py-0.5 font-mono " + card.PRStatusClass}
-				templ_7745c5c3_Err = templ.RenderCSSItems(ctx, templ_7745c5c3_Buffer, templ_7745c5c3_Var120...)
+				var templ_7745c5c3_Var129 = []any{"w-fit rounded-chip border px-1.5 py-0.5 font-mono " + card.PRStatusClass}
+				templ_7745c5c3_Err = templ.RenderCSSItems(ctx, templ_7745c5c3_Buffer, templ_7745c5c3_Var129...)
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 200, "<div class=\"")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 217, "<div class=\"")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				var templ_7745c5c3_Var121 string
-				templ_7745c5c3_Var121, templ_7745c5c3_Err = templ.JoinStringErrs(templ.CSSClasses(templ_7745c5c3_Var120).String())
+				var templ_7745c5c3_Var130 string
+				templ_7745c5c3_Var130, templ_7745c5c3_Err = templ.JoinStringErrs(templ.CSSClasses(templ_7745c5c3_Var129).String())
 				if templ_7745c5c3_Err != nil {
 					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 1, Col: 0}
 				}
-				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var121))
+				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var130))
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 201, "\" data-board-card-pr-status>")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 218, "\" data-board-card-pr-status>")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				var templ_7745c5c3_Var122 string
-				templ_7745c5c3_Var122, templ_7745c5c3_Err = templ.JoinStringErrs(card.PRStatus)
+				var templ_7745c5c3_Var131 string
+				templ_7745c5c3_Var131, templ_7745c5c3_Err = templ.JoinStringErrs(card.PRStatus)
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 607, Col: 135}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 728, Col: 135}
 				}
-				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var122))
+				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var131))
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 202, "</div>")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 219, "</div>")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 203, "</div>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 220, "</div>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -2356,7 +2515,7 @@ func boardCardView2(card boardCardView) templ.Component {
 				return templ_7745c5c3_Err
 			}
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 204, "</article>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 221, "</article>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -2380,74 +2539,74 @@ func boardRuntimeBadge(card boardCardView) templ.Component {
 			}()
 		}
 		ctx = templ.InitializeContext(ctx)
-		templ_7745c5c3_Var123 := templ.GetChildren(ctx)
-		if templ_7745c5c3_Var123 == nil {
-			templ_7745c5c3_Var123 = templ.NopComponent
+		templ_7745c5c3_Var132 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var132 == nil {
+			templ_7745c5c3_Var132 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 205, "<div id=\"")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 222, "<div id=\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		var templ_7745c5c3_Var124 string
-		templ_7745c5c3_Var124, templ_7745c5c3_Err = templ.JoinStringErrs(card.DomID + "-runtime-badge")
+		var templ_7745c5c3_Var133 string
+		templ_7745c5c3_Var133, templ_7745c5c3_Err = templ.JoinStringErrs(card.DomID + "-runtime-badge")
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 619, Col: 36}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 740, Col: 36}
 		}
-		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var124))
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var133))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 206, "\" class=\"flex min-w-0 items-center gap-1.5 text-2xs text-ok\" data-board-runtime-badge data-board-card-expanded")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 223, "\" class=\"flex min-w-0 items-center gap-1.5 text-2xs text-ok\" data-board-runtime-badge data-board-card-expanded")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		if card.RuntimeSummary != "" {
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 207, " tabindex=\"0\" role=\"img\" aria-label=\"")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 224, " tabindex=\"0\" role=\"img\" aria-label=\"")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			var templ_7745c5c3_Var125 string
-			templ_7745c5c3_Var125, templ_7745c5c3_Err = templ.JoinStringErrs("Agent runtime: " + card.RuntimeSummary)
+			var templ_7745c5c3_Var134 string
+			templ_7745c5c3_Var134, templ_7745c5c3_Err = templ.JoinStringErrs("Agent runtime: " + card.RuntimeSummary)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 626, Col: 55}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 747, Col: 55}
 			}
-			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var125))
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 208, "\" data-help-trigger data-help-scope=\"runtime-identity\" data-help-term=\"")
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var134))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			var templ_7745c5c3_Var126 string
-			templ_7745c5c3_Var126, templ_7745c5c3_Err = templ.JoinStringErrs(card.DomID + "-runtime-identity")
-			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 629, Col: 52}
-			}
-			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var126))
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 225, "\" data-help-trigger data-help-scope=\"runtime-identity\" data-help-term=\"")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 209, "\" data-help-title=\"Agent runtime\" data-help-description=\"")
+			var templ_7745c5c3_Var135 string
+			templ_7745c5c3_Var135, templ_7745c5c3_Err = templ.JoinStringErrs(card.DomID + "-runtime-identity")
+			if templ_7745c5c3_Err != nil {
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 750, Col: 52}
+			}
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var135))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			var templ_7745c5c3_Var127 string
-			templ_7745c5c3_Var127, templ_7745c5c3_Err = templ.JoinStringErrs(card.RuntimeDetail)
-			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 631, Col: 45}
-			}
-			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var127))
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 226, "\" data-help-title=\"Agent runtime\" data-help-description=\"")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 210, "\" onclick=\"event.stopPropagation()\"")
+			var templ_7745c5c3_Var136 string
+			templ_7745c5c3_Var136, templ_7745c5c3_Err = templ.JoinStringErrs(card.RuntimeDetail)
+			if templ_7745c5c3_Err != nil {
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 752, Col: 45}
+			}
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var136))
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 227, "\" onclick=\"event.stopPropagation()\"")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 211, ">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 228, ">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -2455,33 +2614,33 @@ func boardRuntimeBadge(card boardCardView) templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 212, "<span class=\"min-w-0 truncate font-mono\"><span class=\"runtime-badge-cozy\" data-runtime-density=\"cozy\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 229, "<span class=\"min-w-0 truncate font-mono\"><span class=\"runtime-badge-cozy\" data-runtime-density=\"cozy\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		var templ_7745c5c3_Var128 string
-		templ_7745c5c3_Var128, templ_7745c5c3_Err = templ.JoinStringErrs(card.RuntimeCozyText)
+		var templ_7745c5c3_Var137 string
+		templ_7745c5c3_Var137, templ_7745c5c3_Err = templ.JoinStringErrs(card.RuntimeCozyText)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 637, Col: 86}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 758, Col: 86}
 		}
-		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var128))
-		if templ_7745c5c3_Err != nil {
-			return templ_7745c5c3_Err
-		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 213, "</span> <span class=\"runtime-badge-comfy\" data-runtime-density=\"comfy\">")
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var137))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		var templ_7745c5c3_Var129 string
-		templ_7745c5c3_Var129, templ_7745c5c3_Err = templ.JoinStringErrs(card.RuntimeComfyText)
-		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 638, Col: 89}
-		}
-		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var129))
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 230, "</span> <span class=\"runtime-badge-comfy\" data-runtime-density=\"comfy\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 214, "</span></span></div>")
+		var templ_7745c5c3_Var138 string
+		templ_7745c5c3_Var138, templ_7745c5c3_Err = templ.JoinStringErrs(card.RuntimeComfyText)
+		if templ_7745c5c3_Err != nil {
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 759, Col: 89}
+		}
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var138))
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 231, "</span></span></div>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -2505,87 +2664,87 @@ func boardKanbanDragMoveForm(card boardCardView) templ.Component {
 			}()
 		}
 		ctx = templ.InitializeContext(ctx)
-		templ_7745c5c3_Var130 := templ.GetChildren(ctx)
-		if templ_7745c5c3_Var130 == nil {
-			templ_7745c5c3_Var130 = templ.NopComponent
+		templ_7745c5c3_Var139 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var139 == nil {
+			templ_7745c5c3_Var139 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 215, "<form class=\"hidden\" hx-post=\"/api/v1/kanban/move\" hx-target=\"#snapshot\" hx-swap=\"morph:innerHTML\" data-kanban-drag-move-form><input type=\"hidden\" name=\"kanban_drag\" value=\"true\"> <input type=\"hidden\" name=\"kanban_board\" value=\"")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 232, "<form class=\"hidden\" hx-post=\"/api/v1/kanban/move\" hx-target=\"#snapshot\" hx-swap=\"morph:innerHTML\" data-kanban-drag-move-form><input type=\"hidden\" name=\"kanban_drag\" value=\"true\"> <input type=\"hidden\" name=\"kanban_board\" value=\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		var templ_7745c5c3_Var131 string
-		templ_7745c5c3_Var131, templ_7745c5c3_Err = templ.JoinStringErrs(card.Scope)
+		var templ_7745c5c3_Var140 string
+		templ_7745c5c3_Var140, templ_7745c5c3_Err = templ.JoinStringErrs(card.Scope)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 646, Col: 61}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 767, Col: 61}
 		}
-		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var131))
-		if templ_7745c5c3_Err != nil {
-			return templ_7745c5c3_Err
-		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 216, "\"> <input type=\"hidden\" name=\"project_id\" value=\"")
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var140))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		var templ_7745c5c3_Var132 string
-		templ_7745c5c3_Var132, templ_7745c5c3_Err = templ.JoinStringErrs(card.MoveProject)
-		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 647, Col: 65}
-		}
-		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var132))
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 233, "\"> <input type=\"hidden\" name=\"project_id\" value=\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 217, "\"> <input type=\"hidden\" name=\"issue_id\" value=\"")
+		var templ_7745c5c3_Var141 string
+		templ_7745c5c3_Var141, templ_7745c5c3_Err = templ.JoinStringErrs(card.MoveProject)
+		if templ_7745c5c3_Err != nil {
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 768, Col: 65}
+		}
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var141))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		var templ_7745c5c3_Var133 string
-		templ_7745c5c3_Var133, templ_7745c5c3_Err = templ.JoinStringErrs(card.IssueID)
-		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 648, Col: 59}
-		}
-		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var133))
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 234, "\"> <input type=\"hidden\" name=\"issue_id\" value=\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 218, "\"> <input type=\"hidden\" name=\"current_state\" value=\"")
+		var templ_7745c5c3_Var142 string
+		templ_7745c5c3_Var142, templ_7745c5c3_Err = templ.JoinStringErrs(card.IssueID)
+		if templ_7745c5c3_Err != nil {
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 769, Col: 59}
+		}
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var142))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		var templ_7745c5c3_Var134 string
-		templ_7745c5c3_Var134, templ_7745c5c3_Err = templ.JoinStringErrs(card.CurrentState)
-		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 649, Col: 69}
-		}
-		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var134))
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 235, "\"> <input type=\"hidden\" name=\"current_state\" value=\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 219, "\"> <input type=\"hidden\" name=\"target_state\" value=\"\" data-kanban-drag-target-state> ")
+		var templ_7745c5c3_Var143 string
+		templ_7745c5c3_Var143, templ_7745c5c3_Err = templ.JoinStringErrs(card.CurrentState)
+		if templ_7745c5c3_Err != nil {
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 770, Col: 69}
+		}
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var143))
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 236, "\"> <input type=\"hidden\" name=\"target_state\" value=\"\" data-kanban-drag-target-state> ")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		if card.PRNumber != "" {
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 220, "<input type=\"hidden\" name=\"pr_number\" value=\"")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 237, "<input type=\"hidden\" name=\"pr_number\" value=\"")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			var templ_7745c5c3_Var135 string
-			templ_7745c5c3_Var135, templ_7745c5c3_Err = templ.JoinStringErrs(card.PRNumber)
+			var templ_7745c5c3_Var144 string
+			templ_7745c5c3_Var144, templ_7745c5c3_Err = templ.JoinStringErrs(card.PRNumber)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 652, Col: 62}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 773, Col: 62}
 			}
-			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var135))
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var144))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 221, "\">")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 238, "\">")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 222, "</form>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 239, "</form>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -2612,74 +2771,74 @@ func boardLanePicker(view boardView) templ.Component {
 			}()
 		}
 		ctx = templ.InitializeContext(ctx)
-		templ_7745c5c3_Var136 := templ.GetChildren(ctx)
-		if templ_7745c5c3_Var136 == nil {
-			templ_7745c5c3_Var136 = templ.NopComponent
+		templ_7745c5c3_Var145 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var145 == nil {
+			templ_7745c5c3_Var145 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 223, "<details id=\"board-lane-picker\" class=\"relative col-span-3 justify-self-start md:col-span-1\" data-board-lane-picker data-preserve-details=\"board-lane-picker\"><summary class=\"flex min-h-11 cursor-pointer list-none items-center gap-1.5 rounded-chip border border-line px-2.5 py-1 text-2xs text-sec hover:text-text [&::-webkit-details-marker]:hidden md:min-h-0\">Lanes <span data-board-lane-count class=\"tabular-nums\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 240, "<details id=\"board-lane-picker\" class=\"relative col-span-3 justify-self-start md:col-span-1\" data-board-lane-picker data-preserve-details=\"board-lane-picker\"><summary class=\"flex min-h-11 cursor-pointer list-none items-center gap-1.5 rounded-chip border border-line px-2.5 py-1 text-2xs text-sec hover:text-text [&::-webkit-details-marker]:hidden md:min-h-0\">Lanes <span data-board-lane-count class=\"tabular-nums\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		var templ_7745c5c3_Var137 string
-		templ_7745c5c3_Var137, templ_7745c5c3_Err = templ.JoinStringErrs(boardLaneCountLabel(view))
+		var templ_7745c5c3_Var146 string
+		templ_7745c5c3_Var146, templ_7745c5c3_Err = templ.JoinStringErrs(boardLaneCountLabel(view))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 663, Col: 85}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 784, Col: 85}
 		}
-		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var137))
-		if templ_7745c5c3_Err != nil {
-			return templ_7745c5c3_Err
-		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 224, "</span> <span class=\"rounded-chip bg-warn/15 px-1.5 py-0.5 font-mono text-warn\" data-board-hidden-card-count title=\"")
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var146))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		var templ_7745c5c3_Var138 string
-		templ_7745c5c3_Var138, templ_7745c5c3_Err = templ.JoinStringErrs(boardLaneHiddenCardSummary(view))
-		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 667, Col: 44}
-		}
-		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var138))
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 241, "</span> <span class=\"rounded-chip bg-warn/15 px-1.5 py-0.5 font-mono text-warn\" data-board-hidden-card-count title=\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 225, "\" aria-label=\"")
+		var templ_7745c5c3_Var147 string
+		templ_7745c5c3_Var147, templ_7745c5c3_Err = templ.JoinStringErrs(boardLaneHiddenCardSummary(view))
+		if templ_7745c5c3_Err != nil {
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 788, Col: 44}
+		}
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var147))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		var templ_7745c5c3_Var139 string
-		templ_7745c5c3_Var139, templ_7745c5c3_Err = templ.JoinStringErrs(boardLaneHiddenCardSummary(view))
-		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 668, Col: 49}
-		}
-		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var139))
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 242, "\" aria-label=\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 226, "\"")
+		var templ_7745c5c3_Var148 string
+		templ_7745c5c3_Var148, templ_7745c5c3_Err = templ.JoinStringErrs(boardLaneHiddenCardSummary(view))
+		if templ_7745c5c3_Err != nil {
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 789, Col: 49}
+		}
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var148))
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 243, "\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		if view.HiddenCards == 0 {
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 227, " hidden")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 244, " hidden")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 228, ">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 245, ">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		var templ_7745c5c3_Var140 string
-		templ_7745c5c3_Var140, templ_7745c5c3_Err = templ.JoinStringErrs(boardLaneHiddenCardBadgeLabel(view))
+		var templ_7745c5c3_Var149 string
+		templ_7745c5c3_Var149, templ_7745c5c3_Err = templ.JoinStringErrs(boardLaneHiddenCardBadgeLabel(view))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 670, Col: 41}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 791, Col: 41}
 		}
-		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var140))
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var149))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 229, "</span>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 246, "</span>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -2687,7 +2846,7 @@ func boardLanePicker(view boardView) templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 230, "</summary><div class=\"absolute left-0 top-full z-40 mt-1 flex max-h-[calc(100vh-10rem)] w-[calc(100vw-2.5rem)] flex-col gap-1 overflow-y-auto rounded-card border border-line bg-elev p-1.5 md:left-auto md:right-0 md:max-h-none md:w-80 md:overflow-visible\"><div class=\"flex items-center justify-between gap-2 border-b border-line px-1 pb-1.5\"><span class=\"text-2xs font-medium uppercase text-sec\">Visibility</span> <button type=\"button\" class=\"inline-flex min-h-11 items-center gap-1.5 rounded-chip border border-line px-2 text-2xs font-medium text-sec hover:border-accent hover:text-accent disabled:pointer-events-none disabled:opacity-40 md:min-h-7\" data-board-lane-reset-all aria-label=\"Reset all lanes to Auto\" title=\"Reset all lanes to Auto\" disabled aria-disabled=\"true\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 247, "</summary><div class=\"absolute left-0 top-full z-40 mt-1 flex max-h-[calc(100vh-10rem)] w-[calc(100vw-2.5rem)] flex-col gap-1 overflow-y-auto rounded-card border border-line bg-elev p-1.5 md:left-auto md:right-0 md:max-h-none md:w-80 md:overflow-visible\"><div class=\"flex items-center justify-between gap-2 border-b border-line px-1 pb-1.5\"><span class=\"text-2xs font-medium uppercase text-sec\">Visibility</span> <button type=\"button\" class=\"inline-flex min-h-11 items-center gap-1.5 rounded-chip border border-line px-2 text-2xs font-medium text-sec hover:border-accent hover:text-accent disabled:pointer-events-none disabled:opacity-40 md:min-h-7\" data-board-lane-reset-all aria-label=\"Reset all lanes to Auto\" title=\"Reset all lanes to Auto\" disabled aria-disabled=\"true\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -2695,264 +2854,264 @@ func boardLanePicker(view boardView) templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 231, "<span>Reset all</span></button></div>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 248, "<span>Reset all</span></button></div>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		for _, lane := range view.Lanes {
-			var templ_7745c5c3_Var141 = []any{boardLaneVisibilityRowClass(lane)}
-			templ_7745c5c3_Err = templ.RenderCSSItems(ctx, templ_7745c5c3_Buffer, templ_7745c5c3_Var141...)
+			var templ_7745c5c3_Var150 = []any{boardLaneVisibilityRowClass(lane)}
+			templ_7745c5c3_Err = templ.RenderCSSItems(ctx, templ_7745c5c3_Buffer, templ_7745c5c3_Var150...)
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 232, "<div class=\"")
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
-			var templ_7745c5c3_Var142 string
-			templ_7745c5c3_Var142, templ_7745c5c3_Err = templ.JoinStringErrs(templ.CSSClasses(templ_7745c5c3_Var141).String())
-			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 1, Col: 0}
-			}
-			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var142))
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 233, "\" data-board-lane-row=\"")
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
-			var templ_7745c5c3_Var143 string
-			templ_7745c5c3_Var143, templ_7745c5c3_Err = templ.JoinStringErrs(lane.LaneID)
-			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 690, Col: 86}
-			}
-			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var143))
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 234, "\" data-board-lane-card-count=\"")
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
-			var templ_7745c5c3_Var144 string
-			templ_7745c5c3_Var144, templ_7745c5c3_Err = templ.JoinStringErrs(strconv.Itoa(lane.CardCount))
-			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 690, Col: 146}
-			}
-			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var144))
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 235, "\" data-board-lane-hidden-populated=\"")
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
-			var templ_7745c5c3_Var145 string
-			templ_7745c5c3_Var145, templ_7745c5c3_Err = templ.JoinStringErrs(boardBoolAttr(boardLaneHiddenPopulated(lane)))
-			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 690, Col: 229}
-			}
-			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var145))
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 236, "\"><div class=\"flex min-w-0 items-center gap-2\"><span class=\"min-w-0 flex-1 truncate font-medium\">")
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
-			var templ_7745c5c3_Var146 string
-			templ_7745c5c3_Var146, templ_7745c5c3_Err = templ.JoinStringErrs(lane.Title)
-			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 692, Col: 68}
-			}
-			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var146))
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 237, "</span> <span class=\"rounded-chip bg-surface px-1.5 py-0.5 font-mono text-2xs text-sec tabular-nums\">")
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
-			var templ_7745c5c3_Var147 string
-			templ_7745c5c3_Var147, templ_7745c5c3_Err = templ.JoinStringErrs(lane.Count)
-			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 693, Col: 111}
-			}
-			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var147))
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 238, "</span></div><div class=\"grid grid-cols-[minmax(0,1fr)_auto_auto] items-center gap-1.5\"><span class=\"min-w-0 truncate text-2xs text-sec\" title=\"")
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
-			var templ_7745c5c3_Var148 string
-			templ_7745c5c3_Var148, templ_7745c5c3_Err = templ.JoinStringErrs(boardLaneVisibilityStatusTitle(lane))
-			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 696, Col: 99}
-			}
-			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var148))
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 239, "\" data-board-lane-visibility-status>")
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
-			var templ_7745c5c3_Var149 string
-			templ_7745c5c3_Var149, templ_7745c5c3_Err = templ.JoinStringErrs(boardLaneVisibilityStatusLabel(lane))
-			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 696, Col: 174}
-			}
-			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var149))
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 240, "</span> <select class=\"h-11 rounded-chip border border-line bg-surface px-2 text-2xs text-text outline-none focus:border-accent md:h-7\" data-board-lane-visibility=\"")
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
-			var templ_7745c5c3_Var150 string
-			templ_7745c5c3_Var150, templ_7745c5c3_Err = templ.JoinStringErrs(lane.LaneID)
-			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 699, Col: 47}
-			}
-			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var150))
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 241, "\" data-board-lane-visibility-state=\"")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 249, "<div class=\"")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var151 string
-			templ_7745c5c3_Var151, templ_7745c5c3_Err = templ.JoinStringErrs(string(boardLaneVisibilityAuto))
+			templ_7745c5c3_Var151, templ_7745c5c3_Err = templ.JoinStringErrs(templ.CSSClasses(templ_7745c5c3_Var150).String())
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 700, Col: 73}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 1, Col: 0}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var151))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 242, "\" data-board-lane-visibility-effective=\"")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 250, "\" data-board-lane-row=\"")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var152 string
-			templ_7745c5c3_Var152, templ_7745c5c3_Err = templ.JoinStringErrs(boardBoolAttr(lane.DefaultVisible))
+			templ_7745c5c3_Var152, templ_7745c5c3_Err = templ.JoinStringErrs(lane.LaneID)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 701, Col: 80}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 811, Col: 86}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var152))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 243, "\" aria-label=\"")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 251, "\" data-board-lane-card-count=\"")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var153 string
-			templ_7745c5c3_Var153, templ_7745c5c3_Err = templ.JoinStringErrs("Visibility for " + lane.Title + " lane")
+			templ_7745c5c3_Var153, templ_7745c5c3_Err = templ.JoinStringErrs(strconv.Itoa(lane.CardCount))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 702, Col: 60}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 811, Col: 146}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var153))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 244, "\" title=\"")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 252, "\" data-board-lane-hidden-populated=\"")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var154 string
-			templ_7745c5c3_Var154, templ_7745c5c3_Err = templ.JoinStringErrs(boardLaneVisibilityStatusTitle(lane))
+			templ_7745c5c3_Var154, templ_7745c5c3_Err = templ.JoinStringErrs(boardBoolAttr(boardLaneHiddenPopulated(lane)))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 703, Col: 51}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 811, Col: 229}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var154))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 245, "\"><option value=\"")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 253, "\"><div class=\"flex min-w-0 items-center gap-2\"><span class=\"min-w-0 flex-1 truncate font-medium\">")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var155 string
-			templ_7745c5c3_Var155, templ_7745c5c3_Err = templ.JoinStringErrs(string(boardLaneVisibilityAuto))
+			templ_7745c5c3_Var155, templ_7745c5c3_Err = templ.JoinStringErrs(lane.Title)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 705, Col: 54}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 813, Col: 68}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var155))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 246, "\" selected>Auto</option> <option value=\"")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 254, "</span> <span class=\"rounded-chip bg-surface px-1.5 py-0.5 font-mono text-2xs text-sec tabular-nums\">")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var156 string
-			templ_7745c5c3_Var156, templ_7745c5c3_Err = templ.JoinStringErrs(string(boardLaneVisibilityShow))
+			templ_7745c5c3_Var156, templ_7745c5c3_Err = templ.JoinStringErrs(lane.Count)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 706, Col: 54}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 814, Col: 111}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var156))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 247, "\">Show</option> <option value=\"")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 255, "</span></div><div class=\"grid grid-cols-[minmax(0,1fr)_auto_auto] items-center gap-1.5\"><span class=\"min-w-0 truncate text-2xs text-sec\" title=\"")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var157 string
-			templ_7745c5c3_Var157, templ_7745c5c3_Err = templ.JoinStringErrs(string(boardLaneVisibilityHide))
+			templ_7745c5c3_Var157, templ_7745c5c3_Err = templ.JoinStringErrs(boardLaneVisibilityStatusTitle(lane))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 707, Col: 54}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 817, Col: 99}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var157))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 248, "\">Hide</option></select> <button type=\"button\" class=\"inline-flex size-11 items-center justify-center rounded-chip border border-line text-sec hover:border-accent hover:text-accent disabled:pointer-events-none disabled:opacity-40 md:size-7\" data-board-lane-reset=\"")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 256, "\" data-board-lane-visibility-status>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var158 string
-			templ_7745c5c3_Var158, templ_7745c5c3_Err = templ.JoinStringErrs(lane.LaneID)
+			templ_7745c5c3_Var158, templ_7745c5c3_Err = templ.JoinStringErrs(boardLaneVisibilityStatusLabel(lane))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 712, Col: 42}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 817, Col: 174}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var158))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 249, "\" value=\"")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 257, "</span> <select class=\"h-11 rounded-chip border border-line bg-surface px-2 text-2xs text-text outline-none focus:border-accent md:h-7\" data-board-lane-visibility=\"")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var159 string
 			templ_7745c5c3_Var159, templ_7745c5c3_Err = templ.JoinStringErrs(lane.LaneID)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 713, Col: 26}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 820, Col: 47}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var159))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 250, "\" aria-label=\"")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 258, "\" data-board-lane-visibility-state=\"")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var160 string
-			templ_7745c5c3_Var160, templ_7745c5c3_Err = templ.JoinStringErrs("Reset " + lane.Title + " lane to Auto")
+			templ_7745c5c3_Var160, templ_7745c5c3_Err = templ.JoinStringErrs(string(boardLaneVisibilityAuto))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 714, Col: 59}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 821, Col: 73}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var160))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 251, "\" title=\"Reset lane to Auto\" disabled aria-disabled=\"true\">")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 259, "\" data-board-lane-visibility-effective=\"")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			var templ_7745c5c3_Var161 string
+			templ_7745c5c3_Var161, templ_7745c5c3_Err = templ.JoinStringErrs(boardBoolAttr(lane.DefaultVisible))
+			if templ_7745c5c3_Err != nil {
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 822, Col: 80}
+			}
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var161))
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 260, "\" aria-label=\"")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			var templ_7745c5c3_Var162 string
+			templ_7745c5c3_Var162, templ_7745c5c3_Err = templ.JoinStringErrs("Visibility for " + lane.Title + " lane")
+			if templ_7745c5c3_Err != nil {
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 823, Col: 60}
+			}
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var162))
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 261, "\" title=\"")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			var templ_7745c5c3_Var163 string
+			templ_7745c5c3_Var163, templ_7745c5c3_Err = templ.JoinStringErrs(boardLaneVisibilityStatusTitle(lane))
+			if templ_7745c5c3_Err != nil {
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 824, Col: 51}
+			}
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var163))
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 262, "\"><option value=\"")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			var templ_7745c5c3_Var164 string
+			templ_7745c5c3_Var164, templ_7745c5c3_Err = templ.JoinStringErrs(string(boardLaneVisibilityAuto))
+			if templ_7745c5c3_Err != nil {
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 826, Col: 54}
+			}
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var164))
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 263, "\" selected>Auto</option> <option value=\"")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			var templ_7745c5c3_Var165 string
+			templ_7745c5c3_Var165, templ_7745c5c3_Err = templ.JoinStringErrs(string(boardLaneVisibilityShow))
+			if templ_7745c5c3_Err != nil {
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 827, Col: 54}
+			}
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var165))
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 264, "\">Show</option> <option value=\"")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			var templ_7745c5c3_Var166 string
+			templ_7745c5c3_Var166, templ_7745c5c3_Err = templ.JoinStringErrs(string(boardLaneVisibilityHide))
+			if templ_7745c5c3_Err != nil {
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 828, Col: 54}
+			}
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var166))
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 265, "\">Hide</option></select> <button type=\"button\" class=\"inline-flex size-11 items-center justify-center rounded-chip border border-line text-sec hover:border-accent hover:text-accent disabled:pointer-events-none disabled:opacity-40 md:size-7\" data-board-lane-reset=\"")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			var templ_7745c5c3_Var167 string
+			templ_7745c5c3_Var167, templ_7745c5c3_Err = templ.JoinStringErrs(lane.LaneID)
+			if templ_7745c5c3_Err != nil {
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 833, Col: 42}
+			}
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var167))
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 266, "\" value=\"")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			var templ_7745c5c3_Var168 string
+			templ_7745c5c3_Var168, templ_7745c5c3_Err = templ.JoinStringErrs(lane.LaneID)
+			if templ_7745c5c3_Err != nil {
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 834, Col: 26}
+			}
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var168))
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 267, "\" aria-label=\"")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			var templ_7745c5c3_Var169 string
+			templ_7745c5c3_Var169, templ_7745c5c3_Err = templ.JoinStringErrs("Reset " + lane.Title + " lane to Auto")
+			if templ_7745c5c3_Err != nil {
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 835, Col: 59}
+			}
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var169))
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 268, "\" title=\"Reset lane to Auto\" disabled aria-disabled=\"true\">")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -2960,12 +3119,12 @@ func boardLanePicker(view boardView) templ.Component {
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 252, "</button></div></div>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 269, "</button></div></div>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 253, "</div></details>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 270, "</div></details>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -2989,12 +3148,12 @@ func boardLaneScript() templ.Component {
 			}()
 		}
 		ctx = templ.InitializeContext(ctx)
-		templ_7745c5c3_Var161 := templ.GetChildren(ctx)
-		if templ_7745c5c3_Var161 == nil {
-			templ_7745c5c3_Var161 = templ.NopComponent
+		templ_7745c5c3_Var170 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var170 == nil {
+			templ_7745c5c3_Var170 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 254, "<script>\n\t\t(function () {\n\t\t\tvar storagePrefix = \"detent.ui.board.lanes.v2.\";\n\t\t\tvar legacyStoragePrefix = \"detent.ui.board.lanes.\";\n\t\t\tvar storageVersion = 1;\n\t\t\tvar stateAuto = \"auto\";\n\t\t\tvar stateShow = \"show\";\n\t\t\tvar stateHide = \"hide\";\n\t\t\tvar pickerOpen = false;\n\t\t\tvar activeLaneID = \"\";\n\t\t\tvar lanePositionFrame = 0;\n\n\t\t\tfunction visibilityStorage() {\n\t\t\t\ttry {\n\t\t\t\t\treturn window.localStorage;\n\t\t\t\t} catch (err) {\n\t\t\t\t\treturn null;\n\t\t\t\t}\n\t\t\t}\n\t\t\tfunction storageKey(root) {\n\t\t\t\treturn storagePrefix + (root.getAttribute(\"data-board-key\") || \"fleet\");\n\t\t\t}\n\t\t\tfunction legacyStorageKey(root) {\n\t\t\t\treturn legacyStoragePrefix + (root.getAttribute(\"data-board-key\") || \"fleet\");\n\t\t\t}\n\t\t\tfunction emptyPrefs() {\n\t\t\t\treturn { show: new Set(), hide: new Set() };\n\t\t\t}\n\t\t\tfunction laneIDSet(ids) {\n\t\t\t\tvar out = new Set();\n\t\t\t\tif (!Array.isArray(ids)) return out;\n\t\t\t\tids.forEach(function (id) {\n\t\t\t\t\tif (typeof id === \"string\" && id.trim() !== \"\") out.add(id);\n\t\t\t\t});\n\t\t\t\treturn out;\n\t\t\t}\n\t\t\tfunction normalizedPrefs(showIDs, hideIDs) {\n\t\t\t\tvar prefs = emptyPrefs();\n\t\t\t\tlaneIDSet(showIDs).forEach(function (id) {\n\t\t\t\t\tprefs.show.add(id);\n\t\t\t\t});\n\t\t\t\tlaneIDSet(hideIDs).forEach(function (id) {\n\t\t\t\t\tif (!prefs.show.has(id)) prefs.hide.add(id);\n\t\t\t\t});\n\t\t\t\treturn prefs;\n\t\t\t}\n\t\t\tfunction discardLegacyPrefs(root, store) {\n\t\t\t\tvar legacy = legacyStorageKey(root);\n\t\t\t\ttry {\n\t\t\t\t\tif (legacy !== storageKey(root)) store.removeItem(legacy);\n\t\t\t\t} catch (err) {}\n\t\t\t}\n\t\t\tfunction readPrefs(root) {\n\t\t\t\tvar store = visibilityStorage();\n\t\t\t\tif (!store) return emptyPrefs();\n\t\t\t\tdiscardLegacyPrefs(root, store);\n\t\t\t\tvar raw = \"\";\n\t\t\t\ttry {\n\t\t\t\t\traw = store.getItem(storageKey(root));\n\t\t\t\t} catch (err) {\n\t\t\t\t\treturn emptyPrefs();\n\t\t\t\t}\n\t\t\t\tif (!raw) return emptyPrefs();\n\t\t\t\ttry {\n\t\t\t\t\tvar parsed = JSON.parse(raw);\n\t\t\t\t\tif (!parsed || parsed.v !== storageVersion) {\n\t\t\t\t\t\ttry {\n\t\t\t\t\t\t\tstore.removeItem(storageKey(root));\n\t\t\t\t\t\t} catch (err) {}\n\t\t\t\t\t\treturn emptyPrefs();\n\t\t\t\t\t}\n\t\t\t\t\treturn normalizedPrefs(parsed.show, parsed.hide);\n\t\t\t\t} catch (err) {\n\t\t\t\t\ttry {\n\t\t\t\t\t\tstore.removeItem(storageKey(root));\n\t\t\t\t\t} catch (err) {}\n\t\t\t\t\treturn emptyPrefs();\n\t\t\t\t}\n\t\t\t}\n\t\t\tfunction writePrefs(root, prefs) {\n\t\t\t\tvar store = visibilityStorage();\n\t\t\t\tif (!store) return;\n\t\t\t\tvar show = Array.from(prefs.show).filter(Boolean).sort();\n\t\t\t\tvar hide = Array.from(prefs.hide).filter(function (id) {\n\t\t\t\t\treturn Boolean(id) && !prefs.show.has(id);\n\t\t\t\t}).sort();\n\t\t\t\tif (show.length === 0 && hide.length === 0) {\n\t\t\t\t\ttry {\n\t\t\t\t\t\tstore.removeItem(storageKey(root));\n\t\t\t\t\t} catch (err) {}\n\t\t\t\t\treturn;\n\t\t\t\t}\n\t\t\t\ttry {\n\t\t\t\t\tstore.setItem(storageKey(root), JSON.stringify({ v: storageVersion, show: show, hide: hide }));\n\t\t\t\t} catch (err) {}\n\t\t\t}\n\t\t\tfunction prefsHaveOverrides(prefs) {\n\t\t\t\treturn prefs.show.size > 0 || prefs.hide.size > 0;\n\t\t\t}\n\t\t\tfunction queryRoot(scope) {\n\t\t\t\tif (scope && typeof scope.querySelector === \"function\" && typeof scope.querySelectorAll === \"function\") return scope;\n\t\t\t\treturn document;\n\t\t\t}\n\t\t\tfunction boardLanesRoot(scope) {\n\t\t\t\tif (scope instanceof Element && scope.matches(\"[data-board-lanes]\")) return scope;\n\t\t\t\tif (scope && typeof scope.querySelector === \"function\") return scope.querySelector(\"[data-board-lanes]\");\n\t\t\t\treturn null;\n\t\t\t}\n\t\t\tfunction findByData(scope, attr, value) {\n\t\t\t\tvar root = queryRoot(scope);\n\t\t\t\tvar nodes = root.querySelectorAll(\"[\" + attr + \"]\");\n\t\t\t\tfor (var i = 0; i < nodes.length; i += 1) {\n\t\t\t\t\tif (nodes[i].getAttribute(attr) === value) return nodes[i];\n\t\t\t\t}\n\t\t\t\treturn null;\n\t\t\t}\n\t\t\tfunction laneID(lane) {\n\t\t\t\treturn lane.getAttribute(\"data-board-lane\") || \"\";\n\t\t\t}\n\t\t\tfunction laneDefaultVisible(lane) {\n\t\t\t\treturn lane.getAttribute(\"data-board-lane-default\") === \"true\";\n\t\t\t}\n\t\t\tfunction laneCardCount(lane) {\n\t\t\t\tvar parsed = Number.parseInt(lane.getAttribute(\"data-board-lane-card-count\") || \"0\", 10);\n\t\t\t\tif (!Number.isFinite(parsed) || parsed < 0) return 0;\n\t\t\t\treturn parsed;\n\t\t\t}\n\t\t\tfunction laneTitle(lane) {\n\t\t\t\treturn lane.getAttribute(\"data-board-lane-title\") || \"lane\";\n\t\t\t}\n\t\t\tfunction visibleBoardLanes(root) {\n\t\t\t\treturn Array.from(root.querySelectorAll(\"[data-board-lane]\")).filter(function (lane) {\n\t\t\t\t\treturn lane.getAttribute(\"data-lane-hidden\") !== \"true\";\n\t\t\t\t});\n\t\t\t}\n\t\t\tfunction lanePositionIndex(root, lanes, preferredID) {\n\t\t\t\tif (lanes.length === 0) return -1;\n\t\t\t\tif (preferredID) {\n\t\t\t\t\tvar preferred = lanes.findIndex(function (lane) {\n\t\t\t\t\t\treturn laneID(lane) === preferredID;\n\t\t\t\t\t});\n\t\t\t\t\tif (preferred >= 0) return preferred;\n\t\t\t\t}\n\t\t\t\tif (!root.isConnected) return 0;\n\t\t\t\tvar rootRect = root.getBoundingClientRect();\n\t\t\t\tvar center = rootRect.left + root.clientWidth / 2;\n\t\t\t\tvar nearest = 0;\n\t\t\t\tvar nearestDistance = Number.POSITIVE_INFINITY;\n\t\t\t\tlanes.forEach(function (lane, index) {\n\t\t\t\t\tvar rect = lane.getBoundingClientRect();\n\t\t\t\t\tvar distance = Math.abs(rect.left + rect.width / 2 - center);\n\t\t\t\t\tif (distance < nearestDistance) {\n\t\t\t\t\t\tnearest = index;\n\t\t\t\t\t\tnearestDistance = distance;\n\t\t\t\t\t}\n\t\t\t\t});\n\t\t\t\treturn nearest;\n\t\t\t}\n\t\t\tfunction updateLanePosition(scope, root, preferredID) {\n\t\t\t\tvar lanes = visibleBoardLanes(root);\n\t\t\t\tvar index = lanePositionIndex(root, lanes, preferredID);\n\t\t\t\tvar current = index < 0 ? 0 : index + 1;\n\t\t\t\tvar position = queryRoot(scope).querySelector(\"[data-board-lane-position]\");\n\t\t\t\tif (position) {\n\t\t\t\t\tvar currentNode = position.querySelector(\"[data-board-lane-position-current]\");\n\t\t\t\t\tvar totalNode = position.querySelector(\"[data-board-lane-position-total]\");\n\t\t\t\t\tif (currentNode) currentNode.textContent = String(current);\n\t\t\t\t\tif (totalNode) totalNode.textContent = String(lanes.length);\n\t\t\t\t\tposition.setAttribute(\"aria-label\", \"Lane \" + current + \" of \" + lanes.length);\n\t\t\t\t}\n\t\t\t\tif (root.isConnected && index >= 0) activeLaneID = laneID(lanes[index]);\n\t\t\t}\n\t\t\tfunction scheduleLanePosition(root) {\n\t\t\t\tif (!root || !root.isConnected) return;\n\t\t\t\twindow.cancelAnimationFrame(lanePositionFrame);\n\t\t\t\tlanePositionFrame = window.requestAnimationFrame(function () {\n\t\t\t\t\tupdateLanePosition(document, root, \"\");\n\t\t\t\t});\n\t\t\t}\n\t\t\tfunction formatNumber(value) {\n\t\t\t\treturn new Intl.NumberFormat(\"en-US\").format(value);\n\t\t\t}\n\t\t\tfunction cardCountLabel(count, singular, plural) {\n\t\t\t\treturn formatNumber(count) + \" \" + (count === 1 ? singular : plural);\n\t\t\t}\n\t\t\tfunction laneOverrideState(lane, prefs) {\n\t\t\t\tvar id = laneID(lane);\n\t\t\t\tif (prefs.show.has(id)) return stateShow;\n\t\t\t\tif (prefs.hide.has(id)) return stateHide;\n\t\t\t\treturn stateAuto;\n\t\t\t}\n\t\t\tfunction laneVisible(lane, state) {\n\t\t\t\tif (state === stateShow) return true;\n\t\t\t\tif (state === stateHide) return false;\n\t\t\t\treturn laneDefaultVisible(lane);\n\t\t\t}\n\t\t\tfunction stateLabel(lane, state, visible) {\n\t\t\t\tvar label = \"\";\n\t\t\t\tif (state === stateShow) {\n\t\t\t\t\tlabel = \"Always shown\";\n\t\t\t\t} else if (state === stateHide) {\n\t\t\t\t\tlabel = \"Always hidden\";\n\t\t\t\t} else {\n\t\t\t\t\tlabel = visible ? \"Auto shown\" : \"Auto hidden\";\n\t\t\t\t}\n\t\t\t\tif (!visible && laneCardCount(lane) > 0) {\n\t\t\t\t\treturn label + \" - \" + cardCountLabel(laneCardCount(lane), \"hidden card\", \"hidden cards\");\n\t\t\t\t}\n\t\t\t\treturn label;\n\t\t\t}\n\t\t\tfunction stateTitle(lane, state, visible) {\n\t\t\t\tvar title = \"\";\n\t\t\t\tif (state === stateShow) {\n\t\t\t\t\ttitle = \"Always show is saved for this lane.\";\n\t\t\t\t} else if (state === stateHide) {\n\t\t\t\t\ttitle = \"Always hide is saved for this lane.\";\n\t\t\t\t} else {\n\t\t\t\t\ttitle = \"Auto follows the board default.\";\n\t\t\t\t}\n\t\t\t\tif (!visible && laneCardCount(lane) > 0) {\n\t\t\t\t\treturn title + \" \" + cardCountLabel(laneCardCount(lane), \"card is\", \"cards are\") + \" hidden while this lane is off.\";\n\t\t\t\t}\n\t\t\t\treturn title;\n\t\t\t}\n\t\t\tfunction hiddenLaneSummary(lanes) {\n\t\t\t\tif (lanes.length === 0) return \"All populated lanes are visible.\";\n\t\t\t\tif (lanes.length === 1) {\n\t\t\t\t\tvar lane = lanes[0];\n\t\t\t\t\treturn cardCountLabel(lane.count, \"hidden card\", \"hidden cards\") + \" in \" + lane.title + \".\";\n\t\t\t\t}\n\t\t\t\tvar total = lanes.reduce(function (sum, lane) {\n\t\t\t\t\treturn sum + lane.count;\n\t\t\t\t}, 0);\n\t\t\t\tvar labels = lanes.map(function (lane) {\n\t\t\t\t\treturn lane.title + \" (\" + formatNumber(lane.count) + \")\";\n\t\t\t\t}).join(\", \");\n\t\t\t\treturn cardCountLabel(total, \"hidden card\", \"hidden cards\") + \" across \" + cardCountLabel(lanes.length, \"lane\", \"lanes\") + \": \" + labels + \".\";\n\t\t\t}\n\t\t\tfunction setResetDisabled(button, disabled) {\n\t\t\t\tif (!(button instanceof HTMLButtonElement)) return;\n\t\t\t\tbutton.disabled = disabled;\n\t\t\t\tbutton.setAttribute(\"aria-disabled\", disabled ? \"true\" : \"false\");\n\t\t\t}\n\t\t\tfunction updateLaneControls(scope, lane, state, visible) {\n\t\t\t\tvar id = laneID(lane);\n\t\t\t\tvar row = findByData(scope, \"data-board-lane-row\", id);\n\t\t\t\tvar hiddenPopulated = !visible && laneCardCount(lane) > 0;\n\t\t\t\tif (row instanceof HTMLElement) {\n\t\t\t\t\trow.dataset.boardLaneVisibilityState = state;\n\t\t\t\t\trow.dataset.boardLaneVisibilityEffective = visible ? \"visible\" : \"hidden\";\n\t\t\t\t\trow.dataset.boardLaneHiddenPopulated = hiddenPopulated ? \"true\" : \"false\";\n\t\t\t\t\trow.classList.toggle(\"border-warn/45\", hiddenPopulated);\n\t\t\t\t\trow.classList.toggle(\"bg-warn/10\", hiddenPopulated);\n\t\t\t\t\trow.classList.toggle(\"border-transparent\", !hiddenPopulated);\n\t\t\t\t\tvar status = row.querySelector(\"[data-board-lane-visibility-status]\");\n\t\t\t\t\tif (status) {\n\t\t\t\t\t\tstatus.textContent = stateLabel(lane, state, visible);\n\t\t\t\t\t\tstatus.setAttribute(\"title\", stateTitle(lane, state, visible));\n\t\t\t\t\t}\n\t\t\t\t}\n\t\t\t\tvar select = findByData(scope, \"data-board-lane-visibility\", id);\n\t\t\t\tif (select instanceof HTMLSelectElement) {\n\t\t\t\t\tselect.value = state;\n\t\t\t\t\tselect.dataset.boardLaneVisibilityState = state;\n\t\t\t\t\tselect.dataset.boardLaneVisibilityEffective = visible ? \"visible\" : \"hidden\";\n\t\t\t\t\tselect.setAttribute(\"title\", stateTitle(lane, state, visible));\n\t\t\t\t}\n\t\t\t\tsetResetDisabled(findByData(scope, \"data-board-lane-reset\", id), state === stateAuto);\n\t\t\t}\n\t\t\tfunction updateHiddenCardBadge(scope, hiddenCards, hiddenLanes) {\n\t\t\t\tvar root = queryRoot(scope);\n\t\t\t\tvar badge = root.querySelector(\"[data-board-hidden-card-count]\");\n\t\t\t\tif (!badge) return;\n\t\t\t\tvar summary = hiddenLaneSummary(hiddenLanes);\n\t\t\t\tbadge.hidden = hiddenCards === 0;\n\t\t\t\tbadge.textContent = hiddenCards > 0 ? formatNumber(hiddenCards) + \" hidden\" : \"\";\n\t\t\t\tbadge.setAttribute(\"title\", summary);\n\t\t\t\tbadge.setAttribute(\"aria-label\", summary);\n\t\t\t}\n\t\t\tfunction updateResetAll(scope, prefs) {\n\t\t\t\tqueryRoot(scope).querySelectorAll(\"[data-board-lane-reset-all]\").forEach(function (button) {\n\t\t\t\t\tsetResetDisabled(button, !prefsHaveOverrides(prefs));\n\t\t\t\t});\n\t\t\t}\n\t\t\tfunction applyTo(scope) {\n\t\t\t\tvar root = boardLanesRoot(scope);\n\t\t\t\tif (!root) return false;\n\t\t\t\tvar prefs = readPrefs(root);\n\t\t\t\tvar total = 0;\n\t\t\t\tvar visible = 0;\n\t\t\t\tvar hiddenCards = 0;\n\t\t\t\tvar hiddenLanes = [];\n\t\t\t\troot.querySelectorAll(\"[data-board-lane]\").forEach(function (lane) {\n\t\t\t\t\ttotal += 1;\n\t\t\t\t\tvar state = laneOverrideState(lane, prefs);\n\t\t\t\t\tvar show = laneVisible(lane, state);\n\t\t\t\t\tvar cards = laneCardCount(lane);\n\t\t\t\t\tlane.setAttribute(\"data-lane-hidden\", show ? \"false\" : \"true\");\n\t\t\t\t\tlane.setAttribute(\"data-board-lane-visibility-state\", state);\n\t\t\t\t\tlane.setAttribute(\"data-board-lane-pinned\", state === stateAuto ? \"false\" : \"true\");\n\t\t\t\t\tif (show) {\n\t\t\t\t\t\tvisible += 1;\n\t\t\t\t\t} else if (cards > 0) {\n\t\t\t\t\t\thiddenCards += cards;\n\t\t\t\t\t\thiddenLanes.push({ title: laneTitle(lane), count: cards });\n\t\t\t\t\t}\n\t\t\t\t\tupdateLaneControls(scope, lane, state, show);\n\t\t\t\t});\n\t\t\t\tvar count = queryRoot(scope).querySelector(\"[data-board-lane-count]\");\n\t\t\t\tif (count) count.textContent = visible + \"/\" + total;\n\t\t\t\tupdateHiddenCardBadge(scope, hiddenCards, hiddenLanes);\n\t\t\t\tupdateResetAll(scope, prefs);\n\t\t\t\tvar picker = queryRoot(scope).querySelector(\"[data-board-lane-picker]\");\n\t\t\t\tif (picker && pickerOpen) picker.setAttribute(\"open\", \"\");\n\t\t\t\tupdateLanePosition(scope, root, activeLaneID);\n\t\t\t\tif (root.isConnected) scheduleLanePosition(root);\n\t\t\t\tif (typeof window.__detentBoardKanbanDragAdjustSnapshot === \"function\") {\n\t\t\t\t\twindow.__detentBoardKanbanDragAdjustSnapshot(scope);\n\t\t\t\t}\n\t\t\t\treturn true;\n\t\t\t}\n\t\t\tfunction apply() {\n\t\t\t\tapplyTo(document);\n\t\t\t}\n\t\t\tfunction adjustedBoardHTML(html) {\n\t\t\t\tif (typeof html !== \"string\" || html.indexOf(\"data-board-lanes\") < 0) return \"\";\n\t\t\t\tvar template = document.createElement(\"template\");\n\t\t\t\ttemplate.innerHTML = html;\n\t\t\t\tif (!applyTo(template.content)) return \"\";\n\t\t\t\treturn template.innerHTML;\n\t\t\t}\n\t\t\tfunction snapshotSwapTarget(event) {\n\t\t\t\tvar target = event.detail && event.detail.target;\n\t\t\t\tif (!(target instanceof Element)) target = event.target;\n\t\t\t\tif (!(target instanceof Element)) return false;\n\t\t\t\treturn target.id === \"snapshot\" || Boolean(target.closest(\"#snapshot\"));\n\t\t\t}\n\t\t\tfunction applyBeforeSwap(event) {\n\t\t\t\tvar detail = event.detail || {};\n\t\t\t\tif (!snapshotSwapTarget(event) || typeof detail.serverResponse !== \"string\") return;\n\t\t\t\tvar adjusted = adjustedBoardHTML(detail.serverResponse);\n\t\t\t\tif (!adjusted) return;\n\t\t\t\tdetail.serverResponse = adjusted;\n\t\t\t}\n\t\t\tfunction applyBeforeSSEMessage(event) {\n\t\t\t\tvar detail = event.detail || {};\n\t\t\t\tvar target = detail.elt;\n\t\t\t\tif (!(target instanceof Element)) target = event.target;\n\t\t\t\tif (!(target instanceof Element) || target.id !== \"snapshot\") return;\n\t\t\t\tif (!window.htmx || typeof window.htmx.swap !== \"function\") return;\n\t\t\t\tvar adjusted = adjustedBoardHTML(detail.data);\n\t\t\t\tif (!adjusted) return;\n\t\t\t\tevent.preventDefault();\n\t\t\t\twindow.htmx.swap(target, adjusted, { swapStyle: target.getAttribute(\"hx-swap\") || \"innerHTML\" }, { contextElement: target });\n\t\t\t}\n\t\t\tfunction setLaneState(root, id, state) {\n\t\t\t\tvar prefs = readPrefs(root);\n\t\t\t\tprefs.show.delete(id);\n\t\t\t\tprefs.hide.delete(id);\n\t\t\t\tif (state === stateShow) prefs.show.add(id);\n\t\t\t\tif (state === stateHide) prefs.hide.add(id);\n\t\t\t\twritePrefs(root, prefs);\n\t\t\t\tapply();\n\t\t\t}\n\t\t\tdocument.addEventListener(\"change\", function (event) {\n\t\t\t\tvar target = event.target instanceof Element ? event.target : null;\n\t\t\t\tvar select = target ? target.closest(\"[data-board-lane-visibility]\") : null;\n\t\t\t\tif (!(select instanceof HTMLSelectElement)) return;\n\t\t\t\tvar root = document.querySelector(\"[data-board-lanes]\");\n\t\t\t\tif (!root) return;\n\t\t\t\tvar state = select.value;\n\t\t\t\tif (state !== stateShow && state !== stateHide) state = stateAuto;\n\t\t\t\tsetLaneState(root, select.getAttribute(\"data-board-lane-visibility\") || \"\", state);\n\t\t\t});\n\t\t\tdocument.addEventListener(\"toggle\", function (event) {\n\t\t\t\tvar picker = event.target;\n\t\t\t\tif (picker instanceof Element && picker.hasAttribute(\"data-board-lane-picker\")) {\n\t\t\t\t\tpickerOpen = picker.open;\n\t\t\t\t}\n\t\t\t}, true);\n\t\t\tdocument.addEventListener(\"click\", function (event) {\n\t\t\t\tvar target = event.target instanceof Element ? event.target : null;\n\t\t\t\tvar root = document.querySelector(\"[data-board-lanes]\");\n\t\t\t\tvar reset = target ? target.closest(\"[data-board-lane-reset]\") : null;\n\t\t\t\tif (reset instanceof HTMLButtonElement && root) {\n\t\t\t\t\tevent.preventDefault();\n\t\t\t\t\tsetLaneState(root, reset.value || reset.getAttribute(\"data-board-lane-reset\") || \"\", stateAuto);\n\t\t\t\t\treturn;\n\t\t\t\t}\n\t\t\t\tvar resetAll = target ? target.closest(\"[data-board-lane-reset-all]\") : null;\n\t\t\t\tif (resetAll instanceof HTMLButtonElement && root) {\n\t\t\t\t\tevent.preventDefault();\n\t\t\t\t\twritePrefs(root, emptyPrefs());\n\t\t\t\t\tapply();\n\t\t\t\t\treturn;\n\t\t\t\t}\n\t\t\t\tvar picker = document.querySelector(\"[data-board-lane-picker]\");\n\t\t\t\tif (picker && picker.open && !picker.contains(event.target)) {\n\t\t\t\t\tpicker.removeAttribute(\"open\");\n\t\t\t\t\tpickerOpen = false;\n\t\t\t\t}\n\t\t\t});\n\t\t\tdocument.addEventListener(\"keydown\", function (event) {\n\t\t\t\tif (event.key !== \"Escape\") return;\n\t\t\t\tvar picker = document.querySelector(\"[data-board-lane-picker]\");\n\t\t\t\tif (picker && picker.open) {\n\t\t\t\t\tpicker.removeAttribute(\"open\");\n\t\t\t\t\tpickerOpen = false;\n\t\t\t\t}\n\t\t\t});\n\t\t\tdocument.addEventListener(\"htmx:beforeSwap\", applyBeforeSwap);\n\t\t\tdocument.addEventListener(\"htmx:sseBeforeMessage\", applyBeforeSSEMessage);\n\t\t\tdocument.addEventListener(\"htmx:afterSettle\", apply);\n\t\t\tdocument.addEventListener(\"DOMContentLoaded\", apply);\n\t\t\tdocument.addEventListener(\"scroll\", function (event) {\n\t\t\t\tvar root = event.target instanceof Element && event.target.matches(\"[data-board-lanes]\") ? event.target : null;\n\t\t\t\tif (root) scheduleLanePosition(root);\n\t\t\t}, true);\n\t\t\twindow.addEventListener(\"resize\", function () {\n\t\t\t\tscheduleLanePosition(document.querySelector(\"[data-board-lanes]\"));\n\t\t\t});\n\t\t\twindow.addEventListener(\"storage\", function (event) {\n\t\t\t\tif (event.key && event.key.indexOf(storagePrefix) === 0) apply();\n\t\t\t});\n\t\t\tapply();\n\t\t})();\n\t</script>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 271, "<script>\n\t\t(function () {\n\t\t\tvar storagePrefix = \"detent.ui.board.lanes.v2.\";\n\t\t\tvar legacyStoragePrefix = \"detent.ui.board.lanes.\";\n\t\t\tvar storageVersion = 1;\n\t\t\tvar stateAuto = \"auto\";\n\t\t\tvar stateShow = \"show\";\n\t\t\tvar stateHide = \"hide\";\n\t\t\tvar pickerOpen = false;\n\t\t\tvar activeLaneID = \"\";\n\t\t\tvar lanePositionFrame = 0;\n\n\t\t\tfunction visibilityStorage() {\n\t\t\t\ttry {\n\t\t\t\t\treturn window.localStorage;\n\t\t\t\t} catch (err) {\n\t\t\t\t\treturn null;\n\t\t\t\t}\n\t\t\t}\n\t\t\tfunction storageKey(root) {\n\t\t\t\treturn storagePrefix + (root.getAttribute(\"data-board-key\") || \"fleet\");\n\t\t\t}\n\t\t\tfunction legacyStorageKey(root) {\n\t\t\t\treturn legacyStoragePrefix + (root.getAttribute(\"data-board-key\") || \"fleet\");\n\t\t\t}\n\t\t\tfunction emptyPrefs() {\n\t\t\t\treturn { show: new Set(), hide: new Set() };\n\t\t\t}\n\t\t\tfunction laneIDSet(ids) {\n\t\t\t\tvar out = new Set();\n\t\t\t\tif (!Array.isArray(ids)) return out;\n\t\t\t\tids.forEach(function (id) {\n\t\t\t\t\tif (typeof id === \"string\" && id.trim() !== \"\") out.add(id);\n\t\t\t\t});\n\t\t\t\treturn out;\n\t\t\t}\n\t\t\tfunction normalizedPrefs(showIDs, hideIDs) {\n\t\t\t\tvar prefs = emptyPrefs();\n\t\t\t\tlaneIDSet(showIDs).forEach(function (id) {\n\t\t\t\t\tprefs.show.add(id);\n\t\t\t\t});\n\t\t\t\tlaneIDSet(hideIDs).forEach(function (id) {\n\t\t\t\t\tif (!prefs.show.has(id)) prefs.hide.add(id);\n\t\t\t\t});\n\t\t\t\treturn prefs;\n\t\t\t}\n\t\t\tfunction discardLegacyPrefs(root, store) {\n\t\t\t\tvar legacy = legacyStorageKey(root);\n\t\t\t\ttry {\n\t\t\t\t\tif (legacy !== storageKey(root)) store.removeItem(legacy);\n\t\t\t\t} catch (err) {}\n\t\t\t}\n\t\t\tfunction readPrefs(root) {\n\t\t\t\tvar store = visibilityStorage();\n\t\t\t\tif (!store) return emptyPrefs();\n\t\t\t\tdiscardLegacyPrefs(root, store);\n\t\t\t\tvar raw = \"\";\n\t\t\t\ttry {\n\t\t\t\t\traw = store.getItem(storageKey(root));\n\t\t\t\t} catch (err) {\n\t\t\t\t\treturn emptyPrefs();\n\t\t\t\t}\n\t\t\t\tif (!raw) return emptyPrefs();\n\t\t\t\ttry {\n\t\t\t\t\tvar parsed = JSON.parse(raw);\n\t\t\t\t\tif (!parsed || parsed.v !== storageVersion) {\n\t\t\t\t\t\ttry {\n\t\t\t\t\t\t\tstore.removeItem(storageKey(root));\n\t\t\t\t\t\t} catch (err) {}\n\t\t\t\t\t\treturn emptyPrefs();\n\t\t\t\t\t}\n\t\t\t\t\treturn normalizedPrefs(parsed.show, parsed.hide);\n\t\t\t\t} catch (err) {\n\t\t\t\t\ttry {\n\t\t\t\t\t\tstore.removeItem(storageKey(root));\n\t\t\t\t\t} catch (err) {}\n\t\t\t\t\treturn emptyPrefs();\n\t\t\t\t}\n\t\t\t}\n\t\t\tfunction writePrefs(root, prefs) {\n\t\t\t\tvar store = visibilityStorage();\n\t\t\t\tif (!store) return;\n\t\t\t\tvar show = Array.from(prefs.show).filter(Boolean).sort();\n\t\t\t\tvar hide = Array.from(prefs.hide).filter(function (id) {\n\t\t\t\t\treturn Boolean(id) && !prefs.show.has(id);\n\t\t\t\t}).sort();\n\t\t\t\tif (show.length === 0 && hide.length === 0) {\n\t\t\t\t\ttry {\n\t\t\t\t\t\tstore.removeItem(storageKey(root));\n\t\t\t\t\t} catch (err) {}\n\t\t\t\t\treturn;\n\t\t\t\t}\n\t\t\t\ttry {\n\t\t\t\t\tstore.setItem(storageKey(root), JSON.stringify({ v: storageVersion, show: show, hide: hide }));\n\t\t\t\t} catch (err) {}\n\t\t\t}\n\t\t\tfunction prefsHaveOverrides(prefs) {\n\t\t\t\treturn prefs.show.size > 0 || prefs.hide.size > 0;\n\t\t\t}\n\t\t\tfunction queryRoot(scope) {\n\t\t\t\tif (scope && typeof scope.querySelector === \"function\" && typeof scope.querySelectorAll === \"function\") return scope;\n\t\t\t\treturn document;\n\t\t\t}\n\t\t\tfunction boardLanesRoot(scope) {\n\t\t\t\tif (scope instanceof Element && scope.matches(\"[data-board-lanes]\")) return scope;\n\t\t\t\tif (scope && typeof scope.querySelector === \"function\") return scope.querySelector(\"[data-board-lanes]\");\n\t\t\t\treturn null;\n\t\t\t}\n\t\t\tfunction findByData(scope, attr, value) {\n\t\t\t\tvar root = queryRoot(scope);\n\t\t\t\tvar nodes = root.querySelectorAll(\"[\" + attr + \"]\");\n\t\t\t\tfor (var i = 0; i < nodes.length; i += 1) {\n\t\t\t\t\tif (nodes[i].getAttribute(attr) === value) return nodes[i];\n\t\t\t\t}\n\t\t\t\treturn null;\n\t\t\t}\n\t\t\tfunction laneID(lane) {\n\t\t\t\treturn lane.getAttribute(\"data-board-lane\") || \"\";\n\t\t\t}\n\t\t\tfunction laneDefaultVisible(lane) {\n\t\t\t\treturn lane.getAttribute(\"data-board-lane-default\") === \"true\";\n\t\t\t}\n\t\t\tfunction laneCardCount(lane) {\n\t\t\t\tvar parsed = Number.parseInt(lane.getAttribute(\"data-board-lane-card-count\") || \"0\", 10);\n\t\t\t\tif (!Number.isFinite(parsed) || parsed < 0) return 0;\n\t\t\t\treturn parsed;\n\t\t\t}\n\t\t\tfunction laneTitle(lane) {\n\t\t\t\treturn lane.getAttribute(\"data-board-lane-title\") || \"lane\";\n\t\t\t}\n\t\t\tfunction visibleBoardLanes(root) {\n\t\t\t\treturn Array.from(root.querySelectorAll(\"[data-board-lane]\")).filter(function (lane) {\n\t\t\t\t\treturn lane.getAttribute(\"data-lane-hidden\") !== \"true\";\n\t\t\t\t});\n\t\t\t}\n\t\t\tfunction lanePositionIndex(root, lanes, preferredID) {\n\t\t\t\tif (lanes.length === 0) return -1;\n\t\t\t\tif (preferredID) {\n\t\t\t\t\tvar preferred = lanes.findIndex(function (lane) {\n\t\t\t\t\t\treturn laneID(lane) === preferredID;\n\t\t\t\t\t});\n\t\t\t\t\tif (preferred >= 0) return preferred;\n\t\t\t\t}\n\t\t\t\tif (!root.isConnected) return 0;\n\t\t\t\tvar rootRect = root.getBoundingClientRect();\n\t\t\t\tvar center = rootRect.left + root.clientWidth / 2;\n\t\t\t\tvar nearest = 0;\n\t\t\t\tvar nearestDistance = Number.POSITIVE_INFINITY;\n\t\t\t\tlanes.forEach(function (lane, index) {\n\t\t\t\t\tvar rect = lane.getBoundingClientRect();\n\t\t\t\t\tvar distance = Math.abs(rect.left + rect.width / 2 - center);\n\t\t\t\t\tif (distance < nearestDistance) {\n\t\t\t\t\t\tnearest = index;\n\t\t\t\t\t\tnearestDistance = distance;\n\t\t\t\t\t}\n\t\t\t\t});\n\t\t\t\treturn nearest;\n\t\t\t}\n\t\t\tfunction updateLanePosition(scope, root, preferredID) {\n\t\t\t\tvar lanes = visibleBoardLanes(root);\n\t\t\t\tvar index = lanePositionIndex(root, lanes, preferredID);\n\t\t\t\tvar current = index < 0 ? 0 : index + 1;\n\t\t\t\tvar position = queryRoot(scope).querySelector(\"[data-board-lane-position]\");\n\t\t\t\tif (position) {\n\t\t\t\t\tvar currentNode = position.querySelector(\"[data-board-lane-position-current]\");\n\t\t\t\t\tvar totalNode = position.querySelector(\"[data-board-lane-position-total]\");\n\t\t\t\t\tif (currentNode) currentNode.textContent = String(current);\n\t\t\t\t\tif (totalNode) totalNode.textContent = String(lanes.length);\n\t\t\t\t\tposition.setAttribute(\"aria-label\", \"Lane \" + current + \" of \" + lanes.length);\n\t\t\t\t}\n\t\t\t\tif (root.isConnected && index >= 0) activeLaneID = laneID(lanes[index]);\n\t\t\t}\n\t\t\tfunction scheduleLanePosition(root) {\n\t\t\t\tif (!root || !root.isConnected) return;\n\t\t\t\twindow.cancelAnimationFrame(lanePositionFrame);\n\t\t\t\tlanePositionFrame = window.requestAnimationFrame(function () {\n\t\t\t\t\tupdateLanePosition(document, root, \"\");\n\t\t\t\t});\n\t\t\t}\n\t\t\tfunction formatNumber(value) {\n\t\t\t\treturn new Intl.NumberFormat(\"en-US\").format(value);\n\t\t\t}\n\t\t\tfunction cardCountLabel(count, singular, plural) {\n\t\t\t\treturn formatNumber(count) + \" \" + (count === 1 ? singular : plural);\n\t\t\t}\n\t\t\tfunction laneOverrideState(lane, prefs) {\n\t\t\t\tvar id = laneID(lane);\n\t\t\t\tif (prefs.show.has(id)) return stateShow;\n\t\t\t\tif (prefs.hide.has(id)) return stateHide;\n\t\t\t\treturn stateAuto;\n\t\t\t}\n\t\t\tfunction laneVisible(lane, state) {\n\t\t\t\tif (state === stateShow) return true;\n\t\t\t\tif (state === stateHide) return false;\n\t\t\t\treturn laneDefaultVisible(lane);\n\t\t\t}\n\t\t\tfunction stateLabel(lane, state, visible) {\n\t\t\t\tvar label = \"\";\n\t\t\t\tif (state === stateShow) {\n\t\t\t\t\tlabel = \"Always shown\";\n\t\t\t\t} else if (state === stateHide) {\n\t\t\t\t\tlabel = \"Always hidden\";\n\t\t\t\t} else {\n\t\t\t\t\tlabel = visible ? \"Auto shown\" : \"Auto hidden\";\n\t\t\t\t}\n\t\t\t\tif (!visible && laneCardCount(lane) > 0) {\n\t\t\t\t\treturn label + \" - \" + cardCountLabel(laneCardCount(lane), \"hidden card\", \"hidden cards\");\n\t\t\t\t}\n\t\t\t\treturn label;\n\t\t\t}\n\t\t\tfunction stateTitle(lane, state, visible) {\n\t\t\t\tvar title = \"\";\n\t\t\t\tif (state === stateShow) {\n\t\t\t\t\ttitle = \"Always show is saved for this lane.\";\n\t\t\t\t} else if (state === stateHide) {\n\t\t\t\t\ttitle = \"Always hide is saved for this lane.\";\n\t\t\t\t} else {\n\t\t\t\t\ttitle = \"Auto follows the board default.\";\n\t\t\t\t}\n\t\t\t\tif (!visible && laneCardCount(lane) > 0) {\n\t\t\t\t\treturn title + \" \" + cardCountLabel(laneCardCount(lane), \"card is\", \"cards are\") + \" hidden while this lane is off.\";\n\t\t\t\t}\n\t\t\t\treturn title;\n\t\t\t}\n\t\t\tfunction hiddenLaneSummary(lanes) {\n\t\t\t\tif (lanes.length === 0) return \"All populated lanes are visible.\";\n\t\t\t\tif (lanes.length === 1) {\n\t\t\t\t\tvar lane = lanes[0];\n\t\t\t\t\treturn cardCountLabel(lane.count, \"hidden card\", \"hidden cards\") + \" in \" + lane.title + \".\";\n\t\t\t\t}\n\t\t\t\tvar total = lanes.reduce(function (sum, lane) {\n\t\t\t\t\treturn sum + lane.count;\n\t\t\t\t}, 0);\n\t\t\t\tvar labels = lanes.map(function (lane) {\n\t\t\t\t\treturn lane.title + \" (\" + formatNumber(lane.count) + \")\";\n\t\t\t\t}).join(\", \");\n\t\t\t\treturn cardCountLabel(total, \"hidden card\", \"hidden cards\") + \" across \" + cardCountLabel(lanes.length, \"lane\", \"lanes\") + \": \" + labels + \".\";\n\t\t\t}\n\t\t\tfunction setResetDisabled(button, disabled) {\n\t\t\t\tif (!(button instanceof HTMLButtonElement)) return;\n\t\t\t\tbutton.disabled = disabled;\n\t\t\t\tbutton.setAttribute(\"aria-disabled\", disabled ? \"true\" : \"false\");\n\t\t\t}\n\t\t\tfunction updateLaneControls(scope, lane, state, visible) {\n\t\t\t\tvar id = laneID(lane);\n\t\t\t\tvar row = findByData(scope, \"data-board-lane-row\", id);\n\t\t\t\tvar hiddenPopulated = !visible && laneCardCount(lane) > 0;\n\t\t\t\tif (row instanceof HTMLElement) {\n\t\t\t\t\trow.dataset.boardLaneVisibilityState = state;\n\t\t\t\t\trow.dataset.boardLaneVisibilityEffective = visible ? \"visible\" : \"hidden\";\n\t\t\t\t\trow.dataset.boardLaneHiddenPopulated = hiddenPopulated ? \"true\" : \"false\";\n\t\t\t\t\trow.classList.toggle(\"border-warn/45\", hiddenPopulated);\n\t\t\t\t\trow.classList.toggle(\"bg-warn/10\", hiddenPopulated);\n\t\t\t\t\trow.classList.toggle(\"border-transparent\", !hiddenPopulated);\n\t\t\t\t\tvar status = row.querySelector(\"[data-board-lane-visibility-status]\");\n\t\t\t\t\tif (status) {\n\t\t\t\t\t\tstatus.textContent = stateLabel(lane, state, visible);\n\t\t\t\t\t\tstatus.setAttribute(\"title\", stateTitle(lane, state, visible));\n\t\t\t\t\t}\n\t\t\t\t}\n\t\t\t\tvar select = findByData(scope, \"data-board-lane-visibility\", id);\n\t\t\t\tif (select instanceof HTMLSelectElement) {\n\t\t\t\t\tselect.value = state;\n\t\t\t\t\tselect.dataset.boardLaneVisibilityState = state;\n\t\t\t\t\tselect.dataset.boardLaneVisibilityEffective = visible ? \"visible\" : \"hidden\";\n\t\t\t\t\tselect.setAttribute(\"title\", stateTitle(lane, state, visible));\n\t\t\t\t}\n\t\t\t\tsetResetDisabled(findByData(scope, \"data-board-lane-reset\", id), state === stateAuto);\n\t\t\t}\n\t\t\tfunction updateHiddenCardBadge(scope, hiddenCards, hiddenLanes) {\n\t\t\t\tvar root = queryRoot(scope);\n\t\t\t\tvar badge = root.querySelector(\"[data-board-hidden-card-count]\");\n\t\t\t\tif (!badge) return;\n\t\t\t\tvar summary = hiddenLaneSummary(hiddenLanes);\n\t\t\t\tbadge.hidden = hiddenCards === 0;\n\t\t\t\tbadge.textContent = hiddenCards > 0 ? formatNumber(hiddenCards) + \" hidden\" : \"\";\n\t\t\t\tbadge.setAttribute(\"title\", summary);\n\t\t\t\tbadge.setAttribute(\"aria-label\", summary);\n\t\t\t}\n\t\t\tfunction updateResetAll(scope, prefs) {\n\t\t\t\tqueryRoot(scope).querySelectorAll(\"[data-board-lane-reset-all]\").forEach(function (button) {\n\t\t\t\t\tsetResetDisabled(button, !prefsHaveOverrides(prefs));\n\t\t\t\t});\n\t\t\t}\n\t\t\tfunction applyTo(scope) {\n\t\t\t\tvar root = boardLanesRoot(scope);\n\t\t\t\tif (!root) return false;\n\t\t\t\tvar prefs = readPrefs(root);\n\t\t\t\tvar total = 0;\n\t\t\t\tvar visible = 0;\n\t\t\t\tvar hiddenCards = 0;\n\t\t\t\tvar hiddenLanes = [];\n\t\t\t\troot.querySelectorAll(\"[data-board-lane]\").forEach(function (lane) {\n\t\t\t\t\ttotal += 1;\n\t\t\t\t\tvar state = laneOverrideState(lane, prefs);\n\t\t\t\t\tvar show = laneVisible(lane, state);\n\t\t\t\t\tvar cards = laneCardCount(lane);\n\t\t\t\t\tlane.setAttribute(\"data-lane-hidden\", show ? \"false\" : \"true\");\n\t\t\t\t\tlane.setAttribute(\"data-board-lane-visibility-state\", state);\n\t\t\t\t\tlane.setAttribute(\"data-board-lane-pinned\", state === stateAuto ? \"false\" : \"true\");\n\t\t\t\t\tif (show) {\n\t\t\t\t\t\tvisible += 1;\n\t\t\t\t\t} else if (cards > 0) {\n\t\t\t\t\t\thiddenCards += cards;\n\t\t\t\t\t\thiddenLanes.push({ title: laneTitle(lane), count: cards });\n\t\t\t\t\t}\n\t\t\t\t\tupdateLaneControls(scope, lane, state, show);\n\t\t\t\t});\n\t\t\t\tvar count = queryRoot(scope).querySelector(\"[data-board-lane-count]\");\n\t\t\t\tif (count) count.textContent = visible + \"/\" + total;\n\t\t\t\tupdateHiddenCardBadge(scope, hiddenCards, hiddenLanes);\n\t\t\t\tupdateResetAll(scope, prefs);\n\t\t\t\tvar picker = queryRoot(scope).querySelector(\"[data-board-lane-picker]\");\n\t\t\t\tif (picker && pickerOpen) picker.setAttribute(\"open\", \"\");\n\t\t\t\tupdateLanePosition(scope, root, activeLaneID);\n\t\t\t\tif (root.isConnected) scheduleLanePosition(root);\n\t\t\t\tif (typeof window.__detentBoardKanbanDragAdjustSnapshot === \"function\") {\n\t\t\t\t\twindow.__detentBoardKanbanDragAdjustSnapshot(scope);\n\t\t\t\t}\n\t\t\t\treturn true;\n\t\t\t}\n\t\t\tfunction apply() {\n\t\t\t\tapplyTo(document);\n\t\t\t}\n\t\t\tfunction adjustedBoardHTML(html) {\n\t\t\t\tif (typeof html !== \"string\" || html.indexOf(\"data-board-lanes\") < 0) return \"\";\n\t\t\t\tvar template = document.createElement(\"template\");\n\t\t\t\ttemplate.innerHTML = html;\n\t\t\t\tif (!applyTo(template.content)) return \"\";\n\t\t\t\treturn template.innerHTML;\n\t\t\t}\n\t\t\tfunction snapshotSwapTarget(event) {\n\t\t\t\tvar target = event.detail && event.detail.target;\n\t\t\t\tif (!(target instanceof Element)) target = event.target;\n\t\t\t\tif (!(target instanceof Element)) return false;\n\t\t\t\treturn target.id === \"snapshot\" || Boolean(target.closest(\"#snapshot\"));\n\t\t\t}\n\t\t\tfunction applyBeforeSwap(event) {\n\t\t\t\tvar detail = event.detail || {};\n\t\t\t\tif (!snapshotSwapTarget(event) || typeof detail.serverResponse !== \"string\") return;\n\t\t\t\tvar adjusted = adjustedBoardHTML(detail.serverResponse);\n\t\t\t\tif (!adjusted) return;\n\t\t\t\tdetail.serverResponse = adjusted;\n\t\t\t}\n\t\t\tfunction applyBeforeSSEMessage(event) {\n\t\t\t\tvar detail = event.detail || {};\n\t\t\t\tvar target = detail.elt;\n\t\t\t\tif (!(target instanceof Element)) target = event.target;\n\t\t\t\tif (!(target instanceof Element) || target.id !== \"snapshot\") return;\n\t\t\t\tif (!window.htmx || typeof window.htmx.swap !== \"function\") return;\n\t\t\t\tvar adjusted = adjustedBoardHTML(detail.data);\n\t\t\t\tif (!adjusted) return;\n\t\t\t\tevent.preventDefault();\n\t\t\t\twindow.htmx.swap(target, adjusted, { swapStyle: target.getAttribute(\"hx-swap\") || \"innerHTML\" }, { contextElement: target });\n\t\t\t}\n\t\t\tfunction setLaneState(root, id, state) {\n\t\t\t\tvar prefs = readPrefs(root);\n\t\t\t\tprefs.show.delete(id);\n\t\t\t\tprefs.hide.delete(id);\n\t\t\t\tif (state === stateShow) prefs.show.add(id);\n\t\t\t\tif (state === stateHide) prefs.hide.add(id);\n\t\t\t\twritePrefs(root, prefs);\n\t\t\t\tapply();\n\t\t\t}\n\t\t\tdocument.addEventListener(\"change\", function (event) {\n\t\t\t\tvar target = event.target instanceof Element ? event.target : null;\n\t\t\t\tvar select = target ? target.closest(\"[data-board-lane-visibility]\") : null;\n\t\t\t\tif (!(select instanceof HTMLSelectElement)) return;\n\t\t\t\tvar root = document.querySelector(\"[data-board-lanes]\");\n\t\t\t\tif (!root) return;\n\t\t\t\tvar state = select.value;\n\t\t\t\tif (state !== stateShow && state !== stateHide) state = stateAuto;\n\t\t\t\tsetLaneState(root, select.getAttribute(\"data-board-lane-visibility\") || \"\", state);\n\t\t\t});\n\t\t\tdocument.addEventListener(\"toggle\", function (event) {\n\t\t\t\tvar picker = event.target;\n\t\t\t\tif (picker instanceof Element && picker.hasAttribute(\"data-board-lane-picker\")) {\n\t\t\t\t\tpickerOpen = picker.open;\n\t\t\t\t}\n\t\t\t}, true);\n\t\t\tdocument.addEventListener(\"click\", function (event) {\n\t\t\t\tvar target = event.target instanceof Element ? event.target : null;\n\t\t\t\tvar root = document.querySelector(\"[data-board-lanes]\");\n\t\t\t\tvar reset = target ? target.closest(\"[data-board-lane-reset]\") : null;\n\t\t\t\tif (reset instanceof HTMLButtonElement && root) {\n\t\t\t\t\tevent.preventDefault();\n\t\t\t\t\tsetLaneState(root, reset.value || reset.getAttribute(\"data-board-lane-reset\") || \"\", stateAuto);\n\t\t\t\t\treturn;\n\t\t\t\t}\n\t\t\t\tvar resetAll = target ? target.closest(\"[data-board-lane-reset-all]\") : null;\n\t\t\t\tif (resetAll instanceof HTMLButtonElement && root) {\n\t\t\t\t\tevent.preventDefault();\n\t\t\t\t\twritePrefs(root, emptyPrefs());\n\t\t\t\t\tapply();\n\t\t\t\t\treturn;\n\t\t\t\t}\n\t\t\t\tvar picker = document.querySelector(\"[data-board-lane-picker]\");\n\t\t\t\tif (picker && picker.open && !picker.contains(event.target)) {\n\t\t\t\t\tpicker.removeAttribute(\"open\");\n\t\t\t\t\tpickerOpen = false;\n\t\t\t\t}\n\t\t\t});\n\t\t\tdocument.addEventListener(\"keydown\", function (event) {\n\t\t\t\tif (event.key !== \"Escape\") return;\n\t\t\t\tvar picker = document.querySelector(\"[data-board-lane-picker]\");\n\t\t\t\tif (picker && picker.open) {\n\t\t\t\t\tpicker.removeAttribute(\"open\");\n\t\t\t\t\tpickerOpen = false;\n\t\t\t\t}\n\t\t\t});\n\t\t\tdocument.addEventListener(\"htmx:beforeSwap\", applyBeforeSwap);\n\t\t\tdocument.addEventListener(\"htmx:sseBeforeMessage\", applyBeforeSSEMessage);\n\t\t\tdocument.addEventListener(\"htmx:afterSettle\", apply);\n\t\t\tdocument.addEventListener(\"DOMContentLoaded\", apply);\n\t\t\tdocument.addEventListener(\"scroll\", function (event) {\n\t\t\t\tvar root = event.target instanceof Element && event.target.matches(\"[data-board-lanes]\") ? event.target : null;\n\t\t\t\tif (root) scheduleLanePosition(root);\n\t\t\t}, true);\n\t\t\twindow.addEventListener(\"resize\", function () {\n\t\t\t\tscheduleLanePosition(document.querySelector(\"[data-board-lanes]\"));\n\t\t\t});\n\t\t\twindow.addEventListener(\"storage\", function (event) {\n\t\t\t\tif (event.key && event.key.indexOf(storagePrefix) === 0) apply();\n\t\t\t});\n\t\t\tapply();\n\t\t})();\n\t</script>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -3025,12 +3184,12 @@ func boardKanbanDragScript() templ.Component {
 			}()
 		}
 		ctx = templ.InitializeContext(ctx)
-		templ_7745c5c3_Var162 := templ.GetChildren(ctx)
-		if templ_7745c5c3_Var162 == nil {
-			templ_7745c5c3_Var162 = templ.NopComponent
+		templ_7745c5c3_Var171 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var171 == nil {
+			templ_7745c5c3_Var171 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 255, "<script>\n\t\t(function () {\n\t\t\tif (window.__detentBoardKanbanDragHandlersRegistered) return;\n\t\t\twindow.__detentBoardKanbanDragHandlersRegistered = true;\n\t\t\tvar DRAG_THRESHOLD_PX = 6;\n\t\t\tvar TOUCH_MOVE_TOLERANCE_PX = 10;\n\t\t\tvar TOUCH_LONG_PRESS_MS = 450;\n\t\t\tvar TOUCH_EDGE_ZONE_PX = 56;\n\t\t\tvar TOUCH_EDGE_ADVANCE_MS = 500;\n\t\t\t// Real mouse clicks travel a few pixels between press and release,\n\t\t\t// so distance alone cannot separate a click from a drag. A short\n\t\t\t// gesture released back over the source lane is a click: finish the\n\t\t\t// drag without swallowing the click so the detail sheet still opens.\n\t\t\tvar CLICK_GESTURE_MS = 250;\n\t\t\tvar draggedIssueID = \"\";\n\t\t\tvar draggedAllowedTargetKeys = [];\n\t\t\tvar pending = null;\n\t\t\tvar active = null;\n\t\t\tvar recentTouchStart = null;\n\t\t\tfunction connectionAllowsMoves() {\n\t\t\t\treturn document.documentElement.getAttribute(\"data-detent-connection\") === \"connected\";\n\t\t\t}\n\t\t\tfunction clearPending() {\n\t\t\t\tif (pending && pending.longPressTimer) window.clearTimeout(pending.longPressTimer);\n\t\t\t\tpending = null;\n\t\t\t\trecentTouchStart = null;\n\t\t\t}\n\t\t\tfunction touchWithIdentifier(touches, identifier) {\n\t\t\t\tif (!touches || identifier === null || identifier === undefined) return null;\n\t\t\t\tfor (var index = 0; index < touches.length; index += 1) {\n\t\t\t\t\tif (touches[index].identifier === identifier) return touches[index];\n\t\t\t\t}\n\t\t\t\treturn null;\n\t\t\t}\n\t\t\tfunction recentTouchIdentifier(card, event) {\n\t\t\t\tif (event.pointerType !== \"touch\" || !recentTouchStart) return null;\n\t\t\t\tif (Date.now() - recentTouchStart.startedAt >= 100) return null;\n\t\t\t\tif (!(recentTouchStart.target instanceof Node) || !card.contains(recentTouchStart.target)) return null;\n\t\t\t\treturn recentTouchStart.identifier;\n\t\t\t}\n\t\t\tfunction feedback(message, kind) {\n\t\t\t\tvar target = document.getElementById(\"board-feedback\");\n\t\t\t\tif (!target) return;\n\t\t\t\tvar text = String(message || \"\").trim();\n\t\t\t\ttarget.className = \"flex flex-none items-center gap-2 px-5 pt-3.5 text-xs \" + (kind === \"error\" ? \"text-err\" : \"text-sec\");\n\t\t\t\ttarget.textContent = text;\n\t\t\t\ttarget.hidden = text === \"\";\n\t\t\t}\n\t\t\tfunction queryRoot(scope) {\n\t\t\t\tif (scope && typeof scope.querySelector === \"function\" && typeof scope.querySelectorAll === \"function\") return scope;\n\t\t\t\treturn document;\n\t\t\t}\n\t\t\tfunction draggedCard(scope) {\n\t\t\t\tif (!draggedIssueID || !window.CSS || typeof CSS.escape !== \"function\") return null;\n\t\t\t\treturn queryRoot(scope).querySelector(\"[data-kanban-card][data-kanban-issue-id='\" + CSS.escape(draggedIssueID) + \"']\");\n\t\t\t}\n\t\t\tfunction cardByIssueID(scope, issueID) {\n\t\t\t\tvar cards = queryRoot(scope).querySelectorAll(\"[data-kanban-card][data-kanban-issue-id]\");\n\t\t\t\tfor (var index = 0; index < cards.length; index += 1) {\n\t\t\t\t\tif (cards[index].dataset.kanbanIssueId === issueID) return cards[index];\n\t\t\t\t}\n\t\t\t\treturn null;\n\t\t\t}\n\t\t\tfunction laneByState(scope, state) {\n\t\t\t\tvar lanes = queryRoot(scope).querySelectorAll(\"[data-kanban-drop-state]\");\n\t\t\t\tfor (var index = 0; index < lanes.length; index += 1) {\n\t\t\t\t\tif (lanes[index].dataset.kanbanDropState === state) return lanes[index];\n\t\t\t\t}\n\t\t\t\treturn null;\n\t\t\t}\n\t\t\tfunction cardContainer(lane) {\n\t\t\t\treturn lane instanceof HTMLElement ? lane.querySelector(\"[data-kanban-card-container]\") : null;\n\t\t\t}\n\t\t\tfunction updateEmptyLine(container) {\n\t\t\t\tif (!(container instanceof HTMLElement)) return;\n\t\t\t\tvar emptyLine = container.querySelector(\"[data-kanban-empty-line]\");\n\t\t\t\tif (emptyLine instanceof HTMLElement) emptyLine.hidden = Boolean(container.querySelector(\"[data-kanban-card]\"));\n\t\t\t}\n\t\t\tfunction placeCardInLane(card, state, scope) {\n\t\t\t\tvar lane = laneByState(scope, state);\n\t\t\t\tvar container = cardContainer(lane);\n\t\t\t\tif (!(card instanceof HTMLElement) || !(lane instanceof HTMLElement) || !(container instanceof HTMLElement)) return null;\n\t\t\t\tvar previousContainer = card.parentElement;\n\t\t\t\tcontainer.appendChild(card);\n\t\t\t\tlane.dataset.laneHidden = \"false\";\n\t\t\t\tupdateEmptyLine(previousContainer);\n\t\t\t\tupdateEmptyLine(container);\n\t\t\t\treturn lane;\n\t\t\t}\n\t\t\tfunction copyPendingMove(source, target) {\n\t\t\t\t[\n\t\t\t\t\t\"kanbanPendingMove\",\n\t\t\t\t\t\"kanbanPendingOrigin\",\n\t\t\t\t\t\"kanbanPendingSeq\",\n\t\t\t\t\t\"kanbanPendingTargetWasHidden\"\n\t\t\t\t].forEach(function (key) {\n\t\t\t\t\tif (source.dataset[key] === undefined) {\n\t\t\t\t\t\tdelete target.dataset[key];\n\t\t\t\t\t} else {\n\t\t\t\t\t\ttarget.dataset[key] = source.dataset[key];\n\t\t\t\t\t}\n\t\t\t\t});\n\t\t\t}\n\t\t\tfunction clearPendingMove(card) {\n\t\t\t\tif (!(card instanceof HTMLElement)) return;\n\t\t\t\tdelete card.dataset.kanbanPendingMove;\n\t\t\t\tdelete card.dataset.kanbanPendingOrigin;\n\t\t\t\tdelete card.dataset.kanbanPendingSeq;\n\t\t\t\tdelete card.dataset.kanbanPendingTargetWasHidden;\n\t\t\t}\n\t\t\tfunction pendingMoveSuperseded(liveCard, serverCard) {\n\t\t\t\tvar targetState = liveCard.dataset.kanbanPendingMove || \"\";\n\t\t\t\tif ((serverCard.dataset.kanbanCurrentState || \"\") === targetState) return true;\n\t\t\t\tvar pendingSeq = Number.parseInt(liveCard.dataset.kanbanPendingSeq || \"\", 10);\n\t\t\t\tvar serverSeq = Number.parseInt(serverCard.dataset.kanbanDataSeq || \"\", 10);\n\t\t\t\treturn Number.isFinite(pendingSeq) && Number.isFinite(serverSeq) && serverSeq > pendingSeq;\n\t\t\t}\n\t\t\tfunction applyPendingMoveState(scope) {\n\t\t\t\tvar root = queryRoot(scope);\n\t\t\t\tvar applied = false;\n\t\t\t\tdocument.querySelectorAll(\"#snapshot [data-kanban-card][data-kanban-pending-move]\").forEach(function (liveCard) {\n\t\t\t\t\tif (!(liveCard instanceof HTMLElement)) return;\n\t\t\t\t\tvar issueID = liveCard.dataset.kanbanIssueId || \"\";\n\t\t\t\t\tvar serverCard = cardByIssueID(root, issueID);\n\t\t\t\t\tif (!(serverCard instanceof HTMLElement)) return;\n\t\t\t\t\tif (pendingMoveSuperseded(liveCard, serverCard)) {\n\t\t\t\t\t\tif (serverCard === liveCard) clearPendingMove(serverCard);\n\t\t\t\t\t\treturn;\n\t\t\t\t\t}\n\t\t\t\t\tcopyPendingMove(liveCard, serverCard);\n\t\t\t\t\tif (placeCardInLane(serverCard, liveCard.dataset.kanbanPendingMove || \"\", root)) applied = true;\n\t\t\t\t});\n\t\t\t\treturn applied;\n\t\t\t}\n\t\t\tfunction targetKeysFromValue(value) {\n\t\t\t\treturn String(value || \"\").split(/\\s+/).filter(Boolean);\n\t\t\t}\n\t\t\tfunction allowedTargetKeys(card) {\n\t\t\t\tif (card instanceof HTMLElement) {\n\t\t\t\t\tvar keys = targetKeysFromValue(card.dataset.kanbanAllowedTargets || \"\");\n\t\t\t\t\tif (keys.length > 0) return keys;\n\t\t\t\t}\n\t\t\t\treturn draggedAllowedTargetKeys.slice();\n\t\t\t}\n\t\t\tfunction laneAllowed(card, lane) {\n\t\t\t\tif (!(lane instanceof HTMLElement)) return false;\n\t\t\t\tvar key = lane.dataset.kanbanDropKey || \"\";\n\t\t\t\treturn key !== \"\" && allowedTargetKeys(card).includes(key);\n\t\t\t}\n\t\t\tfunction setDropTargetState(card, scope) {\n\t\t\t\tvar sourceLane = card instanceof HTMLElement ? card.closest(\"[data-kanban-drop-state]\") : null;\n\t\t\t\tqueryRoot(scope).querySelectorAll(\"[data-kanban-drop-state]\").forEach(function (lane) {\n\t\t\t\t\tif (!(lane instanceof HTMLElement)) return;\n\t\t\t\t\tif (lane.dataset.kanbanDropWasHidden === undefined) {\n\t\t\t\t\t\tlane.dataset.kanbanDropWasHidden = lane.dataset.laneHidden || \"false\";\n\t\t\t\t\t}\n\t\t\t\t\tlane.dataset.laneHidden = \"false\";\n\t\t\t\t\tif (lane === sourceLane) {\n\t\t\t\t\t\t// The origin lane is not a transition target, but styling\n\t\t\t\t\t\t// it blocked reads as an error; mark it as the source so\n\t\t\t\t\t\t// the operator can see where the card came from.\n\t\t\t\t\t\tlane.dataset.kanbanDropSource = \"true\";\n\t\t\t\t\t\tdelete lane.dataset.kanbanDropAllowed;\n\t\t\t\t\t\tlane.removeAttribute(\"aria-disabled\");\n\t\t\t\t\t\treturn;\n\t\t\t\t\t}\n\t\t\t\t\tdelete lane.dataset.kanbanDropSource;\n\t\t\t\t\tvar allowed = laneAllowed(card, lane);\n\t\t\t\t\tlane.dataset.kanbanDropAllowed = allowed ? \"true\" : \"false\";\n\t\t\t\t\tlane.setAttribute(\"aria-disabled\", allowed ? \"false\" : \"true\");\n\t\t\t\t});\n\t\t\t}\n\t\t\tfunction applyActiveDragState(scope) {\n\t\t\t\tif (!draggedIssueID || draggedAllowedTargetKeys.length === 0) return false;\n\t\t\t\tvar root = queryRoot(scope);\n\t\t\t\tvar card = draggedCard(root);\n\t\t\t\tif (card instanceof HTMLElement) card.dataset.kanbanDragging = \"true\";\n\t\t\t\tsetDropTargetState(card, root);\n\t\t\t\tapplyTouchDragStyles(card, root);\n\t\t\t\treturn true;\n\t\t\t}\n\t\t\tfunction applyDragState(scope) {\n\t\t\t\tvar pendingApplied = applyPendingMoveState(scope);\n\t\t\t\treturn applyActiveDragState(scope) || pendingApplied;\n\t\t\t}\n\t\t\twindow.__detentBoardKanbanDragAdjustSnapshot = applyDragState;\n\t\t\tfunction clearDropTargetState() {\n\t\t\t\tdocument.querySelectorAll(\"[data-kanban-drop-state]\").forEach(function (lane) {\n\t\t\t\t\tif (!(lane instanceof HTMLElement)) return;\n\t\t\t\t\tif (lane.dataset.kanbanDropWasHidden !== undefined) {\n\t\t\t\t\t\tlane.dataset.laneHidden = lane.dataset.kanbanDropWasHidden;\n\t\t\t\t\t\tdelete lane.dataset.kanbanDropWasHidden;\n\t\t\t\t\t}\n\t\t\t\t\tdelete lane.dataset.kanbanDropAllowed;\n\t\t\t\t\tdelete lane.dataset.kanbanDropSource;\n\t\t\t\t\tlane.removeAttribute(\"aria-disabled\");\n\t\t\t\t});\n\t\t\t\tdocument.querySelectorAll(\"[data-kanban-card][data-kanban-dragging='true']\").forEach(function (card) {\n\t\t\t\t\tif (card instanceof HTMLElement) delete card.dataset.kanbanDragging;\n\t\t\t\t});\n\t\t\t}\n\t\t\tfunction responseMessage(response) {\n\t\t\t\tif (!response) return \"\";\n\t\t\t\tvar doc = new DOMParser().parseFromString(response, \"text/html\");\n\t\t\t\treturn (doc.body.textContent || \"\").trim();\n\t\t\t}\n\t\t\tfunction buildGhost(card, rect) {\n\t\t\t\tvar ghost = card.cloneNode(true);\n\t\t\t\tghost.removeAttribute(\"id\");\n\t\t\t\tghost.querySelectorAll(\"[id]\").forEach(function (node) {\n\t\t\t\t\tnode.removeAttribute(\"id\");\n\t\t\t\t});\n\t\t\t\tvar form = ghost.querySelector(\"[data-kanban-drag-move-form]\");\n\t\t\t\tif (form) form.remove();\n\t\t\t\tdelete ghost.dataset.kanbanDragging;\n\t\t\t\tvar origin = document.createElement(\"div\");\n\t\t\t\torigin.className = \"mb-1.5 flex items-center gap-1.5 border-b border-line pb-1.5 font-mono text-2xs font-medium text-accent\";\n\t\t\t\torigin.textContent = \"From \" + (card.dataset.kanbanCurrentState || \"current lane\");\n\t\t\t\tghost.insertBefore(origin, ghost.firstChild);\n\t\t\t\tghost.setAttribute(\"aria-hidden\", \"true\");\n\t\t\t\tghost.style.position = \"fixed\";\n\t\t\t\tghost.style.left = \"0\";\n\t\t\t\tghost.style.top = \"0\";\n\t\t\t\tghost.style.margin = \"0\";\n\t\t\t\tghost.style.width = rect.width + \"px\";\n\t\t\t\tghost.style.height = rect.height + \"px\";\n\t\t\t\tghost.style.pointerEvents = \"none\";\n\t\t\t\tghost.style.zIndex = \"1000\";\n\t\t\t\tghost.style.opacity = \"0.9\";\n\t\t\t\tghost.style.boxShadow = \"0 12px 32px rgba(0, 0, 0, 0.35)\";\n\t\t\t\tghost.style.willChange = \"transform\";\n\t\t\t\tdocument.body.appendChild(ghost);\n\t\t\t\treturn ghost;\n\t\t\t}\n\t\t\tfunction moveGhost(ghost, x, y, offsetX, offsetY) {\n\t\t\t\tghost.style.transform = \"translate(\" + Math.round(x - offsetX) + \"px, \" + Math.round(y - offsetY) + \"px)\";\n\t\t\t}\n\t\t\tfunction laneFromPoint(x, y) {\n\t\t\t\tvar hit = document.elementFromPoint(x, y);\n\t\t\t\treturn hit instanceof Element ? hit.closest(\"[data-kanban-drop-state]\") : null;\n\t\t\t}\n\t\t\tfunction applyTouchStyle(element, styles) {\n\t\t\t\tif (!active || active.pointerType !== \"touch\" || !(element instanceof HTMLElement) || !element.isConnected) return;\n\t\t\t\tif (!active.touchStyles.has(element)) {\n\t\t\t\t\tvar original = {};\n\t\t\t\t\tObject.keys(styles).forEach(function (property) {\n\t\t\t\t\t\toriginal[property] = element.style[property];\n\t\t\t\t\t});\n\t\t\t\t\tactive.touchStyles.set(element, original);\n\t\t\t\t}\n\t\t\t\tObject.keys(styles).forEach(function (property) {\n\t\t\t\t\telement.style[property] = styles[property];\n\t\t\t\t});\n\t\t\t}\n\t\t\tfunction applyTouchDragStyles(card, scope) {\n\t\t\t\tif (!active || active.pointerType !== \"touch\") return;\n\t\t\t\tvar root = queryRoot(scope);\n\t\t\t\tvar lanes = root.querySelector(\"[data-board-lanes]\");\n\t\t\t\tapplyTouchStyle(lanes, { touchAction: \"none\", scrollSnapType: \"none\" });\n\t\t\t\tapplyTouchStyle(card, {\n\t\t\t\t\ttouchAction: \"none\",\n\t\t\t\t\toutline: \"2px solid var(--color-accent)\",\n\t\t\t\t\toutlineOffset: \"2px\"\n\t\t\t\t});\n\t\t\t}\n\t\t\tfunction restoreTouchDragStyles() {\n\t\t\t\tif (!active || !active.touchStyles) return;\n\t\t\t\tactive.touchStyles.forEach(function (styles, element) {\n\t\t\t\t\tObject.keys(styles).forEach(function (property) {\n\t\t\t\t\t\telement.style[property] = styles[property];\n\t\t\t\t\t});\n\t\t\t\t});\n\t\t\t\tactive.touchStyles.clear();\n\t\t\t}\n\t\t\t// Native drags auto-scrolled the lane strip at the viewport edges;\n\t\t\t// pointer drags must do it themselves. Scrolls only while the\n\t\t\t// pointer moves, which is enough to reach off-screen lanes.\n\t\t\tfunction autoScrollLanes(x) {\n\t\t\t\tvar lanes = document.getElementById(\"board-lanes\");\n\t\t\t\tif (!lanes) return;\n\t\t\t\tvar rect = lanes.getBoundingClientRect();\n\t\t\t\tif (x < rect.left + 48) {\n\t\t\t\t\tlanes.scrollLeft -= 16;\n\t\t\t\t} else if (x > rect.right - 48) {\n\t\t\t\t\tlanes.scrollLeft += 16;\n\t\t\t\t}\n\t\t\t}\n\t\t\tfunction visibleDropLanes(lanes) {\n\t\t\t\treturn Array.from(lanes.querySelectorAll(\"[data-kanban-drop-state]\")).filter(function (lane) {\n\t\t\t\t\treturn lane instanceof HTMLElement && lane.dataset.laneHidden !== \"true\";\n\t\t\t\t});\n\t\t\t}\n\t\t\tfunction closestLaneIndex(lanes, laneNodes) {\n\t\t\t\tvar center = lanes.getBoundingClientRect().left + lanes.clientWidth / 2;\n\t\t\t\tvar closest = 0;\n\t\t\t\tvar distance = Infinity;\n\t\t\t\tlaneNodes.forEach(function (lane, index) {\n\t\t\t\t\tvar rect = lane.getBoundingClientRect();\n\t\t\t\t\tvar candidate = Math.abs(rect.left + rect.width / 2 - center);\n\t\t\t\t\tif (candidate < distance) {\n\t\t\t\t\t\tdistance = candidate;\n\t\t\t\t\t\tclosest = index;\n\t\t\t\t\t}\n\t\t\t\t});\n\t\t\t\treturn closest;\n\t\t\t}\n\t\t\tfunction advanceTouchLane(direction) {\n\t\t\t\tif (!active || active.pointerType !== \"touch\" || active.edgeDirection !== direction) return;\n\t\t\t\tactive.edgeTimer = null;\n\t\t\t\tvar lanes = document.getElementById(\"board-lanes\");\n\t\t\t\tif (!lanes) return;\n\t\t\t\tvar laneNodes = visibleDropLanes(lanes);\n\t\t\t\tif (laneNodes.length === 0) return;\n\t\t\t\tvar current = closestLaneIndex(lanes, laneNodes);\n\t\t\t\tvar target = Math.max(0, Math.min(laneNodes.length - 1, current + direction));\n\t\t\t\tif (target !== current) {\n\t\t\t\t\tlaneNodes[target].scrollIntoView({ behavior: \"smooth\", block: \"nearest\", inline: \"start\" });\n\t\t\t\t}\n\t\t\t\tif (active && active.edgeDirection === direction && target !== current) {\n\t\t\t\t\tactive.edgeTimer = window.setTimeout(function () {\n\t\t\t\t\t\tadvanceTouchLane(direction);\n\t\t\t\t\t}, TOUCH_EDGE_ADVANCE_MS);\n\t\t\t\t}\n\t\t\t}\n\t\t\tfunction updateTouchEdgeAdvance(x) {\n\t\t\t\tif (!active || active.pointerType !== \"touch\") return;\n\t\t\t\tvar lanes = document.getElementById(\"board-lanes\");\n\t\t\t\tif (!lanes) return;\n\t\t\t\tvar rect = lanes.getBoundingClientRect();\n\t\t\t\tvar direction = x < rect.left + TOUCH_EDGE_ZONE_PX ? -1 : (x > rect.right - TOUCH_EDGE_ZONE_PX ? 1 : 0);\n\t\t\t\tif (direction === active.edgeDirection) return;\n\t\t\t\tif (active.edgeTimer) window.clearTimeout(active.edgeTimer);\n\t\t\t\tactive.edgeDirection = direction;\n\t\t\t\tactive.edgeTimer = direction === 0 ? null : window.setTimeout(function () {\n\t\t\t\t\tadvanceTouchLane(direction);\n\t\t\t\t}, TOUCH_EDGE_ADVANCE_MS);\n\t\t\t}\n\t\t\tfunction stopTouchEdgeAdvance() {\n\t\t\t\tif (!active) return;\n\t\t\t\tif (active.edgeTimer) window.clearTimeout(active.edgeTimer);\n\t\t\t\tactive.edgeTimer = null;\n\t\t\t\tactive.edgeDirection = 0;\n\t\t\t}\n\t\t\tfunction suppressNextClick() {\n\t\t\t\tvar until = Date.now() + 400;\n\t\t\t\tdocument.addEventListener(\"click\", function suppress(event) {\n\t\t\t\t\tdocument.removeEventListener(\"click\", suppress, true);\n\t\t\t\t\tif (Date.now() > until) return;\n\t\t\t\t\tevent.preventDefault();\n\t\t\t\t\tevent.stopImmediatePropagation();\n\t\t\t\t}, true);\n\t\t\t}\n\t\t\tfunction beginDrag(event) {\n\t\t\t\tvar press = pending;\n\t\t\t\tif (!press) return;\n\t\t\t\tif (press.longPressTimer) window.clearTimeout(press.longPressTimer);\n\t\t\t\tdraggedIssueID = press.issueID;\n\t\t\t\tdraggedAllowedTargetKeys = press.targets;\n\t\t\t\tvar card = draggedCard(document) || press.card;\n\t\t\t\tactive = {\n\t\t\t\t\tpointerId: press.pointerId,\n\t\t\t\t\tpointerType: press.pointerType,\n\t\t\t\t\ttouchIdentifier: press.touchIdentifier,\n\t\t\t\t\toffsetX: press.startX - press.rect.left,\n\t\t\t\t\toffsetY: press.startY - press.rect.top,\n\t\t\t\t\tghost: buildGhost(card, press.rect),\n\t\t\t\t\tlastLaneBlocked: false,\n\t\t\t\t\tstartedAt: press.startedAt,\n\t\t\t\t\tcaptureElement: press.card,\n\t\t\t\t\ttouchStyles: new Map(),\n\t\t\t\t\tedgeDirection: 0,\n\t\t\t\t\tedgeTimer: null\n\t\t\t\t};\n\t\t\t\tpending = null;\n\t\t\t\trecentTouchStart = null;\n\t\t\t\tif (active.pointerType === \"touch\" && typeof active.captureElement.setPointerCapture === \"function\") {\n\t\t\t\t\ttry {\n\t\t\t\t\t\tactive.captureElement.setPointerCapture(active.pointerId);\n\t\t\t\t\t} catch (_) {}\n\t\t\t\t}\n\t\t\t\tcard.dataset.kanbanDragging = \"true\";\n\t\t\t\tsetDropTargetState(card, document);\n\t\t\t\tapplyTouchDragStyles(card, document);\n\t\t\t\tfeedback(\"Moving \" + (card.dataset.kanbanCurrentState || \"card\") + \".\");\n\t\t\t\tmoveGhost(active.ghost, event.clientX, event.clientY, active.offsetX, active.offsetY);\n\t\t\t}\n\t\t\tfunction finishDrag(keepClick) {\n\t\t\t\tif (active) {\n\t\t\t\t\tstopTouchEdgeAdvance();\n\t\t\t\t\trestoreTouchDragStyles();\n\t\t\t\t\tif (active.ghost) active.ghost.remove();\n\t\t\t\t\tif (active.captureElement && typeof active.captureElement.releasePointerCapture === \"function\") {\n\t\t\t\t\t\ttry {\n\t\t\t\t\t\t\tif (active.captureElement.hasPointerCapture(active.pointerId)) active.captureElement.releasePointerCapture(active.pointerId);\n\t\t\t\t\t\t} catch (_) {}\n\t\t\t\t\t}\n\t\t\t\t}\n\t\t\t\tclearPending();\n\t\t\t\tactive = null;\n\t\t\t\tdraggedIssueID = \"\";\n\t\t\t\tdraggedAllowedTargetKeys = [];\n\t\t\t\tclearDropTargetState();\n\t\t\t\t// A drag ends with the pointer still over a card, so the release\n\t\t\t\t// also fires a click; swallow it or the detail sheet opens.\n\t\t\t\tif (!keepClick) suppressNextClick();\n\t\t\t}\n\t\t\tfunction cancelDrag(keepClick) {\n\t\t\t\tif (!active) {\n\t\t\t\t\tclearPending();\n\t\t\t\t\treturn;\n\t\t\t\t}\n\t\t\t\tfinishDrag(keepClick);\n\t\t\t\tfeedback(\"Move cancelled.\", \"error\");\n\t\t\t}\n\t\t\tfunction rollbackPendingMove(card) {\n\t\t\t\tif (!(card instanceof HTMLElement) || !card.dataset.kanbanPendingMove) return;\n\t\t\t\tvar targetLane = card.closest(\"[data-kanban-drop-state]\");\n\t\t\t\tvar targetWasHidden = card.dataset.kanbanPendingTargetWasHidden === \"true\";\n\t\t\t\tvar originState = card.dataset.kanbanPendingOrigin || \"\";\n\t\t\t\tclearPendingMove(card);\n\t\t\t\tplaceCardInLane(card, originState, document);\n\t\t\t\tif (targetLane instanceof HTMLElement) {\n\t\t\t\t\ttargetLane.dataset.laneHidden = targetWasHidden ? \"true\" : \"false\";\n\t\t\t\t\tupdateEmptyLine(cardContainer(targetLane));\n\t\t\t\t}\n\t\t\t}\n\t\t\tfunction moveDragTo(x, y) {\n\t\t\t\tif (!active) return;\n\t\t\t\tmoveGhost(active.ghost, x, y, active.offsetX, active.offsetY);\n\t\t\t\tif (active.pointerType === \"touch\") {\n\t\t\t\t\tupdateTouchEdgeAdvance(x);\n\t\t\t\t} else {\n\t\t\t\t\tautoScrollLanes(x);\n\t\t\t\t}\n\t\t\t\tvar lane = laneFromPoint(x, y);\n\t\t\t\tvar card = draggedCard(document);\n\t\t\t\tvar blocked = lane instanceof HTMLElement && lane.dataset.kanbanDropSource !== \"true\" && !laneAllowed(card, lane);\n\t\t\t\tif (blocked && !active.lastLaneBlocked) {\n\t\t\t\t\tfeedback(\"Move blocked by transition policy.\", \"error\");\n\t\t\t\t} else if (!blocked && active.lastLaneBlocked) {\n\t\t\t\t\tfeedback(\"Moving \" + ((card && card.dataset.kanbanCurrentState) || \"card\") + \".\");\n\t\t\t\t}\n\t\t\t\tactive.lastLaneBlocked = blocked;\n\t\t\t}\n\t\t\tdocument.addEventListener(\"pointerdown\", function (event) {\n\t\t\t\tif (active || event.button !== 0 || event.isPrimary === false) return;\n\t\t\t\tvar pressedElement = event.target instanceof Element ? event.target : null;\n\t\t\t\tvar pressedCard = pressedElement ? pressedElement.closest(\"[data-kanban-card]\") : null;\n\t\t\t\tif (pressedCard && !connectionAllowsMoves()) {\n\t\t\t\t\tif (pressedElement.closest(\"a, button, input, select, textarea, summary, label, [data-help-trigger]\")) return;\n\t\t\t\t\tfeedback(\"Moves are disabled while the board reconnects. Reload if the connection does not recover.\", \"error\");\n\t\t\t\t\treturn;\n\t\t\t\t}\n\t\t\t\tif (pressedCard && pressedCard.dataset.kanbanMoveDisabled === \"true\") {\n\t\t\t\t\tif (pressedElement.closest(\"a, button, input, select, textarea, summary, label, [data-help-trigger]\")) return;\n\t\t\t\t\tfeedback(pressedCard.dataset.kanbanMoveDisabledReason || \"This card cannot be moved.\", \"error\");\n\t\t\t\t\treturn;\n\t\t\t\t}\n\t\t\t\tvar card = pressedCard && pressedCard.dataset.kanbanAction === \"move\" ? pressedCard : null;\n\t\t\t\tif (!card) return;\n\t\t\t\tif (card.dataset.kanbanPendingMove) return;\n\t\t\t\tvar issueID = card.dataset.kanbanIssueId || \"\";\n\t\t\t\tif (!issueID) return;\n\t\t\t\tpending = {\n\t\t\t\t\tpointerId: event.pointerId,\n\t\t\t\t\tpointerType: event.pointerType,\n\t\t\t\t\ttouchIdentifier: recentTouchIdentifier(card, event),\n\t\t\t\t\tcard: card,\n\t\t\t\t\tissueID: issueID,\n\t\t\t\t\ttargets: targetKeysFromValue(card.dataset.kanbanAllowedTargets || \"\"),\n\t\t\t\t\trect: card.getBoundingClientRect(),\n\t\t\t\t\tstartX: event.clientX,\n\t\t\t\t\tstartY: event.clientY,\n\t\t\t\t\tlastX: event.clientX,\n\t\t\t\t\tlastY: event.clientY,\n\t\t\t\t\tstartedAt: Date.now(),\n\t\t\t\t\tlongPressTimer: null\n\t\t\t\t};\n\t\t\t\tif (event.pointerType === \"touch\") {\n\t\t\t\t\tvar pointerId = event.pointerId;\n\t\t\t\t\tpending.longPressTimer = window.setTimeout(function () {\n\t\t\t\t\t\tif (!pending || pending.pointerId !== pointerId) return;\n\t\t\t\t\t\tbeginDrag({ clientX: pending.lastX, clientY: pending.lastY });\n\t\t\t\t\t}, TOUCH_LONG_PRESS_MS);\n\t\t\t\t}\n\t\t\t});\n\t\t\tdocument.addEventListener(\"touchstart\", function (event) {\n\t\t\t\tif (active || !event.changedTouches || event.changedTouches.length === 0) return;\n\t\t\t\tvar touch = event.changedTouches[0];\n\t\t\t\trecentTouchStart = {\n\t\t\t\t\tidentifier: touch.identifier,\n\t\t\t\t\ttarget: event.target,\n\t\t\t\t\tstartedAt: Date.now()\n\t\t\t\t};\n\t\t\t\tif (pending && pending.pointerType === \"touch\" && event.target instanceof Node && pending.card.contains(event.target)) {\n\t\t\t\t\tpending.touchIdentifier = touch.identifier;\n\t\t\t\t}\n\t\t\t});\n\t\t\tdocument.addEventListener(\"pointermove\", function (event) {\n\t\t\t\tif (pending && event.pointerId === pending.pointerId) {\n\t\t\t\t\tif (pending.pointerType === \"touch\") {\n\t\t\t\t\t\tif (Math.hypot(event.clientX - pending.startX, event.clientY - pending.startY) >= TOUCH_MOVE_TOLERANCE_PX) {\n\t\t\t\t\t\t\tclearPending();\n\t\t\t\t\t\t\treturn;\n\t\t\t\t\t\t}\n\t\t\t\t\t\tpending.lastX = event.clientX;\n\t\t\t\t\t\tpending.lastY = event.clientY;\n\t\t\t\t\t\treturn;\n\t\t\t\t\t}\n\t\t\t\t\t// A missed pointerup (released outside the window) must not\n\t\t\t\t\t// leave a stale press that turns a later hover into a drag.\n\t\t\t\t\tif (event.buttons === 0) {\n\t\t\t\t\t\tclearPending();\n\t\t\t\t\t\treturn;\n\t\t\t\t\t}\n\t\t\t\t\tif (Math.hypot(event.clientX - pending.startX, event.clientY - pending.startY) < DRAG_THRESHOLD_PX) return;\n\t\t\t\t\tbeginDrag(event);\n\t\t\t\t\treturn;\n\t\t\t\t}\n\t\t\t\tif (!active || event.pointerId !== active.pointerId) return;\n\t\t\t\tif (active.pointerType !== \"touch\" && event.buttons === 0) {\n\t\t\t\t\t// The release happened outside the window, so no click is\n\t\t\t\t\t// coming — cancelling must not arm the click suppressor or\n\t\t\t\t\t// it would eat the next real click after recovery.\n\t\t\t\t\tcancelDrag(true);\n\t\t\t\t\treturn;\n\t\t\t\t}\n\t\t\t\tevent.preventDefault();\n\t\t\t\tmoveDragTo(event.clientX, event.clientY);\n\t\t\t}, { passive: false });\n\t\t\tfunction dropAt(x, y) {\n\t\t\t\tif (!active) return;\n\t\t\t\tif (!connectionAllowsMoves()) {\n\t\t\t\t\tcancelDrag();\n\t\t\t\t\tfeedback(\"Move cancelled because the board connection was lost.\", \"error\");\n\t\t\t\t\treturn;\n\t\t\t\t}\n\t\t\t\tvar lane = laneFromPoint(x, y);\n\t\t\t\tvar card = draggedCard(document);\n\t\t\t\tif (!(lane instanceof HTMLElement)) {\n\t\t\t\t\tcancelDrag();\n\t\t\t\t\treturn;\n\t\t\t\t}\n\t\t\t\tif (lane.dataset.kanbanDropSource === \"true\") {\n\t\t\t\t\tif (Date.now() - active.startedAt < CLICK_GESTURE_MS) {\n\t\t\t\t\t\tfinishDrag(true);\n\t\t\t\t\t\tfeedback(\"\");\n\t\t\t\t\t\treturn;\n\t\t\t\t\t}\n\t\t\t\t\tcancelDrag();\n\t\t\t\t\treturn;\n\t\t\t\t}\n\t\t\t\tif (!laneAllowed(card, lane)) {\n\t\t\t\t\tfinishDrag();\n\t\t\t\t\tfeedback(\"Move blocked by transition policy.\", \"error\");\n\t\t\t\t\treturn;\n\t\t\t\t}\n\t\t\t\tvar form = card ? card.querySelector(\"[data-kanban-drag-move-form]\") : null;\n\t\t\t\tvar targetState = form ? form.querySelector(\"[data-kanban-drag-target-state]\") : null;\n\t\t\t\tif (!(form instanceof HTMLFormElement) || !(targetState instanceof HTMLInputElement)) {\n\t\t\t\t\tcancelDrag();\n\t\t\t\t\treturn;\n\t\t\t\t}\n\t\t\t\ttargetState.value = lane.dataset.kanbanDropState || \"\";\n\t\t\t\tcard.dataset.kanbanPendingMove = targetState.value;\n\t\t\t\tcard.dataset.kanbanPendingOrigin = card.dataset.kanbanCurrentState || \"\";\n\t\t\t\tif (card.dataset.kanbanDataSeq) card.dataset.kanbanPendingSeq = card.dataset.kanbanDataSeq;\n\t\t\t\tcard.dataset.kanbanPendingTargetWasHidden = lane.dataset.kanbanDropWasHidden || lane.dataset.laneHidden || \"false\";\n\t\t\t\tplaceCardInLane(card, targetState.value, document);\n\t\t\t\tfinishDrag();\n\t\t\t\tplaceCardInLane(card, targetState.value, document);\n\t\t\t\tform.requestSubmit();\n\t\t\t}\n\t\t\tdocument.addEventListener(\"pointerup\", function (event) {\n\t\t\t\tif (pending && event.pointerId === pending.pointerId) {\n\t\t\t\t\tclearPending();\n\t\t\t\t\treturn;\n\t\t\t\t}\n\t\t\t\tif (!active || event.pointerId !== active.pointerId) return;\n\t\t\t\tdropAt(event.clientX, event.clientY);\n\t\t\t});\n\t\t\tdocument.addEventListener(\"pointercancel\", function (event) {\n\t\t\t\tif (pending && event.pointerId === pending.pointerId) {\n\t\t\t\t\tclearPending();\n\t\t\t\t\treturn;\n\t\t\t\t}\n\t\t\t\tif (active && event.pointerId === active.pointerId && active.pointerType !== \"touch\") cancelDrag();\n\t\t\t});\n\t\t\tdocument.addEventListener(\"touchmove\", function (event) {\n\t\t\t\tif (!active || active.pointerType !== \"touch\") return;\n\t\t\t\tevent.preventDefault();\n\t\t\t\tvar touch = touchWithIdentifier(event.touches, active.touchIdentifier);\n\t\t\t\tif (!touch && active.touchIdentifier === null && event.touches && event.touches.length === 1) touch = event.touches[0];\n\t\t\t\tif (touch) moveDragTo(touch.clientX, touch.clientY);\n\t\t\t}, { passive: false });\n\t\t\tdocument.addEventListener(\"touchend\", function (event) {\n\t\t\t\tif (pending && pending.pointerType === \"touch\") {\n\t\t\t\t\tvar pendingTouch = touchWithIdentifier(event.changedTouches, pending.touchIdentifier);\n\t\t\t\t\tif (!pendingTouch && !(pending.touchIdentifier === null && event.touches && event.touches.length === 0)) return;\n\t\t\t\t\tclearPending();\n\t\t\t\t\treturn;\n\t\t\t\t}\n\t\t\t\tif (!active || active.pointerType !== \"touch\") return;\n\t\t\t\tvar touch = touchWithIdentifier(event.changedTouches, active.touchIdentifier);\n\t\t\t\tif (!touch && active.touchIdentifier === null && event.touches && event.touches.length === 0) touch = event.changedTouches && event.changedTouches[0];\n\t\t\t\tif (touch) dropAt(touch.clientX, touch.clientY);\n\t\t\t});\n\t\t\tdocument.addEventListener(\"touchcancel\", function (event) {\n\t\t\t\tif (pending && pending.pointerType === \"touch\") {\n\t\t\t\t\tvar pendingTouch = touchWithIdentifier(event.changedTouches, pending.touchIdentifier);\n\t\t\t\t\tif (!pendingTouch && !(pending.touchIdentifier === null && event.touches && event.touches.length === 0)) return;\n\t\t\t\t\tclearPending();\n\t\t\t\t\treturn;\n\t\t\t\t}\n\t\t\t\tif (!active || active.pointerType !== \"touch\") return;\n\t\t\t\tvar touch = touchWithIdentifier(event.changedTouches, active.touchIdentifier);\n\t\t\t\tif (touch || (active.touchIdentifier === null && event.touches && event.touches.length === 0)) cancelDrag();\n\t\t\t});\n\t\t\tdocument.addEventListener(\"contextmenu\", function (event) {\n\t\t\t\tvar touchPress = pending && pending.pointerType === \"touch\";\n\t\t\t\tvar touchDrag = active && active.pointerType === \"touch\";\n\t\t\t\tif ((touchPress || touchDrag) && event.target instanceof Element && event.target.closest(\"[data-kanban-card]\")) {\n\t\t\t\t\tevent.preventDefault();\n\t\t\t\t}\n\t\t\t});\n\t\t\tdocument.addEventListener(\"keydown\", function (event) {\n\t\t\t\tif (event.key === \"Escape\" && active) cancelDrag();\n\t\t\t});\n\t\t\tdocument.addEventListener(\"detent:connectionChange\", function (event) {\n\t\t\t\tif (!event.detail || event.detail.state === \"connected\") return;\n\t\t\t\tif (active) cancelDrag();\n\t\t\t\telse clearPending();\n\t\t\t});\n\t\t\twindow.addEventListener(\"blur\", function () {\n\t\t\t\tif (active) cancelDrag();\n\t\t\t});\n\t\t\t// Native HTML5 drags stay disabled inside cards (links, images):\n\t\t\t// they would start a compositor drag session that steals the pointer.\n\t\t\tdocument.addEventListener(\"dragstart\", function (event) {\n\t\t\t\tif (event.target instanceof Element && event.target.closest(\"[data-kanban-card]\")) {\n\t\t\t\t\tevent.preventDefault();\n\t\t\t\t}\n\t\t\t});\n\t\t\tdocument.addEventListener(\"htmx:afterSettle\", function () {\n\t\t\t\tapplyDragState(document);\n\t\t\t});\n\t\t\tfunction handleMoveError(event) {\n\t\t\t\tvar form = event.detail && event.detail.elt;\n\t\t\t\tif (!(form instanceof HTMLFormElement) || !form.matches(\"[data-kanban-drag-move-form]\")) return;\n\t\t\t\tvar issueIDInput = form.querySelector(\"input[name='issue_id']\");\n\t\t\t\tvar issueID = issueIDInput instanceof HTMLInputElement ? issueIDInput.value : \"\";\n\t\t\t\tvar card = form.closest(\"[data-kanban-card][data-kanban-pending-move]\");\n\t\t\t\tif (!(card instanceof HTMLElement) || !card.isConnected) card = cardByIssueID(document, issueID);\n\t\t\t\trollbackPendingMove(card);\n\t\t\t\tvar response = event.detail.xhr ? event.detail.xhr.responseText : \"\";\n\t\t\t\tfeedback(responseMessage(response) || \"Move failed.\", \"error\");\n\t\t\t}\n\t\t\tdocument.body.addEventListener(\"htmx:responseError\", handleMoveError);\n\t\t\tdocument.body.addEventListener(\"htmx:sendError\", handleMoveError);\n\t\t\tdocument.body.addEventListener(\"htmx:timeout\", handleMoveError);\n\t\t})();\n\t</script>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 272, "<script>\n\t\t(function () {\n\t\t\tif (window.__detentBoardKanbanDragHandlersRegistered) return;\n\t\t\twindow.__detentBoardKanbanDragHandlersRegistered = true;\n\t\t\tvar DRAG_THRESHOLD_PX = 6;\n\t\t\tvar TOUCH_MOVE_TOLERANCE_PX = 10;\n\t\t\tvar TOUCH_LONG_PRESS_MS = 450;\n\t\t\tvar TOUCH_EDGE_ZONE_PX = 56;\n\t\t\tvar TOUCH_EDGE_ADVANCE_MS = 500;\n\t\t\t// Real mouse clicks travel a few pixels between press and release,\n\t\t\t// so distance alone cannot separate a click from a drag. A short\n\t\t\t// gesture released back over the source lane is a click: finish the\n\t\t\t// drag without swallowing the click so the detail sheet still opens.\n\t\t\tvar CLICK_GESTURE_MS = 250;\n\t\t\tvar draggedIssueID = \"\";\n\t\t\tvar draggedAllowedTargetKeys = [];\n\t\t\tvar pending = null;\n\t\t\tvar active = null;\n\t\t\tvar recentTouchStart = null;\n\t\t\tfunction connectionAllowsMoves() {\n\t\t\t\treturn document.documentElement.getAttribute(\"data-detent-connection\") === \"connected\";\n\t\t\t}\n\t\t\tfunction clearPending() {\n\t\t\t\tif (pending && pending.longPressTimer) window.clearTimeout(pending.longPressTimer);\n\t\t\t\tpending = null;\n\t\t\t\trecentTouchStart = null;\n\t\t\t}\n\t\t\tfunction touchWithIdentifier(touches, identifier) {\n\t\t\t\tif (!touches || identifier === null || identifier === undefined) return null;\n\t\t\t\tfor (var index = 0; index < touches.length; index += 1) {\n\t\t\t\t\tif (touches[index].identifier === identifier) return touches[index];\n\t\t\t\t}\n\t\t\t\treturn null;\n\t\t\t}\n\t\t\tfunction recentTouchIdentifier(card, event) {\n\t\t\t\tif (event.pointerType !== \"touch\" || !recentTouchStart) return null;\n\t\t\t\tif (Date.now() - recentTouchStart.startedAt >= 100) return null;\n\t\t\t\tif (!(recentTouchStart.target instanceof Node) || !card.contains(recentTouchStart.target)) return null;\n\t\t\t\treturn recentTouchStart.identifier;\n\t\t\t}\n\t\t\tfunction feedback(message, kind) {\n\t\t\t\tvar target = document.getElementById(\"board-feedback\");\n\t\t\t\tif (!target) return;\n\t\t\t\tvar text = String(message || \"\").trim();\n\t\t\t\ttarget.className = \"flex flex-none items-center gap-2 px-5 pt-3.5 text-xs \" + (kind === \"error\" ? \"text-err\" : \"text-sec\");\n\t\t\t\ttarget.textContent = text;\n\t\t\t\ttarget.hidden = text === \"\";\n\t\t\t}\n\t\t\tfunction queryRoot(scope) {\n\t\t\t\tif (scope && typeof scope.querySelector === \"function\" && typeof scope.querySelectorAll === \"function\") return scope;\n\t\t\t\treturn document;\n\t\t\t}\n\t\t\tfunction draggedCard(scope) {\n\t\t\t\tif (!draggedIssueID || !window.CSS || typeof CSS.escape !== \"function\") return null;\n\t\t\t\treturn queryRoot(scope).querySelector(\"[data-kanban-card][data-kanban-issue-id='\" + CSS.escape(draggedIssueID) + \"']\");\n\t\t\t}\n\t\t\tfunction cardByIssueID(scope, issueID) {\n\t\t\t\tvar cards = queryRoot(scope).querySelectorAll(\"[data-kanban-card][data-kanban-issue-id]\");\n\t\t\t\tfor (var index = 0; index < cards.length; index += 1) {\n\t\t\t\t\tif (cards[index].dataset.kanbanIssueId === issueID) return cards[index];\n\t\t\t\t}\n\t\t\t\treturn null;\n\t\t\t}\n\t\t\tfunction laneByState(scope, state) {\n\t\t\t\tvar lanes = queryRoot(scope).querySelectorAll(\"[data-kanban-drop-state]\");\n\t\t\t\tfor (var index = 0; index < lanes.length; index += 1) {\n\t\t\t\t\tif (lanes[index].dataset.kanbanDropState === state) return lanes[index];\n\t\t\t\t}\n\t\t\t\treturn null;\n\t\t\t}\n\t\t\tfunction cardContainer(lane) {\n\t\t\t\treturn lane instanceof HTMLElement ? lane.querySelector(\"[data-kanban-card-container]\") : null;\n\t\t\t}\n\t\t\tfunction updateEmptyLine(container) {\n\t\t\t\tif (!(container instanceof HTMLElement)) return;\n\t\t\t\tvar emptyLine = container.querySelector(\"[data-kanban-empty-line]\");\n\t\t\t\tif (emptyLine instanceof HTMLElement) emptyLine.hidden = Boolean(container.querySelector(\"[data-kanban-card]\"));\n\t\t\t}\n\t\t\tfunction placeCardInLane(card, state, scope) {\n\t\t\t\tvar lane = laneByState(scope, state);\n\t\t\t\tvar container = cardContainer(lane);\n\t\t\t\tif (!(card instanceof HTMLElement) || !(lane instanceof HTMLElement) || !(container instanceof HTMLElement)) return null;\n\t\t\t\tvar previousContainer = card.parentElement;\n\t\t\t\tcontainer.appendChild(card);\n\t\t\t\tlane.dataset.laneHidden = \"false\";\n\t\t\t\tupdateEmptyLine(previousContainer);\n\t\t\t\tupdateEmptyLine(container);\n\t\t\t\treturn lane;\n\t\t\t}\n\t\t\tfunction copyPendingMove(source, target) {\n\t\t\t\t[\n\t\t\t\t\t\"kanbanPendingMove\",\n\t\t\t\t\t\"kanbanPendingOrigin\",\n\t\t\t\t\t\"kanbanPendingSeq\",\n\t\t\t\t\t\"kanbanPendingTargetWasHidden\"\n\t\t\t\t].forEach(function (key) {\n\t\t\t\t\tif (source.dataset[key] === undefined) {\n\t\t\t\t\t\tdelete target.dataset[key];\n\t\t\t\t\t} else {\n\t\t\t\t\t\ttarget.dataset[key] = source.dataset[key];\n\t\t\t\t\t}\n\t\t\t\t});\n\t\t\t}\n\t\t\tfunction clearPendingMove(card) {\n\t\t\t\tif (!(card instanceof HTMLElement)) return;\n\t\t\t\tdelete card.dataset.kanbanPendingMove;\n\t\t\t\tdelete card.dataset.kanbanPendingOrigin;\n\t\t\t\tdelete card.dataset.kanbanPendingSeq;\n\t\t\t\tdelete card.dataset.kanbanPendingTargetWasHidden;\n\t\t\t}\n\t\t\tfunction pendingMoveSuperseded(liveCard, serverCard) {\n\t\t\t\tvar targetState = liveCard.dataset.kanbanPendingMove || \"\";\n\t\t\t\tif ((serverCard.dataset.kanbanCurrentState || \"\") === targetState) return true;\n\t\t\t\tvar pendingSeq = Number.parseInt(liveCard.dataset.kanbanPendingSeq || \"\", 10);\n\t\t\t\tvar serverSeq = Number.parseInt(serverCard.dataset.kanbanDataSeq || \"\", 10);\n\t\t\t\treturn Number.isFinite(pendingSeq) && Number.isFinite(serverSeq) && serverSeq > pendingSeq;\n\t\t\t}\n\t\t\tfunction applyPendingMoveState(scope) {\n\t\t\t\tvar root = queryRoot(scope);\n\t\t\t\tvar applied = false;\n\t\t\t\tdocument.querySelectorAll(\"#snapshot [data-kanban-card][data-kanban-pending-move]\").forEach(function (liveCard) {\n\t\t\t\t\tif (!(liveCard instanceof HTMLElement)) return;\n\t\t\t\t\tvar issueID = liveCard.dataset.kanbanIssueId || \"\";\n\t\t\t\t\tvar serverCard = cardByIssueID(root, issueID);\n\t\t\t\t\tif (!(serverCard instanceof HTMLElement)) return;\n\t\t\t\t\tif (pendingMoveSuperseded(liveCard, serverCard)) {\n\t\t\t\t\t\tif (serverCard === liveCard) clearPendingMove(serverCard);\n\t\t\t\t\t\treturn;\n\t\t\t\t\t}\n\t\t\t\t\tcopyPendingMove(liveCard, serverCard);\n\t\t\t\t\tif (placeCardInLane(serverCard, liveCard.dataset.kanbanPendingMove || \"\", root)) applied = true;\n\t\t\t\t});\n\t\t\t\treturn applied;\n\t\t\t}\n\t\t\tfunction targetKeysFromValue(value) {\n\t\t\t\treturn String(value || \"\").split(/\\s+/).filter(Boolean);\n\t\t\t}\n\t\t\tfunction allowedTargetKeys(card) {\n\t\t\t\tif (card instanceof HTMLElement) {\n\t\t\t\t\tvar keys = targetKeysFromValue(card.dataset.kanbanAllowedTargets || \"\");\n\t\t\t\t\tif (keys.length > 0) return keys;\n\t\t\t\t}\n\t\t\t\treturn draggedAllowedTargetKeys.slice();\n\t\t\t}\n\t\t\tfunction laneAllowed(card, lane) {\n\t\t\t\tif (!(lane instanceof HTMLElement)) return false;\n\t\t\t\tvar key = lane.dataset.kanbanDropKey || \"\";\n\t\t\t\treturn key !== \"\" && allowedTargetKeys(card).includes(key);\n\t\t\t}\n\t\t\tfunction setDropTargetState(card, scope) {\n\t\t\t\tvar sourceLane = card instanceof HTMLElement ? card.closest(\"[data-kanban-drop-state]\") : null;\n\t\t\t\tqueryRoot(scope).querySelectorAll(\"[data-kanban-drop-state]\").forEach(function (lane) {\n\t\t\t\t\tif (!(lane instanceof HTMLElement)) return;\n\t\t\t\t\tif (lane.dataset.kanbanDropWasHidden === undefined) {\n\t\t\t\t\t\tlane.dataset.kanbanDropWasHidden = lane.dataset.laneHidden || \"false\";\n\t\t\t\t\t}\n\t\t\t\t\tlane.dataset.laneHidden = \"false\";\n\t\t\t\t\tif (lane === sourceLane) {\n\t\t\t\t\t\t// The origin lane is not a transition target, but styling\n\t\t\t\t\t\t// it blocked reads as an error; mark it as the source so\n\t\t\t\t\t\t// the operator can see where the card came from.\n\t\t\t\t\t\tlane.dataset.kanbanDropSource = \"true\";\n\t\t\t\t\t\tdelete lane.dataset.kanbanDropAllowed;\n\t\t\t\t\t\tlane.removeAttribute(\"aria-disabled\");\n\t\t\t\t\t\treturn;\n\t\t\t\t\t}\n\t\t\t\t\tdelete lane.dataset.kanbanDropSource;\n\t\t\t\t\tvar allowed = laneAllowed(card, lane);\n\t\t\t\t\tlane.dataset.kanbanDropAllowed = allowed ? \"true\" : \"false\";\n\t\t\t\t\tlane.setAttribute(\"aria-disabled\", allowed ? \"false\" : \"true\");\n\t\t\t\t});\n\t\t\t}\n\t\t\tfunction applyActiveDragState(scope) {\n\t\t\t\tif (!draggedIssueID || draggedAllowedTargetKeys.length === 0) return false;\n\t\t\t\tvar root = queryRoot(scope);\n\t\t\t\tvar card = draggedCard(root);\n\t\t\t\tif (card instanceof HTMLElement) card.dataset.kanbanDragging = \"true\";\n\t\t\t\tsetDropTargetState(card, root);\n\t\t\t\tapplyTouchDragStyles(card, root);\n\t\t\t\treturn true;\n\t\t\t}\n\t\t\tfunction applyDragState(scope) {\n\t\t\t\tvar pendingApplied = applyPendingMoveState(scope);\n\t\t\t\treturn applyActiveDragState(scope) || pendingApplied;\n\t\t\t}\n\t\t\twindow.__detentBoardKanbanDragAdjustSnapshot = applyDragState;\n\t\t\tfunction clearDropTargetState() {\n\t\t\t\tdocument.querySelectorAll(\"[data-kanban-drop-state]\").forEach(function (lane) {\n\t\t\t\t\tif (!(lane instanceof HTMLElement)) return;\n\t\t\t\t\tif (lane.dataset.kanbanDropWasHidden !== undefined) {\n\t\t\t\t\t\tlane.dataset.laneHidden = lane.dataset.kanbanDropWasHidden;\n\t\t\t\t\t\tdelete lane.dataset.kanbanDropWasHidden;\n\t\t\t\t\t}\n\t\t\t\t\tdelete lane.dataset.kanbanDropAllowed;\n\t\t\t\t\tdelete lane.dataset.kanbanDropSource;\n\t\t\t\t\tlane.removeAttribute(\"aria-disabled\");\n\t\t\t\t});\n\t\t\t\tdocument.querySelectorAll(\"[data-kanban-card][data-kanban-dragging='true']\").forEach(function (card) {\n\t\t\t\t\tif (card instanceof HTMLElement) delete card.dataset.kanbanDragging;\n\t\t\t\t});\n\t\t\t}\n\t\t\tfunction responseMessage(response) {\n\t\t\t\tif (!response) return \"\";\n\t\t\t\tvar doc = new DOMParser().parseFromString(response, \"text/html\");\n\t\t\t\treturn (doc.body.textContent || \"\").trim();\n\t\t\t}\n\t\t\tfunction buildGhost(card, rect) {\n\t\t\t\tvar ghost = card.cloneNode(true);\n\t\t\t\tghost.removeAttribute(\"id\");\n\t\t\t\tghost.querySelectorAll(\"[id]\").forEach(function (node) {\n\t\t\t\t\tnode.removeAttribute(\"id\");\n\t\t\t\t});\n\t\t\t\tvar form = ghost.querySelector(\"[data-kanban-drag-move-form]\");\n\t\t\t\tif (form) form.remove();\n\t\t\t\tdelete ghost.dataset.kanbanDragging;\n\t\t\t\tvar origin = document.createElement(\"div\");\n\t\t\t\torigin.className = \"mb-1.5 flex items-center gap-1.5 border-b border-line pb-1.5 font-mono text-2xs font-medium text-accent\";\n\t\t\t\torigin.textContent = \"From \" + (card.dataset.kanbanCurrentState || \"current lane\");\n\t\t\t\tghost.insertBefore(origin, ghost.firstChild);\n\t\t\t\tghost.setAttribute(\"aria-hidden\", \"true\");\n\t\t\t\tghost.style.position = \"fixed\";\n\t\t\t\tghost.style.left = \"0\";\n\t\t\t\tghost.style.top = \"0\";\n\t\t\t\tghost.style.margin = \"0\";\n\t\t\t\tghost.style.width = rect.width + \"px\";\n\t\t\t\tghost.style.height = rect.height + \"px\";\n\t\t\t\tghost.style.pointerEvents = \"none\";\n\t\t\t\tghost.style.zIndex = \"1000\";\n\t\t\t\tghost.style.opacity = \"0.9\";\n\t\t\t\tghost.style.boxShadow = \"0 12px 32px rgba(0, 0, 0, 0.35)\";\n\t\t\t\tghost.style.willChange = \"transform\";\n\t\t\t\tdocument.body.appendChild(ghost);\n\t\t\t\treturn ghost;\n\t\t\t}\n\t\t\tfunction moveGhost(ghost, x, y, offsetX, offsetY) {\n\t\t\t\tghost.style.transform = \"translate(\" + Math.round(x - offsetX) + \"px, \" + Math.round(y - offsetY) + \"px)\";\n\t\t\t}\n\t\t\tfunction laneFromPoint(x, y) {\n\t\t\t\tvar hit = document.elementFromPoint(x, y);\n\t\t\t\treturn hit instanceof Element ? hit.closest(\"[data-kanban-drop-state]\") : null;\n\t\t\t}\n\t\t\tfunction applyTouchStyle(element, styles) {\n\t\t\t\tif (!active || active.pointerType !== \"touch\" || !(element instanceof HTMLElement) || !element.isConnected) return;\n\t\t\t\tif (!active.touchStyles.has(element)) {\n\t\t\t\t\tvar original = {};\n\t\t\t\t\tObject.keys(styles).forEach(function (property) {\n\t\t\t\t\t\toriginal[property] = element.style[property];\n\t\t\t\t\t});\n\t\t\t\t\tactive.touchStyles.set(element, original);\n\t\t\t\t}\n\t\t\t\tObject.keys(styles).forEach(function (property) {\n\t\t\t\t\telement.style[property] = styles[property];\n\t\t\t\t});\n\t\t\t}\n\t\t\tfunction applyTouchDragStyles(card, scope) {\n\t\t\t\tif (!active || active.pointerType !== \"touch\") return;\n\t\t\t\tvar root = queryRoot(scope);\n\t\t\t\tvar lanes = root.querySelector(\"[data-board-lanes]\");\n\t\t\t\tapplyTouchStyle(lanes, { touchAction: \"none\", scrollSnapType: \"none\" });\n\t\t\t\tapplyTouchStyle(card, {\n\t\t\t\t\ttouchAction: \"none\",\n\t\t\t\t\toutline: \"2px solid var(--color-accent)\",\n\t\t\t\t\toutlineOffset: \"2px\"\n\t\t\t\t});\n\t\t\t}\n\t\t\tfunction restoreTouchDragStyles() {\n\t\t\t\tif (!active || !active.touchStyles) return;\n\t\t\t\tactive.touchStyles.forEach(function (styles, element) {\n\t\t\t\t\tObject.keys(styles).forEach(function (property) {\n\t\t\t\t\t\telement.style[property] = styles[property];\n\t\t\t\t\t});\n\t\t\t\t});\n\t\t\t\tactive.touchStyles.clear();\n\t\t\t}\n\t\t\t// Native drags auto-scrolled the lane strip at the viewport edges;\n\t\t\t// pointer drags must do it themselves. Scrolls only while the\n\t\t\t// pointer moves, which is enough to reach off-screen lanes.\n\t\t\tfunction autoScrollLanes(x) {\n\t\t\t\tvar lanes = document.getElementById(\"board-lanes\");\n\t\t\t\tif (!lanes) return;\n\t\t\t\tvar rect = lanes.getBoundingClientRect();\n\t\t\t\tif (x < rect.left + 48) {\n\t\t\t\t\tlanes.scrollLeft -= 16;\n\t\t\t\t} else if (x > rect.right - 48) {\n\t\t\t\t\tlanes.scrollLeft += 16;\n\t\t\t\t}\n\t\t\t}\n\t\t\tfunction visibleDropLanes(lanes) {\n\t\t\t\treturn Array.from(lanes.querySelectorAll(\"[data-kanban-drop-state]\")).filter(function (lane) {\n\t\t\t\t\treturn lane instanceof HTMLElement && lane.dataset.laneHidden !== \"true\";\n\t\t\t\t});\n\t\t\t}\n\t\t\tfunction closestLaneIndex(lanes, laneNodes) {\n\t\t\t\tvar center = lanes.getBoundingClientRect().left + lanes.clientWidth / 2;\n\t\t\t\tvar closest = 0;\n\t\t\t\tvar distance = Infinity;\n\t\t\t\tlaneNodes.forEach(function (lane, index) {\n\t\t\t\t\tvar rect = lane.getBoundingClientRect();\n\t\t\t\t\tvar candidate = Math.abs(rect.left + rect.width / 2 - center);\n\t\t\t\t\tif (candidate < distance) {\n\t\t\t\t\t\tdistance = candidate;\n\t\t\t\t\t\tclosest = index;\n\t\t\t\t\t}\n\t\t\t\t});\n\t\t\t\treturn closest;\n\t\t\t}\n\t\t\tfunction advanceTouchLane(direction) {\n\t\t\t\tif (!active || active.pointerType !== \"touch\" || active.edgeDirection !== direction) return;\n\t\t\t\tactive.edgeTimer = null;\n\t\t\t\tvar lanes = document.getElementById(\"board-lanes\");\n\t\t\t\tif (!lanes) return;\n\t\t\t\tvar laneNodes = visibleDropLanes(lanes);\n\t\t\t\tif (laneNodes.length === 0) return;\n\t\t\t\tvar current = closestLaneIndex(lanes, laneNodes);\n\t\t\t\tvar target = Math.max(0, Math.min(laneNodes.length - 1, current + direction));\n\t\t\t\tif (target !== current) {\n\t\t\t\t\tlaneNodes[target].scrollIntoView({ behavior: \"smooth\", block: \"nearest\", inline: \"start\" });\n\t\t\t\t}\n\t\t\t\tif (active && active.edgeDirection === direction && target !== current) {\n\t\t\t\t\tactive.edgeTimer = window.setTimeout(function () {\n\t\t\t\t\t\tadvanceTouchLane(direction);\n\t\t\t\t\t}, TOUCH_EDGE_ADVANCE_MS);\n\t\t\t\t}\n\t\t\t}\n\t\t\tfunction updateTouchEdgeAdvance(x) {\n\t\t\t\tif (!active || active.pointerType !== \"touch\") return;\n\t\t\t\tvar lanes = document.getElementById(\"board-lanes\");\n\t\t\t\tif (!lanes) return;\n\t\t\t\tvar rect = lanes.getBoundingClientRect();\n\t\t\t\tvar direction = x < rect.left + TOUCH_EDGE_ZONE_PX ? -1 : (x > rect.right - TOUCH_EDGE_ZONE_PX ? 1 : 0);\n\t\t\t\tif (direction === active.edgeDirection) return;\n\t\t\t\tif (active.edgeTimer) window.clearTimeout(active.edgeTimer);\n\t\t\t\tactive.edgeDirection = direction;\n\t\t\t\tactive.edgeTimer = direction === 0 ? null : window.setTimeout(function () {\n\t\t\t\t\tadvanceTouchLane(direction);\n\t\t\t\t}, TOUCH_EDGE_ADVANCE_MS);\n\t\t\t}\n\t\t\tfunction stopTouchEdgeAdvance() {\n\t\t\t\tif (!active) return;\n\t\t\t\tif (active.edgeTimer) window.clearTimeout(active.edgeTimer);\n\t\t\t\tactive.edgeTimer = null;\n\t\t\t\tactive.edgeDirection = 0;\n\t\t\t}\n\t\t\tfunction suppressNextClick() {\n\t\t\t\tvar until = Date.now() + 400;\n\t\t\t\tdocument.addEventListener(\"click\", function suppress(event) {\n\t\t\t\t\tdocument.removeEventListener(\"click\", suppress, true);\n\t\t\t\t\tif (Date.now() > until) return;\n\t\t\t\t\tevent.preventDefault();\n\t\t\t\t\tevent.stopImmediatePropagation();\n\t\t\t\t}, true);\n\t\t\t}\n\t\t\tfunction beginDrag(event) {\n\t\t\t\tvar press = pending;\n\t\t\t\tif (!press) return;\n\t\t\t\tif (press.longPressTimer) window.clearTimeout(press.longPressTimer);\n\t\t\t\tdraggedIssueID = press.issueID;\n\t\t\t\tdraggedAllowedTargetKeys = press.targets;\n\t\t\t\tvar card = draggedCard(document) || press.card;\n\t\t\t\tactive = {\n\t\t\t\t\tpointerId: press.pointerId,\n\t\t\t\t\tpointerType: press.pointerType,\n\t\t\t\t\ttouchIdentifier: press.touchIdentifier,\n\t\t\t\t\toffsetX: press.startX - press.rect.left,\n\t\t\t\t\toffsetY: press.startY - press.rect.top,\n\t\t\t\t\tghost: buildGhost(card, press.rect),\n\t\t\t\t\tlastLaneBlocked: false,\n\t\t\t\t\tstartedAt: press.startedAt,\n\t\t\t\t\tcaptureElement: press.card,\n\t\t\t\t\ttouchStyles: new Map(),\n\t\t\t\t\tedgeDirection: 0,\n\t\t\t\t\tedgeTimer: null\n\t\t\t\t};\n\t\t\t\tpending = null;\n\t\t\t\trecentTouchStart = null;\n\t\t\t\tif (active.pointerType === \"touch\" && typeof active.captureElement.setPointerCapture === \"function\") {\n\t\t\t\t\ttry {\n\t\t\t\t\t\tactive.captureElement.setPointerCapture(active.pointerId);\n\t\t\t\t\t} catch (_) {}\n\t\t\t\t}\n\t\t\t\tcard.dataset.kanbanDragging = \"true\";\n\t\t\t\tsetDropTargetState(card, document);\n\t\t\t\tapplyTouchDragStyles(card, document);\n\t\t\t\tfeedback(\"Moving \" + (card.dataset.kanbanCurrentState || \"card\") + \".\");\n\t\t\t\tmoveGhost(active.ghost, event.clientX, event.clientY, active.offsetX, active.offsetY);\n\t\t\t}\n\t\t\tfunction finishDrag(keepClick) {\n\t\t\t\tif (active) {\n\t\t\t\t\tstopTouchEdgeAdvance();\n\t\t\t\t\trestoreTouchDragStyles();\n\t\t\t\t\tif (active.ghost) active.ghost.remove();\n\t\t\t\t\tif (active.captureElement && typeof active.captureElement.releasePointerCapture === \"function\") {\n\t\t\t\t\t\ttry {\n\t\t\t\t\t\t\tif (active.captureElement.hasPointerCapture(active.pointerId)) active.captureElement.releasePointerCapture(active.pointerId);\n\t\t\t\t\t\t} catch (_) {}\n\t\t\t\t\t}\n\t\t\t\t}\n\t\t\t\tclearPending();\n\t\t\t\tactive = null;\n\t\t\t\tdraggedIssueID = \"\";\n\t\t\t\tdraggedAllowedTargetKeys = [];\n\t\t\t\tclearDropTargetState();\n\t\t\t\t// A drag ends with the pointer still over a card, so the release\n\t\t\t\t// also fires a click; swallow it or the detail sheet opens.\n\t\t\t\tif (!keepClick) suppressNextClick();\n\t\t\t}\n\t\t\tfunction cancelDrag(keepClick) {\n\t\t\t\tif (!active) {\n\t\t\t\t\tclearPending();\n\t\t\t\t\treturn;\n\t\t\t\t}\n\t\t\t\tfinishDrag(keepClick);\n\t\t\t\tfeedback(\"Move cancelled.\", \"error\");\n\t\t\t}\n\t\t\tfunction rollbackPendingMove(card) {\n\t\t\t\tif (!(card instanceof HTMLElement) || !card.dataset.kanbanPendingMove) return;\n\t\t\t\tvar targetLane = card.closest(\"[data-kanban-drop-state]\");\n\t\t\t\tvar targetWasHidden = card.dataset.kanbanPendingTargetWasHidden === \"true\";\n\t\t\t\tvar originState = card.dataset.kanbanPendingOrigin || \"\";\n\t\t\t\tclearPendingMove(card);\n\t\t\t\tplaceCardInLane(card, originState, document);\n\t\t\t\tif (targetLane instanceof HTMLElement) {\n\t\t\t\t\ttargetLane.dataset.laneHidden = targetWasHidden ? \"true\" : \"false\";\n\t\t\t\t\tupdateEmptyLine(cardContainer(targetLane));\n\t\t\t\t}\n\t\t\t}\n\t\t\tfunction moveDragTo(x, y) {\n\t\t\t\tif (!active) return;\n\t\t\t\tmoveGhost(active.ghost, x, y, active.offsetX, active.offsetY);\n\t\t\t\tif (active.pointerType === \"touch\") {\n\t\t\t\t\tupdateTouchEdgeAdvance(x);\n\t\t\t\t} else {\n\t\t\t\t\tautoScrollLanes(x);\n\t\t\t\t}\n\t\t\t\tvar lane = laneFromPoint(x, y);\n\t\t\t\tvar card = draggedCard(document);\n\t\t\t\tvar blocked = lane instanceof HTMLElement && lane.dataset.kanbanDropSource !== \"true\" && !laneAllowed(card, lane);\n\t\t\t\tif (blocked && !active.lastLaneBlocked) {\n\t\t\t\t\tfeedback(\"Move blocked by transition policy.\", \"error\");\n\t\t\t\t} else if (!blocked && active.lastLaneBlocked) {\n\t\t\t\t\tfeedback(\"Moving \" + ((card && card.dataset.kanbanCurrentState) || \"card\") + \".\");\n\t\t\t\t}\n\t\t\t\tactive.lastLaneBlocked = blocked;\n\t\t\t}\n\t\t\tdocument.addEventListener(\"pointerdown\", function (event) {\n\t\t\t\tif (active || event.button !== 0 || event.isPrimary === false) return;\n\t\t\t\tvar pressedElement = event.target instanceof Element ? event.target : null;\n\t\t\t\tvar pressedCard = pressedElement ? pressedElement.closest(\"[data-kanban-card]\") : null;\n\t\t\t\tif (pressedCard && !connectionAllowsMoves()) {\n\t\t\t\t\tif (pressedElement.closest(\"a, button, input, select, textarea, summary, label, [data-help-trigger]\")) return;\n\t\t\t\t\tfeedback(\"Moves are disabled while the board reconnects. Reload if the connection does not recover.\", \"error\");\n\t\t\t\t\treturn;\n\t\t\t\t}\n\t\t\t\tif (pressedCard && pressedCard.dataset.kanbanMoveDisabled === \"true\") {\n\t\t\t\t\tif (pressedElement.closest(\"a, button, input, select, textarea, summary, label, [data-help-trigger]\")) return;\n\t\t\t\t\tfeedback(pressedCard.dataset.kanbanMoveDisabledReason || \"This card cannot be moved.\", \"error\");\n\t\t\t\t\treturn;\n\t\t\t\t}\n\t\t\t\tvar card = pressedCard && pressedCard.dataset.kanbanAction === \"move\" ? pressedCard : null;\n\t\t\t\tif (!card) return;\n\t\t\t\tif (card.dataset.kanbanPendingMove) return;\n\t\t\t\tvar issueID = card.dataset.kanbanIssueId || \"\";\n\t\t\t\tif (!issueID) return;\n\t\t\t\tpending = {\n\t\t\t\t\tpointerId: event.pointerId,\n\t\t\t\t\tpointerType: event.pointerType,\n\t\t\t\t\ttouchIdentifier: recentTouchIdentifier(card, event),\n\t\t\t\t\tcard: card,\n\t\t\t\t\tissueID: issueID,\n\t\t\t\t\ttargets: targetKeysFromValue(card.dataset.kanbanAllowedTargets || \"\"),\n\t\t\t\t\trect: card.getBoundingClientRect(),\n\t\t\t\t\tstartX: event.clientX,\n\t\t\t\t\tstartY: event.clientY,\n\t\t\t\t\tlastX: event.clientX,\n\t\t\t\t\tlastY: event.clientY,\n\t\t\t\t\tstartedAt: Date.now(),\n\t\t\t\t\tlongPressTimer: null\n\t\t\t\t};\n\t\t\t\tif (event.pointerType === \"touch\") {\n\t\t\t\t\tvar pointerId = event.pointerId;\n\t\t\t\t\tpending.longPressTimer = window.setTimeout(function () {\n\t\t\t\t\t\tif (!pending || pending.pointerId !== pointerId) return;\n\t\t\t\t\t\tbeginDrag({ clientX: pending.lastX, clientY: pending.lastY });\n\t\t\t\t\t}, TOUCH_LONG_PRESS_MS);\n\t\t\t\t}\n\t\t\t});\n\t\t\tdocument.addEventListener(\"touchstart\", function (event) {\n\t\t\t\tif (active || !event.changedTouches || event.changedTouches.length === 0) return;\n\t\t\t\tvar touch = event.changedTouches[0];\n\t\t\t\trecentTouchStart = {\n\t\t\t\t\tidentifier: touch.identifier,\n\t\t\t\t\ttarget: event.target,\n\t\t\t\t\tstartedAt: Date.now()\n\t\t\t\t};\n\t\t\t\tif (pending && pending.pointerType === \"touch\" && event.target instanceof Node && pending.card.contains(event.target)) {\n\t\t\t\t\tpending.touchIdentifier = touch.identifier;\n\t\t\t\t}\n\t\t\t});\n\t\t\tdocument.addEventListener(\"pointermove\", function (event) {\n\t\t\t\tif (pending && event.pointerId === pending.pointerId) {\n\t\t\t\t\tif (pending.pointerType === \"touch\") {\n\t\t\t\t\t\tif (Math.hypot(event.clientX - pending.startX, event.clientY - pending.startY) >= TOUCH_MOVE_TOLERANCE_PX) {\n\t\t\t\t\t\t\tclearPending();\n\t\t\t\t\t\t\treturn;\n\t\t\t\t\t\t}\n\t\t\t\t\t\tpending.lastX = event.clientX;\n\t\t\t\t\t\tpending.lastY = event.clientY;\n\t\t\t\t\t\treturn;\n\t\t\t\t\t}\n\t\t\t\t\t// A missed pointerup (released outside the window) must not\n\t\t\t\t\t// leave a stale press that turns a later hover into a drag.\n\t\t\t\t\tif (event.buttons === 0) {\n\t\t\t\t\t\tclearPending();\n\t\t\t\t\t\treturn;\n\t\t\t\t\t}\n\t\t\t\t\tif (Math.hypot(event.clientX - pending.startX, event.clientY - pending.startY) < DRAG_THRESHOLD_PX) return;\n\t\t\t\t\tbeginDrag(event);\n\t\t\t\t\treturn;\n\t\t\t\t}\n\t\t\t\tif (!active || event.pointerId !== active.pointerId) return;\n\t\t\t\tif (active.pointerType !== \"touch\" && event.buttons === 0) {\n\t\t\t\t\t// The release happened outside the window, so no click is\n\t\t\t\t\t// coming — cancelling must not arm the click suppressor or\n\t\t\t\t\t// it would eat the next real click after recovery.\n\t\t\t\t\tcancelDrag(true);\n\t\t\t\t\treturn;\n\t\t\t\t}\n\t\t\t\tevent.preventDefault();\n\t\t\t\tmoveDragTo(event.clientX, event.clientY);\n\t\t\t}, { passive: false });\n\t\t\tfunction dropAt(x, y) {\n\t\t\t\tif (!active) return;\n\t\t\t\tif (!connectionAllowsMoves()) {\n\t\t\t\t\tcancelDrag();\n\t\t\t\t\tfeedback(\"Move cancelled because the board connection was lost.\", \"error\");\n\t\t\t\t\treturn;\n\t\t\t\t}\n\t\t\t\tvar lane = laneFromPoint(x, y);\n\t\t\t\tvar card = draggedCard(document);\n\t\t\t\tif (!(lane instanceof HTMLElement)) {\n\t\t\t\t\tcancelDrag();\n\t\t\t\t\treturn;\n\t\t\t\t}\n\t\t\t\tif (lane.dataset.kanbanDropSource === \"true\") {\n\t\t\t\t\tif (Date.now() - active.startedAt < CLICK_GESTURE_MS) {\n\t\t\t\t\t\tfinishDrag(true);\n\t\t\t\t\t\tfeedback(\"\");\n\t\t\t\t\t\treturn;\n\t\t\t\t\t}\n\t\t\t\t\tcancelDrag();\n\t\t\t\t\treturn;\n\t\t\t\t}\n\t\t\t\tif (!laneAllowed(card, lane)) {\n\t\t\t\t\tfinishDrag();\n\t\t\t\t\tfeedback(\"Move blocked by transition policy.\", \"error\");\n\t\t\t\t\treturn;\n\t\t\t\t}\n\t\t\t\tvar form = card ? card.querySelector(\"[data-kanban-drag-move-form]\") : null;\n\t\t\t\tvar targetState = form ? form.querySelector(\"[data-kanban-drag-target-state]\") : null;\n\t\t\t\tif (!(form instanceof HTMLFormElement) || !(targetState instanceof HTMLInputElement)) {\n\t\t\t\t\tcancelDrag();\n\t\t\t\t\treturn;\n\t\t\t\t}\n\t\t\t\ttargetState.value = lane.dataset.kanbanDropState || \"\";\n\t\t\t\tcard.dataset.kanbanPendingMove = targetState.value;\n\t\t\t\tcard.dataset.kanbanPendingOrigin = card.dataset.kanbanCurrentState || \"\";\n\t\t\t\tif (card.dataset.kanbanDataSeq) card.dataset.kanbanPendingSeq = card.dataset.kanbanDataSeq;\n\t\t\t\tcard.dataset.kanbanPendingTargetWasHidden = lane.dataset.kanbanDropWasHidden || lane.dataset.laneHidden || \"false\";\n\t\t\t\tplaceCardInLane(card, targetState.value, document);\n\t\t\t\tfinishDrag();\n\t\t\t\tplaceCardInLane(card, targetState.value, document);\n\t\t\t\tform.requestSubmit();\n\t\t\t}\n\t\t\tdocument.addEventListener(\"pointerup\", function (event) {\n\t\t\t\tif (pending && event.pointerId === pending.pointerId) {\n\t\t\t\t\tclearPending();\n\t\t\t\t\treturn;\n\t\t\t\t}\n\t\t\t\tif (!active || event.pointerId !== active.pointerId) return;\n\t\t\t\tdropAt(event.clientX, event.clientY);\n\t\t\t});\n\t\t\tdocument.addEventListener(\"pointercancel\", function (event) {\n\t\t\t\tif (pending && event.pointerId === pending.pointerId) {\n\t\t\t\t\tclearPending();\n\t\t\t\t\treturn;\n\t\t\t\t}\n\t\t\t\tif (active && event.pointerId === active.pointerId && active.pointerType !== \"touch\") cancelDrag();\n\t\t\t});\n\t\t\tdocument.addEventListener(\"touchmove\", function (event) {\n\t\t\t\tif (!active || active.pointerType !== \"touch\") return;\n\t\t\t\tevent.preventDefault();\n\t\t\t\tvar touch = touchWithIdentifier(event.touches, active.touchIdentifier);\n\t\t\t\tif (!touch && active.touchIdentifier === null && event.touches && event.touches.length === 1) touch = event.touches[0];\n\t\t\t\tif (touch) moveDragTo(touch.clientX, touch.clientY);\n\t\t\t}, { passive: false });\n\t\t\tdocument.addEventListener(\"touchend\", function (event) {\n\t\t\t\tif (pending && pending.pointerType === \"touch\") {\n\t\t\t\t\tvar pendingTouch = touchWithIdentifier(event.changedTouches, pending.touchIdentifier);\n\t\t\t\t\tif (!pendingTouch && !(pending.touchIdentifier === null && event.touches && event.touches.length === 0)) return;\n\t\t\t\t\tclearPending();\n\t\t\t\t\treturn;\n\t\t\t\t}\n\t\t\t\tif (!active || active.pointerType !== \"touch\") return;\n\t\t\t\tvar touch = touchWithIdentifier(event.changedTouches, active.touchIdentifier);\n\t\t\t\tif (!touch && active.touchIdentifier === null && event.touches && event.touches.length === 0) touch = event.changedTouches && event.changedTouches[0];\n\t\t\t\tif (touch) dropAt(touch.clientX, touch.clientY);\n\t\t\t});\n\t\t\tdocument.addEventListener(\"touchcancel\", function (event) {\n\t\t\t\tif (pending && pending.pointerType === \"touch\") {\n\t\t\t\t\tvar pendingTouch = touchWithIdentifier(event.changedTouches, pending.touchIdentifier);\n\t\t\t\t\tif (!pendingTouch && !(pending.touchIdentifier === null && event.touches && event.touches.length === 0)) return;\n\t\t\t\t\tclearPending();\n\t\t\t\t\treturn;\n\t\t\t\t}\n\t\t\t\tif (!active || active.pointerType !== \"touch\") return;\n\t\t\t\tvar touch = touchWithIdentifier(event.changedTouches, active.touchIdentifier);\n\t\t\t\tif (touch || (active.touchIdentifier === null && event.touches && event.touches.length === 0)) cancelDrag();\n\t\t\t});\n\t\t\tdocument.addEventListener(\"contextmenu\", function (event) {\n\t\t\t\tvar touchPress = pending && pending.pointerType === \"touch\";\n\t\t\t\tvar touchDrag = active && active.pointerType === \"touch\";\n\t\t\t\tif ((touchPress || touchDrag) && event.target instanceof Element && event.target.closest(\"[data-kanban-card]\")) {\n\t\t\t\t\tevent.preventDefault();\n\t\t\t\t}\n\t\t\t});\n\t\t\tdocument.addEventListener(\"keydown\", function (event) {\n\t\t\t\tif (event.key === \"Escape\" && active) cancelDrag();\n\t\t\t});\n\t\t\tdocument.addEventListener(\"detent:connectionChange\", function (event) {\n\t\t\t\tif (!event.detail || event.detail.state === \"connected\") return;\n\t\t\t\tif (active) cancelDrag();\n\t\t\t\telse clearPending();\n\t\t\t});\n\t\t\twindow.addEventListener(\"blur\", function () {\n\t\t\t\tif (active) cancelDrag();\n\t\t\t});\n\t\t\t// Native HTML5 drags stay disabled inside cards (links, images):\n\t\t\t// they would start a compositor drag session that steals the pointer.\n\t\t\tdocument.addEventListener(\"dragstart\", function (event) {\n\t\t\t\tif (event.target instanceof Element && event.target.closest(\"[data-kanban-card]\")) {\n\t\t\t\t\tevent.preventDefault();\n\t\t\t\t}\n\t\t\t});\n\t\t\tdocument.addEventListener(\"htmx:afterSettle\", function () {\n\t\t\t\tapplyDragState(document);\n\t\t\t});\n\t\t\tfunction handleMoveError(event) {\n\t\t\t\tvar form = event.detail && event.detail.elt;\n\t\t\t\tif (!(form instanceof HTMLFormElement) || !form.matches(\"[data-kanban-drag-move-form]\")) return;\n\t\t\t\tvar issueIDInput = form.querySelector(\"input[name='issue_id']\");\n\t\t\t\tvar issueID = issueIDInput instanceof HTMLInputElement ? issueIDInput.value : \"\";\n\t\t\t\tvar card = form.closest(\"[data-kanban-card][data-kanban-pending-move]\");\n\t\t\t\tif (!(card instanceof HTMLElement) || !card.isConnected) card = cardByIssueID(document, issueID);\n\t\t\t\trollbackPendingMove(card);\n\t\t\t\tvar response = event.detail.xhr ? event.detail.xhr.responseText : \"\";\n\t\t\t\tfeedback(responseMessage(response) || \"Move failed.\", \"error\");\n\t\t\t}\n\t\t\tdocument.body.addEventListener(\"htmx:responseError\", handleMoveError);\n\t\t\tdocument.body.addEventListener(\"htmx:sendError\", handleMoveError);\n\t\t\tdocument.body.addEventListener(\"htmx:timeout\", handleMoveError);\n\t\t})();\n\t</script>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -3056,61 +3215,61 @@ func boardScopeSelect(data DashboardData) templ.Component {
 			}()
 		}
 		ctx = templ.InitializeContext(ctx)
-		templ_7745c5c3_Var163 := templ.GetChildren(ctx)
-		if templ_7745c5c3_Var163 == nil {
-			templ_7745c5c3_Var163 = templ.NopComponent
+		templ_7745c5c3_Var172 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var172 == nil {
+			templ_7745c5c3_Var172 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 256, "<details class=\"group/scope relative min-w-0\"><summary class=\"flex min-w-0 cursor-pointer list-none items-center gap-1.5 rounded-card border border-line px-2.5 py-1 text-xs text-sec hover:text-text [&::-webkit-details-marker]:hidden\"><span class=\"min-w-0 truncate\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 273, "<details class=\"group/scope relative min-w-0\"><summary class=\"flex min-w-0 cursor-pointer list-none items-center gap-1.5 rounded-card border border-line px-2.5 py-1 text-xs text-sec hover:text-text [&::-webkit-details-marker]:hidden\"><span class=\"min-w-0 truncate\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		var templ_7745c5c3_Var164 string
-		templ_7745c5c3_Var164, templ_7745c5c3_Err = templ.JoinStringErrs(boardScopeLabel(data))
+		var templ_7745c5c3_Var173 string
+		templ_7745c5c3_Var173, templ_7745c5c3_Err = templ.JoinStringErrs(boardScopeLabel(data))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 1835, Col: 57}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 1956, Col: 57}
 		}
-		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var164))
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var173))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 257, "</span> <span aria-hidden=\"true\">▾</span></summary><div class=\"absolute left-0 top-full z-40 mt-1 flex w-52 flex-col gap-0.5 rounded-card border border-line bg-elev p-1.5\"><a href=\"/\" class=\"rounded-chip px-2 py-1 text-xs text-text hover:bg-surface\">All projects</a> ")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 274, "</span> <span aria-hidden=\"true\">▾</span></summary><div class=\"absolute left-0 top-full z-40 mt-1 flex w-52 flex-col gap-0.5 rounded-card border border-line bg-elev p-1.5\"><a href=\"/\" class=\"rounded-chip px-2 py-1 text-xs text-text hover:bg-surface\">All projects</a> ")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		for _, project := range appShellProjects(DashboardShellDataFromDashboard(data)) {
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 258, "<a href=\"")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 275, "<a href=\"")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			var templ_7745c5c3_Var165 templ.SafeURL
-			templ_7745c5c3_Var165, templ_7745c5c3_Err = templ.JoinURLErrs(templ.SafeURL(project.Href))
+			var templ_7745c5c3_Var174 templ.SafeURL
+			templ_7745c5c3_Var174, templ_7745c5c3_Err = templ.JoinURLErrs(templ.SafeURL(project.Href))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 1841, Col: 41}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 1962, Col: 41}
 			}
-			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var165))
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 259, "\" class=\"truncate rounded-chip px-2 py-1 text-xs text-text hover:bg-surface\">")
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var174))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			var templ_7745c5c3_Var166 string
-			templ_7745c5c3_Var166, templ_7745c5c3_Err = templ.JoinStringErrs(project.Name)
-			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 1841, Col: 133}
-			}
-			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var166))
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 276, "\" class=\"truncate rounded-chip px-2 py-1 text-xs text-text hover:bg-surface\">")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 260, "</a>")
+			var templ_7745c5c3_Var175 string
+			templ_7745c5c3_Var175, templ_7745c5c3_Err = templ.JoinStringErrs(project.Name)
+			if templ_7745c5c3_Err != nil {
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 1962, Col: 133}
+			}
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var175))
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 277, "</a>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 261, "</div></details>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 278, "</div></details>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}

--- a/tests/visual/freshness.spec.js
+++ b/tests/visual/freshness.spec.js
@@ -231,6 +231,72 @@ test("zero, one, and twenty warnings keep one indicator slot and fixed lanes", a
   await expect(overlay.getByRole("link", { name: "Open" })).toHaveCount(20);
 });
 
+test("dismiss updates both counts and stays gone through the next SSE morph", async ({
+  page,
+}) => {
+  await page.route("**/api/v1/projects/**", async (route) => {
+    if (route.request().url().includes("/staleness-warnings/")) {
+      await route.fulfill({ status: 200, body: "" });
+      return;
+    }
+    await route.continue();
+  });
+  await openBoardScenario(page, "board-staleness-twenty");
+  await page.locator("#board-alerts-toggle").click();
+
+  const bar = page.locator("#board-alerts");
+  const overlay = page.locator("body > #board-alerts-overlay");
+  const warnings = overlay.locator('[data-board-alert="staleness-warning"]');
+  const dismissedID = await warnings.first().getAttribute("data-staleness-warning-id");
+  await warnings.first().getByRole("button", { name: "Dismiss", exact: true }).click();
+
+  await expect(bar).toHaveAttribute("data-board-alert-count", "19");
+  await expect(bar.locator("[data-board-alert-count-label]")).toHaveText("19 warnings");
+  await expect(overlay.locator("[data-board-alert-count-label]")).toHaveText("19 warnings");
+  await expect(warnings).toHaveCount(19);
+  await expect(
+    overlay.locator(`[data-staleness-warning-id="${dismissedID}"]`),
+  ).toHaveCount(0);
+  await expect(
+    overlay.getByRole("button", { name: "Dismiss all staleness warnings (19)" }),
+  ).toBeVisible();
+
+  await morphCurrentSnapshot(page);
+  await expect(bar).toHaveAttribute("data-board-alert-count", "19");
+  await expect(warnings).toHaveCount(19);
+  await expect(
+    overlay.locator(`[data-staleness-warning-id="${dismissedID}"]`),
+  ).toHaveCount(0);
+});
+
+test("bulk dismiss submits the rendered warning IDs and clears both counts", async ({
+  page,
+}) => {
+  let submittedBody = "";
+  await page.route("**/api/v1/projects/**", async (route) => {
+    if (route.request().url().includes("/staleness-warnings/")) {
+      submittedBody = route.request().postData() || "";
+      await route.fulfill({ status: 200, body: "" });
+      return;
+    }
+    await route.continue();
+  });
+  page.on("dialog", (dialog) => dialog.accept());
+  await openBoardScenario(page, "board-staleness-twenty");
+  await page.locator("#board-alerts-toggle").click();
+
+  const overlay = page.locator("body > #board-alerts-overlay");
+  await overlay
+    .getByRole("button", { name: "Dismiss all staleness warnings (20)" })
+    .click();
+
+  await expect(page.locator("#board-alerts")).toHaveCount(0);
+  await expect(overlay).toBeHidden();
+  expect(new URLSearchParams(submittedBody).getAll("warning_id")).toHaveLength(20);
+  await morphCurrentSnapshot(page);
+  await expect(page.locator("#board-alerts")).toHaveCount(0);
+});
+
 test("warning disclosure state survives morphs without auto-expanding", async ({
   page,
 }) => {

--- a/tests/visual/freshness.spec.js
+++ b/tests/visual/freshness.spec.js
@@ -248,11 +248,31 @@ test("dismiss updates both counts and stays gone through the next SSE morph", as
   const overlay = page.locator("body > #board-alerts-overlay");
   const warnings = overlay.locator('[data-board-alert="staleness-warning"]');
   const dismissedID = await warnings.first().getAttribute("data-staleness-warning-id");
+  const nextLead = warnings.nth(1);
+  const nextLeadSummary = await nextLead.getAttribute("data-board-alert-summary");
+  const nextLeadTone = await nextLead.getAttribute("data-board-alert-tone");
+  const nextLeadGlyph = await nextLead
+    .locator("template[data-board-alert-glyph-template]")
+    .evaluate((element) => element.innerHTML);
   await warnings.first().getByRole("button", { name: "Dismiss", exact: true }).click();
 
   await expect(bar).toHaveAttribute("data-board-alert-count", "19");
   await expect(bar.locator("[data-board-alert-count-label]")).toHaveText("19 warnings");
   await expect(overlay.locator("[data-board-alert-count-label]")).toHaveText("19 warnings");
+  await expect(bar).toHaveAttribute("data-board-alert-tone", nextLeadTone);
+  await expect(bar.locator("[data-board-alert-lead-summary]")).toHaveText(nextLeadSummary);
+  await expect(page.locator("#board-alerts-toggle")).toHaveAttribute(
+    "aria-label",
+    `19 board warnings. Highest severity: ${nextLeadSummary}. Expand details.`,
+  );
+  expect(
+    await bar.locator("[data-board-alert-lead-glyph]").evaluate((element) => element.innerHTML),
+  ).toBe(nextLeadGlyph);
+  expect(
+    await overlay
+      .locator("[data-board-alert-lead-glyph]")
+      .evaluate((element) => element.innerHTML),
+  ).toBe(nextLeadGlyph);
   await expect(warnings).toHaveCount(19);
   await expect(
     overlay.locator(`[data-staleness-warning-id="${dismissedID}"]`),


### PR DESCRIPTION
## Summary

- Project persisted staleness acknowledgements into the shared effective snapshot immediately, so API, health, doctor, TUI, and SSE consumers cannot restore dismissed warnings while refresh is delayed or degraded.
- Validate active warning ownership, support transactional and idempotent dismissal of the explicit rendered ID set, and expire acknowledgement state after bounded inactivity.
- Reconcile the board badge, overlay count, canonical overlay, and bulk control on the successful response frame while preserving the collapsed alert-bar footprint.

Fixes #1966

## UI Surface Contract

- [x] N/A, or the linked issue explicitly authorizes any high-impact UI surface, layout, density, first-viewport, or responsive visibility tradeoff.
- [x] Persistent top-of-screen messaging is explicitly authorized by the issue, or this PR does not add it.
- [x] Visual changes to primary operator screens include screenshot or browser verification below.

Browser verification: all 10 Chromium freshness scenarios pass, including dismiss-then-SSE-morph, explicit-ID bulk dismiss, fixed collapsed height, and narrow overlay scrolling. The recovered worker also verified the overlay at 1440x900 with DPR 1 against an isolated ephemeral server.

## Test Plan

- [x] `GOTOOLCHAIN=go1.26.6 make check` with the CI-pinned golangci-lint 2.1.6
- [x] `go test ./internal/store ./internal/staleness ./internal/orchestrator ./internal/web`
- [x] `DETENT_BINARY="$PWD/tmp/detent" node_modules/.bin/playwright test tests/visual/freshness.spec.js --project=chromium`
- [x] `make generate` and generated-output cleanliness check