### PR TITLE
feat(scheduling): add shared owner lease

### DIFF
--- a/config.reference.yaml
+++ b/config.reference.yaml
@@ -1057,6 +1057,28 @@
 #   before_remove: null
 #   # hooks.timeout_ms | type: integer | default: 60000 | required: No | validation: must be greater than 0
 #   timeout_ms: 60000
+# # schedule_ownership | type: object | default: see child fields | required: No | validation: None
+# schedule_ownership:
+#   # schedule_ownership.enabled | type: boolean | default: false | required: No | validation: None
+#   enabled: false
+#   # schedule_ownership.backend | type: string | default: "github_ref" | required: No | validation: must be github_ref
+#   backend: "github_ref"
+#   # schedule_ownership.key | type: string | default: none | required: Conditional | validation: is required when enabled is true
+#   key: null
+#   # schedule_ownership.endpoint | type: string | default: none | required: No | validation: None
+#   endpoint: null
+#   # schedule_ownership.repository | type: string | default: none | required: No | validation: must use owner/name syntax
+#   repository: null
+#   # schedule_ownership.branch | type: string | default: "detent-schedule-coordination" | required: No | validation: must be a valid branch name
+#   branch: "detent-schedule-coordination"
+#   # schedule_ownership.lease_seconds | type: integer | default: 300 | required: No | validation: must be greater than zero
+#   lease_seconds: 300
+#   # schedule_ownership.heartbeat_seconds | type: integer | default: 60 | required: No | validation: must be greater than zero; must leave more than twice max_clock_skew_seconds before lease expiry
+#   heartbeat_seconds: 60
+#   # schedule_ownership.retry_seconds | type: integer | default: 15 | required: No | validation: must be greater than zero
+#   retry_seconds: 15
+#   # schedule_ownership.max_clock_skew_seconds | type: integer | default: 15 | required: No | validation: must be less than half lease_seconds; must not be negative
+#   max_clock_skew_seconds: 15
 # # intake | type: object | default: see child fields | required: Conditional | validation: tracker.repository is required for intake sources
 # intake:
 #   # intake.sources | type: list<object> | default: [] | required: No | validation: requires tracker.kind github

--- a/docs/config.md
+++ b/docs/config.md
@@ -818,6 +818,17 @@ only to resettable budget pacing and never clears a per-issue hard hold.
 | `routines[].prompt` | `string` | `none` | Conditional | is required |
 | `routines[].schedule` | `string` | `none` | Conditional | is required<br>must be a valid five-field cron expression |
 | `routines[].target_state` | `string` | `"Todo" when configured` | No | must name a configured workflow state |
+| `schedule_ownership` | `object` | `see child fields` | No | None |
+| `schedule_ownership.backend` | `string` | `"github_ref"` | No | must be github_ref |
+| `schedule_ownership.branch` | `string` | `"detent-schedule-coordination"` | No | must be a valid branch name |
+| `schedule_ownership.enabled` | `boolean` | `false` | No | None |
+| `schedule_ownership.endpoint` | `string` | `none` | No | None |
+| `schedule_ownership.heartbeat_seconds` | `integer` | `60` | No | must be greater than zero<br>must leave more than twice max_clock_skew_seconds before lease expiry |
+| `schedule_ownership.key` | `string` | `none` | Conditional | is required when enabled is true |
+| `schedule_ownership.lease_seconds` | `integer` | `300` | No | must be greater than zero |
+| `schedule_ownership.max_clock_skew_seconds` | `integer` | `15` | No | must be less than half lease_seconds<br>must not be negative |
+| `schedule_ownership.repository` | `string` | `none` | No | must use owner/name syntax |
+| `schedule_ownership.retry_seconds` | `integer` | `15` | No | must be greater than zero |
 | `server` | `object` | `see child fields` | No | None |
 | `server.board_snapshot_stale_after_seconds` | `integer` | `900` | No | must be greater than 0 |
 | `server.host` | `string` | `"127.0.0.1"` | No | is required |

--- a/docs/scheduled-routines.md
+++ b/docs/scheduled-routines.md
@@ -2,6 +2,48 @@
 
 [Back to README](../README.md#documentation)
 
+## Shared schedule ownership
+
+Scheduled intake sources, maintenance routines, and backlog admission remain
+inert until the project commits a shared ownership backend. All Detent daemons
+configured for the same key contend for one project lease, and only its holder
+starts the three cron loops. Webhook intake and explicit `RunOnce` operations
+do not require the scheduler lease.
+
+```yaml
+schedule_ownership:
+  enabled: true
+  backend: github_ref
+  key: example/production
+  repository: example/detent-coordination
+  branch: detent-schedule-coordination
+  lease_seconds: 300
+  heartbeat_seconds: 60
+  retry_seconds: 15
+  max_clock_skew_seconds: 15
+```
+
+The `github_ref` backend stores lease and issue-creation records on the named
+coordination branch. It uses GitHub's expected-head commit check as a shared
+compare-and-swap boundary; the branch is created from the repository's default
+branch on first use. The credential must be able to read the repository and
+create commits on that branch. A dedicated coordination repository keeps these
+small state commits out of a product repository's normal branch history.
+
+`key` is the committed fleet-wide project identity and must be identical on
+every host. `instance_name` supplies the owner shown by `detent doctor`; Detent
+uses the hostname when it is omitted. The heartbeat renews before the holder's
+local safety deadline. A contender waits through the lease TTL plus the
+configured maximum clock skew before takeover, so failover is bounded without
+allowing clock drift to create two active holders. Changing ownership backend
+settings requires a Detent restart.
+
+Issue fingerprints use durable records on the same branch. A creator reserves
+the fingerprint before posting and records the resulting issue. If a create
+response becomes uncertain, successors reconcile the marker and do not issue a
+second POST. `detent doctor` fails when scheduled operations lack ownership,
+the backend is unreachable, or no active owner is renewing the project lease.
+
 ## Alert and Scheduled Intake
 
 GitHub projects can turn external events and repository scans into normal board

--- a/internal/cli/boot.go
+++ b/internal/cli/boot.go
@@ -312,6 +312,7 @@ func startRunningWithDependencies(ctx context.Context, cfg BootConfig, deps star
 		Activity:           activityBroker,
 		GitHubToken:        runtimeGitHubToken.get(),
 		RefreshGitHubToken: refreshGitHubToken,
+		ScheduleOwner:      cfg.Global.InstanceName,
 		ConnectorFactory:   cfg.ConnectorFactory,
 		Runner:             cfg.Runner,
 	}, runtimeStore, nil, runtimeGitHubToken.get)

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -262,6 +262,7 @@ type doctorDeps struct {
 	gitRemoteURL         func(context.Context, string) (string, error)
 	gitTracked           func(context.Context, string) (bool, error)
 	workflowSourcePolicy doctorWorkflowSourcePolicyFunc
+	scheduleOwnership    doctorScheduleOwnershipProbe
 	autoPromoteConnector func(workflowconfig.Config) (doctorAutoPromoteConnector, error)
 	proposalConnector    func(workflowconfig.Config) (doctorWorkflowProposalConnector, error)
 	modelProbe           func(context.Context, doctorRouteModelProbeRequest) error
@@ -1183,6 +1184,9 @@ func (d doctorDeps) withDefaults() doctorDeps {
 	if d.workflowSourcePolicy == nil {
 		d.workflowSourcePolicy = defaults.workflowSourcePolicy
 	}
+	if d.scheduleOwnership == nil {
+		d.scheduleOwnership = defaults.scheduleOwnership
+	}
 	if d.autoPromoteConnector == nil {
 		d.autoPromoteConnector = defaults.autoPromoteConnector
 	}
@@ -1231,6 +1235,7 @@ func defaultDoctorDeps() doctorDeps {
 		gitRemoteURL:         defaultGitRemoteURL,
 		gitTracked:           defaultGitTracked,
 		workflowSourcePolicy: defaultDoctorWorkflowSourcePolicy,
+		scheduleOwnership:    defaultDoctorScheduleOwnership,
 		autoPromoteConnector: defaultDoctorAutoPromoteConnector,
 		proposalConnector:    defaultDoctorProposalConnector,
 		modelProbe:           defaultDoctorRouteModelProbe,

--- a/internal/cli/doctor_github.go
+++ b/internal/cli/doctor_github.go
@@ -406,7 +406,7 @@ func doctorTrackerStateMap(value workflowconfig.StringOrMap) map[string]string {
 
 func doctorWorkflowConfigWithRuntimeGitHubToken(cfg workflowconfig.Config, token string) workflowconfig.Config {
 	token = strings.TrimSpace(token)
-	if token != "" && doctorTrackerUsesGitHubReads(cfg.Tracker.Kind) {
+	if token != "" && (doctorTrackerUsesGitHubReads(cfg.Tracker.Kind) || cfg.ScheduleOwnership.Enabled) {
 		cfg.Tracker.APIKey = token
 	}
 	return cfg

--- a/internal/cli/doctor_project.go
+++ b/internal/cli/doctor_project.go
@@ -335,6 +335,10 @@ func checkDoctorProjectWithProgress(
 		}
 	}
 	checks = append(checks, workflowCheck)
+	if workflow.Config.SchedulersEnabled() {
+		setDoctorCurrentCheck("Project " + id + " schedule ownership")
+		checks = append(checks, checkDoctorScheduleOwnership(ctx, id, workflow.Config, deps))
+	}
 	setDoctorCurrentCheck("Project " + id + " capabilities")
 	checks = append(checks, checkDoctorCapabilities(project, workflow))
 	setDoctorCurrentCheck("Project " + id + " workflow source policy")

--- a/internal/cli/doctor_schedule_ownership.go
+++ b/internal/cli/doctor_schedule_ownership.go
@@ -1,0 +1,118 @@
+package cli
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"strings"
+	"time"
+
+	workflowconfig "github.com/digitaldrywood/detent/internal/config"
+	ghconnector "github.com/digitaldrywood/detent/internal/connector/github"
+	"github.com/digitaldrywood/detent/internal/coordination"
+	"github.com/digitaldrywood/detent/internal/scheduleowner"
+)
+
+type doctorScheduleOwnershipProbe func(context.Context, workflowconfig.Config) (scheduleowner.Status, error)
+
+func checkDoctorScheduleOwnership(
+	ctx context.Context,
+	projectID string,
+	cfg workflowconfig.Config,
+	deps doctorDeps,
+) doctorCheck {
+	name := "Project " + projectID + " schedule ownership"
+	if !cfg.ScheduleOwnership.Enabled {
+		return doctorCheck{
+			Name:   name,
+			Status: doctorFail,
+			Detail: "scheduled operations are enabled but schedule_ownership.enabled is false",
+			Hint:   "Commit a shared schedule_ownership backend and key before running schedulers on any host.",
+		}
+	}
+	probe := deps.scheduleOwnership
+	if probe == nil {
+		probe = defaultDoctorScheduleOwnership
+	}
+	status, err := probe(ctx, cfg)
+	if err != nil {
+		return doctorCheck{
+			Name:   name,
+			Status: doctorFail,
+			Detail: fmt.Sprintf("no reachable schedule owner: %v", err),
+			Hint:   "Fix the coordination repository, branch permissions, or GitHub credentials, then rerun detent doctor.",
+		}
+	}
+	if !status.Active {
+		detail := "coordination backend is reachable but no active schedule owner is present"
+		if status.Owner != "" {
+			detail = fmt.Sprintf("schedule owner %s generation %d expired at %s", status.Owner, status.Generation, doctorScheduleOwnershipTime(status.ExpiresAt))
+		}
+		return doctorCheck{
+			Name:   name,
+			Status: doctorFail,
+			Detail: detail,
+			Hint:   "Start one configured Detent daemon and confirm it can acquire and renew the project schedule lease.",
+		}
+	}
+	return doctorCheck{
+		Name:   name,
+		Status: doctorOK,
+		Detail: fmt.Sprintf("owner %s holds generation %d; renewed %s; expires no earlier than %s", status.Owner, status.Generation, doctorScheduleOwnershipTime(status.RenewedAt), doctorScheduleOwnershipTime(status.ExpiresAt)),
+	}
+}
+
+func defaultDoctorScheduleOwnership(ctx context.Context, cfg workflowconfig.Config) (scheduleowner.Status, error) {
+	coordinationEndpoint := ""
+	if cfg.Tracker.Kind == workflowconfig.TrackerGitHub || cfg.Tracker.Kind == workflowconfig.TrackerGitHubLocal {
+		coordinationEndpoint = cfg.Tracker.Endpoint
+	}
+	ownership := cfg.ScheduleOwnership.Normalized(cfg.Tracker.Repository, coordinationEndpoint)
+	httpClient := ghconnector.NewPooledHTTPClient(ghconnector.HTTPTransportConfig{
+		MaxIdleConns:        cfg.Tracker.HTTPMaxIdleConns,
+		MaxIdleConnsPerHost: cfg.Tracker.HTTPMaxIdleConnsPerHost,
+		IdleConnTimeout:     time.Duration(cfg.Tracker.HTTPIdleConnTimeoutMS) * time.Millisecond,
+	})
+	defer func() {
+		if closeErr := httpClient.Close(); closeErr != nil {
+			slog.Default().DebugContext(ctx, "close doctor schedule ownership client failed", "error", closeErr)
+		}
+	}()
+	tokenSource := ghconnector.NewTokenResolver(ghconnector.TokenResolverConfig{
+		Endpoint:                ownership.Endpoint,
+		APIKey:                  cfg.Tracker.APIKey,
+		GitHubAppID:             cfg.Tracker.GitHubAppID,
+		GitHubAppPrivateKey:     cfg.Tracker.GitHubAppPrivateKey,
+		GitHubAppPrivateKeyPath: cfg.Tracker.GitHubAppPrivateKeyPath,
+		GitHubAppInstallationID: cfg.Tracker.GitHubAppInstallationID,
+		HTTPClient:              httpClient,
+	})
+	client, err := ghconnector.NewClient(ghconnector.ClientConfig{
+		Endpoint:    ownership.Endpoint,
+		TokenSource: tokenSource,
+		HTTPClient:  httpClient,
+	})
+	if err != nil {
+		return scheduleowner.Status{}, err
+	}
+	store, err := coordination.NewGitHubRefStore(coordination.GitHubRefConfig{
+		Repository: ownership.Repository,
+		Branch:     ownership.Branch,
+		Client:     client,
+	})
+	if err != nil {
+		return scheduleowner.Status{}, err
+	}
+	manager, err := scheduleowner.New(ownership, "doctor", store, scheduleowner.Dependencies{})
+	if err != nil {
+		return scheduleowner.Status{}, err
+	}
+	return manager.Current(ctx)
+}
+
+func doctorScheduleOwnershipTime(value time.Time) string {
+	if value.IsZero() {
+		return "unknown"
+	}
+	return strings.TrimSpace(value.UTC().Format(time.RFC3339))
+}

--- a/internal/cli/doctor_schedule_ownership_test.go
+++ b/internal/cli/doctor_schedule_ownership_test.go
@@ -1,0 +1,46 @@
+package cli
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	workflowconfig "github.com/digitaldrywood/detent/internal/config"
+	"github.com/digitaldrywood/detent/internal/scheduleowner"
+)
+
+func TestCheckDoctorScheduleOwnership(t *testing.T) {
+	t.Parallel()
+	now := time.Date(2026, 8, 24, 12, 0, 0, 0, time.UTC)
+	tests := []struct {
+		name       string
+		enabled    bool
+		status     scheduleowner.Status
+		probeErr   error
+		wantStatus doctorStatus
+		wantDetail string
+	}{
+		{name: "missing config", wantStatus: doctorFail, wantDetail: "enabled is false"},
+		{name: "backend unreachable", enabled: true, probeErr: errors.New("forbidden"), wantStatus: doctorFail, wantDetail: "no reachable schedule owner"},
+		{name: "no owner", enabled: true, status: scheduleowner.Status{}, wantStatus: doctorFail, wantDetail: "no active schedule owner"},
+		{name: "expired owner", enabled: true, status: scheduleowner.Status{Owner: "alpha", Generation: 2, ExpiresAt: now.Add(-time.Minute)}, wantStatus: doctorFail, wantDetail: "expired"},
+		{name: "active owner", enabled: true, status: scheduleowner.Status{Owner: "alpha", Generation: 3, RenewedAt: now, ExpiresAt: now.Add(5 * time.Minute), Active: true}, wantStatus: doctorOK, wantDetail: "owner alpha holds generation 3"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			cfg := workflowconfig.Default()
+			cfg.ScheduleOwnership.Enabled = tt.enabled
+			check := checkDoctorScheduleOwnership(t.Context(), "example", cfg, doctorDeps{
+				scheduleOwnership: func(context.Context, workflowconfig.Config) (scheduleowner.Status, error) {
+					return tt.status, tt.probeErr
+				},
+			})
+			if check.Status != tt.wantStatus || !strings.Contains(check.Detail, tt.wantDetail) {
+				t.Fatalf("check = %#v, want status %s detail %q", check, tt.wantStatus, tt.wantDetail)
+			}
+		})
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -22,6 +22,7 @@ import (
 	"github.com/digitaldrywood/detent/internal/intake"
 	"github.com/digitaldrywood/detent/internal/pathsafe"
 	"github.com/digitaldrywood/detent/internal/retro"
+	"github.com/digitaldrywood/detent/internal/scheduleowner"
 	"github.com/digitaldrywood/detent/internal/scheduler"
 	"github.com/digitaldrywood/detent/internal/selector"
 	commandshell "github.com/digitaldrywood/detent/internal/shell"
@@ -147,29 +148,30 @@ type WorkflowOverlay struct {
 }
 
 type Config struct {
-	Identity         Identity           `yaml:"identity,omitempty"`
-	ActiveHours      activehours.Config `yaml:"active_hours,omitempty"`
-	Tracker          Tracker            `yaml:"tracker"`
-	Polling          Polling            `yaml:"polling"`
-	Workspace        Workspace          `yaml:"workspace"`
-	Workpad          Workpad            `yaml:"workpad,omitempty"`
-	Deliverable      Deliverable        `yaml:"deliverable,omitempty"`
-	Dependencies     Dependencies       `yaml:"dependencies,omitempty"`
-	Worker           Worker             `yaml:"worker"`
-	Agent            Agent              `yaml:"agent"`
-	Agents           Agents             `yaml:"agents"`
-	Codex            Codex              `yaml:"codex"`
-	Gate             gate.Config        `yaml:"gate"`
-	Plan             gate.PlanConfig    `yaml:"plan"`
-	Server           Server             `yaml:"server"`
-	Observability    Observability      `yaml:"observability"`
-	Budget           Budget             `yaml:"budget"`
-	Release          Release            `yaml:"release,omitempty"`
-	Hooks            Hooks              `yaml:"hooks"`
-	Intake           intake.Config      `yaml:"intake,omitempty"`
-	Retro            retro.Config       `yaml:"retro,omitempty"`
-	Routines         []Routine          `yaml:"routines,omitempty"`
-	BacklogAdmission BacklogAdmission   `yaml:"backlog_admission,omitempty"`
+	Identity          Identity             `yaml:"identity,omitempty"`
+	ActiveHours       activehours.Config   `yaml:"active_hours,omitempty"`
+	Tracker           Tracker              `yaml:"tracker"`
+	Polling           Polling              `yaml:"polling"`
+	Workspace         Workspace            `yaml:"workspace"`
+	Workpad           Workpad              `yaml:"workpad,omitempty"`
+	Deliverable       Deliverable          `yaml:"deliverable,omitempty"`
+	Dependencies      Dependencies         `yaml:"dependencies,omitempty"`
+	Worker            Worker               `yaml:"worker"`
+	Agent             Agent                `yaml:"agent"`
+	Agents            Agents               `yaml:"agents"`
+	Codex             Codex                `yaml:"codex"`
+	Gate              gate.Config          `yaml:"gate"`
+	Plan              gate.PlanConfig      `yaml:"plan"`
+	Server            Server               `yaml:"server"`
+	Observability     Observability        `yaml:"observability"`
+	Budget            Budget               `yaml:"budget"`
+	Release           Release              `yaml:"release,omitempty"`
+	Hooks             Hooks                `yaml:"hooks"`
+	ScheduleOwnership scheduleowner.Config `yaml:"schedule_ownership,omitempty"`
+	Intake            intake.Config        `yaml:"intake,omitempty"`
+	Retro             retro.Config         `yaml:"retro,omitempty"`
+	Routines          []Routine            `yaml:"routines,omitempty"`
+	BacklogAdmission  BacklogAdmission     `yaml:"backlog_admission,omitempty"`
 
 	configuredFields map[string]struct{}
 }
@@ -1502,6 +1504,14 @@ func Default() Config {
 			VersionBump:     "auto",
 		},
 		Budget: budget,
+		ScheduleOwnership: scheduleowner.Config{
+			Backend:             scheduleowner.BackendGitHubRef,
+			Branch:              scheduleowner.DefaultBranch,
+			LeaseSeconds:        scheduleowner.DefaultLeaseSeconds,
+			HeartbeatSeconds:    scheduleowner.DefaultHeartbeatSeconds,
+			RetrySeconds:        scheduleowner.DefaultRetrySeconds,
+			MaxClockSkewSeconds: scheduleowner.DefaultMaxClockSkewSeconds,
+		},
 		BacklogAdmission: BacklogAdmission{
 			Schedule:               DefaultBacklogAdmissionSchedule,
 			EffortFile:             BacklogAdmissionEffortFileWorkflow,
@@ -1570,6 +1580,12 @@ func (c *Config) Validate() error {
 	}
 	c.Budget.validate("budget", &problems)
 	c.Hooks.validate(&problems)
+	coordinationEndpoint := ""
+	if c.Tracker.Kind == TrackerGitHub || c.Tracker.Kind == TrackerGitHubLocal {
+		coordinationEndpoint = c.Tracker.Endpoint
+	}
+	c.ScheduleOwnership = c.ScheduleOwnership.Normalized(c.Tracker.Repository, coordinationEndpoint)
+	problems = append(problems, c.ScheduleOwnership.Validate("schedule_ownership")...)
 	states := make([]string, 0, len(c.configuredWorkflowStates()))
 	for _, state := range c.configuredWorkflowStates() {
 		states = append(states, state)
@@ -1798,10 +1814,27 @@ func (c *Config) normalize() {
 	c.Server.Normalize()
 	c.Observability.Normalize()
 	c.Hooks.Shell = commandshell.Normalize(c.Hooks.Shell)
+	coordinationEndpoint := ""
+	if c.Tracker.Kind == TrackerGitHub || c.Tracker.Kind == TrackerGitHubLocal {
+		coordinationEndpoint = c.Tracker.Endpoint
+	}
+	c.ScheduleOwnership = c.ScheduleOwnership.Normalized(c.Tracker.Repository, coordinationEndpoint)
 	c.Intake.Normalize()
 	c.Retro.Normalize()
 	c.Routines = NormalizeRoutines(c.Routines)
 	c.BacklogAdmission.Normalize()
+}
+
+func (c Config) SchedulersEnabled() bool {
+	if len(c.Routines) > 0 || c.BacklogAdmission.Enabled {
+		return true
+	}
+	for _, source := range c.Intake.Sources {
+		if source.Kind == intake.KindSchedule {
+			return true
+		}
+	}
+	return false
 }
 
 func (c *Config) validateTracker(problems *[]string) {

--- a/internal/config/configdoc/configdoc.go
+++ b/internal/config/configdoc/configdoc.go
@@ -244,6 +244,7 @@ func expandable(typ reflect.Type) bool {
 		path == "github.com/digitaldrywood/detent/internal/gate" ||
 		path == "github.com/digitaldrywood/detent/internal/intake" ||
 		path == "github.com/digitaldrywood/detent/internal/retro" ||
+		path == "github.com/digitaldrywood/detent/internal/scheduleowner" ||
 		path == "github.com/digitaldrywood/detent/internal/selector"
 }
 

--- a/internal/config/schedule_ownership_test.go
+++ b/internal/config/schedule_ownership_test.go
@@ -1,0 +1,114 @@
+package config
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/digitaldrywood/detent/internal/intake"
+	"github.com/digitaldrywood/detent/internal/scheduleowner"
+)
+
+func TestParseWorkflowScheduleOwnership(t *testing.T) {
+	t.Parallel()
+	workflow, err := ParseWorkflow([]byte(`---
+tracker:
+  kind: github
+  api_key: token
+  github_status_source: label
+  repository: example/issues
+schedule_ownership:
+  enabled: true
+  backend: github_ref
+  key: example/production
+  repository: example/coordination
+  branch: scheduler-state
+  lease_seconds: 240
+  heartbeat_seconds: 60
+  retry_seconds: 10
+  max_clock_skew_seconds: 10
+---
+Prompt
+`))
+	if err != nil {
+		t.Fatalf("ParseWorkflow() error = %v", err)
+	}
+	if err := workflow.Config.Validate(); err != nil {
+		t.Fatalf("Validate() error = %v", err)
+	}
+	got := workflow.Config.ScheduleOwnership
+	if !got.Enabled || got.Backend != scheduleowner.BackendGitHubRef || got.Key != "example/production" ||
+		got.Repository != "example/coordination" || got.Branch != "scheduler-state" || got.LeaseSeconds != 240 ||
+		got.HeartbeatSeconds != 60 || got.RetrySeconds != 10 || got.MaxClockSkewSeconds != 10 {
+		t.Fatalf("ScheduleOwnership = %#v", got)
+	}
+}
+
+func TestScheduleOwnershipValidation(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name   string
+		mutate func(*scheduleowner.Config)
+		want   string
+	}{
+		{name: "missing key", mutate: func(cfg *scheduleowner.Config) { cfg.Key = "" }, want: "key is required"},
+		{name: "invalid repository", mutate: func(cfg *scheduleowner.Config) { cfg.Repository = "repo" }, want: "owner/name"},
+		{name: "heartbeat too late", mutate: func(cfg *scheduleowner.Config) { cfg.HeartbeatSeconds = 280 }, want: "heartbeat_seconds"},
+		{name: "clock skew too large", mutate: func(cfg *scheduleowner.Config) { cfg.MaxClockSkewSeconds = 150 }, want: "less than half"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			cfg := Default()
+			cfg.Tracker.Kind = TrackerGitHub
+			cfg.Tracker.APIKey = "token"
+			cfg.Tracker.Repository = "example/issues"
+			cfg.ScheduleOwnership.Enabled = true
+			cfg.ScheduleOwnership.Key = "example/production"
+			cfg.ScheduleOwnership.Repository = "example/coordination"
+			tt.mutate(&cfg.ScheduleOwnership)
+			err := cfg.Validate()
+			if err == nil || !strings.Contains(err.Error(), tt.want) {
+				t.Fatalf("Validate() error = %v, want %q", err, tt.want)
+			}
+		})
+	}
+}
+
+func TestSchedulersEnabled(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name string
+		cfg  Config
+		want bool
+	}{
+		{name: "none", cfg: Default()},
+		{name: "webhook only", cfg: func() Config {
+			cfg := Default()
+			cfg.Intake.Sources = []intake.Source{{Kind: intake.KindWebhook}}
+			return cfg
+		}()},
+		{name: "scheduled intake", cfg: func() Config {
+			cfg := Default()
+			cfg.Intake.Sources = []intake.Source{{Kind: intake.KindSchedule}}
+			return cfg
+		}(), want: true},
+		{name: "routine", cfg: func() Config {
+			cfg := Default()
+			cfg.Routines = []Routine{{Name: "audit"}}
+			return cfg
+		}(), want: true},
+		{name: "admission", cfg: func() Config {
+			cfg := Default()
+			cfg.BacklogAdmission.Enabled = true
+			return cfg
+		}(), want: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := tt.cfg.SchedulersEnabled(); got != tt.want {
+				t.Fatalf("SchedulersEnabled() = %t, want %t", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/coordination/github_ref.go
+++ b/internal/coordination/github_ref.go
@@ -1,0 +1,292 @@
+package coordination
+
+import (
+	"bytes"
+	"context"
+	"encoding/base64"
+	"errors"
+	"fmt"
+	"io"
+	"path"
+	"strings"
+	"time"
+)
+
+const githubRefStateQuery = `
+query DetentCoordinationState($owner: String!, $name: String!, $qualifiedName: String!, $expression: String!, $path: String!) {
+  repository(owner: $owner, name: $name) {
+    id
+    defaultBranchRef { target { oid } }
+    ref(qualifiedName: $qualifiedName) {
+      target {
+        oid
+        ... on Commit {
+          history(first: 1, path: $path) { nodes { committedDate } }
+        }
+      }
+    }
+    object(expression: $expression) {
+      ... on Blob { oid text }
+    }
+  }
+}`
+
+const githubRefCreateMutation = `
+mutation DetentCoordinationCreateRef($input: CreateRefInput!) {
+  createRef(input: $input) { ref { id target { oid } } }
+}`
+
+const githubRefCommitMutation = `
+mutation DetentCoordinationCommit($input: CreateCommitOnBranchInput!) {
+  createCommitOnBranch(input: $input) { commit { oid committedDate } }
+}`
+
+var (
+	ErrInvalidGitHubRefConfig = errors.New("github ref coordination config is invalid")
+	ErrInvalidGitHubResponse  = errors.New("github ref coordination response is invalid")
+)
+
+type GraphQLClient interface {
+	GraphQL(context.Context, string, map[string]any, any) error
+}
+
+type GitHubRefConfig struct {
+	Repository string
+	Branch     string
+	Client     GraphQLClient
+	Now        func() time.Time
+}
+
+type GitHubRefStore struct {
+	client GraphQLClient
+	owner  string
+	name   string
+	branch string
+	now    func() time.Time
+}
+
+type githubRefState struct {
+	record           Record
+	found            bool
+	repositoryID     string
+	defaultBranchOID string
+	branchFound      bool
+}
+
+func NewGitHubRefStore(cfg GitHubRefConfig) (*GitHubRefStore, error) {
+	owner, name, ok := strings.Cut(strings.TrimSpace(cfg.Repository), "/")
+	if !ok || strings.TrimSpace(owner) == "" || strings.TrimSpace(name) == "" || strings.Contains(name, "/") {
+		return nil, fmt.Errorf("%w: repository must use owner/name syntax", ErrInvalidGitHubRefConfig)
+	}
+	branch := strings.TrimSpace(strings.TrimPrefix(strings.TrimSpace(cfg.Branch), "refs/heads/"))
+	if branch == "" {
+		return nil, fmt.Errorf("%w: branch is required", ErrInvalidGitHubRefConfig)
+	}
+	if cfg.Client == nil {
+		return nil, fmt.Errorf("%w: graphql client is required", ErrInvalidGitHubRefConfig)
+	}
+	now := cfg.Now
+	if now == nil {
+		now = time.Now
+	}
+	return &GitHubRefStore{
+		client: cfg.Client,
+		owner:  strings.TrimSpace(owner),
+		name:   strings.TrimSpace(name),
+		branch: branch,
+		now:    now,
+	}, nil
+}
+
+func (s *GitHubRefStore) Get(ctx context.Context, key string) (Record, bool, error) {
+	state, err := s.read(ctx, key)
+	if err != nil {
+		return Record{}, false, err
+	}
+	return state.record, state.found, nil
+}
+
+func (s *GitHubRefStore) Close() error {
+	if s == nil {
+		return nil
+	}
+	closer, ok := s.client.(io.Closer)
+	if !ok {
+		return nil
+	}
+	return closer.Close()
+}
+
+func (s *GitHubRefStore) CompareAndSwap(ctx context.Context, key string, expectedVersion string, value []byte) (Record, bool, error) {
+	state, err := s.read(ctx, key)
+	if err != nil {
+		return Record{}, false, err
+	}
+	if state.record.Version != strings.TrimSpace(expectedVersion) {
+		return Record{}, false, nil
+	}
+	if !state.branchFound {
+		if expectedVersion != "" {
+			return Record{}, false, nil
+		}
+		if err := s.createBranch(ctx, state.repositoryID, state.defaultBranchOID); err != nil {
+			refreshed, readErr := s.read(ctx, key)
+			if readErr == nil && refreshed.branchFound {
+				return Record{}, false, nil
+			}
+			return Record{}, false, err
+		}
+		return Record{}, false, nil
+	}
+
+	cleanKey, err := cleanCoordinationKey(key)
+	if err != nil {
+		return Record{}, false, err
+	}
+	variables := map[string]any{
+		"input": map[string]any{
+			"branch": map[string]any{
+				"repositoryNameWithOwner": s.owner + "/" + s.name,
+				"branchName":              s.branch,
+			},
+			"message":         map[string]any{"headline": "chore(detent): update coordination state"},
+			"expectedHeadOid": state.record.Version,
+			"fileChanges": map[string]any{
+				"additions": []map[string]any{{
+					"path":     cleanKey,
+					"contents": base64.StdEncoding.EncodeToString(value),
+				}},
+			},
+		},
+	}
+	var response struct {
+		CreateCommitOnBranch *struct {
+			Commit *struct {
+				OID           string    `json:"oid"`
+				CommittedDate time.Time `json:"committedDate"`
+			} `json:"commit"`
+		} `json:"createCommitOnBranch"`
+	}
+	if err := s.client.GraphQL(ctx, githubRefCommitMutation, variables, &response); err != nil {
+		refreshed, readErr := s.read(ctx, cleanKey)
+		if readErr == nil {
+			if refreshed.record.Version != state.record.Version && bytes.Equal(refreshed.record.Value, value) {
+				return refreshed.record, true, nil
+			}
+			if refreshed.record.Version != state.record.Version {
+				return Record{}, false, nil
+			}
+		}
+		return Record{}, false, err
+	}
+	if response.CreateCommitOnBranch == nil || response.CreateCommitOnBranch.Commit == nil || strings.TrimSpace(response.CreateCommitOnBranch.Commit.OID) == "" {
+		return Record{}, false, ErrInvalidGitHubResponse
+	}
+	modifiedAt := response.CreateCommitOnBranch.Commit.CommittedDate.UTC()
+	if modifiedAt.IsZero() {
+		modifiedAt = s.now().UTC()
+	}
+	return Record{
+		Value:      append([]byte(nil), value...),
+		Version:    strings.TrimSpace(response.CreateCommitOnBranch.Commit.OID),
+		ModifiedAt: modifiedAt,
+	}, true, nil
+}
+
+func (s *GitHubRefStore) read(ctx context.Context, key string) (githubRefState, error) {
+	cleanKey, err := cleanCoordinationKey(key)
+	if err != nil {
+		return githubRefState{}, err
+	}
+	variables := map[string]any{
+		"owner":         s.owner,
+		"name":          s.name,
+		"qualifiedName": "refs/heads/" + s.branch,
+		"expression":    s.branch + ":" + cleanKey,
+		"path":          cleanKey,
+	}
+	var response struct {
+		Repository *struct {
+			ID               string `json:"id"`
+			DefaultBranchRef *struct {
+				Target struct {
+					OID string `json:"oid"`
+				} `json:"target"`
+			} `json:"defaultBranchRef"`
+			Ref *struct {
+				Target struct {
+					OID     string `json:"oid"`
+					History struct {
+						Nodes []struct {
+							CommittedDate time.Time `json:"committedDate"`
+						} `json:"nodes"`
+					} `json:"history"`
+				} `json:"target"`
+			} `json:"ref"`
+			Object *struct {
+				OID  string `json:"oid"`
+				Text string `json:"text"`
+			} `json:"object"`
+		} `json:"repository"`
+	}
+	if err := s.client.GraphQL(ctx, githubRefStateQuery, variables, &response); err != nil {
+		return githubRefState{}, err
+	}
+	if response.Repository == nil || strings.TrimSpace(response.Repository.ID) == "" {
+		return githubRefState{}, ErrInvalidGitHubResponse
+	}
+	state := githubRefState{repositoryID: strings.TrimSpace(response.Repository.ID)}
+	if response.Repository.DefaultBranchRef != nil {
+		state.defaultBranchOID = strings.TrimSpace(response.Repository.DefaultBranchRef.Target.OID)
+	}
+	if response.Repository.Ref == nil {
+		return state, nil
+	}
+	state.branchFound = true
+	state.record.Version = strings.TrimSpace(response.Repository.Ref.Target.OID)
+	if response.Repository.Object == nil {
+		return state, nil
+	}
+	state.found = true
+	state.record.Value = []byte(response.Repository.Object.Text)
+	if nodes := response.Repository.Ref.Target.History.Nodes; len(nodes) > 0 {
+		state.record.ModifiedAt = nodes[0].CommittedDate.UTC()
+	}
+	return state, nil
+}
+
+func (s *GitHubRefStore) createBranch(ctx context.Context, repositoryID string, oid string) error {
+	if strings.TrimSpace(repositoryID) == "" || strings.TrimSpace(oid) == "" {
+		return fmt.Errorf("%w: default branch is unavailable", ErrInvalidGitHubResponse)
+	}
+	variables := map[string]any{
+		"input": map[string]any{
+			"repositoryId": repositoryID,
+			"name":         "refs/heads/" + s.branch,
+			"oid":          oid,
+		},
+	}
+	var response struct {
+		CreateRef *struct {
+			Ref *struct {
+				ID string `json:"id"`
+			} `json:"ref"`
+		} `json:"createRef"`
+	}
+	if err := s.client.GraphQL(ctx, githubRefCreateMutation, variables, &response); err != nil {
+		return err
+	}
+	if response.CreateRef == nil || response.CreateRef.Ref == nil || strings.TrimSpace(response.CreateRef.Ref.ID) == "" {
+		return ErrInvalidGitHubResponse
+	}
+	return nil
+}
+
+func cleanCoordinationKey(key string) (string, error) {
+	key = strings.TrimSpace(strings.ReplaceAll(key, "\\", "/"))
+	cleaned := path.Clean(key)
+	if key == "" || cleaned == "." || cleaned == "/" || strings.HasPrefix(cleaned, "../") || cleaned == ".." || strings.HasPrefix(cleaned, "/") {
+		return "", fmt.Errorf("%w: key must be a relative path", ErrInvalidGitHubRefConfig)
+	}
+	return cleaned, nil
+}

--- a/internal/coordination/github_ref_test.go
+++ b/internal/coordination/github_ref_test.go
@@ -1,0 +1,126 @@
+package coordination
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestGitHubRefStoreBootstrapsAndComparesHead(t *testing.T) {
+	t.Parallel()
+	client := newGitHubRefTestClient()
+	store, err := NewGitHubRefStore(GitHubRefConfig{Repository: "example/coordination", Branch: "scheduler", Client: client})
+	if err != nil {
+		t.Fatalf("NewGitHubRefStore() error = %v", err)
+	}
+
+	if _, swapped, err := store.CompareAndSwap(t.Context(), "projects/one.json", "", []byte("one")); err != nil || swapped {
+		t.Fatalf("bootstrap CompareAndSwap() = swapped %t, error %v", swapped, err)
+	}
+	record, found, err := store.Get(t.Context(), "projects/one.json")
+	if err != nil || found || record.Version != "base" {
+		t.Fatalf("Get() after bootstrap = %#v, %t, %v", record, found, err)
+	}
+	first, swapped, err := store.CompareAndSwap(t.Context(), "projects/one.json", record.Version, []byte("one"))
+	if err != nil || !swapped || first.Version != "commit-1" {
+		t.Fatalf("first CompareAndSwap() = %#v, %t, %v", first, swapped, err)
+	}
+	if _, swapped, err := store.CompareAndSwap(t.Context(), "projects/one.json", record.Version, []byte("two")); err != nil || swapped {
+		t.Fatalf("stale CompareAndSwap() = swapped %t, error %v", swapped, err)
+	}
+	got, found, err := store.Get(t.Context(), "projects/one.json")
+	if err != nil || !found || string(got.Value) != "one" || got.Version != "commit-1" {
+		t.Fatalf("Get() = %#v, %t, %v", got, found, err)
+	}
+}
+
+func TestGitHubRefStoreRejectsUnsafeKeys(t *testing.T) {
+	t.Parallel()
+	store, err := NewGitHubRefStore(GitHubRefConfig{Repository: "example/coordination", Branch: "scheduler", Client: newGitHubRefTestClient()})
+	if err != nil {
+		t.Fatalf("NewGitHubRefStore() error = %v", err)
+	}
+	if _, _, err := store.Get(t.Context(), "../outside"); !errors.Is(err, ErrInvalidGitHubRefConfig) {
+		t.Fatalf("Get() error = %v, want ErrInvalidGitHubRefConfig", err)
+	}
+}
+
+type githubRefTestClient struct {
+	mu       sync.Mutex
+	branch   bool
+	head     string
+	defaultO string
+	values   map[string]string
+	modified map[string]time.Time
+	commits  int
+}
+
+func newGitHubRefTestClient() *githubRefTestClient {
+	return &githubRefTestClient{defaultO: "base", values: map[string]string{}, modified: map[string]time.Time{}}
+}
+
+func (c *githubRefTestClient) GraphQL(_ context.Context, query string, variables map[string]any, out any) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	switch {
+	case strings.Contains(query, "DetentCoordinationState"):
+		key, _ := variables["path"].(string)
+		repository := map[string]any{
+			"id":               "R_1",
+			"defaultBranchRef": map[string]any{"target": map[string]any{"oid": c.defaultO}},
+		}
+		if c.branch {
+			history := []map[string]any{}
+			if modified := c.modified[key]; !modified.IsZero() {
+				history = append(history, map[string]any{"committedDate": modified})
+			}
+			repository["ref"] = map[string]any{"target": map[string]any{"oid": c.head, "history": map[string]any{"nodes": history}}}
+			if value, ok := c.values[key]; ok {
+				repository["object"] = map[string]any{"oid": "blob", "text": value}
+			}
+		}
+		return decodeGitHubRefTestResponse(out, map[string]any{"repository": repository})
+	case strings.Contains(query, "DetentCoordinationCreateRef"):
+		if c.branch {
+			return errors.New("reference already exists")
+		}
+		c.branch = true
+		c.head = c.defaultO
+		return decodeGitHubRefTestResponse(out, map[string]any{"createRef": map[string]any{"ref": map[string]any{"id": "REF_1"}}})
+	case strings.Contains(query, "DetentCoordinationCommit"):
+		input := variables["input"].(map[string]any)
+		expected := input["expectedHeadOid"].(string)
+		if expected != c.head {
+			return errors.New("expected head does not match")
+		}
+		addition := input["fileChanges"].(map[string]any)["additions"].([]map[string]any)[0]
+		key := addition["path"].(string)
+		encoded := addition["contents"].(string)
+		value, err := base64.StdEncoding.DecodeString(encoded)
+		if err != nil {
+			return err
+		}
+		c.commits++
+		c.head = fmt.Sprintf("commit-%d", c.commits)
+		modified := time.Date(2026, 8, 24, 12, c.commits, 0, 0, time.UTC)
+		c.values[key] = string(value)
+		c.modified[key] = modified
+		return decodeGitHubRefTestResponse(out, map[string]any{"createCommitOnBranch": map[string]any{"commit": map[string]any{"oid": c.head, "committedDate": modified}}})
+	default:
+		return errors.New("unexpected graphql operation")
+	}
+}
+
+func decodeGitHubRefTestResponse(out any, value any) error {
+	raw, err := json.Marshal(value)
+	if err != nil {
+		return err
+	}
+	return json.Unmarshal(raw, out)
+}

--- a/internal/coordination/store.go
+++ b/internal/coordination/store.go
@@ -1,0 +1,17 @@
+package coordination
+
+import (
+	"context"
+	"time"
+)
+
+type Record struct {
+	Value      []byte
+	Version    string
+	ModifiedAt time.Time
+}
+
+type Store interface {
+	Get(context.Context, string) (Record, bool, error)
+	CompareAndSwap(context.Context, string, string, []byte) (Record, bool, error)
+}

--- a/internal/intake/intake.go
+++ b/internal/intake/intake.go
@@ -57,6 +57,10 @@ type IssueStore interface {
 	SetIntakeIssueState(context.Context, string, string) error
 }
 
+type IssueCreator interface {
+	EnsureIntakeIssue(context.Context, string, IssueDraft) (Issue, bool, error)
+}
+
 type WebhookAdapter interface {
 	Decode([]byte) (Event, error)
 }
@@ -397,13 +401,18 @@ func (m *Manager) process(ctx context.Context, source Source, store IssueStore, 
 	if found {
 		return m.updateExisting(ctx, source, store, marker, issue, draft, pendingDraft, result)
 	}
-	issue, err = store.CreateIntakeIssue(ctx, pendingDraft)
+	created := true
+	if creator, ok := store.(IssueCreator); ok {
+		issue, created, err = creator.EnsureIntakeIssue(ctx, marker, pendingDraft)
+	} else {
+		issue, err = store.CreateIntakeIssue(ctx, pendingDraft)
+	}
 	if err != nil {
 		return result, fmt.Errorf("create intake issue: %w", err)
 	}
 	m.issues[marker] = issue
 	result.Issue = issue
-	result.Created = true
+	result.Created = created
 	if err := store.SetIntakeIssueState(ctx, issue.ID, source.Creates.Status); err != nil {
 		return result, fmt.Errorf("set intake issue %s state: %w", issue.Identifier, err)
 	}

--- a/internal/project/connector_config_test.go
+++ b/internal/project/connector_config_test.go
@@ -28,6 +28,18 @@ func TestTrackerStateMapConvertsWorkflowMap(t *testing.T) {
 	}
 }
 
+func TestWorkflowConfigWithGitHubTokenSupportsScheduleOwnership(t *testing.T) {
+	t.Parallel()
+	cfg := workflowconfig.Default()
+	cfg.Tracker.Kind = workflowconfig.TrackerMemory
+	cfg.ScheduleOwnership.Enabled = true
+
+	got := workflowConfigWithGitHubToken(cfg, "runtime-token")
+	if got.Tracker.APIKey != "runtime-token" {
+		t.Fatalf("Tracker.APIKey = %q, want runtime-token", got.Tracker.APIKey)
+	}
+}
+
 func TestWorkflowConfigWithProjectPathsResolvesArtifactWorkflowPaths(t *testing.T) {
 	t.Parallel()
 

--- a/internal/project/project.go
+++ b/internal/project/project.go
@@ -4,11 +4,15 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"log/slog"
+	"os"
 	"path/filepath"
 	"strings"
 	"sync"
 	"time"
+
+	"golang.org/x/sync/errgroup"
 
 	"github.com/digitaldrywood/detent/internal/activehours"
 	"github.com/digitaldrywood/detent/internal/activity"
@@ -18,8 +22,10 @@ import (
 	configwatcher "github.com/digitaldrywood/detent/internal/config/watcher"
 	"github.com/digitaldrywood/detent/internal/connector"
 	"github.com/digitaldrywood/detent/internal/connector/factory"
+	ghconnector "github.com/digitaldrywood/detent/internal/connector/github"
 	"github.com/digitaldrywood/detent/internal/connector/local"
 	"github.com/digitaldrywood/detent/internal/connector/memory"
+	"github.com/digitaldrywood/detent/internal/coordination"
 	"github.com/digitaldrywood/detent/internal/efficiency"
 	"github.com/digitaldrywood/detent/internal/hub"
 	"github.com/digitaldrywood/detent/internal/intake"
@@ -29,6 +35,7 @@ import (
 	"github.com/digitaldrywood/detent/internal/retro"
 	"github.com/digitaldrywood/detent/internal/routine"
 	runpkg "github.com/digitaldrywood/detent/internal/runner"
+	"github.com/digitaldrywood/detent/internal/scheduleowner"
 	"github.com/digitaldrywood/detent/internal/scheduler"
 	"github.com/digitaldrywood/detent/internal/selector"
 	"github.com/digitaldrywood/detent/internal/store"
@@ -136,6 +143,8 @@ type Dependencies struct {
 	RetroStore                store.RetroStore
 	RoutineStore              store.RoutineStore
 	AdmissionStore            store.AdmissionStore
+	ScheduleStore             coordination.Store
+	ScheduleOwner             string
 }
 
 type Project struct {
@@ -157,6 +166,9 @@ type Project struct {
 	retro                     *retro.Manager
 	routine                   *routine.Manager
 	admission                 *admission.Manager
+	scheduleOwner             *scheduleowner.Manager
+	issueCoordinator          *scheduleowner.IssueCoordinator
+	scheduleConfig            scheduleowner.Config
 	retroProduct              connector.Connector
 	events                    *hub.Hub[Event]
 	logger                    *slog.Logger
@@ -222,12 +234,24 @@ func New(cfg Config, deps Dependencies) (*Project, error) {
 	if logger == nil {
 		logger = slog.Default()
 	}
+	projectScheduleOwner, issueCoordinator, scheduleConfig, err := buildScheduleOwnership(workflow.Config, deps, logger)
+	if err != nil {
+		return nil, errors.Join(fmt.Errorf("create project schedule ownership: %w", err), closeConnector(projectConnector))
+	}
+	retainScheduleOwner := false
+	defer func() {
+		if !retainScheduleOwner {
+			if closeErr := closeScheduleOwner(projectScheduleOwner); closeErr != nil {
+				logger.Warn("close unused schedule ownership failed", "project_id", id, "error", closeErr)
+			}
+		}
+	}()
 	intakeDependencies := deps.IntakeDependencies
 	intakeDependencies.Root = intakeRoot(cfg.Project, workflow.Config)
 	if intakeDependencies.Logger == nil {
 		intakeDependencies.Logger = logger
 	}
-	projectIntake, err := intake.New(workflow.Config.Intake, intakeStore(projectConnector), intakeDependencies)
+	projectIntake, err := intake.New(workflow.Config.Intake, coordinatedIntakeStore(projectConnector, issueCoordinator), intakeDependencies)
 	if err != nil {
 		return nil, fmt.Errorf("create project intake: %w", err)
 	}
@@ -255,7 +279,7 @@ func New(cfg Config, deps Dependencies) (*Project, error) {
 		Definitions:  workflow.Config.Routines,
 		SearchStates: workflow.Config.KanbanStateNames(),
 		Runner:       deps.Runner,
-		Issues:       routineIssueStore(projectConnector),
+		Issues:       coordinatedRoutineIssueStore(projectConnector, issueCoordinator),
 		Metrics:      deps.WorkflowMetrics,
 	}, deps.RoutineStore, logger, nil)
 	if err != nil {
@@ -349,7 +373,7 @@ func New(cfg Config, deps Dependencies) (*Project, error) {
 	workflowModifiedAt := workflowFileModifiedAt(cfg.Project)
 
 	cfg.Project.ID = string(id)
-	return &Project{
+	project := &Project{
 		id:                        id,
 		cfg:                       cfg.Project,
 		workflow:                  workflow,
@@ -368,6 +392,9 @@ func New(cfg Config, deps Dependencies) (*Project, error) {
 		retro:                     projectRetro,
 		routine:                   projectRoutine,
 		admission:                 projectAdmission,
+		scheduleOwner:             projectScheduleOwner,
+		issueCoordinator:          issueCoordinator,
+		scheduleConfig:            scheduleConfig,
 		retroProduct:              retroProductConnector,
 		events:                    projectEvents,
 		logger:                    logger,
@@ -381,7 +408,9 @@ func New(cfg Config, deps Dependencies) (*Project, error) {
 			ModifiedAt: workflowModifiedAt,
 			LoadedAt:   time.Now().UTC(),
 		},
-	}, nil
+	}
+	retainScheduleOwner = true
+	return project, nil
 }
 
 func (p *Project) ID() ID {
@@ -781,9 +810,10 @@ func (p *Project) closeConnector() error {
 	p.mu.Lock()
 	projectConnector := p.connector
 	retroProductConnector := p.retroProduct
+	scheduleOwner := p.scheduleOwner
 	p.mu.Unlock()
 
-	return errors.Join(closeConnector(projectConnector), closeConnector(retroProductConnector))
+	return errors.Join(closeConnector(projectConnector), closeConnector(retroProductConnector), closeScheduleOwner(scheduleOwner))
 }
 
 func (p *Project) stop(ctx context.Context, publishEvents bool) error {
@@ -873,14 +903,10 @@ func (p *Project) waitDone(ctx context.Context, done <-chan struct{}) error {
 func (p *Project) run(ctx context.Context, done chan struct{}, orch *orchestrator.Orchestrator) {
 	watcherCtx, stopWatcher := context.WithCancel(ctx)
 	watcherDone := p.startWorkflowWatcher(watcherCtx)
-	intakeCtx, stopIntake := context.WithCancel(ctx)
-	intakeDone := p.startIntake(intakeCtx)
 	retroCtx, stopRetro := context.WithCancel(ctx)
 	retroDone := p.startRetro(retroCtx)
-	routineCtx, stopRoutine := context.WithCancel(ctx)
-	routineDone := p.startRoutine(routineCtx)
-	admissionCtx, stopAdmission := context.WithCancel(ctx)
-	admissionDone := p.startAdmission(admissionCtx)
+	schedulesCtx, stopSchedules := context.WithCancel(ctx)
+	schedulesDone := p.startSchedules(schedulesCtx)
 
 	runStarted := logProjectShutdownBoundaryBegin(p.logger, "orchestrator_run", "component", "orchestrator", "project_id", p.id)
 	err := orch.Run(ctx)
@@ -897,14 +923,6 @@ func (p *Project) run(ctx context.Context, done chan struct{}, orch *orchestrato
 	} else {
 		logProjectShutdownBoundaryEndResult(p.logger, "workflow_watcher_stop", watcherStarted, "skipped", nil, "component", "workflow_watcher", "project_id", p.id)
 	}
-	intakeStarted := logProjectShutdownBoundaryBegin(p.logger, "intake_stop", "component", "intake", "project_id", p.id)
-	stopIntake()
-	if intakeDone != nil {
-		<-intakeDone
-		logProjectShutdownBoundaryEnd(p.logger, "intake_stop", intakeStarted, nil, "component", "intake", "project_id", p.id)
-	} else {
-		logProjectShutdownBoundaryEndResult(p.logger, "intake_stop", intakeStarted, "skipped", nil, "component", "intake", "project_id", p.id)
-	}
 	retroStarted := logProjectShutdownBoundaryBegin(p.logger, "retro_stop", "component", "retro", "project_id", p.id)
 	stopRetro()
 	if retroDone != nil {
@@ -913,22 +931,10 @@ func (p *Project) run(ctx context.Context, done chan struct{}, orch *orchestrato
 	} else {
 		logProjectShutdownBoundaryEndResult(p.logger, "retro_stop", retroStarted, "skipped", nil, "component", "retro", "project_id", p.id)
 	}
-	routineStarted := logProjectShutdownBoundaryBegin(p.logger, "routine_stop", "component", "routine", "project_id", p.id)
-	stopRoutine()
-	if routineDone != nil {
-		<-routineDone
-		logProjectShutdownBoundaryEnd(p.logger, "routine_stop", routineStarted, nil, "component", "routine", "project_id", p.id)
-	} else {
-		logProjectShutdownBoundaryEndResult(p.logger, "routine_stop", routineStarted, "skipped", nil, "component", "routine", "project_id", p.id)
-	}
-	admissionStarted := logProjectShutdownBoundaryBegin(p.logger, "backlog_admission_stop", "component", "backlog_admission", "project_id", p.id)
-	stopAdmission()
-	if admissionDone != nil {
-		<-admissionDone
-		logProjectShutdownBoundaryEnd(p.logger, "backlog_admission_stop", admissionStarted, nil, "component", "backlog_admission", "project_id", p.id)
-	} else {
-		logProjectShutdownBoundaryEndResult(p.logger, "backlog_admission_stop", admissionStarted, "skipped", nil, "component", "backlog_admission", "project_id", p.id)
-	}
+	schedulesStarted := logProjectShutdownBoundaryBegin(p.logger, "schedules_stop", "component", "schedules", "project_id", p.id)
+	stopSchedules()
+	<-schedulesDone
+	logProjectShutdownBoundaryEnd(p.logger, "schedules_stop", schedulesStarted, nil, "component", "schedules", "project_id", p.id)
 	if errors.Is(err, context.Canceled) && ctx.Err() != nil {
 		err = nil
 	}
@@ -957,23 +963,6 @@ func (p *Project) run(ctx context.Context, done chan struct{}, orch *orchestrato
 	close(done)
 }
 
-func (p *Project) startIntake(ctx context.Context) <-chan struct{} {
-	p.mu.Lock()
-	manager := p.intake
-	p.mu.Unlock()
-	if manager == nil {
-		return nil
-	}
-	done := make(chan struct{})
-	go func() {
-		defer close(done)
-		if err := manager.Run(ctx); err != nil && ctx.Err() == nil {
-			p.logger.Error("project intake stopped", "project_id", p.id, "error", err)
-		}
-	}()
-	return done
-}
-
 func (p *Project) startRetro(ctx context.Context) <-chan struct{} {
 	p.mu.Lock()
 	manager := p.retro
@@ -991,38 +980,45 @@ func (p *Project) startRetro(ctx context.Context) <-chan struct{} {
 	return done
 }
 
-func (p *Project) startRoutine(ctx context.Context) <-chan struct{} {
+func (p *Project) startSchedules(ctx context.Context) <-chan struct{} {
 	p.mu.Lock()
-	manager := p.routine
+	owner := p.scheduleOwner
+	schedulersEnabled := p.workflow.Config.SchedulersEnabled()
 	p.mu.Unlock()
-	if manager == nil {
-		return nil
-	}
 	done := make(chan struct{})
 	go func() {
 		defer close(done)
-		if err := manager.Run(ctx); err != nil && ctx.Err() == nil {
-			p.logger.Error("project routine stopped", "project_id", p.id, "error", err)
+		if owner == nil {
+			if schedulersEnabled {
+				p.logger.Error("project schedules disabled because schedule ownership is not configured", "project_id", p.id)
+			}
+			<-ctx.Done()
+			return
+		}
+		if err := owner.Run(ctx, p.runOwnedSchedules); err != nil && ctx.Err() == nil {
+			p.logger.Error("project schedules stopped", "project_id", p.id, "error", err)
 		}
 	}()
 	return done
 }
 
-func (p *Project) startAdmission(ctx context.Context) <-chan struct{} {
+func (p *Project) runOwnedSchedules(ctx context.Context) error {
 	p.mu.Lock()
-	manager := p.admission
+	intakeManager := p.intake
+	routineManager := p.routine
+	admissionManager := p.admission
 	p.mu.Unlock()
-	if manager == nil {
-		return nil
+	group, runCtx := errgroup.WithContext(ctx)
+	if intakeManager != nil {
+		group.Go(func() error { return intakeManager.Run(runCtx) })
 	}
-	done := make(chan struct{})
-	go func() {
-		defer close(done)
-		if err := manager.Run(ctx); err != nil && ctx.Err() == nil {
-			p.logger.Error("project backlog admission stopped", "project_id", p.id, "error", err)
-		}
-	}()
-	return done
+	if routineManager != nil {
+		group.Go(func() error { return routineManager.Run(runCtx) })
+	}
+	if admissionManager != nil {
+		group.Go(func() error { return admissionManager.Run(runCtx) })
+	}
+	return group.Wait()
 }
 
 func logProjectShutdownBoundaryBegin(logger *slog.Logger, operation string, attrs ...any) time.Time {
@@ -1265,6 +1261,8 @@ func (p *Project) handleWorkflowUpdate(ctx context.Context, update configwatcher
 	projectRetro := p.retro
 	projectRoutine := p.routine
 	projectAdmission := p.admission
+	issueCoordinator := p.issueCoordinator
+	scheduleConfig := p.scheduleConfig
 	globalDispatchGate := p.orchDeps.GlobalDispatchGate
 	p.mu.Unlock()
 	workflow := normalizeWorkflow(update.Workflow)
@@ -1276,6 +1274,9 @@ func (p *Project) handleWorkflowUpdate(ctx context.Context, update configwatcher
 	}
 	if err := workflowconfig.ValidateWorkflowAdmission(workflow); err != nil {
 		return p.workflowReloadError("workflow reload validation failed", update.Path, err)
+	}
+	if workflow.Config.ScheduleOwnership != scheduleConfig {
+		return p.workflowReloadError("workflow reload validation failed", update.Path, errors.New("schedule_ownership changes require a Detent restart"))
 	}
 	admissionCriteria := workflowconfig.AdmissionCriteria{}
 	admissionEffortRubric := workflowconfig.AdmissionEffortRubric{}
@@ -1330,7 +1331,7 @@ func (p *Project) handleWorkflowUpdate(ctx context.Context, update configwatcher
 	if projectIntake != nil {
 		preparedIntake, err = projectIntake.Prepare(
 			workflow.Config.Intake,
-			intakeStore(projectConnector),
+			coordinatedIntakeStore(projectConnector, issueCoordinator),
 			intakeRoot(projectConfig, workflow.Config),
 		)
 		if err != nil {
@@ -1375,7 +1376,7 @@ func (p *Project) handleWorkflowUpdate(ctx context.Context, update configwatcher
 			Definitions:  workflow.Config.Routines,
 			SearchStates: workflow.Config.KanbanStateNames(),
 			Runner:       runner,
-			Issues:       routineIssueStore(projectConnector),
+			Issues:       coordinatedRoutineIssueStore(projectConnector, issueCoordinator),
 			Metrics:      p.orchDeps.WorkflowMetrics,
 		}); err != nil {
 			return p.workflowReloadError("apply workflow routine reload failed", update.Path, err)
@@ -1564,12 +1565,137 @@ func intakeStore(projectConnector connector.Connector) intake.IssueStore {
 	return store
 }
 
+type coordinatedIntakeIssueStore struct {
+	intake.IssueStore
+	coordinator *scheduleowner.IssueCoordinator
+}
+
+func (s coordinatedIntakeIssueStore) EnsureIntakeIssue(
+	ctx context.Context,
+	marker string,
+	draft intake.IssueDraft,
+) (intake.Issue, bool, error) {
+	return s.coordinator.Ensure(ctx, marker, draft, s.IssueStore)
+}
+
+func coordinatedIntakeStore(projectConnector connector.Connector, coordinator *scheduleowner.IssueCoordinator) intake.IssueStore {
+	store := intakeStore(projectConnector)
+	if store == nil || coordinator == nil {
+		return store
+	}
+	return coordinatedIntakeIssueStore{IssueStore: store, coordinator: coordinator}
+}
+
 func routineIssueStore(projectConnector connector.Connector) routine.IssueStore {
 	issueStore, ok := projectConnector.(routine.IssueStore)
 	if !ok {
 		return nil
 	}
 	return issueStore
+}
+
+type coordinatedRoutineStore struct {
+	routine.IssueStore
+	coordinator *scheduleowner.IssueCoordinator
+}
+
+func (s coordinatedRoutineStore) EnsureIntakeIssue(
+	ctx context.Context,
+	marker string,
+	draft intake.IssueDraft,
+) (intake.Issue, bool, error) {
+	return s.coordinator.Ensure(ctx, marker, draft, s.IssueStore)
+}
+
+func coordinatedRoutineIssueStore(projectConnector connector.Connector, coordinator *scheduleowner.IssueCoordinator) routine.IssueStore {
+	store := routineIssueStore(projectConnector)
+	if store == nil || coordinator == nil {
+		return store
+	}
+	return coordinatedRoutineStore{IssueStore: store, coordinator: coordinator}
+}
+
+func buildScheduleOwnership(
+	cfg workflowconfig.Config,
+	deps Dependencies,
+	logger *slog.Logger,
+) (*scheduleowner.Manager, *scheduleowner.IssueCoordinator, scheduleowner.Config, error) {
+	coordinationEndpoint := ""
+	if cfg.Tracker.Kind == workflowconfig.TrackerGitHub || cfg.Tracker.Kind == workflowconfig.TrackerGitHubLocal {
+		coordinationEndpoint = cfg.Tracker.Endpoint
+	}
+	ownership := cfg.ScheduleOwnership.Normalized(cfg.Tracker.Repository, coordinationEndpoint)
+	if !ownership.Enabled {
+		return nil, nil, ownership, nil
+	}
+	coordinationStore := deps.ScheduleStore
+	var coordinationCloser io.Closer
+	if coordinationStore == nil {
+		httpClient := ghconnector.NewPooledHTTPClient(ghconnector.HTTPTransportConfig{
+			MaxIdleConns:        cfg.Tracker.HTTPMaxIdleConns,
+			MaxIdleConnsPerHost: cfg.Tracker.HTTPMaxIdleConnsPerHost,
+			IdleConnTimeout:     time.Duration(cfg.Tracker.HTTPIdleConnTimeoutMS) * time.Millisecond,
+		})
+		coordinationToken := strings.TrimSpace(deps.GitHubToken)
+		if coordinationToken == "" {
+			coordinationToken = strings.TrimSpace(cfg.Tracker.APIKey)
+		}
+		var tokenSource ghconnector.TokenSource = ghconnector.NewTokenResolver(ghconnector.TokenResolverConfig{
+			Endpoint:                ownership.Endpoint,
+			APIKey:                  coordinationToken,
+			GitHubAppID:             cfg.Tracker.GitHubAppID,
+			GitHubAppPrivateKey:     cfg.Tracker.GitHubAppPrivateKey,
+			GitHubAppPrivateKeyPath: cfg.Tracker.GitHubAppPrivateKeyPath,
+			GitHubAppInstallationID: cfg.Tracker.GitHubAppInstallationID,
+			HTTPClient:              httpClient,
+		})
+		if deps.RefreshGitHubToken != nil && coordinationToken != "" {
+			tokenSource = ghconnector.NewRefreshableTokenSource(coordinationToken, deps.RefreshGitHubToken)
+		}
+		client, err := ghconnector.NewClient(ghconnector.ClientConfig{
+			Endpoint:    ownership.Endpoint,
+			TokenSource: tokenSource,
+			HTTPClient:  httpClient,
+			Logger:      logger,
+		})
+		if err != nil {
+			return nil, nil, ownership, errors.Join(err, httpClient.Close())
+		}
+		githubStore, storeErr := coordination.NewGitHubRefStore(coordination.GitHubRefConfig{
+			Repository: ownership.Repository,
+			Branch:     ownership.Branch,
+			Client:     client,
+		})
+		if storeErr != nil {
+			return nil, nil, ownership, errors.Join(storeErr, client.Close())
+		}
+		coordinationStore = githubStore
+		coordinationCloser = githubStore
+	}
+	owner := strings.TrimSpace(deps.ScheduleOwner)
+	if owner == "" {
+		hostname, hostnameErr := os.Hostname()
+		if hostnameErr != nil {
+			if coordinationCloser != nil {
+				return nil, nil, ownership, errors.Join(hostnameErr, coordinationCloser.Close())
+			}
+			return nil, nil, ownership, hostnameErr
+		}
+		owner = hostname
+		owner = strings.TrimSpace(owner)
+	}
+	manager, err := scheduleowner.New(ownership, owner, coordinationStore, scheduleowner.Dependencies{Closer: coordinationCloser, Logger: logger})
+	if err != nil {
+		if coordinationCloser != nil {
+			return nil, nil, ownership, errors.Join(err, coordinationCloser.Close())
+		}
+		return nil, nil, ownership, err
+	}
+	coordinator, err := scheduleowner.NewIssueCoordinator(ownership, coordinationStore, scheduleowner.Dependencies{})
+	if err != nil {
+		return nil, nil, ownership, errors.Join(err, manager.Close())
+	}
+	return manager, coordinator, ownership, nil
 }
 
 func admissionIssueStore(projectConnector connector.Connector) admission.IssueStore {
@@ -1674,7 +1800,7 @@ func projectRelativePath(base string, path string) string {
 
 func workflowConfigWithGitHubToken(workflow workflowconfig.Config, token string) workflowconfig.Config {
 	token = strings.TrimSpace(token)
-	if token != "" && (workflow.Tracker.Kind == workflowconfig.TrackerGitHub || workflow.Tracker.Kind == workflowconfig.TrackerGitHubLocal) {
+	if token != "" && (workflow.Tracker.Kind == workflowconfig.TrackerGitHub || workflow.Tracker.Kind == workflowconfig.TrackerGitHubLocal || workflow.ScheduleOwnership.Enabled) {
 		workflow.Tracker.APIKey = token
 	}
 	return workflow
@@ -1797,6 +1923,13 @@ func closeConnector(projectConnector connector.Connector) error {
 		return nil
 	}
 	return closer.Close()
+}
+
+func closeScheduleOwner(owner *scheduleowner.Manager) error {
+	if owner == nil {
+		return nil
+	}
+	return owner.Close()
 }
 
 func resolveSchedulerFactory(deps Dependencies) schedulerFactory {

--- a/internal/project/project.go
+++ b/internal/project/project.go
@@ -1599,12 +1599,25 @@ type coordinatedRoutineStore struct {
 	coordinator *scheduleowner.IssueCoordinator
 }
 
-func (s coordinatedRoutineStore) EnsureIntakeIssue(
+func (s coordinatedRoutineStore) EnsureRoutineIssue(
 	ctx context.Context,
 	marker string,
 	draft intake.IssueDraft,
 ) (intake.Issue, bool, error) {
-	return s.coordinator.Ensure(ctx, marker, draft, s.IssueStore)
+	return s.coordinator.EnsureRecurring(ctx, marker, draft, s)
+}
+
+func (s coordinatedRoutineStore) IntakeIssueClosed(ctx context.Context, issueID string) (bool, error) {
+	issues, err := s.FetchIssueStatesByIDs(ctx, []string{issueID})
+	if err != nil {
+		return false, err
+	}
+	for _, issue := range issues {
+		if strings.TrimSpace(issue.ID) == strings.TrimSpace(issueID) {
+			return issue.Closed, nil
+		}
+	}
+	return false, nil
 }
 
 func coordinatedRoutineIssueStore(projectConnector connector.Connector, coordinator *scheduleowner.IssueCoordinator) routine.IssueStore {

--- a/internal/routine/manager.go
+++ b/internal/routine/manager.go
@@ -59,6 +59,10 @@ type IssueStore interface {
 	SetIntakeIssueState(context.Context, string, string) error
 }
 
+type IssueCreator interface {
+	EnsureRoutineIssue(context.Context, string, intake.IssueDraft) (intake.Issue, bool, error)
+}
+
 type RunRecord = routinemodel.RunRecord
 
 type IssueRecord = routinemodel.IssueRecord
@@ -493,6 +497,9 @@ func createRoutineIssue(
 	marker string,
 	draft intake.IssueDraft,
 ) (intake.Issue, bool, error) {
+	if creator, ok := store.(IssueCreator); ok {
+		return creator.EnsureRoutineIssue(ctx, marker, draft)
+	}
 	if creator, ok := store.(intake.IssueCreator); ok {
 		return creator.EnsureIntakeIssue(ctx, marker, draft)
 	}

--- a/internal/routine/manager.go
+++ b/internal/routine/manager.go
@@ -422,7 +422,7 @@ func (m *Manager) fileProposals(ctx context.Context, settings Settings, definiti
 		}
 		fileAttempts++
 		labels := proposalLabels(definition, proposal)
-		issue, createErr := settings.Issues.CreateIntakeIssue(ctx, intake.IssueDraft{
+		issue, created, createErr := createRoutineIssue(ctx, settings.Issues, marker, intake.IssueDraft{
 			Title:  proposal.Title,
 			Body:   scopeMarker + "\n" + marker + "\n\n" + proposal.Body,
 			Labels: labels,
@@ -431,6 +431,17 @@ func (m *Manager) fileProposals(ctx context.Context, settings Settings, definiti
 		openMarkers[marker] = struct{}{}
 		record := IssueRecord{ID: issue.ID, Identifier: issue.Identifier, URL: issue.URL}
 		if strings.TrimSpace(record.ID) != "" {
+			if !created {
+				if _, ok := filedIssueSet[strings.TrimSpace(record.ID)]; !ok {
+					if err := m.store.RecordRoutineIssue(ctx, settings.ProjectID, definition.Name, record); err != nil {
+						runErr = errors.Join(runErr, fmt.Errorf("record reconciled routine issue %s: %w", proposal.DedupKey, err))
+						break
+					}
+					filedIssueSet[strings.TrimSpace(record.ID)] = struct{}{}
+				}
+				result.Deduplicated++
+				continue
+			}
 			result.Filed = append(result.Filed, record)
 			filedIssueSet[strings.TrimSpace(record.ID)] = struct{}{}
 			if err := m.store.RecordRoutineIssue(ctx, settings.ProjectID, definition.Name, record); err != nil {
@@ -474,6 +485,19 @@ func (m *Manager) fileProposals(ctx context.Context, settings Settings, definiti
 		)
 	}
 	return result, runErr
+}
+
+func createRoutineIssue(
+	ctx context.Context,
+	store IssueStore,
+	marker string,
+	draft intake.IssueDraft,
+) (intake.Issue, bool, error) {
+	if creator, ok := store.(intake.IssueCreator); ok {
+		return creator.EnsureIntakeIssue(ctx, marker, draft)
+	}
+	issue, err := store.CreateIntakeIssue(ctx, draft)
+	return issue, true, err
 }
 
 func (m *Manager) nextScheduled(ctx context.Context) (time.Time, string, bool, error) {

--- a/internal/scheduleowner/config.go
+++ b/internal/scheduleowner/config.go
@@ -1,0 +1,136 @@
+package scheduleowner
+
+import (
+	"strings"
+	"time"
+)
+
+const (
+	BackendGitHubRef           = "github_ref"
+	DefaultBranch              = "detent-schedule-coordination"
+	DefaultLeaseSeconds        = 300
+	DefaultHeartbeatSeconds    = 60
+	DefaultRetrySeconds        = 15
+	DefaultMaxClockSkewSeconds = 15
+)
+
+type Config struct {
+	Enabled             bool   `yaml:"enabled"`
+	Backend             string `yaml:"backend"`
+	Key                 string `yaml:"key"`
+	Endpoint            string `yaml:"endpoint,omitempty"`
+	Repository          string `yaml:"repository"`
+	Branch              string `yaml:"branch"`
+	LeaseSeconds        int    `yaml:"lease_seconds"`
+	HeartbeatSeconds    int    `yaml:"heartbeat_seconds"`
+	RetrySeconds        int    `yaml:"retry_seconds"`
+	MaxClockSkewSeconds int    `yaml:"max_clock_skew_seconds"`
+}
+
+func (c Config) Normalized(defaultRepository string, defaultEndpoint string) Config {
+	c.Backend = strings.ToLower(strings.TrimSpace(c.Backend))
+	if c.Backend == "" {
+		c.Backend = BackendGitHubRef
+	}
+	c.Key = strings.TrimSpace(c.Key)
+	c.Endpoint = strings.TrimSpace(c.Endpoint)
+	if c.Endpoint == "" {
+		c.Endpoint = strings.TrimSpace(defaultEndpoint)
+	}
+	c.Repository = strings.TrimSpace(c.Repository)
+	if c.Repository == "" {
+		c.Repository = strings.TrimSpace(defaultRepository)
+	}
+	c.Branch = strings.TrimSpace(strings.TrimPrefix(strings.TrimSpace(c.Branch), "refs/heads/"))
+	if c.Branch == "" {
+		c.Branch = DefaultBranch
+	}
+	if c.LeaseSeconds == 0 {
+		c.LeaseSeconds = DefaultLeaseSeconds
+	}
+	if c.HeartbeatSeconds == 0 {
+		c.HeartbeatSeconds = DefaultHeartbeatSeconds
+	}
+	if c.RetrySeconds == 0 {
+		c.RetrySeconds = DefaultRetrySeconds
+	}
+	if c.MaxClockSkewSeconds == 0 {
+		c.MaxClockSkewSeconds = DefaultMaxClockSkewSeconds
+	}
+	return c
+}
+
+func (c Config) Validate(prefix string) []string {
+	if !c.Enabled {
+		return nil
+	}
+	if prefix == "" {
+		prefix = "schedule_ownership"
+	}
+	problems := []string{}
+	if c.Backend != BackendGitHubRef {
+		problems = append(problems, prefix+".backend must be github_ref")
+	}
+	if c.Key == "" {
+		problems = append(problems, prefix+".key is required when enabled is true")
+	} else if strings.ContainsAny(c.Key, "\r\n") {
+		problems = append(problems, prefix+".key must be a single line")
+	}
+	if !validRepository(c.Repository) {
+		problems = append(problems, prefix+".repository must use owner/name syntax")
+	}
+	if !validBranch(c.Branch) {
+		problems = append(problems, prefix+".branch must be a valid branch name")
+	}
+	if c.LeaseSeconds <= 0 {
+		problems = append(problems, prefix+".lease_seconds must be greater than zero")
+	}
+	if c.HeartbeatSeconds <= 0 {
+		problems = append(problems, prefix+".heartbeat_seconds must be greater than zero")
+	}
+	if c.RetrySeconds <= 0 {
+		problems = append(problems, prefix+".retry_seconds must be greater than zero")
+	}
+	if c.MaxClockSkewSeconds < 0 {
+		problems = append(problems, prefix+".max_clock_skew_seconds must not be negative")
+	}
+	if c.MaxClockSkewSeconds*2 >= c.LeaseSeconds {
+		problems = append(problems, prefix+".max_clock_skew_seconds must be less than half lease_seconds")
+	}
+	if c.HeartbeatSeconds >= c.LeaseSeconds-c.MaxClockSkewSeconds*2 {
+		problems = append(problems, prefix+".heartbeat_seconds must leave more than twice max_clock_skew_seconds before lease expiry")
+	}
+	return problems
+}
+
+func (c Config) LeaseTTL() time.Duration {
+	return time.Duration(c.LeaseSeconds) * time.Second
+}
+
+func (c Config) HeartbeatInterval() time.Duration {
+	return time.Duration(c.HeartbeatSeconds) * time.Second
+}
+
+func (c Config) RetryInterval() time.Duration {
+	return time.Duration(c.RetrySeconds) * time.Second
+}
+
+func (c Config) MaxClockSkew() time.Duration {
+	return time.Duration(c.MaxClockSkewSeconds) * time.Second
+}
+
+func validRepository(repository string) bool {
+	owner, name, ok := strings.Cut(strings.TrimSpace(repository), "/")
+	return ok && strings.TrimSpace(owner) != "" && strings.TrimSpace(name) != "" && !strings.Contains(name, "/")
+}
+
+func validBranch(branch string) bool {
+	branch = strings.TrimSpace(branch)
+	return branch != "" &&
+		!strings.HasPrefix(branch, "/") &&
+		!strings.HasSuffix(branch, "/") &&
+		!strings.HasSuffix(branch, ".") &&
+		!strings.Contains(branch, "..") &&
+		!strings.Contains(branch, "@{") &&
+		!strings.ContainsAny(branch, " ~^:?*[\\")
+}

--- a/internal/scheduleowner/issue.go
+++ b/internal/scheduleowner/issue.go
@@ -30,6 +30,11 @@ type IssueBackend interface {
 	CreateIntakeIssue(context.Context, intake.IssueDraft) (intake.Issue, error)
 }
 
+type RecurringIssueBackend interface {
+	IssueBackend
+	IntakeIssueClosed(context.Context, string) (bool, error)
+}
+
 type IssueCoordinator struct {
 	config Config
 	store  coordination.Store
@@ -68,6 +73,28 @@ func NewIssueCoordinator(config Config, store coordination.Store, deps Dependenc
 }
 
 func (c *IssueCoordinator) Ensure(ctx context.Context, marker string, draft intake.IssueDraft, backend IssueBackend) (intake.Issue, bool, error) {
+	return c.ensure(ctx, marker, draft, backend, nil)
+}
+
+func (c *IssueCoordinator) EnsureRecurring(
+	ctx context.Context,
+	marker string,
+	draft intake.IssueDraft,
+	backend RecurringIssueBackend,
+) (intake.Issue, bool, error) {
+	if backend == nil {
+		return intake.Issue{}, false, ErrMissingIssueBackend
+	}
+	return c.ensure(ctx, marker, draft, backend, backend.IntakeIssueClosed)
+}
+
+func (c *IssueCoordinator) ensure(
+	ctx context.Context,
+	marker string,
+	draft intake.IssueDraft,
+	backend IssueBackend,
+	issueClosed func(context.Context, string) (bool, error),
+) (intake.Issue, bool, error) {
 	if backend == nil {
 		return intake.Issue{}, false, ErrMissingIssueBackend
 	}
@@ -93,7 +120,7 @@ func (c *IssueCoordinator) Ensure(ctx context.Context, marker string, draft inta
 			if !swapped {
 				continue
 			}
-			return c.createReserved(ctx, key, marker, draft, backend, reserved, reservationToken)
+			return c.createReserved(ctx, key, marker, draft, backend, reserved, reservationToken, issueClosed)
 		}
 		effect, err := decodeEffect(record.Value)
 		if err != nil {
@@ -101,6 +128,22 @@ func (c *IssueCoordinator) Ensure(ctx context.Context, marker string, draft inta
 		}
 		switch effect.Status {
 		case effectComplete:
+			if issueClosed != nil {
+				closed, closeErr := issueClosed(ctx, effect.Issue.ID)
+				if closeErr != nil {
+					return intake.Issue{}, false, fmt.Errorf("revalidate coordinated issue: %w", closeErr)
+				}
+				if closed {
+					reserved, swapped, reserveErr := c.reserve(ctx, key, record.Version, reservationToken)
+					if reserveErr != nil {
+						return intake.Issue{}, false, reserveErr
+					}
+					if !swapped {
+						continue
+					}
+					return c.createReserved(ctx, key, marker, draft, backend, reserved, reservationToken, issueClosed)
+				}
+			}
 			return effect.Issue, false, nil
 		case effectReserved:
 			if c.now().Before(record.ModifiedAt.Add(c.config.LeaseTTL() + c.config.MaxClockSkew())) {
@@ -116,13 +159,13 @@ func (c *IssueCoordinator) Ensure(ctx context.Context, marker string, draft inta
 			if !swapped {
 				continue
 			}
-			return c.createReserved(ctx, key, marker, draft, backend, reserved, reservationToken)
+			return c.createReserved(ctx, key, marker, draft, backend, reserved, reservationToken, issueClosed)
 		case effectCreating:
 			issue, exists, findErr := backend.FindIntakeIssue(ctx, marker)
 			if findErr != nil {
 				return intake.Issue{}, false, fmt.Errorf("reconcile coordinated issue: %w", findErr)
 			}
-			if exists {
+			if exists && (issueClosed == nil || !issue.Closed) {
 				completed, completeErr := c.completeDurably(ctx, key, effect.Token, issue)
 				return completed, false, completeErr
 			}
@@ -156,6 +199,7 @@ func (c *IssueCoordinator) createReserved(
 	backend IssueBackend,
 	record coordination.Record,
 	token string,
+	issueClosed func(context.Context, string) (bool, error),
 ) (intake.Issue, bool, error) {
 	creatingValue, err := json.Marshal(effectState{Schema: effectSchema, Status: effectCreating, Token: token})
 	if err != nil {
@@ -166,13 +210,13 @@ func (c *IssueCoordinator) createReserved(
 		return intake.Issue{}, false, err
 	}
 	if !swapped {
-		return c.Ensure(ctx, marker, draft, backend)
+		return c.ensure(ctx, marker, draft, backend, issueClosed)
 	}
 	issue, found, err := backend.FindIntakeIssue(ctx, marker)
 	if err != nil {
 		return intake.Issue{}, false, fmt.Errorf("reconcile coordinated issue before create: %w", err)
 	}
-	if found {
+	if found && (issueClosed == nil || !issue.Closed) {
 		completed, completeErr := c.completeDurably(ctx, key, token, issue)
 		return completed, false, completeErr
 	}
@@ -181,7 +225,7 @@ func (c *IssueCoordinator) createReserved(
 		reconcileCtx, reconcileCancel := context.WithTimeout(context.WithoutCancel(ctx), min(c.config.RetryInterval(), 30*time.Second))
 		reconciled, exists, findErr := backend.FindIntakeIssue(reconcileCtx, marker)
 		reconcileCancel()
-		if findErr == nil && exists {
+		if findErr == nil && exists && (issueClosed == nil || !reconciled.Closed) {
 			completed, completeErr := c.completeDurably(ctx, key, token, reconciled)
 			return completed, false, completeErr
 		}

--- a/internal/scheduleowner/issue.go
+++ b/internal/scheduleowner/issue.go
@@ -1,0 +1,260 @@
+package scheduleowner
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/digitaldrywood/detent/internal/coordination"
+	"github.com/digitaldrywood/detent/internal/intake"
+)
+
+const (
+	effectSchema   = 1
+	effectReserved = "reserved"
+	effectCreating = "creating"
+	effectComplete = "complete"
+)
+
+var (
+	ErrMissingIssueBackend  = errors.New("coordinated issue backend is required")
+	ErrMissingMarker        = errors.New("coordinated issue marker is required")
+	ErrIssueCreateUncertain = errors.New("coordinated issue creation outcome is uncertain")
+)
+
+type IssueBackend interface {
+	FindIntakeIssue(context.Context, string) (intake.Issue, bool, error)
+	CreateIntakeIssue(context.Context, intake.IssueDraft) (intake.Issue, error)
+}
+
+type IssueCoordinator struct {
+	config Config
+	store  coordination.Store
+	now    func() time.Time
+	wait   func(context.Context, time.Duration) error
+	token  func() (string, error)
+}
+
+type effectState struct {
+	Schema int          `json:"schema"`
+	Status string       `json:"status"`
+	Token  string       `json:"token"`
+	Issue  intake.Issue `json:"issue,omitempty"`
+}
+
+func NewIssueCoordinator(config Config, store coordination.Store, deps Dependencies) (*IssueCoordinator, error) {
+	if store == nil {
+		return nil, ErrMissingStore
+	}
+	if problems := config.Validate("schedule_ownership"); len(problems) > 0 {
+		return nil, errors.New(strings.Join(problems, "; "))
+	}
+	now := deps.Now
+	if now == nil {
+		now = time.Now
+	}
+	wait := deps.Wait
+	if wait == nil {
+		wait = waitContext
+	}
+	token := deps.Token
+	if token == nil {
+		token = randomToken
+	}
+	return &IssueCoordinator{config: config, store: store, now: now, wait: wait, token: token}, nil
+}
+
+func (c *IssueCoordinator) Ensure(ctx context.Context, marker string, draft intake.IssueDraft, backend IssueBackend) (intake.Issue, bool, error) {
+	if backend == nil {
+		return intake.Issue{}, false, ErrMissingIssueBackend
+	}
+	marker = strings.TrimSpace(marker)
+	if marker == "" {
+		return intake.Issue{}, false, ErrMissingMarker
+	}
+	reservationToken, err := c.token()
+	if err != nil {
+		return intake.Issue{}, false, fmt.Errorf("create issue reservation token: %w", err)
+	}
+	key := effectPath(c.config.Key, marker)
+	for ctx.Err() == nil {
+		record, found, err := c.store.Get(ctx, key)
+		if err != nil {
+			return intake.Issue{}, false, err
+		}
+		if !found {
+			reserved, swapped, err := c.reserve(ctx, key, record.Version, reservationToken)
+			if err != nil {
+				return intake.Issue{}, false, err
+			}
+			if !swapped {
+				continue
+			}
+			return c.createReserved(ctx, key, marker, draft, backend, reserved, reservationToken)
+		}
+		effect, err := decodeEffect(record.Value)
+		if err != nil {
+			return intake.Issue{}, false, err
+		}
+		switch effect.Status {
+		case effectComplete:
+			return effect.Issue, false, nil
+		case effectReserved:
+			if c.now().Before(record.ModifiedAt.Add(c.config.LeaseTTL() + c.config.MaxClockSkew())) {
+				if err := c.wait(ctx, c.config.RetryInterval()); err != nil {
+					return intake.Issue{}, false, err
+				}
+				continue
+			}
+			reserved, swapped, err := c.reserve(ctx, key, record.Version, reservationToken)
+			if err != nil {
+				return intake.Issue{}, false, err
+			}
+			if !swapped {
+				continue
+			}
+			return c.createReserved(ctx, key, marker, draft, backend, reserved, reservationToken)
+		case effectCreating:
+			issue, exists, findErr := backend.FindIntakeIssue(ctx, marker)
+			if findErr != nil {
+				return intake.Issue{}, false, fmt.Errorf("reconcile coordinated issue: %w", findErr)
+			}
+			if exists {
+				completed, completeErr := c.completeDurably(ctx, key, effect.Token, issue)
+				return completed, false, completeErr
+			}
+			if c.now().Before(record.ModifiedAt.Add(c.config.LeaseTTL() + c.config.MaxClockSkew())) {
+				if err := c.wait(ctx, c.config.RetryInterval()); err != nil {
+					return intake.Issue{}, false, err
+				}
+				continue
+			}
+			return intake.Issue{}, false, ErrIssueCreateUncertain
+		default:
+			return intake.Issue{}, false, ErrIssueCreateUncertain
+		}
+	}
+	return intake.Issue{}, false, ctx.Err()
+}
+
+func (c *IssueCoordinator) reserve(ctx context.Context, key string, version string, token string) (coordination.Record, bool, error) {
+	value, err := json.Marshal(effectState{Schema: effectSchema, Status: effectReserved, Token: token})
+	if err != nil {
+		return coordination.Record{}, false, err
+	}
+	return c.store.CompareAndSwap(ctx, key, version, value)
+}
+
+func (c *IssueCoordinator) createReserved(
+	ctx context.Context,
+	key string,
+	marker string,
+	draft intake.IssueDraft,
+	backend IssueBackend,
+	record coordination.Record,
+	token string,
+) (intake.Issue, bool, error) {
+	creatingValue, err := json.Marshal(effectState{Schema: effectSchema, Status: effectCreating, Token: token})
+	if err != nil {
+		return intake.Issue{}, false, err
+	}
+	_, swapped, err := c.store.CompareAndSwap(ctx, key, record.Version, creatingValue)
+	if err != nil {
+		return intake.Issue{}, false, err
+	}
+	if !swapped {
+		return c.Ensure(ctx, marker, draft, backend)
+	}
+	issue, found, err := backend.FindIntakeIssue(ctx, marker)
+	if err != nil {
+		return intake.Issue{}, false, fmt.Errorf("reconcile coordinated issue before create: %w", err)
+	}
+	if found {
+		completed, completeErr := c.completeDurably(ctx, key, token, issue)
+		return completed, false, completeErr
+	}
+	issue, createErr := backend.CreateIntakeIssue(ctx, draft)
+	if createErr != nil {
+		reconcileCtx, reconcileCancel := context.WithTimeout(context.WithoutCancel(ctx), min(c.config.RetryInterval(), 30*time.Second))
+		reconciled, exists, findErr := backend.FindIntakeIssue(reconcileCtx, marker)
+		reconcileCancel()
+		if findErr == nil && exists {
+			completed, completeErr := c.completeDurably(ctx, key, token, reconciled)
+			return completed, false, completeErr
+		}
+		return intake.Issue{}, false, errors.Join(ErrIssueCreateUncertain, createErr, findErr)
+	}
+	completed, err := c.completeDurably(ctx, key, token, issue)
+	return completed, true, err
+}
+
+func (c *IssueCoordinator) completeDurably(ctx context.Context, key string, token string, issue intake.Issue) (intake.Issue, error) {
+	completeCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), min(c.config.HeartbeatInterval(), 30*time.Second))
+	defer cancel()
+	return c.complete(completeCtx, key, token, issue)
+}
+
+func (c *IssueCoordinator) complete(ctx context.Context, key string, token string, issue intake.Issue) (intake.Issue, error) {
+	for range maxCASAttempts {
+		record, found, err := c.store.Get(ctx, key)
+		if err != nil {
+			return intake.Issue{}, err
+		}
+		if !found {
+			return intake.Issue{}, ErrIssueCreateUncertain
+		}
+		effect, err := decodeEffect(record.Value)
+		if err != nil {
+			return intake.Issue{}, err
+		}
+		if effect.Status == effectComplete {
+			return effect.Issue, nil
+		}
+		if effect.Status != effectCreating || effect.Token != token {
+			return intake.Issue{}, ErrIssueCreateUncertain
+		}
+		completed, swapped, err := c.completeFromRecord(ctx, key, record, token, issue)
+		if err != nil {
+			return intake.Issue{}, err
+		}
+		if swapped {
+			return completed, nil
+		}
+	}
+	return intake.Issue{}, ErrCASLimitExceeded
+}
+
+func (c *IssueCoordinator) completeFromRecord(
+	ctx context.Context,
+	key string,
+	record coordination.Record,
+	token string,
+	issue intake.Issue,
+) (intake.Issue, bool, error) {
+	value, err := json.Marshal(effectState{Schema: effectSchema, Status: effectComplete, Token: token, Issue: issue})
+	if err != nil {
+		return intake.Issue{}, false, err
+	}
+	_, swapped, err := c.store.CompareAndSwap(ctx, key, record.Version, value)
+	return issue, swapped, err
+}
+
+func decodeEffect(value []byte) (effectState, error) {
+	var effect effectState
+	if err := json.Unmarshal(value, &effect); err != nil {
+		return effectState{}, fmt.Errorf("decode coordinated issue effect: %w", err)
+	}
+	if effect.Schema != effectSchema || effect.Token == "" {
+		return effectState{}, ErrIssueCreateUncertain
+	}
+	if effect.Status != effectReserved && effect.Status != effectCreating && effect.Status != effectComplete {
+		return effectState{}, ErrIssueCreateUncertain
+	}
+	if effect.Status == effectComplete && strings.TrimSpace(effect.Issue.ID) == "" {
+		return effectState{}, ErrIssueCreateUncertain
+	}
+	return effect, nil
+}

--- a/internal/scheduleowner/issue_test.go
+++ b/internal/scheduleowner/issue_test.go
@@ -1,0 +1,179 @@
+package scheduleowner
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/digitaldrywood/detent/internal/intake"
+)
+
+func TestIssueCoordinatorCreateRacePostsOnce(t *testing.T) {
+	t.Parallel()
+	clock := newTestClock(time.Date(2026, 8, 24, 12, 0, 0, 0, time.UTC))
+	store := newMemoryCoordinationStore(clock.Now)
+	backend := &blockingIssueBackend{
+		marker:        "<!-- detent-intake:fingerprint -->",
+		createStarted: make(chan struct{}),
+		createRelease: make(chan struct{}),
+	}
+	alpha := newTestIssueCoordinator(t, testConfig(), "alpha", store, clock)
+	beta := newTestIssueCoordinator(t, testConfig(), "beta", store, clock)
+	draft := intake.IssueDraft{Title: "One", Body: "body\n\n" + backend.marker}
+
+	results := make(chan ensureResult, 2)
+	go func() {
+		issue, created, err := alpha.Ensure(t.Context(), backend.marker, draft, backend)
+		results <- ensureResult{issue: issue, created: created, err: err}
+	}()
+	<-backend.createStarted
+	go func() {
+		issue, created, err := beta.Ensure(t.Context(), backend.marker, draft, backend)
+		results <- ensureResult{issue: issue, created: created, err: err}
+	}()
+	second := <-results
+	close(backend.createRelease)
+	first := <-results
+	for _, result := range []ensureResult{first, second} {
+		if result.err != nil || result.issue.ID != "issue-1" {
+			t.Fatalf("Ensure() = %#v", result)
+		}
+	}
+	if first.created == second.created {
+		t.Fatalf("created results = %t, %t, want one creator", first.created, second.created)
+	}
+	if got := backend.CreateCount(); got != 1 {
+		t.Fatalf("CreateIntakeIssue() calls = %d, want 1", got)
+	}
+}
+
+func TestIssueCoordinatorDoesNotStealUncertainCreate(t *testing.T) {
+	t.Parallel()
+	clock := newTestClock(time.Date(2026, 8, 24, 12, 0, 0, 0, time.UTC))
+	store := newMemoryCoordinationStore(clock.Now)
+	config := testConfig()
+	marker := "<!-- detent-intake:uncertain -->"
+	value, err := json.Marshal(effectState{Schema: effectSchema, Status: effectCreating, Token: "dead-owner"})
+	if err != nil {
+		t.Fatalf("Marshal() error = %v", err)
+	}
+	if _, swapped, err := store.CompareAndSwap(t.Context(), effectPath(config.Key, marker), "", value); err != nil || !swapped {
+		t.Fatalf("seed CompareAndSwap() = %t, %v", swapped, err)
+	}
+	clock.Advance(config.LeaseTTL() + config.MaxClockSkew() + time.Second)
+	coordinator := newTestIssueCoordinator(t, config, "successor", store, clock)
+	backend := &blockingIssueBackend{marker: marker}
+	if _, _, err := coordinator.Ensure(t.Context(), marker, intake.IssueDraft{Title: "Uncertain"}, backend); !errors.Is(err, ErrIssueCreateUncertain) {
+		t.Fatalf("Ensure() error = %v, want ErrIssueCreateUncertain", err)
+	}
+	if got := backend.CreateCount(); got != 0 {
+		t.Fatalf("CreateIntakeIssue() calls = %d, want 0", got)
+	}
+}
+
+func TestIssueCoordinatorCompletesAfterCreateContextCancellation(t *testing.T) {
+	t.Parallel()
+	clock := newTestClock(time.Date(2026, 8, 24, 12, 0, 0, 0, time.UTC))
+	store := newMemoryCoordinationStore(clock.Now)
+	coordinator := newTestIssueCoordinator(t, testConfig(), "alpha", store, clock)
+	marker := "<!-- detent-intake:canceled-create -->"
+	ctx, cancel := context.WithCancel(t.Context())
+	backend := &cancelingIssueBackend{cancel: cancel, marker: marker}
+
+	issue, created, err := coordinator.Ensure(ctx, marker, intake.IssueDraft{Title: "One", Body: marker}, backend)
+	if err != nil || !created || issue.ID != "issue-1" {
+		t.Fatalf("Ensure() = %#v, %t, %v", issue, created, err)
+	}
+	second := newTestIssueCoordinator(t, testConfig(), "beta", store, clock)
+	issue, created, err = second.Ensure(t.Context(), marker, intake.IssueDraft{Title: "One", Body: marker}, backend)
+	if err != nil || created || issue.ID != "issue-1" {
+		t.Fatalf("second Ensure() = %#v, %t, %v", issue, created, err)
+	}
+}
+
+type ensureResult struct {
+	issue   intake.Issue
+	created bool
+	err     error
+}
+
+type blockingIssueBackend struct {
+	mu            sync.Mutex
+	marker        string
+	issue         intake.Issue
+	creates       int
+	createStarted chan struct{}
+	createRelease chan struct{}
+	startedOnce   sync.Once
+}
+
+type cancelingIssueBackend struct {
+	cancel context.CancelFunc
+	marker string
+	issue  intake.Issue
+}
+
+func (b *cancelingIssueBackend) FindIntakeIssue(_ context.Context, marker string) (intake.Issue, bool, error) {
+	return b.issue, marker == b.marker && b.issue.ID != "", nil
+}
+
+func (b *cancelingIssueBackend) CreateIntakeIssue(_ context.Context, draft intake.IssueDraft) (intake.Issue, error) {
+	b.issue = intake.Issue{ID: "issue-1", Identifier: "example#1", Body: draft.Body}
+	b.cancel()
+	return b.issue, nil
+}
+
+func (b *blockingIssueBackend) FindIntakeIssue(_ context.Context, marker string) (intake.Issue, bool, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if marker != b.marker || b.issue.ID == "" {
+		return intake.Issue{}, false, nil
+	}
+	return b.issue, true, nil
+}
+
+func (b *blockingIssueBackend) CreateIntakeIssue(ctx context.Context, draft intake.IssueDraft) (intake.Issue, error) {
+	b.mu.Lock()
+	b.creates++
+	b.issue = intake.Issue{ID: "issue-1", Identifier: "example#1", Body: draft.Body}
+	issue := b.issue
+	b.mu.Unlock()
+	if b.createStarted != nil {
+		b.startedOnce.Do(func() { close(b.createStarted) })
+	}
+	if b.createRelease != nil {
+		select {
+		case <-ctx.Done():
+			return intake.Issue{}, ctx.Err()
+		case <-b.createRelease:
+		}
+	}
+	return issue, nil
+}
+
+func (b *blockingIssueBackend) CreateCount() int {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.creates
+}
+
+func newTestIssueCoordinator(
+	t *testing.T,
+	config Config,
+	token string,
+	store *memoryCoordinationStore,
+	clock *testClock,
+) *IssueCoordinator {
+	t.Helper()
+	coordinator, err := NewIssueCoordinator(config, store, Dependencies{
+		Now:   clock.Now,
+		Token: func() (string, error) { return token, nil },
+	})
+	if err != nil {
+		t.Fatalf("NewIssueCoordinator() error = %v", err)
+	}
+	return coordinator
+}

--- a/internal/scheduleowner/issue_test.go
+++ b/internal/scheduleowner/issue_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"sync"
 	"testing"
 	"time"
@@ -94,6 +95,33 @@ func TestIssueCoordinatorCompletesAfterCreateContextCancellation(t *testing.T) {
 	}
 }
 
+func TestIssueCoordinatorRecurringIssueReplacesClosedCompletion(t *testing.T) {
+	t.Parallel()
+	clock := newTestClock(time.Date(2026, 8, 24, 12, 0, 0, 0, time.UTC))
+	store := newMemoryCoordinationStore(clock.Now)
+	coordinator := newTestIssueCoordinator(t, testConfig(), "alpha", store, clock)
+	marker := "<!-- detent-routine:recurring -->"
+	backend := &blockingIssueBackend{marker: marker}
+	draft := intake.IssueDraft{Title: "Recurring", Body: marker}
+
+	first, created, err := coordinator.EnsureRecurring(t.Context(), marker, draft, backend)
+	if err != nil || !created || first.ID != "issue-1" {
+		t.Fatalf("first EnsureRecurring() = %#v, %t, %v", first, created, err)
+	}
+	backend.Close(first.ID)
+	second, created, err := coordinator.EnsureRecurring(t.Context(), marker, draft, backend)
+	if err != nil || !created || second.ID != "issue-2" {
+		t.Fatalf("second EnsureRecurring() = %#v, %t, %v", second, created, err)
+	}
+	third, created, err := coordinator.EnsureRecurring(t.Context(), marker, draft, backend)
+	if err != nil || created || third.ID != second.ID {
+		t.Fatalf("third EnsureRecurring() = %#v, %t, %v", third, created, err)
+	}
+	if got := backend.CreateCount(); got != 2 {
+		t.Fatalf("CreateIntakeIssue() calls = %d, want 2", got)
+	}
+}
+
 type ensureResult struct {
 	issue   intake.Issue
 	created bool
@@ -138,7 +166,7 @@ func (b *blockingIssueBackend) FindIntakeIssue(_ context.Context, marker string)
 func (b *blockingIssueBackend) CreateIntakeIssue(ctx context.Context, draft intake.IssueDraft) (intake.Issue, error) {
 	b.mu.Lock()
 	b.creates++
-	b.issue = intake.Issue{ID: "issue-1", Identifier: "example#1", Body: draft.Body}
+	b.issue = intake.Issue{ID: fmt.Sprintf("issue-%d", b.creates), Identifier: fmt.Sprintf("example#%d", b.creates), Body: draft.Body}
 	issue := b.issue
 	b.mu.Unlock()
 	if b.createStarted != nil {
@@ -152,6 +180,20 @@ func (b *blockingIssueBackend) CreateIntakeIssue(ctx context.Context, draft inta
 		}
 	}
 	return issue, nil
+}
+
+func (b *blockingIssueBackend) IntakeIssueClosed(_ context.Context, issueID string) (bool, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.issue.ID == issueID && b.issue.Closed, nil
+}
+
+func (b *blockingIssueBackend) Close(issueID string) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if b.issue.ID == issueID {
+		b.issue.Closed = true
+	}
 }
 
 func (b *blockingIssueBackend) CreateCount() int {

--- a/internal/scheduleowner/manager.go
+++ b/internal/scheduleowner/manager.go
@@ -1,0 +1,420 @@
+package scheduleowner
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"strings"
+	"time"
+
+	"github.com/digitaldrywood/detent/internal/coordination"
+)
+
+const (
+	leaseSchema    = 1
+	maxCASAttempts = 16
+)
+
+var (
+	ErrLeaseLost        = errors.New("schedule ownership lease lost")
+	ErrInvalidLease     = errors.New("schedule ownership lease is invalid")
+	ErrMissingStore     = errors.New("schedule ownership store is required")
+	ErrMissingOwner     = errors.New("schedule ownership owner is required")
+	ErrCASLimitExceeded = errors.New("schedule ownership compare-and-swap retry limit exceeded")
+)
+
+type Dependencies struct {
+	Now    func() time.Time
+	Wait   func(context.Context, time.Duration) error
+	Token  func() (string, error)
+	Closer io.Closer
+	Logger *slog.Logger
+}
+
+type Lease struct {
+	Owner      string
+	Token      string
+	Generation uint64
+	RenewedAt  time.Time
+	ExpiresAt  time.Time
+}
+
+type Status struct {
+	Owner      string
+	Generation uint64
+	RenewedAt  time.Time
+	ExpiresAt  time.Time
+	Active     bool
+}
+
+type Manager struct {
+	config Config
+	owner  string
+	path   string
+	store  coordination.Store
+	now    func() time.Time
+	wait   func(context.Context, time.Duration) error
+	token  func() (string, error)
+	closer io.Closer
+	logger *slog.Logger
+}
+
+type leaseState struct {
+	Schema     int    `json:"schema"`
+	Owner      string `json:"owner,omitempty"`
+	Token      string `json:"token,omitempty"`
+	Generation uint64 `json:"generation"`
+}
+
+func New(config Config, owner string, store coordination.Store, deps Dependencies) (*Manager, error) {
+	if store == nil {
+		return nil, ErrMissingStore
+	}
+	owner = strings.TrimSpace(owner)
+	if owner == "" {
+		return nil, ErrMissingOwner
+	}
+	if problems := config.Validate("schedule_ownership"); len(problems) > 0 {
+		return nil, errors.New(strings.Join(problems, "; "))
+	}
+	now := deps.Now
+	if now == nil {
+		now = time.Now
+	}
+	wait := deps.Wait
+	if wait == nil {
+		wait = waitContext
+	}
+	token := deps.Token
+	if token == nil {
+		token = randomToken
+	}
+	logger := deps.Logger
+	if logger == nil {
+		logger = slog.Default()
+	}
+	return &Manager{
+		config: config,
+		owner:  owner,
+		path:   leasePath(config.Key),
+		store:  store,
+		now:    now,
+		wait:   wait,
+		token:  token,
+		closer: deps.Closer,
+		logger: logger,
+	}, nil
+}
+
+func (m *Manager) Current(ctx context.Context) (Status, error) {
+	record, found, err := m.store.Get(ctx, m.path)
+	if err != nil {
+		return Status{}, err
+	}
+	if !found {
+		return Status{}, nil
+	}
+	state, err := decodeLeaseState(record.Value)
+	if err != nil {
+		return Status{}, err
+	}
+	expiresAt := record.ModifiedAt.Add(m.config.LeaseTTL() + m.config.MaxClockSkew())
+	return Status{
+		Owner:      state.Owner,
+		Generation: state.Generation,
+		RenewedAt:  record.ModifiedAt,
+		ExpiresAt:  expiresAt,
+		Active:     state.Owner != "" && m.now().Before(expiresAt),
+	}, nil
+}
+
+func (m *Manager) Close() error {
+	if m == nil {
+		return nil
+	}
+	if m.closer == nil {
+		return nil
+	}
+	return m.closer.Close()
+}
+
+func (m *Manager) Acquire(ctx context.Context) (Lease, bool, error) {
+	token, err := m.token()
+	if err != nil {
+		return Lease{}, false, fmt.Errorf("create schedule ownership token: %w", err)
+	}
+	for range maxCASAttempts {
+		record, found, err := m.store.Get(ctx, m.path)
+		if err != nil {
+			return Lease{}, false, err
+		}
+		state := leaseState{Schema: leaseSchema}
+		if found {
+			state, err = decodeLeaseState(record.Value)
+			if err != nil {
+				return Lease{}, false, err
+			}
+			if state.Owner != "" && m.now().Before(record.ModifiedAt.Add(m.config.LeaseTTL()+m.config.MaxClockSkew())) {
+				return Lease{}, false, nil
+			}
+		}
+		state.Owner = m.owner
+		state.Token = token
+		state.Generation++
+		value, err := json.Marshal(state)
+		if err != nil {
+			return Lease{}, false, err
+		}
+		updated, swapped, err := m.store.CompareAndSwap(ctx, m.path, record.Version, value)
+		if err != nil {
+			return Lease{}, false, err
+		}
+		if !swapped {
+			continue
+		}
+		return m.leaseFromRecord(state, updated), true, nil
+	}
+	return Lease{}, false, ErrCASLimitExceeded
+}
+
+func (m *Manager) Release(ctx context.Context, lease Lease) error {
+	for range maxCASAttempts {
+		record, found, err := m.store.Get(ctx, m.path)
+		if err != nil {
+			return err
+		}
+		if !found {
+			return nil
+		}
+		state, err := decodeLeaseState(record.Value)
+		if err != nil {
+			return err
+		}
+		if !leaseMatches(state, lease) {
+			return nil
+		}
+		state.Owner = ""
+		state.Token = ""
+		value, err := json.Marshal(state)
+		if err != nil {
+			return err
+		}
+		_, swapped, err := m.store.CompareAndSwap(ctx, m.path, record.Version, value)
+		if err != nil {
+			return err
+		}
+		if swapped {
+			return nil
+		}
+	}
+	return ErrCASLimitExceeded
+}
+
+func (m *Manager) Run(ctx context.Context, work func(context.Context) error) error {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if work == nil {
+		return nil
+	}
+	for ctx.Err() == nil {
+		lease, acquired, err := m.Acquire(ctx)
+		if err != nil {
+			m.logger.WarnContext(ctx, "schedule ownership acquisition failed", "owner", m.owner, "key", m.config.Key, "error", err)
+			if waitErr := m.wait(ctx, m.config.RetryInterval()); waitErr != nil {
+				return nil
+			}
+			continue
+		}
+		if !acquired {
+			if waitErr := m.wait(ctx, m.config.RetryInterval()); waitErr != nil {
+				return nil
+			}
+			continue
+		}
+		m.logger.InfoContext(ctx, "schedule ownership acquired", "owner", lease.Owner, "key", m.config.Key, "generation", lease.Generation)
+		err = m.hold(ctx, lease, work)
+		if ctx.Err() != nil {
+			return nil
+		}
+		if errors.Is(err, ErrLeaseLost) {
+			m.logger.WarnContext(ctx, "schedule ownership lost", "owner", lease.Owner, "key", m.config.Key, "generation", lease.Generation)
+			if waitErr := m.wait(ctx, m.config.RetryInterval()); waitErr != nil {
+				return nil
+			}
+			continue
+		}
+		return err
+	}
+	return nil
+}
+
+func (m *Manager) hold(ctx context.Context, lease Lease, work func(context.Context) error) error {
+	ownedCtx, cancel := context.WithCancel(ctx)
+	workDone := make(chan error, 1)
+	go func() {
+		workDone <- work(ownedCtx)
+	}()
+	validUntil := m.now().Add(m.config.LeaseTTL() - m.config.MaxClockSkew())
+	timer := time.NewTimer(nextRenewalDelay(m.now(), validUntil, m.config.HeartbeatInterval()))
+	defer timer.Stop()
+
+	finish := func(result error, release bool) error {
+		cancel()
+		workErr := <-workDone
+		if release {
+			releaseTimeout := min(m.config.HeartbeatInterval(), 30*time.Second)
+			releaseCtx, releaseCancel := context.WithTimeout(context.WithoutCancel(ctx), releaseTimeout)
+			releaseErr := m.Release(releaseCtx, lease)
+			releaseCancel()
+			if releaseErr != nil {
+				m.logger.Warn("schedule ownership release failed", "owner", lease.Owner, "key", m.config.Key, "generation", lease.Generation, "error", releaseErr)
+			}
+		}
+		if result != nil {
+			return result
+		}
+		if workErr != nil && !errors.Is(workErr, context.Canceled) {
+			return workErr
+		}
+		return nil
+	}
+
+	for {
+		select {
+		case <-ctx.Done():
+			return finish(nil, true)
+		case workErr := <-workDone:
+			cancel()
+			releaseTimeout := min(m.config.HeartbeatInterval(), 30*time.Second)
+			releaseCtx, releaseCancel := context.WithTimeout(context.WithoutCancel(ctx), releaseTimeout)
+			releaseErr := m.Release(releaseCtx, lease)
+			releaseCancel()
+			return errors.Join(workErr, releaseErr)
+		case <-timer.C:
+			if !m.now().Before(validUntil) {
+				return finish(ErrLeaseLost, false)
+			}
+			renewCtx, renewCancel := context.WithDeadline(ctx, validUntil)
+			renewed, err := m.renew(renewCtx, lease)
+			renewCancel()
+			if err == nil {
+				lease = renewed
+				validUntil = m.now().Add(m.config.LeaseTTL() - m.config.MaxClockSkew())
+				timer.Reset(nextRenewalDelay(m.now(), validUntil, m.config.HeartbeatInterval()))
+				continue
+			}
+			if errors.Is(err, ErrLeaseLost) || !m.now().Before(validUntil) {
+				return finish(ErrLeaseLost, false)
+			}
+			m.logger.WarnContext(ctx, "schedule ownership renewal failed", "owner", lease.Owner, "key", m.config.Key, "generation", lease.Generation, "error", err)
+			timer.Reset(nextRenewalDelay(m.now(), validUntil, m.config.RetryInterval()))
+		}
+	}
+}
+
+func (m *Manager) renew(ctx context.Context, lease Lease) (Lease, error) {
+	for range maxCASAttempts {
+		record, found, err := m.store.Get(ctx, m.path)
+		if err != nil {
+			return Lease{}, err
+		}
+		if !found {
+			return Lease{}, ErrLeaseLost
+		}
+		state, err := decodeLeaseState(record.Value)
+		if err != nil {
+			return Lease{}, err
+		}
+		if !leaseMatches(state, lease) {
+			return Lease{}, ErrLeaseLost
+		}
+		value, err := json.Marshal(state)
+		if err != nil {
+			return Lease{}, err
+		}
+		updated, swapped, err := m.store.CompareAndSwap(ctx, m.path, record.Version, value)
+		if err != nil {
+			return Lease{}, err
+		}
+		if swapped {
+			return m.leaseFromRecord(state, updated), nil
+		}
+	}
+	return Lease{}, ErrCASLimitExceeded
+}
+
+func (m *Manager) leaseFromRecord(state leaseState, record coordination.Record) Lease {
+	return Lease{
+		Owner:      state.Owner,
+		Token:      state.Token,
+		Generation: state.Generation,
+		RenewedAt:  record.ModifiedAt,
+		ExpiresAt:  record.ModifiedAt.Add(m.config.LeaseTTL() + m.config.MaxClockSkew()),
+	}
+}
+
+func decodeLeaseState(value []byte) (leaseState, error) {
+	var state leaseState
+	if err := json.Unmarshal(value, &state); err != nil {
+		return leaseState{}, fmt.Errorf("%w: %w", ErrInvalidLease, err)
+	}
+	if state.Schema != leaseSchema || (state.Owner == "") != (state.Token == "") {
+		return leaseState{}, ErrInvalidLease
+	}
+	return state, nil
+}
+
+func leaseMatches(state leaseState, lease Lease) bool {
+	return state.Owner == lease.Owner && state.Token == lease.Token && state.Generation == lease.Generation
+}
+
+func leasePath(key string) string {
+	digest := sha256.Sum256([]byte(strings.TrimSpace(key)))
+	return ".detent/schedules/" + hex.EncodeToString(digest[:]) + "/lease.json"
+}
+
+func effectPath(key string, marker string) string {
+	projectDigest := sha256.Sum256([]byte(strings.TrimSpace(key)))
+	effectDigest := sha256.Sum256([]byte(strings.TrimSpace(marker)))
+	return ".detent/schedules/" + hex.EncodeToString(projectDigest[:]) + "/effects/" + hex.EncodeToString(effectDigest[:]) + ".json"
+}
+
+func nextRenewalDelay(now time.Time, validUntil time.Time, interval time.Duration) time.Duration {
+	remaining := validUntil.Sub(now)
+	if remaining <= 0 {
+		return time.Nanosecond
+	}
+	if interval <= 0 || interval > remaining {
+		return remaining
+	}
+	return interval
+}
+
+func waitContext(ctx context.Context, delay time.Duration) error {
+	if delay <= 0 {
+		return ctx.Err()
+	}
+	timer := time.NewTimer(delay)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-timer.C:
+		return nil
+	}
+}
+
+func randomToken() (string, error) {
+	var value [16]byte
+	if _, err := rand.Read(value[:]); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(value[:]), nil
+}

--- a/internal/scheduleowner/manager_test.go
+++ b/internal/scheduleowner/manager_test.go
@@ -1,0 +1,212 @@
+package scheduleowner
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/digitaldrywood/detent/internal/coordination"
+)
+
+func TestManagersContendForOneProjectLease(t *testing.T) {
+	t.Parallel()
+	clock := newTestClock(time.Date(2026, 8, 24, 12, 0, 0, 0, time.UTC))
+	store := newMemoryCoordinationStore(clock.Now)
+	config := testConfig()
+	alpha := newTestManager(t, config, "alpha", "alpha-token", store, clock)
+	beta := newTestManager(t, config, "beta", "beta-token", store, clock)
+
+	start := make(chan struct{})
+	results := make(chan acquireResult, 2)
+	for _, manager := range []*Manager{alpha, beta} {
+		manager := manager
+		go func() {
+			<-start
+			lease, acquired, err := manager.Acquire(t.Context())
+			results <- acquireResult{lease: lease, acquired: acquired, err: err}
+		}()
+	}
+	close(start)
+	acquired := 0
+	owner := ""
+	for range 2 {
+		result := <-results
+		if result.err != nil {
+			t.Fatalf("Acquire() error = %v", result.err)
+		}
+		if result.acquired {
+			acquired++
+			owner = result.lease.Owner
+		}
+	}
+	if acquired != 1 || (owner != "alpha" && owner != "beta") {
+		t.Fatalf("acquired = %d, owner = %q, want one owner", acquired, owner)
+	}
+}
+
+func TestOwnerDeathAllowsOneSuccessorAfterExpiry(t *testing.T) {
+	t.Parallel()
+	clock := newTestClock(time.Date(2026, 8, 24, 12, 0, 0, 0, time.UTC))
+	store := newMemoryCoordinationStore(clock.Now)
+	config := testConfig()
+	alpha := newTestManager(t, config, "alpha", "alpha-token", store, clock)
+	beta := newTestManager(t, config, "beta", "beta-token", store, clock)
+
+	first, acquired, err := alpha.Acquire(t.Context())
+	if err != nil || !acquired {
+		t.Fatalf("alpha Acquire() = %#v, %t, %v", first, acquired, err)
+	}
+	if _, acquired, err := beta.Acquire(t.Context()); err != nil || acquired {
+		t.Fatalf("beta early Acquire() = %t, %v", acquired, err)
+	}
+	clock.Advance(config.LeaseTTL() + config.MaxClockSkew() + time.Second)
+	second, acquired, err := beta.Acquire(t.Context())
+	if err != nil || !acquired {
+		t.Fatalf("beta failover Acquire() = %#v, %t, %v", second, acquired, err)
+	}
+	if second.Owner != "beta" || second.Generation != first.Generation+1 {
+		t.Fatalf("successor lease = %#v, first = %#v", second, first)
+	}
+	if _, acquired, err := alpha.Acquire(t.Context()); err != nil || acquired {
+		t.Fatalf("alpha post-failover Acquire() = %t, %v", acquired, err)
+	}
+}
+
+func TestRunStopsWorkBeforeReleasingLease(t *testing.T) {
+	t.Parallel()
+	clock := newTestClock(time.Date(2026, 8, 24, 12, 0, 0, 0, time.UTC))
+	store := newMemoryCoordinationStore(clock.Now)
+	manager := newTestManager(t, testConfig(), "alpha", "alpha-token", store, clock)
+	ctx, cancel := context.WithCancel(t.Context())
+	started := make(chan struct{})
+	stopped := make(chan struct{})
+	done := make(chan error, 1)
+	go func() {
+		done <- manager.Run(ctx, func(workCtx context.Context) error {
+			close(started)
+			<-workCtx.Done()
+			close(stopped)
+			return workCtx.Err()
+		})
+	}()
+	<-started
+	cancel()
+	if err := <-done; err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+	select {
+	case <-stopped:
+	default:
+		t.Fatal("owned work was not stopped before Run returned")
+	}
+	status, err := manager.Current(t.Context())
+	if err != nil {
+		t.Fatalf("Current() error = %v", err)
+	}
+	if status.Active || status.Owner != "" {
+		t.Fatalf("Current() = %#v, want released", status)
+	}
+}
+
+type acquireResult struct {
+	lease    Lease
+	acquired bool
+	err      error
+}
+
+type testClock struct {
+	mu  sync.Mutex
+	now time.Time
+}
+
+func newTestClock(now time.Time) *testClock {
+	return &testClock{now: now}
+}
+
+func (c *testClock) Now() time.Time {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.now
+}
+
+func (c *testClock) Advance(duration time.Duration) {
+	c.mu.Lock()
+	c.now = c.now.Add(duration)
+	c.mu.Unlock()
+}
+
+type memoryCoordinationStore struct {
+	mu      sync.Mutex
+	now     func() time.Time
+	version int
+	records map[string]coordination.Record
+}
+
+func newMemoryCoordinationStore(now func() time.Time) *memoryCoordinationStore {
+	return &memoryCoordinationStore{now: now, records: map[string]coordination.Record{}}
+}
+
+func (s *memoryCoordinationStore) Get(_ context.Context, key string) (coordination.Record, bool, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	record, found := s.records[key]
+	record.Value = append([]byte(nil), record.Value...)
+	return record, found, nil
+}
+
+func (s *memoryCoordinationStore) CompareAndSwap(
+	_ context.Context,
+	key string,
+	expectedVersion string,
+	value []byte,
+) (coordination.Record, bool, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	current := s.records[key]
+	if current.Version != expectedVersion {
+		return coordination.Record{}, false, nil
+	}
+	s.version++
+	record := coordination.Record{
+		Value:      append([]byte(nil), value...),
+		Version:    fmt.Sprintf("v%d", s.version),
+		ModifiedAt: s.now().UTC(),
+	}
+	s.records[key] = record
+	return record, true, nil
+}
+
+func testConfig() Config {
+	return Config{
+		Enabled:             true,
+		Backend:             BackendGitHubRef,
+		Key:                 "example/production",
+		Repository:          "example/coordination",
+		Branch:              "scheduler",
+		LeaseSeconds:        10,
+		HeartbeatSeconds:    2,
+		RetrySeconds:        1,
+		MaxClockSkewSeconds: 1,
+	}
+}
+
+func newTestManager(
+	t *testing.T,
+	config Config,
+	owner string,
+	token string,
+	store coordination.Store,
+	clock *testClock,
+) *Manager {
+	t.Helper()
+	manager, err := New(config, owner, store, Dependencies{
+		Now:   clock.Now,
+		Token: func() (string, error) { return token, nil },
+	})
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	return manager
+}


### PR DESCRIPTION
## Summary

- add a committed GitHub-ref ownership lease so scheduled intake, routines, and backlog admission run on exactly one host
- fence owner failover and make fingerprint issue creation durable across contention and uncertain create responses
- report missing, unreachable, expired, and active schedule ownership through `detent doctor`

Fixes #1969

## UI Surface Contract

- [x] N/A, or the linked issue explicitly authorizes any high-impact UI surface, layout, density, first-viewport, or responsive visibility tradeoff.
- [x] Persistent top-of-screen messaging is explicitly authorized by the issue, or this PR does not add it.
- [x] Visual changes to primary operator screens include screenshot or browser verification below. No visual changes.

## Test Plan

- [x] `go test ./internal/coordination ./internal/scheduleowner ./internal/config ./internal/intake ./internal/routine ./internal/project ./internal/cli`
- [x] `PATH="$TMPDIR/detent-tools:$PATH" GOTOOLCHAIN=go1.26.2 make check` (golangci-lint v2.1.6; 78.8% aggregate coverage)