### PR TITLE
fix(board): keep project lists alphabetical

### DIFF
--- a/internal/web/templates/dashboard_data.go
+++ b/internal/web/templates/dashboard_data.go
@@ -1343,7 +1343,17 @@ type projectStatusView struct {
 
 func sortProjectSmallMultiples(projects []ProjectSmallMultiple) {
 	sort.SliceStable(projects, func(i, j int) bool {
-		return projectSmallMultipleName(projects[i]) < projectSmallMultipleName(projects[j])
+		leftName := projectSmallMultipleName(projects[i])
+		rightName := projectSmallMultipleName(projects[j])
+		leftFolded := strings.ToLower(leftName)
+		rightFolded := strings.ToLower(rightName)
+		if leftFolded != rightFolded {
+			return leftFolded < rightFolded
+		}
+		if leftName != rightName {
+			return leftName < rightName
+		}
+		return projects[i].ID < projects[j].ID
 	})
 }
 

--- a/internal/web/templates/dashboard_data.go
+++ b/internal/web/templates/dashboard_data.go
@@ -1336,7 +1336,6 @@ func sidebarProjectItems(data DashboardShellData) []sidebarProjectItem {
 }
 
 type projectStatusView struct {
-	Rank       int
 	Label      string
 	DotClass   string
 	BadgeClass string
@@ -1344,16 +1343,6 @@ type projectStatusView struct {
 
 func sortProjectSmallMultiples(projects []ProjectSmallMultiple) {
 	sort.SliceStable(projects, func(i, j int) bool {
-		left := projectSmallMultipleStatus(projects[i])
-		right := projectSmallMultipleStatus(projects[j])
-		if left.Rank != right.Rank {
-			return left.Rank < right.Rank
-		}
-		leftActivity := projectSmallMultipleActivity(projects[i])
-		rightActivity := projectSmallMultipleActivity(projects[j])
-		if leftActivity != rightActivity {
-			return leftActivity > rightActivity
-		}
 		return projectSmallMultipleName(projects[i]) < projectSmallMultipleName(projects[j])
 	})
 }
@@ -1361,33 +1350,33 @@ func sortProjectSmallMultiples(projects []ProjectSmallMultiple) {
 func projectSmallMultipleStatus(project ProjectSmallMultiple) projectStatusView {
 	switch {
 	case project.Dispatch.NeedsHumanAttention:
-		return projectStatusView{Rank: 0, Label: "needs attention", DotClass: "bg-err", BadgeClass: "bg-err/15 text-err"}
+		return projectStatusView{Label: "needs attention", DotClass: "bg-err", BadgeClass: "bg-err/15 text-err"}
 	case snapshotHasRefreshSignal(project.Refresh) && project.Refresh.Degraded():
 		label := "stale"
 		if !project.Refresh.StalenessWindowExceeded && strings.TrimSpace(project.Refresh.LastError) != "" {
 			label = "refresh failed"
 		}
-		return projectStatusView{Rank: 0, Label: label, DotClass: "bg-warn", BadgeClass: "bg-warn/15 text-warn"}
+		return projectStatusView{Label: label, DotClass: "bg-warn", BadgeClass: "bg-warn/15 text-warn"}
 	case project.Paused:
-		return projectStatusView{Rank: 4, Label: "paused", DotClass: "bg-warn", BadgeClass: "bg-warn/15 text-warn"}
+		return projectStatusView{Label: "paused", DotClass: "bg-warn", BadgeClass: "bg-warn/15 text-warn"}
 	case snapshotHasRefreshSignal(project.Refresh) && project.Refresh.Initializing():
-		return projectStatusView{Rank: 3, Label: "initializing", DotClass: "bg-dim", BadgeClass: "bg-elev text-sec"}
+		return projectStatusView{Label: "initializing", DotClass: "bg-dim", BadgeClass: "bg-elev text-sec"}
 	case snapshotHasRefreshSignal(project.Refresh) && project.Refresh.Behind():
-		return projectStatusView{Rank: 2, Label: "behind", DotClass: "bg-warn", BadgeClass: "bg-warn/15 text-warn"}
+		return projectStatusView{Label: "behind", DotClass: "bg-warn", BadgeClass: "bg-warn/15 text-warn"}
 	case project.ActiveHours.Configured && !project.ActiveHours.Open:
-		return projectStatusView{Rank: 3, Label: "off hours", DotClass: "bg-dim", BadgeClass: "bg-elev text-sec"}
+		return projectStatusView{Label: "off hours", DotClass: "bg-dim", BadgeClass: "bg-elev text-sec"}
 	case project.BoardBlocked > 0:
 		dotClass := "bg-dim"
 		if project.Running > 0 {
 			dotClass = "bg-ok dt-pulse"
 		}
-		return projectStatusView{Rank: 0, Label: "blocked", DotClass: dotClass, BadgeClass: "bg-err/15 text-err"}
+		return projectStatusView{Label: "blocked", DotClass: dotClass, BadgeClass: "bg-err/15 text-err"}
 	case project.Running > 0:
-		return projectStatusView{Rank: 1, Label: "active", DotClass: "bg-ok dt-pulse", BadgeClass: "bg-elev text-sec"}
+		return projectStatusView{Label: "active", DotClass: "bg-ok dt-pulse", BadgeClass: "bg-elev text-sec"}
 	case project.BoardLoad > 0:
-		return projectStatusView{Rank: 2, Label: "queued", DotClass: "bg-dim", BadgeClass: "bg-elev text-sec"}
+		return projectStatusView{Label: "queued", DotClass: "bg-dim", BadgeClass: "bg-elev text-sec"}
 	default:
-		return projectStatusView{Rank: 3, Label: "idle", DotClass: "bg-dim", BadgeClass: "bg-elev text-sec"}
+		return projectStatusView{Label: "idle", DotClass: "bg-dim", BadgeClass: "bg-elev text-sec"}
 	}
 }
 
@@ -1531,11 +1520,6 @@ func projectSmallMultiplesGridClass(cards []projectSmallMultipleCard) string {
 		return "mt-4 grid min-w-0 gap-2"
 	}
 	return "mt-4 grid min-w-0 gap-2"
-}
-
-func projectSmallMultipleActivity(project ProjectSmallMultiple) float64 {
-	active := project.Running*10000 + project.QueueCount*1000 + project.Blocked*100 + project.Completed
-	return float64(active) + project.ThroughputTokensPerSecond + project.CurrentSpendUSD
 }
 
 func projectSmallMultipleName(project ProjectSmallMultiple) string {

--- a/internal/web/templates/dashboard_data_test.go
+++ b/internal/web/templates/dashboard_data_test.go
@@ -1,6 +1,7 @@
 package templates
 
 import (
+	"slices"
 	"strconv"
 	"strings"
 	"testing"
@@ -905,7 +906,7 @@ func TestProjectSmallMultipleCards(t *testing.T) {
 		wantFirst projectSmallMultipleCard
 	}{
 		{
-			name: "sorts by activity and builds compact charts",
+			name: "sorts alphabetically and builds compact charts",
 			projects: []ProjectSmallMultiple{
 				{
 					ID:         "quiet",
@@ -1133,39 +1134,59 @@ func TestProjectKanbanCardsUseProjectColors(t *testing.T) {
 	}
 }
 
-func TestSidebarProjectItemsUseAttentionFirstDefaultOrder(t *testing.T) {
+func TestProjectListOrderRemainsStableAcrossLiveUpdates(t *testing.T) {
 	t.Parallel()
 
-	got := sidebarProjectItems(DashboardShellData{Projects: []ProjectSmallMultiple{
-		{ID: "paused", Name: "Paused", Paused: true, BoardLoad: 2, BoardBlocked: 1},
-		{ID: "idle", Name: "Idle"},
-		{ID: "queued", Name: "Queued", QueueCount: 1, BoardLoad: 1, BoardTodo: 1},
-		{ID: "active", Name: "Active", Running: 1, BoardLoad: 1, BoardActive: 1},
-		{ID: "blocked", Name: "Blocked", Blocked: 1, BoardBlocked: 1},
-	}})
-	want := []string{"blocked", "active", "queued", "idle", "paused"}
+	initial := []ProjectSmallMultiple{
+		{ID: "charlie", Name: "Charlie", Paused: true, BoardLoad: 2, BoardBlocked: 1},
+		{ID: "alpha", Name: "Alpha", Running: 1, BoardLoad: 1, BoardActive: 1},
+		{ID: "bravo", Name: "Bravo"},
+	}
+	updated := []ProjectSmallMultiple{
+		{ID: "charlie", Name: "Charlie", Running: 3, BoardLoad: 3, BoardActive: 3},
+		{ID: "alpha", Name: "Alpha", Paused: true},
+		{ID: "bravo", Name: "Bravo", BoardBlocked: 2},
+	}
+	want := []string{"alpha", "bravo", "charlie"}
+	tests := []struct {
+		name string
+		list func([]ProjectSmallMultiple) []string
+	}{
+		{
+			name: "fleet project cards",
+			list: func(projects []ProjectSmallMultiple) []string {
+				cards := projectSmallMultipleCards(DashboardData{Projects: projects})
+				ids := make([]string, 0, len(cards))
+				for _, card := range cards {
+					ids = append(ids, card.ID)
+				}
+				return ids
+			},
+		},
+		{
+			name: "sidebar and board project filter",
+			list: func(projects []ProjectSmallMultiple) []string {
+				items := appShellProjects(DashboardShellData{Projects: projects})
+				ids := make([]string, 0, len(items))
+				for _, item := range items {
+					ids = append(ids, item.ID)
+				}
+				return ids
+			},
+		},
+	}
 
-	if len(got) != len(want) {
-		t.Fatalf("sidebarProjectItems() len = %d, want %d; got %#v", len(got), len(want), got)
-	}
-	for i, wantID := range want {
-		if got[i].ID != wantID {
-			t.Fatalf("sidebarProjectItems()[%d].ID = %q, want %q; got %#v", i, got[i].ID, wantID, got)
-		}
-		if got[i].DefaultIndex != i {
-			t.Fatalf("sidebarProjectItems()[%d].DefaultIndex = %d, want %d; got %#v", i, got[i].DefaultIndex, i, got)
-		}
-		if got[i].Href != "/projects/"+wantID+"/kanban" {
-			t.Fatalf("sidebarProjectItems()[%d].Href = %q, want kanban project opener; got %#v", i, got[i].Href, got)
-		}
-	}
-	idle := got[3]
-	paused := got[4]
-	if paused.StatusLabel != "paused" {
-		t.Fatalf("paused StatusLabel = %q, want paused", paused.StatusLabel)
-	}
-	if paused.DotClass == idle.DotClass {
-		t.Fatalf("paused DotClass = idle DotClass = %q, want distinct classes", paused.DotClass)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			for state, projects := range map[string][]ProjectSmallMultiple{"initial": initial, "updated": updated} {
+				got := tt.list(projects)
+				if !slices.Equal(got, want) {
+					t.Fatalf("%s project IDs = %v, want %v", state, got, want)
+				}
+			}
+		})
 	}
 }
 

--- a/internal/web/templates/dashboard_data_test.go
+++ b/internal/web/templates/dashboard_data_test.go
@@ -1138,16 +1138,18 @@ func TestProjectListOrderRemainsStableAcrossLiveUpdates(t *testing.T) {
 	t.Parallel()
 
 	initial := []ProjectSmallMultiple{
-		{ID: "charlie", Name: "Charlie", Paused: true, BoardLoad: 2, BoardBlocked: 1},
-		{ID: "alpha", Name: "Alpha", Running: 1, BoardLoad: 1, BoardActive: 1},
+		{ID: "charlie", Name: "charlie", Paused: true, BoardLoad: 2, BoardBlocked: 1},
+		{ID: "alpha", Name: "alpha", Running: 1, BoardLoad: 1, BoardActive: 1},
 		{ID: "bravo", Name: "Bravo"},
+		{ID: "zoo", Name: "Zoo", Running: 2},
 	}
 	updated := []ProjectSmallMultiple{
-		{ID: "charlie", Name: "Charlie", Running: 3, BoardLoad: 3, BoardActive: 3},
-		{ID: "alpha", Name: "Alpha", Paused: true},
+		{ID: "charlie", Name: "charlie", Running: 3, BoardLoad: 3, BoardActive: 3},
+		{ID: "alpha", Name: "alpha", Paused: true},
 		{ID: "bravo", Name: "Bravo", BoardBlocked: 2},
+		{ID: "zoo", Name: "Zoo"},
 	}
-	want := []string{"alpha", "bravo", "charlie"}
+	want := []string{"alpha", "bravo", "charlie", "zoo"}
 	tests := []struct {
 		name string
 		list func([]ProjectSmallMultiple) []string


### PR DESCRIPTION
## Summary

- sort every shared project-list rendering path by display name only
- keep sidebar, board project filter, and fleet ordering stable across live status and activity changes
- remove obsolete status-rank and activity sort machinery

Fixes #1975

## UI Surface Contract

- [x] The linked issue explicitly authorizes this project-list ordering change.
- [x] This PR does not add persistent top-of-screen messaging.
- [x] Verified `/fleet` and `/` with the isolated screenshots dev-runtime on an ephemeral port; sidebar and board scope filter rendered the same eight projects alphabetically across mixed statuses.

## Test Plan

- [x] Focused table-driven ordering regression test
- [x] `go test ./internal/web/... -count=1`
- [x] `make check`