### PR TITLE
fix(orchestrator): calibrate lifetime limits

### DIFF
--- a/.detent/skills/golangci-go-toolchain-alignment.md
+++ b/.detent/skills/golangci-go-toolchain-alignment.md
@@ -1,0 +1,29 @@
+---
+name: golangci-go-toolchain-alignment
+description: Diagnose golangci-lint panics or false lint floods caused by a mismatch between the active Go toolchain and the Go version used to build the linter.
+when_to_use: Use when golangci-lint reports that a file requires a newer Go version, panics in go/types while loading packages, or suddenly reports widespread findings after a host tool upgrade.
+---
+
+# Align golangci-lint with the project Go toolchain
+
+Treat `file requires newer Go version` from `go/types` as a tool provenance
+failure until the project source proves otherwise. Record `go version`,
+`go env GOVERSION GOROOT`, and `golangci-lint version`; the latter reports the
+Go version embedded in the linter binary.
+
+Compare those values with the versions pinned by the repository's setup target
+and CI workflow. A linter built with an older Go release can ask a newer active
+`go` command to select version-gated dependency files, then fail when its
+embedded type checker reads them. Conversely, an unpinned newer linter can
+enable or strengthen analyzers and flood an otherwise clean branch with
+unrelated findings.
+
+Build the repository-pinned linter into the task's disposable directory using
+the repository-pinned Go toolchain. Put that disposable directory first on
+`PATH` only for the validation command; do not replace the host's global tools.
+Rerun the unchanged gate with both versions aligned. Fix findings introduced by
+the current diff, but do not expand the task to repair baseline findings that
+appear only under an unpinned tool pair.
+
+If the aligned pair still fails, investigate the reported source normally. Do
+not dismiss a reproducible canonical-toolchain failure as an environment issue.

--- a/config.reference.yaml
+++ b/config.reference.yaml
@@ -586,10 +586,10 @@
 #   no_progress_token_limit: 25000000
 #   # agent.no_progress_spend_limit_usd | type: number | default: 3 | required: No | validation: must be greater than or equal to 0
 #   no_progress_spend_limit_usd: 3
-#   # agent.lifetime_session_limit | type: integer | default: 15 | required: No | validation: must be greater than or equal to 0
-#   lifetime_session_limit: 15
-#   # agent.lifetime_token_limit | type: integer | default: 40000000 | required: No | validation: must be greater than or equal to 0
-#   lifetime_token_limit: 40000000
+#   # agent.lifetime_session_limit | type: integer | default: 120 | required: No | validation: must be greater than or equal to 0
+#   lifetime_session_limit: 120
+#   # agent.lifetime_token_limit | type: integer | default: 750000000 | required: No | validation: must be greater than or equal to 0
+#   lifetime_token_limit: 750000000
 #   # agent.lifetime_limit_cooldown_seconds | type: integer | default: 3600 | required: No | validation: must be greater than 0 when a lifetime limit is enabled
 #   lifetime_limit_cooldown_seconds: 3600
 #   # agent.lifetime_limit_override_label | type: string | default: "allow-lifetime-limit" | required: No | validation: None

--- a/docs/config.md
+++ b/docs/config.md
@@ -556,8 +556,8 @@ only to resettable budget pacing and never clears a per-issue hard hold.
 | `agent.lessons.recall_n` | `integer` | `10` | No | must be greater than or equal to 0 |
 | `agent.lifetime_limit_cooldown_seconds` | `integer` | `3600` | No | must be greater than 0 when a lifetime limit is enabled |
 | `agent.lifetime_limit_override_label` | `string` | `"allow-lifetime-limit"` | No | None |
-| `agent.lifetime_session_limit` | `integer` | `15` | No | must be greater than or equal to 0 |
-| `agent.lifetime_token_limit` | `integer` | `40000000` | No | must be greater than or equal to 0 |
+| `agent.lifetime_session_limit` | `integer` | `120` | No | must be greater than or equal to 0 |
+| `agent.lifetime_token_limit` | `integer` | `750000000` | No | must be greater than or equal to 0 |
 | `agent.max_concurrent_agents` | `integer` | `10` | No | must be greater than 0 |
 | `agent.max_concurrent_agents_by_state` | `mapping<string, integer>` | `{}` | No | limits must be positive integers |
 | `agent.max_retry_backoff_ms` | `integer` | `300000` | No | must be greater than 0 |

--- a/internal/cli/doctor_lifetime_limit.go
+++ b/internal/cli/doctor_lifetime_limit.go
@@ -1,0 +1,68 @@
+package cli
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	workflowconfig "github.com/digitaldrywood/detent/internal/config"
+	"github.com/digitaldrywood/detent/internal/store"
+)
+
+func checkDoctorLifetimeLimits(ctx context.Context, projectID, storePath string, cfg workflowconfig.Config, deps doctorDeps) doctorCheck {
+	name := "Project " + projectID + " lifetime limits"
+	if strings.TrimSpace(storePath) == "" {
+		return doctorCheck{Name: name, Status: doctorOK, Detail: "no completed issue history recorded yet"}
+	}
+	deps = deps.withDefaults()
+	db, err := deps.openSQLiteReadOnly(ctx, storePath)
+	if err != nil {
+		if errors.Is(err, errDoctorTelemetryStoreUnavailable) {
+			return doctorCheck{Name: name, Status: doctorOK, Detail: "no completed issue history recorded yet"}
+		}
+		return doctorCheck{Name: name, Status: doctorWarn, Detail: fmt.Sprintf("completed issue history could not be read: %v", err)}
+	}
+	history, queryErr := store.QueryProjectLifetimeUsage(ctx, db, projectID)
+	closeErr := db.Close()
+	if queryErr != nil {
+		if strings.Contains(strings.ToLower(queryErr.Error()), "no such table") {
+			return doctorCheck{Name: name, Status: doctorOK, Detail: "no completed issue history recorded yet"}
+		}
+		return doctorCheck{Name: name, Status: doctorWarn, Detail: fmt.Sprintf("completed issue history query failed: %v", queryErr)}
+	}
+	if closeErr != nil {
+		return doctorCheck{Name: name, Status: doctorWarn, Detail: fmt.Sprintf("completed issue history close failed: %v", closeErr)}
+	}
+	if history.CompletedIssues == 0 {
+		return doctorCheck{Name: name, Status: doctorOK, Detail: "no completed issue history recorded yet"}
+	}
+
+	sessionLimit := cfg.Agent.LifetimeSessionLimit
+	tokenLimit := cfg.Agent.LifetimeTokenLimit
+	contextDetail := fmt.Sprintf(
+		"project p95 from %d completed issues: sessions %d, tokens %d",
+		history.CompletedIssues,
+		history.P95Sessions,
+		history.P95Tokens,
+	)
+	below := make([]string, 0, 2)
+	if sessionLimit > 0 && sessionLimit < history.P95Sessions {
+		below = append(below, fmt.Sprintf("agent.lifetime_session_limit %d is below project p95 %d", sessionLimit, history.P95Sessions))
+	}
+	if tokenLimit > 0 && tokenLimit < history.P95Tokens {
+		below = append(below, fmt.Sprintf("agent.lifetime_token_limit %d is below project p95 %d", tokenLimit, history.P95Tokens))
+	}
+	if len(below) > 0 {
+		return doctorCheck{
+			Name:   name,
+			Status: doctorWarn,
+			Detail: strings.Join(below, "; ") + "; " + contextDetail,
+			Hint:   "Raise each configured lifetime limit to at least its project p95, or set it to 0 to disable that limit deliberately.",
+		}
+	}
+	if sessionLimit == 0 && tokenLimit == 0 {
+		return doctorCheck{Name: name, Status: doctorOK, Detail: "lifetime limits are disabled; " + contextDetail}
+	}
+	return doctorCheck{Name: name, Status: doctorOK, Detail: "configured lifetime limits are not below " + contextDetail}
+}

--- a/internal/cli/doctor_lifetime_limit_test.go
+++ b/internal/cli/doctor_lifetime_limit_test.go
@@ -1,0 +1,82 @@
+package cli
+
+import (
+	"database/sql"
+	"fmt"
+	"path/filepath"
+	"testing"
+	"time"
+
+	workflowconfig "github.com/digitaldrywood/detent/internal/config"
+	"github.com/digitaldrywood/detent/internal/store"
+)
+
+func TestDoctorLifetimeLimitsCompareConfiguredCapsToProjectP95(t *testing.T) {
+	t.Parallel()
+
+	path := createDoctorLifetimeHistoryStore(t)
+	tests := []struct {
+		name         string
+		sessionLimit int64
+		tokenLimit   int64
+		wantStatus   doctorStatus
+		wantDetail   []string
+	}{
+		{name: "caps above p95", sessionLimit: 120, tokenLimit: 750_000_000, wantStatus: doctorOK, wantDetail: []string{"20 completed issues", "sessions 60", "tokens 200000000"}},
+		{name: "cap equal to p95", sessionLimit: 60, tokenLimit: 200_000_000, wantStatus: doctorOK},
+		{name: "session cap below p95", sessionLimit: 59, tokenLimit: 750_000_000, wantStatus: doctorWarn, wantDetail: []string{"lifetime_session_limit 59", "project p95 60"}},
+		{name: "token cap below p95", sessionLimit: 120, tokenLimit: 199_999_999, wantStatus: doctorWarn, wantDetail: []string{"lifetime_token_limit 199999999", "project p95 200000000"}},
+		{name: "disabled caps", wantStatus: doctorOK, wantDetail: []string{"disabled"}},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			cfg := workflowconfig.Config{}
+			cfg.Agent.LifetimeSessionLimit = test.sessionLimit
+			cfg.Agent.LifetimeTokenLimit = test.tokenLimit
+			check := checkDoctorLifetimeLimits(t.Context(), "detent", path, cfg, doctorDeps{})
+			if check.Status != test.wantStatus {
+				t.Fatalf("Status = %s, want %s: %#v", check.Status, test.wantStatus, check)
+			}
+			for _, fragment := range test.wantDetail {
+				if !containsAll(check.Detail, fragment) {
+					t.Fatalf("Detail = %q, want containing %q", check.Detail, fragment)
+				}
+			}
+		})
+	}
+}
+
+func createDoctorLifetimeHistoryStore(t *testing.T) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "detent.db")
+	backend, err := store.Open(t.Context(), store.Config{Path: path})
+	if err != nil {
+		t.Fatalf("store.Open() error = %v", err)
+	}
+	if err := backend.Close(); err != nil {
+		t.Fatalf("Close() error = %v", err)
+	}
+	db, err := sql.Open("sqlite", path)
+	if err != nil {
+		t.Fatalf("sql.Open() error = %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	completedAt := time.Date(2026, 8, 24, 12, 0, 0, 0, time.UTC).Format(time.RFC3339Nano)
+	for index := 1; index <= 18; index++ {
+		insertDoctorLifetimeReceipt(t, db, fmt.Sprintf("issue-%d", index), int64(index), int64(index)*1_000_000, false, completedAt)
+	}
+	insertDoctorLifetimeReceipt(t, db, "issue-p95", 60, 200_000_000, false, completedAt)
+	insertDoctorLifetimeReceipt(t, db, "issue-runaway", 450, 374_000_000, false, completedAt)
+	insertDoctorLifetimeReceipt(t, db, "issue-running", 900, 900_000_000, true, completedAt)
+	return path
+}
+
+func insertDoctorLifetimeReceipt(t *testing.T, db *sql.DB, issueID string, sessions, tokens int64, inProgress bool, completedAt string) {
+	t.Helper()
+	if _, err := db.ExecContext(t.Context(), `INSERT INTO efficiency_receipts (
+project_id, issue_id, sessions, total_tokens, first_dispatched_at, completed_at, in_progress, refreshed_at
+) VALUES ('detent', ?, ?, ?, ?, ?, ?, ?)`, issueID, sessions, tokens, completedAt, completedAt, inProgress, completedAt); err != nil {
+		t.Fatalf("insert efficiency receipt %s: %v", issueID, err)
+	}
+}

--- a/internal/cli/doctor_project.go
+++ b/internal/cli/doctor_project.go
@@ -360,6 +360,10 @@ func checkDoctorProjectWithProgress(
 	setDoctorCurrentCheck("Project " + id + " progress brake")
 	checks = append(checks, checkDoctorProgressBrake(id, workflow.Config))
 	if strings.TrimSpace(storePath) != "" {
+		setDoctorCurrentCheck("Project " + id + " lifetime limits")
+		checks = append(checks, checkDoctorLifetimeLimits(ctx, id, storePath, workflow.Config, deps))
+	}
+	if strings.TrimSpace(storePath) != "" {
 		setDoctorCurrentCheck("Project " + id + " historical throughput")
 		checks = append(checks, checkDoctorHistoricalThroughput(ctx, id, storePath, workflow.Config.Agent.MaxConcurrentAgents, deps)...)
 	}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -70,8 +70,8 @@ const (
 	DefaultNoProgressLimit                   = 3
 	DefaultNoProgressTokenLimit              = 25_000_000
 	DefaultNoProgressSpendLimitUSD           = 3.0
-	DefaultLifetimeSessionLimit              = 15
-	DefaultLifetimeTokenLimit                = 40_000_000
+	DefaultLifetimeSessionLimit              = 120
+	DefaultLifetimeTokenLimit                = 750_000_000
 	DefaultLifetimeLimitCooldownSeconds      = 3600
 	DefaultLifetimeLimitOverrideLabel        = "allow-lifetime-limit"
 	DefaultFailureBreakerSameClassLimit      = 5

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -775,6 +775,17 @@ func TestLifetimeLimitConfiguration(t *testing.T) {
 	}
 }
 
+func TestLifetimeLimitDefaultsSeparateHistoricalRunaways(t *testing.T) {
+	t.Parallel()
+
+	if DefaultLifetimeSessionLimit != 120 {
+		t.Fatalf("DefaultLifetimeSessionLimit = %d, want 120", DefaultLifetimeSessionLimit)
+	}
+	if DefaultLifetimeTokenLimit != 750_000_000 {
+		t.Fatalf("DefaultLifetimeTokenLimit = %d, want 750000000", DefaultLifetimeTokenLimit)
+	}
+}
+
 func TestFailureBreakerConfiguration(t *testing.T) {
 	t.Parallel()
 

--- a/internal/orchestrator/lifetime_limit.go
+++ b/internal/orchestrator/lifetime_limit.go
@@ -28,6 +28,7 @@ type LifetimeUsageStore interface {
 
 type lifetimeLimitDecision struct {
 	Usage           store.TokenSpend
+	ProjectHistory  store.ProjectLifetimeUsage
 	SessionLimit    int64
 	TokenLimit      int64
 	SessionsReached bool
@@ -53,6 +54,8 @@ func (o *Orchestrator) enforceLifetimeLimits(ctx context.Context, state *State, 
 		return
 	}
 	state.ensureInitialized(o.cfg)
+	var projectHistory store.ProjectLifetimeUsage
+	projectHistoryLoaded := false
 	for _, issue := range issues {
 		if strings.TrimSpace(issue.ID) == "" || !stateIn(issue.State, o.cfg.ActiveStates) {
 			continue
@@ -74,8 +77,28 @@ func (o *Orchestrator) enforceLifetimeLimits(ctx context.Context, state *State, 
 		if !decision.reached() || o.lifetimeLimitOverride(issue) || o.lifetimeLimitRecoveryPermit(ctx, issue, usage) {
 			continue
 		}
+		if !projectHistoryLoaded {
+			projectHistory = o.projectLifetimeUsage(ctx)
+			projectHistoryLoaded = true
+		}
+		decision.ProjectHistory = projectHistory
 		o.parkLifetimeLimit(ctx, state, issue, decision, now)
 	}
+}
+
+func (o *Orchestrator) projectLifetimeUsage(ctx context.Context) store.ProjectLifetimeUsage {
+	historyStore, ok := o.lifetimeUsage.(store.ProjectLifetimeUsageStore)
+	if !ok {
+		return store.ProjectLifetimeUsage{}
+	}
+	history, err := historyStore.ProjectLifetimeUsage(ctx, o.workflowMetricsProjectID())
+	if err != nil {
+		if o.logger != nil {
+			o.logger.Warn("project lifetime usage lookup failed", "project_id", o.workflowMetricsProjectID(), "error", err)
+		}
+		return store.ProjectLifetimeUsage{}
+	}
+	return history
 }
 
 func (o *Orchestrator) lifetimeLimitsEnabled() bool {
@@ -224,6 +247,22 @@ func (o *Orchestrator) lifetimeLimitComment(issue connector.Issue, decision life
 	b.WriteString(strconv.FormatInt(decision.Usage.TotalTokens, 10))
 	b.WriteString(" / ")
 	b.WriteString(formatLifetimeLimit(decision.TokenLimit))
+	if decision.ProjectHistory.CompletedIssues > 0 {
+		b.WriteString("\n- project_session_context: ")
+		b.WriteString(strconv.FormatInt(decision.Usage.Sessions, 10))
+		b.WriteString(" sessions; project p95 is ")
+		b.WriteString(strconv.FormatInt(decision.ProjectHistory.P95Sessions, 10))
+		b.WriteString(" across ")
+		b.WriteString(strconv.FormatInt(decision.ProjectHistory.CompletedIssues, 10))
+		b.WriteString(" completed issues")
+		b.WriteString("\n- project_token_context: ")
+		b.WriteString(strconv.FormatInt(decision.Usage.TotalTokens, 10))
+		b.WriteString(" tokens; project p95 is ")
+		b.WriteString(strconv.FormatInt(decision.ProjectHistory.P95Tokens, 10))
+		b.WriteString(" across ")
+		b.WriteString(strconv.FormatInt(decision.ProjectHistory.CompletedIssues, 10))
+		b.WriteString(" completed issues")
+	}
 	b.WriteString("\n- cooldown_until: ")
 	b.WriteString(resumeAt.UTC().Format(time.RFC3339))
 	b.WriteString("\n\nAfter the cooldown, Detent permits one additional session before re-evaluating cumulative usage.")

--- a/internal/orchestrator/lifetime_limit_test.go
+++ b/internal/orchestrator/lifetime_limit_test.go
@@ -3,6 +3,7 @@ package orchestrator
 import (
 	"context"
 	"errors"
+	"strings"
 	"testing"
 	"time"
 
@@ -45,15 +46,39 @@ func TestEnforceLifetimeLimits(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name       string
-		usage      store.TokenSpend
-		labels     []string
-		usageErr   error
-		wantParked bool
+		name         string
+		usage        store.TokenSpend
+		history      store.ProjectLifetimeUsage
+		labels       []string
+		usageErr     error
+		sessionLimit int64
+		tokenLimit   int64
+		wantParked   bool
+		wantComment  []string
 	}{
 		{name: "below limits", usage: store.TokenSpend{Sessions: 14, TotalTokens: 39_000_000}},
 		{name: "session limit", usage: store.TokenSpend{Sessions: 15, TotalTokens: 12_000_000}, wantParked: true},
 		{name: "token limit", usage: store.TokenSpend{Sessions: 8, TotalTokens: 40_000_000}, wantParked: true},
+		{
+			name:         "project p95 remains allowed by calibrated defaults",
+			usage:        store.TokenSpend{Sessions: 60, TotalTokens: 200_000_000},
+			history:      store.ProjectLifetimeUsage{ProjectID: "detent", CompletedIssues: 270, MeanSessions: 11.7, P95Sessions: 60, P95Tokens: 200_000_000},
+			sessionLimit: 120,
+			tokenLimit:   750_000_000,
+		},
+		{
+			name:         "ten times mean reaches runaway cap",
+			usage:        store.TokenSpend{Sessions: 120, TotalTokens: 200_000_000},
+			history:      store.ProjectLifetimeUsage{ProjectID: "detent", CompletedIssues: 270, MeanSessions: 12, P95Sessions: 60, P95Tokens: 200_000_000},
+			sessionLimit: 120,
+			tokenLimit:   750_000_000,
+			wantParked:   true,
+			wantComment: []string{
+				"120 sessions; project p95 is 60",
+				"200000000 tokens; project p95 is 200000000",
+				"270 completed issues",
+			},
+		},
 		{name: "operator override", usage: store.TokenSpend{Sessions: 20, TotalTokens: 50_000_000}, labels: []string{"ALLOW-LIFETIME-LIMIT"}},
 		{name: "usage unavailable fails open", usageErr: errors.New("database unavailable")},
 	}
@@ -62,8 +87,14 @@ func TestEnforceLifetimeLimits(t *testing.T) {
 			t.Parallel()
 
 			cfg := lifetimeLimitTestConfig()
+			if test.sessionLimit > 0 {
+				cfg.LifetimeSessionLimit = test.sessionLimit
+			}
+			if test.tokenLimit > 0 {
+				cfg.LifetimeTokenLimit = test.tokenLimit
+			}
 			tracker := &backendCapacityTestConnector{}
-			usage := &lifetimeUsageStoreStub{spend: test.usage, err: test.usageErr}
+			usage := &lifetimeUsageStoreStub{spend: test.usage, history: test.history, err: test.usageErr}
 			metrics := &lifetimeWorkflowMetricsStub{}
 			orch := &Orchestrator{
 				cfg:             cfg,
@@ -93,6 +124,11 @@ func TestEnforceLifetimeLimits(t *testing.T) {
 			}
 			if len(tracker.comments) != 1 {
 				t.Fatalf("tracker comments = %d, want 1", len(tracker.comments))
+			}
+			for _, fragment := range test.wantComment {
+				if !strings.Contains(tracker.comments[0], fragment) {
+					t.Fatalf("tracker comment = %q, want containing %q", tracker.comments[0], fragment)
+				}
 			}
 			if blocked.Recovery == nil || blocked.Recovery.Predicate != blockedRecoveryPredicateLifetimeLimit {
 				t.Fatalf("blocked recovery = %#v, want lifetime predicate", blocked.Recovery)
@@ -183,12 +219,17 @@ func lifetimeLimitTestIssue() connector.Issue {
 }
 
 type lifetimeUsageStoreStub struct {
-	spend store.TokenSpend
-	err   error
+	spend   store.TokenSpend
+	history store.ProjectLifetimeUsage
+	err     error
 }
 
 func (s *lifetimeUsageStoreStub) IssueTokenSpend(context.Context, store.IssueIdentity) (store.TokenSpend, error) {
 	return s.spend, s.err
+}
+
+func (s *lifetimeUsageStoreStub) ProjectLifetimeUsage(context.Context, string) (store.ProjectLifetimeUsage, error) {
+	return s.history, nil
 }
 
 type lifetimeWorkflowMetricsStub struct {

--- a/internal/store/lifetime_history.go
+++ b/internal/store/lifetime_history.go
@@ -1,0 +1,92 @@
+package store
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"math"
+	"sort"
+	"strings"
+)
+
+type ProjectLifetimeUsage struct {
+	ProjectID       string
+	CompletedIssues int64
+	MeanSessions    float64
+	MeanTokens      float64
+	P95Sessions     int64
+	P95Tokens       int64
+}
+
+type ProjectLifetimeUsageStore interface {
+	ProjectLifetimeUsage(context.Context, string) (ProjectLifetimeUsage, error)
+}
+
+type ProjectLifetimeUsageQuerier interface {
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+}
+
+func (s *sqliteStore) ProjectLifetimeUsage(ctx context.Context, projectID string) (ProjectLifetimeUsage, error) {
+	return QueryProjectLifetimeUsage(ctx, s.db, projectID)
+}
+
+func QueryProjectLifetimeUsage(ctx context.Context, queryer ProjectLifetimeUsageQuerier, projectID string) (ProjectLifetimeUsage, error) {
+	projectID = strings.TrimSpace(projectID)
+	if projectID == "" {
+		return ProjectLifetimeUsage{}, ErrProjectRequired
+	}
+	rows, err := queryer.QueryContext(ctx, `
+SELECT sessions, total_tokens
+FROM efficiency_receipts
+WHERE project_id = ? AND in_progress = 0
+ORDER BY id`, projectID)
+	if err != nil {
+		return ProjectLifetimeUsage{}, fmt.Errorf("querying project lifetime usage: %w", err)
+	}
+	defer rows.Close()
+
+	sessions := make([]int64, 0)
+	tokens := make([]int64, 0)
+	var sessionTotal int64
+	var tokenTotal int64
+	for rows.Next() {
+		var issueSessions int64
+		var issueTokens int64
+		if err := rows.Scan(&issueSessions, &issueTokens); err != nil {
+			return ProjectLifetimeUsage{}, fmt.Errorf("scanning project lifetime usage: %w", err)
+		}
+		sessions = append(sessions, issueSessions)
+		tokens = append(tokens, issueTokens)
+		sessionTotal += issueSessions
+		tokenTotal += issueTokens
+	}
+	if err := rows.Err(); err != nil {
+		return ProjectLifetimeUsage{}, fmt.Errorf("reading project lifetime usage: %w", err)
+	}
+
+	usage := ProjectLifetimeUsage{ProjectID: projectID, CompletedIssues: int64(len(sessions))}
+	if len(sessions) == 0 {
+		return usage, nil
+	}
+	usage.MeanSessions = float64(sessionTotal) / float64(len(sessions))
+	usage.MeanTokens = float64(tokenTotal) / float64(len(tokens))
+	usage.P95Sessions = nearestRankPercentile(sessions, 0.95)
+	usage.P95Tokens = nearestRankPercentile(tokens, 0.95)
+	return usage, nil
+}
+
+func nearestRankPercentile(values []int64, percentile float64) int64 {
+	if len(values) == 0 {
+		return 0
+	}
+	sorted := append([]int64(nil), values...)
+	sort.Slice(sorted, func(i, j int) bool { return sorted[i] < sorted[j] })
+	index := int(math.Ceil(percentile*float64(len(sorted)))) - 1
+	if index < 0 {
+		index = 0
+	}
+	if index >= len(sorted) {
+		index = len(sorted) - 1
+	}
+	return sorted[index]
+}

--- a/internal/store/lifetime_history_test.go
+++ b/internal/store/lifetime_history_test.go
@@ -1,0 +1,44 @@
+package store
+
+import (
+	"database/sql"
+	"fmt"
+	"math"
+	"testing"
+	"time"
+)
+
+func TestProjectLifetimeUsageUsesCompletedProjectHistory(t *testing.T) {
+	t.Parallel()
+
+	backend := openTestStore(t, t.Context())
+	db := backend.(*sqliteStore).db
+	completedAt := time.Date(2026, 8, 24, 12, 0, 0, 0, time.UTC).Format(time.RFC3339Nano)
+	for index := 1; index <= 18; index++ {
+		insertLifetimeHistoryReceipt(t, db, "detent", fmt.Sprintf("issue-%d", index), int64(index), int64(index)*1_000_000, false, completedAt)
+	}
+	insertLifetimeHistoryReceipt(t, db, "detent", "issue-p95", 60, 200_000_000, false, completedAt)
+	insertLifetimeHistoryReceipt(t, db, "detent", "issue-runaway", 450, 374_000_000, false, completedAt)
+	insertLifetimeHistoryReceipt(t, db, "detent", "issue-running", 900, 900_000_000, true, completedAt)
+	insertLifetimeHistoryReceipt(t, db, "other", "issue-other", 800, 800_000_000, false, completedAt)
+
+	usage, err := backend.(ProjectLifetimeUsageStore).ProjectLifetimeUsage(t.Context(), "detent")
+	if err != nil {
+		t.Fatalf("ProjectLifetimeUsage() error = %v", err)
+	}
+	if usage.CompletedIssues != 20 || usage.P95Sessions != 60 || usage.P95Tokens != 200_000_000 {
+		t.Fatalf("ProjectLifetimeUsage() = %#v, want 20 completed issues with p95 60/200000000", usage)
+	}
+	if math.Abs(usage.MeanSessions-34.05) > 0.000001 {
+		t.Fatalf("MeanSessions = %v, want 34.05", usage.MeanSessions)
+	}
+}
+
+func insertLifetimeHistoryReceipt(t *testing.T, db *sql.DB, projectID, issueID string, sessions, tokens int64, inProgress bool, completedAt string) {
+	t.Helper()
+	if _, err := db.ExecContext(t.Context(), `INSERT INTO efficiency_receipts (
+project_id, issue_id, sessions, total_tokens, first_dispatched_at, completed_at, in_progress, refreshed_at
+) VALUES (?, ?, ?, ?, ?, ?, ?, ?)`, projectID, issueID, sessions, tokens, completedAt, completedAt, inProgress, completedAt); err != nil {
+		t.Fatalf("insert efficiency receipt %s: %v", issueID, err)
+	}
+}


### PR DESCRIPTION
## Summary

- raise cold-start lifetime defaults to 120 sessions and 750,000,000 tokens
- calculate completed-project p95 session/token usage for doctor warnings and lifetime park comments
- cover calibrated p95/runaway behavior, project history filtering, doctor thresholds, and generated config defaults
- draft a reusable skill for aligning golangci-lint with the project Go toolchain

Fixes #1976

## UI Surface Contract

- [x] N/A, or the linked issue explicitly authorizes any high-impact UI surface, layout, density, first-viewport, or responsive visibility tradeoff.
- [x] Persistent top-of-screen messaging is explicitly authorized by the issue, or this PR does not add it.
- [x] Visual changes to primary operator screens include screenshot or browser verification below. (N/A: no visual changes.)

## Test Plan

- [x] `make generate`
- [x] `go test ./internal/config ./internal/store ./internal/orchestrator ./internal/cli -count=1`
- [x] `make check` with Go 1.26.2 and repository-pinned golangci-lint v2.1.6
