### PR TITLE
fix(intake): scan tracked TODO files

### DIFF
--- a/docs/scheduled-routines.md
+++ b/docs/scheduled-routines.md
@@ -92,10 +92,12 @@ configured starting status and then enter the existing label, issue-field, or
 ProjectV2 gate pipeline. ProjectV2 intake also requires `tracker.repository` so
 Detent knows where to create the repository issue before adding it to the board.
 
-The built-in `stale-todos` scanner walks the project source root for TODO and
-FIXME entries while skipping generated/dependency trees such as `.git`,
-`node_modules`, `vendor`, `tmp`, `dist`, and `build`. Scanner schedules use
-standard five-field cron expressions.
+The built-in `stale-todos` scanner asks Git for tracked files beneath the
+project source root, then scans eligible regular files for TODO and FIXME
+entries. Untracked and gitignored files, including generated output, are not
+scanned. The source root must be inside a Git worktree and the `git` executable
+must be available; otherwise the scan returns an actionable error. Scanner
+schedules use standard five-field cron expressions.
 
 Host-local policy can override the workflow policy inside a project entry in
 `global.yaml` using the same `intake` shape. An explicit `sources: []` override

--- a/internal/intake/scanner.go
+++ b/internal/intake/scanner.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io/fs"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"regexp"
 	"strconv"
@@ -41,34 +42,35 @@ func (scannerFactory) New(name string, root string) (Scanner, error) {
 }
 
 func (s staleTODOScanner) Scan(ctx context.Context) ([]Event, error) {
+	paths, err := s.trackedPaths(ctx)
+	if err != nil {
+		return nil, err
+	}
+
 	root := os.DirFS(s.root)
 	events := []Event{}
-	err := fs.WalkDir(root, ".", func(path string, entry fs.DirEntry, walkErr error) error {
-		if walkErr != nil {
-			return walkErr
-		}
+	for _, path := range paths {
 		if err := ctx.Err(); err != nil {
-			return err
+			return nil, err
 		}
-		if entry.IsDir() {
-			if path != "." && skippedDirectory(entry.Name()) {
-				return fs.SkipDir
-			}
-			return nil
+		if !scannablePath(path) {
+			continue
 		}
-		if !entry.Type().IsRegular() || !scannablePath(path) {
-			return nil
+
+		info, err := os.Lstat(filepath.Join(s.root, filepath.FromSlash(path)))
+		if errors.Is(err, fs.ErrNotExist) {
+			continue
 		}
-		info, err := entry.Info()
 		if err != nil {
-			return err
+			return nil, fmt.Errorf("inspect tracked stale TODO file %q: %w", path, err)
 		}
-		if info.Size() > maxScannedFileBytes {
-			return nil
+		if !info.Mode().IsRegular() || info.Size() > maxScannedFileBytes {
+			continue
 		}
+
 		file, err := root.Open(path)
 		if err != nil {
-			return err
+			return nil, fmt.Errorf("open tracked stale TODO file %q: %w", path, err)
 		}
 		scanner := bufio.NewScanner(file)
 		scanner.Buffer(make([]byte, 64*1024), maxScannedFileBytes)
@@ -96,21 +98,29 @@ func (s staleTODOScanner) Scan(ctx context.Context) ([]Event, error) {
 				},
 			})
 		}
-		return errors.Join(scanner.Err(), file.Close())
-	})
-	if err != nil {
-		return nil, fmt.Errorf("walk stale TODO source: %w", err)
+		if err := errors.Join(scanner.Err(), file.Close()); err != nil {
+			return nil, fmt.Errorf("scan tracked stale TODO file %q: %w", path, err)
+		}
 	}
 	return events, nil
 }
 
-func skippedDirectory(name string) bool {
-	switch strings.ToLower(strings.TrimSpace(name)) {
-	case ".git", ".detent", "node_modules", "vendor", "tmp", "dist", "build":
-		return true
-	default:
-		return false
+func (s staleTODOScanner) trackedPaths(ctx context.Context) ([]string, error) {
+	cmd := exec.CommandContext(ctx, "git")
+	cmd.Args = []string{"git", "-C", s.root, "ls-files", "--cached", "-z", "--", "."}
+	output, err := cmd.Output()
+	if err != nil {
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return nil, ctxErr
+		}
+		return nil, fmt.Errorf("list git-tracked files for stale TODO scan: %w; source root must be a Git worktree with git available", err)
 	}
+
+	paths := strings.Split(strings.TrimSuffix(string(output), "\x00"), "\x00")
+	if len(paths) == 1 && paths[0] == "" {
+		return nil, nil
+	}
+	return paths, nil
 }
 
 func scannablePath(path string) bool {

--- a/internal/intake/scanner.go
+++ b/internal/intake/scanner.go
@@ -107,8 +107,21 @@ func (s staleTODOScanner) Scan(ctx context.Context) ([]Event, error) {
 
 func (s staleTODOScanner) trackedPaths(ctx context.Context) ([]string, error) {
 	cmd := exec.CommandContext(ctx, "git")
-	cmd.Args = []string{"git", "-C", s.root, "ls-files", "--cached", "-z", "--", "."}
+	cmd.Args = []string{"git", "-C", s.root, "rev-parse", "--is-inside-work-tree"}
 	output, err := cmd.Output()
+	if err != nil {
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return nil, ctxErr
+		}
+		return nil, fmt.Errorf("validate stale TODO source root: %w; source root must be a Git worktree with git available", err)
+	}
+	if strings.TrimSpace(string(output)) != "true" {
+		return nil, errors.New("validate stale TODO source root: source root must be a Git worktree")
+	}
+
+	cmd = exec.CommandContext(ctx, "git")
+	cmd.Args = []string{"git", "-C", s.root, "ls-files", "--cached", "-z", "--", "."}
+	output, err = cmd.Output()
 	if err != nil {
 		if ctxErr := ctx.Err(); ctxErr != nil {
 			return nil, ctxErr

--- a/internal/intake/scanner_test.go
+++ b/internal/intake/scanner_test.go
@@ -3,36 +3,89 @@ package intake
 import (
 	"context"
 	"os"
+	"os/exec"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
-func TestStaleTODOScannerFindsSourceTodosAndSkipsExcludedTrees(t *testing.T) {
-	t.Parallel()
+func TestStaleTODOScanner(t *testing.T) {
+	tests := []struct {
+		name      string
+		setup     func(*testing.T, string)
+		wantPaths []string
+		wantErr   string
+	}{
+		{
+			name: "Git worktree scans only tracked regular files",
+			setup: func(t *testing.T, root string) {
+				writeScannerTestFile(t, root, ".gitignore", ".next/\n")
+				writeScannerTestFile(t, root, "main.go", "package main\n\n// TODO: handle retries\n")
+				writeScannerTestFile(t, root, ".next/server/chunk.js", "// TODO: compiled vendor chunk\n")
+				writeScannerTestFile(t, root, "untracked.go", "// TODO: untracked source\n")
 
-	root := t.TempDir()
-	if err := os.WriteFile(filepath.Join(root, "main.go"), []byte("package main\n\n// TODO: handle retries\n"), 0o600); err != nil {
-		t.Fatalf("WriteFile(main.go) error = %v", err)
-	}
-	if err := os.MkdirAll(filepath.Join(root, "vendor", "example"), 0o700); err != nil {
-		t.Fatalf("MkdirAll(vendor) error = %v", err)
-	}
-	if err := os.WriteFile(filepath.Join(root, "vendor", "example", "dep.go"), []byte("// TODO: vendored\n"), 0o600); err != nil {
-		t.Fatalf("WriteFile(dep.go) error = %v", err)
+				cmd := exec.CommandContext(t.Context(), "git")
+				cmd.Args = []string{"git", "-C", root, "init", "--quiet"}
+				if output, err := cmd.CombinedOutput(); err != nil {
+					t.Fatalf("git init error = %v, output = %s", err, output)
+				}
+				cmd = exec.CommandContext(t.Context(), "git")
+				cmd.Args = []string{"git", "-C", root, "add", "--", ".gitignore", "main.go"}
+				if output, err := cmd.CombinedOutput(); err != nil {
+					t.Fatalf("git add error = %v, output = %s", err, output)
+				}
+			},
+			wantPaths: []string{"main.go"},
+		},
+		{
+			name: "non-Git root returns actionable error",
+			setup: func(t *testing.T, root string) {
+				t.Setenv("GIT_CEILING_DIRECTORIES", os.TempDir())
+				writeScannerTestFile(t, root, "main.go", "// TODO: source without repository\n")
+			},
+			wantErr: "source root must be a Git worktree",
+		},
 	}
 
-	scanner, err := DefaultScannerFactory().New("stale-todos", root)
-	if err != nil {
-		t.Fatalf("New() error = %v", err)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			root := t.TempDir()
+			tt.setup(t, root)
+
+			scanner, err := DefaultScannerFactory().New("stale-todos", root)
+			if err != nil {
+				t.Fatalf("New() error = %v", err)
+			}
+			events, err := scanner.Scan(context.Background())
+			if tt.wantErr != "" {
+				if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
+					t.Fatalf("Scan() error = %v, want error containing %q", err, tt.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("Scan() error = %v", err)
+			}
+
+			gotPaths := make([]string, 0, len(events))
+			for _, event := range events {
+				gotPaths = append(gotPaths, event.Fields["path"])
+			}
+			if strings.Join(gotPaths, ",") != strings.Join(tt.wantPaths, ",") {
+				t.Fatalf("event paths = %v, want %v", gotPaths, tt.wantPaths)
+			}
+		})
 	}
-	events, err := scanner.Scan(context.Background())
-	if err != nil {
-		t.Fatalf("Scan() error = %v", err)
+}
+
+func writeScannerTestFile(t *testing.T, root string, path string, contents string) {
+	t.Helper()
+
+	fullPath := filepath.Join(root, filepath.FromSlash(path))
+	if err := os.MkdirAll(filepath.Dir(fullPath), 0o700); err != nil {
+		t.Fatalf("MkdirAll(%s) error = %v", filepath.Dir(fullPath), err)
 	}
-	if len(events) != 1 {
-		t.Fatalf("events = %#v, want one source TODO", events)
-	}
-	if events[0].Fields["path"] != "main.go" || events[0].Fields["line"] != "3" {
-		t.Fatalf("event location = %#v, want main.go:3", events[0].Fields)
+	if err := os.WriteFile(fullPath, []byte(contents), 0o600); err != nil {
+		t.Fatalf("WriteFile(%s) error = %v", fullPath, err)
 	}
 }

--- a/internal/intake/scanner_test.go
+++ b/internal/intake/scanner_test.go
@@ -45,6 +45,17 @@ func TestStaleTODOScanner(t *testing.T) {
 			},
 			wantErr: "source root must be a Git worktree",
 		},
+		{
+			name: "bare repository returns actionable error",
+			setup: func(t *testing.T, root string) {
+				cmd := exec.CommandContext(t.Context(), "git")
+				cmd.Args = []string{"git", "-C", root, "init", "--bare", "--quiet"}
+				if output, err := cmd.CombinedOutput(); err != nil {
+					t.Fatalf("git init --bare error = %v, output = %s", err, output)
+				}
+			},
+			wantErr: "source root must be a Git worktree",
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Summary

- Restrict stale-TODO intake to Git-tracked regular source files so ignored and untracked generated output cannot create findings.
- Preserve tracked TODO reporting and return an actionable error when the source root is not a Git worktree or Git is unavailable.
- Document the Git requirement and cover tracked, ignored, untracked, and non-Git paths with regression tests.

Fixes #1981

## UI Surface Contract

- [x] N/A, or the linked issue explicitly authorizes any high-impact UI surface, layout, density, first-viewport, or responsive visibility tradeoff.
- [x] Persistent top-of-screen messaging is explicitly authorized by the issue, or this PR does not add it.
- [x] Visual changes to primary operator screens include screenshot or browser verification below.

## Test Plan

- [x] `make check`
