### PR TITLE
fix(budget): keep fallback projections advisory

### DIFF
--- a/internal/budget/budget.go
+++ b/internal/budget/budget.go
@@ -60,6 +60,13 @@ type TokenEstimate struct {
 	Sessions          int64
 }
 
+type EstimateSource string
+
+const (
+	EstimateSourceDefault    EstimateSource = "default"
+	EstimateSourceHistorical EstimateSource = "historical"
+)
+
 type Decision struct {
 	Allowed    bool
 	Refusal    *Refusal
@@ -69,6 +76,13 @@ type Decision struct {
 type Projection struct {
 	Estimate TokenEstimate
 	CostUSD  float64
+}
+
+func (p Projection) EstimateSource() EstimateSource {
+	if p.Estimate.Sessions > 0 {
+		return EstimateSourceHistorical
+	}
+	return EstimateSourceDefault
 }
 
 type DailyStatus struct {

--- a/internal/budget/budget_test.go
+++ b/internal/budget/budget_test.go
@@ -284,6 +284,30 @@ func TestCheckerCheckDispatch(t *testing.T) {
 	}
 }
 
+func TestProjectionEstimateSource(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		sessions int64
+		want     EstimateSource
+	}{
+		{name: "default estimate has no sessions", want: EstimateSourceDefault},
+		{name: "historical estimate records sessions", sessions: 5, want: EstimateSourceHistorical},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			projection := Projection{Estimate: TokenEstimate{Sessions: tt.sessions}}
+			if got := projection.EstimateSource(); got != tt.want {
+				t.Fatalf("EstimateSource() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestCheckerDailyStatus(t *testing.T) {
 	t.Parallel()
 

--- a/internal/cli/runner_test.go
+++ b/internal/cli/runner_test.go
@@ -389,6 +389,33 @@ func TestBuildBudgetDispatchGuards(t *testing.T) {
 	if checker == nil || estimator == nil {
 		t.Fatalf("enabled guards = %T/%T, want checker and estimator", checker, estimator)
 	}
+
+	startedAt := time.Date(2026, 8, 25, 12, 0, 0, 0, time.UTC)
+	for index, inputTokens := range []int64{10, 20, 30, 40, 50} {
+		sessionID, err := storeBackend.StartSession(ctx, store.SessionStart{
+			StartedAt: startedAt.Add(time.Duration(index) * time.Minute),
+			Model:     "gpt-history",
+		})
+		if err != nil {
+			t.Fatalf("StartSession() error = %v", err)
+		}
+		if err := storeBackend.FinishSession(ctx, sessionID, store.SessionFinish{
+			CompletedAt: startedAt.Add(time.Duration(index+1) * time.Minute),
+			InputTokens: inputTokens,
+			TotalTokens: inputTokens,
+			FinalState:  runnerpkg.FinalStateCompleted,
+			Model:       "gpt-history",
+		}); err != nil {
+			t.Fatalf("FinishSession() error = %v", err)
+		}
+	}
+	estimate, err := estimator.EstimateDispatch(ctx, "gpt-history")
+	if err != nil {
+		t.Fatalf("EstimateDispatch() error = %v", err)
+	}
+	if estimate.Sessions != 5 || estimate.InputTokens != 50 {
+		t.Fatalf("EstimateDispatch() = %#v, want five-session p90 input 50", estimate)
+	}
 }
 
 func TestBuildBudgetDispatchGuardsIsolatesProjectDailySpend(t *testing.T) {

--- a/internal/orchestrator/deliverable_recovery.go
+++ b/internal/orchestrator/deliverable_recovery.go
@@ -288,6 +288,7 @@ func (o *Orchestrator) blockHumanOwnedWorkerFailure(
 	detail string,
 	humanAction string,
 	eventName string,
+	eventAttrs ...any,
 ) bool {
 	if state == nil || event.Err == nil || strings.TrimSpace(cause) == "" {
 		return false
@@ -352,11 +353,13 @@ func (o *Orchestrator) blockHumanOwnedWorkerFailure(
 		Event:   eventName,
 		Message: "parked " + issueLabel(issue) + ": " + detail,
 	})
-	telemetry.LogLifecycleMessage(o.logger, slog.LevelError, telemetry.LifecycleSafetyControl, eventName, detail, o.runningLifecycleCorrelation(issue, running),
+	attrs := []any{
 		"cause", cause,
 		"human_action", humanAction,
 		"error", event.Err,
-	)
+	}
+	attrs = append(attrs, eventAttrs...)
+	telemetry.LogLifecycleMessage(o.logger, slog.LevelError, telemetry.LifecycleSafetyControl, eventName, detail, o.runningLifecycleCorrelation(issue, running), attrs...)
 	return true
 }
 

--- a/internal/orchestrator/run_completion.go
+++ b/internal/orchestrator/run_completion.go
@@ -411,9 +411,10 @@ func (o *Orchestrator) handleRunResult(ctx context.Context, state *State, event 
 			event,
 			running,
 			budgetProjectionCeilingFailureCause,
-			fmt.Sprintf("session cost %.6f USD exceeded the admitted projection %.6f USD", projectionErr.ObservedCostUSD, projectionErr.ProjectedCostUSD),
+			fmt.Sprintf("session cost %.6f USD exceeded the admitted projection %.6f USD using estimate source %q", projectionErr.ObservedCostUSD, projectionErr.ProjectedCostUSD, projectionErr.EstimateSource),
 			"inspect the preserved worktree and either narrow the task or adjust the budget policy before moving the issue to Rework",
 			"worker_budget_projection_ceiling_tripped",
+			"estimate_source", projectionErr.EstimateSource,
 		) {
 			return
 		}

--- a/internal/orchestrator/run_completion_token_ceiling_test.go
+++ b/internal/orchestrator/run_completion_token_ceiling_test.go
@@ -1,11 +1,14 @@
 package orchestrator
 
 import (
+	"bytes"
 	"context"
+	"log/slog"
 	"strings"
 	"testing"
 	"time"
 
+	"github.com/digitaldrywood/detent/internal/budget"
 	"github.com/digitaldrywood/detent/internal/connector"
 	runpkg "github.com/digitaldrywood/detent/internal/runner"
 )
@@ -127,13 +130,14 @@ func TestHandleRunResultParksSlowTokenCeilingFailureWithoutRetry(t *testing.T) {
 func TestHandleRunResultParksBudgetProjectionFailureWithoutRetry(t *testing.T) {
 	t.Parallel()
 
+	var logs bytes.Buffer
 	tracker := &dependencyAutoUnblockConnector{}
 	cfg := normalizeConfig(Config{
 		ActiveStates:   []string{"Todo", "In Progress", "Rework"},
 		ObservedStates: []string{"Blocked"},
 		TerminalStates: []string{"Done", "Cancelled"},
 	})
-	orch := &Orchestrator{cfg: cfg, connector: tracker}
+	orch := &Orchestrator{cfg: cfg, connector: tracker, logger: slog.New(slog.NewTextHandler(&logs, nil))}
 	state := newState(cfg)
 	issue := connector.Issue{
 		ID:         "issue-budget-projection",
@@ -156,6 +160,7 @@ func TestHandleRunResultParksBudgetProjectionFailureWithoutRetry(t *testing.T) {
 			ObservedCostUSD:  40.25,
 			ProjectedCostUSD: 10.00,
 			Model:            "gpt-5.6-sol",
+			EstimateSource:   budget.EstimateSourceHistorical,
 		},
 		CompletedAt:  completedAt,
 		Retryable:    false,
@@ -173,7 +178,12 @@ func TestHandleRunResultParksBudgetProjectionFailureWithoutRetry(t *testing.T) {
 	if len(tracker.updates) != 1 || tracker.updates[0].state != blockedStatusState {
 		t.Fatalf("state updates = %#v, want one Blocked transition", tracker.updates)
 	}
-	if len(tracker.comments) != 1 || !strings.Contains(tracker.comments[0].body, "40.250000") || !strings.Contains(tracker.comments[0].body, "10.000000") {
+	if len(tracker.comments) != 1 || !strings.Contains(tracker.comments[0].body, "40.250000") || !strings.Contains(tracker.comments[0].body, "10.000000") || !strings.Contains(tracker.comments[0].body, "historical") {
 		t.Fatalf("comments = %#v, want observed and projected cost", tracker.comments)
+	}
+	for _, want := range []string{"worker_budget_projection_ceiling_tripped", "estimate_source=historical"} {
+		if !strings.Contains(logs.String(), want) {
+			t.Fatalf("logs = %q, want %q", logs.String(), want)
+		}
 	}
 }

--- a/internal/runner/agent.go
+++ b/internal/runner/agent.go
@@ -2159,7 +2159,10 @@ func runResultWithBudgetProjection(projection *budget.Projection) RunResult {
 	if projection == nil {
 		return RunResult{}
 	}
-	return RunResult{budgetProjection: &dispatchBudgetProjection{CostUSD: projection.CostUSD}}
+	return RunResult{budgetProjection: &dispatchBudgetProjection{
+		CostUSD:        projection.CostUSD,
+		EstimateSource: projection.EstimateSource(),
+	}}
 }
 
 func budgetRefusalFromDecision(issue connector.Issue, refusal budget.Refusal) *BudgetRefusal {
@@ -2882,6 +2885,7 @@ func (r *Runner) finishSession(
 			telemetry.WorkAttemptIDKey, workAttemptID,
 			telemetry.DetentSessionIDKey, sessionID,
 			"model", usageModel,
+			"estimate_source", result.budgetProjection.EstimateSource,
 			"projected_cost_usd", *projectedCostUSD,
 			"actual_cost_usd", actualCostUSD,
 			"projection_overshoot_usd", projectionOvershootUSD,
@@ -3039,7 +3043,7 @@ func (r *Runner) enforceSessionBudgetProjection(
 	backendKind string,
 	update AgentUpdate,
 ) error {
-	if projection == nil || projection.CostUSD <= 0 || update.Type != AgentUpdateTokenUsage {
+	if projection == nil || projection.EstimateSource != budget.EstimateSourceHistorical || projection.CostUSD <= 0 || update.Type != AgentUpdateTokenUsage {
 		return nil
 	}
 	observedCostUSD := costOffsetUSD + r.usageCostUSD(
@@ -3056,6 +3060,7 @@ func (r *Runner) enforceSessionBudgetProjection(
 		ObservedCostUSD:  observedCostUSD,
 		ProjectedCostUSD: projection.CostUSD,
 		Model:            model,
+		EstimateSource:   projection.EstimateSource,
 	}
 }
 

--- a/internal/runner/runner_test.go
+++ b/internal/runner/runner_test.go
@@ -2462,66 +2462,99 @@ func TestRunnerRunKillsSessionAtTokenCeilingAndRecordsLesson(t *testing.T) {
 	}
 }
 
-func TestRunnerRunStopsSessionWhenBudgetProjectionIsExceeded(t *testing.T) {
+func TestRunnerRunEnforcesOnlyHistoricalBudgetProjection(t *testing.T) {
 	t.Parallel()
 
 	startedAt := time.Date(2026, 8, 19, 12, 0, 0, 0, time.UTC)
-	agentBackend := &fakeCodexClient{updates: []AgentUpdate{
+	tests := []struct {
+		name             string
+		estimateSessions int64
+		wantError        bool
+		wantFinalState   string
+	}{
 		{
-			Type:   AgentUpdateTokenUsage,
-			Tokens: AgentTokenUsage{InputTokens: 5, TotalTokens: 5},
+			name:           "default estimate remains advisory",
+			wantFinalState: FinalStateCompleted,
 		},
 		{
-			Type:   AgentUpdateTokenUsage,
-			Tokens: AgentTokenUsage{InputTokens: 11, TotalTokens: 11},
+			name:             "historical estimate stops overspend",
+			estimateSessions: 5,
+			wantError:        true,
+			wantFinalState:   FinalStateBudgetProjectionExceeded,
 		},
-	}}
-	sessionStore := &fakeSessionStore{sessionID: 1943}
-	runner, err := NewRunner(Dependencies{
-		Workflow: config.Workflow{
-			Config: config.Config{Budget: config.Budget{BillingMode: config.BillingModeMetered}},
-			Prompt: "Work on {{ issue.identifier }}",
-		},
-		Workspace: &fakeWorkspaceBackend{
-			info: workspace.Info{Path: t.TempDir(), Key: "issue-1943", Branch: "detent/issue-1943"},
-		},
-		AgentBackend: agentBackend,
-		Store:        sessionStore,
-		Pricing: budget.PricingTable{
-			"gpt-budget": {USDPerInputToken: 0.01},
-		},
-		BudgetChecker: &fakeBudgetChecker{projection: &budget.Projection{
-			Estimate: budget.TokenEstimate{InputTokens: 10, TotalTokens: 10},
-			CostUSD:  0.10,
-		}},
-		Now: newFakeClock(
-			startedAt,
-			startedAt.Add(time.Second),
-			startedAt.Add(2*time.Second),
-			startedAt.Add(3*time.Second),
-			startedAt.Add(4*time.Second),
-		).Now,
-	})
-	if err != nil {
-		t.Fatalf("NewRunner() error = %v", err)
 	}
 
-	result, err := runner.Run(t.Context(), RunRequest{Issue: connector.Issue{
-		ID:            "issue-1943",
-		Identifier:    "digitaldrywood/detent#1943",
-		ModelOverride: "gpt-budget",
-	}})
-	if !errors.Is(err, ErrSessionBudgetProjectionExceeded) {
-		t.Fatalf("Run() error = %v, want ErrSessionBudgetProjectionExceeded", err)
-	}
-	if result.FinalState != FinalStateBudgetProjectionExceeded {
-		t.Fatalf("FinalState = %q, want %q", result.FinalState, FinalStateBudgetProjectionExceeded)
-	}
-	if agentBackend.calls != 1 {
-		t.Fatalf("backend calls = %d, want one stopped turn", agentBackend.calls)
-	}
-	if sessionStore.usage.CostUSD <= 0.10 || sessionStore.usage.ProjectedCostUSD == nil || *sessionStore.usage.ProjectedCostUSD != 0.10 {
-		t.Fatalf("UsageEvent = %#v, want recorded projection and crossing cost", sessionStore.usage)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			agentBackend := &fakeCodexClient{updates: []AgentUpdate{
+				{
+					Type:   AgentUpdateTokenUsage,
+					Tokens: AgentTokenUsage{InputTokens: 5, TotalTokens: 5},
+				},
+				{
+					Type:   AgentUpdateTokenUsage,
+					Tokens: AgentTokenUsage{InputTokens: 11, TotalTokens: 11},
+				},
+			}}
+			sessionStore := &fakeSessionStore{sessionID: 1943}
+			runner, err := NewRunner(Dependencies{
+				Workflow: config.Workflow{
+					Config: config.Config{Budget: config.Budget{BillingMode: config.BillingModeMetered}},
+					Prompt: "Work on {{ issue.identifier }}",
+				},
+				Workspace: &fakeWorkspaceBackend{
+					info: workspace.Info{Path: t.TempDir(), Key: "issue-1943", Branch: "detent/issue-1943"},
+				},
+				AgentBackend: agentBackend,
+				Store:        sessionStore,
+				Pricing: budget.PricingTable{
+					"gpt-budget": {USDPerInputToken: 0.01},
+				},
+				BudgetChecker: &fakeBudgetChecker{projection: &budget.Projection{
+					Estimate: budget.TokenEstimate{InputTokens: 10, TotalTokens: 10, Sessions: tt.estimateSessions},
+					CostUSD:  0.10,
+				}},
+				Now: newFakeClock(
+					startedAt,
+					startedAt.Add(time.Second),
+					startedAt.Add(2*time.Second),
+					startedAt.Add(3*time.Second),
+					startedAt.Add(4*time.Second),
+				).Now,
+			})
+			if err != nil {
+				t.Fatalf("NewRunner() error = %v", err)
+			}
+
+			result, err := runner.Run(t.Context(), RunRequest{Issue: connector.Issue{
+				ID:            "issue-1943",
+				Identifier:    "digitaldrywood/detent#1943",
+				ModelOverride: "gpt-budget",
+			}})
+			if got := errors.Is(err, ErrSessionBudgetProjectionExceeded); got != tt.wantError {
+				t.Fatalf("Run() projection error = %t, want %t: %v", got, tt.wantError, err)
+			}
+			if result.FinalState != tt.wantFinalState {
+				t.Fatalf("FinalState = %q, want %q", result.FinalState, tt.wantFinalState)
+			}
+			if agentBackend.calls != 1 {
+				t.Fatalf("backend calls = %d, want one turn", agentBackend.calls)
+			}
+			if sessionStore.usage.CostUSD <= 0.10 || sessionStore.usage.ProjectedCostUSD == nil || *sessionStore.usage.ProjectedCostUSD != 0.10 {
+				t.Fatalf("UsageEvent = %#v, want recorded projection and crossing cost", sessionStore.usage)
+			}
+			if sessionStore.usage.ProjectionOvershootUSD <= 0 {
+				t.Fatalf("ProjectionOvershootUSD = %.6f, want recorded overshoot", sessionStore.usage.ProjectionOvershootUSD)
+			}
+			if tt.wantError {
+				var projectionErr *SessionBudgetProjectionError
+				if !errors.As(err, &projectionErr) || projectionErr.EstimateSource != budget.EstimateSourceHistorical {
+					t.Fatalf("Run() error = %#v, want historical estimate source", err)
+				}
+			}
+		})
 	}
 }
 
@@ -3568,14 +3601,15 @@ func TestRunnerFinishSessionRecordsBudgetProjectionOvershoot(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name          string
-		projectedCost float64
-		inputTokens   int64
-		wantOvershoot float64
-		wantWarning   bool
+		name           string
+		projectedCost  float64
+		inputTokens    int64
+		estimateSource budget.EstimateSource
+		wantOvershoot  float64
+		wantWarning    bool
 	}{
-		{name: "actual cost exceeds admitted projection", projectedCost: 0.10, inputTokens: 20, wantOvershoot: 0.10, wantWarning: true},
-		{name: "actual cost stays below admitted projection", projectedCost: 0.25, inputTokens: 20},
+		{name: "default projection overshoot remains observable", projectedCost: 0.10, inputTokens: 20, estimateSource: budget.EstimateSourceDefault, wantOvershoot: 0.10, wantWarning: true},
+		{name: "historical projection stays below estimate", projectedCost: 0.25, inputTokens: 20, estimateSource: budget.EstimateSourceHistorical},
 	}
 
 	for _, tt := range tests {
@@ -3604,7 +3638,7 @@ func TestRunnerFinishSessionRecordsBudgetProjectionOvershoot(t *testing.T) {
 				RunResult{
 					FinalState:       FinalStateCompleted,
 					Tokens:           TokenTotals{InputTokens: tt.inputTokens, TotalTokens: tt.inputTokens, RuntimeSeconds: 60},
-					budgetProjection: &dispatchBudgetProjection{CostUSD: tt.projectedCost},
+					budgetProjection: &dispatchBudgetProjection{CostUSD: tt.projectedCost, EstimateSource: tt.estimateSource},
 				},
 				"gpt-test",
 				"codex",
@@ -3626,7 +3660,7 @@ func TestRunnerFinishSessionRecordsBudgetProjectionOvershoot(t *testing.T) {
 				t.Fatalf("overshoot warning present = %t, want %t\n%s", gotWarning, tt.wantWarning, logs.String())
 			}
 			if tt.wantWarning {
-				for _, want := range []string{"projected_cost_usd=0.1", "actual_cost_usd=0.2", "projection_overshoot_usd=0.1"} {
+				for _, want := range []string{"estimate_source=default", "projected_cost_usd=0.1", "actual_cost_usd=0.2", "projection_overshoot_usd=0.1"} {
 					if !strings.Contains(logs.String(), want) {
 						t.Fatalf("overshoot warning missing %q:\n%s", want, logs.String())
 					}

--- a/internal/runner/types.go
+++ b/internal/runner/types.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/digitaldrywood/detent/internal/agentidentity"
+	"github.com/digitaldrywood/detent/internal/budget"
 	"github.com/digitaldrywood/detent/internal/connector"
 	"github.com/digitaldrywood/detent/internal/gate"
 	"github.com/digitaldrywood/detent/internal/procgroup"
@@ -426,6 +427,7 @@ type SessionBudgetProjectionError struct {
 	ObservedCostUSD  float64
 	ProjectedCostUSD float64
 	Model            string
+	EstimateSource   budget.EstimateSource
 }
 
 type SessionMemoryCeilingError struct {
@@ -468,11 +470,12 @@ func (e *SessionBudgetProjectionError) Error() string {
 		return ErrSessionBudgetProjectionExceeded.Error()
 	}
 	return fmt.Sprintf(
-		"%s: observed_cost_usd=%.6f projected_cost_usd=%.6f model=%s",
+		"%s: observed_cost_usd=%.6f projected_cost_usd=%.6f model=%s estimate_source=%s",
 		ErrSessionBudgetProjectionExceeded,
 		e.ObservedCostUSD,
 		e.ProjectedCostUSD,
 		strings.TrimSpace(e.Model),
+		e.EstimateSource,
 	)
 }
 
@@ -621,7 +624,8 @@ type RunResult struct {
 }
 
 type dispatchBudgetProjection struct {
-	CostUSD float64
+	CostUSD        float64
+	EstimateSource budget.EstimateSource
 }
 
 type UsageUpdateHandler func(UsageUpdate) error


### PR DESCRIPTION
## Summary

- Keep cold-start/default budget projections advisory while preserving admission and overshoot telemetry.
- Continue enforcing projections backed by historical sessions and expose `estimate_source` in projection safety events.
- Verify the production guard builder consumes stored session history for p90 estimates.

Fixes #1980

## UI Surface Contract

- [x] N/A, or the linked issue explicitly authorizes any high-impact UI surface, layout, density, first-viewport, or responsive visibility tradeoff.
- [x] Persistent top-of-screen messaging is explicitly authorized by the issue, or this PR does not add it.
- [x] Visual changes to primary operator screens include screenshot or browser verification below.

No UI changes.

## Test Plan

- [x] `make check`
- [x] Focused and complete tests for budget, CLI wiring, runner enforcement/telemetry, and orchestrator safety events.