### PR TITLE
fix(cli): coalesce credential watcher updates

### DIFF
--- a/internal/cli/backend_credentials.go
+++ b/internal/cli/backend_credentials.go
@@ -23,7 +23,10 @@ import (
 
 var codexHomeAssignmentPattern = regexp.MustCompile(`(?:^|[[:space:];])CODEX_HOME=(?:"([^"]*)"|'([^']*)'|([^[:space:];|&]+))`)
 
-const backendCredentialWatchRetryDelay = 5 * time.Second
+const (
+	backendCredentialWatchRetryDelay     = 5 * time.Second
+	backendCredentialWatchReconcileDelay = 150 * time.Millisecond
+)
 
 type backendCredentialTarget struct {
 	projectID project.ID
@@ -44,6 +47,28 @@ type credentialFileStamp struct {
 type backendCredentialWatchSet struct {
 	cancel context.CancelFunc
 	done   <-chan struct{}
+}
+
+type backendCredentialWatchTimer interface {
+	C() <-chan time.Time
+	Reset(time.Duration) bool
+	Stop() bool
+}
+
+type standardBackendCredentialWatchTimer struct {
+	timer *time.Timer
+}
+
+func (t *standardBackendCredentialWatchTimer) C() <-chan time.Time {
+	return t.timer.C
+}
+
+func (t *standardBackendCredentialWatchTimer) Reset(delay time.Duration) bool {
+	return t.timer.Reset(delay)
+}
+
+func (t *standardBackendCredentialWatchTimer) Stop() bool {
+	return t.timer.Stop()
 }
 
 func startBackendCredentialWatchers(
@@ -295,19 +320,24 @@ func startBackendCredentialFileWatcherWithRetry(
 				continue
 			}
 
-			if stamp, stampErr := readCredentialFileStamp(path); stampErr == nil {
-				if backendCredentialStampChanged(&lastStamp, stamp) && notify != nil {
-					notify(ctx)
-				}
-			} else if !errors.Is(stampErr, os.ErrNotExist) {
-				logger.Warn("read backend credential file metadata failed", "path", path, "error", stampErr)
-			}
 			if retrying {
 				logger.Info("backend credential file watcher attached", "path", path)
 			}
 			loggedWatchFailure = false
 
-			if !monitorBackendCredentialFile(ctx, path, updates, notify, logger, retryDelay, &lastStamp) {
+			if !monitorBackendCredentialFile(
+				ctx,
+				path,
+				updates,
+				notify,
+				logger,
+				retryDelay,
+				backendCredentialWatchReconcileDelay,
+				&lastStamp,
+				func(delay time.Duration) backendCredentialWatchTimer {
+					return &standardBackendCredentialWatchTimer{timer: time.NewTimer(delay)}
+				},
+			) {
 				return
 			}
 			retrying = true
@@ -327,10 +357,42 @@ func monitorBackendCredentialFile(
 	notify func(context.Context),
 	logger *slog.Logger,
 	pollInterval time.Duration,
+	reconcileDelay time.Duration,
 	lastStamp **credentialFileStamp,
+	newTimer func(time.Duration) backendCredentialWatchTimer,
 ) bool {
+	if reconcileDelay <= 0 {
+		reconcileDelay = backendCredentialWatchReconcileDelay
+	}
+	if newTimer == nil {
+		newTimer = func(delay time.Duration) backendCredentialWatchTimer {
+			return &standardBackendCredentialWatchTimer{timer: time.NewTimer(delay)}
+		}
+	}
 	poll := time.NewTicker(pollInterval)
 	defer poll.Stop()
+	reconcile := newTimer(reconcileDelay)
+	if !reconcile.Stop() {
+		<-reconcile.C()
+	}
+	defer reconcile.Stop()
+	var reconcileC <-chan time.Time
+	scheduleReconcile := func(reset bool) {
+		if reconcileC != nil {
+			if !reset {
+				return
+			}
+			if !reconcile.Stop() {
+				select {
+				case <-reconcile.C():
+				default:
+				}
+			}
+		}
+		reconcile.Reset(reconcileDelay)
+		reconcileC = reconcile.C()
+	}
+	scheduleReconcile(true)
 	for {
 		select {
 		case <-ctx.Done():
@@ -343,15 +405,32 @@ func monitorBackendCredentialFile(
 				logger.Warn("reload backend credential file metadata failed", "path", update.Path, "error", update.Err)
 				continue
 			}
-			if backendCredentialStampChanged(lastStamp, update.Value) && notify != nil {
-				notify(ctx)
-			}
+			scheduleReconcile(true)
 		case <-poll.C:
-			stamp, err := readCredentialFileStamp(path)
-			if err == nil && backendCredentialStampChanged(lastStamp, stamp) && notify != nil {
-				notify(ctx)
-			}
+			scheduleReconcile(false)
+		case <-reconcileC:
+			reconcileC = nil
+			reconcileBackendCredentialStamp(ctx, path, notify, logger, lastStamp)
 		}
+	}
+}
+
+func reconcileBackendCredentialStamp(
+	ctx context.Context,
+	path string,
+	notify func(context.Context),
+	logger *slog.Logger,
+	lastStamp **credentialFileStamp,
+) {
+	stamp, err := readCredentialFileStamp(path)
+	if err != nil {
+		if !errors.Is(err, os.ErrNotExist) {
+			logger.Warn("read backend credential file metadata failed", "path", path, "error", err)
+		}
+		return
+	}
+	if backendCredentialStampChanged(lastStamp, stamp) && notify != nil {
+		notify(ctx)
 	}
 }
 

--- a/internal/cli/backend_credentials_test.go
+++ b/internal/cli/backend_credentials_test.go
@@ -6,6 +6,8 @@ import (
 	"path/filepath"
 	"testing"
 	"time"
+
+	configwatcher "github.com/digitaldrywood/detent/internal/config/watcher"
 )
 
 func TestCodexCredentialPath(t *testing.T) {
@@ -153,5 +155,113 @@ func TestBackendCredentialFileWatcherRetriesMissingDirectory(t *testing.T) {
 	case <-done:
 	case <-time.After(5 * time.Second):
 		t.Fatal("credential watcher did not stop after cancellation")
+	}
+}
+
+func TestBackendCredentialReconciliationCoalescesRetryAttachmentAndFilesystemEvent(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join(t.TempDir(), "auth.json")
+	if err := os.WriteFile(path, []byte("new account"), 0o600); err != nil {
+		t.Fatalf("create credential file: %v", err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	updates := make(chan configwatcher.FileUpdate[credentialFileStamp], 2)
+	notified := make(chan struct{}, 2)
+	timer := newControlledBackendCredentialWatchTimer()
+	done := make(chan bool, 1)
+	var lastStamp *credentialFileStamp
+	go func() {
+		done <- monitorBackendCredentialFile(
+			ctx,
+			path,
+			updates,
+			func(context.Context) { notified <- struct{}{} },
+			nil,
+			time.Hour,
+			time.Hour,
+			&lastStamp,
+			func(time.Duration) backendCredentialWatchTimer { return timer },
+		)
+	}()
+
+	timer.waitForReset(t)
+	updates <- configwatcher.FileUpdate[credentialFileStamp]{
+		Path:  path,
+		Value: credentialFileStamp{size: 1},
+	}
+	timer.waitForReset(t)
+	timer.fire(t)
+
+	select {
+	case <-notified:
+	case <-time.After(time.Second):
+		t.Fatal("credential creation while detached did not trigger notification")
+	}
+
+	updates <- configwatcher.FileUpdate[credentialFileStamp]{
+		Path:  path,
+		Value: credentialFileStamp{size: 2},
+	}
+	timer.waitForReset(t)
+	timer.fire(t)
+	select {
+	case <-notified:
+		t.Fatal("retry attachment and filesystem event triggered duplicate notifications")
+	case <-time.After(25 * time.Millisecond):
+	}
+
+	cancel()
+	select {
+	case monitoring := <-done:
+		if monitoring {
+			t.Fatal("credential monitor requested retry after cancellation")
+		}
+	case <-time.After(time.Second):
+		t.Fatal("credential monitor did not stop after cancellation")
+	}
+}
+
+type controlledBackendCredentialWatchTimer struct {
+	ticks  chan time.Time
+	resets chan time.Duration
+}
+
+func newControlledBackendCredentialWatchTimer() *controlledBackendCredentialWatchTimer {
+	return &controlledBackendCredentialWatchTimer{
+		ticks:  make(chan time.Time, 1),
+		resets: make(chan time.Duration, 4),
+	}
+}
+
+func (t *controlledBackendCredentialWatchTimer) C() <-chan time.Time {
+	return t.ticks
+}
+
+func (t *controlledBackendCredentialWatchTimer) Reset(delay time.Duration) bool {
+	t.resets <- delay
+	return true
+}
+
+func (t *controlledBackendCredentialWatchTimer) Stop() bool {
+	return true
+}
+
+func (t *controlledBackendCredentialWatchTimer) waitForReset(testingT *testing.T) {
+	testingT.Helper()
+	select {
+	case <-t.resets:
+	case <-time.After(time.Second):
+		testingT.Fatal("timed out waiting for credential reconciliation reset")
+	}
+}
+
+func (t *controlledBackendCredentialWatchTimer) fire(testingT *testing.T) {
+	testingT.Helper()
+	select {
+	case t.ticks <- time.Now():
+	case <-time.After(time.Second):
+		testingT.Fatal("timed out firing credential reconciliation timer")
 	}
 }


### PR DESCRIPTION
## Summary

- Coalesce credential watcher attachment, filesystem events, and periodic reconciliation before comparing the settled file stamp.
- Preserve notifications for credentials created while the watcher is detached.
- Add deterministic controlled-timer coverage for missing-directory attachment and duplicate suppression.

Fixes #1979

## UI Surface Contract

- [x] N/A, or the linked issue explicitly authorizes any high-impact UI surface, layout, density, first-viewport, or responsive visibility tradeoff.
- [x] Persistent top-of-screen messaging is explicitly authorized by the issue, or this PR does not add it.
- [x] Visual changes to primary operator screens include screenshot or browser verification below.

## Test Plan

- [x] `go test -race ./internal/cli -run '^(TestBackendCredentialFileWatcherRetriesMissingDirectory|TestBackendCredentialReconciliationCoalescesRetryAttachmentAndFilesystemEvent)$' -count=100`
- [x] `make check`