### PR TITLE
fix(board): exclude completed history from workload

### DIFF
--- a/internal/cli/runner.go
+++ b/internal/cli/runner.go
@@ -630,6 +630,8 @@ func publishSnapshotOnce(
 			lastErrorAt := now
 			merged = mergeSnapshot(merged, telemetry.Snapshot{
 				Project:      projectMetadata,
+				Tracker:      unknownSnapshotSection(),
+				Runtime:      unknownSnapshotSection(),
 				DashboardURL: cleanDashboardURL(dashboardURL),
 				Shutdown:     telemetry.Shutdown{Status: "running"},
 				Refresh: telemetry.Refresh{

--- a/internal/cli/runner_test.go
+++ b/internal/cli/runner_test.go
@@ -708,6 +708,33 @@ func TestPublishSnapshotOnceAssignsMonotonicSeq(t *testing.T) {
 	}
 }
 
+func TestPublishSnapshotOnceMarksStateFailureSectionsUnknown(t *testing.T) {
+	t.Parallel()
+
+	registry := projectpkg.NewRegistry()
+	mustSetProject(t, registry, startRefreshProject(t, "alpha"))
+
+	snapshotHub := hub.New[telemetry.Snapshot]()
+	var seq atomic.Uint64
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	if err := publishSnapshotOnce(ctx, registry, nil, snapshotHub, &seq, nil, time.Now(), nil, nil, "", nil); err != nil {
+		t.Fatalf("publishSnapshotOnce() error = %v", err)
+	}
+
+	snapshot, ok := snapshotHub.Latest()
+	if !ok || len(snapshot.Projects) != 1 {
+		t.Fatalf("snapshot = %#v, want one degraded project", snapshot)
+	}
+	projectSnapshot := snapshot.Projects[0]
+	if projectSnapshot.Tracker.Source != telemetry.SnapshotSourceUnknown || projectSnapshot.Runtime.Source != telemetry.SnapshotSourceUnknown {
+		t.Fatalf("project sections = tracker %#v runtime %#v, want unknown", projectSnapshot.Tracker, projectSnapshot.Runtime)
+	}
+	if telemetry.BoardWorkloadCompleteForProject(snapshot, "alpha") {
+		t.Fatal("BoardWorkloadCompleteForProject() = true, want false")
+	}
+}
+
 func TestPublishSnapshotOnceUsesLastKnownTrackerStateUntilHydration(t *testing.T) {
 	t.Parallel()
 

--- a/internal/orchestrator/status_reconciliation_test.go
+++ b/internal/orchestrator/status_reconciliation_test.go
@@ -23,6 +23,7 @@ func TestReconcileClosedCompletedIssueStatusesMovesNonTerminalStatesToDone(t *te
 			state := newState(orch.cfg)
 			now := time.Date(2026, 6, 8, 12, 0, 0, 0, time.UTC)
 			issue := statusReconcileIssue("issue-"+strings.ToLower(strings.ReplaceAll(stateName, " ", "-")), stateName, true, "completed")
+			state.Completed[issue.ID] = Completed{Issue: cloneIssue(issue), FinalState: FinalStateCompleted}
 
 			reconciled := orch.reconcileClosedCompletedIssueStatuses(context.Background(), &state, []connector.Issue{issue}, now)
 
@@ -31,6 +32,9 @@ func TestReconcileClosedCompletedIssueStatusesMovesNonTerminalStatesToDone(t *te
 			}
 			if _, ok := reconciled[issue.ID]; !ok {
 				t.Fatalf("reconciled[%q] missing", issue.ID)
+			}
+			if got := state.Completed[issue.ID]; got.Issue.State != "Done" || got.FinalState != FinalStateCompleted {
+				t.Fatalf("Completed[%q] state = (%q, %q), want Done/%s", issue.ID, got.Issue.State, got.FinalState, FinalStateCompleted)
 			}
 			if len(state.RecentEvents) != 1 {
 				t.Fatalf("RecentEvents len = %d, want 1", len(state.RecentEvents))

--- a/internal/orchestrator/workflow_metrics.go
+++ b/internal/orchestrator/workflow_metrics.go
@@ -243,6 +243,10 @@ func updateIssueStateSnapshots(state *State, issueID string, issue connector.Iss
 			updated,
 		)
 	}
+	if completed, ok := state.Completed[issueID]; ok {
+		completed.Issue = mergeIssueTrackerFields(completed.Issue, transitioned)
+		state.Completed[issueID] = completed
+	}
 }
 
 func applyIssueStateSnapshot(issue *connector.Issue, targetState string, at time.Time) {

--- a/internal/telemetry/workload.go
+++ b/internal/telemetry/workload.go
@@ -153,7 +153,9 @@ func boardWorkloadSections(snapshot Snapshot, projectID string) (SnapshotSection
 	if projectID != "" {
 		for _, project := range snapshot.Projects {
 			if strings.TrimSpace(project.Project.ID) == projectID {
-				return project.Tracker, project.Runtime, !project.Tracker.IsZero() || !project.Runtime.IsZero()
+				projectDeclared := !project.Tracker.IsZero() || !project.Runtime.IsZero()
+				fleetDeclared := !snapshot.Tracker.IsZero() || !snapshot.Runtime.IsZero()
+				return project.Tracker, project.Runtime, projectDeclared || fleetDeclared
 			}
 		}
 	}

--- a/internal/telemetry/workload.go
+++ b/internal/telemetry/workload.go
@@ -14,11 +14,28 @@ type BoardWorkloadCounts struct {
 }
 
 func BoardWorkload(snapshot Snapshot) BoardWorkloadCounts {
-	return boardWorkload(snapshot, "")
+	return boardWorkload(snapshot, "", !boardWorkloadUsesCompleteProjection(snapshot, ""))
 }
 
 func BoardWorkloadForProject(snapshot Snapshot, projectID string) BoardWorkloadCounts {
-	return boardWorkload(snapshot, strings.TrimSpace(projectID))
+	projectID = strings.TrimSpace(projectID)
+	return boardWorkload(snapshot, projectID, !boardWorkloadUsesCompleteProjection(snapshot, projectID))
+}
+
+func CurrentBoardWorkload(snapshot Snapshot) BoardWorkloadCounts {
+	return boardWorkload(snapshot, "", false)
+}
+
+func CurrentBoardWorkloadForProject(snapshot Snapshot, projectID string) BoardWorkloadCounts {
+	return boardWorkload(snapshot, strings.TrimSpace(projectID), false)
+}
+
+func BoardWorkloadComplete(snapshot Snapshot) bool {
+	return boardWorkloadComplete(snapshot, "")
+}
+
+func BoardWorkloadCompleteForProject(snapshot Snapshot, projectID string) bool {
+	return boardWorkloadComplete(snapshot, strings.TrimSpace(projectID))
 }
 
 type boardWorkloadIssue struct {
@@ -27,7 +44,7 @@ type boardWorkloadIssue struct {
 	rank    int
 }
 
-func boardWorkload(snapshot Snapshot, projectID string) BoardWorkloadCounts {
+func boardWorkload(snapshot Snapshot, projectID string, includeCompleted bool) BoardWorkloadCounts {
 	issues := map[string]boardWorkloadIssue{}
 	sequence := 0
 	add := func(issue Issue, fallback string, rank int, waiting bool) {
@@ -60,8 +77,10 @@ func boardWorkload(snapshot Snapshot, projectID string) BoardWorkloadCounts {
 		}
 	}
 
-	for _, row := range snapshot.Completed {
-		add(row.Issue, normalizedWorkloadState(row.FinalState), 5, false)
+	if includeCompleted {
+		for _, row := range snapshot.Completed {
+			add(row.Issue, normalizedWorkloadState(row.FinalState), 5, false)
+		}
 	}
 	for _, row := range snapshot.Queue {
 		add(row.Issue, "Todo", 10, false)
@@ -115,6 +134,30 @@ func boardWorkload(snapshot Snapshot, projectID string) BoardWorkloadCounts {
 		}
 	}
 	return counts
+}
+
+func boardWorkloadComplete(snapshot Snapshot, projectID string) bool {
+	tracker, runtime, declared := boardWorkloadSections(snapshot, projectID)
+	if !declared {
+		return true
+	}
+	return tracker.Available() && tracker.Complete && runtime.Available() && runtime.Complete
+}
+
+func boardWorkloadUsesCompleteProjection(snapshot Snapshot, projectID string) bool {
+	_, _, declared := boardWorkloadSections(snapshot, projectID)
+	return declared && boardWorkloadComplete(snapshot, projectID)
+}
+
+func boardWorkloadSections(snapshot Snapshot, projectID string) (SnapshotSection, SnapshotSection, bool) {
+	if projectID != "" {
+		for _, project := range snapshot.Projects {
+			if strings.TrimSpace(project.Project.ID) == projectID {
+				return project.Tracker, project.Runtime, !project.Tracker.IsZero() || !project.Runtime.IsZero()
+			}
+		}
+	}
+	return snapshot.Tracker, snapshot.Runtime, !snapshot.Tracker.IsZero() || !snapshot.Runtime.IsZero()
 }
 
 func boardWorkloadProjectMatches(issue Issue, fallbackProjectID string, projectID string) bool {

--- a/internal/telemetry/workload_test.go
+++ b/internal/telemetry/workload_test.go
@@ -216,6 +216,15 @@ func TestBoardWorkloadComplete(t *testing.T) {
 			projectID: "detent",
 			want:      true,
 		},
+		{
+			name: "missing project sections in declared fleet are incomplete",
+			snapshot: Snapshot{
+				Tracker:  SnapshotSection{Source: SnapshotSourceLive, Complete: true},
+				Runtime:  SnapshotSection{Source: SnapshotSourceLive, Complete: true},
+				Projects: []ProjectSnapshot{{Project: Project{ID: "detent"}}},
+			},
+			projectID: "detent",
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/telemetry/workload_test.go
+++ b/internal/telemetry/workload_test.go
@@ -112,6 +112,30 @@ func TestBoardWorkload(t *testing.T) {
 			want: BoardWorkloadCounts{Load: 1, Active: 1},
 		},
 		{
+			name: "complete current projection excludes completed-only workload states",
+			snapshot: Snapshot{
+				Tracker: SnapshotSection{Source: SnapshotSourceLive, Complete: true},
+				Runtime: SnapshotSection{Source: SnapshotSourceLive, Complete: true},
+				Completed: []Completed{
+					{Issue: Issue{ID: "blocked", State: "Blocked"}, FinalState: "completed"},
+					{Issue: Issue{ID: "review", State: "Human Review"}, FinalState: "completed"},
+				},
+			},
+			want: BoardWorkloadCounts{},
+		},
+		{
+			name: "incomplete tracker retains completed-only workload lower bounds",
+			snapshot: Snapshot{
+				Tracker: SnapshotSection{Source: SnapshotSourceMixed},
+				Runtime: SnapshotSection{Source: SnapshotSourceLive, Complete: true},
+				Completed: []Completed{
+					{Issue: Issue{ID: "blocked", State: "Blocked"}, FinalState: "completed"},
+					{Issue: Issue{ID: "review", State: "Human Review"}, FinalState: "completed"},
+				},
+			},
+			want: BoardWorkloadCounts{Load: 1, Active: 1, Blocked: 1},
+		},
+		{
 			name: "review lane aliases count as active",
 			snapshot: Snapshot{BoardIssues: []Issue{
 				{ID: "review", State: "Review"},
@@ -141,6 +165,106 @@ func TestBoardWorkload(t *testing.T) {
 			}
 			if got != tt.want {
 				t.Fatalf("BoardWorkload() = %+v, want %+v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestBoardWorkloadComplete(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		snapshot  Snapshot
+		projectID string
+		want      bool
+	}{
+		{name: "legacy snapshot", want: true},
+		{
+			name: "complete fleet projection",
+			snapshot: Snapshot{
+				Tracker: SnapshotSection{Source: SnapshotSourceLive, Complete: true},
+				Runtime: SnapshotSection{Source: SnapshotSourceLive, Complete: true},
+			},
+			want: true,
+		},
+		{
+			name: "incomplete tracker",
+			snapshot: Snapshot{
+				Tracker: SnapshotSection{Source: SnapshotSourceMixed},
+				Runtime: SnapshotSection{Source: SnapshotSourceLive, Complete: true},
+			},
+		},
+		{
+			name: "unknown runtime",
+			snapshot: Snapshot{
+				Tracker: SnapshotSection{Source: SnapshotSourceCached, Complete: true},
+				Runtime: SnapshotSection{Source: SnapshotSourceUnknown},
+			},
+		},
+		{
+			name: "project sections override incomplete fleet summary",
+			snapshot: Snapshot{
+				Tracker: SnapshotSection{Source: SnapshotSourceMixed},
+				Runtime: SnapshotSection{Source: SnapshotSourceMixed},
+				Projects: []ProjectSnapshot{{
+					Project: Project{ID: "detent"},
+					Tracker: SnapshotSection{Source: SnapshotSourceLive, Complete: true},
+					Runtime: SnapshotSection{Source: SnapshotSourceLive, Complete: true},
+				}},
+			},
+			projectID: "detent",
+			want:      true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := BoardWorkloadComplete(tt.snapshot)
+			if tt.projectID != "" {
+				got = BoardWorkloadCompleteForProject(tt.snapshot, tt.projectID)
+			}
+			if got != tt.want {
+				t.Fatalf("BoardWorkloadComplete() = %t, want %t", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestCurrentBoardWorkloadExcludesCompletedHistory(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		snapshot Snapshot
+		want     BoardWorkloadCounts
+	}{
+		{
+			name: "completed-only states are not current",
+			snapshot: Snapshot{Completed: []Completed{
+				{Issue: Issue{ID: "blocked", State: "Blocked"}, FinalState: "completed"},
+				{Issue: Issue{ID: "review", State: "Human Review"}, FinalState: "completed"},
+			}},
+		},
+		{
+			name: "current rows remain visible",
+			snapshot: Snapshot{
+				BoardIssues: []Issue{{ID: "blocked", State: "Blocked"}, {ID: "review", State: "Human Review"}},
+				Completed: []Completed{
+					{Issue: Issue{ID: "blocked", State: "Blocked"}, FinalState: "completed"},
+					{Issue: Issue{ID: "review", State: "Human Review"}, FinalState: "completed"},
+				},
+			},
+			want: BoardWorkloadCounts{Load: 1, Active: 1, Blocked: 1},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := CurrentBoardWorkload(tt.snapshot); got != tt.want {
+				t.Fatalf("CurrentBoardWorkload() = %+v, want %+v", got, tt.want)
 			}
 		})
 	}

--- a/internal/tmuxstatus/status.go
+++ b/internal/tmuxstatus/status.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log/slog"
 	"os/exec"
+	"strconv"
 	"strings"
 	"sync"
 
@@ -74,14 +75,31 @@ func newStatus(ctx context.Context, runner commandRunner, pane string, logger *s
 }
 
 type Counts struct {
-	Running int
-	Ready   int
-	Waiting int
-	Blocked int
+	Running    int
+	Ready      int
+	Waiting    int
+	Blocked    int
+	Incomplete bool
 }
 
 func Format(counts Counts) string {
-	return fmt.Sprintf("detent %dr/%dq/%dw/%db", counts.Running, counts.Ready, counts.Waiting, counts.Blocked)
+	return fmt.Sprintf(
+		"detent %dr/%sq/%sw/%sb",
+		counts.Running,
+		workloadCountLabel(counts.Ready, counts.Incomplete),
+		workloadCountLabel(counts.Waiting, counts.Incomplete),
+		workloadCountLabel(counts.Blocked, counts.Incomplete),
+	)
+}
+
+func workloadCountLabel(count int, incomplete bool) string {
+	if !incomplete {
+		return strconv.Itoa(count)
+	}
+	if count == 0 {
+		return "?"
+	}
+	return strconv.Itoa(count) + "+"
 }
 
 func (s *Status) Update(ctx context.Context, snapshot telemetry.Snapshot) error {
@@ -89,12 +107,13 @@ func (s *Status) Update(ctx context.Context, snapshot telemetry.Snapshot) error 
 		return nil
 	}
 	effective := snapshot.EffectiveCounts()
-	workload := telemetry.BoardWorkload(snapshot)
+	workload := telemetry.CurrentBoardWorkload(snapshot)
 	name := Format(Counts{
-		Running: effective.Running,
-		Ready:   workload.Todo,
-		Waiting: workload.Waiting,
-		Blocked: workload.Blocked,
+		Running:    effective.Running,
+		Ready:      workload.Todo,
+		Waiting:    workload.Waiting,
+		Blocked:    workload.Blocked,
+		Incomplete: !telemetry.BoardWorkloadComplete(snapshot),
 	})
 	if name == s.lastName {
 		currentName, err := s.runner.Output(ctx, "display-message", "-t", s.target, "-p", "#{window_name}")

--- a/internal/tmuxstatus/status_test.go
+++ b/internal/tmuxstatus/status_test.go
@@ -54,6 +54,8 @@ func TestFormat(t *testing.T) {
 		{name: "idle", want: "detent 0r/0q/0w/0b"},
 		{name: "active", counts: Counts{Running: 2, Ready: 1, Waiting: 4, Blocked: 3}, want: "detent 2r/1q/4w/3b"},
 		{name: "large counts stay compact", counts: Counts{Running: 120, Ready: 45, Waiting: 18, Blocked: 8}, want: "detent 120r/45q/18w/8b"},
+		{name: "incomplete zeros are unknown", counts: Counts{Running: 2, Incomplete: true}, want: "detent 2r/?q/?w/?b"},
+		{name: "incomplete counts are lower bounds", counts: Counts{Running: 2, Ready: 3, Blocked: 1, Incomplete: true}, want: "detent 2r/3+q/?w/1+b"},
 	}
 
 	for _, test := range tests {

--- a/internal/web/api.go
+++ b/internal/web/api.go
@@ -613,13 +613,14 @@ func issueResponse(reference string, projectID string, snapshot telemetry.Snapsh
 }
 
 func countsResponse(snapshot telemetry.Snapshot) countsAPIResponse {
-	workload := telemetry.BoardWorkload(snapshot)
+	workload := telemetry.CurrentBoardWorkload(snapshot)
 	return countsAPIResponse{
 		Running:  len(snapshot.Running),
 		Retrying: len(snapshot.Queue),
 		Ready:    workload.Todo,
 		Waiting:  workload.Waiting,
 		Blocked:  workload.Blocked,
+		Complete: telemetry.BoardWorkloadComplete(snapshot),
 	}
 }
 
@@ -1481,11 +1482,12 @@ type boardAPIResponse struct {
 }
 
 type countsAPIResponse struct {
-	Running  int `json:"running"`
-	Retrying int `json:"retrying"`
-	Ready    int `json:"ready"`
-	Waiting  int `json:"waiting"`
-	Blocked  int `json:"blocked"`
+	Running  int  `json:"running"`
+	Retrying int  `json:"retrying"`
+	Ready    int  `json:"ready"`
+	Waiting  int  `json:"waiting"`
+	Blocked  int  `json:"blocked"`
+	Complete bool `json:"complete"`
 }
 
 type runningAPIResponse struct {

--- a/internal/web/projects.go
+++ b/internal/web/projects.go
@@ -73,39 +73,45 @@ func projectSmallMultiplesFromSnapshot(snapshot telemetry.Snapshot) []templates.
 	if len(snapshot.Projects) > 0 {
 		projects := make([]templates.ProjectSmallMultiple, 0, len(snapshot.Projects))
 		for _, project := range snapshot.Projects {
-			projects = append(projects, projectSmallMultipleFromSnapshot(project, telemetry.BoardWorkloadForProject(snapshot, projectID(project.Project))))
+			id := projectID(project.Project)
+			projects = append(projects, projectSmallMultipleFromSnapshot(
+				project,
+				telemetry.CurrentBoardWorkloadForProject(snapshot, id),
+				telemetry.BoardWorkloadCompleteForProject(snapshot, id),
+			))
 		}
 		return projects
 	}
 	if snapshot.Project == (telemetry.Project{}) {
 		return nil
 	}
-	workload := telemetry.BoardWorkload(snapshot)
+	workload := telemetry.CurrentBoardWorkload(snapshot)
 	return []templates.ProjectSmallMultiple{
 		{
-			ID:           projectID(snapshot.Project),
-			Name:         strings.TrimSpace(snapshot.Project.DisplayName),
-			URL:          strings.TrimSpace(snapshot.Project.URL),
-			Color:        snapshotProjectColor(snapshot.Project.Color),
-			Pool:         strings.TrimSpace(snapshot.Project.Pool),
-			ActiveHours:  snapshot.Project.ActiveHours,
-			Dispatch:     snapshot.Dispatch,
-			Refresh:      snapshot.Refresh,
-			Running:      snapshot.Counts.Running,
-			QueueCount:   snapshot.Counts.Queue,
-			Blocked:      snapshot.Counts.Blocked,
-			BoardLoad:    workload.Load,
-			BoardTodo:    workload.Todo,
-			BoardActive:  workload.Active,
-			BoardWaiting: workload.Waiting,
-			BoardBlocked: workload.Blocked,
-			Completed:    snapshot.Counts.Completed,
-			TotalTokens:  snapshot.Tokens.Total,
+			ID:                      projectID(snapshot.Project),
+			Name:                    strings.TrimSpace(snapshot.Project.DisplayName),
+			URL:                     strings.TrimSpace(snapshot.Project.URL),
+			Color:                   snapshotProjectColor(snapshot.Project.Color),
+			Pool:                    strings.TrimSpace(snapshot.Project.Pool),
+			ActiveHours:             snapshot.Project.ActiveHours,
+			Dispatch:                snapshot.Dispatch,
+			Refresh:                 snapshot.Refresh,
+			Running:                 snapshot.Counts.Running,
+			QueueCount:              snapshot.Counts.Queue,
+			Blocked:                 snapshot.Counts.Blocked,
+			BoardLoad:               workload.Load,
+			BoardTodo:               workload.Todo,
+			BoardActive:             workload.Active,
+			BoardWaiting:            workload.Waiting,
+			BoardBlocked:            workload.Blocked,
+			BoardWorkloadIncomplete: !telemetry.BoardWorkloadComplete(snapshot),
+			Completed:               snapshot.Counts.Completed,
+			TotalTokens:             snapshot.Tokens.Total,
 		},
 	}
 }
 
-func projectSmallMultipleFromSnapshot(project telemetry.ProjectSnapshot, workload telemetry.BoardWorkloadCounts) templates.ProjectSmallMultiple {
+func projectSmallMultipleFromSnapshot(project telemetry.ProjectSnapshot, workload telemetry.BoardWorkloadCounts, workloadComplete bool) templates.ProjectSmallMultiple {
 	return templates.ProjectSmallMultiple{
 		ID:                        projectID(project.Project),
 		Name:                      strings.TrimSpace(project.Project.DisplayName),
@@ -123,6 +129,7 @@ func projectSmallMultipleFromSnapshot(project telemetry.ProjectSnapshot, workloa
 		BoardActive:               workload.Active,
 		BoardWaiting:              workload.Waiting,
 		BoardBlocked:              workload.Blocked,
+		BoardWorkloadIncomplete:   !workloadComplete,
 		Completed:                 project.Counts.Completed,
 		TotalTokens:               project.Tokens.Total,
 		ThroughputTokensPerSecond: project.Throughput.TokensPerSecond,

--- a/internal/web/projects_test.go
+++ b/internal/web/projects_test.go
@@ -72,6 +72,73 @@ func TestProjectSmallMultiplesUseBoardWorkloadTaxonomy(t *testing.T) {
 	}
 }
 
+func TestCountsResponseMarksWorkloadCompleteness(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		snapshot telemetry.Snapshot
+		want     countsAPIResponse
+	}{
+		{
+			name: "complete projection excludes completed history",
+			snapshot: telemetry.Snapshot{
+				Tracker: telemetry.SnapshotSection{Source: telemetry.SnapshotSourceLive, Complete: true},
+				Runtime: telemetry.SnapshotSection{Source: telemetry.SnapshotSourceLive, Complete: true},
+				Completed: []telemetry.Completed{{
+					Issue:      telemetry.Issue{ID: "blocked", State: "Blocked"},
+					FinalState: "completed",
+				}},
+			},
+			want: countsAPIResponse{Complete: true},
+		},
+		{
+			name: "incomplete projection excludes unsupported history",
+			snapshot: telemetry.Snapshot{
+				Tracker: telemetry.SnapshotSection{Source: telemetry.SnapshotSourceMixed},
+				Runtime: telemetry.SnapshotSection{Source: telemetry.SnapshotSourceLive, Complete: true},
+				Completed: []telemetry.Completed{{
+					Issue:      telemetry.Issue{ID: "blocked", State: "Blocked"},
+					FinalState: "completed",
+				}},
+			},
+			want: countsAPIResponse{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := countsResponse(tt.snapshot); got != tt.want {
+				t.Fatalf("countsResponse() = %#v, want %#v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestProjectSmallMultiplesMarkCompletedOnlyIncompleteWorkloadUnknown(t *testing.T) {
+	t.Parallel()
+
+	snapshot := telemetry.Snapshot{
+		Projects: []telemetry.ProjectSnapshot{{
+			Project: telemetry.Project{ID: "detent"},
+			Tracker: telemetry.SnapshotSection{Source: telemetry.SnapshotSourceMixed},
+			Runtime: telemetry.SnapshotSection{Source: telemetry.SnapshotSourceLive, Complete: true},
+		}},
+		Completed: []telemetry.Completed{{
+			Issue: telemetry.Issue{ID: "review", ProjectID: "detent", State: "Human Review"},
+		}},
+	}
+
+	projects := projectSmallMultiplesFromSnapshot(snapshot)
+	if len(projects) != 1 {
+		t.Fatalf("projectSmallMultiplesFromSnapshot() len = %d, want 1", len(projects))
+	}
+	if projects[0].BoardLoad != 0 || !projects[0].BoardWorkloadIncomplete {
+		t.Fatalf("project workload = load %d incomplete %t, want 0/true", projects[0].BoardLoad, projects[0].BoardWorkloadIncomplete)
+	}
+}
+
 func TestApplyProjectBudgetSnapshot(t *testing.T) {
 	t.Parallel()
 

--- a/internal/web/templates/board_data.go
+++ b/internal/web/templates/board_data.go
@@ -1073,14 +1073,24 @@ func boardVisibilityKey(data DashboardData) string {
 }
 
 func boardFigures(snapshot telemetry.Snapshot) []primitives.Figure {
-	workload := telemetry.BoardWorkload(snapshot)
+	workload := telemetry.CurrentBoardWorkload(snapshot)
 	return []primitives.Figure{
 		{ID: "fig-running", Value: runningCountLabel(snapshot), Label: "running"},
-		{ID: "fig-ready", Value: formatCount(workload.Todo), Label: "ready"},
-		{ID: "fig-waiting", Value: formatCount(workload.Waiting), Label: "waiting"},
-		{ID: "fig-blocked", Value: formatCount(workload.Blocked), Label: "blocked", Err: workload.Blocked > 0},
+		{ID: "fig-ready", Value: boardWorkloadCountLabel(snapshot, workload.Todo), Label: "ready"},
+		{ID: "fig-waiting", Value: boardWorkloadCountLabel(snapshot, workload.Waiting), Label: "waiting"},
+		{ID: "fig-blocked", Value: boardWorkloadCountLabel(snapshot, workload.Blocked), Label: "blocked", Err: workload.Blocked > 0},
 		{ID: "fig-completed", Value: formatCount(completedCount(snapshot)), Label: "completed"},
 	}
+}
+
+func boardWorkloadCountLabel(snapshot telemetry.Snapshot, count int) string {
+	if telemetry.BoardWorkloadComplete(snapshot) {
+		return formatCount(count)
+	}
+	if count == 0 {
+		return "unknown"
+	}
+	return formatCount(count) + "+"
 }
 
 func boardFiguresFromDashboard(data DashboardData) []primitives.Figure {

--- a/internal/web/templates/board_data_test.go
+++ b/internal/web/templates/board_data_test.go
@@ -1528,6 +1528,77 @@ func TestBoardFiguresSeparateWaitingFromBlockedLane(t *testing.T) {
 	}
 }
 
+func TestBoardFiguresExposeIncompleteWorkloadProjection(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		snapshot    telemetry.Snapshot
+		wantReady   string
+		wantWaiting string
+		wantBlocked string
+	}{
+		{
+			name: "complete projection ignores completed-only rows",
+			snapshot: telemetry.Snapshot{
+				Tracker: telemetry.SnapshotSection{Source: telemetry.SnapshotSourceLive, Complete: true},
+				Runtime: telemetry.SnapshotSection{Source: telemetry.SnapshotSourceLive, Complete: true},
+				Completed: []telemetry.Completed{
+					{Issue: telemetry.Issue{ID: "blocked", State: "Blocked"}, FinalState: "completed"},
+					{Issue: telemetry.Issue{ID: "review", State: "Human Review"}, FinalState: "completed"},
+				},
+			},
+			wantReady:   "0",
+			wantWaiting: "0",
+			wantBlocked: "0",
+		},
+		{
+			name: "incomplete projection reports lower bound and unknown zeros",
+			snapshot: telemetry.Snapshot{
+				Tracker: telemetry.SnapshotSection{Source: telemetry.SnapshotSourceMixed},
+				Runtime: telemetry.SnapshotSection{Source: telemetry.SnapshotSourceLive, Complete: true},
+				Completed: []telemetry.Completed{
+					{Issue: telemetry.Issue{ID: "blocked", State: "Blocked"}, FinalState: "completed"},
+					{Issue: telemetry.Issue{ID: "review", State: "Human Review"}, FinalState: "completed"},
+				},
+			},
+			wantReady:   "unknown",
+			wantWaiting: "unknown",
+			wantBlocked: "unknown",
+		},
+		{
+			name: "incomplete projection reports current rows as lower bounds",
+			snapshot: telemetry.Snapshot{
+				Tracker:     telemetry.SnapshotSection{Source: telemetry.SnapshotSourceMixed},
+				Runtime:     telemetry.SnapshotSection{Source: telemetry.SnapshotSourceLive, Complete: true},
+				BoardIssues: []telemetry.Issue{{ID: "blocked", State: "Blocked"}},
+			},
+			wantReady:   "unknown",
+			wantWaiting: "unknown",
+			wantBlocked: "1+",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			byID := map[string]primitives.Figure{}
+			for _, figure := range boardFigures(tt.snapshot) {
+				byID[figure.ID] = figure
+			}
+			if got := byID["fig-ready"].Value; got != tt.wantReady {
+				t.Fatalf("ready figure = %q, want %q", got, tt.wantReady)
+			}
+			if got := byID["fig-waiting"].Value; got != tt.wantWaiting {
+				t.Fatalf("waiting figure = %q, want %q", got, tt.wantWaiting)
+			}
+			if got := byID["fig-blocked"].Value; got != tt.wantBlocked {
+				t.Fatalf("blocked figure = %q, want %q", got, tt.wantBlocked)
+			}
+		})
+	}
+}
+
 func TestBoardExceptionsRequireOptIn(t *testing.T) {
 	data := boardTestData()
 	if got := boardExceptions(data, true); len(got) != 0 {

--- a/internal/web/templates/dashboard_data.go
+++ b/internal/web/templates/dashboard_data.go
@@ -420,6 +420,7 @@ type ProjectSmallMultiple struct {
 	BoardActive               int
 	BoardWaiting              int
 	BoardBlocked              int
+	BoardWorkloadIncomplete   bool
 	Completed                 int
 	TotalTokens               int64
 	ThroughputTokensPerSecond float64
@@ -1324,8 +1325,8 @@ func sidebarProjectItems(data DashboardShellData) []sidebarProjectItem {
 			DotClass:     status.DotClass,
 			ProjectColor: projectColorForProject(project),
 			BadgeClass:   status.BadgeClass,
-			CountLabel:   formatCount(project.BoardLoad),
-			RunningLabel: formatCount(project.BoardLoad) + " board load",
+			CountLabel:   projectBoardWorkloadCountLabel(project),
+			RunningLabel: projectBoardWorkloadCountLabel(project) + " board load",
 			Breakdown:    projectWorkloadBreakdown(project),
 			DefaultIndex: len(items),
 			Active:       active,
@@ -1333,6 +1334,16 @@ func sidebarProjectItems(data DashboardShellData) []sidebarProjectItem {
 		})
 	}
 	return items
+}
+
+func projectBoardWorkloadCountLabel(project ProjectSmallMultiple) string {
+	if !project.BoardWorkloadIncomplete {
+		return formatCount(project.BoardLoad)
+	}
+	if project.BoardLoad == 0 {
+		return "unknown"
+	}
+	return formatCount(project.BoardLoad) + "+"
 }
 
 type projectStatusView struct {

--- a/internal/web/templates/dashboard_data.go
+++ b/internal/web/templates/dashboard_data.go
@@ -1410,10 +1410,10 @@ func sidebarProjectBadgeLabel(item sidebarProjectItem) string {
 
 func projectWorkloadBreakdown(project ProjectSmallMultiple) string {
 	return strings.Join([]string{
-		formatCount(project.BoardTodo) + " ready",
-		formatCount(project.BoardActive) + " active",
-		formatCount(project.BoardWaiting) + " waiting",
-		formatCount(project.BoardBlocked) + " blocked",
+		workloadCountLabel(project.BoardTodo, project.BoardWorkloadIncomplete) + " ready",
+		workloadCountLabel(project.BoardActive, project.BoardWorkloadIncomplete) + " active",
+		workloadCountLabel(project.BoardWaiting, project.BoardWorkloadIncomplete) + " waiting",
+		workloadCountLabel(project.BoardBlocked, project.BoardWorkloadIncomplete) + " blocked",
 	}, " · ")
 }
 

--- a/internal/web/templates/dashboard_data_test.go
+++ b/internal/web/templates/dashboard_data_test.go
@@ -23,6 +23,39 @@ func TestWorkAttemptStatusClassTreatsDeliveredAsSuccessful(t *testing.T) {
 	}
 }
 
+func TestProjectWorkloadBreakdownMarksIncompleteCounts(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		project ProjectSmallMultiple
+		want    string
+	}{
+		{
+			name:    "complete counts are exact",
+			project: ProjectSmallMultiple{BoardTodo: 1, BoardActive: 2},
+			want:    "1 ready · 2 active · 0 waiting · 0 blocked",
+		},
+		{
+			name: "incomplete counts are lower bounds or unknown",
+			project: ProjectSmallMultiple{
+				BoardActive:             2,
+				BoardWorkloadIncomplete: true,
+			},
+			want: "unknown ready · 2+ active · unknown waiting · unknown blocked",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := projectWorkloadBreakdown(tt.project); got != tt.want {
+				t.Fatalf("projectWorkloadBreakdown() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestDiagnosticsConditionRowsPreserveEveryConditionClass(t *testing.T) {
 	t.Parallel()
 	now := time.Date(2026, 8, 22, 12, 0, 0, 0, time.UTC)

--- a/internal/web/templates/shell_data.go
+++ b/internal/web/templates/shell_data.go
@@ -243,6 +243,8 @@ func appShellProjects(data DashboardShellData) []appShellProject {
 		item.Initials = appProjectInitials(item.Name, item.ID)
 		if project.Paused {
 			item.Count = "paused"
+		} else if project.BoardWorkloadIncomplete {
+			item.Count = projectBoardWorkloadCountLabel(project)
 		} else if project.BoardLoad > 0 || project.BoardBlocked > 0 {
 			item.Count = strconv.Itoa(project.BoardLoad)
 		}

--- a/internal/web/templates/shell_data.go
+++ b/internal/web/templates/shell_data.go
@@ -209,6 +209,7 @@ type appShellProject struct {
 	Active                     int
 	Waiting                    int
 	Blocked                    int
+	BoardWorkloadIncomplete    bool
 	Paused                     bool
 	Selected                   bool
 	ActiveHoursVisible         bool
@@ -227,16 +228,17 @@ func appShellProjects(data DashboardShellData) []appShellProject {
 			continue
 		}
 		item := appShellProject{
-			ID:       id,
-			Name:     projectSmallMultipleName(project),
-			Href:     projectOpenPath(id),
-			Live:     project.Running > 0,
-			Todo:     project.BoardTodo,
-			Active:   project.BoardActive,
-			Waiting:  project.BoardWaiting,
-			Blocked:  project.BoardBlocked,
-			Paused:   project.Paused,
-			Selected: strings.TrimSpace(data.ProjectID) == id,
+			ID:                      id,
+			Name:                    projectSmallMultipleName(project),
+			Href:                    projectOpenPath(id),
+			Live:                    project.Running > 0,
+			Todo:                    project.BoardTodo,
+			Active:                  project.BoardActive,
+			Waiting:                 project.BoardWaiting,
+			Blocked:                 project.BoardBlocked,
+			BoardWorkloadIncomplete: project.BoardWorkloadIncomplete,
+			Paused:                  project.Paused,
+			Selected:                strings.TrimSpace(data.ProjectID) == id,
 		}
 		item.ActiveHoursVisible, item.ActiveHoursCozyLabel, item.ActiveHoursCompactLabel, item.ActiveHoursHelpDescription = appProjectActiveHoursIndicator(project)
 		item.ActiveHoursVisible = item.ActiveHoursVisible && !item.Paused
@@ -374,11 +376,21 @@ func appProjectDotKind(project appShellProject) primitives.Kind {
 
 func appProjectBreakdown(project appShellProject) string {
 	return strings.Join([]string{
-		strconv.Itoa(project.Todo) + " ready",
-		strconv.Itoa(project.Active) + " active",
-		strconv.Itoa(project.Waiting) + " waiting",
-		strconv.Itoa(project.Blocked) + " blocked",
+		workloadCountLabel(project.Todo, project.BoardWorkloadIncomplete) + " ready",
+		workloadCountLabel(project.Active, project.BoardWorkloadIncomplete) + " active",
+		workloadCountLabel(project.Waiting, project.BoardWorkloadIncomplete) + " waiting",
+		workloadCountLabel(project.Blocked, project.BoardWorkloadIncomplete) + " blocked",
 	}, " · ")
+}
+
+func workloadCountLabel(value int, incomplete bool) string {
+	if !incomplete {
+		return strconv.Itoa(value)
+	}
+	if value == 0 {
+		return "unknown"
+	}
+	return strconv.Itoa(value) + "+"
 }
 
 func appProjectStatus(project appShellProject) string {

--- a/internal/web/templates/shell_data_test.go
+++ b/internal/web/templates/shell_data_test.go
@@ -479,6 +479,18 @@ func TestAppShellProjects(t *testing.T) {
 			wantPaused:    true,
 		},
 		{
+			name:          "incomplete load reports lower bound",
+			project:       ProjectSmallMultiple{ID: "partial", BoardLoad: 2, BoardActive: 2, BoardWorkloadIncomplete: true},
+			wantCount:     "2+",
+			wantBreakdown: "0 ready · 2 active · 0 waiting · 0 blocked",
+		},
+		{
+			name:          "incomplete empty load reports unknown",
+			project:       ProjectSmallMultiple{ID: "unknown", BoardWorkloadIncomplete: true},
+			wantCount:     "unknown",
+			wantBreakdown: "0 ready · 0 active · 0 waiting · 0 blocked",
+		},
+		{
 			name:          "idle shows no badge",
 			project:       ProjectSmallMultiple{ID: "idle"},
 			wantBreakdown: "0 ready · 0 active · 0 waiting · 0 blocked",

--- a/internal/web/templates/shell_data_test.go
+++ b/internal/web/templates/shell_data_test.go
@@ -482,13 +482,13 @@ func TestAppShellProjects(t *testing.T) {
 			name:          "incomplete load reports lower bound",
 			project:       ProjectSmallMultiple{ID: "partial", BoardLoad: 2, BoardActive: 2, BoardWorkloadIncomplete: true},
 			wantCount:     "2+",
-			wantBreakdown: "0 ready · 2 active · 0 waiting · 0 blocked",
+			wantBreakdown: "unknown ready · 2+ active · unknown waiting · unknown blocked",
 		},
 		{
 			name:          "incomplete empty load reports unknown",
 			project:       ProjectSmallMultiple{ID: "unknown", BoardWorkloadIncomplete: true},
 			wantCount:     "unknown",
-			wantBreakdown: "0 ready · 0 active · 0 waiting · 0 blocked",
+			wantBreakdown: "unknown ready · unknown active · unknown waiting · unknown blocked",
 		},
 		{
 			name:          "idle shows no badge",


### PR DESCRIPTION
## Summary

- derive operator-facing workload from current tracker/runtime rows and exclude retained completion history from exact figures
- expose incomplete projections as `complete: false`, `unknown`, or supported `N+` lower bounds across API, board, sidebar, and tmux surfaces
- refresh retained completion issue state during terminal reconciliation without overwriting the runner outcome

Fixes #1982

## UI Surface Contract

- [x] This change does not alter layout, density, first-viewport, or responsive visibility.
- [x] This change adds no persistent top-of-screen messaging.
- [x] Server-rendered regression tests verify exact, `unknown`, and `N+` labels; no CSS/layout changed, and the worker does not expose `mcp__chrome-devtools__navigate_page` for browser screenshots.

## Test Plan

- [x] Focused telemetry, orchestrator, web/template, and tmux status tests
- [x] `PATH="$TMPDIR/golangci/bin:$PATH" GOTOOLCHAIN=go1.26.6 make check` (CI-pinned golangci-lint v2.1.6; 78.9% coverage)
