### PR TITLE
fix(orchestrator): preserve blocked park cause

### DIFF
--- a/internal/orchestrator/blocked_cause_recovery.go
+++ b/internal/orchestrator/blocked_cause_recovery.go
@@ -874,7 +874,7 @@ func (o *Orchestrator) currentBlockedOperatorStop(ctx context.Context, state *St
 	entry, ok := o.latestWorkflowLaneEntry(ctx, issue)
 	return ok &&
 		normalizeState(entry.Event.PhaseName) == normalizeState(blockedStatusState) &&
-		blockedEntryMatchesCurrent(issue, entry.Event.StartedAt) &&
+		workflowLaneEntryMatchesCurrent(issue, entry.Event) &&
 		strings.EqualFold(strings.TrimSpace(entry.Event.Reason), string(store.WorkAttemptTerminalOperatorStopped))
 }
 
@@ -894,7 +894,7 @@ func (o *Orchestrator) currentBlockedRecoveryPark(
 	entry, ok := o.latestWorkflowLaneEntry(ctx, issue)
 	if !ok ||
 		normalizeState(entry.Event.PhaseName) != normalizeState(blockedStatusState) ||
-		!blockedEntryMatchesCurrent(issue, entry.Event.StartedAt) ||
+		!workflowLaneEntryMatchesCurrent(issue, entry.Event) ||
 		entry.Metadata.BlockedRecovery == nil {
 		return workflowLaneBlockedRecoveryMetadata{}, false
 	}
@@ -916,12 +916,13 @@ func (o *Orchestrator) currentBlockedRecoveryParkedAt(
 		}
 	}
 	entry, ok := o.latestWorkflowLaneEntry(ctx, issue)
+	parkedAt := workflowLaneTransitionAt(entry.Event)
 	if ok &&
 		normalizeState(entry.Event.PhaseName) == normalizeState(blockedStatusState) &&
-		blockedEntryMatchesCurrent(issue, entry.Event.StartedAt) &&
+		workflowLaneEntryMatchesCurrent(issue, entry.Event) &&
 		entry.Metadata.BlockedRecovery != nil &&
-		!entry.Event.StartedAt.IsZero() {
-		return entry.Event.StartedAt.UTC(), true
+		!parkedAt.IsZero() {
+		return parkedAt, true
 	}
 	if issue.StageUpdatedAt != nil && !issue.StageUpdatedAt.IsZero() {
 		return issue.StageUpdatedAt.UTC(), true

--- a/internal/orchestrator/blocked_recovery.go
+++ b/internal/orchestrator/blocked_recovery.go
@@ -486,7 +486,7 @@ func reworkBreakerAutoUnparkReady(issue connector.Issue, park reworkBreakerPark,
 	if normalizeState(issue.State) != normalizeState(blockedStatusState) || issue.Closed || reworkBreakerIssueHeld(issue, terminalStates) {
 		return false
 	}
-	if issue.StageUpdatedAt != nil && issue.StageUpdatedAt.After(park.Event.StartedAt.Add(reworkBreakerStageUpdateSkew)) {
+	if issue.StageUpdatedAt != nil && issue.StageUpdatedAt.After(workflowLaneTransitionAt(park.Event).Add(reworkBreakerStageUpdateSkew)) {
 		return false
 	}
 	pr := issue.PullRequest

--- a/internal/orchestrator/dependency_autounblock.go
+++ b/internal/orchestrator/dependency_autounblock.go
@@ -113,7 +113,7 @@ func (o *Orchestrator) autoUnblockDependencyIssues(
 			continue
 		}
 		hydrated, workpadRefs, workpadCurrent := o.issueWithCurrentWorkpadDependencyRefs(ctx, hydrated)
-		if dependencyAutoUnblockWorkpadHold(hydrated) {
+		if dependencyAutoUnblockWorkpadHold(hydrated, workpadCurrent) {
 			o.logDependencyAutoUnblockDecision(hydrated, "hold", "workpad_status_not_blocked", nil, "")
 			continue
 		}
@@ -172,9 +172,9 @@ func (o *Orchestrator) autoUnblockDependencyIssues(
 	return transitioned
 }
 
-func dependencyAutoUnblockWorkpadHold(issue connector.Issue) bool {
+func dependencyAutoUnblockWorkpadHold(issue connector.Issue, current bool) bool {
 	signal := issue.WorkpadSignal
-	return signal != nil && signal.Invalid == nil && signal.Source == workpad.SourceStructured &&
+	return current && signal != nil && signal.Invalid == nil && signal.Source == workpad.SourceStructured &&
 		strings.TrimSpace(signal.Status) != "" && strings.TrimSpace(signal.Status) != workpad.StatusBlocked
 }
 
@@ -397,8 +397,10 @@ func (o *Orchestrator) issueWithCurrentWorkpadDependencyRefs(
 	ctx context.Context,
 	issue connector.Issue,
 ) (connector.Issue, []connector.BlockedRef, bool) {
-	if !o.workpadBlockersMatchCurrentBlockedEntry(ctx, issue) {
-		return issue, nil, false
+	current := o.workpadSignalMatchesCurrentBlockedEntry(ctx, issue)
+	if !current || issue.WorkpadSignal == nil || strings.TrimSpace(issue.WorkpadSignal.Status) != workpad.StatusBlocked ||
+		len(issue.WorkpadSignal.Blockers) == 0 {
+		return issue, nil, current
 	}
 	refs := workpadDependencyRefs(issue)
 	issue.BlockedBy = mergeDependencyBlockedRefs(issue.BlockedBy, refs)
@@ -407,13 +409,12 @@ func (o *Orchestrator) issueWithCurrentWorkpadDependencyRefs(
 	return issue, refs, true
 }
 
-func (o *Orchestrator) workpadBlockersMatchCurrentBlockedEntry(ctx context.Context, issue connector.Issue) bool {
+func (o *Orchestrator) workpadSignalMatchesCurrentBlockedEntry(ctx context.Context, issue connector.Issue) bool {
 	signal := issue.WorkpadSignal
-	if signal == nil || signal.Invalid != nil || signal.Source != workpad.SourceStructured ||
-		strings.TrimSpace(signal.Status) != workpad.StatusBlocked || len(signal.Blockers) == 0 {
+	if signal == nil || signal.Invalid != nil || signal.Source != workpad.SourceStructured {
 		return false
 	}
-	commentAt, ok := workpadSignalCommentTime(issue, signal.CommentURL)
+	commentAt, ok := workpadSignalCommentTime(issue, signal)
 	if !ok {
 		return true
 	}
@@ -446,9 +447,15 @@ func (o *Orchestrator) workpadBlockersMatchCurrentBlockedEntry(ctx context.Conte
 	return true
 }
 
-func workpadSignalCommentTime(issue connector.Issue, commentURL string) (time.Time, bool) {
-	commentURL = strings.TrimSpace(commentURL)
+func workpadSignalCommentTime(issue connector.Issue, signal *workpad.Signal) (time.Time, bool) {
+	if signal == nil {
+		return time.Time{}, false
+	}
+	commentURL := strings.TrimSpace(signal.CommentURL)
 	if commentURL == "" {
+		if signal.RecordedAt != nil && !signal.RecordedAt.IsZero() {
+			return signal.RecordedAt.UTC(), true
+		}
 		return time.Time{}, false
 	}
 	for index := len(issue.Comments) - 1; index >= 0; index-- {
@@ -463,6 +470,9 @@ func workpadSignalCommentTime(issue connector.Issue, commentURL string) (time.Ti
 			return comment.CreatedAt.UTC(), true
 		}
 		return time.Time{}, false
+	}
+	if signal.RecordedAt != nil && !signal.RecordedAt.IsZero() {
+		return signal.RecordedAt.UTC(), true
 	}
 	return time.Time{}, false
 }

--- a/internal/orchestrator/dependency_autounblock.go
+++ b/internal/orchestrator/dependency_autounblock.go
@@ -113,6 +113,10 @@ func (o *Orchestrator) autoUnblockDependencyIssues(
 			continue
 		}
 		hydrated, workpadRefs, workpadCurrent := o.issueWithCurrentWorkpadDependencyRefs(ctx, hydrated)
+		if dependencyAutoUnblockWorkpadHold(hydrated) {
+			o.logDependencyAutoUnblockDecision(hydrated, "hold", "workpad_status_not_blocked", nil, "")
+			continue
+		}
 		if reason := o.blockedCauseHoldReason(hydrated, state, nil, cfg, workpadCurrent); reason != "" {
 			o.logDependencyAutoUnblockDecision(hydrated, "hold", reason, nil, "")
 			continue
@@ -166,6 +170,12 @@ func (o *Orchestrator) autoUnblockDependencyIssues(
 		return nil
 	}
 	return transitioned
+}
+
+func dependencyAutoUnblockWorkpadHold(issue connector.Issue) bool {
+	signal := issue.WorkpadSignal
+	return signal != nil && signal.Invalid == nil && signal.Source == workpad.SourceStructured &&
+		strings.TrimSpace(signal.Status) != "" && strings.TrimSpace(signal.Status) != workpad.StatusBlocked
 }
 
 func (o *Orchestrator) autoPromoteBlockerIssues(
@@ -417,7 +427,7 @@ func (o *Orchestrator) workpadBlockersMatchCurrentBlockedEntry(ctx context.Conte
 		if event.PhaseType != store.WorkflowPhaseTypeLane || !strings.EqualFold(strings.TrimSpace(event.Status), "entered") {
 			continue
 		}
-		if normalizeState(event.PhaseName) != normalizeState(blockedStatusState) || !blockedEntryMatchesCurrent(issue, event.StartedAt) {
+		if normalizeState(event.PhaseName) != normalizeState(blockedStatusState) || !workflowLaneEntryMatchesCurrent(issue, event) {
 			return false
 		}
 		currentIndex = index
@@ -1053,7 +1063,7 @@ func (o *Orchestrator) issueStickyBlockReason(ctx context.Context, state *State,
 		return ""
 	}
 	if normalizeState(entry.Event.PhaseName) != normalizeState(blockedStatusState) ||
-		!blockedEntryMatchesCurrent(issue, entry.Event.StartedAt) {
+		!workflowLaneEntryMatchesCurrent(issue, entry.Event) {
 		return ""
 	}
 	if stickyBlockReason(entry.Event.Reason) {

--- a/internal/orchestrator/dependency_autounblock_test.go
+++ b/internal/orchestrator/dependency_autounblock_test.go
@@ -440,18 +440,24 @@ func recordDependencyLaneEntry(
 	phase string,
 	reason string,
 	at time.Time,
+	metadata ...workflowLaneMetadata,
 ) {
 	t.Helper()
+	metadataJSON := ""
+	if len(metadata) > 0 {
+		metadataJSON = workflowLaneMetadataJSON(issue, metadata[0])
+	}
 	if _, err := metrics.RecordWorkflowPhaseEvent(t.Context(), store.WorkflowPhaseEvent{
-		ProjectID:  defaultWorkflowMetricsProjectID,
-		IssueID:    issue.ID,
-		Identifier: issue.Identifier,
-		IssueURL:   issue.URL,
-		PhaseType:  store.WorkflowPhaseTypeLane,
-		PhaseName:  phase,
-		Reason:     reason,
-		Status:     "entered",
-		StartedAt:  at,
+		ProjectID:    defaultWorkflowMetricsProjectID,
+		IssueID:      issue.ID,
+		Identifier:   issue.Identifier,
+		IssueURL:     issue.URL,
+		PhaseType:    store.WorkflowPhaseTypeLane,
+		PhaseName:    phase,
+		Reason:       reason,
+		Status:       "entered",
+		StartedAt:    at,
+		MetadataJSON: metadataJSON,
 	}); err != nil {
 		t.Fatalf("RecordWorkflowPhaseEvent() error = %v", err)
 	}
@@ -774,6 +780,69 @@ func TestTickAutoUnblockSkipsPersistedReworkLimitBlockedIssue(t *testing.T) {
 	}
 	if len(tracker.comments) != 0 {
 		t.Fatalf("comments = %#v, want no auto-unblock comment", tracker.comments)
+	}
+}
+
+func TestDependencyAutoUnblockHoldsCurrentNonDependencyParkAfterTrackerTimestampLag(t *testing.T) {
+	t.Parallel()
+
+	parkedAt := time.Date(2026, 8, 25, 20, 13, 0, 0, time.UTC)
+	tests := []struct {
+		name          string
+		reason        string
+		mutationAt    time.Time
+		workpadStatus string
+	}{
+		{name: "rework limit", reason: "rework_limit", mutationAt: parkedAt.Add(3 * time.Second)},
+		{name: "spend without pull request evidence", reason: spendProgressReason, mutationAt: parkedAt.Add(3 * time.Second)},
+		{name: "in progress workpad owns blocked cause", reason: "rework_limit", workpadStatus: workpad.StatusInProgress},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			waiting := dependencyAutoUnblockIssue("issue-current-non-dependency-park", blockedStatusState)
+			waiting.StageUpdatedAt = timePointer(parkedAt.Add(2 * time.Second))
+			waiting.BlockedBy = []connector.BlockedRef{{
+				Identifier: "digitaldrywood/detent#415",
+				Source:     connector.BlockedRefSourceNative,
+			}}
+			waiting.PullRequest = &connector.PullRequest{Number: 2901}
+			if tt.workpadStatus != "" {
+				waiting.WorkpadSignal = &workpad.Signal{Source: workpad.SourceStructured, Status: tt.workpadStatus}
+			}
+			blocker := dependencyAutoUnblockIssue("issue-415", "Done")
+			blocker.Identifier = "digitaldrywood/detent#415"
+			blocker.Closed = true
+			tracker := &dependencyAutoUnblockConnector{
+				stateIssues: []connector.Issue{waiting},
+				blockers:    []connector.Issue{blocker},
+			}
+			orch := dependencyAutoUnblockOrchestrator(tracker, DependencyAutoUnblockConfig{
+				Enabled:      true,
+				SourceStates: []string{blockedStatusState},
+				TargetState:  "Todo",
+				Readiness:    DependencyReadinessTerminalOrMerged,
+			})
+			metrics := &autoPromoteWorkflowMetricsRecorder{}
+			orch.workflowMetrics = metrics
+			metadata := workflowLaneMetadata{BlockedRecovery: &workflowLaneBlockedRecoveryMetadata{Cause: tt.reason}}
+			if !tt.mutationAt.IsZero() {
+				metadata.TrackerMutationAt = tt.mutationAt.Format(time.RFC3339Nano)
+			}
+			recordDependencyLaneEntry(t, metrics, waiting, blockedStatusState, tt.reason, parkedAt, metadata)
+			state := newState(orch.cfg)
+
+			orch.autoUnblockDependencyIssues(t.Context(), &state, tracker.stateIssues, parkedAt.Add(time.Minute))
+
+			if len(tracker.updates) != 0 {
+				t.Fatalf("updates = %#v, want %s park held", tracker.updates, tt.reason)
+			}
+			if len(tracker.comments) != 0 {
+				t.Fatalf("comments = %#v, want no auto-unblock comment", tracker.comments)
+			}
+		})
 	}
 }
 

--- a/internal/orchestrator/dependency_autounblock_test.go
+++ b/internal/orchestrator/dependency_autounblock_test.go
@@ -846,6 +846,49 @@ func TestDependencyAutoUnblockHoldsCurrentNonDependencyParkAfterTrackerTimestamp
 	}
 }
 
+func TestDependencyAutoUnblockIgnoresNonBlockedWorkpadFromPriorLaneOccupancy(t *testing.T) {
+	t.Parallel()
+
+	blockedAt := time.Date(2026, 8, 25, 20, 13, 2, 0, time.UTC)
+	previousLaneAt := blockedAt.Add(-time.Hour)
+	workpadAt := previousLaneAt.Add(-time.Hour)
+	waiting := dependencyAutoUnblockIssue("issue-stale-workpad", blockedStatusState)
+	waiting.StageUpdatedAt = &blockedAt
+	waiting.BlockedBy = []connector.BlockedRef{{
+		Identifier: "digitaldrywood/detent#415",
+		Source:     connector.BlockedRefSourceNative,
+	}}
+	waiting.WorkpadSignal = &workpad.Signal{
+		Source:     workpad.SourceStructured,
+		Status:     workpad.StatusInProgress,
+		RecordedAt: &workpadAt,
+	}
+	blocker := dependencyAutoUnblockIssue("issue-415", "Done")
+	blocker.Identifier = "digitaldrywood/detent#415"
+	blocker.Closed = true
+	tracker := &dependencyAutoUnblockConnector{
+		stateIssues: []connector.Issue{waiting},
+		blockers:    []connector.Issue{blocker},
+	}
+	orch := dependencyAutoUnblockOrchestrator(tracker, DependencyAutoUnblockConfig{
+		Enabled:      true,
+		SourceStates: []string{blockedStatusState},
+		TargetState:  "Todo",
+		Readiness:    DependencyReadinessTerminalOrMerged,
+	})
+	metrics := &autoPromoteWorkflowMetricsRecorder{}
+	orch.workflowMetrics = metrics
+	recordDependencyLaneEntry(t, metrics, waiting, autoPromoteReworkState, "dispatch", previousLaneAt)
+	recordDependencyLaneEntry(t, metrics, waiting, blockedStatusState, "tracker_state_observed", blockedAt)
+	state := newState(orch.cfg)
+
+	orch.autoUnblockDependencyIssues(t.Context(), &state, tracker.stateIssues, blockedAt.Add(time.Minute))
+
+	if got, want := tracker.updates, []dependencyAutoUnblockUpdate{{issueID: waiting.ID, state: "Todo"}}; !slices.Equal(got, want) {
+		t.Fatalf("updates = %#v, want stale Workpad ignored and dependency park moved to Todo", got)
+	}
+}
+
 func TestTickAutoUnblocksDependencyParkNewerThanStickyHistory(t *testing.T) {
 	t.Parallel()
 

--- a/internal/orchestrator/workflow_metrics.go
+++ b/internal/orchestrator/workflow_metrics.go
@@ -41,6 +41,7 @@ type workflowLaneMetadata struct {
 	DependencyAutoUnblock *workflowLaneDependencyAutoUnblockMetadata `json:"dependency_auto_unblock,omitempty"`
 	ReworkBreaker         *workflowLaneReworkBreakerMetadata         `json:"rework_breaker,omitempty"`
 	BlockedRecovery       *workflowLaneBlockedRecoveryMetadata       `json:"blocked_recovery,omitempty"`
+	TrackerMutationAt     string                                     `json:"tracker_mutation_at,omitempty"`
 	BlockedCauseStatus    string                                     `json:"blocked_cause_status,omitempty"`
 	ActionSignatures      []workflowLaneActionSignatureMetadata      `json:"action_signatures,omitempty"`
 	Provenance            provenance.Attribution                     `json:"provenance"`
@@ -172,6 +173,13 @@ func (o *Orchestrator) updateIssueStateByIDWithMetadataMode(
 			return nil
 		}
 		return err
+	}
+	if o.now != nil {
+		mutationAt := o.clockNow().UTC()
+		if mutationAt.Before(at) {
+			mutationAt = at.UTC()
+		}
+		metadata.TrackerMutationAt = mutationAt.Format(time.RFC3339Nano)
 	}
 	if stateIn(targetState, o.cfg.TerminalStates) {
 		terminalIssue := cloneIssue(issue)
@@ -471,7 +479,7 @@ func (o *Orchestrator) refreshCurrentLaneEntries(ctx context.Context, state *Sta
 		if !enteredAt.IsZero() {
 			next[laneKey] = enteredAt
 		}
-		if !eventBacked || trackerTransition.EnteredAt.After(latestEvent.StartedAt) {
+		if !eventBacked || trackerTransition.EnteredAt.After(workflowLaneTransitionAt(latestEvent)) {
 			o.recordObservedLaneEntry(ctx, issue, enteredAt, observedAttribution)
 			if normalizeState(issue.State) == normalizeState(autoPromoteReworkState) {
 				observed := cloneIssue(issue)
@@ -752,6 +760,23 @@ func workflowLaneMetadataFromJSON(raw string) (workflowLaneMetadata, bool) {
 	return metadata, true
 }
 
+func workflowLaneTransitionAt(event store.WorkflowPhaseEvent) time.Time {
+	at := event.StartedAt.UTC()
+	metadata, ok := workflowLaneMetadataFromJSON(event.MetadataJSON)
+	if !ok || strings.TrimSpace(metadata.TrackerMutationAt) == "" {
+		return at
+	}
+	mutationAt, err := time.Parse(time.RFC3339Nano, metadata.TrackerMutationAt)
+	if err != nil || !mutationAt.After(at) {
+		return at
+	}
+	return mutationAt.UTC()
+}
+
+func workflowLaneEntryMatchesCurrent(issue connector.Issue, event store.WorkflowPhaseEvent) bool {
+	return blockedEntryMatchesCurrent(issue, workflowLaneTransitionAt(event))
+}
+
 func BlockedIssueHasCurrentRecoveryPredicate(
 	issue connector.Issue,
 	phaseName string,
@@ -759,11 +784,13 @@ func BlockedIssueHasCurrentRecoveryPredicate(
 	metadataJSON string,
 ) bool {
 	if normalizeState(issue.State) != normalizeState(blockedStatusState) ||
-		normalizeState(phaseName) != normalizeState(blockedStatusState) ||
-		!blockedEntryMatchesCurrent(issue, enteredAt) {
+		normalizeState(phaseName) != normalizeState(blockedStatusState) {
 		return false
 	}
 	metadata, ok := workflowLaneMetadataFromJSON(metadataJSON)
+	if !workflowLaneEntryMatchesCurrent(issue, store.WorkflowPhaseEvent{StartedAt: enteredAt, MetadataJSON: metadataJSON}) {
+		return false
+	}
 	return ok &&
 		metadata.BlockedRecovery != nil &&
 		strings.TrimSpace(metadata.BlockedRecovery.Owner) != "" &&

--- a/internal/orchestrator/workflow_metrics.go
+++ b/internal/orchestrator/workflow_metrics.go
@@ -174,12 +174,11 @@ func (o *Orchestrator) updateIssueStateByIDWithMetadataMode(
 		}
 		return err
 	}
-	if o.now != nil {
-		mutationAt := o.clockNow().UTC()
-		if mutationAt.Before(at) {
-			mutationAt = at.UTC()
+	if metadata.BlockedRecovery != nil {
+		mutationAt, ok := o.confirmTrackerStateTransition(ctx, issueID, issue, targetState)
+		if ok {
+			metadata.TrackerMutationAt = mutationAt.Format(time.RFC3339Nano)
 		}
-		metadata.TrackerMutationAt = mutationAt.Format(time.RFC3339Nano)
 	}
 	if stateIn(targetState, o.cfg.TerminalStates) {
 		terminalIssue := cloneIssue(issue)
@@ -207,6 +206,45 @@ func (o *Orchestrator) updateIssueStateByIDWithMetadataMode(
 		o.captureReworkLesson(issue, at, reason)
 	}
 	return nil
+}
+
+func (o *Orchestrator) confirmTrackerStateTransition(
+	ctx context.Context,
+	issueID string,
+	issue connector.Issue,
+	targetState string,
+) (time.Time, bool) {
+	transitioned := cloneIssue(issue)
+	transitioned.ID = strings.TrimSpace(firstNonBlank(transitioned.ID, issueID))
+	transitioned.State = strings.TrimSpace(targetState)
+	transitioned.StageUpdatedAt = nil
+	transitioned.StageUpdatedActor = connector.IssueActor{}
+	if reader, ok := o.connector.(connector.IssueStateTransitionReader); ok && reader != nil {
+		transition, found, err := reader.IssueStateTransition(ctx, transitioned)
+		if err != nil {
+			if o.logger != nil {
+				o.logger.Warn("tracker state transition confirmation failed", "issue_id", issueID, "target_state", targetState, "error", err)
+			}
+		} else if found && !transition.EnteredAt.IsZero() {
+			return transition.EnteredAt.UTC(), true
+		}
+	}
+
+	issues, err := o.connector.FetchIssueStatesByIDs(ctx, []string{issueID})
+	if err != nil {
+		if o.logger != nil {
+			o.logger.Warn("tracker state confirmation failed", "issue_id", issueID, "target_state", targetState, "error", err)
+		}
+		return time.Time{}, false
+	}
+	for _, current := range issues {
+		if !sameIssueIdentity(transitioned, current) || normalizeState(current.State) != normalizeState(targetState) ||
+			current.StageUpdatedAt == nil || current.StageUpdatedAt.IsZero() {
+			continue
+		}
+		return current.StageUpdatedAt.UTC(), true
+	}
+	return time.Time{}, false
 }
 
 func updateIssueStateSnapshots(state *State, issueID string, issue connector.Issue, targetState string, at time.Time) {

--- a/internal/orchestrator/workflow_metrics_test.go
+++ b/internal/orchestrator/workflow_metrics_test.go
@@ -584,6 +584,61 @@ func TestUpdateIssueStateByIDSkipsWorkflowMetricsForBlockedUpdate(t *testing.T) 
 	}
 }
 
+func TestUpdateIssueStateRecordsTrackerMutationConfirmation(t *testing.T) {
+	t.Parallel()
+
+	requestedAt := time.Date(2026, 8, 25, 20, 13, 0, 0, time.UTC)
+	trackerStageAt := requestedAt.Add(2 * time.Second)
+	mutationAt := requestedAt.Add(3 * time.Second)
+	issue := connector.Issue{
+		ID:         "issue-mutation-confirmation",
+		Identifier: "digitaldrywood/detent#1987",
+		State:      "Human Review",
+	}
+	recorder := &autoPromoteWorkflowMetricsRecorder{}
+	orch := &Orchestrator{
+		cfg:             normalizeConfig(Config{}),
+		connector:       &workflowMetricsConnector{},
+		workflowMetrics: recorder,
+		now:             func() time.Time { return mutationAt },
+	}
+	state := newState(orch.cfg)
+	state.BoardIssues = []connector.Issue{cloneIssue(issue)}
+	metadata := workflowLaneMetadata{BlockedRecovery: &workflowLaneBlockedRecoveryMetadata{Cause: "rework_limit"}}
+
+	if err := orch.updateIssueStateByIDWithMetadata(
+		t.Context(),
+		&state,
+		issue.ID,
+		issue,
+		blockedStatusState,
+		requestedAt,
+		"rework_limit",
+		metadata,
+	); err != nil {
+		t.Fatalf("updateIssueStateByIDWithMetadata() error = %v", err)
+	}
+
+	events := recorder.snapshot()
+	if len(events) != 2 {
+		t.Fatalf("workflow events = %#v, want exit and entry", events)
+	}
+	entered := events[1]
+	gotMetadata, ok := workflowLaneMetadataFromJSON(entered.MetadataJSON)
+	if !ok || gotMetadata.TrackerMutationAt != mutationAt.Format(time.RFC3339Nano) {
+		t.Fatalf("tracker mutation confirmation = %q, want %q", gotMetadata.TrackerMutationAt, mutationAt.Format(time.RFC3339Nano))
+	}
+
+	current := cloneIssue(issue)
+	current.State = blockedStatusState
+	current.StageUpdatedAt = &trackerStageAt
+	state.BoardIssues = []connector.Issue{current}
+	orch.refreshCurrentLaneEntries(t.Context(), &state, requestedAt.Add(time.Minute))
+	if got := len(recorder.snapshot()); got != len(events) {
+		t.Fatalf("workflow event count after tracker reconciliation = %d, want %d", got, len(events))
+	}
+}
+
 func TestUpdateIssueStateByIDCapturesReworkLesson(t *testing.T) {
 	t.Parallel()
 

--- a/internal/orchestrator/workflow_metrics_test.go
+++ b/internal/orchestrator/workflow_metrics_test.go
@@ -589,18 +589,22 @@ func TestUpdateIssueStateRecordsTrackerMutationConfirmation(t *testing.T) {
 
 	requestedAt := time.Date(2026, 8, 25, 20, 13, 0, 0, time.UTC)
 	trackerStageAt := requestedAt.Add(2 * time.Second)
-	mutationAt := requestedAt.Add(3 * time.Second)
+	responseAt := requestedAt.Add(3 * time.Second)
 	issue := connector.Issue{
 		ID:         "issue-mutation-confirmation",
 		Identifier: "digitaldrywood/detent#1987",
 		State:      "Human Review",
 	}
 	recorder := &autoPromoteWorkflowMetricsRecorder{}
+	tracker := &workflowMetricsConnector{
+		stateEnteredAt:      trackerStageAt,
+		stateEnteredAtFound: true,
+	}
 	orch := &Orchestrator{
 		cfg:             normalizeConfig(Config{}),
-		connector:       &workflowMetricsConnector{},
+		connector:       tracker,
 		workflowMetrics: recorder,
-		now:             func() time.Time { return mutationAt },
+		now:             func() time.Time { return responseAt },
 	}
 	state := newState(orch.cfg)
 	state.BoardIssues = []connector.Issue{cloneIssue(issue)}
@@ -625,8 +629,8 @@ func TestUpdateIssueStateRecordsTrackerMutationConfirmation(t *testing.T) {
 	}
 	entered := events[1]
 	gotMetadata, ok := workflowLaneMetadataFromJSON(entered.MetadataJSON)
-	if !ok || gotMetadata.TrackerMutationAt != mutationAt.Format(time.RFC3339Nano) {
-		t.Fatalf("tracker mutation confirmation = %q, want %q", gotMetadata.TrackerMutationAt, mutationAt.Format(time.RFC3339Nano))
+	if !ok || gotMetadata.TrackerMutationAt != trackerStageAt.Format(time.RFC3339Nano) {
+		t.Fatalf("tracker mutation confirmation = %q, want tracker time %q instead of response time %q", gotMetadata.TrackerMutationAt, trackerStageAt.Format(time.RFC3339Nano), responseAt.Format(time.RFC3339Nano))
 	}
 
 	current := cloneIssue(issue)


### PR DESCRIPTION
## Summary

- Preserve the tracker-confirmed mutation time on durable lane events so a newly applied breaker park is not mistaken for stale history.
- Keep dependency recovery from claiming Blocked cards whose structured Workpad is still owned by active or completed work.
- Cover rework-limit and spend-breaker parks while preserving legitimate dependency recovery and later operator re-entry.

Fixes #1987

## UI Surface Contract

- [x] N/A; this PR does not change a UI surface, layout, density, first viewport, or responsive visibility.
- [x] This PR does not add persistent top-of-screen messaging.
- [x] N/A; there are no visual changes to primary operator screens.

## Test Plan

- [x] `go test ./internal/orchestrator -run '^(TestDependencyAutoUnblockHoldsCurrentNonDependencyParkAfterTrackerTimestampLag|TestTickAutoUnblocksDependencyParkNewerThanStickyHistory|TestTickRecoversCurrentWorkpadDependencyBlockers|TestUpdateIssueStateRecordsTrackerMutationConfirmation)$' -count=1`\n- [x] `go test ./internal/orchestrator -count=1`\n- [x] `make check` with the repository-pinned Go 1.26.6 and golangci-lint v2.1.6 toolchain