### PR TITLE
fix(orchestrator): attribute worker lane moves

### DIFF
--- a/internal/orchestrator/dispatch.go
+++ b/internal/orchestrator/dispatch.go
@@ -960,6 +960,14 @@ func (o *Orchestrator) usageUpdateHandler(
 		if startupTimer != nil {
 			startupTimer.Stop()
 		}
+		if strings.TrimSpace(update.WorkerGitHubActor.Login) != "" {
+			select {
+			case <-ctx.Done():
+				return ctx.Err()
+			case o.runUpdates <- runUpdate{issueID: issueID, usage: update}:
+				return nil
+			}
+		}
 
 		select {
 		case o.runUpdates <- runUpdate{issueID: issueID, usage: update}:

--- a/internal/orchestrator/lane_revocation.go
+++ b/internal/orchestrator/lane_revocation.go
@@ -67,8 +67,8 @@ func (o *Orchestrator) beginLaneRevocation(
 		now = o.clockNow().UTC()
 	}
 	fromState := strings.TrimSpace(running.Issue.State)
+	attribution := laneRevocationAttribution(state, refreshed)
 	running.Issue = mergeIssueTrackerFields(running.Issue, refreshed)
-	attribution := laneRevocationAttribution(state, running.Issue)
 	reason = laneRevocationReason(reason, attribution)
 	pending := &pendingLaneRevocation{
 		issue:       cloneIssue(running.Issue),
@@ -293,10 +293,13 @@ func (o *Orchestrator) finishLaneRevocation(ctx context.Context, state *State, p
 func laneRevocationAttribution(state *State, issue connector.Issue) provenance.Attribution {
 	if state != nil {
 		if attribution, ok := state.laneProvenance[workflowLaneEntryKey(issue)]; ok {
-			return provenance.Prepare(attribution)
+			attribution = provenance.Prepare(attribution)
+			if provenance.NormalizeOrigin(attribution.Origin) != provenance.OriginIndeterminate {
+				return attribution
+			}
 		}
 	}
-	return provenance.AttributionFromSource(provenance.SourceTrackerObservation, provenance.Actor{})
+	return observedLaneAttribution(state, issue, issue.StageUpdatedActor)
 }
 
 func laneRevocationReason(reason string, attribution provenance.Attribution) string {

--- a/internal/orchestrator/lane_revocation_test.go
+++ b/internal/orchestrator/lane_revocation_test.go
@@ -253,16 +253,33 @@ func TestLaneRevocationRecordsOriginAndDiscardedWork(t *testing.T) {
 
 	now := time.Date(2026, 8, 18, 19, 20, 0, 0, time.UTC)
 	tests := []struct {
-		name           string
-		origin         provenance.Attribution
-		detentAuthored bool
-		wantReason     string
-		wantErrorClass string
-		wantOrigin     provenance.Origin
+		name            string
+		origin          provenance.Attribution
+		originCached    bool
+		transitionActor connector.IssueActor
+		detentAuthored  bool
+		wantReason      string
+		wantErrorClass  string
+		wantOrigin      provenance.Origin
 	}{
+		{
+			name:            "active agent move before provenance refresh",
+			transitionActor: connector.IssueActor{Login: "operator-token", Kind: "User"},
+			wantReason:      laneRevocationStateChanged,
+			wantErrorClass:  string(store.WorkAttemptTerminalLaneRevoked),
+			wantOrigin:      provenance.OriginAgent,
+		},
+		{
+			name:            "external automation actor overrides active agent fallback",
+			transitionActor: connector.IssueActor{Login: "external-bot", Kind: "Bot"},
+			wantReason:      laneRevocationStateChanged,
+			wantErrorClass:  string(store.WorkAttemptTerminalLaneRevoked),
+			wantOrigin:      provenance.OriginAutomation,
+		},
 		{
 			name:           "operator move keeps tracker revocation",
 			origin:         provenance.AttributionFromSource(provenance.SourceHumanSession, provenance.Actor{Login: "operator", Kind: "User"}),
+			originCached:   true,
 			wantReason:     laneRevocationStateChanged,
 			wantErrorClass: string(store.WorkAttemptTerminalLaneRevoked),
 			wantOrigin:     provenance.OriginHuman,
@@ -283,6 +300,7 @@ func TestLaneRevocationRecordsOriginAndDiscardedWork(t *testing.T) {
 			issue := laneRevocationIssue("issue-origin", "digitaldrywood/detent#1903", "Rework")
 			parked := cloneIssue(issue)
 			parked.State = "Human Review"
+			parked.StageUpdatedActor = tt.transitionActor
 			tracker := &autoPromoteTickConnector{stateIssues: []connector.Issue{parked}}
 			attempts := &recordingWorkAttemptStore{}
 			cfg := normalizeConfig(Config{
@@ -318,11 +336,11 @@ func TestLaneRevocationRecordsOriginAndDiscardedWork(t *testing.T) {
 				if err := orch.updateIssueStateByID(t.Context(), &state, issue.ID, issue, parked.State, now.Add(-time.Minute), "completed_active_review_transition"); err != nil {
 					t.Fatalf("record Detent lane transition: %v", err)
 				}
-			} else {
+			} else if tt.originCached {
 				state.laneProvenance[workflowLaneEntryKey(parked)] = tt.origin
 			}
 
-			orch.reconcileRunningIssues(t.Context(), &state, now)
+			orch.refreshActiveRuns(t.Context(), &state, now, githubBudgetReserveDecision{degraded: true})
 
 			if !errors.Is(context.Cause(runCtx), runpkg.ErrLaneRevoked) {
 				t.Fatalf("context cause = %v, want ErrLaneRevoked", context.Cause(runCtx))
@@ -369,13 +387,58 @@ func TestLaneRevocationRecordsOriginAndDiscardedWork(t *testing.T) {
 			if len(tracker.comments) != 1 {
 				t.Fatalf("comments = %#v, want discarded-work notice", tracker.comments)
 			}
-			for _, fragment := range []string{tt.wantReason, "output_tokens: 13422", "runtime_seconds: 397"} {
+			for _, fragment := range []string{tt.wantReason, "lane_change_origin: " + string(tt.wantOrigin), "output_tokens: 13422", "runtime_seconds: 397"} {
 				if !strings.Contains(tracker.comments[0].body, fragment) {
 					t.Fatalf("comment %q missing %q", tracker.comments[0].body, fragment)
 				}
 			}
 			if !hasLaneRevocationEvent(state.RecentEvents, "worker_lane_output_discarded") {
 				t.Fatalf("RecentEvents = %#v, want discarded output event", state.RecentEvents)
+			}
+		})
+	}
+}
+
+func TestLaneRevocationAttributionEvidencePrecedence(t *testing.T) {
+	t.Parallel()
+
+	issue := laneRevocationIssue("issue-attribution", "digitaldrywood/detent#1988", "Human Review")
+	human := provenance.AttributionFromSource(provenance.SourceHumanSession, provenance.Actor{Login: "operator", Kind: "User"})
+	indeterminate := provenance.AttributionFromSource(provenance.SourceTrackerObservation, provenance.Actor{})
+	tests := []struct {
+		name            string
+		running         bool
+		cached          *provenance.Attribution
+		transitionActor connector.IssueActor
+		want            provenance.Origin
+	}{
+		{name: "active agent", running: true, transitionActor: connector.IssueActor{Login: "operator-token", Kind: "User"}, want: provenance.OriginAgent},
+		{name: "external automation", running: true, transitionActor: connector.IssueActor{Login: "external-bot", Kind: "Bot"}, want: provenance.OriginAutomation},
+		{name: "operator", running: true, cached: &human, want: provenance.OriginHuman},
+		{name: "missing evidence", want: provenance.OriginIndeterminate},
+		{name: "indeterminate cache does not hide active agent", running: true, cached: &indeterminate, want: provenance.OriginAgent},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			state := State{
+				Running:        map[string]Running{},
+				laneProvenance: map[string]provenance.Attribution{},
+			}
+			if tt.running {
+				state.Running[issue.ID] = Running{Issue: issue}
+			}
+			if tt.cached != nil {
+				state.laneProvenance[workflowLaneEntryKey(issue)] = *tt.cached
+			}
+			observed := cloneIssue(issue)
+			observed.StageUpdatedActor = tt.transitionActor
+
+			got := laneRevocationAttribution(&state, observed)
+			if got.Origin != tt.want {
+				t.Fatalf("laneRevocationAttribution() = %#v, want origin %q", got, tt.want)
 			}
 		})
 	}

--- a/internal/orchestrator/lane_revocation_test.go
+++ b/internal/orchestrator/lane_revocation_test.go
@@ -257,6 +257,7 @@ func TestLaneRevocationRecordsOriginAndDiscardedWork(t *testing.T) {
 		origin          provenance.Attribution
 		originCached    bool
 		transitionActor connector.IssueActor
+		workerActor     connector.IssueActor
 		detentAuthored  bool
 		wantReason      string
 		wantErrorClass  string
@@ -270,8 +271,17 @@ func TestLaneRevocationRecordsOriginAndDiscardedWork(t *testing.T) {
 			wantOrigin:      provenance.OriginAgent,
 		},
 		{
+			name:            "active app worker move before provenance refresh",
+			transitionActor: connector.IssueActor{Login: "detent-worker[bot]", Kind: "Bot"},
+			workerActor:     connector.IssueActor{Login: "detent-worker[bot]", Kind: "Bot"},
+			wantReason:      laneRevocationStateChanged,
+			wantErrorClass:  string(store.WorkAttemptTerminalLaneRevoked),
+			wantOrigin:      provenance.OriginAgent,
+		},
+		{
 			name:            "external automation actor overrides active agent fallback",
 			transitionActor: connector.IssueActor{Login: "external-bot", Kind: "Bot"},
+			workerActor:     connector.IssueActor{Login: "detent-worker[bot]", Kind: "Bot"},
 			wantReason:      laneRevocationStateChanged,
 			wantErrorClass:  string(store.WorkAttemptTerminalLaneRevoked),
 			wantOrigin:      provenance.OriginAutomation,
@@ -320,11 +330,12 @@ func TestLaneRevocationRecordsOriginAndDiscardedWork(t *testing.T) {
 			state := newState(cfg)
 			runCtx, stop := context.WithCancelCause(context.Background())
 			state.Running[issue.ID] = Running{
-				Issue:         issue,
-				Attempt:       3,
-				WorkAttemptID: 1903,
-				Generation:    9,
-				StartedAt:     now.Add(-397 * time.Second),
+				Issue:             issue,
+				Attempt:           3,
+				WorkAttemptID:     1903,
+				Generation:        9,
+				StartedAt:         now.Add(-397 * time.Second),
+				WorkerGitHubActor: tt.workerActor,
 				Tokens: runpkg.TokenTotals{
 					OutputTokens:   13_422,
 					TotalTokens:    42_000,
@@ -410,10 +421,12 @@ func TestLaneRevocationAttributionEvidencePrecedence(t *testing.T) {
 		running         bool
 		cached          *provenance.Attribution
 		transitionActor connector.IssueActor
+		workerActor     connector.IssueActor
 		want            provenance.Origin
 	}{
 		{name: "active agent", running: true, transitionActor: connector.IssueActor{Login: "operator-token", Kind: "User"}, want: provenance.OriginAgent},
-		{name: "external automation", running: true, transitionActor: connector.IssueActor{Login: "external-bot", Kind: "Bot"}, want: provenance.OriginAutomation},
+		{name: "active app worker", running: true, transitionActor: connector.IssueActor{Login: "detent-worker[bot]", Kind: "Bot"}, workerActor: connector.IssueActor{Login: "detent-worker[bot]", Kind: "Bot"}, want: provenance.OriginAgent},
+		{name: "external automation", running: true, transitionActor: connector.IssueActor{Login: "external-bot", Kind: "Bot"}, workerActor: connector.IssueActor{Login: "detent-worker[bot]", Kind: "Bot"}, want: provenance.OriginAutomation},
 		{name: "operator", running: true, cached: &human, want: provenance.OriginHuman},
 		{name: "missing evidence", want: provenance.OriginIndeterminate},
 		{name: "indeterminate cache does not hide active agent", running: true, cached: &indeterminate, want: provenance.OriginAgent},
@@ -428,7 +441,7 @@ func TestLaneRevocationAttributionEvidencePrecedence(t *testing.T) {
 				laneProvenance: map[string]provenance.Attribution{},
 			}
 			if tt.running {
-				state.Running[issue.ID] = Running{Issue: issue}
+				state.Running[issue.ID] = Running{Issue: issue, WorkerGitHubActor: tt.workerActor}
 			}
 			if tt.cached != nil {
 				state.laneProvenance[workflowLaneEntryKey(issue)] = *tt.cached

--- a/internal/orchestrator/reconcile.go
+++ b/internal/orchestrator/reconcile.go
@@ -439,6 +439,9 @@ func mergeIssueTrackerFields(current, refreshed connector.Issue) connector.Issue
 	}
 	if refreshed.StageUpdatedAt != nil {
 		merged.StageUpdatedAt = refreshed.StageUpdatedAt
+		merged.StageUpdatedActor = refreshed.StageUpdatedActor
+	} else if strings.TrimSpace(refreshed.StageUpdatedActor.Login) != "" || strings.TrimSpace(refreshed.StageUpdatedActor.Kind) != "" {
+		merged.StageUpdatedActor = refreshed.StageUpdatedActor
 	}
 	if refreshed.ModelOverride != "" {
 		merged.ModelOverride = refreshed.ModelOverride

--- a/internal/orchestrator/run_completion.go
+++ b/internal/orchestrator/run_completion.go
@@ -44,6 +44,9 @@ func (o *Orchestrator) handleRunUpdate(state *State, event runUpdate) {
 	if !event.usage.RuntimeIdentity.IsZero() {
 		running.RuntimeIdentity = running.RuntimeIdentity.Merge(event.usage.RuntimeIdentity)
 	}
+	if strings.TrimSpace(event.usage.WorkerGitHubActor.Login) != "" {
+		running.WorkerGitHubActor = event.usage.WorkerGitHubActor
+	}
 	if event.usage.TurnCount > 0 {
 		running.TurnCount = event.usage.TurnCount
 	}

--- a/internal/orchestrator/run_update_test.go
+++ b/internal/orchestrator/run_update_test.go
@@ -5,8 +5,29 @@ import (
 	"testing"
 	"time"
 
+	"github.com/digitaldrywood/detent/internal/connector"
 	runpkg "github.com/digitaldrywood/detent/internal/runner"
 )
+
+func TestHandleRunUpdateRecordsWorkerGitHubActor(t *testing.T) {
+	t.Parallel()
+
+	state := newState(Config{})
+	issue := connector.Issue{ID: "issue-1988"}
+	state.Running[issue.ID] = Running{Issue: issue}
+	orch := &Orchestrator{}
+
+	orch.handleRunUpdate(&state, runUpdate{
+		issueID: issue.ID,
+		usage: runpkg.UsageUpdate{
+			WorkerGitHubActor: connector.IssueActor{Login: "detent-worker[bot]", Kind: "Bot"},
+		},
+	})
+
+	if got := state.Running[issue.ID].WorkerGitHubActor; got.Login != "detent-worker[bot]" || got.Kind != "Bot" {
+		t.Fatalf("WorkerGitHubActor = %#v, want Detent worker bot", got)
+	}
+}
 
 func TestUsageUpdateHandlerDoesNotBlockWhenBufferIsFull(t *testing.T) {
 	t.Parallel()
@@ -35,6 +56,31 @@ func TestUsageUpdateHandlerDoesNotBlockWhenBufferIsFull(t *testing.T) {
 		}
 	case <-time.After(100 * time.Millisecond):
 		t.Fatal("usage update blocked with a full buffer")
+	}
+}
+
+func TestUsageUpdateHandlerDeliversWorkerGitHubActor(t *testing.T) {
+	t.Parallel()
+
+	orch := &Orchestrator{
+		runUpdates: make(chan runUpdate, 1),
+	}
+	orch.runUpdates <- runUpdate{issueID: "queued"}
+	done := make(chan error, 1)
+
+	go func() {
+		done <- orch.usageUpdateHandler(t.Context(), "issue-1988", nil)(runpkg.UsageUpdate{
+			WorkerGitHubActor: connector.IssueActor{Login: "detent-worker[bot]", Kind: "Bot"},
+		})
+	}()
+
+	<-orch.runUpdates
+	update := <-orch.runUpdates
+	if update.issueID != "issue-1988" || update.usage.WorkerGitHubActor.Login != "detent-worker[bot]" {
+		t.Fatalf("run update = %#v, want worker GitHub actor", update)
+	}
+	if err := <-done; err != nil {
+		t.Fatalf("usage update error = %v", err)
 	}
 }
 

--- a/internal/orchestrator/state.go
+++ b/internal/orchestrator/state.go
@@ -141,6 +141,7 @@ type Running struct {
 	SessionID                   string
 	DetentSessionID             int64
 	RuntimeIdentity             agentidentity.Identity
+	WorkerGitHubActor           connector.IssueActor
 	TurnCount                   int
 	LastEventAt                 time.Time
 	LastEvent                   string

--- a/internal/orchestrator/workflow_metrics.go
+++ b/internal/orchestrator/workflow_metrics.go
@@ -779,15 +779,22 @@ func observedLaneAttribution(state *State, issue connector.Issue, transitionActo
 		Kind:  transitionActor.Kind,
 	}
 	attribution := provenance.AttributionFromSource(provenance.SourceTrackerObservation, actor)
-	if provenance.NormalizeOrigin(attribution.Origin) == provenance.OriginAutomation {
-		return attribution
-	}
 	if state != nil {
-		if _, ok := state.Running[strings.TrimSpace(issue.ID)]; ok {
+		if running, ok := state.Running[strings.TrimSpace(issue.ID)]; ok {
+			if provenance.NormalizeOrigin(attribution.Origin) == provenance.OriginAutomation &&
+				!sameTrackerActor(transitionActor, running.WorkerGitHubActor) {
+				return attribution
+			}
 			return provenance.AttributionFromSource(provenance.SourceDetentAgentSession, actor)
 		}
 	}
 	return attribution
+}
+
+func sameTrackerActor(left connector.IssueActor, right connector.IssueActor) bool {
+	leftLogin := strings.TrimSpace(left.Login)
+	rightLogin := strings.TrimSpace(right.Login)
+	return leftLogin != "" && rightLogin != "" && strings.EqualFold(leftLogin, rightLogin)
 }
 
 func workflowLaneMetadataFromJSON(raw string) (workflowLaneMetadata, bool) {

--- a/internal/orchestrator/workflow_metrics.go
+++ b/internal/orchestrator/workflow_metrics.go
@@ -774,16 +774,20 @@ func workflowOriginForReason(reason string) provenance.Origin {
 }
 
 func observedLaneAttribution(state *State, issue connector.Issue, transitionActor connector.IssueActor) provenance.Attribution {
-	source := provenance.SourceTrackerObservation
-	if state != nil {
-		if _, ok := state.Running[strings.TrimSpace(issue.ID)]; ok {
-			source = provenance.SourceDetentAgentSession
-		}
-	}
-	return provenance.AttributionFromSource(source, provenance.Actor{
+	actor := provenance.Actor{
 		Login: transitionActor.Login,
 		Kind:  transitionActor.Kind,
-	})
+	}
+	attribution := provenance.AttributionFromSource(provenance.SourceTrackerObservation, actor)
+	if provenance.NormalizeOrigin(attribution.Origin) == provenance.OriginAutomation {
+		return attribution
+	}
+	if state != nil {
+		if _, ok := state.Running[strings.TrimSpace(issue.ID)]; ok {
+			return provenance.AttributionFromSource(provenance.SourceDetentAgentSession, actor)
+		}
+	}
+	return attribution
 }
 
 func workflowLaneMetadataFromJSON(raw string) (workflowLaneMetadata, bool) {

--- a/internal/runner/agent.go
+++ b/internal/runner/agent.go
@@ -753,9 +753,10 @@ func (r *Runner) publishWorkspaceCreateStarted(req RunRequest) error {
 		Message: "workspace creation started",
 	}
 	return req.OnUsageUpdate(UsageUpdate{
-		LastEventAt:  at,
-		LastEvent:    event.Event,
-		RecentEvents: []telemetry.ActivityEvent{event},
+		LastEventAt:       at,
+		LastEvent:         event.Event,
+		RecentEvents:      []telemetry.ActivityEvent{event},
+		WorkerGitHubActor: req.workerGitHubActor,
 	})
 }
 
@@ -1286,6 +1287,7 @@ func (r *Runner) Run(ctx context.Context, req RunRequest) (RunResult, error) {
 		r.logWorkerEvent(req.Issue, "worker_github_credential_refused", "error", err)
 		return RunResult{}, err
 	}
+	req.workerGitHubActor = workerGitHub.Principal
 
 	runWorkspace := r.workspace
 	if req.Admission != nil {
@@ -4052,6 +4054,7 @@ func (r *Runner) publishRunUpdate(
 		LastMessageTruncation: runtimeoutput.CloneTruncation(progress.lastMessageTruncation),
 		RecentEvents:          progress.recentActivity(),
 		RuntimeIdentity:       result.RuntimeIdentity,
+		WorkerGitHubActor:     req.workerGitHubActor,
 		WorkProductPushed:     progress.pullRequestHeadPushed() || progress.pullRequestUpdated(),
 		Tokens:                result.Tokens,
 		RateLimits:            result.RateLimits,

--- a/internal/runner/types.go
+++ b/internal/runner/types.go
@@ -523,6 +523,7 @@ type RunRequest struct {
 	MergePrecheck             *MergePrecheck
 	ForgeRetry                *ForgeRetry
 	sessionBrake              *sessionBrakeController
+	workerGitHubActor         connector.IssueActor
 	deliverableRecoveryBranch string
 	sessionTurnOffset         int
 }
@@ -659,6 +660,7 @@ type UsageUpdate struct {
 	LastMessageTruncation *runtimeoutput.Truncation
 	RecentEvents          []telemetry.ActivityEvent
 	RuntimeIdentity       agentidentity.Identity
+	WorkerGitHubActor     connector.IssueActor
 	WorkProductPushed     bool
 	Tokens                TokenTotals
 	DiffStats             DiffStats

--- a/internal/runner/worker_github.go
+++ b/internal/runner/worker_github.go
@@ -61,6 +61,8 @@ type workerGitHubPolicy struct {
 	Token                string
 	OrchestratorToken    string
 	CredentialIdentity   string
+	Principal            connector.IssueActor
+	PrincipalID          int64
 	RateLimitURL         string
 	GraphQLURL           string
 	MinRemaining         int64
@@ -443,19 +445,23 @@ func (p workerGitHubPolicy) classifyCredential(ctx context.Context) (workerGitHu
 	if p.CredentialMode == "" {
 		p.CredentialMode = workerGitHubCredentialUnclassified
 	}
+	if p.PrincipalID <= 0 || strings.TrimSpace(p.Principal.Login) == "" {
+		principalID, principal, err := p.authenticatedPrincipal(ctx, p.Token)
+		if err != nil {
+			return workerGitHubPolicy{}, fmt.Errorf("%w: verify worker credential principal: %w", ErrWorkerGitHubBudgetMonitor, err)
+		}
+		p.PrincipalID = principalID
+		p.Principal = principal
+	}
 	if p.CredentialMode == workerGitHubCredentialUnclassified && strings.TrimSpace(p.OrchestratorToken) == "" {
 		p.CredentialMode = workerGitHubCredentialDistinct
 	}
 	if p.CredentialMode == workerGitHubCredentialUnclassified {
-		workerID, err := p.authenticatedUserID(ctx, p.Token)
-		if err != nil {
-			return workerGitHubPolicy{}, fmt.Errorf("%w: verify worker credential principal: %w", ErrWorkerGitHubBudgetMonitor, err)
-		}
-		orchestratorID, err := p.authenticatedUserID(ctx, p.OrchestratorToken)
+		orchestratorID, _, err := p.authenticatedPrincipal(ctx, p.OrchestratorToken)
 		if err != nil {
 			return workerGitHubPolicy{}, fmt.Errorf("%w: verify orchestrator credential principal: %w", ErrWorkerGitHubBudgetMonitor, err)
 		}
-		if workerID == orchestratorID {
+		if p.PrincipalID == orchestratorID {
 			p.CredentialMode = workerGitHubCredentialShared
 		} else {
 			p.CredentialMode = workerGitHubCredentialDistinct
@@ -486,13 +492,13 @@ func (p workerGitHubPolicy) classifyCredential(ctx context.Context) (workerGitHu
 	return p, nil
 }
 
-func (p workerGitHubPolicy) authenticatedUserID(ctx context.Context, token string) (int64, error) {
+func (p workerGitHubPolicy) authenticatedPrincipal(ctx context.Context, token string) (int64, connector.IssueActor, error) {
 	ctx, cancel := p.probeContext(ctx)
 	defer cancel()
-	body := bytes.NewBufferString(`{"query":"query WorkerCredentialIdentity { viewer { databaseId } }"}`)
+	body := bytes.NewBufferString(`{"query":"query WorkerCredentialIdentity { viewer { databaseId login __typename } }"}`)
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, p.GraphQLURL, body)
 	if err != nil {
-		return 0, err
+		return 0, connector.IssueActor{}, err
 	}
 	req.Header.Set("Authorization", "Bearer "+token)
 	req.Header.Set("Accept", "application/vnd.github+json")
@@ -501,31 +507,36 @@ func (p workerGitHubPolicy) authenticatedUserID(ctx context.Context, token strin
 	req.Header.Set("User-Agent", "detent-worker-github-governor")
 	resp, err := p.HTTPClient.Do(req)
 	if err != nil {
-		return 0, err
+		return 0, connector.IssueActor{}, err
 	}
 	defer resp.Body.Close()
 	raw, err := io.ReadAll(io.LimitReader(resp.Body, workerGitHubRateLimitBodyMaxBytes))
 	if err != nil {
-		return 0, err
+		return 0, connector.IssueActor{}, err
 	}
 	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
-		return 0, fmt.Errorf("github authenticated user graphql probe returned HTTP %d", resp.StatusCode)
+		return 0, connector.IssueActor{}, fmt.Errorf("github authenticated user graphql probe returned HTTP %d", resp.StatusCode)
 	}
 	var payload struct {
 		Data struct {
 			Viewer struct {
-				DatabaseID int64 `json:"databaseId"`
+				DatabaseID int64  `json:"databaseId"`
+				Login      string `json:"login"`
+				TypeName   string `json:"__typename"`
 			} `json:"viewer"`
 		} `json:"data"`
 		Errors []json.RawMessage `json:"errors"`
 	}
 	if err := json.Unmarshal(raw, &payload); err != nil {
-		return 0, fmt.Errorf("decode github authenticated user graphql probe: %w", err)
+		return 0, connector.IssueActor{}, fmt.Errorf("decode github authenticated user graphql probe: %w", err)
 	}
-	if len(payload.Errors) > 0 || payload.Data.Viewer.DatabaseID <= 0 {
-		return 0, errors.New("github authenticated user graphql probe omitted the user id")
+	if len(payload.Errors) > 0 || payload.Data.Viewer.DatabaseID <= 0 || strings.TrimSpace(payload.Data.Viewer.Login) == "" {
+		return 0, connector.IssueActor{}, errors.New("github authenticated user graphql probe omitted the principal identity")
 	}
-	return payload.Data.Viewer.DatabaseID, nil
+	return payload.Data.Viewer.DatabaseID, connector.IssueActor{
+		Login: strings.TrimSpace(payload.Data.Viewer.Login),
+		Kind:  strings.TrimSpace(payload.Data.Viewer.TypeName),
+	}, nil
 }
 
 func (p workerGitHubPolicy) probe(ctx context.Context) (workerGitHubBudget, error) {

--- a/internal/runner/worker_github_test.go
+++ b/internal/runner/worker_github_test.go
@@ -74,6 +74,8 @@ func TestNewWorkerGitHubPolicy(t *testing.T) {
 				t.Fatalf("CredentialMode = %q, want %q", policy.CredentialMode, tt.wantMode)
 			}
 			if tt.wantMode == workerGitHubCredentialShared {
+				policy.Principal.Login = "detent-worker[bot]"
+				policy.PrincipalID = 42
 				classified, classifyErr := policy.classifyCredential(context.Background())
 				if classifyErr != nil {
 					t.Fatalf("classifyCredential() error = %v", classifyErr)
@@ -392,6 +394,9 @@ func TestWorkerGitHubCredentialPrincipalClassification(t *testing.T) {
 			if classified.CredentialMode != tt.wantMode {
 				t.Fatalf("CredentialMode = %q, want %q", classified.CredentialMode, tt.wantMode)
 			}
+			if classified.Principal.Login != "detent-worker[bot]" {
+				t.Fatalf("Principal = %#v, want Detent worker bot", classified.Principal)
+			}
 			warning := strings.Contains(logs.String(), "worker github credential uses shared REST budget")
 			if warning != tt.wantWarning {
 				t.Fatalf("shared-budget warning present = %t, want %t: %q", warning, tt.wantWarning, logs.String())
@@ -419,9 +424,11 @@ func TestWorkerGitHubSharedReserveValidation(t *testing.T) {
 			policy := workerGitHubPolicy{
 				Enabled:           true,
 				CredentialMode:    tt.mode,
+				PrincipalID:       42,
 				MinRemaining:      tt.reserve,
 				OrchestratorFloor: 1000,
 			}
+			policy.Principal.Login = "detent-worker[bot]"
 			_, err := policy.classifyCredential(context.Background())
 			if got := errors.Is(err, ErrWorkerGitHubSharedReserve); got != tt.wantError {
 				t.Fatalf("classifyCredential() error = %v, shared reserve error=%t, want %t", err, got, tt.wantError)
@@ -500,7 +507,7 @@ func workerGitHubRateLimitServer(t *testing.T, remaining func(int64) int64) *htt
 		switch r.URL.Path {
 		case "/graphql":
 			w.Header().Set("Content-Type", "application/json")
-			_, _ = w.Write([]byte(`{"data":{"viewer":{"databaseId":42}}}`))
+			_, _ = w.Write([]byte(`{"data":{"viewer":{"databaseId":42,"login":"detent-worker[bot]","__typename":"Bot"}}}`))
 		case "/rate_limit":
 			if r.Header.Get("Authorization") != "Bearer worker-token" {
 				t.Errorf("Authorization = %q, want worker bearer token", r.Header.Get("Authorization"))
@@ -528,11 +535,16 @@ func workerGitHubPrincipalServer(t *testing.T, orchestratorUserID int64) *httpte
 			return
 		}
 		userID := int64(42)
+		login := "detent-worker[bot]"
 		if r.Header.Get("Authorization") == "Bearer orchestrator-token" {
 			userID = orchestratorUserID
+			login = "detent-orchestrator[bot]"
+			if userID == 42 {
+				login = "detent-worker[bot]"
+			}
 		}
 		w.Header().Set("Content-Type", "application/json")
-		_, _ = fmt.Fprintf(w, `{"data":{"viewer":{"databaseId":%d}}}`, userID)
+		_, _ = fmt.Fprintf(w, `{"data":{"viewer":{"databaseId":%d,"login":%q,"__typename":"Bot"}}}`, userID, login)
 	}))
 }
 


### PR DESCRIPTION
## Summary

- Attribute tracker lane mutations to the same issue's active Detent agent when no stronger provenance exists.
- Preserve explicit operator and external automation evidence while keeping lane revocation and completion fencing enforced.

Fixes #1988

## UI Surface Contract

- [x] N/A; this PR does not change a UI surface, layout, density, first viewport, or responsive visibility.
- [x] This PR does not add persistent top-of-screen messaging.
- [x] N/A; this PR does not change primary operator screens.

## Test Plan

- [x] `make check`
- [x] Reproduced the pre-fix `indeterminate` origin through active-run reconciliation before lane-provenance refresh.
- [x] Covered active-agent, external-automation, operator, and missing-evidence attribution with standard-library table-driven tests.
- [x] Verified discarded-output comments and durable lane-revocation metadata report the same resolved origin.
