### PR TITLE
fix(orchestrator): preserve rework transitions

### DIFF
--- a/internal/orchestrator/autopromote_tick_test.go
+++ b/internal/orchestrator/autopromote_tick_test.go
@@ -584,6 +584,77 @@ func TestTickAutoPromoteCompletedActiveIssues(t *testing.T) {
 	}
 }
 
+func TestAutoPromoteDoesNotReconcileReworkBeforeCompletion(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 8, 26, 18, 34, 0, 0, time.UTC)
+	issue := autoPromoteTickIssue("issue-sticky-rework", []string{"bug"}, &connector.PullRequest{
+		Number:         2928,
+		URL:            "https://github.test/getparable/parable/pull/2928",
+		State:          "OPEN",
+		MergeableState: "clean",
+		CIStatus:       "success",
+	})
+	issue.State = "Rework"
+	cfg := normalizeConfig(Config{
+		AutoPromote: AutoPromoteConfig{
+			Enabled:       true,
+			GateWaitState: autoPromoteGateWaitReview,
+			Gate: gate.Config{
+				Kind:                   gate.KindCommand,
+				RequireAutomatedReview: new(false),
+			},
+		},
+		ActiveStates:   []string{"Todo", "In Progress", "Rework", "Merging"},
+		TerminalStates: []string{"Done", "Cancelled"},
+	})
+
+	tests := []struct {
+		name           string
+		completedState string
+		running        bool
+		wantTransition bool
+	}{
+		{name: "operator moved completed item to rework", completedState: "In Progress"},
+		{name: "rework worker is running", completedState: "In Progress", running: true},
+		{name: "rework worker completed", completedState: "Rework", wantTransition: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			state := newState(cfg)
+			state.Completed[issue.ID] = Completed{
+				Issue:      promotedIssue(issue, tt.completedState, now.Add(-time.Hour)),
+				FinalState: FinalStateCompleted,
+			}
+			if tt.running {
+				state.Running[issue.ID] = Running{
+					Issue:               issue,
+					DispatchSourceState: "Rework",
+					StartedAt:           now.Add(-time.Minute),
+				}
+			}
+			tracker := &autoPromoteTickConnector{stateIssues: []connector.Issue{issue}}
+			orch := &Orchestrator{
+				cfg:       cfg,
+				connector: tracker,
+				logger:    slog.New(slog.NewTextHandler(io.Discard, nil)),
+			}
+
+			result := orch.transitionCompletedActiveIssuesToReview(t.Context(), &state, []connector.Issue{issue}, now)
+
+			_, transitioned := result.transitioned[issue.ID]
+			if transitioned != tt.wantTransition {
+				t.Fatalf("transitioned = %v, want %v", transitioned, tt.wantTransition)
+			}
+			if got := len(tracker.updates); got != boolInt(tt.wantTransition) {
+				t.Fatalf("updates = %#v, want transition %v", tracker.updates, tt.wantTransition)
+			}
+		})
+	}
+}
+
 func TestTickRoutesCompletedActiveArtifactToReview(t *testing.T) {
 	t.Parallel()
 

--- a/internal/orchestrator/completion_transition.go
+++ b/internal/orchestrator/completion_transition.go
@@ -34,6 +34,10 @@ func (o *Orchestrator) transitionCompletedActiveIssuesToReview(
 		if !ok {
 			continue
 		}
+		if normalizeState(issue.State) == normalizeState(cfg.ReworkState) &&
+			normalizeState(completed.Issue.State) != normalizeState(issue.State) {
+			continue
+		}
 		targetState := completedActiveReviewTargetState(
 			issue,
 			completed.FinalState,


### PR DESCRIPTION
## Summary

- Keep operator and worker Rework transitions sticky when the only completion record belongs to an earlier lane.
- Continue normal Human Review reconciliation after a Rework worker actually completes.
- Add table-driven coverage for manual Rework, active Rework, and completed Rework sequences.

Fixes #1991

## UI Surface Contract

- [x] N/A, or the linked issue explicitly authorizes any high-impact UI surface, layout, density, first-viewport, or responsive visibility tradeoff.
- [x] Persistent top-of-screen messaging is explicitly authorized by the issue, or this PR does not add it.
- [x] Visual changes to primary operator screens include screenshot or browser verification below.

## Test Plan

- [x] `make check`
