### PR TITLE
fix(orchestrator): preserve blocked cause

### DIFF
--- a/internal/orchestrator/autopromote_tick_test.go
+++ b/internal/orchestrator/autopromote_tick_test.go
@@ -5464,7 +5464,7 @@ func TestHandleRunResultBlocksMergeWorkerAfterRepeatedInterruptedSessions(t *tes
 	if !ok || blocked.Issue.State != blockedStatusState {
 		t.Fatalf("Blocked[%q] = %#v, want Blocked issue", issue.ID, blocked)
 	}
-	orch.setBlockedStatusIssue(&state, connector.Issue{
+	orch.setBlockedStatusIssue(t.Context(), &state, connector.Issue{
 		ID:         issue.ID,
 		Identifier: issue.Identifier,
 		Title:      issue.Title,

--- a/internal/orchestrator/blocked_cause_recovery.go
+++ b/internal/orchestrator/blocked_cause_recovery.go
@@ -992,7 +992,7 @@ func (o *Orchestrator) recordBlockedRecoveryDecision(
 		if issue.StageUpdatedAt != nil {
 			blockedAt = issue.StageUpdatedAt.UTC()
 		}
-		o.setBlockedStatusIssue(state, issue, blockedAt)
+		o.setBlockedStatusIssue(ctx, state, issue, blockedAt)
 		entry, ok = state.Blocked[issue.ID]
 		if !ok {
 			return

--- a/internal/orchestrator/blocked_cause_recovery_test.go
+++ b/internal/orchestrator/blocked_cause_recovery_test.go
@@ -634,7 +634,7 @@ func TestRepeatedFailureParkRecoveryUsesRecordedRESTBudgetFailures(t *testing.T)
 			if _, ok := transitioned[issue.ID]; ok {
 				t.Fatalf("transitioned[%q] present for held park", issue.ID)
 			}
-			orch.trackBlockedStatusIssues(&state, []connector.Issue{issue}, observedAt.Add(time.Minute))
+			orch.trackBlockedStatusIssues(t.Context(), &state, []connector.Issue{issue}, observedAt.Add(time.Minute))
 			blocked := state.Blocked[issue.ID]
 			if blocked.RecoveryAction != tt.wantAction || blocked.RecoveryReason != tt.wantReason {
 				t.Fatalf("blocked recovery = %q/%q, want %q/%q", blocked.RecoveryAction, blocked.RecoveryReason, tt.wantAction, tt.wantReason)
@@ -713,7 +713,7 @@ func TestBlockedCauseRecoveryUsesCurrentCauseAfterDependencyResolution(t *testin
 			}
 
 			orch.recoverBlockedIssues(t.Context(), &state, []connector.Issue{issue}, parkedAt.Add(time.Minute))
-			orch.trackBlockedStatusIssues(&state, []connector.Issue{issue}, parkedAt.Add(2*time.Minute))
+			orch.trackBlockedStatusIssues(t.Context(), &state, []connector.Issue{issue}, parkedAt.Add(2*time.Minute))
 
 			blocked := state.Blocked[issue.ID]
 			if blocked.RecoveryAction != "hold" || blocked.RecoveryReason != noCommitsToDeliverReason {
@@ -742,7 +742,7 @@ func TestBlockedCauseRecoveryNamesUnresolvedDependency(t *testing.T) {
 	state := newState(orch.cfg)
 
 	orch.recoverBlockedIssues(t.Context(), &state, []connector.Issue{issue}, now)
-	orch.trackBlockedStatusIssues(&state, []connector.Issue{issue}, now.Add(time.Minute))
+	orch.trackBlockedStatusIssues(t.Context(), &state, []connector.Issue{issue}, now.Add(time.Minute))
 
 	blocked := state.Blocked[issue.ID]
 	if blocked.RecoveryAction != "defer" || blocked.RecoveryReason != "dependency_recovery" {

--- a/internal/orchestrator/blocked_recovery_test.go
+++ b/internal/orchestrator/blocked_recovery_test.go
@@ -104,7 +104,7 @@ func TestSetBlockedStatusIssueStoresSpecificCurrentCause(t *testing.T) {
 			name:         "resolved dependency records missing cause",
 			blockedState: "Done",
 			trackerState: connector.BlockedRefTrackerStateClosed,
-			wantCause:    "blocked, cause unrecorded",
+			wantCause:    "blocked outside Detent; no cause recorded by the tracker",
 			wantReason:   BlockedRecoveryReasonMissingPullRequest,
 		},
 		{
@@ -142,7 +142,7 @@ func TestSetBlockedStatusIssueStoresSpecificCurrentCause(t *testing.T) {
 				}},
 			}
 
-			orch.setBlockedStatusIssue(&state, issue, time.Date(2026, 8, 18, 22, 30, 0, 0, time.UTC))
+			orch.setBlockedStatusIssue(t.Context(), &state, issue, time.Date(2026, 8, 18, 22, 30, 0, 0, time.UTC))
 
 			blocked := state.Blocked[issue.ID]
 			if blocked.Reason != tt.wantCause || blocked.RecoveryReason != string(tt.wantReason) {
@@ -195,12 +195,12 @@ func TestSetBlockedStatusIssueReplacesUnrecordedCause(t *testing.T) {
 			state := newState(cfg)
 			now := time.Date(2026, 8, 24, 16, 45, 0, 0, time.UTC)
 			issue := connector.Issue{ID: "issue-refresh", State: blockedStatusState}
-			orch.setBlockedStatusIssue(&state, issue, now)
+			orch.setBlockedStatusIssue(t.Context(), &state, issue, now)
 
 			refreshed := tt.refreshed
 			refreshed.ID = issue.ID
 			refreshed.State = blockedStatusState
-			orch.setBlockedStatusIssue(&state, refreshed, now.Add(time.Minute))
+			orch.setBlockedStatusIssue(t.Context(), &state, refreshed, now.Add(time.Minute))
 
 			blocked := state.Blocked[issue.ID]
 			if blocked.Reason != tt.wantCause || blocked.RecoveryReason != string(tt.wantRecovery) {

--- a/internal/orchestrator/merge_duration_test.go
+++ b/internal/orchestrator/merge_duration_test.go
@@ -174,7 +174,7 @@ func TestMergeWorkerDurationCeilingCancelsProgressingRunAndReleasesSlot(t *testi
 		t.Fatalf("logs = %q, want WARN breach with progress marker", got)
 	}
 
-	orch.setBlockedStatusIssue(&state, connector.Issue{
+	orch.setBlockedStatusIssue(t.Context(), &state, connector.Issue{
 		ID:    issue.ID,
 		State: blockedStatusState,
 	}, completedAt.Add(time.Minute))
@@ -499,7 +499,7 @@ func TestMergeWorkerDurationTransitionFailureKeepsDispatchBlocked(t *testing.T) 
 		normalizeState(blocked.Issue.State) != normalizeState(autoPromoteMergingState) {
 		t.Fatalf("Blocked[%q] = %#v, want merge duration reconciliation hold", issue.ID, blocked)
 	}
-	orch.trackCandidateBlockedStatusIssues(&state, []connector.Issue{issue}, completedAt)
+	orch.trackCandidateBlockedStatusIssues(t.Context(), &state, []connector.Issue{issue}, completedAt)
 	if _, ok := state.Blocked[issue.ID]; !ok {
 		t.Fatalf("Blocked[%q] cleared by tracker hydration", issue.ID)
 	}

--- a/internal/orchestrator/reconcile.go
+++ b/internal/orchestrator/reconcile.go
@@ -9,6 +9,7 @@ import (
 	"github.com/digitaldrywood/detent/internal/gate"
 	runpkg "github.com/digitaldrywood/detent/internal/runner"
 	"github.com/digitaldrywood/detent/internal/staleness"
+	"github.com/digitaldrywood/detent/internal/store"
 	"github.com/digitaldrywood/detent/internal/telemetry"
 )
 
@@ -498,14 +499,14 @@ func (o *Orchestrator) trackBlockedCandidates(state *State, issues []connector.I
 	o.dispatchPlanner().trackBlockedCandidates(state, issues, now)
 }
 
-func (o *Orchestrator) trackBlockedStatusIssues(state *State, issues []connector.Issue, now time.Time) {
+func (o *Orchestrator) trackBlockedStatusIssues(ctx context.Context, state *State, issues []connector.Issue, now time.Time) {
 	seenBlocked := make(map[string]struct{}, len(issues))
 	for _, issue := range issues {
 		if issue.ID == "" {
 			continue
 		}
 		seenBlocked[issue.ID] = struct{}{}
-		o.setBlockedStatusIssue(state, issue, now)
+		o.setBlockedStatusIssue(ctx, state, issue, now)
 	}
 
 	for issueID, blocked := range state.Blocked {
@@ -518,7 +519,7 @@ func (o *Orchestrator) trackBlockedStatusIssues(state *State, issues []connector
 	}
 }
 
-func (o *Orchestrator) trackCandidateBlockedStatusIssues(state *State, issues []connector.Issue, now time.Time) {
+func (o *Orchestrator) trackCandidateBlockedStatusIssues(ctx context.Context, state *State, issues []connector.Issue, now time.Time) {
 	blockedState := normalizeState(blockedStatusState)
 	for _, issue := range issues {
 		if issue.ID == "" {
@@ -532,7 +533,7 @@ func (o *Orchestrator) trackCandidateBlockedStatusIssues(state *State, issues []
 			clearBlockedStatusIssue(state, issue.ID)
 			continue
 		}
-		o.setBlockedStatusIssue(state, issue, now)
+		o.setBlockedStatusIssue(ctx, state, issue, now)
 	}
 }
 
@@ -542,13 +543,14 @@ func clearBlockedStatusIssue(state *State, issueID string) {
 	}
 }
 
-func (o *Orchestrator) setBlockedStatusIssue(state *State, issue connector.Issue, now time.Time) {
+func (o *Orchestrator) setBlockedStatusIssue(ctx context.Context, state *State, issue connector.Issue, now time.Time) {
 	if existing, ok := state.Blocked[issue.ID]; ok && existing.Source == BlockedSourceProjectStatus {
 		existing.Issue = mergeIssueTrackerFields(existing.Issue, issue)
-		refreshedReason := blockedStatusReason(existing.Issue, o.cfg.TerminalStates)
-		if currentReason := strings.TrimSpace(existing.Reason); currentReason == "" ||
-			(strings.EqualFold(currentReason, staleness.ReasonBlockedCauseUnrecorded) &&
-				!strings.EqualFold(refreshedReason, staleness.ReasonBlockedCauseUnrecorded)) {
+		refreshedReason := o.reconciledBlockedStatusReason(ctx, state, existing.Issue)
+		currentReason := strings.TrimSpace(existing.Reason)
+		existing.Reason = refreshedReason
+		if existing.RecoveryAction == "" &&
+			(blockedStatusReasonUnknown(currentReason) && !blockedStatusReasonUnknown(refreshedReason)) {
 			recovery := evaluateBlockedRecovery(existing.Issue, normalizeBlockedRecoveryConfig(BlockedRecoveryConfig{
 				Enabled:      true,
 				SourceStates: []string{blockedStatusState},
@@ -568,7 +570,7 @@ func (o *Orchestrator) setBlockedStatusIssue(state *State, issue connector.Issue
 	}), o.cfg.TerminalStates)
 	state.Blocked[issue.ID] = Blocked{
 		Issue:          cloneIssue(issue),
-		Reason:         blockedStatusReason(issue, o.cfg.TerminalStates),
+		Reason:         o.reconciledBlockedStatusReason(ctx, state, issue),
 		RecoveryReason: string(recovery.Reason),
 		RecoveryTarget: recovery.TargetState,
 		BlockedAt:      now,
@@ -581,12 +583,120 @@ func blockedFromDependency(blocked Blocked) bool {
 		(blocked.Source == "" && blocked.Reason == blockedReasonDependency)
 }
 
-func blockedStatusReason(issue connector.Issue, terminalStates []string) string {
+func (o *Orchestrator) reconciledBlockedStatusReason(ctx context.Context, state *State, issue connector.Issue) string {
+	detentCauses := []string{blockedStatusRuntimeCause(state, issue)}
+	if timeline, ok := o.issueWorkflowTimeline(ctx, issue); ok {
+		detentCauses = append(detentCauses, blockedStatusTimelineCause(issue, timeline.Events))
+	}
+	return blockedStatusReason(issue, o.cfg.TerminalStates, detentCauses...)
+}
+
+func blockedStatusRuntimeCause(state *State, issue connector.Issue) string {
+	if state == nil {
+		return ""
+	}
+	blocked, ok := state.Blocked[strings.TrimSpace(issue.ID)]
+	if !ok || !blockedEntryMatchesCurrent(issue, blocked.BlockedAt) {
+		return ""
+	}
+	detentOwned := blocked.Source != BlockedSourceProjectStatus ||
+		blocked.Recovery != nil || strings.TrimSpace(blocked.RecoveryAction) != ""
+	if detentOwned {
+		if cause := strings.TrimSpace(blocked.Reason); blockedStatusCauseRecorded(cause) {
+			return cause
+		}
+	}
+	if cause := blockedRecoveryMetadataCause(blocked.Recovery); blockedStatusCauseRecorded(cause) {
+		return cause
+	}
+	if blocked.Source == BlockedSourceOperatorStop {
+		if cause := firstNonBlank(blocked.StopReason, blocked.Reason); blockedStatusCauseRecorded(cause) {
+			return cause
+		}
+	}
+	if strings.TrimSpace(blocked.RecoveryAction) != "" {
+		if cause := strings.TrimSpace(blocked.RecoveryReason); blockedStatusCauseRecorded(cause) {
+			return cause
+		}
+	}
+	if blocked.Source != BlockedSourceProjectStatus {
+		if cause := strings.TrimSpace(blocked.Reason); blockedStatusCauseRecorded(cause) {
+			return cause
+		}
+	}
+	return ""
+}
+
+func blockedStatusTimelineCause(issue connector.Issue, events []store.WorkflowPhaseEvent) string {
+	entry, ok := latestCurrentLaneEntry(events, blockedStatusState)
+	if !ok || !workflowLaneEntryMatchesCurrent(issue, entry) {
+		return ""
+	}
+	metadata, _ := workflowLaneMetadataFromJSON(entry.MetadataJSON)
+	if cause := blockedRecoveryMetadataCause(metadata.BlockedRecovery); blockedStatusCauseRecorded(cause) {
+		return cause
+	}
+	if cause := strings.TrimSpace(entry.Reason); blockedStatusLaneCauseRecorded(cause) {
+		return cause
+	}
+
+	enteredAt := workflowLaneTransitionAt(entry).Add(-reworkBreakerStageUpdateSkew)
+	for index := len(events) - 1; index >= 0; index-- {
+		event := events[index]
+		if event.PhaseType != store.WorkflowPhaseTypeRecovery || !blockedStatusRecoveryCauseEvent(event.PhaseName) {
+			continue
+		}
+		eventAt := event.StartedAt
+		if event.FinishedAt.After(eventAt) {
+			eventAt = event.FinishedAt
+		}
+		if eventAt.Before(enteredAt) {
+			continue
+		}
+		if cause := strings.TrimSpace(event.Reason); blockedStatusCauseRecorded(cause) {
+			return cause
+		}
+	}
+	return ""
+}
+
+func blockedStatusLaneCauseRecorded(reason string) bool {
+	reason = strings.TrimSpace(reason)
+	return blockedStatusCauseRecorded(reason) &&
+		!strings.EqualFold(reason, "tracker_state_observed") &&
+		!strings.EqualFold(reason, "state_transition")
+}
+
+func blockedStatusRecoveryCauseEvent(name string) bool {
+	name = strings.ToLower(strings.TrimSpace(name))
+	return name == "stale_completion_rejected" || strings.Contains(name, "park") || strings.Contains(name, "revok")
+}
+
+func blockedStatusCauseRecorded(reason string) bool {
+	return !blockedStatusReasonUnknown(reason)
+}
+
+func blockedStatusReasonUnknown(reason string) bool {
+	reason = strings.TrimSpace(reason)
+	return reason == "" ||
+		strings.EqualFold(reason, staleness.ReasonBlockedCauseUnrecorded) ||
+		strings.EqualFold(reason, staleness.ReasonBlockedOutsideDetent)
+}
+
+// blockedStatusReason applies the operator-facing cause precedence: Detent's
+// current park record or event history, tracker reason, dependency refs, then
+// the explicit external-block fallback.
+func blockedStatusReason(issue connector.Issue, terminalStates []string, detentCauses ...string) string {
+	for _, reason := range detentCauses {
+		if reason = strings.TrimSpace(reason); blockedStatusCauseRecorded(reason) {
+			return reason
+		}
+	}
 	if reason := strings.TrimSpace(issue.BlockerReason); reason != "" {
 		return reason
 	}
 	if blockedRefsUnresolved(issue.BlockedBy, terminalStates) {
 		return blockedReasonDependency
 	}
-	return staleness.ReasonBlockedCauseUnrecorded
+	return staleness.ReasonBlockedOutsideDetent
 }

--- a/internal/orchestrator/reconcile.go
+++ b/internal/orchestrator/reconcile.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/digitaldrywood/detent/internal/connector"
 	"github.com/digitaldrywood/detent/internal/gate"
+	"github.com/digitaldrywood/detent/internal/provenance"
 	runpkg "github.com/digitaldrywood/detent/internal/runner"
 	"github.com/digitaldrywood/detent/internal/staleness"
 	"github.com/digitaldrywood/detent/internal/store"
@@ -614,11 +615,6 @@ func blockedStatusRuntimeCause(state *State, issue connector.Issue) string {
 			return cause
 		}
 	}
-	if strings.TrimSpace(blocked.RecoveryAction) != "" {
-		if cause := strings.TrimSpace(blocked.RecoveryReason); blockedStatusCauseRecorded(cause) {
-			return cause
-		}
-	}
 	if blocked.Source != BlockedSourceProjectStatus {
 		if cause := strings.TrimSpace(blocked.Reason); blockedStatusCauseRecorded(cause) {
 			return cause
@@ -640,6 +636,9 @@ func blockedStatusTimelineCause(issue connector.Issue, events []store.WorkflowPh
 		return cause
 	}
 
+	if !blockedStatusDetentAuthoredLane(metadata) {
+		return ""
+	}
 	enteredAt := workflowLaneTransitionAt(entry).Add(-reworkBreakerStageUpdateSkew)
 	for index := len(events) - 1; index >= 0; index-- {
 		event := events[index]
@@ -658,6 +657,20 @@ func blockedStatusTimelineCause(issue connector.Issue, events []store.WorkflowPh
 		}
 	}
 	return ""
+}
+
+func blockedStatusDetentAuthoredLane(metadata workflowLaneMetadata) bool {
+	switch provenance.NormalizeOrigin(metadata.Provenance.Origin) {
+	case provenance.OriginDetent,
+		provenance.OriginAgent,
+		provenance.OriginRoutine,
+		provenance.OriginRetro,
+		provenance.OriginDependency,
+		provenance.OriginAdmission:
+		return true
+	default:
+		return false
+	}
 }
 
 func blockedStatusLaneCauseRecorded(reason string) bool {

--- a/internal/orchestrator/reconcile_test.go
+++ b/internal/orchestrator/reconcile_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/digitaldrywood/detent/internal/gate"
 	runpkg "github.com/digitaldrywood/detent/internal/runner"
 	"github.com/digitaldrywood/detent/internal/scheduler"
+	"github.com/digitaldrywood/detent/internal/store"
 )
 
 func TestTickReconcilesRunningIssueTrackerState(t *testing.T) {
@@ -165,6 +166,176 @@ func TestReconcileRunningIssuesStopsWorkerOutsideActiveLane(t *testing.T) {
 	case <-runCtx.Done():
 	default:
 		t.Fatal("worker context remains active after the item moved to Blocked")
+	}
+}
+
+func TestTrackBlockedStatusIssuesResolvesCauseByPrecedence(t *testing.T) {
+	t.Parallel()
+
+	parkedAt := time.Date(2026, 8, 27, 9, 30, 0, 0, time.UTC)
+	tests := []struct {
+		name            string
+		issue           connector.Issue
+		runtimeCause    string
+		detentCause     string
+		revocationCause string
+		wantReason      string
+		wantOldAbsent   bool
+	}{
+		{
+			name: "live Detent park record",
+			issue: connector.Issue{
+				ID:            "issue-live-detent-park",
+				Identifier:    "digitaldrywood/detent#1994",
+				State:         blockedStatusState,
+				BlockerReason: "tracker fallback",
+			},
+			runtimeCause:  "session token ceiling exceeded",
+			wantReason:    "session token ceiling exceeded",
+			wantOldAbsent: true,
+		},
+		{
+			name: "persisted Detent park after restart",
+			issue: connector.Issue{
+				ID:            "issue-detent-park",
+				Identifier:    "digitaldrywood/detent#1995",
+				State:         blockedStatusState,
+				BlockerReason: "tracker fallback",
+				BlockedBy: []connector.BlockedRef{{
+					Identifier: "digitaldrywood/detent#1800",
+					State:      "In Progress",
+				}},
+			},
+			detentCause:   "rework_limit",
+			wantReason:    "rework_limit",
+			wantOldAbsent: true,
+		},
+		{
+			name: "tracker authored block",
+			issue: connector.Issue{
+				ID:            "issue-tracker-block",
+				Identifier:    "digitaldrywood/detent#1996",
+				State:         blockedStatusState,
+				BlockerReason: "waiting for operator approval",
+				BlockedBy: []connector.BlockedRef{{
+					Identifier: "digitaldrywood/detent#1800",
+					State:      "In Progress",
+				}},
+			},
+			wantReason: "waiting for operator approval",
+		},
+		{
+			name: "dependency block",
+			issue: connector.Issue{
+				ID:         "issue-dependency-block",
+				Identifier: "digitaldrywood/detent#1997",
+				State:      blockedStatusState,
+				BlockedBy: []connector.BlockedRef{{
+					Identifier: "digitaldrywood/detent#1800",
+					State:      "In Progress",
+				}},
+			},
+			wantReason: blockedReasonDependency,
+		},
+		{
+			name: "external block without tracker cause",
+			issue: connector.Issue{
+				ID:         "issue-external-block",
+				Identifier: "digitaldrywood/detent#1998",
+				State:      blockedStatusState,
+			},
+			wantReason:    "blocked outside Detent; no cause recorded by the tracker",
+			wantOldAbsent: true,
+		},
+		{
+			name: "lane revocation event",
+			issue: connector.Issue{
+				ID:         "issue-lane-revocation",
+				Identifier: "digitaldrywood/detent#1999",
+				State:      blockedStatusState,
+			},
+			revocationCause: "current tracker lane is not worker-owned",
+			wantReason:      "current tracker lane is not worker-owned",
+			wantOldAbsent:   true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			metrics := &autoPromoteWorkflowMetricsRecorder{}
+			if tt.detentCause != "" {
+				metadata := workflowLaneMetadata{
+					BlockedRecovery: &workflowLaneBlockedRecoveryMetadata{Cause: tt.detentCause},
+				}
+				if _, err := metrics.RecordWorkflowPhaseEvent(t.Context(), store.WorkflowPhaseEvent{
+					ProjectID:    defaultWorkflowMetricsProjectID,
+					IssueID:      tt.issue.ID,
+					Identifier:   tt.issue.Identifier,
+					PhaseType:    store.WorkflowPhaseTypeLane,
+					PhaseName:    blockedStatusState,
+					Reason:       tt.detentCause,
+					Status:       "entered",
+					StartedAt:    parkedAt,
+					MetadataJSON: workflowLaneMetadataJSON(tt.issue, metadata),
+				}); err != nil {
+					t.Fatalf("RecordWorkflowPhaseEvent() error = %v", err)
+				}
+			} else if tt.revocationCause != "" {
+				for _, event := range []store.WorkflowPhaseEvent{
+					{
+						ProjectID:  defaultWorkflowMetricsProjectID,
+						IssueID:    tt.issue.ID,
+						Identifier: tt.issue.Identifier,
+						PhaseType:  store.WorkflowPhaseTypeLane,
+						PhaseName:  blockedStatusState,
+						Reason:     "tracker_state_observed",
+						Status:     "entered",
+						StartedAt:  parkedAt,
+					},
+					{
+						ProjectID:  defaultWorkflowMetricsProjectID,
+						IssueID:    tt.issue.ID,
+						Identifier: tt.issue.Identifier,
+						PhaseType:  store.WorkflowPhaseTypeRecovery,
+						PhaseName:  "stale_completion_rejected",
+						Reason:     tt.revocationCause,
+						Status:     "rejected",
+						StartedAt:  parkedAt.Add(time.Second),
+						FinishedAt: parkedAt.Add(time.Second),
+					},
+				} {
+					if _, err := metrics.RecordWorkflowPhaseEvent(t.Context(), event); err != nil {
+						t.Fatalf("RecordWorkflowPhaseEvent() error = %v", err)
+					}
+				}
+			}
+
+			cfg := normalizeConfig(Config{TerminalStates: []string{"Done", "Cancelled"}})
+			orch := &Orchestrator{cfg: cfg, workflowMetrics: metrics}
+			state := newState(cfg)
+			if tt.runtimeCause != "" {
+				state.Blocked[tt.issue.ID] = Blocked{
+					Issue:     tt.issue,
+					Reason:    tt.runtimeCause,
+					Source:    BlockedSourceProjectStatus,
+					BlockedAt: parkedAt,
+					Recovery: &workflowLaneBlockedRecoveryMetadata{
+						Cause: "token_ceiling_circuit_breaker",
+					},
+				}
+			}
+			orch.trackBlockedStatusIssues(t.Context(), &state, []connector.Issue{tt.issue}, parkedAt.Add(time.Minute))
+
+			got := state.Snapshot(parkedAt.Add(2 * time.Minute)).Blocked
+			if len(got) != 1 || got[0].Error != tt.wantReason {
+				t.Fatalf("rendered blocked card = %#v, want reason %q", got, tt.wantReason)
+			}
+			if tt.wantOldAbsent && strings.Contains(got[0].Error, "cause unrecorded") {
+				t.Fatalf("rendered blocked card reason = %q, want recorded cause", got[0].Error)
+			}
+		})
 	}
 }
 

--- a/internal/orchestrator/reconcile_test.go
+++ b/internal/orchestrator/reconcile_test.go
@@ -12,8 +12,10 @@ import (
 
 	"github.com/digitaldrywood/detent/internal/connector"
 	"github.com/digitaldrywood/detent/internal/gate"
+	"github.com/digitaldrywood/detent/internal/provenance"
 	runpkg "github.com/digitaldrywood/detent/internal/runner"
 	"github.com/digitaldrywood/detent/internal/scheduler"
+	"github.com/digitaldrywood/detent/internal/staleness"
 	"github.com/digitaldrywood/detent/internal/store"
 )
 
@@ -174,13 +176,17 @@ func TestTrackBlockedStatusIssuesResolvesCauseByPrecedence(t *testing.T) {
 
 	parkedAt := time.Date(2026, 8, 27, 9, 30, 0, 0, time.UTC)
 	tests := []struct {
-		name            string
-		issue           connector.Issue
-		runtimeCause    string
-		detentCause     string
-		revocationCause string
-		wantReason      string
-		wantOldAbsent   bool
+		name             string
+		issue            connector.Issue
+		runtimeCause     string
+		runtimeRecovery  string
+		recoveryAction   string
+		recoveryReason   string
+		detentCause      string
+		revocationCause  string
+		revocationOrigin provenance.Origin
+		wantReason       string
+		wantOldAbsent    bool
 	}{
 		{
 			name: "live Detent park record",
@@ -190,9 +196,10 @@ func TestTrackBlockedStatusIssuesResolvesCauseByPrecedence(t *testing.T) {
 				State:         blockedStatusState,
 				BlockerReason: "tracker fallback",
 			},
-			runtimeCause:  "session token ceiling exceeded",
-			wantReason:    "session token ceiling exceeded",
-			wantOldAbsent: true,
+			runtimeCause:    "session token ceiling exceeded",
+			runtimeRecovery: "token_ceiling_circuit_breaker",
+			wantReason:      "session token ceiling exceeded",
+			wantOldAbsent:   true,
 		},
 		{
 			name: "persisted Detent park after restart",
@@ -209,6 +216,19 @@ func TestTrackBlockedStatusIssuesResolvesCauseByPrecedence(t *testing.T) {
 			detentCause:   "rework_limit",
 			wantReason:    "rework_limit",
 			wantOldAbsent: true,
+		},
+		{
+			name: "recovery policy is not a blocked cause",
+			issue: connector.Issue{
+				ID:         "issue-recovery-policy",
+				Identifier: "digitaldrywood/detent#1996",
+				State:      blockedStatusState,
+			},
+			runtimeCause:   staleness.ReasonBlockedOutsideDetent,
+			recoveryAction: "hold",
+			recoveryReason: "no_recovery_predicate",
+			wantReason:     staleness.ReasonBlockedOutsideDetent,
+			wantOldAbsent:  true,
 		},
 		{
 			name: "tracker authored block",
@@ -254,9 +274,22 @@ func TestTrackBlockedStatusIssuesResolvesCauseByPrecedence(t *testing.T) {
 				Identifier: "digitaldrywood/detent#1999",
 				State:      blockedStatusState,
 			},
-			revocationCause: "current tracker lane is not worker-owned",
-			wantReason:      "current tracker lane is not worker-owned",
-			wantOldAbsent:   true,
+			revocationCause:  "current tracker lane is not worker-owned",
+			revocationOrigin: provenance.OriginDetent,
+			wantReason:       "current tracker lane is not worker-owned",
+			wantOldAbsent:    true,
+		},
+		{
+			name: "external tracker cause survives stale completion",
+			issue: connector.Issue{
+				ID:            "issue-external-stale-completion",
+				Identifier:    "digitaldrywood/detent#2000",
+				State:         blockedStatusState,
+				BlockerReason: "waiting for operator approval",
+			},
+			revocationCause:  "worker lease is no longer active",
+			revocationOrigin: provenance.OriginHuman,
+			wantReason:       "waiting for operator approval",
 		},
 	}
 
@@ -283,16 +316,24 @@ func TestTrackBlockedStatusIssuesResolvesCauseByPrecedence(t *testing.T) {
 					t.Fatalf("RecordWorkflowPhaseEvent() error = %v", err)
 				}
 			} else if tt.revocationCause != "" {
+				source := provenance.SourceDetentInstance
+				if tt.revocationOrigin == provenance.OriginHuman {
+					source = provenance.SourceHumanSession
+				}
+				metadata := workflowLaneMetadata{
+					Provenance: provenance.AttributionFromSource(source, provenance.Actor{}),
+				}
 				for _, event := range []store.WorkflowPhaseEvent{
 					{
-						ProjectID:  defaultWorkflowMetricsProjectID,
-						IssueID:    tt.issue.ID,
-						Identifier: tt.issue.Identifier,
-						PhaseType:  store.WorkflowPhaseTypeLane,
-						PhaseName:  blockedStatusState,
-						Reason:     "tracker_state_observed",
-						Status:     "entered",
-						StartedAt:  parkedAt,
+						ProjectID:    defaultWorkflowMetricsProjectID,
+						IssueID:      tt.issue.ID,
+						Identifier:   tt.issue.Identifier,
+						PhaseType:    store.WorkflowPhaseTypeLane,
+						PhaseName:    blockedStatusState,
+						Reason:       "tracker_state_observed",
+						Status:       "entered",
+						StartedAt:    parkedAt,
+						MetadataJSON: workflowLaneMetadataJSON(tt.issue, metadata),
 					},
 					{
 						ProjectID:  defaultWorkflowMetricsProjectID,
@@ -316,14 +357,18 @@ func TestTrackBlockedStatusIssuesResolvesCauseByPrecedence(t *testing.T) {
 			orch := &Orchestrator{cfg: cfg, workflowMetrics: metrics}
 			state := newState(cfg)
 			if tt.runtimeCause != "" {
+				var recovery *workflowLaneBlockedRecoveryMetadata
+				if tt.runtimeRecovery != "" {
+					recovery = &workflowLaneBlockedRecoveryMetadata{Cause: tt.runtimeRecovery}
+				}
 				state.Blocked[tt.issue.ID] = Blocked{
-					Issue:     tt.issue,
-					Reason:    tt.runtimeCause,
-					Source:    BlockedSourceProjectStatus,
-					BlockedAt: parkedAt,
-					Recovery: &workflowLaneBlockedRecoveryMetadata{
-						Cause: "token_ceiling_circuit_breaker",
-					},
+					Issue:          tt.issue,
+					Reason:         tt.runtimeCause,
+					RecoveryAction: tt.recoveryAction,
+					RecoveryReason: tt.recoveryReason,
+					Source:         BlockedSourceProjectStatus,
+					BlockedAt:      parkedAt,
+					Recovery:       recovery,
 				}
 			}
 			orch.trackBlockedStatusIssues(t.Context(), &state, []connector.Issue{tt.issue}, parkedAt.Add(time.Minute))

--- a/internal/orchestrator/run_completion_token_ceiling_test.go
+++ b/internal/orchestrator/run_completion_token_ceiling_test.go
@@ -99,7 +99,7 @@ func TestHandleRunResultParksSlowTokenCeilingFailureWithoutRetry(t *testing.T) {
 	if !stickyBlockReason(blocked.Reason) {
 		t.Fatalf("stickyBlockReason(%q) = false, want current token ceiling park to suppress dependency recovery", blocked.Reason)
 	}
-	orch.setBlockedStatusIssue(&state, connector.Issue{
+	orch.setBlockedStatusIssue(t.Context(), &state, connector.Issue{
 		ID:         issue.ID,
 		Identifier: issue.Identifier,
 		Title:      issue.Title,

--- a/internal/orchestrator/targeted_reconcile.go
+++ b/internal/orchestrator/targeted_reconcile.go
@@ -69,7 +69,7 @@ func (o *Orchestrator) applyTargetedReconcile(
 	o.updateTargetedIssueEntries(state, issue)
 
 	if normalizeState(issue.State) == normalizeState(blockedStatusState) {
-		o.setBlockedStatusIssue(state, issue, now)
+		o.setBlockedStatusIssue(ctx, state, issue, now)
 	} else {
 		clearBlockedStatusIssue(state, issue.ID)
 	}

--- a/internal/orchestrator/tick.go
+++ b/internal/orchestrator/tick.go
@@ -960,9 +960,9 @@ func (o *Orchestrator) dispatchTickIssues(
 		if !transitions.blockedRefreshOK {
 			currentBlockedStatusIssues = mergeIssueSlices(currentBlockedStatusIssues, previous.blockedStatusIssues)
 		}
-		o.trackBlockedStatusIssues(state, currentBlockedStatusIssues, now)
+		o.trackBlockedStatusIssues(ctx, state, currentBlockedStatusIssues, now)
 	} else {
-		o.trackCandidateBlockedStatusIssues(state, fetched.candidates, now)
+		o.trackCandidateBlockedStatusIssues(ctx, state, fetched.candidates, now)
 	}
 	o.dispatchReadyIssues(ctx, state, issues, now)
 }

--- a/internal/staleness/staleness.go
+++ b/internal/staleness/staleness.go
@@ -19,6 +19,7 @@ const (
 	KindRepeatedDecision         = "repeated_decision"
 	defaultWarningIDLength       = 16
 	ReasonBlockedCauseUnrecorded = "blocked, cause unrecorded"
+	ReasonBlockedOutsideDetent   = "blocked outside Detent; no cause recorded by the tracker"
 )
 
 type Config struct {

--- a/internal/web/templates/board_data.go
+++ b/internal/web/templates/board_data.go
@@ -1657,7 +1657,8 @@ func boardCardBlockedWaitingText(card projectKanbanCard) string {
 }
 
 func boardBlockedWaiting(source telemetry.BlockedSource, recoveryAction string, recoveryReason string, reason string) bool {
-	if strings.EqualFold(strings.TrimSpace(reason), staleness.ReasonBlockedCauseUnrecorded) {
+	if strings.EqualFold(strings.TrimSpace(reason), staleness.ReasonBlockedCauseUnrecorded) ||
+		strings.EqualFold(strings.TrimSpace(reason), staleness.ReasonBlockedOutsideDetent) {
 		return false
 	}
 	switch strings.ToLower(strings.TrimSpace(recoveryAction)) {

--- a/internal/web/templates/board_data_test.go
+++ b/internal/web/templates/board_data_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/digitaldrywood/detent/internal/agentidentity"
 	"github.com/digitaldrywood/detent/internal/efficiency"
 	"github.com/digitaldrywood/detent/internal/observability"
+	"github.com/digitaldrywood/detent/internal/staleness"
 	"github.com/digitaldrywood/detent/internal/telemetry"
 	"github.com/digitaldrywood/detent/internal/web/ui/primitives"
 )
@@ -1967,6 +1968,15 @@ func TestBoardBlockedCauseBadge(t *testing.T) {
 			wantText: "needs review - blocked, cause unrecorded",
 		},
 		{
+			name: "external block without tracker cause needs review",
+			card: projectKanbanCard{
+				BlockedSource: telemetry.BlockedSourceProjectStatus,
+				BlockedReason: staleness.ReasonBlockedOutsideDetent,
+			},
+			wantKind: primitives.KindErr,
+			wantText: "needs review - " + staleness.ReasonBlockedOutsideDetent,
+		},
+		{
 			name: "human delivery failure needs review",
 			card: projectKanbanCard{
 				BlockedSource:         telemetry.BlockedSourceProjectStatus,
@@ -1992,6 +2002,47 @@ func TestBoardBlockedCauseBadge(t *testing.T) {
 				t.Fatalf("boardCardExtra() exposed unnamed dependency: %q", text)
 			}
 		})
+	}
+}
+
+func TestBoardBlockedTimelineCauseRendersRecordedReason(t *testing.T) {
+	t.Parallel()
+
+	data := boardTestData()
+	blockedAt := data.Snapshot.GeneratedAt.Add(-time.Minute)
+	cause := "current tracker lane is not worker-owned"
+	data.Snapshot.Blocked = []telemetry.Blocked{{
+		Issue: telemetry.Issue{
+			ID:         "issue-revoked-block",
+			Identifier: "digitaldrywood/detent#1995",
+			ProjectID:  "detent",
+			Title:      "Revoked worker lane",
+			State:      "Blocked",
+		},
+		Error:     cause,
+		Source:    telemetry.BlockedSourceProjectStatus,
+		BlockedAt: &blockedAt,
+	}}
+
+	view := boardViewFromDashboard(data)
+	var card boardCardView
+	for _, lane := range view.Lanes {
+		for _, candidate := range lane.Cards {
+			if candidate.IssueID == "issue-revoked-block" {
+				card = candidate
+			}
+		}
+	}
+	if card.IssueID == "" {
+		t.Fatalf("rendered board missing revoked Blocked card: %#v", view.Lanes)
+	}
+
+	html := renderBoardComponent(t, boardCardView2(card))
+	if !strings.Contains(html, cause) {
+		t.Fatalf("rendered blocked card missing timeline cause %q:\n%s", cause, html)
+	}
+	if strings.Contains(html, "cause unrecorded") {
+		t.Fatalf("rendered blocked card contradicted its timeline:\n%s", html)
 	}
 }
 


### PR DESCRIPTION
## Summary

- restore Detent-authored Blocked causes from current runtime state and durable workflow history before consulting tracker fields
- define the precedence as Detent cause, tracker reason, unresolved dependencies, then an explicit external-block fallback
- add reconciliation and rendered-card invariants for live parks, restart recovery, tracker blocks, dependencies, external blocks, and lane revocation

Fixes #1995

## UI Surface Contract

- [x] The linked issue explicitly authorizes this operator-facing blocked-cause correction.
- [x] This PR does not add persistent top-of-screen messaging.
- [x] Browser verification used an isolated random-port real handler. The semantic snapshot and viewport checks showed the recorded revocation cause on both the Blocked card and detail sheet, with no cause-unrecorded text.

## Test Plan

- [x] `PATH="$TMPDIR/issue-1995-pinned-bin:$PATH" GOTOOLCHAIN=go1.26.6 make check`
- [x] `go test ./internal/orchestrator -count=1`
- [x] `go test ./internal/staleness -count=1`
- [x] focused rendered-card template tests
- [x] isolated Chrome DevTools verification against an `httptest` random-port server