### PR TITLE
fix(orchestrator): preserve pushed lane-revocation work

### DIFF
--- a/db/queries/store.sql
+++ b/db/queries/store.sql
@@ -104,6 +104,11 @@ SET completed_at = sqlc.arg(completed_at),
     skill_draft_proposed = sqlc.arg(skill_draft_proposed)
 WHERE id = sqlc.arg(id);
 
+-- name: UpdateCodexSessionFinalStateByWorkAttempt :exec
+UPDATE codex_sessions
+SET final_state = sqlc.arg(final_state)
+WHERE work_attempt_id = sqlc.arg(work_attempt_id);
+
 -- name: UpdateCodexSessionIdentity :execrows
 UPDATE codex_sessions
 SET agent_backend_id = COALESCE(sqlc.narg(agent_backend_id), agent_backend_id),

--- a/internal/orchestrator/dispatch_test.go
+++ b/internal/orchestrator/dispatch_test.go
@@ -3641,6 +3641,7 @@ type recordingWorkAttemptStore struct {
 	starts                  []store.WorkAttemptStart
 	heartbeats              []store.WorkAttemptHeartbeat
 	completions             []store.WorkAttemptCompletion
+	completionErrors        []error
 	decisions               []store.SchedulerDecision
 	reclaimed               []store.WorkAttempt
 	recent                  []store.WorkAttempt
@@ -3689,6 +3690,11 @@ func (s *recordingWorkAttemptStore) RecordWorkAttemptHeartbeat(_ context.Context
 
 func (s *recordingWorkAttemptStore) CompleteWorkAttempt(_ context.Context, attrs store.WorkAttemptCompletion) error {
 	s.completions = append(s.completions, attrs)
+	if len(s.completionErrors) > 0 {
+		err := s.completionErrors[0]
+		s.completionErrors = s.completionErrors[1:]
+		return err
+	}
 	return nil
 }
 

--- a/internal/orchestrator/lane_revocation.go
+++ b/internal/orchestrator/lane_revocation.go
@@ -22,7 +22,33 @@ const (
 	laneRevocationDetentStateChanged         = "detent_tracker_lane_changed"
 	laneRevocationDetentErrorClass           = "detent_lane_revoked"
 	laneRevocationCompletionFenceUnavailable = "completion_fence_unavailable"
+	laneRevocationDeliveredClassification    = "delivered_before_revocation"
+	laneRevocationDiscardedClassification    = "unpushed_work_discarded"
+	laneRevocationEmptyClassification        = "revoked_without_work"
+	laneRevocationDeliveryReceiptKind        = "pushed_work_product"
 )
+
+type laneRevocationDeliveryReceipt struct {
+	Schema     int       `json:"schema"`
+	Kind       string    `json:"kind"`
+	RecordedAt time.Time `json:"recorded_at"`
+	Source     string    `json:"source"`
+	PRNumber   int       `json:"pr_number,omitempty"`
+	PRHeadSHA  string    `json:"pr_head_sha,omitempty"`
+}
+
+type laneRevocationOutcome struct {
+	classification    string
+	terminalState     store.WorkAttemptTerminalState
+	sessionFinalState string
+	errorClass        string
+	errorMessage      string
+	phase             string
+	statusMessage     string
+	activityEvent     string
+	comment           bool
+	workDiscarded     bool
+}
 
 type pendingLaneRevocation struct {
 	issue         connector.Issue
@@ -259,48 +285,60 @@ func (o *Orchestrator) finishLaneRevocation(ctx context.Context, state *State, p
 		tokens = running.Tokens
 	}
 	running.Tokens = tokens
-	workDiscarded := laneRevocationDiscardedWork(event, running, tokens)
-	errorClass := laneRevocationErrorClass(pending.reason, pending.origin)
-	state.TokenTotals = addTokenTotals(state.TokenTotals, tokens)
-	state.RateLimits = mergeRateLimits(state.RateLimits, event.Result.RateLimits)
-	o.recordProjectAttemptOutcome(
-		state,
-		event.IssueID,
-		completedAt,
-		store.WorkAttemptTerminalLaneRevoked,
-		runpkg.ErrLaneRevoked,
-		errorClass,
-		pending.reason,
-	)
-	o.completeDurableWorkAttemptWithMetadata(
+	running.WorkProductPushed = running.WorkProductPushed || event.Result.PullRequestHeadPushed || event.Result.PullRequestUpdated
+	receipt := laneRevocationReceipt(event, running, completedAt)
+	outcome := classifyLaneRevocation(receipt, laneRevocationProducedWork(event, running, tokens), pending.reason, pending.origin)
+	metadata := map[string]any{"lane_revocation": map[string]any{
+		"classification":  outcome.classification,
+		"generation":      pending.generation,
+		"from_state":      pending.fromState,
+		"to_state":        pending.toState,
+		"reason":          pending.reason,
+		"origin":          pending.origin,
+		"requested_at":    pending.requestedAt,
+		"reap_outcome":    pending.reapOutcome,
+		"work_discarded":  outcome.workDiscarded,
+		"output_tokens":   tokens.OutputTokens,
+		"total_tokens":    tokens.TotalTokens,
+		"runtime_seconds": tokens.RuntimeSeconds,
+		"turns":           running.TurnCount,
+		"files_changed":   running.DiffStats.FilesChanged,
+	}}
+	if receipt != nil {
+		metadata["delivery_receipt"] = receipt
+	}
+	attemptCompleted := o.completeDurableWorkAttemptWithSessionState(
 		ctx,
 		state,
 		running,
 		completedAt,
-		store.WorkAttemptTerminalLaneRevoked,
-		errorClass,
-		pending.reason,
-		"lane_revoked",
-		"worker stopped after leaving a worker-owned lane",
-		map[string]any{"lane_revocation": map[string]any{
-			"generation":      pending.generation,
-			"from_state":      pending.fromState,
-			"to_state":        pending.toState,
-			"reason":          pending.reason,
-			"origin":          pending.origin,
-			"requested_at":    pending.requestedAt,
-			"reap_outcome":    pending.reapOutcome,
-			"work_discarded":  workDiscarded,
-			"output_tokens":   tokens.OutputTokens,
-			"total_tokens":    tokens.TotalTokens,
-			"runtime_seconds": tokens.RuntimeSeconds,
-			"turns":           running.TurnCount,
-			"files_changed":   running.DiffStats.FilesChanged,
-		}},
+		outcome.terminalState,
+		outcome.sessionFinalState,
+		outcome.errorClass,
+		outcome.errorMessage,
+		outcome.phase,
+		outcome.statusMessage,
+		metadata,
 	)
-	if workDiscarded {
-		o.reportLaneRevocationDiscardedWork(ctx, state, pending, event, running, tokens)
+	if o.workAttempts != nil && running.WorkAttemptID > 0 && !attemptCompleted {
+		return
 	}
+	state.TokenTotals = addTokenTotals(state.TokenTotals, tokens)
+	state.RateLimits = mergeRateLimits(state.RateLimits, event.Result.RateLimits)
+	attemptErr := error(nil)
+	if outcome.terminalState == store.WorkAttemptTerminalLaneRevoked {
+		attemptErr = runpkg.ErrLaneRevoked
+	}
+	o.recordProjectAttemptOutcome(
+		state,
+		event.IssueID,
+		completedAt,
+		outcome.terminalState,
+		attemptErr,
+		outcome.errorClass,
+		outcome.errorMessage,
+	)
+	o.reportLaneRevocationOutcome(ctx, state, pending, event, running, tokens, outcome)
 	delete(o.pendingLaneRevocations, event.IssueID)
 	delete(state.Running, event.IssueID)
 	delete(state.Claimed, event.IssueID)
@@ -372,7 +410,59 @@ func laneRevocationErrorClass(reason string, origin provenance.Origin) string {
 	return string(store.WorkAttemptTerminalLaneRevoked)
 }
 
-func laneRevocationDiscardedWork(event runpkg.Completion, running Running, tokens TokenTotals) bool {
+func laneRevocationReceipt(event runpkg.Completion, running Running, completedAt time.Time) *laneRevocationDeliveryReceipt {
+	if !running.WorkProductPushed {
+		return nil
+	}
+	source := "work_attempt"
+	if event.Result.PullRequestHeadPushed || event.Result.PullRequestUpdated {
+		source = "runner_result"
+	}
+	receipt := &laneRevocationDeliveryReceipt{
+		Schema:     1,
+		Kind:       laneRevocationDeliveryReceiptKind,
+		RecordedAt: completedAt,
+		Source:     source,
+	}
+	if running.Issue.PullRequest != nil {
+		receipt.PRNumber = running.Issue.PullRequest.Number
+		receipt.PRHeadSHA = strings.TrimSpace(running.Issue.PullRequest.HeadSHA)
+	}
+	return receipt
+}
+
+func classifyLaneRevocation(receipt *laneRevocationDeliveryReceipt, workProduced bool, reason string, origin provenance.Origin) laneRevocationOutcome {
+	if receipt != nil && receipt.Schema == 1 && receipt.Kind == laneRevocationDeliveryReceiptKind {
+		return laneRevocationOutcome{
+			classification:    laneRevocationDeliveredClassification,
+			terminalState:     store.WorkAttemptTerminalDelivered,
+			sessionFinalState: string(store.WorkAttemptTerminalDelivered),
+			phase:             "completed",
+			statusMessage:     "work was pushed but finalization was rejected",
+			activityEvent:     "worker_lane_delivery_preserved",
+			comment:           true,
+		}
+	}
+	outcome := laneRevocationOutcome{
+		classification:    laneRevocationEmptyClassification,
+		terminalState:     store.WorkAttemptTerminalLaneRevoked,
+		sessionFinalState: runpkg.FinalStateLaneRevoked,
+		errorClass:        laneRevocationErrorClass(reason, origin),
+		errorMessage:      strings.TrimSpace(reason),
+		phase:             "lane_revoked",
+		statusMessage:     "worker stopped after leaving a worker-owned lane",
+		activityEvent:     "worker_lane_revoked",
+	}
+	if workProduced {
+		outcome.classification = laneRevocationDiscardedClassification
+		outcome.activityEvent = "worker_lane_output_discarded"
+		outcome.comment = true
+		outcome.workDiscarded = true
+	}
+	return outcome
+}
+
+func laneRevocationProducedWork(event runpkg.Completion, running Running, tokens TokenTotals) bool {
 	return event.Result.TurnStarted ||
 		running.TurnCount > 0 ||
 		strings.TrimSpace(event.Result.Output) != "" ||
@@ -380,53 +470,67 @@ func laneRevocationDiscardedWork(event runpkg.Completion, running Running, token
 		tokens.OutputTokens > 0 ||
 		tokens.TotalTokens > 0 ||
 		diffStatsPresent(event.Result.DiffStats) ||
-		diffStatsPresent(running.DiffStats) ||
-		running.WorkProductPushed
+		diffStatsPresent(running.DiffStats)
 }
 
-func (o *Orchestrator) reportLaneRevocationDiscardedWork(
+func (o *Orchestrator) reportLaneRevocationOutcome(
 	ctx context.Context,
 	state *State,
 	pending *pendingLaneRevocation,
 	event runpkg.Completion,
 	running Running,
 	tokens TokenTotals,
+	outcome laneRevocationOutcome,
 ) {
 	at := event.CompletedAt.UTC()
 	if at.IsZero() {
 		at = o.clockNow().UTC()
 	}
 	origin := string(provenance.NormalizeOrigin(pending.origin))
+	message := "worker for " + issueLabel(running.Issue) + " was stopped after a " + origin + " lane change from " + pending.fromState + " to " + pending.toState
+	if outcome.terminalState == store.WorkAttemptTerminalDelivered {
+		message = "pushed work for " + issueLabel(running.Issue) + " was preserved after finalization was rejected by a " + origin + " lane change from " + pending.fromState + " to " + pending.toState
+	} else if outcome.workDiscarded {
+		message = "unpushed worker output for " + issueLabel(running.Issue) + " was discarded after a " + origin + " lane change from " + pending.fromState + " to " + pending.toState
+	}
 	recordStateEvent(state, telemetry.ActivityEvent{
 		At:      at,
-		Event:   "worker_lane_output_discarded",
-		Message: "worker output for " + issueLabel(running.Issue) + " was discarded after a " + origin + " lane change from " + pending.fromState + " to " + pending.toState,
+		Event:   outcome.activityEvent,
+		Message: message,
 	})
-	if o.connector == nil {
+	if !outcome.comment || o.connector == nil {
 		return
 	}
-	body := laneRevocationDiscardedWorkComment(pending, event, running, tokens)
+	body := laneRevocationOutcomeComment(pending, event, running, tokens, outcome)
 	if err := o.connector.CreateComment(context.WithoutCancel(ctx), running.Issue.ID, body); err != nil {
 		recordStateEvent(state, telemetry.ActivityEvent{
 			At:      at,
-			Event:   "worker_lane_output_discard_notice_failed",
-			Message: "failed to report discarded worker output for " + issueLabel(running.Issue) + ": " + err.Error(),
+			Event:   "worker_lane_outcome_notice_failed",
+			Message: "failed to report lane-revocation outcome for " + issueLabel(running.Issue) + ": " + err.Error(),
 		})
 		if o.logger != nil {
-			o.logger.Warn("discarded worker output comment failed", "issue_id", running.Issue.ID, "identifier", running.Issue.Identifier, "error", err)
+			o.logger.Warn("lane revocation outcome comment failed", "issue_id", running.Issue.ID, "identifier", running.Issue.Identifier, "error", err)
 		}
 	}
 }
 
-func laneRevocationDiscardedWorkComment(
+func laneRevocationOutcomeComment(
 	pending *pendingLaneRevocation,
 	event runpkg.Completion,
 	running Running,
 	tokens TokenTotals,
+	outcome laneRevocationOutcome,
 ) string {
 	var b strings.Builder
-	b.WriteString("Detent stopped this worker after the tracker moved the issue out of a worker-owned lane. The session produced work that was not accepted by the completion fence.")
-	b.WriteString("\n\n- reason: worker_lane_revocation_output_discarded")
+	if outcome.terminalState == store.WorkAttemptTerminalDelivered {
+		b.WriteString("Detent stopped this worker after the tracker moved the issue out of a worker-owned lane. Your work was pushed but finalization was rejected; the pushed work remains available.")
+		b.WriteString("\n\n- reason: worker_lane_revocation_delivery_preserved")
+	} else {
+		b.WriteString("Detent stopped this worker after the tracker moved the issue out of a worker-owned lane. The session produced work that was not pushed and could not be delivered.")
+		b.WriteString("\n\n- reason: worker_lane_revocation_output_discarded")
+	}
+	b.WriteString("\n- classification: ")
+	b.WriteString(outcome.classification)
 	b.WriteString("\n- revocation_reason: ")
 	b.WriteString(pending.reason)
 	b.WriteString("\n- lane_change_origin: ")

--- a/internal/orchestrator/lane_revocation_test.go
+++ b/internal/orchestrator/lane_revocation_test.go
@@ -113,6 +113,204 @@ func TestLaneRevocationPreservesTrackerDestination(t *testing.T) {
 	}
 }
 
+func TestLaneRevocationPreservesPushedWork(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 8, 27, 10, 30, 0, 0, time.UTC)
+	issue := laneRevocationIssue("issue-delivered", "digitaldrywood/detent#1998", "In Progress")
+	issue.PullRequest = &connector.PullRequest{Number: 2001, HeadSHA: "abc123"}
+	parked := cloneIssue(issue)
+	parked.State = "Human Review"
+	tracker := &autoPromoteTickConnector{stateIssues: []connector.Issue{parked}}
+	attempts := &recordingWorkAttemptStore{}
+	cfg := normalizeConfig(Config{
+		Project:        scheduler.ProjectCandidate{ID: "detent"},
+		ActiveStates:   []string{"Todo", "In Progress", "Rework", "Merging"},
+		ObservedStates: []string{"Human Review"},
+	})
+	orch := &Orchestrator{
+		cfg:                    cfg,
+		connector:              tracker,
+		workAttempts:           attempts,
+		pendingLaneRevocations: map[string]*pendingLaneRevocation{},
+		logger:                 slog.New(slog.NewTextHandler(io.Discard, nil)),
+		now:                    func() time.Time { return now },
+	}
+	state := newState(cfg)
+	state.Running[issue.ID] = Running{
+		Issue:         issue,
+		Attempt:       4,
+		WorkAttemptID: 1998,
+		Generation:    3,
+		StartedAt:     now.Add(-time.Hour),
+		Tokens:        runpkg.TokenTotals{OutputTokens: 2_000, TotalTokens: 8_000, RuntimeSeconds: 600},
+	}
+
+	orch.reconcileRunningIssues(t.Context(), &state, now)
+	orch.handleRunResult(t.Context(), &state, runpkg.Completion{
+		IssueID: issue.ID,
+		Request: runpkg.RunRequest{Issue: issue, WorkAttemptID: 1998, Generation: 3},
+		Result: runpkg.RunResult{
+			FinalState:            runpkg.FinalStateLaneRevoked,
+			Output:                "pushed PR head",
+			TurnStarted:           true,
+			PullRequestHeadPushed: true,
+		},
+		CompletedAt: now.Add(time.Second),
+		Err:         runpkg.ErrLaneRevoked,
+	})
+
+	if len(attempts.completions) != 1 {
+		t.Fatalf("work attempt completions = %#v, want one", attempts.completions)
+	}
+	completion := attempts.completions[0]
+	if completion.TerminalState != store.WorkAttemptTerminalDelivered {
+		t.Fatalf("terminal state = %q, want delivered", completion.TerminalState)
+	}
+	if completion.SessionFinalState != "delivered" {
+		t.Fatalf("session final state = %q, want delivered", completion.SessionFinalState)
+	}
+	if !strings.Contains(completion.WorkerMetadataJSON, `"delivery_receipt":{"schema":1,"kind":"pushed_work_product"`) {
+		t.Fatalf("worker metadata = %s, want durable pushed-work receipt", completion.WorkerMetadataJSON)
+	}
+	if strings.Contains(completion.WorkerMetadataJSON, `"work_discarded":true`) {
+		t.Fatalf("worker metadata = %s, must not mark pushed work discarded", completion.WorkerMetadataJSON)
+	}
+	if len(tracker.comments) != 1 || !strings.Contains(tracker.comments[0].body, "work was pushed but finalization was rejected") {
+		t.Fatalf("comments = %#v, want pushed-work finalization notice", tracker.comments)
+	}
+	if hasLaneRevocationEvent(state.RecentEvents, "worker_lane_output_discarded") {
+		t.Fatalf("RecentEvents = %#v, must not report discarded output", state.RecentEvents)
+	}
+	if !hasLaneRevocationEvent(state.RecentEvents, "worker_lane_delivery_preserved") {
+		t.Fatalf("RecentEvents = %#v, want preserved delivery event", state.RecentEvents)
+	}
+}
+
+func TestLaneRevocationAccountsTokensAfterDurableCompletion(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 8, 27, 20, 45, 0, 0, time.UTC)
+	issue := laneRevocationIssue("issue-completion-retry", "digitaldrywood/detent#1998", "In Progress")
+	parked := cloneIssue(issue)
+	parked.State = "Human Review"
+	tracker := &autoPromoteTickConnector{stateIssues: []connector.Issue{parked}}
+	attempts := &recordingWorkAttemptStore{completionErrors: []error{errors.New("store unavailable")}}
+	cfg := normalizeConfig(Config{
+		Project:        scheduler.ProjectCandidate{ID: "detent"},
+		ActiveStates:   []string{"Todo", "In Progress", "Rework", "Merging"},
+		ObservedStates: []string{"Human Review"},
+	})
+	orch := &Orchestrator{
+		cfg:                    cfg,
+		connector:              tracker,
+		workAttempts:           attempts,
+		pendingLaneRevocations: map[string]*pendingLaneRevocation{},
+		logger:                 slog.New(slog.NewTextHandler(io.Discard, nil)),
+		now:                    func() time.Time { return now },
+	}
+	state := newState(cfg)
+	state.TokenTotals = TokenTotals{InputTokens: 3, OutputTokens: 2, TotalTokens: 5, RuntimeSeconds: 1}
+	state.Running[issue.ID] = Running{
+		Issue:         issue,
+		WorkAttemptID: 1998,
+		Generation:    4,
+		StartedAt:     now.Add(-time.Minute),
+		Tokens:        TokenTotals{InputTokens: 30, OutputTokens: 20, TotalTokens: 50, RuntimeSeconds: 10},
+	}
+
+	orch.reconcileRunningIssues(t.Context(), &state, now)
+	orch.handleRunResult(t.Context(), &state, runpkg.Completion{
+		IssueID:     issue.ID,
+		Request:     runpkg.RunRequest{Issue: issue, WorkAttemptID: 1998, Generation: 4},
+		CompletedAt: now.Add(time.Second),
+		Err:         runpkg.ErrLaneRevoked,
+		Result:      runpkg.RunResult{FinalState: runpkg.FinalStateLaneRevoked},
+	})
+
+	if got := state.TokenTotals.TotalTokens; got != 5 {
+		t.Fatalf("token total after failed completion = %d, want 5", got)
+	}
+	pending := orch.pendingLaneRevocations[issue.ID]
+	if pending == nil {
+		t.Fatal("pending lane revocation missing after failed completion")
+	}
+	orch.finishLaneRevocation(t.Context(), &state, pending)
+
+	if got := state.TokenTotals.TotalTokens; got != 55 {
+		t.Fatalf("token total after completion retry = %d, want 55", got)
+	}
+	if len(attempts.completions) != 2 {
+		t.Fatalf("work attempt completion calls = %d, want 2", len(attempts.completions))
+	}
+	if _, ok := orch.pendingLaneRevocations[issue.ID]; ok {
+		t.Fatal("pending lane revocation retained after successful retry")
+	}
+}
+
+func TestClassifyLaneRevocationDrivesAllOutcomeSurfaces(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name          string
+		receipt       *laneRevocationDeliveryReceipt
+		workProduced  bool
+		wantClass     string
+		wantTerminal  store.WorkAttemptTerminalState
+		wantSession   string
+		wantEvent     string
+		wantComment   bool
+		wantDiscarded bool
+	}{
+		{
+			name:         "pushed work with rejected finalization",
+			receipt:      &laneRevocationDeliveryReceipt{Schema: 1, Kind: laneRevocationDeliveryReceiptKind},
+			workProduced: true,
+			wantClass:    laneRevocationDeliveredClassification,
+			wantTerminal: store.WorkAttemptTerminalDelivered,
+			wantSession:  "delivered",
+			wantEvent:    "worker_lane_delivery_preserved",
+			wantComment:  true,
+		},
+		{
+			name:          "genuinely unpushed work",
+			workProduced:  true,
+			wantClass:     laneRevocationDiscardedClassification,
+			wantTerminal:  store.WorkAttemptTerminalLaneRevoked,
+			wantSession:   runpkg.FinalStateLaneRevoked,
+			wantEvent:     "worker_lane_output_discarded",
+			wantComment:   true,
+			wantDiscarded: true,
+		},
+		{
+			name:         "revoked before work",
+			wantClass:    laneRevocationEmptyClassification,
+			wantTerminal: store.WorkAttemptTerminalLaneRevoked,
+			wantSession:  runpkg.FinalStateLaneRevoked,
+			wantEvent:    "worker_lane_revoked",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := classifyLaneRevocation(tt.receipt, tt.workProduced, laneRevocationStateChanged, provenance.OriginHuman)
+			if got.classification != tt.wantClass || got.terminalState != tt.wantTerminal || got.sessionFinalState != tt.wantSession {
+				t.Fatalf("classification = %#v, want class %q terminal %q session %q", got, tt.wantClass, tt.wantTerminal, tt.wantSession)
+			}
+			if got.activityEvent != tt.wantEvent || got.comment != tt.wantComment || got.workDiscarded != tt.wantDiscarded {
+				t.Fatalf("rendering outcome = %#v, want event %q comment %v discarded %v", got, tt.wantEvent, tt.wantComment, tt.wantDiscarded)
+			}
+			if got.terminalState == store.WorkAttemptTerminalDelivered {
+				if got.errorClass != "" || got.errorMessage != "" || strings.Contains(got.statusMessage, "discard") || strings.Contains(got.activityEvent, "discard") {
+					t.Fatalf("delivered outcome contains revoked/discarded surface: %#v", got)
+				}
+			}
+		})
+	}
+}
+
 func TestCompletionLaneHandshakeClassifiesCurrentAttempt(t *testing.T) {
 	t.Parallel()
 

--- a/internal/orchestrator/work_attempts.go
+++ b/internal/orchestrator/work_attempts.go
@@ -415,6 +415,22 @@ func (o *Orchestrator) completeDurableWorkAttemptWithMetadata(
 	statusMessage string,
 	metadata map[string]any,
 ) bool {
+	return o.completeDurableWorkAttemptWithSessionState(ctx, state, running, completedAt, terminalState, "", errorClass, errorMessage, phase, statusMessage, metadata)
+}
+
+func (o *Orchestrator) completeDurableWorkAttemptWithSessionState(
+	ctx context.Context,
+	state *State,
+	running Running,
+	completedAt time.Time,
+	terminalState store.WorkAttemptTerminalState,
+	sessionFinalState string,
+	errorClass string,
+	errorMessage string,
+	phase string,
+	statusMessage string,
+	metadata map[string]any,
+) bool {
 	if o == nil || o.workAttempts == nil || running.WorkAttemptID <= 0 {
 		return false
 	}
@@ -441,6 +457,7 @@ func (o *Orchestrator) completeDurableWorkAttemptWithMetadata(
 		CompletedAt:            completedAt,
 		Status:                 store.WorkAttemptStatusTerminal,
 		TerminalState:          terminalState,
+		SessionFinalState:      strings.TrimSpace(sessionFinalState),
 		ErrorClass:             strings.TrimSpace(errorClass),
 		ErrorMessage:           o.operatorText(errorMessage),
 		Phase:                  phase,

--- a/internal/store/migrations/00045_backfill_lane_revocation_delivery_receipts.sql
+++ b/internal/store/migrations/00045_backfill_lane_revocation_delivery_receipts.sql
@@ -1,0 +1,93 @@
+-- +goose Up
+UPDATE work_attempts
+SET worker_metadata_json = json_set(
+      CASE WHEN json_valid(worker_metadata_json) THEN worker_metadata_json ELSE '{}' END,
+      '$.delivery_receipt',
+      json_object(
+        'schema', 1,
+        'kind', 'pushed_work_product',
+        'recorded_at', completed_at,
+        'source', 'historical_backfill',
+        'pr_number', json_extract(worker_metadata_json, '$.pr_number'),
+        'pr_head_sha', json_extract(worker_metadata_json, '$.pr_head_sha')
+      ),
+      '$.lane_revocation_receipt_backfill',
+      json_object(
+        'migration', 45,
+        'original_terminal_state', COALESCE(terminal_state, ''),
+        'original_error_class', COALESCE(error_class, ''),
+        'original_error_message', COALESCE(error_message, ''),
+        'original_phase', COALESCE(phase, ''),
+        'original_status_message', COALESCE(status_message, ''),
+        'original_worker_metadata_json', CASE WHEN json_valid(worker_metadata_json) THEN worker_metadata_json ELSE '{}' END
+      )
+    )
+WHERE json_type(
+        CASE WHEN json_valid(worker_metadata_json) THEN worker_metadata_json ELSE '{}' END,
+        '$.delivery_receipt'
+      ) IS NULL
+  AND (
+    (
+      lower(trim(COALESCE(terminal_state, ''))) = 'delivered'
+      AND json_extract(worker_metadata_json, '$.historical_lane_revocation.classification') = 'delivered_before_revocation'
+    )
+    OR (
+      lower(trim(COALESCE(terminal_state, ''))) = 'lane_revoked'
+      AND lower(trim(COALESCE(error_message, ''))) IN ('tracker_lane_changed', 'detent_tracker_lane_changed')
+      AND json_extract(
+        CASE WHEN json_valid(worker_metadata_json) THEN worker_metadata_json ELSE '{}' END,
+        '$.work_product_pushed'
+      ) = 1
+    )
+  );
+
+UPDATE work_attempts
+SET terminal_state = 'delivered',
+    error_class = NULL,
+    error_message = NULL,
+    phase = 'completed',
+    status_message = 'work was pushed but finalization was rejected',
+    worker_metadata_json = json_set(
+      worker_metadata_json,
+      '$.lane_revocation.classification', 'delivered_before_revocation',
+      '$.lane_revocation.work_discarded', json('false')
+    )
+WHERE json_extract(worker_metadata_json, '$.lane_revocation_receipt_backfill.migration') = 45
+  AND json_extract(worker_metadata_json, '$.delivery_receipt.schema') = 1
+  AND json_extract(worker_metadata_json, '$.delivery_receipt.kind') = 'pushed_work_product';
+
+UPDATE codex_sessions
+SET final_state = 'delivered'
+WHERE EXISTS (
+  SELECT 1
+  FROM work_attempts
+  WHERE work_attempts.id = codex_sessions.work_attempt_id
+    AND lower(trim(COALESCE(work_attempts.terminal_state, ''))) = 'delivered'
+    AND json_extract(work_attempts.worker_metadata_json, '$.lane_revocation_receipt_backfill.migration') = 45
+    AND json_extract(work_attempts.worker_metadata_json, '$.delivery_receipt.schema') = 1
+    AND json_extract(work_attempts.worker_metadata_json, '$.delivery_receipt.kind') = 'pushed_work_product'
+);
+
+-- +goose Down
+UPDATE codex_sessions
+SET final_state = COALESCE((
+  SELECT NULLIF(json_extract(work_attempts.worker_metadata_json, '$.lane_revocation_receipt_backfill.original_terminal_state'), '')
+  FROM work_attempts
+  WHERE work_attempts.id = codex_sessions.work_attempt_id
+    AND json_extract(work_attempts.worker_metadata_json, '$.lane_revocation_receipt_backfill.migration') = 45
+), final_state)
+WHERE EXISTS (
+  SELECT 1
+  FROM work_attempts
+  WHERE work_attempts.id = codex_sessions.work_attempt_id
+    AND json_extract(work_attempts.worker_metadata_json, '$.lane_revocation_receipt_backfill.migration') = 45
+);
+
+UPDATE work_attempts
+SET terminal_state = NULLIF(json_extract(worker_metadata_json, '$.lane_revocation_receipt_backfill.original_terminal_state'), ''),
+    error_class = NULLIF(json_extract(worker_metadata_json, '$.lane_revocation_receipt_backfill.original_error_class'), ''),
+    error_message = NULLIF(json_extract(worker_metadata_json, '$.lane_revocation_receipt_backfill.original_error_message'), ''),
+    phase = NULLIF(json_extract(worker_metadata_json, '$.lane_revocation_receipt_backfill.original_phase'), ''),
+    status_message = NULLIF(json_extract(worker_metadata_json, '$.lane_revocation_receipt_backfill.original_status_message'), ''),
+    worker_metadata_json = json_extract(worker_metadata_json, '$.lane_revocation_receipt_backfill.original_worker_metadata_json')
+WHERE json_extract(worker_metadata_json, '$.lane_revocation_receipt_backfill.migration') = 45;

--- a/internal/store/sqlc/store.sql.go
+++ b/internal/store/sqlc/store.sql.go
@@ -4230,6 +4230,22 @@ func (q *Queries) UpdateAPIKeyLastUsed(ctx context.Context, arg UpdateAPIKeyLast
 	return result.RowsAffected()
 }
 
+const updateCodexSessionFinalStateByWorkAttempt = `-- name: UpdateCodexSessionFinalStateByWorkAttempt :exec
+UPDATE codex_sessions
+SET final_state = ?1
+WHERE work_attempt_id = ?2
+`
+
+type UpdateCodexSessionFinalStateByWorkAttemptParams struct {
+	FinalState    sql.NullString `json:"final_state"`
+	WorkAttemptID sql.NullInt64  `json:"work_attempt_id"`
+}
+
+func (q *Queries) UpdateCodexSessionFinalStateByWorkAttempt(ctx context.Context, arg UpdateCodexSessionFinalStateByWorkAttemptParams) error {
+	_, err := q.db.ExecContext(ctx, updateCodexSessionFinalStateByWorkAttempt, arg.FinalState, arg.WorkAttemptID)
+	return err
+}
+
 const updateCodexSessionIdentity = `-- name: UpdateCodexSessionIdentity :execrows
 UPDATE codex_sessions
 SET agent_backend_id = COALESCE(?1, agent_backend_id),

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -777,6 +777,7 @@ type WorkAttemptCompletion struct {
 	CompletedAt            time.Time
 	Status                 WorkAttemptStatus
 	TerminalState          WorkAttemptTerminalState
+	SessionFinalState      string
 	ErrorClass             string
 	ErrorMessage           string
 	Phase                  string

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -229,6 +229,145 @@ INSERT INTO codex_sessions (id, work_attempt_id, identifier, started_at, complet
 	}
 }
 
+func TestLaneRevocationDeliveryReceiptMigrationUpDown(t *testing.T) {
+	ctx := t.Context()
+	db, err := sql.Open("sqlite", filepath.Join(t.TempDir(), "detent.db"))
+	if err != nil {
+		t.Fatalf("sql.Open() error = %v", err)
+	}
+	db.SetMaxOpenConns(1)
+	t.Cleanup(func() {
+		if err := db.Close(); err != nil {
+			t.Fatalf("db.Close() error = %v", err)
+		}
+	})
+	if err := configureSQLite(ctx, db, 0); err != nil {
+		t.Fatalf("configureSQLite() error = %v", err)
+	}
+
+	migrationMu.Lock()
+	defer migrationMu.Unlock()
+	goose.SetBaseFS(migrationsFS)
+	defer goose.SetBaseFS(nil)
+	if err := goose.SetDialect("sqlite3"); err != nil {
+		t.Fatalf("goose.SetDialect() error = %v", err)
+	}
+	if err := goose.UpToContext(ctx, db, "migrations", 44); err != nil {
+		t.Fatalf("goose.UpToContext(44) error = %v", err)
+	}
+
+	if _, err := db.ExecContext(ctx, `
+INSERT INTO work_attempts (
+  id, project_id, worker_type, status, started_at, completed_at,
+  terminal_state, error_class, error_message, phase, status_message, worker_metadata_json
+) VALUES
+  (4001, 'detent', 'implementation', 'terminal', '2026-08-27T08:00:00Z', '2026-08-27T09:00:00Z',
+   'lane_revoked', 'lane_revoked', 'tracker_lane_changed', 'lane_revoked', 'worker stopped after leaving a worker-owned lane',
+   '{"work_product_pushed":true,"pr_number":2001,"pr_head_sha":"abc123","lane_revocation":{"work_discarded":true}}'),
+  (4002, 'detent', 'implementation', 'terminal', '2026-08-27T08:00:00Z', '2026-08-27T09:00:00Z',
+   'lane_revoked', 'lane_revoked', 'tracker_lane_changed', 'lane_revoked', 'worker stopped after leaving a worker-owned lane',
+   '{"work_product_pushed":false,"lane_revocation":{"work_discarded":true}}'),
+  (4003, 'detent', 'implementation', 'terminal', '2026-08-27T08:00:00Z', '2026-08-27T09:00:00Z',
+   'lane_revoked', 'lane_revoked', 'operator_hold', 'lane_revoked', 'operator stopped the worker',
+   '{"work_product_pushed":true,"lane_revocation":{"work_discarded":true}}');
+INSERT INTO codex_sessions (id, work_attempt_id, identifier, started_at, completed_at, final_state) VALUES
+  (4101, 4001, 'digitaldrywood/detent#1998', '2026-08-27T08:00:00Z', '2026-08-27T09:00:00Z', 'lane_revoked'),
+  (4102, 4002, 'digitaldrywood/detent#1998', '2026-08-27T08:00:00Z', '2026-08-27T09:00:00Z', 'lane_revoked');
+`); err != nil {
+		t.Fatalf("seed post-migration lane revocations error = %v", err)
+	}
+
+	if err := goose.UpToContext(ctx, db, "migrations", 45); err != nil {
+		t.Fatalf("goose.UpToContext(45) error = %v", err)
+	}
+	if got := queryString(t, db, "SELECT terminal_state FROM work_attempts WHERE id = 4001"); got != "delivered" {
+		t.Fatalf("pushed terminal state = %q, want delivered", got)
+	}
+	if got := queryString(t, db, "SELECT final_state FROM codex_sessions WHERE id = 4101"); got != "delivered" {
+		t.Fatalf("pushed session final state = %q, want delivered", got)
+	}
+	if got := queryString(t, db, "SELECT json_extract(worker_metadata_json, '$.delivery_receipt.kind') FROM work_attempts WHERE id = 4001"); got != "pushed_work_product" {
+		t.Fatalf("delivery receipt kind = %q, want pushed_work_product", got)
+	}
+	if got := queryInt(t, db, "SELECT json_extract(worker_metadata_json, '$.lane_revocation.work_discarded') FROM work_attempts WHERE id = 4001"); got != 0 {
+		t.Fatalf("pushed work_discarded = %d, want false", got)
+	}
+	if got := queryString(t, db, "SELECT terminal_state FROM work_attempts WHERE id = 4002"); got != "lane_revoked" {
+		t.Fatalf("unpushed terminal state = %q, want lane_revoked", got)
+	}
+	if got := queryString(t, db, "SELECT final_state FROM codex_sessions WHERE id = 4102"); got != "lane_revoked" {
+		t.Fatalf("unpushed session final state = %q, want lane_revoked", got)
+	}
+	if got := queryString(t, db, "SELECT terminal_state FROM work_attempts WHERE id = 4003"); got != "lane_revoked" {
+		t.Fatalf("operator hold terminal state = %q, want lane_revoked", got)
+	}
+
+	if err := goose.DownToContext(ctx, db, "migrations", 44); err != nil {
+		t.Fatalf("goose.DownToContext(44) error = %v", err)
+	}
+	if got := queryString(t, db, "SELECT terminal_state FROM work_attempts WHERE id = 4001"); got != "lane_revoked" {
+		t.Fatalf("restored pushed terminal state = %q, want lane_revoked", got)
+	}
+	if got := queryString(t, db, "SELECT final_state FROM codex_sessions WHERE id = 4101"); got != "lane_revoked" {
+		t.Fatalf("restored pushed session final state = %q, want lane_revoked", got)
+	}
+	if got := queryInt(t, db, "SELECT COUNT(*) FROM work_attempts WHERE json_extract(worker_metadata_json, '$.delivery_receipt.kind') IS NOT NULL"); got != 0 {
+		t.Fatalf("delivery receipts after down = %d, want 0", got)
+	}
+}
+
+func TestCompleteWorkAttemptFinalizesLinkedSessionOutcome(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	backend := openTestStore(t, ctx)
+	now := time.Date(2026, 8, 27, 11, 0, 0, 0, time.UTC)
+	attemptID, err := backend.StartWorkAttempt(ctx, WorkAttemptStart{
+		ProjectID:     "detent",
+		IssueID:       "issue-1998",
+		Identifier:    "digitaldrywood/detent#1998",
+		WorkerType:    "implementation",
+		AttemptNumber: 1,
+		StartedAt:     now.Add(-time.Hour),
+	})
+	if err != nil {
+		t.Fatalf("StartWorkAttempt() error = %v", err)
+	}
+	sessionID, err := backend.StartSession(ctx, SessionStart{
+		WorkAttemptID: attemptID,
+		ProjectID:     "detent",
+		IssueID:       "issue-1998",
+		Identifier:    "digitaldrywood/detent#1998",
+		StartedAt:     now.Add(-time.Hour),
+	})
+	if err != nil {
+		t.Fatalf("StartSession() error = %v", err)
+	}
+	if err := backend.FinishSession(ctx, sessionID, SessionFinish{
+		CompletedAt: now,
+		FinalState:  "lane_revoked",
+	}); err != nil {
+		t.Fatalf("FinishSession() error = %v", err)
+	}
+
+	if err := backend.CompleteWorkAttempt(ctx, WorkAttemptCompletion{
+		AttemptID:         attemptID,
+		CompletedAt:       now,
+		TerminalState:     WorkAttemptTerminalDelivered,
+		SessionFinalState: "delivered",
+	}); err != nil {
+		t.Fatalf("CompleteWorkAttempt() error = %v", err)
+	}
+
+	session, err := backend.Queries().GetCodexSession(ctx, sessionID)
+	if err != nil {
+		t.Fatalf("GetCodexSession() error = %v", err)
+	}
+	if session.FinalState.String != "delivered" {
+		t.Fatalf("session final_state = %q, want delivered", session.FinalState.String)
+	}
+}
+
 func TestCachedTokenTelemetryMigrationUpDown(t *testing.T) {
 	ctx := context.Background()
 	dbPath := filepath.Join(t.TempDir(), "detent.db")

--- a/internal/store/work_attempts.go
+++ b/internal/store/work_attempts.go
@@ -149,7 +149,20 @@ func (s *sqliteStore) CompleteWorkAttempt(ctx context.Context, attrs WorkAttempt
 		return err
 	}
 
-	rows, err := s.queries.CompleteWorkAttempt(ctx, sqlc.CompleteWorkAttemptParams{
+	queries := s.queries
+	var tx *sql.Tx
+	if strings.TrimSpace(attrs.SessionFinalState) != "" {
+		tx, err = s.db.BeginTx(ctx, nil)
+		if err != nil {
+			return fmt.Errorf("begin work attempt completion: %w", err)
+		}
+		defer func() {
+			_ = tx.Rollback()
+		}()
+		queries = queries.WithTx(tx)
+	}
+
+	rows, err := queries.CompleteWorkAttempt(ctx, sqlc.CompleteWorkAttemptParams{
 		Status:                 string(status),
 		TerminalState:          nullString(string(terminalState)),
 		CompletedAt:            sql.NullString{String: completedAt, Valid: true},
@@ -174,7 +187,22 @@ func (s *sqliteStore) CompleteWorkAttempt(ctx context.Context, attrs WorkAttempt
 	if err != nil {
 		return fmt.Errorf("completing work attempt: %w", err)
 	}
-	return requireAffected(rows, "work attempt", attrs.AttemptID)
+	if err := requireAffected(rows, "work attempt", attrs.AttemptID); err != nil {
+		return err
+	}
+	if tx == nil {
+		return nil
+	}
+	if err := queries.UpdateCodexSessionFinalStateByWorkAttempt(ctx, sqlc.UpdateCodexSessionFinalStateByWorkAttemptParams{
+		FinalState:    nullString(attrs.SessionFinalState),
+		WorkAttemptID: nullPositiveInt64(attrs.AttemptID),
+	}); err != nil {
+		return fmt.Errorf("updating work attempt session final state: %w", err)
+	}
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("commit work attempt completion: %w", err)
+	}
+	return nil
 }
 
 func (s *sqliteStore) WorkAttempt(ctx context.Context, id int64) (WorkAttempt, error) {


### PR DESCRIPTION
## Summary

- Classify lane revocations from durable pushed-work receipts and drive work-attempt, session, activity, and comment outcomes from one finalizer.
- Distinguish pushed work whose finalization was rejected from genuinely unpushed output that was discarded.
- Backfill post-migration misclassifications and keep linked session outcomes aligned atomically.
- Apply token, rate-limit, and project accounting only after durable completion so retries cannot replay usage.

Fixes #1998

## UI Surface Contract

- [x] N/A, or the linked issue explicitly authorizes any high-impact UI surface, layout, density, first-viewport, or responsive visibility tradeoff.
- [x] Persistent top-of-screen messaging is explicitly authorized by the issue, or this PR does not add it.
- [x] Visual changes to primary operator screens include screenshot or browser verification below.

## Test Plan

- [x] `make generate`
- [x] `go test ./internal/orchestrator ./internal/store -count=1`
- [x] `make check` with the repository/CI-pinned golangci-lint v2.1.6; 78.8% coverage