### PR TITLE
feat(codex): retain startup evidence

### DIFF
--- a/internal/backendcapacity/capacity.go
+++ b/internal/backendcapacity/capacity.go
@@ -71,6 +71,30 @@ type Details struct {
 	Reason  string
 	Trigger string
 	ResetAt *time.Time
+	Startup *StartupEvidence
+}
+
+type StartupEvidence struct {
+	Stage              string                 `json:"stage"`
+	StageStartedAt     time.Time              `json:"stage_started_at"`
+	FailedAt           time.Time              `json:"failed_at"`
+	ElapsedMS          int64                  `json:"elapsed_ms"`
+	DeadlineMS         int64                  `json:"deadline_ms"`
+	WorkerHost         string                 `json:"worker_host"`
+	ConcurrentStartups int                    `json:"concurrent_startups"`
+	ActiveWorkers      int                    `json:"active_workers"`
+	Process            StartupProcessEvidence `json:"process"`
+}
+
+type StartupProcessEvidence struct {
+	StartedAt    *time.Time `json:"started_at,omitempty"`
+	Ready        bool       `json:"ready"`
+	ReadyAt      *time.Time `json:"ready_at,omitempty"`
+	ReadyAfterMS int64      `json:"ready_after_ms,omitempty"`
+	ExitObserved bool       `json:"exit_observed"`
+	ExitedAt     *time.Time `json:"exited_at,omitempty"`
+	ExitAfterMS  int64      `json:"exit_after_ms,omitempty"`
+	ExitStatus   string     `json:"exit_status,omitempty"`
 }
 
 type Error struct {
@@ -189,7 +213,32 @@ func cloneDetails(details Details) Details {
 		resetAt := *details.ResetAt
 		details.ResetAt = &resetAt
 	}
+	if details.Startup != nil {
+		startup := *details.Startup
+		startup.Process.StartedAt = cloneTime(details.Startup.Process.StartedAt)
+		startup.Process.ReadyAt = cloneTime(details.Startup.Process.ReadyAt)
+		startup.Process.ExitedAt = cloneTime(details.Startup.Process.ExitedAt)
+		details.Startup = &startup
+	}
 	return details
+}
+
+func SetStartupHostSnapshot(err error, host string, concurrentStartups int, activeWorkers int) {
+	var capacityErr *Error
+	if !errors.As(err, &capacityErr) || capacityErr == nil || capacityErr.Details.Startup == nil {
+		return
+	}
+	capacityErr.Details.Startup.WorkerHost = strings.TrimSpace(host)
+	capacityErr.Details.Startup.ConcurrentStartups = max(concurrentStartups, 0)
+	capacityErr.Details.Startup.ActiveWorkers = max(activeWorkers, 0)
+}
+
+func cloneTime(value *time.Time) *time.Time {
+	if value == nil {
+		return nil
+	}
+	cloned := *value
+	return &cloned
 }
 
 func matchingKind(text string, rules Rules) (string, bool) {

--- a/internal/codex/appserver.go
+++ b/internal/codex/appserver.go
@@ -778,8 +778,11 @@ func (s *AppServer) startThread(
 	onUpdate UpdateHandler,
 ) (threadID string, runtimeIdentity agentidentity.Identity, err error) {
 	startedAt := s.now()
+	startupComplete := false
 	defer func() {
-		err = startupStageError(err, "thread/start", startedAt, s.now(), s.readTimeout)
+		if !startupComplete {
+			err = startupStageError(err, "thread/start", startedAt, s.now(), s.readTimeout)
+		}
 	}()
 	params := map[string]any{
 		"cwd": req.Workspace,
@@ -827,6 +830,7 @@ func (s *AppServer) startThread(
 	if !identity.IsZero() {
 		update = runtimeIdentityUpdate("thread/start", response.Thread.ID, identity)
 	}
+	startupComplete = true
 	if err := emitUpdate(update, onUpdate); err != nil {
 		return "", agentidentity.Identity{}, err
 	}
@@ -841,8 +845,11 @@ func (s *AppServer) resumeThread(
 	onUpdate UpdateHandler,
 ) (resumedThreadID string, runtimeIdentity agentidentity.Identity, err error) {
 	startedAt := s.now()
+	startupComplete := false
 	defer func() {
-		err = startupStageError(err, "thread/resume", startedAt, s.now(), s.readTimeout)
+		if !startupComplete {
+			err = startupStageError(err, "thread/resume", startedAt, s.now(), s.readTimeout)
+		}
 	}()
 	params := map[string]any{
 		"threadId": threadID,
@@ -889,6 +896,7 @@ func (s *AppServer) resumeThread(
 	if !identity.IsZero() {
 		update = runtimeIdentityUpdate("thread/resume", response.Thread.ID, identity)
 	}
+	startupComplete = true
 	if err := emitUpdate(update, onUpdate); err != nil {
 		return "", agentidentity.Identity{}, err
 	}

--- a/internal/codex/appserver.go
+++ b/internal/codex/appserver.go
@@ -161,6 +161,7 @@ type AppServer struct {
 	logger           *slog.Logger
 	readTimeout      time.Duration
 	turnTimeout      time.Duration
+	now              func() time.Time
 }
 
 type AppServerOption func(*AppServer)
@@ -344,6 +345,7 @@ func NewAppServer(factory TransportFactory, opts ...AppServerOption) (*AppServer
 		logger:      slog.Default(),
 		readTimeout: defaultReadTimeout,
 		turnTimeout: defaultTurnTimeout,
+		now:         time.Now,
 	}
 
 	for _, opt := range opts {
@@ -363,6 +365,9 @@ func NewAppServer(factory TransportFactory, opts ...AppServerOption) (*AppServer
 	}
 	if server.turnTimeout <= 0 {
 		server.turnTimeout = defaultTurnTimeout
+	}
+	if server.now == nil {
+		server.now = time.Now
 	}
 
 	return server, nil
@@ -397,13 +402,15 @@ func (s *AppServer) RunTurn(ctx context.Context, req RunTurnRequest, onUpdate Up
 
 	transport, err := s.transportFactory.NewTransport(ctx)
 	if err != nil {
-		return RunTurnResult{}, fmt.Errorf("start codex app-server transport: %w", err)
+		now := s.now()
+		return RunTurnResult{}, startupStageError(fmt.Errorf("start codex app-server transport: %w", err), "process/start", now, now, 0)
 	}
 	defer func() {
 		closeErr := closeTransport(ctx, transport, s.readTimeout)
 		if closeErr != nil {
 			err = errors.Join(err, closeErr)
 		}
+		attachStartupProcessEvidence(err, transport)
 	}()
 
 	if identity := transportProcessIdentity(transport); identity != "" {
@@ -686,7 +693,11 @@ func (s *AppServer) VerifyThread(ctx context.Context, threadID string) (err erro
 	return nil
 }
 
-func (s *AppServer) initialize(ctx context.Context, transport Transport, onUpdate UpdateHandler) error {
+func (s *AppServer) initialize(ctx context.Context, transport Transport, onUpdate UpdateHandler) (err error) {
+	startedAt := s.now()
+	defer func() {
+		err = startupStageError(err, "initialize", startedAt, s.now(), s.readTimeout)
+	}()
 	params := map[string]any{
 		"capabilities": map[string]any{
 			"experimentalApi": true,
@@ -700,6 +711,7 @@ func (s *AppServer) initialize(ctx context.Context, transport Transport, onUpdat
 	if _, err := s.awaitResponse(ctx, transport, initializeRequestID, nil, nil, onUpdate); err != nil {
 		return err
 	}
+	markTransportReady(transport, s.now())
 
 	return transport.Send(ctx, Message{
 		Method: "initialized",
@@ -764,7 +776,11 @@ func (s *AppServer) startThread(
 	transport Transport,
 	req RunTurnRequest,
 	onUpdate UpdateHandler,
-) (string, agentidentity.Identity, error) {
+) (threadID string, runtimeIdentity agentidentity.Identity, err error) {
+	startedAt := s.now()
+	defer func() {
+		err = startupStageError(err, "thread/start", startedAt, s.now(), s.readTimeout)
+	}()
 	params := map[string]any{
 		"cwd": req.Workspace,
 	}
@@ -823,7 +839,11 @@ func (s *AppServer) resumeThread(
 	req RunTurnRequest,
 	threadID string,
 	onUpdate UpdateHandler,
-) (string, agentidentity.Identity, error) {
+) (resumedThreadID string, runtimeIdentity agentidentity.Identity, err error) {
+	startedAt := s.now()
+	defer func() {
+		err = startupStageError(err, "thread/resume", startedAt, s.now(), s.readTimeout)
+	}()
 	params := map[string]any{
 		"threadId": threadID,
 		"cwd":      req.Workspace,
@@ -888,7 +908,11 @@ func (s *AppServer) startTurn(
 	threadID string,
 	elicitationState *mcpElicitationState,
 	onUpdate UpdateHandler,
-) (startTurnResult, error) {
+) (turn startTurnResult, err error) {
+	startedAt := s.now()
+	defer func() {
+		err = startupStageError(err, "turn/start", startedAt, s.now(), s.readTimeout)
+	}()
 	params := map[string]any{
 		"threadId": threadID,
 		"input": []map[string]any{
@@ -916,7 +940,6 @@ func (s *AppServer) startTurn(
 		return startTurnResult{}, err
 	}
 
-	turn := startTurnResult{}
 	trackTurnStarted := func(update Update) error {
 		if update.Type == UpdateTurnStarted {
 			turn.StartedEmitted = true

--- a/internal/codex/appserver_test.go
+++ b/internal/codex/appserver_test.go
@@ -71,6 +71,55 @@ func TestAppServerStartupFailuresIdentifyStageAndDeadline(t *testing.T) {
 	}
 }
 
+func TestAppServerUpdateHandlerFailureIsNotStartupFailure(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		response Message
+		run      func(*AppServer, Transport, UpdateHandler) error
+	}{
+		{
+			name:     "thread start",
+			response: responseMessage(t, threadStartRequestID, `{"thread":{"id":"thread-1"}}`),
+			run: func(server *AppServer, transport Transport, onUpdate UpdateHandler) error {
+				_, _, err := server.startThread(t.Context(), transport, RunTurnRequest{}, onUpdate)
+				return err
+			},
+		},
+		{
+			name:     "thread resume",
+			response: responseMessage(t, threadResumeRequestID, `{"thread":{"id":"thread-1"}}`),
+			run: func(server *AppServer, transport Transport, onUpdate UpdateHandler) error {
+				_, _, err := server.resumeThread(t.Context(), transport, RunTurnRequest{}, "thread-1", onUpdate)
+				return err
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			transport := newFakeAppServerTransport([]Message{tt.response})
+			server, err := NewAppServer(staticTransportFactory{transport: transport})
+			if err != nil {
+				t.Fatalf("NewAppServer() error = %v", err)
+			}
+			err = tt.run(server, transport, func(Update) error { return context.DeadlineExceeded })
+			if !errors.Is(err, context.DeadlineExceeded) {
+				t.Fatalf("startup call error = %v, want update handler deadline", err)
+			}
+			if _, ok := startupEvidence(err); ok {
+				t.Fatalf("startup evidence present on update handler error %v", err)
+			}
+			if details, ok := ClassifyCapacityError(err, nil, time.Now()); ok && details.Kind == backendcapacity.StartupTimeoutKind {
+				t.Fatalf("update handler error classified as startup timeout: %#v", details)
+			}
+		})
+	}
+}
+
 func TestAppServerStartupFailureRetainsProcessReadinessAndExit(t *testing.T) {
 	t.Parallel()
 

--- a/internal/codex/appserver_test.go
+++ b/internal/codex/appserver_test.go
@@ -14,7 +14,90 @@ import (
 	"time"
 
 	"github.com/digitaldrywood/detent/internal/agentidentity"
+	"github.com/digitaldrywood/detent/internal/backendcapacity"
 )
+
+func TestAppServerStartupFailuresIdentifyStageAndDeadline(t *testing.T) {
+	t.Parallel()
+
+	const deadline = 5 * time.Millisecond
+	tests := []struct {
+		name  string
+		stage string
+		run   func(*AppServer, Transport) error
+	}{
+		{name: "initialize", stage: "initialize", run: func(server *AppServer, transport Transport) error {
+			return server.initialize(t.Context(), transport, nil)
+		}},
+		{name: "thread start", stage: "thread/start", run: func(server *AppServer, transport Transport) error {
+			_, _, err := server.startThread(t.Context(), transport, RunTurnRequest{}, nil)
+			return err
+		}},
+		{name: "thread resume", stage: "thread/resume", run: func(server *AppServer, transport Transport) error {
+			_, _, err := server.resumeThread(t.Context(), transport, RunTurnRequest{}, "thread-1", nil)
+			return err
+		}},
+		{name: "turn start", stage: "turn/start", run: func(server *AppServer, transport Transport) error {
+			_, err := server.startTurn(t.Context(), transport, RunTurnRequest{}, "thread-1", nil, nil)
+			return err
+		}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			transport := newBlockingAppServerTransport(nil)
+			server, err := NewAppServer(staticTransportFactory{transport: transport}, WithReadTimeout(deadline))
+			if err != nil {
+				t.Fatalf("NewAppServer() error = %v", err)
+			}
+			err = tt.run(server, transport)
+			if !errors.Is(err, context.DeadlineExceeded) {
+				t.Fatalf("startup error = %v, want deadline exceeded", err)
+			}
+			evidence, ok := startupEvidence(err)
+			if !ok {
+				t.Fatalf("startup evidence missing from %v", err)
+			}
+			if evidence.Stage != tt.stage || evidence.DeadlineMS != deadline.Milliseconds() || evidence.ElapsedMS < 1 {
+				t.Fatalf("startup evidence = %#v, want stage %q and deadline %s", evidence, tt.stage, deadline)
+			}
+			details, ok := ClassifyCapacityError(err, nil, time.Now())
+			if !ok || details.Kind != backendcapacity.StartupTimeoutKind || details.Startup == nil || details.Startup.Stage != tt.stage {
+				t.Fatalf("capacity details = %#v, want exact startup stage", details)
+			}
+		})
+	}
+}
+
+func TestAppServerStartupFailureRetainsProcessReadinessAndExit(t *testing.T) {
+	t.Parallel()
+
+	startedAt := time.Date(2026, 8, 27, 12, 0, 0, 0, time.UTC)
+	transport := &startupEvidenceTransport{
+		blockingAppServerTransport: newBlockingAppServerTransport([]Message{
+			responseMessage(t, initializeRequestID, `{"userAgent":"codex-cli/test"}`),
+		}),
+		evidence: backendcapacity.StartupProcessEvidence{StartedAt: &startedAt},
+	}
+	server, err := NewAppServer(staticTransportFactory{transport: transport}, WithReadTimeout(5*time.Millisecond))
+	if err != nil {
+		t.Fatalf("NewAppServer() error = %v", err)
+	}
+
+	_, err = server.RunTurn(t.Context(), RunTurnRequest{}, nil)
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("RunTurn() error = %v, want deadline exceeded", err)
+	}
+	evidence, ok := startupEvidence(err)
+	if !ok || evidence.Stage != "thread/start" {
+		t.Fatalf("startup evidence = %#v, %v", evidence, ok)
+	}
+	if !evidence.Process.Ready || evidence.Process.ReadyAt == nil || !evidence.Process.ExitObserved || evidence.Process.ExitedAt == nil || evidence.Process.ExitStatus != "closed after startup failure" {
+		t.Fatalf("process evidence = %#v, want ready and exit observations", evidence.Process)
+	}
+}
 
 func TestAppServerRunTurnStartsLifecycleAndStreamsUpdates(t *testing.T) {
 	t.Parallel()
@@ -1890,6 +1973,28 @@ func (t *fakeAppServerTransport) sentMessages() []Message {
 
 type blockingAppServerTransport struct {
 	*fakeAppServerTransport
+}
+
+type startupEvidenceTransport struct {
+	*blockingAppServerTransport
+	evidence backendcapacity.StartupProcessEvidence
+}
+
+func (t *startupEvidenceTransport) MarkStartupReady(readyAt time.Time) {
+	t.evidence.Ready = true
+	t.evidence.ReadyAt = &readyAt
+}
+
+func (t *startupEvidenceTransport) Close(context.Context) error {
+	exitedAt := time.Now().UTC()
+	t.evidence.ExitObserved = true
+	t.evidence.ExitedAt = &exitedAt
+	t.evidence.ExitStatus = "closed after startup failure"
+	return nil
+}
+
+func (t *startupEvidenceTransport) StartupProcessEvidence() backendcapacity.StartupProcessEvidence {
+	return t.evidence
 }
 
 func newBlockingAppServerTransport(received []Message) *blockingAppServerTransport {

--- a/internal/codex/capacity.go
+++ b/internal/codex/capacity.go
@@ -67,7 +67,8 @@ func ClassifyCapacityError(err error, limits *telemetry.RateLimits, now time.Tim
 		return backendcapacity.Details{}, false
 	}
 	text := codexCapacityErrorText(err)
-	if codexStartupOperation(text) {
+	startup, hasStartupEvidence := startupEvidence(err)
+	if hasStartupEvidence || codexStartupOperation(text) {
 		switch {
 		case errors.Is(err, context.DeadlineExceeded):
 			return backendcapacity.Details{
@@ -75,6 +76,7 @@ func ClassifyCapacityError(err error, limits *telemetry.RateLimits, now time.Tim
 				Kind:    backendcapacity.StartupTimeoutKind,
 				Reason:  "backend startup handshake timed out",
 				Trigger: boundedCapacityTrigger(text),
+				Startup: startupEvidencePointer(startup, hasStartupEvidence),
 			}, true
 		case errors.Is(err, io.EOF), strings.Contains(strings.ToLower(text), "process exited"), strings.Contains(strings.ToLower(text), "start codex app-server transport"):
 			return backendcapacity.Details{
@@ -82,6 +84,7 @@ func ClassifyCapacityError(err error, limits *telemetry.RateLimits, now time.Tim
 				Kind:    backendcapacity.StartupFailureKind,
 				Reason:  "backend startup handshake failed",
 				Trigger: boundedCapacityTrigger(text),
+				Startup: startupEvidencePointer(startup, hasStartupEvidence),
 			}, true
 		}
 	}
@@ -102,6 +105,13 @@ func ClassifyCapacityError(err error, limits *telemetry.RateLimits, now time.Tim
 	}
 	details.Trigger = boundedCapacityTrigger(evidence)
 	return details, true
+}
+
+func startupEvidencePointer(evidence backendcapacity.StartupEvidence, ok bool) *backendcapacity.StartupEvidence {
+	if !ok {
+		return nil
+	}
+	return &evidence
 }
 
 func codexSubscriptionLimitText(text string) bool {

--- a/internal/codex/startup.go
+++ b/internal/codex/startup.go
@@ -1,0 +1,80 @@
+package codex
+
+import (
+	"errors"
+	"time"
+
+	"github.com/digitaldrywood/detent/internal/backendcapacity"
+)
+
+type StartupError struct {
+	Evidence backendcapacity.StartupEvidence
+	Err      error
+}
+
+func (e *StartupError) Error() string {
+	if e == nil || e.Err == nil {
+		return "codex app-server startup failed"
+	}
+	return e.Err.Error()
+}
+
+func (e *StartupError) Unwrap() error {
+	if e == nil {
+		return nil
+	}
+	return e.Err
+}
+
+func startupStageError(err error, stage string, startedAt time.Time, failedAt time.Time, deadline time.Duration) error {
+	if err == nil {
+		return nil
+	}
+	var existing *StartupError
+	if errors.As(err, &existing) {
+		return err
+	}
+	startedAt = startedAt.UTC()
+	failedAt = failedAt.UTC()
+	return &StartupError{
+		Evidence: backendcapacity.StartupEvidence{
+			Stage:          stage,
+			StageStartedAt: startedAt,
+			FailedAt:       failedAt,
+			ElapsedMS:      max(failedAt.Sub(startedAt).Milliseconds(), 0),
+			DeadlineMS:     max(deadline.Milliseconds(), 0),
+		},
+		Err: err,
+	}
+}
+
+func startupEvidence(err error) (backendcapacity.StartupEvidence, bool) {
+	var startupErr *StartupError
+	if !errors.As(err, &startupErr) || startupErr == nil {
+		return backendcapacity.StartupEvidence{}, false
+	}
+	return startupErr.Evidence, true
+}
+
+func attachStartupProcessEvidence(err error, transport Transport) {
+	var startupErr *StartupError
+	if !errors.As(err, &startupErr) || startupErr == nil {
+		return
+	}
+	provider, ok := transport.(interface {
+		StartupProcessEvidence() backendcapacity.StartupProcessEvidence
+	})
+	if !ok {
+		return
+	}
+	startupErr.Evidence.Process = provider.StartupProcessEvidence()
+}
+
+func markTransportReady(transport Transport, readyAt time.Time) {
+	marker, ok := transport.(interface {
+		MarkStartupReady(time.Time)
+	})
+	if ok {
+		marker.MarkStartupReady(readyAt.UTC())
+	}
+}

--- a/internal/codex/transport.go
+++ b/internal/codex/transport.go
@@ -12,6 +12,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/digitaldrywood/detent/internal/backendcapacity"
 	"github.com/digitaldrywood/detent/internal/procgroup"
 )
 
@@ -37,6 +38,10 @@ type localTransport struct {
 	cmd            *exec.Cmd
 	processGroupID int
 	workerProcess  procgroup.Identity
+	startedAt      time.Time
+	readyAt        time.Time
+	exitedAt       time.Time
+	exitStatus     string
 	stdin          io.WriteCloser
 	stdout         io.ReadCloser
 	stderr         io.ReadCloser
@@ -127,6 +132,7 @@ func (f *LocalTransportFactory) NewTransport(ctx context.Context) (Transport, er
 			stderrWriter.Close(),
 		)
 	}
+	processStartedAt := time.Now().UTC()
 	if err := errors.Join(stdoutWriter.Close(), stderrWriter.Close()); err != nil {
 		terminateErr := procgroup.TerminateTree(cmd, procgroup.GroupID(cmd))
 		waitErr := cmd.Wait()
@@ -145,6 +151,7 @@ func (f *LocalTransportFactory) NewTransport(ctx context.Context) (Transport, er
 	transport := &localTransport{
 		cmd:            cmd,
 		processGroupID: procgroup.GroupID(cmd),
+		startedAt:      processStartedAt,
 		stdin:          stdin,
 		stdout:         stdout,
 		stderr:         stderr,
@@ -305,6 +312,38 @@ func (t *localTransport) WorkerProcess() procgroup.Identity {
 	return t.workerProcess
 }
 
+func (t *localTransport) MarkStartupReady(readyAt time.Time) {
+	t.waitMu.Lock()
+	defer t.waitMu.Unlock()
+	if t.readyAt.IsZero() {
+		t.readyAt = readyAt.UTC()
+	}
+}
+
+func (t *localTransport) StartupProcessEvidence() backendcapacity.StartupProcessEvidence {
+	t.waitMu.Lock()
+	defer t.waitMu.Unlock()
+	startedAt := t.startedAt
+	if !t.workerProcess.StartedAt.IsZero() {
+		startedAt = t.workerProcess.StartedAt.UTC()
+	}
+	evidence := backendcapacity.StartupProcessEvidence{
+		StartedAt:    timePointer(startedAt),
+		Ready:        !t.readyAt.IsZero(),
+		ReadyAt:      timePointer(t.readyAt),
+		ExitObserved: !t.exitedAt.IsZero(),
+		ExitedAt:     timePointer(t.exitedAt),
+		ExitStatus:   strings.TrimSpace(t.exitStatus),
+	}
+	if !startedAt.IsZero() && !t.readyAt.IsZero() {
+		evidence.ReadyAfterMS = max(t.readyAt.Sub(startedAt).Milliseconds(), 0)
+	}
+	if !startedAt.IsZero() && !t.exitedAt.IsZero() {
+		evidence.ExitAfterMS = max(t.exitedAt.Sub(startedAt).Milliseconds(), 0)
+	}
+	return evidence
+}
+
 func transportContextError(ctxErr error, operation string, err error) error {
 	return fmt.Errorf("%w: %s: %w", ctxErr, operation, err)
 }
@@ -397,6 +436,10 @@ func (t *localTransport) wait() {
 	}
 	t.waitMu.Lock()
 	t.waitErr = err
+	t.exitedAt = time.Now().UTC()
+	if t.cmd != nil && t.cmd.ProcessState != nil {
+		t.exitStatus = t.cmd.ProcessState.String()
+	}
 	t.waitMu.Unlock()
 	close(t.done)
 }
@@ -530,4 +573,12 @@ func contextOrBackground(ctx context.Context) context.Context {
 		return context.Background()
 	}
 	return ctx
+}
+
+func timePointer(value time.Time) *time.Time {
+	if value.IsZero() {
+		return nil
+	}
+	value = value.UTC()
+	return &value
 }

--- a/internal/orchestrator/backend_capacity_test.go
+++ b/internal/orchestrator/backend_capacity_test.go
@@ -3,6 +3,7 @@ package orchestrator
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"log/slog"
@@ -306,6 +307,19 @@ func TestHandleRunResultTracksStartupTimeoutAsCapacityAndBreakerSignal(t *testin
 		Type:   backendcapacity.ErrorTypeTransientOverload,
 		Kind:   backendcapacity.StartupTimeoutKind,
 		Reason: "backend startup handshake timed out",
+		Startup: &backendcapacity.StartupEvidence{
+			Stage:              "thread/start",
+			ElapsedMS:          5001,
+			DeadlineMS:         5000,
+			WorkerHost:         "worker-a",
+			ConcurrentStartups: 3,
+			ActiveWorkers:      7,
+			Process: backendcapacity.StartupProcessEvidence{
+				Ready:        true,
+				ExitObserved: true,
+				ExitStatus:   "signal: killed",
+			},
+		},
 	}, context.DeadlineExceeded)
 
 	orch.handleRunResult(t.Context(), &state, runpkg.Completion{
@@ -332,6 +346,15 @@ func TestHandleRunResultTracksStartupTimeoutAsCapacityAndBreakerSignal(t *testin
 	completion := attempts.completions[0]
 	if completion.TerminalState != store.WorkAttemptTerminalTimedOut || completion.ErrorClass != backendcapacity.StartupTimeoutErrorClass || completion.StatusMessage != "retrying after backend startup timeout" {
 		t.Fatalf("completion = %#v, want startup timeout telemetry", completion)
+	}
+	var metadata struct {
+		BackendStartup backendcapacity.StartupEvidence `json:"backend_startup"`
+	}
+	if err := json.Unmarshal([]byte(completion.WorkerMetadataJSON), &metadata); err != nil {
+		t.Fatalf("unmarshal worker metadata: %v", err)
+	}
+	if metadata.BackendStartup.Stage != "thread/start" || metadata.BackendStartup.ElapsedMS != 5001 || metadata.BackendStartup.DeadlineMS != 5000 || metadata.BackendStartup.ConcurrentStartups != 3 || metadata.BackendStartup.ActiveWorkers != 7 || !metadata.BackendStartup.Process.Ready || !metadata.BackendStartup.Process.ExitObserved {
+		t.Fatalf("backend startup metadata = %#v, want durable stage, timing, host, and process evidence", metadata.BackendStartup)
 	}
 }
 

--- a/internal/orchestrator/transient_overload.go
+++ b/internal/orchestrator/transient_overload.go
@@ -65,7 +65,7 @@ func (o *Orchestrator) handleTransientOverload(
 		event.Err.Error(),
 		"waiting",
 		statusMessage,
-		nil,
+		startupFailureMetadata(overloadErr.Details),
 	)
 	if workspaceIssueTerminal(running.Issue, o.cfg.TerminalStates) {
 		o.releaseClaim(state, running.Issue.ID)
@@ -123,4 +123,11 @@ func (o *Orchestrator) handleTransientOverload(
 			"error", event.Err,
 		)
 	}
+}
+
+func startupFailureMetadata(details backendcapacity.Details) map[string]any {
+	if details.Startup == nil {
+		return nil
+	}
+	return map[string]any{"backend_startup": details.Startup}
 }

--- a/internal/runner/dispatch_pacer.go
+++ b/internal/runner/dispatch_pacer.go
@@ -26,6 +26,8 @@ type StartupDispatchPacer struct {
 	jitter             time.Duration
 	rampStarts         int
 	started            int
+	activeByHost       map[string]int
+	startingByHost     map[string]int
 	sleep              func(context.Context, time.Duration) error
 	randomJitter       func(time.Duration) time.Duration
 }
@@ -46,7 +48,92 @@ func NewStartupDispatchPacer(cfg StartupDispatchPacerConfig) *StartupDispatchPac
 		rampStarts:         cfg.RampStarts,
 		sleep:              cfg.Sleep,
 		randomJitter:       cfg.RandomJitter,
+		activeByHost:       make(map[string]int),
+		startingByHost:     make(map[string]int),
 	}
+}
+
+type startupHostSnapshot struct {
+	concurrentStartups int
+	activeWorkers      int
+}
+
+type startupObservation interface {
+	Ready()
+	Snapshot() startupHostSnapshot
+	Finish()
+}
+
+type startupCensus interface {
+	BeginStartup(string) startupObservation
+}
+
+type dispatchStartupObservation struct {
+	pacer    *StartupDispatchPacer
+	host     string
+	ready    bool
+	finished bool
+}
+
+func (p *StartupDispatchPacer) BeginStartup(host string) startupObservation {
+	observation := &dispatchStartupObservation{pacer: p, host: host}
+	if p == nil {
+		return observation
+	}
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.activeByHost[host]++
+	p.startingByHost[host]++
+	return observation
+}
+
+func (o *dispatchStartupObservation) Ready() {
+	if o == nil || o.pacer == nil {
+		return
+	}
+	o.pacer.mu.Lock()
+	defer o.pacer.mu.Unlock()
+	if o.ready || o.finished {
+		return
+	}
+	o.ready = true
+	decrementHostCount(o.pacer.startingByHost, o.host)
+}
+
+func (o *dispatchStartupObservation) Snapshot() startupHostSnapshot {
+	if o == nil || o.pacer == nil {
+		return startupHostSnapshot{}
+	}
+	o.pacer.mu.Lock()
+	defer o.pacer.mu.Unlock()
+	return startupHostSnapshot{
+		concurrentStartups: o.pacer.startingByHost[o.host],
+		activeWorkers:      o.pacer.activeByHost[o.host],
+	}
+}
+
+func (o *dispatchStartupObservation) Finish() {
+	if o == nil || o.pacer == nil {
+		return
+	}
+	o.pacer.mu.Lock()
+	defer o.pacer.mu.Unlock()
+	if o.finished {
+		return
+	}
+	o.finished = true
+	decrementHostCount(o.pacer.activeByHost, o.host)
+	if !o.ready {
+		decrementHostCount(o.pacer.startingByHost, o.host)
+	}
+}
+
+func decrementHostCount(counts map[string]int, host string) {
+	if counts[host] <= 1 {
+		delete(counts, host)
+		return
+	}
+	counts[host]--
 }
 
 func (p *StartupDispatchPacer) Wait(ctx context.Context) error {

--- a/internal/runner/dispatch_pacer.go
+++ b/internal/runner/dispatch_pacer.go
@@ -22,6 +22,7 @@ type StartupDispatchPacerConfig struct {
 
 type StartupDispatchPacer struct {
 	mu                 sync.Mutex
+	censusMu           sync.Mutex
 	maxStartsPerSecond int
 	jitter             time.Duration
 	rampStarts         int
@@ -80,8 +81,8 @@ func (p *StartupDispatchPacer) BeginStartup(host string) startupObservation {
 	if p == nil {
 		return observation
 	}
-	p.mu.Lock()
-	defer p.mu.Unlock()
+	p.censusMu.Lock()
+	defer p.censusMu.Unlock()
 	p.activeByHost[host]++
 	p.startingByHost[host]++
 	return observation
@@ -91,8 +92,8 @@ func (o *dispatchStartupObservation) Ready() {
 	if o == nil || o.pacer == nil {
 		return
 	}
-	o.pacer.mu.Lock()
-	defer o.pacer.mu.Unlock()
+	o.pacer.censusMu.Lock()
+	defer o.pacer.censusMu.Unlock()
 	if o.ready || o.finished {
 		return
 	}
@@ -104,8 +105,8 @@ func (o *dispatchStartupObservation) Snapshot() startupHostSnapshot {
 	if o == nil || o.pacer == nil {
 		return startupHostSnapshot{}
 	}
-	o.pacer.mu.Lock()
-	defer o.pacer.mu.Unlock()
+	o.pacer.censusMu.Lock()
+	defer o.pacer.censusMu.Unlock()
 	return startupHostSnapshot{
 		concurrentStartups: o.pacer.startingByHost[o.host],
 		activeWorkers:      o.pacer.activeByHost[o.host],
@@ -116,8 +117,8 @@ func (o *dispatchStartupObservation) Finish() {
 	if o == nil || o.pacer == nil {
 		return
 	}
-	o.pacer.mu.Lock()
-	defer o.pacer.mu.Unlock()
+	o.pacer.censusMu.Lock()
+	defer o.pacer.censusMu.Unlock()
 	if o.finished {
 		return
 	}

--- a/internal/runner/dispatch_pacer_test.go
+++ b/internal/runner/dispatch_pacer_test.go
@@ -73,6 +73,32 @@ func TestStartupDispatchPacerRampsInitialStarts(t *testing.T) {
 	}
 }
 
+func TestStartupDispatchPacerTracksHostScopedStartupAndActiveCounts(t *testing.T) {
+	t.Parallel()
+
+	pacer := NewStartupDispatchPacer(StartupDispatchPacerConfig{})
+	first := pacer.BeginStartup("worker-a")
+	second := pacer.BeginStartup("worker-a")
+	other := pacer.BeginStartup("worker-b")
+
+	if got := second.Snapshot(); got.concurrentStartups != 2 || got.activeWorkers != 2 {
+		t.Fatalf("worker-a snapshot = %#v, want 2 startups and 2 active workers", got)
+	}
+	if got := other.Snapshot(); got.concurrentStartups != 1 || got.activeWorkers != 1 {
+		t.Fatalf("worker-b snapshot = %#v, want host-isolated counts", got)
+	}
+	first.Ready()
+	if got := second.Snapshot(); got.concurrentStartups != 1 || got.activeWorkers != 2 {
+		t.Fatalf("worker-a ready snapshot = %#v, want 1 startup and 2 active workers", got)
+	}
+	first.Finish()
+	second.Finish()
+	other.Finish()
+	if len(pacer.startingByHost) != 0 || len(pacer.activeByHost) != 0 {
+		t.Fatalf("finished census = startups %#v active %#v, want empty", pacer.startingByHost, pacer.activeByHost)
+	}
+}
+
 func TestSupervisorPacesNormalDispatchBeforeRunningWorker(t *testing.T) {
 	t.Parallel()
 

--- a/internal/runner/dispatch_pacer_test.go
+++ b/internal/runner/dispatch_pacer_test.go
@@ -99,6 +99,50 @@ func TestStartupDispatchPacerTracksHostScopedStartupAndActiveCounts(t *testing.T
 	}
 }
 
+func TestStartupDispatchPacerCensusDoesNotWaitForPacingSleep(t *testing.T) {
+	t.Parallel()
+
+	sleeping := make(chan struct{})
+	release := make(chan struct{})
+	pacer := NewStartupDispatchPacer(StartupDispatchPacerConfig{
+		MaxStartsPerSecond: 1,
+		RampStarts:         2,
+		Sleep: func(context.Context, time.Duration) error {
+			close(sleeping)
+			<-release
+			return nil
+		},
+	})
+	if err := pacer.Wait(t.Context()); err != nil {
+		t.Fatalf("first Wait() error = %v", err)
+	}
+	waitDone := make(chan error, 1)
+	go func() {
+		waitDone <- pacer.Wait(t.Context())
+	}()
+	<-sleeping
+
+	observation := pacer.BeginStartup("worker-a")
+	snapshotDone := make(chan startupHostSnapshot, 1)
+	go func() {
+		snapshotDone <- observation.Snapshot()
+	}()
+	select {
+	case got := <-snapshotDone:
+		if got.concurrentStartups != 1 || got.activeWorkers != 1 {
+			t.Fatalf("snapshot = %#v, want 1 startup and 1 active worker", got)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("Snapshot() waited for pacing sleep")
+	}
+
+	close(release)
+	if err := <-waitDone; err != nil {
+		t.Fatalf("second Wait() error = %v", err)
+	}
+	observation.Finish()
+}
+
 func TestSupervisorPacesNormalDispatchBeforeRunningWorker(t *testing.T) {
 	t.Parallel()
 

--- a/internal/runner/supervisor.go
+++ b/internal/runner/supervisor.go
@@ -9,6 +9,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/digitaldrywood/detent/internal/backendcapacity"
 	"github.com/digitaldrywood/detent/internal/telemetry"
 )
 
@@ -205,6 +206,20 @@ func (s *Supervisor) Run(ctx context.Context, request RunRequest) (completion Co
 			return completion
 		}
 	}
+	var startup startupObservation
+	if census, ok := s.dispatchPacer.(startupCensus); ok {
+		startup = census.BeginStartup(request.WorkerHost)
+		defer startup.Finish()
+		usageHandler := request.OnUsageUpdate
+		if usageHandler != nil {
+			request.OnUsageUpdate = func(update UsageUpdate) error {
+				if update.TurnCount > 0 || update.LastEvent == string(AgentUpdateTurnStarted) {
+					startup.Ready()
+				}
+				return usageHandler(update)
+			}
+		}
+	}
 
 	result, err := s.backend.Run(ctx, request)
 	if cause := context.Cause(ctx); errors.Is(cause, ErrMergeWorkerStartupTimeout) ||
@@ -218,6 +233,10 @@ func (s *Supervisor) Run(ctx context.Context, request RunRequest) (completion Co
 		if errors.Is(cause, ErrLaneRevoked) {
 			result.FinalState = FinalStateLaneRevoked
 		}
+	}
+	if startup != nil {
+		snapshot := startup.Snapshot()
+		backendcapacity.SetStartupHostSnapshot(err, request.WorkerHost, snapshot.concurrentStartups, snapshot.activeWorkers)
 	}
 	completion.CompletedAt = s.now()
 	completion.Result = result

--- a/internal/runner/supervisor_test.go
+++ b/internal/runner/supervisor_test.go
@@ -338,6 +338,28 @@ func TestSupervisorUsesFlatSameAttemptRetryForTransientOverload(t *testing.T) {
 	}
 }
 
+func TestSupervisorAddsSharedHostCensusToStartupFailure(t *testing.T) {
+	t.Parallel()
+
+	pacer := NewStartupDispatchPacer(StartupDispatchPacerConfig{})
+	otherProject := pacer.BeginStartup("worker-a")
+	defer otherProject.Finish()
+	supervisor, err := NewSupervisor(startupFailureBackend{}, SupervisorConfig{DispatchPacer: pacer})
+	if err != nil {
+		t.Fatalf("NewSupervisor() error = %v", err)
+	}
+
+	completion := supervisor.Run(t.Context(), RunRequest{WorkerHost: "worker-a"})
+	capacityErr, ok := backendcapacity.As(completion.Err)
+	if !ok || capacityErr.Details.Startup == nil {
+		t.Fatalf("completion error = %v, want startup capacity evidence", completion.Err)
+	}
+	evidence := capacityErr.Details.Startup
+	if evidence.WorkerHost != "worker-a" || evidence.ConcurrentStartups != 2 || evidence.ActiveWorkers != 2 {
+		t.Fatalf("startup evidence = %#v, want shared worker-a census", evidence)
+	}
+}
+
 func TestSupervisorLogsBackendErrorBodyForRunnerErrors(t *testing.T) {
 	t.Parallel()
 
@@ -674,6 +696,25 @@ type capacityBackend struct {
 }
 
 type transientOverloadBackend struct{}
+
+type startupFailureBackend struct{}
+
+func (startupFailureBackend) Run(context.Context, RunRequest) (RunResult, error) {
+	return RunResult{}, backendcapacity.NewError(
+		backendcapacity.Scope{BackendID: "codex", BackendKind: "codex", Provider: "openai"},
+		backendcapacity.Details{
+			Type:   backendcapacity.ErrorTypeTransientOverload,
+			Kind:   backendcapacity.StartupTimeoutKind,
+			Reason: "backend startup handshake timed out",
+			Startup: &backendcapacity.StartupEvidence{
+				Stage:      "initialize",
+				ElapsedMS:  5000,
+				DeadlineMS: 5000,
+			},
+		},
+		context.DeadlineExceeded,
+	)
+}
 
 func (transientOverloadBackend) Run(context.Context, RunRequest) (RunResult, error) {
 	return RunResult{}, backendcapacity.NewError(


### PR DESCRIPTION
## Summary

- Record exact Codex app-server startup stage latency and configured response deadline on startup failures.
- Retain process start, readiness, and exit timing together with host-scoped concurrent startup and active-worker counts.
- Preserve the existing timeout, pacing, concurrency, and retry policies while adding durable `backend_startup` work-attempt metadata.

Fixes #2000

## UI Surface Contract

- [x] N/A; this change does not affect UI surface, layout, density, first-viewport, or responsive visibility.
- [x] This PR does not add persistent top-of-screen messaging.
- [x] N/A; this PR has no visual changes to primary operator screens.

## Test Plan

- [x] `go test ./internal/backendcapacity ./internal/codex ./internal/runner ./internal/orchestrator -count=1`
- [x] `go test ./internal/procgroup -run '^TestTerminateEscalatesSurvivingProcessGroup$' -count=10 -v`
- [x] `make check` with the CI-pinned golangci-lint v2.1.6 (78.9% total coverage; package and file floors passed)