### PR TITLE
fix(orchestrator): arbitrate lane writes

### DIFF
--- a/db/queries/store.sql
+++ b/db/queries/store.sql
@@ -787,6 +787,19 @@ WHERE work_attempts.id = sqlc.arg(work_attempt_id)
   AND work_attempts.completed_at IS NULL
 RETURNING *;
 
+-- name: SupersedeLaneMutationReceipts :execrows
+UPDATE lane_mutation_receipts
+SET tracker_result = 'superseded',
+    resolved_at = sqlc.arg(superseded_at),
+    error_message = NULL
+WHERE project_id = sqlc.arg(project_id)
+  AND issue_id = sqlc.arg(issue_id)
+  AND work_attempt_id = sqlc.arg(work_attempt_id)
+  AND generation = sqlc.arg(generation)
+  AND id < sqlc.arg(newer_receipt_id)
+  AND tracker_result IN ('prepared', 'applied')
+  AND consumed_at IS NULL;
+
 -- name: ResolveLaneMutationReceipt :execrows
 UPDATE lane_mutation_receipts
 SET tracker_result = sqlc.arg(tracker_result),

--- a/db/queries/store.sql
+++ b/db/queries/store.sql
@@ -755,6 +755,75 @@ INSERT INTO work_attempts (
 ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 RETURNING *;
 
+-- name: CreateLaneMutationReceipt :one
+INSERT INTO lane_mutation_receipts (
+  project_id,
+  issue_id,
+  work_attempt_id,
+  generation,
+  disposition,
+  from_state,
+  to_state,
+  reason,
+  tracker_result,
+  requested_at
+)
+SELECT
+  sqlc.arg(project_id),
+  sqlc.arg(issue_id),
+  work_attempts.id,
+  sqlc.arg(generation),
+  sqlc.arg(disposition),
+  sqlc.arg(from_state),
+  sqlc.arg(to_state),
+  sqlc.arg(reason),
+  'prepared',
+  sqlc.arg(requested_at)
+FROM work_attempts
+WHERE work_attempts.id = sqlc.arg(work_attempt_id)
+  AND work_attempts.project_id = sqlc.arg(project_id)
+  AND COALESCE(work_attempts.issue_id, '') = sqlc.arg(issue_id)
+  AND work_attempts.status = 'active'
+  AND work_attempts.completed_at IS NULL
+RETURNING *;
+
+-- name: ResolveLaneMutationReceipt :execrows
+UPDATE lane_mutation_receipts
+SET tracker_result = sqlc.arg(tracker_result),
+    resolved_at = sqlc.arg(resolved_at),
+    error_message = NULLIF(sqlc.arg(error_message), '')
+WHERE id = sqlc.arg(id)
+  AND work_attempt_id = sqlc.arg(work_attempt_id)
+  AND generation = sqlc.arg(generation)
+  AND tracker_result = 'prepared'
+  AND consumed_at IS NULL;
+
+-- name: LaneMutationReceiptForOwner :one
+SELECT *
+FROM lane_mutation_receipts
+WHERE project_id = sqlc.arg(project_id)
+  AND issue_id = sqlc.arg(issue_id)
+  AND work_attempt_id = sqlc.arg(work_attempt_id)
+  AND generation = sqlc.arg(generation)
+  AND lower(trim(to_state)) = lower(trim(sqlc.arg(to_state)))
+  AND tracker_result IN ('prepared', 'applied')
+  AND consumed_at IS NULL
+ORDER BY id DESC
+LIMIT 1;
+
+-- name: ConsumeLaneMutationReceipt :one
+UPDATE lane_mutation_receipts
+SET consumed_at = sqlc.arg(consumed_at)
+WHERE id = sqlc.arg(id)
+  AND project_id = sqlc.arg(project_id)
+  AND issue_id = sqlc.arg(issue_id)
+  AND work_attempt_id = sqlc.arg(work_attempt_id)
+  AND generation = sqlc.arg(generation)
+  AND lower(trim(to_state)) = lower(trim(sqlc.arg(to_state)))
+  AND tracker_result IN ('prepared', 'applied')
+  AND consumed_at IS NULL
+RETURNING *;
+
 -- name: GetWorkAttempt :one
 SELECT *
 FROM work_attempts

--- a/internal/orchestrator/artifact_completion.go
+++ b/internal/orchestrator/artifact_completion.go
@@ -322,7 +322,7 @@ func (o *Orchestrator) parkArtifactGateConvergence(
 		autoPromoteReworkState,
 		DiffStats{},
 	)
-	if err := o.updateIssueStateByIDWithMetadata(ctx, state, issue.ID, issue, blockedStatusState, completedAt, artifactGateConvergenceReason, metadata); err != nil {
+	if err := o.updateIssueStateByIDWithMetadata(ctx, state, issue.ID, issue, blockedStatusState, completedAt, artifactGateConvergenceReason, metadata, laneMutationRevokeWorker); err != nil {
 		if o.logger != nil {
 			o.logger.WarnContext(ctx, "artifact gate convergence breaker state transition failed",
 				"issue_id", issue.ID,

--- a/internal/orchestrator/autopromote_tick.go
+++ b/internal/orchestrator/autopromote_tick.go
@@ -911,7 +911,7 @@ func (o *Orchestrator) applyStaleMergingPullRequestDecision(
 	now time.Time,
 ) bool {
 	issueID := strings.TrimSpace(issue.ID)
-	if err := o.updateIssueStateByID(ctx, state, issueID, issue, decision.targetState, now, decision.reason); err != nil {
+	if err := o.updateIssueStateByID(ctx, state, issueID, issue, decision.targetState, now, decision.reason, laneMutationRevokeWorker); err != nil {
 		if o.logger != nil {
 			o.logger.Warn(
 				"stale_merging_pr_reconciliation_failed",
@@ -1782,7 +1782,7 @@ func (o *Orchestrator) applyStaleMergedPullRequestDecision(
 	now time.Time,
 ) bool {
 	issueID := strings.TrimSpace(issue.ID)
-	if err := o.updateIssueStateByID(ctx, state, issueID, issue, targetState, now, string(decision.Reason)); err != nil {
+	if err := o.updateIssueStateByID(ctx, state, issueID, issue, targetState, now, string(decision.Reason), laneMutationRevokeWorker); err != nil {
 		if o.logger != nil {
 			o.logger.Warn(
 				"stale_merged_pr_reconciliation_failed",
@@ -1893,7 +1893,7 @@ func (o *Orchestrator) applyStaleTodoPullRequestDecision(
 	now time.Time,
 ) bool {
 	issueID := strings.TrimSpace(issue.ID)
-	if err := o.updateIssueStateByID(ctx, state, issueID, issue, targetState, now, string(decision.Reason)); err != nil {
+	if err := o.updateIssueStateByID(ctx, state, issueID, issue, targetState, now, string(decision.Reason), laneMutationRevokeWorker); err != nil {
 		if o.logger != nil {
 			o.logger.Warn(
 				"stale_todo_pr_reconciliation_failed",
@@ -2731,6 +2731,7 @@ func (o *Orchestrator) applyAutoPromoteDecision(
 
 	issueID := strings.TrimSpace(issue.ID)
 	transitionReason := string(decision.Reason)
+	disposition := laneMutationPreserveOwnership
 	body := autoPromoteComment(summary, decision, displayStateName(issue.State), targetState)
 	metadata := workflowLaneMetadata{}
 	if decision.Action == AutoPromoteActionRework {
@@ -2750,6 +2751,7 @@ func (o *Orchestrator) applyAutoPromoteDecision(
 			return false
 		}
 		if limit.Exceeded() {
+			disposition = laneMutationRevokeWorker
 			targetState = blockedStatusState
 			transitionReason = "rework_limit"
 			body = autoPromoteReworkLimitComment(summary, decision, displayStateName(issue.State), limit)
@@ -2767,7 +2769,7 @@ func (o *Orchestrator) applyAutoPromoteDecision(
 		}
 	}
 
-	if err := o.updateIssueStateByIDWithMetadata(ctx, state, issueID, issue, targetState, now, transitionReason, metadata); err != nil {
+	if err := o.updateIssueStateByIDWithMetadata(ctx, state, issueID, issue, targetState, now, transitionReason, metadata, disposition); err != nil {
 		if o.logger != nil {
 			o.logger.Warn(
 				"auto promote transition failed",

--- a/internal/orchestrator/autopromote_tick_test.go
+++ b/internal/orchestrator/autopromote_tick_test.go
@@ -1061,6 +1061,7 @@ func TestLatestSuccessfulGateWaitAttemptRequiresCurrentImplementationEvidence(t 
 func TestTickAutoPromotesCompletedGateWaitWhileDispatchRunning(t *testing.T) {
 	t.Parallel()
 
+	ctx := t.Context()
 	now := time.Date(2026, 7, 9, 18, 50, 0, 0, time.UTC)
 	oldReview := now.Add(-10 * time.Minute)
 	issue := autoPromoteTickIssue("issue-running-gate-wait", []string{"bug"}, &connector.PullRequest{
@@ -1092,23 +1093,44 @@ func TestTickAutoPromotesCompletedGateWaitWhileDispatchRunning(t *testing.T) {
 		TerminalStates: []string{"Done", "Cancelled"},
 	})
 	state := newState(cfg)
+	runtimeStore, err := store.Open(ctx, store.Config{Backend: store.BackendSQLite, Path: filepath.Join(t.TempDir(), "detent.db")})
+	if err != nil {
+		t.Fatalf("store.Open() error = %v", err)
+	}
+	t.Cleanup(func() { _ = runtimeStore.Close() })
+	attemptID, err := runtimeStore.StartWorkAttempt(ctx, store.WorkAttemptStart{
+		ProjectID:      defaultWorkflowMetricsProjectID,
+		IssueID:        issue.ID,
+		Identifier:     issue.Identifier,
+		WorkerType:     "agent",
+		Lane:           issue.State,
+		AttemptNumber:  1,
+		StartedAt:      now.Add(-time.Minute),
+		LeaseExpiresAt: now.Add(time.Minute),
+	})
+	if err != nil {
+		t.Fatalf("StartWorkAttempt() error = %v", err)
+	}
 	state.Completed[issue.ID] = Completed{
 		Issue:       issue,
 		CompletedAt: now.Add(-5 * time.Minute),
 		FinalState:  FinalStateCompleted,
 	}
 	state.Running[issue.ID] = Running{
-		Issue:     issue,
-		StartedAt: now.Add(-time.Minute),
+		Issue:         issue,
+		WorkAttemptID: attemptID,
+		Generation:    1,
+		StartedAt:     now.Add(-time.Minute),
 	}
 	tracker := &autoPromoteTickConnector{stateIssues: []connector.Issue{issue}}
 	orch := &Orchestrator{
-		cfg:       cfg,
-		connector: tracker,
-		logger:    slog.New(slog.NewTextHandler(io.Discard, nil)),
+		cfg:           cfg,
+		connector:     tracker,
+		laneMutations: runtimeStore,
+		logger:        slog.New(slog.NewTextHandler(io.Discard, nil)),
 	}
 
-	result := orch.autoPromoteHumanReviewIssues(context.Background(), &state, []connector.Issue{issue}, now)
+	result := orch.autoPromoteHumanReviewIssues(ctx, &state, []connector.Issue{issue}, now)
 
 	if got, want := tracker.updates, []autoPromoteTickUpdate{{issueID: issue.ID, state: "Merging"}}; !reflect.DeepEqual(got, want) {
 		t.Fatalf("updates = %#v, want %#v", got, want)

--- a/internal/orchestrator/backend_capacity.go
+++ b/internal/orchestrator/backend_capacity.go
@@ -242,7 +242,7 @@ func (o *Orchestrator) restoreBackendCapacityIssueState(
 		return running
 	}
 	issue := cloneIssue(running.Issue)
-	if err := o.updateIssueState(ctx, state, issue, source, now, "backend_capacity_pause"); err != nil {
+	if err := o.updateIssueState(ctx, state, issue, source, now, "backend_capacity_pause", laneMutationAcceptCompletion); err != nil {
 		if o.logger != nil {
 			o.logger.Warn("backend capacity state restore failed", "issue_id", issue.ID, "source_state", source, "error", err)
 		}
@@ -1117,7 +1117,7 @@ func (o *Orchestrator) applyBackendCapacityBlockedRecovery(
 	recovery BackendRecovery,
 	now time.Time,
 ) bool {
-	if err := o.updateIssueState(ctx, state, issue, targetState, now, "backend_capacity_recovered"); err != nil {
+	if err := o.updateIssueState(ctx, state, issue, targetState, now, "backend_capacity_recovered", laneMutationPreserveOwnership); err != nil {
 		if o.logger != nil {
 			o.logger.Warn(
 				"backend capacity blocked recovery failed",

--- a/internal/orchestrator/blocked_cause_recovery.go
+++ b/internal/orchestrator/blocked_cause_recovery.go
@@ -464,7 +464,7 @@ func (o *Orchestrator) recoverCauseBlockedIssue(
 	}
 	targetState := blockedCauseTargetState(issue, signals, park.TargetState)
 	metadata := workflowLaneMetadataWithActionSignature(workflowLaneMetadata{}, workflowActionCauseBlockedRecovery, signature)
-	if err := o.updateIssueStateByIDWithMetadata(ctx, state, issue.ID, issue, targetState, now, "cause_blocked_recovery", metadata); err != nil {
+	if err := o.updateIssueStateByIDWithMetadata(ctx, state, issue.ID, issue, targetState, now, "cause_blocked_recovery", metadata, laneMutationPreserveOwnership); err != nil {
 		o.recordBlockedRecoveryDecision(ctx, state, issue, "hold", "transition_failed", &park, currentFingerprint)
 		return false
 	}
@@ -617,6 +617,7 @@ func (o *Orchestrator) reconcileBlockedReadyPullRequest(
 		now,
 		workflowActionBlockedReadyPRReconciliation,
 		metadata,
+		laneMutationPreserveOwnership,
 	); err != nil {
 		o.recordBlockedRecoveryDecision(ctx, state, issue, "defer", "ready_pr_reconciliation_transition_failed", &park, signature)
 		if o.logger != nil {

--- a/internal/orchestrator/blocked_recovery.go
+++ b/internal/orchestrator/blocked_recovery.go
@@ -587,7 +587,7 @@ func (o *Orchestrator) applyReworkBreakerAutoUnpark(
 		targetState = autoPromoteMergingState
 	}
 	metadata := workflowLaneMetadataWithActionSignature(workflowLaneMetadata{}, workflowActionReworkBreakerAutoUnpark, park.Signature)
-	if err := o.updateIssueStateByIDStrictWithMetadata(ctx, state, issueID, issue, targetState, now, "rework_breaker_auto_unpark", metadata); err != nil {
+	if err := o.updateIssueStateByIDStrictWithMetadata(ctx, state, issueID, issue, targetState, now, "rework_breaker_auto_unpark", metadata, laneMutationPreserveOwnership); err != nil {
 		if o.logger != nil {
 			o.logger.Warn("rework breaker auto-unpark transition failed", "issue_id", issueID, "identifier", issue.Identifier, "reason", park.Reason, "signature", park.Signature, "error", err)
 		}
@@ -653,7 +653,7 @@ func (o *Orchestrator) applyBlockedRecovery(
 		targetState = autoPromoteReworkState
 	}
 	metadata := workflowLaneMetadataWithActionSignature(workflowLaneMetadata{}, workflowActionBlockedRecovery, signature)
-	if err := o.updateIssueStateByIDWithMetadata(ctx, state, issueID, issue, targetState, now, "blocked_recovery", metadata); err != nil {
+	if err := o.updateIssueStateByIDWithMetadata(ctx, state, issueID, issue, targetState, now, "blocked_recovery", metadata, laneMutationPreserveOwnership); err != nil {
 		if o.logger != nil {
 			o.logger.Warn("blocked recovery transition failed", "issue_id", issueID, "identifier", issue.Identifier, "from_state", issue.State, "target_state", targetState, "reason", decision.Reason, "signature", signature, "error", err)
 		}

--- a/internal/orchestrator/blocker_evidence.go
+++ b/internal/orchestrator/blocker_evidence.go
@@ -606,6 +606,7 @@ func (o *Orchestrator) applyRecordedBlockerRecovery(
 		now,
 		workflowActionRecordedBlockerRecovery,
 		metadata,
+		laneMutationPreserveOwnership,
 	); err != nil {
 		if o.logger != nil {
 			o.logger.Warn("recorded blocker recovery failed", "issue_id", issue.ID, "identifier", issue.Identifier, "target_state", targetState, "error", err)

--- a/internal/orchestrator/completion_transition.go
+++ b/internal/orchestrator/completion_transition.go
@@ -70,7 +70,7 @@ func (o *Orchestrator) transitionCompletedActiveIssuesToReview(
 			continue
 		}
 
-		if err := o.updateIssueStateByID(ctx, state, issueID, issue, targetState, now, "completed_active_review_transition"); err != nil {
+		if err := o.updateIssueStateByID(ctx, state, issueID, issue, targetState, now, "completed_active_review_transition", laneMutationAcceptCompletion); err != nil {
 			if o.logger != nil {
 				o.logger.Warn(
 					"completed issue review transition failed",
@@ -136,7 +136,7 @@ func (o *Orchestrator) transitionActiveArtifactGateWaitIssuesToReview(
 			continue
 		}
 
-		if err := o.updateIssueStateByID(ctx, state, issueID, issue, targetState, now, "artifact_gate_wait_review_reconciliation"); err != nil {
+		if err := o.updateIssueStateByID(ctx, state, issueID, issue, targetState, now, "artifact_gate_wait_review_reconciliation", laneMutationAcceptCompletion); err != nil {
 			if o.logger != nil {
 				o.logger.Warn(
 					"artifact gate wait review reconciliation failed",
@@ -398,7 +398,7 @@ func (o *Orchestrator) transitionTimedOutCompletedActiveGateWait(
 		return true, promoted
 	}
 	targetState := cfg.SourceState
-	if err := o.updateIssueStateByID(ctx, state, issueID, issue, targetState, now, "auto_promote_gate_wait_timeout"); err != nil {
+	if err := o.updateIssueStateByID(ctx, state, issueID, issue, targetState, now, "auto_promote_gate_wait_timeout", laneMutationAcceptCompletion); err != nil {
 		if o.logger != nil {
 			o.logger.Warn(
 				"completed issue gate wait timeout transition failed",

--- a/internal/orchestrator/deliverable_recovery.go
+++ b/internal/orchestrator/deliverable_recovery.go
@@ -208,7 +208,7 @@ func (o *Orchestrator) blockDeliverableRecoveryFailure(
 	reasonCode := deliverableRecoveryReasonCode(lookup)
 	metadata.BlockedRecovery.HoldReason = reasonCode
 	metadata.BlockedRecovery.OperatorRemedy = humanAction
-	if err := o.updateIssueStateByIDWithMetadata(ctx, state, issue.ID, issue, blockedStatusState, event.CompletedAt, reason, metadata); err != nil {
+	if err := o.updateIssueStateByIDWithMetadata(ctx, state, issue.ID, issue, blockedStatusState, event.CompletedAt, reason, metadata, laneMutationRevokeWorker); err != nil {
 		if o.logger != nil {
 			o.logger.Warn(
 				"deliverable recovery block transition failed",
@@ -306,7 +306,7 @@ func (o *Orchestrator) blockHumanOwnedWorkerFailure(
 	metadata.BlockedRecovery.Owner = blockedRecoveryOwnerHuman
 	metadata.BlockedRecovery.HoldReason = cause
 	metadata.BlockedRecovery.OperatorRemedy = humanAction
-	if err := o.updateIssueStateByIDWithMetadata(ctx, state, issue.ID, issue, blockedStatusState, event.CompletedAt, cause, metadata); err != nil {
+	if err := o.updateIssueStateByIDWithMetadata(ctx, state, issue.ID, issue, blockedStatusState, event.CompletedAt, cause, metadata, laneMutationRevokeWorker); err != nil {
 		if o.logger != nil {
 			o.logger.Warn(eventName+" state transition failed", "issue_id", issue.ID, "identifier", issue.Identifier, "error", err)
 		}

--- a/internal/orchestrator/dependency_autounblock.go
+++ b/internal/orchestrator/dependency_autounblock.go
@@ -287,7 +287,7 @@ func (o *Orchestrator) applyBlockerAutoPromote(
 	now time.Time,
 ) bool {
 	issueID := strings.TrimSpace(blocker.ID)
-	if err := o.updateIssueStateByID(ctx, state, issueID, blocker, targetState, now, "blocker_auto_promote"); err != nil {
+	if err := o.updateIssueStateByID(ctx, state, issueID, blocker, targetState, now, "blocker_auto_promote", laneMutationPreserveOwnership); err != nil {
 		if o.logger != nil {
 			o.logger.Warn(
 				"blocker auto-promote transition failed",
@@ -956,7 +956,7 @@ func (o *Orchestrator) applyDependencyAutoUnblock(
 			Blockers:   dependencyAutoUnblockBlockerLabels(blockers),
 		},
 	}
-	if err := o.updateIssueStateByIDStrictWithMetadata(ctx, state, issueID, issue, targetState, now, "dependency_auto_unblock", metadata); err != nil {
+	if err := o.updateIssueStateByIDStrictWithMetadata(ctx, state, issueID, issue, targetState, now, "dependency_auto_unblock", metadata, laneMutationPreserveOwnership); err != nil {
 		if o.logger != nil {
 			o.logger.Warn("dependency auto-unblock transition failed", "issue_id", issueID, "identifier", issue.Identifier, "from_state", issue.State, "target_state", targetState, "error", err)
 		}

--- a/internal/orchestrator/dispatch.go
+++ b/internal/orchestrator/dispatch.go
@@ -550,7 +550,7 @@ func (o *Orchestrator) dispatchIssueWithAdmission(
 	dispatchStartTargetState := ""
 	if targetState != "" {
 		sourceState := issue.State
-		if err := o.updateIssueState(runCtx, state, issue, targetState, now, "dispatch_start"); err != nil {
+		if err := o.updateIssueState(runCtx, state, issue, targetState, now, "dispatch_start", laneMutationPreserveOwnership); err != nil {
 			if recovery {
 				releaseDispatchRecoveryAdmission(state, issue.ID)
 			}

--- a/internal/orchestrator/epic.go
+++ b/internal/orchestrator/epic.go
@@ -383,7 +383,7 @@ func (o *Orchestrator) resolveMissingEpicChildren(ctx context.Context, index *ep
 
 func (o *Orchestrator) finalizeCompletedEpic(ctx context.Context, state *State, issue connector.Issue, children []connector.BlockedRef) {
 	if !stateIn(issue.State, o.cfg.TerminalStates) {
-		if err := o.updateIssueState(ctx, state, issue, doneStateName(o.cfg.TerminalStates), time.Now(), "epic_children_completed"); err != nil && o.logger != nil {
+		if err := o.updateIssueState(ctx, state, issue, doneStateName(o.cfg.TerminalStates), time.Now(), "epic_children_completed", laneMutationAcceptCompletion); err != nil && o.logger != nil {
 			o.logger.Warn("move completed epic to done failed", "issue_id", issue.ID, "error", err)
 		}
 	}

--- a/internal/orchestrator/github_rest_capacity.go
+++ b/internal/orchestrator/github_rest_capacity.go
@@ -827,7 +827,7 @@ func (o *Orchestrator) reconcileRepeatedFailureGitHubRESTBudgetPark(
 	}
 	targetState := o.repeatedFailureRecoveryTarget(evidence.TargetState)
 	metadata := workflowLaneMetadataWithActionSignature(workflowLaneMetadata{}, workflowActionGitHubRESTBudgetRecovery, signature)
-	if err := o.updateIssueStateByIDStrictWithMetadata(ctx, state, issue.ID, issue, targetState, now, workflowActionGitHubRESTBudgetRecovery, metadata); err != nil {
+	if err := o.updateIssueStateByIDStrictWithMetadata(ctx, state, issue.ID, issue, targetState, now, workflowActionGitHubRESTBudgetRecovery, metadata, laneMutationPreserveOwnership); err != nil {
 		o.recordBlockedRecoveryDecision(ctx, state, issue, "defer", "transition_failed", &park, signature)
 		o.setGitHubRESTBudgetParkSurface(state, issue.ID, githubRESTBudgetStatusMessage("capacity recovered; lane transition failed", current))
 		return true, false

--- a/internal/orchestrator/implement_progress.go
+++ b/internal/orchestrator/implement_progress.go
@@ -919,7 +919,7 @@ func (o *Orchestrator) blockImplementProgress(
 	if predicate == blockedRecoveryPredicateManaged {
 		metadata.BlockedRecovery.Owner = blockedRecoveryOwnerHuman
 	}
-	if err := o.updateIssueStateByIDWithMetadata(ctx, state, issueID, issue, blockedStatusState, blockedAt, blockReason, metadata); err != nil {
+	if err := o.updateIssueStateByIDWithMetadata(ctx, state, issueID, issue, blockedStatusState, blockedAt, blockReason, metadata, laneMutationRevokeWorker); err != nil {
 		if o.logger != nil {
 			o.logger.Warn(
 				"no progress limit state transition failed",

--- a/internal/orchestrator/lane_mutation.go
+++ b/internal/orchestrator/lane_mutation.go
@@ -1,0 +1,223 @@
+package orchestrator
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/digitaldrywood/detent/internal/connector"
+	"github.com/digitaldrywood/detent/internal/store"
+)
+
+type laneMutationDisposition = store.LaneMutationDisposition
+
+const (
+	laneMutationPreserveOwnership = store.LaneMutationPreserveOwnership
+	laneMutationAcceptCompletion  = store.LaneMutationAcceptCompletion
+	laneMutationRevokeWorker      = store.LaneMutationRevokeWorker
+)
+
+var errLaneMutationDispositionRequired = errors.New("live worker lease requires a lane mutation disposition")
+
+func (o *Orchestrator) prepareLaneMutation(
+	ctx context.Context,
+	state *State,
+	issueID string,
+	issue connector.Issue,
+	targetState string,
+	at time.Time,
+	reason string,
+	dispositions []laneMutationDisposition,
+) (store.LaneMutationReceipt, Running, bool, error) {
+	if state == nil {
+		return store.LaneMutationReceipt{}, Running{}, false, nil
+	}
+	issueID = strings.TrimSpace(issueID)
+	running, leased := state.Running[issueID]
+	if !leased {
+		return store.LaneMutationReceipt{}, Running{}, false, nil
+	}
+	if len(dispositions) != 1 {
+		return store.LaneMutationReceipt{}, running, true, errLaneMutationDispositionRequired
+	}
+	disposition := dispositions[0]
+	switch disposition {
+	case laneMutationPreserveOwnership, laneMutationAcceptCompletion, laneMutationRevokeWorker:
+	default:
+		return store.LaneMutationReceipt{}, running, true, fmt.Errorf("invalid live worker lane mutation disposition %q", disposition)
+	}
+	if running.WorkAttemptID <= 0 || running.Generation == 0 {
+		return store.LaneMutationReceipt{}, running, true, errors.New("live worker lane mutation requires a work-attempt ID and generation")
+	}
+	if o.laneMutations == nil {
+		return store.LaneMutationReceipt{}, running, true, errors.New("live worker lane mutation receipt store is unavailable")
+	}
+	if at.IsZero() {
+		at = o.clockNow().UTC()
+	}
+	fromState := strings.TrimSpace(running.Issue.State)
+	if fromState == "" {
+		fromState = strings.TrimSpace(issue.State)
+	}
+	receipt, err := o.laneMutations.BeginLaneMutation(context.WithoutCancel(ctx), store.LaneMutationStart{
+		ProjectID:     o.workflowMetricsProjectID(),
+		IssueID:       issueID,
+		WorkAttemptID: running.WorkAttemptID,
+		Generation:    running.Generation,
+		Disposition:   disposition,
+		FromState:     fromState,
+		ToState:       strings.TrimSpace(targetState),
+		Reason:        strings.TrimSpace(reason),
+		RequestedAt:   at.UTC(),
+	})
+	if err != nil {
+		return store.LaneMutationReceipt{}, running, true, fmt.Errorf("persist live worker lane mutation receipt: %w", err)
+	}
+	return receipt, running, true, nil
+}
+
+func (o *Orchestrator) resolveLaneMutation(
+	ctx context.Context,
+	receipt store.LaneMutationReceipt,
+	result store.LaneMutationTrackerResult,
+	at time.Time,
+	mutationErr error,
+) error {
+	if receipt.ID <= 0 || o.laneMutations == nil {
+		return nil
+	}
+	if at.IsZero() {
+		at = o.clockNow().UTC()
+	}
+	errMessage := ""
+	if mutationErr != nil {
+		errMessage = mutationErr.Error()
+	}
+	if err := o.laneMutations.ResolveLaneMutation(context.WithoutCancel(ctx), store.LaneMutationResolution{
+		ReceiptID:     receipt.ID,
+		WorkAttemptID: receipt.WorkAttemptID,
+		Generation:    receipt.Generation,
+		TrackerResult: result,
+		ResolvedAt:    at.UTC(),
+		ErrorMessage:  errMessage,
+	}); err != nil {
+		return fmt.Errorf("resolve live worker lane mutation receipt: %w", err)
+	}
+	return nil
+}
+
+func (o *Orchestrator) applyLaneMutationDisposition(
+	ctx context.Context,
+	state *State,
+	running Running,
+	receipt store.LaneMutationReceipt,
+	issue connector.Issue,
+	at time.Time,
+) {
+	if at.IsZero() {
+		at = receipt.ResolvedAt
+	}
+	if at.IsZero() {
+		at = receipt.RequestedAt
+	}
+	if at.IsZero() {
+		at = o.clockNow().UTC()
+	}
+	transitioned := mergeIssueTrackerFields(running.Issue, issue)
+	applyIssueStateSnapshot(&transitioned, receipt.ToState, at)
+	receipt.TrackerResult = store.LaneMutationTrackerApplied
+	receipt.ResolvedAt = at.UTC()
+	switch receipt.Disposition {
+	case laneMutationPreserveOwnership, laneMutationAcceptCompletion:
+		running.Issue = transitioned
+		running.laneMutation = receipt
+		state.Running[receipt.IssueID] = running
+		if claimed, ok := state.Claimed[receipt.IssueID]; ok {
+			claimed.Issue = cloneIssue(transitioned)
+			state.Claimed[receipt.IssueID] = claimed
+		}
+	case laneMutationRevokeWorker:
+		o.beginLaneRevocationForMutation(ctx, state, running, transitioned, at, receipt)
+	}
+}
+
+func (o *Orchestrator) laneMutationReceipt(
+	ctx context.Context,
+	running Running,
+	toState string,
+) (store.LaneMutationReceipt, bool, error) {
+	if runningLaneMutationMatches(running, connector.Issue{State: toState}) {
+		return running.laneMutation, true, nil
+	}
+	if o.laneMutations == nil || running.WorkAttemptID <= 0 || running.Generation == 0 || strings.TrimSpace(running.Issue.ID) == "" {
+		return store.LaneMutationReceipt{}, false, nil
+	}
+	receipt, err := o.laneMutations.LaneMutationReceipt(context.WithoutCancel(ctx), store.LaneMutationLookup{
+		ProjectID:     o.workflowMetricsProjectID(),
+		IssueID:       running.Issue.ID,
+		WorkAttemptID: running.WorkAttemptID,
+		Generation:    running.Generation,
+		ToState:       toState,
+	})
+	if errors.Is(err, store.ErrNotFound) {
+		return store.LaneMutationReceipt{}, false, nil
+	}
+	if err != nil {
+		return store.LaneMutationReceipt{}, false, fmt.Errorf("load live worker lane mutation receipt: %w", err)
+	}
+	if receipt.IssueID != strings.TrimSpace(running.Issue.ID) ||
+		receipt.WorkAttemptID != running.WorkAttemptID ||
+		receipt.Generation != running.Generation ||
+		normalizeState(receipt.ToState) != normalizeState(toState) {
+		return store.LaneMutationReceipt{}, false, errors.New("live worker lane mutation receipt does not match the current owner")
+	}
+	return receipt, true, nil
+}
+
+func (o *Orchestrator) consumeLaneMutationReceipt(
+	ctx context.Context,
+	receipt store.LaneMutationReceipt,
+	running Running,
+	toState string,
+	at time.Time,
+) (store.LaneMutationReceipt, error) {
+	if o.laneMutations == nil {
+		return store.LaneMutationReceipt{}, errors.New("live worker lane mutation receipt store is unavailable")
+	}
+	if receipt.IssueID != strings.TrimSpace(running.Issue.ID) ||
+		receipt.WorkAttemptID != running.WorkAttemptID ||
+		receipt.Generation != running.Generation ||
+		normalizeState(receipt.ToState) != normalizeState(toState) {
+		return store.LaneMutationReceipt{}, errors.New("live worker lane mutation receipt does not match the current owner")
+	}
+	if at.IsZero() {
+		at = o.clockNow().UTC()
+	}
+	consumed, err := o.laneMutations.ConsumeLaneMutation(context.WithoutCancel(ctx), store.LaneMutationConsumption{
+		ReceiptID:     receipt.ID,
+		ProjectID:     receipt.ProjectID,
+		IssueID:       receipt.IssueID,
+		WorkAttemptID: receipt.WorkAttemptID,
+		Generation:    receipt.Generation,
+		ToState:       toState,
+		ConsumedAt:    at.UTC(),
+	})
+	if err != nil {
+		return store.LaneMutationReceipt{}, fmt.Errorf("consume live worker lane mutation receipt: %w", err)
+	}
+	if consumed.ID != receipt.ID || consumed.Disposition != receipt.Disposition {
+		return store.LaneMutationReceipt{}, errors.New("consumed live worker lane mutation receipt changed identity")
+	}
+	return consumed, nil
+}
+
+func runningLaneMutationMatches(running Running, issue connector.Issue) bool {
+	receipt := running.laneMutation
+	return receipt.ID > 0 &&
+		receipt.IssueID == strings.TrimSpace(running.Issue.ID) &&
+		receipt.WorkAttemptID == running.WorkAttemptID &&
+		receipt.Generation == running.Generation &&
+		normalizeState(receipt.ToState) == normalizeState(issue.State)
+}

--- a/internal/orchestrator/lane_mutation_test.go
+++ b/internal/orchestrator/lane_mutation_test.go
@@ -1,0 +1,496 @@
+package orchestrator
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"log/slog"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/digitaldrywood/detent/internal/connector"
+	"github.com/digitaldrywood/detent/internal/provenance"
+	runpkg "github.com/digitaldrywood/detent/internal/runner"
+	"github.com/digitaldrywood/detent/internal/scheduler"
+	"github.com/digitaldrywood/detent/internal/store"
+)
+
+func TestLiveLeaseLaneMutationFailsClosed(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name         string
+		generation   uint64
+		attemptDelta int64
+		dispositions []laneMutationDisposition
+		wantErr      string
+	}{
+		{name: "missing disposition", generation: 7, wantErr: errLaneMutationDispositionRequired.Error()},
+		{name: "missing generation", dispositions: []laneMutationDisposition{laneMutationPreserveOwnership}, wantErr: "work-attempt ID and generation"},
+		{name: "stale work attempt", generation: 7, attemptDelta: 1, dispositions: []laneMutationDisposition{laneMutationPreserveOwnership}, wantErr: "persist live worker lane mutation receipt"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			ctx := t.Context()
+			now := time.Date(2026, 8, 27, 14, 0, 0, 0, time.UTC)
+			issue := laneRevocationIssue("issue-fail-closed", "digitaldrywood/detent#1999", "In Progress")
+			cfg := laneMutationTestConfig()
+			runtimeStore, attemptID := openLaneMutationTestStore(t, ctx, cfg.Project.ID, issue, now)
+			tracker := &autoPromoteTickConnector{stateIssues: []connector.Issue{issue}}
+			orch := newLaneMutationTestOrchestrator(cfg, tracker, runtimeStore, &recordingWorkAttemptStore{}, now)
+			state := newState(cfg)
+			state.Running[issue.ID] = Running{
+				Issue:         issue,
+				WorkAttemptID: attemptID + tt.attemptDelta,
+				Generation:    tt.generation,
+			}
+
+			err := orch.updateIssueStateByID(ctx, &state, issue.ID, issue, "Rework", now, "test_transition", tt.dispositions...)
+			if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
+				t.Fatalf("updateIssueStateByID() error = %v, want containing %q", err, tt.wantErr)
+			}
+			if len(tracker.updates) != 0 {
+				t.Fatalf("tracker updates = %#v, want none", tracker.updates)
+			}
+		})
+	}
+}
+
+func TestGatePromotionReceiptSurvivesRestartAndCompletionFence(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	now := time.Date(2026, 8, 27, 14, 10, 0, 0, time.UTC)
+	runningIssue := laneRevocationIssue("issue-gate-promotion", "digitaldrywood/detent#1999", "In Progress")
+	gateIssue := cloneIssue(runningIssue)
+	gateIssue.State = "Human Review"
+	cfg := laneMutationTestConfig()
+	runtimeStore, attemptID := openLaneMutationTestStore(t, ctx, cfg.Project.ID, runningIssue, now)
+	tracker := &autoPromoteTickConnector{stateIssues: []connector.Issue{gateIssue}}
+	attempts := &recordingWorkAttemptStore{}
+	orch := newLaneMutationTestOrchestrator(cfg, tracker, runtimeStore, attempts, now)
+	state := newState(cfg)
+	runCtx, stop := context.WithCancelCause(context.Background())
+	state.Running[runningIssue.ID] = Running{
+		Issue:         runningIssue,
+		WorkAttemptID: attemptID,
+		Generation:    11,
+		StartedAt:     now.Add(-time.Minute),
+		stop:          stop,
+	}
+
+	if !orch.applyAutoPromoteDecision(ctx, &state, gateIssue, AutoPromoteSummary{}, autoPromoteDecision(AutoPromoteActionPromote, AutoPromoteReasonReady), "Merging", now) {
+		t.Fatal("applyAutoPromoteDecision() = false, want transition")
+	}
+	receipt := state.Running[runningIssue.ID].laneMutation
+	assertLaneMutationReceipt(t, receipt, laneMutationPreserveOwnership, "In Progress", "Merging", string(AutoPromoteReasonReady))
+	if cause := context.Cause(runCtx); cause != nil {
+		t.Fatalf("worker context cause = %v, want active lease", cause)
+	}
+
+	restartedRunning := state.Running[runningIssue.ID]
+	restartedRunning.laneMutation = store.LaneMutationReceipt{}
+	state.Running[runningIssue.ID] = restartedRunning
+	state.LastRunningReconcileAt = time.Time{}
+	orch.reconcileRunningIssues(ctx, &state, now.Add(time.Second))
+	if got := state.Running[runningIssue.ID].laneMutation.ID; got != receipt.ID {
+		t.Fatalf("recovered receipt ID = %d, want %d", got, receipt.ID)
+	}
+	if cause := context.Cause(runCtx); cause != nil {
+		t.Fatalf("worker context cause after reconciliation = %v, want active lease", cause)
+	}
+
+	orch.handleRunResult(ctx, &state, runpkg.Completion{
+		IssueID:     runningIssue.ID,
+		Request:     runpkg.RunRequest{Issue: runningIssue, WorkAttemptID: attemptID, Generation: 11},
+		CompletedAt: now.Add(2 * time.Second),
+		Result:      runpkg.RunResult{FinalState: runpkg.FinalStateCompleted, TurnStarted: true},
+	})
+	assertLaneMutationConsumed(t, ctx, runtimeStore, receipt)
+}
+
+func TestReworkLimitParkingRevokesGenerationWithExactReceipt(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	now := time.Date(2026, 8, 27, 14, 20, 0, 0, time.UTC)
+	runningIssue := laneRevocationIssue("issue-rework-limit-lease", "digitaldrywood/detent#1999", "In Progress")
+	gateIssue := cloneIssue(runningIssue)
+	gateIssue.State = "Human Review"
+	gateIssue.PullRequest = &connector.PullRequest{Number: 1999, State: "OPEN"}
+	cfg := laneMutationTestConfig()
+	cfg.AutoPromote.ReworkLimit = 1
+	runtimeStore, attemptID := openLaneMutationTestStore(t, ctx, cfg.Project.ID, runningIssue, now)
+	tracker := &autoPromoteTickConnector{stateIssues: []connector.Issue{gateIssue}}
+	attempts := &recordingWorkAttemptStore{}
+	metrics := &autoPromoteWorkflowMetricsRecorder{}
+	if _, err := metrics.RecordWorkflowPhaseEvent(ctx, store.WorkflowPhaseEvent{
+		ProjectID:    cfg.Project.ID,
+		IssueID:      gateIssue.ID,
+		Identifier:   gateIssue.Identifier,
+		PhaseType:    store.WorkflowPhaseTypeLane,
+		PhaseName:    "Rework",
+		Reason:       string(AutoPromoteReasonP1Findings),
+		Status:       "entered",
+		StartedAt:    now.Add(-time.Hour),
+		MetadataJSON: "{}",
+	}); err != nil {
+		t.Fatalf("RecordWorkflowPhaseEvent() error = %v", err)
+	}
+	orch := newLaneMutationTestOrchestrator(cfg, tracker, runtimeStore, attempts, now)
+	orch.workflowMetrics = metrics
+	state := newState(cfg)
+	runCtx, stop := context.WithCancelCause(context.Background())
+	state.Running[runningIssue.ID] = Running{
+		Issue:         runningIssue,
+		WorkAttemptID: attemptID,
+		Generation:    12,
+		StartedAt:     now.Add(-time.Minute),
+		stop:          stop,
+	}
+
+	if !orch.applyAutoPromoteDecision(ctx, &state, gateIssue, AutoPromoteSummary{}, autoPromoteDecision(AutoPromoteActionRework, AutoPromoteReasonP1Findings), "Rework", now) {
+		t.Fatal("applyAutoPromoteDecision() = false, want transition")
+	}
+	if !errors.Is(context.Cause(runCtx), runpkg.ErrLaneRevoked) {
+		t.Fatalf("worker context cause = %v, want ErrLaneRevoked", context.Cause(runCtx))
+	}
+	pending := orch.pendingLaneRevocations[runningIssue.ID]
+	if pending == nil {
+		t.Fatal("pending lane revocation missing")
+	}
+	assertLaneMutationReceipt(t, pending.mutation, laneMutationRevokeWorker, "In Progress", "Blocked", "rework_limit")
+	receipt := pending.mutation
+
+	restartedCtx, restartedStop := context.WithCancelCause(context.Background())
+	restartedRunning := state.Running[runningIssue.ID]
+	restartedRunning.Issue = runningIssue
+	restartedRunning.laneMutation = store.LaneMutationReceipt{}
+	restartedRunning.stop = restartedStop
+	state.Running[runningIssue.ID] = restartedRunning
+	state.LastRunningReconcileAt = time.Time{}
+	orch.pendingLaneRevocations = map[string]*pendingLaneRevocation{}
+	orch.reconcileRunningIssues(ctx, &state, now.Add(time.Second))
+	if !errors.Is(context.Cause(restartedCtx), runpkg.ErrLaneRevoked) {
+		t.Fatalf("restarted worker context cause = %v, want ErrLaneRevoked", context.Cause(restartedCtx))
+	}
+	pending = orch.pendingLaneRevocations[runningIssue.ID]
+	if pending == nil || pending.mutation.ID != receipt.ID {
+		t.Fatalf("restarted pending lane revocation = %#v, want receipt %d", pending, receipt.ID)
+	}
+
+	metadata := finishLaneMutationRevocation(t, ctx, orch, &state, attempts, runningIssue, attemptID, 12, now.Add(2*time.Second))
+	if metadata.FromState != "In Progress" || metadata.ToState != "Blocked" || metadata.Reason != "rework_limit" || metadata.Origin != provenance.OriginDetent {
+		t.Fatalf("lane revocation metadata = %#v", metadata)
+	}
+	assertLaneMutationConsumed(t, ctx, runtimeStore, pending.mutation)
+}
+
+func TestMergeRevocationParkingRevokesGenerationWithExactReceipt(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	now := time.Date(2026, 8, 27, 14, 30, 0, 0, time.UTC)
+	issue := laneRevocationIssue("issue-merge-revocation-lease", "digitaldrywood/detent#1999", "Merging")
+	issue.PullRequest = &connector.PullRequest{Number: 2001, State: "OPEN"}
+	cfg := laneMutationTestConfig()
+	runtimeStore, attemptID := openLaneMutationTestStore(t, ctx, cfg.Project.ID, issue, now)
+	tracker := &autoPromoteTickConnector{stateIssues: []connector.Issue{issue}}
+	prNumber := int64(issue.PullRequest.Number)
+	attempts := &recordingWorkAttemptStore{history: []store.WorkAttempt{
+		{TerminalState: store.WorkAttemptTerminalMergeRevoked, ErrorMessage: "head_changed", PRNumber: &prNumber},
+		{TerminalState: store.WorkAttemptTerminalMergeRevoked, ErrorMessage: "head_changed", PRNumber: &prNumber},
+		{TerminalState: store.WorkAttemptTerminalMergeRevoked, ErrorMessage: "head_changed", PRNumber: &prNumber},
+	}}
+	orch := newLaneMutationTestOrchestrator(cfg, tracker, runtimeStore, attempts, now)
+	state := newState(cfg)
+	runCtx, stop := context.WithCancelCause(context.Background())
+	state.Running[issue.ID] = Running{
+		Issue:         issue,
+		Mode:          runpkg.RunModeMerge,
+		WorkAttemptID: attemptID,
+		Generation:    13,
+		StartedAt:     now.Add(-time.Minute),
+		stop:          stop,
+	}
+
+	handled, parked := orch.parkRepeatedMergeRevocations(ctx, &state, issue, now)
+	if !handled || !parked {
+		t.Fatalf("parkRepeatedMergeRevocations() = (%v, %v), want (true, true)", handled, parked)
+	}
+	if !errors.Is(context.Cause(runCtx), runpkg.ErrLaneRevoked) {
+		t.Fatalf("worker context cause = %v, want ErrLaneRevoked", context.Cause(runCtx))
+	}
+	pending := orch.pendingLaneRevocations[issue.ID]
+	if pending == nil {
+		t.Fatal("pending lane revocation missing")
+	}
+	assertLaneMutationReceipt(t, pending.mutation, laneMutationRevokeWorker, "Merging", "Blocked", string(AutoPromoteReasonMergeRevocationLimit))
+
+	metadata := finishLaneMutationRevocation(t, ctx, orch, &state, attempts, issue, attemptID, 13, now.Add(time.Second))
+	if metadata.FromState != "Merging" || metadata.ToState != "Blocked" || metadata.Reason != string(AutoPromoteReasonMergeRevocationLimit) || metadata.Origin != provenance.OriginDetent {
+		t.Fatalf("lane revocation metadata = %#v", metadata)
+	}
+	assertLaneMutationConsumed(t, ctx, runtimeStore, pending.mutation)
+}
+
+func TestRecoveryLaneMutationsPreserveGeneration(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		apply  func(context.Context, *Orchestrator, *State, connector.Issue, time.Time) bool
+		target string
+		reason string
+	}{
+		{
+			name: "dependency unblocking",
+			apply: func(ctx context.Context, orch *Orchestrator, state *State, issue connector.Issue, now time.Time) bool {
+				return orch.applyDependencyAutoUnblock(ctx, state, issue, nil, "resolved-set", "Todo", now)
+			},
+			target: "Todo",
+			reason: "dependency_auto_unblock",
+		},
+		{
+			name: "blocked-cause recovery",
+			apply: func(ctx context.Context, orch *Orchestrator, state *State, issue connector.Issue, now time.Time) bool {
+				parkedInspector := staticBlockedRecoveryInspector{snapshot: runpkg.BlockedRecoverySnapshot{ConfigFingerprint: "old", Health: "ready", WorkspaceStatus: "missing"}}
+				currentInspector := staticBlockedRecoveryInspector{snapshot: runpkg.BlockedRecoverySnapshot{ConfigFingerprint: "new", Health: "ready", WorkspaceStatus: "missing"}}
+				orch.recoveryInspector = parkedInspector
+				metadata := orch.newBlockedRecoveryMetadata(ctx, issue, runpkg.RunModeImplement, "test_cause", blockedRecoveryPredicateFingerprintChange, "Todo", DiffStats{})
+				orch.recoveryInspector = currentInspector
+				state.Blocked[issue.ID] = Blocked{Issue: issue, Source: BlockedSourceProjectStatus, BlockedAt: now.Add(-time.Minute), Recovery: metadata.BlockedRecovery}
+				return orch.recoverCauseBlockedIssue(ctx, state, issue, now)
+			},
+			target: "Todo",
+			reason: "cause_blocked_recovery",
+		},
+	}
+
+	for index, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := t.Context()
+			now := time.Date(2026, 8, 27, 14, 40+index, 0, 0, time.UTC)
+			issue := dependencyAutoUnblockIssue("issue-recovery-"+strings.ReplaceAll(tt.name, " ", "-"), "Blocked")
+			cfg := laneMutationTestConfig()
+			runtimeStore, attemptID := openLaneMutationTestStore(t, ctx, cfg.Project.ID, issue, now)
+			tracker := &dependencyAutoUnblockConnector{stateIssues: []connector.Issue{issue}}
+			attempts := &recordingWorkAttemptStore{}
+			orch := newLaneMutationTestOrchestrator(cfg, tracker, runtimeStore, attempts, now)
+			orch.workflowMetrics = runtimeStore
+			state := newState(cfg)
+			runCtx, stop := context.WithCancelCause(context.Background())
+			state.Running[issue.ID] = Running{
+				Issue:         issue,
+				WorkAttemptID: attemptID,
+				Generation:    uint64(20 + index),
+				StartedAt:     now.Add(-time.Minute),
+				stop:          stop,
+			}
+
+			if !tt.apply(ctx, orch, &state, issue, now) {
+				t.Fatalf("%s transition = false", tt.name)
+			}
+			receipt := state.Running[issue.ID].laneMutation
+			assertLaneMutationReceipt(t, receipt, laneMutationPreserveOwnership, "Blocked", tt.target, tt.reason)
+			if cause := context.Cause(runCtx); cause != nil {
+				t.Fatalf("worker context cause = %v, want active lease", cause)
+			}
+		})
+	}
+}
+
+func TestAcceptCompletionLaneMutationConsumesExactReceipt(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	now := time.Date(2026, 8, 27, 14, 50, 0, 0, time.UTC)
+	issue := laneRevocationIssue("issue-accepted-completion", "digitaldrywood/detent#1999", "In Progress")
+	cfg := laneMutationTestConfig()
+	runtimeStore, attemptID := openLaneMutationTestStore(t, ctx, cfg.Project.ID, issue, now)
+	tracker := &autoPromoteTickConnector{stateIssues: []connector.Issue{issue}}
+	attempts := &recordingWorkAttemptStore{}
+	orch := newLaneMutationTestOrchestrator(cfg, tracker, runtimeStore, attempts, now)
+	state := newState(cfg)
+	state.Running[issue.ID] = Running{Issue: issue, WorkAttemptID: attemptID, Generation: 31, StartedAt: now.Add(-time.Minute)}
+
+	if err := orch.updateIssueStateByID(ctx, &state, issue.ID, issue, "Done", now, "accepted_completion", laneMutationAcceptCompletion); err != nil {
+		t.Fatalf("updateIssueStateByID() error = %v", err)
+	}
+	receipt := state.Running[issue.ID].laneMutation
+	assertLaneMutationReceipt(t, receipt, laneMutationAcceptCompletion, "In Progress", "Done", "accepted_completion")
+	orch.handleRunResult(ctx, &state, runpkg.Completion{
+		IssueID:     issue.ID,
+		Request:     runpkg.RunRequest{Issue: issue, WorkAttemptID: attemptID, Generation: 31},
+		CompletedAt: now.Add(time.Second),
+		Result:      runpkg.RunResult{FinalState: runpkg.FinalStateCompleted, TurnStarted: true},
+	})
+	assertLaneMutationConsumed(t, ctx, runtimeStore, receipt)
+	if len(attempts.completions) != 1 || attempts.completions[0].TerminalState != store.WorkAttemptTerminalSuccess {
+		t.Fatalf("work attempt completions = %#v, want success", attempts.completions)
+	}
+}
+
+func TestDurableCompletionConsumesAcceptReceiptCreatedAfterFence(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	now := time.Date(2026, 8, 27, 14, 55, 0, 0, time.UTC)
+	issue := laneRevocationIssue("issue-post-fence-completion", "digitaldrywood/detent#1999", "Merging")
+	cfg := laneMutationTestConfig()
+	runtimeStore, attemptID := openLaneMutationTestStore(t, ctx, cfg.Project.ID, issue, now)
+	tracker := &autoPromoteTickConnector{stateIssues: []connector.Issue{issue}}
+	attempts := &recordingWorkAttemptStore{}
+	orch := newLaneMutationTestOrchestrator(cfg, tracker, runtimeStore, attempts, now)
+	state := newState(cfg)
+	running := Running{Issue: issue, WorkAttemptID: attemptID, Generation: 32, StartedAt: now.Add(-time.Minute)}
+	state.Running[issue.ID] = running
+
+	if err := orch.updateIssueStateByID(ctx, &state, issue.ID, issue, "Done", now, "post_fence_completion", laneMutationAcceptCompletion); err != nil {
+		t.Fatalf("updateIssueStateByID() error = %v", err)
+	}
+	receipt := state.Running[issue.ID].laneMutation
+	assertLaneMutationReceipt(t, receipt, laneMutationAcceptCompletion, "Merging", "Done", "post_fence_completion")
+	if !orch.completeDurableWorkAttemptWithMetadata(ctx, &state, running, now.Add(time.Second), store.WorkAttemptTerminalSuccess, "", "", "completed", "worker completed", nil) {
+		t.Fatal("completeDurableWorkAttemptWithMetadata() = false, want true")
+	}
+	assertLaneMutationConsumed(t, ctx, runtimeStore, receipt)
+}
+
+type laneMutationRevocationMetadata struct {
+	FromState string            `json:"from_state"`
+	ToState   string            `json:"to_state"`
+	Reason    string            `json:"reason"`
+	Origin    provenance.Origin `json:"origin"`
+}
+
+func laneMutationTestConfig() Config {
+	return normalizeConfig(Config{
+		Project:        scheduler.ProjectCandidate{ID: "detent"},
+		ActiveStates:   []string{"Todo", "In Progress", "Rework", "Merging"},
+		ObservedStates: []string{"Human Review", "Blocked"},
+		TerminalStates: []string{"Done", "Cancelled"},
+		AutoPromote: AutoPromoteConfig{
+			Enabled:     true,
+			PassState:   "Merging",
+			ReworkState: "Rework",
+		},
+	})
+}
+
+func openLaneMutationTestStore(
+	t *testing.T,
+	ctx context.Context,
+	projectID string,
+	issue connector.Issue,
+	now time.Time,
+) (store.Store, int64) {
+	t.Helper()
+
+	runtimeStore, err := store.Open(ctx, store.Config{Backend: store.BackendSQLite, Path: filepath.Join(t.TempDir(), "detent.db")})
+	if err != nil {
+		t.Fatalf("store.Open() error = %v", err)
+	}
+	t.Cleanup(func() { _ = runtimeStore.Close() })
+	attemptID, err := runtimeStore.StartWorkAttempt(ctx, store.WorkAttemptStart{
+		ProjectID:      projectID,
+		IssueID:        issue.ID,
+		Identifier:     issue.Identifier,
+		WorkerType:     "agent",
+		Lane:           issue.State,
+		AttemptNumber:  1,
+		StartedAt:      now.Add(-time.Minute),
+		LeaseExpiresAt: now.Add(time.Minute),
+	})
+	if err != nil {
+		t.Fatalf("StartWorkAttempt() error = %v", err)
+	}
+	return runtimeStore, attemptID
+}
+
+func newLaneMutationTestOrchestrator(
+	cfg Config,
+	tracker connector.Connector,
+	runtimeStore store.Store,
+	attempts store.WorkAttemptStore,
+	now time.Time,
+) *Orchestrator {
+	return &Orchestrator{
+		cfg:                    cfg,
+		connector:              tracker,
+		workflowMetrics:        runtimeStore,
+		workAttempts:           attempts,
+		laneMutations:          runtimeStore,
+		pendingLaneRevocations: map[string]*pendingLaneRevocation{},
+		logger:                 slog.New(slog.NewTextHandler(io.Discard, nil)),
+		now:                    func() time.Time { return now },
+	}
+}
+
+func assertLaneMutationReceipt(
+	t *testing.T,
+	receipt store.LaneMutationReceipt,
+	disposition laneMutationDisposition,
+	fromState string,
+	toState string,
+	reason string,
+) {
+	t.Helper()
+
+	if receipt.ID <= 0 || receipt.Disposition != disposition || receipt.FromState != fromState || receipt.ToState != toState || receipt.Reason != reason || receipt.TrackerResult != store.LaneMutationTrackerApplied {
+		t.Fatalf("lane mutation receipt = %#v", receipt)
+	}
+}
+
+func assertLaneMutationConsumed(t *testing.T, ctx context.Context, runtimeStore store.Store, receipt store.LaneMutationReceipt) {
+	t.Helper()
+
+	_, err := runtimeStore.LaneMutationReceipt(ctx, store.LaneMutationLookup{
+		ProjectID:     receipt.ProjectID,
+		IssueID:       receipt.IssueID,
+		WorkAttemptID: receipt.WorkAttemptID,
+		Generation:    receipt.Generation,
+		ToState:       receipt.ToState,
+	})
+	if !errors.Is(err, store.ErrNotFound) {
+		t.Fatalf("LaneMutationReceipt() error = %v, want ErrNotFound after consumption", err)
+	}
+}
+
+func finishLaneMutationRevocation(
+	t *testing.T,
+	ctx context.Context,
+	orch *Orchestrator,
+	state *State,
+	attempts *recordingWorkAttemptStore,
+	issue connector.Issue,
+	attemptID int64,
+	generation uint64,
+	completedAt time.Time,
+) laneMutationRevocationMetadata {
+	t.Helper()
+
+	orch.handleRunResult(ctx, state, runpkg.Completion{
+		IssueID:     issue.ID,
+		Request:     runpkg.RunRequest{Issue: issue, WorkAttemptID: attemptID, Generation: generation},
+		CompletedAt: completedAt,
+		Err:         runpkg.ErrLaneRevoked,
+		Result:      runpkg.RunResult{FinalState: runpkg.FinalStateLaneRevoked, TurnStarted: true},
+	})
+	if len(attempts.completions) != 1 || attempts.completions[0].TerminalState != store.WorkAttemptTerminalLaneRevoked {
+		t.Fatalf("work attempt completions = %#v, want lane_revoked", attempts.completions)
+	}
+	var decoded struct {
+		LaneRevocation laneMutationRevocationMetadata `json:"lane_revocation"`
+	}
+	if err := json.Unmarshal([]byte(attempts.completions[0].WorkerMetadataJSON), &decoded); err != nil {
+		t.Fatalf("decode lane revocation metadata: %v", err)
+	}
+	return decoded.LaneRevocation
+}

--- a/internal/orchestrator/lane_revocation.go
+++ b/internal/orchestrator/lane_revocation.go
@@ -2,6 +2,7 @@ package orchestrator
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strconv"
 	"strings"
@@ -37,6 +38,8 @@ type pendingLaneRevocation struct {
 	reapOutcome   procgroup.TerminationOutcome
 	reapDone      bool
 	reapErr       error
+	mutation      store.LaneMutationReceipt
+	mutationRead  bool
 }
 
 func (o *Orchestrator) beginLaneRevocation(
@@ -47,6 +50,29 @@ func (o *Orchestrator) beginLaneRevocation(
 	now time.Time,
 	reason string,
 ) {
+	o.beginLaneRevocationWithMutation(ctx, state, running, refreshed, now, reason, store.LaneMutationReceipt{})
+}
+
+func (o *Orchestrator) beginLaneRevocationForMutation(
+	ctx context.Context,
+	state *State,
+	running Running,
+	refreshed connector.Issue,
+	now time.Time,
+	receipt store.LaneMutationReceipt,
+) {
+	o.beginLaneRevocationWithMutation(ctx, state, running, refreshed, now, receipt.Reason, receipt)
+}
+
+func (o *Orchestrator) beginLaneRevocationWithMutation(
+	ctx context.Context,
+	state *State,
+	running Running,
+	refreshed connector.Issue,
+	now time.Time,
+	reason string,
+	receipt store.LaneMutationReceipt,
+) {
 	issueID := strings.TrimSpace(running.Issue.ID)
 	if state == nil || issueID == "" {
 		return
@@ -55,7 +81,10 @@ func (o *Orchestrator) beginLaneRevocation(
 		if !pending.reapDone {
 			o.reapPendingLaneRevocation(ctx, state, pending)
 		}
-		if pending.completion != nil && pending.reapDone {
+		if pending.completion != nil && pending.reapDone && !pending.mutationRead {
+			o.consumePendingLaneRevocation(ctx, pending, pending.completion.CompletedAt)
+		}
+		if pending.completion != nil && pending.reapDone && pending.mutationRead {
 			o.finishLaneRevocation(ctx, state, pending)
 		}
 		return
@@ -68,17 +97,24 @@ func (o *Orchestrator) beginLaneRevocation(
 	}
 	fromState := strings.TrimSpace(running.Issue.State)
 	attribution := laneRevocationAttribution(state, refreshed)
+	if receipt.ID > 0 {
+		fromState = strings.TrimSpace(receipt.FromState)
+		attribution = provenance.AttributionFromSource(provenance.SourceDetentInstance, provenance.Actor{})
+		reason = strings.TrimSpace(receipt.Reason)
+	}
 	running.Issue = mergeIssueTrackerFields(running.Issue, refreshed)
 	reason = laneRevocationReason(reason, attribution)
 	pending := &pendingLaneRevocation{
-		issue:       cloneIssue(running.Issue),
-		fromState:   fromState,
-		toState:     strings.TrimSpace(running.Issue.State),
-		reason:      strings.TrimSpace(reason),
-		origin:      attribution.Origin,
-		requestedAt: now.UTC(),
-		generation:  running.Generation,
-		running:     running,
+		issue:        cloneIssue(running.Issue),
+		fromState:    fromState,
+		toState:      strings.TrimSpace(running.Issue.State),
+		reason:       strings.TrimSpace(reason),
+		origin:       attribution.Origin,
+		requestedAt:  now.UTC(),
+		generation:   running.Generation,
+		running:      running,
+		mutation:     receipt,
+		mutationRead: receipt.ID == 0,
 	}
 	o.pendingLaneRevocations[issueID] = pending
 	state.Running[issueID] = running
@@ -172,14 +208,33 @@ func (o *Orchestrator) handleLaneRevocationCompletion(
 	if !pending.reapDone {
 		o.reapPendingLaneRevocation(ctx, state, pending)
 	}
-	if pending.reapDone {
+	if pending.reapDone && !pending.mutationRead {
+		o.consumePendingLaneRevocation(ctx, pending, event.CompletedAt)
+	}
+	if pending.reapDone && pending.mutationRead {
 		o.finishLaneRevocation(ctx, state, pending)
 	}
 	return true
 }
 
+func (o *Orchestrator) consumePendingLaneRevocation(ctx context.Context, pending *pendingLaneRevocation, at time.Time) {
+	if pending == nil || pending.mutationRead || pending.mutation.ID <= 0 {
+		return
+	}
+	consumed, err := o.consumeLaneMutationReceipt(ctx, pending.mutation, pending.running, pending.toState, at)
+	if err != nil {
+		pending.reapErr = errors.Join(pending.reapErr, err)
+		if o.logger != nil {
+			o.logger.Warn("lane revocation receipt consumption failed", "issue_id", pending.issue.ID, "receipt_id", pending.mutation.ID, "error", err)
+		}
+		return
+	}
+	pending.mutation = consumed
+	pending.mutationRead = true
+}
+
 func (o *Orchestrator) finishLaneRevocation(ctx context.Context, state *State, pending *pendingLaneRevocation) {
-	if pending == nil || pending.completion == nil || !pending.reapDone {
+	if pending == nil || pending.completion == nil || !pending.reapDone || !pending.mutationRead {
 		return
 	}
 	event := *pending.completion
@@ -205,7 +260,7 @@ func (o *Orchestrator) finishLaneRevocation(ctx context.Context, state *State, p
 	}
 	running.Tokens = tokens
 	workDiscarded := laneRevocationDiscardedWork(event, running, tokens)
-	errorClass := laneRevocationErrorClass(pending.reason)
+	errorClass := laneRevocationErrorClass(pending.reason, pending.origin)
 	state.TokenTotals = addTokenTotals(state.TokenTotals, tokens)
 	state.RateLimits = mergeRateLimits(state.RateLimits, event.Result.RateLimits)
 	o.recordProjectAttemptOutcome(
@@ -310,8 +365,8 @@ func laneRevocationReason(reason string, attribution provenance.Attribution) str
 	return reason
 }
 
-func laneRevocationErrorClass(reason string) string {
-	if strings.TrimSpace(reason) == laneRevocationDetentStateChanged {
+func laneRevocationErrorClass(reason string, origin provenance.Origin) string {
+	if strings.TrimSpace(reason) == laneRevocationDetentStateChanged || provenance.NormalizeOrigin(origin) == provenance.OriginDetent {
 		return laneRevocationDetentErrorClass
 	}
 	return string(store.WorkAttemptTerminalLaneRevoked)

--- a/internal/orchestrator/lane_revocation_test.go
+++ b/internal/orchestrator/lane_revocation_test.go
@@ -264,11 +264,11 @@ func TestLaneRevocationRecordsOriginAndDiscardedWork(t *testing.T) {
 		wantOrigin      provenance.Origin
 	}{
 		{
-			name:            "active agent move before provenance refresh",
+			name:            "active user move before provenance refresh",
 			transitionActor: connector.IssueActor{Login: "operator-token", Kind: "User"},
 			wantReason:      laneRevocationStateChanged,
 			wantErrorClass:  string(store.WorkAttemptTerminalLaneRevoked),
-			wantOrigin:      provenance.OriginAgent,
+			wantOrigin:      provenance.OriginIndeterminate,
 		},
 		{
 			name:            "active app worker move before provenance refresh",
@@ -344,9 +344,7 @@ func TestLaneRevocationRecordsOriginAndDiscardedWork(t *testing.T) {
 				stop: stop,
 			}
 			if tt.detentAuthored {
-				if err := orch.updateIssueStateByID(t.Context(), &state, issue.ID, issue, parked.State, now.Add(-time.Minute), "completed_active_review_transition"); err != nil {
-					t.Fatalf("record Detent lane transition: %v", err)
-				}
+				recordIssueStateMutationProvenance(&state, issue.ID, issue, parked.State, now.Add(-time.Minute), "completed_active_review_transition", workflowLaneMetadata{})
 			} else if tt.originCached {
 				state.laneProvenance[workflowLaneEntryKey(parked)] = tt.origin
 			}
@@ -424,12 +422,12 @@ func TestLaneRevocationAttributionEvidencePrecedence(t *testing.T) {
 		workerActor     connector.IssueActor
 		want            provenance.Origin
 	}{
-		{name: "active agent", running: true, transitionActor: connector.IssueActor{Login: "operator-token", Kind: "User"}, want: provenance.OriginAgent},
+		{name: "user actor during active run", running: true, transitionActor: connector.IssueActor{Login: "operator-token", Kind: "User"}, want: provenance.OriginIndeterminate},
 		{name: "active app worker", running: true, transitionActor: connector.IssueActor{Login: "detent-worker[bot]", Kind: "Bot"}, workerActor: connector.IssueActor{Login: "detent-worker[bot]", Kind: "Bot"}, want: provenance.OriginAgent},
 		{name: "external automation", running: true, transitionActor: connector.IssueActor{Login: "external-bot", Kind: "Bot"}, workerActor: connector.IssueActor{Login: "detent-worker[bot]", Kind: "Bot"}, want: provenance.OriginAutomation},
 		{name: "operator", running: true, cached: &human, want: provenance.OriginHuman},
 		{name: "missing evidence", want: provenance.OriginIndeterminate},
-		{name: "indeterminate cache does not hide active agent", running: true, cached: &indeterminate, want: provenance.OriginAgent},
+		{name: "indeterminate cache remains indeterminate during active run", running: true, cached: &indeterminate, want: provenance.OriginIndeterminate},
 	}
 
 	for _, tt := range tests {
@@ -522,6 +520,18 @@ func TestLaneChangeFinishRaceRejectsArtifactCompletion(t *testing.T) {
 	}
 	if len(attempts.completions) != 1 || attempts.completions[0].TerminalState != store.WorkAttemptTerminalLaneRevoked {
 		t.Fatalf("work attempt completions = %#v, want lane_revoked", attempts.completions)
+	}
+	var metadata struct {
+		LaneRevocation struct {
+			FromState string `json:"from_state"`
+			ToState   string `json:"to_state"`
+		} `json:"lane_revocation"`
+	}
+	if err := json.Unmarshal([]byte(attempts.completions[0].WorkerMetadataJSON), &metadata); err != nil {
+		t.Fatalf("decode lane revocation metadata: %v", err)
+	}
+	if metadata.LaneRevocation.FromState != "Production" || metadata.LaneRevocation.ToState != "Blocked" {
+		t.Fatalf("lane transition = %s -> %s, want Production -> Blocked", metadata.LaneRevocation.FromState, metadata.LaneRevocation.ToState)
 	}
 	if !hasLaneRevocationEvent(state.RecentEvents, "stale_worker_completion_rejected") {
 		t.Fatalf("RecentEvents = %#v, want stale completion rejection", state.RecentEvents)

--- a/internal/orchestrator/lifetime_limit.go
+++ b/internal/orchestrator/lifetime_limit.go
@@ -168,7 +168,7 @@ func (o *Orchestrator) parkLifetimeLimit(
 	metadata.BlockedRecovery.LifetimeTokenLimit = decision.TokenLimit
 
 	transitioned := false
-	if err := o.updateIssueStateByIDStrictWithMetadata(ctx, state, issue.ID, issue, blockedStatusState, now, lifetimeLimitReason, metadata); err != nil {
+	if err := o.updateIssueStateByIDStrictWithMetadata(ctx, state, issue.ID, issue, blockedStatusState, now, lifetimeLimitReason, metadata, laneMutationRevokeWorker); err != nil {
 		if o.logger != nil {
 			o.logger.Error("lifetime issue limit state transition failed", "issue_id", issue.ID, "identifier", issue.Identifier, "error", err)
 		}
@@ -329,7 +329,7 @@ func (o *Orchestrator) reconcileLifetimeLimitPark(
 	}
 	signature := lifetimeLimitUsageSignature(usage)
 	metadata := workflowLaneMetadataWithActionSignature(workflowLaneMetadata{}, workflowActionLifetimeLimitRecovery, signature)
-	if err := o.updateIssueStateByIDStrictWithMetadata(ctx, state, issue.ID, issue, targetState, now, workflowActionLifetimeLimitRecovery, metadata); err != nil {
+	if err := o.updateIssueStateByIDStrictWithMetadata(ctx, state, issue.ID, issue, targetState, now, workflowActionLifetimeLimitRecovery, metadata, laneMutationPreserveOwnership); err != nil {
 		o.recordBlockedRecoveryDecision(ctx, state, issue, "defer", "transition_failed", &park, signature)
 		return true, false
 	}

--- a/internal/orchestrator/merge_duration.go
+++ b/internal/orchestrator/merge_duration.go
@@ -104,6 +104,7 @@ func (o *Orchestrator) parkMergeWorkerDurationExceeded(
 		completedAt,
 		mergeWorkerDurationExceededReason,
 		metadata,
+		laneMutationRevokeWorker,
 	)
 	if transitionErr != nil && o.logger != nil {
 		o.logger.Error(
@@ -211,6 +212,7 @@ func (o *Orchestrator) reconcileMergeDurationHolds(
 			now,
 			mergeWorkerDurationExceededReason,
 			workflowLaneMetadata{BlockedRecovery: blocked.Recovery},
+			laneMutationRevokeWorker,
 		); err != nil {
 			if o.logger != nil {
 				o.logger.Warn(

--- a/internal/orchestrator/merge_required_checks.go
+++ b/internal/orchestrator/merge_required_checks.go
@@ -99,6 +99,7 @@ func (o *Orchestrator) reconcilePersistentlyMissingRequiredCheckPark(
 		now,
 		workflowActionMergeRequiredCheckParkRecovery,
 		metadata,
+		laneMutationPreserveOwnership,
 	); err != nil {
 		o.recordBlockedRecoveryDecision(ctx, state, issue, "defer", "required_check_recovery_transition_failed", &park, signature)
 		return true, false
@@ -180,6 +181,7 @@ func (o *Orchestrator) blockPersistentlyMissingRequiredChecks(
 		event.CompletedAt,
 		reason,
 		metadata,
+		laneMutationRevokeWorker,
 	); err != nil {
 		o.failProgrammaticMergeWorkerResult(ctx, state, event, running, "merge_worker_persistent_missing_required_check_block_failed", err)
 		return

--- a/internal/orchestrator/merge_revocation.go
+++ b/internal/orchestrator/merge_revocation.go
@@ -366,6 +366,7 @@ func (o *Orchestrator) parkRepeatedMergeRevocations(
 		now,
 		string(AutoPromoteReasonMergeRevocationLimit),
 		metadata,
+		laneMutationRevokeWorker,
 	); err != nil {
 		if o.logger != nil {
 			o.logger.Warn(
@@ -531,6 +532,7 @@ func (o *Orchestrator) routeMergeRevocation(ctx context.Context, state *State, r
 		revocation.targetState,
 		at,
 		string(store.WorkAttemptTerminalMergeRevoked)+":"+revocation.reason,
+		laneMutationRevokeWorker,
 	); err != nil {
 		if o.logger != nil {
 			o.logger.Warn(
@@ -772,6 +774,7 @@ func (o *Orchestrator) escalateMergeRevocationCommentLoss(
 		targetState,
 		at,
 		reason,
+		laneMutationRevokeWorker,
 	); err != nil {
 		if o.logger != nil {
 			o.logger.Warn(

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -166,6 +166,7 @@ type Dependencies struct {
 	Runner               Runner
 	WorkspaceReaper      WorkspaceReaper
 	WorkflowMetrics      WorkflowMetricsRecorder
+	LaneMutations        store.LaneMutationStore
 	Efficiency           efficiency.Recorder
 	LifecycleExporter    efficiency.LifecycleExporter
 	WorkAttempts         store.WorkAttemptStore
@@ -224,6 +225,7 @@ type Orchestrator struct {
 	cfg                     Config
 	connector               connector.Connector
 	workflowMetrics         WorkflowMetricsRecorder
+	laneMutations           store.LaneMutationStore
 	efficiency              efficiency.Recorder
 	lifecycleExporter       efficiency.LifecycleExporter
 	workAttempts            store.WorkAttemptStore
@@ -480,6 +482,17 @@ func New(cfg Config, deps Dependencies) (*Orchestrator, error) {
 			agentResume = candidate
 		}
 	}
+	laneMutations := deps.LaneMutations
+	if laneMutations == nil {
+		if candidate, ok := deps.WorkAttempts.(store.LaneMutationStore); ok {
+			laneMutations = candidate
+		}
+	}
+	if laneMutations == nil {
+		if candidate, ok := deps.WorkflowMetrics.(store.LaneMutationStore); ok {
+			laneMutations = candidate
+		}
+	}
 	progressSpend := deps.ProgressSpend
 	if progressSpend == nil {
 		if candidate, ok := deps.WorkflowMetrics.(store.ProgressSpendStore); ok {
@@ -561,6 +574,7 @@ func New(cfg Config, deps Dependencies) (*Orchestrator, error) {
 		cfg:                     cfg,
 		connector:               deps.Connector,
 		workflowMetrics:         deps.WorkflowMetrics,
+		laneMutations:           laneMutations,
 		efficiency:              deps.Efficiency,
 		lifecycleExporter:       deps.LifecycleExporter,
 		workAttempts:            deps.WorkAttempts,

--- a/internal/orchestrator/plan_review.go
+++ b/internal/orchestrator/plan_review.go
@@ -361,7 +361,7 @@ func (o *Orchestrator) applyPlanReviewDecision(
 	if normalizeState(targetState) == normalizeState(autoPromoteReworkState) {
 		metadata = workflowLaneMetadataWithActionSignature(metadata, workflowActionPlanReviewRework, reworkSignature)
 	}
-	if err := o.updateIssueStateByIDWithMetadata(ctx, state, issueID, issue, targetState, now, "plan_review_decision", metadata); err != nil {
+	if err := o.updateIssueStateByIDWithMetadata(ctx, state, issueID, issue, targetState, now, "plan_review_decision", metadata, laneMutationRevokeWorker); err != nil {
 		if o.logger != nil {
 			o.logger.Warn(
 				"plan review transition failed",

--- a/internal/orchestrator/reconcile.go
+++ b/internal/orchestrator/reconcile.go
@@ -176,7 +176,7 @@ func (o *Orchestrator) reconcileClosedCompletedIssueStatuses(ctx context.Context
 		if !closedCompletedIssueNeedsStatusReconciliation(issue, o.cfg.TerminalStates) {
 			continue
 		}
-		if err := o.updateIssueStateByID(ctx, state, issueID, issue, targetState, now, "closed_completed_status_reconciled"); err != nil {
+		if err := o.updateIssueStateByID(ctx, state, issueID, issue, targetState, now, "closed_completed_status_reconciled", laneMutationAcceptCompletion); err != nil {
 			if o.logger != nil {
 				o.logger.Warn("reconcile closed completed issue status failed", "issue_id", issueID, "identifier", issue.Identifier, "from_state", issue.State, "target_state", targetState, "error", err)
 			}
@@ -293,7 +293,10 @@ func (o *Orchestrator) reconcileRunningIssues(ctx context.Context, state *State,
 			if !pending.reapDone {
 				o.reapPendingLaneRevocation(ctx, state, pending)
 			}
-			if pending.completion != nil && pending.reapDone {
+			if pending.completion != nil && pending.reapDone && !pending.mutationRead {
+				o.consumePendingLaneRevocation(ctx, pending, pending.completion.CompletedAt)
+			}
+			if pending.completion != nil && pending.reapDone && pending.mutationRead {
 				o.finishLaneRevocation(ctx, state, pending)
 			}
 			continue
@@ -301,6 +304,26 @@ func (o *Orchestrator) reconcileRunningIssues(ctx context.Context, state *State,
 		mergeWorker := running.Mode == runpkg.RunModeMerge || mergeWorkerIssue(running.Issue)
 		refreshedRunning := running
 		refreshedRunning.Issue = o.hydrateRunningIssueComments(ctx, mergeIssueTrackerFields(running.Issue, issue))
+		receipt, receiptFound, receiptErr := o.laneMutationReceipt(ctx, running, refreshedRunning.Issue.State)
+		if receiptErr != nil {
+			if o.logger != nil {
+				o.logger.Warn("running issue lane mutation receipt lookup failed", "issue_id", id, "error", receiptErr)
+			}
+			continue
+		}
+		if receiptFound {
+			if receipt.Disposition == laneMutationRevokeWorker {
+				o.beginLaneRevocationForMutation(ctx, state, running, refreshedRunning.Issue, now, receipt)
+				continue
+			}
+			refreshedRunning.laneMutation = receipt
+			state.Running[id] = refreshedRunning
+			if claimed, ok := state.Claimed[id]; ok {
+				claimed.Issue = cloneIssue(refreshedRunning.Issue)
+				state.Claimed[id] = claimed
+			}
+			continue
+		}
 		if mergeWorker && running.Generation == 0 {
 			var revoked bool
 			refreshedRunning, revoked = o.revokeRunningMergeIfIneligible(ctx, state, refreshedRunning, now)

--- a/internal/orchestrator/run_completion.go
+++ b/internal/orchestrator/run_completion.go
@@ -130,6 +130,7 @@ func (o *Orchestrator) handleRunResult(ctx context.Context, state *State, event 
 		return
 	}
 	if running.Generation > 0 {
+		beforeRefresh := running
 		refreshed, err := o.refreshCompletionLane(ctx, running)
 		if err != nil {
 			availabilityErr, unavailable := connector.AsTrackerAvailability(err)
@@ -143,19 +144,51 @@ func (o *Orchestrator) handleRunResult(ctx context.Context, state *State, event 
 				return
 			}
 		} else {
+			receiptAccepted := false
+			receipt, receiptFound, receiptErr := o.laneMutationReceipt(ctx, running, refreshed.State)
+			if receiptErr != nil {
+				o.rejectWorkerCompletion(ctx, state, event, running, "lane mutation receipt is unavailable", receiptErr)
+				return
+			}
+			if receiptFound {
+				running.laneMutation = receipt
+				consumed, consumeErr := o.consumeLaneMutationReceipt(ctx, receipt, running, refreshed.State, event.CompletedAt)
+				if consumeErr != nil {
+					o.rejectWorkerCompletion(ctx, state, event, running, "lane mutation receipt could not be consumed", consumeErr)
+					return
+				}
+				receipt = consumed
+				running.laneMutation = store.LaneMutationReceipt{}
+				switch receipt.Disposition {
+				case laneMutationPreserveOwnership:
+					receiptAccepted = true
+					if !stateIn(refreshed.State, o.cfg.ActiveStates) || workspaceIssueTerminal(refreshed, o.cfg.TerminalStates) {
+						running.CompletionLane = strings.TrimSpace(refreshed.State)
+						running.CompletionAcceptedAt = event.CompletedAt.UTC()
+					}
+				case laneMutationAcceptCompletion:
+					receiptAccepted = true
+					running.CompletionLane = strings.TrimSpace(refreshed.State)
+					running.CompletionAcceptedAt = event.CompletedAt.UTC()
+				case laneMutationRevokeWorker:
+					o.beginLaneRevocationForMutation(ctx, state, beforeRefresh, refreshed, event.CompletedAt, receipt)
+					o.handleLaneRevocationCompletion(ctx, state, event, beforeRefresh)
+					return
+				}
+			}
 			running.Issue = refreshed
 			state.Running[event.IssueID] = running
 			if claimed, found := state.Claimed[event.IssueID]; found {
 				claimed.Issue = cloneIssue(refreshed)
 				state.Claimed[event.IssueID] = claimed
 			}
-			if !stateIn(refreshed.State, o.cfg.ActiveStates) || workspaceIssueTerminal(refreshed, o.cfg.TerminalStates) {
+			if !receiptAccepted && (!stateIn(refreshed.State, o.cfg.ActiveStates) || workspaceIssueTerminal(refreshed, o.cfg.TerminalStates)) {
 				if accepted, ok := o.acceptCurrentAttemptCompletionLane(ctx, state, running, refreshed, event.CompletedAt); ok {
 					running = accepted
 				} else {
 					o.rejectWorkerCompletion(ctx, state, event, running, "current tracker lane is not worker-owned", nil)
-					o.beginLaneRevocation(ctx, state, running, refreshed, event.CompletedAt, laneRevocationStateChanged)
-					o.handleLaneRevocationCompletion(ctx, state, event, running)
+					o.beginLaneRevocation(ctx, state, beforeRefresh, refreshed, event.CompletedAt, laneRevocationStateChanged)
+					o.handleLaneRevocationCompletion(ctx, state, event, beforeRefresh)
 					return
 				}
 			}
@@ -936,7 +969,7 @@ func (o *Orchestrator) parkInstantFailure(
 		running.DiffStats,
 	)
 	if targetState != "" {
-		if err := o.updateIssueStateByIDWithMetadata(ctx, state, issue.ID, issue, targetState, event.CompletedAt, "instant_fail_circuit_breaker", metadata); err != nil {
+		if err := o.updateIssueStateByIDWithMetadata(ctx, state, issue.ID, issue, targetState, event.CompletedAt, "instant_fail_circuit_breaker", metadata, laneMutationRevokeWorker); err != nil {
 			if o.logger != nil {
 				o.logger.Error(
 					"instant fail circuit breaker state transition failed",
@@ -1030,7 +1063,7 @@ func (o *Orchestrator) tripTokenCeilingCircuitBreaker(
 		running.DiffStats,
 	)
 	if targetState != "" {
-		if err := o.updateIssueStateByIDWithMetadata(ctx, state, issue.ID, issue, targetState, event.CompletedAt, "token_ceiling_circuit_breaker", metadata); err != nil {
+		if err := o.updateIssueStateByIDWithMetadata(ctx, state, issue.ID, issue, targetState, event.CompletedAt, "token_ceiling_circuit_breaker", metadata, laneMutationRevokeWorker); err != nil {
 			if o.logger != nil {
 				o.logger.Error(
 					"token ceiling circuit breaker state transition failed",
@@ -1218,7 +1251,7 @@ func (o *Orchestrator) parkRepeatedFailure(
 		applyGitHubRESTBudgetEvidence(metadata.BlockedRecovery, budgetEvidence)
 	}
 	if targetState != "" {
-		if err := o.updateIssueStateByIDWithMetadata(ctx, state, issue.ID, issue, targetState, event.CompletedAt, "repeated_failure_circuit_breaker", metadata); err != nil {
+		if err := o.updateIssueStateByIDWithMetadata(ctx, state, issue.ID, issue, targetState, event.CompletedAt, "repeated_failure_circuit_breaker", metadata, laneMutationRevokeWorker); err != nil {
 			if o.logger != nil {
 				o.logger.Error(
 					"repeated failure circuit breaker state transition failed",
@@ -1499,7 +1532,7 @@ func (o *Orchestrator) completeProgrammaticMergeWorkerResult(
 		activityAt := event.CompletedAt.UTC()
 		mergedIssue.PullRequest.ActivityAt = &activityAt
 	}
-	if err := o.updateIssueStateByID(ctx, state, issueID, mergedIssue, targetState, event.CompletedAt, "merge_worker_programmatic_merge"); err != nil {
+	if err := o.updateIssueStateByID(ctx, state, issueID, mergedIssue, targetState, event.CompletedAt, "merge_worker_programmatic_merge", laneMutationAcceptCompletion); err != nil {
 		running.Issue = mergedIssue
 		o.failProgrammaticMergeWorkerResult(ctx, state, event, running, "programmatic_merge_state_update_failed", err)
 		return true
@@ -2171,7 +2204,7 @@ func (o *Orchestrator) reworkMergeWorkerResult(
 ) {
 	issueID := strings.TrimSpace(event.IssueID)
 	running.Issue = issue
-	if err := o.updateIssueStateByID(ctx, state, issueID, issue, autoPromoteReworkState, event.CompletedAt, reason); err != nil {
+	if err := o.updateIssueStateByID(ctx, state, issueID, issue, autoPromoteReworkState, event.CompletedAt, reason, laneMutationAcceptCompletion); err != nil {
 		o.failProgrammaticMergeWorkerResult(ctx, state, event, running, "merge_worker_rework_failed", err)
 		return
 	}
@@ -2311,7 +2344,7 @@ func (o *Orchestrator) blockExhaustedMergeWorker(
 		autoPromoteReworkState,
 		running.DiffStats,
 	)
-	if err := o.updateIssueStateByIDWithMetadata(ctx, state, issueID, running.Issue, blockedStatusState, completedAt, reason, metadata); err != nil {
+	if err := o.updateIssueStateByIDWithMetadata(ctx, state, issueID, running.Issue, blockedStatusState, completedAt, reason, metadata, laneMutationRevokeWorker); err != nil {
 		if o.logger != nil {
 			o.logger.Warn(
 				"merge_worker_block_failed",
@@ -2424,7 +2457,7 @@ func (o *Orchestrator) completePlanRunning(
 		o.scheduleRetry(state, issue, nextAttempt(running.Attempt), event.CompletedAt, "plan comment failed: "+err.Error(), false, running.WorkerHost)
 		return
 	}
-	if err := o.updateIssueStateByID(ctx, state, issueID, issue, cfg.Stop, event.CompletedAt, "plan_artifact_created"); err != nil {
+	if err := o.updateIssueStateByID(ctx, state, issueID, issue, cfg.Stop, event.CompletedAt, "plan_artifact_created", laneMutationAcceptCompletion); err != nil {
 		o.recordProjectAttemptOutcome(state, event.IssueID, event.CompletedAt, store.WorkAttemptTerminalFailure, err, "plan_transition_failed", err.Error())
 		o.completeDurableWorkAttempt(ctx, state, running, event.CompletedAt, store.WorkAttemptTerminalFailure, "plan_transition_failed", err.Error(), "reviewing", "plan review transition failed")
 		o.scheduleRetry(state, issue, nextAttempt(running.Attempt), event.CompletedAt, "plan review transition failed: "+err.Error(), false, running.WorkerHost)
@@ -2637,7 +2670,7 @@ func (o *Orchestrator) ensureClosedCompletedRunningIssueDone(ctx context.Context
 	if strings.TrimSpace(targetState) == "" {
 		return issue
 	}
-	if err := o.updateIssueStateByID(ctx, state, issueID, issue, targetState, now, "closed_completed_running_done"); err != nil {
+	if err := o.updateIssueStateByID(ctx, state, issueID, issue, targetState, now, "closed_completed_running_done", laneMutationAcceptCompletion); err != nil {
 		if o.logger != nil {
 			o.logger.Warn("mark closed completed running issue done failed", "issue_id", issueID, "identifier", issue.Identifier, "from_state", issue.State, "target_state", targetState, "error", err)
 		}

--- a/internal/orchestrator/session_brake.go
+++ b/internal/orchestrator/session_brake.go
@@ -132,6 +132,7 @@ func (o *Orchestrator) handleSessionBrake(
 		completedAt,
 		brake.Reason,
 		metadata,
+		laneMutationRevokeWorker,
 	); err != nil {
 		if o.logger != nil {
 			o.logger.Error(

--- a/internal/orchestrator/spend_progress.go
+++ b/internal/orchestrator/spend_progress.go
@@ -403,7 +403,7 @@ func (o *Orchestrator) blockSpendProgress(
 		autoPromoteReworkState,
 		DiffStats{},
 	)
-	if err := o.updateIssueStateByIDWithMetadata(ctx, state, issueID, issue, blockedStatusState, blockedAt, spendProgressReason, metadata); err != nil {
+	if err := o.updateIssueStateByIDWithMetadata(ctx, state, issueID, issue, blockedStatusState, blockedAt, spendProgressReason, metadata, laneMutationRevokeWorker); err != nil {
 		if o.logger != nil {
 			o.logger.Warn("spend progress circuit breaker state transition failed", "issue_id", issueID, "identifier", issue.Identifier, "error", err)
 		}

--- a/internal/orchestrator/state.go
+++ b/internal/orchestrator/state.go
@@ -163,6 +163,7 @@ type Running struct {
 	CompletionLane              string
 	CompletionWorkpadURL        string
 	CompletionAcceptedAt        time.Time
+	laneMutation                store.LaneMutationReceipt
 	StopDestination             string
 	StopPriorityOptions         []telemetry.StopRunPriorityOption
 	globalSlot                  scheduler.Slot

--- a/internal/orchestrator/stop_run.go
+++ b/internal/orchestrator/stop_run.go
@@ -370,7 +370,7 @@ func (o *Orchestrator) finishOperatorStopTransition(ctx context.Context, state *
 		)
 		metadata.BlockedRecovery.Owner = blockedRecoveryOwnerOperator
 	}
-	err := o.updateIssueStateByIDStrictWithMetadata(ctx, state, issue.ID, issue, result.Destination, result.CompletedAt, string(store.WorkAttemptTerminalOperatorStopped), metadata)
+	err := o.updateIssueStateByIDStrictWithMetadata(ctx, state, issue.ID, issue, result.Destination, result.CompletedAt, string(store.WorkAttemptTerminalOperatorStopped), metadata, laneMutationRevokeWorker)
 	if err != nil {
 		return o.failOperatorStopTransition(ctx, state, issue, result, err)
 	}

--- a/internal/orchestrator/stranded_active.go
+++ b/internal/orchestrator/stranded_active.go
@@ -103,6 +103,7 @@ func (o *Orchestrator) recoverStrandedActiveIssues(
 			now,
 			strandedActiveRecoveryReason,
 			workflowLaneMetadata{},
+			laneMutationRevokeWorker,
 		); err != nil {
 			if o.logger != nil {
 				o.logger.Warn(

--- a/internal/orchestrator/targeted_reconcile.go
+++ b/internal/orchestrator/targeted_reconcile.go
@@ -61,6 +61,7 @@ func (o *Orchestrator) applyTargetedReconcile(
 		return
 	}
 
+	priorRunning, hadRunning := state.Running[strings.TrimSpace(result.Issue.ID)]
 	issue := mergeTargetedIssue(state, result.Issue, now)
 	visibleStates := append(append([]string(nil), o.cfg.ActiveStates...), o.cfg.ObservedStates...)
 	state.BoardIssues = reconcileTargetedIssueSlice(state.BoardIssues, issue, stateIn(issue.State, visibleStates))
@@ -76,6 +77,24 @@ func (o *Orchestrator) applyTargetedReconcile(
 
 	if running, ok := state.Running[issue.ID]; ok &&
 		(!stateIn(running.Issue.State, o.cfg.ActiveStates) || workspaceIssueTerminal(running.Issue, o.cfg.TerminalStates)) {
+		if hadRunning {
+			receipt, receiptFound, receiptErr := o.laneMutationReceipt(ctx, priorRunning, running.Issue.State)
+			if receiptErr != nil {
+				if o.logger != nil {
+					o.logger.Warn("targeted lane mutation receipt lookup failed", "issue_id", issue.ID, "error", receiptErr)
+				}
+				return
+			}
+			if receiptFound {
+				if receipt.Disposition == laneMutationRevokeWorker {
+					o.beginLaneRevocationForMutation(ctx, state, priorRunning, running.Issue, now, receipt)
+					return
+				}
+				running.laneMutation = receipt
+				state.Running[issue.ID] = running
+				return
+			}
+		}
 		if accepted, acceptedCompletion := o.acceptCurrentAttemptCompletionLane(ctx, state, running, running.Issue, now); acceptedCompletion {
 			state.Running[issue.ID] = accepted
 			return
@@ -84,7 +103,10 @@ func (o *Orchestrator) applyTargetedReconcile(
 			o.completeTerminalRunning(ctx, state, issue.ID, running, terminalCompletedAt(running.Issue, o.cfg.TerminalStates, now), running.Tokens)
 			return
 		}
-		o.beginLaneRevocation(ctx, state, running, running.Issue, now, laneRevocationStateChanged)
+		if hadRunning {
+			running = priorRunning
+		}
+		o.beginLaneRevocation(ctx, state, running, issue, now, laneRevocationStateChanged)
 	}
 }
 

--- a/internal/orchestrator/terminal_attempt_retry.go
+++ b/internal/orchestrator/terminal_attempt_retry.go
@@ -59,7 +59,7 @@ func (o *Orchestrator) demoteTerminalAttemptRetry(
 	if targetState == "" {
 		return issue, false, false
 	}
-	if err := o.updateIssueState(ctx, state, issue, targetState, at, terminalAttemptWithoutWorkProductReason); err != nil {
+	if err := o.updateIssueState(ctx, state, issue, targetState, at, terminalAttemptWithoutWorkProductReason, laneMutationRevokeWorker); err != nil {
 		if o.logger != nil {
 			o.logger.Warn(
 				"terminal attempt retry demotion failed",
@@ -239,7 +239,7 @@ func (o *Orchestrator) parkRetryCycleLimit(
 		"Todo",
 		diffStats,
 	)
-	if err := o.updateIssueStateByIDWithMetadata(ctx, state, issue.ID, issue, targetState, at, cause, metadata); err != nil {
+	if err := o.updateIssueStateByIDWithMetadata(ctx, state, issue.ID, issue, targetState, at, cause, metadata, laneMutationRevokeWorker); err != nil {
 		if o.logger != nil {
 			o.logger.Error("retry cycle limit state transition failed", "issue_id", issue.ID, "identifier", issue.Identifier, "cause", cause, "target_state", targetState, "error", err)
 		}

--- a/internal/orchestrator/work_attempts.go
+++ b/internal/orchestrator/work_attempts.go
@@ -430,6 +430,12 @@ func (o *Orchestrator) completeDurableWorkAttemptWithMetadata(
 	if strings.TrimSpace(statusMessage) == "" {
 		statusMessage = string(terminalState)
 	}
+	if err := o.consumeAcceptedLaneMutationAtCompletion(ctx, state, running, completedAt); err != nil {
+		if o.logger != nil {
+			o.logger.Warn("consume accepted lane mutation before work attempt completion failed", "attempt_id", running.WorkAttemptID, "issue_id", running.Issue.ID, "error", err)
+		}
+		return false
+	}
 	completion := store.WorkAttemptCompletion{
 		AttemptID:              running.WorkAttemptID,
 		CompletedAt:            completedAt,
@@ -457,6 +463,32 @@ func (o *Orchestrator) completeDurableWorkAttemptWithMetadata(
 	}
 	o.applyWorkAttemptCompletionSnapshot(state, running, completion)
 	return true
+}
+
+func (o *Orchestrator) consumeAcceptedLaneMutationAtCompletion(
+	ctx context.Context,
+	state *State,
+	running Running,
+	completedAt time.Time,
+) error {
+	if state == nil {
+		return nil
+	}
+	issueID := strings.TrimSpace(running.Issue.ID)
+	current, ok := state.Running[issueID]
+	if !ok || current.WorkAttemptID != running.WorkAttemptID || current.Generation != running.Generation {
+		return nil
+	}
+	receipt := current.laneMutation
+	if receipt.ID <= 0 || receipt.Disposition != laneMutationAcceptCompletion {
+		return nil
+	}
+	if _, err := o.consumeLaneMutationReceipt(ctx, receipt, current, receipt.ToState, completedAt); err != nil {
+		return err
+	}
+	current.laneMutation = store.LaneMutationReceipt{}
+	state.Running[issueID] = current
+	return nil
 }
 
 func (o *Orchestrator) runningWorkAttemptHeartbeat(state *State, running Running, now time.Time) store.WorkAttemptHeartbeat {

--- a/internal/orchestrator/workflow_metrics.go
+++ b/internal/orchestrator/workflow_metrics.go
@@ -112,8 +112,9 @@ func (o *Orchestrator) updateIssueState(
 	targetState string,
 	at time.Time,
 	reason string,
+	dispositions ...laneMutationDisposition,
 ) error {
-	return o.updateIssueStateByID(ctx, state, issue.ID, issue, targetState, at, reason)
+	return o.updateIssueStateByID(ctx, state, issue.ID, issue, targetState, at, reason, dispositions...)
 }
 
 func (o *Orchestrator) updateIssueStateByID(
@@ -124,8 +125,9 @@ func (o *Orchestrator) updateIssueStateByID(
 	targetState string,
 	at time.Time,
 	reason string,
+	dispositions ...laneMutationDisposition,
 ) error {
-	return o.updateIssueStateByIDWithMetadata(ctx, state, issueID, issue, targetState, at, reason, workflowLaneMetadata{})
+	return o.updateIssueStateByIDWithMetadata(ctx, state, issueID, issue, targetState, at, reason, workflowLaneMetadata{}, dispositions...)
 }
 
 func (o *Orchestrator) updateIssueStateByIDWithMetadata(
@@ -137,8 +139,9 @@ func (o *Orchestrator) updateIssueStateByIDWithMetadata(
 	at time.Time,
 	reason string,
 	metadata workflowLaneMetadata,
+	dispositions ...laneMutationDisposition,
 ) error {
-	return o.updateIssueStateByIDWithMetadataMode(ctx, state, issueID, issue, targetState, at, reason, metadata, false)
+	return o.updateIssueStateByIDWithMetadataMode(ctx, state, issueID, issue, targetState, at, reason, metadata, false, dispositions...)
 }
 
 func (o *Orchestrator) updateIssueStateByIDStrictWithMetadata(
@@ -150,8 +153,9 @@ func (o *Orchestrator) updateIssueStateByIDStrictWithMetadata(
 	at time.Time,
 	reason string,
 	metadata workflowLaneMetadata,
+	dispositions ...laneMutationDisposition,
 ) error {
-	return o.updateIssueStateByIDWithMetadataMode(ctx, state, issueID, issue, targetState, at, reason, metadata, true)
+	return o.updateIssueStateByIDWithMetadataMode(ctx, state, issueID, issue, targetState, at, reason, metadata, true, dispositions...)
 }
 
 func (o *Orchestrator) updateIssueStateByIDWithMetadataMode(
@@ -164,16 +168,25 @@ func (o *Orchestrator) updateIssueStateByIDWithMetadataMode(
 	reason string,
 	metadata workflowLaneMetadata,
 	strict bool,
+	dispositions ...laneMutationDisposition,
 ) error {
+	receipt, running, leased, err := o.prepareLaneMutation(ctx, state, issueID, issue, targetState, at, reason, dispositions)
+	if err != nil {
+		return err
+	}
 	if err := o.connector.UpdateIssueState(ctx, issueID, targetState); err != nil {
 		if errors.Is(err, connector.ErrStateUpdateBlocked) && !strict {
+			if receiptErr := o.resolveLaneMutation(ctx, receipt, store.LaneMutationTrackerBlocked, at, err); receiptErr != nil {
+				return receiptErr
+			}
 			if o.logger != nil {
 				o.logger.Debug("skip blocked issue state update", "issue_id", issueID, "target_state", targetState, "error", err)
 			}
 			return nil
 		}
-		return err
+		return errors.Join(err, o.resolveLaneMutation(ctx, receipt, store.LaneMutationTrackerFailed, at, err))
 	}
+	receiptErr := o.resolveLaneMutation(ctx, receipt, store.LaneMutationTrackerApplied, at, nil)
 	if metadata.BlockedRecovery != nil {
 		mutationAt, ok := o.confirmTrackerStateTransition(ctx, issueID, issue, targetState)
 		if ok {
@@ -205,7 +218,10 @@ func (o *Orchestrator) updateIssueStateByIDWithMetadataMode(
 	if normalizeState(targetState) == normalizeState(autoPromoteReworkState) && normalizeState(issue.State) != normalizeState(targetState) {
 		o.captureReworkLesson(issue, at, reason)
 	}
-	return nil
+	if leased {
+		o.applyLaneMutationDisposition(ctx, state, running, receipt, issue, at)
+	}
+	return receiptErr
 }
 
 func (o *Orchestrator) confirmTrackerStateTransition(
@@ -781,11 +797,11 @@ func observedLaneAttribution(state *State, issue connector.Issue, transitionActo
 	attribution := provenance.AttributionFromSource(provenance.SourceTrackerObservation, actor)
 	if state != nil {
 		if running, ok := state.Running[strings.TrimSpace(issue.ID)]; ok {
-			if provenance.NormalizeOrigin(attribution.Origin) == provenance.OriginAutomation &&
-				!sameTrackerActor(transitionActor, running.WorkerGitHubActor) {
-				return attribution
+			if provenance.NormalizeOrigin(attribution.Origin) == provenance.OriginAutomation {
+				if sameTrackerActor(transitionActor, running.WorkerGitHubActor) {
+					return provenance.AttributionFromSource(provenance.SourceDetentAgentSession, actor)
+				}
 			}
-			return provenance.AttributionFromSource(provenance.SourceDetentAgentSession, actor)
 		}
 	}
 	return attribution

--- a/internal/orchestrator/workflow_metrics_test.go
+++ b/internal/orchestrator/workflow_metrics_test.go
@@ -290,7 +290,7 @@ func TestObservedLaneAttribution(t *testing.T) {
 		wantOrigin    provenance.Origin
 		wantInitiator provenance.Initiator
 	}{
-		{name: "active Detent agent using user token", state: &activeAgent, actor: operatorActor, wantOrigin: provenance.OriginAgent, wantInitiator: provenance.InitiatorDetentAgentSession},
+		{name: "active worker with user actor remains indeterminate", state: &activeAgent, actor: operatorActor, wantOrigin: provenance.OriginIndeterminate, wantInitiator: provenance.InitiatorIndeterminate},
 		{name: "unverified user actor", state: statePointer(newState(Config{})), actor: operatorActor, wantOrigin: provenance.OriginIndeterminate, wantInitiator: provenance.InitiatorIndeterminate},
 		{name: "external bot", state: statePointer(newState(Config{})), actor: connector.IssueActor{Login: "audit[bot]", Kind: "Bot"}, wantOrigin: provenance.OriginAutomation, wantInitiator: provenance.InitiatorExternalAutomation},
 		{name: "missing state and actor", wantOrigin: provenance.OriginIndeterminate, wantInitiator: provenance.InitiatorIndeterminate},

--- a/internal/store/lane_mutations.go
+++ b/internal/store/lane_mutations.go
@@ -1,0 +1,184 @@
+package store
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"math"
+	"strings"
+	"time"
+
+	"github.com/digitaldrywood/detent/internal/store/sqlc"
+)
+
+func (s *sqliteStore) BeginLaneMutation(ctx context.Context, attrs LaneMutationStart) (LaneMutationReceipt, error) {
+	if err := validateLaneMutationStart(attrs); err != nil {
+		return LaneMutationReceipt{}, err
+	}
+	requestedAt, err := requiredTimestamp("requested_at", attrs.RequestedAt)
+	if err != nil {
+		return LaneMutationReceipt{}, err
+	}
+	receipt, err := s.queries.CreateLaneMutationReceipt(ctx, sqlc.CreateLaneMutationReceiptParams{
+		ProjectID:     strings.TrimSpace(attrs.ProjectID),
+		IssueID:       strings.TrimSpace(attrs.IssueID),
+		Generation:    int64(attrs.Generation),
+		Disposition:   string(attrs.Disposition),
+		FromState:     strings.TrimSpace(attrs.FromState),
+		ToState:       strings.TrimSpace(attrs.ToState),
+		Reason:        strings.TrimSpace(attrs.Reason),
+		RequestedAt:   requestedAt,
+		WorkAttemptID: attrs.WorkAttemptID,
+	})
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return LaneMutationReceipt{}, ErrNotFound
+		}
+		return LaneMutationReceipt{}, fmt.Errorf("beginning lane mutation: %w", err)
+	}
+	return laneMutationReceiptFromRow(receipt)
+}
+
+func (s *sqliteStore) ResolveLaneMutation(ctx context.Context, attrs LaneMutationResolution) error {
+	if attrs.ReceiptID <= 0 || attrs.WorkAttemptID <= 0 || attrs.Generation == 0 || attrs.Generation > math.MaxInt64 {
+		return errors.New("lane mutation owner is required")
+	}
+	switch attrs.TrackerResult {
+	case LaneMutationTrackerApplied, LaneMutationTrackerBlocked, LaneMutationTrackerFailed:
+	default:
+		return fmt.Errorf("invalid lane mutation tracker result %q", attrs.TrackerResult)
+	}
+	resolvedAt, err := requiredTimestamp("resolved_at", attrs.ResolvedAt)
+	if err != nil {
+		return err
+	}
+	rows, err := s.queries.ResolveLaneMutationReceipt(ctx, sqlc.ResolveLaneMutationReceiptParams{
+		TrackerResult: string(attrs.TrackerResult),
+		ResolvedAt:    sql.NullString{String: resolvedAt, Valid: true},
+		ErrorMessage:  strings.TrimSpace(attrs.ErrorMessage),
+		ID:            attrs.ReceiptID,
+		WorkAttemptID: attrs.WorkAttemptID,
+		Generation:    int64(attrs.Generation),
+	})
+	if err != nil {
+		return fmt.Errorf("resolving lane mutation: %w", err)
+	}
+	return requireAffected(rows, "lane mutation receipt", attrs.ReceiptID)
+}
+
+func (s *sqliteStore) LaneMutationReceipt(ctx context.Context, attrs LaneMutationLookup) (LaneMutationReceipt, error) {
+	if err := validateLaneMutationOwner(attrs.ProjectID, attrs.IssueID, attrs.WorkAttemptID, attrs.Generation, attrs.ToState); err != nil {
+		return LaneMutationReceipt{}, err
+	}
+	receipt, err := s.queries.LaneMutationReceiptForOwner(ctx, sqlc.LaneMutationReceiptForOwnerParams{
+		ProjectID:     strings.TrimSpace(attrs.ProjectID),
+		IssueID:       strings.TrimSpace(attrs.IssueID),
+		WorkAttemptID: attrs.WorkAttemptID,
+		Generation:    int64(attrs.Generation),
+		ToState:       strings.TrimSpace(attrs.ToState),
+	})
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return LaneMutationReceipt{}, ErrNotFound
+		}
+		return LaneMutationReceipt{}, fmt.Errorf("loading lane mutation receipt: %w", err)
+	}
+	return laneMutationReceiptFromRow(receipt)
+}
+
+func (s *sqliteStore) ConsumeLaneMutation(ctx context.Context, attrs LaneMutationConsumption) (LaneMutationReceipt, error) {
+	if attrs.ReceiptID <= 0 {
+		return LaneMutationReceipt{}, errors.New("lane mutation receipt ID is required")
+	}
+	if err := validateLaneMutationOwner(attrs.ProjectID, attrs.IssueID, attrs.WorkAttemptID, attrs.Generation, attrs.ToState); err != nil {
+		return LaneMutationReceipt{}, err
+	}
+	consumedAt, err := requiredTimestamp("consumed_at", attrs.ConsumedAt)
+	if err != nil {
+		return LaneMutationReceipt{}, err
+	}
+	receipt, err := s.queries.ConsumeLaneMutationReceipt(ctx, sqlc.ConsumeLaneMutationReceiptParams{
+		ConsumedAt:    sql.NullString{String: consumedAt, Valid: true},
+		ID:            attrs.ReceiptID,
+		ProjectID:     strings.TrimSpace(attrs.ProjectID),
+		IssueID:       strings.TrimSpace(attrs.IssueID),
+		WorkAttemptID: attrs.WorkAttemptID,
+		Generation:    int64(attrs.Generation),
+		ToState:       strings.TrimSpace(attrs.ToState),
+	})
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return LaneMutationReceipt{}, ErrNotFound
+		}
+		return LaneMutationReceipt{}, fmt.Errorf("consuming lane mutation: %w", err)
+	}
+	return laneMutationReceiptFromRow(receipt)
+}
+
+func validateLaneMutationOwner(projectID string, issueID string, workAttemptID int64, generation uint64, toState string) error {
+	if strings.TrimSpace(projectID) == "" || strings.TrimSpace(issueID) == "" || workAttemptID <= 0 ||
+		generation == 0 || generation > math.MaxInt64 || strings.TrimSpace(toState) == "" {
+		return errors.New("lane mutation owner and target state are required")
+	}
+	return nil
+}
+
+func validateLaneMutationStart(attrs LaneMutationStart) error {
+	if strings.TrimSpace(attrs.ProjectID) == "" || strings.TrimSpace(attrs.IssueID) == "" || attrs.WorkAttemptID <= 0 ||
+		attrs.Generation == 0 || attrs.Generation > math.MaxInt64 {
+		return errors.New("lane mutation owner is required")
+	}
+	if strings.TrimSpace(attrs.ToState) == "" {
+		return errors.New("lane mutation target state is required")
+	}
+	if strings.TrimSpace(attrs.Reason) == "" {
+		return errors.New("lane mutation reason is required")
+	}
+	switch attrs.Disposition {
+	case LaneMutationPreserveOwnership, LaneMutationAcceptCompletion, LaneMutationRevokeWorker:
+		return nil
+	default:
+		return fmt.Errorf("invalid lane mutation disposition %q", attrs.Disposition)
+	}
+}
+
+func laneMutationReceiptFromRow(row sqlc.LaneMutationReceipt) (LaneMutationReceipt, error) {
+	requestedAt, err := parseTimestamp("requested_at", row.RequestedAt)
+	if err != nil {
+		return LaneMutationReceipt{}, err
+	}
+	var resolvedAt time.Time
+	if row.ResolvedAt.Valid {
+		resolvedAt, err = parseTimestamp("resolved_at", row.ResolvedAt.String)
+		if err != nil {
+			return LaneMutationReceipt{}, err
+		}
+	}
+	var consumedAt time.Time
+	if row.ConsumedAt.Valid {
+		consumedAt, err = parseTimestamp("consumed_at", row.ConsumedAt.String)
+		if err != nil {
+			return LaneMutationReceipt{}, err
+		}
+	}
+	if row.Generation <= 0 {
+		return LaneMutationReceipt{}, errors.New("lane mutation generation is invalid")
+	}
+	return LaneMutationReceipt{
+		ID:            row.ID,
+		ProjectID:     strings.TrimSpace(row.ProjectID),
+		IssueID:       strings.TrimSpace(row.IssueID),
+		WorkAttemptID: row.WorkAttemptID,
+		Generation:    uint64(row.Generation),
+		Disposition:   LaneMutationDisposition(row.Disposition),
+		FromState:     strings.TrimSpace(row.FromState),
+		ToState:       strings.TrimSpace(row.ToState),
+		Reason:        strings.TrimSpace(row.Reason),
+		TrackerResult: LaneMutationTrackerResult(row.TrackerResult),
+		RequestedAt:   requestedAt.UTC(),
+		ResolvedAt:    resolvedAt.UTC(),
+		ConsumedAt:    consumedAt.UTC(),
+		ErrorMessage:  row.ErrorMessage.String,
+	}, nil
+}

--- a/internal/store/lane_mutations.go
+++ b/internal/store/lane_mutations.go
@@ -20,7 +20,15 @@ func (s *sqliteStore) BeginLaneMutation(ctx context.Context, attrs LaneMutationS
 	if err != nil {
 		return LaneMutationReceipt{}, err
 	}
-	receipt, err := s.queries.CreateLaneMutationReceipt(ctx, sqlc.CreateLaneMutationReceiptParams{
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return LaneMutationReceipt{}, fmt.Errorf("beginning lane mutation transaction: %w", err)
+	}
+	defer func() {
+		_ = tx.Rollback()
+	}()
+	queries := s.queries.WithTx(tx)
+	receipt, err := queries.CreateLaneMutationReceipt(ctx, sqlc.CreateLaneMutationReceiptParams{
 		ProjectID:     strings.TrimSpace(attrs.ProjectID),
 		IssueID:       strings.TrimSpace(attrs.IssueID),
 		Generation:    int64(attrs.Generation),
@@ -36,6 +44,19 @@ func (s *sqliteStore) BeginLaneMutation(ctx context.Context, attrs LaneMutationS
 			return LaneMutationReceipt{}, ErrNotFound
 		}
 		return LaneMutationReceipt{}, fmt.Errorf("beginning lane mutation: %w", err)
+	}
+	if _, err := queries.SupersedeLaneMutationReceipts(ctx, sqlc.SupersedeLaneMutationReceiptsParams{
+		SupersededAt:   sql.NullString{String: requestedAt, Valid: true},
+		ProjectID:      strings.TrimSpace(attrs.ProjectID),
+		IssueID:        strings.TrimSpace(attrs.IssueID),
+		WorkAttemptID:  attrs.WorkAttemptID,
+		Generation:     int64(attrs.Generation),
+		NewerReceiptID: receipt.ID,
+	}); err != nil {
+		return LaneMutationReceipt{}, fmt.Errorf("superseding lane mutation receipts: %w", err)
+	}
+	if err := tx.Commit(); err != nil {
+		return LaneMutationReceipt{}, fmt.Errorf("committing lane mutation: %w", err)
 	}
 	return laneMutationReceiptFromRow(receipt)
 }

--- a/internal/store/lane_mutations_test.go
+++ b/internal/store/lane_mutations_test.go
@@ -284,3 +284,97 @@ func TestLaneMutationReceiptLifecycle(t *testing.T) {
 		t.Fatalf("second ConsumeLaneMutation() error = %v, want ErrNotFound", err)
 	}
 }
+
+func TestNewLaneMutationReceiptSupersedesEarlierOwnerReceipts(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	backend := openTestStore(t, ctx)
+	now := time.Date(2026, 8, 27, 14, 0, 0, 0, time.UTC)
+	attemptID, err := backend.StartWorkAttempt(ctx, WorkAttemptStart{
+		ProjectID:      "detent",
+		IssueID:        "issue-1999",
+		Identifier:     "digitaldrywood/detent#1999",
+		WorkerType:     "agent",
+		Lane:           "In Progress",
+		StartedAt:      now.Add(-time.Minute),
+		LeaseExpiresAt: now.Add(time.Minute),
+	})
+	if err != nil {
+		t.Fatalf("StartWorkAttempt() error = %v", err)
+	}
+
+	first, err := backend.BeginLaneMutation(ctx, LaneMutationStart{
+		ProjectID:     "detent",
+		IssueID:       "issue-1999",
+		WorkAttemptID: attemptID,
+		Generation:    14,
+		Disposition:   LaneMutationPreserveOwnership,
+		FromState:     "In Progress",
+		ToState:       "Blocked",
+		Reason:        "first_write",
+		RequestedAt:   now,
+	})
+	if err != nil {
+		t.Fatalf("BeginLaneMutation(first) error = %v", err)
+	}
+	if err := backend.ResolveLaneMutation(ctx, LaneMutationResolution{
+		ReceiptID:     first.ID,
+		WorkAttemptID: attemptID,
+		Generation:    14,
+		TrackerResult: LaneMutationTrackerApplied,
+		ResolvedAt:    now.Add(time.Second),
+	}); err != nil {
+		t.Fatalf("ResolveLaneMutation(first) error = %v", err)
+	}
+
+	second, err := backend.BeginLaneMutation(ctx, LaneMutationStart{
+		ProjectID:     "detent",
+		IssueID:       "issue-1999",
+		WorkAttemptID: attemptID,
+		Generation:    14,
+		Disposition:   LaneMutationRevokeWorker,
+		FromState:     "Blocked",
+		ToState:       "Done",
+		Reason:        "second_write",
+		RequestedAt:   now.Add(2 * time.Second),
+	})
+	if err != nil {
+		t.Fatalf("BeginLaneMutation(second) error = %v", err)
+	}
+
+	if _, err := backend.LaneMutationReceipt(ctx, LaneMutationLookup{
+		ProjectID:     "detent",
+		IssueID:       "issue-1999",
+		WorkAttemptID: attemptID,
+		Generation:    14,
+		ToState:       "Blocked",
+	}); !errors.Is(err, ErrNotFound) {
+		t.Fatalf("LaneMutationReceipt(first target) error = %v, want ErrNotFound", err)
+	}
+	recovered, err := backend.LaneMutationReceipt(ctx, LaneMutationLookup{
+		ProjectID:     "detent",
+		IssueID:       "issue-1999",
+		WorkAttemptID: attemptID,
+		Generation:    14,
+		ToState:       "Done",
+	})
+	if err != nil {
+		t.Fatalf("LaneMutationReceipt(second target) error = %v", err)
+	}
+	if recovered.ID != second.ID {
+		t.Fatalf("recovered receipt ID = %d, want %d", recovered.ID, second.ID)
+	}
+
+	sqliteBackend, ok := backend.(*sqliteStore)
+	if !ok {
+		t.Fatalf("Open() returned %T, want *sqliteStore", backend)
+	}
+	var trackerResult string
+	if err := sqliteBackend.db.QueryRowContext(ctx, "SELECT tracker_result FROM lane_mutation_receipts WHERE id = ?", first.ID).Scan(&trackerResult); err != nil {
+		t.Fatalf("query first tracker result: %v", err)
+	}
+	if trackerResult != string(LaneMutationTrackerSuperseded) {
+		t.Fatalf("first tracker result = %q, want %q", trackerResult, LaneMutationTrackerSuperseded)
+	}
+}

--- a/internal/store/lane_mutations_test.go
+++ b/internal/store/lane_mutations_test.go
@@ -1,0 +1,286 @@
+package store
+
+import (
+	"errors"
+	"path/filepath"
+	"strconv"
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestLaneMutationReceiptRequiresMatchingActiveAttempt(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name          string
+		issueID       string
+		completeFirst bool
+		wantErr       error
+	}{
+		{name: "matching active attempt", issueID: "issue-1999"},
+		{name: "different issue", issueID: "issue-other", wantErr: ErrNotFound},
+		{name: "terminal attempt", issueID: "issue-1999", completeFirst: true, wantErr: ErrNotFound},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			ctx := t.Context()
+			backend := openTestStore(t, ctx)
+			now := time.Date(2026, 8, 27, 13, 0, 0, 0, time.UTC)
+			attemptID, err := backend.StartWorkAttempt(ctx, WorkAttemptStart{
+				ProjectID:      "detent",
+				IssueID:        "issue-1999",
+				Identifier:     "digitaldrywood/detent#1999",
+				WorkerType:     "agent",
+				Lane:           "In Progress",
+				AttemptNumber:  1,
+				StartedAt:      now.Add(-time.Minute),
+				LeaseExpiresAt: now.Add(time.Minute),
+			})
+			if err != nil {
+				t.Fatalf("StartWorkAttempt() error = %v", err)
+			}
+			if tt.completeFirst {
+				if err := backend.CompleteWorkAttempt(ctx, WorkAttemptCompletion{
+					AttemptID:     attemptID,
+					CompletedAt:   now,
+					TerminalState: WorkAttemptTerminalSuccess,
+				}); err != nil {
+					t.Fatalf("CompleteWorkAttempt() error = %v", err)
+				}
+			}
+
+			receipt, err := backend.BeginLaneMutation(ctx, LaneMutationStart{
+				ProjectID:     "detent",
+				IssueID:       tt.issueID,
+				WorkAttemptID: attemptID,
+				Generation:    7,
+				Disposition:   LaneMutationPreserveOwnership,
+				FromState:     "In Progress",
+				ToState:       "Merging",
+				Reason:        "gate_passed",
+				RequestedAt:   now,
+			})
+			if !errors.Is(err, tt.wantErr) {
+				t.Fatalf("BeginLaneMutation() error = %v, want %v", err, tt.wantErr)
+			}
+			if tt.wantErr != nil {
+				if receipt.ID != 0 {
+					t.Fatalf("receipt = %#v, want zero", receipt)
+				}
+				return
+			}
+			if receipt.ID <= 0 || receipt.WorkAttemptID != attemptID || receipt.Generation != 7 || receipt.TrackerResult != LaneMutationTrackerPrepared {
+				t.Fatalf("receipt = %#v, want prepared matching owner", receipt)
+			}
+		})
+	}
+}
+
+func TestLaneMutationReceiptArbitratesConcurrentAttemptCompletion(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	backend := openTestStore(t, ctx)
+	now := time.Date(2026, 8, 27, 13, 45, 0, 0, time.UTC)
+	for iteration := range 16 {
+		issueID := "issue-concurrent-" + strconv.Itoa(iteration)
+		attemptID, err := backend.StartWorkAttempt(ctx, WorkAttemptStart{
+			ProjectID:      "detent",
+			IssueID:        issueID,
+			Identifier:     "digitaldrywood/detent#1999",
+			WorkerType:     "agent",
+			Lane:           "In Progress",
+			StartedAt:      now,
+			LeaseExpiresAt: now.Add(time.Minute),
+		})
+		if err != nil {
+			t.Fatalf("StartWorkAttempt() error = %v", err)
+		}
+
+		start := make(chan struct{})
+		var receipt LaneMutationReceipt
+		var receiptErr error
+		var completionErr error
+		var wait sync.WaitGroup
+		wait.Add(2)
+		go func() {
+			defer wait.Done()
+			<-start
+			receipt, receiptErr = backend.BeginLaneMutation(ctx, LaneMutationStart{
+				ProjectID:     "detent",
+				IssueID:       issueID,
+				WorkAttemptID: attemptID,
+				Generation:    uint64(iteration + 1),
+				Disposition:   LaneMutationPreserveOwnership,
+				FromState:     "In Progress",
+				ToState:       "Merging",
+				Reason:        "gate_passed",
+				RequestedAt:   now,
+			})
+		}()
+		go func() {
+			defer wait.Done()
+			<-start
+			completionErr = backend.CompleteWorkAttempt(ctx, WorkAttemptCompletion{
+				AttemptID:     attemptID,
+				CompletedAt:   now.Add(time.Second),
+				TerminalState: WorkAttemptTerminalSuccess,
+			})
+		}()
+		close(start)
+		wait.Wait()
+
+		if completionErr != nil {
+			t.Fatalf("CompleteWorkAttempt() error = %v", completionErr)
+		}
+		if receiptErr != nil && !errors.Is(receiptErr, ErrNotFound) {
+			t.Fatalf("BeginLaneMutation() error = %v, want nil or ErrNotFound", receiptErr)
+		}
+		if receiptErr == nil && (receipt.ID <= 0 || receipt.WorkAttemptID != attemptID || receipt.Generation != uint64(iteration+1)) {
+			t.Fatalf("receipt = %#v, want exact concurrent owner", receipt)
+		}
+	}
+}
+
+func TestLaneMutationReceiptSurvivesRestart(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	dbPath := filepath.Join(t.TempDir(), "detent.db")
+	now := time.Date(2026, 8, 27, 13, 30, 0, 0, time.UTC)
+	backend, err := Open(ctx, Config{Backend: BackendSQLite, Path: dbPath})
+	if err != nil {
+		t.Fatalf("Open() error = %v", err)
+	}
+	attemptID, err := backend.StartWorkAttempt(ctx, WorkAttemptStart{
+		ProjectID:      "detent",
+		IssueID:        "issue-1999",
+		Identifier:     "digitaldrywood/detent#1999",
+		WorkerType:     "agent",
+		Lane:           "In Progress",
+		StartedAt:      now.Add(-time.Minute),
+		LeaseExpiresAt: now.Add(time.Minute),
+	})
+	if err != nil {
+		t.Fatalf("StartWorkAttempt() error = %v", err)
+	}
+	receipt, err := backend.BeginLaneMutation(ctx, LaneMutationStart{
+		ProjectID:     "detent",
+		IssueID:       "issue-1999",
+		WorkAttemptID: attemptID,
+		Generation:    13,
+		Disposition:   LaneMutationPreserveOwnership,
+		FromState:     "In Progress",
+		ToState:       "Merging",
+		Reason:        "gate_passed",
+		RequestedAt:   now,
+	})
+	if err != nil {
+		t.Fatalf("BeginLaneMutation() error = %v", err)
+	}
+	if err := backend.ResolveLaneMutation(ctx, LaneMutationResolution{
+		ReceiptID:     receipt.ID,
+		WorkAttemptID: attemptID,
+		Generation:    13,
+		TrackerResult: LaneMutationTrackerApplied,
+		ResolvedAt:    now.Add(time.Second),
+	}); err != nil {
+		t.Fatalf("ResolveLaneMutation() error = %v", err)
+	}
+	if err := backend.Close(); err != nil {
+		t.Fatalf("Close() error = %v", err)
+	}
+
+	restarted, err := Open(ctx, Config{Backend: BackendSQLite, Path: dbPath})
+	if err != nil {
+		t.Fatalf("Open(restart) error = %v", err)
+	}
+	t.Cleanup(func() { _ = restarted.Close() })
+	recovered, err := restarted.LaneMutationReceipt(ctx, LaneMutationLookup{
+		ProjectID:     "detent",
+		IssueID:       "issue-1999",
+		WorkAttemptID: attemptID,
+		Generation:    13,
+		ToState:       "merging",
+	})
+	if err != nil {
+		t.Fatalf("LaneMutationReceipt() error = %v", err)
+	}
+	if recovered.ID != receipt.ID || recovered.Disposition != LaneMutationPreserveOwnership || recovered.TrackerResult != LaneMutationTrackerApplied {
+		t.Fatalf("recovered receipt = %#v, want %#v", recovered, receipt)
+	}
+}
+
+func TestLaneMutationReceiptLifecycle(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	backend := openTestStore(t, ctx)
+	now := time.Date(2026, 8, 27, 13, 15, 0, 0, time.UTC)
+	attemptID, err := backend.StartWorkAttempt(ctx, WorkAttemptStart{
+		ProjectID:      "detent",
+		IssueID:        "issue-1999",
+		Identifier:     "digitaldrywood/detent#1999",
+		WorkerType:     "agent",
+		Lane:           "In Progress",
+		AttemptNumber:  1,
+		StartedAt:      now.Add(-time.Minute),
+		LeaseExpiresAt: now.Add(time.Minute),
+	})
+	if err != nil {
+		t.Fatalf("StartWorkAttempt() error = %v", err)
+	}
+	receipt, err := backend.BeginLaneMutation(ctx, LaneMutationStart{
+		ProjectID:     "detent",
+		IssueID:       "issue-1999",
+		WorkAttemptID: attemptID,
+		Generation:    11,
+		Disposition:   LaneMutationAcceptCompletion,
+		FromState:     "Merging",
+		ToState:       "Done",
+		Reason:        "pull_request_merged",
+		RequestedAt:   now,
+	})
+	if err != nil {
+		t.Fatalf("BeginLaneMutation() error = %v", err)
+	}
+	if err := backend.ResolveLaneMutation(ctx, LaneMutationResolution{
+		ReceiptID:     receipt.ID,
+		WorkAttemptID: attemptID,
+		Generation:    11,
+		TrackerResult: LaneMutationTrackerApplied,
+		ResolvedAt:    now.Add(time.Second),
+	}); err != nil {
+		t.Fatalf("ResolveLaneMutation() error = %v", err)
+	}
+	consumed, err := backend.ConsumeLaneMutation(ctx, LaneMutationConsumption{
+		ReceiptID:     receipt.ID,
+		ProjectID:     "detent",
+		IssueID:       "issue-1999",
+		WorkAttemptID: attemptID,
+		Generation:    11,
+		ToState:       "Done",
+		ConsumedAt:    now.Add(2 * time.Second),
+	})
+	if err != nil {
+		t.Fatalf("ConsumeLaneMutation() error = %v", err)
+	}
+	if consumed.TrackerResult != LaneMutationTrackerApplied || consumed.ConsumedAt.IsZero() || consumed.Disposition != LaneMutationAcceptCompletion {
+		t.Fatalf("consumed receipt = %#v", consumed)
+	}
+	if _, err := backend.ConsumeLaneMutation(ctx, LaneMutationConsumption{
+		ReceiptID:     receipt.ID,
+		ProjectID:     "detent",
+		IssueID:       "issue-1999",
+		WorkAttemptID: attemptID,
+		Generation:    11,
+		ToState:       "Done",
+		ConsumedAt:    now.Add(3 * time.Second),
+	}); !errors.Is(err, ErrNotFound) {
+		t.Fatalf("second ConsumeLaneMutation() error = %v, want ErrNotFound", err)
+	}
+}

--- a/internal/store/migrations/00044_create_lane_mutation_receipts.sql
+++ b/internal/store/migrations/00044_create_lane_mutation_receipts.sql
@@ -1,0 +1,24 @@
+-- +goose Up
+CREATE TABLE lane_mutation_receipts (
+  id INTEGER PRIMARY KEY,
+  project_id TEXT NOT NULL,
+  issue_id TEXT NOT NULL,
+  work_attempt_id INTEGER NOT NULL,
+  generation INTEGER NOT NULL CHECK (generation > 0),
+  disposition TEXT NOT NULL CHECK (disposition IN ('preserve_ownership', 'accept_completion', 'revoke_worker')),
+  from_state TEXT NOT NULL,
+  to_state TEXT NOT NULL,
+  reason TEXT NOT NULL,
+  tracker_result TEXT NOT NULL DEFAULT 'prepared' CHECK (tracker_result IN ('prepared', 'applied', 'blocked', 'failed')),
+  requested_at TEXT NOT NULL,
+  resolved_at TEXT,
+  consumed_at TEXT,
+  error_message TEXT,
+  FOREIGN KEY (work_attempt_id) REFERENCES work_attempts(id)
+);
+
+CREATE INDEX lane_mutation_receipts_owner_idx
+ON lane_mutation_receipts(project_id, issue_id, work_attempt_id, generation, id DESC);
+
+-- +goose Down
+DROP TABLE IF EXISTS lane_mutation_receipts;

--- a/internal/store/migrations/00044_create_lane_mutation_receipts.sql
+++ b/internal/store/migrations/00044_create_lane_mutation_receipts.sql
@@ -9,7 +9,7 @@ CREATE TABLE lane_mutation_receipts (
   from_state TEXT NOT NULL,
   to_state TEXT NOT NULL,
   reason TEXT NOT NULL,
-  tracker_result TEXT NOT NULL DEFAULT 'prepared' CHECK (tracker_result IN ('prepared', 'applied', 'blocked', 'failed')),
+  tracker_result TEXT NOT NULL DEFAULT 'prepared' CHECK (tracker_result IN ('prepared', 'applied', 'blocked', 'failed', 'superseded')),
   requested_at TEXT NOT NULL,
   resolved_at TEXT,
   consumed_at TEXT,

--- a/internal/store/sqlc/models.go
+++ b/internal/store/sqlc/models.go
@@ -235,6 +235,23 @@ type IssueParkAcknowledgement struct {
 	AcknowledgedAt string         `json:"acknowledged_at"`
 }
 
+type LaneMutationReceipt struct {
+	ID            int64          `json:"id"`
+	ProjectID     string         `json:"project_id"`
+	IssueID       string         `json:"issue_id"`
+	WorkAttemptID int64          `json:"work_attempt_id"`
+	Generation    int64          `json:"generation"`
+	Disposition   string         `json:"disposition"`
+	FromState     string         `json:"from_state"`
+	ToState       string         `json:"to_state"`
+	Reason        string         `json:"reason"`
+	TrackerResult string         `json:"tracker_result"`
+	RequestedAt   string         `json:"requested_at"`
+	ResolvedAt    sql.NullString `json:"resolved_at"`
+	ConsumedAt    sql.NullString `json:"consumed_at"`
+	ErrorMessage  sql.NullString `json:"error_message"`
+}
+
 type MergeRequiredCheckStreak struct {
 	ProjectID                 string `json:"project_id"`
 	IssueID                   string `json:"issue_id"`

--- a/internal/store/sqlc/store.sql.go
+++ b/internal/store/sqlc/store.sql.go
@@ -4067,6 +4067,44 @@ func (q *Queries) SetAPIKeyExpiresAt(ctx context.Context, arg SetAPIKeyExpiresAt
 	return result.RowsAffected()
 }
 
+const supersedeLaneMutationReceipts = `-- name: SupersedeLaneMutationReceipts :execrows
+UPDATE lane_mutation_receipts
+SET tracker_result = 'superseded',
+    resolved_at = ?1,
+    error_message = NULL
+WHERE project_id = ?2
+  AND issue_id = ?3
+  AND work_attempt_id = ?4
+  AND generation = ?5
+  AND id < ?6
+  AND tracker_result IN ('prepared', 'applied')
+  AND consumed_at IS NULL
+`
+
+type SupersedeLaneMutationReceiptsParams struct {
+	SupersededAt   sql.NullString `json:"superseded_at"`
+	ProjectID      string         `json:"project_id"`
+	IssueID        string         `json:"issue_id"`
+	WorkAttemptID  int64          `json:"work_attempt_id"`
+	Generation     int64          `json:"generation"`
+	NewerReceiptID int64          `json:"newer_receipt_id"`
+}
+
+func (q *Queries) SupersedeLaneMutationReceipts(ctx context.Context, arg SupersedeLaneMutationReceiptsParams) (int64, error) {
+	result, err := q.db.ExecContext(ctx, supersedeLaneMutationReceipts,
+		arg.SupersededAt,
+		arg.ProjectID,
+		arg.IssueID,
+		arg.WorkAttemptID,
+		arg.Generation,
+		arg.NewerReceiptID,
+	)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected()
+}
+
 const timeoutExpiredWorkAttempts = `-- name: TimeoutExpiredWorkAttempts :many
 UPDATE work_attempts
 SET status = ?,

--- a/internal/store/sqlc/store.sql.go
+++ b/internal/store/sqlc/store.sql.go
@@ -262,6 +262,60 @@ func (q *Queries) CompletedIssueCycleRows(ctx context.Context) ([]CompletedIssue
 	return items, nil
 }
 
+const consumeLaneMutationReceipt = `-- name: ConsumeLaneMutationReceipt :one
+UPDATE lane_mutation_receipts
+SET consumed_at = ?1
+WHERE id = ?2
+  AND project_id = ?3
+  AND issue_id = ?4
+  AND work_attempt_id = ?5
+  AND generation = ?6
+  AND lower(trim(to_state)) = lower(trim(?7))
+  AND tracker_result IN ('prepared', 'applied')
+  AND consumed_at IS NULL
+RETURNING id, project_id, issue_id, work_attempt_id, generation, disposition, from_state, to_state, reason, tracker_result, requested_at, resolved_at, consumed_at, error_message
+`
+
+type ConsumeLaneMutationReceiptParams struct {
+	ConsumedAt    sql.NullString `json:"consumed_at"`
+	ID            int64          `json:"id"`
+	ProjectID     string         `json:"project_id"`
+	IssueID       string         `json:"issue_id"`
+	WorkAttemptID int64          `json:"work_attempt_id"`
+	Generation    int64          `json:"generation"`
+	ToState       string         `json:"to_state"`
+}
+
+func (q *Queries) ConsumeLaneMutationReceipt(ctx context.Context, arg ConsumeLaneMutationReceiptParams) (LaneMutationReceipt, error) {
+	row := q.db.QueryRowContext(ctx, consumeLaneMutationReceipt,
+		arg.ConsumedAt,
+		arg.ID,
+		arg.ProjectID,
+		arg.IssueID,
+		arg.WorkAttemptID,
+		arg.Generation,
+		arg.ToState,
+	)
+	var i LaneMutationReceipt
+	err := row.Scan(
+		&i.ID,
+		&i.ProjectID,
+		&i.IssueID,
+		&i.WorkAttemptID,
+		&i.Generation,
+		&i.Disposition,
+		&i.FromState,
+		&i.ToState,
+		&i.Reason,
+		&i.TrackerResult,
+		&i.RequestedAt,
+		&i.ResolvedAt,
+		&i.ConsumedAt,
+		&i.ErrorMessage,
+	)
+	return i, err
+}
+
 const consumeMagicLink = `-- name: ConsumeMagicLink :one
 UPDATE auth_magic_links
 SET used_at = ?1
@@ -634,6 +688,83 @@ func (q *Queries) CreateDetentRun(ctx context.Context, arg CreateDetentRunParams
 		&i.OutputTokens,
 		&i.TotalTokens,
 		&i.RuntimeSeconds,
+	)
+	return i, err
+}
+
+const createLaneMutationReceipt = `-- name: CreateLaneMutationReceipt :one
+INSERT INTO lane_mutation_receipts (
+  project_id,
+  issue_id,
+  work_attempt_id,
+  generation,
+  disposition,
+  from_state,
+  to_state,
+  reason,
+  tracker_result,
+  requested_at
+)
+SELECT
+  ?1,
+  ?2,
+  work_attempts.id,
+  ?3,
+  ?4,
+  ?5,
+  ?6,
+  ?7,
+  'prepared',
+  ?8
+FROM work_attempts
+WHERE work_attempts.id = ?9
+  AND work_attempts.project_id = ?1
+  AND COALESCE(work_attempts.issue_id, '') = ?2
+  AND work_attempts.status = 'active'
+  AND work_attempts.completed_at IS NULL
+RETURNING id, project_id, issue_id, work_attempt_id, generation, disposition, from_state, to_state, reason, tracker_result, requested_at, resolved_at, consumed_at, error_message
+`
+
+type CreateLaneMutationReceiptParams struct {
+	ProjectID     string `json:"project_id"`
+	IssueID       string `json:"issue_id"`
+	Generation    int64  `json:"generation"`
+	Disposition   string `json:"disposition"`
+	FromState     string `json:"from_state"`
+	ToState       string `json:"to_state"`
+	Reason        string `json:"reason"`
+	RequestedAt   string `json:"requested_at"`
+	WorkAttemptID int64  `json:"work_attempt_id"`
+}
+
+func (q *Queries) CreateLaneMutationReceipt(ctx context.Context, arg CreateLaneMutationReceiptParams) (LaneMutationReceipt, error) {
+	row := q.db.QueryRowContext(ctx, createLaneMutationReceipt,
+		arg.ProjectID,
+		arg.IssueID,
+		arg.Generation,
+		arg.Disposition,
+		arg.FromState,
+		arg.ToState,
+		arg.Reason,
+		arg.RequestedAt,
+		arg.WorkAttemptID,
+	)
+	var i LaneMutationReceipt
+	err := row.Scan(
+		&i.ID,
+		&i.ProjectID,
+		&i.IssueID,
+		&i.WorkAttemptID,
+		&i.Generation,
+		&i.Disposition,
+		&i.FromState,
+		&i.ToState,
+		&i.Reason,
+		&i.TrackerResult,
+		&i.RequestedAt,
+		&i.ResolvedAt,
+		&i.ConsumedAt,
+		&i.ErrorMessage,
 	)
 	return i, err
 }
@@ -2249,6 +2380,56 @@ func (q *Queries) IssueWorkflowTimelineRows(ctx context.Context, arg IssueWorkfl
 	return items, nil
 }
 
+const laneMutationReceiptForOwner = `-- name: LaneMutationReceiptForOwner :one
+SELECT id, project_id, issue_id, work_attempt_id, generation, disposition, from_state, to_state, reason, tracker_result, requested_at, resolved_at, consumed_at, error_message
+FROM lane_mutation_receipts
+WHERE project_id = ?1
+  AND issue_id = ?2
+  AND work_attempt_id = ?3
+  AND generation = ?4
+  AND lower(trim(to_state)) = lower(trim(?5))
+  AND tracker_result IN ('prepared', 'applied')
+  AND consumed_at IS NULL
+ORDER BY id DESC
+LIMIT 1
+`
+
+type LaneMutationReceiptForOwnerParams struct {
+	ProjectID     string `json:"project_id"`
+	IssueID       string `json:"issue_id"`
+	WorkAttemptID int64  `json:"work_attempt_id"`
+	Generation    int64  `json:"generation"`
+	ToState       string `json:"to_state"`
+}
+
+func (q *Queries) LaneMutationReceiptForOwner(ctx context.Context, arg LaneMutationReceiptForOwnerParams) (LaneMutationReceipt, error) {
+	row := q.db.QueryRowContext(ctx, laneMutationReceiptForOwner,
+		arg.ProjectID,
+		arg.IssueID,
+		arg.WorkAttemptID,
+		arg.Generation,
+		arg.ToState,
+	)
+	var i LaneMutationReceipt
+	err := row.Scan(
+		&i.ID,
+		&i.ProjectID,
+		&i.IssueID,
+		&i.WorkAttemptID,
+		&i.Generation,
+		&i.Disposition,
+		&i.FromState,
+		&i.ToState,
+		&i.Reason,
+		&i.TrackerResult,
+		&i.RequestedAt,
+		&i.ResolvedAt,
+		&i.ConsumedAt,
+		&i.ErrorMessage,
+	)
+	return i, err
+}
+
 const lifetimeTotals = `-- name: LifetimeTotals :one
 SELECT
   CAST(COALESCE(SUM(input_tokens), 0) AS INTEGER) AS input_tokens,
@@ -3809,6 +3990,42 @@ func (q *Queries) ReclaimActiveWorkAttempts(ctx context.Context, arg ReclaimActi
 		return nil, err
 	}
 	return items, nil
+}
+
+const resolveLaneMutationReceipt = `-- name: ResolveLaneMutationReceipt :execrows
+UPDATE lane_mutation_receipts
+SET tracker_result = ?1,
+    resolved_at = ?2,
+    error_message = NULLIF(?3, '')
+WHERE id = ?4
+  AND work_attempt_id = ?5
+  AND generation = ?6
+  AND tracker_result = 'prepared'
+  AND consumed_at IS NULL
+`
+
+type ResolveLaneMutationReceiptParams struct {
+	TrackerResult string         `json:"tracker_result"`
+	ResolvedAt    sql.NullString `json:"resolved_at"`
+	ErrorMessage  interface{}    `json:"error_message"`
+	ID            int64          `json:"id"`
+	WorkAttemptID int64          `json:"work_attempt_id"`
+	Generation    int64          `json:"generation"`
+}
+
+func (q *Queries) ResolveLaneMutationReceipt(ctx context.Context, arg ResolveLaneMutationReceiptParams) (int64, error) {
+	result, err := q.db.ExecContext(ctx, resolveLaneMutationReceipt,
+		arg.TrackerResult,
+		arg.ResolvedAt,
+		arg.ErrorMessage,
+		arg.ID,
+		arg.WorkAttemptID,
+		arg.Generation,
+	)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected()
 }
 
 const revokeAPIKey = `-- name: RevokeAPIKey :execrows

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -654,10 +654,11 @@ const (
 type LaneMutationTrackerResult string
 
 const (
-	LaneMutationTrackerPrepared LaneMutationTrackerResult = "prepared"
-	LaneMutationTrackerApplied  LaneMutationTrackerResult = "applied"
-	LaneMutationTrackerBlocked  LaneMutationTrackerResult = "blocked"
-	LaneMutationTrackerFailed   LaneMutationTrackerResult = "failed"
+	LaneMutationTrackerPrepared   LaneMutationTrackerResult = "prepared"
+	LaneMutationTrackerApplied    LaneMutationTrackerResult = "applied"
+	LaneMutationTrackerBlocked    LaneMutationTrackerResult = "blocked"
+	LaneMutationTrackerFailed     LaneMutationTrackerResult = "failed"
+	LaneMutationTrackerSuperseded LaneMutationTrackerResult = "superseded"
 )
 
 type LaneMutationReceipt struct {

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -53,6 +53,7 @@ type Store interface {
 	WorkflowMetricsStore
 	ProvenanceStore
 	WorkAttemptStore
+	LaneMutationStore
 	ProjectDispatchStatusStore
 	HealthNotificationStateStore
 	StalenessWarningStore
@@ -155,6 +156,13 @@ type WorkAttemptStore interface {
 	ReclaimActiveWorkAttempts(context.Context, WorkAttemptReclaim) ([]WorkAttempt, error)
 	RecordSchedulerDecision(context.Context, SchedulerDecision) (int64, error)
 	ListRecentSchedulerDecisions(context.Context, SchedulerDecisionQuery) ([]SchedulerDecision, error)
+}
+
+type LaneMutationStore interface {
+	BeginLaneMutation(context.Context, LaneMutationStart) (LaneMutationReceipt, error)
+	ResolveLaneMutation(context.Context, LaneMutationResolution) error
+	LaneMutationReceipt(context.Context, LaneMutationLookup) (LaneMutationReceipt, error)
+	ConsumeLaneMutation(context.Context, LaneMutationConsumption) (LaneMutationReceipt, error)
 }
 
 type ConcurrencyStore interface {
@@ -633,6 +641,79 @@ type WorkAttempt struct {
 	DetentSessionID        int64
 	ProviderSessionID      string
 	RuntimeIdentity        agentidentity.Identity
+}
+
+type LaneMutationDisposition string
+
+const (
+	LaneMutationPreserveOwnership LaneMutationDisposition = "preserve_ownership"
+	LaneMutationAcceptCompletion  LaneMutationDisposition = "accept_completion"
+	LaneMutationRevokeWorker      LaneMutationDisposition = "revoke_worker"
+)
+
+type LaneMutationTrackerResult string
+
+const (
+	LaneMutationTrackerPrepared LaneMutationTrackerResult = "prepared"
+	LaneMutationTrackerApplied  LaneMutationTrackerResult = "applied"
+	LaneMutationTrackerBlocked  LaneMutationTrackerResult = "blocked"
+	LaneMutationTrackerFailed   LaneMutationTrackerResult = "failed"
+)
+
+type LaneMutationReceipt struct {
+	ID            int64
+	ProjectID     string
+	IssueID       string
+	WorkAttemptID int64
+	Generation    uint64
+	Disposition   LaneMutationDisposition
+	FromState     string
+	ToState       string
+	Reason        string
+	TrackerResult LaneMutationTrackerResult
+	RequestedAt   time.Time
+	ResolvedAt    time.Time
+	ConsumedAt    time.Time
+	ErrorMessage  string
+}
+
+type LaneMutationStart struct {
+	ProjectID     string
+	IssueID       string
+	WorkAttemptID int64
+	Generation    uint64
+	Disposition   LaneMutationDisposition
+	FromState     string
+	ToState       string
+	Reason        string
+	RequestedAt   time.Time
+}
+
+type LaneMutationResolution struct {
+	ReceiptID     int64
+	WorkAttemptID int64
+	Generation    uint64
+	TrackerResult LaneMutationTrackerResult
+	ResolvedAt    time.Time
+	ErrorMessage  string
+}
+
+type LaneMutationLookup struct {
+	ProjectID     string
+	IssueID       string
+	WorkAttemptID int64
+	Generation    uint64
+	ToState       string
+}
+
+type LaneMutationConsumption struct {
+	ReceiptID     int64
+	ProjectID     string
+	IssueID       string
+	WorkAttemptID int64
+	Generation    uint64
+	ToState       string
+	ConsumedAt    time.Time
 }
 
 type WorkAttemptStart struct {


### PR DESCRIPTION
## Summary

- persist owner- and generation-matched receipts before Detent tracker lane writes against live worker leases
- consume exact preserve, accept-completion, and revoke intent during reconciliation and completion while retaining revocation before-images
- keep unverified live-run user transitions indeterminate and cover the background mutation paths with restart and race tests

Fixes #1999

## UI Surface Contract

- [x] N/A, or the linked issue explicitly authorizes any high-impact UI surface, layout, density, first-viewport, or responsive visibility tradeoff.
- [x] Persistent top-of-screen messaging is explicitly authorized by the issue, or this PR does not add it.
- [x] Visual changes to primary operator screens include screenshot or browser verification below.

No UI changes.

## Test Plan

- [x] `make generate`
- [x] focused lane mutation and completion tests under `go test -race`
- [x] `go test ./internal/store ./internal/orchestrator`
- [x] `make check` with the repository-pinned Go 1.26.6 and golangci-lint 2.1.6 toolchain (78.8% aggregate coverage)