### PR TITLE
fix(github): clear deleted current-head checks

### DIFF
--- a/internal/connector/github/adapter_test.go
+++ b/internal/connector/github/adapter_test.go
@@ -14,6 +14,7 @@ import (
 	"slices"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -2151,6 +2152,136 @@ func TestConnectorFetchFreshIssuesByStatesRechecksPullRequestStatusForPromotion(
 		if count != 2 {
 			t.Fatalf("%s request count = %d, want fresh status fetch each call; requests = %#v", pattern, count, requests)
 		}
+	}
+}
+
+func TestConnectorFreshPullRequestStatusReconcilesDeletedChecks(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name             string
+		secondCheckState int
+		wantError        bool
+		wantCIStatus     string
+		wantPublishedCI  string
+		wantRunning      []string
+	}{
+		{
+			name:            "authoritative snapshot removes deleted pending check",
+			wantCIStatus:    "success",
+			wantPublishedCI: "pass",
+		},
+		{
+			name:             "failed snapshot retains pending check",
+			secondCheckState: http.StatusServiceUnavailable,
+			wantError:        true,
+			wantCIStatus:     "pending",
+			wantPublishedCI:  "pending",
+			wantRunning:      []string{"Request Codex security review"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			var checkRunPageOneRequests atomic.Int64
+			var checkRunPageTwoRequests atomic.Int64
+			var logs bytes.Buffer
+			var server *httptest.Server
+			server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				switch r.URL.RequestURI() {
+				case "/repos/digitaldrywood/detent/commits/head-current/check-runs?per_page=100":
+					if checkRunPageOneRequests.Add(1) == 1 {
+						w.Header().Set("ETag", `"checks-page-1-v1"`)
+						w.Header().Set("Link", `<`+server.URL+`/repos/digitaldrywood/detent/commits/head-current/check-runs?per_page=100&page=2>; rel="next"`)
+						_, _ = w.Write([]byte(`{"check_runs":[{"id":2,"name":"Unit tests","status":"completed","conclusion":"success"}]}`))
+						return
+					}
+					if tt.secondCheckState != 0 {
+						w.WriteHeader(tt.secondCheckState)
+						_, _ = w.Write([]byte(`{"message":"temporary upstream failure"}`))
+						return
+					}
+					if r.Header.Get("If-None-Match") != "" {
+						w.WriteHeader(http.StatusNotModified)
+						return
+					}
+					w.Header().Set("ETag", `"checks-page-1-v2"`)
+					w.Header().Set("Link", `<`+server.URL+`/repos/digitaldrywood/detent/commits/head-current/check-runs?per_page=100&page=2>; rel="next"`)
+					_, _ = w.Write([]byte(`{"check_runs":[{"id":2,"name":"Unit tests","status":"completed","conclusion":"success"}]}`))
+				case "/repos/digitaldrywood/detent/commits/head-current/check-runs?per_page=100&page=2":
+					if checkRunPageTwoRequests.Add(1) == 1 {
+						w.Header().Set("ETag", `"checks-page-2-v1"`)
+						_, _ = w.Write([]byte(`{"check_runs":[{"id":1,"name":"Request Codex security review","status":"queued"}]}`))
+						return
+					}
+					if r.Header.Get("If-None-Match") != "" {
+						w.WriteHeader(http.StatusNotModified)
+						return
+					}
+					w.Header().Set("ETag", `"checks-page-2-v2"`)
+					_, _ = w.Write([]byte(`{"check_runs":[]}`))
+				case "/repos/digitaldrywood/detent/commits/head-current/statuses?per_page=100",
+					"/repos/digitaldrywood/detent/pulls/2028/reviews?per_page=100":
+					_, _ = w.Write([]byte(`[]`))
+				default:
+					w.WriteHeader(http.StatusNotFound)
+					_, _ = w.Write([]byte(`{"message":"not found"}`))
+				}
+			}))
+			t.Cleanup(server.Close)
+
+			githubConnector, err := NewConnector(Config{
+				Endpoint:   server.URL,
+				APIKey:     "token",
+				HTTPClient: server.Client(),
+				Logger:     slog.New(slog.NewTextHandler(&logs, nil)),
+			})
+			if err != nil {
+				t.Fatalf("NewConnector() error = %v", err)
+			}
+			pullRequest := pullRequestNode{Number: 2028, HeadSHA: "head-current"}
+			repo := pullRequestRepo{Owner: "digitaldrywood", Name: "detent"}
+
+			if err := githubConnector.populatePullRequestStatus(context.Background(), repo, &pullRequest, false); err != nil {
+				t.Fatalf("populatePullRequestStatus() first error = %v", err)
+			}
+			if pullRequest.CI.State != "pending" || !slices.Equal(pullRequest.CI.RunningChecks, []string{"Request Codex security review"}) {
+				t.Fatalf("first CI = %#v, want pending security review", pullRequest.CI)
+			}
+
+			err = githubConnector.populatePullRequestStatus(context.Background(), repo, &pullRequest, false)
+			if tt.wantError && err == nil {
+				t.Fatal("populatePullRequestStatus() second error = nil, want error")
+			}
+			if !tt.wantError && err != nil {
+				t.Fatalf("populatePullRequestStatus() second error = %v", err)
+			}
+			if pullRequest.CI.State != tt.wantCIStatus {
+				t.Fatalf("second CI state = %q, want %q", pullRequest.CI.State, tt.wantCIStatus)
+			}
+			if !slices.Equal(pullRequest.CI.RunningChecks, tt.wantRunning) {
+				t.Fatalf("second RunningChecks = %#v, want %#v", pullRequest.CI.RunningChecks, tt.wantRunning)
+			}
+			issue := connector.Issue{}
+			attachPullRequestToIssue(&issue, repo, pullRequest)
+			if issue.PullRequest.CIStatus != tt.wantPublishedCI || !slices.Equal(issue.PullRequest.RunningChecks, tt.wantRunning) {
+				t.Fatalf("published PullRequest = %#v, want CI %q and running %#v", issue.PullRequest, tt.wantPublishedCI, tt.wantRunning)
+			}
+			if tt.secondCheckState == 0 {
+				for _, fragment := range []string{
+					"github pull request checks reconciled",
+					"request_purpose=reconcile_current_head_checks",
+					`removed_running_checks="[Request Codex security review]"`,
+				} {
+					if !strings.Contains(logs.String(), fragment) {
+						t.Fatalf("logs missing %q:\n%s", fragment, logs.String())
+					}
+				}
+			}
+		})
 	}
 }
 

--- a/internal/connector/github/conditional.go
+++ b/internal/connector/github/conditional.go
@@ -52,6 +52,26 @@ func (c *Client) storeRESTConditionalEntry(method string, path string, headers h
 	c.mu.Unlock()
 }
 
+func (c *Client) deleteRESTConditionalEntriesForEndpoint(method string, path string) {
+	if c == nil {
+		return
+	}
+	methodPrefix := strings.ToUpper(strings.TrimSpace(method)) + " "
+	endpointPath := strings.TrimSpace(path)
+	if queryIndex := strings.IndexByte(endpointPath, '?'); queryIndex >= 0 {
+		endpointPath = endpointPath[:queryIndex]
+	}
+	exactKey := methodPrefix + endpointPath
+	queryPrefix := exactKey + "?"
+	c.mu.Lock()
+	for key := range c.restCache {
+		if key == exactKey || strings.HasPrefix(key, queryPrefix) {
+			delete(c.restCache, key)
+		}
+	}
+	c.mu.Unlock()
+}
+
 func (c *Client) evictOldestRESTConditionalEntryLocked() {
 	oldestKey := ""
 	oldestAt := time.Time{}

--- a/internal/connector/github/conditional_test.go
+++ b/internal/connector/github/conditional_test.go
@@ -239,3 +239,39 @@ func TestClientRESTConditionalCacheIsBounded(t *testing.T) {
 		t.Fatalf("conditional cache size = %d, want %d", got, restConditionalCacheMaxEntries)
 	}
 }
+
+func TestClientDeleteRESTConditionalEntriesForEndpointRemovesEveryPage(t *testing.T) {
+	t.Parallel()
+
+	client, err := NewClient(ClientConfig{
+		Endpoint:    "https://api.github.test/graphql",
+		TokenSource: StaticTokenSource("test-token"),
+	})
+	if err != nil {
+		t.Fatalf("NewClient() error = %v", err)
+	}
+	headers := http.Header{"Etag": []string{`"value"`}}
+	endpoint := "/repos/example/repo/commits/head-sha/check-runs"
+	paths := []string{
+		endpoint,
+		endpoint + "?per_page=100",
+		endpoint + "?per_page=100&page=2",
+		endpoint + "?page=3&per_page=100",
+	}
+	for _, path := range paths {
+		client.storeRESTConditionalEntry(http.MethodGet, path, headers, []byte(`{}`))
+	}
+	unrelated := "/repos/example/repo/commits/other-sha/check-runs?per_page=100"
+	client.storeRESTConditionalEntry(http.MethodGet, unrelated, headers, []byte(`{}`))
+
+	client.deleteRESTConditionalEntriesForEndpoint(http.MethodGet, endpoint+"?per_page=100")
+
+	for _, path := range paths {
+		if _, ok := client.restConditionalEntry(http.MethodGet, path); ok {
+			t.Fatalf("conditional entry %q still exists", path)
+		}
+	}
+	if _, ok := client.restConditionalEntry(http.MethodGet, unrelated); !ok {
+		t.Fatalf("unrelated conditional entry %q was removed", unrelated)
+	}
+}

--- a/internal/connector/github/pull_requests.go
+++ b/internal/connector/github/pull_requests.go
@@ -1041,6 +1041,10 @@ func samePullRequestRepo(left pullRequestRepo, right pullRequestRepo) bool {
 }
 
 func (c *Connector) populatePullRequestStatus(ctx context.Context, repo pullRequestRepo, pullRequest *pullRequestNode, useStatusCache bool) error {
+	previousStatus, hadPreviousStatus := pullRequestStatus{}, false
+	if c.pullRequests != nil {
+		previousStatus, hadPreviousStatus = c.pullRequests.Peek(repo, pullRequest.Number, pullRequest.HeadSHA)
+	}
 	if useStatusCache && c.pullRequests != nil {
 		if status, ok := c.pullRequests.Get(repo, pullRequest.Number, pullRequest.HeadSHA); ok {
 			c.logPullRequestCache(ctx, repo, pullRequest, true, false, "")
@@ -1053,6 +1057,7 @@ func (c *Connector) populatePullRequestStatus(ctx context.Context, repo pullRequ
 	status := pullRequestStatus{}
 	checksUnavailable := false
 	if strings.TrimSpace(pullRequest.HeadSHA) != "" {
+		c.deletePullRequestCIConditionalEntries(repo, pullRequest.HeadSHA)
 		ci, err := c.fetchPullRequestCI(ctx, repo, pullRequest.HeadSHA)
 		if err != nil {
 			if errors.Is(err, ErrNotFound) {
@@ -1067,6 +1072,9 @@ func (c *Connector) populatePullRequestStatus(ctx context.Context, repo pullRequ
 			}
 		} else {
 			status.ci = ci
+			if hadPreviousStatus {
+				c.logPullRequestCheckReconciliation(ctx, repo, pullRequest, previousStatus.ci, ci)
+			}
 		}
 	}
 	reviews, err := c.fetchPullRequestReviews(ctx, repo, pullRequest.Number, pullRequest.HeadSHA)
@@ -1084,6 +1092,60 @@ func (c *Connector) populatePullRequestStatus(ctx context.Context, repo pullRequ
 	}
 	applyPullRequestStatus(pullRequest, status)
 	return nil
+}
+
+func (c *Connector) deletePullRequestCIConditionalEntries(repo pullRequestRepo, headSHA string) {
+	if c == nil || c.client == nil {
+		return
+	}
+	c.client.deleteRESTConditionalEntriesForEndpoint(http.MethodGet, restCommitCheckRunsPath(repo, headSHA))
+	c.client.deleteRESTConditionalEntriesForEndpoint(http.MethodGet, restCommitStatusesPath(repo, headSHA))
+}
+
+func (c *Connector) logPullRequestCheckReconciliation(ctx context.Context, repo pullRequestRepo, pullRequest *pullRequestNode, previous pullRequestCI, current pullRequestCI) {
+	if c == nil || c.logger == nil || pullRequest == nil {
+		return
+	}
+	currentNames := make(map[string]struct{}, len(current.Checks))
+	for _, check := range current.Checks {
+		if name := strings.TrimSpace(check.Name); name != "" {
+			currentNames[name] = struct{}{}
+		}
+	}
+	removedChecks := make([]string, 0)
+	for _, check := range previous.Checks {
+		name := strings.TrimSpace(check.Name)
+		if name == "" {
+			continue
+		}
+		if _, ok := currentNames[name]; !ok {
+			removedChecks = append(removedChecks, name)
+		}
+	}
+	removedChecks = uniqueNonBlank(removedChecks)
+	if len(removedChecks) == 0 {
+		return
+	}
+	removedNames := make(map[string]struct{}, len(removedChecks))
+	for _, name := range removedChecks {
+		removedNames[name] = struct{}{}
+	}
+	removedRunningChecks := make([]string, 0)
+	for _, name := range previous.RunningChecks {
+		if _, ok := removedNames[name]; ok {
+			removedRunningChecks = append(removedRunningChecks, name)
+		}
+	}
+	c.logger.InfoContext(ctx, "github pull request checks reconciled",
+		"endpoint_family", "check runs",
+		"request_purpose", "reconcile_current_head_checks",
+		"repository", pullRequestRepoName(repo),
+		"pr_number", pullRequest.Number,
+		"head_sha", strings.TrimSpace(pullRequest.HeadSHA),
+		"authoritative_check_count", len(current.Checks),
+		"removed_checks", removedChecks,
+		"removed_running_checks", uniqueNonBlank(removedRunningChecks),
+	)
 }
 
 func (c *Connector) applyCachedPullRequestStatusAfterThrottle(ctx context.Context, repo pullRequestRepo, pullRequest *pullRequestNode, state pullRequestHydrationState) bool {

--- a/internal/connector/github/pullrequestcache.go
+++ b/internal/connector/github/pullrequestcache.go
@@ -185,6 +185,21 @@ func (c *pullRequestStatusCache) Get(repo pullRequestRepo, number int, headSHA s
 	return pullRequestStatus{}, false
 }
 
+func (c *pullRequestStatusCache) Peek(repo pullRequestRepo, number int, headSHA string) (pullRequestStatus, bool) {
+	key, ok := newPullRequestStatusCacheKey(repo, number, headSHA)
+	if !ok {
+		return pullRequestStatus{}, false
+	}
+
+	c.mu.RLock()
+	entry, ok := c.entries[key]
+	c.mu.RUnlock()
+	if !ok {
+		return pullRequestStatus{}, false
+	}
+	return clonePullRequestStatus(entry.status), true
+}
+
 func (c *pullRequestStatusCache) Set(repo pullRequestRepo, number int, headSHA string, status pullRequestStatus) {
 	key, ok := newPullRequestStatusCacheKey(repo, number, headSHA)
 	if !ok {


### PR DESCRIPTION
## Summary

- make current-head check reconciliation bypass stale conditional REST snapshots
- replace deleted pending checks with the authoritative upstream inventory while preserving fail-closed fetch behavior
- log removed cached and running check names for operator diagnosis

Fixes #2012

## UI Surface Contract

- [x] N/A, or the linked issue explicitly authorizes any high-impact UI surface, layout, density, first-viewport, or responsive visibility tradeoff.
- [x] Persistent top-of-screen messaging is explicitly authorized by the issue, or this PR does not add it.
- [x] Visual changes to primary operator screens include screenshot or browser verification below. N/A: no UI changes.

## Test Plan

- [x] `go test ./internal/connector/github ./internal/explain -count=1`
- [x] focused failed workspace race tests after transient subprocess-pressure failure
- [x] `make check` with repository-pinned golangci-lint v2.1.6