### PR TITLE
fix(ci): restore lint gate on main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,11 +37,11 @@ jobs:
         uses: actions/cache@v5
         with:
           path: ~/go/bin/golangci-lint
-          key: golangci-lint-${{ runner.os }}-go1.26.6-v2.1.6
+          key: golangci-lint-${{ runner.os }}-go1.26.6-v2.9.0
 
       - name: Install golangci-lint
         if: steps.golangci-lint-cache.outputs.cache-hit != 'true'
-        run: go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.1.6
+        run: go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.9.0
 
       - name: Cache golangci-lint analysis
         uses: actions/cache@v5

--- a/Makefile
+++ b/Makefile
@@ -171,7 +171,7 @@ setup:
 	go install github.com/a-h/templ/cmd/templ@v0.3.1001
 	go install github.com/sqlc-dev/sqlc/cmd/sqlc@latest
 	go install github.com/pressly/goose/v3/cmd/goose@latest
-	go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.1.6
+	go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.9.0
 	@if [ -f package.json ]; then npm install; fi
 
 clean:

--- a/docs/merge-train.md
+++ b/docs/merge-train.md
@@ -46,8 +46,8 @@ after a source-clean rebase, noisy status polling, uncached tool install, and
 duplicated non-blocking post-merge work are optimization targets.
 
 The repository CI caches the project-pinned golangci-lint binary and only builds
-it with `go install` on cache miss. The official prebuilt action was evaluated,
-but the prebuilt `v2.1.6` binary targets an older Go toolchain than this repo and
-newer prebuilt lint releases change the enforced lint set. `GoReleaser Snapshot`
-now runs on pull requests, `main`, release tags, nightly schedule, and manual
-dispatch so packaging signal is available before and after merge.
+it with `go install` on cache miss. CI builds golangci-lint `v2.9.0` with the
+repository Go toolchain so analyzer behavior and toolchain provenance stay
+aligned. `GoReleaser Snapshot` runs on pull requests, `main`, release tags,
+nightly schedule, and manual dispatch so packaging signal is available before
+and after merge.

--- a/install_test.go
+++ b/install_test.go
@@ -661,7 +661,8 @@ func runInstallWithTimeout(t *testing.T, root string, env []string, timeout time
 func reservePort(t *testing.T) int {
 	t.Helper()
 
-	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	var listenConfig net.ListenConfig
+	listener, err := listenConfig.Listen(t.Context(), "tcp", "127.0.0.1:0")
 	if err != nil {
 		t.Fatalf("Listen() error = %v", err)
 	}
@@ -677,7 +678,7 @@ func reservePort(t *testing.T) int {
 func startDetentServer(t *testing.T, binary string, workdir string, env []string, port int) func() {
 	t.Helper()
 
-	cmd := exec.Command(binary, "--host", "127.0.0.1", "--port", strconv.Itoa(port))
+	cmd := exec.CommandContext(t.Context(), binary, "--host", "127.0.0.1", "--port", strconv.Itoa(port))
 	cmd.Dir = workdir
 	cmd.Env = env
 
@@ -932,7 +933,7 @@ func assertInstalledVersionMetadata(t *testing.T, binary string, root string, en
 func gitOutput(t *testing.T, root string, args ...string) (string, bool) {
 	t.Helper()
 
-	cmd := exec.Command("git", args...)
+	cmd := exec.CommandContext(t.Context(), "git", args...)
 	cmd.Dir = root
 	out, err := cmd.Output()
 	if err != nil {

--- a/internal/auth/service_test.go
+++ b/internal/auth/service_test.go
@@ -276,7 +276,7 @@ func assertTokenHashedAtRest(t *testing.T, path string, rawToken string) {
 		t.Fatalf("sql.Open() error = %v", err)
 	}
 	var stored string
-	if err := db.QueryRow("SELECT token_hash FROM auth_magic_links ORDER BY id DESC LIMIT 1").Scan(&stored); err != nil {
+	if err := db.QueryRowContext(t.Context(), "SELECT token_hash FROM auth_magic_links ORDER BY id DESC LIMIT 1").Scan(&stored); err != nil {
 		t.Fatalf("query token hash error = %v", err)
 	}
 	sum := sha256.Sum256([]byte(rawToken))

--- a/internal/claudecode/process_unix_test.go
+++ b/internal/claudecode/process_unix_test.go
@@ -105,7 +105,7 @@ func TestClaudeCodeDeadParentHelper(t *testing.T) {
 		return
 	}
 
-	cmd := exec.Command("sleep", "3600")
+	cmd := exec.CommandContext(t.Context(), "sleep", "3600")
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	if err := cmd.Start(); err != nil {

--- a/internal/cli/boot.go
+++ b/internal/cli/boot.go
@@ -231,7 +231,7 @@ func startRunningWithDependencies(ctx context.Context, cfg BootConfig, deps star
 		}()
 	}
 
-	listener, displayURL, err := listenForBoot(cfg)
+	listener, displayURL, err := listenForBoot(runCtx, cfg)
 	if err != nil {
 		return fmt.Errorf("bind Detent web listener %s: %w", serverAddr(cfg), err)
 	}
@@ -756,7 +756,7 @@ func syncGlobalDispatchProjects(
 
 func startOnboarding(ctx context.Context, cfg BootConfig) error {
 	logger := slog.Default()
-	listener, displayURL, err := listenForBoot(cfg)
+	listener, displayURL, err := listenForBoot(ctx, cfg)
 	if err != nil {
 		return err
 	}
@@ -1940,8 +1940,9 @@ func unbracketIPv6Host(host string) string {
 	return unbracketed
 }
 
-func listenForBoot(cfg BootConfig) (net.Listener, string, error) {
-	listener, err := net.Listen("tcp", serverAddr(cfg))
+func listenForBoot(ctx context.Context, cfg BootConfig) (net.Listener, string, error) {
+	var listenConfig net.ListenConfig
+	listener, err := listenConfig.Listen(ctx, "tcp", serverAddr(cfg))
 	if err != nil {
 		return nil, "", err
 	}

--- a/internal/cli/boot_test.go
+++ b/internal/cli/boot_test.go
@@ -890,7 +890,8 @@ func TestAcquireRuntimeInstanceLockReportsLiveHolder(t *testing.T) {
 func TestStartRunningBindsBeforeCreatingRuntimeDatabase(t *testing.T) {
 	t.Parallel()
 
-	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	var listenConfig net.ListenConfig
+	listener, err := listenConfig.Listen(t.Context(), "tcp", "127.0.0.1:0")
 	if err != nil {
 		t.Fatalf("Listen() error = %v", err)
 	}

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -2019,7 +2019,7 @@ func writeGlobalConfig(t *testing.T, path string, projects []globalconfig.Projec
 func runCLITestGit(t *testing.T, dir string, args ...string) string {
 	t.Helper()
 
-	cmd := exec.Command("git", args...)
+	cmd := exec.CommandContext(t.Context(), "git", args...)
 	cmd.Dir = dir
 	output, err := cmd.CombinedOutput()
 	if err != nil {

--- a/internal/cli/dev_runtime_capture_browser.go
+++ b/internal/cli/dev_runtime_capture_browser.go
@@ -60,7 +60,7 @@ func startDemoCaptureBrowser(ctx context.Context, cfg demoCaptureConfig) (*demoC
 	if err != nil {
 		return nil, err
 	}
-	port, err := freeDemoCaptureTCPPort()
+	port, err := freeDemoCaptureTCPPort(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -177,8 +177,9 @@ func executableDemoCaptureFile(path string) bool {
 	return !info.IsDir()
 }
 
-func freeDemoCaptureTCPPort() (int, error) {
-	listener, err := net.Listen("tcp", "127.0.0.1:0")
+func freeDemoCaptureTCPPort(ctx context.Context) (int, error) {
+	var listenConfig net.ListenConfig
+	listener, err := listenConfig.Listen(ctx, "tcp", "127.0.0.1:0")
 	if err != nil {
 		return 0, fmt.Errorf("reserve browser debug port: %w", err)
 	}

--- a/internal/cli/doctor_artifact_gate_convergence_test.go
+++ b/internal/cli/doctor_artifact_gate_convergence_test.go
@@ -28,7 +28,7 @@ func TestCheckDoctorArtifactGateConvergence(t *testing.T) {
 			t.Errorf("db.Close() error = %v", err)
 		}
 	})
-	if _, err := db.Exec(`CREATE TABLE work_attempts (
+	if _, err := db.ExecContext(t.Context(), `CREATE TABLE work_attempts (
   id INTEGER PRIMARY KEY,
   project_id TEXT NOT NULL,
   issue_id TEXT,
@@ -95,7 +95,7 @@ func insertDoctorArtifactGateAttempt(
 ) {
 	t.Helper()
 	metadata := `{"artifact_gate_convergence":{"status_field":"render_status","dispatch_status":"recut","completion_status":"recut","unchanged":true,"consecutive_unchanged":` + strconv.Itoa(consecutive) + `,"limit":3,"tripped":` + strconv.FormatBool(tripped) + `}}`
-	if _, err := db.Exec(
+	if _, err := db.ExecContext(t.Context(),
 		`INSERT INTO work_attempts (project_id, issue_id, identifier, terminal_state, completed_at, worker_metadata_json) VALUES (?, ?, ?, 'success', ?, ?)`,
 		projectID,
 		issueID,

--- a/internal/cli/doctor_backend_capacity_test.go
+++ b/internal/cli/doctor_backend_capacity_test.go
@@ -24,7 +24,7 @@ func TestDoctorBackendCapacityDiagnostics(t *testing.T) {
 		t.Fatalf("Open() error = %v", err)
 	}
 	t.Cleanup(func() { _ = db.Close() })
-	if _, err := db.Exec(`CREATE TABLE work_attempts (
+	if _, err := db.ExecContext(t.Context(), `CREATE TABLE work_attempts (
 		project_id TEXT NOT NULL,
 		identifier TEXT,
 		issue_id TEXT,
@@ -47,7 +47,7 @@ func TestDoctorBackendCapacityDiagnostics(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Marshal() error = %v", err)
 	}
-	if _, err := db.Exec(
+	if _, err := db.ExecContext(t.Context(),
 		`INSERT INTO work_attempts (project_id, identifier, issue_id, capacity_snapshot_json, error_class, completed_at) VALUES (?, ?, ?, ?, ?, ?)`,
 		"detent", "digitaldrywood/detent#1142", "issue-1142", string(snapshot), "backend_capacity", now.Format(time.RFC3339Nano),
 	); err != nil {
@@ -103,7 +103,7 @@ func TestDoctorOverloadRetryCount(t *testing.T) {
 		t.Fatalf("Open() error = %v", err)
 	}
 	t.Cleanup(func() { _ = db.Close() })
-	if _, err := db.Exec(`CREATE TABLE work_attempts (
+	if _, err := db.ExecContext(t.Context(), `CREATE TABLE work_attempts (
 		project_id TEXT NOT NULL,
 		error_class TEXT,
 		completed_at TEXT
@@ -122,7 +122,7 @@ func TestDoctorOverloadRetryCount(t *testing.T) {
 		{projectID: "detent", errorClass: "backend_capacity", completed: now.Add(-10 * time.Minute)},
 	}
 	for _, row := range rows {
-		if _, err := db.Exec(
+		if _, err := db.ExecContext(t.Context(),
 			`INSERT INTO work_attempts (project_id, error_class, completed_at) VALUES (?, ?, ?)`,
 			row.projectID,
 			row.errorClass,

--- a/internal/cli/doctor_park_review_test.go
+++ b/internal/cli/doctor_park_review_test.go
@@ -112,7 +112,7 @@ func insertDoctorIssueParks(t *testing.T, path, issueID, identifier string, offs
 	defer func() { _ = db.Close() }()
 	for index := range count {
 		at := time.Date(2026, 8, 9, 16+offset+index, 0, 0, 0, time.UTC)
-		if _, err := db.Exec(`INSERT INTO work_attempts (
+		if _, err := db.ExecContext(t.Context(), `INSERT INTO work_attempts (
 project_id, issue_id, identifier, worker_type, attempt_number, status, started_at, completed_at, terminal_state, error_class
 ) VALUES ('detent', ?, ?, 'codex', ?, 'terminal', ?, ?, 'no_progress', 'no_progress_limit')`, issueID, identifier, offset+index+1, at.Add(-time.Minute).Format(time.RFC3339Nano), at.Format(time.RFC3339Nano)); err != nil {
 			t.Fatalf("insert park %d: %v", index, err)

--- a/internal/cli/doctor_test.go
+++ b/internal/cli/doctor_test.go
@@ -3089,7 +3089,7 @@ func TestCheckDoctorBlockedRecoveryWarnsOnlyWithoutCurrentPredicate(t *testing.T
 	t.Cleanup(func() {
 		_ = db.Close()
 	})
-	if _, err := db.Exec(`
+	if _, err := db.ExecContext(t.Context(), `
 CREATE TABLE workflow_phase_events (
   id INTEGER PRIMARY KEY,
   issue_id TEXT,
@@ -3118,7 +3118,7 @@ CREATE TABLE workflow_phase_events (
 		{issue: current, at: currentAt},
 		{issue: stale, at: currentAt},
 	} {
-		if _, err := db.Exec(
+		if _, err := db.ExecContext(t.Context(),
 			`INSERT INTO workflow_phase_events (issue_id, identifier, issue_url, phase_type, phase_name, status, started_at, metadata_json) VALUES (?, ?, ?, 'lane', 'Blocked', 'entered', ?, ?)`,
 			row.issue.ID,
 			row.issue.Identifier,
@@ -4928,11 +4928,11 @@ func TestCheckDoctorDailyBudgetAccuracy(t *testing.T) {
 			if err != nil {
 				t.Fatalf("sql.Open() error = %v", err)
 			}
-			if _, err := db.Exec(tt.schema); err != nil {
+			if _, err := db.ExecContext(t.Context(), tt.schema); err != nil {
 				t.Fatalf("create schema error = %v", err)
 			}
 			if tt.seed != "" {
-				if _, err := db.Exec(tt.seed); err != nil {
+				if _, err := db.ExecContext(t.Context(), tt.seed); err != nil {
 					t.Fatalf("seed session error = %v", err)
 				}
 			}
@@ -6682,7 +6682,8 @@ func (b *synchronizedBuffer) String() string {
 func occupiedDoctorPort(t *testing.T, host string, statusCode int, body string) int {
 	t.Helper()
 
-	listener, err := net.Listen("tcp", net.JoinHostPort(host, "0"))
+	var listenConfig net.ListenConfig
+	listener, err := listenConfig.Listen(t.Context(), "tcp", net.JoinHostPort(host, "0"))
 	if err != nil {
 		t.Fatalf("Listen(%q) error = %v", host, err)
 	}

--- a/internal/cli/doctor_workflow_lint_test.go
+++ b/internal/cli/doctor_workflow_lint_test.go
@@ -586,7 +586,7 @@ func TestCheckDoctorWorkflowRuntimeLintFindsWaitDeadlockAndCeilingDeaths(t *test
 	db := openDoctorWorkflowLintDB(t)
 	insertSchedulerDecision := func(at time.Time) {
 		t.Helper()
-		if _, err := db.Exec(`INSERT INTO scheduler_decisions (project_id, identifier, lane, result, reason, attempt_number, decision_at) VALUES (?, ?, ?, ?, ?, ?, ?)`,
+		if _, err := db.ExecContext(t.Context(), `INSERT INTO scheduler_decisions (project_id, identifier, lane, result, reason, attempt_number, decision_at) VALUES (?, ?, ?, ?, ?, ?, ?)`,
 			"alpha", "digitaldrywood/detent#1174", "Todo", "skipped", "artifact_gate_wait_status", 0, at.Format(time.RFC3339Nano)); err != nil {
 			t.Fatalf("insert scheduler decision: %v", err)
 		}
@@ -600,13 +600,13 @@ func TestCheckDoctorWorkflowRuntimeLintFindsWaitDeadlockAndCeilingDeaths(t *test
 			totalTokens = int64(16_100_000 + index*100_000)
 			errorMessage = fmt.Sprintf("session token ceiling exceeded: total_tokens=%d ceiling_tokens=16000000 source=max_session_tokens", totalTokens)
 		}
-		if _, err := db.Exec(`INSERT INTO work_attempts (project_id, worker_type, completed_at, error_message, metrics_json) VALUES (?, ?, ?, ?, ?)`,
+		if _, err := db.ExecContext(t.Context(), `INSERT INTO work_attempts (project_id, worker_type, completed_at, error_message, metrics_json) VALUES (?, ?, ?, ?, ?)`,
 			"alpha", "agent", now.Add(-time.Duration(index)*time.Hour).Format(time.RFC3339Nano), errorMessage, fmt.Sprintf(`{"total_tokens":%d}`, totalTokens)); err != nil {
 			t.Fatalf("insert work attempt: %v", err)
 		}
 	}
 	for index := range 10 {
-		if _, err := db.Exec(`INSERT INTO work_attempts (project_id, worker_type, completed_at, error_message, metrics_json) VALUES (?, ?, ?, '', ?)`,
+		if _, err := db.ExecContext(t.Context(), `INSERT INTO work_attempts (project_id, worker_type, completed_at, error_message, metrics_json) VALUES (?, ?, ?, '', ?)`,
 			"alpha", "merge", now.Add(-time.Duration(index)*time.Minute).Format(time.RFC3339Nano), `{"total_tokens":25000000}`); err != nil {
 			t.Fatalf("insert merge work attempt: %v", err)
 		}
@@ -708,7 +708,7 @@ func TestDoctorWaitStatusIncidentsPreservesContinuousWaitSemantics(t *testing.T)
 
 			db := openDoctorWorkflowLintDB(t)
 			for _, decision := range tt.decisions {
-				if _, err := db.Exec(`INSERT INTO scheduler_decisions (project_id, identifier, lane, result, reason, attempt_number, decision_at) VALUES (?, ?, ?, ?, ?, ?, ?)`,
+				if _, err := db.ExecContext(t.Context(), `INSERT INTO scheduler_decisions (project_id, identifier, lane, result, reason, attempt_number, decision_at) VALUES (?, ?, ?, ?, ?, ?, ?)`,
 					decision.project, "digitaldrywood/detent#1878", decision.lane, decision.result, decision.reason, decision.attempt, decision.at.Format(time.RFC3339Nano)); err != nil {
 					t.Fatalf("insert scheduler decision: %v", err)
 				}
@@ -742,7 +742,7 @@ func TestDoctorWaitStatusIncidentsQueryUsesBoundedPlan(t *testing.T) {
 	t.Parallel()
 
 	db := openDoctorWorkflowLintDB(t)
-	if _, err := db.Exec(`CREATE INDEX scheduler_decisions_project_at_idx ON scheduler_decisions(project_id, decision_at DESC, id DESC)`); err != nil {
+	if _, err := db.ExecContext(t.Context(), `CREATE INDEX scheduler_decisions_project_at_idx ON scheduler_decisions(project_id, decision_at DESC, id DESC)`); err != nil {
 		t.Fatalf("create scheduler decision index: %v", err)
 	}
 	cutoff := time.Date(2026, 8, 17, 14, 0, 0, 0, time.UTC).Format(time.RFC3339Nano)
@@ -783,20 +783,20 @@ func TestCheckDoctorWorkflowRuntimeLintCleanHistoryIsQuiet(t *testing.T) {
 
 	now := time.Date(2026, 7, 12, 17, 0, 0, 0, time.UTC)
 	db := openDoctorWorkflowLintDB(t)
-	if _, err := db.Exec(`INSERT INTO scheduler_decisions (project_id, identifier, lane, result, reason, attempt_number, decision_at) VALUES (?, ?, ?, ?, ?, ?, ?)`,
+	if _, err := db.ExecContext(t.Context(), `INSERT INTO scheduler_decisions (project_id, identifier, lane, result, reason, attempt_number, decision_at) VALUES (?, ?, ?, ?, ?, ?, ?)`,
 		"alpha", "digitaldrywood/detent#1", "Todo", "skipped", "artifact_gate_wait_status", 0, now.Add(-20*time.Minute).Format(time.RFC3339Nano)); err != nil {
 		t.Fatalf("insert scheduler decision: %v", err)
 	}
-	if _, err := db.Exec(`INSERT INTO scheduler_decisions (project_id, identifier, lane, result, reason, attempt_number, decision_at) VALUES (?, ?, ?, ?, ?, ?, ?)`,
+	if _, err := db.ExecContext(t.Context(), `INSERT INTO scheduler_decisions (project_id, identifier, lane, result, reason, attempt_number, decision_at) VALUES (?, ?, ?, ?, ?, ?, ?)`,
 		"alpha", "digitaldrywood/detent#1", "In Progress", "selected", "", 1, now.Add(-10*time.Minute).Format(time.RFC3339Nano)); err != nil {
 		t.Fatalf("insert scheduler reset decision: %v", err)
 	}
-	if _, err := db.Exec(`INSERT INTO scheduler_decisions (project_id, identifier, lane, result, reason, attempt_number, decision_at) VALUES (?, ?, ?, ?, ?, ?, ?)`,
+	if _, err := db.ExecContext(t.Context(), `INSERT INTO scheduler_decisions (project_id, identifier, lane, result, reason, attempt_number, decision_at) VALUES (?, ?, ?, ?, ?, ?, ?)`,
 		"alpha", "digitaldrywood/detent#1", "Todo", "skipped", "artifact_gate_wait_status", 0, now.Add(-time.Minute).Format(time.RFC3339Nano)); err != nil {
 		t.Fatalf("insert current scheduler decision: %v", err)
 	}
 	for index := range 5 {
-		if _, err := db.Exec(`INSERT INTO work_attempts (project_id, worker_type, completed_at, error_message, metrics_json) VALUES (?, ?, ?, '', ?)`,
+		if _, err := db.ExecContext(t.Context(), `INSERT INTO work_attempts (project_id, worker_type, completed_at, error_message, metrics_json) VALUES (?, ?, ?, '', ?)`,
 			"alpha", "agent", now.Add(-time.Duration(index)*time.Hour).Format(time.RFC3339Nano), `{"total_tokens":12000000}`); err != nil {
 			t.Fatalf("insert work attempt: %v", err)
 		}
@@ -825,7 +825,7 @@ func TestCheckDoctorWorkflowRuntimeLintTracksWaitIncidentAcrossLaneChange(t *tes
 		{lane: "Todo", at: now.Add(-20 * time.Minute)},
 		{lane: "In Progress", at: now.Add(-time.Minute)},
 	} {
-		if _, err := db.Exec(`INSERT INTO scheduler_decisions (project_id, identifier, lane, result, reason, attempt_number, decision_at) VALUES (?, ?, ?, ?, ?, ?, ?)`,
+		if _, err := db.ExecContext(t.Context(), `INSERT INTO scheduler_decisions (project_id, identifier, lane, result, reason, attempt_number, decision_at) VALUES (?, ?, ?, ?, ?, ?, ?)`,
 			"alpha", "digitaldrywood/detent#1174", decision.lane, "skipped", "artifact_gate_wait_status", 0, decision.at.Format(time.RFC3339Nano)); err != nil {
 			t.Fatalf("insert scheduler decision: %v", err)
 		}
@@ -863,7 +863,7 @@ func TestCheckDoctorWorkflowRuntimeLintIgnoresDeathsBelowRaisedCap(t *testing.T)
 		} else if index == 2 {
 			totalTokens = 40_000_000
 		}
-		if _, err := db.Exec(`INSERT INTO work_attempts (project_id, worker_type, completed_at, error_message, metrics_json) VALUES (?, ?, ?, ?, ?)`,
+		if _, err := db.ExecContext(t.Context(), `INSERT INTO work_attempts (project_id, worker_type, completed_at, error_message, metrics_json) VALUES (?, ?, ?, ?, ?)`,
 			"alpha", "agent", now.Add(-time.Duration(index)*time.Hour).Format(time.RFC3339Nano), errorMessage, fmt.Sprintf(`{"total_tokens":%d}`, totalTokens)); err != nil {
 			t.Fatalf("insert work attempt: %v", err)
 		}
@@ -934,7 +934,7 @@ func openDoctorWorkflowLintDB(t *testing.T) *sql.DB {
 )`,
 	}
 	for _, statement := range statements {
-		if _, err := db.Exec(statement); err != nil {
+		if _, err := db.ExecContext(t.Context(), statement); err != nil {
 			t.Fatalf("create workflow lint table: %v", err)
 		}
 	}

--- a/internal/cli/doctor_workflow_optimization_test.go
+++ b/internal/cli/doctor_workflow_optimization_test.go
@@ -247,7 +247,7 @@ func TestDoctorOrphanRecoveryTelemetryUsesTwentyFourHourWindow(t *testing.T) {
 		`INSERT INTO codex_sessions (work_attempt_id, started_at, final_state) VALUES (1, strftime('%Y-%m-%dT%H:%M:%SZ', 'now', '-25 hours'), 'orphaned')`,
 		`INSERT INTO codex_sessions (work_attempt_id, started_at, final_state, orphan_recovery_outcome, input_tokens, cached_input_tokens) VALUES (1, strftime('%Y-%m-%dT%H:%M:%SZ', 'now', '-1 hour'), 'completed', 'resumed', 1000, 850)`,
 	} {
-		if _, err := db.Exec(statement); err != nil {
+		if _, err := db.ExecContext(t.Context(), statement); err != nil {
 			t.Fatalf("Exec(%q) error = %v", statement, err)
 		}
 	}

--- a/internal/cli/doctor_workflow_source_test.go
+++ b/internal/cli/doctor_workflow_source_test.go
@@ -331,7 +331,7 @@ func runDoctorWorkflowSourceGit(t *testing.T, dir string, args ...string) string
 	t.Helper()
 
 	gitArgs := append([]string{"-c", "gc.auto=0", "-c", "maintenance.auto=false"}, args...)
-	cmd := exec.Command("git", gitArgs...)
+	cmd := exec.CommandContext(t.Context(), "git", gitArgs...)
 	cmd.Dir = dir
 	output, err := cmd.CombinedOutput()
 	if err != nil {

--- a/internal/cli/onboarding_test.go
+++ b/internal/cli/onboarding_test.go
@@ -1938,7 +1938,7 @@ func runGitOutput(t *testing.T, dir string, args ...string) string {
 	if strings.TrimSpace(dir) != "" {
 		commandArgs = append([]string{"-C", dir}, args...)
 	}
-	cmd := exec.Command("git", commandArgs...)
+	cmd := exec.CommandContext(t.Context(), "git", commandArgs...)
 	output, err := cmd.CombinedOutput()
 	if err != nil {
 		t.Fatalf("git %s error = %v\n%s", strings.Join(args, " "), err, output)

--- a/internal/cli/onboarding_workflow_builder_test.go
+++ b/internal/cli/onboarding_workflow_builder_test.go
@@ -972,7 +972,7 @@ func initOnboardingWorkflowBuilderGitRepository(t *testing.T, remote string) str
 func runOnboardingWorkflowBuilderGit(t *testing.T, dir string, args ...string) {
 	t.Helper()
 
-	cmd := exec.Command("git", args...)
+	cmd := exec.CommandContext(t.Context(), "git", args...)
 	cmd.Dir = dir
 	output, err := cmd.CombinedOutput()
 	if err != nil {

--- a/internal/cli/runner_test.go
+++ b/internal/cli/runner_test.go
@@ -2059,7 +2059,7 @@ func runRunnerGit(t *testing.T, dir string, args ...string) string {
 func runRunnerCommand(t *testing.T, dir string, name string, args ...string) string {
 	t.Helper()
 
-	cmd := exec.Command(name, args...)
+	cmd := exec.CommandContext(t.Context(), name, args...)
 	cmd.Dir = dir
 	output, err := cmd.CombinedOutput()
 	if err != nil {

--- a/internal/cli/runtime_test.go
+++ b/internal/cli/runtime_test.go
@@ -784,7 +784,7 @@ func runRuntimeWorkflowGit(t *testing.T, repo string, args ...string) string {
 func runRuntimeWorkflowCommand(t *testing.T, dir string, name string, args ...string) string {
 	t.Helper()
 
-	cmd := exec.Command(name, args...)
+	cmd := exec.CommandContext(t.Context(), name, args...)
 	if dir != "" {
 		cmd.Dir = dir
 	}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1599,7 +1599,7 @@ func TestValidateGitHubIssueFieldRequiresRepository(t *testing.T) {
 	if err == nil || !strings.Contains(err.Error(), "tracker.repository") {
 		t.Fatalf("Validate() error = %v, want repository requirement", err)
 	}
-	if err != nil && strings.Contains(err.Error(), "tracker.project_slug") {
+	if strings.Contains(err.Error(), "tracker.project_slug") {
 		t.Fatalf("Validate() error = %v, want no project_slug requirement in issue_field mode", err)
 	}
 }
@@ -1618,7 +1618,7 @@ func TestValidateGitHubLabelRequiresRepository(t *testing.T) {
 	if err == nil || !strings.Contains(err.Error(), "tracker.repository") {
 		t.Fatalf("Validate() error = %v, want repository requirement", err)
 	}
-	if err != nil && strings.Contains(err.Error(), "tracker.project_slug") {
+	if strings.Contains(err.Error(), "tracker.project_slug") {
 		t.Fatalf("Validate() error = %v, want no project_slug requirement in label mode", err)
 	}
 }

--- a/internal/instancelock/lock_test.go
+++ b/internal/instancelock/lock_test.go
@@ -19,7 +19,7 @@ func TestAcquireExcludesAnotherProcessAndReleases(t *testing.T) {
 		t.Fatalf("Acquire() error = %v", err)
 	}
 
-	command := exec.Command(os.Args[0], "-test.run=^TestAcquireHelperProcess$")
+	command := exec.CommandContext(t.Context(), os.Args[0], "-test.run=^TestAcquireHelperProcess$")
 	command.Env = append(os.Environ(), "DETENT_INSTANCE_LOCK_HELPER="+path)
 	output, err := command.CombinedOutput()
 	if err != nil {

--- a/internal/orchestrator/e2e_test.go
+++ b/internal/orchestrator/e2e_test.go
@@ -292,7 +292,7 @@ func e2eRunGit(t *testing.T, dir string, args ...string) string {
 func e2eRunCommand(t *testing.T, dir string, name string, args ...string) string {
 	t.Helper()
 
-	cmd := exec.Command(name, args...)
+	cmd := exec.CommandContext(t.Context(), name, args...)
 	cmd.Dir = dir
 	output, err := cmd.CombinedOutput()
 	if err != nil {

--- a/internal/procgroup/process_group_unix_test.go
+++ b/internal/procgroup/process_group_unix_test.go
@@ -23,7 +23,7 @@ func TestConfigure(t *testing.T) {
 	}{
 		{
 			name: "fresh command",
-			cmd:  exec.Command("true"),
+			cmd:  exec.CommandContext(t.Context(), "true"),
 		},
 		{
 			name: "existing syscall attributes",
@@ -75,7 +75,7 @@ func TestGroupID(t *testing.T) {
 		{
 			name: "nil process",
 			cmd: func(*testing.T) *exec.Cmd {
-				return exec.Command("true")
+				return exec.CommandContext(t.Context(), "true")
 			},
 			want: func(t *testing.T, _ *exec.Cmd, got int) {
 				if got != 0 {

--- a/internal/project/workflow_source_test.go
+++ b/internal/project/workflow_source_test.go
@@ -400,7 +400,7 @@ func runWorkflowSourceGit(t *testing.T, repo string, args ...string) string {
 func runWorkflowSourceCommand(t *testing.T, dir string, name string, args ...string) string {
 	t.Helper()
 
-	cmd := exec.Command(name, args...)
+	cmd := exec.CommandContext(t.Context(), name, args...)
 	if dir != "" {
 		cmd.Dir = dir
 	}

--- a/internal/runner/runner_test.go
+++ b/internal/runner/runner_test.go
@@ -5535,7 +5535,7 @@ func initRunnerSourceRepo(t *testing.T) string {
 func runRunnerGit(t *testing.T, dir string, args ...string) string {
 	t.Helper()
 
-	cmd := exec.Command("git", append([]string{"-C", dir}, args...)...)
+	cmd := exec.CommandContext(t.Context(), "git", append([]string{"-C", dir}, args...)...)
 	output, err := cmd.CombinedOutput()
 	if err != nil {
 		t.Fatalf("git %s failed: %v\n%s", strings.Join(cmd.Args[1:], " "), err, output)

--- a/internal/service/systemd.go
+++ b/internal/service/systemd.go
@@ -161,9 +161,10 @@ func (m *systemdManager) systemctlArgs(args ...string) []string {
 }
 
 func systemdUnit(cfg Config) string {
-	execStart := systemdQuote(cfg.BinaryPath)
+	execStartParts := make([]string, 0, len(cfg.Arguments)+1)
+	execStartParts = append(execStartParts, systemdQuote(cfg.BinaryPath))
 	for _, argument := range cfg.Arguments {
-		execStart += " " + systemdQuote(argument)
+		execStartParts = append(execStartParts, systemdQuote(argument))
 	}
 	return strings.Join([]string{
 		"[Unit]",
@@ -174,7 +175,7 @@ func systemdUnit(cfg Config) string {
 		"[Service]",
 		"Type=simple",
 		"Environment=\"PATH=" + systemdEscape(cfg.Path) + "\"",
-		"ExecStart=" + execStart,
+		"ExecStart=" + strings.Join(execStartParts, " "),
 		"Restart=on-failure",
 		"RestartSec=5",
 		"KillMode=control-group",

--- a/internal/store/park_summary_test.go
+++ b/internal/store/park_summary_test.go
@@ -122,7 +122,7 @@ func TestParkSummaryAggregatesCausesAndTokenBreakdown(t *testing.T) {
 	insertParkAttempt(t, db, first, "terminal", "failure", "", `{"brake_cause":"per_issue_max_usd"}`)
 	insertParkAttempt(t, db, last, "terminal", "failure", "", `{"brake_cause":"per_issue_max_usd"}`)
 	insertParkAttempt(t, db, last.Add(time.Second), "terminal", "no_progress", "no_progress_limit", `{}`)
-	if _, err := db.db.Exec(`INSERT INTO usage_events (
+	if _, err := db.db.ExecContext(t.Context(), `INSERT INTO usage_events (
 project_id, issue_id, identifier, model, input_tokens, cached_input_tokens, output_tokens, reasoning_output_tokens,
 total_tokens, runtime_seconds, started_at, finished_at, event_day, outcome
 ) VALUES ('detent', 'issue-6', 'digitaldrywood/detent.build#6', 'gpt', 100, 80, 20, 10, 130, 1, ?, ?, '2026-08-12', 'success')`, first.Format(time.RFC3339Nano), last.Format(time.RFC3339Nano)); err != nil {
@@ -284,7 +284,7 @@ func insertParkAttempt(t *testing.T, db *sqliteStore, at time.Time, status, term
 	if !at.IsZero() {
 		completed = at.Format(time.RFC3339Nano)
 	}
-	if _, err := db.db.Exec(`INSERT INTO work_attempts (
+	if _, err := db.db.ExecContext(t.Context(), `INSERT INTO work_attempts (
 project_id, issue_id, identifier, issue_url, worker_type, attempt_number, status, started_at, completed_at,
 terminal_state, error_class, worker_metadata_json
 ) VALUES ('detent', 'issue-6', 'digitaldrywood/detent.build#6', 'https://github.com/digitaldrywood/detent.build/issues/6', 'codex', 1, ?, ?, ?, ?, ?, ?)`, status, time.Date(2026, 8, 9, 15, 0, 0, 0, time.UTC).Format(time.RFC3339Nano), completed, terminalState, errorClass, metadata); err != nil {
@@ -294,7 +294,7 @@ terminal_state, error_class, worker_metadata_json
 
 func insertParkAttemptIdentity(t *testing.T, db *sqliteStore, at time.Time, issueID, identifier, issueURL string) {
 	t.Helper()
-	if _, err := db.db.Exec(`INSERT INTO work_attempts (
+	if _, err := db.db.ExecContext(t.Context(), `INSERT INTO work_attempts (
 project_id, issue_id, identifier, issue_url, worker_type, attempt_number, status, started_at, completed_at,
 terminal_state, worker_metadata_json
 ) VALUES ('detent', NULLIF(?, ''), NULLIF(?, ''), NULLIF(?, ''), 'codex', 1, 'terminal', ?, ?, 'no_progress', '{}')`,
@@ -305,7 +305,7 @@ terminal_state, worker_metadata_json
 
 func insertParkTransition(t *testing.T, db *sqliteStore, at time.Time, reason, metadata string) {
 	t.Helper()
-	if _, err := db.db.Exec(`INSERT INTO workflow_phase_events (
+	if _, err := db.db.ExecContext(t.Context(), `INSERT INTO workflow_phase_events (
 project_id, issue_id, identifier, issue_url, phase_type, phase_name, reason, status, started_at, event_day, metadata_json
 ) VALUES ('detent', 'issue-6', 'digitaldrywood/detent.build#6', 'https://github.com/digitaldrywood/detent.build/issues/6', 'lane', 'Blocked', ?, 'entered', ?, '2026-08-12', ?)`, reason, at.Format(time.RFC3339Nano), metadata); err != nil {
 		t.Fatalf("insert workflow transition: %v", err)

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -3387,7 +3387,7 @@ func queryString(t *testing.T, db *sql.DB, query string) string {
 	t.Helper()
 
 	var value string
-	if err := db.QueryRow(query).Scan(&value); err != nil {
+	if err := db.QueryRowContext(t.Context(), query).Scan(&value); err != nil {
 		t.Fatalf("querying %q: %v", query, err)
 	}
 	return value
@@ -3397,7 +3397,7 @@ func queryInt(t *testing.T, db *sql.DB, query string) int64 {
 	t.Helper()
 
 	var value int64
-	if err := db.QueryRow(query).Scan(&value); err != nil {
+	if err := db.QueryRowContext(t.Context(), query).Scan(&value); err != nil {
 		t.Fatalf("querying %q: %v", query, err)
 	}
 	return value
@@ -3422,7 +3422,7 @@ func assertColumnAbsent(t *testing.T, db *sql.DB, table string, column string) {
 func assertIndexPresent(t *testing.T, db *sql.DB, index string) {
 	t.Helper()
 	var count int
-	if err := db.QueryRow("SELECT COUNT(*) FROM sqlite_master WHERE type = 'index' AND name = ?", index).Scan(&count); err != nil {
+	if err := db.QueryRowContext(t.Context(), "SELECT COUNT(*) FROM sqlite_master WHERE type = 'index' AND name = ?", index).Scan(&count); err != nil {
 		t.Fatalf("query index %q error = %v", index, err)
 	}
 	if count != 1 {
@@ -3433,7 +3433,7 @@ func assertIndexPresent(t *testing.T, db *sql.DB, index string) {
 func assertIndexAbsent(t *testing.T, db *sql.DB, index string) {
 	t.Helper()
 	var count int
-	if err := db.QueryRow("SELECT COUNT(*) FROM sqlite_master WHERE type = 'index' AND name = ?", index).Scan(&count); err != nil {
+	if err := db.QueryRowContext(t.Context(), "SELECT COUNT(*) FROM sqlite_master WHERE type = 'index' AND name = ?", index).Scan(&count); err != nil {
 		t.Fatalf("query index %q error = %v", index, err)
 	}
 	if count != 0 {
@@ -3445,7 +3445,7 @@ func columnCount(t *testing.T, db *sql.DB, table string, column string) int64 {
 	t.Helper()
 
 	var count int64
-	if err := db.QueryRow("SELECT COUNT(*) FROM pragma_table_info(?) WHERE name = ?", tableIdentifier(t, table), column).Scan(&count); err != nil {
+	if err := db.QueryRowContext(t.Context(), "SELECT COUNT(*) FROM pragma_table_info(?) WHERE name = ?", tableIdentifier(t, table), column).Scan(&count); err != nil {
 		t.Fatalf("querying %s.%s column: %v", table, column, err)
 	}
 	return count

--- a/internal/update/update.go
+++ b/internal/update/update.go
@@ -1057,7 +1057,7 @@ func escapeBatchValue(value string) string {
 }
 
 func startProcess(command string, args []string) error {
-	return exec.Command(command, args...).Start() // #nosec G204 -- updater commands and arguments are resolved internally and bypass a shell.
+	return exec.CommandContext(context.Background(), command, args...).Start() // #nosec G204 -- updater commands and arguments are resolved internally and bypass a shell.
 }
 
 func runCommand(ctx context.Context, command string, args []string, stdout io.Writer, stderr io.Writer) error {

--- a/internal/web/server_shutdown_test.go
+++ b/internal/web/server_shutdown_test.go
@@ -44,7 +44,8 @@ func TestServerShutdownDrainsAsyncWritesAfterActiveHandlers(t *testing.T) {
 		return c.NoContent(http.StatusAccepted)
 	})
 
-	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	var listenConfig net.ListenConfig
+	listener, err := listenConfig.Listen(t.Context(), "tcp", "127.0.0.1:0")
 	if err != nil {
 		t.Fatalf("Listen() error = %v", err)
 	}

--- a/internal/web/server_test.go
+++ b/internal/web/server_test.go
@@ -9626,7 +9626,8 @@ func TestServerReadHeaderTimeoutDropsStalledHeaders(t *testing.T) {
 	}
 
 	addr := startWebServer(t, server)
-	conn, err := net.Dial("tcp", addr)
+	var dialer net.Dialer
+	conn, err := dialer.DialContext(t.Context(), "tcp", addr)
 	if err != nil {
 		t.Fatalf("Dial() error = %v", err)
 	}
@@ -13556,7 +13557,8 @@ func openEventStream(t *testing.T, server *web.Server) io.ReadCloser {
 func startWebServer(t *testing.T, server *web.Server) string {
 	t.Helper()
 
-	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	var listenConfig net.ListenConfig
+	listener, err := listenConfig.Listen(t.Context(), "tcp", "127.0.0.1:0")
 	if err != nil {
 		t.Fatalf("Listen() error = %v", err)
 	}
@@ -13600,7 +13602,8 @@ func openRawEventStream(t *testing.T, addr string, paths ...string) (net.Conn, i
 func openRawEventStreamWithHeaders(t *testing.T, addr string, path string, headers map[string]string) (net.Conn, io.ReadCloser, *bufio.Reader) {
 	t.Helper()
 
-	conn, err := net.Dial("tcp", addr)
+	var dialer net.Dialer
+	conn, err := dialer.DialContext(t.Context(), "tcp", addr)
 	if err != nil {
 		t.Fatalf("Dial() error = %v", err)
 	}

--- a/internal/workspace/workspace_test.go
+++ b/internal/workspace/workspace_test.go
@@ -1784,7 +1784,7 @@ func TestLocalGitPreserveFailedWorkspaceReleasesBranch(t *testing.T) {
 				runGit(t, source, "add", "README.md")
 				runGit(t, source, "commit", "-m", "source change")
 
-				cmd := exec.Command("git", "-C", workspace, "merge", "main")
+				cmd := exec.CommandContext(t.Context(), "git", "-C", workspace, "merge", "main")
 				output, err := cmd.CombinedOutput()
 				if err == nil {
 					t.Fatalf("git merge succeeded, want conflict:\n%s", output)
@@ -2498,7 +2498,7 @@ func linkedWorktreeGitDir(t *testing.T, workspacePath string) string {
 func branchExists(t *testing.T, dir string, branch string) bool {
 	t.Helper()
 
-	cmd := exec.Command("git", "-C", dir, "show-ref", "--verify", "--quiet", "refs/heads/"+branch)
+	cmd := exec.CommandContext(t.Context(), "git", "-C", dir, "show-ref", "--verify", "--quiet", "refs/heads/"+branch)
 	err := cmd.Run()
 	if err == nil {
 		return true
@@ -2514,7 +2514,7 @@ func branchExists(t *testing.T, dir string, branch string) bool {
 func runCommand(t *testing.T, dir string, name string, args ...string) string {
 	t.Helper()
 
-	cmd := exec.Command(name, args...)
+	cmd := exec.CommandContext(t.Context(), name, args...)
 	cmd.Dir = dir
 	output, err := cmd.CombinedOutput()
 	if err != nil {

--- a/release_lookup_test.go
+++ b/release_lookup_test.go
@@ -83,7 +83,7 @@ func TestResolveReleaseTag(t *testing.T) {
 				t.Fatalf("WriteFile() error = %v", err)
 			}
 
-			cmd := exec.Command("bash", "./scripts/resolve-release-tag.sh")
+			cmd := exec.CommandContext(t.Context(), "bash", "./scripts/resolve-release-tag.sh")
 			cmd.Env = append(os.Environ(),
 				"DETENT_RELEASE_LOOKUP_GH="+ghPath,
 				"DETENT_RELEASE_LOOKUP_SLEEP="+sleepPath,


### PR DESCRIPTION
## Summary

- pin local setup and CI to golangci-lint 2.9.0 built with Go 1.26.6
- migrate baseline network, subprocess, and SQL calls to context-aware APIs
- fix upgraded nilness and string-concatenation findings without disabling linters
- document the aligned lint toolchain provenance

Fixes #2008

## UI Surface Contract

- [x] N/A; this change does not alter UI surfaces.
- [x] This PR does not add persistent top-of-screen messaging.
- [x] N/A; this PR has no visual changes.

## Test Plan

- [x] `GOTOOLCHAIN=go1.26.6 make lint` with golangci-lint 2.9.0
- [x] `GOTOOLCHAIN=go1.26.6 go test ./internal/cli ./internal/service ./internal/update ./internal/config`
- [x] `GOTOOLCHAIN=go1.26.6 go test . -run '^TestResolveReleaseTag$'`
- [x] `GOTOOLCHAIN=go1.26.6 make check` (78.8% coverage; package/file floors pass)