### PR TITLE
fix(orchestrator): accept operational completion

### DIFF
--- a/.detent/skills/durable-tracker-authorizations.md
+++ b/.detent/skills/durable-tracker-authorizations.md
@@ -1,0 +1,15 @@
+---
+name: durable-tracker-authorizations
+description: Preserve pre-dispatch authorization across mutable tracker state without letting a late agent declaration bypass completion, breaker, or promotion gates.
+when_to_use: Use when issue fields, labels, or Workpad declarations opt a Detent attempt out of an ordinary deliverable or approval requirement and the decision must survive restart.
+---
+
+# Bind mutable declarations to accepted attempts
+
+1. Identify the ordinary gate being relaxed and preserve it as the fallback for every invalid, missing, or late declaration.
+2. Parse the authorization from the issue before dispatch and snapshot only a valid supported value on the running attempt. Never infer pre-authorization from tracker state fetched at completion.
+3. At completion, require the dispatch snapshot, the matching current declaration with its evidence, and all work-product invariants. Persist a distinct accepted kind and progress reason only when every condition passes.
+4. Treat the durable successful-attempt record as the authority for downstream transitions. Current issue text may remain a required consistency check, but it is never sufficient by itself.
+5. Restore accepted state after restart only from terminal attempt metadata that carries the kind, progress reason, and completion evidence timing. Do not reconstruct acceptance from the current issue body or Workpad alone.
+6. Audit every consumer of the raw declaration. Transition, gate-wait, revocation, reconciliation, and dashboard paths must either require the accepted-attempt marker or be limited to parsing and diagnostics.
+7. Test pre-authorized acceptance, undeclared assertion, authorization added after dispatch, dirty or unpushed repository work, restart restoration, and revocation with current-only tracker state.

--- a/docs/structured-workpad-signaling-migration.md
+++ b/docs/structured-workpad-signaling-migration.md
@@ -97,3 +97,40 @@ Also update the state-specific instructions:
 For `tracker.kind: github_local`, keep GitHub issues read-only unless a human
 explicitly authorizes upstream metadata writes. The local Workpad still needs
 the same `detent-status` block.
+
+## Operational completion without a pull request
+
+An issue author may opt an issue into operational completion by putting this
+block in the issue body before the worker is dispatched:
+
+```detent-completion
+schema: 1
+completion_kind: operational
+```
+
+This contract is for authorized host or service work whose intended result has
+no repository diff and no pull request. The completing worker must leave a
+clean workspace and declare the matching kind and concrete verification
+evidence in the final Workpad status block:
+
+```detent-status
+schema: 1
+status: complete
+fields:
+  completion_kind: operational
+  completion_evidence: "what changed on the host and how it was verified"
+blockers: []
+human_action: null
+```
+
+Detent snapshots the issue-body authorization at dispatch. Adding the
+authorization only at completion time is not accepted. An undeclared or
+invalid operational assertion follows the ordinary pull-request gate and the
+existing no-progress breaker. A valid declaration is recorded as
+`operational_completion`, including its completion kind in the work-attempt
+journal and dashboard, and can advance without a linked pull request. Projects
+using a human-review gate still require that approval before Done.
+
+Add both blocks to the project's `WORKFLOW.md` guidance. `detent doctor` warns
+when an active or observed issue opts into operational completion but the
+workflow prompt does not mention this contract.

--- a/internal/cli/doctor_operational_completion.go
+++ b/internal/cli/doctor_operational_completion.go
@@ -1,0 +1,86 @@
+package cli
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	workflowconfig "github.com/digitaldrywood/detent/internal/config"
+	"github.com/digitaldrywood/detent/internal/workpad"
+)
+
+const doctorOperationalCompletionSampleLimit = 5
+
+func checkDoctorOperationalCompletion(
+	ctx context.Context,
+	id string,
+	cfg workflowconfig.Config,
+	workflowPrompt string,
+	deps doctorDeps,
+) doctorCheck {
+	name := "Project " + id + " operational completion"
+	if deps.autoPromoteConnector == nil {
+		deps.autoPromoteConnector = defaultDoctorAutoPromoteConnector
+	}
+	projectConnector, err := deps.autoPromoteConnector(cfg)
+	if err != nil {
+		return doctorCheck{Name: name, Status: doctorWarn, Detail: fmt.Sprintf("create operational completion diagnostic connector: %v", err), Hint: "Fix tracker credentials and rerun detent doctor."}
+	}
+	if projectConnector == nil {
+		return doctorCheck{Name: name, Status: doctorWarn, Detail: "create operational completion diagnostic connector: connector is nil", Hint: "Fix tracker configuration and rerun detent doctor."}
+	}
+
+	states := append(append([]string(nil), cfg.Tracker.ActiveStates...), cfg.Tracker.ObservedStates...)
+	issues, fetchErr := projectConnector.FetchIssuesByStates(ctx, states)
+	closeErr := closeDoctorAutoPromoteConnector(projectConnector)
+	if fetchErr != nil {
+		return doctorCheck{Name: name, Status: doctorWarn, Detail: fmt.Sprintf("fetch operational completion authorizations: %v", fetchErr), Hint: "Fix tracker connectivity and rerun detent doctor."}
+	}
+
+	authorized := make([]string, 0)
+	for _, issue := range issues {
+		kind, found, parseErr := workpad.CompletionAuthorizationFromIssueBody(issue.Description)
+		if parseErr != nil || !found || kind != workpad.CompletionOperational {
+			continue
+		}
+		identifier := strings.TrimSpace(issue.Identifier)
+		if identifier == "" {
+			identifier = strings.TrimSpace(issue.ID)
+		}
+		if identifier != "" {
+			authorized = append(authorized, identifier)
+		}
+	}
+
+	check := doctorCheck{Name: name, Status: doctorOK}
+	switch {
+	case len(authorized) == 0:
+		check.Detail = "no active or observed issue authorizes operational completion"
+	case doctorWorkflowMentionsOperationalCompletion(workflowPrompt):
+		check.Detail = fmt.Sprintf("workflow documents the operational completion contract used by %d issue(s)", len(authorized))
+	default:
+		check.Status = doctorWarn
+		check.Detail = fmt.Sprintf("%d issue(s) authorize operational completion but the workflow does not document the detent-completion contract: %s", len(authorized), strings.Join(firstDoctorOperationalCompletionIdentifiers(authorized), ", "))
+		check.Hint = "Document the issue-body detent-completion authorization and the matching Workpad completion_kind: operational declaration in WORKFLOW.md."
+	}
+	if closeErr != nil {
+		check.Status = doctorWarn
+		check.Detail += "; connector close failed: " + closeErr.Error()
+		if check.Hint == "" {
+			check.Hint = "Rerun detent doctor and check local network resources."
+		}
+	}
+	return check
+}
+
+func doctorWorkflowMentionsOperationalCompletion(prompt string) bool {
+	prompt = strings.ToLower(prompt)
+	return strings.Contains(prompt, "detent-completion") && strings.Contains(prompt, "completion_kind: operational")
+}
+
+func firstDoctorOperationalCompletionIdentifiers(identifiers []string) []string {
+	if len(identifiers) <= doctorOperationalCompletionSampleLimit {
+		return identifiers
+	}
+	return identifiers[:doctorOperationalCompletionSampleLimit]
+}

--- a/internal/cli/doctor_operational_completion_test.go
+++ b/internal/cli/doctor_operational_completion_test.go
@@ -1,0 +1,65 @@
+package cli
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	workflowconfig "github.com/digitaldrywood/detent/internal/config"
+	"github.com/digitaldrywood/detent/internal/connector"
+)
+
+func TestCheckDoctorOperationalCompletion(t *testing.T) {
+	t.Parallel()
+
+	authorizedIssue := connector.Issue{
+		ID:          "issue-62",
+		Identifier:  "digitaldrywood/leadpipe#62",
+		Description: "```detent-completion\nschema: 1\ncompletion_kind: operational\n```",
+	}
+	tests := []struct {
+		name       string
+		issues     []connector.Issue
+		prompt     string
+		wantStatus doctorStatus
+		wantDetail string
+	}{
+		{
+			name:       "authorization without workflow contract warns",
+			issues:     []connector.Issue{authorizedIssue},
+			prompt:     "Complete work and open a pull request.",
+			wantStatus: doctorWarn,
+			wantDetail: "digitaldrywood/leadpipe#62",
+		},
+		{
+			name:       "documented contract passes",
+			issues:     []connector.Issue{authorizedIssue},
+			prompt:     "Pre-authorize no-PR work with a detent-completion block, then declare completion_kind: operational with evidence.",
+			wantStatus: doctorOK,
+			wantDetail: "documents the operational completion contract",
+		},
+		{
+			name:       "ordinary issues pass",
+			issues:     []connector.Issue{{ID: "issue-code", Description: "Implement the code change."}},
+			wantStatus: doctorOK,
+			wantDetail: "no active or observed issue authorizes",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			cfg := validDoctorWorkflow(t.TempDir())
+			cfg.Tracker.Kind = workflowconfig.TrackerGitHub
+			check := checkDoctorOperationalCompletion(context.Background(), "leadpipe", cfg, tt.prompt, doctorDeps{
+				autoPromoteConnector: func(workflowconfig.Config) (doctorAutoPromoteConnector, error) {
+					return &fakeDoctorAutoPromoteConnector{issues: tt.issues}, nil
+				},
+			})
+			if check.Status != tt.wantStatus || !strings.Contains(check.Detail, tt.wantDetail) {
+				t.Fatalf("check = %#v, want status %s detail containing %q", check, tt.wantStatus, tt.wantDetail)
+			}
+		})
+	}
+}

--- a/internal/cli/doctor_project.go
+++ b/internal/cli/doctor_project.go
@@ -392,6 +392,8 @@ func checkDoctorProjectWithProgress(
 	if doctorTrackerUsesGitHubReads(workflow.Config.Tracker.Kind) {
 		setDoctorCurrentCheck("Project " + id + " issue agent models")
 		checks = append(checks, checkDoctorIssueAgentModels(ctx, id, project, workflow.Config, deps))
+		setDoctorCurrentCheck("Project " + id + " operational completion")
+		checks = append(checks, checkDoctorOperationalCompletion(ctx, id, workflow.Config, workflow.Prompt, deps))
 		setDoctorCurrentCheck("Project " + id + " authorization eligibility")
 		checks = append(checks, checkDoctorAuthorizationEligibility(ctx, id, project, workflow.Config, deps))
 		setDoctorCurrentCheck("Project " + id + " ownership eligibility")

--- a/internal/orchestrator/autopromote.go
+++ b/internal/orchestrator/autopromote.go
@@ -154,6 +154,17 @@ func EvaluateAutoPromote(
 		return decision
 	}
 	if completion, ok := operationalCompletionFromIssue(issue); ok {
+		if gate.Effective(cfg.Gate).Kind == gate.KindHumanReview {
+			operationalSummary := summary
+			operationalSummary.PullRequestPresent = true
+			gateDecision := gate.Evaluate(cfg.Gate, issue.Labels, gateSummary(operationalSummary), now, gate.EvaluationOptions{})
+			if gateDecision.Action != gate.ActionPass {
+				decision := autoPromoteDecision(autoPromoteActionFromGate(gateDecision.Action), autoPromoteReasonFromGate(gateDecision.Reason))
+				decision.OperationalEvidence = completion.evidence
+				autoPromoteApplyWorkpadDecisionFields(&decision, workpad)
+				return decision
+			}
+		}
 		decision := autoPromoteDecision(AutoPromoteActionComplete, AutoPromoteReasonOperationalCompletion)
 		decision.OperationalEvidence = completion.evidence
 		autoPromoteApplyWorkpadDecisionFields(&decision, workpad)
@@ -200,6 +211,9 @@ type operationalCompletion struct {
 
 func operationalCompletionFromIssue(issue connector.Issue) (operationalCompletion, bool) {
 	if issue.PullRequest != nil || workAttemptPRNumber(issue) != nil {
+		return operationalCompletion{}, false
+	}
+	if !workpad.OperationalCompletionAuthorized(issue.Description) {
 		return operationalCompletion{}, false
 	}
 	signal, ok := autoPromoteIssueWorkpadSignal(issue)

--- a/internal/orchestrator/autopromote.go
+++ b/internal/orchestrator/autopromote.go
@@ -43,6 +43,7 @@ type AutoPromoteSummary struct {
 	ArtifactStatus                        string
 	LastActivityAt                        *time.Time
 	CompletedFinalState                   string
+	OperationalCompletionAccepted         bool
 	AutomatedReviewWaitExpired            bool
 }
 
@@ -153,7 +154,7 @@ func EvaluateAutoPromote(
 		autoPromoteApplyWorkpadDecisionFields(&decision, workpad)
 		return decision
 	}
-	if completion, ok := operationalCompletionFromIssue(issue); ok {
+	if completion, ok := operationalCompletionFromIssue(issue); ok && summary.OperationalCompletionAccepted {
 		if gate.Effective(cfg.Gate).Kind == gate.KindHumanReview {
 			operationalSummary := summary
 			operationalSummary.PullRequestPresent = true

--- a/internal/orchestrator/autopromote_test.go
+++ b/internal/orchestrator/autopromote_test.go
@@ -705,6 +705,7 @@ func TestEvaluateAutoPromoteOperationalCompletion(t *testing.T) {
 	tests := []struct {
 		name         string
 		body         string
+		authorized   bool
 		pullRequest  *connector.PullRequest
 		wantAction   AutoPromoteAction
 		wantReason   AutoPromoteReason
@@ -713,9 +714,16 @@ func TestEvaluateAutoPromoteOperationalCompletion(t *testing.T) {
 		{
 			name:         "declared operational completion",
 			body:         operationalCompletionWorkpadBody("Runner service is healthy and accepting jobs."),
+			authorized:   true,
 			wantAction:   AutoPromoteActionComplete,
 			wantReason:   AutoPromoteReasonOperationalCompletion,
 			wantEvidence: "Runner service is healthy and accepting jobs.",
+		},
+		{
+			name:       "undeclared operational assertion",
+			body:       operationalCompletionWorkpadBody("Runner service is healthy and accepting jobs."),
+			wantAction: AutoPromoteActionSkip,
+			wantReason: AutoPromoteReasonMissingPullRequest,
 		},
 		{
 			name:       "ordinary no diff completion",
@@ -732,6 +740,7 @@ func TestEvaluateAutoPromoteOperationalCompletion(t *testing.T) {
 		{
 			name:        "operational declaration with pull request placeholder",
 			body:        operationalCompletionWorkpadBody("Runner service is healthy and accepting jobs."),
+			authorized:  true,
 			pullRequest: &connector.PullRequest{HydrationUnavailableReason: "rate_limited"},
 			wantAction:  AutoPromoteActionSkip,
 			wantReason:  AutoPromoteReasonPullRequestHydrationUnavailable,
@@ -743,6 +752,9 @@ func TestEvaluateAutoPromoteOperationalCompletion(t *testing.T) {
 			t.Parallel()
 
 			issue := autoPromoteTestIssue("issue-operational-completion", nil)
+			if tt.authorized {
+				issue.Description = operationalCompletionAuthorizationBody()
+			}
 			issue.PullRequest = tt.pullRequest
 			issue.Comments = []connector.IssueComment{{
 				Body: tt.body,
@@ -763,6 +775,39 @@ func TestEvaluateAutoPromoteOperationalCompletion(t *testing.T) {
 			}
 			if tt.wantAction == AutoPromoteActionComplete && got.WorkpadCommentURL != "https://github.test/comment/operational-completion" {
 				t.Fatalf("WorkpadCommentURL = %q", got.WorkpadCommentURL)
+			}
+		})
+	}
+}
+
+func TestEvaluateAutoPromoteOperationalCompletionHonorsHumanReview(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		labels     []string
+		wantAction AutoPromoteAction
+		wantReason AutoPromoteReason
+	}{
+		{name: "awaits approval", wantAction: AutoPromoteActionAwaitReview, wantReason: AutoPromoteReasonHumanApprovalMissing},
+		{name: "approved completion", labels: []string{"approved-by-human"}, wantAction: AutoPromoteActionComplete, wantReason: AutoPromoteReasonOperationalCompletion},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			issue := autoPromoteTestIssue("issue-operational-human-review", tt.labels)
+			issue.Description = operationalCompletionAuthorizationBody()
+			issue.PullRequest = nil
+			issue.Comments = []connector.IssueComment{{Body: operationalCompletionWorkpadBody("Backfill verified.")}}
+			decision := EvaluateAutoPromote(issue, AutoPromoteSummary{}, AutoPromoteConfig{
+				Enabled:        true,
+				TerminalStates: []string{"Done"},
+				Gate:           gate.Config{Kind: gate.KindHumanReview, ApprovalLabel: "approved-by-human"},
+			}, time.Now())
+
+			if decision.Action != tt.wantAction || decision.Reason != tt.wantReason {
+				t.Fatalf("decision = %#v, want action %q reason %q", decision, tt.wantAction, tt.wantReason)
 			}
 		})
 	}

--- a/internal/orchestrator/autopromote_test.go
+++ b/internal/orchestrator/autopromote_test.go
@@ -706,6 +706,7 @@ func TestEvaluateAutoPromoteOperationalCompletion(t *testing.T) {
 		name         string
 		body         string
 		authorized   bool
+		accepted     bool
 		pullRequest  *connector.PullRequest
 		wantAction   AutoPromoteAction
 		wantReason   AutoPromoteReason
@@ -715,9 +716,17 @@ func TestEvaluateAutoPromoteOperationalCompletion(t *testing.T) {
 			name:         "declared operational completion",
 			body:         operationalCompletionWorkpadBody("Runner service is healthy and accepting jobs."),
 			authorized:   true,
+			accepted:     true,
 			wantAction:   AutoPromoteActionComplete,
 			wantReason:   AutoPromoteReasonOperationalCompletion,
 			wantEvidence: "Runner service is healthy and accepting jobs.",
+		},
+		{
+			name:       "authorization without accepted attempt",
+			body:       operationalCompletionWorkpadBody("Runner service is healthy and accepting jobs."),
+			authorized: true,
+			wantAction: AutoPromoteActionSkip,
+			wantReason: AutoPromoteReasonMissingPullRequest,
 		},
 		{
 			name:       "undeclared operational assertion",
@@ -741,6 +750,7 @@ func TestEvaluateAutoPromoteOperationalCompletion(t *testing.T) {
 			name:        "operational declaration with pull request placeholder",
 			body:        operationalCompletionWorkpadBody("Runner service is healthy and accepting jobs."),
 			authorized:  true,
+			accepted:    true,
 			pullRequest: &connector.PullRequest{HydrationUnavailableReason: "rate_limited"},
 			wantAction:  AutoPromoteActionSkip,
 			wantReason:  AutoPromoteReasonPullRequestHydrationUnavailable,
@@ -762,6 +772,7 @@ func TestEvaluateAutoPromoteOperationalCompletion(t *testing.T) {
 			}}
 			got := EvaluateAutoPromote(issue, AutoPromoteSummary{
 				PullRequestHydrationUnavailableReason: pullRequestHydrationUnavailableReason(tt.pullRequest),
+				OperationalCompletionAccepted:         tt.accepted,
 			}, cfg, time.Now())
 
 			if got.Action != tt.wantAction {
@@ -800,7 +811,7 @@ func TestEvaluateAutoPromoteOperationalCompletionHonorsHumanReview(t *testing.T)
 			issue.Description = operationalCompletionAuthorizationBody()
 			issue.PullRequest = nil
 			issue.Comments = []connector.IssueComment{{Body: operationalCompletionWorkpadBody("Backfill verified.")}}
-			decision := EvaluateAutoPromote(issue, AutoPromoteSummary{}, AutoPromoteConfig{
+			decision := EvaluateAutoPromote(issue, AutoPromoteSummary{OperationalCompletionAccepted: true}, AutoPromoteConfig{
 				Enabled:        true,
 				TerminalStates: []string{"Done"},
 				Gate:           gate.Config{Kind: gate.KindHumanReview, ApprovalLabel: "approved-by-human"},

--- a/internal/orchestrator/autopromote_tick.go
+++ b/internal/orchestrator/autopromote_tick.go
@@ -354,7 +354,8 @@ func (o *Orchestrator) latestSuccessfulOperationalCompletionAttempt(
 			continue
 		}
 		if strings.TrimSpace(record.WorkpadStatus) != workpad.StatusComplete ||
-			!slices.Contains(record.ProgressKinds, "audit_artifact") {
+			strings.TrimSpace(record.CompletionKind) != workpad.CompletionOperational ||
+			!slices.Contains(record.ProgressKinds, "operational_completion") {
 			continue
 		}
 		return attempt, true, nil
@@ -3074,7 +3075,10 @@ func (o *Orchestrator) logAutoPromoteDecision(issue connector.Issue, decision Au
 
 func appendAutoPromoteWorkpadAttrs(attrs []any, decision AutoPromoteDecision) []any {
 	if evidence := strings.TrimSpace(decision.OperationalEvidence); evidence != "" {
-		attrs = append(attrs, "operational_evidence", evidence)
+		attrs = append(attrs,
+			"completion_kind", workpad.CompletionOperational,
+			"operational_evidence", evidence,
+		)
 	}
 	if url := strings.TrimSpace(decision.WorkpadCommentURL); url != "" {
 		attrs = append(attrs, "workpad_comment_url", url)
@@ -3187,6 +3191,8 @@ func autoPromoteComment(
 		b.WriteString(failedChecks)
 	}
 	if evidence := strings.TrimSpace(decision.OperationalEvidence); evidence != "" {
+		b.WriteString("\n- completion_kind: ")
+		b.WriteString(workpad.CompletionOperational)
 		b.WriteString("\n- operational_evidence: ")
 		b.WriteString(evidence)
 	}

--- a/internal/orchestrator/autopromote_tick.go
+++ b/internal/orchestrator/autopromote_tick.go
@@ -112,6 +112,7 @@ func (o *Orchestrator) autoPromoteHumanReviewIssues(
 		issue, securityAudit := o.liveSecurityAuditEvaluation(ctx, issue)
 		summary := AutoPromoteSummaryFromIssue(issue)
 		summary.CompletedFinalState = autoPromoteCompletedFinalState(state, issueID)
+		summary.OperationalCompletionAccepted = autoPromoteOperationalCompletionAccepted(state, issueID)
 		summary.AutomatedReviewWaitExpired = autoPromoteReviewWaitExpired(state, issueID, cfg, now)
 		summary.SecurityAudit = securityAudit
 		decision := EvaluateAutoPromote(issue, summary, cfg, now)
@@ -180,6 +181,14 @@ func autoPromoteCompletedFinalState(state *State, issueID string) string {
 		return ""
 	}
 	return completed.FinalState
+}
+
+func autoPromoteOperationalCompletionAccepted(state *State, issueID string) bool {
+	if state == nil {
+		return false
+	}
+	completed, ok := state.Completed[strings.TrimSpace(issueID)]
+	return ok && strings.TrimSpace(completed.CompletionKind) == workpad.CompletionOperational
 }
 
 func autoPromoteReviewWaitExpired(state *State, issueID string, cfg AutoPromoteConfig, now time.Time) bool {
@@ -422,11 +431,16 @@ func gateWaitAttemptMatchesPullRequest(attempt store.WorkAttempt, issue connecto
 }
 
 func completedFromGateWaitAttempt(issue connector.Issue, attempt store.WorkAttempt) Completed {
+	completionKind := ""
+	if record, ok := implementProgressRecordFromAttempt(attempt); ok {
+		completionKind = strings.TrimSpace(record.CompletionKind)
+	}
 	return Completed{
-		Issue:       cloneIssue(issue),
-		StartedAt:   attempt.StartedAt,
-		CompletedAt: attempt.CompletedAt,
-		FinalState:  FinalStateCompleted,
+		Issue:          cloneIssue(issue),
+		StartedAt:      attempt.StartedAt,
+		CompletedAt:    attempt.CompletedAt,
+		FinalState:     FinalStateCompleted,
+		CompletionKind: completionKind,
 	}
 }
 

--- a/internal/orchestrator/autopromote_tick.go
+++ b/internal/orchestrator/autopromote_tick.go
@@ -458,8 +458,9 @@ func autoPromoteActiveGatePendingIssue(
 		return false
 	}
 	autoCfg = normalizeAutoPromoteConfig(autoCfg)
+	operationalCompletionAccepted := completedOperationalCompletionAccepted(issue, completed.CompletionKind)
 	return completedActiveFinalStateReviewEligible(completed.FinalState, autoCfg.SourceState) &&
-		completedActiveIssueReadyForReview(issue, gateRequiresPullRequest(autoCfg.Gate))
+		completedActiveIssueReadyForReview(issue, gateRequiresPullRequest(autoCfg.Gate), operationalCompletionAccepted)
 }
 
 func autoPromoteActiveGateTrackedIssue(

--- a/internal/orchestrator/autopromote_tick_test.go
+++ b/internal/orchestrator/autopromote_tick_test.go
@@ -2353,6 +2353,28 @@ func TestLogAutoPromoteDecisionNamesPendingChecks(t *testing.T) {
 	}
 }
 
+func TestLogAutoPromoteDecisionIncludesOperationalCompletionKind(t *testing.T) {
+	t.Parallel()
+
+	var logs strings.Builder
+	orch := &Orchestrator{
+		logger: slog.New(slog.NewTextHandler(&logs, &slog.HandlerOptions{Level: slog.LevelInfo})),
+	}
+	orch.logAutoPromoteDecision(
+		autoPromoteTickIssue("issue-operational-log", []string{"operations"}, nil),
+		AutoPromoteDecision{
+			Action:              AutoPromoteActionComplete,
+			Reason:              AutoPromoteReasonOperationalCompletion,
+			OperationalEvidence: "Backfill verified.",
+		},
+		"Done",
+	)
+
+	if !strings.Contains(logs.String(), "completion_kind=operational") {
+		t.Fatalf("logs %q missing operational completion kind", logs.String())
+	}
+}
+
 func TestTickReconcilesStaleTodoLinkedPullRequests(t *testing.T) {
 	t.Parallel()
 
@@ -3882,6 +3904,9 @@ func TestStaleMergingOperationalCompletionReconcilesDone(t *testing.T) {
 
 			issue := autoPromoteTickIssue("issue-operational-merging", []string{"bug"}, nil)
 			issue.State = "Merging"
+			if tt.wantReason == string(AutoPromoteReasonOperationalCompletion) {
+				issue.Description = operationalCompletionAuthorizationBody()
+			}
 			issue.Comments = []connector.IssueComment{{
 				Body: tt.body,
 				URL:  "https://github.test/comment/operational-merging",
@@ -3923,10 +3948,11 @@ func TestAutoPromoteOperationalCompletionAfterRuntimeStateLoss(t *testing.T) {
 			"run_mode": runpkg.RunModeImplement,
 			implementProgressMetadataKey: implementProgressRecord{
 				Outcome:            string(store.WorkAttemptTerminalSuccess),
-				Reason:             implementProgressReasonNonDiff,
+				Reason:             implementOperationalCompletion,
 				WorkspaceDiffStats: implementProgressDiffStats{Status: "clean"},
 				WorkpadStatus:      workpad.StatusComplete,
-				ProgressKinds:      []string{"audit_artifact"},
+				ProgressKinds:      []string{"operational_completion"},
+				CompletionKind:     workpad.CompletionOperational,
 			},
 		}),
 	}
@@ -3946,7 +3972,7 @@ func TestAutoPromoteOperationalCompletionAfterRuntimeStateLoss(t *testing.T) {
 			}()},
 		},
 		{
-			name: "attempt without audit artifact",
+			name: "attempt without operational completion marker",
 			attempts: []store.WorkAttempt{func() store.WorkAttempt {
 				attempt := successfulAttempt
 				attempt.WorkerMetadataJSON = marshalWorkAttemptJSON(map[string]any{
@@ -3968,6 +3994,7 @@ func TestAutoPromoteOperationalCompletionAfterRuntimeStateLoss(t *testing.T) {
 
 			issue := autoPromoteTickIssue("issue-operational-restart", []string{"bug"}, nil)
 			issue.State = "In Progress"
+			issue.Description = operationalCompletionAuthorizationBody()
 			issue.Comments = []connector.IssueComment{{
 				Body:      operationalCompletionWorkpadBody("Runner service is healthy and accepting jobs."),
 				URL:       "https://github.test/comment/operational-restart",
@@ -4035,10 +4062,11 @@ func TestReconcileStaleMergingOperationalCompletionWaitsForDurableAttempt(t *tes
 		WorkerMetadataJSON: marshalWorkAttemptJSON(map[string]any{
 			"run_mode": runpkg.RunModeImplement,
 			implementProgressMetadataKey: implementProgressRecord{
-				Outcome:       string(store.WorkAttemptTerminalSuccess),
-				Reason:        implementProgressReasonNonDiff,
-				WorkpadStatus: workpad.StatusComplete,
-				ProgressKinds: []string{"audit_artifact"},
+				Outcome:        string(store.WorkAttemptTerminalSuccess),
+				Reason:         implementOperationalCompletion,
+				WorkpadStatus:  workpad.StatusComplete,
+				ProgressKinds:  []string{"operational_completion"},
+				CompletionKind: workpad.CompletionOperational,
 			},
 		}),
 	}
@@ -4057,6 +4085,7 @@ func TestReconcileStaleMergingOperationalCompletionWaitsForDurableAttempt(t *tes
 
 			issue := autoPromoteTickIssue("issue-operational-stale-merging", []string{"bug"}, nil)
 			issue.State = "Merging"
+			issue.Description = operationalCompletionAuthorizationBody()
 			issue.Comments = []connector.IssueComment{{
 				Body:      operationalCompletionWorkpadBody("Runner service is healthy and accepting jobs."),
 				URL:       "https://github.test/comment/operational-stale-merging",

--- a/internal/orchestrator/blocked_recovery.go
+++ b/internal/orchestrator/blocked_recovery.go
@@ -550,6 +550,7 @@ func (o *Orchestrator) reworkBreakerAutoPromoteGateReady(
 	issueID := strings.TrimSpace(issue.ID)
 	summary := AutoPromoteSummaryFromIssue(issue)
 	summary.CompletedFinalState = autoPromoteCompletedFinalState(state, issueID)
+	summary.OperationalCompletionAccepted = autoPromoteOperationalCompletionAccepted(state, issueID)
 	summary.AutomatedReviewWaitExpired = autoPromoteReviewWaitExpired(state, issueID, cfg, now)
 	decision := EvaluateAutoPromote(issue, summary, cfg, now)
 	if decision.Reason == AutoPromoteReasonValidatorMissing {

--- a/internal/orchestrator/completion_transition.go
+++ b/internal/orchestrator/completion_transition.go
@@ -42,6 +42,7 @@ func (o *Orchestrator) transitionCompletedActiveIssuesToReview(
 		targetState := completedActiveReviewTargetState(
 			issue,
 			completed.FinalState,
+			completed.CompletionKind,
 			o.cfg.ActiveStates,
 			o.cfg.TerminalStates,
 			cfg,
@@ -272,6 +273,7 @@ func (o *Orchestrator) logCompletedActiveAutoPromoteSameState(
 func completedActiveReviewTargetState(
 	issue connector.Issue,
 	finalState string,
+	completionKind string,
 	activeStates []string,
 	terminalStates []string,
 	cfg AutoPromoteConfig,
@@ -285,10 +287,11 @@ func completedActiveReviewTargetState(
 	case normalizeState(reviewState), normalizeState(autoPromoteMergingState):
 		return ""
 	}
-	if !completedActiveIssueReadyForReview(issue, gateRequiresPullRequest(cfg.Gate)) {
+	operationalCompletionAccepted := completedOperationalCompletionAccepted(issue, completionKind)
+	if !completedActiveIssueReadyForReview(issue, gateRequiresPullRequest(cfg.Gate), operationalCompletionAccepted) {
 		return ""
 	}
-	if !completedActiveShouldEnterReview(issue, cfg) {
+	if !completedActiveShouldEnterReview(issue, cfg, operationalCompletionAccepted) {
 		return ""
 	}
 	if completedActiveFinalStateReviewEligible(finalState, reviewState) {
@@ -297,8 +300,8 @@ func completedActiveReviewTargetState(
 	return ""
 }
 
-func completedActiveShouldEnterReview(issue connector.Issue, cfg AutoPromoteConfig) bool {
-	if _, ok := operationalCompletionFromIssue(issue); ok {
+func completedActiveShouldEnterReview(issue connector.Issue, cfg AutoPromoteConfig, operationalCompletionAccepted bool) bool {
+	if operationalCompletionAccepted {
 		return true
 	}
 	if autoPromoteHumanReviewRequired(issue, cfg, cfg.Gate) {
@@ -342,8 +345,8 @@ func completedActiveFinalStateReviewEligible(finalState string, reviewState stri
 	}
 }
 
-func completedActiveIssueReadyForReview(issue connector.Issue, requirePullRequest bool) bool {
-	if _, ok := operationalCompletionFromIssue(issue); ok {
+func completedActiveIssueReadyForReview(issue connector.Issue, requirePullRequest bool, operationalCompletionAccepted bool) bool {
+	if operationalCompletionAccepted {
 		return true
 	}
 	if !requirePullRequest {
@@ -353,6 +356,14 @@ func completedActiveIssueReadyForReview(issue connector.Issue, requirePullReques
 		return false
 	}
 	return normalizePullRequestState(issue.PullRequest.State) == "open"
+}
+
+func completedOperationalCompletionAccepted(issue connector.Issue, completionKind string) bool {
+	if strings.TrimSpace(completionKind) != workpad.CompletionOperational {
+		return false
+	}
+	_, ok := operationalCompletionFromIssue(issue)
+	return ok
 }
 
 func (o *Orchestrator) transitionTimedOutCompletedActiveGateWait(

--- a/internal/orchestrator/completion_transition.go
+++ b/internal/orchestrator/completion_transition.go
@@ -8,6 +8,7 @@ import (
 	"github.com/digitaldrywood/detent/internal/connector"
 	"github.com/digitaldrywood/detent/internal/gate"
 	"github.com/digitaldrywood/detent/internal/telemetry"
+	"github.com/digitaldrywood/detent/internal/workpad"
 )
 
 func (o *Orchestrator) transitionCompletedActiveIssuesToReview(
@@ -193,6 +194,7 @@ func (o *Orchestrator) tryDirectCompletedActiveAutoPromote(
 
 	summary := AutoPromoteSummaryFromIssue(issue)
 	summary.CompletedFinalState = completedFinalState
+	summary.OperationalCompletionAccepted = autoPromoteOperationalCompletionAccepted(state, issue.ID)
 	decision := EvaluateAutoPromote(issue, summary, cfg, now)
 	if autoPromoteDecisionNeedsWorkpadHydration(decision) {
 		issue, decision = o.hydrateAutoPromoteWorkpadDecision(ctx, issue, summary, cfg, now)
@@ -374,6 +376,7 @@ func (o *Orchestrator) transitionTimedOutCompletedActiveGateWait(
 	if cfg.GateWaitTimeoutAction == autoPromoteGateWaitTimeoutMerge {
 		summary := AutoPromoteSummaryFromIssue(issue)
 		summary.CompletedFinalState = completed.FinalState
+		summary.OperationalCompletionAccepted = strings.TrimSpace(completed.CompletionKind) == workpad.CompletionOperational
 		summary.AutomatedReviewWaitExpired = true
 		decision := EvaluateAutoPromote(issue, summary, cfg, now)
 		if autoPromoteDecisionNeedsWorkpadHydration(decision) {

--- a/internal/orchestrator/completion_transition_test.go
+++ b/internal/orchestrator/completion_transition_test.go
@@ -17,11 +17,12 @@ func TestCompletedActiveReviewTargetState(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name       string
-		issue      connector.Issue
-		finalState string
-		cfg        AutoPromoteConfig
-		want       string
+		name           string
+		issue          connector.Issue
+		finalState     string
+		completionKind string
+		cfg            AutoPromoteConfig
+		want           string
 	}{
 		{
 			name:       "todo completed with open pull request advances to human review when disabled",
@@ -73,7 +74,8 @@ func TestCompletedActiveReviewTargetState(t *testing.T) {
 			want:       autoPromoteSourceState,
 		},
 		{
-			name: "operational rework completion advances to review",
+			name:           "operational rework completion advances to review",
+			completionKind: workpad.CompletionOperational,
 			issue: func() connector.Issue {
 				issue := completionTransitionIssue("Rework", "")
 				issue.Description = operationalCompletionAuthorizationBody()
@@ -88,6 +90,22 @@ func TestCompletedActiveReviewTargetState(t *testing.T) {
 				Gate:    gate.Config{Kind: gate.KindCommand},
 			},
 			want: autoPromoteSourceState,
+		},
+		{
+			name: "unaccepted operational completion stays active",
+			issue: func() connector.Issue {
+				issue := completionTransitionIssue("In Progress", "")
+				issue.Description = operationalCompletionAuthorizationBody()
+				issue.Comments = []connector.IssueComment{{
+					Body: operationalCompletionWorkpadBody("Runner service is healthy and accepting jobs."),
+				}}
+				return issue
+			}(),
+			finalState: FinalStateCompleted,
+			cfg: AutoPromoteConfig{
+				Enabled: true,
+				Gate:    gate.Config{Kind: gate.KindCommand},
+			},
 		},
 		{
 			name:       "artifact rework completed without pull request advances to configured review",
@@ -207,6 +225,7 @@ func TestCompletedActiveReviewTargetState(t *testing.T) {
 			got := completedActiveReviewTargetState(
 				tt.issue,
 				tt.finalState,
+				tt.completionKind,
 				activeStates,
 				terminalStates,
 				tt.cfg,
@@ -292,6 +311,49 @@ func TestAutoPromoteActiveGatePendingIssueIncludesCompletedArtifact(t *testing.T
 
 	if !autoPromoteActiveGatePendingIssue(issue, &state, cfg, cfg.AutoPromote) {
 		t.Fatal("completed artifact gate wait was not recognized without a pull request")
+	}
+}
+
+func TestAutoPromoteActiveGatePendingIssueRequiresAcceptedOperationalCompletion(t *testing.T) {
+	t.Parallel()
+
+	issue := completionTransitionIssue("In Progress", "")
+	issue.Description = operationalCompletionAuthorizationBody()
+	issue.Comments = []connector.IssueComment{{
+		Body: operationalCompletionWorkpadBody("Runner service is healthy and accepting jobs."),
+	}}
+	cfg := normalizeConfig(Config{
+		ActiveStates:   []string{"Todo", "In Progress", "Rework", "Merging"},
+		ObservedStates: []string{"Human Review", "Blocked"},
+		TerminalStates: []string{"Done", "Cancelled"},
+		AutoPromote: AutoPromoteConfig{
+			Enabled:       true,
+			GateWaitState: autoPromoteGateWaitSource,
+			Gate:          gate.Config{Kind: gate.KindCommand},
+		},
+	})
+	tests := []struct {
+		name           string
+		completionKind string
+		want           bool
+	}{
+		{name: "current declaration without accepted attempt"},
+		{name: "accepted operational completion", completionKind: workpad.CompletionOperational, want: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			state := newState(cfg)
+			state.Completed[issue.ID] = Completed{
+				Issue:          issue,
+				FinalState:     FinalStateCompleted,
+				CompletionKind: tt.completionKind,
+			}
+			if got := autoPromoteActiveGatePendingIssue(issue, &state, cfg, cfg.AutoPromote); got != tt.want {
+				t.Fatalf("autoPromoteActiveGatePendingIssue() = %t, want %t", got, tt.want)
+			}
+		})
 	}
 }
 

--- a/internal/orchestrator/completion_transition_test.go
+++ b/internal/orchestrator/completion_transition_test.go
@@ -75,6 +75,7 @@ func TestCompletedActiveReviewTargetState(t *testing.T) {
 			name: "operational rework completion advances to review",
 			issue: func() connector.Issue {
 				issue := completionTransitionIssue("Rework", "")
+				issue.Description = operationalCompletionAuthorizationBody()
 				issue.Comments = []connector.IssueComment{{
 					Body: operationalCompletionWorkpadBody("Runner service is healthy and accepting jobs."),
 				}}
@@ -391,6 +392,7 @@ func TestTransitionCompletedActiveIssuesCompletesOperationalWorkWithoutPullReque
 
 	now := time.Date(2026, 8, 18, 18, 0, 0, 0, time.UTC)
 	issue := completionTransitionIssue("In Progress", "")
+	issue.Description = operationalCompletionAuthorizationBody()
 	issue.Comments = []connector.IssueComment{{
 		Body: operationalCompletionWorkpadBody("Runner service is healthy and accepting jobs."),
 		URL:  "https://github.test/comment/operational-completion",
@@ -432,6 +434,7 @@ func TestTransitionCompletedActiveIssuesCompletesOperationalWorkWithoutPullReque
 	for _, fragment := range []string{
 		"Completed this issue operationally",
 		"reason: operational_completion",
+		"completion_kind: operational",
 		"operational_evidence: Runner service is healthy and accepting jobs.",
 		"workpad_comment: https://github.test/comment/operational-completion",
 	} {
@@ -862,6 +865,13 @@ func operationalCompletionWorkpadBody(evidence string) string {
 		"  completion_evidence: \"" + evidence + "\"\n" +
 		"blockers: []\n" +
 		"human_action: null\n" +
+		"```"
+}
+
+func operationalCompletionAuthorizationBody() string {
+	return "## Completion contract\n\n```detent-completion\n" +
+		"schema: 1\n" +
+		"completion_kind: operational\n" +
 		"```"
 }
 

--- a/internal/orchestrator/completion_transition_test.go
+++ b/internal/orchestrator/completion_transition_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/digitaldrywood/detent/internal/connector"
 	"github.com/digitaldrywood/detent/internal/gate"
+	"github.com/digitaldrywood/detent/internal/workpad"
 )
 
 func TestCompletedActiveReviewTargetState(t *testing.T) {
@@ -409,9 +410,10 @@ func TestTransitionCompletedActiveIssuesCompletesOperationalWorkWithoutPullReque
 	orch := &Orchestrator{cfg: cfg, connector: tracker}
 	state := newState(cfg)
 	state.Completed[issue.ID] = Completed{
-		Issue:       issue,
-		CompletedAt: now.Add(-time.Minute),
-		FinalState:  FinalStateCompleted,
+		Issue:          issue,
+		CompletedAt:    now.Add(-time.Minute),
+		FinalState:     FinalStateCompleted,
+		CompletionKind: workpad.CompletionOperational,
 	}
 
 	result := orch.transitionCompletedActiveIssuesToReview(t.Context(), &state, []connector.Issue{issue}, now)

--- a/internal/orchestrator/dispatch_loop.go
+++ b/internal/orchestrator/dispatch_loop.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/digitaldrywood/detent/internal/store"
+	"github.com/digitaldrywood/detent/internal/workpad"
 )
 
 const dispatchLoopDetectedReason = "dispatch_loop_detected"
@@ -110,6 +111,8 @@ func dispatchLoopCurrentAdvanced(
 		return implementProgressSignatureUsable(decision.CurrentSignature)
 	case implementMergedCompletionReason:
 		return true
+	case implementOperationalCompletion:
+		return strings.TrimSpace(decision.CompletionKind) == workpad.CompletionOperational
 	case "pull_request_hydrator_unavailable", "pull_request_hydration_failed", "pull_request_hydration_unavailable",
 		"attempt_history_lookup_failed", "workspace_diffstat_unavailable", "workspace_diffstat_unavailable_without_pull_request",
 		"workspace_diff_fingerprint_unavailable_without_pull_request", workspaceHeadUnavailableReason,
@@ -168,6 +171,8 @@ func dispatchLoopRecordAdvanced(record implementProgressRecord) bool {
 		return implementProgressSignatureUsable(record.CurrentSignature.signature())
 	case "signature_changed", implementMergedCompletionReason:
 		return true
+	case implementOperationalCompletion:
+		return strings.TrimSpace(record.CompletionKind) == workpad.CompletionOperational
 	default:
 		return false
 	}

--- a/internal/orchestrator/implement_progress.go
+++ b/internal/orchestrator/implement_progress.go
@@ -148,9 +148,10 @@ func (o *Orchestrator) evaluateImplementCompletionProgress(
 		if workpadCurrent {
 			decision.WorkpadStatus, decision.HumanAction = implementProgressBlockedHumanAction(issue)
 		}
-		if workpadCurrent && running.DispatchProgress.CompletionKind == workpad.CompletionOperational &&
-			implementProgressDiffStatsClean(running.DiffStats) {
-			if _, ok := operationalCompletionFromIssue(issue); ok {
+		operationalCompletionCandidate := false
+		if workpadCurrent && running.DispatchProgress.CompletionKind == workpad.CompletionOperational {
+			_, operationalCompletionCandidate = operationalCompletionFromIssue(issue)
+			if operationalCompletionCandidate && implementProgressOperationalWorkspaceClean(running.DiffStats) {
 				decision.WorkpadStatus = workpad.StatusComplete
 				decision.Reason = implementOperationalCompletion
 				decision.ProgressKinds = []string{"operational_completion"}
@@ -208,6 +209,16 @@ func (o *Orchestrator) evaluateImplementCompletionProgress(
 				decision.Block = true
 				return decision
 			}
+		}
+		if operationalCompletionCandidate && (running.DiffStats.UnpushedCommits > 0 || running.DiffStats.CommitsAhead > 0) {
+			decision.Outcome = store.WorkAttemptTerminalNoProgress
+			decision.Reason = strandedUnpushedWorkReason
+			decision.ConsecutiveNoProgress = 1 + consecutiveImplementStrandedWorkAttempts(attempts, autoPromoteReworkSignature{})
+			decision.Block = decision.NoProgressLimit > 0 && decision.ConsecutiveNoProgress >= decision.NoProgressLimit
+			if decision.Block {
+				decision.BlockReason = strandedUnpushedWorkReason
+			}
+			return decision
 		}
 		if stranded, deferReason := implementProgressUnpushedClassification(running.DiffStats, nil); deferReason != "" {
 			decision.Reason = deferReason
@@ -813,6 +824,12 @@ func implementProgressDiffStatsClean(diffStats DiffStats) bool {
 		diffStats.FilesChanged == 0 &&
 		diffStats.AddedLines == 0 &&
 		diffStats.RemovedLines == 0
+}
+
+func implementProgressOperationalWorkspaceClean(diffStats DiffStats) bool {
+	return implementProgressDiffStatsClean(diffStats) &&
+		diffStats.UnpushedCommits == 0 &&
+		diffStats.CommitsAhead == 0
 }
 
 func implementProgressUnpushedClassification(diffStats DiffStats, pullRequest *connector.PullRequest) (bool, string) {

--- a/internal/orchestrator/implement_progress.go
+++ b/internal/orchestrator/implement_progress.go
@@ -20,6 +20,7 @@ const (
 	implementProgressOutcomeNoProgress = "no_progress"
 	implementProgressReasonNonDiff     = "verifiable_non_diff_progress"
 	implementProgressReasonMixed       = "workspace_diff_and_verifiable_non_diff_progress"
+	implementOperationalCompletion     = "operational_completion"
 	implementDependencyDeferralReason  = "dependency_deferral"
 	implementMergedCompletionReason    = "merged_pull_request_completion"
 	noProgressLimitReason              = "no_progress_limit"
@@ -54,6 +55,7 @@ type implementCompletionProgressDecision struct {
 	DependencyBlockers     []implementDependencyBlocker
 	RejectedBlockerRefs    []string
 	ProgressKinds          []string
+	CompletionKind         string
 }
 
 type implementProgressRecord struct {
@@ -78,6 +80,7 @@ type implementProgressRecord struct {
 	DependencyBlockers     []implementDependencyBlocker      `json:"dependency_blockers,omitempty"`
 	RejectedBlockerRefs    []string                          `json:"rejected_blocker_refs,omitempty"`
 	ProgressKinds          []string                          `json:"progress_kinds,omitempty"`
+	CompletionKind         string                            `json:"completion_kind,omitempty"`
 }
 
 type implementProgressArtifactSnapshot struct {
@@ -86,6 +89,7 @@ type implementProgressArtifactSnapshot struct {
 	WorkpadRead    bool
 	WorkpadReason  string
 	WorkpadFields  map[string]string
+	CompletionKind string
 }
 
 type implementDependencyBlocker struct {
@@ -143,6 +147,16 @@ func (o *Orchestrator) evaluateImplementCompletionProgress(
 		)
 		if workpadCurrent {
 			decision.WorkpadStatus, decision.HumanAction = implementProgressBlockedHumanAction(issue)
+		}
+		if workpadCurrent && running.DispatchProgress.CompletionKind == workpad.CompletionOperational &&
+			implementProgressDiffStatsClean(running.DiffStats) {
+			if _, ok := operationalCompletionFromIssue(issue); ok {
+				decision.WorkpadStatus = workpad.StatusComplete
+				decision.Reason = implementOperationalCompletion
+				decision.ProgressKinds = []string{"operational_completion"}
+				decision.CompletionKind = workpad.CompletionOperational
+				return decision
+			}
 		}
 		if workpadCurrent && implementProgressMergedCompletionCandidate(issue, running.DiffStats) &&
 			implementProgressLinkedPullRequest(issue) && issue.PullRequest == nil {
@@ -416,6 +430,9 @@ func implementProgressArtifactSnapshotFromIssue(issue connector.Issue, workpadRe
 		NativeBlockers: implementProgressBlockedRefIdentifiers(issue.BlockedBy),
 		WorkpadRead:    workpadRead,
 	}
+	if kind, found, err := workpad.CompletionAuthorizationFromIssueBody(issue.Description); err == nil && found {
+		snapshot.CompletionKind = kind
+	}
 	if !workpadRead {
 		return snapshot
 	}
@@ -474,6 +491,9 @@ func implementProgressHasNewString(current, previous []string) bool {
 
 func implementProgressFieldsAdvanced(previous, current map[string]string) bool {
 	for name, value := range current {
+		if name == workpad.FieldCompletionKind || name == workpad.FieldCompletionEvidence {
+			continue
+		}
 		if previousValue, ok := previous[name]; !ok || strings.TrimSpace(previousValue) != strings.TrimSpace(value) {
 			return true
 		}
@@ -741,6 +761,7 @@ func implementCompletionProgressMetadata(decision implementCompletionProgressDec
 		DependencyBlockers:     append([]implementDependencyBlocker(nil), decision.DependencyBlockers...),
 		RejectedBlockerRefs:    append([]string(nil), decision.RejectedBlockerRefs...),
 		ProgressKinds:          append([]string(nil), decision.ProgressKinds...),
+		CompletionKind:         strings.TrimSpace(decision.CompletionKind),
 	}
 	if decision.PreviousSignatureFound {
 		previous := implementProgressSignatureRecordFromSignature(decision.PreviousSignature)

--- a/internal/orchestrator/implement_progress_test.go
+++ b/internal/orchestrator/implement_progress_test.go
@@ -243,6 +243,22 @@ func TestHandleRunResultClassifiesImplementWorkerProgress(t *testing.T) {
 			currentWorkpadBody: operationalCompletionWorkpadBody("Backfill completed and verified."),
 		},
 		{
+			name: "operational completion with undelivered commits is stranded",
+			runningIssue: func() connector.Issue {
+				issue := implementProgressIssueWithoutPR()
+				issue.Description = operationalCompletionAuthorizationBody()
+				return issue
+			}(),
+			diffStats:          DiffStats{UnpushedCommits: 1, CommitsAhead: 1, Status: "clean"},
+			noProgressLimit:    3,
+			wantTerminal:       store.WorkAttemptTerminalNoProgress,
+			wantReason:         strandedUnpushedWorkReason,
+			wantConsecutive:    1,
+			wantRetry:          true,
+			runningWorkpadBody: implementProgressStructuredWorkpad("in_progress", "", nil),
+			currentWorkpadBody: operationalCompletionWorkpadBody("Backfill completed and verified."),
+		},
+		{
 			name:               "undeclared operational assertion remains no progress",
 			runningIssue:       implementProgressIssueWithoutPR(),
 			diffStats:          DiffStats{Status: "clean"},
@@ -1524,6 +1540,30 @@ func TestImplementProgressMergedCompletionQualification(t *testing.T) {
 			}
 			if got := implementProgressMergedCompletion(issue, diffStats); got != tt.qualifies {
 				t.Fatalf("implementProgressMergedCompletion() = %t, want %t", got, tt.qualifies)
+			}
+		})
+	}
+}
+
+func TestImplementProgressOperationalWorkspaceClean(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		diffStats DiffStats
+		want      bool
+	}{
+		{name: "clean delivery", diffStats: DiffStats{Status: "clean"}, want: true},
+		{name: "workspace diff", diffStats: DiffStats{FilesChanged: 1, Status: "changed"}},
+		{name: "unpushed commit", diffStats: DiffStats{UnpushedCommits: 1, Status: "clean"}},
+		{name: "commit ahead", diffStats: DiffStats{CommitsAhead: 1, Status: "clean"}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := implementProgressOperationalWorkspaceClean(tt.diffStats); got != tt.want {
+				t.Fatalf("implementProgressOperationalWorkspaceClean() = %t, want %t", got, tt.want)
 			}
 		})
 	}

--- a/internal/orchestrator/implement_progress_test.go
+++ b/internal/orchestrator/implement_progress_test.go
@@ -56,6 +56,7 @@ func TestHandleRunResultClassifiesImplementWorkerProgress(t *testing.T) {
 		wantBlockReason    string
 		wantRejectedRef    string
 		wantProgressKinds  []string
+		wantCompletionKind string
 		workpadHumanAction string
 		workpadBlockerRef  string
 		runningWorkpadBody string
@@ -223,6 +224,35 @@ func TestHandleRunResultClassifiesImplementWorkerProgress(t *testing.T) {
 			wantReason:      "completed_clean_diff_without_pull_request",
 			wantConsecutive: 1,
 			wantRetry:       true,
+		},
+		{
+			name: "preauthorized operational completion is deliverable progress",
+			runningIssue: func() connector.Issue {
+				issue := implementProgressIssueWithoutPR()
+				issue.Description = operationalCompletionAuthorizationBody()
+				return issue
+			}(),
+			diffStats:          DiffStats{Status: "clean"},
+			noProgressLimit:    3,
+			wantTerminal:       store.WorkAttemptTerminalSuccess,
+			wantReason:         string(AutoPromoteReasonOperationalCompletion),
+			wantProgressKinds:  []string{"operational_completion"},
+			wantCompletionKind: workpad.CompletionOperational,
+			wantReview:         true,
+			runningWorkpadBody: implementProgressStructuredWorkpad("in_progress", "", nil),
+			currentWorkpadBody: operationalCompletionWorkpadBody("Backfill completed and verified."),
+		},
+		{
+			name:               "undeclared operational assertion remains no progress",
+			runningIssue:       implementProgressIssueWithoutPR(),
+			diffStats:          DiffStats{Status: "clean"},
+			noProgressLimit:    3,
+			wantTerminal:       store.WorkAttemptTerminalNoProgress,
+			wantReason:         "completed_clean_diff_without_pull_request",
+			wantConsecutive:    1,
+			wantRetry:          true,
+			runningWorkpadBody: implementProgressStructuredWorkpad("in_progress", "", nil),
+			currentWorkpadBody: operationalCompletionWorkpadBody("Backfill completed and verified."),
 		},
 		{
 			name:              "first dependency deferral releases claim without tripping loop",
@@ -608,6 +638,9 @@ func TestHandleRunResultClassifiesImplementWorkerProgress(t *testing.T) {
 			}
 			if record.BlockReason != tt.wantBlockReason {
 				t.Fatalf("block reason = %q, want %q", record.BlockReason, tt.wantBlockReason)
+			}
+			if record.CompletionKind != tt.wantCompletionKind {
+				t.Fatalf("completion kind = %q, want %q", record.CompletionKind, tt.wantCompletionKind)
 			}
 			if tt.wantProgressKinds != nil && !reflect.DeepEqual(record.ProgressKinds, tt.wantProgressKinds) {
 				t.Fatalf("progress kinds = %#v, want %#v", record.ProgressKinds, tt.wantProgressKinds)
@@ -1632,6 +1665,7 @@ func TestImplementProgressArtifactKinds(t *testing.T) {
 		{name: "linked blocker", previous: implementProgressArtifactSnapshot{}, current: implementProgressArtifactSnapshot{NativeBlockers: []string{"blocker-id"}}, want: []string{"linked_blocker"}},
 		{name: "typed workpad predicate", previous: implementProgressArtifactSnapshot{WorkpadRead: true}, current: implementProgressArtifactSnapshot{WorkpadRead: true, WorkpadReason: "missing_current_head_ci"}, want: []string{"workpad_predicate"}},
 		{name: "audit artifact", previous: implementProgressArtifactSnapshot{WorkpadRead: true}, current: implementProgressArtifactSnapshot{WorkpadRead: true, WorkpadFields: map[string]string{"duplicate_groups": "23"}}, want: []string{"audit_artifact"}},
+		{name: "completion assertion is not an audit artifact", previous: implementProgressArtifactSnapshot{WorkpadRead: true}, current: implementProgressArtifactSnapshot{WorkpadRead: true, WorkpadFields: map[string]string{workpad.FieldCompletionKind: workpad.CompletionOperational, workpad.FieldCompletionEvidence: "done"}}, want: []string{}},
 		{name: "unverified workpad is ignored", previous: implementProgressArtifactSnapshot{}, current: implementProgressArtifactSnapshot{WorkpadReason: "missing_current_head_ci", WorkpadFields: map[string]string{"duplicate_groups": "23"}}, want: []string{}},
 	}
 

--- a/internal/orchestrator/merge_revocation.go
+++ b/internal/orchestrator/merge_revocation.go
@@ -65,7 +65,8 @@ func (o *Orchestrator) revokeRunningMergeIfIneligible(
 	if _, pending := o.pendingMergeRevocations[running.Issue.ID]; pending {
 		return running, true
 	}
-	if decision, revoked := mergeRevocationForIssue(running.Issue, o.cfg, false); revoked {
+	operationalCompletionAccepted := autoPromoteOperationalCompletionAccepted(state, running.Issue.ID)
+	if decision, revoked := mergeRevocationForIssue(running.Issue, o.cfg, false, operationalCompletionAccepted); revoked {
 		o.beginMergeRevocation(state, running, decision, now)
 		return running, true
 	}
@@ -87,22 +88,29 @@ func (o *Orchestrator) revokeRunningMergeIfIneligible(
 		return running, false
 	}
 	running.Issue = mergeIssueTrackerFields(running.Issue, refreshed)
-	if decision, revoked := mergeRevocationForIssue(running.Issue, o.cfg, true); revoked {
+	if decision, revoked := mergeRevocationForIssue(running.Issue, o.cfg, true, operationalCompletionAccepted); revoked {
 		o.beginMergeRevocation(state, running, decision, now)
 		return running, true
 	}
 	return running, false
 }
 
-func mergeRevocationForIssue(issue connector.Issue, cfg Config, checkPullRequest bool) (mergeRevocation, bool) {
+func mergeRevocationForIssue(
+	issue connector.Issue,
+	cfg Config,
+	checkPullRequest bool,
+	operationalCompletionAccepted bool,
+) (mergeRevocation, bool) {
 	if normalizeState(issue.State) != normalizeState(autoPromoteMergingState) {
 		return mergeRevocation{
 			issue:  cloneIssue(issue),
 			reason: mergeRevocationStateChanged,
 		}, true
 	}
-	if _, ok := operationalCompletionFromIssue(issue); ok {
-		return mergeRevocation{}, false
+	if operationalCompletionAccepted {
+		if _, ok := operationalCompletionFromIssue(issue); ok {
+			return mergeRevocation{}, false
+		}
 	}
 	if _, revoked := mergeApprovalLabelRevoked(issue, cfg); revoked {
 		return mergeRevocation{

--- a/internal/orchestrator/merge_revocation_test.go
+++ b/internal/orchestrator/merge_revocation_test.go
@@ -194,7 +194,7 @@ func TestDraftMergeRevocationUsesConfiguredSourceState(t *testing.T) {
 		},
 	}
 
-	revocation, revoked := mergeRevocationForIssue(issue, cfg, true)
+	revocation, revoked := mergeRevocationForIssue(issue, cfg, true, false)
 	if !revoked {
 		t.Fatal("mergeRevocationForIssue() did not revoke a draft pull request")
 	}
@@ -208,14 +208,22 @@ func TestMergeRevocationDoesNotReportMissingPullRequestForOperationalCompletion(
 
 	cfg := normalizeConfig(Config{AutoPromote: AutoPromoteConfig{SourceState: "Human Review"}})
 	tests := []struct {
-		name        string
-		body        string
-		wantRevoked bool
-		wantReason  string
+		name                          string
+		body                          string
+		operationalCompletionAccepted bool
+		wantRevoked                   bool
+		wantReason                    string
 	}{
 		{
-			name: "declared operational completion",
-			body: operationalCompletionWorkpadBody("Runner service is healthy and accepting jobs."),
+			name:                          "accepted operational completion",
+			body:                          operationalCompletionWorkpadBody("Runner service is healthy and accepting jobs."),
+			operationalCompletionAccepted: true,
+		},
+		{
+			name:        "current declaration without accepted attempt",
+			body:        operationalCompletionWorkpadBody("Runner service is healthy and accepting jobs."),
+			wantRevoked: true,
+			wantReason:  mergeRevocationMissingPullRequest,
 		},
 		{
 			name:        "ordinary no diff completion",
@@ -237,7 +245,7 @@ func TestMergeRevocationDoesNotReportMissingPullRequestForOperationalCompletion(
 					Body: tt.body,
 				}},
 			}
-			revocation, revoked := mergeRevocationForIssue(issue, cfg, true)
+			revocation, revoked := mergeRevocationForIssue(issue, cfg, true, tt.operationalCompletionAccepted)
 			if revoked != tt.wantRevoked || revocation.reason != tt.wantReason {
 				t.Fatalf("mergeRevocationForIssue() = %#v, %t; want revoked %t reason %q", revocation, revoked, tt.wantRevoked, tt.wantReason)
 			}

--- a/internal/orchestrator/merge_revocation_test.go
+++ b/internal/orchestrator/merge_revocation_test.go
@@ -230,8 +230,9 @@ func TestMergeRevocationDoesNotReportMissingPullRequestForOperationalCompletion(
 			t.Parallel()
 
 			issue := connector.Issue{
-				ID:    "issue-operational-merge",
-				State: "Merging",
+				ID:          "issue-operational-merge",
+				State:       "Merging",
+				Description: operationalCompletionAuthorizationBody(),
 				Comments: []connector.IssueComment{{
 					Body: tt.body,
 				}},

--- a/internal/orchestrator/run_completion.go
+++ b/internal/orchestrator/run_completion.go
@@ -645,6 +645,7 @@ func (o *Orchestrator) handleRunResult(ctx context.Context, state *State, event 
 		StartedAt:       running.StartedAt,
 		CompletedAt:     event.CompletedAt,
 		FinalState:      finalState,
+		CompletionKind:  strings.TrimSpace(progress.CompletionKind),
 		Tokens:          event.Result.Tokens,
 		RuntimeIdentity: running.RuntimeIdentity,
 	}

--- a/internal/orchestrator/run_completion.go
+++ b/internal/orchestrator/run_completion.go
@@ -1463,7 +1463,12 @@ func (o *Orchestrator) completeProgrammaticMergeWorkerResult(
 		return true
 	}
 	issue = refreshedIssue
-	if revocation, revoked := mergeRevocationForIssue(issue, o.cfg, true); revoked &&
+	if revocation, revoked := mergeRevocationForIssue(
+		issue,
+		o.cfg,
+		true,
+		autoPromoteOperationalCompletionAccepted(state, issue.ID),
+	); revoked &&
 		mergeRevocationRequiresImmediateStop(revocation, event.Result) {
 		o.finishMergeRevocation(ctx, state, event, running, revocation)
 		return true

--- a/internal/orchestrator/run_completion.go
+++ b/internal/orchestrator/run_completion.go
@@ -872,7 +872,8 @@ func resetWorkerFailureBreakers(state *State, issueID string) {
 }
 
 func implementCompletionHasDurableProgress(running Running, decision implementCompletionProgressDecision) bool {
-	if strings.TrimSpace(running.CompletionLane) != "" || implementProgressLinkedPullRequest(decision.Issue) {
+	if strings.TrimSpace(running.CompletionLane) != "" || implementProgressLinkedPullRequest(decision.Issue) ||
+		strings.TrimSpace(decision.CompletionKind) == workpad.CompletionOperational {
 		return true
 	}
 	for _, kind := range decision.ProgressKinds {

--- a/internal/orchestrator/snapshot.go
+++ b/internal/orchestrator/snapshot.go
@@ -977,6 +977,7 @@ func applyIssueCompletionProgress(issues []telemetry.Issue, attempts []telemetry
 			Outcome:               strings.TrimSpace(record.Outcome),
 			Reason:                strings.TrimSpace(record.Reason),
 			Kinds:                 append([]string(nil), record.ProgressKinds...),
+			CompletionKind:        strings.TrimSpace(record.CompletionKind),
 			ConsecutiveNoProgress: record.ConsecutiveNoProgress,
 			NoProgressLimit:       record.NoProgressLimit,
 		}

--- a/internal/orchestrator/snapshot.go
+++ b/internal/orchestrator/snapshot.go
@@ -532,6 +532,7 @@ func (s State) applyAutoPromoteDecisionSnapshots(snapshots []telemetry.Issue, is
 			}
 			summary := AutoPromoteSummaryFromIssue(issues[i])
 			summary.CompletedFinalState = autoPromoteCompletedFinalState(&s, issueID)
+			summary.OperationalCompletionAccepted = autoPromoteOperationalCompletionAccepted(&s, issueID)
 			summary.AutomatedReviewWaitExpired = autoPromoteReviewWaitExpired(&s, issueID, s.AutoPromote, now)
 			decision = EvaluateAutoPromote(issues[i], summary, s.AutoPromote, now)
 		}

--- a/internal/orchestrator/snapshot_test.go
+++ b/internal/orchestrator/snapshot_test.go
@@ -125,12 +125,12 @@ func TestStateSnapshotCarriesLatestCompletionProgress(t *testing.T) {
 			Status:             string(store.WorkAttemptStatusTerminal),
 			TerminalState:      string(store.WorkAttemptTerminalSuccess),
 			CompletedAt:        timePointer(now),
-			WorkerMetadataJSON: `{"completion_progress":{"outcome":"success","reason":"verifiable_non_diff_progress","progress_kinds":["audit_artifact"],"no_progress_limit":3}}`,
+			WorkerMetadataJSON: `{"completion_progress":{"outcome":"success","reason":"operational_completion","progress_kinds":["operational_completion"],"completion_kind":"operational","no_progress_limit":3}}`,
 		},
 	}
 
 	progress := state.Snapshot(now).BoardIssues[0].CompletionProgress
-	if progress.Outcome != "success" || progress.Reason != implementProgressReasonNonDiff || !reflect.DeepEqual(progress.Kinds, []string{"audit_artifact"}) {
+	if progress.Outcome != "success" || progress.Reason != implementOperationalCompletion || progress.CompletionKind != "operational" || !reflect.DeepEqual(progress.Kinds, []string{"operational_completion"}) {
 		t.Fatalf("CompletionProgress = %#v", progress)
 	}
 }

--- a/internal/orchestrator/spend_progress.go
+++ b/internal/orchestrator/spend_progress.go
@@ -15,6 +15,7 @@ import (
 	runpkg "github.com/digitaldrywood/detent/internal/runner"
 	"github.com/digitaldrywood/detent/internal/store"
 	"github.com/digitaldrywood/detent/internal/telemetry"
+	"github.com/digitaldrywood/detent/internal/workpad"
 )
 
 const (
@@ -305,6 +306,8 @@ func spendProgressAttemptAccepted(attempt store.WorkAttempt) bool {
 	switch strings.TrimSpace(record.Reason) {
 	case "pull_request_created_or_updated", "signature_changed":
 		return true
+	case implementOperationalCompletion:
+		return strings.TrimSpace(record.CompletionKind) == workpad.CompletionOperational
 	default:
 		return false
 	}
@@ -377,6 +380,11 @@ func implementAcceptedStateChange(_ Running, decision implementCompletionProgres
 	switch strings.TrimSpace(decision.Reason) {
 	case "pull_request_created_or_updated", "signature_changed", implementMergedCompletionReason:
 		return true, decision.Reason
+	case implementOperationalCompletion:
+		if strings.TrimSpace(decision.CompletionKind) == workpad.CompletionOperational {
+			return true, decision.Reason
+		}
+		return false, ""
 	default:
 		return false, ""
 	}

--- a/internal/orchestrator/spend_progress_test.go
+++ b/internal/orchestrator/spend_progress_test.go
@@ -14,6 +14,7 @@ import (
 	runpkg "github.com/digitaldrywood/detent/internal/runner"
 	"github.com/digitaldrywood/detent/internal/scheduler"
 	"github.com/digitaldrywood/detent/internal/store"
+	"github.com/digitaldrywood/detent/internal/workpad"
 )
 
 func TestEvaluateSpendProgress(t *testing.T) {
@@ -396,6 +397,8 @@ func TestImplementAcceptedStateChangeRequiresWorkProductProgress(t *testing.T) {
 		{name: "pull request update", decision: implementCompletionProgressDecision{Reason: "pull_request_created_or_updated"}, want: true, wantReason: "pull_request_created_or_updated"},
 		{name: "signature change", decision: implementCompletionProgressDecision{Reason: "signature_changed"}, want: true, wantReason: "signature_changed"},
 		{name: "merged completion", decision: implementCompletionProgressDecision{Reason: implementMergedCompletionReason}, want: true, wantReason: implementMergedCompletionReason},
+		{name: "operational reason without accepted kind", decision: implementCompletionProgressDecision{Reason: implementOperationalCompletion}},
+		{name: "operational completion", decision: implementCompletionProgressDecision{Reason: string(AutoPromoteReasonOperationalCompletion), CompletionKind: workpad.CompletionOperational}, want: true, wantReason: string(AutoPromoteReasonOperationalCompletion)},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -406,6 +409,135 @@ func TestImplementAcceptedStateChangeRequiresWorkProductProgress(t *testing.T) {
 			}
 			if reason != tt.wantReason {
 				t.Fatalf("reason = %q, want %q", reason, tt.wantReason)
+			}
+		})
+	}
+}
+
+func TestOperationalCompletionSpendBreakerContract(t *testing.T) {
+	t.Parallel()
+
+	base := time.Date(2026, 8, 26, 20, 0, 0, 0, time.UTC)
+	tests := []struct {
+		name            string
+		authorized      bool
+		wantTerminal    store.WorkAttemptTerminalState
+		wantState       string
+		wantBlocked     bool
+		wantAccepted    bool
+		wantCompletion  string
+		wantSpendCase   string
+		wantAcceptedWhy string
+	}{
+		{
+			name:            "preauthorized operational completion bypasses no PR breaker",
+			authorized:      true,
+			wantTerminal:    store.WorkAttemptTerminalSuccess,
+			wantState:       "Done",
+			wantAccepted:    true,
+			wantCompletion:  workpad.CompletionOperational,
+			wantAcceptedWhy: string(AutoPromoteReasonOperationalCompletion),
+		},
+		{
+			name:          "undeclared operational assertion trips existing breaker",
+			wantTerminal:  store.WorkAttemptTerminalNoProgress,
+			wantState:     blockedStatusState,
+			wantBlocked:   true,
+			wantSpendCase: spendProgressCaseNoPR,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			createdAt := base.Add(-time.Hour)
+			recordedAt := base.Add(-time.Minute)
+			issue := implementProgressIssueWithoutPR()
+			issue.ID = "issue-operational"
+			issue.Identifier = "digitaldrywood/leadpipe#62"
+			issue.CreatedAt = &createdAt
+			if tt.authorized {
+				issue.Description = operationalCompletionAuthorizationBody()
+			}
+			issue.Comments = []connector.IssueComment{{Body: implementProgressStructuredWorkpad("in_progress", "", nil)}}
+			refreshed := cloneIssue(issue)
+			refreshed.Comments = []connector.IssueComment{{
+				Body:      operationalCompletionWorkpadBody("Classifier-v4 host backfill completed and verified."),
+				CreatedAt: &recordedAt,
+			}}
+			tracker := &implementProgressConnector{refreshed: refreshed}
+			attempts := &implementProgressAttemptStore{}
+			cfg := normalizeConfig(Config{
+				Project:              scheduler.ProjectCandidate{ID: "leadpipe"},
+				BillingMode:          "subscription",
+				NoProgressTokenLimit: 25_000_000,
+				AutoPromote: AutoPromoteConfig{
+					Enabled:         true,
+					NoProgressLimit: 0,
+				},
+				ActiveStates:   []string{"Todo", "In Progress", "Rework", "Merging"},
+				ObservedStates: []string{"Human Review", "Blocked"},
+				TerminalStates: []string{"Done", "Cancelled"},
+			})
+			orch := &Orchestrator{
+				cfg:          cfg,
+				connector:    tracker,
+				workAttempts: attempts,
+				progressSpend: &spendProgressStore{result: store.IssueSpendSince{
+					TotalTokens: 25_604_036,
+					Sessions:    3,
+				}},
+			}
+			state := newState(cfg)
+			running := Running{
+				Issue:            issue,
+				Attempt:          3,
+				WorkAttemptID:    7187,
+				Mode:             runpkg.RunModeImplement,
+				StartedAt:        base.Add(-time.Minute),
+				DiffStats:        DiffStats{Status: "clean"},
+				DispatchProgress: implementProgressArtifactSnapshotFromIssue(issue, true),
+			}
+			state.Running[issue.ID] = running
+			state.Claimed[issue.ID] = Claimed{Issue: issue, ClaimedAt: running.StartedAt}
+
+			orch.handleRunResult(t.Context(), &state, runpkg.Completion{
+				IssueID:     issue.ID,
+				CompletedAt: base,
+				Request:     runpkg.RunRequest{Mode: runpkg.RunModeImplement},
+				Result: runpkg.RunResult{
+					FinalState: FinalStateCompleted,
+					DiffStats:  DiffStats{Status: "clean"},
+				},
+			})
+			if tt.authorized {
+				orch.transitionCompletedActiveIssuesToReview(t.Context(), &state, []connector.Issue{refreshed}, base.Add(time.Second))
+			}
+
+			if len(attempts.completions) != 1 {
+				t.Fatalf("completions = %#v, want one", attempts.completions)
+			}
+			completion := attempts.completions[0]
+			if completion.TerminalState != tt.wantTerminal {
+				t.Fatalf("terminal state = %q, want %q", completion.TerminalState, tt.wantTerminal)
+			}
+			if len(tracker.updates) != 1 || tracker.updates[0].state != tt.wantState {
+				t.Fatalf("updates = %#v, want state %q", tracker.updates, tt.wantState)
+			}
+			if _, blocked := state.Blocked[issue.ID]; blocked != tt.wantBlocked {
+				t.Fatalf("blocked = %t, want %t", blocked, tt.wantBlocked)
+			}
+			progress := implementProgressRecordFromCompletion(t, completion)
+			if progress.CompletionKind != tt.wantCompletion {
+				t.Fatalf("completion kind = %q, want %q", progress.CompletionKind, tt.wantCompletion)
+			}
+			spend, ok := spendProgressRecordFromAttempt(store.WorkAttempt{WorkerMetadataJSON: completion.WorkerMetadataJSON})
+			if !ok {
+				t.Fatal("spend progress metadata missing")
+			}
+			if spend.AcceptedStateChange != tt.wantAccepted || spend.AcceptedReason != tt.wantAcceptedWhy || spend.Case != tt.wantSpendCase {
+				t.Fatalf("spend progress = %#v", spend)
 			}
 		})
 	}
@@ -656,6 +788,8 @@ func TestSpendProgressAttemptAcceptedCompatibility(t *testing.T) {
 		{name: "native accepted record", record: map[string]any{spendProgressMetadataKey: spendProgressRecord{AcceptedStateChange: true}}, want: true},
 		{name: "legacy pull request change", record: map[string]any{implementProgressMetadataKey: implementProgressRecord{Outcome: string(store.WorkAttemptTerminalSuccess), Reason: "pull_request_created_or_updated"}}, want: true},
 		{name: "legacy signature change", record: map[string]any{implementProgressMetadataKey: implementProgressRecord{Outcome: string(store.WorkAttemptTerminalSuccess), Reason: "signature_changed"}}, want: true},
+		{name: "operational completion", record: map[string]any{implementProgressMetadataKey: implementProgressRecord{Outcome: string(store.WorkAttemptTerminalSuccess), Reason: implementOperationalCompletion, CompletionKind: workpad.CompletionOperational}}, want: true},
+		{name: "operational reason without accepted kind", record: map[string]any{implementProgressMetadataKey: implementProgressRecord{Outcome: string(store.WorkAttemptTerminalSuccess), Reason: implementOperationalCompletion}}},
 		{name: "unaccepted record", record: map[string]any{implementProgressMetadataKey: implementProgressRecord{Outcome: string(store.WorkAttemptTerminalSuccess), Reason: "unchanged_signature_clean_diff"}}},
 	}
 	for _, tt := range tests {

--- a/internal/orchestrator/spend_progress_test.go
+++ b/internal/orchestrator/spend_progress_test.go
@@ -421,6 +421,7 @@ func TestOperationalCompletionSpendBreakerContract(t *testing.T) {
 	tests := []struct {
 		name            string
 		authorized      bool
+		authorizedLate  bool
 		wantTerminal    store.WorkAttemptTerminalState
 		wantState       string
 		wantBlocked     bool
@@ -445,6 +446,14 @@ func TestOperationalCompletionSpendBreakerContract(t *testing.T) {
 			wantBlocked:   true,
 			wantSpendCase: spendProgressCaseNoPR,
 		},
+		{
+			name:           "authorization added at completion trips existing breaker",
+			authorizedLate: true,
+			wantTerminal:   store.WorkAttemptTerminalNoProgress,
+			wantState:      blockedStatusState,
+			wantBlocked:    true,
+			wantSpendCase:  spendProgressCaseNoPR,
+		},
 	}
 
 	for _, tt := range tests {
@@ -462,6 +471,9 @@ func TestOperationalCompletionSpendBreakerContract(t *testing.T) {
 			}
 			issue.Comments = []connector.IssueComment{{Body: implementProgressStructuredWorkpad("in_progress", "", nil)}}
 			refreshed := cloneIssue(issue)
+			if tt.authorizedLate {
+				refreshed.Description = operationalCompletionAuthorizationBody()
+			}
 			refreshed.Comments = []connector.IssueComment{{
 				Body:      operationalCompletionWorkpadBody("Classifier-v4 host backfill completed and verified."),
 				CreatedAt: &recordedAt,

--- a/internal/orchestrator/state.go
+++ b/internal/orchestrator/state.go
@@ -221,6 +221,7 @@ type Completed struct {
 	StartedAt       time.Time
 	CompletedAt     time.Time
 	FinalState      string
+	CompletionKind  string
 	Tokens          TokenTotals
 	MergeTiming     MergeTiming
 	RuntimeIdentity agentidentity.Identity

--- a/internal/runner/prompt.go
+++ b/internal/runner/prompt.go
@@ -737,7 +737,12 @@ func appendBlockedHandoffBlock(prompt string, opts PromptOptions) string {
 		"blockers: []\n" +
 		"human_action: null\n" +
 		"```\n\n" +
-		"Operational work completed outside the repository with no diff and no pull request may instead declare:\n\n" +
+		"Operational work completed outside the repository with no diff and no pull request may instead declare completion only when the issue body authorized it before dispatch with:\n\n" +
+		"```detent-completion\n" +
+		"schema: 1\n" +
+		"completion_kind: operational\n" +
+		"```\n\n" +
+		"The final Workpad declaration must then include evidence:\n\n" +
 		"```detent-status\n" +
 		"schema: 1\n" +
 		"status: complete\n" +
@@ -747,7 +752,8 @@ func appendBlockedHandoffBlock(prompt string, opts PromptOptions) string {
 		"blockers: []\n" +
 		"human_action: null\n" +
 		"```\n\n" +
-		"Use the operational declaration only when the completed work intentionally has no repository change or pull request. " +
+		"Use the operational declaration only when the issue was pre-authorized and the completed work intentionally has no repository change or pull request. " +
+		"Adding authorization at completion time does not qualify. " +
 		"An ordinary no-diff completion continues through the configured pull-request gate.\n\n" +
 		"Narrative Workpad sentences are never read as blockers. Legacy fallback during the deprecation window: keep a machine-readable issue-body line such as `Blocked by: #123` or `Depends on: owner/repo#123` only when native dependencies are unavailable and the project has not migrated."
 }

--- a/internal/runner/prompt_test.go
+++ b/internal/runner/prompt_test.go
@@ -287,7 +287,9 @@ func TestBuildPromptDocumentsWorkpadStatusContract(t *testing.T) {
 			"blockers: []\n" +
 			"human_action: null\n" +
 			"```",
-		"Operational work completed outside the repository with no diff and no pull request may instead declare:",
+		"Operational work completed outside the repository with no diff and no pull request may instead declare completion only when the issue body authorized it before dispatch with:",
+		"```detent-completion",
+		"Adding authorization at completion time does not qualify.",
 		"completion_kind: operational",
 		"completion_evidence: \"what changed on the host and how it was verified\"",
 	} {

--- a/internal/telemetry/snapshot.go
+++ b/internal/telemetry/snapshot.go
@@ -1032,6 +1032,7 @@ type CompletionProgress struct {
 	Outcome               string   `json:"outcome,omitempty"`
 	Reason                string   `json:"reason,omitempty"`
 	Kinds                 []string `json:"kinds,omitempty"`
+	CompletionKind        string   `json:"completion_kind,omitempty"`
 	ConsecutiveNoProgress int      `json:"consecutive_no_progress,omitempty"`
 	NoProgressLimit       int      `json:"no_progress_limit,omitempty"`
 }
@@ -1039,7 +1040,7 @@ type CompletionProgress struct {
 const CompletionProgressOutcomeNoProgress = "no_progress"
 
 func (p CompletionProgress) IsZero() bool {
-	return p.Outcome == "" && p.Reason == "" && len(p.Kinds) == 0 && p.ConsecutiveNoProgress == 0 && p.NoProgressLimit == 0
+	return p.Outcome == "" && p.Reason == "" && len(p.Kinds) == 0 && p.CompletionKind == "" && p.ConsecutiveNoProgress == 0 && p.NoProgressLimit == 0
 }
 
 type ParkSummary struct {

--- a/internal/web/templates/board_data.go
+++ b/internal/web/templates/board_data.go
@@ -1419,7 +1419,11 @@ func boardCardCompletionProgress(progress telemetry.CompletionProgress) (string,
 	}
 	if len(labels) > 0 {
 		summary := "Last turn · " + strings.Join(labels, " + ")
-		return summary, summary + "; reason: " + strings.TrimSpace(progress.Reason), primitives.KindInfo
+		detail := summary
+		if completionKind := strings.TrimSpace(progress.CompletionKind); completionKind != "" {
+			detail += "; completion kind: " + completionKind
+		}
+		return summary, detail + "; reason: " + strings.TrimSpace(progress.Reason), primitives.KindInfo
 	}
 	return "", "", ""
 }

--- a/internal/web/templates/board_data_test.go
+++ b/internal/web/templates/board_data_test.go
@@ -99,6 +99,11 @@ func TestBoardCardRendersCompletionProgressClassification(t *testing.T) {
 			want:     []string{"Last turn · audit artifact", "verifiable_non_diff_progress"},
 		},
 		{
+			name:     "operational completion",
+			progress: telemetry.CompletionProgress{Outcome: "success", Reason: "operational_completion", Kinds: []string{"operational_completion"}, CompletionKind: "operational"},
+			want:     []string{"Last turn · operational completion", "completion kind: operational", "operational_completion"},
+		},
+		{
 			name:     "prose-only no progress",
 			progress: telemetry.CompletionProgress{Outcome: telemetry.CompletionProgressOutcomeNoProgress, Reason: "completed_clean_diff_without_pull_request", ConsecutiveNoProgress: 2, NoProgressLimit: 3},
 			want:     []string{"Last turn · no progress 2/3", "completed_clean_diff_without_pull_request"},

--- a/internal/workpad/workpad.go
+++ b/internal/workpad/workpad.go
@@ -94,6 +94,11 @@ type statusBlockYAML struct {
 	Fields      map[string]string `yaml:"fields"`
 }
 
+type completionAuthorizationYAML struct {
+	Schema         int    `yaml:"schema"`
+	CompletionKind string `yaml:"completion_kind"`
+}
+
 type blockerYAML struct {
 	Ref             string         `yaml:"ref"`
 	Reason          string         `yaml:"reason"`
@@ -151,6 +156,72 @@ func LastStatusBlock(body string) (string, bool) {
 		trimmed := strings.TrimSpace(line)
 		if !inFence {
 			char, length, ok := statusFenceOpening(trimmed)
+			if !ok {
+				continue
+			}
+			inFence = true
+			fenceChar = char
+			fenceLen = length
+			lines = lines[:0]
+			continue
+		}
+		if statusFenceClosing(trimmed, fenceChar, fenceLen) {
+			last = strings.Join(lines, "\n")
+			found = true
+			inFence = false
+			continue
+		}
+		lines = append(lines, line)
+	}
+
+	return last, found
+}
+
+func CompletionAuthorizationFromIssueBody(body string) (string, bool, error) {
+	content, found := lastCompletionAuthorizationBlock(body)
+	if !found {
+		return "", false, nil
+	}
+
+	var raw completionAuthorizationYAML
+	decoder := yaml.NewDecoder(strings.NewReader(content))
+	decoder.KnownFields(true)
+	if err := decoder.Decode(&raw); err != nil {
+		return "", true, fmt.Errorf("parse detent-completion YAML: %w", err)
+	}
+	var extra any
+	if err := decoder.Decode(&extra); err == nil {
+		return "", true, errors.New("parse detent-completion YAML: multiple YAML documents are not supported")
+	} else if !errors.Is(err, io.EOF) {
+		return "", true, errors.New("parse detent-completion YAML: multiple YAML documents are not supported")
+	}
+	if raw.Schema != 1 {
+		return "", true, errors.New("detent-completion schema must be 1")
+	}
+	kind := normalizeToken(raw.CompletionKind)
+	if kind != CompletionOperational {
+		return "", true, fmt.Errorf("completion_kind %q must be operational", strings.TrimSpace(raw.CompletionKind))
+	}
+	return kind, true, nil
+}
+
+func OperationalCompletionAuthorized(body string) bool {
+	kind, found, err := CompletionAuthorizationFromIssueBody(body)
+	return err == nil && found && kind == CompletionOperational
+}
+
+func lastCompletionAuthorizationBlock(body string) (string, bool) {
+	var last string
+	found := false
+	inFence := false
+	fenceChar := byte(0)
+	fenceLen := 0
+	lines := []string{}
+
+	for _, line := range strings.Split(body, "\n") {
+		trimmed := strings.TrimSpace(line)
+		if !inFence {
+			char, length, ok := namedFenceOpening(trimmed, "detent-completion")
 			if !ok {
 				continue
 			}
@@ -592,6 +663,10 @@ func ContentHash(content string) string {
 }
 
 func statusFenceOpening(line string) (byte, int, bool) {
+	return namedFenceOpening(line, "detent-status")
+}
+
+func namedFenceOpening(line string, name string) (byte, int, bool) {
 	if len(line) < 3 || (line[0] != '`' && line[0] != '~') {
 		return 0, 0, false
 	}
@@ -604,7 +679,7 @@ func statusFenceOpening(line string) (byte, int, bool) {
 		return 0, 0, false
 	}
 	fields := strings.Fields(strings.TrimSpace(line[length:]))
-	if len(fields) == 0 || fields[0] != "detent-status" {
+	if len(fields) == 0 || fields[0] != name {
 		return 0, 0, false
 	}
 	return char, length, true

--- a/internal/workpad/workpad_test.go
+++ b/internal/workpad/workpad_test.go
@@ -315,6 +315,76 @@ func TestOperationalCompletion(t *testing.T) {
 	}
 }
 
+func TestCompletionAuthorizationFromIssueBody(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		body      string
+		wantKind  string
+		wantFound bool
+		wantError string
+	}{
+		{
+			name:      "operational completion authorized",
+			body:      "## Completion contract\n\n```detent-completion\nschema: 1\ncompletion_kind: operational\n```",
+			wantKind:  CompletionOperational,
+			wantFound: true,
+		},
+		{
+			name:      "last authorization wins",
+			body:      "```detent-completion\nschema: 1\ncompletion_kind: unsupported\n```\n\n```detent-completion\nschema: 1\ncompletion_kind: operational\n```",
+			wantKind:  CompletionOperational,
+			wantFound: true,
+		},
+		{name: "ordinary issue body"},
+		{
+			name:      "unsupported completion kind",
+			body:      "```detent-completion\nschema: 1\ncompletion_kind: repository\n```",
+			wantFound: true,
+			wantError: `completion_kind "repository" must be operational`,
+		},
+		{
+			name:      "unknown field",
+			body:      "```detent-completion\nschema: 1\ncompletion_kind: operational\nextra: nope\n```",
+			wantFound: true,
+			wantError: "field extra not found",
+		},
+		{
+			name:      "wrong schema",
+			body:      "```detent-completion\nschema: 2\ncompletion_kind: operational\n```",
+			wantFound: true,
+			wantError: "schema must be 1",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			kind, found, err := CompletionAuthorizationFromIssueBody(tt.body)
+			if found != tt.wantFound {
+				t.Fatalf("found = %t, want %t", found, tt.wantFound)
+			}
+			if tt.wantError != "" {
+				if err == nil || !strings.Contains(err.Error(), tt.wantError) {
+					t.Fatalf("error = %v, want containing %q", err, tt.wantError)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("CompletionAuthorizationFromIssueBody() error = %v", err)
+			}
+			if kind != tt.wantKind {
+				t.Fatalf("kind = %q, want %q", kind, tt.wantKind)
+			}
+			if got := OperationalCompletionAuthorized(tt.body); got != (tt.wantKind == CompletionOperational) {
+				t.Fatalf("OperationalCompletionAuthorized() = %t", got)
+			}
+		})
+	}
+}
+
 func TestParseRef(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

- Require issue-body operational authorization captured at dispatch before a no-PR Workpad declaration counts as accepted progress.
- Route accepted operational work through spend braking, PR-free promotion, optional human approval, and durable restart reconciliation.
- Bind completion transition, gate-wait, and merge revocation to the durable accepted-attempt marker rather than mutable current tracker text alone.
- Surface the completion kind in work-attempt audit data and board detail, document/doctor the workflow contract, and capture the reusable authorization audit in a draft skill.

Fixes #1997

## UI Surface Contract

- [x] N/A; this PR makes no high-impact UI surface, layout, density, first-viewport, or responsive visibility tradeoff.
- [x] This PR does not add persistent top-of-screen messaging.
- [x] N/A; there is no primary-screen layout or visual change. Board completion-detail behavior is covered by a view-model test.

## Test Plan

- [x] `make check` with Go 1.26.0 and golangci-lint 2.9.0.
- [x] Exact-file coverage: `implement_progress.go` 91.5% (550/601), `spend_progress.go` 91.2% (269/295).
- [x] `go test ./internal/orchestrator -run=^$ -fuzz=FuzzSafetyCriticalOrchestratorBoundaries -fuzztime=30s` (260,091 executions).
- [x] Focused operational-completion regressions and affected package suites.
- [x] Current-head CI run `33200739275` for `bd49256a` is green (11/11 checks).