### PR TITLE
test(update): synchronize HTTP download timeout

### DIFF
--- a/internal/update/update_test.go
+++ b/internal/update/update_test.go
@@ -417,26 +417,70 @@ func TestGitHubClientDownloadRejectsOversize(t *testing.T) {
 func TestGitHubClientDownloadHonorsHTTPTimeout(t *testing.T) {
 	t.Parallel()
 
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		w.WriteHeader(http.StatusOK)
-		if flusher, ok := w.(http.Flusher); ok {
-			flusher.Flush()
-		}
-		time.Sleep(100 * time.Millisecond)
-		_, _ = w.Write([]byte("late"))
-	}))
-	t.Cleanup(server.Close)
-
-	httpClient := server.Client()
-	httpClient.Timeout = 10 * time.Millisecond
+	readStarted := make(chan struct{}, 1)
+	httpClient := &http.Client{
+		Transport: roundTripFunc(func(request *http.Request) (*http.Response, error) {
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Body: &contextBlockingBody{
+					done:        request.Context().Done(),
+					contextErr:  request.Context().Err,
+					readStarted: readStarted,
+				},
+				Header: make(http.Header),
+			}, nil
+		}),
+		Timeout: 100 * time.Millisecond,
+	}
 	client := NewGitHubClient(GitHubClientConfig{HTTPClient: httpClient})
-	_, err := client.Download(context.Background(), server.URL)
-	if err == nil {
-		t.Fatal("Download() error = nil, want timeout")
+	result := make(chan error, 1)
+	go func() {
+		_, err := client.Download(context.Background(), "https://example.test/release")
+		result <- err
+	}()
+
+	select {
+	case <-readStarted:
+	case <-time.After(5 * time.Second):
+		t.Fatal("Download() did not start reading the response body")
 	}
-	if !strings.Contains(err.Error(), "timeout") && !errors.Is(err, context.DeadlineExceeded) {
-		t.Fatalf("Download() error = %v, want timeout", err)
+
+	select {
+	case err := <-result:
+		if err == nil {
+			t.Fatal("Download() error = nil, want timeout")
+		}
+		if !strings.Contains(err.Error(), "timeout") && !errors.Is(err, context.DeadlineExceeded) {
+			t.Fatalf("Download() error = %v, want timeout", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("Download() did not return after the HTTP client timeout")
 	}
+}
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(request *http.Request) (*http.Response, error) {
+	return f(request)
+}
+
+type contextBlockingBody struct {
+	done        <-chan struct{}
+	contextErr  func() error
+	readStarted chan<- struct{}
+}
+
+func (b *contextBlockingBody) Read([]byte) (int, error) {
+	select {
+	case b.readStarted <- struct{}{}:
+	default:
+	}
+	<-b.done
+	return 0, b.contextErr()
+}
+
+func (*contextBlockingBody) Close() error {
+	return nil
 }
 
 func TestServiceAppliesReleaseUpdateWithMinisignSignatureFromHTTPServer(t *testing.T) {


### PR DESCRIPTION
## Summary

- replace the download timeout wall-clock race with a synchronized response body
- verify the HTTP client timeout cancels `Download` while reading the response body

Fixes #2019

## UI Surface Contract

- [x] N/A, or the linked issue explicitly authorizes any high-impact UI surface, layout, density, first-viewport, or responsive visibility tradeoff.
- [x] Persistent top-of-screen messaging is explicitly authorized by the issue, or this PR does not add it.
- [x] Visual changes to primary operator screens include screenshot or browser verification below.

## Test Plan

- [x] `go test -race ./internal/update -run '^TestGitHubClientDownloadHonorsHTTPTimeout$' -count=50`
- [x] `golangci-lint run --timeout=5m ./internal/update/...`
- [x] `make check`