### PR TITLE
fix(orchestrator): credit linked PR progress

### DIFF
--- a/db/queries/store.sql
+++ b/db/queries/store.sql
@@ -627,7 +627,7 @@ SELECT
   CAST(COALESCE(MAX(finished_at), '') AS TEXT) AS last_session_at
 FROM usage_events
 WHERE project_id = sqlc.arg(project_id)
-  AND finished_at > sqlc.arg(since)
+  AND started_at > sqlc.arg(since)
   AND (
     (sqlc.arg(issue_id) != '' AND COALESCE(issue_id, '') = sqlc.arg(issue_id))
     OR (sqlc.arg(identifier) != '' AND COALESCE(identifier, '') = sqlc.arg(identifier))

--- a/internal/cli/dashboard_client.go
+++ b/internal/cli/dashboard_client.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/digitaldrywood/detent/internal/explain"
 	"github.com/digitaldrywood/detent/internal/operatortool"
+	"github.com/digitaldrywood/detent/internal/store"
 )
 
 const (
@@ -142,6 +143,34 @@ func (c *DashboardReadClient) ExplainIssue(ctx context.Context, projectID string
 
 func (c *DashboardReadClient) AcknowledgeIssueParks(ctx context.Context, projectID string, reference string) (explain.IssueExplanation, error) {
 	return c.issueExplanation(ctx, http.MethodPost, projectID, reference)
+}
+
+func (c *DashboardReadClient) CreditIssueProgress(ctx context.Context, projectID string, reference string) (store.IssueProgressCredit, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if err := ctx.Err(); err != nil {
+		return store.IssueProgressCredit{}, err
+	}
+	projectID = strings.TrimSpace(projectID)
+	reference = strings.TrimSpace(reference)
+	if projectID == "" || reference == "" {
+		return store.IssueProgressCredit{}, ValidationError("--project and issue reference are required")
+	}
+	if c == nil || c.baseURL == nil {
+		return store.IssueProgressCredit{}, errors.New("dashboard API client is not configured")
+	}
+	requestURL := *c.baseURL
+	requestURL.Path = "/api/v1/projects/" + projectID + "/issues/progress-credit"
+	requestURL.RawPath = "/api/v1/projects/" + url.PathEscape(projectID) + "/issues/progress-credit"
+	query := requestURL.Query()
+	query.Set("reference", reference)
+	query.Set("schema", strconv.Itoa(explain.SchemaVersion))
+	requestURL.RawQuery = query.Encode()
+
+	var result store.IssueProgressCredit
+	_, err := c.requestJSON(ctx, http.MethodPost, requestURL, &result)
+	return result, err
 }
 
 func (c *DashboardReadClient) issueExplanation(ctx context.Context, method string, projectID string, reference string) (explain.IssueExplanation, error) {

--- a/internal/cli/dashboard_client_test.go
+++ b/internal/cli/dashboard_client_test.go
@@ -19,6 +19,7 @@ import (
 	globalconfig "github.com/digitaldrywood/detent/internal/config/global"
 	"github.com/digitaldrywood/detent/internal/explain"
 	"github.com/digitaldrywood/detent/internal/operatortool"
+	"github.com/digitaldrywood/detent/internal/store"
 )
 
 func TestDashboardReadClientExecutesSharedOperatorTool(t *testing.T) {
@@ -180,6 +181,36 @@ func TestDashboardReadClientAcknowledgesIssueParks(t *testing.T) {
 	got, err := dashboardClientForServer(t, server, "").AcknowledgeIssueParks(t.Context(), "detent", "#1643")
 	if err != nil {
 		t.Fatalf("AcknowledgeIssueParks() error = %v", err)
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("result = %#v, want %#v", got, want)
+	}
+}
+
+func TestDashboardReadClientCreditsIssueProgress(t *testing.T) {
+	t.Parallel()
+
+	want := store.IssueProgressCredit{
+		ProjectID:  "detent",
+		IssueID:    "issue-2015",
+		Identifier: "digitaldrywood/detent#2015",
+		CreditedAt: time.Date(2026, 8, 28, 12, 34, 56, 0, time.UTC),
+	}
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		if request.Method != http.MethodPost || request.URL.Path != "/api/v1/projects/detent/issues/progress-credit" {
+			t.Errorf("request = %s %s", request.Method, request.URL.Path)
+		}
+		if got := request.URL.Query().Get("reference"); got != "#2015" {
+			t.Errorf("reference = %q", got)
+		}
+		writer.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(writer).Encode(want)
+	}))
+	t.Cleanup(server.Close)
+
+	got, err := dashboardClientForServer(t, server, "").CreditIssueProgress(t.Context(), "detent", "#2015")
+	if err != nil {
+		t.Fatalf("CreditIssueProgress() error = %v", err)
 	}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("result = %#v, want %#v", got, want)
@@ -542,6 +573,77 @@ func TestIssueCommandOutputAndScoping(t *testing.T) {
 	}
 }
 
+func TestIssueCommandCreditsProgress(t *testing.T) {
+	t.Parallel()
+
+	credit := store.IssueProgressCredit{
+		ProjectID:  "detent",
+		IssueID:    "issue-2015",
+		Identifier: "digitaldrywood/detent#2015",
+		CreditedAt: time.Date(2026, 8, 28, 12, 34, 56, 0, time.UTC),
+	}
+	tests := []struct {
+		name      string
+		stdoutTTY bool
+	}{
+		{name: "pretty", stdoutTTY: true},
+		{name: "json"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+				if request.Method != http.MethodPost || request.URL.Path != "/api/v1/projects/detent/issues/progress-credit" {
+					t.Errorf("request = %s %s", request.Method, request.URL.Path)
+				}
+				_ = json.NewEncoder(writer).Encode(credit)
+			}))
+			t.Cleanup(server.Close)
+			parsed, err := url.Parse(server.URL)
+			if err != nil {
+				t.Fatalf("Parse() error = %v", err)
+			}
+			port, err := strconv.Atoi(parsed.Port())
+			if err != nil {
+				t.Fatalf("Atoi() error = %v", err)
+			}
+			opts := dashboardClientOptions(server.Client().Do, "", "")
+			opts.read = func(string) (globalconfig.Config, error) {
+				return globalconfig.Config{Port: &port}, nil
+			}
+			configPath := "/config/global.yaml"
+			host := parsed.Hostname()
+			cmd := newIssueCommand(&configPath, &host, &port, opts)
+			cmd.SilenceUsage = true
+			cmd.SetContext(withCommandOutputOptions(t.Context(), commandOutputOptions{
+				lookupEnv: opts.lookupEnv,
+				stdoutTTY: func() bool { return tt.stdoutTTY },
+			}))
+			var stdout bytes.Buffer
+			cmd.SetOut(&stdout)
+			cmd.SetErr(&bytes.Buffer{})
+			cmd.SetArgs([]string{"#2015", "--credit-progress", "--project", "detent"})
+			if err := cmd.Execute(); err != nil {
+				t.Fatalf("Execute() error = %v", err)
+			}
+			if tt.stdoutTTY {
+				if want := "Credited accepted progress for digitaldrywood/detent#2015 at 2026-08-28T12:34:56Z"; !strings.Contains(stdout.String(), want) {
+					t.Fatalf("stdout = %q, want containing %q", stdout.String(), want)
+				}
+				return
+			}
+			var got store.IssueProgressCredit
+			if err := json.Unmarshal(stdout.Bytes(), &got); err != nil {
+				t.Fatalf("Unmarshal() error = %v; stdout = %s", err, stdout.String())
+			}
+			if !reflect.DeepEqual(got, credit) {
+				t.Fatalf("JSON result = %#v, want %#v", got, credit)
+			}
+		})
+	}
+}
+
 func TestIssueCommandHelpCoversScopingAndJSON(t *testing.T) {
 	t.Parallel()
 
@@ -553,7 +655,7 @@ func TestIssueCommandHelpCoversScopingAndJSON(t *testing.T) {
 	if err := cmd.Execute(); err != nil {
 		t.Fatalf("Execute() error = %v", err)
 	}
-	for _, want := range []string{"detent issue '#1643' --explain --project detent", "--format json", "--project string", "running Detent service"} {
+	for _, want := range []string{"detent issue '#1643' --explain --project detent", "--credit-progress", "--format json", "--project string", "running Detent service"} {
 		if !strings.Contains(stdout.String(), want) {
 			t.Fatalf("help missing %q:\n%s", want, stdout.String())
 		}

--- a/internal/cli/issue.go
+++ b/internal/cli/issue.go
@@ -12,24 +12,27 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/digitaldrywood/detent/internal/explain"
+	"github.com/digitaldrywood/detent/internal/store"
 )
 
 func newIssueCommand(configPath *string, host *string, port *int, opts options) *cobra.Command {
 	var explainIssue bool
 	var acknowledgeParks bool
+	var creditProgress bool
 	var projectID string
 	cmd := &cobra.Command{
 		Use:   "issue <ref>",
 		Short: "Inspect an issue through the running Detent service",
-		Long:  "Inspect or acknowledge an issue through the running Detent service. Issue operations use bounded HTTP requests and never open the runtime database or contact the tracker directly.",
+		Long:  "Inspect, acknowledge parks, or credit accepted progress through the running Detent service. Issue operations use bounded HTTP requests and never open the runtime database or contact the tracker directly.",
 		Example: strings.TrimSpace(`detent issue '#1643' --explain --project detent
 detent issue digitaldrywood/detent#1643 --explain --project detent --format json
 	detent issue https://github.com/digitaldrywood/detent/issues/1643 --explain --project detent | jq '.current_lane'
-	detent issue '#1643' --acknowledge-parks --project detent`),
+	detent issue '#1643' --acknowledge-parks --project detent
+	detent issue '#1643' --credit-progress --project detent`),
 		Args: ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if explainIssue == acknowledgeParks {
-				return NewValidationError("exactly one issue operation is required", "Use either --explain or --acknowledge-parks.", nil)
+			if issueOperationCount(explainIssue, acknowledgeParks, creditProgress) != 1 {
+				return NewValidationError("exactly one issue operation is required", "Use --explain, --acknowledge-parks, or --credit-progress.", nil)
 			}
 			if strings.TrimSpace(projectID) == "" {
 				return NewValidationError("--project is required", "Pass the Detent project ID that owns the issue, for example --project detent.", nil)
@@ -41,6 +44,15 @@ detent issue digitaldrywood/detent#1643 --explain --project detent --format json
 			client, err := newDashboardReadClient(cmd.Context(), derefString(configPath), derefString(host), derefInt(port, -1), flagChanged(cmd, "port"), opts)
 			if err != nil {
 				return err
+			}
+			if creditProgress {
+				credit, err := client.CreditIssueProgress(cmd.Context(), projectID, args[0])
+				if err != nil {
+					return classifyDashboardReadError(err)
+				}
+				return out.Write(func(writer io.Writer) error {
+					return writeIssueProgressCreditPretty(writer, credit)
+				}, credit)
 			}
 			var result explain.IssueExplanation
 			if acknowledgeParks {
@@ -58,8 +70,31 @@ detent issue digitaldrywood/detent#1643 --explain --project detent --format json
 	}
 	cmd.Flags().BoolVar(&explainIssue, "explain", false, "show the versioned issue explanation read model")
 	cmd.Flags().BoolVar(&acknowledgeParks, "acknowledge-parks", false, "acknowledge the issue's current park sequence")
+	cmd.Flags().BoolVar(&creditProgress, "credit-progress", false, "reset spend-since-progress counters for this issue")
 	cmd.Flags().StringVar(&projectID, "project", "", "Detent project ID that owns the issue (required)")
 	return cmd
+}
+
+func issueOperationCount(operations ...bool) int {
+	count := 0
+	for _, enabled := range operations {
+		if enabled {
+			count++
+		}
+	}
+	return count
+}
+
+func writeIssueProgressCreditPretty(writer io.Writer, credit store.IssueProgressCredit) error {
+	identity := credit.Identifier
+	if identity == "" {
+		identity = credit.IssueID
+	}
+	if identity == "" {
+		identity = credit.IssueURL
+	}
+	_, err := fmt.Fprintf(writer, "Credited accepted progress for %s at %s\n", identity, credit.CreditedAt.UTC().Format(time.RFC3339))
+	return err
 }
 
 func classifyDashboardReadError(err error) error {

--- a/internal/connector/connector.go
+++ b/internal/connector/connector.go
@@ -166,6 +166,10 @@ type PullRequestHydrator interface {
 	HydratePullRequest(context.Context, Issue) (Issue, error)
 }
 
+type PullRequestReferenceRefresher interface {
+	RefreshPullRequestReference(context.Context, Issue) (Issue, error)
+}
+
 type PullRequestHeadLookup interface {
 	LookupPullRequestByHead(context.Context, string, string, string) (PullRequest, bool, error)
 }

--- a/internal/connector/github/adapter_test.go
+++ b/internal/connector/github/adapter_test.go
@@ -4024,6 +4024,25 @@ func TestConnectorFetchIssueStatesByIDsCapturesIssueMetadata(t *testing.T) {
 	}
 }
 
+func TestConnectorRefreshPullRequestReferenceCapturesClosingReference(t *testing.T) {
+	t.Parallel()
+
+	server := newGraphQLTestServer(t, []graphqlTestResponse{
+		{
+			body: `{"data":{"nodes":[{"__typename":"Issue","id":"I_kw1","closedByPullRequestsReferences":{"pageInfo":{"hasNextPage":false,"endCursor":null},"nodes":[{"number":42,"url":"https://github.com/example/repo/pull/42","state":"OPEN","updatedAt":"2026-08-28T00:38:50Z","repository":{"nameWithOwner":"example/repo"}}]}}]}}`,
+		},
+	})
+	c := newGitHubTestConnector(t, server, Config{ProjectSlug: "PVT_1"})
+
+	got, err := c.RefreshPullRequestReference(t.Context(), connector.Issue{ID: "I_kw1", Identifier: "example/repo#1"})
+	if err != nil {
+		t.Fatalf("RefreshPullRequestReference() error = %v", err)
+	}
+	if got.PRNumber == nil || *got.PRNumber != 42 || got.PRRepository != "example/repo" {
+		t.Fatalf("pull request reference = (%v, %q), want (42, example/repo)", got.PRNumber, got.PRRepository)
+	}
+}
+
 func TestConnectorFetchIssueStatesByIDsPaginatesProjectItems(t *testing.T) {
 	t.Parallel()
 

--- a/internal/connector/github/statuslabel.go
+++ b/internal/connector/github/statuslabel.go
@@ -134,10 +134,14 @@ func (c *Connector) fetchLabelIssuesByStates(ctx context.Context, stateNames []s
 }
 
 func (c *Connector) attachLabelIssuePullRequestReferences(ctx context.Context, issues []connector.Issue) error {
-	return c.attachLabelIssuePullRequestReferencesWithState(ctx, issues, false)
+	return c.attachIssuePullRequestReferences(ctx, issues, true, false)
 }
 
 func (c *Connector) attachLabelIssuePullRequestReferencesWithState(ctx context.Context, issues []connector.Issue, includeState bool) error {
+	return c.attachIssuePullRequestReferences(ctx, issues, true, includeState)
+}
+
+func (c *Connector) attachIssuePullRequestReferences(ctx context.Context, issues []connector.Issue, includeLabelTransition bool, includeState bool) error {
 	indexesByID := make(map[string][]int, len(issues))
 	ids := make([]string, 0, len(issues))
 	for index, issue := range issues {
@@ -185,10 +189,12 @@ func (c *Connector) attachLabelIssuePullRequestReferencesWithState(ctx context.C
 
 		for batchIndex, id := range batch {
 			node := nodesByID[id]
-			for _, index := range indexesByID[id] {
-				if transition, ok := currentLabelTransition(node.TimelineItems.Nodes, c.statusLabelForState(issues[index].State)); ok {
-					issues[index].StageUpdatedAt = &transition.EnteredAt
-					issues[index].StageUpdatedActor = transition.Actor
+			if includeLabelTransition {
+				for _, index := range indexesByID[id] {
+					if transition, ok := currentLabelTransition(node.TimelineItems.Nodes, c.statusLabelForState(issues[index].State)); ok {
+						issues[index].StageUpdatedAt = &transition.EnteredAt
+						issues[index].StageUpdatedActor = transition.Actor
+					}
 				}
 			}
 			needsPullRequest := false
@@ -241,6 +247,14 @@ func (c *Connector) attachLabelIssuePullRequestReferencesWithState(ctx context.C
 		}
 	}
 	return nil
+}
+
+func (c *Connector) RefreshPullRequestReference(ctx context.Context, issue connector.Issue) (connector.Issue, error) {
+	issues := []connector.Issue{issue}
+	if err := c.attachIssuePullRequestReferences(ctx, issues, false, false); err != nil {
+		return issue, fmt.Errorf("refresh github issue pull request reference: %w", err)
+	}
+	return issues[0], nil
 }
 
 func currentLabelTransition(events []timelineItem, labelName string) (connector.IssueStateTransition, bool) {

--- a/internal/orchestrator/implement_progress_test.go
+++ b/internal/orchestrator/implement_progress_test.go
@@ -1965,17 +1965,20 @@ func implementProgressRecordFromCompletion(t *testing.T, completion store.WorkAt
 }
 
 type implementProgressConnector struct {
-	hydrated         connector.Issue
-	refreshed        connector.Issue
-	hydrateErr       error
-	hydrateErrs      []error
-	refreshErr       error
-	hydrations       int
-	updates          []implementProgressUpdate
-	comments         []implementProgressComment
-	relabelStarted   chan autoPromoteTickRelabel
-	relabelRelease   chan struct{}
-	resolvedBlockers []connector.Issue
+	hydrated           connector.Issue
+	refreshed          connector.Issue
+	referenced         connector.Issue
+	hydrateErr         error
+	hydrateErrs        []error
+	refreshErr         error
+	referenceErr       error
+	hydrations         int
+	referenceRefreshes int
+	updates            []implementProgressUpdate
+	comments           []implementProgressComment
+	relabelStarted     chan autoPromoteTickRelabel
+	relabelRelease     chan struct{}
+	resolvedBlockers   []connector.Issue
 }
 
 type implementProgressUpdate struct {
@@ -2008,6 +2011,17 @@ func (c *implementProgressConnector) FetchIssueStatesByIDs(context.Context, []st
 		return nil, nil
 	}
 	return []connector.Issue{cloneIssue(c.refreshed)}, nil
+}
+
+func (c *implementProgressConnector) RefreshPullRequestReference(_ context.Context, issue connector.Issue) (connector.Issue, error) {
+	c.referenceRefreshes++
+	if c.referenceErr != nil {
+		return connector.Issue{}, c.referenceErr
+	}
+	if strings.TrimSpace(c.referenced.ID) == "" {
+		return cloneIssue(issue), nil
+	}
+	return cloneIssue(c.referenced), nil
 }
 
 func (c *implementProgressConnector) FetchIssueComments(context.Context, connector.Issue) ([]connector.IssueComment, error) {

--- a/internal/orchestrator/run_completion.go
+++ b/internal/orchestrator/run_completion.go
@@ -374,7 +374,7 @@ func (o *Orchestrator) handleRunResult(ctx context.Context, state *State, event 
 		spendProgress := spendProgressDecision{}
 		if !mergeWorkerIssue(running.Issue) {
 			evidenceWarning := ""
-			if !pushEvidenceRefreshed && (implementProgressLinkedPullRequest(running.Issue) || event.Result.PullRequestUpdated) {
+			if !pushEvidenceRefreshed && o.spendProgressEnabled() {
 				running.Issue, evidenceWarning = o.refreshSpendProgressIssue(ctx, running.Issue)
 			}
 			spendProgress = o.evaluateSpendProgress(ctx, running, event.CompletedAt, false, "")
@@ -595,8 +595,16 @@ func (o *Orchestrator) handleRunResult(ctx context.Context, state *State, event 
 		o.scheduleCITriggerLabel(ctx, running.Issue, gate.Effective(o.cfg.AutoPromote.Gate).RequiredStatusChecks, running.Attempt, true, forceReapply)
 	}
 	o.commentObservedLaneTransition(ctx, dispatchedIssue, running.Issue, event.CompletedAt)
+	evidenceWarning := ""
+	if o.spendProgressEnabled() && !implementProgressLinkedPullRequest(running.Issue) {
+		running.Issue, evidenceWarning = o.refreshSpendProgressIssue(ctx, running.Issue)
+	}
 	accepted, acceptedReason := implementAcceptedStateChange(running, progress)
 	spendProgress := o.evaluateSpendProgress(ctx, running, event.CompletedAt, accepted, acceptedReason)
+	if evidenceWarning != "" {
+		spendProgress.Warning = evidenceWarning
+		spendProgress.Block = false
+	}
 	if progress.Warning != "" && strings.HasPrefix(progress.Reason, "pull_request_hydrat") {
 		spendProgress.Warning = progress.Warning
 		spendProgress.Block = false

--- a/internal/orchestrator/spend_progress.go
+++ b/internal/orchestrator/spend_progress.go
@@ -3,6 +3,7 @@ package orchestrator
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log/slog"
 	"strconv"
@@ -133,6 +134,15 @@ func (o *Orchestrator) evaluateSpendProgress(
 		return decision
 	}
 	decision.Since = spendProgressBaseline(running.Issue, attempts)
+	creditedAt, err := o.spendProgressCredit(ctx, running.Issue)
+	if err != nil {
+		decision.Warning = err.Error()
+		o.warnSpendProgress(running.Issue, "progress credit lookup failed", err)
+		return decision
+	}
+	if creditedAt.After(decision.Since) {
+		decision.Since = creditedAt
+	}
 	if decision.Since.IsZero() {
 		decision.Since = time.Unix(0, 0).UTC()
 	}
@@ -160,6 +170,30 @@ func (o *Orchestrator) evaluateSpendProgress(
 		decision.Block = true
 	}
 	return decision
+}
+
+func (o *Orchestrator) spendProgressCredit(ctx context.Context, issue connector.Issue) (time.Time, error) {
+	credits, ok := o.progressSpend.(store.ProgressCreditStore)
+	if !ok {
+		return time.Time{}, nil
+	}
+	credit, err := credits.IssueProgressCredit(ctx, store.IssueIdentity{
+		ProjectID:  strings.TrimSpace(o.cfg.Project.ID),
+		IssueID:    strings.TrimSpace(issue.ID),
+		Identifier: strings.TrimSpace(issue.Identifier),
+		IssueURL:   strings.TrimSpace(issue.URL),
+	})
+	if errors.Is(err, store.ErrNotFound) {
+		return time.Time{}, nil
+	}
+	if err != nil {
+		return time.Time{}, fmt.Errorf("reading operator progress credit: %w", err)
+	}
+	return credit.CreditedAt.UTC(), nil
+}
+
+func (o *Orchestrator) spendProgressEnabled() bool {
+	return o != nil && (o.cfg.NoProgressTokenLimit > 0 || (!o.cfg.subscriptionBilling() && o.cfg.NoProgressSpendLimitUSD > 0))
 }
 
 func spendProgressTokenLimitReached(totalTokens int64, tokenLimit int64) bool {
@@ -253,14 +287,29 @@ func (o *Orchestrator) refreshSpendProgressIssue(ctx context.Context, issue conn
 		if o == nil || o.connector == nil || strings.TrimSpace(refreshed.ID) == "" {
 			return refreshed, "pull request evidence refresh unavailable"
 		}
-		issues, err := o.connector.FetchIssueStatesByIDs(ctx, []string{refreshed.ID})
-		if err != nil {
-			return refreshed, "pull request evidence refresh failed: " + err.Error()
-		}
-		for _, candidate := range issues {
-			if strings.TrimSpace(candidate.ID) == strings.TrimSpace(refreshed.ID) {
-				refreshed = mergeIssueTrackerFields(refreshed, candidate)
-				break
+		refresher, ok := o.connector.(connector.PullRequestReferenceRefresher)
+		if ok {
+			linked, err := refresher.RefreshPullRequestReference(ctx, refreshed)
+			if err != nil {
+				return refreshed, "pull request reference refresh failed: " + err.Error()
+			}
+			refreshed = mergeIssueTrackerFields(refreshed, linked)
+			if strings.TrimSpace(linked.PRRepository) != "" {
+				refreshed.PRRepository = strings.TrimSpace(linked.PRRepository)
+			}
+		} else {
+			issues, err := o.connector.FetchIssueStatesByIDs(ctx, []string{refreshed.ID})
+			if err != nil {
+				return refreshed, "pull request evidence refresh failed: " + err.Error()
+			}
+			for _, candidate := range issues {
+				if strings.TrimSpace(candidate.ID) == strings.TrimSpace(refreshed.ID) {
+					refreshed = mergeIssueTrackerFields(refreshed, candidate)
+					if strings.TrimSpace(candidate.PRRepository) != "" {
+						refreshed.PRRepository = strings.TrimSpace(candidate.PRRepository)
+					}
+					break
+				}
 			}
 		}
 	}
@@ -484,6 +533,7 @@ func spendProgressComment(issue connector.Issue, decision spendProgressDecision)
 	b.WriteString(decision.Case)
 	b.WriteString("\n- issue: ")
 	b.WriteString(issueLabel(issue))
+	b.WriteString("\n- pr_evidence_checked: issue PR linkage, hydrated PR metadata, and tracker closing references including Fixes #N")
 	b.WriteString("\n- billing_mode: ")
 	b.WriteString(decision.BillingMode)
 	b.WriteString("\n- blocked_by: ")

--- a/internal/orchestrator/spend_progress_test.go
+++ b/internal/orchestrator/spend_progress_test.go
@@ -53,6 +53,7 @@ func TestEvaluateSpendProgress(t *testing.T) {
 		wantSpendCalls   int
 		wantHistoryCalls int
 		wantSince        time.Time
+		creditAt         time.Time
 	}{
 		{name: "disabled avoids tracking", limit: 0, spend: store.IssueSpendSince{CostUSD: 100}, wantLimit: 0, wantSpendCalls: 0, wantHistoryCalls: 0},
 		{name: "normal three retry sessions stay below default", limit: 3, spend: store.IssueSpendSince{CostUSD: 2.7, Sessions: 3}, wantLimit: 3, wantSpendCalls: 1, wantHistoryCalls: 1, wantSince: createdAt},
@@ -64,6 +65,7 @@ func TestEvaluateSpendProgress(t *testing.T) {
 		{name: "subscription token breaker stays below threshold", billingMode: "subscription", tokenLimit: 25_000_000, spend: store.IssueSpendSince{TotalTokens: 24_999_999, Sessions: 3}, wantSpendCalls: 1, wantHistoryCalls: 1, wantSince: createdAt},
 		{name: "July telemetry replay", limit: 5, spend: store.IssueSpendSince{CostUSD: 6.75, Sessions: 5}, wantBlock: true, wantBlockedBy: "usd", wantLimit: 5, wantSpendCalls: 1, wantHistoryCalls: 1, wantSince: createdAt},
 		{name: "old sessions reset after accepted change", limit: 5, spend: store.IssueSpendSince{CostUSD: 1.25, Sessions: 1}, history: []store.WorkAttempt{acceptedAttempt}, wantLimit: 5, wantSpendCalls: 1, wantHistoryCalls: 1, wantSince: acceptedAt},
+		{name: "operator credit resets old sessions", limit: 5, spend: store.IssueSpendSince{CostUSD: 1.25, Sessions: 1}, creditAt: base.Add(-5 * time.Minute), wantLimit: 5, wantSpendCalls: 1, wantHistoryCalls: 1, wantSince: base.Add(-5 * time.Minute)},
 		{name: "current accepted change resets without spend lookup", limit: 5, spend: store.IssueSpendSince{CostUSD: 100}, accepted: true, acceptedReason: "signature_changed", wantAccepted: true, wantReason: "signature_changed", wantLimit: 5, wantSpendCalls: 0, wantHistoryCalls: 0, wantSince: base},
 		{
 			name:  "dirty to clean pull request resets spend",
@@ -154,6 +156,9 @@ func TestEvaluateSpendProgress(t *testing.T) {
 			t.Parallel()
 
 			spend := &spendProgressStore{result: tt.spend}
+			if !tt.creditAt.IsZero() {
+				spend.credit = store.IssueProgressCredit{CreditedAt: tt.creditAt}
+			}
 			attempts := &implementProgressAttemptStore{history: tt.history}
 			billingMode := tt.billingMode
 			if billingMode == "" {
@@ -271,7 +276,7 @@ func TestSpendProgressCommentNamesEvidenceCase(t *testing.T) {
 				Case:      spendProgressCaseNoPR,
 				BlockedBy: "usd",
 			},
-			wantContains: []string{"resource consumption continued without any PR evidence", "case: spend_without_pr_evidence", "Shrink the task"},
+			wantContains: []string{"resource consumption continued without any PR evidence", "case: spend_without_pr_evidence", "pr_evidence_checked: issue PR linkage, hydrated PR metadata, and tracker closing references including Fixes #N", "Shrink the task"},
 		},
 		{
 			name: "static PR evidence",
@@ -282,7 +287,7 @@ func TestSpendProgressCommentNamesEvidenceCase(t *testing.T) {
 				BlockedBy:     "usd",
 				PRFingerprint: &spendProgressPRFingerprint{Number: 214, HeadSHA: "same-head", MergeableState: "dirty", CIStatus: "failure"},
 			},
-			wantContains: []string{"resource consumption continued while a linked PR existed but could not merge", "case: spend_with_static_pr_evidence", "merge-train capacity", "pr_head_sha: same-head"},
+			wantContains: []string{"resource consumption continued while a linked PR existed but could not merge", "case: spend_with_static_pr_evidence", "pr_evidence_checked: issue PR linkage, hydrated PR metadata, and tracker closing references including Fixes #N", "merge-train capacity", "pr_head_sha: same-head"},
 		},
 	}
 	for _, tt := range tests {
@@ -311,8 +316,10 @@ func TestRefreshSpendProgressIssue(t *testing.T) {
 	linkedIssue := spendProgressIssueWithPR("head", "dirty", "failure")
 	linkedIssue.ID = baseIssue.ID
 	linkedIssue.Identifier = baseIssue.Identifier
+	linkedIssue.PRRepository = "digitaldrywood/detent"
 	degradedIssue := cloneIssue(linkedIssue)
 	degradedIssue.PullRequest.HydrationDegradedReason = connector.PullRequestHydrationReasonStaleCachedPullData
+	fallbackTracker := &implementProgressConnector{refreshed: linkedIssue, hydrated: linkedIssue}
 
 	tests := []struct {
 		name        string
@@ -323,13 +330,25 @@ func TestRefreshSpendProgressIssue(t *testing.T) {
 		wantHead    string
 	}{
 		{name: "missing connector", orch: &Orchestrator{}, issue: baseIssue, wantWarning: "refresh unavailable"},
-		{name: "refresh failure", orch: &Orchestrator{connector: &implementProgressConnector{refreshErr: errors.New("github unavailable")}}, issue: baseIssue, wantWarning: "refresh failed"},
+		{name: "reference refresh failure", orch: &Orchestrator{connector: &implementProgressConnector{referenceErr: errors.New("github unavailable")}}, issue: baseIssue, wantWarning: "reference refresh failed"},
+		{name: "fallback refresh failure", orch: &Orchestrator{connector: connectorOnly{Connector: &implementProgressConnector{refreshErr: errors.New("github unavailable")}}}, issue: baseIssue, wantWarning: "evidence refresh failed"},
 		{name: "refresh confirms no PR", orch: &Orchestrator{connector: &implementProgressConnector{refreshed: baseIssue}}, issue: baseIssue},
 		{
-			name: "refresh discovers and hydrates PR",
+			name: "fallback refresh discovers and hydrates PR",
+			orch: &Orchestrator{connector: spendProgressHydratingConnector{
+				Connector: fallbackTracker,
+				hydrator:  fallbackTracker,
+			}},
+			issue:    baseIssue,
+			wantPR:   true,
+			wantHead: "head",
+		},
+		{
+			name: "closing reference discovers and hydrates PR",
 			orch: &Orchestrator{connector: &implementProgressConnector{
-				refreshed: linkedIssue,
-				hydrated:  linkedIssue,
+				refreshed:  baseIssue,
+				referenced: linkedIssue,
+				hydrated:   linkedIssue,
 			}},
 			issue:    baseIssue,
 			wantPR:   true,
@@ -373,12 +392,24 @@ func TestRefreshSpendProgressIssue(t *testing.T) {
 			if tt.wantHead != "" && issue.PullRequest.HeadSHA != tt.wantHead {
 				t.Fatalf("head = %q, want %q", issue.PullRequest.HeadSHA, tt.wantHead)
 			}
+			if tt.wantPR && issue.PRRepository == "" {
+				t.Fatal("PRRepository is empty")
+			}
 		})
 	}
 }
 
 type connectorOnly struct {
 	connector.Connector
+}
+
+type spendProgressHydratingConnector struct {
+	connector.Connector
+	hydrator connector.PullRequestHydrator
+}
+
+func (c spendProgressHydratingConnector) HydratePullRequest(ctx context.Context, issue connector.Issue) (connector.Issue, error) {
+	return c.hydrator.HydratePullRequest(ctx, issue)
 }
 
 func TestImplementAcceptedStateChangeRequiresWorkProductProgress(t *testing.T) {
@@ -711,6 +742,76 @@ func TestHandleRunResultAcceptsPRAdvanceBeforeWorkerError(t *testing.T) {
 	}
 }
 
+func TestHandleRunResultDiscoversWorkerOpenedPRBeforeWorkerError(t *testing.T) {
+	t.Parallel()
+
+	base := time.Date(2026, 8, 28, 0, 0, 0, 0, time.UTC)
+	createdAt := base.Add(-8 * 24 * time.Hour)
+	runningIssue := implementProgressIssueWithoutPR()
+	runningIssue.CreatedAt = &createdAt
+	linkedIssue := spendProgressIssueWithPR("new-head", "dirty", "pending")
+	linkedIssue.ID = runningIssue.ID
+	linkedIssue.Identifier = runningIssue.Identifier
+	linkedIssue.PRRepository = "digitaldrywood/detent"
+	linkedIssue.Title = runningIssue.Title
+	linkedIssue.State = runningIssue.State
+	linkedIssue.URL = runningIssue.URL
+	linkedIssue.CreatedAt = runningIssue.CreatedAt
+	tracker := &implementProgressConnector{
+		refreshed:  runningIssue,
+		referenced: linkedIssue,
+		hydrated:   linkedIssue,
+	}
+	attempts := &implementProgressAttemptStore{}
+	cfg := normalizeConfig(Config{
+		Project:              scheduler.ProjectCandidate{ID: "detent"},
+		BillingMode:          "subscription",
+		NoProgressTokenLimit: 25_000_000,
+		ActiveStates:         []string{"In Progress"},
+		ObservedStates:       []string{"Blocked"},
+		TerminalStates:       []string{"Done"},
+	})
+	orch := &Orchestrator{
+		cfg:           cfg,
+		connector:     tracker,
+		workAttempts:  attempts,
+		progressSpend: &spendProgressStore{result: store.IssueSpendSince{TotalTokens: 46_465_472, Sessions: 4}},
+	}
+	state := newState(cfg)
+	running := Running{
+		Issue:               runningIssue,
+		Attempt:             4,
+		WorkAttemptID:       42,
+		Mode:                runpkg.RunModeImplement,
+		StartedAt:           base.Add(-10 * time.Minute),
+		DispatchSourceState: "Rework",
+		DispatchTargetState: "In Progress",
+	}
+	state.Running[runningIssue.ID] = running
+	state.Claimed[runningIssue.ID] = Claimed{Issue: runningIssue, ClaimedAt: running.StartedAt}
+
+	orch.handleRunResult(context.Background(), &state, runpkg.Completion{
+		IssueID:     runningIssue.ID,
+		CompletedAt: base,
+		Request:     runpkg.RunRequest{Mode: runpkg.RunModeImplement},
+		Err:         errors.New("session token ceiling exceeded"),
+	})
+
+	if _, blocked := state.Blocked[runningIssue.ID]; blocked {
+		t.Fatalf("Blocked[%q] present after linked PR discovery", runningIssue.ID)
+	}
+	if tracker.referenceRefreshes != 1 || tracker.hydrations != 1 {
+		t.Fatalf("reference refreshes = %d, hydrations = %d, want 1 each", tracker.referenceRefreshes, tracker.hydrations)
+	}
+	if len(attempts.completions) != 1 {
+		t.Fatalf("completions = %#v, want one", attempts.completions)
+	}
+	record, ok := spendProgressRecordFromAttempt(store.WorkAttempt{WorkerMetadataJSON: attempts.completions[0].WorkerMetadataJSON})
+	if !ok || !record.AcceptedStateChange || record.AcceptedReason != "pull_request_created" {
+		t.Fatalf("spend metadata = %#v, ok=%t", record, ok)
+	}
+}
+
 func TestSpendProgressUSDMessagesLabelNotionalValue(t *testing.T) {
 	t.Parallel()
 
@@ -767,6 +868,7 @@ func TestEvaluateSpendProgressFailsOpen(t *testing.T) {
 	}{
 		{name: "missing spend store", attempts: &implementProgressAttemptStore{}, missing: true, want: "progress usage store unavailable"},
 		{name: "history lookup failure", attempts: &implementProgressAttemptStore{historyErr: errors.New("history unavailable")}, spend: &spendProgressStore{}, want: "history unavailable"},
+		{name: "credit lookup failure", attempts: &implementProgressAttemptStore{}, spend: &spendProgressStore{creditErr: errors.New("credit unavailable")}, want: "credit unavailable"},
 		{name: "spend lookup failure", attempts: &implementProgressAttemptStore{}, spend: &spendProgressStore{err: errors.New("spend unavailable")}, want: "spend unavailable"},
 	}
 	for _, tt := range tests {
@@ -819,14 +921,36 @@ func TestSpendProgressAttemptAcceptedCompatibility(t *testing.T) {
 }
 
 type spendProgressStore struct {
-	result store.IssueSpendSince
-	err    error
-	query  store.IssueSpendSinceQuery
-	calls  int
+	result    store.IssueSpendSince
+	err       error
+	query     store.IssueSpendSinceQuery
+	calls     int
+	credit    store.IssueProgressCredit
+	creditErr error
 }
 
 func (s *spendProgressStore) IssueSpendSince(_ context.Context, query store.IssueSpendSinceQuery) (store.IssueSpendSince, error) {
 	s.calls++
 	s.query = query
 	return s.result, s.err
+}
+
+func (s *spendProgressStore) CreditIssueProgress(_ context.Context, identity store.IssueIdentity, at time.Time) (store.IssueProgressCredit, error) {
+	return store.IssueProgressCredit{
+		ProjectID:  identity.ProjectID,
+		IssueID:    identity.IssueID,
+		Identifier: identity.Identifier,
+		IssueURL:   identity.IssueURL,
+		CreditedAt: at,
+	}, s.creditErr
+}
+
+func (s *spendProgressStore) IssueProgressCredit(context.Context, store.IssueIdentity) (store.IssueProgressCredit, error) {
+	if s.creditErr != nil {
+		return store.IssueProgressCredit{}, s.creditErr
+	}
+	if s.credit.CreditedAt.IsZero() {
+		return store.IssueProgressCredit{}, store.ErrNotFound
+	}
+	return s.credit, nil
 }

--- a/internal/store/migrations/00047_create_issue_progress_credits.sql
+++ b/internal/store/migrations/00047_create_issue_progress_credits.sql
@@ -1,0 +1,16 @@
+-- +goose Up
+CREATE TABLE issue_progress_credits (
+  project_id TEXT NOT NULL,
+  issue_key TEXT NOT NULL,
+  issue_id TEXT,
+  identifier TEXT,
+  issue_url TEXT,
+  credited_at TEXT NOT NULL,
+  PRIMARY KEY (project_id, issue_key)
+);
+
+CREATE INDEX issue_progress_credits_identity_idx
+ON issue_progress_credits(project_id, issue_id, identifier, issue_url);
+
+-- +goose Down
+DROP TABLE IF EXISTS issue_progress_credits;

--- a/internal/store/progress_credit.go
+++ b/internal/store/progress_credit.go
@@ -1,0 +1,81 @@
+package store
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+)
+
+func (s *sqliteStore) CreditIssueProgress(ctx context.Context, identity IssueIdentity, at time.Time) (IssueProgressCredit, error) {
+	identity = normalizeParkIdentity(identity)
+	if identity.ProjectID == "" {
+		return IssueProgressCredit{}, ErrProjectRequired
+	}
+	key := parkIssueKey(identity.IssueID, identity.Identifier, identity.IssueURL)
+	if key == "" {
+		return IssueProgressCredit{}, errors.New("issue identity is required")
+	}
+	creditedAt, err := requiredTimestamp("credited_at", at)
+	if err != nil {
+		return IssueProgressCredit{}, err
+	}
+	_, err = s.db.ExecContext(ctx, `
+INSERT INTO issue_progress_credits (
+  project_id, issue_key, issue_id, identifier, issue_url, credited_at
+) VALUES (?, ?, NULLIF(?, ''), NULLIF(?, ''), NULLIF(?, ''), ?)
+ON CONFLICT(project_id, issue_key) DO UPDATE SET
+  issue_id = excluded.issue_id,
+  identifier = excluded.identifier,
+  issue_url = excluded.issue_url,
+  credited_at = excluded.credited_at
+`, identity.ProjectID, key, identity.IssueID, identity.Identifier, identity.IssueURL, creditedAt)
+	if err != nil {
+		return IssueProgressCredit{}, fmt.Errorf("crediting issue progress: %w", err)
+	}
+	return IssueProgressCredit{
+		ProjectID:  identity.ProjectID,
+		IssueID:    identity.IssueID,
+		Identifier: identity.Identifier,
+		IssueURL:   identity.IssueURL,
+		CreditedAt: at.UTC(),
+	}, nil
+}
+
+func (s *sqliteStore) IssueProgressCredit(ctx context.Context, identity IssueIdentity) (IssueProgressCredit, error) {
+	identity = normalizeParkIdentity(identity)
+	if identity.ProjectID == "" {
+		return IssueProgressCredit{}, ErrProjectRequired
+	}
+	if parkIssueKey(identity.IssueID, identity.Identifier, identity.IssueURL) == "" {
+		return IssueProgressCredit{}, errors.New("issue identity is required")
+	}
+	row := s.db.QueryRowContext(ctx, `
+SELECT project_id, COALESCE(issue_id, ''), COALESCE(identifier, ''), COALESCE(issue_url, ''), credited_at
+FROM issue_progress_credits
+WHERE project_id = ?
+  AND (
+    (? != '' AND COALESCE(issue_id, '') = ?)
+    OR (? != '' AND COALESCE(identifier, '') = ?)
+    OR (? != '' AND COALESCE(issue_url, '') = ?)
+  )
+ORDER BY credited_at DESC
+LIMIT 1
+`, identity.ProjectID, identity.IssueID, identity.IssueID, identity.Identifier, identity.Identifier, identity.IssueURL, identity.IssueURL)
+	var credit IssueProgressCredit
+	var creditedAt string
+	if err := row.Scan(&credit.ProjectID, &credit.IssueID, &credit.Identifier, &credit.IssueURL, &creditedAt); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return IssueProgressCredit{}, ErrNotFound
+		}
+		return IssueProgressCredit{}, fmt.Errorf("reading issue progress credit: %w", err)
+	}
+	parsed, err := parseTimestamp("credited_at", strings.TrimSpace(creditedAt))
+	if err != nil {
+		return IssueProgressCredit{}, err
+	}
+	credit.CreditedAt = parsed.UTC()
+	return credit, nil
+}

--- a/internal/store/progress_credit_test.go
+++ b/internal/store/progress_credit_test.go
@@ -1,0 +1,78 @@
+package store
+
+import (
+	"errors"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestIssueProgressCreditPersistsAndAdvances(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join(t.TempDir(), "detent.db")
+	db := openParkTestStore(t, path)
+	identity := IssueIdentity{
+		ProjectID:  "detent",
+		IssueID:    "issue-2015",
+		Identifier: "digitaldrywood/detent#2015",
+		IssueURL:   "https://github.com/digitaldrywood/detent/issues/2015",
+	}
+	first := time.Date(2026, 8, 28, 12, 0, 0, 0, time.UTC)
+	second := first.Add(time.Hour)
+
+	if _, err := db.CreditIssueProgress(t.Context(), identity, first); err != nil {
+		t.Fatalf("CreditIssueProgress() error = %v", err)
+	}
+	credit, err := db.IssueProgressCredit(t.Context(), IssueIdentity{ProjectID: identity.ProjectID, Identifier: identity.Identifier})
+	if err != nil {
+		t.Fatalf("IssueProgressCredit() error = %v", err)
+	}
+	if !credit.CreditedAt.Equal(first) || credit.IssueID != identity.IssueID || credit.IssueURL != identity.IssueURL {
+		t.Fatalf("credit = %#v, want first credit with complete identity", credit)
+	}
+	if _, err := db.CreditIssueProgress(t.Context(), identity, second); err != nil {
+		t.Fatalf("CreditIssueProgress() advance error = %v", err)
+	}
+	if err := db.Close(); err != nil {
+		t.Fatalf("Close() error = %v", err)
+	}
+
+	db = openParkTestStore(t, path)
+	credit, err = db.IssueProgressCredit(t.Context(), IssueIdentity{ProjectID: identity.ProjectID, IssueURL: identity.IssueURL})
+	if err != nil {
+		t.Fatalf("IssueProgressCredit() after restart error = %v", err)
+	}
+	if !credit.CreditedAt.Equal(second) {
+		t.Fatalf("CreditedAt = %s, want %s", credit.CreditedAt, second)
+	}
+}
+
+func TestIssueProgressCreditValidatesIdentity(t *testing.T) {
+	t.Parallel()
+
+	db := openParkTestStore(t, filepath.Join(t.TempDir(), "detent.db"))
+	now := time.Date(2026, 8, 28, 12, 0, 0, 0, time.UTC)
+	tests := []struct {
+		name     string
+		identity IssueIdentity
+		at       time.Time
+		want     error
+	}{
+		{name: "missing project", identity: IssueIdentity{IssueID: "issue-2015"}, at: now, want: ErrProjectRequired},
+		{name: "missing issue identity", identity: IssueIdentity{ProjectID: "detent"}, at: now},
+		{name: "missing timestamp", identity: IssueIdentity{ProjectID: "detent", IssueID: "issue-2015"}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			_, err := db.CreditIssueProgress(t.Context(), tt.identity, tt.at)
+			if err == nil {
+				t.Fatal("CreditIssueProgress() error = nil")
+			}
+			if tt.want != nil && !errors.Is(err, tt.want) {
+				t.Fatalf("CreditIssueProgress() error = %v, want %v", err, tt.want)
+			}
+		})
+	}
+}

--- a/internal/store/sqlc/models.go
+++ b/internal/store/sqlc/models.go
@@ -235,6 +235,15 @@ type IssueParkAcknowledgement struct {
 	AcknowledgedAt string         `json:"acknowledged_at"`
 }
 
+type IssueProgressCredit struct {
+	ProjectID  string         `json:"project_id"`
+	IssueKey   string         `json:"issue_key"`
+	IssueID    sql.NullString `json:"issue_id"`
+	Identifier sql.NullString `json:"identifier"`
+	IssueURL   sql.NullString `json:"issue_url"`
+	CreditedAt string         `json:"credited_at"`
+}
+
 type LaneMutationReceipt struct {
 	ID            int64          `json:"id"`
 	ProjectID     string         `json:"project_id"`

--- a/internal/store/sqlc/store.sql.go
+++ b/internal/store/sqlc/store.sql.go
@@ -2332,7 +2332,7 @@ SELECT
   CAST(COALESCE(MAX(finished_at), '') AS TEXT) AS last_session_at
 FROM usage_events
 WHERE project_id = ?1
-  AND finished_at > ?2
+  AND started_at > ?2
   AND (
     (?3 != '' AND COALESCE(issue_id, '') = ?3)
     OR (?4 != '' AND COALESCE(identifier, '') = ?4)

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -137,6 +137,11 @@ type ProgressSpendStore interface {
 	IssueSpendSince(context.Context, IssueSpendSinceQuery) (IssueSpendSince, error)
 }
 
+type ProgressCreditStore interface {
+	CreditIssueProgress(context.Context, IssueIdentity, time.Time) (IssueProgressCredit, error)
+	IssueProgressCredit(context.Context, IssueIdentity) (IssueProgressCredit, error)
+}
+
 type WorkflowMetricsStore interface {
 	RecordWorkflowPhaseEvent(context.Context, WorkflowPhaseEvent) (int64, error)
 	WorkflowMetricsReport(context.Context, WorkflowMetricsQuery) (WorkflowMetricsReport, error)
@@ -1203,6 +1208,14 @@ type IssueSpendSince struct {
 	Sessions       int64
 	FirstSessionAt time.Time
 	LastSessionAt  time.Time
+}
+
+type IssueProgressCredit struct {
+	ProjectID  string    `json:"project_id"`
+	IssueID    string    `json:"issue_id,omitempty"`
+	Identifier string    `json:"identifier,omitempty"`
+	IssueURL   string    `json:"issue_url,omitempty"`
+	CreditedAt time.Time `json:"credited_at"`
 }
 
 type ModelTokenSpend struct {

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -2037,6 +2037,7 @@ func TestIssueSpendSinceUsesAcceptedProgressBoundaryAndIssueIdentity(t *testing.
 	base := time.Date(2026, 7, 11, 12, 0, 0, 0, time.UTC)
 	events := []UsageEvent{
 		{ProjectID: "detent", IssueID: "issue-214", Identifier: "gopherguides/gopher-ai#214", CostUSD: 9, TotalTokens: 900, StartedAt: base.Add(-time.Minute), FinishedAt: base, Outcome: "completed"},
+		{ProjectID: "detent", IssueID: "issue-214", Identifier: "gopherguides/gopher-ai#214", CostUSD: 40, TotalTokens: 4_000, StartedAt: base.Add(-time.Minute), FinishedAt: base.Add(5 * time.Minute), Outcome: "completed"},
 		{ProjectID: "detent", IssueID: "issue-214", Identifier: "gopherguides/gopher-ai#214", CostUSD: 1.25, TotalTokens: 125, StartedAt: base.Add(time.Minute), FinishedAt: base.Add(2 * time.Minute), Outcome: "completed"},
 		{ProjectID: "detent", IssueID: "issue-214", Identifier: "gopherguides/gopher-ai#214", CostUSD: 2.5, TotalTokens: 250, StartedAt: base.Add(3 * time.Minute), FinishedAt: base.Add(4 * time.Minute), Outcome: "completed"},
 		{ProjectID: "detent", IssueID: "other", Identifier: "gopherguides/gopher-ai#999", CostUSD: 20, TotalTokens: 2_000, StartedAt: base.Add(time.Minute), FinishedAt: base.Add(2 * time.Minute), Outcome: "completed"},

--- a/internal/web/issue_explanation.go
+++ b/internal/web/issue_explanation.go
@@ -54,6 +54,29 @@ func (s *Server) apiIssueParkAcknowledgement(c echo.Context) error {
 	return c.JSON(http.StatusOK, explanation)
 }
 
+func (s *Server) apiIssueProgressCredit(c echo.Context) error {
+	explanation, ok, err := s.issueExplanation(c)
+	if !ok {
+		return err
+	}
+	credits, ok := s.store.(store.ProgressCreditStore)
+	if !ok {
+		return c.JSON(http.StatusServiceUnavailable, errorResponse("runtime_unavailable", "Issue progress credit store is unavailable"))
+	}
+	identity := store.IssueIdentity{
+		ProjectID:  explanation.Identity.ProjectID,
+		IssueID:    explanation.Identity.IssueID,
+		Identifier: explanation.Identity.Identifier,
+		IssueURL:   explanation.Identity.IssueURL,
+	}
+	credit, err := credits.CreditIssueProgress(c.Request().Context(), identity, s.now().UTC())
+	if err != nil {
+		s.logger.Error("issue progress credit failed", slog.Any("error", err))
+		return c.JSON(http.StatusServiceUnavailable, errorResponse("runtime_unavailable", "Issue progress credit store is unavailable"))
+	}
+	return c.JSON(http.StatusOK, credit)
+}
+
 func (s *Server) issueExplanation(c echo.Context) (explain.IssueExplanation, bool, error) {
 	projectID := strings.TrimSpace(c.Param("project_id"))
 	reference := strings.TrimSpace(c.QueryParam("reference"))

--- a/internal/web/issue_explanation_test.go
+++ b/internal/web/issue_explanation_test.go
@@ -211,6 +211,50 @@ func TestIssueExplanationAPIAcknowledgesCurrentParkSequence(t *testing.T) {
 	}
 }
 
+func TestIssueExplanationAPICreditsAcceptedProgress(t *testing.T) {
+	t.Parallel()
+
+	backend, err := store.Open(t.Context(), store.Config{Path: filepath.Join(t.TempDir(), "detent.db")})
+	if err != nil {
+		t.Fatalf("store.Open() error = %v", err)
+	}
+	t.Cleanup(func() { _ = backend.Close() })
+	creditedAt := time.Date(2026, 8, 28, 12, 34, 56, 0, time.UTC)
+	fake := &fakeIssueExplainer{result: explain.IssueExplanation{
+		Schema:   explain.SchemaVersion,
+		Identity: explain.Identity{ProjectID: "detent", IssueID: "issue-2015", Identifier: "digitaldrywood/detent#2015", IssueURL: "https://github.com/digitaldrywood/detent/issues/2015"},
+	}}
+	deps := testDeps(t)
+	deps.Store = backend
+	deps.IssueExplainer = fake
+	server, err := web.NewServer(web.Config{
+		GlobalConfig: globalconfig.Config{APIToken: "detent_test_token"},
+		Now:          func() time.Time { return creditedAt },
+	}, deps)
+	if err != nil {
+		t.Fatalf("NewServer() error = %v", err)
+	}
+	path := "/api/v1/projects/detent/issues/progress-credit?reference=%232015&schema=3"
+	recorder := performJSON(t, server.Handler(), http.MethodPost, path, "", map[string]string{"Authorization": "Bearer detent_test_token"})
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d; body = %s", recorder.Code, http.StatusOK, recorder.Body.String())
+	}
+	var got store.IssueProgressCredit
+	if err := json.Unmarshal(recorder.Body.Bytes(), &got); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if got.Identifier != "digitaldrywood/detent#2015" || !got.CreditedAt.Equal(creditedAt) {
+		t.Fatalf("response = %#v, want credited issue at %s", got, creditedAt)
+	}
+	persisted, err := backend.(store.ProgressCreditStore).IssueProgressCredit(t.Context(), store.IssueIdentity{ProjectID: "detent", IssueID: "issue-2015"})
+	if err != nil {
+		t.Fatalf("IssueProgressCredit() error = %v", err)
+	}
+	if !persisted.CreditedAt.Equal(creditedAt) {
+		t.Fatalf("persisted credit = %#v, want %s", persisted, creditedAt)
+	}
+}
+
 type fakeIssueExplainer struct {
 	result      explain.IssueExplanation
 	err         error

--- a/internal/web/openapi.yaml
+++ b/internal/web/openapi.yaml
@@ -262,6 +262,43 @@ paths:
         "404": {$ref: "#/components/responses/Problem"}
         "409": {$ref: "#/components/responses/Problem"}
         "503": {$ref: "#/components/responses/Unavailable"}
+  /api/v1/projects/{project_id}/issues/progress-credit:
+    parameters:
+      - $ref: "#/components/parameters/ProjectID"
+    post:
+      operationId: creditIssueProgress
+      summary: Credit accepted progress for an issue
+      description: Resets spend-since-progress counters by recording an operator-approved baseline.
+      tags: [projects, operations]
+      security:
+        - bearerAuth: []
+        - apiKeyAuth: []
+      x-detent-access: project-scoped
+      x-detent-scope: write
+      x-detent-project-parameter: project_id
+      x-detent-echo-path: /api/v1/projects/:project_id/issues/progress-credit
+      parameters:
+        - in: query
+          name: reference
+          required: true
+          description: Issue ID, canonical identifier, issue URL, bare number, or hash-prefixed number.
+          schema: {type: string, minLength: 1}
+        - in: query
+          name: schema
+          description: Requested issue-resolution schema version. Omit to use the current version.
+          schema: {type: integer, enum: [3]}
+      responses:
+        "200":
+          description: Recorded issue progress credit.
+          content:
+            application/json:
+              schema: {$ref: "#/components/schemas/IssueProgressCredit"}
+        "400": {$ref: "#/components/responses/Problem"}
+        "401": {$ref: "#/components/responses/Problem"}
+        "403": {$ref: "#/components/responses/Problem"}
+        "404": {$ref: "#/components/responses/Problem"}
+        "409": {$ref: "#/components/responses/Problem"}
+        "503": {$ref: "#/components/responses/Unavailable"}
   /api/v1/projects/{project_id}/staleness-warnings/acknowledge:
     parameters:
       - $ref: "#/components/parameters/ProjectID"
@@ -1138,6 +1175,15 @@ components:
         evidence:
           type: array
           items: {$ref: "#/components/schemas/IssueExplanationEvidence"}
+    IssueProgressCredit:
+      type: object
+      required: [project_id, credited_at]
+      properties:
+        project_id: {type: string}
+        issue_id: {type: string}
+        identifier: {type: string}
+        issue_url: {type: string, format: uri}
+        credited_at: {type: string, format: date-time}
     IssueParkSummary:
       type: object
       required: [attempt_count, park_count, acknowledged_park_sequence, causes, tokens]

--- a/internal/web/openapi_test.go
+++ b/internal/web/openapi_test.go
@@ -99,6 +99,28 @@ func TestServerOpenAPIIssueExplanationSchemaVersion(t *testing.T) {
 	assertOpenAPISchemaVersion(t, responseSchema.Value.Enum)
 }
 
+func TestServerOpenAPIIssueProgressCredit(t *testing.T) {
+	t.Parallel()
+
+	server := newOpenAPITestServer(t, web.ModeRunning, testDeps(t))
+	httpServer := httptest.NewServer(server.Handler())
+	t.Cleanup(httpServer.Close)
+	document := parseOpenAPI(t, requestOpenAPI(t, httpServer.URL))
+
+	path := document.Paths.Find("/api/v1/projects/{project_id}/issues/progress-credit")
+	if path == nil || path.Post == nil {
+		t.Fatal("OpenAPI issue progress credit operation is missing")
+	}
+	response := path.Post.Responses.Value("200")
+	if response == nil || response.Value == nil {
+		t.Fatal("OpenAPI issue progress credit response is missing")
+	}
+	schema := response.Value.Content.Get("application/json").Schema
+	if schema == nil || schema.Ref != "#/components/schemas/IssueProgressCredit" {
+		t.Fatalf("OpenAPI issue progress credit schema = %#v", schema)
+	}
+}
+
 func assertOpenAPISchemaVersion(t *testing.T, values []any) {
 	t.Helper()
 	want := strconv.Itoa(explain.SchemaVersion)

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -445,6 +445,7 @@ func (s *Server) registerRoutes() {
 	s.echo.GET("/api/v1/projects/:project_id/work-attempts/:attempt_id", s.apiWorkAttemptReceipt, apiDashboardReadAuth, apiReadScope)
 	s.echo.GET("/api/v1/projects/:project_id/issues/explanation", s.apiIssueExplanation, apiReadAuth, apiReadScope)
 	s.echo.POST("/api/v1/projects/:project_id/issues/explanation", s.apiIssueParkAcknowledgement, apiMutateAuth, apiProjectWriteScope)
+	s.echo.POST("/api/v1/projects/:project_id/issues/progress-credit", s.apiIssueProgressCredit, apiMutateAuth, apiProjectWriteScope)
 	s.echo.POST("/api/v1/projects/:project_id/staleness-warnings/acknowledge", s.apiStalenessWarningsAcknowledgement, apiDashboardMutateAuth, apiProjectWriteScope)
 	s.echo.POST("/api/v1/projects/:project_id/staleness-warnings/:warning_id/acknowledge", s.apiStalenessWarningAcknowledgement, apiDashboardMutateAuth, apiProjectWriteScope)
 	s.echo.POST("/api/v1/projects/:project_id/work-attempts/:attempt_id/recovery", s.apiWorkAttemptRecovery, apiDashboardMutateAuth, apiProjectWriteScope)


### PR DESCRIPTION
## Summary

- Discover GitHub closing PR references before spend-breaker evaluation and credit PR creation or accepted head advances as progress.
- Add durable per-issue operator progress credits through the authenticated API and detent issue --credit-progress.
- Report the PR evidence sources checked and cover the recorded 46.4M-token incident sequence.

Fixes #2015

## UI Surface Contract

- [x] N/A; this PR does not change a UI surface or layout.
- [x] This PR does not add persistent top-of-screen messaging.
- [x] N/A; this PR has no visual changes to primary operator screens.

## Test Plan

- [x] make check
- [x] spend_progress.go exact-file coverage: 92.8% (296/319 statements)
- [x] FuzzSafetyCriticalOrchestratorBoundaries for 30 seconds (665,626 executions)