### PR TITLE
fix(cli): stabilize runtime gh auth timeout

### DIFF
--- a/internal/cli/global_reload.go
+++ b/internal/cli/global_reload.go
@@ -204,11 +204,25 @@ func (r *globalConfigReloader) runtimeGitHubToken(ctx context.Context, cfg globa
 }
 
 func resolveGlobalRuntimeGitHubToken(ctx context.Context, cfg globalconfig.Config) (string, error) {
+	return resolveGlobalRuntimeGitHubTokenWithCommandContext(ctx, cfg, context.WithTimeout)
+}
+
+func resolveGlobalRuntimeGitHubTokenWithCommandContext(
+	ctx context.Context,
+	cfg globalconfig.Config,
+	commandContext runtimeCommandContextFactory,
+) (string, error) {
 	deps := runtimeDeps{}.withDefaults()
 	if strings.TrimSpace(cfg.GitHubToken) != "" {
 		deps.lookupEnv = withoutRuntimeGitHubTokenEnv(deps.lookupEnv)
 		if githubTokenSentinel(cfg.GitHubToken) {
-			deps.ghAuthToken = defaultGHAuthTokenWithoutRuntimeEnv
+			deps.ghAuthToken = func(ctx context.Context) (string, error) {
+				return runGHAuthTokenWithCommandContext(
+					ctx,
+					environmentWithoutKeys([]string{"GITHUB_TOKEN"}),
+					commandContext,
+				)
+			}
 		}
 	}
 	token, _, err := resolveRuntimeGitHubToken(ctx, &cfg, deps)

--- a/internal/cli/runtime.go
+++ b/internal/cli/runtime.go
@@ -100,6 +100,8 @@ type runtimeDeps struct {
 	loadWorkflow func(string) (workflowconfig.Workflow, error)
 }
 
+type runtimeCommandContextFactory func(context.Context, time.Duration) (context.Context, context.CancelFunc)
+
 func newRuntimeGitHubTokenState(value string) *runtimeGitHubTokenState {
 	state := &runtimeGitHubTokenState{}
 	state.set(value)
@@ -486,8 +488,16 @@ func runtimeGlobalGitHubToken(token RuntimeSecret) string {
 }
 
 func runtimeGitHubTokenRefresher(globalState *globalConfigState, tokenState *runtimeGitHubTokenState) func(context.Context) (string, error) {
+	return runtimeGitHubTokenRefresherWithCommandContext(globalState, tokenState, context.WithTimeout)
+}
+
+func runtimeGitHubTokenRefresherWithCommandContext(
+	globalState *globalConfigState,
+	tokenState *runtimeGitHubTokenState,
+	commandContext runtimeCommandContextFactory,
+) func(context.Context) (string, error) {
 	return func(ctx context.Context) (string, error) {
-		resolved, err := resolveGlobalRuntimeGitHubToken(ctx, globalState.get())
+		resolved, err := resolveGlobalRuntimeGitHubTokenWithCommandContext(ctx, globalState.get(), commandContext)
 		if err != nil {
 			return "", err
 		}
@@ -564,11 +574,15 @@ func defaultGHAuthToken(ctx context.Context) (string, error) {
 	return runGHAuthToken(ctx, nil)
 }
 
-func defaultGHAuthTokenWithoutRuntimeEnv(ctx context.Context) (string, error) {
-	return runGHAuthToken(ctx, environmentWithoutKeys([]string{"GITHUB_TOKEN"}))
+func runGHAuthToken(ctx context.Context, env []string) (string, error) {
+	return runGHAuthTokenWithCommandContext(ctx, env, context.WithTimeout)
 }
 
-func runGHAuthToken(ctx context.Context, env []string) (string, error) {
+func runGHAuthTokenWithCommandContext(
+	ctx context.Context,
+	env []string,
+	commandContext runtimeCommandContextFactory,
+) (string, error) {
 	if ctx == nil {
 		ctx = context.Background()
 	}
@@ -577,7 +591,7 @@ func runGHAuthToken(ctx context.Context, env []string) (string, error) {
 		return "", errors.New("gh was not found on PATH")
 	}
 
-	commandCtx, cancel := context.WithTimeout(ctx, runtimeCommandTimeout)
+	commandCtx, cancel := commandContext(ctx, runtimeCommandTimeout)
 	defer cancel()
 
 	cmd := exec.CommandContext(commandCtx, path, "auth", "token") // #nosec G204 -- gh path is PATH-resolved and arguments are fixed.

--- a/internal/cli/runtime_test.go
+++ b/internal/cli/runtime_test.go
@@ -9,7 +9,9 @@ import (
 	"runtime"
 	"strconv"
 	"strings"
+	"sync"
 	"testing"
+	"time"
 
 	workflowconfig "github.com/digitaldrywood/detent/internal/config"
 	globalconfig "github.com/digitaldrywood/detent/internal/config/global"
@@ -673,36 +675,90 @@ func TestRuntimeGitHubTokenRefresherUsesCurrentGlobalConfig(t *testing.T) {
 }
 
 func TestRuntimeGitHubTokenRefresherResolvesConfiguredGHSentinelWithoutActionsToken(t *testing.T) {
-	t.Setenv("GITHUB_TOKEN", "actions-token")
-	fakeGHDir := t.TempDir()
-	writeFakeGHAuthToken(t, fakeGHDir)
-	t.Setenv("PATH", fakeGHDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	tests := []struct {
+		name      string
+		expire    bool
+		wantToken string
+		wantErr   error
+	}{
+		{
+			name:      "command completes before deadline",
+			wantToken: "gh-token",
+		},
+		{
+			name:    "production deadline expires before command",
+			expire:  true,
+			wantErr: context.DeadlineExceeded,
+		},
+	}
 
-	workflowPath := filepath.Join(t.TempDir(), "workflow.md")
-	if err := os.WriteFile(workflowPath, []byte("---\ntracker:\n  kind: github\n---\nPrompt\n"), 0o644); err != nil {
-		t.Fatalf("WriteFile() error = %v", err)
-	}
-	globalState := newGlobalConfigState(globalconfig.Config{})
-	tokenState := newRuntimeGitHubTokenState("")
-	refresh := runtimeGitHubTokenRefresher(globalState, tokenState)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv("GITHUB_TOKEN", "actions-token")
+			fakeGHDir := t.TempDir()
+			writeFakeGHAuthToken(t, fakeGHDir)
+			t.Setenv("PATH", fakeGHDir+string(os.PathListSeparator)+os.Getenv("PATH"))
 
-	globalState.set(globalconfig.Config{
-		GitHubToken: "gh",
-		Projects: []globalconfig.Project{{
-			ID:       "detent",
-			Workflow: workflowPath,
-			Workdir:  ".",
-		}},
-	})
-	got, err := refresh(context.Background())
-	if err != nil {
-		t.Fatalf("refresh() error = %v", err)
-	}
-	if got != "gh-token" {
-		t.Fatalf("refresh() = %q, want gh-token", got)
-	}
-	if tokenState.get() != "gh-token" {
-		t.Fatalf("runtime token state = %q, want gh-token", tokenState.get())
+			workflowPath := filepath.Join(t.TempDir(), "workflow.md")
+			if err := os.WriteFile(workflowPath, []byte("---\ntracker:\n  kind: github\n---\nPrompt\n"), 0o644); err != nil {
+				t.Fatalf("WriteFile() error = %v", err)
+			}
+			globalState := newGlobalConfigState(globalconfig.Config{})
+			tokenState := newRuntimeGitHubTokenState("")
+			commandContexts := newControlledRuntimeCommandContexts()
+			t.Cleanup(commandContexts.AllowCommand)
+			refresh := runtimeGitHubTokenRefresherWithCommandContext(globalState, tokenState, commandContexts.New)
+
+			globalState.set(globalconfig.Config{
+				GitHubToken: "gh",
+				Projects: []globalconfig.Project{{
+					ID:       "detent",
+					Workflow: workflowPath,
+					Workdir:  ".",
+				}},
+			})
+			type refreshResult struct {
+				token string
+				err   error
+			}
+			result := make(chan refreshResult, 1)
+			go func() {
+				token, err := refresh(context.Background())
+				result <- refreshResult{token: token, err: err}
+			}()
+
+			select {
+			case timeout := <-commandContexts.ready:
+				if timeout != runtimeCommandTimeout {
+					t.Fatalf("command timeout = %s, want %s", timeout, runtimeCommandTimeout)
+				}
+			case <-time.After(runtimeCommandTestDeadlockGuard):
+				t.Fatal("timed out waiting for command context")
+			}
+			if _, ok := commandContexts.commandContext.Deadline(); !ok {
+				t.Fatal("command context has no deadline")
+			}
+			if tt.expire {
+				commandContexts.Expire()
+			}
+			commandContexts.AllowCommand()
+
+			var got refreshResult
+			select {
+			case got = <-result:
+			case <-time.After(runtimeCommandTestDeadlockGuard):
+				t.Fatal("timed out waiting for token refresh")
+			}
+			if !errors.Is(got.err, tt.wantErr) {
+				t.Fatalf("refresh() error = %v, want %v", got.err, tt.wantErr)
+			}
+			if got.token != tt.wantToken {
+				t.Fatalf("refresh() = %q, want %q", got.token, tt.wantToken)
+			}
+			if tokenState.get() != tt.wantToken {
+				t.Fatalf("runtime token state = %q, want %q", tokenState.get(), tt.wantToken)
+			}
+		})
 	}
 }
 
@@ -808,6 +864,85 @@ func writeFakeGHAuthToken(t *testing.T, dir string) {
 	if err := os.WriteFile(path, []byte(body), 0o755); err != nil {
 		t.Fatalf("WriteFile(%s) error = %v", path, err)
 	}
+}
+
+const runtimeCommandTestDeadlockGuard = 30 * time.Second
+
+type controlledRuntimeCommandContexts struct {
+	ready          chan time.Duration
+	release        chan struct{}
+	releaseOnce    sync.Once
+	commandContext *controlledRuntimeCommandContext
+}
+
+func newControlledRuntimeCommandContexts() *controlledRuntimeCommandContexts {
+	return &controlledRuntimeCommandContexts{
+		ready:   make(chan time.Duration, 1),
+		release: make(chan struct{}),
+	}
+}
+
+func (c *controlledRuntimeCommandContexts) New(
+	ctx context.Context,
+	timeout time.Duration,
+) (context.Context, context.CancelFunc) {
+	commandContext := &controlledRuntimeCommandContext{
+		deadline: time.Now().Add(timeout),
+		done:     make(chan struct{}),
+		value:    ctx.Value,
+	}
+	c.commandContext = commandContext
+	c.ready <- timeout
+	<-c.release
+	return commandContext, func() {
+		commandContext.cancel(context.Canceled)
+	}
+}
+
+func (c *controlledRuntimeCommandContexts) Expire() {
+	c.commandContext.cancel(context.DeadlineExceeded)
+}
+
+func (c *controlledRuntimeCommandContexts) AllowCommand() {
+	c.releaseOnce.Do(func() {
+		close(c.release)
+	})
+}
+
+type controlledRuntimeCommandContext struct {
+	deadline time.Time
+	done     chan struct{}
+	value    func(any) any
+	once     sync.Once
+	mu       sync.RWMutex
+	err      error
+}
+
+func (c *controlledRuntimeCommandContext) Deadline() (time.Time, bool) {
+	return c.deadline, true
+}
+
+func (c *controlledRuntimeCommandContext) Done() <-chan struct{} {
+	return c.done
+}
+
+func (c *controlledRuntimeCommandContext) Err() error {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return c.err
+}
+
+func (c *controlledRuntimeCommandContext) Value(key any) any {
+	return c.value(key)
+}
+
+func (c *controlledRuntimeCommandContext) cancel(err error) {
+	c.once.Do(func() {
+		c.mu.Lock()
+		c.err = err
+		c.mu.Unlock()
+		close(c.done)
+	})
 }
 
 func mapLookup(values map[string]string) func(string) string {


### PR DESCRIPTION
## Summary

- inject a private command-context factory while preserving the production five-second timeout
- control `gh auth token` completion and expiration explicitly in the sentinel refresh test
- retain production timeout coverage without a wall-clock race

Fixes #2017

## UI Surface Contract

- [x] N/A, or the linked issue explicitly authorizes any high-impact UI surface, layout, density, first-viewport, or responsive visibility tradeoff.
- [x] Persistent top-of-screen messaging is explicitly authorized by the issue, or this PR does not add it.
- [x] Visual changes to primary operator screens include screenshot or browser verification below.

## Test Plan

- [x] `env -u DETENT_API_TOKEN GOTOOLCHAIN=go1.26.6 go test -race ./internal/cli -run '^TestRuntimeGitHubTokenRefresherResolvesConfiguredGHSentinelWithoutActionsToken$' -count=20`\n- [x] `go test -race -timeout=30m ./internal/cli -count=10`\n- [x] `make check`