### PR TITLE
fix(ci): stabilize Windows test gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -200,6 +200,7 @@ jobs:
   portability-verify:
     name: Portability Verify (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
+    timeout-minutes: ${{ matrix.os == 'windows-latest' && 45 || 10 }}
     strategy:
       fail-fast: false
       matrix:
@@ -222,7 +223,21 @@ jobs:
         run: go vet ./...
 
       - name: Test
+        if: runner.os != 'Windows'
         run: go test ./...
+
+      - name: Test with bounded Windows concurrency
+        if: runner.os == 'Windows'
+        run: go run ./tools/testgate -output tmp/windows-test-evidence -parallel 4 -timeout 10m ./...
+
+      - name: Upload Windows test evidence
+        if: always() && runner.os == 'Windows'
+        uses: actions/upload-artifact@v7
+        with:
+          name: windows-test-evidence
+          path: tmp/windows-test-evidence
+          if-no-files-found: error
+          retention-days: 14
 
   windows-core:
     name: Windows Core
@@ -235,11 +250,11 @@ jobs:
           go-version: '1.26.6'
           cache: true
 
-      - name: Run non-agent core tests
-        run: go test ./cmd/detent ./internal/config ./internal/config/global ./internal/store ./internal/web ./internal/tui ./internal/orchestrator ./internal/cli
+      - name: Build command smoke
+        run: go build -o tmp/detent.exe ./cmd/detent
 
-      - name: Build command
-        run: go build ./cmd/detent
+      - name: Run command smoke
+        run: .\tmp\detent.exe --help
 
   installer-smoke:
     name: Installer Smoke (${{ matrix.os }})

--- a/ci_workflow_test.go
+++ b/ci_workflow_test.go
@@ -52,7 +52,7 @@ var requiredPRStatusChecks = []requiredStatusCheck{
 	},
 	{
 		name:     "Portability Verify (windows-latest)",
-		budget:   "8m",
+		budget:   "45m",
 		jobStart: "  portability-verify:",
 		jobEnd:   "  windows-core:",
 		markers:  []string{"name: Portability Verify (${{ matrix.os }})", "os: [macos-latest, windows-latest]", "go build ./...", "go vet ./...", "go test ./..."},

--- a/docs/execution-seams.md
+++ b/docs/execution-seams.md
@@ -132,16 +132,19 @@ Required PR merge checks, branch protection/rulesets, and
 - `Test Coverage` - budget: `4m`
 - `Browser Visual` - budget: `5m`
 - `Portability Verify (macos-latest)` - budget: `8m`
-- `Portability Verify (windows-latest)` - budget: `8m`
+- `Portability Verify (windows-latest)` - budget: `45m`
 - `Windows Core` - budget: `4m`
 - `Installer Smoke (ubuntu-latest)` - budget: `6m`
 - `Installer Smoke (windows-latest)` - budget: `6m`
 - `GoReleaser Snapshot` - budget: `8m`
 
 The required portability checks are limited to build, vet, and the non-race
-test suite so each platform stays within its `8m` merge-path budget. Repeated
-race loops, the full race suite on macOS and Windows, and the Windows SQLite
-artifact lifecycle stress loop run nightly and on manual dispatch in
+test suite. Windows runs packages sequentially with four-way test parallelism
+inside a `45m` job budget and retains per-package JSON evidence plus a failure
+classification summary. `Windows Core` owns only the command smoke, so no Go
+package has two required Windows test owners. Repeated race loops, the full
+race suite on macOS and Windows, and the Windows SQLite artifact lifecycle
+stress loop run nightly and on manual dispatch in
 `.github/workflows/portability-stress.yml`. That workflow has a `45m` ceiling;
 failures are surfaced as failed `Portability Stress` workflow runs with the
 failing command output in the job log.

--- a/internal/cli/runner_test.go
+++ b/internal/cli/runner_test.go
@@ -209,7 +209,7 @@ agents:
           - WebFetch
         include_partial_messages: true
         turn_timeout_ms: 60000
-        stall_timeout_ms: 10000
+        stall_timeout_ms: 0
         shell: sh
         extra_args:
           - --custom
@@ -238,7 +238,9 @@ Prompt {{ issue.identifier }}
 		t.Fatalf("buildRunner() error = %v", err)
 	}
 
-	result, err := run.Run(context.Background(), runnerpkg.RunRequest{
+	ctx, cancel := context.WithTimeout(t.Context(), time.Minute)
+	defer cancel()
+	result, err := run.Run(ctx, runnerpkg.RunRequest{
 		Issue: connector.Issue{
 			ID:         "issue-833",
 			Identifier: "digitaldrywood/detent#833",

--- a/internal/codex/appserver.go
+++ b/internal/codex/appserver.go
@@ -165,9 +165,12 @@ type AppServer struct {
 	readTimeout      time.Duration
 	turnTimeout      time.Duration
 	now              func() time.Time
+	timeoutContext   timeoutContextFactory
 }
 
 type AppServerOption func(*AppServer)
+
+type timeoutContextFactory func(context.Context, time.Duration, error) (context.Context, context.CancelFunc)
 
 type ClientInfo struct {
 	Name    string `json:"name"`
@@ -351,6 +354,12 @@ func NewAppServer(factory TransportFactory, opts ...AppServerOption) (*AppServer
 		readTimeout: defaultReadTimeout,
 		turnTimeout: defaultTurnTimeout,
 		now:         time.Now,
+		timeoutContext: func(ctx context.Context, timeout time.Duration, cause error) (context.Context, context.CancelFunc) {
+			if cause != nil {
+				return context.WithTimeoutCause(ctx, timeout, cause)
+			}
+			return context.WithTimeout(ctx, timeout)
+		},
 	}
 
 	for _, opt := range opts {
@@ -373,6 +382,9 @@ func NewAppServer(factory TransportFactory, opts ...AppServerOption) (*AppServer
 	}
 	if server.now == nil {
 		server.now = time.Now
+	}
+	if server.timeoutContext == nil {
+		return nil, errors.New("timeout context factory is nil")
 	}
 
 	return server, nil
@@ -1070,7 +1082,7 @@ func (s *AppServer) awaitResponse(
 	onUpdate UpdateHandler,
 ) (json.RawMessage, error) {
 	for {
-		msg, err := receiveWithTimeout(ctx, transport, s.readTimeout)
+		msg, err := receiveWithTimeout(ctx, transport, s.readTimeout, s.timeoutContext)
 		if err != nil {
 			return nil, fmt.Errorf("wait for %s response: %w", requestName(requestID), err)
 		}
@@ -1123,7 +1135,7 @@ func (s *AppServer) streamTurn(
 	onUpdate UpdateHandler,
 ) error {
 	for {
-		msg, err := receiveTurnMessage(ctx, transport, turnTimeout, stallTimeout)
+		msg, err := receiveTurnMessage(ctx, transport, turnTimeout, stallTimeout, s.timeoutContext)
 		if err != nil {
 			return fmt.Errorf("stream turn: %w", err)
 		}
@@ -1168,13 +1180,14 @@ func receiveTurnMessage(
 	transport Transport,
 	turnTimeout time.Duration,
 	stallTimeout time.Duration,
+	timeoutContext timeoutContextFactory,
 ) (Message, error) {
 	if stallTimeout <= 0 || turnTimeout > 0 && turnTimeout < stallTimeout {
-		return receiveWithTimeout(ctx, transport, turnTimeout)
+		return receiveWithTimeout(ctx, transport, turnTimeout, timeoutContext)
 	}
 
 	stallErr := fmt.Errorf("%w after %s", ErrStreamStalled, stallTimeout)
-	receiveCtx, cancel := context.WithTimeoutCause(contextOrBackground(ctx), stallTimeout, stallErr)
+	receiveCtx, cancel := timeoutContext(contextOrBackground(ctx), stallTimeout, stallErr)
 	defer cancel()
 
 	msg, err := transport.Receive(receiveCtx)
@@ -2433,13 +2446,13 @@ func (p *creditsSnapshotPayload) credits() *CreditsSnapshot {
 	}
 }
 
-func receiveWithTimeout(ctx context.Context, transport Transport, timeout time.Duration) (Message, error) {
+func receiveWithTimeout(ctx context.Context, transport Transport, timeout time.Duration, timeoutContext timeoutContextFactory) (Message, error) {
 	ctx = contextOrBackground(ctx)
 	if timeout <= 0 {
 		return transport.Receive(ctx)
 	}
 
-	receiveCtx, cancel := context.WithTimeout(ctx, timeout)
+	receiveCtx, cancel := timeoutContext(ctx, timeout, nil)
 	defer cancel()
 	return transport.Receive(receiveCtx)
 }

--- a/internal/codex/appserver_test.go
+++ b/internal/codex/appserver_test.go
@@ -10,6 +10,7 @@ import (
 	"reflect"
 	"strconv"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -52,7 +53,17 @@ func TestAppServerStartupFailuresIdentifyStageAndDeadline(t *testing.T) {
 			if err != nil {
 				t.Fatalf("NewAppServer() error = %v", err)
 			}
-			err = tt.run(server, transport)
+			factory := newControlledTimeoutFactory()
+			server.timeoutContext = factory.context
+			now := time.Date(2026, 8, 28, 12, 0, 0, 0, time.UTC)
+			server.now = func() time.Time {
+				current := now
+				now = now.Add(deadline)
+				return current
+			}
+			err = runWithTimeoutExpiration(t, factory, deadline, nil, func() error {
+				return tt.run(server, transport)
+			})
 			if !errors.Is(err, context.DeadlineExceeded) {
 				t.Fatalf("startup error = %v, want deadline exceeded", err)
 			}
@@ -134,8 +145,19 @@ func TestAppServerStartupFailureRetainsProcessReadinessAndExit(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewAppServer() error = %v", err)
 	}
+	factory := newControlledTimeoutFactory()
+	server.timeoutContext = factory.context
+	now := startedAt
+	server.now = func() time.Time {
+		current := now
+		now = now.Add(5 * time.Millisecond)
+		return current
+	}
 
-	_, err = server.RunTurn(t.Context(), RunTurnRequest{}, nil)
+	err = runWithTimeoutExpiration(t, factory, 5*time.Millisecond, nil, func() error {
+		_, runErr := server.RunTurn(t.Context(), RunTurnRequest{}, nil)
+		return runErr
+	})
 	if !errors.Is(err, context.DeadlineExceeded) {
 		t.Fatalf("RunTurn() error = %v, want deadline exceeded", err)
 	}
@@ -1063,12 +1085,16 @@ func TestAppServerRunTurnRequestTurnTimeoutOverridesDefault(t *testing.T) {
 		t.Fatalf("NewAppServer() error = %v", err)
 	}
 
-	startedAt := time.Now()
-	_, err = server.RunTurn(context.Background(), RunTurnRequest{
-		Workspace:   "/tmp/detent-workspace",
-		Prompt:      "timeout",
-		TurnTimeout: 10 * time.Millisecond,
-	}, nil)
+	factory := newControlledTimeoutFactory()
+	server.timeoutContext = factory.context
+	err = runWithTimeoutExpiration(t, factory, 10*time.Millisecond, nil, func() error {
+		_, runErr := server.RunTurn(context.Background(), RunTurnRequest{
+			Workspace:   "/tmp/detent-workspace",
+			Prompt:      "timeout",
+			TurnTimeout: 10 * time.Millisecond,
+		}, nil)
+		return runErr
+	})
 	if err == nil {
 		t.Fatal("RunTurn() error = nil, want request timeout")
 	}
@@ -1077,9 +1103,6 @@ func TestAppServerRunTurnRequestTurnTimeoutOverridesDefault(t *testing.T) {
 	}
 	if errors.Is(err, ErrStreamStalled) {
 		t.Fatalf("RunTurn() error = %v, want disabled stall timeout", err)
-	}
-	if elapsed := time.Since(startedAt); elapsed > time.Second {
-		t.Fatalf("RunTurn() elapsed = %v, want request timeout instead of default", elapsed)
 	}
 }
 
@@ -1100,20 +1123,21 @@ func TestAppServerRunTurnEnforcesStallTimeout(t *testing.T) {
 		t.Fatalf("NewAppServer() error = %v", err)
 	}
 
-	startedAt := time.Now()
-	_, err = server.RunTurn(context.Background(), RunTurnRequest{
-		Workspace:    "/tmp/detent-workspace",
-		Prompt:       "stall",
-		StallTimeout: 10 * time.Millisecond,
-	}, nil)
+	factory := newControlledTimeoutFactory()
+	server.timeoutContext = factory.context
+	err = runWithTimeoutExpiration(t, factory, 10*time.Millisecond, ErrStreamStalled, func() error {
+		_, runErr := server.RunTurn(context.Background(), RunTurnRequest{
+			Workspace:    "/tmp/detent-workspace",
+			Prompt:       "stall",
+			StallTimeout: 10 * time.Millisecond,
+		}, nil)
+		return runErr
+	})
 	if !errors.Is(err, ErrStreamStalled) {
 		t.Fatalf("RunTurn() error = %v, want ErrStreamStalled", err)
 	}
 	if !strings.Contains(err.Error(), "after 10ms") {
 		t.Fatalf("RunTurn() error = %v, want configured stall duration", err)
-	}
-	if elapsed := time.Since(startedAt); elapsed > time.Second {
-		t.Fatalf("RunTurn() elapsed = %v, want stall timeout instead of turn timeout", elapsed)
 	}
 }
 
@@ -1225,7 +1249,23 @@ func TestReceiveTurnMessageTimeoutSelection(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			transport := newBlockingAppServerTransport(nil)
-			_, err := receiveTurnMessage(tt.context(), transport, tt.turnTimeout, tt.stallTimeout)
+			factory := newControlledTimeoutFactory()
+			run := func() error {
+				_, err := receiveTurnMessage(tt.context(), transport, tt.turnTimeout, tt.stallTimeout, factory.context)
+				return err
+			}
+			var err error
+			if errors.Is(tt.want, context.Canceled) {
+				err = run()
+			} else {
+				timeout := tt.turnTimeout
+				var cause error
+				if tt.stallTimeout > 0 && (tt.turnTimeout <= 0 || tt.stallTimeout <= tt.turnTimeout) {
+					timeout = tt.stallTimeout
+					cause = ErrStreamStalled
+				}
+				err = runWithTimeoutExpiration(t, factory, timeout, cause, run)
+			}
 			if !errors.Is(err, tt.want) {
 				t.Fatalf("receiveTurnMessage() error = %v, want %v", err, tt.want)
 			}
@@ -2091,6 +2131,22 @@ type blockingAppServerTransport struct {
 	*fakeAppServerTransport
 }
 
+type controlledTimeoutFactory struct {
+	active chan *controlledTimeoutContext
+}
+
+type controlledTimeoutContext struct {
+	duration        time.Duration
+	configuredCause error
+	deadline        time.Time
+	done            chan struct{}
+	factory         *controlledTimeoutFactory
+	activeOnce      sync.Once
+	once            sync.Once
+	mu              sync.Mutex
+	err             error
+}
+
 type startupEvidenceTransport struct {
 	*blockingAppServerTransport
 	evidence backendcapacity.StartupProcessEvidence
@@ -2117,11 +2173,122 @@ func newBlockingAppServerTransport(received []Message) *blockingAppServerTranspo
 	return &blockingAppServerTransport{fakeAppServerTransport: newFakeAppServerTransport(received)}
 }
 
+func newControlledTimeoutFactory() *controlledTimeoutFactory {
+	return &controlledTimeoutFactory{active: make(chan *controlledTimeoutContext, 64)}
+}
+
+func (f *controlledTimeoutFactory) context(parent context.Context, duration time.Duration, cause error) (context.Context, context.CancelFunc) {
+	controlled := &controlledTimeoutContext{
+		duration:        duration,
+		configuredCause: cause,
+		deadline:        time.Now().Add(duration),
+		done:            make(chan struct{}),
+		factory:         f,
+	}
+	go func() {
+		select {
+		case <-parent.Done():
+			controlled.expire(parent.Err())
+		case <-controlled.Done():
+		}
+	}()
+	return controlled, func() { controlled.expire(context.Canceled) }
+}
+
+func (c *controlledTimeoutContext) Deadline() (time.Time, bool) {
+	return c.deadline, true
+}
+
+func (c *controlledTimeoutContext) Done() <-chan struct{} {
+	return c.done
+}
+
+func (c *controlledTimeoutContext) Err() error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.err
+}
+
+func (c *controlledTimeoutContext) Value(any) any {
+	return nil
+}
+
+func (c *controlledTimeoutContext) expire(err error) {
+	c.once.Do(func() {
+		c.mu.Lock()
+		c.err = err
+		c.mu.Unlock()
+		close(c.done)
+	})
+}
+
+func (c *controlledTimeoutContext) activate() {
+	c.activeOnce.Do(func() { c.factory.active <- c })
+}
+
+func runWithTimeoutExpiration(
+	t *testing.T,
+	factory *controlledTimeoutFactory,
+	duration time.Duration,
+	cause error,
+	run func() error,
+) error {
+	t.Helper()
+
+	done := make(chan error, 1)
+	go func() { done <- run() }()
+	controlled := waitForControlledTimeout(t, factory, duration, cause)
+	if controlled.configuredCause != nil {
+		controlled.expire(controlled.configuredCause)
+	} else {
+		controlled.expire(context.DeadlineExceeded)
+	}
+
+	timer := time.NewTimer(30 * time.Second)
+	defer timer.Stop()
+	select {
+	case err := <-done:
+		return err
+	case <-timer.C:
+		t.Fatal("timed out waiting for operation after controlled timeout")
+		return nil
+	}
+}
+
+func waitForControlledTimeout(
+	t *testing.T,
+	factory *controlledTimeoutFactory,
+	duration time.Duration,
+	cause error,
+) *controlledTimeoutContext {
+	t.Helper()
+
+	timer := time.NewTimer(30 * time.Second)
+	defer timer.Stop()
+	for {
+		select {
+		case controlled := <-factory.active:
+			if controlled.duration != duration {
+				continue
+			}
+			if cause == nil && controlled.configuredCause == nil || cause != nil && errors.Is(controlled.configuredCause, cause) {
+				return controlled
+			}
+		case <-timer.C:
+			t.Fatalf("timed out waiting for controlled timeout %s", duration)
+			return nil
+		}
+	}
+}
+
 func (t *blockingAppServerTransport) Receive(ctx context.Context) (Message, error) {
 	if len(t.received) > 0 {
 		msg := t.received[0]
 		t.received = t.received[1:]
 		return msg, nil
+	}
+	if controlled, ok := ctx.(*controlledTimeoutContext); ok {
+		controlled.activate()
 	}
 	<-ctx.Done()
 	return Message{}, ctx.Err()

--- a/internal/codex/backend_test.go
+++ b/internal/codex/backend_test.go
@@ -225,10 +225,15 @@ func TestAgentBackendEnforcesConfiguredStallTimeout(t *testing.T) {
 		t.Fatalf("NewAgentBackend() error = %v", err)
 	}
 
-	_, err = backend.RunTurn(context.Background(), runner.AgentTurnRequest{
-		Workspace: "/tmp/detent-workspace",
-		Prompt:    "stall",
-	}, nil)
+	factory := newControlledTimeoutFactory()
+	server.timeoutContext = factory.context
+	err = runWithTimeoutExpiration(t, factory, 10*time.Millisecond, ErrStreamStalled, func() error {
+		_, runErr := backend.RunTurn(context.Background(), runner.AgentTurnRequest{
+			Workspace: "/tmp/detent-workspace",
+			Prompt:    "stall",
+		}, nil)
+		return runErr
+	})
 	if !errors.Is(err, ErrStreamStalled) {
 		t.Fatalf("RunTurn() error = %v, want configured ErrStreamStalled", err)
 	}

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -6,8 +6,10 @@ import (
 	"errors"
 	"fmt"
 	"math"
+	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -3198,9 +3200,17 @@ func TestBusyTimeoutMillis(t *testing.T) {
 func openTestStore(t *testing.T, ctx context.Context) Store {
 	t.Helper()
 
+	database, err := migratedTestDatabase()
+	if err != nil {
+		t.Fatalf("build migrated store fixture: %v", err)
+	}
+	path := filepath.Join(t.TempDir(), "detent.db")
+	if err := os.WriteFile(path, database, 0o600); err != nil {
+		t.Fatalf("write migrated store fixture: %v", err)
+	}
 	backend, err := Open(ctx, Config{
 		Backend: BackendSQLite,
-		Path:    filepath.Join(t.TempDir(), "detent.db"),
+		Path:    path,
 	})
 	if err != nil {
 		t.Fatalf("Open() error = %v", err)
@@ -3212,6 +3222,26 @@ func openTestStore(t *testing.T, ctx context.Context) Store {
 	})
 	return backend
 }
+
+var migratedTestDatabase = sync.OnceValues(func() (_ []byte, returnErr error) {
+	dir, err := os.MkdirTemp("", "detent-store-test-")
+	if err != nil {
+		return nil, err
+	}
+	defer func() {
+		returnErr = errors.Join(returnErr, os.RemoveAll(dir))
+	}()
+
+	path := filepath.Join(dir, "detent.db")
+	backend, err := Open(context.Background(), Config{Backend: BackendSQLite, Path: path})
+	if err != nil {
+		return nil, err
+	}
+	if err := backend.Close(); err != nil {
+		return nil, err
+	}
+	return os.ReadFile(path)
+})
 
 type cycleSessionSeed struct {
 	IssueID     string

--- a/internal/store/storetest/fixture.go
+++ b/internal/store/storetest/fixture.go
@@ -1,0 +1,70 @@
+package storetest
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+
+	"github.com/digitaldrywood/detent/internal/store"
+)
+
+var migratedDatabase = sync.OnceValues(buildMigratedDatabase)
+
+func Open(t testing.TB) store.Store {
+	t.Helper()
+
+	backend, err := store.Open(t.Context(), store.Config{
+		Backend: store.BackendSQLite,
+		Path:    NewDatabasePath(t),
+	})
+	if err != nil {
+		t.Fatalf("store.Open() error = %v", err)
+	}
+	t.Cleanup(func() {
+		if err := backend.Close(); err != nil {
+			t.Errorf("store.Close() error = %v", err)
+		}
+	})
+	return backend
+}
+
+func NewDatabasePath(t testing.TB) string {
+	t.Helper()
+
+	database, err := migratedDatabase()
+	if err != nil {
+		t.Fatalf("build migrated store fixture: %v", err)
+	}
+	path := filepath.Join(t.TempDir(), "detent.db")
+	if err := os.WriteFile(path, database, 0o600); err != nil {
+		t.Fatalf("write migrated store fixture: %v", err)
+	}
+	return path
+}
+
+func buildMigratedDatabase() (_ []byte, returnErr error) {
+	dir, err := os.MkdirTemp("", "detent-store-fixture-")
+	if err != nil {
+		return nil, err
+	}
+	defer func() {
+		returnErr = errors.Join(returnErr, os.RemoveAll(dir))
+	}()
+
+	path := filepath.Join(dir, "detent.db")
+	backend, err := store.Open(context.Background(), store.Config{
+		Backend: store.BackendSQLite,
+		Path:    path,
+	})
+	if err != nil {
+		return nil, err
+	}
+	if err := backend.Close(); err != nil {
+		return nil, err
+	}
+	database, readErr := os.ReadFile(path)
+	return database, readErr
+}

--- a/internal/store/storetest/fixture_test.go
+++ b/internal/store/storetest/fixture_test.go
@@ -1,0 +1,46 @@
+package storetest
+
+import (
+	"context"
+	"database/sql"
+	"testing"
+
+	"github.com/digitaldrywood/detent/internal/store"
+)
+
+func TestOpenUsesIsolatedMigratedDatabase(t *testing.T) {
+	t.Parallel()
+
+	first := Open(t)
+	evidence, err := first.RuntimeEvidence(context.Background(), store.RuntimeEvidenceQuery{})
+	if err != nil {
+		t.Fatalf("RuntimeEvidence() error = %v", err)
+	}
+	if evidence.MigrationVersion <= 0 {
+		t.Fatalf("MigrationVersion = %d, want positive", evidence.MigrationVersion)
+	}
+
+	firstPath := NewDatabasePath(t)
+	secondPath := NewDatabasePath(t)
+	firstDB, err := sql.Open("sqlite", firstPath)
+	if err != nil {
+		t.Fatalf("sql.Open(first) error = %v", err)
+	}
+	t.Cleanup(func() { _ = firstDB.Close() })
+	if _, err := firstDB.ExecContext(t.Context(), "CREATE TABLE fixture_probe (id INTEGER PRIMARY KEY)"); err != nil {
+		t.Fatalf("create fixture probe: %v", err)
+	}
+
+	secondDB, err := sql.Open("sqlite", secondPath)
+	if err != nil {
+		t.Fatalf("sql.Open(second) error = %v", err)
+	}
+	t.Cleanup(func() { _ = secondDB.Close() })
+	var count int
+	if err := secondDB.QueryRowContext(t.Context(), "SELECT COUNT(*) FROM sqlite_master WHERE type = 'table' AND name = 'fixture_probe'").Scan(&count); err != nil {
+		t.Fatalf("query fixture probe: %v", err)
+	}
+	if count != 0 {
+		t.Fatalf("fixture probe count = %d, want 0", count)
+	}
+}

--- a/internal/web/board_card_test.go
+++ b/internal/web/board_card_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -217,34 +218,21 @@ func TestAPIBoardSessionAttachBackfillsAndFollows(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewServer() error = %v", err)
 	}
-	httpServer := httptest.NewServer(server.Handler())
-	t.Cleanup(httpServer.Close)
+	withBoardSSEStream(t, server.Handler(), "/api/v1/board/session/events?project=detent&issue=issue-1156", func(reader *bufio.Reader, closeStream func()) {
+		if data := readBoardSSEData(t, reader); !strings.Contains(data, "backfill output") {
+			t.Fatalf("backfill SSE = %q", data)
+		}
+		if got := broker.SubscriberCount(activity.Key{ProjectID: "detent", IssueID: issue.ID}); got != 1 {
+			t.Fatalf("SubscriberCount() = %d, want 1", got)
+		}
 
-	ctx, cancel := context.WithCancel(context.Background())
-	request, err := http.NewRequestWithContext(ctx, http.MethodGet, httpServer.URL+"/api/v1/board/session/events?project=detent&issue=issue-1156", nil)
-	if err != nil {
-		t.Fatalf("NewRequestWithContext() error = %v", err)
-	}
-	response, err := http.DefaultClient.Do(request)
-	if err != nil {
-		t.Fatalf("Do() error = %v", err)
-	}
-	t.Cleanup(func() { _ = response.Body.Close() })
-	reader := bufio.NewReader(response.Body)
-	if data := readBoardSSEData(t, reader); !strings.Contains(data, "backfill output") {
-		t.Fatalf("backfill SSE = %q", data)
-	}
-	if got := broker.SubscriberCount(activity.Key{ProjectID: "detent", IssueID: issue.ID}); got != 1 {
-		t.Fatalf("SubscriberCount() = %d, want 1", got)
-	}
-
-	broker.Publish(activity.Key{ProjectID: "detent", IssueID: issue.ID}, activity.Event{DetentSessionID: 7, Kind: "assistant", Title: "Agent", Content: "live output"})
-	if data := readBoardSSEData(t, reader); !strings.Contains(data, "live output") {
-		t.Fatalf("live SSE = %q", data)
-	}
-	cancel()
-	_ = response.Body.Close()
-	waitForBoardSubscriberCount(t, broker, activity.Key{ProjectID: "detent", IssueID: issue.ID}, 0)
+		broker.Publish(activity.Key{ProjectID: "detent", IssueID: issue.ID}, activity.Event{DetentSessionID: 7, Kind: "assistant", Title: "Agent", Content: "live output"})
+		if data := readBoardSSEData(t, reader); !strings.Contains(data, "live output") {
+			t.Fatalf("live SSE = %q", data)
+		}
+		closeStream()
+		waitForBoardSubscriberCount(t, broker, activity.Key{ProjectID: "detent", IssueID: issue.ID}, 0)
+	})
 }
 
 func TestAPIBoardActivityStreamShowsDispatchSkipWithinTick(t *testing.T) {
@@ -261,36 +249,23 @@ func TestAPIBoardActivityStreamShowsDispatchSkipWithinTick(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewServer() error = %v", err)
 	}
-	httpServer := httptest.NewServer(server.Handler())
-	t.Cleanup(httpServer.Close)
+	withBoardSSEStream(t, server.Handler(), "/api/v1/board/activity/events?project=detent&issue=issue-1156", func(reader *bufio.Reader, _ func()) {
+		_ = readBoardSSEData(t, reader)
 
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
-	t.Cleanup(cancel)
-	request, err := http.NewRequestWithContext(ctx, http.MethodGet, httpServer.URL+"/api/v1/board/activity/events?project=detent&issue=issue-1156", nil)
-	if err != nil {
-		t.Fatalf("NewRequestWithContext() error = %v", err)
-	}
-	response, err := http.DefaultClient.Do(request)
-	if err != nil {
-		t.Fatalf("Do() error = %v", err)
-	}
-	t.Cleanup(func() { _ = response.Body.Close() })
-	reader := bufio.NewReader(response.Body)
-	_ = readBoardSSEData(t, reader)
-
-	if _, err := backend.RecordSchedulerDecision(ctx, store.SchedulerDecision{
-		ProjectID:  "detent",
-		IssueID:    issue.ID,
-		Identifier: issue.Identifier,
-		Result:     store.SchedulerDecisionResultSkipped,
-		Reason:     "artifact_gate_wait_status",
-		DecisionAt: time.Now().UTC(),
-	}); err != nil {
-		t.Fatalf("RecordSchedulerDecision() error = %v", err)
-	}
-	if data := readBoardSSEData(t, reader); !strings.Contains(data, "artifact_gate_wait_status") || !strings.Contains(data, "Dispatch skipped") {
-		t.Fatalf("activity SSE = %q", data)
-	}
+		if _, err := backend.RecordSchedulerDecision(t.Context(), store.SchedulerDecision{
+			ProjectID:  "detent",
+			IssueID:    issue.ID,
+			Identifier: issue.Identifier,
+			Result:     store.SchedulerDecisionResultSkipped,
+			Reason:     "artifact_gate_wait_status",
+			DecisionAt: time.Now().UTC(),
+		}); err != nil {
+			t.Fatalf("RecordSchedulerDecision() error = %v", err)
+		}
+		if data := readBoardSSEData(t, reader); !strings.Contains(data, "artifact_gate_wait_status") || !strings.Contains(data, "Dispatch skipped") {
+			t.Fatalf("activity SSE = %q", data)
+		}
+	})
 }
 
 func TestAPIBoardSessionPagesFailedRolloutHistory(t *testing.T) {
@@ -376,6 +351,42 @@ func liveSessionElementID(t *testing.T, body string) string {
 		t.Fatalf("live session element id unterminated:\n%s", body)
 	}
 	return body[start : start+end]
+}
+
+func withBoardSSEStream(t *testing.T, handler http.Handler, path string, run func(*bufio.Reader, func())) {
+	t.Helper()
+
+	httpServer := httptest.NewServer(handler)
+	ctx, cancel := context.WithTimeout(t.Context(), sseTestOperationTimeout)
+	var response *http.Response
+	var closeOnce sync.Once
+	closeStream := func() {
+		closeOnce.Do(func() {
+			cancel()
+			if response != nil {
+				_ = response.Body.Close()
+			}
+		})
+	}
+	request, err := http.NewRequestWithContext(ctx, http.MethodGet, httpServer.URL+path, nil)
+	if err != nil {
+		cancel()
+		httpServer.Close()
+		t.Fatalf("NewRequestWithContext() error = %v", err)
+	}
+	response, err = http.DefaultClient.Do(request)
+	if err != nil {
+		cancel()
+		if response != nil {
+			_ = response.Body.Close()
+		}
+		httpServer.Close()
+		t.Fatalf("Do() error = %v", err)
+	}
+	defer httpServer.Close()
+	defer response.Body.Close()
+	defer cancel()
+	run(bufio.NewReader(response.Body), closeStream)
 }
 
 func readBoardSSEData(t *testing.T, reader *bufio.Reader) string {

--- a/internal/web/server_test.go
+++ b/internal/web/server_test.go
@@ -49,12 +49,13 @@ import (
 	"github.com/digitaldrywood/detent/internal/selector"
 	"github.com/digitaldrywood/detent/internal/store"
 	"github.com/digitaldrywood/detent/internal/store/sqlc"
+	"github.com/digitaldrywood/detent/internal/store/storetest"
 	"github.com/digitaldrywood/detent/internal/telemetry"
 	"github.com/digitaldrywood/detent/internal/web"
 	"github.com/digitaldrywood/detent/internal/web/demofixtures"
 )
 
-const sseTestReadTimeout = 5 * time.Second
+const sseTestOperationTimeout = 30 * time.Second
 
 func TestMain(m *testing.M) {
 	if err := os.Unsetenv("DETENT_API_TOKEN"); err != nil {
@@ -2030,11 +2031,9 @@ func TestDemoScenarioEventsPreserveProjectSubview(t *testing.T) {
 		t.Fatalf("NewServer() error = %v", err)
 	}
 	addr := startWebServer(t, server)
-	conn, body, reader := openRawEventStreamWithHeaders(t, addr, "/events?project=dogfood&view=kanban", map[string]string{
+	conn, reader := openRawEventStreamWithHeaders(t, addr, "/events?project=dogfood&view=kanban", map[string]string{
 		web.DemoScenarioHeader: "kanban-full-integration",
 	})
-	defer conn.Close()
-	defer body.Close()
 
 	buildEvent := readRawSSEFrame(t, conn, reader)
 	if buildEvent.name != "build" {
@@ -6497,9 +6496,7 @@ func TestProjectKanbanEventsSendBoardOnlySnapshot(t *testing.T) {
 	}
 
 	addr := startWebServer(t, server)
-	conn, body, reader := openRawEventStream(t, addr, "/events?project=detent&view=kanban")
-	defer conn.Close()
-	defer body.Close()
+	conn, reader := openRawEventStream(t, addr, "/events?project=detent&view=kanban")
 
 	if err := deps.Hub.Publish(telemetry.Snapshot{
 		GeneratedAt: now,
@@ -6569,9 +6566,7 @@ func TestFleetKanbanEventsSendBoardOnlySnapshot(t *testing.T) {
 	}
 
 	addr := startWebServer(t, server)
-	conn, body, reader := openRawEventStream(t, addr, "/events?view=kanban")
-	defer conn.Close()
-	defer body.Close()
+	conn, reader := openRawEventStream(t, addr, "/events?view=kanban")
 
 	if err := deps.Hub.Publish(telemetry.Snapshot{
 		GeneratedAt: now,
@@ -8673,7 +8668,6 @@ func TestServerEventsReplaysLatestSnapshot(t *testing.T) {
 	}
 
 	body := openEventStream(t, server)
-	defer body.Close()
 
 	event := readSSEEvent(t, body)
 	if event.name != "snapshot" {
@@ -8702,7 +8696,6 @@ func TestServerEventsStartsWithBuildVersion(t *testing.T) {
 	}
 
 	body := openEventStream(t, server)
-	defer body.Close()
 
 	event := readSSEFrame(t, body)
 	if event.name != "build" {
@@ -8725,7 +8718,6 @@ func TestServerEventsStreamsPublishedSnapshots(t *testing.T) {
 	}
 
 	body := openEventStream(t, server)
-	defer body.Close()
 
 	if err := deps.Hub.Publish(telemetry.Snapshot{Counts: telemetry.Counts{Running: 4}}); err != nil {
 		t.Fatalf("Publish() error = %v", err)
@@ -8769,9 +8761,7 @@ func TestServerEventsStreamsSidebarGitHubAPIHealth(t *testing.T) {
 	}
 
 	addr := startWebServer(t, server)
-	conn, body, reader := openRawEventStream(t, addr)
-	defer conn.Close()
-	defer body.Close()
+	conn, reader := openRawEventStream(t, addr)
 
 	var event sseEvent
 	for index, want := range []string{"snapshot", "live-status", "github-api-health"} {
@@ -8847,7 +8837,7 @@ func TestServerEventsPreserveProjectKanbanVisibilityMetadata(t *testing.T) {
 
 	ts := httptest.NewServer(server.Handler())
 	t.Cleanup(ts.Close)
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	ctx, cancel := context.WithTimeout(t.Context(), sseTestOperationTimeout)
 	t.Cleanup(cancel)
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, ts.URL+"/events?project=detent&view=kanban", nil)
 	if err != nil {
@@ -8967,9 +8957,7 @@ func TestServerEventsProjectKanbanUsesReloadedConfigOnRepublishedSnapshot(t *tes
 	}
 
 	addr := startWebServer(t, server)
-	conn, body, reader := openRawEventStream(t, addr, "/events?project=detent&view=kanban")
-	defer conn.Close()
-	defer body.Close()
+	conn, reader := openRawEventStream(t, addr, "/events?project=detent&view=kanban")
 
 	event := readRawSSEEvent(t, conn, reader)
 	if event.name != "snapshot" {
@@ -9022,9 +9010,7 @@ func TestServerEventsStreamsSidebarUpdates(t *testing.T) {
 	}
 
 	addr := startWebServer(t, server)
-	conn, body, reader := openRawEventStream(t, addr)
-	defer conn.Close()
-	defer body.Close()
+	conn, reader := openRawEventStream(t, addr)
 
 	if err := deps.Hub.Publish(telemetry.Snapshot{
 		GeneratedAt: time.Date(2026, 6, 12, 15, 0, 0, 0, time.UTC),
@@ -9097,9 +9083,7 @@ func TestServerEventsPreservesStaticSidebarNavigation(t *testing.T) {
 	}
 
 	addr := startWebServer(t, server)
-	conn, body, reader := openRawEventStream(t, addr, "/events?nav=reports")
-	defer conn.Close()
-	defer body.Close()
+	conn, reader := openRawEventStream(t, addr, "/events?nav=reports")
 
 	if err := deps.Hub.Publish(telemetry.Snapshot{
 		GeneratedAt: time.Date(2026, 6, 12, 15, 0, 0, 0, time.UTC),
@@ -9129,9 +9113,7 @@ func TestServerEventsStreamsAnalyticsSnapshotForAnalyticsNav(t *testing.T) {
 	}
 
 	addr := startWebServer(t, server)
-	conn, body, reader := openRawEventStream(t, addr, "/events?nav=analytics")
-	defer conn.Close()
-	defer body.Close()
+	conn, reader := openRawEventStream(t, addr, "/events?nav=analytics")
 
 	if err := deps.Hub.Publish(telemetry.Snapshot{
 		GeneratedAt: time.Date(2026, 6, 12, 15, 0, 0, 0, time.UTC),
@@ -9183,9 +9165,7 @@ func TestServerEventsStreamsHealthSnapshotForHealthNav(t *testing.T) {
 	}
 
 	addr := startWebServer(t, server)
-	conn, body, reader := openRawEventStream(t, addr, "/events?nav=health")
-	defer conn.Close()
-	defer body.Close()
+	conn, reader := openRawEventStream(t, addr, "/events?nav=health")
 
 	if err := deps.Hub.Publish(telemetry.Snapshot{
 		GeneratedAt: now,
@@ -9268,9 +9248,7 @@ func TestServerEventsPreserveProjectContextForStaticSidebarNavigation(t *testing
 			}
 
 			addr := startWebServer(t, server)
-			conn, body, reader := openRawEventStream(t, addr, tt.path)
-			defer conn.Close()
-			defer body.Close()
+			conn, reader := openRawEventStream(t, addr, tt.path)
 
 			if err := deps.Hub.Publish(telemetry.Snapshot{
 				GeneratedAt: time.Date(2026, 6, 12, 15, 0, 0, 0, time.UTC),
@@ -9346,9 +9324,7 @@ func TestServerEventsEnrichesSnapshotOncePerPublish(t *testing.T) {
 	}
 
 	first := openEventStream(t, server)
-	defer first.Close()
 	second := openEventStream(t, server)
-	defer second.Close()
 
 	if err := deps.Hub.Publish(telemetry.Snapshot{GeneratedAt: generatedAt}); err != nil {
 		t.Fatalf("Publish() error = %v", err)
@@ -9428,7 +9404,6 @@ func TestServerEventsStreamsLiveDashboardSections(t *testing.T) {
 	}
 
 	body := openEventStream(t, server)
-	defer body.Close()
 	generatedAt := time.Date(2026, 5, 31, 15, 0, 0, 0, time.UTC)
 
 	if err := deps.Hub.Publish(telemetry.Snapshot{
@@ -9574,7 +9549,6 @@ func TestServerEventsSendsTickEvents(t *testing.T) {
 	}
 
 	body := openEventStream(t, server)
-	defer body.Close()
 
 	event := readSSEEvent(t, body)
 	if event.name != "tick" {
@@ -9598,9 +9572,7 @@ func TestServerEventsStreamsPastHTTPTimeouts(t *testing.T) {
 	}
 
 	addr := startWebServer(t, server)
-	conn, body, reader := openRawEventStream(t, addr)
-	defer conn.Close()
-	defer body.Close()
+	conn, reader := openRawEventStream(t, addr)
 
 	for range 2 {
 		event := readRawSSEEvent(t, conn, reader)
@@ -10243,7 +10215,6 @@ func TestServerEventsOverlayManualRefreshOnStaleDegradedState(t *testing.T) {
 	}
 
 	body := openEventStream(t, server)
-	defer body.Close()
 
 	event := readSSEEvent(t, body)
 	if event.name != "snapshot" {
@@ -12219,20 +12190,7 @@ func newBudgetTestProject(t *testing.T, id string, perDayMaxUSD float64, perIssu
 
 func openWebTestStore(t *testing.T) store.Store {
 	t.Helper()
-
-	backend, err := store.Open(context.Background(), store.Config{
-		Backend: store.BackendSQLite,
-		Path:    filepath.Join(t.TempDir(), "detent.db"),
-	})
-	if err != nil {
-		t.Fatalf("Open() error = %v", err)
-	}
-	t.Cleanup(func() {
-		if err := backend.Close(); err != nil {
-			t.Fatalf("Close() error = %v", err)
-		}
-	})
-	return backend
+	return storetest.Open(t)
 }
 
 func seedWorkflowTrendEvents(t *testing.T, ctx context.Context, backend store.Store, now time.Time) {
@@ -13524,10 +13482,15 @@ func openEventStream(t *testing.T, server *web.Server) io.ReadCloser {
 	t.Helper()
 
 	ts := httptest.NewServer(server.Handler())
-	t.Cleanup(ts.Close)
-
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
-	t.Cleanup(cancel)
+	ctx, cancel := context.WithTimeout(context.Background(), sseTestOperationTimeout)
+	var body io.ReadCloser
+	t.Cleanup(func() {
+		cancel()
+		if body != nil {
+			_ = body.Close()
+		}
+		ts.Close()
+	})
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, ts.URL+"/events", nil)
 	if err != nil {
@@ -13551,7 +13514,8 @@ func openEventStream(t *testing.T, server *web.Server) io.ReadCloser {
 		t.Fatalf("Content-Type = %q, want text/event-stream", got)
 	}
 
-	return resp.Body
+	body = resp.Body
+	return body
 }
 
 func startWebServer(t *testing.T, server *web.Server) string {
@@ -13569,19 +13533,21 @@ func startWebServer(t *testing.T, server *web.Server) string {
 	}()
 
 	t.Cleanup(func() {
-		ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+		ctx, cancel := context.WithTimeout(context.Background(), sseTestOperationTimeout)
 		defer cancel()
 
 		if err := server.Shutdown(ctx); err != nil {
 			t.Errorf("Shutdown() error = %v", err)
 		}
 
+		joinTimer := time.NewTimer(sseTestOperationTimeout)
+		defer joinTimer.Stop()
 		select {
 		case err := <-errs:
 			if err != nil && !errors.Is(err, http.ErrServerClosed) {
 				t.Errorf("StartListener() error = %v", err)
 			}
-		case <-time.After(time.Second):
+		case <-joinTimer.C:
 			t.Errorf("timed out waiting for StartListener to return")
 		}
 	})
@@ -13589,7 +13555,7 @@ func startWebServer(t *testing.T, server *web.Server) string {
 	return listener.Addr().String()
 }
 
-func openRawEventStream(t *testing.T, addr string, paths ...string) (net.Conn, io.ReadCloser, *bufio.Reader) {
+func openRawEventStream(t *testing.T, addr string, paths ...string) (net.Conn, *bufio.Reader) {
 	t.Helper()
 
 	path := "/events"
@@ -13599,18 +13565,21 @@ func openRawEventStream(t *testing.T, addr string, paths ...string) (net.Conn, i
 	return openRawEventStreamWithHeaders(t, addr, path, nil)
 }
 
-func openRawEventStreamWithHeaders(t *testing.T, addr string, path string, headers map[string]string) (net.Conn, io.ReadCloser, *bufio.Reader) {
+func openRawEventStreamWithHeaders(t *testing.T, addr string, path string, headers map[string]string) (net.Conn, *bufio.Reader) {
 	t.Helper()
 
 	var dialer net.Dialer
-	conn, err := dialer.DialContext(t.Context(), "tcp", addr)
+	dialContext, cancelDial := context.WithTimeout(t.Context(), sseTestOperationTimeout)
+	conn, err := dialer.DialContext(dialContext, "tcp", addr)
+	cancelDial()
 	if err != nil {
 		t.Fatalf("Dial() error = %v", err)
 	}
-	closeOnFailure := true
+	var body io.ReadCloser
 	t.Cleanup(func() {
-		if closeOnFailure {
-			conn.Close()
+		_ = conn.Close()
+		if body != nil {
+			_ = body.Close()
 		}
 	})
 
@@ -13625,7 +13594,7 @@ func openRawEventStreamWithHeaders(t *testing.T, addr string, path string, heade
 	if _, err := io.WriteString(conn, request.String()); err != nil {
 		t.Fatalf("WriteString() error = %v", err)
 	}
-	if err := conn.SetReadDeadline(time.Now().Add(sseTestReadTimeout)); err != nil {
+	if err := conn.SetReadDeadline(time.Now().Add(sseTestOperationTimeout)); err != nil {
 		t.Fatalf("SetReadDeadline() error = %v", err)
 	}
 
@@ -13643,8 +13612,8 @@ func openRawEventStreamWithHeaders(t *testing.T, addr string, path string, heade
 		t.Fatalf("Content-Type = %q, want text/event-stream", got)
 	}
 
-	closeOnFailure = false
-	return conn, resp.Body, bufio.NewReader(resp.Body)
+	body = resp.Body
+	return conn, bufio.NewReader(body)
 }
 
 func readRawSSEEvent(t *testing.T, conn net.Conn, reader *bufio.Reader) sseEvent {
@@ -13673,7 +13642,7 @@ func readRawSSEFrame(t *testing.T, conn net.Conn, reader *bufio.Reader) sseEvent
 	t.Helper()
 
 	var event sseEvent
-	deadline := time.Now().Add(sseTestReadTimeout)
+	deadline := time.Now().Add(sseTestOperationTimeout)
 	for {
 		if err := conn.SetReadDeadline(deadline); err != nil {
 			t.Fatalf("SetReadDeadline() error = %v", err)
@@ -13730,7 +13699,7 @@ func readSSEFrameMatching(t *testing.T, r io.Reader, includeBuild bool) sseEvent
 	}()
 
 	var event sseEvent
-	deadline := time.After(sseTestReadTimeout)
+	deadline := time.After(sseTestOperationTimeout)
 	for {
 		select {
 		case line, ok := <-lines:

--- a/internal/web/staleness_warning_test.go
+++ b/internal/web/staleness_warning_test.go
@@ -53,9 +53,7 @@ func TestStalenessWarningAcknowledgementSurvivesNextSSESnapshot(t *testing.T) {
 		t.Fatalf("NewServer() error = %v", err)
 	}
 	addr := startWebServer(t, server)
-	conn, body, reader := openRawEventStream(t, addr, "/events?view=board")
-	defer conn.Close()
-	defer body.Close()
+	conn, reader := openRawEventStream(t, addr, "/events?view=board")
 
 	initial := readRawSSEEventNamed(t, conn, reader, "snapshot")
 	if !strings.Contains(initial.data, "detent#1") || !strings.Contains(initial.data, `data-board-alert-count="2"`) {

--- a/tools/testgate/main.go
+++ b/tools/testgate/main.go
@@ -18,11 +18,13 @@ import (
 )
 
 type testEvent struct {
-	Action  string  `json:"Action"`
-	Package string  `json:"Package"`
-	Test    string  `json:"Test"`
-	Output  string  `json:"Output"`
-	Elapsed float64 `json:"Elapsed"`
+	Action      string  `json:"Action"`
+	Package     string  `json:"Package"`
+	ImportPath  string  `json:"ImportPath"`
+	FailedBuild string  `json:"FailedBuild"`
+	Test        string  `json:"Test"`
+	Output      string  `json:"Output"`
+	Elapsed     float64 `json:"Elapsed"`
 }
 
 type packageResult struct {
@@ -45,12 +47,13 @@ type gateSummary struct {
 }
 
 type evidenceCollector struct {
-	dir       string
-	combined  io.Writer
-	console   io.Writer
-	files     map[string]*os.File
-	results   map[string]*packageResult
-	closeErrs []error
+	dir        string
+	combined   io.Writer
+	console    io.Writer
+	files      map[string]*os.File
+	results    map[string]*packageResult
+	buildLines map[string][][]byte
+	closeErrs  []error
 }
 
 func main() {
@@ -146,11 +149,12 @@ func runGoTest(ctx context.Context, packages []string, parallel int, timeout tim
 
 func newEvidenceCollector(dir string, combined, console io.Writer) *evidenceCollector {
 	return &evidenceCollector{
-		dir:      dir,
-		combined: combined,
-		console:  console,
-		files:    make(map[string]*os.File),
-		results:  make(map[string]*packageResult),
+		dir:        dir,
+		combined:   combined,
+		console:    console,
+		files:      make(map[string]*os.File),
+		results:    make(map[string]*packageResult),
+		buildLines: make(map[string][][]byte),
 	}
 }
 
@@ -174,7 +178,14 @@ func (c *evidenceCollector) collectLine(line []byte) error {
 	}
 
 	var event testEvent
-	if err := json.Unmarshal(line, &event); err != nil || event.Package == "" {
+	if err := json.Unmarshal(line, &event); err != nil {
+		return nil
+	}
+	if event.ImportPath != "" {
+		c.buildLines[event.ImportPath] = append(c.buildLines[event.ImportPath], line)
+		return nil
+	}
+	if event.Package == "" {
 		return nil
 	}
 	result := c.result(event.Package)
@@ -182,10 +193,26 @@ func (c *evidenceCollector) collectLine(line []byte) error {
 	if err != nil {
 		return err
 	}
+	if err := c.flushBuildLines(event.FailedBuild, file); err != nil {
+		return err
+	}
 	if _, err := file.Write(append(line, '\n')); err != nil {
 		return err
 	}
 	result.apply(event)
+	return nil
+}
+
+func (c *evidenceCollector) flushBuildLines(importPath string, file io.Writer) error {
+	if importPath == "" {
+		return nil
+	}
+	for _, line := range c.buildLines[importPath] {
+		if _, err := file.Write(append(line, '\n')); err != nil {
+			return err
+		}
+	}
+	delete(c.buildLines, importPath)
 	return nil
 }
 
@@ -243,8 +270,8 @@ func (c *evidenceCollector) summary(parallel int, timeout time.Duration) gateSum
 }
 
 func (r *packageResult) apply(event testEvent) {
-	if event.Action == "pass" && event.Test == "" {
-		r.Outcome = "pass"
+	if (event.Action == "pass" || event.Action == "skip") && event.Test == "" {
+		r.Outcome = event.Action
 		r.Elapsed = event.Elapsed
 	}
 	if event.Action == "fail" {

--- a/tools/testgate/main.go
+++ b/tools/testgate/main.go
@@ -1,0 +1,320 @@
+package main
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+)
+
+type testEvent struct {
+	Action  string  `json:"Action"`
+	Package string  `json:"Package"`
+	Test    string  `json:"Test"`
+	Output  string  `json:"Output"`
+	Elapsed float64 `json:"Elapsed"`
+}
+
+type packageResult struct {
+	Package        string  `json:"package"`
+	Outcome        string  `json:"outcome"`
+	Classification string  `json:"classification,omitempty"`
+	Elapsed        float64 `json:"elapsed_seconds,omitempty"`
+	EvidenceFile   string  `json:"evidence_file"`
+
+	packageTimeout bool
+	testTimeouts   map[string]bool
+}
+
+type gateSummary struct {
+	Schema             int             `json:"schema"`
+	PackageParallelism int             `json:"package_parallelism"`
+	TestParallelism    int             `json:"test_parallelism"`
+	PackageTimeout     string          `json:"package_timeout"`
+	Packages           []packageResult `json:"packages"`
+}
+
+type evidenceCollector struct {
+	dir       string
+	combined  io.Writer
+	console   io.Writer
+	files     map[string]*os.File
+	results   map[string]*packageResult
+	closeErrs []error
+}
+
+func main() {
+	os.Exit(run(context.Background(), os.Args[1:], os.Stdout, os.Stderr))
+}
+
+func run(ctx context.Context, args []string, stdout, stderr io.Writer) int {
+	flags := flag.NewFlagSet("testgate", flag.ContinueOnError)
+	flags.SetOutput(stderr)
+
+	outputDir := flags.String("output", filepath.Join("tmp", "windows-test-evidence"), "test evidence output directory")
+	testParallelism := flags.Int("parallel", 4, "maximum parallel tests within one package")
+	packageTimeout := flags.Duration("timeout", 10*time.Minute, "timeout for each test package")
+
+	if err := flags.Parse(args); err != nil {
+		return 2
+	}
+	if strings.TrimSpace(*outputDir) == "" {
+		fmt.Fprintln(stderr, "-output is required")
+		return 2
+	}
+	if *testParallelism <= 0 {
+		fmt.Fprintln(stderr, "-parallel must be positive")
+		return 2
+	}
+	if *packageTimeout <= 0 {
+		fmt.Fprintln(stderr, "-timeout must be positive")
+		return 2
+	}
+	packages := flags.Args()
+	if len(packages) == 0 {
+		packages = []string{"./..."}
+	}
+
+	if err := os.MkdirAll(*outputDir, 0o755); err != nil {
+		fmt.Fprintf(stderr, "create evidence directory: %v\n", err)
+		return 1
+	}
+	combinedPath := filepath.Join(*outputDir, "combined.jsonl")
+	combined, err := os.Create(combinedPath)
+	if err != nil {
+		fmt.Fprintf(stderr, "create combined evidence: %v\n", err)
+		return 1
+	}
+
+	collector := newEvidenceCollector(*outputDir, combined, stdout)
+	commandErr := runGoTest(ctx, packages, *testParallelism, *packageTimeout, collector)
+	closeErr := errors.Join(collector.close(), combined.Close())
+	summaryErr := writeSummary(*outputDir, collector.summary(*testParallelism, *packageTimeout))
+	if commandErr != nil {
+		fmt.Fprintf(stderr, "Windows test gate failed: %v\n", commandErr)
+	}
+	if closeErr != nil {
+		fmt.Fprintf(stderr, "close test evidence: %v\n", closeErr)
+	}
+	if summaryErr != nil {
+		fmt.Fprintf(stderr, "write test summary: %v\n", summaryErr)
+	}
+	if commandErr != nil || closeErr != nil || summaryErr != nil {
+		return 1
+	}
+	return 0
+}
+
+func runGoTest(ctx context.Context, packages []string, parallel int, timeout time.Duration, collector *evidenceCollector) error {
+	cmd := exec.CommandContext(ctx, "go", "test")
+	cmd.Args = append(cmd.Args,
+		"-json",
+		"-p=1",
+		"-parallel="+strconv.Itoa(parallel),
+		"-timeout="+timeout.String(),
+	)
+	cmd.Args = append(cmd.Args, packages...)
+	output, err := cmd.StdoutPipe()
+	if err != nil {
+		return fmt.Errorf("capture go test output: %w", err)
+	}
+	cmd.Stderr = cmd.Stdout
+	if err := cmd.Start(); err != nil {
+		return fmt.Errorf("start go test: %w", err)
+	}
+
+	scanErr := collector.collect(output)
+	waitErr := cmd.Wait()
+	if scanErr != nil {
+		return errors.Join(fmt.Errorf("collect go test evidence: %w", scanErr), waitErr)
+	}
+	if waitErr != nil {
+		return waitErr
+	}
+	return nil
+}
+
+func newEvidenceCollector(dir string, combined, console io.Writer) *evidenceCollector {
+	return &evidenceCollector{
+		dir:      dir,
+		combined: combined,
+		console:  console,
+		files:    make(map[string]*os.File),
+		results:  make(map[string]*packageResult),
+	}
+}
+
+func (c *evidenceCollector) collect(input io.Reader) error {
+	scanner := bufio.NewScanner(input)
+	scanner.Buffer(make([]byte, 64*1024), 4*1024*1024)
+	for scanner.Scan() {
+		line := append([]byte(nil), scanner.Bytes()...)
+		if err := c.collectLine(line); err != nil {
+			return err
+		}
+	}
+	return scanner.Err()
+}
+
+func (c *evidenceCollector) collectLine(line []byte) error {
+	for _, writer := range []io.Writer{c.combined, c.console} {
+		if _, err := writer.Write(append(line, '\n')); err != nil {
+			return err
+		}
+	}
+
+	var event testEvent
+	if err := json.Unmarshal(line, &event); err != nil || event.Package == "" {
+		return nil
+	}
+	result := c.result(event.Package)
+	file, err := c.file(result)
+	if err != nil {
+		return err
+	}
+	if _, err := file.Write(append(line, '\n')); err != nil {
+		return err
+	}
+	result.apply(event)
+	return nil
+}
+
+func (c *evidenceCollector) result(packagePath string) *packageResult {
+	if result, ok := c.results[packagePath]; ok {
+		return result
+	}
+	result := &packageResult{
+		Package:      packagePath,
+		Outcome:      "running",
+		EvidenceFile: packageEvidenceName(packagePath),
+		testTimeouts: make(map[string]bool),
+	}
+	c.results[packagePath] = result
+	return result
+}
+
+func (c *evidenceCollector) file(result *packageResult) (*os.File, error) {
+	if file, ok := c.files[result.Package]; ok {
+		return file, nil
+	}
+	file, err := os.Create(filepath.Join(c.dir, result.EvidenceFile))
+	if err != nil {
+		return nil, fmt.Errorf("create %s evidence: %w", result.Package, err)
+	}
+	c.files[result.Package] = file
+	return file, nil
+}
+
+func (c *evidenceCollector) close() error {
+	for _, file := range c.files {
+		if err := file.Close(); err != nil {
+			c.closeErrs = append(c.closeErrs, err)
+		}
+	}
+	return errors.Join(c.closeErrs...)
+}
+
+func (c *evidenceCollector) summary(parallel int, timeout time.Duration) gateSummary {
+	packages := make([]packageResult, 0, len(c.results))
+	for _, result := range c.results {
+		result.finalize()
+		packages = append(packages, *result)
+	}
+	sort.Slice(packages, func(i, j int) bool {
+		return packages[i].Package < packages[j].Package
+	})
+	return gateSummary{
+		Schema:             1,
+		PackageParallelism: 1,
+		TestParallelism:    parallel,
+		PackageTimeout:     timeout.String(),
+		Packages:           packages,
+	}
+}
+
+func (r *packageResult) apply(event testEvent) {
+	if event.Action == "pass" && event.Test == "" {
+		r.Outcome = "pass"
+		r.Elapsed = event.Elapsed
+	}
+	if event.Action == "fail" {
+		if event.Test == "" {
+			r.Outcome = "fail"
+			r.Elapsed = event.Elapsed
+		} else if operationTimeoutOutput(event.Output) {
+			r.testTimeouts[event.Test] = true
+		}
+	}
+	if packageTimeoutOutput(event.Output) {
+		r.packageTimeout = true
+	}
+	if event.Test != "" && operationTimeoutOutput(event.Output) {
+		r.testTimeouts[event.Test] = true
+	}
+}
+
+func (r *packageResult) finalize() {
+	if r.Outcome != "fail" {
+		return
+	}
+	switch {
+	case r.packageTimeout:
+		r.Classification = "package_timeout"
+	case len(r.testTimeouts) > 0:
+		r.Classification = "operation_timeout"
+	default:
+		r.Classification = "assertion"
+	}
+}
+
+func packageTimeoutOutput(output string) bool {
+	return strings.Contains(strings.ToLower(output), "panic: test timed out after")
+}
+
+func operationTimeoutOutput(output string) bool {
+	output = strings.ToLower(output)
+	for _, marker := range []string{
+		"context deadline exceeded",
+		"deadline exceeded",
+		"i/o timeout",
+		"operation timed out",
+		"stream stalled",
+		"timed out waiting",
+		"timeout waiting",
+	} {
+		if strings.Contains(output, marker) {
+			return true
+		}
+	}
+	return false
+}
+
+func packageEvidenceName(packagePath string) string {
+	name := strings.TrimPrefix(packagePath, "github.com/digitaldrywood/detent/")
+	name = strings.Trim(name, "/")
+	replacer := strings.NewReplacer("/", "__", "\\", "__", ":", "_", " ", "_")
+	name = replacer.Replace(name)
+	if name == "" {
+		name = "root"
+	}
+	return name + ".jsonl"
+}
+
+func writeSummary(dir string, summary gateSummary) error {
+	file, err := os.Create(filepath.Join(dir, "summary.json"))
+	if err != nil {
+		return err
+	}
+	encodeErr := json.NewEncoder(file).Encode(summary)
+	return errors.Join(encodeErr, file.Close())
+}

--- a/tools/testgate/main_test.go
+++ b/tools/testgate/main_test.go
@@ -1,0 +1,164 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestPackageResultClassifiesFailures(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		events []testEvent
+		want   string
+	}{
+		{
+			name: "assertion",
+			events: []testEvent{
+				{Action: "output", Test: "TestValue", Output: "value = 1, want 2"},
+				{Action: "fail", Test: "TestValue"},
+				{Action: "fail"},
+			},
+			want: "assertion",
+		},
+		{
+			name: "operation timeout",
+			events: []testEvent{
+				{Action: "output", Test: "TestStream", Output: "claude stream stalled after 10s"},
+				{Action: "fail", Test: "TestStream"},
+				{Action: "fail"},
+			},
+			want: "operation_timeout",
+		},
+		{
+			name: "package timeout takes precedence",
+			events: []testEvent{
+				{Action: "output", Test: "TestStream", Output: "context deadline exceeded"},
+				{Action: "output", Output: "panic: test timed out after 10m0s"},
+				{Action: "fail"},
+			},
+			want: "package_timeout",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			result := packageResult{Outcome: "running", testTimeouts: make(map[string]bool)}
+			for _, event := range tt.events {
+				result.apply(event)
+			}
+			result.finalize()
+			if result.Classification != tt.want {
+				t.Fatalf("Classification = %q, want %q", result.Classification, tt.want)
+			}
+		})
+	}
+}
+
+func TestEvidenceCollectorRetainsPerPackageJSON(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	var combined bytes.Buffer
+	collector := newEvidenceCollector(dir, &combined, io.Discard)
+	lines := []string{
+		`{"Action":"run","Package":"github.com/digitaldrywood/detent/internal/store"}`,
+		`{"Action":"pass","Package":"github.com/digitaldrywood/detent/internal/store","Elapsed":1.25}`,
+		`{"Action":"run","Package":"github.com/digitaldrywood/detent/internal/web"}`,
+		`{"Action":"output","Package":"github.com/digitaldrywood/detent/internal/web","Test":"TestSSE","Output":"context deadline exceeded\n"}`,
+		`{"Action":"fail","Package":"github.com/digitaldrywood/detent/internal/web","Test":"TestSSE"}`,
+		`{"Action":"fail","Package":"github.com/digitaldrywood/detent/internal/web","Elapsed":2.5}`,
+	}
+	if err := collector.collect(strings.NewReader(strings.Join(lines, "\n") + "\n")); err != nil {
+		t.Fatalf("collect() error = %v", err)
+	}
+	if err := collector.close(); err != nil {
+		t.Fatalf("close() error = %v", err)
+	}
+
+	summary := collector.summary(4, 10*time.Minute)
+	if summary.PackageParallelism != 1 || summary.TestParallelism != 4 || summary.PackageTimeout != "10m0s" {
+		t.Fatalf("summary budget = %#v", summary)
+	}
+	if len(summary.Packages) != 2 {
+		t.Fatalf("packages len = %d, want 2", len(summary.Packages))
+	}
+	if got := summary.Packages[0]; got.Package != "github.com/digitaldrywood/detent/internal/store" || got.Outcome != "pass" || got.Classification != "" {
+		t.Fatalf("store result = %#v", got)
+	}
+	if got := summary.Packages[1]; got.Package != "github.com/digitaldrywood/detent/internal/web" || got.Outcome != "fail" || got.Classification != "operation_timeout" {
+		t.Fatalf("web result = %#v", got)
+	}
+	for _, result := range summary.Packages {
+		data, err := os.ReadFile(filepath.Join(dir, result.EvidenceFile))
+		if err != nil {
+			t.Fatalf("ReadFile(%s) error = %v", result.EvidenceFile, err)
+		}
+		if !bytes.Contains(data, []byte(result.Package)) {
+			t.Fatalf("%s does not contain package %q", result.EvidenceFile, result.Package)
+		}
+	}
+	if got := strings.Count(combined.String(), "\n"); got != len(lines) {
+		t.Fatalf("combined line count = %d, want %d", got, len(lines))
+	}
+}
+
+func TestRunValidatesArguments(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		args    []string
+		wantErr string
+	}{
+		{name: "missing output", args: []string{"-output", ""}, wantErr: "-output is required"},
+		{name: "invalid parallel", args: []string{"-parallel", "0"}, wantErr: "-parallel must be positive"},
+		{name: "invalid timeout", args: []string{"-timeout", "0s"}, wantErr: "-timeout must be positive"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			var stderr bytes.Buffer
+			if code := run(t.Context(), tt.args, io.Discard, &stderr); code != 2 {
+				t.Fatalf("run() = %d, want 2", code)
+			}
+			if !strings.Contains(stderr.String(), tt.wantErr) {
+				t.Fatalf("stderr = %q, want containing %q", stderr.String(), tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestGateSummaryJSONUsesClassificationNames(t *testing.T) {
+	t.Parallel()
+
+	summary := gateSummary{
+		Schema:             1,
+		PackageParallelism: 1,
+		TestParallelism:    4,
+		PackageTimeout:     "10m0s",
+		Packages: []packageResult{
+			{Package: "example/assertion", Outcome: "fail", Classification: "assertion", EvidenceFile: "assertion.jsonl"},
+			{Package: "example/operation", Outcome: "fail", Classification: "operation_timeout", EvidenceFile: "operation.jsonl"},
+			{Package: "example/package", Outcome: "fail", Classification: "package_timeout", EvidenceFile: "package.jsonl"},
+		},
+	}
+	data, err := json.Marshal(summary)
+	if err != nil {
+		t.Fatalf("Marshal() error = %v", err)
+	}
+	for _, want := range []string{"assertion", "operation_timeout", "package_timeout"} {
+		if !bytes.Contains(data, []byte(want)) {
+			t.Fatalf("summary JSON missing %q: %s", want, data)
+		}
+	}
+}

--- a/tools/testgate/main_test.go
+++ b/tools/testgate/main_test.go
@@ -63,6 +63,51 @@ func TestPackageResultClassifiesFailures(t *testing.T) {
 	}
 }
 
+func TestPackageResultRecordsPackageSkip(t *testing.T) {
+	t.Parallel()
+
+	result := packageResult{Outcome: "running", testTimeouts: make(map[string]bool)}
+	result.apply(testEvent{Action: "skip", Elapsed: 0.25})
+
+	if result.Outcome != "skip" || result.Elapsed != 0.25 {
+		t.Fatalf("result = %#v, want skipped package with elapsed time", result)
+	}
+}
+
+func TestEvidenceCollectorRetainsBuildEventsWithFailedPackage(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	collector := newEvidenceCollector(dir, io.Discard, io.Discard)
+	buildPath := "example.com/project/pkg [example.com/project/pkg.test]"
+	lines := []string{
+		`{"ImportPath":"` + buildPath + `","Action":"build-output","Output":"pkg_test.go:12:2: undefined: missing\\n"}`,
+		`{"ImportPath":"` + buildPath + `","Action":"build-fail"}`,
+		`{"Action":"fail","Package":"example.com/project/pkg","FailedBuild":"` + buildPath + `"}`,
+	}
+	if err := collector.collect(strings.NewReader(strings.Join(lines, "\n") + "\n")); err != nil {
+		t.Fatalf("collect() error = %v", err)
+	}
+	if err := collector.close(); err != nil {
+		t.Fatalf("close() error = %v", err)
+	}
+
+	summary := collector.summary(4, 10*time.Minute)
+	if len(summary.Packages) != 1 {
+		t.Fatalf("packages len = %d, want 1", len(summary.Packages))
+	}
+	result := summary.Packages[0]
+	data, err := os.ReadFile(filepath.Join(dir, result.EvidenceFile))
+	if err != nil {
+		t.Fatalf("ReadFile(%s) error = %v", result.EvidenceFile, err)
+	}
+	for _, want := range []string{"undefined: missing", "build-fail", `"FailedBuild"`} {
+		if !bytes.Contains(data, []byte(want)) {
+			t.Fatalf("package evidence missing %q: %s", want, data)
+		}
+	}
+}
+
 func TestEvidenceCollectorRetainsPerPackageJSON(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

- Make the portability job the single required Windows package-test owner with sequential package execution and four-way test concurrency.
- Retain per-package JSON evidence and classify assertion, operation timeout, and package timeout failures.
- Reuse migrated SQLite fixtures, centralize SSE cleanup, and replace production timeout correctness oracles with controlled or test-owned deadlines.

Fixes #2026

## UI Surface Contract

- [x] N/A; this change does not alter a UI surface, layout, density, first viewport, or responsive visibility.
- [x] This PR does not add persistent top-of-screen messaging.
- [x] This PR has no visual changes to primary operator screens.

## Test Plan

- [x] Focused changed packages under `-p=1 -parallel=4`.
- [x] Controlled timers, shell route, migrated fixtures, SSE lifecycles, and classifier cases under `-race -count=10`.
- [x] Rebased root/store/web/evidence packages under `-race`.
- [x] `make lint` (0 issues).
- [x] `make check` (78.8% overall coverage; all package and file floors pass).