### PR TITLE
fix(orchestrator): defer GitHub monitor outages

### DIFF
--- a/internal/orchestrator/dispatch.go
+++ b/internal/orchestrator/dispatch.go
@@ -167,6 +167,7 @@ func (o *Orchestrator) dispatchReadyIssues(ctx context.Context, state *State, is
 		},
 		retryDispatchFailed: func(issue connector.Issue, retry Retry) {
 			releaseForgeAvailabilityProbe(state, issue.ID, "deferred", dispatchFailureRetryReason(lastDispatchFailure), now)
+			releaseWorkerGitHubMonitorProbe(state, issue.ID, "deferred", dispatchFailureRetryReason(lastDispatchFailure), now)
 			planner.scheduleRetry(state, issue, retry.Attempt, now, dispatchFailureRetryReason(lastDispatchFailure), false, retry.WorkerHost)
 			rescheduled := state.Retry[issue.ID]
 			rescheduled.RetryMode = retry.RetryMode
@@ -175,6 +176,8 @@ func (o *Orchestrator) dispatchReadyIssues(ctx context.Context, state *State, is
 			rescheduled.ForgeUnavailable = retry.ForgeUnavailable
 			rescheduled.ForgeHost = retry.ForgeHost
 			rescheduled.ForgeRetry = cloneForgeRetry(retry.ForgeRetry)
+			rescheduled.GitHubMonitor = retry.GitHubMonitor
+			rescheduled.GitHubCredential = retry.GitHubCredential
 			rescheduled.Wait = retry.Wait
 			rescheduled.Wait.PendingChecks = append([]string(nil), retry.Wait.PendingChecks...)
 			state.Retry[issue.ID] = rescheduled
@@ -312,6 +315,7 @@ const (
 	dispatchIssueFailureGitHubRESTPaused      = "github_rest_capacity_paused"
 	dispatchIssueFailureTrackerUnavailable    = "tracker_unavailable"
 	dispatchIssueFailureForgeUnavailable      = "forge_unavailable"
+	dispatchIssueFailureGitHubMonitor         = "worker_github_budget_monitor_unavailable"
 	dispatchIssueFailureCIUnavailable         = "ci_unavailable"
 	dispatchIssueFailureMemoryPressure        = "memory_pressure_high"
 	dispatchIssueFailureRecoveryRamp          = "dispatch_recovery_ramp"
@@ -404,6 +408,9 @@ func (o *Orchestrator) dispatchIssueWithAdmission(
 	}
 	if forgeAvailabilityBlocks(state, issue, queuedRetry, o.cfg.ForgeHost, now) {
 		return dispatchIssueOutcome{reason: dispatchIssueFailureForgeUnavailable}
+	}
+	if workerGitHubMonitorBlocks(state, issue.ID, queuedRetry, now) {
+		return dispatchIssueOutcome{reason: dispatchIssueFailureGitHubMonitor}
 	}
 	if _, paused := activeGitHubRESTCapacityOutage(state, now); paused {
 		return dispatchIssueOutcome{reason: dispatchIssueFailureGitHubRESTPaused}
@@ -655,6 +662,7 @@ func (o *Orchestrator) dispatchIssueWithAdmission(
 		CapacityScope:       capacityScope,
 		CapacityProbe:       capacityProbeKey != "",
 		ForgeProbeHost:      reservedForgeProbeHost(state, issue.ID),
+		GitHubCredential:    reservedGitHubCredential(state, issue.ID),
 		ModelPermitExempt:   !modelPermitRequired,
 		StopDestination:     o.cfg.StopRunTargetState,
 		StopPriorityOptions: stopRunPriorityOptions(o.cfg.StopRunPriorityNames),

--- a/internal/orchestrator/dispatch_planner.go
+++ b/internal/orchestrator/dispatch_planner.go
@@ -278,6 +278,9 @@ func (p dispatchPlanner) retryAction(
 	if forgeAvailabilityBlocks(state, issue, retry, p.cfg.ForgeHost, now) {
 		return dispatchAction{}, false, dispatchSkipForgeUnavailable
 	}
+	if workerGitHubMonitorBlocks(state, issue.ID, retry, now) {
+		return dispatchAction{}, false, dispatchSkipGitHubMonitor
+	}
 	if outage, paused := activeGitHubRESTCapacityOutage(state, now); paused {
 		if retry.DueAt.Before(outage.ResumeAt) {
 			retry.DueAt = outage.ResumeAt
@@ -297,6 +300,15 @@ func (p dispatchPlanner) retryAction(
 			}
 		}
 	}
+	workerGitHubMonitorProbeReserved := false
+	if retry.GitHubMonitor {
+		if _, active := state.GitHubMonitors[strings.TrimSpace(retry.GitHubCredential)]; active {
+			_, workerGitHubMonitorProbeReserved = reserveWorkerGitHubMonitorProbe(state, issue.ID, retry, now)
+			if !workerGitHubMonitorProbeReserved {
+				return dispatchAction{}, false, dispatchSkipGitHubMonitor
+			}
+		}
+	}
 	delete(state.Retry, retry.Issue.ID)
 
 	modelPermitRequired := p.modelPermitRequiredAtDispatch(issue) || retry.MergePrecheck != nil
@@ -311,6 +323,9 @@ func (p dispatchPlanner) retryAction(
 	if !decision.dispatchable {
 		if forgeProbeReserved {
 			releaseForgeAvailabilityProbe(state, issue.ID, "deferred", decision.reason, now)
+		}
+		if workerGitHubMonitorProbeReserved {
+			releaseWorkerGitHubMonitorProbe(state, issue.ID, "deferred", decision.reason, now)
 		}
 		if decision.reason == dispatchSkipProjectFailureBreaker {
 			if retry.DueAt.Before(state.FailureBreaker.ResumeAt) {
@@ -344,6 +359,9 @@ func (p dispatchPlanner) retryAction(
 	if !ok {
 		if forgeProbeReserved {
 			releaseForgeAvailabilityProbe(state, issue.ID, "deferred", dispatchSkipWorkerHostUnavailable, now)
+		}
+		if workerGitHubMonitorProbeReserved {
+			releaseWorkerGitHubMonitorProbe(state, issue.ID, "deferred", dispatchSkipWorkerHostUnavailable, now)
 		}
 		return dispatchAction{}, false, dispatchSkipWorkerHostUnavailable
 	}
@@ -402,6 +420,7 @@ func (p dispatchPlanner) markDispatched(state *State, action dispatchAction, now
 		Attempt:           action.attempt,
 		StartedAt:         now,
 		WorkerHost:        action.workerHost,
+		GitHubCredential:  reservedGitHubCredential(state, issue.ID),
 		ModelPermitExempt: !action.modelPermitRequired,
 	}
 	state.Claimed[issue.ID] = Claimed{
@@ -613,6 +632,7 @@ const (
 	dispatchSkipTrackerUnavailable        = scheduler.DecisionReasonTrackerUnavailable
 	dispatchSkipCompletionDeferred        = scheduler.DecisionReasonCompletionDeferred
 	dispatchSkipForgeUnavailable          = scheduler.DecisionReasonForgeUnavailable
+	dispatchSkipGitHubMonitor             = scheduler.DecisionReasonGitHubMonitor
 	dispatchSkipCIUnavailable             = scheduler.DecisionReasonCIUnavailable
 	dispatchSkipProjectFailureBreaker     = scheduler.DecisionReasonProjectFailureBreakerPaused
 	dispatchSkipRateWindowBackpressure    = scheduler.DecisionReasonProviderRateWindowBackpressure
@@ -681,6 +701,9 @@ func (p dispatchPlanner) dispatchableIssueDecisionForModelRequirement(
 	}
 	if forgeAvailabilityBlocks(state, issue, Retry{}, p.cfg.ForgeHost, now) {
 		return dispatchableDecision{reason: dispatchSkipForgeUnavailable}
+	}
+	if workerGitHubMonitorBlocks(state, issue.ID, Retry{}, now) {
+		return dispatchableDecision{reason: dispatchSkipGitHubMonitor}
 	}
 	if activeCIUnavailable(state) && ciDependentDispatch(issue) {
 		return dispatchableDecision{reason: dispatchSkipCIUnavailable}

--- a/internal/orchestrator/lane_revocation.go
+++ b/internal/orchestrator/lane_revocation.go
@@ -228,6 +228,11 @@ func (o *Orchestrator) handleLaneRevocationCompletion(
 	if !ok {
 		return false
 	}
+	completedAt := event.CompletedAt.UTC()
+	if completedAt.IsZero() {
+		completedAt = o.clockNow().UTC()
+	}
+	releaseWorkerGitHubMonitorProbe(state, event.IssueID, "deferred", pending.reason, completedAt)
 	pending.running = running
 	pending.running.Issue = cloneIssue(pending.issue)
 	pending.completion = &event

--- a/internal/orchestrator/run_completion.go
+++ b/internal/orchestrator/run_completion.go
@@ -89,6 +89,7 @@ func (o *Orchestrator) handleRunUpdate(state *State, event runUpdate) {
 	o.trackRunningHeartbeat(state, running, state.Claimed[event.issueID], o.clockNow())
 	if event.usage.RateLimits != nil {
 		state.RateLimits = mergeRateLimits(state.RateLimits, event.usage.RateLimits)
+		o.recoverWorkerGitHubMonitorFromUpdate(state, running, event.usage.RateLimits, event.usage.LastEventAt)
 		o.recoverBackendCapacityFromStatus(state, running, event.usage.RateLimits, event.usage.LastEventAt)
 	}
 	if strings.TrimSpace(event.usage.SessionID) != "" || event.usage.TurnCount > 0 {
@@ -134,15 +135,19 @@ func (o *Orchestrator) handleRunResult(ctx context.Context, state *State, event 
 		beforeRefresh := running
 		refreshed, err := o.refreshCompletionLane(ctx, running)
 		if err != nil {
-			availabilityErr, unavailable := connector.AsTrackerAvailability(err)
-			if unavailable && availabilityErr != nil {
-				o.deferTrackerUnavailableCompletion(ctx, state, event, running, availabilityErr)
-				return
-			} else {
+			if !errors.Is(event.Err, runpkg.ErrWorkerGitHubBudgetMonitor) {
+				availabilityErr, unavailable := connector.AsTrackerAvailability(err)
+				if unavailable && availabilityErr != nil {
+					o.deferTrackerUnavailableCompletion(ctx, state, event, running, availabilityErr)
+					return
+				}
 				o.rejectWorkerCompletion(ctx, state, event, running, laneRevocationCompletionFenceUnavailable, err)
 				o.beginLaneRevocation(ctx, state, running, running.Issue, event.CompletedAt, laneRevocationCompletionFenceUnavailable)
 				o.handleLaneRevocationCompletion(ctx, state, event, running)
 				return
+			}
+			if o.logger != nil {
+				o.logger.Warn("worker GitHub monitor completion lane refresh unavailable; preserving monitor deferral", "issue_id", event.IssueID, "error", err)
 			}
 		} else {
 			receiptAccepted := false
@@ -226,6 +231,9 @@ func (o *Orchestrator) handleRunResult(ctx context.Context, state *State, event 
 		state.RateLimits = mergeRateLimits(state.RateLimits, event.Result.RateLimits)
 	}
 	delete(state.Running, event.IssueID)
+	if o.handleGitHubMonitorCompletion(ctx, state, event, running) {
+		return
+	}
 	o.refreshEfficiencyReceipt(ctx, running.Issue, event.CompletedAt)
 	if o.handleModelPermitDeferred(ctx, state, event, running) {
 		return

--- a/internal/orchestrator/shadow.go
+++ b/internal/orchestrator/shadow.go
@@ -86,6 +86,9 @@ func (s *State) ensureInitialized(cfg Config) {
 	if s.ForgeUnavailable == nil {
 		s.ForgeUnavailable = map[string]ForgeCondition{}
 	}
+	if s.GitHubMonitors == nil {
+		s.GitHubMonitors = map[string]GitHubMonitor{}
+	}
 	if s.DependencyAutoUnblocks == nil {
 		s.DependencyAutoUnblocks = map[string]DependencyAutoUnblockRecord{}
 	}

--- a/internal/orchestrator/snapshot.go
+++ b/internal/orchestrator/snapshot.go
@@ -116,6 +116,7 @@ func (s State) Snapshot(now time.Time) telemetry.Snapshot {
 		RateLimits:              cloneRateLimits(s.RateLimits),
 		TrackerUnavailable:      trackerUnavailableSnapshots(s.TrackerUnavailable),
 		ForgeUnavailable:        forgeUnavailableSnapshots(s.ForgeUnavailable),
+		GitHubMonitors:          workerGitHubMonitorSnapshots(s.GitHubMonitors),
 		CIUnavailable:           ciUnavailableSnapshots(s.CIUnavailable),
 		BackendOutages:          backendOutageSnapshots(s.BackendOutages),
 		FailureBreakers:         projectFailureBreakerSnapshots(s),
@@ -221,6 +222,14 @@ func trackerUnavailableSnapshots(condition *TrackerCondition) []telemetry.Tracke
 
 func forgeUnavailableSnapshots(conditions map[string]ForgeCondition) []telemetry.ForgeCondition {
 	result := make([]telemetry.ForgeCondition, 0, len(conditions))
+	for _, key := range sortedKeys(conditions) {
+		result = append(result, conditions[key])
+	}
+	return result
+}
+
+func workerGitHubMonitorSnapshots(conditions map[string]GitHubMonitor) []telemetry.GitHubMonitor {
+	result := make([]telemetry.GitHubMonitor, 0, len(conditions))
 	for _, key := range sortedKeys(conditions) {
 		result = append(result, conditions[key])
 	}

--- a/internal/orchestrator/state.go
+++ b/internal/orchestrator/state.go
@@ -96,6 +96,7 @@ type State struct {
 	trackerEvidence          map[string]trackerAvailabilityEvidence
 	deferredCompletions      map[string]deferredCompletion
 	ForgeUnavailable         map[string]ForgeCondition
+	GitHubMonitors           map[string]GitHubMonitor
 	CIUnavailable            *CICondition
 	BackendOutages           map[string]BackendOutage
 	BackendRecoveries        map[string]BackendRecovery
@@ -157,6 +158,7 @@ type Running struct {
 	CapacityScope               backendcapacity.Scope
 	CapacityProbe               bool
 	ForgeProbeHost              string
+	GitHubCredential            string
 	ModelPermitExempt           bool
 	CIStopRequested             bool
 	CompletionOwnershipReleased bool
@@ -259,6 +261,8 @@ type Retry struct {
 	ForgeUnavailable   bool
 	ForgeHost          string
 	ForgeRetry         *runpkg.ForgeRetry
+	GitHubMonitor      bool
+	GitHubCredential   string
 	Wait               RetryWait
 }
 
@@ -383,6 +387,7 @@ func newState(cfg Config) State {
 		trackerEvidence:          map[string]trackerAvailabilityEvidence{},
 		deferredCompletions:      map[string]deferredCompletion{},
 		ForgeUnavailable:         map[string]ForgeCondition{},
+		GitHubMonitors:           map[string]GitHubMonitor{},
 		BackendOutages:           map[string]BackendOutage{},
 		BackendRecoveries:        map[string]BackendRecovery{},
 		DiffStats:                map[string]DiffStats{},
@@ -466,6 +471,7 @@ func (s State) clone() State {
 		trackerEvidence:          maps.Clone(s.trackerEvidence),
 		deferredCompletions:      cloneDeferredCompletions(s.deferredCompletions),
 		ForgeUnavailable:         maps.Clone(s.ForgeUnavailable),
+		GitHubMonitors:           maps.Clone(s.GitHubMonitors),
 		CIUnavailable:            cloneCICondition(s.CIUnavailable),
 		BackendOutages:           maps.Clone(s.BackendOutages),
 		BackendRecoveries:        cloneBackendRecoveries(s.BackendRecoveries),

--- a/internal/orchestrator/stop_run.go
+++ b/internal/orchestrator/stop_run.go
@@ -226,6 +226,11 @@ func (o *Orchestrator) handleOperatorStopCompletion(ctx context.Context, state *
 	if !ok {
 		return false
 	}
+	completedAt := event.CompletedAt.UTC()
+	if completedAt.IsZero() {
+		completedAt = o.clockNow().UTC()
+	}
+	releaseWorkerGitHubMonitorProbe(state, event.IssueID, "deferred", "operator stop completion", completedAt)
 	pending.completion = &event
 	pending.running = running
 	if pending.reapErr != nil || !pending.reapDone {

--- a/internal/orchestrator/terminal_attempt_retry.go
+++ b/internal/orchestrator/terminal_attempt_retry.go
@@ -438,7 +438,7 @@ func workAttemptCompletedAfter(left telemetry.WorkAttempt, right telemetry.WorkA
 
 func terminalAttemptRetryableFailure(attempt telemetry.WorkAttempt) bool {
 	errorClass := strings.TrimSpace(attempt.ErrorClass)
-	if errorClass == forgeUnavailableErrorClass || errorClass == workspaceBranchHoldErrorClass {
+	if errorClass == forgeUnavailableErrorClass || errorClass == workspaceBranchHoldErrorClass || errorClass == workerGitHubMonitorErrorClass {
 		return false
 	}
 	if errorClass == githubRESTCapacityError {

--- a/internal/orchestrator/work_attempts.go
+++ b/internal/orchestrator/work_attempts.go
@@ -96,6 +96,7 @@ func (o *Orchestrator) recoverDurableWorkAttempts(ctx context.Context, state *St
 		o.recoverWorkspaceBranchHolds(ctx, state, recent, now)
 		o.recoverForgeAvailabilityWaits(ctx, state, recent, now)
 		o.recoverGitHubRESTCapacityWaits(ctx, state, recent, now)
+		o.recoverWorkerGitHubMonitorWaits(ctx, state, recent, now)
 	}
 	decisions, err := o.workAttempts.ListRecentSchedulerDecisions(ctx, store.SchedulerDecisionQuery{
 		ProjectID: projectID,
@@ -870,6 +871,9 @@ func (o *Orchestrator) capacitySnapshotJSON(state *State, issue connector.Issue)
 	}
 	if state != nil && len(state.ForgeUnavailable) > 0 {
 		snapshot["forge_unavailable"] = forgeUnavailableSnapshots(state.ForgeUnavailable)
+	}
+	if state != nil && len(state.GitHubMonitors) > 0 {
+		snapshot["worker_github_budget_monitor_unavailable"] = workerGitHubMonitorSnapshots(state.GitHubMonitors)
 	}
 	if state != nil && len(state.DispatchRecoveries) > 0 {
 		snapshot["dispatch_recoveries"] = dispatchRecoveriesCapacitySnapshot(state.DispatchRecoveries, pool.Name, pool.Capacity)

--- a/internal/orchestrator/worker_github_monitor.go
+++ b/internal/orchestrator/worker_github_monitor.go
@@ -114,6 +114,11 @@ func (o *Orchestrator) handleGitHubMonitorCompletion(
 	}
 	condition := o.registerGitHubMonitor(state, failure, running, event.CompletedAt)
 	o.finishForgeAvailabilityProbe(state, event, running)
+	if event.Result.TurnStarted {
+		o.recoverBackendCapacity(state, running, condition.LastObservedAt)
+	} else {
+		o.deferBackendCapacityProbe(state, running, condition.LastObservedAt, event.Err)
+	}
 	o.releaseTerminalAttemptClaim(ctx, state, running.Issue, event.CompletedAt)
 	releaseDispatchRecoveryAdmission(state, event.IssueID)
 	o.completeDurableWorkAttemptWithMetadata(

--- a/internal/orchestrator/worker_github_monitor.go
+++ b/internal/orchestrator/worker_github_monitor.go
@@ -1,0 +1,453 @@
+package orchestrator
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log/slog"
+	"strings"
+	"time"
+
+	"github.com/digitaldrywood/detent/internal/connector"
+	runpkg "github.com/digitaldrywood/detent/internal/runner"
+	"github.com/digitaldrywood/detent/internal/store"
+	"github.com/digitaldrywood/detent/internal/telemetry"
+)
+
+const (
+	workerGitHubMonitorErrorClass        = "worker_github_budget_monitor_unavailable"
+	workerGitHubMonitorUnknownCredential = "github-rest:unclassified"
+)
+
+type GitHubMonitor = telemetry.GitHubMonitor
+
+type workerGitHubMonitorFailure struct {
+	CredentialIdentity string
+	Consumer           string
+	Operation          string
+	Message            string
+}
+
+type workerGitHubMonitorWaitMetadata struct {
+	CredentialIdentity string    `json:"credential_identity"`
+	Consumer           string    `json:"consumer"`
+	Operation          string    `json:"operation"`
+	DetectedAt         time.Time `json:"detected_at"`
+	LastObservedAt     time.Time `json:"last_observed_at"`
+	NextProbeAt        time.Time `json:"next_probe_at"`
+	LastProbeAt        time.Time `json:"last_probe_at,omitzero"`
+	LastProbeResult    string    `json:"last_probe_result,omitempty"`
+	LastProbeDetail    string    `json:"last_probe_detail,omitempty"`
+	ProbeAttempts      int       `json:"probe_attempts"`
+}
+
+func workerGitHubMonitorFailureFromCompletion(event runpkg.Completion, state *State) (workerGitHubMonitorFailure, bool) {
+	if !errors.Is(event.Err, runpkg.ErrWorkerGitHubBudgetMonitor) {
+		return workerGitHubMonitorFailure{}, false
+	}
+	failure := workerGitHubMonitorFailure{Message: errorString(event.Err)}
+	if monitorErr, ok := runpkg.AsWorkerGitHubBudgetMonitorError(event.Err); ok {
+		failure.CredentialIdentity = strings.TrimSpace(monitorErr.CredentialIdentity)
+		failure.Consumer = strings.TrimSpace(monitorErr.Consumer)
+		failure.Operation = strings.TrimSpace(monitorErr.Operation)
+	}
+	if failure.CredentialIdentity == "" || failure.Consumer == "" {
+		for _, limits := range []*telemetry.RateLimits{event.Result.RateLimits, rateLimitsFromState(state)} {
+			budget, ok := workerGitHubMonitorBudget(limits)
+			if !ok {
+				continue
+			}
+			if failure.CredentialIdentity == "" {
+				failure.CredentialIdentity = strings.TrimSpace(budget.CredentialIdentity)
+			}
+			if failure.Consumer == "" {
+				failure.Consumer = strings.TrimSpace(budget.Consumer)
+			}
+			break
+		}
+	}
+	if failure.CredentialIdentity == "" {
+		failure.CredentialIdentity = workerGitHubMonitorUnknownCredential
+	}
+	if failure.Consumer != telemetry.RESTConsumerWorker && failure.Consumer != telemetry.RESTConsumerSharedPool {
+		failure.Consumer = telemetry.RESTConsumerWorker
+	}
+	if failure.Operation == "" {
+		failure.Operation = "unknown"
+	}
+	return failure, true
+}
+
+func workerGitHubMonitorBudget(limits *telemetry.RateLimits) (telemetry.RESTBudget, bool) {
+	if limits == nil {
+		return telemetry.RESTBudget{}, false
+	}
+	for _, budget := range limits.GitHubRESTBudgets {
+		consumer := strings.TrimSpace(budget.Consumer)
+		if (consumer == telemetry.RESTConsumerWorker || consumer == telemetry.RESTConsumerSharedPool) && strings.TrimSpace(budget.CredentialIdentity) != "" {
+			return budget, true
+		}
+	}
+	return telemetry.RESTBudget{}, false
+}
+
+func (o *Orchestrator) handleGitHubMonitorCompletion(
+	ctx context.Context,
+	state *State,
+	event runpkg.Completion,
+	running Running,
+) bool {
+	failure, unavailable := workerGitHubMonitorFailureFromCompletion(event, state)
+	if !unavailable {
+		return false
+	}
+	if event.Result.Tokens != (TokenTotals{}) {
+		running.Tokens = event.Result.Tokens
+	}
+	if diffStatsPresent(event.Result.DiffStats) {
+		running.DiffStats = event.Result.DiffStats
+	}
+	state.TokenTotals = addTokenTotals(state.TokenTotals, running.Tokens)
+	if diffStatsPresent(running.DiffStats) {
+		state.DiffStats[event.IssueID] = running.DiffStats
+	}
+	condition := o.registerGitHubMonitor(state, failure, running, event.CompletedAt)
+	o.finishForgeAvailabilityProbe(state, event, running)
+	o.releaseTerminalAttemptClaim(ctx, state, running.Issue, event.CompletedAt)
+	releaseDispatchRecoveryAdmission(state, event.IssueID)
+	o.completeDurableWorkAttemptWithMetadata(
+		ctx,
+		state,
+		running,
+		event.CompletedAt,
+		store.WorkAttemptTerminalCapacity,
+		workerGitHubMonitorErrorClass,
+		failure.Message,
+		"waiting",
+		workerGitHubMonitorStatusMessage(condition),
+		map[string]any{"worker_github_monitor_wait": workerGitHubMonitorMetadata(condition)},
+	)
+	if !workspaceIssueTerminal(running.Issue, o.cfg.TerminalStates) {
+		state.Retry[running.Issue.ID] = Retry{
+			Issue:            cloneIssue(running.Issue),
+			Attempt:          running.Attempt,
+			DueAt:            condition.NextProbeAt,
+			Error:            failure.Message,
+			WorkerHost:       running.WorkerHost,
+			GitHubMonitor:    true,
+			GitHubCredential: condition.CredentialIdentity,
+		}
+	}
+	if state.FailureBreaker.Active() && state.FailureBreaker.CanaryIssueID == running.Issue.ID {
+		o.deferProjectFailureBreakerCanary(state, running.Issue.ID, event.CompletedAt, condition.NextProbeAt.Sub(event.CompletedAt))
+	}
+	recordStateEvent(state, telemetry.ActivityEvent{
+		At:      event.CompletedAt.UTC(),
+		Event:   workerGitHubMonitorErrorClass,
+		Message: "waiting for worker GitHub REST monitor recovery for credential " + condition.CredentialIdentity + " without tripping a failure breaker",
+	})
+	telemetry.LogLifecycleMessage(o.logger, slog.LevelWarn, telemetry.LifecycleSafetyControl, workerGitHubMonitorErrorClass, "worker GitHub REST budget monitor unavailable", o.runningLifecycleCorrelation(running.Issue, running),
+		"credential_identity", condition.CredentialIdentity,
+		"consumer", condition.Consumer,
+		"operation", condition.Operation,
+		"next_probe_at", condition.NextProbeAt,
+		"probe_attempts", condition.ProbeAttempts,
+		"error", event.Err,
+	)
+	return true
+}
+
+func (o *Orchestrator) registerGitHubMonitor(
+	state *State,
+	failure workerGitHubMonitorFailure,
+	running Running,
+	observedAt time.Time,
+) GitHubMonitor {
+	if observedAt.IsZero() {
+		observedAt = o.clockNow()
+	}
+	observedAt = observedAt.UTC()
+	if state.GitHubMonitors == nil {
+		state.GitHubMonitors = map[string]GitHubMonitor{}
+	}
+	key := strings.TrimSpace(failure.CredentialIdentity)
+	condition, exists := state.GitHubMonitors[key]
+	if !exists {
+		condition = GitHubMonitor{
+			ProjectID:          strings.TrimSpace(o.cfg.Project.ID),
+			CredentialIdentity: key,
+			DetectedAt:         observedAt,
+		}
+	}
+	probeFailed := condition.ProbeIssueID == running.Issue.ID
+	condition.Consumer = strings.TrimSpace(failure.Consumer)
+	condition.Operation = strings.TrimSpace(failure.Operation)
+	condition.LastObservedAt = observedAt
+	condition.LastError = strings.TrimSpace(failure.Message)
+	if probeFailed {
+		condition.ProbeIssueID = ""
+		condition.LastProbeAt = observedAt
+		condition.LastProbeResult = "failed"
+		condition.LastProbeDetail = condition.LastError
+	}
+	if !exists || probeFailed || condition.NextProbeAt.IsZero() {
+		condition.NextProbeAt = observedAt.Add(backendCapacityProbeDelayForAttempt(condition.ProbeAttempts)).UTC()
+	}
+	state.GitHubMonitors[key] = condition
+	return condition
+}
+
+func workerGitHubMonitorMetadata(condition GitHubMonitor) workerGitHubMonitorWaitMetadata {
+	return workerGitHubMonitorWaitMetadata{
+		CredentialIdentity: condition.CredentialIdentity,
+		Consumer:           condition.Consumer,
+		Operation:          condition.Operation,
+		DetectedAt:         condition.DetectedAt,
+		LastObservedAt:     condition.LastObservedAt,
+		NextProbeAt:        condition.NextProbeAt,
+		LastProbeAt:        condition.LastProbeAt,
+		LastProbeResult:    condition.LastProbeResult,
+		LastProbeDetail:    condition.LastProbeDetail,
+		ProbeAttempts:      condition.ProbeAttempts,
+	}
+}
+
+func workerGitHubMonitorStatusMessage(condition GitHubMonitor) string {
+	message := "worker GitHub REST budget monitor unavailable for credential " + strings.TrimSpace(condition.CredentialIdentity)
+	if !condition.NextProbeAt.IsZero() {
+		message += "; next canary at " + condition.NextProbeAt.UTC().Format(time.RFC3339)
+	}
+	return message
+}
+
+func workerGitHubMonitorBlocks(state *State, issueID string, retry Retry, now time.Time) bool {
+	if state == nil || len(state.GitHubMonitors) == 0 {
+		return false
+	}
+	if retry.GitHubMonitor {
+		condition, ok := state.GitHubMonitors[strings.TrimSpace(retry.GitHubCredential)]
+		if !ok || condition.ProbeIssueID == issueID {
+			return false
+		}
+		return condition.ProbeIssueID != "" || now.Before(condition.NextProbeAt)
+	}
+	for _, condition := range state.GitHubMonitors {
+		if condition.ProbeIssueID != issueID {
+			return true
+		}
+	}
+	return false
+}
+
+func reserveWorkerGitHubMonitorProbe(state *State, issueID string, retry Retry, now time.Time) (string, bool) {
+	if state == nil || !retry.GitHubMonitor {
+		return "", false
+	}
+	key := strings.TrimSpace(retry.GitHubCredential)
+	condition, ok := state.GitHubMonitors[key]
+	if !ok || condition.ProbeIssueID != "" || now.Before(condition.NextProbeAt) {
+		return "", false
+	}
+	condition.ProbeIssueID = issueID
+	condition.ProbeAttempts++
+	condition.LastProbeAt = now.UTC()
+	condition.LastProbeResult = "in_progress"
+	condition.LastProbeDetail = "worker GitHub REST monitor canary started"
+	condition.NextProbeAt = time.Time{}
+	state.GitHubMonitors[key] = condition
+	return key, true
+}
+
+func releaseWorkerGitHubMonitorProbe(state *State, issueID string, result string, detail string, now time.Time) {
+	if state == nil {
+		return
+	}
+	for key, condition := range state.GitHubMonitors {
+		if condition.ProbeIssueID != issueID {
+			continue
+		}
+		condition.ProbeIssueID = ""
+		condition.LastProbeAt = now.UTC()
+		condition.LastProbeResult = strings.TrimSpace(result)
+		condition.LastProbeDetail = strings.TrimSpace(detail)
+		if condition.NextProbeAt.IsZero() {
+			condition.NextProbeAt = now.Add(backendCapacityProbeDelayForAttempt(condition.ProbeAttempts)).UTC()
+		}
+		state.GitHubMonitors[key] = condition
+	}
+}
+
+func reservedGitHubCredential(state *State, issueID string) string {
+	if state == nil {
+		return ""
+	}
+	for key, condition := range state.GitHubMonitors {
+		if condition.ProbeIssueID == issueID {
+			return key
+		}
+	}
+	return ""
+}
+
+func (o *Orchestrator) recoverWorkerGitHubMonitorFromUpdate(state *State, running Running, limits *telemetry.RateLimits, observedAt time.Time) {
+	credential := strings.TrimSpace(running.GitHubCredential)
+	if state == nil || credential == "" || limits == nil {
+		return
+	}
+	for _, budget := range limits.GitHubRESTBudgets {
+		budgetCredential := strings.TrimSpace(budget.CredentialIdentity)
+		if credential != workerGitHubMonitorUnknownCredential && budgetCredential != credential {
+			continue
+		}
+		if credential == workerGitHubMonitorUnknownCredential && budgetCredential == "" {
+			continue
+		}
+		if budget.ObservedAt != nil && !budget.ObservedAt.IsZero() {
+			observedAt = budget.ObservedAt.UTC()
+		}
+		o.completeWorkerGitHubMonitorRecovery(state, credential, observedAt)
+		return
+	}
+}
+
+func (o *Orchestrator) completeWorkerGitHubMonitorRecovery(state *State, credential string, recoveredAt time.Time) {
+	credential = strings.TrimSpace(credential)
+	condition, ok := state.GitHubMonitors[credential]
+	if !ok {
+		return
+	}
+	if recoveredAt.IsZero() {
+		recoveredAt = o.clockNow()
+	}
+	delete(state.GitHubMonitors, credential)
+	for issueID, retry := range state.Retry {
+		if !retry.GitHubMonitor || strings.TrimSpace(retry.GitHubCredential) != credential {
+			continue
+		}
+		retry.DueAt = recoveredAt.UTC()
+		retry.GitHubMonitor = false
+		state.Retry[issueID] = retry
+	}
+	recordStateEvent(state, telemetry.ActivityEvent{
+		At:      recoveredAt.UTC(),
+		Event:   "worker_github_budget_monitor_recovered",
+		Message: "worker GitHub REST budget monitor recovered for credential " + credential + " via canary",
+	})
+	telemetry.LogLifecycleMessage(o.logger, slog.LevelInfo, telemetry.LifecycleSafetyControl, "worker_github_budget_monitor_recovered", "worker GitHub REST budget monitor recovered", telemetry.LifecycleCorrelation{ProjectID: o.cfg.Project.ID},
+		"credential_identity", credential,
+		"detected_at", condition.DetectedAt,
+		"recovered_at", recoveredAt,
+		"source", "canary",
+	)
+}
+
+func (o *Orchestrator) recoverWorkerGitHubMonitorWaits(ctx context.Context, state *State, attempts []store.WorkAttempt, now time.Time) {
+	if state == nil || len(attempts) == 0 {
+		return
+	}
+	latest := latestStoreTerminalAttemptsByIssue(attempts)
+	waits := make(map[string]workerGitHubMonitorWaitMetadata, len(latest))
+	issueIDs := make([]string, 0, len(latest))
+	for issueID, attempt := range latest {
+		metadata, ok := workerGitHubMonitorWaitMetadataFromAttempt(attempt)
+		if !ok {
+			continue
+		}
+		waits[issueID] = metadata
+		issueIDs = append(issueIDs, issueID)
+	}
+	if len(waits) == 0 {
+		return
+	}
+	issuesByID, validated := o.validateGitHubRESTWaitIssues(ctx, issueIDs)
+	for issueID, metadata := range waits {
+		attempt := latest[issueID]
+		issue := githubRESTWaitIssueFromAttempt(attempt)
+		if validated {
+			var ok bool
+			issue, ok = issuesByID[issueID]
+			if !ok || !stateIn(issue.State, o.cfg.ActiveStates) || workspaceIssueTerminal(issue, o.cfg.TerminalStates) {
+				continue
+			}
+		}
+		o.restoreWorkerGitHubMonitorWait(state, issue, attempt, metadata, now)
+	}
+}
+
+func workerGitHubMonitorWaitMetadataFromAttempt(attempt store.WorkAttempt) (workerGitHubMonitorWaitMetadata, bool) {
+	if attempt.TerminalState != store.WorkAttemptTerminalCapacity || strings.TrimSpace(attempt.ErrorClass) != workerGitHubMonitorErrorClass {
+		return workerGitHubMonitorWaitMetadata{}, false
+	}
+	var metadata struct {
+		Wait workerGitHubMonitorWaitMetadata `json:"worker_github_monitor_wait"`
+	}
+	if json.Unmarshal([]byte(attempt.WorkerMetadataJSON), &metadata) != nil {
+		return workerGitHubMonitorWaitMetadata{}, false
+	}
+	wait := metadata.Wait
+	wait.CredentialIdentity = strings.TrimSpace(wait.CredentialIdentity)
+	wait.Consumer = strings.TrimSpace(wait.Consumer)
+	wait.Operation = strings.TrimSpace(wait.Operation)
+	if wait.CredentialIdentity == "" ||
+		wait.Consumer != telemetry.RESTConsumerWorker && wait.Consumer != telemetry.RESTConsumerSharedPool ||
+		wait.Operation == "" || wait.DetectedAt.IsZero() || wait.LastObservedAt.IsZero() || wait.NextProbeAt.IsZero() || wait.ProbeAttempts < 0 {
+		return workerGitHubMonitorWaitMetadata{}, false
+	}
+	return wait, true
+}
+
+func (o *Orchestrator) restoreWorkerGitHubMonitorWait(
+	state *State,
+	issue connector.Issue,
+	attempt store.WorkAttempt,
+	metadata workerGitHubMonitorWaitMetadata,
+	now time.Time,
+) {
+	if state.GitHubMonitors == nil {
+		state.GitHubMonitors = map[string]GitHubMonitor{}
+	}
+	nextProbeAt := metadata.NextProbeAt.UTC()
+	if nextProbeAt.Before(now) {
+		nextProbeAt = now.UTC()
+	}
+	condition, exists := state.GitHubMonitors[metadata.CredentialIdentity]
+	if !exists {
+		condition = GitHubMonitor{
+			ProjectID:          strings.TrimSpace(o.cfg.Project.ID),
+			CredentialIdentity: metadata.CredentialIdentity,
+			DetectedAt:         metadata.DetectedAt.UTC(),
+		}
+	}
+	if condition.DetectedAt.IsZero() || metadata.DetectedAt.Before(condition.DetectedAt) {
+		condition.DetectedAt = metadata.DetectedAt.UTC()
+	}
+	if condition.LastObservedAt.IsZero() || metadata.LastObservedAt.After(condition.LastObservedAt) {
+		condition.Consumer = metadata.Consumer
+		condition.Operation = metadata.Operation
+		condition.LastObservedAt = metadata.LastObservedAt.UTC()
+		condition.LastError = strings.TrimSpace(attempt.ErrorMessage)
+		condition.LastProbeAt = metadata.LastProbeAt.UTC()
+		condition.LastProbeResult = metadata.LastProbeResult
+		condition.LastProbeDetail = metadata.LastProbeDetail
+	}
+	if condition.NextProbeAt.IsZero() || nextProbeAt.Before(condition.NextProbeAt) {
+		condition.NextProbeAt = nextProbeAt
+	}
+	condition.ProbeAttempts = max(condition.ProbeAttempts, metadata.ProbeAttempts)
+	state.GitHubMonitors[metadata.CredentialIdentity] = condition
+	state.Retry[issue.ID] = Retry{
+		Issue:            cloneIssue(issue),
+		Attempt:          attempt.AttemptNumber,
+		DueAt:            nextProbeAt,
+		Error:            strings.TrimSpace(attempt.ErrorMessage),
+		WorkerHost:       strings.TrimSpace(attempt.WorkerHost),
+		GitHubMonitor:    true,
+		GitHubCredential: metadata.CredentialIdentity,
+	}
+	recordStateEvent(state, telemetry.ActivityEvent{
+		At:      now.UTC(),
+		Event:   "worker_github_budget_monitor_wait_restored",
+		Message: fmt.Sprintf("restored durable worker GitHub REST monitor wait for %s on credential %s", issueLabel(issue), metadata.CredentialIdentity),
+	})
+}

--- a/internal/orchestrator/worker_github_monitor_test.go
+++ b/internal/orchestrator/worker_github_monitor_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/digitaldrywood/detent/internal/backendcapacity"
 	"github.com/digitaldrywood/detent/internal/connector"
 	runpkg "github.com/digitaldrywood/detent/internal/runner"
 	"github.com/digitaldrywood/detent/internal/scheduler"
@@ -354,6 +355,94 @@ func TestWorkerGitHubMonitorDeferredCanaryUsesBoundedBackoff(t *testing.T) {
 	wantNextProbeAt := releasedAt.Add(backendCapacityProbeDelayForAttempt(1))
 	if condition.ProbeIssueID != "" || !condition.NextProbeAt.Equal(wantNextProbeAt) || condition.LastProbeResult != "deferred" {
 		t.Fatalf("released condition = %#v, want bounded canary backoff until %s", condition, wantNextProbeAt)
+	}
+}
+
+func TestWorkerGitHubMonitorCompletionSettlesBackendCapacityCanary(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 8, 29, 0, 0, 0, 0, time.UTC)
+	credential := "github-rest:shared-worker"
+	issue := dispatchTestIssue("issue-capacity-canary", "In Progress")
+	scope := backendcapacity.Scope{BackendID: "codex", BackendKind: "codex", Provider: "openai"}
+	cfg := normalizeConfig(Config{Project: scheduler.ProjectCandidate{ID: "detent"}})
+	orch := &Orchestrator{cfg: cfg, logger: slog.New(slog.NewTextHandler(io.Discard, nil))}
+	state := newState(cfg)
+	state.BackendOutages[scope.Key()] = BackendOutage{
+		Scope: scope, ResumeAt: now.Add(time.Hour), ProbeIssueID: issue.ID, ProbeAttempts: 1,
+	}
+	running := Running{Issue: issue, CapacityScope: scope, CapacityProbe: true}
+	event := runpkg.Completion{
+		IssueID: issue.ID, CompletedAt: now,
+		Err: &runpkg.WorkerGitHubBudgetMonitorError{
+			CredentialIdentity: credential, Consumer: telemetry.RESTConsumerSharedPool,
+			Operation: "launch_probe", Err: errors.New("api.github.com unavailable"),
+		},
+	}
+
+	if handled := orch.handleGitHubMonitorCompletion(t.Context(), &state, event, running); !handled {
+		t.Fatal("handleGitHubMonitorCompletion() handled = false")
+	}
+
+	outage := state.BackendOutages[scope.Key()]
+	if outage.ProbeIssueID != "" || outage.LastProbeResult != "failed" || outage.NextProbeAt.IsZero() {
+		t.Fatalf("backend outage = %#v, want launch canary released and deferred", outage)
+	}
+}
+
+func TestWorkerGitHubMonitorCanaryReleasedByEarlierCompletionHandlers(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 8, 29, 0, 15, 0, 0, time.UTC)
+	credential := "github-rest:shared-worker"
+	issue := dispatchTestIssue("issue-monitor-canary", "In Progress")
+	tests := []struct {
+		name   string
+		setup  func(*Orchestrator)
+		handle func(*Orchestrator, *State, runpkg.Completion, Running) bool
+	}{
+		{
+			name: "operator stop",
+			setup: func(orch *Orchestrator) {
+				orch.pendingStops = map[string]*pendingStopRun{issue.ID: {}}
+			},
+			handle: func(orch *Orchestrator, state *State, event runpkg.Completion, running Running) bool {
+				return orch.handleOperatorStopCompletion(t.Context(), state, event, running)
+			},
+		},
+		{
+			name: "lane revocation",
+			setup: func(orch *Orchestrator) {
+				orch.pendingLaneRevocations = map[string]*pendingLaneRevocation{
+					issue.ID: {issue: issue, reason: laneRevocationStateChanged, reapDone: true},
+				}
+			},
+			handle: func(orch *Orchestrator, state *State, event runpkg.Completion, running Running) bool {
+				return orch.handleLaneRevocationCompletion(t.Context(), state, event, running)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			cfg := normalizeConfig(Config{})
+			orch := &Orchestrator{cfg: cfg, now: func() time.Time { return now }}
+			tt.setup(orch)
+			state := newState(cfg)
+			state.GitHubMonitors[credential] = GitHubMonitor{
+				CredentialIdentity: credential, ProbeIssueID: issue.ID, ProbeAttempts: 1,
+			}
+			if handled := tt.handle(orch, &state, runpkg.Completion{IssueID: issue.ID, CompletedAt: now}, Running{Issue: issue}); !handled {
+				t.Fatal("completion handled = false")
+			}
+			condition := state.GitHubMonitors[credential]
+			wantNextProbeAt := now.Add(backendCapacityProbeDelayForAttempt(1))
+			if condition.ProbeIssueID != "" || condition.LastProbeResult != "deferred" || !condition.NextProbeAt.Equal(wantNextProbeAt) {
+				t.Fatalf("condition = %#v, want canary released until %s", condition, wantNextProbeAt)
+			}
+		})
 	}
 }
 

--- a/internal/orchestrator/worker_github_monitor_test.go
+++ b/internal/orchestrator/worker_github_monitor_test.go
@@ -1,0 +1,481 @@
+package orchestrator
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"log/slog"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/digitaldrywood/detent/internal/connector"
+	runpkg "github.com/digitaldrywood/detent/internal/runner"
+	"github.com/digitaldrywood/detent/internal/scheduler"
+	"github.com/digitaldrywood/detent/internal/store"
+	"github.com/digitaldrywood/detent/internal/telemetry"
+)
+
+func TestWorkerGitHubMonitorCompletionDefersBeforeFailureProcessing(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 8, 28, 20, 0, 0, 0, time.UTC)
+	issue := implementProgressIssueWithoutPR()
+	issue.ID = "issue-worker-github-monitor"
+	issue.Identifier = "digitaldrywood/detent#2028"
+	cfg := normalizeConfig(Config{
+		Project:             scheduler.ProjectCandidate{ID: "detent"},
+		MaxConcurrentAgents: 1,
+		ActiveStates:        []string{"Todo", "In Progress"},
+		TerminalStates:      []string{"Done", "Cancelled"},
+	})
+	attempts := &implementProgressAttemptStore{}
+	orch := &Orchestrator{
+		cfg:          cfg,
+		connector:    &implementProgressConnector{},
+		workAttempts: attempts,
+		logger:       slog.New(slog.NewTextHandler(io.Discard, nil)),
+	}
+	state := newState(cfg)
+	state.Running[issue.ID] = Running{
+		Issue: issue, Attempt: 4, WorkAttemptID: 2028, Mode: runpkg.RunModeImplement,
+		StartedAt: now.Add(-25 * time.Minute), DiffStats: DiffStats{Status: "clean"},
+		Tokens: TokenTotals{InputTokens: 2_000_000, OutputTokens: 1_000_000, TotalTokens: 3_000_000},
+	}
+	state.Claimed[issue.ID] = Claimed{Issue: issue, ClaimedAt: now.Add(-25 * time.Minute)}
+	state.InstantFailures[issue.ID] = InstantFailure{Issue: issue, Count: instantFailureThreshold - 1}
+	state.RepeatedFailures[issue.ID] = RepeatedFailure{Issue: issue, Count: repeatedFailureThreshold - 1}
+	state.FailureBreaker.Failures["existing"] = []ProjectFailure{{IssueID: "other", At: now.Add(-time.Minute)}}
+	instantFailures := map[string]InstantFailure{issue.ID: state.InstantFailures[issue.ID]}
+	repeatedFailures := map[string]RepeatedFailure{issue.ID: state.RepeatedFailures[issue.ID]}
+	failureBreaker := cloneProjectFailureBreaker(state.FailureBreaker)
+
+	monitorErr := &runpkg.WorkerGitHubBudgetMonitorError{
+		CredentialIdentity: "github-rest:shared-worker",
+		Consumer:           telemetry.RESTConsumerSharedPool,
+		Operation:          "periodic_probe",
+		Err:                errors.New("periodic rate-limit probe timed out"),
+	}
+	supervisor, err := runpkg.NewSupervisor(staticWorkerGitHubMonitorBackend{
+		result: runpkg.RunResult{FinalState: runpkg.FinalStateFailed, TurnStarted: true, DiffStats: DiffStats{Status: "clean"}},
+		err:    monitorErr,
+	}, runpkg.SupervisorConfig{Now: func() time.Time { return now }})
+	if err != nil {
+		t.Fatalf("NewSupervisor() error = %v", err)
+	}
+	completion := supervisor.Run(t.Context(), runpkg.RunRequest{Issue: issue, Attempt: 4, Mode: runpkg.RunModeImplement})
+	if completion.Retryable || completion.RetryAttempt != 0 {
+		t.Fatalf("runner completion = %#v, want cooperative monitor stop", completion)
+	}
+	orch.handleRunResult(t.Context(), &state, completion)
+
+	if len(attempts.completions) != 1 || attempts.completions[0].TerminalState != store.WorkAttemptTerminalCapacity {
+		t.Fatalf("completions = %#v, want one capacity wait", attempts.completions)
+	}
+	if attempts.completions[0].ErrorClass != "worker_github_budget_monitor_unavailable" {
+		t.Fatalf("error class = %q, want credential-scoped monitor wait", attempts.completions[0].ErrorClass)
+	}
+	if strings.Contains(attempts.completions[0].WorkerMetadataJSON, "completion_progress") || strings.Contains(attempts.completions[0].ErrorClass, "no_progress") {
+		t.Fatalf("completion = %#v, monitor outage was rewritten by progress processing", attempts.completions[0])
+	}
+	var metrics struct {
+		InputTokens  int64 `json:"input_tokens"`
+		OutputTokens int64 `json:"output_tokens"`
+		TotalTokens  int64 `json:"total_tokens"`
+	}
+	if err := json.Unmarshal([]byte(attempts.completions[0].MetricsJSON), &metrics); err != nil {
+		t.Fatalf("decode metrics: %v", err)
+	}
+	if metrics.InputTokens != 2_000_000 || metrics.OutputTokens != 1_000_000 || metrics.TotalTokens != 3_000_000 {
+		t.Fatalf("metrics = %#v, want actual usage intact", metrics)
+	}
+	if state.TokenTotals.TotalTokens != 3_000_000 {
+		t.Fatalf("aggregate tokens = %#v, want actual attempt usage retained", state.TokenTotals)
+	}
+	if state.DiffStats[issue.ID].Status != "clean" {
+		t.Fatalf("diff stats = %#v, want actual attempt telemetry retained", state.DiffStats[issue.ID])
+	}
+	condition, ok := state.GitHubMonitors[monitorErr.CredentialIdentity]
+	if !ok || condition.Consumer != monitorErr.Consumer || condition.Operation != monitorErr.Operation || !condition.NextProbeAt.Equal(now.Add(5*time.Minute)) {
+		t.Fatalf("monitor condition = %#v, want one shared credential wait", condition)
+	}
+	snapshot := state.Snapshot(now)
+	if len(snapshot.GitHubMonitors) != 1 || snapshot.GitHubMonitors[0].CredentialIdentity != monitorErr.CredentialIdentity {
+		t.Fatalf("snapshot monitor conditions = %#v, want visible credential wait", snapshot.GitHubMonitors)
+	}
+	retry, ok := state.Retry[issue.ID]
+	if !ok || retry.Attempt != 4 || !retry.DueAt.Equal(condition.NextProbeAt) || !retry.GitHubMonitor || retry.GitHubCredential != monitorErr.CredentialIdentity {
+		t.Fatalf("retry = %#v, want same-attempt monitor canary wait", retry)
+	}
+	if !reflect.DeepEqual(state.InstantFailures, instantFailures) {
+		t.Fatalf("instant failures = %#v, want unchanged", state.InstantFailures)
+	}
+	if !reflect.DeepEqual(state.RepeatedFailures, repeatedFailures) {
+		t.Fatalf("repeated failures = %#v, want unchanged", state.RepeatedFailures)
+	}
+	if !reflect.DeepEqual(state.FailureBreaker, failureBreaker) {
+		t.Fatalf("project failure breaker = %#v, want unchanged", state.FailureBreaker)
+	}
+	if _, blocked := state.Blocked[issue.ID]; blocked {
+		t.Fatalf("issue %q was blocked by machine-recoverable monitor outage", issue.ID)
+	}
+}
+
+func TestConcurrentWorkerGitHubMonitorCompletionsShareCredentialCondition(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 8, 28, 21, 0, 0, 0, time.UTC)
+	cfg := normalizeConfig(Config{
+		Project:             scheduler.ProjectCandidate{ID: "detent"},
+		MaxConcurrentAgents: 7,
+		ActiveStates:        []string{"Todo", "In Progress"},
+		TerminalStates:      []string{"Done", "Cancelled"},
+	})
+	attempts := &implementProgressAttemptStore{}
+	orch := &Orchestrator{
+		cfg:          cfg,
+		connector:    &implementProgressConnector{},
+		workAttempts: attempts,
+		logger:       slog.New(slog.NewTextHandler(io.Discard, nil)),
+	}
+	state := newState(cfg)
+	state.FailureBreaker.Failures["existing"] = []ProjectFailure{{IssueID: "other", At: now.Add(-time.Minute)}}
+	issues := []connector.Issue{
+		{ID: "issue-launch", Identifier: "digitaldrywood/detent#2028", State: "In Progress"},
+		{ID: "issue-periodic", Identifier: "digitaldrywood/detent#2029", State: "In Progress"},
+	}
+	operations := []string{"launch_probe", "periodic_probe"}
+	for index, issue := range issues {
+		state.Running[issue.ID] = Running{
+			Issue: issue, Attempt: index + 2, WorkAttemptID: int64(300 + index), Mode: runpkg.RunModeImplement,
+			StartedAt: now.Add(-25 * time.Minute), Tokens: TokenTotals{TotalTokens: 1},
+		}
+		state.Claimed[issue.ID] = Claimed{Issue: issue, ClaimedAt: now.Add(-25 * time.Minute)}
+		state.InstantFailures[issue.ID] = InstantFailure{Issue: issue, Count: instantFailureThreshold - 1}
+		state.RepeatedFailures[issue.ID] = RepeatedFailure{Issue: issue, Count: repeatedFailureThreshold - 1}
+		orch.handleRunResult(t.Context(), &state, runpkg.Completion{
+			IssueID: issue.ID, CompletedAt: now.Add(time.Duration(index) * time.Second),
+			Request: runpkg.RunRequest{Issue: issue, Attempt: index + 2, Mode: runpkg.RunModeImplement},
+			Result: runpkg.RunResult{
+				FinalState:  runpkg.FinalStateFailed,
+				TurnStarted: true,
+				Tokens:      TokenTotals{InputTokens: int64(index+1) * 1_000_000, TotalTokens: int64(index+1) * 1_000_000},
+			},
+			Err: &runpkg.WorkerGitHubBudgetMonitorError{
+				CredentialIdentity: "github-rest:shared-worker",
+				Consumer:           telemetry.RESTConsumerSharedPool,
+				Operation:          operations[index],
+				Err:                errors.New("api.github.com unavailable"),
+			},
+		})
+	}
+
+	if len(state.GitHubMonitors) != 1 {
+		t.Fatalf("monitor conditions = %#v, want one credential-scoped condition", state.GitHubMonitors)
+	}
+	condition := state.GitHubMonitors["github-rest:shared-worker"]
+	if !condition.NextProbeAt.Equal(now.Add(5 * time.Minute)) {
+		t.Fatalf("NextProbeAt = %s, want first outage backoff preserved", condition.NextProbeAt)
+	}
+	if len(state.Retry) != len(issues) || len(attempts.completions) != len(issues) {
+		t.Fatalf("retries = %#v completions = %#v, want one durable same-attempt wait per worker", state.Retry, attempts.completions)
+	}
+	for index, issue := range issues {
+		retry := state.Retry[issue.ID]
+		if retry.Attempt != index+2 || !retry.DueAt.Equal(condition.NextProbeAt) || retry.GitHubCredential != condition.CredentialIdentity {
+			t.Fatalf("Retry[%q] = %#v, want shared recovery condition", issue.ID, retry)
+		}
+		if attempts.completions[index].TerminalState != store.WorkAttemptTerminalCapacity || strings.Contains(attempts.completions[index].WorkerMetadataJSON, "completion_progress") {
+			t.Fatalf("completion[%d] = %#v, want capacity without progress rewrite", index, attempts.completions[index])
+		}
+		if state.InstantFailures[issue.ID].Count != instantFailureThreshold-1 || state.RepeatedFailures[issue.ID].Count != repeatedFailureThreshold-1 {
+			t.Fatalf("failure brakes changed for %q: instant=%#v repeated=%#v", issue.ID, state.InstantFailures[issue.ID], state.RepeatedFailures[issue.ID])
+		}
+	}
+	if len(state.FailureBreaker.Failures["existing"]) != 1 || state.FailureBreaker.Active() {
+		t.Fatalf("project failure breaker = %#v, want unchanged", state.FailureBreaker)
+	}
+	if state.TokenTotals.TotalTokens != 3_000_000 {
+		t.Fatalf("aggregate tokens = %#v, want both attempts retained", state.TokenTotals)
+	}
+}
+
+func TestRecoverDurableWorkerGitHubMonitorWaits(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 8, 28, 22, 0, 0, 0, time.UTC)
+	nextProbeAt := now.Add(3 * time.Minute)
+	issues := []connector.Issue{
+		{ID: "issue-restart-a", Identifier: "digitaldrywood/detent#2028", State: "In Progress"},
+		{ID: "issue-restart-b", Identifier: "digitaldrywood/detent#2029", State: "In Progress"},
+	}
+	metadata := func(operation string, observedAt time.Time) string {
+		return marshalWorkAttemptJSON(map[string]any{
+			"worker_github_monitor_wait": workerGitHubMonitorWaitMetadata{
+				CredentialIdentity: "github-rest:shared-worker",
+				Consumer:           telemetry.RESTConsumerSharedPool,
+				Operation:          operation,
+				DetectedAt:         now.Add(-2 * time.Minute),
+				LastObservedAt:     observedAt,
+				NextProbeAt:        nextProbeAt,
+				ProbeAttempts:      1,
+			},
+		})
+	}
+	attempts := &recordingWorkAttemptStore{recent: []store.WorkAttempt{
+		{
+			ID: 402, ProjectID: "detent", IssueID: issues[1].ID, Identifier: issues[1].Identifier, Lane: issues[1].State,
+			AttemptNumber: 3, Status: store.WorkAttemptStatusTerminal, CompletedAt: now.Add(-time.Minute),
+			TerminalState: store.WorkAttemptTerminalCapacity, ErrorClass: workerGitHubMonitorErrorClass,
+			ErrorMessage: "periodic probe unavailable", WorkerMetadataJSON: metadata("periodic_probe", now.Add(-time.Minute)),
+		},
+		{
+			ID: 401, ProjectID: "detent", IssueID: issues[0].ID, Identifier: issues[0].Identifier, Lane: issues[0].State,
+			AttemptNumber: 2, Status: store.WorkAttemptStatusTerminal, CompletedAt: now.Add(-90 * time.Second),
+			TerminalState: store.WorkAttemptTerminalCapacity, ErrorClass: workerGitHubMonitorErrorClass,
+			ErrorMessage: "launch probe unavailable", WorkerMetadataJSON: metadata("launch_probe", now.Add(-90*time.Second)),
+		},
+	}}
+	cfg := normalizeConfig(Config{
+		Project: scheduler.ProjectCandidate{ID: "detent"}, ActiveStates: []string{"Todo", "In Progress"},
+		TerminalStates: []string{"Done", "Cancelled"}, MaxConcurrentAgents: 2,
+	})
+	orch := &Orchestrator{
+		cfg: cfg, connector: &rateLimitConnector{issuesByID: issues}, workAttempts: attempts,
+		logger: slog.New(slog.NewTextHandler(io.Discard, nil)), now: func() time.Time { return now },
+	}
+	state := newState(cfg)
+
+	orch.recoverDurableWorkAttempts(t.Context(), &state, now)
+
+	if len(state.GitHubMonitors) != 1 || len(state.Retry) != 2 {
+		t.Fatalf("conditions = %#v retries = %#v, want one condition and both issue waits", state.GitHubMonitors, state.Retry)
+	}
+	condition := state.GitHubMonitors["github-rest:shared-worker"]
+	if !condition.NextProbeAt.Equal(nextProbeAt) || condition.ProbeAttempts != 1 || condition.Operation != "periodic_probe" {
+		t.Fatalf("restored condition = %#v, want latest observation and bounded probe state", condition)
+	}
+	for _, issue := range issues {
+		retry := state.Retry[issue.ID]
+		if !retry.GitHubMonitor || retry.GitHubCredential != condition.CredentialIdentity || !retry.DueAt.Equal(nextProbeAt) {
+			t.Fatalf("Retry[%q] = %#v, want restored credential wait", issue.ID, retry)
+		}
+	}
+	if terminalAttemptRetryableFailure(telemetryWorkAttempt(attempts.recent[0], now)) {
+		t.Fatal("durable worker GitHub monitor wait treated as generic terminal retry")
+	}
+}
+
+func TestWorkerGitHubMonitorAllowsOneCanaryAndRecoversCredential(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 8, 28, 23, 0, 0, 0, time.UTC)
+	cfg := normalizeConfig(Config{
+		Project: scheduler.ProjectCandidate{ID: "detent"}, ActiveStates: []string{"In Progress"},
+		TerminalStates: []string{"Done", "Cancelled"}, MaxConcurrentAgents: 2,
+	})
+	issues := []connector.Issue{
+		dispatchTestIssue("issue-canary-a", "In Progress"),
+		dispatchTestIssue("issue-canary-b", "In Progress"),
+	}
+	state := newState(cfg)
+	credential := "github-rest:shared-worker"
+	state.GitHubMonitors[credential] = GitHubMonitor{
+		ProjectID: "detent", CredentialIdentity: credential, Consumer: telemetry.RESTConsumerSharedPool,
+		Operation: "periodic_probe", DetectedAt: now.Add(-5 * time.Minute), LastObservedAt: now.Add(-5 * time.Minute), NextProbeAt: now,
+	}
+	for index, issue := range issues {
+		state.Retry[issue.ID] = Retry{
+			Issue: issue, Attempt: index + 2, DueAt: now,
+			GitHubMonitor: true, GitHubCredential: credential,
+		}
+	}
+	plan := newDispatchPlanner(cfg).plan(&state, issues, now, dispatchPlanHooks{})
+
+	if len(plan.Dispatches) != 1 {
+		t.Fatalf("dispatches = %#v, want exactly one credential canary", plan.Dispatches)
+	}
+	owner := plan.Dispatches[0].IssueID
+	condition := state.GitHubMonitors[credential]
+	if condition.ProbeIssueID != owner || condition.ProbeAttempts != 1 || condition.LastProbeResult != "in_progress" {
+		t.Fatalf("condition = %#v, want single canary owner", condition)
+	}
+	running := state.Running[owner]
+	if running.GitHubCredential != credential {
+		t.Fatalf("Running[%q] = %#v, want canary credential ownership", owner, running)
+	}
+	recoveredAt := now.Add(time.Second)
+	orch := &Orchestrator{cfg: cfg, logger: slog.New(slog.NewTextHandler(io.Discard, nil)), now: func() time.Time { return recoveredAt }}
+	orch.handleRunUpdate(&state, runUpdate{
+		issueID: owner,
+		usage: runpkg.UsageUpdate{
+			LastEventAt: recoveredAt,
+			RateLimits: &telemetry.RateLimits{GitHubRESTBudgets: []telemetry.RESTBudget{{
+				Consumer: telemetry.RESTConsumerSharedPool, CredentialIdentity: credential, Remaining: 4200,
+			}}},
+		},
+	})
+
+	if _, ok := state.GitHubMonitors[credential]; ok {
+		t.Fatalf("condition %q remained after successful canary observation", credential)
+	}
+	for issueID, retry := range state.Retry {
+		if retry.GitHubMonitor || !retry.DueAt.Equal(recoveredAt) {
+			t.Fatalf("Retry[%q] = %#v, want released immediately after recovery", issueID, retry)
+		}
+	}
+}
+
+func TestWorkerGitHubMonitorDeferredCanaryUsesBoundedBackoff(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 8, 28, 23, 10, 0, 0, time.UTC)
+	credential := "github-rest:shared-worker"
+	issueID := "issue-canary"
+	state := newState(normalizeConfig(Config{}))
+	state.GitHubMonitors[credential] = GitHubMonitor{
+		CredentialIdentity: credential,
+		NextProbeAt:        now,
+	}
+	retry := Retry{GitHubMonitor: true, GitHubCredential: credential}
+
+	if _, reserved := reserveWorkerGitHubMonitorProbe(&state, issueID, retry, now); !reserved {
+		t.Fatal("monitor canary was not reserved")
+	}
+	condition := state.GitHubMonitors[credential]
+	if !condition.NextProbeAt.IsZero() || condition.ProbeAttempts != 1 {
+		t.Fatalf("reserved condition = %#v, want in-flight probe without a due time", condition)
+	}
+	releasedAt := now.Add(time.Second)
+	releaseWorkerGitHubMonitorProbe(&state, issueID, "deferred", "worker unavailable", releasedAt)
+	condition = state.GitHubMonitors[credential]
+	wantNextProbeAt := releasedAt.Add(backendCapacityProbeDelayForAttempt(1))
+	if condition.ProbeIssueID != "" || !condition.NextProbeAt.Equal(wantNextProbeAt) || condition.LastProbeResult != "deferred" {
+		t.Fatalf("released condition = %#v, want bounded canary backoff until %s", condition, wantNextProbeAt)
+	}
+}
+
+func TestWorkerGitHubMonitorRawSentinelUsesRecoverableFallbackScope(t *testing.T) {
+	t.Parallel()
+
+	failure, ok := workerGitHubMonitorFailureFromCompletion(runpkg.Completion{
+		Err: errors.Join(errors.New("probe failed"), runpkg.ErrWorkerGitHubBudgetMonitor),
+	}, nil)
+	if !ok {
+		t.Fatal("raw worker GitHub monitor sentinel was not intercepted")
+	}
+	if failure.CredentialIdentity != workerGitHubMonitorUnknownCredential || failure.Consumer != telemetry.RESTConsumerWorker || failure.Operation != "unknown" {
+		t.Fatalf("fallback failure = %#v, want recoverable unclassified scope", failure)
+	}
+}
+
+func TestWorkerGitHubMonitorCanaryRecoversUnclassifiedCredential(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 8, 28, 23, 15, 0, 0, time.UTC)
+	cfg := normalizeConfig(Config{Project: scheduler.ProjectCandidate{ID: "detent"}, MaxConcurrentAgents: 1})
+	state := newState(cfg)
+	state.GitHubMonitors[workerGitHubMonitorUnknownCredential] = GitHubMonitor{
+		ProjectID: "detent", CredentialIdentity: workerGitHubMonitorUnknownCredential,
+		Consumer: telemetry.RESTConsumerWorker, DetectedAt: now.Add(-time.Minute), LastObservedAt: now.Add(-time.Minute), NextProbeAt: now,
+	}
+	issue := dispatchTestIssue("issue-unclassified", "In Progress")
+	state.Running[issue.ID] = Running{Issue: issue, GitHubCredential: workerGitHubMonitorUnknownCredential}
+	orch := &Orchestrator{cfg: cfg, logger: slog.New(slog.NewTextHandler(io.Discard, nil))}
+	orch.handleRunUpdate(&state, runUpdate{
+		issueID: issue.ID,
+		usage: runpkg.UsageUpdate{
+			LastEventAt: now,
+			RateLimits: &telemetry.RateLimits{GitHubRESTBudgets: []telemetry.RESTBudget{{
+				Consumer: telemetry.RESTConsumerWorker, CredentialIdentity: "github-rest:classified", Remaining: 4200,
+			}}},
+		},
+	})
+
+	if _, ok := state.GitHubMonitors[workerGitHubMonitorUnknownCredential]; ok {
+		t.Fatal("unclassified credential condition remained after its canary published a scoped observation")
+	}
+}
+
+func TestWorkerGitHubMonitorCompletionSurvivesLaneRefreshFailure(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 8, 28, 23, 30, 0, 0, time.UTC)
+	issue := connector.Issue{ID: "issue-fence", Identifier: "digitaldrywood/detent#2028", State: "In Progress"}
+	cfg := normalizeConfig(Config{
+		Project: scheduler.ProjectCandidate{ID: "detent"}, ActiveStates: []string{"In Progress"},
+		TerminalStates: []string{"Done"}, MaxConcurrentAgents: 1,
+	})
+	attempts := &implementProgressAttemptStore{}
+	orch := &Orchestrator{
+		cfg: cfg, connector: &rateLimitConnector{fetchByIDErr: errors.New("tracker path unavailable")}, workAttempts: attempts,
+		logger: slog.New(slog.NewTextHandler(io.Discard, nil)),
+	}
+	state := newState(cfg)
+	state.Running[issue.ID] = Running{Issue: issue, Attempt: 2, WorkAttemptID: 500, Generation: 9, StartedAt: now.Add(-time.Minute)}
+	state.Claimed[issue.ID] = Claimed{Issue: issue, ClaimedAt: now.Add(-time.Minute)}
+	orch.handleRunResult(t.Context(), &state, runpkg.Completion{
+		IssueID: issue.ID, CompletedAt: now,
+		Request: runpkg.RunRequest{Issue: issue, Attempt: 2, WorkAttemptID: 500, Generation: 9},
+		Err: &runpkg.WorkerGitHubBudgetMonitorError{
+			CredentialIdentity: "github-rest:worker", Consumer: telemetry.RESTConsumerWorker,
+			Operation: "periodic_probe", Err: errors.New("DNS unavailable"),
+		},
+	})
+
+	if len(attempts.completions) != 1 || attempts.completions[0].ErrorClass != workerGitHubMonitorErrorClass {
+		t.Fatalf("completions = %#v, want monitor deferral despite completion-fence outage", attempts.completions)
+	}
+	if len(state.GitHubMonitors) != 1 || len(state.Retry) != 1 {
+		t.Fatalf("conditions = %#v retries = %#v, want durable monitor wait", state.GitHubMonitors, state.Retry)
+	}
+}
+
+func TestWorkerGitHubMonitorWaitMetadataValidation(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 8, 28, 23, 45, 0, 0, time.UTC)
+	valid := workerGitHubMonitorWaitMetadata{
+		CredentialIdentity: "github-rest:worker", Consumer: telemetry.RESTConsumerWorker, Operation: "periodic_probe",
+		DetectedAt: now.Add(-time.Minute), LastObservedAt: now.Add(-time.Minute), NextProbeAt: now,
+	}
+	attempt := func(wait workerGitHubMonitorWaitMetadata) store.WorkAttempt {
+		return store.WorkAttempt{
+			TerminalState: store.WorkAttemptTerminalCapacity, ErrorClass: workerGitHubMonitorErrorClass,
+			WorkerMetadataJSON: marshalWorkAttemptJSON(map[string]any{"worker_github_monitor_wait": wait}),
+		}
+	}
+	tests := []struct {
+		name    string
+		attempt store.WorkAttempt
+		want    bool
+	}{
+		{name: "valid", attempt: attempt(valid), want: true},
+		{name: "malformed", attempt: store.WorkAttempt{TerminalState: store.WorkAttemptTerminalCapacity, ErrorClass: workerGitHubMonitorErrorClass, WorkerMetadataJSON: `{`}},
+		{name: "ordinary failure", attempt: store.WorkAttempt{TerminalState: store.WorkAttemptTerminalFailure, ErrorClass: workerGitHubMonitorErrorClass, WorkerMetadataJSON: attempt(valid).WorkerMetadataJSON}},
+		{name: "missing credential", attempt: attempt(workerGitHubMonitorWaitMetadata{Consumer: valid.Consumer, Operation: valid.Operation, DetectedAt: valid.DetectedAt, LastObservedAt: valid.LastObservedAt, NextProbeAt: valid.NextProbeAt})},
+		{name: "missing probe time", attempt: attempt(workerGitHubMonitorWaitMetadata{CredentialIdentity: valid.CredentialIdentity, Consumer: valid.Consumer, Operation: valid.Operation, DetectedAt: valid.DetectedAt, LastObservedAt: valid.LastObservedAt})},
+		{name: "negative attempts", attempt: attempt(workerGitHubMonitorWaitMetadata{CredentialIdentity: valid.CredentialIdentity, Consumer: valid.Consumer, Operation: valid.Operation, DetectedAt: valid.DetectedAt, LastObservedAt: valid.LastObservedAt, NextProbeAt: valid.NextProbeAt, ProbeAttempts: -1})},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			_, got := workerGitHubMonitorWaitMetadataFromAttempt(tt.attempt)
+			if got != tt.want {
+				t.Fatalf("workerGitHubMonitorWaitMetadataFromAttempt() valid = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+type staticWorkerGitHubMonitorBackend struct {
+	result runpkg.RunResult
+	err    error
+}
+
+func (b staticWorkerGitHubMonitorBackend) Run(context.Context, runpkg.RunRequest) (runpkg.RunResult, error) {
+	return b.result, b.err
+}

--- a/internal/runner/supervisor.go
+++ b/internal/runner/supervisor.go
@@ -258,6 +258,7 @@ func cooperativeStopError(err error) bool {
 		errors.Is(err, ErrSessionMemoryCeilingExceeded) ||
 		errors.Is(err, ErrSessionTurnLimitExceeded) ||
 		errors.Is(err, ErrSessionNoProgress) ||
+		errors.Is(err, ErrWorkerGitHubBudgetMonitor) ||
 		IsDeliverableConfigurationError(err)
 }
 

--- a/internal/runner/worker_github.go
+++ b/internal/runner/worker_github.go
@@ -85,6 +85,48 @@ type workerGitHubBudget struct {
 	ObservedAt time.Time
 }
 
+type WorkerGitHubBudgetMonitorError struct {
+	CredentialIdentity string
+	Consumer           string
+	Operation          string
+	Err                error
+}
+
+func (e *WorkerGitHubBudgetMonitorError) Error() string {
+	if e == nil {
+		return ErrWorkerGitHubBudgetMonitor.Error()
+	}
+	message := ErrWorkerGitHubBudgetMonitor.Error()
+	if operation := strings.TrimSpace(e.Operation); operation != "" {
+		message += ": operation=" + operation
+	}
+	if consumer := strings.TrimSpace(e.Consumer); consumer != "" {
+		message += " consumer=" + consumer
+	}
+	if credential := strings.TrimSpace(e.CredentialIdentity); credential != "" {
+		message += " credential_identity=" + credential
+	}
+	if e.Err != nil {
+		message += ": " + e.Err.Error()
+	}
+	return message
+}
+
+func (e *WorkerGitHubBudgetMonitorError) Unwrap() []error {
+	if e == nil || e.Err == nil {
+		return []error{ErrWorkerGitHubBudgetMonitor}
+	}
+	return []error{ErrWorkerGitHubBudgetMonitor, e.Err}
+}
+
+func AsWorkerGitHubBudgetMonitorError(err error) (*WorkerGitHubBudgetMonitorError, bool) {
+	var monitorErr *WorkerGitHubBudgetMonitorError
+	if !errors.As(err, &monitorErr) || monitorErr == nil {
+		return nil, false
+	}
+	return monitorErr, true
+}
+
 func (r *Runner) workerGitHubPolicy(ctx context.Context, cfg config.Config, issueIdentifier string) (workerGitHubPolicy, error) {
 	policy, err := newWorkerGitHubPolicy(ctx, cfg, r.projectID, issueIdentifier, r.lookupEnv, nil, nil, r.logger)
 	if err != nil {
@@ -104,7 +146,7 @@ func (r *Runner) ProbeGitHubRESTBudget(ctx context.Context, issue connector.Issu
 	}
 	budget, err := policy.probe(ctx)
 	if err != nil {
-		return telemetry.RESTBudget{}, true, err
+		return telemetry.RESTBudget{}, true, policy.monitorError("recovery_probe", err)
 	}
 	return policy.restBudget(budget), true, nil
 }
@@ -378,10 +420,10 @@ func startWorkerGitHubGovernor(ctx context.Context, policy workerGitHubPolicy, o
 	policy = classified
 	budget, err := policy.probe(ctx)
 	if err != nil {
-		return ctx, func() error { return nil }, fmt.Errorf("%w: %w", ErrWorkerGitHubBudgetMonitor, err)
+		return ctx, func() error { return nil }, policy.monitorError("launch_probe", err)
 	}
 	if err := policy.observe(budget, onUpdate); err != nil {
-		return ctx, func() error { return nil }, err
+		return ctx, func() error { return nil }, policy.monitorError("launch_observation", err)
 	}
 	if err := policy.reserveError(budget); err != nil {
 		return ctx, func() error { return nil }, err
@@ -410,11 +452,11 @@ func startWorkerGitHubGovernor(ctx context.Context, policy workerGitHubPolicy, o
 			case <-poll:
 				budget, probeErr := policy.probe(governedCtx)
 				if probeErr != nil {
-					cancel(fmt.Errorf("%w: %w", ErrWorkerGitHubBudgetMonitor, probeErr))
+					cancel(policy.monitorError("periodic_probe", probeErr))
 					return
 				}
 				if observeErr := policy.observe(budget, onUpdate); observeErr != nil {
-					cancel(fmt.Errorf("%w: publish worker github budget: %w", ErrWorkerGitHubBudgetMonitor, observeErr))
+					cancel(policy.monitorError("periodic_observation", observeErr))
 					return
 				}
 				if reserveErr := policy.reserveError(budget); reserveErr != nil {
@@ -448,7 +490,7 @@ func (p workerGitHubPolicy) classifyCredential(ctx context.Context) (workerGitHu
 	if p.PrincipalID <= 0 || strings.TrimSpace(p.Principal.Login) == "" {
 		principalID, principal, err := p.authenticatedPrincipal(ctx, p.Token)
 		if err != nil {
-			return workerGitHubPolicy{}, fmt.Errorf("%w: verify worker credential principal: %w", ErrWorkerGitHubBudgetMonitor, err)
+			return workerGitHubPolicy{}, p.monitorError("credential_classification_worker", err)
 		}
 		p.PrincipalID = principalID
 		p.Principal = principal
@@ -459,7 +501,7 @@ func (p workerGitHubPolicy) classifyCredential(ctx context.Context) (workerGitHu
 	if p.CredentialMode == workerGitHubCredentialUnclassified {
 		orchestratorID, _, err := p.authenticatedPrincipal(ctx, p.OrchestratorToken)
 		if err != nil {
-			return workerGitHubPolicy{}, fmt.Errorf("%w: verify orchestrator credential principal: %w", ErrWorkerGitHubBudgetMonitor, err)
+			return workerGitHubPolicy{}, p.monitorError("credential_classification_orchestrator", err)
 		}
 		if p.PrincipalID == orchestratorID {
 			p.CredentialMode = workerGitHubCredentialShared
@@ -676,4 +718,13 @@ func (p workerGitHubPolicy) budgetConsumer() string {
 		return telemetry.RESTConsumerSharedPool
 	}
 	return telemetry.RESTConsumerWorker
+}
+
+func (p workerGitHubPolicy) monitorError(operation string, err error) error {
+	return &WorkerGitHubBudgetMonitorError{
+		CredentialIdentity: strings.TrimSpace(p.CredentialIdentity),
+		Consumer:           p.budgetConsumer(),
+		Operation:          strings.TrimSpace(operation),
+		Err:                err,
+	}
 }

--- a/internal/runner/worker_github_test.go
+++ b/internal/runner/worker_github_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
@@ -17,6 +18,7 @@ import (
 	"time"
 
 	"github.com/digitaldrywood/detent/internal/config"
+	"github.com/digitaldrywood/detent/internal/connector"
 	"github.com/digitaldrywood/detent/internal/procgroup"
 	"github.com/digitaldrywood/detent/internal/telemetry"
 )
@@ -443,10 +445,12 @@ func TestWorkerGitHubGovernorBoundsStalledProbe(t *testing.T) {
 	requestStarted := make(chan struct{}, 1)
 	cancelProbe := make(chan context.CancelFunc, 1)
 	policy := workerGitHubPolicy{
-		Enabled:      true,
-		Token:        "worker-token",
-		GraphQLURL:   "https://api.github.test/graphql",
-		RateLimitURL: "https://api.github.test/rate_limit",
+		Enabled:            true,
+		CredentialMode:     workerGitHubCredentialDistinct,
+		Token:              "worker-token",
+		CredentialIdentity: "github-rest:worker",
+		GraphQLURL:         "https://api.github.test/graphql",
+		RateLimitURL:       "https://api.github.test/rate_limit",
 		HTTPClient: workerGitHubHTTPClientFunc(func(request *http.Request) (*http.Response, error) {
 			requestStarted <- struct{}{}
 			<-request.Context().Done()
@@ -458,6 +462,7 @@ func TestWorkerGitHubGovernorBoundsStalledProbe(t *testing.T) {
 			return probeCtx, cancel
 		},
 	}
+	preclassifyWorkerGitHubPolicy(&policy)
 	result := make(chan error, 1)
 	go func() {
 		_, _, err := startWorkerGitHubGovernor(context.Background(), policy, nil)
@@ -481,8 +486,192 @@ func TestWorkerGitHubGovernorBoundsStalledProbe(t *testing.T) {
 		if !errors.Is(err, ErrWorkerGitHubBudgetMonitor) || !errors.Is(err, context.Canceled) {
 			t.Fatalf("startWorkerGitHubGovernor() error = %v, want bounded canceled probe", err)
 		}
+		monitorErr, ok := AsWorkerGitHubBudgetMonitorError(err)
+		if !ok || monitorErr.Operation != "launch_probe" || monitorErr.CredentialIdentity == "" {
+			t.Fatalf("monitor error = %#v, want credential-scoped launch probe", monitorErr)
+		}
 	case <-time.After(2 * time.Second):
 		t.Fatal("governor did not return after the probe context was canceled")
+	}
+}
+
+func TestWorkerGitHubMonitorErrorsCarryCredentialScope(t *testing.T) {
+	t.Parallel()
+
+	transportErr := errors.New("github transport unavailable")
+	server := workerGitHubRateLimitServer(t, func(int64) int64 { return 4200 })
+	t.Cleanup(server.Close)
+	tests := []struct {
+		name          string
+		wantOperation string
+		run           func() error
+	}{
+		{
+			name:          "launch probe",
+			wantOperation: "launch_probe",
+			run: func() error {
+				policy := workerGitHubTestPolicy(server, new(bytes.Buffer))
+				preclassifyWorkerGitHubPolicy(&policy)
+				policy.HTTPClient = workerGitHubHTTPClientFunc(func(*http.Request) (*http.Response, error) {
+					return nil, transportErr
+				})
+				_, _, err := startWorkerGitHubGovernor(t.Context(), policy, nil)
+				return err
+			},
+		},
+		{
+			name:          "launch observation",
+			wantOperation: "launch_observation",
+			run: func() error {
+				policy := workerGitHubTestPolicy(server, new(bytes.Buffer))
+				preclassifyWorkerGitHubPolicy(&policy)
+				_, _, err := startWorkerGitHubGovernor(t.Context(), policy, func(AgentUpdate) error {
+					return transportErr
+				})
+				return err
+			},
+		},
+		{
+			name:          "periodic probe",
+			wantOperation: "periodic_probe",
+			run: func() error {
+				poll := make(chan time.Time, 1)
+				var calls atomic.Int64
+				policy := workerGitHubTestPolicy(server, new(bytes.Buffer))
+				preclassifyWorkerGitHubPolicy(&policy)
+				policy.Poll = poll
+				policy.HTTPClient = workerGitHubHTTPClientFunc(func(*http.Request) (*http.Response, error) {
+					if calls.Add(1) > 1 {
+						return nil, transportErr
+					}
+					return workerGitHubRateLimitResponse(), nil
+				})
+				governedCtx, stop, err := startWorkerGitHubGovernor(t.Context(), policy, nil)
+				if err != nil {
+					return err
+				}
+				poll <- time.Now()
+				<-governedCtx.Done()
+				return stop()
+			},
+		},
+		{
+			name:          "periodic observation",
+			wantOperation: "periodic_observation",
+			run: func() error {
+				poll := make(chan time.Time, 1)
+				var updates atomic.Int64
+				policy := workerGitHubTestPolicy(server, new(bytes.Buffer))
+				preclassifyWorkerGitHubPolicy(&policy)
+				policy.Poll = poll
+				governedCtx, stop, err := startWorkerGitHubGovernor(t.Context(), policy, func(AgentUpdate) error {
+					if updates.Add(1) > 1 {
+						return transportErr
+					}
+					return nil
+				})
+				if err != nil {
+					return err
+				}
+				poll <- time.Now()
+				<-governedCtx.Done()
+				return stop()
+			},
+		},
+		{
+			name:          "worker credential classification",
+			wantOperation: "credential_classification_worker",
+			run: func() error {
+				policy := workerGitHubTestPolicy(server, new(bytes.Buffer))
+				policy.CredentialMode = workerGitHubCredentialUnclassified
+				policy.HTTPClient = workerGitHubHTTPClientFunc(func(*http.Request) (*http.Response, error) {
+					return nil, transportErr
+				})
+				_, _, err := startWorkerGitHubGovernor(t.Context(), policy, nil)
+				return err
+			},
+		},
+		{
+			name:          "orchestrator credential classification",
+			wantOperation: "credential_classification_orchestrator",
+			run: func() error {
+				policy := workerGitHubTestPolicy(server, new(bytes.Buffer))
+				policy.CredentialMode = workerGitHubCredentialUnclassified
+				policy.OrchestratorToken = "orchestrator-token"
+				policy.HTTPClient = workerGitHubHTTPClientFunc(func(request *http.Request) (*http.Response, error) {
+					if request.Header.Get("Authorization") == "Bearer orchestrator-token" {
+						return nil, transportErr
+					}
+					return workerGitHubPrincipalResponse(), nil
+				})
+				_, _, err := startWorkerGitHubGovernor(t.Context(), policy, nil)
+				return err
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			err := tt.run()
+			if !errors.Is(err, ErrWorkerGitHubBudgetMonitor) || !errors.Is(err, transportErr) {
+				t.Fatalf("error = %v, want monitor and transport errors", err)
+			}
+			monitorErr, ok := AsWorkerGitHubBudgetMonitorError(err)
+			if !ok {
+				t.Fatalf("error = %T %v, want WorkerGitHubBudgetMonitorError", err, err)
+			}
+			if monitorErr.Operation != tt.wantOperation || monitorErr.CredentialIdentity != "github-rest:worker" || monitorErr.Consumer != telemetry.RESTConsumerWorker {
+				t.Fatalf("monitor error = %#v, want operation %q and worker credential scope", monitorErr, tt.wantOperation)
+			}
+		})
+	}
+}
+
+func TestWorkerGitHubPeriodicMonitorFailureThroughSupervisor(t *testing.T) {
+	t.Parallel()
+
+	poll := make(chan time.Time, 1)
+	var calls atomic.Int64
+	policy := workerGitHubPolicy{
+		Enabled:            true,
+		CredentialMode:     workerGitHubCredentialDistinct,
+		Token:              "worker-token",
+		CredentialIdentity: "github-rest:worker",
+		RateLimitURL:       "https://api.github.test/rate_limit",
+		GraphQLURL:         "https://api.github.test/graphql",
+		MinRemaining:       1000,
+		OrchestratorFloor:  1000,
+		Poll:               poll,
+		HTTPClient: workerGitHubHTTPClientFunc(func(*http.Request) (*http.Response, error) {
+			if calls.Add(1) > 1 {
+				return nil, errors.New("periodic DNS failure")
+			}
+			return workerGitHubRateLimitResponse(), nil
+		}),
+		Logger: slog.New(slog.NewTextHandler(io.Discard, nil)),
+	}
+	preclassifyWorkerGitHubPolicy(&policy)
+	backend := workerGitHubGovernorBackend{
+		policy: policy,
+		poll:   poll,
+		result: RunResult{FinalState: FinalStateFailed, TurnStarted: true, Tokens: TokenTotals{InputTokens: 2_000_000, OutputTokens: 1_000_000, TotalTokens: 3_000_000}},
+	}
+	supervisor, err := NewSupervisor(backend, SupervisorConfig{})
+	if err != nil {
+		t.Fatalf("NewSupervisor() error = %v", err)
+	}
+	completion := supervisor.Run(t.Context(), RunRequest{Issue: connector.Issue{ID: "issue-2028"}, Attempt: 4})
+
+	monitorErr, ok := AsWorkerGitHubBudgetMonitorError(completion.Err)
+	if !ok || monitorErr.Operation != "periodic_probe" {
+		t.Fatalf("completion error = %#v, want periodic monitor failure", completion.Err)
+	}
+	if completion.Retryable || completion.RetryAttempt != 0 || completion.RetryDelay != 0 {
+		t.Fatalf("generic retry state = %v, %d, %s; want cooperative monitor stop", completion.Retryable, completion.RetryAttempt, completion.RetryDelay)
+	}
+	if completion.Result.Tokens.TotalTokens != 3_000_000 {
+		t.Fatalf("tokens = %#v, want actual usage intact", completion.Result.Tokens)
 	}
 }
 
@@ -570,10 +759,51 @@ type workerGitHubCaptureBackend struct {
 	request AgentTurnRequest
 }
 
+type workerGitHubGovernorBackend struct {
+	policy workerGitHubPolicy
+	poll   chan<- time.Time
+	result RunResult
+}
+
 type workerGitHubHTTPClientFunc func(*http.Request) (*http.Response, error)
 
 func (f workerGitHubHTTPClientFunc) Do(request *http.Request) (*http.Response, error) {
 	return f(request)
+}
+
+func (b workerGitHubGovernorBackend) Run(ctx context.Context, _ RunRequest) (RunResult, error) {
+	governedCtx, stop, err := startWorkerGitHubGovernor(ctx, b.policy, nil)
+	if err != nil {
+		return b.result, err
+	}
+	b.poll <- time.Now()
+	<-governedCtx.Done()
+	cause := context.Cause(governedCtx)
+	_ = stop()
+	return b.result, cause
+}
+
+func workerGitHubRateLimitResponse() *http.Response {
+	resetAt := time.Now().Add(time.Hour).Unix()
+	body := fmt.Sprintf(`{"resources":{"core":{"limit":5000,"used":800,"remaining":4200,"reset":%d}}}`, resetAt)
+	return &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     make(http.Header),
+		Body:       io.NopCloser(strings.NewReader(body)),
+	}
+}
+
+func workerGitHubPrincipalResponse() *http.Response {
+	return &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     make(http.Header),
+		Body:       io.NopCloser(strings.NewReader(`{"data":{"viewer":{"databaseId":42,"login":"detent-worker[bot]","__typename":"Bot"}}}`)),
+	}
+}
+
+func preclassifyWorkerGitHubPolicy(policy *workerGitHubPolicy) {
+	policy.PrincipalID = 42
+	policy.Principal.Login = "detent-worker[bot]"
 }
 
 func (b *workerGitHubCaptureBackend) RunTurn(_ context.Context, request AgentTurnRequest, _ AgentUpdateHandler) (AgentTurnResult, error) {

--- a/internal/scheduler/decision_reasons.go
+++ b/internal/scheduler/decision_reasons.go
@@ -25,6 +25,7 @@ const (
 	DecisionReasonForgeUnavailableRecovery         = "forge_unavailable_recovery"
 	DecisionReasonGitHubRESTCapacityPaused         = "github_rest_capacity_paused"
 	DecisionReasonGitHubRESTRecovery               = "github_rest_recovery"
+	DecisionReasonGitHubMonitor                    = "worker_github_budget_monitor_unavailable"
 	DecisionReasonGlobalCapacityFull               = DispatchGateReasonGlobalCapacityFull
 	DecisionReasonHydrateFailed                    = "hydrate_failed"
 	DecisionReasonInactiveState                    = "inactive_state"
@@ -68,6 +69,7 @@ var emittedDecisionReasons = []string{
 	DecisionReasonForgeUnavailableRecovery,
 	DecisionReasonGitHubRESTCapacityPaused,
 	DecisionReasonGitHubRESTRecovery,
+	DecisionReasonGitHubMonitor,
 	DecisionReasonHydrateFailed,
 	DecisionReasonInactiveState,
 	DecisionReasonInvalidCandidate,

--- a/internal/store/capacity_constraints.go
+++ b/internal/store/capacity_constraints.go
@@ -21,6 +21,7 @@ const (
 	CapacityConstraintRateWindow         CapacityConstraintReason = "provider_rate_window_backpressure"
 	CapacityConstraintTrackerUnavailable CapacityConstraintReason = "tracker_unavailable"
 	CapacityConstraintForgeUnavailable   CapacityConstraintReason = "forge_unavailable"
+	CapacityConstraintGitHubMonitor      CapacityConstraintReason = "worker_github_budget_monitor_unavailable"
 	CapacityConstraintCIUnavailable      CapacityConstraintReason = "ci_unavailable"
 )
 
@@ -55,7 +56,7 @@ func QueryCapacityConstraintWaits(
 SELECT project_id, COALESCE(lane, ''), wait_reason, decision_at, capacity_snapshot_json
 FROM scheduler_decisions
 WHERE result = ?
-  AND wait_reason IN (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+  AND wait_reason IN (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
   AND decision_at >= ?`,
 		string(SchedulerDecisionResultSkipped),
 		poolCapacityWaitReason,
@@ -69,6 +70,7 @@ WHERE result = ?
 		string(CapacityConstraintRateWindow),
 		string(CapacityConstraintTrackerUnavailable),
 		string(CapacityConstraintForgeUnavailable),
+		string(CapacityConstraintGitHubMonitor),
 		string(CapacityConstraintCIUnavailable),
 		"local_slot_unavailable",
 		since,
@@ -172,6 +174,8 @@ func capacityConstraintReason(waitReason string, globalAvailable *int) (Capacity
 		return CapacityConstraintTrackerUnavailable, true
 	case string(CapacityConstraintForgeUnavailable):
 		return CapacityConstraintForgeUnavailable, true
+	case string(CapacityConstraintGitHubMonitor):
+		return CapacityConstraintGitHubMonitor, true
 	case string(CapacityConstraintCIUnavailable):
 		return CapacityConstraintCIUnavailable, true
 	default:

--- a/internal/store/capacity_constraints_test.go
+++ b/internal/store/capacity_constraints_test.go
@@ -80,6 +80,12 @@ func TestCapacityConstraintReason(t *testing.T) {
 			wantOK:     true,
 		},
 		{
+			name:       "worker GitHub monitor unavailable",
+			waitReason: "worker_github_budget_monitor_unavailable",
+			want:       CapacityConstraintGitHubMonitor,
+			wantOK:     true,
+		},
+		{
 			name:       "CI unavailable",
 			waitReason: "ci_unavailable",
 			want:       CapacityConstraintCIUnavailable,

--- a/internal/telemetry/snapshot.go
+++ b/internal/telemetry/snapshot.go
@@ -47,6 +47,7 @@ type Snapshot struct {
 	RateLimits              *RateLimits         `json:"rate_limits"`
 	TrackerUnavailable      []TrackerCondition  `json:"tracker_unavailable,omitempty"`
 	ForgeUnavailable        []ForgeCondition    `json:"forge_unavailable,omitempty"`
+	GitHubMonitors          []GitHubMonitor     `json:"worker_github_budget_monitor_unavailable,omitempty"`
 	CIUnavailable           []CICondition       `json:"ci_unavailable,omitempty"`
 	BackendOutages          []BackendOutage     `json:"backend_outages,omitempty"`
 	FailureBreakers         []FailureBreaker    `json:"failure_breakers,omitempty"`
@@ -232,6 +233,22 @@ type ForgeCondition struct {
 	ProbeAttempts   int       `json:"probe_attempts,omitempty"`
 	ProbeIssueID    string    `json:"probe_issue_id,omitempty"`
 	LastError       string    `json:"last_error,omitempty"`
+}
+
+type GitHubMonitor struct {
+	ProjectID          string    `json:"project_id,omitempty"`
+	CredentialIdentity string    `json:"credential_identity"`
+	Consumer           string    `json:"consumer"`
+	Operation          string    `json:"operation,omitempty"`
+	DetectedAt         time.Time `json:"detected_at"`
+	LastObservedAt     time.Time `json:"last_observed_at"`
+	NextProbeAt        time.Time `json:"next_probe_at"`
+	LastProbeAt        time.Time `json:"last_probe_at,omitzero"`
+	LastProbeResult    string    `json:"last_probe_result,omitempty"`
+	LastProbeDetail    string    `json:"last_probe_detail,omitempty"`
+	ProbeAttempts      int       `json:"probe_attempts,omitempty"`
+	ProbeIssueID       string    `json:"probe_issue_id,omitempty"`
+	LastError          string    `json:"last_error,omitempty"`
 }
 
 type AdmissionProposal struct {


### PR DESCRIPTION
## Summary

- intercept worker GitHub REST monitor failures before generic completion and progress processing, preserving usage while excluding all work-failure brakes
- persist one credential-scoped retryable wait with bounded probe metadata and reconstruct it after restart
- admit one recovery canary per credential and release all affected retries after a successful observation

Fixes #2028

## UI Surface Contract

- [x] N/A — this PR does not change any UI surface, layout, density, or responsive visibility.
- [x] This PR does not add persistent top-of-screen messaging.
- [x] N/A — this PR has no visual changes to operator screens.

## Test Plan

- [x] `go test ./internal/runner ./internal/orchestrator ./internal/store ./internal/scheduler ./internal/telemetry -count=1`
- [x] `make check`