### PR TITLE
fix(orchestrator): hold completed rework heads

### DIFF
--- a/internal/orchestrator/autopromote_tick.go
+++ b/internal/orchestrator/autopromote_tick.go
@@ -2,6 +2,7 @@ package orchestrator
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"slices"
@@ -28,6 +29,8 @@ const (
 	autoPromoteGateWaitTimeoutMerge       = "merge"
 	autoPromoteGateWaitTimeoutHumanReview = "human_review"
 	defaultAutoPromoteGateWaitTimeout     = time.Hour
+	completedReworkGateWaitReason         = "completed_rework_gate_wait"
+	completionGateWaitMetadataKey         = "completion_gate_wait"
 	mergeWorkerProjectStateFull           = "project_state_capacity_full"
 	mergeBaseRefreshRequiredChecksPending = "required_checks_pending"
 	mergeBaseRefreshLaneUnavailable       = "merge_lane_capacity_unavailable"
@@ -37,6 +40,12 @@ const (
 	mergeSelectionReasonClean             = "clean_head"
 	mergeSelectionReasonQueue             = "queue_order"
 )
+
+type completionGateWaitRecord struct {
+	Reason         string               `json:"reason"`
+	MergeableState string               `json:"mergeable_state,omitempty"`
+	P1Findings     []AutoPromoteFinding `json:"p1_findings,omitempty"`
+}
 
 type autoPromoteTickResult struct {
 	transitioned       map[string]struct{}
@@ -334,7 +343,7 @@ func (o *Orchestrator) latestSuccessfulGateWaitAttempt(
 		if attempt.TerminalState != store.WorkAttemptTerminalSuccess {
 			continue
 		}
-		if !gateWaitAttemptMatchesPullRequest(attempt, issue) {
+		if !gateWaitAttemptMatchesPullRequest(attempt, issue, normalizeAutoPromoteConfig(o.cfg.AutoPromote).ReworkState) {
 			continue
 		}
 		return attempt, true, nil
@@ -397,7 +406,7 @@ func (o *Orchestrator) recentAgentTerminalAttempts(
 	return attempts, nil
 }
 
-func gateWaitAttemptMatchesPullRequest(attempt store.WorkAttempt, issue connector.Issue) bool {
+func gateWaitAttemptMatchesPullRequest(attempt store.WorkAttempt, issue connector.Issue, reworkState string) bool {
 	record, ok := implementProgressRecordFromAttempt(attempt)
 	if !ok || strings.TrimSpace(record.Outcome) != string(store.WorkAttemptTerminalSuccess) {
 		return false
@@ -427,6 +436,35 @@ func gateWaitAttemptMatchesPullRequest(attempt store.WorkAttempt, issue connecto
 		}
 		matched = true
 	}
+	gateWaitRecord, _ := completionGateWaitRecordFromAttempt(attempt)
+	gateWaitReason := strings.TrimSpace(gateWaitRecord.Reason)
+	if gateWaitReason == completedReworkGateWaitReason {
+		if normalizeState(issue.State) != normalizeState(reworkState) ||
+			normalizeState(record.TrackerState) != normalizeState(issue.State) ||
+			record.WorkspaceDiffStats.FilesChanged != 0 ||
+			record.WorkspaceDiffStats.AddedLines != 0 ||
+			record.WorkspaceDiffStats.RemovedLines != 0 ||
+			record.WorkspaceDiffStats.UnpushedCommits != 0 ||
+			strings.TrimSpace(record.WorkspaceDiffStats.Status) == "" {
+			return false
+		}
+		currentSummary := AutoPromoteSummaryFromIssue(issue)
+		currentSignature := autoPromoteReworkSignatureFromIssue(issue, currentSummary)
+		if autoPromoteHasNewStrings(record.CurrentSignature.FailedChecks, currentSignature.FailedChecks) {
+			return false
+		}
+		if !autoPromoteMergeConflicts(gateWaitRecord.MergeableState) && autoPromoteMergeConflicts(currentSummary.MergeableState) {
+			return false
+		}
+		if autoPromoteHasNewFinding(gateWaitRecord.P1Findings, currentSummary.P1Findings) {
+			return false
+		}
+		if issue.StageUpdatedAt != nil && issue.StageUpdatedAt.After(attempt.CompletedAt) {
+			return false
+		}
+	} else if normalizeState(issue.State) == normalizeState(reworkState) {
+		return false
+	}
 	return matched
 }
 
@@ -441,7 +479,58 @@ func completedFromGateWaitAttempt(issue connector.Issue, attempt store.WorkAttem
 		CompletedAt:    attempt.CompletedAt,
 		FinalState:     FinalStateCompleted,
 		CompletionKind: completionKind,
+		GateWaitReason: completionGateWaitReasonFromAttempt(attempt),
 	}
+}
+
+func completedReworkGateWaitProgress(
+	running Running,
+	decision implementCompletionProgressDecision,
+	cfg Config,
+	finalState string,
+) (implementCompletionProgressDecision, string) {
+	autoCfg := normalizeAutoPromoteConfig(cfg.AutoPromote)
+	dispatchState := firstNonBlank(running.DispatchSourceState, running.Issue.State)
+	if strings.TrimSpace(finalState) != FinalStateCompleted ||
+		normalizeState(dispatchState) != normalizeState(autoCfg.ReworkState) ||
+		!autoPromoteReworkGateWaitTrackedIssue(decision.Issue, cfg, autoCfg) ||
+		decision.Block || decision.DependencyDeferral ||
+		!implementProgressSignatureUsable(decision.CurrentSignature) ||
+		!implementProgressOperationalWorkspaceClean(decision.WorkspaceDiffStats) {
+		return decision, ""
+	}
+	decision.Outcome = store.WorkAttemptTerminalSuccess
+	decision.Block = false
+	decision.BlockReason = ""
+	return decision, completedReworkGateWaitReason
+}
+
+func completionGateWaitMetadata(reason string, issue connector.Issue) map[string]any {
+	reason = strings.TrimSpace(reason)
+	if reason == "" {
+		return nil
+	}
+	summary := AutoPromoteSummaryFromIssue(issue)
+	return map[string]any{completionGateWaitMetadataKey: completionGateWaitRecord{
+		Reason:         reason,
+		MergeableState: strings.TrimSpace(summary.MergeableState),
+		P1Findings:     append([]AutoPromoteFinding(nil), summary.P1Findings...),
+	}}
+}
+
+func completionGateWaitReasonFromAttempt(attempt store.WorkAttempt) string {
+	record, _ := completionGateWaitRecordFromAttempt(attempt)
+	return strings.TrimSpace(record.Reason)
+}
+
+func completionGateWaitRecordFromAttempt(attempt store.WorkAttempt) (completionGateWaitRecord, bool) {
+	var root struct {
+		CompletionGateWait completionGateWaitRecord `json:"completion_gate_wait"`
+	}
+	if err := json.Unmarshal([]byte(strings.TrimSpace(attempt.WorkerMetadataJSON)), &root); err != nil {
+		return completionGateWaitRecord{}, false
+	}
+	return root.CompletionGateWait, strings.TrimSpace(root.CompletionGateWait.Reason) != ""
 }
 
 func autoPromoteActiveGatePendingIssue(
@@ -450,11 +539,17 @@ func autoPromoteActiveGatePendingIssue(
 	cfg Config,
 	autoCfg AutoPromoteConfig,
 ) bool {
-	if state == nil || !autoPromoteActiveGateEligibleIssue(issue, cfg, autoCfg) {
+	if state == nil {
 		return false
 	}
 	completed, ok := state.Completed[strings.TrimSpace(issue.ID)]
 	if !ok {
+		return false
+	}
+	if strings.TrimSpace(completed.GateWaitReason) == completedReworkGateWaitReason {
+		return autoPromoteCompletedReworkGateWaitCurrent(issue, completed, cfg, autoCfg)
+	}
+	if !autoPromoteActiveGateEligibleIssue(issue, cfg, autoCfg) {
 		return false
 	}
 	autoCfg = normalizeAutoPromoteConfig(autoCfg)
@@ -476,7 +571,8 @@ func autoPromoteDurableGateWaitTrackedIssue(
 	cfg Config,
 	autoCfg AutoPromoteConfig,
 ) bool {
-	if autoPromoteActiveGateTrackedIssue(issue, cfg, autoCfg) {
+	if autoPromoteActiveGateTrackedIssue(issue, cfg, autoCfg) ||
+		autoPromoteReworkGateWaitTrackedIssue(issue, cfg, autoCfg) {
 		return true
 	}
 	autoCfg = normalizeAutoPromoteConfig(autoCfg)
@@ -485,6 +581,91 @@ func autoPromoteDurableGateWaitTrackedIssue(
 		!stateIn(issue.State, cfg.TerminalStates) &&
 		!autoPromoteHumanReviewRequired(issue, autoCfg, autoCfg.Gate) &&
 		issueHasOpenPullRequest(issue)
+}
+
+func autoPromoteReworkGateWaitTrackedIssue(
+	issue connector.Issue,
+	cfg Config,
+	autoCfg AutoPromoteConfig,
+) bool {
+	autoCfg = normalizeAutoPromoteConfig(autoCfg)
+	return strings.TrimSpace(issue.ID) != "" &&
+		stateIn(issue.State, cfg.ActiveStates) &&
+		!stateIn(issue.State, cfg.TerminalStates) &&
+		normalizeState(issue.State) == normalizeState(autoCfg.ReworkState) &&
+		autoPromoteSourceGateWaitEnabled(autoCfg) &&
+		!autoPromoteHumanReviewRequired(issue, autoCfg, autoCfg.Gate) &&
+		issueHasOpenPullRequest(issue)
+}
+
+func autoPromoteCompletedReworkGateWaitCurrent(
+	issue connector.Issue,
+	completed Completed,
+	cfg Config,
+	autoCfg AutoPromoteConfig,
+) bool {
+	autoCfg = normalizeAutoPromoteConfig(autoCfg)
+	if !autoPromoteReworkGateWaitTrackedIssue(issue, cfg, autoCfg) ||
+		strings.TrimSpace(completed.GateWaitReason) != completedReworkGateWaitReason ||
+		!completedActiveFinalStateReviewEligible(completed.FinalState, autoCfg.SourceState) {
+		return false
+	}
+	return completedReworkGateWaitEvidenceCurrent(completed, issue)
+}
+
+func completedReworkGateWaitEvidenceCurrent(completed Completed, issue connector.Issue) bool {
+	previous := completed.Issue
+	if normalizeState(previous.State) != normalizeState(issue.State) ||
+		previous.PullRequest == nil || issue.PullRequest == nil ||
+		pullRequestNumber(previous) != pullRequestNumber(issue) ||
+		strings.TrimSpace(previous.PullRequest.HeadSHA) == "" ||
+		strings.TrimSpace(previous.PullRequest.HeadSHA) != strings.TrimSpace(issue.PullRequest.HeadSHA) {
+		return false
+	}
+	if issue.StageUpdatedAt != nil && !completed.CompletedAt.IsZero() && issue.StageUpdatedAt.After(completed.CompletedAt) {
+		return false
+	}
+	previousSummary := AutoPromoteSummaryFromIssue(previous)
+	currentSummary := AutoPromoteSummaryFromIssue(issue)
+	if autoPromoteHasNewStrings(previousSummary.FailedChecks, currentSummary.FailedChecks) {
+		return false
+	}
+	if !autoPromoteMergeConflicts(previousSummary.MergeableState) && autoPromoteMergeConflicts(currentSummary.MergeableState) {
+		return false
+	}
+	return !autoPromoteHasNewFinding(previousSummary.P1Findings, currentSummary.P1Findings)
+}
+
+func autoPromoteHasNewStrings(previous []string, current []string) bool {
+	previous = uniqueStrings(previous)
+	for _, value := range uniqueStrings(current) {
+		if !slices.Contains(previous, value) {
+			return true
+		}
+	}
+	return false
+}
+
+func autoPromoteHasNewFinding(previous []AutoPromoteFinding, current []AutoPromoteFinding) bool {
+	known := make(map[string]struct{}, len(previous))
+	for _, finding := range previous {
+		known[autoPromoteFindingKey(finding)] = struct{}{}
+	}
+	for _, finding := range current {
+		if _, ok := known[autoPromoteFindingKey(finding)]; !ok {
+			return true
+		}
+	}
+	return false
+}
+
+func autoPromoteFindingKey(finding AutoPromoteFinding) string {
+	return strings.Join([]string{
+		strings.TrimSpace(finding.Body),
+		strings.TrimSpace(finding.URL),
+		strings.TrimSpace(finding.Path),
+		strconv.Itoa(finding.Line),
+	}, "\x00")
 }
 
 func autoPromoteActiveGateEligibleIssue(

--- a/internal/orchestrator/autopromote_tick.go
+++ b/internal/orchestrator/autopromote_tick.go
@@ -473,14 +473,23 @@ func completedFromGateWaitAttempt(issue connector.Issue, attempt store.WorkAttem
 	if record, ok := implementProgressRecordFromAttempt(attempt); ok {
 		completionKind = strings.TrimSpace(record.CompletionKind)
 	}
+	gateWaitReason := completionGateWaitReasonFromAttempt(attempt)
 	return Completed{
-		Issue:          cloneIssue(issue),
-		StartedAt:      attempt.StartedAt,
-		CompletedAt:    attempt.CompletedAt,
-		FinalState:     FinalStateCompleted,
-		CompletionKind: completionKind,
-		GateWaitReason: completionGateWaitReasonFromAttempt(attempt),
+		Issue:            cloneIssue(issue),
+		StartedAt:        attempt.StartedAt,
+		CompletedAt:      attempt.CompletedAt,
+		FinalState:       FinalStateCompleted,
+		CompletionKind:   completionKind,
+		GateWaitReason:   gateWaitReason,
+		gateWaitEvidence: completionGateWaitEvidence(gateWaitReason, issue),
 	}
+}
+
+func completionGateWaitEvidence(reason string, issue connector.Issue) connector.Issue {
+	if strings.TrimSpace(reason) != completedReworkGateWaitReason {
+		return connector.Issue{}
+	}
+	return cloneIssue(issue)
 }
 
 func completedReworkGateWaitProgress(
@@ -614,7 +623,10 @@ func autoPromoteCompletedReworkGateWaitCurrent(
 }
 
 func completedReworkGateWaitEvidenceCurrent(completed Completed, issue connector.Issue) bool {
-	previous := completed.Issue
+	previous := completed.gateWaitEvidence
+	if strings.TrimSpace(previous.ID) == "" {
+		previous = completed.Issue
+	}
 	if normalizeState(previous.State) != normalizeState(issue.State) ||
 		previous.PullRequest == nil || issue.PullRequest == nil ||
 		pullRequestNumber(previous) != pullRequestNumber(issue) ||

--- a/internal/orchestrator/autopromote_tick_test.go
+++ b/internal/orchestrator/autopromote_tick_test.go
@@ -467,6 +467,7 @@ func TestTickAutoPromoteCompletedActiveIssues(t *testing.T) {
 	tests := []struct {
 		name                 string
 		issue                connector.Issue
+		gateWaitReason       string
 		wantUpdates          []autoPromoteTickUpdate
 		wantCommentFragments []string
 	}{
@@ -489,6 +490,30 @@ func TestTickAutoPromoteCompletedActiveIssues(t *testing.T) {
 				"Auto-promoted this issue from In Progress to Merging.",
 				"reason: ready",
 				"https://github.test/digitaldrywood/detent/pull/142",
+			},
+		},
+		{
+			name: "promotes completed Rework gate wait directly to merging",
+			issue: func() connector.Issue {
+				issue := autoPromoteTickIssue("issue-rework-ready", []string{"bug"}, &connector.PullRequest{
+					Number:                 2030,
+					URL:                    "https://github.test/digitaldrywood/detent/pull/2030",
+					State:                  "OPEN",
+					HeadSHA:                "same-head",
+					MergeableState:         "clean",
+					CIStatus:               "success",
+					CodexReviewState:       "COMMENTED",
+					CodexReviewSubmittedAt: &oldReview,
+				})
+				issue.State = "Rework"
+				return issue
+			}(),
+			gateWaitReason: completedReworkGateWaitReason,
+			wantUpdates:    []autoPromoteTickUpdate{{issueID: "issue-rework-ready", state: "Merging"}},
+			wantCommentFragments: []string{
+				"Auto-promoted this issue from Rework to Merging.",
+				"reason: ready",
+				"https://github.test/digitaldrywood/detent/pull/2030",
 			},
 		},
 		{
@@ -552,8 +577,9 @@ func TestTickAutoPromoteCompletedActiveIssues(t *testing.T) {
 			})
 			state := newState(cfg)
 			state.Completed[tt.issue.ID] = Completed{
-				Issue:      tt.issue,
-				FinalState: FinalStateCompleted,
+				Issue:          tt.issue,
+				FinalState:     FinalStateCompleted,
+				GateWaitReason: tt.gateWaitReason,
 			}
 			mergingSlot := dispatchTestIssue(tt.issue.ID+"-merging-slot", "Merging")
 			state.Running[mergingSlot.ID] = Running{Issue: mergingSlot}
@@ -1055,6 +1081,151 @@ func TestLatestSuccessfulGateWaitAttemptRequiresCurrentImplementationEvidence(t 
 				t.Fatalf("latestSuccessfulGateWaitAttempt() ID = %d, want %d", attempt.ID, tt.wantID)
 			}
 		})
+	}
+}
+
+func TestRestoreDurableReworkGateWaitCompletion(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 8, 28, 18, 45, 0, 0, time.UTC)
+	cfg := normalizeConfig(Config{
+		Project: scheduler.ProjectCandidate{ID: "detent"},
+		AutoPromote: AutoPromoteConfig{
+			Enabled:       true,
+			GateWaitState: autoPromoteGateWaitSource,
+			Gate:          gate.Config{Kind: gate.KindCommand, RequireAutomatedReview: new(false)},
+		},
+		ActiveStates:   []string{"Todo", "In Progress", "Rework", "Merging"},
+		TerminalStates: []string{"Done", "Cancelled"},
+	})
+	tests := []struct {
+		name             string
+		recordedFailures []string
+		prepareIssue     func(*connector.Issue)
+		includeMarker    bool
+		wantRestore      bool
+	}{
+		{name: "restores unchanged exact head", includeMarker: true, wantRestore: true},
+		{
+			name:          "head movement invalidates completion",
+			includeMarker: true,
+			prepareIssue: func(issue *connector.Issue) {
+				issue.PullRequest.HeadSHA = "new-head"
+			},
+		},
+		{
+			name:          "new failing check invalidates completion",
+			includeMarker: true,
+			prepareIssue: func(issue *connector.Issue) {
+				issue.PullRequest.RequiredCheckFailures = []connector.PullRequestCheck{{Name: "Test", Status: "completed", Conclusion: "failure"}}
+			},
+		},
+		{
+			name:          "new merge conflict invalidates completion",
+			includeMarker: true,
+			prepareIssue: func(issue *connector.Issue) {
+				issue.PullRequest.MergeableState = "dirty"
+			},
+		},
+		{
+			name:             "cleared failing check retains completion",
+			recordedFailures: []string{"Test"},
+			includeMarker:    true,
+			wantRestore:      true,
+		},
+		{
+			name:          "new P1 review invalidates completion",
+			includeMarker: true,
+			prepareIssue: func(issue *connector.Issue) {
+				submittedAt := now.Add(-time.Minute)
+				issue.PullRequest.CodexReviewState = "P1"
+				issue.PullRequest.CodexReviewSubmittedAt = &submittedAt
+				issue.PullRequest.CodexReviewFindings = []connector.PullRequestFinding{{Body: "Fix the race."}}
+			},
+		},
+		{
+			name:          "later Rework entry invalidates completion",
+			includeMarker: true,
+			prepareIssue: func(issue *connector.Issue) {
+				enteredAt := now.Add(-time.Minute)
+				issue.StageUpdatedAt = &enteredAt
+			},
+		},
+		{name: "ordinary success without marker is not restored"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			issue := autoPromoteTickIssue("issue-rework-gate-restart", []string{"bug"}, &connector.PullRequest{
+				Number:         2030,
+				State:          "OPEN",
+				HeadSHA:        "same-head",
+				MergeableState: "clean",
+				CIStatus:       "success",
+			})
+			issue.State = "Rework"
+			recordedIssue := cloneIssue(issue)
+			if tt.prepareIssue != nil {
+				tt.prepareIssue(&issue)
+			}
+			signature := autoPromoteReworkSignature{PRNumber: 2030, HeadSHA: "same-head", FailedChecks: tt.recordedFailures}
+			attempt := successfulReworkGateWaitAttempt(now.Add(-2*time.Minute), recordedIssue, signature, tt.includeMarker)
+			attempts := &recordingWorkAttemptStore{history: []store.WorkAttempt{attempt}}
+			orch := &Orchestrator{cfg: cfg, workAttempts: attempts}
+			state := newState(cfg)
+
+			orch.restoreDurableGateWaitCompletions(t.Context(), &state, []connector.Issue{issue})
+
+			completed, restored := state.Completed[issue.ID]
+			if restored != tt.wantRestore {
+				t.Fatalf("Completed[%q] present = %v, want %v", issue.ID, restored, tt.wantRestore)
+			}
+			if !tt.wantRestore {
+				return
+			}
+			if completed.GateWaitReason != completedReworkGateWaitReason {
+				t.Fatalf("GateWaitReason = %q, want %q", completed.GateWaitReason, completedReworkGateWaitReason)
+			}
+			decision := newDispatchPlanner(cfg).dispatchableIssueDecision(issue, &state, false, now, "")
+			if decision.dispatchable || decision.reason != dispatchSkipAwaitingGate {
+				t.Fatalf("dispatch decision = %#v, want awaiting gate", decision)
+			}
+		})
+	}
+}
+
+func successfulReworkGateWaitAttempt(
+	completedAt time.Time,
+	issue connector.Issue,
+	signature autoPromoteReworkSignature,
+	includeMarker bool,
+) store.WorkAttempt {
+	prNumber := signature.PRNumber
+	metadata := implementCompletionProgressMetadata(implementCompletionProgressDecision{
+		Outcome:            store.WorkAttemptTerminalSuccess,
+		Reason:             "unchanged_signature_clean_diff",
+		CurrentSignature:   signature,
+		WorkspaceDiffStats: DiffStats{Status: "clean"},
+		TrackerState:       "Rework",
+	})
+	if includeMarker {
+		metadata = mergeWorkAttemptMetadata(metadata, completionGateWaitMetadata(completedReworkGateWaitReason, issue))
+	}
+	return store.WorkAttempt{
+		ID:                 2030,
+		ProjectID:          "detent",
+		IssueID:            issue.ID,
+		Identifier:         issue.Identifier,
+		IssueURL:           issue.URL,
+		PRNumber:           &prNumber,
+		WorkerType:         "agent",
+		Lane:               "Rework",
+		Status:             store.WorkAttemptStatusTerminal,
+		StartedAt:          completedAt.Add(-time.Minute),
+		CompletedAt:        completedAt,
+		TerminalState:      store.WorkAttemptTerminalSuccess,
+		WorkerMetadataJSON: marshalWorkAttemptJSON(metadata),
 	}
 }
 

--- a/internal/orchestrator/dispatch_test.go
+++ b/internal/orchestrator/dispatch_test.go
@@ -1179,6 +1179,54 @@ func TestDispatchableCompletedReworkGateWaitEvidence(t *testing.T) {
 	}
 }
 
+func TestTargetedReconcilePreservesCompletedReworkGateWaitEvidence(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 8, 28, 19, 0, 0, 0, time.UTC)
+	cfg := normalizeConfig(Config{
+		MaxConcurrentAgents: 1,
+		AutoPromote: AutoPromoteConfig{
+			Enabled:       true,
+			GateWaitState: autoPromoteGateWaitSource,
+			Gate:          gate.Config{Kind: gate.KindCommand, RequireAutomatedReview: new(false)},
+		},
+		ActiveStates:   []string{"Todo", "In Progress", "Rework", "Merging"},
+		TerminalStates: []string{"Done", "Cancelled"},
+	})
+	completedIssue := dispatchTestIssueWithPullRequest("issue-rework-gate-refresh", "Rework", "OPEN")
+	completedIssue.PullRequest.HeadSHA = "completed-head"
+	completedIssue.PullRequest.MergeableState = "clean"
+	completedIssue.PullRequest.CIStatus = "success"
+	refreshedIssue := cloneIssue(completedIssue)
+	refreshedIssue.PullRequest.HeadSHA = "replacement-head"
+
+	state := newState(cfg)
+	state.Completed[completedIssue.ID] = Completed{
+		Issue:            cloneIssue(completedIssue),
+		CompletedAt:      now.Add(-2 * time.Minute),
+		FinalState:       FinalStateCompleted,
+		GateWaitReason:   completedReworkGateWaitReason,
+		gateWaitEvidence: completionGateWaitEvidence(completedReworkGateWaitReason, completedIssue),
+	}
+	orch := Orchestrator{cfg: cfg}
+	orch.updateTargetedIssueEntries(&state, refreshedIssue)
+
+	completed := state.Completed[completedIssue.ID]
+	if got := completed.Issue.PullRequest.HeadSHA; got != "replacement-head" {
+		t.Fatalf("Completed issue head = %q, want refreshed head", got)
+	}
+	if got := completed.gateWaitEvidence.PullRequest.HeadSHA; got != "completed-head" {
+		t.Fatalf("gate-wait evidence head = %q, want completion-time head", got)
+	}
+	if autoPromoteActiveGatePendingIssue(refreshedIssue, &state, cfg, cfg.AutoPromote) {
+		t.Fatal("replacement head remained pending the completed-head gate")
+	}
+	decision := newDispatchPlanner(cfg).dispatchableIssueDecision(refreshedIssue, &state, false, now, "")
+	if !decision.dispatchable {
+		t.Fatalf("replacement-head dispatch decision = %#v, want dispatchable", decision)
+	}
+}
+
 func TestDispatchableArtifactGateWaitStatus(t *testing.T) {
 	t.Parallel()
 

--- a/internal/orchestrator/dispatch_test.go
+++ b/internal/orchestrator/dispatch_test.go
@@ -1080,6 +1080,105 @@ func TestDispatchableSkipsQuietWindowActiveIssueWithOpenPullRequest(t *testing.T
 	}
 }
 
+func TestDispatchableCompletedReworkGateWaitEvidence(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 8, 28, 18, 30, 0, 0, time.UTC)
+	cfg := normalizeConfig(Config{
+		MaxConcurrentAgents: 1,
+		AutoPromote: AutoPromoteConfig{
+			Enabled:       true,
+			GateWaitState: autoPromoteGateWaitSource,
+			Gate:          gate.Config{Kind: gate.KindCommand, RequireAutomatedReview: new(false)},
+		},
+		ActiveStates:   []string{"Todo", "In Progress", "Rework", "Merging"},
+		TerminalStates: []string{"Done", "Cancelled"},
+	})
+	tests := []struct {
+		name            string
+		prepareComplete func(*connector.Issue)
+		prepareCurrent  func(*connector.Issue)
+		wantDispatch    bool
+	}{
+		{name: "unchanged exact head remains waiting"},
+		{
+			name: "new pull request head permits dispatch",
+			prepareCurrent: func(issue *connector.Issue) {
+				issue.PullRequest.HeadSHA = "new-head"
+			},
+			wantDispatch: true,
+		},
+		{
+			name: "new failing check permits dispatch",
+			prepareCurrent: func(issue *connector.Issue) {
+				issue.PullRequest.RequiredCheckFailures = []connector.PullRequestCheck{{Name: "Test", Status: "completed", Conclusion: "failure"}}
+			},
+			wantDispatch: true,
+		},
+		{
+			name: "new P1 review permits dispatch",
+			prepareCurrent: func(issue *connector.Issue) {
+				issue.PullRequest.CodexReviewState = "P1"
+				issue.PullRequest.CodexReviewFindings = []connector.PullRequestFinding{{Body: "Fix the race.", Path: "internal/orchestrator/run_completion.go", Line: 577}}
+			},
+			wantDispatch: true,
+		},
+		{
+			name: "cleared failing check remains waiting for promotion",
+			prepareComplete: func(issue *connector.Issue) {
+				issue.PullRequest.RequiredCheckFailures = []connector.PullRequestCheck{{Name: "Test", Status: "completed", Conclusion: "failure"}}
+			},
+		},
+		{
+			name: "lane movement permits dispatch",
+			prepareCurrent: func(issue *connector.Issue) {
+				issue.State = "In Progress"
+			},
+			wantDispatch: true,
+		},
+		{
+			name: "later Rework entry permits dispatch",
+			prepareCurrent: func(issue *connector.Issue) {
+				enteredAt := now.Add(-time.Minute)
+				issue.StageUpdatedAt = &enteredAt
+			},
+			wantDispatch: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			completedIssue := dispatchTestIssueWithPullRequest("issue-rework-gate-wait", "Rework", "OPEN")
+			completedIssue.PullRequest.HeadSHA = "same-head"
+			completedIssue.PullRequest.MergeableState = "clean"
+			completedIssue.PullRequest.CIStatus = "success"
+			if tt.prepareComplete != nil {
+				tt.prepareComplete(&completedIssue)
+			}
+			currentIssue := cloneIssue(completedIssue)
+			if tt.prepareCurrent != nil {
+				tt.prepareCurrent(&currentIssue)
+			}
+			state := newState(cfg)
+			state.Completed[currentIssue.ID] = Completed{
+				Issue:          completedIssue,
+				CompletedAt:    now.Add(-2 * time.Minute),
+				FinalState:     FinalStateCompleted,
+				GateWaitReason: completedReworkGateWaitReason,
+			}
+
+			decision := newDispatchPlanner(cfg).dispatchableIssueDecision(currentIssue, &state, false, now, "")
+			if decision.dispatchable != tt.wantDispatch {
+				t.Fatalf("dispatchable = %v, want %v; reason = %q", decision.dispatchable, tt.wantDispatch, decision.reason)
+			}
+			if !tt.wantDispatch && decision.reason != dispatchSkipAwaitingGate {
+				t.Fatalf("reason = %q, want %q", decision.reason, dispatchSkipAwaitingGate)
+			}
+		})
+	}
+}
+
 func TestDispatchableArtifactGateWaitStatus(t *testing.T) {
 	t.Parallel()
 

--- a/internal/orchestrator/implement_progress_test.go
+++ b/internal/orchestrator/implement_progress_test.go
@@ -1060,6 +1060,91 @@ func TestHandleRunResultStopsCompletedGateWaitContinuations(t *testing.T) {
 	}
 }
 
+func TestHandleRunResultDoesNotSupersedeReworkPullRequestUpdates(t *testing.T) {
+	t.Parallel()
+
+	base := time.Date(2026, 8, 28, 19, 15, 0, 0, time.UTC)
+	completedIssue := implementProgressIssue("completed-head")
+	completedIssue.State = "Rework"
+	replacementIssue := cloneIssue(completedIssue)
+	replacementIssue.PullRequest.HeadSHA = "replacement-head"
+	signature := autoPromoteReworkSignature{PRNumber: 1070, HeadSHA: "completed-head"}
+	tests := []struct {
+		name   string
+		result runpkg.RunResult
+	}{
+		{
+			name:   "head push",
+			result: runpkg.RunResult{PullRequestHeadPushed: true},
+		},
+		{
+			name:   "pull request update",
+			result: runpkg.RunResult{PullRequestUpdated: true},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			tracker := &implementProgressConnector{hydrated: replacementIssue}
+			attempts := &implementProgressAttemptStore{history: []store.WorkAttempt{
+				successfulReworkGateWaitAttempt(base.Add(-2*time.Minute), completedIssue, signature, true),
+			}}
+			cfg := normalizeConfig(Config{
+				Project: scheduler.ProjectCandidate{ID: "detent"},
+				AutoPromote: AutoPromoteConfig{
+					Enabled:       true,
+					GateWaitState: autoPromoteGateWaitSource,
+					Gate:          gate.Config{Kind: gate.KindCommand},
+				},
+				ActiveStates:           []string{"Todo", "In Progress", "Rework", "Merging"},
+				ObservedStates:         []string{"Human Review", "Blocked"},
+				TerminalStates:         []string{"Done", "Cancelled"},
+				ContinuationRetryDelay: time.Minute,
+			})
+			orch := &Orchestrator{
+				cfg:          cfg,
+				connector:    tracker,
+				workAttempts: attempts,
+				logger:       slog.New(slog.NewTextHandler(io.Discard, nil)),
+			}
+			state := newState(cfg)
+			state.Running[completedIssue.ID] = Running{
+				Issue:               completedIssue,
+				Attempt:             2,
+				WorkAttemptID:       42,
+				Mode:                runpkg.RunModeImplement,
+				DispatchSourceState: "Rework",
+				StartedAt:           base.Add(-time.Minute),
+				DiffStats:           DiffStats{Status: "clean"},
+			}
+			state.Claimed[completedIssue.ID] = Claimed{Issue: completedIssue, ClaimedAt: base.Add(-time.Minute)}
+
+			result := tt.result
+			result.FinalState = FinalStateCompleted
+			result.DiffStats = DiffStats{Status: "clean"}
+			orch.handleRunResult(context.Background(), &state, runpkg.Completion{
+				IssueID:     completedIssue.ID,
+				CompletedAt: base,
+				Request:     runpkg.RunRequest{Mode: runpkg.RunModeImplement},
+				Result:      result,
+			})
+
+			if len(attempts.completions) != 1 || attempts.completions[0].TerminalState != store.WorkAttemptTerminalSuccess {
+				t.Fatalf("completions = %#v, want successful replacement-head completion", attempts.completions)
+			}
+			record := implementProgressRecordFromCompletion(t, attempts.completions[0])
+			if record.CurrentSignature.HeadSHA != "replacement-head" {
+				t.Fatalf("completion head = %q, want replacement-head", record.CurrentSignature.HeadSHA)
+			}
+			completed := state.Completed[completedIssue.ID]
+			if completed.gateWaitEvidence.PullRequest == nil || completed.gateWaitEvidence.PullRequest.HeadSHA != "replacement-head" {
+				t.Fatalf("gate-wait evidence = %#v, want replacement head", completed.gateWaitEvidence.PullRequest)
+			}
+		})
+	}
+}
+
 func TestHandleRunResultHoldsCompletedReworkGateWait(t *testing.T) {
 	t.Parallel()
 

--- a/internal/orchestrator/implement_progress_test.go
+++ b/internal/orchestrator/implement_progress_test.go
@@ -1060,6 +1060,127 @@ func TestHandleRunResultStopsCompletedGateWaitContinuations(t *testing.T) {
 	}
 }
 
+func TestHandleRunResultHoldsCompletedReworkGateWait(t *testing.T) {
+	t.Parallel()
+
+	base := time.Date(2026, 8, 28, 18, 0, 0, 0, time.UTC)
+	signature := autoPromoteReworkSignature{
+		PRNumber: 1070,
+		HeadSHA:  "same-head",
+	}
+	tests := []struct {
+		name          string
+		history       []store.WorkAttempt
+		completionErr error
+		wantReason    string
+		wantClaimed   bool
+		wantTerminal  store.WorkAttemptTerminalState
+	}{
+		{
+			name:         "first successful completion",
+			wantReason:   "first_completed_attempt",
+			wantTerminal: store.WorkAttemptTerminalSuccess,
+		},
+		{
+			name:         "successful completion with unchanged fingerprint",
+			history:      []store.WorkAttempt{implementProgressHistoryAttempt(1, signature, store.WorkAttemptTerminalSuccess)},
+			wantReason:   "unchanged_signature_clean_diff",
+			wantTerminal: store.WorkAttemptTerminalSuccess,
+		},
+		{
+			name:          "persistence failure retains claim",
+			completionErr: errors.New("attempt store unavailable"),
+			wantReason:    "first_completed_attempt",
+			wantClaimed:   true,
+			wantTerminal:  store.WorkAttemptTerminalSuccess,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			issue := implementProgressIssue("same-head")
+			issue.State = "Rework"
+			tracker := &implementProgressConnector{hydrated: issue}
+			attempts := &implementProgressAttemptStore{history: tt.history, completionErr: tt.completionErr}
+			cfg := normalizeConfig(Config{
+				Project: scheduler.ProjectCandidate{ID: "detent"},
+				AutoPromote: AutoPromoteConfig{
+					Enabled:         true,
+					GateWaitState:   autoPromoteGateWaitSource,
+					NoProgressLimit: 3,
+					Gate:            gate.Config{Kind: gate.KindCommand},
+				},
+				ActiveStates:           []string{"Todo", "In Progress", "Rework", "Merging"},
+				ObservedStates:         []string{"Human Review", "Blocked"},
+				TerminalStates:         []string{"Done", "Cancelled"},
+				ContinuationRetryDelay: time.Minute,
+			})
+			orch := &Orchestrator{
+				cfg:          cfg,
+				connector:    tracker,
+				workAttempts: attempts,
+				logger:       slog.New(slog.NewTextHandler(io.Discard, nil)),
+			}
+			state := newState(cfg)
+			state.Running[issue.ID] = Running{
+				Issue:               issue,
+				Attempt:             2,
+				WorkAttemptID:       42,
+				Mode:                runpkg.RunModeImplement,
+				DispatchSourceState: "Rework",
+				StartedAt:           base.Add(-time.Minute),
+				DiffStats:           DiffStats{Status: "clean"},
+			}
+			state.Claimed[issue.ID] = Claimed{Issue: issue, ClaimedAt: base.Add(-time.Minute)}
+
+			orch.handleRunResult(context.Background(), &state, runpkg.Completion{
+				IssueID:     issue.ID,
+				CompletedAt: base,
+				Request:     runpkg.RunRequest{Mode: runpkg.RunModeImplement},
+				Result: runpkg.RunResult{
+					FinalState: FinalStateCompleted,
+					DiffStats:  DiffStats{Status: "clean"},
+				},
+			})
+
+			if len(attempts.completions) != 1 || attempts.completions[0].TerminalState != tt.wantTerminal {
+				t.Fatalf("completions = %#v, want terminal %q", attempts.completions, tt.wantTerminal)
+			}
+			persisted := store.WorkAttempt{
+				TerminalState:      attempts.completions[0].TerminalState,
+				WorkerMetadataJSON: attempts.completions[0].WorkerMetadataJSON,
+			}
+			record, ok := implementProgressRecordFromAttempt(persisted)
+			if !ok || record.Reason != tt.wantReason {
+				t.Fatalf("completion progress = %#v, want reason %q", record, tt.wantReason)
+			}
+			if reason := completionGateWaitReasonFromAttempt(persisted); reason != completedReworkGateWaitReason {
+				t.Fatalf("completion gate wait reason = %q, want %q", reason, completedReworkGateWaitReason)
+			}
+			completed, ok := state.Completed[issue.ID]
+			if !ok {
+				t.Fatalf("Completed[%q] missing after Rework gate-wait completion", issue.ID)
+			}
+			if completed.GateWaitReason != completedReworkGateWaitReason {
+				t.Fatalf("Completed[%q].GateWaitReason = %q, want %q", issue.ID, completed.GateWaitReason, completedReworkGateWaitReason)
+			}
+			if _, ok := state.Retry[issue.ID]; ok {
+				t.Fatalf("Retry[%q] present after Rework gate-wait completion", issue.ID)
+			}
+			_, claimed := state.Claimed[issue.ID]
+			if claimed != tt.wantClaimed {
+				t.Fatalf("Claimed[%q] present = %v, want %v", issue.ID, claimed, tt.wantClaimed)
+			}
+			if !tt.wantClaimed {
+				if !autoPromoteActiveGatePendingIssue(issue, &state, cfg, cfg.AutoPromote) {
+					t.Fatal("Rework completion is not pending the source-lane gate")
+				}
+			}
+		})
+	}
+}
+
 func TestHandleRunResultCommentsOnObservedLaneTransition(t *testing.T) {
 	t.Parallel()
 

--- a/internal/orchestrator/run_completion.go
+++ b/internal/orchestrator/run_completion.go
@@ -586,6 +586,7 @@ func (o *Orchestrator) handleRunResult(ctx context.Context, state *State, event 
 	}
 	progress := o.evaluateImplementCompletionProgress(ctx, running, finalState, event.Result.PullRequestUpdated)
 	progress = o.evaluateDispatchLoopProgress(ctx, running, progress)
+	progress, gateWaitReason := completedReworkGateWaitProgress(running, progress, o.cfg, finalState)
 	running.Issue = progress.Issue
 	if terminalState == store.WorkAttemptTerminalSuccess && implementCompletionHasDurableProgress(running, progress) {
 		resetWorkerFailureBreakers(state, event.IssueID)
@@ -655,6 +656,7 @@ func (o *Orchestrator) handleRunResult(ctx context.Context, state *State, event 
 		spendProgressMetadata(spendProgress),
 		artifactGateConvergenceMetadata(artifactConvergence),
 		deliverableCommandEvidenceMetadata(event.Result),
+		completionGateWaitMetadata(gateWaitReason, progress.Issue),
 	))
 
 	state.Completed[event.IssueID] = Completed{
@@ -664,6 +666,7 @@ func (o *Orchestrator) handleRunResult(ctx context.Context, state *State, event 
 		CompletedAt:     event.CompletedAt,
 		FinalState:      finalState,
 		CompletionKind:  strings.TrimSpace(progress.CompletionKind),
+		GateWaitReason:  gateWaitReason,
 		Tokens:          event.Result.Tokens,
 		RuntimeIdentity: running.RuntimeIdentity,
 	}
@@ -691,6 +694,14 @@ func (o *Orchestrator) handleRunResult(ctx context.Context, state *State, event 
 	}
 	if terminalState == store.WorkAttemptTerminalSuccess &&
 		autoPromoteActiveGatePendingIssue(running.Issue, state, o.cfg, o.cfg.AutoPromote) {
+		if gateWaitReason != "" && !attemptCompleted {
+			recordStateEvent(state, telemetry.ActivityEvent{
+				At:      event.CompletedAt,
+				Event:   "rework_gate_wait_persist_failed",
+				Message: "retained claim for " + issueLabel(running.Issue) + " after Rework gate-wait persistence failed",
+			})
+			return
+		}
 		o.finishCompletedGateWaitRun(ctx, state, running.Issue)
 		return
 	}
@@ -811,7 +822,7 @@ func (o *Orchestrator) completeRedundantGateWaitRun(
 	event runpkg.Completion,
 	running Running,
 ) bool {
-	if !autoPromoteActiveGateTrackedIssue(running.Issue, o.cfg, o.cfg.AutoPromote) {
+	if !autoPromoteDurableGateWaitTrackedIssue(running.Issue, o.cfg, o.cfg.AutoPromote) {
 		return false
 	}
 	attempt, ok, err := o.latestSuccessfulGateWaitAttempt(ctx, running.Issue)

--- a/internal/orchestrator/run_completion.go
+++ b/internal/orchestrator/run_completion.go
@@ -660,15 +660,16 @@ func (o *Orchestrator) handleRunResult(ctx context.Context, state *State, event 
 	))
 
 	state.Completed[event.IssueID] = Completed{
-		Issue:           cloneIssue(running.Issue),
-		SessionID:       running.SessionID,
-		StartedAt:       running.StartedAt,
-		CompletedAt:     event.CompletedAt,
-		FinalState:      finalState,
-		CompletionKind:  strings.TrimSpace(progress.CompletionKind),
-		GateWaitReason:  gateWaitReason,
-		Tokens:          event.Result.Tokens,
-		RuntimeIdentity: running.RuntimeIdentity,
+		Issue:            cloneIssue(running.Issue),
+		SessionID:        running.SessionID,
+		StartedAt:        running.StartedAt,
+		CompletedAt:      event.CompletedAt,
+		FinalState:       finalState,
+		CompletionKind:   strings.TrimSpace(progress.CompletionKind),
+		GateWaitReason:   gateWaitReason,
+		gateWaitEvidence: completionGateWaitEvidence(gateWaitReason, progress.Issue),
+		Tokens:           event.Result.Tokens,
+		RuntimeIdentity:  running.RuntimeIdentity,
 	}
 	state.TokenTotals = addTokenTotals(state.TokenTotals, event.Result.Tokens)
 	if event.Result.RateLimits != nil {
@@ -822,6 +823,9 @@ func (o *Orchestrator) completeRedundantGateWaitRun(
 	event runpkg.Completion,
 	running Running,
 ) bool {
+	if event.Result.PullRequestHeadPushed || event.Result.PullRequestUpdated {
+		return false
+	}
 	if !autoPromoteDurableGateWaitTrackedIssue(running.Issue, o.cfg, o.cfg.AutoPromote) {
 		return false
 	}

--- a/internal/orchestrator/state.go
+++ b/internal/orchestrator/state.go
@@ -218,16 +218,17 @@ type Blocked struct {
 }
 
 type Completed struct {
-	Issue           connector.Issue
-	SessionID       string
-	StartedAt       time.Time
-	CompletedAt     time.Time
-	FinalState      string
-	CompletionKind  string
-	GateWaitReason  string
-	Tokens          TokenTotals
-	MergeTiming     MergeTiming
-	RuntimeIdentity agentidentity.Identity
+	Issue            connector.Issue
+	SessionID        string
+	StartedAt        time.Time
+	CompletedAt      time.Time
+	FinalState       string
+	CompletionKind   string
+	GateWaitReason   string
+	gateWaitEvidence connector.Issue
+	Tokens           TokenTotals
+	MergeTiming      MergeTiming
+	RuntimeIdentity  agentidentity.Identity
 }
 
 type MergeTiming struct {
@@ -509,6 +510,7 @@ func (s State) clone() State {
 	}
 	for id, completed := range s.Completed {
 		completed.Issue = cloneIssue(completed.Issue)
+		completed.gateWaitEvidence = cloneIssue(completed.gateWaitEvidence)
 		cloned.Completed[id] = completed
 	}
 	for id, retry := range s.Retry {

--- a/internal/orchestrator/state.go
+++ b/internal/orchestrator/state.go
@@ -224,6 +224,7 @@ type Completed struct {
 	CompletedAt     time.Time
 	FinalState      string
 	CompletionKind  string
+	GateWaitReason  string
 	Tokens          TokenTotals
 	MergeTiming     MergeTiming
 	RuntimeIdentity agentidentity.Identity


### PR DESCRIPTION
## Summary

- Persist successful clean Rework completion as an exact-head source-gate wait so unchanged work cannot be dispatched repeatedly.
- Restore that wait after restart and release it only when actionable lane, pull-request head, check, merge-conflict, or P1 evidence changes.

Fixes #2030

## UI Surface Contract

- [x] N/A, or the linked issue explicitly authorizes any high-impact UI surface, layout, density, first-viewport, or responsive visibility tradeoff.
- [x] Persistent top-of-screen messaging is explicitly authorized by the issue, or this PR does not add it.
- [x] N/A — this PR has no visual changes to primary operator screens.

## Test Plan

- [x] `go test ./internal/orchestrator -count=1`
- [x] `make check`