### PR TITLE
test(orchestrator): stabilize descendant reap

### DIFF
--- a/internal/orchestrator/stop_run_process_unix_test.go
+++ b/internal/orchestrator/stop_run_process_unix_test.go
@@ -33,7 +33,15 @@ func TestStopRunReapsDescendantThatSurvivesParentCancellation(t *testing.T) {
 		started:            make(chan procgroup.Identity, 1),
 		descendantSurvived: make(chan int, 1),
 	}
-	observedDescendant := make(chan int, 1)
+	beforeTermination := make(chan int, 1)
+	allowTermination := make(chan struct{})
+	var allowTerminationOnce sync.Once
+	releaseTermination := func() {
+		allowTerminationOnce.Do(func() {
+			close(allowTermination)
+		})
+	}
+	defer releaseTermination()
 	orch, err := orchestrator.New(
 		orchestrator.Config{
 			PollInterval:        time.Hour,
@@ -52,10 +60,11 @@ func TestStopRunReapsDescendantThatSurvivesParentCancellation(t *testing.T) {
 			ReapWorkerProcess: func(ctx context.Context, identity procgroup.Identity, grace time.Duration) (procgroup.TerminationOutcome, error) {
 				select {
 				case descendantPID := <-runner.descendantSurvived:
-					observedDescendant <- descendantPID
+					beforeTermination <- descendantPID
 				case <-time.After(time.Second):
 					return "", errors.New("parent cancellation did not leave a surviving descendant")
 				}
+				<-allowTermination
 				return procgroup.Terminate(ctx, identity, grace)
 			},
 		},
@@ -85,10 +94,11 @@ func TestStopRunReapsDescendantThatSurvivesParentCancellation(t *testing.T) {
 		t.Fatalf("StopRun() = %#v, %v", result, err)
 	}
 
-	descendantPID := <-observedDescendant
+	descendantPID := <-beforeTermination
 	if !operatorStopProcessAlive(descendantPID) {
 		t.Fatalf("descendant %d exited before process-group termination", descendantPID)
 	}
+	releaseTermination()
 	waitForOperatorStopState(t, orch, func(state orchestrator.State) bool {
 		_, stillRunning := state.Running[issue.ID]
 		return !stillRunning


### PR DESCRIPTION
## Summary

- pause the injected worker reaper at an explicit pre-termination boundary
- verify parent cancellation leaves the descendant alive before releasing process-group termination
- release the test gate idempotently so cleanup cannot strand the process tree

Fixes #2038

## UI Surface Contract

- [x] N/A, or the linked issue explicitly authorizes any high-impact UI surface, layout, density, first-viewport, or responsive visibility tradeoff.
- [x] Persistent top-of-screen messaging is explicitly authorized by the issue, or this PR does not add it.
- [x] Visual changes to primary operator screens include screenshot or browser verification below.

No UI changes.

## Test Plan

- [x] `go test -race ./internal/orchestrator -run '^TestStopRunReapsDescendantThatSurvivesParentCancellation$' -count=100`
- [x] `go test -race ./...`
- [x] `make check`
