### PR TITLE
fix(project): isolate definition failures

### DIFF
--- a/internal/project/manager.go
+++ b/internal/project/manager.go
@@ -234,42 +234,45 @@ func (m *Manager) Start(ctx context.Context) error {
 	m.running = true
 
 	projects := make([]*Project, 0, len(m.cfg.Projects))
-	registered := make([]ID, 0, len(m.cfg.Projects))
+	rollbackIDs := make([]ID, 0, len(m.cfg.Projects))
 	for _, cfg := range m.cfg.Projects {
 		id, project, err := m.createProjectLocked(cfg)
 		if err != nil {
 			if m.handleInitialCreationFailureLocked(ctx, cfg, err) {
+				if errors.Is(err, ErrProjectDefinition) {
+					rollbackIDs = append(rollbackIDs, normalizeProjectID(ID(cfg.ID)))
+				}
 				continue
 			}
-			for _, registeredID := range registered {
-				m.registry.Delete(registeredID)
+			for _, rollbackID := range rollbackIDs {
+				m.registry.Delete(rollbackID)
 			}
 			m.running = false
 			m.mu.Unlock()
 			return errors.Join(err, closeProjectSlice(ctx, projects))
 		}
 		if _, ok := m.registry.Get(id); ok {
-			for _, registeredID := range registered {
-				m.registry.Delete(registeredID)
+			for _, rollbackID := range rollbackIDs {
+				m.registry.Delete(rollbackID)
 			}
 			m.running = false
 			m.mu.Unlock()
 			return errors.Join(ErrProjectExists, project.close(ctx, false), closeProjectSlice(ctx, projects))
 		}
 		if err := m.registry.Set(project); err != nil {
-			for _, registeredID := range registered {
-				m.registry.Delete(registeredID)
+			for _, rollbackID := range rollbackIDs {
+				m.registry.Delete(rollbackID)
 			}
 			m.running = false
 			m.mu.Unlock()
 			return errors.Join(err, project.close(ctx, false), closeProjectSlice(ctx, projects))
 		}
-		registered = append(registered, id)
+		rollbackIDs = append(rollbackIDs, id)
 		projects = append(projects, project)
 	}
 	if err := validatePauseExitReferences(projects); err != nil {
-		for _, registeredID := range registered {
-			m.registry.Delete(registeredID)
+		for _, rollbackID := range rollbackIDs {
+			m.registry.Delete(rollbackID)
 		}
 		m.running = false
 		m.mu.Unlock()
@@ -280,7 +283,7 @@ func (m *Manager) Start(ctx context.Context) error {
 
 	started, err := m.startInitialProjects(ctx, projects, startup)
 	if err != nil {
-		return errors.Join(err, m.rollbackInitialStart(ctx, registered, projects, started))
+		return errors.Join(err, m.rollbackInitialStart(ctx, rollbackIDs, projects, started))
 	}
 	if len(started) > 0 {
 		m.mu.Lock()
@@ -871,7 +874,7 @@ func (m *Manager) startInitialProjects(
 
 func (m *Manager) rollbackInitialStart(
 	ctx context.Context,
-	registered []ID,
+	rollbackIDs []ID,
 	projects []*Project,
 	started []startedProject,
 ) error {
@@ -887,7 +890,7 @@ func (m *Manager) rollbackInitialStart(
 	defer m.mu.Unlock()
 
 	if cleanupCtx.Err() == nil {
-		for _, id := range registered {
+		for _, id := range rollbackIDs {
 			m.registry.Delete(id)
 		}
 	}

--- a/internal/project/manager.go
+++ b/internal/project/manager.go
@@ -984,7 +984,8 @@ func (m *Manager) handleInitialCreationFailureLocked(
 	cfg globalconfig.Project,
 	err error,
 ) bool {
-	if !errors.Is(err, ErrConnectorCreation) {
+	isConnectorFailure := errors.Is(err, ErrConnectorCreation)
+	if !isConnectorFailure && !errors.Is(err, ErrProjectDefinition) {
 		return false
 	}
 
@@ -993,7 +994,7 @@ func (m *Manager) handleInitialCreationFailureLocked(
 		return false
 	}
 	cfg.ID = string(id)
-	if !connector.IsRetryable(err) {
+	if !isConnectorFailure || !connector.IsRetryable(err) {
 		runtimeErr := RuntimeError{Message: err.Error(), At: m.nowUTC(), Terminal: true}
 		if pendingErr := m.registry.SetPending(cfg, runtimeErr); pendingErr != nil {
 			return false

--- a/internal/project/manager_test.go
+++ b/internal/project/manager_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"errors"
 	"log/slog"
+	"path/filepath"
 	"reflect"
 	"slices"
 	"strings"
@@ -391,6 +392,97 @@ func TestManagerKeepsPermanentConnectorFactoryFailureTerminal(t *testing.T) {
 	case delay := <-retryStarted:
 		t.Fatalf("retry scheduled for permanent failure with delay %v", delay)
 	default:
+	}
+}
+
+func TestManagerStartIsolatesProjectDefinitionFailures(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name           string
+		invalidProject func(*testing.T, globalconfig.Project, project.Dependencies) (*project.Project, error)
+		wantError      string
+	}{
+		{
+			name: "load",
+			invalidProject: func(t *testing.T, cfg globalconfig.Project, deps project.Dependencies) (*project.Project, error) {
+				t.Helper()
+				cfg.Workflow = filepath.Join(t.TempDir(), "missing-workflow.md")
+				return project.Load(cfg, deps)
+			},
+			wantError: "missing-workflow.md",
+		},
+		{
+			name: "validation",
+			invalidProject: func(t *testing.T, cfg globalconfig.Project, deps project.Dependencies) (*project.Project, error) {
+				t.Helper()
+				workflowCfg := workflowConfig("memory")
+				workflowCfg.Routines = []workflowconfig.Routine{{
+					Name: "audit", Schedule: "0 3 * * 1", Prompt: "Inspect.",
+				}}
+				return project.New(project.Config{
+					Project:  cfg,
+					Workflow: workflowconfig.Workflow{Config: workflowCfg},
+				}, deps)
+			},
+			wantError: "schedule_ownership.enabled must be true",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			events := hub.New[project.Event](hub.WithBuffer(4))
+			coordinationStore := &projectCoordinationStore{}
+			manager, err := project.NewManager(project.ManagerConfig{
+				Projects: []globalconfig.Project{
+					{ID: "invalid", Weight: 1},
+					{ID: "valid", Weight: 1},
+				},
+			}, project.ManagerDependencies{
+				Events: events,
+				ProjectFactory: func(cfg globalconfig.Project) (*project.Project, error) {
+					if cfg.ID == "invalid" {
+						return tt.invalidProject(t, cfg, project.Dependencies{
+							Events: events, Runner: blockingRunner{},
+							RoutineStore: &projectRoutineStore{}, ScheduleStore: coordinationStore,
+						})
+					}
+					return newManagerTestProject(t, cfg, events)
+				},
+			})
+			if err != nil {
+				t.Fatalf("NewManager() error = %v", err)
+			}
+
+			if err := manager.Start(t.Context()); err != nil {
+				t.Fatalf("Start() error = %v, want isolated project degradation", err)
+			}
+			if _, ok := manager.Registry().Get("invalid"); ok {
+				t.Fatal("Registry().Get(invalid) ok = true, want no constructed runtime")
+			}
+			health, ok := manager.Registry().Pending("invalid")
+			if !ok {
+				t.Fatal("Registry().Pending(invalid) ok = false, want terminal degraded state")
+			}
+			if health.Status != project.HealthStatusDegraded || !health.RetryStopped || !health.NextRetryAt.IsZero() {
+				t.Fatalf("pending health = %#v, want terminal degraded state", health)
+			}
+			if !strings.Contains(health.LastError, tt.wantError) {
+				t.Fatalf("LastError = %q, want containing %q", health.LastError, tt.wantError)
+			}
+			valid, ok := manager.Registry().Get("valid")
+			if !ok || !valid.Running() {
+				t.Fatalf("Registry().Get(valid) = %#v, %t, want running project", valid, ok)
+			}
+			if calls := coordinationStore.Calls(); calls != 0 {
+				t.Fatalf("schedule ownership coordination calls = %d, want 0", calls)
+			}
+			if err := valid.Close(); err != nil {
+				t.Fatalf("Close() error = %v", err)
+			}
+		})
 	}
 }
 

--- a/internal/project/manager_test.go
+++ b/internal/project/manager_test.go
@@ -486,6 +486,36 @@ func TestManagerStartIsolatesProjectDefinitionFailures(t *testing.T) {
 	}
 }
 
+func TestManagerStartRollsBackPendingProjectDefinitionFailure(t *testing.T) {
+	t.Parallel()
+
+	factoryErr := errors.New("fatal project factory failure")
+	manager, err := project.NewManager(project.ManagerConfig{
+		Projects: []globalconfig.Project{
+			{ID: "invalid", Weight: 1},
+			{ID: "fatal", Weight: 1},
+		},
+	}, project.ManagerDependencies{
+		ProjectFactory: func(cfg globalconfig.Project) (*project.Project, error) {
+			if cfg.ID == "invalid" {
+				cfg.Workflow = filepath.Join(t.TempDir(), "missing-workflow.md")
+				return project.Load(cfg, project.Dependencies{})
+			}
+			return nil, factoryErr
+		},
+	})
+	if err != nil {
+		t.Fatalf("NewManager() error = %v", err)
+	}
+
+	if err := manager.Start(t.Context()); !errors.Is(err, factoryErr) {
+		t.Fatalf("Start() error = %v, want %v", err, factoryErr)
+	}
+	if _, ok := manager.Registry().Pending("invalid"); ok {
+		t.Fatal("Registry().Pending(invalid) ok = true after startup rollback")
+	}
+}
+
 func TestManagerReconcileRemovesPendingConnectorRetry(t *testing.T) {
 	t.Parallel()
 

--- a/internal/project/project.go
+++ b/internal/project/project.go
@@ -46,6 +46,7 @@ import (
 var (
 	ErrAlreadyRunning      = errors.New("project already running")
 	ErrConnectorCreation   = errors.New("project connector creation failed")
+	ErrProjectDefinition   = errors.New("project definition failed")
 	ErrMissingConnector    = errors.New("project connector is required")
 	ErrMissingOrchestrator = errors.New("project orchestrator is required")
 	ErrMissingProject      = errors.New("project is required")
@@ -101,6 +102,22 @@ type WorkflowSourceStatus struct {
 type Config struct {
 	Project  globalconfig.Project
 	Workflow workflowconfig.Workflow
+}
+
+type projectDefinitionError struct {
+	err error
+}
+
+func (e projectDefinitionError) Error() string {
+	return e.err.Error()
+}
+
+func (e projectDefinitionError) Unwrap() error {
+	return e.err
+}
+
+func (e projectDefinitionError) Is(target error) bool {
+	return target == ErrProjectDefinition
 }
 
 type ConnectorFactory func(workflowconfig.Config) (connector.Connector, error)
@@ -223,7 +240,7 @@ func (s *scheduleFaultState) current() RuntimeError {
 func Load(cfg globalconfig.Project, deps Dependencies) (*Project, error) {
 	workflow, err := LoadWorkflow(cfg)
 	if err != nil {
-		return nil, fmt.Errorf("load project workflow: %w", err)
+		return nil, projectDefinitionError{err: fmt.Errorf("load project workflow: %w", err)}
 	}
 
 	return New(Config{Project: cfg, Workflow: workflow}, deps)
@@ -240,10 +257,10 @@ func New(cfg Config, deps Dependencies) (*Project, error) {
 	workflow.Config = workflowConfigWithProjectIdentity(cfg.Project, workflow.Config)
 	workflow.Config = workflowConfigWithGitHubToken(workflow.Config, deps.GitHubToken)
 	if err := workflow.Config.Validate(); err != nil {
-		return nil, fmt.Errorf("validate project workflow: %w", err)
+		return nil, projectDefinitionError{err: fmt.Errorf("validate project workflow: %w", err)}
 	}
 	if err := workflowconfig.ValidateWorkflowAdmission(workflow); err != nil {
-		return nil, fmt.Errorf("validate project workflow: %w", err)
+		return nil, projectDefinitionError{err: fmt.Errorf("validate project workflow: %w", err)}
 	}
 
 	connectorFactory := resolveConnectorFactory(deps)


### PR DESCRIPTION
## Summary

- classify workflow load and validation errors as project-definition failures without changing their messages or underlying error chains
- record invalid definitions as terminal pending health during multi-project startup while valid projects continue to run
- cover missing workflow and schedule-ownership validation failures, including absence of schedule lease calls

Fixes #2042

## UI Surface Contract

- [x] N/A, or the linked issue explicitly authorizes any high-impact UI surface, layout, density, first-viewport, or responsive visibility tradeoff.
- [x] Persistent top-of-screen messaging is explicitly authorized by the issue, or this PR does not add it.
- [x] Visual changes to primary operator screens include screenshot or browser verification below.

No UI changes.

## Test Plan

- [x] `go test ./internal/project -run ^'TestManagerStartIsolatesProjectDefinitionFailures$' -count=1`
- [x] `go test ./internal/project -count=1`
- [x] `make check`