### PR TITLE
test(project): stabilize ownership health fault

### DIFF
--- a/internal/project/project_test.go
+++ b/internal/project/project_test.go
@@ -304,10 +304,7 @@ func TestScheduleOwnershipAcquisitionFailureDegradesRunningProject(t *testing.T)
 	if err := registry.Set(got); err != nil {
 		t.Fatalf("Registry.Set() error = %v", err)
 	}
-	health := registry.Health()
-	if len(health) != 1 || health[0].Status != project.HealthStatusDegraded || !strings.Contains(health[0].LastError, "coordination unavailable") {
-		t.Fatalf("Registry.Health() = %#v, want persistent schedule ownership fault", health)
-	}
+	waitForScheduleOwnershipFault(t, registry)
 }
 
 func TestNewLeavesBacklogAdmissionDisabledByDefault(t *testing.T) {
@@ -1856,6 +1853,25 @@ func waitForCoordinationCalls(t *testing.T, store *projectCoordinationStore, min
 		case <-ticker.C:
 		case <-deadline:
 			t.Fatalf("timed out waiting for %d coordination calls; got %d", minimum, store.Calls())
+		}
+	}
+}
+
+func waitForScheduleOwnershipFault(t *testing.T, registry *project.Registry) {
+	t.Helper()
+
+	ticker := time.NewTicker(10 * time.Millisecond)
+	defer ticker.Stop()
+	deadline := time.After(10 * time.Second)
+	for {
+		health := registry.Health()
+		if len(health) == 1 && health[0].Status == project.HealthStatusDegraded && strings.Contains(health[0].LastError, "coordination unavailable") {
+			return
+		}
+		select {
+		case <-ticker.C:
+		case <-deadline:
+			t.Fatalf("Registry.Health() = %#v, want persistent schedule ownership fault", health)
 		}
 	}
 }


### PR DESCRIPTION
## Summary

- wait for the observable degraded project health boundary before asserting the schedule ownership fault
- preserve explicit proof that schedule ownership acquisition reached the coordination store
- retain the persistent `coordination unavailable` health assertion

Fixes #2039

## UI Surface Contract

- [x] N/A, or the linked issue explicitly authorizes any high-impact UI surface, layout, density, first-viewport, or responsive visibility tradeoff.
- [x] Persistent top-of-screen messaging is explicitly authorized by the issue, or this PR does not add it.
- [x] Visual changes to primary operator screens include screenshot or browser verification below. N/A: test-only change.

## Test Plan

- [x] `go test -race ./internal/project -run ^TestScheduleOwnershipAcquisitionFailureDegradesRunningProject$ -count=100`
- [x] `env -u DETENT_API_TOKEN go test -race ./...`
- [x] `make check`