### PR TITLE
fix(runner): park credential-blocked workers

### DIFF
--- a/internal/runner/agent.go
+++ b/internal/runner/agent.go
@@ -1114,6 +1114,9 @@ func (r *Runner) runAgentTurn(
 		if deliverableErr := progress.deliverableError(); deliverableErr != nil {
 			turnErr = deliverableErr
 			result.FinalState = FinalStateFailed
+		} else if credentialErr := workerCredentialBlockerError(progress.finalMessage()); credentialErr != nil {
+			turnErr = credentialErr
+			result.FinalState = FinalStateFailed
 		}
 	}
 	result.DeliverableCommands = deliverableCommandEvidenceFromError(turnErr)
@@ -1992,24 +1995,96 @@ func IsDeliverableConfigurationError(err error) bool {
 		if deliverableErr == nil {
 			continue
 		}
-		detail := strings.ToLower(strings.TrimSpace(deliverableErr.Message + "\n" + deliverableErr.Body))
-		for _, phrase := range []string{
-			"gh auth login",
-			"populate gh_token",
-			"not logged into any github hosts",
-			"no credentials provided",
-			"bad credentials",
-			"authentication failed",
-			"authentication required",
-			"could not read username",
-			"permission denied (publickey)",
-			"github token is not configured",
-			"gh_token environment variable is empty",
-			"executable file not found",
-		} {
-			if strings.Contains(detail, phrase) {
-				return true
-			}
+		if deliverableCredentialFailureDetail(deliverableErr.Message + "\n" + deliverableErr.Body) {
+			return true
+		}
+	}
+	return false
+}
+
+func workerCredentialBlockerError(message string) error {
+	message = strings.TrimSpace(message)
+	if message == "" {
+		return nil
+	}
+	firstLine, _, _ := strings.Cut(message, "\n")
+	firstLine = strings.TrimSpace(strings.TrimLeft(firstLine, "#>*_- "))
+	blocked := strings.HasPrefix(strings.ToLower(firstLine), "blocked") || strings.HasPrefix(strings.ToLower(firstLine), "work is blocked")
+	if !blocked || !workerGitHubCredentialFailureDetail(message) {
+		return nil
+	}
+	return &DeliverableCommandError{
+		OperationClass: "pull_request",
+		Operation:      "read GitHub issue and pull request",
+		Status:         "blocked",
+		Message:        truncateDeliverableDetail(firstLine),
+		Body:           truncateDeliverableDetail(message),
+	}
+}
+
+func workerGitHubCredentialFailureDetail(detail string) bool {
+	detail = strings.ToLower(strings.TrimSpace(detail))
+	if !githubCredentialFailureDetail(detail) {
+		return false
+	}
+	for _, marker := range []string{
+		"github",
+		"gh auth",
+		"gh issue",
+		"gh pr",
+		"gh api",
+		"git clone",
+		"git fetch",
+		"git push",
+		"could not read username",
+		"permission denied (publickey)",
+	} {
+		if strings.Contains(detail, marker) {
+			return true
+		}
+	}
+	return false
+}
+
+func deliverableCredentialFailureDetail(detail string) bool {
+	if githubCredentialFailureDetail(detail) {
+		return true
+	}
+	detail = strings.ToLower(strings.TrimSpace(detail))
+	for _, phrase := range []string{
+		"executable file not found",
+	} {
+		if strings.Contains(detail, phrase) {
+			return true
+		}
+	}
+	return false
+}
+
+func githubCredentialFailureDetail(detail string) bool {
+	detail = strings.ToLower(strings.TrimSpace(detail))
+	for _, phrase := range []string{
+		"gh auth login",
+		"populate gh_token",
+		"not logged into any github hosts",
+		"no credentials provided",
+		"bad credentials",
+		"authentication failed",
+		"authentication required",
+		"could not read username",
+		"permission denied (publickey)",
+		"github token is not configured",
+		"gh_token environment variable is empty",
+		"missing github authentication",
+		"missing github credentials",
+		"github authentication is unavailable",
+		"github credentials are unavailable",
+		"github credential injection is disabled",
+		"github credential policy is disabled",
+		"github_credential_policy: isolated_disabled",
+	} {
+		if strings.Contains(detail, phrase) {
+			return true
 		}
 	}
 	return false
@@ -4371,6 +4446,15 @@ func (p *agentRunProgress) outputText() string {
 		}
 	}
 	return out.String()
+}
+
+func (p *agentRunProgress) finalMessage() string {
+	for index := len(p.messageOrder) - 1; index >= 0; index-- {
+		if message := p.messages[p.messageOrder[index]]; message != nil {
+			return message.String()
+		}
+	}
+	return ""
 }
 
 func (r *Runner) publishRunUpdate(

--- a/internal/runner/runner_test.go
+++ b/internal/runner/runner_test.go
@@ -3576,6 +3576,70 @@ func TestRunnerMergeFallbackOutcomes(t *testing.T) {
 	}
 }
 
+func TestRunnerClassifiesReportedCredentialBlocker(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		priorOutput string
+		output      string
+		wantError   bool
+	}{
+		{name: "credential blocker", output: "Blocked by missing GitHub authentication.\n\n`gh issue view` and `gh pr view` fail.", wantError: true},
+		{name: "credential detail after generic blocker heading", output: "Blocked.\n\nGitHub authentication is unavailable, so `gh issue view` fails.", wantError: true},
+		{name: "completed credential fix", output: "Fixed the path that previously reported Blocked by missing GitHub authentication."},
+		{name: "earlier blocker followed by success", priorOutput: "Blocked by missing GitHub authentication.", output: "Configured the worker credential and completed the requested change."},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			workspaceBackend := &fakeWorkspaceBackend{info: workspace.Info{Path: t.TempDir()}}
+			updates := make([]AgentUpdate, 0, 2)
+			if tt.priorOutput != "" {
+				updates = append(updates, AgentUpdate{
+					Type:   AgentUpdateMessageDelta,
+					ItemID: "prior-message",
+					Delta:  tt.priorOutput,
+				})
+			}
+			updates = append(updates, AgentUpdate{
+				Type:   AgentUpdateMessageDelta,
+				ItemID: "final-message",
+				Delta:  tt.output,
+			})
+			agentBackend := &fakeCodexClient{updates: updates}
+			runner, err := NewRunner(Dependencies{
+				Workflow:     config.Workflow{Config: config.Default()},
+				Workspace:    workspaceBackend,
+				AgentBackend: agentBackend,
+			})
+			if err != nil {
+				t.Fatalf("NewRunner() error = %v", err)
+			}
+
+			result, runErr := runner.Run(t.Context(), RunRequest{Issue: connector.Issue{
+				ID:         "issue-2020",
+				Identifier: "digitaldrywood/detent#2020",
+				State:      "Rework",
+			}})
+			if (runErr != nil) != tt.wantError {
+				t.Fatalf("Run() error = %v, want error %t", runErr, tt.wantError)
+			}
+			if tt.wantError {
+				if !IsDeliverableConfigurationError(runErr) {
+					t.Fatalf("IsDeliverableConfigurationError(%v) = false, want true", runErr)
+				}
+				if result.FinalState != FinalStateFailed {
+					t.Fatalf("FinalState = %q, want %q", result.FinalState, FinalStateFailed)
+				}
+			} else if result.FinalState != FinalStateCompleted {
+				t.Fatalf("FinalState = %q, want %q", result.FinalState, FinalStateCompleted)
+			}
+		})
+	}
+}
+
 func TestRunnerMergeFallbackModelPermit(t *testing.T) {
 	t.Parallel()
 

--- a/internal/runner/worker_github_test.go
+++ b/internal/runner/worker_github_test.go
@@ -102,6 +102,38 @@ func TestNewWorkerGitHubPolicy(t *testing.T) {
 	}
 }
 
+func TestWorkerCredentialBlockerError(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		message string
+		want    bool
+	}{
+		{name: "reported missing authentication", message: "Blocked by missing GitHub authentication.\n\n`gh issue view` and `gh pr view` fail.", want: true},
+		{name: "credential detail after generic blocker heading", message: "Blocked.\n\nGitHub authentication is unavailable, so `gh issue view` fails.", want: true},
+		{name: "reported disabled credential policy", message: "Work is blocked: GitHub credential injection is disabled for this worker.", want: true},
+		{name: "reported git credential failure", message: "Blocked because git push failed: could not read username for HTTPS remote.", want: true},
+		{name: "successful fix mentioning incident", message: "Fixed the path that previously reported Blocked by missing GitHub authentication."},
+		{name: "unrelated blocker", message: "Blocked by an ambiguous product decision."},
+		{name: "unrelated authentication blocker", message: "Blocked because authentication is required for the private package registry."},
+		{name: "credential diagnosis without blocker", message: "GitHub authentication was missing, so I configured the worker and completed the change."},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			err := workerCredentialBlockerError(tt.message)
+			if (err != nil) != tt.want {
+				t.Fatalf("workerCredentialBlockerError() = %v, want error %t", err, tt.want)
+			}
+			if err != nil && !IsDeliverableConfigurationError(err) {
+				t.Fatalf("IsDeliverableConfigurationError(%v) = false, want true", err)
+			}
+		})
+	}
+}
+
 func TestNewWorkerGitHubPolicyUsesGitHubEndpointForNonGitHubTracker(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

- detect terminal worker handoffs that explicitly report a GitHub or git credential blocker
- classify those handoffs through the existing non-retryable deliverable-configuration path so Detent parks the issue instead of redispatching it
- preserve the intentional `worker.github_token` isolation policy and cover recovered/successful handoffs against false positives

Fixes #2020

## UI Surface Contract

- [x] N/A, or the linked issue explicitly authorizes any high-impact UI surface, layout, density, first-viewport, or responsive visibility tradeoff.
- [x] Persistent top-of-screen messaging is explicitly authorized by the issue, or this PR does not add it.
- [x] Visual changes to primary operator screens include screenshot or browser verification below.

## Test Plan

- [x] `go test ./internal/runner ./internal/orchestrator -run '^(TestRunnerClassifiesReportedCredentialBlocker|TestWorkerCredentialBlockerError|TestMissingDeliverableCredentialsParkIssueWithoutRetry)$' -count=1`
- [x] `make check`
