### PR TITLE
fix(health): gate readiness on startup

### DIFF
--- a/docs/ONBOARDING.md
+++ b/docs/ONBOARDING.md
@@ -207,7 +207,7 @@ read-only; do not pass `--allow-write-probes` before Phase 2.5:
 
 ```sh
 detent doctor --port 0
-curl -fsS http://127.0.0.1:<port>/health | jq -e '.status == "ok"'
+curl -fsS http://127.0.0.1:<port>/health | jq -e '.status == "ok" and .ready and .lifecycle == "ready"'
 curl -fsS http://127.0.0.1:<port>/api/v1/state
 ```
 
@@ -3173,7 +3173,7 @@ awk 'NF {last=$0} END {exit last == "MUTATION_CONFIRMED=true" ? 0 : 1}' "$ONBOAR
 
    ```sh
    ss -ltnp | rg ':<port>|detent'
-   curl -fsS http://<dashboard-check-host>:<port>/health | jq -e '.status == "ok" and .mode == "running"'
+   curl -fsS http://<dashboard-check-host>:<port>/health | jq -e '.status == "ok" and .mode == "running" and .ready and .lifecycle == "ready"'
    curl -fsS http://<dashboard-check-host>:<port>/api/v1/state
    ```
 
@@ -3351,7 +3351,7 @@ awk 'NF {last=$0} END {exit last == "MUTATION_CONFIRMED=true" ? 0 : 1}' "$ONBOAR
 
    ```sh
    detent doctor --port 0 --allow-write-probes
-   curl -fsS http://<dashboard-check-host>:<port>/health | jq -e '.status == "ok" and .mode == "running"'
+   curl -fsS http://<dashboard-check-host>:<port>/health | jq -e '.status == "ok" and .mode == "running" and .ready and .lifecycle == "ready"'
    ```
 
 3. **Reload the runtime that needs the change.** Detent watches the active

--- a/docs/bootstrap.md
+++ b/docs/bootstrap.md
@@ -185,7 +185,7 @@ complete, annotated reference instance to compare against as you work.
 
    ```sh
    detent doctor --port 0 --allow-write-probes
-   curl -fsS http://127.0.0.1:4000/health | jq -e '.status == "ok" and .mode == "running"'
+   curl -fsS http://127.0.0.1:4000/health | jq -e '.status == "ok" and .mode == "running" and .ready and .lifecycle == "ready"'
    ```
 
 9. **Start Detent and confirm the dashboard:**

--- a/docs/dashboard-api.md
+++ b/docs/dashboard-api.md
@@ -194,7 +194,7 @@ Useful endpoints:
 | `/projects/<id>/diagnostics` | Project health, board flow, and telemetry diagnostics. |
 | `/settings` | Fleet settings and configuration summary. |
 | `/reports` | Usage reports for spend, tokens, projects, issues, PRs, and models. |
-| `/health` | Server health and configured dependency checks. |
+| `/health` | Server health, startup readiness, and configured dependency checks. |
 | `/events` | Server-sent dashboard updates. Use `?view=kanban` for the fleet board and `?project=<id>&view=kanban` for a project board. |
 | `/api/v1/openapi.yaml` | Public OpenAPI 3 catalog for the stable JSON API. HTML, HTMX, and SSE routes are excluded. |
 | `/api/v1/state` | JSON telemetry snapshot. |
@@ -218,6 +218,13 @@ object reports `behind_by_seconds`, each project reports
 `stale_after_seconds` expands with the observed multi-project sweep and includes
 headroom. A refresh becomes `degraded` only after that window is exceeded or a
 refresh source reaches its failure threshold.
+`/health` returns HTTP `503` with `status: "not_ready"`, `ready: false`, and a
+`lifecycle` of `starting` until running-mode startup succeeds. A fatal startup
+changes `lifecycle` to `failed` before serving stops. Other dashboard and API
+routes remain available during startup for diagnostics. After startup,
+`ready: true` and `lifecycle: "ready"` distinguish process readiness from
+project degradation and other operational health details.
+
 `/health` also reports `snapshot_generated_at`, `snapshot_age_seconds`, the
 current refresh object, per-project `tick_liveness`, and
 `orphaned_agent_processes` with process and session counts, total RSS, age, and

--- a/internal/cli/boot.go
+++ b/internal/cli/boot.go
@@ -448,6 +448,7 @@ func startRunningWithDependencies(ctx context.Context, cfg BootConfig, deps star
 	resourceWorkers.Go(func() {
 		persistBoardSnapshots(runCtx, snapshotHub, boardSnapshotStore, deps.boardSnapshotInterval, logger)
 	})
+	startupLifecycle := web.NewStartupLifecycle()
 	//nolint:contextcheck // Echo middleware receives request contexts at serve time.
 	server, err := web.NewServer(web.Config{
 		Mode:               web.ModeRunning,
@@ -472,6 +473,7 @@ func startRunningWithDependencies(ctx context.Context, cfg BootConfig, deps star
 		Store:               runtimeStore,
 		Registry:            manager.Registry(),
 		Connector:           firstConnector(manager),
+		StartupLifecycle:    startupLifecycle,
 		Refresher:           refresherForRegistry(manager.Registry()),
 		OperatorMoves:       registryRefresher{registry: manager.Registry()},
 		Recovery:            recoveryForRegistry(manager.Registry()),
@@ -562,11 +564,11 @@ func startRunningWithDependencies(ctx context.Context, cfg BootConfig, deps star
 		}
 		listenerOwned = false
 		if cfg.Shutdown == nil {
-			return runStartupAndServe(runCtx, startProjects, func(ctx context.Context) error {
+			return runStartupAndServe(runCtx, startupLifecycle, startProjects, func(ctx context.Context) error {
 				return serveWithTerminalDashboard(ctx, server, listener, snapshotHub, cfg.Build, runtimeLogPath(cfg), cfg.Output, nil, nil, nil)
 			})
 		}
-		return runStartupAndServe(runCtx, startProjects, func(ctx context.Context) error {
+		return runStartupAndServe(runCtx, startupLifecycle, startProjects, func(ctx context.Context) error {
 			return runWithShutdown(ctx, runningShutdownConfig{
 				Controller:        cfg.Shutdown,
 				Registry:          manager.Registry(),
@@ -596,11 +598,11 @@ func startRunningWithDependencies(ctx context.Context, cfg BootConfig, deps star
 	}
 	listenerOwned = false
 	if cfg.Shutdown == nil {
-		return runStartupAndServe(runCtx, startProjects, func(ctx context.Context) error {
+		return runStartupAndServe(runCtx, startupLifecycle, startProjects, func(ctx context.Context) error {
 			return serve(ctx, server, listener)
 		})
 	}
-	return runStartupAndServe(runCtx, startProjects, func(ctx context.Context) error {
+	return runStartupAndServe(runCtx, startupLifecycle, startProjects, func(ctx context.Context) error {
 		return runWithShutdown(ctx, runningShutdownConfig{
 			Controller:  cfg.Shutdown,
 			Registry:    manager.Registry(),
@@ -842,6 +844,7 @@ type startupServeResult struct {
 
 func runStartupAndServe(
 	ctx context.Context,
+	lifecycle *web.StartupLifecycle,
 	startup func(context.Context) error,
 	serveApp func(context.Context) error,
 ) error {
@@ -864,6 +867,7 @@ func runStartupAndServe(
 		result := <-results
 		switch result.name {
 		case "startup":
+			completeStartupLifecycle(lifecycle, result.err)
 			if result.err != nil {
 				cancel()
 				serveResult := <-results
@@ -881,6 +885,7 @@ func runStartupAndServe(
 			cancel()
 			if !startupDone {
 				startupResult := <-results
+				completeStartupLifecycle(lifecycle, startupResult.err)
 				if primaryShutdownError(result.err) {
 					logSecondaryShutdownError("startup", result.err, startupResult.err)
 					return result.err
@@ -895,6 +900,17 @@ func runStartupAndServe(
 			return result.err
 		}
 	}
+}
+
+func completeStartupLifecycle(lifecycle *web.StartupLifecycle, err error) {
+	if lifecycle == nil {
+		return
+	}
+	if err != nil {
+		lifecycle.MarkFailed()
+		return
+	}
+	lifecycle.MarkReady()
 }
 
 func primaryShutdownError(err error) bool {

--- a/internal/cli/boot_test.go
+++ b/internal/cli/boot_test.go
@@ -1037,8 +1037,38 @@ func TestStartRunningPublishesStartupSnapshotBeforeProjectStartCompletes(t *test
 	if !strings.Contains(body, `"running":0`) {
 		t.Fatalf("startup snapshot body missing zero running count:\n%s", body)
 	}
+	healthRequest, err := http.NewRequestWithContext(t.Context(), http.MethodGet, baseURL+"/health", nil)
+	if err != nil {
+		t.Fatalf("create GET /health request error = %v", err)
+	}
+	healthResponse, err := (&http.Client{Timeout: time.Second}).Do(healthRequest)
+	if err != nil {
+		t.Fatalf("GET /health error = %v", err)
+	}
+	healthBody, readErr := io.ReadAll(healthResponse.Body)
+	closeErr := healthResponse.Body.Close()
+	if readErr != nil {
+		t.Fatalf("read /health response error = %v", readErr)
+	}
+	if closeErr != nil {
+		t.Fatalf("close /health response error = %v", closeErr)
+	}
+	if healthResponse.StatusCode != http.StatusServiceUnavailable {
+		t.Fatalf("GET /health status = %d, want %d; body = %s", healthResponse.StatusCode, http.StatusServiceUnavailable, healthBody)
+	}
+	for _, want := range []string{`"status":"not_ready"`, `"ready":false`, `"lifecycle":"starting"`} {
+		if !strings.Contains(string(healthBody), want) {
+			t.Fatalf("startup health response missing %q:\n%s", want, healthBody)
+		}
+	}
 
 	close(provisionRelease)
+	healthBody = []byte(waitForDashboard(t, baseURL+"/health", done))
+	for _, want := range []string{`"status":"ok"`, `"ready":true`, `"lifecycle":"ready"`} {
+		if !strings.Contains(string(healthBody), want) {
+			t.Fatalf("ready health response missing %q:\n%s", want, healthBody)
+		}
+	}
 	cancel()
 	select {
 	case err := <-done:

--- a/internal/cli/shutdown_test.go
+++ b/internal/cli/shutdown_test.go
@@ -21,6 +21,7 @@ import (
 	projectpkg "github.com/digitaldrywood/detent/internal/project"
 	"github.com/digitaldrywood/detent/internal/store"
 	"github.com/digitaldrywood/detent/internal/telemetry"
+	"github.com/digitaldrywood/detent/internal/web"
 )
 
 func TestShutdownControllerQueuesRequests(t *testing.T) {
@@ -1121,7 +1122,7 @@ func TestRunWithShutdownGracefulResultPrecedesServeCleanupError(t *testing.T) {
 func TestRunStartupAndServeForcedResultPrecedesStartupAuthError(t *testing.T) {
 	t.Parallel()
 
-	err := runStartupAndServe(context.Background(), func(ctx context.Context) error {
+	err := runStartupAndServe(context.Background(), web.NewStartupLifecycle(), func(ctx context.Context) error {
 		<-ctx.Done()
 		cause := fmt.Errorf("resolve github_token via gh auth token: %w", errors.New("context deadline exceeded"))
 		return GitHubAuthError(cause)
@@ -1134,6 +1135,31 @@ func TestRunStartupAndServeForcedResultPrecedesStartupAuthError(t *testing.T) {
 	}
 	if got := ClassifyError(err).Slug; got != errorCodeShutdownForced {
 		t.Fatalf("ClassifyError() = %q, want %q", got, errorCodeShutdownForced)
+	}
+}
+
+func TestRunStartupAndServeMarksFailedBeforeCancelingServe(t *testing.T) {
+	t.Parallel()
+
+	lifecycle := web.NewStartupLifecycle()
+	serveStarted := make(chan struct{})
+	observed := make(chan web.StartupLifecycleState, 1)
+	startupErr := errors.New("startup failed")
+	err := runStartupAndServe(context.Background(), lifecycle, func(context.Context) error {
+		<-serveStarted
+		return startupErr
+	}, func(ctx context.Context) error {
+		close(serveStarted)
+		<-ctx.Done()
+		observed <- lifecycle.State()
+		return ctx.Err()
+	})
+
+	if !errors.Is(err, startupErr) {
+		t.Fatalf("runStartupAndServe() error = %v, want %v", err, startupErr)
+	}
+	if got := <-observed; got != web.StartupLifecycleFailed {
+		t.Fatalf("lifecycle at serve cancellation = %q, want %q", got, web.StartupLifecycleFailed)
 	}
 }
 

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -54,6 +54,7 @@ type Dependencies struct {
 	Store               store.Store
 	Registry            *project.Registry
 	Connector           connector.Connector
+	StartupLifecycle    *StartupLifecycle
 	Refresher           Refresher
 	OperatorMoves       OperatorMoveReconciler
 	Recovery            WorkAttemptRecovery
@@ -86,6 +87,44 @@ const (
 	ModeRunning    Mode = "running"
 	ModeOnboarding Mode = "onboarding"
 )
+
+type StartupLifecycleState string
+
+const (
+	StartupLifecycleStarting StartupLifecycleState = "starting"
+	StartupLifecycleReady    StartupLifecycleState = "ready"
+	StartupLifecycleFailed   StartupLifecycleState = "failed"
+)
+
+type StartupLifecycle struct {
+	state atomic.Uint32
+}
+
+func NewStartupLifecycle() *StartupLifecycle {
+	return &StartupLifecycle{}
+}
+
+func (l *StartupLifecycle) State() StartupLifecycleState {
+	if l == nil {
+		return StartupLifecycleReady
+	}
+	switch l.state.Load() {
+	case 0:
+		return StartupLifecycleStarting
+	case 1:
+		return StartupLifecycleReady
+	default:
+		return StartupLifecycleFailed
+	}
+}
+
+func (l *StartupLifecycle) MarkReady() {
+	l.state.Store(1)
+}
+
+func (l *StartupLifecycle) MarkFailed() {
+	l.state.Store(2)
+}
 
 const (
 	defaultHTTPReadHeaderTimeout = 5 * time.Second
@@ -134,6 +173,7 @@ type Server struct {
 	store               store.Store
 	registry            *project.Registry
 	connector           connector.Connector
+	startupLifecycle    *StartupLifecycle
 	refresher           Refresher
 	operatorMoves       OperatorMoveReconciler
 	recovery            WorkAttemptRecovery
@@ -251,6 +291,11 @@ func NewServer(cfg Config, deps Dependencies) (*Server, error) {
 	if observeProcesses == nil {
 		observeProcesses = procgroup.Observe
 	}
+	startupLifecycle := deps.StartupLifecycle
+	if startupLifecycle == nil {
+		startupLifecycle = NewStartupLifecycle()
+		startupLifecycle.MarkReady()
+	}
 
 	server := &Server{
 		echo:                e,
@@ -258,6 +303,7 @@ func NewServer(cfg Config, deps Dependencies) (*Server, error) {
 		store:               deps.Store,
 		registry:            deps.Registry,
 		connector:           deps.Connector,
+		startupLifecycle:    startupLifecycle,
 		refresher:           deps.Refresher,
 		operatorMoves:       deps.OperatorMoves,
 		recovery:            deps.Recovery,
@@ -1120,6 +1166,7 @@ func (s *Server) health(c echo.Context) error {
 	if _, _, err := s.demoScenarioOrError(c); err != nil {
 		return err
 	}
+	lifecycle := s.startupLifecycle.State()
 	status := "ok"
 	now := s.now().UTC()
 	sessionsRemaining := 0
@@ -1224,8 +1271,16 @@ func (s *Server) health(c echo.Context) error {
 		}
 	}
 	updateStatus.State = updateStatus.DisplayState(now)
-	return c.JSON(http.StatusOK, healthResponse{
+	httpStatus := http.StatusOK
+	ready := lifecycle == StartupLifecycleReady
+	if !ready {
+		httpStatus = http.StatusServiceUnavailable
+		status = "not_ready"
+	}
+	return c.JSON(httpStatus, healthResponse{
 		Status:                 status,
+		Ready:                  ready,
+		Lifecycle:              lifecycle,
 		Version:                s.build.Version,
 		Commit:                 s.build.Commit,
 		ProjectStatus:          projectStatus,
@@ -1708,6 +1763,8 @@ func (s *Server) connectorName() string {
 
 type healthResponse struct {
 	Status                 string                           `json:"status"`
+	Ready                  bool                             `json:"ready"`
+	Lifecycle              StartupLifecycleState            `json:"lifecycle"`
 	Version                string                           `json:"version"`
 	Commit                 string                           `json:"commit"`
 	ProjectStatus          string                           `json:"project_status"`

--- a/internal/web/server_test.go
+++ b/internal/web/server_test.go
@@ -142,6 +142,68 @@ func TestNewServerConfiguresHTTPTimeouts(t *testing.T) {
 	}
 }
 
+func TestHealthReportsStartupLifecycle(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name          string
+		transition    func(*web.StartupLifecycle)
+		wantHTTP      int
+		wantStatus    string
+		wantReady     bool
+		wantLifecycle web.StartupLifecycleState
+	}{
+		{
+			name:          "starting",
+			transition:    func(*web.StartupLifecycle) {},
+			wantHTTP:      http.StatusServiceUnavailable,
+			wantStatus:    "not_ready",
+			wantLifecycle: web.StartupLifecycleStarting,
+		},
+		{
+			name:          "ready",
+			transition:    (*web.StartupLifecycle).MarkReady,
+			wantHTTP:      http.StatusOK,
+			wantStatus:    "ok",
+			wantReady:     true,
+			wantLifecycle: web.StartupLifecycleReady,
+		},
+		{
+			name:          "failed",
+			transition:    (*web.StartupLifecycle).MarkFailed,
+			wantHTTP:      http.StatusServiceUnavailable,
+			wantStatus:    "not_ready",
+			wantLifecycle: web.StartupLifecycleFailed,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			lifecycle := web.NewStartupLifecycle()
+			tt.transition(lifecycle)
+			deps := testDeps(t)
+			deps.StartupLifecycle = lifecycle
+			server, err := web.NewServer(web.Config{}, deps)
+			if err != nil {
+				t.Fatalf("NewServer() error = %v", err)
+			}
+
+			payload := requestJSON(t, server, http.MethodGet, "/health", tt.wantHTTP)
+			if got := payload["status"]; got != tt.wantStatus {
+				t.Fatalf("status = %#v, want %q", got, tt.wantStatus)
+			}
+			if got := payload["ready"]; got != tt.wantReady {
+				t.Fatalf("ready = %#v, want %t", got, tt.wantReady)
+			}
+			if got := payload["lifecycle"]; got != string(tt.wantLifecycle) {
+				t.Fatalf("lifecycle = %#v, want %q", got, tt.wantLifecycle)
+			}
+		})
+	}
+}
+
 func TestServerRoutes(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

- return HTTP 503 with explicit starting or failed lifecycle state until running startup succeeds
- publish startup failure before canceling the serving context while preserving early dashboard diagnostics
- document and test the ready lifecycle contract across the health handler and real boot path

Fixes #2047

## UI Surface Contract

- [x] N/A; this change does not alter dashboard layout, density, first-viewport content, or responsive visibility.
- [x] This PR does not add persistent top-of-screen messaging.
- [x] This PR has no visual changes to primary operator screens.

## Test Plan

- [x] `make check`