### PR TITLE
fix(board): show retry-limit attempt error

### DIFF
--- a/internal/orchestrator/reconcile.go
+++ b/internal/orchestrator/reconcile.go
@@ -570,9 +570,11 @@ func clearBlockedStatusIssue(state *State, issueID string) {
 func (o *Orchestrator) setBlockedStatusIssue(ctx context.Context, state *State, issue connector.Issue, now time.Time) {
 	if existing, ok := state.Blocked[issue.ID]; ok && existing.Source == BlockedSourceProjectStatus {
 		existing.Issue = mergeIssueTrackerFields(existing.Issue, issue)
-		refreshedReason := o.reconciledBlockedStatusReason(ctx, state, existing.Issue)
+		refreshedReason, attemptError, workAttemptID := o.reconciledBlockedStatusDetails(ctx, state, existing.Issue)
 		currentReason := strings.TrimSpace(existing.Reason)
 		existing.Reason = refreshedReason
+		existing.AttemptError = attemptError
+		existing.WorkAttemptID = workAttemptID
 		if existing.RecoveryAction == "" &&
 			(blockedStatusReasonUnknown(currentReason) && !blockedStatusReasonUnknown(refreshedReason)) {
 			recovery := evaluateBlockedRecovery(existing.Issue, normalizeBlockedRecoveryConfig(BlockedRecoveryConfig{
@@ -592,13 +594,16 @@ func (o *Orchestrator) setBlockedStatusIssue(ctx context.Context, state *State, 
 		SourceStates: []string{blockedStatusState},
 		TargetState:  autoPromoteReworkState,
 	}), o.cfg.TerminalStates)
+	reason, attemptError, workAttemptID := o.reconciledBlockedStatusDetails(ctx, state, issue)
 	state.Blocked[issue.ID] = Blocked{
 		Issue:          cloneIssue(issue),
-		Reason:         o.reconciledBlockedStatusReason(ctx, state, issue),
+		Reason:         reason,
+		AttemptError:   attemptError,
 		RecoveryReason: string(recovery.Reason),
 		RecoveryTarget: recovery.TargetState,
 		BlockedAt:      now,
 		Source:         BlockedSourceProjectStatus,
+		WorkAttemptID:  workAttemptID,
 	}
 }
 
@@ -607,12 +612,28 @@ func blockedFromDependency(blocked Blocked) bool {
 		(blocked.Source == "" && blocked.Reason == blockedReasonDependency)
 }
 
-func (o *Orchestrator) reconciledBlockedStatusReason(ctx context.Context, state *State, issue connector.Issue) string {
+func (o *Orchestrator) reconciledBlockedStatusDetails(
+	ctx context.Context,
+	state *State,
+	issue connector.Issue,
+) (string, string, int64) {
 	detentCauses := []string{blockedStatusRuntimeCause(state, issue)}
+	attemptError := ""
+	workAttemptID := int64(0)
+	if state != nil {
+		if blocked, ok := state.Blocked[strings.TrimSpace(issue.ID)]; ok && blockedEntryMatchesCurrent(issue, blocked.BlockedAt) {
+			attemptError = strings.TrimSpace(blocked.AttemptError)
+			workAttemptID = blocked.WorkAttemptID
+		}
+	}
 	if timeline, ok := o.issueWorkflowTimeline(ctx, issue); ok {
 		detentCauses = append(detentCauses, blockedStatusTimelineCause(issue, timeline.Events))
+		if durableError, durableAttemptID := blockedStatusTimelineAttemptEvidence(issue, timeline.Events); durableError != "" {
+			attemptError = durableError
+			workAttemptID = durableAttemptID
+		}
 	}
-	return blockedStatusReason(issue, o.cfg.TerminalStates, detentCauses...)
+	return blockedStatusReason(issue, o.cfg.TerminalStates, detentCauses...), attemptError, workAttemptID
 }
 
 func blockedStatusRuntimeCause(state *State, issue connector.Issue) string {
@@ -680,6 +701,18 @@ func blockedStatusTimelineCause(issue connector.Issue, events []store.WorkflowPh
 		}
 	}
 	return ""
+}
+
+func blockedStatusTimelineAttemptEvidence(issue connector.Issue, events []store.WorkflowPhaseEvent) (string, int64) {
+	entry, ok := latestCurrentLaneEntry(events, blockedStatusState)
+	if !ok || !workflowLaneEntryMatchesCurrent(issue, entry) {
+		return "", 0
+	}
+	metadata, _ := workflowLaneMetadataFromJSON(entry.MetadataJSON)
+	if metadata.BlockedRecovery == nil {
+		return "", 0
+	}
+	return strings.TrimSpace(metadata.BlockedRecovery.AttemptError), metadata.BlockedRecovery.WorkAttemptID
 }
 
 func blockedStatusDetentAuthoredLane(metadata workflowLaneMetadata) bool {

--- a/internal/orchestrator/run_completion.go
+++ b/internal/orchestrator/run_completion.go
@@ -782,7 +782,7 @@ func (o *Orchestrator) handleWorkspacePreparationFailure(
 		nil,
 	)
 	if attemptCompleted {
-		count, known := o.consecutiveRetryCycleCount(ctx, state, running.Issue, workspacePreparationRetryLimitCause, event.CompletedAt)
+		count, latest, known := o.consecutiveRetryCycleCount(ctx, state, running.Issue, workspacePreparationRetryLimitCause, event.CompletedAt)
 		switch {
 		case !known:
 			o.recordRetryCycleHistoryUnavailable(state, running.Issue, workspacePreparationRetryLimitCause, event.CompletedAt)
@@ -795,6 +795,7 @@ func (o *Orchestrator) handleWorkspacePreparationFailure(
 				running.DiffStats,
 				workspacePreparationRetryLimitCause,
 				count,
+				latest,
 				event.CompletedAt,
 			); parked {
 				return

--- a/internal/orchestrator/snapshot.go
+++ b/internal/orchestrator/snapshot.go
@@ -889,6 +889,7 @@ func blockedSnapshots(blocked map[string]Blocked, claims map[string]Claimed, now
 		item := telemetry.Blocked{
 			Issue:                   issue,
 			Error:                   entry.Reason,
+			AttemptError:            entry.AttemptError,
 			Source:                  entry.Source,
 			RecoveryAction:          entry.RecoveryAction,
 			RecoveryReason:          entry.RecoveryReason,

--- a/internal/orchestrator/state.go
+++ b/internal/orchestrator/state.go
@@ -195,6 +195,7 @@ const (
 type Blocked struct {
 	Issue                   connector.Issue
 	Reason                  string
+	AttemptError            string
 	RecoveryAction          string
 	RecoveryReason          string
 	RecoveryTarget          string

--- a/internal/orchestrator/terminal_attempt_retry.go
+++ b/internal/orchestrator/terminal_attempt_retry.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/digitaldrywood/detent/internal/connector"
+	"github.com/digitaldrywood/detent/internal/runtimeoutput"
 	"github.com/digitaldrywood/detent/internal/store"
 	"github.com/digitaldrywood/detent/internal/telemetry"
 )
@@ -23,6 +24,7 @@ const (
 	workspacePreparationRetryLimitEvent         = "workspace_preparation_retry_limit_reached"
 	terminalAttemptRetryHistoryUnavailableEvent = "terminal_attempt_retry_history_unavailable"
 	workspaceRetryHistoryUnavailableEvent       = "workspace_preparation_retry_history_unavailable"
+	retryCycleAttemptErrorMaxBytes              = 4096
 )
 
 func (o *Orchestrator) demoteTerminalAttemptRetry(
@@ -44,12 +46,12 @@ func (o *Orchestrator) demoteTerminalAttemptRetry(
 		return issue, false, false
 	}
 	if durable {
-		count, known := o.consecutiveRetryCycleCount(ctx, state, issue, retryCause, at)
+		count, latest, known := o.consecutiveRetryCycleCount(ctx, state, issue, retryCause, at)
 		switch {
 		case !known:
 			o.recordRetryCycleHistoryUnavailable(state, issue, retryCause, at)
 		case count >= consecutiveRetryCycleLimit:
-			parked, ok := o.parkRetryCycleLimit(ctx, state, issue, runMode, diffStats, retryCause, count, at)
+			parked, ok := o.parkRetryCycleLimit(ctx, state, issue, runMode, diffStats, retryCause, count, latest, at)
 			if ok {
 				return parked, true, true
 			}
@@ -112,19 +114,23 @@ func (o *Orchestrator) consecutiveRetryCycleCount(
 	issue connector.Issue,
 	cause string,
 	at time.Time,
-) (int, bool) {
+) (int, telemetry.WorkAttempt, bool) {
 	attempts, ok := o.recentIssueTerminalAttempts(ctx, state, issue, consecutiveRetryCycleLimit, at)
 	if !ok {
-		return 0, false
+		return 0, telemetry.WorkAttempt{}, false
 	}
 	count := 0
+	latest := telemetry.WorkAttempt{}
 	for _, attempt := range attempts {
 		if !retryCycleAttemptMatches(attempt, cause) {
 			break
 		}
+		if count == 0 {
+			latest = attempt
+		}
 		count++
 	}
-	return count, true
+	return count, latest, true
 }
 
 func (o *Orchestrator) recentIssueTerminalAttempts(
@@ -224,6 +230,7 @@ func (o *Orchestrator) parkRetryCycleLimit(
 	diffStats DiffStats,
 	cause string,
 	count int,
+	latest telemetry.WorkAttempt,
 	at time.Time,
 ) (connector.Issue, bool) {
 	if o == nil || o.connector == nil || state == nil {
@@ -239,6 +246,10 @@ func (o *Orchestrator) parkRetryCycleLimit(
 		"Todo",
 		diffStats,
 	)
+	attemptError := retryCycleAttemptError(o, latest)
+	metadata.BlockedRecovery.WorkAttemptID = latest.AttemptID
+	metadata.BlockedRecovery.AttemptNumber = latest.AttemptNumber
+	metadata.BlockedRecovery.AttemptError = attemptError
 	if err := o.updateIssueStateByIDWithMetadata(ctx, state, issue.ID, issue, targetState, at, cause, metadata, laneMutationRevokeWorker); err != nil {
 		if o.logger != nil {
 			o.logger.Error("retry cycle limit state transition failed", "issue_id", issue.ID, "identifier", issue.Identifier, "cause", cause, "target_state", targetState, "error", err)
@@ -263,16 +274,12 @@ func (o *Orchestrator) parkRetryCycleLimit(
 		RecoveryTarget: metadata.BlockedRecovery.TargetState,
 		BlockedAt:      at,
 		Source:         BlockedSourceProjectStatus,
+		AttemptError:   attemptError,
+		WorkAttemptID:  latest.AttemptID,
 		Recovery:       metadata.BlockedRecovery,
 	}
 	if o.connector != nil {
-		comment := fmt.Sprintf(
-			"Detent stopped retrying %s after %d consecutive %s attempts. The issue is parked in `%s` until its recovery fingerprint changes.",
-			issueLabel(issue),
-			count,
-			retryCycleDescription(cause),
-			targetState,
-		)
+		comment := retryCycleLimitComment(issue, cause, count, targetState, latest, attemptError)
 		if err := o.connector.CreateComment(ctx, issue.ID, comment); err != nil && o.logger != nil {
 			o.logger.Warn("retry cycle limit comment failed", "issue_id", issue.ID, "identifier", issue.Identifier, "cause", cause, "error", err)
 		}
@@ -292,6 +299,39 @@ func (o *Orchestrator) parkRetryCycleLimit(
 		)
 	}
 	return issue, true
+}
+
+func retryCycleAttemptError(o *Orchestrator, attempt telemetry.WorkAttempt) string {
+	value := strings.TrimSpace(attempt.ErrorMessage)
+	if o != nil {
+		value = o.operatorText(value)
+	}
+	return runtimeoutput.Truncate(value, retryCycleAttemptErrorMaxBytes).Value
+}
+
+func retryCycleLimitComment(
+	issue connector.Issue,
+	cause string,
+	count int,
+	targetState string,
+	attempt telemetry.WorkAttempt,
+	attemptError string,
+) string {
+	comment := fmt.Sprintf(
+		"Detent stopped retrying %s after %d consecutive %s attempts. The issue is parked in `%s` until its recovery fingerprint changes.",
+		issueLabel(issue),
+		count,
+		retryCycleDescription(cause),
+		targetState,
+	)
+	if attemptError == "" {
+		return comment
+	}
+	attemptNumber := attempt.AttemptNumber
+	if attemptNumber <= 0 && attempt.AttemptID > 0 {
+		attemptNumber = int(attempt.AttemptID)
+	}
+	return fmt.Sprintf("%s\n\n- latest_attempt: %d\n- last_error:\n\n```text\n%s\n```", comment, attemptNumber, attemptError)
 }
 
 func retryCycleDescription(cause string) string {

--- a/internal/orchestrator/terminal_attempt_retry_test.go
+++ b/internal/orchestrator/terminal_attempt_retry_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"slices"
 	"strings"
 	"testing"
@@ -12,6 +13,7 @@ import (
 	"github.com/digitaldrywood/detent/internal/backendcapacity"
 	"github.com/digitaldrywood/detent/internal/connector"
 	runpkg "github.com/digitaldrywood/detent/internal/runner"
+	"github.com/digitaldrywood/detent/internal/runtimeoutput"
 	"github.com/digitaldrywood/detent/internal/scheduler"
 	"github.com/digitaldrywood/detent/internal/store"
 	"github.com/digitaldrywood/detent/internal/telemetry"
@@ -243,6 +245,8 @@ func TestHandleRunResultParksTerminalRetryAtDurableLimit(t *testing.T) {
 		FailureRetryBaseDelay: time.Second,
 	})
 	o := &Orchestrator{cfg: cfg, connector: tracker, workAttempts: attempts}
+	metrics := &autoPromoteWorkflowMetricsRecorder{}
+	o.workflowMetrics = metrics
 	state := newState(cfg)
 
 	for attempt := 1; attempt <= consecutiveRetryCycleLimit; attempt++ {
@@ -265,7 +269,7 @@ func TestHandleRunResultParksTerminalRetryAtDurableLimit(t *testing.T) {
 		o.handleRunResult(t.Context(), &state, runpkg.Completion{
 			IssueID:      issue.ID,
 			Request:      runpkg.RunRequest{Mode: runpkg.RunModePlan},
-			Err:          errors.New("runner failed before producing work"),
+			Err:          fmt.Errorf("runner failed on attempt %d before producing work", attempt),
 			CompletedAt:  completedAt,
 			RetryAttempt: attempt + 1,
 			RetryDelay:   time.Second,
@@ -282,11 +286,60 @@ func TestHandleRunResultParksTerminalRetryAtDurableLimit(t *testing.T) {
 	if !ok || blocked.Reason != terminalAttemptRetryLimitCause || blocked.Recovery == nil {
 		t.Fatalf("Blocked[%q] = %#v, want terminal retry limit park", issue.ID, blocked)
 	}
+	wantError := "runner failed on attempt 3 before producing work"
+	if blocked.AttemptError != wantError || blocked.WorkAttemptID != 3 {
+		t.Fatalf("Blocked[%q] attempt evidence = %q/%d, want %q/3", issue.ID, blocked.AttemptError, blocked.WorkAttemptID, wantError)
+	}
+	if blocked.Recovery.AttemptError != wantError || blocked.Recovery.WorkAttemptID != 3 {
+		t.Fatalf("Blocked[%q].Recovery attempt evidence = %q/%d, want %q/3", issue.ID, blocked.Recovery.AttemptError, blocked.Recovery.WorkAttemptID, wantError)
+	}
 	if _, ok := state.Retry[issue.ID]; ok {
 		t.Fatalf("Retry[%q] present after durable terminal retry limit", issue.ID)
 	}
 	if len(attempts.completions) != consecutiveRetryCycleLimit {
 		t.Fatalf("work attempt completions = %d, want %d", len(attempts.completions), consecutiveRetryCycleLimit)
+	}
+	if len(tracker.comments) != 1 || !strings.Contains(tracker.comments[0], wantError) {
+		t.Fatalf("retry-limit comments = %#v, want latest parked-attempt error", tracker.comments)
+	}
+
+	hydratedIssue := cloneIssue(issue)
+	hydratedIssue.State = blockedStatusState
+	parkedAt := now.Add(consecutiveRetryCycleLimit * time.Minute)
+	hydratedIssue.StageUpdatedAt = &parkedAt
+	restarted := &Orchestrator{cfg: cfg, workflowMetrics: metrics}
+	restartedState := newState(cfg)
+	restarted.setBlockedStatusIssue(t.Context(), &restartedState, hydratedIssue, parkedAt.Add(time.Minute))
+	restartedBlocked := restartedState.Blocked[issue.ID]
+	if restartedBlocked.Reason != terminalAttemptRetryLimitCause || restartedBlocked.AttemptError != wantError || restartedBlocked.WorkAttemptID != 3 {
+		t.Fatalf("restarted Blocked[%q] = %#v, want durable cause and attempt evidence", issue.ID, restartedBlocked)
+	}
+	snapshot := blockedSnapshots(restartedState.Blocked, nil, parkedAt.Add(time.Minute), nil)
+	if len(snapshot) != 1 || snapshot[0].Error != terminalAttemptRetryLimitCause || snapshot[0].AttemptError != wantError || snapshot[0].WorkAttemptID != 3 {
+		t.Fatalf("restarted blocked snapshot = %#v, want durable cause and attempt evidence", snapshot)
+	}
+}
+
+func TestRetryCycleAttemptErrorIsBoundedByOutputPolicy(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		configMax int
+		wantMax   int
+	}{
+		{name: "configured output policy", configMax: len(runtimeoutput.Marker) + 32, wantMax: len(runtimeoutput.Marker) + 32},
+		{name: "retry evidence hard limit", wantMax: retryCycleAttemptErrorMaxBytes},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			orchestrator := &Orchestrator{cfg: Config{OutputTruncationMaxBytes: tt.configMax}}
+			got := retryCycleAttemptError(orchestrator, telemetry.WorkAttempt{ErrorMessage: strings.Repeat("sensitive diagnostic ", 1000)})
+			if len(got) > tt.wantMax || !strings.Contains(got, runtimeoutput.Marker) {
+				t.Fatalf("retryCycleAttemptError() bytes = %d, want <= %d with truncation marker", len(got), tt.wantMax)
+			}
+		})
 	}
 }
 

--- a/internal/orchestrator/workflow_metrics.go
+++ b/internal/orchestrator/workflow_metrics.go
@@ -89,6 +89,9 @@ type workflowLaneBlockedRecoveryMetadata struct {
 	LifetimeTokens          int64  `json:"lifetime_tokens,omitempty"`
 	LifetimeSessionLimit    int64  `json:"lifetime_session_limit,omitempty"`
 	LifetimeTokenLimit      int64  `json:"lifetime_token_limit,omitempty"`
+	WorkAttemptID           int64  `json:"work_attempt_id,omitempty"`
+	AttemptNumber           int    `json:"attempt_number,omitempty"`
+	AttemptError            string `json:"attempt_error,omitempty"`
 }
 
 func (m workflowLaneBlockedRecoveryMetadata) intentResumable() bool {

--- a/internal/orchestrator/workspace_preparation_test.go
+++ b/internal/orchestrator/workspace_preparation_test.go
@@ -3,6 +3,7 @@ package orchestrator
 import (
 	"fmt"
 	"slices"
+	"strings"
 	"testing"
 	"time"
 
@@ -92,6 +93,9 @@ func TestWorkspacePreparationRetriesAreBoundedAndPreserveFailureBreakers(t *test
 			if !ok || blocked.Reason != workspacePreparationRetryLimitCause || blocked.Recovery == nil || blocked.RecoveryReason != blockedRecoveryPredicateFingerprintChange {
 				t.Fatalf("Blocked[%q] = %#v, want durable fingerprint-recovery park", issue.ID, blocked)
 			}
+			if blocked.AttemptError != tt.err.Error() || blocked.WorkAttemptID != retryLimit {
+				t.Fatalf("Blocked[%q] attempt evidence = %q/%d, want %q/%d", issue.ID, blocked.AttemptError, blocked.WorkAttemptID, tt.err.Error(), retryLimit)
+			}
 			if _, ok := state.Retry[issue.ID]; ok {
 				t.Fatalf("Retry[%q] present after workspace preparation retry limit", issue.ID)
 			}
@@ -103,6 +107,9 @@ func TestWorkspacePreparationRetriesAreBoundedAndPreserveFailureBreakers(t *test
 			}
 			if event, ok := recentStateEvent(state, workspacePreparationRetryLimitEvent); !ok || event.Message == "" {
 				t.Fatalf("RecentEvents = %#v, want workspace preparation limit event", state.RecentEvents)
+			}
+			if len(tracker.comments) != 1 || !strings.Contains(tracker.comments[0], tt.err.Error()) {
+				t.Fatalf("retry-limit comments = %#v, want latest workspace-preparation error", tracker.comments)
 			}
 		})
 	}

--- a/internal/telemetry/snapshot.go
+++ b/internal/telemetry/snapshot.go
@@ -1324,6 +1324,7 @@ type Blocked struct {
 	WorkspacePath           string               `json:"workspace_path,omitempty"`
 	SessionID               string               `json:"session_id,omitempty"`
 	Error                   string               `json:"error,omitempty"`
+	AttemptError            string               `json:"attempt_error,omitempty"`
 	Source                  BlockedSource        `json:"source,omitempty"`
 	RecoveryAction          string               `json:"recovery_action,omitempty"`
 	RecoveryReason          string               `json:"recovery_reason,omitempty"`

--- a/internal/web/api.go
+++ b/internal/web/api.go
@@ -605,7 +605,7 @@ func issueResponse(reference string, projectID string, snapshot telemetry.Snapsh
 		payload.Workspace = workspaceResponse(blocked.WorkspacePath, blocked.WorkerHost)
 		payload.Blocked = blockedIssueResponse(blocked)
 		payload.RecentEvents = recentEvents(blocked.LastEventAt, blocked.LastEvent, blocked.LastMessage)
-		payload.LastError = optionalString(blocked.Error)
+		payload.LastError = optionalString(blockedLastError(blocked))
 		return payload, nil
 	}
 
@@ -709,6 +709,7 @@ func blockedEntries(entries []telemetry.Blocked) []blockedAPIResponse {
 			BudgetAlert:             false,
 			State:                   entry.State,
 			Error:                   optionalString(entry.Error),
+			AttemptError:            optionalString(entry.AttemptError),
 			Source:                  string(entry.Source),
 			RecoveryAction:          optionalString(entry.RecoveryAction),
 			RecoveryReason:          optionalString(entry.RecoveryReason),
@@ -807,6 +808,7 @@ func blockedIssueResponse(entry telemetry.Blocked) *blockedIssueAPIResponse {
 		SessionID:               optionalString(entry.SessionID),
 		State:                   entry.State,
 		Error:                   optionalString(entry.Error),
+		AttemptError:            optionalString(entry.AttemptError),
 		Source:                  string(entry.Source),
 		RecoveryAction:          optionalString(entry.RecoveryAction),
 		RecoveryReason:          optionalString(entry.RecoveryReason),
@@ -823,6 +825,13 @@ func blockedIssueResponse(entry telemetry.Blocked) *blockedIssueAPIResponse {
 		LastMessage:             optionalString(entry.LastMessage),
 		LastEventAt:             timestampStringPtr(entry.LastEventAt),
 	}
+}
+
+func blockedLastError(entry telemetry.Blocked) string {
+	if attemptError := strings.TrimSpace(entry.AttemptError); attemptError != "" {
+		return attemptError
+	}
+	return strings.TrimSpace(entry.Error)
 }
 
 func recentEvents(at *time.Time, event string, message string) []recentEventAPIResponse {
@@ -1560,6 +1569,7 @@ type blockedAPIResponse struct {
 	BudgetAlert             bool                           `json:"budget_alert?"`
 	State                   string                         `json:"state"`
 	Error                   *string                        `json:"error"`
+	AttemptError            *string                        `json:"attempt_error"`
 	Source                  string                         `json:"source,omitempty"`
 	RecoveryAction          *string                        `json:"recovery_action"`
 	RecoveryReason          *string                        `json:"recovery_reason"`
@@ -1828,6 +1838,7 @@ type blockedIssueAPIResponse struct {
 	SessionID               *string                        `json:"session_id"`
 	State                   string                         `json:"state"`
 	Error                   *string                        `json:"error"`
+	AttemptError            *string                        `json:"attempt_error"`
 	Source                  string                         `json:"source,omitempty"`
 	RecoveryAction          *string                        `json:"recovery_action"`
 	RecoveryReason          *string                        `json:"recovery_reason"`

--- a/internal/web/api_issue_test.go
+++ b/internal/web/api_issue_test.go
@@ -102,6 +102,41 @@ func TestAPIIssuePrecedenceAndScope(t *testing.T) {
 	}
 }
 
+func TestAPIIssueSurfacesRetryLimitAttemptError(t *testing.T) {
+	t.Parallel()
+
+	issue := telemetry.Issue{
+		ID:         "issue-2052",
+		Identifier: "digitaldrywood/detent#2052",
+		Number:     2052,
+		ProjectID:  "detent",
+		State:      "Blocked",
+	}
+	snapshots := hub.New[telemetry.Snapshot]()
+	if err := snapshots.Publish(telemetry.Snapshot{Blocked: []telemetry.Blocked{{
+		Issue:        issue,
+		Error:        "terminal_attempt_retry_limit",
+		AttemptError: "custom backend rejected --lease-ttl",
+	}}}); err != nil {
+		t.Fatalf("Publish() error = %v", err)
+	}
+	deps := testDeps(t)
+	deps.Hub = snapshots
+	server, err := web.NewServer(web.Config{}, deps)
+	if err != nil {
+		t.Fatalf("NewServer() error = %v", err)
+	}
+
+	payload := requestJSON(t, server, http.MethodGet, "/api/v1/issue-2052", http.StatusOK)
+	if payload["last_error"] != "custom backend rejected --lease-ttl" {
+		t.Fatalf("last_error = %#v, want parked-attempt evidence", payload["last_error"])
+	}
+	blocked := payload["blocked"].(map[string]any)
+	if blocked["error"] != "terminal_attempt_retry_limit" || blocked["attempt_error"] != "custom backend rejected --lease-ttl" {
+		t.Fatalf("blocked = %#v, want structured cause alongside attempt evidence", blocked)
+	}
+}
+
 func TestAPIIssueSurfacesWorkpadBlockerResolution(t *testing.T) {
 	t.Parallel()
 

--- a/internal/web/templates/board_data_test.go
+++ b/internal/web/templates/board_data_test.go
@@ -56,6 +56,39 @@ func TestBoardDetailSheetRendersEfficiencyReceipt(t *testing.T) {
 	}
 }
 
+func TestBoardDetailSheetShowsRetryLimitAttemptError(t *testing.T) {
+	t.Parallel()
+
+	card := projectKanbanCard{
+		IssueID:     "issue-2052",
+		IssueNumber: "#2052",
+		Identifier:  "digitaldrywood/detent#2052",
+		ProjectID:   "detent",
+		Title:       "Retry limit evidence",
+		Stage:       "Blocked",
+	}
+	data := DashboardData{
+		ProjectID: "detent",
+		Snapshot: telemetry.Snapshot{Blocked: []telemetry.Blocked{{
+			Issue: telemetry.Issue{
+				ID:         card.IssueID,
+				Identifier: card.Identifier,
+				ProjectID:  card.ProjectID,
+				State:      card.Stage,
+			},
+			Error:        "terminal_attempt_retry_limit",
+			AttemptError: "custom backend rejected --lease-ttl",
+		}}},
+	}
+
+	html := renderBoardComponent(t, BoardCardSheet(data, card, false, false, KanbanConversationData{}, BoardActivityData{}, BoardSessionData{}))
+	for _, want := range []string{"terminal_attempt_retry_limit", "last attempt", "custom backend rejected --lease-ttl"} {
+		if !strings.Contains(html, want) {
+			t.Fatalf("detail sheet missing %q:\n%s", want, html)
+		}
+	}
+}
+
 func TestBoardCardRendersCumulativeParkSummary(t *testing.T) {
 	t.Parallel()
 

--- a/internal/web/templates/sheet_data.go
+++ b/internal/web/templates/sheet_data.go
@@ -118,7 +118,7 @@ func sheetSessionFor(snapshot telemetry.Snapshot, card projectKanbanCard) sheetS
 				SessionID:       strings.TrimSpace(blocked.SessionID),
 				LastEvent:       strings.TrimSpace(blocked.LastEvent),
 				Message:         strings.TrimSpace(blocked.LastMessage),
-				Error:           strings.TrimSpace(blocked.Error),
+				Error:           blockedSessionError(blocked),
 				RuntimeIdentity: card.RuntimeIdentity,
 			}
 			return session
@@ -133,6 +133,18 @@ func sheetSessionFor(snapshot telemetry.Snapshot, card projectKanbanCard) sheetS
 		}
 	}
 	return sheetSession{}
+}
+
+func blockedSessionError(blocked telemetry.Blocked) string {
+	cause := strings.TrimSpace(blocked.Error)
+	attemptError := strings.TrimSpace(blocked.AttemptError)
+	if cause == "" {
+		return attemptError
+	}
+	if attemptError == "" {
+		return cause
+	}
+	return cause + " — last attempt: " + attemptError
 }
 
 func findEfficiencyReceipt(receipts []efficiency.Receipt, issue telemetry.Issue) (efficiency.Receipt, bool) {


### PR DESCRIPTION
## Summary

- Persist the bounded latest matching work-attempt error with retry-limit park metadata while preserving the structured recovery cause.
- Restore the evidence after refresh or restart and show it in the board detail and issue API for terminal and workspace-preparation retry limits.

Fixes #2052

## UI Surface Contract

- [x] Issue #2052 explicitly authorizes showing retry-limit error evidence on the board detail; this does not change layout, density, first-viewport, or responsive visibility.
- [x] This PR does not add persistent top-of-screen messaging.
- [x] This is a content-only change in existing markup; server-rendered regression coverage verifies the board detail output without a visual baseline change.

## Test Plan

- [x] `make check`