### PR TITLE
feat(doctor): report workflow ref working-tree drift

### DIFF
--- a/internal/cli/doctor_project.go
+++ b/internal/cli/doctor_project.go
@@ -271,16 +271,31 @@ func checkDoctorProjectWithProgress(
 		workflow.Config.Identity = identity
 	}
 	workflow.Config.ActiveHours = projectpkg.EffectiveActiveHours(project, workflow.Config.ActiveHours)
-	if err := workflow.Config.Validate(); err != nil {
-		return []doctorCheck{
+	validationErr := workflow.Config.Validate()
+	workflowRefDriftCheck, workflowRefDrift := checkDoctorWorkflowRefDrift(
+		ctx,
+		id,
+		project,
+		projectSourceRoot(project, workflow.Config),
+		validationErr,
+		githubToken,
+		deps,
+	)
+	if validationErr != nil {
+		failedChecks := []doctorCheck{
 			{
 				Name:              workflowCheckName,
 				Status:            doctorFail,
-				Detail:            fmt.Sprintf("%s: %v", project.Workflow, err),
+				Detail:            fmt.Sprintf("%s: %v", project.Workflow, validationErr),
 				Hint:              "Fix invalid Detent configuration in detent.yaml or legacy WORKFLOW.md frontmatter.",
 				ProjectDefinition: doctorProjectDefinition(id, workflow.Definition),
 			},
-			{
+		}
+		if workflowRefDrift {
+			failedChecks = append(failedChecks, workflowRefDriftCheck)
+		}
+		return append(failedChecks,
+			doctorCheck{
 				Name:   "Project " + id + " source repo",
 				Status: doctorWarn,
 				Detail: "skipped because WORKFLOW.md is invalid",
@@ -288,7 +303,7 @@ func checkDoctorProjectWithProgress(
 			},
 			checkDoctorIssueEffortGuidanceUnavailable(id, "WORKFLOW.md is invalid"),
 			checkDoctorFollowupGuidanceUnavailable(id, "WORKFLOW.md is invalid"),
-		}
+		)
 	}
 	if pauseCheck, ok := checkDoctorProjectPause(ctx, id, project, workflow.Config, deps); ok {
 		checks = append(checks, pauseCheck)
@@ -348,6 +363,9 @@ func checkDoctorProjectWithProgress(
 	setDoctorCurrentCheck("Project " + id + " workflow source policy")
 	if sourcePolicyCheck, ok := checkDoctorWorkflowSourcePolicy(ctx, id, project, workflow.Config, projectSourceRoot(project, workflow.Config), deps); ok {
 		checks = append(checks, sourcePolicyCheck)
+	}
+	if workflowRefDrift {
+		checks = append(checks, workflowRefDriftCheck)
 	}
 	setDoctorCurrentCheck("Project " + id + " local workflow overlay")
 	if overlayCheck, ok := checkDoctorLocalWorkflowOverlay(ctx, id, workflow, deps); ok {

--- a/internal/cli/doctor_workflow_source.go
+++ b/internal/cli/doctor_workflow_source.go
@@ -8,10 +8,15 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"reflect"
+	"sort"
 	"strings"
+
+	"gopkg.in/yaml.v3"
 
 	workflowconfig "github.com/digitaldrywood/detent/internal/config"
 	globalconfig "github.com/digitaldrywood/detent/internal/config/global"
+	projectpkg "github.com/digitaldrywood/detent/internal/project"
 )
 
 type doctorWorkflowSourcePolicyFunc func(context.Context, string, globalconfig.Project, string, string) doctorCheck
@@ -143,6 +148,275 @@ func checkDoctorWorkflowRefFreshness(ctx context.Context, projectID string, proj
 	}
 }
 
+func checkDoctorWorkflowRefDrift(
+	ctx context.Context,
+	projectID string,
+	project globalconfig.Project,
+	sourceRoot string,
+	effectiveValidationErr error,
+	githubToken RuntimeSecret,
+	deps doctorDeps,
+) (doctorCheck, bool) {
+	ref := strings.TrimSpace(project.WorkflowRef)
+	if ref == "" {
+		return doctorCheck{}, false
+	}
+	if strings.TrimSpace(project.Workdir) != "" {
+		expandedWorkdir, err := expandDoctorWorkspacePath(project.Workdir)
+		if err != nil {
+			return doctorCheck{}, false
+		}
+		sourceRoot = expandedWorkdir
+	}
+
+	revision, err := doctorWorkflowSourceGit(ctx, sourceRoot, "rev-parse", "--verify", ref+"^{commit}")
+	if err != nil {
+		return doctorCheck{}, false
+	}
+	revision = strings.TrimSpace(revision)
+	workflowPath, relativeWorkflowPath, configPath, relativeConfigPath, err := doctorWorkflowDefinitionPaths(project, sourceRoot)
+	if err != nil {
+		return doctorCheck{}, false
+	}
+
+	workingWorkflow, err := os.ReadFile(workflowPath)
+	if err != nil {
+		return doctorWorkflowRefReadFailure(projectID, ref, revision, "working-tree WORKFLOW.md", err), true
+	}
+	refWorkflow, err := doctorWorkflowSourceGit(ctx, sourceRoot, "show", revision+":"+relativeWorkflowPath)
+	if err != nil {
+		return doctorWorkflowRefReadFailure(projectID, ref, revision, "ref-backed WORKFLOW.md", err), true
+	}
+	workingConfig, workingHasConfig, err := doctorReadOptionalWorkflowSourceFile(configPath)
+	if err != nil {
+		return doctorWorkflowRefReadFailure(projectID, ref, revision, "working-tree detent.yaml", err), true
+	}
+	refConfig, refHasConfig, err := doctorReadOptionalWorkflowRefFile(ctx, sourceRoot, revision, relativeConfigPath)
+	if err != nil {
+		return doctorWorkflowRefReadFailure(projectID, ref, revision, "ref-backed detent.yaml", err), true
+	}
+
+	differences := doctorWorkflowDefinitionDifferences(
+		workingWorkflow,
+		[]byte(refWorkflow),
+		workingConfig,
+		workingHasConfig,
+		refConfig,
+		refHasConfig,
+	)
+	if len(differences) == 0 {
+		return doctorCheck{}, false
+	}
+
+	status := doctorWarn
+	details := []string{
+		fmt.Sprintf(
+			"project %s working-tree project definition differs from workflow_ref %s at %s",
+			projectID,
+			ref,
+			doctorShortRevision(revision),
+		),
+	}
+	details = append(details, differences...)
+	workingValidationErr := doctorWorkingTreeWorkflowValidation(project, workflowPath, githubToken, deps)
+	if workingValidationErr == nil && effectiveValidationErr != nil {
+		status = doctorFail
+		details = append(details, "working-tree configuration passes validation while ref-backed configuration fails: "+effectiveValidationErr.Error())
+	}
+
+	return doctorCheck{
+		Name:   "Project " + projectID + " workflow ref drift",
+		Status: status,
+		Detail: strings.Join(details, "; "),
+		Hint: fmt.Sprintf(
+			"Commit the intended project-definition changes to the branch behind %s and fetch it, or restore the working-tree files to match; Detent continues reading commit %s.",
+			ref,
+			doctorShortRevision(revision),
+		),
+	}, true
+}
+
+func doctorWorkflowRefReadFailure(projectID string, ref string, revision string, file string, err error) doctorCheck {
+	return doctorCheck{
+		Name:   "Project " + projectID + " workflow ref drift",
+		Status: doctorWarn,
+		Detail: fmt.Sprintf("project %s workflow_ref %s at %s could not be compared with %s: %v", projectID, ref, doctorShortRevision(revision), file, err),
+		Hint:   "Restore readable working-tree project-definition files, then rerun detent doctor.",
+	}
+}
+
+func doctorWorkingTreeWorkflowValidation(project globalconfig.Project, workflowPath string, githubToken RuntimeSecret, deps doctorDeps) error {
+	if deps.loadWorkflow == nil {
+		return errors.New("working-tree workflow loader is unavailable")
+	}
+	workflow, err := deps.loadWorkflow(workflowPath)
+	if err != nil {
+		return err
+	}
+	workflow.Config = doctorWorkflowConfigWithRuntimeGitHubToken(workflow.Config, runtimeGlobalGitHubToken(githubToken))
+	if project.Identity.Configured() {
+		identity := project.Identity
+		identity.Normalize()
+		workflow.Config.Identity = identity
+	}
+	workflow.Config.ActiveHours = projectpkg.EffectiveActiveHours(project, workflow.Config.ActiveHours)
+	return workflow.Config.Validate()
+}
+
+func doctorWorkflowDefinitionDifferences(
+	workingWorkflow []byte,
+	refWorkflow []byte,
+	workingConfig []byte,
+	workingHasConfig bool,
+	refConfig []byte,
+	refHasConfig bool,
+) []string {
+	var differences []string
+	if !bytes.Equal(doctorNormalizedWorkflowPolicy(workingWorkflow), doctorNormalizedWorkflowPolicy(refWorkflow)) {
+		differences = append(differences, doctorWorkflowFileDifferences(workingWorkflow, refWorkflow)...)
+	}
+	if workingHasConfig != refHasConfig || !bytes.Equal(doctorNormalizedWorkflowPolicy(workingConfig), doctorNormalizedWorkflowPolicy(refConfig)) {
+		paths, err := doctorYAMLDriftPaths(workingConfig, refConfig)
+		switch {
+		case err != nil:
+			differences = append(differences, "detent.yaml differs")
+		case len(paths) > 0:
+			differences = append(differences, "detent.yaml keys differ: "+strings.Join(paths, ", "))
+		default:
+			differences = append(differences, "detent.yaml comments or formatting differ")
+		}
+	}
+	return differences
+}
+
+func doctorWorkflowFileDifferences(working []byte, ref []byte) []string {
+	workingFrontmatter, workingPrompt, workingErr := doctorWorkflowDocumentParts(working)
+	refFrontmatter, refPrompt, refErr := doctorWorkflowDocumentParts(ref)
+	if workingErr != nil || refErr != nil {
+		return []string{"WORKFLOW.md differs"}
+	}
+
+	var differences []string
+	paths, err := doctorYAMLDriftPaths(workingFrontmatter, refFrontmatter)
+	if err != nil {
+		differences = append(differences, "WORKFLOW.md configuration differs")
+	} else if len(paths) > 0 {
+		differences = append(differences, "WORKFLOW.md config keys differ: "+strings.Join(paths, ", "))
+	}
+	if !bytes.Equal(doctorNormalizedWorkflowPolicy(workingPrompt), doctorNormalizedWorkflowPolicy(refPrompt)) {
+		differences = append(differences, "WORKFLOW.md prompt differs")
+	}
+	if len(differences) == 0 {
+		differences = append(differences, "WORKFLOW.md comments or formatting differ")
+	}
+	return differences
+}
+
+func doctorWorkflowDocumentParts(raw []byte) ([]byte, []byte, error) {
+	normalized := bytes.TrimPrefix(doctorNormalizedWorkflowPolicy(raw), []byte{0xef, 0xbb, 0xbf})
+	if !bytes.HasPrefix(normalized, []byte("---\n")) {
+		return nil, normalized, nil
+	}
+	body := normalized[len("---\n"):]
+	if before, after, ok := bytes.Cut(body, []byte("\n---\n")); ok {
+		return before, after, nil
+	}
+	if before, ok := bytes.CutSuffix(body, []byte("\n---")); ok {
+		return before, nil, nil
+	}
+	return nil, nil, errors.New("unterminated YAML frontmatter")
+}
+
+func doctorYAMLDriftPaths(working []byte, ref []byte) ([]string, error) {
+	workingValue, err := doctorYAMLValue(working)
+	if err != nil {
+		return nil, err
+	}
+	refValue, err := doctorYAMLValue(ref)
+	if err != nil {
+		return nil, err
+	}
+	paths := make([]string, 0)
+	doctorCollectYAMLDriftPaths("", workingValue, refValue, &paths)
+	sort.Strings(paths)
+	return paths, nil
+}
+
+func doctorYAMLValue(raw []byte) (any, error) {
+	if len(bytes.TrimSpace(raw)) == 0 {
+		return map[string]any{}, nil
+	}
+	var value any
+	if err := yaml.Unmarshal(raw, &value); err != nil {
+		return nil, err
+	}
+	if value == nil {
+		return map[string]any{}, nil
+	}
+	return value, nil
+}
+
+func doctorCollectYAMLDriftPaths(path string, working any, ref any, paths *[]string) {
+	workingMap, workingIsMap := working.(map[string]any)
+	refMap, refIsMap := ref.(map[string]any)
+	if workingIsMap || refIsMap {
+		if !workingIsMap && working != nil || !refIsMap && ref != nil {
+			*paths = append(*paths, path)
+			return
+		}
+		if workingMap == nil {
+			workingMap = map[string]any{}
+		}
+		if refMap == nil {
+			refMap = map[string]any{}
+		}
+		keys := make(map[string]struct{}, len(workingMap)+len(refMap))
+		for key := range workingMap {
+			keys[key] = struct{}{}
+		}
+		for key := range refMap {
+			keys[key] = struct{}{}
+		}
+		for key := range keys {
+			childPath := key
+			if path != "" {
+				childPath = path + "." + key
+			}
+			doctorCollectYAMLDriftPaths(childPath, workingMap[key], refMap[key], paths)
+		}
+		return
+	}
+	if reflect.DeepEqual(working, ref) {
+		return
+	}
+	if path == "" {
+		path = "document"
+	}
+	*paths = append(*paths, path)
+}
+
+func doctorReadOptionalWorkflowSourceFile(path string) ([]byte, bool, error) {
+	raw, err := os.ReadFile(path)
+	if errors.Is(err, os.ErrNotExist) {
+		return nil, false, nil
+	}
+	if err != nil {
+		return nil, false, err
+	}
+	return raw, true, nil
+}
+
+func doctorReadOptionalWorkflowRefFile(ctx context.Context, sourceRoot string, revision string, path string) ([]byte, bool, error) {
+	raw, err := doctorWorkflowSourceGit(ctx, sourceRoot, "show", revision+":"+path)
+	if err == nil {
+		return []byte(raw), true, nil
+	}
+	if _, existsErr := doctorWorkflowSourceGit(ctx, sourceRoot, "cat-file", "-e", revision+":"+path); existsErr != nil {
+		return nil, false, nil
+	}
+	return nil, false, err
+}
+
 func checkDoctorMutableWorkflowSource(
 	ctx context.Context,
 	projectID string,
@@ -239,25 +513,37 @@ func doctorNormalizedWorkflowPolicy(raw []byte) []byte {
 }
 
 func doctorWorkflowConfigPaths(project globalconfig.Project, sourceRoot string) (string, string, error) {
+	_, _, configPath, relativeConfigPath, err := doctorWorkflowDefinitionPaths(project, sourceRoot)
+	return configPath, relativeConfigPath, err
+}
+
+func doctorWorkflowDefinitionPaths(project globalconfig.Project, sourceRoot string) (string, string, string, string, error) {
 	workflowPath := strings.TrimSpace(project.Workflow)
 	if filepath.IsAbs(workflowPath) || workflowPath == "~" || strings.HasPrefix(workflowPath, "~/") {
 		expanded, err := expandDoctorWorkspacePath(workflowPath)
 		if err != nil {
-			return "", "", fmt.Errorf("resolve workflow path: %w", err)
+			return "", "", "", "", fmt.Errorf("resolve workflow path: %w", err)
 		}
 		workflowPath = expanded
 	} else {
 		workflowPath = filepath.Join(sourceRoot, workflowPath)
 	}
+	relativeWorkflowPath, err := filepath.Rel(sourceRoot, workflowPath)
+	if err != nil {
+		return "", "", "", "", fmt.Errorf("resolve WORKFLOW.md path relative to source root: %w", err)
+	}
+	if relativeWorkflowPath == ".." || strings.HasPrefix(relativeWorkflowPath, ".."+string(filepath.Separator)) {
+		return "", "", "", "", fmt.Errorf("effective WORKFLOW.md %s is outside source root %s", workflowPath, sourceRoot)
+	}
 	configPath := workflowconfig.DefinitionPath(workflowPath)
 	relativePath, err := filepath.Rel(sourceRoot, configPath)
 	if err != nil {
-		return "", "", fmt.Errorf("resolve detent.yaml path relative to source root: %w", err)
+		return "", "", "", "", fmt.Errorf("resolve detent.yaml path relative to source root: %w", err)
 	}
 	if relativePath == ".." || strings.HasPrefix(relativePath, ".."+string(filepath.Separator)) {
-		return "", "", fmt.Errorf("effective detent.yaml %s is outside source root %s", configPath, sourceRoot)
+		return "", "", "", "", fmt.Errorf("effective detent.yaml %s is outside source root %s", configPath, sourceRoot)
 	}
-	return configPath, filepath.ToSlash(relativePath), nil
+	return workflowPath, filepath.ToSlash(relativeWorkflowPath), configPath, filepath.ToSlash(relativePath), nil
 }
 
 func doctorWorkflowRemoteBranch(fullRef string) (string, string, bool) {

--- a/internal/cli/doctor_workflow_source_test.go
+++ b/internal/cli/doctor_workflow_source_test.go
@@ -139,6 +139,137 @@ func TestDefaultDoctorWorkflowSourcePolicy(t *testing.T) {
 	}
 }
 
+func TestCheckDoctorWorkflowRefDrift(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name         string
+		workflowRef  string
+		mutate       func(*testing.T, string)
+		wantFinding  bool
+		wantStatus   doctorStatus
+		wantDetail   []string
+		unwantDetail []string
+	}{
+		{
+			name:        "config keys differ",
+			workflowRef: "origin/main",
+			mutate: func(t *testing.T, repo string) {
+				writeDoctorWorkflowSourceFile(t, filepath.Join(repo, "detent.yaml"), "schema: 1\ntracker:\n  kind: memory\nagent:\n  max_turns: 99\n")
+			},
+			wantFinding: true,
+			wantStatus:  doctorWarn,
+			wantDetail:  []string{"working-tree project definition differs", "detent.yaml keys differ: agent.max_turns"},
+		},
+		{
+			name:        "workflow prompt differs",
+			workflowRef: "origin/main",
+			mutate: func(t *testing.T, repo string) {
+				writeDoctorWorkflowSourceFile(t, filepath.Join(repo, "WORKFLOW.md"), "Updated agent direction.\n")
+			},
+			wantFinding: true,
+			wantStatus:  doctorWarn,
+			wantDetail:  []string{"WORKFLOW.md prompt differs"},
+		},
+		{
+			name:        "validation outcome differs",
+			workflowRef: "origin/main",
+			mutate:      writeDoctorWorkflowSourceValidationDrift,
+			wantFinding: true,
+			wantStatus:  doctorFail,
+			wantDetail: []string{
+				"detent.yaml keys differ: schedule_ownership.enabled, schedule_ownership.key, schedule_ownership.repository",
+				"working-tree configuration passes validation while ref-backed configuration fails",
+				"schedule_ownership.enabled must be true",
+			},
+		},
+		{
+			name:        "working tree matches ref",
+			workflowRef: "origin/main",
+			wantFinding: false,
+		},
+		{
+			name:        "workflow ref is not configured",
+			wantFinding: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			repo, _ := initDoctorWorkflowSourceRepository(t)
+			if tt.mutate != nil {
+				tt.mutate(t, repo)
+			}
+			project := globalconfig.Project{
+				ID:          "alpha",
+				Workflow:    filepath.Join(repo, "WORKFLOW.md"),
+				WorkflowRef: tt.workflowRef,
+				Workdir:     repo,
+			}
+			effectiveWorkflow, err := loadDoctorProjectWorkflowUncached(context.Background(), project, doctorDeps{loadWorkflow: workflowconfig.LoadWorkflow})
+			if err != nil {
+				t.Fatalf("loadDoctorProjectWorkflowUncached() error = %v", err)
+			}
+			effectiveValidationErr := effectiveWorkflow.Config.Validate()
+
+			check, found := checkDoctorWorkflowRefDrift(
+				context.Background(),
+				"alpha",
+				project,
+				repo,
+				effectiveValidationErr,
+				RuntimeSecret{},
+				doctorDeps{loadWorkflow: workflowconfig.LoadWorkflow},
+			)
+			if found != tt.wantFinding {
+				t.Fatalf("checkDoctorWorkflowRefDrift() found = %t, want %t; check = %#v", found, tt.wantFinding, check)
+			}
+			if !found {
+				return
+			}
+			if check.Status != tt.wantStatus {
+				t.Fatalf("Status = %s, want %s; detail = %q", check.Status, tt.wantStatus, check.Detail)
+			}
+			revision := runDoctorWorkflowSourceGit(t, repo, "rev-parse", "origin/main")
+			wantRevision := "workflow_ref origin/main at " + doctorShortRevision(revision)
+			if !strings.Contains(check.Detail, wantRevision) {
+				t.Fatalf("Detail = %q, want containing %q", check.Detail, wantRevision)
+			}
+			for _, want := range tt.wantDetail {
+				if !strings.Contains(check.Detail, want) {
+					t.Fatalf("Detail = %q, want containing %q", check.Detail, want)
+				}
+			}
+			for _, unwanted := range tt.unwantDetail {
+				if strings.Contains(check.Detail, unwanted) {
+					t.Fatalf("Detail = %q, want not containing %q", check.Detail, unwanted)
+				}
+			}
+		})
+	}
+}
+
+func TestCheckDoctorProjectReportsWorkflowRefDriftWhenEffectiveConfigIsInvalid(t *testing.T) {
+	t.Parallel()
+
+	repo, _ := initDoctorWorkflowSourceRepository(t)
+	writeDoctorWorkflowSourceValidationDrift(t, repo)
+	project := globalconfig.Project{
+		ID:          "alpha",
+		Workflow:    filepath.Join(repo, "WORKFLOW.md"),
+		WorkflowRef: "origin/main",
+		Workdir:     repo,
+	}
+	deps := successfulDoctorDeps()
+	deps.loadWorkflow = workflowconfig.LoadWorkflow
+
+	checks := checkDoctorProject(context.Background(), project, deps, RuntimeSecret{}, false)
+	assertDoctorCheck(t, doctorReport{Checks: checks}, "Project alpha workflow", doctorFail, "schedule_ownership.enabled must be true")
+	assertDoctorCheck(t, doctorReport{Checks: checks}, "Project alpha workflow ref drift", doctorFail, "working-tree configuration passes validation")
+}
+
 func TestCheckDoctorWorkflowSourcePolicyUsesGitHubDefaultBranch(t *testing.T) {
 	t.Parallel()
 
@@ -286,6 +417,18 @@ func initDoctorWorkflowSourceRepository(t *testing.T) (string, string) {
 	runDoctorWorkflowSourceGit(t, repo, "config", "user.name", "Detent Test")
 	runDoctorWorkflowSourceGit(t, repo, "config", "user.email", "detent@example.com")
 	return repo, remote
+}
+
+func writeDoctorWorkflowSourceValidationDrift(t *testing.T, repo string) {
+	t.Helper()
+
+	invalid := "schema: 1\ntracker:\n  kind: github\n  api_key: token\n  github_status_source: label\n  repository: example/issues\nroutines:\n  - name: audit\n    schedule: 0 * * * *\n    prompt: Inspect.\n"
+	writeDoctorWorkflowSourceFile(t, filepath.Join(repo, "detent.yaml"), invalid)
+	runDoctorWorkflowSourceGit(t, repo, "add", "detent.yaml")
+	runDoctorWorkflowSourceGit(t, repo, "commit", "-m", "add scheduled routine")
+	runDoctorWorkflowSourceGit(t, repo, "push", "origin", "main")
+	valid := invalid + "schedule_ownership:\n  enabled: true\n  key: example/production\n  repository: example/coordination\n"
+	writeDoctorWorkflowSourceFile(t, filepath.Join(repo, "detent.yaml"), valid)
 }
 
 func cleanupDoctorWorkflowSourceRepository(t *testing.T, root string) {


### PR DESCRIPTION
## Summary

- add a distinct doctor finding when `workflow_ref` projects have working-tree `detent.yaml` or `WORKFLOW.md` drift
- report semantic config key paths plus the configured ref and resolved commit instead of a raw diff
- escalate the finding when the working-tree definition validates but the ref-backed definition fails

Fixes #2051

## UI Surface Contract

- [x] N/A; this PR changes CLI doctor output only.
- [x] This PR does not add persistent top-of-screen messaging.
- [x] This PR does not change primary operator screens.

## Test Plan

- [x] `go test ./internal/cli -count=1`
- [x] `make check`