### PR TITLE
fix(runner): reap workers before scratch cleanup

### DIFF
--- a/db/queries/store.sql
+++ b/db/queries/store.sql
@@ -139,6 +139,8 @@ UPDATE codex_sessions
 SET worker_pid = sqlc.arg(worker_pid),
     worker_pgid = sqlc.arg(worker_pgid),
     worker_started_at = sqlc.arg(worker_started_at),
+    worker_cleanup_root = sqlc.narg(worker_cleanup_root),
+    worker_cleanup_path = sqlc.narg(worker_cleanup_path),
     worker_reaped_at = NULL,
     worker_reap_outcome = NULL,
     worker_reap_reason = NULL
@@ -153,6 +155,8 @@ SELECT
   CAST(worker_pid AS INTEGER) AS worker_pid,
   CAST(COALESCE(worker_pgid, 0) AS INTEGER) AS worker_pgid,
   CAST(worker_started_at AS TEXT) AS worker_started_at,
+  CAST(COALESCE(worker_cleanup_root, '') AS TEXT) AS worker_cleanup_root,
+  CAST(COALESCE(worker_cleanup_path, '') AS TEXT) AS worker_cleanup_path,
   CAST(COALESCE(final_state, '') AS TEXT) AS final_state,
   CAST(COALESCE(completed_at, '') AS TEXT) AS completed_at
 FROM codex_sessions

--- a/internal/cli/doctor_worker_processes_test.go
+++ b/internal/cli/doctor_worker_processes_test.go
@@ -2,6 +2,9 @@ package cli
 
 import (
 	"context"
+	"errors"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -70,7 +73,16 @@ func TestApplyWorkerProcessesFixRecordsReapCause(t *testing.T) {
 
 	startedAt := time.Date(2026, 8, 18, 12, 0, 0, 0, time.UTC)
 	reapedAt := startedAt.Add(time.Hour)
-	processStore := &workerProcessesFixTestStore{}
+	cleanupRoot := t.TempDir()
+	cleanupPath := filepath.Join(cleanupRoot, "run-1885")
+	if err := os.MkdirAll(cleanupPath, 0o700); err != nil {
+		t.Fatalf("create cleanup path: %v", err)
+	}
+	processStore := &workerProcessesFixTestStore{processes: []store.WorkerProcess{{
+		SessionID:   1885,
+		CleanupRoot: cleanupRoot,
+		CleanupPath: cleanupPath,
+	}}}
 	result := workerProcessesFixResult{Processes: []workerProcessFixOutcome{{SessionID: 1885, PID: 4242, GroupID: 4242, StartedAt: startedAt}}}
 	var gotIdentity procgroup.Identity
 	err := applyWorkerProcessesFix(
@@ -92,10 +104,18 @@ func TestApplyWorkerProcessesFixRecordsReapCause(t *testing.T) {
 	if len(processStore.reaps) != 1 || processStore.reaps[0].Reason != "doctor_reap" || processStore.reaps[0].Outcome != store.WorkerProcessOutcomeKilled || !processStore.reaps[0].ReapedAt.Equal(reapedAt) {
 		t.Fatalf("reap records = %#v", processStore.reaps)
 	}
+	if _, err := os.Stat(cleanupPath); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("cleanup path stat error = %v, want not exist", err)
+	}
 }
 
 type workerProcessesFixTestStore struct {
-	reaps []store.WorkerProcessReap
+	processes []store.WorkerProcess
+	reaps     []store.WorkerProcessReap
+}
+
+func (s *workerProcessesFixTestStore) ListActiveWorkerProcesses(context.Context) ([]store.WorkerProcess, error) {
+	return s.processes, nil
 }
 
 func (s *workerProcessesFixTestStore) MarkSessionWorkerProcessReaped(_ context.Context, _ int64, reap store.WorkerProcessReap) error {

--- a/internal/cli/fix_worker_processes.go
+++ b/internal/cli/fix_worker_processes.go
@@ -35,6 +35,7 @@ type workerProcessFixOutcome struct {
 }
 
 type workerProcessFixStore interface {
+	ListActiveWorkerProcesses(context.Context) ([]store.WorkerProcess, error)
 	MarkSessionWorkerProcessReaped(context.Context, int64, store.WorkerProcessReap) error
 	Close() error
 }
@@ -152,6 +153,14 @@ func applyWorkerProcessesFix(
 	if now == nil {
 		now = time.Now
 	}
+	registered, err := processStore.ListActiveWorkerProcesses(ctx)
+	if err != nil {
+		return fmt.Errorf("list worker processes: %w", err)
+	}
+	registrations := make(map[int64]store.WorkerProcess, len(registered))
+	for _, process := range registered {
+		registrations[process.SessionID] = process
+	}
 	for index := range result.Processes {
 		process := &result.Processes[index]
 		outcome, err := reap(ctx, procgroup.Identity{PID: process.PID, GroupID: process.GroupID, StartedAt: process.StartedAt}, procgroup.DefaultTerminationGrace)
@@ -159,6 +168,9 @@ func applyWorkerProcessesFix(
 			return fmt.Errorf("reap worker process %d: %w", process.PID, err)
 		}
 		process.Outcome = string(outcome)
+		if err := cleanupWorkerProcessArtifacts(registrations[process.SessionID]); err != nil {
+			return fmt.Errorf("clean worker process %d artifacts: %w", process.PID, err)
+		}
 		if err := processStore.MarkSessionWorkerProcessReaped(ctx, process.SessionID, store.WorkerProcessReap{
 			ReapedAt: now().UTC(),
 			Outcome:  process.Outcome,

--- a/internal/cli/worker_processes.go
+++ b/internal/cli/worker_processes.go
@@ -3,12 +3,14 @@ package cli
 import (
 	"context"
 	"errors"
+	"fmt"
 	"log/slog"
 	"strings"
 	"time"
 
 	"github.com/digitaldrywood/detent/internal/procgroup"
 	"github.com/digitaldrywood/detent/internal/store"
+	"github.com/digitaldrywood/detent/internal/workspace"
 )
 
 type workerProcessStore interface {
@@ -70,6 +72,12 @@ func reapWorkerProcesses(
 			result = errors.Join(result, reapErr)
 			continue
 		}
+		if cleanupErr := cleanupWorkerProcessArtifacts(process); cleanupErr != nil {
+			attrs = append(attrs, "error", cleanupErr)
+			logger.Info("worker process lifecycle decision", attrs...)
+			result = errors.Join(result, cleanupErr)
+			continue
+		}
 		logger.Info("worker process lifecycle decision", attrs...)
 		if err := processStore.MarkSessionWorkerProcessReaped(ctx, process.SessionID, store.WorkerProcessReap{
 			ReapedAt: now().UTC(),
@@ -80,4 +88,11 @@ func reapWorkerProcesses(
 		}
 	}
 	return result
+}
+
+func cleanupWorkerProcessArtifacts(process store.WorkerProcess) error {
+	if err := workspace.CleanupOwnedPath(process.CleanupRoot, process.CleanupPath); err != nil {
+		return fmt.Errorf("clean worker process artifacts: %w", err)
+	}
+	return nil
 }

--- a/internal/cli/worker_processes_test.go
+++ b/internal/cli/worker_processes_test.go
@@ -3,7 +3,10 @@ package cli
 import (
 	"bytes"
 	"context"
+	"errors"
 	"log/slog"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -11,6 +14,65 @@ import (
 	"github.com/digitaldrywood/detent/internal/procgroup"
 	"github.com/digitaldrywood/detent/internal/store"
 )
+
+func TestReapWorkerProcessesCleansArtifactsOnlyAfterVerifiedExit(t *testing.T) {
+	t.Parallel()
+
+	reapErr := errors.New("process group remained alive")
+	tests := []struct {
+		name       string
+		reapErr    error
+		wantExists bool
+		wantReaped bool
+	}{
+		{name: "verified exit", wantReaped: true},
+		{name: "unverified exit", reapErr: reapErr, wantExists: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			cleanupRoot := t.TempDir()
+			cleanupPath := filepath.Join(cleanupRoot, "run-2011")
+			if err := os.MkdirAll(filepath.Join(cleanupPath, ".detent", "tmp"), 0o700); err != nil {
+				t.Fatalf("create cleanup path: %v", err)
+			}
+			processStore := &shutdownWorkerProcessStore{processes: []store.WorkerProcess{{
+				SessionID: 2011,
+				WorkerProcessIdentity: store.WorkerProcessIdentity{
+					PID:       4242,
+					GroupID:   4242,
+					StartedAt: time.Date(2026, 8, 27, 12, 40, 0, 0, time.UTC),
+				},
+				CleanupRoot: cleanupRoot,
+				CleanupPath: cleanupPath,
+			}}}
+
+			err := reapWorkerProcesses(
+				context.Background(),
+				processStore,
+				slog.New(slog.NewTextHandler(&bytes.Buffer{}, nil)),
+				"startup",
+				time.Millisecond,
+				time.Now,
+				func(context.Context, procgroup.Identity, time.Duration) (procgroup.TerminationOutcome, error) {
+					return procgroup.TerminationOutcomeTerminated, tt.reapErr
+				},
+			)
+			if got := errors.Is(err, reapErr); got != (tt.reapErr != nil) {
+				t.Fatalf("reapWorkerProcesses() error = %v, want reap error %v", err, tt.reapErr != nil)
+			}
+			_, statErr := os.Stat(cleanupPath)
+			if got := statErr == nil; got != tt.wantExists {
+				t.Fatalf("cleanup path exists = %v, want %v, stat error = %v", got, tt.wantExists, statErr)
+			}
+			if got := len(processStore.reaped) == 1; got != tt.wantReaped {
+				t.Fatalf("process marked reaped = %v, want %v", got, tt.wantReaped)
+			}
+		})
+	}
+}
 
 func TestReapWorkerProcessesAtStartup(t *testing.T) {
 	t.Parallel()

--- a/internal/runner/agent.go
+++ b/internal/runner/agent.go
@@ -64,7 +64,7 @@ type sessionProviderStore interface {
 }
 
 type sessionWorkerProcessStore interface {
-	UpdateSessionWorkerProcess(context.Context, int64, store.WorkerProcessIdentity) error
+	UpdateSessionWorkerProcess(context.Context, int64, store.WorkerProcessRegistration) error
 }
 
 type sessionWorkerProcessReaper interface {
@@ -1077,7 +1077,7 @@ func (r *Runner) runAgentTurn(
 			turnStarted = true
 		}
 		r.logAgentUpdate(runRequest, detentSessionID, update)
-		if err := r.persistSessionWorkerProcess(updateCtx, detentSessionID, update); err != nil {
+		if err := r.persistSessionWorkerProcess(updateCtx, detentSessionID, update, info.Path, filepath.Join(info.Path, ".detent", "tmp")); err != nil {
 			return err
 		}
 		if err := r.persistSessionProviderIdentity(updateCtx, detentSessionID, update); err != nil {
@@ -2726,7 +2726,7 @@ func (r *Runner) Validate(ctx context.Context, req ValidatorRequest) (gate.Valid
 			update.RuntimeIdentity = update.RuntimeIdentity.ObserveAt(eventAt)
 		}
 		r.logAgentUpdate(runReq, sessionID, update)
-		if err := r.persistSessionWorkerProcess(updateCtx, sessionID, update); err != nil {
+		if err := r.persistSessionWorkerProcess(updateCtx, sessionID, update, info.Path, filepath.Join(info.Path, ".detent", "tmp")); err != nil {
 			return err
 		}
 		if err := r.persistSessionProviderIdentity(updateCtx, sessionID, update); err != nil {
@@ -3115,7 +3115,7 @@ func (r *Runner) persistSessionProviderIdentity(ctx context.Context, sessionID i
 	return nil
 }
 
-func (r *Runner) persistSessionWorkerProcess(ctx context.Context, sessionID int64, update AgentUpdate) error {
+func (r *Runner) persistSessionWorkerProcess(ctx context.Context, sessionID int64, update AgentUpdate, cleanupRoot string, cleanupPath string) error {
 	identity := update.WorkerProcess
 	if sessionID <= 0 || identity.PID <= 0 || identity.StartedAt.IsZero() {
 		return nil
@@ -3124,10 +3124,14 @@ func (r *Runner) persistSessionWorkerProcess(ctx context.Context, sessionID int6
 	if !ok {
 		return nil
 	}
-	if err := processStore.UpdateSessionWorkerProcess(ctx, sessionID, store.WorkerProcessIdentity{
-		PID:       identity.PID,
-		GroupID:   identity.GroupID,
-		StartedAt: identity.StartedAt,
+	if err := processStore.UpdateSessionWorkerProcess(ctx, sessionID, store.WorkerProcessRegistration{
+		WorkerProcessIdentity: store.WorkerProcessIdentity{
+			PID:       identity.PID,
+			GroupID:   identity.GroupID,
+			StartedAt: identity.StartedAt,
+		},
+		CleanupRoot: strings.TrimSpace(cleanupRoot),
+		CleanupPath: strings.TrimSpace(cleanupPath),
 	}); err != nil {
 		return fmt.Errorf("update agent session worker process: %w", err)
 	}
@@ -3163,6 +3167,11 @@ func (r *Runner) reapSessionWorkerProcess(ctx context.Context, sessionID int64, 
 			attrs = append(attrs, "error", reapErr)
 			r.logWorkerEventLevel(slog.LevelInfo, issue, "worker_process_reap_decision", attrs...)
 			return fmt.Errorf("reap agent session worker process: %w", reapErr)
+		}
+		if cleanupErr := workspace.CleanupOwnedPath(process.CleanupRoot, process.CleanupPath); cleanupErr != nil {
+			attrs = append(attrs, "error", cleanupErr)
+			r.logWorkerEventLevel(slog.LevelInfo, issue, "worker_process_reap_decision", attrs...)
+			return fmt.Errorf("clean agent session worker artifacts: %w", cleanupErr)
 		}
 		r.logWorkerEventLevel(slog.LevelInfo, issue, "worker_process_reap_decision", attrs...)
 		if err := processStore.MarkSessionWorkerProcessReaped(context.WithoutCancel(ctx), sessionID, store.WorkerProcessReap{

--- a/internal/runner/agent.go
+++ b/internal/runner/agent.go
@@ -821,6 +821,27 @@ func runAgentBackendTurnWithToolsUsingLimit(
 	onUpdate agentContextUpdateHandler,
 	turnLimit durationLimitContextFactory,
 ) (AgentTurnResult, error, error) {
+	result, cleanupScratch, runErr := runAgentBackendTurnWithToolsUsingLimitPreservingScratch(
+		ctx,
+		backend,
+		request,
+		tools,
+		toolHandler,
+		onUpdate,
+		turnLimit,
+	)
+	return result, runErr, runWorkerScratchCleanup(cleanupScratch)
+}
+
+func runAgentBackendTurnWithToolsUsingLimitPreservingScratch(
+	ctx context.Context,
+	backend AgentBackend,
+	request AgentTurnRequest,
+	tools []AgentTool,
+	toolHandler AgentToolHandler,
+	onUpdate agentContextUpdateHandler,
+	turnLimit durationLimitContextFactory,
+) (AgentTurnResult, func() error, error) {
 	if turnLimit == nil {
 		turnLimit = withAgentDurationLimit
 	}
@@ -912,32 +933,46 @@ func runAgentBackendTurnWithToolsUsingLimit(
 	workspacePath := strings.TrimSpace(request.Workspace)
 	if workspacePath == "" {
 		result, err := run(ctx, request)
-		return result, err, nil
+		return result, nil, err
 	}
 
 	tempDir, err := workspace.PrepareWorkerScratch(ctx, workspacePath)
 	if workspace.IsMissingWorkspaceError(err) {
 		result, runErr := run(ctx, request)
-		return result, runErr, nil
+		return result, nil, runErr
 	}
 	if err != nil {
-		return AgentTurnResult{}, fmt.Errorf("prepare worker scratch: %w", err), nil
+		return AgentTurnResult{}, nil, fmt.Errorf("prepare worker scratch: %w", err)
 	}
 	request.TempDir = tempDir
+	cleanupScratch := func() error {
+		if cleanupErr := workspace.CleanupWorkerScratch(workspacePath); cleanupErr != nil {
+			return fmt.Errorf("cleanup worker scratch: %w", cleanupErr)
+		}
+		return nil
+	}
 	if err := configureWorkerGitHubEnvironment(&request); err != nil {
-		cleanupErr := workspace.CleanupWorkerScratch(workspacePath)
-		return AgentTurnResult{}, fmt.Errorf("prepare worker github environment: %w", err), cleanupErr
+		return AgentTurnResult{}, cleanupScratch, fmt.Errorf("prepare worker github environment: %w", err)
 	}
 	if err := configureWorkerCache(&request); err != nil {
-		cleanupErr := workspace.CleanupWorkerScratch(workspacePath)
-		return AgentTurnResult{}, fmt.Errorf("prepare worker cache: %w", err), cleanupErr
+		return AgentTurnResult{}, cleanupScratch, fmt.Errorf("prepare worker cache: %w", err)
 	}
 	result, runErr := run(ctx, request)
-	cleanupErr := workspace.CleanupWorkerScratch(workspacePath)
-	if cleanupErr != nil {
-		cleanupErr = fmt.Errorf("cleanup worker scratch: %w", cleanupErr)
+	return result, cleanupScratch, runErr
+}
+
+func runWorkerScratchCleanup(cleanup func() error) error {
+	if cleanup == nil {
+		return nil
 	}
-	return result, runErr, cleanupErr
+	return cleanup()
+}
+
+func cleanupWorkerScratchAfterProcessReap(cleanup func() error, reapErr error) error {
+	if reapErr != nil {
+		return nil
+	}
+	return runWorkerScratchCleanup(cleanup)
 }
 
 func observeAgentRSS(
@@ -1030,7 +1065,7 @@ func (r *Runner) runAgentTurn(
 		}
 	}
 	turnStarted := false
-	turnResult, turnErr, scratchCleanupErr := runAgentBackendTurnWithToolsUsingLimit(ctx, backend, turnRequest, runRequest.AgentTools, runRequest.AgentToolHandler, func(updateCtx context.Context, update AgentUpdate) error {
+	turnResult, cleanupScratch, turnErr := runAgentBackendTurnWithToolsUsingLimitPreservingScratch(ctx, backend, turnRequest, runRequest.AgentTools, runRequest.AgentToolHandler, func(updateCtx context.Context, update AgentUpdate) error {
 		eventAt := r.now()
 		if update.Type == AgentUpdateTokenUsage {
 			update.Tokens = usage.normalize(update.Tokens)
@@ -1088,6 +1123,7 @@ func (r *Runner) runAgentTurn(
 		runRequest.Issue,
 		workerProcessReapReason(ctx, turnErr),
 	)
+	scratchCleanupErr := cleanupWorkerScratchAfterProcessReap(cleanupScratch, processReapErr)
 	if processReapErr != nil {
 		turnErr = errors.Join(turnErr, fmt.Errorf("%w: %w", ErrWorkerProcessReap, processReapErr))
 	}
@@ -2664,7 +2700,7 @@ func (r *Runner) Validate(ctx context.Context, req ValidatorRequest) (gate.Valid
 	var output strings.Builder
 	usage := newSessionTokenUsage(false)
 	modelProvider, serviceTier, effort := agentTurnIdentityOptions(backendConfig)
-	turnResult, turnErr, scratchCleanupErr := runAgentBackendTurnWithToolsUsingLimit(sessionCtx, backend, AgentTurnRequest{
+	turnResult, cleanupScratch, turnErr := runAgentBackendTurnWithToolsUsingLimitPreservingScratch(sessionCtx, backend, AgentTurnRequest{
 		Workspace:          info.Path,
 		Prompt:             prompt,
 		Model:              selectedModel,
@@ -2730,6 +2766,7 @@ func (r *Runner) Validate(ctx context.Context, req ValidatorRequest) (gate.Valid
 		req.Issue,
 		workerProcessReapReason(sessionCtx, turnErr),
 	)
+	scratchCleanupErr := cleanupWorkerScratchAfterProcessReap(cleanupScratch, processReapErr)
 	if processReapErr != nil {
 		turnErr = errors.Join(turnErr, fmt.Errorf("%w: %w", ErrWorkerProcessReap, processReapErr))
 	}

--- a/internal/runner/duration_limit_test.go
+++ b/internal/runner/duration_limit_test.go
@@ -713,7 +713,7 @@ func (s *durationReapSessionStore) MarkSessionWorkerProcessReaped(_ context.Cont
 	return nil
 }
 
-func (s *durationBlockingSessionStore) UpdateSessionWorkerProcess(ctx context.Context, _ int64, _ store.WorkerProcessIdentity) error {
+func (s *durationBlockingSessionStore) UpdateSessionWorkerProcess(ctx context.Context, _ int64, _ store.WorkerProcessRegistration) error {
 	_, s.hasDeadline = ctx.Deadline()
 	s.expireSession()
 	<-ctx.Done()

--- a/internal/runner/runner_test.go
+++ b/internal/runner/runner_test.go
@@ -5287,7 +5287,7 @@ func TestRunnerAuditUsesEmptyReadOnlySubscriptionWorkspace(t *testing.T) {
 	}
 }
 
-func TestRunnerAuditRetainsWorkerScratchWhenProcessReapFails(t *testing.T) {
+func TestRunnerAuditRetainsWorkerScratchUntilLaterProcessReapSucceeds(t *testing.T) {
 	t.Parallel()
 
 	auditRoot := t.TempDir()
@@ -5365,6 +5365,17 @@ func TestRunnerAuditRetainsWorkerScratchWhenProcessReapFails(t *testing.T) {
 	}
 	if _, err := os.Stat(filepath.Join(backend.request.Workspace, ".detent", "tmp")); err != nil {
 		t.Fatalf("worker scratch stat error after reap failure = %v", err)
+	}
+
+	reapErr = nil
+	if err := runner.reapSessionWorkerProcess(t.Context(), sessionID, connector.Issue{
+		ID:         snapshot.IssueID,
+		Identifier: snapshot.Identifier,
+	}, "startup"); err != nil {
+		t.Fatalf("reapSessionWorkerProcess() later error = %v", err)
+	}
+	if _, err := os.Stat(backend.request.Workspace); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("audit workspace stat error after later reap = %v, want not exist", err)
 	}
 }
 
@@ -6383,6 +6394,18 @@ type scratchReapSessionStore struct {
 	reaps   []store.WorkerProcessReap
 }
 
+func (s *scratchReapSessionStore) UpdateSessionWorkerProcess(ctx context.Context, sessionID int64, registration store.WorkerProcessRegistration) error {
+	if err := s.fakeSessionStore.UpdateSessionWorkerProcess(ctx, sessionID, registration); err != nil {
+		return err
+	}
+	if sessionID == s.process.SessionID {
+		s.process.WorkerProcessIdentity = registration.WorkerProcessIdentity
+		s.process.CleanupRoot = registration.CleanupRoot
+		s.process.CleanupPath = registration.CleanupPath
+	}
+	return nil
+}
+
 func (s *scratchReapSessionStore) ListActiveWorkerProcesses(context.Context) ([]store.WorkerProcess, error) {
 	return []store.WorkerProcess{s.process}, nil
 }
@@ -6550,7 +6573,7 @@ type fakeSessionStore struct {
 	resumeLookups   int
 	resumeLookup    store.AgentResumeLookup
 	providerUpdates []store.SessionProviderIdentity
-	workerProcesses []store.WorkerProcessIdentity
+	workerProcesses []store.WorkerProcessRegistration
 	resumeUpdates   []store.SessionResumeState
 }
 
@@ -6576,8 +6599,8 @@ func (s *fakeSessionStore) UpdateSessionProviderIdentity(_ context.Context, _ in
 	return nil
 }
 
-func (s *fakeSessionStore) UpdateSessionWorkerProcess(_ context.Context, _ int64, identity store.WorkerProcessIdentity) error {
-	s.workerProcesses = append(s.workerProcesses, identity)
+func (s *fakeSessionStore) UpdateSessionWorkerProcess(_ context.Context, _ int64, registration store.WorkerProcessRegistration) error {
+	s.workerProcesses = append(s.workerProcesses, registration)
 	return nil
 }
 

--- a/internal/runner/runner_test.go
+++ b/internal/runner/runner_test.go
@@ -1409,6 +1409,139 @@ func TestRunAgentTurnReclaimsWorkerScratch(t *testing.T) {
 	}
 }
 
+func TestRunAgentTurnCleansWorkerScratchAfterProcessReap(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		reapErr     error
+		wantScratch bool
+	}{
+		{name: "reaped process group"},
+		{name: "process group exit not verified", reapErr: errors.New("process group remained alive"), wantScratch: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			workspacePath := t.TempDir()
+			t.Cleanup(func() {
+				if err := workspace.CleanupWorkerScratch(workspacePath); err != nil {
+					t.Fatalf("CleanupWorkerScratch() error = %v", err)
+				}
+			})
+			startedAt := time.Date(2026, 8, 27, 12, 40, 0, 0, time.UTC)
+			const sessionID = int64(2954)
+			identity := procgroup.Identity{PID: 17626, GroupID: 17626, StartedAt: startedAt}
+			backend := &scratchWritingAgentBackend{workerProcess: identity}
+			sessionStore := &scratchReapSessionStore{
+				fakeSessionStore: &fakeSessionStore{},
+				process: store.WorkerProcess{
+					SessionID: sessionID,
+					WorkerProcessIdentity: store.WorkerProcessIdentity{
+						PID:       identity.PID,
+						GroupID:   identity.GroupID,
+						StartedAt: identity.StartedAt,
+					},
+				},
+			}
+			scratchPresentDuringReap := false
+			r := &Runner{
+				now:             time.Now,
+				logger:          slog.New(slog.NewTextHandler(io.Discard, nil)),
+				store:           sessionStore,
+				workerReapGrace: time.Second,
+				reapWorkerProcess: func(context.Context, procgroup.Identity, time.Duration) (procgroup.TerminationOutcome, error) {
+					_, err := os.Stat(backend.tempDir)
+					scratchPresentDuringReap = err == nil
+					return procgroup.TerminationOutcomeTerminated, tt.reapErr
+				},
+			}
+
+			execution := r.runAgentTurn(
+				context.Background(),
+				backend,
+				AgentTurnRequest{Workspace: workspacePath},
+				RunRequest{Issue: connector.Issue{ID: "issue-2011", Identifier: "digitaldrywood/detent#2011"}},
+				workspace.Info{Path: workspacePath},
+				workspace.Issue{ID: "issue-2011", Identifier: "digitaldrywood/detent#2011"},
+				config.Agent{},
+				"",
+				nil,
+				time.Now(),
+				sessionID,
+				agentidentity.Identity{},
+				nil,
+				0,
+				"",
+				"",
+			)
+
+			if !scratchPresentDuringReap {
+				t.Fatal("worker scratch was removed before process reaping")
+			}
+			if got := errors.Is(execution.err, ErrWorkerProcessReap); got != (tt.reapErr != nil) {
+				t.Fatalf("runAgentTurn() worker reap error = %v, want %v: %v", got, tt.reapErr != nil, execution.err)
+			}
+			_, statErr := os.Stat(backend.tempDir)
+			if got := statErr == nil; got != tt.wantScratch {
+				t.Fatalf("worker scratch exists after turn = %v, want %v, stat error = %v", got, tt.wantScratch, statErr)
+			}
+		})
+	}
+}
+
+func TestRunAgentTurnRecreatesWorkerScratchForEveryAttempt(t *testing.T) {
+	t.Parallel()
+
+	workspacePath := t.TempDir()
+	backend := &scratchWritingAgentBackend{}
+	r := &Runner{
+		now:    time.Now,
+		logger: slog.New(slog.NewTextHandler(io.Discard, nil)),
+	}
+	tests := []struct {
+		name string
+	}{
+		{name: "initial attempt"},
+		{name: "reused workspace attempt"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			execution := r.runAgentTurn(
+				context.Background(),
+				backend,
+				AgentTurnRequest{Workspace: workspacePath},
+				RunRequest{Issue: connector.Issue{ID: "issue-2011", Identifier: "digitaldrywood/detent#2011"}},
+				workspace.Info{Path: workspacePath},
+				workspace.Issue{ID: "issue-2011", Identifier: "digitaldrywood/detent#2011"},
+				config.Agent{},
+				"",
+				nil,
+				time.Now(),
+				0,
+				agentidentity.Identity{},
+				nil,
+				0,
+				"",
+				"",
+			)
+
+			if execution.err != nil || execution.cleanupErr != nil {
+				t.Fatalf("runAgentTurn() errors = %v, %v", execution.err, execution.cleanupErr)
+			}
+			if !backend.scratchReady[len(backend.scratchReady)-1] {
+				t.Fatal("worker scratch did not exist when backend turn started")
+			}
+			if _, err := os.Stat(backend.tempDir); !errors.Is(err, os.ErrNotExist) {
+				t.Fatalf("worker scratch stat error after turn = %v, want not exist", err)
+			}
+		})
+	}
+}
+
 func TestConfiguredRuntimeIdentityKeepsClaudeIntentDistinct(t *testing.T) {
 	t.Parallel()
 
@@ -5154,6 +5287,87 @@ func TestRunnerAuditUsesEmptyReadOnlySubscriptionWorkspace(t *testing.T) {
 	}
 }
 
+func TestRunnerAuditRetainsWorkerScratchWhenProcessReapFails(t *testing.T) {
+	t.Parallel()
+
+	auditRoot := t.TempDir()
+	startedAt := time.Date(2026, 8, 27, 12, 40, 0, 0, time.UTC)
+	identity := procgroup.Identity{PID: 17626, GroupID: 17626, StartedAt: startedAt}
+	backend := &fakeCodexClient{
+		updates: []AgentUpdate{
+			{Type: AgentUpdateProcessStarted, WorkerProcess: identity},
+			{Type: AgentUpdateMessageDelta, Delta: `{"verdict":"pass","summary":"No actionable security findings.","findings":[]}`},
+		},
+		result: AgentTurnResult{AuthenticationMode: securityaudit.AuthenticationSubscription},
+	}
+	const sessionID = int64(2011)
+	sessionStore := &scratchReapSessionStore{
+		fakeSessionStore: &fakeSessionStore{sessionID: sessionID},
+		process: store.WorkerProcess{
+			SessionID: sessionID,
+			WorkerProcessIdentity: store.WorkerProcessIdentity{
+				PID:       identity.PID,
+				GroupID:   identity.GroupID,
+				StartedAt: identity.StartedAt,
+			},
+		},
+	}
+	reapErr := errors.New("process group remained alive")
+	scratchPresentDuringReap := false
+	runner, err := NewRunner(Dependencies{
+		SecurityAuditRoot: auditRoot,
+		Workflow: config.Workflow{Config: config.Config{
+			Gate: gate.Config{SecurityAudit: gate.SecurityAuditConfig{Enabled: true}},
+			Agents: config.Agents{
+				Backends: []config.AgentBackend{{ID: "codex", Kind: config.AgentBackendCodex, Protocol: "app-server", Command: "codex app-server"}},
+				Routes:   []config.AgentRoute{{Name: "default", Backend: "codex", Default: true}},
+			},
+		}},
+		Workspace:     &fakeWorkspaceBackend{},
+		AgentBackends: map[string]AgentBackend{"codex": backend},
+		Store:         sessionStore,
+		ReapWorkerProcess: func(_ context.Context, got procgroup.Identity, _ time.Duration) (procgroup.TerminationOutcome, error) {
+			if got != identity {
+				t.Fatalf("worker identity = %#v, want %#v", got, identity)
+			}
+			_, statErr := os.Stat(filepath.Join(backend.request.Workspace, ".detent", "tmp"))
+			scratchPresentDuringReap = statErr == nil
+			return procgroup.TerminationOutcomeTerminated, reapErr
+		},
+	})
+	if err != nil {
+		t.Fatalf("NewRunner() error = %v", err)
+	}
+
+	snapshot := securityaudit.Snapshot{
+		ProjectID:        "detent",
+		IssueID:          "issue-2011",
+		Identifier:       "digitaldrywood/detent#2011",
+		IssueURL:         "https://github.test/digitaldrywood/detent/issues/2011",
+		IssueTitle:       "Retain worker scratch through process reaping",
+		IssueDescription: "Worker scratch must outlive provider descendants.",
+		Repository:       "digitaldrywood/detent",
+		PRNumber:         2012,
+		PRTitle:          "Retain worker scratch through process reaping",
+		BaseSHA:          "base-1",
+		HeadSHA:          "head-1",
+		Diff:             "diff --git a/internal/runner/agent.go b/internal/runner/agent.go",
+	}
+	_, err = runner.Audit(t.Context(), SecurityAuditRequest{
+		Issue:    connector.Issue{ID: snapshot.IssueID, Identifier: snapshot.Identifier},
+		Snapshot: snapshot,
+	})
+	if !errors.Is(err, ErrWorkerProcessReap) || !errors.Is(err, reapErr) {
+		t.Fatalf("Audit() error = %v, want worker process reap failure", err)
+	}
+	if !scratchPresentDuringReap {
+		t.Fatal("worker scratch was removed before process reaping")
+	}
+	if _, err := os.Stat(filepath.Join(backend.request.Workspace, ".detent", "tmp")); err != nil {
+		t.Fatalf("worker scratch stat error after reap failure = %v", err)
+	}
+}
+
 func TestParseValidatorResultRejectsMissingOutput(t *testing.T) {
 	t.Parallel()
 
@@ -6135,12 +6349,21 @@ type deliverableRecoveryAgentBackend struct {
 }
 
 type scratchWritingAgentBackend struct {
-	runErr  error
-	tempDir string
+	runErr        error
+	tempDir       string
+	workerProcess procgroup.Identity
+	scratchReady  []bool
 }
 
-func (b *scratchWritingAgentBackend) RunTurn(_ context.Context, req AgentTurnRequest, _ AgentUpdateHandler) (AgentTurnResult, error) {
+func (b *scratchWritingAgentBackend) RunTurn(_ context.Context, req AgentTurnRequest, onUpdate AgentUpdateHandler) (AgentTurnResult, error) {
 	b.tempDir = req.TempDir
+	_, scratchErr := os.Stat(req.TempDir)
+	b.scratchReady = append(b.scratchReady, scratchErr == nil)
+	if b.workerProcess.PID > 0 {
+		if err := onUpdate(AgentUpdate{Type: AgentUpdateProcessStarted, WorkerProcess: b.workerProcess}); err != nil {
+			return AgentTurnResult{}, err
+		}
+	}
 	cacheDir := filepath.Join(req.TempDir, "go-mod", "modernc.org", "libc@v1.73.4")
 	if err := os.MkdirAll(cacheDir, 0o755); err != nil {
 		return AgentTurnResult{}, err
@@ -6152,6 +6375,23 @@ func (b *scratchWritingAgentBackend) RunTurn(_ context.Context, req AgentTurnReq
 		return AgentTurnResult{}, err
 	}
 	return AgentTurnResult{ThreadID: "thread-1305", TurnID: "turn-1305", SessionID: "thread-1305-turn-1305"}, b.runErr
+}
+
+type scratchReapSessionStore struct {
+	*fakeSessionStore
+	process store.WorkerProcess
+	reaps   []store.WorkerProcessReap
+}
+
+func (s *scratchReapSessionStore) ListActiveWorkerProcesses(context.Context) ([]store.WorkerProcess, error) {
+	return []store.WorkerProcess{s.process}, nil
+}
+
+func (s *scratchReapSessionStore) MarkSessionWorkerProcessReaped(_ context.Context, sessionID int64, reap store.WorkerProcessReap) error {
+	if sessionID == s.process.SessionID {
+		s.reaps = append(s.reaps, reap)
+	}
+	return nil
 }
 
 func (b *toolUpdateAgentBackend) RunTurn(_ context.Context, _ AgentTurnRequest, onUpdate AgentUpdateHandler) (AgentTurnResult, error) {

--- a/internal/runner/security_audit.go
+++ b/internal/runner/security_audit.go
@@ -104,7 +104,7 @@ func (r *Runner) Audit(ctx context.Context, req SecurityAuditRequest) (execution
 		if update.WorkerProcess.PID > 0 {
 			execution.WorkerProcess = update.WorkerProcess
 		}
-		if err := r.persistSessionWorkerProcess(updateCtx, sessionID, update); err != nil {
+		if err := r.persistSessionWorkerProcess(updateCtx, sessionID, update, r.securityAuditRoot, auditWorkspace); err != nil {
 			return err
 		}
 		if err := r.persistSessionProviderIdentity(updateCtx, sessionID, update); err != nil {

--- a/internal/runner/security_audit.go
+++ b/internal/runner/security_audit.go
@@ -43,7 +43,11 @@ func (r *Runner) Audit(ctx context.Context, req SecurityAuditRequest) (execution
 	if err != nil {
 		return execution, err
 	}
+	removeAuditWorkspace := true
 	defer func() {
+		if !removeAuditWorkspace {
+			return
+		}
 		if cleanupErr := os.RemoveAll(auditWorkspace); cleanupErr != nil {
 			err = errors.Join(err, fmt.Errorf("remove security audit workspace: %w", cleanupErr))
 		}
@@ -70,7 +74,8 @@ func (r *Runner) Audit(ctx context.Context, req SecurityAuditRequest) (execution
 	runResult := RunResult{FinalState: FinalStateCompleted, RuntimeIdentity: runtimeIdentity}
 	var output strings.Builder
 	modelProvider, serviceTier, effort := agentTurnIdentityOptions(backendConfig)
-	turnResult, turnErr, scratchCleanupErr := runAgentBackendTurnWithToolsUsingLimit(ctx, backend, AgentTurnRequest{
+	removeAuditWorkspace = false
+	turnResult, cleanupScratch, turnErr := runAgentBackendTurnWithToolsUsingLimitPreservingScratch(ctx, backend, AgentTurnRequest{
 		Workspace:               auditWorkspace,
 		Prompt:                  prompt,
 		ToolInstructions:        securityaudit.ToolInstructions(),
@@ -117,8 +122,10 @@ func (r *Runner) Audit(ctx context.Context, req SecurityAuditRequest) (execution
 		}
 		return nil
 	}, r.turnLimit)
-	turnErr = errors.Join(turnErr, scratchCleanupErr)
-	if reapErr := r.reapSessionWorkerProcess(ctx, sessionID, req.Issue, workerProcessReapReason(ctx, turnErr)); reapErr != nil {
+	reapErr := r.reapSessionWorkerProcess(ctx, sessionID, req.Issue, workerProcessReapReason(ctx, turnErr))
+	removeAuditWorkspace = reapErr == nil
+	turnErr = errors.Join(turnErr, cleanupWorkerScratchAfterProcessReap(cleanupScratch, reapErr))
+	if reapErr != nil {
 		turnErr = errors.Join(turnErr, fmt.Errorf("%w: %w", ErrWorkerProcessReap, reapErr))
 	}
 

--- a/internal/store/migrations/00050_add_worker_cleanup_path.sql
+++ b/internal/store/migrations/00050_add_worker_cleanup_path.sql
@@ -1,0 +1,7 @@
+-- +goose Up
+ALTER TABLE codex_sessions ADD COLUMN worker_cleanup_root TEXT;
+ALTER TABLE codex_sessions ADD COLUMN worker_cleanup_path TEXT;
+
+-- +goose Down
+ALTER TABLE codex_sessions DROP COLUMN worker_cleanup_path;
+ALTER TABLE codex_sessions DROP COLUMN worker_cleanup_root;

--- a/internal/store/sqlc/models.go
+++ b/internal/store/sqlc/models.go
@@ -174,6 +174,8 @@ type CodexSession struct {
 	WorkerReapOutcome            sql.NullString `json:"worker_reap_outcome"`
 	ProjectID                    sql.NullString `json:"project_id"`
 	WorkerReapReason             sql.NullString `json:"worker_reap_reason"`
+	WorkerCleanupRoot            sql.NullString `json:"worker_cleanup_root"`
+	WorkerCleanupPath            sql.NullString `json:"worker_cleanup_path"`
 }
 
 type DetentRun struct {

--- a/internal/store/sqlc/store.sql.go
+++ b/internal/store/sqlc/store.sql.go
@@ -503,7 +503,7 @@ INSERT INTO codex_sessions (
   orphan_recovery_outcome,
   orphan_recovery_fallback_reason
 ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-RETURNING id, run_id, issue_id, identifier, issue_url, started_at, completed_at, turns, input_tokens, output_tokens, total_tokens, runtime_seconds, final_state, model, cached_input_tokens, reasoning_output_tokens, model_context_window, requested_model, agent_backend_id, agent_backend_kind, agent_role, provider_thread_id, provider_session_id, resumed_from_session_id, work_attempt_id, agent_route, provider, provider_provenance, requested_model_provenance, model_provenance, reasoning_effort, reasoning_effort_provenance, service_tier, service_tier_provenance, identity_observed_at, orphan_recovery_outcome, skill_draft_proposed, orphan_recovery_fallback_reason, worker_pid, worker_pgid, worker_started_at, worker_reaped_at, worker_reap_outcome, project_id, worker_reap_reason
+RETURNING id, run_id, issue_id, identifier, issue_url, started_at, completed_at, turns, input_tokens, output_tokens, total_tokens, runtime_seconds, final_state, model, cached_input_tokens, reasoning_output_tokens, model_context_window, requested_model, agent_backend_id, agent_backend_kind, agent_role, provider_thread_id, provider_session_id, resumed_from_session_id, work_attempt_id, agent_route, provider, provider_provenance, requested_model_provenance, model_provenance, reasoning_effort, reasoning_effort_provenance, service_tier, service_tier_provenance, identity_observed_at, orphan_recovery_outcome, skill_draft_proposed, orphan_recovery_fallback_reason, worker_pid, worker_pgid, worker_started_at, worker_reaped_at, worker_reap_outcome, project_id, worker_reap_reason, worker_cleanup_root, worker_cleanup_path
 `
 
 type CreateCodexSessionParams struct {
@@ -633,6 +633,8 @@ func (q *Queries) CreateCodexSession(ctx context.Context, arg CreateCodexSession
 		&i.WorkerReapOutcome,
 		&i.ProjectID,
 		&i.WorkerReapReason,
+		&i.WorkerCleanupRoot,
+		&i.WorkerCleanupPath,
 	)
 	return i, err
 }
@@ -1841,7 +1843,7 @@ func (q *Queries) GetAPIKeyByHash(ctx context.Context, keyHash string) (ApiKey, 
 }
 
 const getCodexSession = `-- name: GetCodexSession :one
-SELECT id, run_id, issue_id, identifier, issue_url, started_at, completed_at, turns, input_tokens, output_tokens, total_tokens, runtime_seconds, final_state, model, cached_input_tokens, reasoning_output_tokens, model_context_window, requested_model, agent_backend_id, agent_backend_kind, agent_role, provider_thread_id, provider_session_id, resumed_from_session_id, work_attempt_id, agent_route, provider, provider_provenance, requested_model_provenance, model_provenance, reasoning_effort, reasoning_effort_provenance, service_tier, service_tier_provenance, identity_observed_at, orphan_recovery_outcome, skill_draft_proposed, orphan_recovery_fallback_reason, worker_pid, worker_pgid, worker_started_at, worker_reaped_at, worker_reap_outcome, project_id, worker_reap_reason
+SELECT id, run_id, issue_id, identifier, issue_url, started_at, completed_at, turns, input_tokens, output_tokens, total_tokens, runtime_seconds, final_state, model, cached_input_tokens, reasoning_output_tokens, model_context_window, requested_model, agent_backend_id, agent_backend_kind, agent_role, provider_thread_id, provider_session_id, resumed_from_session_id, work_attempt_id, agent_route, provider, provider_provenance, requested_model_provenance, model_provenance, reasoning_effort, reasoning_effort_provenance, service_tier, service_tier_provenance, identity_observed_at, orphan_recovery_outcome, skill_draft_proposed, orphan_recovery_fallback_reason, worker_pid, worker_pgid, worker_started_at, worker_reaped_at, worker_reap_outcome, project_id, worker_reap_reason, worker_cleanup_root, worker_cleanup_path
 FROM codex_sessions
 WHERE id = ?
 `
@@ -1895,6 +1897,8 @@ func (q *Queries) GetCodexSession(ctx context.Context, id int64) (CodexSession, 
 		&i.WorkerReapOutcome,
 		&i.ProjectID,
 		&i.WorkerReapReason,
+		&i.WorkerCleanupRoot,
+		&i.WorkerCleanupPath,
 	)
 	return i, err
 }
@@ -2935,6 +2939,8 @@ SELECT
   CAST(worker_pid AS INTEGER) AS worker_pid,
   CAST(COALESCE(worker_pgid, 0) AS INTEGER) AS worker_pgid,
   CAST(worker_started_at AS TEXT) AS worker_started_at,
+  CAST(COALESCE(worker_cleanup_root, '') AS TEXT) AS worker_cleanup_root,
+  CAST(COALESCE(worker_cleanup_path, '') AS TEXT) AS worker_cleanup_path,
   CAST(COALESCE(final_state, '') AS TEXT) AS final_state,
   CAST(COALESCE(completed_at, '') AS TEXT) AS completed_at
 FROM codex_sessions
@@ -2944,15 +2950,17 @@ ORDER BY started_at, id
 `
 
 type ListActiveWorkerProcessesRow struct {
-	SessionID       int64  `json:"session_id"`
-	IssueID         string `json:"issue_id"`
-	Identifier      string `json:"identifier"`
-	IssueURL        string `json:"issue_url"`
-	WorkerPid       int64  `json:"worker_pid"`
-	WorkerPgid      int64  `json:"worker_pgid"`
-	WorkerStartedAt string `json:"worker_started_at"`
-	FinalState      string `json:"final_state"`
-	CompletedAt     string `json:"completed_at"`
+	SessionID         int64  `json:"session_id"`
+	IssueID           string `json:"issue_id"`
+	Identifier        string `json:"identifier"`
+	IssueURL          string `json:"issue_url"`
+	WorkerPid         int64  `json:"worker_pid"`
+	WorkerPgid        int64  `json:"worker_pgid"`
+	WorkerStartedAt   string `json:"worker_started_at"`
+	WorkerCleanupRoot string `json:"worker_cleanup_root"`
+	WorkerCleanupPath string `json:"worker_cleanup_path"`
+	FinalState        string `json:"final_state"`
+	CompletedAt       string `json:"completed_at"`
 }
 
 func (q *Queries) ListActiveWorkerProcesses(ctx context.Context) ([]ListActiveWorkerProcessesRow, error) {
@@ -2972,6 +2980,8 @@ func (q *Queries) ListActiveWorkerProcesses(ctx context.Context) ([]ListActiveWo
 			&i.WorkerPid,
 			&i.WorkerPgid,
 			&i.WorkerStartedAt,
+			&i.WorkerCleanupRoot,
+			&i.WorkerCleanupPath,
 			&i.FinalState,
 			&i.CompletedAt,
 		); err != nil {
@@ -3632,7 +3642,7 @@ func (q *Queries) ListPendingWorkAttemptCapacityReleases(ctx context.Context, pr
 }
 
 const listRecentCodexSessions = `-- name: ListRecentCodexSessions :many
-SELECT id, run_id, issue_id, identifier, issue_url, started_at, completed_at, turns, input_tokens, output_tokens, total_tokens, runtime_seconds, final_state, model, cached_input_tokens, reasoning_output_tokens, model_context_window, requested_model, agent_backend_id, agent_backend_kind, agent_role, provider_thread_id, provider_session_id, resumed_from_session_id, work_attempt_id, agent_route, provider, provider_provenance, requested_model_provenance, model_provenance, reasoning_effort, reasoning_effort_provenance, service_tier, service_tier_provenance, identity_observed_at, orphan_recovery_outcome, skill_draft_proposed, orphan_recovery_fallback_reason, worker_pid, worker_pgid, worker_started_at, worker_reaped_at, worker_reap_outcome, project_id, worker_reap_reason
+SELECT id, run_id, issue_id, identifier, issue_url, started_at, completed_at, turns, input_tokens, output_tokens, total_tokens, runtime_seconds, final_state, model, cached_input_tokens, reasoning_output_tokens, model_context_window, requested_model, agent_backend_id, agent_backend_kind, agent_role, provider_thread_id, provider_session_id, resumed_from_session_id, work_attempt_id, agent_route, provider, provider_provenance, requested_model_provenance, model_provenance, reasoning_effort, reasoning_effort_provenance, service_tier, service_tier_provenance, identity_observed_at, orphan_recovery_outcome, skill_draft_proposed, orphan_recovery_fallback_reason, worker_pid, worker_pgid, worker_started_at, worker_reaped_at, worker_reap_outcome, project_id, worker_reap_reason, worker_cleanup_root, worker_cleanup_path
 FROM codex_sessions
 ORDER BY completed_at DESC, id DESC
 LIMIT ?
@@ -3693,6 +3703,8 @@ func (q *Queries) ListRecentCodexSessions(ctx context.Context, limit int64) ([]C
 			&i.WorkerReapOutcome,
 			&i.ProjectID,
 			&i.WorkerReapReason,
+			&i.WorkerCleanupRoot,
+			&i.WorkerCleanupPath,
 		); err != nil {
 			return nil, err
 		}
@@ -4663,17 +4675,21 @@ UPDATE codex_sessions
 SET worker_pid = ?1,
     worker_pgid = ?2,
     worker_started_at = ?3,
+    worker_cleanup_root = ?4,
+    worker_cleanup_path = ?5,
     worker_reaped_at = NULL,
     worker_reap_outcome = NULL,
     worker_reap_reason = NULL
-WHERE id = ?4
+WHERE id = ?6
 `
 
 type UpdateCodexSessionWorkerProcessParams struct {
-	WorkerPid       sql.NullInt64  `json:"worker_pid"`
-	WorkerPgid      sql.NullInt64  `json:"worker_pgid"`
-	WorkerStartedAt sql.NullString `json:"worker_started_at"`
-	ID              int64          `json:"id"`
+	WorkerPid         sql.NullInt64  `json:"worker_pid"`
+	WorkerPgid        sql.NullInt64  `json:"worker_pgid"`
+	WorkerStartedAt   sql.NullString `json:"worker_started_at"`
+	WorkerCleanupRoot sql.NullString `json:"worker_cleanup_root"`
+	WorkerCleanupPath sql.NullString `json:"worker_cleanup_path"`
+	ID                int64          `json:"id"`
 }
 
 func (q *Queries) UpdateCodexSessionWorkerProcess(ctx context.Context, arg UpdateCodexSessionWorkerProcessParams) (int64, error) {
@@ -4681,6 +4697,8 @@ func (q *Queries) UpdateCodexSessionWorkerProcess(ctx context.Context, arg Updat
 		arg.WorkerPid,
 		arg.WorkerPgid,
 		arg.WorkerStartedAt,
+		arg.WorkerCleanupRoot,
+		arg.WorkerCleanupPath,
 		arg.ID,
 	)
 	if err != nil {

--- a/internal/store/sqlite.go
+++ b/internal/store/sqlite.go
@@ -267,19 +267,21 @@ func (s *sqliteStore) UpdateSessionProviderIdentity(ctx context.Context, session
 	return requireAffected(rows, "codex session", sessionID)
 }
 
-func (s *sqliteStore) UpdateSessionWorkerProcess(ctx context.Context, sessionID int64, identity WorkerProcessIdentity) error {
-	if sessionID <= 0 || identity.PID <= 0 || identity.StartedAt.IsZero() {
+func (s *sqliteStore) UpdateSessionWorkerProcess(ctx context.Context, sessionID int64, registration WorkerProcessRegistration) error {
+	if sessionID <= 0 || registration.PID <= 0 || registration.StartedAt.IsZero() {
 		return ErrNotFound
 	}
-	startedAt, err := requiredTimestamp("worker_started_at", identity.StartedAt)
+	startedAt, err := requiredTimestamp("worker_started_at", registration.StartedAt)
 	if err != nil {
 		return err
 	}
 	rows, err := s.queries.UpdateCodexSessionWorkerProcess(ctx, sqlc.UpdateCodexSessionWorkerProcessParams{
-		WorkerPid:       sql.NullInt64{Int64: int64(identity.PID), Valid: true},
-		WorkerPgid:      sql.NullInt64{Int64: int64(identity.GroupID), Valid: true},
-		WorkerStartedAt: sql.NullString{String: startedAt, Valid: true},
-		ID:              sessionID,
+		WorkerPid:         sql.NullInt64{Int64: int64(registration.PID), Valid: true},
+		WorkerPgid:        sql.NullInt64{Int64: int64(registration.GroupID), Valid: true},
+		WorkerStartedAt:   sql.NullString{String: startedAt, Valid: true},
+		WorkerCleanupRoot: nullString(registration.CleanupRoot),
+		WorkerCleanupPath: nullString(registration.CleanupPath),
+		ID:                sessionID,
 	})
 	if err != nil {
 		return fmt.Errorf("updating codex session worker process: %w", err)
@@ -317,6 +319,8 @@ func (s *sqliteStore) ListActiveWorkerProcesses(ctx context.Context) ([]WorkerPr
 				GroupID:   int(row.WorkerPgid),
 				StartedAt: startedAt,
 			},
+			CleanupRoot: strings.TrimSpace(row.WorkerCleanupRoot),
+			CleanupPath: strings.TrimSpace(row.WorkerCleanupPath),
 		})
 	}
 	return processes, nil

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -85,7 +85,7 @@ type StatsStore interface {
 	StartSession(context.Context, SessionStart) (int64, error)
 	UpdateSessionIdentity(context.Context, int64, agentidentity.Identity) error
 	UpdateSessionProviderIdentity(context.Context, int64, SessionProviderIdentity) error
-	UpdateSessionWorkerProcess(context.Context, int64, WorkerProcessIdentity) error
+	UpdateSessionWorkerProcess(context.Context, int64, WorkerProcessRegistration) error
 	ListActiveWorkerProcesses(context.Context) ([]WorkerProcess, error)
 	MarkSessionWorkerProcessReaped(context.Context, int64, WorkerProcessReap) error
 	UpdateSessionResumeState(context.Context, int64, SessionResumeState) error
@@ -444,6 +444,12 @@ type WorkerProcessIdentity struct {
 	StartedAt time.Time
 }
 
+type WorkerProcessRegistration struct {
+	WorkerProcessIdentity
+	CleanupRoot string
+	CleanupPath string
+}
+
 type WorkerProcess struct {
 	SessionID   int64
 	IssueID     string
@@ -452,6 +458,8 @@ type WorkerProcess struct {
 	FinalState  string
 	CompletedAt time.Time
 	WorkerProcessIdentity
+	CleanupRoot string
+	CleanupPath string
 }
 
 type WorkerProcessReap struct {

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -1860,10 +1860,16 @@ func TestActiveWorkerProcessesAreJournaledAndReaped(t *testing.T) {
 	}
 
 	processStartedAt := startedAt.Add(time.Second)
-	if err := backend.UpdateSessionWorkerProcess(ctx, sessionID, WorkerProcessIdentity{
-		PID:       4242,
-		GroupID:   4242,
-		StartedAt: processStartedAt,
+	cleanupRoot := t.TempDir()
+	cleanupPath := filepath.Join(cleanupRoot, "run-1214")
+	if err := backend.UpdateSessionWorkerProcess(ctx, sessionID, WorkerProcessRegistration{
+		WorkerProcessIdentity: WorkerProcessIdentity{
+			PID:       4242,
+			GroupID:   4242,
+			StartedAt: processStartedAt,
+		},
+		CleanupRoot: cleanupRoot,
+		CleanupPath: cleanupPath,
 	}); err != nil {
 		t.Fatalf("UpdateSessionWorkerProcess() error = %v", err)
 	}
@@ -1875,7 +1881,7 @@ func TestActiveWorkerProcessesAreJournaledAndReaped(t *testing.T) {
 	if len(active) != 1 {
 		t.Fatalf("ListActiveWorkerProcesses() len = %d, want 1", len(active))
 	}
-	if got := active[0]; got.SessionID != sessionID || got.Identifier != "digitaldrywood/detent#1214" || got.PID != 4242 || got.GroupID != 4242 || !got.StartedAt.Equal(processStartedAt) {
+	if got := active[0]; got.SessionID != sessionID || got.Identifier != "digitaldrywood/detent#1214" || got.PID != 4242 || got.GroupID != 4242 || !got.StartedAt.Equal(processStartedAt) || got.CleanupRoot != cleanupRoot || got.CleanupPath != cleanupPath {
 		t.Fatalf("active worker process = %#v", got)
 	}
 	if err := backend.FinishSession(ctx, sessionID, SessionFinish{

--- a/internal/web/server_test.go
+++ b/internal/web/server_test.go
@@ -7247,7 +7247,7 @@ func TestHealthReportsOnlyWorkerProcessesWithoutLiveSessions(t *testing.T) {
 			if err != nil {
 				t.Fatalf("StartSession() error = %v", err)
 			}
-			if err := deps.Store.UpdateSessionWorkerProcess(t.Context(), sessionID, store.WorkerProcessIdentity{PID: 1885, GroupID: 1885, StartedAt: startedAt}); err != nil {
+			if err := deps.Store.UpdateSessionWorkerProcess(t.Context(), sessionID, store.WorkerProcessRegistration{WorkerProcessIdentity: store.WorkerProcessIdentity{PID: 1885, GroupID: 1885, StartedAt: startedAt}}); err != nil {
 				t.Fatalf("UpdateSessionWorkerProcess() error = %v", err)
 			}
 			if tt.terminal {

--- a/internal/workspace/workspace.go
+++ b/internal/workspace/workspace.go
@@ -1512,6 +1512,23 @@ func CleanupWorkerScratch(workspacePath string) error {
 	return nil
 }
 
+func CleanupOwnedPath(root string, path string) error {
+	if strings.TrimSpace(root) == "" || strings.TrimSpace(path) == "" {
+		return nil
+	}
+	root, err := canonicalExistingPath(root)
+	if errors.Is(err, fs.ErrNotExist) {
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("resolve cleanup root: %w", err)
+	}
+	if err := removeWorkspacePath(root, path); err != nil {
+		return fmt.Errorf("remove owned path: %w", err)
+	}
+	return nil
+}
+
 func remediateWorkspacePathPermissions(root string, path string) (string, error) {
 	validated, err := validateWorkspacePath(root, path)
 	if err != nil {

--- a/internal/workspace/workspace_test.go
+++ b/internal/workspace/workspace_test.go
@@ -2273,6 +2273,63 @@ func TestWorkerScratchLifecycleRemediatesGeneratedCachePermissions(t *testing.T)
 	}
 }
 
+func TestCleanupOwnedPathConfinesRemovalToRegisteredRoot(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		path       func(root string, outside string) string
+		wantErr    bool
+		wantExists bool
+	}{
+		{
+			name: "registered descendant",
+			path: func(root string, _ string) string {
+				return filepath.Join(root, "run-2011")
+			},
+		},
+		{
+			name: "cleanup root",
+			path: func(root string, _ string) string {
+				return root
+			},
+			wantErr:    true,
+			wantExists: true,
+		},
+		{
+			name: "outside root",
+			path: func(_ string, outside string) string {
+				return outside
+			},
+			wantErr:    true,
+			wantExists: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			root := t.TempDir()
+			outside := t.TempDir()
+			path := tt.path(root, outside)
+			if path != root && path != outside {
+				if err := os.MkdirAll(filepath.Join(path, "cache"), 0o700); err != nil {
+					t.Fatalf("create cleanup path: %v", err)
+				}
+			}
+			err := CleanupOwnedPath(root, path)
+			if got := err != nil; got != tt.wantErr {
+				t.Fatalf("CleanupOwnedPath() error = %v, want error %v", err, tt.wantErr)
+			}
+			_, statErr := os.Stat(path)
+			if got := statErr == nil; got != tt.wantExists {
+				t.Fatalf("cleanup path exists = %v, want %v, stat error = %v", got, tt.wantExists, statErr)
+			}
+		})
+	}
+}
+
 func TestPrepareWorkerScratchInstallsGitExcludeBeforeUse(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

- keep each worker temporary directory available until its process group has exited
- retain worker scratch when process-group exit cannot be verified
- recreate worker scratch for every attempt, including reused workspaces
- persist confined cleanup targets so later startup and doctor reaps release retained audit workspaces

Fixes #2011

## UI Surface Contract

- [x] N/A, or the linked issue explicitly authorizes any high-impact UI surface, layout, density, first-viewport, or responsive visibility tradeoff.
- [x] Persistent top-of-screen messaging is explicitly authorized by the issue, or this PR does not add it.
- [x] Visual changes to primary operator screens include screenshot or browser verification below.

## Test Plan

- [x] `make check`
- [x] Focused worker scratch, startup recovery, and security-audit lifecycle regressions
- [x] Race validation for runner, CLI, store, and workspace packages
