### PR TITLE
fix(codex): scope turn completion to root

### DIFF
--- a/internal/codex/appserver.go
+++ b/internal/codex/appserver.go
@@ -532,7 +532,7 @@ func (s *AppServer) RunTurn(ctx context.Context, req RunTurnRequest, onUpdate Up
 		}
 	}
 
-	if err := s.streamTurn(ctx, transport, req.turnTimeout(s.turnTimeout), req.StallTimeout, req.ToolHandler, elicitationState, onUpdate); err != nil {
+	if err := s.streamTurn(ctx, transport, threadID, turnID, req.turnTimeout(s.turnTimeout), req.StallTimeout, req.ToolHandler, elicitationState, onUpdate); err != nil {
 		return RunTurnResult{}, err
 	}
 
@@ -1130,6 +1130,8 @@ func (r RunTurnRequest) turnTimeout(fallback time.Duration) time.Duration {
 func (s *AppServer) streamTurn(
 	ctx context.Context,
 	transport Transport,
+	threadID string,
+	turnID string,
 	turnTimeout time.Duration,
 	stallTimeout time.Duration,
 	toolHandler DynamicToolHandler,
@@ -1163,7 +1165,7 @@ func (s *AppServer) streamTurn(
 		if err := emitUpdate(update, onUpdate); err != nil {
 			return err
 		}
-		if update.Type != UpdateTurnCompleted {
+		if update.Type != UpdateTurnCompleted || !turnCompletionMatches(update, threadID, turnID) {
 			continue
 		}
 		if update.Status == "" || update.Status == "completed" {
@@ -1175,6 +1177,16 @@ func (s *AppServer) streamTurn(
 			Body:    update.BackendErrorBody,
 		}
 	}
+}
+
+func turnCompletionMatches(update Update, threadID string, turnID string) bool {
+	if updateThreadID := strings.TrimSpace(update.ThreadID); updateThreadID != "" && updateThreadID != strings.TrimSpace(threadID) {
+		return false
+	}
+	if updateTurnID := strings.TrimSpace(update.TurnID); updateTurnID != "" && updateTurnID != strings.TrimSpace(turnID) {
+		return false
+	}
+	return true
 }
 
 func receiveTurnMessage(

--- a/internal/codex/appserver.go
+++ b/internal/codex/appserver.go
@@ -286,6 +286,7 @@ type Update struct {
 	WorkerProcess       procgroup.Identity
 	ThreadID            string
 	TurnID              string
+	AuxiliaryTurn       bool
 	ItemID              string
 	Tool                string
 	Command             string
@@ -1162,10 +1163,11 @@ func (s *AppServer) streamTurn(
 		if !ok {
 			continue
 		}
+		update.AuxiliaryTurn = !turnUpdateMatches(update, threadID, turnID)
 		if err := emitUpdate(update, onUpdate); err != nil {
 			return err
 		}
-		if update.Type != UpdateTurnCompleted || !turnCompletionMatches(update, threadID, turnID) {
+		if update.Type != UpdateTurnCompleted || update.AuxiliaryTurn {
 			continue
 		}
 		if update.Status == "" || update.Status == "completed" {
@@ -1179,7 +1181,7 @@ func (s *AppServer) streamTurn(
 	}
 }
 
-func turnCompletionMatches(update Update, threadID string, turnID string) bool {
+func turnUpdateMatches(update Update, threadID string, turnID string) bool {
 	if updateThreadID := strings.TrimSpace(update.ThreadID); updateThreadID != "" && updateThreadID != strings.TrimSpace(threadID) {
 		return false
 	}

--- a/internal/codex/appserver_test.go
+++ b/internal/codex/appserver_test.go
@@ -2106,10 +2106,10 @@ func TestAppServerRunTurnWaitsForRootCompletion(t *testing.T) {
 			if len(completions) != 2 {
 				t.Fatalf("completion updates = %#v, want child and root completions", completions)
 			}
-			if completions[0].ThreadID != "thread-child" || completions[0].TurnID != "turn-child" {
+			if completions[0].ThreadID != "thread-child" || completions[0].TurnID != "turn-child" || !completions[0].AuxiliaryTurn {
 				t.Fatalf("child completion = %#v", completions[0])
 			}
-			if completions[1].ThreadID != "thread-root" || completions[1].TurnID != "turn-root" {
+			if completions[1].ThreadID != "thread-root" || completions[1].TurnID != "turn-root" || completions[1].AuxiliaryTurn {
 				t.Fatalf("root completion = %#v", completions[1])
 			}
 		})

--- a/internal/codex/appserver_test.go
+++ b/internal/codex/appserver_test.go
@@ -1160,7 +1160,7 @@ func TestAppServerStreamTurnResetsStallTimeoutAfterActivity(t *testing.T) {
 		t.Fatalf("NewAppServer() error = %v", err)
 	}
 
-	if err := server.streamTurn(context.Background(), transport, time.Hour, time.Second, nil, nil, nil); err != nil {
+	if err := server.streamTurn(context.Background(), transport, "thread-1", "turn-1", time.Hour, time.Second, nil, nil, nil); err != nil {
 		t.Fatalf("streamTurn() error = %v", err)
 	}
 	if len(transport.deadlines) != 2 {
@@ -1190,7 +1190,7 @@ func TestAppServerStreamTurnResetsTurnTimeoutAfterActivity(t *testing.T) {
 		t.Fatalf("NewAppServer() error = %v", err)
 	}
 
-	if err := server.streamTurn(context.Background(), transport, time.Second, 0, nil, nil, nil); err != nil {
+	if err := server.streamTurn(context.Background(), transport, "thread-1", "turn-1", time.Second, 0, nil, nil, nil); err != nil {
 		t.Fatalf("streamTurn() error = %v", err)
 	}
 	if len(transport.deadlines) != 2 {
@@ -2041,6 +2041,78 @@ func TestAppServerRunTurnReportsTurnErrorBody(t *testing.T) {
 	}
 	if updates[2].Status != "failed" || updates[2].BackendErrorBody != backendError {
 		t.Fatalf("failed update = %#v, want status failed with backend error", updates[2])
+	}
+}
+
+func TestAppServerRunTurnWaitsForRootCompletion(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name            string
+		childCompletion string
+	}{
+		{
+			name:            "completed child",
+			childCompletion: `{"threadId":"thread-child","turn":{"id":"turn-child","status":"completed"}}`,
+		},
+		{
+			name:            "interrupted child",
+			childCompletion: `{"threadId":"thread-child","turn":{"id":"turn-child","status":"interrupted","error":null}}`,
+		},
+		{
+			name:            "failed child",
+			childCompletion: `{"threadId":"thread-child","turn":{"id":"turn-child","status":"failed","error":{"message":"child failed"}}}`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			transport := newFakeAppServerTransport([]Message{
+				responseMessage(t, 1, `{"userAgent":"codex-cli/0.151.0"}`),
+				responseMessage(t, 2, `{"thread":{"id":"thread-root","model":"gpt-5.6-sol"}}`),
+				responseMessage(t, 3, `{"turn":{"id":"turn-root"}}`),
+				notificationMessage(t, "turn/completed", tt.childCompletion),
+				notificationMessage(t, "turn/completed", `{"threadId":"thread-root","turn":{"id":"turn-root","status":"completed"}}`),
+			})
+			server, err := NewAppServer(staticTransportFactory{transport: transport},
+				WithReadTimeout(time.Second),
+				WithTurnTimeout(time.Second),
+			)
+			if err != nil {
+				t.Fatalf("NewAppServer() error = %v", err)
+			}
+
+			var completions []Update
+			result, err := server.RunTurn(context.Background(), RunTurnRequest{
+				Workspace: "/tmp/detent-workspace",
+				Prompt:    "Ship issue #2059",
+			}, func(update Update) error {
+				if update.Type == UpdateTurnCompleted {
+					completions = append(completions, update)
+				}
+				return nil
+			})
+			if err != nil {
+				t.Fatalf("RunTurn() error = %v", err)
+			}
+			if result.ThreadID != "thread-root" || result.TurnID != "turn-root" {
+				t.Fatalf("RunTurn() result = %#v", result)
+			}
+			if len(transport.received) != 0 {
+				t.Fatalf("unread transport messages = %d, want root completion consumed", len(transport.received))
+			}
+			if len(completions) != 2 {
+				t.Fatalf("completion updates = %#v, want child and root completions", completions)
+			}
+			if completions[0].ThreadID != "thread-child" || completions[0].TurnID != "turn-child" {
+				t.Fatalf("child completion = %#v", completions[0])
+			}
+			if completions[1].ThreadID != "thread-root" || completions[1].TurnID != "turn-root" {
+				t.Fatalf("root completion = %#v", completions[1])
+			}
+		})
 	}
 }
 

--- a/internal/codex/backend.go
+++ b/internal/codex/backend.go
@@ -228,6 +228,7 @@ func agentUpdateFromCodex(update Update) runner.AgentUpdate {
 		WorkerProcess:       update.WorkerProcess,
 		ThreadID:            update.ThreadID,
 		TurnID:              update.TurnID,
+		AuxiliaryTurn:       update.AuxiliaryTurn,
 		ProviderSessionID:   providerSessionID,
 		ItemID:              update.ItemID,
 		Tool:                update.Tool,

--- a/internal/codex/backend_test.go
+++ b/internal/codex/backend_test.go
@@ -173,9 +173,10 @@ func TestAgentUpdateFromCodexCarriesCumulativeAndLastTokenUsage(t *testing.T) {
 
 	contextWindow := int64(200_000)
 	update := agentUpdateFromCodex(Update{
-		Type:     UpdateTokenUsage,
-		ThreadID: "thread-1716",
-		TurnID:   "turn-2",
+		Type:          UpdateTokenUsage,
+		ThreadID:      "thread-1716",
+		TurnID:        "turn-2",
+		AuxiliaryTurn: true,
 		Tokens: TokenUsage{
 			InputTokens:        14_300_000,
 			CachedInputTokens:  13_900_000,
@@ -199,6 +200,9 @@ func TestAgentUpdateFromCodexCarriesCumulativeAndLastTokenUsage(t *testing.T) {
 	}
 	if update.ProviderSessionID != "thread-1716-turn-2" {
 		t.Fatalf("ProviderSessionID = %q, want thread-turn identity", update.ProviderSessionID)
+	}
+	if !update.AuxiliaryTurn {
+		t.Fatal("AuxiliaryTurn = false, want child turn marker")
 	}
 }
 

--- a/internal/runner/agent.go
+++ b/internal/runner/agent.go
@@ -1073,7 +1073,7 @@ func (r *Runner) runAgentTurn(
 		if !update.RuntimeIdentity.IsZero() {
 			update.RuntimeIdentity = update.RuntimeIdentity.ObserveAt(eventAt)
 		}
-		if update.Type == AgentUpdateTurnStarted || strings.TrimSpace(update.TurnID) != "" {
+		if !update.AuxiliaryTurn && (update.Type == AgentUpdateTurnStarted || strings.TrimSpace(update.TurnID) != "") {
 			turnStarted = true
 		}
 		r.logAgentUpdate(runRequest, detentSessionID, update)
@@ -3094,7 +3094,7 @@ func (r *Runner) startSession(
 }
 
 func (r *Runner) persistSessionProviderIdentity(ctx context.Context, sessionID int64, update AgentUpdate) error {
-	if sessionID <= 0 {
+	if sessionID <= 0 || update.AuxiliaryTurn {
 		return nil
 	}
 	threadID := strings.TrimSpace(update.ThreadID)
@@ -3793,7 +3793,7 @@ func (p *agentRunProgress) apply(update AgentUpdate, eventAt time.Time) {
 		p.rssObservedAt = eventAt.UTC()
 		return
 	}
-	if update.TurnID != "" {
+	if update.TurnID != "" && !update.AuxiliaryTurn {
 		p.turnIDs[update.TurnID] = struct{}{}
 		if update.ThreadID != "" {
 			p.sessionID = update.ThreadID + "-" + update.TurnID

--- a/internal/runner/runner_test.go
+++ b/internal/runner/runner_test.go
@@ -698,6 +698,54 @@ func TestAgentRunProgressUsesStreamedCommandErrorInsteadOfCommandPayload(t *test
 	}
 }
 
+func TestAgentRunProgressExcludesAuxiliaryTurnsFromRootAccounting(t *testing.T) {
+	t.Parallel()
+
+	progress := newAgentRunProgress(runtimeoutput.Policy{}, "", "", 0, "", 0)
+	eventAt := time.Now()
+	progress.apply(AgentUpdate{
+		Type:     AgentUpdateTurnStarted,
+		ThreadID: "thread-root",
+		TurnID:   "turn-root",
+	}, eventAt)
+	progress.apply(AgentUpdate{
+		Type:          AgentUpdateTurnCompleted,
+		ThreadID:      "thread-child",
+		TurnID:        "turn-child",
+		AuxiliaryTurn: true,
+		Status:        "completed",
+	}, eventAt.Add(time.Second))
+
+	if progress.turnCount() != 1 {
+		t.Fatalf("turnCount() = %d, want 1", progress.turnCount())
+	}
+	if progress.sessionID != "thread-root-turn-root" {
+		t.Fatalf("sessionID = %q, want root provider session", progress.sessionID)
+	}
+	if progress.lastEvent != string(AgentUpdateTurnCompleted) || progress.lastMessage != "turn completed" {
+		t.Fatalf("child telemetry = event %q message %q, want completed turn activity", progress.lastEvent, progress.lastMessage)
+	}
+}
+
+func TestRunnerSkipsAuxiliaryTurnProviderIdentityPersistence(t *testing.T) {
+	t.Parallel()
+
+	sessionStore := &fakeSessionStore{}
+	runner := &Runner{store: sessionStore}
+	err := runner.persistSessionProviderIdentity(t.Context(), 2059, AgentUpdate{
+		ThreadID:          "thread-child",
+		TurnID:            "turn-child",
+		AuxiliaryTurn:     true,
+		ProviderSessionID: "thread-child-turn-child",
+	})
+	if err != nil {
+		t.Fatalf("persistSessionProviderIdentity() error = %v", err)
+	}
+	if len(sessionStore.providerUpdates) != 0 {
+		t.Fatalf("provider updates = %#v, want child identity excluded", sessionStore.providerUpdates)
+	}
+}
+
 func TestCommandAfterLastGitPush(t *testing.T) {
 	t.Parallel()
 

--- a/internal/runner/types.go
+++ b/internal/runner/types.go
@@ -426,6 +426,7 @@ type AgentUpdate struct {
 	WorkerProcess       procgroup.Identity
 	ThreadID            string
 	TurnID              string
+	AuxiliaryTurn       bool
 	ProviderSessionID   string
 	ItemID              string
 	Tool                string


### PR DESCRIPTION
## Summary

- correlate Codex completion notifications with the root worker thread and turn
- retain child completion telemetry without ending or failing the parent worker
- cover completed, interrupted, and failed child turns before root completion

Fixes #2059

## UI Surface Contract

- [x] N/A, or the linked issue explicitly authorizes any high-impact UI surface, layout, density, first-viewport, or responsive visibility tradeoff.
- [x] Persistent top-of-screen messaging is explicitly authorized by the issue, or this PR does not add it.
- [x] Visual changes to primary operator screens include screenshot or browser verification below.

## Test Plan

- [x] `make check`
