### PR TITLE
fix(update): recover startup crash loops

### DIFF
--- a/cmd/detent/main.go
+++ b/cmd/detent/main.go
@@ -102,6 +102,7 @@ func newRootCommandWithRestart(ctx context.Context, shutdownController *cli.Shut
 		cli.WithVersion(build.Version),
 		cli.WithBuild(build),
 		cli.WithLoggerFunc(setupLoggerFromRuntime),
+		cli.WithStartupRecovery(),
 	}
 	if shutdownController != nil {
 		opts = append(opts, cli.WithShutdownController(shutdownController))

--- a/cmd/detent/update.go
+++ b/cmd/detent/update.go
@@ -13,6 +13,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/digitaldrywood/detent/internal/cli"
+	globalconfig "github.com/digitaldrywood/detent/internal/config/global"
 	detentupdate "github.com/digitaldrywood/detent/internal/update"
 )
 
@@ -64,11 +65,17 @@ func newUpdateCommand(ctx context.Context, factory updateFactory) *cobra.Command
 				if out.IsJSON() {
 					streamOut = cmd.ErrOrStderr()
 				}
+				preflight, recoveryStatePath, safetyErr := updateSafetyOptions(cmd)
+				if safetyErr != nil {
+					return safetyErr
+				}
 				opts := detentupdate.ApplyOptions{
-					AssumeYes:   assumeYes,
-					FromRelease: fromRelease,
-					Stdout:      streamOut,
-					Stderr:      cmd.ErrOrStderr(),
+					AssumeYes:         assumeYes,
+					FromRelease:       fromRelease,
+					Preflight:         preflight,
+					RecoveryStatePath: recoveryStatePath,
+					Stdout:            streamOut,
+					Stderr:            cmd.ErrOrStderr(),
 				}
 				if !assumeYes && !fromRelease && !out.IsJSON() {
 					opts.Confirm = confirmUpdate(cmd)
@@ -90,6 +97,28 @@ func newUpdateCommand(ctx context.Context, factory updateFactory) *cobra.Command
 	cmd.Flags().BoolVar(&fromRelease, "from-release", false, "replace a go-install-managed binary with the latest release asset")
 	cmd.Flags().BoolVar(&jsonOutput, "json", false, "write machine-readable update status")
 	return cmd
+}
+
+func updateSafetyOptions(cmd *cobra.Command) (detentupdate.BinaryPreflight, string, error) {
+	configPath := ""
+	if cmd.InheritedFlags().Lookup("config") != nil {
+		value, err := cmd.InheritedFlags().GetString("config")
+		if err != nil {
+			return nil, "", fmt.Errorf("resolve update config flag: %w", err)
+		}
+		configPath = value
+	}
+	resolution, err := globalconfig.ResolvePath(configPath)
+	if err != nil {
+		return nil, "", fmt.Errorf("resolve update startup config: %w", err)
+	}
+	preflight := detentupdate.CommandPreflight(
+		"--config", resolution.Path,
+		"--port", "0",
+		"--format", "json",
+		"doctor", "--startup-preflight",
+	)
+	return preflight, detentupdate.RecoveryStatePath(resolution.Path), nil
 }
 
 func newDefaultUpdateRunner(context.Context) (updateRunner, error) {

--- a/internal/cli/boot.go
+++ b/internal/cli/boot.go
@@ -557,6 +557,13 @@ func startRunningWithDependencies(ctx context.Context, cfg BootConfig, deps star
 		})
 		return nil
 	}
+	readiness := startupReadiness{}
+	if cfg.StartupRecovery != nil {
+		readiness.AwaitServe = func(ctx context.Context) error {
+			return awaitStartupServer(ctx, startupServerURL(listener.Addr()))
+		}
+		readiness.MarkHealthy = cfg.StartupRecovery.MarkHealthy
+	}
 
 	if useDashboard {
 		if err := printBootBanner(cfg, displayURL); err != nil {
@@ -564,11 +571,11 @@ func startRunningWithDependencies(ctx context.Context, cfg BootConfig, deps star
 		}
 		listenerOwned = false
 		if cfg.Shutdown == nil {
-			return runStartupAndServe(runCtx, startupLifecycle, startProjects, func(ctx context.Context) error {
+			return runStartupAndServe(runCtx, startupLifecycle, startProjects, readiness, func(ctx context.Context) error {
 				return serveWithTerminalDashboard(ctx, server, listener, snapshotHub, cfg.Build, runtimeLogPath(cfg), cfg.Output, nil, nil, nil)
 			})
 		}
-		return runStartupAndServe(runCtx, startupLifecycle, startProjects, func(ctx context.Context) error {
+		return runStartupAndServe(runCtx, startupLifecycle, startProjects, readiness, func(ctx context.Context) error {
 			return runWithShutdown(ctx, runningShutdownConfig{
 				Controller:        cfg.Shutdown,
 				Registry:          manager.Registry(),
@@ -598,11 +605,11 @@ func startRunningWithDependencies(ctx context.Context, cfg BootConfig, deps star
 	}
 	listenerOwned = false
 	if cfg.Shutdown == nil {
-		return runStartupAndServe(runCtx, startupLifecycle, startProjects, func(ctx context.Context) error {
+		return runStartupAndServe(runCtx, startupLifecycle, startProjects, readiness, func(ctx context.Context) error {
 			return serve(ctx, server, listener)
 		})
 	}
-	return runStartupAndServe(runCtx, startupLifecycle, startProjects, func(ctx context.Context) error {
+	return runStartupAndServe(runCtx, startupLifecycle, startProjects, readiness, func(ctx context.Context) error {
 		return runWithShutdown(ctx, runningShutdownConfig{
 			Controller:  cfg.Shutdown,
 			Registry:    manager.Registry(),
@@ -842,10 +849,16 @@ type startupServeResult struct {
 	err  error
 }
 
+type startupReadiness struct {
+	AwaitServe  func(context.Context) error
+	MarkHealthy func(context.Context) error
+}
+
 func runStartupAndServe(
 	ctx context.Context,
 	lifecycle *web.StartupLifecycle,
 	startup func(context.Context) error,
+	readiness startupReadiness,
 	serveApp func(context.Context) error,
 ) error {
 	if ctx == nil {
@@ -861,16 +874,39 @@ func runStartupAndServe(
 	go func() {
 		results <- startupServeResult{name: "serve", err: serveApp(runCtx)}
 	}()
+	serveReady := readiness.AwaitServe == nil
+	if readiness.AwaitServe != nil {
+		go func() {
+			results <- startupServeResult{name: "readiness", err: readiness.AwaitServe(runCtx)}
+		}()
+	}
 
 	startupDone := false
+	healthyMarked := false
 	for {
-		result := <-results
+		var result startupServeResult
+		if startupDone && serveReady && !healthyMarked {
+			select {
+			case result = <-results:
+			default:
+				completeStartupLifecycle(lifecycle, nil)
+				if readiness.MarkHealthy != nil {
+					if err := readiness.MarkHealthy(runCtx); err != nil {
+						slog.Default().Warn("record healthy startup failed", "error", err)
+					}
+				}
+				healthyMarked = true
+				result = <-results
+			}
+		} else {
+			result = <-results
+		}
 		switch result.name {
 		case "startup":
-			completeStartupLifecycle(lifecycle, result.err)
 			if result.err != nil {
+				completeStartupLifecycle(lifecycle, result.err)
 				cancel()
-				serveResult := <-results
+				serveResult := awaitStartupServeResult(results, "serve")
 				if primaryShutdownError(serveResult.err) {
 					logSecondaryShutdownError("startup", serveResult.err, result.err)
 					return serveResult.err
@@ -881,10 +917,14 @@ func runStartupAndServe(
 				return result.err
 			}
 			startupDone = true
+		case "readiness":
+			if result.err == nil {
+				serveReady = true
+			}
 		case "serve":
 			cancel()
 			if !startupDone {
-				startupResult := <-results
+				startupResult := awaitStartupServeResult(results, "startup")
 				completeStartupLifecycle(lifecycle, startupResult.err)
 				if primaryShutdownError(result.err) {
 					logSecondaryShutdownError("startup", result.err, startupResult.err)
@@ -896,10 +936,60 @@ func runStartupAndServe(
 					}
 					return startupResult.err
 				}
+			} else if !healthyMarked {
+				completeStartupLifecycle(lifecycle, errors.New("serving stopped before startup readiness"))
 			}
 			return result.err
 		}
 	}
+}
+
+func awaitStartupServeResult(results <-chan startupServeResult, name string) startupServeResult {
+	for result := range results {
+		if result.name == name {
+			return result
+		}
+	}
+	return startupServeResult{name: name, err: context.Canceled}
+}
+
+func awaitStartupServer(ctx context.Context, baseURL string) error {
+	endpoint := strings.TrimRight(baseURL, "/") + "/.detent-startup-readiness"
+	client := http.Client{Timeout: time.Second}
+	for {
+		request, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
+		if err != nil {
+			return err
+		}
+		response, err := client.Do(request)
+		if err == nil {
+			_ = response.Body.Close()
+			return nil
+		}
+		timer := time.NewTimer(25 * time.Millisecond)
+		select {
+		case <-ctx.Done():
+			timer.Stop()
+			return ctx.Err()
+		case <-timer.C:
+		}
+	}
+}
+
+func startupServerURL(addr net.Addr) string {
+	host, port, err := net.SplitHostPort(addr.String())
+	if err != nil {
+		return ""
+	}
+	ip := net.ParseIP(strings.SplitN(host, "%", 2)[0])
+	if ip != nil && ip.IsUnspecified() {
+		if ip.To4() != nil {
+			host = "127.0.0.1"
+		} else {
+			host = "::1"
+		}
+	}
+	return "http://" + net.JoinHostPort(host, port)
 }
 
 func completeStartupLifecycle(lifecycle *web.StartupLifecycle, err error) {

--- a/internal/cli/boot_test.go
+++ b/internal/cli/boot_test.go
@@ -772,6 +772,29 @@ func TestStartRunningRefusesSharedRuntimeDatabase(t *testing.T) {
 	}
 }
 
+func TestStartupServerURL(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		addr *net.TCPAddr
+		want string
+	}{
+		{name: "specific host", addr: &net.TCPAddr{IP: net.ParseIP("100.109.187.102"), Port: 4000}, want: "http://100.109.187.102:4000"},
+		{name: "IPv4 wildcard", addr: &net.TCPAddr{IP: net.IPv4zero, Port: 4000}, want: "http://127.0.0.1:4000"},
+		{name: "IPv6 wildcard", addr: &net.TCPAddr{IP: net.IPv6zero, Port: 4000}, want: "http://[::1]:4000"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := startupServerURL(tt.addr); got != tt.want {
+				t.Fatalf("startupServerURL() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestRuntimeStoreLocation(t *testing.T) {
 	t.Parallel()
 

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -200,6 +200,7 @@ type BootConfig struct {
 	HardExit         func(int)
 	Runner           orchestrator.Runner
 	ConnectorFactory project.ConnectorFactory
+	StartupRecovery  StartupRecovery
 }
 
 type IsolatedRuntimeInfo struct {
@@ -217,6 +218,13 @@ type IsolatedRuntimeInfo struct {
 }
 
 type BootFunc func(context.Context, BootConfig) error
+
+type StartupRecovery interface {
+	MarkHealthy(context.Context) error
+	HandleFailure(context.Context, error)
+}
+
+type StartupRecoveryFactory func(context.Context, BootConfig) (StartupRecovery, error)
 
 type SignalFunc func(context.Context, Signal) error
 
@@ -255,6 +263,7 @@ type options struct {
 	shutdown          *ShutdownController
 	restart           *RestartRequest
 	service           ServiceFactory
+	startupRecovery   StartupRecoveryFactory
 }
 
 func WithBootFunc(boot BootFunc) Option {
@@ -330,6 +339,12 @@ func WithServiceFactory(factory ServiceFactory) Option {
 		if factory != nil {
 			opts.service = factory
 		}
+	}
+}
+
+func WithStartupRecovery() Option {
+	return func(opts *options) {
+		opts.startupRecovery = newDefaultStartupRecovery
 	}
 }
 
@@ -430,7 +445,20 @@ detent --format json config path`),
 					slog.Warn(warning.Detail, "check", warning.Name, "hint", warning.Hint)
 				}
 			}
-			return opts.boot(cmd.Context(), boot)
+			var recovery StartupRecovery
+			if opts.startupRecovery != nil && boot.Mode == BootModeRunning {
+				recovery, err = opts.startupRecovery(cmd.Context(), boot)
+				if err != nil {
+					slog.Warn("initialize startup recovery failed", "error", err)
+				} else {
+					boot.StartupRecovery = recovery
+				}
+			}
+			bootErr := opts.boot(cmd.Context(), boot)
+			if bootErr != nil && recovery != nil {
+				recovery.HandleFailure(cmd.Context(), bootErr)
+			}
+			return bootErr
 		},
 	}
 	cmd.SetContext(withCommandOutputOptions(ctx, commandOutputOptions{

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -287,6 +287,7 @@ func newDoctorCommandWithDeps(configPath *string, env *string, logLevel *string,
 	workflowTokenThreshold := doctorWorkflowDefaultTokenThreshold
 	workflowProposalThreshold := doctorWorkflowProposalDefaultThreshold
 	strict := false
+	startupPreflight := false
 	projectID := ""
 	cmd := &cobra.Command{
 		Use:          "doctor",
@@ -306,7 +307,7 @@ func newDoctorCommandWithDeps(configPath *string, env *string, logLevel *string,
 			if out.IsJSON() {
 				progressOut = cmd.ErrOrStderr()
 			}
-			report := runDoctor(cmd.Context(), doctorConfig{
+			config := doctorConfig{
 				ConfigPath:                derefString(configPath),
 				Host:                      derefString(host),
 				ProjectID:                 projectID,
@@ -323,7 +324,13 @@ func newDoctorCommandWithDeps(configPath *string, env *string, logLevel *string,
 					LogLevel: runtimeStringFlag{Value: derefString(logLevel), Set: flagChanged(cmd, "log-level")},
 					Port:     runtimeIntFlag{Value: derefInt(port, -1), Set: flagChanged(cmd, "port")},
 				},
-			}, opts, deps)
+			}
+			var report doctorReport
+			if startupPreflight {
+				report = runDoctorStartupPreflight(cmd.Context(), config, opts, deps)
+			} else {
+				report = runDoctor(cmd.Context(), config, opts, deps)
+			}
 			report.strict = strict
 			if workflowWrite {
 				if err := confirmDoctorWorkflowOptimizationWrite(cmd, report.WorkflowOptimization); err != nil {
@@ -354,6 +361,7 @@ func newDoctorCommandWithDeps(configPath *string, env *string, logLevel *string,
 	cmd.Flags().IntVar(&workflowProposalThreshold, "proposal-threshold", doctorWorkflowProposalDefaultThreshold, "minimum repeated signal count before emitting a governed self-improvement proposal")
 	cmd.Flags().BoolVar(&workflowProposeIssues, "propose-issues", false, "create governed backlog issue proposals for repeated workflow optimization signals")
 	cmd.Flags().BoolVar(&strict, "strict", false, "fail when checks warn or workflow optimization findings exist")
+	cmd.Flags().BoolVar(&startupPreflight, "startup-preflight", false, "limit checks to candidate startup compatibility")
 	cmd.Flags().StringVar(&projectID, "project", "", "limit project checks to the selected project id")
 	cmd.SetContext(withCommandOutputOptions(context.Background(), commandOutputOptions{
 		lookupEnv: opts.lookupEnv,

--- a/internal/cli/doctor_startup_preflight.go
+++ b/internal/cli/doctor_startup_preflight.go
@@ -1,0 +1,68 @@
+package cli
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	workflowconfig "github.com/digitaldrywood/detent/internal/config"
+	projectpkg "github.com/digitaldrywood/detent/internal/project"
+)
+
+func runDoctorStartupPreflight(ctx context.Context, cfg doctorConfig, opts options, deps doctorDeps) doctorReport {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	deps = deps.withDefaults()
+	report := doctorReport{}
+	boot, err := resolveBootConfig(ctx, cfg.ConfigPath, cfg.Host, cfg.Flags, opts)
+	if err != nil {
+		report.Add(doctorCheck{
+			Name:   "Candidate startup",
+			Status: doctorFail,
+			Detail: err.Error(),
+			Hint:   "Keep the current binary and fix the candidate compatibility failure before updating.",
+		})
+		return report
+	}
+	report.Add(doctorCheck{
+		Name:   "Candidate startup",
+		Status: doctorOK,
+		Detail: fmt.Sprintf("candidate resolved %s via %s", boot.Global.Path, boot.ConfigPathRule),
+	})
+	if boot.Mode != BootModeRunning {
+		return report
+	}
+
+	githubToken := runtimeGlobalGitHubToken(boot.Runtime.GitHubToken)
+	for _, configuredProject := range boot.Global.Projects {
+		id := doctorProjectID(configuredProject)
+		workflow, loadErr := loadDoctorProjectWorkflow(ctx, configuredProject, deps)
+		if loadErr == nil {
+			workflow.Config = doctorWorkflowConfigWithRuntimeGitHubToken(workflow.Config, githubToken)
+			if configuredProject.Identity.Configured() {
+				identity := configuredProject.Identity
+				identity.Normalize()
+				workflow.Config.Identity = identity
+			}
+			workflow.Config.ActiveHours = projectpkg.EffectiveActiveHours(configuredProject, workflow.Config.ActiveHours)
+			loadErr = errors.Join(workflow.Config.Validate(), workflowconfig.ValidateWorkflowAdmission(workflow))
+		}
+		if loadErr != nil {
+			report.Add(doctorCheck{
+				Name:   "Project " + id + " startup",
+				Status: doctorWarn,
+				Detail: "candidate will isolate this project as degraded: " + strings.TrimSpace(loadErr.Error()),
+				Hint:   "Fix the project definition independently; it does not prevent the Detent host from booting.",
+			})
+			continue
+		}
+		report.Add(doctorCheck{
+			Name:   "Project " + id + " startup",
+			Status: doctorOK,
+			Detail: "candidate loaded and validated the effective project definition",
+		})
+	}
+	return report
+}

--- a/internal/cli/doctor_startup_preflight_test.go
+++ b/internal/cli/doctor_startup_preflight_test.go
@@ -1,0 +1,80 @@
+package cli
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	workflowconfig "github.com/digitaldrywood/detent/internal/config"
+	globalconfig "github.com/digitaldrywood/detent/internal/config/global"
+)
+
+func TestRunDoctorStartupPreflight(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		loadErr     error
+		wantStatus  doctorStatus
+		wantDetail  string
+		wantFailure bool
+	}{
+		{
+			name:       "valid project is startup compatible",
+			wantStatus: doctorOK,
+			wantDetail: "loaded and validated",
+		},
+		{
+			name:        "invalid project is isolated without blocking host boot",
+			loadErr:     errors.New("schedule ownership is invalid"),
+			wantStatus:  doctorWarn,
+			wantDetail:  "isolate this project as degraded",
+			wantFailure: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			configPath := t.TempDir() + "/global.yaml"
+			global := validDoctorGlobalWithProjects(configPath, "alpha")
+			deps := successfulDoctorDeps()
+			deps.loadWorkflow = func(string) (workflowconfig.Workflow, error) {
+				if tt.loadErr != nil {
+					return workflowconfig.Workflow{}, tt.loadErr
+				}
+				return workflowconfig.Workflow{Config: validDoctorWorkflow("/alpha")}, nil
+			}
+
+			report := runDoctorStartupPreflight(context.Background(), doctorConfig{
+				ConfigPath: configPath,
+				Flags: runtimeFlags{
+					Port: runtimeIntFlag{Value: 0, Set: true},
+				},
+			}, successfulDoctorOptionsWithConfig(configPath, global), deps)
+
+			assertDoctorCheck(t, report, "Candidate startup", doctorOK, "candidate resolved")
+			assertDoctorCheck(t, report, "Project alpha startup", tt.wantStatus, tt.wantDetail)
+			if got := report.HasFailures(); got != tt.wantFailure {
+				t.Fatalf("HasFailures() = %t, want %t", got, tt.wantFailure)
+			}
+		})
+	}
+}
+
+func TestRunDoctorStartupPreflightRejectsUnresolvableBootConfig(t *testing.T) {
+	t.Parallel()
+
+	configPath := t.TempDir() + "/global.yaml"
+	opts := successfulDoctorOptions(configPath)
+	opts.resolvePath = func(string) (globalconfig.PathResolution, error) {
+		return globalconfig.PathResolution{}, errors.New("candidate cannot resolve global config")
+	}
+	report := runDoctorStartupPreflight(context.Background(), doctorConfig{ConfigPath: configPath}, opts, successfulDoctorDeps())
+
+	assertDoctorCheck(t, report, "Candidate startup", doctorFail, "cannot resolve global config")
+	if !report.HasFailures() {
+		t.Fatal("HasFailures() = false, want candidate rejection")
+	}
+}

--- a/internal/cli/shutdown_test.go
+++ b/internal/cli/shutdown_test.go
@@ -1126,7 +1126,7 @@ func TestRunStartupAndServeForcedResultPrecedesStartupAuthError(t *testing.T) {
 		<-ctx.Done()
 		cause := fmt.Errorf("resolve github_token via gh auth token: %w", errors.New("context deadline exceeded"))
 		return GitHubAuthError(cause)
-	}, func(context.Context) error {
+	}, startupReadiness{}, func(context.Context) error {
 		return ErrShutdownForced
 	})
 
@@ -1148,7 +1148,7 @@ func TestRunStartupAndServeMarksFailedBeforeCancelingServe(t *testing.T) {
 	err := runStartupAndServe(context.Background(), lifecycle, func(context.Context) error {
 		<-serveStarted
 		return startupErr
-	}, func(ctx context.Context) error {
+	}, startupReadiness{}, func(ctx context.Context) error {
 		close(serveStarted)
 		<-ctx.Done()
 		observed <- lifecycle.State()
@@ -1160,6 +1160,95 @@ func TestRunStartupAndServeMarksFailedBeforeCancelingServe(t *testing.T) {
 	}
 	if got := <-observed; got != web.StartupLifecycleFailed {
 		t.Fatalf("lifecycle at serve cancellation = %q, want %q", got, web.StartupLifecycleFailed)
+	}
+}
+
+func TestRunStartupAndServeMarksHealthyAfterServingReadiness(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name             string
+		serveBeforeReady bool
+		wantHealthy      int32
+	}{
+		{name: "serving failure preserves rollback state", serveBeforeReady: true},
+		{name: "serving readiness commits healthy startup", wantHealthy: 1},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+			startupDone := make(chan struct{})
+			serveReady := make(chan struct{})
+			serveFailed := make(chan struct{})
+			healthyMarked := make(chan struct{})
+			var healthyCalls atomic.Int32
+			serveErr := errors.New("serve failed before readiness")
+
+			done := make(chan error, 1)
+			go func() {
+				done <- runStartupAndServe(ctx, web.NewStartupLifecycle(), func(context.Context) error {
+					close(startupDone)
+					return nil
+				}, startupReadiness{
+					AwaitServe: func(ctx context.Context) error {
+						select {
+						case <-serveReady:
+							return nil
+						case <-ctx.Done():
+							return ctx.Err()
+						}
+					},
+					MarkHealthy: func(context.Context) error {
+						healthyCalls.Add(1)
+						close(healthyMarked)
+						return nil
+					},
+				}, func(ctx context.Context) error {
+					if tt.serveBeforeReady {
+						<-startupDone
+						close(serveFailed)
+						return serveErr
+					}
+					<-ctx.Done()
+					return ctx.Err()
+				})
+			}()
+
+			select {
+			case <-startupDone:
+			case <-time.After(time.Second):
+				t.Fatal("startup did not finish")
+			}
+			if tt.serveBeforeReady {
+				select {
+				case <-serveFailed:
+				case <-time.After(time.Second):
+					t.Fatal("serving failure did not occur")
+				}
+			} else {
+				close(serveReady)
+				select {
+				case <-healthyMarked:
+				case <-done:
+					t.Fatal("runStartupAndServe returned before marking healthy")
+				case <-time.After(time.Second):
+					t.Fatal("startup was not marked healthy after serving readiness")
+				}
+				cancel()
+			}
+
+			err := <-done
+			if tt.serveBeforeReady && !errors.Is(err, serveErr) {
+				t.Fatalf("runStartupAndServe() error = %v, want %v", err, serveErr)
+			}
+			if got := healthyCalls.Load(); got != tt.wantHealthy {
+				t.Fatalf("healthy calls = %d, want %d", got, tt.wantHealthy)
+			}
+		})
 	}
 }
 

--- a/internal/cli/startup_recovery.go
+++ b/internal/cli/startup_recovery.go
@@ -1,0 +1,104 @@
+package cli
+
+import (
+	"context"
+	"os"
+	"runtime"
+	"strings"
+
+	"github.com/digitaldrywood/detent/internal/notify"
+	detentupdate "github.com/digitaldrywood/detent/internal/update"
+)
+
+func newDefaultStartupRecovery(_ context.Context, cfg BootConfig) (StartupRecovery, error) {
+	executable, err := os.Executable()
+	if err != nil {
+		return nil, err
+	}
+	version := runtimeUpdateVersion(cfg)
+	statePath := detentupdate.RecoveryStatePath(cfg.Global.Path)
+	preflight := candidateStartupPreflight(cfg)
+	applyOptions := detentupdate.ApplyOptions{
+		AssumeYes:         true,
+		Preflight:         preflight,
+		RecoveryStatePath: statePath,
+	}
+
+	var updater detentupdate.Updater
+	autoUpdate := cfg.Global.Update.AutoCheckEnabled && cfg.Global.Update.AutoApplyEnabled
+	if autoUpdate {
+		updater = newRuntimeUpdater(cfg, executable, version)
+	}
+	hostname, hostnameErr := os.Hostname()
+	if hostnameErr != nil {
+		hostname = ""
+	}
+	instance := strings.TrimSpace(cfg.Global.InstanceName)
+	if instance == "" {
+		instance = strings.TrimSpace(cfg.Global.Global.Identity.Name)
+	}
+	if instance == "" {
+		instance = strings.TrimSpace(strings.SplitN(hostname, ".", 2)[0])
+	}
+
+	return detentupdate.NewStartupRecovery(detentupdate.StartupRecoveryConfig{
+		StatePath:      statePath,
+		CurrentVersion: version,
+		ExecutablePath: executable,
+		GOOS:           runtime.GOOS,
+		AutoUpdate:     autoUpdate,
+		Updater:        updater,
+		ApplyOptions:   applyOptions,
+		Instance:       instance,
+		Host:           hostname,
+		Notify:         startupCrashLoopNotifier(cfg),
+	})
+}
+
+func newRuntimeUpdater(cfg BootConfig, executable string, version string) detentupdate.Updater {
+	return detentupdate.NewService(detentupdate.Config{
+		CurrentVersion: version,
+		ExecutablePath: executable,
+		GOOS:           runtime.GOOS,
+		GOARCH:         runtime.GOARCH,
+		Client: detentupdate.NewGitHubClient(detentupdate.GitHubClientConfig{
+			Token: strings.TrimSpace(cfg.Runtime.GitHubToken.Value),
+		}),
+	})
+}
+
+func candidateStartupPreflight(cfg BootConfig) detentupdate.BinaryPreflight {
+	args := []string{
+		"--config", cfg.Global.Path,
+		"--port", "0",
+		"--format", "json",
+		"doctor", "--startup-preflight",
+	}
+	return detentupdate.CommandPreflight(args...)
+}
+
+func startupCrashLoopNotifier(cfg BootConfig) func(context.Context, detentupdate.CrashLoopEvent) error {
+	health := cfg.Global.Notifications.Health
+	if strings.TrimSpace(health.Webhook.URL) == "" {
+		return nil
+	}
+	webhook, err := notify.NewWebhook(notify.WebhookConfig{
+		URL:     health.Webhook.URL,
+		Headers: health.Webhook.Headers,
+		Timeout: health.Webhook.Timeout(),
+	})
+	if err != nil {
+		return func(context.Context, detentupdate.CrashLoopEvent) error { return err }
+	}
+	return func(ctx context.Context, event detentupdate.CrashLoopEvent) error {
+		return webhook.Send(ctx, event)
+	}
+}
+
+func runtimeUpdateVersion(cfg BootConfig) string {
+	version := strings.TrimSpace(cfg.Version)
+	if version == "" {
+		version = strings.TrimSpace(cfg.Build.Version)
+	}
+	return version
+}

--- a/internal/cli/startup_recovery_test.go
+++ b/internal/cli/startup_recovery_test.go
@@ -1,0 +1,116 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	globalconfig "github.com/digitaldrywood/detent/internal/config/global"
+	detentupdate "github.com/digitaldrywood/detent/internal/update"
+)
+
+func TestRootCommandHandlesBootFailureWithStartupRecovery(t *testing.T) {
+	t.Parallel()
+
+	bootErr := errors.New("startup validation failed")
+	configPath := t.TempDir() + "/global.yaml"
+	global := validDoctorGlobalWithProjects(configPath)
+	recovery := &recordingStartupRecovery{}
+	cmd := NewRootCommand(context.Background(),
+		func(opts *options) {
+			configured := successfulDoctorOptionsWithConfig(configPath, global)
+			opts.resolvePath = configured.resolvePath
+			opts.read = configured.read
+			opts.startupRecovery = func(_ context.Context, cfg BootConfig) (StartupRecovery, error) {
+				if cfg.Mode != BootModeRunning || cfg.Global.Path != configPath {
+					t.Fatalf("startup recovery config = %#v, want running %s", cfg, configPath)
+				}
+				return recovery, nil
+			}
+		},
+		WithVersion("0.93.0"),
+		WithBootFunc(func(_ context.Context, cfg BootConfig) error {
+			if cfg.StartupRecovery != recovery {
+				t.Fatal("BootConfig.StartupRecovery was not injected")
+			}
+			return bootErr
+		}),
+	)
+	cmd.SetArgs([]string{"--config", configPath, "--headless", "--port", "0"})
+	cmd.SetOut(io.Discard)
+	cmd.SetErr(io.Discard)
+
+	err := cmd.Execute()
+	if !errors.Is(err, bootErr) {
+		t.Fatalf("Execute() error = %v, want %v", err, bootErr)
+	}
+	if len(recovery.failures) != 1 || !errors.Is(recovery.failures[0], bootErr) {
+		t.Fatalf("HandleFailure() errors = %v, want startup error", recovery.failures)
+	}
+}
+
+func TestStartupCrashLoopNotifierUsesHealthWebhook(t *testing.T) {
+	t.Parallel()
+
+	var body bytes.Buffer
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, request *http.Request) {
+		if request.Method != http.MethodPost {
+			t.Errorf("method = %s, want POST", request.Method)
+		}
+		_, _ = io.Copy(&body, request.Body)
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	t.Cleanup(server.Close)
+
+	cfg := BootConfig{Global: globalconfig.Config{
+		Notifications: globalconfig.Notifications{
+			Health: globalconfig.HealthNotifications{
+				Webhook: globalconfig.NotificationWebhook{
+					URL:       server.URL,
+					TimeoutMS: int(time.Second / time.Millisecond),
+				},
+			},
+		},
+	}}
+	notify := startupCrashLoopNotifier(cfg)
+	if notify == nil {
+		t.Fatal("startupCrashLoopNotifier() = nil, want configured webhook")
+	}
+	event := detentupdate.CrashLoopEvent{
+		Event:        "detent_startup_crash_loop",
+		Version:      "0.93.0",
+		FailureCount: 3,
+		Error:        "startup validation failed",
+	}
+	if err := notify(context.Background(), event); err != nil {
+		t.Fatalf("notify() error = %v", err)
+	}
+
+	var got detentupdate.CrashLoopEvent
+	if err := json.Unmarshal(body.Bytes(), &got); err != nil {
+		t.Fatalf("Unmarshal() error = %v", err)
+	}
+	if got.Event != event.Event || got.Version != event.Version || got.FailureCount != event.FailureCount || got.Error != event.Error {
+		t.Fatalf("webhook event = %#v, want %#v", got, event)
+	}
+}
+
+type recordingStartupRecovery struct {
+	healthyCalls int
+	failures     []error
+}
+
+func (r *recordingStartupRecovery) MarkHealthy(context.Context) error {
+	r.healthyCalls++
+	return nil
+}
+
+func (r *recordingStartupRecovery) HandleFailure(_ context.Context, err error) {
+	r.failures = append(r.failures, err)
+}

--- a/internal/cli/update_runtime.go
+++ b/internal/cli/update_runtime.go
@@ -63,6 +63,10 @@ func newRuntimeUpdateScheduler(
 		ReserveDrain:     reserveDrain,
 		Logger:           logger,
 		StatePath:        runtimeUpdateStatePath(cfg),
+		ApplyOptions: detentupdate.ApplyOptions{
+			Preflight:         candidateStartupPreflight(cfg),
+			RecoveryStatePath: detentupdate.RecoveryStatePath(cfg.Global.Path),
+		},
 	}
 	executable, err := os.Executable()
 	if err != nil {
@@ -78,19 +82,8 @@ func newRuntimeUpdateScheduler(
 	if !schedulerConfig.Enabled {
 		return detentupdate.NewScheduler(schedulerConfig)
 	}
-	version := strings.TrimSpace(cfg.Version)
-	if version == "" {
-		version = strings.TrimSpace(cfg.Build.Version)
-	}
-	schedulerConfig.Updater = detentupdate.NewService(detentupdate.Config{
-		CurrentVersion: version,
-		ExecutablePath: executable,
-		GOOS:           runtime.GOOS,
-		GOARCH:         runtime.GOARCH,
-		Client: detentupdate.NewGitHubClient(detentupdate.GitHubClientConfig{
-			Token: strings.TrimSpace(cfg.Runtime.GitHubToken.Value),
-		}),
-	})
+	version := runtimeUpdateVersion(cfg)
+	schedulerConfig.Updater = newRuntimeUpdater(cfg, executable, version)
 	schedulerConfig.RequestRestart = func(binary string) bool {
 		if strings.TrimSpace(binary) == "" {
 			binary = executable

--- a/internal/update/preflight.go
+++ b/internal/update/preflight.go
@@ -1,0 +1,24 @@
+package update
+
+import (
+	"context"
+	"fmt"
+	"os/exec"
+	"strings"
+)
+
+func CommandPreflight(args ...string) BinaryPreflight {
+	commandArgs := append([]string(nil), args...)
+	return func(ctx context.Context, path string) error {
+		cmd := exec.CommandContext(ctx, path, commandArgs...) // #nosec G204 -- the verified candidate path is executed directly without a shell.
+		output, err := cmd.CombinedOutput()
+		if err == nil {
+			return nil
+		}
+		detail := strings.TrimSpace(string(output))
+		if detail == "" {
+			return fmt.Errorf("run candidate startup preflight: %w", err)
+		}
+		return fmt.Errorf("run candidate startup preflight: %w: %s", err, detail)
+	}
+}

--- a/internal/update/preflight_test.go
+++ b/internal/update/preflight_test.go
@@ -1,0 +1,62 @@
+package update
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+)
+
+func TestCommandPreflight(t *testing.T) {
+	t.Parallel()
+
+	executable, err := os.Executable()
+	if err != nil {
+		t.Fatalf("Executable() error = %v", err)
+	}
+	tests := []struct {
+		name    string
+		mode    string
+		wantErr string
+	}{
+		{name: "candidate accepts configuration", mode: "success"},
+		{name: "candidate rejects configuration", mode: "failure", wantErr: "candidate startup rejected"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			preflight := CommandPreflight("-test.run=^TestCommandPreflightHelper$", "--", "startup-preflight="+tt.mode)
+			err := preflight(context.Background(), executable)
+			if tt.wantErr == "" && err != nil {
+				t.Fatalf("preflight() error = %v", err)
+			}
+			if tt.wantErr != "" && (err == nil || !strings.Contains(err.Error(), tt.wantErr)) {
+				t.Fatalf("preflight() error = %v, want containing %q", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestCommandPreflightHelper(t *testing.T) {
+	mode := ""
+	for _, arg := range os.Args {
+		if value, ok := strings.CutPrefix(arg, "startup-preflight="); ok {
+			mode = value
+			break
+		}
+	}
+	switch mode {
+	case "":
+		return
+	case "success":
+		return
+	case "failure":
+		_, _ = fmt.Fprintln(os.Stderr, "candidate startup rejected")
+		os.Exit(7)
+	default:
+		t.Fatalf("unexpected helper mode %q", mode)
+	}
+}

--- a/internal/update/replacement_preflight_test.go
+++ b/internal/update/replacement_preflight_test.go
@@ -1,0 +1,114 @@
+package update
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestReplaceBinaryPreflightsBeforeReplacement(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name          string
+		preflightErr  error
+		wantTarget    string
+		wantBackup    bool
+		wantBeforeRun bool
+	}{
+		{
+			name:         "rejected candidate leaves current binary untouched",
+			preflightErr: errors.New("candidate cannot boot configuration"),
+			wantTarget:   "old",
+		},
+		{
+			name:          "accepted candidate preserves rollback binary",
+			wantTarget:    "new",
+			wantBackup:    true,
+			wantBeforeRun: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			dir := t.TempDir()
+			target := filepath.Join(dir, "detent")
+			backup := PreviousBinaryPath(target)
+			if err := os.WriteFile(target, []byte("old"), 0o750); err != nil {
+				t.Fatalf("WriteFile(target) error = %v", err)
+			}
+			beforeRun := false
+			err := ReplaceBinary(context.Background(), Replacement{
+				Target:         target,
+				Binary:         []byte("new"),
+				Mode:           0o755,
+				GOOS:           "linux",
+				BackupPath:     backup,
+				PreserveBackup: true,
+				Preflight: func(_ context.Context, path string) error {
+					if path == target {
+						t.Fatal("Preflight() received installed target, want staged candidate")
+					}
+					raw, err := os.ReadFile(path)
+					if err != nil {
+						return err
+					}
+					if string(raw) != "new" {
+						return errors.New("unexpected candidate content")
+					}
+					return tt.preflightErr
+				},
+				BeforeReplace: func(_ context.Context, gotTarget string, gotBackup string) error {
+					beforeRun = true
+					if gotTarget != target || gotBackup != backup {
+						t.Fatalf("BeforeReplace(%q, %q), want (%q, %q)", gotTarget, gotBackup, target, backup)
+					}
+					return nil
+				},
+				Verify: func(_ context.Context, path string) (string, error) {
+					raw, err := os.ReadFile(path)
+					if err != nil {
+						return "", err
+					}
+					if string(raw) != "new" {
+						return "", errors.New("installed content is not candidate")
+					}
+					return "version: v1.2.4", nil
+				},
+			})
+			if tt.preflightErr == nil && err != nil {
+				t.Fatalf("ReplaceBinary() error = %v", err)
+			}
+			if tt.preflightErr != nil && (err == nil || !strings.Contains(err.Error(), tt.preflightErr.Error())) {
+				t.Fatalf("ReplaceBinary() error = %v, want containing %q", err, tt.preflightErr)
+			}
+
+			raw, err := os.ReadFile(target)
+			if err != nil {
+				t.Fatalf("ReadFile(target) error = %v", err)
+			}
+			if string(raw) != tt.wantTarget {
+				t.Fatalf("target = %q, want %q", raw, tt.wantTarget)
+			}
+			if beforeRun != tt.wantBeforeRun {
+				t.Fatalf("BeforeReplace() ran = %t, want %t", beforeRun, tt.wantBeforeRun)
+			}
+			backupRaw, backupErr := os.ReadFile(backup)
+			if tt.wantBackup {
+				if backupErr != nil {
+					t.Fatalf("ReadFile(backup) error = %v", backupErr)
+				}
+				if string(backupRaw) != "old" {
+					t.Fatalf("backup = %q, want old", backupRaw)
+				}
+			} else if !errors.Is(backupErr, os.ErrNotExist) {
+				t.Fatalf("ReadFile(backup) error = %v, want not exist", backupErr)
+			}
+		})
+	}
+}

--- a/internal/update/scheduler.go
+++ b/internal/update/scheduler.go
@@ -53,6 +53,7 @@ type SchedulerConfig struct {
 	ReserveIdle        func(context.Context) (func(), bool)
 	ReserveDrain       func(context.Context) (func(), error)
 	RequestRestart     func(string) bool
+	ApplyOptions       ApplyOptions
 	Logger             *slog.Logger
 	Now                func() time.Time
 	NextDelay          func(time.Duration) time.Duration
@@ -323,11 +324,11 @@ func (s *Scheduler) applyLocked(ctx context.Context, releaseIdle func()) (Status
 		status.LastError = ""
 	})
 
-	applied, err := s.cfg.Updater.Apply(ctx, ApplyOptions{
-		AssumeYes: true,
-		Stdout:    io.Discard,
-		Stderr:    io.Discard,
-	})
+	applyOptions := s.cfg.ApplyOptions
+	applyOptions.AssumeYes = true
+	applyOptions.Stdout = io.Discard
+	applyOptions.Stderr = io.Discard
+	applied, err := s.cfg.Updater.Apply(ctx, applyOptions)
 	if err != nil {
 		persistErr := s.recordFailure(s.cfg.Now(), err)
 		return applied, fmt.Errorf("apply Detent update: %w", errors.Join(err, persistErr))

--- a/internal/update/scheduler_test.go
+++ b/internal/update/scheduler_test.go
@@ -172,6 +172,53 @@ func TestSchedulerAutoApplyBehavior(t *testing.T) {
 	}
 }
 
+func TestSchedulerPassesUpdateSafetyOptions(t *testing.T) {
+	t.Parallel()
+
+	updater := &schedulerUpdaterStub{
+		checkStatus: Status{
+			CurrentVersion:  "1.2.3",
+			LatestVersion:   "1.2.4",
+			UpdateAvailable: true,
+			Action:          ActionAvailable,
+			InstallSource:   InstallSourceRelease,
+		},
+		applyStatus: Status{
+			CurrentVersion: "1.2.3",
+			LatestVersion:  "1.2.4",
+			Action:         ActionUpdated,
+		},
+	}
+	preflight := func(context.Context, string) error { return nil }
+	scheduler, err := NewScheduler(SchedulerConfig{
+		Enabled:          true,
+		AutoApplyEnabled: true,
+		CheckInterval:    time.Hour,
+		Updater:          updater,
+		ReserveIdle:      func(context.Context) (func(), bool) { return func() {}, true },
+		ReserveDrain:     schedulerDrainReservation,
+		RequestRestart:   func(string) bool { return true },
+		ApplyOptions: ApplyOptions{
+			Preflight:         preflight,
+			RecoveryStatePath: "/var/lib/detent/startup-recovery.json",
+		},
+	})
+	if err != nil {
+		t.Fatalf("NewScheduler() error = %v", err)
+	}
+	if _, err := scheduler.CheckNow(context.Background()); err != nil {
+		t.Fatalf("CheckNow() error = %v", err)
+	}
+
+	if len(updater.applyOptions) != 1 {
+		t.Fatalf("Apply() options = %d, want 1", len(updater.applyOptions))
+	}
+	got := updater.applyOptions[0]
+	if !got.AssumeYes || got.Preflight == nil || got.RecoveryStatePath != "/var/lib/detent/startup-recovery.json" {
+		t.Fatalf("ApplyOptions = %#v, want preflight and durable recovery state", got)
+	}
+}
+
 func TestSchedulerDefersAutoApplyUntilIdle(t *testing.T) {
 	t.Parallel()
 
@@ -989,13 +1036,14 @@ func seedSchedulerLastCheck(t *testing.T, statePath string, checkedAt time.Time)
 }
 
 type schedulerUpdaterStub struct {
-	mu          sync.Mutex
-	checkStatus Status
-	checkErr    error
-	applyStatus Status
-	applyErr    error
-	checkCalls  int
-	applyCalls  int
+	mu           sync.Mutex
+	checkStatus  Status
+	checkErr     error
+	applyStatus  Status
+	applyErr     error
+	checkCalls   int
+	applyCalls   int
+	applyOptions []ApplyOptions
 }
 
 func (s *schedulerUpdaterStub) Check(context.Context) (Status, error) {
@@ -1005,10 +1053,11 @@ func (s *schedulerUpdaterStub) Check(context.Context) (Status, error) {
 	return s.checkStatus, s.checkErr
 }
 
-func (s *schedulerUpdaterStub) Apply(context.Context, ApplyOptions) (Status, error) {
+func (s *schedulerUpdaterStub) Apply(_ context.Context, opts ApplyOptions) (Status, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.applyCalls++
+	s.applyOptions = append(s.applyOptions, opts)
 	return s.applyStatus, s.applyErr
 }
 

--- a/internal/update/startup_recovery.go
+++ b/internal/update/startup_recovery.go
@@ -1,0 +1,447 @@
+package update
+
+import (
+	"context"
+	"crypto/sha256"
+	"errors"
+	"fmt"
+	"log/slog"
+	"os"
+	"runtime"
+	"strings"
+	"sync"
+	"time"
+)
+
+const startupCrashLoopThreshold = 3
+
+type CrashLoopEvent struct {
+	Event         string     `json:"event"`
+	Instance      string     `json:"instance,omitempty"`
+	Host          string     `json:"host,omitempty"`
+	Version       string     `json:"version"`
+	FailureCount  int        `json:"failure_count"`
+	FirstFailedAt time.Time  `json:"first_failed_at"`
+	LastFailedAt  time.Time  `json:"last_failed_at"`
+	NextRetryAt   *time.Time `json:"next_retry_at,omitempty"`
+	Error         string     `json:"error"`
+	StatePath     string     `json:"state_path"`
+	Action        string     `json:"action,omitempty"`
+}
+
+type StartupRecoveryConfig struct {
+	StatePath      string
+	CurrentVersion string
+	ExecutablePath string
+	GOOS           string
+	HomeDir        string
+	Env            map[string]string
+	AutoUpdate     bool
+	Updater        Updater
+	ApplyOptions   ApplyOptions
+	Instance       string
+	Host           string
+	Logger         *slog.Logger
+	Now            func() time.Time
+	Wait           func(context.Context, time.Duration) bool
+	Notify         func(context.Context, CrashLoopEvent) error
+	Rollback       func(context.Context, PendingUpdate) error
+	Remove         func(string) error
+}
+
+type StartupRecovery struct {
+	cfg   StartupRecoveryConfig
+	mu    sync.Mutex
+	state startupRecoveryState
+}
+
+func NewStartupRecovery(cfg StartupRecoveryConfig) (*StartupRecovery, error) {
+	cfg.StatePath = strings.TrimSpace(cfg.StatePath)
+	if cfg.StatePath == "" {
+		return nil, errors.New("startup recovery state path is required")
+	}
+	cfg.CurrentVersion = strings.TrimSpace(cfg.CurrentVersion)
+	if cfg.CurrentVersion == "" {
+		return nil, errors.New("startup recovery current version is required")
+	}
+	cfg.ExecutablePath = strings.TrimSpace(cfg.ExecutablePath)
+	if cfg.Logger == nil {
+		cfg.Logger = slog.Default()
+	}
+	if cfg.Now == nil {
+		cfg.Now = time.Now
+	}
+	if cfg.Wait == nil {
+		cfg.Wait = waitForStartupRetry
+	}
+	if cfg.Remove == nil {
+		cfg.Remove = os.Remove
+	}
+	if cfg.GOOS == "" {
+		cfg.GOOS = runtime.GOOS
+	}
+	state, _, err := loadStartupRecoveryState(cfg.StatePath)
+	if err != nil {
+		cfg.Logger.Warn("load startup recovery state failed", "path", cfg.StatePath, "error", err)
+		state = startupRecoveryState{}
+	}
+	return &StartupRecovery{cfg: cfg, state: state}, nil
+}
+
+func (r *StartupRecovery) MarkHealthy(context.Context) error {
+	if r == nil {
+		return nil
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	now := r.cfg.Now().UTC()
+	if failure := r.state.ActiveFailure; failure != nil && failure.CrashLoop {
+		archived := *failure
+		r.state.LastCrashLoop = &archived
+	}
+	if pending := r.state.PendingUpdate; pending != nil {
+		switch r.cfg.CurrentVersion {
+		case strings.TrimSpace(pending.ToVersion):
+			if err := r.removePreviousBinary(pending.PreviousBinaryPath); err != nil {
+				return err
+			}
+			r.state.PendingUpdate = nil
+		case strings.TrimSpace(pending.FromVersion):
+			if pending.RollbackRequestedAt != nil {
+				r.state.LastRollback = &StartupRollback{
+					FromVersion:  pending.ToVersion,
+					ToVersion:    pending.FromVersion,
+					RolledBackAt: now,
+				}
+			}
+			if err := r.removePreviousBinary(pending.PreviousBinaryPath); err != nil {
+				return err
+			}
+			r.state.PendingUpdate = nil
+		}
+	}
+	r.state.ActiveFailure = nil
+	r.state.LastHealthyAt = &now
+	return saveStartupRecoveryState(r.cfg.StatePath, r.state)
+}
+
+func (r *StartupRecovery) HandleFailure(ctx context.Context, cause error) {
+	if r == nil || cause == nil {
+		return
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
+	failure, pending, shouldUpdate, saveErr := r.recordFailure(cause)
+	if saveErr != nil {
+		r.cfg.Logger.Error("persist startup failure failed", "path", r.cfg.StatePath, "error", saveErr)
+	}
+	if pending != nil && failure.Count >= startupCrashLoopThreshold {
+		r.rollbackPendingUpdate(ctx, *pending)
+	} else if shouldUpdate {
+		r.applyRecoveryUpdate(ctx)
+	}
+	r.signalCrashLoop(ctx)
+	r.waitBeforeRetry(ctx)
+}
+
+func (r *StartupRecovery) recordFailure(cause error) (StartupFailure, *PendingUpdate, bool, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	now := r.cfg.Now().UTC()
+	message := strings.TrimSpace(cause.Error())
+	signature := startupFailureSignature(r.cfg.CurrentVersion, message)
+	failure := r.state.ActiveFailure
+	if failure == nil || failure.Version != r.cfg.CurrentVersion || failure.Signature != signature {
+		failure = &StartupFailure{
+			Version:       r.cfg.CurrentVersion,
+			Signature:     signature,
+			Message:       message,
+			FirstFailedAt: now,
+		}
+		r.state.ActiveFailure = failure
+	}
+	failure.Count++
+	failure.Message = message
+	failure.LastFailedAt = now
+	failure.Backoff = startupFailureBackoff(failure.Count)
+	failure.CrashLoop = failure.Count >= startupCrashLoopThreshold
+	if failure.Backoff > 0 {
+		next := now.Add(failure.Backoff)
+		failure.NextRetryAt = &next
+	} else {
+		failure.NextRetryAt = nil
+	}
+	if failure.CrashLoop {
+		archived := *failure
+		r.state.LastCrashLoop = &archived
+	}
+
+	var pending *PendingUpdate
+	if candidate := r.state.PendingUpdate; candidate != nil && strings.TrimSpace(candidate.ToVersion) == r.cfg.CurrentVersion {
+		copy := *candidate
+		pending = &copy
+	}
+	shouldUpdate := pending == nil && r.cfg.AutoUpdate && r.cfg.Updater != nil && r.state.LastRecoveryUpdateAttemptVersion != r.cfg.CurrentVersion
+	if shouldUpdate {
+		r.state.LastRecoveryUpdateAttemptVersion = r.cfg.CurrentVersion
+		failure.RecoveryAction = "checking_for_update"
+	}
+	err := saveStartupRecoveryState(r.cfg.StatePath, r.state)
+	return *failure, pending, shouldUpdate, err
+}
+
+func (r *StartupRecovery) applyRecoveryUpdate(ctx context.Context) {
+	status, err := r.cfg.Updater.Check(ctx)
+	manualInstall := false
+	if err == nil {
+		switch {
+		case !status.UpdateAvailable:
+			status.Action = ActionUpToDate
+		case status.InstallSource != InstallSourceRelease:
+			manualInstall = true
+			status.Action = ActionDelegate
+			status.Message = "startup recovery cannot safely replace a non-release-managed Detent binary"
+		default:
+			status, err = r.cfg.Updater.Apply(ctx, r.cfg.ApplyOptions)
+		}
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.reloadStateLocked()
+	failure := r.state.ActiveFailure
+	if failure == nil {
+		return
+	}
+	if err != nil {
+		failure.RecoveryAction = "update_failed"
+		failure.LastRecoveryError = err.Error()
+		r.cfg.Logger.Error("startup recovery update failed", "version", r.cfg.CurrentVersion, "error", err)
+	} else if manualInstall {
+		failure.RecoveryAction = "update_requires_manual_install"
+		failure.LastRecoveryError = status.Message
+		r.cfg.Logger.Warn("startup recovery update requires a release-managed binary", "version", r.cfg.CurrentVersion, "install_source", status.InstallSource)
+	} else if status.Action == ActionUpdated {
+		failure.RecoveryAction = "update_applied"
+		failure.LastRecoveryError = ""
+		r.cfg.Logger.Warn("startup recovery update applied", "from_version", status.CurrentVersion, "to_version", status.LatestVersion)
+	} else {
+		failure.RecoveryAction = "update_unavailable"
+		failure.LastRecoveryError = strings.TrimSpace(status.Message)
+		r.cfg.Logger.Warn("startup recovery found no applicable update", "version", r.cfg.CurrentVersion, "action", status.Action)
+	}
+	if saveErr := saveStartupRecoveryState(r.cfg.StatePath, r.state); saveErr != nil {
+		r.cfg.Logger.Error("persist startup recovery update outcome failed", "path", r.cfg.StatePath, "error", saveErr)
+	}
+}
+
+func (r *StartupRecovery) rollbackPendingUpdate(ctx context.Context, pending PendingUpdate) {
+	r.mu.Lock()
+	if r.state.PendingUpdate != nil {
+		now := r.cfg.Now().UTC()
+		r.state.PendingUpdate.RollbackRequestedAt = &now
+		if r.state.ActiveFailure != nil {
+			r.state.ActiveFailure.RecoveryAction = "rolling_back_update"
+		}
+		if err := saveStartupRecoveryState(r.cfg.StatePath, r.state); err != nil {
+			r.cfg.Logger.Error("persist startup rollback intent failed", "path", r.cfg.StatePath, "error", err)
+		}
+	}
+	r.mu.Unlock()
+
+	rollback := r.cfg.Rollback
+	if rollback == nil {
+		rollback = func(ctx context.Context, pending PendingUpdate) error {
+			if err := restorePreviousBinary(ctx, pending, r.cfg.GOOS); err != nil {
+				return err
+			}
+			return restorePendingInstallLock(pending, r.cfg.GOOS, DetectionOptions{
+				HomeDir: r.cfg.HomeDir,
+				Env:     r.cfg.Env,
+			})
+		}
+	}
+	err := rollback(ctx, pending)
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.reloadStateLocked()
+	failure := r.state.ActiveFailure
+	if err != nil {
+		if failure != nil {
+			failure.RecoveryAction = "rollback_failed"
+			failure.LastRecoveryError = err.Error()
+		}
+		r.cfg.Logger.Error("startup recovery rollback failed", "from_version", pending.ToVersion, "to_version", pending.FromVersion, "error", err)
+	} else {
+		now := r.cfg.Now().UTC()
+		if failure != nil {
+			failure.RecoveryAction = "rolled_back_update"
+			failure.LastRecoveryError = ""
+		}
+		r.state.LastRollback = &StartupRollback{FromVersion: pending.ToVersion, ToVersion: pending.FromVersion, RolledBackAt: now}
+		if r.cfg.GOOS != "windows" {
+			r.state.PendingUpdate = nil
+		}
+		r.cfg.Logger.Error("rolled back Detent after repeated startup failure", "from_version", pending.ToVersion, "to_version", pending.FromVersion)
+	}
+	if saveErr := saveStartupRecoveryState(r.cfg.StatePath, r.state); saveErr != nil {
+		r.cfg.Logger.Error("persist startup rollback outcome failed", "path", r.cfg.StatePath, "error", saveErr)
+	}
+}
+
+func restorePendingInstallLock(pending PendingUpdate, goos string, opts DetectionOptions) error {
+	path := strings.TrimSpace(pending.InstallLockPath)
+	if path != "" {
+		if pending.PreviousInstallLockFound {
+			return writeInstallLockContents(path, pending.PreviousInstallLock)
+		}
+		return removePendingReleaseInstallLock(path, pending, goos)
+	}
+	if pending.InstallSource == InstallSourceRelease {
+		return writeReleaseInstallLock(goos, opts, pending.ExecutablePath, pending.FromVersion)
+	}
+	resolved, ok := installLockPath(goos, opts)
+	if !ok {
+		return nil
+	}
+	return removePendingReleaseInstallLock(resolved, pending, goos)
+}
+
+func removePendingReleaseInstallLock(path string, pending PendingUpdate, goos string) error {
+	metadata, ok := readInstallLock(path)
+	if !ok || strings.TrimSpace(metadata.version) != strings.TrimSpace(pending.ToVersion) ||
+		!samePath(cleanPath(metadata.binary, goos), cleanPath(pending.ExecutablePath, goos), goos) {
+		return nil
+	}
+	if err := os.Remove(path); err != nil && !errors.Is(err, os.ErrNotExist) {
+		return fmt.Errorf("remove rolled back release install lock: %w", err)
+	}
+	return nil
+}
+
+func (r *StartupRecovery) signalCrashLoop(ctx context.Context) {
+	r.mu.Lock()
+	failure := r.state.ActiveFailure
+	if failure == nil || !failure.CrashLoop || failure.Notified {
+		r.mu.Unlock()
+		return
+	}
+	event := CrashLoopEvent{
+		Event:         "detent_startup_crash_loop",
+		Instance:      r.cfg.Instance,
+		Host:          r.cfg.Host,
+		Version:       failure.Version,
+		FailureCount:  failure.Count,
+		FirstFailedAt: failure.FirstFailedAt,
+		LastFailedAt:  failure.LastFailedAt,
+		NextRetryAt:   failure.NextRetryAt,
+		Error:         failure.Message,
+		StatePath:     r.cfg.StatePath,
+		Action:        failure.RecoveryAction,
+	}
+	r.mu.Unlock()
+
+	r.cfg.Logger.Error(
+		"Detent startup crash loop detected",
+		"version", event.Version,
+		"failure_count", event.FailureCount,
+		"error", event.Error,
+		"state_path", event.StatePath,
+		"next_retry_at", event.NextRetryAt,
+		"action", event.Action,
+	)
+	if r.cfg.Notify == nil {
+		return
+	}
+	if err := r.cfg.Notify(ctx, event); err != nil {
+		r.cfg.Logger.Error("deliver startup crash loop notification failed", "error", err)
+		return
+	}
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if failure := r.state.ActiveFailure; failure != nil && failure.Signature == eventSignature(event) {
+		failure.Notified = true
+		if err := saveStartupRecoveryState(r.cfg.StatePath, r.state); err != nil {
+			r.cfg.Logger.Error("persist startup crash loop notification failed", "path", r.cfg.StatePath, "error", err)
+		}
+	}
+}
+
+func (r *StartupRecovery) waitBeforeRetry(ctx context.Context) {
+	r.mu.Lock()
+	failure := r.state.ActiveFailure
+	if failure == nil || failure.Backoff <= 0 {
+		r.mu.Unlock()
+		return
+	}
+	delay := failure.Backoff
+	nextRetryAt := failure.NextRetryAt
+	count := failure.Count
+	r.mu.Unlock()
+
+	r.cfg.Logger.Warn("delaying restart after repeated startup failure", "failure_count", count, "delay", delay, "next_retry_at", nextRetryAt)
+	r.cfg.Wait(ctx, delay)
+}
+
+func (r *StartupRecovery) reloadStateLocked() {
+	state, found, err := loadStartupRecoveryState(r.cfg.StatePath)
+	if err != nil {
+		r.cfg.Logger.Error("reload startup recovery state failed", "path", r.cfg.StatePath, "error", err)
+		return
+	}
+	if found {
+		r.state = state
+	}
+}
+
+func (r *StartupRecovery) removePreviousBinary(path string) error {
+	path = strings.TrimSpace(path)
+	if path == "" {
+		return nil
+	}
+	if err := r.cfg.Remove(path); err != nil && !errors.Is(err, os.ErrNotExist) {
+		return fmt.Errorf("remove healthy update rollback binary: %w", err)
+	}
+	return nil
+}
+
+func startupFailureSignature(version string, message string) string {
+	return fmt.Sprintf("%x", sha256.Sum256([]byte(strings.TrimSpace(version)+"\x00"+strings.TrimSpace(message))))
+}
+
+func eventSignature(event CrashLoopEvent) string {
+	return startupFailureSignature(event.Version, event.Error)
+}
+
+func startupFailureBackoff(count int) time.Duration {
+	switch count {
+	case 0, 1:
+		return 0
+	case 2:
+		return 5 * time.Second
+	case 3:
+		return 30 * time.Second
+	case 4:
+		return 2 * time.Minute
+	case 5:
+		return 10 * time.Minute
+	default:
+		return 30 * time.Minute
+	}
+}
+
+func waitForStartupRetry(ctx context.Context, delay time.Duration) bool {
+	timer := time.NewTimer(delay)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		return false
+	case <-timer.C:
+		return true
+	}
+}

--- a/internal/update/startup_recovery_state.go
+++ b/internal/update/startup_recovery_state.go
@@ -1,0 +1,171 @@
+package update
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+const startupRecoveryStateSchema = 1
+
+const startupRecoveryStateName = "detent-startup-recovery.json"
+
+type StartupFailure struct {
+	Version           string        `json:"version"`
+	Signature         string        `json:"signature"`
+	Message           string        `json:"message"`
+	Count             int           `json:"count"`
+	FirstFailedAt     time.Time     `json:"first_failed_at"`
+	LastFailedAt      time.Time     `json:"last_failed_at"`
+	NextRetryAt       *time.Time    `json:"next_retry_at,omitempty"`
+	Backoff           time.Duration `json:"backoff"`
+	CrashLoop         bool          `json:"crash_loop"`
+	Notified          bool          `json:"notified"`
+	RecoveryAction    string        `json:"recovery_action,omitempty"`
+	LastRecoveryError string        `json:"last_recovery_error,omitempty"`
+}
+
+type PendingUpdate struct {
+	FromVersion              string        `json:"from_version"`
+	ToVersion                string        `json:"to_version"`
+	InstallSource            InstallSource `json:"install_source"`
+	ExecutablePath           string        `json:"executable_path"`
+	PreviousBinaryPath       string        `json:"previous_binary_path"`
+	InstallLockPath          string        `json:"install_lock_path,omitempty"`
+	PreviousInstallLock      string        `json:"previous_install_lock,omitempty"`
+	PreviousInstallLockFound bool          `json:"previous_install_lock_found,omitempty"`
+	AppliedAt                time.Time     `json:"applied_at"`
+	RollbackRequestedAt      *time.Time    `json:"rollback_requested_at,omitempty"`
+}
+
+type StartupRollback struct {
+	FromVersion  string    `json:"from_version"`
+	ToVersion    string    `json:"to_version"`
+	RolledBackAt time.Time `json:"rolled_back_at"`
+}
+
+type startupRecoveryState struct {
+	Schema                           int              `json:"schema"`
+	ActiveFailure                    *StartupFailure  `json:"active_failure,omitempty"`
+	PendingUpdate                    *PendingUpdate   `json:"pending_update,omitempty"`
+	LastCrashLoop                    *StartupFailure  `json:"last_crash_loop,omitempty"`
+	LastRollback                     *StartupRollback `json:"last_rollback,omitempty"`
+	LastHealthyAt                    *time.Time       `json:"last_healthy_at,omitempty"`
+	LastRecoveryUpdateAttemptVersion string           `json:"last_recovery_update_attempt_version,omitempty"`
+}
+
+func RecoveryStatePath(configPath string) string {
+	configPath = strings.TrimSpace(configPath)
+	if configPath == "" {
+		return ""
+	}
+	return filepath.Join(filepath.Dir(configPath), startupRecoveryStateName)
+}
+
+func loadStartupRecoveryState(path string) (startupRecoveryState, bool, error) {
+	path = strings.TrimSpace(path)
+	if path == "" {
+		return startupRecoveryState{}, false, nil
+	}
+	raw, err := os.ReadFile(path)
+	if errors.Is(err, os.ErrNotExist) {
+		return startupRecoveryState{}, false, nil
+	}
+	if err != nil {
+		return startupRecoveryState{}, false, fmt.Errorf("read startup recovery state: %w", err)
+	}
+	var state startupRecoveryState
+	if err := json.Unmarshal(raw, &state); err != nil {
+		return startupRecoveryState{}, false, fmt.Errorf("decode startup recovery state: %w", err)
+	}
+	if state.Schema != startupRecoveryStateSchema {
+		return startupRecoveryState{}, false, fmt.Errorf("decode startup recovery state: unsupported schema %d", state.Schema)
+	}
+	return state, true, nil
+}
+
+func saveStartupRecoveryState(path string, state startupRecoveryState) (saveErr error) {
+	path = strings.TrimSpace(path)
+	if path == "" {
+		return nil
+	}
+	state.Schema = startupRecoveryStateSchema
+	raw, err := json.Marshal(state)
+	if err != nil {
+		return fmt.Errorf("encode startup recovery state: %w", err)
+	}
+	directory := filepath.Dir(path)
+	if err := os.MkdirAll(directory, 0o755); err != nil {
+		return fmt.Errorf("create startup recovery state directory: %w", err)
+	}
+	temporary, err := os.CreateTemp(directory, ".startup-recovery-*")
+	if err != nil {
+		return fmt.Errorf("create temporary startup recovery state: %w", err)
+	}
+	temporaryPath := temporary.Name()
+	defer func() {
+		if temporaryPath == "" {
+			return
+		}
+		if err := os.Remove(temporaryPath); err != nil && !errors.Is(err, os.ErrNotExist) {
+			saveErr = errors.Join(saveErr, fmt.Errorf("remove temporary startup recovery state: %w", err))
+		}
+	}()
+	if err := temporary.Chmod(0o600); err != nil {
+		return closeStartupRecoveryState(temporary, fmt.Errorf("secure temporary startup recovery state: %w", err))
+	}
+	if _, err := temporary.Write(raw); err != nil {
+		return closeStartupRecoveryState(temporary, fmt.Errorf("write temporary startup recovery state: %w", err))
+	}
+	if err := temporary.Sync(); err != nil {
+		return closeStartupRecoveryState(temporary, fmt.Errorf("sync temporary startup recovery state: %w", err))
+	}
+	if err := temporary.Close(); err != nil {
+		return fmt.Errorf("close temporary startup recovery state: %w", err)
+	}
+	if err := os.Rename(temporaryPath, path); err != nil {
+		return fmt.Errorf("replace startup recovery state: %w", err)
+	}
+	temporaryPath = ""
+	return nil
+}
+
+func closeStartupRecoveryState(file *os.File, operationErr error) error {
+	if err := file.Close(); err != nil {
+		return errors.Join(operationErr, fmt.Errorf("close temporary startup recovery state: %w", err))
+	}
+	return operationErr
+}
+
+func recordPendingUpdate(path string, pending PendingUpdate) error {
+	state, _, err := loadStartupRecoveryState(path)
+	if err != nil {
+		return err
+	}
+	pending.FromVersion = strings.TrimSpace(pending.FromVersion)
+	pending.ToVersion = strings.TrimSpace(pending.ToVersion)
+	pending.ExecutablePath = strings.TrimSpace(pending.ExecutablePath)
+	pending.PreviousBinaryPath = strings.TrimSpace(pending.PreviousBinaryPath)
+	pending.InstallLockPath = strings.TrimSpace(pending.InstallLockPath)
+	if pending.FromVersion == "" || pending.ToVersion == "" || pending.ExecutablePath == "" || pending.PreviousBinaryPath == "" || pending.AppliedAt.IsZero() {
+		return errors.New("record pending update: versions, binary paths, and applied timestamp are required")
+	}
+	state.PendingUpdate = &pending
+	return saveStartupRecoveryState(path, state)
+}
+
+func clearPendingUpdate(path string, toVersion string) error {
+	state, found, err := loadStartupRecoveryState(path)
+	if err != nil || !found {
+		return err
+	}
+	if state.PendingUpdate == nil || strings.TrimSpace(state.PendingUpdate.ToVersion) != strings.TrimSpace(toVersion) {
+		return nil
+	}
+	state.PendingUpdate = nil
+	return saveStartupRecoveryState(path, state)
+}

--- a/internal/update/startup_recovery_test.go
+++ b/internal/update/startup_recovery_test.go
@@ -1,0 +1,398 @@
+package update
+
+import (
+	"context"
+	"errors"
+	"io"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"slices"
+	"testing"
+	"time"
+)
+
+func TestStartupFailureBackoff(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		count int
+		want  time.Duration
+	}{
+		{count: 0},
+		{count: 1},
+		{count: 2, want: 5 * time.Second},
+		{count: 3, want: 30 * time.Second},
+		{count: 4, want: 2 * time.Minute},
+		{count: 5, want: 10 * time.Minute},
+		{count: 6, want: 30 * time.Minute},
+		{count: 100, want: 30 * time.Minute},
+	}
+
+	for _, tt := range tests {
+		if got := startupFailureBackoff(tt.count); got != tt.want {
+			t.Errorf("startupFailureBackoff(%d) = %s, want %s", tt.count, got, tt.want)
+		}
+	}
+}
+
+func TestStartupRecoveryPersistsCrashLoopAcrossProcesses(t *testing.T) {
+	t.Parallel()
+
+	statePath := filepath.Join(t.TempDir(), startupRecoveryStateName)
+	startedAt := time.Date(2026, 8, 28, 17, 50, 0, 0, time.UTC)
+	var waits []time.Duration
+	var notifications []CrashLoopEvent
+
+	for attempt := 1; attempt <= 4; attempt++ {
+		attempt := attempt
+		recovery := newTestStartupRecovery(t, StartupRecoveryConfig{
+			StatePath:      statePath,
+			CurrentVersion: "0.93.0",
+			Now: func() time.Time {
+				return startedAt.Add(time.Duration(attempt-1) * time.Minute)
+			},
+			Wait: func(_ context.Context, delay time.Duration) bool {
+				waits = append(waits, delay)
+				return true
+			},
+			Notify: func(_ context.Context, event CrashLoopEvent) error {
+				notifications = append(notifications, event)
+				return nil
+			},
+		})
+		recovery.HandleFailure(context.Background(), errors.New("validate current configuration"))
+	}
+
+	state := readTestStartupRecoveryState(t, statePath)
+	if state.ActiveFailure == nil {
+		t.Fatal("ActiveFailure = nil, want persisted startup failure")
+	}
+	failure := state.ActiveFailure
+	if failure.Count != 4 || !failure.CrashLoop || !failure.Notified {
+		t.Fatalf("ActiveFailure = %#v, want count 4 notified crash loop", failure)
+	}
+	if failure.Backoff != 2*time.Minute {
+		t.Fatalf("Backoff = %s, want 2m", failure.Backoff)
+	}
+	if state.LastCrashLoop == nil || state.LastCrashLoop.Count != 4 {
+		t.Fatalf("LastCrashLoop = %#v, want latest count 4", state.LastCrashLoop)
+	}
+	if !slices.Equal(waits, []time.Duration{5 * time.Second, 30 * time.Second, 2 * time.Minute}) {
+		t.Fatalf("waits = %v, want escalating delays", waits)
+	}
+	if len(notifications) != 1 {
+		t.Fatalf("notifications = %d, want 1", len(notifications))
+	}
+	event := notifications[0]
+	if event.Event != "detent_startup_crash_loop" || event.Version != "0.93.0" || event.FailureCount != startupCrashLoopThreshold {
+		t.Fatalf("notification = %#v, want third identical failure", event)
+	}
+	if event.StatePath != statePath || event.NextRetryAt == nil || !event.NextRetryAt.Equal(startedAt.Add(2*time.Minute+30*time.Second)) {
+		t.Fatalf("notification retry evidence = %#v, want durable state path and next retry", event)
+	}
+}
+
+func TestStartupRecoveryAttemptsOneUpdatePerVersion(t *testing.T) {
+	t.Parallel()
+
+	statePath := filepath.Join(t.TempDir(), startupRecoveryStateName)
+	updater := &startupRecoveryUpdater{
+		checkStatus: Status{
+			UpdateAvailable: true,
+			InstallSource:   InstallSourceRelease,
+		},
+		applyStatus: Status{Action: ActionUpToDate, Message: "already current"},
+	}
+	for range 2 {
+		recovery := newTestStartupRecovery(t, StartupRecoveryConfig{
+			StatePath:      statePath,
+			CurrentVersion: "0.93.0",
+			AutoUpdate:     true,
+			Updater:        updater,
+		})
+		recovery.HandleFailure(context.Background(), errors.New("startup failed"))
+	}
+
+	if updater.applyCalls != 1 {
+		t.Fatalf("Apply() calls = %d, want 1", updater.applyCalls)
+	}
+	if updater.checkCalls != 1 {
+		t.Fatalf("Check() calls = %d, want 1", updater.checkCalls)
+	}
+	state := readTestStartupRecoveryState(t, statePath)
+	if state.LastRecoveryUpdateAttemptVersion != "0.93.0" {
+		t.Fatalf("LastRecoveryUpdateAttemptVersion = %q, want 0.93.0", state.LastRecoveryUpdateAttemptVersion)
+	}
+	if state.ActiveFailure == nil || state.ActiveFailure.RecoveryAction != "update_unavailable" {
+		t.Fatalf("ActiveFailure = %#v, want persisted unavailable update", state.ActiveFailure)
+	}
+}
+
+func TestStartupRecoveryDoesNotMutateUnsafeInstallSource(t *testing.T) {
+	t.Parallel()
+
+	statePath := filepath.Join(t.TempDir(), startupRecoveryStateName)
+	updater := &startupRecoveryUpdater{
+		checkStatus: Status{
+			UpdateAvailable: true,
+			InstallSource:   InstallSourceGoInstall,
+		},
+	}
+	recovery := newTestStartupRecovery(t, StartupRecoveryConfig{
+		StatePath:      statePath,
+		CurrentVersion: "0.93.0",
+		AutoUpdate:     true,
+		Updater:        updater,
+	})
+	recovery.HandleFailure(context.Background(), errors.New("startup failed"))
+
+	if updater.checkCalls != 1 || updater.applyCalls != 0 {
+		t.Fatalf("updater calls = check %d apply %d, want check 1 apply 0", updater.checkCalls, updater.applyCalls)
+	}
+	state := readTestStartupRecoveryState(t, statePath)
+	if state.ActiveFailure == nil || state.ActiveFailure.RecoveryAction != "update_requires_manual_install" {
+		t.Fatalf("ActiveFailure = %#v, want manual install action", state.ActiveFailure)
+	}
+}
+
+func TestStartupRecoveryRollsBackRepeatedlyFailingUpdate(t *testing.T) {
+	t.Parallel()
+
+	statePath := filepath.Join(t.TempDir(), startupRecoveryStateName)
+	pending := PendingUpdate{
+		FromVersion:        "0.93.0",
+		ToVersion:          "0.94.0",
+		InstallSource:      InstallSourceRelease,
+		ExecutablePath:     "/opt/detent/bin/detent",
+		PreviousBinaryPath: "/opt/detent/bin/detent.previous",
+		AppliedAt:          time.Date(2026, 8, 29, 1, 0, 0, 0, time.UTC),
+	}
+	if err := recordPendingUpdate(statePath, pending); err != nil {
+		t.Fatalf("recordPendingUpdate() error = %v", err)
+	}
+	rollbackCalls := 0
+	for range startupCrashLoopThreshold {
+		recovery := newTestStartupRecovery(t, StartupRecoveryConfig{
+			StatePath:      statePath,
+			CurrentVersion: pending.ToVersion,
+			GOOS:           "linux",
+			Rollback: func(_ context.Context, got PendingUpdate) error {
+				rollbackCalls++
+				if got != pending {
+					t.Fatalf("rollback pending = %#v, want %#v", got, pending)
+				}
+				return nil
+			},
+		})
+		recovery.HandleFailure(context.Background(), errors.New("candidate cannot start"))
+	}
+
+	if rollbackCalls != 1 {
+		t.Fatalf("rollback calls = %d, want 1", rollbackCalls)
+	}
+	state := readTestStartupRecoveryState(t, statePath)
+	if state.PendingUpdate != nil {
+		t.Fatalf("PendingUpdate = %#v, want cleared after rollback", state.PendingUpdate)
+	}
+	if state.LastRollback == nil || state.LastRollback.FromVersion != pending.ToVersion || state.LastRollback.ToVersion != pending.FromVersion {
+		t.Fatalf("LastRollback = %#v, want 0.94.0 to 0.93.0", state.LastRollback)
+	}
+	if state.ActiveFailure == nil || state.ActiveFailure.RecoveryAction != "rolled_back_update" {
+		t.Fatalf("ActiveFailure = %#v, want rolled back action", state.ActiveFailure)
+	}
+}
+
+func TestStartupRecoveryRestoresInstallLockAfterRollback(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name         string
+		previousLock string
+		wantLock     string
+		wantLockFile bool
+	}{
+		{name: "removes release lock added over go install"},
+		{name: "restores prior lock contents", previousLock: "binary=/opt/other/detent\nversion=0.90.0\n", wantLock: "binary=/opt/other/detent\nversion=0.90.0\n", wantLockFile: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			dir := t.TempDir()
+			goBin := filepath.Join(dir, "go", "bin")
+			if err := os.MkdirAll(goBin, 0o755); err != nil {
+				t.Fatalf("MkdirAll(go bin) error = %v", err)
+			}
+			executable := filepath.Join(goBin, "detent")
+			previous := PreviousBinaryPath(executable)
+			lockPath := filepath.Join(dir, "state", "install.lock")
+			if err := os.WriteFile(executable, []byte("candidate"), 0o755); err != nil {
+				t.Fatalf("WriteFile(executable) error = %v", err)
+			}
+			if err := os.WriteFile(previous, []byte("previous"), 0o755); err != nil {
+				t.Fatalf("WriteFile(previous) error = %v", err)
+			}
+			if err := writeInstallLock(lockPath, executable, "0.94.0", time.Now()); err != nil {
+				t.Fatalf("writeInstallLock() error = %v", err)
+			}
+
+			statePath := filepath.Join(dir, startupRecoveryStateName)
+			pending := PendingUpdate{
+				FromVersion:              "0.93.0",
+				ToVersion:                "0.94.0",
+				InstallSource:            InstallSourceGoInstall,
+				ExecutablePath:           executable,
+				PreviousBinaryPath:       previous,
+				InstallLockPath:          lockPath,
+				PreviousInstallLock:      tt.previousLock,
+				PreviousInstallLockFound: tt.wantLockFile,
+				AppliedAt:                time.Date(2026, 8, 29, 1, 0, 0, 0, time.UTC),
+			}
+			if err := recordPendingUpdate(statePath, pending); err != nil {
+				t.Fatalf("recordPendingUpdate() error = %v", err)
+			}
+			for range startupCrashLoopThreshold {
+				recovery := newTestStartupRecovery(t, StartupRecoveryConfig{
+					StatePath:      statePath,
+					CurrentVersion: pending.ToVersion,
+					ExecutablePath: executable,
+					GOOS:           "linux",
+					HomeDir:        dir,
+					Env: map[string]string{
+						"GOBIN":               goBin,
+						"DETENT_INSTALL_LOCK": lockPath,
+					},
+				})
+				recovery.HandleFailure(context.Background(), errors.New("candidate cannot serve"))
+			}
+
+			raw, err := os.ReadFile(executable)
+			if err != nil {
+				t.Fatalf("ReadFile(executable) error = %v", err)
+			}
+			if string(raw) != "previous" {
+				t.Fatalf("executable = %q, want previous", raw)
+			}
+			lockRaw, err := os.ReadFile(lockPath)
+			if tt.wantLockFile {
+				if err != nil {
+					t.Fatalf("ReadFile(lock) error = %v", err)
+				}
+				if string(lockRaw) != tt.wantLock {
+					t.Fatalf("install lock = %q, want %q", lockRaw, tt.wantLock)
+				}
+			} else if !errors.Is(err, os.ErrNotExist) {
+				t.Fatalf("ReadFile(lock) error = %v, want not exist", err)
+			}
+			if got := DetectInstallSource(DetectionOptions{
+				CurrentVersion: "0.93.0",
+				ExecutablePath: executable,
+				GOOS:           "linux",
+				HomeDir:        dir,
+				Env: map[string]string{
+					"GOBIN":               goBin,
+					"DETENT_INSTALL_LOCK": lockPath,
+				},
+			}).Source; got != InstallSourceGoInstall {
+				t.Fatalf("install source after rollback = %q, want %q", got, InstallSourceGoInstall)
+			}
+		})
+	}
+}
+
+func TestStartupRecoveryMarkHealthyCommitsPendingUpdate(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	statePath := filepath.Join(dir, startupRecoveryStateName)
+	previousPath := filepath.Join(dir, "detent.previous")
+	if err := os.WriteFile(previousPath, []byte("previous"), 0o700); err != nil {
+		t.Fatalf("WriteFile(previous) error = %v", err)
+	}
+	pending := PendingUpdate{
+		FromVersion:        "0.93.0",
+		ToVersion:          "0.94.0",
+		InstallSource:      InstallSourceRelease,
+		ExecutablePath:     filepath.Join(dir, "detent"),
+		PreviousBinaryPath: previousPath,
+		AppliedAt:          time.Date(2026, 8, 29, 1, 0, 0, 0, time.UTC),
+	}
+	if err := recordPendingUpdate(statePath, pending); err != nil {
+		t.Fatalf("recordPendingUpdate() error = %v", err)
+	}
+
+	healthyAt := pending.AppliedAt.Add(time.Minute)
+	recovery := newTestStartupRecovery(t, StartupRecoveryConfig{
+		StatePath:      statePath,
+		CurrentVersion: pending.ToVersion,
+		Now:            func() time.Time { return healthyAt },
+	})
+	if err := recovery.MarkHealthy(context.Background()); err != nil {
+		t.Fatalf("MarkHealthy() error = %v", err)
+	}
+
+	if _, err := os.Stat(previousPath); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("Stat(previous) error = %v, want not exist", err)
+	}
+	state := readTestStartupRecoveryState(t, statePath)
+	if state.PendingUpdate != nil || state.ActiveFailure != nil {
+		t.Fatalf("state = %#v, want healthy state without pending update or active failure", state)
+	}
+	if state.LastHealthyAt == nil || !state.LastHealthyAt.Equal(healthyAt) {
+		t.Fatalf("LastHealthyAt = %v, want %v", state.LastHealthyAt, healthyAt)
+	}
+}
+
+func newTestStartupRecovery(t *testing.T, cfg StartupRecoveryConfig) *StartupRecovery {
+	t.Helper()
+	if cfg.ExecutablePath == "" {
+		cfg.ExecutablePath = "/opt/detent/bin/detent"
+	}
+	if cfg.Logger == nil {
+		cfg.Logger = slog.New(slog.NewTextHandler(io.Discard, nil))
+	}
+	if cfg.Now == nil {
+		cfg.Now = func() time.Time { return time.Date(2026, 8, 28, 17, 50, 0, 0, time.UTC) }
+	}
+	if cfg.Wait == nil {
+		cfg.Wait = func(context.Context, time.Duration) bool { return true }
+	}
+	recovery, err := NewStartupRecovery(cfg)
+	if err != nil {
+		t.Fatalf("NewStartupRecovery() error = %v", err)
+	}
+	return recovery
+}
+
+func readTestStartupRecoveryState(t *testing.T, path string) startupRecoveryState {
+	t.Helper()
+	state, found, err := loadStartupRecoveryState(path)
+	if err != nil {
+		t.Fatalf("loadStartupRecoveryState() error = %v", err)
+	}
+	if !found {
+		t.Fatal("loadStartupRecoveryState() found = false, want true")
+	}
+	return state
+}
+
+type startupRecoveryUpdater struct {
+	checkStatus Status
+	checkErr    error
+	checkCalls  int
+	applyStatus Status
+	applyErr    error
+	applyCalls  int
+}
+
+func (u *startupRecoveryUpdater) Check(context.Context) (Status, error) {
+	u.checkCalls++
+	return u.checkStatus, u.checkErr
+}
+
+func (u *startupRecoveryUpdater) Apply(context.Context, ApplyOptions) (Status, error) {
+	u.applyCalls++
+	return u.applyStatus, u.applyErr
+}

--- a/internal/update/update.go
+++ b/internal/update/update.go
@@ -97,9 +97,10 @@ type ReleaseClient interface {
 	Download(context.Context, string) ([]byte, error)
 }
 
-type ProcessStarter func(string, []string) error
+type ProcessStarter func(context.Context, string, []string) error
 type CommandRunner func(context.Context, string, []string, io.Writer, io.Writer) error
 type BinaryVerifier func(context.Context, string) (string, error)
+type BinaryPreflight func(context.Context, string) error
 type BinarySigner func(context.Context, string) error
 type CodeSignatureVerifier func(context.Context, string) (bool, error)
 type ChecksumSignatureVerifier func(context.Context, []byte, []byte) error
@@ -306,6 +307,8 @@ type ApplyOptions struct {
 	FromRelease           bool
 	Confirm               func(Status) (bool, error)
 	SelectGoInstallAction func(Status) (GoInstallAction, error)
+	Preflight             BinaryPreflight
+	RecoveryStatePath     string
 	Stdout                io.Writer
 	Stderr                io.Writer
 }
@@ -326,8 +329,13 @@ type Replacement struct {
 	Context               context.Context //nolint:containedctx // Replacement carries AfterReplace cancellation across Windows handoff.
 	StartProcess          ProcessStarter
 	Verify                BinaryVerifier
+	Preflight             BinaryPreflight
 	Sign                  BinarySigner
 	CodeSignatureVerifier CodeSignatureVerifier
+	BackupPath            string
+	PreserveBackup        bool
+	BeforeReplace         func(context.Context, string, string) error
+	AfterRevert           func(context.Context, string) error
 	AfterReplace          func(context.Context, string) error
 }
 
@@ -550,13 +558,41 @@ func (s *Service) applyReleaseUpdate(ctx context.Context, status Status, release
 		return status, err
 	}
 	replacement := Replacement{
-		Target:  s.cfg.ExecutablePath,
-		Binary:  binary,
-		Mode:    mode,
-		GOOS:    s.cfg.GOOS,
-		Context: ctx,
-		Verify:  s.cfg.BinaryVerifier,
-		Sign:    s.cfg.BinarySigner,
+		Target:         s.cfg.ExecutablePath,
+		Binary:         binary,
+		Mode:           mode,
+		GOOS:           s.cfg.GOOS,
+		Context:        ctx,
+		Verify:         s.cfg.BinaryVerifier,
+		Preflight:      opts.Preflight,
+		Sign:           s.cfg.BinarySigner,
+		BackupPath:     PreviousBinaryPath(s.cfg.ExecutablePath),
+		PreserveBackup: strings.TrimSpace(opts.RecoveryStatePath) != "",
+	}
+	if replacement.PreserveBackup {
+		replacement.BeforeReplace = func(_ context.Context, target string, previous string) error {
+			lockSnapshot, lockFound, err := snapshotInstallLock(s.cfg.GOOS, DetectionOptions{
+				HomeDir: s.cfg.HomeDir,
+				Env:     s.cfg.Env,
+			})
+			if err != nil {
+				return err
+			}
+			return recordPendingUpdate(opts.RecoveryStatePath, PendingUpdate{
+				FromVersion:              status.CurrentVersion,
+				ToVersion:                status.LatestVersion,
+				InstallSource:            status.InstallSource,
+				ExecutablePath:           target,
+				PreviousBinaryPath:       previous,
+				InstallLockPath:          lockSnapshot.path,
+				PreviousInstallLock:      lockSnapshot.contents,
+				PreviousInstallLockFound: lockFound,
+				AppliedAt:                time.Now().UTC(),
+			})
+		}
+		replacement.AfterRevert = func(_ context.Context, _ string) error {
+			return clearPendingUpdate(opts.RecoveryStatePath, status.LatestVersion)
+		}
 	}
 	replacement.AfterReplace = func(_ context.Context, target string) error {
 		return writeReleaseInstallLock(s.cfg.GOOS, DetectionOptions{
@@ -803,8 +839,13 @@ func replaceBinaryNow(ctx context.Context, replacement Replacement) error {
 	if writeErr != nil {
 		return writeErr
 	}
+	if replacement.Preflight != nil {
+		if err := replacement.Preflight(ctx, tempPath); err != nil {
+			return fmt.Errorf("preflight candidate binary: %w", err)
+		}
+	}
 
-	backupPath, err := backupBinary(target)
+	backupPath, err := backupBinary(target, replacement.BackupPath)
 	if err != nil {
 		return err
 	}
@@ -814,9 +855,21 @@ func replaceBinaryNow(ctx context.Context, replacement Replacement) error {
 			removeFile(backupPath)
 		}
 	}()
+	if replacement.BeforeReplace != nil {
+		if err := replacement.BeforeReplace(ctx, target, backupPath); err != nil {
+			if replacement.AfterRevert != nil {
+				err = errors.Join(err, replacement.AfterRevert(ctx, target))
+			}
+			return err
+		}
+	}
 
 	if err := os.Rename(tempPath, target); err != nil {
-		return fmt.Errorf("replace binary %s: %w", target, err)
+		replaceErr := fmt.Errorf("replace binary %s: %w", target, err)
+		if replacement.AfterRevert != nil {
+			replaceErr = errors.Join(replaceErr, replacement.AfterRevert(ctx, target))
+		}
+		return replaceErr
 	}
 	cleanup = false
 	if err := finalizeReplacement(ctx, replacement); err != nil {
@@ -824,7 +877,13 @@ func replaceBinaryNow(ctx context.Context, replacement Replacement) error {
 			return fmt.Errorf("%w; rollback failed: %w", err, rollbackErr)
 		}
 		cleanupBackup = false
+		if replacement.AfterRevert != nil {
+			err = errors.Join(err, replacement.AfterRevert(ctx, target))
+		}
 		return err
+	}
+	if replacement.PreserveBackup {
+		cleanupBackup = false
 	}
 	return nil
 }
@@ -842,7 +901,15 @@ func replacementMode(target string, fallback os.FileMode) os.FileMode {
 	return 0o755
 }
 
-func backupBinary(target string) (string, error) {
+func PreviousBinaryPath(target string) string {
+	target = strings.TrimSpace(target)
+	if target == "" {
+		return ""
+	}
+	return target + ".previous"
+}
+
+func backupBinary(target string, destination string) (string, error) {
 	source, err := os.Open(target)
 	if errors.Is(err, os.ErrNotExist) {
 		return "", nil
@@ -860,6 +927,10 @@ func backupBinary(target string) (string, error) {
 	}
 	dir := filepath.Dir(target)
 	base := filepath.Base(target)
+	if strings.TrimSpace(destination) != "" {
+		dir = filepath.Dir(destination)
+		base = filepath.Base(destination)
+	}
 	backup, err := os.CreateTemp(dir, "."+base+".rollback-*")
 	if err != nil {
 		return "", fmt.Errorf("create rollback binary: %w", err)
@@ -884,6 +955,13 @@ func backupBinary(target string) (string, error) {
 	if err := backup.Close(); err != nil {
 		removeFile(backupPath)
 		return "", fmt.Errorf("close rollback binary: %w", err)
+	}
+	if strings.TrimSpace(destination) != "" {
+		if err := os.Rename(backupPath, destination); err != nil {
+			removeFile(backupPath)
+			return "", fmt.Errorf("preserve rollback binary: %w", err)
+		}
+		backupPath = destination
 	}
 	return backupPath, nil
 }
@@ -954,9 +1032,26 @@ func stageWindowsReplacement(ctx context.Context, replacement Replacement) error
 			removeFile(source)
 		}
 	}()
+	if replacement.Preflight != nil {
+		if err := replacement.Preflight(ctx, source); err != nil {
+			return fmt.Errorf("preflight candidate binary: %w", err)
+		}
+	}
+	backupPath := strings.TrimSpace(replacement.BackupPath)
+	if replacement.BeforeReplace != nil {
+		if err := replacement.BeforeReplace(ctx, replacement.Target, backupPath); err != nil {
+			if replacement.AfterRevert != nil {
+				err = errors.Join(err, replacement.AfterRevert(ctx, replacement.Target))
+			}
+			return err
+		}
+	}
 
-	script, err := writeWindowsUpdateScript(dir, source, replacement.Target)
+	script, err := writeWindowsUpdateScript(dir, source, replacement.Target, backupPath)
 	if err != nil {
+		if replacement.AfterRevert != nil {
+			err = errors.Join(err, replacement.AfterRevert(ctx, replacement.Target))
+		}
 		return err
 	}
 	cleanupScript := true
@@ -970,8 +1065,12 @@ func stageWindowsReplacement(ctx context.Context, replacement Replacement) error
 	if starter == nil {
 		starter = startProcess
 	}
-	if err := starter("cmd.exe", []string{"/D", "/C", "start", "", "/B", "cmd.exe", "/D", "/C", script}); err != nil {
-		return fmt.Errorf("start windows updater: %w", err)
+	if err := starter(detachedProcessContext(ctx), "cmd.exe", []string{"/D", "/C", "start", "", "/B", "cmd.exe", "/D", "/C", script}); err != nil {
+		startErr := fmt.Errorf("start windows updater: %w", err)
+		if replacement.AfterRevert != nil {
+			startErr = errors.Join(startErr, replacement.AfterRevert(ctx, replacement.Target))
+		}
+		return startErr
 	}
 	if replacement.AfterReplace != nil {
 		if replacement.Context != nil {
@@ -1003,13 +1102,13 @@ func writeWindowsUpdateBinary(dir string, base string, binary []byte, mode os.Fi
 	return tempPath, nil
 }
 
-func writeWindowsUpdateScript(dir string, source string, target string) (string, error) {
+func writeWindowsUpdateScript(dir string, source string, target string, backup string) (string, error) {
 	script, err := os.CreateTemp(dir, ".detent-update-*.cmd")
 	if err != nil {
 		return "", fmt.Errorf("create windows update script: %w", err)
 	}
 	scriptPath := script.Name()
-	raw := windowsUpdateScript(source, target)
+	raw := windowsUpdateScript(source, target, backup)
 	if _, err := script.WriteString(raw); err != nil {
 		closeErr := script.Close()
 		removeFile(scriptPath)
@@ -1033,12 +1132,19 @@ func writeWindowsUpdateScript(dir string, source string, target string) (string,
 	return scriptPath, nil
 }
 
-func windowsUpdateScript(source string, target string) string {
+func windowsUpdateScript(source string, target string, backup string) string {
+	backupStep := ""
+	if strings.TrimSpace(backup) != "" {
+		backupStep = `copy /Y "%target%" "%backup%" >nul 2>nul
+if errorlevel 1 exit /b 1
+`
+	}
 	return fmt.Sprintf(`@echo off
 setlocal DisableDelayedExpansion
 set "source=%s"
 set "target=%s"
-set /a attempts=0
+set "backup=%s"
+%sset /a attempts=0
 :retry
 move /Y "%%source%%" "%%target%%" >nul 2>nul
 if not exist "%%source%%" goto done
@@ -1049,15 +1155,43 @@ goto retry
 :done
 del "%%~f0" >nul 2>nul
 exit /b 0
-`, escapeBatchValue(source), escapeBatchValue(target))
+`, escapeBatchValue(source), escapeBatchValue(target), escapeBatchValue(backup), backupStep)
+}
+
+func restorePreviousBinary(ctx context.Context, pending PendingUpdate, goos string) error {
+	target := strings.TrimSpace(pending.ExecutablePath)
+	previous := strings.TrimSpace(pending.PreviousBinaryPath)
+	if target == "" || previous == "" {
+		return errors.New("restore previous binary: executable and previous binary paths are required")
+	}
+	if goos != "windows" {
+		return rollbackBinary(target, previous)
+	}
+	dir := filepath.Dir(target)
+	script, err := writeWindowsUpdateScript(dir, previous, target, "")
+	if err != nil {
+		return err
+	}
+	if err := startProcess(detachedProcessContext(ctx), "cmd.exe", []string{"/D", "/C", "start", "", "/B", "cmd.exe", "/D", "/C", script}); err != nil {
+		removeFile(script)
+		return fmt.Errorf("start windows rollback: %w", err)
+	}
+	return nil
 }
 
 func escapeBatchValue(value string) string {
 	return strings.ReplaceAll(value, "%", "%%")
 }
 
-func startProcess(command string, args []string) error {
-	return exec.CommandContext(context.Background(), command, args...).Start() // #nosec G204 -- updater commands and arguments are resolved internally and bypass a shell.
+func detachedProcessContext(ctx context.Context) context.Context {
+	if ctx == nil {
+		return context.Background()
+	}
+	return context.WithoutCancel(ctx)
+}
+
+func startProcess(ctx context.Context, command string, args []string) error {
+	return exec.CommandContext(ctx, command, args...).Start() // #nosec G204 -- updater commands and arguments are resolved internally and bypass a shell.
 }
 
 func runCommand(ctx context.Context, command string, args []string, stdout io.Writer, stderr io.Writer) error {
@@ -1672,6 +1806,26 @@ func writeReleaseInstallLock(goos string, opts DetectionOptions, binary string, 
 	return writeInstallLock(lockPath, binary, version, time.Now().UTC())
 }
 
+type installLockSnapshot struct {
+	path     string
+	contents string
+}
+
+func snapshotInstallLock(goos string, opts DetectionOptions) (installLockSnapshot, bool, error) {
+	path, ok := installLockPath(goos, opts)
+	if !ok {
+		return installLockSnapshot{}, false, nil
+	}
+	raw, err := os.ReadFile(path)
+	if errors.Is(err, os.ErrNotExist) {
+		return installLockSnapshot{path: path}, false, nil
+	}
+	if err != nil {
+		return installLockSnapshot{}, false, fmt.Errorf("read install lock before update: %w", err)
+	}
+	return installLockSnapshot{path: path, contents: string(raw)}, true, nil
+}
+
 func installLockPath(goos string, opts DetectionOptions) (string, bool) {
 	if lockPath := envValue(opts.Env, "DETENT_INSTALL_LOCK"); lockPath != "" {
 		return lockPath, true
@@ -1697,6 +1851,14 @@ func writeInstallLock(path string, binary string, version string, installedAt ti
 	if strings.TrimSpace(binary) == "" {
 		return errors.New("install lock binary path is required")
 	}
+	raw := fmt.Sprintf("binary=%s\nversion=%s\ninstalled_at=%s\n", binary, strings.TrimSpace(version), installedAt.UTC().Format(time.RFC3339))
+	return writeInstallLockContents(path, raw)
+}
+
+func writeInstallLockContents(path string, raw string) error {
+	if strings.TrimSpace(path) == "" {
+		return errors.New("install lock path is required")
+	}
 	dir := filepath.Dir(path)
 	if err := os.MkdirAll(dir, 0o755); err != nil {
 		return fmt.Errorf("create install lock dir: %w", err)
@@ -1713,7 +1875,6 @@ func writeInstallLock(path string, binary string, version string, installedAt ti
 			removeFile(tempPath)
 		}
 	}()
-	raw := fmt.Sprintf("binary=%s\nversion=%s\ninstalled_at=%s\n", binary, strings.TrimSpace(version), installedAt.UTC().Format(time.RFC3339))
 	if _, err := temp.WriteString(raw); err != nil {
 		closeErr := temp.Close()
 		if closeErr != nil {

--- a/internal/update/update_test.go
+++ b/internal/update/update_test.go
@@ -487,6 +487,7 @@ func TestServiceAppliesReleaseUpdateWithMinisignSignatureFromHTTPServer(t *testi
 	tmp := t.TempDir()
 	binary := filepath.Join(tmp, "bin", "detent")
 	lockPath := filepath.Join(tmp, "state", "install.lock")
+	recoveryStatePath := filepath.Join(tmp, "state", startupRecoveryStateName)
 	if err := os.MkdirAll(filepath.Dir(binary), 0o755); err != nil {
 		t.Fatalf("MkdirAll(binary dir) error = %v", err)
 	}
@@ -552,7 +553,22 @@ func TestServiceAppliesReleaseUpdateWithMinisignSignatureFromHTTPServer(t *testi
 		},
 	})
 
-	status, err := service.Apply(context.Background(), ApplyOptions{AssumeYes: true})
+	var preflightPath string
+	status, err := service.Apply(context.Background(), ApplyOptions{
+		AssumeYes:         true,
+		RecoveryStatePath: recoveryStatePath,
+		Preflight: func(_ context.Context, path string) error {
+			preflightPath = path
+			raw, err := os.ReadFile(path)
+			if err != nil {
+				return err
+			}
+			if strings.TrimSpace(string(raw)) != "updated" {
+				return fmt.Errorf("candidate content = %q", raw)
+			}
+			return nil
+		},
+	})
 	if err != nil {
 		t.Fatalf("Apply() error = %v", err)
 	}
@@ -568,6 +584,27 @@ func TestServiceAppliesReleaseUpdateWithMinisignSignatureFromHTTPServer(t *testi
 	}
 	if strings.TrimSpace(string(raw)) != "updated" {
 		t.Fatalf("updated binary = %q, want updated", raw)
+	}
+	if preflightPath == "" || preflightPath == binary {
+		t.Fatalf("preflight path = %q, want staged candidate", preflightPath)
+	}
+	previousPath := PreviousBinaryPath(binary)
+	previousRaw, err := os.ReadFile(previousPath)
+	if err != nil {
+		t.Fatalf("ReadFile(previous) error = %v", err)
+	}
+	if string(previousRaw) != "old" {
+		t.Fatalf("previous binary = %q, want old", previousRaw)
+	}
+	recoveryState := readTestStartupRecoveryState(t, recoveryStatePath)
+	if recoveryState.PendingUpdate == nil {
+		t.Fatal("PendingUpdate = nil, want rollback metadata")
+	}
+	if got := recoveryState.PendingUpdate; got.FromVersion != "1.2.3" || got.ToVersion != "1.2.4" || got.PreviousBinaryPath != previousPath {
+		t.Fatalf("PendingUpdate = %#v, want 1.2.3 to 1.2.4 with previous binary", got)
+	}
+	if got := recoveryState.PendingUpdate; got.InstallLockPath != lockPath || !got.PreviousInstallLockFound || got.PreviousInstallLock != "binary="+binary+"\n" {
+		t.Fatalf("PendingUpdate install lock = %#v, want preserved pre-update metadata", got)
 	}
 	if got := InstalledReleaseVersion(DetectionOptions{
 		ExecutablePath: binary,
@@ -1273,7 +1310,7 @@ func TestReplaceBinaryStagesWindowsReplacement(t *testing.T) {
 		Binary: []byte("new"),
 		Mode:   0o755,
 		GOOS:   "windows",
-		StartProcess: func(command string, args []string) error {
+		StartProcess: func(_ context.Context, command string, args []string) error {
 			startedCommand = command
 			startedArgs = append(startedArgs, args...)
 			return nil


### PR DESCRIPTION
## Summary

- preflight staged release candidates against the effective configuration and retain the previous binary until healthy startup
- persist identical startup failures across process restarts, escalate retry delay, attempt one safe release recovery per version, and roll back repeatedly failing updates
- defer the healthy commit until the serving stack responds, and restore prior install metadata during rollback
- emit durable journal evidence plus the configured health webhook without depending on the dashboard or runtime database

Fixes #2050

## UI Surface Contract

- [x] N/A, or the linked issue explicitly authorizes any high-impact UI surface, layout, density, first-viewport, or responsive visibility tradeoff.
- [x] Persistent top-of-screen messaging is explicitly authorized by the issue, or this PR does not add it.
- [x] Visual changes to primary operator screens include screenshot or browser verification below.

No UI changes.

## Test Plan

- [x] focused race tests for serving readiness, rollback, install metadata, and shared-runtime shutdown
- [x] `make check` on amended head `1432d9b5`