### PR TITLE
fix(service): isolate launchd Codex skills

### DIFF
--- a/.detent/skills/launchd-codex-tcc-isolation.md
+++ b/.detent/skills/launchd-codex-tcc-isolation.md
@@ -1,0 +1,15 @@
+---
+name: launchd-codex-tcc-isolation
+description: Isolate Codex app-server startup stalls that occur only in a macOS launchd process after initialize succeeds.
+when_to_use: Use when direct Codex app-server probes work but a launchd-managed Detent worker times out at thread/start or thread/resume.
+---
+
+# Launchd Codex TCC Isolation
+
+- Keep the live Detent job untouched. Use a unique temporary launchd label, port `0`, isolated config/database/workspace/Codex home, and a trap that unloads only the temporary job.
+- Reproduce with a bounded JSON-RPC probe that sends `initialize`, `initialized`, and `thread/start` with an absolute workspace path. Compare direct and launchd runs from both `/` and a checkout before attributing the failure to cwd.
+- Match launchd's visible environment in a direct process. If the direct probe still succeeds, distinguish visible environment from macOS responsible-process and TCC context.
+- Bisect Codex home state from a fresh authenticated home. Restore config, plugins, hooks, and skills independently; then isolate individual skill entries when the skills root reproduces the stall.
+- For a suspected symlink into `~/Desktop`, `~/Documents`, `~/Downloads`, `~/Library/CloudStorage`, or `~/Library/Mobile Documents`, run one minimal read through the temporary launch agent. `Operation not permitted` confirms that launchd lacks the terminal process's Files & Folders access.
+- Do not mutate or relocate operator-owned skills as part of diagnosis. A service mitigation should preserve auth, config, plugins, state, worker temp directories, process-group ownership, and startup diagnostics while excluding only inaccessible host-skill links with an explicit warning.
+- Verify the final binary through an isolated launchd-started Detent service. Require a non-empty provider thread ID, non-empty turn ID, and token updates, then unload the temporary job and confirm no probe process remains.

--- a/internal/cli/codex_service_profile.go
+++ b/internal/cli/codex_service_profile.go
@@ -26,11 +26,10 @@ type codexServiceCommand struct {
 }
 
 func prepareCodexCommandForRuntime(command string) (codexServiceCommand, error) {
-	manager, _ := os.LookupEnv(servicepkg.ManagerEnvironment)
 	return prepareCodexCommandForService(
 		command,
 		runtime.GOOS,
-		manager,
+		string(servicepkg.ManagerFromProcessEnvironment(runtime.GOOS, os.LookupEnv)),
 		os.LookupEnv,
 		os.UserHomeDir,
 	)
@@ -249,31 +248,14 @@ func removeManagedProfileLink(path string) (bool, error) {
 }
 
 func launchdProtectedSkillLink(path string, userHome string) (bool, error) {
-	current := filepath.Clean(path)
-	for range 32 {
-		info, err := os.Lstat(current)
-		if errors.Is(err, os.ErrPermission) || errors.Is(err, os.ErrNotExist) {
-			return true, nil
-		}
-		if err != nil {
-			return false, err
-		}
-		if info.Mode()&os.ModeSymlink == 0 {
-			return launchdProtectedPath(current, userHome), nil
-		}
-		target, err := os.Readlink(current)
-		if err != nil {
-			return false, err
-		}
-		if !filepath.IsAbs(target) {
-			target = filepath.Join(filepath.Dir(current), target)
-		}
-		current = filepath.Clean(target)
-		if launchdProtectedPath(current, userHome) {
-			return true, nil
-		}
+	resolved, err := filepath.EvalSymlinks(filepath.Clean(path))
+	if errors.Is(err, os.ErrPermission) || errors.Is(err, os.ErrNotExist) {
+		return true, nil
 	}
-	return true, nil
+	if err != nil {
+		return false, err
+	}
+	return launchdProtectedPath(resolved, userHome), nil
 }
 
 func launchdProtectedPath(path string, userHome string) bool {

--- a/internal/cli/codex_service_profile.go
+++ b/internal/cli/codex_service_profile.go
@@ -1,0 +1,309 @@
+package cli
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"sync"
+
+	servicepkg "github.com/digitaldrywood/detent/internal/service"
+)
+
+const (
+	launchdCodexProfileDir    = ".detent-launchd"
+	launchdCodexProfileMarker = ".detent-profile-v1"
+)
+
+var launchdCodexProfileMu sync.Mutex
+
+type codexServiceCommand struct {
+	Command       string
+	Environment   map[string]string
+	OmittedSkills []string
+}
+
+func prepareCodexCommandForRuntime(command string) (codexServiceCommand, error) {
+	manager, _ := os.LookupEnv(servicepkg.ManagerEnvironment)
+	return prepareCodexCommandForService(
+		command,
+		runtime.GOOS,
+		manager,
+		os.LookupEnv,
+		os.UserHomeDir,
+	)
+}
+
+func prepareCodexCommandForService(
+	command string,
+	goos string,
+	manager string,
+	lookupEnv func(string) (string, bool),
+	userHomeDir func() (string, error),
+) (codexServiceCommand, error) {
+	prepared := codexServiceCommand{Command: command}
+	if goos != "darwin" || strings.TrimSpace(manager) != string(servicepkg.ManagerLaunchd) {
+		return prepared, nil
+	}
+
+	credentialPath, err := codexCredentialPath(command, lookupEnv, userHomeDir)
+	if err != nil {
+		return codexServiceCommand{}, err
+	}
+	home, err := userHomeDir()
+	if err != nil {
+		return codexServiceCommand{}, fmt.Errorf("resolve launchd user home: %w", err)
+	}
+	sourceHome := filepath.Dir(credentialPath)
+	profileHome, omittedSkills, err := prepareLaunchdCodexHome(sourceHome, home)
+	if err != nil {
+		return codexServiceCommand{}, err
+	}
+	prepared.Command = replaceCodexHomeAssignment(command, profileHome)
+	prepared.Environment = map[string]string{"CODEX_HOME": profileHome}
+	prepared.OmittedSkills = omittedSkills
+	return prepared, nil
+}
+
+func prepareLaunchdCodexHome(sourceHome string, userHome string) (string, []string, error) {
+	launchdCodexProfileMu.Lock()
+	defer launchdCodexProfileMu.Unlock()
+
+	sourceHome = filepath.Clean(sourceHome)
+	userHome = filepath.Clean(userHome)
+	resolvedSource, err := filepath.EvalSymlinks(sourceHome)
+	if err != nil {
+		return "", nil, fmt.Errorf("resolve Codex home %s: %w", sourceHome, err)
+	}
+	if launchdProtectedPath(resolvedSource, userHome) {
+		return "", nil, fmt.Errorf("codex home %s is in a macOS privacy-protected location", resolvedSource)
+	}
+
+	profileHome := filepath.Join(sourceHome, launchdCodexProfileDir)
+	if err := ensureLaunchdCodexProfile(profileHome); err != nil {
+		return "", nil, err
+	}
+	entries, err := os.ReadDir(sourceHome)
+	if err != nil {
+		return "", nil, fmt.Errorf("read Codex home %s: %w", sourceHome, err)
+	}
+	for _, entry := range entries {
+		if entry.Name() == "skills" || entry.Name() == launchdCodexProfileDir {
+			continue
+		}
+		if err := ensureProfileLink(
+			filepath.Join(sourceHome, entry.Name()),
+			filepath.Join(profileHome, entry.Name()),
+		); err != nil {
+			return "", nil, err
+		}
+	}
+
+	omittedSkills, err := syncLaunchdCodexSkills(sourceHome, profileHome, userHome)
+	if err != nil {
+		return "", nil, err
+	}
+	if err := rejectProtectedAgentSkills(userHome); err != nil {
+		return "", nil, err
+	}
+	return profileHome, omittedSkills, nil
+}
+
+func ensureLaunchdCodexProfile(profileHome string) error {
+	info, err := os.Stat(profileHome)
+	switch {
+	case errors.Is(err, os.ErrNotExist):
+		if err := os.MkdirAll(profileHome, 0o700); err != nil {
+			return fmt.Errorf("create launchd Codex profile %s: %w", profileHome, err)
+		}
+		if err := os.WriteFile(filepath.Join(profileHome, launchdCodexProfileMarker), []byte("1\n"), 0o600); err != nil {
+			return fmt.Errorf("mark launchd Codex profile %s: %w", profileHome, err)
+		}
+		return nil
+	case err != nil:
+		return fmt.Errorf("inspect launchd Codex profile %s: %w", profileHome, err)
+	case !info.IsDir():
+		return fmt.Errorf("launchd Codex profile path %s is not a directory", profileHome)
+	}
+	if _, err := os.Stat(filepath.Join(profileHome, launchdCodexProfileMarker)); err != nil {
+		return fmt.Errorf("launchd Codex profile %s is not managed by Detent", profileHome)
+	}
+	if info.Mode().Perm()&0o077 != 0 {
+		return fmt.Errorf("launchd Codex profile %s permissions are broader than 0700", profileHome)
+	}
+	return nil
+}
+
+func syncLaunchdCodexSkills(sourceHome string, profileHome string, userHome string) ([]string, error) {
+	sourceSkills := filepath.Join(sourceHome, "skills")
+	profileSkills := filepath.Join(profileHome, "skills")
+	if err := os.MkdirAll(profileSkills, 0o700); err != nil {
+		return nil, fmt.Errorf("create launchd Codex skills profile %s: %w", profileSkills, err)
+	}
+	entries, err := os.ReadDir(sourceSkills)
+	if errors.Is(err, os.ErrNotExist) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("read Codex skills %s: %w", sourceSkills, err)
+	}
+
+	omitted := make([]string, 0)
+	for _, entry := range entries {
+		source := filepath.Join(sourceSkills, entry.Name())
+		destination := filepath.Join(profileSkills, entry.Name())
+		protected, err := launchdProtectedSkillLink(source, userHome)
+		if err != nil {
+			return nil, fmt.Errorf("inspect Codex skill %s: %w", source, err)
+		}
+		if protected {
+			localFallback, err := removeManagedProfileLink(destination)
+			if err != nil {
+				return nil, err
+			}
+			if !localFallback {
+				omitted = append(omitted, entry.Name())
+			}
+			continue
+		}
+		if err := ensureProfileLink(source, destination); err != nil {
+			return nil, err
+		}
+	}
+	return omitted, nil
+}
+
+func rejectProtectedAgentSkills(userHome string) error {
+	skillsRoot := filepath.Join(userHome, ".agents", "skills")
+	entries, err := os.ReadDir(skillsRoot)
+	if errors.Is(err, os.ErrNotExist) {
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("read agent skills %s: %w", skillsRoot, err)
+	}
+	var protected []string
+	for _, entry := range entries {
+		path := filepath.Join(skillsRoot, entry.Name())
+		unsafe, err := launchdProtectedSkillLink(path, userHome)
+		if err != nil {
+			return fmt.Errorf("inspect agent skill %s: %w", path, err)
+		}
+		if unsafe {
+			protected = append(protected, entry.Name())
+		}
+	}
+	if len(protected) == 0 {
+		return nil
+	}
+	return fmt.Errorf("launchd cannot access protected ~/.agents/skills links: %s", strings.Join(protected, ", "))
+}
+
+func ensureProfileLink(source string, destination string) error {
+	info, err := os.Lstat(destination)
+	if errors.Is(err, os.ErrNotExist) {
+		if err := os.Symlink(source, destination); err != nil {
+			return fmt.Errorf("link launchd Codex profile entry %s: %w", destination, err)
+		}
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("inspect launchd Codex profile entry %s: %w", destination, err)
+	}
+	if info.Mode()&os.ModeSymlink == 0 {
+		return nil
+	}
+	target, err := os.Readlink(destination)
+	if err != nil {
+		return fmt.Errorf("read launchd Codex profile link %s: %w", destination, err)
+	}
+	if target == source {
+		return nil
+	}
+	if err := os.Remove(destination); err != nil {
+		return fmt.Errorf("replace launchd Codex profile link %s: %w", destination, err)
+	}
+	if err := os.Symlink(source, destination); err != nil {
+		return fmt.Errorf("link launchd Codex profile entry %s: %w", destination, err)
+	}
+	return nil
+}
+
+func removeManagedProfileLink(path string) (bool, error) {
+	info, err := os.Lstat(path)
+	if errors.Is(err, os.ErrNotExist) {
+		return false, nil
+	}
+	if err != nil {
+		return false, fmt.Errorf("inspect launchd Codex skill profile %s: %w", path, err)
+	}
+	if info.Mode()&os.ModeSymlink == 0 {
+		return true, nil
+	}
+	if err := os.Remove(path); err != nil {
+		return false, fmt.Errorf("remove protected launchd Codex skill link %s: %w", path, err)
+	}
+	return false, nil
+}
+
+func launchdProtectedSkillLink(path string, userHome string) (bool, error) {
+	current := filepath.Clean(path)
+	for range 32 {
+		info, err := os.Lstat(current)
+		if errors.Is(err, os.ErrPermission) || errors.Is(err, os.ErrNotExist) {
+			return true, nil
+		}
+		if err != nil {
+			return false, err
+		}
+		if info.Mode()&os.ModeSymlink == 0 {
+			return launchdProtectedPath(current, userHome), nil
+		}
+		target, err := os.Readlink(current)
+		if err != nil {
+			return false, err
+		}
+		if !filepath.IsAbs(target) {
+			target = filepath.Join(filepath.Dir(current), target)
+		}
+		current = filepath.Clean(target)
+		if launchdProtectedPath(current, userHome) {
+			return true, nil
+		}
+	}
+	return true, nil
+}
+
+func launchdProtectedPath(path string, userHome string) bool {
+	protectedRoots := []string{
+		filepath.Join(userHome, "Desktop"),
+		filepath.Join(userHome, "Documents"),
+		filepath.Join(userHome, "Downloads"),
+		filepath.Join(userHome, "Library", "CloudStorage"),
+		filepath.Join(userHome, "Library", "Mobile Documents"),
+	}
+	for _, root := range protectedRoots {
+		relative, err := filepath.Rel(root, path)
+		if err == nil && relative != ".." && !strings.HasPrefix(relative, ".."+string(filepath.Separator)) {
+			return true
+		}
+	}
+	return false
+}
+
+func replaceCodexHomeAssignment(command string, profileHome string) string {
+	match := codexHomeAssignmentPattern.FindStringIndex(command)
+	if len(match) == 0 {
+		return command
+	}
+	matched := command[match[0]:match[1]]
+	assignmentOffset := strings.Index(matched, "CODEX_HOME=")
+	if assignmentOffset < 0 {
+		return command
+	}
+	assignmentStart := match[0] + assignmentOffset
+	quotedProfile := "'" + strings.ReplaceAll(profileHome, "'", "'\\''") + "'"
+	return command[:assignmentStart] + "CODEX_HOME=" + quotedProfile + command[match[1]:]
+}

--- a/internal/cli/codex_service_profile.go
+++ b/internal/cli/codex_service_profile.go
@@ -259,6 +259,12 @@ func launchdProtectedSkillLink(path string, userHome string) (bool, error) {
 }
 
 func launchdProtectedPath(path string, userHome string) bool {
+	if resolved, err := filepath.EvalSymlinks(path); err == nil {
+		path = resolved
+	}
+	if resolved, err := filepath.EvalSymlinks(userHome); err == nil {
+		userHome = resolved
+	}
 	protectedRoots := []string{
 		filepath.Join(userHome, "Desktop"),
 		filepath.Join(userHome, "Documents"),

--- a/internal/cli/codex_service_profile.go
+++ b/internal/cli/codex_service_profile.go
@@ -130,7 +130,7 @@ func ensureLaunchdCodexProfile(profileHome string) error {
 	if _, err := os.Stat(filepath.Join(profileHome, launchdCodexProfileMarker)); err != nil {
 		return fmt.Errorf("launchd Codex profile %s is not managed by Detent", profileHome)
 	}
-	if info.Mode().Perm()&0o077 != 0 {
+	if runtime.GOOS != "windows" && info.Mode().Perm()&0o077 != 0 {
 		return fmt.Errorf("launchd Codex profile %s permissions are broader than 0700", profileHome)
 	}
 	return nil

--- a/internal/cli/codex_service_profile_test.go
+++ b/internal/cli/codex_service_profile_test.go
@@ -1,0 +1,181 @@
+package cli
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+
+	servicepkg "github.com/digitaldrywood/detent/internal/service"
+)
+
+func TestPrepareCodexCommandForServiceCreatesLaunchdProfile(t *testing.T) {
+	t.Parallel()
+
+	home := t.TempDir()
+	sourceHome := filepath.Join(home, ".codex")
+	for _, path := range []string{
+		sourceHome,
+		filepath.Join(sourceHome, "plugins"),
+		filepath.Join(sourceHome, "skills", ".system"),
+		filepath.Join(sourceHome, "skills", "local"),
+	} {
+		if err := os.MkdirAll(path, 0o700); err != nil {
+			t.Fatalf("MkdirAll(%q) error = %v", path, err)
+		}
+	}
+	for _, name := range []string{"auth.json", "config.toml"} {
+		if err := os.WriteFile(filepath.Join(sourceHome, name), []byte(name), 0o600); err != nil {
+			t.Fatalf("WriteFile(%q) error = %v", name, err)
+		}
+	}
+	protectedTarget := filepath.Join(home, "Library", "CloudStorage", "Dropbox", "templui-pro")
+	if err := os.MkdirAll(protectedTarget, 0o700); err != nil {
+		t.Fatalf("MkdirAll() protected target error = %v", err)
+	}
+	if err := os.Symlink(protectedTarget, filepath.Join(sourceHome, "skills", "templui-pro")); err != nil {
+		t.Fatalf("Symlink() protected skill error = %v", err)
+	}
+
+	prepared, err := prepareCodexCommandForService(
+		"codex app-server",
+		"darwin",
+		string(servicepkg.ManagerLaunchd),
+		func(string) (string, bool) { return "", false },
+		func() (string, error) { return home, nil },
+	)
+	if err != nil {
+		t.Fatalf("prepareCodexCommandForService() error = %v", err)
+	}
+	profileHome := filepath.Join(sourceHome, launchdCodexProfileDir)
+	if prepared.Command != "codex app-server" {
+		t.Fatalf("Command = %q, want unchanged command", prepared.Command)
+	}
+	if got := prepared.Environment["CODEX_HOME"]; got != profileHome {
+		t.Fatalf("CODEX_HOME = %q, want %q", got, profileHome)
+	}
+	if !reflect.DeepEqual(prepared.OmittedSkills, []string{"templui-pro"}) {
+		t.Fatalf("OmittedSkills = %#v, want templui-pro", prepared.OmittedSkills)
+	}
+	for _, path := range []string{
+		filepath.Join(profileHome, "auth.json"),
+		filepath.Join(profileHome, "config.toml"),
+		filepath.Join(profileHome, "plugins"),
+		filepath.Join(profileHome, "skills", ".system"),
+		filepath.Join(profileHome, "skills", "local"),
+	} {
+		info, err := os.Lstat(path)
+		if err != nil {
+			t.Fatalf("Lstat(%q) error = %v", path, err)
+		}
+		if info.Mode()&os.ModeSymlink == 0 {
+			t.Fatalf("%s is not a symlink", path)
+		}
+	}
+	if _, err := os.Lstat(filepath.Join(profileHome, "skills", "templui-pro")); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("protected profile skill error = %v, want not exist", err)
+	}
+	if _, err := os.Stat(filepath.Join(profileHome, launchdCodexProfileMarker)); err != nil {
+		t.Fatalf("profile marker error = %v", err)
+	}
+
+	if _, err := prepareCodexCommandForService(
+		"codex app-server",
+		"darwin",
+		string(servicepkg.ManagerLaunchd),
+		func(string) (string, bool) { return "", false },
+		func() (string, error) { return home, nil },
+	); err != nil {
+		t.Fatalf("second prepareCodexCommandForService() error = %v", err)
+	}
+}
+
+func TestPrepareCodexCommandForServiceRewritesConfiguredHome(t *testing.T) {
+	t.Parallel()
+
+	home := t.TempDir()
+	sourceHome := filepath.Join(home, "codex profile")
+	if err := os.MkdirAll(sourceHome, 0o700); err != nil {
+		t.Fatalf("MkdirAll() error = %v", err)
+	}
+	command := "env CODEX_HOME='" + sourceHome + "' codex app-server"
+	prepared, err := prepareCodexCommandForService(
+		command,
+		"darwin",
+		string(servicepkg.ManagerLaunchd),
+		func(string) (string, bool) { return "", false },
+		func() (string, error) { return home, nil },
+	)
+	if err != nil {
+		t.Fatalf("prepareCodexCommandForService() error = %v", err)
+	}
+	profileHome := filepath.Join(sourceHome, launchdCodexProfileDir)
+	want := "env CODEX_HOME='" + profileHome + "' codex app-server"
+	if prepared.Command != want {
+		t.Fatalf("Command = %q, want %q", prepared.Command, want)
+	}
+	if prepared.Environment["CODEX_HOME"] != profileHome {
+		t.Fatalf("Environment = %#v, want CODEX_HOME %q", prepared.Environment, profileHome)
+	}
+}
+
+func TestPrepareCodexCommandForServiceLeavesNonLaunchdCommandUnchanged(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		goos    string
+		manager string
+	}{
+		{name: "manual macOS", goos: "darwin", manager: string(servicepkg.ManagerManual)},
+		{name: "Linux service", goos: "linux", manager: string(servicepkg.ManagerLaunchd)},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			prepared, err := prepareCodexCommandForService(
+				"codex app-server",
+				tt.goos,
+				tt.manager,
+				func(string) (string, bool) { return "", false },
+				func() (string, error) { return "", errors.New("must not resolve home") },
+			)
+			if err != nil {
+				t.Fatalf("prepareCodexCommandForService() error = %v", err)
+			}
+			if prepared.Command != "codex app-server" || len(prepared.Environment) != 0 {
+				t.Fatalf("prepared = %#v, want unchanged command", prepared)
+			}
+		})
+	}
+}
+
+func TestPrepareCodexCommandForServiceRejectsProtectedAgentSkill(t *testing.T) {
+	t.Parallel()
+
+	home := t.TempDir()
+	sourceHome := filepath.Join(home, ".codex")
+	agentSkills := filepath.Join(home, ".agents", "skills")
+	protectedTarget := filepath.Join(home, "Documents", "shared-skill")
+	for _, path := range []string{sourceHome, agentSkills, protectedTarget} {
+		if err := os.MkdirAll(path, 0o700); err != nil {
+			t.Fatalf("MkdirAll(%q) error = %v", path, err)
+		}
+	}
+	if err := os.Symlink(protectedTarget, filepath.Join(agentSkills, "shared")); err != nil {
+		t.Fatalf("Symlink() error = %v", err)
+	}
+
+	_, err := prepareCodexCommandForService(
+		"codex app-server",
+		"darwin",
+		string(servicepkg.ManagerLaunchd),
+		func(string) (string, bool) { return "", false },
+		func() (string, error) { return home, nil },
+	)
+	if err == nil || !strings.Contains(err.Error(), "protected ~/.agents/skills links: shared") {
+		t.Fatalf("error = %v, want protected agent skill detail", err)
+	}
+}

--- a/internal/cli/codex_service_profile_test.go
+++ b/internal/cli/codex_service_profile_test.go
@@ -179,3 +179,32 @@ func TestPrepareCodexCommandForServiceRejectsProtectedAgentSkill(t *testing.T) {
 		t.Fatalf("error = %v, want protected agent skill detail", err)
 	}
 }
+
+func TestLaunchdProtectedSkillLinkResolvesSymlinkedParent(t *testing.T) {
+	t.Parallel()
+
+	home := t.TempDir()
+	protectedRoot := filepath.Join(home, "Documents", "shared")
+	if err := os.MkdirAll(filepath.Join(protectedRoot, "skill"), 0o700); err != nil {
+		t.Fatalf("MkdirAll() error = %v", err)
+	}
+	linkedParent := filepath.Join(home, "shared")
+	if err := os.Symlink(protectedRoot, linkedParent); err != nil {
+		t.Fatalf("Symlink() error = %v", err)
+	}
+	skillLink := filepath.Join(home, ".codex", "skills", "shared")
+	if err := os.MkdirAll(filepath.Dir(skillLink), 0o700); err != nil {
+		t.Fatalf("MkdirAll() skill root error = %v", err)
+	}
+	if err := os.Symlink(filepath.Join(linkedParent, "skill"), skillLink); err != nil {
+		t.Fatalf("Symlink() skill error = %v", err)
+	}
+
+	protected, err := launchdProtectedSkillLink(skillLink, home)
+	if err != nil {
+		t.Fatalf("launchdProtectedSkillLink() error = %v", err)
+	}
+	if !protected {
+		t.Fatal("launchdProtectedSkillLink() = false, want true")
+	}
+}

--- a/internal/cli/codex_service_profile_test.go
+++ b/internal/cli/codex_service_profile_test.go
@@ -183,7 +183,15 @@ func TestPrepareCodexCommandForServiceRejectsProtectedAgentSkill(t *testing.T) {
 func TestLaunchdProtectedSkillLinkResolvesSymlinkedParent(t *testing.T) {
 	t.Parallel()
 
-	home := t.TempDir()
+	root := t.TempDir()
+	realHome := filepath.Join(root, "real-home")
+	if err := os.MkdirAll(realHome, 0o700); err != nil {
+		t.Fatalf("MkdirAll() home error = %v", err)
+	}
+	home := filepath.Join(root, "home")
+	if err := os.Symlink(realHome, home); err != nil {
+		t.Fatalf("Symlink() home error = %v", err)
+	}
 	protectedRoot := filepath.Join(home, "Documents", "shared")
 	if err := os.MkdirAll(filepath.Join(protectedRoot, "skill"), 0o700); err != nil {
 		t.Fatalf("MkdirAll() error = %v", err)

--- a/internal/cli/runner.go
+++ b/internal/cli/runner.go
@@ -21,6 +21,7 @@ import (
 	"github.com/digitaldrywood/detent/internal/hub"
 	"github.com/digitaldrywood/detent/internal/observability"
 	"github.com/digitaldrywood/detent/internal/orchestrator"
+	"github.com/digitaldrywood/detent/internal/procgroup"
 	"github.com/digitaldrywood/detent/internal/project"
 	"github.com/digitaldrywood/detent/internal/projectcolor"
 	runnerpkg "github.com/digitaldrywood/detent/internal/runner"
@@ -283,9 +284,22 @@ func buildCodexAgentBackend(command string, cfg workflowconfig.CodexOptions) (ru
 	if command == "" {
 		return nil, errors.New("codex command is required")
 	}
+	serviceCommand, err := prepareCodexCommandForRuntime(command)
+	if err != nil {
+		return nil, fmt.Errorf("prepare Codex service profile: %w", err)
+	}
+	command = serviceCommand.Command
+	if len(serviceCommand.OmittedSkills) > 0 {
+		slog.Warn(
+			"launchd Codex profile omitted skills in macOS privacy-protected locations",
+			"skills", strings.Join(serviceCommand.OmittedSkills, ","),
+		)
+	}
 
 	factory, err := codex.NewLocalTransportFactory(func(ctx context.Context) *exec.Cmd {
-		return buildCodexCommandFromConfig(ctx, command, cfg.Shell)
+		cmd := buildCodexCommandFromConfig(ctx, command, cfg.Shell)
+		procgroup.SetEnvironment(cmd, procgroup.Environment{Variables: serviceCommand.Environment})
+		return cmd
 	})
 	if err != nil {
 		return nil, fmt.Errorf("create codex transport factory: %w", err)

--- a/internal/service/launchd.go
+++ b/internal/service/launchd.go
@@ -119,12 +119,20 @@ func launchdPlist(cfg Config) string {
 	for _, argument := range cfg.Arguments {
 		lines = append(lines, `    <string>`+escape(argument)+`</string>`)
 	}
+	lines = append(lines, `  </array>`)
+	if workingDirectory := strings.TrimSpace(cfg.HomeDir); workingDirectory != "" {
+		lines = append(lines,
+			`  <key>WorkingDirectory</key>`,
+			`  <string>`+escape(workingDirectory)+`</string>`,
+		)
+	}
 	lines = append(lines,
-		`  </array>`,
 		`  <key>EnvironmentVariables</key>`,
 		`  <dict>`,
 		`    <key>PATH</key>`,
 		`    <string>`+escape(cfg.Path)+`</string>`,
+		`    <key>`+ManagerEnvironment+`</key>`,
+		`    <string>`+string(ManagerLaunchd)+`</string>`,
 		`  </dict>`,
 		`  <key>RunAtLoad</key>`,
 		`  <true/>`,

--- a/internal/service/launchd_test.go
+++ b/internal/service/launchd_test.go
@@ -16,6 +16,7 @@ func TestLaunchdPlistIncludesRuntimeSettings(t *testing.T) {
 	plist := launchdPlist(Config{
 		BinaryPath: "/Applications/Detent & Tools/detent",
 		Arguments:  []string{"--config", "/Users/name/Library/Application Support/Detent/global.yaml", "--headless"},
+		HomeDir:    "/Users/name & operator",
 		Path:       "/Users/name/bin:/usr/bin",
 	})
 	for _, want := range []string{
@@ -25,6 +26,10 @@ func TestLaunchdPlistIncludesRuntimeSettings(t *testing.T) {
 		"<key>RunAtLoad</key>",
 		"<key>SuccessfulExit</key>",
 		"<string>/Users/name/bin:/usr/bin</string>",
+		"<key>WorkingDirectory</key>",
+		"<string>/Users/name &amp; operator</string>",
+		"<key>DETENT_SERVICE_MANAGER</key>",
+		"<string>launchd</string>",
 	} {
 		if !strings.Contains(plist, want) {
 			t.Fatalf("plist missing %q:\n%s", want, plist)

--- a/internal/service/service.go
+++ b/internal/service/service.go
@@ -32,6 +32,8 @@ const (
 
 const ManagerEnvironment = "DETENT_SERVICE_MANAGER"
 
+const launchdServiceEnvironment = "XPC_SERVICE_NAME"
+
 type State string
 
 const (
@@ -141,6 +143,18 @@ type Status struct {
 
 func (s Status) Running() bool {
 	return s.State == StateRunning
+}
+
+func ManagerFromProcessEnvironment(goos string, lookupEnv func(string) (string, bool)) ManagerName {
+	if manager, ok := lookupEnv(ManagerEnvironment); ok && strings.TrimSpace(manager) != "" {
+		return ManagerName(strings.TrimSpace(manager))
+	}
+	if goos == "darwin" {
+		if serviceName, ok := lookupEnv(launchdServiceEnvironment); ok && strings.TrimSpace(serviceName) == launchdLabel {
+			return ManagerLaunchd
+		}
+	}
+	return ""
 }
 
 type Controller struct {

--- a/internal/service/service.go
+++ b/internal/service/service.go
@@ -30,6 +30,8 @@ const (
 	ManagerLaunchd ManagerName = "launchd"
 )
 
+const ManagerEnvironment = "DETENT_SERVICE_MANAGER"
+
 type State string
 
 const (

--- a/internal/service/service_test.go
+++ b/internal/service/service_test.go
@@ -244,6 +244,53 @@ func TestStatusRunningRequiresRunningState(t *testing.T) {
 	}
 }
 
+func TestManagerFromProcessEnvironment(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		goos string
+		env  map[string]string
+		want ManagerName
+	}{
+		{
+			name: "explicit manager",
+			goos: "darwin",
+			env:  map[string]string{ManagerEnvironment: string(ManagerLaunchd)},
+			want: ManagerLaunchd,
+		},
+		{
+			name: "legacy launchd definition",
+			goos: "darwin",
+			env:  map[string]string{launchdServiceEnvironment: launchdLabel},
+			want: ManagerLaunchd,
+		},
+		{
+			name: "unrelated XPC service",
+			goos: "darwin",
+			env:  map[string]string{launchdServiceEnvironment: "application.com.example.client"},
+		},
+		{
+			name: "non-macOS process",
+			goos: "linux",
+			env:  map[string]string{launchdServiceEnvironment: launchdLabel},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := ManagerFromProcessEnvironment(tt.goos, func(key string) (string, bool) {
+				value, ok := tt.env[key]
+				return value, ok
+			})
+			if got != tt.want {
+				t.Fatalf("ManagerFromProcessEnvironment() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestInspectManualUsesInstanceLock(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

- identify macOS TCC denial of privacy-protected Codex skill links as the launchd-only thread/start stall
- run launchd Codex workers from a Detent-managed profile that preserves auth, config, plugins, and state while omitting inaccessible standalone skills with a warning
- give generated launchd services a stable home working directory and explicit service-manager context
- add launchd definition and Codex profile regression coverage plus a reusable diagnosis skill

Fixes #2061

## UI Surface Contract

- [x] N/A, or the linked issue explicitly authorizes any high-impact UI surface, layout, density, first-viewport, or responsive visibility tradeoff.
- [x] Persistent top-of-screen messaging is explicitly authorized by the issue, or this PR does not add it.
- [x] Visual changes to primary operator screens include screenshot or browser verification below.

## Test Plan

- [x] `go test ./internal/service ./internal/cli`
- [x] isolated launchd-started Detent service dispatched a real Codex worker with a provider thread ID, turn ID, and token updates while a protected skill link was present
- [x] `make check` (78.9% overall coverage; package and file floors passed)