### PR TITLE
Credit within-attempt dispatch progress

### DIFF
--- a/internal/orchestrator/dispatch.go
+++ b/internal/orchestrator/dispatch.go
@@ -530,7 +530,8 @@ func (o *Orchestrator) dispatchIssueWithAdmission(
 			priorAttempt = breakerAttempt
 		}
 	}
-	workAttemptID, ok := o.startDurableWorkAttempt(runCtx, state, issue, attempt, now, workerHost, runMode)
+	dispatchLoopStart := newDispatchLoopStartRecord(issue, runMode)
+	workAttemptID, ok := o.startDurableWorkAttempt(runCtx, state, issue, attempt, now, workerHost, runMode, dispatchLoopStart)
 	if !ok {
 		if recovery {
 			releaseDispatchRecoveryAdmission(state, issue.ID)
@@ -566,12 +567,13 @@ func (o *Orchestrator) dispatchIssueWithAdmission(
 			}
 			o.releaseGlobalDispatchSlot(globalSlot)
 			o.completeDurableWorkAttempt(ctx, state, Running{
-				Issue:         issue,
-				Attempt:       attempt,
-				WorkAttemptID: workAttemptID,
-				Mode:          runMode,
-				StartedAt:     now,
-				WorkerHost:    workerHost,
+				Issue:             issue,
+				Attempt:           attempt,
+				WorkAttemptID:     workAttemptID,
+				Mode:              runMode,
+				DispatchLoopStart: dispatchLoopStart,
+				StartedAt:         now,
+				WorkerHost:        workerHost,
 			}, now, store.WorkAttemptTerminalFailure, workAttemptErrorStartTransition, err.Error(), "starting", "start state transition failed")
 			o.logWorkerLifecycle(issue, "worker_capacity_released",
 				telemetry.WorkAttemptIDKey, workAttemptID,
@@ -666,6 +668,7 @@ func (o *Orchestrator) dispatchIssueWithAdmission(
 		DispatchArtifactStatus: strings.TrimSpace(dispatchArtifactStatus),
 		ArtifactStatusField:    strings.TrimSpace(artifactStatusField),
 		DeliverableKind:        o.cfg.DeliverableKind,
+		DispatchLoopStart:      dispatchLoopStart,
 		StartedAt:              now,
 		WorkerHost:             workerHost,
 		CapacityScope:          capacityScope,
@@ -976,6 +979,20 @@ func (o *Orchestrator) usageUpdateHandler(
 		}
 		if startupTimer != nil {
 			startupTimer.Stop()
+		}
+		if update.DispatchLoopStart != nil {
+			applied := make(chan struct{})
+			select {
+			case <-ctx.Done():
+				return ctx.Err()
+			case o.runUpdates <- runUpdate{issueID: issueID, usage: update, applied: applied}:
+			}
+			select {
+			case <-ctx.Done():
+				return ctx.Err()
+			case <-applied:
+				return nil
+			}
 		}
 		if strings.TrimSpace(update.WorkerGitHubActor.Login) != "" {
 			select {

--- a/internal/orchestrator/dispatch_loop.go
+++ b/internal/orchestrator/dispatch_loop.go
@@ -6,11 +6,15 @@ import (
 	"slices"
 	"strings"
 
+	"github.com/digitaldrywood/detent/internal/connector"
+	runpkg "github.com/digitaldrywood/detent/internal/runner"
 	"github.com/digitaldrywood/detent/internal/store"
 	"github.com/digitaldrywood/detent/internal/workpad"
 )
 
 const dispatchLoopDetectedReason = "dispatch_loop_detected"
+
+const dispatchLoopStartMetadataKey = "dispatch_loop_start"
 
 const dispatchLoopMinimumDispatches = 2
 
@@ -22,17 +26,34 @@ func dispatchLoopBlockMessage(decision implementCompletionProgressDecision) stri
 }
 
 type dispatchLoopFingerprint struct {
-	Lane            string
-	PRNumber        int64
-	PRHeadSHA       string
-	FailedChecks    []string
-	FilesChanged    int
-	AddedLines      int
-	RemovedLines    int
-	UnpushedCommits int
-	WorkspaceHead   string
-	DiffFingerprint string
-	DiffStatus      string
+	Lane            string   `json:"lane,omitempty"`
+	PRNumber        int64    `json:"pr_number,omitempty"`
+	PRHeadSHA       string   `json:"pr_head_sha,omitempty"`
+	FailedChecks    []string `json:"failed_checks,omitempty"`
+	FilesChanged    int      `json:"files_changed"`
+	AddedLines      int      `json:"added_lines"`
+	RemovedLines    int      `json:"removed_lines"`
+	UnpushedCommits int      `json:"unpushed_commits,omitempty"`
+	WorkspaceHead   string   `json:"workspace_head,omitempty"`
+	DiffFingerprint string   `json:"diff_fingerprint,omitempty"`
+	DiffStatus      string   `json:"diff_status,omitempty"`
+}
+
+type dispatchLoopStartRecord struct {
+	Fingerprint            dispatchLoopFingerprint `json:"fingerprint"`
+	Captured               bool                    `json:"captured"`
+	Persisted              bool                    `json:"persisted"`
+	LaneAvailable          bool                    `json:"lane_available"`
+	PullRequestAvailable   bool                    `json:"pull_request_available"`
+	WorkspaceDiffAvailable bool                    `json:"workspace_diff_available"`
+	WorkspaceHeadAvailable bool                    `json:"workspace_head_available"`
+}
+
+type dispatchLoopCompletionEvidence struct {
+	LaneAvailable          bool
+	PullRequestAvailable   bool
+	WorkspaceDiffAvailable bool
+	WorkspaceHeadAvailable bool
 }
 
 func (o *Orchestrator) evaluateDispatchLoopProgress(
@@ -60,6 +81,14 @@ func (o *Orchestrator) evaluateDispatchLoopProgress(
 	}
 
 	current := dispatchLoopFingerprintFromDecision(decision, currentLane)
+	withinAttemptAdvanced, withinAttemptComplete := dispatchLoopWithinAttemptProgress(
+		running.DispatchLoopStart,
+		current,
+		dispatchLoopCompletionEvidenceFromDecision(decision, current),
+	)
+	if withinAttemptAdvanced || !withinAttemptComplete {
+		return resetDispatchLoopDecision(decision)
+	}
 	previous, found := latestDispatchLoopFingerprint(attempts, currentLane)
 	if dispatchLoopCurrentAdvanced(decision, current, previous, found) {
 		return resetDispatchLoopDecision(decision)
@@ -122,7 +151,7 @@ func dispatchLoopCurrentAdvanced(
 	if found {
 		return !dispatchLoopFingerprintEqual(previous, current)
 	}
-	return !implementProgressDiffStatsClean(decision.WorkspaceDiffStats) && diffStatsPresent(decision.WorkspaceDiffStats)
+	return false
 }
 
 func latestDispatchLoopFingerprint(attempts []store.WorkAttempt, currentLane string) (dispatchLoopFingerprint, bool) {
@@ -144,7 +173,7 @@ func consecutiveDispatchLoopAttempts(attempts []store.WorkAttempt, current dispa
 			return count
 		}
 		fingerprint := dispatchLoopFingerprintFromRecord(attempt, record, current.Lane)
-		if !dispatchLoopFingerprintEqual(fingerprint, current) || dispatchLoopRecordAdvanced(record) {
+		if !dispatchLoopFingerprintEqual(fingerprint, current) || dispatchLoopRecordBreaksSequence(attempt, record, fingerprint) {
 			return count
 		}
 		count++
@@ -152,7 +181,15 @@ func consecutiveDispatchLoopAttempts(attempts []store.WorkAttempt, current dispa
 	return count
 }
 
-func dispatchLoopRecordAdvanced(record implementProgressRecord) bool {
+func dispatchLoopRecordBreaksSequence(attempt store.WorkAttempt, record implementProgressRecord, completion dispatchLoopFingerprint) bool {
+	advanced, complete := dispatchLoopWithinAttemptProgress(
+		record.DispatchLoopStart,
+		completion,
+		dispatchLoopCompletionEvidenceFromRecord(attempt, record, completion),
+	)
+	if advanced || !complete {
+		return true
+	}
 	if record.ConsecutiveNoProgress > 0 {
 		return false
 	}
@@ -176,6 +213,125 @@ func dispatchLoopRecordAdvanced(record implementProgressRecord) bool {
 	default:
 		return false
 	}
+}
+
+func newDispatchLoopStartRecord(issue connector.Issue, mode string) dispatchLoopStartRecord {
+	if strings.TrimSpace(mode) != RunModeImplement {
+		return dispatchLoopStartRecord{}
+	}
+	signature := autoPromoteReworkSignatureFromIssue(issue, AutoPromoteSummaryFromIssue(issue))
+	lane := normalizeState(issue.State)
+	return dispatchLoopStartRecord{
+		Fingerprint:          dispatchLoopFingerprintFromValues(lane, signature, implementProgressDiffStats{}),
+		LaneAvailable:        lane != "",
+		PullRequestAvailable: dispatchLoopPullRequestEvidenceAvailable(workAttemptPRNumber(issue), signature, ""),
+	}
+}
+
+func dispatchLoopStartRecordFromSnapshot(
+	running Running,
+	snapshot runpkg.DispatchLoopStartSnapshot,
+) dispatchLoopStartRecord {
+	record := running.DispatchLoopStart
+	diff := implementProgressDiffStatsFromDiffStats(snapshot.DiffStats)
+	record.Fingerprint = dispatchLoopFingerprintFromValues(
+		normalizeState(firstNonBlank(running.DispatchSourceState, running.Issue.State)),
+		record.Fingerprint.signature(),
+		diff,
+	)
+	record.Captured = true
+	record.Persisted = true
+	record.WorkspaceDiffAvailable = snapshot.WorkspaceDiffAvailable
+	record.WorkspaceHeadAvailable = snapshot.WorkspaceHeadAvailable
+	return record
+}
+
+func (f dispatchLoopFingerprint) signature() autoPromoteReworkSignature {
+	return autoPromoteReworkSignature{
+		PRNumber:     f.PRNumber,
+		HeadSHA:      strings.TrimSpace(f.PRHeadSHA),
+		FailedChecks: append([]string(nil), f.FailedChecks...),
+	}
+}
+
+func dispatchLoopWithinAttemptProgress(
+	start dispatchLoopStartRecord,
+	completion dispatchLoopFingerprint,
+	evidence dispatchLoopCompletionEvidence,
+) (bool, bool) {
+	if !start.Captured || !start.Persisted {
+		return false, false
+	}
+	if start.LaneAvailable && evidence.LaneAvailable && start.Fingerprint.Lane != completion.Lane {
+		return true, true
+	}
+	if start.PullRequestAvailable && evidence.PullRequestAvailable &&
+		(start.Fingerprint.PRNumber != completion.PRNumber || start.Fingerprint.PRHeadSHA != completion.PRHeadSHA) {
+		return true, true
+	}
+	if start.WorkspaceDiffAvailable && evidence.WorkspaceDiffAvailable &&
+		!dispatchLoopWorkspaceDiffEqual(start.Fingerprint, completion) {
+		return true, true
+	}
+	if start.WorkspaceHeadAvailable && evidence.WorkspaceHeadAvailable && start.Fingerprint.WorkspaceHead != completion.WorkspaceHead {
+		return true, true
+	}
+	complete := start.LaneAvailable && evidence.LaneAvailable &&
+		start.PullRequestAvailable && evidence.PullRequestAvailable &&
+		start.WorkspaceDiffAvailable && evidence.WorkspaceDiffAvailable &&
+		start.WorkspaceHeadAvailable && evidence.WorkspaceHeadAvailable
+	return false, complete
+}
+
+func dispatchLoopCompletionEvidenceFromDecision(
+	decision implementCompletionProgressDecision,
+	fingerprint dispatchLoopFingerprint,
+) dispatchLoopCompletionEvidence {
+	return dispatchLoopCompletionEvidence{
+		LaneAvailable:          fingerprint.Lane != "",
+		PullRequestAvailable:   dispatchLoopPullRequestEvidenceAvailable(workAttemptPRNumber(decision.Issue), decision.CurrentSignature, decision.Reason),
+		WorkspaceDiffAvailable: diffStatsPresent(decision.WorkspaceDiffStats),
+		WorkspaceHeadAvailable: strings.TrimSpace(decision.WorkspaceDiffStats.HeadSHA) != "",
+	}
+}
+
+func dispatchLoopCompletionEvidenceFromRecord(
+	attempt store.WorkAttempt,
+	record implementProgressRecord,
+	fingerprint dispatchLoopFingerprint,
+) dispatchLoopCompletionEvidence {
+	return dispatchLoopCompletionEvidence{
+		LaneAvailable:          fingerprint.Lane != "",
+		PullRequestAvailable:   dispatchLoopPullRequestEvidenceAvailable(attempt.PRNumber, record.CurrentSignature.signature(), record.Reason),
+		WorkspaceDiffAvailable: implementProgressDiffStatsPresent(record.WorkspaceDiffStats),
+		WorkspaceHeadAvailable: strings.TrimSpace(record.WorkspaceDiffStats.HeadSHA) != "",
+	}
+}
+
+func dispatchLoopPullRequestEvidenceAvailable(number *int64, signature autoPromoteReworkSignature, reason string) bool {
+	switch strings.TrimSpace(reason) {
+	case "pull_request_hydrator_unavailable", "pull_request_hydration_failed", "pull_request_hydration_unavailable":
+		return false
+	}
+	if number == nil && signature.PRNumber == 0 {
+		return true
+	}
+	return implementProgressSignatureUsable(signature)
+}
+
+func dispatchLoopWorkspaceDiffEqual(left dispatchLoopFingerprint, right dispatchLoopFingerprint) bool {
+	return left.FilesChanged == right.FilesChanged &&
+		left.AddedLines == right.AddedLines &&
+		left.RemovedLines == right.RemovedLines &&
+		left.UnpushedCommits == right.UnpushedCommits &&
+		left.DiffFingerprint == right.DiffFingerprint &&
+		left.DiffStatus == right.DiffStatus
+}
+
+func implementProgressDiffStatsPresent(diff implementProgressDiffStats) bool {
+	return diff.FilesChanged != 0 || diff.AddedLines != 0 || diff.RemovedLines != 0 ||
+		diff.UnpushedCommits != 0 || strings.TrimSpace(diff.HeadSHA) != "" ||
+		strings.TrimSpace(diff.Fingerprint) != "" || strings.TrimSpace(diff.Status) != ""
 }
 
 func dispatchLoopFingerprintFromDecision(decision implementCompletionProgressDecision, lane string) dispatchLoopFingerprint {

--- a/internal/orchestrator/dispatch_loop_test.go
+++ b/internal/orchestrator/dispatch_loop_test.go
@@ -1,7 +1,9 @@
 package orchestrator
 
 import (
+	"encoding/json"
 	"errors"
+	"strings"
 	"testing"
 	"time"
 
@@ -14,8 +16,8 @@ import (
 func TestEvaluateDispatchLoopProgress(t *testing.T) {
 	t.Parallel()
 
-	clean := implementProgressDiffStats{Status: "clean"}
-	dirty := implementProgressDiffStats{FilesChanged: 1, AddedLines: 4, Fingerprint: "same-diff", Status: "changed"}
+	clean := implementProgressDiffStats{HeadSHA: "same-workspace-head", Status: "clean"}
+	dirty := implementProgressDiffStats{FilesChanged: 1, AddedLines: 4, HeadSHA: "same-workspace-head", Fingerprint: "same-diff", Status: "changed"}
 	signature := autoPromoteReworkSignature{PRNumber: 42, HeadSHA: "same-head"}
 	tests := []struct {
 		name            string
@@ -27,6 +29,7 @@ func TestEvaluateDispatchLoopProgress(t *testing.T) {
 		wantReason      string
 		wantBlockReason string
 		limit           int
+		omitStart       bool
 	}{
 		{
 			name: "successful terminal states count",
@@ -79,6 +82,13 @@ func TestEvaluateDispatchLoopProgress(t *testing.T) {
 			wantCount:  1,
 			wantReason: implementDependencyDeferralReason,
 			limit:      1,
+		},
+		{
+			name:       "missing dispatch start fails open",
+			running:    dispatchLoopRunning("Rework", DiffStats{Status: "clean"}),
+			decision:   dispatchLoopDecision("Rework", store.WorkAttemptTerminalSuccess, autoPromoteReworkSignature{}, DiffStats{Status: "clean"}),
+			omitStart:  true,
+			wantReason: implementDependencyDeferralReason,
 		},
 		{
 			name: "diff advancement resets",
@@ -154,6 +164,13 @@ func TestEvaluateDispatchLoopProgress(t *testing.T) {
 			if tt.limit > 0 {
 				tt.decision.NoProgressLimit = tt.limit
 			}
+			if !tt.omitStart {
+				tt.running.DispatchLoopStart = dispatchLoopTestStart(
+					tt.running.DispatchSourceState,
+					tt.decision.CurrentSignature,
+					implementProgressDiffStatsFromDiffStats(tt.decision.WorkspaceDiffStats),
+				)
+			}
 			orch := &Orchestrator{
 				cfg: Config{
 					Project:                 scheduler.ProjectCandidate{ID: "detent"},
@@ -168,6 +185,190 @@ func TestEvaluateDispatchLoopProgress(t *testing.T) {
 				t.Fatalf("evaluateDispatchLoopProgress() = count %d block %v reason %q block reason %q, want %d %v %q %q", got.ConsecutiveNoProgress, got.Block, got.Reason, got.BlockReason, tt.wantCount, tt.wantBlock, tt.wantReason, tt.wantBlockReason)
 			}
 		})
+	}
+}
+
+func TestEvaluateDispatchLoopProgressCreditsWithinAttemptProgress(t *testing.T) {
+	t.Parallel()
+
+	currentSignature := autoPromoteReworkSignature{PRNumber: 42, HeadSHA: "current-pr-head"}
+	currentDiff := implementProgressDiffStats{FilesChanged: 2, AddedLines: 8, HeadSHA: "current-workspace-head", Fingerprint: "current-diff", Status: "changed"}
+	baseStart := dispatchLoopTestStart("Rework", currentSignature, currentDiff)
+	tests := []struct {
+		name   string
+		mutate func(*dispatchLoopStartRecord)
+	}{
+		{name: "lane", mutate: func(start *dispatchLoopStartRecord) { start.Fingerprint.Lane = "todo" }},
+		{name: "workspace diff", mutate: func(start *dispatchLoopStartRecord) {
+			start.Fingerprint.FilesChanged = 0
+			start.Fingerprint.AddedLines = 0
+			start.Fingerprint.DiffFingerprint = ""
+			start.Fingerprint.DiffStatus = "clean"
+		}},
+		{name: "workspace head", mutate: func(start *dispatchLoopStartRecord) { start.Fingerprint.WorkspaceHead = "previous-workspace-head" }},
+		{name: "pull request head", mutate: func(start *dispatchLoopStartRecord) { start.Fingerprint.PRHeadSHA = "previous-pr-head" }},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			running := dispatchLoopRunning("Rework", DiffStats{
+				FilesChanged: 2,
+				AddedLines:   8,
+				HeadSHA:      "current-workspace-head",
+				Fingerprint:  "current-diff",
+				Status:       "changed",
+			})
+			running.DispatchLoopStart = baseStart
+			tt.mutate(&running.DispatchLoopStart)
+			decision := dispatchLoopDecision("Rework", store.WorkAttemptTerminalFailure, currentSignature, running.DiffStats)
+			orch := &Orchestrator{
+				cfg: Config{Project: scheduler.ProjectCandidate{ID: "detent"}},
+				workAttempts: &implementProgressAttemptStore{history: []store.WorkAttempt{
+					dispatchLoopHistoryAttempt(2, store.WorkAttemptTerminalFailure, currentSignature, currentDiff, nil, 2),
+					dispatchLoopHistoryAttempt(1, store.WorkAttemptTerminalFailure, currentSignature, currentDiff, nil, 1),
+				}},
+			}
+
+			got := orch.evaluateDispatchLoopProgress(t.Context(), running, decision)
+
+			if got.ConsecutiveNoProgress != 0 || got.Block || got.Reason != implementDependencyDeferralReason {
+				t.Fatalf("evaluateDispatchLoopProgress() = count %d block %v reason %q, want reset", got.ConsecutiveNoProgress, got.Block, got.Reason)
+			}
+		})
+	}
+}
+
+func TestEvaluateDispatchLoopProgressFailsOpenWithUnavailableCompletionEvidence(t *testing.T) {
+	t.Parallel()
+
+	running := dispatchLoopRunning("Rework", DiffStats{HeadSHA: "workspace-head", Status: "clean"})
+	running.DispatchLoopStart = dispatchLoopTestStart(
+		"Rework",
+		autoPromoteReworkSignature{},
+		implementProgressDiffStats{HeadSHA: "workspace-head", Status: "clean"},
+	)
+	decision := dispatchLoopDecision("Rework", store.WorkAttemptTerminalFailure, autoPromoteReworkSignature{}, DiffStats{Status: "clean"})
+	decision.WorkspaceDiffStats = DiffStats{}
+	orch := &Orchestrator{
+		cfg: Config{Project: scheduler.ProjectCandidate{ID: "detent"}},
+		workAttempts: &implementProgressAttemptStore{history: []store.WorkAttempt{
+			dispatchLoopHistoryAttempt(2, store.WorkAttemptTerminalFailure, autoPromoteReworkSignature{}, implementProgressDiffStats{HeadSHA: "workspace-head", Status: "clean"}, nil, 2),
+			dispatchLoopHistoryAttempt(1, store.WorkAttemptTerminalFailure, autoPromoteReworkSignature{}, implementProgressDiffStats{HeadSHA: "workspace-head", Status: "clean"}, nil, 1),
+		}},
+	}
+
+	got := orch.evaluateDispatchLoopProgress(t.Context(), running, decision)
+
+	if got.ConsecutiveNoProgress != 0 || got.Block {
+		t.Fatalf("evaluateDispatchLoopProgress() = count %d block %v, want fail-open reset", got.ConsecutiveNoProgress, got.Block)
+	}
+}
+
+func TestEvaluateDispatchLoopProgressLateFailureBreaksSequence(t *testing.T) {
+	t.Parallel()
+
+	currentSignature := autoPromoteReworkSignature{PRNumber: 42, HeadSHA: "pushed-head"}
+	currentDiff := implementProgressDiffStats{HeadSHA: "pushed-head", Status: "clean"}
+	lateProgress := dispatchLoopHistoryAttemptWithStart(
+		1,
+		store.WorkAttemptTerminalFailure,
+		dispatchLoopTestStart("Rework", autoPromoteReworkSignature{}, implementProgressDiffStats{HeadSHA: "base-head", Status: "clean"}),
+		currentSignature,
+		implementProgressDiffStats{},
+		0,
+	)
+	unchangedRetry := dispatchLoopHistoryAttempt(2, store.WorkAttemptTerminalFailure, currentSignature, currentDiff, nil, 1)
+	running := dispatchLoopRunning("Rework", DiffStats{HeadSHA: "pushed-head", Status: "clean"})
+	running.DispatchLoopStart = dispatchLoopTestStart("Rework", currentSignature, currentDiff)
+	decision := dispatchLoopDecision("Rework", store.WorkAttemptTerminalFailure, currentSignature, running.DiffStats)
+	orch := &Orchestrator{
+		cfg:          Config{Project: scheduler.ProjectCandidate{ID: "detent"}},
+		workAttempts: &implementProgressAttemptStore{history: []store.WorkAttempt{unchangedRetry, lateProgress}},
+	}
+
+	got := orch.evaluateDispatchLoopProgress(t.Context(), running, decision)
+
+	if got.ConsecutiveNoProgress != 2 || got.Block || got.Reason == dispatchLoopDetectedReason {
+		t.Fatalf("evaluateDispatchLoopProgress() = count %d block %v reason %q, want late progress to exclude attempt 1", got.ConsecutiveNoProgress, got.Block, got.Reason)
+	}
+}
+
+func TestDispatchLoopStartPersistence(t *testing.T) {
+	t.Parallel()
+
+	issue := implementProgressIssueWithoutPR()
+	start := newDispatchLoopStartRecord(issue, runpkg.RunModeImplement)
+	attempts := &implementProgressAttemptStore{}
+	orch := &Orchestrator{
+		cfg:          normalizeConfig(Config{Project: scheduler.ProjectCandidate{ID: "detent"}}),
+		workAttempts: attempts,
+	}
+	state := newState(orch.cfg)
+	if _, ok := orch.startDurableWorkAttempt(t.Context(), &state, issue, 1, time.Now(), "local", runpkg.RunModeImplement, start); !ok {
+		t.Fatal("startDurableWorkAttempt() = false")
+	}
+	if len(attempts.starts) != 1 {
+		t.Fatalf("starts = %d, want 1", len(attempts.starts))
+	}
+	persistedStart := dispatchLoopStartFromMetadata(t, attempts.starts[0].WorkerMetadataJSON)
+	if persistedStart.Captured || persistedStart.Persisted || !persistedStart.LaneAvailable || !persistedStart.PullRequestAvailable {
+		t.Fatalf("initial dispatch loop start = %#v, want durable pre-workspace baseline", persistedStart)
+	}
+
+	state.Running[issue.ID] = Running{
+		Issue:             issue,
+		WorkAttemptID:     1,
+		Mode:              runpkg.RunModeImplement,
+		DispatchLoopStart: start,
+	}
+	orch.handleRunUpdate(&state, runUpdate{
+		issueID: issue.ID,
+		usage: runpkg.UsageUpdate{DispatchLoopStart: &runpkg.DispatchLoopStartSnapshot{
+			WorkspaceDiffAvailable: true,
+			WorkspaceHeadAvailable: true,
+			DiffStats:              DiffStats{HeadSHA: "dispatch-head", Status: "clean"},
+		}},
+	})
+	if len(attempts.heartbeats) != 1 {
+		t.Fatalf("heartbeats = %d, want 1", len(attempts.heartbeats))
+	}
+	persistedStart = dispatchLoopStartFromMetadata(t, attempts.heartbeats[0].WorkerMetadataJSON)
+	if !persistedStart.Captured || !persistedStart.Persisted || persistedStart.Fingerprint.WorkspaceHead != "dispatch-head" {
+		t.Fatalf("heartbeat dispatch loop start = %#v, want complete persisted baseline", persistedStart)
+	}
+}
+
+func TestDispatchLoopStartPersistenceFailureFailsOpen(t *testing.T) {
+	t.Parallel()
+
+	issue := implementProgressIssueWithoutPR()
+	attempts := &implementProgressAttemptStore{heartbeatErr: errors.New("store unavailable")}
+	orch := &Orchestrator{workAttempts: attempts}
+	state := newState(Config{})
+	state.Running[issue.ID] = Running{
+		Issue:             issue,
+		WorkAttemptID:     1,
+		Mode:              runpkg.RunModeImplement,
+		DispatchLoopStart: newDispatchLoopStartRecord(issue, runpkg.RunModeImplement),
+	}
+
+	orch.handleRunUpdate(&state, runUpdate{
+		issueID: issue.ID,
+		usage: runpkg.UsageUpdate{DispatchLoopStart: &runpkg.DispatchLoopStartSnapshot{
+			WorkspaceDiffAvailable: true,
+			WorkspaceHeadAvailable: true,
+			DiffStats:              DiffStats{HeadSHA: "dispatch-head", Status: "clean"},
+		}},
+	})
+
+	if state.Running[issue.ID].DispatchLoopStart.Persisted {
+		t.Fatalf("dispatch loop start = %#v, want untrusted after persistence failure", state.Running[issue.ID].DispatchLoopStart)
+	}
+	decision := dispatchLoopDecision("In Progress", store.WorkAttemptTerminalFailure, autoPromoteReworkSignature{}, DiffStats{HeadSHA: "dispatch-head", Status: "clean"})
+	got := orch.evaluateDispatchLoopProgress(t.Context(), state.Running[issue.ID], decision)
+	if got.ConsecutiveNoProgress != 0 || got.Block {
+		t.Fatalf("evaluateDispatchLoopProgress() = count %d block %v, want persistence failure to fail open", got.ConsecutiveNoProgress, got.Block)
 	}
 }
 
@@ -199,7 +400,8 @@ func TestHandleRunResultTripsDispatchLoopAfterFailures(t *testing.T) {
 		Mode:                runpkg.RunModeImplement,
 		DispatchSourceState: "Rework",
 		StartedAt:           now.Add(-time.Minute),
-		DiffStats:           DiffStats{Status: "clean"},
+		DiffStats:           dispatchLoopTestRunnerDiff(DiffStats{Status: "clean"}),
+		DispatchLoopStart:   dispatchLoopTestStart("Rework", autoPromoteReworkSignature{}, implementProgressDiffStatsFromDiffStats(dispatchLoopTestRunnerDiff(DiffStats{Status: "clean"}))),
 	}
 	state.Claimed[issue.ID] = Claimed{Issue: issue, ClaimedAt: now.Add(-time.Minute)}
 
@@ -207,7 +409,7 @@ func TestHandleRunResultTripsDispatchLoopAfterFailures(t *testing.T) {
 		IssueID:     issue.ID,
 		CompletedAt: now,
 		Request:     runpkg.RunRequest{Mode: runpkg.RunModeImplement},
-		Result:      runpkg.RunResult{FinalState: runpkg.FinalStateFailed, DiffStats: DiffStats{Status: "clean"}},
+		Result:      runpkg.RunResult{FinalState: runpkg.FinalStateFailed, DiffStats: dispatchLoopTestRunnerDiff(DiffStats{Status: "clean"})},
 		Err:         errors.New("worker failed without progress"),
 	})
 
@@ -224,11 +426,12 @@ func TestHandleRunResultTripsDispatchLoopAfterFailures(t *testing.T) {
 
 func dispatchLoopRunning(lane string, diff DiffStats) Running {
 	issue := connector.Issue{ID: "issue-loop", Identifier: "digitaldrywood/detent#1886", State: lane}
-	return Running{Issue: issue, DispatchSourceState: lane, DiffStats: diff, Mode: runpkg.RunModeImplement}
+	return Running{Issue: issue, DispatchSourceState: lane, DiffStats: dispatchLoopTestRunnerDiff(diff), Mode: runpkg.RunModeImplement}
 }
 
 func dispatchLoopDecision(lane string, outcome store.WorkAttemptTerminalState, signature autoPromoteReworkSignature, diff DiffStats) implementCompletionProgressDecision {
 	issue := connector.Issue{ID: "issue-loop", Identifier: "digitaldrywood/detent#1886", State: lane}
+	diff = dispatchLoopTestRunnerDiff(diff)
 	return implementCompletionProgressDecision{
 		Issue:              issue,
 		Outcome:            outcome,
@@ -260,6 +463,9 @@ func dispatchLoopHistoryAttemptInLane(
 	count int,
 	lane string,
 ) store.WorkAttempt {
+	if strings.TrimSpace(diff.HeadSHA) == "" {
+		diff.HeadSHA = "same-workspace-head"
+	}
 	return store.WorkAttempt{
 		ID:            id,
 		ProjectID:     "detent",
@@ -271,6 +477,7 @@ func dispatchLoopHistoryAttemptInLane(
 		TerminalState: terminal,
 		CompletedAt:   time.Date(2026, 8, 18, 14, int(id), 0, 0, time.UTC),
 		WorkerMetadataJSON: marshalWorkAttemptJSON(map[string]any{
+			dispatchLoopStartMetadataKey: dispatchLoopTestStart(lane, signature, diff),
 			implementProgressMetadataKey: implementProgressRecord{
 				Outcome:               string(terminal),
 				Reason:                implementDependencyDeferralReason,
@@ -285,7 +492,32 @@ func dispatchLoopHistoryAttemptInLane(
 	}
 }
 
+func dispatchLoopHistoryAttemptWithStart(
+	id int64,
+	terminal store.WorkAttemptTerminalState,
+	start dispatchLoopStartRecord,
+	signature autoPromoteReworkSignature,
+	diff implementProgressDiffStats,
+	count int,
+) store.WorkAttempt {
+	attempt := dispatchLoopHistoryAttemptInLane(id, terminal, signature, diff, nil, count, start.Fingerprint.Lane)
+	attempt.WorkerMetadataJSON = marshalWorkAttemptJSON(map[string]any{
+		dispatchLoopStartMetadataKey: start,
+		implementProgressMetadataKey: implementProgressRecord{
+			Outcome:               string(terminal),
+			Reason:                "late_cleanup_failure",
+			CurrentSignature:      implementProgressSignatureRecordFromSignature(signature),
+			WorkspaceDiffStats:    diff,
+			TrackerState:          start.Fingerprint.Lane,
+			ConsecutiveNoProgress: count,
+			NoProgressLimit:       3,
+		},
+	})
+	return attempt
+}
+
 func dispatchLoopReportedPRUpdateAttempt(id int64) store.WorkAttempt {
+	diff := implementProgressDiffStats{HeadSHA: "same-workspace-head", Status: "clean"}
 	return store.WorkAttempt{
 		ID:            id,
 		ProjectID:     "detent",
@@ -297,12 +529,43 @@ func dispatchLoopReportedPRUpdateAttempt(id int64) store.WorkAttempt {
 		TerminalState: store.WorkAttemptTerminalSuccess,
 		CompletedAt:   time.Date(2026, 8, 18, 14, int(id), 0, 0, time.UTC),
 		WorkerMetadataJSON: marshalWorkAttemptJSON(map[string]any{
+			dispatchLoopStartMetadataKey: dispatchLoopTestStart("In Progress", autoPromoteReworkSignature{}, diff),
 			implementProgressMetadataKey: implementProgressRecord{
 				Outcome:            string(store.WorkAttemptTerminalSuccess),
 				Reason:             "pull_request_created_or_updated",
-				WorkspaceDiffStats: implementProgressDiffStats{Status: "clean"},
+				WorkspaceDiffStats: diff,
 				ProgressKinds:      []string{"pull_request"},
 			},
 		}),
 	}
+}
+
+func dispatchLoopTestRunnerDiff(diff DiffStats) DiffStats {
+	if strings.TrimSpace(diff.HeadSHA) == "" {
+		diff.HeadSHA = "same-workspace-head"
+	}
+	return diff
+}
+
+func dispatchLoopTestStart(lane string, signature autoPromoteReworkSignature, diff implementProgressDiffStats) dispatchLoopStartRecord {
+	return dispatchLoopStartRecord{
+		Fingerprint:            dispatchLoopFingerprintFromValues(lane, signature, diff),
+		Captured:               true,
+		Persisted:              true,
+		LaneAvailable:          true,
+		PullRequestAvailable:   true,
+		WorkspaceDiffAvailable: true,
+		WorkspaceHeadAvailable: strings.TrimSpace(diff.HeadSHA) != "",
+	}
+}
+
+func dispatchLoopStartFromMetadata(t *testing.T, metadata string) dispatchLoopStartRecord {
+	t.Helper()
+	var root struct {
+		DispatchLoopStart dispatchLoopStartRecord `json:"dispatch_loop_start"`
+	}
+	if err := json.Unmarshal([]byte(metadata), &root); err != nil {
+		t.Fatalf("unmarshal dispatch loop start metadata: %v", err)
+	}
+	return root.DispatchLoopStart
 }

--- a/internal/orchestrator/implement_progress.go
+++ b/internal/orchestrator/implement_progress.go
@@ -81,6 +81,7 @@ type implementProgressRecord struct {
 	RejectedBlockerRefs    []string                          `json:"rejected_blocker_refs,omitempty"`
 	ProgressKinds          []string                          `json:"progress_kinds,omitempty"`
 	CompletionKind         string                            `json:"completion_kind,omitempty"`
+	DispatchLoopStart      dispatchLoopStartRecord           `json:"-"`
 }
 
 type implementProgressArtifactSnapshot struct {
@@ -750,6 +751,7 @@ func implementProgressRecordFromAttempt(attempt store.WorkAttempt) (implementPro
 func implementProgressRecordFromAnyAttempt(attempt store.WorkAttempt) (implementProgressRecord, bool) {
 	var root struct {
 		CompletionProgress implementProgressRecord `json:"completion_progress"`
+		DispatchLoopStart  dispatchLoopStartRecord `json:"dispatch_loop_start"`
 	}
 	if err := json.Unmarshal([]byte(strings.TrimSpace(attempt.WorkerMetadataJSON)), &root); err != nil {
 		return implementProgressRecord{}, false
@@ -758,6 +760,7 @@ func implementProgressRecordFromAnyAttempt(attempt store.WorkAttempt) (implement
 	if strings.TrimSpace(record.Outcome) == "" {
 		return implementProgressRecord{}, false
 	}
+	record.DispatchLoopStart = root.DispatchLoopStart
 	return record, true
 }
 

--- a/internal/orchestrator/implement_progress_test.go
+++ b/internal/orchestrator/implement_progress_test.go
@@ -355,7 +355,7 @@ func TestHandleRunResultClassifiesImplementWorkerProgress(t *testing.T) {
 			wantRetry:         true,
 		},
 		{
-			name:         "July telemetry replay trips third clean completion without linked PR",
+			name:         "legacy telemetry replay fails open without dispatch start evidence",
 			runningIssue: implementProgressIssueWithoutPR(),
 			history: []store.WorkAttempt{
 				implementProgressLegacyNoPRHistoryAttempt(2),
@@ -364,11 +364,9 @@ func TestHandleRunResultClassifiesImplementWorkerProgress(t *testing.T) {
 			diffStats:       DiffStats{Status: "clean"},
 			noProgressLimit: 3,
 			wantTerminal:    store.WorkAttemptTerminalNoProgress,
-			wantReason:      dispatchLoopDetectedReason,
-			wantConsecutive: 3,
-			wantBlocked:     true,
-			wantBlockReason: dispatchLoopDetectedReason,
-			wantComment:     "consecutive_no_progress_attempts: 3",
+			wantReason:      "completed_clean_diff_without_pull_request",
+			wantConsecutive: 0,
+			wantRetry:       true,
 		},
 		{
 			name:         "identical non-empty diff trips third completion without linked PR",
@@ -441,7 +439,7 @@ func TestHandleRunResultClassifiesImplementWorkerProgress(t *testing.T) {
 			wantTerminal:       store.WorkAttemptTerminalSuccess,
 			wantReason:         "verifiable_non_diff_progress",
 			wantProgressKinds:  []string{"audit_artifact"},
-			wantConsecutive:    2,
+			wantConsecutive:    0,
 			wantRetry:          true,
 			runningWorkpadBody: implementProgressStructuredWorkpad("in_progress", "", nil),
 			currentWorkpadBody: implementProgressStructuredWorkpad("in_progress", "", map[string]string{"duplicate_active_email_groups": "23"}),
@@ -454,7 +452,7 @@ func TestHandleRunResultClassifiesImplementWorkerProgress(t *testing.T) {
 			noProgressLimit:    3,
 			wantTerminal:       store.WorkAttemptTerminalNoProgress,
 			wantReason:         "completed_clean_diff_without_pull_request",
-			wantConsecutive:    2,
+			wantConsecutive:    0,
 			wantRetry:          true,
 			runningWorkpadBody: implementProgressStructuredWorkpad("in_progress", "baseline prose", nil),
 			currentWorkpadBody: implementProgressStructuredWorkpad("in_progress", "expanded prose without a machine artifact", nil),
@@ -567,6 +565,18 @@ func TestHandleRunResultClassifiesImplementWorkerProgress(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
+			if diffStatsPresent(tt.diffStats) && tt.wantReason != workspaceHeadUnavailableReason && strings.TrimSpace(tt.diffStats.HeadSHA) == "" {
+				tt.diffStats.HeadSHA = "same-workspace-head"
+			}
+			dispatchStartDiff := tt.diffStats
+			if slices.Contains(tt.wantProgressKinds, "workspace_diff") {
+				dispatchStartDiff.FilesChanged = 0
+				dispatchStartDiff.AddedLines = 0
+				dispatchStartDiff.RemovedLines = 0
+				dispatchStartDiff.UnpushedCommits = 0
+				dispatchStartDiff.Fingerprint = ""
+				dispatchStartDiff.Status = "clean"
+			}
 
 			if tt.runningWorkpadBody != "" {
 				tt.runningIssue.Comments = []connector.IssueComment{{Body: tt.runningWorkpadBody, URL: "https://github.test/workpad"}}
@@ -614,6 +624,11 @@ func TestHandleRunResultClassifiesImplementWorkerProgress(t *testing.T) {
 				StartedAt:        base.Add(-time.Minute),
 				DiffStats:        tt.diffStats,
 				DispatchProgress: implementProgressArtifactSnapshotFromIssue(tt.runningIssue, true),
+				DispatchLoopStart: dispatchLoopTestStart(
+					tt.runningIssue.State,
+					autoPromoteReworkSignatureFromIssue(tt.runningIssue, AutoPromoteSummaryFromIssue(tt.runningIssue)),
+					implementProgressDiffStatsFromDiffStats(dispatchStartDiff),
+				),
 			}
 			state.Running[tt.runningIssue.ID] = running
 			state.Claimed[tt.runningIssue.ID] = Claimed{Issue: tt.runningIssue, ClaimedAt: running.StartedAt}
@@ -2034,6 +2049,7 @@ func implementProgressStructuredWorkpad(status string, prose string, fields map[
 }
 
 func implementProgressHistoryAttempt(id int64, signature autoPromoteReworkSignature, terminal store.WorkAttemptTerminalState) store.WorkAttempt {
+	diff := implementProgressDiffStats{HeadSHA: "same-workspace-head", Status: "clean"}
 	return store.WorkAttempt{
 		ID:                 id,
 		ProjectID:          "detent",
@@ -2041,10 +2057,11 @@ func implementProgressHistoryAttempt(id int64, signature autoPromoteReworkSignat
 		Identifier:         "digitaldrywood/detent#1070",
 		IssueURL:           "https://github.test/digitaldrywood/detent/issues/1070",
 		WorkerType:         "agent",
+		Lane:               "In Progress",
 		Status:             store.WorkAttemptStatusTerminal,
 		TerminalState:      terminal,
 		CompletedAt:        time.Date(2026, 7, 8, 15, int(id), 0, 0, time.UTC),
-		WorkerMetadataJSON: implementProgressMetadataJSON(signature, terminal),
+		WorkerMetadataJSON: implementProgressMetadataJSONWithDiff(signature, diff, terminal),
 	}
 }
 
@@ -2071,6 +2088,7 @@ func implementProgressLegacyNoPRHistoryAttempt(id int64) store.WorkAttempt {
 }
 
 func implementProgressDependencyDeferralHistoryAttempt(id int64, identifier string, state string) store.WorkAttempt {
+	diff := implementProgressDiffStats{HeadSHA: "same-workspace-head", Status: "clean"}
 	return store.WorkAttempt{
 		ID:            id,
 		ProjectID:     "detent",
@@ -2078,17 +2096,20 @@ func implementProgressDependencyDeferralHistoryAttempt(id int64, identifier stri
 		Identifier:    "digitaldrywood/detent#1200",
 		IssueURL:      "https://github.test/digitaldrywood/detent/issues/1200",
 		WorkerType:    "agent",
+		Lane:          "In Progress",
 		Status:        store.WorkAttemptStatusTerminal,
 		TerminalState: store.WorkAttemptTerminalSuccess,
 		CompletedAt:   time.Date(2026, 8, 8, 18, int(id), 0, 0, time.UTC),
 		WorkerMetadataJSON: marshalWorkAttemptJSON(map[string]any{
-			"run_mode": runpkg.RunModeImplement,
+			"run_mode":                   runpkg.RunModeImplement,
+			dispatchLoopStartMetadataKey: dispatchLoopTestStart("In Progress", autoPromoteReworkSignature{}, diff),
 			implementProgressMetadataKey: implementProgressRecord{
 				Outcome:            string(store.WorkAttemptTerminalSuccess),
 				Reason:             implementDependencyDeferralReason,
 				DependencyDeferral: true,
 				DependencyBlockers: []implementDependencyBlocker{{ID: "blocker", Identifier: identifier, State: state}},
-				WorkspaceDiffStats: implementProgressDiffStats{Status: "clean"},
+				WorkspaceDiffStats: diff,
+				TrackerState:       "In Progress",
 			},
 		}),
 	}
@@ -2099,6 +2120,11 @@ func implementProgressNoPRHistoryAttempt(id int64, diffStats DiffStats, humanAct
 	if strings.TrimSpace(humanAction) != "" {
 		workpadStatus = "blocked"
 	}
+	diffStats = dispatchLoopTestRunnerDiff(diffStats)
+	lane := strings.TrimSpace(trackerState)
+	if lane == "" {
+		lane = "In Progress"
+	}
 	return store.WorkAttempt{
 		ID:            id,
 		ProjectID:     "detent",
@@ -2106,18 +2132,20 @@ func implementProgressNoPRHistoryAttempt(id int64, diffStats DiffStats, humanAct
 		Identifier:    "digitaldrywood/detent#1200",
 		IssueURL:      "https://github.test/digitaldrywood/detent/issues/1200",
 		WorkerType:    "agent",
+		Lane:          lane,
 		Status:        store.WorkAttemptStatusTerminal,
 		TerminalState: store.WorkAttemptTerminalSuccess,
 		CompletedAt:   time.Date(2026, 7, 11, 12, int(id), 0, 0, time.UTC),
 		WorkerMetadataJSON: marshalWorkAttemptJSON(map[string]any{
-			"run_mode": runpkg.RunModeImplement,
+			"run_mode":                   runpkg.RunModeImplement,
+			dispatchLoopStartMetadataKey: dispatchLoopTestStart(lane, autoPromoteReworkSignature{}, implementProgressDiffStatsFromDiffStats(diffStats)),
 			implementProgressMetadataKey: map[string]any{
 				"outcome":            string(store.WorkAttemptTerminalSuccess),
 				"reason":             "workspace_diff_present_without_pull_request",
 				"workspace_diffstat": implementProgressDiffStatsFromDiffStats(diffStats),
 				"workpad_status":     workpadStatus,
 				"human_action":       humanAction,
-				"tracker_state":      trackerState,
+				"tracker_state":      lane,
 			},
 		}),
 	}
@@ -2148,13 +2176,24 @@ func implementProgressStrandedHistoryAttempt(id int64, signature autoPromoteRewo
 }
 
 func implementProgressMetadataJSON(signature autoPromoteReworkSignature, terminal store.WorkAttemptTerminalState) string {
+	return implementProgressMetadataJSONWithDiff(
+		signature,
+		implementProgressDiffStats{HeadSHA: "same-workspace-head", Status: "clean"},
+		terminal,
+	)
+}
+
+func implementProgressMetadataJSONWithDiff(signature autoPromoteReworkSignature, diff implementProgressDiffStats, terminal store.WorkAttemptTerminalState) string {
 	return marshalWorkAttemptJSON(map[string]any{
-		"run_mode": runpkg.RunModeImplement,
+		"run_mode":                   runpkg.RunModeImplement,
+		dispatchLoopStartMetadataKey: dispatchLoopTestStart("In Progress", signature, diff),
 		implementProgressMetadataKey: implementProgressRecord{
-			Outcome:          string(terminal),
-			Reason:           "test_history",
-			CurrentSignature: implementProgressSignatureRecordFromSignature(signature),
-			CurrentHeadSHA:   signature.HeadSHA,
+			Outcome:            string(terminal),
+			Reason:             "test_history",
+			CurrentSignature:   implementProgressSignatureRecordFromSignature(signature),
+			CurrentHeadSHA:     signature.HeadSHA,
+			WorkspaceDiffStats: diff,
+			TrackerState:       "In Progress",
 		},
 	})
 }
@@ -2289,12 +2328,16 @@ type implementProgressAttemptStore struct {
 	history       []store.WorkAttempt
 	historyErr    error
 	completionErr error
+	heartbeatErr  error
 	completions   []store.WorkAttemptCompletion
+	starts        []store.WorkAttemptStart
+	heartbeats    []store.WorkAttemptHeartbeat
 	historyCalls  int
 	queries       []store.WorkAttemptHistoryQuery
 }
 
-func (s *implementProgressAttemptStore) StartWorkAttempt(context.Context, store.WorkAttemptStart) (int64, error) {
+func (s *implementProgressAttemptStore) StartWorkAttempt(_ context.Context, attrs store.WorkAttemptStart) (int64, error) {
+	s.starts = append(s.starts, attrs)
 	return 1, nil
 }
 
@@ -2302,8 +2345,9 @@ func (s *implementProgressAttemptStore) WorkAttempt(context.Context, int64) (sto
 	return store.WorkAttempt{}, store.ErrNotFound
 }
 
-func (s *implementProgressAttemptStore) RecordWorkAttemptHeartbeat(context.Context, store.WorkAttemptHeartbeat) error {
-	return nil
+func (s *implementProgressAttemptStore) RecordWorkAttemptHeartbeat(_ context.Context, attrs store.WorkAttemptHeartbeat) error {
+	s.heartbeats = append(s.heartbeats, attrs)
+	return s.heartbeatErr
 }
 
 func (s *implementProgressAttemptStore) CompleteWorkAttempt(_ context.Context, attrs store.WorkAttemptCompletion) error {

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -365,6 +365,7 @@ type configUpdateRequest struct {
 type runUpdate struct {
 	issueID string
 	usage   runpkg.UsageUpdate
+	applied chan struct{}
 }
 
 type capacityClearRequest struct {
@@ -771,6 +772,9 @@ func (o *Orchestrator) Run(ctx context.Context) error {
 			o.handleRunResult(ctx, &state, result)
 		case update := <-o.runUpdates:
 			o.handleRunUpdate(&state, update)
+			if update.applied != nil {
+				close(update.applied)
+			}
 		case result := <-heartbeatResults:
 			o.handleHeartbeatResult(&state, result)
 		case event := <-o.validatorCapacityEvents:

--- a/internal/orchestrator/run_completion.go
+++ b/internal/orchestrator/run_completion.go
@@ -36,6 +36,9 @@ func (o *Orchestrator) handleRunUpdate(state *State, event runUpdate) {
 	if !ok {
 		return
 	}
+	if event.usage.DispatchLoopStart != nil {
+		running.DispatchLoopStart = dispatchLoopStartRecordFromSnapshot(running, *event.usage.DispatchLoopStart)
+	}
 
 	if event.usage.SessionID != "" {
 		running.SessionID = event.usage.SessionID
@@ -108,6 +111,10 @@ func (o *Orchestrator) handleRunUpdate(state *State, event runUpdate) {
 		}
 		heartbeat := o.runningWorkAttemptHeartbeat(state, running, now)
 		if err := o.workAttempts.RecordWorkAttemptHeartbeat(context.Background(), heartbeat); err != nil {
+			if event.usage.DispatchLoopStart != nil {
+				running.DispatchLoopStart.Persisted = false
+				state.Running[event.issueID] = running
+			}
 			if o.logger != nil {
 				o.logger.Warn("work attempt usage heartbeat failed", "attempt_id", running.WorkAttemptID, "issue_id", event.issueID, "error", err)
 			}

--- a/internal/orchestrator/run_update_test.go
+++ b/internal/orchestrator/run_update_test.go
@@ -84,6 +84,32 @@ func TestUsageUpdateHandlerDeliversWorkerGitHubActor(t *testing.T) {
 	}
 }
 
+func TestUsageUpdateHandlerWaitsForDispatchLoopStartApplication(t *testing.T) {
+	t.Parallel()
+
+	orch := &Orchestrator{runUpdates: make(chan runUpdate, 1)}
+	done := make(chan error, 1)
+	go func() {
+		done <- orch.usageUpdateHandler(t.Context(), "issue-2084", nil)(runpkg.UsageUpdate{
+			DispatchLoopStart: &runpkg.DispatchLoopStartSnapshot{WorkspaceDiffAvailable: true},
+		})
+	}()
+
+	update := <-orch.runUpdates
+	if update.applied == nil || update.usage.DispatchLoopStart == nil {
+		t.Fatalf("run update = %#v, want acknowledged dispatch loop start", update)
+	}
+	select {
+	case err := <-done:
+		t.Fatalf("usage update returned before application acknowledgment: %v", err)
+	default:
+	}
+	close(update.applied)
+	if err := <-done; err != nil {
+		t.Fatalf("usage update error = %v", err)
+	}
+}
+
 func TestUsageUpdateHandlerReturnsCanceledContext(t *testing.T) {
 	t.Parallel()
 

--- a/internal/orchestrator/state.go
+++ b/internal/orchestrator/state.go
@@ -137,6 +137,7 @@ type Running struct {
 	DispatchArtifactStatus      string
 	ArtifactStatusField         string
 	DeliverableKind             string
+	DispatchLoopStart           dispatchLoopStartRecord
 	StartedAt                   time.Time
 	WorkerHost                  string
 	ProcessIdentity             string

--- a/internal/orchestrator/work_attempts.go
+++ b/internal/orchestrator/work_attempts.go
@@ -311,9 +311,14 @@ func (o *Orchestrator) startDurableWorkAttempt(
 	now time.Time,
 	workerHost string,
 	runMode string,
+	dispatchLoopStart dispatchLoopStartRecord,
 ) (int64, bool) {
 	if o == nil || o.workAttempts == nil {
 		return 0, true
+	}
+	metadata := map[string]any{"run_mode": strings.TrimSpace(runMode)}
+	if strings.TrimSpace(runMode) == runpkg.RunModeImplement {
+		metadata[dispatchLoopStartMetadataKey] = dispatchLoopStart
 	}
 	start := store.WorkAttemptStart{
 		ProjectID:              strings.TrimSpace(o.cfg.Project.ID),
@@ -332,7 +337,7 @@ func (o *Orchestrator) startDurableWorkAttempt(
 		StatusMessage:          "worker lease acquired",
 		GitHubRateSnapshotJSON: o.githubRateSnapshotJSON(state),
 		CapacitySnapshotJSON:   o.capacitySnapshotJSON(state, issue),
-		WorkerMetadataJSON:     marshalWorkAttemptJSON(map[string]any{"run_mode": strings.TrimSpace(runMode)}),
+		WorkerMetadataJSON:     marshalWorkAttemptJSON(metadata),
 		MetricsJSON:            "{}",
 		NextAction:             "start worker",
 	}
@@ -1048,6 +1053,9 @@ func runningWorkAttemptMetadataJSON(running Running, metadata map[string]any) st
 		"run_mode":            strings.TrimSpace(running.Mode),
 		"issue_title":         strings.TrimSpace(running.Issue.Title),
 		"work_product_pushed": running.WorkProductPushed,
+	}
+	if strings.TrimSpace(running.Mode) == runpkg.RunModeImplement {
+		out[dispatchLoopStartMetadataKey] = running.DispatchLoopStart
 	}
 	for key, value := range metadata {
 		key = strings.TrimSpace(key)

--- a/internal/runner/agent.go
+++ b/internal/runner/agent.go
@@ -1430,6 +1430,7 @@ func (r *Runner) Run(ctx context.Context, req RunRequest) (RunResult, error) {
 		if workflow.Config.Deliverable.Kind == config.DeliverableArtifact {
 			initialArtifactEvidence = r.observeWorkspaceArtifactEvidence(runWorkspace, ctx, info, workspaceIssue, "initial")
 		}
+		r.publishDispatchLoopStart(req, recoveryState)
 		targetRefObserver = func(observerCtx context.Context) *DeliverableTargetRefEvidence {
 			postCommand := r.observeWorkspaceDeliverableState(runWorkspace, observerCtx, info, workspaceIssue, "post_command")
 			return deliverableTargetRefEvidence(info.Branch, initialDeliverableState, postCommand)
@@ -2444,6 +2445,23 @@ func artifactProgressEvidence(initial, current workspaceArtifactEvidenceObservat
 	}
 	evidence.Warning = strings.Join(warnings, "; ")
 	return evidence
+}
+
+func (r *Runner) publishDispatchLoopStart(req RunRequest, recovery *workspace.RecoveryState) {
+	if req.OnUsageUpdate == nil {
+		return
+	}
+	snapshot := DispatchLoopStartSnapshot{}
+	if recovery != nil {
+		snapshot.WorkspaceDiffAvailable = true
+		snapshot.WorkspaceHeadAvailable = strings.TrimSpace(recovery.HeadSHA) != ""
+		snapshot.DiffStats = diffStatsFromWorkspace(recovery.DiffStat)
+		snapshot.DiffStats.UnpushedCommits = recovery.UnpushedCommits
+		snapshot.DiffStats.HeadSHA = strings.TrimSpace(recovery.HeadSHA)
+	}
+	if err := req.OnUsageUpdate(UsageUpdate{DispatchLoopStart: &snapshot}); err != nil && r.logger != nil {
+		r.logger.Warn("dispatch loop start snapshot publish failed", "issue_id", req.Issue.ID, "identifier", req.Issue.Identifier, "error", err)
+	}
 }
 
 func (r *Runner) workspaceDeliverableState(

--- a/internal/runner/runner_test.go
+++ b/internal/runner/runner_test.go
@@ -277,13 +277,16 @@ func TestRunnerRunPreparesWorkspaceRunsCodexAndRecordsSession(t *testing.T) {
 	if result.Tokens.ModelContextWindow == nil || *result.Tokens.ModelContextWindow != modelContextWindow {
 		t.Fatalf("RunResult ModelContextWindow = %#v, want %d", result.Tokens.ModelContextWindow, modelContextWindow)
 	}
-	if len(usageUpdates) != 5 {
-		t.Fatalf("usage updates len = %d, want workspace start plus 4 agent updates", len(usageUpdates))
+	if len(usageUpdates) != 6 {
+		t.Fatalf("usage updates len = %d, want workspace start, dispatch baseline, plus 4 agent updates", len(usageUpdates))
 	}
 	if usageUpdates[0].LastEvent != "workspace_create_started" || !usageUpdates[0].LastEventAt.Equal(startedAt) {
 		t.Fatalf("workspace usage update = %#v, want startup progress", usageUpdates[0])
 	}
-	usageUpdates = usageUpdates[1:]
+	if usageUpdates[1].DispatchLoopStart == nil || !usageUpdates[1].DispatchLoopStart.WorkspaceDiffAvailable {
+		t.Fatalf("dispatch loop start update = %#v, want available workspace baseline", usageUpdates[1])
+	}
+	usageUpdates = usageUpdates[2:]
 	if usageUpdates[0].DetentSessionID != 42 || usageUpdates[0].LastEvent != string(AgentUpdateRuntimeIdentity) {
 		t.Fatalf("initial usage update = %#v, want configured route identity", usageUpdates[0])
 	}
@@ -3037,8 +3040,8 @@ func TestRunnerRunKillsSessionAtTokenCeilingAndRecordsLesson(t *testing.T) {
 	if sessionStore.phase.Status != FinalStateTokenCeilingExceeded || sessionStore.phase.TotalTokens != 120 {
 		t.Fatalf("WorkflowPhaseEvent = %#v, want token ceiling status and 120 tokens", sessionStore.phase)
 	}
-	if len(usageUpdates) != 4 {
-		t.Fatalf("usage update count = %d, want workspace start, configured identity, and 2 token updates", len(usageUpdates))
+	if len(usageUpdates) != 5 {
+		t.Fatalf("usage update count = %d, want workspace start, dispatch baseline, configured identity, and 2 token updates", len(usageUpdates))
 	}
 	if got := usageUpdates[len(usageUpdates)-1].Tokens.TotalTokens; got != 120 {
 		t.Fatalf("last live usage total tokens = %d, want ceiling-crossing 120", got)

--- a/internal/runner/types.go
+++ b/internal/runner/types.go
@@ -746,6 +746,13 @@ type UsageUpdate struct {
 	RSSBytes              uint64
 	RSSCeilingBytes       uint64
 	RSSObservedAt         time.Time
+	DispatchLoopStart     *DispatchLoopStartSnapshot
+}
+
+type DispatchLoopStartSnapshot struct {
+	WorkspaceDiffAvailable bool
+	WorkspaceHeadAvailable bool
+	DiffStats              DiffStats
 }
 
 type BudgetRefusal struct {


### PR DESCRIPTION
## Summary

- persist a complete dispatch-start loop fingerprint before the agent turn
- credit verified lane, workspace diff/head, and PR-head movement within failed or successful attempts
- fail open when capture, persistence, or comparison evidence is unavailable
- cover the commit/push plus late-cleanup-failure regression sequence

Fixes #2084

## UI Surface Contract

- [x] N/A; this change has no UI surface or layout impact.
- [x] This PR does not add persistent top-of-screen messaging.
- [x] This PR has no visual changes to primary operator screens.

## Test Plan

- [x] `go test ./internal/orchestrator ./internal/runner`
- [x] `go test ./internal/orchestrator -run '^$' -fuzz=. -fuzztime=30s`
- [x] `make check`