### PR TITLE
test(orchestrator): make refresh failure deterministic

### DIFF
--- a/internal/orchestrator/orchestrator_test.go
+++ b/internal/orchestrator/orchestrator_test.go
@@ -2459,7 +2459,7 @@ func TestRequestRefreshPublishesFailureWhileDegradedPersists(t *testing.T) {
 	}
 	waitForFetchCalls(t, tracker, 2)
 
-	state := waitForState(t, orch, func(state orchestrator.State) bool {
+	state := waitForStateWithin(t, orch, slowCIIntegrationWaitTimeout, func(state orchestrator.State) bool {
 		snapshot := state.Snapshot(time.Now())
 		return snapshot.Refresh.Manual != nil &&
 			snapshot.Refresh.Manual.ID == refresh.RequestID &&


### PR DESCRIPTION
## Summary

- wait for the matching failed manual-refresh publication with the slow-CI deadlock guard
- preserve production retry timing and degraded-state assertions

Fixes #2078

## UI Surface Contract

- [x] N/A, or the linked issue explicitly authorizes any high-impact UI surface, layout, density, first-viewport, or responsive visibility tradeoff.
- [x] Persistent top-of-screen messaging is explicitly authorized by the issue, or this PR does not add it.
- [x] Visual changes to primary operator screens include screenshot or browser verification below.

No UI changes.

## Test Plan

- [x] `go test -race ./internal/orchestrator -run "^TestRequestRefreshPublishesFailureWhileDegradedPersists$" -count=10`
- [x] `go test -race -count=10 ./internal/orchestrator`
- [x] `make check`