### PR TITLE
fix(orchestrator): classify stranded work

### DIFF
--- a/internal/orchestrator/blocked_cause_recovery.go
+++ b/internal/orchestrator/blocked_cause_recovery.go
@@ -37,25 +37,29 @@ const (
 )
 
 type blockedCauseSignals struct {
-	ConfigFingerprint    string            `json:"config_fingerprint,omitempty"`
-	ToolingFingerprint   string            `json:"tooling_fingerprint,omitempty"`
-	BaseFingerprint      string            `json:"base_fingerprint,omitempty"`
-	WorkspaceHeadSHA     string            `json:"workspace_head_sha,omitempty"`
-	WorkspaceFingerprint string            `json:"workspace_fingerprint,omitempty"`
-	WorkspaceStatus      string            `json:"workspace_status,omitempty"`
-	WorkspacePresent     bool              `json:"workspace_present,omitempty"`
-	WorkspaceFiles       int               `json:"workspace_files,omitempty"`
-	UnpushedCommits      int               `json:"unpushed_commits,omitempty"`
-	Health               string            `json:"health,omitempty"`
-	Description          string            `json:"description,omitempty"`
-	ModelOverride        string            `json:"model_override,omitempty"`
-	Labels               []string          `json:"labels,omitempty"`
-	Workpad              *workpad.Signal   `json:"workpad,omitempty"`
-	Fields               map[string]string `json:"fields,omitempty"`
-	PRNumber             int               `json:"pr_number,omitempty"`
-	PRHeadSHA            string            `json:"pr_head_sha,omitempty"`
-	PRBaseSHA            string            `json:"pr_base_sha,omitempty"`
-	PRDiffFingerprint    string            `json:"pr_diff_fingerprint,omitempty"`
+	ConfigFingerprint              string            `json:"config_fingerprint,omitempty"`
+	ToolingFingerprint             string            `json:"tooling_fingerprint,omitempty"`
+	BaseFingerprint                string            `json:"base_fingerprint,omitempty"`
+	WorkspaceHeadSHA               string            `json:"workspace_head_sha,omitempty"`
+	WorkspaceFingerprint           string            `json:"workspace_fingerprint,omitempty"`
+	WorkspaceStatus                string            `json:"workspace_status,omitempty"`
+	WorkspacePresent               bool              `json:"workspace_present,omitempty"`
+	WorkspaceFiles                 int               `json:"workspace_files,omitempty"`
+	UnpushedCommits                int               `json:"unpushed_commits,omitempty"`
+	UnpushedCommitRefs             []string          `json:"unpushed_commit_refs,omitempty"`
+	TrackedPaths                   []string          `json:"tracked_paths,omitempty"`
+	CommitsNotInPullRequest        []string          `json:"commits_not_in_pull_request,omitempty"`
+	PullRequestComparisonAvailable bool              `json:"pull_request_comparison_available,omitempty"`
+	Health                         string            `json:"health,omitempty"`
+	Description                    string            `json:"description,omitempty"`
+	ModelOverride                  string            `json:"model_override,omitempty"`
+	Labels                         []string          `json:"labels,omitempty"`
+	Workpad                        *workpad.Signal   `json:"workpad,omitempty"`
+	Fields                         map[string]string `json:"fields,omitempty"`
+	PRNumber                       int               `json:"pr_number,omitempty"`
+	PRHeadSHA                      string            `json:"pr_head_sha,omitempty"`
+	PRBaseSHA                      string            `json:"pr_base_sha,omitempty"`
+	PRDiffFingerprint              string            `json:"pr_diff_fingerprint,omitempty"`
 }
 
 type blockedCauseIdentity struct {
@@ -134,24 +138,32 @@ func (o *Orchestrator) blockedCauseSignals(
 		}
 		snapshot.UnpushedCommits = fallback.UnpushedCommits
 		snapshot.WorkspaceFiles = fallback.FilesChanged
+		snapshot.UnpushedCommitRefs = append([]string(nil), fallback.UnpushedCommitRefs...)
+		snapshot.TrackedPaths = append([]string(nil), fallback.TrackedPaths...)
+		snapshot.CommitsNotInPullRequest = append([]string(nil), fallback.CommitsNotInPullRequest...)
+		snapshot.PullRequestComparisonAvailable = fallback.PullRequestComparisonAvailable
 		snapshot.WorkspaceStatus = "present"
 	}
 	signals := blockedCauseSignals{
-		ConfigFingerprint:    strings.TrimSpace(snapshot.ConfigFingerprint),
-		ToolingFingerprint:   strings.TrimSpace(snapshot.ToolingFingerprint),
-		BaseFingerprint:      strings.TrimSpace(snapshot.BaseFingerprint),
-		WorkspaceHeadSHA:     strings.TrimSpace(snapshot.HeadSHA),
-		WorkspaceFingerprint: strings.TrimSpace(snapshot.WorkspaceFingerprint),
-		WorkspaceStatus:      strings.TrimSpace(snapshot.WorkspaceStatus),
-		WorkspacePresent:     snapshot.WorkspacePresent,
-		WorkspaceFiles:       snapshot.WorkspaceFiles,
-		UnpushedCommits:      snapshot.UnpushedCommits,
-		Health:               strings.TrimSpace(snapshot.Health),
-		Description:          strings.TrimSpace(issue.Description),
-		ModelOverride:        strings.TrimSpace(issue.ModelOverride),
-		Labels:               blockedCauseLabels(issue.Labels, o.cfg.StatusLabelPrefix),
-		Workpad:              blockedCauseWorkpadSignal(issue.WorkpadSignal),
-		Fields:               blockedCauseFields(issue.Fields),
+		ConfigFingerprint:              strings.TrimSpace(snapshot.ConfigFingerprint),
+		ToolingFingerprint:             strings.TrimSpace(snapshot.ToolingFingerprint),
+		BaseFingerprint:                strings.TrimSpace(snapshot.BaseFingerprint),
+		WorkspaceHeadSHA:               strings.TrimSpace(snapshot.HeadSHA),
+		WorkspaceFingerprint:           strings.TrimSpace(snapshot.WorkspaceFingerprint),
+		WorkspaceStatus:                strings.TrimSpace(snapshot.WorkspaceStatus),
+		WorkspacePresent:               snapshot.WorkspacePresent,
+		WorkspaceFiles:                 snapshot.WorkspaceFiles,
+		UnpushedCommits:                snapshot.UnpushedCommits,
+		UnpushedCommitRefs:             append([]string(nil), snapshot.UnpushedCommitRefs...),
+		TrackedPaths:                   append([]string(nil), snapshot.TrackedPaths...),
+		CommitsNotInPullRequest:        append([]string(nil), snapshot.CommitsNotInPullRequest...),
+		PullRequestComparisonAvailable: snapshot.PullRequestComparisonAvailable,
+		Health:                         strings.TrimSpace(snapshot.Health),
+		Description:                    strings.TrimSpace(issue.Description),
+		ModelOverride:                  strings.TrimSpace(issue.ModelOverride),
+		Labels:                         blockedCauseLabels(issue.Labels, o.cfg.StatusLabelPrefix),
+		Workpad:                        blockedCauseWorkpadSignal(issue.WorkpadSignal),
+		Fields:                         blockedCauseFields(issue.Fields),
 	}
 	if issue.PRNumber != nil {
 		signals.PRNumber = *issue.PRNumber
@@ -807,10 +819,14 @@ func (o *Orchestrator) blockedReadyPullRequestDeferredReason(
 	if !signals.WorkspacePresent || strings.TrimSpace(signals.WorkspaceStatus) != "present" || strings.TrimSpace(signals.WorkspaceHeadSHA) == "" {
 		return "workspace_head_unavailable"
 	}
-	if signals.WorkspaceFiles > 0 {
-		return "workspace_diff_present"
+	if len(signals.TrackedPaths) > 0 {
+		return "workspace_tracked_changes_present"
 	}
-	if strings.TrimSpace(signals.WorkspaceHeadSHA) != strings.TrimSpace(pullRequest.HeadSHA) {
+	if signals.PullRequestComparisonAvailable {
+		if len(signals.CommitsNotInPullRequest) > 0 {
+			return "workspace_commits_not_in_pull_request"
+		}
+	} else if signals.UnpushedCommits > 0 && strings.TrimSpace(signals.WorkspaceHeadSHA) != strings.TrimSpace(pullRequest.HeadSHA) {
 		return "workspace_pull_request_head_mismatch"
 	}
 	if !mergeWorkerProgrammaticMergeReady(issue) || !reworkBreakerCIGreen(pullRequest) || len(pullRequest.StaleSuccessfulChecks) > 0 {

--- a/internal/orchestrator/blocked_cause_recovery_test.go
+++ b/internal/orchestrator/blocked_cause_recovery_test.go
@@ -1471,10 +1471,11 @@ func TestRecoverBlockedReadyPullRequestToMerging(t *testing.T) {
 	t.Parallel()
 
 	baseSnapshot := runpkg.BlockedRecoverySnapshot{
-		HeadSHA:          "ready-head",
-		WorkspacePresent: true,
-		WorkspaceStatus:  "present",
-		Health:           "ready",
+		HeadSHA:                        "ready-head",
+		WorkspacePresent:               true,
+		WorkspaceStatus:                "present",
+		PullRequestComparisonAvailable: true,
+		Health:                         "ready",
 	}
 	tests := []struct {
 		name         string
@@ -1546,7 +1547,7 @@ func TestRecoverBlockedReadyPullRequestToMerging(t *testing.T) {
 			snapshot: baseSnapshot,
 		},
 		{
-			name:  "head mismatched pull request",
+			name:  "head mismatch without risk evidence",
 			cause: strandedUnpushedWorkReason,
 			owner: blockedRecoveryOwnerOrchestrator,
 			snapshot: runpkg.BlockedRecoverySnapshot{
@@ -1555,17 +1556,49 @@ func TestRecoverBlockedReadyPullRequestToMerging(t *testing.T) {
 				WorkspaceStatus:  "present",
 				Health:           "ready",
 			},
+			wantMerging: true,
 		},
 		{
-			name:  "dirty workspace",
+			name:  "untracked-only workspace with matching pull request head",
 			cause: strandedUnpushedWorkReason,
 			owner: blockedRecoveryOwnerOrchestrator,
 			snapshot: runpkg.BlockedRecoverySnapshot{
-				HeadSHA:          "ready-head",
-				WorkspacePresent: true,
-				WorkspaceFiles:   1,
-				WorkspaceStatus:  "present",
-				Health:           "ready",
+				HeadSHA:                        "ready-head",
+				WorkspacePresent:               true,
+				WorkspaceFiles:                 1,
+				UnpushedCommits:                1,
+				WorkspaceStatus:                "present",
+				PullRequestComparisonAvailable: true,
+				Health:                         "ready",
+			},
+			wantMerging: true,
+		},
+		{
+			name:  "tracked workspace path",
+			cause: strandedUnpushedWorkReason,
+			owner: blockedRecoveryOwnerOrchestrator,
+			snapshot: runpkg.BlockedRecoverySnapshot{
+				HeadSHA:                        "ready-head",
+				WorkspacePresent:               true,
+				WorkspaceFiles:                 1,
+				TrackedPaths:                   []string{"tracked.go"},
+				WorkspaceStatus:                "present",
+				PullRequestComparisonAvailable: true,
+				Health:                         "ready",
+			},
+		},
+		{
+			name:  "commit absent from pull request",
+			cause: strandedUnpushedWorkReason,
+			owner: blockedRecoveryOwnerOrchestrator,
+			snapshot: runpkg.BlockedRecoverySnapshot{
+				HeadSHA:                        "workspace-head",
+				WorkspacePresent:               true,
+				UnpushedCommits:                1,
+				CommitsNotInPullRequest:        []string{"abc123 fix: preserve work"},
+				WorkspaceStatus:                "present",
+				PullRequestComparisonAvailable: true,
+				Health:                         "ready",
 			},
 		},
 		{

--- a/internal/orchestrator/dispatch_loop.go
+++ b/internal/orchestrator/dispatch_loop.go
@@ -330,7 +330,8 @@ func dispatchLoopWorkspaceDiffEqual(left dispatchLoopFingerprint, right dispatch
 
 func implementProgressDiffStatsPresent(diff implementProgressDiffStats) bool {
 	return diff.FilesChanged != 0 || diff.AddedLines != 0 || diff.RemovedLines != 0 ||
-		diff.UnpushedCommits != 0 || strings.TrimSpace(diff.HeadSHA) != "" ||
+		diff.UnpushedCommits != 0 || len(diff.UnpushedCommitRefs) != 0 || len(diff.TrackedPaths) != 0 ||
+		len(diff.CommitsNotInPullRequest) != 0 || diff.PullRequestComparisonAvailable || strings.TrimSpace(diff.HeadSHA) != "" ||
 		strings.TrimSpace(diff.Fingerprint) != "" || strings.TrimSpace(diff.Status) != ""
 }
 

--- a/internal/orchestrator/implement_progress.go
+++ b/internal/orchestrator/implement_progress.go
@@ -108,13 +108,17 @@ type implementProgressSignatureRecord struct {
 }
 
 type implementProgressDiffStats struct {
-	FilesChanged    int    `json:"files_changed"`
-	AddedLines      int    `json:"added_lines"`
-	RemovedLines    int    `json:"removed_lines"`
-	UnpushedCommits int    `json:"unpushed_commits,omitempty"`
-	HeadSHA         string `json:"head_sha,omitempty"`
-	Fingerprint     string `json:"fingerprint,omitempty"`
-	Status          string `json:"status,omitempty"`
+	FilesChanged                   int      `json:"files_changed"`
+	AddedLines                     int      `json:"added_lines"`
+	RemovedLines                   int      `json:"removed_lines"`
+	UnpushedCommits                int      `json:"unpushed_commits,omitempty"`
+	UnpushedCommitRefs             []string `json:"unpushed_commit_refs,omitempty"`
+	TrackedPaths                   []string `json:"tracked_paths,omitempty"`
+	CommitsNotInPullRequest        []string `json:"commits_not_in_pull_request,omitempty"`
+	PullRequestComparisonAvailable bool     `json:"pull_request_comparison_available,omitempty"`
+	HeadSHA                        string   `json:"head_sha,omitempty"`
+	Fingerprint                    string   `json:"fingerprint,omitempty"`
+	Status                         string   `json:"status,omitempty"`
 }
 
 func (o *Orchestrator) evaluateImplementCompletionProgress(
@@ -338,6 +342,7 @@ func (o *Orchestrator) evaluateImplementCompletionProgress(
 	}
 	decision.Issue = issue
 	decision.TrackerState = strings.TrimSpace(issue.State)
+	decision.WorkspaceDiffStats = implementProgressReconcilePullRequestEvidence(running.DiffStats, issue.PullRequest)
 	decision.ProgressKinds = implementProgressArtifactKinds(
 		running.DispatchProgress,
 		implementProgressArtifactSnapshotFromIssue(issue, workpadCurrent),
@@ -369,7 +374,7 @@ func (o *Orchestrator) evaluateImplementCompletionProgress(
 		decision.PreviousSignatureFound = true
 		decision.FailedChecksAdded, decision.FailedChecksRemoved = implementProgressFailedCheckDelta(previous.FailedChecks, signature.FailedChecks)
 	}
-	if stranded, deferReason := implementProgressUnpushedClassification(running.DiffStats, issue.PullRequest); deferReason != "" {
+	if stranded, deferReason := implementProgressUnpushedClassification(decision.WorkspaceDiffStats, issue.PullRequest); deferReason != "" {
 		decision.Reason = deferReason
 		return decision
 	} else if stranded {
@@ -391,8 +396,8 @@ func (o *Orchestrator) evaluateImplementCompletionProgress(
 		decision.ProgressKinds = append([]string{"pull_request"}, decision.ProgressKinds...)
 		return decision
 	}
-	if !implementProgressDiffStatsClean(running.DiffStats) {
-		if !diffStatsPresent(running.DiffStats) {
+	if !implementProgressDiffStatsClean(decision.WorkspaceDiffStats) {
+		if !diffStatsPresent(decision.WorkspaceDiffStats) {
 			decision.Reason = "workspace_diffstat_unavailable"
 			return decision
 		}
@@ -686,7 +691,7 @@ func consecutiveImplementStrandedWorkAttempts(attempts []store.WorkAttempt, curr
 	count := 0
 	for _, attempt := range attempts {
 		record, ok := implementProgressRecordFromAttempt(attempt)
-		if !ok || !implementProgressSignatureEqual(record.CurrentSignature.signature(), current) || record.WorkspaceDiffStats.UnpushedCommits <= 0 {
+		if !ok || !implementProgressSignatureEqual(record.CurrentSignature.signature(), current) || !implementProgressRecordedStrandedEvidence(record.WorkspaceDiffStats) {
 			return count
 		}
 		count++
@@ -813,14 +818,22 @@ func (r implementProgressSignatureRecord) signature() autoPromoteReworkSignature
 
 func implementProgressDiffStatsFromDiffStats(diffStats DiffStats) implementProgressDiffStats {
 	return implementProgressDiffStats{
-		FilesChanged:    diffStats.FilesChanged,
-		AddedLines:      diffStats.AddedLines,
-		RemovedLines:    diffStats.RemovedLines,
-		UnpushedCommits: diffStats.UnpushedCommits,
-		HeadSHA:         strings.TrimSpace(diffStats.HeadSHA),
-		Fingerprint:     strings.TrimSpace(diffStats.Fingerprint),
-		Status:          strings.TrimSpace(diffStats.Status),
+		FilesChanged:                   diffStats.FilesChanged,
+		AddedLines:                     diffStats.AddedLines,
+		RemovedLines:                   diffStats.RemovedLines,
+		UnpushedCommits:                diffStats.UnpushedCommits,
+		UnpushedCommitRefs:             append([]string(nil), diffStats.UnpushedCommitRefs...),
+		TrackedPaths:                   append([]string(nil), diffStats.TrackedPaths...),
+		CommitsNotInPullRequest:        append([]string(nil), diffStats.CommitsNotInPullRequest...),
+		PullRequestComparisonAvailable: diffStats.PullRequestComparisonAvailable,
+		HeadSHA:                        strings.TrimSpace(diffStats.HeadSHA),
+		Fingerprint:                    strings.TrimSpace(diffStats.Fingerprint),
+		Status:                         strings.TrimSpace(diffStats.Status),
 	}
+}
+
+func implementProgressRecordedStrandedEvidence(diffStats implementProgressDiffStats) bool {
+	return diffStats.UnpushedCommits > 0 || len(diffStats.TrackedPaths) > 0 || len(diffStats.CommitsNotInPullRequest) > 0
 }
 
 func implementProgressSignatureUsable(signature autoPromoteReworkSignature) bool {
@@ -843,17 +856,39 @@ func implementProgressDiffStatsClean(diffStats DiffStats) bool {
 func implementProgressOperationalWorkspaceClean(diffStats DiffStats) bool {
 	return implementProgressDiffStatsClean(diffStats) &&
 		diffStats.UnpushedCommits == 0 &&
-		diffStats.CommitsAhead == 0
+		diffStats.CommitsAhead == 0 &&
+		len(diffStats.TrackedPaths) == 0 &&
+		len(diffStats.CommitsNotInPullRequest) == 0
+}
+
+func implementProgressReconcilePullRequestEvidence(diffStats DiffStats, pullRequest *connector.PullRequest) DiffStats {
+	if pullRequest == nil || strings.TrimSpace(diffStats.HeadSHA) == "" ||
+		strings.TrimSpace(diffStats.HeadSHA) != strings.TrimSpace(pullRequest.HeadSHA) {
+		return diffStats
+	}
+	diffStats.UnpushedCommits = 0
+	diffStats.UnpushedCommitRefs = nil
+	diffStats.CommitsNotInPullRequest = nil
+	diffStats.PullRequestComparisonAvailable = true
+	return diffStats
 }
 
 func implementProgressUnpushedClassification(diffStats DiffStats, pullRequest *connector.PullRequest) (bool, string) {
+	if pullRequest != nil {
+		if len(diffStats.TrackedPaths) > 0 {
+			return true, ""
+		}
+		if diffStats.PullRequestComparisonAvailable {
+			return len(diffStats.CommitsNotInPullRequest) > 0, ""
+		}
+	}
 	if diffStats.UnpushedCommits <= 0 {
 		return false, ""
 	}
-	if !implementProgressDiffStatsClean(diffStats) {
-		return true, ""
-	}
 	if pullRequest == nil {
+		if !implementProgressDiffStatsClean(diffStats) {
+			return true, ""
+		}
 		return false, unpushedRemoteTruthUnavailable
 	}
 	workspaceHead := strings.TrimSpace(diffStats.HeadSHA)
@@ -1052,7 +1087,7 @@ func implementProgressRecoveryReason(decision implementCompletionProgressDecisio
 	if humanAction := strings.TrimSpace(decision.HumanAction); humanAction != "" {
 		return humanAction
 	}
-	if decision.WorkspaceDiffStats.UnpushedCommits > 0 {
+	if implementProgressStrandedEvidence(decision.WorkspaceDiffStats) {
 		return "validate and push the stranded workspace commits, then open or update the pull request and move the issue to Rework"
 	}
 	return "inspect the linked PR and worker logs, then move the issue back to Rework or Todo after a human confirms the next action"
@@ -1064,7 +1099,7 @@ func implementProgressBlockComment(issue connector.Issue, decision implementComp
 		b.WriteString("Routed this issue to Blocked: loop detected after ")
 		b.WriteString(strconv.Itoa(decision.ConsecutiveNoProgress))
 		b.WriteString(" dispatches without lane, diff, commit, or pull request advancement.")
-	} else if decision.WorkspaceDiffStats.UnpushedCommits > 0 {
+	} else if implementProgressStrandedEvidence(decision.WorkspaceDiffStats) {
 		b.WriteString("Routed this issue to Blocked because the implement worker completed repeatedly with work produced but stranded unpushed in the workspace.")
 	} else {
 		b.WriteString("Routed this issue to Blocked because the implement worker completed repeatedly without deliverable progress.")
@@ -1139,6 +1174,7 @@ func implementProgressBlockComment(issue connector.Issue, decision implementComp
 			b.WriteString("\n- unpushed_commits: ")
 			b.WriteString(strconv.Itoa(decision.WorkspaceDiffStats.UnpushedCommits))
 		}
+		appendStrandedWorkEvidence(&b, decision.WorkspaceDiffStats)
 	}
 	if humanAction := strings.TrimSpace(decision.HumanAction); humanAction != "" {
 		b.WriteString("\n\nHuman action requested by the Workpad:\n\n")
@@ -1149,6 +1185,33 @@ func implementProgressBlockComment(issue connector.Issue, decision implementComp
 		}
 	}
 	return b.String()
+}
+
+func implementProgressStrandedEvidence(diffStats DiffStats) bool {
+	return diffStats.UnpushedCommits > 0 || len(diffStats.TrackedPaths) > 0 || len(diffStats.CommitsNotInPullRequest) > 0
+}
+
+func appendStrandedWorkEvidence(b *strings.Builder, diffStats DiffStats) {
+	appendQuotedEvidence(b, "tracked_paths", diffStats.TrackedPaths)
+	appendQuotedEvidence(b, "commits_not_in_pull_request", diffStats.CommitsNotInPullRequest)
+	if len(diffStats.CommitsNotInPullRequest) == 0 {
+		appendQuotedEvidence(b, "unpushed_commit_refs", diffStats.UnpushedCommitRefs)
+	}
+}
+
+func appendQuotedEvidence(b *strings.Builder, label string, values []string) {
+	if len(values) == 0 {
+		return
+	}
+	b.WriteString("\n- ")
+	b.WriteString(label)
+	b.WriteString(": ")
+	for index, value := range values {
+		if index > 0 {
+			b.WriteString(", ")
+		}
+		b.WriteString(strconv.Quote(value))
+	}
 }
 
 func appendDispatchLoopWorkspaceEvidence(b *strings.Builder, decision implementCompletionProgressDecision) {

--- a/internal/orchestrator/implement_progress_test.go
+++ b/internal/orchestrator/implement_progress_test.go
@@ -104,15 +104,41 @@ func TestHandleRunResultClassifiesImplementWorkerProgress(t *testing.T) {
 			wantReason:      "first_completed_attempt",
 			wantCurrentHead: "same-head",
 			wantHydrations:  1,
-			wantConsecutive: 1,
+			wantConsecutive: 0,
 			wantReview:      true,
 		},
 		{
-			name:             "new pull request head with newer unpushed commit remains stranded",
-			runningIssue:     implementProgressIssue("same-head", "Test"),
-			hydratedIssue:    implementProgressIssue("new-head", "Test"),
-			history:          []store.WorkAttempt{implementProgressHistoryAttempt(1, signature, store.WorkAttemptTerminalSuccess)},
-			diffStats:        DiffStats{UnpushedCommits: 1, HeadSHA: "workspace-head", Status: "clean"},
+			name:          "hydrated pull request head supersedes stale commit comparison",
+			runningIssue:  implementProgressIssue("dispatch-head", "Test"),
+			hydratedIssue: implementProgressIssue("pushed-head", "Test"),
+			diffStats: DiffStats{
+				UnpushedCommits:                1,
+				UnpushedCommitRefs:             []string{"abc123 fix: pushed work"},
+				CommitsNotInPullRequest:        []string{"abc123 fix: pushed work"},
+				PullRequestComparisonAvailable: true,
+				HeadSHA:                        "pushed-head",
+				Status:                         "clean",
+			},
+			noProgressLimit: 3,
+			wantTerminal:    store.WorkAttemptTerminalSuccess,
+			wantReason:      "first_completed_attempt",
+			wantCurrentHead: "pushed-head",
+			wantHydrations:  1,
+			wantConsecutive: 0,
+			wantReview:      true,
+		},
+		{
+			name:          "new pull request head with newer unpushed commit remains stranded",
+			runningIssue:  implementProgressIssue("same-head", "Test"),
+			hydratedIssue: implementProgressIssue("new-head", "Test"),
+			history:       []store.WorkAttempt{implementProgressHistoryAttempt(1, signature, store.WorkAttemptTerminalSuccess)},
+			diffStats: DiffStats{
+				UnpushedCommits:                1,
+				CommitsNotInPullRequest:        []string{"abc123 fix: preserve work"},
+				PullRequestComparisonAvailable: true,
+				HeadSHA:                        "workspace-head",
+				Status:                         "clean",
+			},
 			noProgressLimit:  3,
 			wantTerminal:     store.WorkAttemptTerminalNoProgress,
 			wantReason:       strandedUnpushedWorkReason,
@@ -145,7 +171,14 @@ func TestHandleRunResultClassifiesImplementWorkerProgress(t *testing.T) {
 				implementProgressStrandedHistoryAttempt(2, signature),
 				implementProgressStrandedHistoryAttempt(1, signature),
 			},
-			diffStats:        DiffStats{UnpushedCommits: 1, HeadSHA: "workspace-head", Status: "clean"},
+			diffStats: DiffStats{
+				UnpushedCommits:                1,
+				UnpushedCommitRefs:             []string{"abc123 fix: preserve work"},
+				CommitsNotInPullRequest:        []string{"abc123 fix: preserve work"},
+				PullRequestComparisonAvailable: true,
+				HeadSHA:                        "workspace-head",
+				Status:                         "clean",
+			},
 			noProgressLimit:  3,
 			wantTerminal:     store.WorkAttemptTerminalNoProgress,
 			wantReason:       strandedUnpushedWorkReason,
@@ -155,13 +188,40 @@ func TestHandleRunResultClassifiesImplementWorkerProgress(t *testing.T) {
 			wantHydrations:   1,
 			wantBlocked:      true,
 			wantBlockReason:  strandedUnpushedWorkReason,
-			wantComment:      "unpushed_commits: 1",
+			wantComment:      "commits_not_in_pull_request: \"abc123 fix: preserve work\"",
 		},
 		{
-			name:            "dirty workspace remains stranded despite matching pull request head",
-			runningIssue:    implementProgressIssue("same-head", "Test"),
-			hydratedIssue:   implementProgressIssue("same-head", "Test"),
-			diffStats:       DiffStats{FilesChanged: 1, AddedLines: 1, UnpushedCommits: 1, HeadSHA: "same-head", Status: "changed"},
+			name:          "untracked file with matching pull request head is not stranded",
+			runningIssue:  implementProgressIssue("same-head", "Test"),
+			hydratedIssue: implementProgressIssue("same-head", "Test"),
+			diffStats: DiffStats{
+				FilesChanged:                   1,
+				AddedLines:                     1,
+				UnpushedCommits:                1,
+				PullRequestComparisonAvailable: true,
+				HeadSHA:                        "same-head",
+				Status:                         "changed",
+			},
+			noProgressLimit: 1,
+			wantTerminal:    store.WorkAttemptTerminalSuccess,
+			wantReason:      "first_completed_attempt",
+			wantConsecutive: 0,
+			wantCurrentHead: "same-head",
+			wantHydrations:  1,
+			wantReview:      true,
+		},
+		{
+			name:          "tracked file with matching pull request head remains stranded",
+			runningIssue:  implementProgressIssue("same-head", "Test"),
+			hydratedIssue: implementProgressIssue("same-head", "Test"),
+			diffStats: DiffStats{
+				FilesChanged:                   1,
+				AddedLines:                     1,
+				TrackedPaths:                   []string{"tracked.go"},
+				PullRequestComparisonAvailable: true,
+				HeadSHA:                        "same-head",
+				Status:                         "changed",
+			},
 			noProgressLimit: 1,
 			wantTerminal:    store.WorkAttemptTerminalNoProgress,
 			wantReason:      strandedUnpushedWorkReason,
@@ -170,7 +230,7 @@ func TestHandleRunResultClassifiesImplementWorkerProgress(t *testing.T) {
 			wantHydrations:  1,
 			wantBlocked:     true,
 			wantBlockReason: strandedUnpushedWorkReason,
-			wantComment:     "unpushed_commits: 1",
+			wantComment:     "tracked_paths: \"tracked.go\"",
 		},
 		{
 			name:            "missing workspace head defers unpushed classification",
@@ -1682,6 +1742,20 @@ func TestImplementProgressHelperBoundaries(t *testing.T) {
 		t.Fatal("legacy dirty completion matched no progress")
 	}
 
+	evidence := DiffStats{
+		UnpushedCommitRefs:             []string{"abc123 fix: preserve work"},
+		TrackedPaths:                   []string{"tracked.go"},
+		CommitsNotInPullRequest:        []string{"abc123 fix: preserve work"},
+		PullRequestComparisonAvailable: true,
+	}
+	recordedEvidence := implementProgressDiffStatsFromDiffStats(evidence)
+	if !reflect.DeepEqual(recordedEvidence.UnpushedCommitRefs, evidence.UnpushedCommitRefs) ||
+		!reflect.DeepEqual(recordedEvidence.TrackedPaths, evidence.TrackedPaths) ||
+		!reflect.DeepEqual(recordedEvidence.CommitsNotInPullRequest, evidence.CommitsNotInPullRequest) ||
+		!recordedEvidence.PullRequestComparisonAvailable {
+		t.Fatalf("implementProgressDiffStatsFromDiffStats() evidence = %#v, want %#v", recordedEvidence, evidence)
+	}
+
 	invalidAttempts := []store.WorkAttempt{
 		{TerminalState: store.WorkAttemptTerminalFailure, WorkerMetadataJSON: `{}`},
 		{TerminalState: store.WorkAttemptTerminalSuccess, WorkerMetadataJSON: `{`},
@@ -1779,6 +1853,8 @@ func TestImplementProgressOperationalWorkspaceClean(t *testing.T) {
 		{name: "workspace diff", diffStats: DiffStats{FilesChanged: 1, Status: "changed"}},
 		{name: "unpushed commit", diffStats: DiffStats{UnpushedCommits: 1, Status: "clean"}},
 		{name: "commit ahead", diffStats: DiffStats{CommitsAhead: 1, Status: "clean"}},
+		{name: "tracked path", diffStats: DiffStats{TrackedPaths: []string{"tracked.go"}, Status: "clean"}},
+		{name: "commit absent from pull request", diffStats: DiffStats{CommitsNotInPullRequest: []string{"abc123 fix: preserve work"}, Status: "clean"}},
 	}
 
 	for _, tt := range tests {
@@ -1788,6 +1864,40 @@ func TestImplementProgressOperationalWorkspaceClean(t *testing.T) {
 				t.Fatalf("implementProgressOperationalWorkspaceClean() = %t, want %t", got, tt.want)
 			}
 		})
+	}
+}
+
+func TestCompletedReworkGateWaitProgressPreservesStrandedCommitDecision(t *testing.T) {
+	t.Parallel()
+
+	issue := implementProgressIssue("pull-request-head")
+	issue.State = "Rework"
+	cfg := normalizeConfig(Config{
+		AutoPromote: AutoPromoteConfig{
+			Enabled:       true,
+			GateWaitState: autoPromoteGateWaitSource,
+			Gate:          gate.Config{Kind: gate.KindCommand},
+		},
+		ActiveStates:   []string{"Todo", "In Progress", "Rework", "Merging"},
+		TerminalStates: []string{"Done", "Cancelled"},
+	})
+	decision := implementCompletionProgressDecision{
+		Issue:            issue,
+		Outcome:          store.WorkAttemptTerminalNoProgress,
+		Reason:           strandedUnpushedWorkReason,
+		CurrentSignature: autoPromoteReworkSignature{PRNumber: 1070, HeadSHA: "pull-request-head"},
+		WorkspaceDiffStats: DiffStats{
+			CommitsNotInPullRequest:        []string{"abc123 fix: preserve work"},
+			PullRequestComparisonAvailable: true,
+			HeadSHA:                        "workspace-head",
+			Status:                         "clean",
+		},
+	}
+	running := Running{Issue: issue, DispatchSourceState: "Rework"}
+
+	got, reason := completedReworkGateWaitProgress(running, decision, cfg, FinalStateCompleted)
+	if reason != "" || got.Outcome != store.WorkAttemptTerminalNoProgress || got.Reason != strandedUnpushedWorkReason {
+		t.Fatalf("completedReworkGateWaitProgress() = outcome %q reason %q gate wait %q, want preserved stranded decision", got.Outcome, got.Reason, reason)
 	}
 }
 

--- a/internal/orchestrator/safety_fuzz_test.go
+++ b/internal/orchestrator/safety_fuzz_test.go
@@ -24,12 +24,13 @@ func (s *releaseErrorSafetyScheduler) ReleaseSlot(slot scheduler.Slot) error {
 }
 
 func FuzzSafetyCriticalOrchestratorBoundaries(f *testing.F) {
-	f.Add(0, 0, 0, "", "clean", int64(1), " head ", "lint,test", int64(1), "head", "test,lint", int64(60), int64(0), true, int64(0), int64(1), int64(2), true, uint8(0))
-	f.Add(1, 2, 3, "fingerprint", "dirty", int64(1), "head-a", "test", int64(2), "head-b", "lint", int64(-60), int64(0), true, int64(10), int64(-10), int64(0), false, uint8(1))
-	f.Add(0, 0, 0, "clean", "dirty", int64(1), "same-head", "fail", int64(1), "same-head", "pass", int64(0), int64(0), false, int64(0), int64(0), int64(0), false, uint8(2))
-	f.Add(0, 0, 0, "", "", int64(0), "", "", int64(0), "", "", int64(0), int64(0), false, int64(0), int64(10), int64(0), false, uint8(3))
-	f.Add(1, 0, 0, "old-output", "same-deliverable", int64(1), "old-receipt", "recut", int64(1), "new-receipt", "pending_review", int64(0), int64(0), false, int64(0), int64(0), int64(0), false, uint8(0))
-	f.Add(2, 0, 0, "new-output", "new-deliverable", int64(1), "same-receipt", "recut", int64(2), "same-receipt", "pending_review", int64(0), int64(0), false, int64(0), int64(0), int64(0), false, uint8(1))
+	f.Add(0, 0, 0, "", "clean", int64(1), " head ", "lint,test", int64(1), "head", "test,lint", int64(60), int64(0), true, int64(0), int64(1), int64(2), true, false, uint8(0))
+	f.Add(1, 2, 3, "fingerprint", "dirty", int64(1), "head-a", "test", int64(2), "head-b", "lint", int64(-60), int64(0), true, int64(10), int64(-10), int64(0), false, false, uint8(1))
+	f.Add(0, 0, 0, "clean", "dirty", int64(1), "same-head", "fail", int64(1), "same-head", "pass", int64(0), int64(0), false, int64(0), int64(0), int64(0), false, false, uint8(2))
+	f.Add(0, 0, 0, "", "", int64(0), "", "", int64(0), "", "", int64(0), int64(0), false, int64(0), int64(10), int64(0), false, false, uint8(3))
+	f.Add(1, 0, 0, "old-output", "same-deliverable", int64(1), "old-receipt", "recut", int64(1), "new-receipt", "pending_review", int64(0), int64(0), false, int64(0), int64(0), int64(0), false, false, uint8(0))
+	f.Add(2, 0, 0, "new-output", "new-deliverable", int64(1), "same-receipt", "recut", int64(2), "same-receipt", "pending_review", int64(0), int64(0), false, int64(0), int64(0), int64(0), false, false, uint8(1))
+	f.Add(1, 0, 0, "tracked-output", "changed", int64(1), "same-head", "recut", int64(1), "same-head", "pending_review", int64(0), int64(0), false, int64(0), int64(0), int64(0), false, true, uint8(1))
 
 	f.Fuzz(func(
 		t *testing.T,
@@ -51,6 +52,7 @@ func FuzzSafetyCriticalOrchestratorBoundaries(f *testing.F) {
 		stageSeconds int64,
 		acceptedSeconds int64,
 		accepted bool,
+		tracked bool,
 		gateScenario uint8,
 	) {
 		diffStats := DiffStats{
@@ -67,11 +69,14 @@ func FuzzSafetyCriticalOrchestratorBoundaries(f *testing.F) {
 		unpushed := diffStats
 		unpushed.UnpushedCommits = 1
 		unpushed.HeadSHA = leftHead
+		if tracked {
+			unpushed.TrackedPaths = []string{"tracked.go"}
+		}
 		gotStranded, gotDeferred := implementProgressUnpushedClassification(unpushed, &connector.PullRequest{HeadSHA: rightHead})
 		wantStranded := false
 		wantDeferred := ""
 		switch {
-		case !implementProgressDiffStatsClean(unpushed):
+		case len(unpushed.TrackedPaths) > 0:
 			wantStranded = true
 		case strings.TrimSpace(leftHead) == "":
 			wantDeferred = workspaceHeadUnavailableReason

--- a/internal/orchestrator/state.go
+++ b/internal/orchestrator/state.go
@@ -1035,6 +1035,10 @@ func diffStatsPresent(diffStats DiffStats) bool {
 		diffStats.AddedLines != 0 ||
 		diffStats.RemovedLines != 0 ||
 		diffStats.UnpushedCommits != 0 ||
+		len(diffStats.UnpushedCommitRefs) != 0 ||
+		len(diffStats.TrackedPaths) != 0 ||
+		len(diffStats.CommitsNotInPullRequest) != 0 ||
+		diffStats.PullRequestComparisonAvailable ||
 		diffStats.CommitsAhead != 0 ||
 		diffStats.RemoteBranchExists ||
 		diffStats.DeliveryStateChecked ||

--- a/internal/runner/agent.go
+++ b/internal/runner/agent.go
@@ -1788,7 +1788,7 @@ func (r *Runner) Run(ctx context.Context, req RunRequest) (RunResult, error) {
 	}
 	turnErr = classifyForgeDeliverableError(turnErr, forgeHost, result.PullRequestHeadPushed)
 	result.budgetProjection = budgetProjection
-	if brakeDiff := sessionBrake.resultDiffStats(); brakeDiff != (DiffStats{}) {
+	if brakeDiff := sessionBrake.resultDiffStats(); !diffStatsEmpty(brakeDiff) {
 		result.DiffStats = brakeDiff
 	}
 	var deliverableState *workspace.DeliverableState
@@ -1796,8 +1796,7 @@ func (r *Runner) Run(ctx context.Context, req RunRequest) (RunResult, error) {
 	if mode == RunModeImplement && result.PullRequestHeadPushed && errors.As(turnErr, &exhaustedDeliverable) {
 		if recoveryState := r.workspaceRecoveryState(runWorkspace, ctx, info, workspaceIssue, "deliverable_recovery"); recoveryState != nil {
 			result.DiffStats = diffStatsFromWorkspace(recoveryState.DiffStat)
-			result.DiffStats.UnpushedCommits = recoveryState.UnpushedCommits
-			result.DiffStats.HeadSHA = strings.TrimSpace(recoveryState.HeadSHA)
+			applyRecoveryState(&result.DiffStats, recoveryState)
 		}
 		deliverableState = r.workspaceDeliverableState(runWorkspace, ctx, info, workspaceIssue)
 		applyDeliverableState(&result.DiffStats, deliverableState)
@@ -1888,8 +1887,7 @@ func (r *Runner) Run(ctx context.Context, req RunRequest) (RunResult, error) {
 	result.DiffStats = diffStatsFromWorkspace(diffStat)
 	if mode == RunModeImplement {
 		if recoveryState := r.workspaceRecoveryState(runWorkspace, ctx, info, workspaceIssue, "final"); recoveryState != nil {
-			result.DiffStats.UnpushedCommits = recoveryState.UnpushedCommits
-			result.DiffStats.HeadSHA = strings.TrimSpace(recoveryState.HeadSHA)
+			applyRecoveryState(&result.DiffStats, recoveryState)
 		}
 	}
 	applyDeliverableState(&result.DiffStats, deliverableState)
@@ -2314,7 +2312,7 @@ func mergeAgentTurnExecutions(initial agentTurnExecution, recovery agentTurnExec
 	result.PullRequestHeadPushed = initial.result.PullRequestHeadPushed || recovery.result.PullRequestHeadPushed
 	result.CITriggerLabelReapplied = initial.result.CITriggerLabelReapplied || recovery.result.CITriggerLabelReapplied
 	result.ForgeWriteCompleted = initial.result.ForgeWriteCompleted || recovery.result.ForgeWriteCompleted
-	if result.DiffStats == (DiffStats{}) {
+	if diffStatsEmpty(result.DiffStats) {
 		result.DiffStats = initial.result.DiffStats
 	}
 	return agentTurnExecution{
@@ -2456,8 +2454,7 @@ func (r *Runner) publishDispatchLoopStart(req RunRequest, recovery *workspace.Re
 		snapshot.WorkspaceDiffAvailable = true
 		snapshot.WorkspaceHeadAvailable = strings.TrimSpace(recovery.HeadSHA) != ""
 		snapshot.DiffStats = diffStatsFromWorkspace(recovery.DiffStat)
-		snapshot.DiffStats.UnpushedCommits = recovery.UnpushedCommits
-		snapshot.DiffStats.HeadSHA = strings.TrimSpace(recovery.HeadSHA)
+		applyRecoveryState(&snapshot.DiffStats, recovery)
 	}
 	if err := req.OnUsageUpdate(UsageUpdate{DispatchLoopStart: &snapshot}); err != nil && r.logger != nil {
 		r.logger.Warn("dispatch loop start snapshot publish failed", "issue_id", req.Issue.ID, "identifier", req.Issue.Identifier, "error", err)
@@ -2872,7 +2869,7 @@ func (r *Runner) Validate(ctx context.Context, req ValidatorRequest) (gate.Valid
 	turnErr = sessionBrake.wrapTurnLimit(ctx, turnErr)
 	turnErr = sessionBrake.wrapDuration(ctx, turnErr, durationFromMillis(workflow.Config.Agent.MaxSessionDurationMS))
 	sessionBrake.Stop()
-	if brakeDiff := sessionBrake.resultDiffStats(); brakeDiff != (DiffStats{}) {
+	if brakeDiff := sessionBrake.resultDiffStats(); !diffStatsEmpty(brakeDiff) {
 		runResult.DiffStats = brakeDiff
 	}
 	turnErr = errors.Join(turnErr, scratchCleanupErr)
@@ -3757,12 +3754,20 @@ func workspaceIssue(projectID string, issue connector.Issue) workspace.Issue {
 		baseRef = strings.TrimSpace(issue.PullRequest.BaseSHA)
 	}
 	return workspace.Issue{
-		ProjectID:  projectID,
-		ID:         issue.ID,
-		Identifier: issue.Identifier,
-		BranchName: issue.BranchName,
-		BaseRef:    baseRef,
+		ProjectID:          projectID,
+		ID:                 issue.ID,
+		Identifier:         issue.Identifier,
+		BranchName:         issue.BranchName,
+		BaseRef:            baseRef,
+		PullRequestHeadSHA: pullRequestHeadSHA(issue.PullRequest),
 	}
+}
+
+func pullRequestHeadSHA(pullRequest *connector.PullRequest) string {
+	if pullRequest == nil {
+		return ""
+	}
+	return strings.TrimSpace(pullRequest.HeadSHA)
 }
 
 func applyAgentUpdate(result *RunResult, update AgentUpdate) {
@@ -4803,6 +4808,35 @@ func diffStatsFromWorkspace(stat workspace.DiffStat) DiffStats {
 		Fingerprint:  strings.TrimSpace(stat.Fingerprint),
 		Status:       status,
 	}
+}
+
+func applyRecoveryState(diffStats *DiffStats, state *workspace.RecoveryState) {
+	if diffStats == nil || state == nil {
+		return
+	}
+	diffStats.UnpushedCommits = state.UnpushedCommits
+	diffStats.UnpushedCommitRefs = append([]string(nil), state.UnpushedCommitRefs...)
+	diffStats.TrackedPaths = append([]string(nil), state.TrackedPaths...)
+	diffStats.CommitsNotInPullRequest = append([]string(nil), state.CommitsNotInPullRequest...)
+	diffStats.PullRequestComparisonAvailable = state.PullRequestComparisonAvailable
+	diffStats.HeadSHA = strings.TrimSpace(state.HeadSHA)
+}
+
+func diffStatsEmpty(diffStats DiffStats) bool {
+	return diffStats.FilesChanged == 0 &&
+		diffStats.AddedLines == 0 &&
+		diffStats.RemovedLines == 0 &&
+		diffStats.UnpushedCommits == 0 &&
+		len(diffStats.UnpushedCommitRefs) == 0 &&
+		len(diffStats.TrackedPaths) == 0 &&
+		len(diffStats.CommitsNotInPullRequest) == 0 &&
+		!diffStats.PullRequestComparisonAvailable &&
+		diffStats.CommitsAhead == 0 &&
+		!diffStats.RemoteBranchExists &&
+		!diffStats.DeliveryStateChecked &&
+		strings.TrimSpace(diffStats.HeadSHA) == "" &&
+		strings.TrimSpace(diffStats.Fingerprint) == "" &&
+		strings.TrimSpace(diffStats.Status) == ""
 }
 
 func (r *Runner) logWorkerEvent(issue connector.Issue, event string, attrs ...any) {

--- a/internal/runner/blocked_recovery.go
+++ b/internal/runner/blocked_recovery.go
@@ -50,6 +50,10 @@ func (r *Runner) BlockedRecoverySnapshot(ctx context.Context, req RunRequest) Bl
 	snapshot.HeadSHA = strings.TrimSpace(recovery.HeadSHA)
 	snapshot.WorkspaceFiles = recovery.DiffStat.Files
 	snapshot.UnpushedCommits = recovery.UnpushedCommits
+	snapshot.UnpushedCommitRefs = append([]string(nil), recovery.UnpushedCommitRefs...)
+	snapshot.TrackedPaths = append([]string(nil), recovery.TrackedPaths...)
+	snapshot.CommitsNotInPullRequest = append([]string(nil), recovery.CommitsNotInPullRequest...)
+	snapshot.PullRequestComparisonAvailable = recovery.PullRequestComparisonAvailable
 	snapshot.WorkspaceFingerprint = strings.TrimSpace(recovery.WorkspaceFingerprint)
 	if snapshot.WorkspaceFingerprint == "" {
 		snapshot.WorkspaceFingerprint = strings.TrimSpace(recovery.DiffStat.Fingerprint)

--- a/internal/runner/runner_test.go
+++ b/internal/runner/runner_test.go
@@ -6411,7 +6411,7 @@ func TestRunnerRunTreatsMissingWorkspaceFinalDiffAsCompleted(t *testing.T) {
 	if result.FinalState != FinalStateCompleted {
 		t.Fatalf("FinalState = %q, want %q", result.FinalState, FinalStateCompleted)
 	}
-	if result.DiffStats != (DiffStats{}) {
+	if !diffStatsEmpty(result.DiffStats) {
 		t.Fatalf("DiffStats = %#v, want empty when workspace disappeared", result.DiffStats)
 	}
 	if sessionStore.finished.FinalState != FinalStateCompleted {

--- a/internal/runner/session_brake.go
+++ b/internal/runner/session_brake.go
@@ -478,6 +478,7 @@ func (r *Runner) sessionProgressSnapshot(
 			workspaceErr = err
 		} else {
 			snapshot.DiffStats = diffStatsFromWorkspace(recovery.DiffStat)
+			applyRecoveryState(&snapshot.DiffStats, &recovery)
 			snapshot.HeadSHA = strings.TrimSpace(recovery.HeadSHA)
 			snapshot.WorkspaceFingerprint = strings.TrimSpace(recovery.WorkspaceFingerprint)
 			snapshot.UnpushedCommits = recovery.UnpushedCommits

--- a/internal/runner/types.go
+++ b/internal/runner/types.go
@@ -233,16 +233,20 @@ type GitHubRESTBudgetProber interface {
 }
 
 type BlockedRecoverySnapshot struct {
-	ConfigFingerprint    string
-	ToolingFingerprint   string
-	BaseFingerprint      string
-	HeadSHA              string
-	WorkspaceFingerprint string
-	WorkspaceStatus      string
-	WorkspacePresent     bool
-	WorkspaceFiles       int
-	UnpushedCommits      int
-	Health               string
+	ConfigFingerprint              string
+	ToolingFingerprint             string
+	BaseFingerprint                string
+	HeadSHA                        string
+	WorkspaceFingerprint           string
+	WorkspaceStatus                string
+	WorkspacePresent               bool
+	WorkspaceFiles                 int
+	UnpushedCommits                int
+	UnpushedCommitRefs             []string
+	TrackedPaths                   []string
+	CommitsNotInPullRequest        []string
+	PullRequestComparisonAvailable bool
+	Health                         string
 }
 
 type Validator interface {
@@ -768,16 +772,20 @@ type BudgetRefusal struct {
 }
 
 type DiffStats struct {
-	FilesChanged         int
-	AddedLines           int
-	RemovedLines         int
-	UnpushedCommits      int
-	CommitsAhead         int
-	RemoteBranchExists   bool
-	DeliveryStateChecked bool
-	HeadSHA              string
-	Fingerprint          string
-	Status               string
+	FilesChanged                   int
+	AddedLines                     int
+	RemovedLines                   int
+	UnpushedCommits                int
+	UnpushedCommitRefs             []string
+	TrackedPaths                   []string
+	CommitsNotInPullRequest        []string
+	PullRequestComparisonAvailable bool
+	CommitsAhead                   int
+	RemoteBranchExists             bool
+	DeliveryStateChecked           bool
+	HeadSHA                        string
+	Fingerprint                    string
+	Status                         string
 }
 
 type TokenTotals struct {

--- a/internal/workspace/diffstat.go
+++ b/internal/workspace/diffstat.go
@@ -16,6 +16,8 @@ import (
 	"strings"
 )
 
+const recoveryEvidenceLimit = 20
+
 var (
 	diffStatFilesPattern   = regexp.MustCompile(`(\d+)\s+files?\s+changed`)
 	diffStatAddedPattern   = regexp.MustCompile(`(\d+)\s+insertions?\(\+\)`)
@@ -62,7 +64,11 @@ func (l *LocalGit) RecoveryState(ctx context.Context, info Info, issue Issue) (R
 	if err != nil {
 		return RecoveryState{}, err
 	}
-	unpushedCommits, err := gitUnpushedCommitCount(ctx, normalized.Path)
+	unpushedCommits, unpushedCommitRefs, err := gitUnpushedCommitEvidence(ctx, normalized.Path)
+	if err != nil {
+		return RecoveryState{}, err
+	}
+	trackedPaths, err := gitTrackedPaths(ctx, normalized.Path)
 	if err != nil {
 		return RecoveryState{}, err
 	}
@@ -70,12 +76,26 @@ func (l *LocalGit) RecoveryState(ctx context.Context, info Info, issue Issue) (R
 	if err != nil {
 		return RecoveryState{}, fmt.Errorf("git resolve recovery head: %w", err)
 	}
+	head = strings.TrimSpace(head)
+	commitsNotInPullRequest, comparisonAvailable, err := gitCommitsNotInPullRequest(
+		ctx,
+		normalized.Path,
+		head,
+		issue.PullRequestHeadSHA,
+	)
+	if err != nil {
+		return RecoveryState{}, err
+	}
 	return RecoveryState{
-		DiffStat:             stat,
-		BaseFingerprint:      gitRecoveryBaseFingerprint(ctx, normalized.Path, issue.BaseRef),
-		HeadSHA:              strings.TrimSpace(head),
-		WorkspaceFingerprint: workspaceRecoveryFingerprint(strings.TrimSpace(head), stat.Fingerprint),
-		UnpushedCommits:      unpushedCommits,
+		DiffStat:                       stat,
+		BaseFingerprint:                gitRecoveryBaseFingerprint(ctx, normalized.Path, issue.BaseRef),
+		HeadSHA:                        head,
+		WorkspaceFingerprint:           workspaceRecoveryFingerprint(head, stat.Fingerprint),
+		UnpushedCommits:                unpushedCommits,
+		UnpushedCommitRefs:             unpushedCommitRefs,
+		TrackedPaths:                   trackedPaths,
+		CommitsNotInPullRequest:        commitsNotInPullRequest,
+		PullRequestComparisonAvailable: comparisonAvailable,
 	}, nil
 }
 
@@ -196,23 +216,92 @@ func gitDiffStatOutput(ctx context.Context, workspacePath string) (DiffStat, err
 	return gitDiffStatWithEnv(ctx, workspacePath, env, "HEAD")
 }
 
-func gitUnpushedCommitCount(ctx context.Context, workspacePath string) (int, error) {
+func gitUnpushedCommitEvidence(ctx context.Context, workspacePath string) (int, []string, error) {
 	remoteRefs, err := runGitAt(ctx, workspacePath, "for-each-ref", "--count=1", "--format=%(refname)", "refs/remotes")
 	if err != nil {
-		return 0, fmt.Errorf("git list remote refs: %w", err)
+		return 0, nil, fmt.Errorf("git list remote refs: %w", err)
 	}
 	if strings.TrimSpace(remoteRefs) == "" {
-		return 0, nil
+		return 0, nil, nil
 	}
 	output, err := runGitAt(ctx, workspacePath, "rev-list", "--count", "HEAD", "--not", "--remotes")
 	if err != nil {
-		return 0, fmt.Errorf("git count unpushed commits: %w", err)
+		return 0, nil, fmt.Errorf("git count unpushed commits: %w", err)
 	}
 	count, err := strconv.Atoi(strings.TrimSpace(output))
 	if err != nil {
-		return 0, fmt.Errorf("parse unpushed commit count: %w", err)
+		return 0, nil, fmt.Errorf("parse unpushed commit count: %w", err)
 	}
-	return count, nil
+	if count == 0 {
+		return 0, nil, nil
+	}
+	refs, err := gitCommitEvidence(ctx, workspacePath, "HEAD", "--not", "--remotes")
+	if err != nil {
+		return 0, nil, fmt.Errorf("git list unpushed commits: %w", err)
+	}
+	return count, refs, nil
+}
+
+func gitTrackedPaths(ctx context.Context, workspacePath string) ([]string, error) {
+	output, err := runGitAt(ctx, workspacePath, "diff", "--name-only", "--no-ext-diff", "-z", "HEAD", "--")
+	if err != nil {
+		return nil, fmt.Errorf("git list tracked workspace changes: %w", err)
+	}
+	return boundedNULFields(output, recoveryEvidenceLimit, false), nil
+}
+
+func gitCommitsNotInPullRequest(
+	ctx context.Context,
+	workspacePath string,
+	head string,
+	pullRequestHead string,
+) ([]string, bool, error) {
+	head = strings.TrimSpace(head)
+	pullRequestHead = strings.TrimSpace(pullRequestHead)
+	if pullRequestHead == "" {
+		return nil, false, nil
+	}
+	if head == pullRequestHead {
+		return nil, true, nil
+	}
+	if _, err := runGitAt(ctx, workspacePath, "cat-file", "-e", pullRequestHead+"^{commit}"); err != nil {
+		return nil, false, nil
+	}
+	refs, err := gitCommitEvidence(ctx, workspacePath, head, "--not", pullRequestHead)
+	if err != nil {
+		return nil, false, fmt.Errorf("git compare workspace commits to pull request: %w", err)
+	}
+	return refs, true, nil
+}
+
+func gitCommitEvidence(ctx context.Context, workspacePath string, revisions ...string) ([]string, error) {
+	args := []string{"log", "--format=%H %s%x00", "-n", strconv.Itoa(recoveryEvidenceLimit)}
+	args = append(args, revisions...)
+	output, err := runGitAt(ctx, workspacePath, args...)
+	if err != nil {
+		return nil, err
+	}
+	return boundedNULFields(output, recoveryEvidenceLimit, true), nil
+}
+
+func boundedNULFields(output string, limit int, trimSpace bool) []string {
+	if limit <= 0 {
+		return nil
+	}
+	fields := make([]string, 0, min(strings.Count(output, "\x00"), limit))
+	for field := range strings.SplitSeq(output, "\x00") {
+		if trimSpace {
+			field = strings.TrimSpace(field)
+		}
+		if field == "" {
+			continue
+		}
+		fields = append(fields, field)
+		if len(fields) == limit {
+			break
+		}
+	}
+	return fields
 }
 
 func gitDeliveryState(ctx context.Context, workspacePath string, branch string, baseRef string) (DeliverableState, error) {

--- a/internal/workspace/diffstat_test.go
+++ b/internal/workspace/diffstat_test.go
@@ -197,15 +197,18 @@ func TestLocalGitRecoveryStateDetectsStrandedWork(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Create() error = %v", err)
 	}
+	issue.PullRequestHeadSHA = strings.TrimSpace(runGit(t, info.Path, "rev-parse", "HEAD"))
 
 	if err := os.WriteFile(filepath.Join(info.Path, "committed.txt"), []byte("committed\n"), 0o600); err != nil {
 		t.Fatalf("write committed file: %v", err)
 	}
 	runGit(t, info.Path, "add", "committed.txt")
 	runGit(t, info.Path, "commit", "-m", "test: add committed work")
+	commitSHA := strings.TrimSpace(runGit(t, info.Path, "rev-parse", "HEAD"))
 	if err := os.WriteFile(filepath.Join(info.Path, "dirty.txt"), []byte("dirty\n"), 0o600); err != nil {
 		t.Fatalf("write dirty file: %v", err)
 	}
+	runGit(t, info.Path, "add", "dirty.txt")
 
 	got, err := provider.RecoveryState(context.Background(), info, issue)
 	if err != nil {
@@ -213,6 +216,17 @@ func TestLocalGitRecoveryStateDetectsStrandedWork(t *testing.T) {
 	}
 	if got.UnpushedCommits != 1 || got.DiffStat.Files != 1 || got.DiffStat.Added != 1 {
 		t.Fatalf("RecoveryState() = %+v, want one unpushed commit and one dirty file", got)
+	}
+	if len(got.TrackedPaths) != 1 || got.TrackedPaths[0] != "dirty.txt" {
+		t.Fatalf("RecoveryState().TrackedPaths = %v, want [dirty.txt]", got.TrackedPaths)
+	}
+	if !got.PullRequestComparisonAvailable || len(got.CommitsNotInPullRequest) != 1 ||
+		!strings.Contains(got.CommitsNotInPullRequest[0], commitSHA) ||
+		!strings.Contains(got.CommitsNotInPullRequest[0], "test: add committed work") {
+		t.Fatalf("RecoveryState() pull request commit evidence = %v, available=%t, want %s and subject", got.CommitsNotInPullRequest, got.PullRequestComparisonAvailable, commitSHA)
+	}
+	if len(got.UnpushedCommitRefs) != 1 || !strings.Contains(got.UnpushedCommitRefs[0], commitSHA) {
+		t.Fatalf("RecoveryState().UnpushedCommitRefs = %v, want %s", got.UnpushedCommitRefs, commitSHA)
 	}
 	if want := strings.TrimSpace(runGit(t, info.Path, "rev-parse", "HEAD")); got.HeadSHA != want {
 		t.Fatalf("RecoveryState().HeadSHA = %q, want %q", got.HeadSHA, want)
@@ -224,6 +238,42 @@ func TestLocalGitRecoveryStateDetectsStrandedWork(t *testing.T) {
 	}
 	if pushed.UnpushedCommits != 0 || pushed.DiffStat != got.DiffStat {
 		t.Fatalf("RecoveryState() after push = %+v, want no unpushed commits and unchanged dirty diff %+v", pushed, got.DiffStat)
+	}
+}
+
+func TestLocalGitRecoveryStateExcludesUntrackedPathsFromStrandedEvidence(t *testing.T) {
+	t.Parallel()
+
+	source := initSourceRepo(t)
+	remote := initBareRemote(t)
+	runGit(t, source, "remote", "add", "origin", remote)
+	runGit(t, source, "push", "-u", "origin", "main")
+	backend, err := NewBackend(KindLocalGit, LocalGitOptions{
+		Root: filepath.Join(t.TempDir(), "workspaces"), SourceRoot: source, AutoBranch: true,
+	})
+	if err != nil {
+		t.Fatalf("NewBackend() error = %v", err)
+	}
+	provider := backend.(RecoveryStateProvider)
+	issue := Issue{Identifier: "DD-UNTRACKED"}
+	info, err := backend.Create(t.Context(), issue)
+	if err != nil {
+		t.Fatalf("Create() error = %v", err)
+	}
+	issue.PullRequestHeadSHA = strings.TrimSpace(runGit(t, info.Path, "rev-parse", "HEAD"))
+	if err := os.WriteFile(filepath.Join(info.Path, "session-marker.ses"), []byte("1722600000000 01234567-89ab-cdef-0123-456789abcdef\n"), 0o600); err != nil {
+		t.Fatalf("write untracked session marker: %v", err)
+	}
+
+	got, err := provider.RecoveryState(t.Context(), info, issue)
+	if err != nil {
+		t.Fatalf("RecoveryState() error = %v", err)
+	}
+	if got.DiffStat.Files != 1 || got.UnpushedCommits != 0 {
+		t.Fatalf("RecoveryState() = %+v, want one aggregate diff file and no unpushed commits", got)
+	}
+	if len(got.TrackedPaths) != 0 || len(got.CommitsNotInPullRequest) != 0 || !got.PullRequestComparisonAvailable {
+		t.Fatalf("RecoveryState() stranded evidence = tracked %v commits %v available=%t, want no evidence and available comparison", got.TrackedPaths, got.CommitsNotInPullRequest, got.PullRequestComparisonAvailable)
 	}
 }
 

--- a/internal/workspace/workspace.go
+++ b/internal/workspace/workspace.go
@@ -89,11 +89,15 @@ type IssueRecoveryStateProvider interface {
 }
 
 type RecoveryState struct {
-	DiffStat             DiffStat
-	BaseFingerprint      string
-	HeadSHA              string
-	WorkspaceFingerprint string
-	UnpushedCommits      int
+	DiffStat                       DiffStat
+	BaseFingerprint                string
+	HeadSHA                        string
+	WorkspaceFingerprint           string
+	UnpushedCommits                int
+	UnpushedCommitRefs             []string
+	TrackedPaths                   []string
+	CommitsNotInPullRequest        []string
+	PullRequestComparisonAvailable bool
 }
 
 type ArtifactEvidence struct {
@@ -146,11 +150,12 @@ type IssueCleaner interface {
 }
 
 type Issue struct {
-	ProjectID  string
-	ID         string
-	Identifier string
-	BranchName string
-	BaseRef    string
+	ProjectID          string
+	ID                 string
+	Identifier         string
+	BranchName         string
+	BaseRef            string
+	PullRequestHeadSHA string
 }
 
 type Info struct {


### PR DESCRIPTION
## Summary

- separate aggregate workspace diff stats from tracked-file stranded-work evidence
- compare workspace commits directly with the linked pull request head
- record bounded tracked paths and commit SHA/subject evidence when work is at risk
- allow untracked-only workspace artifacts to pass completion and blocked recovery

Fixes #2092

## UI Surface Contract

- [x] N/A, or the linked issue explicitly authorizes any high-impact UI surface, layout, density, first-viewport, or responsive visibility tradeoff.
- [x] Persistent top-of-screen messaging is explicitly authorized by the issue, or this PR does not add it.
- [x] Visual changes to primary operator screens include screenshot or browser verification below. N/A: no UI changes.

## Test Plan

- [x] `go test ./internal/workspace ./internal/runner ./internal/orchestrator -count=1`
- [x] `go test ./internal/orchestrator -run "^$" -fuzz=FuzzSafetyCriticalOrchestratorBoundaries -fuzztime=30s`
- [x] `PATH="$TMPDIR/golangci-go1.26.6/bin:$PATH" GOTOOLCHAIN=go1.26.6 make check`