### PR TITLE
feat(hub): define tracker contract

### DIFF
--- a/internal/hubserver/service.go
+++ b/internal/hubserver/service.go
@@ -11,6 +11,8 @@ import (
 	"time"
 
 	"github.com/labstack/echo/v4"
+
+	"github.com/digitaldrywood/detent/internal/tracker"
 )
 
 const (
@@ -21,6 +23,7 @@ const (
 type Service struct {
 	echo      *echo.Echo
 	database  *database
+	tracker   tracker.Tracker
 	config    Config
 	ready     atomic.Bool
 	closeOnce sync.Once
@@ -42,16 +45,24 @@ func Open(ctx context.Context, cfg Config) (*Service, error) {
 	if err != nil {
 		return nil, err
 	}
+	workTracker, err := tracker.NewStore(database)
+	if err != nil {
+		return nil, errors.Join(err, database.Close())
+	}
 
 	e := echo.New()
 	e.HideBanner = true
 	e.HidePort = true
 	e.Server.ReadHeaderTimeout = defaultHTTPReadHeaderTimeout
 	e.Server.IdleTimeout = defaultHTTPIdleTimeout
-	service := &Service{echo: e, database: database, config: cfg}
+	service := &Service{echo: e, database: database, tracker: workTracker, config: cfg}
 	e.GET("/health", service.health)
 	service.ready.Store(true)
 	return service, nil
+}
+
+func (s *Service) Tracker() tracker.Tracker {
+	return s.tracker
 }
 
 func Run(ctx context.Context, cfg Config) (resultErr error) {

--- a/internal/hubserver/tracker_store.go
+++ b/internal/hubserver/tracker_store.go
@@ -54,6 +54,19 @@ LEFT JOIN queue_entries q ON q.id = (
 )
 `
 
+const candidateOrder = `
+ORDER BY
+  CASE WHEN q.priority_override IS NULL THEN 1 ELSE 0 END,
+  q.priority_override,
+  CASE WHEN q.rank IS NULL OR trim(q.rank) = '' THEN 1 ELSE 0 END,
+  q.rank,
+  i.created_at,
+  r.github_owner,
+  r.github_name,
+  i.github_number,
+  i.id
+LIMIT ?`
+
 type databaseQueryer interface {
 	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
 }
@@ -102,7 +115,7 @@ func (d *database) ListCandidateRecords(ctx context.Context, query tracker.Candi
 		limit = tracker.DefaultCandidateLimit
 	}
 	args = append(args, limit)
-	statement := workItemColumns + "WHERE " + strings.Join(clauses, " AND ") + " ORDER BY i.id LIMIT ?"
+	statement := workItemColumns + "WHERE " + strings.Join(clauses, " AND ") + candidateOrder
 
 	return d.readWorkItemRecords(ctx, statement, args)
 }

--- a/internal/hubserver/tracker_store.go
+++ b/internal/hubserver/tracker_store.go
@@ -1,0 +1,585 @@
+package hubserver
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/digitaldrywood/detent/internal/tracker"
+)
+
+const workItemColumns = `
+SELECT
+  i.id,
+  r.id,
+  r.github_node_id,
+  r.github_owner,
+  r.github_name,
+  i.github_node_id,
+  i.github_database_id,
+  i.github_number,
+  i.title,
+  i.body,
+  i.url,
+  i.github_state,
+  ws.id,
+  ws.source_name,
+  ws.detent_state,
+  ws.terminal,
+  ws.dispatchable,
+  q.scope,
+  q.state,
+  q.rank,
+  q.priority_override,
+  i.labels_json,
+  i.assignees_json,
+  i.source_updated_at,
+  i.synchronized_at,
+  i.created_at,
+  i.updated_at
+FROM issues i
+JOIN repositories r ON r.id = i.repository_id
+LEFT JOIN workflow_states ws ON ws.id = i.workflow_state_id
+LEFT JOIN queue_entries q ON q.id = (
+  SELECT candidate.id
+  FROM queue_entries candidate
+  WHERE candidate.issue_id = i.id
+    AND (? = '' OR candidate.scope = ?)
+  ORDER BY CASE WHEN candidate.scope = ? THEN 0 ELSE 1 END, candidate.scope, candidate.id
+  LIMIT 1
+)
+`
+
+type databaseQueryer interface {
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+}
+
+var _ tracker.Store = (*database)(nil)
+
+func (d *database) ListCandidateRecords(ctx context.Context, query tracker.CandidateQuery) ([]tracker.Record, error) {
+	if query.Limit < 0 {
+		return nil, fmt.Errorf("%w: limit must not be negative", tracker.ErrInvalidCandidateQuery)
+	}
+	query.Scope = strings.TrimSpace(query.Scope)
+	workflowStates := normalizedQueryStrings(query.WorkflowStates)
+	if len(query.WorkflowStates) > 0 && len(workflowStates) == 0 {
+		return nil, fmt.Errorf("%w: workflow states must include a non-empty value", tracker.ErrInvalidCandidateQuery)
+	}
+
+	clauses := []string{
+		"lower(trim(i.github_state)) = 'open'",
+		"ws.id IS NOT NULL",
+		"ws.terminal = 0",
+	}
+	args := []any{query.Scope, query.Scope, query.Scope}
+	if len(workflowStates) == 0 {
+		clauses = append(clauses, "ws.dispatchable = 1")
+	} else {
+		clauses = append(clauses, "lower(ws.detent_state) IN ("+placeholders(len(workflowStates))+")")
+		for _, state := range workflowStates {
+			args = append(args, state)
+		}
+	}
+	if query.Scope != "" {
+		clauses = append(clauses, "q.id IS NOT NULL")
+	}
+	repositoryIDs, err := normalizedRepositoryIDs(query.RepositoryIDs)
+	if err != nil {
+		return nil, err
+	}
+	if len(repositoryIDs) > 0 {
+		clauses = append(clauses, "r.id IN ("+placeholders(len(repositoryIDs))+")")
+		for _, id := range repositoryIDs {
+			args = append(args, id)
+		}
+	}
+	limit := query.Limit
+	if limit == 0 {
+		limit = tracker.DefaultCandidateLimit
+	}
+	args = append(args, limit)
+	statement := workItemColumns + "WHERE " + strings.Join(clauses, " AND ") + " ORDER BY i.id LIMIT ?"
+
+	return d.readWorkItemRecords(ctx, statement, args)
+}
+
+func (d *database) GetWorkItemRecords(ctx context.Context, ids []tracker.WorkItemID) ([]tracker.Record, error) {
+	ids, err := normalizedWorkItemIDs(ids)
+	if err != nil || len(ids) == 0 {
+		return []tracker.Record{}, err
+	}
+	args := []any{"", "", ""}
+	for _, id := range ids {
+		args = append(args, id)
+	}
+	statement := workItemColumns + "WHERE i.id IN (" + placeholders(len(ids)) + ") ORDER BY i.id"
+	return d.readWorkItemRecords(ctx, statement, args)
+}
+
+func (d *database) readWorkItemRecords(ctx context.Context, statement string, args []any) (records []tracker.Record, resultErr error) {
+	tx, err := d.db.BeginTx(ctx, &sql.TxOptions{ReadOnly: true})
+	if err != nil {
+		return nil, fmt.Errorf("begin hub tracker read: %w", err)
+	}
+	defer func() {
+		if resultErr != nil {
+			resultErr = errors.Join(resultErr, tx.Rollback())
+		}
+	}()
+
+	records, err = queryWorkItemRecords(ctx, tx, statement, args)
+	if err != nil {
+		return nil, err
+	}
+	if err := enrichWorkItemRecords(ctx, tx, records); err != nil {
+		return nil, err
+	}
+	if err := tx.Commit(); err != nil {
+		return nil, fmt.Errorf("commit hub tracker read: %w", err)
+	}
+	return records, nil
+}
+
+func queryWorkItemRecords(ctx context.Context, queryer databaseQueryer, statement string, args []any) ([]tracker.Record, error) {
+	rows, err := queryer.QueryContext(ctx, statement, args...)
+	if err != nil {
+		return nil, fmt.Errorf("query hub work items: %w", err)
+	}
+	defer rows.Close()
+
+	records := make([]tracker.Record, 0)
+	for rows.Next() {
+		record, err := scanWorkItemRecord(rows)
+		if err != nil {
+			return nil, err
+		}
+		records = append(records, record)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate hub work items: %w", err)
+	}
+	return records, nil
+}
+
+func scanWorkItemRecord(row interface{ Scan(...any) error }) (tracker.Record, error) {
+	var record tracker.Record
+	var githubDatabaseID sql.NullInt64
+	var workflowID sql.NullInt64
+	var workflowSourceName sql.NullString
+	var workflowName sql.NullString
+	var workflowTerminal sql.NullBool
+	var workflowDispatchable sql.NullBool
+	var queueScope sql.NullString
+	var queueState sql.NullString
+	var queueRank sql.NullString
+	var priorityRank sql.NullInt64
+	var labelsJSON string
+	var assigneesJSON string
+	var sourceUpdatedAt string
+	var sourceSyncedAt string
+	var createdAt string
+	var updatedAt string
+	err := row.Scan(
+		&record.ID,
+		&record.Repository.ID,
+		&record.Repository.GitHubNodeID,
+		&record.Repository.Owner,
+		&record.Repository.Name,
+		&record.GitHub.NodeID,
+		&githubDatabaseID,
+		&record.GitHub.Number,
+		&record.Title,
+		&record.Body,
+		&record.URL,
+		&record.SourceState,
+		&workflowID,
+		&workflowSourceName,
+		&workflowName,
+		&workflowTerminal,
+		&workflowDispatchable,
+		&queueScope,
+		&queueState,
+		&queueRank,
+		&priorityRank,
+		&labelsJSON,
+		&assigneesJSON,
+		&sourceUpdatedAt,
+		&sourceSyncedAt,
+		&createdAt,
+		&updatedAt,
+	)
+	if err != nil {
+		return tracker.Record{}, fmt.Errorf("scan hub work item: %w", err)
+	}
+	if githubDatabaseID.Valid {
+		record.GitHub.DatabaseID = &githubDatabaseID.Int64
+	}
+	if workflowID.Valid {
+		record.WorkflowState = &tracker.WorkflowState{
+			ID:           workflowID.Int64,
+			SourceName:   workflowSourceName.String,
+			Name:         workflowName.String,
+			Terminal:     workflowTerminal.Bool,
+			Dispatchable: workflowDispatchable.Bool,
+		}
+	}
+	if queueScope.Valid {
+		record.Queue = &tracker.QueueSummary{
+			Scope: queueScope.String,
+			State: queueState.String,
+			Rank:  queueRank.String,
+		}
+		if priorityRank.Valid {
+			priority := int(priorityRank.Int64)
+			record.Queue.PriorityRank = &priority
+		}
+	}
+	if err := json.Unmarshal([]byte(labelsJSON), &record.Labels); err != nil {
+		return tracker.Record{}, fmt.Errorf("decode hub work item labels: %w", err)
+	}
+	if err := json.Unmarshal([]byte(assigneesJSON), &record.Assignees); err != nil {
+		return tracker.Record{}, fmt.Errorf("decode hub work item assignees: %w", err)
+	}
+	if record.SourceUpdatedAt, err = parsedTime(sourceUpdatedAt); err != nil {
+		return tracker.Record{}, fmt.Errorf("decode hub work item source updated timestamp: %w", err)
+	}
+	if record.SourceSyncedAt, err = parsedTime(sourceSyncedAt); err != nil {
+		return tracker.Record{}, fmt.Errorf("decode hub work item synchronized timestamp: %w", err)
+	}
+	if record.CreatedAt, err = parsedTime(createdAt); err != nil {
+		return tracker.Record{}, fmt.Errorf("decode hub work item created timestamp: %w", err)
+	}
+	if record.UpdatedAt, err = parsedTime(updatedAt); err != nil {
+		return tracker.Record{}, fmt.Errorf("decode hub work item updated timestamp: %w", err)
+	}
+	record.SyncStatus = tracker.SyncStatusSynced
+	record.ObservedAt = time.Now().UTC()
+	return record, nil
+}
+
+func enrichWorkItemRecords(ctx context.Context, queryer databaseQueryer, records []tracker.Record) error {
+	if len(records) == 0 {
+		return nil
+	}
+	index := make(map[tracker.WorkItemID]*tracker.Record, len(records))
+	ids := make([]tracker.WorkItemID, 0, len(records))
+	for i := range records {
+		index[records[i].ID] = &records[i]
+		ids = append(ids, records[i].ID)
+	}
+	if err := loadWorkItemRelations(ctx, queryer, index, ids); err != nil {
+		return err
+	}
+	if err := loadWorkItemLeases(ctx, queryer, index, ids); err != nil {
+		return err
+	}
+	if err := loadWorkItemPullRequests(ctx, queryer, index, ids); err != nil {
+		return err
+	}
+	return loadWorkItemSyncStatus(ctx, queryer, index, ids)
+}
+
+func loadWorkItemRelations(ctx context.Context, queryer databaseQueryer, index map[tracker.WorkItemID]*tracker.Record, ids []tracker.WorkItemID) error {
+	marks := placeholders(len(ids))
+	statement := `
+SELECT d.dependent_issue_id, 'blocker', related.id, r.github_owner, r.github_name, related.github_number, related.title, related.url, related.github_state, ws.id, ws.source_name, ws.detent_state, ws.terminal, ws.dispatchable
+FROM issue_dependencies d
+JOIN issues related ON related.id = d.blocker_issue_id
+JOIN repositories r ON r.id = related.repository_id
+LEFT JOIN workflow_states ws ON ws.id = related.workflow_state_id
+WHERE d.dependent_issue_id IN (` + marks + `)
+UNION ALL
+SELECT d.blocker_issue_id, 'dependent', related.id, r.github_owner, r.github_name, related.github_number, related.title, related.url, related.github_state, ws.id, ws.source_name, ws.detent_state, ws.terminal, ws.dispatchable
+FROM issue_dependencies d
+JOIN issues related ON related.id = d.dependent_issue_id
+JOIN repositories r ON r.id = related.repository_id
+LEFT JOIN workflow_states ws ON ws.id = related.workflow_state_id
+WHERE d.blocker_issue_id IN (` + marks + `)
+ORDER BY 1, 2, 3`
+	args := make([]any, 0, len(ids)*2)
+	for _, id := range ids {
+		args = append(args, id)
+	}
+	for _, id := range ids {
+		args = append(args, id)
+	}
+	rows, err := queryer.QueryContext(ctx, statement, args...)
+	if err != nil {
+		return fmt.Errorf("query hub work item relationships: %w", err)
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var parentID tracker.WorkItemID
+		var relation string
+		var reference tracker.WorkItemReference
+		var owner string
+		var name string
+		var sourceState string
+		var workflowID sql.NullInt64
+		var workflowSourceName sql.NullString
+		var workflowName sql.NullString
+		var workflowTerminal sql.NullBool
+		var workflowDispatchable sql.NullBool
+		if err := rows.Scan(&parentID, &relation, &reference.ID, &owner, &name, &reference.IssueNumber, &reference.Title, &reference.URL, &sourceState, &workflowID, &workflowSourceName, &workflowName, &workflowTerminal, &workflowDispatchable); err != nil {
+			return fmt.Errorf("scan hub work item relationship: %w", err)
+		}
+		reference.Repository = owner + "/" + name
+		reference.SourceState = tracker.SourceState(strings.ToLower(strings.TrimSpace(sourceState)))
+		if workflowID.Valid {
+			reference.WorkflowState = &tracker.WorkflowState{ID: workflowID.Int64, SourceName: workflowSourceName.String, Name: workflowName.String, Terminal: workflowTerminal.Bool, Dispatchable: workflowDispatchable.Bool}
+		}
+		record, err := indexedWorkItem(index, parentID)
+		if err != nil {
+			return err
+		}
+		if relation == "blocker" {
+			record.Blockers = append(record.Blockers, reference)
+		} else {
+			record.Dependents = append(record.Dependents, reference)
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return fmt.Errorf("iterate hub work item relationships: %w", err)
+	}
+	return nil
+}
+
+func loadWorkItemLeases(ctx context.Context, queryer databaseQueryer, index map[tracker.WorkItemID]*tracker.Record, ids []tracker.WorkItemID) error {
+	statement := `
+SELECT l.issue_id, l.lease_id, l.fencing_token, l.machine_id, m.hostname, m.display_name, l.session_id, l.acquired_at, l.renewed_at, l.expires_at
+FROM leases l
+JOIN machines m ON m.id = l.machine_id
+WHERE l.released_at IS NULL AND l.issue_id IN (` + placeholders(len(ids)) + `)
+ORDER BY l.issue_id`
+	rows, err := queryer.QueryContext(ctx, statement, workItemIDArgs(ids)...)
+	if err != nil {
+		return fmt.Errorf("query hub work item leases: %w", err)
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var issueID tracker.WorkItemID
+		var lease tracker.LeaseSummary
+		var acquiredAt string
+		var renewedAt string
+		var expiresAt string
+		if err := rows.Scan(&issueID, &lease.ID, &lease.FencingToken, &lease.Machine.ID, &lease.Machine.Hostname, &lease.Machine.DisplayName, &lease.SessionID, &acquiredAt, &renewedAt, &expiresAt); err != nil {
+			return fmt.Errorf("scan hub work item lease: %w", err)
+		}
+		var err error
+		if lease.AcquiredAt, err = parseTimeValue(acquiredAt); err != nil {
+			return fmt.Errorf("decode hub lease acquired timestamp: %w", err)
+		}
+		if lease.RenewedAt, err = parseTimeValue(renewedAt); err != nil {
+			return fmt.Errorf("decode hub lease renewed timestamp: %w", err)
+		}
+		if lease.ExpiresAt, err = parseTimeValue(expiresAt); err != nil {
+			return fmt.Errorf("decode hub lease expiry timestamp: %w", err)
+		}
+		record, err := indexedWorkItem(index, issueID)
+		if err != nil {
+			return err
+		}
+		record.Lease = &lease
+	}
+	if err := rows.Err(); err != nil {
+		return fmt.Errorf("iterate hub work item leases: %w", err)
+	}
+	return nil
+}
+
+func loadWorkItemPullRequests(ctx context.Context, queryer databaseQueryer, index map[tracker.WorkItemID]*tracker.Record, ids []tracker.WorkItemID) error {
+	statement := `
+SELECT issue_id, id, github_node_id, github_number, title, url, github_state, draft, head_ref, head_sha, base_ref, base_sha, mergeable_state, checks_summary_json, reviews_summary_json, merge_ready, merge_readiness_refreshed_at
+FROM pull_requests
+WHERE issue_id IN (` + placeholders(len(ids)) + `)
+ORDER BY issue_id, github_number`
+	rows, err := queryer.QueryContext(ctx, statement, workItemIDArgs(ids)...)
+	if err != nil {
+		return fmt.Errorf("query hub work item pull requests: %w", err)
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var issueID tracker.WorkItemID
+		var pullRequest tracker.PullRequestSummary
+		var checksJSON string
+		var reviewsJSON string
+		var refreshedAt sql.NullString
+		if err := rows.Scan(&issueID, &pullRequest.ID, &pullRequest.GitHubNodeID, &pullRequest.Number, &pullRequest.Title, &pullRequest.URL, &pullRequest.State, &pullRequest.Draft, &pullRequest.HeadRef, &pullRequest.HeadSHA, &pullRequest.BaseRef, &pullRequest.BaseSHA, &pullRequest.Merge.State, &checksJSON, &reviewsJSON, &pullRequest.Merge.Ready, &refreshedAt); err != nil {
+			return fmt.Errorf("scan hub work item pull request: %w", err)
+		}
+		if err := json.Unmarshal([]byte(checksJSON), &pullRequest.Checks); err != nil {
+			return fmt.Errorf("decode hub pull request checks summary: %w", err)
+		}
+		if err := json.Unmarshal([]byte(reviewsJSON), &pullRequest.Reviews); err != nil {
+			return fmt.Errorf("decode hub pull request reviews summary: %w", err)
+		}
+		if refreshedAt.Valid {
+			parsed, err := parseTimeValue(refreshedAt.String)
+			if err != nil {
+				return fmt.Errorf("decode hub pull request merge timestamp: %w", err)
+			}
+			pullRequest.Merge.RefreshedAt = &parsed
+		}
+		record, err := indexedWorkItem(index, issueID)
+		if err != nil {
+			return err
+		}
+		record.PullRequests = append(record.PullRequests, pullRequest)
+	}
+	if err := rows.Err(); err != nil {
+		return fmt.Errorf("iterate hub work item pull requests: %w", err)
+	}
+	return nil
+}
+
+func loadWorkItemSyncStatus(ctx context.Context, queryer databaseQueryer, index map[tracker.WorkItemID]*tracker.Record, ids []tracker.WorkItemID) error {
+	statement := `
+SELECT issue_id, status, attempts, next_retry_at, terminal_error
+FROM github_outbox
+WHERE issue_id IN (` + placeholders(len(ids)) + `) AND completed_at IS NULL
+ORDER BY issue_id, id`
+	rows, err := queryer.QueryContext(ctx, statement, workItemIDArgs(ids)...)
+	if err != nil {
+		return fmt.Errorf("query hub work item sync status: %w", err)
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var issueID tracker.WorkItemID
+		var status string
+		var attempts int
+		var nextRetryAt sql.NullString
+		var terminalError sql.NullString
+		if err := rows.Scan(&issueID, &status, &attempts, &nextRetryAt, &terminalError); err != nil {
+			return fmt.Errorf("scan hub work item sync status: %w", err)
+		}
+		record, err := indexedWorkItem(index, issueID)
+		if err != nil {
+			return err
+		}
+		candidate := classifySyncStatus(status, attempts, nextRetryAt.Valid, terminalError.String)
+		if syncStatusPriority(candidate) > syncStatusPriority(record.SyncStatus) {
+			record.SyncStatus = candidate
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return fmt.Errorf("iterate hub work item sync status: %w", err)
+	}
+	return nil
+}
+
+func indexedWorkItem(index map[tracker.WorkItemID]*tracker.Record, id tracker.WorkItemID) (*tracker.Record, error) {
+	record, ok := index[id]
+	if !ok || record == nil {
+		return nil, fmt.Errorf("hub work item enrichment references unknown item %d", id)
+	}
+	return record, nil
+}
+
+func classifySyncStatus(status string, attempts int, retryScheduled bool, terminalError string) tracker.SyncStatus {
+	status = strings.ToLower(strings.TrimSpace(status))
+	if strings.TrimSpace(terminalError) != "" || status == "error" || status == "failed" || status == "dead_letter" {
+		return tracker.SyncStatusError
+	}
+	if status == "retrying" || attempts > 0 || retryScheduled {
+		return tracker.SyncStatusRetrying
+	}
+	if status == "complete" || status == "completed" || status == "succeeded" || status == "synced" {
+		return tracker.SyncStatusSynced
+	}
+	return tracker.SyncStatusPending
+}
+
+func syncStatusPriority(status tracker.SyncStatus) int {
+	switch status {
+	case tracker.SyncStatusError:
+		return 4
+	case tracker.SyncStatusStale:
+		return 3
+	case tracker.SyncStatusRetrying:
+		return 2
+	case tracker.SyncStatusPending:
+		return 1
+	default:
+		return 0
+	}
+}
+
+func normalizedWorkItemIDs(ids []tracker.WorkItemID) ([]tracker.WorkItemID, error) {
+	result := make([]tracker.WorkItemID, 0, len(ids))
+	seen := make(map[tracker.WorkItemID]struct{}, len(ids))
+	for _, id := range ids {
+		if id <= 0 {
+			return nil, fmt.Errorf("%w: %d", tracker.ErrInvalidWorkItemID, id)
+		}
+		if _, ok := seen[id]; ok {
+			continue
+		}
+		seen[id] = struct{}{}
+		result = append(result, id)
+	}
+	return result, nil
+}
+
+func normalizedRepositoryIDs(ids []tracker.RepositoryID) ([]tracker.RepositoryID, error) {
+	result := make([]tracker.RepositoryID, 0, len(ids))
+	seen := make(map[tracker.RepositoryID]struct{}, len(ids))
+	for _, id := range ids {
+		if id <= 0 {
+			return nil, fmt.Errorf("%w: repository ID must be positive: %d", tracker.ErrInvalidCandidateQuery, id)
+		}
+		if _, ok := seen[id]; ok {
+			continue
+		}
+		seen[id] = struct{}{}
+		result = append(result, id)
+	}
+	return result, nil
+}
+
+func normalizedQueryStrings(values []string) []string {
+	result := make([]string, 0, len(values))
+	seen := make(map[string]struct{}, len(values))
+	for _, value := range values {
+		value = strings.ToLower(strings.TrimSpace(value))
+		if value == "" {
+			continue
+		}
+		if _, ok := seen[value]; ok {
+			continue
+		}
+		seen[value] = struct{}{}
+		result = append(result, value)
+	}
+	return result
+}
+
+func placeholders(count int) string {
+	if count <= 0 {
+		return ""
+	}
+	return strings.TrimSuffix(strings.Repeat("?,", count), ",")
+}
+
+func workItemIDArgs(ids []tracker.WorkItemID) []any {
+	args := make([]any, 0, len(ids))
+	for _, id := range ids {
+		args = append(args, id)
+	}
+	return args
+}
+
+func parsedTime(value string) (*time.Time, error) {
+	parsed, err := parseTimeValue(value)
+	if err != nil {
+		return nil, err
+	}
+	return &parsed, nil
+}
+
+func parseTimeValue(value string) (time.Time, error) {
+	return time.Parse(time.RFC3339Nano, strings.TrimSpace(value))
+}

--- a/internal/hubserver/tracker_store_test.go
+++ b/internal/hubserver/tracker_store_test.go
@@ -1,0 +1,159 @@
+package hubserver
+
+import (
+	"errors"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/digitaldrywood/detent/internal/tracker"
+)
+
+func TestTrackerReadsNormalizedWorkItems(t *testing.T) {
+	t.Parallel()
+
+	service := openTestService(t, Config{DatabasePath: filepath.Join(t.TempDir(), "hub.db")})
+	repositoryID, issueID := seedProjection(t, service.database.db)
+	blockerID := insertHubTestIssue(t, service, repositoryID, 2, "I_blocker", "closed", nil)
+	dependentID := insertHubTestIssue(t, service, repositoryID, 3, "I_dependent", "open", nil)
+	if _, err := service.database.db.ExecContext(t.Context(), "INSERT INTO issue_dependencies (blocker_issue_id, dependent_issue_id, provenance, created_at, updated_at) VALUES (?, ?, ?, ?, ?), (?, ?, ?, ?, ?)", blockerID, issueID, "native", testTimestamp, testTimestamp, issueID, dependentID, "native", testTimestamp, testTimestamp); err != nil {
+		t.Fatalf("insert dependencies: %v", err)
+	}
+	if _, err := service.database.db.ExecContext(t.Context(), "INSERT INTO queue_entries (issue_id, workflow_state_id, scope, state, rank, priority_override, created_at, updated_at) SELECT ?, workflow_state_id, ?, ?, ?, ?, ?, ? FROM issues WHERE id = ?", issueID, "fleet", "Todo", "a0", 2, testTimestamp, testTimestamp, issueID); err != nil {
+		t.Fatalf("insert queue entry: %v", err)
+	}
+	if _, err := service.database.db.ExecContext(t.Context(), "UPDATE issues SET body = ?, labels_json = ?, assignees_json = ?, github_database_id = ? WHERE id = ?", " Work item body ", `["hub"," Feature ","hub"]`, `["detent-bot"]`, 2068, issueID); err != nil {
+		t.Fatalf("update issue projection: %v", err)
+	}
+	if _, err := service.database.db.ExecContext(t.Context(), "UPDATE pull_requests SET checks_summary_json = ?, reviews_summary_json = ?, mergeable_state = ?, merge_ready = 1, merge_readiness_refreshed_at = ? WHERE issue_id = ?", `{"status":"completed","passed":3,"total":3}`, `{"decision":"approved","approvals":1}`, "clean", testTimestamp, issueID); err != nil {
+		t.Fatalf("update pull request projection: %v", err)
+	}
+	if _, err := service.database.db.ExecContext(t.Context(), "INSERT INTO machines (id, hostname, display_name, capacity, version, last_heartbeat_at, registered_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?)", "machine-a", "worker-a", "Worker A", 1, "test", testTimestamp, testTimestamp, testTimestamp); err != nil {
+		t.Fatalf("insert machine: %v", err)
+	}
+	future := time.Now().UTC().Add(time.Hour).Format(time.RFC3339Nano)
+	if _, err := service.database.db.ExecContext(t.Context(), "INSERT INTO leases (lease_id, issue_id, machine_id, session_id, expires_at, acquired_at, renewed_at, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)", "lease-a", issueID, "machine-a", "session-a", future, testTimestamp, testTimestamp, testTimestamp, testTimestamp); err != nil {
+		t.Fatalf("insert lease: %v", err)
+	}
+	if _, err := service.database.db.ExecContext(t.Context(), "INSERT INTO github_outbox (idempotency_key, repository_id, issue_id, mutation_kind, desired_json, status, attempts, next_retry_at, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)", "sync-a", repositoryID, issueID, "label", `{}`, "pending", 1, future, testTimestamp, testTimestamp); err != nil {
+		t.Fatalf("insert outbox: %v", err)
+	}
+
+	items, err := service.Tracker().GetWorkItems(t.Context(), []tracker.WorkItemID{tracker.WorkItemID(issueID)})
+	if err != nil {
+		t.Fatalf("GetWorkItems() error = %v", err)
+	}
+	if len(items) != 1 {
+		t.Fatalf("GetWorkItems() count = %d, want 1", len(items))
+	}
+	item := items[0]
+	if item.Repository.ID != tracker.RepositoryID(repositoryID) || item.Repository.Owner != "digitaldrywood" || item.GitHub.NodeID != "I_issue" || item.GitHub.Number != 1 || item.GitHub.DatabaseID == nil || *item.GitHub.DatabaseID != 2068 {
+		t.Errorf("source identity = repository %#v GitHub %#v", item.Repository, item.GitHub)
+	}
+	if item.BodyExcerpt != "Work item body" || strings.Join(item.Labels, ",") != "hub,Feature" || strings.Join(item.Assignees, ",") != "detent-bot" {
+		t.Errorf("normalized content = body %q labels %v assignees %v", item.BodyExcerpt, item.Labels, item.Assignees)
+	}
+	if item.Queue == nil || item.Queue.Scope != "fleet" || item.Queue.PriorityRank == nil || *item.Queue.PriorityRank != 2 {
+		t.Errorf("Queue = %#v", item.Queue)
+	}
+	if len(item.Blockers) != 1 || item.Blockers[0].ID != tracker.WorkItemID(blockerID) || len(item.Dependents) != 1 || item.Dependents[0].ID != tracker.WorkItemID(dependentID) {
+		t.Errorf("relationships = blockers %#v dependents %#v", item.Blockers, item.Dependents)
+	}
+	if item.ActiveLease == nil || item.ActiveLease.ID != "lease-a" || item.ActiveLease.Machine.Hostname != "worker-a" || item.ActiveLease.SessionID != "session-a" {
+		t.Errorf("ActiveLease = %#v", item.ActiveLease)
+	}
+	if len(item.PullRequests) != 1 || item.PullRequests[0].HeadRef != "feature" || item.PullRequests[0].Checks.Passed != 3 || item.PullRequests[0].Reviews.Decision != "approved" || !item.PullRequests[0].Merge.Ready || item.PullRequests[0].Merge.State != "clean" {
+		t.Errorf("PullRequests = %#v", item.PullRequests)
+	}
+	if item.SyncStatus != tracker.SyncStatusRetrying {
+		t.Errorf("SyncStatus = %q, want retrying", item.SyncStatus)
+	}
+	if item.Dispatchability.Dispatchable || len(item.Dispatchability.Reasons) != 1 || item.Dispatchability.Reasons[0].Code != tracker.DispatchReasonLeaseActive {
+		t.Errorf("Dispatchability = %#v, want active lease reason", item.Dispatchability)
+	}
+
+	candidates, err := service.Tracker().ListCandidates(t.Context(), tracker.CandidateQuery{RepositoryIDs: []tracker.RepositoryID{tracker.RepositoryID(repositoryID)}, WorkflowStates: []string{" todo ", "TODO"}, Scope: "fleet", Limit: 10})
+	if err != nil {
+		t.Fatalf("ListCandidates() error = %v", err)
+	}
+	if len(candidates) != 1 || candidates[0].ID != tracker.WorkItemID(issueID) {
+		t.Fatalf("ListCandidates() = %#v, want issue %d", candidates, issueID)
+	}
+}
+
+func TestTrackerReadsPartialProjection(t *testing.T) {
+	t.Parallel()
+
+	service := openTestService(t, Config{DatabasePath: filepath.Join(t.TempDir(), "hub.db")})
+	repositoryID, _ := seedProjection(t, service.database.db)
+	issueID := insertHubTestIssue(t, service, repositoryID, 4, "I_partial", "mystery", nil)
+	items, err := service.Tracker().GetWorkItems(t.Context(), []tracker.WorkItemID{tracker.WorkItemID(issueID), tracker.WorkItemID(issueID)})
+	if err != nil {
+		t.Fatalf("GetWorkItems() error = %v", err)
+	}
+	if len(items) != 1 {
+		t.Fatalf("GetWorkItems() count = %d, want 1", len(items))
+	}
+	item := items[0]
+	if item.SourceState != tracker.SourceStateUnknown || item.WorkflowState != nil || item.Labels == nil || item.Assignees == nil || item.Blockers == nil || item.Dependents == nil || item.PullRequests == nil || item.Dispatchability.Reasons == nil {
+		t.Fatalf("partial WorkItem was not normalized: %#v", item)
+	}
+	wantReasons := []tracker.DispatchReasonCode{tracker.DispatchReasonSourceStateUnknown, tracker.DispatchReasonWorkflowStateMissing}
+	if len(item.Dispatchability.Reasons) != len(wantReasons) {
+		t.Fatalf("Dispatchability reasons = %#v, want %v", item.Dispatchability.Reasons, wantReasons)
+	}
+	for i, want := range wantReasons {
+		if item.Dispatchability.Reasons[i].Code != want {
+			t.Errorf("Dispatchability reason %d = %q, want %q", i, item.Dispatchability.Reasons[i].Code, want)
+		}
+	}
+}
+
+func TestTrackerReadValidation(t *testing.T) {
+	t.Parallel()
+
+	service := openTestService(t, Config{DatabasePath: filepath.Join(t.TempDir(), "hub.db")})
+	tests := []struct {
+		name string
+		read func() error
+		want error
+	}{
+		{name: "negative limit", read: func() error {
+			_, err := service.Tracker().ListCandidates(t.Context(), tracker.CandidateQuery{Limit: -1})
+			return err
+		}, want: tracker.ErrInvalidCandidateQuery},
+		{name: "empty workflow states", read: func() error {
+			_, err := service.Tracker().ListCandidates(t.Context(), tracker.CandidateQuery{WorkflowStates: []string{" "}})
+			return err
+		}, want: tracker.ErrInvalidCandidateQuery},
+		{name: "invalid repository ID", read: func() error {
+			_, err := service.Tracker().ListCandidates(t.Context(), tracker.CandidateQuery{RepositoryIDs: []tracker.RepositoryID{0}})
+			return err
+		}, want: tracker.ErrInvalidCandidateQuery},
+		{name: "invalid ID", read: func() error {
+			_, err := service.Tracker().GetWorkItems(t.Context(), []tracker.WorkItemID{0})
+			return err
+		}, want: tracker.ErrInvalidWorkItemID},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if err := test.read(); !errors.Is(err, test.want) {
+				t.Fatalf("read error = %v, want %v", err, test.want)
+			}
+		})
+	}
+}
+
+func insertHubTestIssue(t *testing.T, service *Service, repositoryID int64, number int, nodeID string, state string, workflowID *int64) int64 {
+	t.Helper()
+	result, err := service.database.db.ExecContext(t.Context(), "INSERT INTO issues (repository_id, workflow_state_id, github_node_id, github_number, title, url, github_state, source_version, source_updated_at, synchronized_at, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)", repositoryID, workflowID, nodeID, number, "Issue", "https://example.test/"+nodeID, state, "v1", testTimestamp, testTimestamp, testTimestamp, testTimestamp)
+	if err != nil {
+		t.Fatalf("insert issue: %v", err)
+	}
+	issueID, err := result.LastInsertId()
+	if err != nil {
+		t.Fatalf("issue ID: %v", err)
+	}
+	return issueID
+}

--- a/internal/hubserver/tracker_store_test.go
+++ b/internal/hubserver/tracker_store_test.go
@@ -110,6 +110,47 @@ func TestTrackerReadsPartialProjection(t *testing.T) {
 	}
 }
 
+func TestTrackerCandidatesApplyQueueOrderBeforeLimit(t *testing.T) {
+	t.Parallel()
+
+	service := openTestService(t, Config{DatabasePath: filepath.Join(t.TempDir(), "hub.db")})
+	repositoryID, lowPriorityID := seedProjection(t, service.database.db)
+	var workflowID int64
+	if err := service.database.db.QueryRowContext(t.Context(), "SELECT workflow_state_id FROM issues WHERE id = ?", lowPriorityID).Scan(&workflowID); err != nil {
+		t.Fatalf("read workflow state: %v", err)
+	}
+	highPriorityLaterID := insertHubTestIssue(t, service, repositoryID, 2, "I_high_later", "open", &workflowID)
+	highPriorityEarlierID := insertHubTestIssue(t, service, repositoryID, 3, "I_high_earlier", "open", &workflowID)
+	entries := []struct {
+		issueID  int64
+		rank     string
+		priority int
+	}{
+		{issueID: lowPriorityID, rank: "00", priority: 2},
+		{issueID: highPriorityLaterID, rank: "z0", priority: 0},
+		{issueID: highPriorityEarlierID, rank: "a0", priority: 0},
+	}
+	for _, entry := range entries {
+		if _, err := service.database.db.ExecContext(t.Context(), "INSERT INTO queue_entries (issue_id, workflow_state_id, scope, state, rank, priority_override, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?)", entry.issueID, workflowID, "fleet", "Todo", entry.rank, entry.priority, testTimestamp, testTimestamp); err != nil {
+			t.Fatalf("insert queue entry for issue %d: %v", entry.issueID, err)
+		}
+	}
+
+	candidates, err := service.Tracker().ListCandidates(t.Context(), tracker.CandidateQuery{Scope: "fleet", Limit: 2})
+	if err != nil {
+		t.Fatalf("ListCandidates() error = %v", err)
+	}
+	want := []tracker.WorkItemID{tracker.WorkItemID(highPriorityEarlierID), tracker.WorkItemID(highPriorityLaterID)}
+	if len(candidates) != len(want) {
+		t.Fatalf("ListCandidates() count = %d, want %d", len(candidates), len(want))
+	}
+	for i := range want {
+		if candidates[i].ID != want[i] {
+			t.Errorf("ListCandidates()[%d].ID = %d, want %d", i, candidates[i].ID, want[i])
+		}
+	}
+}
+
 func TestTrackerReadValidation(t *testing.T) {
 	t.Parallel()
 

--- a/internal/tracker/normalize.go
+++ b/internal/tracker/normalize.go
@@ -1,0 +1,261 @@
+package tracker
+
+import (
+	"strings"
+	"time"
+	"unicode/utf8"
+)
+
+const bodyExcerptLimit = 500
+
+type Record struct {
+	ID              WorkItemID
+	Repository      RepositoryReference
+	GitHub          GitHubIssueReference
+	Title           string
+	Body            string
+	URL             string
+	SourceState     string
+	WorkflowState   *WorkflowState
+	Queue           *QueueSummary
+	Labels          []string
+	Assignees       []string
+	CreatedAt       *time.Time
+	UpdatedAt       *time.Time
+	SourceUpdatedAt *time.Time
+	SourceSyncedAt  *time.Time
+	Blockers        []WorkItemReference
+	Dependents      []WorkItemReference
+	Lease           *LeaseSummary
+	PullRequests    []PullRequestSummary
+	SyncStatus      SyncStatus
+	ObservedAt      time.Time
+}
+
+func Normalize(record Record) WorkItem {
+	github := record.GitHub
+	github.NodeID = strings.TrimSpace(github.NodeID)
+	if github.DatabaseID != nil {
+		databaseID := *github.DatabaseID
+		github.DatabaseID = &databaseID
+	}
+	item := WorkItem{
+		ID:              record.ID,
+		Repository:      normalizeRepository(record.Repository),
+		GitHub:          github,
+		Title:           strings.TrimSpace(record.Title),
+		BodyExcerpt:     bodyExcerpt(record.Body),
+		URL:             strings.TrimSpace(record.URL),
+		SourceState:     normalizeSourceState(record.SourceState),
+		WorkflowState:   normalizeWorkflowState(record.WorkflowState),
+		Queue:           normalizeQueue(record.Queue),
+		Labels:          normalizeStrings(record.Labels),
+		Assignees:       normalizeStrings(record.Assignees),
+		CreatedAt:       cloneTime(record.CreatedAt),
+		UpdatedAt:       cloneTime(record.UpdatedAt),
+		SourceUpdatedAt: cloneTime(record.SourceUpdatedAt),
+		SourceSyncedAt:  cloneTime(record.SourceSyncedAt),
+		Blockers:        normalizeReferences(record.Blockers),
+		Dependents:      normalizeReferences(record.Dependents),
+		PullRequests:    normalizePullRequests(record.PullRequests),
+		SyncStatus:      normalizeSyncStatus(record.SyncStatus),
+	}
+	item.ActiveLease = activeLease(record.Lease, record.ObservedAt)
+	item.Dispatchability = deriveDispatchability(item)
+	return item
+}
+
+func normalizeRecords(records []Record) []WorkItem {
+	items := make([]WorkItem, 0, len(records))
+	for _, record := range records {
+		items = append(items, Normalize(record))
+	}
+	return items
+}
+
+func deriveDispatchability(item WorkItem) Dispatchability {
+	reasons := make([]DispatchReason, 0)
+	switch item.SourceState {
+	case SourceStateClosed:
+		reasons = append(reasons, DispatchReason{Code: DispatchReasonIssueClosed, Message: "issue is closed"})
+	case SourceStateOpen:
+	default:
+		reasons = append(reasons, DispatchReason{Code: DispatchReasonSourceStateUnknown, Message: "issue source state is unknown"})
+	}
+
+	if item.WorkflowState == nil || item.WorkflowState.Name == "" {
+		reasons = append(reasons, DispatchReason{Code: DispatchReasonWorkflowStateMissing, Message: "workflow state is unavailable"})
+	} else if item.WorkflowState.Terminal {
+		reasons = append(reasons, DispatchReason{Code: DispatchReasonWorkflowStateTerminal, Message: "workflow state is terminal"})
+	} else if !item.WorkflowState.Dispatchable {
+		reasons = append(reasons, DispatchReason{Code: DispatchReasonWorkflowStateNotDispatchable, Message: "workflow state is not dispatchable"})
+	}
+
+	for i := range item.Blockers {
+		blocker := item.Blockers[i]
+		if blocker.SourceState == SourceStateClosed || blocker.WorkflowState != nil && blocker.WorkflowState.Terminal {
+			continue
+		}
+		blockerID := blocker.ID
+		reasons = append(reasons, DispatchReason{
+			Code:       DispatchReasonBlockerUnresolved,
+			Message:    "required blocker is unresolved",
+			WorkItemID: &blockerID,
+		})
+	}
+
+	if item.ActiveLease != nil {
+		reasons = append(reasons, DispatchReason{
+			Code:    DispatchReasonLeaseActive,
+			Message: "work item has an active lease",
+			LeaseID: item.ActiveLease.ID,
+		})
+	}
+	switch item.SyncStatus {
+	case SyncStatusError:
+		reasons = append(reasons, DispatchReason{Code: DispatchReasonSyncError, Message: "GitHub synchronization has an error"})
+	case SyncStatusStale:
+		reasons = append(reasons, DispatchReason{Code: DispatchReasonSyncStale, Message: "GitHub projection is stale"})
+	}
+
+	return Dispatchability{Dispatchable: len(reasons) == 0, Reasons: reasons}
+}
+
+func normalizeRepository(repository RepositoryReference) RepositoryReference {
+	repository.GitHubNodeID = strings.TrimSpace(repository.GitHubNodeID)
+	repository.Owner = strings.TrimSpace(repository.Owner)
+	repository.Name = strings.TrimSpace(repository.Name)
+	return repository
+}
+
+func normalizeSourceState(value string) SourceState {
+	switch strings.ToLower(strings.TrimSpace(value)) {
+	case string(SourceStateOpen):
+		return SourceStateOpen
+	case string(SourceStateClosed):
+		return SourceStateClosed
+	default:
+		return SourceStateUnknown
+	}
+}
+
+func normalizeSyncStatus(value SyncStatus) SyncStatus {
+	switch SyncStatus(strings.ToLower(strings.TrimSpace(string(value)))) {
+	case SyncStatusSynced:
+		return SyncStatusSynced
+	case SyncStatusPending:
+		return SyncStatusPending
+	case SyncStatusRetrying:
+		return SyncStatusRetrying
+	case SyncStatusError:
+		return SyncStatusError
+	case SyncStatusStale:
+		return SyncStatusStale
+	default:
+		return SyncStatusStale
+	}
+}
+
+func normalizeWorkflowState(state *WorkflowState) *WorkflowState {
+	if state == nil {
+		return nil
+	}
+	result := *state
+	result.SourceName = strings.TrimSpace(result.SourceName)
+	result.Name = strings.TrimSpace(result.Name)
+	return &result
+}
+
+func normalizeQueue(queue *QueueSummary) *QueueSummary {
+	if queue == nil {
+		return nil
+	}
+	result := *queue
+	result.Scope = strings.TrimSpace(result.Scope)
+	result.State = strings.TrimSpace(result.State)
+	result.Rank = strings.TrimSpace(result.Rank)
+	if result.PriorityRank != nil {
+		priority := *result.PriorityRank
+		result.PriorityRank = &priority
+	}
+	return &result
+}
+
+func normalizeReferences(references []WorkItemReference) []WorkItemReference {
+	result := make([]WorkItemReference, 0, len(references))
+	for _, reference := range references {
+		reference.Repository = strings.TrimSpace(reference.Repository)
+		reference.Title = strings.TrimSpace(reference.Title)
+		reference.URL = strings.TrimSpace(reference.URL)
+		reference.SourceState = normalizeSourceState(string(reference.SourceState))
+		reference.WorkflowState = normalizeWorkflowState(reference.WorkflowState)
+		result = append(result, reference)
+	}
+	return result
+}
+
+func normalizePullRequests(pullRequests []PullRequestSummary) []PullRequestSummary {
+	result := make([]PullRequestSummary, 0, len(pullRequests))
+	for _, pullRequest := range pullRequests {
+		pullRequest.GitHubNodeID = strings.TrimSpace(pullRequest.GitHubNodeID)
+		pullRequest.Title = strings.TrimSpace(pullRequest.Title)
+		pullRequest.URL = strings.TrimSpace(pullRequest.URL)
+		pullRequest.State = strings.ToLower(strings.TrimSpace(pullRequest.State))
+		pullRequest.HeadRef = strings.TrimSpace(pullRequest.HeadRef)
+		pullRequest.HeadSHA = strings.TrimSpace(pullRequest.HeadSHA)
+		pullRequest.BaseRef = strings.TrimSpace(pullRequest.BaseRef)
+		pullRequest.BaseSHA = strings.TrimSpace(pullRequest.BaseSHA)
+		pullRequest.Merge.State = strings.TrimSpace(pullRequest.Merge.State)
+		pullRequest.Merge.RefreshedAt = cloneTime(pullRequest.Merge.RefreshedAt)
+		result = append(result, pullRequest)
+	}
+	return result
+}
+
+func activeLease(lease *LeaseSummary, observedAt time.Time) *LeaseSummary {
+	if lease == nil || !observedAt.IsZero() && !lease.ExpiresAt.After(observedAt) {
+		return nil
+	}
+	result := *lease
+	result.ID = LeaseID(strings.TrimSpace(string(result.ID)))
+	result.Machine.ID = MachineID(strings.TrimSpace(string(result.Machine.ID)))
+	result.Machine.Hostname = strings.TrimSpace(result.Machine.Hostname)
+	result.Machine.DisplayName = strings.TrimSpace(result.Machine.DisplayName)
+	result.SessionID = strings.TrimSpace(result.SessionID)
+	return &result
+}
+
+func normalizeStrings(values []string) []string {
+	result := make([]string, 0, len(values))
+	seen := make(map[string]struct{}, len(values))
+	for _, value := range values {
+		value = strings.TrimSpace(value)
+		key := strings.ToLower(value)
+		if key == "" {
+			continue
+		}
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		seen[key] = struct{}{}
+		result = append(result, value)
+	}
+	return result
+}
+
+func bodyExcerpt(body string) string {
+	body = strings.TrimSpace(body)
+	if utf8.RuneCountInString(body) <= bodyExcerptLimit {
+		return body
+	}
+	runes := []rune(body)
+	return strings.TrimSpace(string(runes[:bodyExcerptLimit])) + "…"
+}
+
+func cloneTime(value *time.Time) *time.Time {
+	if value == nil {
+		return nil
+	}
+	result := *value
+	return &result
+}

--- a/internal/tracker/normalize_test.go
+++ b/internal/tracker/normalize_test.go
@@ -1,0 +1,225 @@
+package tracker
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestNormalizeWorkItem(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 9, 2, 12, 0, 0, 0, time.UTC)
+	todo := &WorkflowState{ID: 1, SourceName: " Todo ", Name: " Todo ", Dispatchable: true}
+	done := &WorkflowState{ID: 2, SourceName: " Done ", Name: " Done ", Terminal: true}
+	priority := 2
+	tests := []struct {
+		name              string
+		record            Record
+		wantDispatchable  bool
+		wantReasons       []DispatchReasonCode
+		wantState         SourceState
+		wantSync          SyncStatus
+		wantActiveLease   bool
+		wantLabels        []string
+		wantBodySuffix    string
+		wantBlockerID     WorkItemID
+		wantReasonLeaseID LeaseID
+	}{
+		{
+			name: "complete source record",
+			record: Record{
+				ID:            7,
+				Repository:    RepositoryReference{ID: 3, GitHubNodeID: " R_repo ", Owner: " digitaldrywood ", Name: " detent "},
+				GitHub:        GitHubIssueReference{NodeID: "I_issue", Number: 2068},
+				Title:         " Tracker contract ",
+				Body:          " normalized body ",
+				URL:           " https://example.test/issues/2068 ",
+				SourceState:   " OPEN ",
+				WorkflowState: todo,
+				Queue:         &QueueSummary{Scope: " fleet ", State: " Todo ", Rank: " a0 ", PriorityRank: &priority},
+				Labels:        []string{" feature ", "Feature", "hub"},
+				Assignees:     []string{" detent-bot ", ""},
+				Blockers:      []WorkItemReference{{ID: 6, SourceState: SourceStateClosed, WorkflowState: done}},
+				SyncStatus:    SyncStatusSynced,
+				ObservedAt:    now,
+			},
+			wantDispatchable: true,
+			wantState:        SourceStateOpen,
+			wantSync:         SyncStatusSynced,
+			wantLabels:       []string{"feature", "hub"},
+		},
+		{
+			name:   "missing upstream fields",
+			record: Record{ID: 8, Labels: nil, Assignees: nil},
+			wantReasons: []DispatchReasonCode{
+				DispatchReasonSourceStateUnknown,
+				DispatchReasonWorkflowStateMissing,
+				DispatchReasonSyncStale,
+			},
+			wantState:  SourceStateUnknown,
+			wantSync:   SyncStatusStale,
+			wantLabels: []string{},
+		},
+		{
+			name: "partial blocked leased errored record",
+			record: Record{
+				ID:            9,
+				SourceState:   "closed",
+				WorkflowState: done,
+				Blockers:      []WorkItemReference{{ID: 5, SourceState: SourceStateOpen, WorkflowState: todo}},
+				Lease:         &LeaseSummary{ID: " lease-9 ", Machine: MachineSummary{ID: " machine-a "}, SessionID: " session-a ", ExpiresAt: now.Add(time.Minute)},
+				SyncStatus:    SyncStatusError,
+				ObservedAt:    now,
+			},
+			wantReasons: []DispatchReasonCode{
+				DispatchReasonIssueClosed,
+				DispatchReasonWorkflowStateTerminal,
+				DispatchReasonBlockerUnresolved,
+				DispatchReasonLeaseActive,
+				DispatchReasonSyncError,
+			},
+			wantState:         SourceStateClosed,
+			wantSync:          SyncStatusError,
+			wantActiveLease:   true,
+			wantBlockerID:     5,
+			wantReasonLeaseID: "lease-9",
+		},
+		{
+			name:             "expired lease omitted",
+			record:           Record{ID: 10, SourceState: "open", WorkflowState: todo, Lease: &LeaseSummary{ID: "expired", ExpiresAt: now.Add(-time.Second)}, SyncStatus: SyncStatusPending, ObservedAt: now},
+			wantDispatchable: true,
+			wantState:        SourceStateOpen,
+			wantSync:         SyncStatusPending,
+			wantLabels:       []string{},
+		},
+		{
+			name:             "unicode body excerpt",
+			record:           Record{ID: 11, SourceState: "open", WorkflowState: todo, Body: strings.Repeat("木", bodyExcerptLimit+1), SyncStatus: SyncStatusSynced},
+			wantDispatchable: true,
+			wantState:        SourceStateOpen,
+			wantSync:         SyncStatusSynced,
+			wantLabels:       []string{},
+			wantBodySuffix:   "…",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			got := Normalize(test.record)
+			if got.Dispatchability.Dispatchable != test.wantDispatchable {
+				t.Fatalf("Dispatchable = %t, want %t; reasons = %#v", got.Dispatchability.Dispatchable, test.wantDispatchable, got.Dispatchability.Reasons)
+			}
+			if got.Dispatchability.Reasons == nil {
+				t.Fatal("Dispatchability.Reasons = nil, want structured reason slice")
+			}
+			if gotCodes := dispatchReasonCodes(got.Dispatchability.Reasons); strings.Join(gotCodes, ",") != strings.Join(reasonCodeStrings(test.wantReasons), ",") {
+				t.Fatalf("reason codes = %v, want %v", gotCodes, test.wantReasons)
+			}
+			if got.SourceState != test.wantState {
+				t.Errorf("SourceState = %q, want %q", got.SourceState, test.wantState)
+			}
+			if got.SyncStatus != test.wantSync {
+				t.Errorf("SyncStatus = %q, want %q", got.SyncStatus, test.wantSync)
+			}
+			if (got.ActiveLease != nil) != test.wantActiveLease {
+				t.Errorf("ActiveLease present = %t, want %t", got.ActiveLease != nil, test.wantActiveLease)
+			}
+			if test.wantReasonLeaseID != "" {
+				if got.ActiveLease == nil || got.ActiveLease.ID != test.wantReasonLeaseID {
+					t.Errorf("ActiveLease = %#v, want ID %q", got.ActiveLease, test.wantReasonLeaseID)
+				}
+			}
+			if test.wantBlockerID != 0 {
+				if got.Blockers[0].ID != test.wantBlockerID || got.Dispatchability.Reasons[2].WorkItemID == nil || *got.Dispatchability.Reasons[2].WorkItemID != test.wantBlockerID {
+					t.Errorf("blocker identity was not retained: item=%#v reasons=%#v", got.Blockers, got.Dispatchability.Reasons)
+				}
+			}
+			if test.wantLabels != nil && strings.Join(got.Labels, ",") != strings.Join(test.wantLabels, ",") {
+				t.Errorf("Labels = %v, want %v", got.Labels, test.wantLabels)
+			}
+			if test.wantBodySuffix != "" && !strings.HasSuffix(got.BodyExcerpt, test.wantBodySuffix) {
+				t.Errorf("BodyExcerpt suffix = %q, want %q", got.BodyExcerpt, test.wantBodySuffix)
+			}
+		})
+	}
+}
+
+func TestStoreTrackerReadsNormalizedItems(t *testing.T) {
+	t.Parallel()
+
+	store := &fakeStore{records: []Record{{ID: 1, SourceState: "open", WorkflowState: &WorkflowState{Name: "Todo", Dispatchable: true}, SyncStatus: SyncStatusSynced}}}
+	backend, err := NewStore(store)
+	if err != nil {
+		t.Fatalf("NewStore() error = %v", err)
+	}
+	items, err := backend.ListCandidates(t.Context(), CandidateQuery{Scope: "fleet"})
+	if err != nil {
+		t.Fatalf("ListCandidates() error = %v", err)
+	}
+	if len(items) != 1 || !items[0].Dispatchability.Dispatchable || store.candidateQuery.Scope != "fleet" {
+		t.Fatalf("ListCandidates() = %#v; query = %#v", items, store.candidateQuery)
+	}
+	items, err = backend.GetWorkItems(t.Context(), []WorkItemID{1})
+	if err != nil {
+		t.Fatalf("GetWorkItems() error = %v", err)
+	}
+	if len(items) != 1 || len(store.workItemIDs) != 1 || store.workItemIDs[0] != 1 {
+		t.Fatalf("GetWorkItems() = %#v; IDs = %v", items, store.workItemIDs)
+	}
+
+	mutationErrors := []error{}
+	_, err = backend.Claim(t.Context(), ClaimRequest{})
+	mutationErrors = append(mutationErrors, err)
+	_, err = backend.Renew(t.Context(), RenewRequest{})
+	mutationErrors = append(mutationErrors, err)
+	mutationErrors = append(mutationErrors, backend.Release(t.Context(), ReleaseRequest{}))
+	mutationErrors = append(mutationErrors, backend.AppendEvent(t.Context(), WorkEvent{}))
+	for i, mutationErr := range mutationErrors {
+		if !errors.Is(mutationErr, ErrNotImplemented) {
+			t.Errorf("mutation error %d = %v, want ErrNotImplemented", i, mutationErr)
+		}
+	}
+}
+
+func TestNewStoreRequiresStore(t *testing.T) {
+	t.Parallel()
+	if _, err := NewStore(nil); !errors.Is(err, ErrStoreRequired) {
+		t.Fatalf("NewStore(nil) error = %v, want ErrStoreRequired", err)
+	}
+}
+
+type fakeStore struct {
+	records        []Record
+	candidateQuery CandidateQuery
+	workItemIDs    []WorkItemID
+}
+
+func (s *fakeStore) ListCandidateRecords(_ context.Context, query CandidateQuery) ([]Record, error) {
+	s.candidateQuery = query
+	return s.records, nil
+}
+
+func (s *fakeStore) GetWorkItemRecords(_ context.Context, ids []WorkItemID) ([]Record, error) {
+	s.workItemIDs = append([]WorkItemID(nil), ids...)
+	return s.records, nil
+}
+
+func dispatchReasonCodes(reasons []DispatchReason) []string {
+	result := make([]string, 0, len(reasons))
+	for _, reason := range reasons {
+		result = append(result, string(reason.Code))
+	}
+	return result
+}
+
+func reasonCodeStrings(reasons []DispatchReasonCode) []string {
+	result := make([]string, 0, len(reasons))
+	for _, reason := range reasons {
+		result = append(result, string(reason))
+	}
+	return result
+}

--- a/internal/tracker/tracker.go
+++ b/internal/tracker/tracker.go
@@ -1,0 +1,289 @@
+package tracker
+
+import (
+	"context"
+	"errors"
+	"time"
+)
+
+const DefaultCandidateLimit = 100
+
+var (
+	ErrInvalidCandidateQuery = errors.New("invalid tracker candidate query")
+	ErrInvalidWorkItemID     = errors.New("invalid tracker work item ID")
+	ErrNotImplemented        = errors.New("tracker operation not implemented")
+	ErrStoreRequired         = errors.New("tracker store is required")
+)
+
+type WorkItemID int64
+
+type RepositoryID int64
+
+type MachineID string
+
+type LeaseID string
+
+type FencingToken int64
+
+type SourceState string
+
+const (
+	SourceStateUnknown SourceState = "unknown"
+	SourceStateOpen    SourceState = "open"
+	SourceStateClosed  SourceState = "closed"
+)
+
+type SyncStatus string
+
+const (
+	SyncStatusSynced   SyncStatus = "synced"
+	SyncStatusPending  SyncStatus = "pending"
+	SyncStatusRetrying SyncStatus = "retrying"
+	SyncStatusError    SyncStatus = "error"
+	SyncStatusStale    SyncStatus = "stale"
+)
+
+type DispatchReasonCode string
+
+const (
+	DispatchReasonSourceStateUnknown           DispatchReasonCode = "source_state_unknown"
+	DispatchReasonIssueClosed                  DispatchReasonCode = "issue_closed"
+	DispatchReasonWorkflowStateMissing         DispatchReasonCode = "workflow_state_missing"
+	DispatchReasonWorkflowStateTerminal        DispatchReasonCode = "workflow_state_terminal"
+	DispatchReasonWorkflowStateNotDispatchable DispatchReasonCode = "workflow_state_not_dispatchable"
+	DispatchReasonBlockerUnresolved            DispatchReasonCode = "blocker_unresolved"
+	DispatchReasonLeaseActive                  DispatchReasonCode = "lease_active"
+	DispatchReasonSyncError                    DispatchReasonCode = "sync_error"
+	DispatchReasonSyncStale                    DispatchReasonCode = "sync_stale"
+)
+
+type RepositoryReference struct {
+	ID           RepositoryID `json:"id"`
+	GitHubNodeID string       `json:"github_node_id"`
+	Owner        string       `json:"owner"`
+	Name         string       `json:"name"`
+}
+
+type GitHubIssueReference struct {
+	NodeID     string `json:"node_id"`
+	DatabaseID *int64 `json:"database_id,omitempty"`
+	Number     int    `json:"number"`
+}
+
+type WorkflowState struct {
+	ID           int64  `json:"id"`
+	SourceName   string `json:"source_name"`
+	Name         string `json:"name"`
+	Terminal     bool   `json:"terminal"`
+	Dispatchable bool   `json:"dispatchable"`
+}
+
+type QueueSummary struct {
+	Scope        string `json:"scope"`
+	State        string `json:"state"`
+	Rank         string `json:"rank"`
+	PriorityRank *int   `json:"priority_rank,omitempty"`
+}
+
+type WorkItemReference struct {
+	ID            WorkItemID     `json:"id"`
+	Repository    string         `json:"repository"`
+	IssueNumber   int            `json:"issue_number"`
+	Title         string         `json:"title"`
+	URL           string         `json:"url"`
+	SourceState   SourceState    `json:"source_state"`
+	WorkflowState *WorkflowState `json:"workflow_state,omitempty"`
+}
+
+type MachineSummary struct {
+	ID          MachineID `json:"id"`
+	Hostname    string    `json:"hostname"`
+	DisplayName string    `json:"display_name"`
+}
+
+type LeaseSummary struct {
+	ID           LeaseID        `json:"id"`
+	FencingToken FencingToken   `json:"fencing_token"`
+	Machine      MachineSummary `json:"machine"`
+	SessionID    string         `json:"session_id"`
+	AcquiredAt   time.Time      `json:"acquired_at"`
+	RenewedAt    time.Time      `json:"renewed_at"`
+	ExpiresAt    time.Time      `json:"expires_at"`
+}
+
+type CheckSummary struct {
+	Status     string `json:"status,omitempty"`
+	Conclusion string `json:"conclusion,omitempty"`
+	Total      int    `json:"total,omitempty"`
+	Pending    int    `json:"pending,omitempty"`
+	Passed     int    `json:"passed,omitempty"`
+	Failed     int    `json:"failed,omitempty"`
+}
+
+type ReviewSummary struct {
+	State            string `json:"state,omitempty"`
+	Decision         string `json:"decision,omitempty"`
+	Approvals        int    `json:"approvals,omitempty"`
+	ChangesRequested int    `json:"changes_requested,omitempty"`
+	Comments         int    `json:"comments,omitempty"`
+}
+
+type MergeSummary struct {
+	State       string     `json:"state,omitempty"`
+	Ready       bool       `json:"ready"`
+	RefreshedAt *time.Time `json:"refreshed_at,omitempty"`
+}
+
+type PullRequestSummary struct {
+	ID           int64         `json:"id"`
+	GitHubNodeID string        `json:"github_node_id"`
+	Number       int           `json:"number"`
+	Title        string        `json:"title"`
+	URL          string        `json:"url"`
+	State        string        `json:"state"`
+	Draft        bool          `json:"draft"`
+	HeadRef      string        `json:"head_ref"`
+	HeadSHA      string        `json:"head_sha"`
+	BaseRef      string        `json:"base_ref"`
+	BaseSHA      string        `json:"base_sha"`
+	Checks       CheckSummary  `json:"checks"`
+	Reviews      ReviewSummary `json:"reviews"`
+	Merge        MergeSummary  `json:"merge"`
+}
+
+type DispatchReason struct {
+	Code       DispatchReasonCode `json:"code"`
+	Message    string             `json:"message"`
+	WorkItemID *WorkItemID        `json:"work_item_id,omitempty"`
+	LeaseID    LeaseID            `json:"lease_id,omitempty"`
+}
+
+type Dispatchability struct {
+	Dispatchable bool             `json:"dispatchable"`
+	Reasons      []DispatchReason `json:"reasons"`
+}
+
+type WorkItem struct {
+	ID              WorkItemID           `json:"id"`
+	Repository      RepositoryReference  `json:"repository"`
+	GitHub          GitHubIssueReference `json:"github"`
+	Title           string               `json:"title"`
+	BodyExcerpt     string               `json:"body_excerpt"`
+	URL             string               `json:"url"`
+	SourceState     SourceState          `json:"source_state"`
+	WorkflowState   *WorkflowState       `json:"workflow_state,omitempty"`
+	Queue           *QueueSummary        `json:"queue,omitempty"`
+	Labels          []string             `json:"labels"`
+	Assignees       []string             `json:"assignees"`
+	CreatedAt       *time.Time           `json:"created_at,omitempty"`
+	UpdatedAt       *time.Time           `json:"updated_at,omitempty"`
+	SourceUpdatedAt *time.Time           `json:"source_updated_at,omitempty"`
+	SourceSyncedAt  *time.Time           `json:"source_synced_at,omitempty"`
+	Blockers        []WorkItemReference  `json:"blockers"`
+	Dependents      []WorkItemReference  `json:"dependents"`
+	Dispatchability Dispatchability      `json:"dispatchability"`
+	ActiveLease     *LeaseSummary        `json:"active_lease,omitempty"`
+	PullRequests    []PullRequestSummary `json:"pull_requests"`
+	SyncStatus      SyncStatus           `json:"github_sync_status"`
+}
+
+type CandidateQuery struct {
+	RepositoryIDs  []RepositoryID `json:"repository_ids,omitempty"`
+	WorkflowStates []string       `json:"workflow_states,omitempty"`
+	Scope          string         `json:"scope,omitempty"`
+	Limit          int            `json:"limit,omitempty"`
+}
+
+type ClaimRequest struct {
+	WorkItemID WorkItemID    `json:"work_item_id"`
+	MachineID  MachineID     `json:"machine_id"`
+	SessionID  string        `json:"session_id"`
+	TTL        time.Duration `json:"ttl"`
+}
+
+type RenewRequest struct {
+	LeaseID      LeaseID       `json:"lease_id"`
+	FencingToken FencingToken  `json:"fencing_token"`
+	TTL          time.Duration `json:"ttl"`
+}
+
+type ReleaseRequest struct {
+	LeaseID      LeaseID      `json:"lease_id"`
+	FencingToken FencingToken `json:"fencing_token"`
+	Reason       string       `json:"reason,omitempty"`
+}
+
+type Lease struct {
+	LeaseSummary
+	WorkItemID WorkItemID `json:"work_item_id"`
+}
+
+type WorkEvent struct {
+	WorkItemID   WorkItemID     `json:"work_item_id"`
+	FencingToken *FencingToken  `json:"fencing_token,omitempty"`
+	MachineID    MachineID      `json:"machine_id,omitempty"`
+	SessionID    string         `json:"session_id,omitempty"`
+	RunID        string         `json:"run_id,omitempty"`
+	Kind         string         `json:"kind"`
+	Payload      map[string]any `json:"payload,omitempty"`
+	OccurredAt   time.Time      `json:"occurred_at"`
+}
+
+type Tracker interface {
+	ListCandidates(context.Context, CandidateQuery) ([]WorkItem, error)
+	GetWorkItems(context.Context, []WorkItemID) ([]WorkItem, error)
+	Claim(context.Context, ClaimRequest) (Lease, error)
+	Renew(context.Context, RenewRequest) (Lease, error)
+	Release(context.Context, ReleaseRequest) error
+	AppendEvent(context.Context, WorkEvent) error
+}
+
+type Store interface {
+	ListCandidateRecords(context.Context, CandidateQuery) ([]Record, error)
+	GetWorkItemRecords(context.Context, []WorkItemID) ([]Record, error)
+}
+
+func NewStore(store Store) (Tracker, error) {
+	if store == nil {
+		return nil, ErrStoreRequired
+	}
+	return &storeTracker{store: store}, nil
+}
+
+type storeTracker struct {
+	store Store
+}
+
+var _ Tracker = (*storeTracker)(nil)
+
+func (t *storeTracker) ListCandidates(ctx context.Context, query CandidateQuery) ([]WorkItem, error) {
+	records, err := t.store.ListCandidateRecords(ctx, query)
+	if err != nil {
+		return nil, err
+	}
+	return normalizeRecords(records), nil
+}
+
+func (t *storeTracker) GetWorkItems(ctx context.Context, ids []WorkItemID) ([]WorkItem, error) {
+	records, err := t.store.GetWorkItemRecords(ctx, ids)
+	if err != nil {
+		return nil, err
+	}
+	return normalizeRecords(records), nil
+}
+
+func (*storeTracker) Claim(context.Context, ClaimRequest) (Lease, error) {
+	return Lease{}, ErrNotImplemented
+}
+
+func (*storeTracker) Renew(context.Context, RenewRequest) (Lease, error) {
+	return Lease{}, ErrNotImplemented
+}
+
+func (*storeTracker) Release(context.Context, ReleaseRequest) error {
+	return ErrNotImplemented
+}
+
+func (*storeTracker) AppendEvent(context.Context, WorkEvent) error {
+	return ErrNotImplemented
+}


### PR DESCRIPTION
## Summary

- define a transport-independent tracker contract and normalized work-item model
- add structured dispatchability reasons and complete hub projection summaries
- implement transactional SQLite candidate and work-item reads behind the tracker interface
- cover complete, missing, and partial upstream data with table-driven tests

Fixes #2068

## UI Surface Contract

- [x] N/A; this PR does not change a UI surface, layout, density, first viewport, or responsive visibility.
- [x] This PR does not add persistent top-of-screen messaging.
- [x] This PR makes no visual changes to primary operator screens.

## Test Plan

- [x] `go test ./internal/tracker ./internal/hubserver`
- [x] `go test -race ./internal/tracker ./internal/hubserver`
- [x] focused NilAway and golangci-lint with CI-aligned Go 1.26.6 tooling
- [x] `make check` (78.8% total coverage; package/file floors pass)
