### PR TITLE
feat(hub): derive dispatch queue

### DIFF
--- a/internal/hubserver/tracker_store.go
+++ b/internal/hubserver/tracker_store.go
@@ -56,15 +56,13 @@ LEFT JOIN queue_entries q ON q.id = (
 
 const candidateOrder = `
 ORDER BY
-  CASE WHEN q.priority_override IS NULL THEN 1 ELSE 0 END,
-  q.priority_override,
+  CASE q.priority_override WHEN 0 THEN 0 WHEN 1 THEN 1 WHEN 2 THEN 2 WHEN 3 THEN 3 ELSE 4 END,
   CASE WHEN q.rank IS NULL OR trim(q.rank) = '' THEN 1 ELSE 0 END,
-  q.rank,
+  trim(q.rank),
   i.created_at,
-  r.github_owner,
-  r.github_name,
-  i.github_number,
-  i.id
+  lower(trim(r.github_owner)),
+  lower(trim(r.github_name)),
+  i.github_number
 LIMIT ?`
 
 type databaseQueryer interface {
@@ -87,11 +85,11 @@ func (d *database) ListCandidateRecords(ctx context.Context, query tracker.Candi
 		"lower(trim(i.github_state)) = 'open'",
 		"ws.id IS NOT NULL",
 		"ws.terminal = 0",
+		"lower(trim(ws.detent_state)) <> 'cancelled'",
+		"ws.dispatchable = 1",
 	}
 	args := []any{query.Scope, query.Scope, query.Scope}
-	if len(workflowStates) == 0 {
-		clauses = append(clauses, "ws.dispatchable = 1")
-	} else {
+	if len(workflowStates) > 0 {
 		clauses = append(clauses, "lower(ws.detent_state) IN ("+placeholders(len(workflowStates))+")")
 		for _, state := range workflowStates {
 			args = append(args, state)

--- a/internal/hubserver/tracker_store_test.go
+++ b/internal/hubserver/tracker_store_test.go
@@ -15,7 +15,15 @@ func TestTrackerReadsNormalizedWorkItems(t *testing.T) {
 
 	service := openTestService(t, Config{DatabasePath: filepath.Join(t.TempDir(), "hub.db")})
 	repositoryID, issueID := seedProjection(t, service.database.db)
-	blockerID := insertHubTestIssue(t, service, repositoryID, 2, "I_blocker", "closed", nil)
+	result, err := service.database.db.ExecContext(t.Context(), "INSERT INTO workflow_states (repository_id, source_name, detent_state, terminal, dispatchable, created_at, updated_at) VALUES (?, ?, ?, 1, 0, ?, ?)", repositoryID, "Done", "Done", testTimestamp, testTimestamp)
+	if err != nil {
+		t.Fatalf("insert terminal workflow state: %v", err)
+	}
+	terminalWorkflowID, err := result.LastInsertId()
+	if err != nil {
+		t.Fatalf("terminal workflow state ID: %v", err)
+	}
+	blockerID := insertHubTestIssue(t, service, repositoryID, 2, "I_blocker", "closed", &terminalWorkflowID)
 	dependentID := insertHubTestIssue(t, service, repositoryID, 3, "I_dependent", "open", nil)
 	if _, err := service.database.db.ExecContext(t.Context(), "INSERT INTO issue_dependencies (blocker_issue_id, dependent_issue_id, provenance, created_at, updated_at) VALUES (?, ?, ?, ?, ?), (?, ?, ?, ?, ?)", blockerID, issueID, "native", testTimestamp, testTimestamp, issueID, dependentID, "native", testTimestamp, testTimestamp); err != nil {
 		t.Fatalf("insert dependencies: %v", err)
@@ -148,6 +156,54 @@ func TestTrackerCandidatesApplyQueueOrderBeforeLimit(t *testing.T) {
 		if candidates[i].ID != want[i] {
 			t.Errorf("ListCandidates()[%d].ID = %d, want %d", i, candidates[i].ID, want[i])
 		}
+	}
+}
+
+func TestTrackerCandidatesExcludeCancelledState(t *testing.T) {
+	t.Parallel()
+
+	service := openTestService(t, Config{DatabasePath: filepath.Join(t.TempDir(), "hub.db")})
+	repositoryID, activeID := seedProjection(t, service.database.db)
+	result, err := service.database.db.ExecContext(t.Context(), "INSERT INTO workflow_states (repository_id, source_name, detent_state, terminal, dispatchable, created_at, updated_at) VALUES (?, ?, ?, 0, 1, ?, ?)", repositoryID, "Cancelled", "Cancelled", testTimestamp, testTimestamp)
+	if err != nil {
+		t.Fatalf("insert cancelled workflow state: %v", err)
+	}
+	cancelledWorkflowID, err := result.LastInsertId()
+	if err != nil {
+		t.Fatalf("cancelled workflow state ID: %v", err)
+	}
+	cancelledID := insertHubTestIssue(t, service, repositoryID, 2, "I_cancelled", "open", &cancelledWorkflowID)
+
+	candidates, err := service.Tracker().ListCandidates(t.Context(), tracker.CandidateQuery{WorkflowStates: []string{"Todo", "Cancelled"}})
+	if err != nil {
+		t.Fatalf("ListCandidates() error = %v", err)
+	}
+	if len(candidates) != 1 || candidates[0].ID != tracker.WorkItemID(activeID) {
+		t.Fatalf("ListCandidates() = %#v, want active issue %d and not cancelled issue %d", candidates, activeID, cancelledID)
+	}
+}
+
+func TestTrackerCandidatesRequireConfiguredCandidateState(t *testing.T) {
+	t.Parallel()
+
+	service := openTestService(t, Config{DatabasePath: filepath.Join(t.TempDir(), "hub.db")})
+	repositoryID, activeID := seedProjection(t, service.database.db)
+	result, err := service.database.db.ExecContext(t.Context(), "INSERT INTO workflow_states (repository_id, source_name, detent_state, terminal, dispatchable, created_at, updated_at) VALUES (?, ?, ?, 0, 0, ?, ?)", repositoryID, "Backlog", "Backlog", testTimestamp, testTimestamp)
+	if err != nil {
+		t.Fatalf("insert non-candidate workflow state: %v", err)
+	}
+	backlogWorkflowID, err := result.LastInsertId()
+	if err != nil {
+		t.Fatalf("non-candidate workflow state ID: %v", err)
+	}
+	backlogID := insertHubTestIssue(t, service, repositoryID, 2, "I_backlog", "open", &backlogWorkflowID)
+
+	candidates, err := service.Tracker().ListCandidates(t.Context(), tracker.CandidateQuery{WorkflowStates: []string{"Todo", "Backlog"}})
+	if err != nil {
+		t.Fatalf("ListCandidates() error = %v", err)
+	}
+	if len(candidates) != 1 || candidates[0].ID != tracker.WorkItemID(activeID) {
+		t.Fatalf("ListCandidates() = %#v, want active issue %d and not non-candidate issue %d", candidates, activeID, backlogID)
 	}
 }
 

--- a/internal/tracker/dispatch.go
+++ b/internal/tracker/dispatch.go
@@ -1,0 +1,318 @@
+package tracker
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+)
+
+func DeriveDispatchQueue(candidates []WorkItem, snapshot DispatchSnapshot) DispatchQueue {
+	queue := DispatchQueue{
+		Dispatchable:    make([]WorkItem, 0, len(candidates)),
+		NonDispatchable: make([]WorkItem, 0, len(candidates)),
+	}
+	for _, candidate := range candidates {
+		candidate.Dispatchability = deriveSnapshotDispatchability(candidate, snapshot)
+		if candidate.Dispatchability.Dispatchable {
+			queue.Dispatchable = append(queue.Dispatchable, candidate)
+		} else {
+			queue.NonDispatchable = append(queue.NonDispatchable, candidate)
+		}
+	}
+	sortWorkItemsForDispatch(queue.Dispatchable)
+	sortWorkItemsForDispatch(queue.NonDispatchable)
+	return queue
+}
+
+func deriveSnapshotDispatchability(item WorkItem, snapshot DispatchSnapshot) Dispatchability {
+	reasons := deriveDispatchReasons(item, snapshot.EvaluatedAt, snapshot.TargetMachineID)
+	ownLease := ownsActiveLease(item, snapshot)
+	if usage, ok := snapshot.RepositoryConcurrency[item.Repository.ID]; ok && concurrencyFull(usage, ownLease) {
+		active := effectiveActive(usage.Active, ownLease)
+		reasons = append(reasons, DispatchReason{
+			Code:       DispatchReasonRepositoryConcurrencyLimit,
+			Message:    fmt.Sprintf("repository concurrency limit reached: %d of %d active", active, usage.Limit),
+			Repository: item.Repository.ID,
+			Active:     active,
+			Limit:      usage.Limit,
+		})
+	}
+	project := workItemProject(item)
+	if usage, ok := projectConcurrency(snapshot.ProjectConcurrency, project); ok && concurrencyFull(usage, ownLease) {
+		active := effectiveActive(usage.Active, ownLease)
+		reasons = append(reasons, DispatchReason{
+			Code:    DispatchReasonProjectConcurrencyLimit,
+			Message: fmt.Sprintf("project concurrency limit reached: %d of %d active", active, usage.Limit),
+			Scope:   project,
+			Active:  active,
+			Limit:   usage.Limit,
+		})
+	}
+	if reason := machineAvailabilityReason(item, snapshot); reason != nil {
+		reasons = append(reasons, *reason)
+	}
+	if reason := operatorPauseReason(item, snapshot); reason != nil {
+		reasons = append(reasons, *reason)
+	}
+	if reason := syncSafetyReason(item, snapshot); reason != nil {
+		reasons = append(reasons, *reason)
+	}
+	return Dispatchability{Dispatchable: len(reasons) == 0, Reasons: reasons}
+}
+
+func machineAvailabilityReason(item WorkItem, snapshot DispatchSnapshot) *DispatchReason {
+	compatible := false
+	healthy := false
+	active := 0
+	limit := 0
+	for _, machine := range snapshot.Machines {
+		if snapshot.TargetMachineID != "" && machine.ID != snapshot.TargetMachineID {
+			continue
+		}
+		if !machineCompatible(machine, item) {
+			continue
+		}
+		compatible = true
+		if !machine.Healthy {
+			continue
+		}
+		healthy = true
+		machineActive := effectiveActive(machine.ActiveLeases, ownsActiveLease(item, snapshot) && machine.ID == snapshot.TargetMachineID)
+		if snapshot.TargetMachineID != "" {
+			active = machineActive
+			limit = machine.Capacity
+		}
+		if machine.Capacity > machineActive {
+			return nil
+		}
+	}
+	if !compatible {
+		return &DispatchReason{
+			Code:      DispatchReasonNoCompatibleMachine,
+			Message:   "no compatible machine is available for this work item",
+			MachineID: snapshot.TargetMachineID,
+		}
+	}
+	if !healthy {
+		return &DispatchReason{
+			Code:      DispatchReasonMachineUnhealthy,
+			Message:   "no compatible machine is healthy",
+			MachineID: snapshot.TargetMachineID,
+		}
+	}
+	return &DispatchReason{
+		Code:      DispatchReasonMachineCapacityFull,
+		Message:   "all compatible healthy machines are at capacity",
+		MachineID: snapshot.TargetMachineID,
+		Active:    active,
+		Limit:     limit,
+	}
+}
+
+func machineCompatible(machine MachineAvailability, item WorkItem) bool {
+	if len(machine.RepositoryIDs) > 0 && !containsRepository(machine.RepositoryIDs, item.Repository.ID) {
+		return false
+	}
+	if len(machine.ProjectScopes) == 0 {
+		return true
+	}
+	project := workItemProject(item)
+	for _, scope := range machine.ProjectScopes {
+		if strings.EqualFold(strings.TrimSpace(scope), project) {
+			return true
+		}
+	}
+	return false
+}
+
+func operatorPauseReason(item WorkItem, snapshot DispatchSnapshot) *DispatchReason {
+	if snapshot.OperatorPaused {
+		return &DispatchReason{Code: DispatchReasonOperatorPaused, Message: "dispatch is paused by the operator"}
+	}
+	if containsRepository(snapshot.PausedRepositories, item.Repository.ID) {
+		return &DispatchReason{
+			Code:       DispatchReasonOperatorPaused,
+			Message:    "dispatch is paused by the operator for this repository",
+			Repository: item.Repository.ID,
+		}
+	}
+	project := workItemProject(item)
+	if project != "" && containsFolded(snapshot.PausedProjects, project) {
+		return &DispatchReason{
+			Code:    DispatchReasonOperatorPaused,
+			Message: "dispatch is paused by the operator for this project",
+			Scope:   project,
+		}
+	}
+	return nil
+}
+
+func syncSafetyReason(item WorkItem, snapshot DispatchSnapshot) *DispatchReason {
+	if snapshot.SyncSafetyBlocked {
+		return &DispatchReason{Code: DispatchReasonSyncUnsafe, Message: "dispatch is prevented by the Hub synchronization safety gate"}
+	}
+	if containsRepository(snapshot.SyncUnsafeRepositories, item.Repository.ID) {
+		return &DispatchReason{
+			Code:       DispatchReasonSyncUnsafe,
+			Message:    "repository synchronization is not safe for dispatch",
+			Repository: item.Repository.ID,
+		}
+	}
+	return nil
+}
+
+func concurrencyFull(usage ConcurrencyUsage, discountOwnedLease bool) bool {
+	return usage.Limit <= 0 || effectiveActive(usage.Active, discountOwnedLease) >= usage.Limit
+}
+
+func effectiveActive(active int, discountOwnedLease bool) int {
+	active = nonNegative(active)
+	if discountOwnedLease && active > 0 {
+		return active - 1
+	}
+	return active
+}
+
+func nonNegative(value int) int {
+	if value < 0 {
+		return 0
+	}
+	return value
+}
+
+func containsRepository(repositories []RepositoryID, repository RepositoryID) bool {
+	for _, candidate := range repositories {
+		if candidate == repository {
+			return true
+		}
+	}
+	return false
+}
+
+func containsFolded(values []string, target string) bool {
+	for _, value := range values {
+		if strings.EqualFold(strings.TrimSpace(value), target) {
+			return true
+		}
+	}
+	return false
+}
+
+func projectConcurrency(usages map[string]ConcurrencyUsage, project string) (ConcurrencyUsage, bool) {
+	if project == "" {
+		return ConcurrencyUsage{}, false
+	}
+	if usage, ok := usages[project]; ok {
+		return usage, true
+	}
+	keys := make([]string, 0)
+	for scope := range usages {
+		if strings.EqualFold(strings.TrimSpace(scope), project) {
+			keys = append(keys, scope)
+		}
+	}
+	if len(keys) == 0 {
+		return ConcurrencyUsage{}, false
+	}
+	sort.Strings(keys)
+	return usages[keys[0]], true
+}
+
+func workItemProject(item WorkItem) string {
+	if item.Queue == nil {
+		return ""
+	}
+	return strings.TrimSpace(item.Queue.Scope)
+}
+
+func ownsActiveLease(item WorkItem, snapshot DispatchSnapshot) bool {
+	return snapshot.TargetMachineID != "" && item.ActiveLease != nil && item.ActiveLease.Machine.ID == snapshot.TargetMachineID && (snapshot.EvaluatedAt.IsZero() || item.ActiveLease.ExpiresAt.After(snapshot.EvaluatedAt))
+}
+
+func sortWorkItemsForDispatch(items []WorkItem) {
+	sort.SliceStable(items, func(i, j int) bool {
+		return compareWorkItemsForDispatch(items[i], items[j]) < 0
+	})
+}
+
+func compareWorkItemsForDispatch(left, right WorkItem) int {
+	if comparison := compareInt(queuePriority(left), queuePriority(right)); comparison != 0 {
+		return comparison
+	}
+	if comparison := compareQueueRanks(left, right); comparison != 0 {
+		return comparison
+	}
+	if comparison := compareCreationTimes(left.CreatedAt, right.CreatedAt); comparison != 0 {
+		return comparison
+	}
+	leftRepository := canonicalRepository(left.Repository)
+	rightRepository := canonicalRepository(right.Repository)
+	if comparison := strings.Compare(leftRepository, rightRepository); comparison != 0 {
+		return comparison
+	}
+	return compareInt(left.GitHub.Number, right.GitHub.Number)
+}
+
+func queuePriority(item WorkItem) int {
+	if item.Queue == nil || item.Queue.PriorityRank == nil {
+		return QueuePriorityLow + 1
+	}
+	switch *item.Queue.PriorityRank {
+	case QueuePriorityUrgent, QueuePriorityHigh, QueuePriorityNormal, QueuePriorityLow:
+		return *item.Queue.PriorityRank
+	default:
+		return QueuePriorityLow + 1
+	}
+}
+
+func compareQueueRanks(left, right WorkItem) int {
+	leftRank := ""
+	rightRank := ""
+	if left.Queue != nil {
+		leftRank = strings.TrimSpace(left.Queue.Rank)
+	}
+	if right.Queue != nil {
+		rightRank = strings.TrimSpace(right.Queue.Rank)
+	}
+	if leftRank == "" && rightRank != "" {
+		return 1
+	}
+	if leftRank != "" && rightRank == "" {
+		return -1
+	}
+	return strings.Compare(leftRank, rightRank)
+}
+
+func compareCreationTimes(left, right *time.Time) int {
+	if left == nil && right != nil {
+		return 1
+	}
+	if left != nil && right == nil {
+		return -1
+	}
+	if left == nil {
+		return 0
+	}
+	if left.Before(*right) {
+		return -1
+	}
+	if left.After(*right) {
+		return 1
+	}
+	return 0
+}
+
+func canonicalRepository(repository RepositoryReference) string {
+	return strings.ToLower(strings.TrimSpace(repository.Owner)) + "/" + strings.ToLower(strings.TrimSpace(repository.Name))
+}
+
+func compareInt(left, right int) int {
+	if left < right {
+		return -1
+	}
+	if left > right {
+		return 1
+	}
+	return 0
+}

--- a/internal/tracker/dispatch.go
+++ b/internal/tracker/dispatch.go
@@ -26,7 +26,7 @@ func DeriveDispatchQueue(candidates []WorkItem, snapshot DispatchSnapshot) Dispa
 }
 
 func deriveSnapshotDispatchability(item WorkItem, snapshot DispatchSnapshot) Dispatchability {
-	reasons := deriveDispatchReasons(item, snapshot.EvaluatedAt, snapshot.TargetMachineID)
+	reasons := deriveDispatchReasons(item, snapshot.EvaluatedAt, snapshot.TargetMachineID, snapshot.TargetSessionID)
 	ownLease := ownsActiveLease(item, snapshot)
 	if usage, ok := snapshot.RepositoryConcurrency[item.Repository.ID]; ok && concurrencyFull(usage, ownLease) {
 		active := effectiveActive(usage.Active, ownLease)
@@ -227,7 +227,7 @@ func workItemProject(item WorkItem) string {
 }
 
 func ownsActiveLease(item WorkItem, snapshot DispatchSnapshot) bool {
-	return snapshot.TargetMachineID != "" && item.ActiveLease != nil && item.ActiveLease.Machine.ID == snapshot.TargetMachineID && (snapshot.EvaluatedAt.IsZero() || item.ActiveLease.ExpiresAt.After(snapshot.EvaluatedAt))
+	return leaseIsActive(item.ActiveLease, snapshot.EvaluatedAt) && leaseOwnedBy(item.ActiveLease, snapshot.TargetMachineID, snapshot.TargetSessionID)
 }
 
 func sortWorkItemsForDispatch(items []WorkItem) {

--- a/internal/tracker/dispatch_test.go
+++ b/internal/tracker/dispatch_test.go
@@ -46,15 +46,38 @@ func TestDeriveDispatchQueueReasons(t *testing.T) {
 			name: "own lease can resume",
 			item: func() WorkItem {
 				item := readyWorkItem(4, 1, "digitaldrywood", "detent", 4, nil, "", now)
-				item.ActiveLease = &LeaseSummary{ID: "lease-a", Machine: MachineSummary{ID: "machine-a"}, ExpiresAt: now.Add(time.Minute)}
+				item.ActiveLease = &LeaseSummary{ID: "lease-a", Machine: MachineSummary{ID: "machine-a"}, SessionID: "session-a", ExpiresAt: now.Add(time.Minute)}
 				return item
 			}(),
 			snapshot: DispatchSnapshot{
 				EvaluatedAt:           now,
 				TargetMachineID:       "machine-a",
+				TargetSessionID:       "session-a",
 				Machines:              []MachineAvailability{{ID: "machine-a", Healthy: true, Capacity: 1, ActiveLeases: 1}},
 				RepositoryConcurrency: map[RepositoryID]ConcurrencyUsage{1: {Active: 1, Limit: 1}},
 				ProjectConcurrency:    map[string]ConcurrencyUsage{"fleet": {Active: 1, Limit: 1}},
+			},
+		},
+		{
+			name: "same machine different session cannot resume",
+			item: func() WorkItem {
+				item := readyWorkItem(18, 1, "digitaldrywood", "detent", 18, nil, "", now)
+				item.ActiveLease = &LeaseSummary{ID: "lease-a", Machine: MachineSummary{ID: "machine-a"}, SessionID: "session-a", ExpiresAt: now.Add(time.Minute)}
+				return item
+			}(),
+			snapshot: DispatchSnapshot{
+				EvaluatedAt:           now,
+				TargetMachineID:       "machine-a",
+				TargetSessionID:       "session-b",
+				Machines:              []MachineAvailability{{ID: "machine-a", Healthy: true, Capacity: 1, ActiveLeases: 1}},
+				RepositoryConcurrency: map[RepositoryID]ConcurrencyUsage{1: {Active: 1, Limit: 1}},
+				ProjectConcurrency:    map[string]ConcurrencyUsage{"fleet": {Active: 1, Limit: 1}},
+			},
+			wantCodes: []DispatchReasonCode{
+				DispatchReasonLeaseActive,
+				DispatchReasonRepositoryConcurrencyLimit,
+				DispatchReasonProjectConcurrencyLimit,
+				DispatchReasonMachineCapacityFull,
 			},
 		},
 		{
@@ -240,7 +263,7 @@ func TestDeriveDispatchQueueStructuredReasonDetails(t *testing.T) {
 	now := time.Date(2026, 9, 2, 12, 0, 0, 0, time.UTC)
 	item := readyWorkItem(1, 7, "digitaldrywood", "detent", 2072, nil, "a", now)
 	item.Blockers = []WorkItemReference{{ID: 6, WorkflowState: &WorkflowState{Name: "Todo"}}}
-	item.ActiveLease = &LeaseSummary{ID: "lease-b", Machine: MachineSummary{ID: "machine-b"}, ExpiresAt: now.Add(time.Minute)}
+	item.ActiveLease = &LeaseSummary{ID: "lease-b", Machine: MachineSummary{ID: "machine-b"}, SessionID: "session-b", ExpiresAt: now.Add(time.Minute)}
 	snapshot := DispatchSnapshot{
 		EvaluatedAt:            now,
 		TargetMachineID:        "machine-a",
@@ -271,8 +294,8 @@ func TestDeriveDispatchQueueStructuredReasonDetails(t *testing.T) {
 	if reasons[0].WorkItemID == nil || *reasons[0].WorkItemID != 6 {
 		t.Errorf("blocker reason = %#v, want blocker 6", reasons[0])
 	}
-	if reasons[1].LeaseID != "lease-b" || reasons[1].MachineID != "machine-b" {
-		t.Errorf("lease reason = %#v, want lease-b on machine-b", reasons[1])
+	if reasons[1].LeaseID != "lease-b" || reasons[1].MachineID != "machine-b" || reasons[1].SessionID != "session-b" {
+		t.Errorf("lease reason = %#v, want lease-b on machine-b in session-b", reasons[1])
 	}
 	if reasons[2].Repository != 7 || reasons[2].Active != 2 || reasons[2].Limit != 2 {
 		t.Errorf("repository reason = %#v, want repository 7 at 2/2", reasons[2])

--- a/internal/tracker/dispatch_test.go
+++ b/internal/tracker/dispatch_test.go
@@ -1,0 +1,322 @@
+package tracker
+
+import (
+	"reflect"
+	"testing"
+	"time"
+)
+
+func TestDeriveDispatchQueueReasons(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 9, 2, 12, 0, 0, 0, time.UTC)
+	availableMachine := MachineAvailability{ID: "machine-a", Healthy: true, Capacity: 2}
+	tests := []struct {
+		name      string
+		item      WorkItem
+		snapshot  DispatchSnapshot
+		wantCodes []DispatchReasonCode
+	}{
+		{
+			name:     "all gates allow dispatch",
+			item:     readyWorkItem(1, 1, "digitaldrywood", "detent", 1, nil, "", now),
+			snapshot: DispatchSnapshot{EvaluatedAt: now, Machines: []MachineAvailability{availableMachine}},
+		},
+		{
+			name: "required blocker unresolved",
+			item: func() WorkItem {
+				item := readyWorkItem(2, 1, "digitaldrywood", "detent", 2, nil, "", now)
+				item.Blockers = []WorkItemReference{{ID: 99, SourceState: SourceStateOpen, WorkflowState: &WorkflowState{Name: "Todo", Dispatchable: true}}}
+				return item
+			}(),
+			snapshot:  DispatchSnapshot{EvaluatedAt: now, Machines: []MachineAvailability{availableMachine}},
+			wantCodes: []DispatchReasonCode{DispatchReasonBlockerUnresolved},
+		},
+		{
+			name: "foreign lease active",
+			item: func() WorkItem {
+				item := readyWorkItem(3, 1, "digitaldrywood", "detent", 3, nil, "", now)
+				item.ActiveLease = &LeaseSummary{ID: "lease-b", Machine: MachineSummary{ID: "machine-b"}, ExpiresAt: now.Add(time.Minute)}
+				return item
+			}(),
+			snapshot:  DispatchSnapshot{EvaluatedAt: now, TargetMachineID: "machine-a", Machines: []MachineAvailability{availableMachine}},
+			wantCodes: []DispatchReasonCode{DispatchReasonLeaseActive},
+		},
+		{
+			name: "own lease can resume",
+			item: func() WorkItem {
+				item := readyWorkItem(4, 1, "digitaldrywood", "detent", 4, nil, "", now)
+				item.ActiveLease = &LeaseSummary{ID: "lease-a", Machine: MachineSummary{ID: "machine-a"}, ExpiresAt: now.Add(time.Minute)}
+				return item
+			}(),
+			snapshot: DispatchSnapshot{
+				EvaluatedAt:           now,
+				TargetMachineID:       "machine-a",
+				Machines:              []MachineAvailability{{ID: "machine-a", Healthy: true, Capacity: 1, ActiveLeases: 1}},
+				RepositoryConcurrency: map[RepositoryID]ConcurrencyUsage{1: {Active: 1, Limit: 1}},
+				ProjectConcurrency:    map[string]ConcurrencyUsage{"fleet": {Active: 1, Limit: 1}},
+			},
+		},
+		{
+			name: "expired lease is ignored",
+			item: func() WorkItem {
+				item := readyWorkItem(5, 1, "digitaldrywood", "detent", 5, nil, "", now)
+				item.ActiveLease = &LeaseSummary{ID: "expired", Machine: MachineSummary{ID: "machine-b"}, ExpiresAt: now.Add(-time.Nanosecond)}
+				return item
+			}(),
+			snapshot: DispatchSnapshot{EvaluatedAt: now, Machines: []MachineAvailability{availableMachine}},
+		},
+		{
+			name:      "repository concurrency full",
+			item:      readyWorkItem(6, 1, "digitaldrywood", "detent", 6, nil, "", now),
+			snapshot:  DispatchSnapshot{EvaluatedAt: now, Machines: []MachineAvailability{availableMachine}, RepositoryConcurrency: map[RepositoryID]ConcurrencyUsage{1: {Active: 2, Limit: 2}}},
+			wantCodes: []DispatchReasonCode{DispatchReasonRepositoryConcurrencyLimit},
+		},
+		{
+			name:      "project concurrency full",
+			item:      readyWorkItem(7, 1, "digitaldrywood", "detent", 7, nil, "", now),
+			snapshot:  DispatchSnapshot{EvaluatedAt: now, Machines: []MachineAvailability{availableMachine}, ProjectConcurrency: map[string]ConcurrencyUsage{" FLEET ": {Active: 1, Limit: 1}}},
+			wantCodes: []DispatchReasonCode{DispatchReasonProjectConcurrencyLimit},
+		},
+		{
+			name:     "repository and project have room",
+			item:     readyWorkItem(8, 1, "digitaldrywood", "detent", 8, nil, "", now),
+			snapshot: DispatchSnapshot{EvaluatedAt: now, Machines: []MachineAvailability{availableMachine}, RepositoryConcurrency: map[RepositoryID]ConcurrencyUsage{1: {Active: 1, Limit: 2}}, ProjectConcurrency: map[string]ConcurrencyUsage{"fleet": {Active: 0, Limit: 1}}},
+		},
+		{
+			name:      "no compatible machine",
+			item:      readyWorkItem(9, 1, "digitaldrywood", "detent", 9, nil, "", now),
+			snapshot:  DispatchSnapshot{EvaluatedAt: now, Machines: []MachineAvailability{{ID: "machine-b", Healthy: true, Capacity: 1, RepositoryIDs: []RepositoryID{2}}}},
+			wantCodes: []DispatchReasonCode{DispatchReasonNoCompatibleMachine},
+		},
+		{
+			name:      "target machine is outside project scope",
+			item:      readyWorkItem(10, 1, "digitaldrywood", "detent", 10, nil, "", now),
+			snapshot:  DispatchSnapshot{EvaluatedAt: now, TargetMachineID: "machine-a", Machines: []MachineAvailability{{ID: "machine-a", Healthy: true, Capacity: 1, ProjectScopes: []string{"other"}}, {ID: "machine-b", Healthy: true, Capacity: 1}}},
+			wantCodes: []DispatchReasonCode{DispatchReasonNoCompatibleMachine},
+		},
+		{
+			name:      "compatible machine unhealthy",
+			item:      readyWorkItem(11, 1, "digitaldrywood", "detent", 11, nil, "", now),
+			snapshot:  DispatchSnapshot{EvaluatedAt: now, Machines: []MachineAvailability{{ID: "machine-a", Capacity: 1}}},
+			wantCodes: []DispatchReasonCode{DispatchReasonMachineUnhealthy},
+		},
+		{
+			name:      "compatible healthy machine full",
+			item:      readyWorkItem(12, 1, "digitaldrywood", "detent", 12, nil, "", now),
+			snapshot:  DispatchSnapshot{EvaluatedAt: now, Machines: []MachineAvailability{{ID: "machine-a", Healthy: true, Capacity: 1, ActiveLeases: 1}}},
+			wantCodes: []DispatchReasonCode{DispatchReasonMachineCapacityFull},
+		},
+		{
+			name:      "operator globally paused",
+			item:      readyWorkItem(13, 1, "digitaldrywood", "detent", 13, nil, "", now),
+			snapshot:  DispatchSnapshot{EvaluatedAt: now, Machines: []MachineAvailability{availableMachine}, OperatorPaused: true},
+			wantCodes: []DispatchReasonCode{DispatchReasonOperatorPaused},
+		},
+		{
+			name:      "repository paused",
+			item:      readyWorkItem(14, 1, "digitaldrywood", "detent", 14, nil, "", now),
+			snapshot:  DispatchSnapshot{EvaluatedAt: now, Machines: []MachineAvailability{availableMachine}, PausedRepositories: []RepositoryID{1}},
+			wantCodes: []DispatchReasonCode{DispatchReasonOperatorPaused},
+		},
+		{
+			name:      "project paused",
+			item:      readyWorkItem(15, 1, "digitaldrywood", "detent", 15, nil, "", now),
+			snapshot:  DispatchSnapshot{EvaluatedAt: now, Machines: []MachineAvailability{availableMachine}, PausedProjects: []string{" FLEET "}},
+			wantCodes: []DispatchReasonCode{DispatchReasonOperatorPaused},
+		},
+		{
+			name:      "global sync safety gate",
+			item:      readyWorkItem(16, 1, "digitaldrywood", "detent", 16, nil, "", now),
+			snapshot:  DispatchSnapshot{EvaluatedAt: now, Machines: []MachineAvailability{availableMachine}, SyncSafetyBlocked: true},
+			wantCodes: []DispatchReasonCode{DispatchReasonSyncUnsafe},
+		},
+		{
+			name:      "repository sync unsafe",
+			item:      readyWorkItem(17, 1, "digitaldrywood", "detent", 17, nil, "", now),
+			snapshot:  DispatchSnapshot{EvaluatedAt: now, Machines: []MachineAvailability{availableMachine}, SyncUnsafeRepositories: []RepositoryID{1}},
+			wantCodes: []DispatchReasonCode{DispatchReasonSyncUnsafe},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			original := test.item.Dispatchability
+			queue := DeriveDispatchQueue([]WorkItem{test.item}, test.snapshot)
+			if !reflect.DeepEqual(test.item.Dispatchability, original) {
+				t.Fatalf("DeriveDispatchQueue mutated input Dispatchability: got %#v, want %#v", test.item.Dispatchability, original)
+			}
+			if len(test.wantCodes) == 0 {
+				if len(queue.Dispatchable) != 1 || len(queue.NonDispatchable) != 0 {
+					t.Fatalf("queue = %#v, want one dispatchable item", queue)
+				}
+				if queue.Dispatchable[0].Dispatchability.Reasons == nil {
+					t.Fatal("dispatchable reasons = nil, want empty structured slice")
+				}
+				return
+			}
+			if len(queue.Dispatchable) != 0 || len(queue.NonDispatchable) != 1 {
+				t.Fatalf("queue = %#v, want one non-dispatchable item", queue)
+			}
+			gotCodes := reasonCodes(queue.NonDispatchable[0].Dispatchability.Reasons)
+			if !reflect.DeepEqual(gotCodes, test.wantCodes) {
+				t.Fatalf("reason codes = %v, want %v", gotCodes, test.wantCodes)
+			}
+		})
+	}
+}
+
+func TestDeriveDispatchQueueTotalOrder(t *testing.T) {
+	t.Parallel()
+
+	oldest := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	newer := oldest.Add(time.Hour)
+	same := oldest.Add(2 * time.Hour)
+	urgent := QueuePriorityUrgent
+	high := QueuePriorityHigh
+	normal := QueuePriorityNormal
+	low := QueuePriorityLow
+	items := []WorkItem{
+		readyWorkItem(105, 1, "zeta", "unset", 1, nil, "a", oldest),
+		readyWorkItem(209, 4, "gamma", "repo", 10, &high, "b", same),
+		readyWorkItem(103, 1, "zeta", "normal", 1, &normal, "a", oldest),
+		readyWorkItem(202, 1, "zeta", "high-z", 1, &high, "z", oldest),
+		readyWorkItem(207, 3, "beta", "repo", 1, &high, "b", same),
+		readyWorkItem(101, 1, "zeta", "urgent", 1, &urgent, "", same),
+		readyWorkItem(204, 1, "zeta", "older", 1, &high, "b", oldest),
+		readyWorkItem(208, 4, "gamma", "repo", 2, &high, "b", same),
+		readyWorkItem(104, 1, "zeta", "low", 1, &low, "a", oldest),
+		readyWorkItem(203, 1, "zeta", "rank-unset", 1, &high, "", oldest),
+		readyWorkItem(201, 1, "zeta", "high-a", 1, &high, "a", newer),
+		readyWorkItem(206, 2, "alpha", "repo", 10, &high, "b", same),
+		readyWorkItem(205, 1, "zeta", "newer", 1, &high, "b", newer),
+	}
+	want := []WorkItemID{101, 201, 204, 205, 206, 207, 208, 209, 202, 203, 103, 104, 105}
+	reversed := make([]WorkItem, len(items))
+	for i := range items {
+		reversed[len(items)-1-i] = items[i]
+	}
+	rotated := append(append([]WorkItem(nil), items[5:]...), items[:5]...)
+	snapshot := DispatchSnapshot{EvaluatedAt: same, Machines: []MachineAvailability{{ID: "machine-a", Healthy: true, Capacity: 1}}}
+
+	for name, input := range map[string][]WorkItem{"original": items, "reversed": reversed, "rotated": rotated} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			queue := DeriveDispatchQueue(input, snapshot)
+			if len(queue.NonDispatchable) != 0 {
+				t.Fatalf("non-dispatchable = %#v, want none", queue.NonDispatchable)
+			}
+			got := workItemIDs(queue.Dispatchable)
+			if !reflect.DeepEqual(got, want) {
+				t.Fatalf("ordered IDs = %v, want %v", got, want)
+			}
+		})
+	}
+}
+
+func TestDeriveDispatchQueueDeterministicAcrossMachineStateOrder(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 9, 2, 12, 0, 0, 0, time.UTC)
+	items := []WorkItem{
+		readyWorkItem(2, 1, "digitaldrywood", "detent", 2, nil, "b", now),
+		readyWorkItem(1, 1, "digitaldrywood", "detent", 1, nil, "a", now),
+	}
+	first := DispatchSnapshot{EvaluatedAt: now, Machines: []MachineAvailability{{ID: "machine-full", Healthy: true, Capacity: 1, ActiveLeases: 1}, {ID: "machine-open", Healthy: true, Capacity: 1}}}
+	second := first
+	second.Machines = []MachineAvailability{first.Machines[1], first.Machines[0]}
+
+	left := DeriveDispatchQueue(items, first)
+	right := DeriveDispatchQueue(items, second)
+	if !reflect.DeepEqual(left, right) {
+		t.Fatalf("queues differ for identical machine state: left %#v right %#v", left, right)
+	}
+}
+
+func TestDeriveDispatchQueueStructuredReasonDetails(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 9, 2, 12, 0, 0, 0, time.UTC)
+	item := readyWorkItem(1, 7, "digitaldrywood", "detent", 2072, nil, "a", now)
+	item.Blockers = []WorkItemReference{{ID: 6, WorkflowState: &WorkflowState{Name: "Todo"}}}
+	item.ActiveLease = &LeaseSummary{ID: "lease-b", Machine: MachineSummary{ID: "machine-b"}, ExpiresAt: now.Add(time.Minute)}
+	snapshot := DispatchSnapshot{
+		EvaluatedAt:            now,
+		TargetMachineID:        "machine-a",
+		RepositoryConcurrency:  map[RepositoryID]ConcurrencyUsage{7: {Active: 2, Limit: 2}},
+		ProjectConcurrency:     map[string]ConcurrencyUsage{"fleet": {Active: 1, Limit: 1}},
+		Machines:               []MachineAvailability{{ID: "machine-a", Healthy: true, Capacity: 1, ActiveLeases: 1}},
+		PausedRepositories:     []RepositoryID{7},
+		SyncUnsafeRepositories: []RepositoryID{7},
+	}
+
+	queue := DeriveDispatchQueue([]WorkItem{item}, snapshot)
+	if len(queue.NonDispatchable) != 1 {
+		t.Fatalf("non-dispatchable count = %d, want 1", len(queue.NonDispatchable))
+	}
+	reasons := queue.NonDispatchable[0].Dispatchability.Reasons
+	wantCodes := []DispatchReasonCode{
+		DispatchReasonBlockerUnresolved,
+		DispatchReasonLeaseActive,
+		DispatchReasonRepositoryConcurrencyLimit,
+		DispatchReasonProjectConcurrencyLimit,
+		DispatchReasonMachineCapacityFull,
+		DispatchReasonOperatorPaused,
+		DispatchReasonSyncUnsafe,
+	}
+	if got := reasonCodes(reasons); !reflect.DeepEqual(got, wantCodes) {
+		t.Fatalf("reason codes = %v, want %v", got, wantCodes)
+	}
+	if reasons[0].WorkItemID == nil || *reasons[0].WorkItemID != 6 {
+		t.Errorf("blocker reason = %#v, want blocker 6", reasons[0])
+	}
+	if reasons[1].LeaseID != "lease-b" || reasons[1].MachineID != "machine-b" {
+		t.Errorf("lease reason = %#v, want lease-b on machine-b", reasons[1])
+	}
+	if reasons[2].Repository != 7 || reasons[2].Active != 2 || reasons[2].Limit != 2 {
+		t.Errorf("repository reason = %#v, want repository 7 at 2/2", reasons[2])
+	}
+	if reasons[3].Scope != "fleet" || reasons[3].Active != 1 || reasons[3].Limit != 1 {
+		t.Errorf("project reason = %#v, want fleet at 1/1", reasons[3])
+	}
+	if reasons[4].MachineID != "machine-a" || reasons[4].Active != 1 || reasons[4].Limit != 1 {
+		t.Errorf("machine reason = %#v, want machine-a at 1/1", reasons[4])
+	}
+	if reasons[5].Repository != 7 || reasons[6].Repository != 7 {
+		t.Errorf("repository gate reasons = %#v %#v, want repository 7", reasons[5], reasons[6])
+	}
+}
+
+func readyWorkItem(id WorkItemID, repositoryID RepositoryID, owner, repository string, number int, priority *int, rank string, created time.Time) WorkItem {
+	return WorkItem{
+		ID:            id,
+		Repository:    RepositoryReference{ID: repositoryID, Owner: owner, Name: repository},
+		GitHub:        GitHubIssueReference{Number: number},
+		SourceState:   SourceStateOpen,
+		WorkflowState: &WorkflowState{Name: "Todo", Dispatchable: true},
+		Queue:         &QueueSummary{Scope: "fleet", State: "Todo", Rank: rank, PriorityRank: priority},
+		CreatedAt:     &created,
+		Blockers:      []WorkItemReference{},
+		SyncStatus:    SyncStatusSynced,
+		Dispatchability: Dispatchability{
+			Reasons: []DispatchReason{},
+		},
+	}
+}
+
+func reasonCodes(reasons []DispatchReason) []DispatchReasonCode {
+	codes := make([]DispatchReasonCode, 0, len(reasons))
+	for _, reason := range reasons {
+		codes = append(codes, reason.Code)
+	}
+	return codes
+}
+
+func workItemIDs(items []WorkItem) []WorkItemID {
+	ids := make([]WorkItemID, 0, len(items))
+	for _, item := range items {
+		ids = append(ids, item.ID)
+	}
+	return ids
+}

--- a/internal/tracker/normalize.go
+++ b/internal/tracker/normalize.go
@@ -74,6 +74,11 @@ func normalizeRecords(records []Record) []WorkItem {
 }
 
 func deriveDispatchability(item WorkItem) Dispatchability {
+	reasons := deriveDispatchReasons(item, time.Time{}, "")
+	return Dispatchability{Dispatchable: len(reasons) == 0, Reasons: reasons}
+}
+
+func deriveDispatchReasons(item WorkItem, evaluatedAt time.Time, targetMachineID MachineID) []DispatchReason {
 	reasons := make([]DispatchReason, 0)
 	switch item.SourceState {
 	case SourceStateClosed:
@@ -93,7 +98,7 @@ func deriveDispatchability(item WorkItem) Dispatchability {
 
 	for i := range item.Blockers {
 		blocker := item.Blockers[i]
-		if blocker.SourceState == SourceStateClosed || blocker.WorkflowState != nil && blocker.WorkflowState.Terminal {
+		if blocker.WorkflowState != nil && blocker.WorkflowState.Terminal {
 			continue
 		}
 		blockerID := blocker.ID
@@ -104,11 +109,12 @@ func deriveDispatchability(item WorkItem) Dispatchability {
 		})
 	}
 
-	if item.ActiveLease != nil {
+	if item.ActiveLease != nil && (evaluatedAt.IsZero() || item.ActiveLease.ExpiresAt.After(evaluatedAt)) && (targetMachineID == "" || item.ActiveLease.Machine.ID != targetMachineID) {
 		reasons = append(reasons, DispatchReason{
-			Code:    DispatchReasonLeaseActive,
-			Message: "work item has an active lease",
-			LeaseID: item.ActiveLease.ID,
+			Code:      DispatchReasonLeaseActive,
+			Message:   "work item has an active lease held by another machine",
+			LeaseID:   item.ActiveLease.ID,
+			MachineID: item.ActiveLease.Machine.ID,
 		})
 	}
 	switch item.SyncStatus {
@@ -118,7 +124,7 @@ func deriveDispatchability(item WorkItem) Dispatchability {
 		reasons = append(reasons, DispatchReason{Code: DispatchReasonSyncStale, Message: "GitHub projection is stale"})
 	}
 
-	return Dispatchability{Dispatchable: len(reasons) == 0, Reasons: reasons}
+	return reasons
 }
 
 func normalizeRepository(repository RepositoryReference) RepositoryReference {

--- a/internal/tracker/normalize.go
+++ b/internal/tracker/normalize.go
@@ -74,11 +74,11 @@ func normalizeRecords(records []Record) []WorkItem {
 }
 
 func deriveDispatchability(item WorkItem) Dispatchability {
-	reasons := deriveDispatchReasons(item, time.Time{}, "")
+	reasons := deriveDispatchReasons(item, time.Time{}, "", "")
 	return Dispatchability{Dispatchable: len(reasons) == 0, Reasons: reasons}
 }
 
-func deriveDispatchReasons(item WorkItem, evaluatedAt time.Time, targetMachineID MachineID) []DispatchReason {
+func deriveDispatchReasons(item WorkItem, evaluatedAt time.Time, targetMachineID MachineID, targetSessionID string) []DispatchReason {
 	reasons := make([]DispatchReason, 0)
 	switch item.SourceState {
 	case SourceStateClosed:
@@ -109,12 +109,13 @@ func deriveDispatchReasons(item WorkItem, evaluatedAt time.Time, targetMachineID
 		})
 	}
 
-	if item.ActiveLease != nil && (evaluatedAt.IsZero() || item.ActiveLease.ExpiresAt.After(evaluatedAt)) && (targetMachineID == "" || item.ActiveLease.Machine.ID != targetMachineID) {
+	if leaseIsActive(item.ActiveLease, evaluatedAt) && !leaseOwnedBy(item.ActiveLease, targetMachineID, targetSessionID) {
 		reasons = append(reasons, DispatchReason{
 			Code:      DispatchReasonLeaseActive,
-			Message:   "work item has an active lease held by another machine",
+			Message:   "work item has an active lease held by another machine or session",
 			LeaseID:   item.ActiveLease.ID,
 			MachineID: item.ActiveLease.Machine.ID,
+			SessionID: item.ActiveLease.SessionID,
 		})
 	}
 	switch item.SyncStatus {
@@ -125,6 +126,15 @@ func deriveDispatchReasons(item WorkItem, evaluatedAt time.Time, targetMachineID
 	}
 
 	return reasons
+}
+
+func leaseIsActive(lease *LeaseSummary, evaluatedAt time.Time) bool {
+	return lease != nil && (evaluatedAt.IsZero() || lease.ExpiresAt.After(evaluatedAt))
+}
+
+func leaseOwnedBy(lease *LeaseSummary, targetMachineID MachineID, targetSessionID string) bool {
+	targetSessionID = strings.TrimSpace(targetSessionID)
+	return targetMachineID != "" && targetSessionID != "" && lease != nil && lease.Machine.ID == targetMachineID && strings.TrimSpace(lease.SessionID) == targetSessionID
 }
 
 func normalizeRepository(repository RepositoryReference) RepositoryReference {

--- a/internal/tracker/normalize_test.go
+++ b/internal/tracker/normalize_test.go
@@ -88,6 +88,21 @@ func TestNormalizeWorkItem(t *testing.T) {
 			wantReasonLeaseID: "lease-9",
 		},
 		{
+			name: "closed blocker without configured terminal state",
+			record: Record{
+				ID:            12,
+				SourceState:   "open",
+				WorkflowState: todo,
+				Blockers:      []WorkItemReference{{ID: 6, SourceState: SourceStateClosed}},
+				SyncStatus:    SyncStatusSynced,
+			},
+			wantReasons:   []DispatchReasonCode{DispatchReasonBlockerUnresolved},
+			wantState:     SourceStateOpen,
+			wantSync:      SyncStatusSynced,
+			wantLabels:    []string{},
+			wantBlockerID: 6,
+		},
+		{
 			name:             "expired lease omitted",
 			record:           Record{ID: 10, SourceState: "open", WorkflowState: todo, Lease: &LeaseSummary{ID: "expired", ExpiresAt: now.Add(-time.Second)}, SyncStatus: SyncStatusPending, ObservedAt: now},
 			wantDispatchable: true,
@@ -134,7 +149,13 @@ func TestNormalizeWorkItem(t *testing.T) {
 				}
 			}
 			if test.wantBlockerID != 0 {
-				if got.Blockers[0].ID != test.wantBlockerID || got.Dispatchability.Reasons[2].WorkItemID == nil || *got.Dispatchability.Reasons[2].WorkItemID != test.wantBlockerID {
+				matchedReason := false
+				for _, reason := range got.Dispatchability.Reasons {
+					if reason.Code == DispatchReasonBlockerUnresolved && reason.WorkItemID != nil && *reason.WorkItemID == test.wantBlockerID {
+						matchedReason = true
+					}
+				}
+				if got.Blockers[0].ID != test.wantBlockerID || !matchedReason {
 					t.Errorf("blocker identity was not retained: item=%#v reasons=%#v", got.Blockers, got.Dispatchability.Reasons)
 				}
 			}
@@ -169,6 +190,13 @@ func TestStoreTrackerReadsNormalizedItems(t *testing.T) {
 	}
 	if len(items) != 1 || len(store.workItemIDs) != 1 || store.workItemIDs[0] != 1 {
 		t.Fatalf("GetWorkItems() = %#v; IDs = %v", items, store.workItemIDs)
+	}
+	queue, err := backend.ListDispatchQueue(t.Context(), CandidateQuery{Scope: "fleet"}, DispatchSnapshot{Machines: []MachineAvailability{{ID: "machine-a", Healthy: true, Capacity: 1}}})
+	if err != nil {
+		t.Fatalf("ListDispatchQueue() error = %v", err)
+	}
+	if len(queue.Dispatchable) != 1 || len(queue.NonDispatchable) != 0 {
+		t.Fatalf("ListDispatchQueue() = %#v, want one dispatchable item", queue)
 	}
 
 	mutationErrors := []error{}

--- a/internal/tracker/tracker.go
+++ b/internal/tracker/tracker.go
@@ -8,6 +8,13 @@ import (
 
 const DefaultCandidateLimit = 100
 
+const (
+	QueuePriorityUrgent = iota
+	QueuePriorityHigh
+	QueuePriorityNormal
+	QueuePriorityLow
+)
+
 var (
 	ErrInvalidCandidateQuery = errors.New("invalid tracker candidate query")
 	ErrInvalidWorkItemID     = errors.New("invalid tracker work item ID")
@@ -53,6 +60,13 @@ const (
 	DispatchReasonWorkflowStateNotDispatchable DispatchReasonCode = "workflow_state_not_dispatchable"
 	DispatchReasonBlockerUnresolved            DispatchReasonCode = "blocker_unresolved"
 	DispatchReasonLeaseActive                  DispatchReasonCode = "lease_active"
+	DispatchReasonRepositoryConcurrencyLimit   DispatchReasonCode = "repository_concurrency_limit"
+	DispatchReasonProjectConcurrencyLimit      DispatchReasonCode = "project_concurrency_limit"
+	DispatchReasonNoCompatibleMachine          DispatchReasonCode = "no_compatible_machine"
+	DispatchReasonMachineUnhealthy             DispatchReasonCode = "machine_unhealthy"
+	DispatchReasonMachineCapacityFull          DispatchReasonCode = "machine_capacity_full"
+	DispatchReasonOperatorPaused               DispatchReasonCode = "operator_paused"
+	DispatchReasonSyncUnsafe                   DispatchReasonCode = "sync_unsafe"
 	DispatchReasonSyncError                    DispatchReasonCode = "sync_error"
 	DispatchReasonSyncStale                    DispatchReasonCode = "sync_stale"
 )
@@ -156,11 +170,48 @@ type DispatchReason struct {
 	Message    string             `json:"message"`
 	WorkItemID *WorkItemID        `json:"work_item_id,omitempty"`
 	LeaseID    LeaseID            `json:"lease_id,omitempty"`
+	Repository RepositoryID       `json:"repository_id,omitempty"`
+	Scope      string             `json:"scope,omitempty"`
+	MachineID  MachineID          `json:"machine_id,omitempty"`
+	Active     int                `json:"active,omitempty"`
+	Limit      int                `json:"limit,omitempty"`
 }
 
 type Dispatchability struct {
 	Dispatchable bool             `json:"dispatchable"`
 	Reasons      []DispatchReason `json:"reasons"`
+}
+
+type ConcurrencyUsage struct {
+	Active int `json:"active"`
+	Limit  int `json:"limit"`
+}
+
+type MachineAvailability struct {
+	ID            MachineID      `json:"id"`
+	Healthy       bool           `json:"healthy"`
+	Capacity      int            `json:"capacity"`
+	ActiveLeases  int            `json:"active_leases"`
+	RepositoryIDs []RepositoryID `json:"repository_ids,omitempty"`
+	ProjectScopes []string       `json:"project_scopes,omitempty"`
+}
+
+type DispatchSnapshot struct {
+	EvaluatedAt            time.Time                         `json:"evaluated_at"`
+	TargetMachineID        MachineID                         `json:"target_machine_id,omitempty"`
+	RepositoryConcurrency  map[RepositoryID]ConcurrencyUsage `json:"repository_concurrency,omitempty"`
+	ProjectConcurrency     map[string]ConcurrencyUsage       `json:"project_concurrency,omitempty"`
+	Machines               []MachineAvailability             `json:"machines"`
+	OperatorPaused         bool                              `json:"operator_paused"`
+	PausedRepositories     []RepositoryID                    `json:"paused_repositories,omitempty"`
+	PausedProjects         []string                          `json:"paused_projects,omitempty"`
+	SyncSafetyBlocked      bool                              `json:"sync_safety_blocked"`
+	SyncUnsafeRepositories []RepositoryID                    `json:"sync_unsafe_repositories,omitempty"`
+}
+
+type DispatchQueue struct {
+	Dispatchable    []WorkItem `json:"dispatchable"`
+	NonDispatchable []WorkItem `json:"non_dispatchable"`
 }
 
 type WorkItem struct {
@@ -231,6 +282,7 @@ type WorkEvent struct {
 
 type Tracker interface {
 	ListCandidates(context.Context, CandidateQuery) ([]WorkItem, error)
+	ListDispatchQueue(context.Context, CandidateQuery, DispatchSnapshot) (DispatchQueue, error)
 	GetWorkItems(context.Context, []WorkItemID) ([]WorkItem, error)
 	Claim(context.Context, ClaimRequest) (Lease, error)
 	Renew(context.Context, RenewRequest) (Lease, error)
@@ -261,7 +313,17 @@ func (t *storeTracker) ListCandidates(ctx context.Context, query CandidateQuery)
 	if err != nil {
 		return nil, err
 	}
-	return normalizeRecords(records), nil
+	items := normalizeRecords(records)
+	sortWorkItemsForDispatch(items)
+	return items, nil
+}
+
+func (t *storeTracker) ListDispatchQueue(ctx context.Context, query CandidateQuery, snapshot DispatchSnapshot) (DispatchQueue, error) {
+	items, err := t.ListCandidates(ctx, query)
+	if err != nil {
+		return DispatchQueue{}, err
+	}
+	return DeriveDispatchQueue(items, snapshot), nil
 }
 
 func (t *storeTracker) GetWorkItems(ctx context.Context, ids []WorkItemID) ([]WorkItem, error) {

--- a/internal/tracker/tracker.go
+++ b/internal/tracker/tracker.go
@@ -173,6 +173,7 @@ type DispatchReason struct {
 	Repository RepositoryID       `json:"repository_id,omitempty"`
 	Scope      string             `json:"scope,omitempty"`
 	MachineID  MachineID          `json:"machine_id,omitempty"`
+	SessionID  string             `json:"session_id,omitempty"`
 	Active     int                `json:"active,omitempty"`
 	Limit      int                `json:"limit,omitempty"`
 }
@@ -199,6 +200,7 @@ type MachineAvailability struct {
 type DispatchSnapshot struct {
 	EvaluatedAt            time.Time                         `json:"evaluated_at"`
 	TargetMachineID        MachineID                         `json:"target_machine_id,omitempty"`
+	TargetSessionID        string                            `json:"target_session_id,omitempty"`
 	RepositoryConcurrency  map[RepositoryID]ConcurrencyUsage `json:"repository_concurrency,omitempty"`
 	ProjectConcurrency     map[string]ConcurrencyUsage       `json:"project_concurrency,omitempty"`
 	Machines               []MachineAvailability             `json:"machines"`


### PR DESCRIPTION
## Summary

- derive a deterministic dispatch queue from normalized Hub candidates and a complete fleet snapshot
- preserve non-dispatchable candidates with structured blocker, lease, concurrency, machine, pause, and sync-safety reasons
- enforce configured candidate states and align durable SQL ordering with the tracker domain comparator

Fixes #2072

## UI Surface Contract

- [x] N/A; this PR does not change a UI surface, layout, density, first viewport, or responsive visibility.
- [x] This PR does not add persistent top-of-screen messaging.
- [x] N/A; this PR makes no visual changes to primary operator screens.

## Test Plan

- [x] `go test ./internal/tracker ./internal/hubserver`
- [x] `go test -race ./internal/tracker ./internal/hubserver`
- [x] `go vet ./internal/tracker ./internal/hubserver`
- [x] `make check` with repository-pinned Go 1.26.6 and golangci-lint 2.9.0 (78.9% aggregate coverage; tracker 90.7%)